### PR TITLE
All matcher messages must be lazy; SummaryReporter prints per character.

### DIFF
--- a/packages/jest-cli/src/reporters/SummaryReporter.js
+++ b/packages/jest-cli/src/reporters/SummaryReporter.js
@@ -64,6 +64,17 @@ class SummareReporter extends BaseReporter {
     this._estimatedTime = 0;
   }
 
+  // If we write more than one character at a time it is possible that
+  // Node.js exits in the middle of printing the result. This was first observed
+  // in Node.js 0.10 and still persists in Node.js 6.7+.
+  // Let's print the test failure summary character by character which is safer
+  // when hundreds of tests are failing.
+  _write(string: string) {
+    for (let i = 0; i < string.length; i++) {
+      process.stderr.write(string.charAt(i));
+    }
+  }
+
   onRunStart(
     config: Config,
     aggregatedResults: AggregatedResult,
@@ -197,9 +208,9 @@ class SummareReporter extends BaseReporter {
       aggregatedResults.testResults.forEach(testResult => {
         const {failureMessage} = testResult;
         if (failureMessage) {
-          this.log(
+          this._write(
             getResultHeader(testResult, config) + '\n' +
-            failureMessage,
+            failureMessage + '\n',
           );
         }
       });

--- a/packages/jest-matchers/src/matchers.js
+++ b/packages/jest-matchers/src/matchers.js
@@ -73,7 +73,7 @@ const matchers: MatchersObject = {
     const pass = received === expected;
 
     const message = pass
-      ?  () => matcherHint('.not.toBe') + '\n\n' +
+      ? () => matcherHint('.not.toBe') + '\n\n' +
         `Expected value to not be (using ===):\n` +
         `  ${printExpected(expected)}\n` +
         `Received:\n` +
@@ -95,7 +95,7 @@ const matchers: MatchersObject = {
     const pass = equals(received, expected, [iterableEquality]);
 
     const message = pass
-      ?  () => matcherHint('.not.toEqual') + '\n\n' +
+      ? () => matcherHint('.not.toEqual') + '\n\n' +
         `Expected value to not equal:\n` +
         `  ${printExpected(expected)}\n` +
         `Received:\n` +
@@ -146,10 +146,10 @@ const matchers: MatchersObject = {
     ensureNoExpected(expected, '.toBeTruthy');
     const pass = !!actual;
     const message = pass
-      ? matcherHint('.not.toBeTruthy', 'received', '') + '\n\n' +
+      ? () => matcherHint('.not.toBeTruthy', 'received', '') + '\n\n' +
         `Expected value not to be truthy, instead received\n` +
         `  ${printReceived(actual)}`
-      : matcherHint('.toBeTruthy', 'received', '') + '\n\n' +
+      : () => matcherHint('.toBeTruthy', 'received', '') + '\n\n' +
         `Expected value to be truthy, instead received\n` +
         `  ${printReceived(actual)}`;
     return {message, pass};
@@ -159,10 +159,10 @@ const matchers: MatchersObject = {
     ensureNoExpected(expected, '.toBeFalsy');
     const pass = !actual;
     const message = pass
-      ? matcherHint('.not.toBeFalsy', 'received', '') + '\n\n' +
+      ? () => matcherHint('.not.toBeFalsy', 'received', '') + '\n\n' +
         `Expected value not to be falsy, instead received\n` +
         `  ${printReceived(actual)}`
-      : matcherHint('.toBeFalsy', 'received', '') + '\n\n' +
+      : () => matcherHint('.toBeFalsy', 'received', '') + '\n\n' +
         `Expected value to be falsy, instead received\n` +
         `  ${printReceived(actual)}`;
     return {message, pass};
@@ -172,10 +172,10 @@ const matchers: MatchersObject = {
     ensureNoExpected(expected, '.toBeNaN');
     const pass = Number.isNaN(actual);
     const message = pass
-      ? matcherHint('.not.toBeNaN', 'received', '') + '\n\n' +
+      ? () => matcherHint('.not.toBeNaN', 'received', '') + '\n\n' +
         `Expected value not to be NaN, instead received\n` +
         `  ${printReceived(actual)}`
-      : matcherHint('.toBeNaN', 'received', '') + '\n\n' +
+      : () => matcherHint('.toBeNaN', 'received', '') + '\n\n' +
         `Expected value to be NaN, instead received\n` +
         `  ${printReceived(actual)}`;
     return {message, pass};
@@ -185,10 +185,10 @@ const matchers: MatchersObject = {
     ensureNoExpected(expected, '.toBeNull');
     const pass = actual === null;
     const message = pass
-      ? matcherHint('.not.toBeNull', 'received', '') + '\n\n' +
+      ? () => matcherHint('.not.toBeNull', 'received', '') + '\n\n' +
         `Expected value not to be null, instead received\n` +
         `  ${printReceived(actual)}`
-      : matcherHint('.toBeNull', 'received', '') + '\n\n' +
+      : () => matcherHint('.toBeNull', 'received', '') + '\n\n' +
         `Expected value to be null, instead received\n` +
         `  ${printReceived(actual)}`;
     return {message, pass};
@@ -198,10 +198,10 @@ const matchers: MatchersObject = {
     ensureNoExpected(expected, '.toBeDefined');
     const pass = actual !== void 0;
     const message = pass
-      ? matcherHint('.not.toBeDefined', 'received', '') + '\n\n' +
+      ? () => matcherHint('.not.toBeDefined', 'received', '') + '\n\n' +
         `Expected value not to be defined, instead received\n` +
         `  ${printReceived(actual)}`
-      : matcherHint('.toBeDefined', 'received', '') + '\n\n' +
+      : () => matcherHint('.toBeDefined', 'received', '') + '\n\n' +
         `Expected value to be defined, instead received\n` +
         `  ${printReceived(actual)}`;
     return {message, pass};
@@ -211,10 +211,10 @@ const matchers: MatchersObject = {
     ensureNoExpected(expected, '.toBeUndefined');
     const pass = actual === void 0;
     const message = pass
-      ? matcherHint('.not.toBeUndefined', 'received', '') + '\n\n' +
+      ? () => matcherHint('.not.toBeUndefined', 'received', '') + '\n\n' +
         `Expected value not to be undefined, instead received\n` +
         `  ${printReceived(actual)}`
-      : matcherHint('.toBeUndefined', 'received', '') + '\n\n' +
+      : () => matcherHint('.toBeUndefined', 'received', '') + '\n\n' +
         `Expected value to be undefined, instead received\n` +
         `  ${printReceived(actual)}`;
 
@@ -225,12 +225,12 @@ const matchers: MatchersObject = {
     ensureNumbers(actual, expected, '.toBeGreaterThan');
     const pass = actual > expected;
     const message = pass
-      ? matcherHint('.not.toBeGreaterThan') + '\n\n' +
+      ? () => matcherHint('.not.toBeGreaterThan') + '\n\n' +
         `Expected value not to be greater than:\n` +
         `  ${printExpected(expected)}\n` +
         `Received:\n` +
         `  ${printReceived(actual)}`
-      : matcherHint('.toBeGreaterThan') + '\n\n' +
+      : () => matcherHint('.toBeGreaterThan') + '\n\n' +
         `Expected value to be greater than:\n` +
         `  ${printExpected(expected)}\n` +
         `Received:\n` +
@@ -242,12 +242,12 @@ const matchers: MatchersObject = {
     ensureNumbers(actual, expected, '.toBeGreaterThanOrEqual');
     const pass = actual >= expected;
     const message = pass
-      ? matcherHint('.not.toBeGreaterThanOrEqual') + '\n\n' +
+      ? () => matcherHint('.not.toBeGreaterThanOrEqual') + '\n\n' +
         `Expected value not to be greater than or equal:\n` +
         `  ${printExpected(expected)}\n` +
         `Received:\n` +
         `  ${printReceived(actual)}`
-      : matcherHint('.toBeGreaterThanOrEqual') + '\n\n' +
+      : () => matcherHint('.toBeGreaterThanOrEqual') + '\n\n' +
         `Expected value to be greater than or equal:\n` +
         `  ${printExpected(expected)}\n` +
         `Received:\n` +
@@ -259,12 +259,12 @@ const matchers: MatchersObject = {
     ensureNumbers(actual, expected, '.toBeLessThan');
     const pass = actual < expected;
     const message = pass
-      ? matcherHint('.not.toBeLessThan') + '\n\n' +
+      ? () => matcherHint('.not.toBeLessThan') + '\n\n' +
         `Expected value not to be less than:\n` +
         `  ${printExpected(expected)}\n` +
         `Received:\n` +
         `  ${printReceived(actual)}`
-      : matcherHint('.toBeLessThan') + '\n\n' +
+      : () => matcherHint('.toBeLessThan') + '\n\n' +
         `Expected value to be less than:\n` +
         `  ${printExpected(expected)}\n` +
         `Received:\n` +
@@ -276,12 +276,12 @@ const matchers: MatchersObject = {
     ensureNumbers(actual, expected, '.toBeLessThanOrEqual');
     const pass = actual <= expected;
     const message = pass
-      ? matcherHint('.not.toBeLessThanOrEqual') + '\n\n' +
+      ? () => matcherHint('.not.toBeLessThanOrEqual') + '\n\n' +
         `Expected value not to be less than or equal:\n` +
         `  ${printExpected(expected)}\n` +
         `Received:\n` +
         `  ${printReceived(actual)}`
-      : matcherHint('.toBeLessThanOrEqual') + '\n\n' +
+      : () => matcherHint('.toBeLessThanOrEqual') + '\n\n' +
         `Expected value to be less than or equal:\n` +
         `  ${printExpected(expected)}\n` +
         `Received:\n` +

--- a/packages/jest-matchers/src/spyMatchers.js
+++ b/packages/jest-matchers/src/spyMatchers.js
@@ -47,10 +47,11 @@ const createToBeCalledMatcher = matcherName => (received, expected) => {
     : received.mock.calls;
   const pass = count > 0;
   const message = pass
-    ? matcherHint('.not' + matcherName, RECEIVED_NAME[type], '') + '\n\n' +
+    ? () => matcherHint('.not' + matcherName, RECEIVED_NAME[type], '') +
+      '\n\n' +
       `Expected ${type} not to be called ` +
       formatReceivedCalls(calls, CALL_PRINT_LIMIT, {sameSentence: true})
-    : matcherHint(matcherName, RECEIVED_NAME[type], '') + '\n\n' +
+    : () => matcherHint(matcherName, RECEIVED_NAME[type], '') + '\n\n' +
       `Expected ${type} to have been called.`;
 
   return {message, pass};
@@ -71,10 +72,10 @@ const createToBeCalledWithMatcher = matcherName =>
     const pass = calls.some(call => equals(call, expected));
 
     const message = pass
-      ? matcherHint('.not' + matcherName, RECEIVED_NAME[type]) + '\n\n' +
+      ? () => matcherHint('.not' + matcherName, RECEIVED_NAME[type]) + '\n\n' +
         `Expected ${type} not to have been called with:\n` +
         `  ${printExpected(expected)}`
-      : matcherHint(matcherName, RECEIVED_NAME[type]) + '\n\n' +
+      : () => matcherHint(matcherName, RECEIVED_NAME[type]) + '\n\n' +
         `Expected ${type} to have been called with:\n` +
          `  ${printExpected(expected)}\n` +
          formatReceivedCalls(calls, CALL_PRINT_LIMIT);
@@ -97,10 +98,10 @@ const createLastCalledWithMatcher = matcherName =>
     const pass = equals(calls[calls.length - 1], expected);
 
     const message = pass
-      ? matcherHint('.not' + matcherName, RECEIVED_NAME[type]) + '\n\n' +
+      ? () => matcherHint('.not' + matcherName, RECEIVED_NAME[type]) + '\n\n' +
         `Expected ${type} to not have been last called with:\n` +
         `  ${printExpected(expected)}`
-      : matcherHint(matcherName, RECEIVED_NAME[type]) + '\n\n' +
+      : () => matcherHint(matcherName, RECEIVED_NAME[type]) + '\n\n' +
         `Expected ${type} to have been last called with:\n` +
          `  ${printExpected(expected)}\n` +
          formatReceivedCalls(calls, LAST_CALL_PRINT_LIMIT, {isLast: true});
@@ -129,7 +130,7 @@ const spyMatchers: MatchersObject = {
       : received.mock.calls.length;
     const pass = count === expected;
     const message = pass
-      ? matcherHint(
+      ? () => matcherHint(
           '.not' +
           matcherName,
           RECEIVED_NAME[type],
@@ -139,7 +140,7 @@ const spyMatchers: MatchersObject = {
         `Expected ${type} not to be called ` +
         `${EXPECTED_COLOR(pluralize('time', expected))}, but it was` +
         ` called exactly ${RECEIVED_COLOR(pluralize('time', count))}.`
-      : matcherHint(matcherName, RECEIVED_NAME[type], String(expected)) +
+      : () => matcherHint(matcherName, RECEIVED_NAME[type], String(expected)) +
         '\n\n' +
         `Expected ${type} to have been called ` +
         `${EXPECTED_COLOR(pluralize('time', expected))},` +

--- a/packages/jest-snapshot/src/index.js
+++ b/packages/jest-snapshot/src/index.js
@@ -93,7 +93,7 @@ const toMatchSnapshot = function(received: any, expected: void) {
     );
 
     const message =
-      matcherHint('.toMatchSnapshot', 'value', '') + '\n\n' +
+      () => matcherHint('.toMatchSnapshot', 'value', '') + '\n\n' +
       `${RECEIVED_COLOR('Received value')} does not match ` +
       `${EXPECTED_COLOR('stored snapshot ' + count)}.\n\n` +
       (diffMessage || (


### PR DESCRIPTION
**Summary**
Seems like calling prettyFormat on every spy matcher causes a memory leak. This stops the bleeding but should certainly be fixed so that we don't leak when pretty-printing, obviously. At least I have a repro now :)

**Test plan**
jest at FB

Fixes #1834