### PR TITLE
Add config.testEnvData (and --testEnvData=<<json string>>)

### DIFF
--- a/bin/jest.js
+++ b/bin/jest.js
@@ -7,7 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 /* jshint node: true */
-"use strict";
+'use strict';
 
 var fs = require('fs');
 var harmonize = require('harmonize');
@@ -84,6 +84,13 @@ var argv = optimist
       ),
       type: 'boolean'
     },
+    testEnvData: {
+      description: _wrapDesc(
+        'A JSON object (string) that specifies data that will be made ' +
+        'available in the test environment (via jest.getEnvData())'
+      ),
+      type: 'string'
+    },
     version: {
       alias: 'v',
       description: _wrapDesc('Print the version and exit'),
@@ -105,8 +112,12 @@ var argv = optimist
         'tests for changed files? Or for a specific set of files?'
       );
     }
+
+    if (argv.testEnvData) {
+      argv.testEnvData = JSON.parse(argv.testEnvData);
+    }
   })
-  .argv
+  .argv;
 
 if (argv.help) {
   optimist.showHelp();
@@ -154,7 +165,7 @@ if (fs.existsSync(cwdJestBinPath)) {
     process.on('exit', function(){
        process.exit(1);
     });
-    
+
     return;
   }
 } else {

--- a/src/HasteModuleLoader/HasteModuleLoader.js
+++ b/src/HasteModuleLoader/HasteModuleLoader.js
@@ -972,6 +972,17 @@ Loader.prototype.resetModuleRegistry = function() {
             return jestRuntime.exports;
           }.bind(this),
 
+          getTestEnvData: function() {
+            var frozenCopy = {};
+            // Make a shallow copy only because a deep copy seems like
+            // overkill..
+            Object.keys(this._config.testEnvData).forEach(function(key) {
+              frozenCopy[key] = this._config.testEnvData[key];
+            }, this);
+            Object.freeze(frozenCopy);
+            return frozenCopy;
+          }.bind(this),
+
           genMockFromModule: function(moduleName) {
             return this._generateMock(
               this._currentlyExecutingModulePath,

--- a/src/HasteModuleLoader/__tests__/HasteModuleLoader-NODE_PATH-test.js
+++ b/src/HasteModuleLoader/__tests__/HasteModuleLoader-NODE_PATH-test.js
@@ -17,7 +17,7 @@ describe('HasteModuleLoader', function() {
   var HasteModuleLoader;
   var mockEnvironment;
   var resourceMap;
-  
+
   var CONFIG = utils.normalizeConfig({
     name: 'HasteModuleLoader-tests',
     rootDir: path.resolve(__dirname, 'test_root')
@@ -50,7 +50,7 @@ describe('HasteModuleLoader', function() {
   }
 
   pit('uses NODE_PATH to find modules', function() {
-    var nodePath = process.cwd() + 
+    var nodePath = process.cwd() +
       '/src/HasteModuleLoader/__tests__/NODE_PATH_dir';
     initHasteModuleLoader(nodePath);
     return buildLoader().then(function(loader) {
@@ -58,7 +58,7 @@ describe('HasteModuleLoader', function() {
       expect(exports).toBeDefined();
     });
   });
-  
+
   pit('finds modules in NODE_PATH containing multiple paths', function() {
     var cwd = process.cwd();
     var nodePath = cwd + '/some/other/path' + path.delimiter + cwd +
@@ -69,19 +69,19 @@ describe('HasteModuleLoader', function() {
       expect(exports).toBeDefined();
     });
   });
-  
+
   pit('doesnt find modules if NODE_PATH is relative', function() {
     var nodePath = process.cwd().substr(path.sep.length) +
       'src/HasteModuleLoader/__tests__/NODE_PATH_dir';
     initHasteModuleLoader(nodePath);
     return buildLoader().then(function(loader) {
       try {
-         var exports = loader.requireModuleOrMock(null, 
+         var exports = loader.requireModuleOrMock(null,
              'RegularModuleInNodePath');
          expect(exports).toBeUndefined();
       } catch (e) {
         expect(
-          (e.message.indexOf('Cannot find module'))).toBeGreaterThan(-1);    
+          (e.message.indexOf('Cannot find module'))).toBeGreaterThan(-1);
       }
     });
   });

--- a/src/HasteModuleLoader/__tests__/HasteModuleLoader-getTestEnvData-test.js
+++ b/src/HasteModuleLoader/__tests__/HasteModuleLoader-getTestEnvData-test.js
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2014, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
+jest.autoMockOff();
+
+var path = require('path');
+var q = require('q');
+var utils = require('../../lib/utils');
+
+describe('HasteModuleLoader', function() {
+  var HasteModuleLoader;
+  var mockEnvironment;
+  var resourceMap;
+
+  var config;
+  beforeEach(function() {
+    HasteModuleLoader = require('../HasteModuleLoader');
+    config = utils.normalizeConfig({
+      name: 'HasteModuleLoader-tests',
+      rootDir: path.resolve(__dirname, 'test_root'),
+      testEnvData: {someTestData: 42},
+    });
+  });
+
+  function buildLoader() {
+    if (!resourceMap) {
+      return HasteModuleLoader.loadResourceMap(config).then(function(map) {
+        resourceMap = map;
+        return buildLoader();
+      });
+    } else {
+      return q(new HasteModuleLoader(config, mockEnvironment, resourceMap));
+    }
+  }
+
+  pit('passes config data through to jest.envData', function() {
+    return buildLoader().then(function(loader) {
+      var envData = loader.requireModule(null, 'jest-runtime').getTestEnvData();
+      expect(envData).toEqual(config.testEnvData);
+    });
+  });
+
+  pit('freezes jest.envData object', function() {
+    return buildLoader().then(function(loader) {
+      var envData = loader.requireModule(null, 'jest-runtime').getTestEnvData();
+      expect(Object.isFrozen(envData)).toBe(true);
+    });
+  });
+});

--- a/src/jest.js
+++ b/src/jest.js
@@ -86,6 +86,11 @@ function _promiseConfig(argv, packageRoot) {
     if (argv.coverage) {
       config.collectCoverage = true;
     }
+
+    if (argv.testEnvData) {
+      config.testEnvData = argv.testEnvData;
+    }
+
     return config;
   });
 }

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -14,17 +14,18 @@ var Q = require('q');
 
 var DEFAULT_CONFIG_VALUES = {
   cacheDirectory: path.resolve(__dirname, '..', '..', '.haste_cache'),
+  coverageCollector: require.resolve('../IstanbulCollector'),
   globals: {},
+  moduleFileExtensions: ['js', 'json'],
   moduleLoader: require.resolve('../HasteModuleLoader/HasteModuleLoader'),
   modulePathIgnorePatterns: [],
-  coverageCollector: require.resolve('../IstanbulCollector'),
   testDirectoryName: '__tests__',
   testEnvironment: require.resolve('../JSDomEnvironment'),
+  testEnvData: {},
   testFileExtensions: ['js'],
-  testReporter: require.resolve('../IstanbulTestReporter'),
-  moduleFileExtensions: ['js', 'json'],
   testPathDirs: ['<rootDir>'],
   testPathIgnorePatterns: ['/node_modules/'],
+  testReporter: require.resolve('../IstanbulTestReporter'),
   testRunner: require.resolve('../jasmineTestRunner/jasmineTestRunner')
 };
 
@@ -217,6 +218,7 @@ function normalizeConfig(config) {
       case 'setupJSTestLoaderOptions':
       case 'setupJSMockLoaderOptions':
       case 'testDirectoryName':
+      case 'testEnvData':
       case 'testFileExtensions':
       case 'testReporter':
       case 'moduleFileExtensions':


### PR DESCRIPTION
config.testEnvData makes it possible to specify data that should be made available to the test environment via jest.getTestEnvData().

(cc @zpao )