### PR TITLE
Add AppVeyor Jasmine reporter

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "graceful-fs": "^4.1.6",
     "istanbul-api": "^1.0.0-aplha.10",
     "istanbul-lib-coverage": "^1.0.0",
+    "jasmine-reporters": "^2.2.0",
     "lerna": "2.0.0-beta.26",
     "minimatch": "^3.0.3",
     "mkdirp": "^0.5.1",

--- a/testSetupFile.js
+++ b/testSetupFile.js
@@ -7,6 +7,13 @@
  */
 'use strict';
 
+const jasmineReporters = require('jasmine-reporters');
+
 // Some of the `jest-runtime` tests are very slow and cause
 // timeouts on travis
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 70000;
+
+if (process.env.APPVEYOR_API_URL) {
+  // Running on AppVeyor, add the custom reporter.
+  jasmine.getEnv().addReporter(new jasmineReporters.AppVeyorReporter());
+}


### PR DESCRIPTION
Uses the AppVeyor Jasmine reporter from the `jasmine-reporters` project to report test details to AppVeyor.

Example: https://ci.appveyor.com/project/Daniel15/jest-71o27/build/3/tests (this is building my fork of Jest)

Before: "Tests" tab is empty
![](http://ss.dan.cx/2016/09/chrome_03-12.02.43.png)

After: "Tests" tab is populated
![](http://ss.dan.cx/2016/09/chrome_03-12.01.33.png)

Failing tests show the output when clicked:
![](http://ss.dan.cx/2016/09/chrome_03-12.01.48.png)