### PR TITLE
Modules with 'export default' could not be mocked

### DIFF
--- a/src/lib/moduleMocker.js
+++ b/src/lib/moduleMocker.js
@@ -70,7 +70,7 @@ function getType(ref) {
     return 'array';
   } else if (isA('Object', ref)) {
     return 'object';
-  } else if (isA('Number', ref) || isA('String', ref)) {
+  } else if (isA('Number', ref) || isA('String', ref) || isA('Boolean', ref)) {
     return 'constant';
   } else if (isA('Map', ref) || isA('WeakMap', ref) || isA('Set', ref)) {
     return 'collection';
@@ -350,7 +350,7 @@ function getMetadata(component, _refs) {
     if (type !== 'undefined') {
       getSlots(component).forEach(slot => {
         if (
-          slot.charAt(0) === '_' ||
+          (slot.charAt(0) === '_' && slot !== '__esModule') ||
           (
             type === 'function' &&
             component._isMockFunction &&


### PR DESCRIPTION
Jest could not mock a module that exports something with `default` keyword.

```bash
Using Jest CLI v0.8.0, jasmine1
 FAIL  __tests__/index.js (0.338s)
● index › it should run
  - TypeError: (0 , _bar2.default) is not a function
        at index (index.js:8:20)
        at Spec.<anonymous> (__tests__/index.js:7:10)
```

This happens because Babel [relies](https://github.com/babel/babel/blob/7f0eed0c6659e5ea55987965830edaf53a7e6bfb/packages/babel-helpers/src/helpers.js#L238) on a presence of `__esModule` property when transpiling imports.

Jest will not copy this property to mock for two reasons:

* it considers underscored properties to be private
* it ignores boolean properties

I've provided a monkey-patch solution mostly to illustrate an unexpected behavior and not by any means expect it to be accepted.

Also, here's a [repo](https://github.com/sameoldmadness/jest-babel-error) with a minimal example.