### PR TITLE
Create a valid cache file path, fixes #945.

### DIFF
--- a/packages/jest-haste-map/src/__tests__/index-test.js
+++ b/packages/jest-haste-map/src/__tests__/index-test.js
@@ -164,6 +164,20 @@ describe('HasteMap', () => {
     expect(HasteMap.H).toBe(require('../constants'));
   });
 
+  it('creates valid cache file paths', () => {
+    jest.resetModuleRegistry();
+    HasteMap = require('../');
+
+    expect(HasteMap.getCacheFilePath('/', '@scoped/package', 'random-value'))
+      .toMatch(/^\/-scoped-package-(.*)$/);
+
+    expect(
+      HasteMap.getCacheFilePath('/', '@scoped/package', 'random-value')
+    ).not.toEqual(
+      HasteMap.getCacheFilePath('/', '-scoped-package', 'random-value')
+    );
+  });
+
   pit('matches files against a pattern', () => {
     const hasteMap = new HasteMap(defaultConfig);
 

--- a/packages/jest-haste-map/src/index.js
+++ b/packages/jest-haste-map/src/index.js
@@ -145,8 +145,11 @@ class HasteMap {
 
   static getCacheFilePath(tmpdir, name) {
     const hash = crypto.createHash('md5');
-    Array.from(arguments).slice(2).forEach(arg => hash.update(arg));
-    return path.join(tmpdir, name + '-' + hash.digest('hex'));
+    Array.from(arguments).slice(1).forEach(arg => hash.update(arg));
+    return path.join(
+      tmpdir,
+      name.replace(/\W/g, '-') + '-' + hash.digest('hex')
+    );
   }
 
   build() {


### PR DESCRIPTION
We changed this to include the config name that is passed in, but we weren't thinking about scoped packages. Fixed that and added a test so it won't break again :)