### PR TITLE
Prepend configuration name with `haste-map`

### DIFF
--- a/packages/jest-haste-map/src/index.js
+++ b/packages/jest-haste-map/src/index.js
@@ -199,7 +199,7 @@ class HasteMap {
 
     this._cachePath = HasteMap.getCacheFilePath(
       this._options.cacheDirectory,
-      this._options.name,
+      `haste-map-${this._options.name}`,
       VERSION,
       this._options.roots.join(':'),
       this._options.extensions.join(':'),


### PR DESCRIPTION
**Summary**

During debugging some FS problem on my machine I found that one of the files created looked a bit ugly with no sensible name. After some more debugging I found out that this was the haste-map generated by jest.

**Test plan**

Run jest and check if the generated file in the cache has been changed to a filename with `haste-map` prepended.

