### PR TITLE
Pass correct args to makeConcurrent's originalFn while catching error

### DIFF
--- a/packages/jest-jasmine2/src/jasmine-async.js
+++ b/packages/jest-jasmine2/src/jasmine-async.js
@@ -90,7 +90,7 @@ function makeConcurrent(originalFn: Function, env) {
         );
       }
     } catch (error) {
-      return originalFn.call(env, Promise.reject(error));
+      return originalFn.call(env, specName, () => Promise.reject(error));
     }
 
     return originalFn.call(env, specName, () => promise, timeout);


### PR DESCRIPTION
**Summary**
Fixes #1868 

`it.concurrent` fails to report handled error due to mismatched arguments being passed to `originalFn` in `makeConcurrent()` which ends up throwing UnhandledPromiseRejectionWarning.

**Test plan**
Pass correct arguments to function.

**Before**
<img width="560" alt="screen shot 2016-12-07 at 12 21 55" src="https://cloud.githubusercontent.com/assets/5106466/20965820/d3037736-bc77-11e6-9a79-485f5d166aab.png">

**After**
<img width="560" alt="screen shot 2016-12-07 at 12 22 12" src="https://cloud.githubusercontent.com/assets/5106466/20965821/d3183540-bc77-11e6-9afb-6de804af27ca.png">
