### PR TITLE
fix swallowed error causing jest to hang up

### DIFF
--- a/packages/jest-haste-map/src/index.js
+++ b/packages/jest-haste-map/src/index.js
@@ -75,8 +75,9 @@ const canUseWatchman = ((): boolean => {
   try {
     execSync('watchman version', {stdio: ['ignore']});
     return true;
-  } catch (e) {}
-  return false;
+  } catch (e) {
+    return false;
+  }
 })();
 
 const escapePathSeparator =


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

See what I initially thought the issue was [here](https://github.com/facebook/jest/issues/1820). The memory leak warning was fixed with `npm install -g npm@next` (thanks for the tip), but the jest issue still remained.

I couldn't get any output at all when running `jest`, so I looked into the packages and found an empty catch block in `jest-haste-map/src/index.js` resulting in a swallowed error. The problem caused jest to never run or properly exit and the jest prompt would hang there continuously.

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

All tests passed after running `npm test`. 

