### PR TITLE
add watcher debounce

### DIFF
--- a/bin/jest.js
+++ b/bin/jest.js
@@ -16,6 +16,7 @@ const sane = require('sane');
 const which = require('which');
 
 const WATCHMAN_BIN = 'watchman';
+const WATCHER_DEBOUNCE = 200;
 
 /**
  * Takes a description string, puts it on the next line, indents it, and makes
@@ -312,7 +313,14 @@ function runJest() {
 
   if (argv.watch !== undefined) {
     getWatcher(function(watcher) {
-      watcher.on('all', runJestCLI);
+      let tid;
+      watcher.on('all', () => {
+        if (tid) {
+          clearTimeout(tid);
+          tid = null;
+        }
+        tid = setTimeout(runJestCLI, WATCHER_DEBOUNCE);
+      });
       if (argv.watch !== 'skip') {
         runJestCLI();
       }


### PR DESCRIPTION
which mitigate the problems that watcher triggers multiple change event in a short period, especially switching branches while jest --watch is running. This doesn't kill antecedent test process but should be net better than current which causes multiple tests running simultaneously.