### PR TITLE
Added message to coverage reporter.

### DIFF
--- a/packages/jest-cli/src/reporters/CoverageReporter.js
+++ b/packages/jest-cli/src/reporters/CoverageReporter.js
@@ -29,6 +29,7 @@ const generateEmptyCoverage = require('../generateEmptyCoverage');
 const istanbulCoverage = require('istanbul-lib-coverage');
 
 const FAIL_COLOR = chalk.bold.red;
+const RUNNING_TEST_COLOR = chalk.bold.gray;
 
 class CoverageReporter extends BaseReporter {
   _coverageMap: CoverageMap;
@@ -74,6 +75,9 @@ class CoverageReporter extends BaseReporter {
 
   _addUntestedFiles(config: Config, runnerContext: RunnerContext) {
     if (config.collectCoverageFrom && config.collectCoverageFrom.length) {
+      this.log(RUNNING_TEST_COLOR(
+        'Running coverage for untested files...',
+      ));
       const files = runnerContext.hasteFS.matchFilesWithGlob(
         config.collectCoverageFrom,
         config.rootDir,

--- a/packages/jest-cli/src/reporters/DefaultReporter.js
+++ b/packages/jest-cli/src/reporters/DefaultReporter.js
@@ -65,7 +65,7 @@ class DefaultReporter extends BaseReporter {
       results.numFailedTestSuites -
       results.numRuntimeErrorTestSuites;
     if (process.stdout.isTTY && remaining > 0) {
-      process.stderr.write(RUNNING_TEST_COLOR(
+      this.log(RUNNING_TEST_COLOR(
         `Running ${pluralize('test suite', remaining)}...`,
       ));
     }


### PR DESCRIPTION
When I'm running coverage with the `collectCoverageFrom` option enabled it may take a while for Jest to finish the execution because it will go through all the files in the directory that have not been tested.

This PR aims to add a message similar to `Running ${number} test suites` to the coverage so that you know something in going on and the CLI is not stuck.

![screen shot 2016-08-25 at 3 08 32 pm](https://cloud.githubusercontent.com/assets/1207250/17992811/5a18638c-6aff-11e6-9a8c-13c9238c07fe.png)

Also, I've changed the DefaultReporter to use `this.log` instead of `process.stderr.write`.