### PR TITLE
Use name prop as component name for stateless components

### DIFF
--- a/packages/jest-react-native/src/index.js
+++ b/packages/jest-react-native/src/index.js
@@ -14,7 +14,7 @@ module.exports = {
     const Component = class extends RealComponent {
       render() {
         return React.createElement(
-          RealComponent.displayName,
+          RealComponent.name || RealComponent.displayName,
           this.props,
           this.props.children,
         );

--- a/packages/jest-react-native/src/index.js
+++ b/packages/jest-react-native/src/index.js
@@ -14,7 +14,7 @@ module.exports = {
     const Component = class extends RealComponent {
       render() {
         return React.createElement(
-          RealComponent.name || RealComponent.displayName,
+          RealComponent.displayName || RealComponent.name,
           this.props,
           this.props.children,
         );


### PR DESCRIPTION
Now it's able to mock `arrow-style` components aka `stateless components` aka `lambdas`