### PR TITLE
Run setupTestFrameworkScriptFile after extendJasmineExpect

### DIFF
--- a/packages/jest-jasmine2/src/index.js
+++ b/packages/jest-jasmine2/src/index.js
@@ -86,10 +86,6 @@ function jasmine2(
   environment.global.describe.skip = environment.global.xdescribe;
   environment.global.describe.only = environment.global.fdescribe;
 
-  if (config.setupTestFrameworkScriptFile) {
-    runtime.requireModule(config.setupTestFrameworkScriptFile);
-  }
-
   if (!jasmine || !env) {
     throw new Error('jasmine2 could not be initialized by Jest');
   }
@@ -128,6 +124,10 @@ function jasmine2(
   runtime.requireInternalModule(
     path.resolve(__dirname, './extendJasmineExpect.js'),
   );
+
+  if (config.setupTestFrameworkScriptFile) {
+    runtime.requireModule(config.setupTestFrameworkScriptFile);
+  }
 
   if (config.timers === 'fake') {
     environment.fakeTimers.useFakeTimers();


### PR DESCRIPTION
**Summary**
This fixes #1730. Having setupTestFrameworkScriptFile run after extendJasmineExpect makes sure that it is possible to override global.expect to use another expectation library like chai.

**Test plan**
A demo of jest working with chai is here: https://github.com/0xR/snapshot-experiments/pull/1.

You can run `npm test` which will run the tests which have chai assertions. The integrate-chai fork of jest-jasmine2 is installed to demo that the codes solves the issue.

**Future work**
Document how to use jest with chai.

