### PR TITLE
Fix handling of test suites that fail to run

### DIFF
--- a/src/DefaultTestReporter.js
+++ b/src/DefaultTestReporter.js
@@ -142,13 +142,14 @@ function (config, aggregatedResults) {
     );
   }
 
-  var pluralTestSuites =
-      aggregatedResults.numTotalTestSuites === 1 ?
-      'test suite' : 'test suites';
+  var numTestSuitesExecuted =
+    aggregatedResults.numTotalTestSuites -
+    aggregatedResults.numFailedToRunTestSuites;
 
   results += ' (' + numTotalTests + ' total in ' +
-    aggregatedResults.numTotalTestSuites + ' ' +
-    pluralTestSuites + ', run time ' + runTime + 's)';
+    numTestSuitesExecuted + ' ' +
+    'test suite' + (numTestSuitesExecuted === 1 ? '' : 's') +
+    ', run time ' + runTime + 's)';
 
   this.log(results);
 };

--- a/src/DefaultTestReporter.js
+++ b/src/DefaultTestReporter.js
@@ -135,7 +135,7 @@ function (config, aggregatedResults) {
   if (aggregatedResults.numFailedToRunTestSuites) {
     results += ', ';
     results += this._formatMsg(
-      aggregatedResults.numFailedToRunTestSuites + ' test suit' +
+      aggregatedResults.numFailedToRunTestSuites + ' test suite' +
         (aggregatedResults.numFailedToRunTestSuites === 1 ? '' : 's') +
         ' failed to run',
       colors.RED + colors.BOLD

--- a/src/DefaultTestReporter.js
+++ b/src/DefaultTestReporter.js
@@ -132,11 +132,11 @@ function (config, aggregatedResults) {
     colors.GREEN + colors.BOLD
   );
 
-  if (aggregatedResults.numFailedToRunTestSuites) {
+  if (aggregatedResults.numRuntimeErrorTestSuites) {
     results += ', ';
     results += this._formatMsg(
-      aggregatedResults.numFailedToRunTestSuites + ' test suite' +
-        (aggregatedResults.numFailedToRunTestSuites === 1 ? '' : 's') +
+      aggregatedResults.numRuntimeErrorTestSuites + ' test suite' +
+        (aggregatedResults.numRuntimeErrorTestSuites === 1 ? '' : 's') +
         ' failed to run',
       colors.RED + colors.BOLD
     );
@@ -144,7 +144,7 @@ function (config, aggregatedResults) {
 
   var numTestSuitesExecuted =
     aggregatedResults.numTotalTestSuites -
-    aggregatedResults.numFailedToRunTestSuites;
+    aggregatedResults.numRuntimeErrorTestSuites;
 
   results += ' (' + numTotalTests + ' total in ' +
     numTestSuitesExecuted + ' ' +
@@ -183,7 +183,7 @@ DefaultTestReporter.prototype._printWaitingOn = function(aggregatedResults) {
   var completedTestSuites =
     aggregatedResults.numPassedTestSuites +
     aggregatedResults.numFailedTestSuites +
-    aggregatedResults.numFailedToRunTestSuites;
+    aggregatedResults.numRuntimeErrorTestSuites;
   var remainingTestSuites =
     aggregatedResults.numTotalTestSuites -
     completedTestSuites;

--- a/src/DefaultTestReporter.js
+++ b/src/DefaultTestReporter.js
@@ -132,6 +132,16 @@ function (config, aggregatedResults) {
     colors.GREEN + colors.BOLD
   );
 
+  if (aggregatedResults.numFailedToRunTestSuites) {
+    results += ', ';
+    results += this._formatMsg(
+      aggregatedResults.numFailedToRunTestSuites + ' test suit' +
+        (aggregatedResults.numFailedToRunTestSuites === 1 ? '' : 's') +
+        ' failed to run',
+      colors.RED + colors.BOLD
+    );
+  }
+
   var pluralTestSuites =
       aggregatedResults.numTotalTestSuites === 1 ?
       'test suite' : 'test suites';
@@ -171,7 +181,8 @@ function (passed, testName, columns) {
 DefaultTestReporter.prototype._printWaitingOn = function(aggregatedResults) {
   var completedTestSuites =
     aggregatedResults.numPassedTestSuites +
-    aggregatedResults.numFailedTestSuites;
+    aggregatedResults.numFailedTestSuites +
+    aggregatedResults.numFailedToRunTestSuites;
   var remainingTestSuites =
     aggregatedResults.numTotalTestSuites -
     completedTestSuites;

--- a/src/TestRunner.js
+++ b/src/TestRunner.js
@@ -476,7 +476,7 @@ class TestRunner {
    *   numTotalTestSuites: total number of test suites considered
    *   numPassedTestSuites: number of test suites run and passed
    *   numFailedTestSuites: number of test suites run and failed
-   *   numFailedToRunTestSuites: number of test suites failed to run
+   *   numRuntimeErrorTestSuites: number of test suites failed to run
    *   numTotalTests: total number of tests executed
    *   numPassedTests: number of tests run and passed
    *   numFailedTests: number of tests run and failed
@@ -506,7 +506,7 @@ class TestRunner {
       numTotalTestSuites: testPaths.length,
       numPassedTestSuites: 0,
       numFailedTestSuites: 0,
-      numFailedToRunTestSuites: 0,
+      numRuntimeErrorTestSuites: 0,
       numTotalTests: 0,
       numPassedTests: 0,
       numFailedTests: 0,
@@ -544,7 +544,7 @@ class TestRunner {
         testResults: {},
       };
       aggregatedResults.testResults.push(testResult);
-      aggregatedResults.numFailedToRunTestSuites++;
+      aggregatedResults.numRuntimeErrorTestSuites++;
       if (reporter.onTestResult) {
         reporter.onTestResult(config, testResult, aggregatedResults);
       }
@@ -557,7 +557,7 @@ class TestRunner {
       .then(function() {
         aggregatedResults.success =
           aggregatedResults.numFailedTests === 0 &&
-          aggregatedResults.numFailedToRunTestSuites === 0;
+          aggregatedResults.numRuntimeErrorTestSuites === 0;
         if (reporter.onRunComplete) {
           reporter.onRunComplete(config, aggregatedResults);
         }

--- a/src/TestRunner.js
+++ b/src/TestRunner.js
@@ -476,6 +476,7 @@ class TestRunner {
    *   numTotalTestSuites: total number of test suites considered
    *   numPassedTestSuites: number of test suites run and passed
    *   numFailedTestSuites: number of test suites run and failed
+   *   numFailedToRunTestSuites: number of test suites failed to run
    *   numTotalTests: total number of tests executed
    *   numPassedTests: number of tests run and passed
    *   numFailedTests: number of tests run and failed
@@ -505,6 +506,7 @@ class TestRunner {
       numTotalTestSuites: testPaths.length,
       numPassedTestSuites: 0,
       numFailedTestSuites: 0,
+      numFailedToRunTestSuites: 0,
       numTotalTests: 0,
       numPassedTests: 0,
       numFailedTests: 0,
@@ -524,7 +526,7 @@ class TestRunner {
       if (testResult.numFailingTests > 0) {
         aggregatedResults.numFailedTestSuites++;
       } else {
-        aggregatedResults.numFailedTestSuites++;
+        aggregatedResults.numPassedTestSuites++;
       }
       reporter.onTestResult && reporter.onTestResult(
         config,
@@ -542,7 +544,7 @@ class TestRunner {
         testResults: {},
       };
       aggregatedResults.testResults.push(testResult);
-      aggregatedResults.numFailedTestSuites++;
+      aggregatedResults.numFailedToRunTestSuites++;
       if (reporter.onTestResult) {
         reporter.onTestResult(config, testResult, aggregatedResults);
       }
@@ -553,7 +555,9 @@ class TestRunner {
 
     return testRun
       .then(function() {
-        aggregatedResults.success = aggregatedResults.numFailedTests === 0;
+        aggregatedResults.success =
+          aggregatedResults.numFailedTests === 0 &&
+          aggregatedResults.numFailedToRunTestSuites === 0;
         if (reporter.onRunComplete) {
           reporter.onRunComplete(config, aggregatedResults);
         }

--- a/src/lib/formatTestResults.js
+++ b/src/lib/formatTestResults.js
@@ -55,6 +55,7 @@ module.exports = (results, codeCoverageFormatter) => {
     startTime: results.startTime,
     numTotalTests: results.numTotalTests,
     numTotalTestSuites: results.numTotalTestSuites,
+    numRuntimeErrorTestSuites: results.numRuntimeErrorTestSuites,
     numPassedTests: results.numPassedTests,
     numFailedTests: results.numFailedTests,
     testResults,


### PR DESCRIPTION
There are a few problems that unfortunately I introduced in #557:

- test suites with passing tests are not counted
- test suites that fail to run do not fail the test run (they do not increase the number of failing tests, because the runner does not know how many tests the failed suite has)

These problems are fixed and the test suites that fail to run (if any) are reported separately.

Here is an example:

<img width="636" alt="jest-failed-test-suites" src="https://cloud.githubusercontent.com/assets/1218821/10717015/750e82a8-7b53-11e5-8bba-08cb036d41e7.png">