### PR TITLE
Implement `addMatchers` shortcut on `jest`

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -8,6 +8,7 @@ permalink: docs/api.html
 
 #### The `jest` object
 
+  - `jest.addMatchers(matchers)`
   - [`jest.autoMockOff()`](#jest-automockoff)
   - [`jest.autoMockOn()`](#jest-automockon)
   - [`jest.clearAllTimers()`](#jest-clearalltimers)

--- a/src/HasteModuleLoader/HasteModuleLoader.js
+++ b/src/HasteModuleLoader/HasteModuleLoader.js
@@ -952,6 +952,12 @@ Loader.prototype.resetModuleRegistry = function() {
     'jest-runtime': function(currPath) {
       var jestRuntime = {
         exports: {
+          addMatchers: function(matchers) {
+            var jasmine = this._environment.global.jasmine;
+            var spec = jasmine.getEnv().currentSpec;
+            spec.addMatchers(matchers);
+          }.bind(this),
+
           autoMockOff: function() {
             this._shouldAutoMock = false;
             return jestRuntime.exports;


### PR DESCRIPTION
This will make it easier to use arrow functions when writing unit tests that have custom matchers:

```js
beforeEach(() => {
  jest.addMatchers({
    toBeOne() {
      return this.actual === 1;
    }
  });
});
```