### PR TITLE
Replace Array.includes with Array.indexOf for node v4 support

### DIFF
--- a/packages/jest-cli/src/jest.js
+++ b/packages/jest-cli/src/jest.js
@@ -376,7 +376,7 @@ const runCLI = (
           if (
             isRunning &&
             testWatcher &&
-            [KEYS.Q, KEYS.ENTER, KEYS.A, KEYS.O, KEYS.P].includes(key)
+            [KEYS.Q, KEYS.ENTER, KEYS.A, KEYS.O, KEYS.P].indexOf(key) !== -1
           ) {
             testWatcher.setState({interrupted: true});
             return;


### PR DESCRIPTION
`Array.prototype.includes` is not supported in Node v4.

Fixes #2178 
