### PR TITLE
spelling errors

### DIFF
--- a/examples/jquery/__tests__/displayUser-test.js
+++ b/examples/jquery/__tests__/displayUser-test.js
@@ -34,7 +34,7 @@ describe('displayUser', () => {
     $('#button').click();
 
     // Assert that the fetchCurrentUser function was called, and that the
-    // #username span's innter text was updated as we'd it expect.
+    // #username span's inner text was updated as we'd expect it to.
     expect(fetchCurrentUser).toBeCalled();
     expect($('#username').text()).toEqual('Johnny Cash - Logged In');
   });


### PR DESCRIPTION
Minor spelling errors

inner instead of 'inter'
we'd expect it to instead of we'd it expect