### PR TITLE
Make jest easier to use from node instead of CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "jest-cli",
   "description": "Painless JavaScript Unit Testing.",
-  "version": "0.1.16",
+  "version": "0.1.17",
+  "main": "bin/jest.js",
   "dependencies": {
     "coffee-script": "1.7.1",
     "cover": "~0.2.8",


### PR DESCRIPTION
This makes jest much easier to use from node by way of a few changes:
- Declare a main JS file, so you can require('jest-cli').
- Take a callback function to `runCLI` which is called with boolean success instead of ending the process (remove all references to process from runCLI).
- Allow for `testPathPattern` to be provided directly, which allows passing `{testPathPattern: /(my.*custom)|pattern/}` as options to `runCLI`.
- Set a default empty `argv`, to allow for passing null.

After this change, writing a basic grunt task to run your tests is super straightforward:

```
grunt.registerTask('jest', function() {
    require('jest-cli').runCLI(this.options(), __dirname, this.async());
});
```
