### PR TITLE
Update default maxWorkers to be number of CPUs

### DIFF
--- a/src/TestRunner.js
+++ b/src/TestRunner.js
@@ -35,7 +35,7 @@ var DEFAULT_OPTIONS = {
    * It's probably good to keep this at something close to the number of cores
    * on the machine that's running the test.
    */
-  maxWorkers: Math.max(os.cpus().length - 1, 1),
+  maxWorkers: Math.max(os.cpus().length, 1),
 
   /**
    * The path to the executable node binary.


### PR DESCRIPTION
On a dual core machine, we had a Jest build with 33 files that took 138 seconds to run. After playing with `maxWorkers`:

maxWorkers | time to run 
----------------- | -----------
1 | 138 
2 | 99 
3 | 100 
4 | 102 

I think it's safe to assume that most of the configurations will benefit of running the tests more parallelised.