### PR TITLE
Fix moduleNameMapper in jest-react-native

### DIFF
--- a/packages/jest-react-native/jest-preset.json
+++ b/packages/jest-react-native/jest-preset.json
@@ -8,7 +8,7 @@
   },
   "moduleNameMapper": {
     "^[./a-zA-Z0-9$_-]+\\.(bmp|gif|jpg|jpeg|png|psd|svg|webp)$": "RelativeImageStub",
-    "^React$": "<rootDir>node_modules/react"
+    "^React$": "<rootDir>/node_modules/react"
   },
   "modulePathIgnorePatterns": [
     "<rootDir>/node_modules/react-native/Libraries/react-native/",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
This is attempt to fix segmentation fault on Node 4. Since "Segmentation fault" means that we tried to access memory that we do not have access to, it could happen that we tried to reach not-existing directory.

**Test plan**
Travis
