### PR TITLE
s/chalk.gray/chalk.dim

### DIFF
--- a/packages/jest-cli/src/reporters/VerboseReporter.js
+++ b/packages/jest-cli/src/reporters/VerboseReporter.js
@@ -86,7 +86,7 @@ class VerboseReporter extends DefaultReporter {
     const time = test.duration
       ? ` (${test.duration.toFixed(0)}ms)`
       : '';
-    this._logLine(status + ' ' + chalk.gray(test.title + time), indentLevel);
+    this._logLine(status + ' ' + chalk.dim(test.title + time), indentLevel);
   }
 
   _logLine(str?: string, indentLevel?: number) {

--- a/packages/jest-cli/src/reporters/getConsoleOutput.js
+++ b/packages/jest-cli/src/reporters/getConsoleOutput.js
@@ -36,7 +36,7 @@ module.exports = (root: string, verbose: boolean, buffer: ConsoleBuffer) => {
 
     return (
       output + TITLE_INDENT + chalk.dim(typeMessage) +
-      ' ' + chalk.gray(origin) + '\n' + message + '\n'
+      ' ' + chalk.dim(origin) + '\n' + message + '\n'
     );
   }, '');
 };

--- a/packages/jest-cli/src/reporters/getResultHeader.js
+++ b/packages/jest-cli/src/reporters/getResultHeader.js
@@ -42,7 +42,7 @@ module.exports = (testResult: TestResult, config: Config) => {
 
   const dirname = path.dirname(pathStr);
   const basename = path.basename(pathStr);
-  const testFileStr = chalk.gray(dirname + path.sep) + chalk.bold(basename);
+  const testFileStr = chalk.dim(dirname + path.sep) + chalk.bold(basename);
   return `${allTestsPassed ? PASS : FAIL} ${testFileStr}` +
   (testDetail.length ? ` (${testDetail.join(', ')})` : '');
 };

--- a/packages/jest-diff/src/constants.js
+++ b/packages/jest-diff/src/constants.js
@@ -13,4 +13,4 @@
 const chalk = require('chalk');
 
 module.exports.NO_DIFF_MESSAGE =
-  chalk.gray.underline('Compared values have no visual difference');
+  chalk.dim.underline('Compared values have no visual difference');

--- a/packages/jest-diff/src/diffStrings.js
+++ b/packages/jest-diff/src/diffStrings.js
@@ -62,7 +62,7 @@ function diffStrings(a: string, b: string, options: ?DiffOptions): ?string {
 
       const color = part.added
         ? chalk.green
-        : (part.removed ? chalk.red : chalk.gray);
+        : (part.removed ? chalk.red : chalk.dim);
       return color(part.value);
     }).join('');
   }

--- a/packages/jest-util/src/JasmineFormatter.js
+++ b/packages/jest-util/src/JasmineFormatter.js
@@ -151,7 +151,7 @@ class JasmineFormatter {
       const type = Object.prototype.toString.call(object);
       const output = [];
       if (type === '[object Map]') {
-        indent = chalk.gray('|') + ' ' + indent;
+        indent = chalk.dim('|') + ' ' + indent;
         for (const value of object) {
           output.push(
             indent + value[0] + ': ' + this.prettyPrint(
@@ -168,7 +168,7 @@ class JasmineFormatter {
           output.push(
             this.prettyPrint(
               value,
-              chalk.gray('|') + ' ' + indent,
+              chalk.dim('|') + ' ' + indent,
               cycleWeakMap,
             ),
           );
@@ -179,7 +179,7 @@ class JasmineFormatter {
       const orderedKeys = Object.keys(object).sort();
       let value;
       const keysOutput = [];
-      const keyIndent = chalk.gray('|') + ' ';
+      const keyIndent = chalk.dim('|') + ' ';
       for (let i = 0; i < orderedKeys.length; i++) {
         value = object[orderedKeys[i]];
         keysOutput.push(

--- a/packages/jest-util/src/__tests__/JasmineFormatter-test.js
+++ b/packages/jest-util/src/__tests__/JasmineFormatter-test.js
@@ -39,7 +39,7 @@ describe('JasmineFormatter', () => {
       '| | bar: \'baz\'\n' +
       '| }\n' +
       '}';
-      expect(printed).toBe(expected.replace(/\|/g, chalk.gray('|')));
+      expect(printed).toBe(expected.replace(/\|/g, chalk.dim('|')));
     });
 
     it('should pretty print Sets', () => {
@@ -68,7 +68,7 @@ describe('JasmineFormatter', () => {
       '| | ]\n' +
       '| }\n' +
       '}';
-      expect(printed).toBe(expected.replace(/\|/g, chalk.gray('|')));
+      expect(printed).toBe(expected.replace(/\|/g, chalk.dim('|')));
     });
   });
 });

--- a/packages/jest-util/src/__tests__/__snapshots__/formatFailureMessage-test.js.snap
+++ b/packages/jest-util/src/__tests__/__snapshots__/formatFailureMessage-test.js.snap
@@ -2,8 +2,8 @@ exports[`formatFailureMessage should exclude jasmine from stack trace for window
 "  [1m● [22m › windows test
 
       at stack (..\\jest-jasmine2\\vendor\\jasmine-2.4.1.js:1580:17)
-[90m      
-      at Object.addResult ([34m..\\jest-jasmine2\\vendor\\jasmine-2.4.1.js[90m:1550:14)
-      at Object.it ([34mbuild\\__tests__\\formatFailureMessage-test.js[90m:45:41)[39m
+[2m      
+      [2mat Object.addResult ([2m[0m[34m..\\jest-jasmine2\\vendor\\jasmine-2.4.1.js[39m[0m[2m:1550:14)[2m
+      [2mat Object.it ([2m[0m[34mbuild\\__tests__\\formatFailureMessage-test.js[39m[0m[2m:45:41)[2m[22m
 "
 `;

--- a/packages/jest-util/src/formatFailureMessage.js
+++ b/packages/jest-util/src/formatFailureMessage.js
@@ -26,7 +26,7 @@ const MESSAGE_INDENT = '    ';
 const STACK_INDENT = '      ';
 const ANCESTRY_SEPARATOR = ' \u203A ';
 const TITLE_BULLET = chalk.bold('\u25cf ');
-const STACK_TRACE_COLOR = chalk.gray;
+const STACK_TRACE_COLOR = chalk.dim;
 const STACK_PATH_REGEXP = /\s*at.*\(?(\:\d*\:\d*|native)\)?/;
 const EXEC_ERROR_MESSAGE = 'Test suite failed to run';
 
@@ -104,13 +104,14 @@ const formatPaths = (config, relativeTestPath, line) => {
   filePath = path.relative(config.rootDir, filePath);
 
   if (new RegExp(config.testRegex).test(filePath)) {
-    filePath = chalk.blue(filePath);
+    filePath = chalk.reset.blue(filePath);
   } else if (filePath === relativeTestPath) {
     // highlight paths from the current test file
-    filePath = chalk.cyan(filePath);
+    filePath = chalk.reset.cyan(filePath);
   }
   // make paths relative to the <rootDir>
-  return matches[1] + filePath + matches[3];
+  return STACK_TRACE_COLOR(matches[1])
+    + filePath + STACK_TRACE_COLOR(matches[3]);
 };
 
 const formatStackTrace = (stack, config, testPath) => {

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -44,7 +44,7 @@ const fixedWidth = str => {
   const strs = str.match(new RegExp(`(.{1,${WIDTH}})`, 'g'));
   let lastString = strs[strs.length - 1];
   if (lastString.length < WIDTH) {
-    lastString += Array(WIDTH - lastString.length).join(chalk.gray('.'));
+    lastString += Array(WIDTH - lastString.length).join(chalk.dim('.'));
   }
   return strs.slice(0, -1).concat(lastString).join('\n');
 };
@@ -72,7 +72,7 @@ function buildFile(file, silent) {
   spawnSync('mkdir', ['-p', path.dirname(destPath)]);
   if (minimatch(file, IGNORE_PATTERN)) {
     silent || process.stdout.write(
-      chalk.gray('  \u2022 ') +
+      chalk.dim('  \u2022 ') +
       path.relative(PACKAGES_DIR, file) +
       ' (ignore)\n'
     );


### PR DESCRIPTION
some terminal color schemes (solarized) have the same color for `background` and `bright black` (that is  used in `chalk.gray`) which makes the output invisible.
`chalk.dim` however works just fine and produces almost the same result.