### PR TITLE
[docs] Add an argument pattern for toThrowError.

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -634,6 +634,11 @@ describe('drinking flavors', () => {
 
     // Test that we get a DisgustingFlavorError
     expect(drinkOctopus).toThrowError(DisgustingFlavorError);
+
+    // Test that we get a DisgustingFlavorError
+    // with error message 'yuck, octopus flavor'
+    expect(drinkOctopus).toThrowError(
+      DisgustingFlavorError, 'yuck, octopus flavor');
   });
 });
 ```


### PR DESCRIPTION
**Summary**
Add a `toThrowError(ErrorType, message)` demonstration.
Cause Jasmine has 4 argument patterns for `toThrowError`, and seems Jest use all of them.
So add the missed one to make less confusing.

**Test plan**
Its a doc. 