### PR TITLE
Pass jest runtime to test setup scripts (closes #108)

### DIFF
--- a/src/HasteModuleLoader/HasteModuleLoader.js
+++ b/src/HasteModuleLoader/HasteModuleLoader.js
@@ -938,6 +938,10 @@ Loader.prototype.requireModuleOrMock = function(currPath, moduleName) {
   }
 };
 
+Loader.prototype.getJestRuntime = function(dir) {
+    return this._builtInModules['jest-runtime'](dir).exports;
+};
+
 /**
  * Clears all cached module objects. This allows one to reset the state of
  * all modules in the system. It will reset (read: clear) the export objects

--- a/src/TestRunner.js
+++ b/src/TestRunner.js
@@ -362,7 +362,8 @@ TestRunner.prototype.runTest = function(testFilePath) {
           global: env.global,
           require: moduleLoader.constructBoundRequire(
             config.setupEnvScriptFile
-          )
+          ),
+          jest: moduleLoader.getJestRuntime(config.setupEnvScriptFile)
         }
       );
     }

--- a/src/jasmineTestRunner/jasmineTestRunner.js
+++ b/src/jasmineTestRunner/jasmineTestRunner.js
@@ -176,7 +176,8 @@ function jasmineTestRunner(config, environment, moduleLoader, testPath) {
           __filename: config.setupTestFrameworkScriptFile,
           require: moduleLoader.constructBoundRequire(
             config.setupTestFrameworkScriptFile
-          )
+          ),
+          jest: moduleLoader.getJestRuntime(config.setupTestFrameworkScriptFile)
         }
       );
     }


### PR DESCRIPTION
This gives the two setup scripts `setupTestFrameworkScriptFile` and `setupEnvScriptFile` access to the jest runtime of the test.