### PR TITLE
Pass the `maxWorkers` option on to node-haste

### DIFF
--- a/src/HasteModuleLoader/HasteModuleLoader.js
+++ b/src/HasteModuleLoader/HasteModuleLoader.js
@@ -107,7 +107,7 @@ function _constructHasteInst(config, options) {
       },
       version: JSON.stringify(config),
       useNativeFind: true,
-      maxProcesses: os.cpus().length,
+      maxProcesses: options.maxWorkers || os.cpus().length,
       maxOpenFiles: options.maxOpenFiles || 100
     }
   );

--- a/src/TestRunner.js
+++ b/src/TestRunner.js
@@ -106,10 +106,10 @@ class TestRunner {
     if (this._moduleLoaderResourceMap === null) {
       if (this._opts.useCachedModuleLoaderResourceMap) {
         this._moduleLoaderResourceMap =
-          ModuleLoader.loadResourceMapFromCacheFile(this._config);
+          ModuleLoader.loadResourceMapFromCacheFile(this._config, this._opts);
       } else {
         this._moduleLoaderResourceMap =
-          ModuleLoader.loadResourceMap(this._config);
+          ModuleLoader.loadResourceMap(this._config, this._opts);
       }
     }
     return this._moduleLoaderResourceMap;


### PR DESCRIPTION
Test runner options were not being passed to the loader. This changes `TestRunner` to pass the options and `HasteModuleLoader` to use the `maxWorkers` option value for node-haste's `maxProcesses` option.

I also submitted a CLA just now.