### PR TITLE
default name and rootDir when not provided in config object

### DIFF
--- a/packages/jest-cli/src/config/read.js
+++ b/packages/jest-cli/src/config/read.js
@@ -66,6 +66,8 @@ function readRawConfig(argv, root) {
   }
 
   if (typeof argv.config === 'object') {
+    argv.config.name = argv.config.name || root.replace(/[/\\]|\s/g, '-');
+    argv.config.rootDir = argv.config.rootDir || root;
     return Promise.resolve(normalize(argv.config, argv));
   }
 

--- a/src/config/__tests__/read-test.js
+++ b/src/config/__tests__/read-test.js
@@ -10,25 +10,21 @@
 'use strict';
 
 jest.unmock('../read')
-  .unmock('jest-util')
+  .unmock('jest-util');
+
+let readConfig;
+let normalizeConfig;
+let rootDir;
 
 describe('readConfig', () => {
-  let readConfig;
-  let normalizeConfig;
-  let rootDir;
-
   beforeEach(() => {
     readConfig = require('../read');
     normalizeConfig = require('../normalize');
     normalizeConfig.mockImplementation(config => config);
-    rootDir = '/root/path/foo'
+    rootDir = '/root/path/foo';
   });
 
   describe('config object', () => {
-    beforeEach(() => {
-
-    });
-
     pit('defaults the name and rootDir', () => {
       return readConfig({
         config: {},

--- a/src/config/__tests__/read-test.js
+++ b/src/config/__tests__/read-test.js
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails oncall+jsinfra
+ */
+'use strict';
+
+jest.unmock('../read')
+  .unmock('jest-util')
+
+describe('readConfig', () => {
+  let readConfig;
+  let normalizeConfig;
+  let rootDir;
+
+  beforeEach(() => {
+    readConfig = require('../read');
+    normalizeConfig = require('../normalize');
+    normalizeConfig.mockImplementation(config => config);
+    rootDir = '/root/path/foo'
+  });
+
+  describe('config object', () => {
+    beforeEach(() => {
+
+    });
+
+    pit('defaults the name and rootDir', () => {
+      return readConfig({
+        config: {},
+      }, rootDir).then(config => {
+        expect(config.name).toBe('-root-path-foo');
+        expect(config.rootDir).toBe(rootDir);
+      });
+    });
+
+    pit('uses the privded name and rootDir', () => {
+      return readConfig({
+        config: {
+          name: 'bar',
+          rootDir: '/root/path/bar',
+        },
+      }, rootDir).then(config => {
+        expect(config.name).toBe('bar');
+        expect(config.rootDir).toBe('/root/path/bar');
+      });
+    });
+  });
+});


### PR DESCRIPTION
This PR addresses #955. I ran into the same problem when using grunt-jest passing a `config` object in the options. Similar to how it behaves when using `package.json` as the configuration source, I'm defaulting the `name` and `rootDir` when they are not provided.