### PR TITLE
Fix config.transform link in babel-jest README

### DIFF
--- a/packages/babel-jest/README.md
+++ b/packages/babel-jest/README.md
@@ -10,4 +10,4 @@ If you are already using `jest-cli`, just add `babel-jest` and it will automatic
 npm install --save-dev babel-jest
 ```
 
-If you would like to write your own preprocessor, uninstall and delete babel-jest and set the [config.transform](http://facebook.github.io/jest/docs/api.html#transform-object-string-string) option to your preprocessor.
+If you would like to write your own preprocessor, uninstall and delete babel-jest and set the [config.transform](http://facebook.github.io/jest/docs/configuration.html#transform-object-string-string) option to your preprocessor.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

`config.transform` link in `babel-jest` README doesn't link to the correct URL.

**Test plan**

Click the link.
