### PR TITLE
mockComponent: add ability to accept react component

### DIFF
--- a/packages/jest-react-native/src/index.js
+++ b/packages/jest-react-native/src/index.js
@@ -9,8 +9,17 @@
 
 module.exports = {
   mockComponent: moduleName => {
-    const RealComponent = require.requireActual(moduleName);
     const React = require('react');
+    
+    let RealComponent;
+    
+    if (typeof moduleName === 'function' || typeof moduleName === 'object') {
+      // react component is passed
+      RealComponent = moduleName;
+    } else {
+      RealComponent = require.requireActual(moduleName);
+    }
+      
     const Component = class extends RealComponent {
       render() {
         return React.createElement(


### PR DESCRIPTION
Actually depends on https://github.com/facebook/jest/pull/1795 which adds ability to mock stateless components

Why? These 2 PRs actually enable usage of this module in app tests.

It would be just nice to `import` and use `jest-react-native` as a small utility module...