### PR TITLE
Fixes Jest tests when using it with newer versions of jsdom.

### DIFF
--- a/src/lib/jsdom-compat.js
+++ b/src/lib/jsdom-compat.js
@@ -98,8 +98,8 @@ if (utilsId) {
   };
 }
 
-var define = require('jsdom/lib/jsdom/level2/html').define;
 var jsdom = require('jsdom');
+var define = require('jsdom/lib/jsdom/level2/html').define;
 var elements = jsdom.defaultLevel;
 
 function _getTimeRangeDummy() {


### PR DESCRIPTION
When updating JSdom to the newer version that is compatible with node, 3.1.2, `npm test` will throw some errors.
```
 FAIL  HasteModuleLoader/__tests__/HasteModuleLoader-genMockFromModule-test.js
TypeError: Cannot call method 'appendHtmlToDocument' of undefined
  at setInnerHTML (/Users/fabs/Dev/fb/jest/node_modules/jsdom/lib/jsdom/level1/core.js:48:22)
  at HTMLDocument.inheritFrom.write (/Users/fabs/Dev/fb/jest/node_modules/jsdom/lib/jsdom/level1/core.js:1706:7)
  at Object.exports.jsdom (/Users/fabs/Dev/fb/jest/node_modules/jsdom/lib/jsdom.js:59:7)
  at new JSDomEnvironment (/Users/fabs/Dev/fb/jest/src/JSDomEnvironment.js:32:47)
  at TestRunner.runTest (/Users/fabs/Dev/fb/jest/src/TestRunner.js:322:13)
  at onMessage (/Users/fabs/Dev/fb/jest/src/TestWorker.js:50:25)
  at Socket.<anonymous> (/Users/fabs/Dev/fb/jest/node_modules/node-worker-pool/nodeWorkerUtils.js:39:11)
  at Socket.emit (events.js:95:17)
  at Socket.<anonymous> (_stream_readable.js:765:14)
  at Socket.emit (events.js:92:17)
  at emitReadable_ (_stream_readable.js:427:10)
  at emitReadable (_stream_readable.js:423:5)
  at readableAddChunk (_stream_readable.js:166:9)
  at Socket.Readable.push (_stream_readable.js:128:10)
  at Pipe.onread (net.js:529:21)
```
![screen shot 2015-04-29 at 10 17 30 pm](https://cloud.githubusercontent.com/assets/28530/7406780/96b58406-eebd-11e4-815d-de56390c809b.png)

`require('jsdom')` needs to happen before the other `jsdom` requires because some internal states are setup on that first call, and the second call depend on those.
After this change tests started passing just fine. I also tested with the current jsdom version and everything is fine too.