### PR TITLE
Update unmockedModulePathPatterns in examples/react/package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jest-cli",
   "description": "Painless JavaScript Unit Testing.",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "main": "src/jest.js",
   "dependencies": {
     "coffee-script": "^1.8.0",


### PR DESCRIPTION
`["<rootDir>/node_modules/react"]` was causing a runtime error when the test was run where the `CallbackQueue` object inside the `ReactUpdates.js` file didn't have a `getPooled` method causing the program to crash. Changing the value to `["react"]` resolved this issue.