### PR TITLE
Add support for cobertura coverage reporter.

### DIFF
--- a/src/IstanbulTestReporter.js
+++ b/src/IstanbulTestReporter.js
@@ -29,7 +29,7 @@ function (config, aggregatedResults) {
   );
 
   if (config.collectCoverage) {
-    reporter.addAll([ 'json', 'text', 'lcov', 'clover' ]);
+    reporter.addAll([ 'json', 'text', 'lcov', 'clover', 'cobertura' ]);
     reporter.write(collector, true, function () {
         console.log('All reports generated');
     });


### PR DESCRIPTION
Added the cobertura coverage reporter to the default set of reporters. Can be used for Jenkins and shippable.com.