### PR TITLE
Replace Q with Bluebird

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,5 +1,6 @@
 {
   "-W093": true,
+  "-W079": true,
   "asi": false,
   "bitwise": true,
   "boss": false,

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "node-haste": "^1.2.8",
     "node-worker-pool": "~2.4.2",
     "optimist": "~0.6.0",
-    "q": "~0.9.7",
+    "bluebird": "~2.9.30",
     "resolve": "~0.6.1",
     "through": "^2.3.4",
     "lodash.template": "^3.0.0"

--- a/src/HasteModuleLoader/HasteModuleLoader.js
+++ b/src/HasteModuleLoader/HasteModuleLoader.js
@@ -21,7 +21,7 @@ var moduleMocker = require('../lib/moduleMocker');
 var NodeHaste = require('node-haste/lib/Haste');
 var os = require('os');
 var path = require('path');
-var Q = require('q');
+var Promise = require('bluebird');
 var resolve = require('resolve');
 var utils = require('../lib/utils');
 
@@ -162,44 +162,36 @@ function Loader(config, environment, resourceMap) {
 }
 
 Loader.loadResourceMap = function(config, options) {
-  options = options || {};
-
-  var deferred = Q.defer();
-  try {
-    _constructHasteInst(config, options).update(
-      _getCacheFilePath(config),
-      function(resourceMap) {
-        deferred.resolve(resourceMap);
-      }
-    );
-  } catch (e) {
-    deferred.reject(e);
-  }
-
-  return deferred.promise;
+  return new Promise(function(resolve, reject) {
+    try {
+      _constructHasteInst(config, options || {}).update(
+        _getCacheFilePath(config),
+        resolve
+      );
+    } catch (e) {
+      reject(e);
+    }
+  });
 };
 
 Loader.loadResourceMapFromCacheFile = function(config, options) {
-  options = options || {};
-
-  var deferred = Q.defer();
-  try {
-    var hasteInst = _constructHasteInst(config, options);
-    hasteInst.loadMap(
-      _getCacheFilePath(config),
-      function(err, map) {
-        if (err) {
-          deferred.reject(err);
-        } else {
-          deferred.resolve(map);
+  return new Promise(function(resolve, reject) {
+    try {
+      var hasteInst = _constructHasteInst(config, options || {});
+      hasteInst.loadMap(
+        _getCacheFilePath(config),
+        function(err, map) {
+          if (err) {
+            reject(err);
+          } else {
+            resolve(map);
+          }
         }
-      }
-    );
-  } catch (e) {
-    deferred.reject(e);
-  }
-
-  return deferred.promise;
+      );
+    } catch (e) {
+      reject(e);
+    }
+  });
 };
 
 /**

--- a/src/HasteModuleLoader/__tests__/HasteModuleLoader-NODE_PATH-test.js
+++ b/src/HasteModuleLoader/__tests__/HasteModuleLoader-NODE_PATH-test.js
@@ -10,7 +10,7 @@
 jest.autoMockOff();
 
 var path = require('path');
-var q = require('q');
+var Promise = require('bluebird');
 var utils = require('../../lib/utils');
 
 describe('HasteModuleLoader', function() {
@@ -30,7 +30,9 @@ describe('HasteModuleLoader', function() {
         return buildLoader();
       });
     } else {
-      return q(new HasteModuleLoader(CONFIG, mockEnvironment, resourceMap));
+      return Promise.resolve(
+        new HasteModuleLoader(CONFIG, mockEnvironment, resourceMap)
+      );
     }
   }
 

--- a/src/HasteModuleLoader/__tests__/HasteModuleLoader-genMockFromModule-test.js
+++ b/src/HasteModuleLoader/__tests__/HasteModuleLoader-genMockFromModule-test.js
@@ -10,7 +10,7 @@
 jest.autoMockOff();
 
 var path = require('path');
-var q = require('q');
+var Promise = require('bluebird');
 var utils = require('../../lib/utils');
 
 describe('nodeHasteModuleLoader', function() {
@@ -30,7 +30,9 @@ describe('nodeHasteModuleLoader', function() {
         return buildLoader();
       });
     } else {
-      return q(new HasteModuleLoader(CONFIG, mockEnvironment, resourceMap));
+      return Promise.resolve(
+        new HasteModuleLoader(CONFIG, mockEnvironment, resourceMap)
+      );
     }
   }
 

--- a/src/HasteModuleLoader/__tests__/HasteModuleLoader-getTestEnvData-test.js
+++ b/src/HasteModuleLoader/__tests__/HasteModuleLoader-getTestEnvData-test.js
@@ -10,7 +10,7 @@
 jest.autoMockOff();
 
 var path = require('path');
-var q = require('q');
+var Promise = require('bluebird');
 var utils = require('../../lib/utils');
 
 describe('HasteModuleLoader', function() {
@@ -35,7 +35,9 @@ describe('HasteModuleLoader', function() {
         return buildLoader();
       });
     } else {
-      return q(new HasteModuleLoader(config, mockEnvironment, resourceMap));
+      return Promise.resolve(
+        new HasteModuleLoader(config, mockEnvironment, resourceMap)
+      );
     }
   }
 

--- a/src/HasteModuleLoader/__tests__/HasteModuleLoader-requireMock-test.js
+++ b/src/HasteModuleLoader/__tests__/HasteModuleLoader-requireMock-test.js
@@ -10,7 +10,7 @@
 jest.autoMockOff();
 
 var path = require('path');
-var q = require('q');
+var Promise = require('bluebird');
 var utils = require('../../lib/utils');
 
 describe('HasteModuleLoader', function() {
@@ -30,7 +30,9 @@ describe('HasteModuleLoader', function() {
         return buildLoader();
       });
     } else {
-      return q(new HasteModuleLoader(CONFIG, mockEnvironment, resourceMap));
+      return Promise.resolve(
+        new HasteModuleLoader(CONFIG, mockEnvironment, resourceMap)
+      );
     }
   }
 
@@ -144,7 +146,7 @@ describe('HasteModuleLoader', function() {
         expect(loader.requireMock(null, 'events').EventEmitter).toBeDefined();
       });
     });
-	  
+
     pit('throws on non-existant @providesModule modules', function() {
       return buildLoader().then(function(loader) {
         expect(function() {

--- a/src/HasteModuleLoader/__tests__/HasteModuleLoader-requireModule-test.js
+++ b/src/HasteModuleLoader/__tests__/HasteModuleLoader-requireModule-test.js
@@ -10,7 +10,7 @@
 jest.autoMockOff();
 
 var path = require('path');
-var q = require('q');
+var Promise = require('bluebird');
 var utils = require('../../lib/utils');
 
 describe('HasteModuleLoader', function() {
@@ -30,7 +30,9 @@ describe('HasteModuleLoader', function() {
         return buildLoader();
       });
     } else {
-      return q(new HasteModuleLoader(CONFIG, mockEnvironment, resourceMap));
+      return Promise.resolve(
+        new HasteModuleLoader(CONFIG, mockEnvironment, resourceMap)
+      );
     }
   }
 

--- a/src/HasteModuleLoader/__tests__/HasteModuleLoader-requireModuleOrMock-test.js
+++ b/src/HasteModuleLoader/__tests__/HasteModuleLoader-requireModuleOrMock-test.js
@@ -10,7 +10,7 @@
 jest.autoMockOff();
 
 var path = require('path');
-var q = require('q');
+var Promise = require('bluebird');
 var utils = require('../../lib/utils');
 
 describe('HasteModuleLoader', function() {
@@ -30,7 +30,9 @@ describe('HasteModuleLoader', function() {
         return buildLoader();
       });
     } else {
-      return q(new HasteModuleLoader(CONFIG, mockEnvironment, resourceMap));
+      return Promise.resolve(
+        new HasteModuleLoader(CONFIG, mockEnvironment, resourceMap)
+      );
     }
   }
 

--- a/src/TestWorker.js
+++ b/src/TestWorker.js
@@ -8,7 +8,6 @@
 'use strict';
 
 var optimist = require('optimist');
-//var q = require('q');
 var TestRunner = require('./TestRunner');
 var workerUtils = require('node-worker-pool/nodeWorkerUtils');
 

--- a/src/jasmineTestRunner/JasmineReporter.js
+++ b/src/jasmineTestRunner/JasmineReporter.js
@@ -11,7 +11,7 @@ var colors = require('../lib/colors');
 var diff = require('diff');
 var formatMsg = require('../lib/utils').formatMsg;
 var jasmine = require('../../vendor/jasmine/jasmine-1.3.0').jasmine;
-var Q = require('q');
+var Promise = require('bluebird');
 
 var ERROR_TITLE_COLOR = colors.RED + colors.BOLD + colors.UNDERLINE;
 var DIFFABLE_MATCHERS = {
@@ -26,7 +26,7 @@ function JasmineReporter(config) {
   jasmine.Reporter.call(this);
   this._config = config || {};
   this._logs = [];
-  this._resultsDeferred = Q.defer();
+  this._resultsDeferred = Promise.defer();
 }
 
 JasmineReporter.prototype = Object.create(jasmine.Reporter.prototype);

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -10,7 +10,7 @@
 var colors = require('./colors');
 var fs = require('graceful-fs');
 var path = require('path');
-var Q = require('q');
+var Promise = require('bluebird');
 
 var DEFAULT_CONFIG_VALUES = {
   cacheDirectory: path.resolve(__dirname, '..', '..', '.haste_cache'),
@@ -291,9 +291,10 @@ function pathNormalize(dir) {
   return path.normalize(dir.replace(/\\/g, '/')).replace(/\\/g, '/');
 }
 
+var readFile = Promise.promisify(fs.readFile);
 function loadConfigFromFile(filePath) {
   var fileDir = path.dirname(filePath);
-  return Q.nfcall(fs.readFile, filePath, 'utf8').then(function(fileData) {
+  return readFile(filePath, 'utf8').then(function(fileData) {
     var config = JSON.parse(fileData);
     if (!config.hasOwnProperty('rootDir')) {
       config.rootDir = fileDir;
@@ -306,7 +307,7 @@ function loadConfigFromFile(filePath) {
 
 function loadConfigFromPackageJson(filePath) {
   var pkgJsonDir = path.dirname(filePath);
-  return Q.nfcall(fs.readFile, filePath, 'utf8').then(function(fileData) {
+  return readFile(filePath, 'utf8').then(function(fileData) {
     var packageJsonData = JSON.parse(fileData);
     var config = packageJsonData.jest;
     config.name = packageJsonData.name;
@@ -443,6 +444,7 @@ function formatMsg(msg, color, _config) {
 // (mostly because these paths represent noisy/unhelpful libs)
 var STACK_TRACE_LINE_IGNORE_RE = new RegExp('^(?:' + [
     path.resolve(__dirname, '..', 'node_modules', 'q'),
+    path.resolve(__dirname, '..', 'node_modules', 'bluebird'),
     path.resolve(__dirname, '..', 'vendor', 'jasmine')
 ].join('|') + ')');
 


### PR DESCRIPTION
The [bluebird](https://github.com/petkaantonov/bluebird) seems to have better performance than [Q](https://github.com/kriskowal/q).

An [issue](https://github.com/petkaantonov/bluebird/issues/661) was noticed after the switch, which is solved locally, but probably Bluebird will fix it at library level.