### PR TITLE
single jest run for all packages

### DIFF
--- a/integration_tests/__tests__/coverage_report-test.js
+++ b/integration_tests/__tests__/coverage_report-test.js
@@ -14,8 +14,10 @@ const runJest = require('../runJest');
 const fs = require('fs');
 const path = require('path');
 
+const DIR = path.resolve(__dirname, '../coverage_report');
+
 it('outputs coverage report', () => {
-  const {stdout, status} = runJest('coverage_report', ['--coverage']);
+  const {stdout, status} = runJest(DIR, ['--coverage']);
   const coverageDir = path.resolve(__dirname, '../coverage_report/coverage');
 
   // should be no `setup.file` in the coverage report. It's ignored
@@ -26,7 +28,7 @@ it('outputs coverage report', () => {
 });
 
 it('collects coverage only from specified files', () => {
-  const {stdout} = runJest('coverage_report', [
+  const {stdout} = runJest(DIR, [
     '--coverage',
     '--collectCoverageFrom', // overwrites the one in package.json
     'setup.js',

--- a/integration_tests/__tests__/empty_suite_error-test.js
+++ b/integration_tests/__tests__/empty_suite_error-test.js
@@ -8,11 +8,14 @@
 
 'use strict';
 
+const path = require('path');
 const runJest = require('../runJest');
+
+const DIR = path.resolve(__dirname, '../empty_suite_error');
 
 describe('JSON Reporter', () => {
   it('fails the test suite if it contains no tests', () => {
-    const result = runJest('empty_suite_error', []);
+    const result = runJest(DIR, []);
     const stderr = result.stderr.toString();
     expect(stderr).toMatch('Runtime Error');
     expect(stderr).toMatch(

--- a/integration_tests/runJest.js
+++ b/integration_tests/runJest.js
@@ -16,6 +16,12 @@ const JEST_PATH = path.resolve(__dirname, '../packages/jest-cli/bin/jest.js');
 //  [ 'status', 'signal', 'output', 'pid', 'stdout', 'stderr',
 //    'envPairs', 'options', 'args', 'file' ]
 function runJest(dir, args) {
+  const isRelative = dir[0] !== '/';
+
+  if (isRelative) {
+    dir = path.resolve(__dirname, dir);
+  }
+
   const localPackageJson = path.resolve(dir, 'package.json');
   if (!fileExists(localPackageJson)) {
     throw new Error(`
@@ -27,7 +33,7 @@ function runJest(dir, args) {
   }
 
   const result = spawnSync(JEST_PATH, args || [], {
-    cwd: path.resolve(__dirname, dir),
+    cwd: dir,
   });
 
   result.stdout = result.stdout && result.stdout.toString();

--- a/package.json
+++ b/package.json
@@ -31,5 +31,23 @@
     "test": "npm run typecheck && npm run lint && npm run build && npm run t",
     "typecheck": "flow check",
     "watch": "npm run build; node ./scripts/watch.js"
+  },
+  "jest": {
+    "automock": false,
+    "modulePathIgnorePatterns": [
+      "examples/.*",
+      "packages\/.*\/build"
+    ],
+    "rootDir": "./",
+    "scriptPreprocessor": "<rootDir>/packages/babel-jest",
+    "setupTestFrameworkScriptFile": "<rootDir>/testSetupFile.js",
+    "testPathIgnorePatterns": [
+      "/node_modules/",
+      "/examples/",
+      "integration_tests\/.*\/__tests__",
+      "\\.snap$",
+      "packages\/.*\/build"
+    ],
+    "testRegex": ".*-test.\\js"
   }
 }

--- a/packages/babel-plugin-jest-hoist/package.json
+++ b/packages/babel-plugin-jest-hoist/package.json
@@ -7,11 +7,6 @@
   },
   "license": "BSD-3-Clause",
   "main": "build/index.js",
-  "jest": {
-    "rootDir": "./src",
-    "scriptPreprocessor": "../../babel-jest",
-    "testEnvironment": "node"
-  },
   "scripts": {
     "test": "../../packages/jest-cli/bin/jest.js"
   }

--- a/packages/jest-changed-files/package.json
+++ b/packages/jest-changed-files/package.json
@@ -10,11 +10,6 @@
   "devDependencies": {
     "rimraf": "^2.5.2"
   },
-  "jest": {
-    "rootDir": "./src",
-    "scriptPreprocessor": "../../babel-jest",
-    "testEnvironment": "node"
-  },
   "scripts": {
     "test": "../../packages/jest-cli/bin/jest.js"
   }

--- a/packages/jest-cli/package.json
+++ b/packages/jest-cli/package.json
@@ -40,14 +40,6 @@
   "scripts": {
     "test": "./bin/jest.js"
   },
-  "jest": {
-    "rootDir": "./src",
-    "scriptPreprocessor": "../../babel-jest",
-    "testEnvironment": "node",
-    "testPathIgnorePatterns": [
-      "/__tests__/[^/]*/.+"
-    ]
-  },
   "bugs": {
     "url": "https://github.com/facebook/jest/issues"
   },

--- a/packages/jest-config/package.json
+++ b/packages/jest-config/package.json
@@ -18,11 +18,6 @@
     "jest-util": "^14.0.0",
     "json-stable-stringify": "^1.0.0"
   },
-  "jest": {
-    "rootDir": "./build",
-    "scriptPreprocessor": "../../babel-jest",
-    "testEnvironment": "jest-environment-node"
-  },
   "scripts": {
     "test": "../../packages/jest-cli/bin/jest.js"
   }

--- a/packages/jest-diff/package.json
+++ b/packages/jest-diff/package.json
@@ -13,12 +13,6 @@
     "jest-matcher-utils": "^14.0.0",
     "pretty-format": "^3.5.0"
   },
-  "jest": {
-    "automock": false,
-    "rootDir": "./src",
-    "scriptPreprocessor": "../../babel-jest",
-    "testEnvironment": "node"
-  },
   "scripts": {
     "test": "../../packages/jest-cli/bin/jest.js"
   }

--- a/packages/jest-environment-node/package.json
+++ b/packages/jest-environment-node/package.json
@@ -10,11 +10,6 @@
   "dependencies": {
     "jest-util": "^14.0.0"
   },
-  "jest": {
-    "rootDir": "./src",
-    "scriptPreprocessor": "../../babel-jest",
-    "testEnvironment": "node"
-  },
   "scripts": {
     "test": "../../packages/jest-cli/bin/jest.js"
   }

--- a/packages/jest-file-exists/package.json
+++ b/packages/jest-file-exists/package.json
@@ -7,12 +7,6 @@
   },
   "license": "BSD-3-Clause",
   "main": "build/index.js",
-  "jest": {
-    "automock": false,
-    "rootDir": "./src",
-    "scriptPreprocessor": "../../babel-jest",
-    "testEnvironment": "node"
-  },
   "scripts": {
     "test": "../../packages/jest-cli/bin/jest.js"
   }

--- a/packages/jest-haste-map/package.json
+++ b/packages/jest-haste-map/package.json
@@ -12,11 +12,6 @@
     "graceful-fs": "^4.1.3",
     "worker-farm": "^1.3.1"
   },
-  "jest": {
-    "rootDir": "./src",
-    "scriptPreprocessor": "../../babel-jest",
-    "testEnvironment": "node"
-  },
   "scripts": {
     "test": "../../packages/jest-cli/bin/jest.js"
   },

--- a/packages/jest-haste-map/src/__tests__/index-test.js
+++ b/packages/jest-haste-map/src/__tests__/index-test.js
@@ -9,6 +9,8 @@
  */
 'use strict';
 
+jest.enableAutomock();
+
 jest.unmock('../constants')
   .unmock('../lib/docblock')
   .unmock('../lib/extractRequires')

--- a/packages/jest-jasmine2/package.json
+++ b/packages/jest-jasmine2/package.json
@@ -14,11 +14,6 @@
     "jest-snapshot": "^14.0.0",
     "jest-util": "^14.0.0"
   },
-  "jest": {
-    "rootDir": "./src",
-    "scriptPreprocessor": "../../babel-jest",
-    "testEnvironment": "node"
-  },
   "scripts": {
     "test": "../../packages/jest-cli/bin/jest.js"
   }

--- a/packages/jest-matcher-utils/package.json
+++ b/packages/jest-matcher-utils/package.json
@@ -8,11 +8,6 @@
   },
   "license": "BSD-3-Clause",
   "main": "build/index.js",
-  "jest": {
-    "rootDir": "./src",
-    "scriptPreprocessor": "../../babel-jest",
-    "testEnvironment": "node"
-  },
   "scripts": {
     "test": "../../packages/jest-cli/bin/jest.js"
   }

--- a/packages/jest-matchers/package.json
+++ b/packages/jest-matchers/package.json
@@ -14,12 +14,6 @@
   "devDependencies": {
     "strip-ansi": "^3.0.1"
   },
-  "jest": {
-    "automock": false,
-    "rootDir": "./src",
-    "scriptPreprocessor": "../../babel-jest",
-    "testEnvironment": "node"
-  },
   "scripts": {
     "test": "../../packages/jest-cli/bin/jest.js"
   }

--- a/packages/jest-mock/package.json
+++ b/packages/jest-mock/package.json
@@ -7,11 +7,6 @@
   },
   "license": "BSD-3-Clause",
   "main": "build/index.js",
-  "jest": {
-    "rootDir": "./src",
-    "scriptPreprocessor": "../../babel-jest",
-    "testEnvironment": "node"
-  },
   "scripts": {
     "test": "../../packages/jest-cli/bin/jest.js"
   }

--- a/packages/jest-react-native/package.json
+++ b/packages/jest-react-native/package.json
@@ -10,11 +10,6 @@
   "dependencies": {
     "react-native": "0.30.0"
   },
-  "jest": {
-    "rootDir": "./src",
-    "scriptPreprocessor": "../../babel-jest",
-    "testEnvironment": "node"
-  },
   "scripts": {
     "test": "../../packages/jest-cli/bin/jest.js"
   }

--- a/packages/jest-repl/package.json
+++ b/packages/jest-repl/package.json
@@ -16,12 +16,6 @@
   "bin": {
     "jest-repl": "./bin/jest-repl.js"
   },
-  "jest": {
-    "automock": false,
-    "rootDir": "./src",
-    "scriptPreprocessor": "../../babel-jest",
-    "testEnvironment": "node"
-  },
   "scripts": {
     "test": "../../packages/jest-cli/bin/jest.js"
   }

--- a/packages/jest-resolve-dependencies/package.json
+++ b/packages/jest-resolve-dependencies/package.json
@@ -11,11 +11,6 @@
     "jest-file-exists": "^14.0.0",
     "jest-resolve": "^14.1.0"
   },
-  "jest": {
-    "rootDir": "./src",
-    "scriptPreprocessor": "../../babel-jest",
-    "testEnvironment": "node"
-  },
   "scripts": {
     "test": "../../packages/jest-cli/bin/jest.js"
   }

--- a/packages/jest-resolve/package.json
+++ b/packages/jest-resolve/package.json
@@ -13,11 +13,6 @@
     "jest-haste-map": "^14.1.0",
     "resolve": "^1.1.6"
   },
-  "jest": {
-    "rootDir": "./src",
-    "scriptPreprocessor": "../../babel-jest",
-    "testEnvironment": "node"
-  },
   "scripts": {
     "test": "../../packages/jest-cli/bin/jest.js"
   }

--- a/packages/jest-runtime/package.json
+++ b/packages/jest-runtime/package.json
@@ -29,20 +29,8 @@
   },
   "devDependencies": {
     "jest-config": "^14.1.0",
-    "jest-environment-node": "^14.0.0"
-  },
-  "jest": {
-    "automock": false,
-    "preprocessorIgnorePatterns": [
-      "node_modules"
-    ],
-    "rootDir": "./src",
-    "scriptPreprocessor": "<rootDir>/../../babel-jest",
-    "setupTestFrameworkScriptFile": "<rootDir>/__mocks__/env.js",
-    "testEnvironment": "node",
-    "testPathIgnorePatterns": [
-      "/__tests__/[^/]*/.+"
-    ]
+    "jest-environment-node": "^14.0.0",
+    "jest-environment-jsdom": "^14.0.0"
   },
   "scripts": {
     "test": "../../packages/jest-cli/bin/jest.js"

--- a/packages/jest-runtime/src/__tests__/Runtime-requireModuleOrMock-test.js
+++ b/packages/jest-runtime/src/__tests__/Runtime-requireModuleOrMock-test.js
@@ -11,266 +11,135 @@
 
 let createRuntime;
 
-describe('Runtime', () => {
-  const moduleNameMapper = {
-    '^image![a-zA-Z0-9$_-]+$': 'GlobalImageStub',
-    '^[./a-zA-Z0-9$_-]+\.png$': 'RelativeImageStub',
-    'mappedToPath': '<rootDir>/GlobalImageStub.js',
-    'mappedToDirectory': '<rootDir>/MyDirectoryModule',
-    'module/name/(.*)': '<rootDir>/mapped_module_$1.js',
-  };
+const moduleNameMapper = {
+  '^image![a-zA-Z0-9$_-]+$': 'GlobalImageStub',
+  '^[./a-zA-Z0-9$_-]+\.png$': 'RelativeImageStub',
+  'mappedToPath': '<rootDir>/GlobalImageStub.js',
+  'mappedToDirectory': '<rootDir>/MyDirectoryModule',
+  'module/name/(.*)': '<rootDir>/mapped_module_$1.js',
+};
 
-  beforeEach(() => {
-    createRuntime = require('createRuntime');
-  });
-
-  describe('requireModuleOrMock', () => {
-    it('mocks modules by default', () =>
-      createRuntime(__filename, {moduleNameMapper}).then(runtime => {
-        const exports = runtime.requireModuleOrMock(
-          runtime.__mockRootPath,
-          'RegularModule',
-        );
-        expect(exports.setModuleStateValue._isMockFunction).toBe(true);
-      }),
-    );
-
-    it(`doesn't mock modules when explicitly unmocked`, () =>
-      createRuntime(__filename, {moduleNameMapper}).then(runtime => {
-        const root = runtime.requireModule(runtime.__mockRootPath);
-        root.jest.unmock('RegularModule');
-        const exports = runtime.requireModuleOrMock(
-          runtime.__mockRootPath,
-          'RegularModule',
-        );
-        expect(exports.isRealModule).toBe(true);
-      }),
-    );
-
-    it(`doesn't mock modules when explicitly unmocked via a different denormalized module name`, () =>
-      createRuntime(__filename, {moduleNameMapper}).then(runtime => {
-        const root = runtime.requireModule(runtime.__mockRootPath);
-        root.jest.unmock('./RegularModule');
-        const exports = runtime.requireModuleOrMock(
-          runtime.__mockRootPath,
-          'RegularModule',
-        );
-        expect(exports.isRealModule).toBe(true);
-      }),
-    );
-
-    it(`doesn't mock modules when disableAutomock() has been called`, () =>
-      createRuntime(__filename, {moduleNameMapper}).then(runtime => {
-        const root = runtime.requireModule(runtime.__mockRootPath);
-        root.jest.disableAutomock();
-        const exports = runtime.requireModuleOrMock(
-          runtime.__mockRootPath,
-          'RegularModule',
-        );
-        expect(exports.isRealModule).toBe(true);
-      }),
-    );
-
-    it('uses manual mock when automocking on and mock is avail', () =>
-      createRuntime(__filename, {moduleNameMapper}).then(runtime => {
-        const exports = runtime.requireModuleOrMock(
-          runtime.__mockRootPath,
-          'ManuallyMocked',
-        );
-        expect(exports.isManualMockModule).toBe(true);
-      }),
-    );
-
-    it('does not use manual mock when automocking is off and a real module is available', () =>
-      createRuntime(__filename, {moduleNameMapper}).then(runtime => {
-        const root = runtime.requireModule(runtime.__mockRootPath);
-        root.jest.disableAutomock();
-        const exports = runtime.requireModuleOrMock(
-          runtime.__mockRootPath,
-          'ManuallyMocked',
-        );
-        expect(exports.isManualMockModule).toBe(false);
-      }),
-    );
-
-    it('resolves mapped module names and unmocks them by default', () =>
-      createRuntime(__filename, {moduleNameMapper}).then(runtime => {
-        let exports = runtime.requireModuleOrMock(
-          runtime.__mockRootPath,
-          'image!not-really-a-module',
-        );
-        expect(exports.isGlobalImageStub).toBe(true);
-
-        exports = runtime.requireModuleOrMock(
-          runtime.__mockRootPath,
-          'mappedToPath',
-        );
-        expect(exports.isGlobalImageStub).toBe(true);
-
-        exports = runtime.requireModuleOrMock(
-          runtime.__mockRootPath,
-          'mappedToDirectory',
-        );
-        expect(exports.isIndex).toBe(true);
-
-        exports = runtime.requireModuleOrMock(
-          runtime.__mockRootPath,
-          'cat.png',
-        );
-        expect(exports.isRelativeImageStub).toBe(true);
-
-        exports = runtime.requireModuleOrMock(
-          runtime.__mockRootPath,
-          '../photos/dog.png',
-        );
-        expect(exports.isRelativeImageStub).toBe(true);
-
-        exports = runtime.requireModuleOrMock(
-          runtime.__mockRootPath,
-          'module/name/test',
-        );
-        expect(exports).toBe('mapped_module');
-      }),
-    );
-
-    it('automocking be disabled by default', () =>
-      createRuntime(__filename, {
-        moduleNameMapper,
-        automock: false,
-      }).then(runtime => {
-        const exports = runtime.requireModuleOrMock(
-          runtime.__mockRootPath,
-          'RegularModule',
-        );
-        expect(exports.setModuleStateValue._isMockFunction).toBe(undefined);
-      }),
-    );
-
-    describe('transitive dependencies', () => {
-      const expectUnmocked = nodeModule => {
-        const moduleData = nodeModule();
-        expect(moduleData.isUnmocked()).toBe(true);
-        expect(moduleData.transitiveNPM3Dep).toEqual('npm3-transitive-dep');
-        expect(moduleData.internalImplementation())
-          .toEqual('internal-module-code');
-      };
-
-      it('unmocks transitive dependencies in node_modules by default', () =>
-        createRuntime(__filename, {
-          moduleNameMapper,
-          unmockedModulePathPatterns: ['npm3-main-dep'],
-        }).then(runtime => {
-          const root = runtime.requireModule(
-            runtime.__mockRootPath,
-            './root.js',
-          );
-          expectUnmocked(runtime.requireModuleOrMock(
-            runtime.__mockRootPath,
-            'npm3-main-dep',
-          ));
-
-          // Test twice to make sure Runtime caching works properly
-          root.jest.resetModuleRegistry();
-          expectUnmocked(runtime.requireModuleOrMock(
-            runtime.__mockRootPath,
-            'npm3-main-dep',
-          ));
-
-          // Directly requiring the transitive dependency will mock it
-          const transitiveDep = runtime.requireModuleOrMock(
-            runtime.__mockRootPath,
-            'npm3-transitive-dep',
-          );
-          expect(transitiveDep()).toEqual(undefined);
-        }),
-      );
-
-      it('unmocks transitive dependencies in node_modules when using unmock', () =>
-        createRuntime(__filename, {moduleNameMapper}).then(runtime => {
-          const root = runtime.requireModule(runtime.__mockRootPath);
-          root.jest.unmock('npm3-main-dep');
-          expectUnmocked(runtime.requireModuleOrMock(
-            runtime.__mockRootPath,
-            'npm3-main-dep',
-          ));
-
-          // Test twice to make sure Runtime caching works properly
-          root.jest.resetModuleRegistry();
-          expectUnmocked(runtime.requireModuleOrMock(
-            runtime.__mockRootPath,
-            'npm3-main-dep',
-          ));
-
-          // Directly requiring the transitive dependency will mock it
-          const transitiveDep = runtime.requireModuleOrMock(
-            runtime.__mockRootPath,
-            'npm3-transitive-dep',
-          );
-          expect(transitiveDep()).toEqual(undefined);
-        }),
-      );
-
-      it('unmocks transitive dependencies in node_modules by default when using both patterns and unmock', () =>
-        createRuntime(__filename, {
-          moduleNameMapper,
-          unmockedModulePathPatterns: ['banana-module'],
-        }).then(runtime => {
-          const root = runtime.requireModule(runtime.__mockRootPath);
-          root.jest.unmock('npm3-main-dep');
-          expectUnmocked(runtime.requireModuleOrMock(
-            runtime.__mockRootPath,
-            'npm3-main-dep',
-          ));
-
-          // Test twice to make sure Runtime caching works properly
-          root.jest.resetModuleRegistry();
-          expectUnmocked(runtime.requireModuleOrMock(
-            runtime.__mockRootPath,
-            'npm3-main-dep',
-          ));
-
-          // Directly requiring the transitive dependency will mock it
-          const transitiveDep = runtime.requireModuleOrMock(
-            runtime.__mockRootPath,
-            'npm3-transitive-dep',
-          );
-          expect(transitiveDep()).toEqual(undefined);
-        }),
-      );
-
-      it('mocks deep dependencies when using unmock', () =>
-        createRuntime(__filename, {moduleNameMapper}).then(runtime => {
-          const root = runtime.requireModule(
-            runtime.__mockRootPath,
-            './root.js',
-          );
-          root.jest.unmock('FooContainer.react');
-
-          const FooContainer = runtime.requireModuleOrMock(
-            runtime.__mockRootPath,
-            'FooContainer.react',
-          );
-
-          expect(new FooContainer().render().indexOf('5')).toBe(-1);
-        }),
-      );
-
-      it('does not mock deep dependencies when using deepUnmock', () =>
-        createRuntime(__filename, {moduleNameMapper}).then(runtime => {
-          const root = runtime.requireModule(
-            runtime.__mockRootPath,
-            './root.js',
-          );
-          root.jest.deepUnmock('FooContainer.react');
-
-          const FooContainer = runtime.requireModuleOrMock(
-            runtime.__mockRootPath,
-            'FooContainer.react',
-          );
-
-          expect(new FooContainer().render().indexOf('5')).not.toBe(-1);
-        }),
-      );
-    });
-  });
+beforeEach(() => {
+  createRuntime = require('createRuntime');
 });
+
+it('mocks modules by default', () =>
+  createRuntime(__filename, {moduleNameMapper}).then(runtime => {
+    const exports = runtime.requireModuleOrMock(
+      runtime.__mockRootPath,
+      'RegularModule',
+    );
+    expect(exports.setModuleStateValue._isMockFunction).toBe(true);
+  }),
+);
+
+it(`doesn't mock modules when explicitly unmocked`, () =>
+  createRuntime(__filename, {moduleNameMapper}).then(runtime => {
+    const root = runtime.requireModule(runtime.__mockRootPath);
+    root.jest.unmock('RegularModule');
+    const exports = runtime.requireModuleOrMock(
+      runtime.__mockRootPath,
+      'RegularModule',
+    );
+    expect(exports.isRealModule).toBe(true);
+  }),
+);
+
+it(`doesn't mock modules when explicitly unmocked via a different denormalized module name`, () =>
+  createRuntime(__filename, {moduleNameMapper}).then(runtime => {
+    const root = runtime.requireModule(runtime.__mockRootPath);
+    root.jest.unmock('./RegularModule');
+    const exports = runtime.requireModuleOrMock(
+      runtime.__mockRootPath,
+      'RegularModule',
+    );
+    expect(exports.isRealModule).toBe(true);
+  }),
+);
+
+it(`doesn't mock modules when disableAutomock() has been called`, () =>
+  createRuntime(__filename, {moduleNameMapper}).then(runtime => {
+    const root = runtime.requireModule(runtime.__mockRootPath);
+    root.jest.disableAutomock();
+    const exports = runtime.requireModuleOrMock(
+      runtime.__mockRootPath,
+      'RegularModule',
+    );
+    expect(exports.isRealModule).toBe(true);
+  }),
+);
+
+it('uses manual mock when automocking on and mock is avail', () =>
+  createRuntime(__filename, {moduleNameMapper}).then(runtime => {
+    const exports = runtime.requireModuleOrMock(
+      runtime.__mockRootPath,
+      'ManuallyMocked',
+    );
+    expect(exports.isManualMockModule).toBe(true);
+  }),
+);
+
+it('does not use manual mock when automocking is off and a real module is available', () =>
+  createRuntime(__filename, {moduleNameMapper}).then(runtime => {
+    const root = runtime.requireModule(runtime.__mockRootPath);
+    root.jest.disableAutomock();
+    const exports = runtime.requireModuleOrMock(
+      runtime.__mockRootPath,
+      'ManuallyMocked',
+    );
+    expect(exports.isManualMockModule).toBe(false);
+  }),
+);
+
+it('resolves mapped module names and unmocks them by default', () =>
+  createRuntime(__filename, {moduleNameMapper}).then(runtime => {
+    let exports = runtime.requireModuleOrMock(
+      runtime.__mockRootPath,
+      'image!not-really-a-module',
+    );
+    expect(exports.isGlobalImageStub).toBe(true);
+
+    exports = runtime.requireModuleOrMock(
+      runtime.__mockRootPath,
+      'mappedToPath',
+    );
+    expect(exports.isGlobalImageStub).toBe(true);
+
+    exports = runtime.requireModuleOrMock(
+      runtime.__mockRootPath,
+      'mappedToDirectory',
+    );
+    expect(exports.isIndex).toBe(true);
+
+    exports = runtime.requireModuleOrMock(
+      runtime.__mockRootPath,
+      'cat.png',
+    );
+    expect(exports.isRelativeImageStub).toBe(true);
+
+    exports = runtime.requireModuleOrMock(
+      runtime.__mockRootPath,
+      '../photos/dog.png',
+    );
+    expect(exports.isRelativeImageStub).toBe(true);
+
+    exports = runtime.requireModuleOrMock(
+      runtime.__mockRootPath,
+      'module/name/test',
+    );
+    expect(exports).toBe('mapped_module');
+  }),
+);
+
+it('automocking be disabled by default', () =>
+  createRuntime(__filename, {
+    moduleNameMapper,
+    automock: false,
+  }).then(runtime => {
+    const exports = runtime.requireModuleOrMock(
+      runtime.__mockRootPath,
+      'RegularModule',
+    );
+    expect(exports.setModuleStateValue._isMockFunction).toBe(undefined);
+  }),
+);

--- a/packages/jest-runtime/src/__tests__/Runtime-requireModuleOrMock-transitive-deps-test.js
+++ b/packages/jest-runtime/src/__tests__/Runtime-requireModuleOrMock-transitive-deps-test.js
@@ -1,0 +1,151 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails oncall+jsinfra
+ */
+'use strict';
+
+let createRuntime;
+
+const moduleNameMapper = {
+  '^image![a-zA-Z0-9$_-]+$': 'GlobalImageStub',
+  '^[./a-zA-Z0-9$_-]+\.png$': 'RelativeImageStub',
+  'mappedToPath': '<rootDir>/GlobalImageStub.js',
+  'mappedToDirectory': '<rootDir>/MyDirectoryModule',
+  'module/name/(.*)': '<rootDir>/mapped_module_$1.js',
+};
+
+beforeEach(() => {
+  createRuntime = require('createRuntime');
+});
+
+describe('transitive dependencies', () => {
+  const expectUnmocked = nodeModule => {
+    const moduleData = nodeModule();
+    expect(moduleData.isUnmocked()).toBe(true);
+    expect(moduleData.transitiveNPM3Dep).toEqual('npm3-transitive-dep');
+    expect(moduleData.internalImplementation())
+      .toEqual('internal-module-code');
+  };
+
+  it('unmocks transitive dependencies in node_modules by default', () =>
+    createRuntime(__filename, {
+      moduleNameMapper,
+      unmockedModulePathPatterns: ['npm3-main-dep'],
+    }).then(runtime => {
+      const root = runtime.requireModule(
+        runtime.__mockRootPath,
+        './root.js',
+      );
+      expectUnmocked(runtime.requireModuleOrMock(
+        runtime.__mockRootPath,
+        'npm3-main-dep',
+      ));
+
+      // Test twice to make sure Runtime caching works properly
+      root.jest.resetModuleRegistry();
+      expectUnmocked(runtime.requireModuleOrMock(
+        runtime.__mockRootPath,
+        'npm3-main-dep',
+      ));
+
+      // Directly requiring the transitive dependency will mock it
+      const transitiveDep = runtime.requireModuleOrMock(
+        runtime.__mockRootPath,
+        'npm3-transitive-dep',
+      );
+      expect(transitiveDep()).toEqual(undefined);
+    }),
+  );
+
+  it('unmocks transitive dependencies in node_modules when using unmock', () =>
+    createRuntime(__filename, {moduleNameMapper}).then(runtime => {
+      const root = runtime.requireModule(runtime.__mockRootPath);
+      root.jest.unmock('npm3-main-dep');
+      expectUnmocked(runtime.requireModuleOrMock(
+        runtime.__mockRootPath,
+        'npm3-main-dep',
+      ));
+
+      // Test twice to make sure Runtime caching works properly
+      root.jest.resetModuleRegistry();
+      expectUnmocked(runtime.requireModuleOrMock(
+        runtime.__mockRootPath,
+        'npm3-main-dep',
+      ));
+
+      // Directly requiring the transitive dependency will mock it
+      const transitiveDep = runtime.requireModuleOrMock(
+        runtime.__mockRootPath,
+        'npm3-transitive-dep',
+      );
+      expect(transitiveDep()).toEqual(undefined);
+    }),
+  );
+
+  it('unmocks transitive dependencies in node_modules by default when using both patterns and unmock', () =>
+    createRuntime(__filename, {
+      moduleNameMapper,
+      unmockedModulePathPatterns: ['banana-module'],
+    }).then(runtime => {
+      const root = runtime.requireModule(runtime.__mockRootPath);
+      root.jest.unmock('npm3-main-dep');
+      expectUnmocked(runtime.requireModuleOrMock(
+        runtime.__mockRootPath,
+        'npm3-main-dep',
+      ));
+
+      // Test twice to make sure Runtime caching works properly
+      root.jest.resetModuleRegistry();
+      expectUnmocked(runtime.requireModuleOrMock(
+        runtime.__mockRootPath,
+        'npm3-main-dep',
+      ));
+
+      // Directly requiring the transitive dependency will mock it
+      const transitiveDep = runtime.requireModuleOrMock(
+        runtime.__mockRootPath,
+        'npm3-transitive-dep',
+      );
+      expect(transitiveDep()).toEqual(undefined);
+    }),
+  );
+
+  it('mocks deep dependencies when using unmock', () =>
+    createRuntime(__filename, {moduleNameMapper}).then(runtime => {
+      const root = runtime.requireModule(
+        runtime.__mockRootPath,
+        './root.js',
+      );
+      root.jest.unmock('FooContainer.react');
+
+      const FooContainer = runtime.requireModuleOrMock(
+        runtime.__mockRootPath,
+        'FooContainer.react',
+      );
+
+      expect(new FooContainer().render().indexOf('5')).toBe(-1);
+    }),
+  );
+
+  it('does not mock deep dependencies when using deepUnmock', () =>
+    createRuntime(__filename, {moduleNameMapper}).then(runtime => {
+      const root = runtime.requireModule(
+        runtime.__mockRootPath,
+        './root.js',
+      );
+      root.jest.deepUnmock('FooContainer.react');
+
+      const FooContainer = runtime.requireModuleOrMock(
+        runtime.__mockRootPath,
+        'FooContainer.react',
+      );
+
+      expect(new FooContainer().render().indexOf('5')).not.toBe(-1);
+    }),
+  );
+});

--- a/packages/jest-snapshot/package.json
+++ b/packages/jest-snapshot/package.json
@@ -13,11 +13,6 @@
     "jest-util": "^14.0.0",
     "pretty-format": "^3.5.0"
   },
-  "jest": {
-    "rootDir": "./src",
-    "scriptPreprocessor": "../../babel-jest",
-    "testEnvironment": "node"
-  },
   "scripts": {
     "test": "../jest-cli/bin/jest.js"
   }

--- a/packages/jest-util/package.json
+++ b/packages/jest-util/package.json
@@ -17,11 +17,6 @@
   "devDependencies": {
     "jsdom": "^9.2.1"
   },
-  "jest": {
-    "rootDir": "./src",
-    "scriptPreprocessor": "../../babel-jest",
-    "testEnvironment": "node"
-  },
   "scripts": {
     "test": "../../packages/jest-cli/bin/jest.js"
   }

--- a/packages/jest-util/src/__tests__/JasmineFormatter-test.js
+++ b/packages/jest-util/src/__tests__/JasmineFormatter-test.js
@@ -9,8 +9,6 @@
  */
 'use strict';
 
-jest.disableAutomock();
-
 const JasmineFormatter = require('../JasmineFormatter');
 
 const chalk = require('chalk');

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -26,8 +26,8 @@ const mkdirp = require('mkdirp');
 const rimraf = require('rimraf');
 
 const EXAMPLES_DIR = path.resolve(__dirname, '../examples');
-const INTEGRATION_TESTS_DIR = path.resolve(__dirname, '../integration_tests');
 const JEST_CLI_PATH = path.resolve(__dirname, '../packages/jest-cli');
+const JEST_BIN_PATH = path.resolve(JEST_CLI_PATH, 'bin/jest.js');
 const LINKED_MODULES = ['jest-react-native'];
 const NODE_VERSION = Number(process.version.match(/^v(\d+\.\d+)/)[1]);
 const SKIP_ON_OLD_NODE = ['react-native'];
@@ -38,11 +38,6 @@ const packages = getPackages();
 const examples = fs.readdirSync(EXAMPLES_DIR)
   .map(file => path.resolve(EXAMPLES_DIR, file))
   .filter(f => fs.lstatSync(path.resolve(f)).isDirectory());
-
-function runPackageTests(packageDirectory) {
-  console.log(chalk.bold(chalk.cyan('Testing package: ') + packageDirectory));
-  runCommands('npm test', packageDirectory);
-}
 
 function runExampleTests(exampleDirectory) {
   console.log(chalk.bold(chalk.cyan('Testing example: ') + exampleDirectory));
@@ -83,29 +78,17 @@ function runExampleTests(exampleDirectory) {
   // overwrite the jest link and point it to the local jest-cli
   mkdirp.sync(path.resolve(exampleDirectory, './node_modules/.bin'));
   runCommands(
-    `ln -sf ${JEST_CLI_PATH}/bin/jest.js ./node_modules/.bin/jest`,
+    `ln -sf ${JEST_BIN_PATH} ./node_modules/.bin/jest`,
     exampleDirectory
   );
 
   runCommands('npm test', exampleDirectory);
 }
 
-packages.forEach(runPackageTests);
+runCommands(JEST_BIN_PATH, path.resolve(__dirname, '..'));
 
 if (packagesOnly) {
   return;
 }
-
-// Run all tests, these are order dependent.
-runCommands('node bin/jest.js --no-cache', 'packages/jest-cli');
-runCommands('node bin/jest.js', 'packages/jest-cli');
-runCommands('node bin/jest.js --no-watchman --no-cache', 'packages/jest-cli');
-runCommands('node bin/jest.js --no-watchman', 'packages/jest-cli');
-runCommands('node bin/jest.js --runInBand', 'packages/jest-cli');
-runCommands('node bin/jest.js --runInBand --logHeapUsage', 'packages/jest-cli');
-runCommands('node bin/jest.js --notify', 'packages/jest-cli');
-
-console.log(chalk.bold(chalk.cyan('Running integration tests:')));
-runCommands('../packages/jest-cli/bin/jest.js', INTEGRATION_TESTS_DIR);
 
 examples.forEach(runExampleTests);

--- a/testSetupFile.js
+++ b/testSetupFile.js
@@ -7,4 +7,6 @@
  */
 'use strict';
 
-jasmine.DEFAULT_TIMEOUT_INTERVAL = 15000;
+// Some of the `jest-runtime` tests are very slow and cause
+// timeouts on travis
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 40000;


### PR DESCRIPTION
```
488 tests passed (488 total in 62 test suites, 9 snapshots, run time 30.878s)
```