### PR TITLE
Check that main exists in a package.json before using it.

### DIFF
--- a/src/HasteModuleLoader/HasteModuleLoader.js
+++ b/src/HasteModuleLoader/HasteModuleLoader.js
@@ -450,9 +450,12 @@ Loader.prototype._moduleNameToPath = function(currPath, moduleName) {
       // LOAD_AS_DIRECTORY #1
       var packagePath = path.join(modulePath, 'package.json');
       if (fs.existsSync(packagePath)) {
-        var mainPath = path.join(modulePath, require(packagePath).main);
-        if (fs.existsSync(mainPath)) {
-          return mainPath;
+        var packageData = require(packagePath);
+        if (packageData.main) {
+          var mainPath = path.join(modulePath, packageData.main);
+          if (fs.existsSync(mainPath)) {
+            return mainPath;
+          }
         }
       }
 


### PR DESCRIPTION
If `main` isn't in package.json then `path.join` will throw when it gets `undefined`. We should fall through in that case to the next step which tries to read `index.js`