### PR TITLE
Deep-unmock transitive dependencies when using `dontMock` only

### DIFF
--- a/src/HasteModuleLoader/__tests__/HasteModuleLoader-requireModule-test.js
+++ b/src/HasteModuleLoader/__tests__/HasteModuleLoader-requireModule-test.js
@@ -154,27 +154,13 @@ describe('HasteModuleLoader', function() {
       });
     });
 
-    pit(
-      'doesnt override real modules with manual mocks when explicitly ' +
-        'marked with .dontMock()',
-        function() {
-          return buildLoader().then(function(loader) {
-            const root = loader.requireModule(rootPath, './root.js');
-            root.jest.resetModuleRegistry();
-            root.jest.dontMock('ManuallyMocked');
-            const exports = loader.requireModule(rootPath, 'ManuallyMocked');
-            expect(exports.isManualMockModule).toBe(false);
-          });
-        }
-    );
-
-    pit('unmocks transitive dependencies in node_modules by default', () => {
-      return buildLoader().then(loader => {
-        const nodeModule = loader.requireModule(rootPath, 'npm3-main-dep');
-        expect(nodeModule()).toEqual({
-          isMocked: false,
-          transitiveNPM3Dep: 'npm3-transitive-dep',
-        });
+    pit(`doesn't override real modules with manual mocks when explicitly marked with .unmock()`, () => {
+      return buildLoader().then(function(loader) {
+        const root = loader.requireModule(rootPath, './root.js');
+        root.jest.resetModuleRegistry();
+        root.jest.unmock('ManuallyMocked');
+        const exports = loader.requireModule(rootPath, 'ManuallyMocked');
+        expect(exports.isManualMockModule).toBe(false);
       });
     });
   });

--- a/src/HasteModuleLoader/__tests__/HasteModuleLoader-requireModuleOrMock-test.js
+++ b/src/HasteModuleLoader/__tests__/HasteModuleLoader-requireModuleOrMock-test.js
@@ -22,7 +22,7 @@ describe('HasteModuleLoader', function() {
 
   const rootDir = path.join(__dirname, 'test_root');
   const rootPath = path.join(rootDir, 'root.js');
-  const config = utils.normalizeConfig({
+  const baseConfig = utils.normalizeConfig({
     cacheDirectory: global.CACHE_DIRECTORY,
     name: 'HasteModuleLoader-requireModuleOrMock-tests',
     rootDir,
@@ -32,7 +32,8 @@ describe('HasteModuleLoader', function() {
     },
   });
 
-  function buildLoader() {
+  function buildLoader(config) {
+    config = Object.assign({}, baseConfig, config);
     const environment = new JSDOMEnvironment(config);
     const resolver = new HasteResolver(config, {resetCache: false});
     return resolver.getHasteMap().then(
@@ -56,29 +57,25 @@ describe('HasteModuleLoader', function() {
       });
     });
 
-    pit('doesnt mock modules when explicitly dontMock()ed', function() {
+    pit(`doesn't mock modules when explicitly unmocked`, function() {
       return buildLoader().then(function(loader) {
         const root = loader.requireModule(rootDir, rootPath);
-        root.jest.dontMock('RegularModule');
+        root.jest.unmock('RegularModule');
         const exports = loader.requireModuleOrMock(rootPath, 'RegularModule');
         expect(exports.isRealModule).toBe(true);
       });
     });
 
-    pit(
-      'doesnt mock modules when explicitly dontMock()ed via a different ' +
-      'denormalized module name',
-      function() {
-        return buildLoader().then(function(loader) {
-          const root = loader.requireModule(rootDir, rootPath);
-          root.jest.dontMock('./RegularModule');
-          const exports = loader.requireModuleOrMock(rootPath, 'RegularModule');
-          expect(exports.isRealModule).toBe(true);
-        });
-      }
-    );
+    pit(`doesn't mock modules when explicitly unmocked via a different denormalized module name`, () => {
+      return buildLoader().then(function(loader) {
+        const root = loader.requireModule(rootDir, rootPath);
+        root.jest.unmock('./RegularModule');
+        const exports = loader.requireModuleOrMock(rootPath, 'RegularModule');
+        expect(exports.isRealModule).toBe(true);
+      });
+    });
 
-    pit('doesnt mock modules when autoMockOff() has been called', function() {
+    pit(`doesn't mock modules when autoMockOff() has been called`, function() {
       return buildLoader().then(function(loader) {
         const root = loader.requireModule(rootDir, rootPath);
         root.jest.autoMockOff();
@@ -121,6 +118,41 @@ describe('HasteModuleLoader', function() {
 
         exports = loader.requireModuleOrMock(rootPath, 'dog.png');
         expect(exports.isRelativeImageStub).toBe(true);
+      });
+    });
+
+    describe('transitive dependencies', () => {
+      const expectUnmocked = nodeModule => {
+        const moduleData = nodeModule();
+        expect(moduleData.isUnmocked()).toBe(true);
+        expect(moduleData.transitiveNPM3Dep).toEqual('npm3-transitive-dep');
+        expect(moduleData.internalImplementation())
+          .toEqual('internal-module-code');
+      };
+
+      pit('unmocks transitive dependencies in node_modules by default', () => {
+        return buildLoader({
+          unmockedModulePathPatterns: ['npm3-main-dep'],
+        }).then(loader => {
+          const root = loader.requireModule(rootPath, './root.js');
+          expectUnmocked(loader.requireModuleOrMock(rootPath, 'npm3-main-dep'));
+
+          // Test twice to make sure HasteModuleLoader caching works properly
+          root.jest.resetModuleRegistry();
+          expectUnmocked(loader.requireModuleOrMock(rootPath, 'npm3-main-dep'));
+        });
+      });
+
+      pit('unmocks transitive dependencies in node_modules when using unmock', () => {
+        return buildLoader().then(loader => {
+          const root = loader.requireModule(rootPath, './root.js');
+          root.jest.unmock('npm3-main-dep');
+          expectUnmocked(loader.requireModuleOrMock(rootPath, 'npm3-main-dep'));
+
+          // Test twice to make sure HasteModuleLoader caching works properly
+          root.jest.resetModuleRegistry();
+          expectUnmocked(loader.requireModuleOrMock(rootPath, 'npm3-main-dep'));
+        });
       });
     });
   });

--- a/src/HasteModuleLoader/__tests__/test_root/node_modules/npm3-main-dep/index.js
+++ b/src/HasteModuleLoader/__tests__/test_root/node_modules/npm3-main-dep/index.js
@@ -11,6 +11,7 @@
 const transitiveNPM3Dep = require('npm3-transitive-dep');
 
 module.exports = () => ({
-  isMocked: false,
+  isUnmocked: () => true,
   transitiveNPM3Dep: transitiveNPM3Dep(),
+  internalImplementation: transitiveNPM3Dep.internalImplementation,
 });

--- a/src/HasteModuleLoader/__tests__/test_root/node_modules/npm3-transitive-dep/internal-code.js
+++ b/src/HasteModuleLoader/__tests__/test_root/node_modules/npm3-transitive-dep/internal-code.js
@@ -8,7 +8,4 @@
 
 'use strict';
 
-const internalImplementation = require('./internal-code');
-
-module.exports = () => 'npm3-transitive-dep';
-module.exports.internalImplementation = internalImplementation;
+module.exports = () => 'internal-module-code';


### PR DESCRIPTION
…also fixes a bunch of other transitive unmocking things + simplify `_shouldMock` + cache metadata more thoroughly.

This should now work properly. We are deep-unmocking node_modules now which seems like the more sensible solution and works similar to how we deal with npm2. Given that npm2 also dedupes and install order matters (or well, npm is non-deterministic), this should now be the much saner choice for both projects.