### PR TITLE
Properly catch errors while reading package.json

### DIFF
--- a/bin/jest.js
+++ b/bin/jest.js
@@ -9,4 +9,8 @@
 
 'use strict';
 
+if (process.env.NODE_ENV == null) {
+  process.env.NODE_ENV = 'test';
+}
+
 require('../src/cli').Run();

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "diff": "^2.1.1",
     "graceful-fs": "^4.1.3",
     "istanbul": "^0.4.2",
-    "jest-util": "^0.0.3",
+    "jest-util": "^1.0.0",
     "jsdom": "^7.2.0",
     "json-stable-stringify": "^1.0.0",
     "lodash.template": "^3.6.2",

--- a/packages/jest-util/index.js
+++ b/packages/jest-util/index.js
@@ -8,21 +8,8 @@
 
 'use strict';
 
-const fs = require('graceful-fs');
 const formatMessages = require('./lib/formatMessages');
 const path = require('path');
-
-function readFile(filePath) {
-  return new Promise((resolve, reject) => {
-    fs.readFile(filePath, 'utf8', (err, data) => {
-      if (err) {
-        reject(err);
-        return;
-      }
-      resolve(data);
-    });
-  });
-}
 
 function escapeStrForRegex(str) {
   return str.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
@@ -52,5 +39,4 @@ exports.cleanStackTrace = formatMessages.cleanStackTrace;
 exports.deepCopy = deepCopy;
 exports.escapeStrForRegex = escapeStrForRegex;
 exports.formatFailureMessage = formatMessages.formatFailureMessage;
-exports.readFile = readFile;
 exports.replacePathSepForRegex = replacePathSepForRegex;

--- a/packages/jest-util/package.json
+++ b/packages/jest-util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-util",
-  "version": "0.0.3",
+  "version": "1.0.0",
   "main": "index.js",
   "dependencies": {
     "chalk": "^1.1.1",

--- a/src/cli/getJest.js
+++ b/src/cli/getJest.js
@@ -12,54 +12,30 @@ const fs = require('graceful-fs');
 const path = require('path');
 
 function getJest(cwdPackageRoot) {
-  // Get a jest instance
-  let jest;
-
-  // Is there a package.json at our cwdPackageRoot that indicates that there
-  // should be a version of Jest installed?
-  const cwdPkgJsonPath = path.join(cwdPackageRoot, 'package.json');
-
-  // Is there a version of Jest installed at our cwdPackageRoot?
-  const cwdJestBinPath = path.join(cwdPackageRoot, 'node_modules/jest-cli');
-
-  if (fs.existsSync(cwdJestBinPath)) {
-    // If a version of Jest was found installed in the CWD package, use that.
-    jest = require(cwdJestBinPath);
-
-    if (!jest.runCLI) {
-      console.error(
-        'This project requires an older version of Jest than what you have ' +
-        'installed globally.\n' +
-        'Please upgrade this project past Jest version 0.1.5'
-      );
-
-      process.on('exit', () => process.exit(1));
-    }
+  const packageJSONPath = path.join(cwdPackageRoot, 'package.json');
+  const binPath = path.join(cwdPackageRoot, 'node_modules/jest-cli');
+  if (fs.existsSync(binPath)) {
+    return require(binPath);
   } else {
-    // Otherwise, load this version of Jest.
-    jest = require('./../../');
-
-    // If a package.json was found in the CWD package indicating a specific
-    // version of Jest to be used, bail out and ask the user to `npm install`
-    // first
-    if (fs.existsSync(cwdPkgJsonPath)) {
-      const cwdPkgJson = require(cwdPkgJsonPath);
-      const cwdPkgDeps = cwdPkgJson.dependencies;
-      const cwdPkgDevDeps = cwdPkgJson.devDependencies;
-
-      if (cwdPkgDeps && cwdPkgDeps['jest-cli']
-        || cwdPkgDevDeps && cwdPkgDevDeps['jest-cli']) {
+    const jest = require('../jest');
+    // Check if Jest is specified in `package.json` but not installed.
+    if (fs.existsSync(packageJSONPath)) {
+      const packageJSON = require(packageJSONPath);
+      const dependencies = packageJSON.dependencies;
+      const devDependencies = packageJSON.devDependencies;
+      if (
+        (dependencies && dependencies['jest-cli']) ||
+        (devDependencies && devDependencies['jest-cli'])
+      ) {
         console.error(
           'Please run `npm install` to use the version of Jest intended for ' +
           'this project.'
         );
-
         process.on('exit', () => process.exit(1));
       }
     }
+    return jest;
   }
-
-  return jest;
 }
 
 module.exports = getJest;

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -45,8 +45,4 @@ function Run() {
   });
 }
 
-if (process.env.NODE_ENV == null) {
-  process.env.NODE_ENV = 'test';
-}
-
 exports.Run = Run;

--- a/src/config/read.js
+++ b/src/config/read.js
@@ -23,7 +23,8 @@ function readConfig(argv, packageRoot) {
       config.testEnvData = argv.testEnvData;
     }
 
-    config.noHighlight = argv.noHighlight || (!argv.colors && !process.stdout.isTTY);
+    config.noHighlight =
+      argv.noHighlight || (!argv.colors && !process.stdout.isTTY);
 
     if (argv.verbose) {
       config.verbose = argv.verbose;
@@ -59,19 +60,22 @@ function readConfig(argv, packageRoot) {
   });
 }
 
-function readRawConfig(argv, packageRoot) {
+function readRawConfig(argv, root) {
   if (typeof argv.config === 'string') {
-    return loadFromFile(argv.config);
+    return loadFromFile(path.resolve(process.cwd(), argv.config));
   }
 
   if (typeof argv.config === 'object') {
     return Promise.resolve(normalize(argv.config, argv));
   }
 
-  return loadFromPackage(
-    path.join(packageRoot, 'package.json'),
-    argv
-  );
+  return loadFromPackage(path.join(root, 'package.json'), argv)
+    .then(
+      config => config || normalize({
+        name: root.replace(/[/\\]|\s/g, '-'),
+        rootDir: root,
+      }, argv)
+    );
 }
 
 module.exports = readConfig;

--- a/src/jest.js
+++ b/src/jest.js
@@ -212,8 +212,11 @@ function runCLI(argv, root, onComplete) {
           });
         });
       } else {
-        runJest(config, argv, pipe, onComplete);
+        return runJest(config, argv, pipe, onComplete);
       }
+    }, error => {
+      console.error(error.stack);
+      process.exit(1);
     });
 }
 


### PR DESCRIPTION
This got broken a bit in the big refactor in https://github.com/facebook/jest/commit/a33906cebea94e2c87ee49b37c57aa537ea89d16

Running `jest` in a project with no config at all will now work properly again. Running `jest` in a project with a broken package.json (like, say a trailing comma in JSON, because that happens at least once a day), will now properly report an error as well.