### PR TITLE
use git diff relative for onlyChanges

### DIFF
--- a/src/jest.js
+++ b/src/jest.js
@@ -26,7 +26,7 @@ function getVersion() {
 
 function findChangedFiles(dirPath) {
   return new Promise((resolve, reject) => {
-    const args = ['diff', '--name-only', '--diff-filter=ACMR'];
+    const args = ['diff', '--name-only', '--diff-filter=ACMR', '--relative'];
     const child = childProcess.spawn('git', args, {cwd: dirPath});
 
     let stdout = '';


### PR DESCRIPTION
	- in case testPathDirs and git root are different, path will be relative to root
	- fixes https://github.com/facebook/jest/issues/327