### PR TITLE
docs: fix incorrect link

### DIFF
--- a/docs/TutorialReact.md
+++ b/docs/TutorialReact.md
@@ -12,7 +12,7 @@ applications.
 
 ## Setup
 
-If you are just getting started with React, we recommend using [create-react-app](https://github.com/facebookincubator/create-react-app). It is ready to use and [ships with Jest](https://github.com/facebookincubator/create-react-app/tree/master/template#running-tests)!
+If you are just getting started with React, we recommend using [create-react-app](https://github.com/facebookincubator/create-react-app). It is ready to use and [ships with Jest](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md)!
 
 If you have an existing application you'll need to install a few packages to make everything work well together. We are using the `babel-jest` package and the `react` babel preset to transform our code inside of the test environment. Also see [babel integration](/jest/docs/getting-started.html#babel-integration).
 

--- a/docs/TutorialReact.md
+++ b/docs/TutorialReact.md
@@ -12,7 +12,7 @@ applications.
 
 ## Setup
 
-If you are just getting started with React, we recommend using [create-react-app](https://github.com/facebookincubator/create-react-app). It is ready to use and [ships with Jest](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md)!
+If you are just getting started with React, we recommend using [create-react-app](https://github.com/facebookincubator/create-react-app). It is ready to use and [ships with Jest](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#running-tests)!
 
 If you have an existing application you'll need to install a few packages to make everything work well together. We are using the `babel-jest` package and the `react` babel preset to transform our code inside of the test environment. Also see [babel integration](/jest/docs/getting-started.html#babel-integration).
 


### PR DESCRIPTION
**Summary**

I've updated a link for the `create-react-apps` docs which was outdated :smile: 

**Test plan**

1. Open the new link
2. Observe
