### PR TITLE
Update coffee-script to 1.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.2.0",
   "main": "src/jest.js",
   "dependencies": {
-    "coffee-script": "1.7.1",
+    "coffee-script": "^1.8.0",
     "cover": "~0.2.8",
     "diff": "~1.0.4",
     "graceful-fs": "^2.0.3",


### PR DESCRIPTION
coffee-script is at 1.8.0 now. Updating jest's dependency version should fix warnings that look like `npm WARN unmet dependency node_modules/jest-cli requires coffee-script@'1.7.1' but will load` when it is used in a package that depends oncoffee-script 1.8.0.

Here is the CS 1.8.0 change log: http://coffeescript.org/#changelog

Tested by running `npm test` and `cd examples/coffeescript; npm test`.
