### PR TITLE
Only collect coverage if `collectCoverage` is true or --coverage is passed

### DIFF
--- a/src/HasteModuleLoader/HasteModuleLoader.js
+++ b/src/HasteModuleLoader/HasteModuleLoader.js
@@ -175,10 +175,7 @@ class Loader {
     const filename = moduleObj.__filename;
     let moduleContent = transform(filename, this._config);
     let collectorStore;
-    const onlyCollectFrom = this._config.collectCoverageOnlyFrom;
-    const shouldCollectCoverage =
-      (this._config.collectCoverage === true && !onlyCollectFrom) ||
-      (onlyCollectFrom && onlyCollectFrom[filename] === true);
+    const shouldCollectCoverage = this._config.collectCoverage === true;
 
     if (shouldCollectCoverage) {
       if (!hasOwnProperty.call(this._coverageCollectors, filename)) {


### PR DESCRIPTION
Currently Jest will always try to do coverage collection if `collectCoverageOnlyFrom` is provided, even if `collectCoverage` is not actually enabled. This causes an error and all tests automatically fail.