### PR TITLE
Don’t subtract the number of test suites with runtime errors from the…

### DIFF
--- a/src/DefaultTestReporter.js
+++ b/src/DefaultTestReporter.js
@@ -112,6 +112,7 @@ class DefaultTestReporter {
   }
 
   onRunComplete(config, aggregatedResults) {
+    const numTotalTestSuites = aggregatedResults.numTotalTestSuites;
     const numFailedTests = aggregatedResults.numFailedTests;
     const numPassedTests = aggregatedResults.numPassedTests;
     const numTotalTests = aggregatedResults.numTotalTests;
@@ -152,13 +153,9 @@ class DefaultTestReporter {
       colors.GREEN + colors.BOLD
     );
 
-    const numTestSuitesExecuted =
-      aggregatedResults.numTotalTestSuites -
-      aggregatedResults.numRuntimeErrorTestSuites;
-
     results += ' (' + numTotalTests + ' total in ' +
-      numTestSuitesExecuted + ' ' +
-      'test suite' + (numTestSuitesExecuted === 1 ? '' : 's') +
+      numTotalTestSuites + ' ' +
+      'test suite' + (numTotalTestSuites === 1 ? '' : 's') +
       ', run time ' + runTime + 's)';
 
     this.log(results);


### PR DESCRIPTION
… total. This is confusing.

Assuming only two test suites have no-runtime errors here is the output:

Previously: 77 tests failed, 8 test suites failed, 9 tests passed (86 total in 2 test suites, run time 3.33s)
New: 77 tests failed, 8 test suites failed, 9 tests passed (86 total in 15 test suites, run time 3.33s)