### PR TITLE
Throw on module collision

### DIFF
--- a/packages/jest-haste-map/src/__tests__/__snapshots__/index-test.js.snap
+++ b/packages/jest-haste-map/src/__tests__/__snapshots__/index-test.js.snap
@@ -1,3 +1,11 @@
+exports[`HasteMap throws on duplicate module ids if "throwOnModuleCollision" is set to true 1`] = `
+[Error: jest-haste-map: @providesModule naming collision:
+  Duplicate module name: Strawberry
+  Paths: /fruits/raspberry.js collides with /fruits/strawberry.js
+
+This error is caused by a @providesModule declaration with the same name across two different files.]
+`;
+
 exports[`HasteMap tries to crawl using node as a fallback 1`] = `
 "jest-haste-map: Watchman crawl failed. Retrying once with node crawler.
   Usually this happens when watchman isn\'t running. Create an empty \`.watchmanconfig\` file in your project\'s root folder or initialize a git or hg repository in your project.

--- a/packages/jest-haste-map/src/__tests__/__snapshots__/index-test.js.snap
+++ b/packages/jest-haste-map/src/__tests__/__snapshots__/index-test.js.snap
@@ -3,7 +3,7 @@ exports[`HasteMap throws on duplicate module ids if "throwOnModuleCollision" is 
   Duplicate module name: Strawberry
   Paths: /fruits/raspberry.js collides with /fruits/strawberry.js
 
- This error is caused by a @providesModule declaration with the same name across two different files.]
+This error is caused by a @providesModule declaration with the same name across two different files.]
 `;
 
 exports[`HasteMap tries to crawl using node as a fallback 1`] = `
@@ -17,5 +17,5 @@ exports[`HasteMap warns on duplicate module ids 1`] = `
   Duplicate module name: Strawberry
   Paths: /fruits/raspberry.js collides with /fruits/strawberry.js
 
- This warning is caused by a @providesModule declaration with the same name across two different files."
+This warning is caused by a @providesModule declaration with the same name across two different files."
 `;

--- a/packages/jest-haste-map/src/__tests__/__snapshots__/index-test.js.snap
+++ b/packages/jest-haste-map/src/__tests__/__snapshots__/index-test.js.snap
@@ -3,7 +3,7 @@ exports[`HasteMap throws on duplicate module ids if "throwOnModuleCollision" is 
   Duplicate module name: Strawberry
   Paths: /fruits/raspberry.js collides with /fruits/strawberry.js
 
-This error is caused by a @providesModule declaration with the same name across two different files.]
+ This error is caused by a @providesModule declaration with the same name across two different files.]
 `;
 
 exports[`HasteMap tries to crawl using node as a fallback 1`] = `
@@ -17,5 +17,5 @@ exports[`HasteMap warns on duplicate module ids 1`] = `
   Duplicate module name: Strawberry
   Paths: /fruits/raspberry.js collides with /fruits/strawberry.js
 
-This warning is caused by a @providesModule declaration with the same name across two different files."
+ This warning is caused by a @providesModule declaration with the same name across two different files."
 `;

--- a/packages/jest-haste-map/src/__tests__/index-test.js
+++ b/packages/jest-haste-map/src/__tests__/index-test.js
@@ -318,6 +318,22 @@ describe('HasteMap', () => {
       });
   });
 
+  it('throws on duplicate module ids if "throwOnModuleCollision" is set to true', () => {
+    // Raspberry thinks it is a Strawberry
+    mockFs['/fruits/raspberry.js'] = [
+      '/**',
+      ' * @providesModule Strawberry',
+      ' */',
+      'const Banana = require("Banana");',
+    ].join('\n');
+
+    return new HasteMap(Object.assign({throwOnModuleCollision: true}, defaultConfig))
+      .build()
+        .catch(err => {
+          expect(err).toMatchSnapshot();
+        });
+  })
+
   it('splits up modules by platform', () => {
     mockFs = Object.create(null);
     mockFs['/fruits/strawberry.js'] = [

--- a/packages/jest-haste-map/src/__tests__/index-test.js
+++ b/packages/jest-haste-map/src/__tests__/index-test.js
@@ -327,12 +327,12 @@ describe('HasteMap', () => {
       'const Banana = require("Banana");',
     ].join('\n');
 
-    return new HasteMap(Object.assign({throwOnModuleCollision: true}, defaultConfig))
-      .build()
-        .catch(err => {
-          expect(err).toMatchSnapshot();
-        });
-  })
+    return new HasteMap(
+      Object.assign({throwOnModuleCollision: true}, defaultConfig),
+    ).build().catch(err => {
+      expect(err).toMatchSnapshot();
+    });
+  });
 
   it('splits up modules by platform', () => {
     mockFs = Object.create(null);

--- a/packages/jest-haste-map/src/index.js
+++ b/packages/jest-haste-map/src/index.js
@@ -48,8 +48,8 @@ type Options = {
   resetCache?: boolean,
   retainAllFiles: boolean,
   roots: Array<string>,
-  useWatchman?: boolean,
   throwOnModuleCollision?: boolean,
+  useWatchman?: boolean,
 };
 
 type InternalOptions = {
@@ -188,9 +188,9 @@ class HasteMap {
       resetCache: options.resetCache,
       retainAllFiles: options.retainAllFiles,
       roots: options.roots,
+      throwOnModuleCollision: !!options.throwOnModuleCollision,
       useWatchman:
         options.useWatchman == null ? true : options.useWatchman,
-      throwOnModuleCollision: options.throwOnModuleCollision,
     };
     this._console = options.console || global.console;
 
@@ -275,24 +275,18 @@ class HasteMap {
         getPlatformExtension(module[H.PATH]) || H.GENERIC_PLATFORM;
       const existingModule = moduleMap[platform];
       if (existingModule && existingModule[H.PATH] !== module[H.PATH]) {
-        if (this._options.throwOnModuleCollision) {
-          throw new Error(
-            `jest-haste-map: @providesModule naming collision:\n` +
-            `  Duplicate module name: ${id}\n` +
-            `  Paths: ${module[H.PATH]} collides with ` +
-            `${existingModule[H.PATH]}\n\n` +
-            `This error is caused by a @providesModule declaration ` +
-            `with the same name across two different files.`,
-          );
-        }
-        this._console.warn(
+        const message =
           `jest-haste-map: @providesModule naming collision:\n` +
           `  Duplicate module name: ${id}\n` +
           `  Paths: ${module[H.PATH]} collides with ` +
-          `${existingModule[H.PATH]}\n\n` +
-          `This warning is caused by a @providesModule declaration ` +
-          `with the same name across two different files.`,
-        );
+          `${existingModule[H.PATH]}\n\n This ` +
+          `${this._options.throwOnModuleCollision ? 'error' : 'warning'} ` +
+          `is caused by a @providesModule declaration ` +
+          `with the same name across two different files.`;
+        if (this._options.throwOnModuleCollision) {
+          throw new Error(message);
+        }
+        this._console.warn(message);
         return;
       }
 

--- a/packages/jest-haste-map/src/index.js
+++ b/packages/jest-haste-map/src/index.js
@@ -49,6 +49,7 @@ type Options = {
   retainAllFiles: boolean,
   roots: Array<string>,
   useWatchman?: boolean,
+  throwOnModuleCollision?: boolean,
 };
 
 type InternalOptions = {
@@ -189,6 +190,7 @@ class HasteMap {
       roots: options.roots,
       useWatchman:
         options.useWatchman == null ? true : options.useWatchman,
+      throwOnModuleCollision: options.throwOnModuleCollision,
     };
     this._console = options.console || global.console;
 
@@ -273,6 +275,16 @@ class HasteMap {
         getPlatformExtension(module[H.PATH]) || H.GENERIC_PLATFORM;
       const existingModule = moduleMap[platform];
       if (existingModule && existingModule[H.PATH] !== module[H.PATH]) {
+        if (this._options.throwOnModuleCollision) {
+          throw new Error(
+            `jest-haste-map: @providesModule naming collision:\n` +
+            `  Duplicate module name: ${id}\n` +
+            `  Paths: ${module[H.PATH]} collides with ` +
+            `${existingModule[H.PATH]}\n\n` +
+            `This error is caused by a @providesModule declaration ` +
+            `with the same name across two different files.`,
+          );
+        }
         this._console.warn(
           `jest-haste-map: @providesModule naming collision:\n` +
           `  Duplicate module name: ${id}\n` +

--- a/packages/jest-haste-map/src/index.js
+++ b/packages/jest-haste-map/src/index.js
@@ -279,7 +279,7 @@ class HasteMap {
           `jest-haste-map: @providesModule naming collision:\n` +
           `  Duplicate module name: ${id}\n` +
           `  Paths: ${module[H.PATH]} collides with ` +
-          `${existingModule[H.PATH]}\n\n This ` +
+          `${existingModule[H.PATH]}\n\nThis ` +
           `${this._options.throwOnModuleCollision ? 'error' : 'warning'} ` +
           `is caused by a @providesModule declaration ` +
           `with the same name across two different files.`;


### PR DESCRIPTION
### Summary
Add `throwOnModuleCollision` option to `jest-haste-map`. Setting this to `true` will cause it to throw an error (rather than output a warning to console) when a module name collision is detected. This is useful for scenarios where determinism is critical.

### Test plan
`npm test`