### PR TITLE
Require JSON files from same environment as modules

### DIFF
--- a/src/HasteModuleLoader/HasteModuleLoader.js
+++ b/src/HasteModuleLoader/HasteModuleLoader.js
@@ -889,7 +889,7 @@ Loader.prototype.requireModule = function(currPath, moduleName,
 
     // Good ole node...
     if (path.extname(modulePath) === '.json') {
-      moduleObj.exports = JSON.parse(fs.readFileSync(
+      moduleObj.exports = this._environment.global.JSON.parse(fs.readFileSync(
         modulePath,
         'utf8'
       ));

--- a/src/HasteModuleLoader/__tests__/HasteModuleLoader-requireModule-test.js
+++ b/src/HasteModuleLoader/__tests__/HasteModuleLoader-requireModule-test.js
@@ -40,7 +40,8 @@ describe('HasteModuleLoader', function() {
     mockEnvironment = {
       global: {
         console: {},
-        mockClearTimers: jest.genMockFn()
+        mockClearTimers: jest.genMockFn(),
+        JSON: JSON
       },
       runSourceText: jest.genMockFn().mockImplementation(function(codeStr) {
         /* jshint evil:true */


### PR DESCRIPTION
Fixes #228.

Advice for how to unit test this welcome. I added `JSON` to the environment mock to make sure existing tests pass, but couldn't figure out how to create a new mocked environment that will let me assert that the issue described in #228 is fixed.