### PR TITLE
Prepend custom snapshot serializers (instead of appending them)

### DIFF
--- a/integration_tests/__tests__/__snapshots__/snapshot-serializers-test.js.snap
+++ b/integration_tests/__tests__/__snapshots__/snapshot-serializers-test.js.snap
@@ -1,7 +1,20 @@
 exports[`Snapshot serializers renders snapshot 1`] = `
 Object {
+  "snapshot serializers works with default serializers 1": "
+<div
+  id="foo" />
+",
   "snapshot serializers works with first plugin 1": "foo: 1",
   "snapshot serializers works with nested serializable objects 1": "foo: bar: 2",
+  "snapshot serializers works with prepended plugins and default serializers 1": "
+<div
+  aProp={
+    Object {
+      "a": 6,
+    }
+  }
+  bProp={foo: 8} />
+",
   "snapshot serializers works with second plugin 1": "bar: 2",
 }
 `;

--- a/integration_tests/__tests__/snapshot-serializers-test.js
+++ b/integration_tests/__tests__/snapshot-serializers-test.js
@@ -20,8 +20,8 @@ const snapshotPath = path.resolve(snapshotsDir, 'snapshot-test.js.snap');
 const runAndAssert = () => {
   const result = runJest.json('snapshot-serializers');
   const json = result.json;
-  expect(json.numTotalTests).toBe(3);
-  expect(json.numPassedTests).toBe(3);
+  expect(json.numTotalTests).toBe(5);
+  expect(json.numPassedTests).toBe(5);
   expect(json.numFailedTests).toBe(0);
   expect(json.numPendingTests).toBe(0);
   expect(result.status).toBe(0);

--- a/integration_tests/snapshot-serializers/__tests__/snapshot-test.js
+++ b/integration_tests/snapshot-serializers/__tests__/snapshot-test.js
@@ -31,4 +31,29 @@ describe('snapshot serializers', () => {
     };
     expect(test).toMatchSnapshot();
   });
+
+  it('works with default serializers', () => {
+    const test = {
+      $$typeof: Symbol.for('react.test.json'),
+      type: 'div',
+      children: null,
+      props: {
+        id: 'foo',
+      },
+    };
+    expect(test).toMatchSnapshot();
+  });
+  
+  it('works with prepended plugins and default serializers', () => {
+    const test = {
+      $$typeof: Symbol.for('react.test.json'),
+      type: 'div',
+      children: null,
+      props: {
+        aProp: {a: 6},
+        bProp: {foo: 8},
+      },
+    };
+    expect(test).toMatchSnapshot();
+  });
 });

--- a/packages/jest-snapshot/src/__tests__/plugins-test.js
+++ b/packages/jest-snapshot/src/__tests__/plugins-test.js
@@ -20,7 +20,7 @@ const testPath = serializers => {
 
   const plugins = getPlugins();
   expect(plugins.length).toBe(serializers.length + 2);
-  plugins.splice(0, 2);
+  plugins.splice(-2, 2);
   expect(plugins).toEqual(expected);
 };
 

--- a/packages/jest-snapshot/src/plugins.js
+++ b/packages/jest-snapshot/src/plugins.js
@@ -18,6 +18,6 @@ let PLUGINS = [ReactElementPlugin, ReactTestComponentPlugin];
 
 exports.addPlugins = (plugins: Array<Path>) =>
   // $FlowFixMe
-  PLUGINS = PLUGINS.concat(plugins.map(p => require(p)));
+  PLUGINS = plugins.map(p => require(p)).concat(PLUGINS);
 
 exports.getPlugins = () => PLUGINS;

--- a/packages/jest-snapshot/src/plugins.js
+++ b/packages/jest-snapshot/src/plugins.js
@@ -18,6 +18,6 @@ let PLUGINS = [ReactElementPlugin, ReactTestComponentPlugin];
 
 exports.addPlugins = (plugins: Array<Path>) =>
   // $FlowFixMe
-  PLUGINS = plugins.map(p => require(p)).concat(PLUGINS);
+  PLUGINS = plugins.map(plugin => require(plugin)).concat(PLUGINS);
 
 exports.getPlugins = () => PLUGINS;


### PR DESCRIPTION
**Summary**

This PR applies a small change on #1842, prepending instead of appending custom serializers to the default ones provided by Jest. This allows those serializers to work not only on *parts* of the snapshot, but also on the snapshot *as a whole*, since they are given precedence with respect to the default ones.  This, in turn, allows React components to be rendered not only with the default `ReactTestComponent` plugin, but also with a custom HTML previewer (an idea introduced in #1862).

**Test plan**

Unit test and integration tests are included. Integration tests show that default and custom serializers work, both independently and in tandem.
