### PR TITLE
Adds native to the list of jest-react-native platforms to fix testing with react-relay.

### DIFF
--- a/packages/jest-react-native/jest-preset.json
+++ b/packages/jest-react-native/jest-preset.json
@@ -1,7 +1,7 @@
 {
   "haste": {
     "defaultPlatform": "ios",
-    "platforms": ["android", "ios"],
+    "platforms": ["android", "ios", "native"],
     "providesModuleNodeModules": [
       "react",
       "react-native"


### PR DESCRIPTION
**Summary**

When using jest with React Native and Relay and recommended default settings, jest throws :
```
    Cannot find module 'react-dom' from 'relayUnstableBatchedUpdates.js'

      at Resolver.resolveModule (node_modules/jest-resolve/build/index.js:151:17)
      at Object.<anonymous> (node_modules/react-relay/lib/relayUnstableBatchedUpdates.js:15:18)
      at new RelayEnvironment (node_modules/react-relay/lib/RelayEnvironment.js:39:63)
```

Investigating this, I found out that https://github.com/facebook/jest/blob/master/packages/jest-react-native/jest-preset.json didn't have "native" in the list of platforms, hence jest can't pick up `relayUnstableBatchedUpdates.native.js` in react-relay. 

**Test plan**

I copied and paste the content of https://github.com/facebook/jest/blob/master/packages/jest-react-native/jest-preset.json in my `package.json` `jest` section, as well as removed the `preset` entry. Same result.
I then did :
```patch
-       "platforms": ["android", "ios"],
+      "platforms": ["android", "ios", "native"],
```

This fixes the issue.



