### PR TITLE
WIP: haste ignores using testPathIgnorePatterns, not all node_modules

### DIFF
--- a/packages/jest-haste-map/src/index.js
+++ b/packages/jest-haste-map/src/index.js
@@ -672,10 +672,7 @@ class HasteMap extends EventEmitter {
    * Helpers
    */
   _ignore(filePath: Path): boolean {
-    return (
-      this._options.ignorePattern.test(filePath) ||
-      (!this._options.retainAllFiles && this._isNodeModulesDir(filePath))
-    );
+    return this._options.ignorePattern.test(filePath);
   }
 
   _isNodeModulesDir(filePath: Path): boolean {

--- a/packages/jest-runtime/src/index.js
+++ b/packages/jest-runtime/src/index.js
@@ -195,7 +195,9 @@ class Runtime {
     options?: HasteMapOptions,
   ): HasteMap {
     const ignorePattern = new RegExp(
-      [config.cacheDirectory].concat(config.modulePathIgnorePatterns).join('|'),
+      [config.cacheDirectory].concat(
+          config.modulePathIgnorePatterns,
+          config.testPathIgnorePatterns).join('|'),
     );
 
     return new HasteMap({


### PR DESCRIPTION
**Summary**
An attempt to fix the issue raised in #2145, which is blocking https://github.com/facebookincubator/create-react-app/pull/1081.

**Test plan**

This PR is incomplete because [this test](https://github.com/modernserf/jest/blob/master/packages/jest-haste-map/src/__tests__/index-test.js#L214) is failing; furthermore, I should introduce a test that fails in master but works in this PR to illustrate the feature it solves. 

I need some help with this.