### PR TITLE
Make jest-snapshot less jest/jasmine-specific

### DIFF
--- a/packages/jest-jasmine2/src/index.js
+++ b/packages/jest-jasmine2/src/index.js
@@ -224,7 +224,8 @@ function jasmine2(
     }
   });
 
-  const snapshotState = snapshot.getSnapshotState(jasmine, testPath);
+  const snapshotState = snapshot.createSnapshotState(testPath);
+  snapshot.patchJasmine(jasmine, snapshotState);
 
   env.addReporter(reporter);
 

--- a/packages/jest-snapshot/src/SnapshotState.js
+++ b/packages/jest-snapshot/src/SnapshotState.js
@@ -10,6 +10,9 @@
 'use strict';
 
 import type {SnapshotFileT} from './SnapshotFile';
+import type {Path} from 'types/Config';
+
+const SnapshotFile = require('./SnapshotFile');
 
 export type SnapshotState = {
   added: number,
@@ -22,4 +25,29 @@ export type SnapshotState = {
   snapshot: SnapshotFileT,
   unmatched: number,
   updated: number,
+};
+
+module.exports = {
+  createSnapshotState(filePath: Path): SnapshotState {
+    let _index = 0;
+    let _name = '';
+
+    /* $FlowFixMe */
+    return Object.assign(Object.create(null), {
+      getCounter: () => _index,
+      getSpecName: () => _name,
+      incrementCounter: () => ++_index,
+      setCounter(index) {
+        _index = index;
+      },
+      setSpecName(name) {
+        _name = name;
+      },
+      snapshot: SnapshotFile.forFile(filePath),
+      added: 0,
+      updated: 0,
+      matched: 0,
+      unmatched: 0,
+    });
+  },
 };

--- a/packages/jest-snapshot/src/index.js
+++ b/packages/jest-snapshot/src/index.js
@@ -37,7 +37,7 @@ const patchAttr = (attr, state) => {
   }(attr.onStart);
 };
 
-const patchJasmine = (jasmine, state) => {
+const patchJasmine = (jasmine: Jasmine, state) => {
   jasmine.Spec = (realSpec => {
     const Spec = function Spec(attr) {
       patchAttr(attr, state);
@@ -82,6 +82,7 @@ module.exports = {
   matcher,
   processSnapshot,
   createSnapshotState,
+  patchJasmine,
   getSnapshotState: (jasmine: Jasmine, filePath: Path): SnapshotState => {
     const state = createSnapshotState(filePath);
     patchJasmine(jasmine, state);

--- a/packages/jest-snapshot/src/index.js
+++ b/packages/jest-snapshot/src/index.js
@@ -15,6 +15,7 @@ import type {Path} from 'types/Config';
 import type {SnapshotState} from './SnapshotState';
 
 const SnapshotFile = require('./SnapshotFile');
+const createSnapshotState = require('./SnapshotState').createSnapshotState;
 
 const fileExists = require('jest-file-exists');
 const fs = require('fs');
@@ -80,27 +81,9 @@ module.exports = {
   },
   matcher,
   processSnapshot,
+  createSnapshotState,
   getSnapshotState: (jasmine: Jasmine, filePath: Path): SnapshotState => {
-    let _index = 0;
-    let _name = '';
-    /* $FlowFixMe */
-    const state = Object.assign(Object.create(null), {
-      getCounter: () => _index,
-      getSpecName: () => _name,
-      incrementCounter: () => ++_index,
-      setCounter(index) {
-        _index = index;
-      },
-      setSpecName(name) {
-        _name = name;
-      },
-      snapshot: SnapshotFile.forFile(filePath),
-      added: 0,
-      updated: 0,
-      matched: 0,
-      unmatched: 0,
-    });
-
+    const state = createSnapshotState(filePath);
     patchJasmine(jasmine, state);
     return state;
   },

--- a/packages/jest-snapshot/src/index.js
+++ b/packages/jest-snapshot/src/index.js
@@ -19,6 +19,7 @@ const SnapshotFile = require('./SnapshotFile');
 const fileExists = require('jest-file-exists');
 const fs = require('fs');
 const matcher = require('./matcher');
+const processSnapshot = require('./processSnapshot');
 const path = require('path');
 
 const EXTENSION = SnapshotFile.SNAPSHOT_EXTENSION;
@@ -78,6 +79,7 @@ module.exports = {
     };
   },
   matcher,
+  processSnapshot,
   getSnapshotState: (jasmine: Jasmine, filePath: Path): SnapshotState => {
     let _index = 0;
     let _name = '';

--- a/packages/jest-snapshot/src/index.js
+++ b/packages/jest-snapshot/src/index.js
@@ -11,7 +11,6 @@
 
 import type {HasteFS} from 'types/HasteMap';
 import type {Jasmine} from 'types/Jasmine';
-import type {Path} from 'types/Config';
 import type {SnapshotState} from './SnapshotState';
 
 const SnapshotFile = require('./SnapshotFile');
@@ -37,7 +36,7 @@ const patchAttr = (attr, state) => {
   }(attr.onStart);
 };
 
-const patchJasmine = (jasmine: Jasmine, state) => {
+const patchJasmine = (jasmine: Jasmine, state: SnapshotState) => {
   jasmine.Spec = (realSpec => {
     const Spec = function Spec(attr) {
       patchAttr(attr, state);
@@ -83,9 +82,4 @@ module.exports = {
   processSnapshot,
   createSnapshotState,
   patchJasmine,
-  getSnapshotState: (jasmine: Jasmine, filePath: Path): SnapshotState => {
-    const state = createSnapshotState(filePath);
-    patchJasmine(jasmine, state);
-    return state;
-  },
 };

--- a/packages/jest-snapshot/src/processSnapshot.js
+++ b/packages/jest-snapshot/src/processSnapshot.js
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+'use strict';
+
+import type {SnapshotState} from './SnapshotState';
+
+type ProcessSnapshotResult = {
+  pass: boolean,
+  expected?: any,
+};
+
+module.exports = function processSnapshot(
+  snapshotState: SnapshotState,
+  key: string,
+  actual: any,
+  options: Object,
+): ProcessSnapshotResult {
+  const snapshot = snapshotState.snapshot;
+  const hasSnapshot = snapshot.has(key);
+  let pass = false;
+  let matches;
+
+  if (
+    !snapshot.fileExists() ||
+    (hasSnapshot && options.updateSnapshot) ||
+    !hasSnapshot
+  ) {
+    if (options.updateSnapshot) {
+      if (!snapshot.matches(key, actual).pass) {
+        if (hasSnapshot) {
+          snapshotState.updated++;
+        } else {
+          snapshotState.added++;
+        }
+        snapshot.add(key, actual);
+      } else {
+        snapshotState.matched++;
+      }
+    } else {
+      snapshot.add(key, actual);
+      snapshotState.added++;
+    }
+    pass = true;
+  } else {
+    matches = snapshot.matches(key, actual);
+    pass = matches.pass;
+    if (!pass) {
+      snapshotState.unmatched++;
+    } else {
+      snapshotState.matched++;
+    }
+  }
+
+  return {
+    pass,
+    expected: matches && matches.expected,
+  };
+};


### PR DESCRIPTION
### WIP - DO NOT MERGE (yet)

Work in progress as per discussion in #1341. I still need to add some tests (around `processSnapshot` (aka the "raw matcher") and `createSnapshotState`), but wanted to get some feedback first.

* Adds three new named exports to jest-snapshot: `processSnapshot`, `createSnapshotState`, and `patchJasmine`
  * `processSnapshot` performs all the business logic of creating, updating, and comparing snapshots, then returns either `{pass: true}` or `{pass: false, expected: any}`.
  * `createSnapshotState` creates a SnapshotState object for a given file path
  * `patchJasmine` is the same function that was previously defined in `index.js`
* Removes the `getSnapshotState` export from jest-snapshot, which created a snapshot state and then patched jasmine with it.
* Updates jest-jasmine2 to use `createSnapshotState` and `patchJasmine` instead of `getSnapshotState`.

Edit 8/22/16: I changed the interface of `processSnapshot` a bit from my original PR, so I have updated the description to match.