### PR TITLE
Doc tweaks

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -26,7 +26,9 @@ In your test files, Jest puts each of these methods and objects into the global 
   - [`require.requireMock(moduleName)`](#require-requiremock-modulename)
   - [`test(name, fn)`](#basic-testing) is an alias for `it`
   - `xdescribe(name, fn)`
+  - `fdescribe(name, fn)`
   - `xit(name, fn)`
+  - `xtest(name, fn)`
 
 #### Writing assertions with `expect`
 
@@ -538,6 +540,8 @@ describe('an essay on the best flavor', () => {
 })
 ```
 
+This matcher also accepts a string, which it converts to a RegExp.
+
 ### `.toMatchSnapshot()`
 
 This ensures that a React component matches the most recent snapshot. Check out [the React + Jest tutorial](https://facebook.github.io/jest/docs/tutorial-react.html) for more information on snapshot testing.
@@ -819,9 +823,9 @@ jest.mock('../moduleName', () => {
 }, {virtual: true});
 ```
 
-Returns the `jest` object for chaining.
-
 *Note: When using `babel-jest`, calls to `mock` will automatically be hoisted to the top of the code block. Use `doMock` if you want to explicitly avoid this behavior.*
+
+Returns the `jest` object for chaining.
 
 ### `jest.resetModules()`
 
@@ -859,11 +863,14 @@ Exhausts the **micro**-task queue (usually interfaced in node via `process.nextT
 When this API is called, all pending micro-tasks that have been queued via `process.nextTick` will be executed. Additionally, if those micro-tasks themselves schedule new micro-tasks, those will be continually exhausted until there are no more micro-tasks remaining in the queue.
 
 ### `jest.runAllTimers()`
-Exhausts the **macro**-task queue (i.e., all tasks queued by `setTimeout()` and `setInterval()`).
+Exhausts the **macro**-task queue (i.e., all tasks queued by `setTimeout()`, `setInterval()`, and `setImmediate()`).
 
 When this API is called, all pending "macro-tasks" that have been queued via `setTimeout()` or `setInterval()` will be executed. Additionally if those macro-tasks themselves schedule new macro-tasks, those will be continually exhausted until there are no more macro-tasks remaining in the queue.
 
 This is often useful for synchronously executing setTimeouts during a test in order to synchronously assert about some behavior that would only happen after the `setTimeout()` or `setInterval()` callbacks executed. See the [Timer mocks](/jest/docs/timer-mocks.html) doc for more information.
+
+### `jest.runAllImmediates()`
+Exhausts all tasks queued by `setImmediate()`.
 
 ### `jest.runOnlyPendingTimers()`
 Executes only the macro-tasks that are currently pending (i.e., only the tasks that have been queued by `setTimeout()` or `setInterval()` up to this point). If any of the currently pending macro-tasks schedule new macro-tasks, those new tasks will not be executed by this call.

--- a/docs/API.md
+++ b/docs/API.md
@@ -736,6 +736,8 @@ jest.fn(() => {
 ### `jest.clearAllMocks()`
 Clears the `mock.calls` and `mock.instances` properties of all mocks. Equivalent to calling `.mockClear()` on every mocked function.
 
+Returns the `jest` object for chaining.
+
 ### `jest.clearAllTimers()`
 Removes any pending timers from the timer system.
 
@@ -750,10 +752,14 @@ This is usually useful when you have a scenario where the number of dependencies
 
 Examples of dependencies that might be considered "implementation details" are things ranging from language built-ins (e.g. Array.prototype methods) to highly common utility methods (e.g. underscore/lo-dash, array utilities etc) and entire libraries like React.js.
 
+Returns the `jest` object for chaining.
+
 *Note: this method was previously called `autoMockOff`. When using `babel-jest`, calls to `disableAutomock` will automatically be hoisted to the top of the code block. Use `autoMockOff` if you want to explicitly avoid this behavior.*
 
 ### `jest.enableAutomock()`
 Enables automatic mocking in the module loader.
+
+Returns the `jest` object for chaining.
 
 *Note: this method was previously called `autoMockOn`. When using `babel-jest`, calls to `enableAutomock` will automatically be hoisted to the top of the code block. Use `autoMockOn` if you want to explicitly avoid this behavior.*
 
@@ -813,6 +819,8 @@ jest.mock('../moduleName', () => {
 }, {virtual: true});
 ```
 
+Returns the `jest` object for chaining.
+
 *Note: When using `babel-jest`, calls to `mock` will automatically be hoisted to the top of the code block. Use `doMock` if you want to explicitly avoid this behavior.*
 
 ### `jest.resetModules()`
@@ -843,6 +851,8 @@ it('works too', () => {
 });
 ```
 
+Returns the `jest` object for chaining.
+
 ### `jest.runAllTicks()`
 Exhausts the **micro**-task queue (usually interfaced in node via `process.nextTick`).
 
@@ -867,6 +877,8 @@ On occasion there are times where the automatically generated mock the module sy
 
 In these rare scenarios you can use this API to manually fill the slot in the module system's mock-module registry.
 
+Returns the `jest` object for chaining.
+
 *Note It is recommended to use [`jest.mock()`](#jest-mock-modulename-factory) instead. The `jest.mock` API's second argument is a module factory instead of the expected exported module object.*
 
 ### `jest.unmock(moduleName)`
@@ -874,13 +886,19 @@ Indicates that the module system should never return a mocked version of the spe
 
 The most common use of this API is for specifying the module a given test intends to be testing (and thus doesn't want automatically mocked).
 
+Returns the `jest` object for chaining.
+
 *Note: this method was previously called `dontMock`. When using `babel-jest`, calls to `unmock` will automatically be hoisted to the top of the code block. Use `dontMock` if you want to explicitly avoid this behavior.*
 
 ### `jest.useFakeTimers()`
 Instructs Jest to use fake versions of the standard timer functions (`setTimeout`, `setInterval`, `clearTimeout`, `clearInterval`, `nextTick`, `setImmediate` and `clearImmediate`).
 
+Returns the `jest` object for chaining.
+
 ### `jest.useRealTimers()`
 Instructs Jest to use the real versions of the standard timer functions.
+
+Returns the `jest` object for chaining.
 
 ## Miscellaneous
 


### PR DESCRIPTION
**Summary**
Adds some APIs I noticed were missing from documentation. Noted which methods on the `jest` global are chainable.

**Test plan**
N/A? :)