### PR TITLE
Fix chmod error when different owner's dir exists in preprocess-cache

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -399,15 +399,10 @@ function readAndPreprocessFileContent(filePath, config) {
           'preprocess-cache'
         );
 
-        try {
+        if (!fs.existsSync(cacheDir)) {
           fs.mkdirSync(cacheDir);
-        } catch(e) {
-          if (e.code !== 'EEXIST') {
-            throw e;
-          }
+          fs.chmodSync(cacheDir, '777');
         }
-
-        fs.chmodSync(cacheDir, '777');
 
         var cacheKey;
         // If preprocessor defines custom cache hashing and


### PR DESCRIPTION
If `/tmp/jest_preprocess_cache` already exists by different owner then preprocess-cache raises `chmodSync` permission error.

e.g. When many users run Jest on a shared-server, raise following error:

```
Error: /<snip>/node_modules/babel-jest: EPERM, operation not permitted '/tmp/jest_preprocess_cache'
  at Object.fs.chmodSync (fs.js:833:18)
  at Object.readAndPreprocessFileContent (/<snip>/node_modules/jest-cli/src/lib/utils.js:392:12)
  at Loader._execModule (/<snip>/node_modules/jest-cli/src/HasteModuleLoader/HasteModuleLoader.js:209:11)
  at Loader.requireModule (/<snip>/node_modules/jest-cli/src/HasteModuleLoader/HasteModuleLoader.js:914:12)
  at jasmineTestRunner (/<snip>/node_modules/jest-cli/src/jasmineTestRunner/jasmineTestRunner.js:292:16)
  at /<snip>/node_modules/jest-cli/src/TestRunner.js:376:12
  at tryCatcher (/<snip>/node_modules/jest-cli/node_modules/bluebird/js/main/util.js:26:23)
  at Promise._settlePromiseFromHandler (/<snip>/node_modules/jest-cli/node_modules/bluebird/js/main/promise.js:503:31)
  at Promise._settlePromiseAt (/<snip>/node_modules/jest-cli/node_modules/bluebird/js/main/promise.js:577:18)
  at Promise._settlePromises (/<snip>/node_modules/jest-cli/node_modules/bluebird/js/main/promise.js:693:14)
  at Async._drainQueue (/<snip>/node_modules/jest-cli/node_modules/bluebird/js/main/async.js:123:16)
  at Async._drainQueues (/<snip>/node_modules/jest-cli/node_modules/bluebird/js/main/async.js:133:10)
  at Async.drainQueues (/<snip>/node_modules/jest-cli/node_modules/bluebird/js/main/async.js:15:14)
  at process._tickCallback (node.js:448:13)
```

So, I fixed it.