### PR TITLE
Add new option to force output colorization

### DIFF
--- a/src/cli/processArgs.js
+++ b/src/cli/processArgs.js
@@ -102,6 +102,12 @@ function processArgs() {
         ),
         type: 'boolean',
       },
+      colors: {
+        description: _wrapDesc(
+          'Forces test results output highlighting (even if stdout is not a TTY)'
+        ),
+        type: 'boolean',
+      },
       noStackTrace: {
         description: _wrapDesc(
           'Disables stack trace in test results output'

--- a/src/config/defaults.js
+++ b/src/config/defaults.js
@@ -39,6 +39,7 @@ module.exports = {
   testReporter: require.resolve('../reporters/IstanbulTestReporter'),
   testURL: 'about:blank',
   noHighlight: false,
+  colors: false,
   noStackTrace: false,
   preprocessCachingDisabled: false,
   verbose: false,

--- a/src/config/normalize.js
+++ b/src/config/normalize.js
@@ -202,6 +202,7 @@ function normalize(config, argv) {
       case 'testURL':
       case 'moduleFileExtensions':
       case 'noHighlight':
+      case 'colors':
       case 'noStackTrace':
       case 'logHeapUsage':
       case 'cache':

--- a/src/config/read.js
+++ b/src/config/read.js
@@ -23,7 +23,7 @@ function readConfig(argv, packageRoot) {
       config.testEnvData = argv.testEnvData;
     }
 
-    config.noHighlight = argv.noHighlight || !process.stdout.isTTY;
+    config.noHighlight = argv.noHighlight || (!argv.colors && !process.stdout.isTTY);
 
     if (argv.verbose) {
       config.verbose = argv.verbose;


### PR DESCRIPTION
See https://github.com/facebook/jest/issues/805.

Use case: 
`jest --colors` to force the output colorization even if `stdout` is not a TTY.

If `--colors` and `--noHighlight` are both present. The output colorization is disabled.

