### PR TITLE
Reasonable default value for rootDir when loading config from a file

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -337,13 +337,12 @@ function readFile(filePath) {
 }
 
 function loadConfigFromFile(filePath) {
-  var fileDir = path.dirname(filePath);
   return readFile(filePath).then(function(fileData) {
     var config = JSON.parse(fileData);
     if (!config.hasOwnProperty('rootDir')) {
-      config.rootDir = fileDir;
+      config.rootDir = process.cwd();
     } else {
-      config.rootDir = path.resolve(fileDir, config.rootDir);
+      config.rootDir = path.resolve(path.dirname(filePath), config.rootDir);
     }
     return normalizeConfig(config);
   });


### PR DESCRIPTION
Most unix programs will use the current working directory when not told otherwise, Jest does not when setting a config-file on the CLI. This patch aims to change this.