### PR TITLE
Add last 3 actual calls for toBeCalledWith message

### DIFF
--- a/packages/jest-cli/src/__tests__/customMatchers-test.js
+++ b/packages/jest-cli/src/__tests__/customMatchers-test.js
@@ -16,7 +16,24 @@ const CALLED_AT_LEAST_ONCE = 'Expected to be called at least once';
 const SHOULD_NOT_BE_CALLED = 'Expected not to be called';
 const NOT_EXPECTED_VALUES = (
   'Was never called with the expected values.\n' +
-  `Expected:\n${formatter.prettyPrint([1, {}, 'Error'])}`
+  `Expected:\n${formatter.prettyPrint([1, {}, 'Error'])}\n` +
+  `Actual:\n${formatter.prettyPrint([1, {}, ''])}`
+);
+const NOT_EXPECTED_VALUES_EXACTLY_FOUR = (
+  'Was never called with the expected values.\n' +
+  `Expected:\n${formatter.prettyPrint([5])}\n` +
+  `Actual:\n${formatter.prettyPrint([4])},` +
+  `\n${formatter.prettyPrint([3])},` +
+  `\n${formatter.prettyPrint([2])}` +
+  `\nand 1 other call.`
+);
+const NOT_EXPECTED_VALUES_MORE_THAN_FOUR = (
+  'Was never called with the expected values.\n' +
+  `Expected:\n${formatter.prettyPrint([5])}\n` +
+  `Actual:\n${formatter.prettyPrint([8])},` +
+  `\n${formatter.prettyPrint([7])},` +
+  `\n${formatter.prettyPrint([6])}` +
+  `\nand 4 other calls.`
 );
 const NOT_EXPECTED_VALUES_LAST_TIME = (
   `Wasn't called with the expected values.\n` +
@@ -135,7 +152,7 @@ describe('Jest custom matchers in Jasmine 2', () => {
       expectation.not.toBeCalled();
     });
 
-    it(`doesn't show any message when succeding`, () => {
+    it(`doesn't show any message when succeeding`, () => {
       const expectation = getMockedFunctionWithExpectationResult(
         (passed, result) => {
           expect(passed).toBe(true);
@@ -188,7 +205,7 @@ describe('Jest custom matchers in Jasmine 2', () => {
 
   describe('toBeCalledWith', () => {
 
-    it(`doesn't show any message when succeding`, () => {
+    it(`doesn't show any message when succeeding`, () => {
       const expectation = getMockedFunctionWithExpectationResult(
         (passed, result) => {
           expect(passed).toBe(true);
@@ -210,7 +227,7 @@ describe('Jest custom matchers in Jasmine 2', () => {
       expectation.not.toBeCalledWith(1, {}, '');
     });
 
-    it('shows a custom message when the test fails', () => {
+    it('shows a custom message when the test fails without other calls when calls >= 3', () => {
       const expectation = getMockedFunctionWithExpectationResult(
         (passed, result) => {
           expect(passed).toBe(false);
@@ -222,6 +239,39 @@ describe('Jest custom matchers in Jasmine 2', () => {
       expectation.toBeCalledWith(1, {}, 'Error');
     });
 
+    it('shows a custom message with amount of singular amount of other calls when calls === 4', () => {
+      const expectation = getMockedFunctionWithExpectationResult(
+        (passed, result) => {
+          expect(passed).toBe(false);
+          expect(result.message).toBe(NOT_EXPECTED_VALUES_EXACTLY_FOUR);
+        }
+      );
+
+      expectation.function(1);
+      expectation.function(2);
+      expectation.function(3);
+      expectation.function(4);
+      expectation.toBeCalledWith(5);
+    });
+
+    it('shows a custom message with plurar amount of other calls when calls > 4', () => {
+      const expectation = getMockedFunctionWithExpectationResult(
+        (passed, result) => {
+          expect(passed).toBe(false);
+          expect(result.message).toBe(NOT_EXPECTED_VALUES_MORE_THAN_FOUR);
+        }
+      );
+
+      expectation.function(1);
+      expectation.function(2);
+      expectation.function(3);
+      expectation.function(4);
+      expectation.function(6);
+      expectation.function(7);
+      expectation.function(8);
+      expectation.toBeCalledWith(5);
+    });    
+    
   });
 
 });

--- a/packages/jest-jasmine2/src/index.js
+++ b/packages/jest-jasmine2/src/index.js
@@ -195,6 +195,11 @@ function jasmine2(config, environment, moduleLoader, testPath) {
             ? actual.calls.all().map(x => x.args)
             : actual.mock.calls;
           const expected = Array.prototype.slice.call(arguments, 1);
+          const limit = 3;
+          const lastActualCalls = calls.slice(-limit);
+          const isOverLimit = calls.length > limit;
+          const overLimitAmount = calls.length - limit;
+          const callsStr = overLimitAmount > 1 ? 'calls' : 'call';
           const pass = calls.some(call => util.equals(call, expected));
           if (!pass) {
             return {
@@ -203,7 +208,12 @@ function jasmine2(config, environment, moduleLoader, testPath) {
                 return (
                   'Was never called with the expected values.\n' +
                   'Expected:\n' +
-                  reporter.getFormatter().prettyPrint(expected)
+                  reporter.getFormatter().prettyPrint(expected) +
+                  '\nActual:\n' +
+                  lastActualCalls.map(call => 
+                      reporter.getFormatter().prettyPrint(call)
+                  ).reverse().join(',\n') +
+                  (isOverLimit ? '\nand ' + overLimitAmount + ' other ' + callsStr + '.' : '')
                 );
               },
             };


### PR DESCRIPTION
This PR continues from #918 and fixes #954 by adding the last 3 (or less) actual values that were called to the error message when using `toBeCalledWith`

Details:
- If there are less or exactly 3 calls, it just shows the 3 calls comma separated
- If there's exactly 4 calls, it appends `and 1 other call` to the message
- If there's more than 4 calls, it appends `and X other calls` to the message (when X is the amount > 3)
- The calls are sliced from the end of the calls array and the messages are reversed so they appear in "correct" order.

Tests included (plus 2 typo fixes in the same test file :neckbeard:) 

Ping @cpojer 