### PR TITLE
Pretty-print snapshot output.

### DIFF
--- a/integration_tests/__tests__/snapshot-test.js
+++ b/integration_tests/__tests__/snapshot-test.js
@@ -34,11 +34,9 @@ describe('Snapshot', () => {
     expect(json.numPendingTests).toBe(0);
     expect(result.status).toBe(0);
 
-    const content = fs.readFileSync(snapshotFile);
-
-    const output = JSON.parse(content);
+    const content = require(snapshotFile);
     expect(
-      output['snapshot is not influenced by previous counter 0']
+      content['snapshot is not influenced by previous counter 0']
     ).not.toBe(undefined);
   });
 });

--- a/integration_tests/snapshot/__tests__/snapshot.js
+++ b/integration_tests/snapshot/__tests__/snapshot.js
@@ -11,15 +11,15 @@
 
 describe('snapshot', () => {
 
-  it('works with plain objects', () => {
+  it('works with plain objects and the title has `escape` characters', () => {
     const test = {
       a: 1,
       b: '2',
-      c: 'three',
+      c: 'three`',
     };
-    expect(JSON.stringify(test)).toMatchSnapshot();
+    expect(test).toMatchSnapshot();
     test.d = '4';
-    expect(JSON.stringify(test)).toMatchSnapshot();
+    expect(test).toMatchSnapshot();
   });
 
   it('is not influenced by previous counter', () => {
@@ -28,7 +28,7 @@ describe('snapshot', () => {
       b:'43',
       c:'fourtythree',
     };
-    expect(JSON.stringify(test)).toMatchSnapshot();
+    expect(test).toMatchSnapshot();
   });
 
   it('cannot be used with .not', () => {

--- a/packages/jest-snapshot/package.json
+++ b/packages/jest-snapshot/package.json
@@ -8,7 +8,8 @@
   "license": "BSD-3-Clause",
   "main": "src/index.js",
   "dependencies": {
-    "jest-util": "^12.1.0"
+    "jest-util": "^12.1.0",
+    "pretty-format": "^2.0.0"
   },
   "scripts": {
     "test": "../jest-cli/bin/jest.js"

--- a/packages/jest-snapshot/src/__tests__/SnapshotFile-test.js
+++ b/packages/jest-snapshot/src/__tests__/SnapshotFile-test.js
@@ -24,10 +24,10 @@ jest
     readFileSync: jest.fn(fileName => {
       const EXPECTED_FILE_NAME = '/foo/__tests__/__snapshots__/baz.js.snap';
       expect(fileName).toBe(EXPECTED_FILE_NAME);
-      return '{}';
+      return null;
     }),
     writeFileSync: jest.fn((path, content) => {
-      expect(content).toBe('{"foo":"bar"}');
+      expect(content).toBe('exports[`foo`] = `"bar"`;\n');
     }),
   }));
 
@@ -54,7 +54,7 @@ describe('SnapshotFile', () => {
   it('stores and retrieves snapshots', () => {
     const snapshotFile = SnapshotFile.forFile(TEST_FILE);
     snapshotFile.add(SNAPSHOT, SNAPSHOT_VALUE);
-    expect(snapshotFile.get(SNAPSHOT)).toBe(SNAPSHOT_VALUE);
+    expect(snapshotFile.get(SNAPSHOT)).toBe('"' + SNAPSHOT_VALUE + '"');
   });
 
   it('can tell if a snapshot file has a snapshot', () => {
@@ -69,17 +69,17 @@ describe('SnapshotFile', () => {
     const INCORRECT_VALUE = 'baz';
     const snapshotFile = SnapshotFile.forFile(TEST_FILE);
     snapshotFile.add(SNAPSHOT, SNAPSHOT_VALUE);
-    expect(snapshotFile.matches(SNAPSHOT, SNAPSHOT_VALUE)).toBe(true);
-    expect(snapshotFile.matches(SNAPSHOT, INCORRECT_VALUE)).toBe(false);
+    expect(snapshotFile.matches(SNAPSHOT, SNAPSHOT_VALUE).pass).toBe(true);
+    expect(snapshotFile.matches(SNAPSHOT, INCORRECT_VALUE).pass).toBe(false);
   });
 
   it('can replace snapshot values', () => {
     const NEW_VALUE = 'baz';
     const snapshotFile = SnapshotFile.forFile(TEST_FILE);
     snapshotFile.add(SNAPSHOT, SNAPSHOT_VALUE);
-    expect(snapshotFile.matches(SNAPSHOT, SNAPSHOT_VALUE)).toBe(true);
+    expect(snapshotFile.matches(SNAPSHOT, SNAPSHOT_VALUE).pass).toBe(true);
     snapshotFile.add(SNAPSHOT, NEW_VALUE);
-    expect(snapshotFile.matches(SNAPSHOT, NEW_VALUE)).toBe(true);
+    expect(snapshotFile.matches(SNAPSHOT, NEW_VALUE).pass).toBe(true);
   });
 
   it('can add the same key twice', () => {
@@ -93,7 +93,7 @@ describe('SnapshotFile', () => {
   it('loads and saves file correctly', () => {
     const snapshotFile = SnapshotFile.forFile(TEST_FILE);
     snapshotFile.add(SNAPSHOT, SNAPSHOT_VALUE);
-    expect(snapshotFile.get(SNAPSHOT)).toBe(SNAPSHOT_VALUE);
+    expect(snapshotFile.get(SNAPSHOT)).toBe('"' + SNAPSHOT_VALUE + '"');
     snapshotFile.save();
   });
 });

--- a/packages/jest-snapshot/src/__tests__/getMatchers-test.js
+++ b/packages/jest-snapshot/src/__tests__/getMatchers-test.js
@@ -8,7 +8,9 @@
  * @emails oncall+jsinfra
  */
 'use strict';
-jest.unmock('../getMatchers');
+
+jest.disableAutomock();
+
 const getMatchers = require('../getMatchers');
 
 describe('getMatchers', () => {


### PR DESCRIPTION
This refactors the snapshot serialization a little bit:

* Use @thejameskyle's pretty-format plugin to pretty-print objects (see screenshot below). We now allow any value to be used with `toMatchSnapshot`. We can add other serializers (for react output, for example), later.
* Add a dirty flag to only attempt to save a file if `toMatchSnapshot` was called and a snapshot was changed.
* Move some things around in getMatchers, because there was an inline require there.

![Imgur](http://i.imgur.com/d2TKgYq.png)