### PR TITLE
Speed up output for failing tests

### DIFF
--- a/src/jasmineTestRunner/__tests__/JasmineReporter-test.js
+++ b/src/jasmineTestRunner/__tests__/JasmineReporter-test.js
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) 2015, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
+require('mock-modules').autoMockOff();
+
+describe('JasmineReporter', function() {
+  // modules
+  var JasmineReporter;
+  var colors;
+
+  // other variables
+  var reporter;
+
+  beforeEach(function() {
+    JasmineReporter = require('../JasmineReporter');
+    colors = require('../../lib/colors');
+
+    reporter = new JasmineReporter();
+  });
+
+  describe('colorization', function() {
+    function getRunner(actualResult, expectedResult, passed) {
+      return {
+        suites: function() {
+          return [
+            {
+              parentSuite: null,
+              specs: function() {
+                return [
+                  {
+                    results: function() {
+                      return {
+                        getItems: function() {
+                          return [
+                            {
+                              actual: actualResult,
+                              expected: expectedResult,
+                              matcherName: 'toBe',
+                              passed: function() { return passed; },
+                              trace: {},
+                              type: 'expect',
+                            }
+                          ];
+                        },
+                      };
+                    },
+                  },
+                ];
+              },
+              suites: function() { return []; },
+            },
+          ];
+        },
+      };
+    }
+
+    function errorize(str) {
+      return colors.RED + colors.BOLD + colors.UNDERLINE + str + colors.RESET;
+    }
+
+    function highlight(str) {
+      return colors.RED_BG + str + colors.RESET;
+    }
+
+    pit('colorizes single-line failures using a per-char diff', function() {
+      var runner = getRunner('foo', 'foobar', false);
+      reporter.reportRunnerResults(runner);
+
+      return reporter.getResults().then(function(result) {
+        var message = result.testResults[0].failureMessages[0];
+        expect(message).toBe(
+          errorize('Expected:') + ' \'foo\' ' +
+          errorize('toBe:') + ' \'foo' + highlight('bar') + '\''
+        );
+      });
+    });
+
+    pit('colorizes multi-line failures using a per-line diff', function() {
+      var runner = getRunner('foo\nbar\nbaz', 'foo\nxxx\nbaz', false);
+      reporter.reportRunnerResults(runner);
+
+      return reporter.getResults().then(function(result) {
+        var message = result.testResults[0].failureMessages[0];
+        expect(message).toBe(
+          errorize('Expected:') + ' \'foo\n' + highlight('bar\n') + 'baz\' ' +
+          errorize('toBe:') + ' \'foo\n' + highlight('xxx\n') + 'baz\''
+        );
+      });
+    });
+  });
+});


### PR DESCRIPTION
Summary:

Jest may appear to hang (for dozens of seconds, up to minutes) when
printing failed test results.

An example of the kind of failure output that can trigger this condition
is a dump of a very large JS object and a short string. All of the time
is spent in the diffing algorithm that we use to color-highlight the
differences between the expected and actual value. This scenario is one
of the worst cases for the underlying Myers LCS diff algorithm, which
runs in O(n+d^2) time (where "d" is the length of the edit script
between the two strings).

This commit ameliorates the worst case scenario by switching to a
line-level diff whenever newlines are present in either string. There
will still be pathological cases that can be very slow (really huge
multi-line diffs, or very long single-line diffs) but this change is
relatively cheap and delivers a nice benefit for the most common cases.

Reference: D1896663

Test Plan:

Add automated tests (unfortunately, fairly tied to Jasmine specifics)
and run using `npm test`.

In a separate project, add some test failures, see fast line-level diffs
for examples like the one mentioned above, and character-level diffs in
other cases.