### PR TITLE
non-local jest-cli run will not fail, but will show big red warning

### DIFF
--- a/packages/jest-cli/src/cli/getJest.js
+++ b/packages/jest-cli/src/cli/getJest.js
@@ -12,6 +12,7 @@
 
 import type {Path} from 'types/Config';
 
+const chalk = require('chalk');
 const fs = require('graceful-fs');
 const path = require('path');
 
@@ -33,11 +34,12 @@ function getJest(packageRoot: Path) {
         (dependencies && dependencies['jest-cli']) ||
         (devDependencies && devDependencies['jest-cli'])
       ) {
-        console.error(
-          'Please run `npm install` to use the version of Jest intended for ' +
-          'this project.',
-        );
-        process.on('exit', () => process.exit(1));
+        process.on('exit', () => console.log(
+          chalk.red(
+            'Please run `npm install` to use the version of Jest intended ' +
+            'for this project.',
+          ),
+        ));
       }
     }
     return jest;


### PR DESCRIPTION
Fixes #1293 

Running `jest` from a a location other than `<package>/node_modules` will no longer exit with a non-zero exit code, but it will highlight the warning message when the tests complete.