### PR TITLE
Use precompiled version of jasmine-only

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,12 +4,10 @@
   "version": "0.6.1",
   "main": "src/jest.js",
   "dependencies": {
-    "coffee-script": "^1.10.0",
     "cover": "^0.2.9",
     "diff": "^2.1.1",
     "graceful-fs": "^4.1.2",
     "istanbul": "^0.3.19",
-    "jasmine-only": "^0.1.1",
     "jasmine-pit": "^2.0.2",
     "jsdom": "7.0.2",
     "json-stable-stringify": "^1.0.0",

--- a/src/jasmineTestRunner/jasmineTestRunner.js
+++ b/src/jasmineTestRunner/jasmineTestRunner.js
@@ -14,30 +14,12 @@ var path = require('path');
 var utils = require('../lib/utils');
 var transform = require('../lib/transform');
 
-var JASMINE_PATH = require.resolve('../../vendor/jasmine/jasmine-1.3.0');
-var jasmineFileContent =
-  fs.readFileSync(require.resolve(JASMINE_PATH), 'utf8');
+const JASMINE_PATH = require.resolve('../../vendor/jasmine/jasmine-1.3.0');
+const jasmineFileContent = fs.readFileSync(JASMINE_PATH, 'utf8');
 
-var JASMINE_ONLY_ROOT = path.dirname(require.resolve('jasmine-only'));
-var POTENTIALLY_PRECOMPILED_FILE = path.join(
-  JASMINE_ONLY_ROOT,
-  'app',
-  'js',
-  'jasmine_only.js'
-);
-var COFFEE_SCRIPT_FILE = path.join(
-  JASMINE_ONLY_ROOT,
-  'app',
-  'js',
-  'jasmine_only.coffee'
-);
-
-var jasmineOnlyContent =
-  fs.existsSync(POTENTIALLY_PRECOMPILED_FILE)
-  ? fs.readFileSync(POTENTIALLY_PRECOMPILED_FILE, 'utf8')
-  : require('coffee-script').compile(
-      fs.readFileSync(COFFEE_SCRIPT_FILE, 'utf8')
-    );
+const JASMINE_ONLY_PATH = 
+  require.resolve('../../vendor/jasmine-only/jasmine-only.js');
+const jasmineOnlyContent = fs.readFileSync(JASMINE_ONLY_PATH, 'utf8');
 
 function jasmineTestRunner(config, environment, moduleLoader, testPath) {
   var hasKey = function(obj, keyName) {

--- a/vendor/jasmine-only/jasmine-only.js
+++ b/vendor/jasmine-only/jasmine-only.js
@@ -1,0 +1,98 @@
+/* jasmine-only - 0.1.1
+ * Exclusivity spec helpers for jasmine: `describe.only` and `it.only`
+ * https://github.com/davemo/jasmine-only
+ */
+(function() {
+  var __hasProp = {}.hasOwnProperty,
+    __extends = function(child, parent) { for (var key in parent) { if (__hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; };
+
+  (function(jasmine) {
+    var describeOnly, env, itOnly, root;
+    root = (1, eval)('this');
+    env = jasmine.getEnv();
+    describeOnly = function(description, specDefinitions) {
+      var suite;
+      suite = new jasmine.Suite(this, description, null, this.currentSuite);
+      suite.exclusive_ = 1;
+      this.exclusive_ = Math.max(this.exclusive_, 1);
+      return this.describe_(suite, specDefinitions);
+    };
+    itOnly = function(description, func) {
+      var spec;
+      spec = this.it(description, func);
+      spec.exclusive_ = 2;
+      this.exclusive_ = 2;
+      return spec;
+    };
+    env.exclusive_ = 0;
+    env.describe = function(description, specDefinitions) {
+      var suite;
+      suite = new jasmine.Suite(this, description, null, this.currentSuite);
+      return this.describe_(suite, specDefinitions);
+    };
+    env.describe_ = function(suite, specDefinitions) {
+      var declarationError, e, parentSuite;
+      parentSuite = this.currentSuite;
+      if (parentSuite) {
+        parentSuite.add(suite);
+      } else {
+        this.currentRunner_.add(suite);
+      }
+      this.currentSuite = suite;
+      declarationError = null;
+      try {
+        specDefinitions.call(suite);
+      } catch (_error) {
+        e = _error;
+        declarationError = e;
+      }
+      if (declarationError) {
+        this.it("encountered a declaration exception", function() {
+          throw declarationError;
+        });
+      }
+      this.currentSuite = parentSuite;
+      return suite;
+    };
+    env.specFilter = function(spec) {
+      return this.exclusive_ <= spec.exclusive_;
+    };
+    env.describe.only = function() {
+      return describeOnly.apply(env, arguments);
+    };
+    env.it.only = function() {
+      return itOnly.apply(env, arguments);
+    };
+    root.describe.only = function(description, specDefinitions) {
+      return env.describe.only(description, specDefinitions);
+    };
+    root.it.only = function(description, func) {
+      return env.it.only(description, func);
+    };
+    root.iit = root.it.only;
+    root.ddescribe = root.describe.only;
+    jasmine.Spec = (function(_super) {
+      __extends(Spec, _super);
+
+      function Spec(env, suite, description) {
+        this.exclusive_ = suite.exclusive_;
+        Spec.__super__.constructor.call(this, env, suite, description);
+      }
+
+      return Spec;
+
+    })(jasmine.Spec);
+    return jasmine.Suite = (function(_super) {
+      __extends(Suite, _super);
+
+      function Suite(env, suite, specDefinitions, parentSuite) {
+        this.exclusive_ = parentSuite && parentSuite.exclusive_ || 0;
+        Suite.__super__.constructor.call(this, env, suite, specDefinitions, parentSuite);
+      }
+
+      return Suite;
+
+    })(jasmine.Suite);
+  })(jasmine);
+
+}).call(this);


### PR DESCRIPTION
Ship a static, precompiled version of jasmine-only by @davemo to drop the coffee-script requirement. Fixes #578.

Not sure if we need to update the headers of the precompiled file to include the license. FWIW According to the package.json its under the Apache License 2.0.

Test plan:
- Create a test file with one `describe`-block and two tests: One created with `it` and one with `it.only`, let both tests print to STDOUT, verify only the contents of the test created with `it.only` are printed to STDOUT.
- Create a test file with one `describe`- and one `describe.only`-block, in both blocks print to STDOUT, verify that only the `describe.only`-block prints to STDOUT.