### PR TITLE
Simplify promise chain in jest-cli

### DIFF
--- a/packages/jest-cli/src/jest.js
+++ b/packages/jest-cli/src/jest.js
@@ -96,11 +96,10 @@ function runJest(config, argv, pipe, onComplete) {
               source.getNoTestsFoundMessage(patternInfo, config, data) + '\n',
             );
           }
-          return data.paths;
+          return new TestRunner(hasteMap, config, {maxWorkers}).runTests(
+            data.paths,
+          );
         })
-        .then(testPaths =>
-          new TestRunner(hasteMap, config, {maxWorkers}).runTests(testPaths),
-        )
         .then(runResults => {
           if (config.testResultsProcessor) {
             /* $FlowFixMe */
@@ -112,10 +111,8 @@ function runJest(config, argv, pipe, onComplete) {
               JSON.stringify(formatTestResults(runResults, config)),
             );
           }
-          return runResults;
-        })
-        .then(runResults => onComplete && onComplete(runResults.success))
-        .catch(error => {
+          return onComplete && onComplete(runResults.success);
+        }).catch(error => {
           if (error.type == 'DependencyGraphError') {
             throw new Error([
               '\nError: ' + error.message + '\n\n',


### PR DESCRIPTION
I'm getting a test failure on my local machine:

```
 FAIL  __tests__/Intro-test.js
  Test suite failed to run:
    /Users/forbeslindesay/Documents/GitHub/jest/examples/react-native/node_modules/jest-react-native/node_modules/react-native/Libraries/Fetch/fetch.js:15
    import 'whatwg-fetch';
    ^^^^^^
    SyntaxError: Unexpected token import
      
      at transformAndBuildScript (../../packages/jest-runtime/build/transform.js:328:10)
```

The changes I've made shouldn't make any difference to behaviour but simplifies things slightly.  It should also be marginally more performant because it skips creating a couple of completely un-used promises.