### PR TITLE
include untracked files when watching

### DIFF
--- a/src/lib/git.js
+++ b/src/lib/git.js
@@ -13,7 +13,7 @@ const childProcess = require('child_process');
 
 function findChangedFiles(cwd) {
   return new Promise((resolve, reject) => {
-    const args = ['diff', '--name-only', '--diff-filter=ACMR', '--relative'];
+    const args = ['ls-files', '--other', '--modified', '--exclude-standard'];
     const child = childProcess.spawn('git', args, {cwd});
 
     let stdout = '';


### PR DESCRIPTION
Relates to #856 

This pull request changes the git lib file to find all changed files with the `git ls-files` command instead of `git diff`. Git diff only lists staged files.

ps. If we watch on all changed files, I wonder what is the point of `--watch=all`. 