### PR TITLE
Add async error test for promise and async/await

### DIFF
--- a/examples/async/__mocks__/request.js
+++ b/examples/async/__mocks__/request.js
@@ -9,7 +9,9 @@ export default function request(url) {
   return new Promise((resolve, reject) => {
     const userID = parseInt(url.substr('/users/'.length), 10);
     process.nextTick(
-      () => users[userID] ? resolve(users[userID]) : reject({error: userID})
+      () => users[userID] ? resolve(users[userID]) : reject({
+        error: 'Do not have userID ' + userID,
+      })
     );
   });
 }

--- a/examples/async/__tests__/user-test.js
+++ b/examples/async/__tests__/user-test.js
@@ -18,4 +18,23 @@ describe('async tests', () => {
     const userName = await user.getUserName(4);
     expect(userName).toEqual('Mark');
   });
+
+  // Async error test do not use traditional jasmine toThrow().
+  // Instead, they can be processed with standard javascript style.
+  pit('tests error with promises', () => {
+    return user.getUserName(3)
+      .catch(e => expect(e).toEqual({
+        error: 'Do not have userID 3',
+      }));
+  });
+
+  pit('tests error with async/await', async () => {
+    try {
+      await user.getUserName(2);
+    } catch (e) {
+      expect(e).toEqual({
+        error: 'Do not have userID 2',
+      });
+    }
+  });
 });


### PR DESCRIPTION
I test many times,seems there isnt a suitable  way to use Jasmine's `toThrow style` to test `async error`.
So i add some codes to illustrate using standard javascript style to test async error .
Do there have a `toThrow` version test ? I can not make a suitable `toThrow` test. if there is,should add both of those illustration codes.