### PR TITLE
Add custom equality matcher to support ES 2015 iterables

### DIFF
--- a/packages/jest-jasmine2/src/__tests__/iterators-test.js
+++ b/packages/jest-jasmine2/src/__tests__/iterators-test.js
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails oncall+jsinfra
+ */
+'use strict';
+
+describe('compare iterables correctly', () => {
+
+  it('works for arrays', () => {
+    const obj = [1, {}, []];
+
+    expect(obj).toEqual(obj);
+    expect([1, 2, 3]).toEqual([1, 2, 3]);
+    expect([1]).not.toEqual([2]);
+    expect([1, 2, 3]).not.toEqual([1, 2]);
+    expect([1, 2, 3]).not.toEqual([1, 2, 3, 4]);
+  });
+
+  it('works for custom iterables', () => {
+    const iterable = {
+      0: 'a',
+      1: 'b',
+      2: 'c',
+      length: 3,
+      [Symbol.iterator]: Array.prototype[Symbol.iterator],
+    };
+
+    expect(iterable).toEqual(['a', 'b', 'c']);
+    expect(iterable).not.toEqual(['a', 'b']);
+    expect(iterable).not.toEqual(['a', 'b', 'c', 'd']);
+  });
+
+  it('works for Sets', () => {
+    const numbers = [1, 2, 3, 4];
+    const setOfNumbers = new Set(numbers);
+
+    expect(setOfNumbers).not.toEqual(new Set());
+    expect(setOfNumbers).not.toBe(numbers);
+    expect(setOfNumbers).not.toEqual([1, 2, 3]);
+    expect(setOfNumbers).toEqual(numbers);
+  });
+
+  it('works for Maps', () => {
+    const keyValuePairs = [['key1', 'value1'], ['key2', 'value2']];
+    const map = new Map(keyValuePairs);
+
+    expect(map).not.toBe(keyValuePairs);
+    expect(map).toEqual(keyValuePairs);
+  });
+
+});

--- a/packages/jest-jasmine2/src/__tests__/iterators-test.js
+++ b/packages/jest-jasmine2/src/__tests__/iterators-test.js
@@ -9,12 +9,12 @@
  */
 'use strict';
 
-describe('compare iterables correctly', () => {
+describe('iterators', () => {
 
   it('works for arrays', () => {
-    const obj = [1, {}, []];
+    const mixedArray = [1, {}, []];
 
-    expect(obj).toEqual(obj);
+    expect(mixedArray).toEqual(mixedArray);
     expect([1, 2, 3]).toEqual([1, 2, 3]);
     expect([1]).not.toEqual([2]);
     expect([1, 2, 3]).not.toEqual([1, 2]);
@@ -29,28 +29,47 @@ describe('compare iterables correctly', () => {
       length: 3,
       [Symbol.iterator]: Array.prototype[Symbol.iterator],
     };
-
-    expect(iterable).toEqual(['a', 'b', 'c']);
+    const expectedIterable = {
+      0: 'a',
+      1: 'b',
+      2: 'c',
+      length: 3,
+      [Symbol.iterator]: Array.prototype[Symbol.iterator],
+    };
+    expect(iterable).toEqual(expectedIterable);
     expect(iterable).not.toEqual(['a', 'b']);
+    expect(iterable).not.toEqual(['a', 'b', 'c']);
     expect(iterable).not.toEqual(['a', 'b', 'c', 'd']);
   });
 
   it('works for Sets', () => {
     const numbers = [1, 2, 3, 4];
     const setOfNumbers = new Set(numbers);
-
     expect(setOfNumbers).not.toEqual(new Set());
     expect(setOfNumbers).not.toBe(numbers);
+    expect(setOfNumbers).not.toEqual([1, 2]);
     expect(setOfNumbers).not.toEqual([1, 2, 3]);
-    expect(setOfNumbers).toEqual(numbers);
+    expect(setOfNumbers).toEqual(new Set(numbers));
+
+    const nestedSets = new Set([new Set([1, 2])]);
+    expect(nestedSets).not.toEqual(new Set([new Set([1, 4])]));
+    expect(nestedSets).toEqual(new Set([new Set([1, 2])]));
   });
 
   it('works for Maps', () => {
     const keyValuePairs = [['key1', 'value1'], ['key2', 'value2']];
+    const smallerKeyValuePairs = [['key1', 'value1']];
+    const biggerKeyValuePairs = [
+      ['key1', 'value1'], ['key2', 'value2'], ['key3', 'value3'],
+    ];
     const map = new Map(keyValuePairs);
-
+    expect(map).not.toEqual(smallerKeyValuePairs);
+    expect(map).not.toEqual(new Map(smallerKeyValuePairs));
+    expect(map).not.toEqual(biggerKeyValuePairs);
+    expect(map).not.toEqual(new Map(biggerKeyValuePairs));
+    expect(map).not.toEqual(keyValuePairs);
     expect(map).not.toBe(keyValuePairs);
-    expect(map).toEqual(keyValuePairs);
+    expect(map).toEqual(new Map(keyValuePairs));
   });
 
 });

--- a/packages/jest-jasmine2/src/index.js
+++ b/packages/jest-jasmine2/src/index.js
@@ -70,15 +70,15 @@ function jasmine2(config, environment, moduleLoader, testPath) {
     }
   });
 
-  const hasIterator = object => !!(object !== null && object[Symbol.iterator]);
-  const jestCustomEqualityTesters = [];
+  const hasIterator = object => !!(object != null && object[Symbol.iterator]);
   const iterableEquality = (a, b) => {
     if (
       typeof a !== 'object' ||
       typeof b !== 'object' ||
       Array.isArray(a) ||
       Array.isArray(b) ||
-      ![a, b].every(hasIterator)
+      !hasIterator(a) ||
+      !hasIterator(b)
     ) {
       return undefined;
     }
@@ -94,7 +94,7 @@ function jasmine2(config, environment, moduleLoader, testPath) {
         !jasmine.matchersUtil.equals(
           aValue,
           nextB.value,
-          jestCustomEqualityTesters
+          [iterableEquality]
         )
       ) {
         return false;
@@ -105,12 +105,9 @@ function jasmine2(config, environment, moduleLoader, testPath) {
     }
     return true;
   };
-  jestCustomEqualityTesters.push(iterableEquality);
 
   env.beforeEach(() => {
-    jestCustomEqualityTesters.forEach(
-      tester => jasmine.addCustomEqualityTester(tester)
-    );
+    jasmine.addCustomEqualityTester(iterableEquality);
 
     jasmine.addMatchers({
       toBeCalled: () => ({

--- a/packages/jest-jasmine2/src/index.js
+++ b/packages/jest-jasmine2/src/index.js
@@ -69,7 +69,32 @@ function jasmine2(config, environment, moduleLoader, testPath) {
       moduleLoader.requireModule(null, config.setupTestFrameworkScriptFile);
     }
   });
+
+  const iterableEquality = (left, right) => {
+    let result; // result needs to be `undefined` if not an iterator
+    if (left && right && left[Symbol.iterator] && right[Symbol.iterator]) {
+      const leftIterator = left[Symbol.iterator]();
+      const rightIterator = right[Symbol.iterator]();
+      let nextLeft = leftIterator.next();
+      let nextRight = rightIterator.next();
+
+      result = true;
+      while (result && !nextLeft.done) {
+        result = jasmine.matchersUtil.equals(nextLeft, nextRight);
+        nextLeft = leftIterator.next();
+        nextRight = rightIterator.next();
+      }
+
+      if (!nextRight.done) {
+        result = false;
+      }
+    }
+
+    return result;
+  };
+
   env.beforeEach(() => {
+    jasmine.addCustomEqualityTester(iterableEquality);
     jasmine.addMatchers({
       toBeCalled: () => ({
         compare: (actual, expected) => {


### PR DESCRIPTION
Allows jest to check for equalities of Sets/Maps and Array-like by adding a [custom equality tester](http://jasmine.github.io/2.0/custom_equality.html) for iterators.
Jasmine run custom equality before the normal equality checker, so I also add a test to ensure it didn't break normal Arrays equality (as they implement `Symbol.iterator`).