### PR TITLE
Add modulePaths and moduleDirectories options

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -55,8 +55,10 @@ Jest uses Jasmine 2 by default. An introduction to Jasmine 2 can be found
   - [`coverageThreshold` [object]](#coveragethreshold-object)
   - [`globals` [object]](#globals-object)
   - [`mocksPattern` [string]](#mockspattern-string)
+  - [`moduleDirectories` [array<string>]](#moduledirectories-array-string)
   - [`moduleFileExtensions` [array<string>]](#modulefileextensions-array-string)
   - [`moduleNameMapper` [object<string, string>]](#modulenamemapper-object-string-string)
+  - [`modulePaths` [array<string>]](#modulepaths-array-string)
   - [`modulePathIgnorePatterns` [array<string>]](#modulepathignorepatterns-array-string)
   - [`preprocessorIgnorePatterns` [array<string>]](#preprocessorignorepatterns-array-string)
   - [`rootDir` [string]](#rootdir-string)
@@ -456,6 +458,19 @@ If you are using TypeScript this should be `['js', 'json', 'ts']`
 (default: `[]`)
 
 An array of regexp pattern strings that are matched against all module paths before those paths are to be considered 'visible' to the module loader. If a given module's path matches any of the patterns, it will not be `require()`-able in the test environment.
+
+### `modulePaths` [array<string>]
+(default: `[]`)
+
+An alternative API to setting the `NODE_PATH` env variable, `modulePaths` is an array of absolute paths to
+additional locations to search when resolving modules.
+
+### `moduleDirectories` [array<string>]
+(default: `['node_modules']`)
+
+An array of directory names to be searched recursively up from the requiring module's location. Setting this option
+will _override_ the default, if you wish to still search `node_modules` for packages include it
+along with any other options: `['node_modules', 'bower_components']`
 
 ### `moduleNameMapper` [object<string, string>]
 (default: `null`)

--- a/packages/jest-cli/src/Runtime/__tests__/Runtime-NODE_PATH-test.js
+++ b/packages/jest-cli/src/Runtime/__tests__/Runtime-NODE_PATH-test.js
@@ -42,6 +42,17 @@ describe('Runtime', () => {
     });
   });
 
+  pit('uses modulePaths to find modules', () => {
+    const nodePath = __dirname + '/NODE_PATH_dir';
+    return createLocalRuntime(null, {modulePaths: nodePath}).then(runtime => {
+      const exports = runtime.requireModuleOrMock(
+        runtime.__mockRootPath,
+        'RegularModuleInNodePath'
+      );
+      expect(exports).toBeDefined();
+    });
+  });
+
   pit('finds modules in NODE_PATH containing multiple paths', () => {
     const nodePath =
       cwd + '/some/other/path' + path.delimiter + __dirname + '/NODE_PATH_dir';

--- a/packages/jest-cli/src/Runtime/__tests__/Runtime-moduleDirectories-test.js
+++ b/packages/jest-cli/src/Runtime/__tests__/Runtime-moduleDirectories-test.js
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails oncall+jsinfra
+ */
+'use strict';
+
+jest.disableAutomock();
+jest.mock(
+  'jest-environment-jsdom',
+  () => require('../../../__mocks__/jest-environment-jsdom')
+);
+
+const path = require('path');
+
+const moduleDirectories = ['module_dir'];
+
+let createRuntime;
+let rootDir;
+
+describe('Runtime', () => {
+
+  beforeEach(() => {
+    rootDir = path.resolve(path.dirname(__filename), 'test_root');
+    createRuntime = require('createRuntime');
+  });
+
+  pit('uses configured moduleDirectories', () =>
+    createRuntime(__filename, {moduleDirectories}).then(runtime => {
+      const exports = runtime.requireModule(
+        runtime.__mockRootPath,
+        'moduleDirModule'
+      );
+      expect(exports).toBeDefined();
+    })
+  );
+
+  pit('resolves packages', () =>
+    createRuntime(__filename, {moduleDirectories}).then(runtime => {
+      const exports = runtime.requireModule(
+        runtime.__mockRootPath,
+        'my-module'
+      );
+      expect(exports.isNodeModule).toEqual(true);
+    })
+  );
+
+  pit('finds closest module from moduleDirectories', () =>
+    createRuntime(__filename, {moduleDirectories}).then(runtime => {
+
+      const exports = runtime.requireModule(
+        path.join(rootDir, 'subDir2/MyModule.js'),
+        'moduleDirModule'
+      );
+      expect(exports.modulePath).toEqual('subdir2/module_dir/moduleDirModule.js');
+    })
+  );
+
+  pit('only checks the configured directories', () =>
+    createRuntime(__filename, {moduleDirectories}).then(runtime => {
+      expect(() => {
+        runtime.requireModule(runtime.__mockRootPath, 'not-a-haste-package');
+      }).toThrow(
+        new Error('Cannot find module \'not-a-haste-package\' from \'root.js\'')
+      );
+    })
+  );
+});

--- a/packages/jest-cli/src/Runtime/__tests__/Runtime-requireModule-test.js
+++ b/packages/jest-cli/src/Runtime/__tests__/Runtime-requireModule-test.js
@@ -59,18 +59,23 @@ describe('Runtime requireModule', () => {
     })
   );
 
-  pit('provides `module.paths` to modules', () =>
-    createRuntime(__filename).then(runtime => {
+  pit('provides `module.paths` to modules', () => {
+    const altModuleDir = 'bower_components';
+    const moduleDirectories = ['node_modules', altModuleDir];
+
+    return createRuntime(__filename, {moduleDirectories}).then(runtime => {
       const exports = runtime.requireModule(
         runtime.__mockRootPath,
         'RegularModule'
       );
       expect(exports.paths.length).toBeGreaterThan(0);
       exports.paths.forEach(path => {
-        expect(path.endsWith('node_modules')).toBe(true);
+        expect(
+          moduleDirectories.some(dir => path.endsWith(dir))
+        ).toBe(true);
       });
-    })
-  );
+    });
+  });
 
   pit('throws on non-existent @providesModule modules', () =>
     createRuntime(__filename).then(runtime => {

--- a/packages/jest-cli/src/Runtime/__tests__/test_root/module_dir/moduleDirModule.js
+++ b/packages/jest-cli/src/Runtime/__tests__/test_root/module_dir/moduleDirModule.js
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+exports.modulePath = 'module_dir/moduleDirModule.js';

--- a/packages/jest-cli/src/Runtime/__tests__/test_root/module_dir/my-module/core.js
+++ b/packages/jest-cli/src/Runtime/__tests__/test_root/module_dir/my-module/core.js
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+exports.isNodeModule = true;

--- a/packages/jest-cli/src/Runtime/__tests__/test_root/module_dir/my-module/package.json
+++ b/packages/jest-cli/src/Runtime/__tests__/test_root/module_dir/my-module/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "my-module",
+  "main": "./core.js"
+}

--- a/packages/jest-cli/src/Runtime/__tests__/test_root/subdir2/module_dir/moduleDirModule.js
+++ b/packages/jest-cli/src/Runtime/__tests__/test_root/subdir2/module_dir/moduleDirModule.js
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+exports.modulePath = 'subdir2/module_dir/moduleDirModule.js';

--- a/packages/jest-cli/src/config/defaults.js
+++ b/packages/jest-cli/src/config/defaults.js
@@ -26,6 +26,7 @@ module.exports = {
   },
   modulePathIgnorePatterns: [],
   moduleNameMapper: [],
+  moduleDirectories: ['node_modules'],
   testDirectoryName: '__tests__',
   mocksPattern: '__mocks__',
   testEnvironment: 'jest-environment-jsdom',

--- a/packages/jest-cli/src/config/normalize.js
+++ b/packages/jest-cli/src/config/normalize.js
@@ -52,12 +52,12 @@ function _replaceRootDirTags(rootDir, config) {
 
 function getTestEnvironment(config) {
   const env = config.testEnvironment;
-  let module = Resolver.findNodeModule(env, config.rootDir);
+  let module = Resolver.findNodeModule(env, {basedir: config.rootDir});
   if (module) {
     return module;
   }
 
-  module = Resolver.findNodeModule(`jest-environment-${env}`, config.rootDir);
+  module = Resolver.findNodeModule(`jest-environment-${env}`, {basedir: config.rootDir});
   if (module) {
     return module;
   }
@@ -140,7 +140,7 @@ function normalize(config, argv) {
       babelJest = config.scriptPreprocessor;
     }
   } else {
-    babelJest = Resolver.findNodeModule('babel-jest', config.rootDir);
+    babelJest = Resolver.findNodeModule('babel-jest', {basedir: config.rootDir});
     if (babelJest) {
       config.scriptPreprocessor = babelJest;
     }
@@ -148,7 +148,7 @@ function normalize(config, argv) {
 
   if (babelJest) {
     const polyfillPath =
-      Resolver.findNodeModule('babel-polyfill', config.rootDir);
+      Resolver.findNodeModule('babel-polyfill', {basedir: config.rootDir});
     if (polyfillPath) {
       config.setupFiles.unshift(polyfillPath);
     }
@@ -157,7 +157,7 @@ function normalize(config, argv) {
 
   if (!('preprocessorIgnorePatterns' in config)) {
     const isRNProject =
-      !!Resolver.findNodeModule('react-native', config.rootDir);
+      !!Resolver.findNodeModule('react-native', {basedir: config.rootDir});
     config.preprocessorIgnorePatterns =
       isRNProject ? [] : [constants.NODE_MODULES];
   } else if (!config.preprocessorIgnorePatterns) {
@@ -243,6 +243,8 @@ function normalize(config, argv) {
       case 'testReporter':
       case 'testURL':
       case 'moduleFileExtensions':
+      case 'moduleDirectories':
+      case 'modulePaths':
       case 'noHighlight':
       case 'colors':
       case 'noStackTrace':

--- a/packages/jest-cli/src/lib/createResolver.js
+++ b/packages/jest-cli/src/lib/createResolver.js
@@ -30,6 +30,7 @@ module.exports = function createResolver(config, moduleMap) {
     defaultPlatform: config.haste.defaultPlatform,
     extensions,
     hasCoreModules: true,
+    modulePaths: config.modulePaths,
     moduleDirectories: config.moduleDirectories,
     moduleNameMapper: getModuleNameMapper(config),
     platforms: config.haste.platforms,


### PR DESCRIPTION
passes through config options to node-resolve for paths, and moduleDirectory

`NODE_PATH` settings makes a bit of this redundant but as a config option it feels a bit more first class, and allows for nicely mapping webpack configs to jest configs. I did make sure that NODE_PATH is always respected.

(note by @cpojer: @bypass-lint)