### PR TITLE
Amend jest snapshots to tie in nicely with Ava

### DIFF
--- a/packages/jest-snapshot/src/index.js
+++ b/packages/jest-snapshot/src/index.js
@@ -63,7 +63,7 @@ const initializeSnapshotState = (
 const getSnapshotState = () => snapshotState;
 
 const toMatchSnapshot = function(received: any, expected: void) {
-  this.dontThrow();
+  this.dontThrow && this.dontThrow();
 
   const {currentTestName, isNot, snapshotState} = this;
 
@@ -87,7 +87,6 @@ const toMatchSnapshot = function(received: any, expected: void) {
   } else {
     const {count, expected, actual} = result;
 
-
     const expectedString = expected.trim();
     const actualString = actual.trim();
     const diffMessage = diff(
@@ -100,21 +99,24 @@ const toMatchSnapshot = function(received: any, expected: void) {
       },
     );
 
-    const message =
-      () => matcherHint('.toMatchSnapshot', 'value', '') + '\n\n' +
-      `${RECEIVED_COLOR('Received value')} does not match ` +
+    const report =
+      () => `${RECEIVED_COLOR('Received value')} does not match ` +
       `${EXPECTED_COLOR('stored snapshot ' + count)}.\n\n` +
       (diffMessage || (
         RECEIVED_COLOR('- ' + expectedString) + '\n' +
         EXPECTED_COLOR('+ ' + actualString)
       ));
 
-    return {message, pass: false};
+    const message =
+      () => matcherHint('.toMatchSnapshot', 'value', '') + '\n\n' +
+      report();
+
+    return {message, pass: false, report};
   }
 };
 
 const toThrowErrorMatchingSnapshot = function(received: any, expected: void) {
-  this.dontThrow();
+  this.dontThrow && this.dontThrow();
   const {isNot} = this;
 
   if (isNot) {


### PR DESCRIPTION
**Summary**

I am currently working on implementation of jest snapshots into Ava (https://github.com/avajs/ava/pull/1113) and wanted to smooth a few rough edges when implementing with another runner.

In particular:

- jest-snapshots relies on a context that has `dontThrow` function - that however depends too much on the implementation
- message on failure contains information about where the failure occurred; that way, the first line of the message says `expect(value).toMatchSnapshot()` - which again displays an implementation detail that isn't necessary

I'm happy to change the solution but it would be great to address these issues.

**Test plan**

When integrated with Ava, we get this kind of output:

<img width="634" alt="screen shot 2016-11-18 at 2 16 55 pm" src="https://cloud.githubusercontent.com/assets/6726858/20437141/c36189d4-adaa-11e6-97c7-67ab834e742a.png">

(Amazingly, when combined with `nyc` for test coverage, it works seamlessly without any additional work!)
