### PR TITLE
Promise.defer shouldn't exist, don't use it

### DIFF
--- a/src/jasmineTestRunner/JasmineReporter.js
+++ b/src/jasmineTestRunner/JasmineReporter.js
@@ -25,7 +25,7 @@ function JasmineReporter(config) {
   jasmine.Reporter.call(this);
   this._config = config || {};
   this._logs = [];
-  this._resultsDeferred = Promise.defer();
+  this._resultsPromise = new Promise((resolve) => { this._resolve = resolve; });
 }
 
 JasmineReporter.prototype = Object.create(jasmine.Reporter.prototype);
@@ -53,7 +53,7 @@ JasmineReporter.prototype.reportRunnerResults = function(runner) {
     }
   });
 
-  this._resultsDeferred.resolve({
+  this._resolve({
     numFailingTests: numFailingTests,
     numPassingTests: numPassingTests,
     testResults: testResults
@@ -61,7 +61,7 @@ JasmineReporter.prototype.reportRunnerResults = function(runner) {
 };
 
 JasmineReporter.prototype.getResults = function() {
-  return this._resultsDeferred.promise;
+  return this._resultsPromise;
 };
 
 JasmineReporter.prototype.log = function(str) {


### PR DESCRIPTION
I *think* I understand what's going on and did this right but maybe not…

While v8 currently supports `Promise.defer`, it won't always.