### PR TITLE
jest-haste-map: prevent duplicate fs change events from being emitted.

### DIFF
--- a/packages/jest-haste-map/src/__tests__/index-test.js
+++ b/packages/jest-haste-map/src/__tests__/index-test.js
@@ -683,10 +683,19 @@ describe('HasteMap', () => {
               '/fruits',
               undefined,
             );
+            mockEmitters['/fruits'].emit(
+              'all',
+              'delete',
+              'banana.js',
+              '/fruits',
+              undefined,
+            );
 
             hasteMap.once(
               'change',
               addErrorHandler(({eventsQueue, hasteFS, moduleMap}) => {
+                expect(eventsQueue).toHaveLength(1);
+
                 expect(eventsQueue).toEqual([{
                   filePath,
                   stat: undefined,
@@ -751,6 +760,29 @@ describe('HasteMap', () => {
                 expect(moduleMap.getModule('Tomato')).toBeDefined();
                 expect(moduleMap.getModule('Pear')).toBeNull();
                 expect(moduleMap.getModule('Kiwi')).toBe('/fruits/pear.js');
+                next();
+              }),
+            );
+          },
+          () => {
+            mockEmitters['/fruits'].emit(
+              'all',
+              'change',
+              'tomato.js',
+              '/fruits',
+              statObject,
+            );
+            mockEmitters['/fruits'].emit(
+              'all',
+              'change',
+              'tomato.js',
+              '/fruits',
+              statObject,
+            );
+            hasteMap.once(
+              'change',
+              addErrorHandler(({eventsQueue, hasteFS, moduleMap}) => {
+                expect(eventsQueue).toHaveLength(1);
                 next();
               }),
             );

--- a/packages/jest-haste-map/src/index.js
+++ b/packages/jest-haste-map/src/index.js
@@ -525,6 +525,7 @@ class HasteMap extends EventEmitter {
       ? sane.WatchmanWatcher
       : sane.NodeWatcher;
     const extensions = this._options.extensions;
+    let changeQueue = Promise.resolve();
     let eventsQueue = [];
     // We only need to copy the entire haste map once on every "frame".
     let mustCopy = true;
@@ -569,16 +570,6 @@ class HasteMap extends EventEmitter {
       root: Path,
       stat: {mtime: Date},
     ) => {
-      if (mustCopy) {
-        mustCopy = false;
-        hasteMap = {
-          clocks: copy(hasteMap.clocks),
-          files: copy(hasteMap.files),
-          map: copy(hasteMap.map),
-          mocks: copy(hasteMap.mocks),
-        };
-      }
-
       filePath = path.join(root, filePath);
       if (
         this._ignore(filePath) ||
@@ -587,40 +578,76 @@ class HasteMap extends EventEmitter {
         return;
       }
 
-      // Delete the file and all of its metadata.
-      const moduleName =
-        hasteMap.files[filePath] && hasteMap.files[filePath][H.ID];
-      delete hasteMap.files[filePath];
-      delete hasteMap.map[moduleName];
-      if (
-        this._options.mocksPattern &&
-        this._options.mocksPattern.test(filePath)
-      ) {
-        const mockName = getMockName(filePath);
-        delete hasteMap.mocks[mockName];
-      }
-
-      // If the file was added or changed, parse it and update the haste map.
-      if (type === 'add' || type === 'change') {
-        const fileMetadata = ['', stat.mtime.getTime(), 0, []];
-        hasteMap.files[filePath] = fileMetadata;
-        const promise = this._processFile(
-          hasteMap,
-          hasteMap.map,
-          hasteMap.mocks,
-          filePath,
-          {
-            forceInBand: true,
-          },
-        );
-        if (promise) {
-          promise.then(() => eventsQueue.push({filePath, stat, type}));
+      changeQueue = changeQueue.then(() => {
+        // If we get duplicate events for the same file, ignore them.
+        if (
+          eventsQueue.find(event => (
+            event.type === type &&
+            event.filePath === filePath && (
+              (!event.stat && !stat) ||
+              (
+                event.stat &&
+                stat &&
+                event.stat.mtime.getTime() === stat.mtime.getTime()
+              )
+            )
+          ))
+        ) {
+          return null;
         }
-        // Cleanup
-        this._workerPromise = null;
-      } else {
-        eventsQueue.push({filePath, stat, type});
-      }
+
+        if (mustCopy) {
+          mustCopy = false;
+          hasteMap = {
+            clocks: copy(hasteMap.clocks),
+            files: copy(hasteMap.files),
+            map: copy(hasteMap.map),
+            mocks: copy(hasteMap.mocks),
+          };
+        }
+
+        const add = () => eventsQueue.push({filePath, stat, type});
+
+        // Delete the file and all of its metadata.
+        const moduleName =
+          hasteMap.files[filePath] && hasteMap.files[filePath][H.ID];
+        delete hasteMap.files[filePath];
+        delete hasteMap.map[moduleName];
+        if (
+          this._options.mocksPattern &&
+          this._options.mocksPattern.test(filePath)
+        ) {
+          const mockName = getMockName(filePath);
+          delete hasteMap.mocks[mockName];
+        }
+
+        // If the file was added or changed, parse it and update the haste map.
+        if (type === 'add' || type === 'change') {
+          const fileMetadata = ['', stat.mtime.getTime(), 0, []];
+          hasteMap.files[filePath] = fileMetadata;
+          const promise = this._processFile(
+            hasteMap,
+            hasteMap.map,
+            hasteMap.mocks,
+            filePath,
+            {
+              forceInBand: true,
+            },
+          );
+          // Cleanup
+          this._workerPromise = null;
+          if (promise) {
+            return promise.then(add);
+          }
+        } else {
+          add();
+        }
+        return null;
+      }).catch(error => {
+        this._console.error(
+          `jest-haste-map: watch error:\n  ${error}\n`,
+        );
+      });
     };
 
     this._changeInterval = setInterval(emitChange, CHANGE_INTERVAL);


### PR DESCRIPTION
**Summary**
It's possible we receive multiple events if one folder is watched twice for some reason.

Example:
* Roots are `<rootDir>` and `<rootDir>/packages`
* `touch packages/a.js`
* Two events are emitted to the `onChange` handler.

This diff also changes the onChange handler into a queue based system, just to make sure this is all done in sequence.

**Test plan**

jest + manual verification.

cc @matryoshcow @davidaurelio