### PR TITLE
Remove react-native special case.

### DIFF
--- a/packages/jest-config/src/__tests__/normalize-test.js
+++ b/packages/jest-config/src/__tests__/normalize-test.js
@@ -556,24 +556,6 @@ describe('normalize', () => {
       expect(config.setupFiles.map(uniformPath))
         .toEqual(['/root/node_modules/babel-polyfill']);
     });
-
-    it('correctly identifies react-native', () => {
-      // The default Resolver.findNodeModule fn finds `react-native`.
-      let config = normalize({
-        rootDir: '/root',
-      });
-      expect(config.preprocessorIgnorePatterns).toEqual([]);
-
-      // This version doesn't find react native and sets the default to
-      // /node_modules/
-      Resolver.findNodeModule.mockImplementation(() => null);
-      config = normalize({
-        rootDir: '/root',
-      });
-
-      expect(config.preprocessorIgnorePatterns.map(uniformPath))
-        .toEqual(['/node_modules']);
-    });
   });
 
   describe('Upgrade help', () => {

--- a/packages/jest-config/src/defaults.js
+++ b/packages/jest-config/src/defaults.js
@@ -15,7 +15,9 @@ import type {DefaultConfig} from 'types/Config';
 const constants = require('./constants');
 const os = require('os');
 const path = require('path');
-const utils = require('jest-util');
+const {replacePathSepForRegex} = require('jest-util');
+
+const NODE_MODULES_REGEXP = replacePathSepForRegex(constants.NODE_MODULES);
 
 module.exports = ({
   automock: false,
@@ -23,9 +25,7 @@ module.exports = ({
   browser: false,
   cacheDirectory: path.join(os.tmpdir(), 'jest'),
   colors: false,
-  coveragePathIgnorePatterns: [
-    utils.replacePathSepForRegex(constants.NODE_MODULES),
-  ],
+  coveragePathIgnorePatterns: [NODE_MODULES_REGEXP],
   coverageReporters: ['json', 'text', 'lcov', 'clover'],
   globals: {},
   haste: {
@@ -44,12 +44,11 @@ module.exports = ({
   noStackTrace: false,
   notify: false,
   preset: null,
+  preprocessorIgnorePatterns: [NODE_MODULES_REGEXP],
   resetModules: false,
   testEnvironment: 'jest-environment-jsdom',
   testPathDirs: ['<rootDir>'],
-  testPathIgnorePatterns: [
-    utils.replacePathSepForRegex(constants.NODE_MODULES),
-  ],
+  testPathIgnorePatterns: [NODE_MODULES_REGEXP],
   testRegex: '(/__tests__/.*|\\.(test|spec))\\.jsx?$',
   testURL: 'about:blank',
   timers: 'real',

--- a/packages/jest-config/src/normalize.js
+++ b/packages/jest-config/src/normalize.js
@@ -292,17 +292,6 @@ function normalize(config, argv) {
     config.usesBabelJest = true;
   }
 
-  if (!('preprocessorIgnorePatterns' in config)) {
-    const isRNProject =
-      !!Resolver.findNodeModule('react-native', {
-        basedir: config.rootDir,
-      });
-    config.preprocessorIgnorePatterns =
-      isRNProject ? [] : [constants.NODE_MODULES];
-  } else if (!config.preprocessorIgnorePatterns) {
-    config.preprocessorIgnorePatterns = [];
-  }
-
   Object.keys(config).reduce((newConfig, key) => {
     let value;
     switch (key) {


### PR DESCRIPTION
**Summary**
I added this ugly special case a while back when we didn't have great react-native support. Now we don't actually need this any more as I expect the community to fully switch over to the preset.

Fixes #1655

**Test plan**
the react-native example still passes.