### PR TITLE
Print the name of the file that eval fails on.

### DIFF
--- a/src/environments/JSDOMEnvironment.js
+++ b/src/environments/JSDOMEnvironment.js
@@ -33,7 +33,13 @@ class JSDOMEnvironment {
   }
 
   runSourceText(sourceText, filename) {
-    return this.global.eval(sourceText + '\n//# sourceURL=' + filename);
+    let evalResult;
+    try {
+      evalResult = this.global.eval(sourceText + '\n//# sourceURL=' + filename);
+    } catch (e) {
+      throw new Error("Eval error " + filename + " " + e.toString());
+    }
+    return evalResult;
   }
 
   runWithRealTimers(cb) {


### PR DESCRIPTION
This is so that when developers run into this problem, which is likely a
problem with node-haste that they can add it to their `modulePathIgnorePatterns`
rules.

It might actually also make sense to remind the user of `modulePathIgnorePatterns`
existence at this point...

Closes #686