### PR TITLE
Don't mock non-enum accessors

### DIFF
--- a/src/lib/__tests__/moduleMocker-test.js
+++ b/src/lib/__tests__/moduleMocker-test.js
@@ -61,6 +61,25 @@ describe('moduleMocker', function() {
       expect(bar.x()).toBe('Bar');
     });
 
+    it('does not mock non-enumerable getters', function() {
+      var foo = Object.defineProperties({}, {
+        nonEnumMethod: {
+          value: function() {}
+        },
+        nonEnumGetter: {
+          get: function() { throw 1; }
+        }
+      });
+      var fooMock = moduleMocker.generateFromMetadata(
+        moduleMocker.getMetadata(foo)
+      );
+
+      expect(typeof foo.nonEnumMethod).toBe('function');
+
+      expect(fooMock.nonEnumMethod.mock).not.toBeUndefined();
+      expect(fooMock.nonEnumGetter).toBeUndefined();
+    });
+
     it('mocks ES6 non-enumerable methods', function() {
         // ES6: class ClassFoo { foo() { } }
         // Converted with https://babeljs.io/repl/

--- a/src/lib/moduleMocker.js
+++ b/src/lib/moduleMocker.js
@@ -59,7 +59,10 @@ function getSlots(object) {
   // Simply attempting to access any of these throws an error.
   var forbiddenProps = [ 'caller', 'callee', 'arguments' ];
   var collectProp = function(prop) {
-    if (forbiddenProps.indexOf(prop) === -1) {
+    var propDesc = Object.getOwnPropertyDescriptor(object, prop);
+    if (forbiddenProps.indexOf(prop) === -1 &&
+        // Include only enumerable accessors.
+        (propDesc.enumerable || !propDesc.get)) {
       slots[prop] = true;
     }
   };


### PR DESCRIPTION
Don't mock non-enumerable accessors yet: they may throw, and fail in the mocker, when the mocker tries to get the value by the slot. Fixes #389, #380.