### PR TITLE
Add `module.filename` + cleanup in Runtime.

### DIFF
--- a/packages/jest-cli/src/Runtime/__tests__/Runtime-requireModule-test.js
+++ b/packages/jest-cli/src/Runtime/__tests__/Runtime-requireModule-test.js
@@ -63,6 +63,15 @@ describe('Runtime', () => {
       });
     });
 
+    pit('provides `module.filename` to modules', () => {
+      return buildLoader().then(loader => {
+        const exports = loader.requireModule(rootPath, 'RegularModule');
+        expect(exports.filename.endsWith(
+          'test_root' + path.sep + 'RegularModule.js'
+        )).toBe(true);
+      });
+    });
+
     pit('provides `module.paths` to modules', () => {
       return buildLoader().then(loader => {
         const exports = loader.requireModule(rootPath, 'RegularModule');

--- a/packages/jest-cli/src/Runtime/__tests__/test_root/RegularModule.js
+++ b/packages/jest-cli/src/Runtime/__tests__/test_root/RegularModule.js
@@ -36,4 +36,5 @@ exports.isRealModule = true;
 exports.setModuleStateValue = setModuleStateValue;
 exports.parent = module.parent;
 exports.paths = module.paths;
+exports.filename = module.filename;
 exports.jest = jest;


### PR DESCRIPTION
I don't know where `module.__filename` came from but it isn't a thing. `module.filename` is, however.

I also made some minor cleanups to Runtime.

Fixes #968.