### PR TITLE
react-clone-referenced-element added to ignore

### DIFF
--- a/packages/jest-react-native/jest-preset.json
+++ b/packages/jest-react-native/jest-preset.json
@@ -18,7 +18,7 @@
   ],
   "persistModuleRegistryBetweenSpecs": true,
   "preprocessorIgnorePatterns": [
-    "node_modules/(?!react-native)"
+    "node_modules/(?!react-native|react-clone-referenced-element)"
   ],
   "setupFiles": [
     "<rootDir>/node_modules/jest-react-native/build/index.js"


### PR DESCRIPTION
I get a syntax issue when using ListView which depends on react-clone-referenced-element.

```
Runtime Error
  - SyntaxError: Unexpected token ...
        at transformAndBuildScript (node_modules/jest-runtime/build/transform.js:306:10)
        at Object.<anonymous> (node_modules/react-native/Libraries/CustomComponents/ListView/ListView.js:44:28)
        at Object.ListView (node_modules/react-native/Libraries/react-native/react-native.js:39:23)
```