### PR TITLE
Added a new config variable.

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -243,6 +243,7 @@ function normalizeConfig(config) {
         return newConfig;
       case 'bail':
       case 'preprocessCachingDisabled':
+      case 'preprocessorOptions':
       case 'coverageReporters':
       case 'collectCoverage':
       case 'coverageCollector':


### PR DESCRIPTION
In a related issue: https://github.com/babel/babel-jest/pull/48 we have come upon a need to pass options to the preprocessor, the config variable is already sent to the preprocessor so no additional code change is needed to achieve this.