### PR TITLE
[lint] Ignore all node_modules directories in existance

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,7 +1,5 @@
 bin/
 docs/
-examples/**/node_modules/
-node_modules/
-packages/**/node_modules/
+**/node_modules/**
 vendor/
 website/


### PR DESCRIPTION
The problem was that the ignore patterns we had weren't right when passed to `glob`. This meant that `glob` was returning thousands of files it shouldn't have which eslint was then checking again and finally ignoring there.

We don't ever want to lint anything in any `node_modules` directory so just ignore all of them all the time.

After a simple `npm install` inside `examples/async` this brought be down from 17s back to what I had before that install, ~5s.