### PR TITLE
Hoist `jest.mock` with 2 arguments.

### DIFF
--- a/packages/babel-plugin-jest-hoist/src/__test_modules__/e.js
+++ b/packages/babel-plugin-jest-hoist/src/__test_modules__/e.js
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+export default () => 'unmocked';

--- a/packages/babel-plugin-jest-hoist/src/__tests__/integration-automock-off-test.js
+++ b/packages/babel-plugin-jest-hoist/src/__tests__/integration-automock-off-test.js
@@ -17,7 +17,7 @@ import b from '../__test_modules__/b';
 jest.disableAutomock();
 jest.mock('../__test_modules__/b');
 
-describe('babel-plugin-jest-unmock', () => {
+describe('babel-plugin-jest-hoist', () => {
   it('hoists disableAutomock call before imports', () => {
     expect(a._isMockFunction).toBe(undefined);
   });

--- a/packages/babel-plugin-jest-hoist/src/__tests__/integration-test.js
+++ b/packages/babel-plugin-jest-hoist/src/__tests__/integration-test.js
@@ -17,6 +17,7 @@ import a from '../__test_modules__/a';
 import b from '../__test_modules__/b';
 import c from '../__test_modules__/c';
 import d from '../__test_modules__/d';
+import e from '../__test_modules__/e';
 
 // These will all be hoisted above imports
 jest.unmock('react');
@@ -24,6 +25,10 @@ jest.unmock('../__test_modules__/Unmocked');
 jest
   .unmock('../__test_modules__/c')
   .unmock('../__test_modules__/d');
+jest.mock('../__test_modules__/e', {
+  _isMock: true,
+  fn: () => { let a; a; },
+});
 
 // These will not be hoisted
 jest.unmock('../__test_modules__/a').dontMock('../__test_modules__/b');
@@ -31,7 +36,7 @@ jest.unmock('../__test_modules__/' + 'c');
 jest.dontMock('../__test_modules__/Mocked');
 
 
-describe('babel-plugin-jest-unmock', () => {
+describe('babel-plugin-jest-hoist', () => {
   it('hoists react unmock call before imports', () => {
     expect(typeof React).toEqual('object');
     expect(React.isValidElement.mock).toBe(undefined);
@@ -46,6 +51,10 @@ describe('babel-plugin-jest-unmock', () => {
 
     expect(d._isMockFunction).toBe(undefined);
     expect(d()).toEqual('unmocked');
+  });
+
+  it('hoists mock call with 2 arguments', () => {
+    expect(e._isMock).toBe(true);
   });
 
   it('does not hoist dontMock calls before imports', () => {

--- a/packages/babel-plugin-jest-hoist/src/__tests__/integration-test.js
+++ b/packages/babel-plugin-jest-hoist/src/__tests__/integration-test.js
@@ -25,10 +25,10 @@ jest.unmock('../__test_modules__/Unmocked');
 jest
   .unmock('../__test_modules__/c')
   .unmock('../__test_modules__/d');
-jest.mock('../__test_modules__/e', {
+jest.mock('../__test_modules__/e', () => ({
   _isMock: true,
   fn: () => { let a; a; },
-});
+}));
 
 // These will not be hoisted
 jest.unmock('../__test_modules__/a').dontMock('../__test_modules__/b');

--- a/packages/babel-plugin-jest-hoist/src/index.js
+++ b/packages/babel-plugin-jest-hoist/src/index.js
@@ -10,9 +10,48 @@
 
 const JEST_GLOBAL = {name: 'jest'};
 
+const idVisitor = {
+  ReferencedIdentifier(path) {
+    this.ids.add(path);
+  },
+};
+
 const FUNCTIONS = {
   mock: {
-    checkArgs: args => args.length === 1 && args[0].isStringLiteral(),
+    checkArgs: args => {
+      if (args.length === 1) {
+        return args[0].isStringLiteral();
+      } else if (args.length === 2) {
+        const ids = new Set();
+        args[1].traverse(idVisitor, {ids});
+
+        const outerScope = args[1].parentPath.scope;
+
+        for (let id of ids) {
+          let found = false;
+          let scope = id.scope;
+
+          while (scope !== outerScope) {
+            if (scope.bindings[id.node.name]) {
+              found = true;
+              break;
+            }
+
+            scope = scope.parent;
+          }
+
+          if (!found) {
+            throw new Error(
+              'babel-plugin-jest-hoist: The second argument of `jest.mock()` ' +
+              'is not allowed to reference any outside variables.'
+            );
+          }
+        }
+
+        return true;
+      }
+      return false;
+    },
   },
   unmock: {
     checkArgs: args => args.length === 1 && args[0].isStringLiteral(),

--- a/src/HasteModuleLoader/HasteModuleLoader.js
+++ b/src/HasteModuleLoader/HasteModuleLoader.js
@@ -598,6 +598,12 @@ class Loader {
       this._explicitShouldMock[moduleID] = false;
       return runtime;
     };
+    const setMock = (moduleName, moduleExports) => {
+      const moduleID = this._getNormalizedModuleID(currPath, moduleName);
+      this._explicitShouldMock[moduleID] = true;
+      this._explicitlySetMocks[moduleID] = moduleExports;
+      return runtime;
+    };
 
     const runtime = {
       addMatchers: matchers => {
@@ -641,7 +647,11 @@ class Loader {
         return fn;
       },
 
-      mock: moduleName => {
+      mock: (moduleName, moduleExports) => {
+        if (moduleExports !== undefined) {
+          return setMock(moduleName, moduleExports);
+        }
+
         const moduleID = this._getNormalizedModuleID(currPath, moduleName);
         this._explicitShouldMock[moduleID] = true;
         return runtime;
@@ -658,12 +668,7 @@ class Loader {
       runOnlyPendingTimers: () =>
         this._environment.fakeTimers.runOnlyPendingTimers(),
 
-      setMock: (moduleName, moduleExports) => {
-        const moduleID = this._getNormalizedModuleID(currPath, moduleName);
-        this._explicitShouldMock[moduleID] = true;
-        this._explicitlySetMocks[moduleID] = moduleExports;
-        return runtime;
-      },
+      setMock,
 
       useFakeTimers: () => this._environment.fakeTimers.useFakeTimers(),
       useRealTimers: () => this._environment.fakeTimers.useRealTimers(),

--- a/src/HasteModuleLoader/HasteModuleLoader.js
+++ b/src/HasteModuleLoader/HasteModuleLoader.js
@@ -598,6 +598,15 @@ class Loader {
       this._explicitShouldMock[moduleID] = false;
       return runtime;
     };
+    const mock = (moduleName, mockFactory) => {
+      if (mockFactory !== undefined) {
+        return setMockFactory(moduleName, mockFactory);
+      }
+
+      const moduleID = this._getNormalizedModuleID(currPath, moduleName);
+      this._explicitShouldMock[moduleID] = true;
+      return runtime;
+    };
     const setMockFactory = (moduleName, mockFactory) => {
       const moduleID = this._getNormalizedModuleID(currPath, moduleName);
       this._explicitShouldMock[moduleID] = true;
@@ -647,15 +656,8 @@ class Loader {
         return fn;
       },
 
-      mock: (moduleName, mockFactory) => {
-        if (mockFactory !== undefined) {
-          return setMockFactory(moduleName, mockFactory);
-        }
-
-        const moduleID = this._getNormalizedModuleID(currPath, moduleName);
-        this._explicitShouldMock[moduleID] = true;
-        return runtime;
-      },
+      doMock: mock,
+      mock,
 
       resetModuleRegistry: () => {
         this.resetModuleRegistry();


### PR DESCRIPTION
Comes from #796

How about throwing if second argument references outside variables? So we will be able to allow referencing later.

edit by @cpojer:
@bypass-lint internal eslint invariant-rule is silly