### PR TITLE
change toString of process copy

### DIFF
--- a/integration_tests/__tests__/globals-test.js
+++ b/integration_tests/__tests__/globals-test.js
@@ -11,7 +11,9 @@
 
 describe('Common globals', () => {
   it('check process', () => {
-    expect(Object.prototype.toString.call(global.process))
-      .toBe('[object process]');
+    if (Symbol && Symbol.toStringTag) {
+      expect(Object.prototype.toString.call(global.process))
+        .toBe('[object process]');
+    }
   });
 });

--- a/integration_tests/__tests__/globals-test.js
+++ b/integration_tests/__tests__/globals-test.js
@@ -12,6 +12,6 @@
 describe('Common globals', () => {
   it('check process', () => {
     expect(Object.prototype.toString.call(global.process))
-    .toBe('[object process]');
+      .toBe('[object process]');
   });
 });

--- a/packages/jest-util/src/__tests__/globals-test.js
+++ b/packages/jest-util/src/__tests__/globals-test.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails oncall+jsinfra
+ */
+'use strict';
+
+describe('Common globals', () => {
+  it('check process', () => {
+    expect(Object.prototype.toString.call(global.process))
+    .toBe('[object process]');
+  });
+});

--- a/packages/jest-util/src/installCommonGlobals.js
+++ b/packages/jest-util/src/installCommonGlobals.js
@@ -31,7 +31,12 @@ module.exports = (global: Global, globals: ConfigGlobals) => {
 
   // `global.process` is mutated by FakeTimers. Make a copy of the
   // object for the jsdom environment to prevent memory leaks.
-  global.process = Object.assign({}, process);
+  // Symbol toStringTag is added to improve detection by
+  // Libraries (bluebird checks for this)
+  // $FlowFixMe Flow has problems with Symbols as computed
+  global.process = Object.assign({}, process, {
+    [Symbol.toStringTag]: 'process',
+  });
   global.process.setMaxListeners = process.setMaxListeners.bind(process);
   global.process.getMaxListeners = process.getMaxListeners.bind(process);
   global.process.emit = process.emit.bind(process);

--- a/packages/jest-util/src/installCommonGlobals.js
+++ b/packages/jest-util/src/installCommonGlobals.js
@@ -31,9 +31,8 @@ module.exports = (global: Global, globals: ConfigGlobals) => {
 
   // `global.process` is mutated by FakeTimers. Make a copy of the
   // object for the jsdom environment to prevent memory leaks.
-  // Symbol toStringTag is added to improve detection by
-  // Libraries (bluebird checks for this)
-  // $FlowFixMe Flow has problems with Symbols as computed
+  // Overwrite toString to make it look like the real process object
+  // $FlowFixMe
   global.process = Object.assign({}, process, {
     [Symbol.toStringTag]: 'process',
   });

--- a/packages/jest-util/src/installCommonGlobals.js
+++ b/packages/jest-util/src/installCommonGlobals.js
@@ -1,12 +1,12 @@
 /**
- * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
- *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
- *
- * @flow
- */
+* Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+*
+* This source code is licensed under the BSD-style license found in the
+* LICENSE file in the root directory of this source tree. An additional grant
+* of patent rights can be found in the PATENTS file in the same directory.
+*
+* @flow
+*/
 'use strict';
 
 import type {ConfigGlobals} from 'types/Config';
@@ -32,10 +32,14 @@ module.exports = (global: Global, globals: ConfigGlobals) => {
   // `global.process` is mutated by FakeTimers. Make a copy of the
   // object for the jsdom environment to prevent memory leaks.
   // Overwrite toString to make it look like the real process object
-  // $FlowFixMe
-  global.process = Object.assign({}, process, {
-    [Symbol.toStringTag]: 'process',
-  });
+  let toStringOverwrite;
+  if (Symbol && Symbol.toStringTag) {
+    // $FlowFixMe
+    toStringOverwrite = {
+      [Symbol.toStringTag]: 'process',
+    };
+  }
+  global.process = Object.assign({}, process, toStringOverwrite);
   global.process.setMaxListeners = process.setMaxListeners.bind(process);
   global.process.getMaxListeners = process.getMaxListeners.bind(process);
   global.process.emit = process.emit.bind(process);


### PR DESCRIPTION
This improves compat with some libraries like bluebird.
They seem to check for the toString result of process.