### PR TITLE
Remove stripJestVersion

### DIFF
--- a/integration_tests/__tests__/coverage_report-test.js
+++ b/integration_tests/__tests__/coverage_report-test.js
@@ -9,7 +9,7 @@
  */
 'use strict';
 
-const {stripJestVersion, linkJestPackage} = require('../utils');
+const {linkJestPackage} = require('../utils');
 const runJest = require('../runJest');
 const fs = require('fs');
 const path = require('path');
@@ -27,7 +27,7 @@ it('outputs coverage report', () => {
   //  is listed with 0 % coverage.
   // - `not-required-in-test-suite.js` is not required but it is listed
   //  with 0 % coverage.
-  expect(stripJestVersion(stdout)).toMatchSnapshot();
+  expect(stdout).toMatchSnapshot();
 
   expect(() => fs.accessSync(coverageDir, fs.F_OK)).not.toThrow();
   expect(status).toBe(0);
@@ -42,5 +42,5 @@ it('collects coverage only from specified files', () => {
   ]);
 
   // Coverage report should only have `setup.js` coverage info
-  expect(stripJestVersion(stdout)).toMatchSnapshot();
+  expect(stdout).toMatchSnapshot();
 });

--- a/integration_tests/__tests__/debug-test.js
+++ b/integration_tests/__tests__/debug-test.js
@@ -10,7 +10,7 @@
 
 jest.unmock('../runJest');
 
-const {linkJestPackage, run, stripJestVersion} = require('../utils');
+const {linkJestPackage} = require('../utils');
 const path = require('path');
 const runJest = require('../runJest');
 

--- a/integration_tests/__tests__/transform-test.js
+++ b/integration_tests/__tests__/transform-test.js
@@ -10,7 +10,7 @@
 
 jest.unmock('../runJest');
 
-const {linkJestPackage, run, stripJestVersion} = require('../utils');
+const {linkJestPackage, run} = require('../utils');
 const path = require('path');
 const runJest = require('../runJest');
 
@@ -35,7 +35,7 @@ describe('babel-jest', () => {
     expect(stdout).not.toMatch('not-covered.js');
     expect(stdout).not.toMatch('excluded-from-coverage.js');
     // coverage result should not change
-    expect(stripJestVersion(stdout)).toMatchSnapshot();
+    expect(stdout).toMatchSnapshot();
   });
 });
 
@@ -53,7 +53,7 @@ describe('no babel-jest', () => {
     expect(stdout).toMatch('covered.js');
     expect(stdout).not.toMatch('excluded-from-coverage.js');
     // coverage result should not change
-    expect(stripJestVersion(stdout)).toMatchSnapshot();
+    expect(stdout).toMatchSnapshot();
   });
 });
 
@@ -76,7 +76,7 @@ describe('custom preprocessor', () => {
   it('instruments files', () => {
     const {stdout, status} = runJest(dir, ['--no-cache', '--coverage']);
     // coverage should be empty because there's no real instrumentation
-    expect(stripJestVersion(stdout)).toMatchSnapshot();
+    expect(stdout).toMatchSnapshot();
     expect(status).toBe(0);
   });
 });

--- a/integration_tests/utils.js
+++ b/integration_tests/utils.js
@@ -46,12 +46,8 @@ const fileExists = filePath => {
   }
 };
 
-const stripJestVersion = stdout =>
-  stdout.replace(/Jest CLI v\d{1,2}\.\d{1,2}\.\d{1,2}/, '<<REPLACED>>');
-
 module.exports = {
   fileExists,
   linkJestPackage,
   run,
-  stripJestVersion,
 };


### PR DESCRIPTION
Since we no longer output the version by default, our snapshots work
without needing to strip out the jest version.