### PR TITLE
Bump harmonize to 1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "cover": "~0.2.8",
     "diff": "~1.0.4",
     "graceful-fs": "^2.0.3",
-    "harmonize": "~1.33.7",
+    "harmonize": "1.4.0",
     "istanbul": "^0.3.2",
     "jasmine-only": "0.1.0",
     "jasmine-pit": "~2.0.0",


### PR DESCRIPTION
Please bump harmonize to support running in node v0.12 and iojs. This request obviously does not attempt to address all issues to fully support node v0.12 or iojs, but does allow users to install and run jest-cli in those environments. Tested in node v0.10.36, node v0.12.0, and iojs v1.2.0.

Fixes facebook/jest/issues/235. 
Part of the work required for facebook/jest/issues/243. 

See dcodeIO/node-harmonize/issues/1.