### PR TITLE
Fix file transformer example

### DIFF
--- a/docs/TutorialWebpack.md
+++ b/docs/TutorialWebpack.md
@@ -106,10 +106,7 @@ const path = require('path');
 
 module.exports = {
   process(src, filename, config, options) {
-    return "module.exports = '" + path.basename(filename) + "';";
-  },
-  getCacheKey(fileData, filename, configString, options) {
-    return filename;
+    return 'module.exports = ' + JSON.stringify(path.basename(filename)) + ';';
   },
 };
 ```


### PR DESCRIPTION
1. Uses `JSON.stringify()` so that quotes in the filename don't kill it.
2. Removes `getCacheKey()` because this example is broken in my testing with it if it just returns `filename`. Perhaps we need to hash the result of this call? I have a reeaaaaly long path of the temp folder as a result, and Jest errors failing to create a cache at that location.