### PR TITLE
Add tests for babel-plugin-jest-hoist

### DIFF
--- a/packages/babel-plugin-jest-hoist/src/__tests__/babel-plugin-jest-hoist-test.js
+++ b/packages/babel-plugin-jest-hoist/src/__tests__/babel-plugin-jest-hoist-test.js
@@ -1,0 +1,27 @@
+// require('babel-register');
+
+const fs = require('fs');
+const path = require('path');
+const babel = require('babel-core');
+
+const rootDir = path.resolve(__dirname);
+const options = {plugins: [rootDir + '/../index']};
+
+describe('babel-plugin-jest-hoist', () => {
+
+  // Read all test dirs
+  fs.readdirSync(rootDir).forEach(suiteName => {
+    const filePath = rootDir + '/' + suiteName;
+
+    if (fs.statSync(filePath).isDirectory()) {
+
+      // Run test case with fixtures
+      it(suiteName.replace(/-/g, ' '), () => {
+        const expected = fs.readFileSync(filePath + '/expected.js').toString();
+        const actual = fs.readFileSync(filePath + '/actual.js').toString();
+        const code = babel.transform(actual, options).code;
+        expect(code.trim()).toEqual(expected.trim());
+      });
+    }
+  });
+});

--- a/packages/babel-plugin-jest-hoist/src/__tests__/babel-plugin-jest-hoist-test.js
+++ b/packages/babel-plugin-jest-hoist/src/__tests__/babel-plugin-jest-hoist-test.js
@@ -1,5 +1,3 @@
-// require('babel-register');
-
 const fs = require('fs');
 const path = require('path');
 const babel = require('babel-core');

--- a/packages/babel-plugin-jest-hoist/src/__tests__/should-hoist-jest-mock/actual.js
+++ b/packages/babel-plugin-jest-hoist/src/__tests__/should-hoist-jest-mock/actual.js
@@ -1,0 +1,3 @@
+import foo from 'foo';
+jest.mock('bar', () => {});
+console.log(foo);

--- a/packages/babel-plugin-jest-hoist/src/__tests__/should-hoist-jest-mock/expected.js
+++ b/packages/babel-plugin-jest-hoist/src/__tests__/should-hoist-jest-mock/expected.js
@@ -1,0 +1,3 @@
+jest.mock('bar', () => {});
+import foo from 'foo';
+console.log(foo);

--- a/packages/babel-plugin-jest-hoist/src/__tests__/should-hoist-jest-unmock-and-mock/actual.js
+++ b/packages/babel-plugin-jest-hoist/src/__tests__/should-hoist-jest-unmock-and-mock/actual.js
@@ -1,0 +1,4 @@
+import foo from 'foo';
+jest.unmock('foo');
+jest.mock('bar', () => {});
+console.log(foo);

--- a/packages/babel-plugin-jest-hoist/src/__tests__/should-hoist-jest-unmock-and-mock/expected.js
+++ b/packages/babel-plugin-jest-hoist/src/__tests__/should-hoist-jest-unmock-and-mock/expected.js
@@ -1,0 +1,4 @@
+jest.unmock('foo');
+jest.mock('bar', () => {});
+import foo from 'foo';
+console.log(foo);

--- a/packages/babel-plugin-jest-hoist/src/__tests__/should-hoist-jest-unmock/actual.js
+++ b/packages/babel-plugin-jest-hoist/src/__tests__/should-hoist-jest-unmock/actual.js
@@ -1,0 +1,3 @@
+import foo from 'foo';
+jest.unmock('bar');
+console.log(foo);

--- a/packages/babel-plugin-jest-hoist/src/__tests__/should-hoist-jest-unmock/expected.js
+++ b/packages/babel-plugin-jest-hoist/src/__tests__/should-hoist-jest-unmock/expected.js
@@ -1,0 +1,3 @@
+jest.unmock('bar');
+import foo from 'foo';
+console.log(foo);


### PR DESCRIPTION
We were having some issues with Jest not hoisting `jest.mock` calls in our tests, so I put this together to make a fix. But it looks like it's doing what it should be doing. Either way I thought we could merge these in so we have some tests.

It's using the fixture actual/expected style that babel itself uses in it's plugin tests. :)