### PR TITLE
Fix "NaN% Failed" notification

### DIFF
--- a/packages/jest-cli/src/reporters/NotifyReporter.js
+++ b/packages/jest-cli/src/reporters/NotifyReporter.js
@@ -35,7 +35,7 @@ class NotifyReporter extends BaseReporter {
         result.numPassedTests,
       );
     } else {
-      let failed = result.numFailedTests / result.numTotalTests;
+      const failed = result.numFailedTests / result.numTotalTests;
 
       title = util.format(
         '%d%% Failed',

--- a/packages/jest-cli/src/reporters/NotifyReporter.js
+++ b/packages/jest-cli/src/reporters/NotifyReporter.js
@@ -35,9 +35,11 @@ class NotifyReporter extends BaseReporter {
         result.numPassedTests,
       );
     } else {
+      let failed = result.numFailedTests / result.numTotalTests;
+
       title = util.format(
         '%d%% Failed',
-        Math.ceil((result.numFailedTests / result.numTotalTests) * 100),
+        Math.ceil(Number.isNaN(failed) ? 0 : failed * 100),
       );
       message = util.format(
         (isDarwin ? '\u26D4\uFE0F ' : '') + '%d of %d tests failed',


### PR DESCRIPTION
**Summary**

This PR solves this incorrect or bad formatted notification when using `--notify`:
![image](https://cloud.githubusercontent.com/assets/1002461/20600489/e4d81f58-b221-11e6-9b91-9a3021734ae8.png)

Code example:
```js
describe('Test suite', () => {

  // describe('Boolean test', () => {
  // 
  //   it('Expect true', () => {
  //     expect(true).toBeTruthy();
  //   });
  //   
  //   it('Expect false', () => {
  //     expect(false).toBeFalsy();
  //   })
  // 
  // });
});
```

After this change, the notification is:
![image](https://cloud.githubusercontent.com/assets/1002461/20600470/d2831790-b221-11e6-914f-acfd477129d3.png)


**Test plan**

Tests ran green locally

