### PR TITLE
Apply strict mode on moduleMocker.js

### DIFF
--- a/src/lib/moduleMocker.js
+++ b/src/lib/moduleMocker.js
@@ -5,9 +5,7 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-// This module uses the Function constructor, so it can't currently run
-// in strict mode
-/* jshint strict:false */
+'use strict';
 
 function isA(typeName, value) {
   return Object.prototype.toString.apply(value) === '[object ' + typeName + ']';


### PR DESCRIPTION
I mistakenly said that we couldn't use strict mode on this module.
Adding 'use strict' to it and removing the comment that explained why it wasn't used.