### PR TITLE
Add coveragePathIgnorePatterns to jest configuration

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -54,6 +54,7 @@ Jest uses Jasmine 2 by default. An introduction to Jasmine 2 can be found
   - [`bail` [boolean]](#bail-boolean)
   - [`cacheDirectory` [string]](#cachedirectory-string)
   - [`coverageDirectory` [string]](#coveragedirectory-string)
+  - [`coveragePathIgnorePattern` [array<string>]](#coveragepathignorepattern-array-string)
   - [`collectCoverage` [boolean]](#collectcoverage-boolean)
   - [`collectCoverageOnlyFrom` [object]](#collectcoverageonlyfrom-object)
   - [`coverageThreshold` [object]](#coveragethreshold-object)
@@ -447,6 +448,13 @@ Jest attempts to scan your dependency tree once (up-front) and cache it in order
 (default: `undefined`)
 
 The directory where Jest should output its coverage files.
+
+### `coveragePathIgnorePattern` [array<string>]
+(default: `['/node_modules/']`)
+
+An array of regexp pattern strings that are matched against all file paths before executing the test. If the file path matches any of the patterns, coverage information will be skipped.
+
+These pattern strings match against the full path. Use the `<rootDir>` string token to  include the path to your project's root directory to prevent it from accidentally ignoring all of your files in different environments that may have different root directories. Example: `['<rootDir>/build/', '<rootDir>/node_modules/']`.
 
 ### `collectCoverage` [boolean]
 (default: `false`)

--- a/packages/jest-config/src/__tests__/normalize-test.js
+++ b/packages/jest-config/src/__tests__/normalize-test.js
@@ -285,6 +285,57 @@ describe('normalize', () => {
     });
   });
 
+  describe('coveragePathIgnorePatterns', () => {
+    it('does not normalize paths relative to rootDir', () => {
+      // This is a list of patterns, so we can't assume any of them are
+      // directories
+      const config = normalize({
+        rootDir: '/root/path/foo',
+        coveragePathIgnorePatterns: [
+          'bar/baz',
+          'qux/quux',
+        ],
+      }, '/root/path');
+
+      expect(config.coveragePathIgnorePatterns).toEqual([
+        joinForPattern('bar', 'baz'),
+        joinForPattern('qux', 'quux'),
+      ]);
+    });
+
+    it('does not normalize trailing slashes', () => {
+      // This is a list of patterns, so we can't assume any of them are
+      // directories
+      const config = normalize({
+        rootDir: '/root/path/foo',
+        coveragePathIgnorePatterns: [
+          'bar/baz',
+          'qux/quux/',
+        ],
+      });
+
+      expect(config.coveragePathIgnorePatterns).toEqual([
+        joinForPattern('bar', 'baz'),
+        joinForPattern('qux', 'quux', ''),
+      ]);
+    });
+
+    it('substitutes <rootDir> tokens', () => {
+      const config = normalize({
+        rootDir: '/root/path/foo',
+        coveragePathIgnorePatterns: [
+          'hasNoToken',
+          '<rootDir>/hasAToken',
+        ],
+      });
+
+      expect(config.coveragePathIgnorePatterns).toEqual([
+        'hasNoToken',
+        joinForPattern('', 'root', 'path', 'foo', 'hasAToken'),
+      ]);
+    });
+  });
+
   describe('testPathIgnorePatterns', () => {
     it('does not normalize paths relative to rootDir', () => {
       // This is a list of patterns, so we can't assume any of them are

--- a/packages/jest-config/src/defaults.js
+++ b/packages/jest-config/src/defaults.js
@@ -23,6 +23,9 @@ module.exports = ({
   cacheDirectory: os.tmpdir(),
   colors: false,
   coverageCollector: require.resolve('./IstanbulCollector'),
+  coveragePathIgnorePatterns: [
+    utils.replacePathSepForRegex(constants.NODE_MODULES),
+  ],
   coverageReporters: ['json', 'text', 'lcov', 'clover'],
   globals: {},
   haste: {

--- a/packages/jest-config/src/normalize.js
+++ b/packages/jest-config/src/normalize.js
@@ -232,6 +232,7 @@ function normalize(config, argv) {
         ]);
         break;
 
+      case 'coveragePathIgnorePatterns':
       case 'modulePathIgnorePatterns':
       case 'preprocessorIgnorePatterns':
       case 'testPathIgnorePatterns':

--- a/packages/jest-runtime/src/index.js
+++ b/packages/jest-runtime/src/index.js
@@ -63,6 +63,7 @@ class Runtime {
   _shouldMockModuleCache: Object;
   _shouldUnmockTransitiveDependenciesCache: Object;
   _testRegex: RegExp;
+  _coverageRegex: RegExp;
   _transitiveShouldMock: Object;
   _unmockList: ?RegExp;
   _virtualMocks: Object;
@@ -87,6 +88,9 @@ class Runtime {
       config.mocksPattern ? new RegExp(config.mocksPattern) : null;
     this._shouldAutoMock = config.automock;
     this._testRegex = new RegExp(config.testRegex.replace(/\//g, path.sep));
+    this._coverageRegex = new RegExp(
+      config.coveragePathIgnorePatterns.replace(/\//g, path.sep),
+    );
     this._virtualMocks = Object.create(null);
 
     this._mockMetaDataCache = Object.create(null);
@@ -337,7 +341,7 @@ class Runtime {
     let collectorStore;
     if (
       shouldCollectCoverage &&
-      !filename.includes(NODE_MODULES) &&
+      !this._coverageRegex.test(filename) &&
       !(this._mocksPattern && this._mocksPattern.test(filename)) &&
       !this._testRegex.test(filename)
     ) {


### PR DESCRIPTION
This allows users to choose which files to ignore coverage information from.