### PR TITLE
Add defaultPlatform extensions to resolveModule extensions

### DIFF
--- a/integration_tests/__tests__/resolve-test.js
+++ b/integration_tests/__tests__/resolve-test.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails oncall+jsinfra
+ */
+'use strict';
+
+const runJest = require('../runJest');
+
+test('resolve platform modules', () => {
+  const result = runJest('resolve');
+  expect(result.status).toBe(process.platform !== 'win32' ? 0 : null);
+});

--- a/integration_tests/resolve/__tests__/resolve-test.js
+++ b/integration_tests/resolve/__tests__/resolve-test.js
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
+let platform;
+
+function testRequire(filename) {
+  return () => platform = require(filename);
+}
+
+test('should resolve filename.<platform>.js', () => {
+  expect(testRequire('../test1.android.js')).not.toThrow();
+  expect(platform.extension).toBe('android.js');
+});
+
+test('should resolve filename.native.js', () => {
+  expect(testRequire('../test1.native.js')).not.toThrow();
+  expect(platform.extension).toBe('native.js');
+});
+
+test('should resolve filename.js', () => {
+  expect(testRequire('../test1.js')).not.toThrow();
+  expect(platform.extension).toBe('js');
+});
+
+test('should resolve filename.json', () => {
+  expect(testRequire('../test1.json')).not.toThrow();
+  expect(platform.extension).toBe('json');
+});
+
+test('should resolve filename.<platform>.js', () => {
+  expect(testRequire('../test1')).not.toThrow();
+  expect(platform.extension).toBe('android.js');
+});
+
+test('should resolve filename.native.js', () => {
+  expect(testRequire('../test2')).not.toThrow();
+  expect(platform.extension).toBe('native.js');
+});
+
+test('should resolve filename.js', () => {
+  expect(testRequire('../test3')).not.toThrow();
+  expect(platform.extension).toBe('js');
+});
+
+test('should resolve filename.json', () => {
+  expect(testRequire('../test4')).not.toThrow();
+  expect(platform.extension).toBe('json');
+});

--- a/integration_tests/resolve/package.json
+++ b/integration_tests/resolve/package.json
@@ -1,0 +1,7 @@
+{
+  "jest": {
+    "haste": {
+      "defaultPlatform": "android"
+    }
+  }
+}

--- a/integration_tests/resolve/test1.android.js
+++ b/integration_tests/resolve/test1.android.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
+module.exports = {extension: 'android.js'};

--- a/integration_tests/resolve/test1.js
+++ b/integration_tests/resolve/test1.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
+module.exports = {extension: 'js'};

--- a/integration_tests/resolve/test1.json
+++ b/integration_tests/resolve/test1.json
@@ -1,0 +1,3 @@
+{
+    "extension": "json"
+}

--- a/integration_tests/resolve/test1.native.js
+++ b/integration_tests/resolve/test1.native.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
+module.exports = {extension: 'native.js'};

--- a/integration_tests/resolve/test2.js
+++ b/integration_tests/resolve/test2.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
+module.exports = {extension: 'js'};

--- a/integration_tests/resolve/test2.json
+++ b/integration_tests/resolve/test2.json
@@ -1,0 +1,3 @@
+{
+    "extension": "json"
+}

--- a/integration_tests/resolve/test2.native.js
+++ b/integration_tests/resolve/test2.native.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
+module.exports = {extension: 'native.js'};

--- a/integration_tests/resolve/test3.js
+++ b/integration_tests/resolve/test3.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
+module.exports = {extension: 'js'};

--- a/integration_tests/resolve/test3.json
+++ b/integration_tests/resolve/test3.json
@@ -1,0 +1,3 @@
+{
+    "extension": "json"
+}

--- a/integration_tests/resolve/test4.json
+++ b/integration_tests/resolve/test4.json
@@ -1,0 +1,3 @@
+{
+    "extension": "json"
+}

--- a/packages/jest-resolve/src/index.js
+++ b/packages/jest-resolve/src/index.js
@@ -93,9 +93,15 @@ class Resolver {
   ): Path {
     const dirname = path.dirname(from);
     const paths = this._options.modulePaths;
-    const extensions = this._options.extensions;
     const moduleDirectory = this._options.moduleDirectories;
     const key = dirname + path.delimiter + moduleName;
+    const defaultPlatform = this._options.defaultPlatform;
+    let exts = ['.' + NATIVE_PLATFORM + '.js'].concat(
+      this._options.extensions || [],
+    );
+    if (defaultPlatform) {
+      exts = ['.' + defaultPlatform + '.js'].concat(exts);
+    }
 
     // 0. If we have already resolved this module for this directory name,
     //    return a value from the cache.
@@ -115,7 +121,7 @@ class Resolver {
       module = Resolver.findNodeModule(moduleName, {
         basedir: dirname,
         browser: this._options.browser,
-        extensions,
+        extensions: exts,
         moduleDirectory,
         paths,
       });


### PR DESCRIPTION
**Summary**

Jest currently is not able to resolve internal modules with a platform extension such as .android.js / .ios.js.
This solves this issue by allowing the Resolver from jest-resolve to find a module also by using the defaultPlatform option.
This also allows to test android and ios platforms by defining the defaultPlatform accordingly

**Test plan**

ls -l ./src:

> -rw-r--r-- 1 user user 1K Oct 18 12:59 App.android.js
> -rw-r--r-- 1 user user 1K Oct 18 12:59 App.ios.js

in \_\_tests\_\_/App-test.js:
```javascript
import 'react-native'
import React from 'react'
import App from '../src/App'

import renderer from 'react-test-renderer'

it('renders correctly', () => {
    const tree = renderer.create(
        <App/>
    ).toJSON();
    expect(tree).toMatchSnapshot();
})
```

```
jest --no-cache
```
