### PR TITLE
Print top level `it` or `test` calls in Jest.

### DIFF
--- a/integration_tests/__tests__/verbose-test.js
+++ b/integration_tests/__tests__/verbose-test.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails oncall+jsinfra
+ */
+'use strict';
+
+const runJest = require('../runJest');
+
+describe('Verbose', () => {
+  it('outputs coverage report', () => {
+    const result = runJest('verbose_logger', ['--verbose']);
+    const stdout = result.stdout.toString();
+
+    expect(result.status).toBe(1);
+
+    expect(stdout).toMatch('it works just fine');
+    expect(stdout).toMatch('it does not work');
+  });
+});

--- a/integration_tests/verbose_logger/__tests__/verbose-test.js
+++ b/integration_tests/verbose_logger/__tests__/verbose-test.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
+test('works just fine', () => {
+  expect(1).toBe(1);
+});
+
+test('does not work', () => {
+  expect(1).toBe(2);
+});

--- a/integration_tests/verbose_logger/package.json
+++ b/integration_tests/verbose_logger/package.json
@@ -1,0 +1,5 @@
+{
+  "jest": {
+    "testEnvironment": "node"
+  }
+}

--- a/packages/jest-config/src/reporters/VerboseLogger.js
+++ b/packages/jest-config/src/reporters/VerboseLogger.js
@@ -25,10 +25,10 @@ class VerboseLogger {
   }
 
   static groupTestsBySuites(testResults: Array<AssertionResult>) {
-    const root: Suite = {
+    const root = {
       suites: [],
       tests: [],
-      title: 'Root Suite',
+      title: '',
     };
 
     testResults.forEach(testResult => {
@@ -48,27 +48,21 @@ class VerboseLogger {
       targetSuite.tests.push(testResult);
     });
 
-    return root.suites;
+    return root;
   }
 
   logTestResults(testResults: Array<AssertionResult>) {
-    VerboseLogger.groupTestsBySuites(testResults).forEach(suite =>
-      this._logSuite(suite, 0),
-    );
-
+    this._logSuite(VerboseLogger.groupTestsBySuites(testResults), 0);
     this._logLine();
   }
 
   _logSuite(suite: Suite, indentLevel: number) {
-    this._logLine(suite.title, indentLevel);
+    if (suite.title) {
+      this._logLine(suite.title, indentLevel);
+    }
 
-    suite.tests.forEach(test =>
-      this._logTest(test, indentLevel + 1),
-    );
-
-    suite.suites.forEach(childSuite =>
-      this._logSuite(childSuite, indentLevel + 1),
-    );
+    suite.tests.forEach(test => this._logTest(test, indentLevel + 1));
+    suite.suites.forEach(suite => this._logSuite(suite, indentLevel + 1));
   }
 
   _getIcon(status: string) {
@@ -84,7 +78,7 @@ class VerboseLogger {
   _logTest(test: AssertionResult, indentLevel: number) {
     const status = this._getIcon(test.status);
     const time = test.duration
-      ? ` (${test.duration.toFixed(0)} ms)`
+      ? ` (${test.duration.toFixed(0)}ms)`
       : '';
     this._logLine(status + ' ' + chalk.gray(test.title + time), indentLevel);
   }

--- a/packages/jest-config/src/reporters/__tests__/VerboseLogger-test.js
+++ b/packages/jest-config/src/reporters/__tests__/VerboseLogger-test.js
@@ -9,6 +9,8 @@
 
 jest.disableAutomock();
 
+const wrap = obj => ({suites: obj, tests: [], title: ''});
+
 describe('VerboseLogger', () => {
   let groupTestsBySuites;
 
@@ -19,7 +21,7 @@ describe('VerboseLogger', () => {
   describe('groupTestsBySuites', () => {
 
     it('should handle empty results', () => {
-      expect(groupTestsBySuites([])).toEqual([]);
+      expect(groupTestsBySuites([])).toEqual(wrap([]));
     });
 
     it('should group A1 in A', () => {
@@ -28,7 +30,7 @@ describe('VerboseLogger', () => {
         ancestorTitles: ['A'],
         failureMessages: [],
         numPassingAsserts: 1,
-      }])).toEqual([{
+      }])).toEqual(wrap([{
         title: 'A',
         suites: [],
         tests: [{
@@ -37,7 +39,7 @@ describe('VerboseLogger', () => {
           failureMessages: [],
           numPassingAsserts: 1,
         }],
-      }]);
+      }]));
     });
 
     it('should group A1 in A; B1 in B', () => {
@@ -51,7 +53,7 @@ describe('VerboseLogger', () => {
         ancestorTitles: ['B'],
         failureMessages: [],
         numPassingAsserts: 1,
-      }])).toEqual([{
+      }])).toEqual(wrap([{
         title: 'A',
         suites: [],
         tests: [{
@@ -69,7 +71,7 @@ describe('VerboseLogger', () => {
           failureMessages: [],
           numPassingAsserts: 1,
         }],
-      }]);
+      }]));
     });
 
     it('should group A1, A2 in A', () => {
@@ -83,7 +85,7 @@ describe('VerboseLogger', () => {
         ancestorTitles: ['A'],
         failureMessages: [],
         numPassingAsserts: 1,
-      }])).toEqual([{
+      }])).toEqual(wrap([{
         title: 'A',
         suites: [],
         tests: [{
@@ -97,7 +99,7 @@ describe('VerboseLogger', () => {
           failureMessages: [],
           numPassingAsserts: 1,
         }],
-      }]);
+      }]));
     });
 
     it('should group A1, A2 in A; B1, B2 in B', () => {
@@ -121,7 +123,7 @@ describe('VerboseLogger', () => {
         ancestorTitles: ['B'],
         failureMessages: [],
         numPassingAsserts: 1,
-      }])).toEqual([{
+      }])).toEqual(wrap([{
         title: 'A',
         suites: [],
         tests: [{
@@ -149,7 +151,7 @@ describe('VerboseLogger', () => {
           failureMessages: [],
           numPassingAsserts: 1,
         }],
-      }]);
+      }]));
     });
 
     it('should group AB1 in AB', () => {
@@ -158,7 +160,7 @@ describe('VerboseLogger', () => {
         ancestorTitles: ['A', 'B'],
         failureMessages: [],
         numPassingAsserts: 1,
-      }])).toEqual([{
+      }])).toEqual(wrap([{
         title: 'A',
         suites: [{
           title: 'B',
@@ -171,7 +173,7 @@ describe('VerboseLogger', () => {
           }],
         }],
         tests: [],
-      }]);
+      }]));
     });
 
     it('should group AB1, AB2 in AB', () => {
@@ -185,7 +187,7 @@ describe('VerboseLogger', () => {
         ancestorTitles: ['A', 'B'],
         failureMessages: [],
         numPassingAsserts: 1,
-      }])).toEqual([{
+      }])).toEqual(wrap([{
         title: 'A',
         suites: [{
           title: 'B',
@@ -203,7 +205,7 @@ describe('VerboseLogger', () => {
           }],
         }],
         tests: [],
-      }]);
+      }]));
     });
 
     it('should group A1 in A; AB1 in AB', () => {
@@ -217,7 +219,7 @@ describe('VerboseLogger', () => {
         ancestorTitles: ['A', 'B'],
         failureMessages: [],
         numPassingAsserts: 1,
-      }])).toEqual([{
+      }])).toEqual(wrap([{
         title: 'A',
         suites: [{
           title: 'B',
@@ -235,7 +237,7 @@ describe('VerboseLogger', () => {
           failureMessages: [],
           numPassingAsserts: 1,
         }],
-      }]);
+      }]));
     });
 
     it('should group AB1 in AB; A1 in A', () => {
@@ -249,7 +251,7 @@ describe('VerboseLogger', () => {
         ancestorTitles: ['A'],
         failureMessages: [],
         numPassingAsserts: 1,
-      }])).toEqual([{
+      }])).toEqual(wrap([{
         title: 'A',
         suites: [{
           title: 'B',
@@ -267,7 +269,7 @@ describe('VerboseLogger', () => {
           failureMessages: [],
           numPassingAsserts: 1,
         }],
-      }]);
+      }]));
     });
 
     it('should group AB1 in AB; CD1 in CD', () => {
@@ -281,7 +283,7 @@ describe('VerboseLogger', () => {
         ancestorTitles: ['C', 'D'],
         failureMessages: [],
         numPassingAsserts: 1,
-      }])).toEqual([{
+      }])).toEqual(wrap([{
         title: 'A',
         suites: [{
           title: 'B',
@@ -307,7 +309,7 @@ describe('VerboseLogger', () => {
           }],
         }],
         tests: [],
-      }]);
+      }]));
     });
 
     it('should group ABC1 in ABC; BC1 in BC; D1 in D; A1 in A', () => {
@@ -331,7 +333,7 @@ describe('VerboseLogger', () => {
         ancestorTitles: ['A'],
         failureMessages: [],
         numPassingAsserts: 1,
-      }])).toEqual([{
+      }])).toEqual(wrap([{
         title: 'A',
         suites: [{
           title: 'B',
@@ -375,7 +377,7 @@ describe('VerboseLogger', () => {
           failureMessages: [],
           numPassingAsserts: 1,
         }],
-      }]);
+      }]));
     });
 
   });

--- a/packages/jest-jasmine2/vendor/jasmine-2.4.1.js
+++ b/packages/jest-jasmine2/vendor/jasmine-2.4.1.js
@@ -703,7 +703,7 @@ getJasmineRequireObj().Env = function(j$) {
     var topSuite = new j$.Suite({
       env: this,
       id: getNextSuiteId(),
-      description: 'Jasmine__TopLevel__Suite',
+      description: 'test',
       queueRunner: queueRunnerFactory
     });
     runnableLookupTable[topSuite.id] = topSuite;

--- a/packages/jest-util/src/formatFailureMessage.js
+++ b/packages/jest-util/src/formatFailureMessage.js
@@ -61,7 +61,7 @@ const formatStackTrace = (stackTrace: string, config) => {
 
 const formatFailureMessage = (testResult: TestResult, config: Config) => {
   const ancestrySeparator = ' \u203A ';
-  const descBullet = config.verbose ? '' : chalk.bold('\u25cf ');
+  const descBullet = config.verbose ? ' ' : chalk.bold('\u25cf ');
 
   if (testResult.testExecError) {
     const error = testResult.testExecError;


### PR DESCRIPTION
Fixes #1121.

cc @dmitriiabramov I think we should redo how we print failure messages. Errors should be printed in-line with the verbose messages instead of printing all the tests and then printing all the failures. Should be a relatively simple change in DefaultTestReporter.