### PR TITLE
Improve `--watch` performance and fix `jest -o`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## master
 
+## jest-cli 0.9.2, babel-jest 9.0.3
+
+* Improved performance of `--watch`.
+* Fixed `jest -o` issue when no files were changed.
+* Improved code coverage reporting when using `babel-jest`.
+
 ## 0.9.1
 
 * Fixed `--watch`.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jest-cli",
   "description": "Painless JavaScript Unit Testing.",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "main": "src/jest.js",
   "dependencies": {
     "chalk": "^1.1.1",

--- a/packages/babel-jest/package.json
+++ b/packages/babel-jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-jest",
-  "version": "9.0.2",
+  "version": "9.0.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/facebook/jest.git"

--- a/src/HasteModuleLoader/__tests__/HasteModuleLoader-jsdom-env-test.js
+++ b/src/HasteModuleLoader/__tests__/HasteModuleLoader-jsdom-env-test.js
@@ -11,6 +11,8 @@
 
 jest.autoMockOff();
 
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 15000;
+
 const path = require('path');
 const utils = require('../../lib/utils');
 

--- a/src/TestRunner.js
+++ b/src/TestRunner.js
@@ -6,7 +6,6 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
- /* eslint-disable fb-www/object-create-only-one-param */
 'use strict';
 
 const Test = require('./Test');
@@ -15,51 +14,14 @@ const fs = require('graceful-fs');
 const getCacheFilePath = require('node-haste').Cache.getCacheFilePath;
 const getCacheKey = require('./lib/getCacheKey');
 const mkdirp = require('mkdirp');
-const os = require('os');
 const path = require('path');
 const promisify = require('./lib/promisify');
 const utils = require('./lib/utils');
 const workerFarm = require('worker-farm');
 
 const TEST_WORKER_PATH = require.resolve('./TestWorker');
-
-const DEFAULT_OPTIONS = {
-
-  /**
-   * When true, runs all tests serially in the current process, rather than
-   * creating a worker pool of child processes.
-   *
-   * This can be useful for debugging, or when the environment limits to a
-   * single process.
-   */
-  runInBand: false,
-
-  /**
-   * The maximum number of workers to run tests concurrently with.
-   *
-   * It's probably good to keep this at something close to the number of cores
-   * on the machine that's running the test.
-   */
-  maxWorkers: Math.max(os.cpus().length, 1),
-
-  /**
-   * The path to the executable node binary.
-   *
-   * This is used in the process of booting each of the workers.
-   */
-  nodePath: process.execPath,
-
-  /**
-   * The args to be passed to the node binary executable.
-   *
-   * This is used in the process of booting each of the workers.
-   * Passing --debug off to child processes can screw with socket connections
-   * of the parent process.
-   */
-  nodeArgv: process.execArgv.filter(arg => arg.indexOf('--debug') == -1),
-};
-
 const HIDDEN_FILE_RE = /\/\.[^\/]*$/;
+
 function optionPathToRegex(p) {
   return utils.escapeStrForRegex(p.replace(/\//g, path.sep));
 }
@@ -67,7 +29,14 @@ function optionPathToRegex(p) {
 class TestRunner {
 
   constructor(config, options) {
-    this._opts = Object.assign({}, DEFAULT_OPTIONS, options);
+    this._opts = Object.assign(
+      {
+        // When true, runs all tests serially in the current process, rather
+        // than parallelizing test runs.
+        runInBand: false,
+      },
+      options
+    );
     this._config = Object.freeze(config);
 
     try {
@@ -142,6 +111,9 @@ class TestRunner {
   }
 
   promiseTestPathsRelatedTo(changedPaths) {
+    if (!changedPaths.size) {
+      return Promise.resolve([]);
+    }
     const relatedPaths = new Set();
     return this._resolver.getAllModules().then(allModules => {
       const changed = new Set();
@@ -172,6 +144,9 @@ class TestRunner {
   }
 
   promiseHasteTestPathsRelatedTo(changedPaths) {
+    if (!changedPaths.size) {
+      return Promise.resolve([]);
+    }
     return Promise.all([
       this._getAllTestPaths(),
       this._resolver.getHasteMap(),


### PR DESCRIPTION
* We now limit the default number of CPUs to `cpus - 1`. This doesn't have a very noticeable impact on performance because of all the caching we are now doing in workers
* For `--watch`, we are now using `floor(cpus / 2)` so that people can comfortably keep using their editors.
* When `jest -o` was invoked with no changed files, it would hang. Fixed that and added a descriptive message.
* Removed some outdated and unused config options for TestRunner.
* Bumped the timeout for the jsdom test because travis sometimes takes too long.

The long term plan is to split the TestRunner code into a simple TestRunner and a class that finds matching tests. That should clean everything up quite a bit :)