### PR TITLE
resolved issue #320

### DIFF
--- a/examples/react-es6/package.json
+++ b/examples/react-es6/package.json
@@ -13,7 +13,8 @@
     "scriptPreprocessor": "<rootDir>/node_modules/babel-jest",
     "unmockedModulePathPatterns": [
       "<rootDir>/node_modules/react",
-      "<rootDir>/node_modules/react-tools"
+      "<rootDir>/node_modules/react-tools",
+      "<rootDir>/CheckboxWithLabel.js"
     ]
   }
 }


### PR DESCRIPTION
The problem occured because of the following code,

    jest.dontMock('../CheckboxWithLabel');

was not placed at the top of the result code of babel-jest.