### PR TITLE
typo-fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@ Painless JavaScript Testing
 
 ## Getting Started
 
-[Egghead.io video](https://egghead.io/lessons/javascript-test-javascript-with-jest)
-
 <generated_getting_started_start />
 [Egghead.io video](https://egghead.io/lessons/javascript-test-javascript-with-jest)
 


### PR DESCRIPTION
Fix the typo error in readme.md file. Removed the duplicate link of the same video.