### PR TITLE
string or object for config

### DIFF
--- a/bin/jest.js
+++ b/bin/jest.js
@@ -139,9 +139,9 @@ function runCLI(argv, packageRoot, onComplete) {
 
   var config;
   if (argv.config) {
-    if (argv.config instanceof String) {
+    if (typeof argv.config === 'string') {    
       config = utils.loadConfigFromFile(argv.config);
-    } else if (argv.config instanceof Object) {
+    } else if (typeof argv.config === 'object') {    
       config = Q(utils.normalizeConfig(argv.config));
     }
   } else {


### PR DESCRIPTION
This allows you to do things like this:

``` javascript
var jest = require('jest-cli'),
    path = require('path'),
    root = path.join(__dirname, '../../');

var c = {
    rootDir: root,
    scriptPreprocessor: "./spec/support/preprocessor.js",
    unmockedModulePathPatterns: [
        "node_modules/react"
    ],
    testDirectoryName: "spec",
    testPathIgnorePatterns: [
        "node_modules",
        "spec/support"
    ],
    moduleFileExtensions: [
        "js",
        "json",
        "react"
    ]
};

jest.runCLI({
    config: c
}, root, function () {
    console.log('done');
});

```

The objective of this change is to make it easier to write a gulp plugin without having to reimplement the work that the CLI code does.
