### PR TITLE
haste-map Allow directives in non docblock comments

### DIFF
--- a/packages/jest-haste-map/src/lib/__tests__/docblock-test.js
+++ b/packages/jest-haste-map/src/lib/__tests__/docblock-test.js
@@ -16,6 +16,26 @@ const docblock = require('../docblock');
 
 describe('docblock', () => {
 
+  it('extracts valid docblock with one asterisk', () => {
+    const code =
+      '/*' + os.EOL + ' * @providesModule foo' + os.EOL + '*/' + os.EOL +
+      'const x = foo;';
+    expect(docblock.extract(code)).toBe(
+      '/*' + os.EOL + ' * @providesModule foo' + os.EOL + '*/',
+    );
+  });
+
+  it('extracts valid docblock with line comment', () => {
+    const code =
+      '/**' + os.EOL + ' * @providesModule foo' + os.EOL +
+      '* // TODO: test' + os.EOL + '*/' + os.EOL +
+      'const x = foo;';
+    expect(docblock.extract(code)).toBe(
+      '/**' + os.EOL + ' * @providesModule foo' + os.EOL +
+      '* // TODO: test' + os.EOL + '*/',
+    );
+  });
+
   it('extracts valid docblock', () => {
     const code =
       '/**' + os.EOL + ' * @providesModule foo' + os.EOL + '*/' + os.EOL +
@@ -80,6 +100,17 @@ describe('docblock', () => {
       'providesModule': 'foo',
       'css': 'a b',
       'preserve-whitespace': '',
+    });
+  });
+
+  it('parses directives out of a docblock with line comments', () => {
+    const code =
+      '/**' + os.EOL + '' +
+      ' * @providesModule foo' + os.EOL + '' +
+      ' * // TODO: test' + os.EOL + '' +
+      ' */';
+    expect(docblock.parse(code)).toEqual({
+      'providesModule': 'foo',
     });
   });
 

--- a/packages/jest-haste-map/src/lib/__tests__/docblock-test.js
+++ b/packages/jest-haste-map/src/lib/__tests__/docblock-test.js
@@ -16,15 +16,6 @@ const docblock = require('../docblock');
 
 describe('docblock', () => {
 
-  it('extracts valid docblock with one asterisk', () => {
-    const code =
-      '/*' + os.EOL + ' * @providesModule foo' + os.EOL + '*/' + os.EOL +
-      'const x = foo;';
-    expect(docblock.extract(code)).toBe(
-      '/*' + os.EOL + ' * @providesModule foo' + os.EOL + '*/',
-    );
-  });
-
   it('extracts valid docblock with line comment', () => {
     const code =
       '/**' + os.EOL + ' * @providesModule foo' + os.EOL +
@@ -54,11 +45,13 @@ describe('docblock', () => {
     );
   });
 
-  it('returns nothing for no docblock', () => {
+  it('extracts from invalid docblock', () => {
     const code =
       '/*' + os.EOL + ' * @providesModule foo' + os.EOL + '*/' + os.EOL +
-      'const x = foo;' + os.EOL + '/**foo*/';
-    expect(docblock.extract(code)).toBe('');
+      'const x = foo;';
+    expect(docblock.extract(code)).toBe(
+      '/*' + os.EOL + ' * @providesModule foo' + os.EOL + '*/',
+    );
   });
 
   it('returns extract and parsedocblock', () => {

--- a/packages/jest-haste-map/src/lib/docblock.js
+++ b/packages/jest-haste-map/src/lib/docblock.js
@@ -11,13 +11,14 @@
 
 const commentEndRe = /\*\/$/;
 const commentStartRe = /^\/\*\*/;
-const docblockRe = /^\s*(\/\*\*(.|\r?\n)*?\*\/)/;
+const docblockRe = /^\s*(\/\*\*?(.|\r?\n)*?\*\/)/;
 const ltrimRe = /^\s*/;
 const multilineRe =
   /(?:^|\r?\n) *(@[^\r\n]*?) *\r?\n *([^@\r\n\s][^@\r\n]+?) *\r?\n/g;
 const propertyRe = /(?:^|\r?\n) *@(\S+) *([^\r\n]*)/g;
 const stringStartRe = /(\r?\n|^) *\*/g;
 const wsRe = /[\t ]+/g;
+const lineCommentRe = /\/\/*([^\r\n]*)/g;
 
 function extract(contents: string): string {
   const match = contents.match(docblockRe);
@@ -29,6 +30,7 @@ function parse(docblock: string): { [key: string]: string } {
     .replace(commentStartRe, '')
     .replace(commentEndRe, '')
     .replace(wsRe, ' ')
+    .replace(lineCommentRe, '')
     .replace(stringStartRe, '$1');
 
   // Normalize multi-line directives


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Allows to parse directives from multiline comments and strips line comments from docblocks / multiline comments.


Fixes #2004
Fixes #2005 