### PR TITLE
Fixed bug in array order toMatchObject

### DIFF
--- a/packages/jest-matchers/src/__tests__/__snapshots__/matchers-test.js.snap
+++ b/packages/jest-matchers/src/__tests__/__snapshots__/matchers-test.js.snap
@@ -2402,6 +2402,66 @@ Received:
   [31m\"bar\"[39m"
 `;
 
+exports[`toMatchObject() {pass: false} expect([1, 2, 3]).toMatchObject([1, 2, 2]) 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).toMatchObject([22m[32mexpected[39m[2m)[22m
+
+Expected value to match object:
+  [32m[1, 2, 2][39m
+Received:
+  [31m[1, 2, 3][39m
+Difference:
+[32m- Expected[39m
+[31m+ Received[39m
+
+[33m@@ -1,5 +1,5 @@
+[39m[2m Array [[22m
+[2m   1,[22m
+[2m   2,[22m
+[32m-  2,[39m
+[31m+  3,[39m
+[2m ][22m"
+`;
+
+exports[`toMatchObject() {pass: false} expect([1, 2, 3]).toMatchObject([2, 3, 1]) 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).toMatchObject([22m[32mexpected[39m[2m)[22m
+
+Expected value to match object:
+  [32m[2, 3, 1][39m
+Received:
+  [31m[1, 2, 3][39m
+Difference:
+[32m- Expected[39m
+[31m+ Received[39m
+
+[33m@@ -1,5 +1,5 @@
+[39m[2m Array [[22m
+[31m+  1,[39m
+[2m   2,[22m
+[2m   3,[22m
+[32m-  1,[39m
+[2m ][22m"
+`;
+
+exports[`toMatchObject() {pass: false} expect([1, 2, 3]).toMatchObject(Array []) 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).toMatchObject([22m[32mexpected[39m[2m)[22m
+
+Expected value to match object:
+  [32mArray [][39m
+Received:
+  [31m[1, 2, 3][39m
+Difference:
+[32m- Expected[39m
+[31m+ Received[39m
+
+[33m@@ -1,1 +1,5 @@
+[39m[32m-Array [][39m
+[31m+Array [[39m
+[31m+  1,[39m
+[31m+  2,[39m
+[31m+  3,[39m
+[31m+][39m"
+`;
+
 exports[`toMatchObject() {pass: false} expect([1, 2]).toMatchObject([1, 3]) 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).toMatchObject([22m[32mexpected[39m[2m)[22m
 
@@ -2858,6 +2918,15 @@ Expected value not to match object:
   [32m2015-11-30T00:00:00.000Z[39m
 Received:
   [31m2015-11-30T00:00:00.000Z[39m"
+`;
+
+exports[`toMatchObject() {pass: true} expect(Array []).toMatchObject(Array []) 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).not.toMatchObject([22m[32mexpected[39m[2m)[22m
+
+Expected value not to match object:
+  [32mArray [][39m
+Received:
+  [31mArray [][39m"
 `;
 
 exports[`toMatchObject() throws expect("44").toMatchObject({}) 1`] = `

--- a/packages/jest-matchers/src/__tests__/__snapshots__/matchers-test.js.snap
+++ b/packages/jest-matchers/src/__tests__/__snapshots__/matchers-test.js.snap
@@ -2442,26 +2442,6 @@ Difference:
 [2m ][22m"
 `;
 
-exports[`toMatchObject() {pass: false} expect([1, 2, 3]).toMatchObject(Array []) 1`] = `
-"[2mexpect([22m[31mreceived[39m[2m).toMatchObject([22m[32mexpected[39m[2m)[22m
-
-Expected value to match object:
-  [32mArray [][39m
-Received:
-  [31m[1, 2, 3][39m
-Difference:
-[32m- Expected[39m
-[31m+ Received[39m
-
-[33m@@ -1,1 +1,5 @@
-[39m[32m-Array [][39m
-[31m+Array [[39m
-[31m+  1,[39m
-[31m+  2,[39m
-[31m+  3,[39m
-[31m+][39m"
-`;
-
 exports[`toMatchObject() {pass: false} expect([1, 2]).toMatchObject([1, 3]) 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).toMatchObject([22m[32mexpected[39m[2m)[22m
 

--- a/packages/jest-matchers/src/__tests__/matchers-test.js
+++ b/packages/jest-matchers/src/__tests__/matchers-test.js
@@ -637,6 +637,7 @@ describe('toMatchObject()', () => {
     [{a: [{a: 'a', b: 'b'}]}, {a:[{a: 'a'}]}],
     [[1, 2], [1, 2]],
     [{a: undefined}, {a: undefined}],
+    [[], []]
   ].forEach(([n1, n2]) => {
     it(`{pass: true} expect(${stringify(n1)}).toMatchObject(${stringify(n2)})`, () => {
       jestExpect(n1).toMatchObject(n2);
@@ -663,6 +664,8 @@ describe('toMatchObject()', () => {
      [{a: [{a: 'a', b: 'b'}]}, {a:[{a: 'c'}]}],
      [{a: 1, b: 1, c: 1, d: {e: {f: 555}}}, {d: {e: {f: 222}}}],
      [{}, {a: undefined}],
+     [[1, 2, 3], [2, 3, 1]],
+     [[1, 2, 3], [1, 2, 2]]
   ].forEach(([n1, n2]) => {
     it(`{pass: false} expect(${stringify(n1)}).toMatchObject(${stringify(n2)})`, () => {
       jestExpect(n1).not.toMatchObject(n2);

--- a/packages/jest-matchers/src/__tests__/matchers-test.js
+++ b/packages/jest-matchers/src/__tests__/matchers-test.js
@@ -637,7 +637,7 @@ describe('toMatchObject()', () => {
     [{a: [{a: 'a', b: 'b'}]}, {a:[{a: 'a'}]}],
     [[1, 2], [1, 2]],
     [{a: undefined}, {a: undefined}],
-    [[], []]
+    [[], []],
   ].forEach(([n1, n2]) => {
     it(`{pass: true} expect(${stringify(n1)}).toMatchObject(${stringify(n2)})`, () => {
       jestExpect(n1).toMatchObject(n2);
@@ -665,7 +665,7 @@ describe('toMatchObject()', () => {
      [{a: 1, b: 1, c: 1, d: {e: {f: 555}}}, {d: {e: {f: 222}}}],
      [{}, {a: undefined}],
      [[1, 2, 3], [2, 3, 1]],
-     [[1, 2, 3], [1, 2, 2]]
+     [[1, 2, 3], [1, 2, 2]],
   ].forEach(([n1, n2]) => {
     it(`{pass: false} expect(${stringify(n1)}).toMatchObject(${stringify(n2)})`, () => {
       jestExpect(n1).not.toMatchObject(n2);

--- a/packages/jest-matchers/src/matchers.js
+++ b/packages/jest-matchers/src/matchers.js
@@ -573,8 +573,8 @@ const matchers: MatchersObject = {
           return false;
         }
 
-        for (let i=0; i<expected.length; i++) {
-          if (compare(expected[i], received[i])===false) {
+        for (let i = 0; i < expected.length; i++) {
+          if (compare(expected[i], received[i]) === false) {
             return false;
           }
         }

--- a/packages/jest-matchers/src/matchers.js
+++ b/packages/jest-matchers/src/matchers.js
@@ -573,11 +573,13 @@ const matchers: MatchersObject = {
           return false;
         }
 
-        return expected.every(exp => {
-          return received.some(act => {
-            return compare(exp, act);
-          });
-        });
+        for (let i=0; i<expected.length; i++) {
+          if (compare(expected[i], received[i])===false) {
+            return false;
+          }
+        }
+
+        return true;
       }
 
       if (expected instanceof Date && received instanceof Date) {

--- a/packages/jest-matchers/src/matchers.js
+++ b/packages/jest-matchers/src/matchers.js
@@ -573,13 +573,7 @@ const matchers: MatchersObject = {
           return false;
         }
 
-        for (let i = 0; i < expected.length; i++) {
-          if (compare(expected[i], received[i]) === false) {
-            return false;
-          }
-        }
-
-        return true;
+        return expected.every((exp, i) => compare(exp, received[i]));
       }
 
       if (expected instanceof Date && received instanceof Date) {
@@ -611,12 +605,8 @@ const matchers: MatchersObject = {
           return received;
         }
 
-        const matchArray = [];
-        for (let i = 0; i < expected.length; i++) {
-          matchArray.push(findMatchObject(expected[i], received[i]));
-        }
-
-        return matchArray;
+        return expected.map((exp, i) => findMatchObject(exp, received[i]));
+        
       } else if (received instanceof Date) {
         return received;
       } else if (typeof received === 'object' && received !== null && typeof expected === 'object' && expected !== null) {


### PR DESCRIPTION
Fixes issue #2212.

Added tests to check that the matcher maintains array-ordering.