### PR TITLE
Stop using Node `--inspect` option in the docs on debugging

### DIFF
--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -11,17 +11,29 @@ Uh oh, something went wrong? Use this guide to resolve issues with Jest.
 
 ### Tests are Failing and You Don't Know Why
 
-Try using the debugger built into >= Node 6.3.
+Try using the debugging support built into Node.
 
 Place a `debugger;` statement in any of your tests, and then, in your project's directory, run:
 
-`node --debug-brk --inspect ./node_modules/.bin/jest -i [any other arguments here]`
+`node --debug-brk ./node_modules/.bin/jest -i [any other arguments here]`
+
+This will run Jest in a Node process that an external debugger can connect to. Note that the process 
+will pause until the debugger has connected to it.
+
+For example, to connect the [Node Inspector](https://github.com/node-inspector/node-inspector) 
+debugger to the paused process, you would first install it (if you don't have it installed already):
+
+`npm install -g node-inspector`
+
+Then simply run it:
+
+`node-inspector`
 
 This will output a link that you can open in Chrome. After opening that link, the Chrome Developer Tools will be displayed, and a breakpoint will be set at the first line of the Jest CLI script (this is done simply to give you time to open the developer tools and to prevent Jest from executing before you have time to do so). Click the button that looks like a "play" button in the upper right hand side of the screen to continue execution. When Jest executes the test that contains the `debugger` statement, execution will pause and you can examine the current scope and call stack.
 
 *Note: the `-i` cli option makes sure Jest runs test in the same process rather than spawning processes for individual tests. Normally Jest parallelizes test runs across processes but it is hard to debug many processes at the same time.*
 
-More information on the V8 inspector can be found here: https://nodejs.org/api/debugger.html#debugger_v8_inspector_integration_for_node_js
+More information on Node debugging can be found here: https://nodejs.org/api/debugger.html
 
 ### Caching Issues
 


### PR DESCRIPTION
**Summary**

Stop using Node `--inspect` option in the docs on debugging

The technique described in the instructions does not pick up
breakpoints set with `debugger` statements. This issue is being
tracked by https://github.com/facebook/jest/issues/1652, but
it's unclear how long it will take to resolve as it's actually
a Node issue.

As a work-around, have updated docs to describe connecting an
external debugger to the Node process.

**Test plan**

I have locally generated and previewed the updated documentation using the `npm start` command in the `website` directory.