### PR TITLE
Print test path and time in verbose mode

### DIFF
--- a/src/DefaultTestReporter.js
+++ b/src/DefaultTestReporter.js
@@ -73,7 +73,7 @@ function(config, testResult, aggregatedResults) {
   */
 
   if (config.verbose) {
-    this.verboseLog(testResult.testResults);
+    this.verboseLog(testResult.testResults, resultHeader);
   } else {
     this.log(resultHeader);
   }

--- a/src/lib/testLogger.js
+++ b/src/lib/testLogger.js
@@ -34,7 +34,8 @@ function VerboseLogger(config, customProcess) {
  * @see {@link _createTestNode}
  * @see {@link traverseTestResults}
  */
-VerboseLogger.prototype.verboseLog = function(testResults) {
+VerboseLogger.prototype.verboseLog = function(testResults, resultHeader) {
+  this.log(resultHeader);
   this.traverseTestResults(_createTestTree(testResults));
   this.log('');
 };
@@ -66,7 +67,7 @@ VerboseLogger.prototype.traverseTestResults = function(node, indentation) {
 
   indentationIncrement = '  ';
   indentation = indentation || '';
-  if (Object.prototype.toString.call(node.testTitles) === '[object Array]') {
+  if (Array.isArray(node.testTitles)) {
     this.printTestTitles(node.testTitles, indentation);
     this.traverseTestResults(node.childNodes, indentation);
   } else {


### PR DESCRIPTION
This one prints test path and time to be consistent in the header output in the short mode.