### PR TITLE
Add --noHighlight option

### DIFF
--- a/bin/jest.js
+++ b/bin/jest.js
@@ -95,7 +95,13 @@ var argv = optimist
       alias: 'v',
       description: _wrapDesc('Print the version and exit'),
       type: 'boolean'
-    }
+    },
+    noHighlight: {
+      description: _wrapDesc(
+        'Disables test results output highlighting'
+      ),
+      type: 'boolean'
+    },
   })
   .check(function(argv) {
     if (argv.runInBand && argv.hasOwnProperty('maxWorkers')) {

--- a/src/DefaultTestReporter.js
+++ b/src/DefaultTestReporter.js
@@ -15,95 +15,23 @@ var FAIL_COLOR = colors.RED_BG + colors.BOLD;
 var PASS_COLOR = colors.GREEN_BG + colors.BOLD;
 var TEST_NAME_COLOR = colors.BOLD;
 
-// Used in colorized mode.
-function _formatMsgColorized(msg, color) {
-  return colors.colorize(msg, color);
-}
-
-// Used in plain mode to output.
-function _formatMsgPlain(msg) {
-  return msg;
-}
-
-var _formatMsg;
-
-function _printConsoleMessage(process, msg) {
-  switch (msg.type) {
-    case 'dir':
-    case 'log':
-      process.stdout.write(msg.data);
-      break;
-    case 'warn':
-      process.stderr.write(
-        _formatMsg(msg.data, colors.YELLOW)
-      );
-      break;
-    case 'error':
-      process.stderr.write(
-        _formatMsg(msg.data, colors.RED)
-      );
-      break;
-    default:
-      throw new Error('Unknown console message type!: ' + msg.type);
-  }
-}
-
-function _getResultHeader(passed, testName, columns) {
-  var passFailTag = passed
-    ? _formatMsg(' PASS ', PASS_COLOR)
-    : _formatMsg(' FAIL ', FAIL_COLOR);
-
-  return [
-    passFailTag,
-    _formatMsg(testName, TEST_NAME_COLOR)
-  ].concat(columns || []).join(' ');
-}
-
-function _printWaitingOn(process, aggregatedResults) {
-  var completedTests =
-    aggregatedResults.numPassedTests +
-    aggregatedResults.numFailedTests;
-  var remainingTests = aggregatedResults.numTotalTests - completedTests;
-  if (remainingTests > 0) {
-    var pluralTests = remainingTests === 1 ? 'test' : 'tests';
-    process.stdout.write(
-      _formatMsg(
-        'Waiting on ' + remainingTests + ' ' + pluralTests + '...',
-        colors.GRAY + colors.BOLD
-      )
-    );
-  }
-}
-
-function _clearWaitingOn(process, config) {
-  // Don't write special chars in noHighlight mode
-  // to get clean output for logs.
-  var command = config.noHighlight
-    ? '\n'
-    : '\r\x1B[K';
-  process.stdout.write(command);
-}
-
 function DefaultTestReporter(customProcess) {
-  this.process = customProcess || process;
+  this._process = customProcess || process;
 }
 
 DefaultTestReporter.prototype.log = function(str) {
-  this.process.stdout.write(str + '\n');
+  this._process.stdout.write(str + '\n');
 };
 
 DefaultTestReporter.prototype.onRunStart =
 function(config, aggregatedResults) {
-  _formatMsg = config.noHighlight
-    ? _formatMsgPlain
-    : _formatMsgColorized;
-
-  _printWaitingOn(this.process, aggregatedResults);
+  this._config = config;
+  this._printWaitingOn(aggregatedResults);
 };
 
 DefaultTestReporter.prototype.onTestResult =
 function(config, testResult, aggregatedResults) {
-  _clearWaitingOn(this.process, config);
+  this._clearWaitingOn();
 
   var pathStr =
     config.rootDir
@@ -111,7 +39,7 @@ function(config, testResult, aggregatedResults) {
     : testResult.testFilePath;
 
   if (testResult.testExecError) {
-    this.log(_getResultHeader(false, pathStr));
+    this.log(this._getResultHeader(false, pathStr));
     this.log(testResult.testExecError);
     return false;
   }
@@ -125,7 +53,7 @@ function(config, testResult, aggregatedResults) {
 
   var testRunTimeString = '(' + testRunTime + 's)';
   if (testRunTime > 2.5) {
-    testRunTimeString = _formatMsg(testRunTimeString, FAIL_COLOR);
+    testRunTimeString = this._formatMsg(testRunTimeString, FAIL_COLOR);
   }
 
   /*
@@ -134,19 +62,17 @@ function(config, testResult, aggregatedResults) {
   }
   */
 
-  this.log(_getResultHeader(allTestsPassed, pathStr, [
+  this.log(this._getResultHeader(allTestsPassed, pathStr, [
     testRunTimeString
   ]));
 
-  testResult.logMessages.forEach(function (message) {
-    _printConsoleMessage(this.process, message);
-  }, this);
+  testResult.logMessages.forEach(this._printConsoleMessage.bind(this));
 
   if (!allTestsPassed) {
     this.log(formatFailureMessage(testResult, /*color*/!config.noHighlight));
   }
 
-  _printWaitingOn(this.process, aggregatedResults);
+  this._printWaitingOn(aggregatedResults);
 };
 
 DefaultTestReporter.prototype.onRunComplete =
@@ -162,13 +88,13 @@ function (config, aggregatedResults) {
 
   var results = '';
   if (numFailedTests) {
-    results += _formatMsg(
+    results += this._formatMsg(
       numFailedTests + ' test' + (numFailedTests === 1 ? '' : 's') + ' failed',
       colors.RED + colors.BOLD
     );
     results += ', ';
   }
-  results += _formatMsg(
+  results += this._formatMsg(
     numPassedTests + ' test' + (numPassedTests === 1 ? '' : 's') + ' passed',
     colors.GREEN + colors.BOLD
   );
@@ -176,6 +102,71 @@ function (config, aggregatedResults) {
 
   this.log(results);
   this.log('Run time: ' + runTime + 's');
+};
+
+DefaultTestReporter.prototype._printConsoleMessage = function(msg) {
+  switch (msg.type) {
+    case 'dir':
+    case 'log':
+      this._process.stdout.write(msg.data);
+      break;
+    case 'warn':
+      this._process.stderr.write(
+        this._formatMsg(msg.data, colors.YELLOW)
+      );
+      break;
+    case 'error':
+      this._process.stderr.write(
+        this._formatMsg(msg.data, colors.RED)
+      );
+      break;
+    default:
+      throw new Error('Unknown console message type!: ' + msg.type);
+  }
+};
+
+DefaultTestReporter.prototype._clearWaitingOn = function() {
+  // Don't write special chars in noHighlight mode
+  // to get clean output for logs.
+  var command = this._config.noHighlight
+    ? '\n'
+    : '\r\x1B[K';
+  this._process.stdout.write(command);
+};
+
+DefaultTestReporter.prototype._formatMsg = function(msg, color) {
+  if (this._config.noHighlight) {
+    return msg;
+  }
+  return colors.colorize(msg, color);
+};
+
+DefaultTestReporter.prototype._getResultHeader =
+function (passed, testName, columns) {
+  var passFailTag = passed
+    ? this._formatMsg(' PASS ', PASS_COLOR)
+    : this._formatMsg(' FAIL ', FAIL_COLOR);
+
+  return [
+    passFailTag,
+    this._formatMsg(testName, TEST_NAME_COLOR)
+  ].concat(columns || []).join(' ');
+};
+
+DefaultTestReporter.prototype._printWaitingOn = function(aggregatedResults) {
+  var completedTests =
+    aggregatedResults.numPassedTests +
+    aggregatedResults.numFailedTests;
+  var remainingTests = aggregatedResults.numTotalTests - completedTests;
+  if (remainingTests > 0) {
+    var pluralTests = remainingTests === 1 ? 'test' : 'tests';
+    this._process.stdout.write(
+      this._formatMsg(
+        'Waiting on ' + remainingTests + ' ' + pluralTests + '...',
+        colors.GRAY + colors.BOLD
+      )
+    );
+  }
 };
 
 module.exports = DefaultTestReporter;

--- a/src/jasmineTestRunner/JasmineReporter.js
+++ b/src/jasmineTestRunner/JasmineReporter.js
@@ -12,18 +12,6 @@ var diff = require('diff');
 var jasmine = require('../../vendor/jasmine/jasmine-1.3.0').jasmine;
 var Q = require('q');
 
-// Used in colorized mode.
-function _formatMsgColorized(msg, color) {
-  return colors.colorize(msg, color);
-}
-
-// Used in plain mode to output.
-function _formatMsgPlain(msg) {
-  return msg;
-}
-
-var _formatMsg;
-
 var ERROR_TITLE_COLOR = colors.RED + colors.BOLD + colors.UNDERLINE;
 var DIFFABLE_MATCHERS = {
   toBe: true,
@@ -33,7 +21,140 @@ var DIFFABLE_MATCHERS = {
 };
 var LINEBREAK_REGEX = /[\r\n]/;
 
-function _highlightDifferences(a, b) {
+function JasmineReporter(config) {
+  jasmine.Reporter.call(this);
+  this._config = config || {};
+  this._logs = [];
+  this._resultsDeferred = Q.defer();
+}
+
+JasmineReporter.prototype = Object.create(jasmine.Reporter.prototype);
+
+// All describe() suites have finished
+JasmineReporter.prototype.reportRunnerResults = function(runner) {
+  var testResults = [];
+
+  // Find the top-level suite in order to flatten test results from there
+  if (runner.suites().length) {
+    runner.suites().forEach(function(suite) {
+      if (suite.parentSuite === null) {
+        this._extractSuiteResults(testResults, [], suite);
+      }
+    }, this);
+  }
+
+  var numFailingTests = 0;
+  var numPassingTests = 0;
+  testResults.forEach(function(testResult) {
+    if (testResult.failureMessages.length > 0) {
+      numFailingTests++;
+    } else {
+      numPassingTests++;
+    }
+  });
+
+  this._resultsDeferred.resolve({
+    numFailingTests: numFailingTests,
+    numPassingTests: numPassingTests,
+    testResults: testResults
+  });
+};
+
+JasmineReporter.prototype.getResults = function() {
+  return this._resultsDeferred.promise;
+};
+
+JasmineReporter.prototype.log = function(str) {
+  console.log('logging: ', str);
+};
+
+JasmineReporter.prototype._extractSuiteResults =
+function (container, ancestorTitles, suite) {
+  ancestorTitles = ancestorTitles.concat([suite.description]);
+
+  suite.specs().forEach(
+    this._extractSpecResults.bind(this, container, ancestorTitles)
+  );
+  suite.suites().forEach(
+    this._extractSuiteResults.bind(this, container, ancestorTitles)
+  );
+};
+
+JasmineReporter.prototype._extractSpecResults =
+function (container, ancestorTitles, spec) {
+  var results = {
+    title: 'it ' + spec.description,
+    ancestorTitles: ancestorTitles,
+    failureMessages: [],
+    logMessages: [],
+    numPassingAsserts: 0
+  };
+
+  spec.results().getItems().forEach(function(result) {
+    switch (result.type) {
+      case 'log':
+        results.logMessages.push(result.toString());
+        break;
+      case 'expect':
+        if (result.passed()) {
+          results.numPassingAsserts++;
+
+        // Exception thrown
+        } else if (!result.matcherName && result.trace.stack) {
+          // jasmine doesn't give us access to the actual Error object, so we
+          // have to regexp out the message from the stack string in order to
+          // colorize the `message` value
+          result.trace.stack = result.trace.stack.replace(
+            /(^.*$(?=\n\s*at))/m,
+            this._formatMsg('$1', ERROR_TITLE_COLOR)
+          );
+
+          results.failureMessages.push(result.trace.stack);
+        } else {
+          var message;
+          if (DIFFABLE_MATCHERS[result.matcherName]) {
+            var ppActual = this._prettyPrint(result.actual);
+            var ppExpected = this._prettyPrint(result.expected);
+            var colorDiff = this._highlightDifferences(ppActual, ppExpected);
+
+            var matcherName = (result.isNot ? 'NOT ' : '') + result.matcherName;
+
+            message =
+              this._formatMsg('Expected:', ERROR_TITLE_COLOR) +
+                ' ' + colorDiff.a +
+                ' ' + this._formatMsg(matcherName + ':', ERROR_TITLE_COLOR) +
+                ' ' + colorDiff.b;
+          } else {
+            message = this._formatMsg(result.message, ERROR_TITLE_COLOR);
+          }
+
+          if (result.trace.stack) {
+            // Replace the error message with a colorized version of the error
+            message = result.trace.stack.replace(result.trace.message, message);
+
+            // Remove the 'Error: ' prefix from the stack trace
+            message = message.replace(/^.*Error:\s*/, '');
+
+            // Remove jasmine jonx from the stack trace
+            message = message.split('\n').filter(function(line) {
+              return !/vendor\/jasmine\//.test(line);
+            }).join('\n');
+          }
+
+          results.failureMessages.push(message);
+        }
+        break;
+      default:
+        throw new Error(
+          'Unexpected jasmine spec result type: ', result.type
+        );
+    }
+  }, this);
+
+  container.push(results);
+};
+
+JasmineReporter.prototype._highlightDifferences = function (a, b) {
   var differ;
   if (a.match(LINEBREAK_REGEX) || b.match(LINEBREAK_REGEX)) {
     // `diff` uses the Myers LCS diff algorithm which runs in O(n+d^2) time
@@ -50,18 +171,18 @@ function _highlightDifferences(a, b) {
   for (var i = 0, il = changes.length; i < il; i++) {
     change = changes[i];
     if (change.added) {
-      ret.b += _formatMsg(change.value, colors.RED_BG);
+      ret.b += this._formatMsg(change.value, colors.RED_BG);
     } else if (change.removed) {
-      ret.a += _formatMsg(change.value, colors.RED_BG);
+      ret.a += this._formatMsg(change.value, colors.RED_BG);
     } else {
       ret.a += change.value;
       ret.b += change.value;
     }
   }
   return ret;
-}
+};
 
-function _prettyPrint(obj, indent, cycleWeakMap) {
+JasmineReporter.prototype._prettyPrint = function(obj, indent, cycleWeakMap) {
   if (!indent) {
     indent = '';
   }
@@ -98,7 +219,7 @@ function _prettyPrint(obj, indent, cycleWeakMap) {
     var orderedKeys = Object.keys(obj).sort();
     var value;
     var keysOutput = [];
-    var keyIndent = _formatMsg('|', colors.GRAY) + ' ';
+    var keyIndent = this._formatMsg('|', colors.GRAY) + ' ';
     for (var i = 0; i < orderedKeys.length; i++) {
       if (orderedKeys[i] === '__jstest_pp_cycle__') {
         continue;
@@ -106,7 +227,7 @@ function _prettyPrint(obj, indent, cycleWeakMap) {
       value = obj[orderedKeys[i]];
       keysOutput.push(
         indent + keyIndent + orderedKeys[i] + ': ' +
-        _prettyPrint(value, indent + keyIndent, cycleWeakMap)
+        this._prettyPrint(value, indent + keyIndent, cycleWeakMap)
       );
     }
     delete obj.__jstest_pp_cycle__;
@@ -114,140 +235,13 @@ function _prettyPrint(obj, indent, cycleWeakMap) {
   } else {
     return jasmine.pp(obj);
   }
-}
+};
 
-function _extractSuiteResults(container, ancestorTitles, suite) {
-  ancestorTitles = ancestorTitles.concat([suite.description]);
-
-  suite.specs().forEach(
-    _extractSpecResults.bind(null, container, ancestorTitles)
-  );
-  suite.suites().forEach(
-    _extractSuiteResults.bind(null, container, ancestorTitles)
-  );
-}
-
-function _extractSpecResults(container, ancestorTitles, spec) {
-  var results = {
-    title: 'it ' + spec.description,
-    ancestorTitles: ancestorTitles,
-    failureMessages: [],
-    logMessages: [],
-    numPassingAsserts: 0
-  };
-
-  spec.results().getItems().forEach(function(result) {
-    switch (result.type) {
-      case 'log':
-        results.logMessages.push(result.toString());
-        break;
-      case 'expect':
-        if (result.passed()) {
-          results.numPassingAsserts++;
-
-        // Exception thrown
-        } else if (!result.matcherName && result.trace.stack) {
-          // jasmine doesn't give us access to the actual Error object, so we
-          // have to regexp out the message from the stack string in order to
-          // colorize the `message` value
-          result.trace.stack = result.trace.stack.replace(
-            /(^.*$(?=\n\s*at))/m,
-            _formatMsg('$1', ERROR_TITLE_COLOR)
-          );
-
-          results.failureMessages.push(result.trace.stack);
-        } else {
-          var message;
-          if (DIFFABLE_MATCHERS[result.matcherName]) {
-            var ppActual = _prettyPrint(result.actual);
-            var ppExpected = _prettyPrint(result.expected);
-            var colorDiff = _highlightDifferences(ppActual, ppExpected);
-
-            var matcherName = (result.isNot ? 'NOT ' : '') + result.matcherName;
-
-            message =
-              _formatMsg('Expected:', ERROR_TITLE_COLOR) +
-                ' ' + colorDiff.a +
-                ' ' + _formatMsg(matcherName + ':', ERROR_TITLE_COLOR) +
-                ' ' + colorDiff.b;
-          } else {
-            message = _formatMsg(result.message, ERROR_TITLE_COLOR);
-          }
-
-          if (result.trace.stack) {
-            // Replace the error message with a colorized version of the error
-            message = result.trace.stack.replace(result.trace.message, message);
-
-            // Remove the 'Error: ' prefix from the stack trace
-            message = message.replace(/^.*Error:\s*/, '');
-
-            // Remove jasmine jonx from the stack trace
-            message = message.split('\n').filter(function(line) {
-              return !/vendor\/jasmine\//.test(line);
-            }).join('\n');
-          }
-
-          results.failureMessages.push(message);
-        }
-        break;
-      default:
-        throw new Error(
-          'Unexpected jasmine spec result type: ', result.type
-        );
-    }
-  });
-
-  container.push(results);
-}
-
-function JasmineReporter(config) {
-  jasmine.Reporter.call(this);
-  this._config = config || {};
-  this._logs = [];
-  this._resultsDeferred = Q.defer();
-}
-JasmineReporter.prototype = Object.create(jasmine.Reporter.prototype);
-
-// All describe() suites have finished
-JasmineReporter.prototype.reportRunnerResults = function(runner) {
-  var testResults = [];
-
-  _formatMsg = this._config.noHighlight
-    ? _formatMsgPlain
-    : _formatMsgColorized;
-
-  // Find the top-level suite in order to flatten test results from there
-  if (runner.suites().length) {
-    runner.suites().forEach(function(suite) {
-      if (suite.parentSuite === null) {
-        _extractSuiteResults(testResults, [], suite);
-      }
-    });
+JasmineReporter.prototype._formatMsg = function(msg, color) {
+  if (this._config.noHighlight) {
+    return msg;
   }
-
-  var numFailingTests = 0;
-  var numPassingTests = 0;
-  testResults.forEach(function(testResult) {
-    if (testResult.failureMessages.length > 0) {
-      numFailingTests++;
-    } else {
-      numPassingTests++;
-    }
-  });
-
-  this._resultsDeferred.resolve({
-    numFailingTests: numFailingTests,
-    numPassingTests: numPassingTests,
-    testResults: testResults
-  });
-};
-
-JasmineReporter.prototype.getResults = function() {
-  return this._resultsDeferred.promise;
-};
-
-JasmineReporter.prototype.log = function(str) {
-  console.log('logging: ', str);
+  return colors.colorize(msg, color);
 };
 
 module.exports = JasmineReporter;

--- a/src/jasmineTestRunner/jasmineTestRunner.js
+++ b/src/jasmineTestRunner/jasmineTestRunner.js
@@ -235,7 +235,9 @@ function jasmineTestRunner(config, environment, moduleLoader, testPath) {
     }
   });
 
-  var jasmineReporter = new JasmineReporter();
+  var jasmineReporter = new JasmineReporter({
+    noHighlight: config.noHighlight,
+  });
   jasmine.getEnv().addReporter(jasmineReporter);
 
   // Run the test by require()ing it

--- a/src/jest.js
+++ b/src/jest.js
@@ -91,6 +91,10 @@ function _promiseConfig(argv, packageRoot) {
       config.testEnvData = argv.testEnvData;
     }
 
+    if (argv.noHighlight) {
+      config.noHighlight = argv.noHighlight;
+    }
+
     return config;
   });
 }

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -26,7 +26,8 @@ var DEFAULT_CONFIG_VALUES = {
   testPathDirs: ['<rootDir>'],
   testPathIgnorePatterns: ['/node_modules/'],
   testReporter: require.resolve('../IstanbulTestReporter'),
-  testRunner: require.resolve('../jasmineTestRunner/jasmineTestRunner')
+  testRunner: require.resolve('../jasmineTestRunner/jasmineTestRunner'),
+  noHighlight: false,
 };
 
 function _replaceRootDirTags(rootDir, config) {
@@ -222,6 +223,7 @@ function normalizeConfig(config) {
       case 'testFileExtensions':
       case 'testReporter':
       case 'moduleFileExtensions':
+      case 'noHighlight':
         value = config[key];
         break;
 


### PR DESCRIPTION
Ability to get plain output for better debug logs (that avoids having in logs things like "[0m[1m" from the highlighter).