### PR TITLE
Set `process.env.NODE_ENV = ‘test’` by default.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Fixed mocking of fields that start with an underscore ("private fields").
 * Fixed unmocking behavior with npm3.
 * Fixed test runtime error reporting and stack traces.
+* Jest sets `process.NODE_ENV` to `test` unless otherwise specified.
 
 ## 0.8.2
 

--- a/bin/jest.js
+++ b/bin/jest.js
@@ -298,4 +298,8 @@ function runJest() {
   });
 }
 
+if (process.env.NODE_ENV == null) {
+  process.env.NODE_ENV = 'test';
+}
+
 runJest();


### PR DESCRIPTION
This is very useful for turning on specific babel transforms in jest 0.9.0: https://github.com/facebook/jest/blob/master/examples/react/.babelrc#L4

This convention is also used by frameworks like Relay, see https://github.com/facebook/relay/blob/master/package.json#L26 and it is confusing not to have this.

The default can be overwritten by defining the `NODE_ENV` environment variable before calling jest, so `NODE_ENV=prod jest` will continue to work.