### PR TITLE
Make JSDOM a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "istanbul": "^0.4.2",
     "jest-mock": "^1.0.0",
     "jest-util": "^1.0.0",
-    "jsdom": "^7.2.0",
     "json-stable-stringify": "^1.0.0",
     "lodash.template": "^3.6.2",
     "mkdirp": "^0.5.1",
@@ -25,7 +24,11 @@
   "devDependencies": {
     "babel-eslint": "^4.1.3",
     "eslint": "^1.7.3",
-    "fbjs-scripts": "^0.5.0"
+    "fbjs-scripts": "^0.5.0",
+    "jsdom": "^7.2.0"
+  },
+  "peerDependencies": {
+    "jsdom": ">= 7"
   },
   "bin": {
     "jest": "./bin/jest.js"


### PR DESCRIPTION
This allows the end user to choose which version they want installed and makes Jest's management of the version unnecessary. It is still pulled in under `devDependencies` for local testing when developing Jest itself.

Closes #824 