### PR TITLE
Fix website site script so it runs in node 4

### DIFF
--- a/website/server/server.js
+++ b/website/server/server.js
@@ -12,7 +12,7 @@ var PROJECT_ROOT = path.resolve(__dirname, '..');
 var FILE_SERVE_ROOT = path.join(PROJECT_ROOT, 'src');
 
 var port = argv.port;
-if (argv.$0 === 'node ./server/generate.js') {
+if (argv.$0.indexOf('node ./server/generate.js') !== -1) {
   // Using a different port so that you can publish the website
   // and keeping the server up at the same time.
   port = 8079;


### PR DESCRIPTION
Looks like the only change to pick up from Relay here was the looser check for argv. It seems to contain the full path to the node executable now, not just node.