### PR TITLE
Mock functions that begin with '_'

### DIFF
--- a/src/lib/__tests__/moduleMocker-getMetadata-test.js
+++ b/src/lib/__tests__/moduleMocker-getMetadata-test.js
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2014, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
+jest.autoMockOff();
+
+describe('moduleMocker-getMetadata', function() {
+  var moduleMocker;
+
+  beforeEach(function() {
+    moduleMocker = require('../moduleMocker');
+  });
+
+  it('mocks functions that begin with underscores', function () {
+    var component = {
+      foo: function() {},
+      _bar: function() {},
+      _: function() {}
+    };
+
+    var members = Object.keys(moduleMocker.getMetadata(component).members);
+    expect(members).toContain('foo');
+    expect(members).toContain('_bar');
+    expect(members).toContain('_');
+  });
+});

--- a/src/lib/moduleMocker.js
+++ b/src/lib/moduleMocker.js
@@ -266,9 +266,8 @@ function _getMetadata(component, _refs) {
   if (type !== 'array') {
     if (type !== 'undefined') {
       for (var slot in component) {
-        if (slot.charAt(0) === '_' ||
-            (type === 'function' && component._isMockFunction &&
-             slot.match(/^mock/))) {
+        if (type === 'function' && component._isMockFunction &&
+            slot.match(/^mock/)) {
           continue;
         }
 


### PR DESCRIPTION
Exported function that begin with '_' are public and part of the module's API and should be mocked.