### PR TITLE
Fixed error/typo

### DIFF
--- a/docs/TutorialReact.md
+++ b/docs/TutorialReact.md
@@ -116,13 +116,13 @@ it('changes the class when hovered', () => {
   expect(tree).toMatchSnapshot();
 
   // manually trigger the callback
-  tree.props.onMouseEnter();
+  component.props.onMouseEnter();
   // re-rendering
   tree = component.toJSON();
   expect(tree).toMatchSnapshot();
 
   // manually trigger the callback
-  tree.props.onMouseLeave();
+  component.props.onMouseLeave();
   // re-rendering
   tree = component.toJSON();
   expect(tree).toMatchSnapshot();


### PR DESCRIPTION
tree.props will error as it holds the JSON, not the object