### PR TITLE
Fix stack trace printing in node 4.

### DIFF
--- a/jest
+++ b/jest
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+/**
+ * Copyright (c) 2014, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+require('./packages/jest-cli/bin/jest');

--- a/packages/jest-matchers/src/__tests__/__snapshots__/toThrowMatchers-test.js.snap
+++ b/packages/jest-matchers/src/__tests__/__snapshots__/toThrowMatchers-test.js.snap
@@ -12,8 +12,8 @@ exports[`.toThrow() error class threw, but class did not match 1`] = `
 Expected the function to throw an error of type:
   [32m\"Err2\"[39m
 Instead, it threw:
-[31m  apple      
-      [2mat Err ([22mpackages/jest-matchers/src/__tests__/toThrowMatchers-test.js[2m:19:5)[22m[39m"
+[31m  Error      
+      [2mat jestExpect ([22mpackages/jest-matchers/src/__tests__/toThrowMatchers-test.js[2m:24:74)[22m[39m"
 `;
 
 exports[`.toThrow() error class threw, but should not have 1`] = `
@@ -22,8 +22,8 @@ exports[`.toThrow() error class threw, but should not have 1`] = `
 Expected the function not to throw an error of type:
   [32m\"Err\"[39m
 Instead, it threw:
-[31m  apple      
-      [2mat Err ([22mpackages/jest-matchers/src/__tests__/toThrowMatchers-test.js[2m:19:5)[22m[39m"
+[31m  Error      
+      [2mat jestExpect ([22mpackages/jest-matchers/src/__tests__/toThrowMatchers-test.js[2m:24:74)[22m[39m"
 `;
 
 exports[`.toThrow() invalid arguments 1`] = `
@@ -49,8 +49,8 @@ exports[`.toThrow() regexp threw, but message did not match 1`] = `
 Expected the function to throw an error matching:
   [32m\"/banana/\"[39m
 Instead, it threw:
-[31m  apple      
-      [2mat jestExpect ([22mpackages/jest-matchers/src/__tests__/toThrowMatchers-test.js[2m:72:35)[22m[39m"
+[31m  Error      
+      [2mat jestExpect ([22mpackages/jest-matchers/src/__tests__/toThrowMatchers-test.js[2m:24:74)[22m[39m"
 `;
 
 exports[`.toThrow() regexp threw, but should not have 1`] = `
@@ -59,8 +59,8 @@ exports[`.toThrow() regexp threw, but should not have 1`] = `
 Expected the function not to throw an error matching:
   [32m\"/apple/\"[39m
 Instead, it threw:
-[31m  apple      
-      [2mat jestExpect ([22mpackages/jest-matchers/src/__tests__/toThrowMatchers-test.js[2m:79:35)[22m[39m"
+[31m  Error      
+      [2mat jestExpect ([22mpackages/jest-matchers/src/__tests__/toThrowMatchers-test.js[2m:24:74)[22m[39m"
 `;
 
 exports[`.toThrow() strings did not throw at all 1`] = `
@@ -77,8 +77,8 @@ exports[`.toThrow() strings threw, but message did not match 1`] = `
 Expected the function to throw an error matching:
   [32m\"banana\"[39m
 Instead, it threw:
-[31m  apple      
-      [2mat jestExpect ([22mpackages/jest-matchers/src/__tests__/toThrowMatchers-test.js[2m:41:33)[22m[39m"
+[31m  Error      
+      [2mat jestExpect ([22mpackages/jest-matchers/src/__tests__/toThrowMatchers-test.js[2m:24:74)[22m[39m"
 `;
 
 exports[`.toThrow() strings threw, but should not have 1`] = `
@@ -87,8 +87,8 @@ exports[`.toThrow() strings threw, but should not have 1`] = `
 Expected the function not to throw an error matching:
   [32m\"apple\"[39m
 Instead, it threw:
-[31m  apple      
-      [2mat jestExpect ([22mpackages/jest-matchers/src/__tests__/toThrowMatchers-test.js[2m:53:35)[22m[39m"
+[31m  Error      
+      [2mat jestExpect ([22mpackages/jest-matchers/src/__tests__/toThrowMatchers-test.js[2m:24:74)[22m[39m"
 `;
 
 exports[`.toThrowError() error class did not throw at all 1`] = `
@@ -105,8 +105,8 @@ exports[`.toThrowError() error class threw, but class did not match 1`] = `
 Expected the function to throw an error of type:
   [32m\"Err2\"[39m
 Instead, it threw:
-[31m  apple      
-      [2mat Err ([22mpackages/jest-matchers/src/__tests__/toThrowMatchers-test.js[2m:19:5)[22m[39m"
+[31m  Error      
+      [2mat jestExpect ([22mpackages/jest-matchers/src/__tests__/toThrowMatchers-test.js[2m:24:74)[22m[39m"
 `;
 
 exports[`.toThrowError() error class threw, but should not have 1`] = `
@@ -115,8 +115,8 @@ exports[`.toThrowError() error class threw, but should not have 1`] = `
 Expected the function not to throw an error of type:
   [32m\"Err\"[39m
 Instead, it threw:
-[31m  apple      
-      [2mat Err ([22mpackages/jest-matchers/src/__tests__/toThrowMatchers-test.js[2m:19:5)[22m[39m"
+[31m  Error      
+      [2mat jestExpect ([22mpackages/jest-matchers/src/__tests__/toThrowMatchers-test.js[2m:24:74)[22m[39m"
 `;
 
 exports[`.toThrowError() invalid arguments 1`] = `
@@ -142,8 +142,8 @@ exports[`.toThrowError() regexp threw, but message did not match 1`] = `
 Expected the function to throw an error matching:
   [32m\"/banana/\"[39m
 Instead, it threw:
-[31m  apple      
-      [2mat jestExpect ([22mpackages/jest-matchers/src/__tests__/toThrowMatchers-test.js[2m:72:35)[22m[39m"
+[31m  Error      
+      [2mat jestExpect ([22mpackages/jest-matchers/src/__tests__/toThrowMatchers-test.js[2m:24:74)[22m[39m"
 `;
 
 exports[`.toThrowError() regexp threw, but should not have 1`] = `
@@ -152,8 +152,8 @@ exports[`.toThrowError() regexp threw, but should not have 1`] = `
 Expected the function not to throw an error matching:
   [32m\"/apple/\"[39m
 Instead, it threw:
-[31m  apple      
-      [2mat jestExpect ([22mpackages/jest-matchers/src/__tests__/toThrowMatchers-test.js[2m:79:35)[22m[39m"
+[31m  Error      
+      [2mat jestExpect ([22mpackages/jest-matchers/src/__tests__/toThrowMatchers-test.js[2m:24:74)[22m[39m"
 `;
 
 exports[`.toThrowError() strings did not throw at all 1`] = `
@@ -170,8 +170,8 @@ exports[`.toThrowError() strings threw, but message did not match 1`] = `
 Expected the function to throw an error matching:
   [32m\"banana\"[39m
 Instead, it threw:
-[31m  apple      
-      [2mat jestExpect ([22mpackages/jest-matchers/src/__tests__/toThrowMatchers-test.js[2m:41:33)[22m[39m"
+[31m  Error      
+      [2mat jestExpect ([22mpackages/jest-matchers/src/__tests__/toThrowMatchers-test.js[2m:24:74)[22m[39m"
 `;
 
 exports[`.toThrowError() strings threw, but should not have 1`] = `
@@ -180,6 +180,6 @@ exports[`.toThrowError() strings threw, but should not have 1`] = `
 Expected the function not to throw an error matching:
   [32m\"apple\"[39m
 Instead, it threw:
-[31m  apple      
-      [2mat jestExpect ([22mpackages/jest-matchers/src/__tests__/toThrowMatchers-test.js[2m:53:35)[22m[39m"
+[31m  Error      
+      [2mat jestExpect ([22mpackages/jest-matchers/src/__tests__/toThrowMatchers-test.js[2m:24:74)[22m[39m"
 `;

--- a/packages/jest-matchers/src/__tests__/toThrowMatchers-test.js
+++ b/packages/jest-matchers/src/__tests__/toThrowMatchers-test.js
@@ -13,6 +13,18 @@
 const jestExpect = require('../').expect;
 const matchErrorSnapshot = require('./_matchErrorSnapshot');
 
+// Custom Error class because node versions have different stack trace strings.
+class Error {
+  constructor(message) {
+    this.message = message;
+    this.name = 'Error';
+    this.stack =
+      'Error\n' +
+      '  at jestExpect' +
+      ' (packages/jest-matchers/src/__tests__/toThrowMatchers-test.js:24:74)';
+  }
+}
+
 ['toThrowError', 'toThrow'].forEach(toThrow => {
   describe('.' + toThrow + '()', () => {
 

--- a/packages/jest-util/src/messages.js
+++ b/packages/jest-util/src/messages.js
@@ -107,17 +107,12 @@ const removeInternalStackEntries = (lines, config) => {
 
 const formatPaths = (config, relativeTestPath, line) => {
   // Extract the file path from the trace line.
-  let matches = line.match(/(^\s*at .*?\()([^()]+)(:[0-9]+:[0-9]+\).*$)/);
-  if (!matches) {
-    matches = line.match(/(^\s+at )([^()]+)(:[0-9]+:[0-9]+.*$)/);
-    if (!matches) {
-      return line;
-    }
+  const match = line.match(/(^\s*at .*?\(?)([^()]+)(:[0-9]+:[0-9]+\)?.*$)/);
+  if (!match) {
+    return line;
   }
 
-  let filePath = matches[2];
-  filePath = path.relative(config.rootDir, filePath);
-
+  let filePath = path.relative(config.rootDir, match[2]);
   if (config.testRegex && new RegExp(config.testRegex).test(filePath)) {
     filePath = chalk.reset.blue(filePath);
   } else if (filePath === relativeTestPath) {
@@ -125,8 +120,7 @@ const formatPaths = (config, relativeTestPath, line) => {
     filePath = chalk.reset.cyan(filePath);
   }
   // make paths relative to the <rootDir>
-  return STACK_TRACE_COLOR(matches[1])
-    + filePath + STACK_TRACE_COLOR(matches[3]);
+  return STACK_TRACE_COLOR(match[1]) + filePath + STACK_TRACE_COLOR(match[3]);
 };
 
 const formatStackTrace = (stack, config: Config, testPath: ?Path) => {


### PR DESCRIPTION
Fixes the failing snapshot test on node 4. Through the snapshot test I learned that stack traces on node 4 and node 6 can be different; the node 6 ones have more information.

This made me realize the node 4 stack trace matching was actually broken and that the two regexes we had could easily be rolled into a single one. Finally, to make the test pass, I created a custom Error class to make sure that the stack trace is definitely the same on all node versions.