### PR TITLE
Clear scrollback on terminal clear in watch mode

### DIFF
--- a/packages/jest-cli/src/jest.js
+++ b/packages/jest-cli/src/jest.js
@@ -34,7 +34,7 @@ const sane = require('sane');
 const which = require('which');
 const TestWatcher = require('./TestWatcher');
 
-const CLEAR = '\x1B[3J\x1B[H';
+const CLEAR = process.platform === 'win32' ? '\x1Bc' : '\x1B[3J\x1B[H';
 const VERSION = require('../package.json').version;
 const WATCHER_DEBOUNCE = 200;
 const WATCHMAN_BIN = 'watchman';

--- a/packages/jest-cli/src/jest.js
+++ b/packages/jest-cli/src/jest.js
@@ -34,7 +34,7 @@ const sane = require('sane');
 const which = require('which');
 const TestWatcher = require('./TestWatcher');
 
-const CLEAR = '\x1B[2J\x1B[H';
+const CLEAR = '\x1B[3J\x1B[H';
 const VERSION = require('../package.json').version;
 const WATCHER_DEBOUNCE = 200;
 const WATCHMAN_BIN = 'watchman';

--- a/packages/jest-cli/src/jest.js
+++ b/packages/jest-cli/src/jest.js
@@ -34,7 +34,7 @@ const sane = require('sane');
 const which = require('which');
 const TestWatcher = require('./TestWatcher');
 
-const CLEAR = process.platform === 'win32' ? '\x1Bc' : '\x1B[3J\x1B[H';
+const CLEAR = process.platform === 'win32' ? '\x1Bc' : '\x1B[2J\x1B[3J\x1B[H';
 const VERSION = require('../package.json').version;
 const WATCHER_DEBOUNCE = 200;
 const WATCHMAN_BIN = 'watchman';


### PR DESCRIPTION
simply tweak clear codes and check 'em in different envs
main purpose was to clear scrollback buffer, instead of just clearing screen

**Summary**

clear scroll back on watch mode. helps a lot if you have output which you want to scroll up

**Test plan**

tested with this diff just to show that I have patched version of jest running:
```diff
diff --git a/packages/jest-cli/src/jest.js b/packages/jest-cli/src/jest.js
index f499dd3..77ff3e1 100644
--- a/packages/jest-cli/src/jest.js
+++ b/packages/jest-cli/src/jest.js
@@ -285,6 +285,7 @@ const runCLI = (
   argv = argv || {};
   if (argv.version) {
     pipe.write(`v${VERSION}\n`);
+    pipe.write(`PATCHED VERSION FROM 1861-clr-scroll-on-watch\n`);
     onComplete && onComplete();
     return;
   }
```

on each test, I have to add `jest/packages` to `NODE_PATH` and do `npm link` inside of `jest/packages/jest-cli`, to make patched `jest` available globally

then run `jest --version` just to ensure that I'm running my patched version, and then, finally, run `jest --watch` 

checked on:
* OS X with zsh
* Windows 7 with cmd
* Ubuntu with bash

(sorry, no videos nor gifs. removed them)


I think I have not break anything with this change. However, windows 10 with powershell is untested. Do you want me to test it also, @cpojer ?

And, cc @gaearon , please take a look on this PR.

__P.S.__ However, I don't have GUI Linux and can't check on it... 