### PR TITLE
Fixed version issues with examples/async

### DIFF
--- a/examples/async/package.json
+++ b/examples/async/package.json
@@ -1,10 +1,10 @@
 {
   "devDependencies": {
-    "babel-jest": "^17.0.0",
+    "babel-jest": "*",
     "babel-plugin-transform-async-to-generator": "^6.5.0",
     "babel-polyfill": "*",
     "babel-preset-es2015": "*",
-    "jest-cli": "^17.0.0"
+    "jest-cli": "*"
   },
   "scripts": {
     "test": "jest"

--- a/examples/async/package.json
+++ b/examples/async/package.json
@@ -1,10 +1,10 @@
 {
   "devDependencies": {
-    "babel-jest": "^9.0.0",
+    "babel-jest": "^17.0.0",
     "babel-plugin-transform-async-to-generator": "^6.5.0",
     "babel-polyfill": "*",
     "babel-preset-es2015": "*",
-    "jest-cli": "*"
+    "jest-cli": "^17.0.0"
   },
   "scripts": {
     "test": "jest"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
This PR fixes an issue in the async example, discussed here: https://github.com/facebook/jest/issues/1939#issuecomment-266013090

The package.json fixes the babel-jest version to ^9.0.0 while for jest-cli the latest ("*") is downloaded. When downloading the packages, a version mismatch can occur which causes Jest mocks not to work.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
Fixing the versions of babel-jest and jest-cli to the same major version (^17.0.0), solves the version mismatching issue.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

-Download packages:
yarn
-Run test example:
npm test

