### PR TITLE
Add concept of internal modules to jest-runtime.

### DIFF
--- a/packages/jest-jasmine2/src/extendJasmineExpect.js
+++ b/packages/jest-jasmine2/src/extendJasmineExpect.js
@@ -7,8 +7,6 @@
  */
 'use strict';
 
-jest.deepUnmock('jest-matchers');
-
 const jestExpect = require('jest-matchers').expect;
 
 const jasmineExpect = global.expect;

--- a/packages/jest-jasmine2/src/index.js
+++ b/packages/jest-jasmine2/src/index.js
@@ -155,7 +155,7 @@ function jasmine2(
     '',
     'jest-check',
     () => {
-      const jasmineCheck = runtime.requireModule(JASMINE_CHECK_PATH);
+      const jasmineCheck = runtime.requireInternalModule(JASMINE_CHECK_PATH);
       return jasmineCheck(environment.global, config.testcheckOptions);
     },
     {virtual: true},
@@ -300,7 +300,9 @@ function jasmine2(
   // `jest-matchers` should be required inside test environment (vm).
   // Otherwise if they throw, the `Error` class will differ from the `Error`
   // class of the test and `error instanceof Error` will return `false`.
-  runtime.requireModule(path.resolve(__dirname, './extendJasmineExpect.js'));
+  runtime.requireInternalModule(
+    path.resolve(__dirname, './extendJasmineExpect.js'),
+  );
 
   runtime.requireModule(testPath);
   env.execute();

--- a/packages/jest-jasmine2/src/jasmine-check.js
+++ b/packages/jest-jasmine2/src/jasmine-check.js
@@ -7,8 +7,6 @@
  */
 'use strict';
 
-jest.unmock('jasmine-check');
-
 const jasmineCheck = require('jasmine-check');
 
 module.exports = (global, configOptions) => {

--- a/packages/jest-runtime/src/__tests__/Runtime-internalModule-test.js
+++ b/packages/jest-runtime/src/__tests__/Runtime-internalModule-test.js
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails oncall+jsinfra
+ */
+'use strict';
+
+const path = require('path');
+
+let createRuntime;
+
+describe('Runtime', () => {
+  beforeEach(() => {
+    createRuntime = require('createRuntime');
+  });
+
+  describe('internalModule', () => {
+    it('loads modules and applies transforms', () =>
+      createRuntime(__filename, {
+        scriptPreprocessor: './test-preprocessor',
+      }).then(runtime => {
+        const modulePath = path.resolve(
+          path.dirname(runtime.__mockRootPath),
+          'internal-root.js',
+        );
+        expect(() => {
+          runtime.requireModule(modulePath);
+        }).toThrow(new Error('preprocessor must not run.'));
+      }),
+    );
+
+    it('loads internal modules without applying transforms', () =>
+      createRuntime(__filename, {
+        scriptPreprocessor: './test-preprocessor',
+      }).then(runtime => {
+        const modulePath = path.resolve(
+          path.dirname(runtime.__mockRootPath),
+          'internal-root.js',
+        );
+        const exports = runtime.requireInternalModule(modulePath);
+        expect(exports()).toBe('internal-module-data');
+      }),
+    );
+  });
+});

--- a/packages/jest-runtime/src/__tests__/test_root/internal-module.js
+++ b/packages/jest-runtime/src/__tests__/test_root/internal-module.js
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+module.exports = () => 'internal-module-data';

--- a/packages/jest-runtime/src/__tests__/test_root/internal-root.js
+++ b/packages/jest-runtime/src/__tests__/test_root/internal-root.js
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+module.exports = require('./internal-module');

--- a/packages/jest-runtime/src/__tests__/test_root/test-preprocessor.js
+++ b/packages/jest-runtime/src/__tests__/test_root/test-preprocessor.js
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+module.exports.process = () => `throw new Error('preprocessor must not run.');`;

--- a/packages/jest-runtime/src/transform.js
+++ b/packages/jest-runtime/src/transform.js
@@ -112,7 +112,7 @@ const readCacheFile = (filePath: Path, cachePath: Path): ?string => {
 
 module.exports = (
   filename: Path,
-  config: Config,
+  config: ?Config,
   options: ?TransformOptions,
 ): vm.Script => {
   const mtime = fs.statSync(filename).mtime;
@@ -133,7 +133,7 @@ module.exports = (
     content = content.replace(/^#!.*/, '');
   }
 
-  if (!ignoreCache.has(config)) {
+  if (config && !ignoreCache.has(config)) {
     ignoreCache.set(
       config,
       new RegExp(config.preprocessorIgnorePatterns.join('|')),
@@ -141,6 +141,7 @@ module.exports = (
   }
 
   if (
+    config &&
     config.scriptPreprocessor &&
     (
       !config.preprocessorIgnorePatterns.length ||


### PR DESCRIPTION
This is necessary to run jest code in a context that is isolated from configuration like preprocessors.

Open questions: should these be cached indefinitely and not be able to be wiped away through `jest.resetModuleRegistry()`?