### PR TITLE
Add code comments documenting passing matcher results

### DIFF
--- a/packages/jest-matchers/src/index.js
+++ b/packages/jest-matchers/src/index.js
@@ -116,6 +116,9 @@ const makeThrowingMatcher = (
     if ((result.pass && isNot) || (!result.pass && !isNot)) { // XOR
       const message = getMessage(result.message);
       const error = new JestAssertionError(message);
+      // Passing the result of the matcher with the error so that a custom reporter
+      // could access the actual and expected objects of the result
+      // for example in order to display a custom visual diff
       error.matcherResult = result;
       // Remove this function from the stack trace frame.
       Error.captureStackTrace(error, throwingMatcher);

--- a/packages/jest-matchers/src/index.js
+++ b/packages/jest-matchers/src/index.js
@@ -116,8 +116,8 @@ const makeThrowingMatcher = (
     if ((result.pass && isNot) || (!result.pass && !isNot)) { // XOR
       const message = getMessage(result.message);
       const error = new JestAssertionError(message);
-      // Passing the result of the matcher with the error so that a custom reporter
-      // could access the actual and expected objects of the result
+      // Passing the result of the matcher with the error so that a custom
+      // reporter could access the actual and expected objects of the result
       // for example in order to display a custom visual diff
       error.matcherResult = result;
       // Remove this function from the stack trace frame.

--- a/packages/jest-matchers/src/matchers.js
+++ b/packages/jest-matchers/src/matchers.js
@@ -103,6 +103,9 @@ const matchers: MatchersObject = {
         (diffString ? `\n\nDifference:\n\n${diffString}` : '');
       };
 
+    // Passing the the actual and expected objects so that a custom reporter
+    // could access them, for example in order to display a custom visual diff,
+    // or create a different error message
     return {actual: received, expected, message, name: 'toBe', pass};
   },
 
@@ -396,6 +399,9 @@ const matchers: MatchersObject = {
         (diffString ? `\n\nDifference:\n\n${diffString}` : '');
       };
 
+    // Passing the the actual and expected objects so that a custom reporter
+    // could access them, for example in order to display a custom visual diff,
+    // or create a different error message
     return {actual: received, expected, message, name: 'toEqual', pass};
   },
 


### PR DESCRIPTION
Adds code comments to explain the reason for changes in https://github.com/facebook/jest/pull/2198 and outline potential use cases for custom integration.

