### PR TITLE
include specName into the concurrent test assertion message

### DIFF
--- a/packages/jest-jasmine2/src/jasmine-async.js
+++ b/packages/jest-jasmine2/src/jasmine-async.js
@@ -85,8 +85,9 @@ function makeConcurrent(originalFn: Function, env) {
     try {
       promise = fn();
       if (!isPromise(promise)) {
-        throw new Error(`Jest: concurrent test "${specName}"
-         must return a Promise.`);
+        throw new Error(
+          `Jest: concurrent test "${specName}" must return a Promise.`,
+        );
       }
     } catch (error) {
       return originalFn.call(env, Promise.reject(error));

--- a/packages/jest-jasmine2/src/jasmine-async.js
+++ b/packages/jest-jasmine2/src/jasmine-async.js
@@ -85,7 +85,8 @@ function makeConcurrent(originalFn: Function, env) {
     try {
       promise = fn();
       if (!isPromise(promise)) {
-        throw new Error('Jest: concurrent tests must return a Promise.');
+        throw new Error(`Jest: concurrent test "${specName}"
+         must return a Promise.`);
       }
     } catch (error) {
       return originalFn.call(env, Promise.reject(error));


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

I see `(node:5197) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): Error: Jest: concurrent tests must return a Promise.` in a CI server log and have no idea what test causes it.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

`specName` should be in the error message.

**Test plan**

No test. Just cosmetics.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
