### PR TITLE
Fix mock-test on node 4.

### DIFF
--- a/packages/jest-mock/src/__tests__/jest-mock-test.js
+++ b/packages/jest-mock/src/__tests__/jest-mock-test.js
@@ -34,10 +34,10 @@ describe('moduleMocker', () => {
   describe('generateFromMetadata', () => {
     it('forwards the function name property', () => {
       function foo() {}
-      const fooMock = moduleMocker.generateFromMetadata(
+      const mock = moduleMocker.generateFromMetadata(
         moduleMocker.getMetadata(foo),
       );
-      expect(fooMock.name).toBe('foo');
+      expect(mock.name).toBe('foo');
     });
 
     it('escapes illegal characters in function name property', () => {
@@ -45,21 +45,24 @@ describe('moduleMocker', () => {
         'foo-bar': () => {},
       };
 
-      const fooBarMock = moduleMocker.generateFromMetadata(
+      const mock = moduleMocker.generateFromMetadata(
         moduleMocker.getMetadata(foo['foo-bar']),
       );
-      expect(fooBarMock.name).toBe('foo$bar');
+      expect(
+        !mock.name ||
+        mock.name === 'foo$bar'
+      ).toBeTruthy();
     });
 
     it('special cases the mockConstructor name', () => {
       function mockConstructor() {}
-      const fooMock = moduleMocker.generateFromMetadata(
+      const mock = moduleMocker.generateFromMetadata(
         moduleMocker.getMetadata(mockConstructor),
       );
       // Depends on node version
       expect(
-        !fooMock.name ||
-        fooMock.name === 'mockConstructor',
+        !mock.name ||
+        mock.name === 'mockConstructor',
       ).toBeTruthy();
     });
 
@@ -92,14 +95,14 @@ describe('moduleMocker', () => {
           get: () => { throw new Error(); },
         },
       });
-      const fooMock = moduleMocker.generateFromMetadata(
+      const mock = moduleMocker.generateFromMetadata(
         moduleMocker.getMetadata(foo),
       );
 
       expect(typeof foo.nonEnumMethod).toBe('function');
 
-      expect(fooMock.nonEnumMethod.mock).not.toBeUndefined();
-      expect(fooMock.nonEnumGetter).toBeUndefined();
+      expect(mock.nonEnumMethod.mock).not.toBeUndefined();
+      expect(mock.nonEnumGetter).toBeUndefined();
     });
 
     it('mocks getters of ES modules', () => {
@@ -112,10 +115,10 @@ describe('moduleMocker', () => {
           get: () => 10,
         },
       });
-      const fooMock = moduleMocker.generateFromMetadata(
+      const mock = moduleMocker.generateFromMetadata(
         moduleMocker.getMetadata(foo),
       );
-      expect(fooMock.enumGetter).toBeDefined();
+      expect(mock.enumGetter).toBeDefined();
     });
 
     it('mocks ES2015 non-enumerable methods', () => {


### PR DESCRIPTION
node 4 doesn't take function names from the object key name.