### PR TITLE
Pass `expected` and `actual` objects from matchers and custom errors from jasmine

### DIFF
--- a/integration_tests/__tests__/json-test.js
+++ b/integration_tests/__tests__/json-test.js
@@ -12,5 +12,5 @@ test('JSON is available in the global scope', () => {
 });
 
 test('JSON.parse creates objects from within this context', () => {
-  expect(JSON.parse("{}").constructor).toBe(Object);
+  expect(JSON.parse('{}').constructor).toBe(Object);
 });

--- a/packages/jest-jasmine2/vendor/jasmine-2.5.2.js
+++ b/packages/jest-jasmine2/vendor/jasmine-2.5.2.js
@@ -1612,7 +1612,8 @@ getJasmineRequireObj().buildExpectationResult = function() {
       matcherName: options.matcherName,
       message: message(),
       stack: stack(),
-      passed: options.passed
+      passed: options.passed,
+      error: options.error
     };
 
     if(!result.passed) {

--- a/packages/jest-jasmine2/vendor/jasmine-2.5.2.js
+++ b/packages/jest-jasmine2/vendor/jasmine-2.5.2.js
@@ -1613,6 +1613,7 @@ getJasmineRequireObj().buildExpectationResult = function() {
       message: message(),
       stack: stack(),
       passed: options.passed,
+      // CUSTOM JEST CHANGE: we pass error message to the result.
       error: options.error
     };
 

--- a/packages/jest-matchers/src/index.js
+++ b/packages/jest-matchers/src/index.js
@@ -29,17 +29,19 @@ const utils = require('jest-matcher-utils');
 
 const GLOBAL_STATE = Symbol.for('$$jest-matchers-object');
 
-class JestAssertionError extends Error {}
+class JestAssertionError extends Error {
+  matcherResult: any
+}
 
 if (!global[GLOBAL_STATE]) {
   Object.defineProperty(
     global,
     GLOBAL_STATE,
     {value: {
-      matchers: Object.create(null), 
+      matchers: Object.create(null),
       state: {
-        assertionsExpected: null, 
-        assertionsMade: 0, 
+        assertionsExpected: null,
+        assertionsMade: 0,
         suppressedErrors: [],
       },
     }},
@@ -114,6 +116,7 @@ const makeThrowingMatcher = (
     if ((result.pass && isNot) || (!result.pass && !isNot)) { // XOR
       const message = getMessage(result.message);
       const error = new JestAssertionError(message);
+      error.matcherResult = result;
       // Remove this function from the stack trace frame.
       Error.captureStackTrace(error, throwingMatcher);
 

--- a/packages/jest-matchers/src/matchers.js
+++ b/packages/jest-matchers/src/matchers.js
@@ -103,7 +103,7 @@ const matchers: MatchersObject = {
         (diffString ? `\n\nDifference:\n\n${diffString}` : '');
       };
 
-    return {message, pass};
+    return {actual: received, expected, message, name: 'toBe', pass};
   },
 
   toBeCloseTo(
@@ -396,7 +396,7 @@ const matchers: MatchersObject = {
         (diffString ? `\n\nDifference:\n\n${diffString}` : '');
       };
 
-    return {message, pass};
+    return {actual: received, expected, message, name: 'toEqual', pass};
   },
 
   toHaveLength(received: any, length: number) {


### PR DESCRIPTION
**Summary**

`Jasmine`'s built-in [matchers are providing](https://github.com/facebook/jest/blob/master/packages/jest-jasmine2/vendor/jasmine-2.5.2.js#L1568) `matcherName`, plus `expected` and `actual` values, allowing external reporters and integrations to provide any custom diff views, such as

![diff](https://cloud.githubusercontent.com/assets/979966/20779359/c57881fe-b7bf-11e6-9be1-4211e2f0c0dd.jpg)

or

![diffws](https://cloud.githubusercontent.com/assets/979966/20779414/259e65b2-b7c0-11e6-89b0-53058b43e8bd.gif)

Also, most of existing standalone assertion libraries, [such as `chai`](https://github.com/chaijs/chai/blob/master/lib/chai/assertion.js#L111), also pass the values in their error object, however [`jasmine` doesn't pass the error object](https://github.com/facebook/jest/blob/master/packages/jest-jasmine2/vendor/jasmine-2.5.2.js#L1611) through.

`Jest` is providing the built-in diff (which looks great in terminal), however, `Jest`'s matchers are not passing through the matcher results (including `expected` and `actual` values), making it impossible for an external reporter (such as wallaby.js tool) to display another diff view.

To address both of the issues:
- no access to the `expected` and `actual` values for `jest` built-in and custom matchers, and generally no access to a matcher result,
- no access to a custom assertion library error, in case if a custom assertion library, such as `chai` or [anything else](https://twitter.com/bruderstein/status/798440122844872704), is used with `jest`,

I have submitted the PR. Note that I have only extended the `toBe` and `toEqual` matchers, as these are the only two where `expected` vs `actual` diff makes sense.