### PR TITLE
Convert rest of tests to use toThowErrorMatchingSnapshot matcher

### DIFF
--- a/packages/jest-jasmine2/src/__tests__/matchers-test.js
+++ b/packages/jest-jasmine2/src/__tests__/matchers-test.js
@@ -11,14 +11,7 @@
 
 describe('matchers', () => {
   it('proxies matchers to jest-matchers', () => {
-    let error;
-    try {
-      expect(1).toBe(2);
-    } catch (e) {
-      error = e;
-    }
-
-    expect(error).toBeDefined();
-    expect(error.message).toMatchSnapshot();
+    expect(() => expect(1).toBe(2))
+      .toThrowErrorMatchingSnapshot();
   });
 });

--- a/packages/jest-matcher-utils/src/__tests__/index-test.js
+++ b/packages/jest-matcher-utils/src/__tests__/index-test.js
@@ -67,15 +67,8 @@ describe('.stringify()', () => {
       toJSON,
     };
 
-    let error;
-    try {
-      expect(evilA).toEqual(evilB);
-    } catch (e) {
-      error = e;
-    }
-
-    expect(error).toBeDefined();
-    expect(error.message).toMatchSnapshot();
+    expect(() => expect(evilA).toEqual(evilB))
+      .toThrowErrorMatchingSnapshot();
   });
 });
 

--- a/packages/jest-matchers/src/__tests__/__snapshots__/addMatchers-test.js.snap
+++ b/packages/jest-matchers/src/__tests__/__snapshots__/addMatchers-test.js.snap
@@ -1,0 +1,1 @@
+exports[`test is available globally 1`] = `"expected 15 to be divisible by 2"`;

--- a/packages/jest-matchers/src/__tests__/addMatchers-test.js
+++ b/packages/jest-matchers/src/__tests__/addMatchers-test.js
@@ -28,13 +28,6 @@ it('is available globally', () => {
   expect(15).toBeDivisibleBy(3);
   expect(15).not.toBeDivisibleBy(6);
 
-  let error;
-  try {
-    expect(15).toBeDivisibleBy(2);
-  } catch (e) {
-    error = e;
-  }
-
-  expect(error).toBeDefined();
-  expect(error.message).toMatch(/to be divisible/);
+  expect(() => expect(15).toBeDivisibleBy(2))
+    .toThrowErrorMatchingSnapshot();
 });


### PR DESCRIPTION
**Summary**

Convert rest of tests that's follow `toThowErrorMatchingSnapshot` matcher pattern to use matcher instead

**Test plan**
jest
