### PR TITLE
.toMatchSnapshot(?string)

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -628,9 +628,12 @@ describe('looking for a new house', () => {
 ```
 
 
-### `.toMatchSnapshot()`
+### `.toMatchSnapshot(?string)`
 
-This ensures that a React component matches the most recent snapshot. Check out [the React + Jest tutorial](https://facebook.github.io/jest/docs/tutorial-react.html) for more information on snapshot testing.
+This ensures that a value matches the most recent snapshot. Check out [the React + Jest tutorial](https://facebook.github.io/jest/docs/tutorial-react.html) for more information on snapshot testing.
+
+You can also specify an optional snapshot name. Otherwise, the name is inferred
+from the test.
 
 ### `.toThrow()`
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -635,6 +635,9 @@ This ensures that a value matches the most recent snapshot. Check out [the React
 You can also specify an optional snapshot name. Otherwise, the name is inferred
 from the test.
 
+*Note: While snapshot testing is most commonly used with React components, any
+serializable value can be used as a snapshot.*
+
 ### `.toThrow()`
 
 Use `.toThrow` to test that a function throws when it is called. For example, if we want to test that `drinkFlavor('octopus')` throws, because octopus flavor is too disgusting to drink, we could write:

--- a/integration_tests/__tests__/toMatchSnapshot-test.js
+++ b/integration_tests/__tests__/toMatchSnapshot-test.js
@@ -141,11 +141,11 @@ test('does not mark snapshots as obsolete in skipped tests', () => {
   }
 });
 
-test('does not accept arguments', () => {
-  const filename = 'does-not-accept-arguments-test.js';
+test('accepts custom snapshot name', () => {
+  const filename = 'accept-custom-snapshot-name-test.js';
   const template = makeTemplate(
-    `test('does not accept arguments', () => {
-      expect(true).toMatchSnapshot('foobar');
+    `test('accepts custom snapshot name', () => {
+      expect(true).toMatchSnapshot('custom-name');
     });
     `,
   );
@@ -154,8 +154,8 @@ test('does not accept arguments', () => {
     makeTests(TESTS_DIR, {[filename]: template()});
     const {stderr, status} = runJest(DIR, [filename]);
     expect(stderr).toMatch(
-      'Matcher does not accept any arguments.',
+      '1 snapshot written in 1 test suite.'
     );
-    expect(status).toBe(1);
+    expect(status).toBe(0);
   }
 });

--- a/packages/jest-snapshot/src/index.js
+++ b/packages/jest-snapshot/src/index.js
@@ -62,7 +62,7 @@ const initializeSnapshotState = (
 
 const getSnapshotState = () => snapshotState;
 
-const toMatchSnapshot = function(received: any, expected: void) {
+const toMatchSnapshot = function(received: any, testName?: string) {
   this.dontThrow && this.dontThrow();
 
   const {currentTestName, isNot, snapshotState} = this;
@@ -73,13 +73,11 @@ const toMatchSnapshot = function(received: any, expected: void) {
     );
   }
 
-  ensureNoExpected(expected, '.toMatchSnapshot');
-
   if (!snapshotState) {
     throw new Error('Jest: snapshot state must be initialized.');
   }
 
-  const result = snapshotState.match(currentTestName, received);
+  const result = snapshotState.match(testName || currentTestName, received);
   const {pass} = result;
 
   if (pass) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

In reference to #1392, changes `.toMatchSnapshot()` to `.toMatchSnapshot(?string)`.

This is primarily so that dynamic tests can have more meaningful snapshot names, compared to having the same name with a different numeric suffix.

See: c46d1b7.

**Test plan**

1. `npm run watch`
2. `npm run jest ./integration_tests/__tests__/toMatchSnapshot-test.js`

See: 8d05bec.
