### PR TITLE
Add enzyme example

### DIFF
--- a/examples/enzyme/.babelrc
+++ b/examples/enzyme/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["es2015", "react"]
+}

--- a/examples/enzyme/CheckboxWithLabel.js
+++ b/examples/enzyme/CheckboxWithLabel.js
@@ -1,0 +1,32 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+import React from 'react';
+
+export default class CheckboxWithLabel extends React.Component {
+
+  constructor(props) {
+    super(props);
+    this.state = {isChecked: false};
+
+    // bind manually because React class components don't auto-bind
+    // http://facebook.github.io/react/blog/2015/01/27/react-v0.13.0-beta-1.html#autobinding
+    this.onChange = this.onChange.bind(this);
+  }
+
+  onChange() {
+    this.setState({isChecked: !this.state.isChecked});
+  }
+
+  render() {
+    return (
+      <label>
+        <input
+          type="checkbox"
+          checked={this.state.isChecked}
+          onChange={this.onChange}
+        />
+        {this.state.isChecked ? this.props.labelOn : this.props.labelOff}
+      </label>
+    );
+  }
+}

--- a/examples/enzyme/__tests__/CheckboxWithLabel-test.js
+++ b/examples/enzyme/__tests__/CheckboxWithLabel-test.js
@@ -1,0 +1,20 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+/* eslint-disable no-unused-vars */
+
+import React from 'react';
+import {shallow} from 'enzyme';
+import CheckboxWithLabel from '../CheckboxWithLabel';
+
+it('CheckboxWithLabel changes the text after click', () => {
+  // Render a checkbox with label in the document
+  const checkbox = shallow(
+    <CheckboxWithLabel labelOn="On" labelOff="Off" />
+  );
+
+  expect(checkbox.text()).toEqual('Off');
+
+  checkbox.find('input').simulate('change');
+
+  expect(checkbox.text()).toEqual('On');
+});

--- a/examples/enzyme/package.json
+++ b/examples/enzyme/package.json
@@ -1,0 +1,18 @@
+{
+  "dependencies": {
+    "react": "~15.3.1",
+    "react-dom": "~15.3.1"
+  },
+  "devDependencies": {
+    "babel-jest": "*",
+    "babel-polyfill": "*",
+    "babel-preset-es2015": "*",
+    "babel-preset-react": "*",
+    "enzyme": "~2.4.1",
+    "jest-cli": "*",
+    "react-addons-test-utils": "15.3.2"
+  },
+  "scripts": {
+    "test": "jest"
+  }
+}


### PR DESCRIPTION
**Summary**

Jest's [DOM testing guide](http://facebook.github.io/jest/docs/tutorial-react.html#dom-testing) uses react-test-utils, an example with Enzyme may be nicer and demonstrate how frictionless using 3rd party libraries alongside Jest can be.

I haven't updated the documentation text (yet) because explaining Enzyme's renderer doesn't mock the DOM seems like a distracting nuance but I can't figure out what to write instead. It occurred to me that to many developers an easier title might be "Normal testing" but that's silly.

**Test plan**

```sh
cd examples/enzyme
npm install
npm test
```
