### PR TITLE
Expand toThrowError, alias toThrow to toThrowError.

### DIFF
--- a/packages/jest-haste-map/package.json
+++ b/packages/jest-haste-map/package.json
@@ -10,12 +10,10 @@
   "dependencies": {
     "fb-watchman": "^1.9.0",
     "graceful-fs": "^4.1.6",
+    "multimatch": "^2.1.0",
     "worker-farm": "^1.3.1"
   },
   "scripts": {
     "test": "../../packages/jest-cli/bin/jest.js"
-  },
-  "devDependencies": {
-    "multimatch": "^2.1.0"
   }
 }

--- a/packages/jest-matcher-utils/src/index.js
+++ b/packages/jest-matcher-utils/src/index.js
@@ -99,6 +99,21 @@ const stringify = (obj: any): string => {
 const printReceived = (object: any) => RECEIVED_COLOR(stringify(object));
 const printExpected = (value: any) => EXPECTED_COLOR(stringify(value));
 
+const printWithType = (
+  name: string,
+  received: string,
+  print: (value: string) => string,
+) => {
+  const type = getType(received);
+  return (
+    name + ':' +
+    (type !== 'null' && type !== 'undefined'
+      ? '\n  ' + type + ': '
+      : ' ') +
+    print(received)
+  );
+};
+
 const ensureNoExpected = (expected: any, matcherName: string) => {
   matcherName || (matcherName = 'This');
   if (typeof expected !== 'undefined') {
@@ -156,5 +171,6 @@ module.exports = {
   pluralize,
   printExpected,
   printReceived,
+  printWithType,
   stringify,
 };

--- a/packages/jest-matchers/src/__tests__/__snapshots__/toThrowMatchers-test.js.snap
+++ b/packages/jest-matchers/src/__tests__/__snapshots__/toThrowMatchers-test.js.snap
@@ -1,3 +1,96 @@
+exports[`.toThrow() error class did not throw at all 1`] = `
+"[2mexpect([22m[31mfunction[39m[2m).toThrow([22m[32mtype[39m[2m)[22m
+
+Expected the function to throw an error of type:
+  [32m\"Err\"[39m
+But it didn\'t throw anything."
+`;
+
+exports[`.toThrow() error class threw, but class did not match 1`] = `
+"[2mexpect([22m[31mfunction[39m[2m).toThrow([22m[32mtype[39m[2m)[22m
+
+Expected the function to throw an error of type:
+  [32m\"Err2\"[39m
+Instead, it threw:
+[31m  apple      
+      [2mat Err ([22mpackages/jest-matchers/src/__tests__/toThrowMatchers-test.js[2m:19:5)[22m[39m"
+`;
+
+exports[`.toThrow() error class threw, but should not have 1`] = `
+"[2mexpect([22m[31mfunction[39m[2m).not.toThrow([22m[32mtype[39m[2m)[22m
+
+Expected the function not to throw an error of type:
+  [32m\"Err\"[39m
+Instead, it threw:
+[31m  apple      
+      [2mat Err ([22mpackages/jest-matchers/src/__tests__/toThrowMatchers-test.js[2m:19:5)[22m[39m"
+`;
+
+exports[`.toThrow() invalid arguments 1`] = `
+"[2mexpect([22m[31mfunction[39m[2m).not.toThrow([22m[32mnumber[39m[2m)[22m
+
+Unexpected argument passed.
+Expected: [32m\"string\"[39m, [32m\"Error (type)\"[39m or [32m\"regexp\"[39m.
+Got:
+  number: [32m111[39m"
+`;
+
+exports[`.toThrow() regexp did not throw at all 1`] = `
+"[2mexpect([22m[31mfunction[39m[2m).toThrow([22m[32mregexp[39m[2m)[22m
+
+Expected the function to throw an error matching:
+  [32m\"/apple/\"[39m
+But it didn\'t throw anything."
+`;
+
+exports[`.toThrow() regexp threw, but message did not match 1`] = `
+"[2mexpect([22m[31mfunction[39m[2m).toThrow([22m[32mregexp[39m[2m)[22m
+
+Expected the function to throw an error matching:
+  [32m\"/banana/\"[39m
+Instead, it threw:
+[31m  apple      
+      [2mat jestExpect ([22mpackages/jest-matchers/src/__tests__/toThrowMatchers-test.js[2m:72:35)[22m[39m"
+`;
+
+exports[`.toThrow() regexp threw, but should not have 1`] = `
+"[2mexpect([22m[31mfunction[39m[2m).not.toThrow([22m[32mregexp[39m[2m)[22m
+
+Expected the function not to throw an error matching:
+  [32m\"/apple/\"[39m
+Instead, it threw:
+[31m  apple      
+      [2mat jestExpect ([22mpackages/jest-matchers/src/__tests__/toThrowMatchers-test.js[2m:79:35)[22m[39m"
+`;
+
+exports[`.toThrow() strings did not throw at all 1`] = `
+"[2mexpect([22m[31mfunction[39m[2m).toThrow([22m[32mstring[39m[2m)[22m
+
+Expected the function to throw an error matching:
+  [32m\"apple\"[39m
+But it didn\'t throw anything."
+`;
+
+exports[`.toThrow() strings threw, but message did not match 1`] = `
+"[2mexpect([22m[31mfunction[39m[2m).toThrow([22m[32mstring[39m[2m)[22m
+
+Expected the function to throw an error matching:
+  [32m\"banana\"[39m
+Instead, it threw:
+[31m  apple      
+      [2mat jestExpect ([22mpackages/jest-matchers/src/__tests__/toThrowMatchers-test.js[2m:41:33)[22m[39m"
+`;
+
+exports[`.toThrow() strings threw, but should not have 1`] = `
+"[2mexpect([22m[31mfunction[39m[2m).not.toThrow([22m[32mstring[39m[2m)[22m
+
+Expected the function not to throw an error matching:
+  [32m\"apple\"[39m
+Instead, it threw:
+[31m  apple      
+      [2mat jestExpect ([22mpackages/jest-matchers/src/__tests__/toThrowMatchers-test.js[2m:53:35)[22m[39m"
+`;
+
 exports[`.toThrowError() error class did not throw at all 1`] = `
 "[2mexpect([22m[31mfunction[39m[2m).toThrowError([22m[32mtype[39m[2m)[22m
 
@@ -12,23 +105,27 @@ exports[`.toThrowError() error class threw, but class did not match 1`] = `
 Expected the function to throw an error of type:
   [32m\"Err2\"[39m
 Instead, it threw:
-  [31m\"Err: apple\"[39m"
+[31m  apple      
+      [2mat Err ([22mpackages/jest-matchers/src/__tests__/toThrowMatchers-test.js[2m:19:5)[22m[39m"
 `;
 
 exports[`.toThrowError() error class threw, but should not have 1`] = `
 "[2mexpect([22m[31mfunction[39m[2m).not.toThrowError([22m[32mtype[39m[2m)[22m
 
-Expeced the function not to throw an error of type:
+Expected the function not to throw an error of type:
   [32m\"Err\"[39m
-But it threw:
-  [31m\"Err: apple\"[39m"
+Instead, it threw:
+[31m  apple      
+      [2mat Err ([22mpackages/jest-matchers/src/__tests__/toThrowMatchers-test.js[2m:19:5)[22m[39m"
 `;
 
 exports[`.toThrowError() invalid arguments 1`] = `
-"Unexpected argument passed. Expected to get
-  [32m\"\\\"string\\\"\"[39m, [32m\"\\\"Error type\\\"\"[39m or [32m\"\\\"regexp\\\"\"[39m.
-Got: 
-  [31m\"number\"[39m: [31m111[39m."
+"[2mexpect([22m[31mfunction[39m[2m).not.toThrowError([22m[32mnumber[39m[2m)[22m
+
+Unexpected argument passed.
+Expected: [32m\"string\"[39m, [32m\"Error (type)\"[39m or [32m\"regexp\"[39m.
+Got:
+  number: [32m111[39m"
 `;
 
 exports[`.toThrowError() regexp did not throw at all 1`] = `
@@ -45,16 +142,18 @@ exports[`.toThrowError() regexp threw, but message did not match 1`] = `
 Expected the function to throw an error matching:
   [32m\"/banana/\"[39m
 Instead, it threw:
-  [31m\"Error: apple\"[39m"
+[31m  apple      
+      [2mat jestExpect ([22mpackages/jest-matchers/src/__tests__/toThrowMatchers-test.js[2m:72:35)[22m[39m"
 `;
 
 exports[`.toThrowError() regexp threw, but should not have 1`] = `
 "[2mexpect([22m[31mfunction[39m[2m).not.toThrowError([22m[32mregexp[39m[2m)[22m
 
-Expeced the function not to throw an error matching:
+Expected the function not to throw an error matching:
   [32m\"/apple/\"[39m
-But it threw:
-  [31m\"Error: apple\"[39m"
+Instead, it threw:
+[31m  apple      
+      [2mat jestExpect ([22mpackages/jest-matchers/src/__tests__/toThrowMatchers-test.js[2m:79:35)[22m[39m"
 `;
 
 exports[`.toThrowError() strings did not throw at all 1`] = `
@@ -71,14 +170,16 @@ exports[`.toThrowError() strings threw, but message did not match 1`] = `
 Expected the function to throw an error matching:
   [32m\"banana\"[39m
 Instead, it threw:
-  [31m\"Error: apple\"[39m"
+[31m  apple      
+      [2mat jestExpect ([22mpackages/jest-matchers/src/__tests__/toThrowMatchers-test.js[2m:41:33)[22m[39m"
 `;
 
 exports[`.toThrowError() strings threw, but should not have 1`] = `
 "[2mexpect([22m[31mfunction[39m[2m).not.toThrowError([22m[32mstring[39m[2m)[22m
 
-Expeced the function not to throw an error matching:
+Expected the function not to throw an error matching:
   [32m\"apple\"[39m
-But it threw:
-  [31m\"Error: apple\"[39m"
+Instead, it threw:
+[31m  apple      
+      [2mat jestExpect ([22mpackages/jest-matchers/src/__tests__/toThrowMatchers-test.js[2m:53:35)[22m[39m"
 `;

--- a/packages/jest-matchers/src/__tests__/toThrowMatchers-test.js
+++ b/packages/jest-matchers/src/__tests__/toThrowMatchers-test.js
@@ -13,102 +13,116 @@
 const jestExpect = require('../').expect;
 const matchErrorSnapshot = require('./_matchErrorSnapshot');
 
-describe('.toThrowError()', () => {
-  test('invalid arguments', () => {
-    expect(() => {
-      jestExpect(() => {}).not.toThrowError();
-    }).toThrow();
+['toThrowError', 'toThrow'].forEach(toThrow => {
+  describe('.' + toThrow + '()', () => {
 
-    expect(() => {
-      jestExpect(() => {}).not.toThrowError([]);
-    }).toThrow();
-  });
-
-  describe('strings', () => {
-    it('passes', () => {
-      jestExpect(() => { throw new Error('apple'); }).toThrowError('apple');
-      jestExpect(() => { throw new Error('banana'); })
-        .not.toThrowError('apple');
-      jestExpect(() => {}).not.toThrowError('apple');
-    });
-
-    test('did not throw at all', () => {
-      matchErrorSnapshot(() => jestExpect(() => {}).toThrowError('apple'));
-    });
-
-    test('threw, but message did not match', () => {
-      matchErrorSnapshot(() =>
-        jestExpect(() => { throw new Error('apple'); }).toThrowError('banana'),
-      );
-    });
-
-    it('properly escapes strings when matching against errors', () => {
-      jestExpect(() => { throw new TypeError('"this"? throws.'); })
-        .toThrowError('"this"? throws.');
-    });
-
-    test('threw, but should not have', () => {
-      matchErrorSnapshot(() => {
-        jestExpect(() => { throw new Error('apple'); })
-          .not.toThrowError('apple');
-      });
-    });
-  });
-
-  describe('regexp', () => {
-    it('passes', () => {
-      expect(() => { throw new Error('apple'); }).toThrowError(/apple/);
-      expect(() => { throw new Error('banana'); }).not.toThrowError(/apple/);
-      expect(() => {}).not.toThrowError(/apple/);
-    });
-
-    test('did not throw at all', () => {
-      matchErrorSnapshot(() => jestExpect(() => {}).toThrowError(/apple/));
-    });
-
-    test('threw, but message did not match', () => {
-      matchErrorSnapshot(() => {
-        jestExpect(() => { throw new Error('apple'); }).toThrowError(/banana/);
-      });
-    });
-
-    test('threw, but should not have', () => {
-      matchErrorSnapshot(() => {
-        jestExpect(() => { throw new Error('apple'); })
-          .not.toThrowError(/apple/);
-      });
-    });
-  });
-
-  describe('error class', () => {
     class Err extends Error {}
     class Err2 extends Error {}
 
-    it('passes', () => {
-      jestExpect(() => { throw new Err(); }).toThrowError(Err);
-      jestExpect(() => { throw new Err(); }).toThrowError(Error);
-      jestExpect(() => { throw new Err(); }).not.toThrowError(Err2);
-      jestExpect(() => {}).not.toThrowError(Err);
+    test('to throw or not to throw', () => {
+      jestExpect(() => { throw new Error('apple'); })[toThrow]();
+      jestExpect(() => {}).not[toThrow]();
     });
 
-    test('did not throw at all', () => {
-      matchErrorSnapshot(() => expect(() => {}).toThrowError(Err));
-    });
+    describe('strings', () => {
+      it('passes', () => {
+        jestExpect(() => { throw new Error('apple'); })[toThrow]('apple');
+        jestExpect(() => { throw new Error('banana'); })
+          .not[toThrow]('apple');
+        jestExpect(() => {}).not[toThrow]('apple');
+      });
 
-    test('threw, but class did not match', () => {
-      matchErrorSnapshot(() => {
-        jestExpect(() => { throw new Err('apple'); }).toThrowError(Err2);
+      test('did not throw at all', () => {
+        matchErrorSnapshot(() => jestExpect(() => {})[toThrow]('apple'));
+      });
+
+      test('threw, but message did not match', () => {
+        matchErrorSnapshot(() =>
+          jestExpect(() => { throw new Error('apple'); })
+            [toThrow]('banana'),
+        );
+      });
+
+      it('properly escapes strings when matching against errors', () => {
+        jestExpect(() => { throw new TypeError('"this"? throws.'); })
+          [toThrow]('"this"? throws.');
+      });
+
+      test('threw, but should not have', () => {
+        matchErrorSnapshot(() => {
+          jestExpect(() => { throw new Error('apple'); })
+            .not[toThrow]('apple');
+        });
       });
     });
 
-    test('threw, but should not have', () => {
-      matchErrorSnapshot(() => {
-        jestExpect(() => { throw new Err('apple'); }).not.toThrowError(Err);
+    describe('regexp', () => {
+      it('passes', () => {
+        expect(() => { throw new Error('apple'); })[toThrow](/apple/);
+        expect(() => { throw new Error('banana'); }).not[toThrow](/apple/);
+        expect(() => {}).not[toThrow](/apple/);
       });
+
+      test('did not throw at all', () => {
+        matchErrorSnapshot(() => jestExpect(() => {})[toThrow](/apple/));
+      });
+
+      test('threw, but message did not match', () => {
+        matchErrorSnapshot(() => {
+          jestExpect(() => { throw new Error('apple'); })
+            [toThrow](/banana/);
+        });
+      });
+
+      test('threw, but should not have', () => {
+        matchErrorSnapshot(() => {
+          jestExpect(() => { throw new Error('apple'); })
+            .not[toThrow](/apple/);
+        });
+      });
+    });
+
+    describe('errors', () => {
+      it('works', () => {
+        it('passes', () => {
+          jestExpect(() => { throw new Err(); })[toThrow](new Err());
+          jestExpect(() => { throw new Err('Message'); })
+            [toThrow](new Err('Message'));
+          jestExpect(() => { throw new Err(); })[toThrow](new Error());
+          jestExpect(() => { throw new Err(); }).not[toThrow](new Err2());
+          jestExpect(() => {}).not[toThrow](new Err());
+        });
+      });
+    });
+
+    describe('error class', () => {
+      it('passes', () => {
+        jestExpect(() => { throw new Err(); })[toThrow](Err);
+        jestExpect(() => { throw new Err(); })[toThrow](Error);
+        jestExpect(() => { throw new Err(); }).not[toThrow](Err2);
+        jestExpect(() => {}).not[toThrow](Err);
+      });
+
+      test('did not throw at all', () => {
+        matchErrorSnapshot(() => expect(() => {})[toThrow](Err));
+      });
+
+      test('threw, but class did not match', () => {
+        matchErrorSnapshot(() => {
+          jestExpect(() => { throw new Err('apple'); })[toThrow](Err2);
+        });
+      });
+
+      test('threw, but should not have', () => {
+        matchErrorSnapshot(() => {
+          jestExpect(() => { throw new Err('apple'); }).not[toThrow](Err);
+        });
+      });
+    });
+
+    test('invalid arguments', () => {
+      matchErrorSnapshot(() => jestExpect(() => {})[toThrow](111));
     });
   });
 
-  test('invalid arguments', () => {
-    matchErrorSnapshot(() => jestExpect(() => {}).toThrowError(111));
-  });
 });

--- a/packages/jest-matchers/src/matchers.js
+++ b/packages/jest-matchers/src/matchers.js
@@ -24,21 +24,11 @@ const {
   matcherHint,
   printReceived,
   printExpected,
+  printWithType,
 } = require('jest-matcher-utils');
 
 const IteratorSymbol = Symbol.iterator;
 const equals = global.jasmine.matchersUtil.equals;
-
-const printWithType = (name, received, print) => {
-  const type = getType(received);
-  return (
-    name + ':' +
-    (type !== 'null' && type !== 'undefined'
-      ? '\n  ' + type + ': '
-      : ' ') +
-    print(received)
-  );
-};
 
 const hasIterator = object => !!(object != null && object[IteratorSymbol]);
 const iterableEquality = (a, b) => {

--- a/packages/jest-util/src/__tests__/__snapshots__/FakeTimers-test.js.snap
+++ b/packages/jest-util/src/__tests__/__snapshots__/FakeTimers-test.js.snap
@@ -4,5 +4,5 @@ exports[`FakeTimers runAllTimers warns when trying to advance timers while real 
 Release Blog Post: https://facebook.github.io/jest/blog/2016/09/01/jest-15.html
 Stack Trace:
       Error
-      [2mat FakeTimers._checkFakeTimers ([22m[0m[34m../FakeTimers.js[39m[0m[2m:347:43)[22m"
+      [2mat FakeTimers._checkFakeTimers ([22m../FakeTimers.js[2m:347:43)[22m"
 `;

--- a/packages/jest-util/src/__tests__/__snapshots__/messages-test.js.snap
+++ b/packages/jest-util/src/__tests__/__snapshots__/messages-test.js.snap
@@ -3,7 +3,7 @@ exports[`test should exclude jasmine from stack trace for windows paths 1`] = `
 
       at stack (..\\jest-jasmine2\\vendor\\jasmine-2.4.1.js:1580:17)
 [2m      
-      [2mat Object.addResult ([2m[0m[34m..\\jest-jasmine2\\vendor\\jasmine-2.4.1.js[39m[0m[2m:1550:14)[2m
-      [2mat Object.it ([2m[0m[34mbuild\\__tests__\\messages-test.js[39m[0m[2m:45:41)[2m[22m
+      [2mat Object.addResult ([2m..\\jest-jasmine2\\vendor\\jasmine-2.4.1.js[2m:1550:14)[2m
+      [2mat Object.it ([2mbuild\\__tests__\\messages-test.js[2m:45:41)[2m[22m
 "
 `;

--- a/packages/jest-util/src/messages.js
+++ b/packages/jest-util/src/messages.js
@@ -118,7 +118,7 @@ const formatPaths = (config, relativeTestPath, line) => {
   let filePath = matches[2];
   filePath = path.relative(config.rootDir, filePath);
 
-  if (new RegExp(config.testRegex).test(filePath)) {
+  if (config.testRegex && new RegExp(config.testRegex).test(filePath)) {
     filePath = chalk.reset.blue(filePath);
   } else if (filePath === relativeTestPath) {
     // highlight paths from the current test file


### PR DESCRIPTION
It really doesn't make sense that toThrow and toThrowError are doing something different. This now merges both of them into the same matcher: one that does *everything*. I believe this is the best user experience.

cc @gaearon @dmitriiabramov 

Fixes #1544 