### PR TITLE
Snapshot preview in the browser

### DIFF
--- a/packages/jest-snapshot/package.json
+++ b/packages/jest-snapshot/package.json
@@ -15,9 +15,7 @@
     "jest-matcher-utils": "^16.0.0",
     "jest-util": "^16.0.0",
     "natural-compare": "^1.4.0",
-    "os-tmpdir": "^1.0.2",
-    "pretty-format": "~4.2.1",
-    "sanitize-filename": "^1.6.1"
+    "pretty-format": "~4.2.1"
   },
   "scripts": {
     "test": "../jest-cli/bin/jest.js"

--- a/packages/jest-snapshot/package.json
+++ b/packages/jest-snapshot/package.json
@@ -8,12 +8,16 @@
   "license": "BSD-3-Clause",
   "main": "build/index.js",
   "dependencies": {
+    "escape-html": "^1.0.3",
+    "fbjs": "^0.8.5",
     "jest-diff": "^16.0.0",
     "jest-file-exists": "^15.0.0",
     "jest-matcher-utils": "^16.0.0",
     "jest-util": "^16.0.0",
     "natural-compare": "^1.4.0",
-    "pretty-format": "~4.2.1"
+    "os-tmpdir": "^1.0.2",
+    "pretty-format": "~4.2.1",
+    "sanitize-filename": "^1.6.1"
   },
   "scripts": {
     "test": "../jest-cli/bin/jest.js"

--- a/packages/jest-snapshot/src/ReactTestComponentToHtml.js
+++ b/packages/jest-snapshot/src/ReactTestComponentToHtml.js
@@ -1,0 +1,160 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+const printString = require('pretty-format/printString');
+const hyphenateStyleName = require('fbjs/lib/hyphenateStyleName');
+const escapeHtml = require('escape-html');
+
+const reactTestInstance = Symbol.for('react.test.json');
+
+// From React: src/renderers/dom/shared/HTMLDOMPropertyConfig.js
+const REACT_PROPS_TO_DOM_ATTRS = {
+  acceptCharset: 'accept-charset',
+  className: 'class',
+  htmlFor: 'for',
+  httpEquiv: 'http-equiv',
+};
+
+// Adapted from React: src/renderers/dom/shared/CSSProperty.js
+const IS_UNITLESS_NUMBER = {
+  animationIterationCount: true,
+  borderImageOutset: true,
+  borderImageSlice: true,
+  borderImageWidth: true,
+  boxFlex: true,
+  boxFlexGroup: true,
+  boxOrdinalGroup: true,
+  columnCount: true,
+  flex: true,
+  flexGrow: true,
+  flexPositive: true,
+  flexShrink: true,
+  flexNegative: true,
+  flexOrder: true,
+  gridRow: true,
+  gridColumn: true,
+  fontWeight: true,
+  lineClamp: true,
+  lineHeight: true,
+  opacity: true,
+  order: true,
+  orphans: true,
+  tabSize: true,
+  widows: true,
+  zIndex: true,
+  zoom: true,
+
+  // SVG-related properties
+  fillOpacity: true,
+  floodOpacity: true,
+  stopOpacity: true,
+  strokeDasharray: true,
+  strokeDashoffset: true,
+  strokeMiterlimit: true,
+  strokeOpacity: true,
+  strokeWidth: true,
+};
+Object.keys(IS_UNITLESS_NUMBER).forEach(prop => {
+  ['Webkit', 'ms', 'Moz', 'O'].forEach(prefix => {
+    const styleName = prefix + prop.charAt(0).toUpperCase() + prop.substring(1);
+    IS_UNITLESS_NUMBER[styleName] = IS_UNITLESS_NUMBER[prop];
+  });
+});
+
+function printChildren(children, print, indent, opts) {
+  return children.map(child => printInstance(child, print, indent, opts))
+    .join(opts.edgeSpacing);
+}
+
+function printProps(props, print, indent, opts) {
+  return Object.keys(props).sort().map(propName => {
+    const propValue = props[propName];
+
+    let printedValue;
+    if (typeof propValue === 'string') {
+      printedValue = print(propValue);
+    } else if (propName === 'style') {
+      printedValue = printStyle(propValue, print);
+    } else {
+      return '';
+    }
+
+    let printedName = propName;
+    if (REACT_PROPS_TO_DOM_ATTRS.hasOwnProperty(propName)) {
+      printedName = REACT_PROPS_TO_DOM_ATTRS[propName];
+    }
+    return opts.spacing + indent(printedName + '=') + printedValue;
+  }).join('');
+}
+
+function printStyle(style, print) {
+  if (style == null) {
+    return '';
+  }
+
+  let css = '';
+  Object.keys(style).sort().forEach(styleName => {
+    const styleValue = style[styleName];
+    css += hyphenateStyleName(styleName) + ':';
+    css += printStyleValue(styleName, styleValue) + ';';
+  });
+
+  return print(css);
+}
+
+// From React: src/renderers/dom/shared/dangerousStyleValue.js
+function printStyleValue(name, value) {
+  if (value == null || typeof value === 'boolean' || value === '') {
+    return '';
+  }
+  if (typeof value === 'number' && value !== 0 &&
+      !(IS_UNITLESS_NUMBER.hasOwnProperty(name) && IS_UNITLESS_NUMBER[name])) {
+    return value + 'px'; // Presumes implicit 'px' suffix for unitless numbers
+  }
+  return ('' + value).trim();
+}
+
+function printInstance(instance, print, indent, opts) {
+  if (typeof instance == 'number') {
+    return print(instance);
+  } else if (typeof instance === 'string') {
+    return printString(instance);
+  }
+
+  let result = '<' + instance.type;
+
+  if (instance.props) {
+    result += printProps(instance.props, print, indent, opts);
+  }
+
+  const children = instance.children;
+  if (children) {
+    const printedChildren = printChildren(children, print, indent, opts);
+    result += '>' + opts.edgeSpacing + indent(printedChildren) +
+      opts.edgeSpacing + '</' + instance.type + '>';
+  } else if (instance.type.toUpperCase() === 'TEXTAREA') {
+    result += '>' + (escapeHtml(instance.props.value) || '') +
+      '</' + instance.type + '>';
+  } else {
+    result += '>' + opts.edgeSpacing + indent('') +
+      opts.edgeSpacing + '</' + instance.type + '>';
+  }
+
+  return result;
+}
+
+module.exports = {
+  test(object) {
+    return object && object.$$typeof === reactTestInstance;
+  },
+  print(val, print, indent, opts) {
+    return printInstance(val, print, indent, opts);
+  },
+};

--- a/packages/jest-snapshot/src/State.js
+++ b/packages/jest-snapshot/src/State.js
@@ -94,7 +94,7 @@ class SnapshotState {
     } else if (isEmpty && fileExists(this._snapshotPath)) {
       if (update) {
         fs.unlinkSync(this._snapshotPath);
-        if (fileExists(this._snapshotPath)) {
+        if (fileExists(this._htmlPreviewPath)) {
           fs.unlinkSync(this._htmlPreviewPath);
         }
       }

--- a/packages/jest-snapshot/src/__tests__/utils-test.js
+++ b/packages/jest-snapshot/src/__tests__/utils-test.js
@@ -8,7 +8,7 @@
 
 'use strict';
 
-const {keyToTestName, testNameToKey, getSnapshotPath} = require('../utils');
+const {keyToTestName, testNameToKey, getSnapshotPath, getHtmlPreviewPath} = require('../utils');
 const path = require('path');
 
 test('keyToTestName()', () => {
@@ -28,5 +28,13 @@ test('getSnapshotPath()', () => {
     '/abc/cde/a-test.js',
   )).toBe(
     path.join('/abc', 'cde', '__snapshots__', 'a-test.js.snap'),
+  );
+});
+
+test('getHtmlPreviewPath()', () => {
+  expect(getHtmlPreviewPath(
+    '/abc/cde/__snapshots__/a-test.js.snap',
+  )).toBe(
+    path.join('/abc', 'cde', '__snapshots__', 'a-test.js.html'),
   );
 });

--- a/packages/jest-snapshot/src/buildHtmlPreview.js
+++ b/packages/jest-snapshot/src/buildHtmlPreview.js
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+
+'use strict';
+
+const naturalCompare = require('natural-compare');
+
+const fullTemplate = ({keys, previews, css}) => `
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Snapshot preview</title>
+    <style>
+      body.jest {
+        display: flex;
+        flex-direction: row;
+        margin: 0;
+        padding: 0;
+        height: 100vh;
+      }
+      .jest--sidebar {
+        width: 18em;
+        padding: 0.3em 0;
+        background-color: #eee;
+        font-family: sans-serif;
+        font-size: 0.8em;
+      }
+      .jest--preview {
+        flex: 1;
+        display: none;
+        transform: translateZ(0);
+      }
+      .jest--preview.shown { display: block; }
+      .jest--key {
+        padding: 0.3em 1em;
+        cursor: pointer;
+      }
+      .jest--key.shown { background-color: #ca461a; color: white; }
+      .jest--key:hover { background-color: #ddd; }
+      .jest--key.shown:hover { background-color: #ba360a; }
+      pre.jest--nonreact { padding: 10px }
+      
+      ${css}
+    </style>
+    <script type="text/javascript">
+      function removeClass(className, classToRemove) {
+        var idx;
+        var el;
+        var classes;
+        var els = document.getElementsByClassName(className);
+        for (var i = 0; i < els.length; i++) {
+          el = els[i];
+          classes = el.className.split(' ');
+          idx = classes.indexOf(classToRemove);
+          if (idx >= 0) {
+            classes.splice(idx, 1);
+            el.className = classes.join(' ');
+          }
+        };
+      }
+      function onClick(id) {
+        removeClass('jest--key', 'shown');
+        removeClass('jest--preview', 'shown');
+        el = document.getElementById('jest--preview_' + id);
+        if (el) el.className += ' shown';
+        el = document.getElementById('jest--key_' + id);
+        if (el) el.className += ' shown';
+      }
+    </script>
+  </head>
+  <body class="jest">
+    <div class="jest--sidebar">
+${keys}
+    </div>
+${previews}
+  </body>
+</html>
+`;
+
+const keyTemplate = (key, idx) => `
+      <div class="jest--key${idx === 0 ? ' shown' : ''}"
+           id="jest--key_${key}"
+           onclick="onClick('${key}')">
+        ${key}
+      </div>
+`;
+
+/* eslint-disable max-len */
+const previewTemplate = (key, idx, htmlSnapshot) => `
+    <div id="jest--preview_${key}" class="jest--preview${idx === 0 ? ' shown' : ''}">
+      ${htmlSnapshot}
+    </div>
+`;
+/* eslint-enable max-len */
+
+module.exports = (
+  htmlSnapshots: {[key: string]: string},
+  css: ?string,
+): string => {
+  const keys = [];
+  const previews = [];
+  Object.keys(htmlSnapshots).sort(naturalCompare).forEach((key, idx) => {
+    keys.push(keyTemplate(key, idx));
+    previews.push(previewTemplate(key, idx, htmlSnapshots[key]));
+  });
+  return fullTemplate({
+    keys: keys.join(''),
+    previews: previews.join(''),
+    css: css || '',
+  });
+};


### PR DESCRIPTION
## Summary

I find the new snapshot testing feature of Jest awesome and I blogged about it in [Picture this: snapshot testing — Jest, reloaded](http://guigrpa.github.io/2016/09/27/picture-this-snapshot-testing/).

While working on adding tests to my application [Mady](https://github.com/guigrpa/mady), I thought that the snapshot workflow may improve if the snapshots could be reviewed *graphically*, especially when they are created (but also after updates). This would not replace, but rather *complement*, a careful review of the text-based snapshots, which obviously contain more information.

## Included in this PR

* A `pretty-format` plugin that generates HTML code for React elements from `react-test-renderer` input (`ReactTestComponentToHtml.js`). For this conversion, several React white lists have been used, as well as `hyphenateStyleName()` from `fbjs`.
* An HTML previewer that generates a static `.html` file with the HTML snapshots corresponding to a `.snap` file (allowing the user to review each one of them separately). The lifecycle of the `.html` files is parallel to the corresponding `.snap` files: they are created and deleted at the same time.
* Updates to `jest-snapshot`'s `utils.js` and `State.js` to save the HTML preview alongside `.snap` files
* Limited unit tests (more could be added)

**Note**: when snapshots do not correspond to React elements, they still trigger the generation of the HTML preview. Snapshots are in this case wrapped in `<pre>` tags and inserted in the template.

**Note-2**: additional dependencies (`fbjs/lib/hyphenateStyleName`, `escape-html`) can be inlined if deemed necessary.

## Examples

Some **examples** of HTML previews generated for Mady with this PR:

* [Example 1 - form](https://rawgit.com/guigrpa/mady/master/src/client/components/__tests__/__snapshots__/080-settings.test.js.html) -- this preview contains only one snapshot (I believe this is much easier to validate than the textual snapshot)
* [Example 2 - tabular component](https://rawgit.com/guigrpa/mady/master/src/client/components/__tests__/__snapshots__/060-translator.test.js.html) -- multiple snapshots for the same component (note that the `TranslatorRow` component is mocked)
* [Example 3 - non-React snapshot](https://rawgit.com/guigrpa/mady/master/src/server/__tests__/__snapshots__/parseSources.test.js.html) -- in this case, the raw snapshot is shown

## Envisaged next steps

Beyond this draft, but included in the PR, I envisage:

* Adding further unit tests (please advise on priority areas)
* Removing HTML snapshots generated during Jest's internal tests (please advise on how this can be done)
* Adding a configuration flag to disable generation of HTML snapshots (although I believe they should be enabled by default)
* Allowing the user to inject CSS in the snapshot preview, so that it more closely resembles the real application. In some of the Mady examples above, this would allow (Font Awesome) icons to be shown

Beyond the scope of this PR, but related:

* Help to integrate the new functionality with the more granular, interactive snapshot-by-snapshot approval process proposed in #1798, #1328 and in [Ben McCormick's post](http://benmccormick.org/2016/09/19/testing-with-jest-snapshots-first-impressions/). For example, Jest could automatically open in the default browser the HTML previews for the snapshots that have changed.
