### PR TITLE
Add proper support for module.paths.

### DIFF
--- a/src/Runtime/__tests__/Runtime-requireModule-test.js
+++ b/src/Runtime/__tests__/Runtime-requireModule-test.js
@@ -63,6 +63,16 @@ describe('Runtime', () => {
       });
     });
 
+    pit('provides `module.paths` to modules', () => {
+      return buildLoader().then(loader => {
+        const exports = loader.requireModule(rootPath, 'RegularModule');
+        expect(exports.paths.length).toBeGreaterThan(0);
+        exports.paths.forEach(path => {
+          expect(path.endsWith('node_modules')).toBe(true);
+        });
+      });
+    });
+
     pit('throws on non-existent @providesModule modules', () => {
       return buildLoader().then(loader => {
         expect(() => {

--- a/src/Runtime/__tests__/test_root/RegularModule.js
+++ b/src/Runtime/__tests__/test_root/RegularModule.js
@@ -35,4 +35,5 @@ exports.getModuleStateValue = getModuleStateValue;
 exports.isRealModule = true;
 exports.setModuleStateValue = setModuleStateValue;
 exports.parent = module.parent;
+exports.paths = module.paths;
 exports.jest = jest;


### PR DESCRIPTION
Fixes #898. Eslint is using private module APIs, so let's add them to Jest.