### PR TITLE
expose --testResultsProcessor

### DIFF
--- a/integration_tests/__tests__/testResultsProcessor-test.js
+++ b/integration_tests/__tests__/testResultsProcessor-test.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
+const runJest = require('../runJest');
+const skipOnWindows = require('skipOnWindows');
+
+skipOnWindows.suite();
+
+test('testNamePattern', () => {
+  const path = require('path');
+  const processorPath = path.resolve(
+    __dirname,
+    '../testResultsProcessor/processor.js'
+  );
+  const result = runJest.json('testResultsProcessor', [
+    '--json',
+    `--testResultsProcessor=${processorPath}`,
+  ]);
+  const json = result.json;
+  expect(json.processed).toBe(true);
+});

--- a/integration_tests/testResultsProcessor/__tests__/processor-test.js
+++ b/integration_tests/testResultsProcessor/__tests__/processor-test.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
+test('should match 1', () => expect(1).toBe(1));

--- a/integration_tests/testResultsProcessor/package.json
+++ b/integration_tests/testResultsProcessor/package.json
@@ -1,0 +1,5 @@
+{
+  "jest": {
+    "testEnvironment": "node"
+  }
+}

--- a/integration_tests/testResultsProcessor/processor.js
+++ b/integration_tests/testResultsProcessor/processor.js
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+module.exports = function(results) {
+  results.processed = true;
+};

--- a/packages/jest-cli/src/cli/args.js
+++ b/packages/jest-cli/src/cli/args.js
@@ -199,6 +199,14 @@ const options = {
       'paths before executing the test.',
     type: 'string',
   },
+  testResultsProcessor: {
+    default: undefined,
+    description:
+      'Allows the use of a custom results processor. ' +
+      'This processor must be a node module that exports ' +
+      'a function expecting as the first argument the result object',
+    type: 'string',
+  },
   testRunner: {
     description:
       'Allows to specify a custom test runner. Jest ships with Jasmine ' +

--- a/packages/jest-cli/src/lib/formatTestResults.js
+++ b/packages/jest-cli/src/lib/formatTestResults.js
@@ -83,7 +83,7 @@ function formatTestResults(
     reporter,
   ));
 
-  return {
+  return Object.assign({}, results, {
     numFailedTests: results.numFailedTests,
     numPassedTests: results.numPassedTests,
     numPendingTests: results.numPendingTests,
@@ -93,7 +93,7 @@ function formatTestResults(
     startTime: results.startTime,
     success: results.success,
     testResults,
-  };
+  });
 }
 
 module.exports = formatTestResults;

--- a/packages/jest-config/src/setFromArgv.js
+++ b/packages/jest-config/src/setFromArgv.js
@@ -73,6 +73,10 @@ function setFromArgv(config, argv) {
     config.expand = argv.expand;
   }
 
+  if (argv.testResultsProcessor) {
+    config.testResultsProcessor = argv.testResultsProcessor;
+  }
+
   config.noStackTrace = argv.noStackTrace;
 
   return config;


### PR DESCRIPTION
Expose the `testResultsProcessor` option on the cli

The option was already available through configuration, 
I've exposed it and add an integration test for testing it.


**Test plan**
yarn test