### PR TITLE
Revert "Update CSS Modules mock"

### DIFF
--- a/docs/TutorialWebpack.md
+++ b/docs/TutorialWebpack.md
@@ -63,18 +63,7 @@ And the mock file's themselves:
 ```js
 // __mocks__/styleMock.js
 
-// Return an object to emulate css modules
-const cssModule = new Proxy({}, {
-  get (_, name) {
-    return name;
-  }
-})
-
-module.exports = new Proxy(cssModule, {
-  get () {
-    return cssModule;
-  }
-})
+module.exports = {};
 ```
 
 ```js


### PR DESCRIPTION
Reverts facebook/jest#1882

I just noticed that the documentation already contains a similar solution for CSS modules, so this change is not necessary.

Sorry about that