### PR TITLE
remove `json` and `verbose` tests from `scripts/test.js`

### DIFF
--- a/scripts/test.js
+++ b/scripts/test.js
@@ -80,8 +80,6 @@ runCommands('node bin/jest.js --no-watchman', 'packages/jest-cli');
 runCommands('node bin/jest.js --testRunner=jasmine1', 'packages/jest-cli');
 runCommands('node bin/jest.js --runInBand', 'packages/jest-cli');
 runCommands('node bin/jest.js --runInBand --logHeapUsage', 'packages/jest-cli');
-runCommands('node bin/jest.js --json', 'packages/jest-cli');
-runCommands('node bin/jest.js --verbose', 'packages/jest-cli');
 runCommands('node bin/jest.js --notify', 'packages/jest-cli');
 
 examples.forEach(runExampleTests);


### PR DESCRIPTION
we already have them in `integration_tests`