### PR TITLE
Document updateSnapshot with testNamePattern

### DIFF
--- a/packages/jest-cli/src/cli/args.js
+++ b/packages/jest-cli/src/cli/args.js
@@ -226,9 +226,11 @@ const options = {
   updateSnapshot: {
     alias: 'u',
     default: false,
-    description: 'Use this flag to re-record snapshots. ' +
-    'Accepts a pattern for suite name. Use together with `--testNamePattern` ' +
-    'to re-record snapshot for test matching the pattern',
+    description:
+      'Use this flag to re-record snapshots. ' +
+      'Can be used together with a test suite pattern or with ' +
+      '`--testNamePattern` to re-record snapshot for test matching ' +
+      'the pattern',
     type: 'boolean',
   },
   testcheckTimes: {

--- a/packages/jest-cli/src/cli/args.js
+++ b/packages/jest-cli/src/cli/args.js
@@ -226,7 +226,9 @@ const options = {
   updateSnapshot: {
     alias: 'u',
     default: false,
-    description: 'Use this flag to re-record snapshots.',
+    description: 'Use this flag to re-record snapshots. ' +
+    'Accepts a pattern for suite name. Use together with `--testNamePattern` ' +
+    'to re-record snapshot for test matching the pattern',
     type: 'boolean',
   },
   testcheckTimes: {


### PR DESCRIPTION
Somewhat helps with facebook#1970

--updateSnapshot accepts <suiteName> to select which snapshots to update
--updateSnapshot can be combined with --testNamePattern to re-record
snapshot for particular test in as suite
