### PR TITLE
WIP - Support negation in transformIgnorePatterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ lerna-debug.log
 npm-debug.log*
 coverage
 .eslintcache
+
+### IntelliJ IDEA ###
+.idea
+*.iml

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -438,8 +438,10 @@ Examples of such compilers include [babel](https://babeljs.io/), [typescript](ht
 (default: `['/node_modules/']`)
 
 An array of regexp pattern strings that are matched against all source file paths before transformation. If the test path matches any of the patterns, it will not be transformed.
+ 
+If you need to negate the sense of an expression, prefix it with `!`. Note that this is not standard regexp syntax.
 
-These pattern strings match against the full path. Use the `<rootDir>` string token to  include the path to your project's root directory to prevent it from accidentally ignoring all of your files in different environments that may have different root directories. Example: `['<rootDir>/bower_components/', '<rootDir>/node_modules/']`.
+Use the `<rootDir>` string token to include the path to your project's root directory to prevent it from accidentally ignoring all of your files in different environments that may have different root directories. Example: `['<rootDir>/bower_components/', '<rootDir>/node_modules/']`.
 
 ### `unmockedModulePathPatterns` [array<string>]
 (default: `[]`)

--- a/packages/jest-runtime/src/__tests__/__snapshots__/transform-test.js.snap
+++ b/packages/jest-runtime/src/__tests__/__snapshots__/transform-test.js.snap
@@ -1,3 +1,18 @@
+exports[`transform respects negation in transformIgnorePatterns 1`] = `
+"({\"Object.<anonymous>\":function(module,exports,require,__dirname,__filename,global,jest){module.exports = \"banana\";
+}});"
+`;
+
+exports[`transform respects negation in transformIgnorePatterns 2`] = `
+"({\"Object.<anonymous>\":function(module,exports,require,__dirname,__filename,global,jest){
+          module.exports = {
+            filename: /styles/App.css,
+            rawFirstLine: root {,
+          };
+        
+}});"
+`;
+
 exports[`transform transforms a file properly 1`] = `
 "({\"Object.<anonymous>\":function(module,exports,require,__dirname,__filename,global,jest){/* istanbul ignore next */var cov_25u22311x4 = function () {var path = \"/fruits/banana.js\",hash = \"04636d4ae73b4b3e24bf6fba39e08c946fd0afb5\",global = new Function(\'return this\')(),gcv = \"__coverage__\",coverageData = { path: \"/fruits/banana.js\", statementMap: { \"0\": { start: { line: 1, column: 0 }, end: { line: 1, column: 26 } } }, fnMap: {}, branchMap: {}, s: { \"0\": 0 }, f: {}, b: {}, _coverageSchema: \"332fd63041d2c1bcb487cc26dd0d5f7d97098a6c\" },coverage = global[gcv] || (global[gcv] = {});if (coverage[path] && coverage[path].hash === hash) {return coverage[path];}coverageData.hash = hash;return coverage[path] = coverageData;}();++cov_25u22311x4.s[0];module.exports = \"banana\";
 }});"

--- a/packages/jest-runtime/src/__tests__/transform-test.js
+++ b/packages/jest-runtime/src/__tests__/transform-test.js
@@ -247,4 +247,22 @@ describe('transform', () => {
     expect(fs.readFileSync).not.toBeCalledWith(cachePath, 'utf8');
     expect(fs.writeFileSync).toBeCalled();
   });
+
+  it('respects negation in transformIgnorePatterns', () => {
+    const transformConfig = Object.assign(config, {
+      transform: [
+        ['^.+\\.js$', 'test-preprocessor'],
+        ['^.+\\.css$', 'css-preprocessor'],
+      ],
+      transformIgnorePatterns: ['!\\.css$'],
+    });
+
+    transform('/fruits/banana.js', transformConfig);
+    transform('/styles/App.css', transformConfig);
+
+    expect(require('test-preprocessor').getCacheKey).not.toBeCalled();
+    expect(require('css-preprocessor').getCacheKey).toBeCalled();
+    expect(vm.Script.mock.calls[0][0]).toMatchSnapshot();
+    expect(vm.Script.mock.calls[1][0]).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->
## Summary

This change makes it possible to supply regex values in the `transformIgnorePatterns` config parameter whose meanings are negated when evaluated. Such patterns need simply be prefixed with '!' for the negation to be applied.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Motivation

I made this change because @gaearon [tweeted](https://twitter.com/dan_abramov/status/806554466325504000) about a nasty regex he ended up needing to write.

## Testing

I added a test case to `transform-tests.js`, which set up an ignore pattern of `!\\.css$`, and transforms a `.js` file and a `.css` file. As expected the JS file is not transformed, and the CSS one is.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

To test, I ran `yarn test`, which ran clean and updated the snapshots.

## Other Notes

While updating the documentation I removed the statement, 'These pattern strings match against the full path.' because this didn't appear to be true in the old implementation and continues not to be true now.

