### PR TITLE
Add information about how to use Node debugger

### DIFF
--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -9,6 +9,18 @@ next: mock-functions
 
 Uh oh, something went wrong? Use this guide to resolve issues with Jest.
 
+### Tests are Failing and You Don't Know Why
+
+Try using the debugger built into >= Node 6.3. 
+
+Place a `debugger;` statement in any of your tests, and then, in your project's directory, run:
+
+`node --debug-brk --inspect ./node_modules/.bin/jest --runInBand [any other arugments here]`
+
+This will output a link that you can open in Chrome. After opening that link, the Chrome Developer Tools will be displayed, and a breakpoint will be set at the first line of the Jest CLI script (this is done simply to give you time to open the developer tools and to prevent Jest from executing before you have time to do so). Click the button that looks like a "play" button in the upper right hand side of the screen to continue execution. When Jest executes the test that contains the `debugger` statement, execution will pause and you can examine the current scope and call stack.
+
+More information on the V8 inspector can be found here: https://nodejs.org/api/debugger.html#debugger_v8_inspector_integration_for_node_js
+
 ### Caching Issues
 
 The preprocessor script was changed or babel was updated and the changes aren't

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -15,9 +15,11 @@ Try using the debugger built into >= Node 6.3.
 
 Place a `debugger;` statement in any of your tests, and then, in your project's directory, run:
 
-`node --debug-brk --inspect ./node_modules/.bin/jest --runInBand [any other arugments here]`
+`node --debug-brk --inspect ./node_modules/.bin/jest --i [any other arguments here]`
 
 This will output a link that you can open in Chrome. After opening that link, the Chrome Developer Tools will be displayed, and a breakpoint will be set at the first line of the Jest CLI script (this is done simply to give you time to open the developer tools and to prevent Jest from executing before you have time to do so). Click the button that looks like a "play" button in the upper right hand side of the screen to continue execution. When Jest executes the test that contains the `debugger` statement, execution will pause and you can examine the current scope and call stack.
+
+*Note: the `-i` cli option makes sure Jest runs test in the same process rather than spawning processes for individual tests. Normally Jest parallelizes test runs across processes but it is hard to debug many processes at the same time.*
 
 More information on the V8 inspector can be found here: https://nodejs.org/api/debugger.html#debugger_v8_inspector_integration_for_node_js
 


### PR DESCRIPTION
This adds information in the troubleshooting section about how to use the Chrome inspector in Node versions greater than or equal to 6.3 to debug Jest tests.

Relevant to this tweet: https://twitter.com/cpojer/status/774440000553226240