### PR TITLE
Respect package.json 'browser' field when resolving dependencies

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -50,6 +50,7 @@ Jest uses Jasmine 2 by default. An introduction to Jasmine 2 can be found
 #### [Configuration Options](#configuration)
 
   - [`automock` [boolean]](#automock-boolean)
+  - [`browser` [boolean]](#browser-boolean)
   - [`bail` [boolean]](#bail-boolean)
   - [`cacheDirectory` [string]](#cachedirectory-string)
   - [`coverageDirectory` [string]](#coveragedirectory-string)
@@ -424,6 +425,11 @@ By default, Jest mocks every module automatically. If you are building a small
 JavaScript library and would like to use Jest, you may not want to use
 automocking. You can disable this option and create manual mocks or explicitly
 mock modules using `jest.mock(moduleName)`.
+
+### `browser` [boolean]
+(default: false)
+
+Respect the Browserify's [`"browser"`](https://github.com/substack/browserify-handbook#browser-field) field in `package.json` when resolving modules. Some modules export different versions based on whether they are operating in Node or a browser.
 
 ### `bail` [boolean]
 (default: false)

--- a/packages/jest-config/src/__tests__/normalize-test.js
+++ b/packages/jest-config/src/__tests__/normalize-test.js
@@ -98,6 +98,17 @@ describe('normalize', () => {
     });
   });
 
+  describe('browser', () => {
+    it('falsy browser is not overwritten', () => {
+      const config = normalize({
+        rootDir: '/root/path/foo',
+        browser: true,
+      });
+
+      expect(config.browser).toBe(true);
+    });
+  });
+
   describe('collectCoverageOnlyFrom', () => {
     it('normalizes all paths relative to rootDir', () => {
       const config = normalize({

--- a/packages/jest-config/src/defaults.js
+++ b/packages/jest-config/src/defaults.js
@@ -19,6 +19,7 @@ const utils = require('jest-util');
 module.exports = ({
   automock: true,
   bail: false,
+  browser: false,
   cacheDirectory: os.tmpdir(),
   colors: false,
   coverageCollector: require.resolve('./IstanbulCollector'),

--- a/packages/jest-config/src/normalize.js
+++ b/packages/jest-config/src/normalize.js
@@ -52,13 +52,17 @@ function _replaceRootDirTags(rootDir, config) {
 
 function getTestEnvironment(config) {
   const env = config.testEnvironment;
-  let module = Resolver.findNodeModule(env, {basedir: config.rootDir});
+  let module = Resolver.findNodeModule(env, {
+    basedir: config.rootDir,
+    browser: config.browser,
+  });
   if (module) {
     return module;
   }
 
   module = Resolver.findNodeModule(`jest-environment-${env}`, {
     basedir: config.rootDir,
+    browser: config.browser,
   });
   if (module) {
     return module;
@@ -163,6 +167,7 @@ function normalize(config, argv) {
   } else {
     babelJest = Resolver.findNodeModule('babel-jest', {
       basedir: config.rootDir,
+      browser: config.browser,
     });
     if (babelJest) {
       config.scriptPreprocessor = babelJest;
@@ -171,7 +176,10 @@ function normalize(config, argv) {
 
   if (babelJest) {
     const polyfillPath =
-      Resolver.findNodeModule('babel-polyfill', {basedir: config.rootDir});
+      Resolver.findNodeModule('babel-polyfill', {
+        basedir: config.rootDir,
+        browser: config.browser,
+      });
     if (polyfillPath) {
       config.setupFiles.unshift(polyfillPath);
     }
@@ -180,7 +188,10 @@ function normalize(config, argv) {
 
   if (!('preprocessorIgnorePatterns' in config)) {
     const isRNProject =
-      !!Resolver.findNodeModule('react-native', {basedir: config.rootDir});
+      !!Resolver.findNodeModule('react-native', {
+        basedir: config.rootDir,
+        browser: config.browser,
+      });
     config.preprocessorIgnorePatterns =
       isRNProject ? [] : [constants.NODE_MODULES];
   } else if (!config.preprocessorIgnorePatterns) {
@@ -246,6 +257,7 @@ function normalize(config, argv) {
         break;
       case 'automock':
       case 'bail':
+      case 'browser':
       case 'cache':
       case 'collectCoverage':
       case 'colors':

--- a/packages/jest-resolve/package.json
+++ b/packages/jest-resolve/package.json
@@ -8,6 +8,7 @@
   "license": "BSD-3-Clause",
   "main": "build/index.js",
   "dependencies": {
+    "browser-resolve": "^1.11.2",
     "jest-haste-map": "^12.1.0",
     "resolve": "^1.1.6"
   },

--- a/packages/jest-resolve/src/index.js
+++ b/packages/jest-resolve/src/index.js
@@ -23,6 +23,7 @@ const fs = require('fs');
 const nodeModulesPaths = require('resolve/lib/node-modules-paths');
 const path = require('path');
 const resolve = require('resolve');
+const browserResolve = require('browser-resolve');
 
 type ResolverConfig = {
   defaultPlatform: ?string,
@@ -113,7 +114,7 @@ class Resolver {
   static findNodeModule(path: Path, options: FindNodeModuleConfig): ?Path {
     const paths = options.paths;
     try {
-      return resolve.sync(
+      return browserResolve.sync(
         path,
         {
           basedir: options.basedir,

--- a/packages/jest-resolve/src/index.js
+++ b/packages/jest-resolve/src/index.js
@@ -33,6 +33,7 @@ type ResolverConfig = {
   moduleNameMapper: ?{[key: string]: RegExp},
   modulePaths: Array<Path>,
   platforms?: Array<string>,
+  browser: boolean,
 };
 
 type FindNodeModuleConfig = {
@@ -40,6 +41,7 @@ type FindNodeModuleConfig = {
   extensions: Array<string>,
   paths?: Array<Path>,
   moduleDirectory: Array<string>,
+  browser: boolean,
 };
 
 export type ResolveModuleConfig = {skipNodeResolution?: boolean};
@@ -87,6 +89,7 @@ class Resolver {
       moduleDirectories: options.moduleDirectories || ['node_modules'],
       moduleNameMapper: options.moduleNameMapper,
       modulePaths: options.modulePaths,
+      browser: options.browser,
     };
 
     this._supportsNativePlatform =
@@ -108,13 +111,15 @@ class Resolver {
       moduleNameMapper: getModuleNameMapper(config),
       modulePaths: config.modulePaths,
       platforms: config.haste.platforms,
+      browser: config.browser,
     });
   }
 
   static findNodeModule(path: Path, options: FindNodeModuleConfig): ?Path {
     const paths = options.paths;
     try {
-      return browserResolve.sync(
+      const resv = options.browser ? browserResolve : resolve;
+      return resv.sync(
         path,
         {
           basedir: options.basedir,
@@ -165,6 +170,7 @@ class Resolver {
         extensions,
         moduleDirectory,
         paths,
+        browser: this._options.browser,
       });
 
       if (module) {

--- a/packages/jest-runtime/src/__tests__/jest-resolve-test.js
+++ b/packages/jest-runtime/src/__tests__/jest-resolve-test.js
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails oncall+jsinfra
+ */
+'use strict';
+
+jest.disableAutomock();
+jest.mock(
+  'jest-environment-jsdom',
+  () => require('../__mocks__/jest-environment-jsdom')
+);
+
+let createRuntime;
+
+describe('resolve', () => {
+  beforeEach(() => {
+    createRuntime = require('createRuntime');
+  });
+
+  it('respects "browser" dependency when browser:true configured', () =>
+    createRuntime(__filename, {
+      browser: true,
+    }).then(runtime => {
+      const exports = runtime.requireModuleOrMock(
+        runtime.__mockRootPath,
+        'jest-resolve-test'
+      );
+      expect(exports.isBrowser).toBe(true);
+    })
+  );
+
+  it('doesn\'t resolve "browser" dependency by default', () =>
+    createRuntime(__filename, {}).then(runtime => {
+      const exports = runtime.requireModuleOrMock(
+        runtime.__mockRootPath,
+        'jest-resolve-test'
+      );
+      expect(exports.isBrowser).toBe(false);
+    })
+  );
+});

--- a/packages/jest-runtime/src/__tests__/test_root/node_modules/jest-resolve-test/browser.js
+++ b/packages/jest-runtime/src/__tests__/test_root/node_modules/jest-resolve-test/browser.js
@@ -1,0 +1,1 @@
+module.exports.isBrowser = true;

--- a/packages/jest-runtime/src/__tests__/test_root/node_modules/jest-resolve-test/node.js
+++ b/packages/jest-runtime/src/__tests__/test_root/node_modules/jest-resolve-test/node.js
@@ -1,0 +1,1 @@
+module.exports.isBrowser = false;

--- a/packages/jest-runtime/src/__tests__/test_root/node_modules/jest-resolve-test/package.json
+++ b/packages/jest-runtime/src/__tests__/test_root/node_modules/jest-resolve-test/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "jest-resolve-test",
+  "version": "1.0.0",
+  "description": "",
+  "main": "./node.js",
+  "browser": "./browser.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/facebook/jest.git"
+  },
+  "author": "",
+  "license": "BSD-3-Clause",
+  "bugs": {
+    "url": "https://github.com/facebook/jest/issues"
+  },
+  "homepage": "https://github.com/facebook/jest#readme",
+  "private": true
+}

--- a/types/Config.js
+++ b/types/Config.js
@@ -22,6 +22,7 @@ export type ConfigGlobals = Object;
 type BaseConfig = {
   automock: boolean,
   bail: boolean,
+  browser: boolean,
   cacheDirectory: Path,
   coverageCollector: Path,
   coverageReporters: Array<string>,


### PR DESCRIPTION
Fixes #61 

This change makes Jest respect the `"browser"` field when resolving packages using [browser-resolve](https://www.npmjs.com/package/browser-resolve).

A consideration to make when evaluating this PR is what to do for server side tests as the wrong module will be resolved in this case. I think the best option would be adding a `browser: <bool>` field to Jest configs? Thoughts?