### PR TITLE
Add support for config key

### DIFF
--- a/packages/jest-config/src/loadFromPackage.js
+++ b/packages/jest-config/src/loadFromPackage.js
@@ -17,7 +17,7 @@ function loadFromPackage(filePath, argv) {
   return promisify(fs.access)(filePath, fs.R_OK).then(
     () => {
       const packageData = require(filePath);
-      const config = packageData.jest || {};
+      const config = packageData.jest || (packageData.config && packageData.config.jest) || {};
       const root = path.dirname(filePath);
       config.rootDir =
         config.rootDir ? path.resolve(root, config.rootDir) : root;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

This follows a convention a bunch of tools have chosen to have their configuration in the `package.json` under the `config` key:

```JSON
{
  "config": {
    "ghooks": {
      "commit-msg": "validate-commit-msg"
    },
    "commitizen": {
      "path": "./node_modules/cz-conventional-changelog"
    },
    "jest": {
      "automock": true
    }
  }
}
```

This PR adds support for Jest also having the config under that key, thus allowing for a cleaner `package.json`!

**Test Plan**

This PR was done via the Github web interface and is untested, opening a PR for discussion purposes only.