### PR TITLE
Default to verbose mode for single files

### DIFF
--- a/integration_tests/__tests__/verbose-test.js
+++ b/integration_tests/__tests__/verbose-test.js
@@ -12,7 +12,7 @@
 const runJest = require('../runJest');
 
 test('Verbose Reporter', () => {
-  const result = runJest('verbose_logger', ['--verbose']);
+  const result = runJest('verbose_logger');
   const stderr = result.stderr.toString();
 
   expect(result.status).toBe(1);

--- a/packages/jest-cli/src/jest.js
+++ b/packages/jest-cli/src/jest.js
@@ -96,6 +96,9 @@ function runJest(config, argv, pipe, onComplete) {
               source.getNoTestsFoundMessage(patternInfo, config, data) + '\n',
             );
           }
+          if (data.paths.length === 1) {
+            config = Object.assign({}, config, {verbose: true});
+          }
           return new TestRunner(hasteMap, config, {maxWorkers}).runTests(
             data.paths,
           );


### PR DESCRIPTION
I'm not sure if this is necessarily the best way to make the change.

1. Config seems to be immutable so I had to clone it in order to update the `verbose` setting.
2. Do we want to enable verbose by default when you just type `jest` if there is only one file, or should we restrict it to when you've typed `jest paty/to/a/file.js`?
3. Should we add a separate integration test for manually passing `--verbose` when there are multiple files.