### PR TITLE
Change preprocessorIgnorePathPatterns for better react-native support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.9.1
 
 * Fixed `--watch`.
+* Improved `babel-jest` integration and `react-native` testing.
 
 ## 0.9.0
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -422,9 +422,11 @@ The path to a module that provides a synchronous function from pre-processing so
 Examples of such compilers include [jstransform](http://github.com/facebook/jstransform), [recast](http://github.com/benjamn/recast), [regenerator](http://github.com/facebook/regenerator), and [traceur](https://github.com/google/traceur-compiler).
 
 ### `config.preprocessorIgnorePatterns` [array<string>]
-(default: `[]`)
+(default: `["/node_modules/"]`)
 
 An array of regexp pattern strings that are matched against all source file paths before preprocessing. If the test path matches any of the patterns, it will not be preprocessed.
+
+*Note: if this option is not specified by the user and Jest detects the project as a [react-native](https://github.com/facebook/react-native) project, it will ignore the default and process every file. It is common on react-native projects to ship npm modules without pre-compiling JavaScript.*
 
 ### `config.setupFiles` [array]
 (default: `[]`)

--- a/docs/TutorialReact.md
+++ b/docs/TutorialReact.md
@@ -143,13 +143,10 @@ preprocessor:
 
 const babel = require('babel-core');
 const jestPreset = require('babel-preset-jest');
-const path = require('path');
-
-const NODE_MODULES = path.sep + 'node_modules' + path.sep;
 
 module.exports = {
   process(src, filename) {
-    if (!filename.includes(NODE_MODULES) && babel.util.canCompile(filename)) {
+    if (babel.util.canCompile(filename)) {
       return babel.transform(src, {
         filename,
         presets: [jestPreset],
@@ -159,7 +156,6 @@ module.exports = {
     return src;
   },
 };
-
 ```
 
 In fact, this is the entire [source code](https://github.com/facebook/jest/blob/master/packages/babel-jest/src/index.js)

--- a/packages/babel-jest/package.json
+++ b/packages/babel-jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-jest",
-  "version": "9.0.1",
+  "version": "9.0.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/facebook/jest.git"

--- a/packages/babel-jest/src/index.js
+++ b/packages/babel-jest/src/index.js
@@ -10,20 +10,10 @@
 
 const babel = require('babel-core');
 const jestPreset = require('babel-preset-jest');
-const path = require('path');
-
-const NODE_MODULES = path.sep + 'node_modules' + path.sep;
-
-const isNodeModule = filename => {
-  if (filename.includes(NODE_MODULES)) {
-    return !filename.includes(NODE_MODULES + 'react-native' + path.sep);
-  }
-  return false;
-};
 
 module.exports = {
   process(src, filename) {
-    if (!isNodeModule(filename) && babel.util.canCompile(filename)) {
+    if (babel.util.canCompile(filename)) {
       return babel.transform(src, {
         filename,
         presets: [jestPreset],

--- a/src/jest.js
+++ b/src/jest.js
@@ -19,7 +19,6 @@ const chalk = require('chalk');
 const childProcess = require('child_process');
 const formatTestResults = require('./lib/formatTestResults');
 const path = require('path');
-const resolve = require('resolve');
 const sane = require('sane');
 const utils = require('./lib/utils');
 const which = require('which');
@@ -232,25 +231,6 @@ function getWatcher(argv, packageRoot, callback) {
   });
 }
 
-function getBabelPlugin(pluginName, config) {
-  try {
-    return resolve.sync(pluginName, {
-      basedir: config.rootDir,
-    });
-  } catch (e) {}
-  return null;
-}
-
-function configureBabel(config) {
-  if (!config.scriptPreprocessor) {
-    const scriptPreprocessor = getBabelPlugin('babel-jest', config);
-    const polyfillPlugin =
-      scriptPreprocessor && getBabelPlugin('babel-polyfill', config);
-    return {scriptPreprocessor, polyfillPlugin};
-  }
-  return null;
-}
-
 function runJest(config, argv, pipe, onComplete) {
   const testRunner = new TestRunner(config, testRunnerOptions(argv));
   let testPaths;
@@ -314,12 +294,7 @@ function runCLI(argv, root, onComplete) {
 
       const testFramework = require(config.testRunner);
       const info = ['v' + getVersion(), testFramework.name];
-      const babelConfig = configureBabel(config);
-      if (babelConfig) {
-        config.scriptPreprocessor = babelConfig.scriptPreprocessor;
-        if (babelConfig.polyfillPlugin) {
-          config.setupFiles.unshift(babelConfig.polyfillPlugin);
-        }
+      if (config.usesBabelJest) {
         info.push('babel-jest');
       }
 

--- a/src/lib/resolveNodeModule.js
+++ b/src/lib/resolveNodeModule.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+const path = require('path');
+const resolve = require('resolve');
+
+const paths =
+  (process.env.NODE_PATH ? process.env.NODE_PATH.split(path.delimiter) : null);
+
+function resolveNodeModule(path, basedir, extensions) {
+  try {
+    return resolve.sync(path, {basedir, paths, extensions});
+  } catch (e) {}
+  return null;
+}
+
+module.exports = resolveNodeModule;


### PR DESCRIPTION
Discussion: https://www.facebook.com/groups/reactnativeoss/permalink/1528961550733807/

I would like `babel-jest` and `jest`'s setup process to be simpler. It turns out that react-native plugin developers commonly ship plugins without precompiling them with babel, leaving it to react native's packager.

This changes the `preprocessorIgnorePathPatterns` config option to default to `['/node_modules/']` or an empty array when react-native is detected as part of the project. Further, I removed the `node_modules` check in babel-jest, because the preprocessor is now not called when the file is a node_module. This has the nice side-effect of *not* copying every single node_module JS file into the cache and the files will now be read from the cache directly! For users of babel-jest, nothing will change. For people using react-native, they'll now be able to use `babel-jest` directly. For people who do not use a preprocessor, this change doesn't have an effect either. It does however change Jest for people who use a custom preprocessor. I expect that if they have something custom (like TypeScript), they won't want `node_modules` to be compiled, so the behavior change should be minimal. It is still possible to set `preprocessorIgnorePattern` to null or an empty array, to make this work.

Finally, I also moved the normalization for `babel-jest` into `utils`. The polyfills are now included even if the `scriptPreprocessor` is explicitly set to `babel-jest` and the message that babel-jest is being used is properly printed to the console. Overall, this seems more correct for people who upgrade from a previous version of Jest to Jest 0.9.0.

Note, for the future I'm planning to provide config presets, like `jest-react-native-preset`. We are quite far from that and blowing up the `normalizeConfig` function to support all this isn't too bad for now. I think this solution is quite elegant, actually.

Reviewers: @vjeux @yungsters @voideanvalue

cc @appden @ms88privat @ide @brentvatne