### PR TITLE
use process exit listener instead of process.exit()

### DIFF
--- a/bin/jest.js
+++ b/bin/jest.js
@@ -110,7 +110,12 @@ var argv = optimist
 
 if (argv.help) {
   optimist.showHelp();
-  process.exit(0);
+
+  process.on('exit', function(){
+    process.exit(1);
+  });
+
+  return;
 }
 
 var cwd = process.cwd();
@@ -145,7 +150,12 @@ if (fs.existsSync(cwdJestBinPath)) {
       'installed globally.\n' +
       'Please upgrade this project past Jest version 0.1.5'
     );
-    process.exit(1);
+
+    process.on('exit', function(){
+       process.exit(1);
+    });
+    
+    return;
   }
 } else {
   // Otherwise, load this version of Jest.
@@ -165,7 +175,12 @@ if (fs.existsSync(cwdJestBinPath)) {
         'Please run `npm install` to use the version of Jest intended for ' +
         'this project.'
       );
-      process.exit(1);
+
+      process.on('exit', function(){
+        process.exit(1);
+      });
+
+      return;
     }
   }
 }
@@ -175,5 +190,7 @@ if (!argv.version) {
 }
 
 jest.runCLI(argv, cwdPackageRoot, function (success) {
-  process.exit(success ? 0 : 1);
+  process.on('exit', function(){
+    process.exit(success ? 0 : 1);
+  });
 });


### PR DESCRIPTION
This is an updated PR using the most recent jest bin from master (from #111), and proposed solution to #110. I do not have the foggiest notion on how to write a test for this, and couldn't find any bin tests anyway...

I have manually checked on Windows 8.1, using the [getting started](https://facebook.github.io/jest/docs/getting-started.html#content) code as the test code and running:

- the tests with the globally installed jest-cli (`0.2.1`)
- then `npm link` this branch and run the tests again.

The problem is present in the most recent version of jest in my example test, and this change resolves it. The added `return`s prevent further code execution quite nicely it seems. In all most attempts to check it (`--help` and missing local install), nothing past the return ran (I would hope not!), but the `process.on('exit')` listeners still fire.

Hope that helps, its nice to finally see some output on my tests :P