### PR TITLE
When using the hide jest usage env, show usage first run only

### DIFF
--- a/packages/jest-cli/src/jest.js
+++ b/packages/jest-cli/src/jest.js
@@ -309,6 +309,7 @@ const runCLI = (
         let isRunning = false;
         let testWatcher;
         let timer;
+        let displayHelp = true;
 
         const writeCurrentPattern = () => {
           clearLine(pipe);
@@ -333,6 +334,9 @@ const runCLI = (
               isRunning = false;
               hasSnapshotFailure = !!results.snapshot.failure;
               if (!process.env.JEST_HIDE_USAGE) {
+                console.log(usage(argv, hasSnapshotFailure));
+              } else if (process.env.JEST_HIDE_USAGE && displayHelp) {
+                displayHelp = false;
                 console.log(usage(argv, hasSnapshotFailure));
               }
             },

--- a/packages/jest-cli/src/jest.js
+++ b/packages/jest-cli/src/jest.js
@@ -333,11 +333,9 @@ const runCLI = (
             results => {
               isRunning = false;
               hasSnapshotFailure = !!results.snapshot.failure;
-              if (!process.env.JEST_HIDE_USAGE) {
+              if (displayHelp) {
                 console.log(usage(argv, hasSnapshotFailure));
-              } else if (process.env.JEST_HIDE_USAGE && displayHelp) {
-                displayHelp = false;
-                console.log(usage(argv, hasSnapshotFailure));
+                displayHelp = !process.env.JEST_HIDE_USAGE;
               }
             },
           ).then(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
First run should show usage, second should not. Hit ? while in watch mode.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
@cpojer asked me to address this from a [previous pull request](https://github.com/facebook/jest/pull/2125#issuecomment-263659285)

**Test plan**
`$ export JEST_HIDE_USAGE=1 && node ./packages/jest-cli/bin/jest.js --watch`
1st run displays usage. With the watcher still runnning, make a minor change to a file, the watcher should rerun tests and not display the usage.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->