### PR TITLE
Allow for external testReporter configuration

### DIFF
--- a/packages/jest-cli/src/TestRunner.js
+++ b/packages/jest-cli/src/TestRunner.js
@@ -244,7 +244,7 @@ class TestRunner {
   runTests(testPaths, reporter) {
     const config = this._config;
     if (!reporter) {
-      const TestReporter = require(config.testReporter);
+      const TestReporter = require(path.resolve(config.testReporter));
       if (config.useStderr) {
         reporter = new TestReporter(Object.create(
           process,


### PR DESCRIPTION
The use case is I needed to make a tweaked version of the IstanbulReporter that also outputted cobertura XML.
