### PR TITLE
Accept single filepath

### DIFF
--- a/bin/jest.js
+++ b/bin/jest.js
@@ -213,13 +213,17 @@ function runCLI(argv, packageRoot, onComplete) {
     }
 
     function _runTestsOnFilePath (path) {
+      console.log('\nRunning test: ' + path + '...');
       return Q.fcall(function() {
         if (argv.runInBand) {
           return testRunner.runTestsInBand([path], _onResultReady);
         } else {
           return testRunner.runTestsParallel([path], _onResultReady);
         }
-      });
+      }).then(function(completionData) {
+          _onRunComplete(completionData);
+          onComplete(completionData.numFailedTests === 0);
+        });
     }
 
     if (argv.onlyChanged) {

--- a/bin/jest.js
+++ b/bin/jest.js
@@ -212,6 +212,16 @@ function runCLI(argv, packageRoot, onComplete) {
         });
     }
 
+    function _runTestsOnFilePath (path) {
+      return Q.fcall(function() {
+        if (argv.runInBand) {
+          return testRunner.runTestsInBand([path], _onResultReady);
+        } else {
+          return testRunner.runTestsParallel([path], _onResultReady);
+        }
+      });
+    }
+
     if (argv.onlyChanged) {
       console.log('Looking for changed files...');
 
@@ -243,7 +253,11 @@ function runCLI(argv, packageRoot, onComplete) {
         }
       });
     } else {
-      _runTestsOnPathPattern(pathPattern).done();
+      if (config.filePath) {
+        _runTestsOnFilePath(config.filePath).done();
+      } else {
+        _runTestsOnPathPattern(pathPattern).done();
+      }
     }
   });
 }

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -213,6 +213,7 @@ function normalizeConfig(config) {
       case 'testDirectoryName':
       case 'testFileExtensions':
       case 'moduleFileExtensions':
+      case 'filePath':
         value = config[key];
         break;
 


### PR DESCRIPTION
This change allows you to run a single test file. I've added the `filePath` property to the config options as the documentation seems to suggest it would be the right place:

```
Options:
  --config, -c
      The path to a jest config file specifying how to find and execute tests.
```

Although I can see the merit in there being a `--file` command line flag too.

The purpose of this change is to make the Jest CLI easier to use with a grunt / gulp style work flow:

`Component.js` is changed -> grunt / gulp watch notices -> runs `spec/component-spec.js`
