### PR TITLE
Adding Verbose as a supported config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Check out the [Getting Started](http://facebook.github.io/jest/docs/getting-star
   - [`config.testPathIgnorePatterns` [array<string>]](http://facebook.github.io/jest/docs/api.html#config-testpathignorepatterns-array-string)
   - [`config.testPathPattern` [string]](http://facebook.github.io/jest/docs/api.html#config-testpathpattern-string)
   - [`config.unmockedModulePathPatterns` [array<string>]](http://facebook.github.io/jest/docs/api.html#config-unmockedmodulepathpatterns-array-string)
+  - [`config.verbose` [boolean]](http://facebook.github.io/jest/docs/api.html#config-verbose-boolean)
 
 #### Globally injected variables
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -371,4 +371,4 @@ It is possible to override this setting in individual tests by explicitly callin
 ### `config.verbose` [boolean]
 (default: `false`)
 
-Indicates whether the tests should be printed into the console using `Mocha`-styled logs for determining if a specific test has failed or succeeded. Errors will still show on the bottom after execution.
+Indicates whether each individual test should be reported during the run. All errors will also still be shown on the bottom after execution.

--- a/docs/API.md
+++ b/docs/API.md
@@ -52,6 +52,7 @@ permalink: docs/api.html
   - [`config.testPathIgnorePatterns` [array<string>]](#config-testpathignorepatterns-array-string)
   - [`config.testPathPattern` [string]](http://facebook.github.io/jest/docs/api.html#config-testpathpattern-string)
   - [`config.unmockedModulePathPatterns` [array<string>]](#config-unmockedmodulepathpatterns-array-string)
+  - [`config.verbose` [boolean]](#config-verbose-boolean)
 
 #### Globally injected variables
 
@@ -366,3 +367,8 @@ An array of regexp pattern strings that are matched against all modules before t
 This is useful for some commonly used 'utility' modules that are almost always used as implementation details almost all the time (like underscore/lo-dash, etc). It's generally a best practice to keep this list as small as possible and always use explicit `jest.mock()`/`jest.dontMock()` calls in individual tests. Explicit per-test setup is far easier for other readers of the test to reason about the environment the test will run in.
 
 It is possible to override this setting in individual tests by explicitly calling `jest.mock()` at the top of the test file.
+
+### `config.verbose` [boolean]
+(default: `false`)
+
+Indicates whether the tests should be printed into the console using `Mocha`-styled logs for determining if a specific test has failed or succeeded. Errors will still show on the bottom after execution.

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -233,7 +233,8 @@ function normalizeConfig(config) {
       case 'noHighlight':
         value = config[key];
         break;
-
+      case 'verbose':
+        
       default:
         throw new Error('Unknown config option: ' + key);
     }

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -231,9 +231,9 @@ function normalizeConfig(config) {
       case 'testReporter':
       case 'moduleFileExtensions':
       case 'noHighlight':
+      case 'verbose':
         value = config[key];
         break;
-      case 'verbose':
         
       default:
         throw new Error('Unknown config option: ' + key);


### PR DESCRIPTION
It is already being checked for throughout the `DefaultTestReporter.js` file. Here are the uses:

[Line 32](https://github.com/facebook/jest/blob/master/src/DefaultTestReporter.js#L32)
[Line 76](https://github.com/facebook/jest/blob/master/src/DefaultTestReporter.js#L76)
[Line 84](https://github.com/facebook/jest/blob/master/src/DefaultTestReporter.js#L84)
[Line 113](https://github.com/facebook/jest/blob/master/src/DefaultTestReporter.js#L113)

Utils.js did not report is a supported option so I enabled it. 

###### Please feel free to reword my description as necessary in the API.md file