### PR TITLE
Have Jest respect NODE_PATH

### DIFF
--- a/src/HasteModuleLoader/HasteModuleLoader.js
+++ b/src/HasteModuleLoader/HasteModuleLoader.js
@@ -485,27 +485,18 @@ Loader.prototype._nodeModuleNameToPath = function(currPath, moduleName) {
   }
 
   var resolveError = null;
-  var paths = [];
   var exts = this._config.moduleFileExtensions
     .map(function(ext){
       return '.' + ext;
     });
   try {
     if (NODE_PATH) {
-      if (NODE_PATH.indexOf(process.cwd()) !== -1) {
-        paths.push(NODE_PATH);
-      }
-      else {
-        paths.push(process.cwd() + '/' + NODE_PATH);
-      }
-
       return resolve.sync(moduleName, {
-        paths: paths,
+        paths: NODE_PATH.split(path.delimiter),
         basedir: path.dirname(currPath),
         extensions: exts
-        });
-    }
-    else {
+      });
+    } else {
       return resolve.sync(moduleName, {
         basedir: path.dirname(currPath),
         extensions: exts

--- a/src/HasteModuleLoader/__tests__/HasteModuleLoader-NODE_PATH-test.js
+++ b/src/HasteModuleLoader/__tests__/HasteModuleLoader-NODE_PATH-test.js
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2014, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
+jest.autoMockOff();
+
+var path = require('path');
+var q = require('q');
+var utils = require('../../lib/utils');
+
+describe('HasteModuleLoader', function() {
+  var HasteModuleLoader;
+  var mockEnvironment;
+  var resourceMap;
+  
+  var CONFIG = utils.normalizeConfig({
+    name: 'HasteModuleLoader-tests',
+    rootDir: path.resolve(__dirname, 'test_root')
+  });
+
+  function buildLoader() {
+    if (!resourceMap) {
+      return HasteModuleLoader.loadResourceMap(CONFIG).then(function(map) {
+        resourceMap = map;
+        return buildLoader();
+      });
+    } else {
+      return q(new HasteModuleLoader(CONFIG, mockEnvironment, resourceMap));
+    }
+  }
+
+  function initHasteModuleLoader(nodePath) {
+    process.env.NODE_PATH = nodePath;
+    HasteModuleLoader = require('../HasteModuleLoader');
+    mockEnvironment = {
+      global: {
+        console: {},
+        mockClearTimers: jest.genMockFn()
+      },
+      runSourceText: jest.genMockFn().mockImplementation(function(codeStr) {
+        /* jshint evil:true */
+        return (new Function('return ' + codeStr))();
+      })
+    };
+  }
+
+  pit('uses NODE_PATH to find modules', function() {
+    var nodePath = process.cwd() + 
+      '/src/HasteModuleLoader/__tests__/NODE_PATH_dir';
+    initHasteModuleLoader(nodePath);
+    return buildLoader().then(function(loader) {
+      var exports = loader.requireModuleOrMock(null, 'RegularModuleInNodePath');
+      expect(exports).toBeDefined();
+    });
+  });
+  
+  pit('finds modules in NODE_PATH containing multiple paths', function() {
+    var cwd = process.cwd();
+    var nodePath = cwd + '/some/other/path' + path.delimiter + cwd +
+      '/src/HasteModuleLoader/__tests__/NODE_PATH_dir';
+    initHasteModuleLoader(nodePath);
+    return buildLoader().then(function(loader) {
+      var exports = loader.requireModuleOrMock(null, 'RegularModuleInNodePath');
+      expect(exports).toBeDefined();
+    });
+  });
+  
+  pit('doesnt find modules if NODE_PATH is relative', function() {
+    var nodePath = process.cwd().substr(path.sep.length) +
+      'src/HasteModuleLoader/__tests__/NODE_PATH_dir';
+    initHasteModuleLoader(nodePath);
+    return buildLoader().then(function(loader) {
+      try {
+         var exports = loader.requireModuleOrMock(null, 
+             'RegularModuleInNodePath');
+         expect(exports).toBeUndefined();
+      } catch (e) {
+        expect(
+          (e.message.indexOf('Cannot find module'))).toBeGreaterThan(-1);    
+      }
+    });
+  });
+
+});

--- a/src/HasteModuleLoader/__tests__/NODE_PATH_dir/RegularModuleInNodePath.js
+++ b/src/HasteModuleLoader/__tests__/NODE_PATH_dir/RegularModuleInNodePath.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2014, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule RegularModule
+ */
+
+'use strict';
+
+var moduleStateValue = 'default';
+
+function setModuleStateValue(value) {
+  moduleStateValue = value;
+}
+
+function getModuleStateValue() {
+  return moduleStateValue;
+}
+
+exports.getModuleStateValue = getModuleStateValue;
+exports.isRealModule = true;
+exports.setModuleStateValue = setModuleStateValue;


### PR DESCRIPTION
Hi, this is some more work toward getting Jest to use/respect the NODE_PATH environment variable. Made some changes to PR #133 (which is in response to issue #102) to add testing, and respect different environments. Also passes the duty of properly formatting NODE_PATH (per node.js documentation) on to the user (Read: Does not attempt to validate NODE_PATH).