### PR TITLE
Teeny docs tweak

### DIFF
--- a/packages/babel-jest/README.md
+++ b/packages/babel-jest/README.md
@@ -7,7 +7,7 @@
 If you are already using `jest-cli`, just add `babel-jest` and it will automatically compile JavaScript code using babel.
 
 ```
-npm install --save babel-jest
+npm install --save-dev babel-jest
 ```
 
 If you would like to write your own preprocessor, uninstall and delete babel-jest and set the [config.scriptPreprocessor](http://facebook.github.io/jest/docs/api.html#scriptpreprocessor-string) option to your preprocessor.


### PR DESCRIPTION
Seems like you should basically always be installing babel-jest with --save-dev rather than --save IIUC.