### PR TITLE
Improve coverage accuracy for TypeScript preprocessor example.

### DIFF
--- a/examples/typescript/preprocessor.js
+++ b/examples/typescript/preprocessor.js
@@ -5,7 +5,7 @@ const tsc = require('typescript');
 module.exports = {
   process(src, path) {
     if (path.endsWith('.ts') || path.endsWith('.tsx')) {
-      return tsc.transpile(
+      let code = tsc.transpile(
         src,
         {
           module: tsc.ModuleKind.CommonJS,
@@ -14,6 +14,9 @@ module.exports = {
         path,
         []
       );
+      code = code.replace(/(}\)\()(.*\|\|.*;)/g, '$1/* istanbul ignore next */$2');
+      code = code.replace(/(var __extends = \(this && this.__extends\))/g, '$1/* istanbul ignore next */');
+      return code;
     }
     return src;
   },

--- a/examples/typescript/preprocessor.js
+++ b/examples/typescript/preprocessor.js
@@ -3,21 +3,20 @@
 const tsc = require('typescript');
 
 module.exports = {
-  process(src, path) {
-    if (path.endsWith('.ts') || path.endsWith('.tsx')) {
-      let code = tsc.transpile(
-        src,
-        {
-          module: tsc.ModuleKind.CommonJS,
-          jsx: tsc.JsxEmit.React,
-        },
-        path,
-        []
-      );
-      code = code.replace(/(}\)\()(.*\|\|.*;)/g, '$1/* istanbul ignore next */$2');
-      code = code.replace(/(var __extends = \(this && this.__extends\))/g, '$1/* istanbul ignore next */');
-      return code;
-    }
-    return src;
-  },
+    process(src, path) {
+        if (path.endsWith('.ts') || path.endsWith('.tsx')) {
+            return tsc.transpile(
+                src, {
+                    module: tsc.ModuleKind.CommonJS,
+                    jsx: tsc.JsxEmit.React,
+                },
+                path, []
+            )
+            .replace(/(}\)\()(.*\|\|.*;)/g, '$1/* istanbul ignore next */$2')
+            .replace(/(var __extends = \(this && this.__extends\))/g, '$1/* istanbul ignore next */')
+            .replace(/(var __assign = \(this && this.__assign\) \|\| Object.assign)/g, '$1 /* istanbul ignore next */');
+        }
+        return src;
+    },
 };
+


### PR DESCRIPTION
Note: These changes are 100% the result of reading [this stackoverflow answer](http://stackoverflow.com/a/33024388/3990593) and all credit must really go to @TwitchBronBron

What these changes do is add istanbul ignore statements to the transpiled code so that the reported coverage better reflects reality on coverage reports. (Without this, the generated `__extends`, `__assign`, etc statements mess with coverage reports)

Tested a few times and it seems to be working great.