### PR TITLE
Fix TestRunner-test

### DIFF
--- a/src/__tests__/TestRunner-test.js
+++ b/src/__tests__/TestRunner-test.js
@@ -8,8 +8,7 @@
 'use strict';
 
 require('jest-runtime')
-  .autoMockOff()
-  .mock('fs');
+  .autoMockOff();
 
 var q = require('q');
 
@@ -87,7 +86,7 @@ describe('TestRunner', function() {
     }
 
     beforeEach(function() {
-      fs = require('fs');
+      fs = require('graceful-fs');
       utils = require('../lib/utils');
       runner = new TestRunner(utils.normalizeConfig({
         rootDir: '.',


### PR DESCRIPTION
Currently the tests in TestRunner are failing because they are mocking
the wrong filesystem module.

graceful-fs cannot be automocked because the resource loader also
depends on it (so mocking it out seems to force auto mocking to be
enabled even though it shouldn’t be)
