### PR TITLE
make option "testFileExtensions" accept an array like ['js','coffee']

### DIFF
--- a/src/TestRunner.js
+++ b/src/TestRunner.js
@@ -76,15 +76,15 @@ function TestRunner(config, options) {
       .join('|')
   );
 
-  this._nodeHasteTestRegExp = new RegExp(                                          
-    '/' + utils.escapeStrForRegex(config.testDirectoryName) + '/' +                
-    '.*\\.(' +                                                                     
-      config.testFileExtensions.map(function(ext) {                                                                    
-        return utils.escapeStrForRegex(ext);                                       
-      })                                                                           
-      .join('|') +                                                                 
-    ')$'                                                                           
-  );  
+  this._nodeHasteTestRegExp = new RegExp(
+    '/' + utils.escapeStrForRegex(config.testDirectoryName) + '/' +
+    '.*\\.(' +
+      config.testFileExtensions.map(function(ext) {
+        return utils.escapeStrForRegex(ext);
+      })
+      .join('|') +
+    ')$'
+  );
   this._opts = Object.create(DEFAULT_OPTIONS);
   if (options) {
     for (var key in options) {


### PR DESCRIPTION
If set "testFileExtensions": [ 'js', 'coffee']

in original code, this._nodeHasteTestRegExp is

```
 //__tests__/.*\.(js\|coffee)$/
```

This make Jest can't find tests: Found 0 matching tests...

The change calls escapeStrForRegex() before join the string, so the gengerated regexp is:

```
//__tests__/.*\.(js|coffee)$/
```

Now Jest can find tests:
Found 3 matching tests...
