### PR TITLE
Update babel-jest for better code coverage

### DIFF
--- a/packages/babel-jest/package.json
+++ b/packages/babel-jest/package.json
@@ -9,6 +9,7 @@
   "main": "src/index.js",
   "dependencies": {
     "babel-core": "^6.0.0",
+    "babel-plugin-transform-runtime": "^6.0.0",
     "babel-preset-jest": "^1.0.0"
   }
 }

--- a/packages/babel-jest/src/index.js
+++ b/packages/babel-jest/src/index.js
@@ -18,6 +18,8 @@ module.exports = {
       return babel.transform(src, {
         filename,
         presets: [jestPreset],
+        auxiliaryCommentBefore: 'istanbul ignore next',
+        plugins: ['transform-runtime'],
         retainLines: true,
       }).code;
     }


### PR DESCRIPTION
The current configuration of babel-jest does not allow for code coverage to get close to 100 because Babel writes functions into the compiled source code. By utilizing the babel-plugin-transform-runtime we are able to tell Babel to require these functions from babel-runtime instead. We are also adding a comment that tells babel to ignore Babel generated lines. In most cases this will allow us to get to 100 coverage.