### PR TITLE
Add getting set up instructions to the contributing doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,12 +21,35 @@ The core team will be monitoring for pull requests. When we get one, we'll run s
 *Before* submitting a pull request, please make sure the following is done…
 
 1. Fork the repo and create your branch from `master`.
+   
+   ```sh
+   git clone https://github.com/facebook/jest
+   cd jest
+   git checkout -b my_branch 
+   ```
+
 2. Run `npm install`. It is recommended to use `npm3`.
-3. If you've added code that should be tested, add tests.
+
+    ```sh
+    npm install
+    ```
+
+3. If you've added code that should be tested, add tests. You
+   can use watch mode to make your life easier.
+
+   ```sh
+   node ./packages/jest-cli/bin/jest.js --watch
+   ``` 
+
 4. If you've changed APIs, update the documentation.
-5. Ensure the test suite passes (`npm test`). To run the test suite you
+5. Ensure the test suite passes via `npm run jest`. To run the test suite you
    may need to install Mercurial (`hg`). On macOS, this can be done
    using [homebrew](http://brew.sh/): `brew install hg`.
+
+   ```sh
+   brew install hg # maybe
+   npm run jest
+   ```
 6. If you haven't already, complete the CLA.
 
 ### Contributor License Agreement (CLA)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,20 +35,22 @@ The core team will be monitoring for pull requests. When we get one, we'll run s
     ```
 
 3. If you've added code that should be tested, add tests. You
-   can use watch mode to make your life easier.
+   can use watch mode that continuously transforms chagned files
+   to make your life easier.
 
    ```sh
-   node ./packages/jest-cli/bin/jest.js --watch
+   # in the background
+   npm run watch
    ``` 
 
 4. If you've changed APIs, update the documentation.
-5. Ensure the test suite passes via `npm run jest`. To run the test suite you
+5. Ensure the test suite passes via `npm test`. To run the test suite you
    may need to install Mercurial (`hg`). On macOS, this can be done
    using [homebrew](http://brew.sh/): `brew install hg`.
 
    ```sh
    brew install hg # maybe
-   npm run jest
+   npm test
    ```
 6. If you haven't already, complete the CLA.
 


### PR DESCRIPTION
**Summary**

Adds instructions for getting started to the CONTRIBUTING docs. I couldn't find any docs ([like this](https://github.com/danger/danger#im-here-to-help-out)) showing me how to grab the code, and run the tests to verify everything is fine. 

So I added it to the contributing docs 👍 