### PR TITLE
Polish concurrent runner output.

### DIFF
--- a/packages/jest-cli/src/TestRunner.js
+++ b/packages/jest-cli/src/TestRunner.js
@@ -166,12 +166,6 @@ class TestRunner {
     const estimatedTime =
       Math.ceil(getEstimatedTime(timings, this._options.maxWorkers) / 1000);
 
-    this._dispatcher.onRunStart(
-      config,
-      aggregatedResults,
-      {estimatedTime},
-    );
-
     const onTestResult = (testPath: Path, testResult: TestResult) => {
       if (testResult.testResults.length === 0) {
         const message = 'Your test suite must contain at least one test.';
@@ -242,8 +236,18 @@ class TestRunner {
       )
     );
 
+    const runInBand = shouldRunInBand();
+    this._dispatcher.onRunStart(
+      config,
+      aggregatedResults,
+      {
+        estimatedTime,
+        showStatus: !runInBand,
+      },
+    );
+
     const testRun =
-      shouldRunInBand()
+      runInBand
       ? this._createInBandTestRun(testPaths, onTestResult, onRunFailure)
       : this._createParallelTestRun(testPaths, onTestResult, onRunFailure);
 
@@ -334,6 +338,7 @@ class TestRunner {
       const CoverageReporter = require('./reporters/CoverageReporter');
       this.addReporter(new CoverageReporter());
     }
+
     this.addReporter(new SummaryReporter());
     if (this._config.notify) {
       this.addReporter(new NotifyReporter());

--- a/packages/jest-cli/src/jest.js
+++ b/packages/jest-cli/src/jest.js
@@ -158,7 +158,7 @@ const runJest = (config, argv, pipe, onComplete) => {
           }
 
           localConsole.log(
-            source.getNoTestsFoundMessage(patternInfo, config, data) + '\n',
+            source.getNoTestsFoundMessage(patternInfo, config, data),
           );
         }
         return data;

--- a/packages/jest-cli/src/reporters/BaseReporter.js
+++ b/packages/jest-cli/src/reporters/BaseReporter.js
@@ -13,7 +13,6 @@ import type {AggregatedResult, TestResult} from 'types/TestResult';
 import type {Config, Path} from 'types/Config';
 import type {ReporterOnStartOptions, RunnerContext} from 'types/Reporters';
 
-const clearLine = require('jest-util').clearLine;
 const preRunMessage = require('../preRunMessage');
 
 class BaseReporter {
@@ -49,10 +48,6 @@ class BaseReporter {
     aggregatedResults: AggregatedResult,
     runnerContext: RunnerContext,
   ): ?Promise<any> {}
-
-  clearLine() {
-    clearLine(process.stderr);
-  }
 
   _setError(error: Error) {
     this._error = error;

--- a/packages/jest-cli/src/reporters/CoverageReporter.js
+++ b/packages/jest-cli/src/reporters/CoverageReporter.js
@@ -22,6 +22,7 @@ type CoverageMap = {|
 
 const BaseReporter = require('./BaseReporter');
 
+const {clearLine} = require('jest-util');
 const {createReporter} = require('istanbul-api');
 const chalk = require('chalk');
 const fs = require('fs');
@@ -124,7 +125,7 @@ class CoverageReporter extends BaseReporter {
         }
       });
       if (isInteractive) {
-        this.clearLine();
+        clearLine(process.stderr);
       }
     }
   }

--- a/packages/jest-cli/src/reporters/DefaultReporter.js
+++ b/packages/jest-cli/src/reporters/DefaultReporter.js
@@ -19,6 +19,7 @@ import type {ReporterOnStartOptions, RunnerContext} from 'types/Reporters';
 const BaseReporter = require('./BaseReporter');
 const Status = require('./Status');
 
+const {clearLine} = require('jest-util');
 const chalk = require('chalk');
 const getConsoleOutput = require('./getConsoleOutput');
 const getResultHeader = require('./getResultHeader');
@@ -125,7 +126,7 @@ class DefaultReporter extends BaseReporter {
     process.stdout.write = this._out;
     // $FlowFixMe
     process.stderr.write = this._err;
-    this.clearLine();
+    clearLine(process.stderr);
   }
 
   onTestResult(

--- a/packages/jest-cli/src/reporters/SummaryReporter.js
+++ b/packages/jest-cli/src/reporters/SummaryReporter.js
@@ -79,30 +79,31 @@ class SummareReporter extends BaseReporter {
     aggregatedResults: AggregatedResult,
     runnerContext: RunnerContext,
   ) {
-    const {testResults} = aggregatedResults;
-    const lastResult = testResults[testResults.length - 1];
-    // Print a newline if the last test did not fail to line up newlines if the
-    // test had failed.
-    if (
-      !config.verbose &&
-      lastResult &&
-      !lastResult.numFailingTests &&
-      !lastResult.testExecError
-    ) {
-      this.log('');
-    }
+    if (aggregatedResults.numTotalTestSuites) {
+      const {testResults} = aggregatedResults;
+      const lastResult = testResults[testResults.length - 1];
+      // Print a newline if the last test did not fail to line up newlines
+      // similar to when an error would have been thrown in the test.
+      if (
+        !config.verbose &&
+        lastResult &&
+        !lastResult.numFailingTests &&
+        !lastResult.testExecError
+      ) {
+        this.log('');
+      }
 
-    this._printSummary(aggregatedResults, config);
-    this._printSnapshotSummary(aggregatedResults.snapshot, config);
-    this.log(
-      (aggregatedResults.numTotalTestSuites
-        ? getSummary(aggregatedResults, {
-          estimatedTime: this._estimatedTime,
-        })
-        : ''
-      ) +
-      '\n' + runnerContext.getTestSummary(),
-    );
+      this._printSummary(aggregatedResults, config);
+      this._printSnapshotSummary(aggregatedResults.snapshot, config);
+
+      this.log(
+        aggregatedResults.numTotalTestSuites
+          ? getSummary(aggregatedResults, {
+            estimatedTime: this._estimatedTime,
+          }) + '\n' + runnerContext.getTestSummary()
+          : '',
+      );
+    }
   }
 
   _printSnapshotSummary(snapshots: SnapshotSummary, config: Config) {

--- a/types/Reporters.js
+++ b/types/Reporters.js
@@ -18,4 +18,5 @@ export type RunnerContext = {|
 
 export type ReporterOnStartOptions = {|
   estimatedTime: number,
+  showStatus: boolean,
 |};


### PR DESCRIPTION
**Summary**
* Fixes #1782 by immediately printing "RUNS" in the single process mode between tests and hiding the summary.
* Hides the cursor and removes a trailing newline.

**Test plan**

`jest cli -i`, `jest haste-map`, `jest` and watch the output.