### PR TITLE
`toChange` matcher for mutable/stateful interfaces diffing

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -539,6 +539,26 @@ describe('my beverage', () => {
 });
 ```
 
+### `.toChange(fn)`
+
+`toChange` checks if the value returned from a function was changed due to the expectation. It uses `===` to check
+strict equality.
+
+For example, this code will validate changes in the of the `beverages` array:
+
+```js
+describe('beverages', () => {
+  it('can get more beverages', () => {
+    const beverages = ['soda'];
+
+    expect(() => {
+      beverages.push('juice');
+    }).toChange(() => beverages.length);
+  });
+});
+```
+
+Don't use `toBe` with floating-point numbers. For example, due to rounding, in JavaScript `0.2 + 0.1` is not strictly equal to `0.3`. If you have floating point numbers, try `.toBeCloseTo` instead.
 ### `.toEqual(value)`
 
 Use `.toEqual` when you want to check that two objects have the same value. This matcher recursively checks the equality of all fields, rather than checking for object identity. For example, `toEqual` and `toBe` behave differently in this test suite, so all the tests pass:

--- a/packages/jest-matchers/src/__tests__/__snapshots__/matchers-test.js.snap
+++ b/packages/jest-matchers/src/__tests__/__snapshots__/matchers-test.js.snap
@@ -1506,6 +1506,19 @@ Matcher does not accept any arguments.
 Got: [32mnull[39m"
 `;
 
+exports[`.toChange() fails for 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).toChange([22m[32mexpected[39m[2m)[22m
+
+Expected resolved value to change (using ===):
+  0
+Received:
+  0
+
+Difference:
+
+[2mCompared values have no visual difference.[22m"
+`;
+
 exports[`.toContain() '"11112111"' contains '"2"' 1`] = `
 "[2mexpect([22m[31mstring[39m[2m).not.toContain([22m[32mvalue[39m[2m)[22m
 

--- a/packages/jest-matchers/src/__tests__/matchers-test.js
+++ b/packages/jest-matchers/src/__tests__/matchers-test.js
@@ -56,6 +56,20 @@ describe('.toBe()', () => {
   });
 });
 
+describe('.toChange()', () => {
+  it('fails for', () => {
+    let a = 0;
+    expect(() => jestExpect(() => { a = a; }).toChange(() => a))
+      .toThrowErrorMatchingSnapshot();
+  });
+
+  it('ok for', () => {
+    let a = 0;
+    expect(() => jestExpect(() => { a += 1; }).toChange(() => a))
+      .not.toThrow();
+  });
+});
+
 describe('.toEqual()', () => {
   [
     [true, false],

--- a/packages/jest-matchers/src/matchers.js
+++ b/packages/jest-matchers/src/matchers.js
@@ -91,6 +91,32 @@ const matchers: MatchersObject = {
     return {message, pass};
   },
 
+  toChange(received: Function, expected: Function) {
+    const beforeValue = expected();
+    received();
+    const newValue = expected();
+
+    const pass = beforeValue !== expected();
+
+    const message = pass
+      ? () => matcherHint('.not.toChange') + '\n\n' +
+        `Expected resolved value not to change:\n` +
+        `  ${beforeValue}\n` +
+        `Received:\n` +
+        `  ${newValue}`
+      : () => {
+        const diffString = diff(newValue, beforeValue);
+        return matcherHint('.toChange') + '\n\n' +
+        `Expected resolved value to change (using ===):\n` +
+        `  ${beforeValue}\n` +
+        `Received:\n` +
+        `  ${newValue}` +
+        (diffString ? `\n\nDifference:\n\n${diffString}` : '');
+      };
+
+    return {message, pass};
+  },
+
   toEqual(received: any, expected: any) {
     const pass = equals(received, expected, [iterableEquality]);
 


### PR DESCRIPTION
A very simple implementation for a RSpec's `to_change` equiv:

**Summary**
There are some cases we want to test mutable/stateful interfaces, such as arrays.
the current way of doing so is:

```js
it('changes the array length', () => {
  const someLength = someArray.length;
  callTheFunction(someArray);
  expect(someArray.length).not.toBe(someLength);
});
```

I think it is way too verbose. RSpec has a convenient way of doing so, so with the new matcher, it will be as simple and *readable* as:

```js
it('changes the array length', () => {
   expect(() => callTheFunction(someArray))
    .toChange(() => someArray.length);
});
```
