### PR TITLE
Prevent module to be hoisted before jest.dontMock in ES6 example

### DIFF
--- a/examples/react-es6/__tests__/CheckboxWithLabel-test.js
+++ b/examples/react-es6/__tests__/CheckboxWithLabel-test.js
@@ -1,7 +1,7 @@
 jest.dontMock('../CheckboxWithLabel');
 
 import React from 'react/addons';
-import CheckboxWithLabel from '../CheckboxWithLabel';
+const CheckboxWithLabel = require('../CheckboxWithLabel');
 var TestUtils = React.addons.TestUtils;
 
 describe('CheckboxWithLabel', () => {


### PR DESCRIPTION
The test of the ES6 example is broken due to jest automocking.

ES5 `require` corresponding to ES6 `import` are hoisted during the compilation. So the `CheckboxWithLabel` module is mocked because the require is placed before `jest.dontMock`.

See [babel-jest#16](https://github.com/babel/babel-jest/issues/16)