### PR TITLE
Make useStderr a proper config value

### DIFF
--- a/bin/jest.js
+++ b/bin/jest.js
@@ -143,7 +143,13 @@ var argv = optimist
         'Exit the test suite immediately upon the first failing test.'
       ),
       type: 'boolean'
-    }
+    },
+    useStderr: {
+      description: _wrapDesc(
+        'Divert all output to stderr.'
+      ),
+      type: 'boolean',
+    },
   })
   .check(function(argv) {
     if (argv.runInBand && argv.hasOwnProperty('maxWorkers')) {

--- a/src/IstanbulTestReporter.js
+++ b/src/IstanbulTestReporter.js
@@ -5,35 +5,25 @@ var istanbul = require('istanbul');
 var collector = new istanbul.Collector();
 var reporter = new istanbul.Reporter();
 
-function IstanbulTestReporter(customProcess) {
-  this.process = customProcess || process;
-}
+class IstanbulTestReporter extends DefaultTestReporter {
+  onTestResult(config, testResult, aggregatedResults) {
+    super.onTestResult(config, testResult, aggregatedResults);
 
-IstanbulTestReporter.prototype = new DefaultTestReporter();
-
-IstanbulTestReporter.prototype.onTestResult =
-function(config, testResult, aggregatedResults) {
-  DefaultTestReporter.prototype.onTestResult.call(
-    this, config, testResult, aggregatedResults
-  );
-
-  if (config.collectCoverage && testResult.coverage) {
-    collector.add(testResult.coverage);
+    if (config.collectCoverage && testResult.coverage) {
+      collector.add(testResult.coverage);
+    }
   }
-};
 
-IstanbulTestReporter.prototype.onRunComplete =
-function (config, aggregatedResults) {
-  DefaultTestReporter.prototype.onRunComplete.call(
-    this, config, aggregatedResults
-  );
+  onRunComplete(config, aggregatedResults) {
+    super.onRunComplete(config, aggregatedResults);
 
-  if (config.collectCoverage) {
-    reporter.addAll(config.coverageReporters);
-    reporter.write(collector, true, function () {
+    if (config.collectCoverage) {
+      reporter.addAll(config.coverageReporters);
+      reporter.write(collector, true, function () {
         console.log('All reports generated');
-    });
+      });
+    }
   }
-};
+}
 
 module.exports = IstanbulTestReporter;

--- a/src/TestRunner.js
+++ b/src/TestRunner.js
@@ -475,7 +475,16 @@ class TestRunner {
     var config = this._config;
     if (!reporter) {
       var TestReporter = require(config.testReporter);
-      reporter = new TestReporter();
+      if (config.useStderr) {
+        reporter = new TestReporter(
+          Object.create(
+            process,
+            { stdout: { value: process.stderr } }
+          )
+        );
+      } else {
+        reporter = new TestReporter();
+      }
     }
 
     testPaths = this._sortTests(testPaths);

--- a/src/jest.js
+++ b/src/jest.js
@@ -96,6 +96,10 @@ function _promiseConfig(argv, packageRoot) {
       config.bail = argv.bail;
     }
 
+    if (argv.useStderr) {
+      config.useStderr = argv.useStderr;
+    }
+
     config.noStackTrace = argv.noStackTrace;
 
     return config;

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -36,7 +36,8 @@ var DEFAULT_CONFIG_VALUES = {
   noHighlight: false,
   noStackTrace: false,
   preprocessCachingDisabled: false,
-  verbose: false
+  verbose: false,
+  useStderr: false,
 };
 
 // This shows up in the stack trace when a test file throws an unhandled error


### PR DESCRIPTION
I've used `config.useStderr` internally to divert stdout to stderr
so we can talk to the caller via json. Instead of having a one-off
config option, I'm making this an actual option with a consistent
behaviour.

Had to convert the `InstanbulTestReporter` into a proper class
so it can do proper inheritence.

cc @cpojer @DmitrySoshnikov 