### PR TITLE
Added support for default platform in requiring filenames

### DIFF
--- a/packages/jest-resolve/src/index.js
+++ b/packages/jest-resolve/src/index.js
@@ -122,6 +122,32 @@ class Resolver {
 
       if (module) {
         return this._moduleNameCache[key] = module;
+      } else {
+	      // 2a. Check for platform-specific modules, e.g. `import Foo from `../../utils/foo`
+	      // where `../../utils/foo.<defaultPlatform.js` do exist, but
+	      // `../../utils/foo.js` does not.
+	      const parsedPath = path.parse( moduleName );
+
+	      if (parsedPath.ext == '') {
+		      const moduleNameWithDefaultPlatform = path.format({
+			      dir: parsedPath.dir,
+			      root: parsedPath.root,
+			      name: parsedPath.name,
+			      ext: `.${this._options.defaultPlatform}`
+		      } );
+
+		      module = Resolver.findNodeModule(moduleNameWithDefaultPlatform, {
+			      basedir: dirname,
+			      browser: this._options.browser,
+			      extensions,
+			      moduleDirectory,
+			      paths,
+		      });
+
+		      if (module) {
+			      return this._moduleNameCache[key] = module;
+		      }
+	      }
       }
     }
 


### PR DESCRIPTION
**Summary**

When react-native application has some component with platform-specific code, Jest can't resolve paths properly. Namely, if `import Foo from `../../utils/foo` is used, where `../../utils/foo.<defaultPlatform.js` do exist, but `../../utils/foo.js` does not, Jest fails.

**Test plan**

In sample app create `foo.ios.js` and `foo.android.js` then from some component try to resolve `foo`. It should pick up the implementation set by `defaultPlatform` from config.
