### PR TITLE
[Website] Allow place holders to be used in code examples

### DIFF
--- a/website/server/convert.js
+++ b/website/server/convert.js
@@ -40,10 +40,13 @@ function rmFile(file) {
 }
 
 function backtickify(str) {
-  const escaped = '`' + str.replace(/\\/g, '\\\\').replace(/`/g, '\\`') + '`';
+  let escaped = '`' + str.replace(/\\/g, '\\\\').replace(/`/g, '\\`') + '`';
   // Replace require( with require\( so node-haste doesn't replace example
   // require calls in the docs
-  return escaped.replace(/require\(/g, 'require\\(');
+  escaped = escaped.replace(/require\(/g, 'require\\(');
+
+  // Replace ${var} with \${var} so we can use place holders
+  return escaped.replace(/\$\{([\w\s\d\'\:\.\(\)\?]*)\}/g,'\\${$1}');
 }
 
 


### PR DESCRIPTION
**Summary**

Addresses an issue introduced in #2025 where the [API Reference doc fails to be generated](https://jest-bot.github.io/jest/docs/api.html#content) when the website is built.

As part of the website generation script, the markdown source files are converted into React components, and the markdown content is HTML-fied and injected into the component. Prior to this fix, any place holders in the original markdown document will persist in the React component. This results in a script error as the variable used in the example is, as expected, not defined in this context:

```
Error: ReferenceError: received is not defined
    at /Users/hramos/git/react/jest/website/node_modules/react-page-middleware/src/guard.js:27:12
    at onOutputGenerated (/Users/hramos/git/react/jest/website/node_modules/react-page-middleware/src/index.js:96:9)
    at Object.done (/Users/hramos/git/react/jest/website/node_modules/react-page-middleware/src/DefaultRouter.js:345:7)
    at renderReactPage (/Users/hramos/git/react/jest/website/node_modules/react-page-middleware/src/renderReactPage.js:130:17)
    at renderComponentPackage (/Users/hramos/git/react/jest/website/node_modules/react-page-middleware/src/DefaultRouter.js:331:3)
    at routePackageHandler (/Users/hramos/git/react/jest/website/node_modules/react-page-middleware/src/DefaultRouter.js:274:5)
    at onComputePackage (/Users/hramos/git/react/jest/website/node_modules/react-page-middleware/src/index.js:100:9)
    at /Users/hramos/git/react/jest/website/node_modules/react-page-middleware/src/guard.js:29:10
    at onWarmed (/Users/hramos/git/react/jest/website/node_modules/react-page-middleware/src/Packager.js:270:9)
    at /Users/hramos/git/react/jest/website/node_modules/react-page-middleware/node_modules/async/lib/async.js:116:25
```

We address this by escaping the dollar sign in any place holders being used in the original markdown document.

The regex used to do this should match, at minimum, the existing place holders:

```
${received}
${pass ? 'not ' : ''}
${actual}
${this.utils.printExpected(expected)}
${this.utils.printReceived(received)}
```

**Test plan**

Built and ran the website locally. The API Reference doc is generated successfully, and the sample code is displayed is correct.

Capture of the actual API Reference doc as generated once this fix is in place (highlights added by the author are not present in the website as generated):
![screencapture-localhost-8080-jest-docs-api-html-1481240186638](https://cloud.githubusercontent.com/assets/165856/21032201/ab482f76-bd5c-11e6-9019-49664f1a086b.png)

