### PR TITLE
Simple implementation and tests for #2191

### DIFF
--- a/packages/jest-config/src/__tests__/normalize-test.js
+++ b/packages/jest-config/src/__tests__/normalize-test.js
@@ -637,6 +637,8 @@ describe('normalize', () => {
         .toEqual('/root/node_modules/ts-jest/coverageprocessor.js');
       expect(config.moduleFileExtensions)
         .toEqual(['js', 'jsx', 'json', 'ts', 'tsx']);
+      expect(config.testRegex)
+        .toEqual('(/__tests__/.*|\\.(test|spec))\\.(j|t)sx?$');
     });
 
     it('uses ts-jest if ts-jest is explicitly specified in a custom transform config', () => {
@@ -659,6 +661,8 @@ describe('normalize', () => {
         .toEqual('/root/node_modules/ts-jest/coverageprocessor.js');
       expect(config.moduleFileExtensions)
         .toEqual(['js', 'jsx', 'json', 'ts', 'tsx']);
+      expect(config.testRegex)
+        .toEqual('(/__tests__/.*|\\.(test|spec))\\.(j|t)sx?$');
     });
 
     it(`doesn't use ts-jest if its not available`, () => {
@@ -672,6 +676,8 @@ describe('normalize', () => {
       expect(config.testResultsProcessor).toEqual(undefined);
       expect(config.moduleFileExtensions)
         .toEqual(['js', 'json', 'jsx', 'node']);
+      expect(config.testRegex)
+        .toEqual('(/__tests__/.*|\\.(test|spec))\\.jsx?$');
     });
 
     it(`doesn't use ts-jest coverage proccessor if another is defined`, () => {
@@ -689,6 +695,8 @@ describe('normalize', () => {
         .toEqual('/root/node_modules/ts-jest/coverageprocessor.js');
       expect(config.moduleFileExtensions)
         .toEqual(['js', 'jsx', 'json', 'ts', 'tsx']);
+      expect(config.testRegex)
+        .toEqual('(/__tests__/.*|\\.(test|spec))\\.(j|t)sx?$');
     });
 
     it(`doesn't use ts module extensions nor defalut if another is defined`, () => {
@@ -707,6 +715,28 @@ describe('normalize', () => {
         .toEqual(['js', 'json', 'jsx', 'node']);
       expect(config.moduleFileExtensions).not
         .toEqual(['js', 'jsx', 'json', 'ts', 'tsx']);
+      expect(config.testRegex)
+        .toEqual('(/__tests__/.*|\\.(test|spec))\\.(j|t)sx?$');
+    });
+
+    it(`doesn't use ts test Regex nor defalut if another is defined`, () => {
+      const config = normalize({
+        rootDir: '/root',
+        testRegex: '\\.spec\\.tsx?$',
+      });
+      const tsTransformerPath = uniformPath(config.transform[1][1]);
+      const testResultsProcessorPath = uniformPath(config.testResultsProcessor);
+      expect(config.transform[1][0]).toBe(DEFAULT_TS_PATTERN);
+      expect(tsTransformerPath)
+        .toEqual('/root/node_modules/ts-jest/preprocessor.js');
+      expect(testResultsProcessorPath)
+        .toEqual('/root/node_modules/ts-jest/coverageprocessor.js');
+      expect(config.moduleFileExtensions)
+        .toEqual(['js', 'jsx', 'json', 'ts', 'tsx']);
+      expect(config.testRegex).not
+        .toEqual('(/__tests__/.*|\\.(test|spec))\\.(j|t)sx?$');
+      expect(config.testRegex).not
+        .toEqual('(/__tests__/.*|\\.(test|spec))\\.jsx?$');
     });
   });
 

--- a/packages/jest-config/src/__tests__/normalize-test.js
+++ b/packages/jest-config/src/__tests__/normalize-test.js
@@ -15,6 +15,7 @@ const utils = require('jest-util');
 const normalize = require('../normalize');
 
 const DEFAULT_JS_PATTERN = require('../constants').DEFAULT_JS_PATTERN;
+const DEFAULT_TS_PATTERN = require('../constants').DEFAULT_TS_PATTERN;
 const DEFAULT_CSS_PATTERN = '^.+\\.(css)$';
 
 describe('normalize', () => {
@@ -611,6 +612,101 @@ describe('normalize', () => {
       expect(config.usesBabelJest).toBe(true);
       expect(config.setupFiles.map(uniformPath))
         .toEqual(['/root/node_modules/babel-polyfill']);
+    });
+  });
+
+  describe('ts-jest', () => {
+    let Resolver;
+    beforeEach(() => {
+      Resolver = require('jest-resolve');
+      Resolver.findNodeModule = jest.fn(
+        name => 'node_modules' + path.sep + name,
+      );
+    });
+
+    it('correctly identifies and uses ts-jest', () => {
+      const config = normalize({
+        rootDir: '/root',
+      });
+      const tsTransformerPath = uniformPath(config.transform[1][1]);
+      const testResultsProcessorPath = uniformPath(config.testResultsProcessor);
+      expect(config.transform[1][0]).toBe(DEFAULT_TS_PATTERN);
+      expect(tsTransformerPath)
+        .toEqual('/root/node_modules/ts-jest/preprocessor.js');
+      expect(testResultsProcessorPath)
+        .toEqual('/root/node_modules/ts-jest/coverageprocessor.js');
+      expect(config.moduleFileExtensions)
+        .toEqual(['js', 'jsx', 'json', 'ts', 'tsx']);
+    });
+
+    it('uses ts-jest if ts-jest is explicitly specified in a custom transform config', () => {
+      const customTSPattern = '^.+\\.ts$';
+      const ROOT_DIR = '<rootDir>' + path.sep;
+      const config = normalize({
+        rootDir: '/root',
+        transform: {
+          [customTSPattern]: (ROOT_DIR + Resolver.findNodeModule(
+            'ts-jest',
+          ) + path.sep + 'preprocessor.js'),
+        },
+      });
+      const tsTransformerPath = uniformPath(config.transform[0][1]);
+      const testResultsProcessorPath = uniformPath(config.testResultsProcessor);
+      expect(config.transform[0][0]).toBe(customTSPattern);
+      expect(tsTransformerPath)
+        .toEqual('/root/node_modules/ts-jest/preprocessor.js');
+      expect(testResultsProcessorPath)
+        .toEqual('/root/node_modules/ts-jest/coverageprocessor.js');
+      expect(config.moduleFileExtensions)
+        .toEqual(['js', 'jsx', 'json', 'ts', 'tsx']);
+    });
+
+    it(`doesn't use ts-jest if its not available`, () => {
+      Resolver.findNodeModule.mockImplementation(() => null);
+
+      const config = normalize({
+        rootDir: '/root',
+      });
+      
+      expect(config.transform).toEqual(undefined);
+      expect(config.testResultsProcessor).toEqual(undefined);
+      expect(config.moduleFileExtensions)
+        .toEqual(['js', 'json', 'jsx', 'node']);
+    });
+
+    it(`doesn't use ts-jest coverage proccessor if another is defined`, () => {
+      const ROOT_DIR = '<rootDir>' + path.sep;
+      const config = normalize({
+        rootDir: '/root',
+        testResultsProcessor: ROOT_DIR + 'anotherProcessor.js',
+      });
+      const tsTransformerPath = uniformPath(config.transform[1][1]);
+      const testResultsProcessorPath = uniformPath(config.testResultsProcessor);
+      expect(config.transform[1][0]).toBe(DEFAULT_TS_PATTERN);
+      expect(tsTransformerPath)
+        .toEqual('/root/node_modules/ts-jest/preprocessor.js');
+      expect(testResultsProcessorPath).not
+        .toEqual('/root/node_modules/ts-jest/coverageprocessor.js');
+      expect(config.moduleFileExtensions)
+        .toEqual(['js', 'jsx', 'json', 'ts', 'tsx']);
+    });
+
+    it(`doesn't use ts module extensions nor defalut if another is defined`, () => {
+      const config = normalize({
+        moduleFileExtensions: ['js', 'ts'],
+        rootDir: '/root',
+      });
+      const tsTransformerPath = uniformPath(config.transform[1][1]);
+      const testResultsProcessorPath = uniformPath(config.testResultsProcessor);
+      expect(config.transform[1][0]).toBe(DEFAULT_TS_PATTERN);
+      expect(tsTransformerPath)
+        .toEqual('/root/node_modules/ts-jest/preprocessor.js');
+      expect(testResultsProcessorPath)
+        .toEqual('/root/node_modules/ts-jest/coverageprocessor.js');
+      expect(config.moduleFileExtensions).not
+        .toEqual(['js', 'json', 'jsx', 'node']);
+      expect(config.moduleFileExtensions).not
+        .toEqual(['js', 'jsx', 'json', 'ts', 'tsx']);
     });
   });
 

--- a/packages/jest-config/src/constants.js
+++ b/packages/jest-config/src/constants.js
@@ -12,3 +12,4 @@ const path = require('path');
 
 exports.NODE_MODULES = path.sep + 'node_modules' + path.sep;
 exports.DEFAULT_JS_PATTERN = '^.+\\.jsx?$';
+exports.DEFAULT_TS_PATTERN = '^.+\\.tsx?$';

--- a/packages/jest-config/src/normalize.js
+++ b/packages/jest-config/src/normalize.js
@@ -316,6 +316,9 @@ function normalize(config, argv) {
     if (!config.moduleFileExtensions) {
       config.moduleFileExtensions = ['js', 'jsx', 'json', 'ts', 'tsx'];
     }
+    if (!config.testRegex) {
+      config.testRegex = '(/__tests__/.*|\\.(test|spec))\\.(j|t)sx?$';
+    }
   }  
 
   Object.keys(config).reduce((newConfig, key) => {


### PR DESCRIPTION
## Summary
This PR implements #2191 issue from `Jest` repo itself and this one also https://github.com/kulshekhar/ts-jest/issues/13.
In simple terms - it allows using `Jest` with `TypeScript` project just by adding `"ts-jest": "latest"` to `devDependencies`.

## Test plan
All below configs should allow normal usage of `Jest` in `TypeScript` project.
Something like this one was used previously:
```Json
{
  "devDependencies": {
    "typescript": "latest",
    "jest": "latest",
    "ts-jest": "latest",
  },
  "jest": {
    "transform": {
      ".(ts|tsx)": "<rootDir>/node_modules/ts-jest/preprocessor.js"
    },
    "testResultsProcessor": "<rootDir>/node_modules/ts-jest/coverageprocessor.js",
    "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
    "moduleFileExtensions": [
      "ts",
      "tsx",
      "js"
    ]
  }
}
```
With this PR config should look like this:
```Json
{
  "devDependencies": {
    "typescript": "latest",
    "jest": "latest",
    "ts-jest": "latest",
  }
}
```
Same behavior seems to work for `babel-jest`.

## P.S.
It probably could also contain implementation for #2203 because it seems to be related, but I'm not sure. Could you please tell, should I implement it in this PR or make another one?