### PR TITLE
No longer try to run cleared timers in `runOnlyPendingTimers`

### DIFF
--- a/src/lib/FakeTimers.js
+++ b/src/lib/FakeTimers.js
@@ -439,6 +439,10 @@ FakeTimers.prototype._getNextTimerHandle = function() {
 FakeTimers.prototype._runTimerHandle = function(timerHandle) {
   var timer = this._timers[timerHandle];
 
+  if (!timer) {
+    return;
+  }
+
   switch (timer.type) {
     case 'timeout':
       var callback = timer.callback;

--- a/src/lib/__tests__/FakeTimers-test.js
+++ b/src/lib/__tests__/FakeTimers-test.js
@@ -572,6 +572,20 @@ describe('FakeTimers', function() {
         'mock3'
       ]);
     });
+
+    it('does not run timers that were cleared in another timer', function() {
+      var global = {};
+      var fakeTimers = new FakeTimers(global);
+
+      var fn = jest.genMockFn();
+      var timer = global.setTimeout(fn, 10);
+      global.setTimeout(function() {
+        global.clearTimeout(timer);
+      }, 0);
+
+      fakeTimers.runOnlyPendingTimers();
+      expect(fn).not.toBeCalled();
+    });
   });
 
   describe('runWithRealTimers', function() {


### PR DESCRIPTION
Fix clearing a timer from within another timer resulting in `TypeError: Cannot read property 'type' of undefined`. 