### PR TITLE
Removes mkdirp from jestcli

### DIFF
--- a/packages/jest-cli/package.json
+++ b/packages/jest-cli/package.json
@@ -17,7 +17,6 @@
     "jest-util": "^12.0.2",
     "json-stable-stringify": "^1.0.0",
     "lodash.template": "^4.2.4",
-    "mkdirp": "^0.5.1",
     "optimist": "^0.6.1",
     "resolve": "^1.1.6",
     "sane": "^1.2.0",

--- a/packages/jest-cli/src/TestRunner.js
+++ b/packages/jest-cli/src/TestRunner.js
@@ -14,7 +14,6 @@ const Test = require('./Test');
 const createHasteMap = require('./lib/createHasteMap');
 const fs = require('graceful-fs');
 const getCacheFilePath = require('jest-haste-map').getCacheFilePath;
-const mkdirp = require('mkdirp');
 const path = require('path');
 const promisify = require('./lib/promisify');
 const resolveNodeModule = require('./lib/resolveNodeModule');
@@ -42,13 +41,7 @@ class TestRunner {
     this._opts = options;
     this._config = Object.freeze(config);
 
-    try {
-      mkdirp.sync(this._config.cacheDirectory, '777');
-    } catch (e) {
-      if (e.code !== 'EEXIST') {
-        throw e;
-      }
-    }
+    utils.createDirectory(this._config.cacheDirectory);
 
     this._hasteMap = createHasteMap(config, {
       maxWorkers: this._opts.maxWorkers,

--- a/packages/jest-util/src/JasmineFormatter.js
+++ b/packages/jest-util/src/JasmineFormatter.js
@@ -18,7 +18,7 @@ class JasmineFormatter {
   constructor(jasmine, environment, config) {
     this._config = config;
     this._jasmine = jasmine;
-    this._environment = environment;
+    this._environment = environment? environment : {global:{}};
     this._diffableMatchers = Object.assign(Object.create(null), {
       toBe: true,
       toNotBe: true,


### PR DESCRIPTION
- removes mkdirp form jest-cli
- fixes broken jasmine formatter when the environment is not passed