### PR TITLE
Add section in documentation for testURL

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -125,6 +125,7 @@ These options let you control Jest's behavior in your `package.json` file. The J
   - [`testRegex` [string]](#testregex-string)
   - [`testResultsProcessor` [string]](#testresultsprocessor-string)
   - [`testRunner` [string]](#testrunner-string)
+  - [`testURL` [string]](#testurl-string)
   - [`timers` [string]](#timers-string)
   - [`unmockedModulePathPatterns` [array<string>]](#unmockedmodulepathpatterns-array-string)
   - [`verbose` [boolean]](#verbose-boolean)
@@ -1209,6 +1210,11 @@ This option allows the use of a custom results processor. This processor must be
 (default: `jasmine2`)
 
 This option allows use of a custom test runner. The default is jasmine2. Jest also ships with jasmine1 which can enabled by setting this option to `jasmine1`. A custom test runner can be provided by specifying a path to a test runner implementation.
+
+### `testURL` [string]
+(default: `about:blank`)
+
+This option sets the url for the jsdom environment. It is reflected in properties such as `location.href`.
 
 ### `timers` [string]
 (default: `real`)

--- a/docs/API.md
+++ b/docs/API.md
@@ -1214,7 +1214,7 @@ This option allows use of a custom test runner. The default is jasmine2. Jest al
 ### `testURL` [string]
 (default: `about:blank`)
 
-This option sets the url for the jsdom environment. It is reflected in properties such as `location.href`.
+This option sets the URL for the jsdom environment. It is reflected in properties such as `location.href`.
 
 ### `timers` [string]
 (default: `real`)


### PR DESCRIPTION
**Summary**
It seems that the `testURL` configuration setting was not documented. This PR adds a section for it.

**Test plan**
There are no code changes, but the config setting referred to can be found [here](https://github.com/facebook/jest/blob/83c254177f6ee58a9669c56e359d22ade0b21977/packages/jest-environment-jsdom/src/index.js#L27).

The default value for testURL is set [here](https://github.com/facebook/jest/blob/2699ed50ae4f849dfc384d3a4f4c4687b9fb24b0/packages/jest-config/src/defaults.js#L54)

