### PR TITLE
[docs] fix default testRegexp

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -319,7 +319,7 @@ An array of regexp pattern strings that are matched against all test paths befor
 These pattern strings match against the full path. Use the `<rootDir>` string token to  include the path to your project's root directory to prevent it from accidentally ignoring all of your files in different environments that may have different root directories. Example: `['<rootDir>/build/', '<rootDir>/node_modules/']`.
 
 ### `testRegex` [string]
-(default: `(/__tests__/.*|\\.(test|spec))\\.(js|jsx)$`)
+(default: `(/__tests__/.*|\\.(test|spec)\\.(js|jsx)$`)
 
 The pattern Jest uses to detect test files. By default it looks for `.js` and `.jsx` files
 inside of `__tests__` folders.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Fixed a minor typo in the docs - in the `testRegex` example:

    Invalid regular expression: /\\__tests__\\.*|\.(test|spec))\.(js|jsx)$/: Unmatched ')'

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

\-