### PR TITLE
Use yellow instead of red for time reporting. Fixes #1928

### DIFF
--- a/packages/jest-cli/src/reporters/utils.js
+++ b/packages/jest-cli/src/reporters/utils.js
@@ -162,7 +162,7 @@ const renderTime = (
 ) => {
   // If we are more than one second over the estimated time, highlight it.
   const renderedTime = (estimatedTime && runTime >= estimatedTime + 1)
-    ? chalk.bold.red(runTime + 's')
+    ? chalk.bold.yellow(runTime + 's')
     : runTime + 's';
   let time = chalk.bold(`Time:`) + `        ${renderedTime}`;
   if (runTime < estimatedTime) {


### PR DESCRIPTION
**Summary**
Addresses #1928. The test time was being printed in red, which is potentially confusing because it could be seen as an error or a problem.

**Test plan**
Ran `npm run build && npm run test-examples`. Output:
<img width="483" alt="" src="https://cloud.githubusercontent.com/assets/368723/19410969/f3c14f90-92bd-11e6-81cd-c8eee0f967af.png">
