### PR TITLE
jest-jasmine-adapter#addMatchers

### DIFF
--- a/packages/jest-cli/src/__tests__/customMatchers-test.js
+++ b/packages/jest-cli/src/__tests__/customMatchers-test.js
@@ -48,236 +48,99 @@ const SHOULD_NOT_HAVE_CALLED_WITH =
 const SHOULD_NOT_HAVE_LAST_CALLED_WITH =
   `Shouldn't have been last called with\n${formatter.prettyPrint([1, {}, ''])}`;
 
-const getMockedFunctionWithExpectationResult = expectationResult => {
-  const mockedFunction = jest.fn();
-  const expectation = expect(mockedFunction);
-  if (expectation.addExpectationResult) {
-    expectation.addExpectationResult =
-      expectation.not.addExpectationResult =
-        expectationResult;
-  } else {
-    // skip this tests for jasmine 1 for now by returning a mocked expectation
-    return {
-      toBeCalled() {},
-      toBeCalledWith() {},
-      lastCalledWith() {},
-      not: {
-        toBeCalled() {},
-        toBeCalledWith() {},
-        lastCalledWith() {},
-      },
-      function: mockedFunction,
-    };
-  }
-  expectation.function = mockedFunction;
-  return expectation;
-};
+describe('toBeCalled', () => {
+  it('shows a custom message when the test fails', () => {
+    const fn = jest.fn();
+    expect(() => expect(fn).toBeCalled()).toThrowError(
+      CALLED_AT_LEAST_ONCE,
+    );
+  });
 
-describe('jasmine', () => {
+  it('shows another message for failing a "not" expression', () => {
+    const fn = jest.fn();
+    fn();
+    expect(() => expect(fn).not.toBeCalled()).toThrowError(
+      SHOULD_NOT_BE_CALLED,
+    );
+  });
 
-  describe('when using a getter for a custom matcher message', () => {
+  it(`doesn't show any message when succeeding`, () => {
+    const fn = jest.fn();
+    fn();
+    expect(fn).toBeCalled();
+  });
+});
 
-    it(`doesn't access message if test passes`, () => {
-      if (jasmine.addMatchers) {
-        let actual = false;
-        jasmine.addMatchers({
-          toTestJasmine: () => ({
-            compare: () => ({
-              pass: true,
-              get message() {
-                actual = true;
-                return 'should never be called';
-              },
-            }),
-          }),
-        });
-        const expectation = getMockedFunctionWithExpectationResult(
-          (passed, result) => {
-            expect(passed).toBe(true);
-            expect(result.message).toBe('');
-          },
-        );
-        expectation.toTestJasmine();
-        expect(actual).toBe(false);
-      }
-    });
+describe('lastCalledWith', () => {
+  it(`doesn't show any message when succeding`, () => {
+    const fn = jest.fn();
+    fn(1, {}, '');
+    expect(fn).lastCalledWith(1, {}, '');
+  });
 
-    it('accesses the message when the test fails', () => {
-      if (jasmine.addMatchers) {
-        const SHOULD_BE_CALLED = 'should be called';
-        let actual = false;
-        jasmine.addMatchers({
-          toTestJasmine: () => ({
-            compare: () => ({
-              pass: false,
-              get message() {
-                actual = true;
-                return SHOULD_BE_CALLED;
-              },
-            }),
-          }),
-        });
+  it('shows another message for failing a "not" expression', () => {
+    const fn = jest.fn();
+    fn(1, {}, '');
+    expect(() => expect(fn).not.lastCalledWith(1, {}, '')).toThrowError(
+      SHOULD_NOT_HAVE_LAST_CALLED_WITH,
+    );
+  });
 
-        const expectation = getMockedFunctionWithExpectationResult(
-          (passed, result) => {
-            expect(passed).toBe(false);
-            expect(result.message).toBe(SHOULD_BE_CALLED);
-          },
-        );
-        expectation.toTestJasmine();
-        expect(actual).toBe(true);
-      }
-    });
-
+  it('shows a custom message when the test fails', () => {
+    const fn = jest.fn();
+    fn(1, {}, '');
+    expect(() => expect(fn).lastCalledWith(1, {}, 'Error')).toThrowError(
+      NOT_EXPECTED_VALUES_LAST_TIME,
+    );
   });
 
 });
 
-describe('Jest custom matchers in Jasmine 2', () => {
-
-  describe('toBeCalled', () => {
-
-    it('shows a custom message when the test fails', () => {
-      const expectation = getMockedFunctionWithExpectationResult(
-        (passed, result) => {
-          expect(passed).toBe(false);
-          expect(result.message).toBe(CALLED_AT_LEAST_ONCE);
-        },
-      );
-      expectation.toBeCalled();
-    });
-
-    it('shows another message for failing a "not" expression', () => {
-      const expectation = getMockedFunctionWithExpectationResult(
-        (passed, result) => {
-          expect(passed).toBe(false);
-          expect(result.message).toBe(SHOULD_NOT_BE_CALLED);
-        },
-      );
-      expectation.function();
-      expectation.not.toBeCalled();
-    });
-
-    it(`doesn't show any message when succeeding`, () => {
-      const expectation = getMockedFunctionWithExpectationResult(
-        (passed, result) => {
-          expect(passed).toBe(true);
-          expect(result.message).toBe('');
-        },
-      );
-      expectation.function();
-      expectation.toBeCalled();
-    });
-
+describe('toBeCalledWith', () => {
+  it(`doesn't show any message when succeeding`, () => {
+    const fn = jest.fn();
+    fn(1, {}, '');
+    expect(fn).toBeCalledWith(1, {}, '');
   });
 
-  describe('lastCalledWith', () => {
-
-    it(`doesn't show any message when succeding`, () => {
-      const expectation = getMockedFunctionWithExpectationResult(
-        (passed, result) => {
-          expect(passed).toBe(true);
-          expect(result.message).toBe('');
-        },
-      );
-      expectation.function(1, {}, '');
-      expectation.lastCalledWith(1, {}, '');
-    });
-
-    it('shows another message for failing a "not" expression', () => {
-      const expectation = getMockedFunctionWithExpectationResult(
-        (passed, result) => {
-          expect(passed).toBe(false);
-          expect(result.message).toBe(SHOULD_NOT_HAVE_LAST_CALLED_WITH);
-        },
-      );
-      expectation.function(1, {}, '');
-      expectation.not.lastCalledWith(1, {}, '');
-    });
-
-    it('shows a custom message when the test fails', () => {
-      const expectation = getMockedFunctionWithExpectationResult(
-        (passed, result) => {
-          expect(passed).toBe(false);
-          expect(result.message).toBe(NOT_EXPECTED_VALUES_LAST_TIME);
-        },
-      );
-
-      expectation.function(1, {}, '');
-      expectation.lastCalledWith(1, {}, 'Error');
-    });
-
+  it('shows another message for failing a "not" expression', () => {
+    const fn = jest.fn();
+    fn(1, {}, '');
+    expect(() => expect(fn).not.toBeCalledWith(1, {}, '')).toThrowError(
+      SHOULD_NOT_HAVE_CALLED_WITH,
+    );
   });
 
-  describe('toBeCalledWith', () => {
-
-    it(`doesn't show any message when succeeding`, () => {
-      const expectation = getMockedFunctionWithExpectationResult(
-        (passed, result) => {
-          expect(passed).toBe(true);
-          expect(result.message).toBe('');
-        },
-      );
-      expectation.function(1, {}, '');
-      expectation.toBeCalledWith(1, {}, '');
-    });
-
-    it('shows another message for failing a "not" expression', () => {
-      const expectation = getMockedFunctionWithExpectationResult(
-        (passed, result) => {
-          expect(passed).toBe(false);
-          expect(result.message).toBe(SHOULD_NOT_HAVE_CALLED_WITH);
-        },
-      );
-      expectation.function(1, {}, '');
-      expectation.not.toBeCalledWith(1, {}, '');
-    });
-
-    it('shows a custom message when the test fails without other calls when calls >= 3', () => {
-      const expectation = getMockedFunctionWithExpectationResult(
-        (passed, result) => {
-          expect(passed).toBe(false);
-          expect(result.message).toBe(NOT_EXPECTED_VALUES);
-        },
-      );
-
-      expectation.function(1, {}, '');
-      expectation.toBeCalledWith(1, {}, 'Error');
-    });
-
-    it('shows a custom message with amount of singular amount of other calls when calls === 4', () => {
-      const expectation = getMockedFunctionWithExpectationResult(
-        (passed, result) => {
-          expect(passed).toBe(false);
-          expect(result.message).toBe(NOT_EXPECTED_VALUES_EXACTLY_FOUR);
-        },
-      );
-
-      expectation.function(1);
-      expectation.function(2);
-      expectation.function(3);
-      expectation.function(4);
-      expectation.toBeCalledWith(5);
-    });
-
-    it('shows a custom message with plurar amount of other calls when calls > 4', () => {
-      const expectation = getMockedFunctionWithExpectationResult(
-        (passed, result) => {
-          expect(passed).toBe(false);
-          expect(result.message).toBe(NOT_EXPECTED_VALUES_MORE_THAN_FOUR);
-        },
-      );
-
-      expectation.function(1);
-      expectation.function(2);
-      expectation.function(3);
-      expectation.function(4);
-      expectation.function(6);
-      expectation.function(7);
-      expectation.function(8);
-      expectation.toBeCalledWith(5);
-    });
-
+  it('shows a custom message when the test fails without other calls when calls >= 3', () => {
+    const fn = jest.fn();
+    fn(1, {}, '');
+    expect(() => expect(fn).toBeCalledWith(1, {}, 'Error')).toThrowError(
+      NOT_EXPECTED_VALUES,
+    );
   });
 
+  it('shows a custom message with amount of singular amount of other calls when calls === 4', () => {
+    const fn = jest.fn();
+    fn(1);
+    fn(2);
+    fn(3);
+    fn(4);
+    expect(() => expect(fn).toBeCalledWith(5)).toThrowError(
+      NOT_EXPECTED_VALUES_EXACTLY_FOUR,
+    );
+  });
+
+  it('shows a custom message with plurar amount of other calls when calls > 4', () => {
+    const fn = jest.fn();
+    fn(1);
+    fn(2);
+    fn(3);
+    fn(4);
+    fn(6);
+    fn(7);
+    fn(8);
+    expect(() => expect(fn).toBeCalledWith(5)).toThrowError(
+      NOT_EXPECTED_VALUES_MORE_THAN_FOUR,
+    );
+  });
 });

--- a/packages/jest-jasmine-adapter/package.json
+++ b/packages/jest-jasmine-adapter/package.json
@@ -1,5 +1,6 @@
 {
-  "name": "jest-jasmine2",
+  "name": "jest-jasmine-adapter",
+  "description": "collection of jasmine globals and util functions to make jest backwards compatible with jasmine",
   "version": "13.2.3",
   "repository": {
     "type": "git",
@@ -7,20 +8,17 @@
   },
   "license": "BSD-3-Clause",
   "main": "build/index.js",
-  "dependencies": {
-    "graceful-fs": "^4.1.3",
-    "jasmine-check": "^0.1.4",
-    "jest-jasmine-adapter": "13.2.3",
-    "jest-matchers": "^13.2.3",
-    "jest-snapshot": "^13.2.3",
-    "jest-util": "^13.2.2"
-  },
   "jest": {
+    "automock": false,
     "rootDir": "./src",
     "scriptPreprocessor": "../../babel-jest",
     "testEnvironment": "node"
   },
   "scripts": {
     "test": "../../packages/jest-cli/bin/jest.js"
+  },
+  "dependencies": {
+    "jasmine": "^2.4.1",
+    "jest-matchers": "13.2.3"
   }
 }

--- a/packages/jest-jasmine-adapter/src/__tests__/addMatchers-test.js
+++ b/packages/jest-jasmine-adapter/src/__tests__/addMatchers-test.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails oncall+jsinfra
+ */
+
+'use strict';
+
+const {JestAssertionError} = require('jest-matchers');
+
+jasmine.addMatchers({
+  ___toBeDivisibleBy(util) {
+    return {
+      compare(actual, expected) {
+        const pass = actual % expected === 0;
+        const message = pass
+          ? `expected ${actual} to not be divisible by ${expected}`
+          : `expected ${actual} to be divisible by ${expected}`;
+        return {pass, message};
+      },
+    };
+  },
+});
+
+it('uses jest matcher and not jasmine matcher', () => {
+  let error;
+
+  try {
+    expect(11).___toBeDivisibleBy(5);
+  } catch (e) {
+    error = e;
+  }
+
+  expect(error instanceof JestAssertionError).toBe(true);
+});

--- a/packages/jest-jasmine-adapter/src/index.js
+++ b/packages/jest-jasmine-adapter/src/index.js
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+'use strict';
+
+const {addMatchers} = require('jest-matchers');
+
+// A single place to store everything jasmine related. (hacks, patches,
+// backward compatibility functions, etc.)
+const setup = () => {
+  const jasmine = global.jasmine || require('jasmine');
+
+  if (!global.jasmine) {
+    global.jasmine = Object.create(null);
+  }
+
+  jasmine.addMatchers = makeAddMatchersFn(jasmine);
+};
+
+// Adapter function that replaces `jasmine.addMatchers` and make it
+// add matchers to `jest-matchers` instead. This way existing custom
+// matchers in www can still work without jasmine.
+const makeAddMatchersFn = jasmine => {
+  return jasmineMatchersObject => {
+    const jestMatchersObject = {};
+
+    Object.keys(jasmineMatchersObject).forEach(name => {
+      jestMatchersObject[name] = function() {
+        const jasmineMatcherResult = jasmineMatchersObject[name](
+          jasmine.matchersUtil,
+           // We don't have access to custom equality matchers
+           // but it doesn't seem like this feature is used a lot anywhere
+          null,
+        );
+
+        // if there is no 'negativeCompare', both should be handled by `compare`
+        const negativeCompare =
+          jasmineMatcherResult.negativeCompare || jasmineMatcherResult.compare;
+
+        return this.isNot
+          ? negativeCompare.apply(null, arguments)
+          : jasmineMatcherResult.compare.apply(null, arguments);
+      };
+    });
+
+    addMatchers(jestMatchersObject);
+  };
+};
+
+module.exports = {
+  setup,
+};

--- a/packages/jest-jasmine2/src/__tests__/matchers-test.js
+++ b/packages/jest-jasmine2/src/__tests__/matchers-test.js
@@ -10,7 +10,6 @@
 'use strict';
 
 jest.disableAutomock();
-const jestExpect = require('jest-matchers').expect;
 
 describe('matchers', () => {
   it('proxies matchers to jest-matchers', () => {

--- a/packages/jest-jasmine2/src/index.js
+++ b/packages/jest-jasmine2/src/index.js
@@ -297,6 +297,8 @@ function jasmine2(
 
   env.addReporter(reporter);
 
+  runtime.requireModule(path.resolve(__dirname, './setupJasmineAdapter.js'));
+
   // `jest-matchers` should be required inside test environment (vm).
   // Otherwise if they throw, the `Error` class will differ from the `Error`
   // class of the test and `error instanceof Error` will return `false`.

--- a/packages/jest-jasmine2/src/setupJasmineAdapter.js
+++ b/packages/jest-jasmine2/src/setupJasmineAdapter.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+jest.deepUnmock('jest-jasmine-adapter');
+require('jest-jasmine-adapter').setup();

--- a/packages/jest-matchers/src/__tests__/matcherContext-test.js
+++ b/packages/jest-matchers/src/__tests__/matcherContext-test.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails oncall+jsinfra
+ */
+
+'use strict';
+
+const {addMatchers} = require('..');
+
+addMatchers({
+  _ensureMatchersHaveAccessToContext(actual) {
+    actual.call(this);
+    return {pass: !this.isNot, message: ''};
+  },
+});
+
+test('matchers can access matcher context', () => {
+  expect(function() {
+    expect(this.isNot).toBe(false);
+  })._ensureMatchersHaveAccessToContext();
+
+  expect(function() {
+    expect(this.isNot).toBe(true);
+  }).not._ensureMatchersHaveAccessToContext();
+});

--- a/packages/jest-matchers/src/types.js
+++ b/packages/jest-matchers/src/types.js
@@ -20,6 +20,7 @@ export type RawMatcherFn = (
   options: any,
 ) => ExpectationResult;
 
+export type MatcherContext = {isNot: boolean};
 export type ThrowingMatcherFn = (actual: any) => void;
 export type MatchersObject = {[id:string]: RawMatcherFn};
 export type Expect = (expected: any) => ExpectationObject;


### PR DESCRIPTION
jasmine.addMatchers now will add matchers to `jest-matchers` and skip jasmine