### PR TITLE
Fixes a typo

### DIFF
--- a/packages/jest-haste-map/src/__tests__/__snapshots__/index-test.js.snap
+++ b/packages/jest-haste-map/src/__tests__/__snapshots__/index-test.js.snap
@@ -8,14 +8,14 @@ This error is caused by a @providesModule declaration with the same name across 
 
 exports[`HasteMap tries to crawl using node as a fallback 1`] = `
 "jest-haste-map: Watchman crawl failed. Retrying once with node crawler.
-  Usually this happens when watchman isn't running. Create an empty \`.watchmanconfig\` file in your project's root folder or initialize a git or hg repository in your project.
+  Usually this happens when watchman isn\'t running. Create an empty \`.watchmanconfig\` file in your project\'s root folder or initialize a git or hg repository in your project.
   Error: watchman error"
 `;
 
 exports[`HasteMap warns on duplicate mock files 1`] = `
 "jest-haste-map: duplicate manual mock found:
   Module name: blueberry
-  Dupicate Mock path: /fruits/__mocks__/subdir2/blueberry.js
+  Duplicate Mock path: /fruits/__mocks__/subdir2/blueberry.js
 This warning is caused by two manual mock files with the same file name.
 Jest will use the mock file found in: 
 /fruits/__mocks__/subdir2/blueberry.js

--- a/packages/jest-haste-map/src/index.js
+++ b/packages/jest-haste-map/src/index.js
@@ -310,7 +310,7 @@ class HasteMap {
           this._console.warn(
             `jest-haste-map: duplicate manual mock found:\n` +
             `  Module name: ${mockPath}\n` +
-            `  Dupicate Mock path: ${filePath}\nThis warning ` +
+            `  Duplicate Mock path: ${filePath}\nThis warning ` +
             `is caused by two manual mock files with the same file name.\n` +
             `Jest will use the mock file found in: \n` +
             `${filePath}\n` +


### PR DESCRIPTION
**Summary**

The motivation behind this change is that hastemap was blaming me for `Dupicate` Mocks.
It should blame me about `Duplicate` Mocks.


