### PR TITLE
Rename pending to skipped, fix “Running XX tests” message.

### DIFF
--- a/src/reporters/DefaultTestReporter.js
+++ b/src/reporters/DefaultTestReporter.js
@@ -131,7 +131,7 @@ class DefaultTestReporter {
 
     if (pendingTests) {
       results +=
-        `${PENDING_COLOR(`${print('test', pendingTests)} pending`)}, `;
+        `${PENDING_COLOR(`${print('test', pendingTests)} skipped`)}, `;
     }
 
     results +=
@@ -150,7 +150,6 @@ class DefaultTestReporter {
     const remaining = results.numTotalTestSuites -
       results.numPassedTestSuites -
       results.numFailedTestSuites -
-      results.numPendingTestSuites -
       results.numRuntimeErrorTestSuites;
     if (!this._config.noHighlight && remaining > 0) {
       this._process.stdout.write(RUNNING_TEST_COLOR(


### PR DESCRIPTION
`pending` is confusing to people at FB and I agree. Skipped makes more sense. This only updates the user output and continues to use `pending` in code – to align it with what Jasmine uses internally.

I also removed a reference to a variable that doesn't exist which broke the `Running XX tests...` feature.