### PR TITLE
Scan for ES6 methods in moduleMocker.js

### DIFF
--- a/src/lib/__tests__/moduleMocker-test.js
+++ b/src/lib/__tests__/moduleMocker-test.js
@@ -7,6 +7,13 @@
  */
 'use strict';
 
+// This was generated with https://babeljs.io/repl/
+/* jshint ignore:start */
+var _classCallCheck = function (instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } };
+var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
+/* jshint ignore:end */
+/* global _classCallCheck, _createClass */
+
 jest.autoMockOff();
 
 describe('moduleMocker', function() {
@@ -52,6 +59,44 @@ describe('moduleMocker', function() {
 
       expect(foo.x()).toBe('Foo');
       expect(bar.x()).toBe('Bar');
+    });
+
+    it('mocks ES6 non-enumerable methods', function() {
+        // ES6: class ClassFoo { foo() { } }
+        // Converted with https://babeljs.io/repl/
+        var ClassFoo = (function () {
+          function ClassFoo() {
+            _classCallCheck(this, ClassFoo);
+          }
+
+          _createClass(ClassFoo, [{
+            key: 'foo',
+            value: function foo() {}
+          }, {
+            key: 'toString',
+            value: function toString() {
+              return 'Foo';
+            }
+          }]);
+
+          return ClassFoo;
+        })();
+        var ClassFooMock = moduleMocker.generateFromMetadata(
+            moduleMocker.getMetadata(ClassFoo)
+        );
+
+        var foo = new ClassFooMock();
+
+        var instanceFoo = new ClassFoo();
+        var instanceFooMock = moduleMocker.generateFromMetadata(
+            moduleMocker.getMetadata(instanceFoo)
+        );
+
+        expect(typeof foo.foo).toBe('function');
+        expect(typeof instanceFooMock.foo).toBe('function');
+        expect(instanceFooMock.foo.mock).not.toBeUndefined();
+
+        expect(instanceFooMock.toString.mock).not.toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
Fixes https://github.com/facebook/jest/issues/332

It's not clear to me if/how I could add a test for this. It depends on attempting to mock a module that exports an ES6 class or instance. If it needs a test to be merged and you can provide some guidance I'll add it.

> There are two hard things in computer science: cache invalidation, naming things, and off-by-one errors.

I'm not sure `scan` is an ideal name, but I don't have anything better at the moment.