### PR TITLE
Add deep-equality matcher for checking collection contents.

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -50,6 +50,7 @@ expect all the time. That's what you use `expect` for.
   - [`.toBeTruthy()`](#tobetruthy)
   - [`.toBeUndefined()`](#tobeundefined)
   - [`.toContain(item)`](#tocontain-item)
+  - [`.toContainEqual(item)`](#tocontainequal-item)
   - [`.toEqual(value)`](#toequal-value)
   - [`.toMatch(regexp)`](#tomatch-regexp)
   - [`.toMatchSnapshot()`](#tomatchsnapshot)
@@ -521,6 +522,20 @@ For example, if `getAllFlavors()` returns a list of flavors and you want to be s
 describe('the list of all flavors', () => {
   it('contains lime', () => {
     expect(getAllFlavors()).toContain('lime');
+  });
+});
+```
+
+### `.toContainEqual(item)`
+
+Use `.toContainEqual` when you want to check that an item is in a list.
+For testing the items in the list, this  matcher recursively checks the equality of all fields, rather than checking for object identity.
+
+```js
+describe('', () => {
+  it('', () => {
+    const myBeverage = { delicious: true, sour: false };
+    expect(myBeverages()).toContainEqual(myBeverage);
   });
 });
 ```

--- a/docs/API.md
+++ b/docs/API.md
@@ -532,9 +532,9 @@ Use `.toContainEqual` when you want to check that an item is in a list.
 For testing the items in the list, this  matcher recursively checks the equality of all fields, rather than checking for object identity.
 
 ```js
-describe('', () => {
-  it('', () => {
-    const myBeverage = { delicious: true, sour: false };
+describe('my beverage', () => {
+  it('is delicious and not sour', () => {
+    const myBeverage = {delicious: true, sour: false};
     expect(myBeverages()).toContainEqual(myBeverage);
   });
 });

--- a/packages/jest-matchers/src/__tests__/__snapshots__/matchers-test.js.snap
+++ b/packages/jest-matchers/src/__tests__/__snapshots__/matchers-test.js.snap
@@ -1567,12 +1567,12 @@ To contain value:
   [32m{}[39m"
 `;
 
-exports[`.toContainEqual() '[{"a":"b"},{"a":"c"}]' does not contain '{"a":"d"}' 1`] = `
-"[2mexpect([22m[31marray[39m[2m).toContain([22m[32mvalue[39m[2m)[22m
+exports[`.toContainEqual() '[{"a":"b"},{"a":"c"}]' does not contain a value equal to'{"a":"d"}' 1`] = `
+"[2mexpect([22m[31marray[39m[2m).toContainEqual([22m[32mvalue[39m[2m)[22m
 
 Expected array:
   [31m[{\"a\":\"b\"},{\"a\":\"c\"}][39m
-To contain value:
+To contain a value equal to:
   [32m{\"a\":\"d\"}[39m"
 `;
 

--- a/packages/jest-matchers/src/__tests__/__snapshots__/matchers-test.js.snap
+++ b/packages/jest-matchers/src/__tests__/__snapshots__/matchers-test.js.snap
@@ -1567,6 +1567,15 @@ To contain value:
   [32m{}[39m"
 `;
 
+exports[`.toContainEqual() '[{"a":"b"},{"a":"c"}]' does not contain '{"a":"d"}' 1`] = `
+"[2mexpect([22m[31marray[39m[2m).toContain([22m[32mvalue[39m[2m)[22m
+
+Expected array:
+  [31m[{\"a\":\"b\"},{\"a\":\"c\"}][39m
+To contain value:
+  [32m{\"a\":\"d\"}[39m"
+`;
+
 exports[`.toEqual() expect("abc").not.toEqual("abc") 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).not.toEqual([22m[32mexpected[39m[2m)[22m
 

--- a/packages/jest-matchers/src/__tests__/matchers-test.js
+++ b/packages/jest-matchers/src/__tests__/matchers-test.js
@@ -309,7 +309,7 @@ describe('.toContainEqual()', () => {
     [[Symbol.for('a')], Symbol.for('a')],
     [[{a:'b'}, {a:'c'}], {a:'b'}],
   ].forEach(([list, v]) => {
-    it(`'${stringify(list)}' contains with deep checking '${stringify(v)}'`, () => {
+    it(`'${stringify(list)}' contains a value equal to '${stringify(v)}'`, () => {
       jestExpect(list).toContainEqual(v);
     });
   });
@@ -317,9 +317,9 @@ describe('.toContainEqual()', () => {
   [
     [[{a:'b'}, {a:'c'}], {a:'d'}],
   ].forEach(([list, v]) => {
-    it(`'${stringify(list)}' does not contain '${stringify(v)}'`, () => {
-      jestExpect(list).not.toContain(v);
-      matchErrorSnapshot(() => jestExpect(list).toContain(v));
+    it(`'${stringify(list)}' does not contain a value equal to'${stringify(v)}'`, () => {
+      jestExpect(list).not.toContainEqual(v);
+      matchErrorSnapshot(() => jestExpect(list).toContainEqual(v));
     });
   });
 });

--- a/packages/jest-matchers/src/__tests__/matchers-test.js
+++ b/packages/jest-matchers/src/__tests__/matchers-test.js
@@ -300,6 +300,30 @@ describe('.toContain()', () => {
   });
 });
 
+describe('.toContainEqual()', () => {
+  [
+    [[1, 2, 3, 4], 1],
+    [['a', 'b', 'c', 'd'], 'a'],
+    [[undefined, null], null],
+    [[undefined, null], undefined],
+    [[Symbol.for('a')], Symbol.for('a')],
+    [[{a:'b'}, {a:'c'}], {a:'b'}],
+  ].forEach(([list, v]) => {
+    it(`'${stringify(list)}' contains with deep checking '${stringify(v)}'`, () => {
+      jestExpect(list).toContainEqual(v);
+    });
+  });
+
+  [
+    [[{a:'b'}, {a:'c'}], {a:'d'}],
+  ].forEach(([list, v]) => {
+    it(`'${stringify(list)}' does not contain '${stringify(v)}'`, () => {
+      jestExpect(list).not.toContain(v);
+      matchErrorSnapshot(() => jestExpect(list).toContain(v));
+    });
+  });
+});
+
 describe('.toBeCloseTo()', () => {
   [
     [0, 0],

--- a/packages/jest-matchers/src/matchers.js
+++ b/packages/jest-matchers/src/matchers.js
@@ -295,7 +295,6 @@ const matchers: MatchersObject = {
         printWithType('Received', collection, printReceived),
       );
     }
-
     const pass = collection.indexOf(value) != -1;
     const message = pass
       ? () => matcherHint('.not.toContain', collectionType, 'value') + '\n\n' +
@@ -307,6 +306,33 @@ const matchers: MatchersObject = {
         `Expected ${collectionType}:\n` +
         `  ${printReceived(collection)}\n` +
         `To contain value:\n` +
+        `  ${printExpected(value)}`;
+
+    return {message, pass};
+  },
+
+  toContainEqual(collection: Array<any>, value: any) {
+    const collectionType = getType(collection);
+    if (!Array.isArray(collection)) {
+      throw new Error(
+        `.toContainEqual() only works with arrays.\n` +
+        printWithType('Received', collection, printReceived),
+      );
+    }
+
+    const pass = collection.findIndex(elem => {
+      return equals(elem, value, [iterableEquality]);
+    }) != -1;
+    const message = pass
+      ? () => matcherHint('.not.toContainEqual', collectionType, 'value') + '\n\n' +
+        `Expected ${collectionType}:\n` +
+        `  ${printReceived(collection)}\n` +
+        `Not to contain value with deep checking:\n` +
+        `  ${printExpected(value)}\n`
+      : () => matcherHint('.toContainEqual', collectionType, 'value') + '\n\n' +
+        `Expected ${collectionType}:\n` +
+        `  ${printReceived(collection)}\n` +
+        `To contain value with deep checking:\n` +
         `  ${printExpected(value)}`;
 
     return {message, pass};

--- a/packages/jest-matchers/src/matchers.js
+++ b/packages/jest-matchers/src/matchers.js
@@ -295,6 +295,7 @@ const matchers: MatchersObject = {
         printWithType('Received', collection, printReceived),
       );
     }
+
     const pass = collection.indexOf(value) != -1;
     const message = pass
       ? () => matcherHint('.not.toContain', collectionType, 'value') + '\n\n' +
@@ -320,19 +321,18 @@ const matchers: MatchersObject = {
       );
     }
 
-    const pass = collection.findIndex(elem => {
-      return equals(elem, value, [iterableEquality]);
-    }) != -1;
+    const pass =
+      collection.findIndex(item => equals(item, value, [iterableEquality])) !== -1;
     const message = pass
       ? () => matcherHint('.not.toContainEqual', collectionType, 'value') + '\n\n' +
         `Expected ${collectionType}:\n` +
         `  ${printReceived(collection)}\n` +
-        `Not to contain value with deep checking:\n` +
+        `Not to contain a value equal to:\n` +
         `  ${printExpected(value)}\n`
       : () => matcherHint('.toContainEqual', collectionType, 'value') + '\n\n' +
         `Expected ${collectionType}:\n` +
         `  ${printReceived(collection)}\n` +
-        `To contain value with deep checking:\n` +
+        `To contain a value equal to:\n` +
         `  ${printExpected(value)}`;
 
     return {message, pass};


### PR DESCRIPTION
This matcher uses the same approach as toContain, except it uses deep-equality checking instead of object equality.

Closes #1369.

**Summary**
As discussed in #1369, a matcher is wanted that checks whether an _equal_ value is present in a collection. The existing `toContain` matcher uses ===, a strict equality check. This new matcher uses the same equality check as `toEqual` does - hence the name.

**Test plan**
Run unit tests.