### PR TITLE
Move `Resolver.create` and `HasteMap.create`

### DIFF
--- a/packages/jest-cli/src/TestWorker.js
+++ b/packages/jest-cli/src/TestWorker.js
@@ -18,10 +18,8 @@ process.on('uncaughtException', err => {
   process.exit(1);
 });
 
+const Runtime = require('jest-runtime');
 const Test = require('./Test');
-
-const createHasteMap = require('jest-haste-map').create;
-const createResolver = require('jest-resolve').create;
 
 type WorkerData = {
   config: Config,
@@ -52,9 +50,9 @@ module.exports = (data: WorkerData, callback: WorkerCallback) => {
   try {
     const name = data.config.name;
     if (!resolvers[name]) {
-      resolvers[name] = createResolver(
+      resolvers[name] = Runtime.createResolver(
         data.config,
-        createHasteMap(data.config).read(),
+        Runtime.createHasteMap(data.config).read(),
       );
     }
 

--- a/packages/jest-cli/src/__tests__/SearchSource-test.js
+++ b/packages/jest-cli/src/__tests__/SearchSource-test.js
@@ -43,7 +43,7 @@ describe('SearchSource', () => {
         rootDir: '.',
         testPathDirs: [],
       });
-      Runtime.buildHasteMap(config, {maxWorkers}).then(hasteMap => {
+      Runtime.createHasteContext(config, {maxWorkers}).then(hasteMap => {
         searchSource = new SearchSource(hasteMap, config);
         done();
       });
@@ -74,7 +74,7 @@ describe('SearchSource', () => {
   describe('testPathsMatching', () => {
     beforeEach(() => {
       findMatchingTests = config =>
-        Runtime.buildHasteMap(config, {maxWorkers}).then(hasteMap =>
+        Runtime.createHasteContext(config, {maxWorkers}).then(hasteMap =>
           new SearchSource(hasteMap, config).findMatchingTests(),
         );
     });
@@ -253,7 +253,7 @@ describe('SearchSource', () => {
         name: 'SearchSource-findRelatedTests-tests',
         rootDir,
       });
-      Runtime.buildHasteMap(config, {maxWorkers}).then(hasteMap => {
+      Runtime.createHasteContext(config, {maxWorkers}).then(hasteMap => {
         searchSource = new SearchSource(hasteMap, config);
         done();
       });

--- a/packages/jest-cli/src/jest.js
+++ b/packages/jest-cli/src/jest.js
@@ -85,7 +85,7 @@ function getWatcher(config, packageRoot, callback) {
 function runJest(config, argv, pipe, onComplete) {
   const patternInfo = buildTestPathPatternInfo(argv);
   const maxWorkers = getMaxWorkers(argv);
-  return Runtime.buildHasteMap(config, {maxWorkers})
+  return Runtime.createHasteContext(config, {maxWorkers})
     .then(hasteMap => {
       const source = new SearchSource(hasteMap, config);
       return source.getTestPaths(patternInfo)

--- a/packages/jest-haste-map/src/index.js
+++ b/packages/jest-haste-map/src/index.js
@@ -10,7 +10,7 @@
 'use strict';
 
 import type {HasteMap as HasteMapObject, ModuleMetaData} from 'types/HasteMap';
-import type {Config, Path} from 'types/Config';
+import type {Path} from 'types/Config';
 import type {WorkerMessage, WorkerMetadata, WorkerCallback} from './types';
 import typeof HType from './constants';
 import typeof FastpathType from './fastpath';
@@ -55,14 +55,8 @@ type InternalOptions = {
   useWatchman: boolean,
 };
 
-type HasteMapOptions = {
-  maxWorkers: number,
-  resetCache: boolean,
-}
-
 const NODE_MODULES = path.sep + 'node_modules' + path.sep;
 const VERSION = require('../package.json').version;
-const SNAPSHOT_EXTENSION = 'snap';
 
 const canUseWatchman = ((): boolean => {
   try {
@@ -196,29 +190,6 @@ class HasteMap {
     this._buildPromise = null;
     this._workerPromise = null;
     this._workerFarm = null;
-  }
-
-  static create(
-    config: Config,
-    options?: HasteMapOptions,
-  ): HasteMap {
-    const ignorePattern = new RegExp(
-      [config.cacheDirectory].concat(config.modulePathIgnorePatterns).join('|'),
-    );
-
-    return new HasteMap({
-      cacheDirectory: config.cacheDirectory,
-      extensions: [SNAPSHOT_EXTENSION].concat(config.moduleFileExtensions),
-      ignorePattern,
-      maxWorkers: (options && options.maxWorkers) || 1,
-      mocksPattern: config.mocksPattern,
-      name: config.name,
-      platforms: config.haste.platforms || ['ios', 'android'],
-      providesModuleNodeModules: config.haste.providesModuleNodeModules,
-      resetCache: options && options.resetCache,
-      roots: config.testPathDirs,
-      useWatchman: config.watchman,
-    });
   }
 
   static getCacheFilePath(tmpdir: Path, name: string): string {

--- a/packages/jest-resolve/src/index.js
+++ b/packages/jest-resolve/src/index.js
@@ -15,7 +15,7 @@ import type {
   HType,
   HTypeValue,
 } from 'types/HasteMap';
-import type {Config, Path} from 'types/Config';
+import type {Path} from 'types/Config';
 
 const H: HType = require('jest-haste-map').H;
 
@@ -50,17 +50,6 @@ const NATIVE_PLATFORM = 'native';
 const nodePaths =
   (process.env.NODE_PATH ? process.env.NODE_PATH.split(path.delimiter) : null);
 
-const getModuleNameMapper = (config: Config) => {
-  if (config.moduleNameMapper.length) {
-    const moduleNameMapper = Object.create(null);
-    config.moduleNameMapper.forEach(
-      map => moduleNameMapper[map[1]] = new RegExp(map[0]),
-    );
-    return moduleNameMapper;
-  }
-  return null;
-};
-
 class Resolver {
   _options: ResolverConfig;
   _supportsNativePlatform: boolean;
@@ -85,22 +74,6 @@ class Resolver {
     this._moduleMap = moduleMap;
     this._moduleNameCache = Object.create(null);
     this._modulePathCache = Object.create(null);
-  }
-
-  static create(
-    config: Config,
-    moduleMap: HasteMap,
-  ): Resolver {
-    return new Resolver(moduleMap, {
-      browser: config.browser,
-      defaultPlatform: config.haste.defaultPlatform,
-      extensions: config.moduleFileExtensions.map(extension => '.' + extension),
-      hasCoreModules: true,
-      moduleDirectories: config.moduleDirectories,
-      moduleNameMapper: getModuleNameMapper(config),
-      modulePaths: config.modulePaths,
-      platforms: config.haste.platforms,
-    });
   }
 
   static findNodeModule(path: Path, options: FindNodeModuleConfig): ?Path {

--- a/packages/jest-runtime/src/__mocks__/createRuntime.js
+++ b/packages/jest-runtime/src/__mocks__/createRuntime.js
@@ -12,8 +12,6 @@ module.exports = function createRuntime(filename, config) {
   const NodeEnvironment = require('jest-environment-node');
   const Runtime = require('../');
 
-  const createHasteMap = require('jest-haste-map').create;
-  const createResolver = require('jest-resolve').create;
   const normalizeConfig = require('jest-config').normalize;
 
   config = normalizeConfig(Object.assign({
@@ -22,13 +20,13 @@ module.exports = function createRuntime(filename, config) {
   }, config));
 
   const environment = new NodeEnvironment(config);
-  return createHasteMap(config, {resetCache: false, maxWorkers: 1})
+  return Runtime.createHasteMap(config, {resetCache: false, maxWorkers: 1})
     .build()
     .then(moduleMap => {
       const runtime = new Runtime(
         config,
         environment,
-        createResolver(config, moduleMap),
+        Runtime.createResolver(config, moduleMap),
       );
 
       runtime.__mockRootPath = path.join(config.rootDir, 'root.js');

--- a/packages/jest-runtime/src/cli/index.js
+++ b/packages/jest-runtime/src/cli/index.js
@@ -61,7 +61,7 @@ function run(cliArgv?: Object, cliInfo?: Array<string>) {
   console.log(`Using Jest Runtime v${VERSION}${info}`);
   readConfig(argv, root)
     .then(config => {
-      Runtime.buildHasteMap(config, {
+      Runtime.createHasteContext(config, {
         maxWorkers: os.cpus().length - 1,
       })
         .then(hasteMap => {


### PR DESCRIPTION
to `Runtime.create(Resolver|HasteMap)`.

This way `jest-haste-map` and `jest-resolve` don’t require knowledge of Jest’s configs and can be used more clearly outside of Jest.