### PR TITLE
Directly run the test if the pattern directly resolves to a file

### DIFF
--- a/src/TestRunner.js
+++ b/src/TestRunner.js
@@ -217,7 +217,7 @@ class TestRunner {
     try {
       const maybeFile = path.resolve(process.cwd(), pathPattern);
       fs.accessSync(maybeFile);
-      return Promise.resolve([pathPattern]);
+      return Promise.resolve([pathPattern].filter(this._isTestFilePath));
     } catch (e) {
       return this._getAllTestPaths()
         .then(paths => paths.filter(path => new RegExp(pathPattern).test(path)));

--- a/src/TestRunner.js
+++ b/src/TestRunner.js
@@ -285,9 +285,7 @@ class TestRunner {
       }
     }
 
-    if (testPaths.length > 1) {
-      testPaths = this._sortTests(testPaths);
-    }
+    testPaths = this._sortTests(testPaths);
 
     const aggregatedResults = {
       success: null,

--- a/src/TestRunner.js
+++ b/src/TestRunner.js
@@ -285,7 +285,9 @@ class TestRunner {
       }
     }
 
-    testPaths = this._sortTests(testPaths);
+    if (testPaths.length > 1) {
+      testPaths = this._sortTests(testPaths);
+    }
 
     const aggregatedResults = {
       success: null,

--- a/src/TestRunner.js
+++ b/src/TestRunner.js
@@ -214,8 +214,14 @@ class TestRunner {
   }
 
   promiseTestPathsMatching(pathPattern) {
-    return this._getAllTestPaths()
-      .then(paths => paths.filter(path => pathPattern.test(path)));
+    try {
+      const maybeFile = path.resolve(process.cwd(), pathPattern);
+      fs.accessSync(maybeFile);
+      return Promise.resolve([pathPattern]);
+    } catch (e) {
+      return this._getAllTestPaths()
+        .then(paths => paths.filter(path => new RegExp(pathPattern).test(path)));
+    }
   }
 
   _getTestPerformanceCachePath() {

--- a/src/jest.js
+++ b/src/jest.js
@@ -47,7 +47,15 @@ function getTestPaths(testRunner, config, patternInfo) {
   if (patternInfo.onlyChanged) {
     return findOnlyChangedTestPaths(testRunner, config);
   } else {
-    return testRunner.promiseTestPathsMatching(new RegExp(patternInfo.pattern));
+    return new Promise((resolve, reject) => {
+      fs.access(patternInfo.pattern, (err) => {
+        resolve(
+          err?
+          testRunner.promiseTestPathsMatching(new RegExp(patternInfo.pattern)):
+          patternInfo.pattern
+        );
+      });
+    });
   }
 }
 

--- a/src/jest.js
+++ b/src/jest.js
@@ -50,9 +50,9 @@ function getTestPaths(testRunner, config, patternInfo) {
     return new Promise((resolve, reject) => {
       fs.access(patternInfo.pattern, (err) => {
         resolve(
-          err?
-          testRunner.promiseTestPathsMatching(new RegExp(patternInfo.pattern)):
-          patternInfo.pattern
+          err ?
+          testRunner.promiseTestPathsMatching(new RegExp(patternInfo.pattern)) :
+          [patternInfo.pattern]
         );
       });
     });

--- a/src/jest.js
+++ b/src/jest.js
@@ -47,15 +47,7 @@ function getTestPaths(testRunner, config, patternInfo) {
   if (patternInfo.onlyChanged) {
     return findOnlyChangedTestPaths(testRunner, config);
   } else {
-    return new Promise((resolve, reject) => {
-      fs.access(patternInfo.pattern, (err) => {
-        resolve(
-          err ?
-          testRunner.promiseTestPathsMatching(new RegExp(patternInfo.pattern)) :
-          [patternInfo.pattern]
-        );
-      });
-    });
+    return testRunner.promiseTestPathsMatching(patternInfo.pattern);
   }
 }
 


### PR DESCRIPTION
Directly run a test when passing path to a file instead of treating it as a pattern.
Also avoid sorting the paths if there's only a single path, as we were doing a lot of things in the `_sortTests` method.