### PR TITLE
MatcherContext

### DIFF
--- a/packages/jest-matchers/src/index.js
+++ b/packages/jest-matchers/src/index.js
@@ -12,8 +12,9 @@
 
 import type {
   Expect,
-  ExpectationResult,
   ExpectationObject,
+  ExpectationResult,
+  MatcherContext,
   MatchersObject,
   RawMatcherFn,
   ThrowingMatcherFn,
@@ -55,14 +56,14 @@ const makeThrowingMatcher = (
   isNot: boolean,
   actual: any,
 ): ThrowingMatcherFn => {
-  return function throwingMatcher(expected, options) {
+  return function throwingMatcher(expected, ...rest) {
+    const matcherContext: MatcherContext = {isNot};
     let result: ExpectationResult;
+
     try {
-      result = matcher(
-        actual,
-        expected,
-        options,
-        {args: arguments},
+      result = matcher.apply(
+        matcherContext,
+        [actual, expected].concat(rest),
       );
     } catch (error) {
       // Remove this and deeper functions from the stack trace frame.

--- a/packages/jest-matchers/src/types.js
+++ b/packages/jest-matchers/src/types.js
@@ -21,6 +21,7 @@ export type RawMatcherFn = (
 ) => ExpectationResult;
 
 export type ThrowingMatcherFn = (actual: any) => void;
+export type MatcherContext = {isNot: boolean};
 export type MatchersObject = {[id:string]: RawMatcherFn};
 export type Expect = (expected: any) => ExpectationObject;
 export type ExpectationObject = {


### PR DESCRIPTION
MatcherContext is going to be `this` inside matcher functions.

why:
1. Right now it has only one value `isNot`, that tells you whether matcher was called with `.not` or not. Snapshot matcher will need this value in order to disable all `.not` invokations.
2. Later we'll be able to pass other context values that snapshots need (current file, suite, test names)