### PR TITLE
RFC: Consolidate reporting, print remaining tests

### DIFF
--- a/bin/jest.js
+++ b/bin/jest.js
@@ -64,37 +64,6 @@ function _findChangedFiles(dirPath) {
   return deferred.promise;
 }
 
-function _onResultReady(config, result) {
-  return defaultTestResultHandler(config, result);
-}
-
-function _onRunComplete(completionData) {
-  var numFailedTests = completionData.numFailedTests;
-  var numTotalTests = completionData.numTotalTests;
-  var numPassedTests = numTotalTests - numFailedTests;
-  var startTime = completionData.startTime;
-  var endTime = completionData.endTime;
-
-  var results = '';
-  if (numFailedTests) {
-    results +=
-	  colors.colorize(
-	    [numFailedTests, (numFailedTests > 1 ? 'tests' : 'test'), 'failed'].join(' '),
-	    colors.RED + colors.BOLD
-	  );
-	results += ', ';
-  }
-  results +=
-    colors.colorize(
-		[numPassedTests, (numPassedTests > 1 ? 'tests' : 'test'), 'passed'].join(' '),
-		colors.GREEN + colors.BOLD
-	);
-  results += ' (' + numTotalTests + ' total)';
-
-  console.log(results);
-  console.log('Run time: ' + ((endTime - startTime) / 1000) + 's');
-}
-
 function _verifyIsGitRepository(dirPath) {
   var deferred = Q.defer();
 
@@ -210,20 +179,13 @@ function runCLI(argv, packageRoot, onComplete) {
 
       return deferred.promise
         .then(function(matchingTestPaths) {
-          var numMatching = matchingTestPaths.length;
-          var pluralizedTest = numMatching > 1 ? 'tests' : 'test';
-
-          console.log(
-            'Found ' + numMatching + ' matching ' + pluralizedTest + '...'
-          );
           if (argv.runInBand) {
-            return testRunner.runTestsInBand(matchingTestPaths, _onResultReady);
+            return testRunner.runTestsInBand(matchingTestPaths, defaultTestResultHandler);
           } else {
-            return testRunner.runTestsParallel(matchingTestPaths, _onResultReady);
+            return testRunner.runTestsParallel(matchingTestPaths, defaultTestResultHandler);
           }
         })
         .then(function(completionData) {
-          _onRunComplete(completionData);
           onComplete(completionData.numFailedTests === 0);
         });
     }

--- a/src/TestRunner.js
+++ b/src/TestRunner.js
@@ -371,19 +371,22 @@ TestRunner.prototype.runTest = function(testFilePath) {
  * its own.
  *
  * @param {Array<String>} testPaths Array of paths to test files
- * @param {Function} onResult Callback called once for each test result
+ * @param {Object} reporter Collection of callbacks called on test events
  * @return {Promise<Object>} Fulfilled with aggregate pass/fail information
  *                           about all tests that were run
  */
-TestRunner.prototype.runTestsInBand = function(testPaths, onResult) {
+TestRunner.prototype.runTestsInBand = function(testPaths, reporter) {
   var config = this._config;
 
   var aggregatedResults = {
     numFailedTests: 0,
+    numPassedTests: 0,
     numTotalTests: testPaths.length,
     startTime: Date.now(),
     endTime: null
   };
+
+  reporter.onRunStart(config, aggregatedResults);
 
   var testSequence = q();
   testPaths.forEach(function(testPath) {
@@ -391,23 +394,26 @@ TestRunner.prototype.runTestsInBand = function(testPaths, onResult) {
       .then(function(testResult) {
         if (testResult.numFailingTests > 0) {
           aggregatedResults.numFailedTests++;
+        } else {
+          aggregatedResults.numPassedTests++;
         }
-        onResult && onResult(config, testResult);
+        reporter.onTestResult(config, testResult, aggregatedResults);
       })
       .catch(function(err) {
         aggregatedResults.numFailedTests++;
-        onResult && onResult(config, {
+        reporter.onTestResult(config, {
           testFilePath: testPath,
           testExecError: err,
           suites: {},
           tests: {},
           logMessages: []
-        });
+        }, aggregatedResults);
       });
   }, this);
 
   return testSequence.then(function() {
     aggregatedResults.endTime = Date.now();
+    reporter.onRunComplete(config, aggregatedResults);
     return aggregatedResults;
   });
 };
@@ -416,19 +422,22 @@ TestRunner.prototype.runTestsInBand = function(testPaths, onResult) {
  * Run all given test paths in parallel using a worker pool.
  *
  * @param {Array<String>} testPaths Array of paths to test files
- * @param {Function} onResult Callback called once for each test result
+ * @param {Object} reporter Collection of callbacks called on test events
  * @return {Promise<Object>} Fulfilled with aggregate pass/fail information
  *                           about all tests that were run
  */
-TestRunner.prototype.runTestsParallel = function(testPaths, onResult) {
+TestRunner.prototype.runTestsParallel = function(testPaths, reporter) {
   var config = this._config;
 
   var aggregatedResults = {
     numFailedTests: 0,
+    numPassedTests: 0,
     numTotalTests: testPaths.length,
     startTime: Date.now(),
     endTime: null
   };
+
+  reporter.onRunStart(config, aggregatedResults);
 
   var workerPool = new WorkerPool(
     this._opts.maxWorkers,
@@ -453,18 +462,20 @@ TestRunner.prototype.runTestsParallel = function(testPaths, onResult) {
           .then(function(testResult) {
             if (testResult.numFailingTests > 0) {
               aggregatedResults.numFailedTests++;
+            } else {
+              aggregatedResults.numPassedTests++;
             }
-            onResult && onResult(config, testResult);
+            reporter.onTestResult(config, testResult, aggregatedResults);
           })
           .catch(function(err) {
             aggregatedResults.numFailedTests++;
-            onResult(config, {
+            reporter.onTestResult(config, {
               testFilePath: testPath,
               testExecError: err.stack || err.message || err,
               suites: {},
               tests: {},
               logMessages: []
-            });
+            }, aggregatedResults);
 
             // Jest uses regular worker messages to initialize workers, so
             // there's no way for node-worker-pool to understand how to
@@ -497,6 +508,7 @@ TestRunner.prototype.runTestsParallel = function(testPaths, onResult) {
     .then(function() {
       return workerPool.destroy().then(function() {
         aggregatedResults.endTime = Date.now();
+        reporter.onRunComplete(config, aggregatedResults);
         return aggregatedResults;
       });
     });


### PR DESCRIPTION
This is an RFC, I'm happy to chop it up for actual committing, but I wanted to have this to start a conversation.

This does a few things:

1) Consolidate console action during a jest run into one place. This is mostly a straight-forward move of code from bin/jest to defaultTestResultHandler.
2) Expose aggregatedResults to every callback, rather than just the end.
3) Add testsPassed as a metric in aggregatedResults so we can make sense of it before the whole run has finished.
4) Print a trailing "Waiting on..." at the bottom of the feedback.
