### PR TITLE
Smaller cleanups:

### DIFF
--- a/flowlibs/console.js
+++ b/flowlibs/console.js
@@ -7,14 +7,8 @@
  *
  * @flow
  */
-
 'use strict';
 
-const path = require('path');
-const os = require('os');
-
-const pkg = require('../package.json');
-
-exports.VERSION = pkg.version;
-exports.MAX_WORKERS = os.cpus().length;
-exports.NODE_MODULES = path.sep + 'node_modules' + path.sep;
+declare module "console" {
+  declare var Console: any;
+}

--- a/package.json
+++ b/package.json
@@ -2,29 +2,31 @@
   "private": true,
   "devDependencies": {
     "babel-core": "^6.9.1",
-    "babel-eslint": "^6.0.4",
+    "babel-eslint": "^6.0.5",
     "babel-plugin-syntax-trailing-function-commas": "^6.8.0",
     "babel-plugin-transform-flow-strip-types": "^6.8.0",
     "chalk": "^1.1.3",
-    "eslint": "^2.12.0",
+    "eslint": "^2.13.1",
     "eslint-plugin-babel": "^3.2.0",
     "fbjs-scripts": "^0.7.1",
     "flow-bin": "^0.27.0",
     "glob": "^7.0.4",
     "graceful-fs": "^4.1.4",
     "lerna": "2.0.0-beta.20",
-    "minimatch": "^3.0.0",
+    "minimatch": "^3.0.2",
     "mkdirp": "^0.5.1",
     "progress": "^1.1.8",
     "rimraf": "^2.5.2"
   },
   "scripts": {
+    "build-clean": "rm -rf ./packages/*/node_modules",
+    "build": "node ./scripts/build.js",
+    "clean": "rm -rf ./packages/*/build; npm run build-clean",
     "lint": "eslint .",
     "postinstall": "node ./scripts/postinstall.js && node ./scripts/build.js",
-    "test": "npm run typecheck && npm run lint && node ./scripts/build.js && node ./scripts/test.js",
+    "t": "node ./scripts/test.js",
+    "test": "npm run typecheck && npm run lint && npm run build && npm run t",
     "typecheck": "flow check",
-    "watch": "node ./scripts/watch.js",
-    "build": "node ./scripts/build.js",
-    "build_clear": "rm -rf ./packages/*/build"
+    "watch": "npm run build; node ./scripts/watch.js"
   }
 }

--- a/packages/jest-cli/src/cli/index.js
+++ b/packages/jest-cli/src/cli/index.js
@@ -11,10 +11,8 @@
 'use strict';
 
 const args = require('./args');
-const fs = require('fs');
 const getJest = require('./getJest');
 const getPackageRoot = require('jest-util').getPackageRoot;
-const path = require('path');
 const warnAboutUnrecognizedOptions = require('jest-util').warnAboutUnrecognizedOptions;
 const yargs = require('yargs');
 

--- a/packages/jest-config/src/reporters/VerboseLogger.js
+++ b/packages/jest-config/src/reporters/VerboseLogger.js
@@ -83,7 +83,7 @@ class VerboseLogger {
 
   _logTest(test: AssertionResult, indentLevel: number) {
     const status = this._getIcon(test.status);
-    this._logLine(status + chalk.gray(test.title), indentLevel);
+    this._logLine(status + ' ' + chalk.gray(test.title), indentLevel);
   }
 
   _logLine(str?: string, indentLevel?: number) {

--- a/packages/jest-environment-jsdom/package.json
+++ b/packages/jest-environment-jsdom/package.json
@@ -8,7 +8,7 @@
   "license": "BSD-3-Clause",
   "main": "build/index.js",
   "dependencies": {
-    "jsdom": "^9.0.0",
+    "jsdom": "^9.2.1",
     "jest-util": "^12.1.0"
   }
 }

--- a/packages/jest-runtime/src/__tests__/Runtime-cli-test.js
+++ b/packages/jest-runtime/src/__tests__/Runtime-cli-test.js
@@ -22,7 +22,7 @@ describe('Runtime', () => {
       const expectedOutput =
         'Please provide a path to a script. (See --help for details)';
       const output = spawnSync(JEST_RUNTIME, [], {
-        encoding : 'utf8',
+        encoding: 'utf8',
         cwd: process.cwd(),
         env: process.env,
       });
@@ -32,7 +32,7 @@ describe('Runtime', () => {
     it('displays script output', () => {
       const scriptPath = path.resolve(__dirname, './test_root/logging.js');
       const output = spawnSync(JEST_RUNTIME, [scriptPath], {
-        encoding : 'utf8',
+        encoding: 'utf8',
         cwd: process.cwd(),
         env: process.env,
       });
@@ -42,7 +42,7 @@ describe('Runtime', () => {
     it('throws script errors', () => {
       const scriptPath = path.resolve(__dirname, './test_root/throwing.js');
       const output = spawnSync(JEST_RUNTIME, [scriptPath], {
-        encoding : 'utf8',
+        encoding: 'utf8',
         cwd: process.cwd(),
         env: process.env,
       });

--- a/packages/jest-runtime/src/cli/index.js
+++ b/packages/jest-runtime/src/cli/index.js
@@ -11,7 +11,6 @@
 'use strict';
 
 const args = require('./args');
-const fs = require('fs');
 const path = require('path');
 const yargs = require('yargs');
 
@@ -21,8 +20,7 @@ const warnAboutUnrecognizedOptions = require('jest-util').warnAboutUnrecognizedO
 const readConfig = require('jest-config').readConfig;
 const Runtime = require('../');
 
-const pkg = require('../../package.json');
-const VERSION = pkg.version;
+const VERSION = require('../../package.json').version;
 
 function Run() {
   const argv = yargs

--- a/packages/jest-util/package.json
+++ b/packages/jest-util/package.json
@@ -15,7 +15,7 @@
     "jest-mock": "^12.1.0"
   },
   "devDependencies": {
-    "jsdom": "^8.3.1"
+    "jsdom": "^9.2.1"
   },
   "jest": {
     "rootDir": "./build",

--- a/packages/jest-util/src/Console.js
+++ b/packages/jest-util/src/Console.js
@@ -37,15 +37,11 @@ const chalk = require('chalk');
 
 class CustomConsole extends Console {
   warn() {
-    return super.warn(
-      chalk.yellow(util.format.apply(this, arguments))
-    );
+    return super.warn(chalk.yellow(util.format.apply(this, arguments)));
   }
 
   error() {
-    return super.error(
-      chalk.red(util.format.apply(this, arguments))
-    );
+    return super.error(chalk.red(util.format.apply(this, arguments)));
   }
 }
 

--- a/scripts/watch.js
+++ b/scripts/watch.js
@@ -29,7 +29,7 @@ getPackages().forEach(p => {
   try {
     fs.accessSync(srcDir, fs.F_OK);
     fs.watch(path.resolve(p, 'src'), {recursive: true}, (event, filename) => {
-      if (['change', 'rename'].indexOf(event) !== -1) {
+      if (event === 'change') {
         console.log(chalk.green('->'), `${event}: ${filename}`);
         rebuild(path.resolve(srcDir, filename));
       }
@@ -43,7 +43,9 @@ setInterval(() => {
   const files = Array.from(filesToBuild.keys());
   if (files.length) {
     filesToBuild = new Map();
-    execSync(`${BUILD_CMD} ${files.join(' ')}`, {stdio: [0, 1, 2]});
+    try {
+      execSync(`${BUILD_CMD} ${files.join(' ')}`, {stdio: [0, 1, 2]});
+    } catch (e) {}
   }
 }, 100);
 


### PR DESCRIPTION
* Add more npm scripts
* update npm dependencies
* watch now builds all and recovers from errors
* code style cleanup
* return proper promise from src/jest.js