### PR TITLE
Remove JSX pragma from React example

### DIFF
--- a/examples/react/CheckboxWithLabel.js
+++ b/examples/react/CheckboxWithLabel.js
@@ -1,4 +1,3 @@
-/** @jsx React.DOM */
 var React = require('react/addons');
 
 var CheckboxWithLabel = React.createClass({

--- a/examples/react/__tests__/CheckboxWithLabel-test.js
+++ b/examples/react/__tests__/CheckboxWithLabel-test.js
@@ -1,5 +1,3 @@
-/** @jsx React.DOM */
-
 jest.dontMock('../CheckboxWithLabel.js');
 
 describe('CheckboxWithLabel', function() {


### PR DESCRIPTION
Removing this since React >= 0.12.0 does not require it.