### PR TITLE
Use `lodash.template`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "q": "~0.9.7",
     "resolve": "~0.6.1",
     "through": "^2.3.4",
-    "underscore": "1.2.4"
+    "lodash.template": "^3.0.0"
   },
   "devDependencies": {
     "jshint": "~2.5.0",

--- a/src/CoverageCollector.js
+++ b/src/CoverageCollector.js
@@ -15,7 +15,7 @@ var COVERAGE_TEMPLATE_PATH = require.resolve('./coverageTemplate');
 var _memoizedCoverageTemplate = null;
 function _getCoverageTemplate() {
   if (_memoizedCoverageTemplate === null) {
-    _memoizedCoverageTemplate = require('underscore').template(
+    _memoizedCoverageTemplate = require('lodash.template')(
       fs.readFileSync(COVERAGE_TEMPLATE_PATH, 'utf8')
     );
   }


### PR DESCRIPTION
I noticed jest is only using `template` and using a really old version so replaced it with just the template dep.