### PR TITLE
Hold the values for actual/expected when test fails (not references)

### DIFF
--- a/packages/jest-jasmine2/src/index.js
+++ b/packages/jest-jasmine2/src/index.js
@@ -39,6 +39,25 @@ function jasmine2(config, environment, moduleLoader, testPath) {
 
     const requireJasmine = environment.global.jasmineRequire;
     jasmine = requireJasmine.core(requireJasmine);
+
+    const jasmineBuildExpectationResult = jasmine.buildExpectationResult;
+
+    // https://github.com/facebook/jest/issues/429
+    jasmine.buildExpectationResult = function(options) {
+
+      if (!options.passed) {
+        function shallowCopy(obj) {
+          return typeof obj !== 'object' || obj === null
+            ? obj : jasmine.util.clone(obj);
+        }
+
+        options.expected = shallowCopy(options.expected);
+        options.actual = shallowCopy(options.actual);
+      }
+
+      return jasmineBuildExpectationResult.apply(jasmine, arguments);
+    };
+
     env = jasmine.getEnv();
     const jasmineInterface = requireJasmine.interface(jasmine, env);
     Object.assign(environment.global, jasmineInterface);


### PR DESCRIPTION
related to https://github.com/facebook/jest/issues/429

It can be an expensive operation, but it only occurs when a test fails.

the following test:
```js
  it('keeps the reference', function() {
    var a = [1];
    expect(a).toEqual([1, 2]);
    a.push(2);
  });
```

before:
![screen shot 2016-04-12 at 5 55 40 pm](https://cloud.githubusercontent.com/assets/940133/14479858/ded42e0e-00d7-11e6-8841-0d817ca02d45.png)

after:
![screen shot 2016-04-12 at 5 56 03 pm](https://cloud.githubusercontent.com/assets/940133/14479860/e3d1710a-00d7-11e6-837f-e2f2bdfb27b7.png)

