### PR TITLE
Fix npm3 module resolution + more caching.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,9 @@
 *.swp
 .DS_STORE
 .haste_cache
-node_modules
+/node_modules
+/examples/**/node_modules/
+/website/node_modules
 npm-debug.log
 build
 website/core/metadata.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@
 * Added a "no tests found" message if no tests can be found.
 * Debounce `--watch` re-runs to not trigger test runs during a
   branch switch in version control.
-* Fixed test runtime error reporting and stack traces
+* Fixed mocking of boolean values.
+* Fixed unmocking behavior with npm3.
+* Fixed test runtime error reporting and stack traces.
 
 ## 0.8.2
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jest-cli",
   "description": "Painless JavaScript Unit Testing.",
-  "version": "0.9.0-fb2",
+  "version": "0.9.0-fb3",
   "main": "src/jest.js",
   "dependencies": {
     "chalk": "^1.1.1",

--- a/src/HasteModuleLoader/__tests__/HasteModuleLoader-requireModule-test.js
+++ b/src/HasteModuleLoader/__tests__/HasteModuleLoader-requireModule-test.js
@@ -26,6 +26,7 @@ describe('HasteModuleLoader', function() {
     cacheDirectory: global.CACHE_DIRECTORY,
     name: 'HasteModuleLoader-requireModule-tests',
     rootDir,
+    unmockedModulePathPatterns: ['npm3-main-dep'],
   });
 
   function buildLoader() {
@@ -143,51 +144,38 @@ describe('HasteModuleLoader', function() {
       });
     });
 
-    describe('features I want to remove, but must exist for now', function() {
-      /**
-       * I'd like to kill this and make all tests use something more explicit
-       * when they want a manual mock, like:
-       *
-       *   require.mock('MyManualMock');
-       *   const ManuallyMocked = require('ManuallyMocked');
-       *
-       *   --or--
-       *
-       *   const ManuallyMocked = require.manualMock('ManuallyMocked');
-       *
-       * For now, however, this is built-in and many tests rely on it, so we
-       * must support it until we can do some cleanup.
-       */
-      pit('provides manual mock when real module doesnt exist', function() {
-        return buildLoader().then(function(loader) {
-          const exports = loader.requireModule(
-            rootPath,
-            'ExclusivelyManualMock'
-          );
-          expect(exports.isExclusivelyManualMockModule).toBe(true);
+    pit('provides manual mock when real module doesnt exist', function() {
+      return buildLoader().then(function(loader) {
+        const exports = loader.requireModule(
+          rootPath,
+          'ExclusivelyManualMock'
+        );
+        expect(exports.isExclusivelyManualMockModule).toBe(true);
+      });
+    });
+
+    pit(
+      'doesnt override real modules with manual mocks when explicitly ' +
+        'marked with .dontMock()',
+        function() {
+          return buildLoader().then(function(loader) {
+            const root = loader.requireModule(rootPath, './root.js');
+            root.jest.resetModuleRegistry();
+            root.jest.dontMock('ManuallyMocked');
+            const exports = loader.requireModule(rootPath, 'ManuallyMocked');
+            expect(exports.isManualMockModule).toBe(false);
+          });
+        }
+    );
+
+    pit('unmocks transitive dependencies in node_modules by default', () => {
+      return buildLoader().then(loader => {
+        const nodeModule = loader.requireModule(rootPath, 'npm3-main-dep');
+        expect(nodeModule()).toEqual({
+          isMocked: false,
+          transitiveNPM3Dep: 'npm3-transitive-dep',
         });
       });
-
-      /**
-       * requireModule() should *always* return the real module. Mocks should
-       * only be returned by requireMock().
-       *
-       * See the 'overrides real modules with manual mock when one exists' test
-       * for more info on why I want to kill this feature.
-       */
-      pit(
-        'doesnt override real modules with manual mocks when explicitly ' +
-          'marked with .dontMock()',
-          function() {
-            return buildLoader().then(function(loader) {
-              const root = loader.requireModule(rootPath, './root.js');
-              root.jest.resetModuleRegistry();
-              root.jest.dontMock('ManuallyMocked');
-              const exports = loader.requireModule(rootPath, 'ManuallyMocked');
-              expect(exports.isManualMockModule).toBe(false);
-            });
-          }
-      );
     });
   });
 });

--- a/src/HasteModuleLoader/__tests__/test_root/ManuallyMocked.js
+++ b/src/HasteModuleLoader/__tests__/test_root/ManuallyMocked.js
@@ -8,4 +8,6 @@
  * @providesModule ManuallyMocked
  */
 
+'use strict';
+
 exports.isManualMockModule = false;

--- a/src/HasteModuleLoader/__tests__/test_root/__mocks__/ExclusivelyManualMock.js
+++ b/src/HasteModuleLoader/__tests__/test_root/__mocks__/ExclusivelyManualMock.js
@@ -5,4 +5,7 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
+
+'use strict';
+
 exports.isExclusivelyManualMockModule = true;

--- a/src/HasteModuleLoader/__tests__/test_root/__mocks__/ManuallyMocked.js
+++ b/src/HasteModuleLoader/__tests__/test_root/__mocks__/ManuallyMocked.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
+
 'use strict';
 
 let OnlyRequiredFromMock;

--- a/src/HasteModuleLoader/__tests__/test_root/node_modules/npm3-main-dep/index.js
+++ b/src/HasteModuleLoader/__tests__/test_root/node_modules/npm3-main-dep/index.js
@@ -8,4 +8,9 @@
 
 'use strict';
 
-exports.modulePath = 'subdir2/MyModule.js';
+const transitiveNPM3Dep = require('npm3-transitive-dep');
+
+module.exports = () => ({
+  isMocked: false,
+  transitiveNPM3Dep: transitiveNPM3Dep(),
+});

--- a/src/HasteModuleLoader/__tests__/test_root/node_modules/npm3-transitive-dep/index.js
+++ b/src/HasteModuleLoader/__tests__/test_root/node_modules/npm3-transitive-dep/index.js
@@ -6,6 +6,4 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-'use strict';
-
-exports.modulePath = 'subdir2/MyModule.js';
+module.exports = () => 'npm3-transitive-dep';

--- a/src/HasteModuleLoader/__tests__/test_root/root.js
+++ b/src/HasteModuleLoader/__tests__/test_root/root.js
@@ -8,6 +8,8 @@
  * @providesModule root
  */
 
+'use strict';
+
 require('ManuallyMocked');
 require('ModuleWithSideEffects');
 require('RegularModule');

--- a/src/HasteModuleLoader/__tests__/test_root/subdir1/MyModule.js
+++ b/src/HasteModuleLoader/__tests__/test_root/subdir1/MyModule.js
@@ -5,4 +5,7 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
+
+'use strict';
+
 exports.modulePath = 'subdir1/MyModule.js';

--- a/src/HasteModuleLoader/__tests__/test_root/subdir1/__mocks__/MyModule.js
+++ b/src/HasteModuleLoader/__tests__/test_root/subdir1/__mocks__/MyModule.js
@@ -5,4 +5,7 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
+
+'use strict';
+
 exports.modulePath = 'subdir1/__mocks__/MyModule.js';

--- a/src/HasteModuleLoader/__tests__/test_root/subdir2/__mocks__/MyModule.js
+++ b/src/HasteModuleLoader/__tests__/test_root/subdir2/__mocks__/MyModule.js
@@ -5,4 +5,7 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
+
+'use strict';
+
 exports.modulePath = 'subdir2/__mocks__/MyModule.js';


### PR DESCRIPTION
This fixes unmock resolution for node_modules when using npm3. The way this is solved is by checking whether the parent dependency is unmocked and both modules are within a `node_modules` folder. 

This has taken a while, mainly because it required #599 to be merged. I also added some more caching that makes test runs even faster. The react-native test suite now completes in about 6s (down from 7.5-8s). There might be more in the near future ;)

This fixes #554, #730, https://github.com/facebook/react/issues/5183, https://github.com/facebook/relay/issues/832 and will be part of 0.9.0. I'll publish 0.9.0-fb3 today with this fix.