### PR TITLE
Fix link to Plotly Academy Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Run `npm test`:
 PASS __tests__/sum-test.js
 ```
 
-Please read the [API documentation](https://facebook.github.io/jest/docs/api.html) to learn about all available assertions, ways of writing tests, configuration options and Jest specific APIs. There is also a great introductory guide available at [Plotly Academy](academy.plot.ly/react/6-testing) that walks you through testing a react and redux application.
+Please read the [API documentation](https://facebook.github.io/jest/docs/api.html) to learn about all available assertions, ways of writing tests, configuration options and Jest specific APIs. There is also a great introductory guide available at [Plotly Academy](http://academy.plot.ly/react/6-testing) that walks you through testing a react and redux application.
 
 The code for this example is available at [examples/getting_started](https://github.com/facebook/jest/tree/master/examples/getting_started).
 


### PR DESCRIPTION
Github seems to prepend the repository url when the link doesn't have a URL scheme.