### PR TITLE
Add support for having test files in the same directory as source files.

### DIFF
--- a/src/Runtime/Runtime.js
+++ b/src/Runtime/Runtime.js
@@ -291,11 +291,15 @@ class Runtime {
       (this._config.collectCoverage && !collectOnlyFrom) ||
       (collectOnlyFrom && collectOnlyFrom[filename])
     );
+    const testFileExtensions = this._config.testFileExtensions;
+    const hasOneOfFileExtensions = testFileExtensions.some(extension => {
+        return filename.includes(extension);
+    });
     let moduleContent = transform(filename, this._config);
     let collectorStore;
     if (
       shouldCollectCoverage &&
-      !filename.includes(this._testDirectoryName) &&
+      !hasOneOfFileExtensions &&
       !filename.includes(constants.NODE_MODULES)
     ) {
       if (!collectors[filename]) {

--- a/src/config/defaults.js
+++ b/src/config/defaults.js
@@ -26,11 +26,11 @@ module.exports = {
   },
   modulePathIgnorePatterns: [],
   moduleNameMapper: [],
-  testDirectoryName: '__tests__',
+  testDirectoryName: 'src',
   mocksPattern: '__mocks__',
   testEnvironment: 'jest-environment-jsdom',
   testEnvData: {},
-  testFileExtensions: ['js'],
+  testFileExtensions: ['spec.js'],
   testPathDirs: ['<rootDir>'],
   testPathIgnorePatterns: [
     utils.replacePathSepForRegex(constants.NODE_MODULES),


### PR DESCRIPTION
Check if the file does have test extension rather than being in the test directory.
Could potentially fix #433 
The side effect of it is that you cannot specify just "js" as your test file extension as this would include all tests in the coverage