### PR TITLE
Add mocks for simple React Native AsyncStorage methods.

### DIFF
--- a/packages/jest-react-native/src/setup.js
+++ b/packages/jest-react-native/src/setup.js
@@ -63,6 +63,14 @@ jest
     };
     return DataSource;
   })
+  .mock('AsyncStorage', () => ({
+    setItem: () => Promise.resolve,
+    removeItem: () => Promise.resolve,
+    clear: () => Promise.resolve,
+    flushAllGetRequests: () => {},
+    multiSet: () => Promise.resolve,
+    multiRemove: () => Promise.resolve,
+  }))
   .mock('ensureComponentIsNative', () => () => true);
 
 global.__DEV__ = true;


### PR DESCRIPTION
## Summary

Add mocks for simple React Native AsyncStorage methods.

## Motivation
It's annoying to have to mock AsyncStorage myself - other people might find it annoying too! 😸 

## Details
This commit adds mocks for the simple AsyncStorage methods like setItem, removeItem etc. that have no interesting return value except a resolved promise. In these cases, most existing implementation code should continue to work transparently.

Some AsyncStorage methods are a little complex, like getItem, etc. and require the user to manually mock these out with their desired return values. No attempt is made to accomodate this workflow.

Thanks again for an excellent library! <3 