### PR TITLE
expose runTimersToTime; add to docs; add example

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -876,7 +876,7 @@ Exhausts all tasks queued by `setImmediate()`.
 ### `jest.runTimersToTime(msToRun)`
 Executes only the macro task queue (i.e. all tasks queued by `setTimeout()` or `setInterval()` and `setImmediate()`).
 
-When this API is called, all pending "macro-tasks" that have been queued via `setTimeout()` or `setInterval()`, and would be executed within `msToRun` milliseconds will be exectured. Additionally if those macro-tasks schedule new macro-tasks that would be executed within the same time frame, those will be executed until there are no more macro-tasks remaining in the queue, that should be run within `msToRun` milliseconds.
+When this API is called, all pending "macro-tasks" that have been queued via `setTimeout()` or `setInterval()`, and would be executed within `msToRun` milliseconds will be executed. Additionally if those macro-tasks schedule new macro-tasks that would be executed within the same time frame, those will be executed until there are no more macro-tasks remaining in the queue, that should be run within `msToRun` milliseconds.
 
 ### `jest.runOnlyPendingTimers()`
 Executes only the macro-tasks that are currently pending (i.e., only the tasks that have been queued by `setTimeout()` or `setInterval()` up to this point). If any of the currently pending macro-tasks schedule new macro-tasks, those new tasks will not be executed by this call.

--- a/docs/API.md
+++ b/docs/API.md
@@ -87,6 +87,7 @@ These methods help create mocks and let you control Jest's overall behavior.
   - [`jest.resetModules()`](#jest-resetmodules)
   - [`jest.runAllTicks()`](#jest-runallticks)
   - [`jest.runAllTimers()`](#jest-runalltimers)
+  - [`jest.runTimersToTime()`](#jest-runtimerstotime)
   - [`jest.runOnlyPendingTimers()`](#jest-runonlypendingtimers)
   - [`jest.setMock(moduleName, moduleExports)`](#jest-setmock-modulename-moduleexports)
   - [`jest.unmock(moduleName)`](#jest-unmock-modulename)
@@ -871,6 +872,11 @@ This is often useful for synchronously executing setTimeouts during a test in or
 
 ### `jest.runAllImmediates()`
 Exhausts all tasks queued by `setImmediate()`.
+
+### `jest.runTimersToTime(msToRun)`
+Executes only the macro task queue (i.e. all tasks queued by `setTimeout()` or `setInterval()` and `setImmediate()`).
+
+When this API is called, all pending "macro-tasks" that have been queued via `setTimeout()` or `setInterval()`, and would be executed within `msToRun` milliseconds will be exectured. Additionally if those macro-tasks schedule new macro-tasks that would be executed within the same time frame, those will be executed until there are no more macro-tasks remaining in the queue, that should be run within `msToRun` milliseconds.
 
 ### `jest.runOnlyPendingTimers()`
 Executes only the macro-tasks that are currently pending (i.e., only the tasks that have been queued by `setTimeout()` or `setInterval()` up to this point). If any of the currently pending macro-tasks schedule new macro-tasks, those new tasks will not be executed by this call.

--- a/examples/timer/__tests__/timerGame-test.js
+++ b/examples/timer/__tests__/timerGame-test.js
@@ -47,5 +47,4 @@ describe('timerGame', () => {
     expect(callback.mock.calls.length).toBe(1);
   });
 
-
 });

--- a/examples/timer/__tests__/timerGame-test.js
+++ b/examples/timer/__tests__/timerGame-test.js
@@ -13,7 +13,7 @@ describe('timerGame', () => {
     expect(setTimeout.mock.calls[0][1]).toBe(1000);
   });
 
-  it('calls the callback after 1 second', () => {
+  it('calls the callback after 1 second via runAllTimers', () => {
     const timerGame = require('../timerGame');
     const callback = jest.fn();
 
@@ -29,5 +29,23 @@ describe('timerGame', () => {
     expect(callback).toBeCalled();
     expect(callback.mock.calls.length).toBe(1);
   });
+
+  it('calls the callback after 1 second via runTimersToTime', () => {
+    const timerGame = require('../timerGame');
+    const callback = jest.fn();
+
+    timerGame(callback);
+
+    // At this point in time, the callback should not have been called yet
+    expect(callback).not.toBeCalled();
+
+    // Fast-forward until all timers have been executed
+    jest.runTimersToTime(1000);
+
+    // Now our callback should have been called!
+    expect(callback).toBeCalled();
+    expect(callback.mock.calls.length).toBe(1);
+  });
+
 
 });

--- a/packages/jest-runtime/src/index.js
+++ b/packages/jest-runtime/src/index.js
@@ -772,6 +772,8 @@ class Runtime {
       runAllTicks: () => this._environment.fakeTimers.runAllTicks(),
       runAllImmediates: () => this._environment.fakeTimers.runAllImmediates(),
       runAllTimers: () => this._environment.fakeTimers.runAllTimers(),
+      runTimersToTime: (msToRun: number) =>
+        this._environment.fakeTimers.runTimersToTime(msToRun),
       runOnlyPendingTimers: () =>
         this._environment.fakeTimers.runOnlyPendingTimers(),
 

--- a/types/Environment.js
+++ b/types/Environment.js
@@ -24,6 +24,7 @@ export type Environment = {|
     runAllImmediates(): void;
     runAllTicks(): void;
     runAllTimers(): void;
+    runTimersToTime(): void;
     runOnlyPendingTimers(): void;
     runWithRealTimers(callback: any): void;
     useFakeTimers(): void;


### PR DESCRIPTION
**Summary**
Jest doesn't currently expose `runTimersToTime` during test runs, even though it supports it internally.

**Test plan**
I've added a test to examples/timers that uses this newly exposed functionality.