### PR TITLE
Expose TestWatcher

### DIFF
--- a/packages/jest-cli/src/jest.js
+++ b/packages/jest-cli/src/jest.js
@@ -451,6 +451,7 @@ const runCLI = (
 module.exports = {
   SearchSource,
   TestRunner,
+  TestWatcher,
   getVersion: () => VERSION,
   run,
   runCLI,


### PR DESCRIPTION
Working on some changes to update facebook/react to use Jest 17 and since it uses .runTests(), it needs access to TestWatcher so the concurrent reporter works.