### PR TITLE
Cache Symbol

### DIFF
--- a/packages/jest-matchers/src/matchers.js
+++ b/packages/jest-matchers/src/matchers.js
@@ -27,7 +27,7 @@ const {
 } = require('jest-matcher-utils');
 
 const equals = global.jasmine.matchersUtil.equals;
-const Symbol = global.Symbol;
+const _Symbol = global.Symbol;
 
 const printWithType = (name, received, print) => {
   const type = getType(received);
@@ -40,7 +40,7 @@ const printWithType = (name, received, print) => {
   );
 };
 
-const hasIterator = object => !!(object != null && object[Symbol.iterator]);
+const hasIterator = object => !!(object != null && object[_Symbol.iterator]);
 const iterableEquality = (a, b) => {
   if (
     typeof a !== 'object' ||
@@ -55,7 +55,7 @@ const iterableEquality = (a, b) => {
   if (a.constructor !== b.constructor) {
     return false;
   }
-  const bIterator = b[Symbol.iterator]();
+  const bIterator = b[_Symbol.iterator]();
 
   for (const aValue of a) {
     const nextB = bIterator.next();

--- a/packages/jest-matchers/src/matchers.js
+++ b/packages/jest-matchers/src/matchers.js
@@ -27,7 +27,7 @@ const {
 } = require('jest-matcher-utils');
 
 const equals = global.jasmine.matchersUtil.equals;
-const _Symbol = Symbol;
+const Symbol = global.Symbol;
 
 const printWithType = (name, received, print) => {
   const type = getType(received);
@@ -40,7 +40,7 @@ const printWithType = (name, received, print) => {
   );
 };
 
-const hasIterator = object => !!(object != null && object[_Symbol.iterator]);
+const hasIterator = object => !!(object != null && object[Symbol.iterator]);
 const iterableEquality = (a, b) => {
   if (
     typeof a !== 'object' ||
@@ -55,7 +55,7 @@ const iterableEquality = (a, b) => {
   if (a.constructor !== b.constructor) {
     return false;
   }
-  const bIterator = b[_Symbol.iterator]();
+  const bIterator = b[Symbol.iterator]();
 
   for (const aValue of a) {
     const nextB = bIterator.next();

--- a/packages/jest-matchers/src/matchers.js
+++ b/packages/jest-matchers/src/matchers.js
@@ -27,6 +27,7 @@ const {
 } = require('jest-matcher-utils');
 
 const equals = global.jasmine.matchersUtil.equals;
+const _Symbol = Symbol;
 
 const printWithType = (name, received, print) => {
   const type = getType(received);
@@ -39,7 +40,7 @@ const printWithType = (name, received, print) => {
   );
 };
 
-const hasIterator = object => !!(object != null && object[Symbol.iterator]);
+const hasIterator = object => !!(object != null && object[_Symbol.iterator]);
 const iterableEquality = (a, b) => {
   if (
     typeof a !== 'object' ||
@@ -54,7 +55,7 @@ const iterableEquality = (a, b) => {
   if (a.constructor !== b.constructor) {
     return false;
   }
-  const bIterator = b[Symbol.iterator]();
+  const bIterator = b[_Symbol.iterator]();
 
   for (const aValue of a) {
     const nextB = bIterator.next();


### PR DESCRIPTION
In React, we have a test that deletes the global Symbol variable and it breaks Jest 15 (whereas Jest 12 is fine): https://github.com/facebook/react/blob/master/src/isomorphic/classic/element/__tests__/ReactElement-test.js#L25-L28

Caching the Symbol object so that it doesn't read from the global one fixes it.