### PR TITLE
Simplify watcher message

### DIFF
--- a/packages/jest-cli/src/SearchSource.js
+++ b/packages/jest-cli/src/SearchSource.js
@@ -218,16 +218,14 @@ class SearchSource {
     data: SearchResult,
   ): string {
     if (patternInfo.onlyChanged) {
-      const guide = patternInfo.watch
-        ? 'with `jest --watchAll` or press `a` to switch to `--watchAll`'
-        : 'without `-o`';
       return (
         chalk.bold(
           'No tests found related to changed and uncommitted files.\n',
         ) +
         chalk.dim(
-          ' When dynamically calling `require` or no tests ' +
-          'related to changed files can be found, run Jest ' + guide + '.',
+          patternInfo.watch ?
+            'Press `a` to run all tests, or run Jest with `--watchAll`.' :
+            'Run Jest without `-o` to run all tests.'
         )
       );
     }


### PR DESCRIPTION
Before:

<img width="1085" alt="screen shot 2016-08-31 at 17 52 05" src="https://cloud.githubusercontent.com/assets/810438/18138586/601ad206-6fa5-11e6-9276-b8a299196ed6.png">

After:

<img width="770" alt="screen shot 2016-08-31 at 18 00 46" src="https://cloud.githubusercontent.com/assets/810438/18138592/64bee9e6-6fa5-11e6-9967-904bd2c1d459.png">

<img width="755" alt="screen shot 2016-08-31 at 18 03 07" src="https://cloud.githubusercontent.com/assets/810438/18138597/6a973bc0-6fa5-11e6-9ffe-f085bec53f70.png">

I’m not sure the message about dynamic `require`s is very valuable here. We could leave it in `-o` documentation.