### PR TITLE
Properly resolve config options.

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -70,8 +70,8 @@ These options let you control Jest's behavior in your `package.json` file. The J
   - [`testRunner` [string]](#testrunner-string)
   - [`testURL` [string]](#testurl-string)
   - [`timers` [string]](#timers-string)
-  - [`transform` [object<string, string>]](#transform-object-string-string)  
-  - [`transformIgnorePatterns` [array<string>]](#transformignorepatterns-array-string)  
+  - [`transform` [object<string, string>]](#transform-object-string-string)
+  - [`transformIgnorePatterns` [array<string>]](#transformignorepatterns-array-string)
   - [`unmockedModulePathPatterns` [array<string>]](#unmockedmodulepathpatterns-array-string)
   - [`verbose` [boolean]](#verbose-boolean)
 
@@ -314,7 +314,7 @@ follows:
 {
   ...
   "jest": {
-    "snapshotSerializers": ["<rootDir>/node_modules/my-serializer-module"]
+    "snapshotSerializers": ["my-serializer-module"]
   }
 }
 ```

--- a/integration_tests/snapshot-serializers/package.json
+++ b/integration_tests/snapshot-serializers/package.json
@@ -2,7 +2,7 @@
   "jest": {
     "testEnvironment": "node",
     "snapshotSerializers": [
-      "<rootDir>/plugins/foo",
+      "./plugins/foo",
       "<rootDir>/plugins/bar"
     ]
   }

--- a/integration_tests/snapshot-serializers/plugins/foo/index.js
+++ b/integration_tests/snapshot-serializers/plugins/foo/index.js
@@ -8,5 +8,5 @@
  */
 'use strict';
 
-const createPlugin = require('../utils').createPlugin;
+const createPlugin = require('../../utils').createPlugin;
 module.exports = createPlugin('foo');

--- a/packages/jest-config/src/__tests__/__snapshots__/normalize-test.js.snap
+++ b/packages/jest-config/src/__tests__/__snapshots__/normalize-test.js.snap
@@ -1,4 +1,4 @@
-exports[`normalize Upgrade help logs a warning when \`scriptPreprocessor\` and/or \`preprocessorIgnorePatterns\` are used 1`] = `
+exports[`Upgrade help logs a warning when \`scriptPreprocessor\` and/or \`preprocessorIgnorePatterns\` are used 1`] = `
 "[33m[1m● [22mThe settings \`scriptPreprocessor\` and \`preprocessorIgnorePatterns\` were replaced by \`transform\` and \`transformIgnorePatterns\` which support multiple preprocessors.
 
   Jest now treats your current settings as: 

--- a/packages/jest-config/src/__tests__/normalize-test.js
+++ b/packages/jest-config/src/__tests__/normalize-test.js
@@ -10,6 +10,8 @@
 
 jest.mock('jest-resolve');
 
+jest.mock('path', () => require.requireActual('path').posix);
+
 const path = require('path');
 const utils = require('jest-util');
 const normalize = require('../normalize');
@@ -17,634 +19,599 @@ const normalize = require('../normalize');
 const DEFAULT_JS_PATTERN = require('../constants').DEFAULT_JS_PATTERN;
 const DEFAULT_CSS_PATTERN = '^.+\\.(css)$';
 
-describe('normalize', () => {
-  let root;
-  let expectedPathFooBar;
-  let expectedPathFooQux;
-  let expectedPathAbs;
-  let expectedPathAbsAnother;
+let root;
+let expectedPathFooBar;
+let expectedPathFooQux;
+let expectedPathAbs;
+let expectedPathAbsAnother;
 
-  // Windows uses backslashes for path separators, which need to be escaped in
-  // regular expressions. This little helper function helps us generate the
-  // expected strings for checking path patterns.
-  function joinForPattern() {
-    return Array.prototype.join.call(
-      arguments,
-      utils.escapeStrForRegex(path.sep),
+// Windows uses backslashes for path separators, which need to be escaped in
+// regular expressions. This little helper function helps us generate the
+// expected strings for checking path patterns.
+function joinForPattern() {
+  return Array.prototype.join.call(
+    arguments,
+    utils.escapeStrForRegex(path.sep),
+  );
+}
+
+beforeEach(() => {
+  root = path.resolve('/');
+  expectedPathFooBar = path.join(root, 'root', 'path', 'foo', 'bar', 'baz');
+  expectedPathFooQux = path.join(root, 'root', 'path', 'foo', 'qux', 'quux');
+  expectedPathAbs = path.join(root, 'an', 'abs', 'path');
+  expectedPathAbsAnother = path.join(root, 'another', 'abs', 'path');
+});
+
+it('errors when an invalid config option is passed in', () => {
+  const error = console.error;
+  console.error = jest.fn();
+  normalize({
+    rootDir: '/root/path/foo',
+    thisIsAnInvalidConfigKey: 'with a value even!',
+  });
+
+  expect(console.error).toBeCalledWith(
+    'Error: Unknown config option "thisIsAnInvalidConfigKey" with value ' +
+    '"with a value even!". This is either a typing error or a user ' +
+    'mistake and fixing it will remove this message.',
+  );
+
+  console.error = error;
+});
+
+it('picks a name based on the rootDir', () => {
+  expect(normalize({
+    rootDir: '/root/path/foo',
+  }).name).toBe('-root-path-foo');
+});
+
+it('keeps custom names based on the rootDir', () => {
+  expect(normalize({
+    name: 'custom-name',
+    rootDir: '/root/path/foo',
+  }).name).toBe('custom-name');
+});
+
+it('sets coverageReporters correctly when argv.json is set', () => {
+  expect(normalize({
+    rootDir: '/root/path/foo',
+  }, {json: true}).coverageReporters).toEqual(['json', 'lcov', 'clover']);
+});
+
+describe('rootDir', () => {
+  it('throws if the config is missing a rootDir property', () => {
+    expect(() => {
+      normalize({});
+    }).toThrow(new Error(`Jest: 'rootDir' config value must be specified.`));
+  });
+});
+
+describe('automock', () => {
+  it('falsy automock is not overwritten', () => {
+    const consoleWarn = console.warn;
+    console.warn = jest.fn();
+    const config = normalize({
+      automock: false,
+      rootDir: '/root/path/foo',
+    });
+
+    expect(config.automock).toBe(false);
+
+    console.warn = consoleWarn;
+  });
+});
+
+describe('browser', () => {
+  it('falsy browser is not overwritten', () => {
+    const config = normalize({
+      browser: true,
+      rootDir: '/root/path/foo',
+    });
+
+    expect(config.browser).toBe(true);
+  });
+});
+
+describe('collectCoverageOnlyFrom', () => {
+  it('normalizes all paths relative to rootDir', () => {
+    const config = normalize({
+      collectCoverageOnlyFrom: {
+        'bar/baz': true,
+        'qux/quux/': true,
+      },
+      rootDir: '/root/path/foo/',
+    }, '/root/path');
+
+    const expected = {};
+    expected[expectedPathFooBar] = true;
+    expected[expectedPathFooQux] = true;
+
+    expect(config.collectCoverageOnlyFrom).toEqual(expected);
+  });
+
+  it('does not change absolute paths', () => {
+    const config = normalize({
+      collectCoverageOnlyFrom: {
+        '/an/abs/path': true,
+        '/another/abs/path': true,
+      },
+      rootDir: '/root/path/foo',
+    });
+
+    const expected = {};
+    expected[expectedPathAbs] = true;
+    expected[expectedPathAbsAnother] = true;
+
+    expect(config.collectCoverageOnlyFrom).toEqual(expected);
+  });
+
+  it('substitutes <rootDir> tokens', () => {
+    const config = normalize({
+      collectCoverageOnlyFrom: {
+        '<rootDir>/bar/baz': true,
+      },
+      rootDir: '/root/path/foo',
+    });
+
+    const expected = {};
+    expected[expectedPathFooBar] = true;
+
+    expect(config.collectCoverageOnlyFrom).toEqual(expected);
+  });
+});
+
+function testPathArray(key) {
+  it('normalizes all paths relative to rootDir', () => {
+    const config = normalize({
+      [key]: [
+        'bar/baz',
+        'qux/quux/',
+      ],
+      rootDir: '/root/path/foo',
+    }, '/root/path');
+
+    expect(config[key]).toEqual([
+      expectedPathFooBar, expectedPathFooQux,
+    ]);
+  });
+
+  it('does not change absolute paths', () => {
+    const config = normalize({
+      [key]: [
+        '/an/abs/path',
+        '/another/abs/path',
+      ],
+      rootDir: '/root/path/foo',
+    });
+
+    expect(config[key]).toEqual([
+      expectedPathAbs, expectedPathAbsAnother,
+    ]);
+  });
+
+  it('substitutes <rootDir> tokens', () => {
+    const config = normalize({
+      [key]: [
+        '<rootDir>/bar/baz',
+      ],
+      rootDir: '/root/path/foo',
+    });
+
+    expect(config[key]).toEqual([expectedPathFooBar]);
+  });
+}
+
+describe('testPathDirs', () => {
+  testPathArray('testPathDirs');
+});
+
+describe('transform', () => {
+  let Resolver;
+  beforeEach(() => {
+    Resolver = require('jest-resolve');
+    Resolver.findNodeModule = jest.fn(name => name);
+  });
+
+  it('normalizes the path', () => {
+    const config = normalize({
+      rootDir: '/root/',
+      transform: {
+        [DEFAULT_CSS_PATTERN]: '<rootDir>/node_modules/jest-util',
+        [DEFAULT_JS_PATTERN]: 'babel-jest',
+        'abs-path': '/qux/quux',
+      },
+    }, '/root/path');
+
+    expect(config.transform).toEqual([
+      [DEFAULT_CSS_PATTERN, '/root/node_modules/jest-util'],
+      [DEFAULT_JS_PATTERN, 'babel-jest'],
+      ['abs-path', '/qux/quux'],
+    ]);
+  });
+});
+
+describe('setupTestFrameworkScriptFile', () => {
+  let Resolver;
+  beforeEach(() => {
+    Resolver = require('jest-resolve');
+    Resolver.findNodeModule = jest.fn(
+      name => name.startsWith('/') ? name : '/root/path/foo' + path.sep + name,
     );
-  }
+  });
 
-  // this helper takes a path starting from root and normalize it to unix style
-  function uniformPath(pathToUniform) {
-    const resolved = path.resolve(pathToUniform);
-    return '/' + resolved.replace(root, '').split(path.sep).join('/');
-  }
+  it('normalizes the path according to rootDir', () => {
+    const config = normalize({
+      rootDir: '/root/path/foo',
+      setupTestFrameworkScriptFile: 'bar/baz',
+    }, '/root/path');
+
+    expect(config.setupTestFrameworkScriptFile).toEqual(expectedPathFooBar);
+  });
+
+  it('does not change absolute paths', () => {
+    const config = normalize({
+      rootDir: '/root/path/foo',
+      setupTestFrameworkScriptFile: '/an/abs/path',
+    });
+
+    expect(config.setupTestFrameworkScriptFile).toEqual(expectedPathAbs);
+  });
+
+  it('substitutes <rootDir> tokens', () => {
+    const config = normalize({
+      rootDir: '/root/path/foo',
+      setupTestFrameworkScriptFile: '<rootDir>/bar/baz',
+    });
+
+    expect(config.setupTestFrameworkScriptFile).toEqual(expectedPathFooBar);
+  });
+});
+
+describe('setupTestFrameworkScriptFile', () => {
+  it('normalizes the path according to rootDir', () => {
+    const config = normalize({
+      rootDir: '/root/path/foo',
+      setupTestFrameworkScriptFile: 'bar/baz',
+    }, '/root/path');
+
+    expect(config.setupTestFrameworkScriptFile).toEqual(expectedPathFooBar);
+  });
+
+  it('does not change absolute paths', () => {
+    const config = normalize({
+      rootDir: '/root/path/foo',
+      setupTestFrameworkScriptFile: '/an/abs/path',
+    });
+
+    expect(config.setupTestFrameworkScriptFile).toEqual(expectedPathAbs);
+  });
+
+  it('substitutes <rootDir> tokens', () => {
+    const config = normalize({
+      rootDir: '/root/path/foo',
+      setupTestFrameworkScriptFile: '<rootDir>/bar/baz',
+    });
+
+    expect(config.setupTestFrameworkScriptFile).toEqual(expectedPathFooBar);
+  });
+});
+
+describe('coveragePathIgnorePatterns', () => {
+  it('does not normalize paths relative to rootDir', () => {
+    // This is a list of patterns, so we can't assume any of them are
+    // directories
+    const config = normalize({
+      coveragePathIgnorePatterns: [
+        'bar/baz',
+        'qux/quux',
+      ],
+      rootDir: '/root/path/foo',
+    }, '/root/path');
+
+    expect(config.coveragePathIgnorePatterns).toEqual([
+      joinForPattern('bar', 'baz'),
+      joinForPattern('qux', 'quux'),
+    ]);
+  });
+
+  it('does not normalize trailing slashes', () => {
+    // This is a list of patterns, so we can't assume any of them are
+    // directories
+    const config = normalize({
+      coveragePathIgnorePatterns: [
+        'bar/baz',
+        'qux/quux/',
+      ],
+      rootDir: '/root/path/foo',
+    });
+
+    expect(config.coveragePathIgnorePatterns).toEqual([
+      joinForPattern('bar', 'baz'),
+      joinForPattern('qux', 'quux', ''),
+    ]);
+  });
+
+  it('substitutes <rootDir> tokens', () => {
+    const config = normalize({
+      coveragePathIgnorePatterns: [
+        'hasNoToken',
+        '<rootDir>/hasAToken',
+      ],
+      rootDir: '/root/path/foo',
+    });
+
+    expect(config.coveragePathIgnorePatterns).toEqual([
+      'hasNoToken',
+      joinForPattern('', 'root', 'path', 'foo', 'hasAToken'),
+    ]);
+  });
+});
+
+describe('testPathIgnorePatterns', () => {
+  it('does not normalize paths relative to rootDir', () => {
+    // This is a list of patterns, so we can't assume any of them are
+    // directories
+    const config = normalize({
+      rootDir: '/root/path/foo',
+      testPathIgnorePatterns: [
+        'bar/baz',
+        'qux/quux',
+      ],
+    }, '/root/path');
+
+    expect(config.testPathIgnorePatterns).toEqual([
+      joinForPattern('bar', 'baz'),
+      joinForPattern('qux', 'quux'),
+    ]);
+  });
+
+  it('does not normalize trailing slashes', () => {
+    // This is a list of patterns, so we can't assume any of them are
+    // directories
+    const config = normalize({
+      rootDir: '/root/path/foo',
+      testPathIgnorePatterns: [
+        'bar/baz',
+        'qux/quux/',
+      ],
+    });
+
+    expect(config.testPathIgnorePatterns).toEqual([
+      joinForPattern('bar', 'baz'),
+      joinForPattern('qux', 'quux', ''),
+    ]);
+  });
+
+  it('substitutes <rootDir> tokens', () => {
+    const config = normalize({
+      rootDir: '/root/path/foo',
+      testPathIgnorePatterns: [
+        'hasNoToken',
+        '<rootDir>/hasAToken',
+      ],
+    });
+
+    expect(config.testPathIgnorePatterns).toEqual([
+      'hasNoToken',
+      joinForPattern('', 'root', 'path', 'foo', 'hasAToken'),
+    ]);
+  });
+});
+
+describe('modulePathIgnorePatterns', () => {
+  it('does not normalize paths relative to rootDir', () => {
+    // This is a list of patterns, so we can't assume any of them are
+    // directories
+    const config = normalize({
+      modulePathIgnorePatterns: [
+        'bar/baz',
+        'qux/quux',
+      ],
+      rootDir: '/root/path/foo',
+    }, '/root/path');
+
+    expect(config.modulePathIgnorePatterns).toEqual([
+      joinForPattern('bar', 'baz'),
+      joinForPattern('qux', 'quux'),
+    ]);
+  });
+
+  it('does not normalize trailing slashes', () => {
+    // This is a list of patterns, so we can't assume any of them are
+    // directories
+    const config = normalize({
+      modulePathIgnorePatterns: [
+        'bar/baz',
+        'qux/quux/',
+      ],
+      rootDir: '/root/path/foo',
+    });
+
+    expect(config.modulePathIgnorePatterns).toEqual([
+      joinForPattern('bar', 'baz'),
+      joinForPattern('qux', 'quux', ''),
+    ]);
+  });
+
+  it('substitutes <rootDir> tokens', () => {
+    const config = normalize({
+      modulePathIgnorePatterns: [
+        'hasNoToken',
+        '<rootDir>/hasAToken',
+      ],
+      rootDir: '/root/path/foo',
+    });
+
+    expect(config.modulePathIgnorePatterns).toEqual([
+      'hasNoToken',
+      joinForPattern('', 'root', 'path', 'foo', 'hasAToken'),
+    ]);
+  });
+});
+
+describe('testRunner', () => {
+  it('defaults to Jasmine 2', () => {
+    const config = normalize({
+      rootDir: '/root/path/foo',
+    });
+
+    expect(config.testRunner).toMatch('jasmine2');
+  });
+
+  it('can be changed to jasmine1', () => {
+    const config = normalize({
+      rootDir: '/root/path/foo',
+      testRunner: 'jasmine1',
+    });
+
+    expect(config.testRunner).toMatch('jasmine1');
+  });
+
+  it('is overwritten by argv', () => {
+    const config = normalize(
+      {
+        rootDir: '/root/path/foo',
+      },
+      {
+        testRunner: 'jasmine1',
+      },
+    );
+
+    expect(config.testRunner).toMatch('jasmine1');
+  });
+});
+
+describe('testEnvironment', () => {
+  let Resolver;
+  beforeEach(() => {
+    Resolver = require('jest-resolve');
+    Resolver.findNodeModule = jest.fn(name => {
+      if (name === 'jsdom') {
+        return 'node_modules/jsdom';
+      }
+      if (name === 'jest-environment-jsdom') {
+        return 'node_modules/jest-environment-jsdom';
+      }
+      return null;
+    });
+  });
+
+  it('resolves to an environment and prefers jest-environment-`name`', () => {
+    const config = normalize({
+      rootDir: '/root',
+      testEnvironment: 'jsdom',
+    });
+
+    expect(config.testEnvironment)
+      .toEqual('node_modules/jest-environment-jsdom');
+  });
+
+  it('throws on invalid environment names', () => {
+    expect(() => normalize({
+      rootDir: '/root',
+      testEnvironment: 'phantom',
+    })).toThrow(new Error(
+      `Jest: test environment "phantom" cannot be found. Make sure the ` +
+      `"testEnvironment" configuration option points to an existing node ` +
+      `module.`,
+    ));
+  });
+});
+
+describe('babel-jest', () => {
+  let Resolver;
+  beforeEach(() => {
+    Resolver = require('jest-resolve');
+    Resolver.findNodeModule = jest.fn(
+      name => '/node_modules' + path.sep + name,
+    );
+  });
+
+  it('correctly identifies and uses babel-jest', () => {
+    const config = normalize({
+      rootDir: '/root',
+    });
+
+    expect(config.transform[0][0]).toBe(DEFAULT_JS_PATTERN);
+    expect(config.transform[0][1])
+      .toEqual('/node_modules' + path.sep + 'babel-jest');
+    expect(config.setupFiles)
+      .toEqual(['/node_modules' + path.sep + 'babel-polyfill']);
+  });
+
+  it('uses babel-jest if babel-jest is explicitly specified in a custom transform config', () => {
+    const customJSPattern = '^.+\\.js$';
+    const config = normalize({
+      rootDir: '/root',
+      transform: {
+        [customJSPattern]: 'babel-jest',
+      },
+    });
+
+    expect(config.transform[0][0]).toBe(customJSPattern);
+    expect(config.transform[0][1]).toEqual('/node_modules/babel-jest');
+    expect(config.setupFiles)
+      .toEqual(['/node_modules' + path.sep + 'babel-polyfill']);
+  });
+
+  it(`doesn't use babel-jest if its not available`, () => {
+    Resolver.findNodeModule.mockImplementation(() => null);
+
+    const config = normalize({
+      rootDir: '/root',
+    });
+
+    expect(config.transform).toEqual(undefined);
+    expect(config.setupFiles).toEqual([]);
+  });
+
+  it('uses polyfills if babel-jest is explicitly specified', () => {
+    const ROOT_DIR = '<rootDir>' + path.sep;
+
+    const config = normalize({
+      rootDir: '/root',
+      transform: {
+        [DEFAULT_JS_PATTERN]: ROOT_DIR + Resolver.findNodeModule(
+          'babel-jest',
+        ),
+      },
+    });
+
+    expect(config.setupFiles)
+      .toEqual(['/node_modules' + path.sep + 'babel-polyfill']);
+  });
+});
+
+describe('Upgrade help', () => {
+
+  let consoleWarn;
 
   beforeEach(() => {
-    root = path.resolve('/');
-    expectedPathFooBar = path.join(root, 'root', 'path', 'foo', 'bar', 'baz');
-    expectedPathFooQux = path.join(root, 'root', 'path', 'foo', 'qux', 'quux');
-    expectedPathAbs = path.join(root, 'an', 'abs', 'path');
-    expectedPathAbsAnother = path.join(root, 'another', 'abs', 'path');
+    consoleWarn = console.warn;
+    console.warn = jest.fn();
   });
 
-  it('errors when an invalid config option is passed in', () => {
-    const error = console.error;
-    console.error = jest.fn();
-    normalize({
+  afterEach(() => {
+    console.warn = consoleWarn;
+  });
+
+  it('logs a warning when `scriptPreprocessor` and/or `preprocessorIgnorePatterns` are used', () => {
+    const config = normalize({
+      preprocessorIgnorePatterns: ['bar/baz', 'qux/quux'],
       rootDir: '/root/path/foo',
-      thisIsAnInvalidConfigKey: 'with a value even!',
+      scriptPreprocessor: 'bar/baz',
     });
 
-    expect(console.error).toBeCalledWith(
-      'Error: Unknown config option "thisIsAnInvalidConfigKey" with value ' +
-      '"with a value even!". This is either a typing error or a user ' +
-      'mistake and fixing it will remove this message.',
-    );
+    expect(config.transform).toEqual([['.*', '/node_modules/bar/baz']]);
+    expect(config.transformIgnorePatterns).toEqual([
+      joinForPattern('bar', 'baz'),
+      joinForPattern('qux', 'quux'),
+    ]);
 
-    console.error = error;
+    expect(config.scriptPreprocessor).toBe(undefined);
+    expect(config.preprocessorIgnorePatterns).toBe(undefined);
+
+    expect(console.warn.mock.calls[0][0]).toMatchSnapshot();
   });
-
-  it('picks a name based on the rootDir', () => {
-    expect(normalize({
-      rootDir: '/root/path/foo',
-    }).name).toBe('-root-path-foo');
-  });
-
-  it('keeps custom names based on the rootDir', () => {
-    expect(normalize({
-      name: 'custom-name',
-      rootDir: '/root/path/foo',
-    }).name).toBe('custom-name');
-  });
-
-  it('sets coverageReporters correctly when argv.json is set', () => {
-    expect(normalize({
-      rootDir: '/root/path/foo',
-    }, {json: true}).coverageReporters).toEqual(['json', 'lcov', 'clover']);
-  });
-
-  describe('rootDir', () => {
-    it('throws if the config is missing a rootDir property', () => {
-      expect(() => {
-        normalize({});
-      }).toThrow(new Error(`Jest: 'rootDir' config value must be specified.`));
-    });
-  });
-
-  describe('automock', () => {
-    it('falsy automock is not overwritten', () => {
-      const consoleWarn = console.warn;
-      console.warn = jest.fn();
-      const config = normalize({
-        automock: false,
-        rootDir: '/root/path/foo',
-      });
-
-      expect(config.automock).toBe(false);
-
-      console.warn = consoleWarn;
-    });
-  });
-
-  describe('browser', () => {
-    it('falsy browser is not overwritten', () => {
-      const config = normalize({
-        browser: true,
-        rootDir: '/root/path/foo',
-      });
-
-      expect(config.browser).toBe(true);
-    });
-  });
-
-  describe('collectCoverageOnlyFrom', () => {
-    it('normalizes all paths relative to rootDir', () => {
-      const config = normalize({
-        collectCoverageOnlyFrom: {
-          'bar/baz': true,
-          'qux/quux/': true,
-        },
-        rootDir: '/root/path/foo/',
-      }, '/root/path');
-
-      const expected = {};
-      expected[expectedPathFooBar] = true;
-      expected[expectedPathFooQux] = true;
-
-      expect(config.collectCoverageOnlyFrom).toEqual(expected);
-    });
-
-    it('does not change absolute paths', () => {
-      const config = normalize({
-        collectCoverageOnlyFrom: {
-          '/an/abs/path': true,
-          '/another/abs/path': true,
-        },
-        rootDir: '/root/path/foo',
-      });
-
-      const expected = {};
-      expected[expectedPathAbs] = true;
-      expected[expectedPathAbsAnother] = true;
-
-      expect(config.collectCoverageOnlyFrom).toEqual(expected);
-    });
-
-    it('substitutes <rootDir> tokens', () => {
-      const config = normalize({
-        collectCoverageOnlyFrom: {
-          '<rootDir>/bar/baz': true,
-        },
-        rootDir: '/root/path/foo',
-      });
-
-      const expected = {};
-      expected[expectedPathFooBar] = true;
-
-      expect(config.collectCoverageOnlyFrom).toEqual(expected);
-    });
-  });
-
-  function testPathArray(key) {
-    it('normalizes all paths relative to rootDir', () => {
-      const config = normalize({
-        [key]: [
-          'bar/baz',
-          'qux/quux/',
-        ],
-        rootDir: '/root/path/foo',
-      }, '/root/path');
-
-      expect(config[key]).toEqual([
-        expectedPathFooBar, expectedPathFooQux,
-      ]);
-    });
-
-    it('does not change absolute paths', () => {
-      const config = normalize({
-        [key]: [
-          '/an/abs/path',
-          '/another/abs/path',
-        ],
-        rootDir: '/root/path/foo',
-      });
-
-      expect(config[key]).toEqual([
-        expectedPathAbs, expectedPathAbsAnother,
-      ]);
-    });
-
-    it('substitutes <rootDir> tokens', () => {
-      const config = normalize({
-        [key]: [
-          '<rootDir>/bar/baz',
-        ],
-        rootDir: '/root/path/foo',
-      });
-
-      expect(config[key]).toEqual([expectedPathFooBar]);
-    });
-  }
-
-  describe('testPathDirs', () => {
-    testPathArray('testPathDirs');
-  });
-
-  describe('snapshotSerializers', () => {
-    testPathArray('snapshotSerializers');
-  });
-
-  describe('transform', () => {
-    it('normalizes the path according to rootDir', () => {
-      const config = normalize({
-        rootDir: '/root/path/foo',
-        transform: {
-          [DEFAULT_CSS_PATTERN]: 'qux/quux',
-          [DEFAULT_JS_PATTERN]: 'bar/baz',
-        },
-      }, '/root/path');
-
-      expect(config.transform).toEqual([
-        [DEFAULT_CSS_PATTERN, expectedPathFooQux],
-        [DEFAULT_JS_PATTERN, expectedPathFooBar],
-      ]);
-    });
-
-    it('does not change absolute paths', () => {
-      const config = normalize({
-        rootDir: '/root/path/foo',
-        transform: {
-          [DEFAULT_CSS_PATTERN]: '/an/abs/path',
-          [DEFAULT_JS_PATTERN]: '/an/abs/path',
-        },
-      });
-
-      expect(config.transform).toEqual([
-        [DEFAULT_CSS_PATTERN, expectedPathAbs],
-        [DEFAULT_JS_PATTERN, expectedPathAbs],
-      ]);
-    });
-
-    it('substitutes <rootDir> tokens', () => {
-      const config = normalize({
-        rootDir: '/root/path/foo',
-        transform: {
-          [DEFAULT_CSS_PATTERN]: '<rootDir>/qux/quux',
-          [DEFAULT_JS_PATTERN]: '<rootDir>/bar/baz',
-        },
-      });
-
-      expect(config.transform).toEqual([
-        [DEFAULT_CSS_PATTERN, expectedPathFooQux],
-        [DEFAULT_JS_PATTERN, expectedPathFooBar],
-      ]);
-    });
-  });
-
-  describe('setupTestFrameworkScriptFile', () => {
-    it('normalizes the path according to rootDir', () => {
-      const config = normalize({
-        rootDir: '/root/path/foo',
-        setupTestFrameworkScriptFile: 'bar/baz',
-      }, '/root/path');
-
-      expect(config.setupTestFrameworkScriptFile).toEqual(expectedPathFooBar);
-    });
-
-    it('does not change absolute paths', () => {
-      const config = normalize({
-        rootDir: '/root/path/foo',
-        setupTestFrameworkScriptFile: '/an/abs/path',
-      });
-
-      expect(config.setupTestFrameworkScriptFile).toEqual(expectedPathAbs);
-    });
-
-    it('substitutes <rootDir> tokens', () => {
-      const config = normalize({
-        rootDir: '/root/path/foo',
-        setupTestFrameworkScriptFile: '<rootDir>/bar/baz',
-      });
-
-      expect(config.setupTestFrameworkScriptFile).toEqual(expectedPathFooBar);
-    });
-  });
-
-  describe('setupTestFrameworkScriptFile', () => {
-    it('normalizes the path according to rootDir', () => {
-      const config = normalize({
-        rootDir: '/root/path/foo',
-        setupTestFrameworkScriptFile: 'bar/baz',
-      }, '/root/path');
-
-      expect(config.setupTestFrameworkScriptFile).toEqual(expectedPathFooBar);
-    });
-
-    it('does not change absolute paths', () => {
-      const config = normalize({
-        rootDir: '/root/path/foo',
-        setupTestFrameworkScriptFile: '/an/abs/path',
-      });
-
-      expect(config.setupTestFrameworkScriptFile).toEqual(expectedPathAbs);
-    });
-
-    it('substitutes <rootDir> tokens', () => {
-      const config = normalize({
-        rootDir: '/root/path/foo',
-        setupTestFrameworkScriptFile: '<rootDir>/bar/baz',
-      });
-
-      expect(config.setupTestFrameworkScriptFile).toEqual(expectedPathFooBar);
-    });
-  });
-
-  describe('coveragePathIgnorePatterns', () => {
-    it('does not normalize paths relative to rootDir', () => {
-      // This is a list of patterns, so we can't assume any of them are
-      // directories
-      const config = normalize({
-        coveragePathIgnorePatterns: [
-          'bar/baz',
-          'qux/quux',
-        ],
-        rootDir: '/root/path/foo',
-      }, '/root/path');
-
-      expect(config.coveragePathIgnorePatterns).toEqual([
-        joinForPattern('bar', 'baz'),
-        joinForPattern('qux', 'quux'),
-      ]);
-    });
-
-    it('does not normalize trailing slashes', () => {
-      // This is a list of patterns, so we can't assume any of them are
-      // directories
-      const config = normalize({
-        coveragePathIgnorePatterns: [
-          'bar/baz',
-          'qux/quux/',
-        ],
-        rootDir: '/root/path/foo',
-      });
-
-      expect(config.coveragePathIgnorePatterns).toEqual([
-        joinForPattern('bar', 'baz'),
-        joinForPattern('qux', 'quux', ''),
-      ]);
-    });
-
-    it('substitutes <rootDir> tokens', () => {
-      const config = normalize({
-        coveragePathIgnorePatterns: [
-          'hasNoToken',
-          '<rootDir>/hasAToken',
-        ],
-        rootDir: '/root/path/foo',
-      });
-
-      expect(config.coveragePathIgnorePatterns).toEqual([
-        'hasNoToken',
-        joinForPattern('', 'root', 'path', 'foo', 'hasAToken'),
-      ]);
-    });
-  });
-
-  describe('testPathIgnorePatterns', () => {
-    it('does not normalize paths relative to rootDir', () => {
-      // This is a list of patterns, so we can't assume any of them are
-      // directories
-      const config = normalize({
-        rootDir: '/root/path/foo',
-        testPathIgnorePatterns: [
-          'bar/baz',
-          'qux/quux',
-        ],
-      }, '/root/path');
-
-      expect(config.testPathIgnorePatterns).toEqual([
-        joinForPattern('bar', 'baz'),
-        joinForPattern('qux', 'quux'),
-      ]);
-    });
-
-    it('does not normalize trailing slashes', () => {
-      // This is a list of patterns, so we can't assume any of them are
-      // directories
-      const config = normalize({
-        rootDir: '/root/path/foo',
-        testPathIgnorePatterns: [
-          'bar/baz',
-          'qux/quux/',
-        ],
-      });
-
-      expect(config.testPathIgnorePatterns).toEqual([
-        joinForPattern('bar', 'baz'),
-        joinForPattern('qux', 'quux', ''),
-      ]);
-    });
-
-    it('substitutes <rootDir> tokens', () => {
-      const config = normalize({
-        rootDir: '/root/path/foo',
-        testPathIgnorePatterns: [
-          'hasNoToken',
-          '<rootDir>/hasAToken',
-        ],
-      });
-
-      expect(config.testPathIgnorePatterns).toEqual([
-        'hasNoToken',
-        joinForPattern('', 'root', 'path', 'foo', 'hasAToken'),
-      ]);
-    });
-  });
-
-  describe('modulePathIgnorePatterns', () => {
-    it('does not normalize paths relative to rootDir', () => {
-      // This is a list of patterns, so we can't assume any of them are
-      // directories
-      const config = normalize({
-        modulePathIgnorePatterns: [
-          'bar/baz',
-          'qux/quux',
-        ],
-        rootDir: '/root/path/foo',
-      }, '/root/path');
-
-      expect(config.modulePathIgnorePatterns).toEqual([
-        joinForPattern('bar', 'baz'),
-        joinForPattern('qux', 'quux'),
-      ]);
-    });
-
-    it('does not normalize trailing slashes', () => {
-      // This is a list of patterns, so we can't assume any of them are
-      // directories
-      const config = normalize({
-        modulePathIgnorePatterns: [
-          'bar/baz',
-          'qux/quux/',
-        ],
-        rootDir: '/root/path/foo',
-      });
-
-      expect(config.modulePathIgnorePatterns).toEqual([
-        joinForPattern('bar', 'baz'),
-        joinForPattern('qux', 'quux', ''),
-      ]);
-    });
-
-    it('substitutes <rootDir> tokens', () => {
-      const config = normalize({
-        modulePathIgnorePatterns: [
-          'hasNoToken',
-          '<rootDir>/hasAToken',
-        ],
-        rootDir: '/root/path/foo',
-      });
-
-      expect(config.modulePathIgnorePatterns).toEqual([
-        'hasNoToken',
-        joinForPattern('', 'root', 'path', 'foo', 'hasAToken'),
-      ]);
-    });
-  });
-
-  describe('testRunner', () => {
-    it('defaults to Jasmine 2', () => {
-      const config = normalize({
-        rootDir: '/root/path/foo',
-      });
-
-      expect(config.testRunner).toMatch('jasmine2');
-    });
-
-    it('can be changed to jasmine1', () => {
-      const config = normalize({
-        rootDir: '/root/path/foo',
-        testRunner: 'jasmine1',
-      });
-
-      expect(config.testRunner).toMatch('jasmine1');
-    });
-
-    it('is overwritten by argv', () => {
-      const config = normalize(
-        {
-          rootDir: '/root/path/foo',
-        },
-        {
-          testRunner: 'jasmine1',
-        },
-      );
-
-      expect(config.testRunner).toMatch('jasmine1');
-    });
-  });
-
-  describe('testEnvironment', () => {
-    let Resolver;
-    beforeEach(() => {
-      Resolver = require('jest-resolve');
-      Resolver.findNodeModule = jest.fn(name => {
-        if (name === 'jsdom') {
-          return 'node_modules/jsdom';
-        }
-        if (name === 'jest-environment-jsdom') {
-          return 'node_modules/jest-environment-jsdom';
-        }
-        return null;
-      });
-    });
-
-    it('resolves to an environment and prefers jest-environment-`name`', () => {
-      const config = normalize({
-        rootDir: '/root',
-        testEnvironment: 'jsdom',
-      });
-
-      expect(config.testEnvironment)
-        .toEqual('node_modules/jest-environment-jsdom');
-    });
-
-    it('throws on invalid environment names', () => {
-      expect(() => normalize({
-        rootDir: '/root',
-        testEnvironment: 'phantom',
-      })).toThrow(new Error(
-        `Jest: test environment "phantom" cannot be found. Make sure the ` +
-        `"testEnvironment" configuration option points to an existing node ` +
-        `module.`,
-      ));
-    });
-  });
-
-  describe('babel-jest', () => {
-    let Resolver;
-    beforeEach(() => {
-      Resolver = require('jest-resolve');
-      Resolver.findNodeModule = jest.fn(
-        name => 'node_modules' + path.sep + name,
-      );
-    });
-
-    it('correctly identifies and uses babel-jest', () => {
-      const config = normalize({
-        rootDir: '/root',
-      });
-
-      expect(config.usesBabelJest).toBe(true);
-      const jsTransformerPath = uniformPath(config.transform[0][1]);
-      expect(config.transform[0][0]).toBe(DEFAULT_JS_PATTERN);
-      expect(jsTransformerPath).toEqual('/root/node_modules/babel-jest');
-      expect(config.setupFiles.map(uniformPath))
-        .toEqual(['/root/node_modules/babel-polyfill']);
-    });
-
-    it('uses babel-jest if babel-jest is explicitly specified in a custom transform config', () => {
-      const customJSPattern = '^.+\\.js$';
-      const ROOT_DIR = '<rootDir>' + path.sep;
-      const config = normalize({
-        rootDir: '/root',
-        transform: {
-          [customJSPattern]: ROOT_DIR + Resolver.findNodeModule(
-            'babel-jest',
-          ),
-        },
-      });
-
-      expect(config.usesBabelJest).toBe(true);
-      const jsTransformerPath = uniformPath(config.transform[0][1]);
-      expect(config.transform[0][0]).toBe(customJSPattern);
-      expect(jsTransformerPath).toEqual('/root/node_modules/babel-jest');
-      expect(config.setupFiles.map(uniformPath))
-        .toEqual(['/root/node_modules/babel-polyfill']);
-    });
-
-    it(`doesn't use babel-jest if its not available`, () => {
-      Resolver.findNodeModule.mockImplementation(() => null);
-
-      const config = normalize({
-        rootDir: '/root',
-      });
-
-      expect(config.usesBabelJest).toEqual(undefined);
-      expect(config.transform).toEqual(undefined);
-      expect(config.setupFiles).toEqual([]);
-    });
-
-    it('uses polyfills if babel-jest is explicitly specified', () => {
-      const ROOT_DIR = '<rootDir>' + path.sep;
-
-      const config = normalize({
-        rootDir: '/root',
-        transform: {
-          [DEFAULT_JS_PATTERN]: ROOT_DIR + Resolver.findNodeModule(
-            'babel-jest',
-          ),
-        },
-      });
-
-      expect(config.usesBabelJest).toBe(true);
-      expect(config.setupFiles.map(uniformPath))
-        .toEqual(['/root/node_modules/babel-polyfill']);
-    });
-  });
-
-  describe('Upgrade help', () => {
-
-    let consoleWarn;
-
-    beforeEach(() => {
-      consoleWarn = console.warn;
-      console.warn = jest.fn();
-    });
-
-    afterEach(() => {
-      console.warn = consoleWarn;
-    });
-
-    it('logs a warning when `scriptPreprocessor` and/or `preprocessorIgnorePatterns` are used', () => {
-      const config = normalize({
-        preprocessorIgnorePatterns: ['bar/baz', 'qux/quux'],
-        rootDir: '/root/path/foo',
-        scriptPreprocessor: 'bar/baz',
-      });
-
-      expect(config.transform).toEqual([['.*', expectedPathFooBar]]);
-      expect(config.transformIgnorePatterns).toEqual([
-        joinForPattern('bar', 'baz'),
-        joinForPattern('qux', 'quux'),
-      ]);
-
-      expect(config.scriptPreprocessor).toBe(undefined);
-      expect(config.preprocessorIgnorePatterns).toBe(undefined);
-
-      expect(console.warn.mock.calls[0][0]).toMatchSnapshot();
-    });
-  });
-
 });

--- a/types/Config.js
+++ b/types/Config.js
@@ -77,7 +77,6 @@ export type Config = DefaultConfig & {|
   transform: Array<[string, Path]>,
   unmockedModulePathPatterns: Array<string>,
   updateSnapshot: boolean,
-  usesBabelJest: boolean,
   watchman: boolean,
   forceExit: boolean,
 |};


### PR DESCRIPTION
**Summary**

This allows to hook in extensions in node_modules as "foo" instead of "<rootDir>/node_modules/foo/index.js"

**Test plan**
jest