### PR TITLE
Fix Jasmine reporter losing spec results when pretty printing JSDOM nodes

### DIFF
--- a/src/testRunners/jasmine/JasmineFormatter.js
+++ b/src/testRunners/jasmine/JasmineFormatter.js
@@ -111,8 +111,8 @@ class JasmineFormatter {
       if (this._jasmine.isDomNode(obj)) {
         let attrStr = '';
         Array.prototype.forEach.call(obj.attributes, attr => {
-          const attrName = attr.nodeName.trim();
-          const attrValue = attr.nodeValue.trim();
+          const attrName = attr.name.trim();
+          const attrValue = attr.value.trim();
           attrStr += ' ' + attrName + '="' + attrValue + '"';
         });
         return (

--- a/src/testRunners/jasmine/__tests__/JasmineFormatter-test.js
+++ b/src/testRunners/jasmine/__tests__/JasmineFormatter-test.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2016, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails oncall+jsinfra
+ */
+'use strict';
+
+jest.autoMockOff();
+
+const path = require('path');
+const VENDOR_PATH = path.resolve(__dirname, '../../../../vendor');
+
+const jasmine = require(`${VENDOR_PATH}/jasmine/jasmine-1.3.0`).jasmine;
+const jasmine2Require = require(`${VENDOR_PATH}/jasmine/jasmine-2.3.4.js`);
+const jasmine2 = jasmine2Require.core(jasmine2Require);
+
+const JasmineFormatter = require('../JasmineFormatter');
+
+const jsdom = require('jsdom').jsdom;
+const fixture = '<html><body id="foo"></body></html>';
+
+let formatter;
+
+describe('JasmineFormatter', () => {
+  describe('pretty printer', () => {
+    it('should handle JSDOM nodes with Jasmine 1.x', () => {
+      formatter = new JasmineFormatter(jasmine);
+
+      expect(() => formatter.prettyPrint(jsdom(fixture).body)).not.toThrow();
+    });
+
+    it('should handle JSDOM nodes with Jasmine 2.x', () => {
+      formatter = new JasmineFormatter(jasmine2);
+
+      expect(() => formatter.prettyPrint(jsdom(fixture).body)).not.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
JSDOM for some reason doesn't support `attributeNode.nodeName`. I looked at the HTML spec and it's safe to use `attributeNode.name` and `attributeNode.value`, so I adjusted the formatter to use what is available. I'll also send a patch to JSDOM to fix this on their side.

It _should_ be here: https://github.com/tmpvar/jsdom/blob/fcece90f9f9505cfccbcdfac21fc66f40fcfae88/lib/jsdom/living/attributes/Attr-impl.js