### PR TITLE
Check actual mtime equality by calling 'mtime'

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -325,7 +325,7 @@ function readAndPreprocessFileContent(filePath, config) {
   var mtime = fs.statSync(filePath).mtime;
   if (_contentCache.hasOwnProperty(filePath)) {
     cacheRec = _contentCache[filePath];
-    if (cacheRec.mtime === mtime) {
+    if (cacheRec.mtime.getTime() === mtime.getTime()) {
       return cacheRec.content;
     }
   }


### PR DESCRIPTION
Cache never worked because of this.