### PR TITLE
include `"moduleFileExtensions"` in CoffeeScript Tutorial

### DIFF
--- a/docs/TutorialCoffeeScript.md
+++ b/docs/TutorialCoffeeScript.md
@@ -17,7 +17,8 @@ Jest doesn't come with builtin support for CoffeeScript but can easily be config
   },
   "jest": {
     "scriptPreprocessor": "preprocessor.js",
-    "testFileExtensions": ["coffee", "litcoffee", "coffee.md", "js"]
+    "testFileExtensions": ["coffee", "litcoffee", "coffee.md", "js"],
+    "moduleFileExtensions": ["coffee", "litcoffee", "coffee.md", "js"]
   }
 ```
 


### PR DESCRIPTION
Jest didn't work for my coffeescript project as written. Through some debugging I found `"moduleFileExtensions"`, which fixed my problem and allowed my coffee files to be tested.

I have submitted a CLA. 