### PR TITLE
Fix jest-haste-map on vagrant.

### DIFF
--- a/packages/jest-haste-map/src/index.js
+++ b/packages/jest-haste-map/src/index.js
@@ -293,7 +293,7 @@ class HasteMap {
   _getWorker() {
     if (!this._workerPromise) {
       let workerFn;
-      if (this._options.maxWorkers === 1) {
+      if (this._options.maxWorkers <= 1) {
         workerFn = worker;
       } else {
         this._workerFarm = workerFarm(


### PR DESCRIPTION
This is a similar fix to what @spicyj did in https://github.com/spicyj/jest/commit/cff14103b247fcf539b5d5434b07fb2a55819d6d a long time ago. I wasn't aware of why we had this but it seems obvious to me that we shouldn't create processes if there are less than one worker available. Not really sure how that could happen but it seems that on vagrant/docker installs the number of cores is 0.

See #980.