### PR TITLE
Normalize newlines across different OS.

### DIFF
--- a/packages/jest-snapshot/src/__tests__/utils-test.js
+++ b/packages/jest-snapshot/src/__tests__/utils-test.js
@@ -8,8 +8,18 @@
 
 'use strict';
 
-const {keyToTestName, testNameToKey, getSnapshotPath} = require('../utils');
+const {
+  getSnapshotPath,
+  keyToTestName,
+  saveSnapshotFile,
+  testNameToKey,
+} = require('../utils');
+const fs = require('fs');
 const path = require('path');
+
+const writeFileSync = fs.writeFileSync;
+beforeEach(() => fs.writeFileSync = jest.fn());
+afterEach(() => fs.writeFileSync = writeFileSync);
 
 test('keyToTestName()', () => {
   expect(keyToTestName('abc cde 12')).toBe('abc cde');
@@ -29,4 +39,15 @@ test('getSnapshotPath()', () => {
   )).toBe(
     path.join('/abc', 'cde', '__snapshots__', 'a-test.js.snap'),
   );
+});
+
+test('saveSnapshotFile()', () => {
+  const filename = path.join(__dirname, 'remove-newlines.snap');
+  const data = {
+    myKey: '<div>\r\n</div>', 
+  };
+
+  saveSnapshotFile(data, filename);
+  expect(fs.writeFileSync)
+    .toBeCalledWith(filename, 'exports[`myKey`] = `<div>\n</div>`;\n');
 });

--- a/packages/jest-snapshot/src/utils.js
+++ b/packages/jest-snapshot/src/utils.js
@@ -76,6 +76,9 @@ const ensureDirectoryExists = (filePath: Path) => {
   } catch (e) {}
 };
 
+const normalizeNewlines =
+  string => string.replace(/\r\n/g, '\n');
+
 const saveSnapshotFile = (
   snapshotData: {[key: string]: string},
   snapshotPath: Path,
@@ -83,7 +86,7 @@ const saveSnapshotFile = (
   const snapshots = Object.keys(snapshotData).sort(naturalCompare)
     .map(key =>
       'exports[`' + escape(key) + '`] = `' +
-      escape(snapshotData[key]) + '`;',
+      normalizeNewlines(escape(snapshotData[key])) + '`;',
     );
 
   ensureDirectoryExists(snapshotPath);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Windows uses `\r\n` for newlines. This PR normalizes this when saving snapshots to `\n`.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Fixes #1878

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

A simple test case is included in the PR.