### PR TITLE
Fixes for windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "scripts": {
     "jasmine1": "node bin/jest.js --testRunner=jasmine1",
     "lint": "eslint .",
-    "postinstall": "[ \"$NODE_ENV\" != production ] && ./setup.sh",
+    "postinstall": "node postinstall.js",
     "prepublish": "npm test",
     "test": "npm run lint && node bin/jest.js && npm run jasmine1"
   },

--- a/postinstall.js
+++ b/postinstall.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
+if (
+  process.platform !== 'win32' &&
+  process.env.NODE_ENV !== 'production'
+) {
+  const exec = require('child_process').exec;
+  exec('./setup.sh', (err, stdout, stderr) => {
+    if (err) {
+      console.error(err);
+      return;
+    }
+    console.log(stdout);
+  });
+}

--- a/src/lib/__tests__/utils-normalizeConfig-test.js
+++ b/src/lib/__tests__/utils-normalizeConfig-test.js
@@ -34,6 +34,12 @@ describe('utils-normalizeConfig', () => {
     );
   }
 
+  // this helper takes a path starting from root and normalize it to unix style
+  function uniformPath(pathToUniform) {
+    const resolved = path.resolve(pathToUniform);
+    return '/' + resolved.replace(root, '').split(path.sep).join('/');
+  }
+
   beforeEach(() => {
     path = require('path');
     root = path.resolve('/');
@@ -399,14 +405,15 @@ describe('utils-normalizeConfig', () => {
     });
 
     it('correctly identifies and uses babel-jest', () => {
+
       const config = normalizeConfig({
         rootDir: '/root',
       });
 
       expect(config.usesBabelJest).toBe(true);
-      expect(config.scriptPreprocessor)
-        .toEqual('/root/node_modules/babel-jest');
-      expect(config.setupFiles).toEqual(['/root/node_modules/babel-polyfill']);
+      const preprocessorPath = uniformPath(config.scriptPreprocessor);
+      expect(preprocessorPath).toEqual('/root/node_modules/babel-jest');
+      expect(config.setupFiles.map(uniformPath)).toEqual(['/root/node_modules/babel-polyfill']);
     });
 
     it(`doesn't use babel-jest if its not available`, () => {
@@ -428,7 +435,8 @@ describe('utils-normalizeConfig', () => {
       });
 
       expect(config.usesBabelJest).toBe(true);
-      expect(config.setupFiles).toEqual(['/root/node_modules/babel-polyfill']);
+      expect(config.setupFiles.map(uniformPath))
+        .toEqual(['/root/node_modules/babel-polyfill']);
     });
 
     it('correctly identifies react-native', () => {
@@ -445,8 +453,8 @@ describe('utils-normalizeConfig', () => {
         rootDir: '/root',
       });
 
-      expect(config.preprocessorIgnorePatterns)
-        .toEqual([path.sep + 'node_modules' + path.sep]);
+      expect(config.preprocessorIgnorePatterns.map(uniformPath))
+        .toEqual(['/node_modules']);
     });
   });
 });


### PR DESCRIPTION
- postinstall breaks npm install on windows, moving the logic inside a javascript file and run it through node
- utils-normalizeConfig-test.js was failing on windows because of difference in path separator and root