### PR TITLE
Better flow annotations.

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -8,7 +8,7 @@
 
 [options]
 module.name_mapper='^types/\(.*\)$' -> '<PROJECT_ROOT>/types/\1.js'
-module.name_mapper='^\(.*packages/jest-[^/]*\)' -> '\1/src/index.js'
+module.name_mapper='\(jest-[^/]*\)' -> '<PROJECT_ROOT>/packages/\1/src/index.js'
 
 suppress_type=$FlowFixMe
 suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe\\($\\|[^(]\\|(\\(>=0\\.\\(2[0-7]\\|1[0-9]\\|[0-9]\\).[0-9]\\)? *\\(site=[a-z,_]*www[a-z,_]*\\)?)\\)

--- a/integration_tests/__tests__/toMatchSnapshot-test.js
+++ b/integration_tests/__tests__/toMatchSnapshot-test.js
@@ -64,7 +64,7 @@ test('basic support', () => {
 
   {
     const {stderr, status} = runJest(DIR, [filename]);
-    expect(stderr).toMatch('Received value does not match the stored snapshot');
+    expect(stderr).toMatch('Received value does not match stored snapshot');
     expect(status).toBe(1);
   }
 
@@ -127,7 +127,8 @@ test('first snapshot fails, second passes', () => {
 
   {
     const {stderr, status} = runJest(DIR, [filename]);
-    expect(stderr).toMatch('Received value does not match the stored snapshot');
+    expect(stderr).toMatch('Received value does not match stored snapshot');
+    expect(stderr).toMatch('- "apple"\n    + "kiwi"');
     expect(stderr).not.toMatch('1 obsolete snapshot found');
     expect(status).toBe(1);
   }

--- a/packages/jest-cli/src/SearchSource.js
+++ b/packages/jest-cli/src/SearchSource.js
@@ -12,7 +12,7 @@
 
 import type {HasteContext} from 'types/HasteMap';
 import type {Path} from 'types/Config';
-import type {ResolveModuleConfig} from '../../jest-resolve/src';
+import type {ResolveModuleConfig} from 'jest-resolve';
 
 const DependencyResolver = require('jest-resolve-dependencies');
 
@@ -27,7 +27,7 @@ const {
 
 type SearchSourceConfig = {
   testPathDirs: Array<Path>,
-  testRegex: RegExp,
+  testRegex: string,
   testPathIgnorePatterns: Array<RegExp>,
 };
 

--- a/packages/jest-cli/src/TestRunner.js
+++ b/packages/jest-cli/src/TestRunner.js
@@ -376,6 +376,7 @@ const buildFailureTestResult = (
   err: TestError,
 ): TestResult => {
   return {
+    console: null,
     failureMessage: null,
     numFailingTests: 1,
     numPassingTests: 0,

--- a/packages/jest-cli/src/runTest.js
+++ b/packages/jest-cli/src/runTest.js
@@ -11,7 +11,7 @@
 
 import type {Path, Config} from 'types/Config';
 import type {TestResult} from 'types/TestResult';
-import type Resolver from '../../jest-resolve/src';
+import type Resolver from 'jest-resolve';
 
 const BufferedConsole = require('./lib/BufferedConsole');
 const Console = require('jest-util').Console;

--- a/packages/jest-environment-jsdom/src/index.js
+++ b/packages/jest-environment-jsdom/src/index.js
@@ -28,14 +28,14 @@ class JSDOMEnvironment {
     this.document = require('jsdom').jsdom(/* markup */undefined, {
       url: config.testURL,
     });
-    this.global = this.document.defaultView;
+    const global = this.global = this.document.defaultView;
     // Node's error-message stack size is limited at 10, but it's pretty useful
     // to see more than that when a test fails.
     this.global.Error.stackTraceLimit = 100;
-    installCommonGlobals(this.global, config.globals);
+    installCommonGlobals(global, config.globals);
 
     this.moduleMocker = new ModuleMocker();
-    this.fakeTimers = new FakeTimers(this.global, this.moduleMocker, config);
+    this.fakeTimers = new FakeTimers(global, this.moduleMocker, config);
   }
 
   dispose(): void {

--- a/packages/jest-haste-map/src/index.js
+++ b/packages/jest-haste-map/src/index.js
@@ -22,7 +22,7 @@ import typeof HType from './constants';
 
 const H = require('./constants');
 const HasteFS = require('./HasteFS');
-const ModuleMap = require('./ModuleMap');
+const HasteModuleMap = require('./ModuleMap');
 
 const crypto = require('crypto');
 const execSync = require('child_process').execSync;
@@ -64,6 +64,8 @@ type InternalOptions = {
   roots: Array<string>,
   useWatchman: boolean,
 };
+
+export type ModuleMap = HasteModuleMap;
 
 const NODE_MODULES = path.sep + 'node_modules' + path.sep;
 const VERSION = require('../package.json').version;
@@ -223,7 +225,7 @@ class HasteMap {
         .then(internalHasteMap => ({
           hasteFS: new HasteFS(internalHasteMap.files),
           moduleMap:
-            new ModuleMap(internalHasteMap.map, internalHasteMap.mocks),
+            new HasteModuleMap(internalHasteMap.map, internalHasteMap.mocks),
           __hasteMapForTest: isTest && internalHasteMap,
         }));
     }
@@ -239,7 +241,7 @@ class HasteMap {
 
   readModuleMap(): ModuleMap {
     const data = this.read();
-    return new ModuleMap(data.map, data.mocks);
+    return new HasteModuleMap(data.map, data.mocks);
   }
 
   /**

--- a/packages/jest-jasmine2/src/index.js
+++ b/packages/jest-jasmine2/src/index.js
@@ -12,7 +12,7 @@
 import type {Config} from 'types/Config';
 import type {Environment} from 'types/Environment';
 import type {TestResult} from 'types/TestResult';
-import type Runtime from '../../jest-runtime/src';
+import type Runtime from 'jest-runtime';
 
 const JasmineReporter = require('./reporter');
 

--- a/packages/jest-jasmine2/src/reporter.js
+++ b/packages/jest-jasmine2/src/reporter.js
@@ -92,19 +92,30 @@ class Jasmine2Reporter {
     });
 
     const testResult = {
-      failureMessage: null,
+      console: null,
+      failureMessage: formatResultsErrors(
+        testResults,
+        this._config,
+        this._testPath,
+      ),
       numFailingTests,
       numPassingTests,
       numPendingTests,
+      perfStats: {
+        end: 0,
+        start: 0,
+      },
+      snapshot: {
+        added: 0,
+        fileDeleted: false,
+        matched: 0,
+        unchecked: 0,
+        unmatched: 0,
+        updated: 0,
+      },
+      testFilePath: this._testPath,
       testResults,
-      snapshot: {},
     };
-
-    testResult.failureMessage = formatResultsErrors(
-      testResult,
-      this._config,
-      this._testPath,
-    );
 
     this._resolve(testResult);
   }

--- a/packages/jest-matchers/src/__tests__/__snapshots__/toThrowMatchers-test.js.snap
+++ b/packages/jest-matchers/src/__tests__/__snapshots__/toThrowMatchers-test.js.snap
@@ -32,7 +32,7 @@ exports[`.toThrow() invalid arguments 1`] = `
 Unexpected argument passed.
 Expected: [32m\"string\"[39m, [32m\"Error (type)\"[39m or [32m\"regexp\"[39m.
 Got:
-  number: [32m111[39m"
+  string: [32m\"111\"[39m"
 `;
 
 exports[`.toThrow() regexp did not throw at all 1`] = `
@@ -125,7 +125,7 @@ exports[`.toThrowError() invalid arguments 1`] = `
 Unexpected argument passed.
 Expected: [32m\"string\"[39m, [32m\"Error (type)\"[39m or [32m\"regexp\"[39m.
 Got:
-  number: [32m111[39m"
+  string: [32m\"111\"[39m"
 `;
 
 exports[`.toThrowError() regexp did not throw at all 1`] = `

--- a/packages/jest-matchers/src/matchers.js
+++ b/packages/jest-matchers/src/matchers.js
@@ -365,8 +365,7 @@ const matchers: MatchersObject = {
       );
     }
 
-    const isString = typeof expected == 'string';
-    if (!(expected instanceof RegExp) && !isString) {
+    if (!(expected instanceof RegExp) && !(typeof expected === 'string')) {
       throw new Error(
         matcherHint('[.not].toMatch', 'string', 'expected') + '\n\n' +
         `${EXPECTED_COLOR('expected')} value must be a string or a regular expression.\n` +
@@ -374,8 +373,11 @@ const matchers: MatchersObject = {
       );
     }
 
-    const pass = new RegExp(isString ? escapeStrForRegex(expected) : expected)
-      .test(received);
+    const pass = new RegExp(
+      typeof expected === 'string'
+        ? escapeStrForRegex(expected)
+        : expected,
+      ).test(received);
     const message = pass
       ? () => matcherHint('.not.toMatch') +
         `\n\nExpected value not to match:\n` +

--- a/packages/jest-matchers/src/spyMatchers.js
+++ b/packages/jest-matchers/src/spyMatchers.js
@@ -126,12 +126,18 @@ const spyMatchers: MatchersObject = {
       : received.mock.calls.length;
     const pass = count === expected;
     const message = pass
-      ? matcherHint('.not' + matcherName, RECEIVED_NAME[type], expected) +
+      ? matcherHint(
+          '.not' +
+          matcherName,
+          RECEIVED_NAME[type],
+          String(expected),
+        ) +
         `\n\n` +
         `Expected ${type} not to be called ` +
         `${EXPECTED_COLOR(pluralize('time', expected))}, but it was` +
         ` called exactly ${RECEIVED_COLOR(pluralize('time', count))}.`
-      : matcherHint(matcherName, RECEIVED_NAME[type], expected) + '\n\n' +
+      : matcherHint(matcherName, RECEIVED_NAME[type], String(expected)) +
+        '\n\n' +
         `Expected ${type} to have been called ` +
         `${EXPECTED_COLOR(pluralize('time', expected))},` +
         ` but it was called ${RECEIVED_COLOR(pluralize('time', count))}.`;

--- a/packages/jest-matchers/src/toThrowMatchers.js
+++ b/packages/jest-matchers/src/toThrowMatchers.js
@@ -66,7 +66,7 @@ const createMatcher = matcherName =>
         matcherHint('.not' + matcherName, 'function', getType(value)) + '\n\n' +
         'Unexpected argument passed.\nExpected: ' +
         `${printExpected('string')}, ${printExpected('Error (type)')} or ${printExpected('regexp')}.\n` +
-        printWithType('Got', expected, printExpected),
+        printWithType('Got', String(expected), printExpected),
       );
     }
   };
@@ -148,7 +148,11 @@ const printActualErrorMessage = error => {
     return (
       `Instead, it threw:\n` +
       RECEIVED_COLOR(
-        '  ' + message + formatStackTrace(stack, {rootDir: process.cwd()}),
+        '  ' + message + formatStackTrace(stack, {
+          noStackTrace: false,
+          rootDir: process.cwd(),
+          testRegex: '',
+        }),
       )
     );
   }

--- a/packages/jest-mock/src/index.js
+++ b/packages/jest-mock/src/index.js
@@ -26,7 +26,6 @@ type MockFunctionState = {
   calls: Array<Array<any>>,
 };
 
-
 const MOCK_CONSTRUCTOR_NAME = 'mockConstructor';
 
 // $FlowFixMe

--- a/packages/jest-resolve-dependencies/src/index.js
+++ b/packages/jest-resolve-dependencies/src/index.js
@@ -12,7 +12,7 @@
 
 import type {HasteFS} from 'types/HasteMap';
 import type {Path} from 'types/Config';
-import type Resolver from '../../jest-resolve/src';
+import type Resolver from 'jest-resolve';
 
 const fileExists = require('jest-file-exists');
 

--- a/packages/jest-resolve/src/index.js
+++ b/packages/jest-resolve/src/index.js
@@ -11,7 +11,7 @@
 'use strict';
 
 import type {Path} from 'types/Config';
-import type ModuleMap from '../../jest-haste-map/src/ModuleMap';
+import type {ModuleMap} from 'jest-haste-map';
 
 const nodeModulesPaths = require('resolve/lib/node-modules-paths');
 const path = require('path');
@@ -26,7 +26,7 @@ type ResolverConfig = {
   moduleDirectories: Array<string>,
   moduleNameMapper: ?{[key: string]: RegExp},
   modulePaths: Array<Path>,
-  platforms: Array<string>,
+  platforms?: Array<string>,
 };
 
 type FindNodeModuleConfig = {

--- a/packages/jest-runtime/src/index.js
+++ b/packages/jest-runtime/src/index.js
@@ -15,12 +15,11 @@ import type {Console} from 'console';
 import type {Environment} from 'types/Environment';
 import type {HasteContext} from 'types/HasteMap';
 import type {Script} from 'vm';
-import type ModuleMap from '../../jest-haste-map/src/ModuleMap';
-import type Resolver from '../../jest-resolve/src';
-import type ModuleMocker from '../../jest-mock/src';
+import type {ModuleMap} from 'jest-haste-map';
+import type ModuleMocker from 'jest-mock';
 
 const HasteMap = require('jest-haste-map');
-const ResolverClass = require('jest-resolve');
+const Resolver = require('jest-resolve');
 
 const fs = require('graceful-fs');
 const path = require('path');
@@ -149,6 +148,19 @@ class Runtime {
     }
   }
 
+  static shouldInstrument(filename: Path, config: Config) {
+    return shouldInstrument(filename, config);
+  }
+
+  static transformSource(
+    filename: Path,
+    config: Config,
+    content: string,
+    instrument: boolean,
+  ) {
+    return transform.transformSource(filename, config, content, instrument);
+  }
+
   static createHasteContext(
     config: Config,
     options: {
@@ -192,6 +204,7 @@ class Runtime {
       platforms: config.haste.platforms || ['ios', 'android'],
       providesModuleNodeModules: config.haste.providesModuleNodeModules,
       resetCache: options && options.resetCache,
+      retainAllFiles: false,
       roots: config.testPathDirs,
       useWatchman: config.watchman,
     });
@@ -201,7 +214,7 @@ class Runtime {
     config: Config,
     moduleMap: ModuleMap,
   ): Resolver {
-    return new ResolverClass(moduleMap, {
+    return new Resolver(moduleMap, {
       browser: config.browser,
       defaultPlatform: config.haste.defaultPlatform,
       extensions: config.moduleFileExtensions.map(extension => '.' + extension),
@@ -770,5 +783,3 @@ class Runtime {
 }
 
 module.exports = Runtime;
-(module.exports: any).shouldInstrument = shouldInstrument;
-(module.exports :any).transformSource = transform.transformSource;

--- a/packages/jest-snapshot/package.json
+++ b/packages/jest-snapshot/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "jest-diff": "^15.1.0",
     "jest-file-exists": "^15.0.0",
+    "jest-matcher-utils": "15.1.0",
     "jest-util": "^15.1.1",
     "natural-compare": "^1.4.0",
     "pretty-format": "~4.0.0"

--- a/packages/jest-snapshot/src/matcher.js
+++ b/packages/jest-snapshot/src/matcher.js
@@ -13,6 +13,11 @@ import type {Path} from 'types/Config';
 import type {SnapshotState} from './SnapshotState';
 
 const diff = require('jest-diff');
+const {
+  EXPECTED_COLOR,
+  matcherHint,
+  RECEIVED_COLOR,
+} = require('jest-matcher-utils');
 
 type CompareResult = {
   pass: boolean,
@@ -70,15 +75,23 @@ module.exports = (
         pass = matches.pass;
         if (!pass) {
           snapshotState.unmatched++;
+          const expectedString = matches.expected.trim();
+          const actualString = matches.actual.trim();
+          const diffMessage = diff(
+            expectedString,
+            actualString,
+            {
+              aAnnotation: 'Snapshot',
+              bAnnotation: 'Received',
+            },
+          );
           message =
-            `Received value does not match the stored snapshot ${count}.\n\n` +
-            String(diff(
-              matches.expected.trim(),
-              matches.actual.trim(),
-              {
-                aAnnotation: 'Snapshot',
-                bAnnotation: 'Received',
-              },
+            matcherHint('.toMatchSnapshot', 'value', '') + '\n\n' +
+            `${RECEIVED_COLOR('Received value')} does not match ` +
+            `${EXPECTED_COLOR('stored snapshot ' + count)}.\n\n` +
+            (diffMessage || (
+              RECEIVED_COLOR('- ' + expectedString) + '\n' +
+              EXPECTED_COLOR('+ ' + actualString)
             ));
         } else {
           snapshotState.matched++;

--- a/packages/jest-snapshot/src/matcher.js
+++ b/packages/jest-snapshot/src/matcher.js
@@ -72,14 +72,14 @@ module.exports = (
           snapshotState.unmatched++;
           message =
             `Received value does not match the stored snapshot ${count}.\n\n` +
-            diff(
+            String(diff(
               matches.expected.trim(),
               matches.actual.trim(),
               {
                 aAnnotation: 'Snapshot',
                 bAnnotation: 'Received',
               },
-            );
+            ));
         } else {
           snapshotState.matched++;
         }

--- a/packages/jest-util/src/FakeTimers.js
+++ b/packages/jest-util/src/FakeTimers.js
@@ -63,7 +63,7 @@ class FakeTimers {
     global: Global,
     moduleMocker: ModuleMocker,
     config: Config,
-    maxLoops: number,
+    maxLoops?: number,
   ) {
 
     this._global = global;

--- a/packages/jest-util/src/__tests__/FakeTimers-test.js
+++ b/packages/jest-util/src/__tests__/FakeTimers-test.js
@@ -337,7 +337,8 @@ describe('FakeTimers', () => {
       console.warn = jest.fn();
       const timers = new FakeTimers(global, moduleMocker, {rootDir: __dirname});
       timers.runAllTimers();
-      expect(console.warn.mock.calls[0][0]).toMatchSnapshot();
+      expect(console.warn.mock.calls[0][0].split('\n').slice(0, -3).join('\n'))
+        .toMatchSnapshot();
       console.warn = consoleWarn;
     });
 

--- a/packages/jest-util/src/__tests__/__snapshots__/FakeTimers-test.js.snap
+++ b/packages/jest-util/src/__tests__/__snapshots__/FakeTimers-test.js.snap
@@ -1,8 +1,5 @@
 exports[`FakeTimers runAllTimers warns when trying to advance timers while real timers are used 1`] = `
 "A function to advance timers was called but the timers API is not mocked with fake timers. Call \`jest.useFakeTimers()\` in this test or enable fake timers globally by setting \`\"timers\": \"fake\"\` in the configuration file. This warning is likely a result of a default configuration change in Jest 15.
 
-Release Blog Post: https://facebook.github.io/jest/blog/2016/09/01/jest-15.html
-Stack Trace:
-      Error
-      [2mat FakeTimers._checkFakeTimers ([22m../FakeTimers.js[2m:352:43)[22m"
+Release Blog Post: https://facebook.github.io/jest/blog/2016/09/01/jest-15.html"
 `;

--- a/packages/jest-util/src/__tests__/messages-test.js
+++ b/packages/jest-util/src/__tests__/messages-test.js
@@ -24,17 +24,15 @@ const windowsStackTrace =
   at attemptAsync (..\\jest-jasmine2\\vendor\\jasmine-2.4.1.js:1919:24)`;
 
 it('should exclude jasmine from stack trace for windows paths', () => {
-  const messages = formatResultsErrors({
-    testResults: [
-      {
-        ancestorTitles: [],
-        failureMessages: [
-          windowsStackTrace,
-        ],
-        title: 'windows test',
-      },
-    ],
-  }, {
+  const messages = formatResultsErrors([
+    {
+      ancestorTitles: [],
+      failureMessages: [
+        windowsStackTrace,
+      ],
+      title: 'windows test',
+    },
+  ], {
     rootDir: '',
   });
 

--- a/packages/jest-util/src/clearLine.js
+++ b/packages/jest-util/src/clearLine.js
@@ -10,7 +10,7 @@
 /* global stream$Writable */
 'use strict';
 
-module.exports = (stream: stream$Writable) => {
+module.exports = (stream: stream$Writable | tty$WriteStream) => {
   if (process.stdout.isTTY) {
     stream.write('\x1b[999D\x1b[K');
   }

--- a/types/TestResult.js
+++ b/types/TestResult.js
@@ -65,7 +65,7 @@ export type Suite = {
 };
 
 export type TestResult = {
-  console?: ConsoleBuffer,
+  console: ?ConsoleBuffer,
   coverage?: Coverage,
   memoryUsage?: Bytes,
   failureMessage: ?string,
@@ -84,7 +84,7 @@ export type TestResult = {
     unmatched: number,
     updated: number,
   },
-  testExecError: Error,
+  testExecError?: Error,
   testFilePath: string,
   testResults: Array<AssertionResult>,
 };


### PR DESCRIPTION
**Summary**
Because of how lerna hooks up node modules (previously with one index file and now with a symlink), Flow was unable to follow the modules properly. This diff adds a module mapper in the flowconfig and fixes up all the invalid Flow annotations that we accumulated over time.

**Test plan**
flow + jest

cc @hzoo this might be interesting to you.