### PR TITLE
Make Jasmine 2 the default, add automock and testEnvironment options.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@
   as packages. `babel-jest` is now being auto-detected.
 * Added `jest.fn()` and `jest.fn(implementation)` as convenient shorcuts for
   `jest.genMockFunction()` and `jest.genMockFunction().mockImplementation()`.
+* Jasmine 2 is now the default test runner. To keep using Jasmine 1, put
+  `testRunner: "jasmine1"` into your configuration.
+* Added an `automock` option to turn off automocking globally.
+* Added a `testEnvironment` option to customize the sandbox environment.
 
 ## 0.8.2
 

--- a/bin/jest.js
+++ b/bin/jest.js
@@ -163,9 +163,10 @@ const argv = optimist
     },
     testRunner: {
       description: _wrapDesc(
-        'Allows to specify a custom test runner. Jest ships with jasmine2 ' +
-        'which can be enabled by setting this option to ' +
-        '`<rootDir>/node_modules/jest-cli/src/testRunners/jasmine/jasmine2.js`'
+        'Allows to specify a custom test runner. Jest ships with Jasmine ' +
+        '1 and 2 which can be enabled by setting this option to ' +
+        '`jasmine1` or `jasmine2`. The default is `jasmine2`. A path to a ' +
+        'custom test runner can be provided: `<rootDir>/path/to/testRunner.js`.'
       ),
       type: 'string',
     },

--- a/package.json
+++ b/package.json
@@ -39,15 +39,12 @@
     "lint": "eslint .",
     "prepublish": "npm test",
     "test": "npm run lint && node bin/jest.js && npm run jasmine1",
-    "jasmine1": "node bin/jest.js --testRunner='<rootDir>/testRunners/jasmine/jasmine1.js'"
+    "jasmine1": "node bin/jest.js --testRunner=jasmine1"
   },
   "jest": {
     "rootDir": "src",
-    "testRunner": "<rootDir>/testRunners/jasmine/jasmine2.js",
-    "testPathIgnorePatterns": [
-      "/__tests__/[^/]*/.+"
-    ],
-    "testEnvironment_EXPERIMENTAL": "<rootDir>/environments/NodeEnvironment",
+    "testPathIgnorePatterns": ["/__tests__/[^/]*/.+"],
+    "testEnvironment": "<rootDir>/environments/NodeEnvironment",
     "globals": {
       "CACHE_DIRECTORY": "<rootDir>/../.haste_cache"
     }

--- a/src/HasteModuleLoader/HasteModuleLoader.js
+++ b/src/HasteModuleLoader/HasteModuleLoader.js
@@ -45,7 +45,7 @@ class Loader {
     this._isCurrentlyExecutingManualMock = null;
     this._testDirectoryName = path.sep + config.testDirectoryName + path.sep;
 
-    this._shouldAutoMock = true;
+    this._shouldAutoMock = config.automock;
     this._extensions = config.moduleFileExtensions.map(ext => '.' + ext);
 
     this._modules = moduleMap.modules;

--- a/src/HasteModuleLoader/__tests__/HasteModuleLoader-requireModuleOrMock-test.js
+++ b/src/HasteModuleLoader/__tests__/HasteModuleLoader-requireModuleOrMock-test.js
@@ -121,6 +121,17 @@ describe('HasteModuleLoader', function() {
       });
     });
 
+    describe('automocking behavior', () => {
+      it('can be disabled by default', () => {
+        return buildLoader({
+          automock: false,
+        }).then(loader => {
+          const exports = loader.requireModuleOrMock(rootPath, 'RegularModule');
+          expect(exports.setModuleStateValue._isMockFunction).toBe(undefined);
+        });
+      });
+    });
+
     describe('transitive dependencies', () => {
       const expectUnmocked = nodeModule => {
         const moduleData = nodeModule();

--- a/src/jest.js
+++ b/src/jest.js
@@ -121,18 +121,6 @@ function readConfig(argv, packageRoot) {
       config.useStderr = true;
     }
 
-    if (argv.testRunner) {
-      try {
-        config.testRunner = require.resolve(
-          argv.testRunner.replace(/<rootDir>/g, config.rootDir)
-        );
-      } catch (e) {
-        throw new Error(
-          `jest: testRunner path "${argv.testRunner}" is not a valid path.`
-        );
-      }
-    }
-
     if (argv.logHeapUsage) {
       config.logHeapUsage = argv.logHeapUsage;
     }
@@ -149,7 +137,7 @@ function readRawConfig(argv, packageRoot) {
   }
 
   if (typeof argv.config === 'object') {
-    return Promise.resolve(utils.normalizeConfig(argv.config));
+    return Promise.resolve(utils.normalizeConfig(argv.config, argv));
   }
 
   const pkgJsonPath = path.join(packageRoot, 'package.json');
@@ -162,7 +150,7 @@ function readRawConfig(argv, packageRoot) {
     } else {
       pkgJson.jest.rootDir = path.resolve(packageRoot, pkgJson.jest.rootDir);
     }
-    const config = utils.normalizeConfig(pkgJson.jest);
+    const config = utils.normalizeConfig(pkgJson.jest, argv);
     config.name = pkgJson.name;
     return Promise.resolve(config);
   }
@@ -171,9 +159,8 @@ function readRawConfig(argv, packageRoot) {
   return Promise.resolve(utils.normalizeConfig({
     name: packageRoot.replace(/[/\\]/g, '_'),
     rootDir: packageRoot,
-    testPathDirs: [packageRoot],
     testPathIgnorePatterns: ['/node_modules/.+'],
-  }));
+  }, argv));
 }
 
 function findOnlyChangedTestPaths(testRunner, config) {

--- a/src/lib/__tests__/utils-normalizeConfig-test.js
+++ b/src/lib/__tests__/utils-normalizeConfig-test.js
@@ -40,15 +40,21 @@ describe('utils-normalizeConfig', () => {
     utils = require('../utils');
   });
 
-  it('throws when an invalid config option is passed in', () => {
+  it('errors when an invalid config option is passed in', () => {
+    const error = console.error;
+    console.error = jest.fn();
+    utils.normalizeConfig({
+      rootDir: '/root/path/foo',
+      thisIsAnInvalidConfigKey: 'with a value even!',
+    });
 
-    expect(() => {
-      utils.normalizeConfig({
-        rootDir: '/root/path/foo',
-        thisIsAnInvalidConfigKey: 'with a value even!',
-      });
-    }).toThrow(new Error('Unknown config option: thisIsAnInvalidConfigKey'));
+    expect(console.error).toBeCalledWith(
+      'Error: Unknown config option "thisIsAnInvalidConfigKey" with value ' +
+      '"with a value even!". This is either a typing error or another user ' +
+      'mistake and fixing it will remove this message.'
+    );
 
+    console.error = error;
   });
 
   describe('rootDir', () => {
@@ -334,6 +340,38 @@ describe('utils-normalizeConfig', () => {
         'hasNoToken',
         joinForPattern('', 'root', 'path', 'foo', 'hasAToken'),
       ]);
+    });
+  });
+
+  describe('testRunner', () => {
+    it('defaults to Jasmine 2', () => {
+      const config = utils.normalizeConfig({
+        rootDir: '/root/path/foo',
+      });
+
+      expect(config.testRunner.endsWith('jasmine2.js')).toBe(true);
+    });
+
+    it('can be changed to jasmine1', () => {
+      const config = utils.normalizeConfig({
+        rootDir: '/root/path/foo',
+        testRunner: 'jasmine1',
+      });
+
+      expect(config.testRunner.endsWith('jasmine1.js')).toBe(true);
+    });
+
+    it('is overwritten by argv', () => {
+      const config = utils.normalizeConfig(
+        {
+          rootDir: '/root/path/foo',
+        },
+        {
+          testRunner: 'jasmine1',
+        }
+      );
+
+      expect(config.testRunner.endsWith('jasmine1.js')).toBe(true);
     });
   });
 });


### PR DESCRIPTION
This makes Jasmine 2 the default. Jasmine 1 can be enabled using `--testRunner=jasmine1` or `"testRunner": "jasmine1"`. In the future, as part of the modularization efforts, we'll split the test runners into separate packages and not ship with more than one by default. I will make sure that the upgrade notes will mention this but it hasn't been a huge hassle at FB to upgrade and the fallback will continue to exist, probably forever.

Because libraries shouldn't use automocking, there is now an option to disable it. @zpao loves me now, at last. The testEnvironment experimental setting is not experimental any more. I also turned the error for invalid config options into a console message – I ran into this a few times at FB when I was upgrading Jest with new config options and then tried to run the old version against the new config. I always had to remove it before being able to run tests, even though the invalid or non-existent config option didn't affect the test run.

The documentation will be updated separately, in a *giant* diff in which I'm rewriting all of the Jest documentation :)