### PR TITLE
Fixes for babel-plugin-jest-hoist.

### DIFF
--- a/integration_tests/babel-plugin-jest-hoist/__tests__/integration-test.js
+++ b/integration_tests/babel-plugin-jest-hoist/__tests__/integration-test.js
@@ -21,6 +21,9 @@ import c from '../__test_modules__/c';
 import d from '../__test_modules__/d';
 import e from '../__test_modules__/e';
 
+// The virtual mock call below will be hoisted above this `require` call.
+const virtualModule = require('virtual-module');
+
 // These will all be hoisted above imports
 jest.unmock('react');
 jest.deepUnmock('../__test_modules__/Unmocked');
@@ -44,6 +47,7 @@ jest.mock('../__test_modules__/e', () => {
     },
   };
 });
+jest.mock('virtual-module', () => 'kiwi', {virtual: true});
 
 // These will not be hoisted
 jest.unmock('../__test_modules__/a').dontMock('../__test_modules__/b');
@@ -116,5 +120,9 @@ describe('babel-plugin-jest-hoist', () => {
     require('../mock-file');
     const mock = require('../banana');
     expect(mock).toEqual('apple');
+  });
+
+  it('works with virtual modules', () => {
+    expect(virtualModule).toBe('kiwi');
   });
 });

--- a/packages/babel-plugin-jest-hoist/src/index.js
+++ b/packages/babel-plugin-jest-hoist/src/index.js
@@ -79,7 +79,7 @@ const FUNCTIONS = Object.create(null);
 FUNCTIONS.mock = args => {
   if (args.length === 1) {
     return args[0].isStringLiteral();
-  } else if (args.length === 2) {
+  } else if (args.length === 2 || args.length === 3) {
     const moduleFactory = args[1];
     invariant(
       moduleFactory.isFunction(),
@@ -108,7 +108,7 @@ FUNCTIONS.mock = args => {
           (scope.hasGlobal(name) && WHITELISTED_IDENTIFIERS[name]) ||
           /^mock/.test(name) ||
           // Allow istanbul's coverage variable to pass.
-          //^(?:__)?cov/.test(name),
+          /^(?:__)?cov/.test(name),
           'The module factory of `jest.mock()` is not allowed to ' +
           'reference any out-of-scope variables.\n' +
           'Invalid variable access: ' + name + '\n' +

--- a/packages/jest-haste-map/src/__tests__/index-test.js
+++ b/packages/jest-haste-map/src/__tests__/index-test.js
@@ -51,6 +51,7 @@ jest.mock('../crawlers/watchman', () =>
 
 jest.mock('sane', () => {
   const watcher = jest.fn(root => {
+    const EventEmitter = require('events').EventEmitter;
     mockEmitters[root] = new EventEmitter();
     mockEmitters[root].close = jest.fn(callback => callback());
     setTimeout(() => mockEmitters[root].emit('ready'), 0);
@@ -62,7 +63,6 @@ jest.mock('sane', () => {
   };
 });
 
-const EventEmitter = require('events').EventEmitter;
 const skipOnWindows = require('skipOnWindows');
 
 const cacheFilePath = '/cache-file';


### PR DESCRIPTION
**Summary**
* Virtual mocks weren't hoisted.
* Fix insane clowniness in static analysis.

**Test plan**
jest