### PR TITLE
Fixes hoist depending on 0.9.2 and not able to run babel-jest

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 
 echo "Setting up Jest's development environment..."
+# Needed for hoist until 0.9.3 is released
+NODE_ENV=production npm link
+(cd packages/babel-plugin-jest-hoist && npm link jest-cli)
+##########################################
+
 node_modules/.bin/lerna bootstrap
 
 (cd packages/jest-jasmine1 && npm link)


### PR DESCRIPTION
Fixes the problem of hoist depending on 0.9.2 and not able to run babel-jest
To see the problem:
`rm -Rf packages/babel-plugin-jest-hoist/node_modules/*`
`npm install`

(in order to see the test fail error stderr needs to be printed, as it's done on https://github.com/facebook/jest/pull/838, also can be reproduce by running directly `npm install` on the package folder)