### PR TITLE
Issue #517 Bug on log error when verbose=true

### DIFF
--- a/src/TestRunner.js
+++ b/src/TestRunner.js
@@ -522,6 +522,7 @@ TestRunner.prototype.runTests = function(testPaths, reporter) {
       testExecError: err,
       suites: {},
       tests: {},
+      testResults: {},
       logMessages: []
     };
     aggregatedResults.testResults.push(testResult);


### PR DESCRIPTION
On verbose mode log error shows "Cannot read property 'length' of undefined"