### PR TITLE
Add --watchAll option

### DIFF
--- a/packages/jest-cli/src/cli/args.js
+++ b/packages/jest-cli/src/cli/args.js
@@ -28,9 +28,11 @@ const check = (argv: Object) => {
     );
   }
 
-  if (argv.watchExtensions && argv.watch === undefined) {
+  if (argv.onlyChanged && argv.watchAll) {
     throw new Error(
-      '--watchExtensions can only be specified together with --watch.',
+      'Both --onlyChanged and --watchAll were specified, but these two ' +
+      'options do not make sense together. Try the --watch option which ' +
+      'reruns only tests related to changed files.',
     );
   }
 
@@ -148,10 +150,18 @@ const options = {
   watch: {
     description: wrap(
       'Watch files for changes and rerun tests related to changed files. ' +
-      'If you want to re-run all tests when a file has changed, you can ' +
-      'call Jest using `--watch=all`.',
+      'If you want to re-run all tests when a file has changed, use the ' +
+      '`--watchAll` option.',
     ),
-    type: 'string',
+    type: 'boolean',
+  },
+  watchAll: {
+    description: wrap(
+      'Watch files for changes and rerun all tests. If you want to re-run ' +
+       'only the tests related to the changed files, use the ' +
+      '`--watch` option.',
+    ),
+    type: 'boolean',
   },
   bail: {
     alias: 'b',

--- a/packages/jest-cli/src/jest.js
+++ b/packages/jest-cli/src/jest.js
@@ -51,7 +51,7 @@ function buildTestPathPatternInfo(argv) {
     return {
       lastCommit: argv.lastCommit,
       onlyChanged: true,
-      watch: argv.watch !== undefined,
+      watch: argv.watch,
     };
   }
   if (argv.testPathPattern) {
@@ -151,10 +151,8 @@ function runCLI(argv: Object, root: Path, onComplete: () => void) {
         pipe.write('test framework = ' + testFramework.name + '\n');
         pipe.write('config = ' + JSON.stringify(config, null, '  ') + '\n');
       }
-      if (argv.watch !== undefined) {
-        if (argv.watch !== 'all') {
-          argv.onlyChanged = true;
-        }
+      if (argv.watch || argv.watchAll) {
+        argv.onlyChanged = !argv.watchAll;
 
         return new Promise(resolve => {
           getWatcher(config, root, watcher => {


### PR DESCRIPTION
Run `jest --watchAll` to automatically rerun all tests (not just the changed ones) when a file changes.