### PR TITLE
Return exit code 1 if coverage threshold requirements are not met

### DIFF
--- a/packages/jest-cli/src/TestRunner.js
+++ b/packages/jest-cli/src/TestRunner.js
@@ -237,22 +237,6 @@ class TestRunner {
           aggregatedResults.snapshot.filesRemoved
         )
       );
-
-      aggregatedResults.wasInterrupted = watcher.isInterrupted();
-    };
-
-    const determineSuccessful = () => {
-      const anyTestFailures = !(
-        aggregatedResults.numFailedTests === 0 &&
-        aggregatedResults.numRuntimeErrorTestSuites === 0
-      );
-      const anyReporterErrors = this._dispatcher.hasErrors();
-
-      aggregatedResults.success = !(
-        anyTestFailures ||
-        aggregatedResults.snapshot.failure ||
-        anyReporterErrors
-      );
     };
 
     const runInBand = shouldRunInBand();
@@ -279,8 +263,22 @@ class TestRunner {
       })
       .then(() => {
         updateSnapshotState();
+        aggregatedResults.wasInterrupted = watcher.isInterrupted();
+
         this._dispatcher.onRunComplete(config, aggregatedResults);
-        determineSuccessful();
+
+        const anyTestFailures = !(
+          aggregatedResults.numFailedTests === 0 &&
+          aggregatedResults.numRuntimeErrorTestSuites === 0
+        );
+        const anyReporterErrors = this._dispatcher.hasErrors();
+
+        aggregatedResults.success = !(
+          anyTestFailures ||
+          aggregatedResults.snapshot.failure ||
+          anyReporterErrors
+        );
+
         this._cacheTestResults(aggregatedResults);
         return aggregatedResults;
       });

--- a/packages/jest-cli/src/TestRunner.js
+++ b/packages/jest-cli/src/TestRunner.js
@@ -225,8 +225,7 @@ class TestRunner {
       )
     );
 
-    const finalizeResults = () => {
-      // Update snapshot state.
+    const updateSnapshotState = () => {
       const status =
         snapshot.cleanup(this._hasteContext.hasteFS, config.updateSnapshot);
       aggregatedResults.snapshot.filesRemoved += status.filesRemoved;
@@ -240,8 +239,9 @@ class TestRunner {
       );
 
       aggregatedResults.wasInterrupted = watcher.isInterrupted();
+    };
 
-      // Check if the test run was successful or not.
+    const determineSuccessful = () => {
       const anyTestFailures = !(
         aggregatedResults.numFailedTests === 0 &&
         aggregatedResults.numRuntimeErrorTestSuites === 0
@@ -278,8 +278,9 @@ class TestRunner {
         }
       })
       .then(() => {
-        finalizeResults();
+        updateSnapshotState();
         this._dispatcher.onRunComplete(config, aggregatedResults);
+        determineSuccessful();
         this._cacheTestResults(aggregatedResults);
         return aggregatedResults;
       });


### PR DESCRIPTION
First of all thanks for this tool!

I'm very new to Jest so please forgive any stupid error or incorrect assumption.
I'm very open to adapt this to the project / community needs, in fact I am trying to understand how to add an integration test for this, any suggestion is more than welcome.

**Summary**

Whenever the `--coverage` flag is passed, jest exits with `0` even if the threshold requirements are not met.

Seems like the solution is to determine if a run is successful after `onRunComplete` is called, because in that function `aggregatedResults` is populated with the required values.

**Test plan**

I've written a small POC which has a 100% coverage requirement which is not met.
With the change after you run `npm test` in this POC you will get `1` as a result from `echo $?`.

```JS
// sum.js
module.exports = (a, b) => a + b;
```

```JS
// __tests__/sum.test.js
test('adds1 +2 to equal3', () => {
  const sum = require('../sum');
  expect(42).toBe(41+1);
});
```

```JSON
// package.json
{
  "name": "jest-example",
  "scripts": {
    "test": "/usr/local/lib/node_modules/jest/jest --coverage"
  },
  "jest": {
    "coverageThreshold": {
      "global": {
        "branches": 100,
        "functions": 100,
        "lines": 100,
        "statements": 100
      }
    }
  },
  "devDependencies": {
    "jest": "^16.0.2"
  }
}
```
