### PR TITLE
expect no `__tests__` files in coverage report

### DIFF
--- a/integration_tests/__tests__/coverage_report-test.js
+++ b/integration_tests/__tests__/coverage_report-test.js
@@ -16,8 +16,11 @@ const path = require('path');
 describe('Coverage Report', () => {
   it('outputs coverage report', () => {
     const result = runJest('coverage_report', ['--coverage']);
+    const stdout = result.stdout.toString();
+
     const coverageDir = path.resolve(__dirname, '../coverage_report/coverage');
-    expect(result.stdout.toString()).toMatch(/All files.*100.*100.*100.*100/);
+    expect(stdout).toMatch(/All files.*100.*100.*100.*100/);
+    expect(stdout).not.toMatch(/^.+__tests__.+\|.+\|.+\|.+\|/gm);
     // this will throw if the coverage directory is not there
     fs.accessSync(coverageDir, fs.F_OK);
     expect(result.status).toBe(0);


### PR DESCRIPTION
should pass when https://github.com/facebook/jest/pull/1039 is in master