### PR TITLE
Give more feedback when a mock/spy is unexpectedly invoked

### DIFF
--- a/packages/jest-matchers/src/__tests__/__snapshots__/spyMatchers-test.js.snap
+++ b/packages/jest-matchers/src/__tests__/__snapshots__/spyMatchers-test.js.snap
@@ -64,7 +64,7 @@ Expected spy to have been called.]
 exports[`test toBeCalled works with jasmine.createSpy 2`] = `
 [Error: [2mexpect([22m[31mspy[39m[2m).not.toBeCalled([22m[2m)[22m
 
-Expected spy not to be called. But it was called with:
+Expected spy not to be called but it was called with:
   [31mArray [][39m]
 `;
 
@@ -85,7 +85,7 @@ Expected mock function to have been called.]
 exports[`test toBeCalled works with jest.fn 2`] = `
 [Error: [2mexpect([22m[31mjest.fn()[39m[2m).not.toBeCalled([22m[2m)[22m
 
-Expected mock function not to be called. But it was called with:
+Expected mock function not to be called but it was called with:
   [31mArray [][39m]
 `;
 
@@ -162,7 +162,7 @@ Expected spy to have been called.]
 exports[`test toHaveBeenCalled works with jasmine.createSpy 2`] = `
 [Error: [2mexpect([22m[31mspy[39m[2m).not.toHaveBeenCalled([22m[2m)[22m
 
-Expected spy not to be called. But it was called with:
+Expected spy not to be called but it was called with:
   [31mArray [][39m]
 `;
 
@@ -183,7 +183,7 @@ Expected mock function to have been called.]
 exports[`test toHaveBeenCalled works with jest.fn 2`] = `
 [Error: [2mexpect([22m[31mjest.fn()[39m[2m).not.toHaveBeenCalled([22m[2m)[22m
 
-Expected mock function not to be called. But it was called with:
+Expected mock function not to be called but it was called with:
   [31mArray [][39m]
 `;
 

--- a/packages/jest-matchers/src/__tests__/__snapshots__/spyMatchers-test.js.snap
+++ b/packages/jest-matchers/src/__tests__/__snapshots__/spyMatchers-test.js.snap
@@ -64,7 +64,8 @@ Expected spy to have been called.]
 exports[`test toBeCalled works with jasmine.createSpy 2`] = `
 [Error: [2mexpect([22m[31mspy[39m[2m).not.toBeCalled([22m[2m)[22m
 
-Expected spy not to be called, but it was called [31mone time[39m.]
+Expected spy not to be called. But it was called with:
+  [31mArray [][39m]
 `;
 
 exports[`test toBeCalled works with jasmine.createSpy 3`] = `
@@ -84,7 +85,8 @@ Expected mock function to have been called.]
 exports[`test toBeCalled works with jest.fn 2`] = `
 [Error: [2mexpect([22m[31mjest.fn()[39m[2m).not.toBeCalled([22m[2m)[22m
 
-Expected mock function not to be called, but it was called [31mone time[39m.]
+Expected mock function not to be called. But it was called with:
+  [31mArray [][39m]
 `;
 
 exports[`test toBeCalled works with jest.fn 3`] = `
@@ -160,7 +162,8 @@ Expected spy to have been called.]
 exports[`test toHaveBeenCalled works with jasmine.createSpy 2`] = `
 [Error: [2mexpect([22m[31mspy[39m[2m).not.toHaveBeenCalled([22m[2m)[22m
 
-Expected spy not to be called, but it was called [31mone time[39m.]
+Expected spy not to be called. But it was called with:
+  [31mArray [][39m]
 `;
 
 exports[`test toHaveBeenCalled works with jasmine.createSpy 3`] = `
@@ -180,7 +183,8 @@ Expected mock function to have been called.]
 exports[`test toHaveBeenCalled works with jest.fn 2`] = `
 [Error: [2mexpect([22m[31mjest.fn()[39m[2m).not.toHaveBeenCalled([22m[2m)[22m
 
-Expected mock function not to be called, but it was called [31mone time[39m.]
+Expected mock function not to be called. But it was called with:
+  [31mArray [][39m]
 `;
 
 exports[`test toHaveBeenCalled works with jest.fn 3`] = `

--- a/packages/jest-matchers/src/spyMatchers.js
+++ b/packages/jest-matchers/src/spyMatchers.js
@@ -48,8 +48,8 @@ const createToBeCalledMatcher = matcherName => (received, expected) => {
   const pass = count > 0;
   const message = pass
     ? matcherHint('.not' + matcherName, RECEIVED_NAME[type], '') + '\n\n' +
-      `Expected ${type} not to be called. ` +
-      formatReceivedCalls(calls, CALL_PRINT_LIMIT)
+      `Expected ${type} not to be called ` +
+      formatReceivedCalls(calls, CALL_PRINT_LIMIT, {sameSentence: true})
     : matcherHint(matcherName, RECEIVED_NAME[type], '') + '\n\n' +
       `Expected ${type} to have been called.`;
 
@@ -167,6 +167,7 @@ const ensureMock = (mockOrSpy, matcherName) => {
 
 const formatReceivedCalls = (calls, limit, options) => {
   if (calls.length) {
+    const but = (options && options.sameSentence) ? 'but' : 'But';
     const count = calls.length - limit;
     const printedCalls =
       calls
@@ -175,8 +176,8 @@ const formatReceivedCalls = (calls, limit, options) => {
         .map(printReceived)
         .join(', ');
     return (
-      `But it was ${options && options.isLast ? 'last ' : ''}called with:\n` +
-      `  ` + printedCalls +
+      `${but} it was ${options && options.isLast ? 'last ' : ''}called ` +
+      `with:\n  ` + printedCalls +
       (count > 0
         ? '\nand ' + RECEIVED_COLOR(pluralize('more call', count)) + '.'
         : ''

--- a/packages/jest-matchers/src/spyMatchers.js
+++ b/packages/jest-matchers/src/spyMatchers.js
@@ -42,11 +42,14 @@ const createToBeCalledMatcher = matcherName => (received, expected) => {
   const count = receivedIsSpy
     ? received.calls.count()
     : received.mock.calls.length;
+  const calls = receivedIsSpy
+    ? received.calls.all().map(x => x.args)
+    : received.mock.calls;
   const pass = count > 0;
   const message = pass
     ? matcherHint('.not' + matcherName, RECEIVED_NAME[type], '') + '\n\n' +
-      `Expected ${type} not to be called, but it was` +
-      ` called ${RECEIVED_COLOR(pluralize('time', count))}.`
+      `Expected ${type} not to be called. ` +
+      formatReceivedCalls(calls, CALL_PRINT_LIMIT)
     : matcherHint(matcherName, RECEIVED_NAME[type], '') + '\n\n' +
       `Expected ${type} to have been called.`;
 


### PR DESCRIPTION
**Summary**
For a detailed summary, see #1786. TL;DR: when a mock/spy is unexpectedly invoked during a test, output the arguments used in the invocation to ease troubleshooting.

**Test plan**
`npm test` should be enough.
