### PR TITLE
[bug] fix regression from jest 17.0.1 mutating options.extensions

### DIFF
--- a/packages/jest-resolve/src/index.js
+++ b/packages/jest-resolve/src/index.js
@@ -96,7 +96,7 @@ class Resolver {
     const moduleDirectory = this._options.moduleDirectories;
     const key = dirname + path.delimiter + moduleName;
     const defaultPlatform = this._options.defaultPlatform;
-    const extensions = this._options.extensions;
+    const extensions = this._options.extensions.slice();
     if (this._supportsNativePlatform()) {
       extensions.unshift('.' + NATIVE_PLATFORM + '.js');
     }


### PR DESCRIPTION
**Summary**

fixes extensions array growing with every module being resolved, this was introduced in 17.0.1 when concat was changed to unshift

**Test plan**

this is quite a simple regression fix, tested it on a project of mine and it fixes the regression causing the test to run extremely slowly due to the array becoming thousands in length

unfortunately I haven't found any tests that would cover the module resolution specifically, should a new test be created for this change?

