### PR TITLE
expose DIFFABLE_MATCHERS to allow customizing it

### DIFF
--- a/packages/jest-util/lib/JasmineFormatter.js
+++ b/packages/jest-util/lib/JasmineFormatter.js
@@ -12,13 +12,6 @@ const chalk = require('chalk');
 const utils = require('../index');
 
 const ERROR_TITLE_COLOR = chalk.bold.underline.red;
-const DIFFABLE_MATCHERS = Object.assign(Object.create(null), {
-  toBe: true,
-  toNotBe: true,
-  toEqual: true,
-  toNotEqual: true,
-});
-
 const LINEBREAK_REGEX = /[\r\n]/;
 
 class JasmineFormatter {
@@ -26,6 +19,16 @@ class JasmineFormatter {
   constructor(jasmine, config) {
     this._config = config;
     this._jasmine = jasmine;
+    this._diffableMatchers = Object.assign(Object.create(null), {
+      toBe: true,
+      toNotBe: true,
+      toEqual: true,
+      toNotEqual: true,
+    });
+  }
+
+  addDiffableMatcher(matcherName) {
+    this._diffableMatchers[matcherName] = true;
   }
 
   formatDiffable(matcherName, isNot, actual, expected) {
@@ -42,7 +45,7 @@ class JasmineFormatter {
 
   formatMatchFailure(result) {
     let message;
-    if (DIFFABLE_MATCHERS[result.matcherName]) {
+    if (this._diffableMatchers[result.matcherName]) {
       const isNot =
         'isNot' in result ? result.isNot : /not to /.test(result.message);
       message = this.formatDiffable(
@@ -153,7 +156,5 @@ class JasmineFormatter {
     );
   }
 }
-
-JasmineFormatter.DIFFABLE_MATCHERS = DIFFABLE_MATCHERS;
 
 module.exports = JasmineFormatter;

--- a/packages/jest-util/lib/JasmineFormatter.js
+++ b/packages/jest-util/lib/JasmineFormatter.js
@@ -154,4 +154,6 @@ class JasmineFormatter {
   }
 }
 
+JasmineFormatter.DIFFABLE_MATCHERS = DIFFABLE_MATCHERS;
+
 module.exports = JasmineFormatter;


### PR DESCRIPTION
expose DIFFABLE_MATCHERS to allow customizing it
this allow formatMatchFailure to use the custom chai-diff messages for any custom matchers:

eg: in a theoretical `test-framework-setup.js`:
```
// ...
const JasmineFormatter = require('jest-util/lib/JasmineFormatter');
JasmineFormatter.DIFFABLE_MATCHERS.toMatchSnapshot = true;
// ...

failureMessage = formatter.formatMatchFailure(res);
```

will show something like:
<img width="1417" alt="screen shot 2016-05-09 at 2 36 01 pm" src="https://cloud.githubusercontent.com/assets/87300/15115038/ce7a75ae-15f4-11e6-8c54-66bc67ee19cb.png">
