### PR TITLE
[WIP] XUnitReporter

### DIFF
--- a/integration_tests/custom-reporters/__tests__/one-test.js
+++ b/integration_tests/custom-reporters/__tests__/one-test.js
@@ -1,0 +1,6 @@
+test('passes', () => {});
+test('fails', () => expect(1).toBe(2));
+
+describe('nested', () => {
+  test('nested test', () => {});
+});

--- a/integration_tests/custom-reporters/__tests__/three-test.js
+++ b/integration_tests/custom-reporters/__tests__/three-test.js
@@ -1,0 +1,1 @@
+throw new Error('failure');

--- a/integration_tests/custom-reporters/__tests__/two-test.js
+++ b/integration_tests/custom-reporters/__tests__/two-test.js
@@ -1,0 +1,6 @@
+test('passes', () => {});
+test('fails', () => expect(1).toBe(2));
+
+describe('nested', () => {
+  test('nested test', () => {});
+});

--- a/integration_tests/custom-reporters/package.json
+++ b/integration_tests/custom-reporters/package.json
@@ -1,0 +1,8 @@
+{
+  "jest": {
+    "testEnvironment": "node",
+    "reporters": [
+      ["<rootDir>/../../packages/jest-cli/build/reporters/XUnitReporter", {"file": "<rootDir>/../../xunit.xml"}]
+    ]
+  }
+}

--- a/packages/jest-cli/src/TestRunner.js
+++ b/packages/jest-cli/src/TestRunner.js
@@ -387,6 +387,42 @@ class TestRunner {
     if (this._config.notify) {
       this.addReporter(new NotifyReporter());
     }
+
+    // Add custom reporters
+    if (this._config.reporters) {
+      this._config.reporters.forEach(entry => {
+        let config;
+        let reporterPath;
+
+        if (Array.isArray(entry)) {
+          config = entry[1];
+          reporterPath = entry[0];
+        } else {
+          if (typeof entry !== 'string') {
+            throw new Error(`
+              Unexpected custom reporter configuration.
+              Expected to get either a path string or an array of [path, config]
+              got: ${entry}
+            `);
+          }
+          reporterPath = entry;
+        }
+
+        try {
+          // $FlowFixMe dynamic paths
+          const reporter = require(reporterPath);
+          this.addReporter(new reporter(config || {}));
+        } catch (error) {
+          console.error(`
+            Failed to setup reporter:
+              ${JSON.stringify(reporterPath)}
+            Config:
+              ${JSON.stringify(this._config.reporters)}
+          `);
+          throw error;
+        }
+      });
+    }
   }
 
   _bailIfNeeded(aggregatedResults: AggregatedResult, watcher: TestWatcher) {

--- a/packages/jest-cli/src/reporters/XUnitReporter.js
+++ b/packages/jest-cli/src/reporters/XUnitReporter.js
@@ -1,0 +1,131 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+'use strict';
+
+import type {AggregatedResult} from 'types/TestResult';
+import type {Config} from 'types/Config';
+import type {RunnerContext} from 'types/Reporters';
+
+const BaseReporter = require('./BaseReporter');
+const path = require('path');
+const fs = require('fs');
+const stripAnsi = require('strip-ansi');
+
+class XUnitReporter extends BaseReporter {
+  _estimatedTime: number;
+
+  constructor(reporterConfig = {}) {
+    super();
+    if (!reporterConfig.file) {
+      throw new Error(`
+        XUnit reporter requires "file" config option to be set.
+        Example:
+          "reporters": [
+            ['jest-cli/build/reporters/xunit', {"file": "<rootDir>/report.xml"}]
+          ]
+      `);
+    }
+    this._file = reporterConfig.file;
+  }
+
+  onRunComplete(
+    config: Config,
+    aggregatedResults: AggregatedResult,
+    runnerContext: RunnerContext,
+  ) {
+    const makeTestcases = testResults => {
+      return testResults.reduce(
+        (testcases, testResult) => {
+          // console.log(testResult);
+          return testcases.concat({
+            error: testResult.failureMessages.join('\n'),
+            name: testResult.title,
+            status: testResult.status,
+            time: testResult.duration,
+          });
+        },
+        [],
+      );
+    };
+
+    const result = aggregatedResults.testResults.reduce(
+      (suites, {testFilePath, testResults, testExecError}) => {
+        const name = path.relative(config.rootDir, testFilePath);
+
+        if (testExecError) {
+          const error = testExecError.toString();
+          const status = 'failed';
+          return suites.concat({
+            name,
+            testcases: [{error, name, status, time: 0}],
+          });
+        } else {
+          return suites.concat({name, testcases: makeTestcases(testResults)});
+        }
+      },
+      [],
+    );
+
+    const makeTestcasesTags = testcases => {
+      return testcases.map(({name, time, error, status}) => {
+        const errorTag = error
+          ? makeTag('error', {message: error, type: 'error'}, '', '      ')
+          : '';
+        return makeTag('testcase', {name, time}, errorTag, '    ');
+      });
+    };
+
+    const testsuiteTags = result.map(suite => {
+      const {testcases, name} = suite;
+      const testCasesTags = makeTestcasesTags(testcases);
+      const tests = testcases.length;
+      const failures = testcases
+        .filter(({status}) => status === 'failed').length;
+
+      return makeTag(
+        'testsuite',
+        {failures, name, tests},
+        testCasesTags.join('\n'),
+        '  ',
+      );
+    }).join('\n');
+
+    const testsuitesTag = makeTag('testsuites', {}, testsuiteTags, '');
+    const xml = '<?xml version="1.0" encoding="UTF-8"?>\n' + testsuitesTag;
+    try {
+      fs.writeFileSync(this._file, xml);
+    } catch (e) {
+      console.error(`
+        Failed to write xUnit report to ${this._file}
+      `);
+      throw e;
+    }
+  }
+}
+
+const makeTag = (name, props = {}, content, indent = '') => {
+  let result = indent + '<' + name + ' ';
+  Object.keys(props).forEach(key => {
+    const value = stripAnsi(
+      props[key]
+        .toString()
+        .replace(/\"/, '\"')
+        .replace(/[<>]/, '')
+        .replace('\n', ' '),
+    );
+    result += ` ${key}="${value}"`;
+  });
+
+  return content
+    ? result + `>\n${content}\n${indent}</${name}>`
+    : result + '/>';
+};
+
+module.exports = XUnitReporter;

--- a/packages/jest-config/src/normalize.js
+++ b/packages/jest-config/src/normalize.js
@@ -365,6 +365,18 @@ function normalize(config, argv) {
           ),
         );
         break;
+      case 'reporters':
+        if (!Array.isArray(config[key])) {
+          throw new Error(`
+            jest: "reporters" config must be an array.
+            Example:
+              "reporters": [
+                ['jest-cli/build/reporters/xunit', {"file": "report.xml"}]
+              ]
+          `);
+        }
+        value = _replaceRootDirTags(config.rootDir, config[key]);
+        break;
       case 'automock':
       case 'bail':
       case 'browser':

--- a/types/Config.js
+++ b/types/Config.js
@@ -69,6 +69,7 @@ export type Config = DefaultConfig & {|
   moduleNameMapper: Array<string>,
   modulePaths: Array<string>,
   name: string,
+  reporters: Array<string | Array<string | Object>>,
   rootDir: Path,
   setupFiles: Array<Path>,
   setupTestFrameworkScriptFile: Path,


### PR DESCRIPTION
hey @ericf 
is there ant way you can check if the generated report is valid in jenkins?
i used this [example](https://gist.github.com/n1k0/4332371) but i remember that xml args can be tricky

```
<?xml version="1.0" encoding="UTF-8"?>
<testsuites >
  <testsuite  failures="1" name="__tests__/two-test.js" tests="3">
    <testcase  name="passes" time="1"/>
    <testcase  name="fails" time="3">
      <error  message="Error: expect(received).toBe(expected) 
Expected value to be (using ===):
  2
Received:
  1
    at Object.test (/Users/dabramov/fb/jest/integration_tests/custom-reporters/__tests__/two-test.js:2:31)
    at Object.anonymous> (/Users/dabramov/fb/jest/packages/jest-cli/node_modules/jest-config/node_modules/jest-jasmine2/build/jasmine-async.js:42:32)
    at attemptAsync (/Users/dabramov/fb/jest/packages/jest-cli/node_modules/jest-config/node_modules/jest-jasmine2/vendor/jasmine-2.5.2.js:1984:24)
    at QueueRunner.run (/Users/dabramov/fb/jest/packages/jest-cli/node_modules/jest-config/node_modules/jest-jasmine2/vendor/jasmine-2.5.2.js:1939:9)
    at /Users/dabramov/fb/jest/packages/jest-cli/node_modules/jest-config/node_modules/jest-jasmine2/vendor/jasmine-2.5.2.js:1966:16
    at /Users/dabramov/fb/jest/packages/jest-cli/node_modules/jest-config/node_modules/jest-jasmine2/vendor/jasmine-2.5.2.js:1909:9
    at Object.fn (/Users/dabramov/fb/jest/packages/jest-cli/node_modules/jest-config/node_modules/jest-jasmine2/build/jasmine-async.js:68:11)
    at attemptAsync (/Users/dabramov/fb/jest/packages/jest-cli/node_modules/jest-config/node_modules/jest-jasmine2/vendor/jasmine-2.5.2.js:1984:24)
    at QueueRunner.run (/Users/dabramov/fb/jest/packages/jest-cli/node_modules/jest-config/node_modules/jest-jasmine2/vendor/jasmine-2.5.2.js:1939:9)
    at QueueRunner.execute (/Users/dabramov/fb/jest/packages/jest-cli/node_modules/jest-config/node_modules/jest-jasmine2/vendor/jasmine-2.5.2.js:1927:10)" type="error"/>
    </testcase>
    <testcase  name="nested test" time="0"/>
  </testsuite>
  <testsuite  failures="1" name="__tests__/one-test.js" tests="3">
    <testcase  name="passes" time="0"/>
    <testcase  name="fails" time="1">
      <error  message="Error: expect(received).toBe(expected) 
Expected value to be (using ===):
  2
Received:
  1
    at Object.test (/Users/dabramov/fb/jest/integration_tests/custom-reporters/__tests__/one-test.js:2:31)
    at Object.anonymous> (/Users/dabramov/fb/jest/packages/jest-cli/node_modules/jest-config/node_modules/jest-jasmine2/build/jasmine-async.js:42:32)
    at attemptAsync (/Users/dabramov/fb/jest/packages/jest-cli/node_modules/jest-config/node_modules/jest-jasmine2/vendor/jasmine-2.5.2.js:1984:24)
    at QueueRunner.run (/Users/dabramov/fb/jest/packages/jest-cli/node_modules/jest-config/node_modules/jest-jasmine2/vendor/jasmine-2.5.2.js:1939:9)
    at /Users/dabramov/fb/jest/packages/jest-cli/node_modules/jest-config/node_modules/jest-jasmine2/vendor/jasmine-2.5.2.js:1966:16
    at /Users/dabramov/fb/jest/packages/jest-cli/node_modules/jest-config/node_modules/jest-jasmine2/vendor/jasmine-2.5.2.js:1909:9
    at Object.fn (/Users/dabramov/fb/jest/packages/jest-cli/node_modules/jest-config/node_modules/jest-jasmine2/build/jasmine-async.js:68:11)
    at attemptAsync (/Users/dabramov/fb/jest/packages/jest-cli/node_modules/jest-config/node_modules/jest-jasmine2/vendor/jasmine-2.5.2.js:1984:24)
    at QueueRunner.run (/Users/dabramov/fb/jest/packages/jest-cli/node_modules/jest-config/node_modules/jest-jasmine2/vendor/jasmine-2.5.2.js:1939:9)
    at QueueRunner.execute (/Users/dabramov/fb/jest/packages/jest-cli/node_modules/jest-config/node_modules/jest-jasmine2/vendor/jasmine-2.5.2.js:1927:10)" type="error"/>
    </testcase>
    <testcase  name="nested test" time="0"/>
  </testsuite>
  <testsuite  failures="1" name="__tests__/three-test.js" tests="1">
    <testcase  name="__tests__/three-test.js" time="0">
      <error  message="Error: failure" type="error"/>
    </testcase>
  </testsuite>
</testsuites>
```