### PR TITLE
Tweak PASS/FAIL color. Fixes #1593

### DIFF
--- a/packages/jest-cli/src/reporters/getResultHeader.js
+++ b/packages/jest-cli/src/reporters/getResultHeader.js
@@ -18,8 +18,8 @@ const path = require('path');
 const LONG_TEST_COLOR = chalk.reset.bold.bgRed;
 // Explicitly reset for these messages since they can get written out in the
 // middle of error logging
-const FAIL = chalk.reset.bold.bgRed(' FAIL ');
-const PASS = chalk.reset.bold.bgGreen(' PASS ');
+const FAIL = chalk.reset.inverse.bold.red(' FAIL ');
+const PASS = chalk.reset.inverse.bold.green(' PASS ');
 
 module.exports = (testResult: TestResult, config: Config) => {
   const pathStr = config.rootDir


### PR DESCRIPTION
**Summary**
See #1593. This should work better on a bigger variety of terminal color schemes.

**Test plan**
Try Jest with different terminal schemes.
