### PR TITLE
Fix path separator replacement bug in Windows

### DIFF
--- a/packages/jest-runtime/src/index.js
+++ b/packages/jest-runtime/src/index.js
@@ -25,7 +25,10 @@ const fs = require('graceful-fs');
 const path = require('path');
 const shouldInstrument = require('./shouldInstrument');
 const transform = require('./transform');
-const utils = require('jest-util');
+const {
+  createDirectory,
+  replacePathSepForRegex,
+} = require('jest-util');
 
 type Module = {|
   children?: Array<any>,
@@ -114,7 +117,7 @@ class Runtime {
     this._mocksPattern =
       config.mocksPattern ? new RegExp(config.mocksPattern) : null;
     this._shouldAutoMock = config.automock;
-    this._testRegex = new RegExp(config.testRegex.replace(/\//g, path.sep));
+    this._testRegex = new RegExp(replacePathSepForRegex(config.testRegex));
     this._virtualMocks = Object.create(null);
 
     this._mockMetaDataCache = Object.create(null);
@@ -171,7 +174,7 @@ class Runtime {
       maxWorkers: number,
     },
   ): Promise<HasteContext> {
-    utils.createDirectory(config.cacheDirectory);
+    createDirectory(config.cacheDirectory);
     const instance = Runtime.createHasteMap(config, {
       console: options.console,
       maxWorkers: options.maxWorkers,


### PR DESCRIPTION
**Summary**

Encountered the following error message while trying to run React tests on Windows:

```
 FAIL  src\renderers\shared\stack\reconciler\__tests__\ReactStateSetters-test.js
  ● Test suite failed to run

    SyntaxError: Invalid regular expression: /\__tests__\/: \ at end of pattern
        at new RegExp (native)

      at new Runtime (node_modules\jest-runtime\build\index.js:111:23)
      at handle (node_modules\worker-farm\lib\child\index.js:41:8)
      at process.<anonymous> (node_modules\worker-farm\lib\child\index.js:47:3)
      at emitTwo (events.js:87:13)
      at process.emit (events.js:172:7)
      at internal\child_process.js:696:12
      at nextTickCallbackWith0Args (node.js:420:9)
```

Node.js version is 4.6.1.

**Test plan**

React tests run properly after the fix.