### PR TITLE
Fix module paths for project symlinks

### DIFF
--- a/src/HasteModuleLoader/HasteModuleLoader.js
+++ b/src/HasteModuleLoader/HasteModuleLoader.js
@@ -614,31 +614,25 @@ Loader.prototype._shouldMock = function(currPath, moduleName) {
   }
 };
 
-Loader.prototype.constructBoundRequire = function(sourceModulePath) {
-  var boundModuleRequire = this.requireModuleOrMock.bind(
-    this,
-    sourceModulePath
-  );
+Loader.prototype.constructBoundRequire = function(unresolvedModulePath) {
+  var modulePath = fs.realpathSync(unresolvedModulePath);
+
+  var boundModuleRequire =
+    this.requireModuleOrMock.bind(this, modulePath);
 
   boundModuleRequire.resolve = function(moduleName) {
-    var ret = this._moduleNameToPath(sourceModulePath, moduleName);
+    var ret = this._moduleNameToPath(modulePath, moduleName);
     if (!ret) {
       throw new Error('Module(' + moduleName + ') not found!');
     }
     return ret;
   }.bind(this);
-  boundModuleRequire.generateMock = this._generateMock.bind(
-    this,
-    sourceModulePath
-  );
-  boundModuleRequire.requireMock = this.requireMock.bind(
-    this,
-    sourceModulePath
-  );
-  boundModuleRequire.requireActual = this.requireModule.bind(
-    this,
-    sourceModulePath
-  );
+  boundModuleRequire.generateMock =
+    this._generateMock.bind(this, modulePath);
+  boundModuleRequire.requireMock =
+    this.requireMock.bind(this, modulePath);
+  boundModuleRequire.requireActual =
+    this.requireModule.bind(this, modulePath);
 
   return boundModuleRequire;
 };


### PR DESCRIPTION
If a project that you're trying to run Jest on is a symlink, all modules will be relative to the symlink. However, the configuration paths (e.g. `<rootDir>/...`) are real paths. This can cause, for example, modules that are configured to be unmocked (via `unmockedModulePathPatterns`) to be mocked.

This fixes the problem by ensuring that we resolve the module path used to resolve all modules.