### PR TITLE
Fixes typo in link to CLI options

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -102,7 +102,7 @@ These methods help create mocks and let you control Jest's overall behavior.
 
 ### The Jest CLI
 
-  - [Jest CLI Options](#jestclioptions)
+  - [Jest CLI Options](#jest-cli-options)
 
 -----
 


### PR DESCRIPTION
This fixes a broken anchor to CLI options on the API docs.

s/jestclioptions/jest-cli-options

