### PR TITLE
Don’t print stack traces from babel.

### DIFF
--- a/integration_tests/__tests__/__snapshots__/failures-test.js.snap
+++ b/integration_tests/__tests__/__snapshots__/failures-test.js.snap
@@ -4,7 +4,6 @@ Object {
   ● Test suite failed to run
 
     Expected an Error, but \"1\" was thrown
-    
 
 ",
   "summary": "Test Suites: 1 failed, 1 total

--- a/packages/jest-runtime/src/transform.js
+++ b/packages/jest-runtime/src/transform.js
@@ -303,17 +303,24 @@ const transformAndBuildScript = (
   const content = stripShebang(fs.readFileSync(filename, 'utf8'));
   let wrappedResult;
 
-  if (
-    !isInternalModule &&
+  try {
+    if (
+      !isInternalModule &&
       (shouldTransform(filename, config) || instrument)
-  ) {
-    wrappedResult =
-      wrap(transformSource(filename, config, content, instrument));
-  } else {
-    wrappedResult = wrap(content);
-  }
+    ) {
+      wrappedResult =
+        wrap(transformSource(filename, config, content, instrument));
+    } else {
+      wrappedResult = wrap(content);
+    }
 
-  return new vm.Script(wrappedResult, {displayErrors: true, filename});
+    return new vm.Script(wrappedResult, {displayErrors: true, filename});
+  } catch (e) {
+    if (e.codeFrame) {
+      e.stack = e.codeFrame;
+    }
+    throw e;
+  }
 };
 
 module.exports = (

--- a/packages/jest-util/src/messages.js
+++ b/packages/jest-util/src/messages.js
@@ -67,22 +67,22 @@ const formatExecError = (
   if (separated.message.indexOf(trim(message)) !== -1) {
     // Often stack trace already contains the duplicate of the message
     message = separated.message;
-  } else {
-    message = message + '\n' + separated.message;
   }
 
   message = message.split(/\n/).map(line => MESSAGE_INDENT + line).join('\n');
-
   stack = stack && !config.noStackTrace
-    ? '\n' + STACK_TRACE_COLOR(formatStackTrace(stack, config, testPath))
+    ? '\n' + formatStackTrace(stack, config, testPath)
     : '';
 
   if (message.match(/^\s*$/) && stack.match(/^\s*$/)) {
     // this can happen if an empty object is thrown.
     message = MESSAGE_INDENT + 'Error: No message was provided';
   }
-  return TITLE_INDENT + TITLE_BULLET + EXEC_ERROR_MESSAGE + '\n\n' +
-    message  + stack + '\n';
+
+  return (
+    TITLE_INDENT + TITLE_BULLET + EXEC_ERROR_MESSAGE + '\n\n' +
+    message + stack + '\n'
+  );
 };
 
 const removeInternalStackEntries = (lines, config: StackTraceOptions) => {


### PR DESCRIPTION
**Summary**

Trying to make @gaearon happy. Fixes #1929

**Test plan**

Add a syntax error, run jest and don't see a stack trace.

<img width="962" alt="screen shot 2016-11-29 at 7 52 17 pm" src="https://cloud.githubusercontent.com/assets/13352/20726419/69d8791a-b66d-11e6-833f-6bac46ac5d8a.png">
