### PR TITLE
Add coverageReporters to the API docs (#1677)

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -918,7 +918,9 @@ The directory where Jest should output its coverage files.
 ### `coverageReporters` [array<string>]
 (default: `['json', 'lcov', 'text']`)
 
-A list of reporter names that Jest should use when writing coverege reports. Any [istanbul reporter](https://github.com/gotwarlost/istanbul/tree/master/lib/report) can be used. Setting this option overwrites the default values so you should add `'text'` or `'text-summary'` reporter if you want to see a coverage summary in the console output.
+A list of reporter names that Jest uses when writing coverage reports. Any [istanbul reporter](https://github.com/gotwarlost/istanbul/tree/master/lib/report) can be used.
+
+*Note: Setting this option overwrites the default values. Add `'text'` or `'text-summary'` to see a coverage summary in the console output.*
 
 ### `collectCoverage` [boolean]
 (default: `false`)

--- a/docs/API.md
+++ b/docs/API.md
@@ -96,6 +96,7 @@ These options let you control Jest's behavior in your `package.json` file. The J
   - [`bail` [boolean]](#bail-boolean)
   - [`cacheDirectory` [string]](#cachedirectory-string)
   - [`coverageDirectory` [string]](#coveragedirectory-string)
+  - [`coverageReporters` [array<string>]](#coveragereporters-array-string)
   - [`collectCoverage` [boolean]](#collectcoverage-boolean)
   - [`collectCoverageOnlyFrom` [object]](#collectcoverageonlyfrom-object)
   - [`coveragePathIgnorePatterns` [array<string>]](#coveragepathignorepattern-array-string)
@@ -913,6 +914,11 @@ Jest attempts to scan your dependency tree once (up-front) and cache it in order
 (default: `undefined`)
 
 The directory where Jest should output its coverage files.
+
+### `coverageReporters` [array<string>]
+(default: `['json', 'lcov', 'text']`)
+
+A list of reporter names that Jest should use when writing coverege reports. Any [istanbul reporter](https://github.com/gotwarlost/istanbul/tree/master/lib/report) can be used. Setting this option overwrites the default values so you should add `'text'` or `'text-summary'` reporter if you want to see a coverage summary in the console output.
 
 ### `collectCoverage` [boolean]
 (default: `false`)


### PR DESCRIPTION
`coverageReporters` option was missing from the API documentation #1677 