### PR TITLE
Prevent workerCount == 0 on single CPU machines

### DIFF
--- a/packages/jest-cli/src/TestRunner.js
+++ b/packages/jest-cli/src/TestRunner.js
@@ -58,7 +58,7 @@ class TestRunner {
     }
 
     this._hasteMap = createHasteMap(config, {
-      maxWorkers: options.runInBand ? 1 : this._opts.maxWorkers,
+      maxWorkers: this._opts.runInBand ? 1 : this._opts.maxWorkers,
       resetCache: !config.cache,
     });
 


### PR DESCRIPTION
When the workerCount is not explicitly set by the user, it defaults to the
number of CPUs on the machine, less 1. The intention of
packages/jest-cli/src/TestRunner.js#L46 is to prevent the worker count from
being 0 if it is running on a single-core CPU. However,
packages/jest-cli/src/TestRunner.js#L61 was referencing the passed-in worker
count rather than the sanitized value. This causes single-core machines to be
completely unable to run tests unless they specify the worker count manually.