### PR TITLE
[JEST-314] Path Resolution Recursion Error

### DIFF
--- a/bin/jest.js
+++ b/bin/jest.js
@@ -134,7 +134,7 @@ var cwd = process.cwd();
 // Is the cwd somewhere within an npm package?
 var cwdPackageRoot = cwd;
 while (!fs.existsSync(path.join(cwdPackageRoot, 'package.json'))) {
-  if (cwdPackageRoot === '/') {
+  if (cwdPackageRoot === '/' || cwdPackageRoot.match(/[A-Z]:\\/)) {
     cwdPackageRoot = cwd;
     break;
   }


### PR DESCRIPTION
This patch fixes an error on [line 137 of bin/jest.js](https://github.com/facebook/jest/blob/master/bin/jest.js#L137) that results in an infinite recursion bug on Windows due to the system root being improperly matched. This patch is documented in issue #314.