### PR TITLE
Windows CLI improvements

### DIFF
--- a/packages/jest-cli/src/jest.js
+++ b/packages/jest-cli/src/jest.js
@@ -38,7 +38,7 @@ const WATCHER_DEBOUNCE = 200;
 const WATCHMAN_BIN = 'watchman';
 const KEYS = {
   A: '61',
-  BACKSPACE: '7f',
+  BACKSPACE: process.platform === 'win32' ? '08' : '7f',
   CONTROL_C: '03',
   CONTROL_D: '04',
   ENTER: '0d',

--- a/packages/jest-cli/src/jest.js
+++ b/packages/jest-cli/src/jest.js
@@ -32,7 +32,7 @@ const readConfig = require('jest-config').readConfig;
 const sane = require('sane');
 const which = require('which');
 
-const CLEAR = '\x1B[2J\x1B[H';
+const CLEAR = '\x1bc';
 const VERSION = require('../package.json').version;
 const WATCHER_DEBOUNCE = 200;
 const WATCHMAN_BIN = 'watchman';

--- a/packages/jest-cli/src/reporters/VerboseReporter.js
+++ b/packages/jest-cli/src/reporters/VerboseReporter.js
@@ -19,6 +19,7 @@ import type {
 
 const DefaultReporter = require('./DefaultReporter');
 const chalk = require('chalk');
+const isWindows = process.platform === 'win32';
 
 class VerboseReporter extends DefaultReporter {
   static groupTestsBySuites(testResults: Array<AssertionResult>) {
@@ -74,11 +75,11 @@ class VerboseReporter extends DefaultReporter {
 
   _getIcon(status: string) {
     if (status === 'failed') {
-      return chalk.red('\u2715');
+      return chalk.red(isWindows ? '\u00D7' : '\u2715');
     } else if (status === 'pending') {
       return chalk.yellow('\u25CB');
     } else {
-      return chalk.green('\u2713');
+      return chalk.green(isWindows ? '\u221A' : '\u2713');
     }
   }
 

--- a/packages/jest-util/src/clearLine.js
+++ b/packages/jest-util/src/clearLine.js
@@ -12,6 +12,6 @@
 
 module.exports = (stream: stream$Writable) => {
   if (process.stdout.isTTY) {
-    stream.write('\r\x1B[K');
+    stream.write('\x1b[999D\x1b[K');
   }
 };


### PR DESCRIPTION
## Using a more solid clear sequence

Unlike the one used today, it clears the whole console on Windows (as opposed to a part of the screen). We have been using the same sequence as I propose here for a month in Create React App, and it works well on all platforms.

The only downside is that it erases the scroll history on Windows. IMO it’s a tolerable downside and less annoying than misaligned output interleaved with older commands.

## Adding Windows fallbacks for ✓ and ✕

Inspired by https://github.com/mochajs/mocha/pull/641.
The pending circle didn’t need updating, it worked fine on Windows.

## Clearing line more aggressively for Windows

This prevents run-on “Determining tests to run“ and “Running N tests...” on Windows.
All changes tested on OS X too.

## Detect Backspace on Windows when matching pattern

Fixes #1555.