### PR TITLE
Clarify what "immediately adjacent" means

### DIFF
--- a/docs/ManualMocks.md
+++ b/docs/ManualMocks.md
@@ -9,7 +9,7 @@ next: timer-mocks
 
 Although autogeneration of mocks is convenient, there are behaviors it misses, such as [fluent interfaces](http://martinfowler.com/bliki/FluentInterface.html). Furthermore, providing useful helpers on mock versions of a module, especially a core module, promotes reuse and can help to hide implementation details.
 
-Manual mocks are defined by writing a module in a `__mocks__/` subdirectory immediately adjacent to the module. When a manual mock exists for a given module, Jest's module system will just use that instead of trying to automatically generate a mock.
+Manual mocks are defined by writing a module in a `__mocks__/` subdirectory either immediately adjacent to the module or in the same directory as the module being mocked (e.g. to mock a module in the ``src/models`` folder, the mock module would be in ``src/models/__mocks__``) When a manual mock exists for a given module, Jest's module system will just use that instead of trying to automatically generate a mock.
 
 Assuming that the module can be loaded by the automocker, it's best to build on the automocked API. This makes it harder for mock APIs to get out of sync with real ones.
 


### PR DESCRIPTION
The phrase "immediately adjacent" is confusing when talking about modules not located in the node_modules folder. I propose we updated the wording to make it clear where the ``__mocks__`` folder should be located when mocking out custom modules.