### PR TITLE
jest-mock: Correctly handle `export ... from ...` in babel-style ES2015 modules

### DIFF
--- a/packages/jest-mock/src/__tests__/jest-mock-test.js
+++ b/packages/jest-mock/src/__tests__/jest-mock-test.js
@@ -91,6 +91,22 @@ describe('moduleMocker', () => {
       expect(fooMock.nonEnumGetter).toBeUndefined();
     });
 
+    it('mocks getters of ES modules', () => {
+      const foo = Object.defineProperties({}, {
+        __esModule: {
+          value: true,
+        },
+        enumGetter: {
+          enumerable: true,
+          get: () => 10,
+        },
+      });
+      const fooMock = moduleMocker.generateFromMetadata(
+        moduleMocker.getMetadata(foo),
+      );
+      expect(fooMock.enumGetter).toBeDefined();
+    });
+
     it('mocks ES2015 non-enumerable methods', () => {
       class ClassFoo {
         foo() {}

--- a/packages/jest-mock/src/index.js
+++ b/packages/jest-mock/src/index.js
@@ -141,7 +141,7 @@ function getSlots(object?: Object): Array<string> {
       const prop = ownNames[i];
       if (!isReadonlyProp(object, prop)) {
         const propDesc = Object.getOwnPropertyDescriptor(object, prop);
-        if (!propDesc.get) {
+        if (!propDesc.get || object.__esModule) {
           slots[prop] = true;
         }
       }


### PR DESCRIPTION
The logic in `getSlots()` in `jest-mock` currently doesn't correctly handle the code generated by babel for `export { ... } from '...'` statements.

This code:
`export { Thing } from "./module-c";`

Generates:
```
"use strict";

Object.defineProperty(exports, "__esModule", {
  value: true
});

var _moduleC = require("./module-c");

Object.defineProperty(exports, "Thing", {
  enumerable: true,
  get: function get() {
    return _moduleC.Thing;
  }
});
```

But `getSlots()` ignores the `Thing` field because it ignores getters. This means that when generating an automatic mock for this module, trying to `import { Thing } from "module-that-uses-export-from"` will result in `Thing` being undefined. A reproduction of the issue is here: https://github.com/benweissmann/jest-issue-repro

This PR detects the `__esModule` field, and correctly handles the module. I've added a unit test to verify the new behavior, and confirmed that this fixes the test in https://github.com/benweissmann/jest-issue-repro

An alternative approach to the special-case i used here would be to include *enumerable* getters in `getSlots()`. However, when I modified the conditional in this PR to be `if (!propDesc.get || propDesc.enumerable)`, another test broke, so I think that's a riskier approach that more severly break backwards-compatiblity. You can see the full test output (https://gist.github.com/benweissmann/d2cedab28fb31fd6eb4a31c5b5e01474) or take a look at my other branch (https://github.com/benweissmann/jest/tree/enumerable-getters)