### PR TITLE
Add `afterAll` and `beforeAll` to docs

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -13,6 +13,8 @@ In your test files, Jest puts each of these methods and objects into the global 
 
   - `afterEach(fn)`
   - `beforeEach(fn)`
+  - `afterAll(fn)`
+  - `beforeAll(fn)`
   - [`describe(name, fn)`](#basic-testing)
   - [`expect(value)`](#expect-value)
   - [`it(name, fn)`](#basic-testing)


### PR DESCRIPTION
I didn’t know that Jest had support for `afterAll` and `beforeAll` until after opening a couple of issues and looking at the Jest source code. It could be really helpful to newcomers in the future to know these hooks exist 😊