### PR TITLE
Update transform and babel-jest docs

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -430,6 +430,8 @@ Examples of such compilers include [babel](https://babeljs.io/), [typescript](ht
 
 *Note: a transformer is only ran once per file unless the file has changed. During development of a transformer it can be useful to run Jest with `--no-cache` or to frequently [delete Jest's cache](/jest/docs/troubleshooting.html#caching-issues).*
 
+*Note: if you are using the `babel-jest` transformer and want to use an additional code preprocessor, keep in mind that when "transform" is overwritten in any way the `babel-jest` is not loaded automatically anymore. If you want to use it to compile JavaScript code it has to be explicitly defined. See [babel-jest plugin](https://github.com/facebook/jest/tree/master/packages/babel-jest#setup)*
+
 ### `transformIgnorePatterns` [array<string>]
 (default: `['/node_modules/']`)
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -424,7 +424,7 @@ Setting this value to `fake` allows the use of fake timers for functions such as
 ### `transform` [object<string, string>]
 (default: `undefined`)
 
-A map from regular expressions to paths to transformers. A transformer is a module that provides a synchronous function for transforming source files. For example, if you wanted to be able to use a new language feature in your modules or tests that isn't yet supported by node, you might plug in one of many compilers that compile a future version of JavaScript to a current one.
+A map from regular expressions to paths to transformers. A transformer is a module that provides a synchronous function for transforming source files. For example, if you wanted to be able to use a new language feature in your modules or tests that isn't yet supported by node, you might plug in one of many compilers that compile a future version of JavaScript to a current one. Example: see the [examples/typescript](/jest/examples/typescript/package.json#L16) example.
 
 Examples of such compilers include [babel](https://babeljs.io/), [typescript](http://www.typescriptlang.org/), and [async-to-gen](http://github.com/leebyron/async-to-gen#jest).
 

--- a/packages/babel-jest/README.md
+++ b/packages/babel-jest/README.md
@@ -11,3 +11,15 @@ npm install --save-dev babel-jest
 ```
 
 If you would like to write your own preprocessor, uninstall and delete babel-jest and set the [config.transform](http://facebook.github.io/jest/docs/configuration.html#transform-object-string-string) option to your preprocessor.
+
+## Setup
+
+*Note: this step is only required if you are using `babel-jest` with additional code preprocessors.*
+
+To explicitly define `babel-jest` as a transformer for your JavaScript code, map *.js* files to the `babel-jest` module.
+
+```json
+"transform": {
+  "^.+\\.js$": "<rootDir>/node_modules/babel-jest"
+},
+```


### PR DESCRIPTION
**Summary**

Clarify that when "transform" is overwritten, the babel-jest is not loaded automatically anymore and should be explicitly defined in the config.

Related to: #2096 