### PR TITLE
Reporting of test counts 

### DIFF
--- a/src/DefaultTestReporter.js
+++ b/src/DefaultTestReporter.js
@@ -107,6 +107,10 @@ function(config, testResult, aggregatedResults) {
     testRunTimeString = colors.colorize(testRunTimeString, FAIL_COLOR);
   }
 
+  var totalTestsStr = '('
+    + (testResult.numFailingTests + testResult.numPassingTests)
+    + ' tests)';
+
   /*
   if (config.collectCoverage) {
     // TODO: Find a nice pretty way to print this out
@@ -114,7 +118,7 @@ function(config, testResult, aggregatedResults) {
   */
 
   this.log(_getResultHeader(allTestsPassed, pathStr, [
-    testRunTimeString
+    totalTestsStr, testRunTimeString
   ]));
 
   testResult.logMessages.forEach(function (message) {

--- a/src/DefaultTestReporter.js
+++ b/src/DefaultTestReporter.js
@@ -130,9 +130,18 @@ function(config, testResult, aggregatedResults) {
 
 DefaultTestReporter.prototype.onRunComplete =
 function (config, aggregatedResults) {
-  var numFailedTests = aggregatedResults.numFailedTests;
-  var numPassedTests = aggregatedResults.numPassedTests;
-  var numTotalTests = aggregatedResults.numTotalTests;
+  var numFailedTests = 0;
+  var numPassedTests = 0;
+
+  aggregatedResults.testResults.forEach(
+    function (testResult) {
+      numFailedTests += testResult.numFailingTests;
+      numPassedTests += testResult.numPassingTests;
+    }
+  );
+
+  var numTotalTests = numFailedTests + numPassedTests;
+
   var runTime = aggregatedResults.runTime;
 
   if (numTotalTests === 0) {


### PR DESCRIPTION
There seems to be a discrepancy between test files ran vs actual tests, as mentioned in Issue #301
This change displays the number of tests for each test file and the actual total number of tests ran / passed & failed.