### PR TITLE
Env Spacing Fix

### DIFF
--- a/packages/jest-cli/src/cli/args.js
+++ b/packages/jest-cli/src/cli/args.js
@@ -154,7 +154,7 @@ const options = {
   env: {
     default: undefined,
     description:
-      'The test environment used for all tests. This can point to any file or' +
+      'The test environment used for all tests. This can point to any file or ' +
       'node module. Examples: `jsdom`, `node` or `path/to/my-environment.js`',
     type: 'string',
   },


### PR DESCRIPTION
Noticed a typo when I was trying to figure out how to grab my env variables for jest testing, went ahead and fixed it. CLA signed