### PR TITLE
Added --detailInfo switch

### DIFF
--- a/bin/jest.js
+++ b/bin/jest.js
@@ -10,7 +10,7 @@
 "use strict";
 
 var child_process = require('child_process');
-var DefaultTestResultHandler = require('../src/DefaultTestResultHandler');
+var defaultTestResultHandler = require('../src/defaultTestResultHandler');
 var fs = require('fs');
 var harmonize = require('harmonize');
 var optimist = require('optimist');
@@ -65,9 +65,13 @@ function _findChangedFiles(dirPath) {
 }
 
 function _onResultReady(argv, config, result) {
-  return new DefaultTestResultHandler(config, result, {
-    showDetailedInfo: argv.detailInfo
-  }).displayResults();
+  if (argv.detailedResults) {
+    return defaultTestResultHandler
+    .printDetailedTestResult(config, result);
+  } else {
+    return defaultTestResultHandler
+    .printConciseTestResult(config, result);
+  }
 }
 
 function _onRunComplete(completionData) {
@@ -86,7 +90,7 @@ function _onRunComplete(completionData) {
 	  );
 	results += ', ';
   }
-  results += 
+  results +=
     colors.colorize(
 		[numPassedTests, (numPassedTests > 1 ? 'tests' : 'test'), 'passed'].join(' '),
 		colors.GREEN + colors.BOLD
@@ -192,9 +196,17 @@ function runCLI(argv, packageRoot, onComplete) {
 			['Found', numMatchingTestPaths, 'matching', (numMatchingTestPaths > 1 ? 'tests...' : 'test...')].join(' ')
 		  );
           if (argv.runInBand) {
-            return testRunner.runTestsInBand(matchingTestPaths, _onResultReady.bind(null, argv));
+            return testRunner
+            .runTestsInBand(
+              matchingTestPaths,
+              _onResultReady.bind(null, argv)
+            );
           } else {
-            return testRunner.runTestsParallel(matchingTestPaths, _onResultReady.bind(null, argv));
+            return testRunner
+            .runTestsParallel(
+              matchingTestPaths,
+              _onResultReady.bind(null, argv)
+            );
           }
         })
         .then(function(completionData) {
@@ -258,7 +270,7 @@ function _main(onComplete) {
         ),
         type: 'boolean'
       },
-      detailInfo: {
+      detailedResults: {
         description: _wrapDesc(
           'Specifies that the results should contain more verbose information'
         ),

--- a/bin/jest.js
+++ b/bin/jest.js
@@ -10,7 +10,7 @@
 "use strict";
 
 var child_process = require('child_process');
-var defaultTestResultHandler = require('../src/defaultTestResultHandler');
+var DefaultTestResultHandler = require('../src/DefaultTestResultHandler');
 var fs = require('fs');
 var harmonize = require('harmonize');
 var optimist = require('optimist');
@@ -64,8 +64,10 @@ function _findChangedFiles(dirPath) {
   return deferred.promise;
 }
 
-function _onResultReady(config, result) {
-  return defaultTestResultHandler(config, result);
+function _onResultReady(argv, config, result) {
+  return new DefaultTestResultHandler(config, result, {
+    showDetailedInfo: argv.detailInfo
+  }).displayResults();
 }
 
 function _onRunComplete(completionData) {
@@ -190,9 +192,9 @@ function runCLI(argv, packageRoot, onComplete) {
 			['Found', numMatchingTestPaths, 'matching', (numMatchingTestPaths > 1 ? 'tests...' : 'test...')].join(' ')
 		  );
           if (argv.runInBand) {
-            return testRunner.runTestsInBand(matchingTestPaths, _onResultReady);
+            return testRunner.runTestsInBand(matchingTestPaths, _onResultReady.bind(null, argv));
           } else {
-            return testRunner.runTestsParallel(matchingTestPaths, _onResultReady);
+            return testRunner.runTestsParallel(matchingTestPaths, _onResultReady.bind(null, argv));
           }
         })
         .then(function(completionData) {
@@ -253,6 +255,12 @@ function _main(onComplete) {
         description: _wrapDesc(
           'Indicates that test coverage information should be collected and ' +
           'reported in the output.'
+        ),
+        type: 'boolean'
+      },
+      detailInfo: {
+        description: _wrapDesc(
+          'Specifies that the results should contain more verbose information'
         ),
         type: 'boolean'
       },

--- a/src/DefaultTestResultHandler.js
+++ b/src/DefaultTestResultHandler.js
@@ -91,7 +91,7 @@ var DefaultTestResultHandler = function DefaultTestResultHandler(jestConfig, tes
  * @param  {Array}   columns  An array of items to append
  * @return {String}           The header
  */
-DefaultTestResultHandler.prototype._getResultHeader = function (passed, testName, columns) {
+DefaultTestResultHandler.getResultHeader = function (passed, testName, columns) {
    var passFailTag = passed ?
                      colors.colorize(' PASS ', PASS_COLOR) :
                      colors.colorize(' FAIL ', FAIL_COLOR);
@@ -110,7 +110,7 @@ DefaultTestResultHandler.prototype.displayResults = function () {
 
   // bail out instantly if the test couldn't be executed
   if (testResult.testExecError) {
-    console.log(this._getResultHeader(false, this.filePath));
+    console.log(DefaultTestResultHandler.getResultHeader(false, this.filePath));
     console.log(testResult.testExecError);
     return false;
   }
@@ -130,7 +130,7 @@ DefaultTestResultHandler.prototype.displayResults = function () {
   }
   */
 
-  console.log(this._getResultHeader(this.allTestsPassed, this.filePath, [
+  console.log(DefaultTestResultHandler.getResultHeader(this.allTestsPassed, this.filePath, [
     testRunTimeString
   ]));
 
@@ -160,7 +160,7 @@ DefaultTestResultHandler.prototype._displayDetailedResults = function () {
     // only display the ancestry, if it changed, not for each
     // test in the suite
     if (testTitleAncestry !== currentAncenstry) {
-      console.log("\n", textComponents.descBullet + testTitleAncestry);
+      console.log(currentAncenstry !== undefined ? "\n" : '', textComponents.descBullet + testTitleAncestry);
       currentAncenstry = testTitleAncestry;
     }
 
@@ -170,6 +170,9 @@ DefaultTestResultHandler.prototype._displayDetailedResults = function () {
     result.failureMessages.forEach(_printErrors);
 
   });
+
+  // add a newline after each test group
+  console.log('');
 };
 
 /**

--- a/src/DefaultTestResultHandler.js
+++ b/src/DefaultTestResultHandler.js
@@ -62,7 +62,7 @@ function _printConsoleMessage(msg) {
   }
 }
 
-var DefaultTestResultHandler = function DefaultTestResultHandler(jestConfig, testResult, options) {
+var TestResultHandler = function (jestConfig, testResult, options) {
   this.showDetailedInfo = options && options.showDetailedInfo === true;
   this.testResult = testResult;
   this.filePath = jestConfig.rootDir ?
@@ -80,7 +80,8 @@ var DefaultTestResultHandler = function DefaultTestResultHandler(jestConfig, tes
     msgBullet: '  - '
   };
 
-  this.textComponents.msgIndent = this.textComponents.msgBullet.replace(/./g, ' ');
+  var msgIndent = this.textComponents.msgBullet.replace(/./g, ' ');
+  this.textComponents.msgIndent = msgIndent;
 };
 
 /**
@@ -91,10 +92,10 @@ var DefaultTestResultHandler = function DefaultTestResultHandler(jestConfig, tes
  * @param  {Array}   columns  An array of items to append
  * @return {String}           The header
  */
-DefaultTestResultHandler.getResultHeader = function (passed, testName, columns) {
+TestResultHandler.getResultHeader = function (passed, testName, columns) {
    var passFailTag = passed ?
-                     colors.colorize(' PASS ', PASS_COLOR) :
-                     colors.colorize(' FAIL ', FAIL_COLOR);
+   colors.colorize(' PASS ', PASS_COLOR) :
+   colors.colorize(' FAIL ', FAIL_COLOR);
 
   return [
     passFailTag,
@@ -105,19 +106,19 @@ DefaultTestResultHandler.getResultHeader = function (passed, testName, columns) 
 /**
  * Kicks off rendering of the results
  */
-DefaultTestResultHandler.prototype.displayResults = function () {
+TestResultHandler.prototype.displayResults = function () {
   var testResult = this.testResult;
 
   // bail out instantly if the test couldn't be executed
   if (testResult.testExecError) {
-    console.log(DefaultTestResultHandler.getResultHeader(false, this.filePath));
+    console.log(TestResultHandler.getResultHeader(false, this.filePath));
     console.log(testResult.testExecError);
     return false;
   }
 
   var testRunTime = testResult.perfStats ?
-                    (testResult.perfStats.end - testResult.perfStats.start) / 1000 :
-                    null;
+  (testResult.perfStats.end - testResult.perfStats.start) / 1000 :
+  null;
 
   var testRunTimeString = '(' + testRunTime + 's)';
   if (testRunTime > 2.5) {
@@ -130,7 +131,8 @@ DefaultTestResultHandler.prototype.displayResults = function () {
   }
   */
 
-  console.log(DefaultTestResultHandler.getResultHeader(this.allTestsPassed, this.filePath, [
+  console.log(TestResultHandler.getResultHeader(
+    this.allTestsPassed, this.filePath, [
     testRunTimeString
   ]));
 
@@ -147,7 +149,7 @@ DefaultTestResultHandler.prototype.displayResults = function () {
 /**
  * Displays both failed and passed tests
  */
-DefaultTestResultHandler.prototype._displayDetailedResults = function () {
+TestResultHandler.prototype._displayDetailedResults = function () {
   var textComponents    = this.textComponents;
   var passedIcon        = textComponents.passedIcon;
   var failedIcon        = textComponents.failedIcon;
@@ -156,11 +158,13 @@ DefaultTestResultHandler.prototype._displayDetailedResults = function () {
 
   var currentAncenstry;
   this.testResult.testResults.forEach(function (result) {
-    var testTitleAncestry = DefaultTestResultHandler.getAncestorTitle(result, ancestrySeparator);
+    var testTitleAncestry = TestResultHandler
+                            .getAncestorTitle(result, ancestrySeparator);
     // only display the ancestry, if it changed, not for each
     // test in the suite
     if (testTitleAncestry !== currentAncenstry) {
-      console.log(currentAncenstry !== undefined ? "\n" : '', textComponents.descBullet + testTitleAncestry);
+      var maybeNewline = currentAncenstry !== undefined ? '\n' : '';
+      console.log(maybeNewline, textComponents.descBullet + testTitleAncestry);
       currentAncenstry = testTitleAncestry;
     }
 
@@ -178,7 +182,7 @@ DefaultTestResultHandler.prototype._displayDetailedResults = function () {
 /**
  * Displays failed tests
  */
-DefaultTestResultHandler.prototype._displayResults = function () {
+TestResultHandler.prototype._displayResults = function () {
   if (!this.allTestsPassed) {
 
     var textComponents    = this.textComponents;
@@ -190,7 +194,10 @@ DefaultTestResultHandler.prototype._displayResults = function () {
         return;
       }
 
-      var testTitleAncestry = DefaultTestResultHandler.getAncestorTitle(result, ancestrySeparator) + ancestrySeparator;
+      var testTitleAncestry = TestResultHandler
+                              .getAncestorTitle(result, ancestrySeparator);
+
+      testTitleAncestry = testTitleAncestry + ancestrySeparator;
       console.log(textComponents.descBullet + testTitleAncestry + result.title);
 
       // log all errors
@@ -204,7 +211,7 @@ DefaultTestResultHandler.prototype._displayResults = function () {
  * Logs the passed in error
  * @param  {Object} errorMsg The error to log
  */
-DefaultTestResultHandler.prototype._printErrors = function (errorMsg) {
+TestResultHandler.prototype._printErrors = function (errorMsg) {
   var textComponents  = this.textComponents;
   var msgBullet       = textComponents.msgBullet;
   var msgIndent       = textComponents.msgIndent;
@@ -225,10 +232,10 @@ DefaultTestResultHandler.prototype._printErrors = function (errorMsg) {
 };
 
 
-DefaultTestResultHandler.getAncestorTitle = function (result, separator) {
+TestResultHandler.getAncestorTitle = function (result, separator) {
   return result.ancestorTitles.map(function (title) {
     return colors.colorize(title, colors.BOLD);
   }).join(separator);
 };
 
-module.exports = DefaultTestResultHandler;
+module.exports = TestResultHandler;

--- a/src/defaultTestResultHandler.js
+++ b/src/defaultTestResultHandler.js
@@ -109,28 +109,6 @@ function _getFilePath(jestConfig, testResult) {
        testResult.testFilePath;
 }
 
-// var TestResultHandler = function (jestConfig, testResult, options) {
-//   this.showDetailedInfo = options && options.showDetailedInfo === true;
-//   this.testResult = testResult;
-//   this.filePath = jestConfig.rootDir ?
-//                   path.relative(jestConfig.rootDir, testResult.testFilePath) :
-//                   testResult.testFilePath;
-//
-//   this.allTestsPassed = testResult.numFailingTests === 0;
-//
-//   // define our text components all in one place
-//   this.textComponents = {
-//     passedIcon: colors.colorize(' \u221A ', colors.GREEN),
-//     failedIcon: colors.colorize(' x ', colors.RED),
-//     ancestrySeparator: ' \u203A ',
-//     descBullet: colors.colorize('\u25cf ', colors.BOLD),
-//     msgBullet: '  - '
-//   };
-//
-//   var msgIndent = this.textComponents.msgBullet.replace(/./g, ' ');
-//   this.textComponents.msgIndent = msgIndent;
-// };
-
 /**
  * Returns a colored string based on whether the
  * test failed or passed


### PR DESCRIPTION
As discussed with @jeffmo this is my first stab at incorporating a switch to display more detailed information, i.e. all tests run, instead of just the final result/fail.

I also took the liberty to rewrite the test result handler for now be a configurable class, which for now only supports showing detailed information or the default output, but could be enhanced to show pending tests etc. (which is something I really want, since it's a good way to keep track of what still has to be done)

I assume this PR will be a work in progress, but I thought I'd put it out there, before continuing further to see what you guys feel about it.

With the `--defailInfo` switch enabled, a test suite could look like this:
![image](https://cloud.githubusercontent.com/assets/3470207/3627404/7d912742-0e89-11e4-9888-398976c1ca60.png)
