### PR TITLE
Fixes bug in watchman.js that constructs invalid queries

### DIFF
--- a/packages/jest-haste-map/src/crawlers/watchman.js
+++ b/packages/jest-haste-map/src/crawlers/watchman.js
@@ -72,8 +72,10 @@ module.exports = function watchmanCrawl(
             ['anyof'].concat(extensions.map(
               extension => ['suffix', extension],
             )),
-            dirExpr,
           ];
+          if (dirExpr.length > 1) {
+            expression.push(dirExpr);
+          }
           const fields = ['name', 'exists', 'mtime_ms'];
 
           const query = clocks[root]


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

This addresses the watchman issue shown here:
<img width="960" alt="screen shot 2016-09-27 at 12 21 54 pm" src="https://cloud.githubusercontent.com/assets/1830497/18888404/0765390e-84ad-11e6-893d-6dab9bbd5962.png">


This happens when dirExpr isn't a valid query and it causes watchman to crash

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

npm run build && npm run test