### PR TITLE
Don't run `npm test` twice

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,4 @@ node_js:
   - "5"
 sudo: false
 before_install: npm i -g npm@latest
+install: npm i --ignore-scripts && npm run postinstall


### PR DESCRIPTION
currently we run `npm test` twice.
1. In `npm prepublish` script (triggered by `npm i`)
2. regular CI test
