### PR TITLE
Escape bug in React component test

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -2,6 +2,7 @@
 .*/packages/babel-plugin-jest-hoist/node_modules/fbjs/.*
 .*/examples/.*
 .*/website/.*
+.*/integration_tests/.*
 
 [include]
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /packages/*/node_modules/
 /packages/*/build/
 /website/node_modules
+/integration_tests/*/node_modules/
 npm-debug.log
 website/core/metadata*.js
 website/src/jest/docs

--- a/integration_tests/package.json
+++ b/integration_tests/package.json
@@ -1,5 +1,5 @@
 {
-  "jest": {
+ "jest": {
     "automock": false,
     "testEnvironment": "node",
     "testPathIgnorePatterns": [

--- a/integration_tests/snapshot-escape/.babelrc
+++ b/integration_tests/snapshot-escape/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["es2015", "react"]
+}

--- a/integration_tests/snapshot-escape/__tests__/snapshot-test.js
+++ b/integration_tests/snapshot-escape/__tests__/snapshot-test.js
@@ -7,4 +7,14 @@
  */
 'use strict';
 
+import React  from 'react';
+import renderer  from 'react/lib/ReactTestRenderer';
+
 test('escape strings', () => expect('one: \\\'').toMatchSnapshot());
+
+test('escape strings in React components', () => {
+  const tree = renderer.create(
+    <div>{'\\\''}</div>
+  ).toJSON();
+  expect(tree).toMatchSnapshot();
+});

--- a/integration_tests/snapshot-escape/package.json
+++ b/integration_tests/snapshot-escape/package.json
@@ -1,5 +1,14 @@
 {
+  "devDependencies": {
+    "babel-jest": "*",
+    "babel-polyfill": "*",
+    "babel-preset-es2015": "*",
+    "babel-preset-react": "*",
+    "jest-cli": "*",
+    "react": "15.2.0"
+  },
   "jest": {
+    "automock": false,
     "testEnvironment": "node"
   }
 }

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -96,4 +96,5 @@ runCommands('node bin/jest.js --notify', 'packages/jest-cli');
 examples.forEach(runExampleTests);
 
 console.log(chalk.bold(chalk.cyan('Running integration tests:')));
+runCommands('npm update', `${INTEGRATION_TESTS_DIR}/snapshot-escape`);
 runCommands('../packages/jest-cli/bin/jest.js', INTEGRATION_TESTS_DIR);


### PR DESCRIPTION
This is a failing test showing the escape issue is still present when using `\` inside React components.

:warning: Do NOT merge this PR until a fix is available. 