### PR TITLE
Preserve setTimeout/setInterval Arguments

### DIFF
--- a/src/lib/FakeTimers.js
+++ b/src/lib/FakeTimers.js
@@ -267,11 +267,18 @@ FakeTimers.prototype._fakeSetInterval = function(callback, intervalDelay) {
     intervalDelay = 0;
   }
 
+  var args = [];
+  for (var ii = 2, ll = arguments.length; ii < ll; ii++) {
+    args.push(arguments[ii]);
+  }
+
   var uuid = this._uuidCounter++;
 
   this._timers[uuid] = {
     type: 'interval',
-    callback: callback,
+    callback: function() {
+      return callback.apply(null, args);
+    },
     expiry: this._now + intervalDelay,
     interval: intervalDelay
   };
@@ -284,11 +291,18 @@ FakeTimers.prototype._fakeSetTimeout = function(callback, delay)  {
     delay = 0;
   }
 
+  var args = [];
+  for (var ii = 2, ll = arguments.length; ii < ll; ii++) {
+    args.push(arguments[ii]);
+  }
+
   var uuid = this._uuidCounter++;
 
   this._timers[uuid] = {
     type: 'timeout',
-    callback: callback,
+    callback: function() {
+      return callback.apply(null, args);
+    },
     expiry: this._now + delay,
     interval: null
   };

--- a/src/lib/__tests__/FakeTimers-test.js
+++ b/src/lib/__tests__/FakeTimers-test.js
@@ -249,6 +249,19 @@ describe('FakeTimers', function() {
       expect(fn.mock.calls.length).toBe(1);
     });
 
+    it('runs callbacks with arguments after the interval', function() {
+      var global = {};
+      var fakeTimers = new FakeTimers(global);
+
+      var fn = jest.genMockFn();
+      global.setTimeout(fn, 0, 'mockArg1', 'mockArg2');
+
+      fakeTimers.runAllTimers();
+      expect(fn.mock.calls).toEqual([
+        ['mockArg1', 'mockArg2']
+      ]);
+    });
+
     it('doesnt pass the callback to native setTimeout', function() {
       var nativeSetTimeout = jest.genMockFn();
 


### PR DESCRIPTION
Preserves the arguments after the supplied `interval` when calling `setTimout` and `setInterval`.
