### PR TITLE
Support `@scoped` packages when writing perf cache

### DIFF
--- a/src/TestRunner.js
+++ b/src/TestRunner.js
@@ -226,7 +226,7 @@ class TestRunner {
 
   _getTestPerformanceCachePath() {
     const config = this._config;
-    return path.join(config.cacheDirectory, 'perf-cache-' + config.name);
+    return getCacheFilePath(config.cacheDirectory, 'perf-cache-' + config.name);
   }
 
   _sortTests(testPaths) {


### PR DESCRIPTION
Runs mkdirp since scoped packages look like `@scope/pkg` which introduce an extra level in the directory hierarchy when creating the filename for the perf cache.

Fixes #845.