### PR TITLE
Expose matcherUtils in extend call context

### DIFF
--- a/packages/jest-matchers/src/__tests__/extend-test.js
+++ b/packages/jest-matchers/src/__tests__/extend-test.js
@@ -39,11 +39,11 @@ it('exposes matcherUtils in context', () => {
       const pass = this.matcherUtils === matcherUtils;
       const message = pass
         ? `expected this.matcherUtils to be defined in an extend call`
-        : `expected this.matcherUtils not to be defined in an extend call`
+        : `expected this.matcherUtils not to be defined in an extend call`;
 
       return {pass, message};
     },
-  })
+  });
 
   jestExpect()._shouldNotError();
 });

--- a/packages/jest-matchers/src/__tests__/extend-test.js
+++ b/packages/jest-matchers/src/__tests__/extend-test.js
@@ -11,6 +11,7 @@
 'use strict';
 
 const jestExpect = require('../').expect;
+const matcherUtils = require('jest-matcher-utils');
 
 jestExpect.extend({
   toBeDivisibleBy(actual, expected) {
@@ -30,4 +31,19 @@ it('is available globally', () => {
 
   jestExpect(() => jestExpect(15).toBeDivisibleBy(2))
     .toThrowErrorMatchingSnapshot();
+});
+
+it('exposes matcherUtils in context', () => {
+  jestExpect.extend({
+    _shouldNotError(actual, expected) {
+      const pass = this.matcherUtils === matcherUtils;
+      const message = pass
+        ? `expected this.matcherUtils to be defined in an extend call`
+        : `expected this.matcherUtils not to be defined in an extend call`
+
+      return {pass, message};
+    },
+  })
+
+  jestExpect()._shouldNotError();
 });

--- a/packages/jest-matchers/src/index.js
+++ b/packages/jest-matchers/src/index.js
@@ -67,8 +67,7 @@ const makeThrowingMatcher = (
       // failures in a test.
       {dontThrow: () => throws = false},
       global[GLOBAL_STATE].state,
-      {isNot},
-      {matcherUtils},
+      {isNot, matcherUtils},
     );
     let result: ExpectationResult;
 

--- a/packages/jest-matchers/src/index.js
+++ b/packages/jest-matchers/src/index.js
@@ -25,7 +25,7 @@ const matchers = require('./matchers');
 const spyMatchers = require('./spyMatchers');
 const toThrowMatchers = require('./toThrowMatchers');
 
-const {stringify} = require('jest-matcher-utils');
+const matcherUtils = require('jest-matcher-utils');
 
 const GLOBAL_STATE = Symbol.for('$$jest-matchers-object');
 
@@ -68,6 +68,7 @@ const makeThrowingMatcher = (
       {dontThrow: () => throws = false},
       global[GLOBAL_STATE].state,
       {isNot},
+      {matcherUtils},
     );
     let result: ExpectationResult;
 
@@ -124,7 +125,7 @@ const _validateResult = result => {
       'Matcher functions should ' +
       'return an object in the following format:\n' +
       '  {message: string | function, pass: boolean}\n' +
-      `'${stringify(result)}' was returned`,
+      `'${matcherUtils.stringify(result)}' was returned`,
     );
   }
 };


### PR DESCRIPTION
**Summary**
Reference issue: #1977 
Exposes `jest-matcher-utils` under namespace within extend calls to help simplify expectation matchers.

**Test plan**
`npm run jest -- extend-test`