### PR TITLE
Remove coverage data after it's been merged

### DIFF
--- a/packages/jest-cli/src/reporters/CoverageReporter.js
+++ b/packages/jest-cli/src/reporters/CoverageReporter.js
@@ -41,7 +41,7 @@ class CoverageReporter extends BaseReporter {
     testResult: TestResult,
     aggregatedResults: AggregatedResult,
   ) {
-    if (testResult.coverage && typeof testResult.coverage !== 'string') {
+    if (testResult.coverage) {
       this._coverageMap.merge(testResult.coverage);
       // Remove coverage data to free up some memory.
       delete testResult.coverage;

--- a/types/TestResult.js
+++ b/types/TestResult.js
@@ -17,6 +17,13 @@ export type Coverage = {|
   sourceText: string,
 |};
 
+export type CoverageMap = {|
+  merge: (data: Object) => void,
+  getCoverageSummary: () => Object,
+  data: Object,
+  addFileCoverage: (fileCoverage: Object) => void,
+|};
+
 export type Error = {|
   message: string,
   stack: ?string,
@@ -49,6 +56,7 @@ export type AssertionResult = {|
 |};
 
 export type AggregatedResult = {|
+  coverageMap?: CoverageMap,
   numFailedTests: number,
   numFailedTestSuites: number,
   numPassedTests: number,


### PR DESCRIPTION
That should make `coverage` object garbage collectable and free up some memory.
I made it a string in case someone tries to access coverage in the future.