### PR TITLE
Update React Native docs with links to a testing series example

### DIFF
--- a/docs/TutorialReactNative.md
+++ b/docs/TutorialReactNative.md
@@ -10,6 +10,8 @@ next: tutorial-async
 At Facebook, we use Jest to test [React Native](http://facebook.github.io/react-native/)
 applications.
 
+Get a deeper insight into testing a working example React Native app reading the following series: [Part 1: Jest – Snapshot come into play](https://blog.callstack.io/unit-testing-react-native-with-the-new-jest-i-snapshots-come-into-play-68ba19b1b9fe#.12zbnbgwc) and [Part 2: Jest – Redux Snapshots for your Actions and Reducers](https://blog.callstack.io/unit-testing-react-native-with-the-new-jest-ii-redux-snapshots-for-your-actions-and-reducers-8559f6f8050b).
+
 *Note: react-native support is experimental. Please create [issues](https://github.com/facebook/jest/issues) with an open source repository attached when you run into problems or send pull requests to help improve the integration.*
 
 ## Setup


### PR DESCRIPTION
**Summary**

Add testing series links [1](https://blog.callstack.io/unit-testing-react-native-with-the-new-jest-i-snapshots-come-into-play-68ba19b1b9fe#.yyst6qpc5) and [2](https://blog.callstack.io/unit-testing-react-native-with-the-new-jest-ii-redux-snapshots-for-your-actions-and-reducers-8559f6f8050b) to RN docs so users can read more about this topic.

**Test plan**

N/A.

---

@cpojer I got the titles from your community update :). Let me know if the PR is fine, I was not sure where to place it. Maybe is preferable a section at the top/end for external links.