### PR TITLE
Change testResultsProcessor API

### DIFF
--- a/integration_tests/testResultsProcessor/processor.js
+++ b/integration_tests/testResultsProcessor/processor.js
@@ -10,4 +10,5 @@
 
 module.exports = function(results) {
   results.processed = true;
+  return results;
 };

--- a/packages/jest-cli/src/jest.js
+++ b/packages/jest-cli/src/jest.js
@@ -228,8 +228,7 @@ const runJest = (config, argv, pipe, testWatcher, onComplete) => {
       .then(runResults => {
         if (config.testResultsProcessor) {
           /* $FlowFixMe */
-          const processor = require(config.testResultsProcessor);
-          processor(runResults);
+          runResults = require(config.testResultsProcessor)(runResults);
         }
         if (argv.json) {
           if (argv.outputFile) {


### PR DESCRIPTION
**Summary**
The test results processor should return the newly created object, otherwise we are just inspiring mutative APIs and it kinda sucks like this. This is a breaking change for Jest 18.

**Test plan**
jest