### PR TITLE
Forward timeout argument for lifecycle hooks

### DIFF
--- a/integration_tests/__tests__/jasmine_async-test.js
+++ b/integration_tests/__tests__/jasmine_async-test.js
@@ -21,11 +21,14 @@ describe('async jasmine', () => {
     );
     const json = result.json;
 
-    expect(json.numTotalTests).toBe(1);
+    expect(json.numTotalTests).toBe(2);
     expect(json.numPassedTests).toBe(1);
-    expect(json.numFailedTests).toBe(0);
+    expect(json.numFailedTests).toBe(1);
     expect(json.numPendingTests).toBe(0);
-    expect(json.testResults[0].message).toBe('');
+
+    const {message} = json.testResults[0];
+    expect(message).toMatch('with failing timeout');
+    expect(message).toMatch('Async callback was not invoked within timeout');
   });
 
   it('works with beforeEach', () => {
@@ -104,13 +107,14 @@ describe('async jasmine', () => {
     const json = result.json;
     const message = json.testResults[0].message;
 
-    expect(json.numTotalTests).toBe(7);
-    expect(json.numPassedTests).toBe(4);
-    expect(json.numFailedTests).toBe(3);
+    expect(json.numTotalTests).toBe(9);
+    expect(json.numPassedTests).toBe(5);
+    expect(json.numFailedTests).toBe(4);
 
     expect(message).toMatch('fails if promise is rejected');
     expect(message).toMatch('works with done.fail');
     expect(message).toMatch('fails a sync test');
+    expect(message).toMatch('fails if a custom timeout is exceeded');
   });
 
   it('works with pit', () => {

--- a/integration_tests/jasmine_async/__tests__/promise_beforeAll-test.js
+++ b/integration_tests/jasmine_async/__tests__/promise_beforeAll-test.js
@@ -17,8 +17,21 @@ describe('promise beforeAll', () => {
     });
   });
 
+  beforeAll(() => {
+    return new Promise(resolve => setTimeout(resolve, 10));
+  }, 500);
+
   // passing tests
   it('runs tests after beforeAll asynchronously completes', () => {
     expect(this.flag).toBe(1);
+  });
+
+  describe('with failing timeout', () => {
+    // failing before hook
+    beforeAll(() => {
+      return new Promise(resolve => setTimeout(resolve, 100));
+    }, 10);
+
+    it('fails', () => {});
   });
 });

--- a/integration_tests/jasmine_async/__tests__/promise_it-test.js
+++ b/integration_tests/jasmine_async/__tests__/promise_it-test.js
@@ -50,4 +50,13 @@ describe('promise it', () => {
   it('fails a sync test', () => {
     expect('sync').toBe('failed');
   });
+
+  it('succeeds if the test finishes in time', () => {
+    return new Promise(resolve => setTimeout(resolve, 10));
+  }, 250);
+
+  // failing tests
+  it('fails if a custom timeout is exceeded', () => {
+    return new Promise(resolve => setTimeout(resolve, 100));
+  }, 10);
 });

--- a/packages/jest-jasmine2/src/jasmine-async.js
+++ b/packages/jest-jasmine2/src/jasmine-async.js
@@ -54,7 +54,7 @@ function promisifyIt(originalFn, env) {
 }
 
 function promisifyLifeCycleFunction(originalFn: Function, env) {
-  return function(fn) {
+  return function(fn, timeout) {
     const hasDoneCallback = fn.length;
     if (!hasDoneCallback) {
       const originalBodyFn = fn;
@@ -68,7 +68,7 @@ function promisifyLifeCycleFunction(originalFn: Function, env) {
       };
     }
 
-    return originalFn.call(env, fn);
+    return originalFn.call(env, fn, timeout);
   };
 }
 


### PR DESCRIPTION
This exposes per-hook timeout settings using the same API used by jasmine natively. This change should be compatible with existing tests unless they were relying on the 2nd parameter being ignored.

Since I was already at it, I also added a test for the `it` timeout for consistency.