### PR TITLE
OS independent path handling in regexes

### DIFF
--- a/packages/jest-haste-map/package.json
+++ b/packages/jest-haste-map/package.json
@@ -10,8 +10,8 @@
   "dependencies": {
     "fb-watchman": "^1.9.0",
     "graceful-fs": "^4.1.3",
-    "worker-farm": "^1.3.1",
-    "jest-util": "^12.1.0"
+	"jest-util": "^12.1.0",
+    "worker-farm": "^1.3.1"
   },
   "jest": {
     "testEnvironment": "node"

--- a/packages/jest-haste-map/package.json
+++ b/packages/jest-haste-map/package.json
@@ -10,7 +10,8 @@
   "dependencies": {
     "fb-watchman": "^1.9.0",
     "graceful-fs": "^4.1.3",
-    "worker-farm": "^1.3.1"
+    "worker-farm": "^1.3.1",
+    "jest-util": "^12.1.0"
   },
   "jest": {
     "testEnvironment": "node"

--- a/packages/jest-haste-map/package.json
+++ b/packages/jest-haste-map/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "fb-watchman": "^1.9.0",
     "graceful-fs": "^4.1.3",
-	"jest-util": "^12.1.0",
+    "jest-util": "^12.1.0",
     "worker-farm": "^1.3.1"
   },
   "jest": {

--- a/packages/jest-haste-map/src/__tests__/index-test.js
+++ b/packages/jest-haste-map/src/__tests__/index-test.js
@@ -15,7 +15,8 @@ jest.unmock('../constants')
   .unmock('../lib/getPlatformExtension')
   .unmock('../worker')
   .unmock('../fastpath')
-  .unmock('../');
+  .unmock('../')
+  .unmock('jest-util');
 
 jest.mock('child_process', () => ({
   // If this does not throw, we'll use the (mocked) watchman crawler

--- a/packages/jest-haste-map/src/index.js
+++ b/packages/jest-haste-map/src/index.js
@@ -17,10 +17,10 @@ const getPlatformExtension = require('./lib/getPlatformExtension');
 const nodeCrawl = require('./crawlers/node');
 const os = require('os');
 const path = require('./fastpath');
+const utils = require('jest-util');
 const watchmanCrawl = require('./crawlers/watchman');
 const worker = require('./worker');
 const workerFarm = require('worker-farm');
-const utils = require('jest-util');
 
 const NODE_MODULES = path.sep + 'node_modules' + path.sep;
 const VERSION = require('../package.json').version;
@@ -32,7 +32,6 @@ const canUseWatchman = (() => {
   } catch (e) {}
   return false;
 })();
-
 
 /**
  * HasteMap is a JavaScript implementation of Facebook's haste module system.
@@ -125,9 +124,11 @@ class HasteMap {
         options.useWatchman === undefined ? true : options.useWatchman,
     };
 
+    const nodeModules = utils.replacePathSepForRegex(NODE_MODULES);
+    const pathSep = utils.replacePathSepForRegex(path.sep);
     const list = options.providesModuleNodeModules;
     this._whitelist = (list && list.length)
-      ? new RegExp(utils.replacePathSepForRegex('(' + NODE_MODULES + '(?:' + list.join('|') + ')(?=$|' + path.sep + '))'), 'g' )
+      ? new RegExp('(' + nodeModules + '(?:' + list.join('|') + ')(?=$|' + pathSep + '))', 'g')
       : null;
 
     this._cachePath = HasteMap.getCacheFilePath(

--- a/packages/jest-haste-map/src/index.js
+++ b/packages/jest-haste-map/src/index.js
@@ -20,6 +20,7 @@ const path = require('./fastpath');
 const watchmanCrawl = require('./crawlers/watchman');
 const worker = require('./worker');
 const workerFarm = require('worker-farm');
+const utils = require('jest-util');
 
 const NODE_MODULES = path.sep + 'node_modules' + path.sep;
 const VERSION = require('../package.json').version;
@@ -31,6 +32,7 @@ const canUseWatchman = (() => {
   } catch (e) {}
   return false;
 })();
+
 
 /**
  * HasteMap is a JavaScript implementation of Facebook's haste module system.
@@ -125,7 +127,7 @@ class HasteMap {
 
     const list = options.providesModuleNodeModules;
     this._whitelist = (list && list.length)
-      ? new RegExp('(' + NODE_MODULES + '(?:' + list.join('|') + ')(?=$|' + path.sep + '))', 'g')
+      ? new RegExp(utils.replacePathSepForRegex('(' + NODE_MODULES + '(?:' + list.join('|') + ')(?=$|' + path.sep + '))'), 'g' )
       : null;
 
     this._cachePath = HasteMap.getCacheFilePath(


### PR DESCRIPTION
added jest-util package to use the `replacePathSepForRegex` function for windows path escaping

Closes #1107