### PR TITLE
SpyMatchers snapshot tests

### DIFF
--- a/packages/jest-matcher-utils/src/index.js
+++ b/packages/jest-matcher-utils/src/index.js
@@ -125,6 +125,9 @@ const ensureNumbers = (actual: any, expected: any, matcherName: string) => {
   ensureExpectedIsNumber(expected, matcherName);
 };
 
+const pluralize =
+  (word: string, count: number) => `${count} ${word}${count === 1 ? '' : 's'}`;
+
 module.exports = {
   ensureActualIsNumber,
   ensureExpectedIsNumber,
@@ -132,6 +135,7 @@ module.exports = {
   ensureNumbers,
   getType,
   highlight,
+  pluralize,
   printExpected,
   stringify,
 };

--- a/packages/jest-matchers/src/__tests__/__snapshots__/spyMatchers-test.js.snap
+++ b/packages/jest-matchers/src/__tests__/__snapshots__/spyMatchers-test.js.snap
@@ -1,0 +1,27 @@
+exports[`test toBeCalled works only on spies or jest.fn 1`] = `[Error: toBeCalled matcher can only be used on a spy or mock function.]`;
+
+exports[`test toBeCalled works with jasmine.createSpy 1`] = `[Error: Expected the spy to be called.]`;
+
+exports[`test toBeCalled works with jasmine.createSpy 2`] = `[Error: Expected the spy not to be called, but it was called 1 time.]`;
+
+exports[`test toBeCalled works with jasmine.createSpy 3`] = `[Error: toBeCalled matcher does not accept any arguments.]`;
+
+exports[`test toBeCalled works with jest.fn 1`] = `[Error: Expected the mock function to be called.]`;
+
+exports[`test toBeCalled works with jest.fn 2`] = `[Error: Expected the mock function not to be called, but it was called 1 time.]`;
+
+exports[`test toBeCalled works with jest.fn 3`] = `[Error: toBeCalled matcher does not accept any arguments.]`;
+
+exports[`test toHaveBeenCalled works only on spies or jest.fn 1`] = `[Error: toHaveBeenCalled matcher can only be used on a spy or mock function.]`;
+
+exports[`test toHaveBeenCalled works with jasmine.createSpy 1`] = `[Error: Expected the spy to be called.]`;
+
+exports[`test toHaveBeenCalled works with jasmine.createSpy 2`] = `[Error: Expected the spy not to be called, but it was called 1 time.]`;
+
+exports[`test toHaveBeenCalled works with jasmine.createSpy 3`] = `[Error: toHaveBeenCalled matcher does not accept any arguments.]`;
+
+exports[`test toHaveBeenCalled works with jest.fn 1`] = `[Error: Expected the mock function to be called.]`;
+
+exports[`test toHaveBeenCalled works with jest.fn 2`] = `[Error: Expected the mock function not to be called, but it was called 1 time.]`;
+
+exports[`test toHaveBeenCalled works with jest.fn 3`] = `[Error: toHaveBeenCalled matcher does not accept any arguments.]`;

--- a/packages/jest-matchers/src/spyMatchers.js
+++ b/packages/jest-matchers/src/spyMatchers.js
@@ -15,6 +15,7 @@ import type {MatchersObject} from './types';
 const {
   ensureNoExpected,
   ensureExpectedIsNumber,
+  pluralize,
 } = require('jest-matcher-utils');
 
 const spyMatchers: MatchersObject = {
@@ -46,10 +47,10 @@ const spyMatchers: MatchersObject = {
       : actual.mock.calls.length;
     const pass = count === expected;
     const message = pass
-      ? `Expected the ${type} not to be called ${expected} times,` +
-        ` but it was called ${count} times.`
-      : `Expected the ${type} to be called ${expected} times,` +
-        ` but it was called ${count} times.`;
+      ? `Expected the ${type} not to be called ${pluralize('time', expected)}` +
+        `, but it was called ${pluralize('time', count)}.`
+      : `Expected the ${type} to be called ${pluralize('time', expected)},` +
+        ` but it was called ${pluralize('time', count)}.`;
 
     return {message, pass};
   },
@@ -59,7 +60,7 @@ const jestToHaveBeenCalled = actual => {
   const pass = actual.mock.calls.length > 0;
   const message = pass
     ? `Expected the mock function not to be called, but it was` +
-      ` called ${actual.mock.calls.length} times.`
+      ` called ${pluralize('time', actual.mock.calls.length)}.`
     : `Expected the mock function to be called.`;
 
   return {message, pass};
@@ -69,7 +70,7 @@ const jasmineToHaveBeenCalled = actual => {
   const pass = actual.calls.any();
   const message = pass
     ? `Expected the spy not to be called, but it was` +
-      ` called ${actual.calls.count()} times.`
+      ` called ${pluralize('time', actual.calls.count())}.`
     : `Expected the spy to be called.`;
 
   return {message, pass};


### PR DESCRIPTION
`t 12627110`
seems like it has also been done already. I just changed the tests to use snapshots instead of regexps to capture the whole message and not just the piece.