### PR TITLE
Make options parsing more strict

### DIFF
--- a/packages/jest-cli/package.json
+++ b/packages/jest-cli/package.json
@@ -8,9 +8,9 @@
     "cover": "^0.2.9",
     "graceful-fs": "^4.1.3",
     "istanbul": "^0.4.2",
+    "jest-changed-files": "^12.1.0",
     "jest-environment-jsdom": "^12.1.0",
     "jest-environment-node": "^12.1.0",
-    "jest-changed-files": "^12.1.0",
     "jest-haste-map": "^12.1.0",
     "jest-jasmine1": "^12.1.0",
     "jest-jasmine2": "^12.1.0",
@@ -19,10 +19,10 @@
     "jest-util": "^12.1.0",
     "json-stable-stringify": "^1.0.0",
     "lodash.template": "^4.2.4",
-    "optimist": "^0.6.1",
     "sane": "^1.2.0",
     "which": "^1.1.1",
-    "worker-farm": "^1.3.1"
+    "worker-farm": "^1.3.1",
+    "yargs": "^4.7.1"
   },
   "bin": {
     "jest": "./bin/jest.js"

--- a/packages/jest-cli/src/cli/index.js
+++ b/packages/jest-cli/src/cli/index.js
@@ -12,7 +12,7 @@ const fs = require('fs');
 const getJest = require('./getJest');
 const path = require('path');
 const processArgs = require('./processArgs');
-const optimist = require('optimist');
+const yargs = require('yargs');
 
 function getPackageRoot() {
   const cwd = process.cwd();
@@ -34,7 +34,7 @@ function Run() {
   const argv = processArgs();
 
   if (argv.help) {
-    optimist.showHelp();
+    yargs.showHelp();
     process.on('exit', () => process.exit(1));
     return;
   }

--- a/packages/jest-cli/src/cli/processArgs.js
+++ b/packages/jest-cli/src/cli/processArgs.js
@@ -225,14 +225,14 @@ function processArgs() {
       }
 
       const yargsSpecialOptions = ['$0', '_'];
-      const allowedOptions = Object.keys(options).reduce((acc, option) => {
-        return acc
+      const allowedOptions = Object.keys(options).reduce((acc, option) => (
+        acc
           .add(option)
-          .add(options[option].alias);
-      }, new Set(yargsSpecialOptions));
-      const unrecognizedOptions = Object.keys(argv).filter(arg => {
-        return !allowedOptions.has(arg);
-      });
+          .add(options[option].alias)
+      ), new Set(yargsSpecialOptions));
+      const unrecognizedOptions = Object.keys(argv).filter(arg => (
+        !allowedOptions.has(arg)
+      ));
       if (unrecognizedOptions.length) {
         throw new Error(
           'Unrecognized options: ' + unrecognizedOptions.join(', ')

--- a/packages/jest-cli/src/cli/processArgs.js
+++ b/packages/jest-cli/src/cli/processArgs.js
@@ -8,7 +8,7 @@
 
 'use strict';
 
-const optimist = require('optimist');
+const yargs = require('yargs');
 
 function _wrapDesc(desc) {
   const indent = '\n      ';
@@ -54,7 +54,7 @@ function processArgs() {
         'available on your machine. (its usually best not to override this ' +
         'default)'
       ),
-      type: 'string', // no, optimist -- its a number.. :(
+      type: 'string', // no, yargs -- its a number.. :(
     },
     onlyChanged: {
       alias: 'o',
@@ -195,7 +195,7 @@ function processArgs() {
     },
   };
 
-  const argv = optimist
+  const argv = yargs
     .usage('Usage: $0 [--config=<pathToConfigFile>] [TestPathRegExp]')
     .options(options)
     .check(argv => {
@@ -224,12 +224,12 @@ function processArgs() {
         argv.testEnvData = JSON.parse(argv.testEnvData);
       }
 
-      const optimistSpecialOptions = ['$0', '_'];
+      const yargsSpecialOptions = ['$0', '_'];
       const allowedOptions = Object.keys(options).reduce((acc, option) => {
         return acc
           .add(option)
           .add(options[option].alias);
-      }, new Set(optimistSpecialOptions));
+      }, new Set(yargsSpecialOptions));
       const unrecognizedOptions = Object.keys(argv).filter(arg => {
         return !allowedOptions.has(arg);
       });
@@ -238,6 +238,7 @@ function processArgs() {
           'Unrecognized options: ' + unrecognizedOptions.join(', ')
         );
       }
+      return true;
     })
     .argv;
 

--- a/packages/jest-cli/src/cli/processArgs.js
+++ b/packages/jest-cli/src/cli/processArgs.js
@@ -29,173 +29,175 @@ function _wrapDesc(desc) {
 }
 
 function processArgs() {
-  return optimist
+  const options = {
+    config: {
+      alias: 'c',
+      description: _wrapDesc(
+        'The path to a jest config file specifying how to find and execute ' +
+        'tests. If no rootDir is set in the config, the current directory ' +
+        'is assumed to be the rootDir for the project.'
+      ),
+      type: 'string',
+    },
+    coverage: {
+      description: _wrapDesc(
+        'Indicates that test coverage information should be collected and ' +
+        'reported in the output.'
+      ),
+      type: 'boolean',
+    },
+    maxWorkers: {
+      alias: 'w',
+      description: _wrapDesc(
+        'Specifies the maximum number of workers the worker-pool will ' +
+        'spawn for running tests. This defaults to the number of the cores ' +
+        'available on your machine. (its usually best not to override this ' +
+        'default)'
+      ),
+      type: 'string', // no, optimist -- its a number.. :(
+    },
+    onlyChanged: {
+      alias: 'o',
+      description: _wrapDesc(
+        'Attempts to identify which tests to run based on which files have ' +
+        'changed in the current repository. Only works if you\'re running ' +
+        'tests in a git repository at the moment.'
+      ),
+      type: 'boolean',
+    },
+    runInBand: {
+      alias: 'i',
+      description: _wrapDesc(
+        'Run all tests serially in the current process (rather than ' +
+        'creating a worker pool of child processes that run tests). This ' +
+        'is sometimes useful for debugging, but such use cases are pretty ' +
+        'rare.'
+      ),
+      type: 'boolean',
+    },
+    testEnvData: {
+      description: _wrapDesc(
+        'A JSON object (string) that specifies data that will be made ' +
+        'available in the test environment (via jest.getTestEnvData())'
+      ),
+      type: 'string',
+    },
+    testPathPattern: {
+      description: _wrapDesc(
+        'A regexp pattern string that is matched against all tests ' +
+        'paths before executing the test.'
+      ),
+      type: 'string',
+    },
+    version: {
+      alias: 'v',
+      description: _wrapDesc('Print the version and exit'),
+      type: 'boolean',
+    },
+    noHighlight: {
+      description: _wrapDesc(
+        'Disables test results output highlighting'
+      ),
+      type: 'boolean',
+    },
+    colors: {
+      description: _wrapDesc(
+        'Forces test results output highlighting (even if stdout is not a TTY)'
+      ),
+      type: 'boolean',
+    },
+    noStackTrace: {
+      description: _wrapDesc(
+        'Disables stack trace in test results output'
+      ),
+      type: 'boolean',
+    },
+    verbose: {
+      description: _wrapDesc(
+        'Display individual test results with the test suite hierarchy.'
+      ),
+      type: 'boolean',
+    },
+    watch: {
+      description: _wrapDesc(
+        'Watch files for changes and rerun tests related to changed files. ' +
+        'If you want to re-run all tests when a file has changed, you can ' +
+        'call Jest using `--watch=all`.'
+      ),
+      type: 'string',
+    },
+    bail: {
+      alias: 'b',
+      description: _wrapDesc(
+        'Exit the test suite immediately upon the first failing test.'
+      ),
+      type: 'boolean',
+    },
+    useStderr: {
+      description: _wrapDesc(
+        'Divert all output to stderr.'
+      ),
+      type: 'boolean',
+    },
+    cache: {
+      default: true,
+      description: _wrapDesc(
+        'Whether to use the preprocessor cache. Disable the cache using ' +
+        '--no-cache.'
+      ),
+      type: 'boolean',
+    },
+    json: {
+      description: _wrapDesc(
+        'Prints the test results in JSON. This mode will send all ' +
+        'other test output and user messages to stderr.'
+      ),
+      type: 'boolean',
+    },
+    setupTestFrameworkScriptFile: {
+      description: _wrapDesc(
+        'The path to a module that runs some code to configure or set up ' +
+        'the testing framework before each test.'
+      ),
+      type: 'string',
+    },
+    testRunner: {
+      description: _wrapDesc(
+        'Allows to specify a custom test runner. Jest ships with Jasmine ' +
+        '1 and 2 which can be enabled by setting this option to ' +
+        '`jasmine1` or `jasmine2`. The default is `jasmine2`. A path to a ' +
+        'custom test runner can be provided: ' +
+        '`<rootDir>/path/to/testRunner.js`.'
+      ),
+      type: 'string',
+    },
+    logHeapUsage: {
+      description: _wrapDesc(
+        'Logs the heap usage after every test. Useful to debug memory ' +
+        'leaks. Use together with `--runInBand` and `--expose-gc` in node.'
+      ),
+      type: 'boolean',
+    },
+    watchman: {
+      default: true,
+      description: _wrapDesc(
+        'Whether to use watchman for file crawling. Disable using ' +
+        '--no-watchman.'
+      ),
+      type: 'boolean',
+    },
+    silent: {
+      default: false,
+      description: _wrapDesc(
+        'Prevent tests from printing messages through the console.'
+      ),
+      type: 'boolean',
+    },
+  };
+
+  const argv = optimist
     .usage('Usage: $0 [--config=<pathToConfigFile>] [TestPathRegExp]')
-    .options({
-      config: {
-        alias: 'c',
-        description: _wrapDesc(
-          'The path to a jest config file specifying how to find and execute ' +
-          'tests. If no rootDir is set in the config, the current directory ' +
-          'is assumed to be the rootDir for the project.'
-        ),
-        type: 'string',
-      },
-      coverage: {
-        description: _wrapDesc(
-          'Indicates that test coverage information should be collected and ' +
-          'reported in the output.'
-        ),
-        type: 'boolean',
-      },
-      maxWorkers: {
-        alias: 'w',
-        description: _wrapDesc(
-          'Specifies the maximum number of workers the worker-pool will ' +
-          'spawn for running tests. This defaults to the number of the cores ' +
-          'available on your machine. (its usually best not to override this ' +
-          'default)'
-        ),
-        type: 'string', // no, optimist -- its a number.. :(
-      },
-      onlyChanged: {
-        alias: 'o',
-        description: _wrapDesc(
-          'Attempts to identify which tests to run based on which files have ' +
-          'changed in the current repository. Only works if you\'re running ' +
-          'tests in a git repository at the moment.'
-        ),
-        type: 'boolean',
-      },
-      runInBand: {
-        alias: 'i',
-        description: _wrapDesc(
-          'Run all tests serially in the current process (rather than ' +
-          'creating a worker pool of child processes that run tests). This ' +
-          'is sometimes useful for debugging, but such use cases are pretty ' +
-          'rare.'
-        ),
-        type: 'boolean',
-      },
-      testEnvData: {
-        description: _wrapDesc(
-          'A JSON object (string) that specifies data that will be made ' +
-          'available in the test environment (via jest.getTestEnvData())'
-        ),
-        type: 'string',
-      },
-      testPathPattern: {
-        description: _wrapDesc(
-          'A regexp pattern string that is matched against all tests ' +
-          'paths before executing the test.'
-        ),
-        type: 'string',
-      },
-      version: {
-        alias: 'v',
-        description: _wrapDesc('Print the version and exit'),
-        type: 'boolean',
-      },
-      noHighlight: {
-        description: _wrapDesc(
-          'Disables test results output highlighting'
-        ),
-        type: 'boolean',
-      },
-      colors: {
-        description: _wrapDesc(
-          'Forces test results output highlighting (even if stdout is not a TTY)'
-        ),
-        type: 'boolean',
-      },
-      noStackTrace: {
-        description: _wrapDesc(
-          'Disables stack trace in test results output'
-        ),
-        type: 'boolean',
-      },
-      verbose: {
-        description: _wrapDesc(
-          'Display individual test results with the test suite hierarchy.'
-        ),
-        type: 'boolean',
-      },
-      watch: {
-        description: _wrapDesc(
-          'Watch files for changes and rerun tests related to changed files. ' +
-          'If you want to re-run all tests when a file has changed, you can ' +
-          'call Jest using `--watch=all`.'
-        ),
-        type: 'string',
-      },
-      bail: {
-        alias: 'b',
-        description: _wrapDesc(
-          'Exit the test suite immediately upon the first failing test.'
-        ),
-        type: 'boolean',
-      },
-      useStderr: {
-        description: _wrapDesc(
-          'Divert all output to stderr.'
-        ),
-        type: 'boolean',
-      },
-      cache: {
-        default: true,
-        description: _wrapDesc(
-          'Whether to use the preprocessor cache. Disable the cache using ' +
-          '--no-cache.'
-        ),
-        type: 'boolean',
-      },
-      json: {
-        description: _wrapDesc(
-          'Prints the test results in JSON. This mode will send all ' +
-          'other test output and user messages to stderr.'
-        ),
-        type: 'boolean',
-      },
-      setupTestFrameworkScriptFile: {
-        description: _wrapDesc(
-          'The path to a module that runs some code to configure or set up ' +
-          'the testing framework before each test.'
-        ),
-        type: 'string',
-      },
-      testRunner: {
-        description: _wrapDesc(
-          'Allows to specify a custom test runner. Jest ships with Jasmine ' +
-          '1 and 2 which can be enabled by setting this option to ' +
-          '`jasmine1` or `jasmine2`. The default is `jasmine2`. A path to a ' +
-          'custom test runner can be provided: ' +
-          '`<rootDir>/path/to/testRunner.js`.'
-        ),
-        type: 'string',
-      },
-      logHeapUsage: {
-        description: _wrapDesc(
-          'Logs the heap usage after every test. Useful to debug memory ' +
-          'leaks. Use together with `--runInBand` and `--expose-gc` in node.'
-        ),
-        type: 'boolean',
-      },
-      watchman: {
-        default: true,
-        description: _wrapDesc(
-          'Whether to use watchman for file crawling. Disable using ' +
-          '--no-watchman.'
-        ),
-        type: 'boolean',
-      },
-      silent: {
-        default: false,
-        description: _wrapDesc(
-          'Prevent tests from printing messages through the console.'
-        ),
-        type: 'boolean',
-      },
-    })
+    .options(options)
     .check(argv => {
       if (argv.runInBand && argv.hasOwnProperty('maxWorkers')) {
         throw new Error(
@@ -221,8 +223,25 @@ function processArgs() {
       if (argv.testEnvData) {
         argv.testEnvData = JSON.parse(argv.testEnvData);
       }
+
+      const optimistSpecialOptions = ['$0', '_'];
+      const allowedOptions = Object.keys(options).reduce((acc, option) => {
+        return acc
+          .add(option)
+          .add(options[option].alias);
+      }, new Set(optimistSpecialOptions));
+      const unrecognizedOptions = Object.keys(argv).filter(arg => {
+        return !allowedOptions.has(arg);
+      });
+      if (unrecognizedOptions.length) {
+        throw new Error(
+          'Unrecognized options: ' + unrecognizedOptions.join(', ')
+        );
+      }
     })
     .argv;
+
+  return argv;
 }
 
 module.exports = processArgs;

--- a/packages/jest-cli/src/cli/processArgs.js
+++ b/packages/jest-cli/src/cli/processArgs.js
@@ -234,7 +234,7 @@ function processArgs() {
         !allowedOptions.has(arg)
       ));
       if (unrecognizedOptions.length) {
-        throw new Error(
+        console.warn(
           'Unrecognized options: ' + unrecognizedOptions.join(', ')
         );
       }


### PR DESCRIPTION
optimist is old, yargs is new.

optimist truncates the help output in the event that `check()` throws an error, meaning the user probably doesn't have any idea what went wrong or why.

yargs shows the untruncated help output.

This is an RFC because we run Jest in a bunch of places and not all will have access to yargs.
