### PR TITLE
Add support for running older processes of Jest

### DIFF
--- a/packages/jest-editor-support/src/Process.js
+++ b/packages/jest-editor-support/src/Process.js
@@ -30,6 +30,13 @@ module.exports.jestChildProcessWithArgs = (
   const [command, ...initialArgs] = runtimeExecutable.split(' ');
   const runtimeArgs = [...initialArgs, ...args];
 
+  // If a path to configuration file was defined, push it to runtimeArgs
+  const configPath = workspace.pathToConfig;
+  if (configPath !== '') {
+    runtimeArgs.push('--config');
+    runtimeArgs.push(configPath);
+  }
+
   // To use our own commands in create-react, we need to tell the command that
   // we're in a CI environment, or it will always append --watch
   const env = process.env;

--- a/packages/jest-editor-support/src/ProjectWorkspace.js
+++ b/packages/jest-editor-support/src/ProjectWorkspace.js
@@ -54,7 +54,8 @@ module.exports = class ProjectWorkspace {
     rootPath: string, 
     pathToJest: string, 
     pathToConfig: string,
-    localJestMajorVersion: number) {
+    localJestMajorVersion: number,
+  ) {
     this.rootPath = rootPath;
     this.pathToJest = pathToJest;
     this.pathToConfig = pathToConfig;

--- a/packages/jest-editor-support/src/ProjectWorkspace.js
+++ b/packages/jest-editor-support/src/ProjectWorkspace.js
@@ -36,6 +36,13 @@ module.exports = class ProjectWorkspace {
 
 
   /**
+   * Path to a local Jest config file.
+   * 
+   * @type {string}
+   */
+  pathToConfig: string;
+
+  /**
    * local Jest major release version, as the runner could run against
    * any version of Jest.
    * 
@@ -46,9 +53,11 @@ module.exports = class ProjectWorkspace {
   constructor(
     rootPath: string, 
     pathToJest: string, 
+    pathToConfig: string,
     localJestMajorVersion: number) {
     this.rootPath = rootPath;
     this.pathToJest = pathToJest;
+    this.pathToConfig = pathToConfig;
     this.localJestMajorVersion = localJestMajorVersion;
   }
 };

--- a/packages/jest-editor-support/src/ProjectWorkspace.js
+++ b/packages/jest-editor-support/src/ProjectWorkspace.js
@@ -34,8 +34,21 @@ module.exports = class ProjectWorkspace {
    */
   pathToJest: string;
 
-  constructor(rootPath: string, pathToJest: string) {
+
+  /**
+   * local Jest major release version, as the runner could run against
+   * any version of Jest.
+   * 
+   * @type {number}
+   */
+  localJestMajorVersion: number;
+
+  constructor(
+    rootPath: string, 
+    pathToJest: string, 
+    localJestMajorVersion: number) {
     this.rootPath = rootPath;
     this.pathToJest = pathToJest;
+    this.localJestMajorVersion = localJestMajorVersion;
   }
 };

--- a/packages/jest-editor-support/src/Runner.js
+++ b/packages/jest-editor-support/src/Runner.js
@@ -32,11 +32,15 @@ module.exports = class Runner extends EventEmitter {
   }
 
   start() {
+    // Handle the arg change on v18
+    const belowEighteen = this.workspace.localJestMajorVersion < 18;
+    const outputArg = belowEighteen ? 'jsonOutputFile' : 'outputFile';
+
     const args = [
       '--json',
       '--useStderr',
       '--watch',
-      '--outputFile',
+      outputArg,
       this.outputPath,
     ];
 

--- a/packages/jest-editor-support/src/Runner.js
+++ b/packages/jest-editor-support/src/Runner.js
@@ -34,7 +34,7 @@ module.exports = class Runner extends EventEmitter {
   start() {
     // Handle the arg change on v18
     const belowEighteen = this.workspace.localJestMajorVersion < 18;
-    const outputArg = belowEighteen ? 'jsonOutputFile' : 'outputFile';
+    const outputArg = belowEighteen ? '--jsonOutputFile' : '--outputFile';
 
     const args = [
       '--json',

--- a/packages/jest-editor-support/src/ScriptParser.js
+++ b/packages/jest-editor-support/src/ScriptParser.js
@@ -23,7 +23,7 @@ export type ParserReturn = {
  * collection of it and expects.
  */
 function parse(file: string): ParserReturn {
-  if (file.match(/\.ts?$/)) {
+  if (file.match(/\.tsx?$/)) {
     // This require is done here so that it can be optional for clients
     const {parse} = require('./parsers/TypeScriptParser');
     return parse(file);

--- a/packages/jest-editor-support/src/ScriptParser.js
+++ b/packages/jest-editor-support/src/ScriptParser.js
@@ -11,19 +11,7 @@
 'use strict';
 
 const {babylonParser} = require('./parsers/BabylonParser');
-import type {Location} from './types';
-
-class Node {
-  start: Location;
-  end: Location;
-  file: string;
-}
-
-class Expect extends Node {}
-
-class ItBlock extends Node {
-  name: string;
-}
+const {ItBlock, Expect} = require('./parsers/ParserNodes.js');
 
 export type ParserReturn = {
   itBlocks: Array<ItBlock>,
@@ -45,8 +33,5 @@ function parse(file: string): ParserReturn {
 }
 
 module.exports = {
-  Expect,
-  ItBlock,
-  Node,
   parse,
 };

--- a/packages/jest-editor-support/src/Settings.js
+++ b/packages/jest-editor-support/src/Settings.js
@@ -58,8 +58,13 @@ module.exports = class Settings extends EventEmitter {
     this.debugprocess.stdout.on('data', (data: Buffer) => {
       const string = data.toString();
       // We can give warnings to versions under 17 now
+      // See https://github.com/facebook/jest/issues/2343 for moving this into 
+      // the config object
       if (string.includes('jest version =')) {
-        const version = string.split('jest version =').pop().split(EOL)[0];
+        const version = string.split('jest version =')
+                              .pop()
+                              .split(EOL)[0]
+                              .trim();
         this.jestVersionMajor = parseInt(version, 1);
       }
       

--- a/packages/jest-editor-support/src/Settings.js
+++ b/packages/jest-editor-support/src/Settings.js
@@ -71,8 +71,8 @@ module.exports = class Settings extends EventEmitter {
       // Pull out the data for the config
       if (string.includes('config =')) {
         const jsonString = string.split('config =')
-                                 .pop()
-                                 .split('No tests found')[0];
+          .pop()
+          .split('No tests found')[0];
         this.settings = JSON.parse(jsonString);
         completed();
       }

--- a/packages/jest-editor-support/src/Settings.js
+++ b/packages/jest-editor-support/src/Settings.js
@@ -65,7 +65,7 @@ module.exports = class Settings extends EventEmitter {
                               .pop()
                               .split(EOL)[0]
                               .trim();
-        this.jestVersionMajor = parseInt(version, 1);
+        this.jestVersionMajor = parseInt(version, 10);
       }
       
       // Pull out the data for the config

--- a/packages/jest-editor-support/src/Settings.js
+++ b/packages/jest-editor-support/src/Settings.js
@@ -62,9 +62,9 @@ module.exports = class Settings extends EventEmitter {
       // the config object
       if (string.includes('jest version =')) {
         const version = string.split('jest version =')
-                              .pop()
-                              .split(EOL)[0]
-                              .trim();
+          .pop()
+          .split(EOL)[0]
+          .trim();
         this.jestVersionMajor = parseInt(version, 10);
       }
       

--- a/packages/jest-editor-support/src/TestReconciler.js
+++ b/packages/jest-editor-support/src/TestReconciler.js
@@ -112,8 +112,7 @@ module.exports = class TestReconciler {
       .splice(2)
       .join('')
       .replace('  ', ' ')
-      .replace(/\[\d\dm/g, '')
-      .replace('Received:', ' Received:')
+      .replace('Received:', ' Received:')
       .replace('Difference:', ' Difference:');
   }
 

--- a/packages/jest-editor-support/src/__tests__/Runner-test.js
+++ b/packages/jest-editor-support/src/__tests__/Runner-test.js
@@ -11,6 +11,7 @@
 const {EventEmitter} = require('events');
 const path = require('path');
 const fixtures = path.resolve(__dirname, 'fixtures');
+const ProjectWorkspace = require('../ProjectWorkspace');
 
 const {readFileSync} = require('fs');
 
@@ -40,7 +41,8 @@ describe('events', () => {
   let fakeProcess;
 
   beforeEach(() => {
-    runner = new Runner();
+    const workspace = new ProjectWorkspace('.', 'node_modules/.bin/jest', 18);
+    runner = new Runner(workspace);
     fakeProcess = new EventEmitter();
     fakeProcess.stdout = new EventEmitter();
     fakeProcess.stderr = new EventEmitter();

--- a/packages/jest-editor-support/src/index.js
+++ b/packages/jest-editor-support/src/index.js
@@ -14,7 +14,8 @@ const Process = require('./Process');
 const ProjectWorkspace = require('./ProjectWorkspace');
 const Runner = require('./Runner');
 const Settings = require('./Settings');
-const {parse, Expect, ItBlock, Node} = require('./ScriptParser');
+const {Expect, ItBlock, Node} = require('./parsers/ParserNodes');
+const {parse} = require('./ScriptParser');
 const TestReconciler =  require('./TestReconciler');
 
 module.exports = {

--- a/packages/jest-editor-support/src/parsers/BabylonParser.js
+++ b/packages/jest-editor-support/src/parsers/BabylonParser.js
@@ -12,7 +12,7 @@
 
 const {readFileSync} = require('fs');
 const babylon = require('babylon');
-const {Expect, ItBlock} = require('../ScriptParser');
+const {Expect, ItBlock} = require('./ParserNodes');
 
 const path = require('path');
 const fs = require('fs');

--- a/packages/jest-editor-support/src/parsers/ParserNodes.js
+++ b/packages/jest-editor-support/src/parsers/ParserNodes.js
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+
+'use strict';
+
+import type {Location} from '../types';
+
+class Node {
+  start: Location;
+  end: Location;
+  file: string;
+}
+
+class Expect extends Node {}
+
+class ItBlock extends Node {
+  name: string;
+}
+
+module.exports = {
+  Expect,
+  ItBlock,
+  Node,
+};

--- a/packages/jest-editor-support/src/parsers/TypeScriptParser.js
+++ b/packages/jest-editor-support/src/parsers/TypeScriptParser.js
@@ -12,7 +12,7 @@
 
 const ts = require('typescript');
 const {readFileSync} = require('fs');
-const {Expect, ItBlock, Node} = require('../ScriptParser');
+const {Expect, ItBlock, Node} = require('./ParserNodes');
 
 function parse(file: string) {
   const sourceFile = ts.createSourceFile(

--- a/packages/jest-editor-support/src/types.js
+++ b/packages/jest-editor-support/src/types.js
@@ -11,8 +11,8 @@
 'use strict';
 
 export type Location = {
-  line: number,
   column: number,
+  line: number,
 }
 
 export type JestFileResults = {


### PR DESCRIPTION
**Summary**

Pre v18 builds of Jest used `jsonOutputFile` but new versions use `outputFile` - unlike the rest of the project, there is no guarantee that you are running the same version of the runner as the source code. 

This lets the extension tell the process what version of Jest is in the current workspace. 

**Test plan**

Passes locally

