### PR TITLE
Fix manual mocks example

### DIFF
--- a/examples/manual_mocks/__tests__/FileSummarizer-test.js
+++ b/examples/manual_mocks/__tests__/FileSummarizer-test.js
@@ -1,3 +1,4 @@
+jest.mock('fs');
 jest.dontMock('../FileSummarizer');
 
 describe('FileSummarizer', function() {


### PR DESCRIPTION
Fix the failing manual_mocks example by explicitly mocking the `fs`-module.

Fixes #541. Fixes #375.