### PR TITLE
Fix Jasmine doc link

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -102,7 +102,7 @@ Jest uses Jasmine 2 by default. An introduction to Jasmine 2 can be found
   - `.not` inverse the next comparison
   - `.toThrow(?message)`
   - `.toBe(value)` comparison using `===`
-  - `.toEqual(value)` deep comparison. Use [`jasmine.any(type)`](http://jasmine.github.io/1.3/introduction.html#section-Matching_Anything_with_<code>jasmine.any</code>) to be softer
+  - `.toEqual(value)` deep comparison. Use [`jasmine.any(type)`](http://jasmine.github.io/1.3/introduction.html#section-Matching_Anything_with_%3Ccode%3Ejasmine.any%3C%2Fcode%3E) to be softer
   - `.toBeFalsy()`
   - `.toBeTruthy()`
   - `.toBeNull()`


### PR DESCRIPTION
The current link is correct in Markdown but for some reason it doesn’t lead to the right place (the last `>` gets lost).