### PR TITLE
Flowify formatTestResults

### DIFF
--- a/packages/jest-cli/src/lib/formatTestResults.js
+++ b/packages/jest-cli/src/lib/formatTestResults.js
@@ -4,17 +4,33 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
  */
+
 'use strict';
 
 const utils = require('jest-util');
 
-const formatResult = (testResult, config, codeCoverageFormatter, reporter) => {
-  const output = {
+import type {
+  AggregatedTestResults,
+  CodeCoverageFormatter,
+  CodeCoverageReporter,
+  TestResult,
+} from 'types/TestResult';
+import type {Config} from 'types/Config';
+
+const formatResult = (
+  testResult: TestResult,
+  config: Config,
+  codeCoverageFormatter: CodeCoverageFormatter,
+  reporter: CodeCoverageReporter,
+): Object => {
+  const output = ({
     name: testResult.testFilePath,
     summary: '',
     message: '',
-  };
+  }: any);
 
   if (testResult.testExecError) {
     const currTime = Date.now();
@@ -42,7 +58,12 @@ const formatResult = (testResult, config, codeCoverageFormatter, reporter) => {
   return output;
 };
 
-function formatTestResults(results, config, codeCoverageFormatter, reporter) {
+function formatTestResults(
+  results: AggregatedTestResults,
+  config: Config,
+  codeCoverageFormatter: CodeCoverageFormatter,
+  reporter: CodeCoverageReporter,
+): Object {
   if (!codeCoverageFormatter) {
     codeCoverageFormatter = coverage => coverage;
   }

--- a/types/TestResult.js
+++ b/types/TestResult.js
@@ -55,3 +55,31 @@ export type TestResult = {
   testFilePath: string,
   testResults: Array<AssertionResult>,
 };
+
+export type AggregatedTestResults = {
+  success: ?boolean,
+  startTime: Date,
+  numTotalTestSuites: number,
+  numPassedTestSuites: number,
+  numFailedTestSuites: number,
+  numRuntimeErrorTestSuites: number,
+  numTotalTests: number,
+  numPassedTests: number,
+  numFailedTests: number,
+  numPendingTests: number,
+  testResults: Array<TestResult>,
+};
+
+export type CodeCoverageResult = {
+  coveredSpans: Array<Object>,
+  uncoveredSpans: Array<Object>,
+  sourceText: string,
+};
+
+// I don't know how this should be typed
+export type CodeCoverageReporter = any;
+
+export type CodeCoverageFormatter = (
+  coverage: ?CodeCoverageResult,
+  reporter: CodeCoverageReporter,
+) => ?Object;


### PR DESCRIPTION
Flowify formatTestResults. 

I couldn't figure out what CodeCoverageResult, CodeCoverageReporter, and CodeCoverageFormatter should be. So I purposely left them inprecise. 