### PR TITLE
Haste-map now cleans up workers if throwOnModuleCollision is set to true

### DIFF
--- a/packages/jest-haste-map/src/index.js
+++ b/packages/jest-haste-map/src/index.js
@@ -354,18 +354,24 @@ class HasteMap {
       );
     }
 
+    const cleanup = () => {
+      if (this._workerFarm) {
+        workerFarm.end(this._workerFarm);
+      }
+      this._workerFarm = null;
+      this._workerPromise = null;
+    };
+
     return Promise.all(promises)
-      .then(() => {
-        if (this._workerFarm) {
-          workerFarm.end(this._workerFarm);
-        }
-        this._workerFarm = null;
-        this._workerPromise = null;
-      })
+      .then(cleanup)
       .then(() => {
         hasteMap.map = map;
         hasteMap.mocks = mocks;
         return hasteMap;
+      })
+      .catch(err => {
+        cleanup();
+        return Promise.reject(err);
       });
   }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

This change ensures that if throwOnModuleCollision is set to true, and a module collision occurs that any workers are cleaned up. Previously, this was not the case which resulted in any calling process appearing to hang after it should have completed.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

Create two files with the same @providesModule name. Then create a test script similar to the following

```javascript
const map = new HasteMap({
  throwOnModuleCollision: true,
  ...
});
map.build().then(() => {
  console.log('done');
}).catch((err) => {
  console.log(err);
});
```

Without this patch the test script will output the error and hang. With the patch applied the test script will output the error and exit normally.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
