### PR TITLE
Fix issue where .jsx dependencies are not resolved

### DIFF
--- a/src/HasteModuleLoader/HasteModuleLoader.js
+++ b/src/HasteModuleLoader/HasteModuleLoader.js
@@ -484,7 +484,10 @@ Loader.prototype._nodeModuleNameToPath = function(currPath, moduleName) {
   try {
     return resolve.sync(moduleName, {
       basedir: path.dirname(currPath),
-      extensions: ['.js', '.json', '.jsx']
+      extensions: this._config.moduleFileExtensions
+        .map(function(ext){ 
+          return '.' + ext; 
+        })
     });
   } catch (e) {
     // Facebook has clowny package.json resolution rules that don't apply to


### PR DESCRIPTION
I've got several projects that will pull in JSX projects via node_modules, when the dependencies are jsx files I'm getting not found.  This fix will fix the problem for me because I've got a JSX preprocessor setup to compile the jsx for the test, I'm not sure if this is the way you would prefer to solve this issue, if you have some other solution I am open to other ideas, but so far this works for me.
