### PR TITLE
Resolve `jest-environment-<name>` before trying `<name>`.

### DIFF
--- a/packages/jest-config/src/__tests__/normalize-test.js
+++ b/packages/jest-config/src/__tests__/normalize-test.js
@@ -476,13 +476,16 @@ describe('normalize', () => {
       Resolver = require('jest-resolve');
       Resolver.findNodeModule = jest.fn(name => {
         if (name === 'jsdom') {
+          return 'node_modules/jsdom';
+        }
+        if (name === 'jest-environment-jsdom') {
           return 'node_modules/jest-environment-jsdom';
         }
         return null;
       });
     });
 
-    it('correctly resolves to an environment', () => {
+    it('resolves to an environment and prefers jest-environment-`name`', () => {
       const config = normalize({
         rootDir: '/root',
         testEnvironment: 'jsdom',

--- a/packages/jest-config/src/normalize.js
+++ b/packages/jest-config/src/normalize.js
@@ -55,24 +55,24 @@ function _replaceRootDirTags(rootDir, config) {
 
 function getTestEnvironment(config) {
   const env = config.testEnvironment;
-  let module = Resolver.findNodeModule(env, {basedir: config.rootDir});
-  if (module) {
-    return module;
-  }
-
-  module = Resolver.findNodeModule(`jest-environment-${env}`, {
+  let module = Resolver.findNodeModule(`jest-environment-${env}`, {
     basedir: config.rootDir,
   });
   if (module) {
     return module;
   }
 
-  try {
-    return require.resolve(env);
-  } catch (e) {}
+  module = Resolver.findNodeModule(env, {basedir: config.rootDir});
+  if (module) {
+    return module;
+  }
 
   try {
     return require.resolve(`jest-environment-${env}`);
+  } catch (e) {}
+
+  try {
+    return require.resolve(env);
   } catch (e) {}
 
   throw new Error(

--- a/packages/jest-runtime/src/transform.js
+++ b/packages/jest-runtime/src/transform.js
@@ -60,6 +60,7 @@ const getCacheKey = (
       mocksPattern: config.mocksPattern,
       moduleFileExtensions: config.moduleFileExtensions,
       moduleNameMapper: config.moduleNameMapper,
+      preprocessorIgnorePatterns: config.preprocessorIgnorePatterns,
       rootDir: config.rootDir,
       testPathDirs: config.testPathDirs,
       testRegex: config.testRegex,


### PR DESCRIPTION
When someone sets this to `jsdom`, we require jsdom instead of `jest-environment-jsdom` so it will break. Reordering will work.

Also added a config option to the transform cache key.