### PR TITLE
Run jest with --harmony if it wasn't already doing so

### DIFF
--- a/bin/jest.js
+++ b/bin/jest.js
@@ -12,6 +12,7 @@
 var child_process = require('child_process');
 var defaultTestResultHandler = require('../src/defaultTestResultHandler');
 var fs = require('fs');
+var harmonize = require('harmonize');
 var optimist = require('optimist');
 var path = require('path');
 var Q = require('q');
@@ -368,5 +369,6 @@ function _main() {
 exports.runCLI = runCLI;
 
 if (require.main === module) {
+  harmonize();
   _main();
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "coffee-script": "1.7.1",
     "cover": "~0.2.8",
     "diff": "~1.0.4",
+    "harmonize": "~1.33.7",
     "jasmine-only": "0.1.0",
     "jasmine-pit": "~1.0.0",
     "jsdom": "~0.10.3",


### PR DESCRIPTION
Jest uses ES6 features in a couple of places. Right now I think it's just
WeakMaps but it would also be useful to test generators as well. ES6 is gated
behind the --harmony flag so we need to explicitly specify it when running jest.

The harmonize module tests to see if Node is currently running in ES6 mode. If
not, it spawns a Node child process with the same args and env as the parent but
with the --harmony flag.

Tested by running `./bin/jest.js -o` from a repo with some changes and didn't
get the crash that says: "Please run node with the --harmony flag!". (I got
another crash but that has to do with Haste).
