### PR TITLE
Add troubleshooting gotcha for npm module mocks

### DIFF
--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -17,7 +17,9 @@ config option.
 
 You can also provide a [manual mock](/jest/docs/manual-mocks.html) by creating
 a `moduleName.js` file in a `__mocks__` folder in the root level of your
-project.
+project. If you have set `testPathDirs` in your `package.json`, you will need to
+make sure that the root level `__mocks__` directory is also incuded in
+`testPathDirs`.
 
 ### Caching Issues
 


### PR DESCRIPTION
When using manual mocks for node modules, they will not be properly
mocked if `testPathDirs` has been set and doesn't include the root level
'__mocks__` directory.

I can imagine this is a common source of confusion, and there doesn't seem to be too many easily searchable answers online. 