### PR TITLE
Update node-haste dependency to v2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "json-stable-stringify": "^1.0.0",
     "lodash.template": "^3.6.2",
     "mkdirp": "^0.5.1",
-    "node-haste": "^2.0.0",
+    "node-haste": "^2.1.0",
     "optimist": "^0.6.1",
     "resolve": "^1.1.6",
     "sane": "^1.2.0",

--- a/src/resolvers/HasteResolver.js
+++ b/src/resolvers/HasteResolver.js
@@ -103,8 +103,12 @@ class HasteResolver {
     }));
   }
 
-  getShallowDependencies(path) {
-    return this._depGraph.getDependencies(path, this._defaultPlatform, false);
+  getShallowDependencies(entryPath) {
+    return this._depGraph.getDependencies({
+      entryPath,
+      platform: this._defaultPlatform,
+      recursive: false,
+    });
   }
 
   getFS() {


### PR DESCRIPTION
node-haste 2.1.0 has a breaking change in the signature of `DependencyGraph#getDependencies`. This changes jest’s only call site.