### PR TITLE
Fix --bail config option bug

### DIFF
--- a/packages/jest-cli/src/TestRunner.js
+++ b/packages/jest-cli/src/TestRunner.js
@@ -283,7 +283,7 @@ class TestRunner {
   }
 
   _bailIfNeeded(aggregatedResults: AggregatedResult) {
-    if (this._config.bail) {
+    if (this._config.bail && aggregatedResults.numFailedTests !== 0) {
       this._dispatcher.onRunComplete(this._config, aggregatedResults);
       process.exit(1);
     }


### PR DESCRIPTION
I upgraded our suite of tests at Pinterest to use jest-cli@14.1.0 and the --bail config option made Jenkins sad. It appears that when the TestRunner was refactored the bail option no longer looked at the numFailedTests. This fixed our issues locally.