### PR TITLE
Upgrade Lerna to beta 26

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "lerna": "2.0.0-beta.24",
+  "lerna": "2.0.0-beta.26",
   "version": "14.1.3",
   "linkedFiles": {
     "prefix": "/**\n * @flow\n */\n"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "graceful-fs": "^4.1.5",
     "istanbul-api": "^1.0.0-aplha.10",
     "istanbul-lib-coverage": "^1.0.0",
-    "lerna": "2.0.0-beta.24",
+    "lerna": "2.0.0-beta.26",
     "minimatch": "^3.0.3",
     "mkdirp": "^0.5.1",
     "progress": "^1.1.8",


### PR DESCRIPTION
Lerna 2.0 beta 24 has known issues in Windows: It appears to run successfully but actually doesn't do anything (https://github.com/lerna/lerna/issues/226#issuecomment-233049613). Need to upgrade to beta 26 to get an actual working version.