### PR TITLE
Make node core modules work on modulePathIgnorePatterns

### DIFF
--- a/src/HasteModuleLoader/HasteModuleLoader.js
+++ b/src/HasteModuleLoader/HasteModuleLoader.js
@@ -123,6 +123,7 @@ function Loader(config, environment, resourceMap) {
   this._reverseDependencyMap = null;
   this._shouldAutoMock = true;
   this._configShouldMockModuleNames = {};
+
   if (_configUnmockListRegExpCache === null) {
     // Node must have been run with --harmony in order for WeakMap to be
     // available
@@ -132,6 +133,7 @@ function Loader(config, environment, resourceMap) {
 
     _configUnmockListRegExpCache = new WeakMap();
   }
+
   if (!config.unmockedModulePathPatterns
       || config.unmockedModulePathPatterns.length === 0) {
     this._unmockListRegExps = [];
@@ -330,6 +332,7 @@ Loader.prototype._getNormalizedModuleID = function(currPath, moduleName) {
   var moduleType;
   var mockAbsPath = null;
   var realAbsPath = null;
+
   if (this._builtInModules.hasOwnProperty(moduleName)) {
     moduleType = 'builtin';
     realAbsPath = moduleName;
@@ -684,6 +687,7 @@ Loader.prototype.getDependenciesFromPath = function(modulePath) {
       'Could not extract dependency information from this type of file!'
     );
   }
+
   return this._getDependencyPathsFromResource(resource);
 };
 

--- a/src/HasteModuleLoader/HasteModuleLoader.js
+++ b/src/HasteModuleLoader/HasteModuleLoader.js
@@ -588,10 +588,7 @@ Loader.prototype._shouldMock = function(currPath, moduleName) {
       this._configShouldMockModuleNames[moduleName] = true;
       for (var i = 0; i < this._unmockListRegExps.length; i++) {
         unmockRegExp = this._unmockListRegExps[i];
-        if ((unmockRegExp.test(modulePath))) {
-          return this._configShouldMockModuleNames[moduleName] = false;
-        }
-        if (modulePath === null){
+        if ((unmockRegExp.test(modulePath)) || (modulePath === null)) {
           return this._configShouldMockModuleNames[moduleName] = false;
         }
 

--- a/src/HasteModuleLoader/HasteModuleLoader.js
+++ b/src/HasteModuleLoader/HasteModuleLoader.js
@@ -588,10 +588,9 @@ Loader.prototype._shouldMock = function(currPath, moduleName) {
       this._configShouldMockModuleNames[moduleName] = true;
       for (var i = 0; i < this._unmockListRegExps.length; i++) {
         unmockRegExp = this._unmockListRegExps[i];
-        if ((unmockRegExp.test(modulePath)) || (modulePath === null)) {
+        if (unmockRegExp.test(modulePath) || modulePath === null) {
           return this._configShouldMockModuleNames[moduleName] = false;
         }
-
       }
       return this._configShouldMockModuleNames[moduleName];
     }

--- a/src/HasteModuleLoader/HasteModuleLoader.js
+++ b/src/HasteModuleLoader/HasteModuleLoader.js
@@ -70,6 +70,7 @@ var NODE_CORE_MODULES = {
 var _configUnmockListRegExpCache = null;
 
 function _buildLoadersList(config) {
+  // debugger;
   return [
     new hasteLoaders.ProjectConfigurationLoader(),
     new hasteLoaders.JSTestLoader(config.setupJSTestLoaderOptions),
@@ -123,7 +124,6 @@ function Loader(config, environment, resourceMap) {
   this._reverseDependencyMap = null;
   this._shouldAutoMock = true;
   this._configShouldMockModuleNames = {};
-
   if (_configUnmockListRegExpCache === null) {
     // Node must have been run with --harmony in order for WeakMap to be
     // available
@@ -133,7 +133,7 @@ function Loader(config, environment, resourceMap) {
 
     _configUnmockListRegExpCache = new WeakMap();
   }
-
+  // debugger;
   if (!config.unmockedModulePathPatterns
       || config.unmockedModulePathPatterns.length === 0) {
     this._unmockListRegExps = [];
@@ -252,6 +252,7 @@ Loader.prototype._execModule = function(moduleObj) {
 };
 
 Loader.prototype._generateMock = function(currPath, moduleName) {
+  // debugger;
   var modulePath = this._moduleNameToPath(currPath, moduleName);
 
   if (!this._mockMetaDataCache.hasOwnProperty(modulePath)) {
@@ -310,6 +311,7 @@ Loader.prototype._getDependencyPathsFromResource = function(resource) {
 
     dependencyPaths.push(this._getRealPathFromNormalizedModuleID(moduleID));
   }
+  console.log(dependencyPaths);
   return dependencyPaths;
 };
 
@@ -332,7 +334,6 @@ Loader.prototype._getNormalizedModuleID = function(currPath, moduleName) {
   var moduleType;
   var mockAbsPath = null;
   var realAbsPath = null;
-
   if (this._builtInModules.hasOwnProperty(moduleName)) {
     moduleType = 'builtin';
     realAbsPath = moduleName;
@@ -472,6 +473,7 @@ Loader.prototype._moduleNameToPath = function(currPath, moduleName) {
 
 Loader.prototype._nodeModuleNameToPath = function(currPath, moduleName) {
   // Handle module names like require('jest/lib/util')
+  // debugger;
   var subModulePath = null;
   var moduleProjectPart = moduleName;
   if (/\//.test(moduleName)) {
@@ -591,9 +593,14 @@ Loader.prototype._shouldMock = function(currPath, moduleName) {
       this._configShouldMockModuleNames[moduleName] = true;
       for (var i = 0; i < this._unmockListRegExps.length; i++) {
         unmockRegExp = this._unmockListRegExps[i];
-        if (unmockRegExp.test(modulePath)) {
+        if ((unmockRegExp.test(modulePath))) {
           return this._configShouldMockModuleNames[moduleName] = false;
         }
+        if (modulePath === null){
+          // debugger;
+          return this._configShouldMockModuleNames[moduleName] = false;
+        }
+
       }
       return this._configShouldMockModuleNames[moduleName];
     }
@@ -687,7 +694,6 @@ Loader.prototype.getDependenciesFromPath = function(modulePath) {
       'Could not extract dependency information from this type of file!'
     );
   }
-
   return this._getDependencyPathsFromResource(resource);
 };
 
@@ -836,7 +842,8 @@ Loader.prototype.requireModule = function(currPath, moduleName,
   if (!moduleResource
       && manualMockResource
       && manualMockResource.path !== this._isCurrentlyExecutingManualMock
-      && this._explicitShouldMock[moduleID] !== false) {
+      && this._explicitShouldMock[moduleID] !== false
+      && !(moduleName in NODE_CORE_MODULES)) {
     modulePath = manualMockResource.path;
   }
 
@@ -901,6 +908,7 @@ Loader.prototype.requireModule = function(currPath, moduleName,
  * @return object
  */
 Loader.prototype.requireModuleOrMock = function(currPath, moduleName) {
+  // debugger;
   if (this._shouldMock(currPath, moduleName)) {
     return this.requireMock(currPath, moduleName);
   } else {

--- a/src/HasteModuleLoader/HasteModuleLoader.js
+++ b/src/HasteModuleLoader/HasteModuleLoader.js
@@ -70,7 +70,6 @@ var NODE_CORE_MODULES = {
 var _configUnmockListRegExpCache = null;
 
 function _buildLoadersList(config) {
-  // debugger;
   return [
     new hasteLoaders.ProjectConfigurationLoader(),
     new hasteLoaders.JSTestLoader(config.setupJSTestLoaderOptions),
@@ -133,7 +132,6 @@ function Loader(config, environment, resourceMap) {
 
     _configUnmockListRegExpCache = new WeakMap();
   }
-  // debugger;
   if (!config.unmockedModulePathPatterns
       || config.unmockedModulePathPatterns.length === 0) {
     this._unmockListRegExps = [];
@@ -252,7 +250,6 @@ Loader.prototype._execModule = function(moduleObj) {
 };
 
 Loader.prototype._generateMock = function(currPath, moduleName) {
-  // debugger;
   var modulePath = this._moduleNameToPath(currPath, moduleName);
 
   if (!this._mockMetaDataCache.hasOwnProperty(modulePath)) {
@@ -311,7 +308,6 @@ Loader.prototype._getDependencyPathsFromResource = function(resource) {
 
     dependencyPaths.push(this._getRealPathFromNormalizedModuleID(moduleID));
   }
-  console.log(dependencyPaths);
   return dependencyPaths;
 };
 
@@ -473,7 +469,6 @@ Loader.prototype._moduleNameToPath = function(currPath, moduleName) {
 
 Loader.prototype._nodeModuleNameToPath = function(currPath, moduleName) {
   // Handle module names like require('jest/lib/util')
-  // debugger;
   var subModulePath = null;
   var moduleProjectPart = moduleName;
   if (/\//.test(moduleName)) {
@@ -597,7 +592,6 @@ Loader.prototype._shouldMock = function(currPath, moduleName) {
           return this._configShouldMockModuleNames[moduleName] = false;
         }
         if (modulePath === null){
-          // debugger;
           return this._configShouldMockModuleNames[moduleName] = false;
         }
 
@@ -908,7 +902,6 @@ Loader.prototype.requireModule = function(currPath, moduleName,
  * @return object
  */
 Loader.prototype.requireModuleOrMock = function(currPath, moduleName) {
-  // debugger;
   if (this._shouldMock(currPath, moduleName)) {
     return this.requireMock(currPath, moduleName);
   } else {


### PR DESCRIPTION
...ock #106
This is not the best fix but it solves the problem for node modules.
I would appreciate some feedback on ways to improve it.
Need to write the tests still.