### PR TITLE
adding --noStackTrace to shorten test result

### DIFF
--- a/bin/jest.js
+++ b/bin/jest.js
@@ -107,6 +107,12 @@ var argv = optimist
       ),
       type: 'boolean'
     },
+    noStackTrace: {
+      description: _wrapDesc(
+        'Disables stack trace in test results output'
+      ),
+      type: 'boolean'
+    },
     verbose: {
       description: _wrapDesc(
         'Display individual test results with the test suite hierarchy.'

--- a/src/jasmineTestRunner/JasmineReporter.js
+++ b/src/jasmineTestRunner/JasmineReporter.js
@@ -144,7 +144,7 @@ function (container, ancestorTitles, spec) {
             message = message.split('\n').filter(function(line) {
               return !/vendor\/jasmine\//.test(line);
             });
-            message = this.__config['noStackTrace'] ? message.slice(0,2) : message;
+            message = this._config['noStackTrace'] ? message.slice(0,2) : message;
             message = message.join('\n');
           }
 

--- a/src/jasmineTestRunner/JasmineReporter.js
+++ b/src/jasmineTestRunner/JasmineReporter.js
@@ -110,6 +110,10 @@ function (container, ancestorTitles, spec) {
             this._formatMsg('$1', ERROR_TITLE_COLOR)
           );
 
+          result.trace.stack = this._config['noStackTrace']
+            ? result.trace.stack.split('\n').slice(0,2).join('\n')
+            : result.trace.stack;
+
           results.failureMessages.push(result.trace.stack);
         } else {
           var message;
@@ -139,7 +143,9 @@ function (container, ancestorTitles, spec) {
             // Remove jasmine jonx from the stack trace
             message = message.split('\n').filter(function(line) {
               return !/vendor\/jasmine\//.test(line);
-            }).join('\n');
+            });
+            message = this.__config['noStackTrace'] ? message.slice(0,2) : message;
+            message = message.join('\n');
           }
 
           results.failureMessages.push(message);

--- a/src/jasmineTestRunner/JasmineReporter.js
+++ b/src/jasmineTestRunner/JasmineReporter.js
@@ -110,7 +110,7 @@ function (container, ancestorTitles, spec) {
             this._formatMsg('$1', ERROR_TITLE_COLOR)
           );
 
-          result.trace.stack = this._config['noStackTrace']
+          result.trace.stack = this._config.noStackTrace
             ? result.trace.stack.split('\n').slice(0,2).join('\n')
             : result.trace.stack;
 
@@ -144,7 +144,7 @@ function (container, ancestorTitles, spec) {
             message = message.split('\n').filter(function(line) {
               return !/vendor\/jasmine\//.test(line);
             });
-            message = this._config['noStackTrace'] ? message.slice(0,2) : message;
+            message = this._config.noStackTrace ? message.slice(0,2) : message;
             message = message.join('\n');
           }
 

--- a/src/jasmineTestRunner/jasmineTestRunner.js
+++ b/src/jasmineTestRunner/jasmineTestRunner.js
@@ -276,6 +276,7 @@ function jasmineTestRunner(config, environment, moduleLoader, testPath) {
 
   var jasmineReporter = new JasmineReporter({
     noHighlight: config.noHighlight,
+    noStackTrace: config.noStackTrace
   });
   jasmine.getEnv().addReporter(jasmineReporter);
 

--- a/src/jest.js
+++ b/src/jest.js
@@ -97,6 +97,8 @@ function _promiseConfig(argv, packageRoot) {
       config.bail = argv.bail;
     }
 
+    config.noStackTrace = argv.noStackTrace;
+
     return config;
   });
 }

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -32,6 +32,7 @@ var DEFAULT_CONFIG_VALUES = {
   testReporter: require.resolve('../IstanbulTestReporter'),
   testRunner: require.resolve('../jasmineTestRunner/jasmineTestRunner'),
   noHighlight: false,
+  noStackTrace: false,
   preprocessCachingDisabled: false,
   verbose: false
 };
@@ -238,6 +239,7 @@ function normalizeConfig(config) {
       case 'testReporter':
       case 'moduleFileExtensions':
       case 'noHighlight':
+      case 'noStackTrace':
       case 'verbose':
         value = config[key];
         break;


### PR DESCRIPTION
Enable config `--noStackTrace` to shorten test result, only the line number of the error will still be shown but no further stack trace.