### PR TITLE
Remove other non-special characters from escapeStrForRegex

### DIFF
--- a/packages/jest-util/src/index.js
+++ b/packages/jest-util/src/index.js
@@ -37,7 +37,7 @@ const escapePathForRegex = (dir: string) => {
 };
 
 const escapeStrForRegex =
-  (string: string) => string.replace(/[[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
+  (string: string) => string.replace(/[[\]{}()*+?.\\^$|]/g, '\\$&');
 
 const replacePathSepForRegex = (string: string) => {
   if (path.sep === '\\') {


### PR DESCRIPTION
Whitespace, comma and hash/pound aren't special either

This should fix #1621