### PR TITLE
Avoid an infinite loop in `wrapAnsiString`

### DIFF
--- a/packages/jest-cli/src/reporters/__tests__/__snapshots__/utils-test.js.snap
+++ b/packages/jest-cli/src/reporters/__tests__/__snapshots__/utils-test.js.snap
@@ -8,6 +8,10 @@ exports[`trimAndFormatPath() trims dirname 1`] = `"[2m...234567890/[22m[1m123
 
 exports[`trimAndFormatPath() trims dirname and basename 1`] = `"[1m...1234.js[22m"`;
 
+exports[`wrapAnsiString() returns the string unaltered if given a terminal width of zero 1`] = `"This string shouldn\'t cause you any trouble"`;
+
+exports[`wrapAnsiString() returns the string unaltered if given a terminal width of zero 2`] = `"This string shouldn\'t cause you any trouble"`;
+
 exports[`wrapAnsiString() wraps a long string containing ansi chars 1`] = `
 "abcde [31m[1mred-
 bold[22m[39m 12344

--- a/packages/jest-cli/src/reporters/__tests__/utils-test.js
+++ b/packages/jest-cli/src/reporters/__tests__/utils-test.js
@@ -25,7 +25,7 @@ describe('wrapAnsiString()', () => {
   });
 
   it('returns the string unaltered if given a terminal width of zero', () => {
-    const string = "This string shouldn't cause you any trouble";
+    const string = `This string shouldn't cause you any trouble`;
     expect(wrapAnsiString(string, 0)).toMatchSnapshot();
     expect(stripAnsi(wrapAnsiString(string, 0))).toMatchSnapshot();
   });

--- a/packages/jest-cli/src/reporters/__tests__/utils-test.js
+++ b/packages/jest-cli/src/reporters/__tests__/utils-test.js
@@ -23,6 +23,12 @@ describe('wrapAnsiString()', () => {
     expect(wrapAnsiString(string, 10)).toMatchSnapshot();
     expect(stripAnsi(wrapAnsiString(string, 10))).toMatchSnapshot();
   });
+
+  it('returns the string unaltered if given a terminal width of zero', () => {
+    const string = "This string shouldn't cause you any trouble";
+    expect(wrapAnsiString(string, 0)).toMatchSnapshot();
+    expect(stripAnsi(wrapAnsiString(string, 0))).toMatchSnapshot();
+  });
 });
 
 describe('trimAndFormatPath()', () => {

--- a/packages/jest-cli/src/reporters/utils.js
+++ b/packages/jest-cli/src/reporters/utils.js
@@ -191,9 +191,14 @@ const renderTime = (
   return time;
 };
 
-// wrap a string that contains ANSI escape sequences. ANSI escape sequences
-// do not add to the string length.
-const wrapAnsiString = (string: string, width: number) => {
+// word-wrap a string that contains ANSI escape sequences.
+// ANSI escape sequences do not add to the string length.
+const wrapAnsiString = (string: string, terminalWidth: number) => {
+  if (terminalWidth === 0) {
+    // if the terminal width is zero, don't bother word-wrapping
+    return string;
+  }
+
   const ANSI_REGEXP = /[\u001b\u009b]\[\d{1,2}m/g;
   const tokens = [];
   let lastIndex = 0;
@@ -218,11 +223,14 @@ const wrapAnsiString = (string: string, width: number) => {
   return tokens.reduce(
     (lines, [kind, token]) => {
       if (kind === 'string') {
-        if (lastLineLength + token.length > width) {
+        if (lastLineLength + token.length > terminalWidth) {
 
           while (token.length) {
-            const chunk = token.slice(0, width - lastLineLength);
-            const remaining = token.slice(width - lastLineLength, token.length);
+            const chunk = token.slice(0, terminalWidth - lastLineLength);
+            const remaining = token.slice(
+              terminalWidth - lastLineLength,
+              token.length,
+            );
             lines[lines.length - 1] += chunk;
             lastLineLength += chunk.length;
             token = remaining;


### PR DESCRIPTION
**Summary**
If a terminal's width is reported by node as `0`, this would get caught in an infinite loop, and crash v8 trying to allocate an ever-expanding array.

This works around this by immediately returning the supplied string if the width supplied is `0`, and adds a test for such a case.

**Test plan**
```javascript
require('jest/node_modules/jest-cli/build/reporters/utils').wrapAnsiString('so long, v8', 0)
```
will now return `'so long, v8'`, rather than crash the v8 runtime

fixes #1863