### PR TITLE
[Feature] mock function promise support

### DIFF
--- a/packages/jest-mock/README.md
+++ b/packages/jest-mock/README.md
@@ -95,6 +95,14 @@ function.
 
 Sets the default return value for the function.
 
+##### `.mockResolveValue(value)`
+
+Sets the default return value to be `Promise.resolve(value)` for the function.
+
+##### `.mockRejectError(error)`
+
+Sets the default return value to be `Promise.reject(error)` for the function.
+
 ##### `.mockImplementationOnce(function)`
 
 Pushes the given mock implementation onto a FIFO queue of mock

--- a/packages/jest-mock/src/__tests__/jest-mock-test.js
+++ b/packages/jest-mock/src/__tests__/jest-mock-test.js
@@ -237,6 +237,43 @@ describe('moduleMocker', () => {
         expect(after).not.toEqual('abcd');
       });
 
+      it('supports resetting mock resolve values', () => {
+        const fn = moduleMocker.getMockFunction();
+        fn.mockResolveValue('abcd');
+
+        const before = fn();
+        expect(before).not.toBeUndefined();
+        expect(before.then).not.toBeUndefined();
+
+        return before.then(value => {
+          expect(value).toEqual('abcd');
+
+          fn.mockReset();
+
+          const after = fn();
+          expect(after).toBeUndefined();
+        });
+      });
+
+      it('supports resetting mock reject errors', () => {
+        const fn = moduleMocker.getMockFunction();
+        const rejectError = new Error('error');
+        fn.mockRejectError(rejectError);
+
+        const before = fn();
+        expect(before).not.toBeUndefined();
+        expect(before.catch).not.toBeUndefined();
+
+        return before.catch(error => {
+          expect(error).toEqual(rejectError);
+
+          fn.mockReset();
+
+          const after = fn();
+          expect(after).toBeUndefined();
+        });
+      });
+
       it('supports resetting single use mock return values', () => {
         const fn = moduleMocker.getMockFunction();
         fn.mockReturnValueOnce('abcd');

--- a/packages/jest-mock/src/index.js
+++ b/packages/jest-mock/src/index.js
@@ -335,6 +335,16 @@ class ModuleMocker {
         return f;
       };
 
+      f.mockResolveValue = value => {
+        // next function call will resolve specified value or this one
+        return f.mockReturnValue(Promise.resolve(value));
+      };
+
+      f.mockRejectError = error => {
+        // next function call will reject specified error or this one
+        return f.mockReturnValue(Promise.reject(error));
+      };
+
       f.mockImplementationOnce = fn => {
         // next function call will use this mock implementation return value
         // or default mock implementation return value


### PR DESCRIPTION
I added new jest-mock functions for easier promise mocking, fixing #1930:
`.mockResolveValue(val)` and `.mockRejectError(err)`

##### Tests?
I am having trouble running the tests locally, I get syntax errors with the hanging commas when trying to run `npm run test` directly in `packages/jest-mock`. I added tests following the patterns I saw in the tests, but have not verified they work.

##### Docs?
I added sections in the `jest-mock` README. Where else do I need to add documentation for these new methods?