### PR TITLE
Split internal module registry from main module registry

### DIFF
--- a/integration_tests/__tests__/runtime-internal-module-registry-test.js
+++ b/integration_tests/__tests__/runtime-internal-module-registry-test.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails oncall+jsinfra
+ */
+'use strict';
+
+const runJest = require('../runJest');
+
+describe('Runtime Internal Module Registry', () => {
+  // Previously, if Jest required a module (e.g. requiring `mkdirp` from `jest-util`)
+  // and the project *using* Jest also required that module, Jest wouldn't
+  // re-require it and thus ignored any mocks that the module may have used.
+  //
+  // This test verifies that that behavior doesn't happen anymore, and correctly
+  // uses two module registries: an internal registry that's used specificly by
+  // Jest to require any internal modules used when setting up the test environment,
+  // and a "normal" module registry that's used by the actual test code (and can safely
+  // be cleared after every test)
+  it('correctly makes use of internal module registry when requiring modules used both in Jest and in a project', () => {
+    const {json} = runJest.json('runtime-internal-module-registry', []);
+
+    expect(json.numTotalTests).toBe(1);
+    expect(json.numPassedTests).toBe(1);
+  });
+});

--- a/integration_tests/__tests__/runtime-internal-module-registry-test.js
+++ b/integration_tests/__tests__/runtime-internal-module-registry-test.js
@@ -12,19 +12,22 @@
 const runJest = require('../runJest');
 
 describe('Runtime Internal Module Registry', () => {
-  // Previously, if Jest required a module (e.g. requiring `mkdirp` from `jest-util`)
-  // and the project *using* Jest also required that module, Jest wouldn't
-  // re-require it and thus ignored any mocks that the module may have used.
+  // Previously, if Jest required a module (e.g. requiring `mkdirp` from
+  // `jest-util`) and the project *using* Jest also required that module, Jest
+  // wouldn't re-require it and thus ignored any mocks that the module may have
+  // used.
   //
   // This test verifies that that behavior doesn't happen anymore, and correctly
   // uses two module registries: an internal registry that's used specificly by
-  // Jest to require any internal modules used when setting up the test environment,
-  // and a "normal" module registry that's used by the actual test code (and can safely
-  // be cleared after every test)
-  it('correctly makes use of internal module registry when requiring modules used both in Jest and in a project', () => {
-    const {json} = runJest.json('runtime-internal-module-registry', []);
+  // Jest to require any internal modules used when setting up the test
+  // environment, and a "normal" module registry that's used by the actual test
+  // code (and can safely be cleared after every test)
+  it('correctly makes use of internal module registry when requiring modules',
+    () => {
+      const {json} = runJest.json('runtime-internal-module-registry', []);
 
-    expect(json.numTotalTests).toBe(1);
-    expect(json.numPassedTests).toBe(1);
-  });
+      expect(json.numTotalTests).toBe(1);
+      expect(json.numPassedTests).toBe(1);
+    }
+  );
 });

--- a/integration_tests/runtime-internal-module-registry/__mocks__/fs.js
+++ b/integration_tests/runtime-internal-module-registry/__mocks__/fs.js
@@ -20,6 +20,6 @@ function mkdirSync() {
 fs.mkdirSync = mkdirSync;
 fs.__wasMkdirCalled = function() {
   return mkdirWasCalled;
-}
+};
 
 module.exports = fs;

--- a/integration_tests/runtime-internal-module-registry/__mocks__/fs.js
+++ b/integration_tests/runtime-internal-module-registry/__mocks__/fs.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+const fs = jest.genMockFromModule('fs');
+
+let mkdirWasCalled = false;
+
+function mkdirSync() {
+  mkdirWasCalled = true;
+  return;
+}
+
+fs.mkdirSync = mkdirSync;
+fs.__wasMkdirCalled = function() {
+  return mkdirWasCalled;
+}
+
+module.exports = fs;

--- a/integration_tests/runtime-internal-module-registry/__tests__/runtime-internal-module-registry-test.js
+++ b/integration_tests/runtime-internal-module-registry/__tests__/runtime-internal-module-registry-test.js
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+jest.mock('fs');
+
+describe('Runtime internal module registry', () => {
+  it('behaves correctly when requiring a module that is used by jest internals', () => {
+    const fs = require('fs');
+
+    // We require from this crazy path so that we can mimick Jest (and it's
+    // transitive deps) being installed along side a projects deps (e.g. with an
+    // NPM3 flat dep tree)
+    const jestUtil = require('../../../packages/jest-util');
+
+    // If FS is mocked correctly, this folder won't actually be created on the
+    // filesystem
+    jestUtil.createDirectory('./dont-create-this-folder');
+
+    expect(fs.__wasMkdirCalled()).toBe(true);
+  });
+});

--- a/integration_tests/runtime-internal-module-registry/package.json
+++ b/integration_tests/runtime-internal-module-registry/package.json
@@ -1,0 +1,5 @@
+{
+  "jest": {
+    "testEnvironment": "node"
+  }
+}


### PR DESCRIPTION
Here's a possible fix for #1571.

When the `mkdirp` module is first required, it's required from `jest-utils`, which is required from [jasmine-check.js](https://github.com/facebook/jest/blob/0504590c40a7621fc68468c6aec0d6eed9c08edb/packages/jest-jasmine2/src/jasmine-check.js), which is required using `requireInternalModule` from [jest-jasmine2/index.js](https://github.com/facebook/jest/blob/0504590c40a7621fc68468c6aec0d6eed9c08edb/packages/jest-jasmine2/src/index.js). Because requiring internal modules and requiring "normal" modules (e.g. in a test or within your own code) use the same module registry, when `mkdirp` is required by the app code, Jest already has required it (as an internal module), and thus it doesn't try to require it again and just returns it from the module registry, meaning it doesn't pick up the `fs` mock from our test file.

This PR splits the module registries so that conflict doesn't happen, and we can reliably use internal modules within Jest without conflicting with the test environment.

P.S. Sorry for being annoying earlier @cpojer...this is my attempt at redemption.