### PR TITLE
Windows fix: path.normalize for TestRunner-fs-test.js

### DIFF
--- a/src/__tests__/TestRunner-fs-test.js
+++ b/src/__tests__/TestRunner-fs-test.js
@@ -27,7 +27,7 @@ describe('TestRunner-fs', function() {
         var relPaths = paths.map(function (absPath) {
           return path.relative(rootDir, absPath);
         });
-        expect(relPaths).toEqual(['__testtests__/test.js']);
+        expect(relPaths).toEqual([path.normalize('__testtests__/test.js')]);
       });
     });
 
@@ -42,7 +42,7 @@ describe('TestRunner-fs', function() {
         var relPaths = paths.map(function (absPath) {
           return path.relative(rootDir, absPath);
         });
-        expect(relPaths).toEqual(['__testtests__/test.jsx']);
+        expect(relPaths).toEqual([path.normalize('__testtests__/test.jsx')]);
       });
     });
 
@@ -57,7 +57,7 @@ describe('TestRunner-fs', function() {
         var relPaths = paths.map(function (absPath) {
           return path.relative(rootDir, absPath);
         });
-        expect(relPaths).toEqual(['__testtests__/test.foobar']);
+        expect(relPaths).toEqual([path.normalize('__testtests__/test.foobar')]);
       });
     });
 
@@ -73,8 +73,8 @@ describe('TestRunner-fs', function() {
           return path.relative(rootDir, absPath);
         });
         expect(relPaths.sort()).toEqual([
-          '__testtests__/test.js',
-          '__testtests__/test.jsx',
+          path.normalize('__testtests__/test.js'),
+          path.normalize('__testtests__/test.jsx'),
         ]);
       });
     });


### PR DESCRIPTION
Fix to 4 jest unit tests at `TestRunner-fs-test.js` that failed on Windows. e.g.:

    - Expected: {
      | 0: '__testtests__\test.js'
      } toEqual: {
      | 0: '__testtests__/test.js'
      }

But `HasteModuleLoader-requireMock-test.js` still has a failing test, but it's not related to paths, and I couldn't fix it:

    HasteModuleLoader › requireMock › it just falls back when loading a native module
    - Expected '%1 is not a valid Win32 application.
      c:\Prog\Others\jest\protron\src\HasteModuleLoader\__tests__\test_root\NativeModule.node' to contain 'NativeModule.node: file too short'.