### PR TITLE
Exclude .haste_cache from packages distributed via npmjs

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,3 +3,4 @@ examples
 packages
 website
 __tests__
+.haste_cache


### PR DESCRIPTION
From the npm documentation (https://docs.npmjs.com/misc/developers#keeping-files-out-of-your-package) when .npmignore file is present it takes precedence over .gitignore and patterns matched by .gitignore won't be excluded from the package uploaded to npmjs.

At the moment .haste_cache directory contribution to the package size of version 0.9.2 is 98% (38M) it may also contain some potentially sensitive data.