### PR TITLE
Run single test in worker

### DIFF
--- a/src/TestRunner.js
+++ b/src/TestRunner.js
@@ -458,10 +458,10 @@ TestRunner.prototype.runTests = function(testPaths, reporter) {
 TestRunner.prototype._createTestRun = function(
   testPaths, onTestResult, onRunFailure
 ) {
-  if (this._opts.runInBand || testPaths.length <= 1) {
+  if (this._opts.runInBand) {
     return this._createInBandTestRun(testPaths, onTestResult, onRunFailure);
   } else {
-    return this._createParallelTestRun(testPaths, onTestResult, onRunFailure);
+    return this._createPooledTestRun(testPaths, onTestResult, onRunFailure);
   }
 };
 
@@ -481,7 +481,7 @@ TestRunner.prototype._createInBandTestRun = function(
   return testSequence;
 };
 
-TestRunner.prototype._createParallelTestRun = function(
+TestRunner.prototype._createPooledTestRun = function(
   testPaths, onTestResult, onRunFailure
 ) {
   var workerPool = new WorkerPool(


### PR DESCRIPTION
Hi,

It seems 8264635 had a consequence when running test: The `--harmony` is required when you run 1 test file, and not required in the other cases.

It could be disturbing (as shown in #244) when you have 2 test files and you decided to delete one. Your tests are broken unless you run with `--harmony`.

That's why I propose to reverse 8264635 . I also rename `_createParallelTestRun` to `_createPooledTestRun` because it seems a prettier name to me if the method could run 1 or several files.
