### PR TITLE
Add an option to retain all files in jest-haste-map.

### DIFF
--- a/packages/jest-haste-map/src/__tests__/index-test.js
+++ b/packages/jest-haste-map/src/__tests__/index-test.js
@@ -218,7 +218,6 @@ describe('HasteMap', () => {
       ' */',
     ].join('\n');
 
-
     const hasteMap = new HasteMap(Object.assign({}, defaultConfig, {
       mocksPattern: '/__mocks__/',
       providesModuleNodeModules: ['react', 'fbjs'],
@@ -267,6 +266,32 @@ describe('HasteMap', () => {
       // The cache file must exactly mirror the data structure returned
       // from a build.
       expect(hasteMap.read()).toEqual(data);
+    });
+  });
+
+  it('retains all files if `retainAllFiles` is specified', () => {
+    mockFs['/fruits/node_modules/fbjs/index.js'] = [
+      '/**',
+      ' * @providesModule fbjs',
+      ' */',
+    ].join('\n');
+
+    const hasteMap = new HasteMap(Object.assign({}, defaultConfig, {
+      mocksPattern: '/__mocks__/',
+      retainAllFiles: true,
+    }));
+
+    return hasteMap.build().then(({__hasteMapForTest: data}) => {
+      // Expect the node module to be part of files but make sure it wasn't
+      // read.
+      expect(
+        data.files['/fruits/node_modules/fbjs/index.js'],
+      ).toEqual(['', 32, 0, []]);
+
+      expect(data.map.fbjs).not.toBeDefined();
+
+      // cache file + 5 modules - the node_module
+      expect(fs.readFileSync.mock.calls.length).toBe(6);
     });
   });
 


### PR DESCRIPTION
This is necessary for adoption in react-native packager.

In Jest we can omit most node modules because we use the `resolve` module which (unfortunately) does real fs access. react-native packager doesn't want this (and we don't either, but it is convenient) so we are adding an option to retain all files in the haste map so packager can use it to optimize its resolution algorithm. Long term I expect this option to be on in Jest as well.

cc @davidaurelio 
