### PR TITLE
Pass `toMatchSnapshot` `expected` and `actual` for custom reporters

### DIFF
--- a/packages/jest-jasmine2/src/setup-jest-globals.js
+++ b/packages/jest-jasmine2/src/setup-jest-globals.js
@@ -32,6 +32,8 @@ const addSuppressedErrors = result => {
 
     result.failedExpectations = suppressedErrors.map(error => ({
       actual: '',
+      // passing error for custom test reporters
+      error,
       expected: '',
       message: error.message,
       passed: false,

--- a/packages/jest-snapshot/src/index.js
+++ b/packages/jest-snapshot/src/index.js
@@ -109,7 +109,17 @@ const toMatchSnapshot = function(received: any, testName?: string) {
       () => matcherHint('.toMatchSnapshot', 'value', '') + '\n\n' +
       report();
 
-    return {message, pass: false, report};
+    // Passing the the actual and expected objects so that a custom reporter
+    // could access them, for example in order to display a custom visual diff,
+    // or create a different error message
+    return {
+      actual: actualString,
+      expected: expectedString,
+      message,
+      name: 'toMatchSnapshot',
+      pass: false,
+      report,
+    };
   }
 };
 


### PR DESCRIPTION
The change is similar to the https://github.com/facebook/jest/pull/2198 and allows custom reporters to access `expected` and `actual` of the `toMatchSnapshot` matcher to provide custom diff views for `jest` snapshots.

