### PR TITLE
do not run in band first time (no timings)

### DIFF
--- a/packages/jest-cli/src/TestRunner.js
+++ b/packages/jest-cli/src/TestRunner.js
@@ -221,7 +221,7 @@ class TestRunner {
       testPaths.length <= 1 ||
       (
         testPaths.length <= 20 &&
-        timings.every(timing => timing < SLOW_TEST_TIME)
+        timings.length > 0 && timings.every(timing => timing < SLOW_TEST_TIME)
       )
     );
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

https://github.com/facebook/jest/issues/1903#issuecomment-261583088

Condition `timings.every(timing => timing < SLOW_TEST_TIME)` returns `true` if no timings. And if no timings — tests will be executed serially.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

Well, my tests executed not in 20 minutes, but in 3 minutes :)
