### PR TITLE
Added testPathPattern to whitelisted normalizeConfig keys

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -236,6 +236,7 @@ function normalizeConfig(config) {
       case 'testDirectoryName':
       case 'testEnvData':
       case 'testFileExtensions':
+      case 'testPathPattern':
       case 'testReporter':
       case 'testURL':
       case 'moduleFileExtensions':


### PR DESCRIPTION
#### What does it do?

Adds the `testPathPattern` key to the whitelisted keys in `utils.normalizeConfig()`

#### Where should the reviewer start?

Read #501 for explanation of the issue

#### How should this be manually tested?

`$ npm test` should pass