### PR TITLE
Update jasmine from the future for better stack trace

### DIFF
--- a/vendor/jasmine/jasmine-1.3.0.js
+++ b/vendor/jasmine/jasmine-1.3.0.js
@@ -2319,11 +2319,10 @@ jasmine.Spec.prototype.waitsFor = function(latchFunction, optional_timeoutMessag
 };
 
 jasmine.Spec.prototype.fail = function (e) {
-  var isError = e instanceof Error;
   var expectationResult = new jasmine.ExpectationResult({
     passed: false,
-    message: isError ? jasmine.util.formatException(e) : 'Throws: ' + e,
-    trace: { stack: isError ? e.stack : null }
+    message: e ? jasmine.util.formatException(e) : 'Exception',
+    trace: { stack: e.stack }
   });
   this.results_.addResult(expectationResult);
 };


### PR DESCRIPTION
Using assert in Jasmine 1.3.0 doesn't give you a proper stack trace. However, this is fixed in 1.3.1 but it's hard for us to bring in all the changes. So I'm brining in a change to fix this particular problem. For posterity here is a link to the code I copied:
https://github.com/pivotal/jasmine/blob/1c2e50d244c07c16b217cdbc26ee17c27ea24033/src/core/Spec.js#L120-127
