### PR TITLE
Complain loudly about unrecognized args

### DIFF
--- a/packages/jest-cli/src/cli/processArgs.js
+++ b/packages/jest-cli/src/cli/processArgs.js
@@ -29,173 +29,175 @@ function _wrapDesc(desc) {
 }
 
 function processArgs() {
-  return optimist
+  const options = {
+    config: {
+      alias: 'c',
+      description: _wrapDesc(
+        'The path to a jest config file specifying how to find and execute ' +
+        'tests. If no rootDir is set in the config, the current directory ' +
+        'is assumed to be the rootDir for the project.'
+      ),
+      type: 'string',
+    },
+    coverage: {
+      description: _wrapDesc(
+        'Indicates that test coverage information should be collected and ' +
+        'reported in the output.'
+      ),
+      type: 'boolean',
+    },
+    maxWorkers: {
+      alias: 'w',
+      description: _wrapDesc(
+        'Specifies the maximum number of workers the worker-pool will ' +
+        'spawn for running tests. This defaults to the number of the cores ' +
+        'available on your machine. (its usually best not to override this ' +
+        'default)'
+      ),
+      type: 'string', // no, optimist -- its a number.. :(
+    },
+    onlyChanged: {
+      alias: 'o',
+      description: _wrapDesc(
+        'Attempts to identify which tests to run based on which files have ' +
+        'changed in the current repository. Only works if you\'re running ' +
+        'tests in a git repository at the moment.'
+      ),
+      type: 'boolean',
+    },
+    runInBand: {
+      alias: 'i',
+      description: _wrapDesc(
+        'Run all tests serially in the current process (rather than ' +
+        'creating a worker pool of child processes that run tests). This ' +
+        'is sometimes useful for debugging, but such use cases are pretty ' +
+        'rare.'
+      ),
+      type: 'boolean',
+    },
+    testEnvData: {
+      description: _wrapDesc(
+        'A JSON object (string) that specifies data that will be made ' +
+        'available in the test environment (via jest.getTestEnvData())'
+      ),
+      type: 'string',
+    },
+    testPathPattern: {
+      description: _wrapDesc(
+        'A regexp pattern string that is matched against all tests ' +
+        'paths before executing the test.'
+      ),
+      type: 'string',
+    },
+    version: {
+      alias: 'v',
+      description: _wrapDesc('Print the version and exit'),
+      type: 'boolean',
+    },
+    noHighlight: {
+      description: _wrapDesc(
+        'Disables test results output highlighting'
+      ),
+      type: 'boolean',
+    },
+    colors: {
+      description: _wrapDesc(
+        'Forces test results output highlighting (even if stdout is not a TTY)'
+      ),
+      type: 'boolean',
+    },
+    noStackTrace: {
+      description: _wrapDesc(
+        'Disables stack trace in test results output'
+      ),
+      type: 'boolean',
+    },
+    verbose: {
+      description: _wrapDesc(
+        'Display individual test results with the test suite hierarchy.'
+      ),
+      type: 'boolean',
+    },
+    watch: {
+      description: _wrapDesc(
+        'Watch files for changes and rerun tests related to changed files. ' +
+        'If you want to re-run all tests when a file has changed, you can ' +
+        'call Jest using `--watch=all`.'
+      ),
+      type: 'string',
+    },
+    bail: {
+      alias: 'b',
+      description: _wrapDesc(
+        'Exit the test suite immediately upon the first failing test.'
+      ),
+      type: 'boolean',
+    },
+    useStderr: {
+      description: _wrapDesc(
+        'Divert all output to stderr.'
+      ),
+      type: 'boolean',
+    },
+    cache: {
+      default: true,
+      description: _wrapDesc(
+        'Whether to use the preprocessor cache. Disable the cache using ' +
+        '--no-cache.'
+      ),
+      type: 'boolean',
+    },
+    json: {
+      description: _wrapDesc(
+        'Prints the test results in JSON. This mode will send all ' +
+        'other test output and user messages to stderr.'
+      ),
+      type: 'boolean',
+    },
+    setupTestFrameworkScriptFile: {
+      description: _wrapDesc(
+        'The path to a module that runs some code to configure or set up ' +
+        'the testing framework before each test.'
+      ),
+      type: 'string',
+    },
+    testRunner: {
+      description: _wrapDesc(
+        'Allows to specify a custom test runner. Jest ships with Jasmine ' +
+        '1 and 2 which can be enabled by setting this option to ' +
+        '`jasmine1` or `jasmine2`. The default is `jasmine2`. A path to a ' +
+        'custom test runner can be provided: ' +
+        '`<rootDir>/path/to/testRunner.js`.'
+      ),
+      type: 'string',
+    },
+    logHeapUsage: {
+      description: _wrapDesc(
+        'Logs the heap usage after every test. Useful to debug memory ' +
+        'leaks. Use together with `--runInBand` and `--expose-gc` in node.'
+      ),
+      type: 'boolean',
+    },
+    watchman: {
+      default: true,
+      description: _wrapDesc(
+        'Whether to use watchman for file crawling. Disable using ' +
+        '--no-watchman.'
+      ),
+      type: 'boolean',
+    },
+    silent: {
+      default: false,
+      description: _wrapDesc(
+        'Prevent tests from printing messages through the console.'
+      ),
+      type: 'boolean',
+    },
+  };
+
+  const argv = optimist
     .usage('Usage: $0 [--config=<pathToConfigFile>] [TestPathRegExp]')
-    .options({
-      config: {
-        alias: 'c',
-        description: _wrapDesc(
-          'The path to a jest config file specifying how to find and execute ' +
-          'tests. If no rootDir is set in the config, the current directory ' +
-          'is assumed to be the rootDir for the project.'
-        ),
-        type: 'string',
-      },
-      coverage: {
-        description: _wrapDesc(
-          'Indicates that test coverage information should be collected and ' +
-          'reported in the output.'
-        ),
-        type: 'boolean',
-      },
-      maxWorkers: {
-        alias: 'w',
-        description: _wrapDesc(
-          'Specifies the maximum number of workers the worker-pool will ' +
-          'spawn for running tests. This defaults to the number of the cores ' +
-          'available on your machine. (its usually best not to override this ' +
-          'default)'
-        ),
-        type: 'string', // no, optimist -- its a number.. :(
-      },
-      onlyChanged: {
-        alias: 'o',
-        description: _wrapDesc(
-          'Attempts to identify which tests to run based on which files have ' +
-          'changed in the current repository. Only works if you\'re running ' +
-          'tests in a git repository at the moment.'
-        ),
-        type: 'boolean',
-      },
-      runInBand: {
-        alias: 'i',
-        description: _wrapDesc(
-          'Run all tests serially in the current process (rather than ' +
-          'creating a worker pool of child processes that run tests). This ' +
-          'is sometimes useful for debugging, but such use cases are pretty ' +
-          'rare.'
-        ),
-        type: 'boolean',
-      },
-      testEnvData: {
-        description: _wrapDesc(
-          'A JSON object (string) that specifies data that will be made ' +
-          'available in the test environment (via jest.getTestEnvData())'
-        ),
-        type: 'string',
-      },
-      testPathPattern: {
-        description: _wrapDesc(
-          'A regexp pattern string that is matched against all tests ' +
-          'paths before executing the test.'
-        ),
-        type: 'string',
-      },
-      version: {
-        alias: 'v',
-        description: _wrapDesc('Print the version and exit'),
-        type: 'boolean',
-      },
-      noHighlight: {
-        description: _wrapDesc(
-          'Disables test results output highlighting'
-        ),
-        type: 'boolean',
-      },
-      colors: {
-        description: _wrapDesc(
-          'Forces test results output highlighting (even if stdout is not a TTY)'
-        ),
-        type: 'boolean',
-      },
-      noStackTrace: {
-        description: _wrapDesc(
-          'Disables stack trace in test results output'
-        ),
-        type: 'boolean',
-      },
-      verbose: {
-        description: _wrapDesc(
-          'Display individual test results with the test suite hierarchy.'
-        ),
-        type: 'boolean',
-      },
-      watch: {
-        description: _wrapDesc(
-          'Watch files for changes and rerun tests related to changed files. ' +
-          'If you want to re-run all tests when a file has changed, you can ' +
-          'call Jest using `--watch=all`.'
-        ),
-        type: 'string',
-      },
-      bail: {
-        alias: 'b',
-        description: _wrapDesc(
-          'Exit the test suite immediately upon the first failing test.'
-        ),
-        type: 'boolean',
-      },
-      useStderr: {
-        description: _wrapDesc(
-          'Divert all output to stderr.'
-        ),
-        type: 'boolean',
-      },
-      cache: {
-        default: true,
-        description: _wrapDesc(
-          'Whether to use the preprocessor cache. Disable the cache using ' +
-          '--no-cache.'
-        ),
-        type: 'boolean',
-      },
-      json: {
-        description: _wrapDesc(
-          'Prints the test results in JSON. This mode will send all ' +
-          'other test output and user messages to stderr.'
-        ),
-        type: 'boolean',
-      },
-      setupTestFrameworkScriptFile: {
-        description: _wrapDesc(
-          'The path to a module that runs some code to configure or set up ' +
-          'the testing framework before each test.'
-        ),
-        type: 'string',
-      },
-      testRunner: {
-        description: _wrapDesc(
-          'Allows to specify a custom test runner. Jest ships with Jasmine ' +
-          '1 and 2 which can be enabled by setting this option to ' +
-          '`jasmine1` or `jasmine2`. The default is `jasmine2`. A path to a ' +
-          'custom test runner can be provided: ' +
-          '`<rootDir>/path/to/testRunner.js`.'
-        ),
-        type: 'string',
-      },
-      logHeapUsage: {
-        description: _wrapDesc(
-          'Logs the heap usage after every test. Useful to debug memory ' +
-          'leaks. Use together with `--runInBand` and `--expose-gc` in node.'
-        ),
-        type: 'boolean',
-      },
-      watchman: {
-        default: true,
-        description: _wrapDesc(
-          'Whether to use watchman for file crawling. Disable using ' +
-          '--no-watchman.'
-        ),
-        type: 'boolean',
-      },
-      silent: {
-        default: false,
-        description: _wrapDesc(
-          'Prevent tests from printing messages through the console.'
-        ),
-        type: 'boolean',
-      },
-    })
+    .options(options)
     .check(argv => {
       if (argv.runInBand && argv.hasOwnProperty('maxWorkers')) {
         throw new Error(
@@ -221,8 +223,25 @@ function processArgs() {
       if (argv.testEnvData) {
         argv.testEnvData = JSON.parse(argv.testEnvData);
       }
+
+      const optimistSpecialOptions = ['$0', '_'];
+      const allowedOptions = Object.keys(options).reduce((acc, option) => {
+        return acc
+          .add(option)
+          .add(options[option].alias);
+      }, new Set(optimistSpecialOptions));
+      const unrecognizedOptions = Object.keys(argv).filter(arg => {
+        return !allowedOptions.has(arg);
+      });
+      if (unrecognizedOptions.length) {
+        throw new Error(
+          'Unrecognized options: ' + unrecognizedOptions.join(', ')
+        );
+      }
     })
     .argv;
+
+  return argv;
 }
 
 module.exports = processArgs;


### PR DESCRIPTION
Jest currently accepts any args at all. Given:

```
jest --silent --invalid foo
```

It will recognize `silent` as a boolean, take `invalid` as an option with value `foo`, and then run the entire test suite. I noticed this when trying to use `--silent` on an older version of Jest that doesn't support it:

```
jest --silent filter
```

I had expected `filter` to reduce the number of tests run, but it ran them all, and on further inspection I discovered that optimist was jamming all the unrecognized options inside `argv` without complaint.

So, this commit makes it search `argv` for unrecognized keys, and if it finds any, it bails. Allowed keys are:

- Explicitly defined options.
- Any `alias` set on an explicitly defined option.
- The special `$0` option which holds the original command.
- The special `_` value which holds all non-option arguments.