### PR TITLE
Clone config instead of subclassing it

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "jsdom": "~0.10.3",
     "node-haste": "^1.2.8",
     "node-worker-pool": "~2.4.2",
+    "object-assign": "^3.0.0",
     "optimist": "~0.6.0",
     "bluebird": "~2.9.30",
     "resolve": "~0.6.1",

--- a/src/TestRunner.js
+++ b/src/TestRunner.js
@@ -11,6 +11,7 @@ var fs = require('graceful-fs');
 var os = require('os');
 var path = require('path');
 var Promise = require('bluebird');
+var assign = require('object-assign');
 var through = require('through');
 var utils = require('./lib/utils');
 var WorkerPool = require('node-worker-pool');
@@ -91,12 +92,7 @@ function TestRunner(config, options) {
       .join('|') +
     ')$'
   );
-  this._opts = Object.create(DEFAULT_OPTIONS);
-  if (options) {
-    for (var key in options) {
-      this._opts[key] = options[key];
-    }
-  }
+  this._opts = assign({}, DEFAULT_OPTIONS, options);
 }
 
 TestRunner.prototype._constructModuleLoader = function(environment, customCfg) {
@@ -317,10 +313,10 @@ TestRunner.prototype.preloadConfigDependencies = function() {
  * @return {Promise<Object>} Results of the test
  */
 TestRunner.prototype.runTest = function(testFilePath) {
-  // Using Object.create() lets us adjust the config object locally without
+  // Shallow copying lets us adjust the config object locally without
   // worrying about the external consequences of changing the config object for
   // needs that are local to this particular function call
-  var config = Object.create(this._config);
+  var config = assign({}, this._config);
   var configDeps = this._loadConfigDependencies();
 
   var env = new configDeps.testEnvironment(config);


### PR DESCRIPTION
The `cacheKey` introduced in https://github.com/facebook/jest/pull/419, in the default case, relies on the stringified value of `config`. Since most (if not all) of the config values are up the prototype (so not own properties of config), they don't get serialized by `JSON.stringify`, which kinda negates the purpose of using the config in the cache key.

I considered changing the hashing instead to use `JSON.stringify(config.__proto__)` or a do a stringify up each level of the prototype chain – but this seemed like the most straight forward solution.

The `readAndPreprocessFileContent` function should probably pass `scriptPreprocessor` and `getCacheKey` a copy of the config too, to prevent accidental mutation. I can submit another PR for that.