### PR TITLE
Remove the hashbang from the entry point module

### DIFF
--- a/packages/jest/src/jest.js
+++ b/packages/jest/src/jest.js
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 /**
  * Copyright (c) 2014, Facebook, Inc. All rights reserved.
  *


### PR DESCRIPTION
Remove the `#!/usr/bin/env node` hashbang from the entry point module of the `jest` package (`src/jest.js`, which is built to `build/jest.js`).

`build/jest.js` is the entry point that is imported when you do `require('jest')`, and it doesn't execute anything when run as an executable, so it doesn't make sense to have the hashbang there.

I ran into some issues trying to bundle this file with webpack (yes, I'm trying to do some weird stuff), it choked on the hashbang when trying to parse the module.