### PR TITLE
Fix typo in MigrationGuide.md

### DIFF
--- a/docs/MigrationGuide.md
+++ b/docs/MigrationGuide.md
@@ -23,7 +23,7 @@ Install Jest Codemods with `npm` by running:
 npm install -g jest-codemods
 ```
 
-To get transform your existing tests, navigate to the project containing the tests and run:
+To transform your existing tests, navigate to the project containing the tests and run:
 
 ```
 jest-codemods


### PR DESCRIPTION
**Summary**

Unnecessary word ('get') in document.


