### PR TITLE
Handle throwing non-Errors without fataling.

### DIFF
--- a/vendor/jasmine/jasmine-1.3.0.js
+++ b/vendor/jasmine/jasmine-1.3.0.js
@@ -2319,10 +2319,11 @@ jasmine.Spec.prototype.waitsFor = function(latchFunction, optional_timeoutMessag
 };
 
 jasmine.Spec.prototype.fail = function (e) {
+  var isError = e instanceof Error;
   var expectationResult = new jasmine.ExpectationResult({
     passed: false,
-    message: e ? jasmine.util.formatException(e) : 'Exception',
-    trace: { stack: e.stack }
+    message: isError ? jasmine.util.formatException(e) : 'Throws: ' + e,
+    trace: { stack: isError ? e.stack : null }
   });
   this.results_.addResult(expectationResult);
 };


### PR DESCRIPTION
Currently, throwing `undefined` will cause Jest to fatal: `TypeError: Cannot read property 'stack' of undefined`. In general, the support for tests throwing non-`Error` values is pretty spotty.

This improves behavior by printing the error and stack trace only if the thrown value is an `Error`. If it is not, we will now print `Throw: <value>`. For example:

```
● Jasmine › it should not fatal on undefined exceptions
  - Throws: undefined
1/1 tests failed
```

For comparison, here is how a normal `Error` value would be printed:

```
● Jasmine › it should not fatal on undefined exceptions
  - Error: Peek-a-boo!
        at Spec.<anonymous> (/data/users/yungsters/www-git/static_upstream/dlite-web/__tests__/DliteWebApplet-test.js:7:11)
        at Timer.list.ontimeout (timers.js:101:19)
1/1 tests failed
```
