### PR TITLE
test.concurrent must support testNamePattern

### DIFF
--- a/integration_tests/testNamePattern/__tests__/testNamePattern-test.js
+++ b/integration_tests/testNamePattern/__tests__/testNamePattern-test.js
@@ -10,4 +10,4 @@
 test('should match 1', () => expect(1).toBe(1));
 test('should match 2', () => expect(1).toBe(1));
 test('should not match 1', () => expect(1).toBe(1));
-test('should not match 2', () => expect(1).toBe(1));
+test.concurrent('should not match 2', () => expect(1).toBe(1));

--- a/packages/jest-jasmine2/src/jasmine-async.js
+++ b/packages/jest-jasmine2/src/jasmine-async.js
@@ -76,6 +76,10 @@ function promisifyLifeCycleFunction(originalFn: Function, env) {
 
 function makeConcurrent(originalFn: Function, env) {
   return function(specName, fn, timeout) {
+    if (env != null && !env.specFilter({getFullName: () => specName || ''})) {
+      return originalFn.call(env, specName, () => Promise.resolve(), timeout);
+    }
+
     let promise;
 
     try {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

`test.concurrent` doesn't respect `testNamePattern`. CLI reports that test is skipped, but actually it is executed.

**Test plan**

 Run modified `testNamePattern-test.js` without applying suggested fix to see.

Or see screenshot (sample user test):
<img width="789" alt="screen shot 2016-11-17 at 08 41 37" src="https://cloud.githubusercontent.com/assets/350686/20380336/b55205d0-aca1-11e6-8940-0f3a537611de.png">

