### PR TITLE
noHighlight option default to not TTY process

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "cover": "~0.2.8",
     "diff": "~1.0.4",
     "graceful-fs": "^2.0.3",
-    "harmonize": "1.4.0",
+    "harmonize": "1.4.2",
     "istanbul": "^0.3.2",
     "jasmine-only": "0.1.0",
     "jasmine-pit": "~2.0.0",

--- a/src/jest.js
+++ b/src/jest.js
@@ -91,9 +91,7 @@ function _promiseConfig(argv, packageRoot) {
       config.testEnvData = argv.testEnvData;
     }
 
-    if (argv.noHighlight) {
-      config.noHighlight = argv.noHighlight;
-    }
+    config.noHighlight = argv.noHighlight || !process.stdout.isTTY;
 
     return config;
   });


### PR DESCRIPTION
For a non-TTY session do `--noHighlight` mode by default.