### PR TITLE
Update jsdom to a modern version

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "harmonize": "~1.33.7",
     "jasmine-only": "0.1.0",
     "jasmine-pit": "~2.0.0",
-    "jsdom": "~0.10.3",
+    "jsdom": "^3.0.1",
     "node-find-files": "~0.0.2",
     "node-haste": "^1.2.8",
     "node-worker-pool": "~2.4.2",

--- a/src/JSDomEnvironment.js
+++ b/src/JSDomEnvironment.js
@@ -29,7 +29,8 @@ function JSDomEnvironment(config) {
   // use it (depending on the context -- such as TestRunner.js when operating as
   // a workerpool parent), this is the best way to ensure we only spend time
   // require()ing this when necessary.
-  this.global = require('./lib/jsdom-compat').jsdom().parentWindow;
+  // this.global = require('./lib/jsdom-compat').jsdom().parentWindow;
+  this.global = require('jsdom').jsdom().parentWindow;
 
   // Node's error-message stack size is limited at 10, but it's pretty useful to
   // see more than that when a test fails.
@@ -71,12 +72,12 @@ function JSDomEnvironment(config) {
 
   // jsdom doesn't have support for window.Image, so we just replace it with a
   // dummy constructor
-  try {
-    /* jshint nonew:false */
-    new this.global.Image();
-  } catch (e) {
-    this.global.Image = function Image() {};
-  }
+  // try {
+  //   /* jshint nonew:false */
+  //   new this.global.Image();
+  // } catch (e) {
+  //   this.global.Image = function Image() {};
+  // }
 
   // Pass through the node `process` global.
   // TODO: Consider locking this down somehow so tests can't do crazy stuff to


### PR DESCRIPTION
This isn't ready BUT I wanted to get this started. I think we should go all the way to current jsdom and skip any intermediate versions. We're just going to get stuck again unless we fix the underlying dependency issues.

- [ ] Stop using our compat layer
  - [ ] Do we need `CSSPropertyParsers`?
  - [ ] Ensure `HTMLMediaElement` is supported upstream
  - [ ] Ensure `HTMLVideoElement` is supported upstream
  - [x] Ensure fix for `HTMLInputElement.checked` is supported upstream (https://github.com/tmpvar/jsdom/pull/1007)
  - [ ] Ensure fix for `HTMLSelectElement` and `multiple` selection is supported upstream
  - [ ] Add tests for the things we had in our compat layer?
- [ ] Ensure all of FB's internal tests pass and aren't depending on old jsdom behavior

cc @domenic who may be able to answer some of the above about support (I bet I could look at changelogs/code, but I know you're interested anyway :smile:). And @nhunzaker who was working on getting us to jsdom@1.5

If anybody wants to help out, let's do PRs against this branch.