### PR TITLE
Fewer max loops to speed up fake timer test

### DIFF
--- a/src/lib/FakeTimers.js
+++ b/src/lib/FakeTimers.js
@@ -11,9 +11,10 @@ var mocks = require('./moduleMocker');
 
 var MS_IN_A_YEAR = 31536000000;
 
-function FakeTimers(global) {
+function FakeTimers(global, maxLoops) {
   this._global = global;
   this._uuidCounter = 0;
+  this._maxLoops = maxLoops || 100000;
 
   this.reset();
 
@@ -79,9 +80,8 @@ FakeTimers.prototype.reset = function() {
 FakeTimers.prototype.runAllTicks = function() {
   // Only run a generous number of ticks and then bail.
   // This is just to help avoid recursive loops
-  var maxTicksToRun = 100000;
 
-  for (var i = 0; i < maxTicksToRun; i++) {
+  for (var i = 0; i < this._maxLoops; i++) {
     var tick = this._ticks.shift();
 
     if (tick === undefined) {
@@ -94,9 +94,9 @@ FakeTimers.prototype.runAllTicks = function() {
     }
   }
 
-  if (i === maxTicksToRun) {
+  if (i === this._maxLoops) {
     throw new Error(
-      'Ran ' + maxTicksToRun + ' ticks, and there are still more! Assuming ' +
+      'Ran ' + this._maxLoops + ' ticks, and there are still more! Assuming ' +
       'we\'ve hit an infinite recursion and bailing out...'
     );
   }
@@ -108,9 +108,8 @@ FakeTimers.prototype.runAllTimers = function() {
 
   // Only run a generous number of timers and then bail.
   // This is just to help avoid recursive loops
-  var maxTimersToRun = 100000;
 
-  for (var i = 0; i < maxTimersToRun; i++) {
+  for (var i = 0; i < this._maxLoops; i++) {
     var nextTimerHandle = this._getNextTimerHandle();
 
     // If there are no more timer handles, stop!
@@ -121,9 +120,9 @@ FakeTimers.prototype.runAllTimers = function() {
     this._runTimerHandle(nextTimerHandle);
   }
 
-  if (i === maxTimersToRun) {
+  if (i === this._maxLoops) {
     throw new Error(
-      'Ran ' + maxTimersToRun + ' timers, and there are still more! Assuming ' +
+      'Ran ' + this._maxLoops + ' timers, and there are still more! Assuming ' +
       'we\'ve hit an infinite recursion and bailing out...'
     );
   }
@@ -143,9 +142,8 @@ FakeTimers.prototype.runOnlyPendingTimers = function() {
 FakeTimers.prototype.runTimersToTime = function(msToRun) {
   // Only run a generous number of timers and then bail.
   // This is jsut to help avoid recursive loops
-  var maxTimersToRun = 100000;
 
-  for (var i = 0; i < maxTimersToRun; i++) {
+  for (var i = 0; i < this._maxLoops; i++) {
     var timerHandle = this._getNextTimerHandle();
 
     // If there are no more timer handles, stop!
@@ -166,9 +164,9 @@ FakeTimers.prototype.runTimersToTime = function(msToRun) {
     }
   }
 
-  if (i === maxTimersToRun) {
+  if (i === this._maxLoops) {
     throw new Error(
-      'Ran ' + maxTimersToRun + ' timers, and there are still more! Assuming ' +
+      'Ran ' + this._maxLoops + ' timers, and there are still more! Assuming ' +
       'we\'ve hit an infinite recursion and bailing out...'
     );
   }

--- a/src/lib/__tests__/FakeTimers-test.js
+++ b/src/lib/__tests__/FakeTimers-test.js
@@ -178,7 +178,7 @@ describe('FakeTimers', function() {
         }
       };
 
-      var fakeTimers = new FakeTimers(global);
+      var fakeTimers = new FakeTimers(global, 100);
 
       global.process.nextTick(function infinitelyRecursingCallback() {
         global.process.nextTick(infinitelyRecursingCallback);
@@ -187,7 +187,7 @@ describe('FakeTimers', function() {
       expect(function() {
         fakeTimers.runAllTicks();
       }).toThrow(
-        'Ran 100000 ticks, and there are still more! Assuming we\'ve hit an ' +
+        'Ran 100 ticks, and there are still more! Assuming we\'ve hit an ' +
         'infinite recursion and bailing out...'
       );
     });
@@ -268,7 +268,7 @@ describe('FakeTimers', function() {
 
     it('throws before allowing infinite recursion', function() {
       var global = {};
-      var fakeTimers = new FakeTimers(global);
+      var fakeTimers = new FakeTimers(global, 100);
 
       global.setTimeout(function infinitelyRecursingCallback() {
         global.setTimeout(infinitelyRecursingCallback, 0);
@@ -277,7 +277,7 @@ describe('FakeTimers', function() {
       expect(function() {
         fakeTimers.runAllTimers();
       }).toThrow(
-        'Ran 100000 timers, and there are still more! Assuming we\'ve hit an ' +
+        'Ran 100 timers, and there are still more! Assuming we\'ve hit an ' +
         'infinite recursion and bailing out...'
       );
     });
@@ -339,7 +339,7 @@ describe('FakeTimers', function() {
 
     it('throws before allowing infinite recursion', function() {
       var global = {};
-      var fakeTimers = new FakeTimers(global);
+      var fakeTimers = new FakeTimers(global, 100);
 
       global.setTimeout(function infinitelyRecursingCallback() {
         global.setTimeout(infinitelyRecursingCallback, 0);
@@ -348,7 +348,7 @@ describe('FakeTimers', function() {
       expect(function() {
         fakeTimers.runTimersToTime(50);
       }).toThrow(
-        'Ran 100000 timers, and there are still more! Assuming we\'ve hit an ' +
+        'Ran 100 timers, and there are still more! Assuming we\'ve hit an ' +
         'infinite recursion and bailing out...'
       );
     });


### PR DESCRIPTION
Previously the FakeTimer test took about 3 seconds on my computer; now it takes about 50 ms.
