### PR TITLE
Support custom config.testRunner setting in normalizeConfig

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -238,6 +238,7 @@ function normalizeConfig(config) {
       case 'testFileExtensions':
       case 'testPathPattern':
       case 'testReporter':
+      case 'testRunner':
       case 'testURL':
       case 'moduleFileExtensions':
       case 'noHighlight':


### PR DESCRIPTION
Adds `testRunner` to the list of config options which are pulled in from custom configuration, allowing custom test runner implementations to be used.