### PR TITLE
Fix to correctly filter out node_modules from coverage report

### DIFF
--- a/src/TestRunner.js
+++ b/src/TestRunner.js
@@ -349,7 +349,7 @@ TestRunner.prototype.runTest = function(testFilePath) {
       moduleLoader.getDependenciesFromPath(testFilePath)
         .filter(function(depPath) {
           // Skip over built-in and node modules
-          return /^\//.test(depPath);
+          return /^\//.test(depPath) && !(/node_modules/.test(depPath));
         }).forEach(function(depPath) {
           config.collectCoverageOnlyFrom[depPath] = true;
         });


### PR DESCRIPTION
This is an update to the TestRunners gather files to include in coverage process. In testing we have found that node_modules were being included in the generated coverage report, which was throwing off our coverage numbers. Our setup is as follows;
    
    app/
       package.json
       node_modules/
       configs.js
       app.js
       specific-application-directory/