### PR TITLE
Move preprocess cache into the `cacheDir` provided by the config.

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -10,7 +10,6 @@
 var crypto = require('crypto');
 var colors = require('./colors');
 var fs = require('graceful-fs');
-var os = require('os');
 var path = require('path');
 var Promise = require('bluebird');
 
@@ -382,8 +381,8 @@ function readAndPreprocessFileContent(filePath, config) {
       // On disk cache is enabled by default, unless explicitly disabled.
       if (config.preprocessCachingDisabled !== true) {
         var cacheDir = path.join(
-          os.tmpDir(),
-          'jest_preprocess_cache'
+          config.cacheDirectory,
+          'preprocess-cache'
         );
 
         try {
@@ -415,9 +414,10 @@ function readAndPreprocessFileContent(filePath, config) {
             .digest('hex');
         }
 
+        var extension = path.extname(filePath);
         var cachePath = path.join(
           cacheDir,
-          cacheKey + '_' + path.basename(filePath)
+          path.basename(filePath, extension) + '_' + cacheKey + extension
         );
 
         if (fs.existsSync(cachePath)) {


### PR DESCRIPTION
This fixes internal issues at FB that writes to a shared tmp file.

I also changed the name of the generated file – this should make debugging for jest developers easier and has no user impact:

`fileName_<hash>.js` instead of `<hash>_fileName.js`