### PR TITLE
Expose jasmine asymmetric matches as part of Jest public API

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -18,6 +18,7 @@ In your test files, Jest puts each of these methods and objects into the global 
   - [`describe(name, fn)`](#basic-testing)
   - [`expect(value)`](#expectvalue)
   - [`expect.extend(matchers)`](#extending-jest-matchers)
+  - [`expect.<asymmetric-match>()`](#asymmetric-jest-matchers)
   - [`it(name, fn)`](#basic-testing)
   - [`it.only(name, fn)`](#basic-testing)
   - [`it.skip(name, fn)`](#basic-testing)
@@ -811,6 +812,54 @@ This will print something like this:
 ```
 
 When an assertion fails, the error message should give as much signal as necessary to the user so they can resolve their issue quickly. It's usually recommended to spend a lot of time crafting a great failure message to make sure users of your custom assertions have a good developer experience.
+
+### Asymmetric Jest Matchers
+
+Sometimes you don't want to check equality of entire object. You just need to assert that value is not empty or has some expected type. For example, we want to check the shape of some message entity:
+
+```
+  expect({
+    timestamp: 1480807810388,
+    text: 'Some text content, but we care only about *this part*'
+  }).toEqual({
+    timestamp: expect.any(Number),
+    text: expect.stringMatching('*this part*')
+  });
+```
+
+There some special values with specific comparing behavior that you can use as a part of expectation. They are useful for asserting some types of data, like timestamps, or long text resources, where only part of it is important for testing. Currently, Jest has the following asymmetric matches:
+  
+  * `expect.anything()` - matches everything, except `null` and `undefined`
+  * `expect.any(<constructor>)` - checks, that actual value is instance of provided `<constructor>`.
+  * `expect.objectContaining(<object>)` - compares only keys, that exist in provided object. All other keys of `actual` value will be ignored.
+  * `expect.arrayContaining(<array>)` - checks that all items from the provided `array` are exist in `actual` value. It allows to have more values in `actual`.
+  * `expect.stringMatching(<string|Regexp>)` - checks that actual value has matches of provided expectation.
+
+These expressions can be used as an argument in `.toEqual` and `.toBeCalledWith`:
+
+```
+  expect(callback).toEqual(expect.any(Function));
+  
+  expect(mySpy).toBeCalledWith(expect.any(Number), expect.any(String))
+```
+
+They can be also used as object keys and may be nested into each other:
+
+```
+  expect(myObject).toEqual(expect.objectContaining({
+    items: expect.arrayContaining([
+      expect.any(Number)
+    ])
+  }));
+```
+
+The example above will match the following object. Array may contain more items, as well as object itself may also have some extra keys:
+  
+```
+{
+  items: [1]
+}
+```
 
 ## Mock Functions
 

--- a/packages/jest-matchers/src/__tests__/__snapshots__/matchers-test.js.snap
+++ b/packages/jest-matchers/src/__tests__/__snapshots__/matchers-test.js.snap
@@ -1746,6 +1746,30 @@ Received:
   [31m\"abc\"[39m"
 `;
 
+exports[`.toEqual() expect("abcd").not.toEqual({"regexp": /bc/}) 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).not.toEqual([22m[32mexpected[39m[2m)[22m
+
+Expected value to not equal:
+  [32m{\"regexp\": /bc/}[39m
+Received:
+  [31m\"abcd\"[39m"
+`;
+
+exports[`.toEqual() expect("abd").toEqual({"regexp": /bc/i}) 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).toEqual([22m[32mexpected[39m[2m)[22m
+
+Expected value to equal:
+  [32m{\"regexp\": /bc/i}[39m
+Received:
+  [31m\"abd\"[39m
+
+Difference:
+
+Comparing two different types of values:
+  Expected: [32mobject[39m
+  Received: [31mstring[39m"
+`;
+
 exports[`.toEqual() expect("banana").toEqual("apple") 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).toEqual([22m[32mexpected[39m[2m)[22m
 
@@ -1753,6 +1777,81 @@ Expected value to equal:
   [32m\"apple\"[39m
 Received:
   [31m\"banana\"[39m"
+`;
+
+exports[`.toEqual() expect([1, 2, 3]).not.toEqual({"sample": [2, 3]}) 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).not.toEqual([22m[32mexpected[39m[2m)[22m
+
+Expected value to not equal:
+  [32m{\"sample\": [2, 3]}[39m
+Received:
+  [31m[1, 2, 3][39m"
+`;
+
+exports[`.toEqual() expect([1, 3]).toEqual({"sample": [1, 2]}) 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).toEqual([22m[32mexpected[39m[2m)[22m
+
+Expected value to equal:
+  [32m{\"sample\": [1, 2]}[39m
+Received:
+  [31m[1, 3][39m
+
+Difference:
+
+Comparing two different types of values:
+  Expected: [32mobject[39m
+  Received: [31marray[39m"
+`;
+
+exports[`.toEqual() expect([Function anonymous]).not.toEqual({"expectedObject": [Function Function]}) 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).not.toEqual([22m[32mexpected[39m[2m)[22m
+
+Expected value to not equal:
+  [32m{\"expectedObject\": [Function Function]}[39m
+Received:
+  [31m[Function anonymous][39m"
+`;
+
+exports[`.toEqual() expect({"a": 1, "b": [Function anonymous], "c": true}).not.toEqual({"a": 1, "b": {"expectedObject": [Function Function]}, "c": {}}) 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).not.toEqual([22m[32mexpected[39m[2m)[22m
+
+Expected value to not equal:
+  [32m{\"a\": 1, \"b\": {\"expectedObject\": [Function Function]}, \"c\": {}}[39m
+Received:
+  [31m{\"a\": 1, \"b\": [Function anonymous], \"c\": true}[39m"
+`;
+
+exports[`.toEqual() expect({"a": 1, "b": 2}).not.toEqual({"sample": {"a": 1}}) 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).not.toEqual([22m[32mexpected[39m[2m)[22m
+
+Expected value to not equal:
+  [32m{\"sample\": {\"a\": 1}}[39m
+Received:
+  [31m{\"a\": 1, \"b\": 2}[39m"
+`;
+
+exports[`.toEqual() expect({"a": 1, "b": 2}).toEqual({"sample": {"a": 2}}) 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).toEqual([22m[32mexpected[39m[2m)[22m
+
+Expected value to equal:
+  [32m{\"sample\": {\"a\": 2}}[39m
+Received:
+  [31m{\"a\": 1, \"b\": 2}[39m
+
+Difference:
+
+[32m- Expected[39m
+[31m+ Received[39m
+
+[33m@@ -1,5 +1,4 @@
+[39m[32m-ObjectContaining {[39m
+[32m-  \"sample\": Object {[39m
+[32m-    \"a\": 2,[39m
+[32m-  },[39m
+[31m+Object {[39m
+[31m+  \"a\": 1,[39m
+[31m+  \"b\": 2,[39m
+[2m }[22m"
 `;
 
 exports[`.toEqual() expect({"a": 5}).toEqual({"b": 6}) 1`] = `
@@ -1817,6 +1916,15 @@ Comparing two different types of values:
   Received: [31mnull[39m"
 `;
 
+exports[`.toEqual() expect(true).not.toEqual({}) 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).not.toEqual([22m[32mexpected[39m[2m)[22m
+
+Expected value to not equal:
+  [32m{}[39m
+Received:
+  [31mtrue[39m"
+`;
+
 exports[`.toEqual() expect(true).not.toEqual(true) 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).not.toEqual([22m[32mexpected[39m[2m)[22m
 
@@ -1833,6 +1941,36 @@ Expected value to equal:
   [32mfalse[39m
 Received:
   [31mtrue[39m"
+`;
+
+exports[`.toEqual() expect(undefined).toEqual({"expectedObject": [Function Function]}) 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).toEqual([22m[32mexpected[39m[2m)[22m
+
+Expected value to equal:
+  [32m{\"expectedObject\": [Function Function]}[39m
+Received:
+  [31mundefined[39m
+
+Difference:
+
+Comparing two different types of values:
+  Expected: [32mobject[39m
+  Received: [31mundefined[39m"
+`;
+
+exports[`.toEqual() expect(undefined).toEqual({}) 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).toEqual([22m[32mexpected[39m[2m)[22m
+
+Expected value to equal:
+  [32m{}[39m
+Received:
+  [31mundefined[39m
+
+Difference:
+
+Comparing two different types of values:
+  Expected: [32mobject[39m
+  Received: [31mundefined[39m"
 `;
 
 exports[`.toHaveLength error cases 1`] = `

--- a/packages/jest-matchers/src/__tests__/matchers-test.js
+++ b/packages/jest-matchers/src/__tests__/matchers-test.js
@@ -64,6 +64,11 @@ describe('.toEqual()', () => {
     [{a: 5}, {b: 6}],
     ['banana', 'apple'],
     [null, undefined],
+    [{a: 1, b: 2}, jestExpect.objectContaining({a: 2})],
+    [[1, 3], jestExpect.arrayContaining([1, 2])],
+    ['abd', jestExpect.stringMatching(/bc/i)],
+    [undefined, jestExpect.anything()],
+    [undefined, jestExpect.any(Function)],
   ].forEach(([a, b]) => {
     test(`expect(${stringify(a)}).toEqual(${stringify(b)})`, () => {
       expect(() => jestExpect(a).toEqual(b))
@@ -76,6 +81,20 @@ describe('.toEqual()', () => {
     [1, 1],
     ['abc', 'abc'],
     [{a: 99}, {a: 99}],
+    [{a: 1, b: 2}, jestExpect.objectContaining({a: 1})],
+    [[1, 2, 3], jestExpect.arrayContaining([2, 3])],
+    ['abcd', jestExpect.stringMatching('bc')],
+    [true, jestExpect.anything()],
+    [() => {}, jestExpect.any(Function)],
+    [{
+      a: 1,
+      b: () => {},
+      c: true,
+    }, {
+      a: 1,
+      b: jestExpect.any(Function),
+      c: jestExpect.anything(),
+    }],
   ].forEach(([a, b]) => {
     test(`expect(${stringify(a)}).not.toEqual(${stringify(b)})`, () => {
       expect(() => jestExpect(a).not.toEqual(b))

--- a/packages/jest-matchers/src/index.js
+++ b/packages/jest-matchers/src/index.js
@@ -130,6 +130,12 @@ expect.extend = (matchersObj: MatchersObject): void => {
   Object.assign(global[GLOBAL_STATE].matchers, matchersObj);
 };
 
+expect.anything = global.jasmine.anything;
+expect.any = global.jasmine.any;
+expect.objectContaining = global.jasmine.objectContaining;
+expect.arrayContaining = global.jasmine.arrayContaining;
+expect.stringMatching = global.jasmine.stringMatching;
+
 const _validateResult = result => {
   if (
     typeof result !== 'object' ||


### PR DESCRIPTION
**Summary**

Jasmine has [some special values with asymmetric equality](https://jasmine.github.io/edge/introduction#section-Matching_Anything_with_<code>jasmine.any</code>). Currently, everything works fine with Jest as well, but it is not documented and causes troubles like this: https://github.com/facebookincubator/create-react-app/pull/1127

Adding this as a part of Jest public API will encourage people to use this feature in cases like [that](https://github.com/facebook/jest/issues/2202) and also will open this for future improvements in developer experience with equality check of big objects.