### PR TITLE
Update react tutorial documentation.

### DIFF
--- a/docs/TutorialReact.md
+++ b/docs/TutorialReact.md
@@ -41,7 +41,7 @@ class CheckboxWithLabel extends React.Component {
   }
 }
 
-export default CheckboxWithLabel;
+module.exports = CheckboxWithLabel;
 ```
 
 The test code is pretty straightforward; we use React's


### PR DESCRIPTION
Update documentation to use `module.exports` instead of `export default *` as fixed in #614.