### PR TITLE
Improve Symlink Fix

### DIFF
--- a/src/HasteModuleLoader/HasteModuleLoader.js
+++ b/src/HasteModuleLoader/HasteModuleLoader.js
@@ -599,10 +599,12 @@ Loader.prototype._shouldMock = function(currPath, moduleName) {
         return false;
       }
 
+      var realPath = fs.realpathSync(modulePath);
       this._configShouldMockModuleNames[moduleName] = true;
       for (var i = 0; i < this._unmockListRegExps.length; i++) {
         unmockRegExp = this._unmockListRegExps[i];
-        if (unmockRegExp.test(modulePath)) {
+        if (unmockRegExp.test(modulePath) ||
+            unmockRegExp.test(realPath)) {
           return this._configShouldMockModuleNames[moduleName] = false;
         }
       }
@@ -614,9 +616,7 @@ Loader.prototype._shouldMock = function(currPath, moduleName) {
   }
 };
 
-Loader.prototype.constructBoundRequire = function(unresolvedModulePath) {
-  var modulePath = fs.realpathSync(unresolvedModulePath);
-
+Loader.prototype.constructBoundRequire = function(modulePath) {
   var boundModuleRequire =
     this.requireModuleOrMock.bind(this, modulePath);
 


### PR DESCRIPTION
I have no idea what's going on, but the Jest symlink situation needs serious reworking. Internally at Facebook, ecf8ad709fbce8acb0e54ee5f8a17ea52e9e1bd4 is causing problems.

I'm reverting the previous fix and simply making Jest unmock a module path if either its real path or symlink path matches a path in the unmock list.