### PR TITLE
Pass down jest config to preprocess script

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -343,7 +343,13 @@ function readAndPreprocessFileContent(filePath, config) {
         return pattern.test(filePath);
       })) {
     try {
-      fileData = require(config.scriptPreprocessor).process(fileData, filePath);
+      fileData = require(config.scriptPreprocessor).process(
+        fileData,
+        filePath,
+        {}, // options
+        [], // excludes
+        config
+      );
     } catch (e) {
       e.message = config.scriptPreprocessor + ': ' + e.message;
       throw e;


### PR DESCRIPTION
The use-case here is that if we want to do caching inside of the
preprocess script, then we want to include the jest configuration to
create a cache-key.