### PR TITLE
reduce maxDepth for very large objects

### DIFF
--- a/packages/jest-matcher-utils/src/__tests__/__snapshots__/index-test.js.snap
+++ b/packages/jest-matcher-utils/src/__tests__/__snapshots__/index-test.js.snap
@@ -1,3 +1,7 @@
+exports[`.stringify() reduces maxDepth if stringifying very large objects 1`] = `"{\"a\": 1, \"b\": [Object]}"`;
+
+exports[`.stringify() reduces maxDepth if stringifying very large objects 2`] = `"{\"a\": 1, \"b\": {\"0\": \"test\", \"1\": \"test\", \"2\": \"test\", \"3\": \"test\", \"4\": \"test\", \"5\": \"test\", \"6\": \"test\", \"7\": \"test\", \"8\": \"test\", \"9\": \"test\"}}"`;
+
 exports[`.stringify() toJSON errors when comparing two objects 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).toEqual([22m[32mexpected[39m[2m)[22m
 

--- a/packages/jest-matcher-utils/src/__tests__/index-test.js
+++ b/packages/jest-matcher-utils/src/__tests__/index-test.js
@@ -70,6 +70,21 @@ describe('.stringify()', () => {
     expect(() => expect(evilA).toEqual(evilB))
       .toThrowErrorMatchingSnapshot();
   });
+
+  test('reduces maxDepth if stringifying very large objects', () => {
+    const big = {a: 1, b: {}};
+    const small = {a: 1, b: {}};
+    for (let i = 0; i < 10000; i += 1) {
+      big.b[i] = 'test';
+    }
+
+    for (let i = 0; i < 10; i += 1) {
+      small.b[i] = 'test';
+    }
+
+    expect(stringify(big)).toMatchSnapshot();
+    expect(stringify(small)).toMatchSnapshot();
+  });
 });
 
 

--- a/packages/jest-matcher-utils/src/index.js
+++ b/packages/jest-matcher-utils/src/index.js
@@ -81,19 +81,26 @@ const getType = (value: any): ValueType => {
   throw new Error(`value of unknown type: ${value}`);
 };
 
-const stringify = (object: any): string => {
+const stringify = (object: any, maxDepth?: number = 10): string => {
+  const MAX_LENGTH = 10000;
+  let result;
+
   try {
-    return prettyFormat(object, {
-      maxDepth: 10,
+    result = prettyFormat(object, {
+      maxDepth,
       min: true,
     });
   } catch (e) {
-    return prettyFormat(object, {
+    result = prettyFormat(object, {
       callToJSON: false,
-      maxDepth: 10,
+      maxDepth,
       min: true,
     });
   }
+
+  return result.length >= MAX_LENGTH && maxDepth > 1
+    ? stringify(object, Math.floor(maxDepth / 2))
+    : result;
 };
 
 const printReceived = (object: any) => RECEIVED_COLOR(stringify(object));


### PR DESCRIPTION
reduce `maxDepth` when pretty formatting the object if the resulting string is too long.
It will reduce depth by 1 every time until it either fits the `MAX_LENGTH` or becomes 1 (just printing the top level keys). This should happen only on failures, so the performance hit from running `format` multiple times should not be that bad.

cc @gaearon 