### PR TITLE
Fix ES6 Map comparison in `jest-diff` #2091

### DIFF
--- a/packages/jest-diff/src/__tests__/diff-test.js
+++ b/packages/jest-diff/src/__tests__/diff-test.js
@@ -63,6 +63,15 @@ describe('no visual difference', () => {
       },
     );
   });
+
+  test("Map key order should not matter", () => {
+    const arg1 = new Map([[1, 'foo'], [2, 'bar']]);
+    const arg2 = new Map([[2, 'bar'], [1, 'foo']]);
+
+    expect(stripAnsi(diff(arg1, arg2))).toBe(
+        'Compared values have no visual difference.',
+    );
+  });
 });
 
 test('oneline strings', () => {

--- a/packages/jest-diff/src/__tests__/diff-test.js
+++ b/packages/jest-diff/src/__tests__/diff-test.js
@@ -80,7 +80,7 @@ describe('no visual difference', () => {
     expect(stripAnsi(diff(arg1, arg2))).toBe(
       'Compared values have no visual difference.',
     );
-  })
+  });
 });
 
 test('oneline strings', () => {

--- a/packages/jest-diff/src/__tests__/diff-test.js
+++ b/packages/jest-diff/src/__tests__/diff-test.js
@@ -69,7 +69,7 @@ describe('no visual difference', () => {
     const arg2 = new Map([[2, 'bar'], [1, 'foo']]);
 
     expect(stripAnsi(diff(arg1, arg2))).toBe(
-        'Compared values have no visual difference.',
+      'Compared values have no visual difference.',
     );
   });
 });

--- a/packages/jest-diff/src/__tests__/diff-test.js
+++ b/packages/jest-diff/src/__tests__/diff-test.js
@@ -64,7 +64,7 @@ describe('no visual difference', () => {
     );
   });
 
-  test("Map key order should not matter", () => {
+  test('Map key order should not matter', () => {
     const arg1 = new Map([[1, 'foo'], [2, 'bar']]);
     const arg2 = new Map([[2, 'bar'], [1, 'foo']]);
 

--- a/packages/jest-diff/src/__tests__/diff-test.js
+++ b/packages/jest-diff/src/__tests__/diff-test.js
@@ -64,7 +64,7 @@ describe('no visual difference', () => {
     );
   });
 
-  test('Map key order should not matter', () => {
+  test('Map key order should be irrelevant', () => {
     const arg1 = new Map([[1, 'foo'], [2, 'bar']]);
     const arg2 = new Map([[2, 'bar'], [1, 'foo']]);
 
@@ -72,6 +72,15 @@ describe('no visual difference', () => {
       'Compared values have no visual difference.',
     );
   });
+
+  test('Set value order should be irrelevant', () => {
+    const arg1 = new Set([1, 2]);
+    const arg2 = new Set([2, 1]);
+
+    expect(stripAnsi(diff(arg1, arg2))).toBe(
+      'Compared values have no visual difference.',
+    );
+  })
 });
 
 test('oneline strings', () => {

--- a/packages/jest-diff/src/index.js
+++ b/packages/jest-diff/src/index.js
@@ -62,13 +62,19 @@ function diff(a: any, b: any, options: ?DiffOptions): ?string {
       return null;
     case 'map':
       return compareObjects(sortMap(a), sortMap(b), options);
+    case 'set':
+      return compareObjects(sortSet(a), sortSet(b), options);
     default:
       return compareObjects(a, b, options);
   }
 }
 
-function sortMap(map) {
+function sortMap(map: Map): Map {
   return new Map([...map.entries()].sort());
+}
+
+function sortSet(set: Set): Set {
+  return new Set([...set.values()].sort());
 }
 
 function compareObjects(a: Object, b: Object, options: ?DiffOptions) {

--- a/packages/jest-diff/src/index.js
+++ b/packages/jest-diff/src/index.js
@@ -69,11 +69,11 @@ function diff(a: any, b: any, options: ?DiffOptions): ?string {
   }
 }
 
-function sortMap(map: Map): Map {
+function sortMap(map) {
   return new Map([...map.entries()].sort());
 }
 
-function sortSet(set: Set): Set {
+function sortSet(set) {
   return new Set([...set.values()].sort());
 }
 

--- a/packages/jest-diff/src/index.js
+++ b/packages/jest-diff/src/index.js
@@ -68,36 +68,36 @@ function diff(a: any, b: any, options: ?DiffOptions): ?string {
 }
 
 function sortMap(map) {
-    return new Map([...map.entries()].sort());
+  return new Map([...map.entries()].sort());
 }
 
 function compareObjects(a: Object, b: Object, options: ?DiffOptions) {
-    let diffMessage;
-    let hasThrown = false;
+  let diffMessage;
+  let hasThrown = false;
 
-    try {
-        diffMessage = diffStrings(
-            prettyFormat(a, FORMAT_OPTIONS),
-            prettyFormat(b, FORMAT_OPTIONS),
-            options,
-        );
-    } catch (e) {
-        hasThrown = true;
-    }
+  try {
+    diffMessage = diffStrings(
+      prettyFormat(a, FORMAT_OPTIONS),
+      prettyFormat(b, FORMAT_OPTIONS),
+      options,
+    );
+  } catch (e) {
+      hasThrown = true;
+  }
 
-    // If the comparison yields no results, compare again but this time
-    // without calling `toJSON`. It's also possible that toJSON might throw.
-    if (!diffMessage || diffMessage === NO_DIFF_MESSAGE) {
-        diffMessage = diffStrings(
-            prettyFormat(a, FALLBACK_FORMAT_OPTIONS),
-            prettyFormat(b, FALLBACK_FORMAT_OPTIONS),
-            options,
-        );
-        if (diffMessage !== NO_DIFF_MESSAGE && !hasThrown) {
-            diffMessage = SIMILAR_MESSAGE + '\n\n' + diffMessage;
-        }
-    }
-    return diffMessage;
+  // If the comparison yields no results, compare again but this time
+  // without calling `toJSON`. It's also possible that toJSON might throw.
+  if (!diffMessage || diffMessage === NO_DIFF_MESSAGE) {
+      diffMessage = diffStrings(
+          prettyFormat(a, FALLBACK_FORMAT_OPTIONS),
+          prettyFormat(b, FALLBACK_FORMAT_OPTIONS),
+          options,
+      );
+      if (diffMessage !== NO_DIFF_MESSAGE && !hasThrown) {
+          diffMessage = SIMILAR_MESSAGE + '\n\n' + diffMessage;
+      }
+  }
+  return diffMessage;
 }
 
 module.exports = diff;

--- a/packages/jest-diff/src/index.js
+++ b/packages/jest-diff/src/index.js
@@ -70,11 +70,11 @@ function diff(a: any, b: any, options: ?DiffOptions): ?string {
 }
 
 function sortMap(map) {
-  return new Map([...map.entries()].sort());
+  return new Map(Array.from(map.entries()).sort());
 }
 
 function sortSet(set) {
-  return new Set([...set.values()].sort());
+  return new Set(Array.from(set.values()).sort());
 }
 
 function compareObjects(a: Object, b: Object, options: ?DiffOptions) {

--- a/packages/jest-diff/src/index.js
+++ b/packages/jest-diff/src/index.js
@@ -82,21 +82,22 @@ function compareObjects(a: Object, b: Object, options: ?DiffOptions) {
       options,
     );
   } catch (e) {
-      hasThrown = true;
+    hasThrown = true;
   }
 
   // If the comparison yields no results, compare again but this time
   // without calling `toJSON`. It's also possible that toJSON might throw.
   if (!diffMessage || diffMessage === NO_DIFF_MESSAGE) {
-      diffMessage = diffStrings(
-          prettyFormat(a, FALLBACK_FORMAT_OPTIONS),
-          prettyFormat(b, FALLBACK_FORMAT_OPTIONS),
-          options,
-      );
-      if (diffMessage !== NO_DIFF_MESSAGE && !hasThrown) {
-          diffMessage = SIMILAR_MESSAGE + '\n\n' + diffMessage;
-      }
+    diffMessage = diffStrings(
+      prettyFormat(a, FALLBACK_FORMAT_OPTIONS),
+      prettyFormat(b, FALLBACK_FORMAT_OPTIONS),
+      options,
+    );
+    if (diffMessage !== NO_DIFF_MESSAGE && !hasThrown) {
+      diffMessage = SIMILAR_MESSAGE + '\n\n' + diffMessage;
+    }
   }
+
   return diffMessage;
 }
 

--- a/packages/jest-diff/src/index.js
+++ b/packages/jest-diff/src/index.js
@@ -60,34 +60,44 @@ function diff(a: any, b: any, options: ?DiffOptions): ?string {
     case 'number':
     case 'boolean':
       return null;
+    case 'map':
+      return compareObjects(sortMap(a), sortMap(b), options);
     default:
-      let diffMessage;
-      let hasThrown = false;
+      return compareObjects(a, b, options);
+  }
+}
 
-      try {
+function sortMap(map) {
+    return new Map([...map.entries()].sort());
+}
+
+function compareObjects(a: Object, b: Object, options: ?DiffOptions) {
+    let diffMessage;
+    let hasThrown = false;
+
+    try {
         diffMessage = diffStrings(
-          prettyFormat(a, FORMAT_OPTIONS),
-          prettyFormat(b, FORMAT_OPTIONS),
-          options,
+            prettyFormat(a, FORMAT_OPTIONS),
+            prettyFormat(b, FORMAT_OPTIONS),
+            options,
         );
-      } catch (e) {
+    } catch (e) {
         hasThrown = true;
-      }
+    }
 
-      // If the comparison yields no results, compare again but this time
-      // without calling `toJSON`. It's also possible that toJSON might throw.
-      if (!diffMessage || diffMessage === NO_DIFF_MESSAGE) {
+    // If the comparison yields no results, compare again but this time
+    // without calling `toJSON`. It's also possible that toJSON might throw.
+    if (!diffMessage || diffMessage === NO_DIFF_MESSAGE) {
         diffMessage = diffStrings(
-          prettyFormat(a, FALLBACK_FORMAT_OPTIONS),
-          prettyFormat(b, FALLBACK_FORMAT_OPTIONS),
-          options,
+            prettyFormat(a, FALLBACK_FORMAT_OPTIONS),
+            prettyFormat(b, FALLBACK_FORMAT_OPTIONS),
+            options,
         );
         if (diffMessage !== NO_DIFF_MESSAGE && !hasThrown) {
-          diffMessage = SIMILAR_MESSAGE + '\n\n' + diffMessage;
+            diffMessage = SIMILAR_MESSAGE + '\n\n' + diffMessage;
         }
-      }
-      return diffMessage;
-  }
+    }
+    return diffMessage;
 }
 
 module.exports = diff;

--- a/packages/jest-matcher-utils/package.json
+++ b/packages/jest-matcher-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jest-matcher-utils",
   "description": "A set of utility functions for jest-matchers and related packages",
-  "version": "17.0.2",
+  "version": "17.0.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/facebook/jest.git"

--- a/packages/jest-matcher-utils/package.json
+++ b/packages/jest-matcher-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jest-matcher-utils",
   "description": "A set of utility functions for jest-matchers and related packages",
-  "version": "17.0.1",
+  "version": "17.0.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/facebook/jest.git"

--- a/packages/jest-matcher-utils/src/__tests__/index-test.js
+++ b/packages/jest-matcher-utils/src/__tests__/index-test.js
@@ -84,4 +84,5 @@ describe('.getType()', () => {
   test('boolean', () => expect(getType(true)).toBe('boolean'));
   test('symbol', () => expect(getType(Symbol.for('a'))).toBe('symbol'));
   test('regexp', () => expect(getType(/abc/)).toBe('regexp'));
+  test('map', () => expect(getType(new Map())).toBe('map'));
 });

--- a/packages/jest-matcher-utils/src/index.js
+++ b/packages/jest-matcher-utils/src/index.js
@@ -21,6 +21,7 @@ export type ValueType =
   | 'number'
   | 'object'
   | 'regexp'
+  | 'map'
   | 'string'
   | 'symbol'
   | 'undefined';

--- a/packages/jest-matcher-utils/src/index.js
+++ b/packages/jest-matcher-utils/src/index.js
@@ -22,6 +22,7 @@ export type ValueType =
   | 'object'
   | 'regexp'
   | 'map'
+  | 'set'
   | 'string'
   | 'symbol'
   | 'undefined';
@@ -68,6 +69,8 @@ const getType = (value: any): ValueType => {
       return 'regexp';
     } else if (value.constructor === Map) {
       return 'map';
+    } else if (value.constructor === Set) {
+      return 'set';
     }
     return 'object';
   // $FlowFixMe https://github.com/facebook/flow/issues/1015

--- a/packages/jest-matcher-utils/src/index.js
+++ b/packages/jest-matcher-utils/src/index.js
@@ -65,6 +65,8 @@ const getType = (value: any): ValueType => {
   } else if (typeof value === 'object') {
     if (value.constructor === RegExp) {
       return 'regexp';
+    } else if (value.constructor === Map) {
+      return 'map';
     }
     return 'object';
   // $FlowFixMe https://github.com/facebook/flow/issues/1015

--- a/packages/jest-matchers/src/__tests__/__snapshots__/matchers-test.js.snap
+++ b/packages/jest-matchers/src/__tests__/__snapshots__/matchers-test.js.snap
@@ -1634,16 +1634,6 @@ Not to contain value:
 "
 `;
 
-exports[`.toContain() '{Symbol(Symbol.iterator): [Function anonymous]}' contains '1' 1`] = `
-"[2mexpect([22m[31mobject[39m[2m).not.toContain([22m[32mvalue[39m[2m)[22m
-
-Expected object:
-  [31m{Symbol(Symbol.iterator): [Function anonymous]}[39m
-Not to contain value:
-  [32m1[39m
-"
-`;
-
 exports[`.toContain() 'Set {"abc", "def"}' contains '"abc"' 1`] = `
 "[2mexpect([22m[31mset[39m[2m).not.toContain([22m[32mvalue[39m[2m)[22m
 
@@ -1745,16 +1735,6 @@ exports[`.toContainEqual() '{Symbol(Symbol.iterator): [Function [Symbol.iterator
 
 Expected object:
   [31m{Symbol(Symbol.iterator): [Function [Symbol.iterator]]}[39m
-Not to contain a value equal to:
-  [32m1[39m
-"
-`;
-
-exports[`.toContainEqual() '{Symbol(Symbol.iterator): [Function anonymous]}' contains a value equal to '1' 1`] = `
-"[2mexpect([22m[31mobject[39m[2m).not.toContainEqual([22m[32mvalue[39m[2m)[22m
-
-Expected object:
-  [31m{Symbol(Symbol.iterator): [Function anonymous]}[39m
 Not to contain a value equal to:
   [32m1[39m
 "

--- a/packages/jest-matchers/src/__tests__/__snapshots__/matchers-test.js.snap
+++ b/packages/jest-matchers/src/__tests__/__snapshots__/matchers-test.js.snap
@@ -1635,9 +1635,9 @@ Not to contain value:
 `;
 
 exports[`.toContain() 'Set {"abc", "def"}' contains '"abc"' 1`] = `
-"[2mexpect([22m[31mobject[39m[2m).not.toContain([22m[32mvalue[39m[2m)[22m
+"[2mexpect([22m[31mset[39m[2m).not.toContain([22m[32mvalue[39m[2m)[22m
 
-Expected object:
+Expected set:
   [31mSet {\"abc\", \"def\"}[39m
 Not to contain value:
   [32m\"abc\"[39m
@@ -1741,9 +1741,9 @@ Not to contain a value equal to:
 `;
 
 exports[`.toContainEqual() 'Set {1, 2, 3, 4}' contains a value equal to '1' 1`] = `
-"[2mexpect([22m[31mobject[39m[2m).not.toContainEqual([22m[32mvalue[39m[2m)[22m
+"[2mexpect([22m[31mset[39m[2m).not.toContainEqual([22m[32mvalue[39m[2m)[22m
 
-Expected object:
+Expected set:
   [31mSet {1, 2, 3, 4}[39m
 Not to contain a value equal to:
   [32m1[39m

--- a/packages/jest-matchers/src/__tests__/__snapshots__/matchers-test.js.snap
+++ b/packages/jest-matchers/src/__tests__/__snapshots__/matchers-test.js.snap
@@ -1634,6 +1634,16 @@ Not to contain value:
 "
 `;
 
+exports[`.toContain() '{Symbol(Symbol.iterator): [Function anonymous]}' contains '1' 1`] = `
+"[2mexpect([22m[31mobject[39m[2m).not.toContain([22m[32mvalue[39m[2m)[22m
+
+Expected object:
+  [31m{Symbol(Symbol.iterator): [Function anonymous]}[39m
+Not to contain value:
+  [32m1[39m
+"
+`;
+
 exports[`.toContain() 'Set {"abc", "def"}' contains '"abc"' 1`] = `
 "[2mexpect([22m[31mset[39m[2m).not.toContain([22m[32mvalue[39m[2m)[22m
 
@@ -1735,6 +1745,16 @@ exports[`.toContainEqual() '{Symbol(Symbol.iterator): [Function [Symbol.iterator
 
 Expected object:
   [31m{Symbol(Symbol.iterator): [Function [Symbol.iterator]]}[39m
+Not to contain a value equal to:
+  [32m1[39m
+"
+`;
+
+exports[`.toContainEqual() '{Symbol(Symbol.iterator): [Function anonymous]}' contains a value equal to '1' 1`] = `
+"[2mexpect([22m[31mobject[39m[2m).not.toContainEqual([22m[32mvalue[39m[2m)[22m
+
+Expected object:
+  [31m{Symbol(Symbol.iterator): [Function anonymous]}[39m
 Not to contain a value equal to:
   [32m1[39m
 "

--- a/packages/jest-matchers/src/__tests__/__snapshots__/spyMatchers-test.js.snap
+++ b/packages/jest-matchers/src/__tests__/__snapshots__/spyMatchers-test.js.snap
@@ -410,7 +410,7 @@ exports[`toHaveBeenCalledTimes accepts only numbers 5`] = `
 
 Expected value must be a number.
 Got:
-  object: [32mMap {}[39m"
+  map: [32mMap {}[39m"
 `;
 
 exports[`toHaveBeenCalledTimes accepts only numbers 6`] = `


### PR DESCRIPTION
**Summary**

#2091 Fix ES6 Map comparison in `jest-diff`

Solution:
1. Recognise Map as map in `getType` method.
2. In case if it is map, sort map keys
3. Use the same comparator which is being used for object comparison