### PR TITLE
Verbose test results

### DIFF
--- a/bin/jest.js
+++ b/bin/jest.js
@@ -110,6 +110,12 @@ var argv = optimist
       ),
       type: 'boolean'
     },
+    verbose: {
+      description: _wrapDesc(
+        'Display individual test results with the test suite hierarchy.'
+      ),
+      type: 'boolean'
+    }
   })
   .check(function(argv) {
     if (argv.runInBand && argv.hasOwnProperty('maxWorkers')) {

--- a/src/DefaultTestReporter.js
+++ b/src/DefaultTestReporter.js
@@ -28,7 +28,7 @@ DefaultTestReporter.prototype.onRunStart =
 function(config, aggregatedResults) {
   this._config = config;
   this._printWaitingOn(aggregatedResults);
-  if(this._config.verbose){
+  if (this._config.verbose) {
     var verboseLogger = new VerboseLogger(this._config, this._process);
     this.verboseLog = verboseLogger.verboseLog.bind(verboseLogger);
   }
@@ -67,7 +67,7 @@ function(config, testResult, aggregatedResults) {
   }
   */
 
-  if (config.verbose){
+  if (config.verbose) {
     this.verboseLog(testResult.testResults);
   } else {
     this.log(this._getResultHeader(allTestsPassed, pathStr, [
@@ -78,7 +78,7 @@ function(config, testResult, aggregatedResults) {
   testResult.logMessages.forEach(this._printConsoleMessage.bind(this));
 
   if (!allTestsPassed) {
-    if(config.verbose){
+    if (config.verbose) {
       aggregatedResults.postSuiteHeaders.push(
         this._getResultHeader(allTestsPassed, pathStr, [
           testRunTimeString
@@ -104,7 +104,7 @@ function (config, aggregatedResults) {
     return;
   }
 
-  if (config.verbose){
+  if (config.verbose) {
     this.log(aggregatedResults.postSuiteHeaders.join('\n'));
   }
 

--- a/src/DefaultTestReporter.js
+++ b/src/DefaultTestReporter.js
@@ -78,7 +78,16 @@ function(config, testResult, aggregatedResults) {
   testResult.logMessages.forEach(this._printConsoleMessage.bind(this));
 
   if (!allTestsPassed) {
-    this.log(formatFailureMessage(testResult, /*color*/!config.noHighlight));
+    if(config.verbose){
+      aggregatedResults.postSuiteHeaders.push(
+        this._getResultHeader(allTestsPassed, pathStr, [
+          testRunTimeString
+        ]),
+        formatFailureMessage(testResult, /*color*/!config.noHighlight)
+      )
+    } else {
+      this.log(formatFailureMessage(testResult, /*color*/!config.noHighlight));
+    }
   }
 
   this._printWaitingOn(aggregatedResults);
@@ -93,6 +102,10 @@ function (config, aggregatedResults) {
 
   if (numTotalTests === 0) {
     return;
+  }
+
+  if (config.verbose){
+    this.log(aggregatedResults.postSuiteHeaders.join('\n'))
   }
 
   var results = '';

--- a/src/DefaultTestReporter.js
+++ b/src/DefaultTestReporter.js
@@ -29,7 +29,7 @@ function(config, aggregatedResults) {
   this._config = config;
   this._printWaitingOn(aggregatedResults);
   if(this._config.verbose){
-    var verboseLogger = new VerboseLogger(this._config, this._process)
+    var verboseLogger = new VerboseLogger(this._config, this._process);
     this.verboseLog = verboseLogger.verboseLog.bind(verboseLogger);
   }
 };
@@ -84,7 +84,7 @@ function(config, testResult, aggregatedResults) {
           testRunTimeString
         ]),
         formatFailureMessage(testResult, /*color*/!config.noHighlight)
-      )
+      );
     } else {
       this.log(formatFailureMessage(testResult, /*color*/!config.noHighlight));
     }
@@ -105,7 +105,7 @@ function (config, aggregatedResults) {
   }
 
   if (config.verbose){
-    this.log(aggregatedResults.postSuiteHeaders.join('\n'))
+    this.log(aggregatedResults.postSuiteHeaders.join('\n'));
   }
 
   var results = '';

--- a/src/DefaultTestReporter.js
+++ b/src/DefaultTestReporter.js
@@ -9,6 +9,7 @@
 
 var colors = require('./lib/colors');
 var formatFailureMessage = require('./lib/utils').formatFailureMessage;
+var formatMsg = require('./lib/utils').formatMsg;
 var path = require('path');
 var VerboseLogger = require('./lib/testLogger');
 
@@ -157,10 +158,7 @@ DefaultTestReporter.prototype._clearWaitingOn = function() {
 };
 
 DefaultTestReporter.prototype._formatMsg = function(msg, color) {
-  if (this._config.noHighlight) {
-    return msg;
-  }
-  return colors.colorize(msg, color);
+  return formatMsg(msg, color, this._config);
 };
 
 DefaultTestReporter.prototype._getResultHeader =

--- a/src/DefaultTestReporter.js
+++ b/src/DefaultTestReporter.js
@@ -10,6 +10,7 @@
 var colors = require('./lib/colors');
 var formatFailureMessage = require('./lib/utils').formatFailureMessage;
 var path = require('path');
+var VerboseLogger = require('./lib/testLogger');
 
 var FAIL_COLOR = colors.RED_BG + colors.BOLD;
 var PASS_COLOR = colors.GREEN_BG + colors.BOLD;
@@ -27,6 +28,10 @@ DefaultTestReporter.prototype.onRunStart =
 function(config, aggregatedResults) {
   this._config = config;
   this._printWaitingOn(aggregatedResults);
+  if(this._config.verbose){
+    var verboseLogger = new VerboseLogger(this._config, this._process)
+    this.verboseLog = verboseLogger.verboseLog.bind(verboseLogger);
+  }
 };
 
 DefaultTestReporter.prototype.onTestResult =
@@ -62,9 +67,13 @@ function(config, testResult, aggregatedResults) {
   }
   */
 
-  this.log(this._getResultHeader(allTestsPassed, pathStr, [
-    testRunTimeString
-  ]));
+  if (config.verbose){
+    this.verboseLog(testResult.testResults);
+  } else {
+    this.log(this._getResultHeader(allTestsPassed, pathStr, [
+      testRunTimeString
+    ]));
+  }
 
   testResult.logMessages.forEach(this._printConsoleMessage.bind(this));
 

--- a/src/TestRunner.js
+++ b/src/TestRunner.js
@@ -415,6 +415,7 @@ TestRunner.prototype.runTests = function(testPaths, reporter) {
     numPassedTests: 0,
     numFailedTests: 0,
     testResults: [],
+    postSuiteHeaders: []
   };
 
   reporter.onRunStart && reporter.onRunStart(config, aggregatedResults);

--- a/src/jasmineTestRunner/JasmineReporter.js
+++ b/src/jasmineTestRunner/JasmineReporter.js
@@ -9,6 +9,7 @@
 
 var colors = require('../lib/colors');
 var diff = require('diff');
+var formatMsg = require('../lib/utils').formatMsg;
 var jasmine = require('../../vendor/jasmine/jasmine-1.3.0').jasmine;
 var Q = require('q');
 
@@ -238,10 +239,7 @@ JasmineReporter.prototype._prettyPrint = function(obj, indent, cycleWeakMap) {
 };
 
 JasmineReporter.prototype._formatMsg = function(msg, color) {
-  if (this._config.noHighlight) {
-    return msg;
-  }
-  return colors.colorize(msg, color);
+  return formatMsg(msg, color, this._config);
 };
 
 module.exports = JasmineReporter;

--- a/src/jest.js
+++ b/src/jest.js
@@ -95,6 +95,10 @@ function _promiseConfig(argv, packageRoot) {
       config.noHighlight = argv.noHighlight;
     }
 
+    if (argv.verbose) {
+      config.verbose = argv.verbose;
+    }
+
     return config;
   });
 }

--- a/src/lib/testLogger.js
+++ b/src/lib/testLogger.js
@@ -9,11 +9,30 @@
 
 var colors = require('./colors');
 
+/**
+ * Creates a VerboseLogger object used to encapsulate verbose logging.
+ *
+ * @param {Object} config - configuration options for the test suite.
+ * @param {Object} customProcess - Optional process.
+ *
+ * NOTE: config is being passed in to preserve a users preferences when using
+ *       the CLI option. @example --noHighLight
+ */
 function VerboseLogger(config, customProcess){
   this._process = customProcess || process;
   this._config = config || {};
 }
 
+/**
+ * Kicks off the verbose logging by constructing a Test Hierarchy and then
+ * printing it with the correct formatting.
+ *
+ * @param {Array} testResults - All information about test results in a test
+ *                              run. Given as an Array of objects.
+ *
+ * @see {@link _createTestNode}
+ * @see {@link traverseTestResults}
+ */
 VerboseLogger.prototype.verboseLog = function(testResults){
   var testTree = _createTestTree(testResults);
   this.traverseTestResults(testTree);
@@ -55,6 +74,12 @@ VerboseLogger.prototype.traverseTestResults = function(node, indentation){
   }
 }
 
+/**
+ *
+ * Pretty print test results to note which are failing and passing.
+ * @param {object} testTitles - All information about test titles in a test run.
+ * @param {string} indentation - Indentation used for formatting.
+ */
 VerboseLogger.prototype.printTestTitles = function(testTitles, indentation){
   var outputColor;
 

--- a/src/lib/testLogger.js
+++ b/src/lib/testLogger.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) 2014, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';

--- a/src/lib/testLogger.js
+++ b/src/lib/testLogger.js
@@ -36,7 +36,7 @@ function VerboseLogger(config, customProcess){
 VerboseLogger.prototype.verboseLog = function(testResults){
   var testTree = _createTestTree(testResults);
   this.traverseTestResults(testTree);
-}
+};
 
 
 /**
@@ -72,7 +72,7 @@ VerboseLogger.prototype.traverseTestResults = function(node, indentation){
       this.traverseTestResults(node[key], indentation + indentationIncrement);
     }
   }
-}
+};
 
 /**
  *
@@ -89,18 +89,18 @@ VerboseLogger.prototype.printTestTitles = function(testTitles, indentation){
       : colors.RED;
     this.log(this._formatMsg(indentation + testTitles[i].title, outputColor));
   }
-}
+};
 
 VerboseLogger.prototype.log = function(str){
   this._process.stdout.write(str + '\n');
-}
+};
 
 VerboseLogger.prototype._formatMsg = function(msg, color) {
   if (this._config.noHighlight) {
     return msg;
   }
   return colors.colorize(msg, color);
-}
+};
 
 /**
  * Prepares the test hierarchy for a `test title` by mapping its ancestry.

--- a/src/lib/testLogger.js
+++ b/src/lib/testLogger.js
@@ -78,17 +78,26 @@ VerboseLogger.prototype.traverseTestResults = function(node, indentation) {
 /**
  *
  * Pretty print test results to note which are failing and passing.
+ * Passing tests are prepended with PASS or a check. Failing tests are prepended
+ * with FAIL or an x.
  * @param {object} testTitles - All information about test titles in a test run.
  * @param {string} indentation - Indentation used for formatting.
  */
 VerboseLogger.prototype.printTestTitles = function(testTitles, indentation) {
-  var outputColor;
+  var prefixColor, statusPrefix;
 
   for (var i = 0; i < testTitles.length; i++){
-    outputColor = testTitles[i].failureMessages.length === 0
-      ? colors.GREEN
-      : colors.RED;
-    this.log(this._formatMsg(indentation + testTitles[i].title, outputColor));
+    if (testTitles[i].failureMessages.length === 0) {
+      prefixColor = colors.GREEN;
+      statusPrefix = this._config.noHighlight ? 'PASS - ' : '\u2713 ';
+    } else {
+      prefixColor = colors.RED;
+      statusPrefix = this._config.noHighlight ? 'FAIL - ' : '\u2715 ';
+    }
+    this.log(
+      this._formatMsg(indentation + statusPrefix, prefixColor)
+      + this._formatMsg(testTitles[i].title, colors.GRAY)
+    );
   }
 };
 

--- a/src/lib/testLogger.js
+++ b/src/lib/testLogger.js
@@ -18,7 +18,7 @@ var colors = require('./colors');
  * NOTE: config is being passed in to preserve a users preferences when using
  *       the CLI option. @example --noHighLight
  */
-function VerboseLogger(config, customProcess){
+function VerboseLogger(config, customProcess) {
   this._process = customProcess || process;
   this._config = config || {};
 }
@@ -33,9 +33,8 @@ function VerboseLogger(config, customProcess){
  * @see {@link _createTestNode}
  * @see {@link traverseTestResults}
  */
-VerboseLogger.prototype.verboseLog = function(testResults){
-  var testTree = _createTestTree(testResults);
-  this.traverseTestResults(testTree);
+VerboseLogger.prototype.verboseLog = function(testResults) {
+  this.traverseTestResults(_createTestTree(testResults));
 };
 
 
@@ -57,17 +56,19 @@ VerboseLogger.prototype.verboseLog = function(testResults){
  * @see{@link _createTestTree}
  *
  */
-VerboseLogger.prototype.traverseTestResults = function(node, indentation){
+VerboseLogger.prototype.traverseTestResults = function(node, indentation) {
   var indentationIncrement;
-  if (typeof node === 'undefined' || node === null){ return; }
+  if (typeof node === 'undefined' || node === null) {
+    return;
+  }
 
   indentationIncrement = '  ';
   indentation = indentation || '';
-  if (Object.prototype.toString.call(node.testTitles) === '[object Array]'){
+  if (Object.prototype.toString.call(node.testTitles) === '[object Array]') {
     this.printTestTitles(node.testTitles, indentation);
     this.traverseTestResults(node.childNodes, indentation);
   } else {
-    for (var key in node){
+    for (var key in node) {
       this.log(indentation + key);
       this.traverseTestResults(node[key], indentation + indentationIncrement);
     }
@@ -80,7 +81,7 @@ VerboseLogger.prototype.traverseTestResults = function(node, indentation){
  * @param {object} testTitles - All information about test titles in a test run.
  * @param {string} indentation - Indentation used for formatting.
  */
-VerboseLogger.prototype.printTestTitles = function(testTitles, indentation){
+VerboseLogger.prototype.printTestTitles = function(testTitles, indentation) {
   var outputColor;
 
   for (var i = 0; i < testTitles.length; i++){
@@ -91,7 +92,7 @@ VerboseLogger.prototype.printTestTitles = function(testTitles, indentation){
   }
 };
 
-VerboseLogger.prototype.log = function(str){
+VerboseLogger.prototype.log = function(str) {
   this._process.stdout.write(str + '\n');
 };
 
@@ -142,12 +143,12 @@ VerboseLogger.prototype._formatMsg = function(msg, color) {
  * @return {Object} A node mapping the hierarchy of `test titles` with common
  *                  ancestors.
  */
-function _createTestNode(testResult, ancestorTitles, currentNode){
+function _createTestNode(testResult, ancestorTitles, currentNode) {
   currentNode = currentNode || { testTitles: [], childNodes: {} };
   if (ancestorTitles.length === 0) {
     currentNode.testTitles.push(testResult);
   } else {
-    if(!currentNode.childNodes[ancestorTitles[0]]){
+    if (!currentNode.childNodes[ancestorTitles[0]]) {
       currentNode.childNodes[ancestorTitles[0]] = {
         testTitles: [],
         childNodes: {}
@@ -176,9 +177,9 @@ function _createTestNode(testResult, ancestorTitles, currentNode){
  * @see {@link _createTestNode}
  *
  */
-function _createTestTree(testResults){
+function _createTestTree(testResults) {
   var tree;
-  for (var i = 0; i < testResults.length; i++){
+  for (var i = 0; i < testResults.length; i++) {
     tree = _createTestNode(testResults[i], testResults[i].ancestorTitles, tree);
   }
 

--- a/src/lib/testLogger.js
+++ b/src/lib/testLogger.js
@@ -6,3 +6,33 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 'use strict';
+
+function _createTestNode(testResult, ancestorTitles, currentNode){
+  currentNode = currentNode || { testTitles: [], childNodes: {} };
+  if (ancestorTitles.length === 0) {
+    currentNode.testTitles.push(testResult);
+  } else {
+    if(!currentNode.childNodes[ancestorTitles[0]]){
+      currentNode.childNodes[ancestorTitles[0]] = {
+        testTitles: [],
+        childNodes: {}
+      };
+    }
+    _createTestNode(
+      testResult,
+      ancestorTitles.slice(1,ancestorTitles.length),
+      currentNode.childNodes[ancestorTitles[0]]
+    );
+  }
+
+  return currentNode;
+}
+
+function _createTestTree(testResults){
+  var tree;
+  for (var i = 0; i < testResults.length; i++){
+    tree = _createTestNode(testResults[i], testResults[i].ancestorTitles, tree);
+  }
+
+  return tree;
+}

--- a/src/lib/testLogger.js
+++ b/src/lib/testLogger.js
@@ -8,6 +8,7 @@
 'use strict';
 
 var colors = require('./colors');
+var formatMsg = require('./utils').formatMsg;
 
 /**
  * Creates a VerboseLogger object used to encapsulate verbose logging.
@@ -25,7 +26,7 @@ function VerboseLogger(config, customProcess) {
 
 /**
  * Kicks off the verbose logging by constructing a Test Hierarchy and then
- * printing it with the correct formatting.
+ * printing it with the correct formatting and a trailing newline.
  *
  * @param {Array} testResults - All information about test results in a test
  *                              run. Given as an Array of objects.
@@ -35,6 +36,7 @@ function VerboseLogger(config, customProcess) {
  */
 VerboseLogger.prototype.verboseLog = function(testResults) {
   this.traverseTestResults(_createTestTree(testResults));
+  this.log('');
 };
 
 
@@ -106,10 +108,7 @@ VerboseLogger.prototype.log = function(str) {
 };
 
 VerboseLogger.prototype._formatMsg = function(msg, color) {
-  if (this._config.noHighlight) {
-    return msg;
-  }
-  return colors.colorize(msg, color);
+  return formatMsg(msg, color, this._config);
 };
 
 /**

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -425,6 +425,14 @@ function formatFailureMessage(testResult, color) {
   }).join('\n');
 }
 
+function formatMsg(msg, color, _config) {
+  _config = _config || {};
+  if (_config.noHighlight) {
+    return msg;
+  }
+  return colors.colorize(msg, color);
+}
+
 // A RegExp that matches paths that should not be included in error stack traces
 // (mostly because these paths represent noisy/unhelpful libs)
 var STACK_TRACE_LINE_IGNORE_RE = new RegExp('^(?:' + [
@@ -434,6 +442,7 @@ var STACK_TRACE_LINE_IGNORE_RE = new RegExp('^(?:' + [
 
 
 exports.escapeStrForRegex = escapeStrForRegex;
+exports.formatMsg = formatMsg;
 exports.getLineCoverageFromCoverageInfo = getLineCoverageFromCoverageInfo;
 exports.getLinePercentCoverageFromCoverageInfo =
   getLinePercentCoverageFromCoverageInfo;


### PR DESCRIPTION
Add a `--verbose` config flag to pretty print the test suite individually
Relates to issue #4 and takes into account some of the suggestions from pull #92 
contributors include myself @PhilVargas and @arcin

called using `jest --verbose`

example of when the test suite passes:
![pass image](http://i.imgur.com/CLLyYCq.png)
example of when the test suite fails:
![fail image](http://i.imgur.com/Ujnq6wc.png)

