### PR TITLE
traverse all nodes to find all test/it/expect blocks

### DIFF
--- a/packages/jest-editor-support/src/__tests__/TypeScriptParser-test.js
+++ b/packages/jest-editor-support/src/__tests__/TypeScriptParser-test.js
@@ -97,7 +97,7 @@ describe('File Parsing for it blocks', () => {
 
   it('For a danger test file (which has flow annotations)', async () => {
     const data = parse(`${fixtures}/dangerjs/travis-ci.example`);
-    expect(data.itBlocks.length).toEqual(7);
+    expect(data.itBlocks.length).toEqual(8);
   });
 
   it('For a danger flow test file ', async () => {
@@ -115,17 +115,16 @@ describe('File Parsing for expects', () => {
 
   it('finds Expects in a danger test file', async () => {
     const data = parse(`${fixtures}/dangerjs/travis-ci.example`);
-    expect(data.expects.length).toEqual(7);
+    expect(data.expects.length).toEqual(8);
   });
 
   it('finds Expects in a danger flow test file ', async () => {
     const data = parse(`${fixtures}/dangerjs/github.example`);
-    expect(data.expects.length).toEqual(2);
+    expect(data.expects.length).toEqual(3);
   });
 
   it('finds Expects in a metaphysics test file', async () => {
     const data = parse(`${fixtures}/metaphysics/partner_show.example`);
-    // Not currently checking inside function calls
-    expect(data.expects.length).toEqual(0);
+    expect(data.expects.length).toEqual(10);
   });
 });


### PR DESCRIPTION
**Summary**

Wanted the TypeScript parser to find all test/it/expect blocks, even when nested inside loops, callback functions/promises.  As a result I realized I could greatly simplify the parser.

**Test plan**

Tweaked the unit tests to account for the additional cases that were missed before.
