### PR TITLE
Printing and Snapshot Fixes

### DIFF
--- a/examples/react-native/__tests__/__snapshots__/Intro-test.js.snap
+++ b/examples/react-native/__tests__/__snapshots__/Intro-test.js.snap
@@ -63,17 +63,17 @@ exports[`test renders the ListView component 1`] = `
     }
   }
   initialListSize={10}
-  onContentSizeChange={[Function bound _onContentSizeChange]}
+  onContentSizeChange={[Function]}
   onEndReachedThreshold={1000}
   onKeyboardDidHide={undefined}
   onKeyboardDidShow={undefined}
   onKeyboardWillHide={undefined}
   onKeyboardWillShow={undefined}
-  onLayout={[Function bound _onLayout]}
-  onScroll={[Function bound _onScroll]}
+  onLayout={[Function]}
+  onScroll={[Function]}
   pageSize={1}
   removeClippedSubviews={true}
-  renderRow={[Function renderRow]}
+  renderRow={[Function]}
   scrollEventThrottle={50}
   scrollRenderAheadDistance={1000}
   stickyHeaderIndices={Array []}>

--- a/examples/snapshot/__tests__/__snapshots__/Link.react-test.js.snap
+++ b/examples/snapshot/__tests__/__snapshots__/Link.react-test.js.snap
@@ -2,8 +2,8 @@ exports[`test changes the class when hovered 1`] = `
 <a
   className="normal"
   href="http://www.facebook.com"
-  onMouseEnter={[Function bound _onMouseEnter]}
-  onMouseLeave={[Function bound _onMouseLeave]}>
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}>
   Facebook
 </a>
 `;
@@ -12,8 +12,8 @@ exports[`test changes the class when hovered 2`] = `
 <a
   className="hovered"
   href="http://www.facebook.com"
-  onMouseEnter={[Function bound _onMouseEnter]}
-  onMouseLeave={[Function bound _onMouseLeave]}>
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}>
   Facebook
 </a>
 `;
@@ -22,8 +22,8 @@ exports[`test changes the class when hovered 3`] = `
 <a
   className="normal"
   href="http://www.facebook.com"
-  onMouseEnter={[Function bound _onMouseEnter]}
-  onMouseLeave={[Function bound _onMouseLeave]}>
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}>
   Facebook
 </a>
 `;
@@ -32,8 +32,8 @@ exports[`test properly escapes quotes 1`] = `
 <a
   className="normal"
   href="#"
-  onMouseEnter={[Function bound _onMouseEnter]}
-  onMouseLeave={[Function bound _onMouseLeave]}>
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}>
   \"Facebook\" \\\'is \\ \'awesome\'
 </a>
 `;
@@ -42,8 +42,8 @@ exports[`test renders as an anchor when no page is set 1`] = `
 <a
   className="normal"
   href="#"
-  onMouseEnter={[Function bound _onMouseEnter]}
-  onMouseLeave={[Function bound _onMouseLeave]}>
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}>
   Facebook
 </a>
 `;
@@ -52,8 +52,8 @@ exports[`test renders correctly 1`] = `
 <a
   className="normal"
   href="http://www.facebook.com"
-  onMouseEnter={[Function bound _onMouseEnter]}
-  onMouseLeave={[Function bound _onMouseLeave]}>
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}>
   Facebook
 </a>
 `;

--- a/packages/jest-diff/package.json
+++ b/packages/jest-diff/package.json
@@ -11,7 +11,7 @@
     "chalk": "^1.1.3",
     "diff": "^3.0.0",
     "jest-matcher-utils": "^15.1.0",
-    "pretty-format": "~4.0.0"
+    "pretty-format": "~4.2.1"
   },
   "scripts": {
     "test": "../../packages/jest-cli/bin/jest.js"

--- a/packages/jest-diff/src/__tests__/__snapshots__/diff-test.js.snap
+++ b/packages/jest-diff/src/__tests__/__snapshots__/diff-test.js.snap
@@ -1,0 +1,15 @@
+exports[`test falls back to not call toJSON if objects look identical 1`] = `
+"[2mCompared values serialize to the same structure.
+Printing internal object structure without calling \`toJSON\` instead.[22m
+
+[32m- Expected[39m
+[31m+ Received[39m
+
+[2m [22m [2mObject {[22m
+[32m-[39m [32m  \"line\": 1,[39m
+[31m+[39m [31m  \"line\": 2,[39m
+[2m [22m [2m  \"toJSON\": [Function toJSON],[22m
+[2m [22m [2m}[22m"
+`;
+
+exports[`test prints a fallback message if two objects truly look identical 1`] = `"[2mCompared values have no visual difference.[22m"`;

--- a/packages/jest-diff/src/__tests__/diff-test.js
+++ b/packages/jest-diff/src/__tests__/diff-test.js
@@ -13,6 +13,10 @@
 const diff = require('../');
 const stripAnsi = require('strip-ansi');
 
+const toJSON = function toJSON() {
+  return 'apple';
+};
+
 describe('different types', () => {
   [
     [1, 'a', 'number', 'string'],
@@ -54,7 +58,7 @@ describe('no visual difference', () => {
       `'${JSON.stringify(values[0])}' and '${JSON.stringify(values[1])}'`,
       () => {
         expect(stripAnsi(diff(values[0], values[1]))).toBe(
-          'Compared values have no visual difference',
+          'Compared values have no visual difference.',
         );
       },
     );
@@ -66,6 +70,18 @@ test('oneline strings', () => {
   expect(stripAnsi(diff('ab', 'aa'))).toBe(null);
   expect(diff('a', 'a')).toMatch(/no visual difference/);
   expect(stripAnsi(diff('123456789', '234567890'))).toBe(null);
+});
+
+test('falls back to not call toJSON if objects look identical', () => {
+  const a = {toJSON, line: 1};
+  const b = {toJSON, line: 2};
+  expect(diff(a, b)).toMatchSnapshot();
+});
+
+test('prints a fallback message if two objects truly look identical', () => {
+  const a = {toJSON, line: 2};
+  const b = {toJSON, line: 2};
+  expect(diff(a, b)).toMatchSnapshot();
 });
 
 test('multiline strings', () => {

--- a/packages/jest-diff/src/constants.js
+++ b/packages/jest-diff/src/constants.js
@@ -12,5 +12,11 @@
 
 const chalk = require('chalk');
 
-module.exports.NO_DIFF_MESSAGE =
-  chalk.dim.underline('Compared values have no visual difference');
+exports.NO_DIFF_MESSAGE =
+  chalk.dim('Compared values have no visual difference.');
+
+exports.SIMILAR_MESSAGE =
+  chalk.dim(
+    'Compared values serialize to the same structure.\n' +
+    'Printing internal object structure without calling `toJSON` instead.',
+  );

--- a/packages/jest-diff/src/diffStrings.js
+++ b/packages/jest-diff/src/diffStrings.js
@@ -25,7 +25,7 @@ const getAnnotation = options =>
   chalk.red('+ ' + ((options && options.bAnnotation) || 'Received')) + '\n\n';
 
 // diff characters if oneliner and diff lines if multiline
-function diffStrings(a: string, b: string, options: ?DiffOptions): ?string {
+function diffStrings(a: string, b: string, options: ?DiffOptions): string {
   let isDifferent = false;
 
   // `diff` uses the Myers LCS diff algorithm which runs in O(n+d^2) time

--- a/packages/jest-matcher-utils/package.json
+++ b/packages/jest-matcher-utils/package.json
@@ -12,6 +12,7 @@
     "test": "../../packages/jest-cli/bin/jest.js"
   },
   "dependencies": {
-    "chalk": "^1.1.3"
+    "chalk": "^1.1.3",
+    "pretty-format": "~4.2.1"
   }
 }

--- a/packages/jest-matcher-utils/src/__tests__/__snapshots__/index-test.js.snap
+++ b/packages/jest-matcher-utils/src/__tests__/__snapshots__/index-test.js.snap
@@ -1,0 +1,19 @@
+exports[`.stringify() toJSON errors when comparing two objects 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).toEqual([22m[32mexpected[39m[2m)[22m
+
+Expected value to equal:
+  [32m{\"b\": 1, \"toJSON\": [Function toJSON]}[39m
+Received:
+  [31m{\"a\": 1, \"toJSON\": [Function toJSON]}[39m
+
+Difference:
+
+[32m- Expected[39m
+[31m+ Received[39m
+
+[2m [22m [2mObject {[22m
+[32m-[39m [32m  \"b\": 1,[39m
+[31m+[39m [31m  \"a\": 1,[39m
+[2m [22m [2m  \"toJSON\": [Function toJSON],[22m
+[2m [22m [2m}[22m"
+`;

--- a/packages/jest-matchers/src/__tests__/__snapshots__/matchers-test.js.snap
+++ b/packages/jest-matchers/src/__tests__/__snapshots__/matchers-test.js.snap
@@ -4,7 +4,7 @@ exports[`.toBe() does not crash on circular references 1`] = `
 Expected value to be (using ===):
   [32m{}[39m
 Received:
-  [31m{\"circular\":\"[Circular]\"}[39m
+  [31m{\"circular\": [Circular]}[39m
 
 Difference:
 
@@ -26,24 +26,6 @@ Received:
   [31m\"a\"[39m"
 `;
 
-exports[`.toBe() fails for '"undefined"' with '.not' 1`] = `
-"[2mexpect([22m[31mreceived[39m[2m).not.toBe([22m[32mexpected[39m[2m)[22m
-
-Expected value to not be (using ===):
-  [32m\"undefined\"[39m
-Received:
-  [31m\"undefined\"[39m"
-`;
-
-exports[`.toBe() fails for '[]' with '.not' 1`] = `
-"[2mexpect([22m[31mreceived[39m[2m).not.toBe([22m[32mexpected[39m[2m)[22m
-
-Expected value to not be (using ===):
-  [32m[][39m
-Received:
-  [31m[][39m"
-`;
-
 exports[`.toBe() fails for '{}' with '.not' 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).not.toBe([22m[32mexpected[39m[2m)[22m
 
@@ -60,6 +42,15 @@ Expected value to not be (using ===):
   [32m1[39m
 Received:
   [31m1[39m"
+`;
+
+exports[`.toBe() fails for 'Array []' with '.not' 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).not.toBe([22m[32mexpected[39m[2m)[22m
+
+Expected value to not be (using ===):
+  [32mArray [][39m
+Received:
+  [31mArray [][39m"
 `;
 
 exports[`.toBe() fails for 'false' with '.not' 1`] = `
@@ -80,6 +71,15 @@ Received:
   [31mnull[39m"
 `;
 
+exports[`.toBe() fails for 'undefined' with '.not' 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).not.toBe([22m[32mexpected[39m[2m)[22m
+
+Expected value to not be (using ===):
+  [32mundefined[39m
+Received:
+  [31mundefined[39m"
+`;
+
 exports[`.toBe() fails for: "abc" and "cde" 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).toBe([22m[32mexpected[39m[2m)[22m
 
@@ -89,39 +89,26 @@ Received:
   [31m\"abc\"[39m"
 `;
 
-exports[`.toBe() fails for: [] and [] 1`] = `
+exports[`.toBe() fails for: {"a": 1} and {"a": 1} 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).toBe([22m[32mexpected[39m[2m)[22m
 
 Expected value to be (using ===):
-  [32m[][39m
+  [32m{\"a\": 1}[39m
 Received:
-  [31m[][39m
+  [31m{\"a\": 1}[39m
 
 Difference:
 
-[2m[4mCompared values have no visual difference[24m[22m"
+[2mCompared values have no visual difference.[22m"
 `;
 
-exports[`.toBe() fails for: {"a":1} and {"a":1} 1`] = `
+exports[`.toBe() fails for: {"a": 1} and {"a": 5} 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).toBe([22m[32mexpected[39m[2m)[22m
 
 Expected value to be (using ===):
-  [32m{\"a\":1}[39m
+  [32m{\"a\": 5}[39m
 Received:
-  [31m{\"a\":1}[39m
-
-Difference:
-
-[2m[4mCompared values have no visual difference[24m[22m"
-`;
-
-exports[`.toBe() fails for: {"a":1} and {"a":5} 1`] = `
-"[2mexpect([22m[31mreceived[39m[2m).toBe([22m[32mexpected[39m[2m)[22m
-
-Expected value to be (using ===):
-  [32m{\"a\":5}[39m
-Received:
-  [31m{\"a\":1}[39m
+  [31m{\"a\": 1}[39m
 
 Difference:
 
@@ -144,7 +131,7 @@ Received:
 
 Difference:
 
-[2m[4mCompared values have no visual difference[24m[22m"
+[2mCompared values have no visual difference.[22m"
 `;
 
 exports[`.toBe() fails for: 1 and 2 1`] = `
@@ -156,11 +143,24 @@ Received:
   [31m1[39m"
 `;
 
-exports[`.toBe() fails for: null and "undefined" 1`] = `
+exports[`.toBe() fails for: Array [] and Array [] 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).toBe([22m[32mexpected[39m[2m)[22m
 
 Expected value to be (using ===):
-  [32m\"undefined\"[39m
+  [32mArray [][39m
+Received:
+  [31mArray [][39m
+
+Difference:
+
+[2mCompared values have no visual difference.[22m"
+`;
+
+exports[`.toBe() fails for: null and undefined 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).toBe([22m[32mexpected[39m[2m)[22m
+
+Expected value to be (using ===):
+  [32mundefined[39m
 Received:
   [31mnull[39m
 
@@ -288,34 +288,6 @@ Received:
   [31m1.23[39m"
 `;
 
-exports[`.toBeDefined(), .toBeUndefined() '"() => {}"' is defined 1`] = `
-"[2mexpect([22m[31mreceived[39m[2m).not.toBeDefined([22m[2m)[22m
-
-Expected value not to be defined, instead received
-  [31m\"() => {}\"[39m"
-`;
-
-exports[`.toBeDefined(), .toBeUndefined() '"() => {}"' is defined 2`] = `
-"[2mexpect([22m[31mreceived[39m[2m).toBeUndefined([22m[2m)[22m
-
-Expected value to be undefined, instead received
-  [31m\"() => {}\"[39m"
-`;
-
-exports[`.toBeDefined(), .toBeUndefined() '"Infinity"' is defined 1`] = `
-"[2mexpect([22m[31mreceived[39m[2m).not.toBeDefined([22m[2m)[22m
-
-Expected value not to be defined, instead received
-  [31m\"Infinity\"[39m"
-`;
-
-exports[`.toBeDefined(), .toBeUndefined() '"Infinity"' is defined 2`] = `
-"[2mexpect([22m[31mreceived[39m[2m).toBeUndefined([22m[2m)[22m
-
-Expected value to be undefined, instead received
-  [31m\"Infinity\"[39m"
-`;
-
 exports[`.toBeDefined(), .toBeUndefined() '"a"' is defined 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).not.toBeDefined([22m[2m)[22m
 
@@ -330,18 +302,18 @@ Expected value to be undefined, instead received
   [31m\"a\"[39m"
 `;
 
-exports[`.toBeDefined(), .toBeUndefined() '[]' is defined 1`] = `
+exports[`.toBeDefined(), .toBeUndefined() '[Function anonymous]' is defined 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).not.toBeDefined([22m[2m)[22m
 
 Expected value not to be defined, instead received
-  [31m[][39m"
+  [31m[Function anonymous][39m"
 `;
 
-exports[`.toBeDefined(), .toBeUndefined() '[]' is defined 2`] = `
+exports[`.toBeDefined(), .toBeUndefined() '[Function anonymous]' is defined 2`] = `
 "[2mexpect([22m[31mreceived[39m[2m).toBeUndefined([22m[2m)[22m
 
 Expected value to be undefined, instead received
-  [31m[][39m"
+  [31m[Function anonymous][39m"
 `;
 
 exports[`.toBeDefined(), .toBeUndefined() '{}' is defined 1`] = `
@@ -352,20 +324,6 @@ Expected value not to be defined, instead received
 `;
 
 exports[`.toBeDefined(), .toBeUndefined() '{}' is defined 2`] = `
-"[2mexpect([22m[31mreceived[39m[2m).toBeUndefined([22m[2m)[22m
-
-Expected value to be undefined, instead received
-  [31m{}[39m"
-`;
-
-exports[`.toBeDefined(), .toBeUndefined() '{}' is defined 3`] = `
-"[2mexpect([22m[31mreceived[39m[2m).not.toBeDefined([22m[2m)[22m
-
-Expected value not to be defined, instead received
-  [31m{}[39m"
-`;
-
-exports[`.toBeDefined(), .toBeUndefined() '{}' is defined 4`] = `
 "[2mexpect([22m[31mreceived[39m[2m).toBeUndefined([22m[2m)[22m
 
 Expected value to be undefined, instead received
@@ -400,6 +358,48 @@ Expected value to be undefined, instead received
   [31m1[39m"
 `;
 
+exports[`.toBeDefined(), .toBeUndefined() 'Array []' is defined 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).not.toBeDefined([22m[2m)[22m
+
+Expected value not to be defined, instead received
+  [31mArray [][39m"
+`;
+
+exports[`.toBeDefined(), .toBeUndefined() 'Array []' is defined 2`] = `
+"[2mexpect([22m[31mreceived[39m[2m).toBeUndefined([22m[2m)[22m
+
+Expected value to be undefined, instead received
+  [31mArray [][39m"
+`;
+
+exports[`.toBeDefined(), .toBeUndefined() 'Infinity' is defined 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).not.toBeDefined([22m[2m)[22m
+
+Expected value not to be defined, instead received
+  [31mInfinity[39m"
+`;
+
+exports[`.toBeDefined(), .toBeUndefined() 'Infinity' is defined 2`] = `
+"[2mexpect([22m[31mreceived[39m[2m).toBeUndefined([22m[2m)[22m
+
+Expected value to be undefined, instead received
+  [31mInfinity[39m"
+`;
+
+exports[`.toBeDefined(), .toBeUndefined() 'Map {}' is defined 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).not.toBeDefined([22m[2m)[22m
+
+Expected value not to be defined, instead received
+  [31mMap {}[39m"
+`;
+
+exports[`.toBeDefined(), .toBeUndefined() 'Map {}' is defined 2`] = `
+"[2mexpect([22m[31mreceived[39m[2m).toBeUndefined([22m[2m)[22m
+
+Expected value to be undefined, instead received
+  [31mMap {}[39m"
+`;
+
 exports[`.toBeDefined(), .toBeUndefined() 'true' is defined 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).not.toBeDefined([22m[2m)[22m
 
@@ -418,32 +418,32 @@ exports[`.toBeDefined(), .toBeUndefined() undefined is undefined 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).toBeDefined([22m[2m)[22m
 
 Expected value to be defined, instead received
-  [31m\"undefined\"[39m"
+  [31mundefined[39m"
 `;
 
 exports[`.toBeDefined(), .toBeUndefined() undefined is undefined 2`] = `
 "[2mexpect([22m[31mreceived[39m[2m).not.toBeUndefined([22m[2m)[22m
 
 Expected value not to be undefined, instead received
-  [31m\"undefined\"[39m"
+  [31mundefined[39m"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() equal numbers: [-Infinity, -Infinity] 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).not.toBeGreaterThanOrEqual([22m[32mexpected[39m[2m)[22m
 
 Expected value not to be greater than or equal:
-  [32m\"-Infinity\"[39m
+  [32m-Infinity[39m
 Received:
-  [31m\"-Infinity\"[39m"
+  [31m-Infinity[39m"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() equal numbers: [-Infinity, -Infinity] 2`] = `
 "[2mexpect([22m[31mreceived[39m[2m).not.toBeLessThanOrEqual([22m[32mexpected[39m[2m)[22m
 
 Expected value not to be less than or equal:
-  [32m\"-Infinity\"[39m
+  [32m-Infinity[39m
 Received:
-  [31m\"-Infinity\"[39m"
+  [31m-Infinity[39m"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() equal numbers: [1, 1] 1`] = `
@@ -504,90 +504,90 @@ exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLe
 "[2mexpect([22m[31mreceived[39m[2m).not.toBeGreaterThanOrEqual([22m[32mexpected[39m[2m)[22m
 
 Expected value not to be greater than or equal:
-  [32m\"Infinity\"[39m
+  [32mInfinity[39m
 Received:
-  [31m\"Infinity\"[39m"
+  [31mInfinity[39m"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() equal numbers: [Infinity, Infinity] 2`] = `
 "[2mexpect([22m[31mreceived[39m[2m).not.toBeLessThanOrEqual([22m[32mexpected[39m[2m)[22m
 
 Expected value not to be less than or equal:
-  [32m\"Infinity\"[39m
+  [32mInfinity[39m
 Received:
-  [31m\"Infinity\"[39m"
+  [31mInfinity[39m"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [-Infinity, Infinity] 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).toBeGreaterThan([22m[32mexpected[39m[2m)[22m
 
 Expected value to be greater than:
-  [32m\"Infinity\"[39m
+  [32mInfinity[39m
 Received:
-  [31m\"-Infinity\"[39m"
+  [31m-Infinity[39m"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [-Infinity, Infinity] 2`] = `
 "[2mexpect([22m[31mreceived[39m[2m).not.toBeLessThan([22m[32mexpected[39m[2m)[22m
 
 Expected value not to be less than:
-  [32m\"Infinity\"[39m
+  [32mInfinity[39m
 Received:
-  [31m\"-Infinity\"[39m"
+  [31m-Infinity[39m"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [-Infinity, Infinity] 3`] = `
 "[2mexpect([22m[31mreceived[39m[2m).not.toBeGreaterThan([22m[32mexpected[39m[2m)[22m
 
 Expected value not to be greater than:
-  [32m\"-Infinity\"[39m
+  [32m-Infinity[39m
 Received:
-  [31m\"Infinity\"[39m"
+  [31mInfinity[39m"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [-Infinity, Infinity] 4`] = `
 "[2mexpect([22m[31mreceived[39m[2m).toBeLessThan([22m[32mexpected[39m[2m)[22m
 
 Expected value to be less than:
-  [32m\"-Infinity\"[39m
+  [32m-Infinity[39m
 Received:
-  [31m\"Infinity\"[39m"
+  [31mInfinity[39m"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [-Infinity, Infinity] 5`] = `
 "[2mexpect([22m[31mreceived[39m[2m).toBeGreaterThanOrEqual([22m[32mexpected[39m[2m)[22m
 
 Expected value to be greater than or equal:
-  [32m\"Infinity\"[39m
+  [32mInfinity[39m
 Received:
-  [31m\"-Infinity\"[39m"
+  [31m-Infinity[39m"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [-Infinity, Infinity] 6`] = `
 "[2mexpect([22m[31mreceived[39m[2m).not.toBeLessThanOrEqual([22m[32mexpected[39m[2m)[22m
 
 Expected value not to be less than or equal:
-  [32m\"Infinity\"[39m
+  [32mInfinity[39m
 Received:
-  [31m\"-Infinity\"[39m"
+  [31m-Infinity[39m"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [-Infinity, Infinity] 7`] = `
 "[2mexpect([22m[31mreceived[39m[2m).not.toBeGreaterThanOrEqual([22m[32mexpected[39m[2m)[22m
 
 Expected value not to be greater than or equal:
-  [32m\"-Infinity\"[39m
+  [32m-Infinity[39m
 Received:
-  [31m\"Infinity\"[39m"
+  [31mInfinity[39m"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [-Infinity, Infinity] 8`] = `
 "[2mexpect([22m[31mreceived[39m[2m).toBeLessThanOrEqual([22m[32mexpected[39m[2m)[22m
 
 Expected value to be less than or equal:
-  [32m\"-Infinity\"[39m
+  [32m-Infinity[39m
 Received:
-  [31m\"Infinity\"[39m"
+  [31mInfinity[39m"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [0.1, 0.2] 1`] = `
@@ -1022,7 +1022,7 @@ Received:
   [31m34[39m"
 `;
 
-exports[`.toBeInstanceOf() failing "a" and "function String() { [native code] }" 1`] = `
+exports[`.toBeInstanceOf() failing "a" and [Function String] 1`] = `
 "[2mexpect([22m[31mvalue[39m[2m).toBeInstanceOf([22m[32mconstructor[39m[2m)[22m
 
 Expected value to be an instance of:
@@ -1033,7 +1033,7 @@ Constructor:
   [31m\"String\"[39m"
 `;
 
-exports[`.toBeInstanceOf() failing {} and "class A {}" 1`] = `
+exports[`.toBeInstanceOf() failing {} and [Function A] 1`] = `
 "[2mexpect([22m[31mvalue[39m[2m).toBeInstanceOf([22m[32mconstructor[39m[2m)[22m
 
 Expected value to be an instance of:
@@ -1041,10 +1041,10 @@ Expected value to be an instance of:
 Received:
   [31m{}[39m
 Constructor:
-  [31m\"undefined\"[39m"
+  [31mundefined[39m"
 `;
 
-exports[`.toBeInstanceOf() failing {} and "class B {}" 1`] = `
+exports[`.toBeInstanceOf() failing {} and [Function B] 1`] = `
 "[2mexpect([22m[31mvalue[39m[2m).toBeInstanceOf([22m[32mconstructor[39m[2m)[22m
 
 Expected value to be an instance of:
@@ -1055,7 +1055,7 @@ Constructor:
   [31m\"A\"[39m"
 `;
 
-exports[`.toBeInstanceOf() failing 1 and "function Number() { [native code] }" 1`] = `
+exports[`.toBeInstanceOf() failing 1 and [Function Number] 1`] = `
 "[2mexpect([22m[31mvalue[39m[2m).toBeInstanceOf([22m[32mconstructor[39m[2m)[22m
 
 Expected value to be an instance of:
@@ -1066,7 +1066,7 @@ Constructor:
   [31m\"Number\"[39m"
 `;
 
-exports[`.toBeInstanceOf() failing true and "function Boolean() { [native code] }" 1`] = `
+exports[`.toBeInstanceOf() failing true and [Function Boolean] 1`] = `
 "[2mexpect([22m[31mvalue[39m[2m).toBeInstanceOf([22m[32mconstructor[39m[2m)[22m
 
 Expected value to be an instance of:
@@ -1077,17 +1077,7 @@ Constructor:
   [31m\"Boolean\"[39m"
 `;
 
-exports[`.toBeInstanceOf() passing [] and "function Array() { [native code] }" 1`] = `
-"[2mexpect([22m[31mvalue[39m[2m).not.toBeInstanceOf([22m[32mconstructor[39m[2m)[22m
-
-Expected value not to be an instance of:
-  [32m\"Array\"[39m
-Received:
-  [31m[][39m
-"
-`;
-
-exports[`.toBeInstanceOf() passing {} and "class A {}" 1`] = `
+exports[`.toBeInstanceOf() passing {} and [Function A] 1`] = `
 "[2mexpect([22m[31mvalue[39m[2m).not.toBeInstanceOf([22m[32mconstructor[39m[2m)[22m
 
 Expected value not to be an instance of:
@@ -1097,13 +1087,23 @@ Received:
 "
 `;
 
-exports[`.toBeInstanceOf() passing {} and "function Map() { [native code] }" 1`] = `
+exports[`.toBeInstanceOf() passing Array [] and [Function Array] 1`] = `
+"[2mexpect([22m[31mvalue[39m[2m).not.toBeInstanceOf([22m[32mconstructor[39m[2m)[22m
+
+Expected value not to be an instance of:
+  [32m\"Array\"[39m
+Received:
+  [31mArray [][39m
+"
+`;
+
+exports[`.toBeInstanceOf() passing Map {} and [Function Map] 1`] = `
 "[2mexpect([22m[31mvalue[39m[2m).not.toBeInstanceOf([22m[32mconstructor[39m[2m)[22m
 
 Expected value not to be an instance of:
   [32m\"Map\"[39m
 Received:
-  [31m{}[39m
+  [31mMap {}[39m
 "
 `;
 
@@ -1118,28 +1118,28 @@ exports[`.toBeNaN() passes 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).not.toBeNaN([22m[2m)[22m
 
 Expected value not to be NaN, instead received
-  [31m\"NaN\"[39m"
+  [31mNaN[39m"
 `;
 
 exports[`.toBeNaN() passes 2`] = `
 "[2mexpect([22m[31mreceived[39m[2m).not.toBeNaN([22m[2m)[22m
 
 Expected value not to be NaN, instead received
-  [31m\"NaN\"[39m"
+  [31mNaN[39m"
 `;
 
 exports[`.toBeNaN() passes 3`] = `
 "[2mexpect([22m[31mreceived[39m[2m).not.toBeNaN([22m[2m)[22m
 
 Expected value not to be NaN, instead received
-  [31m\"NaN\"[39m"
+  [31mNaN[39m"
 `;
 
 exports[`.toBeNaN() passes 4`] = `
 "[2mexpect([22m[31mreceived[39m[2m).not.toBeNaN([22m[2m)[22m
 
 Expected value not to be NaN, instead received
-  [31m\"NaN\"[39m"
+  [31mNaN[39m"
 `;
 
 exports[`.toBeNaN() throws 1`] = `
@@ -1167,7 +1167,7 @@ exports[`.toBeNaN() throws 4`] = `
 "[2mexpect([22m[31mreceived[39m[2m).toBeNaN([22m[2m)[22m
 
 Expected value to be NaN, instead received
-  [31m\"undefined\"[39m"
+  [31mundefined[39m"
 `;
 
 exports[`.toBeNaN() throws 5`] = `
@@ -1181,7 +1181,7 @@ exports[`.toBeNaN() throws 6`] = `
 "[2mexpect([22m[31mreceived[39m[2m).toBeNaN([22m[2m)[22m
 
 Expected value to be NaN, instead received
-  [31m[][39m"
+  [31mArray [][39m"
 `;
 
 exports[`.toBeNaN() throws 7`] = `
@@ -1202,28 +1202,14 @@ exports[`.toBeNaN() throws 9`] = `
 "[2mexpect([22m[31mreceived[39m[2m).toBeNaN([22m[2m)[22m
 
 Expected value to be NaN, instead received
-  [31m\"Infinity\"[39m"
+  [31mInfinity[39m"
 `;
 
 exports[`.toBeNaN() throws 10`] = `
 "[2mexpect([22m[31mreceived[39m[2m).toBeNaN([22m[2m)[22m
 
 Expected value to be NaN, instead received
-  [31m\"-Infinity\"[39m"
-`;
-
-exports[`.toBeNull() fails for '"() => {}"' with .not 1`] = `
-"[2mexpect([22m[31mreceived[39m[2m).toBeNull([22m[2m)[22m
-
-Expected value to be null, instead received
-  [31m\"() => {}\"[39m"
-`;
-
-exports[`.toBeNull() fails for '"Infinity"' with .not 1`] = `
-"[2mexpect([22m[31mreceived[39m[2m).toBeNull([22m[2m)[22m
-
-Expected value to be null, instead received
-  [31m\"Infinity\"[39m"
+  [31m-Infinity[39m"
 `;
 
 exports[`.toBeNull() fails for '"a"' with .not 1`] = `
@@ -1233,21 +1219,14 @@ Expected value to be null, instead received
   [31m\"a\"[39m"
 `;
 
-exports[`.toBeNull() fails for '[]' with .not 1`] = `
+exports[`.toBeNull() fails for '[Function anonymous]' with .not 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).toBeNull([22m[2m)[22m
 
 Expected value to be null, instead received
-  [31m[][39m"
+  [31m[Function anonymous][39m"
 `;
 
 exports[`.toBeNull() fails for '{}' with .not 1`] = `
-"[2mexpect([22m[31mreceived[39m[2m).toBeNull([22m[2m)[22m
-
-Expected value to be null, instead received
-  [31m{}[39m"
-`;
-
-exports[`.toBeNull() fails for '{}' with .not 2`] = `
 "[2mexpect([22m[31mreceived[39m[2m).toBeNull([22m[2m)[22m
 
 Expected value to be null, instead received
@@ -1266,6 +1245,27 @@ exports[`.toBeNull() fails for '1' with .not 1`] = `
 
 Expected value to be null, instead received
   [31m1[39m"
+`;
+
+exports[`.toBeNull() fails for 'Array []' with .not 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).toBeNull([22m[2m)[22m
+
+Expected value to be null, instead received
+  [31mArray [][39m"
+`;
+
+exports[`.toBeNull() fails for 'Infinity' with .not 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).toBeNull([22m[2m)[22m
+
+Expected value to be null, instead received
+  [31mInfinity[39m"
+`;
+
+exports[`.toBeNull() fails for 'Map {}' with .not 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).toBeNull([22m[2m)[22m
+
+Expected value to be null, instead received
+  [31mMap {}[39m"
 `;
 
 exports[`.toBeNull() fails for 'true' with .not 1`] = `
@@ -1296,48 +1296,6 @@ Expected value not to be falsy, instead received
   [31m\"\"[39m"
 `;
 
-exports[`.toBeTruthy(), .toBeFalsy() '"() => {}"' is truthy 1`] = `
-"[2mexpect([22m[31mreceived[39m[2m).not.toBeTruthy([22m[2m)[22m
-
-Expected value not to be truthy, instead received
-  [31m\"() => {}\"[39m"
-`;
-
-exports[`.toBeTruthy(), .toBeFalsy() '"() => {}"' is truthy 2`] = `
-"[2mexpect([22m[31mreceived[39m[2m).toBeFalsy([22m[2m)[22m
-
-Expected value to be falsy, instead received
-  [31m\"() => {}\"[39m"
-`;
-
-exports[`.toBeTruthy(), .toBeFalsy() '"Infinity"' is truthy 1`] = `
-"[2mexpect([22m[31mreceived[39m[2m).not.toBeTruthy([22m[2m)[22m
-
-Expected value not to be truthy, instead received
-  [31m\"Infinity\"[39m"
-`;
-
-exports[`.toBeTruthy(), .toBeFalsy() '"Infinity"' is truthy 2`] = `
-"[2mexpect([22m[31mreceived[39m[2m).toBeFalsy([22m[2m)[22m
-
-Expected value to be falsy, instead received
-  [31m\"Infinity\"[39m"
-`;
-
-exports[`.toBeTruthy(), .toBeFalsy() '"NaN"' is falsy 1`] = `
-"[2mexpect([22m[31mreceived[39m[2m).toBeTruthy([22m[2m)[22m
-
-Expected value to be truthy, instead received
-  [31m\"NaN\"[39m"
-`;
-
-exports[`.toBeTruthy(), .toBeFalsy() '"NaN"' is falsy 2`] = `
-"[2mexpect([22m[31mreceived[39m[2m).not.toBeFalsy([22m[2m)[22m
-
-Expected value not to be falsy, instead received
-  [31m\"NaN\"[39m"
-`;
-
 exports[`.toBeTruthy(), .toBeFalsy() '"a"' is truthy 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).not.toBeTruthy([22m[2m)[22m
 
@@ -1352,32 +1310,18 @@ Expected value to be falsy, instead received
   [31m\"a\"[39m"
 `;
 
-exports[`.toBeTruthy(), .toBeFalsy() '"undefined"' is falsy 1`] = `
-"[2mexpect([22m[31mreceived[39m[2m).toBeTruthy([22m[2m)[22m
-
-Expected value to be truthy, instead received
-  [31m\"undefined\"[39m"
-`;
-
-exports[`.toBeTruthy(), .toBeFalsy() '"undefined"' is falsy 2`] = `
-"[2mexpect([22m[31mreceived[39m[2m).not.toBeFalsy([22m[2m)[22m
-
-Expected value not to be falsy, instead received
-  [31m\"undefined\"[39m"
-`;
-
-exports[`.toBeTruthy(), .toBeFalsy() '[]' is truthy 1`] = `
+exports[`.toBeTruthy(), .toBeFalsy() '[Function anonymous]' is truthy 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).not.toBeTruthy([22m[2m)[22m
 
 Expected value not to be truthy, instead received
-  [31m[][39m"
+  [31m[Function anonymous][39m"
 `;
 
-exports[`.toBeTruthy(), .toBeFalsy() '[]' is truthy 2`] = `
+exports[`.toBeTruthy(), .toBeFalsy() '[Function anonymous]' is truthy 2`] = `
 "[2mexpect([22m[31mreceived[39m[2m).toBeFalsy([22m[2m)[22m
 
 Expected value to be falsy, instead received
-  [31m[][39m"
+  [31m[Function anonymous][39m"
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() '{}' is truthy 1`] = `
@@ -1388,20 +1332,6 @@ Expected value not to be truthy, instead received
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() '{}' is truthy 2`] = `
-"[2mexpect([22m[31mreceived[39m[2m).toBeFalsy([22m[2m)[22m
-
-Expected value to be falsy, instead received
-  [31m{}[39m"
-`;
-
-exports[`.toBeTruthy(), .toBeFalsy() '{}' is truthy 3`] = `
-"[2mexpect([22m[31mreceived[39m[2m).not.toBeTruthy([22m[2m)[22m
-
-Expected value not to be truthy, instead received
-  [31m{}[39m"
-`;
-
-exports[`.toBeTruthy(), .toBeFalsy() '{}' is truthy 4`] = `
 "[2mexpect([22m[31mreceived[39m[2m).toBeFalsy([22m[2m)[22m
 
 Expected value to be falsy, instead received
@@ -1450,6 +1380,62 @@ Expected value to be falsy, instead received
   [31m1[39m"
 `;
 
+exports[`.toBeTruthy(), .toBeFalsy() 'Array []' is truthy 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).not.toBeTruthy([22m[2m)[22m
+
+Expected value not to be truthy, instead received
+  [31mArray [][39m"
+`;
+
+exports[`.toBeTruthy(), .toBeFalsy() 'Array []' is truthy 2`] = `
+"[2mexpect([22m[31mreceived[39m[2m).toBeFalsy([22m[2m)[22m
+
+Expected value to be falsy, instead received
+  [31mArray [][39m"
+`;
+
+exports[`.toBeTruthy(), .toBeFalsy() 'Infinity' is truthy 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).not.toBeTruthy([22m[2m)[22m
+
+Expected value not to be truthy, instead received
+  [31mInfinity[39m"
+`;
+
+exports[`.toBeTruthy(), .toBeFalsy() 'Infinity' is truthy 2`] = `
+"[2mexpect([22m[31mreceived[39m[2m).toBeFalsy([22m[2m)[22m
+
+Expected value to be falsy, instead received
+  [31mInfinity[39m"
+`;
+
+exports[`.toBeTruthy(), .toBeFalsy() 'Map {}' is truthy 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).not.toBeTruthy([22m[2m)[22m
+
+Expected value not to be truthy, instead received
+  [31mMap {}[39m"
+`;
+
+exports[`.toBeTruthy(), .toBeFalsy() 'Map {}' is truthy 2`] = `
+"[2mexpect([22m[31mreceived[39m[2m).toBeFalsy([22m[2m)[22m
+
+Expected value to be falsy, instead received
+  [31mMap {}[39m"
+`;
+
+exports[`.toBeTruthy(), .toBeFalsy() 'NaN' is falsy 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).toBeTruthy([22m[2m)[22m
+
+Expected value to be truthy, instead received
+  [31mNaN[39m"
+`;
+
+exports[`.toBeTruthy(), .toBeFalsy() 'NaN' is falsy 2`] = `
+"[2mexpect([22m[31mreceived[39m[2m).not.toBeFalsy([22m[2m)[22m
+
+Expected value not to be falsy, instead received
+  [31mNaN[39m"
+`;
+
 exports[`.toBeTruthy(), .toBeFalsy() 'false' is falsy 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).toBeTruthy([22m[2m)[22m
 
@@ -1492,6 +1478,20 @@ Expected value to be falsy, instead received
   [31mtrue[39m"
 `;
 
+exports[`.toBeTruthy(), .toBeFalsy() 'undefined' is falsy 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).toBeTruthy([22m[2m)[22m
+
+Expected value to be truthy, instead received
+  [31mundefined[39m"
+`;
+
+exports[`.toBeTruthy(), .toBeFalsy() 'undefined' is falsy 2`] = `
+"[2mexpect([22m[31mreceived[39m[2m).not.toBeFalsy([22m[2m)[22m
+
+Expected value not to be falsy, instead received
+  [31mundefined[39m"
+`;
+
 exports[`.toBeTruthy(), .toBeFalsy() does not accept arguments 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m)[.not].toBeTruthy([22m[2m)[22m
 
@@ -1526,99 +1526,99 @@ Not to contain value:
 "
 `;
 
-exports[`.toContain() '["Symbol(a)"]' contains '"Symbol(a)"' 1`] = `
+exports[`.toContain() '["a", "b", "c", "d"]' contains '"a"' 1`] = `
 "[2mexpect([22m[31marray[39m[2m).not.toContain([22m[32mvalue[39m[2m)[22m
 
 Expected array:
-  [31m[\"Symbol(a)\"][39m
-Not to contain value:
-  [32m\"Symbol(a)\"[39m
-"
-`;
-
-exports[`.toContain() '["a","b","c","d"]' contains '"a"' 1`] = `
-"[2mexpect([22m[31marray[39m[2m).not.toContain([22m[32mvalue[39m[2m)[22m
-
-Expected array:
-  [31m[\"a\",\"b\",\"c\",\"d\"][39m
+  [31m[\"a\", \"b\", \"c\", \"d\"][39m
 Not to contain value:
   [32m\"a\"[39m
 "
 `;
 
-exports[`.toContain() '["undefined",null]' contains '"undefined"' 1`] = `
-"[2mexpect([22m[31marray[39m[2m).not.toContain([22m[32mvalue[39m[2m)[22m
-
-Expected array:
-  [31m[\"undefined\",null][39m
-Not to contain value:
-  [32m\"undefined\"[39m
-"
-`;
-
-exports[`.toContain() '["undefined",null]' contains 'null' 1`] = `
-"[2mexpect([22m[31marray[39m[2m).not.toContain([22m[32mvalue[39m[2m)[22m
-
-Expected array:
-  [31m[\"undefined\",null][39m
-Not to contain value:
-  [32mnull[39m
-"
-`;
-
-exports[`.toContain() '[{},[]]' does not contain '[]' 1`] = `
+exports[`.toContain() '[{}, Array []]' does not contain '{}' 1`] = `
 "[2mexpect([22m[31marray[39m[2m).toContain([22m[32mvalue[39m[2m)[22m
 
 Expected array:
-  [31m[{},[]][39m
-To contain value:
-  [32m[][39m"
-`;
-
-exports[`.toContain() '[{},[]]' does not contain '{}' 1`] = `
-"[2mexpect([22m[31marray[39m[2m).toContain([22m[32mvalue[39m[2m)[22m
-
-Expected array:
-  [31m[{},[]][39m
+  [31m[{}, Array []][39m
 To contain value:
   [32m{}[39m"
 `;
 
-exports[`.toContain() '[1,2,3,4]' contains '1' 1`] = `
+exports[`.toContain() '[{}, Array []]' does not contain 'Array []' 1`] = `
+"[2mexpect([22m[31marray[39m[2m).toContain([22m[32mvalue[39m[2m)[22m
+
+Expected array:
+  [31m[{}, Array []][39m
+To contain value:
+  [32mArray [][39m"
+`;
+
+exports[`.toContain() '[1, 2, 3, 4]' contains '1' 1`] = `
 "[2mexpect([22m[31marray[39m[2m).not.toContain([22m[32mvalue[39m[2m)[22m
 
 Expected array:
-  [31m[1,2,3,4][39m
+  [31m[1, 2, 3, 4][39m
 Not to contain value:
   [32m1[39m
 "
 `;
 
-exports[`.toContain() '[1,2,3]' does not contain '4' 1`] = `
+exports[`.toContain() '[1, 2, 3]' does not contain '4' 1`] = `
 "[2mexpect([22m[31marray[39m[2m).toContain([22m[32mvalue[39m[2m)[22m
 
 Expected array:
-  [31m[1,2,3][39m
+  [31m[1, 2, 3][39m
 To contain value:
   [32m4[39m"
 `;
 
-exports[`.toContain() '[null,"undefined"]' does not contain '1' 1`] = `
+exports[`.toContain() '[Symbol(a)]' contains 'Symbol(a)' 1`] = `
+"[2mexpect([22m[31marray[39m[2m).not.toContain([22m[32mvalue[39m[2m)[22m
+
+Expected array:
+  [31m[Symbol(a)][39m
+Not to contain value:
+  [32mSymbol(a)[39m
+"
+`;
+
+exports[`.toContain() '[null, undefined]' does not contain '1' 1`] = `
 "[2mexpect([22m[31marray[39m[2m).toContain([22m[32mvalue[39m[2m)[22m
 
 Expected array:
-  [31m[null,\"undefined\"][39m
+  [31m[null, undefined][39m
 To contain value:
   [32m1[39m"
 `;
 
-exports[`.toContainEqual() '[{"a":"b"},{"a":"c"}]' does not contain a value equal to'{"a":"d"}' 1`] = `
+exports[`.toContain() '[undefined, null]' contains 'null' 1`] = `
+"[2mexpect([22m[31marray[39m[2m).not.toContain([22m[32mvalue[39m[2m)[22m
+
+Expected array:
+  [31m[undefined, null][39m
+Not to contain value:
+  [32mnull[39m
+"
+`;
+
+exports[`.toContain() '[undefined, null]' contains 'undefined' 1`] = `
+"[2mexpect([22m[31marray[39m[2m).not.toContain([22m[32mvalue[39m[2m)[22m
+
+Expected array:
+  [31m[undefined, null][39m
+Not to contain value:
+  [32mundefined[39m
+"
+`;
+
+exports[`.toContainEqual() '[{"a": "b"}, {"a": "c"}]' does not contain a value equal to'{"a": "d"}' 1`] = `
 "[2mexpect([22m[31marray[39m[2m).toContainEqual([22m[32mvalue[39m[2m)[22m
 
 Expected array:
-  [31m[{\"a\":\"b\"},{\"a\":\"c\"}][39m
+  [31m[{\"a\": \"b\"}, {\"a\": \"c\"}][39m
 To contain a value equal to:
-  [32m{\"a\":\"d\"}[39m"
+  [32m{\"a\": \"d\"}[39m"
 `;
 
 exports[`.toEqual() expect("abc").not.toEqual("abc") 1`] = `
@@ -1639,13 +1639,13 @@ Received:
   [31m\"banana\"[39m"
 `;
 
-exports[`.toEqual() expect({"a":5}).toEqual({"b":6}) 1`] = `
+exports[`.toEqual() expect({"a": 5}).toEqual({"b": 6}) 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).toEqual([22m[32mexpected[39m[2m)[22m
 
 Expected value to equal:
-  [32m{\"b\":6}[39m
+  [32m{\"b\": 6}[39m
 Received:
-  [31m{\"a\":5}[39m
+  [31m{\"a\": 5}[39m
 
 Difference:
 
@@ -1658,13 +1658,13 @@ Difference:
 [2m [22m [2m}[22m"
 `;
 
-exports[`.toEqual() expect({"a":99}).not.toEqual({"a":99}) 1`] = `
+exports[`.toEqual() expect({"a": 99}).not.toEqual({"a": 99}) 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).not.toEqual([22m[32mexpected[39m[2m)[22m
 
 Expected value to not equal:
-  [32m{\"a\":99}[39m
+  [32m{\"a\": 99}[39m
 Received:
-  [31m{\"a\":99}[39m"
+  [31m{\"a\": 99}[39m"
 `;
 
 exports[`.toEqual() expect(1).not.toEqual(1) 1`] = `
@@ -1685,11 +1685,11 @@ Received:
   [31m1[39m"
 `;
 
-exports[`.toEqual() expect(null).toEqual("undefined") 1`] = `
+exports[`.toEqual() expect(null).toEqual(undefined) 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).toEqual([22m[32mexpected[39m[2m)[22m
 
 Expected value to equal:
-  [32m\"undefined\"[39m
+  [32mundefined[39m
 Received:
   [31mnull[39m
 
@@ -1722,7 +1722,7 @@ exports[`.toMatch() passes: [Foo bar, /^foo/i] 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).not.toMatch([22m[32mexpected[39m[2m)[22m
 
 Expected value not to match:
-  [32m\"/^foo/i\"[39m
+  [32m/^foo/i[39m
 Received:
   [31m\"Foo bar\"[39m"
 `;
@@ -1736,35 +1736,20 @@ Received:
   [31m\"foo\"[39m"
 `;
 
-exports[`.toMatch() throws if non String actual value passed: ["() => {}", "foo"] 1`] = `
+exports[`.toMatch() throws if non String actual value passed: [/foo/i, "foo"] 1`] = `
 "[2mexpect([22m[31mstring[39m[2m)[.not].toMatch([22m[32mexpected[39m[2m)[22m
 
 [31mstring[39m value must be a string.
 Received:
-  function: [31m\"() => {}\"[39m"
+  regexp: [31m/foo/i[39m"
 `;
 
-exports[`.toMatch() throws if non String actual value passed: ["/foo/i", "foo"] 1`] = `
+exports[`.toMatch() throws if non String actual value passed: [[Function anonymous], "foo"] 1`] = `
 "[2mexpect([22m[31mstring[39m[2m)[.not].toMatch([22m[32mexpected[39m[2m)[22m
 
 [31mstring[39m value must be a string.
 Received:
-  regexp: [31m\"/foo/i\"[39m"
-`;
-
-exports[`.toMatch() throws if non String actual value passed: ["undefined", "foo"] 1`] = `
-"[2mexpect([22m[31mstring[39m[2m)[.not].toMatch([22m[32mexpected[39m[2m)[22m
-
-[31mstring[39m value must be a string.
-Received: [31m\"undefined\"[39m"
-`;
-
-exports[`.toMatch() throws if non String actual value passed: [[], "foo"] 1`] = `
-"[2mexpect([22m[31mstring[39m[2m)[.not].toMatch([22m[32mexpected[39m[2m)[22m
-
-[31mstring[39m value must be a string.
-Received:
-  array: [31m[][39m"
+  function: [31m[Function anonymous][39m"
 `;
 
 exports[`.toMatch() throws if non String actual value passed: [{}, "foo"] 1`] = `
@@ -1783,6 +1768,14 @@ Received:
   number: [31m1[39m"
 `;
 
+exports[`.toMatch() throws if non String actual value passed: [Array [], "foo"] 1`] = `
+"[2mexpect([22m[31mstring[39m[2m)[.not].toMatch([22m[32mexpected[39m[2m)[22m
+
+[31mstring[39m value must be a string.
+Received:
+  array: [31mArray [][39m"
+`;
+
 exports[`.toMatch() throws if non String actual value passed: [true, "foo"] 1`] = `
 "[2mexpect([22m[31mstring[39m[2m)[.not].toMatch([22m[32mexpected[39m[2m)[22m
 
@@ -1791,27 +1784,19 @@ Received:
   boolean: [31mtrue[39m"
 `;
 
-exports[`.toMatch() throws if non String/RegExp expected value passed: ["foo", "() => {}"] 1`] = `
+exports[`.toMatch() throws if non String actual value passed: [undefined, "foo"] 1`] = `
+"[2mexpect([22m[31mstring[39m[2m)[.not].toMatch([22m[32mexpected[39m[2m)[22m
+
+[31mstring[39m value must be a string.
+Received: [31mundefined[39m"
+`;
+
+exports[`.toMatch() throws if non String/RegExp expected value passed: ["foo", [Function anonymous]] 1`] = `
 "[2mexpect([22m[31mstring[39m[2m)[.not].toMatch([22m[32mexpected[39m[2m)[22m
 
 [32mexpected[39m value must be a string or a regular expression.
 Expected:
-  function: [32m\"() => {}\"[39m"
-`;
-
-exports[`.toMatch() throws if non String/RegExp expected value passed: ["foo", "undefined"] 1`] = `
-"[2mexpect([22m[31mstring[39m[2m)[.not].toMatch([22m[32mexpected[39m[2m)[22m
-
-[32mexpected[39m value must be a string or a regular expression.
-Expected: [32m\"undefined\"[39m"
-`;
-
-exports[`.toMatch() throws if non String/RegExp expected value passed: ["foo", []] 1`] = `
-"[2mexpect([22m[31mstring[39m[2m)[.not].toMatch([22m[32mexpected[39m[2m)[22m
-
-[32mexpected[39m value must be a string or a regular expression.
-Expected:
-  array: [32m[][39m"
+  function: [32m[Function anonymous][39m"
 `;
 
 exports[`.toMatch() throws if non String/RegExp expected value passed: ["foo", {}] 1`] = `
@@ -1830,6 +1815,14 @@ Expected:
   number: [32m1[39m"
 `;
 
+exports[`.toMatch() throws if non String/RegExp expected value passed: ["foo", Array []] 1`] = `
+"[2mexpect([22m[31mstring[39m[2m)[.not].toMatch([22m[32mexpected[39m[2m)[22m
+
+[32mexpected[39m value must be a string or a regular expression.
+Expected:
+  array: [32mArray [][39m"
+`;
+
 exports[`.toMatch() throws if non String/RegExp expected value passed: ["foo", true] 1`] = `
 "[2mexpect([22m[31mstring[39m[2m)[.not].toMatch([22m[32mexpected[39m[2m)[22m
 
@@ -1838,11 +1831,18 @@ Expected:
   boolean: [32mtrue[39m"
 `;
 
+exports[`.toMatch() throws if non String/RegExp expected value passed: ["foo", undefined] 1`] = `
+"[2mexpect([22m[31mstring[39m[2m)[.not].toMatch([22m[32mexpected[39m[2m)[22m
+
+[32mexpected[39m value must be a string or a regular expression.
+Expected: [32mundefined[39m"
+`;
+
 exports[`.toMatch() throws: [bar, /foo/] 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).toMatch([22m[32mexpected[39m[2m)[22m
 
 Expected value to match:
-  [32m\"/foo/\"[39m
+  [32m/foo/[39m
 Received:
   [31m\"bar\"[39m"
 `;

--- a/packages/jest-matchers/src/__tests__/__snapshots__/spyMatchers-test.js.snap
+++ b/packages/jest-matchers/src/__tests__/__snapshots__/spyMatchers-test.js.snap
@@ -3,39 +3,39 @@ exports[`test lastCalledWith works only on spies or jest.fn 1`] = `
 
 [31mjest.fn()[39m value must be a mock function or spy.
 Received:
-  function: [31m"() => {}"[39m]
+  function: [31m[Function fn][39m]
 `;
 
 exports[`test lastCalledWith works with jest.fn and arguments that don't match 1`] = `
 [Error: [2mexpect([22m[31mjest.fn()[39m[2m).lastCalledWith([22m[32mexpected[39m[2m)[22m
 
 Expected mock function to have been last called with:
-  [32m["foo","bar"][39m
+  [32m["foo", "bar"][39m
 But it was last called with:
-  [31m["foo","bar1"][39m]
+  [31m["foo", "bar1"][39m]
 `;
 
 exports[`test lastCalledWith works with jest.fn and arguments that match 1`] = `
 [Error: [2mexpect([22m[31mjest.fn()[39m[2m).not.lastCalledWith([22m[32mexpected[39m[2m)[22m
 
 Expected mock function to not have been last called with:
-  [32m["foo","bar"][39m]
+  [32m["foo", "bar"][39m]
 `;
 
 exports[`test lastCalledWith works with jest.fn and many arguments 1`] = `
 [Error: [2mexpect([22m[31mjest.fn()[39m[2m).not.lastCalledWith([22m[32mexpected[39m[2m)[22m
 
 Expected mock function to not have been last called with:
-  [32m["foo","bar"][39m]
+  [32m["foo", "bar"][39m]
 `;
 
 exports[`test lastCalledWith works with jest.fn and many arguments that don't match 1`] = `
 [Error: [2mexpect([22m[31mjest.fn()[39m[2m).lastCalledWith([22m[32mexpected[39m[2m)[22m
 
 Expected mock function to have been last called with:
-  [32m["foo","bar"][39m
+  [32m["foo", "bar"][39m
 But it was last called with:
-  [31m["foo","bar3"][39m
+  [31m["foo", "bar3"][39m
 and [31mtwo more calls[39m.]
 `;
 
@@ -43,7 +43,7 @@ exports[`test lastCalledWith works with jest.fn and no arguments 1`] = `
 [Error: [2mexpect([22m[31mjest.fn()[39m[2m).lastCalledWith([22m[32mexpected[39m[2m)[22m
 
 Expected mock function to have been last called with:
-  [32m["foo","bar"][39m
+  [32m["foo", "bar"][39m
 But it was [31mnot called[39m.]
 `;
 
@@ -52,7 +52,7 @@ exports[`test toBeCalled works only on spies or jest.fn 1`] = `
 
 [31mjest.fn()[39m value must be a mock function or spy.
 Received:
-  function: [31m"() => {}"[39m]
+  function: [31m[Function fn][39m]
 `;
 
 exports[`test toBeCalled works with jasmine.createSpy 1`] = `
@@ -100,46 +100,46 @@ exports[`test toBeCalledWith works only on spies or jest.fn 1`] = `
 
 [31mjest.fn()[39m value must be a mock function or spy.
 Received:
-  function: [31m"() => {}"[39m]
+  function: [31m[Function fn][39m]
 `;
 
 exports[`test toBeCalledWith works with jest.fn and arguments that don't match 1`] = `
 [Error: [2mexpect([22m[31mjest.fn()[39m[2m).toBeCalledWith([22m[32mexpected[39m[2m)[22m
 
 Expected mock function to have been called with:
-  [32m["foo","bar"][39m
+  [32m["foo", "bar"][39m
 But it was called with:
-  [31m["foo","bar1"][39m]
+  [31m["foo", "bar1"][39m]
 `;
 
 exports[`test toBeCalledWith works with jest.fn and arguments that match 1`] = `
 [Error: [2mexpect([22m[31mjest.fn()[39m[2m).not.toBeCalledWith([22m[32mexpected[39m[2m)[22m
 
 Expected mock function not to have been called with:
-  [32m["foo","bar"][39m]
+  [32m["foo", "bar"][39m]
 `;
 
 exports[`test toBeCalledWith works with jest.fn and many arguments 1`] = `
 [Error: [2mexpect([22m[31mjest.fn()[39m[2m).not.toBeCalledWith([22m[32mexpected[39m[2m)[22m
 
 Expected mock function not to have been called with:
-  [32m["foo","bar"][39m]
+  [32m["foo", "bar"][39m]
 `;
 
 exports[`test toBeCalledWith works with jest.fn and many arguments that don't match 1`] = `
 [Error: [2mexpect([22m[31mjest.fn()[39m[2m).toBeCalledWith([22m[32mexpected[39m[2m)[22m
 
 Expected mock function to have been called with:
-  [32m["foo","bar"][39m
+  [32m["foo", "bar"][39m
 But it was called with:
-  [31m["foo","bar3"][39m, [31m["foo","bar2"][39m, [31m["foo","bar1"][39m]
+  [31m["foo", "bar3"][39m, [31m["foo", "bar2"][39m, [31m["foo", "bar1"][39m]
 `;
 
 exports[`test toBeCalledWith works with jest.fn and no arguments 1`] = `
 [Error: [2mexpect([22m[31mjest.fn()[39m[2m).toBeCalledWith([22m[32mexpected[39m[2m)[22m
 
 Expected mock function to have been called with:
-  [32m["foo","bar"][39m
+  [32m["foo", "bar"][39m
 But it was [31mnot called[39m.]
 `;
 
@@ -148,7 +148,7 @@ exports[`test toHaveBeenCalled works only on spies or jest.fn 1`] = `
 
 [31mjest.fn()[39m value must be a mock function or spy.
 Received:
-  function: [31m"() => {}"[39m]
+  function: [31m[Function fn][39m]
 `;
 
 exports[`test toHaveBeenCalled works with jasmine.createSpy 1`] = `
@@ -196,46 +196,46 @@ exports[`test toHaveBeenCalledWith works only on spies or jest.fn 1`] = `
 
 [31mjest.fn()[39m value must be a mock function or spy.
 Received:
-  function: [31m"() => {}"[39m]
+  function: [31m[Function fn][39m]
 `;
 
 exports[`test toHaveBeenCalledWith works with jasmine.createSpy and arguments that don't match 1`] = `
 [Error: [2mexpect([22m[31mspy[39m[2m).toHaveBeenCalledWith([22m[32mexpected[39m[2m)[22m
 
 Expected spy to have been called with:
-  [32m["foo","bar"][39m
+  [32m["foo", "bar"][39m
 But it was called with:
-  [31m["foo","bar1"][39m]
+  [31m["foo", "bar1"][39m]
 `;
 
 exports[`test toHaveBeenCalledWith works with jasmine.createSpy and arguments that match 1`] = `
 [Error: [2mexpect([22m[31mspy[39m[2m).not.toHaveBeenCalledWith([22m[32mexpected[39m[2m)[22m
 
 Expected spy not to have been called with:
-  [32m["foo","bar"][39m]
+  [32m["foo", "bar"][39m]
 `;
 
 exports[`test toHaveBeenCalledWith works with jasmine.createSpy and many arguments 1`] = `
 [Error: [2mexpect([22m[31mspy[39m[2m).not.toHaveBeenCalledWith([22m[32mexpected[39m[2m)[22m
 
 Expected spy not to have been called with:
-  [32m["foo","bar"][39m]
+  [32m["foo", "bar"][39m]
 `;
 
 exports[`test toHaveBeenCalledWith works with jasmine.createSpy and many arguments that don't match 1`] = `
 [Error: [2mexpect([22m[31mspy[39m[2m).toHaveBeenCalledWith([22m[32mexpected[39m[2m)[22m
 
 Expected spy to have been called with:
-  [32m["foo","bar"][39m
+  [32m["foo", "bar"][39m
 But it was called with:
-  [31m["foo","bar3"][39m, [31m["foo","bar2"][39m, [31m["foo","bar1"][39m]
+  [31m["foo", "bar3"][39m, [31m["foo", "bar2"][39m, [31m["foo", "bar1"][39m]
 `;
 
 exports[`test toHaveBeenCalledWith works with jasmine.createSpy and no arguments 1`] = `
 [Error: [2mexpect([22m[31mspy[39m[2m).toHaveBeenCalledWith([22m[32mexpected[39m[2m)[22m
 
 Expected spy to have been called with:
-  [32m["foo","bar"][39m
+  [32m["foo", "bar"][39m
 But it was [31mnot called[39m.]
 `;
 
@@ -243,39 +243,39 @@ exports[`test toHaveBeenCalledWith works with jest.fn and arguments that don't m
 [Error: [2mexpect([22m[31mjest.fn()[39m[2m).toHaveBeenCalledWith([22m[32mexpected[39m[2m)[22m
 
 Expected mock function to have been called with:
-  [32m["foo","bar"][39m
+  [32m["foo", "bar"][39m
 But it was called with:
-  [31m["foo","bar1"][39m]
+  [31m["foo", "bar1"][39m]
 `;
 
 exports[`test toHaveBeenCalledWith works with jest.fn and arguments that match 1`] = `
 [Error: [2mexpect([22m[31mjest.fn()[39m[2m).not.toHaveBeenCalledWith([22m[32mexpected[39m[2m)[22m
 
 Expected mock function not to have been called with:
-  [32m["foo","bar"][39m]
+  [32m["foo", "bar"][39m]
 `;
 
 exports[`test toHaveBeenCalledWith works with jest.fn and many arguments 1`] = `
 [Error: [2mexpect([22m[31mjest.fn()[39m[2m).not.toHaveBeenCalledWith([22m[32mexpected[39m[2m)[22m
 
 Expected mock function not to have been called with:
-  [32m["foo","bar"][39m]
+  [32m["foo", "bar"][39m]
 `;
 
 exports[`test toHaveBeenCalledWith works with jest.fn and many arguments that don't match 1`] = `
 [Error: [2mexpect([22m[31mjest.fn()[39m[2m).toHaveBeenCalledWith([22m[32mexpected[39m[2m)[22m
 
 Expected mock function to have been called with:
-  [32m["foo","bar"][39m
+  [32m["foo", "bar"][39m
 But it was called with:
-  [31m["foo","bar3"][39m, [31m["foo","bar2"][39m, [31m["foo","bar1"][39m]
+  [31m["foo", "bar3"][39m, [31m["foo", "bar2"][39m, [31m["foo", "bar1"][39m]
 `;
 
 exports[`test toHaveBeenCalledWith works with jest.fn and no arguments 1`] = `
 [Error: [2mexpect([22m[31mjest.fn()[39m[2m).toHaveBeenCalledWith([22m[32mexpected[39m[2m)[22m
 
 Expected mock function to have been called with:
-  [32m["foo","bar"][39m
+  [32m["foo", "bar"][39m
 But it was [31mnot called[39m.]
 `;
 
@@ -284,39 +284,39 @@ exports[`test toHaveBeenLastCalledWith works only on spies or jest.fn 1`] = `
 
 [31mjest.fn()[39m value must be a mock function or spy.
 Received:
-  function: [31m"() => {}"[39m]
+  function: [31m[Function fn][39m]
 `;
 
 exports[`test toHaveBeenLastCalledWith works with jasmine.createSpy and arguments that don't match 1`] = `
 [Error: [2mexpect([22m[31mspy[39m[2m).toHaveBeenLastCalledWith([22m[32mexpected[39m[2m)[22m
 
 Expected spy to have been last called with:
-  [32m["foo","bar"][39m
+  [32m["foo", "bar"][39m
 But it was last called with:
-  [31m["foo","bar1"][39m]
+  [31m["foo", "bar1"][39m]
 `;
 
 exports[`test toHaveBeenLastCalledWith works with jasmine.createSpy and arguments that match 1`] = `
 [Error: [2mexpect([22m[31mspy[39m[2m).not.toHaveBeenLastCalledWith([22m[32mexpected[39m[2m)[22m
 
 Expected spy to not have been last called with:
-  [32m["foo","bar"][39m]
+  [32m["foo", "bar"][39m]
 `;
 
 exports[`test toHaveBeenLastCalledWith works with jasmine.createSpy and many arguments 1`] = `
 [Error: [2mexpect([22m[31mspy[39m[2m).not.toHaveBeenLastCalledWith([22m[32mexpected[39m[2m)[22m
 
 Expected spy to not have been last called with:
-  [32m["foo","bar"][39m]
+  [32m["foo", "bar"][39m]
 `;
 
 exports[`test toHaveBeenLastCalledWith works with jasmine.createSpy and many arguments that don't match 1`] = `
 [Error: [2mexpect([22m[31mspy[39m[2m).toHaveBeenLastCalledWith([22m[32mexpected[39m[2m)[22m
 
 Expected spy to have been last called with:
-  [32m["foo","bar"][39m
+  [32m["foo", "bar"][39m
 But it was last called with:
-  [31m["foo","bar3"][39m
+  [31m["foo", "bar3"][39m
 and [31mtwo more calls[39m.]
 `;
 
@@ -324,7 +324,7 @@ exports[`test toHaveBeenLastCalledWith works with jasmine.createSpy and no argum
 [Error: [2mexpect([22m[31mspy[39m[2m).toHaveBeenLastCalledWith([22m[32mexpected[39m[2m)[22m
 
 Expected spy to have been last called with:
-  [32m["foo","bar"][39m
+  [32m["foo", "bar"][39m
 But it was [31mnot called[39m.]
 `;
 
@@ -332,32 +332,32 @@ exports[`test toHaveBeenLastCalledWith works with jest.fn and arguments that don
 [Error: [2mexpect([22m[31mjest.fn()[39m[2m).toHaveBeenLastCalledWith([22m[32mexpected[39m[2m)[22m
 
 Expected mock function to have been last called with:
-  [32m["foo","bar"][39m
+  [32m["foo", "bar"][39m
 But it was last called with:
-  [31m["foo","bar1"][39m]
+  [31m["foo", "bar1"][39m]
 `;
 
 exports[`test toHaveBeenLastCalledWith works with jest.fn and arguments that match 1`] = `
 [Error: [2mexpect([22m[31mjest.fn()[39m[2m).not.toHaveBeenLastCalledWith([22m[32mexpected[39m[2m)[22m
 
 Expected mock function to not have been last called with:
-  [32m["foo","bar"][39m]
+  [32m["foo", "bar"][39m]
 `;
 
 exports[`test toHaveBeenLastCalledWith works with jest.fn and many arguments 1`] = `
 [Error: [2mexpect([22m[31mjest.fn()[39m[2m).not.toHaveBeenLastCalledWith([22m[32mexpected[39m[2m)[22m
 
 Expected mock function to not have been last called with:
-  [32m["foo","bar"][39m]
+  [32m["foo", "bar"][39m]
 `;
 
 exports[`test toHaveBeenLastCalledWith works with jest.fn and many arguments that don't match 1`] = `
 [Error: [2mexpect([22m[31mjest.fn()[39m[2m).toHaveBeenLastCalledWith([22m[32mexpected[39m[2m)[22m
 
 Expected mock function to have been last called with:
-  [32m["foo","bar"][39m
+  [32m["foo", "bar"][39m
 But it was last called with:
-  [31m["foo","bar3"][39m
+  [31m["foo", "bar3"][39m
 and [31mtwo more calls[39m.]
 `;
 
@@ -365,7 +365,7 @@ exports[`test toHaveBeenLastCalledWith works with jest.fn and no arguments 1`] =
 [Error: [2mexpect([22m[31mjest.fn()[39m[2m).toHaveBeenLastCalledWith([22m[32mexpected[39m[2m)[22m
 
 Expected mock function to have been last called with:
-  [32m["foo","bar"][39m
+  [32m["foo", "bar"][39m
 But it was [31mnot called[39m.]
 `;
 
@@ -382,7 +382,7 @@ exports[`toHaveBeenCalledTimes accepts only numbers 2`] = `
 
 Expected value must be a number.
 Got:
-  array: [32m[][39m]
+  array: [32mArray [][39m]
 `;
 
 exports[`toHaveBeenCalledTimes accepts only numbers 3`] = `
@@ -406,7 +406,7 @@ exports[`toHaveBeenCalledTimes accepts only numbers 5`] = `
 
 Expected value must be a number.
 Got:
-  object: [32m{}[39m]
+  object: [32mMap {}[39m]
 `;
 
 exports[`toHaveBeenCalledTimes accepts only numbers 6`] = `
@@ -414,7 +414,7 @@ exports[`toHaveBeenCalledTimes accepts only numbers 6`] = `
 
 Expected value must be a number.
 Got:
-  function: [32m"() => {}"[39m]
+  function: [32m[Function anonymous][39m]
 `;
 
 exports[`toHaveBeenCalledTimes fails if function called less than expected times 1`] = `
@@ -440,5 +440,5 @@ exports[`toHaveBeenCalledTimes verifies that actual is a Spy 1`] = `
 
 [31mjest.fn()[39m value must be a mock function or spy.
 Received:
-  function: [31m"() => {}"[39m]
+  function: [31m[Function fn][39m]
 `;

--- a/packages/jest-matchers/src/__tests__/__snapshots__/toThrowMatchers-test.js.snap
+++ b/packages/jest-matchers/src/__tests__/__snapshots__/toThrowMatchers-test.js.snap
@@ -39,7 +39,7 @@ exports[`.toThrow() regexp did not throw at all 1`] = `
 "[2mexpect([22m[31mfunction[39m[2m).toThrow([22m[32mregexp[39m[2m)[22m
 
 Expected the function to throw an error matching:
-  [32m\"/apple/\"[39m
+  [32m/apple/[39m
 But it didn\'t throw anything."
 `;
 
@@ -47,7 +47,7 @@ exports[`.toThrow() regexp threw, but message did not match 1`] = `
 "[2mexpect([22m[31mfunction[39m[2m).toThrow([22m[32mregexp[39m[2m)[22m
 
 Expected the function to throw an error matching:
-  [32m\"/banana/\"[39m
+  [32m/banana/[39m
 Instead, it threw:
 [31m  Error      
       [2mat jestExpect ([22mpackages/jest-matchers/src/__tests__/toThrowMatchers-test.js[2m:24:74)[22m[39m"
@@ -57,7 +57,7 @@ exports[`.toThrow() regexp threw, but should not have 1`] = `
 "[2mexpect([22m[31mfunction[39m[2m).not.toThrow([22m[32mregexp[39m[2m)[22m
 
 Expected the function not to throw an error matching:
-  [32m\"/apple/\"[39m
+  [32m/apple/[39m
 Instead, it threw:
 [31m  Error      
       [2mat jestExpect ([22mpackages/jest-matchers/src/__tests__/toThrowMatchers-test.js[2m:24:74)[22m[39m"
@@ -132,7 +132,7 @@ exports[`.toThrowError() regexp did not throw at all 1`] = `
 "[2mexpect([22m[31mfunction[39m[2m).toThrowError([22m[32mregexp[39m[2m)[22m
 
 Expected the function to throw an error matching:
-  [32m\"/apple/\"[39m
+  [32m/apple/[39m
 But it didn\'t throw anything."
 `;
 
@@ -140,7 +140,7 @@ exports[`.toThrowError() regexp threw, but message did not match 1`] = `
 "[2mexpect([22m[31mfunction[39m[2m).toThrowError([22m[32mregexp[39m[2m)[22m
 
 Expected the function to throw an error matching:
-  [32m\"/banana/\"[39m
+  [32m/banana/[39m
 Instead, it threw:
 [31m  Error      
       [2mat jestExpect ([22mpackages/jest-matchers/src/__tests__/toThrowMatchers-test.js[2m:24:74)[22m[39m"
@@ -150,7 +150,7 @@ exports[`.toThrowError() regexp threw, but should not have 1`] = `
 "[2mexpect([22m[31mfunction[39m[2m).not.toThrowError([22m[32mregexp[39m[2m)[22m
 
 Expected the function not to throw an error matching:
-  [32m\"/apple/\"[39m
+  [32m/apple/[39m
 Instead, it threw:
 [31m  Error      
       [2mat jestExpect ([22mpackages/jest-matchers/src/__tests__/toThrowMatchers-test.js[2m:24:74)[22m[39m"

--- a/packages/jest-matchers/src/__tests__/spyMatchers-test.js
+++ b/packages/jest-matchers/src/__tests__/spyMatchers-test.js
@@ -80,7 +80,7 @@ describe('toHaveBeenCalledTimes', () => {
   });
 
   it('verifies that actual is a Spy', () => {
-    const fn = () => {};
+    const fn = function fn() {};
 
     let error;
     try {
@@ -168,7 +168,7 @@ describe('toHaveBeenCalledTimes', () => {
 ].forEach(calledWith => {
   test(`${calledWith} works only on spies or jest.fn`, () => {
     let error;
-    const fn = () => {};
+    const fn = function fn() {};
 
     try {
       jestExpect(fn)[calledWith]();

--- a/packages/jest-snapshot/package.json
+++ b/packages/jest-snapshot/package.json
@@ -13,7 +13,7 @@
     "jest-matcher-utils": "15.1.0",
     "jest-util": "^15.1.1",
     "natural-compare": "^1.4.0",
-    "pretty-format": "~4.0.0"
+    "pretty-format": "~4.2.1"
   },
   "scripts": {
     "test": "../jest-cli/bin/jest.js"

--- a/packages/jest-snapshot/src/SnapshotFile.js
+++ b/packages/jest-snapshot/src/SnapshotFile.js
@@ -1,0 +1,180 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+'use strict';
+
+const ReactElementPlugin = require('pretty-format/plugins/ReactElement');
+const ReactTestComponentPlugin = require('pretty-format/plugins/ReactTestComponent');
+
+const createDirectory = require('jest-util').createDirectory;
+const fileExists = require('jest-file-exists');
+const fs = require('fs');
+const naturalCompare = require('natural-compare');
+const path = require('path');
+const prettyFormat = require('pretty-format');
+
+const jsxLikePlugins = [ReactElementPlugin, ReactTestComponentPlugin];
+const SNAPSHOT_EXTENSION = 'snap';
+
+import type {Path} from 'types/Config';
+
+export type SnapshotFileT = SnapshotFile;
+
+export type MatchResult = {
+  actual: string,
+  expected: string,
+  pass: boolean,
+};
+
+type SnapshotData = {[key: string]: string};
+
+type SaveStatus = {
+  deleted: boolean,
+  saved: boolean,
+};
+
+const ensureDirectoryExists = (filePath: Path) => {
+  try {
+    createDirectory(path.join(path.dirname(filePath)));
+  } catch (e) {}
+};
+
+const escape = string => string.replace(/\`/g, '\\\`');
+const unescape = string => string.replace(/\\(\"|\\|\')/g, '$1');
+
+// Extra line breaks at the beginning and at the end of the snapshot are useful
+// to make the content of the snapshot easier to read
+const addExtraLineBreaks =
+  string => string.includes('\n') ? `\n${string}\n` : string;
+
+class SnapshotFile {
+
+  _content: SnapshotData;
+  _dirty: boolean;
+  _filename: Path;
+  _uncheckedKeys: Set<string>;
+
+  constructor(filename: Path): void {
+    this._filename = filename;
+    this._dirty = false;
+
+    this._content = Object.create(null);
+    if (this.fileExists(filename)) {
+      try {
+        delete require.cache[require.resolve(filename)];
+        /* eslint-disable no-useless-call */
+        Object.assign(this._content, require.call(null, filename));
+        /* eslint-enable no-useless-call */
+      } catch (e) {}
+    }
+    this._uncheckedKeys = new Set(Object.keys(this._content));
+  }
+
+  getUncheckedCount(): number {
+    return this._uncheckedKeys.size || 0;
+  }
+
+  fileExists(): boolean {
+    return fileExists(this._filename);
+  }
+
+  removeUncheckedKeys(): void {
+    if (this._uncheckedKeys.size) {
+      this._dirty = true;
+      this._uncheckedKeys.forEach(key => delete this._content[key]);
+      this._uncheckedKeys.clear();
+    }
+  }
+
+  serialize(data: any): string {
+    return addExtraLineBreaks(prettyFormat(data, {
+      plugins: jsxLikePlugins,
+      printFunctionName: false,
+    }));
+  }
+
+  save(update: boolean): SaveStatus {
+    const status = {
+      deleted: false,
+      saved: false,
+    };
+
+    const isEmpty = Object.keys(this._content).length === 0;
+    if ((this._dirty || this._uncheckedKeys.size) && !isEmpty) {
+      const snapshots = Object.keys(this._content).sort(naturalCompare)
+        .map(key =>
+          'exports[`' + escape(key) + '`] = `' +
+          escape(this._content[key]) + '`;',
+        );
+
+      ensureDirectoryExists(this._filename);
+      fs.writeFileSync(this._filename, snapshots.join('\n\n') + '\n');
+      status.saved = true;
+    } else if (isEmpty && this.fileExists()) {
+      if (update) {
+        fs.unlinkSync(this._filename);
+      }
+      status.deleted = true;
+    }
+
+    return status;
+  }
+
+  has(key: string): boolean {
+    return this._content[key] !== undefined;
+  }
+
+  get(key: string): any {
+    return this._content[key];
+  }
+
+  matches(key: string, value: any): MatchResult {
+    this._uncheckedKeys.delete(key);
+    const serialized = this.serialize(value);
+    const actual = unescape(serialized);
+    const expected = this.get(key);
+    const pass = expected === actual;
+    if (pass) {
+      // Executing a snapshot file as JavaScript and writing the strings back
+      // when other snapshots have changed loses the proper escaping for some
+      // characters. Since we check every snapshot in every test, use the newly
+      // generated formatted string.
+      // Note that this is only relevant when a snapshot is added and the dirty
+      // flag is set.
+      this._content[key] = serialized;
+    }
+    return {
+      actual,
+      expected,
+      pass,
+    };
+  }
+
+  add(key: string, value: any): void {
+    this._dirty = true;
+    this._uncheckedKeys.delete(key);
+    this._content[key] = this.serialize(value);
+  }
+
+}
+
+module.exports = {
+  SNAPSHOT_EXTENSION,
+  forFile(testPath: Path): SnapshotFile {
+    const snapshotsPath = path.join(path.dirname(testPath), '__snapshots__');
+
+    const snapshotFilename = path.join(
+      snapshotsPath,
+      path.basename(testPath) + '.' + SNAPSHOT_EXTENSION,
+    );
+
+    return new SnapshotFile(snapshotFilename);
+  },
+  SnapshotFile,
+};

--- a/packages/jest-snapshot/src/State.js
+++ b/packages/jest-snapshot/src/State.js
@@ -14,7 +14,6 @@ import type {Path} from 'types/Config';
 
 const {
   saveSnapshotFile,
-  fileExists,
   getSnapshotData,
   getSnapshotPath,
   keyToTestName,
@@ -22,6 +21,7 @@ const {
   testNameToKey,
   unescape,
 } = require('./utils');
+const fileExists = require('jest-file-exists');
 const fs = require('fs');
 
 class SnapshotState {

--- a/packages/jest-snapshot/src/__tests__/utils-test.js
+++ b/packages/jest-snapshot/src/__tests__/utils-test.js
@@ -14,7 +14,8 @@ const path = require('path');
 test('keyToTestName()', () => {
   expect(keyToTestName('abc cde 12')).toBe('abc cde');
   expect(keyToTestName('abc cde   12')).toBe('abc cde  ');
-  expect(() => keyToTestName('abc cde')).toThrowError('count at the end');
+  expect(() => keyToTestName('abc cde'))
+    .toThrowError('Snapshot keys must end with a number.');
 });
 
 test('testNameToKey', () => {

--- a/packages/jest-snapshot/src/utils.js
+++ b/packages/jest-snapshot/src/utils.js
@@ -21,8 +21,7 @@ const fs = require('fs');
 const naturalCompare = require('natural-compare');
 const ReactTestComponentPlugin = require('pretty-format/plugins/ReactTestComponent');
 
-const jsxLikePlugins = [ReactElementPlugin, ReactTestComponentPlugin];
-
+const PLUGINS = [ReactElementPlugin, ReactTestComponentPlugin];
 const SNAPSHOT_EXTENSION = 'snap';
 
 const testNameToKey = (testName: string, count: number) =>
@@ -56,15 +55,6 @@ const getSnapshotData = (snapshotPath: Path) => {
   return data;
 };
 
-const fileExistsCache = new Map();
-const memoizedFileExists = (filename: Path) => {
-  if (!fileExistsCache.has(filename)) {
-    fileExistsCache.set(filename, fileExists(filename));
-  }
-
-  return fileExistsCache.get(filename);
-};
-
 // Extra line breaks at the beginning and at the end of the snapshot are useful
 // to make the content of the snapshot easier to read
 const addExtraLineBreaks =
@@ -72,7 +62,8 @@ const addExtraLineBreaks =
 
 const serialize = (data: any): string => {
   return addExtraLineBreaks(prettyFormat(data, {
-    plugins: jsxLikePlugins,
+    plugins: PLUGINS,
+    printFunctionName: false,
   }));
 };
 
@@ -110,5 +101,4 @@ module.exports = {
   saveSnapshotFile,
   escape,
   unescape,
-  fileExists: memoizedFileExists,
 };


### PR DESCRIPTION
**Summary**
This diff:
* Updates pretty-format to 4.2.x.
* Removes function names from snapshots. This has been a frequent source of issues, most recently with a Node.js update and istanbul's coverage plugin. Generally I believe that it is some signal to keep the function names in the snapshot but at the same time it isn't something visible in the UI so we shouldn't include them. Fixes #1740.
* Changes jest-diff to use `pretty-format` instead of our own `JSON.stringify` serialization. Fixes #1640 and #1727.
* If two objects are compared (toEqual) and serialize to the same value because of calls to `toJSON`, we now try to create a second diff that doesn't call `toJSON`. The worst case here is that we'll do twice as much work trying to come up with a diff for the user but it seems like an exceptionally rare case that two objects would look identical in both passes and the best case is that the second diff will actually provide signal to the user. Fixes #1728.

**Test plan**
jest