### PR TITLE
Fixes name for functions that are bound multiple times

### DIFF
--- a/src/lib/__tests__/moduleMocker-test.js
+++ b/src/lib/__tests__/moduleMocker-test.js
@@ -99,5 +99,16 @@ describe('moduleMocker', function() {
 
       expect(instanceFooMock.toString.mock).not.toBeUndefined();
     });
+
+    it('mocks methods that are bound multiple times', function() {
+      var func = function func() {};
+      var multipleBoundFunc = func.bind(null).bind(null);
+
+      var multipleBoundFuncMock = moduleMocker.generateFromMetadata(
+        moduleMocker.getMetadata(multipleBoundFunc)
+      );
+
+      expect(typeof multipleBoundFuncMock).toBe('function');
+    });
   });
 });

--- a/src/lib/moduleMocker.js
+++ b/src/lib/moduleMocker.js
@@ -135,9 +135,8 @@ function createMockFunction(metadata, mockConstructor) {
 
   // Preserve `name` property of mocked function.
   const boundFunctionPrefix = 'bound ';
-  const isBound = name && name.startsWith(boundFunctionPrefix);
   let bindCall = '';
-  if (isBound) {
+  while (name && name.startsWith(boundFunctionPrefix)) {
     name = name.substring(boundFunctionPrefix.length);
     // Call bind() just to alter the function name.
     bindCall = '.bind(null)';


### PR DESCRIPTION
This fixes mocking of the loglevel npm package in my case.