### PR TITLE
upgrade dependencies to fix npm package deprecate warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "flow-bin": "^0.32.0",
     "glob": "^7.0.6",
     "graceful-fs": "^4.1.6",
-    "istanbul-api": "^1.0.0-aplha.10",
+    "istanbul-api": "^1.1.0-alpha.1",
     "istanbul-lib-coverage": "^1.0.0",
     "jasmine-reporters": "^2.2.0",
     "lerna": "2.0.0-beta.28",


### PR DESCRIPTION
**Summary**
When trying to install jest, npm will give following warning:
```
$ npm install jest
npm WARN deprecated minimatch@2.0.10: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
```

I've upgrade istanbul-api to latest release, minimatch have been upgrade to 3.0.2 and the problem is fixed.

**Test plan**
`npm install` don't give the warning now.
