### PR TITLE
Reset the “TestWatcher” state. Fixes #2294

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## jest 18.0.0
 
+* Fixed re-running tests when `--bail` is used together with `--watch`.
 * `pretty-format` is now merged into Jest.
 * `require('v8')` now works properly in a test context.
 * Jest now clears the entire scrollback in watch mode.

--- a/packages/jest-cli/src/jest.js
+++ b/packages/jest-cli/src/jest.js
@@ -333,6 +333,7 @@ const runCLI = (
             results => {
               isRunning = false;
               hasSnapshotFailure = !!results.snapshot.failure;
+              testWatcher.setState({interrupted: false});
               if (displayHelp) {
                 console.log(usage(argv, hasSnapshotFailure));
                 displayHelp = !process.env.JEST_HIDE_USAGE;


### PR DESCRIPTION
**Summary**

See #2294 

**Test plan**

* Have a single test failure, run with `jest --watchAll --bail`.
* When changing the file, the tests should re-run.