### PR TITLE
Clear console when using `--watch`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 * Added `jest-util`, general code cleanup.
 * Fixed an error with Jasmine 2 and tests that `throw 'string errors'`.
 * Fixed issues with unmocking symlinked module names.
+* Clear the terminal window when using `--watch`.
+* By default, `--watch` will now only runs tests related to changed files.
+  `--watch=all` can be used to run all tests on file system changes.
 
 ## jest-cli 0.9.2, babel-jest 9.0.3
 

--- a/src/cli/processArgs.js
+++ b/src/cli/processArgs.js
@@ -122,15 +122,9 @@ function processArgs() {
       },
       watch: {
         description: _wrapDesc(
-          'Watch files for changes and rerun tests related to changed files ' +
-          'and directories. Works with `--onlyChanged` to only run the ' +
-          'affected tests.'
-        ),
-        type: 'boolean',
-      },
-      watchExtensions: {
-        description: _wrapDesc(
-          'Comma separated list of file extensions to watch, defaults to js.'
+          'Watch files for changes and rerun tests related to changed files. ' +
+          'If you want to re-run all tests when a file has changed, you can ' +
+          'call Jest using `--watch=all`.'
         ),
         type: 'string',
       },
@@ -188,7 +182,7 @@ function processArgs() {
         type: 'boolean',
       },
     })
-    .check(function(argv) {
+    .check(argv => {
       if (argv.runInBand && argv.hasOwnProperty('maxWorkers')) {
         throw new Error(
           'Both --runInBand and --maxWorkers were specified, but these two ' +


### PR DESCRIPTION
It also changes the behavior of watch to only run changed tests (by turning on the `onlyChanged` flag). All tests can still be run by doing `jest --watch=all`.