### PR TITLE
Set maxDepth to truncate extraordinarily deep object printing

### DIFF
--- a/integration_tests/__tests__/compare-dom-nodes-test.js
+++ b/integration_tests/__tests__/compare-dom-nodes-test.js
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails oncall+jsinfra
+ */
+'use strict';
+
+const runJest = require('../runJest');
+const skipOnWindows = require('skipOnWindows');
+
+skipOnWindows.suite();
+
+test('does not crash when expect involving a DOM node fails', () => {
+  const result = runJest('compare-dom-nodes');
+
+  expect(result.stderr).toContain('FAIL  __tests__/failed-assertion.js');
+});

--- a/integration_tests/compare-dom-nodes/__tests__/failed-assertion.js
+++ b/integration_tests/compare-dom-nodes/__tests__/failed-assertion.js
@@ -1,0 +1,3 @@
+test('a failed assertion comparing a DOM node does not crash Jest', () => {
+  expect(document.body).toBe(null);
+});

--- a/integration_tests/compare-dom-nodes/package.json
+++ b/integration_tests/compare-dom-nodes/package.json
@@ -1,0 +1,6 @@
+{
+  "jest": {
+    "automock": true,
+    "testEnvironment": "jsdom"
+  }
+}

--- a/packages/jest-matcher-utils/src/index.js
+++ b/packages/jest-matcher-utils/src/index.js
@@ -78,11 +78,13 @@ const getType = (value: any): ValueType => {
 const stringify = (object: any): string => {
   try {
     return prettyFormat(object, {
+      maxDepth: 10,
       min: true,
     });
   } catch (e) {
     return prettyFormat(object, {
       callToJSON: false,
+      maxDepth: 10,
       min: true,
     });
   }


### PR DESCRIPTION
This change is based on the feedback from @cpojer in https://github.com/thejameskyle/pretty-format/pull/47.

Closes #1772 