### PR TITLE
Add `expect` to the list of globally injected variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Check out the [Getting Started](http://facebook.github.io/jest/docs/getting-star
   - `afterEach(fn)`
   - `beforeEach(fn)`
   - `describe(name, fn)`
+  - [`expect(value)`](http://facebook.github.io/jest/docs/api.html#expect-value)
   - `it(name, fn)`
   - `it.only(name, fn)` executes [only](https://github.com/davemo/jasmine-only) this test. Useful when investigating a failure
   - [`jest`](http://facebook.github.io/jest/docs/api.html#the-jest-object)

--- a/docs/API.md
+++ b/docs/API.md
@@ -60,6 +60,7 @@ permalink: docs/api.html
   - `afterEach(fn)`
   - `beforeEach(fn)`
   - `describe(name, fn)`
+  - [`expect(value)`](#expect-value)
   - `it(name, fn)`
   - `it.only(name, fn)` executes [only](https://github.com/davemo/jasmine-only) this test. Useful when investigating a failure
   - [`jest`](#the-jest-object)


### PR DESCRIPTION
Clarify the documentation by indicating that `expect` is a globally injected function. This will help newcomers to understand how it works, and projects like [globals](/sindresorhus/globals) to list globally defined variables (see sindresorhus/globals#46).