### PR TITLE
Add legacy Node deprecation message

### DIFF
--- a/bin/jest.js
+++ b/bin/jest.js
@@ -223,6 +223,17 @@ if (fs.existsSync(cwdJestBinPath)) {
   }
 }
 
+(function printLegacyNodeDeprecationMessage() {
+  if (!/^v0/.test(process.version)) {
+    return;
+  }
+
+  console.log('\n  == NOTICE: ==');
+  console.log('    On August 1st, 2015, Jest v0.5.x will work only on io.js');
+  console.log('    Legacy v0.4.x for Node 0.10.x will still be available on');
+  console.log('    on npm and from the "0.4.x" branch on GitHub.\n');
+})();
+
 if (!argv.version) {
   console.log('Using Jest CLI v' + jest.getVersion());
 }


### PR DESCRIPTION
We're going to merge `0.5.x` to master, and make the legacy `0.4.x` if people still want to run Jest on Node `0.10.x`. This adds a deprecation message to the CLI.