### PR TITLE
Improve --watch command.

### DIFF
--- a/docs/TutorialReact.md
+++ b/docs/TutorialReact.md
@@ -162,7 +162,7 @@ module.exports = {
 
 ```
 
-In fact, this is the entire [source code](https://github.com/facebook/jest/blob/master/packages/babel-jest/src/index.js)
+In fact, this is almost the entire [source code](https://github.com/facebook/jest/blob/master/packages/babel-jest/src/index.js)
 of `babel-jest`!
 
 *Note: Don't forget to install the `babel-core` and `babel-preset-jest` packages

--- a/packages/babel-jest/package.json
+++ b/packages/babel-jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-jest",
-  "version": "9.0.1",
+  "version": "9.0.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/facebook/jest.git"
@@ -9,6 +9,7 @@
   "main": "src/index.js",
   "dependencies": {
     "babel-core": "^6.0.0",
-    "babel-preset-jest": "^1.0.0"
+    "babel-preset-jest": "^1.0.0",
+    "resolve": "^1.1.6"
   }
 }


### PR DESCRIPTION
This fixes the watch command to look for file changes inside of `testPathDirs` instead of checking whether the changed files are test files themselves. I also restructured the code in `src/jest.js` a little bit so the config is available inside of the setup for `--watch`.

Reviewers: @voideanvalue @yungsters @huang47

Fixes #775.