### PR TITLE
Flow type jest-snapshot

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -12,6 +12,7 @@ module.name_mapper='^types/Config$' -> '<PROJECT_ROOT>/types/Config.js'
 module.name_mapper='^types/Environment$' -> '<PROJECT_ROOT>/types/Environment.js'
 module.name_mapper='^types/Global$' -> '<PROJECT_ROOT>/types/Global.js'
 module.name_mapper='^types/TestResult$' -> '<PROJECT_ROOT>/types/TestResult.js'
+module.name_mapper='^types/Jasmine$' -> '<PROJECT_ROOT>/types/Jasmine.js'
 
 suppress_type=$FlowFixMe
 suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe\\($\\|[^(]\\|(\\(>=0\\.\\(2[0-7]\\|1[0-9]\\|[0-9]\\).[0-9]\\)? *\\(site=[a-z,_]*www[a-z,_]*\\)?)\\)

--- a/packages/jest-snapshot/src/SnapshotState.js
+++ b/packages/jest-snapshot/src/SnapshotState.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+'use strict';
+
+import type {SnapshotFileT} from './SnapshotFile';
+
+export type SnapshotState = {
+  currentSpecName: string,
+  getCounter: (() => number),
+  incrementCounter: (() => number),
+  snapshot: SnapshotFileT,
+  added: number,
+  updated: number,
+  matched: number,
+  unmatched: number,
+};

--- a/packages/jest-snapshot/src/getMatchers.js
+++ b/packages/jest-snapshot/src/getMatchers.js
@@ -4,20 +4,36 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
  */
 'use strict';
 
 const JasmineFormatter = require('jest-util').JasmineFormatter;
 
-module.exports = (filePath, options, jasmine, snapshotState) => ({
-  toMatchSnapshot: (util, customEquality) => {
+import type {Jasmine} from 'types/Jasmine';
+import type {Path} from 'types/Config';
+import type {SnapshotState} from './SnapshotState';
+
+type CompareResult = {
+  pass: boolean,
+  message: ?string,
+};
+
+module.exports = (
+  filePath: Path,
+  options: Object,
+  jasmine: Jasmine,
+  snapshotState: SnapshotState
+) => ({
+  toMatchSnapshot: (util: any, customEquality: any) => {
     return {
       negativeCompare() {
         throw new Error(
           'Jest: `.not` can not be used with `.toMatchSnapshot()`.'
         );
       },
-      compare(actual, expected) {
+      compare(actual: any, expected: any): CompareResult {
         if (expected !== undefined) {
           throw new Error(
             'Jest: toMatchSnapshot() does not accept parameters.'
@@ -64,8 +80,11 @@ module.exports = (filePath, options, jasmine, snapshotState) => ({
             const matcherName = 'toMatchSnapshot';
             const formatter = new JasmineFormatter(jasmine, {global: {}}, {});
             formatter.addDiffableMatcher(matcherName);
+
+            const failure: Object = {matcherName};
+
             message = formatter
-              .formatMatchFailure(Object.assign({matcherName}, matches))
+              .formatMatchFailure(Object.assign(failure, matches))
               .replace(
                 'toMatchSnapshot:',
                 'toMatchSnapshot #' + (callCount + 1) + ':'

--- a/types/Jasmine.js
+++ b/types/Jasmine.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+'use strict';
+
+export type Jasmine = Object;

--- a/types/TestResult.js
+++ b/types/TestResult.js
@@ -20,8 +20,9 @@ export type FailedAssertion = {
   matcherName: string,
   message: string,
   trace?: Error,
-  actual: any,
-  expected: any,
+  actual?: any,
+  pass?: boolean,
+  expected?: any,
   isNot: boolean,
 };
 


### PR DESCRIPTION
Adds requisite type declarations and annotations to the jest-snapshot
modules. I’m not *at all* familiar with what this code is responsible
for, so I had to guess at a few types.

Open questions:

  - Is the new Jasmine type appropriate?
  - For SnapshotFile._content, can the value type be more specific?
  - Flow complains about Object.assign() if the 1st argument is a
literal that doesn’t contain all the keys trying to be assigned (see
getMatchers)