### PR TITLE
added name to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "jest",
   "private": true,
   "devDependencies": {
     "babel-core": "^6.16.0",


### PR DESCRIPTION
While working on another PR I noticed that it wasn't possible to `npm link` in the `jester/` folder, to speed up development. 

I think this might have been brought up before, but I could not find any evidence; is there any reason why we don't have a `name` in package.json?