### PR TITLE
Update snapshot example to correspond with test name

### DIFF
--- a/blog/2016-07-27-jest-14.md
+++ b/blog/2016-07-27-jest-14.md
@@ -26,7 +26,7 @@ test('Link renders correctly', () => {
 The first time this test is run, Jest creates a [snapshot file](https://github.com/facebook/jest/blob/master/examples/snapshot/__tests__/__snapshots__/Link.react-test.js.snap) that looks like this:
 
 ```javascript
-exports[`Link changes the class when hovered 1`] = `
+exports[`Link renders correctly 1`] = `
 <a
   className="normal"
   href="http://www.facebook.com"


### PR DESCRIPTION
The test was "Link renders correctly" but the snapshot example was "Link changes the class when hovered", which was a bit confusing.