### PR TITLE
Fix peerinvalid npm error in react example

### DIFF
--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
-    "react": "~15.2.0",
-    "react-dom": "~15.2.0"
+    "react": "~15.3.1",
+    "react-dom": "~15.3.1"
   },
   "devDependencies": {
     "babel-jest": "*",
@@ -9,7 +9,7 @@
     "babel-preset-es2015": "*",
     "babel-preset-react": "*",
     "jest-cli": "*",
-    "react-addons-test-utils": "~0.14.0"
+    "react-addons-test-utils": "~15.3.1"
   },
   "scripts": {
     "test": "jest"


### PR DESCRIPTION
I came across this warning running the `jest` command in the terminal inside the examples/react dir with npm 3.10.6.

```
├── UNMET PEER DEPENDENCY react@15.2.1
└── react-addons-test-utils@0.14.8 
npm WARN react-addons-test-utils@0.14.8 requires a peer of react@^0.14.8 but none was installed.
```

npm 2.14.7 (less of a concern) throws npm ERR!:
```
npm ERR! peerinvalid The package react@15.2.1 does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer react-dom@15.2.1 wants react@^15.2.1
npm ERR! peerinvalid Peer react-addons-test-utils@0.14.8 wants react@^0.14.8
npm3:
```
Looks like these are all strict peer dependencies. I considered just bumping react-addons-test-utils to 15.2.1, but seen as bumping all three to the latest still ran the tests in both npm2 and npm3, I thought that'd be optimal.
