### PR TITLE
Do not force push to gh-pages, a protected branch

### DIFF
--- a/website/publish-gh-pages.js
+++ b/website/publish-gh-pages.js
@@ -47,7 +47,7 @@ cd(`build/${CIRCLE_PROJECT_REPONAME}-gh-pages`)
 
 exec(`git add --all`);
 exec(`git commit -m "update website"`)
-exec(`git push -f https://${GIT_USER}@github.com/${DEPLOY_USER}/${CIRCLE_PROJECT_REPONAME}.git gh-pages`)
+exec(`git push origin gh-pages`)
 cd(`../..`);
 
 echo(`Website is live at: https://${CIRCLE_PROJECT_USERNAME}.github.io/${CIRCLE_PROJECT_REPONAME}/`)


### PR DESCRIPTION
Do a regular `git push` to origin. `gh-pages` is a protected branch in `facebook/jest`.

** Test plan **

Not tested. See https://circleci.com/gh/facebook/jest/3 where the current script failed on `facebook/jest` due to the use of `-f`. This script was based on [React Native's](https://github.com/facebook/react-native/blob/master/website/publish-gh-pages.js#L132) which also does not use `-f`. git pushing to `origin` should effectively push to "jest-bot@github.com/facebook/jest.git" as this is the repo that was checked out earlier in the script.