### PR TITLE
Add failFast flag to abort test suite after first failure

### DIFF
--- a/bin/jest.js
+++ b/bin/jest.js
@@ -117,7 +117,7 @@ var argv = optimist
       type: 'boolean'
     },
     failFast: {
-      alias: 'ff',
+      alias: ['ff', 'f'],
       description: _wrapDesc(
         'Exit the test suite immediately upon the first failing test.'
       ),

--- a/bin/jest.js
+++ b/bin/jest.js
@@ -115,6 +115,13 @@ var argv = optimist
         'Display individual test results with the test suite hierarchy.'
       ),
       type: 'boolean'
+    },
+    failFast: {
+      alias: 'ff',
+      description: _wrapDesc(
+        'Exit the test suite immediately upon the first failing test.'
+      ),
+      type: 'boolean'
     }
   })
   .check(function(argv) {

--- a/bin/jest.js
+++ b/bin/jest.js
@@ -116,8 +116,8 @@ var argv = optimist
       ),
       type: 'boolean'
     },
-    failFast: {
-      alias: ['ff', 'f'],
+    bail: {
+      alias: 'b',
       description: _wrapDesc(
         'Exit the test suite immediately upon the first failing test.'
       ),

--- a/src/DefaultTestReporter.js
+++ b/src/DefaultTestReporter.js
@@ -64,7 +64,7 @@ function(config, testResult, aggregatedResults) {
 
   var resultHeader = this._getResultHeader(allTestsPassed, pathStr, [
       testRunTimeString
-    ])
+    ]);
 
   /*
   if (config.collectCoverage) {
@@ -81,7 +81,7 @@ function(config, testResult, aggregatedResults) {
   testResult.logMessages.forEach(this._printConsoleMessage.bind(this));
 
   if (!allTestsPassed) {
-    var failureMessage = formatFailureMessage(testResult, /*color*/!config.noHighlight)
+    var failureMessage = formatFailureMessage(testResult, !config.noHighlight);
     if (config.verbose) {
       aggregatedResults.postSuiteHeaders.push(
         resultHeader,
@@ -92,8 +92,8 @@ function(config, testResult, aggregatedResults) {
     }
 
     if (config.failFast){
-      this.onRunComplete(config, aggregatedResults)
-      process.exit(0)
+      this.onRunComplete(config, aggregatedResults);
+      process.exit(0);
     }
   }
 

--- a/src/DefaultTestReporter.js
+++ b/src/DefaultTestReporter.js
@@ -63,8 +63,8 @@ function(config, testResult, aggregatedResults) {
   }
 
   var resultHeader = this._getResultHeader(allTestsPassed, pathStr, [
-      testRunTimeString
-    ]);
+    testRunTimeString
+  ]);
 
   /*
   if (config.collectCoverage) {
@@ -91,7 +91,7 @@ function(config, testResult, aggregatedResults) {
       this.log(failureMessage);
     }
 
-    if (config.bail){
+    if (config.bail) {
       this.onRunComplete(config, aggregatedResults);
       this._process.exit(0);
     }

--- a/src/DefaultTestReporter.js
+++ b/src/DefaultTestReporter.js
@@ -91,7 +91,7 @@ function(config, testResult, aggregatedResults) {
       this.log(failureMessage);
     }
 
-    if (config.failFast){
+    if (config.bail){
       this.onRunComplete(config, aggregatedResults);
       process.exit(0);
     }

--- a/src/DefaultTestReporter.js
+++ b/src/DefaultTestReporter.js
@@ -89,6 +89,11 @@ function(config, testResult, aggregatedResults) {
     } else {
       this.log(formatFailureMessage(testResult, /*color*/!config.noHighlight));
     }
+
+    if (config.failFast){
+      this.onRunComplete(config, aggregatedResults)
+      process.exit(0)
+    }
   }
 
   this._printWaitingOn(aggregatedResults);
@@ -99,7 +104,7 @@ function (config, aggregatedResults) {
   var numFailedTests = aggregatedResults.numFailedTests;
   var numPassedTests = aggregatedResults.numPassedTests;
   var numTotalTests = aggregatedResults.numTotalTests;
-  var runTime = aggregatedResults.runTime;
+  var runTime = (Date.now() - aggregatedResults.startTime) / 1000;
 
   if (numTotalTests === 0) {
     return;

--- a/src/DefaultTestReporter.js
+++ b/src/DefaultTestReporter.js
@@ -62,6 +62,10 @@ function(config, testResult, aggregatedResults) {
     testRunTimeString = this._formatMsg(testRunTimeString, FAIL_COLOR);
   }
 
+  var resultHeader = this._getResultHeader(allTestsPassed, pathStr, [
+      testRunTimeString
+    ])
+
   /*
   if (config.collectCoverage) {
     // TODO: Find a nice pretty way to print this out
@@ -71,23 +75,20 @@ function(config, testResult, aggregatedResults) {
   if (config.verbose) {
     this.verboseLog(testResult.testResults);
   } else {
-    this.log(this._getResultHeader(allTestsPassed, pathStr, [
-      testRunTimeString
-    ]));
+    this.log(resultHeader);
   }
 
   testResult.logMessages.forEach(this._printConsoleMessage.bind(this));
 
   if (!allTestsPassed) {
+    var failureMessage = formatFailureMessage(testResult, /*color*/!config.noHighlight)
     if (config.verbose) {
       aggregatedResults.postSuiteHeaders.push(
-        this._getResultHeader(allTestsPassed, pathStr, [
-          testRunTimeString
-        ]),
-        formatFailureMessage(testResult, /*color*/!config.noHighlight)
+        resultHeader,
+        failureMessage
       );
     } else {
-      this.log(formatFailureMessage(testResult, /*color*/!config.noHighlight));
+      this.log(failureMessage);
     }
 
     if (config.failFast){

--- a/src/DefaultTestReporter.js
+++ b/src/DefaultTestReporter.js
@@ -93,7 +93,7 @@ function(config, testResult, aggregatedResults) {
 
     if (config.bail){
       this.onRunComplete(config, aggregatedResults);
-      process.exit(0);
+      this._process.exit(0);
     }
   }
 

--- a/src/TestRunner.js
+++ b/src/TestRunner.js
@@ -452,10 +452,7 @@ TestRunner.prototype.runTests = function(testPaths, reporter) {
   aggregatedResults.startTime = Date.now()
   var testRun = this._createTestRun(testPaths, onTestResult, onRunFailure);
 
-  var startTime = Date.now();
-
   return testRun.then(function() {
-    aggregatedResults.runTime = (Date.now() - startTime) / 1000;
     aggregatedResults.success = aggregatedResults.numFailedTests === 0;
     reporter.onRunComplete && reporter.onRunComplete(config, aggregatedResults);
     return aggregatedResults;

--- a/src/TestRunner.js
+++ b/src/TestRunner.js
@@ -414,7 +414,7 @@ TestRunner.prototype.runTests = function(testPaths, reporter) {
 
   var aggregatedResults = {
     success: null,
-    runTime: null,
+    startTime: null,
     numTotalTests: testPaths.length,
     numPassedTests: 0,
     numFailedTests: 0,
@@ -449,6 +449,7 @@ TestRunner.prototype.runTests = function(testPaths, reporter) {
     }, aggregatedResults);
   };
 
+  aggregatedResults.startTime = Date.now()
   var testRun = this._createTestRun(testPaths, onTestResult, onRunFailure);
 
   var startTime = Date.now();

--- a/src/TestRunner.js
+++ b/src/TestRunner.js
@@ -449,7 +449,7 @@ TestRunner.prototype.runTests = function(testPaths, reporter) {
     }, aggregatedResults);
   };
 
-  aggregatedResults.startTime = Date.now()
+  aggregatedResults.startTime = Date.now();
   var testRun = this._createTestRun(testPaths, onTestResult, onRunFailure);
 
   return testRun.then(function() {

--- a/src/jest.js
+++ b/src/jest.js
@@ -97,6 +97,10 @@ function _promiseConfig(argv, packageRoot) {
       config.verbose = argv.verbose;
     }
 
+    if (argv.failFast) {
+      config.failFast = argv.failFast;
+    }
+
     return config;
   });
 }

--- a/src/jest.js
+++ b/src/jest.js
@@ -97,8 +97,8 @@ function _promiseConfig(argv, packageRoot) {
       config.verbose = argv.verbose;
     }
 
-    if (argv.failFast) {
-      config.failFast = argv.failFast;
+    if (argv.bail) {
+      config.bail = argv.bail;
     }
 
     return config;


### PR DESCRIPTION
Addresses issue #127 to add a flag to abort the test suite after the first failing test file occurs.

- invoke the fail-fast flag by calling jest with the `--bail` options or `-b` alias. 
- if the flag is present and a test fails, exit the worker process from the `DefaultTestReporter`
after calling the cleanup method `onRunComplete` in order to print the test results before abort
- calculate the overall runTime by saving the startTime (instead of final runTime) in `aggregatedResults`. this allows us to calculate the runTime anywhere `aggregatedResults` is available. I.e. to print the overall run time during any individual test, instead of after all the tests have run.

I'm currently having an issue on jest 0.4.5 (from facebook/jest/master) that is forcing noHighlight to always be called. I believe its related to pull #364, but i'm unsure if this is a persistent issue or just my machine. Its happening by default and passing `--noHighlight false` does not remove it.
Looking forward to your feedback! @amasad 

examples:
[Fail fast](https://lh3.googleusercontent.com/XNYuw-bsuvAxp1n3Zb2SDT87SGSenEm9oSws3WeZag=w740-h221-no)  
![Fail fast](https://lh3.googleusercontent.com/XNYuw-bsuvAxp1n3Zb2SDT87SGSenEm9oSws3WeZag=w740-h221-no)

[Fail fast, verbose](https://lh3.googleusercontent.com/IPOasOCrclh3E9UIbcMf-4dR-zH5fa_IN7Ea5iwSxA=w748-h544-no)  
![Fail fast, verbose](https://lh3.googleusercontent.com/IPOasOCrclh3E9UIbcMf-4dR-zH5fa_IN7Ea5iwSxA=w748-h544-no)

[Fail fast, no highlight](https://lh3.googleusercontent.com/cWlgCofQMoJl2ELxyHd5-XRagnlWk1CeJGeXEITOpw=w738-h254-no)
![Fail fast, no highlight](https://lh3.googleusercontent.com/cWlgCofQMoJl2ELxyHd5-XRagnlWk1CeJGeXEITOpw=w738-h254-no)
