### PR TITLE
Fix bug where coverage is not collected #632

### DIFF
--- a/src/HasteModuleLoader/HasteModuleLoader.js
+++ b/src/HasteModuleLoader/HasteModuleLoader.js
@@ -176,9 +176,12 @@ class Loader {
     let moduleContent = transform(filename, this._config);
     let collectorStore;
     const onlyCollectFrom = this._config.collectCoverageOnlyFrom;
+    const hasOnlyCollectFrom =
+      typeof onlyCollectFrom === 'object' &&
+      Object.keys(onlyCollectFrom).length !== 0;
     const shouldCollectCoverage =
-      (this._config.collectCoverage === true && !onlyCollectFrom) ||
-      (onlyCollectFrom && onlyCollectFrom[filename] === true);
+      (this._config.collectCoverage === true && !hasOnlyCollectFrom) ||
+      (hasOnlyCollectFrom && onlyCollectFrom[filename] === true);
 
     if (shouldCollectCoverage) {
       if (!hasOwnProperty.call(this._coverageCollectors, filename)) {


### PR DESCRIPTION
This fixes the bug discussed in #632 where coverage is not being collected correctly when using collectCoverage.

@cyjia tracked down the cause in #632.  The onlyCollectFrom variable is an object, so !onlyCollectFrom always returns false instead of the intent of testing if the collectCoverageOnlyFrom configuration option is being used. 