### PR TITLE
Fix fatal when using `preprocessorIgnorePatterns`

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -234,7 +234,7 @@ function normalizeConfig(config) {
       case 'verbose':
         value = config[key];
         break;
-        
+
       default:
         throw new Error('Unknown config option: ' + key);
     }
@@ -364,7 +364,7 @@ function readAndPreprocessFileContent(filePath, config) {
 
   if (config.scriptPreprocessor &&
       !config.preprocessorIgnorePatterns.some(function(pattern) {
-        return pattern.test(filePath);
+        return new RegExp(pattern).test(filePath);
       })) {
     try {
       var preprocessor = require(config.scriptPreprocessor);


### PR DESCRIPTION
Currently, specifying a non-empty `preprocessorIgnorePatterns` configuration will fatal because `String.prototype.test` is not a valid function.