### PR TITLE
File name in comment chnaged

### DIFF
--- a/docs/TutorialReact.md
+++ b/docs/TutorialReact.md
@@ -74,7 +74,7 @@ Snapshot testing was introduced in Jest 14.0. More information on how it works a
 Let's build a Link component in React that renders hyperlinks:
 
 ```javascript
-// Link.react-test.js
+// Link.react.js
 import React from 'react';
 
 const STATUS = {


### PR DESCRIPTION
This would confuse the reader as both code blocks show same file name.
As the test file calls the correct file name but the name is wrong in react component file name, it results in confusion.