### PR TITLE
Yarn is now preinstalled on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,8 +5,6 @@ environment:
 
 install:
   - ps: Install-Product node $env:nodejs_version x64
-  - choco install yarn
-  - refreshenv
   - node --version
   - yarn --version
   - yarn install


### PR DESCRIPTION
We can delete the `choco install yarn` from `appveyor.yml` now, since Yarn is now preinstalled on AppVeyor :)