### PR TITLE
Reorganize the side-nav-bar

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -105,10 +105,6 @@ These methods help create mocks and let you control Jest's overall behavior.
   - [`jest.useFakeTimers()`](#jestusefaketimers)
   - [`jest.useRealTimers()`](#jestuserealtimers)
 
-### The Jest CLI
-
-  - [Jest CLI Options](#jest-cli-options)
-
 -----
 
 
@@ -1181,40 +1177,3 @@ Returns the `jest` object for chaining.
 Instructs Jest to use the real versions of the standard timer functions.
 
 Returns the `jest` object for chaining.
-
-
-### Jest CLI options
-
-Run `jest --help` to view the various options available.
-
-It is possible to run test suites by providing a pattern. Only the files that the pattern matches will be picked up and executed.
-
-If you have a test suite in a file named `Component-snapshot-test.js` somewhere in the file hierarchy, you can run only that test by adding a pattern right after the `jest` command:
-
-```bash
-jest Component-snapshot
-```
-
-It is possible to further limit the tests that will be run by using the `--testNamePattern` (or simply `-t`) flag.
-
-```bash
-jest Component-snapshot -t "is selected"
-```
-
-It is possible to combine the `--updateSnapshot` (`-u`) flag with the options above in order to re-record snapshots for particular test suites or tests only:
-
-Update snapshots for all files matching the pattern:
-```bash
-jest -u Component-snapshot
-```
-
-Only update snapshots for tests matching the pattern:
-```bash
-jest -u Component-snapshot -t "is selected"
-```
-
-It is possible to specify which files the coverage report will be generated for.
-
-```bash
-jest --collectCoverageFrom='["packages/**/index.js", "!**/vendor/**"]' --coverage
-```

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,0 +1,41 @@
+---
+id: cli
+title: Jest CLI
+layout: docs
+category: Reference
+permalink: docs/cli.html
+---
+
+Run `jest --help` to view the various options available.
+
+It is possible to run test suites by providing a pattern. Only the files that the pattern matches will be picked up and executed.
+
+If you have a test suite in a file named `Component-snapshot-test.js` somewhere in the file hierarchy, you can run only that test by adding a pattern right after the `jest` command:
+
+```bash
+jest Component-snapshot
+```
+
+It is possible to further limit the tests that will be run by using the `--testNamePattern` (or simply `-t`) flag.
+
+```bash
+jest Component-snapshot -t "is selected"
+```
+
+It is possible to combine the `--updateSnapshot` (`-u`) flag with the options above in order to re-record snapshots for particular test suites or tests only:
+
+Update snapshots for all files matching the pattern:
+```bash
+jest -u Component-snapshot
+```
+
+Only update snapshots for tests matching the pattern:
+```bash
+jest -u Component-snapshot -t "is selected"
+```
+
+It is possible to specify which files the coverage report will be generated for.
+
+```bash
+jest --collectCoverageFrom='["packages/**/index.js", "!**/vendor/**"]' --coverage
+```

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -1,10 +1,10 @@
 ---
 id: configuration
-title: Configuration
+title: Configuring package.json
 layout: docs
 category: Reference
 permalink: docs/configuration.html
-next: troubleshooting
+next: cli
 ---
 
 #### The Jest configuration options

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -2,9 +2,9 @@
 id: getting-started
 title: Getting Started
 layout: docs
-category: Quick Start
+category: Introduction
 permalink: docs/getting-started.html
-next: tutorial-react
+next: tutorial-async
 ---
 
 Before you install Jest, you can try out a real version of Jest through [repl.it](https://repl.it). Just edit your test and hit the run button!

--- a/docs/ManualMocks.md
+++ b/docs/ManualMocks.md
@@ -1,10 +1,10 @@
 ---
 id: manual-mocks
-title: Manual mocks
+title: Manual Mocks
 layout: docs
-category: Reference
+category: Guides
 permalink: docs/manual-mocks.html
-next: timer-mocks
+next: tutorial-webpack
 ---
 
 Manual mocks are used to stub out functionality with mock data. For example, instead of accessing a remote resource like a website or a database, you might want to create a manual mock that allows you to use fake data. This ensures your tests will be fast and not flaky.

--- a/docs/MigrationGuide.md
+++ b/docs/MigrationGuide.md
@@ -1,10 +1,10 @@
 ---
 id: migration-guide
-title: Migration Guide
+title: Migrating to Jest
 layout: docs
-category: Quick Start
+category: Guides
 permalink: docs/migration-guide.html
-next: api
+next: troubleshooting
 ---
 
 If you'd like to try out Jest with an existing codebase, there are a number of ways to convert to Jest:

--- a/docs/MockFunctions.md
+++ b/docs/MockFunctions.md
@@ -1,10 +1,10 @@
 ---
 id: mock-functions
-title: Mock functions
+title: Mock Functions
 layout: docs
-category: Reference
+category: Introduction
 permalink: docs/mock-functions.html
-next: manual-mocks
+next: timer-mocks
 ---
 
 Mock functions make it easy to test the links between code by erasing the actual

--- a/docs/TimerMocks.md
+++ b/docs/TimerMocks.md
@@ -1,9 +1,10 @@
 ---
 id: timer-mocks
-title: Timer mocks
+title: Timer Mocks
 layout: docs
-category: Reference
+category: Introduction
 permalink: docs/timer-mocks.html
+next: tutorial-react
 ---
 
 The native timer functions (i.e., `setTimeout`, `setInterval`, `clearTimeout`,

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -2,9 +2,9 @@
 id: troubleshooting
 title: Troubleshooting
 layout: docs
-category: Reference
+category: Guides
 permalink: docs/troubleshooting.html
-next: mock-functions
+next: api
 ---
 
 Uh oh, something went wrong? Use this guide to resolve issues with Jest.

--- a/docs/TutorialAsync.md
+++ b/docs/TutorialAsync.md
@@ -1,10 +1,10 @@
 ---
 id: tutorial-async
-title: Tutorial – Async
+title: Async Tests
 layout: docs
-category: Quick Start
+category: Introduction
 permalink: docs/tutorial-async.html
-next: tutorial-webpack
+next: mock-functions
 ---
 
 *Note: make sure to install `babel-jest` and the async/await feature for this

--- a/docs/TutorialReact.md
+++ b/docs/TutorialReact.md
@@ -1,8 +1,8 @@
 ---
 id: tutorial-react
-title: Tutorial – React
+title: Testing React Apps
 layout: docs
-category: Quick Start
+category: Guides
 permalink: docs/tutorial-react.html
 next: tutorial-react-native
 ---

--- a/docs/TutorialReactNative.md
+++ b/docs/TutorialReactNative.md
@@ -1,10 +1,10 @@
 ---
 id: tutorial-react-native
-title: Tutorial – React Native
+title: Testing React Native Apps
 layout: docs
-category: Quick Start
+category: Guides
 permalink: docs/tutorial-react-native.html
-next: tutorial-async
+next: tutorial-jquery
 ---
 
 At Facebook, we use Jest to test [React Native](http://facebook.github.io/react-native/)

--- a/docs/TutorialWebpack.md
+++ b/docs/TutorialWebpack.md
@@ -1,10 +1,10 @@
 ---
 id: tutorial-webpack
-title: Tutorial – webpack
+title: Webpack
 layout: docs
-category: Quick Start
+category: Guides
 permalink: docs/tutorial-webpack.html
-next: tutorial-jquery
+next: migration-guide
 ---
 
 Jest can be used in projects that use webpack to manage assets, styles, and compilation.

--- a/docs/TutorialjQuery.md
+++ b/docs/TutorialjQuery.md
@@ -1,10 +1,10 @@
 ---
 id: tutorial-jquery
-title: Tutorial – jQuery
+title: DOM Manipulation
 layout: docs
-category: Quick Start
+category: Guides
 permalink: docs/tutorial-jquery.html
-next: migration-guide
+next: manual-mocks
 ---
 
 Another class of functions that is often considered difficult to test is code
@@ -70,7 +70,7 @@ it('displays a user after a click', () => {
 ```
 
 The function being tested adds an event listener on the `#button` DOM element,
-so we need to setup our DOM correctly for the test. Jest ships with `jsdom`
+so we need to set up our DOM correctly for the test. Jest ships with `jsdom`
 which simulates a DOM environment as if you were in the browser. This means that
 every DOM API that we call can be observed in the same way it would be observed
 in a browser!


### PR DESCRIPTION
As described in https://github.com/facebook/jest/issues/2366 the previous organization of the docs was inconsistent.

What we have now:

Introduction = stuff noobs all need to know about Jest
Guides = how to do thing X, where X is anything. Kind of a grab bag
Reference = the type of thing that has 50 boring aspects, we describe each one

I split CLI stuff out into its own reference doc but in general there's more to do there.