### PR TITLE
[npm] Add support for npm scoped packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,13 +13,14 @@
     "jasmine-pit": "^2.0.2",
     "jsdom": "6.5.1",
     "lodash.template": "^3.6.2",
+    "mkdirp": "^0.5.1",
     "node-haste": "^1.2.8",
     "node-worker-pool": "^3.0.2",
     "object-assign": "^4.0.1",
     "optimist": "^0.6.1",
     "resolve": "^1.1.6",
-    "through": "^2.3.8",
     "sane": "^1.2.0",
+    "through": "^2.3.8",
     "which": "^1.1.1"
   },
   "devDependencies": {

--- a/src/HasteModuleLoader/HasteModuleLoader.js
+++ b/src/HasteModuleLoader/HasteModuleLoader.js
@@ -17,6 +17,7 @@
 
 var fs = require('graceful-fs');
 var hasteLoaders = require('node-haste/lib/loaders');
+var mkdirp = require('mkdirp');
 var moduleMocker = require('../lib/moduleMocker');
 var NodeHaste = require('node-haste/lib/Haste');
 var os = require('os');
@@ -88,9 +89,13 @@ function _constructHasteInst(config, options) {
     : '$.'  // never matches
   );
 
-  if (!fs.existsSync(config.cacheDirectory)) {
-    fs.mkdirSync(config.cacheDirectory);
-    fs.chmodSync(config.cacheDirectory, '777');
+  // Support npm package scopes that add an extra directory to the path
+  var scopedCacheDirectory = path.dirname(_getCacheFilePath(config));
+  if (!fs.existsSync(scopedCacheDirectory)) {
+    mkdirp.sync(scopedCacheDirectory, {
+      mode: '777',
+      fs: fs,
+    });
   }
 
   return new NodeHaste(


### PR DESCRIPTION
If you have a scoped package, its name in package.json looks like `@scope/pkg` which messes up the mkdir call since it doesn't expect there to be an extra directory for the Haste cache.

Fixes https://github.com/facebook/jest/issues/446

Test Plan: Use jest in a project that has a scoped name.