### PR TITLE
Improve syntax error reporting; revert babel-runtime change.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Improved responsiveness of the system while using `--watch`.
 * Fixed `jest -o` issue when no files were changed.
 * Improved code coverage reporting when using `babel-jest`.
+* Improved error reporting when a syntax error occurs.
 
 ## 0.9.1
 

--- a/packages/babel-jest/package.json
+++ b/packages/babel-jest/package.json
@@ -9,7 +9,6 @@
   "main": "src/index.js",
   "dependencies": {
     "babel-core": "^6.0.0",
-    "babel-plugin-transform-runtime": "^6.0.0",
     "babel-preset-jest": "^1.0.0"
   }
 }

--- a/packages/babel-jest/src/index.js
+++ b/packages/babel-jest/src/index.js
@@ -15,10 +15,9 @@ module.exports = {
   process(src, filename) {
     if (babel.util.canCompile(filename)) {
       return babel.transform(src, {
+        auxiliaryCommentBefore: 'istanbul ignore next',
         filename,
         presets: [jestPreset],
-        auxiliaryCommentBefore: 'istanbul ignore next',
-        plugins: ['transform-runtime'],
         retainLines: true,
       }).code;
     }

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -319,75 +319,67 @@ function cleanStackTrace(stackTrace) {
   const keepFirstLines = () => (lines++ < KEEP_TRACE_LINES);
   return stackTrace.split('\n').filter(line => (
     keepFirstLines() ||
-    !/jest(-cli)?\/(vendor|src|node_modules)\//.test(line)
+    !/^\s+at.*?jest(-cli)?\/(vendor|src|node_modules)\//.test(line)
   )).join('\n');
 }
 
-/**
- * Given a test result, return a human readable string representing the
- * failures.
- *
- * @param {Object} testResult
- * @param {Object} config Containing the following keys:
- *   `rootPath` - Root directory (for making stack trace paths relative).
- *   `useColor` - True if message should include color flags.
- * @return {String}
- */
 function formatFailureMessage(testResult, config) {
-  const rootPath = config.rootPath;
-  const useColor = config.useColor;
+  const rootDir = config.rootDir;
 
-  const localChalk = new chalk.constructor({enabled: !!useColor});
   const ancestrySeparator = ' \u203A ';
-  const descBullet = localChalk.bold('\u25cf ');
+  const descBullet = config.verbose ? '' : chalk.bold('\u25cf ');
   const msgBullet = '  - ';
   const msgIndent = msgBullet.replace(/./g, ' ');
 
   if (testResult.testExecError) {
     const error = testResult.testExecError;
     return (
-      descBullet + localChalk.bold('Runtime Error') + '\n' +
+      descBullet +
+      (config.verbose ? 'Runtime Error' : chalk.bold('Runtime Error')) + '\n' +
       (error.stack ? cleanStackTrace(error.stack) : error.message)
     );
   }
 
-  return testResult.testResults.filter(function(result) {
-    return result.failureMessages.length !== 0;
-  }).map(function(result) {
-    const failureMessages = result.failureMessages.map(function(errorMsg) {
-      errorMsg = errorMsg.split('\n').map(function(line) {
-        // Extract the file path from the trace line.
-        let matches = line.match(/(^\s+at .*?\()([^()]+)(:[0-9]+:[0-9]+\).*$)/);
-        if (!matches) {
-          matches = line.match(/(^\s+at )([^()]+)(:[0-9]+:[0-9]+.*$)/);
-          if (!matches) {
-            return line;
-          }
-        }
-        var filePath = matches[2];
-        // Filter out noisy and unhelpful lines from the stack trace.
-        if (STACK_TRACE_LINE_IGNORE_RE.test(filePath)) {
-          return null;
-        }
-        return (
-          matches[1] +
-          path.relative(rootPath, filePath) +
-          matches[3]
-        );
-      }).filter(function(line) {
-        return line !== null;
+  return testResult.testResults
+    .filter(result => result.failureMessages.length !== 0)
+    .map(result => {
+      const failureMessages = result.failureMessages.map(errorMsg => {
+        errorMsg = errorMsg.split('\n')
+          .map(line => {
+            // Extract the file path from the trace line.
+            let matches =
+              line.match(/(^\s+at .*?\()([^()]+)(:[0-9]+:[0-9]+\).*$)/);
+            if (!matches) {
+              matches = line.match(/(^\s+at )([^()]+)(:[0-9]+:[0-9]+.*$)/);
+              if (!matches) {
+                return line;
+              }
+            }
+            var filePath = matches[2];
+            // Filter out noisy and unhelpful lines from the stack trace.
+            if (STACK_TRACE_LINE_IGNORE_RE.test(filePath)) {
+              return null;
+            }
+            return (
+              matches[1] +
+              path.relative(rootDir, filePath) +
+              matches[3]
+            );
+          })
+          .filter(line => line !== null)
+          .join('\n');
+
+        return msgBullet + errorMsg.replace(/\n/g, '\n' + msgIndent);
       }).join('\n');
 
-      return msgBullet + errorMsg.replace(/\n/g, '\n' + msgIndent);
-    }).join('\n');
+      const testTitleAncestry = result.ancestorTitles.map(
+        title => chalk.bold(title)
+      ).join(ancestrySeparator) + ancestrySeparator;
 
-    const testTitleAncestry = result.ancestorTitles.map(function(title) {
-      return localChalk.bold(title);
-    }).join(ancestrySeparator) + ancestrySeparator;
-
-    return descBullet + testTitleAncestry + result.title + '\n' +
-      failureMessages;
-  }).join('\n');
+      return descBullet + testTitleAncestry + result.title + '\n' +
+        failureMessages;
+    })
+    .join('\n');
 }
 
 function deepCopy(obj) {

--- a/src/reporters/DefaultTestReporter.js
+++ b/src/reporters/DefaultTestReporter.js
@@ -73,34 +73,23 @@ class DefaultTestReporter {
        `${allTestsPassed ? PASS : FAIL} ${TEST_NAME_COLOR(pathStr)}` +
        (testDetail.length ? ` (${testDetail.join(', ')})` : '');
 
-    /*
-    if (config.collectCoverage) {
-      // TODO: Find a nice pretty way to print this out
-    }
-    */
-
     this.log(resultHeader);
-    if (config.verbose) {
-      this.verboseLogger.logTestResults(testResult.testResults);
+    if (config.verbose && !testResult.testExecError) {
+      this.verboseLogger.logTestResults(
+        testResult.testResults
+      );
     }
 
     if (!allTestsPassed) {
-      const failureMessage = formatFailureMessage(testResult, {
-        rootPath: config.rootDir,
-        useColor: !config.noHighlight,
-      });
-      if (config.verbose) {
-        results.postSuiteHeaders.push(resultHeader, failureMessage);
-      } else {
-        // If we write more than one character at a time it is possible that
-        // node exits in the middle of printing the result.
-        // If you are reading this and you are from the future, this might not
-        // be true any more.
-        for (let i = 0; i < failureMessage.length; i++) {
-          this._process.stdout.write(failureMessage.charAt(i));
-        }
-        this._process.stdout.write('\n');
+      const failureMessage = formatFailureMessage(testResult, config);
+      // If we write more than one character at a time it is possible that
+      // node exits in the middle of printing the result.
+      // If you are reading this and you are from the future, this might not
+      // be true any more.
+      for (let i = 0; i < failureMessage.length; i++) {
+        this._process.stdout.write(failureMessage.charAt(i));
       }
+      this._process.stdout.write('\n');
 
       if (config.bail) {
         this.onRunComplete(config, results);

--- a/src/resolvers/HasteResolver.js
+++ b/src/resolvers/HasteResolver.js
@@ -6,8 +6,6 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* eslint-disable fb-www/object-create-only-one-param */
-
 'use strict';
 
 const DependencyGraph = require('node-haste');


### PR DESCRIPTION
This diff makes a number of changes:

* It adds a useful message when a syntax error happens due to a configuration issue. This is something that a lot of people, including me, run into. There are a couple of scenarios that the new message should address:
 * `babel-jest` is installed but `.babelrc` is not properly set up. The code may use imports but it doesn't transform them into requires
 * no preprocessor is set up at all but people expect code to just work
 * the preprocessor was updated but the cache key doesn't consider everything and people don't know to use `--no-cache`.
 * it also prints the code that it tried to run. This is especially valuable for debugging – something I've run into dozens of times myself and I always had to hack Jest to print the source.
 * Screenshots: [screenshot1](http://i.imgur.com/D83lwC0.png) and [screenshot2](http://i.imgur.com/9priaBG.png)
 * Funny enough, the stack trace filter used to filter every line that contains `node_modules`. Since the message is part of the stack trace, it would filter out `Preprocessor: node_modules/babel-jest`. That took a while to figure out… I changed the stacktrace filter to look for `\s+at` in the beginning of the message.
 * *Note*: this error is *not*  triggered when Babel finds a legit syntax error in the source code. When that happens, babel throws an error that is not based on `SyntaxError`, so it bypasses this check. This is actually nice – it means we can show this message only while people have trouble setting up their preprocessor.
* We were swallowing runtime errors in `--verbose` mode, probably because @gaearon and I were working on the same code on the same time and after the merge of #599 this got lost again. Unfortunately the reporter code is a bit unwieldy and hard to test – there is an internal task that tracks the rewrite of that component.
* This diff also removes `babel-runtime` again. It was added in #785 but I had a chat with some of the babel core developers and it seems like the best course of action is to keep `babel-polyfill`. `babel-runtime` can be added by people who use `babel-jest` through `.babelrc`. Because Jest sets the `NODE_ENV` variable to test, it can be enabled just for the test environment as well. The `auxiliaryCommentBefore` option should be enough to fix code coverage reporting.