### PR TITLE
Add documentation about full paths for *IgnorePatterns options

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -466,6 +466,8 @@ If you are using TypeScript this should be `['js', 'json', 'ts']`
 
 An array of regexp pattern strings that are matched against all module paths before those paths are to be considered 'visible' to the module loader. If a given module's path matches any of the patterns, it will not be `require()`-able in the test environment.
 
+These pattern strings match against the full path. Use the `<rootDir>` string token to  include the path to your project's root directory to prevent it from accidentally ignoring all of your files in different environments that may have different root directories. Example: `['<rootDir>/build/']`.
+
 ### `modulePaths` [array<string>]
 (default: `[]`)
 
@@ -520,6 +522,8 @@ Examples of such compilers include [jstransform](http://github.com/facebook/jstr
 
 An array of regexp pattern strings that are matched against all source file paths before preprocessing. If the test path matches any of the patterns, it will not be preprocessed.
 
+These pattern strings match against the full path. Use the `<rootDir>` string token to  include the path to your project's root directory to prevent it from accidentally ignoring all of your files in different environments that may have different root directories. Example: `['<rootDir>/bower_components/', '<rootDir>/node_modules/']`.
+
 *Note: if this option is not specified by the user and Jest detects the project as a [react-native](https://github.com/facebook/react-native) project, it will ignore the default and process every file. It is common on react-native projects to ship npm modules without pre-compiling JavaScript.*
 
 ### `setupFiles` [array]
@@ -552,6 +556,8 @@ There are times where you only want Jest to search in a single sub-directory (su
 (default: `['/node_modules/']`)
 
 An array of regexp pattern strings that are matched against all test paths before executing the test. If the test path matches any of the patterns, it will be skipped.
+
+These pattern strings match against the full path. Use the `<rootDir>` string token to  include the path to your project's root directory to prevent it from accidentally ignoring all of your files in different environments that may have different root directories. Example: `['<rootDir>/build/', '<rootDir>/node_modules/']`.
 
 ### `testPathPattern` [string]
 (default: `/.*/`) - See notes below for more details on the default setting.


### PR DESCRIPTION
I was recently bit by a problem where my tests were running perfectly
locally, but were passing in Travis CI without running any tests. I
traced this down to the following configuration I had added:

```json
  "jest": {
    "testPathIgnorePatterns": [
      "/node_modules/",
      "/build/"
    ]
  }
```

Since I was unaware that these patterns were matching against the full
path, it took me a while to realize that `/build/` is part of the root
path for all Travis CI runs, and that this pattern was causing all of my
tests to be ignored.

We discussed this a little in #1047 and have opened #1057 to make
this scenario clearer, but I think that the better documentation would
also help prevent people from getting into this pickle in the first
place.

The solution for my problem was to add the `<rootDir>` string token to
my patterns, to make them include the root directory, preventing them
from matching, and ignoring, every file:

```json
  "jest": {
    "testPathIgnorePatterns": [
      "<rootDir>/node_modules/",
      "<rootDir>/build/"
    ]
  }
```

I tried to tailor the examples to each specific option, but as I'm not
that familiar with all of these configuration options, I may have missed
the mark on some of them.

I think that the defaults should perhaps also be changed to include the
`<rootDir>` string token as well, but I'll leave that for another
commit.