### PR TITLE
add support of mockImplementationOnce to mock functions

### DIFF
--- a/docs/MockFunctions.md
+++ b/docs/MockFunctions.md
@@ -117,7 +117,7 @@ return values and full-on replace the implementation of a mock function. This
 can be done with `mockImplementation` or `mockImplementationOnce` methods
 on mock functions.
 
-The `mockImplementation` method is useful when you need define the default
+The `mockImplementation` method is useful when you need to define the default
 implementation of your function:
 
 ```javascript
@@ -160,7 +160,7 @@ myMockFn(function(err, val) {
 
 When the mocked function runs out of implementations defined with
 `mockImplementationOnce`, it will execute the default implementation
-set with `mockImplementation` if it is available:
+set with `mockImplementation` (if it is defined):
 
 ```javascript
 var myMockFn = jest.genMockFunction().mockImplementation(function() {

--- a/docs/MockFunctions.md
+++ b/docs/MockFunctions.md
@@ -114,12 +114,16 @@ function that's not directly being tested.
 
 Still, there are cases where it's useful to go beyond the ability to specify
 return values and full-on replace the implementation of a mock function. This
-can be done with the `mockImplementation` method on mock functions:
+can be done with `mockImplementation` or `mockImplementationOnce` methods
+on mock functions:
 
 ```javascript
 var myObj = {
-  myMethod: jest.genMockFunction().mockImplementation(function() {
+  myMethod: jest.genMockFunction().mockImplementationOnce(function() {
     // do something stateful
+    return this;
+  }).mockImplementation(function() {
+    // do something else stateful
     return this;
   });
 };

--- a/docs/MockFunctions.md
+++ b/docs/MockFunctions.md
@@ -115,20 +115,64 @@ function that's not directly being tested.
 Still, there are cases where it's useful to go beyond the ability to specify
 return values and full-on replace the implementation of a mock function. This
 can be done with `mockImplementation` or `mockImplementationOnce` methods
-on mock functions:
+on mock functions.
+
+The `mockImplementation` method is useful when you need define the default
+implementation of your function:
 
 ```javascript
-var myObj = {
-  myMethod: jest.genMockFunction().mockImplementationOnce(function() {
-    // do something stateful
-    return this;
-  }).mockImplementation(function() {
-    // do something else stateful
-    return this;
-  });
-};
+var myMockFn = jest.genMockFunction().mockImplementation(function(cb) {
+  cb(null, true);
+});
 
-myObj.myMethod(1).myMethod(2);
+myMockFn(function(err, val) {
+  console.log(val);
+});
+> true
+
+myMockFn(function(err, val) {
+  console.log(val);
+});
+> true
+```
+
+When you need to recreate a complex behavior of a mock function such that
+multiple function calls produce different results, use the `mockImplementationOnce`
+method:
+
+```javascript
+var myMockFn = jest.genMockFunction().mockImplementationOnce(function(cb) {
+  cb(null, true);
+}).mockImplementationOnce(function(cb) {
+  cb(null, false);
+});
+
+myMockFn(function(err, val) {
+  console.log(val);
+});
+> true
+
+myMockFn(function(err, val) {
+  console.log(val);
+});
+> false
+```
+
+When the mocked function runs out of implementations defined with
+`mockImplementationOnce`, it will execute the default implementation
+set with `mockImplementation` if it is available:
+
+```javascript
+var myMockFn = jest.genMockFunction().mockImplementation(function() {
+  return 'default';
+}).mockImplementationOnce(function() {
+  return 'first call';
+}).mockImplementationOnce(function() {
+  return 'second call';
+});
+
+console.log(myMockFn(), myMockFn(), myMockFn(), myMockFn());
+> 'first call', 'second call', 'default', 'default'
 ```
 
 For cases where we have methods that are typically chained (and thus always need

--- a/packages/jest-mock/README.md
+++ b/packages/jest-mock/README.md
@@ -90,9 +90,14 @@ function.
 
 Sets the default return value for the function.
 
+##### `.mockImplementationOnce(function)`
+
+Pushes the given mock implementation onto a FIFO queue of mock
+implementations for the function.
+
 ##### `.mockImplementation(function)`
 
-Sets a mock implementation for the function.
+Sets the default mock implementation for the function.
 
 ##### `.mockReturnThis()`
 
@@ -100,12 +105,13 @@ Syntactic sugar for .mockImplementation(function() {return this;})
 
 
 
-In case both `mockImplementation()` and
+In case both `mockImplementationOnce()/mockImplementation()` and
 `mockReturnValueOnce()/mockReturnValue()` are called. The priority of which to
 use is based on what is the last call:
 - if the last call is mockReturnValueOnce() or mockReturnValue(),
-  use the specific return specific return value or default return value.
+  use the specific return value or default return value.
   If specific return values are used up or no default return value is set,
   fall back to try mockImplementation();
-- if the last call is mockImplementation(), run the given implementation
-  and return the result.
+- if the last call is mockImplementationOnce() or mockImplementation(),
+  run the specific implementation and return the result or run default
+  implementation and return the result.

--- a/packages/jest-mock/src/__tests__/jest-mock-test.js
+++ b/packages/jest-mock/src/__tests__/jest-mock-test.js
@@ -123,4 +123,37 @@ describe('moduleMocker', () => {
       ).not.toThrow();
     });
   });
+
+  describe('mockImplementationOnce', () => {
+     it('should mock single call to a mock function', () => {
+      const mockFn = moduleMocker.getMockFunction();
+
+      mockFn.mockImplementationOnce(() => {
+        return 'Foo';
+      }).mockImplementationOnce(() => {
+        return 'Bar';
+      });
+
+      expect(mockFn()).toBe('Foo');
+      expect(mockFn()).toBe('Bar');
+      expect(mockFn()).toBeUndefined();
+    });
+
+    it('should fallback to default mock function when no specific mock is available', () => {
+      const mockFn = moduleMocker.getMockFunction();
+
+      mockFn.mockImplementationOnce(() => {
+        return 'Foo';
+      }).mockImplementationOnce(() => {
+        return 'Bar';
+      }).mockImplementation(() => {
+        return 'Default';
+      });
+
+      expect(mockFn()).toBe('Foo');
+      expect(mockFn()).toBe('Bar');
+      expect(mockFn()).toBe('Default');
+      expect(mockFn()).toBe('Default');
+    });
+  });
 });


### PR DESCRIPTION
It would be great to have a way to define multiple mock implementations of a function similar to the way it's done for the `mockReturnValueOnce` method.

It's useful when one needs to simulate a certain behaviour of a function that is called multimple times and has a callback as one if its arguments.

Example:

```javascript
const mockFn = moduleMocker.getMockFunction();

mockFn.mockImplementationOnce((cb) => {
  cb(null, 'Foo');
}).mockImplementationOnce((cb) => {
  cb(null, 'Bar');
}).mockImplementation((cb) => {
  cb(new Error('FooBar!'));
});
```
