### PR TITLE
Updates for cache directories.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## master
 
+## jest 14.1.0
+
+* Changed Jest's default cache directory.
+* Fixed `jest-react-native` for react 15.3.0.
+* Updated react and react-native example to use `react-test-renderer`.
+* Started to refactor code coverage.
+
+## jest 14.0.2
+
+* `babel-jest` bugfix.
+
 ## jest 14.0.1
 
 * `babel-jest` can now be used to compose a transformer.

--- a/packages/jest-cli/src/SearchSource.js
+++ b/packages/jest-cli/src/SearchSource.js
@@ -228,7 +228,11 @@ class SearchSource {
 
     return (
       `${chalk.bold.red('NO TESTS FOUND')}. ` +
-      `${pluralize('file', data.total || 1, 's')} checked.\n${statsMessage}`
+      (data.total
+        ? `${pluralize('file', data.total || 0, 's')} checked.\n${statsMessage}`
+        : `No files found in ${config.rootDir}.\n` +
+          `Make sure Jest's configuration does not exclude this directory.`
+      )
     );
   }
 

--- a/packages/jest-config/src/defaults.js
+++ b/packages/jest-config/src/defaults.js
@@ -14,13 +14,14 @@ import type {DefaultConfig} from 'types/Config';
 
 const constants = require('./constants');
 const os = require('os');
+const path = require('path');
 const utils = require('jest-util');
 
 module.exports = ({
   automock: true,
   bail: false,
   browser: false,
-  cacheDirectory: os.tmpdir(),
+  cacheDirectory: path.join(os.tmpdir(), 'jest'),
   colors: false,
   coveragePathIgnorePatterns: [
     utils.replacePathSepForRegex(constants.NODE_MODULES),

--- a/packages/jest-haste-map/src/crawlers/node.js
+++ b/packages/jest-haste-map/src/crawlers/node.js
@@ -102,16 +102,20 @@ function findNative(
       .filter(x => !ignore(x));
     const result = [];
     let count = lines.length;
-    lines.forEach(path => {
-      fs.stat(path, (err, stat) => {
-        if (!err && stat) {
-          result.push([path, stat.mtime.getTime()]);
-        }
-        if (--count === 0) {
-          callback(result);
-        }
+    if (!count) {
+      callback([]);
+    } else {
+      lines.forEach(path => {
+        fs.stat(path, (err, stat) => {
+          if (!err && stat) {
+            result.push([path, stat.mtime.getTime()]);
+          }
+          if (--count === 0) {
+            callback(result);
+          }
+        });
       });
-    });
+    }
   });
 }
 

--- a/packages/jest-runtime/src/transform.js
+++ b/packages/jest-runtime/src/transform.js
@@ -288,7 +288,7 @@ const cachedTransformAndWrap = (
 const transformAndBuildScript = (
   filename: Path,
   config: Config,
-  options?: Options,
+  options: ?Options,
 ): vm.Script => {
   const isInternalModule = !!(options && options.isInternalModule);
   const content = stripShebang(fs.readFileSync(filename, 'utf8'));
@@ -309,7 +309,7 @@ const transformAndBuildScript = (
 module.exports = (
   filename: Path,
   config: Config,
-  options?: Options,
+  options: ?Options,
 ): vm.Script => {
   const scriptCacheKey = getScriptCacheKey(filename, config);
   let script = cache.get(scriptCacheKey);


### PR DESCRIPTION
If Jest is run within the OS's cache directory it won't be able to find anything because the cache directory itself is ignored by Jest. This change makes it so that Jest stores everything inside of `tmpdir + '/jest'`. I also updated the error messages and made it so that Jest doesn't appear to be crashing when it cannot find any files at all.

This was discovered by working on https://github.com/facebookincubator/create-react-app/pull/250

cc @gaearon 