### PR TITLE
Fix stack trace and runtime error reporting.

### DIFF
--- a/integration_tests/__tests__/coverage_report-test.js
+++ b/integration_tests/__tests__/coverage_report-test.js
@@ -9,13 +9,11 @@
  */
 'use strict';
 
-jest.unmock('../runJest');
-
 const runJest = require('../runJest');
 const fs = require('fs');
 const path = require('path');
 
-describe('coverage_report', () => {
+describe('Coverage Report', () => {
   it('outputs coverage report', () => {
     const result = runJest('coverage_report', ['--coverage']);
     const coverageDir = path.resolve(__dirname, '../coverage_report/coverage');

--- a/integration_tests/__tests__/json_reporter-test.js
+++ b/integration_tests/__tests__/json_reporter-test.js
@@ -7,11 +7,9 @@
  */
 'use strict';
 
-jest.unmock('../runJest');
-
 const runJest = require('../runJest');
 
-describe('coverage_report', () => {
+describe('JSON Reporter', () => {
   it('outputs coverage report', () => {
     const result = runJest('json_reporter', ['--json']);
     const stdout = result.stdout.toString();

--- a/integration_tests/__tests__/stack_trace-test.js
+++ b/integration_tests/__tests__/stack_trace-test.js
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
+const runJest = require('../runJest');
+
+describe('Stack Trace', () => {
+
+  it('prints a stack trace for runtime errors', () => {
+    const result = runJest('stack_trace', ['runtime-error-test.js']);
+    const stdout = result.stdout.toString();
+
+    expect(stdout).toMatch(
+      /1 test suite failed, 0 tests passed/
+    );
+    expect(result.status).toBe(1);
+    expect(stdout).toMatch(
+      /ReferenceError: thisIsARuntimeError is not defined/
+    );
+    expect(stdout).toMatch(
+      /\s+at\s(?:.+?)\s\(__integration_tests__\/runtime-error-test\.js/
+    );
+  });
+
+  it('does not print a stack trace for runtime errors when --noStackTrace is given', () => {
+    const result = runJest('stack_trace', [
+      'runtime-error-test.js',
+      '--noStackTrace',
+    ]);
+    const stdout = result.stdout.toString();
+
+    expect(stdout).toMatch(
+      /1 test suite failed, 0 tests passed/
+    );
+    expect(result.status).toBe(1);
+
+    expect(stdout).toMatch(
+      /ReferenceError: thisIsARuntimeError is not defined/
+    );
+    expect(stdout).not.toMatch(
+      /\s+at\s(?:.+?)\s\(__integration_tests__\/runtime-error-test\.js/
+    );
+  });
+
+  it('prints a stack trace for matching errors', () => {
+    const result = runJest('stack_trace', ['stack-trace-test.js']);
+    const stdout = result.stdout.toString();
+
+    expect(stdout).toMatch(/1 test failed, 0 tests passed/);
+    expect(result.status).toBe(1);
+
+    expect(stdout).toMatch(
+      /\s+at\s(?:.+?)\s\(__integration_tests__\/stack-trace-test\.js/
+    );
+  });
+
+  it('does not print a stack trace for matching errors when --noStackTrace is given', () => {
+    const result = runJest('stack_trace', [
+      'stack-trace-test.js',
+      '--noStackTrace',
+    ]);
+    const stdout = result.stdout.toString();
+
+    expect(stdout).toMatch(/1 test failed, 0 tests passed/);
+    expect(result.status).toBe(1);
+
+    expect(stdout).not.toMatch(
+      /\s+at\s(?:.+?)\s\(__integration_tests__\/stack-trace-test\.js/
+    );
+  });
+
+  it('prints a stack trace for errors', () => {
+    const result = runJest('stack_trace', ['test-error-test.js']);
+    const stdout = result.stdout.toString();
+
+    expect(stdout).toMatch(/2 tests failed, 0 tests passed/);
+    expect(result.status).toBe(1);
+
+    expect(stdout).toMatch(/Error: this is unexpected\./);
+    expect(stdout).toMatch(/this is a string\. thrown/);
+
+    expect(stdout).toMatch(
+      /\s+at\s(?:.+?)\s\(__integration_tests__\/test-error-test\.js/
+    );
+  });
+
+  it('does not print a stack trace for errors when --noStackTrace is given', () => {
+    const result = runJest('stack_trace', [
+      'test-error-test.js',
+      '--noStackTrace',
+    ]);
+    const stdout = result.stdout.toString();
+
+    expect(stdout).toMatch(/2 tests failed, 0 tests passed/);
+    expect(result.status).toBe(1);
+
+    expect(stdout).not.toMatch(
+      /\s+at\s(?:.+?)\s\(__integration_tests__\/test-error-test\.js/
+    );
+  });
+
+});

--- a/integration_tests/json_reporter/.gitignore
+++ b/integration_tests/json_reporter/.gitignore
@@ -1,1 +1,0 @@
-coverage/

--- a/integration_tests/package.json
+++ b/integration_tests/package.json
@@ -1,7 +1,7 @@
 {
   "jest": {
-    "testPathIgnorePatterns": [
-        "__integration_tests__/(?!__tests__).*"
-      ]
+    "unmockedModulePathPatterns": [
+      "<rootDir>/runJest.js$"
+    ]
   }
 }

--- a/integration_tests/stack_trace/__integration_tests__/runtime-error-test.js
+++ b/integration_tests/stack_trace/__integration_tests__/runtime-error-test.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
+thisIsARuntimeError();

--- a/integration_tests/stack_trace/__integration_tests__/stack-trace-test.js
+++ b/integration_tests/stack_trace/__integration_tests__/stack-trace-test.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
+describe('stack trace', () => {
+  it('fails', () => {
+    expect(1).toBe(3);
+  });
+});

--- a/integration_tests/stack_trace/__integration_tests__/test-error-test.js
+++ b/integration_tests/stack_trace/__integration_tests__/test-error-test.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+/* eslint-disable no-throw-literal */
+'use strict';
+
+describe('error stack trace', () => {
+  it('fails', () => {
+    throw new Error('this is unexpected.');
+  });
+
+  it('fails strings', () => {
+    throw 'this is a string.';
+  });
+});

--- a/integration_tests/stack_trace/package.json
+++ b/integration_tests/stack_trace/package.json
@@ -1,0 +1,5 @@
+{
+  "jest": {
+    "testDirectoryName": "__integration_tests__"
+  }
+}

--- a/packages/jest-cli/src/jest.js
+++ b/packages/jest-cli/src/jest.js
@@ -163,7 +163,7 @@ function runJest(config, argv, pipe, onComplete) {
       }
       if (argv.json) {
         process.stdout.write(
-          JSON.stringify(formatTestResults(runResults))
+          JSON.stringify(formatTestResults(runResults, config))
         );
       }
       return runResults;

--- a/packages/jest-cli/src/lib/formatTestResults.js
+++ b/packages/jest-cli/src/lib/formatTestResults.js
@@ -9,7 +9,7 @@
 
 const utils = require('jest-util');
 
-const formatResult = (testResult, codeCoverageFormatter, reporter) => {
+const formatResult = (testResult, config, codeCoverageFormatter, reporter) => {
   const output = {
     name: testResult.testFilePath,
     summary: '',
@@ -32,7 +32,9 @@ const formatResult = (testResult, codeCoverageFormatter, reporter) => {
 
     if (!allTestsPassed) {
       output.message = utils.formatFailureMessage(testResult, {
-        rootDir: '',
+        noStackTrace: config.noStackTrace,
+        rootDir: config.rootDir,
+        verbose: false,
       });
     }
   }
@@ -40,14 +42,17 @@ const formatResult = (testResult, codeCoverageFormatter, reporter) => {
   return output;
 };
 
-function formatTestResults(results, codeCoverageFormatter, reporter) {
+function formatTestResults(results, config, codeCoverageFormatter, reporter) {
   if (!codeCoverageFormatter) {
     codeCoverageFormatter = coverage => coverage;
   }
 
-  const testResults = results.testResults.map(
-    testResult => formatResult(testResult, codeCoverageFormatter, reporter)
-  );
+  const testResults = results.testResults.map(testResult => formatResult(
+    testResult,
+    config,
+    codeCoverageFormatter,
+    reporter
+  ));
 
   return {
     success: results.success,

--- a/packages/jest-cli/src/reporters/DefaultTestReporter.js
+++ b/packages/jest-cli/src/reporters/DefaultTestReporter.js
@@ -82,7 +82,12 @@ class DefaultTestReporter {
     }
 
     if (!allTestsPassed) {
-      const failureMessage = formatFailureMessage(testResult, config);
+      const failureMessage = formatFailureMessage(testResult, {
+        noStackTrace: config.noStackTrace,
+        rootDir: config.rootDir,
+        verbose: config.verbose,
+      });
+
       // If we write more than one character at a time it is possible that
       // node exits in the middle of printing the result.
       // If you are reading this and you are from the future, this might not
@@ -110,7 +115,7 @@ class DefaultTestReporter {
     const totalErrors = aggregatedResults.numRuntimeErrorTestSuites;
     const runTime = (Date.now() - aggregatedResults.startTime) / 1000;
 
-    if (totalTests === 0) {
+    if (totalTests === 0 && totalErrors === 0) {
       return;
     }
 

--- a/packages/jest-jasmine1/src/reporter.js
+++ b/packages/jest-jasmine1/src/reporter.js
@@ -76,9 +76,7 @@ class JasmineReporter extends jasmine.Reporter {
           if (result.passed()) {
             results.numPassingAsserts++;
           } else if (!result.matcherName && result.trace.stack) {
-            results.failureMessages.push(
-              this._formatter.formatException(result.trace.stack)
-            );
+            results.failureMessages.push(result.trace.stack);
           } else {
             results.failureMessages.push(
               this._formatter.formatMatchFailure(result)

--- a/packages/jest-jasmine2/src/reporter.js
+++ b/packages/jest-jasmine2/src/reporter.js
@@ -80,7 +80,7 @@ class Jasmine2Reporter {
     specResult.failedExpectations.forEach(failed => {
       let message;
       if (!failed.matcherName && failed.stack) {
-        message = this._formatter.formatException(failed.stack);
+        message = failed.stack;
       } else {
         message = this._formatter.formatMatchFailure(failed);
       }

--- a/packages/jest-util/lib/JasmineFormatter.js
+++ b/packages/jest-util/lib/JasmineFormatter.js
@@ -9,7 +9,6 @@
 
 const diff = require('diff');
 const chalk = require('chalk');
-const cleanStackTrace = require('./formatMessages').cleanStackTrace;
 
 const ERROR_TITLE_COLOR = chalk.bold.underline.red;
 const LINEBREAK_REGEX = /[\r\n]/;
@@ -60,21 +59,12 @@ class JasmineFormatter {
 
     // error message & stack live on 'trace' field in jasmine 1.3
     const error = result.trace ? result.trace : result;
-    if (error.stack) {
-      message = this.formatStackTrace(error.stack, error.message, message);
+    if (!this._config.noStackTrace && error.stack) {
+      message = error.stack
+        .replace(message, error.message)
+        .replace(/^.*Error:\s*/, '');
     }
     return message;
-  }
-
-
-  formatException(stackTrace) {
-    // jasmine doesn't give us access to the actual Error object, so we
-    // have to regexp out the message from the stack string in order to
-    // colorize the `message` value
-    return cleanStackTrace(stackTrace.replace(
-      /(^(.|\n)*?(?=\n\s*at\s))/,
-      ERROR_TITLE_COLOR('$1')
-    ));
   }
 
   highlightDifferences(a, b) {
@@ -177,13 +167,6 @@ class JasmineFormatter {
     }
   }
 
-  formatStackTrace(stackTrace, originalMessage, formattedMessage) {
-    return cleanStackTrace(
-      stackTrace
-        .replace(originalMessage, formattedMessage)
-        .replace(/^.*Error:\s*/, '')
-    );
-  }
 }
 
 module.exports = JasmineFormatter;

--- a/packages/jest-util/lib/formatMessages.js
+++ b/packages/jest-util/lib/formatMessages.js
@@ -10,79 +10,69 @@
 const chalk = require('chalk');
 const path = require('path');
 
-const KEEP_TRACE_LINES = 2;
+const ERROR_TITLE_COLOR = chalk.bold.underline.red;
 // filter for noisy stack trace lines
 const STACK_TRACE_LINE_IGNORE_RE =
   /^\s+at.*?jest(-cli)?\/(vendor|src|node_modules|packages)\//;
 
-function cleanStackTrace(stackTrace) {
-  let lines = 0;
-  return stackTrace.split('\n')
-    .filter(line =>
-      (lines++ < KEEP_TRACE_LINES) || !STACK_TRACE_LINE_IGNORE_RE.test(line)
-    )
-    .join('\n');
-}
-
-function formatFailureMessage(testResult, config) {
-  const rootDir = config.rootDir;
-
-  const ancestrySeparator = ' \u203A ';
-  const descBullet = config.verbose ? '' : chalk.bold('\u25cf ');
+const formatStackTrace = (stackTrace, config) => {
   const msgBullet = '  - ';
   const msgIndent = msgBullet.replace(/./g, ' ');
+  return msgBullet + stackTrace
+    // jasmine doesn't give us access to the actual Error object, so we
+    // have to regexp out the message from the stack string in order to
+    // colorize the `message` value
+    .replace(/(^(.|\n)*?(?=\n\s*at\s))/, ERROR_TITLE_COLOR('$1'))
+    .split('\n')
+    .map(line => {
+      // Extract the file path from the trace line.
+      let matches = line.match(/(^\s+at .*?\()([^()]+)(:[0-9]+:[0-9]+\).*$)/);
+      if (!matches) {
+        matches = line.match(/(^\s+at )([^()]+)(:[0-9]+:[0-9]+.*$)/);
+        if (!matches) {
+          return line;
+        }
+      }
+      // Filter out noisy and unhelpful lines from the stack trace.
+      if (config.noStackTrace || STACK_TRACE_LINE_IGNORE_RE.test(line)) {
+        return null;
+      }
+
+      const filePath = matches[2];
+      return matches[1] + path.relative(config.rootDir, filePath) + matches[3];
+    })
+    .filter(line => line !== null)
+    .join('\n' + msgIndent);
+};
+
+function formatFailureMessage(testResult, config) {
+  const ancestrySeparator = ' \u203A ';
+  const descBullet = config.verbose ? '' : chalk.bold('\u25cf ');
 
   if (testResult.testExecError) {
     const error = testResult.testExecError;
     return (
       descBullet +
       (config.verbose ? 'Runtime Error' : chalk.bold('Runtime Error')) + '\n' +
-      (error.stack ? cleanStackTrace(error.stack) : error.message)
+      (error.stack ? formatStackTrace(error.stack, config) : error.message)
     );
   }
 
   return testResult.testResults
     .filter(result => result.failureMessages.length !== 0)
     .map(result => {
-      const failureMessages = result.failureMessages.map(errorMsg => {
-        errorMsg = errorMsg.split('\n')
-          .map(line => {
-            // Extract the file path from the trace line.
-            let matches =
-              line.match(/(^\s+at .*?\()([^()]+)(:[0-9]+:[0-9]+\).*$)/);
-            if (!matches) {
-              matches = line.match(/(^\s+at )([^()]+)(:[0-9]+:[0-9]+.*$)/);
-              if (!matches) {
-                return line;
-              }
-            }
-            // Filter out noisy and unhelpful lines from the stack trace.
-            if (STACK_TRACE_LINE_IGNORE_RE.test(line)) {
-              return null;
-            }
+      const failureMessages = result.failureMessages
+        .map(stackTrace => formatStackTrace(stackTrace, config))
+        .join('\n');
 
-            const filePath = matches[2];
-            return (
-              matches[1] +
-              path.relative(rootDir, filePath) +
-              matches[3]
-            );
-          })
-          .filter(line => line !== null)
-          .join('\n');
+      const testTitleAncestry = result.ancestorTitles
+        .map(title => chalk.bold(title))
+        .join(ancestrySeparator);
 
-        return msgBullet + errorMsg.replace(/\n/g, '\n' + msgIndent);
-      }).join('\n');
-
-      const testTitleAncestry = result.ancestorTitles.map(
-        title => chalk.bold(title)
-      ).join(ancestrySeparator) + ancestrySeparator;
-
-      return descBullet + testTitleAncestry + result.title + '\n' +
-        failureMessages;
+      return descBullet + testTitleAncestry + ancestrySeparator + result.title +
+        '\n' + failureMessages;
     })
     .join('\n');
 }
 
-exports.cleanStackTrace = cleanStackTrace;
 exports.formatFailureMessage = formatFailureMessage;


### PR DESCRIPTION
The reporting code is a huge mess. This simplifies a bunch of things and makes everything go through the same code path and makes `noStackTrace` work again which hasn't worked properly for maybe half a year.

Fixes included:
* When a single test is run and it throws a runtime error, we now show the "1 test suite failed" message.
* Runtime errors, string errors and error objects thrown in tests now all render the same way and go through a single code path.
* Stack trace printing can be disabled with `--noStackTrace`

yay, regex

Fixes #985.

@bypass-lint