### PR TITLE
Remove broken `debugging Jest tests` link from blog

### DIFF
--- a/blog/2016-06-22-jest-13.md
+++ b/blog/2016-06-22-jest-13.md
@@ -26,4 +26,4 @@ With the help of [lerna](https://github.com/lerna/lerna), we continued to modula
 * Added the duration of individual tests in verbose mode.
 * Added the ability to record snapshots in Jest. We'll be publishing a separate blog post about this feature soon.
 
-Finally, we have received a complete website redesign done by Matthew Johnston and added documentation for using [Jest with Webpack](http://facebook.github.io/jest/docs/tutorial-webpack.html#content) and added more information on [debugging Jest tests](http://facebook.github.io/jest/docs/getting-started.html#remote-debugging-with-web-inspector). Happy Jesting!
+Finally, we have received a complete website redesign done by Matthew Johnston and added documentation for using [Jest with Webpack](http://facebook.github.io/jest/docs/tutorial-webpack.html#content). Happy Jesting!


### PR DESCRIPTION
Getting started section Remote debugging with Web Inspector
was removed due outdated information in this commit

https://github.com/facebook/jest/commit/46868fcf1d6c5371ea093984c3896dbf391c034a