### PR TITLE
Fix typo in toBeLessThan example

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -428,7 +428,7 @@ To compare floating point numbers, you can use `toBeLessThan`. For example, if y
 ```js
 describe('ounces per can', () => {
   it('is less than 20', () => {
-    expect(ouncesPerCan()).toBeLessThan(10);
+    expect(ouncesPerCan()).toBeLessThan(20);
   });
 });
 ```


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

In the example for `toBeLessThan(number)` the text says 20 ounces but the code says 10 ounces.

**Test plan**

No test plan because this is a documentation change.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

