### PR TITLE
TestReporter accepts a process to use, no console.log

### DIFF
--- a/src/TestRunner.js
+++ b/src/TestRunner.js
@@ -402,7 +402,8 @@ TestRunner.prototype.runTest = function(testFilePath) {
  */
 TestRunner.prototype.runTests = function(testPaths, reporter) {
   if (!reporter) {
-    reporter = require('./defaultTestReporter');
+    var DefaultTestReporter = require('./DefaultTestReporter');
+    reporter = new DefaultTestReporter();
   }
   var config = this._config;
 


### PR DESCRIPTION
Our custom CLI wants to reuse the default test reporter, but it also wants to replace stdout with a custom stream. This seems like the least invasive way to do so.
