### PR TITLE
Add ability to specify module search paths in config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Check out the [Getting Started](http://facebook.github.io/jest/docs/getting-star
   - [`config.testPathDirs` [array<string>]](http://facebook.github.io/jest/docs/api.html#config-testpathdirs-array-string)
   - [`config.testPathIgnorePatterns` [array<string>]](http://facebook.github.io/jest/docs/api.html#config-testpathignorepatterns-array-string)
   - [`config.unmockedModulePathPatterns` [array<string>]](http://facebook.github.io/jest/docs/api.html#config-unmockedmodulepathpatterns-array-string)
+  - [`config.moduleDirectories` [array<string>]](#)
 
 #### Globally injected variables
 

--- a/src/HasteModuleLoader/HasteModuleLoader.js
+++ b/src/HasteModuleLoader/HasteModuleLoader.js
@@ -125,6 +125,7 @@ function Loader(config, environment, resourceMap) {
   this._reverseDependencyMap = null;
   this._shouldAutoMock = true;
   this._configShouldMockModuleNames = {};
+  this._moduleDirectories = config.moduleDirectories;
 
   if (_configUnmockListRegExpCache === null) {
     // Node must have been run with --harmony in order for WeakMap to be
@@ -415,6 +416,8 @@ Loader.prototype._moduleNameToPath = function(currPath, moduleName) {
   // need to be looked up with context of the module that's calling
   // require().
   if (IS_PATH_BASED_MODULE_NAME.test(moduleName)) {
+    var moduleDirectories = this._moduleDirectories;
+
     // Normalize the relative path to an absolute path
     var modulePath = path.resolve(currPath, '..', moduleName);
 
@@ -426,6 +429,13 @@ Loader.prototype._moduleNameToPath = function(currPath, moduleName) {
     if (fs.existsSync(modulePath) &&
         fs.statSync(modulePath).isFile()) {
       return modulePath;
+    }
+    for (i = 0; i < moduleDirectories.length; i++) {
+      var otherModulePath = path.resolve(moduleDirectories[i], moduleName);
+      if (fs.existsSync(otherModulePath) &&
+          fs.statSync(otherModulePath).isFile()) {
+        return otherModulePath;
+      }
     }
     // LOAD_AS_FILE #2+
     for (i = 0; i < extensions.length; i++) {

--- a/src/lib/__tests__/utils-normalizeConfig-test.js
+++ b/src/lib/__tests__/utils-normalizeConfig-test.js
@@ -290,6 +290,17 @@ describe('utils-normalizeConfig', function() {
       ]);
     });
 
+    describe('moduleDirectories', function() {
+      it('substitutes <rootDir> tokens', function() {
+        var config = utils.normalizeConfig({
+          rootDir: '/root/path/foo',
+          moduleDirectories: ['<rootDir>/bar/baz']
+        });
+
+        expect(config.moduleDirectories[0]).toEqual(expectedPathFooBar);
+      });
+    });
+
     it('does not normalize trailing slashes', function() {
       // This is a list of patterns, so we can't assume any of them are
       // directories

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -24,6 +24,7 @@ var DEFAULT_CONFIG_VALUES = {
   testPathDirs: ['<rootDir>'],
   testPathIgnorePatterns: ['/node_modules/'],
   testRunner: require.resolve('../jasmineTestRunner/jasmineTestRunner'),
+  moduleDirectories: []
 };
 
 function _replaceRootDirTags(rootDir, config) {
@@ -193,6 +194,7 @@ function normalizeConfig(config) {
       case 'testPathIgnorePatterns':
       case 'modulePathIgnorePatterns':
       case 'unmockedModulePathPatterns':
+      case 'moduleDirectories':
         // _replaceRootDirTags is specifically well-suited for substituting
         // <rootDir> in paths (it deals with properly interpreting relative path
         // separators, etc).


### PR DESCRIPTION
Changes the config API by adding a `moduleDirectories` key, where you can specify search paths for modules. Fixes #112.