### PR TITLE
babel-jest should compile react-native.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,4 @@ docs
 examples
 packages
 website
+__tests__

--- a/packages/babel-jest/package.json
+++ b/packages/babel-jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-jest",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/facebook/jest.git"

--- a/packages/babel-jest/src/index.js
+++ b/packages/babel-jest/src/index.js
@@ -6,15 +6,24 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+'use strict';
+
 const babel = require('babel-core');
 const jestPreset = require('babel-preset-jest');
 const path = require('path');
 
 const NODE_MODULES = path.sep + 'node_modules' + path.sep;
 
+const isNodeModule = filename => {
+  if (filename.includes(NODE_MODULES)) {
+    return !filename.includes(NODE_MODULES + 'react-native' + path.sep);
+  }
+  return false;
+};
+
 module.exports = {
   process(src, filename) {
-    if (!filename.includes(NODE_MODULES) && babel.util.canCompile(filename)) {
+    if (!isNodeModule(filename) && babel.util.canCompile(filename)) {
       return babel.transform(src, {
         filename,
         presets: [jestPreset],


### PR DESCRIPTION
This changes it so react-native always gets compiled properly.

I thought long and hard about whether there should be an explicit whitelist, and yeah, probably there should be, but I don't want to overcomplicate things for now. One of the goals of Jest is to simplify the setup process, especially around Facebook's open source projects, and this helps greatly. New documentation for react-native testing is coming probably tomorrow.

see #770.