### PR TITLE
jasmineTestRunner: eliminate the use of for..in on arrays

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jest-cli",
   "description": "Painless JavaScript Unit Testing.",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "main": "src/jest.js",
   "dependencies": {
     "coffee-script": "^1.8.0",

--- a/src/jasmineTestRunner/jasmineTestRunner.js
+++ b/src/jasmineTestRunner/jasmineTestRunner.js
@@ -280,7 +280,9 @@ function jasmineTestRunner(config, environment, moduleLoader, testPath) {
     }
   });
 
-  var jasmineReporter = new JasmineReporter();
+  var jasmineReporter = new JasmineReporter({
+    noHighlight: config.noHighlight,
+  });
   jasmine.getEnv().addReporter(jasmineReporter);
 
   // Run the test by require()ing it

--- a/src/jasmineTestRunner/jasmineTestRunner.js
+++ b/src/jasmineTestRunner/jasmineTestRunner.js
@@ -39,6 +39,74 @@ var jasmineOnlyContent =
     );
 
 function jasmineTestRunner(config, environment, moduleLoader, testPath) {
+  var hasKey = function(obj, keyName) {
+    return (
+      obj !== null
+      && obj !== undefined
+      && obj[keyName] !== environment.global.jasmine.undefined
+    );
+  };
+
+  var checkMissingExpectedKeys = function(a, b, property, mismatchKeys) {
+    if (!hasKey(b, property) && hasKey(a, property)) {
+      mismatchKeys.push(
+        'expected missing key \'' + property + '\', but present in ' +
+        'actual.'
+      );
+    }
+  };
+  var checkMissingActualKeys = function(a, b, property, mismatchKeys) {
+    if (!hasKey(a, property) && hasKey(b, property)) {
+      mismatchKeys.push(
+        'expected has key \'' + property + '\', but missing from actual.'
+      );
+    }
+  };
+  var checkMismatchedValues = function(
+    a,
+    b,
+    property,
+    mismatchKeys,
+    mismatchValues
+  ) {
+    // The only different implementation from the original jasmine
+    var areEqual = this.equals_(
+      a[property],
+      b[property],
+      mismatchKeys,
+      mismatchValues
+    );
+    if (!areEqual) {
+      var aprop;
+      var bprop;
+      if (!a[property]) {
+        aprop = a[property];
+      } else if (a[property].toString) {
+        aprop = environment.global.jasmine.util.htmlEscape(
+          a[property].toString()
+        );
+      } else {
+        aprop = Object.prototype.toString.call(a[property]);
+      }
+
+      if (!b[property]) {
+        bprop = b[property];
+      } else if (b[property].toString) {
+        bprop = environment.global.jasmine.util.htmlEscape(
+          b[property].toString()
+        );
+      } else {
+        bprop = Object.prototype.toString.call(b[property]);
+      }
+
+      mismatchValues.push(
+        '\'' + property + '\' was \'' + bprop +
+        '\' in expected, but was \'' + aprop +
+        '\' in actual.'
+      );
+    }
+  };
+
   // Jasmine does stuff with timers that affect running the tests. However, we
   // also mock out all the timer APIs (to make them test-controllable).
   //
@@ -55,12 +123,9 @@ function jasmineTestRunner(config, environment, moduleLoader, testPath) {
     environment.runSourceText(jasmineOnlyContent);
 
     // Node must have been run with --harmony in order for WeakMap to be
-    // available prior to version 0.12
-    if (typeof WeakMap !== 'function') {
-      throw new Error(
-        'Please run node with the --harmony flag! jest requires WeakMap ' +
-        'which is only available with the --harmony flag in node < v0.12'
-      );
+    // available
+    if (!process.execArgv.some(function(arg) { return arg === '--harmony'; })) {
+      throw new Error('Please run node with the --harmony flag!');
     }
 
     // Mainline Jasmine sets __Jasmine_been_here_before__ on each object to
@@ -79,75 +144,51 @@ function jasmineTestRunner(config, environment, moduleLoader, testPath) {
         _comparedObjects.set(a, b);
         _comparedObjects.set(b, a);
 
-        var hasKey = function(obj, keyName) {
-          return (
-            obj !== null
-            && obj !== undefined
-            && obj[keyName] !== environment.global.jasmine.undefined
-          );
-        };
-
-        for (var property in b) {
-          if (areArrays && typeof b[property] === 'function') {
-            continue;
-          }
-          if (!hasKey(a, property) && hasKey(b, property)) {
-            mismatchKeys.push(
-              'expected has key \'' + property + '\', but missing from actual.'
-            );
-          }
-        }
-        for (property in a) {
-          if (areArrays && typeof a[property] === 'function') {
-            continue;
-          }
-          if (!hasKey(b, property) && hasKey(a, property)) {
-            mismatchKeys.push(
-              'expected missing key \'' + property + '\', but present in ' +
-              'actual.'
-            );
-          }
-        }
-        for (property in b) {
-          // The only different implementation from the original jasmine
-          if (areArrays &&
-              (typeof a[property] === 'function' ||
-               typeof b[property] === 'function')) {
-            continue;
-          }
-          var areEqual = this.equals_(
-            a[property],
-            b[property],
-            mismatchKeys,
-            mismatchValues
-          );
-          if (!areEqual) {
-            var aprop;
-            var bprop;
-            if (!a[property]) {
-              aprop = a[property];
-            } else if (a[property].toString) {
-              aprop = environment.global.jasmine.util.htmlEscape(
-                a[property].toString()
-              );
-            } else {
-              aprop = Object.prototype.toString.call(a[property]);
+        var property;
+        var index;
+        if (areArrays) {
+          var largerLength = Math.max(a.length, b.length);
+          for (index = 0; index < largerLength; index++) {
+            // check that all of b's keys match a's
+            if (index < b.length && typeof b[index] !== 'function') {
+              checkMissingActualKeys(b, a, index, mismatchKeys);
+            }
+            // check that all of a's keys match b's
+            if (index < a.length && typeof a[index] !== 'function') {
+              checkMissingExpectedKeys(a, b, index, mismatchKeys);
             }
 
-            if (!b[property]) {
-              bprop = b[property];
-            } else if (b[property].toString) {
-              bprop = environment.global.jasmine.util.htmlEscape(
-                b[property].toString()
+            // check that every value of b matches every value of a
+            if (typeof a[index] !== 'function' &&
+                typeof b[index] !== 'function') {
+              checkMismatchedValues.call(
+                this,
+                a,
+                b,
+                index,
+                mismatchKeys,
+                mismatchValues
               );
-            } else {
-              bprop = Object.prototype.toString.call(b[property]);
             }
-
-            mismatchValues.push(
-              '\'' + property + '\' was \'' + bprop +
-              '\' in expected, but was \'' + aprop +
-              '\' in actual.'
+          }
+        } else {
+          // check that all of b's keys match a's
+          for (property in b) {
+            checkMissingActualKeys(b, a, property, mismatchKeys);
+          }
+          // check that all of a's keys match b's
+          for (property in a) {
+            checkMissingExpectedKeys(a, b, property, mismatchKeys);
+          }
+          // check that every value of b matches every value of a
+          for (property in b) {
+            checkMismatchedValues.call(
+              this,
+              a,
+              b,
+              property,
+              mismatchKeys,
+              mismatchValues
             );
           }
         }
@@ -176,8 +217,7 @@ function jasmineTestRunner(config, environment, moduleLoader, testPath) {
           __filename: config.setupTestFrameworkScriptFile,
           require: moduleLoader.constructBoundRequire(
             config.setupTestFrameworkScriptFile
-          ),
-          jest: moduleLoader.getJestRuntime(config.setupTestFrameworkScriptFile)
+          )
         }
       );
     }
@@ -236,9 +276,7 @@ function jasmineTestRunner(config, environment, moduleLoader, testPath) {
     }
   });
 
-  var jasmineReporter = new JasmineReporter({
-    noHighlight: config.noHighlight,
-  });
+  var jasmineReporter = new JasmineReporter();
   jasmine.getEnv().addReporter(jasmineReporter);
 
   // Run the test by require()ing it


### PR DESCRIPTION
We shouldn't be iterating over arrays with for..in. This cleans it up
and ensures that we're treating arrays like arrays. It has the side
effect, for Facebook, of allowing us to use our own Arrray.prototype.es6
polyfill without warnings.