### PR TITLE
update coverage .snap

### DIFF
--- a/packages/jest-cli/src/__tests__/__snapshots__/generateEmptyCoverage-test.js.snap
+++ b/packages/jest-cli/src/__tests__/__snapshots__/generateEmptyCoverage-test.js.snap
@@ -1,82 +1,14 @@
 exports[`test generates an empty coverage object for a file without running it 1`] = `
-SourceCoverage {
-  "data": Object {
-    "b": Object {
-      "1": Array [
-        0,
-        0
-      ]
-    },
-    "branchMap": Object {
-      "1": Object {
-        "loc": SourceLocation {
-          "end": Object {
-            "column": 3,
-            "line": 9
-          },
-          "start": Position {
-            "column": 2,
-            "line": 5
-          }
-        },
-        "locations": Array [
-          Object {
-            "end": Object {
-              "column": 2,
-              "line": 5
-            },
-            "start": Object {
-              "column": 2,
-              "line": 5
-            }
-          },
-          Object {
-            "end": Object {
-              "column": 2,
-              "line": 5
-            },
-            "start": Object {
-              "column": 2,
-              "line": 5
-            }
-          }
-        ],
-        "type": "if"
-      }
-    },
-    "f": Object {},
-    "fnMap": Object {},
-    "path": "/sum.js",
-    "s": Object {
-      "1": 0,
-      "2": 0,
-      "3": 0,
-      "4": 0,
-      "5": 0,
-      "6": 0
-    },
-    "statementMap": Object {
-      "1": Object {
-        "end": Object {
-          "column": 45,
-          "line": 2
-        },
-        "start": Object {
-          "column": 0,
-          "line": 2
-        }
-      },
-      "2": Object {
-        "end": Object {
-          "column": 2,
-          "line": 10
-        },
-        "start": Object {
-          "column": 0,
-          "line": 4
-        }
-      },
-      "3": Object {
+Object {
+  "b": Object {
+    "1": Array [
+      0,
+      0
+    ]
+  },
+  "branchMap": Object {
+    "1": Object {
+      "loc": Object {
         "end": Object {
           "column": 3,
           "line": 9
@@ -86,43 +18,128 @@ SourceCoverage {
           "line": 5
         }
       },
-      "4": Object {
-        "end": Object {
-          "column": 13,
-          "line": 6
+      "locations": Array [
+        Object {
+          "end": Object {
+            "column": 3,
+            "line": 9
+          },
+          "start": Object {
+            "column": 2,
+            "line": 5
+          }
         },
-        "start": Object {
-          "column": 4,
-          "line": 6
+        Object {
+          "end": Object {
+            "column": 3,
+            "line": 9
+          },
+          "start": Object {
+            "column": 2,
+            "line": 5
+          }
         }
-      },
-      "5": Object {
-        "end": Object {
-          "column": 13,
-          "line": 8
-        },
-        "start": Object {
-          "column": 4,
-          "line": 8
-        }
-      },
-      "6": Object {
-        "end": Object {
-          "column": 2,
-          "line": 14
-        },
-        "start": Object {
-          "column": 0,
-          "line": 12
-        }
-      }
+      ],
+      "type": "if"
     }
   },
-  "meta": Object {
-    "last": Object {
-      "b": 1,
-      "f": 0,
-      "s": 6
+  "f": Object {
+    "1": 0
+  },
+  "fnMap": Object {
+    "1": Object {
+      "decl": Object {
+        "end": Object {
+          "column": 11,
+          "line": 4
+        },
+        "start": Object {
+          "column": 10,
+          "line": 4
+        }
+      },
+      "loc": Object {
+        "end": Object {
+          "column": 1,
+          "line": 10
+        },
+        "start": Object {
+          "column": 20,
+          "line": 4
+        }
+      },
+      "name": "(anonymous_1)"
+    }
+  },
+  "path": "/sum.js",
+  "s": Object {
+    "1": 0,
+    "2": 0,
+    "3": 0,
+    "4": 0,
+    "5": 0,
+    "6": 0
+  },
+  "statementMap": Object {
+    "1": Object {
+      "end": Object {
+        "column": 45,
+        "line": 2
+      },
+      "start": Object {
+        "column": 0,
+        "line": 2
+      }
+    },
+    "2": Object {
+      "end": Object {
+        "column": 1,
+        "line": 10
+      },
+      "start": Object {
+        "column": 10,
+        "line": 4
+      }
+    },
+    "3": Object {
+      "end": Object {
+        "column": 3,
+        "line": 9
+      },
+      "start": Object {
+        "column": 2,
+        "line": 5
+      }
+    },
+    "4": Object {
+      "end": Object {
+        "column": 13,
+        "line": 6
+      },
+      "start": Object {
+        "column": 4,
+        "line": 6
+      }
+    },
+    "5": Object {
+      "end": Object {
+        "column": 13,
+        "line": 8
+      },
+      "start": Object {
+        "column": 4,
+        "line": 8
+      }
+    },
+    "6": Object {
+      "end": Object {
+        "column": 2,
+        "line": 14
+      },
+      "start": Object {
+        "column": 0,
+        "line": 12
+      }
     }
   }
 }


### PR DESCRIPTION
the object structure changed due to the release of new versions (see https://github.com/istanbuljs/istanbul-lib-coverage/commit/6c9c65ed81ce7c0e8b4efa8a4f5d96f02349c5ea and https://github.com/istanbuljs/istanbul-lib-instrument/commit/add579687c2f617d346a3a7618601ba6d73c83df)

this shouldn't affect the resulting coverage report