### PR TITLE
Verbose logger touchup

### DIFF
--- a/src/DefaultTestReporter.js
+++ b/src/DefaultTestReporter.js
@@ -72,10 +72,9 @@ function(config, testResult, aggregatedResults) {
   }
   */
 
+  this.log(resultHeader);
   if (config.verbose) {
     this.verboseLog(testResult.testResults, resultHeader);
-  } else {
-    this.log(resultHeader);
   }
 
   testResult.logMessages.forEach(this._printConsoleMessage.bind(this));

--- a/src/DefaultTestReporter.js
+++ b/src/DefaultTestReporter.js
@@ -111,7 +111,9 @@ function (config, aggregatedResults) {
   }
 
   if (config.verbose) {
-    this.log(aggregatedResults.postSuiteHeaders.join('\n'));
+    if (aggregatedResults.postSuiteHeaders.length > 0) {
+      this.log(aggregatedResults.postSuiteHeaders.join('\n'));
+    }
   }
 
   var results = '';

--- a/src/lib/testLogger.js
+++ b/src/lib/testLogger.js
@@ -34,8 +34,7 @@ function VerboseLogger(config, customProcess) {
  * @see {@link _createTestNode}
  * @see {@link traverseTestResults}
  */
-VerboseLogger.prototype.verboseLog = function(testResults, resultHeader) {
-  this.log(resultHeader);
+VerboseLogger.prototype.verboseLog = function(testResults) {
   this.traverseTestResults(_createTestTree(testResults));
   this.log('');
 };


### PR DESCRIPTION
touch up some of the changes per comments of #397 

- change reporter logic to always print the results header -> if verbose print suite map as well. changed from if verbose -> print header + suite map else print header

- added a check to see if there were any postSuiteHeaders prior to logging it to avoided printed an extra newline character at the end of the verbose run and prior to the `x tests passed` line