### PR TITLE
Extract watch mode

### DIFF
--- a/packages/jest-cli/src/TestRunner.js
+++ b/packages/jest-cli/src/TestRunner.js
@@ -328,14 +328,16 @@ class TestRunner {
       maxRetries: 2, // Allow for a couple of transient errors.
     }, TEST_WORKER_PATH);
     const mutex = throat(this._options.maxWorkers);
+    const worker = promisify(farm);
+
     // Send test suites to workers continuously instead of all at once to track
     // the start time of individual tests.
-    const runTestInWorker = ({path, config}) => mutex(() => {
+    const runTestInWorker = ({config, path}) => mutex(() => {
       if (watcher.isInterrupted()) {
         return Promise.reject();
       }
       this._dispatcher.onTestStart(config, path);
-      return promisify(farm)({config, path});
+      return worker({config, path});
     });
 
     const onError = (err, path) => {

--- a/packages/jest-cli/src/TestRunner.js
+++ b/packages/jest-cli/src/TestRunner.js
@@ -337,7 +337,13 @@ class TestRunner {
         return Promise.reject();
       }
       this._dispatcher.onTestStart(config, path);
-      return worker({config, path});
+      return worker({
+        config,
+        path,
+        rawModuleMap: watcher.isWatchMode()
+          ? this._hasteContext.moduleMap.getRawModuleMap()
+          : null,
+      });
     });
 
     const onError = (err, path) => {

--- a/packages/jest-cli/src/TestWorker.js
+++ b/packages/jest-cli/src/TestWorker.js
@@ -11,8 +11,7 @@
 
 import type {Config, Path} from 'types/Config';
 import type {Error, TestResult} from 'types/TestResult';
-
-const {separateMessageFromStack} = require('jest-util');
+import type {RawModuleMap} from 'types/HasteMap';
 
 // Make sure uncaught errors are logged before we exit.
 process.on('uncaughtException', err => {
@@ -20,13 +19,17 @@ process.on('uncaughtException', err => {
   process.exit(1);
 });
 
+const {ModuleMap} = require('jest-haste-map');
+const {separateMessageFromStack} = require('jest-util');
+
 const Runtime = require('jest-runtime');
 const runTest = require('./runTest');
 
-type WorkerData = {
+type WorkerData = {|
   config: Config,
   path: Path,
-};
+  rawModuleMap?: RawModuleMap,
+|};
 
 type WorkerCallback = (error: ?Error, result?: TestResult) => void;
 
@@ -48,18 +51,34 @@ const formatError = error => {
 };
 
 const resolvers = Object.create(null);
-
-module.exports = (data: WorkerData, callback: WorkerCallback) => {
-  try {
-    const name = data.config.name;
+const getResolver = (config, rawModuleMap) => {
+  // In watch mode, the raw module map with all haste modules is passed from
+  // the test runner to the watch command. This is because jest-haste-map's
+  // watch mode does not persist the haste map on disk after every file change.
+  // To make this fast and consistent, we pass it from the TestRunner.
+  if (rawModuleMap) {
+    return Runtime.createResolver(
+      config,
+      new ModuleMap(rawModuleMap.map, rawModuleMap.mocks),
+    );
+  } else {
+    const name = config.name;
     if (!resolvers[name]) {
       resolvers[name] = Runtime.createResolver(
-        data.config,
-        Runtime.createHasteMap(data.config).readModuleMap(),
+        config,
+        Runtime.createHasteMap(config).readModuleMap(),
       );
     }
+    return resolvers[name];
+  }
+};
 
-    runTest(data.path, data.config, resolvers[name])
+module.exports = (
+  {config, path, rawModuleMap}: WorkerData,
+  callback: WorkerCallback,
+) => {
+  try {
+    runTest(path, config, getResolver(config, rawModuleMap))
       .then(
         result => callback(null, result),
         error => callback(formatError(error)),

--- a/packages/jest-cli/src/__tests__/TestRunner-test.js
+++ b/packages/jest-cli/src/__tests__/TestRunner-test.js
@@ -11,7 +11,24 @@
 'use strict';
 
 const TestRunner = require('../TestRunner');
+const TestWatcher = require('../TestWatcher');
 const SummaryReporter = require('../reporters/SummaryReporter');
+
+let worker;
+let workerFarmMock;
+
+jest.mock('worker-farm', () => {
+  const mock = jest.fn(
+    (options, worker) => workerFarmMock = jest.fn(
+      (data, callback) => require(worker)(data, callback),
+    ),
+  );
+  mock.end = jest.fn();
+  return mock;
+});
+
+jest.mock('../TestWorker', () => {});
+jest.mock('../reporters/DefaultReporter');
 
 test('.addReporter() .removeReporter()', () => {
   const runner = new TestRunner({}, {}, {});
@@ -20,4 +37,45 @@ test('.addReporter() .removeReporter()', () => {
   expect(runner._dispatcher._reporters).toContain(reporter);
   runner.removeReporter(SummaryReporter);
   expect(runner._dispatcher._reporters).not.toContain(reporter);
+});
+
+
+describe('_createInBandTestRun()', () => {
+  test('injects the rawModuleMap to each the worker in watch mode', () => {
+    const config = {watch: true};
+    const rawModuleMap = jest.fn();
+    const hasteContext = {moduleMap: {getRawModuleMap: () => rawModuleMap}};
+
+    const runner = new TestRunner(hasteContext, config, {maxWorkers: 2});
+
+    return runner._createParallelTestRun(
+      ['./file-test.js', './file2-test.js'],
+      new TestWatcher({isWatchMode: config.watch}),
+      () => {},
+      () => {},
+    ).then(() => {
+      expect(workerFarmMock.mock.calls).toEqual([
+        [{config, path: './file-test.js', rawModuleMap}, jasmine.any(Function)],
+        [{config, path: './file2-test.js', rawModuleMap}, jasmine.any(Function)],
+      ]);
+    })
+  });
+
+  test('does not inject the rawModuleMap in non watch mode', () => {
+    const config = {watch: false};
+
+    const runner = new TestRunner({}, config, {maxWorkers: 1});
+
+    return runner._createParallelTestRun(
+      ['./file-test.js', './file2-test.js'],
+      new TestWatcher({isWatchMode: config.watch}),
+      () => {},
+      () => {},
+    ).then(() => {
+      expect(workerFarmMock.mock.calls).toEqual([
+        [{config, path: './file-test.js', rawModuleMap: null}, jasmine.any(Function)],
+        [{config, path: './file2-test.js', rawModuleMap: null}, jasmine.any(Function)],
+      ]);
+    })
+  });
 });

--- a/packages/jest-cli/src/__tests__/TestRunner-test.js
+++ b/packages/jest-cli/src/__tests__/TestRunner-test.js
@@ -14,7 +14,6 @@ const TestRunner = require('../TestRunner');
 const TestWatcher = require('../TestWatcher');
 const SummaryReporter = require('../reporters/SummaryReporter');
 
-let worker;
 let workerFarmMock;
 
 jest.mock('worker-farm', () => {
@@ -56,9 +55,10 @@ describe('_createInBandTestRun()', () => {
     ).then(() => {
       expect(workerFarmMock.mock.calls).toEqual([
         [{config, path: './file-test.js', rawModuleMap}, jasmine.any(Function)],
+        // eslint-disable-next-line max-len
         [{config, path: './file2-test.js', rawModuleMap}, jasmine.any(Function)],
       ]);
-    })
+    });
   });
 
   test('does not inject the rawModuleMap in non watch mode', () => {
@@ -73,9 +73,11 @@ describe('_createInBandTestRun()', () => {
       () => {},
     ).then(() => {
       expect(workerFarmMock.mock.calls).toEqual([
+        /* eslint-disable max-len */
         [{config, path: './file-test.js', rawModuleMap: null}, jasmine.any(Function)],
         [{config, path: './file2-test.js', rawModuleMap: null}, jasmine.any(Function)],
+        /* eslint-enable max-len */
       ]);
-    })
+    });
   });
 });

--- a/packages/jest-cli/src/__tests__/watch-test.js
+++ b/packages/jest-cli/src/__tests__/watch-test.js
@@ -1,0 +1,158 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails oncall+jsinfra
+ */
+
+'use strict';
+
+const chalk = require('chalk');
+const TestWatcher = require('../TestWatcher');
+const {KEYS} = require('../constants');
+
+const runJestMock = jest.fn();
+
+jest.mock('jest-util', () => ({clearLine: () => {}}));
+jest.doMock('chalk', () => new chalk.constructor({enabled: false}));
+jest.doMock('../constants', () => ({CLEAR: '', KEYS}));
+jest.doMock('../runJest', () => (...args) => {
+  runJestMock(...args);
+
+  // Call the callback
+  args[args.length - 1]({snapshot: {}});
+
+  return Promise.resolve();
+});
+
+const watch = require('../watch');
+
+const USAGE_MESSAGE = `
+Watch Usage
+ › Press o to only run tests related to changed files.
+ › Press p to filter by a filename regex pattern.
+ › Press q to quit watch mode.
+ › Press Enter to trigger a test run.`;
+
+afterEach(runJestMock.mockReset);
+
+describe('Watch mode flows', () => {
+  let pipe;
+  let hasteMap;
+  let argv;
+  let hasteContext;
+  let config;
+  let stdin;
+
+  beforeEach(() => {
+    pipe = {write: jest.fn()};
+    hasteMap = {on: () => {}};
+    argv = {};
+    hasteContext = {};
+    config = {};
+    stdin = new MockStdin();
+  });
+
+  it('Runs Jest once by default and shows usage', () => {
+    watch(config, pipe, argv, hasteMap, hasteContext, stdin);
+    expect(runJestMock).toBeCalledWith(hasteContext, config, argv, pipe,
+      new TestWatcher({isWatchMode: true}), jasmine.any(Function));
+    expect(pipe.write).toBeCalledWith(USAGE_MESSAGE);
+  });
+
+  it('Pressing "o" runs test in "only changed files" mode', () => {
+    watch(config, pipe, argv, hasteMap, hasteContext, stdin);
+    runJestMock.mockReset();
+
+    stdin.emit(KEYS.O);
+
+    expect(runJestMock).toBeCalled();
+    expect(argv).toEqual({
+      '_': '',
+      onlyChanged: true,
+      watch: true,
+      watchAll: false,
+    });
+  });
+
+  it('Pressing "a" runs test in "watch all" mode', () => {
+    watch(config, pipe, argv, hasteMap, hasteContext, stdin);
+    runJestMock.mockReset();
+
+    stdin.emit(KEYS.A);
+
+    expect(runJestMock).toBeCalled();
+    expect(argv).toEqual({
+      '_': '',
+      onlyChanged: false,
+      watch: false,
+      watchAll: true,
+    });
+  });
+
+  it('Pressing "P" enters pattern mode', () => {
+    watch(config, pipe, argv, hasteMap, hasteContext, stdin);
+
+    // Write a enter pattern mode
+    stdin.emit(KEYS.P);
+    expect(pipe.write).toBeCalledWith(' pattern › ');
+
+    // Write a pattern
+    stdin.emit(KEYS.P);
+    stdin.emit(KEYS.O);
+    stdin.emit(KEYS.A);
+    expect(pipe.write).toBeCalledWith(' pattern › poa');
+
+    //Runs Jest again
+    runJestMock.mockReset();
+    stdin.emit(KEYS.ENTER);
+    expect(runJestMock).toBeCalled();
+
+    //Argv is updated with the current pattern
+    expect(argv).toEqual({
+      '_': ['poa'],
+      onlyChanged: false,
+      watch: true,
+      watchAll: false,
+    });
+  });
+
+  it('Pressing "ENTER" reruns the tests', () => {
+    watch(config, pipe, argv, hasteMap, hasteContext, stdin);
+    expect(runJestMock).toHaveBeenCalledTimes(1);
+    stdin.emit(KEYS.ENTER);
+    expect(runJestMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('Pressing "u" reruns the tests in "update snapshot" mode', () => {
+    watch(config, pipe, argv, hasteMap, hasteContext, stdin);
+    runJestMock.mockReset();
+
+    stdin.emit(KEYS.U);
+
+    expect(runJestMock.mock.calls[0][1]).toEqual({updateSnapshot: true});
+  });
+});
+
+class MockStdin {
+  constructor() {
+    this._callbacks = [];
+  }
+
+  setRawMode() {}
+
+  resume() {}
+
+  setEncoding() {}
+
+  on(evt, callback) {
+    this._callbacks.push(callback);
+  }
+
+  emit(key) {
+    this._callbacks.forEach(cb => cb(key));
+  }
+}

--- a/packages/jest-cli/src/constants.js
+++ b/packages/jest-cli/src/constants.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+
+'use strict';
+
+const CLEAR = process.platform === 'win32' ? '\x1Bc' : '\x1B[2J\x1B[3J\x1B[H';
+
+const KEYS = {
+  A: '61',
+  ARROW_DOWN: '1b5b42',
+  ARROW_LEFT: '1b5b44',
+  ARROW_RIGHT: '1b5b43',
+  ARROW_UP: '1b5b41',
+  BACKSPACE: process.platform === 'win32' ? '08' : '7f',
+  CONTROL_C: '03',
+  CONTROL_D: '04',
+  ENTER: '0d',
+  ESCAPE: '1b',
+  O: '6f',
+  P: '70',
+  Q: '71',
+  QUESTION_MARK: '3f',
+  U: '75',
+};
+
+module.exports = {CLEAR, KEYS};

--- a/packages/jest-cli/src/jest.js
+++ b/packages/jest-cli/src/jest.js
@@ -20,19 +20,18 @@ const Runtime = require('jest-runtime');
 const SearchSource = require('./SearchSource');
 const TestRunner = require('./TestRunner');
 
-const {Console, clearLine} = require('jest-util');
-const {formatTestResults} = require('jest-util');
-const {run} = require('./cli');
 const chalk = require('chalk');
+const {Console, clearLine} = require('jest-util');
+const {createDirectory} = require('jest-util');
+const createHasteContext = require('./lib/createHasteContext');
+const getMaxWorkers = require('./lib/getMaxWorkers');
+const logDebugMessages = require('./lib/logDebugMessages');
 const preRunMessage = require('./preRunMessage');
 const readConfig = require('jest-config').readConfig;
-const TestWatcher = require('./TestWatcher');
-const {createDirectory} = require('jest-util');
+const {run} = require('./cli');
 const runJest = require('./runJest');
+const TestWatcher = require('./TestWatcher');
 const watch = require('./watch');
-const getMaxWorkers = require('./lib/getMaxWorkers');
-const createHasteContext = require('./lib/createHasteContext');
-const logDebugMessages = require('./lib/logDebugMessages');
 
 const VERSION = require('../package.json').version;
 

--- a/packages/jest-cli/src/jest.js
+++ b/packages/jest-cli/src/jest.js
@@ -11,7 +11,6 @@
 
 import type {AggregatedResult} from 'types/TestResult';
 import type {Path} from 'types/Config';
-import type {PatternInfo} from './SearchSource';
 
 const realFs = require('fs');
 const fs = require('graceful-fs');
@@ -24,103 +23,16 @@ const TestRunner = require('./TestRunner');
 const {Console, clearLine} = require('jest-util');
 const {formatTestResults} = require('jest-util');
 const {run} = require('./cli');
-const ansiEscapes = require('ansi-escapes');
 const chalk = require('chalk');
-const os = require('os');
-const path = require('path');
 const preRunMessage = require('./preRunMessage');
 const readConfig = require('jest-config').readConfig;
-const sane = require('sane');
-const which = require('which');
 const TestWatcher = require('./TestWatcher');
 const {createDirectory} = require('jest-util');
-const runJest = require('./runjest');
+const runJest = require('./runJest');
+const watch = require('./watch');
 const getMaxWorkers = require('./lib/getMaxWorkers');
-const setWatchMode = require('./lib/setWatchMode');
 
-const CLEAR = process.platform === 'win32' ? '\x1Bc' : '\x1B[2J\x1B[3J\x1B[H';
 const VERSION = require('../package.json').version;
-const WATCHER_DEBOUNCE = 200;
-const WATCHMAN_BIN = 'watchman';
-const KEYS = {
-  A: '61',
-  ARROW_DOWN: '1b5b42',
-  ARROW_LEFT: '1b5b44',
-  ARROW_RIGHT: '1b5b43',
-  ARROW_UP: '1b5b41',
-  BACKSPACE: process.platform === 'win32' ? '08' : '7f',
-  CONTROL_C: '03',
-  CONTROL_D: '04',
-  ENTER: '0d',
-  ESCAPE: '1b',
-  O: '6f',
-  P: '70',
-  Q: '71',
-  QUESTION_MARK: '3f',
-  U: '75',
-};
-
-const getTestSummary = (
-  argv: Object,
-  patternInfo: PatternInfo,
-) => {
-  const testPathPattern = SearchSource.getTestPathPattern(patternInfo);
-  const testInfo = patternInfo.onlyChanged
-    ? chalk.dim(' related to changed files')
-    : patternInfo.input !== ''
-      ? chalk.dim(' matching ') + testPathPattern
-      : '';
-
-  const nameInfo = argv.testNamePattern
-    ? chalk.dim(' with tests matching ') + `"${argv.testNamePattern}"`
-    : '';
-
-  return (
-    chalk.dim('Ran all test suites') +
-    testInfo +
-    nameInfo +
-    chalk.dim('.')
-  );
-};
-
-const getWatcher = (
-  config,
-  packageRoot,
-  callback,
-  options,
-) => {
-  which(WATCHMAN_BIN, (err, resolvedPath) => {
-    const watchman = !err && options.useWatchman && resolvedPath;
-    const glob = config.moduleFileExtensions.map(ext => '**/*' + ext);
-    const watcher = sane(packageRoot, {glob, watchman});
-    callback(watcher);
-  });
-};
-
-const usage = (
-  argv,
-  snapshotFailure,
-  delimiter = '\n',
-) => {
-  /* eslint-disable max-len */
-  const messages = [
-    '\n' + chalk.bold('Watch Usage'),
-    argv.watch
-      ? chalk.dim(' \u203A Press ') + 'a' + chalk.dim(' to run all tests.')
-      : null,
-    (argv.watchAll || argv._) && !argv.noSCM
-      ? chalk.dim(' \u203A Press ') + 'o' + chalk.dim(' to only run tests related to changed files.')
-      : null,
-    snapshotFailure
-      ? chalk.dim(' \u203A Press ') + 'u' + chalk.dim(' to update failing snapshots.')
-      : null,
-    chalk.dim(' \u203A Press ') + 'p' + chalk.dim(' to filter by a filename regex pattern.'),
-    chalk.dim(' \u203A Press ') + 'q' + chalk.dim(' to quit watch mode.'),
-    chalk.dim(' \u203A Press ') + 'Enter' + chalk.dim(' to trigger a test run.'),
-  ];
-  /* eslint-enable max-len */
-  return messages.filter(message => !!message).join(delimiter);
-};
 
 const getHasteMapAndHasteContext = (config, options) => {
   createDirectory(config.cacheDirectory);
@@ -128,7 +40,7 @@ const getHasteMapAndHasteContext = (config, options) => {
     console: options.console,
     maxWorkers: options.maxWorkers,
     resetCache: !config.cache,
-    watch: options.watch
+    watch: options.watch,
   });
 
   return jestHasteMap.build().then(
@@ -145,7 +57,7 @@ const getHasteMapAndHasteContext = (config, options) => {
     hasteMap,
     jestHasteMap,
   }));
-}
+};
 
 const runCLI = (
   argv: Object,
@@ -168,7 +80,6 @@ const runCLI = (
       watch: config.watch,
     }))
     .then(({config, jestHasteMap, hasteMap}) => {
-      let hasteMapFS = hasteMap;
       if (argv.debug) {
         /* $FlowFixMe */
         const testFramework = require(config.testRunner);
@@ -177,173 +88,7 @@ const runCLI = (
         pipe.write('config = ' + JSON.stringify(config, null, '  ') + '\n');
       }
       if (argv.watch || argv.watchAll) {
-        setWatchMode(argv, argv.watch ? 'watch' : 'watchAll', {
-          pattern: argv._,
-        });
-
-        let currentPattern = '';
-        let hasSnapshotFailure = false;
-        let isEnteringPattern = false;
-        let isRunning = false;
-        let testWatcher;
-        let timer;
-        let displayHelp = true;
-
-        jestHasteMap.on('change', ({hasteFS}) => {
-          // hasteMapFS = hasteFS;
-          startRun();
-        });
-
-        const writeCurrentPattern = () => {
-          clearLine(pipe);
-          pipe.write(chalk.dim(' pattern \u203A ') + currentPattern);
-        };
-
-        const startRun = (overrideConfig: Object = {}) => {
-          if (isRunning) {
-            return null;
-          }
-
-          testWatcher = new TestWatcher({isWatchMode: true});
-          pipe.write(CLEAR);
-          preRunMessage.print(pipe);
-          isRunning = true;
-          return runJest(
-            hasteMapFS,
-            Object.freeze(Object.assign({}, config, overrideConfig)),
-            argv,
-            pipe,
-            testWatcher,
-            results => {
-              isRunning = false;
-              hasSnapshotFailure = !!results.snapshot.failure;
-              testWatcher.setState({interrupted: false});
-              if (displayHelp) {
-                console.log(usage(argv, hasSnapshotFailure));
-                displayHelp = !process.env.JEST_HIDE_USAGE;
-              }
-            },
-          ).then(
-            () => {},
-            error => console.error(chalk.red(error.stack)),
-          );
-        };
-
-        const onKeypress = (key: string) => {
-          if (key === KEYS.CONTROL_C || key === KEYS.CONTROL_D) {
-            process.exit(0);
-            return;
-          }
-          if (isEnteringPattern) {
-            switch (key) {
-              case KEYS.ENTER:
-                isEnteringPattern = false;
-                setWatchMode(argv, 'watch', {
-                  pattern: [currentPattern],
-                });
-                startRun();
-                break;
-              case KEYS.ESCAPE:
-                isEnteringPattern = false;
-                pipe.write(ansiEscapes.eraseLines(2));
-                currentPattern = argv._[0];
-                break;
-              case KEYS.ARROW_DOWN:
-              case KEYS.ARROW_LEFT:
-              case KEYS.ARROW_RIGHT:
-              case KEYS.ARROW_UP:
-                break;
-              default:
-                const char = new Buffer(key, 'hex').toString();
-                currentPattern = key === KEYS.BACKSPACE
-                  ? currentPattern.slice(0, -1)
-                  : currentPattern + char;
-                writeCurrentPattern();
-                break;
-            }
-            return;
-          }
-
-          // Abort test run
-          if (
-            isRunning &&
-            testWatcher &&
-            [KEYS.Q, KEYS.ENTER, KEYS.A, KEYS.O, KEYS.P].indexOf(key) !== -1
-          ) {
-            testWatcher.setState({interrupted: true});
-            return;
-          }
-
-          switch (key) {
-            case KEYS.Q:
-              process.exit(0);
-              return;
-            case KEYS.ENTER:
-              startRun();
-              break;
-            case KEYS.U:
-              startRun({updateSnapshot: true});
-              break;
-            case KEYS.A:
-              setWatchMode(argv, 'watchAll');
-              startRun();
-              break;
-            case KEYS.O:
-              setWatchMode(argv, 'watch');
-              startRun();
-              break;
-            case KEYS.P:
-              isEnteringPattern = true;
-              currentPattern = '';
-              pipe.write('\n');
-              writeCurrentPattern();
-              break;
-            case KEYS.QUESTION_MARK:
-              if (process.env.JEST_HIDE_USAGE) {
-                console.log(usage(argv, hasSnapshotFailure));
-              }
-              break;
-          }
-        };
-
-        const onFileChange = (_, filePath: string) => {
-          filePath = path.join(root, filePath);
-          const coverageDirectory =
-            config.coverageDirectory ||
-            path.resolve(config.rootDir, 'coverage');
-          const isValidPath =
-            config.testPathDirs.some(dir => filePath.startsWith(dir)) &&
-            !filePath.includes(coverageDirectory);
-
-          if (!isValidPath) {
-            return;
-          }
-          if (timer) {
-            clearTimeout(timer);
-            timer = null;
-          }
-          if (testWatcher && testWatcher.isInterrupted()) {
-            return;
-          }
-          timer = setTimeout(startRun, WATCHER_DEBOUNCE);
-        };
-
-        if (typeof process.stdin.setRawMode === 'function') {
-          process.stdin.setRawMode(true);
-          process.stdin.resume();
-          process.stdin.setEncoding('hex');
-          process.stdin.on('data', onKeypress);
-        }
-        const callback = watcher => {
-          watcher.on('error', error => {
-            watcher.close();
-            getWatcher(config, root, callback, {useWatchman: false});
-          });
-          watcher.on('all', onFileChange);
-        };
-        // getWatcher(config, root, callback, {useWatchman: true});
-        startRun();
-        return Promise.resolve();
+        return watch(config, pipe, argv, jestHasteMap, hasteMap);
       } else {
         preRunMessage.print(pipe);
         const testWatcher = new TestWatcher({isWatchMode: false});

--- a/packages/jest-cli/src/jest.js
+++ b/packages/jest-cli/src/jest.js
@@ -33,6 +33,7 @@ const readConfig = require('jest-config').readConfig;
 const sane = require('sane');
 const which = require('which');
 const TestWatcher = require('./TestWatcher');
+const {createDirectory} = require('jest-util');
 
 const CLEAR = process.platform === 'win32' ? '\x1Bc' : '\x1B[2J\x1B[3J\x1B[H';
 const VERSION = require('../package.json').version;
@@ -313,6 +314,19 @@ const runCLI = (
         let testWatcher;
         let timer;
         let displayHelp = true;
+        const maxWorkers = getMaxWorkers(argv);
+        const localConsole = new Console(pipe,
+           pipe);
+         createDirectory(config.cacheDirectory);
+         const instance = Runtime.createHasteMap(config, {
+           console: localConsole,
+           maxWorkers,
+           resetCache: !config.cache,
+           watch: config.watch
+         });
+         instance.build().then(hasteMap => {
+           instance.on('change', startRun)
+         })
 
         const writeCurrentPattern = () => {
           clearLine(pipe);
@@ -460,8 +474,8 @@ const runCLI = (
           });
           watcher.on('all', onFileChange);
         };
-        getWatcher(config, root, callback, {useWatchman: true});
-        startRun();
+        // getWatcher(config, root, callback, {useWatchman: true});
+        // startRun();
         return Promise.resolve();
       } else {
         preRunMessage.print(pipe);

--- a/packages/jest-cli/src/jest.js
+++ b/packages/jest-cli/src/jest.js
@@ -82,7 +82,7 @@ const runCLI = (
           return runJest(hasteContext, config, argv, pipe, testWatcher,
             onComplete);
         }
-      })
+      });
     })
     .catch(error => {
       clearLine(process.stderr);

--- a/packages/jest-cli/src/jest.js
+++ b/packages/jest-cli/src/jest.js
@@ -52,9 +52,9 @@ const getHasteMapAndHasteContext = (config, options) => {
       throw error;
     },
   )
-  .then(hasteMap => ({
+  .then(hasteContext => ({
     config,
-    hasteMap,
+    hasteContext,
     jestHasteMap,
   }));
 };
@@ -79,7 +79,7 @@ const runCLI = (
       resetCache: !config.cache,
       watch: config.watch,
     }))
-    .then(({config, jestHasteMap, hasteMap}) => {
+    .then(({config, jestHasteMap, hasteContext}) => {
       if (argv.debug) {
         /* $FlowFixMe */
         const testFramework = require(config.testRunner);
@@ -88,11 +88,11 @@ const runCLI = (
         pipe.write('config = ' + JSON.stringify(config, null, '  ') + '\n');
       }
       if (argv.watch || argv.watchAll) {
-        return watch(config, pipe, argv, jestHasteMap, hasteMap);
+        return watch(config, pipe, argv, jestHasteMap, hasteContext);
       } else {
         preRunMessage.print(pipe);
         const testWatcher = new TestWatcher({isWatchMode: false});
-        return runJest(hasteMap, config, argv, pipe, testWatcher,
+        return runJest(hasteContext, config, argv, pipe, testWatcher,
           onComplete);
       }
     })

--- a/packages/jest-cli/src/lib/__tests__/getMaxWorkers-test.js
+++ b/packages/jest-cli/src/lib/__tests__/getMaxWorkers-test.js
@@ -1,0 +1,32 @@
+/**
+* Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+*
+* This source code is licensed under the BSD-style license found in the
+* LICENSE file in the root directory of this source tree. An additional grant
+* of patent rights can be found in the PATENTS file in the same directory.
+*
+* @flow
+*/
+
+const getMaxWorkers = require('../getMaxWorkers');
+
+jest.mock('os', () => ({
+  cpus: () => ({length: 4}),
+}));
+
+describe('getMaxWorkers', () => {
+  it('Returns 1 when runInBand', () => {
+    const argv = {runInBand: true};
+    expect(getMaxWorkers(argv)).toBe(1);
+  })
+
+  it('Returns the `maxWorkers` when specified', () => {
+    const argv = {maxWorkers: 8};
+    expect(getMaxWorkers(argv)).toBe(8);
+  });
+
+  it('Returns based on the number of cpus', () => {
+    expect(getMaxWorkers({})).toBe(3);
+    expect(getMaxWorkers({watch: true})).toBe(2);
+  });
+})

--- a/packages/jest-cli/src/lib/__tests__/getMaxWorkers-test.js
+++ b/packages/jest-cli/src/lib/__tests__/getMaxWorkers-test.js
@@ -5,7 +5,7 @@
 * LICENSE file in the root directory of this source tree. An additional grant
 * of patent rights can be found in the PATENTS file in the same directory.
 *
-* @flow
+* @emails oncall+jsinfra
 */
 
 const getMaxWorkers = require('../getMaxWorkers');
@@ -18,7 +18,7 @@ describe('getMaxWorkers', () => {
   it('Returns 1 when runInBand', () => {
     const argv = {runInBand: true};
     expect(getMaxWorkers(argv)).toBe(1);
-  })
+  });
 
   it('Returns the `maxWorkers` when specified', () => {
     const argv = {maxWorkers: 8};
@@ -29,4 +29,4 @@ describe('getMaxWorkers', () => {
     expect(getMaxWorkers({})).toBe(3);
     expect(getMaxWorkers({watch: true})).toBe(2);
   });
-})
+});

--- a/packages/jest-cli/src/lib/__tests__/logDebugMessages-test.js
+++ b/packages/jest-cli/src/lib/__tests__/logDebugMessages-test.js
@@ -1,0 +1,53 @@
+/**
+* Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+*
+* This source code is licensed under the BSD-style license found in the
+* LICENSE file in the root directory of this source tree. An additional grant
+* of patent rights can be found in the PATENTS file in the same directory.
+*
+* @emails oncall+jsinfra
+*/
+
+const logDebugMessages = require('../logDebugMessages');
+
+jest.mock('../../../package.json', () => ({version: 123}));
+
+jest.mock('myRunner', () => ({name: 'My Runner'}), {virtual: true});
+
+const getPipe = () => ({write: jest.fn()});
+
+describe('logDebugMessages', () => {
+  it('Prints the jest version', () => {
+    const pipe = getPipe();
+    logDebugMessages({testRunner: 'myRunner'}, pipe);
+    expect(pipe.write).toHaveBeenCalledWith('jest version = 123\n');
+  });
+
+  it('Prints the test framework name', () => {
+    const pipe = getPipe();
+    logDebugMessages({testRunner: 'myRunner'}, pipe);
+    expect(pipe.write).toHaveBeenCalledWith('test framework = My Runner\n');
+  });
+
+  it('Prints the config object', () => {
+    const pipe = getPipe();
+    logDebugMessages({
+      automock: false,
+      rootDir: '/path/to/dir',
+      testPathDirs: ['path/to/dir/test'],
+      testRunner: 'myRunner',
+      watch: true,
+    }, pipe);
+    expect(pipe.write).toHaveBeenCalledWith(
+      `config = {
+  "automock": false,
+  "rootDir": "/path/to/dir",
+  "testPathDirs": [
+    "path/to/dir/test"
+  ],
+  "testRunner": "myRunner",
+  "watch": true
+}\n`
+    );
+  });
+});

--- a/packages/jest-cli/src/lib/__tests__/setWatchMode-test.js
+++ b/packages/jest-cli/src/lib/__tests__/setWatchMode-test.js
@@ -1,0 +1,50 @@
+/**
+* Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+*
+* This source code is licensed under the BSD-style license found in the
+* LICENSE file in the root directory of this source tree. An additional grant
+* of patent rights can be found in the PATENTS file in the same directory.
+*
+* @flow
+*/
+'use strict';
+
+const setWatchMode = require('../setWatchMode');
+
+describe('setWatchMode()', () => {
+  it('Sets watch and watchAll flags based on the mode', () => {
+    let argv = {};
+    setWatchMode(argv, 'watch', {})
+    expect(argv.watch).toBeTruthy();
+    expect(argv.watchAll).toBeFalsy();
+
+    argv = {};
+    setWatchMode(argv, 'watchAll', {})
+    expect(argv.watch).toBeFalsy();
+    expect(argv.watchAll).toBeTruthy();
+  });
+
+  it('Sets the onlyChanged flag then in watch and with no pattern', () => {
+    let argv = {};
+    setWatchMode(argv, 'watch', {})
+    expect(argv.onlyChanged).toBeTruthy();
+
+    argv = {testPathPattern: 'jest-cli'};
+    setWatchMode(argv, 'watch', {})
+    expect(argv.onlyChanged).toBeFalsy();
+
+    argv = {};
+    setWatchMode(argv, 'watchAll', {})
+    expect(argv.onlyChanged).toBeFalsy();
+  });
+
+  it('Sets the noSCM flag when the options specify it', () => {
+    let argv = {};
+    setWatchMode(argv, 'watch', {noSCM: true});
+    expect(argv.noSCM).toBeTruthy();
+
+    argv = {};
+    setWatchMode(argv, 'watch', {noSCM: false});
+    expect(argv.noSCM).toBeFalsy();
+  })
+});

--- a/packages/jest-cli/src/lib/__tests__/setWatchMode-test.js
+++ b/packages/jest-cli/src/lib/__tests__/setWatchMode-test.js
@@ -5,7 +5,7 @@
 * LICENSE file in the root directory of this source tree. An additional grant
 * of patent rights can be found in the PATENTS file in the same directory.
 *
-* @flow
+* @emails oncall+jsinfra
 */
 'use strict';
 
@@ -14,27 +14,27 @@ const setWatchMode = require('../setWatchMode');
 describe('setWatchMode()', () => {
   it('Sets watch and watchAll flags based on the mode', () => {
     let argv = {};
-    setWatchMode(argv, 'watch', {})
+    setWatchMode(argv, 'watch', {});
     expect(argv.watch).toBeTruthy();
     expect(argv.watchAll).toBeFalsy();
 
     argv = {};
-    setWatchMode(argv, 'watchAll', {})
+    setWatchMode(argv, 'watchAll', {});
     expect(argv.watch).toBeFalsy();
     expect(argv.watchAll).toBeTruthy();
   });
 
   it('Sets the onlyChanged flag then in watch and with no pattern', () => {
     let argv = {};
-    setWatchMode(argv, 'watch', {})
+    setWatchMode(argv, 'watch', {});
     expect(argv.onlyChanged).toBeTruthy();
 
     argv = {testPathPattern: 'jest-cli'};
-    setWatchMode(argv, 'watch', {})
+    setWatchMode(argv, 'watch', {});
     expect(argv.onlyChanged).toBeFalsy();
 
     argv = {};
-    setWatchMode(argv, 'watchAll', {})
+    setWatchMode(argv, 'watchAll', {});
     expect(argv.onlyChanged).toBeFalsy();
   });
 
@@ -46,5 +46,5 @@ describe('setWatchMode()', () => {
     argv = {};
     setWatchMode(argv, 'watch', {noSCM: false});
     expect(argv.noSCM).toBeFalsy();
-  })
+  });
 });

--- a/packages/jest-cli/src/lib/buildTestPathPatternInfo.js
+++ b/packages/jest-cli/src/lib/buildTestPathPatternInfo.js
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+'use strict';
+
+import type {PatternInfo} from '../SearchSource';
+const {clearLine} = require('jest-util');
+const chalk = require('chalk');
+
+const buildTestPathPatternInfo = (argv: Object): PatternInfo => {
+  const defaultPattern = {
+    input: '',
+    shouldTreatInputAsPattern: false,
+    testPathPattern: '',
+  };
+  const validatePattern = patternInfo => {
+    const {testPathPattern} = patternInfo;
+    if (testPathPattern) {
+      try {
+        /* eslint-disable no-new */
+        new RegExp(testPathPattern);
+        /* eslint-enable no-new */
+      } catch (error) {
+        clearLine(process.stdout);
+        console.log(chalk.red(
+          'Invalid testPattern ' + String(testPathPattern) + ' supplied. ' +
+          'Running all tests instead.',
+        ));
+        return defaultPattern;
+      }
+    }
+    return patternInfo;
+  };
+  if (argv.onlyChanged) {
+    return {
+      input: '',
+      lastCommit: argv.lastCommit,
+      onlyChanged: true,
+      watch: argv.watch,
+    };
+  }
+  if (argv.testPathPattern) {
+    return validatePattern({
+      input: argv.testPathPattern,
+      shouldTreatInputAsPattern: true,
+      testPathPattern: argv.testPathPattern,
+    });
+  }
+  if (argv._ && argv._.length) {
+    return validatePattern({
+      findRelatedTests: argv.findRelatedTests,
+      input: argv._.join(' '),
+      paths: argv._,
+      shouldTreatInputAsPattern: false,
+      testPathPattern: argv._.join('|'),
+    });
+  }
+  return defaultPattern;
+};
+
+module.exports = buildTestPathPatternInfo;

--- a/packages/jest-cli/src/lib/buildTestPathPatternInfo.js
+++ b/packages/jest-cli/src/lib/buildTestPathPatternInfo.js
@@ -10,6 +10,7 @@
 'use strict';
 
 import type {PatternInfo} from '../SearchSource';
+
 const {clearLine} = require('jest-util');
 const chalk = require('chalk');
 

--- a/packages/jest-cli/src/lib/createHasteContext.js
+++ b/packages/jest-cli/src/lib/createHasteContext.js
@@ -20,6 +20,7 @@ const createHasteContext = (
   {hasteFS, moduleMap}: HasteMap,
 ): HasteContext => ({
   hasteFS,
+  moduleMap,
   resolver: Runtime.createResolver(config, moduleMap),
 });
 

--- a/packages/jest-cli/src/lib/createHasteContext.js
+++ b/packages/jest-cli/src/lib/createHasteContext.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+
+'use strict';
+
+import type {Config} from 'types/Config';
+import type {HasteMap, HasteContext} from 'types/HasteMap';
+
+const Runtime = require('jest-runtime');
+
+const createHasteContext = (
+  config: Config,
+  {hasteFS, moduleMap}: HasteMap,
+): HasteContext => ({
+  hasteFS,
+  resolver: Runtime.createResolver(config, moduleMap),
+});
+
+module.exports = createHasteContext;

--- a/packages/jest-cli/src/lib/getMaxWorkers.js
+++ b/packages/jest-cli/src/lib/getMaxWorkers.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+'use strict';
+
+const os = require('os');
+
+const getMaxWorkers = argv => {
+  if (argv.runInBand) {
+    return 1;
+  } else if (argv.maxWorkers) {
+    return parseInt(argv.maxWorkers, 10);
+  } else {
+    const cpus = os.cpus().length;
+    return Math.max(argv.watch ? Math.floor(cpus / 2) : cpus - 1, 1);
+  }
+};
+
+module.exports = getMaxWorkers;

--- a/packages/jest-cli/src/lib/getMaxWorkers.js
+++ b/packages/jest-cli/src/lib/getMaxWorkers.js
@@ -11,7 +11,8 @@
 
 const os = require('os');
 
-const getMaxWorkers = argv => {
+// eslint-disable-next-line arrow-parens
+const getMaxWorkers = (argv: Object): number => {
   if (argv.runInBand) {
     return 1;
   } else if (argv.maxWorkers) {

--- a/packages/jest-cli/src/lib/logDebugMessages.js
+++ b/packages/jest-cli/src/lib/logDebugMessages.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+
+'use strict';
+
+import type {Config} from 'types/Config';
+
+const VERSION = require('../../package.json').version;
+
+const logDebugMessages = (
+  config: Config,
+  pipe: stream$Writable | tty$WriteStream,
+): void => {
+  /* $FlowFixMe */
+  const testFramework = require(config.testRunner);
+  pipe.write('jest version = ' + VERSION + '\n');
+  pipe.write('test framework = ' + testFramework.name + '\n');
+  pipe.write('config = ' + JSON.stringify(config, null, '  ') + '\n');
+
+};
+
+module.exports = logDebugMessages;

--- a/packages/jest-cli/src/lib/setWatchMode.js
+++ b/packages/jest-cli/src/lib/setWatchMode.js
@@ -1,0 +1,23 @@
+const buildTestPathPatternInfo = require('./buildTestPathPatternInfo');
+
+const setWatchMode = (argv, mode: 'watch' | 'watchAll', options) => {
+  if (mode === 'watch') {
+    argv.watch = true;
+    argv.watchAll = false;
+  } else if (mode === 'watchAll') {
+    argv.watch = false;
+    argv.watchAll = true;
+  }
+
+  // Reset before setting these to the new values
+  argv._ = (options && options.pattern) || '';
+  argv.onlyChanged = false;
+  argv.onlyChanged =
+    buildTestPathPatternInfo(argv).input === '' && !argv.watchAll;
+
+  if (options && options.noSCM) {
+    argv.noSCM = true;
+  }
+};
+
+module.exports = setWatchMode;

--- a/packages/jest-cli/src/lib/setWatchMode.js
+++ b/packages/jest-cli/src/lib/setWatchMode.js
@@ -1,6 +1,21 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+'use strict';
+
 const buildTestPathPatternInfo = require('./buildTestPathPatternInfo');
 
-const setWatchMode = (argv, mode: 'watch' | 'watchAll', options) => {
+const setWatchMode = (
+  argv: Object,
+  mode: 'watch' | 'watchAll',
+  options: Object,
+) => {
   if (mode === 'watch') {
     argv.watch = true;
     argv.watchAll = false;

--- a/packages/jest-cli/src/lib/setWatchMode.js
+++ b/packages/jest-cli/src/lib/setWatchMode.js
@@ -14,7 +14,7 @@ const buildTestPathPatternInfo = require('./buildTestPathPatternInfo');
 const setWatchMode = (
   argv: Object,
   mode: 'watch' | 'watchAll',
-  options: Object,
+  options?: Object,
 ) => {
   if (mode === 'watch') {
     argv.watch = true;

--- a/packages/jest-cli/src/runJest.js
+++ b/packages/jest-cli/src/runJest.js
@@ -10,6 +10,7 @@
 'use strict';
 
 import type {PatternInfo} from './SearchSource';
+import type {HasteContext} from 'types/HasteMap';
 
 const realFs = require('fs');
 const fs = require('graceful-fs');
@@ -49,12 +50,19 @@ const getTestSummary = (
   );
 };
 
-const runJest = (hasteMap, config, argv, pipe, testWatcher, onComplete) => {
+const runJest = (
+  hasteContext: HasteContext,
+  config: any,
+  argv: Object,
+  pipe: stream$Writable | tty$WriteStream,
+  testWatcher: any,
+  onComplete: (testResults: any) => void,
+) => {
   const maxWorkers = getMaxWorkers(argv);
   const localConsole = new Console(pipe, pipe);
   let patternInfo = buildTestPathPatternInfo(argv);
   return Promise.resolve().then(() => {
-    const source = new SearchSource(hasteMap, config);
+    const source = new SearchSource(hasteContext, config);
     return source.getTestPaths(patternInfo)
       .then(data => {
         if (!data.paths.length) {
@@ -87,7 +95,7 @@ const runJest = (hasteMap, config, argv, pipe, testWatcher, onComplete) => {
         }
 
         return new TestRunner(
-          hasteMap,
+          hasteContext,
           config,
           {
             getTestSummary: () => getTestSummary(argv, patternInfo),

--- a/packages/jest-cli/src/runJest.js
+++ b/packages/jest-cli/src/runJest.js
@@ -1,0 +1,128 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+'use strict';
+
+import type {PatternInfo} from './SearchSource';
+
+const realFs = require('fs');
+const fs = require('graceful-fs');
+fs.gracefulify(realFs);
+
+const SearchSource = require('./SearchSource');
+const TestRunner = require('./TestRunner');
+
+const {Console} = require('jest-util');
+const chalk = require('chalk');
+const formatTestResults = require('jest-util');
+const path = require('path');
+const getMaxWorkers = require('./lib/getMaxWorkers');
+const setWatchMode = require('./lib/setWatchMode');
+const buildTestPathPatternInfo = require('./lib/buildTestPathPatternInfo');
+
+const getTestSummary = (
+  argv: Object,
+  patternInfo: PatternInfo,
+) => {
+  const testPathPattern = SearchSource.getTestPathPattern(patternInfo);
+  const testInfo = patternInfo.onlyChanged
+    ? chalk.dim(' related to changed files')
+    : patternInfo.input !== ''
+      ? chalk.dim(' matching ') + testPathPattern
+      : '';
+
+  const nameInfo = argv.testNamePattern
+    ? chalk.dim(' with tests matching ') + `"${argv.testNamePattern}"`
+    : '';
+
+  return (
+    chalk.dim('Ran all test suites') +
+    testInfo +
+    nameInfo +
+    chalk.dim('.')
+  );
+};
+
+const runJest = (hasteMap, config, argv, pipe, testWatcher, onComplete) => {
+  const maxWorkers = getMaxWorkers(argv);
+  const localConsole = new Console(pipe, pipe);
+  let patternInfo = buildTestPathPatternInfo(argv);
+  return Promise.resolve().then(() => {
+    const source = new SearchSource(hasteMap, config);
+    return source.getTestPaths(patternInfo)
+      .then(data => {
+        if (!data.paths.length) {
+          if (patternInfo.onlyChanged && data.noSCM) {
+            if (config.watch) {
+              // Run all the tests
+              setWatchMode(argv, 'watchAll', {
+                noSCM: true,
+              });
+              patternInfo = buildTestPathPatternInfo(argv);
+              return source.getTestPaths(patternInfo);
+            } else {
+              localConsole.log(
+                'Jest can only find uncommitted changed files in a git or hg ' +
+                'repository. If you make your project a git or hg repository ' +
+                '(`git init` or `hg init`), Jest will be able to only ' +
+                'run tests related to files changed since the last commit.',
+              );
+            }
+          }
+
+          localConsole.log(
+            source.getNoTestsFoundMessage(patternInfo, config, data),
+          );
+        }
+        return data;
+      }).then(data => {
+        if (data.paths.length === 1 && config.verbose !== false) {
+          config = Object.assign({}, config, {verbose: true});
+        }
+
+        return new TestRunner(
+          hasteMap,
+          config,
+          {
+            getTestSummary: () => getTestSummary(argv, patternInfo),
+            maxWorkers,
+          },
+        ).runTests(data.paths, testWatcher);
+      })
+      .then(runResults => {
+        if (config.testResultsProcessor) {
+          /* $FlowFixMe */
+          runResults = require(config.testResultsProcessor)(runResults);
+        }
+        if (argv.json) {
+          if (argv.outputFile) {
+            const outputFile = path.resolve(process.cwd(), argv.outputFile);
+
+            fs.writeFileSync(
+              outputFile,
+              JSON.stringify(formatTestResults(runResults)),
+            );
+            process.stdout.write(
+              `Test results written to: ` +
+              `${path.relative(process.cwd(), outputFile)}\n`,
+            );
+          } else {
+            process.stdout.write(
+              JSON.stringify(formatTestResults(runResults)),
+            );
+          }
+        }
+        return onComplete && onComplete(runResults);
+      }).catch(error => {
+        throw error;
+      });
+  });
+};
+
+module.exports = runJest;

--- a/packages/jest-cli/src/runJest.js
+++ b/packages/jest-cli/src/runJest.js
@@ -12,20 +12,17 @@
 import type {PatternInfo} from './SearchSource';
 import type {HasteContext} from 'types/HasteMap';
 
-const realFs = require('fs');
 const fs = require('graceful-fs');
-fs.gracefulify(realFs);
 
 const SearchSource = require('./SearchSource');
 const TestRunner = require('./TestRunner');
 
-const {Console} = require('jest-util');
-const chalk = require('chalk');
-const formatTestResults = require('jest-util');
-const path = require('path');
-const getMaxWorkers = require('./lib/getMaxWorkers');
-const setWatchMode = require('./lib/setWatchMode');
 const buildTestPathPatternInfo = require('./lib/buildTestPathPatternInfo');
+const chalk = require('chalk');
+const {Console, formatTestResults} = require('jest-util');
+const getMaxWorkers = require('./lib/getMaxWorkers');
+const path = require('path');
+const setWatchMode = require('./lib/setWatchMode');
 
 const getTestSummary = (
   argv: Object,

--- a/packages/jest-cli/src/watch.js
+++ b/packages/jest-cli/src/watch.js
@@ -16,12 +16,14 @@ const fs = require('graceful-fs');
 fs.gracefulify(realFs);
 
 const {clearLine} = require('jest-util');
+const Runtime = require('jest-runtime');
 const ansiEscapes = require('ansi-escapes');
 const chalk = require('chalk');
 const preRunMessage = require('./preRunMessage');
 const TestWatcher = require('./TestWatcher');
 const runJest = require('./runjest');
 const setWatchMode = require('./lib/setWatchMode');
+const HasteMap = require('jest-haste-map');
 
 const CLEAR = process.platform === 'win32' ? '\x1Bc' : '\x1B[2J\x1B[3J\x1B[H';
 const KEYS = {
@@ -47,6 +49,7 @@ const watch = (
   config: any,
   pipe: stream$Writable | tty$WriteStream,
   argv: Object,
+  jestHasteMap: HasteMap,
   hasteContext: HasteContext,
 ) => {
   setWatchMode(argv, argv.watch ? 'watch' : 'watchAll', {
@@ -59,6 +62,16 @@ const watch = (
   let isRunning = false;
   let testWatcher;
   let displayHelp = true;
+
+  jestHasteMap.on('change', ({eventsQueue, hasteFS, moduleMap}) => {
+    if (eventsQueue.find(({type}) => type !== 'change')) {
+      hasteContext = {
+        hasteFS,
+        resolver: Runtime.createResolver(config, moduleMap),
+      };
+    }
+    startRun();
+  });
 
   const writeCurrentPattern = () => {
     clearLine(pipe);

--- a/packages/jest-cli/src/watch.js
+++ b/packages/jest-cli/src/watch.js
@@ -1,0 +1,209 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+'use strict';
+
+const realFs = require('fs');
+const fs = require('graceful-fs');
+fs.gracefulify(realFs);
+
+const {clearLine} = require('jest-util');
+const ansiEscapes = require('ansi-escapes');
+const chalk = require('chalk');
+const preRunMessage = require('./preRunMessage');
+const TestWatcher = require('./TestWatcher');
+const runJest = require('./runjest');
+const setWatchMode = require('./lib/setWatchMode');
+
+const CLEAR = process.platform === 'win32' ? '\x1Bc' : '\x1B[2J\x1B[3J\x1B[H';
+const KEYS = {
+  A: '61',
+  ARROW_DOWN: '1b5b42',
+  ARROW_LEFT: '1b5b44',
+  ARROW_RIGHT: '1b5b43',
+  ARROW_UP: '1b5b41',
+  BACKSPACE: process.platform === 'win32' ? '08' : '7f',
+  CONTROL_C: '03',
+  CONTROL_D: '04',
+  ENTER: '0d',
+  ESCAPE: '1b',
+  O: '6f',
+  P: '70',
+  Q: '71',
+  QUESTION_MARK: '3f',
+  U: '75',
+};
+
+
+const watch = (config, pipe, argv, jestHasteMap, hasteMapFS) => {
+  setWatchMode(argv, argv.watch ? 'watch' : 'watchAll', {
+    pattern: argv._,
+  });
+
+  let currentPattern = '';
+  let hasSnapshotFailure = false;
+  let isEnteringPattern = false;
+  let isRunning = false;
+  let testWatcher;
+  let displayHelp = true;
+
+  jestHasteMap.on('change', ({hasteFS}) => {
+    // hasteMapFS = hasteFS;
+    startRun();
+  });
+
+  const writeCurrentPattern = () => {
+    clearLine(pipe);
+    pipe.write(chalk.dim(' pattern \u203A ') + currentPattern);
+  };
+
+  const startRun = (overrideConfig: Object = {}) => {
+    if (isRunning) {
+      return null;
+    }
+
+    testWatcher = new TestWatcher({isWatchMode: true});
+    pipe.write(CLEAR);
+    preRunMessage.print(pipe);
+    isRunning = true;
+    return runJest(
+      hasteMapFS,
+      Object.freeze(Object.assign({}, config, overrideConfig)),
+      argv,
+      pipe,
+      testWatcher,
+      results => {
+        isRunning = false;
+        hasSnapshotFailure = !!results.snapshot.failure;
+        testWatcher.setState({interrupted: false});
+        if (displayHelp) {
+          console.log(usage(argv, hasSnapshotFailure));
+          displayHelp = !process.env.JEST_HIDE_USAGE;
+        }
+      },
+    ).then(
+      () => {},
+      error => console.error(chalk.red(error.stack)),
+    );
+  };
+
+  const onKeypress = (key: string) => {
+    if (key === KEYS.CONTROL_C || key === KEYS.CONTROL_D) {
+      process.exit(0);
+      return;
+    }
+    if (isEnteringPattern) {
+      switch (key) {
+        case KEYS.ENTER:
+          isEnteringPattern = false;
+          setWatchMode(argv, 'watch', {
+            pattern: [currentPattern],
+          });
+          startRun();
+          break;
+        case KEYS.ESCAPE:
+          isEnteringPattern = false;
+          pipe.write(ansiEscapes.eraseLines(2));
+          currentPattern = argv._[0];
+          break;
+        case KEYS.ARROW_DOWN:
+        case KEYS.ARROW_LEFT:
+        case KEYS.ARROW_RIGHT:
+        case KEYS.ARROW_UP:
+          break;
+        default:
+          const char = new Buffer(key, 'hex').toString();
+          currentPattern = key === KEYS.BACKSPACE
+            ? currentPattern.slice(0, -1)
+            : currentPattern + char;
+          writeCurrentPattern();
+          break;
+      }
+      return;
+    }
+
+    // Abort test run
+    if (
+      isRunning &&
+      testWatcher &&
+      [KEYS.Q, KEYS.ENTER, KEYS.A, KEYS.O, KEYS.P].indexOf(key) !== -1
+    ) {
+      testWatcher.setState({interrupted: true});
+      return;
+    }
+
+    switch (key) {
+      case KEYS.Q:
+        process.exit(0);
+        return;
+      case KEYS.ENTER:
+        startRun();
+        break;
+      case KEYS.U:
+        startRun({updateSnapshot: true});
+        break;
+      case KEYS.A:
+        setWatchMode(argv, 'watchAll');
+        startRun();
+        break;
+      case KEYS.O:
+        setWatchMode(argv, 'watch');
+        startRun();
+        break;
+      case KEYS.P:
+        isEnteringPattern = true;
+        currentPattern = '';
+        pipe.write('\n');
+        writeCurrentPattern();
+        break;
+      case KEYS.QUESTION_MARK:
+        if (process.env.JEST_HIDE_USAGE) {
+          console.log(usage(argv, hasSnapshotFailure));
+        }
+        break;
+    }
+  };
+
+  if (typeof process.stdin.setRawMode === 'function') {
+    process.stdin.setRawMode(true);
+    process.stdin.resume();
+    process.stdin.setEncoding('hex');
+    process.stdin.on('data', onKeypress);
+  }
+
+  startRun();
+  return Promise.resolve();
+};
+
+const usage = (
+  argv,
+  snapshotFailure,
+  delimiter = '\n',
+) => {
+  /* eslint-disable max-len */
+  const messages = [
+    '\n' + chalk.bold('Watch Usage'),
+    argv.watch
+      ? chalk.dim(' \u203A Press ') + 'a' + chalk.dim(' to run all tests.')
+      : null,
+    (argv.watchAll || argv._) && !argv.noSCM
+      ? chalk.dim(' \u203A Press ') + 'o' + chalk.dim(' to only run tests related to changed files.')
+      : null,
+    snapshotFailure
+      ? chalk.dim(' \u203A Press ') + 'u' + chalk.dim(' to update failing snapshots.')
+      : null,
+    chalk.dim(' \u203A Press ') + 'p' + chalk.dim(' to filter by a filename regex pattern.'),
+    chalk.dim(' \u203A Press ') + 'q' + chalk.dim(' to quit watch mode.'),
+    chalk.dim(' \u203A Press ') + 'Enter' + chalk.dim(' to trigger a test run.'),
+  ];
+  /* eslint-enable max-len */
+  return messages.filter(message => !!message).join(delimiter);
+};
+
+module.exports = watch;

--- a/packages/jest-cli/src/watch.js
+++ b/packages/jest-cli/src/watch.js
@@ -90,7 +90,9 @@ const watch = (
       results => {
         isRunning = false;
         hasSnapshotFailure = !!results.snapshot.failure;
-        testWatcher.setState({interrupted: false});
+        if (config.bail) {
+          testWatcher.setState({interrupted: false});
+        }
         if (displayHelp) {
           console.log(usage(argv, hasSnapshotFailure));
           displayHelp = !process.env.JEST_HIDE_USAGE;

--- a/packages/jest-cli/src/watch.js
+++ b/packages/jest-cli/src/watch.js
@@ -21,7 +21,7 @@ const ansiEscapes = require('ansi-escapes');
 const chalk = require('chalk');
 const preRunMessage = require('./preRunMessage');
 const TestWatcher = require('./TestWatcher');
-const runJest = require('./runjest');
+const runJest = require('./runJest');
 const setWatchMode = require('./lib/setWatchMode');
 const HasteMap = require('jest-haste-map');
 

--- a/packages/jest-cli/src/watch.js
+++ b/packages/jest-cli/src/watch.js
@@ -21,26 +21,7 @@ const preRunMessage = require('./preRunMessage');
 const runJest = require('./runJest');
 const setWatchMode = require('./lib/setWatchMode');
 const TestWatcher = require('./TestWatcher');
-
-const CLEAR = process.platform === 'win32' ? '\x1Bc' : '\x1B[2J\x1B[3J\x1B[H';
-const KEYS = {
-  A: '61',
-  ARROW_DOWN: '1b5b42',
-  ARROW_LEFT: '1b5b44',
-  ARROW_RIGHT: '1b5b43',
-  ARROW_UP: '1b5b41',
-  BACKSPACE: process.platform === 'win32' ? '08' : '7f',
-  CONTROL_C: '03',
-  CONTROL_D: '04',
-  ENTER: '0d',
-  ESCAPE: '1b',
-  O: '6f',
-  P: '70',
-  Q: '71',
-  QUESTION_MARK: '3f',
-  U: '75',
-};
-
+const {KEYS, CLEAR} = require('./constants');
 
 const watch = (
   config: Config,
@@ -48,6 +29,7 @@ const watch = (
   argv: Object,
   hasteMap: HasteMap,
   hasteContext: HasteContext,
+  stdin?: stream$Readable | tty$ReadStream = process.stdin
 ) => {
   setWatchMode(argv, argv.watch ? 'watch' : 'watchAll', {
     pattern: argv._,
@@ -93,7 +75,7 @@ const watch = (
         // and prevent test runs from the previous run.
         testWatcher = new TestWatcher({isWatchMode: true});
         if (displayHelp) {
-          console.log(usage(argv, hasSnapshotFailure));
+          pipe.write(usage(argv, hasSnapshotFailure));
           displayHelp = !process.env.JEST_HIDE_USAGE;
         }
       },
@@ -174,17 +156,17 @@ const watch = (
         break;
       case KEYS.QUESTION_MARK:
         if (process.env.JEST_HIDE_USAGE) {
-          console.log(usage(argv, hasSnapshotFailure));
+          pipe.write(usage(argv, hasSnapshotFailure));
         }
         break;
     }
   };
 
-  if (typeof process.stdin.setRawMode === 'function') {
-    process.stdin.setRawMode(true);
-    process.stdin.resume();
-    process.stdin.setEncoding('hex');
-    process.stdin.on('data', onKeypress);
+  if (typeof stdin.setRawMode === 'function') {
+    stdin.setRawMode(true);
+    stdin.resume();
+    stdin.setEncoding('hex');
+    stdin.on('data', onKeypress);
   }
 
   startRun();

--- a/packages/jest-cli/src/watch.js
+++ b/packages/jest-cli/src/watch.js
@@ -9,6 +9,8 @@
  */
 'use strict';
 
+import type {HasteContext} from 'types/HasteMap';
+
 const realFs = require('fs');
 const fs = require('graceful-fs');
 fs.gracefulify(realFs);
@@ -20,6 +22,7 @@ const preRunMessage = require('./preRunMessage');
 const TestWatcher = require('./TestWatcher');
 const runJest = require('./runjest');
 const setWatchMode = require('./lib/setWatchMode');
+const HasteMap = require('jest-haste-map');
 
 const CLEAR = process.platform === 'win32' ? '\x1Bc' : '\x1B[2J\x1B[3J\x1B[H';
 const KEYS = {
@@ -41,7 +44,13 @@ const KEYS = {
 };
 
 
-const watch = (config, pipe, argv, jestHasteMap, hasteMapFS) => {
+const watch = (
+  config: any,
+  pipe: stream$Writable | tty$WriteStream,
+  argv: Object,
+  jestHasteMap: HasteMap,
+  hasteContext: HasteContext,
+) => {
   setWatchMode(argv, argv.watch ? 'watch' : 'watchAll', {
     pattern: argv._,
   });
@@ -54,7 +63,7 @@ const watch = (config, pipe, argv, jestHasteMap, hasteMapFS) => {
   let displayHelp = true;
 
   jestHasteMap.on('change', ({hasteFS}) => {
-    // hasteMapFS = hasteFS;
+    // hasteContext = hasteFS;
     startRun();
   });
 
@@ -73,7 +82,7 @@ const watch = (config, pipe, argv, jestHasteMap, hasteMapFS) => {
     preRunMessage.print(pipe);
     isRunning = true;
     return runJest(
-      hasteMapFS,
+      hasteContext,
       Object.freeze(Object.assign({}, config, overrideConfig)),
       argv,
       pipe,

--- a/packages/jest-cli/src/watch.js
+++ b/packages/jest-cli/src/watch.js
@@ -22,7 +22,6 @@ const preRunMessage = require('./preRunMessage');
 const TestWatcher = require('./TestWatcher');
 const runJest = require('./runjest');
 const setWatchMode = require('./lib/setWatchMode');
-const HasteMap = require('jest-haste-map');
 
 const CLEAR = process.platform === 'win32' ? '\x1Bc' : '\x1B[2J\x1B[3J\x1B[H';
 const KEYS = {
@@ -48,7 +47,6 @@ const watch = (
   config: any,
   pipe: stream$Writable | tty$WriteStream,
   argv: Object,
-  jestHasteMap: HasteMap,
   hasteContext: HasteContext,
 ) => {
   setWatchMode(argv, argv.watch ? 'watch' : 'watchAll', {
@@ -61,11 +59,6 @@ const watch = (
   let isRunning = false;
   let testWatcher;
   let displayHelp = true;
-
-  jestHasteMap.on('change', ({hasteFS}) => {
-    // hasteContext = hasteFS;
-    startRun();
-  });
 
   const writeCurrentPattern = () => {
     clearLine(pipe);

--- a/packages/jest-cli/src/watch.js
+++ b/packages/jest-cli/src/watch.js
@@ -60,10 +60,8 @@ const watch = (
   let testWatcher;
   let displayHelp = true;
 
-  hasteMap.on('change', ({eventsQueue, hasteFS, moduleMap}) => {
-    if (eventsQueue.find(({type}) => type !== 'change')) {
-      hasteContext = createHasteContext(config, {hasteFS, moduleMap});
-    }
+  hasteMap.on('change', ({hasteFS, moduleMap}) => {
+    hasteContext = createHasteContext(config, {hasteFS, moduleMap});
     startRun();
   });
 
@@ -90,9 +88,10 @@ const watch = (
       results => {
         isRunning = false;
         hasSnapshotFailure = !!results.snapshot.failure;
-        if (config.bail) {
-          testWatcher.setState({interrupted: false});
-        }
+        // Create a new testWatcher instance so that re-runs won't be blocked.
+        // The old instance that was passed to Jest will still be interrupted
+        // and prevent test runs from the previous run.
+        testWatcher = new TestWatcher({isWatchMode: true});
         if (displayHelp) {
           console.log(usage(argv, hasSnapshotFailure));
           displayHelp = !process.env.JEST_HIDE_USAGE;

--- a/packages/jest-cli/src/watch.js
+++ b/packages/jest-cli/src/watch.js
@@ -12,19 +12,15 @@
 import type {HasteContext} from 'types/HasteMap';
 import type {Config} from 'types/Config';
 
-const realFs = require('fs');
-const fs = require('graceful-fs');
-fs.gracefulify(realFs);
-
-const {clearLine} = require('jest-util');
 const ansiEscapes = require('ansi-escapes');
 const chalk = require('chalk');
-const preRunMessage = require('./preRunMessage');
-const TestWatcher = require('./TestWatcher');
-const runJest = require('./runJest');
-const setWatchMode = require('./lib/setWatchMode');
+const {clearLine} = require('jest-util');
 const createHasteContext = require('./lib/createHasteContext');
 const HasteMap = require('jest-haste-map');
+const preRunMessage = require('./preRunMessage');
+const runJest = require('./runJest');
+const setWatchMode = require('./lib/setWatchMode');
+const TestWatcher = require('./TestWatcher');
 
 const CLEAR = process.platform === 'win32' ? '\x1Bc' : '\x1B[2J\x1B[3J\x1B[H';
 const KEYS = {

--- a/packages/jest-haste-map/src/ModuleMap.js
+++ b/packages/jest-haste-map/src/ModuleMap.js
@@ -15,6 +15,7 @@ import type {
   HTypeValue,
   MockData,
   ModuleMapData,
+  RawModuleMap,
 } from 'types/HasteMap';
 
 const H: HType = require('./constants');
@@ -65,6 +66,13 @@ class ModuleMap {
 
   getMockModule(name: string): ?Path {
     return this._mocks[name];
+  }
+
+  getRawModuleMap(): RawModuleMap {
+    return {
+      map: this._map,
+      mocks: this._mocks,
+    };
   }
 
 }

--- a/packages/jest-haste-map/src/index.js
+++ b/packages/jest-haste-map/src/index.js
@@ -701,8 +701,10 @@ class HasteMap extends EventEmitter {
   }
 
   static H: HType;
+  static ModuleMap: Class<HasteModuleMap>;
 }
 
 HasteMap.H = H;
+HasteMap.ModuleMap = HasteModuleMap;
 
 module.exports = HasteMap;

--- a/packages/jest-runtime/src/index.js
+++ b/packages/jest-runtime/src/index.js
@@ -43,6 +43,7 @@ type HasteMapOptions = {|
   console?: Console,
   maxWorkers: number,
   resetCache: boolean,
+  watch?: boolean,
 |};
 
 type InternalModuleOptions = {|
@@ -171,6 +172,7 @@ class Runtime {
     options: {
       console?: Console,
       maxWorkers: number,
+      watch?: boolean,
     },
   ): Promise<HasteContext> {
     createDirectory(config.cacheDirectory);
@@ -178,6 +180,7 @@ class Runtime {
       console: options.console,
       maxWorkers: options.maxWorkers,
       resetCache: !config.cache,
+      watch: options.watch
     });
     return instance.build().then(
       hasteMap => ({
@@ -212,6 +215,7 @@ class Runtime {
       retainAllFiles: false,
       roots: config.testPathDirs,
       useWatchman: config.watchman,
+      watch: (options && options.watch),
     });
   }
 

--- a/packages/jest-runtime/src/index.js
+++ b/packages/jest-runtime/src/index.js
@@ -180,7 +180,7 @@ class Runtime {
       console: options.console,
       maxWorkers: options.maxWorkers,
       resetCache: !config.cache,
-      watch: options.watch
+      watch: options.watch,
     });
     return instance.build().then(
       hasteMap => ({

--- a/packages/jest-runtime/src/index.js
+++ b/packages/jest-runtime/src/index.js
@@ -185,6 +185,7 @@ class Runtime {
     return instance.build().then(
       hasteMap => ({
         hasteFS: hasteMap.hasteFS,
+        moduleMap: hasteMap.moduleMap,
         resolver: Runtime.createResolver(config, hasteMap.moduleMap),
       }),
       error => {

--- a/packages/jest-runtime/src/index.js
+++ b/packages/jest-runtime/src/index.js
@@ -215,7 +215,7 @@ class Runtime {
       retainAllFiles: false,
       roots: config.testPathDirs,
       useWatchman: config.watchman,
-      watch: (options && options.watch),
+      watch: options && options.watch,
     });
   }
 

--- a/types/HasteMap.js
+++ b/types/HasteMap.js
@@ -18,6 +18,7 @@ export type ModuleMap = _ModuleMap;
 
 export type HasteContext = {|
   hasteFS: HasteFS,
+  moduleMap: ModuleMap,
   resolver: HasteResolver,
 |};
 
@@ -32,10 +33,16 @@ export type InternalHasteMap = {|
   map: ModuleMapData,
   mocks: MockData,
 |};
+
 export type HasteMap = {|
   hasteFS: HasteFS,
   moduleMap: ModuleMap,
   __hasteMapForTest?: ?InternalHasteMap,
+|};
+
+export type RawModuleMap = {|
+  map: ModuleMapData,
+  mocks: MockData,
 |};
 
 export type FileMetaData = [

--- a/types/HasteMap.js
+++ b/types/HasteMap.js
@@ -35,7 +35,7 @@ export type InternalHasteMap = {|
 export type HasteMap = {|
   hasteFS: HasteFS,
   moduleMap: ModuleMap,
-  __hasteMapForTest: ?InternalHasteMap,
+  __hasteMapForTest?: ?InternalHasteMap,
 |};
 
 export type FileMetaData = [


### PR DESCRIPTION
**Summary**

This extracts the watch mode to its own module, which was suggested by @cpojer as a prerequisite for #2324.

This should make watch mode faster and removes some duplicated code from `jest.js`.
Now we only need to reconcile with the file system only when a file is added/removed, but not otherwise

More info https://github.com/facebook/jest/pull/2324#issuecomment-267149669 I hope that this will also allow us to add more tests in the future.

**Known issues:**

~Test interruption is not working and I'm not sure why. It seems that I'm setting the correct state in the `TestWatcher` :(~ UPDATE: I first thought that the issue was introduced in this PR, but it seems that it is also happening in master. Based on my understanding it was introduced in #2312 

![interrupt](https://cloud.githubusercontent.com/assets/574806/21323938/858ed494-c5d4-11e6-8878-295773a7307f.gif)

