### PR TITLE
update ManualMocks.md to reference rootDir

### DIFF
--- a/docs/ManualMocks.md
+++ b/docs/ManualMocks.md
@@ -16,8 +16,9 @@ Manual mocks are defined by writing a module in a `__mocks__/` subdirectory
 immediately adjacent to the module. For example, to mock a module called
 ``user`` in a the ``models`` directory, create a file called ``user.js`` and
 put it in the ``models/__mocks__`` directory. If the module you are mocking is
-a node module, the mock should be placed in the same parent directory as the
-``node_modules`` folder. Eg:
+a node module, the mocks should be placed in the same directory you have set as
+`rootDir` in the configuration options or, by default, the same parent directory
+as the ``node_modules`` folder. Eg:
 
 ```
   node_modules


### PR DESCRIPTION
add docmentation for the correct location of __mocks__ for npm packages when the rootDir config option is set.