### PR TITLE
[CoffeeScript] Update coffee-script to ^1.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.5.1",
   "main": "src/jest.js",
   "dependencies": {
-    "coffee-script": "jashkenas/coffeescript",
+    "coffee-script": "^1.10.0",
     "cover": "^0.2.9",
     "diff": "^2.1.0",
     "graceful-fs": "^4.1.2",


### PR DESCRIPTION
The patch for jest has been published as 1.10.0 so we don't need to download coffee-script from GitHub each time anymore.