### PR TITLE
Properly set globals from within the vm context.

### DIFF
--- a/integration_tests/__tests__/global-test.js
+++ b/integration_tests/__tests__/global-test.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails oncall+jsinfra
+ */
+'use strict';
+
+test('globals are properly defined', () => {
+  expect(global.Object).toBe(Object);
+});

--- a/integration_tests/auto-clear-mocks/package.json
+++ b/integration_tests/auto-clear-mocks/package.json
@@ -1,0 +1,5 @@
+{
+  "jest": {
+    "testEnvironment": "node"
+  }
+}

--- a/packages/jest-runtime/src/transform.js
+++ b/packages/jest-runtime/src/transform.js
@@ -90,11 +90,11 @@ const writeCacheFile = (cachePath: Path, fileData: string) => {
   }
 };
 
-const wrap = content => '({"' +
-  EVAL_RESULT_VARIABLE +
+const wrap = content =>
+  '({"' + EVAL_RESULT_VARIABLE +
   '":function(module,exports,require,__dirname,__filename,global,jest){' +
-   content +
-   '\n}});';
+  content +
+  '\n}});';
 
 const readCacheFile = (filePath: Path, cachePath: Path): ?string => {
   if (!fileExists(cachePath)) {


### PR DESCRIPTION
**Summary**
There appears to be no other way to pull out built-ins from a vm context than actually evaluating them inside of the vm. This takes a bit of code from jsdom and adapts them to set the appropriate globals on the `global` object. This makes it so that `Object` equals `global.Object` inside of a vm context, with the right globals (not the ones from Jest's own context).

Fixes #1597

cc @domenic in case he knows whether there is another way.

**Test plan**
jest (+ will add an integration test)