### PR TITLE
make 'message' optional when adding matchers

### DIFF
--- a/packages/jest-matchers/src/__tests__/__snapshots__/extend-test.js.snap
+++ b/packages/jest-matchers/src/__tests__/__snapshots__/extend-test.js.snap
@@ -1,1 +1,3 @@
 exports[`test is available globally 1`] = `"expected 15 to be divisible by 2"`;
+
+exports[`test is ok if there is no message specified 1`] = `"[31mNo message was specified for this matcher.[39m"`;

--- a/packages/jest-matchers/src/__tests__/extend-test.js
+++ b/packages/jest-matchers/src/__tests__/extend-test.js
@@ -47,3 +47,14 @@ it('exposes matcherUtils in context', () => {
 
   jestExpect()._shouldNotError();
 });
+
+it('is ok if there is no message specified', () => {
+  jestExpect.extend({
+    toFailWithoutMessage(expected) {
+      return {pass: false};
+    },
+  });
+
+  expect(() => jestExpect(true).toFailWithoutMessage())
+    .toThrowErrorMatchingSnapshot();
+});

--- a/packages/jest-matchers/src/index.js
+++ b/packages/jest-matchers/src/index.js
@@ -96,6 +96,12 @@ const makeThrowingMatcher = (
         message = message();
       }
 
+      if (!message) {
+        message = utils.RECEIVED_COLOR(
+          'No message was specified for this matcher.',
+        );
+      }
+
       const error = new JestAssertionError(message);
       // Remove this function from the stack trace frame.
       Error.captureStackTrace(error, throwingMatcher);
@@ -117,16 +123,19 @@ const _validateResult = result => {
   if (
     typeof result !== 'object' ||
     typeof result.pass !== 'boolean' ||
-    !(
-      typeof result.message === 'string' ||
-      typeof result.message === 'function'
+    (
+      result.message &&
+      (
+        typeof result.message !== 'string' &&
+        typeof result.message !== 'function'
+      )
     )
   ) {
     throw new Error(
       'Unexpected return from a matcher function.\n' +
       'Matcher functions should ' +
       'return an object in the following format:\n' +
-      '  {message: string | function, pass: boolean}\n' +
+      '  {message?: string | function, pass: boolean}\n' +
       `'${utils.stringify(result)}' was returned`,
     );
   }


### PR DESCRIPTION
this is not ideal, i would want 'message' to be required but that's blocking the sync with www