### PR TITLE
make `toMatchSnapshot` throw if chained with `.not`

### DIFF
--- a/integration_tests/__tests__/snapshot-test.js
+++ b/integration_tests/__tests__/snapshot-test.js
@@ -28,8 +28,8 @@ describe('Snapshot', () => {
     const result = runJest.json('snapshot', []);
     const json = result.json;
 
-    expect(json.numTotalTests).toBe(2);
-    expect(json.numPassedTests).toBe(2);
+    expect(json.numTotalTests).toBe(3);
+    expect(json.numPassedTests).toBe(3);
     expect(json.numFailedTests).toBe(0);
     expect(json.numPendingTests).toBe(0);
     expect(result.status).toBe(0);

--- a/integration_tests/snapshot/__tests__/snapshot.js
+++ b/integration_tests/snapshot/__tests__/snapshot.js
@@ -31,4 +31,7 @@ describe('snapshot', () => {
     expect(JSON.stringify(test)).toMatchSnapshot();
   });
 
+  it('cannot be used chained with .not', () => {
+    expect(() => expect('').not.toMatchSnapshot()).toThrow();
+  });
 });

--- a/packages/jest-snapshot/src/getMatchers.js
+++ b/packages/jest-snapshot/src/getMatchers.js
@@ -10,6 +10,11 @@
 module.exports = (filePath, options, jasmine, snapshotState) => ({
   toMatchSnapshot: (util, customEquality) => {
     return {
+      negativeCompare() {
+        throw new Error(
+          'Jest: `.not` can not be used with `.toMatchSnapShot()`.'
+        );
+      },
       compare(rendered, expected) {
 
         const currentSpecName = snapshotState.currentSpecName;


### PR DESCRIPTION
Prevent `toMatchSnapshot` from being used with `.not` as it doesn't make sense:

Here' s an example where I force triggered the error (it's not in the code of this PR):
<img width="601" alt="screen shot 2016-05-25 at 10 44 42 am" src="https://cloud.githubusercontent.com/assets/87300/15535633/19138fd8-2266-11e6-8ef7-63997d8270b9.png">
