### PR TITLE
Always recreate mocks in FakeTimers.useFakeTimers()

### DIFF
--- a/integration_tests/__tests__/timer_after_resetAllMocks-test.js
+++ b/integration_tests/__tests__/timer_after_resetAllMocks-test.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails oncall+jsinfra
+ */
+'use strict';
+
+const runJest = require('../runJest');
+const skipOnWindows = require('skipOnWindows');
+
+skipOnWindows.suite();
+
+test('run timers after resetAllMocks test', () => {
+  const result = runJest('timer_after_resetAllMocks');
+  expect(result.status).toBe(0);
+});

--- a/integration_tests/timer_after_resetAllMocks/index.js
+++ b/integration_tests/timer_after_resetAllMocks/index.js
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+module.exports = () => {};

--- a/integration_tests/timer_after_resetAllMocks/package.json
+++ b/integration_tests/timer_after_resetAllMocks/package.json
@@ -1,0 +1,6 @@
+{
+  "jest": {
+    "testEnvironment": "node",
+    "resetMocks": false
+  }
+}

--- a/integration_tests/timer_after_resetAllMocks/timer_and_mock.test.js
+++ b/integration_tests/timer_after_resetAllMocks/timer_and_mock.test.js
@@ -1,0 +1,18 @@
+describe('timers', () => {
+  it('should work before calling resetAllMocks', () => {
+    jest.useFakeTimers();
+    const f = jest.fn();
+    setImmediate(() => f());
+    jest.runAllImmediates();
+    expect(f.mock.calls.length).toBe(1);
+  });
+
+  it('should not break after calling resetAllMocks', () => {
+    jest.resetAllMocks();
+    jest.useFakeTimers();
+    const f = jest.fn();
+    setImmediate(() => f());
+    jest.runAllImmediates();
+    expect(f.mock.calls.length).toBe(1);
+  });
+});

--- a/packages/jest-util/src/FakeTimers.js
+++ b/packages/jest-util/src/FakeTimers.js
@@ -35,7 +35,7 @@ type TimerAPI = {
   clearImmediate(timeoutId?: any): void,
   clearInterval(intervalId?: number): void,
   clearTimeout(timeoutId?: any): void,
-  nextTick?: (callback: Callback) => void,
+  nextTick: (callback: Callback) => void,
   setImmediate(callback: any, ms?: number, ...args: Array<any>): number,
   setInterval(callback: any, ms?: number, ...args: Array<any>): number,
   setTimeout(callback: any, ms?: number, ...args: Array<any>): number,
@@ -44,7 +44,6 @@ type TimerAPI = {
 const MS_IN_A_YEAR = 31536000000;
 
 class FakeTimers {
-
   _cancelledImmediates: {[key: TimerID]: boolean};
   _cancelledTicks: {[key: TimerID]: boolean};
   _config: Config;
@@ -78,17 +77,11 @@ class FakeTimers {
       clearImmediate: global.clearImmediate,
       clearInterval: global.clearInterval,
       clearTimeout: global.clearTimeout,
+      nextTick: global.process && global.process.nextTick,
       setImmediate: global.setImmediate,
       setInterval: global.setInterval,
       setTimeout: global.setTimeout,
     };
-
-    // If there's a process.nextTick on the global, mock it out
-    // (only applicable to node/node-emulating environments)
-    if (typeof global.process === 'object'
-      && typeof global.process.nextTick === 'function') {
-      this._timerAPIs.nextTick = global.process.nextTick;
-    }
 
     this.reset();
     this._createMocks();
@@ -261,18 +254,13 @@ class FakeTimers {
   }
 
   runWithRealTimers(cb: Callback) {
-    const hasNextTick =
-      typeof this._global.process === 'object'
-      && typeof this._global.process.nextTick === 'function';
-
     const prevClearImmediate = this._global.clearImmediate;
     const prevClearInterval = this._global.clearInterval;
     const prevClearTimeout = this._global.clearTimeout;
+    const prevNextTick = this._global.process.nextTick;
     const prevSetImmediate = this._global.setImmediate;
     const prevSetInterval = this._global.setInterval;
     const prevSetTimeout = this._global.setTimeout;
-
-    const prevNextTick = hasNextTick ? this._global.process.nextTick : null;
 
     this.useRealTimers();
 
@@ -288,12 +276,10 @@ class FakeTimers {
     this._global.clearImmediate = prevClearImmediate;
     this._global.clearInterval = prevClearInterval;
     this._global.clearTimeout = prevClearTimeout;
+    this._global.process.nextTick = prevNextTick;
     this._global.setImmediate = prevSetImmediate;
     this._global.setInterval = prevSetInterval;
     this._global.setTimeout = prevSetTimeout;
-    if (hasNextTick) {
-      this._global.process.nextTick = prevNextTick;
-    }
 
     if (errThrown) {
       throw cbErr;
@@ -301,37 +287,25 @@ class FakeTimers {
   }
 
   useRealTimers() {
-    const hasNextTick =
-      typeof this._global.process === 'object'
-      && typeof this._global.process.nextTick === 'function';
-
     this._global.clearImmediate = this._timerAPIs.clearImmediate;
     this._global.clearInterval = this._timerAPIs.clearInterval;
     this._global.clearTimeout = this._timerAPIs.clearTimeout;
+    this._global.process.nextTick = this._timerAPIs.nextTick;
     this._global.setImmediate = this._timerAPIs.setImmediate;
     this._global.setInterval = this._timerAPIs.setInterval;
     this._global.setTimeout = this._timerAPIs.setTimeout;
-    if (hasNextTick) {
-      this._global.process.nextTick = this._timerAPIs.nextTick;
-    }
   }
 
   useFakeTimers() {
-    const hasNextTick =
-      typeof this._global.process === 'object'
-      && typeof this._global.process.nextTick === 'function';
-
     this._createMocks();
 
     this._global.clearImmediate = this._fakeTimerAPIs.clearImmediate;
     this._global.clearInterval = this._fakeTimerAPIs.clearInterval;
     this._global.clearTimeout = this._fakeTimerAPIs.clearTimeout;
+    this._global.process.nextTick = this._fakeTimerAPIs.nextTick;
     this._global.setImmediate = this._fakeTimerAPIs.setImmediate;
     this._global.setInterval = this._fakeTimerAPIs.setInterval;
     this._global.setTimeout = this._fakeTimerAPIs.setTimeout;
-    if (hasNextTick) {
-      this._global.process.nextTick = this._fakeTimerAPIs.nextTick;
-    }
   }
 
   _checkFakeTimers() {
@@ -355,16 +329,11 @@ class FakeTimers {
       clearImmediate: fn(this._fakeClearImmediate.bind(this)),
       clearInterval: fn(this._fakeClearTimer.bind(this)),
       clearTimeout: fn(this._fakeClearTimer.bind(this)),
+      nextTick: fn(this._fakeNextTick.bind(this)),
       setImmediate: fn(this._fakeSetImmediate.bind(this)),
       setInterval: fn(this._fakeSetInterval.bind(this)),
       setTimeout: fn(this._fakeSetTimeout.bind(this)),
     };
-
-    // If there's a process.nextTick on the global, mock it out
-    // (only applicable to node/node-emulating environments)
-    if (this._timerAPIs.nextTick) {
-      this._fakeTimerAPIs.nextTick = fn(this._fakeNextTick.bind(this));
-    }
   }
 
   _fakeClearTimer(uuid: TimerID) {
@@ -395,7 +364,7 @@ class FakeTimers {
     });
 
     const cancelledTicks = this._cancelledTicks;
-    this._timerAPIs.nextTick && this._timerAPIs.nextTick(() => {
+    this._timerAPIs.nextTick(() => {
       if (this._blocked) {return;}
       if (!cancelledTicks.hasOwnProperty(uuid)) {
         // Callback may throw, so update the map prior calling.

--- a/packages/jest-util/src/__tests__/FakeTimers-test.js
+++ b/packages/jest-util/src/__tests__/FakeTimers-test.js
@@ -25,34 +25,34 @@ describe('FakeTimers', () => {
   describe('construction', () => {
     /* eslint-disable no-new */
     it('installs setTimeout mock', () => {
-      const global = {};
+      const global = {process};
       const timers = new FakeTimers(global, moduleMocker);
       timers.useFakeTimers();
       expect(global.setTimeout).not.toBe(undefined);
     });
 
     it('installs clearTimeout mock', () => {
-      const global = {};
+      const global = {process};
       const timers = new FakeTimers(global, moduleMocker);
       timers.useFakeTimers();
       expect(global.clearTimeout).not.toBe(undefined);
     });
 
     it('installs setInterval mock', () => {
-      const global = {};
+      const global = {process};
       const timers = new FakeTimers(global, moduleMocker);
       timers.useFakeTimers();
       expect(global.setInterval).not.toBe(undefined);
     });
 
     it('installs clearInterval mock', () => {
-      const global = {};
+      const global = {process};
       const timers = new FakeTimers(global, moduleMocker);
       timers.useFakeTimers();
       expect(global.clearInterval).not.toBe(undefined);
     });
 
-    it('mocks process.nextTick if on exists on global', () => {
+    it('mocks process.nextTick if it exists on global', () => {
       const origNextTick = () => {};
       const global = {
         process: {
@@ -64,16 +64,10 @@ describe('FakeTimers', () => {
       expect(global.process.nextTick).not.toBe(origNextTick);
     });
 
-    it('doesn\'t mock process.nextTick if real impl isnt present', () => {
-      const global = {};
-      const timers = new FakeTimers(global, moduleMocker);
-      timers.useFakeTimers();
-      expect(global.process).toBe(undefined);
-    });
-
     it('mocks setImmediate if it exists on global', () => {
       const origSetImmediate = () => {};
       const global = {
+        process,
         setImmediate: origSetImmediate,
       };
       const timers = new FakeTimers(global, moduleMocker);
@@ -86,6 +80,7 @@ describe('FakeTimers', () => {
       const origClearImmediate = () => {};
       const global = {
         clearImmediate: origClearImmediate,
+        process,
         setImmediate: origSetImmediate,
       };
       const timers = new FakeTimers(global, moduleMocker);
@@ -190,6 +185,7 @@ describe('FakeTimers', () => {
       const nativeSetImmediate = jest.genMockFn();
 
       const global = {
+        process,
         setImmediate: nativeSetImmediate,
       };
 
@@ -235,6 +231,7 @@ describe('FakeTimers', () => {
       const nativeSetImmediate = jest.genMockFn();
 
       const global = {
+        process,
         setImmediate: nativeSetImmediate,
       };
 
@@ -257,6 +254,7 @@ describe('FakeTimers', () => {
       const nativeSetImmediate = jest.genMockFn();
 
       const global = {
+        process,
         setImmediate: nativeSetImmediate,
       };
 
@@ -301,7 +299,7 @@ describe('FakeTimers', () => {
 
   describe('runAllTimers', () => {
     it('runs all timers in order', () => {
-      const global = {};
+      const global = {process};
       const timers = new FakeTimers(global, moduleMocker);
       timers.useFakeTimers();
 
@@ -347,6 +345,7 @@ describe('FakeTimers', () => {
     it('does nothing when no timers have been scheduled', () => {
       const nativeSetTimeout = jest.genMockFn();
       const global = {
+        process,
         setTimeout: nativeSetTimeout,
       };
 
@@ -356,7 +355,7 @@ describe('FakeTimers', () => {
     });
 
     it('only runs a setTimeout callback once (ever)', () => {
-      const global = {};
+      const global = {process};
       const timers = new FakeTimers(global, moduleMocker);
       timers.useFakeTimers();
 
@@ -372,7 +371,7 @@ describe('FakeTimers', () => {
     });
 
     it('runs callbacks with arguments after the interval', () => {
-      const global = {};
+      const global = {process};
       const timers = new FakeTimers(global, moduleMocker);
       timers.useFakeTimers();
 
@@ -389,6 +388,7 @@ describe('FakeTimers', () => {
       const nativeSetTimeout = jest.genMockFn();
 
       const global = {
+        process,
         setTimeout: nativeSetTimeout,
       };
 
@@ -404,7 +404,7 @@ describe('FakeTimers', () => {
     });
 
     it('throws before allowing infinite recursion', () => {
-      const global = {};
+      const global = {process};
       const timers = new FakeTimers(global, moduleMocker, null, 100);
       timers.useFakeTimers();
 
@@ -423,7 +423,7 @@ describe('FakeTimers', () => {
 
   describe('runTimersToTime', () => {
     it('runs timers in order', () => {
-      const global = {};
+      const global = {process};
       const timers = new FakeTimers(global, moduleMocker);
       timers.useFakeTimers();
 
@@ -470,7 +470,7 @@ describe('FakeTimers', () => {
     });
 
     it('does nothing when no timers have been scheduled', () => {
-      const global = {};
+      const global = {process};
       const timers = new FakeTimers(global, moduleMocker);
       timers.useFakeTimers();
 
@@ -478,7 +478,7 @@ describe('FakeTimers', () => {
     });
 
     it('throws before allowing infinite recursion', () => {
-      const global = {};
+      const global = {process};
       const timers = new FakeTimers(global, moduleMocker, null, 100);
       timers.useFakeTimers();
 
@@ -497,7 +497,7 @@ describe('FakeTimers', () => {
 
   describe('reset', () => {
     it('resets all pending setTimeouts', () => {
-      const global = {};
+      const global = {process};
       const timers = new FakeTimers(global, moduleMocker);
       timers.useFakeTimers();
 
@@ -510,7 +510,7 @@ describe('FakeTimers', () => {
     });
 
     it('resets all pending setIntervals', () => {
-      const global = {};
+      const global = {process};
       const timers = new FakeTimers(global, moduleMocker);
       timers.useFakeTimers();
 
@@ -543,7 +543,7 @@ describe('FakeTimers', () => {
     });
 
     it('resets current runTimersToTime time cursor', () => {
-      const global = {};
+      const global = {process};
       const timers = new FakeTimers(global, moduleMocker);
       timers.useFakeTimers();
 
@@ -564,6 +564,7 @@ describe('FakeTimers', () => {
       const nativeSetImmediate = jest.genMockFn();
 
       const global = {
+        process,
         setImmediate: nativeSetImmediate,
       };
 
@@ -612,7 +613,7 @@ describe('FakeTimers', () => {
     });
 
     it('does not run timers that were cleared in another timer', () => {
-      const global = {};
+      const global = {process};
       const timers = new FakeTimers(global, moduleMocker);
       timers.useFakeTimers();
 
@@ -637,6 +638,7 @@ describe('FakeTimers', () => {
       const global = {
         clearInterval: nativeClearInterval,
         clearTimeout: nativeClearTimeout,
+        process,
         setInterval: nativeSetInterval,
         setTimeout: nativeSetTimeout,
       };
@@ -682,6 +684,7 @@ describe('FakeTimers', () => {
       const global = {
         clearInterval: nativeClearInterval,
         clearTimeout: nativeClearTimeout,
+        process,
         setInterval: nativeSetInterval,
         setTimeout: nativeSetTimeout,
       };
@@ -735,7 +738,10 @@ describe('FakeTimers', () => {
 
     it('resets mock timer functions even if callback throws', () => {
       const nativeSetTimeout = jest.genMockFn();
-      const global = {setTimeout: nativeSetTimeout};
+      const global = {
+        process,
+        setTimeout: nativeSetTimeout,
+      };
       const timers = new FakeTimers(global, moduleMocker);
       timers.useFakeTimers();
 
@@ -764,6 +770,7 @@ describe('FakeTimers', () => {
       const global = {
         clearInterval: nativeClearInterval,
         clearTimeout: nativeClearTimeout,
+        process,
         setInterval: nativeSetInterval,
         setTimeout: nativeSetTimeout,
       };
@@ -809,6 +816,7 @@ describe('FakeTimers', () => {
 
       const global = {
         clearImmediate: nativeClearImmediate,
+        process,
         setImmediate: nativeSetImmediate,
       };
       const timers = new FakeTimers(global, moduleMocker);
@@ -836,6 +844,7 @@ describe('FakeTimers', () => {
       const global = {
         clearInterval: nativeClearInterval,
         clearTimeout: nativeClearTimeout,
+        process,
         setInterval: nativeSetInterval,
         setTimeout: nativeSetTimeout,
       };
@@ -881,6 +890,7 @@ describe('FakeTimers', () => {
 
       const global = {
         clearImmediate: nativeClearImmediate,
+        process,
         setImmediate: nativeSetImmediate,
       };
       const fakeTimers = new FakeTimers(global, moduleMocker);


### PR DESCRIPTION
**Summary**

If the flag `resetMocks` or `jest.resetAllMocks` is used in the test, all the timer-related tests following that will fail with no way of recovering.

**Cause**

`jest.resetAllMocks` resets everything, including mocks created by fakeTimers. There are also no public methods that we can use to re-instantiate a new FakeTimer object to mitigate the problem.

**Solution**

Given that both mock and fake timers are part of the jest, they should be working together out-of-the box without extra code gluing them together. We change the `useFakeTimers` method to always create new mocks so the mocks will not be reverted by `resetAllMocks`. If there is a better way to manage the lifecycle of those mocks, please let me know. I will be happy to make changes.

**Test plan**

I have provided a new integration test suite named `timer_after_resetAllMocks`. It fails on jest 17.0.2 and is passing after this patch.

**Note**

This patch makes flow unhappy and I'm confused as to why it fails. I would love to hear some feedbacks on how to fix this.

```
> @ typecheck /Users/zcho/src/jest-work/jest
> flow check

packages/jest-util/src/FakeTimers.js:90
 90:       this._timerAPIs.nextTick = global.process.nextTick;
                           ^^^^^^^^ property `nextTick`. Property not found in
 90:       this._timerAPIs.nextTick = global.process.nextTick;
           ^^^^^^^^^^^^^^^ object literal
```

