### PR TITLE
Make `Resolver.resolveModule` error node-compliant

### DIFF
--- a/packages/jest-resolve/src/index.js
+++ b/packages/jest-resolve/src/index.js
@@ -114,9 +114,11 @@ class Resolver {
     //    only produces an error based on the dirname but we have the actual
     //    current module name available.
     const relativePath = path.relative(dirname, from);
-    throw new Error(
+    const err = new Error(
       `Cannot find module '${moduleName}' from '${relativePath || '.'}'`
     );
+    err.code = 'MODULE_NOT_FOUND';
+    throw err;
   }
 
   isCoreModule(moduleName) {


### PR DESCRIPTION
When you `require()` a non-existing path/module, Node.js will set the
`code` property of the thrown error to `'MODULE_NOT_FOUND'`.

This change ensures that jest behaves the same way so that other code
relying on this specific value of the `error.code` continues to work.

For the Node.js module/error specification, please see:
https://github.com/nodejs/node/blob/v6.2.0/doc/api/modules.md#file-modules