### PR TITLE
fix hard dependency to react-native

### DIFF
--- a/packages/jest-react-native/package.json
+++ b/packages/jest-react-native/package.json
@@ -7,8 +7,8 @@
   },
   "license": "BSD-3-Clause",
   "main": "build/index.js",
-  "dependencies": {
-    "react-native": "0.30.0"
+  "peerDependencies": {
+    "react-native": ">=0.30.0"
   },
   "scripts": {
     "test": "../../packages/jest-cli/bin/jest.js"


### PR DESCRIPTION
Just updated my project to RN 0.31. 

because `jest-react-native` includes a hard dependency to RN 0.30, the packager is not running anymore and neither is `jest` 

this error is thrown:

> Using Jest CLI v14.1.0, jasmine2, babel-jest, jest-react-native preset
>
> jest-haste-map: @providesModule naming collision:
>   Duplicate module name: react-native
>   Paths: /<MY_PROJECT>/node_modules/jest-react-native/node_modules/react-native/package.json collides with /<MY_PROJECT>/node_modules/react-native/package.json