### PR TITLE
Use typescript compiler more idiomatically

### DIFF
--- a/examples/typescript/preprocessor.js
+++ b/examples/typescript/preprocessor.js
@@ -1,16 +1,14 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
 
 const tsc = require('typescript');
+const tsConfig = require('./tsconfig.json');
 
 module.exports = {
   process(src, path) {
     if (path.endsWith('.ts') || path.endsWith('.tsx')) {
       return tsc.transpile(
         src,
-        {
-          module: tsc.ModuleKind.CommonJS,
-          jsx: tsc.JsxEmit.React,
-        },
+        tsConfig.compilerOptions,
         path,
         []
       );

--- a/examples/typescript/tsconfig.json
+++ b/examples/typescript/tsconfig.json
@@ -1,0 +1,6 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "jsx": "react"
+    }
+}

--- a/examples/typescript/tsconfig.json
+++ b/examples/typescript/tsconfig.json
@@ -1,6 +1,6 @@
 {
-    "compilerOptions": {
-        "module": "commonjs",
-        "jsx": "react"
-    }
+  "compilerOptions": {
+    "module": "commonjs",
+    "jsx": "react"
+  }
 }


### PR DESCRIPTION
**Summary**

When using typescript in a real project, it is idiomatic to provide the typescript compiler options by means of the `tsconfig.json` file. This makes sure the typescript compiler, webpack loaders, IDE's, test runners like jest, all use the same compiler flags (for example `"jsx": "react"`). 

In the current `preprocessor.js` example the configuration was in line. People using typescript with jest will usually change this to load `tsconfig.json` instead. The confusing thing is that the transpiler doesn't want all the options, but just the `compilerOptions` section from the config file. I made that more clear with-this new setup. I've seen two different cases in the last week where people run into this. (Example: https://github.com/mobxjs/mobx/issues/405#issuecomment-255342371). The net result of this that all compiler options where silently ignored.

The minimum required `tsconfig.json` file has been added to the repo and is now used by the preprocessor.

**Test plan**

```bash
➜  typescript git:(master) npm test -- --no-cache

> @ test /home/michel/dev/jest/examples/typescript
> jest "--no-cache"

 PASS  __tests__/CheckboxWithLabel-test.tsx
 PASS  __tests__/sum-test.js
 PASS  __tests__/sum-test.ts
 PASS  __tests__/sub-test.ts

Test Suites: 4 passed, 4 total
Tests:       6 passed, 6 total
Snapshots:   0 total
Time:        1.056s
Ran all test suites.
```
