### PR TITLE
Use es6 load syntax in documentation example

### DIFF
--- a/docs/TutorialReact.md
+++ b/docs/TutorialReact.md
@@ -56,7 +56,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import TestUtils from 'react-addons-test-utils';
 
-const CheckboxWithLabel = require('../CheckboxWithLabel');
+import CheckboxWithLabel from '../CheckboxWithLabel';
 
 describe('CheckboxWithLabel', () => {
 


### PR DESCRIPTION
require() otherwise demands the module to be exported as module.exports