### PR TITLE
.babelrc is now part of the cache key.

### DIFF
--- a/packages/babel-jest/src/index.js
+++ b/packages/babel-jest/src/index.js
@@ -14,7 +14,36 @@ import type {Config, Path} from 'types/Config';
 import type {TransformOptions} from 'types/Transform';
 
 const babel = require('babel-core');
+const crypto = require('crypto');
+const fs = require('fs');
 const jestPreset = require('babel-preset-jest');
+const path = require('path');
+
+const BABELRC_FILENAME = '.babelrc';
+
+const cache = Object.create(null);
+
+const getBabelRC = (filename, {useCache}) => {
+  const paths = [];
+  let directory = filename;
+  while (directory !== (directory = path.dirname(directory))) {
+    if (useCache && cache[directory]) {
+      break;
+    }
+
+    paths.push(directory);
+    const configFilePath = path.join(directory, BABELRC_FILENAME);
+    if (fs.existsSync(configFilePath)) {
+      cache[directory] = fs.readFileSync(configFilePath, 'utf8');
+      break;
+    }
+  }
+  paths.forEach(directoryPath => {
+    cache[directoryPath] = cache[directory];
+  });
+
+  return cache[directory] || '';
+};
 
 const createTransformer = (options: any) => {
   options = Object.assign({}, options, {
@@ -45,6 +74,21 @@ const createTransformer = (options: any) => {
         ).code;
       }
       return src;
+    },
+    getCacheKey(
+      fileData: string,
+      filename: Path,
+      configString: string,
+      {instrument, watch}: TransformOptions,
+    ): string {
+      return crypto.createHash('md5')
+        .update(fileData)
+        .update(configString)
+        // Don't use the in-memory cache in watch mode because the .babelrc
+        // file may be modified.
+        .update(getBabelRC(filename, {useCache: !watch}))
+        .update(instrument ? 'instrument' : '')
+        .digest('hex');
     },
   };
 };

--- a/packages/jest-file-exists/src/index.js
+++ b/packages/jest-file-exists/src/index.js
@@ -18,13 +18,4 @@ const fs = require('fs');
 module.exports = (
   filePath: Path,
   hasteFS: ?HasteFS,
-): boolean => {
-  if (hasteFS && hasteFS.exists(filePath)) {
-    return true;
-  }
-
-  try {
-    return fs.statSync(filePath).isFile();
-  } catch (e) {}
-  return false;
-};
+): boolean => (hasteFS && hasteFS.exists(filePath)) || fs.existsSync(filePath);

--- a/packages/jest-runtime/src/transform.js
+++ b/packages/jest-runtime/src/transform.js
@@ -66,15 +66,23 @@ const getCacheKey = (
       testRegex: config.testRegex,
     }));
   }
-  const confStr = configToJsonMap.get(config) || '';
+  const configString = configToJsonMap.get(config) || '';
   const transformer = getTransformer(filename, config);
 
   if (transformer && typeof transformer.getCacheKey === 'function') {
-    return transformer.getCacheKey(fileData, filename, confStr, {instrument});
+    return transformer.getCacheKey(
+      fileData,
+      filename,
+      configString,
+      {
+        instrument,
+        watch: config.watch,
+      },
+    );
   } else {
     return crypto.createHash('md5')
       .update(fileData)
-      .update(confStr)
+      .update(configString)
       .update(instrument ? 'instrument' : '')
       .digest('hex');
   }
@@ -267,7 +275,10 @@ const transformSource = (
   result = content;
 
   if (transform && shouldTransform(filename, config)) {
-    result = transform.process(result, filename, config, {instrument});
+    result = transform.process(result, filename, config, {
+      instrument,
+      watch: config.watch,
+    });
   }
 
   // That means that the transform has a custom instrumentation

--- a/types/Transform.js
+++ b/types/Transform.js
@@ -13,6 +13,7 @@ import type {Config, Path} from 'types/Config';
 
 export type TransformOptions = {|
   instrument: boolean,
+  watch: boolean,
 |};
 
 export type Transformer = {|


### PR DESCRIPTION
**Summary**
Long standing "bug" in Jest that was confusing to people and required them to run with `--no-cache` once.

**Test plan**

* Run jest
* Change `.babelrc` to remove all the transforms
* Run jest again; it should now throw whereas previously it would still pass because it used the cache files.

cc @taion @kentcdodds 