### PR TITLE
Fix jest highlighting on multiple lines

### DIFF
--- a/src/jasmineTestRunner/JasmineReporter.js
+++ b/src/jasmineTestRunner/JasmineReporter.js
@@ -106,7 +106,7 @@ function (container, ancestorTitles, spec) {
           // have to regexp out the message from the stack string in order to
           // colorize the `message` value
           result.trace.stack = result.trace.stack.replace(
-            /(^.*$(?=\n\s*at))/m,
+            /(^(.|\n)*?(?=\n\s*at\s))/,
             this._formatMsg('$1', ERROR_TITLE_COLOR)
           );
 


### PR DESCRIPTION
Previously, exceptions with newlines in messages didn't get highlighted properly. Only the last line of the message would be highlighted. This fixes that and adds a unit test.

In addition to running the test, I played around with the functionality by messing with things in the examples folder.

cc @DmitrySoshnikov 