### PR TITLE
Docs: add props argument in example code of Tutorial React

### DIFF
--- a/docs/TutorialReact.md
+++ b/docs/TutorialReact.md
@@ -68,8 +68,8 @@ const STATUS = {
 
 export default class Link extends React.Component {
 
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
 
     this._onMouseEnter = this._onMouseEnter.bind(this);
     this._onMouseLeave = this._onMouseLeave.bind(this);


### PR DESCRIPTION
**Summary**

Make the example code under http://facebook.github.io/jest/docs/tutorial-react.html#snapshot-testing consistent with:

* Similar example code later on the same page under http://facebook.github.io/jest/docs/tutorial-react.html#dom-testing
* Similar example code under https://facebook.github.io/react/docs/state-and-lifecycle.html#adding-local-state-to-a-class which makes the statement “Note how we pass props to the base constructor”

**Test plan**

Reviewer confirms that:

* the two bullet points above show the preferred pattern
* there is no benefit for learners to see an alternative pattern