### PR TITLE
add summary to snapshots

### DIFF
--- a/packages/jest-cli/src/reporters/DefaultTestReporter.js
+++ b/packages/jest-cli/src/reporters/DefaultTestReporter.js
@@ -19,14 +19,15 @@ const FAIL = chalk.reset.bold.bgRed(' FAIL ');
 const PASS = chalk.reset.bold.bgGreen(' PASS ');
 
 const FAIL_COLOR = chalk.bold.red;
+const LONG_TEST_COLOR = chalk.reset.bold.bgRed;
 const PASS_COLOR = chalk.bold.green;
 const PENDING_COLOR = chalk.bold.yellow;
 const RUNNING_TEST_COLOR = chalk.bold.gray;
+const SNAPSHOT_SUMMARY = chalk.bold.green;
 const TEST_NAME_COLOR = chalk.bold;
-const LONG_TEST_COLOR = chalk.reset.bold.bgRed;
 
 const print = (word, count) => `${count} ${word}${count === 1 ? '' : 's'}`;
-
+const pluralizeSnapshot = num => 'snapshot' + (num > 1 ? 's' : '');
 class DefaultTestReporter {
 
   constructor(customProcess) {
@@ -137,6 +138,37 @@ class DefaultTestReporter {
     if (pendingTests) {
       results +=
         `${PENDING_COLOR(`${print('test', pendingTests)} skipped`)}, `;
+    }
+
+    let snapshotsAdded = 0;
+    let snapshotsFiles = 0;
+    let snapshotsMatched = 0;
+    let snapshotsRemoved = 0;
+    aggregatedResults.testResults.forEach(result => {
+      if (result.snapshotsAdded) {
+        snapshotsFiles++;
+      }
+      snapshotsAdded += result.snapshotsAdded;
+      snapshotsMatched += result.snapshotsMatched;
+      snapshotsRemoved += result.snapshotsRemoved;
+    });
+    if (snapshotsAdded || snapshotsMatched) {
+      results += `${SNAPSHOT_SUMMARY('Snapshot Summary')}\n`;
+      if (snapshotsAdded) {
+        results +=
+          `* ${snapshotsAdded} ${pluralizeSnapshot(snapshotsAdded)} written ` +
+          `in ${snapshotsFiles} test file${snapshotsFiles > 1 ? 's' :''}\n`;
+      }
+      if (snapshotsRemoved) {
+        results +=
+          `* ${snapshotsRemoved} ${pluralizeSnapshot(snapshotsRemoved)} `+
+          `deleted\n`;
+      }
+      if (snapshotsMatched) {
+        results +=
+          `* ${snapshotsMatched} ${pluralizeSnapshot(snapshotsMatched)} `+
+          `were unchanged\n`;
+      }
     }
 
     results +=

--- a/packages/jest-cli/src/reporters/DefaultTestReporter.js
+++ b/packages/jest-cli/src/reporters/DefaultTestReporter.js
@@ -23,11 +23,13 @@ const LONG_TEST_COLOR = chalk.reset.bold.bgRed;
 const PASS_COLOR = chalk.bold.green;
 const PENDING_COLOR = chalk.bold.yellow;
 const RUNNING_TEST_COLOR = chalk.bold.gray;
+const SNAPSHOT_ADDED = chalk.bold.yellow;
+const SNAPSHOT_MATCHED = chalk.bold.green;
+const SNAPSHOT_REMOVED = chalk.bold.red;
 const SNAPSHOT_SUMMARY = chalk.bold.green;
 const TEST_NAME_COLOR = chalk.bold;
 
-const print = (word, count) => `${count} ${word}${count === 1 ? '' : 's'}`;
-const pluralizeSnapshot = num => 'snapshot' + (num > 1 ? 's' : '');
+const pluralize = (word, count) => `${count} ${word}${count === 1 ? '' : 's'}`;
 class DefaultTestReporter {
 
   constructor(customProcess) {
@@ -127,17 +129,17 @@ class DefaultTestReporter {
     let results = '';
     if (failedTests) {
       results +=
-        `${FAIL_COLOR(`${print('test', failedTests)} failed`)}, `;
+        `${FAIL_COLOR(`${pluralize('test', failedTests)} failed`)}, `;
     }
 
     if (totalErrors) {
       results +=
-        `${FAIL_COLOR(`${print('test suite', totalErrors)} failed`)}, `;
+        `${FAIL_COLOR(`${pluralize('test suite', totalErrors)} failed`)}, `;
     }
 
     if (pendingTests) {
       results +=
-        `${PENDING_COLOR(`${print('test', pendingTests)} skipped`)}, `;
+        `${PENDING_COLOR(`${pluralize('test', pendingTests)} skipped`)}, `;
     }
 
     let snapshotsAdded = 0;
@@ -152,28 +154,31 @@ class DefaultTestReporter {
       snapshotsMatched += result.snapshotsMatched;
       snapshotsRemoved += result.snapshotsRemoved;
     });
-    if (snapshotsAdded || snapshotsMatched) {
-      results += `${SNAPSHOT_SUMMARY('Snapshot Summary')}\n`;
+    if (snapshotsAdded || snapshotsRemoved || snapshotsMatched) {
+      results += `${SNAPSHOT_SUMMARY('Snapshot Summary')}.\n`;
       if (snapshotsAdded) {
         results +=
-          `* ${snapshotsAdded} ${pluralizeSnapshot(snapshotsAdded)} written ` +
-          `in ${snapshotsFiles} test file${snapshotsFiles > 1 ? 's' :''}\n`;
+          `\u203A ` +
+          `${SNAPSHOT_ADDED(pluralize('snapshot', snapshotsAdded))} ` +
+          `written in ${pluralize('test file', snapshotsFiles)}.\n`;
       }
       if (snapshotsRemoved) {
         results +=
-          `* ${snapshotsRemoved} ${pluralizeSnapshot(snapshotsRemoved)} `+
-          `deleted\n`;
+          `\u203A ` +
+          `${SNAPSHOT_REMOVED(pluralize('snapshot', snapshotsRemoved))} ` +
+          `deleted.\n`;
       }
       if (snapshotsMatched) {
         results +=
-          `* ${snapshotsMatched} ${pluralizeSnapshot(snapshotsMatched)} `+
-          `were unchanged\n`;
+          `\u203A ` +
+          `${SNAPSHOT_MATCHED(pluralize('snapshot', snapshotsMatched))} ` +
+          `were unchanged.\n`;
       }
     }
 
     results +=
-      `${PASS_COLOR(`${print('test', passedTests)} passed`)} ` +
-      `(${totalTests} total in ${print('test suite', totalTestSuites)}, ` +
+      `${PASS_COLOR(`${pluralize('test', passedTests)} passed`)} ` +
+      `(${totalTests} total in ${pluralize('test suite', totalTestSuites)}, ` +
       `run time ${runTime}s)`;
 
     this.log(results);
@@ -190,7 +195,7 @@ class DefaultTestReporter {
       results.numRuntimeErrorTestSuites;
     if (!this._config.noHighlight && remaining > 0) {
       this._process.stdout.write(RUNNING_TEST_COLOR(
-        `Running ${print('test suite', remaining)}...`
+        `Running ${pluralize('test suite', remaining)}...`
       ));
     }
   }

--- a/packages/jest-cli/src/reporters/DefaultTestReporter.js
+++ b/packages/jest-cli/src/reporters/DefaultTestReporter.js
@@ -24,7 +24,6 @@ const PASS_COLOR = chalk.bold.green;
 const PENDING_COLOR = chalk.bold.yellow;
 const RUNNING_TEST_COLOR = chalk.bold.gray;
 const SNAPSHOT_ADDED = chalk.bold.yellow;
-const SNAPSHOT_MATCHED = chalk.bold.green;
 const SNAPSHOT_REMOVED = chalk.bold.red;
 const SNAPSHOT_SUMMARY = chalk.bold.green;
 const TEST_NAME_COLOR = chalk.bold;
@@ -154,7 +153,7 @@ class DefaultTestReporter {
       snapshotsMatched += result.snapshotsMatched;
       snapshotsRemoved += result.snapshotsRemoved;
     });
-    if (snapshotsAdded || snapshotsRemoved || snapshotsMatched) {
+    if (snapshotsAdded || snapshotsRemoved) {
       results += `${SNAPSHOT_SUMMARY('Snapshot Summary')}.\n`;
       if (snapshotsAdded) {
         results +=
@@ -168,18 +167,18 @@ class DefaultTestReporter {
           `${SNAPSHOT_REMOVED(pluralize('snapshot', snapshotsRemoved))} ` +
           `deleted.\n`;
       }
-      if (snapshotsMatched) {
-        results +=
-          `\u203A ` +
-          `${SNAPSHOT_MATCHED(pluralize('snapshot', snapshotsMatched))} ` +
-          `were unchanged.\n`;
-      }
     }
+    const totalSnaphots = snapshotsMatched + snapshotsAdded;
 
     results +=
       `${PASS_COLOR(`${pluralize('test', passedTests)} passed`)} ` +
-      `(${totalTests} total in ${pluralize('test suite', totalTestSuites)}, ` +
-      `run time ${runTime}s)`;
+      `(${totalTests} total in ${pluralize('test suite', totalTestSuites)}, `;
+
+    if (totalSnaphots) {
+      results += `${pluralize('snapshot', totalSnaphots)}, `;
+    }
+
+    results +=  `run time ${runTime}s)`;
 
     this.log(results);
   }

--- a/packages/jest-jasmine2/src/index.js
+++ b/packages/jest-jasmine2/src/index.js
@@ -265,7 +265,12 @@ function jasmine2(config, environment, moduleLoader, testPath) {
   env.execute();
   env.snapshotState.snapshot.save();
 
-  return reporter.getResults();
+  return reporter.getResults().then(results => {
+    results.snapshotsAdded = env.snapshotState.snapshotsAdded;
+    results.snapshotsRemoved = env.snapshotState.snapshotsRemoved;
+    results.snapshotsMatched = env.snapshotState.snapshotsMatched;
+    return results;
+  });
 }
 
 module.exports = jasmine2;

--- a/packages/jest-jasmine2/src/index.js
+++ b/packages/jest-jasmine2/src/index.js
@@ -266,9 +266,9 @@ function jasmine2(config, environment, moduleLoader, testPath) {
   env.snapshotState.snapshot.save();
 
   return reporter.getResults().then(results => {
-    results.snapshotsAdded = env.snapshotState.snapshotsAdded;
-    results.snapshotsRemoved = env.snapshotState.snapshotsRemoved;
-    results.snapshotsMatched = env.snapshotState.snapshotsMatched;
+    results.snapshotsAdded = env.snapshotState.added;
+    results.snapshotsRemoved = env.snapshotState.removed;
+    results.snapshotsMatched = env.snapshotState.matched;
     return results;
   });
 }

--- a/packages/jest-snapshot/src/getMatchers.js
+++ b/packages/jest-snapshot/src/getMatchers.js
@@ -35,10 +35,10 @@ module.exports = (filePath, options, jasmine, snapshotState) => ({
           !snapshot.has(key)
         ) {
           if (options.updateSnapshot && snapshot.has(key)) {
-            snapshotState.snapshotsRemoved++;
+            snapshotState.removed++;
           }
           snapshot.add(key, rendered);
-          snapshotState.snapshotsAdded++;
+          snapshotState.added++;
           pass = true;
         } else {
           pass = snapshot.matches(key, rendered);
@@ -59,7 +59,7 @@ module.exports = (filePath, options, jasmine, snapshotState) => ({
               'toMatchSnapshot #' + (callCount + 1) + ':'
             );
           } else {
-            snapshotState.snapshotsMatched++;
+            snapshotState.matched++;
           }
         }
 

--- a/packages/jest-snapshot/src/getMatchers.js
+++ b/packages/jest-snapshot/src/getMatchers.js
@@ -34,7 +34,11 @@ module.exports = (filePath, options, jasmine, snapshotState) => ({
           (snapshot.has(key) && options.updateSnapshot) ||
           !snapshot.has(key)
         ) {
+          if (options.updateSnapshot && snapshot.has(key)) {
+            snapshotState.snapshotsRemoved++;
+          }
           snapshot.add(key, rendered);
+          snapshotState.snapshotsAdded++;
           pass = true;
         } else {
           pass = snapshot.matches(key, rendered);
@@ -54,6 +58,8 @@ module.exports = (filePath, options, jasmine, snapshotState) => ({
               'toMatchSnapshot:',
               'toMatchSnapshot #' + (callCount + 1) + ':'
             );
+          } else {
+            snapshotState.snapshotsMatched++;
           }
         }
 

--- a/packages/jest-snapshot/src/index.js
+++ b/packages/jest-snapshot/src/index.js
@@ -48,9 +48,9 @@ module.exports = {
     state.getCounter = null;
     state.incrementCounter = null;
     state.snapshot = SnapshotFile.forFile(filePath);
-    state.snapshotsAdded = 0;
-    state.snapshotsRemoved = 0;
-    state.snapshotsMatched = 0;
+    state.added = 0;
+    state.removed = 0;
+    state.matched = 0;
 
     patchJasmine(jasmine, state);
     return state;

--- a/packages/jest-snapshot/src/index.js
+++ b/packages/jest-snapshot/src/index.js
@@ -48,6 +48,10 @@ module.exports = {
     state.getCounter = null;
     state.incrementCounter = null;
     state.snapshot = SnapshotFile.forFile(filePath);
+    state.snapshotsAdded = 0;
+    state.snapshotsRemoved = 0;
+    state.snapshotsMatched = 0;
+
     patchJasmine(jasmine, state);
     return state;
   },


### PR DESCRIPTION
Adding an handy summary for snapshots after a test run
Here's two test run, the first one matches all the snapshots, the second one overwrites everything:

![screen shot 2016-05-25 at 6 35 52 pm](https://cloud.githubusercontent.com/assets/87300/15550149/fc28817a-22a7-11e6-95fe-97d499a0050e.png)
