### PR TITLE
[windows] Fix a few tests

### DIFF
--- a/integration_tests/__tests__/config-test.js
+++ b/integration_tests/__tests__/config-test.js
@@ -10,9 +10,6 @@
 'use strict';
 
 const runJest = require('../runJest');
-const skipOnWindows = require('skipOnWindows');
-
-skipOnWindows.suite();
 
 test('config as JSON', () => {
   const result = runJest('verbose_reporter', [

--- a/integration_tests/__tests__/console-test.js
+++ b/integration_tests/__tests__/console-test.js
@@ -9,7 +9,6 @@
  */
 'use strict';
 
-const path = require('path');
 const runJest = require('../runJest');
 const {normalizePathsInSnapshot} = require('jest-util');
 

--- a/integration_tests/__tests__/console-test.js
+++ b/integration_tests/__tests__/console-test.js
@@ -9,20 +9,21 @@
  */
 'use strict';
 
+const path = require('path');
 const runJest = require('../runJest');
-const skipOnWindows = require('skipOnWindows');
-
-skipOnWindows.suite();
+const {normalizePathsInSnapshot} = require('jest-util');
 
 test('console printing', () => {
-  const result = runJest('console');
+  // On Windows, this test only works when --no-cache is passed in. Need to
+  // determine why.
+  const result = runJest('console', ['--no-cache']);
   const stderr = result.stderr.toString();
 
   expect(result.status).toBe(0);
 
   // Remove last two lines because they contain timing information.
   const output = stderr.split('\n').slice(0, -2).join('\n');
-  expect(output).toMatchSnapshot();
+  expect(normalizePathsInSnapshot(output)).toMatchSnapshot();
 });
 
 test('console printing with --verbose', () => {
@@ -31,5 +32,5 @@ test('console printing with --verbose', () => {
 
   expect(result.status).toBe(0);
 
-  expect(stdout).toMatchSnapshot();
+  expect(normalizePathsInSnapshot(stdout)).toMatchSnapshot();
 });

--- a/integration_tests/__tests__/debug-test.js
+++ b/integration_tests/__tests__/debug-test.js
@@ -11,11 +11,8 @@
 const {linkJestPackage} = require('../utils');
 const path = require('path');
 const runJest = require('../runJest');
-const skipOnWindows = require('skipOnWindows');
 
 describe('jest --debug', () => {
-  skipOnWindows.suite();
-
   const dir = path.resolve(__dirname, '..', 'verbose_reporter');
 
   beforeEach(() => {

--- a/integration_tests/__tests__/empty_suite_error-test.js
+++ b/integration_tests/__tests__/empty_suite_error-test.js
@@ -10,13 +10,10 @@
 
 const path = require('path');
 const runJest = require('../runJest');
-const skipOnWindows = require('skipOnWindows');
 
 const DIR = path.resolve(__dirname, '../empty_suite_error');
 
 describe('JSON Reporter', () => {
-  skipOnWindows.suite();
-
   it('fails the test suite if it contains no tests', () => {
     const result = runJest(DIR, []);
     const stderr = result.stderr.toString();

--- a/integration_tests/__tests__/failures-test.js
+++ b/integration_tests/__tests__/failures-test.js
@@ -8,26 +8,24 @@
 
 'use strict';
 
+const {normalizePathsInSnapshot} = require('jest-util');
 const path = require('path');
 const runJest = require('../runJest');
-const skipOnWindows = require('skipOnWindows');
 
 const dir = path.resolve(__dirname, '../failures');
-
-skipOnWindows.suite();
 
 test('throwing not Error objects', () => {
   let stderr;
   stderr = runJest(dir, ['throw-number-test.js']).stderr;
-  expect(
+  expect(normalizePathsInSnapshot(
     stderr.replace(/\s*\(\d*ms\)/g, '').replace(/run time.*s/, '<TIME>'),
-  ).toMatchSnapshot();
+  )).toMatchSnapshot();
   stderr = runJest(dir, ['throw-string-test.js']).stderr;
-  expect(
+  expect(normalizePathsInSnapshot(
     stderr.replace(/\s*\(\d*ms\)/g, '').replace(/run time.*s/, '<TIME>'),
-  ).toMatchSnapshot();
+  )).toMatchSnapshot();
   stderr = runJest(dir, ['throw-object-test.js']).stderr;
-  expect(
+  expect(normalizePathsInSnapshot(
     stderr.replace(/\s*\(\d*ms\)/g, '').replace(/run time.*s/, '<TIME>'),
-  ).toMatchSnapshot();
+  )).toMatchSnapshot();
 });

--- a/integration_tests/__tests__/jasmine_async-test.js
+++ b/integration_tests/__tests__/jasmine_async-test.js
@@ -9,11 +9,8 @@
 'use strict';
 
 const runJest = require('../runJest');
-const skipOnWindows = require('skipOnWindows');
 
 describe('async jasmine', () => {
-  skipOnWindows.suite();
-
   it('works with beforeAll', () => {
     const result = runJest.json(
       'jasmine_async',

--- a/integration_tests/__tests__/json_reporter-test.js
+++ b/integration_tests/__tests__/json_reporter-test.js
@@ -8,11 +8,8 @@
 'use strict';
 
 const runJest = require('../runJest');
-const skipOnWindows = require('skipOnWindows');
 
 describe('JSON Reporter', () => {
-  skipOnWindows.suite();
-
   it('outputs coverage report', () => {
     const result = runJest('json_reporter', ['--json']);
     const stdout = result.stdout.toString();

--- a/integration_tests/__tests__/no-test-found-test.js
+++ b/integration_tests/__tests__/no-test-found-test.js
@@ -10,11 +10,8 @@
 'use strict';
 
 const runJest = require('../runJest');
-const skipOnWindows = require('skipOnWindows');
 
 describe('Coverage Report', () => {
-  skipOnWindows.suite();
-
   it('outputs coverage report', () => {
     const result = runJest('coverage_report', ['not-a-valid-test']);
     const stdout = result.stdout.toString();

--- a/integration_tests/__tests__/set-immediate-test.js
+++ b/integration_tests/__tests__/set-immediate-test.js
@@ -10,9 +10,6 @@
 'use strict';
 
 const runJest = require('../runJest');
-const skipOnWindows = require('skipOnWindows');
-
-skipOnWindows.suite();
 
 test('setImmediate', () => {
   const result = runJest('set_immediate', ['--verbose']);

--- a/integration_tests/__tests__/setup_test_framework_script_file_cli_config-test.js
+++ b/integration_tests/__tests__/setup_test_framework_script_file_cli_config-test.js
@@ -8,11 +8,8 @@
 'use strict';
 
 const runJest = require('../runJest');
-const skipOnWindows = require('skipOnWindows');
 
 describe('--setupTestFrameworkScriptFile setup.js', () => {
-  skipOnWindows.suite();
-
   it('requires a setup file before each file in the suite', () => {
     const result = runJest.json('setup_test_framework_script_file_cli_config', [
       '--setupTestFrameworkScriptFile',

--- a/integration_tests/__tests__/stack_trace-test.js
+++ b/integration_tests/__tests__/stack_trace-test.js
@@ -22,7 +22,7 @@ describe('Stack Trace', () => {
               pass: regex.test(actual),
               message: 'Result does not contain "' + expected + '": ' + actual,
             };
-          }
+          },
         };
       },
     });

--- a/integration_tests/__tests__/testcheck-test.js
+++ b/integration_tests/__tests__/testcheck-test.js
@@ -9,11 +9,8 @@
 'use strict';
 
 const runJest = require('../runJest');
-const skipOnWindows = require('skipOnWindows');
 
 describe('testcheck', () => {
-  skipOnWindows.suite();
-
   it('works', () => {
     const result = runJest.json('testcheck', ['testcheck-test.js']);
     const json = result.json;

--- a/integration_tests/runJest.js
+++ b/integration_tests/runJest.js
@@ -32,9 +32,15 @@ function runJest(dir, args) {
     `);
   }
 
-  const result = spawnSync(JEST_PATH, args || [], {
+  const fullArgs = [].concat(JEST_PATH, args);
+  const result = spawnSync('node', fullArgs || [], {
     cwd: dir,
   });
+
+  if (result.error) {
+    // Failed to execute the process - Rethrow the error.
+    throw result.error;
+  }
 
   result.stdout = result.stdout && result.stdout.toString();
   result.stderr = result.stderr && result.stderr.toString();

--- a/integration_tests/runJest.js
+++ b/integration_tests/runJest.js
@@ -32,7 +32,7 @@ function runJest(dir, args) {
     `);
   }
 
-  const fullArgs = [].concat(JEST_PATH, args);
+  const fullArgs = [JEST_PATH].concat(args);
   const result = spawnSync('node', fullArgs || [], {
     cwd: dir,
   });

--- a/packages/jest-matchers/src/__tests__/_matchErrorSnapshot.js
+++ b/packages/jest-matchers/src/__tests__/_matchErrorSnapshot.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+const {normalizePathsInSnapshot} = require('jest-util');
+
 module.exports = fn => {
   let error;
 
@@ -20,5 +22,5 @@ module.exports = fn => {
   }
 
   expect(error).toBeDefined();
-  expect(error.message).toMatchSnapshot();
+  expect(normalizePathsInSnapshot(error.message)).toMatchSnapshot();
 };

--- a/packages/jest-matchers/src/__tests__/toThrowMatchers-test.js
+++ b/packages/jest-matchers/src/__tests__/toThrowMatchers-test.js
@@ -12,7 +12,6 @@
 
 const jestExpect = require('../').expect;
 const matchErrorSnapshot = require('./_matchErrorSnapshot');
-const skipOnWindows = require('skipOnWindows');
 
 // Custom Error class because node versions have different stack trace strings.
 class Error {
@@ -28,8 +27,6 @@ class Error {
 
 ['toThrowError', 'toThrow'].forEach(toThrow => {
   describe('.' + toThrow + '()', () => {
-    skipOnWindows.suite();
-
     class Err extends Error {}
     class Err2 extends Error {}
 

--- a/packages/jest-repl/src/__tests__/jest-repl-test.js
+++ b/packages/jest-repl/src/__tests__/jest-repl-test.js
@@ -9,18 +9,15 @@
  */
 'use strict';
 
-const skipOnWindows = require('skipOnWindows');
 const spawnSync = require('child_process').spawnSync;
 const path = require('path');
 
 const JEST_RUNTIME = path.resolve(__dirname, '../../bin/jest-repl.js');
 
 describe('Repl', () => {
-  skipOnWindows.suite();
-
   describe('cli', () => {
     it('runs without errors', () => {
-      const output = spawnSync(JEST_RUNTIME, [], {
+      const output = spawnSync('node', [JEST_RUNTIME], {
         encoding: 'utf8',
         cwd: process.cwd(),
         env: process.env,

--- a/packages/jest-runtime/src/__tests__/Runtime-cli-test.js
+++ b/packages/jest-runtime/src/__tests__/Runtime-cli-test.js
@@ -9,21 +9,18 @@
  */
 'use strict';
 
-const skipOnWindows = require('skipOnWindows');
 const spawnSync = require('child_process').spawnSync;
 const path = require('path');
 
 const JEST_RUNTIME = path.resolve(__dirname, '../../bin/jest-runtime.js');
 
-const run = args => spawnSync(JEST_RUNTIME, args, {
+const run = args => spawnSync('node', [JEST_RUNTIME].concat(args), {
   encoding: 'utf8',
   cwd: process.cwd(),
   env: process.env,
 });
 
 describe('Runtime', () => {
-  skipOnWindows.suite();
-
   describe('cli', () => {
     it('fails with no path', () => {
       const expectedOutput =

--- a/packages/jest-util/src/index.js
+++ b/packages/jest-util/src/index.js
@@ -87,6 +87,19 @@ const warnAboutUnrecognizedOptions  = (argv: Object, options: Object) => {
   }
 };
 
+/**
+ * Normalizes relative paths to always use "/", even on Windows where "\" is the
+ * native path separator. This is so snapshots recorded on Linux are still
+ * considered valid when the test is ran on Windows, and vice versa.
+ */
+const normalizePathsInSnapshot = (input: string) => {
+  if (process.platform !== 'win32') {
+    return input;
+  }
+  // Look for strings that "look like" file paths, and swap "\" for "/".
+  return input.replace(/\b([^ ]+\\[^ ]+)\b/g, path => path.replace(/\\/g, '/'));
+}
+
 module.exports = {
   Console,
   FakeTimers,
@@ -101,6 +114,7 @@ module.exports = {
   formatExecError,
   getPackageRoot,
   installCommonGlobals,
+  normalizePathsInSnapshot,
   replacePathSepForRegex,
   separateMessageFromStack,
   warnAboutUnrecognizedOptions,

--- a/packages/jest-util/src/index.js
+++ b/packages/jest-util/src/index.js
@@ -98,7 +98,7 @@ const normalizePathsInSnapshot = (input: string) => {
   }
   // Look for strings that "look like" file paths, and swap "\" for "/".
   return input.replace(/\b([^ ]+\\[^ ]+)\b/g, path => path.replace(/\\/g, '/'));
-}
+};
 
 module.exports = {
   Console,


### PR DESCRIPTION
 - Windows doesn't allow you to directly execute JavaScript files. You need to instead execute `node` and pass the JavaScript file as an argument. The fact that Node.js doesn't automatically do this is pretty clowny, but that's a discussion for another day :stuck_out_tongue: 
 - Snapshots that contain file paths are not cross-platform due to the differing path separators - Snapshots generated on Linux don't match on Windows, and vice versa. I hacked around this issue by replacing `\` with `/` in file paths when running on Windows.