### PR TITLE
Implement watching

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "optimist": "~0.6.0",
     "q": "~0.9.7",
     "resolve": "~0.6.1",
-    "underscore": "1.2.4"
+    "underscore": "1.2.4",
+    "sane": "~0.5.4"
   },
   "devDependencies": {
     "jshint": "~2.5.0"


### PR DESCRIPTION
* Implemented watching option in the TestRunner class.
* Added watching option to the bin.

The way this feature works is that it runs all tests on the first run when `--watch` is passed and then idles while watching the `testPathDirs` and when something has changed, deleted, or added, tests will be run that relates to the changed file (or dir).

I implemented this in `TestRunner` to be able to reuse it internally. And by doing so I had to move a lot of the file pattern matching logic into the class. But I think it's seems like it belonged there anyways.

closes #38 #7

cc @benjamn @jeffmo @tomocchino