### PR TITLE
Set the default value for modulePathIgnorePatterns to ['/node_modules/']

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -27,7 +27,7 @@ var DEFAULT_CONFIG_VALUES = {
   moduleFileExtensions: ['js', 'json'],
   moduleLoader: require.resolve('../HasteModuleLoader/HasteModuleLoader'),
   preprocessorIgnorePatterns: [],
-  modulePathIgnorePatterns: [],
+  modulePathIgnorePatterns: ['/node_modules/'],
   moduleNameMapper: [],
   testDirectoryName: '__tests__',
   testEnvironment: require.resolve('../JSDomEnvironment'),


### PR DESCRIPTION
So it's consistent with the documentation: http://facebook.github.io/jest/docs/api.html#config-modulepathignorepatterns-array-string