### PR TITLE
Website build is broken

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -3,7 +3,7 @@
     "start": "node server/server.js"
   },
   "dependencies": {
-    "React": "git://github.com/facebook/react.git",
+    "react": "~0.12.2",
     "optimist": "0.6.0",
     "react-page-middleware": "git://github.com/facebook/react-page-middleware.git",
     "connect": "2.8.3",


### PR DESCRIPTION
I followed the instructions in website/README.md:
 - Clone jest repo
 - `cd website`
 - `npm install`
 - `npm start`
 - Go to http://localhost:8080/jest/index.html

```
Error: Error: ERROR RENDERING PAGE ON SERVER:
<mapped error>
TypeError: Cannot read property '__reactAutoBindMap' of undefined
Please report this to https://github.com/chjj/marked.
    at Constructor (evalmachine.null:null:15)
    at Parser.tok (evalmachine.null:null:14)
    at Parser.parse (evalmachine.null:null:19)
    at Function.Parser.parse (evalmachine.null:null:17)
    at marked (evalmachine.null:null:19)
    at React.createClass.render (evalmachine.null:null:32)
    at ReactCompositeComponentMixin._renderValidatedComponentWithoutOwnerOrContext (evalmachine.null:null:34)
    at ReactCompositeComponentMixin._renderValidatedComponent (evalmachine.null:null:14)
    at wrapper [as _renderValidatedComponent] (evalmachine.null:null:21)
    at ReactCompositeComponentMixin.mountComponent (evalmachine.null:null:30)
</mapped error>

    at <MY HOME>/jest/website/node_modules/react-page-middleware/src/guard.js:27:12
    at onOutputGenerated (<MY HOME>/jest/website/node_modules/react-page-middleware/src/index.js:96:9)
    at Object.renderReactPage.done (<MY HOME>/jest/website/node_modules/react-page-middleware/src/DefaultRouter.js:352:7)
    at renderReactPage (<MY HOME>/jest/website/node_modules/react-page-middleware/src/renderReactPage.js:127:17)
    at renderComponentPackage (<MY HOME>/jest/website/node_modules/react-page-middleware/src/DefaultRouter.js:338:3)
    at routePackageHandler (<MY HOME>/jest/website/node_modules/react-page-middleware/src/DefaultRouter.js:281:5)
    at onComputePackage (<MY HOME>/jest/website/node_modules/react-page-middleware/src/index.js:100:9)
    at <MY HOME>/jest/website/node_modules/react-page-middleware/src/guard.js:29:10
    at onWarmed (<MY HOME>/jest/website/node_modules/react-page-middleware/src/Packager.js:282:9)
    at <MY HOME>/jest/website/node_modules/react-page-middleware/node_modules/async/lib/async.js:116:25
```

Because of full git paths in website's package.json, the version 0.13.0-rc1 of react-tools is downloaded 
and it is probably the reason of the error: https://github.com/facebook/react/issues/2880

I solve the problem by changing the dependency target: 
```
"React": "git://github.com/facebook/react.git#v0.12.2",
```
EDIT: Amended to:
```
"react": "~0.12.0",
```