### PR TITLE
Fixes notification of updated and removed snapshots

### DIFF
--- a/packages/jest-cli/src/reporters/DefaultTestReporter.js
+++ b/packages/jest-cli/src/reporters/DefaultTestReporter.js
@@ -24,7 +24,7 @@ const PASS_COLOR = chalk.bold.green;
 const PENDING_COLOR = chalk.bold.yellow;
 const RUNNING_TEST_COLOR = chalk.bold.gray;
 const SNAPSHOT_ADDED = chalk.bold.yellow;
-const SNAPSHOT_REMOVED = chalk.bold.red;
+const SNAPSHOT_UPDATED = chalk.bold.yellow;
 const SNAPSHOT_SUMMARY = chalk.bold.green;
 const TEST_NAME_COLOR = chalk.bold;
 
@@ -144,16 +144,20 @@ class DefaultTestReporter {
     let snapshotsAdded = 0;
     let snapshotsFiles = 0;
     let snapshotsMatched = 0;
-    let snapshotsRemoved = 0;
+    let snapshotsUpdated = 0;
     aggregatedResults.testResults.forEach(result => {
-      if (result.snapshotsAdded) {
+      if (
+        result.snapshotsAdded ||
+        result.snapshotsMatched ||
+        result.snapshotsUpdated
+      ) {
         snapshotsFiles++;
       }
       snapshotsAdded += result.snapshotsAdded;
       snapshotsMatched += result.snapshotsMatched;
-      snapshotsRemoved += result.snapshotsRemoved;
+      snapshotsUpdated += result.snapshotsUpdated;
     });
-    if (snapshotsAdded || snapshotsRemoved) {
+    if (snapshotsAdded || snapshotsUpdated) {
       results += `${SNAPSHOT_SUMMARY('Snapshot Summary')}.\n`;
       if (snapshotsAdded) {
         results +=
@@ -161,14 +165,15 @@ class DefaultTestReporter {
           `${SNAPSHOT_ADDED(pluralize('snapshot', snapshotsAdded))} ` +
           `written in ${pluralize('test file', snapshotsFiles)}.\n`;
       }
-      if (snapshotsRemoved) {
+      if (snapshotsUpdated) {
         results +=
           `\u203A ` +
-          `${SNAPSHOT_REMOVED(pluralize('snapshot', snapshotsRemoved))} ` +
-          `deleted.\n`;
+          `${SNAPSHOT_UPDATED(pluralize('snapshot', snapshotsUpdated))} ` +
+          `updated.\n`;
       }
     }
-    const totalSnaphots = snapshotsMatched + snapshotsAdded;
+
+    const totalSnaphots = snapshotsMatched + snapshotsAdded + snapshotsUpdated;
 
     results +=
       `${PASS_COLOR(`${pluralize('test', passedTests)} passed`)} ` +

--- a/packages/jest-jasmine2/src/index.js
+++ b/packages/jest-jasmine2/src/index.js
@@ -273,7 +273,7 @@ function jasmine2(config, environment, moduleLoader, testPath) {
 
   return reporter.getResults().then(results => {
     results.snapshotsAdded = env.snapshotState.added;
-    results.snapshotsRemoved = env.snapshotState.removed;
+    results.snapshotsUpdated = env.snapshotState.updated;
     results.snapshotsMatched = env.snapshotState.matched;
     return results;
   });

--- a/packages/jest-snapshot/src/getMatchers.js
+++ b/packages/jest-snapshot/src/getMatchers.js
@@ -39,18 +39,18 @@ module.exports = (filePath, options, jasmine, snapshotState) => ({
           !snapshot.has(key)
         ) {
           if (options.updateSnapshot) {
-            if (!snapshot.matches(key, rendered)) {
-              snapshotState.removed++;
-              snapshotState.added++;
-              snapshot.add(key, rendered);
+            if (!snapshot.matches(key, actual).pass) {
+              snapshotState.updated++;
+              snapshot.add(key, actual);
+            } else {
+              snapshotState.matched++;
             }
           } else {
-            snapshot.add(key, rendered);
+            snapshot.add(key, actual);
             snapshotState.added++;
-          } 
+          }
           pass = true;
         } else {
-          actual = snapshot.serialize(actual);
           const matches = snapshot.matches(key, actual);
           pass = matches.pass;
           if (!pass) {

--- a/packages/jest-snapshot/src/getMatchers.js
+++ b/packages/jest-snapshot/src/getMatchers.js
@@ -38,11 +38,16 @@ module.exports = (filePath, options, jasmine, snapshotState) => ({
           (snapshot.has(key) && options.updateSnapshot) ||
           !snapshot.has(key)
         ) {
-          if (options.updateSnapshot && snapshot.has(key)) {
-            snapshotState.removed++;
-          }
-          snapshot.add(key, actual);
-          snapshotState.added++;
+          if (options.updateSnapshot) {
+            if (!snapshot.matches(key, rendered)) {
+              snapshotState.removed++;
+              snapshotState.added++;
+              snapshot.add(key, rendered);
+            }
+          } else {
+            snapshot.add(key, rendered);
+            snapshotState.added++;
+          } 
           pass = true;
         } else {
           actual = snapshot.serialize(actual);

--- a/packages/jest-snapshot/src/index.js
+++ b/packages/jest-snapshot/src/index.js
@@ -49,7 +49,7 @@ module.exports = {
     state.incrementCounter = null;
     state.snapshot = SnapshotFile.forFile(filePath);
     state.added = 0;
-    state.removed = 0;
+    state.updated = 0;
     state.matched = 0;
 
     patchJasmine(jasmine, state);


### PR DESCRIPTION
Before this change the updateSnapshot flag was just rewriting all the
snapshot, now it just updates those that are not equals providing
better information in the summary