### PR TITLE
Remove unused postSuiteHeaders field.

### DIFF
--- a/integration_tests/runJest.js
+++ b/integration_tests/runJest.js
@@ -22,7 +22,7 @@ function runJest(dir, args) {
 // Runs `jest` with `--json` option and adds `json` property to the result obj.
 //   'success', 'startTime', 'numTotalTests', 'numTotalTestSuites',
 //   'numRuntimeErrorTestSuites', 'numPassedTests', 'numFailedTests',
-//   'numPendingTests', 'testResults', 'postSuiteHeaders'
+//   'numPendingTests', 'testResults'
 runJest.json = function(dir, args) {
   args = Array.prototype.concat(args || [], '--json');
   const result = runJest(dir, args);

--- a/packages/jest-cli/src/TestRunner.js
+++ b/packages/jest-cli/src/TestRunner.js
@@ -190,7 +190,6 @@ class TestRunner {
       numFailedTests: 0,
       numPendingTests: 0,
       testResults: [],
-      postSuiteHeaders: [],
     };
 
     reporter.onRunStart && reporter.onRunStart(config, aggregatedResults);

--- a/packages/jest-cli/src/lib/formatTestResults.js
+++ b/packages/jest-cli/src/lib/formatTestResults.js
@@ -64,7 +64,6 @@ function formatTestResults(results, config, codeCoverageFormatter, reporter) {
     numFailedTests: results.numFailedTests,
     numPendingTests: results.numPendingTests,
     testResults,
-    postSuiteHeaders: results.postSuiteHeaders,
   };
 }
 

--- a/packages/jest-cli/src/reporters/DefaultTestReporter.js
+++ b/packages/jest-cli/src/reporters/DefaultTestReporter.js
@@ -121,10 +121,6 @@ class DefaultTestReporter {
       return;
     }
 
-    if (config.verbose && aggregatedResults.postSuiteHeaders.length > 0) {
-      this.log(aggregatedResults.postSuiteHeaders.join('\n'));
-    }
-
     let results = '';
     if (failedTests) {
       results +=

--- a/packages/jest-cli/src/reporters/__tests__/DefaultTestReporter-test.js
+++ b/packages/jest-cli/src/reporters/__tests__/DefaultTestReporter-test.js
@@ -44,7 +44,6 @@ describe('DefaultTestReporter', () => {
         numPendingTests: 0,
         numFailedTests: 1,
         testResults: [],
-        postSuiteHeaders: [],
         testFilePath: 'foo',
       };
       testReporter.onRunStart({
@@ -60,5 +59,3 @@ describe('DefaultTestReporter', () => {
 
   });
 });
-
-

--- a/packages/jest-cli/src/reporters/__tests__/IstanbulTestReporter-test.js
+++ b/packages/jest-cli/src/reporters/__tests__/IstanbulTestReporter-test.js
@@ -60,7 +60,6 @@ describe('InstanbulTestReporter', () => {
         numPendingTests: 0,
         numFailedTests: 0,
         testResults: [],
-        postSuiteHeaders: [],
         testFilePath: 'foo',
       };
       const fakeProcess = {


### PR DESCRIPTION
This looks like a remnant from the first verbose printing implementation and is now unused.