### PR TITLE
Fix typo in CommonJSTesting.md

### DIFF
--- a/docs/CommonJSTesting.md
+++ b/docs/CommonJSTesting.md
@@ -76,7 +76,7 @@ var injectedDoWork = injector.instantiate(doWork);
 // is the equivalent of writing
 
 function injectedDoWork() {
-  var XHR = injector.get('XHR');
+  var xhr = injector.get('XHR');
   xhr.open('POST', 'http://facebook.github.io/jest/');
   xhr.send();
 }


### PR DESCRIPTION
I don't know Angular well, but I assume the `injector.get('XHR')` call returns the `xhr` instance.
