### PR TITLE
Bump required Node version and include note in docs

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -35,6 +35,9 @@ We can get up and running with the following 4 steps:
 
 2. Run `npm install jest-cli --save-dev`
 
+    Jest uses ES2015 features and requires a Node.js version of at least 4.0.0
+    to run.
+
 3. Add the following to your `package.json`
 
   ```js

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "jest": "./bin/jest.js"
   },
   "engines": {
-    "node": ">= 2"
+    "node": ">= 4"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Bump the `engines` field in `package.json` to require at least a version `>= 4`.
- Add a note to the "Getting Started"-guide to inform about the minimum required
  Node version. Fixes #563.