### PR TITLE
Assign the documented keys of the `require` object

### DIFF
--- a/src/HasteModuleLoader/HasteModuleLoader.js
+++ b/src/HasteModuleLoader/HasteModuleLoader.js
@@ -521,6 +521,10 @@ class Loader {
     moduleRequire.requireMock = this.requireMock.bind(this, modulePath);
     moduleRequire.requireActual = this.requireModule.bind(this, modulePath);
 
+    // Compatibility with modules using enumerable keys of "require"
+    moduleRequire.cache = Object.create(null);
+    moduleRequire.extensions = Object.create(null);
+
     return moduleRequire;
   }
 


### PR DESCRIPTION
This PR makes Jest working with libs using the enumerable keys of the `require` function/object.

It fixes https://github.com/jhnns/rewire/issues/45

I started with a `Object.keys(require).forEach` but I noted a significant overhead of execution time. So I ended up by assigning manually the 2 properties documented [here](https://nodejs.org/api/globals.html#globals_require)

FYT ?