### PR TITLE
Add -h alias for --help

### DIFF
--- a/packages/jest-cli/src/cli/index.js
+++ b/packages/jest-cli/src/cli/index.js
@@ -22,6 +22,7 @@ function run(argv?: Object, root?: Path) {
   argv = yargs(argv || process.argv.slice(2))
     .usage(args.usage)
     .help()
+    .alias('help', 'h')
     .options(args.options)
     .check(args.check)
     .argv;

--- a/packages/jest-util/src/index.js
+++ b/packages/jest-util/src/index.js
@@ -73,7 +73,7 @@ const getPackageRoot = () => {
 };
 
 const warnAboutUnrecognizedOptions  = (argv: Object, options: Object) => {
-  const yargsSpecialOptions = ['$0', '_', 'help'];
+  const yargsSpecialOptions = ['$0', '_', 'help', 'h'];
   const allowedOptions = Object.keys(options).reduce((acc, option) => (
     acc
       .add(option)


### PR DESCRIPTION
**Summary**

I've ran `jest -h` quite a few times expecting it to behave like `jest --help` (but instead it kicks off my test suite).  This is a fairly small change that aliases `-h` to `--help` so all 3 of these commands work the same:
- `jest -h`
- `jest --help`
- `jest help`

**Test plan**

1. Cloned repo and made code changes
2. Ran `yarn build`
3. Tested a few commands by running things like
- `node ./packages/jest-cli/bin/jest.js -h`
- `node ./packages/jest-cli/bin/jest.js --help`
- `node ./packages/jest-cli/bin/jest.js help`
- `yarn jest -- -h`
- `yarn jest -- --help`
- `yarn jest -- help`
and confirming they work
4. Ran the entire test suite via `yarn test` and `yarn jest-coverage`

**Demo**

![jest-help-alias](https://cloud.githubusercontent.com/assets/434470/21252892/85fbe434-c328-11e6-92d5-2b7db8b5f3e9.gif)


