### PR TITLE
added react-tools to examples/react/package.json

### DIFF
--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -1,10 +1,11 @@
 {
   "dependencies": {
-    "react": "*",
-    "react-dom": "*",
-    "react-addons-test-utils": "*",
     "babel-jest": "*",
-    "jest-cli": "*"
+    "jest-cli": "*",
+    "react": "*",
+    "react-addons-test-utils": "*",
+    "react-dom": "*",
+    "react-tools": "^0.13.3"
   },
   "scripts": {
     "test": "node ../../bin/jest.js"


### PR DESCRIPTION
react-tools is required in dependencies for examples/react to run properly.