### PR TITLE
buildLoader does not have parameters

### DIFF
--- a/src/HasteModuleLoader/__tests__/HasteModuleLoader-genMockFromModule-test.js
+++ b/src/HasteModuleLoader/__tests__/HasteModuleLoader-genMockFromModule-test.js
@@ -27,7 +27,7 @@ describe('nodeHasteModuleLoader', function() {
     if (!resourceMap) {
       return HasteModuleLoader.loadResourceMap(CONFIG).then(function(map) {
         resourceMap = map;
-        return buildLoader(CONFIG);
+        return buildLoader();
       });
     } else {
       return q(new HasteModuleLoader(CONFIG, mockEnvironment, resourceMap));

--- a/src/HasteModuleLoader/__tests__/HasteModuleLoader-requireMock-test.js
+++ b/src/HasteModuleLoader/__tests__/HasteModuleLoader-requireMock-test.js
@@ -27,7 +27,7 @@ describe('HasteModuleLoader', function() {
     if (!resourceMap) {
       return HasteModuleLoader.loadResourceMap(CONFIG).then(function(map) {
         resourceMap = map;
-        return buildLoader(CONFIG);
+        return buildLoader();
       });
     } else {
       return q(new HasteModuleLoader(CONFIG, mockEnvironment, resourceMap));


### PR DESCRIPTION
That is a tiny one, I guess it is a leftover from a refactoring.
Function buildLoader does not have parameters.
