### PR TITLE
Fix jest-hoist for react-native.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,6 @@
 .haste_cache
 __tests__
+blog
 docs
 examples
 packages

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jest-cli",
   "description": "Painless JavaScript Unit Testing.",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "main": "src/jest.js",
   "dependencies": {
     "chalk": "^1.1.1",

--- a/packages/babel-plugin-jest-hoist/src/__tests__/integration-test.js
+++ b/packages/babel-plugin-jest-hoist/src/__tests__/integration-test.js
@@ -49,6 +49,13 @@ jest.unmock('../__test_modules__/' + 'c');
 jest.dontMock('../__test_modules__/Mocked');
 
 describe('babel-plugin-jest-hoist', () => {
+
+  it('does not throw during transform', () => {
+    const object = {};
+    object.__defineGetter__('foo', () => 'bar');
+    expect(object.foo).toEqual('bar');
+  });
+
   it('hoists react unmock call before imports', () => {
     expect(typeof React).toEqual('object');
     expect(React.isValidElement.mock).toBe(undefined);


### PR DESCRIPTION
Because the Object in the hoist transform had `Object.prototype` as its prototype, lookups like `FUNCTIONS[foo]` will break for some keys `foo` like `__defineGetter__`. This fixes it.