### PR TITLE
Add testNamePattern CLI argument

### DIFF
--- a/integration_tests/__tests__/testNamePattern-test.js
+++ b/integration_tests/__tests__/testNamePattern-test.js
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
+const runJest = require('../runJest');
+
+test('testNamePattern', () => {
+  const result = runJest.json('testNamePattern', [
+    '--testNamePattern', 'should match',
+  ]);
+
+  expect(result.status).toBe(0);
+  expect(result.json.numTotalTests).toBe(4);
+  expect(result.json.numPassedTests).toBe(2);
+  expect(result.json.numFailedTests).toBe(0);
+});

--- a/integration_tests/__tests__/testNamePattern-test.js
+++ b/integration_tests/__tests__/testNamePattern-test.js
@@ -8,6 +8,9 @@
 'use strict';
 
 const runJest = require('../runJest');
+const skipOnWindows = require('skipOnWindows');
+
+skipOnWindows.suite();
 
 test('testNamePattern', () => {
   const result = runJest.json('testNamePattern', [

--- a/integration_tests/testNamePattern/__tests__/testNamePattern-test.js
+++ b/integration_tests/testNamePattern/__tests__/testNamePattern-test.js
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
+test('should match 1', () => expect(1).toBe(1));
+test('should match 2', () => expect(1).toBe(1));
+test('should not match 1', () => expect(1).toBe(1));
+test('should not match 2', () => expect(1).toBe(1));

--- a/integration_tests/testNamePattern/package.json
+++ b/integration_tests/testNamePattern/package.json
@@ -1,0 +1,5 @@
+{
+  "jest": {
+    "testEnvironment": "node"
+  }
+}

--- a/packages/jest-cli/src/cli/args.js
+++ b/packages/jest-cli/src/cli/args.js
@@ -91,6 +91,11 @@ const options = {
       'rare.',
     type: 'boolean',
   },
+  testNamePattern: {
+    description:
+      'Run only tests with a name that matches the regex pattern.',
+    type: 'string',
+  },
   testPathPattern: {
     description:
       'A regexp pattern string that is matched against all tests ' +

--- a/packages/jest-cli/src/cli/args.js
+++ b/packages/jest-cli/src/cli/args.js
@@ -92,6 +92,7 @@ const options = {
     type: 'boolean',
   },
   testNamePattern: {
+    alias: 't',
     description:
       'Run only tests with a name that matches the regex pattern.',
     type: 'string',

--- a/packages/jest-config/src/setFromArgv.js
+++ b/packages/jest-config/src/setFromArgv.js
@@ -57,6 +57,10 @@ function setFromArgv(config, argv) {
     config.setupTestFrameworkScriptFile = argv.setupTestFrameworkScriptFile;
   }
 
+  if (argv.testNamePattern) {
+    config.testNamePattern = argv.testNamePattern;
+  }
+
   if (argv.updateSnapshot) {
     config.updateSnapshot = argv.updateSnapshot;
   }

--- a/packages/jest-jasmine2/src/index.js
+++ b/packages/jest-jasmine2/src/index.js
@@ -133,6 +133,11 @@ function jasmine2(
     environment.fakeTimers.useFakeTimers();
   }
 
+  if (config.testNamePattern) {
+    const testNameRegex = new RegExp(config.testNamePattern);
+    env.specFilter = spec => testNameRegex.test(spec.getFullName());
+  }
+
   runtime.requireModule(testPath);
   env.execute();
   return reporter.getResults().then(results => {

--- a/types/Config.js
+++ b/types/Config.js
@@ -75,6 +75,7 @@ export type Config = BaseConfig & {
   setupTestFrameworkScriptFile: Path,
   silent: boolean,
   testcheckOptions: {},
+  testNamePattern: string,
   unmockedModulePathPatterns: Array<string>,
   updateSnapshot: boolean,
   usesBabelJest: boolean,


### PR DESCRIPTION
**Summary**
The `--testNamePattern <regex>` argument (alias `-t <regex>`) allows running only tests with a name that matches a given regex pattern. Fixes #1662.

**Test plan**
Added an integration test in `integration_tests/__tests__/testNamePattern-test.js`.