### PR TITLE
Fixed coverage summary duplication

### DIFF
--- a/packages/jest-cli/src/reporters/CoverageReporter.js
+++ b/packages/jest-cli/src/reporters/CoverageReporter.js
@@ -71,7 +71,8 @@ class CoverageReporter extends BaseReporter {
       if (
         config.coverageReporters &&
         config.coverageReporters.length &&
-        config.coverageReporters.indexOf('text') === -1
+        config.coverageReporters.indexOf('text') === -1 &&
+        config.coverageReporters.indexOf('text-summary') === -1
       ) {
         const results = this._coverageMap.getCoverageSummary().toJSON();
         const format = percent => percent + (percent === 'Unknown' ? '' : '%');


### PR DESCRIPTION
If text-summary reporter selected then coverage summary information duplicated.

![image](https://cloud.githubusercontent.com/assets/821305/19687551/762e529e-9ace-11e6-9e22-79346f0a015c.png)
