### PR TITLE
Clear console like we did before

### DIFF
--- a/packages/jest-cli/src/jest.js
+++ b/packages/jest-cli/src/jest.js
@@ -33,7 +33,7 @@ const readConfig = require('jest-config').readConfig;
 const sane = require('sane');
 const which = require('which');
 
-const CLEAR = '\x1bc';
+const CLEAR = '\x1B[2J\x1B[H';
 const VERSION = require('../package.json').version;
 const WATCHER_DEBOUNCE = 200;
 const WATCHMAN_BIN = 'watchman';


### PR DESCRIPTION
I made this change in #1556 to make console clear work better on Windows. However I now discovered this has a significant downside on OS X: now if you first have a bunch of errors, scroll down, and then a successful run, scrolling up brings a confusing mixed view:

<img width="623" alt="screen shot 2016-09-03 at 10 59 38" src="https://cloud.githubusercontent.com/assets/810438/18224238/f0093a42-71c6-11e6-82da-9525b2596dc6.png">

This change just reverts my tweak and makes it the way it has been before, with clear boundaries between the test runs in the scroll history:

<img width="707" alt="screen shot 2016-09-03 at 11 10 33" src="https://cloud.githubusercontent.com/assets/810438/18224242/1aacf6d0-71c7-11e6-8099-1834b4e1611a.png">


