### PR TITLE
Remove margin-left from list on home page

### DIFF
--- a/website/src/jest/css/jest.css
+++ b/website/src/jest/css/jest.css
@@ -411,6 +411,10 @@ h1:hover .hash-link, h2:hover .hash-link, h3:hover .hash-link, h4:hover .hash-li
   margin: 50px 0;
 }
 
+.home-section ol {
+  margin-left: 0;
+}
+
 .home-divider {
   border-top-color: #bbb;
   margin: 0 auto;


### PR DESCRIPTION
IMO this indentation is kinda odd as both the intro sentence and the list are semantically on the same "level". Feel free to reject if you disagree :+1: 

Before:
![OH GOD WHY](https://cloud.githubusercontent.com/assets/91933/2975393/4f63b3ee-db94-11e3-90bc-1275f6fc3c69.png)

After:
![AW YIS](https://cloud.githubusercontent.com/assets/91933/2975394/50cd2080-db94-11e3-9f71-af6c207ed811.png)
