### PR TITLE
Docs: replace json with jest under snapshotSerializers in Configuration

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -310,9 +310,10 @@ module.exports = {
 To use `my-serializer-module` as a serializer, configuration would be as
 follows:
 
-```json
+```js
 {
-  "json": {
+  ...
+  "jest": {
     "snapshotSerializers": ["<rootDir>/node_modules/my-serializer-module"]
   }
 }


### PR DESCRIPTION
**Summary**

It looks like `json` was a typo for `jest` because:

* `snapshotSerializers` is at the same level of hierarchy as the other keys in `jest-cli/src/normalize.js` and the only reference to `json` in that file is about coverage reporters
* Jest documentation differs from `enzyme-to-json` and `jest-serializer-enzyme`

Because this is the only json code fence in Configuration, I changed it to follow the example of js code fences under `coverageThreshold` and `globals`

**Test plan**

Review by someone who knows for sure, please.