### PR TITLE
Docs: Fix toBeInstanceOf capitalization in API.md

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -453,7 +453,7 @@ Use `.toBeInstanceOf(Class)` to check that an object is an instance of a class. 
 class A {}
 
 expect(new A()).toBeInstanceOf(A);
-expect(() => {}).toBeinstanceOf(Function);
+expect(() => {}).toBeInstanceOf(Function);
 expect(new A()).toBeInstanceOf(Function); // throws
 ```
 


### PR DESCRIPTION
**Summary**

The documentation for `.toBeInstanceOf` in the API.md file was inconsistent.

**Test plan**

No code was changed; markdown review should be sufficient for testing purposes.
