### PR TITLE
Snapshot failures

### DIFF
--- a/packages/jest-cli/src/TestRunner.js
+++ b/packages/jest-cli/src/TestRunner.js
@@ -161,8 +161,8 @@ class TestRunner {
           aggregatedResults.numRuntimeErrorTestSuites === 0;
         return snapshot.cleanup(this._hasteContext, config.updateSnapshot)
           .then(status => {
-            aggregatedResults.snapshotFilesRemoved = status.filesRemoved;
-            aggregatedResults.didUpdate = config.updateSnapshot;
+            aggregatedResults.snapshot.filesRemoved = status.filesRemoved;
+            aggregatedResults.snapshot.didUpdate = config.updateSnapshot;
             this._dispatcher.onRunComplete(config, aggregatedResults);
             aggregatedResults.success = !this._dispatcher.hasErrors();
             return aggregatedResults;
@@ -255,7 +255,6 @@ class TestRunner {
 
 const createAggregatedResults = (numTotalTestSuites: number) => {
   return {
-    didUpdate: false,
     numFailedTests: 0,
     numFailedTestSuites: 0,
     numPassedTests: 0,
@@ -264,7 +263,10 @@ const createAggregatedResults = (numTotalTestSuites: number) => {
     numRuntimeErrorTestSuites: 0,
     numTotalTests: 0,
     numTotalTestSuites,
-    snapshotFilesRemoved: 0,
+    snapshot: {
+      didUpdate: false,
+      filesRemoved: 0,
+    },
     startTime: Date.now(),
     success: false,
     testResults: [],
@@ -291,7 +293,10 @@ const addResult = (
   }
 };
 
-const buildFailureTestResult = (testPath: string, err: TestError) => {
+const buildFailureTestResult = (
+  testPath: string,
+  err: TestError
+): TestResult => {
   return {
     hasUncheckedKeys: false,
     numFailingTests: 1,
@@ -301,11 +306,13 @@ const buildFailureTestResult = (testPath: string, err: TestError) => {
       end: 0,
       start: 0,
     },
-    snapshotFileDeleted: false,
-    snapshotsAdded: 0,
-    snapshotsMatched: 0,
-    snapshotsUnmatched: 0,
-    snapshotsUpdated: 0,
+    snapshot: {
+      fileDeleted: false,
+      added: 0,
+      matched: 0,
+      unmatched: 0,
+      updated: 0,
+    },
     testExecError: err,
     testFilePath: testPath,
     testResults: [],

--- a/packages/jest-cli/src/lib/formatTestResults.js
+++ b/packages/jest-cli/src/lib/formatTestResults.js
@@ -13,7 +13,7 @@
 const utils = require('jest-util');
 
 import type {
-  AggregatedTestResults,
+  AggregatedResult,
   CodeCoverageFormatter,
   CodeCoverageReporter,
   TestResult,
@@ -59,7 +59,7 @@ const formatResult = (
 };
 
 function formatTestResults(
-  results: AggregatedTestResults,
+  results: AggregatedResult,
   config: Config,
   codeCoverageFormatter?: CodeCoverageFormatter,
   reporter?: CodeCoverageReporter,

--- a/packages/jest-cli/src/reporters/NotifyReporter.js
+++ b/packages/jest-cli/src/reporters/NotifyReporter.js
@@ -25,8 +25,11 @@ class NotifyReporter extends BaseReporter {
   onRunComplete(config: Config, result: AggregatedResult): void {
     let title;
     let message;
+    const success = result.numFailedTests === 0 &&
+      result.numRuntimeErrorTestSuites === 0;
 
-    if (result.success) {
+
+    if (success) {
       title = util.format('%d%% Passed', 100);
       message = util.format(
         (isDarwin ? '\u2705 ' : '') + '%d tests passed',

--- a/packages/jest-cli/src/reporters/SummaryReporter.js
+++ b/packages/jest-cli/src/reporters/SummaryReporter.js
@@ -9,25 +9,12 @@
  */
 'use strict';
 
-import type {AggregatedResult} from 'types/TestResult';
+import type {AggregatedResult, SnapshotSummary} from 'types/TestResult';
 import type {Config} from 'types/Config';
 
 const chalk = require('chalk');
 const BaseReporter = require('./BaseReporter');
 
-type SnapshotSummary = {
-  added: number,
-  didUpdate: boolean,
-  filesAdded: number,
-  filesRemoved: number,
-  filesUnmatched: number,
-  filesUpdated: number,
-  matched: number,
-  total: number,
-  unchecked: number,
-  unmatched: number,
-  updated: number,
-};
 
 const FAIL_COLOR = chalk.bold.red;
 const PASS_COLOR = chalk.bold.green;
@@ -50,16 +37,11 @@ class SummareReporter extends BaseReporter {
     const totalErrors = aggregatedResults.numRuntimeErrorTestSuites;
     const runTime = (Date.now() - aggregatedResults.startTime) / 1000;
 
-    const snapshots = this._getSnapshotSummary(aggregatedResults);
-    const snapshotFailure = !!(!snapshots.didUpdate && (
-      snapshots.unchecked ||
-      snapshots.unmatched ||
-      snapshots.filesRemoved
-    ));
+    const snapshots = aggregatedResults.snapshot;
 
     let results = '';
 
-    if (snapshotFailure) {
+    if (snapshots.failure) {
       results += FAIL_COLOR('snapshot failure') + ', ';
     }
 
@@ -87,56 +69,6 @@ class SummareReporter extends BaseReporter {
     this._printSummary(aggregatedResults);
     this._printSnapshotSummary(snapshots);
     this.log(results);
-
-    if (failedTests || totalErrors || snapshotFailure) {
-      this._setError(new Error('Some of the tests failed'));
-    }
-  }
-
-  _getSnapshotSummary(aggregatedResults: AggregatedResult): SnapshotSummary {
-    let added = 0;
-    let filesAdded = 0;
-    let filesRemoved = aggregatedResults.snapshot.filesRemoved;
-    let filesUnmatched = 0;
-    let filesUpdated = 0;
-    let matched = 0;
-    let unchecked = 0;
-    let unmatched = 0;
-    let updated = 0;
-    aggregatedResults.testResults.forEach(result => {
-      if (result.snapshot.added) {
-        filesAdded++;
-      }
-      if (result.snapshot.fileDeleted) {
-        filesRemoved++;
-      }
-      if (result.snapshot.unmatched) {
-        filesUnmatched++;
-      }
-      if (result.snapshot.updated) {
-        filesUpdated++;
-      }
-      if (result.hasUncheckedKeys) {
-        unchecked++;
-      }
-      added += result.snapshot.added;
-      matched += result.snapshot.matched;
-      unmatched += result.snapshot.unmatched;
-      updated += result.snapshot.updated;
-    });
-    return {
-      added,
-      didUpdate: aggregatedResults.snapshot.didUpdate,
-      filesAdded,
-      filesRemoved,
-      filesUnmatched,
-      filesUpdated,
-      matched,
-      total: matched + added + updated,
-      unchecked,
-      unmatched,
-      updated,
-    };
   }
 
   _printSnapshotSummary(snapshots: SnapshotSummary) {

--- a/packages/jest-cli/src/reporters/SummaryReporter.js
+++ b/packages/jest-cli/src/reporters/SummaryReporter.js
@@ -96,7 +96,7 @@ class SummareReporter extends BaseReporter {
   _getSnapshotSummary(aggregatedResults: AggregatedResult): SnapshotSummary {
     let added = 0;
     let filesAdded = 0;
-    let filesRemoved = aggregatedResults.snapshotFilesRemoved;
+    let filesRemoved = aggregatedResults.snapshot.filesRemoved;
     let filesUnmatched = 0;
     let filesUpdated = 0;
     let matched = 0;
@@ -104,29 +104,29 @@ class SummareReporter extends BaseReporter {
     let unmatched = 0;
     let updated = 0;
     aggregatedResults.testResults.forEach(result => {
-      if (result.snapshotsAdded) {
+      if (result.snapshot.added) {
         filesAdded++;
       }
-      if (result.snapshotFileDeleted) {
+      if (result.snapshot.fileDeleted) {
         filesRemoved++;
       }
-      if (result.snapshotsUnmatched) {
+      if (result.snapshot.unmatched) {
         filesUnmatched++;
       }
-      if (result.snapshotsUpdated) {
+      if (result.snapshot.updated) {
         filesUpdated++;
       }
       if (result.hasUncheckedKeys) {
         unchecked++;
       }
-      added += result.snapshotsAdded;
-      matched += result.snapshotsMatched;
-      unmatched += result.snapshotsUnmatched;
-      updated += result.snapshotsUpdated;
+      added += result.snapshot.added;
+      matched += result.snapshot.matched;
+      unmatched += result.snapshot.unmatched;
+      updated += result.snapshot.updated;
     });
     return {
       added,
-      didUpdate: aggregatedResults.didUpdate,
+      didUpdate: aggregatedResults.snapshot.didUpdate,
       filesAdded,
       filesRemoved,
       filesUnmatched,

--- a/packages/jest-jasmine2/src/index.js
+++ b/packages/jest-jasmine2/src/index.js
@@ -314,11 +314,11 @@ function jasmine2(
     const status = currentSnapshot.save(updateSnapshot);
 
     results.hasUncheckedKeys = !status.deleted && hasUncheckedKeys;
-    results.snapshotFileDeleted = status.deleted;
-    results.snapshotsAdded = snapshotState.added;
-    results.snapshotsMatched = snapshotState.matched;
-    results.snapshotsUnmatched = snapshotState.unmatched;
-    results.snapshotsUpdated = snapshotState.updated;
+    results.snapshot.fileDeleted = status.deleted;
+    results.snapshot.added = snapshotState.added;
+    results.snapshot.matched = snapshotState.matched;
+    results.snapshot.unmatched = snapshotState.unmatched;
+    results.snapshot.updated = snapshotState.updated;
     return results;
   });
 }

--- a/packages/jest-jasmine2/src/reporter.js
+++ b/packages/jest-jasmine2/src/reporter.js
@@ -91,6 +91,7 @@ class Jasmine2Reporter {
       numPassingTests,
       numPendingTests,
       testResults,
+      snapshot: {},
     });
   }
 

--- a/types/TestResult.js
+++ b/types/TestResult.js
@@ -42,7 +42,6 @@ export type AssertionResult = {
 };
 
 export type AggregatedResult = {
-  didUpdate: boolean,
   numFailedTests: number,
   numFailedTestSuites: number,
   numPassedTests: number,
@@ -51,7 +50,10 @@ export type AggregatedResult = {
   numRuntimeErrorTestSuites: number,
   numTotalTests: number,
   numTotalTestSuites: number,
-  snapshotFilesRemoved: number,
+  snapshot: {
+    didUpdate: boolean,
+    filesRemoved: number,
+  },
   startTime: number,
   success: boolean,
   testResults: Array<TestResult>,
@@ -75,11 +77,13 @@ export type TestResult = {
     end: Milliseconds,
     start: Milliseconds,
   },
-  snapshotFileDeleted: boolean,
-  snapshotsAdded: number,
-  snapshotsMatched: number,
-  snapshotsUnmatched: number,
-  snapshotsUpdated: number,
+  snapshot: {
+    fileDeleted: boolean,
+    added: number,
+    matched: number,
+    unmatched: number,
+    updated: number,
+  },
   testExecError: Error,
   testFilePath: string,
   testResults: Array<AssertionResult>,

--- a/types/TestResult.js
+++ b/types/TestResult.js
@@ -50,10 +50,7 @@ export type AggregatedResult = {
   numRuntimeErrorTestSuites: number,
   numTotalTests: number,
   numTotalTestSuites: number,
-  snapshot: {
-    didUpdate: boolean,
-    filesRemoved: number,
-  },
+  snapshot: SnapshotSummary,
   startTime: number,
   success: boolean,
   testResults: Array<TestResult>,
@@ -89,20 +86,6 @@ export type TestResult = {
   testResults: Array<AssertionResult>,
 };
 
-export type AggregatedTestResults = {
-  success: ?boolean,
-  startTime: Date,
-  numTotalTestSuites: number,
-  numPassedTestSuites: number,
-  numFailedTestSuites: number,
-  numRuntimeErrorTestSuites: number,
-  numTotalTests: number,
-  numPassedTests: number,
-  numFailedTests: number,
-  numPendingTests: number,
-  testResults: Array<TestResult>,
-};
-
 export type CodeCoverageResult = {
   coveredSpans: Array<Object>,
   uncoveredSpans: Array<Object>,
@@ -115,3 +98,19 @@ export type CodeCoverageFormatter = (
   coverage: ?CodeCoverageResult,
   reporter?: CodeCoverageReporter,
 ) => ?Object;
+
+
+export type SnapshotSummary = {
+  added: number,
+  didUpdate: boolean,
+  failure: boolean,
+  filesAdded: number,
+  filesRemoved: number,
+  filesUnmatched: number,
+  filesUpdated: number,
+  matched: number,
+  total: number,
+  unchecked: number,
+  unmatched: number,
+  updated: number,
+};


### PR DESCRIPTION
moving snapshot logic from reporters to the core of jest.

Decision of whether the test run is successful or not is based on three factors
1. Are there any test failures?
2. Were any snapshots updated/removed/unused?
3. Did any of the reporters throw? (the only case right now is coverage threshold)

**1** and **2** have to be captured in jest itself and not anywhere else, because it's the core functionality of jest. Because we had **2** spread across multiple files, things kept breaking and it especially hard to integrate it with the internal runner.

after this change:
1. Test results are generated **only** in test runner (initially in jasmine though)
2. Reporters only consume results and don't modify anything (there is still one exception in the old code, but i'll fix it)