### PR TITLE
Update to latest JSDOM (9.x)

### DIFF
--- a/packages/jest-environment-jsdom/package.json
+++ b/packages/jest-environment-jsdom/package.json
@@ -8,7 +8,7 @@
   "license": "BSD-3-Clause",
   "main": "src/index.js",
   "dependencies": {
-    "jsdom": "^8.4.1",
+    "jsdom": "^9.0.0",
     "jest-util": "^12.0.2"
   }
 }


### PR DESCRIPTION
Changelog: https://github.com/tmpvar/jsdom/blob/master/Changelog.md

MutationObservers were removed, otherwise just bugfixes.

Also, I tried doing my own jsdom-environment but it wasn't working and was complaining about `jest-utils` not exporting or something of the like.