### PR TITLE
Fixes file change watcher to work with git submodules

### DIFF
--- a/src/lib/git.js
+++ b/src/lib/git.js
@@ -37,13 +37,21 @@ function findChangedFiles(cwd) {
   });
 }
 
+function pathForGitDir(dir) {
+  if (dir.match(/\.git\/modules/)) {
+    return dir.replace('/.git/modules', '');
+  } else {
+    return path.dirname(dir);
+  }
+}
+
 function isGitRepository(cwd) {
   return new Promise(resolve => {
     let stdout = '';
     const child = childProcess.spawn('git', ['rev-parse', '--git-dir'], {cwd});
     child.stdout.on('data', data => stdout += data);
     child.on('close',
-      code =>  resolve(code === 0 ? path.dirname(stdout.trim()) : null)
+      code =>  resolve(code === 0 ? pathForGitDir(stdout.trim()) : null)
     );
   });
 }


### PR DESCRIPTION
When using git submodules the path to the submodule parent is returned rather than the submodule itself and this broke the watcher in my project

For example: if we have `/Users/brent/monorepo` and `/Users/brent/monorepo/product-a`, when we run `jest --onlyChanged` it should search `/Users/brent/monorepo/product-a` but instead it would search `/Users/brent/monorepo/` because `/Users/brent/monorepo/.git/modules/product-a` is returned from `git rev-parse --git-dir` and `path.dirname` for that returns `/Users/brent/monorepo`

You can probably come up with a cleaner solution using some node or git apis that I'm not aware of, just throwing this out there as one possible fix.