### PR TITLE
[haste] Don’t match directories that begin with a whitelisted pattern

### DIFF
--- a/packages/jest-haste-map/src/__tests__/index-test.js
+++ b/packages/jest-haste-map/src/__tests__/index-test.js
@@ -223,6 +223,12 @@ describe('HasteMap', () => {
       ' */',
       'const Test = require("Test");',
     ].join('\n');
+    mockFs['/fruits/node_modules/fbjs2/index.js'] = [
+      '/**',
+      ' * @providesModule fbjs2',
+      ' */',
+    ].join('\n');
+
 
     const hasteMap = new HasteMap(Object.assign({}, defaultConfig, {
       mocksPattern: '/__mocks__/',

--- a/packages/jest-haste-map/src/index.js
+++ b/packages/jest-haste-map/src/index.js
@@ -125,7 +125,7 @@ class HasteMap {
 
     const list = options.providesModuleNodeModules;
     this._whitelist = (list && list.length)
-      ? new RegExp('(' + NODE_MODULES + '(?:' + list.join('|') + '))', 'g')
+      ? new RegExp('(' + NODE_MODULES + '(?:' + list.join('|') + ')(?=$|' + path.sep + '))', 'g')
       : null;
 
     this._cachePath = HasteMap.getCacheFilePath(


### PR DESCRIPTION
The haste map implementation would include directories that start with a whitelisted directory name, e.g. `'parse5'` for `{providesModuleNodeModules: ['parse']}'.