### PR TITLE
docs: fix typo "builtin" -> "built-in"

### DIFF
--- a/docs/TutorialCoffeeScript.md
+++ b/docs/TutorialCoffeeScript.md
@@ -7,7 +7,7 @@ permalink: docs/tutorial-coffeescript.html
 next: tutorial-react
 ---
 
-Jest doesn't come with builtin support for CoffeeScript but can easily be configured in order to make it work. To use CoffeeScript, you need to tell Jest to look for `*.coffee` files and to run them through the CoffeeScript compiler when requiring them. Here's how to set it up with Jest:
+Jest doesn't come with built-in support for CoffeeScript but can easily be configured in order to make it work. To use CoffeeScript, you need to tell Jest to look for `*.coffee` files and to run them through the CoffeeScript compiler when requiring them. Here's how to set it up with Jest:
 
 
 ```javascript


### PR DESCRIPTION
Fix type: "builtin" -> "built-in"

originally: #285