### PR TITLE
jest-runtime always disables automocking by default.

### DIFF
--- a/integration_tests/__tests__/config-test.js
+++ b/integration_tests/__tests__/config-test.js
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails oncall+jsinfra
+ */
+'use strict';
+
+const runJest = require('../runJest');
+
+test('config as JSON', () => {
+  const result = runJest('verbose_reporter', [
+    '--config=' + JSON.stringify({
+      testRegex: 'banana strawbery kiwi',
+      testEnvironment: 'node',
+    }),
+  ]);
+  const stdout = result.stdout.toString();
+
+  expect(result.status).toBe(0);
+  expect(stdout).toMatch('No tests found');
+});
+
+test('works with sane config JSON', () => {
+  const result = runJest('verbose_reporter', [
+    '--config=' + JSON.stringify({
+      testEnvironment: 'node',
+    }),
+  ]);
+  const stderr = result.stderr.toString();
+
+  expect(result.status).toBe(1);
+  expect(stderr).toMatch('works just fine');
+});

--- a/packages/jest-cli/src/__tests__/SearchSource-test.js
+++ b/packages/jest-cli/src/__tests__/SearchSource-test.js
@@ -211,11 +211,13 @@ describe('SearchSource', () => {
 
     it('finds tests that depend directly on the path', () => {
       const filePath = path.join(rootDir, 'RegularModule.js');
+      const loggingDep = path.join(rootDir, 'logging.js');
       const parentDep = path.join(rootDir, 'ModuleWithSideEffects.js');
       const data = searchSource.findRelatedTests(new Set([filePath]));
       expect(data.paths.sort()).toEqual([
         parentDep,
         filePath,
+        loggingDep,
         rootPath,
       ]);
     });

--- a/packages/jest-cli/src/cli/index.js
+++ b/packages/jest-cli/src/cli/index.js
@@ -26,17 +26,6 @@ function run(argv?: Object, root?: Path) {
     .check(args.check)
     .argv;
 
-  const {config} = argv;
-  // If the passed in value looks like JSON, treat it as an object.
-  if (
-    config &&
-    typeof config === 'string' &&
-    config[0] === '{' &&
-    config[config.length - 1] === '}'
-  ) {
-    argv.config = JSON.parse(config);
-  }
-
   warnAboutUnrecognizedOptions(argv, args.options);
 
   if (argv.help) {

--- a/packages/jest-runtime/src/__tests__/Runtime-cli-test.js
+++ b/packages/jest-runtime/src/__tests__/Runtime-cli-test.js
@@ -14,37 +14,42 @@ const path = require('path');
 
 const JEST_RUNTIME = path.resolve(__dirname, '../../bin/jest-runtime.js');
 
+const run = args => spawnSync(JEST_RUNTIME, args, {
+  encoding: 'utf8',
+  cwd: process.cwd(),
+  env: process.env,
+});
+
 describe('Runtime', () => {
   describe('cli', () => {
     it('fails with no path', () => {
       const expectedOutput =
-        'Please provide a path to a script. (See --help for details)';
-      const output = spawnSync(JEST_RUNTIME, [], {
-        encoding: 'utf8',
-        cwd: process.cwd(),
-        env: process.env,
-      });
-      expect(output.stdout.trim()).toBe(expectedOutput);
+        'Please provide a path to a script. (See --help for details)\n';
+      expect(run([]).stdout).toBe(expectedOutput);
     });
 
     it('displays script output', () => {
       const scriptPath = path.resolve(__dirname, './test_root/logging.js');
-      const output = spawnSync(JEST_RUNTIME, [scriptPath, '--no-cache'], {
-        encoding: 'utf8',
-        cwd: process.cwd(),
-        env: process.env,
-      });
-      expect(output.stdout.trim()).toMatch('Hello, world!');
+      expect(run([scriptPath, '--no-cache']).stdout).toMatch('Hello, world!\n');
+    });
+
+    it('always disables automocking', () => {
+      const scriptPath = path.resolve(__dirname, './test_root/logging.js');
+      const output = run([
+        scriptPath,
+        '--no-cache',
+        '--config=' + JSON.stringify({
+          automock: true,
+        }),
+      ]);
+      expect(output.stdout).toMatch('Hello, world!\n');
     });
 
     it('throws script errors', () => {
       const scriptPath = path.resolve(__dirname, './test_root/throwing.js');
-      const output = spawnSync(JEST_RUNTIME, [scriptPath, '--no-cache'], {
-        encoding: 'utf8',
-        cwd: process.cwd(),
-        env: process.env,
-      });
-      expect(output.stderr.trim()).toMatch('Error: throwing');
+      expect(
+        run([scriptPath, '--no-cache']).stderr,
+      ).toMatch('Error: throwing\n');
     });
   });
 });

--- a/packages/jest-runtime/src/__tests__/test_root/logging.js
+++ b/packages/jest-runtime/src/__tests__/test_root/logging.js
@@ -8,4 +8,8 @@
 
 'use strict';
 
-console.log('Hello, world!');
+if (require('RegularModule').getModuleStateValue()) {
+  console.log('Hello, world!');
+} else {
+  console.log('Automocking is not properly disabled in jest-runtime.');
+}

--- a/packages/jest-runtime/src/cli/index.js
+++ b/packages/jest-runtime/src/cli/index.js
@@ -63,6 +63,11 @@ function run(cliArgv?: Object, cliInfo?: Array<string>) {
   }
   readConfig(argv, root)
     .then(config => {
+      // Always disable automocking in scripts.
+      config = Object.assign({}, config, {
+        automock: false,
+        unmockedModulePathPatterns: null,
+      });
       Runtime.createHasteContext(config, {
         maxWorkers: os.cpus().length - 1,
       })

--- a/types/Config.js
+++ b/types/Config.js
@@ -55,7 +55,6 @@ export type Config = BaseConfig & {
   cache: boolean,
   collectCoverageFrom: Array<Glob>,
   collectCoverageOnlyFrom: {[key: string]: Path},
-  colors: boolean,
   collectCoverage: boolean,
   coverageDirectory: string,
   coverageThreshold: {


### PR DESCRIPTION
This seems like a reasonable default. Also made it so runtime can accept a JSON config.

cc @kyldvs 