### PR TITLE
rename jsonOutputFile to outputFile

### DIFF
--- a/integration_tests/__tests__/json_reporter-test.js
+++ b/integration_tests/__tests__/json_reporter-test.js
@@ -29,7 +29,7 @@ describe('JSON Reporter', () => {
   it('writes test result to sum.result.json', () => {
     let jsonResult;
 
-    runJest('json_reporter', ['--json', `--jsonOutputFile=${outputFileName}`]);
+    runJest('json_reporter', ['--json', `--outputFile=${outputFileName}`]);
     const testOutput = fs.readFileSync(outputFilePath, 'utf8');
 
     try {

--- a/packages/jest-cli/src/cli/args.js
+++ b/packages/jest-cli/src/cli/args.js
@@ -125,11 +125,6 @@ const options = {
       'other test output and user messages to stderr.',
     type: 'boolean',
   },
-  jsonOutputFile: {
-    description:
-      'Write test results to a file when the --json option is also specified.',
-    type: 'string',
-  },
   lastCommit: {
     default: false,
     description:
@@ -166,6 +161,11 @@ const options = {
       'changed in the current repository. Only works if you\'re running ' +
       'tests in a git repository at the moment.',
     type: 'boolean',
+  },
+  outputFile: {
+    description:
+      'Write test results to a file when the --json option is also specified.',
+    type: 'string',
   },
   runInBand: {
     alias: 'i',

--- a/packages/jest-cli/src/jest.js
+++ b/packages/jest-cli/src/jest.js
@@ -232,8 +232,8 @@ const runJest = (config, argv, pipe, testWatcher, onComplete) => {
           processor(runResults);
         }
         if (argv.json) {
-          if (argv.jsonOutputFile) {
-            const outputFile = path.resolve(process.cwd(), argv.jsonOutputFile);
+          if (argv.outputFile) {
+            const outputFile = path.resolve(process.cwd(), argv.outputFile);
 
             fs.writeFileSync(
               outputFile,


### PR DESCRIPTION
**Summary**
Renamed `jsonOutputFile` to `outputFile`
`jsonOutputFile` is only used with the `json` parameter, besides it would be better to make it more generic if we plan to support different formats

**Test plan**
```
yarn cache clean
yarn install
yarn test
```

