### PR TITLE
Fix matcher-test snapshot on node 4.

### DIFF
--- a/packages/jest-matchers/src/__tests__/matchers-test.js
+++ b/packages/jest-matchers/src/__tests__/matchers-test.js
@@ -88,7 +88,7 @@ describe('.toEqual()', () => {
     [() => {}, jestExpect.any(Function)],
     [{
       a: 1,
-      b: () => {},
+      b: function b() {},
       c: true,
     }, {
       a: 1,


### PR DESCRIPTION
We have a failure on node 4 and I'm unsure why.