### PR TITLE
normalize line/column numbers for the parser to match the actual line…

### DIFF
--- a/packages/jest-editor-support/src/__tests__/parsers/parserTests.js
+++ b/packages/jest-editor-support/src/__tests__/parsers/parserTests.js
@@ -19,78 +19,78 @@ function parserTests(parse: (file: string) => ParserReturn) {
     it('For the simplest it cases', () => {
       const data = parse(`${fixtures}/global_its.example`);
 
-      expect(data.itBlocks.length, 7);
+      expect(data.itBlocks.length).toEqual(7);
 
       const firstIt = data.itBlocks[0];
       expect(firstIt.name).toEqual('works with old functions');
-      expect(firstIt.start).toEqual({column: 0, line: 1});
-      expect(firstIt.end).toEqual({column: 2, line: 3});
+      expect(firstIt.start).toEqual({column: 1, line: 2});
+      expect(firstIt.end).toEqual({column: 3, line: 4});
 
       const secondIt = data.itBlocks[1];
       expect(secondIt.name).toEqual('works with new functions');
-      expect(secondIt.start).toEqual({column: 0, line: 5});
-      expect(secondIt.end).toEqual({column: 2, line: 7});
+      expect(secondIt.start).toEqual({column: 1, line: 6});
+      expect(secondIt.end).toEqual({column: 3, line: 8});
 
       const thirdIt = data.itBlocks[2];
       expect(thirdIt.name).toEqual('works with flow functions');
-      expect(thirdIt.start).toEqual({column: 0, line: 9});
-      expect(thirdIt.end).toEqual({column: 2, line: 11});
+      expect(thirdIt.start).toEqual({column: 1, line: 10});
+      expect(thirdIt.end).toEqual({column: 3, line: 12});
 
       const fourthIt = data.itBlocks[3];
       expect(fourthIt.name).toEqual('works with it.only');
-      expect(fourthIt.start).toEqual({column: 0, line: 13});
-      expect(fourthIt.end).toEqual({column: 2, line: 15});
+      expect(fourthIt.start).toEqual({column: 1, line: 14});
+      expect(fourthIt.end).toEqual({column: 3, line: 16});
 
       const fifthIt = data.itBlocks[4];
       expect(fifthIt.name).toEqual('works with fit');
-      expect(fifthIt.start).toEqual({column: 0, line: 17});
-      expect(fifthIt.end).toEqual({column: 2, line: 19});
+      expect(fifthIt.start).toEqual({column: 1, line: 18});
+      expect(fifthIt.end).toEqual({column: 3, line: 20});
 
       const sixthIt = data.itBlocks[5];
       expect(sixthIt.name).toEqual('works with test');
-      expect(sixthIt.start).toEqual({column: 0, line: 21});
-      expect(sixthIt.end).toEqual({column: 2, line: 23});
+      expect(sixthIt.start).toEqual({column: 1, line: 22});
+      expect(sixthIt.end).toEqual({column: 3, line: 24});
 
       const seventhIt = data.itBlocks[6];
       expect(seventhIt.name).toEqual('works with test.only');
-      expect(seventhIt.start).toEqual({column: 0, line: 25});
-      expect(seventhIt.end).toEqual({column: 2, line: 27});
+      expect(seventhIt.start).toEqual({column: 1, line: 26});
+      expect(seventhIt.end).toEqual({column: 3, line: 28});
     });
 
     it('For its inside describes', () => {
       const data = parse(`${fixtures}/nested_its.example`);
 
-      expect(data.itBlocks.length, 6);
+      expect(data.itBlocks.length).toEqual(6);
 
       const firstIt = data.itBlocks[0];
       expect(firstIt.name).toEqual('1');
-      expect(firstIt.start).toEqual({column: 2, line: 1});
-      expect(firstIt.end).toEqual({column: 4, line: 2});
+      expect(firstIt.start).toEqual({column: 3, line: 2});
+      expect(firstIt.end).toEqual({column: 5, line: 3});
 
       const secondIt = data.itBlocks[1];
       expect(secondIt.name).toEqual('2');
-      expect(secondIt.start).toEqual({column: 2, line: 3});
-      expect(secondIt.end).toEqual({column: 4, line: 4});
+      expect(secondIt.start).toEqual({column: 3, line: 4});
+      expect(secondIt.end).toEqual({column: 5, line: 5});
 
       const thirdIt = data.itBlocks[2];
       expect(thirdIt.name).toEqual('3');
-      expect(thirdIt.start).toEqual({column: 2, line: 8});
-      expect(thirdIt.end).toEqual({column: 4, line: 9});
+      expect(thirdIt.start).toEqual({column: 3, line: 9});
+      expect(thirdIt.end).toEqual({column: 5, line: 10});
 
       const fourthIt = data.itBlocks[3];
       expect(fourthIt.name).toEqual('4');
-      expect(fourthIt.start).toEqual({column: 2, line: 13});
-      expect(fourthIt.end).toEqual({column: 4, line: 14});
+      expect(fourthIt.start).toEqual({column: 3, line: 14});
+      expect(fourthIt.end).toEqual({column: 5, line: 15});
 
       const fifthIt = data.itBlocks[4];
       expect(fifthIt.name).toEqual('5');
-      expect(fifthIt.start).toEqual({column: 2, line: 18});
-      expect(fifthIt.end).toEqual({column: 4, line: 19});
+      expect(fifthIt.start).toEqual({column: 3, line: 19});
+      expect(fifthIt.end).toEqual({column: 5, line: 20});
 
       const sixthIt = data.itBlocks[5];
       expect(sixthIt.name).toEqual('6');
-      expect(sixthIt.start).toEqual({column: 2, line: 23});
-      expect(sixthIt.end).toEqual({column: 4, line: 24});
+      expect(sixthIt.start).toEqual({column: 3, line: 24});
+      expect(sixthIt.end).toEqual({column: 5, line: 25});
     });
 
     // These tests act more like linters that we don't raise on 
@@ -118,11 +118,19 @@ function parserTests(parse: (file: string) => ParserReturn) {
     it('finds Expects in a danger test file', () => {
       const data = parse(`${fixtures}/dangerjs/travis-ci.example`);
       expect(data.expects.length).toEqual(8);
+
+      const firstExpect = data.expects[0];
+      expect(firstExpect.start).toEqual({column: 5, line: 13});
+      expect(firstExpect.end).toEqual({column: 37, line: 13});
     });
 
     it('finds Expects in a danger flow test file ', () => {
       const data = parse(`${fixtures}/dangerjs/github.example`);
       expect(data.expects.length).toEqual(3);
+
+      const thirdExpect = data.expects[2];
+      expect(thirdExpect.start).toEqual({column: 5, line: 33});
+      expect(thirdExpect.end).toEqual({column: 40, line: 33});
     });
 
     it('finds Expects in a metaphysics test file', () => {

--- a/packages/jest-editor-support/src/parsers/BabylonParser.js
+++ b/packages/jest-editor-support/src/parsers/BabylonParser.js
@@ -64,10 +64,7 @@ const babylonParser = (file: string) => {
     block.start = node.loc.start;
     block.end =  node.loc.end;
     
-    // This makes it consistent with TypeScript's parser output
-    block.start.line -= 1;
-    block.end.line -= 1;
-    block.end.column -= 1;
+    block.start.column += 1;
 
     block.file = file;
     itBlocks.push(block);
@@ -80,6 +77,10 @@ const babylonParser = (file: string) => {
     const expect = new Expect();
     expect.start = node.loc.start;
     expect.end =  node.loc.end;
+
+    expect.start.column += 1;
+    expect.end.column += 1;
+
     expect.file = file;
     expects.push(expect);
   };

--- a/packages/jest-editor-support/src/parsers/TypeScriptParser.js
+++ b/packages/jest-editor-support/src/parsers/TypeScriptParser.js
@@ -24,17 +24,33 @@ function parse(file: string) {
   const itBlocks: Array<ItBlock> = [];
   const expects: Array<Expect> = [];
   function searchNodes(node: ts.Node) {
-    const callExpression = node.expression || {};
-    const identifier = callExpression.expression || {};
-    const {text} = identifier;
-    if (text === 'it' || text === 'test' || text === 'fit') {
-      const isOnlyNode = !callExpression.arguments ? node : callExpression;
-      const position = getNode(sourceFile, isOnlyNode, new ItBlock());
-      position.name = isOnlyNode.arguments[0].text;
-      itBlocks.push(position);
-    } else if (text === 'expect') {
-      const position = getNode(sourceFile, callExpression, new Expect());
-      expects.push(position);
+    if (node.kind === ts.SyntaxKind.CallExpression) {
+      let {text} = node.expression;
+      if (!text) {
+        // Property access (it.only)
+        text = node.expression.expression.text;
+      }
+      if (text === 'it' || text === 'test' || text === 'fit') {
+        const position = getNode(sourceFile, node, new ItBlock());
+        position.name = node.arguments[0].text;
+        itBlocks.push(position);
+      } else {
+        let element = node.expression;
+        let expectText: string;
+        while (!expectText) {
+          expectText = element.text;
+          element = element.expression;
+        }
+        if (expectText === 'expect') {
+          const position = getNode(sourceFile, node, new Expect());
+          if (!expects.some(e => (
+              e.start.line === position.start.line &&
+              e.start.column === position.start.column
+            ))) {
+            expects.push(position);
+          }
+        }
+      }
     }
     ts.forEachChild(node, searchNodes);
   }
@@ -52,14 +68,15 @@ function getNode<T: Node>(
   node: T
 ): T {
   const start = file.getLineAndCharacterOfPosition(expression.getStart(file));
+  // TypeScript parser is 0 based, so we have to increment by 1 to normalize
   node.start = {
-    column: start.character,
-    line: start.line,
+    column: start.character + 1,
+    line: start.line + 1,
   };
   const end = file.getLineAndCharacterOfPosition(expression.getEnd());
   node.end = {
-    column: end.character,
-    line: end.line,
+    column: end.character + 1,
+    line: end.line + 1,
   };
   node.file = file.fileName;
   return node;


### PR DESCRIPTION
**Summary**

Currently jest-editor-support normalized line/column numbers to be 0 based which didn't match the actual representation in the editor.  This normalizes the numbers to be 1 based so they align directly with the lines and columns in an editor.

Also fixed TypeScript parser to correctly pick up start/end of expect blocks.

**Test plan**

Updated the test cases to reflect the correct line/columns
