### PR TITLE
Allow to specify custom argv and root for jest-cli.

### DIFF
--- a/packages/jest-cli/src/jest.js
+++ b/packages/jest-cli/src/jest.js
@@ -17,15 +17,16 @@ const realFs = require('fs');
 const fs = require('graceful-fs');
 fs.gracefulify(realFs);
 
-const TestRunner = require('./TestRunner');
-const SearchSource = require('./SearchSource');
-
 const Runtime = require('jest-runtime');
+const SearchSource = require('./SearchSource');
+const TestRunner = require('./TestRunner');
+
 const chalk = require('chalk');
 const formatTestResults = require('./lib/formatTestResults');
 const os = require('os');
 const path = require('path');
 const readConfig = require('jest-config').readConfig;
+const {run} = require('./cli');
 const sane = require('sane');
 const which = require('which');
 
@@ -208,6 +209,7 @@ function runCLI(argv: Object, root: Path, onComplete: () => void) {
 
 module.exports = {
   getVersion: () => VERSION,
+  run,
   runCLI,
   SearchSource,
   TestRunner,

--- a/packages/jest-config/src/normalize.js
+++ b/packages/jest-config/src/normalize.js
@@ -15,6 +15,9 @@ const constants = require('./constants');
 const path = require('path');
 const utils = require('jest-util');
 
+const JSON_EXTENSION = '.json';
+const PRESET_NAME = 'jest-preset' + JSON_EXTENSION;
+
 function _replaceRootDirTags(rootDir, config) {
   switch (typeof config) {
     case 'object':
@@ -89,10 +92,14 @@ function normalize(config, argv) {
     throw new Error(`Jest: 'rootDir' config value must be specified.`);
   }
 
+  config.rootDir = path.normalize(config.rootDir);
+
   if (config.preset) {
     const presetPath = _replaceRootDirTags(config.rootDir, config.preset);
     const presetModule = Resolver.findNodeModule(
-      path.join(presetPath, 'jest-preset.json'),
+      presetPath.endsWith(JSON_EXTENSION)
+        ? presetPath
+        : path.join(presetPath, PRESET_NAME),
       {
         basedir: config.rootDir,
       },
@@ -116,12 +123,10 @@ function normalize(config, argv) {
       config = Object.assign({}, preset, config);
     } else {
       throw new Error(
-        `Jest: Preset '${config.preset}' not found.`,
+        `Jest: Preset '${presetPath}' not found.`,
       );
     }
   }
-
-  config.rootDir = path.normalize(config.rootDir);
 
   if (!config.name) {
     config.name = config.rootDir.replace(/[/\\]|\s/g, '-');


### PR DESCRIPTION
These are a bunch of extensions to make Jest more viable to scripting.

* `runCLI` sucks and is exported for our internal runner. Some people depend on it, so we cannot really change it. I chose to export `run` instead, so now there are two options; one that works with a custom `argv` event that applies Jest and one that doesn't. `run` should be used by everyone.
* `config` was previously allowed to be an object but for some reason we lost this ability through passing JSON in argv.
* Allow presets to be any `.json` file.