### PR TITLE
Fix eslint error

### DIFF
--- a/packages/jest-cli/src/cli/args.js
+++ b/packages/jest-cli/src/cli/args.js
@@ -154,8 +154,9 @@ const options = {
   env: {
     default: undefined,
     description:
-      'The test environment used for all tests. This can point to any file or ' +
-      'node module. Examples: `jsdom`, `node` or `path/to/my-environment.js`',
+      'The test environment used for all tests. This can point to any file ' +
+      'or node module. Examples: `jsdom`, `node` or ' +
+      '`path/to/my-environment.js`',
     type: 'string',
   },
   json: {


### PR DESCRIPTION
This fixes this eslint error:

```
[...]/jest/packages/jest-cli/src/cli/args.js
  157:1  error  Line 157 exceeds the maximum line length of 80  max-len

✖ 1 problem (1 error, 0 warnings)
```