### PR TITLE
Use `statSync` instead of `accessSync`.

### DIFF
--- a/packages/jest-cli/src/cli/args.js
+++ b/packages/jest-cli/src/cli/args.js
@@ -67,7 +67,7 @@ const check = argv => {
     );
   }
   return true;
-}
+};
 
 const usage = 'Usage: $0 [--config=<pathToConfigFile>] [TestPathRegExp]';
 

--- a/packages/jest-resolve/src/index.js
+++ b/packages/jest-resolve/src/index.js
@@ -58,8 +58,7 @@ class Resolver {
 
   static fileExists(filePath) {
     try {
-      fs.accessSync(filePath, fs.R_OK);
-      return true;
+      return fs.statSync(filePath).isFile();
     } catch (e) {}
     return false;
   }

--- a/packages/jest-snapshot/src/SnapshotFile.js
+++ b/packages/jest-snapshot/src/SnapshotFile.js
@@ -24,8 +24,7 @@ const escape = string => string.replace(/\`/g, '\\`');
 
 const fileExists = filePath => {
   try {
-    fs.accessSync(filePath, fs.R_OK);
-    return true;
+    return fs.statSync(filePath).isFile();
   } catch (e) {}
   return false;
 };


### PR DESCRIPTION
`accessSync` will return true for directories, which we do not want.

Right now, when in the integration test folder, running `jest snapshot` will not find any tests while `jest snapshot.js` will work. This is because there is a snapshot folder, `accessSync` will return true and Jest tries to run the directory as a test file.