### PR TITLE
Fix preprocess cache directory creation race condition

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -399,15 +399,17 @@ function readAndPreprocessFileContent(filePath, config) {
           'preprocess-cache'
         );
 
-        try {
-          fs.mkdirSync(cacheDir);
-        } catch(e) {
-          if (e.code !== 'EEXIST') {
-            throw e;
+        if (!fs.existsSync(cacheDir)) {
+          try {
+            fs.mkdirSync(cacheDir);
+          } catch(e) {
+            if (e.code !== 'EEXIST') {
+              throw e;
+            }
           }
-        }
 
-        fs.chmodSync(cacheDir, '777');
+          fs.chmodSync(cacheDir, '777');
+        }
 
         var cacheKey;
         // If preprocessor defines custom cache hashing and

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -399,10 +399,15 @@ function readAndPreprocessFileContent(filePath, config) {
           'preprocess-cache'
         );
 
-        if (!fs.existsSync(cacheDir)) {
+        try {
           fs.mkdirSync(cacheDir);
-          fs.chmodSync(cacheDir, '777');
+        } catch(e) {
+          if (e.code !== 'EEXIST') {
+            throw e;
+          }
         }
+
+        fs.chmodSync(cacheDir, '777');
 
         var cacheKey;
         // If preprocessor defines custom cache hashing and


### PR DESCRIPTION
This PR reverts https://github.com/facebook/jest/pull/491. The change introduced in that PR introduced a race condition into the creation of the preprocess cache directory, which can result in an unhandled `EEXIST` error. As far as I can see, the change made in that PR isn't required if the user is managing their own cache directory (which is easier to do now following https://github.com/facebook/jest/pull/470).
