### PR TITLE
Report run times of individual specs in verbose mode.

### DIFF
--- a/packages/jest-config/src/normalize.js
+++ b/packages/jest-config/src/normalize.js
@@ -58,7 +58,7 @@ function getTestEnvironment(config) {
   }
 
   module = Resolver.findNodeModule(`jest-environment-${env}`, {
-    basedir: config.rootDir
+    basedir: config.rootDir,
   });
   if (module) {
     return module;

--- a/packages/jest-config/src/reporters/VerboseLogger.js
+++ b/packages/jest-config/src/reporters/VerboseLogger.js
@@ -83,7 +83,10 @@ class VerboseLogger {
 
   _logTest(test: AssertionResult, indentLevel: number) {
     const status = this._getIcon(test.status);
-    this._logLine(status + ' ' + chalk.gray(test.title), indentLevel);
+    const time = test.timeTaken
+      ? ` (${test.timeTaken.toFixed(0)} ms)`
+      : '';
+    this._logLine(status + ' ' + chalk.gray(test.title + time), indentLevel);
   }
 
   _logLine(str?: string, indentLevel?: number) {

--- a/packages/jest-config/src/reporters/VerboseLogger.js
+++ b/packages/jest-config/src/reporters/VerboseLogger.js
@@ -83,8 +83,8 @@ class VerboseLogger {
 
   _logTest(test: AssertionResult, indentLevel: number) {
     const status = this._getIcon(test.status);
-    const time = test.timeTaken
-      ? ` (${test.timeTaken.toFixed(0)} ms)`
+    const time = test.duration
+      ? ` (${test.duration.toFixed(0)} ms)`
       : '';
     this._logLine(status + ' ' + chalk.gray(test.title + time), indentLevel);
   }

--- a/packages/jest-jasmine2/package.json
+++ b/packages/jest-jasmine2/package.json
@@ -10,8 +10,9 @@
   "dependencies": {
     "graceful-fs": "^4.1.3",
     "jasmine-check": "^0.1.4",
+    "jest-snapshot": "^12.1.0",
     "jest-util": "^12.1.0",
-    "jest-snapshot": "^12.1.0"
+    "microtime": "^2.1.1"
   },
   "jest": {
     "rootDir": "./build",

--- a/packages/jest-jasmine2/src/reporter.js
+++ b/packages/jest-jasmine2/src/reporter.js
@@ -33,7 +33,7 @@ type SpecResult = {
   description: string,
   failedExpectations: Array<FailedAssertion>,
   status: Status,
-  timeTaken?: Milliseconds,
+  duration?: Milliseconds,
 };
 
 type Microseconds = number;
@@ -108,7 +108,7 @@ class Jasmine2Reporter {
     ancestorTitles: Array<string>,
   ): AssertionResult {
     const start = this._startTimes.get(specResult.id);
-    const timeTaken = start ? (microtime.now() - start) / 1000 : undefined;
+    const duration = start ? (microtime.now() - start) / 1000 : undefined;
     const status =
       (specResult.status === 'disabled') ? 'pending' : specResult.status;
     const results = {
@@ -117,7 +117,7 @@ class Jasmine2Reporter {
       ancestorTitles,
       failureMessages: [],
       numPassingAsserts: 0, // Jasmine2 only returns an array of failed asserts.
-      timeTaken,
+      duration,
     };
 
     specResult.failedExpectations.forEach(failed => {

--- a/packages/jest-jasmine2/src/reporter.js
+++ b/packages/jest-jasmine2/src/reporter.js
@@ -14,10 +14,12 @@ import type {Environment} from 'types/Environment';
 import type {
   AssertionResult,
   FailedAssertion,
+  Milliseconds,
   Status,
   TestResult,
 } from 'types/TestResult';
 
+const microtime = require('microtime');
 const jasmineRequire = require('../vendor/jasmine-2.4.1.js');
 const jasmine = jasmineRequire.core(jasmineRequire);
 const JasmineFormatter = require('jest-util').JasmineFormatter;
@@ -27,10 +29,14 @@ type Suite = {
 };
 
 type SpecResult = {
+  id: string,
   description: string,
   failedExpectations: Array<FailedAssertion>,
   status: Status,
+  timeTaken?: Milliseconds,
 };
+
+type Microseconds = number;
 
 class Jasmine2Reporter {
   _formatter: JasmineFormatter;
@@ -38,6 +44,7 @@ class Jasmine2Reporter {
   _currentSuites: Array<string>;
   _resolve: any;
   _resultsPromise: Promise<TestResult>;
+  _startTimes: Map<string, Microseconds>;
 
   constructor(config: Config, environment: Environment) {
     this._formatter = new JasmineFormatter(jasmine, environment, config);
@@ -45,6 +52,11 @@ class Jasmine2Reporter {
     this._currentSuites = [];
     this._resolve = null;
     this._resultsPromise = new Promise(resolve => this._resolve = resolve);
+    this._startTimes = new Map();
+  }
+
+  specStarted(spec: {id: string}) {
+    this._startTimes.set(spec.id, microtime.now());
   }
 
   specDone(result: SpecResult): void {
@@ -95,6 +107,8 @@ class Jasmine2Reporter {
     specResult: SpecResult,
     ancestorTitles: Array<string>,
   ): AssertionResult {
+    const start = this._startTimes.get(specResult.id);
+    const timeTaken = start ? (microtime.now() - start) / 1000 : undefined;
     const status =
       (specResult.status === 'disabled') ? 'pending' : specResult.status;
     const results = {
@@ -103,6 +117,7 @@ class Jasmine2Reporter {
       ancestorTitles,
       failureMessages: [],
       numPassingAsserts: 0, // Jasmine2 only returns an array of failed asserts.
+      timeTaken,
     };
 
     specResult.failedExpectations.forEach(failed => {

--- a/types/TestResult.js
+++ b/types/TestResult.js
@@ -38,7 +38,7 @@ export type AssertionResult = {
   ancestorTitles: Array<string>,
   failureMessages: Array<string>,
   numPassingAsserts: number,
-  timeTaken?: number, // milliseconds
+  duration?: number, // milliseconds
 };
 
 export type AggregatedResult = {

--- a/types/TestResult.js
+++ b/types/TestResult.js
@@ -38,7 +38,7 @@ export type AssertionResult = {
   ancestorTitles: Array<string>,
   failureMessages: Array<string>,
   numPassingAsserts: number,
-  duration?: number, // milliseconds
+  duration?: Milliseconds,
 };
 
 export type AggregatedResult = {

--- a/types/TestResult.js
+++ b/types/TestResult.js
@@ -29,12 +29,16 @@ export type FailedAssertion = {
 
 export type Status = 'passed' | 'failed' | 'skipped' | 'pending';
 
+export type Bytes = number;
+export type Milliseconds = number;
+
 export type AssertionResult = {
   title: string,
   status: Status,
   ancestorTitles: Array<string>,
   failureMessages: Array<string>,
   numPassingAsserts: number,
+  timeTaken?: number, // milliseconds
 };
 
 export type AggregatedResult = {
@@ -62,13 +66,14 @@ export type Suite = {
 export type TestResult = {
   coverage?: Coverage,
   hasUncheckedKeys: boolean,
+  memoryUsage?: Bytes,
   message?: string,
   numFailingTests: number,
   numPassingTests: number,
   numPendingTests: number,
   perfStats: {
-    end: number,
-    start: number,
+    end: Milliseconds,
+    start: Milliseconds,
   },
   snapshotFileDeleted: boolean,
   snapshotsAdded: number,


### PR DESCRIPTION
Records the time taken by each spec in a test suite, and prints them when in verbose mode. This is helpful in figuring out why your tests are slow.

Microsecond timing is used so that times will be rounded to nearest rather than truncated.
