### PR TITLE
fix(react example): correct .babelrc and example

### DIFF
--- a/examples/react/.babelrc
+++ b/examples/react/.babelrc
@@ -1,3 +1,3 @@
 {
-  "plugins": ["es2015", "react"]
+  "presets": ["es2015", "react"]
 }

--- a/examples/react/CheckboxWithLabel.js
+++ b/examples/react/CheckboxWithLabel.js
@@ -30,4 +30,4 @@ class CheckboxWithLabel extends React.Component {
   }
 }
 
-export default CheckboxWithLabel;
+module.exports = CheckboxWithLabel;


### PR DESCRIPTION
- in order to use 'babel-plugins-*' to parse the syntax, we can use
  'babel-preset-*' packages that we have already installed.
  for using 'babel-preset-*' packages you need to specify it in the
  .babelrc file as "presets".
  (Look here: https://babeljs.io/docs/plugins/#presets)

  otherwise if you want to use 'plugins' and parse the syntax;
  you have to install 'babel-plugin-*' packages.
  (Look here: https://babeljs.io/docs/plugins/)

- 'export default *' changed to 'module.exports = *' due to
  syntax error.