### PR TITLE
Make the getting started tutorial more clear.

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -34,6 +34,7 @@ describe('sum', () => {
   });
 });
 ```
+> Note: Make sure the `__tests__/` folder is at the same level with `sum.js` file, otherwise the test can not be found.
 
 Add the following to your `package.json`:
 


### PR DESCRIPTION
I happens to put the `__tests__` folder at different level from the folder `sum.js` is in and the Jest can't find module `sum` , after checking out the repo I realize I should put those at the same level. Maybe this will help others.