### PR TITLE
Remove arrow function usage so iojs works again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: node_js
 node_js:
+- "iojs-v2"
+- "iojs-v3"
 - "4"
 sudo: false


### PR DESCRIPTION
If we don't do #536 then we should do this and ship it to 0.5. This fixes the arrow functions that are prevention iojs-v3 from working.

Alternately, we can do this in a 0.5 branch, ship it AND ship 0.6 from master.