### PR TITLE
Replace node-worker-pool with node-worker-farm

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "resolve": "^1.1.6",
     "sane": "^1.2.0",
     "through": "^2.3.8",
-    "which": "^1.1.1"
+    "which": "^1.1.1",
+    "worker-farm": "^1.3.1"
   },
   "devDependencies": {
     "jshint": "^2.8.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "lodash.template": "^3.6.2",
     "mkdirp": "^0.5.1",
     "node-haste": "^1.2.8",
-    "node-worker-pool": "^3.0.2",
     "object-assign": "^4.0.1",
     "optimist": "^0.6.1",
     "resolve": "^1.1.6",

--- a/src/Console.js
+++ b/src/Console.js
@@ -27,106 +27,24 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-/*jshint strict:false*/
+'use strict';
 
 var util = require('util');
+var Console = require('console').Console;
+var colors = require('./lib/colors');
 
-function Console(messageQueue) {
-  if (!(this instanceof Console)) {
-    return new Console(messageQueue);
+class CustomConsole extends Console {
+  warn() {
+    return super.warn(
+      colors.colorize(util.format.apply(this, arguments), colors.YELLOW)
+    );
   }
 
-  Object.defineProperty(this, '_messageQueue', {
-    value: messageQueue,
-    writable: true,
-    enumerable: false,
-    configurable: true
-  });
-
-  Object.defineProperty(this, '_times', {
-    value: {},
-    writable: true,
-    enumerable: false,
-    configurable: true
-  });
-
-  // bind the prototype functions to this Console instance
-  var keys = Object.keys(Console.prototype);
-  for (var v = 0; v < keys.length; v++) {
-    var k = keys[v];
-    this[k] = this[k].bind(this);
+  error() {
+    return super.error(
+      colors.colorize(util.format.apply(this, arguments), colors.RED)
+    );
   }
 }
 
-Console.prototype.log = function() {
-  this._messageQueue.push({
-    type: 'log',
-    data: util.format.apply(this, arguments) + '\n'
-  });
-};
-
-
-Console.prototype.info = Console.prototype.log;
-
-
-Console.prototype.warn = function() {
-  this._messageQueue.push({
-    type: 'warn',
-    data: util.format.apply(this, arguments) + '\n'
-  });
-};
-
-
-Console.prototype.error = function() {
-  this._messageQueue.push({
-    type: 'error',
-    data: util.format.apply(this, arguments) + '\n'
-  });
-};
-
-
-Console.prototype.dir = function(object, options) {
-  this._messageQueue.push({
-    type: 'dir',
-    data: util.inspect(object, util._extend({
-            customInspect: false
-          }, options)) + '\n'
-  });
-};
-
-
-Console.prototype.time = function(label) {
-  this._times[label] = Date.now();
-};
-
-
-Console.prototype.timeEnd = function(label) {
-  var time = this._times[label];
-  if (!time) {
-    throw new Error('No such label: ' + label);
-  }
-  var duration = Date.now() - time;
-  this.log('%s: %dms', label, duration);
-};
-
-
-Console.prototype.trace = function() {
-  // TODO probably can to do this better with V8's debug object once that is
-  // exposed.
-  var err = new Error();
-  err.name = 'Trace';
-  err.message = util.format.apply(this, arguments);
-  /*jshint noarg:false*/
-  Error.captureStackTrace(err, arguments.callee);
-  this.error(err.stack);
-};
-
-
-Console.prototype.assert = function(expression) {
-  if (!expression) {
-    var arr = Array.prototype.slice.call(arguments, 1);
-    require('assert').ok(false, util.format.apply(this, arr));
-  }
-};
-
-module.exports = Console;
+module.exports = CustomConsole;

--- a/src/DefaultTestReporter.js
+++ b/src/DefaultTestReporter.js
@@ -72,8 +72,6 @@ function(config, testResult, aggregatedResults) {
     this.verboseLog(testResult.testResults, resultHeader);
   }
 
-  testResult.logMessages.forEach(this._printConsoleMessage.bind(this));
-
   if (!allTestsPassed) {
     var failureMessage = formatFailureMessage(testResult, {
       rootPath: config.rootDir,
@@ -137,27 +135,6 @@ function (config, aggregatedResults) {
 
   this.log(results);
   this.log('Run time: ' + runTime + 's');
-};
-
-DefaultTestReporter.prototype._printConsoleMessage = function(msg) {
-  switch (msg.type) {
-    case 'dir':
-    case 'log':
-      this._process.stdout.write(msg.data);
-      break;
-    case 'warn':
-      this._process.stderr.write(
-        this._formatMsg(msg.data, colors.YELLOW)
-      );
-      break;
-    case 'error':
-      this._process.stderr.write(
-        this._formatMsg(msg.data, colors.RED)
-      );
-      break;
-    default:
-      throw new Error('Unknown console message type!: ' + msg.type);
-  }
 };
 
 DefaultTestReporter.prototype._clearWaitingOn = function() {

--- a/src/TestWorker.js
+++ b/src/TestWorker.js
@@ -8,6 +8,8 @@
 'use strict';
 
 // Make sure uncaught errors are logged before we exit.
+// Could be transient errors to do with loading and serializing the resouce
+// map.
 process.on('uncaughtException', (err) => {
   console.error(err.stack);
   process.exit(1);
@@ -47,6 +49,7 @@ module.exports = function(data, callback) {
     testRunner.runTest(data.testFilePath)
       .then(
         result => callback(null, result),
+        // TODO: move to error object passing (why limit to strings?).
         err => callback(err.stack || err.message || err)
       );
   } catch (err) {

--- a/src/TestWorker.js
+++ b/src/TestWorker.js
@@ -7,52 +7,49 @@
  */
 'use strict';
 
-var optimist = require('optimist');
+// Make sure uncaught errors are logged before we exit.
+process.on('uncaughtException', (err) => {
+  console.error(err.stack);
+  process.exit(1);
+});
+
 var TestRunner = require('./TestRunner');
-var workerUtils = require('node-worker-pool/nodeWorkerUtils');
 
-if (require.main === module) {
-  try {
-    process.on('uncaughtException', workerUtils.respondWithError);
+var testRunner;
 
-    var argv = optimist.demand(['config']).argv;
-    var config = JSON.parse(argv.config);
+module.exports = function(data, callback) {
+  if (!testRunner) {
+    testRunner = new TestRunner(data.config, {
+      useCachedModuleLoaderResourceMap: true
+    });
 
-    var testRunner = null;
-    var onMessage = function(message) {
-      if (testRunner === null) {
-        testRunner = new TestRunner(config, {
-          useCachedModuleLoaderResourceMap: true,
-        });
+    // Start require()ing config dependencies now.
+    //
+    // Config dependencies are entries in the config that are require()d (in
+    // order to be pluggable) such as 'moduleLoader' or
+    // 'testEnvironment'.
+    testRunner.preloadConfigDependencies();
 
-        // Start require()ing config dependencies now.
-        //
-        // Config dependencies are entries in the config that are require()d (in
-        // order to be pluggable) such as 'moduleLoader' or
-        // 'testEnvironment'.
-        testRunner.preloadConfigDependencies();
-
-        // Start deserializing the resource map to get a potential head-start on
-        // that work before the first "run-test" message comes in.
-        //
-        // This is just a perf optimization -- and it is only an optimization
-        // some of the time (when the there is any significant idle time between
-        // this first initialization message and the first "run-rest" message).
-        //
-        // It is also only an optimization so long as deserialization of the
-        // resource map is a bottleneck (which is the case at the time of this
-        // writing).
-        testRunner.preloadResourceMap();
-      }
-
-      return testRunner.runTest(message.testFilePath)
-        .catch(function(err) {
-          throw (err.stack || err.message || err);
-        });
-    };
-
-    workerUtils.startWorker(null, onMessage);
-  } catch (e) {
-    workerUtils.respondWithError(e);
+    // Start deserializing the resource map to get a potential head-start on
+    // that work before the first "run-test" message comes in.
+    //
+    // This is just a perf optimization -- and it is only an optimization
+    // some of the time (when the there is any significant idle time between
+    // this first initialization message and the first "run-rest" message).
+    //
+    // It is also only an optimization so long as deserialization of the
+    // resource map is a bottleneck (which is the case at the time of this
+    // writing).
+    testRunner.preloadResourceMap();
   }
-}
+
+  try {
+    testRunner.runTest(data.testFilePath)
+      .then(
+        result => callback(null, result),
+        err => callback(err)
+      );
+  } catch (err) {
+    callback(err);
+  }
+};

--- a/src/TestWorker.js
+++ b/src/TestWorker.js
@@ -47,9 +47,9 @@ module.exports = function(data, callback) {
     testRunner.runTest(data.testFilePath)
       .then(
         result => callback(null, result),
-        err => callback(err)
+        err => callback(err.stack || err.message || err)
       );
   } catch (err) {
-    callback(err);
+    callback(err.stack || err.message || err);
   }
 };

--- a/src/jasmineTestRunner/JasmineReporter.js
+++ b/src/jasmineTestRunner/JasmineReporter.js
@@ -86,15 +86,11 @@ function (container, ancestorTitles, spec) {
     title: 'it ' + spec.description,
     ancestorTitles: ancestorTitles,
     failureMessages: [],
-    logMessages: [],
     numPassingAsserts: 0
   };
 
   spec.results().getItems().forEach(function(result) {
     switch (result.type) {
-      case 'log':
-        results.logMessages.push(result.toString());
-        break;
       case 'expect':
         if (result.passed()) {
           results.numPassingAsserts++;

--- a/src/lib/__tests__/promisify-test.js
+++ b/src/lib/__tests__/promisify-test.js
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2014, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
+jest.dontMock('../promisify');
+
+describe('promisify', () => {
+  var promisify;
+
+  beforeEach(() => {
+    promisify = require('../promisify');
+  });
+
+  pit('should resolve', () => {
+    var foo = promisify(callback => {
+      callback(null, 1);
+    });
+
+    return foo().then(res => {
+      expect(res).toBe(1);
+    });
+  });
+
+   pit('should resolve with args', () => {
+    var foo = promisify((a, b, callback) => {
+      callback(null, a + b);
+    });
+
+    return foo(3, 5).then(res => {
+      expect(res).toBe(8);
+    });
+  });
+
+   pit('should reject with args', () => {
+    var foo = promisify((a, b, callback) => {
+      callback(new Error('lol'));
+    });
+
+    return foo(3, 5).catch(err => {
+      expect(err.message).toBe('lol');
+    });
+  });
+});

--- a/src/lib/promisify.js
+++ b/src/lib/promisify.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2014, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
+module.exports = function(fn) {
+  return function() {
+    var args = Array.prototype.slice.call(arguments);
+    return new Promise((resolve, reject) => {
+      args.push((err, res) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(res);
+        }
+      });
+
+      fn.apply(this, args);
+    });
+  }
+};

--- a/src/lib/promisify.js
+++ b/src/lib/promisify.js
@@ -21,5 +21,5 @@ module.exports = function(fn) {
 
       fn.apply(this, args);
     });
-  }
+  };
 };


### PR DESCRIPTION
* More reliable (uses IPC instead of stdin/out)
* No more weird messaging issues (unable to parse, message order, etc)
* Allows (currently, up to 2) initialization errors per worker
* Console logs can appear as they are executed (not buffered)
* Also means that they console logs appear even when there is initialization errors
* Simplifies console and logger implementation
* Easier for debugging (even if the program crashes you can still see your logs)
* Opens up opportunities for future more involved inter-worker communication (say sharing mocking work)
cc @cpojer @DmitrySoshnikov 