### PR TITLE
unmock fs module in manual mocks example after all

### DIFF
--- a/examples/manual_mocks/__tests__/FileSummarizer-test.js
+++ b/examples/manual_mocks/__tests__/FileSummarizer-test.js
@@ -23,4 +23,8 @@ describe('listFilesInDirectorySync', () => {
 
     expect(fileSummary.length).toBe(2);
   });
+
+  afterAll(() => {
+    jest.unmock('fs');
+  });
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
I'm trying the manual mocks example with my Jenkins instance. I use the jasmine-reporters module to write junit result file to the disk. But I found this example always produce nothing. After a long time searching, found the cause is the fs mock. I read the doc of "unmockedModulePathPatterns" option, found: 

> It's generally a best practice to keep this list as small as possible and always use explicit jest.mock()/jest.unmock() calls in individual tests.

So I think the official example should follow it at first.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
Because this is a pr about example, so I think it don't need test.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->