### PR TITLE
Add `forceNodeFilesystemAPI` option to `jest-haste-map`

### DIFF
--- a/packages/jest-haste-map/src/__tests__/index-test.js
+++ b/packages/jest-haste-map/src/__tests__/index-test.js
@@ -28,7 +28,12 @@ jest.mock('worker-farm', () => {
 
 jest.mock('../crawlers/node');
 jest.mock('../crawlers/watchman', () =>
-  jest.fn((roots, extensions, ignore, data) => {
+  jest.fn(options => {
+    const {
+      data,
+      ignore,
+      roots,
+    } = options;
     data.clocks = mockClocks;
 
     const list = mockChangedFiles || mockFs;
@@ -484,8 +489,9 @@ describe('HasteMap', () => {
     const watchman = require('../crawlers/watchman');
     const mockImpl = watchman.getMockImplementation();
     // Wrap the watchman mock and add an invalid file to the file list.
-    watchman.mockImplementation((roots, extensions, ignore, data) => {
-      return mockImpl(roots, extensions, ignore, data).then(() => {
+    watchman.mockImplementation(options => {
+      return mockImpl(options).then(() => {
+        const {data} = options;
         data.files['/fruits/invalid/file.js'] = ['', 34, 0, []];
         return data;
       });
@@ -527,7 +533,8 @@ describe('HasteMap', () => {
     watchman.mockImplementation(() => {
       throw new Error('watchman error');
     });
-    node.mockImplementation((roots, extensions, ignore, data) => {
+    node.mockImplementation(options => {
+      const {data} = options;
       data.files = object({
         '/fruits/banana.js': ['', 32, 0, []],
       });
@@ -554,7 +561,8 @@ describe('HasteMap', () => {
     watchman.mockImplementation(() => {
       return Promise.reject(new Error('watchman error'));
     });
-    node.mockImplementation((roots, extensions, ignore, data) => {
+    node.mockImplementation(options => {
+      const {data} = options;
       data.files = object({
         '/fruits/banana.js': ['', 32, 0, []],
       });

--- a/packages/jest-haste-map/src/crawlers/__tests__/node-test.js
+++ b/packages/jest-haste-map/src/crawlers/__tests__/node-test.js
@@ -175,7 +175,7 @@ describe('node crawler', () => {
     });
   });
 
-  it('uses node fs APIs if "forceNodeFSApi" is set to true, regardless of platform', () => {
+  it('uses node fs APIs if "forceNodeFilesystemAPI" is set to true, regardless of platform', () => {
     process.platform = 'linux';
 
     nodeCrawl = require('../node');
@@ -184,7 +184,7 @@ describe('node crawler', () => {
     return nodeCrawl({
       data: {files},
       extensions: ['js'],
-      forceNodeFSApi: true,
+      forceNodeFilesystemAPI: true,
       ignore: pearMatcher,
       roots: ['/fruits'],
     }).then(data => {

--- a/packages/jest-haste-map/src/crawlers/__tests__/node-test.js
+++ b/packages/jest-haste-map/src/crawlers/__tests__/node-test.js
@@ -94,14 +94,14 @@ describe('node crawler', () => {
       '/vegetables/melon.json',
     ].join('\n');
 
-    const promise = nodeCrawl(
-      ['/fruits', '/vegtables'],
-      ['js', 'json'],
-      pearMatcher,
-      {
+    const promise = nodeCrawl({
+      data: {
         files: Object.create(null),
       },
-    ).then(data => {
+      extensions: ['js', 'json'],
+      ignore: pearMatcher,
+      roots: ['/fruits', '/vegtables'],
+    }).then(data => {
       expect(childProcess.spawn).lastCalledWith('find', [
         '/fruits',
         '/vegtables',
@@ -140,16 +140,20 @@ describe('node crawler', () => {
     files['/fruits/strawberry.js'] = ['', 30, 1, []];
     files['/fruits/tomato.js'] = tomato;
 
-    return nodeCrawl(['/fruits'], ['js'], pearMatcher, {files})
-      .then(data => {
-        expect(data.files).toEqual({
-          '/fruits/strawberry.js': ['', 32, 0, []],
-          '/fruits/tomato.js': tomato,
-        });
-
-        // Make sure it is the *same* unchanged object.
-        expect(data.files['/fruits/tomato.js']).toBe(tomato);
+    return nodeCrawl({
+      data: {files},
+      extensions: ['js'],
+      ignore: pearMatcher,
+      roots: ['/fruits'],
+    }).then(data => {
+      expect(data.files).toEqual({
+        '/fruits/strawberry.js': ['', 32, 0, []],
+        '/fruits/tomato.js': tomato,
       });
+
+      // Make sure it is the *same* unchanged object.
+      expect(data.files['/fruits/tomato.js']).toBe(tomato);
+    });
   });
 
   it('uses node fs APIs on windows', () => {
@@ -158,13 +162,36 @@ describe('node crawler', () => {
     nodeCrawl = require('../node');
 
     const files = Object.create(null);
-    return nodeCrawl(['/fruits'], ['js'], pearMatcher, {files})
-      .then(data => {
-        expect(data.files).toEqual({
-          '/fruits/tomato.js': ['', 32, 0, []],
-          '/fruits/directory/strawberry.js': ['', 33, 0, []],
-        });
+    return nodeCrawl({
+      data: {files},
+      extensions: ['js'],
+      ignore: pearMatcher,
+      roots: ['/fruits'],
+    }).then(data => {
+      expect(data.files).toEqual({
+        '/fruits/tomato.js': ['', 32, 0, []],
+        '/fruits/directory/strawberry.js': ['', 33, 0, []],
       });
+    });
   });
 
+  it('uses node fs APIs if "forceNodeFSApi" is set to true, regardless of platform', () => {
+    process.platform = 'linux';
+
+    nodeCrawl = require('../node');
+
+    const files = Object.create(null);
+    return nodeCrawl({
+      data: {files},
+      extensions: ['js'],
+      forceNodeFSApi: true,
+      ignore: pearMatcher,
+      roots: ['/fruits'],
+    }).then(data => {
+      expect(data.files).toEqual({
+        '/fruits/tomato.js': ['', 32, 0, []],
+        '/fruits/directory/strawberry.js': ['', 33, 0, []],
+      });
+    });
+  });
 });

--- a/packages/jest-haste-map/src/crawlers/__tests__/watchman-test.js
+++ b/packages/jest-haste-map/src/crawlers/__tests__/watchman-test.js
@@ -88,15 +88,15 @@ describe('watchman watch', () => {
     const originalPathRelative = path.relative;
     path.relative = jest.fn(from => '/root-mock' + from);
 
-    return watchmanCrawl(
-      ['/fruits', '/vegetables'],
-      ['js', 'json'],
-      pearMatcher,
-      {
+    return watchmanCrawl({
+      data: {
         clocks: Object.create(null),
         files: Object.create(null),
       },
-    ).then(data => {
+      extensions: ['js', 'json'],
+      ignore: pearMatcher,
+      roots: ['/fruits', '/vegetables'],
+    }).then(data => {
       const client = watchman.Client.mock.instances[0];
       const calls = client.command.mock.calls;
 
@@ -176,15 +176,15 @@ describe('watchman watch', () => {
       '/vegetables': 'c:fake-clock:2',
     });
 
-    return watchmanCrawl(
-      ['/fruits', '/vegetables'],
-      ['js', 'json'],
-      pearMatcher,
-      {
+    return watchmanCrawl({
+      data: {
         clocks,
         files: mockFiles,
       },
-    ).then(data => {
+      extensions: ['js', 'json'],
+      ignore: pearMatcher,
+      roots: ['/fruits', '/vegetables'],
+    }).then(data => {
       // The object was reused.
       expect(data.files).toBe(mockFiles);
 
@@ -241,15 +241,15 @@ describe('watchman watch', () => {
       '/vegetables': 'c:fake-clock:2',
     });
 
-    return watchmanCrawl(
-      ['/fruits', '/vegetables'],
-      ['js', 'json'],
-      pearMatcher,
-      {
+    return watchmanCrawl({
+      data: {
         clocks,
         files: mockFiles,
       },
-    ).then(data => {
+      extensions: ['js', 'json'],
+      ignore: pearMatcher,
+      roots: ['/fruits', '/vegetables'],
+    }).then(data => {
       // The file object was *not* reused.
       expect(data.files).not.toBe(mockFiles);
 
@@ -307,15 +307,15 @@ describe('watchman watch', () => {
       '/vegetables': 'c:fake-clock:2',
     });
 
-    return watchmanCrawl(
-      ['/fruits', '/vegetables'],
-      ['js', 'json'],
-      pearMatcher,
-      {
+    return watchmanCrawl({
+      data: {
         clocks,
         files: mockFiles,
       },
-    ).then(data => {
+      extensions: ['js', 'json'],
+      ignore: pearMatcher,
+      roots: ['/fruits', '/vegetables'],
+    }).then(data => {
       expect(data.clocks).toEqual({
         '/fruits': 'c:fake-clock:3',
         '/vegetables': 'c:fake-clock:4',
@@ -327,5 +327,4 @@ describe('watchman watch', () => {
       });
     });
   });
-
 });

--- a/packages/jest-haste-map/src/crawlers/node.js
+++ b/packages/jest-haste-map/src/crawlers/node.js
@@ -124,6 +124,7 @@ module.exports = function nodeCrawl(
   extensions: Array<string>,
   ignore: IgnoreMatcher,
   data: InternalHasteMap,
+  forceNativeFind: boolean = false,
 ): Promise<InternalHasteMap> {
   return new Promise(resolve => {
     const callback = list => {
@@ -143,7 +144,7 @@ module.exports = function nodeCrawl(
       resolve(data);
     };
 
-    if (process.platform === 'win32') {
+    if (process.platform === 'win32' && !forceNativeFind) {
       find(roots, extensions, ignore, callback);
     } else {
       findNative(roots, extensions, ignore, callback);

--- a/packages/jest-haste-map/src/crawlers/node.js
+++ b/packages/jest-haste-map/src/crawlers/node.js
@@ -9,9 +9,8 @@
  */
 'use strict';
 
-import type {CrawlerOptions} from '../types';
 import type {InternalHasteMap} from 'types/HasteMap';
-import type {IgnoreMatcher} from '../types';
+import type {IgnoreMatcher, CrawlerOptions} from '../types';
 
 const H = require('../constants');
 

--- a/packages/jest-haste-map/src/crawlers/node.js
+++ b/packages/jest-haste-map/src/crawlers/node.js
@@ -20,15 +20,13 @@ const path = require('path');
 const spawn = require('child_process').spawn;
 
 type Callback = (result: Array<[/* id */ string, /* mtime */ number]>) => void;
-type FindOptions = {
-  callback: Callback,
+
+function find(
+  roots: Array<string>,
   extensions: Array<string>,
   ignore: IgnoreMatcher,
-  roots: Array<string>,
-};
-
-function find(options: FindOptions): void {
-  const {callback, extensions, ignore, roots} = options;
+  callback: Callback,
+): void {
   const result = [];
   let activeCalls = 0;
 
@@ -72,8 +70,12 @@ function find(options: FindOptions): void {
   roots.forEach(search);
 }
 
-function findNative(options: FindOptions): void {
-  const {callback, extensions, ignore, roots} = options;
+function findNative(
+  roots: Array<string>,
+  extensions: Array<string>,
+  ignore: IgnoreMatcher,
+  callback: Callback,
+): void {
   const args = [].concat(roots);
   args.push('-type', 'f');
   if (extensions.length) {
@@ -124,7 +126,7 @@ module.exports = function nodeCrawl(
   const {
     data,
     extensions,
-    forceNodeFSApi,
+    forceNodeFilesystemAPI,
     ignore,
     roots,
   } = options;
@@ -147,10 +149,10 @@ module.exports = function nodeCrawl(
       resolve(data);
     };
 
-    if (forceNodeFSApi || process.platform === 'win32') {
-      find({callback, extensions, ignore, roots});
+    if (forceNodeFilesystemAPI || process.platform === 'win32') {
+      find(roots, extensions, ignore, callback);
     } else {
-      findNative({callback, extensions, ignore, roots});
+      findNative(roots, extensions, ignore, callback);
     }
   });
 };

--- a/packages/jest-haste-map/src/crawlers/watchman.js
+++ b/packages/jest-haste-map/src/crawlers/watchman.js
@@ -9,8 +9,8 @@
  */
 'use strict';
 
+import type {CrawlerOptions} from '../types';
 import type {InternalHasteMap} from 'types/HasteMap';
-import type {IgnoreMatcher} from '../types';
 
 const H = require('../constants');
 
@@ -31,11 +31,15 @@ function WatchmanError(error: Error): Error {
 }
 
 module.exports = function watchmanCrawl(
-  roots: Array<string>,
-  extensions: Array<string>,
-  ignore: IgnoreMatcher,
-  data: InternalHasteMap,
+  options: CrawlerOptions,
 ): Promise<InternalHasteMap> {
+  const {
+    data,
+    extensions,
+    ignore,
+    roots,
+  } = options;
+
   return new Promise((resolve, reject) => {
     const client = new watchman.Client();
     client.on('error', error => reject(error));

--- a/packages/jest-haste-map/src/index.js
+++ b/packages/jest-haste-map/src/index.js
@@ -39,7 +39,7 @@ type Options = {
   cacheDirectory?: string,
   console?: Console,
   extensions: Array<string>,
-  forceNativeFind?: boolean,
+  forceNodeFSApi?: boolean,
   ignorePattern: RegExp,
   maxWorkers: number,
   mocksPattern?: string,
@@ -56,7 +56,7 @@ type Options = {
 type InternalOptions = {
   cacheDirectory: string,
   extensions: Array<string>,
-  forceNativeFind: boolean,
+  forceNodeFSApi: boolean,
   ignorePattern: RegExp,
   maxWorkers: number,
   mocksPattern: ?RegExp,
@@ -181,7 +181,7 @@ class HasteMap {
     this._options = {
       cacheDirectory: options.cacheDirectory || os.tmpdir(),
       extensions: options.extensions,
-      forceNativeFind: !!options.forceNativeFind,
+      forceNodeFSApi: !!options.forceNodeFSApi,
       ignorePattern: options.ignorePattern,
       maxWorkers: options.maxWorkers,
       mocksPattern:
@@ -419,32 +419,32 @@ class HasteMap {
           `initialize a git or hg repository in your project.\n` +
           `  ` + error,
         );
-        return nodeCrawl(
-          options.roots,
-          options.extensions,
+        return nodeCrawl({
+          data: hasteMap,
+          extensions: options.extensions,
+          forceNodeFSApi: options.forceNodeFSApi,
           ignore,
-          hasteMap,
-          options.forceNativeFind,
-        ).catch(e => {
-            throw new Error(
-              `Crawler retry failed:\n` +
-              `  Original error: ${error.message}\n` +
-              `  Retry error: ${e.message}\n`,
-            );
-          });
+          roots: options.roots,
+        }).catch(e => {
+          throw new Error(
+            `Crawler retry failed:\n` +
+            `  Original error: ${error.message}\n` +
+            `  Retry error: ${e.message}\n`,
+          );
+        });
       }
 
       throw error;
     };
 
     try {
-      return crawl(
-        options.roots,
-        options.extensions,
+      return crawl({
+        data: hasteMap,
+        extensions: options.extensions,
+        forceNodeFSApi: options.forceNodeFSApi,
         ignore,
-        hasteMap,
-        options.forceNativeFind,
-      ).catch(retry);
+        roots: options.roots,
+      }).catch(retry);
     } catch (error) {
       return retry(error);
     }

--- a/packages/jest-haste-map/src/index.js
+++ b/packages/jest-haste-map/src/index.js
@@ -39,6 +39,7 @@ type Options = {
   cacheDirectory?: string,
   console?: Console,
   extensions: Array<string>,
+  forceNativeFind?: boolean,
   ignorePattern: RegExp,
   maxWorkers: number,
   mocksPattern?: string,
@@ -55,6 +56,7 @@ type Options = {
 type InternalOptions = {
   cacheDirectory: string,
   extensions: Array<string>,
+  forceNativeFind: boolean,
   ignorePattern: RegExp,
   maxWorkers: number,
   mocksPattern: ?RegExp,
@@ -179,6 +181,7 @@ class HasteMap {
     this._options = {
       cacheDirectory: options.cacheDirectory || os.tmpdir(),
       extensions: options.extensions,
+      forceNativeFind: !!options.forceNativeFind,
       ignorePattern: options.ignorePattern,
       maxWorkers: options.maxWorkers,
       mocksPattern:
@@ -416,8 +419,13 @@ class HasteMap {
           `initialize a git or hg repository in your project.\n` +
           `  ` + error,
         );
-        return nodeCrawl(options.roots, options.extensions, ignore, hasteMap)
-          .catch(e => {
+        return nodeCrawl(
+          options.roots,
+          options.extensions,
+          ignore,
+          hasteMap,
+          options.forceNativeFind,
+        ).catch(e => {
             throw new Error(
               `Crawler retry failed:\n` +
               `  Original error: ${error.message}\n` +
@@ -430,8 +438,13 @@ class HasteMap {
     };
 
     try {
-      return crawl(options.roots, options.extensions, ignore, hasteMap)
-        .catch(retry);
+      return crawl(
+        options.roots,
+        options.extensions,
+        ignore,
+        hasteMap,
+        options.forceNativeFind,
+      ).catch(retry);
     } catch (error) {
       return retry(error);
     }

--- a/packages/jest-haste-map/src/index.js
+++ b/packages/jest-haste-map/src/index.js
@@ -39,7 +39,7 @@ type Options = {
   cacheDirectory?: string,
   console?: Console,
   extensions: Array<string>,
-  forceNodeFSApi?: boolean,
+  forceNodeFilesystemAPI?: boolean,
   ignorePattern: RegExp,
   maxWorkers: number,
   mocksPattern?: string,
@@ -56,7 +56,7 @@ type Options = {
 type InternalOptions = {
   cacheDirectory: string,
   extensions: Array<string>,
-  forceNodeFSApi: boolean,
+  forceNodeFilesystemAPI: boolean,
   ignorePattern: RegExp,
   maxWorkers: number,
   mocksPattern: ?RegExp,
@@ -181,7 +181,7 @@ class HasteMap {
     this._options = {
       cacheDirectory: options.cacheDirectory || os.tmpdir(),
       extensions: options.extensions,
-      forceNodeFSApi: !!options.forceNodeFSApi,
+      forceNodeFilesystemAPI: !!options.forceNodeFilesystemAPI,
       ignorePattern: options.ignorePattern,
       maxWorkers: options.maxWorkers,
       mocksPattern:
@@ -422,7 +422,7 @@ class HasteMap {
         return nodeCrawl({
           data: hasteMap,
           extensions: options.extensions,
-          forceNodeFSApi: options.forceNodeFSApi,
+          forceNodeFilesystemAPI: options.forceNodeFilesystemAPI,
           ignore,
           roots: options.roots,
         }).catch(e => {
@@ -441,7 +441,7 @@ class HasteMap {
       return crawl({
         data: hasteMap,
         extensions: options.extensions,
-        forceNodeFSApi: options.forceNodeFSApi,
+        forceNodeFilesystemAPI: options.forceNodeFilesystemAPI,
         ignore,
         roots: options.roots,
       }).catch(retry);

--- a/packages/jest-haste-map/src/types.js
+++ b/packages/jest-haste-map/src/types.js
@@ -10,8 +10,7 @@
 'use strict';
 
 import type {Error} from 'types/TestResult';
-import type {InternalHasteMap} from 'types/HasteMap';
-import type {ModuleMetaData} from 'types/HasteMap';
+import type {InternalHasteMap, ModuleMetaData} from 'types/HasteMap';
 
 export type IgnoreMatcher = (item: string) => boolean;
 
@@ -25,10 +24,10 @@ export type WorkerMetadata = {
 };
 export type WorkerCallback = (error: ?Error, metaData: ?WorkerMetadata) => void;
 
-export type CrawlerOptions = {
+export type CrawlerOptions = {|
   data: InternalHasteMap,
   extensions: Array<string>,
-  forceNodeFSApi: boolean,
+  forceNodeFilesystemAPI: boolean,
   ignore: IgnoreMatcher,
   roots: Array<string>,
-};
+|};

--- a/packages/jest-haste-map/src/types.js
+++ b/packages/jest-haste-map/src/types.js
@@ -10,6 +10,7 @@
 'use strict';
 
 import type {Error} from 'types/TestResult';
+import type {InternalHasteMap} from 'types/HasteMap';
 import type {ModuleMetaData} from 'types/HasteMap';
 
 export type IgnoreMatcher = (item: string) => boolean;
@@ -23,3 +24,11 @@ export type WorkerMetadata = {
   dependencies: ?Array<string>,
 };
 export type WorkerCallback = (error: ?Error, metaData: ?WorkerMetadata) => void;
+
+export type CrawlerOptions = {
+  data: InternalHasteMap,
+  extensions: Array<string>,
+  forceNodeFSApi: boolean,
+  ignore: IgnoreMatcher,
+  roots: Array<string>,
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Add `forceNodeFilesystemAPI` option that forces the node crawler to use the Node file system API regardless of platform.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
unit test

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

