### PR TITLE
Fix Jest for Node 6.

### DIFF
--- a/packages/jest-haste-map/src/__tests__/fastpath-test.js
+++ b/packages/jest-haste-map/src/__tests__/fastpath-test.js
@@ -41,6 +41,17 @@ let fp;
 
 describe('fast-path', () => {
 
+  if (parseInt(process.versions.node.split('.')[0], 10) >= 5) {
+    it('exports path directly', () => {
+      const path = require('path');
+      fp = require('../fastpath');
+      Object.keys(path).forEach(name => {
+        expect(path[name]).toBe(fp[name]);
+      });
+    });
+    return;
+  }
+
   const actualPlatform = process.platform;
   const invalidInputTests = [
     true,

--- a/packages/jest-haste-map/src/fastpath.js
+++ b/packages/jest-haste-map/src/fastpath.js
@@ -45,7 +45,12 @@ const fs = require('fs');
 const path = require('path');
 const util = require('util');
 
-const all = Object.keys(exports).filter(name => name !== 'replace');
+// fastpath is only useful on older versions of nodejs.
+if (parseInt(process.versions.node.split('.')[0], 10) >= 5) {
+  module.exports = Object.assign({replace: () => {}}, path);
+  return;
+}
+
 const IS_WINDOWS = process.platform === 'win32';
 
 function isString(arg) {
@@ -625,11 +630,8 @@ exports.dirname = function _dirname(filename) {
   return device + filename.slice(start, lastSep);
 };
 
-exports.replace = function(props) {
-  if (!props) { props = all; }
-  if (!Array.isArray(props)) { props = [props]; }
-
-  props.forEach(name => {
-    if (exports[name]) { path[name] = exports[name]; }
-  });
+exports.replace = function() {
+  Object.keys(exports)
+    .filter(name => name !== 'replace')
+    .forEach(name => path[name] = exports[name]);
 };

--- a/packages/jest-jasmine1/src/index.js
+++ b/packages/jest-jasmine1/src/index.js
@@ -10,7 +10,6 @@
 const fs = require('graceful-fs');
 const jasminePit = require('jest-util/lib/jasmine-pit');
 const JasmineReporter = require('./reporter');
-const path = require('path');
 
 const JASMINE_PATH = require.resolve('../vendor/jasmine-1.3.0');
 const JASMINE_ONLY_PATH = require.resolve('./jasmine-only.js');
@@ -177,7 +176,7 @@ function jasmine1(config, environment, moduleLoader, testPath) {
       };
 
     if (config.setupTestFrameworkScriptFile) {
-      moduleLoader.requireModule(null, config.setupTestFrameworkScriptFile);
+      moduleLoader.requireModule(config.setupTestFrameworkScriptFile);
     }
   });
 
@@ -261,7 +260,7 @@ function jasmine1(config, environment, moduleLoader, testPath) {
   });
   jasmine.getEnv().addReporter(reporter);
   // Run the test by require()ing it
-  moduleLoader.requireModule(testPath, './' + path.basename(testPath));
+  moduleLoader.requireModule(testPath);
   jasmine.getEnv().execute();
   return reporter.getResults();
 }

--- a/packages/jest-jasmine2/src/index.js
+++ b/packages/jest-jasmine2/src/index.js
@@ -10,7 +10,6 @@
 const fs = require('graceful-fs');
 const jasminePit = require('jest-util/lib/jasmine-pit');
 const JasmineReporter = require('./reporter');
-const path = require('path');
 
 const JASMINE_PATH = require.resolve('../vendor/jasmine-2.4.1.js');
 const jasmineFileContent =
@@ -66,7 +65,7 @@ function jasmine2(config, environment, moduleLoader, testPath) {
     jasminePit.install(environment.global);
 
     if (config.setupTestFrameworkScriptFile) {
-      moduleLoader.requireModule(null, config.setupTestFrameworkScriptFile);
+      moduleLoader.requireModule(config.setupTestFrameworkScriptFile);
     }
   });
   env.beforeEach(() => {
@@ -190,7 +189,7 @@ function jasmine2(config, environment, moduleLoader, testPath) {
 
   env.addReporter(reporter);
   // Run the test by require()ing it
-  moduleLoader.requireModule(testPath, './' + path.basename(testPath));
+  moduleLoader.requireModule(testPath);
   env.execute();
   return reporter.getResults();
 }

--- a/src/Runtime/Runtime.js
+++ b/src/Runtime/Runtime.js
@@ -61,6 +61,11 @@ class Runtime {
     this._modules = moduleMap.map;
     this._mocks = moduleMap.mocks;
 
+    this._mockMetaDataCache = Object.create(null);
+    this._shouldMockModuleCache = Object.create(null);
+    this._shouldUnmockTransitiveDependenciesCache = Object.create(null);
+    this._transitiveShouldMock = Object.create(null);
+
     if (config.collectCoverage) {
       this._CoverageCollector = require(config.coverageCollector);
     }
@@ -84,11 +89,6 @@ class Runtime {
       config.setupFiles.forEach(unmockPath);
       unmockCacheInitialized.set(config, true);
     }
-
-    this._mockMetaDataCache = Object.create(null);
-    this._shouldMockModuleCache = Object.create(null);
-    this._shouldUnmockTransitiveDependenciesCache = Object.create(null);
-    this._transitiveShouldMock = Object.create(null);
 
     // Workers communicate the config as JSON so we have to create a regex
     // object in the module loader instance.
@@ -431,6 +431,7 @@ class Runtime {
     if (!moduleName) {
       return currPath;
     }
+
     const basedir = path.dirname(currPath);
     const filePath = resolveNodeModule(moduleName, basedir, this._extensions);
     if (filePath) {

--- a/src/Runtime/__tests__/Runtime-jest-fn.js
+++ b/src/Runtime/__tests__/Runtime-jest-fn.js
@@ -45,7 +45,7 @@ describe('Runtime', () => {
   describe('jest.fn', () => {
     pit('creates mock functions', () => {
       return buildLoader().then(loader => {
-        const root = loader.requireModule(null, rootPath);
+        const root = loader.requireModule(rootPath);
         const mock = root.jest.fn();
         expect(mock._isMockFunction).toBe(true);
         mock();
@@ -55,7 +55,7 @@ describe('Runtime', () => {
 
     pit('creates mock functions with mock implementations', () => {
       return buildLoader().then(loader => {
-        const root = loader.requireModule(null, rootPath);
+        const root = loader.requireModule(rootPath);
         const mock = root.jest.fn(string => string + ' implementation');
         expect(mock._isMockFunction).toBe(true);
         const value = mock('mock');

--- a/src/Test.js
+++ b/src/Test.js
@@ -36,7 +36,7 @@ class Test {
     const moduleLoader = new ModuleLoader(config, env, moduleMap);
     if (config.setupFiles.length) {
       for (let i = 0; i < config.setupFiles.length; i++) {
-        moduleLoader.requireModule(null, config.setupFiles[i]);
+        moduleLoader.requireModule(config.setupFiles[i]);
       }
     }
 

--- a/src/jest.js
+++ b/src/jest.js
@@ -7,7 +7,7 @@
  */
 'use strict';
 
-require('jest-haste-map/').fastpath.replace();
+require('jest-haste-map').fastpath.replace();
 
 const realFs = require('fs');
 const fs = require('graceful-fs');


### PR DESCRIPTION
Fixes #935 and a bug I introduced in #934.

I also updated it so that `fastpath` is only used in Node < 5. Node 5.7 and upwards have a fast implementation of the `path` module, so it should no longer be necessary then.

Test Plan:
tests pass again; and tests pass in node 6 nightly.