### PR TITLE
Fix component export on React Tutorial page

### DIFF
--- a/docs/TutorialReact.md
+++ b/docs/TutorialReact.md
@@ -41,7 +41,7 @@ class CheckboxWithLabel extends React.Component {
   }
 }
 
-export default CheckboxWithLabel;
+module.exports = CheckboxWithLabel;
 ```
 
 The test code is pretty straightforward; we use React's


### PR DESCRIPTION
Following changes here https://github.com/facebook/jest/commit/bb43b4ed3993ef3f4c2ec976be94e86c86213227 hope it saves someone else several hours of why example does not work.