### PR TITLE
Pretty print React components on new line

### DIFF
--- a/packages/jest-snapshot/src/SnapshotFile.js
+++ b/packages/jest-snapshot/src/SnapshotFile.js
@@ -41,6 +41,11 @@ const ensureDirectoryExists = (filePath: Path) => {
 
 const escape = string => string.replace(/\`/g, '\\`');
 
+// Extra line breaks at the beginning and at the end of the snapshot are useful
+// to make the content of the snapshot easier to read
+const addExtraLineBreaks = string => string.indexOf('\n') > -1
+  ? `\n${string}\n` : string;
+
 const fileExists = (filePath: Path): boolean => {
   try {
     return fs.statSync(filePath).isFile();
@@ -87,9 +92,9 @@ class SnapshotFile {
   }
 
   serialize(data: any): string {
-    return prettyFormat(data, {
+    return addExtraLineBreaks(prettyFormat(data, {
       plugins: [jsxLikeExtension],
-    });
+    }));
   }
 
   save(update: boolean): SaveStatus {

--- a/packages/jest-snapshot/src/__tests__/SnapshotFile-test.js
+++ b/packages/jest-snapshot/src/__tests__/SnapshotFile-test.js
@@ -51,6 +51,13 @@ describe('SnapshotFile', () => {
     expect(snapshotFile.get(SNAPSHOT)).toBe('"' + SNAPSHOT_VALUE + '"');
   });
 
+  it('adds extra new lines for multi-line values', () => {
+    const MULTILINE_VALUE = 'foo\nbar';
+    const snapshotFile = SnapshotFile.forFile(TEST_FILE);
+    snapshotFile.add(SNAPSHOT, MULTILINE_VALUE);
+    expect(snapshotFile.get(SNAPSHOT)).toBe('\n"' + MULTILINE_VALUE + '"\n');
+  });
+
   it('can tell if a snapshot file has a snapshot', () => {
     const NOT_A_SNAPSHOT = 'baz';
     const snapshotFile = SnapshotFile.forFile(TEST_FILE);


### PR DESCRIPTION
Before

    exports[`foo`] = `<Foo
      bar="baz"
    />`;

After

    exports[`foo`] = `
    <Foo
      bar="baz"
    />
    `;

I expect this to be much easier to read and see in the diff view.