### PR TITLE
Speed up eslint via built-in caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ website/src/jest/blog
 lerna-debug.log
 npm-debug.log*
 coverage
+.eslintcache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,16 @@
 language: node_js
+
 node_js:
   - "4"
   - "6"
+
 sudo: false
+
+cache:
+  directories:
+    - "node_modules"
+    - ".eslintcache"
+
 before_install: npm i -g npm@latest
-script:
-  - npm run test-ci
+
+script: npm run test-ci

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,10 @@ install:
   - npm --version
   - npm install
 
+cache:
+  - node_modules
+  - .eslintcache
+
 test_script:
   - npm run build
   # Some snapshot tests don't currently work on Windows, so the tests are

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "clean-all": "rm -rf ./packages/*/node_modules; rm -rf ./integration_tests/*/*/node_modules; npm run build-clean",
     "jest": "node ./packages/jest-cli/bin/jest.js",
     "jest-coverage": "npm run jest -- --coverage",
-    "lint": "eslint .",
+    "lint": "eslint . --cache",
     "postinstall": "node ./scripts/postinstall.js && node ./scripts/build.js",
     "publish": "npm run build-clean && npm run build && lerna publish",
     "test": "npm run typecheck && npm run lint && npm run build && npm run jest && npm run test-examples",


### PR DESCRIPTION
The first run will be normal speed (~7.7s on my mac), but subsequent runs were just over a second.