### PR TITLE
pretty format ReactTestComponents as jsx-like by default

### DIFF
--- a/packages/jest-snapshot/package.json
+++ b/packages/jest-snapshot/package.json
@@ -9,7 +9,7 @@
   "main": "build/index.js",
   "dependencies": {
     "jest-util": "^12.1.0",
-    "pretty-format": "^2.1.0"
+    "pretty-format": "^3.3.0"
   },
   "scripts": {
     "test": "../jest-cli/bin/jest.js"

--- a/packages/jest-snapshot/src/SnapshotFile.js
+++ b/packages/jest-snapshot/src/SnapshotFile.js
@@ -13,6 +13,7 @@ const createDirectory = require('jest-util').createDirectory;
 const fs = require('fs');
 const path = require('path');
 const prettyFormat = require('pretty-format');
+const jsxLikeExtension = require('pretty-format/plugins/ReactTestComponent');
 const SNAPSHOT_EXTENSION = 'snap';
 
 import type {Path} from 'types/Config';
@@ -86,7 +87,9 @@ class SnapshotFile {
   }
 
   serialize(data: any): string {
-    return prettyFormat(data);
+    return prettyFormat(data, {
+      plugins: [jsxLikeExtension],
+    });
   }
 
   save(update: boolean): SaveStatus {


### PR DESCRIPTION
Enabling the jsx-like extension for ReactTestComponent to pretty-format