### PR TITLE
Automatically ignore devDependencies

### DIFF
--- a/src/jest.js
+++ b/src/jest.js
@@ -114,6 +114,9 @@ function _promiseRawConfig(argv, packageRoot) {
     } else {
       pkgJson.jest.rootDir = path.resolve(packageRoot, pkgJson.jest.rootDir);
     }
+    var devDep = utils.getDevDependencies(pkgJson);
+    var ignorePatterns = pkgJson.jest.modulePathIgnorePatterns || [];
+    pkgJson.jest.modulePathIgnorePatterns = ignorePatterns.concat(devDep);
     var config = utils.normalizeConfig(pkgJson.jest);
     config.name = pkgJson.name;
     return q(config);

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -156,7 +156,7 @@ function getDevDependencies(pkgJson) {
 
   devDependencies = Object.keys(devDependencies);
   devDependencies = devDependencies.filter(function isOnlyDev(pkgName) {
-    return !(dependencies[pkgName] || peerDependencies[pkgName])
+    return !(dependencies[pkgName] || peerDependencies[pkgName]);
   });
   devDependencies = devDependencies.map(function addNodeModules(pkgName) {
     return '/node_modules/' + pkgName + '/';

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -149,6 +149,22 @@ function getLinePercentCoverageFromCoverageInfo(coverageInfo) {
   return numCoveredLines / numMeasuredLines;
 }
 
+function getDevDependencies(pkgJson) {
+  var devDependencies = pkgJson.devDependencies || {};
+  var dependencies = pkgJson.dependencies || {};
+  var peerDependencies = pkgJson.peerDependencies || {};
+
+  devDependencies = Object.keys(devDependencies);
+  devDependencies = devDependencies.filter(function isOnlyDev(pkgName) {
+    return !(dependencies[pkgName] || peerDependencies[pkgName])
+  });
+  devDependencies = devDependencies.map(function addNodeModules(pkgName) {
+    return '/node_modules/' + pkgName + '/';
+  });
+
+  return devDependencies;
+}
+
 function normalizeConfig(config) {
   var newConfig = {};
 
@@ -426,6 +442,7 @@ exports.getLinePercentCoverageFromCoverageInfo =
   getLinePercentCoverageFromCoverageInfo;
 exports.loadConfigFromFile = loadConfigFromFile;
 exports.loadConfigFromPackageJson = loadConfigFromPackageJson;
+exports.getDevDependencies = getDevDependencies;
 exports.normalizeConfig = normalizeConfig;
 exports.pathNormalize = pathNormalize;
 exports.readAndPreprocessFileContent = readAndPreprocessFileContent;


### PR DESCRIPTION
One performance issue on Jest is that it scan all files in ``node_modules``. But we want to ignore those development dependencies.

This PR tries to append the development dependencies to ``modulePathIgnorePatterns``.

The definition of the development dependencies is the package
1. in ``devDependencies``
2. and not in ``dependencies``
3. and not in ``peerDependencies``

But there could be an issue, so want to discuss with you guys.
1. People write test with some util package, such like ``lodash``, and they will put it into ``devDependencies`` and will be invisible to Jest.

In this case, maybe I can introduce ``-lodash``, so will exclude it out of the ```modulePathIgnorePatterns``. Any idea?