### PR TITLE
Allow hiding of usage #2049

### DIFF
--- a/packages/jest-cli/src/jest.js
+++ b/packages/jest-cli/src/jest.js
@@ -45,10 +45,10 @@ const KEYS = {
   CONTROL_D: '04',
   ENTER: '0d',
   ESCAPE: '1b',
-  QUESTION_MARK: '3f',
   O: '6f',
   P: '70',
   Q: '71',
+  QUESTION_MARK: '3f',
   U: '75',
 };
 
@@ -175,7 +175,7 @@ const usage = (
   ];
   /* eslint-enable max-len */
   return messages.filter(message => !!message).join(delimiter);
-}
+};
 
 const runJest = (config, argv, pipe, testWatcher, onComplete) => {
   const maxWorkers = getMaxWorkers(argv);
@@ -333,7 +333,7 @@ const runCLI = (
             results => {
               isRunning = false;
               didLastFail = !!results.snapshot.failure;
-              if(!process.env.JEST_HIDE_USAGE) {
+              if (!process.env.JEST_HIDE_USAGE) {
                 console.log(usage(argv, didLastFail));
               }
             },

--- a/packages/jest-cli/src/jest.js
+++ b/packages/jest-cli/src/jest.js
@@ -171,7 +171,6 @@ const usage = (
     chalk.dim(' \u203A Press ') + 'p' + chalk.dim(' to filter by a filename regex pattern.'),
     chalk.dim(' \u203A Press ') + 'q' + chalk.dim(' to quit watch mode.'),
     chalk.dim(' \u203A Press ') + 'Enter' + chalk.dim(' to trigger a test run.'),
-    chalk.dim(' \u203A Press ') + '?' + chalk.dim(' to display usage.'),
   ];
   /* eslint-enable max-len */
   return messages.filter(message => !!message).join(delimiter);
@@ -304,13 +303,13 @@ const runCLI = (
           pattern: argv._,
         });
 
-        let isRunning = false;
-        let didLastFail = false;
-        let isEnteringPattern = false;
         let currentPattern = '';
-        let timer: ?number;
-
+        let hasSnapshotFailure = false;
+        let isEnteringPattern = false;
+        let isRunning = false;
         let testWatcher;
+        let timer;
+
         const writeCurrentPattern = () => {
           clearLine(pipe);
           pipe.write(chalk.dim(' pattern \u203A ') + currentPattern);
@@ -332,9 +331,9 @@ const runCLI = (
             testWatcher,
             results => {
               isRunning = false;
-              didLastFail = !!results.snapshot.failure;
+              hasSnapshotFailure = !!results.snapshot.failure;
               if (!process.env.JEST_HIDE_USAGE) {
-                console.log(usage(argv, didLastFail));
+                console.log(usage(argv, hasSnapshotFailure));
               }
             },
           ).then(
@@ -408,7 +407,9 @@ const runCLI = (
               writeCurrentPattern();
               break;
             case KEYS.QUESTION_MARK:
-              console.log(usage(argv, didLastFail));
+              if (process.env.JEST_HIDE_USAGE) {
+                console.log(usage(argv, hasSnapshotFailure));
+              }
               break;
           }
         };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
This PR introduces two new ideas for the jest-cli after discussion on #2049 .

1) Allow hiding of usage in watch mode by setting the env `JEST_HIDE_USAGE`
2) Displaying the usage by hitting `?`

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
```
$ export JEST_HIDE_USAGE= && node ./packages/jest-cli/bin/jest.js --watch
$ export JEST_HIDE_USAGE=1 && node ./packages/jest-cli/bin/jest.js --watch
```
First run should show usage, second should not. Hit `?` while in watch mode.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

