### PR TITLE
Update regex replace to not require full path matching

### DIFF
--- a/packages/jest-resolve/src/index.js
+++ b/packages/jest-resolve/src/index.js
@@ -207,9 +207,10 @@ class Resolver {
           if (!matches) {
             moduleName = mappedModuleName;
           } else {
-            moduleName = mappedModuleName.replace(/\$([0-9]+)/g, (_, index) => {
-              return matches[parseInt(index, 10)];
-            });
+            moduleName = mappedModuleName.replace(
+              /\$([0-9]+)/g,
+              (_, index) => matches[parseInt(index, 10)],
+            );
           }
           return this.getModule(moduleName) || Resolver.findNodeModule(
             moduleName,

--- a/packages/jest-resolve/src/index.js
+++ b/packages/jest-resolve/src/index.js
@@ -204,9 +204,13 @@ class Resolver {
         const regex = moduleNameMapper[mappedModuleName];
         if (regex.test(moduleName)) {
           const matches = moduleName.match(regex);
-          moduleName = mappedModuleName.replace(/\$([0-9]+)/g, (_, index) => {
-            return matches[parseInt(index, 10)];
-          });
+          if (!matches) {
+            moduleName = mappedModuleName;
+          } else {
+            moduleName = mappedModuleName.replace(/\$([0-9]+)/g, (_, index) => {
+              return matches[parseInt(index, 10)];
+            });
+          }
           return this.getModule(moduleName) || Resolver.findNodeModule(
             moduleName,
             {

--- a/packages/jest-resolve/src/index.js
+++ b/packages/jest-resolve/src/index.js
@@ -203,7 +203,10 @@ class Resolver {
       for (const mappedModuleName in moduleNameMapper) {
         const regex = moduleNameMapper[mappedModuleName];
         if (regex.test(moduleName)) {
-          moduleName = moduleName.replace(regex, mappedModuleName);
+          const matches = moduleName.match(regex);
+          moduleName = mappedModuleName.replace(/\$([0-9]+)/g, (_, index) => {
+            return matches[parseInt(index, 10)];
+          });
           return this.getModule(moduleName) || Resolver.findNodeModule(
             moduleName,
             {

--- a/packages/jest-runtime/src/__tests__/Runtime-requireModuleOrMock-test.js
+++ b/packages/jest-runtime/src/__tests__/Runtime-requireModuleOrMock-test.js
@@ -16,6 +16,7 @@ const moduleNameMapper = {
   'mappedToModule': '<rootDir>/TestModuleNameMapperResolution',
   'mappedToDirectory': '<rootDir>/MyDirectoryModule',
   'module/name/(.*)': '<rootDir>/mapped_module_$1.js',
+  '\\.css$': '<rootDir>/__mocks__/ManuallyMocked',
 };
 
 let createRuntime;
@@ -158,6 +159,12 @@ it('resolves mapped module names and unmocks them by default', () =>
       'module/name/test',
     );
     expect(exports).toBe('mapped_module');
+
+    exports = runtime.requireModuleOrMock(
+      runtime.__mockRootPath,
+      'subdir1/style.css',
+    );
+    expect(exports.isManualMockModule).toBe(true);
   }),
 );
 


### PR DESCRIPTION
**Summary**
The config option `moduleNameMapper` currently requires a full path match. This is because it is doing a regex replace on the original module name. This diff changes that so that instead we are using the mapped name directly. This makes it much easier to match any file of a specific type: like `'\\.css'`. There will be a small backwards compatability possibility for matches that depended on the previously incorrect behavior. (I found one such case in the Pinterest codebase that was resolved by using requireActual instead, which was more correct anyway). 

The previous functionality is:


**Before**

| moduleName             | regex     |   mappedName             | Resolution |
| --------------------- | ------- | ----------------------- | ------ |
| module/name/test   |  /module/name/(.*)/  | mapped_module_$1.js | mapped_module_test.js |
| test/style.css           |  /\.css$/  | __mocks__/ManuallyMocked | test/style__mocks__/ManuallyMocked |


**After**

| moduleName             | regex                         |   mappedName                      | Resolution                       |
| --------------------- | -------------------- | --------------------------- | ---------------------- |
| module/name/test   |  /module/name/(.*)/  | mapped_module_$1.js          | mapped_module_test.js |
| test/style.css           |  /\.css$/                     | __mocks__/ManuallyMocked | __mocks__/ManuallyMocked |


**Test plan**
I ran the changes over the 900 Pinterest tests as well as the jest codebase tests. I also added a test to make sure that the path is used correctly.

#1624 
