### PR TITLE
Update test runner and disable tests on Windows.

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "lint": "eslint .",
     "postinstall": "node postinstall.js",
     "prepublish": "npm test",
-    "test": "npm run lint && npm run jest-no-cache && npm run jest-cache && npm run jest-node-no-cache && npm run jest-node-cache && npm run jest-jasmine1 && npm run jest-in-band && npm run jest-heap-usage && npm run jest-json && npm run jest-verbose && npm link --ignore-scripts && node ./run_tests.js"
+    "test": "npm run lint && npm run jest-no-cache && npm run jest-cache && npm run jest-node-no-cache && npm run jest-node-cache && npm run jest-jasmine1 && npm run jest-in-band && npm run jest-heap-usage && npm run jest-json && npm run jest-verbose && npm link --ignore-scripts && node ./runTests.js"
   },
   "jest": {
     "rootDir": "src",

--- a/packages/babel-plugin-jest-hoist/package.json
+++ b/packages/babel-plugin-jest-hoist/package.json
@@ -13,10 +13,9 @@
   },
   "jest": {
     "scriptPreprocessor": "../babel-jest",
-    "testEnvironment": "../jest-environment-node"
+    "testEnvironment": "node"
   },
   "scripts": {
-    "prepublish": "npm test",
-    "test": "node -e \"const spawn = require('child_process').spawn, path=require('path'); spawn('node', [path.resolve('../../bin/jest.js')], {stdio:'inherit'})\""
+    "test": "../../bin/jest.js"
   }
 }

--- a/packages/jest-environment-node/package.json
+++ b/packages/jest-environment-node/package.json
@@ -10,7 +10,10 @@
   "dependencies": {
     "jest-util": "^11.0.2"
   },
+  "jest": {
+    "testEnvironment": "node"
+  },
   "scripts": {
-    "test": "node -e \"const spawn = require('child_process').spawn, path=require('path'); spawn('node', [path.resolve('../../bin/jest.js')], {stdio:'inherit'})\""
+    "test": "../../bin/jest.js"
   }
 }

--- a/packages/jest-haste-map/package.json
+++ b/packages/jest-haste-map/package.json
@@ -19,7 +19,6 @@
     ]
   },
   "scripts": {
-    "prepublish": "npm test",
-    "test": "node -e \"const spawn = require('child_process').spawn, path=require('path'); spawn('node', [path.resolve('../../bin/jest.js')], {stdio:'inherit'})\""
+    "test": "../../bin/jest.js"
   }
 }

--- a/packages/jest-jasmine1/package.json
+++ b/packages/jest-jasmine1/package.json
@@ -11,10 +11,10 @@
     "graceful-fs": "^4.1.3",
     "jest-util": "^11.0.2"
   },
-  "scripts": {
-    "test": "node -e \"const spawn = require('child_process').spawn, path=require('path'); spawn('node', [path.resolve('../../bin/jest.js')], {stdio:'inherit'})\""
-  },
   "jest": {
     "testEnvironment": "node"
+  },
+  "scripts": {
+    "test": "../../bin/jest.js"
   }
 }

--- a/packages/jest-jasmine2/package.json
+++ b/packages/jest-jasmine2/package.json
@@ -11,10 +11,10 @@
     "graceful-fs": "^4.1.3",
     "jest-util": "^11.0.2"
   },
-  "scripts": {
-    "test": "node -e \"const spawn = require('child_process').spawn, path=require('path'); spawn('node', [path.resolve('../../bin/jest.js')], {stdio:'inherit'})\""
-  },
   "jest": {
     "testEnvironment": "node"
+  },
+  "scripts": {
+    "test": "../../bin/jest.js"
   }
 }

--- a/packages/jest-mock/package.json
+++ b/packages/jest-mock/package.json
@@ -7,10 +7,10 @@
   },
   "license": "BSD-3-Clause",
   "main": "src/index.js",
-  "scripts": {
-    "test": "node -e \"const spawn = require('child_process').spawn, path=require('path'); spawn('node', [path.resolve('../../bin/jest.js')], {stdio:'inherit'})\""
-  },
   "jest": {
     "testEnvironment": "node"
+  },
+  "scripts": {
+    "test": "../../bin/jest.js"
   }
 }

--- a/packages/jest-util/package.json
+++ b/packages/jest-util/package.json
@@ -15,10 +15,10 @@
   "devDependencies": {
     "jsdom": "^8.3.1"
   },
-  "scripts": {
-    "test": "../../bin/jest.js"
-  },
   "jest": {
     "testEnvironment": "node"
+  },
+  "scripts": {
+    "test": "../../bin/jest.js"
   }
 }

--- a/runTests.js
+++ b/runTests.js
@@ -5,11 +5,17 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
+'use strict';
 
 /**
  * This script runs tests for all packages in `./packages` and
  * example projects in `./examples`.
  */
+
+if (process.platform === 'win32') {
+  console.error('Tests for examples and packages are skipped on Windows.');
+  return;
+}
 
 const fs = require('graceful-fs');
 const path = require('path');
@@ -19,7 +25,6 @@ const mkdirp = require('mkdirp');
 const PACKAGES_DIR = './packages';
 const EXAMPLES_DIR = './examples';
 const rimraf = require('rimraf');
-const isWindows = process.platform === 'win32';
 
 const packages = fs.readdirSync(PACKAGES_DIR)
   .map(file => path.resolve(PACKAGES_DIR, file))
@@ -46,46 +51,25 @@ packages.forEach(cwd => {
   runCommands('npm test', cwd);
 });
 
-if (!isWindows) {
-  examples.forEach(cwd => {
-    console.log(chalk.bold(chalk.cyan('Testing example: ') + cwd));
+examples.forEach(cwd => {
+  console.log(chalk.bold(chalk.cyan('Testing example: ') + cwd));
 
-    runCommands('npm update', cwd);
-    rimraf.sync(path.resolve(cwd, './node_modules/jest-cli'));
-    mkdirp.sync(path.resolve(cwd, './node_modules/jest-cli'));
-    mkdirp.sync(path.resolve(cwd, './node_modules/.bin'));
+  runCommands('npm update', cwd);
+  rimraf.sync(path.resolve(cwd, './node_modules/jest-cli'));
+  mkdirp.sync(path.resolve(cwd, './node_modules/jest-cli'));
+  mkdirp.sync(path.resolve(cwd, './node_modules/.bin'));
 
-    // Using `npm link jest-cli` can create problems with module resolution,
-    // so instead of this we'll create an `index.js` file that will export the
-    // local `jest-cli` package.
-    fs.writeFileSync(
-      path.resolve(cwd, './node_modules/jest-cli/index.js'),
-      `module.exports = require('../../../../');\n`, // link to the local jest
-      'utf8'
-    );
+  // Using `npm link jest-cli` can create problems with module resolution,
+  // so instead of this we'll create an `index.js` file that will export the
+  // local `jest-cli` package.
+  fs.writeFileSync(
+    path.resolve(cwd, './node_modules/jest-cli/index.js'),
+    `module.exports = require('../../../../');\n`, // link to the local jest
+    'utf8'
+  );
 
-    // overwrite the jest link and point it to the local jest-cli
-    if (!isWindows) {
-      runCommands('ln -sf ../../bin/jest.js ./node_modules/.bin/jest', cwd);
-    } else {
-      const currentJest = path.resolve(__dirname, './bin/jest.js');
-      fs.writeFile(
-        `.\node_modules\.bin\jest.cmd`,
-        `@IF EXIST "%~dp0\node.exe" (
-          "%~dp0\node.exe"  "${currentJest}" %*
-        ) ELSE (
-          @SETLOCAL
-          @SET PATHEXT=%PATHEXT:;.JS;=;%
-          node  "${currentJest}" %*
-        )`,
-        err => {
-          if (err) {
-            throw err;
-          }
-        }
-      );
+  // overwrite the jest link and point it to the local jest-cli
+  runCommands('ln -sf ../../bin/jest.js ./node_modules/.bin/jest', cwd);
 
-    }
-    runCommands('npm test', cwd);
-  });
-}
+  runCommands('npm test', cwd);
+});


### PR DESCRIPTION
The scripts for `npm test` are not working properly with node 5.11. I reverted them to what they were before we added some basic windows test support.

We are unlikely to ever support running all these tests on windows. It isn't necessary – it's enough that our CI will properly run the tests. Running Jest's core tests on windows should be enough.

Over time I'd like to phase out real Windows support in favor of bash/Ubuntu on Windows. Maybe ~6 months after bash for Windows is stable, so at the end of this year.