### PR TITLE
Update package.json to include Node v0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: node_js
 node_js:
 - "0.10"
+- "0.12"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "jest": "./bin/jest.js"
   },
   "engines": {
-    "node": "0.8.x || 0.10.x"
+    "node": "0.8.x || 0.10.x || 0.12.x"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Without that, npm will show the warning

> npm WARN engine jest-cli@0.3.0: wanted: {"node":"0.8.x || 0.10.x"} (current: {"node":"0.12.0","npm":"2.5.1"})

Of course we can also use a different range.