### PR TITLE
Watch Mode, process exits if a test fails and bail is set to true

### DIFF
--- a/packages/jest-cli/src/TestRunner.js
+++ b/packages/jest-cli/src/TestRunner.js
@@ -289,7 +289,7 @@ class TestRunner {
   }
 
   _bailIfNeeded(aggregatedResults: AggregatedResult) {
-    if (this._config.bail && aggregatedResults.numFailedTests !== 0) {
+    if (this._config.bail && !this._config.bail && aggregatedResults.numFailedTests !== 0) {
       this._dispatcher.onRunComplete(this._config, aggregatedResults);
       process.exit(1);
     }

--- a/packages/jest-cli/src/TestRunner.js
+++ b/packages/jest-cli/src/TestRunner.js
@@ -289,7 +289,7 @@ class TestRunner {
   }
 
   _bailIfNeeded(aggregatedResults: AggregatedResult) {
-    if (this._config.bail && !this._config.bail && aggregatedResults.numFailedTests !== 0) {
+    if (this._config.bail && !this._config.watch && aggregatedResults.numFailedTests !== 0) {
       this._dispatcher.onRunComplete(this._config, aggregatedResults);
       process.exit(1);
     }

--- a/packages/jest-cli/src/TestRunner.js
+++ b/packages/jest-cli/src/TestRunner.js
@@ -289,7 +289,8 @@ class TestRunner {
   }
 
   _bailIfNeeded(aggregatedResults: AggregatedResult) {
-    if (this._config.bail && !this._config.watch && aggregatedResults.numFailedTests !== 0) {
+    if (this._config.bail && !this._config.watch &&
+      aggregatedResults.numFailedTests !== 0) {
       this._dispatcher.onRunComplete(this._config, aggregatedResults);
       process.exit(1);
     }


### PR DESCRIPTION
Fixes #1769.

**Summary**
As described in #1769, when running jest in watch mode, if the option bail is set to true and a test fails, then the process will exit while it should not.

**Test plan**
To reproduce, just create a basic test that fails `expect(1).toBe(2);`, set `bail` to `true` and finally run `jest --watch`. With this PR, this should be fixed, since the function `_bailIfNeeded` is now aware of the watch mode.