### PR TITLE
Exit the binary with a error when coverage fails

### DIFF
--- a/src/TestRunner.js
+++ b/src/TestRunner.js
@@ -543,6 +543,18 @@ class TestRunner {
     return testRun
       .then(function() {
         aggregatedResults.success = aggregatedResults.numFailedTests === 0;
+        aggregatedResults.success = aggregatedResults.testResults.reduce(
+          (sum, curr) => {
+            const results = (
+              Object
+                .keys(curr.coverage)
+                .map(x => curr.coverage[x])
+                .reduce((_, x) => Object.keys(x.branchMap).length === 0, true)
+            );
+            return results;
+          },
+          aggregatedResults.success
+        );
         if (reporter.onRunComplete) {
           reporter.onRunComplete(config, aggregatedResults);
         }


### PR DESCRIPTION
This patch will make the jest binary return a exit code of 1 when the coverage is lower than 100%.

I filed an issue (#526) to add this functionality a couple of weeks ago and then finally got around to add it myself.

I'm however not sure if this is the way it should be done. I'm not really familiar with the codebase so I wasn't sure where to add it. I also wanted to add a optional flag that would enable this functionality but didn't find where that should live either.

If someone could point me in the right direction of getting this PR into good enough shape so it can be merged that would be :100: