### PR TITLE
toEqual Jest matcher.

### DIFF
--- a/packages/jest-jasmine2/src/index.js
+++ b/packages/jest-jasmine2/src/index.js
@@ -115,42 +115,6 @@ function jasmine2(
     throw new Error('jasmine2 could not be initialized by Jest');
   }
 
-  const hasIterator = object => !!(object != null && object[Symbol.iterator]);
-  const iterableEquality = (a, b) => {
-    if (
-      typeof a !== 'object' ||
-      typeof b !== 'object' ||
-      Array.isArray(a) ||
-      Array.isArray(b) ||
-      !hasIterator(a) ||
-      !hasIterator(b)
-    ) {
-      return undefined;
-    }
-    if (a.constructor !== b.constructor) {
-      return false;
-    }
-    const bIterator = b[Symbol.iterator]();
-
-    for (const aValue of a) {
-      const nextB = bIterator.next();
-      if (
-        nextB.done ||
-        !jasmine.matchersUtil.equals(
-          aValue,
-          nextB.value,
-          [iterableEquality],
-        )
-      ) {
-        return false;
-      }
-    }
-    if (!bIterator.next().done) {
-      return false;
-    }
-    return true;
-  };
-
   runtime.setMock(
     '',
     'jest-check',
@@ -162,12 +126,10 @@ function jasmine2(
   );
 
   env.beforeEach(() => {
-    jasmine.addCustomEqualityTester(iterableEquality);
     jasmine.addMatchers({
       toMatchSnapshot: snapshot.matcher(
         testPath,
         config,
-        jasmine,
         snapshotState,
       ),
     });

--- a/packages/jest-snapshot/src/matcher.js
+++ b/packages/jest-snapshot/src/matcher.js
@@ -9,7 +9,6 @@
  */
 'use strict';
 
-import type {Jasmine} from 'types/Jasmine';
 import type {Path} from 'types/Config';
 import type {SnapshotState} from './SnapshotState';
 
@@ -23,7 +22,6 @@ type CompareResult = {
 module.exports = (
   filePath: Path,
   options: Object,
-  jasmine: Jasmine,
   snapshotState: SnapshotState,
 ) => (util: any, customEquality: any) => {
   return {


### PR DESCRIPTION
This just forwards to Jasmine's equality checker. This means we are in control of the printing but we rely on Jasmine to not change the behavior of our toEqual matcher.

Follow-up diff will explore improved messages and colors.