### PR TITLE
Update jsdom dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "istanbul-api": "^1.1.0-alpha.1",
     "istanbul-lib-coverage": "^1.0.0",
     "jasmine-reporters": "^2.2.0",
-    "jsdom": "^9.5.0",
+    "jsdom": "^9.8.0",
     "lerna": "2.0.0-beta.28",
     "minimatch": "^3.0.3",
     "mkdirp": "^0.5.1",

--- a/packages/jest-environment-jsdom/package.json
+++ b/packages/jest-environment-jsdom/package.json
@@ -10,6 +10,6 @@
   "dependencies": {
     "jest-mock": "^16.0.0",
     "jest-util": "^16.0.0",
-    "jsdom": "^9.5.0"
+    "jsdom": "^9.8.0"
   }
 }


### PR DESCRIPTION
**Summary**

The [releases](https://github.com/tmpvar/jsdom/blob/master/Changelog.md#980) since jsdom v9.5.0 include a fix for:
> a performance regression introduced in 9.5.0 for modifying the DOM. It was particularly noticable during initial parsing of a document with many elements; for example, one test showed parsing ten thousand elements taking 36.4 seconds, whereas after this fix it is back to a more reasonable 0.4 seconds.

It also includes implementations for the `document.hasFocus()` API, proper `activeElement` focus behavior for iframes, some `file` interface fixes, plus a few other odds and ends. The iframe focus behavior fixes would avoid hacks in tests like [these ones](https://github.com/facebook/react/pull/7936#pullrequestreview-4373554), while the utility of the performance fix is obvious.

**Test plan**

Ran the existing tests with the updated version of jsdom installed and all passed.

![tests results](https://cloud.githubusercontent.com/assets/517889/19467478/4a43e0e4-94c6-11e6-8cb4-45bcbf1559de.png)

All the tests in `examples/` passed also:

```
> @ test-examples /Users/brandcast/Documents/Developing/jest
> node scripts/test_examples.js

Testing example: /Users/brandcast/Documents/Developing/jest/examples/async
-> running: npm update cwd: /Users/brandcast/Documents/Developing/jest/examples/async
npm WARN deprecated minimatch@2.0.10: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
npm WARN prefer global marked@0.3.6 should be installed with -g
/Users/brandcast/Documents/Developing/jest/examples/async
├── babel-jest@9.0.3
├── babel-plugin-transform-async-to-generator@6.16.0
├── babel-polyfill@6.16.0
├── babel-preset-es2015@6.16.0
└── jest-cli@16.0.1

npm WARN async No description
npm WARN async No repository field.
npm WARN async No license field.
-> running: ln -sf /Users/brandcast/Documents/Developing/jest/packages/jest-cli/bin/jest.js ./node_modules/.bin/jest cwd: /Users/brandcast/Documents/Developing/jest/examples/async
-> running: npm test cwd: /Users/brandcast/Documents/Developing/jest/examples/async

> @ test /Users/brandcast/Documents/Developing/jest/examples/async
> jest

 PASS  __tests__/user-test.js
  ✓ works with promises (11ms)
  ✓ works with async/await (2ms)
  ✓ tests error with promises
  ✓ tests error with async/await (1ms)

Test Suites: 1 passed, 1 total
Tests:       4 passed, 4 total
Snapshots:   0 total
Time:        8.051s
Ran all test suites.
Testing example: /Users/brandcast/Documents/Developing/jest/examples/enzyme
-> running: npm update cwd: /Users/brandcast/Documents/Developing/jest/examples/enzyme
npm WARN deprecated minimatch@2.0.10: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
npm WARN prefer global marked@0.3.6 should be installed with -g
/Users/brandcast/Documents/Developing/jest/examples/enzyme
├── babel-jest@16.0.0
├── babel-polyfill@6.16.0
├── babel-preset-es2015@6.16.0
├── babel-preset-react@6.16.0
├── enzyme@2.4.1
├── jest-cli@16.0.1
├── react@15.3.2
├── react-addons-test-utils@15.3.2
└── react-dom@15.3.2

npm WARN enzyme No description
npm WARN enzyme No repository field.
npm WARN enzyme No license field.
-> running: ln -sf /Users/brandcast/Documents/Developing/jest/packages/jest-cli/bin/jest.js ./node_modules/.bin/jest cwd: /Users/brandcast/Documents/Developing/jest/examples/enzyme
-> running: npm test cwd: /Users/brandcast/Documents/Developing/jest/examples/enzyme

> @ test /Users/brandcast/Documents/Developing/jest/examples/enzyme
> jest

 PASS  __tests__/CheckboxWithLabel-test.js (7.251s)
  ✓ CheckboxWithLabel changes the text after click (36ms)

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        11.309s
Ran all test suites.
Testing example: /Users/brandcast/Documents/Developing/jest/examples/getting_started
-> running: npm update cwd: /Users/brandcast/Documents/Developing/jest/examples/getting_started
npm WARN deprecated minimatch@2.0.10: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
npm WARN prefer global marked@0.3.6 should be installed with -g
/Users/brandcast/Documents/Developing/jest/examples/getting_started
└── jest-cli@16.0.1

npm WARN getting_started No description
npm WARN getting_started No repository field.
npm WARN getting_started No license field.
-> running: ln -sf /Users/brandcast/Documents/Developing/jest/packages/jest-cli/bin/jest.js ./node_modules/.bin/jest cwd: /Users/brandcast/Documents/Developing/jest/examples/getting_started
-> running: npm test cwd: /Users/brandcast/Documents/Developing/jest/examples/getting_started

> @ test /Users/brandcast/Documents/Developing/jest/examples/getting_started
> jest

 PASS  __tests__/sum-test.js
  ✓ adds 1 + 2 to equal 3 (19ms)

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        6.24s
Ran all test suites.
Testing example: /Users/brandcast/Documents/Developing/jest/examples/jquery
-> running: npm update cwd: /Users/brandcast/Documents/Developing/jest/examples/jquery
npm WARN deprecated minimatch@2.0.10: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
npm WARN prefer global marked@0.3.6 should be installed with -g
/Users/brandcast/Documents/Developing/jest/examples/jquery
├── jest-cli@16.0.1
└── jquery@3.1.1

npm WARN jquery No description
npm WARN jquery No repository field.
npm WARN jquery No license field.
-> running: ln -sf /Users/brandcast/Documents/Developing/jest/packages/jest-cli/bin/jest.js ./node_modules/.bin/jest cwd: /Users/brandcast/Documents/Developing/jest/examples/jquery
-> running: npm test cwd: /Users/brandcast/Documents/Developing/jest/examples/jquery

> @ test /Users/brandcast/Documents/Developing/jest/examples/jquery
> jest

 PASS  __tests__/fetchCurrentUser-test.js
 PASS  __tests__/displayUser-test.js

Test Suites: 2 passed, 2 total
Tests:       3 passed, 3 total
Snapshots:   0 total
Time:        6.207s
Ran all test suites.
Testing example: /Users/brandcast/Documents/Developing/jest/examples/manual_mocks
-> running: npm update cwd: /Users/brandcast/Documents/Developing/jest/examples/manual_mocks
npm WARN deprecated minimatch@2.0.10: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
npm WARN prefer global marked@0.3.6 should be installed with -g
/Users/brandcast/Documents/Developing/jest/examples/manual_mocks
└── jest-cli@16.0.1

npm WARN manual_mocks No description
npm WARN manual_mocks No repository field.
npm WARN manual_mocks No license field.
-> running: ln -sf /Users/brandcast/Documents/Developing/jest/packages/jest-cli/bin/jest.js ./node_modules/.bin/jest cwd: /Users/brandcast/Documents/Developing/jest/examples/manual_mocks
-> running: npm test cwd: /Users/brandcast/Documents/Developing/jest/examples/manual_mocks

> @ test /Users/brandcast/Documents/Developing/jest/examples/manual_mocks
> jest

 PASS  __tests__/FileSummarizer-test.js
  listFilesInDirectorySync
    ✓ includes all files in the directory in the summary (95ms)

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        5.78s
Ran all test suites.
Testing example: /Users/brandcast/Documents/Developing/jest/examples/react
-> running: npm update cwd: /Users/brandcast/Documents/Developing/jest/examples/react
npm WARN deprecated minimatch@2.0.10: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
npm WARN prefer global marked@0.3.6 should be installed with -g
/Users/brandcast/Documents/Developing/jest/examples/react
├── babel-jest@16.0.0
├── babel-polyfill@6.16.0
├── babel-preset-es2015@6.16.0
├── babel-preset-react@6.16.0
├── jest-cli@16.0.1
├── react@15.3.2
├── react-addons-test-utils@15.3.2
└── react-dom@15.3.2

npm WARN react No description
npm WARN react No repository field.
npm WARN react No license field.
-> running: ln -sf /Users/brandcast/Documents/Developing/jest/packages/jest-cli/bin/jest.js ./node_modules/.bin/jest cwd: /Users/brandcast/Documents/Developing/jest/examples/react
-> running: npm test cwd: /Users/brandcast/Documents/Developing/jest/examples/react

> @ test /Users/brandcast/Documents/Developing/jest/examples/react
> jest

 PASS  __tests__/CheckboxWithLabel-test.js
  ✓ CheckboxWithLabel changes the text after click (50ms)

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        8.465s
Ran all test suites.
Testing example: /Users/brandcast/Documents/Developing/jest/examples/react-native
-> running: npm update cwd: /Users/brandcast/Documents/Developing/jest/examples/react-native
npm WARN deprecated minimatch@2.0.10: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
npm WARN deprecated cross-spawn-async@2.2.4: cross-spawn no longer requires a build toolchain, use it instead!
npm WARN prefer global marked@0.3.6 should be installed with -g

> spawn-sync@1.0.15 postinstall /Users/brandcast/Documents/Developing/jest/examples/react-native/node_modules/spawn-sync
> node postinstall

jest-rn@1.0.0 /Users/brandcast/Documents/Developing/jest/examples/react-native
├── babel-jest@16.0.0
├── babel-preset-react-native@1.9.0
├── jest-cli@16.0.1
├── jest-react-native@16.0.0
├── UNMET PEER DEPENDENCY react@15.3.0
├── react-native@0.32.0
└── react-test-renderer@15.3.2

npm WARN react-test-renderer@15.3.2 requires a peer of react@^15.3.2 but none was installed.
npm WARN jest-rn@1.0.0 No description
npm WARN jest-rn@1.0.0 No repository field.
npm WARN jest-rn@1.0.0 No license field.
-> running: ln -s /Users/brandcast/Documents/Developing/jest/packages/jest-react-native ./node_modules/ cwd: /Users/brandcast/Documents/Developing/jest/examples/react-native
-> running: ln -sf /Users/brandcast/Documents/Developing/jest/packages/jest-cli/bin/jest.js ./node_modules/.bin/jest cwd: /Users/brandcast/Documents/Developing/jest/examples/react-native
-> running: npm test cwd: /Users/brandcast/Documents/Developing/jest/examples/react-native

> jest-rn@1.0.0 test /Users/brandcast/Documents/Developing/jest/examples/react-native
> jest

 PASS  __tests__/Intro-test.js (5.662s)
  ✓ renders correctly (1023ms)
  ✓ renders the ActivityIndicator component (30ms)
  ✓ renders the Image component (53ms)
  ✓ renders the TextInput component (466ms)
  ✓ renders the ListView component (610ms)

Test Suites: 1 passed, 1 total
Tests:       5 passed, 5 total
Snapshots:   5 passed, 5 total
Time:        10.42s
Ran all test suites.
Testing example: /Users/brandcast/Documents/Developing/jest/examples/snapshot
-> running: npm update cwd: /Users/brandcast/Documents/Developing/jest/examples/snapshot
npm WARN deprecated minimatch@2.0.10: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
npm WARN prefer global marked@0.3.6 should be installed with -g
/Users/brandcast/Documents/Developing/jest/examples/snapshot
├── babel-jest@16.0.0
├── babel-polyfill@6.16.0
├── babel-preset-es2015@6.16.0
├── babel-preset-react@6.16.0
├── jest-cli@16.0.1
├── UNMET PEER DEPENDENCY react@15.3.0
└── react-test-renderer@15.3.2

npm WARN react-test-renderer@15.3.2 requires a peer of react@^15.3.2 but none was installed.
npm WARN snapshot No description
npm WARN snapshot No repository field.
npm WARN snapshot No license field.
-> running: ln -sf /Users/brandcast/Documents/Developing/jest/packages/jest-cli/bin/jest.js ./node_modules/.bin/jest cwd: /Users/brandcast/Documents/Developing/jest/examples/snapshot
-> running: npm test cwd: /Users/brandcast/Documents/Developing/jest/examples/snapshot

> @ test /Users/brandcast/Documents/Developing/jest/examples/snapshot
> jest

 PASS  __tests__/Link.react-test.js
  ✓ renders correctly (27ms)
  ✓ renders as an anchor when no page is set (7ms)
  ✓ properly escapes quotes (2ms)
  ✓ changes the class when hovered (9ms)

Test Suites: 1 passed, 1 total
Tests:       4 passed, 4 total
Snapshots:   6 passed, 6 total
Time:        5.4s
Ran all test suites.
Testing example: /Users/brandcast/Documents/Developing/jest/examples/timer
-> running: npm update cwd: /Users/brandcast/Documents/Developing/jest/examples/timer
npm WARN deprecated minimatch@2.0.10: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
npm WARN prefer global marked@0.3.6 should be installed with -g
/Users/brandcast/Documents/Developing/jest/examples/timer
└── jest-cli@16.0.1

npm WARN timer No description
npm WARN timer No repository field.
npm WARN timer No license field.
-> running: ln -sf /Users/brandcast/Documents/Developing/jest/packages/jest-cli/bin/jest.js ./node_modules/.bin/jest cwd: /Users/brandcast/Documents/Developing/jest/examples/timer
-> running: npm test cwd: /Users/brandcast/Documents/Developing/jest/examples/timer

> @ test /Users/brandcast/Documents/Developing/jest/examples/timer
> jest

 PASS  __tests__/timerGame-test.js
  ● Console

    console.log timerGame.js:6
      Ready....go!
    console.log timerGame.js:6
      Ready....go!
    console.log timerGame.js:8
      Times up -- stop!
    console.log timerGame.js:8
      Times up -- stop!
    console.log timerGame.js:6
      Ready....go!
    console.log timerGame.js:8
      Times up -- stop!

 PASS  __tests__/infiniteTimerGame-test.js
  ● Console

    console.log infiniteTimerGame.js:6
      Ready....go!
    console.log infiniteTimerGame.js:9
      Times up! 10 seconds before the next game starts...


Test Suites: 2 passed, 2 total
Tests:       4 passed, 4 total
Snapshots:   0 total
Time:        5.954s
Ran all test suites.
Testing example: /Users/brandcast/Documents/Developing/jest/examples/typescript
-> running: npm update cwd: /Users/brandcast/Documents/Developing/jest/examples/typescript
npm WARN deprecated minimatch@2.0.10: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
npm WARN prefer global marked@0.3.6 should be installed with -g
/Users/brandcast/Documents/Developing/jest/examples/typescript
├── jest-cli@16.0.1
├── react@15.3.2
├── react-addons-test-utils@15.3.2
├── react-dom@15.3.2
└── typescript@2.0.3

npm WARN typescript No description
npm WARN typescript No repository field.
npm WARN typescript No license field.
-> running: ln -sf /Users/brandcast/Documents/Developing/jest/packages/jest-cli/bin/jest.js ./node_modules/.bin/jest cwd: /Users/brandcast/Documents/Developing/jest/examples/typescript
-> running: npm test cwd: /Users/brandcast/Documents/Developing/jest/examples/typescript

> @ test /Users/brandcast/Documents/Developing/jest/examples/typescript
> jest

 PASS  __tests__/CheckboxWithLabel-test.tsx
 PASS  __tests__/sum-test.js
 PASS  __tests__/sum-test.ts
 PASS  __tests__/sub-test.ts

Test Suites: 4 passed, 4 total
Tests:       6 passed, 6 total
Snapshots:   0 total
Time:        1.872s
Ran all test suites.
```