### PR TITLE
Updating React documentation and npm dependencies

### DIFF
--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -1,11 +1,12 @@
 {
   "dependencies": {
     "react": "~0.14.0",
-    "react-dom": "~0.14.0",
-    "react-addons-test-utils": "~0.14.0"
+    "react-dom": "~0.14.0"
   },
   "devDependencies": {
-    "babel-jest": "*"
+    "react-addons-test-utils": "~0.14.0",
+    "babel-jest": "*",
+    "jest-cli": "*"
   },
   "scripts": {
     "test": "node ../../bin/jest.js"


### PR DESCRIPTION
Updated the npm dependencies in examples/react. Previously didn't include jest-cli. Also updated documentation for the React Tutorial page to update these changes. Example previously would not work because it omitted "<rootDir>/node_modules/fbjs" from the unmockedModulePathPatterns section.