### PR TITLE
Use eslint for linting

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+src/coverageTemplate.js

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,5 @@
+---
+parser: babel-eslint
+
+extends:
+  - ./node_modules/fbjs-scripts/eslint/.eslintrc

--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
     "worker-farm": "^1.3.1"
   },
   "devDependencies": {
+    "babel-eslint": "^4.1.3",
+    "eslint": "^1.7.3",
+    "fbjs-scripts": "^0.3.0",
     "jshint": "^2.8.0",
     "node-find-files": "0.0.4"
   },

--- a/src/CoverageCollector.js
+++ b/src/CoverageCollector.js
@@ -38,7 +38,7 @@ CoverageCollector.prototype.getInstrumentedSource = function(storageVarName) {
     this._instrumentedSourceText = _getCoverageTemplate()({
       instrumented: this._instrumentor,
       coverageStorageVar: storageVarName,
-      source: this._instrumentor.instrument(this._origSourceText)
+      source: this._instrumentor.instrument(this._origSourceText),
     });
   }
   return this._instrumentedSourceText;
@@ -49,7 +49,7 @@ CoverageCollector.prototype.extractRuntimeCoverageInfo = function() {
   var coverageInfo = {
     coveredSpans: [],
     uncoveredSpans: [],
-    sourceText: this._origSourceText
+    sourceText: this._origSourceText,
   };
 
   var nodeIndex;

--- a/src/DefaultTestReporter.js
+++ b/src/DefaultTestReporter.js
@@ -58,7 +58,7 @@ function(config, testResult, aggregatedResults) {
   }
 
   var resultHeader = this._getResultHeader(allTestsPassed, pathStr, [
-    testRunTimeString
+    testRunTimeString,
   ]);
 
   /*
@@ -103,7 +103,7 @@ function(config, testResult, aggregatedResults) {
 };
 
 DefaultTestReporter.prototype.onRunComplete =
-function (config, aggregatedResults) {
+function(config, aggregatedResults) {
   var numFailedTests = aggregatedResults.numFailedTests;
   var numPassedTests = aggregatedResults.numPassedTests;
   var numTotalTests = aggregatedResults.numTotalTests;
@@ -157,14 +157,14 @@ DefaultTestReporter.prototype._formatMsg = function(msg, color) {
 };
 
 DefaultTestReporter.prototype._getResultHeader =
-function (passed, testName, columns) {
+function(passed, testName, columns) {
   var passFailTag = passed
     ? this._formatMsg(' PASS ', PASS_COLOR)
     : this._formatMsg(' FAIL ', FAIL_COLOR);
 
   return [
     passFailTag,
-    this._formatMsg(testName, TEST_NAME_COLOR)
+    this._formatMsg(testName, TEST_NAME_COLOR),
   ].concat(columns || []).join(' ');
 };
 

--- a/src/HasteModuleLoader/HasteModuleLoader.js
+++ b/src/HasteModuleLoader/HasteModuleLoader.js
@@ -66,7 +66,7 @@ const NODE_CORE_MODULES = {
   url: true,
   util: true,
   vm: true,
-  zlib: true
+  zlib: true,
 };
 
 const VENDOR_PATH = path.resolve(__dirname, '../../vendor');
@@ -86,7 +86,7 @@ function _buildLoadersList(config) {
     new hasteLoaders.JSTestLoader(config.setupJSTestLoaderOptions),
     new hasteLoaders.JSMockLoader(config.setupJSMockLoaderOptions),
     new hasteLoaders.JSLoader(config.setupJSLoaderOptions),
-    new hasteLoaders.ResourceLoader()
+    new hasteLoaders.ResourceLoader(),
   ];
 }
 
@@ -114,7 +114,7 @@ function _constructHasteInst(config, options) {
       version: JSON.stringify(config),
       useNativeFind: true,
       maxProcesses: options.maxWorkers || os.cpus().length,
-      maxOpenFiles: options.maxOpenFiles || 100
+      maxOpenFiles: options.maxOpenFiles || 100,
     }
   );
 }
@@ -230,7 +230,7 @@ Loader.prototype._execModule = function(moduleObj) {
     __dirname: path.dirname(modulePath),
     __filename: modulePath,
     global: this._environment.global,
-    jest: this._builtInModules['jest-runtime'](modulePath).exports
+    jest: this._builtInModules['jest-runtime'](modulePath).exports,
   };
 
   var onlyCollectFrom = this._config.collectCoverageOnlyFrom;
@@ -315,7 +315,7 @@ Loader.prototype._getDependencyPathsFromResource = function(resource) {
 
     try {
       var moduleID = this._getNormalizedModuleID(resource.path, requiredModule);
-    } catch(e) {
+    } catch (e) {
       continue;
     }
 
@@ -506,7 +506,7 @@ Loader.prototype._nodeModuleNameToPath = function(currPath, moduleName) {
 
   var resolveError = null;
   var exts = this._config.moduleFileExtensions
-    .map(function(ext){
+    .map(function(ext) {
       return '.' + ext;
     });
   try {
@@ -514,12 +514,12 @@ Loader.prototype._nodeModuleNameToPath = function(currPath, moduleName) {
       return resolve.sync(moduleName, {
         paths: NODE_PATH.split(path.delimiter),
         basedir: path.dirname(currPath),
-        extensions: exts
+        extensions: exts,
       });
     } else {
       return resolve.sync(moduleName, {
         basedir: path.dirname(currPath),
-        extensions: exts
+        extensions: exts,
       });
     }
   } catch (e) {
@@ -599,7 +599,7 @@ Loader.prototype._shouldMock = function(currPath, moduleName) {
         this._getResource('JSMock', moduleName);
       try {
         var modulePath = this._moduleNameToPath(currPath, moduleName);
-      } catch(e) {
+      } catch (e) {
         // If there isn't a real module, we don't have a path to match
         // against the unmockList regexps. If there is also not a manual
         // mock, then we throw because this module doesn't exist anywhere.
@@ -813,7 +813,7 @@ Loader.prototype.requireMock = function(currPath, moduleName) {
   if (manualMockResource) {
     var moduleObj = {
       exports: {},
-      __filename: modulePath
+      __filename: modulePath,
     };
     this._execModule(moduleObj);
     this._mockRegistry[modulePath] = moduleObj.exports;
@@ -906,7 +906,7 @@ Loader.prototype.requireModule = function(currPath, moduleName,
     // be satisfied.
     moduleObj = {
       __filename: modulePath,
-      exports: {}
+      exports: {},
     };
 
     if (!bypassRegistryCache) {
@@ -919,7 +919,7 @@ Loader.prototype.requireModule = function(currPath, moduleName,
         modulePath,
         'utf8'
       ));
-    } else if(path.extname(modulePath) === '.node') {
+    } else if (path.extname(modulePath) === '.node') {
       // Just do a require if it is a native node module
       moduleObj.exports = require(modulePath);
     } else {
@@ -939,7 +939,7 @@ Loader.prototype.requireModule = function(currPath, moduleName,
  */
 Loader.prototype._resolveStubModuleName = function(moduleName) {
   var nameMapper = this._mappedModuleNames;
-  for (let mappedModuleName in nameMapper) {
+  for (const mappedModuleName in nameMapper) {
     var regex = nameMapper[mappedModuleName];
     if (regex.test(moduleName)) {
       return mappedModuleName;
@@ -966,7 +966,7 @@ Loader.prototype.requireModuleOrMock = function(currPath, moduleName) {
 };
 
 Loader.prototype.getJestRuntime = function(dir) {
-    return this._builtInModules['jest-runtime'](dir).exports;
+  return this._builtInModules['jest-runtime'](dir).exports;
 };
 
 /**
@@ -1085,8 +1085,8 @@ Loader.prototype.resetModuleRegistry = function() {
 
           useRealTimers: () => {
             this._environment.fakeTimers.useRealTimers();
-          }
-        }
+          },
+        },
       };
 
       // This is a pretty common API to use in many tests, so this is just a
@@ -1101,8 +1101,8 @@ Loader.prototype.resetModuleRegistry = function() {
     'node-haste': () => ({
       exports: {
         // Do not use this API -- it is deprecated and will go away very soon!
-        getResourceMap: () => this._resourceMap
-      }
+        getResourceMap: () => this._resourceMap,
+      },
     }),
 
     // This is a legacy API that will soon be deprecated.
@@ -1116,7 +1116,7 @@ Loader.prototype.resetModuleRegistry = function() {
             currPath,
             'jest-runtime'
           ).genMockFn(),
-        }
+        },
       };
       mocks.exports.getMockFn = mocks.exports.getMockFunction;
       return mocks;
@@ -1221,11 +1221,11 @@ Loader.prototype.resetModuleRegistry = function() {
             this._currentlyExecutingModulePath,
             moduleName,
             true // yay boolean args!
-          )
-        }
+          ),
+        },
       };
       return mockModules;
-    }
+    },
   };
 };
 

--- a/src/HasteModuleLoader/__tests__/HasteModuleLoader-NODE_PATH-test.js
+++ b/src/HasteModuleLoader/__tests__/HasteModuleLoader-NODE_PATH-test.js
@@ -20,7 +20,7 @@ describe('HasteModuleLoader', function() {
 
   var CONFIG = utils.normalizeConfig({
     name: 'HasteModuleLoader-tests',
-    rootDir: path.resolve(__dirname, 'test_root')
+    rootDir: path.resolve(__dirname, 'test_root'),
   });
 
   function buildLoader() {
@@ -69,12 +69,15 @@ describe('HasteModuleLoader', function() {
     initHasteModuleLoader(nodePath);
     return buildLoader().then(function(loader) {
       try {
-         var exports = loader.requireModuleOrMock(null,
-             'RegularModuleInNodePath');
-         expect(exports).toBeUndefined();
+        var exports = loader.requireModuleOrMock(
+          null,
+          'RegularModuleInNodePath'
+        );
+        expect(exports).toBeUndefined();
       } catch (e) {
         expect(
-          (e.message.indexOf('Cannot find module'))).toBeGreaterThan(-1);
+          (e.message.indexOf('Cannot find module'))
+        ).toBeGreaterThan(-1);
       }
     });
   });

--- a/src/HasteModuleLoader/__tests__/HasteModuleLoader-currentTestPath-test.js
+++ b/src/HasteModuleLoader/__tests__/HasteModuleLoader-currentTestPath-test.js
@@ -10,9 +10,9 @@
 jest.autoMockOff();
 
 describe('nodeHasteModuleLoader', function() {
-    describe('currentTestPath', function() {
-        it('makes the current test path available', function() {
-            expect(jest.currentTestPath()).toMatch(/currentTestPath-test/);
-        });
+  describe('currentTestPath', function() {
+    it('makes the current test path available', function() {
+      expect(jest.currentTestPath()).toMatch(/currentTestPath-test/);
     });
+  });
 });

--- a/src/HasteModuleLoader/__tests__/HasteModuleLoader-genMockFromModule-test.js
+++ b/src/HasteModuleLoader/__tests__/HasteModuleLoader-genMockFromModule-test.js
@@ -20,7 +20,7 @@ describe('nodeHasteModuleLoader', function() {
 
   var CONFIG = utils.normalizeConfig({
     name: 'nodeHasteModuleLoader-tests',
-    rootDir: path.resolve(__dirname, 'test_root')
+    rootDir: path.resolve(__dirname, 'test_root'),
   });
 
   function buildLoader() {
@@ -43,21 +43,28 @@ describe('nodeHasteModuleLoader', function() {
   });
 
   describe('genMockFromModule', function() {
-    pit('does not cause side effects in the rest of the module system when ' +
-        'generating a mock', function() {
-      return buildLoader().then(function(loader) {
-        var testRequire = loader.requireModule.bind(loader, __filename);
+    pit(
+      'does not cause side effects in the rest of the module system when ' +
+      'generating a mock',
+      function() {
+        return buildLoader().then(function(loader) {
+          var testRequire = loader.requireModule.bind(loader, __filename);
 
-        var regularModule = testRequire('RegularModule');
-        var origModuleStateValue = regularModule.getModuleStateValue();
+          var regularModule = testRequire('RegularModule');
+          var origModuleStateValue = regularModule.getModuleStateValue();
 
-        testRequire('jest-runtime').dontMock('RegularModule');
+          testRequire('jest-runtime').dontMock('RegularModule');
 
-        // Generate a mock for a module with side effects
-        testRequire('jest-runtime').genMockFromModule('ModuleWithSideEffects');
+          // Generate a mock for a module with side effects
+          testRequire('jest-runtime').genMockFromModule(
+            'ModuleWithSideEffects'
+          );
 
-        expect(regularModule.getModuleStateValue()).toBe(origModuleStateValue);
-      });
-    });
+          expect(regularModule.getModuleStateValue()).toBe(
+            origModuleStateValue
+          );
+        });
+      }
+    );
   });
 });

--- a/src/HasteModuleLoader/__tests__/HasteModuleLoader-hasDependency-test.js
+++ b/src/HasteModuleLoader/__tests__/HasteModuleLoader-hasDependency-test.js
@@ -25,7 +25,7 @@ describe('nodeHasteModuleLoader', function() {
         return undefined;
       }
       return resources[name];
-    }
+    },
   };
 
   function _generateResource(name, deps) {
@@ -35,7 +35,7 @@ describe('nodeHasteModuleLoader', function() {
       id: name,
       _requiredModuleMap: deps.reduce(function(prev, next) {
         return prev[next] = true;
-      }, {})
+      }, {}),
     };
     if (deps.length) {
       resource.requiredModules = deps;

--- a/src/HasteModuleLoader/__tests__/HasteModuleLoader-requireMock-test.js
+++ b/src/HasteModuleLoader/__tests__/HasteModuleLoader-requireMock-test.js
@@ -20,7 +20,7 @@ describe('HasteModuleLoader', function() {
 
   var CONFIG = utils.normalizeConfig({
     name: 'HasteModuleLoader-tests',
-    rootDir: path.resolve(__dirname, 'test_root')
+    rootDir: path.resolve(__dirname, 'test_root'),
   });
 
   function buildLoader() {

--- a/src/HasteModuleLoader/__tests__/HasteModuleLoader-requireModule-test.js
+++ b/src/HasteModuleLoader/__tests__/HasteModuleLoader-requireModule-test.js
@@ -20,7 +20,7 @@ describe('HasteModuleLoader', function() {
 
   var CONFIG = utils.normalizeConfig({
     name: 'HasteModuleLoader-tests',
-    rootDir: path.join(__dirname, 'test_root')
+    rootDir: path.join(__dirname, 'test_root'),
   });
 
   function buildLoader() {
@@ -171,16 +171,19 @@ describe('HasteModuleLoader', function() {
        * See the 'overrides real modules with manual mock when one exists' test
        * for more info on why I want to kill this feature.
        */
-      pit('doesnt override real modules with manual mocks when explicitly ' +
-          'marked with .dontMock()', function() {
-        return buildLoader().then(function(loader) {
-          loader.requireModule(__filename, 'jest-runtime')
-            .dontMock('ManuallyMocked');
+      pit(
+        'doesnt override real modules with manual mocks when explicitly ' +
+          'marked with .dontMock()',
+          function() {
+            return buildLoader().then(function(loader) {
+              loader.requireModule(__filename, 'jest-runtime')
+              .dontMock('ManuallyMocked');
 
-          var exports = loader.requireModule(__filename, 'ManuallyMocked');
-          expect(exports.isManualMockModule).toBe(false);
-        });
-      });
+              var exports = loader.requireModule(__filename, 'ManuallyMocked');
+              expect(exports.isManualMockModule).toBe(false);
+            });
+          }
+      );
 
       /**
        * This test is only in this section because it seems sketchy to be able
@@ -188,43 +191,47 @@ describe('HasteModuleLoader', function() {
        * more investigation to understand the reasoning behind this before I
        * declare it unnecessary and condemn it.
        */
-      pit('doesnt read from the module registry when bypassModuleRegistry is ' +
-          'set', function() {
-        return buildLoader().then(function(loader) {
-          var registryExports = loader.requireModule(
-            __filename,
-            'RegularModule'
-          );
-          registryExports.setModuleStateValue('registry');
+      pit(
+        'doesnt read from the module registry when bypassModuleRegistry is set',
+        function() {
+          return buildLoader().then(function(loader) {
+            var registryExports = loader.requireModule(
+              __filename,
+              'RegularModule'
+            );
+            registryExports.setModuleStateValue('registry');
 
-          var bypassedExports = loader.requireModule(
-            __filename,
-            'RegularModule',
-            true
-          );
-          expect(bypassedExports.getModuleStateValue()).not.toBe('registry');
-        });
-      });
+            var bypassedExports = loader.requireModule(
+              __filename,
+              'RegularModule',
+              true
+            );
+            expect(bypassedExports.getModuleStateValue()).not.toBe('registry');
+          });
+        }
+      );
 
-      pit('doesnt write to the module registry when bypassModuleRegistry is ' +
-          'set', function() {
-        return buildLoader().then(function(loader) {
-          var registryExports = loader.requireModule(
-            __filename,
-            'RegularModule'
-          );
-          registryExports.setModuleStateValue('registry');
+      pit(
+        'doesnt write to the module registry when bypassModuleRegistry is set',
+        function() {
+          return buildLoader().then(function(loader) {
+            var registryExports = loader.requireModule(
+              __filename,
+              'RegularModule'
+            );
+            registryExports.setModuleStateValue('registry');
 
-          var bypassedExports = loader.requireModule(
-            __filename,
-            'RegularModule',
-            true
-          );
-          bypassedExports.setModuleStateValue('bypassed');
+            var bypassedExports = loader.requireModule(
+              __filename,
+              'RegularModule',
+              true
+            );
+            bypassedExports.setModuleStateValue('bypassed');
 
-          expect(registryExports.getModuleStateValue()).toBe('registry');
-        });
-      });
+            expect(registryExports.getModuleStateValue()).toBe('registry');
+          });
+        }
+      );
     });
   });
 });

--- a/src/HasteModuleLoader/__tests__/HasteModuleLoader-requireModuleOrMock-test.js
+++ b/src/HasteModuleLoader/__tests__/HasteModuleLoader-requireModuleOrMock-test.js
@@ -63,15 +63,18 @@ describe('HasteModuleLoader', function() {
       });
     });
 
-    pit('doesnt mock modules when explicitly dontMock()ed via a different ' +
-        'denormalized module name', function() {
-      return buildLoader().then(function(loader) {
-        loader.requireModuleOrMock(__filename, 'jest-runtime')
+    pit(
+      'doesnt mock modules when explicitly dontMock()ed via a different ' +
+      'denormalized module name',
+      function() {
+        return buildLoader().then(function(loader) {
+          loader.requireModuleOrMock(__filename, 'jest-runtime')
           .dontMock('./test_root/RegularModule');
-        var exports = loader.requireModuleOrMock(__filename, 'RegularModule');
-        expect(exports.isRealModule).toBe(true);
-      });
-    });
+          var exports = loader.requireModuleOrMock(__filename, 'RegularModule');
+          expect(exports.isRealModule).toBe(true);
+        });
+      }
+    );
 
     pit('doesnt mock modules when autoMockOff() has been called', function() {
       return buildLoader().then(function(loader) {
@@ -88,14 +91,20 @@ describe('HasteModuleLoader', function() {
       });
     });
 
-    pit('does not use manual mock when automocking is off and a real ' +
-        'module is available', function() {
-      return buildLoader().then(function(loader) {
-        loader.requireModuleOrMock(__filename, 'jest-runtime').autoMockOff();
-        var exports = loader.requireModuleOrMock(__filename, 'ManuallyMocked');
-        expect(exports.isManualMockModule).toBe(false);
-      });
-    });
+    pit(
+      'does not use manual mock when automocking is off and a real module is ' +
+      'available',
+      function() {
+        return buildLoader().then(function(loader) {
+          loader.requireModuleOrMock(__filename, 'jest-runtime').autoMockOff();
+          var exports = loader.requireModuleOrMock(
+            __filename,
+            'ManuallyMocked'
+          );
+          expect(exports.isManualMockModule).toBe(false);
+        });
+      }
+    );
 
     pit('resolves mapped module names and unmocks them by default', function() {
       return buildLoader().then(function(loader) {

--- a/src/IstanbulTestReporter.js
+++ b/src/IstanbulTestReporter.js
@@ -19,7 +19,7 @@ class IstanbulTestReporter extends DefaultTestReporter {
 
     if (config.collectCoverage) {
       reporter.addAll(config.coverageReporters);
-      reporter.write(collector, true, function () {
+      reporter.write(collector, true, function() {
         console.log('All reports generated');
       });
     }

--- a/src/TestRunner.js
+++ b/src/TestRunner.js
@@ -54,7 +54,7 @@ var DEFAULT_OPTIONS = {
    * Passing --debug off to child processes can screw with socket connections
    * of the parent process.
    */
-  nodeArgv: process.execArgv.filter(arg => arg !== '--debug')
+  nodeArgv: process.execArgv.filter(arg => arg !== '--debug'),
 };
 
 var HIDDEN_FILE_RE = /\/\.[^\/]*$/;
@@ -142,7 +142,7 @@ class TestRunner {
       this._configDeps = {
         ModuleLoader: require(config.moduleLoader),
         testEnvironment: require(config.testEnvironment),
-        testRunner: require(config.testRunner).bind(null)
+        testRunner: require(config.testRunner).bind(null),
       };
     }
     return this._configDeps;
@@ -374,7 +374,7 @@ class TestRunner {
             require: moduleLoader.constructBoundRequire(
               config.setupEnvScriptFile
             ),
-            jest: moduleLoader.getJestRuntime(config.setupEnvScriptFile)
+            jest: moduleLoader.getJestRuntime(config.setupEnvScriptFile),
           }
         );
       }
@@ -509,7 +509,7 @@ class TestRunner {
       numPassedTests: 0,
       numFailedTests: 0,
       testResults: [],
-      postSuiteHeaders: []
+      postSuiteHeaders: [],
     };
 
     reporter.onRunStart && reporter.onRunStart(config, aggregatedResults);
@@ -593,7 +593,7 @@ class TestRunner {
       // with loading/serialization of the resourcemap (which I've seen
       // happen).
       maxRetries: 2,
-      maxConcurrentWorkers: this._opts.maxWorkers
+      maxConcurrentWorkers: this._opts.maxWorkers,
     }, TEST_WORKER_PATH);
 
     var runTest = promisify(farm);

--- a/src/TestWorker.js
+++ b/src/TestWorker.js
@@ -22,7 +22,7 @@ var testRunner;
 module.exports = function(data, callback) {
   if (!testRunner) {
     testRunner = new TestRunner(data.config, {
-      useCachedModuleLoaderResourceMap: true
+      useCachedModuleLoaderResourceMap: true,
     });
 
     // Start require()ing config dependencies now.

--- a/src/__tests__/TestRunner-fs-test.js
+++ b/src/__tests__/TestRunner-fs-test.js
@@ -24,7 +24,7 @@ describe('TestRunner-fs', function() {
         testDirectoryName: '__testtests__',
       }));
       return runner.promiseTestPathsMatching(/.*/).then(function(paths) {
-        var relPaths = paths.map(function (absPath) {
+        var relPaths = paths.map(function(absPath) {
           return path.relative(rootDir, absPath);
         });
         expect(relPaths).toEqual([path.normalize('__testtests__/test.js')]);
@@ -39,7 +39,7 @@ describe('TestRunner-fs', function() {
         testFileExtensions: ['jsx'],
       }));
       return runner.promiseTestPathsMatching(/.*/).then(function(paths) {
-        var relPaths = paths.map(function (absPath) {
+        var relPaths = paths.map(function(absPath) {
           return path.relative(rootDir, absPath);
         });
         expect(relPaths).toEqual([path.normalize('__testtests__/test.jsx')]);
@@ -54,7 +54,7 @@ describe('TestRunner-fs', function() {
         testFileExtensions: ['foobar'],
       }));
       return runner.promiseTestPathsMatching(/.*/).then(function(paths) {
-        var relPaths = paths.map(function (absPath) {
+        var relPaths = paths.map(function(absPath) {
           return path.relative(rootDir, absPath);
         });
         expect(relPaths).toEqual([path.normalize('__testtests__/test.foobar')]);
@@ -69,7 +69,7 @@ describe('TestRunner-fs', function() {
         testFileExtensions: ['js', 'jsx'],
       }));
       return runner.promiseTestPathsMatching(/.*/).then(function(paths) {
-        var relPaths = paths.map(function (absPath) {
+        var relPaths = paths.map(function(absPath) {
           return path.relative(rootDir, absPath);
         });
         expect(relPaths.sort()).toEqual([

--- a/src/__tests__/TestRunner-test.js
+++ b/src/__tests__/TestRunner-test.js
@@ -24,7 +24,7 @@ describe('TestRunner', function() {
       utils = require('../lib/utils');
       runner = new TestRunner(utils.normalizeConfig({
         rootDir: '.',
-        testPathDirs: []
+        testPathDirs: [],
       }));
     });
 
@@ -73,7 +73,7 @@ describe('TestRunner', function() {
       utils = require('../lib/utils');
       runner = new TestRunner(utils.normalizeConfig({
         rootDir: '.',
-        testPathDirs: []
+        testPathDirs: [],
       }));
 
       fakeDepsFromPath = {};
@@ -81,7 +81,7 @@ describe('TestRunner', function() {
         return Promise.resolve({
           getDependentsFromPath: function(modulePath) {
             return fakeDepsFromPath[modulePath] || [];
-          }
+          },
         });
       };
     });
@@ -146,7 +146,7 @@ describe('TestRunner', function() {
         .then(function(relatedTests) {
           expect(relatedTests).toEqual([
             dependentTestPath1,
-            dependentTestPath2
+            dependentTestPath2,
           ]);
         });
     });
@@ -161,7 +161,7 @@ describe('TestRunner', function() {
         [indirectDependentModulePath];
       fakeDepsFromPath[indirectDependentModulePath] = [
         directDependentModulePath,
-        dependentTestPath
+        dependentTestPath,
       ];
 
       // Mock out existsSync to return true, since our test path isn't real

--- a/src/coverageTemplate.js
+++ b/src/coverageTemplate.js
@@ -1,4 +1,3 @@
-
 // Instrumentation Header
 {
     var <%= instrumented.names.statement %>;

--- a/src/jasmineTestRunner/JasmineReporter.js
+++ b/src/jasmineTestRunner/JasmineReporter.js
@@ -17,7 +17,7 @@ var DIFFABLE_MATCHERS = {
   toBe: true,
   toNotBe: true,
   toEqual: true,
-  toNotEqual: true
+  toNotEqual: true,
 };
 var LINEBREAK_REGEX = /[\r\n]/;
 
@@ -56,7 +56,7 @@ JasmineReporter.prototype.reportRunnerResults = function(runner) {
   this._resolve({
     numFailingTests: numFailingTests,
     numPassingTests: numPassingTests,
-    testResults: testResults
+    testResults: testResults,
   });
 };
 
@@ -69,7 +69,7 @@ JasmineReporter.prototype.log = function(str) {
 };
 
 JasmineReporter.prototype._extractSuiteResults =
-function (container, ancestorTitles, suite) {
+function(container, ancestorTitles, suite) {
   ancestorTitles = ancestorTitles.concat([suite.description]);
 
   suite.specs().forEach(
@@ -81,12 +81,12 @@ function (container, ancestorTitles, suite) {
 };
 
 JasmineReporter.prototype._extractSpecResults =
-function (container, ancestorTitles, spec) {
+function(container, ancestorTitles, spec) {
   var results = {
     title: 'it ' + spec.description,
     ancestorTitles: ancestorTitles,
     failureMessages: [],
-    numPassingAsserts: 0
+    numPassingAsserts: 0,
   };
 
   spec.results().getItems().forEach(function(result) {
@@ -156,7 +156,7 @@ function (container, ancestorTitles, spec) {
   container.push(results);
 };
 
-JasmineReporter.prototype._highlightDifferences = function (a, b) {
+JasmineReporter.prototype._highlightDifferences = function(a, b) {
   var differ;
   if (a.match(LINEBREAK_REGEX) || b.match(LINEBREAK_REGEX)) {
     // `diff` uses the Myers LCS diff algorithm which runs in O(n+d^2) time

--- a/src/jasmineTestRunner/jasmineTestRunner.js
+++ b/src/jasmineTestRunner/jasmineTestRunner.js
@@ -264,7 +264,7 @@ function jasmineTestRunner(config, environment, moduleLoader, testPath) {
         return calls.some(function(call) {
           return this.env.equals_(call, args);
         }, this);
-      }
+      },
     });
 
     if (!config.persistModuleRegistryBetweenSpecs) {
@@ -277,7 +277,7 @@ function jasmineTestRunner(config, environment, moduleLoader, testPath) {
 
   var jasmineReporter = new JasmineReporter({
     noHighlight: config.noHighlight,
-    noStackTrace: config.noStackTrace
+    noStackTrace: config.noStackTrace,
   });
   jasmine.getEnv().addReporter(jasmineReporter);
 

--- a/src/jest.js
+++ b/src/jest.js
@@ -144,7 +144,7 @@ function _promiseRawConfig(argv, packageRoot) {
     name: packageRoot.replace(/[/\\]/g, '_'),
     rootDir: packageRoot,
     testPathDirs: [packageRoot],
-    testPathIgnorePatterns: ['/node_modules/.+']
+    testPathIgnorePatterns: ['/node_modules/.+'],
   }));
 }
 
@@ -153,11 +153,13 @@ function _promiseOnlyChangedTestPaths(testRunner, config) {
   return Promise.all(testPathDirsAreGit)
     .then(function(results) {
       if (!results.every(function(result) { return result; })) {
+        /* eslint-disable no-throw-literal */
         throw (
           'It appears that one of your testPathDirs does not exist ' +
           'with in a git repository. Currently --onlyChanged only works ' +
           'with git projects.\n'
         );
+        /* eslint-enable no-throw-literal */
       }
       return Promise.all(config.testPathDirs.map(_findChangedFiles));
     })

--- a/src/lib/FakeTimers.js
+++ b/src/lib/FakeTimers.js
@@ -23,7 +23,7 @@ function FakeTimers(global, maxLoops) {
     setTimeout: global.setTimeout,
     clearTimeout: global.clearTimeout,
     setInterval: global.setInterval,
-    clearInterval: global.clearInterval
+    clearInterval: global.clearInterval,
   };
 
   this._fakeTimerAPIs = {
@@ -38,7 +38,7 @@ function FakeTimers(global, maxLoops) {
     ),
     clearInterval: mocks.getMockFn().mockImpl(
       this._fakeClearTimer.bind(this)
-    )
+    ),
   };
 
   // If there's a process.nextTick on the global, mock it out
@@ -337,7 +337,7 @@ FakeTimers.prototype._fakeNextTick = function(callback) {
     uuid: uuid,
     callback: function() {
       return callback.apply(null, args);
-    }
+    },
   });
 
   var cancelledTicks = this._cancelledTicks;
@@ -362,7 +362,7 @@ FakeTimers.prototype._fakeSetImmediate = function(callback) {
     uuid: uuid,
     callback: function() {
       return callback.apply(null, args);
-    }
+    },
   });
 
   var cancelledImmediates = this._cancelledImmediates;
@@ -395,7 +395,7 @@ FakeTimers.prototype._fakeSetInterval = function(callback, intervalDelay) {
       return callback.apply(null, args);
     },
     expiry: this._now + intervalDelay,
-    interval: intervalDelay
+    interval: intervalDelay,
   };
 
   return uuid;
@@ -419,7 +419,7 @@ FakeTimers.prototype._fakeSetTimeout = function(callback, delay)  {
       return callback.apply(null, args);
     },
     expiry: this._now + delay,
-    interval: null
+    interval: null,
   };
 
   return uuid;

--- a/src/lib/__tests__/FakeTimers-test.js
+++ b/src/lib/__tests__/FakeTimers-test.js
@@ -17,6 +17,7 @@ describe('FakeTimers', function() {
   });
 
   describe('construction', function() {
+    /* eslint-disable no-new */
     /* jshint nonew:false */
     it('installs setTimeout mock', function() {
       var global = {};
@@ -46,8 +47,8 @@ describe('FakeTimers', function() {
       var origNextTick = function() {};
       var global = {
         process: {
-          nextTick: origNextTick
-        }
+          nextTick: origNextTick,
+        },
       };
       new FakeTimers(global);
       expect(global.process.nextTick).not.toBe(origNextTick);
@@ -62,7 +63,7 @@ describe('FakeTimers', function() {
     it('mocks setImmediate if it exists on global', function() {
       var origSetImmediate = function() {};
       var global = {
-        setImmediate: origSetImmediate
+        setImmediate: origSetImmediate,
       };
       new FakeTimers(global);
       expect(global.setImmediate).not.toBe(origSetImmediate);
@@ -70,10 +71,10 @@ describe('FakeTimers', function() {
 
     it('mocks clearImmediate if setImmediate is on global', function() {
       var origSetImmediate = function() {};
-      var origClearImmediate = function(){};
+      var origClearImmediate = function() {};
       var global = {
         setImmediate: origSetImmediate,
-        clearImmediate: origClearImmediate
+        clearImmediate: origClearImmediate,
       };
       new FakeTimers(global);
       expect(global.clearImmediate).not.toBe(origClearImmediate);
@@ -96,8 +97,8 @@ describe('FakeTimers', function() {
     it('runs all ticks, in order', function() {
       var global = {
         process: {
-          nextTick: function() {}
-        }
+          nextTick: function() {},
+        },
       };
 
       var fakeTimers = new FakeTimers(global);
@@ -127,8 +128,8 @@ describe('FakeTimers', function() {
       var nextTick = jest.genMockFn();
       var global = {
         process: {
-          nextTick: nextTick
-        }
+          nextTick: nextTick,
+        },
       };
 
       var fakeTimers = new FakeTimers(global);
@@ -140,8 +141,8 @@ describe('FakeTimers', function() {
     it('only runs a scheduled callback once', function() {
       var global = {
         process: {
-          nextTick: function() {}
-        }
+          nextTick: function() {},
+        },
       };
 
       var fakeTimers = new FakeTimers(global);
@@ -162,8 +163,8 @@ describe('FakeTimers', function() {
 
       var global = {
         process: {
-          nextTick: nativeNextTick
-        }
+          nextTick: nativeNextTick,
+        },
       };
 
       var fakeTimers = new FakeTimers(global);
@@ -184,7 +185,7 @@ describe('FakeTimers', function() {
       var nativeSetImmediate = jest.genMockFn();
 
       var global = {
-        setImmediate: nativeSetImmediate
+        setImmediate: nativeSetImmediate,
       };
 
       var fakeTimers = new FakeTimers(global);
@@ -205,8 +206,8 @@ describe('FakeTimers', function() {
 
       var global = {
         process: {
-          nextTick: nativeNextTick
-        }
+          nextTick: nativeNextTick,
+        },
       };
 
       var fakeTimers = new FakeTimers(global);
@@ -227,7 +228,7 @@ describe('FakeTimers', function() {
       var nativeSetImmediate = jest.genMockFn();
 
       var global = {
-        setImmediate: nativeSetImmediate
+        setImmediate: nativeSetImmediate,
       };
 
       var fakeTimers = new FakeTimers(global);
@@ -248,7 +249,7 @@ describe('FakeTimers', function() {
       var nativeSetImmediate = jest.genMockFn();
 
       var global = {
-        setImmediate: nativeSetImmediate
+        setImmediate: nativeSetImmediate,
       };
 
       var fakeTimers = new FakeTimers(global);
@@ -269,8 +270,8 @@ describe('FakeTimers', function() {
     it('throws before allowing infinite recursion', function() {
       var global = {
         process: {
-          nextTick: function() {}
-        }
+          nextTick: function() {},
+        },
       };
 
       var fakeTimers = new FakeTimers(global, 100);
@@ -322,7 +323,7 @@ describe('FakeTimers', function() {
     it('does nothing when no timers have been scheduled', function() {
       var nativeSetTimeout = jest.genMockFn();
       var global = {
-        setTimeout: nativeSetTimeout
+        setTimeout: nativeSetTimeout,
       };
 
       var fakeTimers = new FakeTimers(global);
@@ -353,7 +354,7 @@ describe('FakeTimers', function() {
 
       fakeTimers.runAllTimers();
       expect(fn.mock.calls).toEqual([
-        ['mockArg1', 'mockArg2']
+        ['mockArg1', 'mockArg2'],
       ]);
     });
 
@@ -361,7 +362,7 @@ describe('FakeTimers', function() {
       var nativeSetTimeout = jest.genMockFn();
 
       var global = {
-        setTimeout: nativeSetTimeout
+        setTimeout: nativeSetTimeout,
       };
 
       var fakeTimers = new FakeTimers(global);
@@ -491,8 +492,8 @@ describe('FakeTimers', function() {
       var global = {
         setImmediate: function() {},
         process: {
-          nextTick: function() {}
-        }
+          nextTick: function() {},
+        },
       };
       var fakeTimers = new FakeTimers(global);
 
@@ -527,7 +528,7 @@ describe('FakeTimers', function() {
       var nativeSetImmediate = jest.genMockFn();
 
       var global = {
-        setImmediate: nativeSetImmediate
+        setImmediate: nativeSetImmediate,
       };
 
       var fakeTimers = new FakeTimers(global);
@@ -569,7 +570,7 @@ describe('FakeTimers', function() {
 
         'mock2',
         'mock1',
-        'mock3'
+        'mock3',
       ]);
     });
 
@@ -599,7 +600,7 @@ describe('FakeTimers', function() {
         clearInterval: nativeClearInterval,
         clearTimeout: nativeClearTimeout,
         setInterval: nativeSetInterval,
-        setTimeout: nativeSetTimeout
+        setTimeout: nativeSetTimeout,
       };
       var fakeTimers = new FakeTimers(global);
 
@@ -643,7 +644,7 @@ describe('FakeTimers', function() {
         clearInterval: nativeClearInterval,
         clearTimeout: nativeClearTimeout,
         setInterval: nativeSetInterval,
-        setTimeout: nativeSetTimeout
+        setTimeout: nativeSetTimeout,
       };
       var fakeTimers = new FakeTimers(global);
 
@@ -723,7 +724,7 @@ describe('FakeTimers', function() {
         setTimeout: nativeSetTimeout,
         setInterval: nativeSetInterval,
         clearTimeout: nativeClearTimeout,
-        clearInterval: nativeClearInterval
+        clearInterval: nativeClearInterval,
       };
       var fakeTimers = new FakeTimers(global);
 
@@ -746,7 +747,7 @@ describe('FakeTimers', function() {
       var nativeProcessNextTick = jest.genMockFn();
 
       var global = {
-        process: {nextTick: nativeProcessNextTick}
+        process: {nextTick: nativeProcessNextTick},
       };
       var fakeTimers = new FakeTimers(global);
 
@@ -765,7 +766,7 @@ describe('FakeTimers', function() {
 
       var global = {
         setImmediate: nativeSetImmediate,
-        clearImmediate: nativeClearImmediate
+        clearImmediate: nativeClearImmediate,
       };
       var fakeTimers = new FakeTimers(global);
 
@@ -792,7 +793,7 @@ describe('FakeTimers', function() {
         setTimeout: nativeSetTimeout,
         setInterval: nativeSetInterval,
         clearTimeout: nativeClearTimeout,
-        clearInterval: nativeClearInterval
+        clearInterval: nativeClearInterval,
       };
       var fakeTimers = new FakeTimers(global);
       fakeTimers.useRealTimers();
@@ -816,7 +817,7 @@ describe('FakeTimers', function() {
       var nativeProcessNextTick = jest.genMockFn();
 
       var global = {
-        process: {nextTick: nativeProcessNextTick}
+        process: {nextTick: nativeProcessNextTick},
       };
       var fakeTimers = new FakeTimers(global);
       fakeTimers.useRealTimers();
@@ -836,7 +837,7 @@ describe('FakeTimers', function() {
 
       var global = {
         setImmediate: nativeSetImmediate,
-        clearImmediate: nativeClearImmediate
+        clearImmediate: nativeClearImmediate,
       };
       var fakeTimers = new FakeTimers(global);
       fakeTimers.useRealTimers();

--- a/src/lib/__tests__/moduleMocker-test.js
+++ b/src/lib/__tests__/moduleMocker-test.js
@@ -18,7 +18,7 @@ describe('moduleMocker', function() {
 
   describe('getMetadata', function() {
     it('returns the function `name` property', function() {
-      function x(){}
+      function x() {}
       var metadata = moduleMocker.getMetadata(x);
       expect(x.name).toBe('x');
       expect(metadata.name).toBe('x');
@@ -27,7 +27,7 @@ describe('moduleMocker', function() {
 
   describe('generateFromMetadata', function() {
     it('forwards the function name property', function() {
-      function foo(){}
+      function foo() {}
       var fooMock = moduleMocker.generateFromMetadata(
         moduleMocker.getMetadata(foo)
       );
@@ -57,11 +57,11 @@ describe('moduleMocker', function() {
     it('does not mock non-enumerable getters', function() {
       var foo = Object.defineProperties({}, {
         nonEnumMethod: {
-          value: function() {}
+          value: function() {},
         },
         nonEnumGetter: {
-          get: function() { throw 1; }
-        }
+          get: function() { throw new Error(); },
+        },
       });
       var fooMock = moduleMocker.generateFromMetadata(
         moduleMocker.getMetadata(foo)

--- a/src/lib/__tests__/promisify-test.js
+++ b/src/lib/__tests__/promisify-test.js
@@ -26,7 +26,7 @@ describe('promisify', () => {
     });
   });
 
-   pit('should resolve with args', () => {
+  pit('should resolve with args', () => {
     var foo = promisify((a, b, callback) => {
       callback(null, a + b);
     });
@@ -36,7 +36,7 @@ describe('promisify', () => {
     });
   });
 
-   pit('should reject with args', () => {
+  pit('should reject with args', () => {
     var foo = promisify((a, b, callback) => {
       callback(new Error('lol'));
     });

--- a/src/lib/__tests__/utils-normalizeConfig-test.js
+++ b/src/lib/__tests__/utils-normalizeConfig-test.js
@@ -23,7 +23,8 @@ describe('utils-normalizeConfig', function() {
   // expected strings for checking path patterns.
   function joinForPattern() {
     return Array.prototype.join.call(
-      arguments,utils.escapeStrForRegex(path.sep)
+      arguments, 
+      utils.escapeStrForRegex(path.sep)
     );
   }
 
@@ -41,7 +42,7 @@ describe('utils-normalizeConfig', function() {
     expect(function() {
       utils.normalizeConfig({
         rootDir: '/root/path/foo',
-        thisIsAnInvalidConfigKey: 'with a value even!'
+        thisIsAnInvalidConfigKey: 'with a value even!',
       });
     }).toThrow('Unknown config option: thisIsAnInvalidConfigKey');
   });
@@ -60,8 +61,8 @@ describe('utils-normalizeConfig', function() {
         rootDir: '/root/path/foo/',
         collectCoverageOnlyFrom: {
           'bar/baz': true,
-          'qux/quux/': true
-        }
+          'qux/quux/': true,
+        },
       }, '/root/path');
 
       var expected = {};
@@ -76,8 +77,8 @@ describe('utils-normalizeConfig', function() {
         rootDir: '/root/path/foo',
         collectCoverageOnlyFrom: {
           '/an/abs/path': true,
-          '/another/abs/path': true
-        }
+          '/another/abs/path': true,
+        },
       });
 
       var expected = {};
@@ -91,8 +92,8 @@ describe('utils-normalizeConfig', function() {
       var config = utils.normalizeConfig({
         rootDir: '/root/path/foo',
         collectCoverageOnlyFrom: {
-          '<rootDir>/bar/baz': true
-        }
+          '<rootDir>/bar/baz': true,
+        },
       });
 
       var expected = {};
@@ -108,12 +109,12 @@ describe('utils-normalizeConfig', function() {
         rootDir: '/root/path/foo',
         testPathDirs: [
           'bar/baz',
-          'qux/quux/'
-        ]
+          'qux/quux/',
+        ],
       }, '/root/path');
 
       expect(config.testPathDirs).toEqual([
-        expectedPathFooBar, expectedPathFooQux
+        expectedPathFooBar, expectedPathFooQux,
       ]);
     });
 
@@ -122,12 +123,12 @@ describe('utils-normalizeConfig', function() {
         rootDir: '/root/path/foo',
         testPathDirs: [
           '/an/abs/path',
-          '/another/abs/path'
-        ]
+          '/another/abs/path',
+        ],
       });
 
       expect(config.testPathDirs).toEqual([
-        expectedPathAbs, expectedPathAbsAnother
+        expectedPathAbs, expectedPathAbsAnother,
       ]);
     });
 
@@ -135,8 +136,8 @@ describe('utils-normalizeConfig', function() {
       var config = utils.normalizeConfig({
         rootDir: '/root/path/foo',
         testPathDirs: [
-          '<rootDir>/bar/baz'
-        ]
+          '<rootDir>/bar/baz',
+        ],
       });
 
       expect(config.testPathDirs).toEqual([expectedPathFooBar]);
@@ -147,7 +148,7 @@ describe('utils-normalizeConfig', function() {
     it('normalizes the path according to rootDir', function() {
       var config = utils.normalizeConfig({
         rootDir: '/root/path/foo',
-        scriptPreprocessor: 'bar/baz'
+        scriptPreprocessor: 'bar/baz',
       }, '/root/path');
 
       expect(config.scriptPreprocessor).toEqual(expectedPathFooBar);
@@ -156,7 +157,7 @@ describe('utils-normalizeConfig', function() {
     it('does not change absolute paths', function() {
       var config = utils.normalizeConfig({
         rootDir: '/root/path/foo',
-        scriptPreprocessor: '/an/abs/path'
+        scriptPreprocessor: '/an/abs/path',
       });
 
       expect(config.scriptPreprocessor).toEqual(expectedPathAbs);
@@ -165,7 +166,7 @@ describe('utils-normalizeConfig', function() {
     it('substitutes <rootDir> tokens', function() {
       var config = utils.normalizeConfig({
         rootDir: '/root/path/foo',
-        scriptPreprocessor: '<rootDir>/bar/baz'
+        scriptPreprocessor: '<rootDir>/bar/baz',
       });
 
       expect(config.scriptPreprocessor).toEqual(expectedPathFooBar);
@@ -176,7 +177,7 @@ describe('utils-normalizeConfig', function() {
     it('normalizes the path according to rootDir', function() {
       var config = utils.normalizeConfig({
         rootDir: '/root/path/foo',
-        setupEnvScriptFile: 'bar/baz'
+        setupEnvScriptFile: 'bar/baz',
       }, '/root/path');
 
       expect(config.setupEnvScriptFile).toEqual(expectedPathFooBar);
@@ -185,7 +186,7 @@ describe('utils-normalizeConfig', function() {
     it('does not change absolute paths', function() {
       var config = utils.normalizeConfig({
         rootDir: '/root/path/foo',
-        setupEnvScriptFile: '/an/abs/path'
+        setupEnvScriptFile: '/an/abs/path',
       });
 
       expect(config.setupEnvScriptFile).toEqual(expectedPathAbs);
@@ -194,7 +195,7 @@ describe('utils-normalizeConfig', function() {
     it('substitutes <rootDir> tokens', function() {
       var config = utils.normalizeConfig({
         rootDir: '/root/path/foo',
-        setupEnvScriptFile: '<rootDir>/bar/baz'
+        setupEnvScriptFile: '<rootDir>/bar/baz',
       });
 
       expect(config.setupEnvScriptFile).toEqual(expectedPathFooBar);
@@ -205,7 +206,7 @@ describe('utils-normalizeConfig', function() {
     it('normalizes the path according to rootDir', function() {
       var config = utils.normalizeConfig({
         rootDir: '/root/path/foo',
-        setupTestFrameworkScriptFile: 'bar/baz'
+        setupTestFrameworkScriptFile: 'bar/baz',
       }, '/root/path');
 
       expect(config.setupTestFrameworkScriptFile).toEqual(expectedPathFooBar);
@@ -214,7 +215,7 @@ describe('utils-normalizeConfig', function() {
     it('does not change absolute paths', function() {
       var config = utils.normalizeConfig({
         rootDir: '/root/path/foo',
-        setupTestFrameworkScriptFile: '/an/abs/path'
+        setupTestFrameworkScriptFile: '/an/abs/path',
       });
 
       expect(config.setupTestFrameworkScriptFile).toEqual(expectedPathAbs);
@@ -223,7 +224,7 @@ describe('utils-normalizeConfig', function() {
     it('substitutes <rootDir> tokens', function() {
       var config = utils.normalizeConfig({
         rootDir: '/root/path/foo',
-        setupTestFrameworkScriptFile: '<rootDir>/bar/baz'
+        setupTestFrameworkScriptFile: '<rootDir>/bar/baz',
       });
 
       expect(config.setupTestFrameworkScriptFile).toEqual(expectedPathFooBar);
@@ -238,13 +239,13 @@ describe('utils-normalizeConfig', function() {
         rootDir: '/root/path/foo',
         testPathIgnorePatterns: [
           'bar/baz',
-          'qux/quux'
-        ]
+          'qux/quux',
+        ],
       }, '/root/path');
 
       expect(config.testPathIgnorePatterns).toEqual([
-        joinForPattern('bar','baz'),
-        joinForPattern('qux','quux')
+        joinForPattern('bar', 'baz'),
+        joinForPattern('qux', 'quux'),
       ]);
     });
 
@@ -255,13 +256,13 @@ describe('utils-normalizeConfig', function() {
         rootDir: '/root/path/foo',
         testPathIgnorePatterns: [
           'bar/baz',
-          'qux/quux/'
-        ]
+          'qux/quux/',
+        ],
       });
 
       expect(config.testPathIgnorePatterns).toEqual([
-        joinForPattern('bar','baz'),
-        joinForPattern('qux','quux','')
+        joinForPattern('bar', 'baz'),
+        joinForPattern('qux', 'quux', ''),
       ]);
     });
 
@@ -270,13 +271,13 @@ describe('utils-normalizeConfig', function() {
         rootDir: '/root/path/foo',
         testPathIgnorePatterns: [
           'hasNoToken',
-          '<rootDir>/hasAToken'
-        ]
+          '<rootDir>/hasAToken',
+        ],
       });
 
       expect(config.testPathIgnorePatterns).toEqual([
         'hasNoToken',
-        joinForPattern('','root','path','foo','hasAToken')
+        joinForPattern('', 'root', 'path', 'foo', 'hasAToken'),
       ]);
     });
   });
@@ -289,13 +290,13 @@ describe('utils-normalizeConfig', function() {
         rootDir: '/root/path/foo',
         modulePathIgnorePatterns: [
           'bar/baz',
-          'qux/quux'
-        ]
+          'qux/quux',
+        ],
       }, '/root/path');
 
       expect(config.modulePathIgnorePatterns).toEqual([
-        joinForPattern('bar','baz'),
-        joinForPattern('qux','quux')
+        joinForPattern('bar', 'baz'),
+        joinForPattern('qux', 'quux'),
       ]);
     });
 
@@ -306,13 +307,13 @@ describe('utils-normalizeConfig', function() {
         rootDir: '/root/path/foo',
         modulePathIgnorePatterns: [
           'bar/baz',
-          'qux/quux/'
-        ]
+          'qux/quux/',
+        ],
       });
 
       expect(config.modulePathIgnorePatterns).toEqual([
-        joinForPattern('bar','baz'),
-        joinForPattern('qux','quux','')
+        joinForPattern('bar', 'baz'),
+        joinForPattern('qux', 'quux', ''),
       ]);
     });
 
@@ -321,13 +322,13 @@ describe('utils-normalizeConfig', function() {
         rootDir: '/root/path/foo',
         modulePathIgnorePatterns: [
           'hasNoToken',
-          '<rootDir>/hasAToken'
-        ]
+          '<rootDir>/hasAToken',
+        ],
       });
 
       expect(config.modulePathIgnorePatterns).toEqual([
         'hasNoToken',
-        joinForPattern('','root','path','foo','hasAToken')
+        joinForPattern('', 'root', 'path', 'foo', 'hasAToken'),
       ]);
     });
   });

--- a/src/lib/formatTestResults.js
+++ b/src/lib/formatTestResults.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
- 'use strict';
+'use strict';
 
 var utils = require('./utils');
 

--- a/src/lib/moduleMocker.js
+++ b/src/lib/moduleMocker.js
@@ -147,6 +147,7 @@ function createMockFunction(metadata, mockConstructor) {
     name = '$' + name;
   }
 
+  /* eslint-disable no-new-func */
   /* jshint evil:true */
   return new Function(
     'mockConstructor',
@@ -154,6 +155,8 @@ function createMockFunction(metadata, mockConstructor) {
       'return mockConstructor.apply(this,arguments);' +
     '}' + bindCall
   )(mockConstructor);
+  /* eslint-enable no-new-func */
+  /* jshint evil:false */
 }
 
 function makeComponent(metadata) {
@@ -183,7 +186,7 @@ function makeComponent(metadata) {
       metadata.members.prototype.members
     ) || {};
     const prototypeSlots = getSlots(prototype);
-    let mockConstructor = function() {
+    const mockConstructor = function() {
       instances.push(this);
       calls.push(Array.prototype.slice.call(arguments));
       if (this instanceof f) {
@@ -361,7 +364,7 @@ function getMetadata(component, _refs) {
           /* jshint eqeqeq:false */
           (type === 'object' && component[slot] != Object.prototype[slot])
         ) {
-          let slotMetadata = getMetadata(component[slot], refs);
+          const slotMetadata = getMetadata(component[slot], refs);
           if (slotMetadata) {
             if (!members) {
               members = {};
@@ -500,5 +503,5 @@ module.exports = {
   // Just a short-hand alias
   getMockFn() {
     return this.getMockFunction();
-  }
+  },
 };

--- a/src/lib/testLogger.js
+++ b/src/lib/testLogger.js
@@ -88,7 +88,7 @@ VerboseLogger.prototype.traverseTestResults = function(node, indentation) {
 VerboseLogger.prototype.printTestTitles = function(testTitles, indentation) {
   var prefixColor, statusPrefix;
 
-  for (var i = 0; i < testTitles.length; i++){
+  for (var i = 0; i < testTitles.length; i++) {
     if (testTitles[i].failureMessages.length === 0) {
       prefixColor = colors.GREEN;
       statusPrefix = this._config.noHighlight ? 'PASS - ' : '\u2713 ';
@@ -159,12 +159,12 @@ function _createTestNode(testResult, ancestorTitles, currentNode) {
     if (!currentNode.childNodes[ancestorTitles[0]]) {
       currentNode.childNodes[ancestorTitles[0]] = {
         testTitles: [],
-        childNodes: {}
+        childNodes: {},
       };
     }
     _createTestNode(
       testResult,
-      ancestorTitles.slice(1,ancestorTitles.length),
+      ancestorTitles.slice(1, ancestorTitles.length),
       currentNode.childNodes[ancestorTitles[0]]
     );
   }

--- a/src/lib/transform.js
+++ b/src/lib/transform.js
@@ -19,7 +19,7 @@ const createDirectory = path => {
   if (!fs.existsSync(path)) {
     try {
       fs.mkdirSync(path);
-    } catch(e) {
+    } catch (e) {
       if (e.code !== 'EEXIST') {
         throw e;
       }

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -13,7 +13,7 @@ var path = require('path');
 
 function replacePathSepForRegex(str) {
   if (path.sep === '\\') {
-    return str.replace(/(\/|\\)/g,'\\\\');
+    return str.replace(/(\/|\\)/g, '\\\\');
   }
   return str;
 }
@@ -22,7 +22,7 @@ var DEFAULT_CONFIG_VALUES = {
   bail: false,
   cacheDirectory: path.resolve(__dirname, '..', '..', '.haste_cache'),
   coverageCollector: require.resolve('../IstanbulCollector'),
-  coverageReporters: [ 'json', 'text', 'lcov', 'clover' ],
+  coverageReporters: ['json', 'text', 'lcov', 'clover'],
   globals: {},
   moduleFileExtensions: ['js', 'json'],
   moduleLoader: require.resolve('../HasteModuleLoader/HasteModuleLoader'),
@@ -218,7 +218,7 @@ function normalizeConfig(config) {
       case 'moduleNameMapper':
         value = Object.keys(config[key]).map(regex => [
           regex,
-          _replaceRootDirTags(config.rootDir, config[key][regex])
+          _replaceRootDirTags(config.rootDir, config[key][regex]),
         ]);
         break;
 
@@ -315,7 +315,7 @@ function _addDot(ext) {
 function uniqueStrings(set) {
   var newSet = [];
   var has = {};
-  set.forEach(function (item) {
+  set.forEach(function(item) {
     if (!has[item]) {
       has[item] = true;
       newSet.push(item);
@@ -411,7 +411,7 @@ function formatFailureMessage(testResult, config) {
   var rootPath = config.rootPath;
   var useColor = config.useColor;
 
-  var colorize = useColor ? colors.colorize : function (str) { return str; };
+  var colorize = useColor ? colors.colorize : function(str) { return str; };
   var ancestrySeparator = ' \u203A ';
   var descBullet = colorize('\u25cf ', colors.BOLD);
   var msgBullet = '  - ';
@@ -422,7 +422,7 @@ function formatFailureMessage(testResult, config) {
     return descBullet + colorize('Runtime Error', colors.BOLD) + '\n' + text;
   }
 
-  return testResult.testResults.filter(function (result) {
+  return testResult.testResults.filter(function(result) {
     return result.failureMessages.length !== 0;
   }).map(function(result) {
     var failureMessages = result.failureMessages.map(function(errorMsg) {
@@ -487,7 +487,7 @@ function deepCopy(obj) {
 var STACK_TRACE_LINE_IGNORE_RE = new RegExp([
   '^timers.js$',
   '^' + path.resolve(__dirname, '..', 'lib', 'moduleMocker.js'),
-  '^' + path.resolve(__dirname, '..', '..', 'vendor', 'jasmine')
+  '^' + path.resolve(__dirname, '..', '..', 'vendor', 'jasmine'),
 ].join('|'));
 
 exports.deepCopy = deepCopy;


### PR DESCRIPTION
This PR adds dependencies on `eslint` and related tools (namely `babel-eslint` and `fbjs-scripts`) and fixes any problems reported by a run of `eslint src`.