### PR TITLE
docs: fix typo

### DIFF
--- a/docs/TutorialjQuery.md
+++ b/docs/TutorialjQuery.md
@@ -56,7 +56,7 @@ describe('displayUser', function() {
     $('#button').click();
 
     // Assert that the fetchCurrentUser function was called, and that the
-    // #username span's innter text was updated as we'd it expect.
+    // #username span's inner text was updated as we'd expect.
     expect(fetchCurrentUser).toBeCalled();
     expect($('#username').text()).toEqual('Johnny Cash - Logged In');
   });


### PR DESCRIPTION
"innter" -> "inner"
"we'd it expect" -> "we'd expect"

@zpoa so sorry to have put this in the wrong place. this makes much more sense. thanks for the correction :)

originally #284