### PR TITLE
Follow symbolic links.

### DIFF
--- a/src/HasteModuleLoader/HasteModuleLoader.js
+++ b/src/HasteModuleLoader/HasteModuleLoader.js
@@ -102,7 +102,8 @@ function _constructHasteInst(config, options) {
       version: JSON.stringify(config),
       useNativeFind: true,
       maxProcesses: os.cpus().length,
-      maxOpenFiles: options.maxOpenFiles || 100
+      maxOpenFiles: options.maxOpenFiles || 100,
+      followSymlinks: true
     }
   );
 }


### PR DESCRIPTION
Requires: https://github.com/jacobstr/node-haste
Fixes: https://github.com/facebook/jest/issues/219

It's maybe a bad idea to change this default but I'll propose it anyway. 

Requires https://github.com/facebook/node-haste/pull/19 to take effect but this ~should~ be deployable in the meantime without adverse effects.