### PR TITLE
Fixes for Jest on Windows

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "lerna": "2.0.0-beta.24",
+  "lerna": "2.0.0-beta.26",
   "version": "14.1.3",
   "linkedFiles": {
     "prefix": "/**\n * @flow\n */\n"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "graceful-fs": "^4.1.5",
     "istanbul-api": "^1.0.0-aplha.10",
     "istanbul-lib-coverage": "^1.0.0",
-    "lerna": "2.0.0-beta.24",
+    "lerna": "2.0.0-beta.26",
     "minimatch": "^3.0.3",
     "mkdirp": "^0.5.1",
     "progress": "^1.1.8",
@@ -28,7 +28,7 @@
     "build-clean": "rm -rf ./packages/*/build",
     "build": "node ./scripts/build.js",
     "clean-all": "rm -rf ./packages/*/node_modules; rm -rf ./integration_tests/*/*/node_modules; npm run build-clean",
-    "jest": "./packages/jest-cli/bin/jest.js",
+    "jest": "node ./packages/jest-cli/bin/jest.js",
     "jest-coverage": "npm run jest -- --coverage",
     "lint": "eslint .",
     "postinstall": "node ./scripts/postinstall.js && node ./scripts/build.js",
@@ -65,6 +65,6 @@
       "\\.snap$",
       "packages/.*/build"
     ],
-    "testRegex": ".*-test.\\js"
+    "testRegex": ".*-test\\.js"
   }
 }

--- a/packages/jest-cli/src/SearchSource.js
+++ b/packages/jest-cli/src/SearchSource.js
@@ -86,9 +86,10 @@ class SearchSource {
     this._options = options || {};
 
     this._testPathDirPattern =
-      new RegExp(config.testPathDirs.map(dir => {
-        return pathToRegex(utils.escapeStrForRegex(dir));
-      }).join('|'));
+      new RegExp(config.testPathDirs.map(
+        dir => utils.escapePathForRegex(dir),
+      ).join('|'));
+
     this._testRegex = new RegExp(pathToRegex(config.testRegex));
     const ignorePattern = config.testPathIgnorePatterns;
     this._testIgnorePattern =

--- a/packages/jest-util/src/index.js
+++ b/packages/jest-util/src/index.js
@@ -14,6 +14,15 @@ const fs = require('fs');
 const mkdirp = require('mkdirp');
 const path = require('path');
 
+const escapePathForRegex = (dir: string) => {
+  if (path.sep === '\\') {
+    // Replace "\" with "/" so it's not escaped by escapeStrForRegex.
+    // replacePathSepForRegex will convert it back.
+    dir = dir.replace(/\\/g, '/');
+  }
+  return replacePathSepForRegex(escapeStrForRegex(dir));
+};
+
 const escapeStrForRegex =
   (string: string) => string.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
 
@@ -57,6 +66,7 @@ exports.NullConsole = require('./NullConsole');
 
 exports.clearLine = require('./clearLine');
 exports.createDirectory = createDirectory;
+exports.escapePathForRegex = escapePathForRegex;
 exports.escapeStrForRegex = escapeStrForRegex;
 exports.formatResultsErrors =
   require('./formatFailureMessage').formatResultsErrors;


### PR DESCRIPTION
 - Upgrade Lerna. Lerna 2.0 beta 24 has known issues in Windows: It appears to run successfully but actually doesn't do anything (https://github.com/lerna/lerna/issues/226#issuecomment-233049613). Need to upgrade to beta 26 to get an actual working version.
 - The regex in `package.json` wasn't working correctly for some reason. Moving the `\` to the right spot (before the `.`) fixed it. (6c7620237ba9fa3a441bb7f26aabc59e9df85467)
 - `SearchSource`  was incorrectly escaping `\` characters in the file path. To avoid this, we convert the `\` to `/` before running `escapeStrForRegex`. `replacePathSepForRegex` (which is what `pathToRegex` calls) converts it back to the correct separator anyways.

Fixes #1462