### PR TITLE
Buffer console messages.

### DIFF
--- a/integration_tests/__tests__/__snapshots__/console-test.js.snap
+++ b/integration_tests/__tests__/__snapshots__/console-test.js.snap
@@ -1,0 +1,35 @@
+exports[`test console printing 1`] = `
+" PASS  __tests__/console-test.js
+  ● Console
+    log __tests__/console-test.js:11
+      This is a log message.
+    info __tests__/console-test.js:13
+      This is an info message.
+    warn __tests__/console-test.js:15
+      This is a warning message.
+    error __tests__/console-test.js:17
+      This is a error message.
+ PASS  __tests__/console2-test.js
+  ● Console
+    error __tests__/console2-test.js:11
+      This is an error from another test file."
+`;
+
+exports[`test console printing with --verbose 1`] = `
+"  log __tests__/console-test.js:11
+    This is a log message.
+
+  info __tests__/console-test.js:13
+    This is an info message.
+
+  warn __tests__/console-test.js:15
+    This is a warning message.
+
+  error __tests__/console-test.js:17
+    This is a error message.
+
+  error __tests__/console2-test.js:11
+    This is an error from another test file.
+
+"
+`;

--- a/integration_tests/__tests__/console-test.js
+++ b/integration_tests/__tests__/console-test.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails oncall+jsinfra
+ */
+'use strict';
+
+const runJest = require('../runJest');
+
+test('console printing', () => {
+  const result = runJest('console');
+  const stderr = result.stderr.toString();
+
+  expect(result.status).toBe(0);
+
+  // Remove last two lines because they contain timing information.
+  const output = stderr.split('\n').slice(0, -2).join('\n');
+  expect(output).toMatchSnapshot();
+});
+
+test('console printing with --verbose', () => {
+  const result = runJest('console', ['--verbose']);
+  const stdout = result.stdout.toString();
+
+  expect(result.status).toBe(0);
+
+  expect(stdout).toMatchSnapshot();
+});

--- a/integration_tests/__tests__/verbose-test.js
+++ b/integration_tests/__tests__/verbose-test.js
@@ -11,13 +11,11 @@
 
 const runJest = require('../runJest');
 
-describe('Verbose', () => {
-  it('outputs coverage report', () => {
-    const result = runJest('verbose_logger', ['--verbose']);
-    const stderr = result.stderr.toString();
+test('Verbose Reporter', () => {
+  const result = runJest('verbose_logger', ['--verbose']);
+  const stderr = result.stderr.toString();
 
-    expect(result.status).toBe(1);
-    expect(stderr).toMatch('works just fine');
-    expect(stderr).toMatch('does not work');
-  });
+  expect(result.status).toBe(1);
+  expect(stderr).toMatch('works just fine');
+  expect(stderr).toMatch('does not work');
 });

--- a/integration_tests/console/__tests__/console-test.js
+++ b/integration_tests/console/__tests__/console-test.js
@@ -4,24 +4,15 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
- *
- * @flow
  */
-
 'use strict';
 
-const Console = require('./Console');
+test('works just fine', () => {
+  console.log('This is a log message.');
 
-class NullConsole extends Console {
-  assert() {}
-  dir() {}
-  error() {}
-  info() {}
-  log() {}
-  time() {}
-  timeEnd() {}
-  trace() {}
-  warn() {}
-}
+  console.info('This is an info message.');
 
-module.exports = NullConsole;
+  console.warn('This is a warning message.');
+
+  console.error('This is a error message.');
+});

--- a/integration_tests/console/__tests__/console2-test.js
+++ b/integration_tests/console/__tests__/console2-test.js
@@ -4,24 +4,10 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
- *
- * @flow
  */
-
 'use strict';
 
-const Console = require('./Console');
+test('works just fine', () => {
+  console.error('This is an error from another test file.');
+});
 
-class NullConsole extends Console {
-  assert() {}
-  dir() {}
-  error() {}
-  info() {}
-  log() {}
-  time() {}
-  timeEnd() {}
-  trace() {}
-  warn() {}
-}
-
-module.exports = NullConsole;

--- a/integration_tests/console/package.json
+++ b/integration_tests/console/package.json
@@ -1,0 +1,5 @@
+{
+  "jest": {
+    "testEnvironment": "node"
+  }
+}

--- a/packages/jest-cli/package.json
+++ b/packages/jest-cli/package.json
@@ -4,6 +4,7 @@
   "version": "14.1.0",
   "main": "build/jest.js",
   "dependencies": {
+    "callsites": "^1.0.1",
     "chalk": "^1.1.1",
     "graceful-fs": "^4.1.3",
     "istanbul-api": "^1.0.0-aplha.10",

--- a/packages/jest-cli/src/lib/BufferedConsole.js
+++ b/packages/jest-cli/src/lib/BufferedConsole.js
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+'use strict';
+
+import type {ConsoleBuffer, LogMessage, LogType} from 'types/Console';
+
+const Console = require('console').Console;
+
+const callsites = require('callsites');
+const format = require('util').format;
+
+class BufferedConsole extends Console {
+
+  _buffer: ConsoleBuffer;
+
+  constructor() {
+    const buffer = [];
+    super({write: message => BufferedConsole.write(buffer, 'log', message)});
+    this._buffer = buffer;
+  }
+
+  static write(
+    buffer: ConsoleBuffer,
+    type: LogType,
+    message: LogMessage,
+    level: ?number,
+  ) {
+    const call = callsites()[level != null ? level : 2];
+    const origin = call.getFileName() + ':' + call.getLineNumber();
+    buffer.push({type, message, origin});
+    return buffer;
+  }
+
+  log() {
+    BufferedConsole.write(this._buffer, 'log', format.apply(null, arguments));
+  }
+
+  info() {
+    BufferedConsole.write(this._buffer, 'info', format.apply(null, arguments));
+  }
+
+  warn() {
+    BufferedConsole.write(this._buffer, 'warn', format.apply(null, arguments));
+  }
+
+  error() {
+    BufferedConsole.write(this._buffer, 'error', format.apply(null, arguments));
+  }
+
+  getBuffer() {
+    return this._buffer;
+  }
+
+}
+
+module.exports = BufferedConsole;

--- a/packages/jest-cli/src/reporters/BaseReporter.js
+++ b/packages/jest-cli/src/reporters/BaseReporter.js
@@ -42,7 +42,6 @@ class BaseReporter {
     for (let i = 0; i < string.length; i++) {
       process.stderr.write(string.charAt(i));
     }
-    process.stderr.write('\n');
   }
 
   _setError(error: Error) {

--- a/packages/jest-cli/src/reporters/DefaultReporter.js
+++ b/packages/jest-cli/src/reporters/DefaultReporter.js
@@ -16,8 +16,10 @@ const BaseReporter = require('./BaseReporter');
 
 const chalk = require('chalk');
 const getResultHeader = require('./getResultHeader');
+const getConsoleOutput = require('./getConsoleOutput');
 
 const RUNNING_TEST_COLOR = chalk.bold.gray;
+const TITLE_BULLET = chalk.bold('\u25cf ');
 
 const pluralize = (word, count) => `${count} ${word}${count === 1 ? '' : 's'}`;
 
@@ -32,13 +34,24 @@ class DefaultReporter extends BaseReporter {
     results: AggregatedResult,
   ) {
     this._clearWaitingOn(config);
-    this._printTestFileHeaderAndFailures(config, testResult);
+    this._printTestFileSummary(config, testResult);
     this._printWaitingOn(results, config);
   }
 
-  _printTestFileHeaderAndFailures(config: Config, testResult: TestResult) {
+  _printTestFileSummary(config: Config, testResult: TestResult) {
     this.log(getResultHeader(testResult, config));
-    testResult.failureMessage && this._write(testResult.failureMessage);
+
+    const consoleBuffer = testResult.console;
+    if (consoleBuffer && consoleBuffer.length) {
+      this._write(
+        '  ' + TITLE_BULLET + 'Console\n' +
+        getConsoleOutput(config.rootDir, config.verbose, consoleBuffer),
+      );
+    }
+
+    if (testResult.failureMessage) {
+      this._write(testResult.failureMessage + '\n');
+    }
   }
 
   _clearWaitingOn(config: Config) {

--- a/packages/jest-cli/src/reporters/SummaryReporter.js
+++ b/packages/jest-cli/src/reporters/SummaryReporter.js
@@ -154,8 +154,10 @@ class SummareReporter extends BaseReporter {
       aggregatedResults.testResults.forEach(testResult => {
         const {failureMessage} = testResult;
         if (failureMessage) {
-          this._write(getResultHeader(testResult, config));
-          this._write(failureMessage);
+          this._write(
+            getResultHeader(testResult, config) + '\n' +
+            failureMessage + '\n',
+          );
         }
       });
       this.log(''); // print empty line

--- a/packages/jest-cli/src/reporters/VerboseReporter.js
+++ b/packages/jest-cli/src/reporters/VerboseReporter.js
@@ -53,7 +53,7 @@ class VerboseReporter extends DefaultReporter {
     if (!testResult.testExecError) {
       this._logTestResults(testResult.testResults);
     }
-    this._printTestFileHeaderAndFailures(config, testResult);
+    this._printTestFileSummary(config, testResult);
     this._printWaitingOn(results, config);
   }
 

--- a/packages/jest-cli/src/reporters/getConsoleOutput.js
+++ b/packages/jest-cli/src/reporters/getConsoleOutput.js
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+'use strict';
+
+import type {ConsoleBuffer} from 'types/Console';
+
+const chalk = require('chalk');
+const path = require('path');
+
+module.exports = (root: string, verbose: boolean, buffer: ConsoleBuffer) => {
+  const TITLE_INDENT = verbose ? '  ' : '    ';
+  const CONSOLE_INDENT = TITLE_INDENT + '  ';
+
+  return buffer.reduce((output, {type, message, origin}) => {
+    origin = path.relative(root, origin);
+    message = message
+      .split(/\n/)
+      .map(line => CONSOLE_INDENT + line)
+      .join('\n');
+
+    if (type === 'warn') {
+      message = chalk.yellow(message);
+      type = chalk.yellow(type);
+    } else if (type === 'error') {
+      message = chalk.red(message);
+      type = chalk.red(type);
+    }
+
+    return (
+      output +
+      TITLE_INDENT +
+      (verbose ? type : chalk.bold(type)) +
+      ' ' + chalk.gray(origin) + '\n' +
+      message + '\n'
+    );
+  }, '');
+};

--- a/packages/jest-util/package.json
+++ b/packages/jest-util/package.json
@@ -11,8 +11,8 @@
     "chalk": "^1.1.1",
     "diff": "^2.1.1",
     "graceful-fs": "^4.1.3",
-    "mkdirp": "^0.5.1",
-    "jest-mock": "^14.0.0"
+    "jest-mock": "^14.0.0",
+    "mkdirp": "^0.5.1"
   },
   "devDependencies": {
     "jsdom": "^9.2.1"

--- a/packages/jest-util/src/Console.js
+++ b/packages/jest-util/src/Console.js
@@ -8,40 +8,52 @@
  * @flow
  */
 
-// Copyright Joyent, Inc. and other Node contributors.
-//
-// Permission is hereby granted, free of charge, to any person obtaining a
-// copy of this software and associated documentation files (the
-// "Software"), to deal in the Software without restriction, including
-// without limitation the rights to use, copy, modify, merge, publish,
-// distribute, sublicense, and/or sell copies of the Software, and to permit
-// persons to whom the Software is furnished to do so, subject to the
-// following conditions:
-//
-// The above copyright notice and this permission notice shall be included
-// in all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
-// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
-// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
-// USE OR OTHER DEALINGS IN THE SOFTWARE.
-
 'use strict';
 
-const util = require('util');
+import type {LogType, LogMessage} from 'types/Console';
+
 const Console = require('console').Console;
-const chalk = require('chalk');
+
+const format = require('util').format;
+
+type Formatter = (type: LogType, message: LogMessage) => string;
 
 class CustomConsole extends Console {
+
+  _formatBuffer: Formatter;
+
+  constructor(
+    stdout: Object,
+    stderr: Object,
+    formatBuffer: ?Formatter,
+  ) {
+    super(stdout, stderr);
+    this._formatBuffer =
+      formatBuffer || ((type, message) => type + ' ' + message);
+  }
+
+  _log(type: LogType, message: string) {
+    super.log(this._formatBuffer(type, message));
+  }
+
+  log() {
+    this._log('log', format.apply(null, arguments));
+  }
+
+  info() {
+    this._log('info', format.apply(null, arguments));
+  }
+
   warn() {
-    return super.warn(chalk.yellow(util.format.apply(this, arguments)));
+    this._log('warn', format.apply(null, arguments));
   }
 
   error() {
-    return super.error(chalk.red(util.format.apply(this, arguments)));
+    this._log('error', format.apply(null, arguments));
+  }
+
+  getBuffer() {
+    return null;
   }
 }
 

--- a/types/Console.js
+++ b/types/Console.js
@@ -7,21 +7,13 @@
  *
  * @flow
  */
-
 'use strict';
 
-const Console = require('./Console');
-
-class NullConsole extends Console {
-  assert() {}
-  dir() {}
-  error() {}
-  info() {}
-  log() {}
-  time() {}
-  timeEnd() {}
-  trace() {}
-  warn() {}
-}
-
-module.exports = NullConsole;
+export type LogMessage = string;
+export type LogEntry = {
+  message: LogMessage,
+  origin: string,
+  type: LogType,
+};
+export type LogType = 'log' | 'info' | 'warn' | 'error';
+export type ConsoleBuffer = Array<LogEntry>;

--- a/types/TestResult.js
+++ b/types/TestResult.js
@@ -9,6 +9,8 @@
  */
 'use strict';
 
+import type {ConsoleBuffer} from './Console';
+
 export type Coverage = Object;
 
 export type Error = {
@@ -63,6 +65,7 @@ export type Suite = {
 };
 
 export type TestResult = {
+  console?: ConsoleBuffer,
   coverage?: Coverage,
   hasUncheckedKeys: boolean,
   memoryUsage?: Bytes,


### PR DESCRIPTION
This is the first iteration of buffering and pretty-printing console messages. There are three possible behaviors:

* `--silent` does not print console messages.
* `--verbose` prints console messages as soon as they happen.
* *new default*: print console messages after a test completes.

We'll be changing the default to verbose mode if only a single test is run in #1418 and I think it is important to log asap in case people are debugging and trying to figure out infinite loops. In a follow-up diff I'll explore a timer in `BufferedConsole` that will attempt to flush console messages if a test is still running after 10 seconds. This applies to a lot of tests at FB but I think it is fine to do this and will work well in open source.

* `jest haste-map --verbose`
<img width="889" alt="screen shot 2016-08-15 at 11 13 32 pm" src="https://cloud.githubusercontent.com/assets/13352/17681494/0486463c-633e-11e6-91a8-991234b95fc2.png">

* `jest haste-map`
<img width="882" alt="screen shot 2016-08-15 at 11 13 48 pm" src="https://cloud.githubusercontent.com/assets/13352/17681495/0486a820-633e-11e6-9d3f-926e0d4a7d96.png">

cc @gaearon @ForbesLindesay 