### PR TITLE
Fix escaping of "\." on Windows

### DIFF
--- a/packages/jest-config/src/normalize.js
+++ b/packages/jest-config/src/normalize.js
@@ -120,7 +120,7 @@ function normalize(config, argv) {
 
     config.moduleFileExtensions = extensions;
     config.testRegex =
-      path.sep + (config.testDirectoryName || '__tests__') + path.sep +
+      '/' + (config.testDirectoryName || '__tests__') + '/' +
       '.*\\.(' + extensions.join('|') + ')$';
 
     delete config.testDirectoryName;

--- a/packages/jest-util/src/index.js
+++ b/packages/jest-util/src/index.js
@@ -23,7 +23,7 @@ const escapeStrForRegex =
 
 const replacePathSepForRegex = (string: string) => {
   if (path.sep === '\\') {
-    return string.replace(/(\/|\\)/g, '\\\\');
+    return string.replace(/(\/|\\(?!\.))/g, '\\\\');
   }
   return string;
 };


### PR DESCRIPTION
This is super ugly, but it's Good Enough™ for now.

The main issue is that `replacePathSepForRegex` doesn't understand if a `\` is actually part of a file path (eg. `C:\src\jest\`), or if it's escaping a regex character (eg. `\.` to match a dot). This means that it incorrectly escapes all `\` characters on Windows, meaning a regex containing `\.js` to match *.js files will never match anything as it'll look for a literal "\.js" in the path.

The 'nicest' hack I could think of was to only escape `\` if it's not followed by `.`. By far the most common escape I've seen is `\.` to match a dot (ie. `\.js` to match .js files) so this is just an escape hatch to allow `\.` (instead of escaping it like `\\.`), while continuing to escape `c:\foo` as expected.

Things will actually work totally fine if you **always** use `/` as the path separator throughout all your Jest configuration, as `replacePathSepForRegex` handles normalizing both `\` and `/` on Windows, and `/` is not ambiguous in the same way as `\`. Because of this, I changed the regex in `normalize.js` to hard-code `/` as the separator. If everyone changes their config to use `/` as the separator and we replace `\` with `/` in `rootDir`, we can modify `replacePathSepForRegex` to **only** replace `/`, which would be more reliable.

Fixes #1095 and #1180, references #1044