### PR TITLE
Pass CWD when instrumented through babel-jest

### DIFF
--- a/packages/babel-jest/src/index.js
+++ b/packages/babel-jest/src/index.js
@@ -81,12 +81,14 @@ const createTransformer = (options: any) => {
       if (transformOptions && transformOptions.instrument) {
         // Copied from jest-runtime transform.js
         plugins = plugins.concat([
-          require('babel-plugin-istanbul').default,
-          {
-            // files outside `cwd` will not be instrumented
-            cwd: config.rootDir,
-            exclude: [],
-          },
+          [
+            require('babel-plugin-istanbul').default,
+            {
+              // files outside `cwd` will not be instrumented
+              cwd: config.rootDir,
+              exclude: [],
+            },
+          ],
         ]);
       }
 

--- a/packages/babel-jest/src/index.js
+++ b/packages/babel-jest/src/index.js
@@ -84,7 +84,8 @@ const createTransformer = (options: any) => {
           [
             require('babel-plugin-istanbul').default,
             {
-              cwd: config.rootDir, // files outside `cwd` will not be instrumented
+              // files outside `cwd` will not be instrumented
+              cwd: config.rootDir,
               exclude: [],
             },
           ]

--- a/packages/babel-jest/src/index.js
+++ b/packages/babel-jest/src/index.js
@@ -79,7 +79,16 @@ const createTransformer = (options: any) => {
       let plugins = options.plugins || [];
 
       if (transformOptions && transformOptions.instrument) {
-        plugins = plugins.concat(require('babel-plugin-istanbul').default);
+        // Copied from jest-runtime transform.js
+        plugins = plugins.concat(
+          [
+            require('babel-plugin-istanbul').default,
+            {
+              cwd: config.rootDir, // files outside `cwd` will not be instrumented
+              exclude: [],
+            },
+          ]
+        );
       }
 
       if (babel.util.canCompile(filename)) {

--- a/packages/babel-jest/src/index.js
+++ b/packages/babel-jest/src/index.js
@@ -80,16 +80,14 @@ const createTransformer = (options: any) => {
 
       if (transformOptions && transformOptions.instrument) {
         // Copied from jest-runtime transform.js
-        plugins = plugins.concat(
-          [
-            require('babel-plugin-istanbul').default,
-            {
-              // files outside `cwd` will not be instrumented
-              cwd: config.rootDir,
-              exclude: [],
-            },
-          ],
-        );
+        plugins = plugins.concat([
+          require('babel-plugin-istanbul').default,
+          {
+            // files outside `cwd` will not be instrumented
+            cwd: config.rootDir,
+            exclude: [],
+          },
+        ]);
       }
 
       if (babel.util.canCompile(filename)) {

--- a/packages/babel-jest/src/index.js
+++ b/packages/babel-jest/src/index.js
@@ -88,7 +88,7 @@ const createTransformer = (options: any) => {
               cwd: config.rootDir,
               exclude: [],
             },
-          ]
+          ],
         );
       }
 


### PR DESCRIPTION
**Summary**

The babel-jest package can sometimes be used to transpile and instrument
at the same time. Only jest-runtime was passing CWD properly to
istanbul. This pull mirrors this behavior in babel-jest as well now.

**Test plan**

After this change, any usage of istanbul that I can see is properly passed a 'cwd' variable equal to the config.rootDir option. No tests or APIs should be impacted by this.

