### PR TITLE
Allow files called just test.jsx? or spec.jsx? in root

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -360,11 +360,12 @@ An array of regexp pattern strings that are matched against all test paths befor
 These pattern strings match against the full path. Use the `<rootDir>` string token to  include the path to your project's root directory to prevent it from accidentally ignoring all of your files in different environments that may have different root directories. Example: `['<rootDir>/build/', '<rootDir>/node_modules/']`.
 
 ### `testRegex` [string]
-(default: `(/__tests__/.*|\\.(test|spec))\\.jsx?$`)
+(default: `(/__tests__/.*|(\\.|/)(test|spec))\\.jsx?$`)
 
 The pattern Jest uses to detect test files. By default it looks for `.js` and `.jsx` files
 inside of `__tests__` folders, as well as any files with a suffix of `.test` or `.spec`
-(e.g. `Component.test.js` or `Component.spec.js`).
+(e.g. `Component.test.js` or `Component.spec.js`). It will also find files called `test.js`
+or `spec.js`.
 
 ### `testResultsProcessor` [string]
 (default: `undefined`)

--- a/integration_tests/__tests__/test-in-root-test.js
+++ b/integration_tests/__tests__/test-in-root-test.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails oncall+jsinfra
+ */
+'use strict';
+
+const path = require('path');
+const runJest = require('../runJest');
+
+it('runs tests in only test.js and spec.js', () => {
+  const result = runJest.json('test-in-root').json;
+
+  expect(result.success).toBe(true);
+  expect(result.numTotalTests).toBe(2);
+
+  const testNames = result.testResults
+      .map(res => res.name)
+      .map(name => path.basename(name))
+      .sort();
+
+  expect(testNames.length).toBe(2);
+  expect(testNames[0]).toBe('spec.js');
+  expect(testNames[1]).toBe('test.js');
+});

--- a/integration_tests/test-in-root/foo.js
+++ b/integration_tests/test-in-root/foo.js
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
+// This test shouldn't run
+test('stub', () => expect(1).toBe(2));

--- a/integration_tests/test-in-root/footest.js
+++ b/integration_tests/test-in-root/footest.js
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
+// This test shouldn't run
+test('stub', () => expect(1).toBe(2));

--- a/integration_tests/test-in-root/package.json
+++ b/integration_tests/test-in-root/package.json
@@ -1,0 +1,5 @@
+{
+  "jest": {
+    "testEnvironment": "node"
+  }
+}

--- a/integration_tests/test-in-root/spec.js
+++ b/integration_tests/test-in-root/spec.js
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
+// This test should run
+test('stub', () => expect(1).toBe(1));

--- a/integration_tests/test-in-root/test.js
+++ b/integration_tests/test-in-root/test.js
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
+// This test should run
+test('stub', () => expect(1).toBe(1));

--- a/packages/jest-config/src/defaults.js
+++ b/packages/jest-config/src/defaults.js
@@ -50,7 +50,7 @@ module.exports = ({
   testEnvironment: 'jest-environment-jsdom',
   testPathDirs: ['<rootDir>'],
   testPathIgnorePatterns: [NODE_MODULES_REGEXP],
-  testRegex: '(/__tests__/.*|\\.(test|spec))\\.jsx?$',
+  testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.jsx?$',
   testURL: 'about:blank',
   timers: 'real',
   transformIgnorePatterns: [NODE_MODULES_REGEXP],


### PR DESCRIPTION
**Summary**

I have a file called `test.js` in the root of my project, and I think jests should automatically pick it up without me providing custom `testRegex`.

**Test plan**

```sh-session
$ node_modules/.bin/jest
 PASS  ./test.js
  ✓ assets should always be an array (2ms)
  ✓ assets should should be reversed (1ms)
  ✓ should invoke callback on success (7ms)
  ✓ should invoke callback on error (1ms)
  ✓ should add file using compilation's publicPath (3ms)
  ✓ should used passed in publicPath
  ○ should handle missing `publicPath`
  ✓ should add file missing "/" to public path
  ✓ should add sourcemap to compilation
  ✓ should skip adding sourcemap to compilation if set to false
  ✓ should include hash of file content if option is set
  ✓ should add to css if `typeOfAsset` is css
  ✓ should replace compilation assets key if `outputPath` is set

Test Suites: 1 passed, 1 total
Tests:       1 skipped, 12 passed, 13 total
Snapshots:   0 total
Time:        1.084s
Ran all test suites.
```

I tried writing a test for it, but there's no tests actually testing the default regex, AFAICT.