### PR TITLE
Fix error with not registering preprocessCachingDisabled as a config key

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -32,6 +32,7 @@ var DEFAULT_CONFIG_VALUES = {
   testReporter: require.resolve('../IstanbulTestReporter'),
   testRunner: require.resolve('../jasmineTestRunner/jasmineTestRunner'),
   noHighlight: false,
+  preprocessCachingDisabled: false
 };
 
 function _replaceRootDirTags(rootDir, config) {
@@ -212,6 +213,7 @@ function normalizeConfig(config) {
           return pattern.replace(/<rootDir>/g, config.rootDir);
         });
         break;
+      case 'preprocessCachingDisabled':
       case 'coverageReporters':
       case 'collectCoverage':
       case 'coverageCollector':


### PR DESCRIPTION
Fix error with not registering `preprocessCachingDisabled` as a config key