### PR TITLE
Fix typo in displayUser-test.js

### DIFF
--- a/examples/jquery/__tests__/displayUser-test.js
+++ b/examples/jquery/__tests__/displayUser-test.js
@@ -15,8 +15,8 @@ describe('displayUser', function() {
     var $ = require('jquery');
     var fetchCurrentUser = require('../fetchCurrentUser');
 
-    // Tell the fetchCurrentUser mock function to automatically it's
-    // callback with some data
+    // Tell the fetchCurrentUser mock function to automatically invoke
+    // its callback with some data
     fetchCurrentUser.mockImplementation(function(cb) {
       cb({
         loggedIn: true,


### PR DESCRIPTION
I assume 'invoke' was missing (or fire, or something else?) and s/it's/its/.
