### PR TITLE
Bind all process event functions

### DIFF
--- a/src/environments/installCommonGlobals.js
+++ b/src/environments/installCommonGlobals.js
@@ -8,25 +8,28 @@
 'use strict';
 
 const utils = require('../lib/utils');
-const EventEmitter = require('events').EventEmitter;
 
 module.exports = (global, globals) => {
   // Forward some APIs
   global.Buffer = Buffer;
   // `global.process` is mutated by FakeTimers. Make a copy of the
   // object for the jsdom environment to prevent memory leaks.
-  global.process = Object.assign({}, process);
+  global.process                    = Object.assign({}, process);
 
-  // Correctly bind all event functions
-  for (var func in EventEmitter.prototype)
-  {
-    if (typeof EventEmitter.prototype[func] == 'function')
-    {
-      global.process[func] = process[func].bind(process);
-    }
-  }
+  // Correctly bind all EventEmitter functions
+  global.process.setMaxListeners    = process.setMaxListeners.bind(process);
+  global.process.getMaxListeners    = process.getMaxListeners.bind(process);
+  global.process.emit               = process.emit.bind(process);
+  global.process.addListener        = process.addListener.bind(process);
+  global.process.on                 = process.on.bind(process);
+  global.process.once               = process.once.bind(process);
+  global.process.removeListener     = process.removeListener.bind(process);
+  global.process.removeAllListeners = process.removeAllListeners.bind(process);
+  global.process.listeners          = process.listeners.bind(process);
+  global.process.listenerCount      = process.listenerCount.bind(process);
 
-  global.setImmediate = setImmediate;
-  global.clearImmediate = clearImmediate;
+  global.setImmediate               = setImmediate;
+  global.clearImmediate             = clearImmediate;
+
   Object.assign(global, utils.deepCopy(globals));
 };

--- a/src/environments/installCommonGlobals.js
+++ b/src/environments/installCommonGlobals.js
@@ -8,6 +8,7 @@
 'use strict';
 
 const utils = require('../lib/utils');
+const EventEmitter = require('events').EventEmitter;
 
 module.exports = (global, globals) => {
   // Forward some APIs
@@ -15,7 +16,16 @@ module.exports = (global, globals) => {
   // `global.process` is mutated by FakeTimers. Make a copy of the
   // object for the jsdom environment to prevent memory leaks.
   global.process = Object.assign({}, process);
-  global.process.on = process.on.bind(process);
+
+  // Correctly bind all event functions
+  for (var func in EventEmitter.prototype)
+  {
+    if (typeof EventEmitter.prototype[func] == 'function')
+    {
+      global.process[func] = process[func].bind(process);
+    }
+  }
+
   global.setImmediate = setImmediate;
   global.clearImmediate = clearImmediate;
   Object.assign(global, utils.deepCopy(globals));


### PR DESCRIPTION
Not all process event functions are correctly bind to the original process object. Currently only process.on is bind correctly. This pull requests binds all EventEmitter functions to the correct object.

I am not 100% sure, but maybe this fix could be applied to all process functions instead of only the EventEmitter ones? This could easily be done as following:

```js
for (var func in process)
{
  if (typeof process[func] == 'function')
  {
    global.process[func] = process[func].bind(process);
  }
}
```