### PR TITLE
Fix `jest -o` when Mercurial or Git are not present.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 ## master
 
+## jest-cli 11.0.2
+
+* Fixed `jest -o` error when Mercurial isn't installed on the system
+* Fixed Jasmine failure message when expected values were mutated after tests.
+
 ## jest-cli 11.0.1, babel-jest 11.0.1
 
-* Added support for mercurial repositories when using `jest -o`
+* Added support for Mercurial repositories when using `jest -o`
 * Added `mockImplementationOnce` API to `jest.fn()`.
 
 ## jest-cli 11.0.0, babel-jest 11.0.0 (pre-releases 0.9 to 0.10)

--- a/src/jest.js
+++ b/src/jest.js
@@ -58,8 +58,8 @@ function findOnlyChangedTestPaths(testRunner, config) {
       if (!repos.every(result => result[0] || result[1])) {
         throw new Error(
           'It appears that one of your testPathDirs does not exist ' +
-          'within a git or hg repository. Currently --onlyChanged only works ' +
-          'with git or hg projects.\n'
+          'within a git or hg repository. Currently `--onlyChanged` ' +
+          'only works with git or hg projects.'
         );
       }
       return Promise.all(Array.from(repos).map(repo => {
@@ -169,7 +169,7 @@ function runJest(config, argv, pipe, onComplete) {
     .then(runResults => onComplete && onComplete(runResults.success))
     .catch(error => {
       if (error.type == 'DependencyGraphError') {
-        console.error([
+        throw new Error([
           '\nError: ' + error.message + '\n\n',
           'This is most likely a setup ',
           'or configuration issue. To resolve a module name collision, ',
@@ -177,11 +177,8 @@ function runJest(config, argv, pipe, onComplete) {
           'http://facebook.github.io/jest/docs/api.html#modulepathignorepatterns-array-string',
         ].join(''));
       } else {
-        console.error(
-          '\nUnexpected Error: ' + error.message + '\n\n' + error.stack
-        );
+        throw error;
       }
-      process.exit(1);
     });
 }
 

--- a/src/lib/git.js
+++ b/src/lib/git.js
@@ -40,15 +40,11 @@ function findChangedFiles(cwd) {
 function isGitRepository(cwd) {
   return new Promise(resolve => {
     let stdout = '';
-    const child = childProcess.spawn(
-      'git',
-      ['rev-parse', '--show-toplevel'],
-      {cwd}
-    );
+    const options = ['rev-parse', '--show-toplevel'];
+    const child = childProcess.spawn('git', options, {cwd});
     child.stdout.on('data', data => stdout += data);
-    child.on('close',
-      code => resolve(code === 0 ? stdout.trim() : null)
-    );
+    child.on('error', () => resolve(null));
+    child.on('close', code => resolve(code === 0 ? stdout.trim() : null));
   });
 }
 

--- a/src/lib/hg.js
+++ b/src/lib/hg.js
@@ -40,15 +40,10 @@ function findChangedFiles(cwd) {
 function isHGRepository(cwd) {
   return new Promise(resolve => {
     let stdout = '';
-    const child = childProcess.spawn(
-      'hg',
-      ['root'],
-      {cwd}
-    );
+    const child = childProcess.spawn('hg', ['root'], {cwd});
     child.stdout.on('data', data => stdout += data);
-    child.on('close',
-      code => resolve(code === 0 ? stdout.trim() : null)
-    );
+    child.on('error', () => resolve(null));
+    child.on('close', code => resolve(code === 0 ? stdout.trim() : null));
   });
 }
 


### PR DESCRIPTION
Fixes #904  and #905.

The promise executor is synchronously called during instantiation, so `.catch()` will not work.