### PR TITLE
Add config.jsdomModulePath

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Check out the [Getting Started](http://facebook.github.io/jest/docs/getting-star
   - [`config.collectCoverage` [boolean]](http://facebook.github.io/jest/docs/api.html#config-collectcoverage-boolean)
   - [`config.collectCoverageOnlyFrom` [object]](http://facebook.github.io/jest/docs/api.html#config-collectcoverageonlyfrom-object)
   - [`config.globals` [object]](http://facebook.github.io/jest/docs/api.html#config-globals-object)
+  - [`config.jsdomModulePath` [string]](http://facebook.github.io/jest/docs/api.html#config-jsdommodulepath-string)
   - [`config.moduleFileExtensions` [array<string>]](http://facebook.github.io/jest/docs/api.html#config-modulefileextensions-array-string)
   - [`config.modulePathIgnorePatterns` [array<string>]](http://facebook.github.io/jest/docs/api.html#config-modulepathignorepatterns-array-string)
   - [`config.moduleNameMapper` [object<string, string>]](http://facebook.github.io/jest/docs/api.html#config-modulenamemapper-object-string-string)

--- a/docs/API.md
+++ b/docs/API.md
@@ -41,6 +41,7 @@ permalink: docs/api.html
   - [`config.collectCoverage` [boolean]](#config-collectcoverage-boolean)
   - [`config.collectCoverageOnlyFrom` [object]](#config-collectcoverageonlyfrom-object)
   - [`config.globals` [object]](#config-globals-object)
+  - [`config.jsdomModulePath` [string]](#config-jsdommodulepath-string)
   - [`config.mocksPattern` [string]](#config-mockspattern-string)
   - [`config.moduleFileExtensions` [array<string>]](#config-modulefileextensions-array-string)
   - [`config.modulePathIgnorePatterns` [array<string>]](#config-modulepathignorepatterns-array-string)
@@ -317,6 +318,11 @@ For example, the following would create a global `__DEV__` variable set to `true
 ```
 
 Note that, if you specify a global reference value (like an object or array) here, and some code mutates that value in the midst of running a test, that mutation will *not* be persisted across test runs for other test files.
+
+### `config.jsdomModulePath` [string]
+(default: `undefined`)
+
+The path to a specific version of the JSDOM module to be used in the test runner. There may be some lag time between JSDOM releases and updating the internally-used version in Jest, thus an alternate version can be provided if necessary.
 
 ### `config.mocksPattern` [string]
 (default: `(?:[\\/]|^)__mocks__[\\/]`)

--- a/src/environments/JSDOMEnvironment.js
+++ b/src/environments/JSDOMEnvironment.js
@@ -14,7 +14,7 @@ class JSDOMEnvironment {
 
   constructor(config) {
     // lazy require
-    this.document = require('jsdom').jsdom(/* markup */undefined, {
+    this.document = require(config.jsdomModulePath || 'jsdom').jsdom(/* markup */undefined, {
       url: config.testURL,
     });
     this.global = this.document.defaultView;

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -126,6 +126,7 @@ function normalizeConfig(config) {
         break;
 
       case 'cacheDirectory':
+      case 'jsdomModulePath':
       case 'testRunner':
       case 'scriptPreprocessor':
       case 'setupEnvScriptFile':


### PR DESCRIPTION
Allows for providing a specific version of JSDOM to use in the runner, rather than the version Jest currently has pulled in as a dep.

Use case:

1. JSDOM updates to a new major version (9.x)
1. Install it in your project as normal, `npm i jsdom@latest --save-dev`
1. Add this to your package.json "jest" entry: `"jsdomModulePath": "node_modules/jsdom"`
1. Remove it later on (or not) when Jest updates to it by default