### PR TITLE
Make failures more obvious with the new printing.

### DIFF
--- a/packages/jest-util/src/__tests__/__snapshots__/formatFailureMessage-test.js.snap
+++ b/packages/jest-util/src/__tests__/__snapshots__/formatFailureMessage-test.js.snap
@@ -1,5 +1,5 @@
 exports[`formatFailureMessage should exclude jasmine from stack trace for windows paths 1`] = `
-"  [1m● [22mwindows test
+"[1m[31m  [1m● [1mwindows test[39m[22m
 
       at stack (..\\jest-jasmine2\\vendor\\jasmine-2.4.1.js:1580:17)
 [2m      

--- a/packages/jest-util/src/formatFailureMessage.js
+++ b/packages/jest-util/src/formatFailureMessage.js
@@ -169,10 +169,12 @@ const formatResultsErrors = (
       .map(line => MESSAGE_INDENT + line)
       .join('\n');
 
-    const title = TITLE_INDENT + TITLE_BULLET +
+    const title = chalk.bold.red(
+      TITLE_INDENT + TITLE_BULLET +
       result.ancestorTitles.join(ANCESTRY_SEPARATOR) +
       (result.ancestorTitles.length ? ANCESTRY_SEPARATOR : '') +
-      result.title + '\n';
+      result.title,
+    ) + '\n';
 
     return title + '\n' + message + '\n' + stack;
   }).join('\n');


### PR DESCRIPTION
This makes the line with the error red and bold. The new printing style is less intrusive so it is easy to miss errors. This should make it clear *which* test is failing.