### PR TITLE
Run all config filename patterns against rel paths

### DIFF
--- a/docs/TutorialReact.md
+++ b/docs/TutorialReact.md
@@ -79,9 +79,9 @@ Since we are writing code using JSX, a bit of one-time setup is required to make
     "react-tools": "*"
   },
   "jest": {
-    "scriptPreprocessor": "<rootDir>/preprocessor.js",
-    "unmockedModulePathPatterns": ["<rootDir>/node_modules/react"],
-    "testPathIgnorePatterns": ["<rootDir>/node_modules"]
+    "scriptPreprocessor": "preprocessor.js",
+    "unmockedModulePathPatterns": ["^node_modules/react/"],
+    "testPathIgnorePatterns": ["^node_modules/"]
   }
 ```
 

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -7,8 +7,8 @@
     "test": "node ../../bin/jest.js"
   },
   "jest": {
-    "scriptPreprocessor": "<rootDir>/preprocessor.js",
-    "unmockedModulePathPatterns": ["<rootDir>/node_modules/react"],
-    "testPathIgnorePatterns": ["<rootDir>/node_modules"]
+    "scriptPreprocessor": "preprocessor.js",
+    "unmockedModulePathPatterns": ["^node_modules/react/"],
+    "testPathIgnorePatterns": ["^node_modules/"]
   }
 }

--- a/src/HasteModuleLoader/HasteModuleLoader.js
+++ b/src/HasteModuleLoader/HasteModuleLoader.js
@@ -89,7 +89,7 @@ function _constructHasteInst(config, options) {
   var HASTE_IGNORE_REGEX = new RegExp(
     config.modulePathIgnorePatterns
     ? config.modulePathIgnorePatterns.join('|')
-    : '__NOT_EXIST__'
+    : '$.'  // never matches
   );
 
   if (!fs.existsSync(CACHE_DIR_PATH)) {
@@ -100,8 +100,9 @@ function _constructHasteInst(config, options) {
     _buildLoadersList(config),
     (config.testPathDirs || []),
     {
-      ignorePaths: function(path) {
-        return path.match(HASTE_IGNORE_REGEX);
+      ignorePaths: function(modulePath) {
+        var relPath = path.relative(config.rootDir, modulePath);
+        return HASTE_IGNORE_REGEX.test(relPath);
       },
       version: JSON.stringify(config),
       useNativeFind: true,
@@ -529,7 +530,10 @@ Loader.prototype._shouldMock = function(currPath, moduleName) {
       var manualMockResource =
         this._getResource('JSMock', moduleName);
       try {
-        var modulePath = this._moduleNameToPath(currPath, moduleName);
+        var modulePath = path.relative(
+          this._config.rootDir,
+          this._moduleNameToPath(currPath, moduleName)
+        );
       } catch(e) {
         // If there isn't a real module, we don't have a path to match
         // against the unmockList regexps. If there is also not a manual

--- a/src/HasteModuleLoader/__tests__/HasteModuleLoader-genMockFromModule-test.js
+++ b/src/HasteModuleLoader/__tests__/HasteModuleLoader-genMockFromModule-test.js
@@ -19,6 +19,7 @@ describe('nodeHasteModuleLoader', function() {
 
   var CONFIG = {
     name: 'nodeHasteModuleLoader-tests',
+    rootDir: __dirname,
     testPathDirs: [path.resolve(__dirname, 'test_root')]
   };
 

--- a/src/HasteModuleLoader/__tests__/HasteModuleLoader-requireMock-test.js
+++ b/src/HasteModuleLoader/__tests__/HasteModuleLoader-requireMock-test.js
@@ -19,6 +19,7 @@ describe('nodeHasteModuleLoader', function() {
 
   var CONFIG = {
     name: 'nodeHasteModuleLoader-tests',
+    rootDir: __dirname,
     testPathDirs: [path.resolve(__dirname, 'test_root')]
   };
 

--- a/src/HasteModuleLoader/__tests__/HasteModuleLoader-requireModule-test.js
+++ b/src/HasteModuleLoader/__tests__/HasteModuleLoader-requireModule-test.js
@@ -19,6 +19,7 @@ describe('nodeHasteModuleLoader', function() {
 
   var CONFIG = {
     name: 'nodeHasteModuleLoader-tests',
+    rootDir: __dirname,
     testPathDirs: [path.resolve(__dirname, 'test_root')]
   };
 

--- a/src/HasteModuleLoader/__tests__/HasteModuleLoader-requireModuleOrMock-test.js
+++ b/src/HasteModuleLoader/__tests__/HasteModuleLoader-requireModuleOrMock-test.js
@@ -19,6 +19,7 @@ describe('nodeHasteModuleLoader', function() {
 
   var CONFIG = {
     name: 'nodeHasteModuleLoader-tests',
+    rootDir: __dirname,
     testPathDirs: [path.resolve(__dirname, 'test_root')]
   };
 

--- a/src/TestRunner.js
+++ b/src/TestRunner.js
@@ -76,7 +76,7 @@ function TestRunner(config, options) {
       .join('|')
   );
   this._nodeHasteTestRegExp = new RegExp(
-    '/' + utils.escapeStrForRegex(config.testDirectoryName) + '/' +
+    '(?:^|/)' + utils.escapeStrForRegex(config.testDirectoryName) + '/' +
     '.*\\.(' +
       utils.escapeStrForRegex(config.testFileExtensions.join('|')) +
     ')$'
@@ -112,17 +112,18 @@ TestRunner.prototype._getModuleLoaderResourceMap = function() {
   return this._moduleLoaderResourceMap;
 };
 
-TestRunner.prototype._isTestFilePath = function(filePath) {
+TestRunner.prototype._isTestFilePath = function(absPath) {
   var testPathIgnorePattern =
     this._config.testPathIgnorePatterns
     ? new RegExp(this._config.testPathIgnorePatterns.join('|'))
     : null;
 
+  var relPath = path.relative(this._config.rootDir, absPath);
   return (
-    this._nodeHasteTestRegExp.test(filePath)
-    && !HIDDEN_FILE_RE.test(filePath)
-    && (!testPathIgnorePattern || !testPathIgnorePattern.test(filePath))
-    && this._testPathDirsRegExp.test(filePath)
+    this._nodeHasteTestRegExp.test(relPath)
+    && !HIDDEN_FILE_RE.test(relPath)
+    && (!testPathIgnorePattern || !testPathIgnorePattern.test(relPath))
+    && this._testPathDirsRegExp.test(absPath)
   );
 };
 


### PR DESCRIPTION
I think this makes more sense generally.

Test Plan: Run bin/jest.js in jest/ and in each example folder.