### PR TITLE
Better error message when json config is invalid

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -3,6 +3,7 @@
 .*/node_modules/fbjs/.*
 .*/examples/.*
 .*/website/.*
+.*/node_modules/jsonlint/.*
 
 [include]
 

--- a/packages/jest-config/package.json
+++ b/packages/jest-config/package.json
@@ -16,7 +16,8 @@
     "jest-mock": "^15.0.0",
     "jest-resolve": "^15.0.1",
     "jest-util": "^15.1.1",
-    "json-stable-stringify": "^1.0.0"
+    "json-stable-stringify": "^1.0.0",
+    "jsonlint": "^1.6.2"
   },
   "scripts": {
     "test": "../../packages/jest-cli/bin/jest.js"

--- a/packages/jest-config/src/__tests__/parseFileContents-test.js
+++ b/packages/jest-config/src/__tests__/parseFileContents-test.js
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails oncall+jsinfra
+ */
+'use strict';
+
+jest.mock('jest-resolve');
+
+//const path = require('path');
+const parseFileContents = require('../parseFileContents');
+
+describe('good json, config object', () => {
+  const goodJson = `{
+    "bail": false,
+    "verbose": true
+  }`;
+
+  it('returns a config object if your json is not bad', () => {
+    const expected = {
+      bail: false,
+      verbose: true,
+    };
+
+    expect(parseFileContents('good-config.json', goodJson)).toEqual(expected);
+  });
+});
+
+describe('bad json, helpful message', () => {
+  const badJson = `{
+    bail: false
+    verbose: true,
+  }`;
+
+  it('tells which line of your json config is bad', () => {
+    const expected = `Jest: Failed to parse config file bad-config.json.
+Error: Parse error on line 1:
+{    bail: false    verb
+-----^
+Expecting 'STRING', '}', got 'undefined'`;
+
+    expect(() => {
+      return parseFileContents('bad-config.json', badJson);
+    }).toThrow(expected);
+  });
+});

--- a/packages/jest-config/src/loadFromFile.js
+++ b/packages/jest-config/src/loadFromFile.js
@@ -12,18 +12,11 @@ const fs = require('fs');
 const normalize = require('./normalize');
 const path = require('path');
 const promisify = require('./lib/promisify');
+const parseFileContents = require('./parseFileContents');
 
 function loadFromFile(filePath, argv) {
   return promisify(fs.readFile)(filePath).then(data => {
-    const parse = () => {
-      try {
-        return JSON.parse(data);
-      } catch (e) {
-        throw new Error(`Jest: Failed to parse config file ${filePath}.`);
-      }
-    };
-
-    const config = parse();
+    const config = parseFileContents(filePath, data);
     config.rootDir = config.rootDir
       ? path.resolve(path.dirname(filePath), config.rootDir)
       : process.cwd();

--- a/packages/jest-config/src/parseFileContents.js
+++ b/packages/jest-config/src/parseFileContents.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+const parser = require('jsonlint').parser;
+
+function parseFileContents(filePath, jsonBuffer) {
+  const jsonData = String(jsonBuffer);
+  try {
+    return parser.parse(jsonData);
+  } catch (e) {
+    const errorMsg = e.toString();
+    throw new Error(`Jest: Failed to parse config file ${ filePath }.`
+        + `\n${ errorMsg }`);
+  }
+}
+
+module.exports = parseFileContents;


### PR DESCRIPTION
Fixes #2225 

Uses jsonlint which will give you an idea of where the problem is when it can't parse the JSON read from the file.

Added tests to cover invalid and valid JSON parsing.  My tests pass.  There were quite a few tests in the existing codebase that do not.  I didn't fix those.
