### PR TITLE
Remove `jest.runAllTicks()` note about promises

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,8 +308,10 @@ Jest uses Jasmine 2 by default. An introduction to Jasmine 2 can be found
 
   - `afterEach(fn)`
   - `beforeEach(fn)`
+  - [`check`](https://facebook.github.io/jest/docs/api.html#property-testing)
   - `describe(name, fn)`
   - [`expect(value)`](https://facebook.github.io/jest/docs/api.html#expect-value)
+  - [`gen`](https://facebook.github.io/jest/docs/api.html#property-testing)
   - `it(name, fn)`
   - `fit(name, fn)` executes only this test. Useful when investigating a failure
   - [`jest`](https://facebook.github.io/jest/docs/api.html#the-jest-object)
@@ -411,8 +413,6 @@ The second argument can be used to specify an explicit module factory that is be
 Exhausts the **micro**-task queue (usually interfaced in node via `process.nextTick`).
 
 When this API is called, all pending micro-tasks that have been queued via `process.nextTick` will be executed. Additionally, if those micro-tasks themselves schedule new micro-tasks, those will be continually exhausted until there are no more micro-tasks remaining in the queue.
-
-This is often useful for synchronously executing all pending promises in the system.
 
 ### `jest.runAllTimers()`
 Exhausts the **macro**-task queue (i.e., all tasks queued by `setTimeout()` and `setInterval()`).
@@ -570,6 +570,49 @@ module should receive a mock implementation or not.
 
 Returns a mock module instead of the actual module, bypassing all checks on
 whether the module should be required normally or not.
+
+## Property testing
+
+Jest supports property testing with the
+[testcheck-js](https://github.com/leebyron/testcheck-js) library. The API is
+the same as that of [jasmine-check](https://github.com/leebyron/jasmine-check):
+
+### `check.it(name, [options], generators, fn)`
+Creates a property test. Test cases will be created by the given `generators`
+and passed as arguments to `fn`. If any test case fails, a shrunken failing
+value will be given in the test output. For example:
+
+```js
+check.it('can recover encoded URIs',
+  [gen.string],
+  s => expect(s).toBe(decodeURI(encodeURI(s))));
+```
+
+If `options` are provided, they override the corresponding command-line options.
+The possible options are:
+
+```
+{
+  times: number;   // The number of test cases to run. Default: 100.
+  maxSize: number; // The maximum size of sized data such as numbers
+                   // (their magnitude) or arrays (their length). This can be
+                   // overridden with `gen.resize`. Default: 200.
+  seed: number;    // The random number seed. Defaults to a random value.
+}
+```
+
+### `check.fit(name, [options], generators, fn)`
+
+Executes this test and skips all others. Like `fit`, but for property tests.
+
+### `check.xit(name, [options], generators, fn)`
+
+Skips this test. Like `xit`, but for property tests.
+
+### `gen`
+
+A library of generators for property tests. See the
+[`testcheck` documentation](https://github.com/leebyron/testcheck-js).
 
 ## Configuration
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -187,8 +187,6 @@ Exhausts the **micro**-task queue (usually interfaced in node via `process.nextT
 
 When this API is called, all pending micro-tasks that have been queued via `process.nextTick` will be executed. Additionally, if those micro-tasks themselves schedule new micro-tasks, those will be continually exhausted until there are no more micro-tasks remaining in the queue.
 
-This is often useful for synchronously executing all pending promises in the system.
-
 ### `jest.runAllTimers()`
 Exhausts the **macro**-task queue (i.e., all tasks queued by `setTimeout()` and `setInterval()`).
 


### PR DESCRIPTION
Promises use their own micro-queue for resolution, which Jest has no control over.

Also re-generated README.md via `cd website && npm start`; has some changes unrelated to the `docs/API.md` change.