### PR TITLE
implement snapshots validation

### DIFF
--- a/integration_tests/__tests__/snapshot-test.js
+++ b/integration_tests/__tests__/snapshot-test.js
@@ -21,7 +21,7 @@ const secondSnapshotFile = path.resolve(
   snapshotDir,
   'second-snapshot-test.js.snap'
 );
-const snapshotCopy = path.resolve(snapshotDir, 'snapshot_copy.js.snap');
+const snapshotCopy = path.resolve(snapshotDir, 'snapshot-test_copy.js.snap');
 const fileExists = filePath => {
   try {
     fs.accessSync(filePath, fs.R_OK);
@@ -32,7 +32,7 @@ const fileExists = filePath => {
 const getSnapshotCopy = () => {
   const exports = Object.create(null);
   // eslint-disable-next-line no-eval
-  eval(fs.readFileSync(snapshotCopy));  
+  eval(fs.readFileSync(snapshotCopy, 'utf-8'));
   return exports;
 };
 
@@ -63,7 +63,7 @@ describe('Snapshot', () => {
   describe('Validation', () => {
     const pathToOriginal = path.resolve(
       __dirname,
-      '../snapshot/__tests__/snapshot.js'
+      '../snapshot/__tests__/snapshot-test.js'
     );
     const originalContent = String(fs.readFileSync(pathToOriginal));
     const pathToCopy = pathToOriginal.replace('.js', '_copy.js');
@@ -77,8 +77,8 @@ describe('Snapshot', () => {
       expect(content).not.toBe(undefined);
       const secondRun = runJest.json('snapshot', []);
 
-      expect(firstRun.json.numTotalTests).toBe(6);
-      expect(secondRun.json.numTotalTests).toBe(3);
+      expect(firstRun.json.numTotalTests).toBe(7);
+      expect(secondRun.json.numTotalTests).toBe(4);
       expect(fileExists(snapshotCopy)).toBe(false);
 
     });
@@ -92,8 +92,8 @@ describe('Snapshot', () => {
       const secondRun = runJest.json('snapshot', []);
       fs.unlinkSync(pathToCopy);
 
-      expect(firstRun.json.numTotalTests).toBe(6);
-      expect(secondRun.json.numTotalTests).toBe(4);
+      expect(firstRun.json.numTotalTests).toBe(7);
+      expect(secondRun.json.numTotalTests).toBe(5);
       expect(fileExists(snapshotCopy)).toBe(false);
     });
 
@@ -111,8 +111,8 @@ describe('Snapshot', () => {
       const secondRun = runJest.json('snapshot', []);
       fs.unlinkSync(pathToCopy);
 
-      expect(firstRun.json.numTotalTests).toBe(6);
-      expect(secondRun.json.numTotalTests).toBe(6);
+      expect(firstRun.json.numTotalTests).toBe(7);
+      expect(secondRun.json.numTotalTests).toBe(7);
       expect(fileExists(snapshotCopy)).toBe(true);
       const afterRemovingSnapshot = getSnapshotCopy();
 

--- a/packages/jest-cli/package.json
+++ b/packages/jest-cli/package.json
@@ -17,6 +17,7 @@
     "jest-mock": "^12.1.0",
     "jest-resolve": "^12.1.1",
     "jest-util": "^12.1.0",
+    "jest-snapshot": "^12.1.0",
     "json-stable-stringify": "^1.0.0",
     "lodash.template": "^4.2.4",
     "sane": "^1.2.0",

--- a/packages/jest-cli/src/TestRunner.js
+++ b/packages/jest-cli/src/TestRunner.js
@@ -161,7 +161,7 @@ class TestRunner {
         return this._hasteMap.then(
           hasteMap => snapshot.cleanup(hasteMap)
         ).then(deletedSnapshot => {
-          aggregatedResults.snapshotFilesDeleted = deletedSnapshot.count;
+          aggregatedResults.snapshotFilesDeleted = deletedSnapshot.size;
           if (reporter.onRunComplete) {
             reporter.onRunComplete(config, aggregatedResults);
           }

--- a/packages/jest-cli/src/TestRunner.js
+++ b/packages/jest-cli/src/TestRunner.js
@@ -25,32 +25,12 @@ const fileExists = filePath => {
   return false;
 };
 
-function pathToRegex(p) {
-  return utils.replacePathSepForRegex(p);
-}
-
 class TestRunner {
 
   constructor(hasteMap, config, options) {
     this._hasteMap = hasteMap;
     this._config = config;
     this._options = options;
-    this._config = Object.freeze(config);
-
-    utils.createDirectory(this._config.cacheDirectory);
-
-    config.moduleFileExtensions.push('snap');
-    this._hasteMap = createHasteMap(config, {
-      maxWorkers: this._options.maxWorkers,
-      resetCache: !config.cache,
-    });
-
-    this._testPathDirPattern =
-      new RegExp(config.testPathDirs.map(dir => pathToRegex(dir)).join('|'));
-    this._testRegex = new RegExp(pathToRegex(config.testRegex));
-    const ignorePattern = this._config.testPathIgnorePatterns;
-    this._testIgnorePattern =
-      ignorePattern.length ? new RegExp(ignorePattern.join('|')) : null;
 
     // Map from testFilePath -> time it takes to run the test. Used to
     // optimally schedule bigger test runs.
@@ -185,22 +165,24 @@ class TestRunner {
         aggregatedResults.success =
           aggregatedResults.numFailedTests === 0 &&
           aggregatedResults.numRuntimeErrorTestSuites === 0;
-
-        return this._hasteMap.matchFiles(/\.snap/).then(res => {
-          aggregatedResults.snapshotsUnlinked = 0;
-          res.forEach(snapFile => {
-            const parts = snapFile.split('__snapshots__/');
-            const testFile = parts[0] + parts[1].slice(0, -5);
-            if (!fileExists(testFile)) {
-              fs.unlinkSync(snapFile);
-              aggregatedResults.snapshotsUnlinked++;
+        return this._hasteMap.then(
+          hasteMap => hasteMap.instance.matchFiles(/\.snap/).then(res => {
+            aggregatedResults.snapshotsUnlinked = 0;
+            res.forEach(snapFile => {
+              const parts = snapFile.split('__snapshots__/');
+              const testFile = parts[0] + parts[1].slice(0, -5);
+              if (!fileExists(testFile)) {
+                fs.unlinkSync(snapFile);
+                aggregatedResults.snapshotsUnlinked++;
+              }
+            });
+            if (reporter.onRunComplete) {
+              reporter.onRunComplete(config, aggregatedResults);
             }
-          });
-          if (reporter.onRunComplete) {
-            reporter.onRunComplete(config, aggregatedResults);
-          }
-          return aggregatedResults;
-        });
+            return aggregatedResults;
+          })
+        );
+
       })
       .then(results => this._cacheTestResults(results).then(() => results));
   }

--- a/packages/jest-cli/src/jest.js
+++ b/packages/jest-cli/src/jest.js
@@ -81,6 +81,7 @@ function getWatcher(config, packageRoot, callback) {
 function runJest(config, argv, pipe, onComplete) {
   const patternInfo = buildTestPathPatternInfo(argv);
   const maxWorkers = getMaxWorkers(argv);
+  config.moduleFileExtensions.push('snap');
   const hasteMap = buildHasteMap(config, {maxWorkers});
 
   const source = new SearchSource(hasteMap, config);

--- a/packages/jest-cli/src/jest.js
+++ b/packages/jest-cli/src/jest.js
@@ -81,7 +81,6 @@ function getWatcher(config, packageRoot, callback) {
 function runJest(config, argv, pipe, onComplete) {
   const patternInfo = buildTestPathPatternInfo(argv);
   const maxWorkers = getMaxWorkers(argv);
-  config.moduleFileExtensions.push('snap');
   const hasteMap = buildHasteMap(config, {maxWorkers});
 
   const source = new SearchSource(hasteMap, config);

--- a/packages/jest-cli/src/lib/buildHasteMap.js
+++ b/packages/jest-cli/src/lib/buildHasteMap.js
@@ -14,10 +14,12 @@ const utils = require('jest-util');
 
 module.exports = (config, options) => {
   utils.createDirectory(config.cacheDirectory);
-  return createHasteMap(config, {
+  const instance = createHasteMap(config, {
     resetCache: !config.cache,
     maxWorkers: options.maxWorkers,
-  }).build().then(moduleMap => ({
+  });
+  return instance.build().then(moduleMap => ({
+    instance,
     moduleMap,
     resolver: createResolver(config, moduleMap),
   }));

--- a/packages/jest-cli/src/lib/createHasteMap.js
+++ b/packages/jest-cli/src/lib/createHasteMap.js
@@ -9,7 +9,7 @@
 'use strict';
 
 const HasteMap = require('jest-haste-map');
-
+const SNAPSHOT_EXTENSION = require('jest-snapshot').EXTENSION;
 module.exports = function createHasteMap(config, options) {
   const ignorePattern = new RegExp(
     [config.cacheDirectory].concat(config.modulePathIgnorePatterns).join('|')
@@ -17,7 +17,7 @@ module.exports = function createHasteMap(config, options) {
 
   return new HasteMap({
     cacheDirectory: config.cacheDirectory,
-    extensions: config.moduleFileExtensions,
+    extensions: [SNAPSHOT_EXTENSION].concat(config.moduleFileExtensions),
     ignorePattern,
     maxWorkers: options && options.maxWorkers,
     mocksPattern: config.mocksPattern,

--- a/packages/jest-cli/src/reporters/DefaultTestReporter.js
+++ b/packages/jest-cli/src/reporters/DefaultTestReporter.js
@@ -25,6 +25,7 @@ const PENDING_COLOR = chalk.bold.yellow;
 const RUNNING_TEST_COLOR = chalk.bold.gray;
 const SNAPSHOT_ADDED = chalk.bold.yellow;
 const SNAPSHOT_UPDATED = chalk.bold.yellow;
+const SNAPSHOT_REMOVED = chalk.bold.red;
 const SNAPSHOT_SUMMARY = chalk.bold;
 const TEST_NAME_COLOR = chalk.bold;
 const TEST_SUMMARY_THRESHOLD = 20;

--- a/packages/jest-cli/src/reporters/DefaultTestReporter.js
+++ b/packages/jest-cli/src/reporters/DefaultTestReporter.js
@@ -162,7 +162,7 @@ class DefaultTestReporter {
       if (result.snapshotsUpdated) {
         filesUpdated++;
       }
-      if (result.snapshotFilesDeleted) {
+      if (result.snapshotFileDeleted) {
         snapshotFilesDeleted++;
       }
       if (result.hasUncheckedKeys) {

--- a/packages/jest-cli/src/reporters/DefaultTestReporter.js
+++ b/packages/jest-cli/src/reporters/DefaultTestReporter.js
@@ -25,6 +25,7 @@ const PENDING_COLOR = chalk.bold.yellow;
 const RUNNING_TEST_COLOR = chalk.bold.gray;
 const SNAPSHOT_ADDED = chalk.bold.yellow;
 const SNAPSHOT_UPDATED = chalk.bold.yellow;
+const SNAPSHOT_SUMMARY = chalk.bold;
 const TEST_NAME_COLOR = chalk.bold;
 const TEST_SUMMARY_THRESHOLD = 20;
 
@@ -178,7 +179,7 @@ class DefaultTestReporter {
 
   _printSnapshotSummary(snapshots) {
     if (snapshots.added || snapshots.updated) {
-      this.log(`${chalk.bold('Snapshot Summary')}.`);
+      this.log(`${SNAPSHOT_SUMMARY('Snapshot Summary')}.`);
       if (snapshots.added) {
         this.log(
           `\u203A ` +

--- a/packages/jest-cli/src/reporters/DefaultTestReporter.js
+++ b/packages/jest-cli/src/reporters/DefaultTestReporter.js
@@ -157,12 +157,16 @@ class DefaultTestReporter {
     let filesUpdated = 0;
     let matched = 0;
     let updated = 0;
+    let snapshotsUnlinked = aggregatedResults.snapshotsUnlinked;
     aggregatedResults.testResults.forEach(result => {
       if (result.snapshotsAdded) {
         filesAdded++;
       }
       if (result.snapshotsUpdated) {
         filesUpdated++;
+      }
+      if (result.snapshotsUnlinked) {
+        snapshotsUnlinked++;
       }
       added += result.snapshotsAdded;
       matched += result.snapshotsMatched;
@@ -172,13 +176,14 @@ class DefaultTestReporter {
       added,
       filesAdded,
       filesUpdated,
+      filesRemoved: snapshotsUnlinked,
       matched,
       updated,
     }
   }
 
   _printSnapshotSummary(snapshots) {
-    if (snapshots.added || snapshots.updated) {
+    if (snapshots.added || snapshots.updated || snapshots.filesRemoved) {
       this.log(`${SNAPSHOT_SUMMARY('Snapshot Summary')}.`);
       if (snapshots.added) {
         this.log(
@@ -193,6 +198,12 @@ class DefaultTestReporter {
           `${SNAPSHOT_UPDATED(pluralize('snapshot', snapshots.updated))} ` +
           `updated in ${pluralize('test file', snapshots.filesUpdated)}.`
         );
+      }
+      if (snapshots.filesRemoved) {
+        results +=
+        `\u203A ` +
+        `${SNAPSHOT_REMOVED(pluralize('snapshot file', snapshots.filesRemoved))} ` +
+        `removed.\n`;
       }
     }
   }

--- a/packages/jest-cli/src/reporters/DefaultTestReporter.js
+++ b/packages/jest-cli/src/reporters/DefaultTestReporter.js
@@ -180,7 +180,7 @@ class DefaultTestReporter {
       filesRemoved: snapshotsUnlinked,
       matched,
       updated,
-    }
+    };
   }
 
   _printSnapshotSummary(snapshots) {
@@ -201,10 +201,11 @@ class DefaultTestReporter {
         );
       }
       if (snapshots.filesRemoved) {
-        results +=
-        `\u203A ` +
-        `${SNAPSHOT_REMOVED(pluralize('snapshot file', snapshots.filesRemoved))} ` +
-        `removed.\n`;
+        this.log(
+          `\u203A ` +
+          `${SNAPSHOT_REMOVED(pluralize('snapshot file', snapshots.filesRemoved))} ` +
+          `removed.\n`
+        );
       }
     }
   }

--- a/packages/jest-jasmine2/src/index.js
+++ b/packages/jest-jasmine2/src/index.js
@@ -280,10 +280,10 @@ function jasmine2(config, environment, moduleLoader, testPath) {
     results.snapshotsAdded = env.snapshotState.added;
     results.snapshotsUpdated = env.snapshotState.updated;
     results.snapshotsMatched = env.snapshotState.matched;
-    results.snapshotFilesDeleted = 0;    
+    results.snapshotFileDeleted = 0;
     results.hasUncheckedKeys = currentSnapshot.hasUncheckedKeys();
     if (status.deleted) {
-      results.snapshotFilesDeleted++;
+      results.snapshotFileDeleted++;
     }
     return results;
   });

--- a/packages/jest-jasmine2/src/index.js
+++ b/packages/jest-jasmine2/src/index.js
@@ -269,14 +269,21 @@ function jasmine2(config, environment, moduleLoader, testPath) {
   env.addReporter(reporter);
   moduleLoader.requireModule(testPath);
   env.execute();
-  const operationResult = env.snapshotState.snapshot.save();
+  const currentSnapshot = env.snapshotState.snapshot;
+  const updateSnapshot = config.updateSnapshot;
+  if (updateSnapshot) {
+    currentSnapshot.removeUncheckedKeys();
+  }
+  const status = currentSnapshot.save(updateSnapshot);
 
   return reporter.getResults().then(results => {
     results.snapshotsAdded = env.snapshotState.added;
     results.snapshotsUpdated = env.snapshotState.updated;
     results.snapshotsMatched = env.snapshotState.matched;
-    if (operationResult.deleted) {
-      results.snapshotsUnlinked = 1;
+    results.snapshotFilesDeleted = 0;    
+    results.hasUncheckedKeys = currentSnapshot.hasUncheckedKeys();
+    if (status.deleted) {
+      results.snapshotFilesDeleted++;
     }
     return results;
   });

--- a/packages/jest-jasmine2/src/index.js
+++ b/packages/jest-jasmine2/src/index.js
@@ -269,12 +269,15 @@ function jasmine2(config, environment, moduleLoader, testPath) {
   env.addReporter(reporter);
   moduleLoader.requireModule(testPath);
   env.execute();
-  env.snapshotState.snapshot.save();
+  const operationResult = env.snapshotState.snapshot.save();
 
   return reporter.getResults().then(results => {
     results.snapshotsAdded = env.snapshotState.added;
     results.snapshotsUpdated = env.snapshotState.updated;
     results.snapshotsMatched = env.snapshotState.matched;
+    if (operationResult.deleted) {
+      results.snapshotsUnlinked = 1;
+    }
     return results;
   });
 }

--- a/packages/jest-snapshot/src/SnapshotFile.js
+++ b/packages/jest-snapshot/src/SnapshotFile.js
@@ -59,7 +59,8 @@ class SnapshotFile {
     };
 
     this._uncheckedKeys.forEach(key => delete this._content[key]);
-    if (this._dirty || this._uncheckedKeys.length) {
+    const isEmpty = Object.keys(this._content).length === 0;
+    if ((this._dirty || this._uncheckedKeys.size) && !isEmpty) {
       const snapshots = [];
       for (const key in this._content) {
         const item = this._content[key];
@@ -71,7 +72,9 @@ class SnapshotFile {
       ensureDirectoryExists(this._filename);
       fs.writeFileSync(this._filename, snapshots.join('\n\n') + '\n');
       operationResult.saved = true;
-    } else if (this.fileExists()) {
+    }
+
+    if (isEmpty && this.fileExists()) {
       fs.unlinkSync(this._filename);
       operationResult.deleted = true;
     }


### PR DESCRIPTION
Snapshots get cleaned in this way:

- Everytime a test has at least one `toMatchSnapshot`:
  we keep track of which snapshots didn't run, we delete those in `save`
- If a test file exists but there's no `toMatchSnapshot`:
  same logic as above, plus `save` will now tell if a snapshot existed
previously so that we can add it to the summary
- if the test file no longer exists:
  we use the hastemap at the end of the run to check if all the
snapshots have an associated test file, we then delete the orphan one.