### PR TITLE
no "use strict" in a es6 module context

### DIFF
--- a/docs/TutorialReact.md
+++ b/docs/TutorialReact.md
@@ -12,7 +12,6 @@ applications. Let's implement a simple checkbox which swaps between two labels:
 
 ```javascript
 // CheckboxWithLabel.js
-'use strict';
 
 import React from 'react';
 
@@ -52,7 +51,6 @@ manipulate React components.
 
 ```javascript
 // __tests__/CheckboxWithLabel-test.js
-'use strict';
 
 jest.unmock('../CheckboxWithLabel');
 

--- a/examples/react/__tests__/CheckboxWithLabel-test.js
+++ b/examples/react/__tests__/CheckboxWithLabel-test.js
@@ -1,7 +1,6 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 /* eslint-disable no-unused-vars */
-'use strict';
 
 jest.unmock('../CheckboxWithLabel');
 


### PR DESCRIPTION
Since modules are strict by default its a bit odd. super tiny nit.