### PR TITLE
Add global.global to "node" environment

### DIFF
--- a/packages/jest-environment-node/src/__tests__/NodeEnvironment-test.js
+++ b/packages/jest-environment-node/src/__tests__/NodeEnvironment-test.js
@@ -26,4 +26,10 @@ describe('NodeEnvironment', () => {
     expect(env1.global.process.on).not.toBe(null);
   });
 
+  it('exposes global.global', () => {
+    const env1 = new NodeEnvironment({});
+
+    expect(env1.global.global).toBe(env1.global);
+  });
+
 });

--- a/packages/jest-environment-node/src/index.js
+++ b/packages/jest-environment-node/src/index.js
@@ -27,6 +27,7 @@ class NodeEnvironment {
   constructor(config: Config) {
     const global = this.global = {};
     vm.createContext(this.global);
+    global.global = global;
     global.clearInterval = clearInterval;
     global.clearTimeout = clearTimeout;
     global.setInterval = setInterval;


### PR DESCRIPTION
This fixes code that tests `global.global === global` to check if it is running in Node, [as RxJS 5 does] (https://github.com/ReactiveX/rxjs/blob/3793e4768dd2655300b67a82be9b30c4c065bac1/src/util/root.ts#L28).