### PR TITLE
Update CSS Modules mock

### DIFF
--- a/docs/TutorialWebpack.md
+++ b/docs/TutorialWebpack.md
@@ -63,6 +63,19 @@ And the mock file's themselves:
 ```js
 // __mocks__/styleMock.js
 
+// Return an object to emulate css modules
+const cssModule = new Proxy({}, {
+  get (_, name) {
+    return name
+  }
+})
+
+module.exports = new Proxy(cssModule, {
+  get () {
+    return cssModule
+  }
+})
+
 module.exports = {};
 ```
 

--- a/docs/TutorialWebpack.md
+++ b/docs/TutorialWebpack.md
@@ -66,17 +66,15 @@ And the mock file's themselves:
 // Return an object to emulate css modules
 const cssModule = new Proxy({}, {
   get (_, name) {
-    return name
+    return name;
   }
 })
 
 module.exports = new Proxy(cssModule, {
   get () {
-    return cssModule
+    return cssModule;
   }
 })
-
-module.exports = {};
 ```
 
 ```js


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

The current CSS Modules mock is returning `undefined` for every class. This makes impossible to test if a component has a class defined. Using this implementation we can have a value for each class.

```js
// Before
import styles from './Style.css'
styles.classA // undefined
styles.classB // undefined

// After
import styles from './Style.css'
style.classA // 'classA'
style.classB // 'classB'
```

I'm aware this solution is not 100% compatible with CSS Modules, i.e. if I import two different modules with the same class name I end up with the same value:

```js
import stylesA from './StylesA.css'
import stylesB from './StylesB.css'
stylesA.label === stylesB.label // true, in CSS Modules it would be false
```

That said this implementation covers 90% of the testing needs for CSS Modules.