### PR TITLE
Run dynamic immediates during runAllTimers

### DIFF
--- a/src/lib/FakeTimers.js
+++ b/src/lib/FakeTimers.js
@@ -167,6 +167,13 @@ FakeTimers.prototype.runAllTimers = function() {
     this._runTimerHandle(nextTimerHandle);
   }
 
+  // Some of the immediate calls could be enqueued
+  // during the previous handling of the timers, we should
+  // run them as well.
+  if (this._immediates.length) {
+    this.runAllImmediates();
+  }
+
   if (i === this._maxLoops) {
     throw new Error(
       'Ran ' + this._maxLoops + ' timers, and there are still more! Assuming ' +


### PR DESCRIPTION
Immediate calls can be enqueued during handling of timers, we should run these dynamically added immediates as well.