### PR TITLE
fix async example test

### DIFF
--- a/examples/async/__tests__/user-test.js
+++ b/examples/async/__tests__/user-test.js
@@ -4,7 +4,7 @@
 
 jest.mock('../request');
 
-import * as user from '../user';
+const user = require('../user');
 
 // Use `pit` instead of `it` for testing promises.
 // The promise that is being tested should be returned.


### PR DESCRIPTION
**Summary**

This PR fixes the `example/async` test (#1853).

It looks like when using ES2015 `import`, the `http` module doesn't seem to be mocked at all because it is being imported by `request.js` which is imported by `user.js`.