### PR TITLE
#1350: Add Request, Response and Header classes to global scope in jest-react-native

### DIFF
--- a/packages/jest-react-native/src/index.js
+++ b/packages/jest-react-native/src/index.js
@@ -28,6 +28,10 @@ jest
 global.__DEV__ = true;
 global.__fbBatchedBridgeConfig = require('./bridge-mock');
 
+global.Request = require('react-native/Libraries/Fetch/fetch').Request;
+global.Response = require('react-native/Libraries/Fetch/fetch').Response;
+global.Headers = require('react-native/Libraries/Fetch/fetch').Headers;
+
 require(
   'react-native/packager/react-packager/src/Resolver/polyfills/Object.es7',
 );

--- a/packages/jest-react-native/src/index.js
+++ b/packages/jest-react-native/src/index.js
@@ -28,9 +28,10 @@ jest
 global.__DEV__ = true;
 global.__fbBatchedBridgeConfig = require('./bridge-mock');
 
-global.Request = require('react-native/Libraries/Fetch/fetch').Request;
-global.Response = require('react-native/Libraries/Fetch/fetch').Response;
-global.Headers = require('react-native/Libraries/Fetch/fetch').Headers;
+const { Response, Request, Headers } = require('react-native/Libraries/Fetch/fetch');
+global.Response = Response;
+global.Request = Request;
+global.Headers = Headers
 
 require(
   'react-native/packager/react-packager/src/Resolver/polyfills/Object.es7',

--- a/packages/jest-react-native/src/index.js
+++ b/packages/jest-react-native/src/index.js
@@ -28,10 +28,11 @@ jest
 global.__DEV__ = true;
 global.__fbBatchedBridgeConfig = require('./bridge-mock');
 
-const { Response, Request, Headers } = require('react-native/Libraries/Fetch/fetch');
+const {Response, Request, Headers, fetch} = require('react-native/Libraries/Fetch/fetch');
 global.Response = Response;
 global.Request = Request;
-global.Headers = Headers
+global.Headers = Headers;
+global.fetch = fetch;
 
 require(
   'react-native/packager/react-packager/src/Resolver/polyfills/Object.es7',


### PR DESCRIPTION
This enables the easy mocking of fetch()