### PR TITLE
Add config.testResultsProcessor

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -68,6 +68,7 @@ Jest uses Jasmine 2 by default. An introduction to Jasmine 2 can be found
   - [`config.testPathDirs` [array<string>]](#config-testpathdirs-array-string)
   - [`config.testPathIgnorePatterns` [array<string>]](#config-testpathignorepatterns-array-string)
   - [`config.testPathPattern` [string]](#config-testpathpattern-string)
+  - [`config.testResultsProcessor` [string]](#config-testresultsprocessor-string)
   - [`config.testRunner` [string]](#config-testrunner-string)
   - [`config.unmockedModulePathPatterns` [array<string>]](#config-unmockedmodulepathpatterns-array-string)
   - [`config.verbose` [boolean]](#config-verbose-boolean)
@@ -507,6 +508,48 @@ An array of regexp pattern strings that are matched against all test paths befor
 A regexp pattern string that is matched against all test paths before executing the test. If the test path does not match the pattern, it will be skipped.
 
 This is useful if you need to override the default. If you are testing one file at a time the default will be set to `/.*/`, however if you pass a blob rather than a single file the default will then be the absolute path of each test file. The override may be needed on windows machines where, for example, the test full path would be `C:/myproject/__tests__/mystest.jsx.jest` and the default pattern would be set as `/C:\myproject\__tests__\mystest.jsx.jest/`.
+
+### `config.testResultsProcessor` [string]
+(default: `undefined`)
+
+This option allows the use of a custom results processor. This processor must be a node module that exports a function expecting an object with the following structure as the first argument:
+
+```
+{
+  "success": bool,
+  "startTime": epoch,
+  "numTotalTestSuites": number,
+  "numPassedTestSuites": number,
+  "numFailedTestSuites": number,
+  "numRuntimeErrorTestSuites": number,
+  "numTotalTests": number,
+  "numPassedTests": number,
+  "numFailedTests": number,
+  "numPendingTests": number,
+  "testResults": [{
+    "numFailingTests": number,
+    "numPassingTests": number,
+    "numPendingTests": number,
+    "testResults": [{
+      "title": string (message in it block),
+      "status": "failed" | "pending" | "passed",
+      "ancestorTitles": [string (message in describe blocks)],
+      "failureMessages": [string],
+      "numPassingAsserts": number
+    },
+    ...
+    ],
+    "perfStats": {
+      "start": epoch,
+      "end": epoch
+    },
+    "testFilePath": absolute path to test file,
+    "coverage": {}
+  },
+  ...
+  ]
+}
+```
 
 ### `config.testRunner` [string]
 (default: `jasmine2`)

--- a/src/config/normalize.js
+++ b/src/config/normalize.js
@@ -150,6 +150,7 @@ function normalize(config, argv) {
       case 'testRunner':
       case 'scriptPreprocessor':
       case 'setupTestFrameworkScriptFile':
+      case 'testResultsProcessor':
         value = path.resolve(
           config.rootDir,
           _replaceRootDirTags(config.rootDir, config[key])

--- a/src/jest.js
+++ b/src/jest.js
@@ -137,6 +137,10 @@ function runJest(config, argv, pipe, onComplete) {
     })
     .then(testPaths => testRunner.runTests(testPaths))
     .then(runResults => {
+      if (config.testResultsProcessor) {
+        const processor = require(config.testResultsProcessor);
+        processor(runResults);
+      }
       if (argv.json) {
         process.stdout.write(
           JSON.stringify(formatTestResults(runResults))


### PR DESCRIPTION
The aim of this config is to allow hooks into the runResults, for instance to generate jUnit test reports.

The json that jest --json outputs only shows part of the runResults object