### PR TITLE
Fixed mockConstructor issue with new node

### DIFF
--- a/packages/jest-mock/src/index.js
+++ b/packages/jest-mock/src/index.js
@@ -226,7 +226,7 @@ function makeComponent(metadata: MockFunctionMetadata): Mock {
       metadata.members.prototype.members
     ) || {};
     const prototypeSlots = getSlots(prototype);
-    const mockConstructor = function() {
+    const mockConstructor = function mockConstructor() {
       instances.push(this);
       calls.push(Array.prototype.slice.call(arguments));
       if (this instanceof f) {


### PR DESCRIPTION
**Summary**
See https://github.com/facebook/jest/issues/1681

It turns out that removing the `const mockConstructor =` fixes the issue. I believe this is a good solution moving forward to avoid issues with previous versions of Node.

Another possible fix would be to allow metadata.name for `jest.fn`, maybe `jest.fn('functionName')` ?

**Test plan**
PR does not change the UI. I ran `npm test`.
