### PR TITLE
address jsonschema mock edge case

### DIFF
--- a/packages/jest-mock/src/__tests__/jest-mock-test.js
+++ b/packages/jest-mock/src/__tests__/jest-mock-test.js
@@ -42,8 +42,8 @@ describe('moduleMocker', () => {
 
     it('escapes illegal characters in function name property', () => {
       let foo = {
-        'foo-bar': function() {}
-      }
+        'foo-bar': () => {},
+      };
 
       const fooBarMock = moduleMocker.generateFromMetadata(
         moduleMocker.getMetadata(foo['foo-bar']),

--- a/packages/jest-mock/src/__tests__/jest-mock-test.js
+++ b/packages/jest-mock/src/__tests__/jest-mock-test.js
@@ -40,6 +40,17 @@ describe('moduleMocker', () => {
       expect(fooMock.name).toBe('foo');
     });
 
+    it('escapes illegal characters in function name property', () => {
+      let foo = {
+        'foo-bar': function() {}
+      }
+
+      const fooBarMock = moduleMocker.generateFromMetadata(
+        moduleMocker.getMetadata(foo['foo-bar']),
+      );
+      expect(fooBarMock.name).toBe('foo$bar');
+    })
+
     it('special cases the mockConstructor name', () => {
       function mockConstructor() {}
       const fooMock = moduleMocker.generateFromMetadata(

--- a/packages/jest-mock/src/index.js
+++ b/packages/jest-mock/src/index.js
@@ -179,8 +179,8 @@ function createMockFunction(
     name = '$' + name;
   }
 
-  if (/\s/.test(name)) {
-    name = name.replace(/\s/g, '$');
+  if (/[\s-]/.test(name)) {
+    name = name.replace(/[\s-]/g, '$');
   }
 
   /* eslint-disable no-new-func */

--- a/packages/jest-mock/src/index.js
+++ b/packages/jest-mock/src/index.js
@@ -179,6 +179,8 @@ function createMockFunction(
     name = '$' + name;
   }
 
+  // It's also a syntax error to define a function with a reserved character
+  // as part of it's name.
   if (/[\s-]/.test(name)) {
     name = name.replace(/[\s-]/g, '$');
   }


### PR DESCRIPTION
Fix to work around this issue:

https://github.com/joeapearson/jest-jsonschema

Problem seems to be that `jsonschema` module creates member functions with `-` in them (e.g. `utc-millisec`), presumably to mirror the json schema [spec](https://tools.ietf.org/html/draft-zyp-json-schema-03)

