### PR TITLE
Wrap git/hg detectors in try-catch. See #905.

### DIFF
--- a/src/lib/git.js
+++ b/src/lib/git.js
@@ -39,12 +39,16 @@ function findChangedFiles(cwd) {
 
 function isGitRepository(cwd) {
   return new Promise(resolve => {
-    let stdout = '';
-    const options = ['rev-parse', '--show-toplevel'];
-    const child = childProcess.spawn('git', options, {cwd});
-    child.stdout.on('data', data => stdout += data);
-    child.on('error', () => resolve(null));
-    child.on('close', code => resolve(code === 0 ? stdout.trim() : null));
+    try {
+      let stdout = '';
+      const options = ['rev-parse', '--show-toplevel'];
+      const child = childProcess.spawn('git', options, {cwd});
+      child.stdout.on('data', data => stdout += data);
+      child.on('error', () => resolve(null));
+      child.on('close', code => resolve(code === 0 ? stdout.trim() : null));
+    } catch (e) {
+      resolve(null);
+    }
   });
 }
 

--- a/src/lib/hg.js
+++ b/src/lib/hg.js
@@ -39,11 +39,15 @@ function findChangedFiles(cwd) {
 
 function isHGRepository(cwd) {
   return new Promise(resolve => {
-    let stdout = '';
-    const child = childProcess.spawn('hg', ['root'], {cwd});
-    child.stdout.on('data', data => stdout += data);
-    child.on('error', () => resolve(null));
-    child.on('close', code => resolve(code === 0 ? stdout.trim() : null));
+    try {
+      let stdout = '';
+      const child = childProcess.spawn('hg', ['root'], {cwd});
+      child.stdout.on('data', data => stdout += data);
+      child.on('error', () => resolve(null));
+      child.on('close', code => resolve(code === 0 ? stdout.trim() : null));
+    } catch (e) {
+      resolve(null);
+    }
   });
 }
 


### PR DESCRIPTION
In #905 it was reported that people without mercurial had some trouble with `jest -o`. I fixed that initially but on some system it seems like `childProcess.spawn` can throw. It doesn't seem to happen on OS X locally but based on what I read about `childProcess.spawn` I do believe it can throw. I think it is best to wrap it in a try-catch now – the worst thing that can happen is to report back as not a git or not an hg repo, which it won't be if the commands fail.

I also took a note to write an integration test for this, now that we have integration tests. I will add a few in a follow up.

Test Plan:
Run `jest -o` with changed files both in a git and hg repo.