### PR TITLE
Make currently-executing test's file path available as jest.currentTestPath()

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -11,6 +11,7 @@ permalink: docs/api.html
   - [`jest.autoMockOff()`](#jest-automockoff)
   - [`jest.autoMockOn()`](#jest-automockon)
   - [`jest.clearAllTimers()`](#jest-clearalltimers)
+  - [`jest.currentTestPath()`](#jest-currenttestpath)
   - [`jest.dontMock(moduleName)`](#jest-dontmock-modulename)
   - [`jest.genMockFromModule(moduleName)`](#jest-genmockfrommodule-modulename)
   - [`jest.genMockFunction()`](#jest-genmockfunction)
@@ -104,6 +105,9 @@ It's worth noting that automatic mocking is on by default, so this method is onl
 Removes any pending timers from the timer system.
 
 This means, if any timers have been scheduled (but have not yet executed), they will be cleared and will never have the opportunity to execute in the future.
+
+### `jest.currentTestPath()`
+Returns the absolute path to the currently executing test file.
 
 ### `jest.dontMock(moduleName)`
 Indicates that the module system should never return a mocked version of the specified module from `require()` (e.g. that it should always return the real module).
@@ -318,8 +322,6 @@ It's worth noting that this code will execute *before* [`config.setupTestFramewo
 The path to a module that runs some code to configure or set up the testing framework before each test. Since [`config.setupEnvScriptFile`](#config-setupenvscriptfile-string) executes before the test framework is installed in the environment, this script file presents you the opportunity of running some code immediately after the test framework has been installed in the environment.
 
 For example, Jest ships with several plug-ins to `jasmine` that work by monkey-patching the jasmine API. If you wanted to add even more jasmine plugins to the mix (or if you wanted some custom, project-wide matchers for example), you could do so in this module.
-
-The currently executing test's file path is available as an injected global in this file as `_jestTestFilePath`.
 
 ### `config.testDirectoryName` [string]
 (default: `'__tests__'`)

--- a/docs/API.md
+++ b/docs/API.md
@@ -319,6 +319,8 @@ The path to a module that runs some code to configure or set up the testing fram
 
 For example, Jest ships with several plug-ins to `jasmine` that work by monkey-patching the jasmine API. If you wanted to add even more jasmine plugins to the mix (or if you wanted some custom, project-wide matchers for example), you could do so in this module.
 
+The currently executing test's file path is available as an injected global in this file as `_jestTestFilePath`.
+
 ### `config.testDirectoryName` [string]
 (default: `'__tests__'`)
 

--- a/src/HasteModuleLoader/HasteModuleLoader.js
+++ b/src/HasteModuleLoader/HasteModuleLoader.js
@@ -966,6 +966,10 @@ Loader.prototype.resetModuleRegistry = function() {
             this._environment.fakeTimers.clearAllTimers();
           }.bind(this),
 
+          currentTestPath: function() {
+            return this._environment.testFilePath;
+          }.bind(this),
+
           dontMock: function(moduleName) {
             var moduleID = this._getNormalizedModuleID(currPath, moduleName);
             this._explicitShouldMock[moduleID] = false;

--- a/src/HasteModuleLoader/__tests__/HasteModuleLoader-currentTestPath-test.js
+++ b/src/HasteModuleLoader/__tests__/HasteModuleLoader-currentTestPath-test.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2014, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
+jest.autoMockOff();
+
+describe('nodeHasteModuleLoader', function() {
+    describe('currentTestPath', function() {
+        it('makes the current test path available', function() {
+            expect(jest.currentTestPath()).toMatch(/currentTestPath-test/);
+        });
+    });
+});

--- a/src/TestRunner.js
+++ b/src/TestRunner.js
@@ -329,7 +329,7 @@ TestRunner.prototype.runTest = function(testFilePath) {
 
   // Pass the testFilePath into the runner, so it can be used to e.g.
   // configure test reporter output.
-  env.global._jestTestFilePath = testFilePath;
+  env.testFilePath = testFilePath;
 
   return this._constructModuleLoader(env, config).then(function(moduleLoader) {
     // This is a kind of janky way to ensure that we only collect coverage

--- a/src/TestRunner.js
+++ b/src/TestRunner.js
@@ -327,6 +327,10 @@ TestRunner.prototype.runTest = function(testFilePath) {
   var consoleMessages = [];
   env.global.console = new Console(consoleMessages);
 
+  // Pass the testFilePath into the runner, so it can be used to e.g.
+  // configure test reporter output.
+  env.global._jestTestFilePath = testFilePath;
+
   return this._constructModuleLoader(env, config).then(function(moduleLoader) {
     // This is a kind of janky way to ensure that we only collect coverage
     // information on modules that are immediate dependencies of the test file.


### PR DESCRIPTION
It is useful to have the current test filename available in the test reporter environment. For instance, we use the JUnitReporter with our CI server, and because each test file is run in its own process, this enables us to output a results file named for each test:

```javascript
// This script enables JUnit XML output by the test runner to be parsed and reported by Bamboo
jasmine.VERBOSE = true;

require('jasmine-reporters');

// massage the test file path into an output filename
var relativeTestPath = 'test' + _jestTestFilePath
    .replace(process.cwd(), '')
    .replace(/\//g, '.')
    .replace('__tests__.', '')
    .replace(/\.jsx?$/, '');

var reporter = new jasmine.JUnitXmlReporter('test_results', true, true, relativeTestPath, true);
jasmine.getEnv().addReporter(reporter);
```

I looked a bit into how to best test this but it seemed … complicated :) I would appreciate any thoughts on a nice way to do this? One possibility would be to add it to the `testEnvData` but I feel like that would be a misuse. Otherwise it seems like the way would be to run an end-to-end test with a `setupTestFrameworkScriptFile` configuration parameter, and assert the test filename therein. I'd be happy to add one if that seems like the right approach.