### PR TITLE
Add babel-jest into the repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 * Fixed unmocking behavior with npm3.
 * Fixed test runtime error reporting and stack traces.
 * Jest sets `process.NODE_ENV` to `test` unless otherwise specified.
+* Added `babel-plugin-jest-unmock`, `babel-jest-preset` and `babel-jest`
+  as packages. `babel-jest` is now being auto-detected.
 
 ## 0.8.2
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -49,7 +49,7 @@ permalink: docs/api.html
   - [`config.rootDir` [string]](#config-rootdir-string)
   - [`config.scriptPreprocessor` [string]](#config-scriptpreprocessor-string)
   - [`config.preprocessorIgnorePatterns` [array<string>]](#config-preprocessorignorepatterns-array-string)
-  - [`config.setupEnvScriptFile` [string]](#config-setupenvscriptfile-string)
+  - [`config.setupFiles` [array]](#config-setupfiles-array)
   - [`config.setupTestFrameworkScriptFile` [string]](#config-setuptestframeworkscriptfile-string)
   - [`config.testDirectoryName` [string]](#config-testdirectoryname-string)
   - [`config.testFileExtensions` [array<string>]](#config-testfileextensions-array-string)
@@ -360,7 +360,7 @@ The root directory that Jest should scan for tests and modules within. If you pu
 
 Oftentimes, you'll want to set this to `'src'` or `'lib'`, corresponding to where in your repository the code is stored.
 
-Note also that you can use `'<rootDir>'` as a string token in any other path-based config settings to refer back to this value. So, for example, if you want your [`config.setupEnvScriptFile`](#config-setupenvscriptfile-string) config entry to point at the `env-setup.js` file at the root of your project, you could set its value to `'<rootDir>/env-setup.js'`.
+Note also that you can use `'<rootDir>'` as a string token in any other path-based config settings to refer back to this value. So, for example, if you want your [`config.setupFiles`](#config-setupfiles-array) config entry to point at the `env-setup.js` file at the root of your project, you could set its value to `['<rootDir>/env-setup.js']`.
 
 ### `config.scriptPreprocessor` [string]
 (default: `undefined`)
@@ -374,17 +374,17 @@ Examples of such compilers include [jstransform](http://github.com/facebook/jstr
 
 An array of regexp pattern strings that are matched against all source file paths before preprocessing. If the test path matches any of the patterns, it will not be preprocessed.
 
-### `config.setupEnvScriptFile` [string]
-(default: `undefined`)
+### `config.setupFiles` [array]
+(default: `[]`)
 
-The path to a module that runs some code to configure or set up the testing environment before each test. Since every test runs in it's own environment, this script will be executed in the testing environment immediately before executing the test code itself.
+The paths to modules that run some code to configure or set up the testing environment before each test. Since every test runs in it's own environment, these scripts will be executed in the testing environment immediately before executing the test code itself.
 
 It's worth noting that this code will execute *before* [`config.setupTestFrameworkScriptFile`](#config-setuptestframeworkscriptfile-string).
 
 ### `config.setupTestFrameworkScriptFile` [string]
 (default: `undefined`)
 
-The path to a module that runs some code to configure or set up the testing framework before each test. Since [`config.setupEnvScriptFile`](#config-setupenvscriptfile-string) executes before the test framework is installed in the environment, this script file presents you the opportunity of running some code immediately after the test framework has been installed in the environment.
+The path to a module that runs some code to configure or set up the testing framework before each test. Since [`config.setupFiles`](#config-setupfiles-array) executes before the test framework is installed in the environment, this script file presents you the opportunity of running some code immediately after the test framework has been installed in the environment.
 
 For example, Jest ships with several plug-ins to `jasmine` that work by monkey-patching the jasmine API. If you wanted to add even more jasmine plugins to the mix (or if you wanted some custom, project-wide matchers for example), you could do so in this module.
 

--- a/examples/react/.babelrc
+++ b/examples/react/.babelrc
@@ -1,8 +1,3 @@
 {
-  "presets": ["es2015", "react"],
-  "env": {
-    "test": {
-      "presets": ["jest"]
-    }
-  }
+  "presets": ["es2015", "react"]
 }

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -4,10 +4,9 @@
     "react-dom": "~0.14.0"
   },
   "devDependencies": {
-    "babel-jest": "*",
+    "babel-jest": "^9.0.0",
     "babel-preset-es2015": "*",
     "babel-preset-react": "*",
-    "babel-preset-jest": "*",
     "jest-cli": "*",
     "react-addons-test-utils": "~0.14.0"
   },
@@ -15,7 +14,6 @@
     "test": "jest"
   },
   "jest": {
-    "scriptPreprocessor": "<rootDir>/node_modules/babel-jest",
     "unmockedModulePathPatterns": [
       "<rootDir>/node_modules/react",
       "<rootDir>/node_modules/react-dom",

--- a/packages/babel-jest/README.md
+++ b/packages/babel-jest/README.md
@@ -1,0 +1,13 @@
+# babel-jest
+
+[Babel](https://github.com/babel/babel) [jest](https://github.com/facebook/jest) plugin
+
+## Usage
+
+If you are already using `jest-cli`, just add `babel-jest` and it will automatically compile JavaScript code using babel.
+
+```
+npm install --save babel-jest
+```
+
+If you would like to write your own preprocessor, uninstall and delete babel-jest and set the [config.scriptPreprocessor](http://facebook.github.io/jest/docs/api.html#config-scriptpreprocessor-string) option to your preprocessor.

--- a/packages/babel-jest/package.json
+++ b/packages/babel-jest/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "babel-jest",
+  "version": "9.0.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/facebook/jest.git"
+  },
+  "license": "BSD-3-Clause",
+  "main": "src/index.js",
+  "dependencies": {
+    "babel-core": "^6.0.0",
+    "babel-preset-jest": "^1.0.0"
+  }
+}

--- a/packages/babel-jest/src/index.js
+++ b/packages/babel-jest/src/index.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+const babel = require('babel-core');
+const jestPreset = require('babel-preset-jest');
+const path = require('path');
+
+const NODE_MODULES = path.sep + 'node_modules' + path.sep;
+
+module.exports = {
+  process(src, filename) {
+    if (!filename.includes(NODE_MODULES) && babel.util.canCompile(filename)) {
+      return babel.transform(src, {
+        filename,
+        presets: [jestPreset],
+        retainLines: true,
+      }).code;
+    }
+    return src;
+  },
+};

--- a/packages/babel-plugin-jest-unmock/README.md
+++ b/packages/babel-plugin-jest-unmock/README.md
@@ -1,6 +1,6 @@
 # babel-plugin-jest-unmock
 
-Babel plugin to hoist `jest.unmock` calls above `import` statements.
+Babel plugin to hoist `jest.unmock` calls above `import` statements. This plugin is automatically included when using [babel-jest](https://github.com/facebook/jest/tree/master/packages/babel-jest).
 
 ## Installation
 

--- a/packages/babel-preset-jest/README.md
+++ b/packages/babel-preset-jest/README.md
@@ -1,6 +1,6 @@
 # babel-preset-jest
 
-> Babel preset for all Jest plugins.
+> Babel preset for all Jest plugins. This preset is automatically included when using [babel-jest](https://github.com/facebook/jest/tree/master/packages/babel-jest).
 
 ## Install
 

--- a/src/Test.js
+++ b/src/Test.js
@@ -32,9 +32,12 @@ class Test {
     );
     env.testFilePath = path;
     const moduleLoader = new ModuleLoader(config, env, moduleMap);
-    if (config.setupEnvScriptFile) {
-      moduleLoader.requireModule(null, config.setupEnvScriptFile);
+    if (config.setupFiles.length) {
+      for (let i = 0; i < config.setupFiles.length; i++) {
+        moduleLoader.requireModule(null, config.setupFiles[i]);
+      }
     }
+
     const start = Date.now();
     return TestRunner(config, env, moduleLoader, path)
       .then(result => {

--- a/src/lib/__tests__/utils-normalizeConfig-test.js
+++ b/src/lib/__tests__/utils-normalizeConfig-test.js
@@ -11,14 +11,14 @@
 
 jest.autoMockOff();
 
-describe('utils-normalizeConfig', function() {
-  var path;
-  var root;
-  var utils;
-  var expectedPathFooBar;
-  var expectedPathFooQux;
-  var expectedPathAbs;
-  var expectedPathAbsAnother;
+describe('utils-normalizeConfig', () => {
+  let path;
+  let root;
+  let utils;
+  let expectedPathFooBar;
+  let expectedPathFooQux;
+  let expectedPathAbs;
+  let expectedPathAbsAnother;
 
   // Windows uses backslashes for path separators, which need to be escaped in
   // regular expressions. This little helper function helps us generate the
@@ -30,7 +30,7 @@ describe('utils-normalizeConfig', function() {
     );
   }
 
-  beforeEach(function() {
+  beforeEach(() => {
     path = require('path');
     root = path.resolve('/');
     expectedPathFooBar = path.join(root, 'root', 'path', 'foo', 'bar', 'baz');
@@ -40,9 +40,9 @@ describe('utils-normalizeConfig', function() {
     utils = require('../utils');
   });
 
-  it('throws when an invalid config option is passed in', function() {
+  it('throws when an invalid config option is passed in', () => {
 
-    expect(function() {
+    expect(() => {
       utils.normalizeConfig({
         rootDir: '/root/path/foo',
         thisIsAnInvalidConfigKey: 'with a value even!',
@@ -51,17 +51,17 @@ describe('utils-normalizeConfig', function() {
 
   });
 
-  describe('rootDir', function() {
-    it('throws if the config is missing a rootDir property', function() {
-      expect(function() {
+  describe('rootDir', () => {
+    it('throws if the config is missing a rootDir property', () => {
+      expect(() => {
         utils.normalizeConfig({});
       }).toThrow(new Error('No rootDir config value found!'));
     });
   });
 
-  describe('collectCoverageOnlyFrom', function() {
-    it('normalizes all paths relative to rootDir', function() {
-      var config = utils.normalizeConfig({
+  describe('collectCoverageOnlyFrom', () => {
+    it('normalizes all paths relative to rootDir', () => {
+      const config = utils.normalizeConfig({
         rootDir: '/root/path/foo/',
         collectCoverageOnlyFrom: {
           'bar/baz': true,
@@ -69,15 +69,15 @@ describe('utils-normalizeConfig', function() {
         },
       }, '/root/path');
 
-      var expected = {};
+      const expected = {};
       expected[expectedPathFooBar] = true;
       expected[expectedPathFooQux] = true;
 
       expect(config.collectCoverageOnlyFrom).toEqual(expected);
     });
 
-    it('does not change absolute paths', function() {
-      var config = utils.normalizeConfig({
+    it('does not change absolute paths', () => {
+      const config = utils.normalizeConfig({
         rootDir: '/root/path/foo',
         collectCoverageOnlyFrom: {
           '/an/abs/path': true,
@@ -85,31 +85,31 @@ describe('utils-normalizeConfig', function() {
         },
       });
 
-      var expected = {};
+      const expected = {};
       expected[expectedPathAbs] = true;
       expected[expectedPathAbsAnother] = true;
 
       expect(config.collectCoverageOnlyFrom).toEqual(expected);
     });
 
-    it('substitutes <rootDir> tokens', function() {
-      var config = utils.normalizeConfig({
+    it('substitutes <rootDir> tokens', () => {
+      const config = utils.normalizeConfig({
         rootDir: '/root/path/foo',
         collectCoverageOnlyFrom: {
           '<rootDir>/bar/baz': true,
         },
       });
 
-      var expected = {};
+      const expected = {};
       expected[expectedPathFooBar] = true;
 
       expect(config.collectCoverageOnlyFrom).toEqual(expected);
     });
   });
 
-  describe('testPathDirs', function() {
-    it('normalizes all paths relative to rootDir', function() {
-      var config = utils.normalizeConfig({
+  describe('testPathDirs', () => {
+    it('normalizes all paths relative to rootDir', () => {
+      const config = utils.normalizeConfig({
         rootDir: '/root/path/foo',
         testPathDirs: [
           'bar/baz',
@@ -122,8 +122,8 @@ describe('utils-normalizeConfig', function() {
       ]);
     });
 
-    it('does not change absolute paths', function() {
-      var config = utils.normalizeConfig({
+    it('does not change absolute paths', () => {
+      const config = utils.normalizeConfig({
         rootDir: '/root/path/foo',
         testPathDirs: [
           '/an/abs/path',
@@ -136,8 +136,8 @@ describe('utils-normalizeConfig', function() {
       ]);
     });
 
-    it('substitutes <rootDir> tokens', function() {
-      var config = utils.normalizeConfig({
+    it('substitutes <rootDir> tokens', () => {
+      const config = utils.normalizeConfig({
         rootDir: '/root/path/foo',
         testPathDirs: [
           '<rootDir>/bar/baz',
@@ -148,9 +148,9 @@ describe('utils-normalizeConfig', function() {
     });
   });
 
-  describe('scriptPreprocessor', function() {
-    it('normalizes the path according to rootDir', function() {
-      var config = utils.normalizeConfig({
+  describe('scriptPreprocessor', () => {
+    it('normalizes the path according to rootDir', () => {
+      const config = utils.normalizeConfig({
         rootDir: '/root/path/foo',
         scriptPreprocessor: 'bar/baz',
       }, '/root/path');
@@ -158,8 +158,8 @@ describe('utils-normalizeConfig', function() {
       expect(config.scriptPreprocessor).toEqual(expectedPathFooBar);
     });
 
-    it('does not change absolute paths', function() {
-      var config = utils.normalizeConfig({
+    it('does not change absolute paths', () => {
+      const config = utils.normalizeConfig({
         rootDir: '/root/path/foo',
         scriptPreprocessor: '/an/abs/path',
       });
@@ -167,8 +167,8 @@ describe('utils-normalizeConfig', function() {
       expect(config.scriptPreprocessor).toEqual(expectedPathAbs);
     });
 
-    it('substitutes <rootDir> tokens', function() {
-      var config = utils.normalizeConfig({
+    it('substitutes <rootDir> tokens', () => {
+      const config = utils.normalizeConfig({
         rootDir: '/root/path/foo',
         scriptPreprocessor: '<rootDir>/bar/baz',
       });
@@ -177,38 +177,9 @@ describe('utils-normalizeConfig', function() {
     });
   });
 
-  describe('setupEnvScriptFile', function() {
-    it('normalizes the path according to rootDir', function() {
-      var config = utils.normalizeConfig({
-        rootDir: '/root/path/foo',
-        setupEnvScriptFile: 'bar/baz',
-      }, '/root/path');
-
-      expect(config.setupEnvScriptFile).toEqual(expectedPathFooBar);
-    });
-
-    it('does not change absolute paths', function() {
-      var config = utils.normalizeConfig({
-        rootDir: '/root/path/foo',
-        setupEnvScriptFile: '/an/abs/path',
-      });
-
-      expect(config.setupEnvScriptFile).toEqual(expectedPathAbs);
-    });
-
-    it('substitutes <rootDir> tokens', function() {
-      var config = utils.normalizeConfig({
-        rootDir: '/root/path/foo',
-        setupEnvScriptFile: '<rootDir>/bar/baz',
-      });
-
-      expect(config.setupEnvScriptFile).toEqual(expectedPathFooBar);
-    });
-  });
-
-  describe('setupTestFrameworkScriptFile', function() {
-    it('normalizes the path according to rootDir', function() {
-      var config = utils.normalizeConfig({
+  describe('setupTestFrameworkScriptFile', () => {
+    it('normalizes the path according to rootDir', () => {
+      const config = utils.normalizeConfig({
         rootDir: '/root/path/foo',
         setupTestFrameworkScriptFile: 'bar/baz',
       }, '/root/path');
@@ -216,8 +187,8 @@ describe('utils-normalizeConfig', function() {
       expect(config.setupTestFrameworkScriptFile).toEqual(expectedPathFooBar);
     });
 
-    it('does not change absolute paths', function() {
-      var config = utils.normalizeConfig({
+    it('does not change absolute paths', () => {
+      const config = utils.normalizeConfig({
         rootDir: '/root/path/foo',
         setupTestFrameworkScriptFile: '/an/abs/path',
       });
@@ -225,8 +196,8 @@ describe('utils-normalizeConfig', function() {
       expect(config.setupTestFrameworkScriptFile).toEqual(expectedPathAbs);
     });
 
-    it('substitutes <rootDir> tokens', function() {
-      var config = utils.normalizeConfig({
+    it('substitutes <rootDir> tokens', () => {
+      const config = utils.normalizeConfig({
         rootDir: '/root/path/foo',
         setupTestFrameworkScriptFile: '<rootDir>/bar/baz',
       });
@@ -235,11 +206,40 @@ describe('utils-normalizeConfig', function() {
     });
   });
 
-  describe('testPathIgnorePatterns', function() {
-    it('does not normalize paths relative to rootDir', function() {
+  describe('setupTestFrameworkScriptFile', () => {
+    it('normalizes the path according to rootDir', () => {
+      const config = utils.normalizeConfig({
+        rootDir: '/root/path/foo',
+        setupTestFrameworkScriptFile: 'bar/baz',
+      }, '/root/path');
+
+      expect(config.setupTestFrameworkScriptFile).toEqual(expectedPathFooBar);
+    });
+
+    it('does not change absolute paths', () => {
+      const config = utils.normalizeConfig({
+        rootDir: '/root/path/foo',
+        setupTestFrameworkScriptFile: '/an/abs/path',
+      });
+
+      expect(config.setupTestFrameworkScriptFile).toEqual(expectedPathAbs);
+    });
+
+    it('substitutes <rootDir> tokens', () => {
+      const config = utils.normalizeConfig({
+        rootDir: '/root/path/foo',
+        setupTestFrameworkScriptFile: '<rootDir>/bar/baz',
+      });
+
+      expect(config.setupTestFrameworkScriptFile).toEqual(expectedPathFooBar);
+    });
+  });
+
+  describe('testPathIgnorePatterns', () => {
+    it('does not normalize paths relative to rootDir', () => {
       // This is a list of patterns, so we can't assume any of them are
       // directories
-      var config = utils.normalizeConfig({
+      const config = utils.normalizeConfig({
         rootDir: '/root/path/foo',
         testPathIgnorePatterns: [
           'bar/baz',
@@ -253,10 +253,10 @@ describe('utils-normalizeConfig', function() {
       ]);
     });
 
-    it('does not normalize trailing slashes', function() {
+    it('does not normalize trailing slashes', () => {
       // This is a list of patterns, so we can't assume any of them are
       // directories
-      var config = utils.normalizeConfig({
+      const config = utils.normalizeConfig({
         rootDir: '/root/path/foo',
         testPathIgnorePatterns: [
           'bar/baz',
@@ -270,8 +270,8 @@ describe('utils-normalizeConfig', function() {
       ]);
     });
 
-    it('substitutes <rootDir> tokens', function() {
-      var config = utils.normalizeConfig({
+    it('substitutes <rootDir> tokens', () => {
+      const config = utils.normalizeConfig({
         rootDir: '/root/path/foo',
         testPathIgnorePatterns: [
           'hasNoToken',
@@ -286,11 +286,11 @@ describe('utils-normalizeConfig', function() {
     });
   });
 
-  describe('modulePathIgnorePatterns', function() {
-    it('does not normalize paths relative to rootDir', function() {
+  describe('modulePathIgnorePatterns', () => {
+    it('does not normalize paths relative to rootDir', () => {
       // This is a list of patterns, so we can't assume any of them are
       // directories
-      var config = utils.normalizeConfig({
+      const config = utils.normalizeConfig({
         rootDir: '/root/path/foo',
         modulePathIgnorePatterns: [
           'bar/baz',
@@ -304,10 +304,10 @@ describe('utils-normalizeConfig', function() {
       ]);
     });
 
-    it('does not normalize trailing slashes', function() {
+    it('does not normalize trailing slashes', () => {
       // This is a list of patterns, so we can't assume any of them are
       // directories
-      var config = utils.normalizeConfig({
+      const config = utils.normalizeConfig({
         rootDir: '/root/path/foo',
         modulePathIgnorePatterns: [
           'bar/baz',
@@ -321,8 +321,8 @@ describe('utils-normalizeConfig', function() {
       ]);
     });
 
-    it('substitutes <rootDir> tokens', function() {
-      var config = utils.normalizeConfig({
+    it('substitutes <rootDir> tokens', () => {
+      const config = utils.normalizeConfig({
         rootDir: '/root/path/foo',
         modulePathIgnorePatterns: [
           'hasNoToken',

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -30,6 +30,7 @@ const DEFAULT_CONFIG_VALUES = {
   haste: {
     providesModuleNodeModules: [],
   },
+  setupFiles: [],
   preprocessorIgnorePatterns: [],
   modulePathIgnorePatterns: [],
   moduleNameMapper: [],
@@ -101,6 +102,14 @@ function normalizeConfig(config) {
 
   config.rootDir = path.normalize(config.rootDir);
 
+  if (config.setupEnvScriptFile) {
+    if (!config.setupFiles) {
+      config.setupFiles = [];
+    }
+    config.setupFiles.push(config.setupEnvScriptFile);
+    delete config.setupEnvScriptFile;
+  }
+
   // Normalize user-supplied config options
   Object.keys(config).reduce(function(newConfig, key) {
     let value;
@@ -116,19 +125,17 @@ function normalizeConfig(config) {
         }, {});
         break;
 
+      case 'setupFiles':
       case 'testPathDirs':
-        value = config[key].map(function(scanDir) {
-          return path.resolve(
-            config.rootDir,
-            _replaceRootDirTags(config.rootDir, scanDir)
-          );
-        });
-        break;
+        value = config[key].map(filePath => path.resolve(
+          config.rootDir,
+          _replaceRootDirTags(config.rootDir, filePath)
+        ));
+          break;
 
       case 'cacheDirectory':
       case 'testRunner':
       case 'scriptPreprocessor':
-      case 'setupEnvScriptFile':
       case 'setupTestFrameworkScriptFile':
         value = path.resolve(
           config.rootDir,


### PR DESCRIPTION
babel-jest is moving into jest as a package. This allows us to consolidate the codebase. Note that we are only re-using the npm package for babel-jest but the implementation actually changed as the `babel-preset-jest` is now being loaded automatically.

When `babel-jest` is installed in the project that jest is being run on, it will now automatically be loaded. See the `examples/react` folder – the only setup needed for babel to work is to enable the default presets (es2015 and react) and to `npm install babel-jest`. In this PR I also added the `setupFiles` config flag. There isn't really a reason to limit this to a single entry.