### PR TITLE
Make pretty printer work for objects without prototype

### DIFF
--- a/vendor/jasmine/jasmine-1.3.0.js
+++ b/vendor/jasmine/jasmine-1.3.0.js
@@ -1929,7 +1929,7 @@ jasmine.PrettyPrinter.prototype.format = function(value) {
 
 jasmine.PrettyPrinter.prototype.iterateObject = function(obj, fn) {
   for (var property in obj) {
-    if (!obj.hasOwnProperty(property)) continue;
+    if (!Object.prototype.hasOwnProperty.call(obj, property)) { continue; }
     if (property == '__Jasmine_been_here_before__') continue;
     fn(property, obj.__lookupGetter__ ? (obj.__lookupGetter__(property) !== jasmine.undefined &&
                                          obj.__lookupGetter__(property) !== null) : false);


### PR DESCRIPTION
This was fixed in Jasmine 2.x, but it seems we cannot easily upgrade Jasmine?

This just pulls in https://github.com/jasmine/jasmine/blob/master/src/core/PrettyPrinter.js#L53 to make the pretty printer work for objects created with `Object.create(null)`.

Without that change, Jasmine throws the error

```
- TypeError: Object object has no method 'hasOwnProperty'
        at jasmine.PrettyPrinter.iterateObject (...)
        ...
```

when trying to pretty print such objects.