### PR TITLE
Correctly compile literate coffee files.

### DIFF
--- a/examples/coffeescript/preprocessor.js
+++ b/examples/coffeescript/preprocessor.js
@@ -4,7 +4,10 @@ module.exports = {
   process: function(src, path) {
     // CoffeeScript files can be .coffee, .litcoffee, or .coffee.md
     if (coffee.helpers.isCoffee(path)) {
-      return coffee.compile(src, {'bare': true});
+      return coffee.compile(src, {
+        'bare': true,
+        'literate': CoffeeScript.helpers.isLiterate(path)
+      });
     }
     return src;
   }


### PR DESCRIPTION
Literate coffee files were being detected, but if you actually tried to compile one you would get an error because the literate option wasn't set on the compiler.
