### PR TITLE
Fix anchors of website [ci skip]

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -39,7 +39,7 @@ expect all the time. That's what you use `expect` for.
   - `.lastCalledWith(arg1, arg2, ...)` is an alias for [`.toHaveBeenLastCalledWith(arg1, arg2, ...)`](#tohavebeenlastcalledwitharg1-arg2-)
   - [`.not`](#not)
   - [`.toBe(value)`](#tobe-value)
-  - `.toBeCalled()` is an alias for [`.toHaveBeenCalled()`] (#tohavebeencalled)
+  - `.toBeCalled()` is an alias for [`.toHaveBeenCalled()`](#tohavebeencalled)
   - `.toBeCalledWith(arg1, arg2, ...)` is an alias for [`.toHaveBeenCalledWith(arg1, arg2, ...)`](#tohavebeencalledwitharg1-arg2-)
   - [`.toHaveBeenCalled()`](#tohavebeencalled)
   - [`.toHaveBeenCalledTimes(number)`](#tohavebeencalledtimesnumber)

--- a/website/core/Header.js
+++ b/website/core/Header.js
@@ -15,7 +15,7 @@ var Header = React.createClass({
 
     var without = "aaaaeeeeiiiioooouuuunc";
 
-    return string
+    var slug = string
       .toString()
 
       // Handle uppercase characters
@@ -26,6 +26,9 @@ var Header = React.createClass({
         new RegExp('[' + accents + ']', 'g'),
         function (c) { return without.charAt(accents.indexOf(c)); })
 
+      // Replace `.` and `(` with blank string like Github does
+      .replace(/\.|\(/g, '')
+
       // Dash special characters
       .replace(/[^a-z0-9]/g, '-')
 
@@ -34,6 +37,13 @@ var Header = React.createClass({
 
       // Trim dashes
       .replace(/^-|-$/g, '');
+
+    // Add trailing `-` if string contains ` ...` in the end like Github does
+    if (/\s[.]{1,}/.test(string)) {
+      slug += '-';
+    }
+
+    return slug;
   },
 
   render: function() {


### PR DESCRIPTION
**Summary**
Anchors generation on Github and Website was working differently,
what caused broken anchors in one the of sources

This PR:
* Making anchors generation consistent
* Fixes broken for website `toHaveBeenCalled` anchor
* Resolves #1851

**Test plan**
Jest website / Github page with API docs