### PR TITLE
Fixed detection of weakMap so jest works on node 0.12

### DIFF
--- a/src/HasteModuleLoader/HasteModuleLoader.js
+++ b/src/HasteModuleLoader/HasteModuleLoader.js
@@ -126,9 +126,12 @@ function Loader(config, environment, resourceMap) {
 
   if (_configUnmockListRegExpCache === null) {
     // Node must have been run with --harmony in order for WeakMap to be
-    // available
-    if (typeof WeakMap === undefined) {
-      throw new Error('Please run node with the --harmony flag!');
+    // available prior to version 0.12
+    if (typeof WeakMap !== 'function') {
+      throw new Error(
+        'Please run node with the --harmony flag! jest requires WeakMap ' +
+        'which is only available with the --harmony flag in node < v0.12'
+      );
     }
 
     _configUnmockListRegExpCache = new WeakMap();

--- a/src/HasteModuleLoader/HasteModuleLoader.js
+++ b/src/HasteModuleLoader/HasteModuleLoader.js
@@ -127,7 +127,7 @@ function Loader(config, environment, resourceMap) {
   if (_configUnmockListRegExpCache === null) {
     // Node must have been run with --harmony in order for WeakMap to be
     // available
-    if (!process.execArgv.some(function(arg) { return arg === '--harmony'; })) {
+    if (typeof WeakMap === undefined) {
       throw new Error('Please run node with the --harmony flag!');
     }
 

--- a/src/jasmineTestRunner/JasmineReporter.js
+++ b/src/jasmineTestRunner/JasmineReporter.js
@@ -61,8 +61,11 @@ function _prettyPrint(obj, indent, cycleWeakMap) {
 
     /* jshint camelcase:false */
     if (!cycleWeakMap) {
-      if (typeof WeakMap === undefined) {
-        throw new Error('Please run node with the --harmony flag!');
+      if (typeof WeakMap !== 'function') {
+        throw new Error(
+          'Please run node with the --harmony flag! jest requires WeakMap ' +
+          'which is only available with the --harmony flag in node < v0.12'
+        );
       }
       cycleWeakMap = new WeakMap();
     }

--- a/src/jasmineTestRunner/jasmineTestRunner.js
+++ b/src/jasmineTestRunner/jasmineTestRunner.js
@@ -55,9 +55,12 @@ function jasmineTestRunner(config, environment, moduleLoader, testPath) {
     environment.runSourceText(jasmineOnlyContent);
 
     // Node must have been run with --harmony in order for WeakMap to be
-    // available
-    if (typeof WeakMap === undefined) {
-      throw new Error('Please run node with the --harmony flag!');
+    // available prior to version 0.12
+    if (typeof WeakMap !== 'function') {
+      throw new Error(
+        'Please run node with the --harmony flag! jest requires WeakMap ' +
+        'which is only available with the --harmony flag in node < v0.12'
+      );
     }
 
     // Mainline Jasmine sets __Jasmine_been_here_before__ on each object to

--- a/src/jasmineTestRunner/jasmineTestRunner.js
+++ b/src/jasmineTestRunner/jasmineTestRunner.js
@@ -56,7 +56,7 @@ function jasmineTestRunner(config, environment, moduleLoader, testPath) {
 
     // Node must have been run with --harmony in order for WeakMap to be
     // available
-    if (!process.execArgv.some(function(arg) { return arg === '--harmony'; })) {
+    if (typeof WeakMap === undefined) {
       throw new Error('Please run node with the --harmony flag!');
     }
 


### PR DESCRIPTION
Node v 0.12 no longer needs harmony flag, so instead of detecting harmony we check if WeakMap is defined to determine if we need the harmony flag. 