### PR TITLE
Refactor jest-haste-map (1/n)

### DIFF
--- a/packages/jest-cli/package.json
+++ b/packages/jest-cli/package.json
@@ -21,7 +21,6 @@
     "jest-snapshot": "^14.0.0",
     "jest-util": "^14.0.0",
     "json-stable-stringify": "^1.0.0",
-    "multimatch": "^2.1.0",
     "node-notifier": "^4.6.0",
     "sane": "^1.2.0",
     "which": "^1.1.1",

--- a/packages/jest-cli/src/SearchSource.js
+++ b/packages/jest-cli/src/SearchSource.js
@@ -134,7 +134,7 @@ class SearchSource {
     testPathPattern: StrOrRegExpPattern,
   ): SearchResult {
     return this._filterTestPathsWithStats(
-      Object.keys(this._hasteContext.moduleMap.files),
+      this._hasteContext.hasteFS.getAllFiles(),
       testPathPattern,
     );
   }
@@ -150,7 +150,7 @@ class SearchSource {
   ): SearchResult {
     if (testPathPattern && !(testPathPattern instanceof RegExp)) {
       const maybeFile = path.resolve(process.cwd(), testPathPattern);
-      if (fileExists(maybeFile, this._hasteContext.moduleMap.files)) {
+      if (fileExists(maybeFile, this._hasteContext.hasteFS)) {
         return this._filterTestPathsWithStats([maybeFile]);
       }
     }
@@ -161,7 +161,7 @@ class SearchSource {
   findRelatedTests(allPaths: Set<Path>): SearchResult {
     const dependencyResolver = new DependencyResolver(
       this._hasteContext.resolver,
-      this._hasteContext.moduleMap,
+      this._hasteContext.hasteFS,
     );
     return {
       paths: dependencyResolver.resolveInverse(

--- a/packages/jest-cli/src/TestWorker.js
+++ b/packages/jest-cli/src/TestWorker.js
@@ -55,7 +55,7 @@ module.exports = (data: WorkerData, callback: WorkerCallback) => {
     if (!resolvers[name]) {
       resolvers[name] = Runtime.createResolver(
         data.config,
-        Runtime.createHasteMap(data.config).read(),
+        Runtime.createHasteMap(data.config).readModuleMap(),
       );
     }
 

--- a/packages/jest-cli/src/reporters/CoverageReporter.js
+++ b/packages/jest-cli/src/reporters/CoverageReporter.js
@@ -10,8 +10,7 @@
 'use strict';
 
 import type {AggregatedResult, TestResult} from 'types/TestResult';
-import type {Config, Glob, Path} from 'types/Config';
-import type {HasteMap} from 'types/HasteMap';
+import type {Config} from 'types/Config';
 import type {RunnerContext} from 'types/Reporters';
 
 type CoverageMap = {
@@ -28,8 +27,6 @@ const chalk = require('chalk');
 const fs = require('fs');
 const generateEmptyCoverage = require('../generateEmptyCoverage');
 const istanbulCoverage = require('istanbul-lib-coverage');
-const path = require('path');
-const multimatch = require('multimatch');
 
 const FAIL_COLOR = chalk.bold.red;
 
@@ -77,8 +74,7 @@ class CoverageReporter extends BaseReporter {
 
   _addUntestedFiles(config: Config, runnerContext: RunnerContext) {
     if (config.collectCoverageFrom && config.collectCoverageFrom.length) {
-      const files = matchFilesWithGlobs(
-        runnerContext.hasteContext.moduleMap,
+      const files = runnerContext.hasteFS.matchFilesWithGlob(
         config.collectCoverageFrom,
         config.rootDir,
       );
@@ -153,21 +149,5 @@ class CoverageReporter extends BaseReporter {
     return this._coverageMap;
   }
 }
-
-// This is a temporary hack until we rewrite HasteMap to be synchronous
-const matchFilesWithGlobs = (
-  moduleMap: HasteMap,
-  globs: Array<Glob>,
-  rootDir: Path
-): Set<Path> => {
-  const files = new Set();
-  for (const file in moduleMap.files) {
-    if (multimatch([path.relative(rootDir, file)], globs).length) {
-      files.add(file);
-    }
-  }
-  return files;
-};
-
 
 module.exports = CoverageReporter;

--- a/packages/jest-file-exists/src/__tests__/index-test.js
+++ b/packages/jest-file-exists/src/__tests__/index-test.js
@@ -18,7 +18,7 @@ test('file exists', () => {
 
 test('file exists if module map is provided', () => {
   expect(fileExists('/random-string.js', {
-    '/random-string.js': true,
+    exists: filePath => filePath === '/random-string.js',
   })).toBe(true);
 });
 
@@ -26,7 +26,7 @@ test('file does not exist', () => {
   expect(fileExists(
     path.join(path.basename(__filename), 'does-probably-not-exist.js'),
     {
-      '/random-string.js': true,
+      exists: filePath => filePath === '/random-string.js',
     },
   )).toBe(false);
 });

--- a/packages/jest-file-exists/src/index.js
+++ b/packages/jest-file-exists/src/index.js
@@ -11,15 +11,15 @@
 'use strict';
 
 import type {Path} from 'types/Config';
-import type {FileMetaData} from 'types/HasteMap';
+import type {HasteFS} from 'types/HasteMap';
 
 const fs = require('fs');
 
 module.exports = (
   filePath: Path,
-  files: ?{[filepath: string]: FileMetaData},
+  hasteFS: ?HasteFS,
 ): boolean => {
-  if (files && files[filePath]) {
+  if (hasteFS && hasteFS.exists(filePath)) {
     return true;
   }
 

--- a/packages/jest-haste-map/package.json
+++ b/packages/jest-haste-map/package.json
@@ -16,6 +16,7 @@
     "test": "../../packages/jest-cli/bin/jest.js"
   },
   "devDependencies": {
+    "multimatch": "^2.1.0",
     "pretty-format": "^3.5.0"
   }
 }

--- a/packages/jest-haste-map/src/HasteFS.js
+++ b/packages/jest-haste-map/src/HasteFS.js
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+'use strict';
+
+import type {Glob, Path} from 'types/Config';
+import type {
+  FileData,
+  HType,
+} from 'types/HasteMap';
+
+const H: HType = require('./constants');
+
+const multimatch = require('multimatch');
+const path = require('path');
+
+class HasteFS {
+
+  _files: FileData;
+
+  constructor(files: FileData) {
+    this._files = files;
+  }
+
+  getDependencies(file: Path): ?Array<string> {
+    return this._files[file] && this._files[file][H.DEPENDENCIES];
+  }
+
+  exists(file: Path): boolean {
+    return !!this._files[file];
+  }
+
+  getAllFiles() {
+    return Object.keys(this._files);
+  }
+
+  matchFiles(pattern: RegExp | string): Array<Path> {
+    if (!(pattern instanceof RegExp)) {
+      pattern = new RegExp(pattern);
+    }
+    const files = [];
+    for (const file in this._files) {
+      if (pattern.test(file)) {
+        files.push(file);
+      }
+    }
+    return files;
+  }
+
+  matchFilesWithGlob(
+    globs: Array<Glob>,
+    root: ?Path,
+  ): Set<Path> {
+    const files = new Set();
+    for (const file in this._files) {
+      const filePath = root ? path.relative(root, file) : file;
+      if (multimatch([filePath], globs).length) {
+        files.add(file);
+      }
+    }
+    return files;
+  }
+
+}
+
+module.exports = HasteFS;

--- a/packages/jest-haste-map/src/ModuleMap.js
+++ b/packages/jest-haste-map/src/ModuleMap.js
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+'use strict';
+
+import type {Path} from 'types/Config';
+import type {
+  HType,
+  HTypeValue,
+  MockData,
+  ModuleMapData,
+} from 'types/HasteMap';
+
+const H: HType = require('./constants');
+
+class ModuleMap {
+
+  _map: ModuleMapData;
+  _mocks: MockData;
+
+  constructor(map: ModuleMapData, mocks: MockData) {
+    this._map = map;
+    this._mocks = mocks;
+  }
+
+  getModule(
+    name: string,
+    platform: ?string,
+    supportsNativePlatform: ?boolean,
+    type: ?HTypeValue,
+  ): ?Path {
+    if (!type) {
+      type = H.MODULE;
+    }
+
+    const map = this._map[name];
+    if (map) {
+      let module = platform && map[platform];
+      if (!module && map[H.NATIVE_PLATFORM] && supportsNativePlatform) {
+        module = map[H.NATIVE_PLATFORM];
+      } else if (!module) {
+        module = map[H.GENERIC_PLATFORM];
+      }
+      if (module && module[H.TYPE] === type) {
+        return module[H.PATH];
+      }
+    }
+
+    return null;
+  }
+
+  getPackage(
+    name: string,
+    platform: ?string,
+    supportsNativePlatform: ?boolean,
+  ): ?Path {
+    return this.getModule(name, platform, null, H.PACKAGE);
+  }
+
+  getMockModule(name: string): ?Path {
+    return this._mocks[name];
+  }
+
+}
+
+module.exports = ModuleMap;

--- a/packages/jest-haste-map/src/constants.js
+++ b/packages/jest-haste-map/src/constants.js
@@ -33,4 +33,5 @@ module.exports = {
 
   /* platforms */
   GENERIC_PLATFORM: 'g',
+  NATIVE_PLATFORM: 'native',
 };

--- a/packages/jest-haste-map/src/crawlers/node.js
+++ b/packages/jest-haste-map/src/crawlers/node.js
@@ -9,7 +9,7 @@
  */
 'use strict';
 
-import type {HasteMap} from 'types/HasteMap';
+import type {InternalHasteMap} from 'types/HasteMap';
 import type {IgnoreMatcher} from '../types';
 
 const H = require('../constants');
@@ -123,8 +123,8 @@ module.exports = function nodeCrawl(
   roots: Array<string>,
   extensions: Array<string>,
   ignore: IgnoreMatcher,
-  data: HasteMap,
-): Promise<HasteMap> {
+  data: InternalHasteMap,
+): Promise<InternalHasteMap> {
   return new Promise(resolve => {
     const callback = list => {
       const files = Object.create(null);

--- a/packages/jest-haste-map/src/crawlers/watchman.js
+++ b/packages/jest-haste-map/src/crawlers/watchman.js
@@ -9,7 +9,7 @@
  */
 'use strict';
 
-import type {HasteMap} from 'types/HasteMap';
+import type {InternalHasteMap} from 'types/HasteMap';
 import type {IgnoreMatcher} from '../types';
 
 const H = require('../constants');
@@ -34,8 +34,8 @@ module.exports = function watchmanCrawl(
   roots: Array<string>,
   extensions: Array<string>,
   ignore: IgnoreMatcher,
-  data: HasteMap,
-): Promise<HasteMap> {
+  data: InternalHasteMap,
+): Promise<InternalHasteMap> {
   return new Promise((resolve, reject) => {
     const client = new watchman.Client();
     client.on('error', error => reject(error));

--- a/packages/jest-runtime/src/__mocks__/createRuntime.js
+++ b/packages/jest-runtime/src/__mocks__/createRuntime.js
@@ -22,11 +22,11 @@ module.exports = function createRuntime(filename, config) {
   const environment = new NodeEnvironment(config);
   return Runtime.createHasteMap(config, {resetCache: false, maxWorkers: 1})
     .build()
-    .then(moduleMap => {
+    .then(hasteMap => {
       const runtime = new Runtime(
         config,
         environment,
-        Runtime.createResolver(config, moduleMap),
+        Runtime.createResolver(config, hasteMap.moduleMap),
       );
 
       runtime.__mockRootPath = path.join(config.rootDir, 'root.js');

--- a/packages/jest-runtime/src/index.js
+++ b/packages/jest-runtime/src/index.js
@@ -14,6 +14,7 @@ import type {Config, Path} from 'types/Config';
 import type {Environment} from 'types/Environment';
 import type {HasteContext} from 'types/HasteMap';
 import type {Script} from 'vm';
+import type ModuleMap from '../../jest-haste-map/src/ModuleMap';
 import type Resolver from '../../jest-resolve/src';
 
 const HasteMap = require('jest-haste-map');
@@ -151,10 +152,9 @@ class Runtime {
       resetCache: !config.cache,
     });
     return instance.build().then(
-      moduleMap => ({
-        instance,
-        moduleMap,
-        resolver: Runtime.createResolver(config, moduleMap),
+      hasteMap => ({
+        hasteFS: hasteMap.hasteFS,
+        resolver: Runtime.createResolver(config, hasteMap.moduleMap),
       }),
       error => {
         throw error;
@@ -187,7 +187,7 @@ class Runtime {
 
   static createResolver(
     config: Config,
-    moduleMap: HasteMap,
+    moduleMap: ModuleMap,
   ): Resolver {
     return new ResolverClass(moduleMap, {
       browser: config.browser,

--- a/packages/jest-snapshot/src/index.js
+++ b/packages/jest-snapshot/src/index.js
@@ -9,7 +9,7 @@
  */
 'use strict';
 
-import type {HasteContext} from 'types/HasteMap';
+import type {HasteFS} from 'types/HasteMap';
 import type {Jasmine} from 'types/Jasmine';
 import type {Path} from 'types/Config';
 import type {SnapshotState} from './SnapshotState';
@@ -54,29 +54,28 @@ const patchJasmine = (jasmine, state) => {
 module.exports = {
   EXTENSION,
   SnapshotFile: SnapshotFile.SnapshotFile,
-  cleanup(hasteContext: HasteContext, update: boolean) {
+  cleanup(hasteFS: HasteFS, update: boolean) {
     const pattern = '\\.' + EXTENSION + '$';
-    return hasteContext.instance.matchFiles(pattern).then(files => {
-      const filesRemoved = files
-        .filter(snapshotFile => !fileExists(
-          path.resolve(
-            path.dirname(snapshotFile),
-            '..',
-            path.basename(snapshotFile, '.' + EXTENSION),
-          ),
-          hasteContext.moduleMap.files,
-        ))
-        .map(snapshotFile => {
-          if (update) {
-            fs.unlinkSync(snapshotFile);
-          }
-        })
-        .length;
+    const files = hasteFS.matchFiles(pattern);
+    const filesRemoved = files
+      .filter(snapshotFile => !fileExists(
+        path.resolve(
+          path.dirname(snapshotFile),
+          '..',
+          path.basename(snapshotFile, '.' + EXTENSION),
+        ),
+        hasteFS,
+      ))
+      .map(snapshotFile => {
+        if (update) {
+          fs.unlinkSync(snapshotFile);
+        }
+      })
+      .length;
 
-      return {
-        filesRemoved,
-      };
-    });
+    return {
+      filesRemoved,
+    };
   },
   matcher,
   getSnapshotState: (jasmine: Jasmine, filePath: Path): SnapshotState => {

--- a/packages/jest-util/src/formatFailureMessage.js
+++ b/packages/jest-util/src/formatFailureMessage.js
@@ -77,26 +77,18 @@ const removeInternalStackEntries = (lines, config) => {
 
   return lines.filter(line => {
     const isPath = STACK_PATH_REGEXP.test(line);
-
     if (!isPath) {
       return true;
     }
-
-    pathCounter += 1;
-
-    if (pathCounter === 1) {
-      return true; // always keep the first line even if it's from jest
-    }
-
-    if (
-      STACK_TRACE_IGNORE.test(line) ||
-      JASMINE_IGNORE.test(line) ||
-      config.noStackTrace
-    ) {
+    if (JASMINE_IGNORE.test(line)) {
       return false;
     }
 
-    return true;
+    if (++pathCounter === 1) {
+      return true; // always keep the first line even if it's from Jest
+    }
+
+    return !(STACK_TRACE_IGNORE.test(line) || config.noStackTrace);
   });
 };
 
@@ -136,7 +128,7 @@ const formatStackTrace = (stack, config, testPath) => {
 const formatResultsErrors = (
   testResults: TestResult,
   config: Config,
-  testPath?: ?Path,
+  testPath: ?Path,
 ): ?string => {
   const failedResults = testResults.testResults.reduce(
     (errors, result) => {

--- a/types/HasteMap.js
+++ b/types/HasteMap.js
@@ -9,30 +9,36 @@
  */
 'use strict';
 
+import type {Path} from 'types/Config';
 import type _HasteMapInstance from '../packages/jest-haste-map/src';
+import type _HasteFS from '../packages/jest-haste-map/src/HasteFS';
 import type HasteResolver from '../packages/jest-resolve/src';
+import type _ModuleMap from '../packages/jest-haste-map/src/ModuleMap';
 
+export type HasteFS = _HasteFS;
 export type HasteMapInstance = _HasteMapInstance;
+export type ModuleMap = _ModuleMap;
 
 export type HasteContext = {
-  instance: HasteMapInstance,
-  moduleMap: HasteMap,
+  hasteFS: HasteFS,
   resolver: HasteResolver,
 };
 
-export type HasteMap = FileMap & ModuleMap;
+export type FileData = {[filepath: Path]: FileMetaData};
+export type MockData = {[id: string]: Path};
+export type ModuleMapData = {[id: string]: ModuleMapItem};
+export type WatchmanClocks = {[filepath: Path]: string};
 
-export type FileMap = {
+export type InternalHasteMap = {
   clocks: WatchmanClocks,
-  files: {[filepath: string]: FileMetaData},
+  files: FileData,
+  map: ModuleMapData,
+  mocks: MockData,
 };
-
-export type ModuleMap = {
-  map: {[id: string]: ModuleMapItem},
-  mocks: {[id: string]: string},
-}
-
-type WatchmanClocks = {[filepath: string]: string};
+export type HasteMap = {
+  hasteFS: HasteFS,
+  moduleMap: ModuleMap,
+};
 
 export type FileMetaData = [
   /* id */ string,
@@ -43,7 +49,7 @@ export type FileMetaData = [
 
 type ModuleMapItem = {[platform: string]: ModuleMetaData};
 export type ModuleMetaData = [
-  /* path */ string,
+  Path,
   /* type */ number,
 ];
 
@@ -57,6 +63,7 @@ export type HType = {
   MODULE: 0,
   PACKAGE: 1,
   GENERIC_PLATFORM: 'g',
+  NATIVE_PLATFORM: 'native',
 };
 
 export type HTypeValue = 0 | 1 | 2 | 3 | 'g';

--- a/types/Reporters.js
+++ b/types/Reporters.js
@@ -8,8 +8,8 @@
  * @flow
  */
 'use strict';
-import type {HasteContext} from 'types/HasteMap';
+import type HasteFS from '../packages/jest-haste-map/src/HasteFS';
 
 export type RunnerContext = {
-  hasteContext: HasteContext,
+  hasteFS: HasteFS,
 };


### PR DESCRIPTION
This is the first diff in a series to make `jest-haste-map` more performant. This diff doesn't impact performance but rather improves APIs so I can do further work:

* Instead of a POJO, a `HasteMap` object now consists of `HasteFS` and `ModuleMap` instances. These classes are intended to be immutable (for now) and have accessors for all data that you might want to read from it. In a follow-up, this will enable us to split up the data for both into separate cache files. Jest workers only need the module map and most of the time only either the file or the module maps are written. By splitting them in half and only writing or reading one, we can cut write time by 50 % and then read time in the worker by another 50 %. On www that's about 300-500ms per invocation of Jest (yes, really!)
* Cleaned up CoverageReporter's glob matching and moved it into HasteFS.
* Cleaned up snapshot cleanup to not require the entire HasteMap.
* Cleaned up all the crap we are passing around.
* Fixed a bug in stack trace cleanup. During debugging the first line was consistently jasmine, which we should always filter, so that the stack trace with user code and be shown (cc @dmitriiabramov).

Please expect some of the uglier parts of this diff to be cleaned up soon.

cc @davidaurelio @matryoshcow