### PR TITLE
adding support for coverage thresholds, should fix #526

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -52,6 +52,7 @@ Jest uses Jasmine 2 by default. An introduction to Jasmine 2 can be found
   - [`coverageDirectory` [string]](#coveragedirectory-string)
   - [`collectCoverage` [boolean]](#collectcoverage-boolean)
   - [`collectCoverageOnlyFrom` [object]](#collectcoverageonlyfrom-object)
+  - [`coverageThreshold` [object]](#coveragethreshold-object)
   - [`globals` [object]](#globals-object)
   - [`mocksPattern` [string]](#mockspattern-string)
   - [`moduleFileExtensions` [array<string>]](#modulefileextensions-array-string)
@@ -396,6 +397,29 @@ Indicates whether the coverage information should be collected while executing t
 (default: `undefined`)
 
 An object that, when present, indicates a set of files for which coverage information should be collected. Any files not present in this set will not have coverage collected for them. Since there is a performance cost for each file that we collect coverage information from, this can help prune this cost down to only the files in which you care about coverage (such as the specific modules that you are testing).
+
+### `coverageThreshold` [object]
+(default: `undefined`)
+
+This will be used to configure minimum threshold enforcement for coverage results. If the thresholds are not met, jest will return failure. Thresholds, when specified as a positive number are taken to be the minimum percentage required. When a threshold is specified as a negative number it represents the maximum number of uncovered entities allowed.
+
+For example, statements: 90 implies minimum statement coverage is 90%. statements: -10 implies that no more than 10 uncovered statements are allowed.
+
+```js
+{
+  ...
+  "jest": {
+    "coverageThreshold": {
+      "global": {
+        "branches": 50,
+        "functions": 50,
+        "lines": 50,
+        "statements": 50
+      }
+    }
+  }
+}
+```
 
 ### `globals` [object]
 (default: `{}`)

--- a/packages/jest-cli/src/config/normalize.js
+++ b/packages/jest-cli/src/config/normalize.js
@@ -219,6 +219,7 @@ function normalize(config, argv) {
       case 'coverageReporters':
       case 'collectCoverage':
       case 'coverageCollector':
+      case 'coverageThreshold':
       case 'globals':
       case 'haste':
       case 'mocksPattern':

--- a/packages/jest-cli/src/config/read.js
+++ b/packages/jest-cli/src/config/read.js
@@ -18,6 +18,10 @@ function readConfig(argv, packageRoot) {
     if (argv.coverage) {
       config.collectCoverage = true;
     }
+    
+    if (config.coverageThreshold) {
+      config.collectCoverage = true;
+    }
 
     if (argv.testEnvData) {
       config.testEnvData = argv.testEnvData;

--- a/packages/jest-cli/src/reporters/IstanbulTestReporter.js
+++ b/packages/jest-cli/src/reporters/IstanbulTestReporter.js
@@ -7,8 +7,8 @@
 */
 'use strict';
 
-const chalk = require('chalk');
 const DefaultTestReporter = require('./DefaultTestReporter');
+const chalk = require('chalk');
 const istanbul = require('istanbul');
 const collector = new istanbul.Collector();
 const testCollectors = Object.create(null);
@@ -57,12 +57,16 @@ class IstanbulTestReporter extends DefaultTestReporter {
 
             if (threshold < 0) {
               if (threshold * -1 < actualUncovered) {
-                errors.push(`Uncovered count for ${key} (${actualUncovered})` +
-                  `exceeds ${name} threshold (${-1 * threshold})`);
+                errors.push(
+                  `Uncovered count for ${key} (${actualUncovered})` +
+                  `exceeds ${name} threshold (${-1 * threshold})`
+                );
               }
             } else if (actual < threshold) {
-              errors.push(`Coverage for ${key} (${actual}` +
-                `%) does not meet ${name} threshold (${threshold}%)`);
+              errors.push(
+                `Coverage for ${key} (${actual}` +
+                `%) does not meet ${name} threshold (${threshold}%)`
+              );
             }
             return errors;
           }, []);
@@ -70,7 +74,7 @@ class IstanbulTestReporter extends DefaultTestReporter {
         const errors = check('global', config.coverageThreshold.global, globalResults);
         
         if (errors.length > 0) {
-          console.error(`${FAIL_COLOR(errors.join('\n'))}`);
+          this.log(`${FAIL_COLOR(errors.join('\n'))}`);
           aggregatedResults.success = false;
         }
       }

--- a/packages/jest-cli/src/reporters/IstanbulTestReporter.js
+++ b/packages/jest-cli/src/reporters/IstanbulTestReporter.js
@@ -51,9 +51,9 @@ class IstanbulTestReporter extends DefaultTestReporter {
             'lines',
             'functions',
           ].reduce((errors, key) => {
-            const actual = actuals[key].pct,
-                actualUncovered = actuals[key].total - actuals[key].covered,
-                threshold = thresholds[key];
+            const actual = actuals[key].pct;
+            const actualUncovered = actuals[key].total - actuals[key].covered;
+            const threshold = thresholds[key];
 
             if (threshold < 0) {
               if (threshold * -1 < actualUncovered) {

--- a/packages/jest-cli/src/reporters/__tests__/IstanbulTestReporter-test.js
+++ b/packages/jest-cli/src/reporters/__tests__/IstanbulTestReporter-test.js
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
+jest.disableAutomock().mock('fs');
+jest.setMock('istanbul', {
+  Collector: jest.fn().mockImplementation(() => {
+    return {
+      getFinalCoverage: jest.fn(),
+    }
+  }),
+  Reporter: jest.fn(),
+  utils: {
+    summarizeCoverage: jest.fn(),
+  },
+});
+const istanbul = require('istanbul');
+
+describe('InstanbulTestReporter', () => {
+  let IstanbulTestReporter;
+
+  beforeEach(() => {
+    IstanbulTestReporter = require('../IstanbulTestReporter');
+  });
+
+  describe('onRunComplete', () => {
+
+    let mockAggResults;
+    let testReporter;
+    const globalResults = {
+      'statements': {
+        'pct': 50,
+      },
+      'branches': {
+        'pct': 0,
+      },
+      'lines': {
+        'pct': 0,
+      },
+      'functions': {
+        'pct': 0,
+      },
+    };
+
+    beforeEach(() => {
+      mockAggResults = {
+        success: true,
+        startTime: 0,
+        numTotalTestSuites: 1,
+        numPassedTestSuites: 1,
+        numFailedTestSuites: 0,
+        numRuntimeErrorTestSuites: 0,
+        numTotalTests: 1,
+        numPassedTests: 1,
+        numPendingTests: 0,
+        numFailedTests: 0,
+        testResults: [],
+        postSuiteHeaders: [],
+        testFilePath: 'foo',
+      };
+      const fakeProcess = {
+        exit: jest.fn(),
+        stdout: {
+          write: jest.fn(),
+        },
+      };
+      testReporter = new IstanbulTestReporter(fakeProcess);
+      istanbul.utils.summarizeCoverage.mockReturnValue(globalResults);
+    });
+
+    it('Sets results success to false on threshold fail.', () => {
+      testReporter.onRunComplete({
+        collectCoverage: true,
+        coverageThreshold: {
+          global: {
+            'statements': 100,
+          },
+        },
+      }, mockAggResults);
+      expect(mockAggResults.success).toBe(false);
+    });
+
+    it('Should return success when threshold is met.', () => {
+      testReporter.onRunComplete({
+        collectCoverage: true,
+        coverageThreshold: {
+          global: {
+            'statements': 50,
+          },
+        },
+      }, mockAggResults);
+      expect(mockAggResults.success).toBe(true);
+    });
+
+  });
+});
+
+


### PR DESCRIPTION
Added support for specifying global coverage thresholds.  If the thresholds aren't met, then jest should exit code 1.