### PR TITLE
Remember to escape the backslash in RegEx

### DIFF
--- a/packages/jest-cli/src/TestRunner.js
+++ b/packages/jest-cli/src/TestRunner.js
@@ -23,10 +23,7 @@ const workerFarm = require('worker-farm');
 const TEST_WORKER_PATH = require.resolve('./TestWorker');
 
 function pathToRegex(p) {
-  if (path.sep === '\\') {
-    return p.replace(/(\/|\\)/g, '\\\\');
-  }
-  return p;
+	return utils.replacePathSepForRegex(p);
 }
 
 class TestRunner {

--- a/packages/jest-cli/src/TestRunner.js
+++ b/packages/jest-cli/src/TestRunner.js
@@ -23,7 +23,7 @@ const workerFarm = require('worker-farm');
 const TEST_WORKER_PATH = require.resolve('./TestWorker');
 
 function pathToRegex(p) {
-	return utils.replacePathSepForRegex(p);
+  return utils.replacePathSepForRegex(p);
 }
 
 class TestRunner {

--- a/packages/jest-cli/src/TestRunner.js
+++ b/packages/jest-cli/src/TestRunner.js
@@ -23,7 +23,10 @@ const workerFarm = require('worker-farm');
 const TEST_WORKER_PATH = require.resolve('./TestWorker');
 
 function pathToRegex(p) {
-  return p.replace(/\//g, path.sep);
+  if (path.sep === '\\') {
+    return p.replace(/(\/|\\)/g, '\\\\');
+  }
+  return p;
 }
 
 class TestRunner {


### PR DESCRIPTION
Jest can't find tests on Windows because of a bad RegEx.

**Steps to reproduce:**
npm install
cd examples
cd getting_started
npm install
npm test

**Results:**

```
> @ test C:\dev\jest\examples\getting_started
> jest

Using Jest CLI v12.1.0, jasmine2
No tests found for "".
```

**Expected results:**
Tests should be found

**Solution:**
The **pathToRegex** function in **TestRunner.js** replaces forward slashes with the directory delimiter, which is a backslash in Windows.  However the backslash happens to be an escape character in RegEx, so the RegEx produced by this substitution is bogus and paths aren't evaluated properly.  The solution is to use a double backslash.  A similar function already exists in the **jest-util** package, but it gets this right.  All I'm doing in this PR is copying the jest-util function to TestRunner.