### PR TITLE
Prevent examples from unintentionally un-mocking all react* modules

### DIFF
--- a/docs/TutorialReact.md
+++ b/docs/TutorialReact.md
@@ -106,9 +106,9 @@ for Jest. Also see [babel integration](/jest/docs/getting-started.html#babel-int
   },
   "jest": {
     "unmockedModulePathPatterns": [
-      "<rootDir>/node_modules/react",
-      "<rootDir>/node_modules/react-dom",
-      "<rootDir>/node_modules/react-addons-test-utils"
+      "<rootDir>/node_modules/react/",
+      "<rootDir>/node_modules/react-dom/",
+      "<rootDir>/node_modules/react-addons-test-utils/"
     ]
   }
 ```

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -16,9 +16,9 @@
   },
   "jest": {
     "unmockedModulePathPatterns": [
-      "<rootDir>/node_modules/react",
-      "<rootDir>/node_modules/react-dom",
-      "<rootDir>/node_modules/react-addons-test-utils"
+      "<rootDir>/node_modules/react/",
+      "<rootDir>/node_modules/react-dom/",
+      "<rootDir>/node_modules/react-addons-test-utils/"
     ]
   }
 }

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -16,9 +16,9 @@
     "testFileExtensions": ["ts", "tsx", "js"],
     "moduleFileExtensions": ["ts", "tsx", "js"],
     "unmockedModulePathPatterns": [
-      "<rootDir>/node_modules/react",
-      "<rootDir>/node_modules/react-dom",
-      "<rootDir>/node_modules/react-addons-test-utils"
+      "<rootDir>/node_modules/react/",
+      "<rootDir>/node_modules/react-dom/",
+      "<rootDir>/node_modules/react-addons-test-utils/"
     ]
   }
 }


### PR DESCRIPTION
As discussed in reactiflux, I've updated the examples and docs so similarly named modules will no longer be un-mocked by mistake.