### PR TITLE
Docs: Setup up jasmine.DEFAULT_TIMEOUT_INTERVAL globally

### DIFF
--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -54,6 +54,8 @@ specified in `jasmine.DEFAULT_TIMEOUT_INTERVAL`.
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000; // 10 second timeout
 ```
 
+If you want to set this up globally, put it in [setupTestFrameworkScriptFile](http://facebook.github.io/jest/docs/api.html#setuptestframeworkscriptfile-string)
+
 ### Watchman Issues
 
 Try running Jest with `--no-watchman` or set the `watchman` configuration option


### PR DESCRIPTION
This took me 10 minutes to figure it out. So I think this might save others 10 precious minutes