### PR TITLE
Add 0.12.x to available node engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "jest": "./bin/jest.js"
   },
   "engines": {
-    "node": "0.8.x || 0.10.x"
+    "node": "0.8.x || 0.10.x || 0.12.x"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
As we upgraded node.js to 0.12, we were unable to use Jest. I have already completed the CLA.