### PR TITLE
Add compatible babel-jest version.

### DIFF
--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -5,7 +5,7 @@
   },
   "devDependencies": {
     "react-addons-test-utils": "~0.14.0",
-    "babel-jest": "*",
+    "babel-jest": "^5.2.1",
     "jest-cli": "*"
   },
   "scripts": {


### PR DESCRIPTION
Latest `babel-jest@6.0.1` which requires `babel-core@6.0.0` breaks React example.