### PR TITLE
Remove jasmine dependency from jest-matchers

### DIFF
--- a/packages/jest-matcher-utils/src/equals.js
+++ b/packages/jest-matcher-utils/src/equals.js
@@ -1,0 +1,255 @@
+/*
+Copyright (c) 2008-2016 Pivotal Labs
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+/* eslint-disable */
+
+'use strict';
+
+// Extracted out of jasmine 2.5.2
+function equals(a, b, customTesters) {
+  customTesters = customTesters || [];
+  return eq(a, b, [], [], customTesters);
+}
+
+function isAsymmetric(obj) {
+  return obj && isA('Function', obj.asymmetricMatch);
+}
+
+function asymmetricMatch(a, b) {
+  var asymmetricA = isAsymmetric(a),
+      asymmetricB = isAsymmetric(b);
+
+  if (asymmetricA && asymmetricB) {
+    return undefined;
+  }
+
+  if (asymmetricA) {
+    return a.asymmetricMatch(b);
+  }
+
+  if (asymmetricB) {
+    return b.asymmetricMatch(a);
+  }
+}
+
+// Equality function lovingly adapted from isEqual in
+//   [Underscore](http://underscorejs.org)
+function eq(a, b, aStack, bStack, customTesters) {
+  var result = true;
+
+  var asymmetricResult = asymmetricMatch(a, b);
+  if (!isUndefined(asymmetricResult)) {
+    return asymmetricResult;
+  }
+
+  for (var i = 0; i < customTesters.length; i++) {
+    var customTesterResult = customTesters[i](a, b);
+    if (!isUndefined(customTesterResult)) {
+      return customTesterResult;
+    }
+  }
+
+  if (a instanceof Error && b instanceof Error) {
+    return a.message == b.message;
+  }
+
+  // Identical objects are equal. `0 === -0`, but they aren't identical.
+  // See the [Harmony `egal` proposal](http://wiki.ecmascript.org/doku.php?id=harmony:egal).
+  if (a === b) { return a !== 0 || 1 / a == 1 / b; }
+  // A strict comparison is necessary because `null == undefined`.
+  if (a === null || b === null) { return a === b; }
+  var className = Object.prototype.toString.call(a);
+  if (className != Object.prototype.toString.call(b)) { return false; }
+  switch (className) {
+    // Strings, numbers, dates, and booleans are compared by value.
+    case '[object String]':
+      // Primitives and their corresponding object wrappers are equivalent; thus, `"5"` is
+      // equivalent to `new String("5")`.
+      return a == String(b);
+    case '[object Number]':
+      // `NaN`s are equivalent, but non-reflexive. An `egal` comparison is performed for
+      // other numeric values.
+      return a != +a ? b != +b : (a === 0 ? 1 / a == 1 / b : a == +b);
+    case '[object Date]':
+    case '[object Boolean]':
+      // Coerce dates and booleans to numeric primitive values. Dates are compared by their
+      // millisecond representations. Note that invalid dates with millisecond representations
+      // of `NaN` are not equivalent.
+      return +a == +b;
+    // RegExps are compared by their source patterns and flags.
+    case '[object RegExp]':
+      return a.source == b.source &&
+        a.global == b.global &&
+        a.multiline == b.multiline &&
+        a.ignoreCase == b.ignoreCase;
+  }
+  if (typeof a != 'object' || typeof b != 'object') { return false; }
+
+  var aIsDomNode = isDomNode(a);
+  var bIsDomNode = isDomNode(b);
+  if (aIsDomNode && bIsDomNode) {
+    // At first try to use DOM3 method isEqualNode
+    if (a.isEqualNode) {
+      return a.isEqualNode(b);
+    }
+    // IE8 doesn't support isEqualNode, try to use outerHTML && innerText
+    var aIsElement = a instanceof Element;
+    var bIsElement = b instanceof Element;
+    if (aIsElement && bIsElement) {
+      return a.outerHTML == b.outerHTML;
+    }
+    if (aIsElement || bIsElement) {
+      return false;
+    }
+    return a.innerText == b.innerText && a.textContent == b.textContent;
+  }
+  if (aIsDomNode || bIsDomNode) {
+    return false;
+  }
+
+  // Assume equality for cyclic structures. The algorithm for detecting cyclic
+  // structures is adapted from ES 5.1 section 15.12.3, abstract operation `JO`.
+  var length = aStack.length;
+  while (length--) {
+    // Linear search. Performance is inversely proportional to the number of
+    // unique nested structures.
+    if (aStack[length] == a) { return bStack[length] == b; }
+  }
+  // Add the first object to the stack of traversed objects.
+  aStack.push(a);
+  bStack.push(b);
+  var size = 0;
+  // Recursively compare objects and arrays.
+  // Compare array lengths to determine if a deep comparison is necessary.
+  if (className == '[object Array]') {
+    size = a.length;
+    if (size !== b.length) {
+      return false;
+    }
+
+    while (size--) {
+      result = eq(a[size], b[size], aStack, bStack, customTesters);
+      if (!result) {
+        return false;
+      }
+    }
+  } else {
+
+    // Objects with different constructors are not equivalent, but `Object`s
+    // or `Array`s from different frames are.
+    // CUSTOM JEST CHANGE:
+    // TODO(cpojer): fix all tests and this and re-enable this check
+    /*
+    var aCtor = a.constructor, bCtor = b.constructor;
+    if (aCtor !== bCtor && !(isFunction(aCtor) && aCtor instanceof aCtor &&
+           isFunction(bCtor) && bCtor instanceof bCtor)) {
+      return false;
+    }
+    */
+  }
+
+  // Deep compare objects.
+  var aKeys = keys(a, className == '[object Array]'), key;
+  size = aKeys.length;
+
+  // Ensure that both objects contain the same number of properties before comparing deep equality.
+  if (keys(b, className == '[object Array]').length !== size) { return false; }
+
+  while (size--) {
+    key = aKeys[size];
+
+    // Deep compare each member
+    result = has(b, key) && eq(a[key], b[key], aStack, bStack, customTesters);
+
+    if (!result) {
+      return false;
+    }
+  }
+  // Remove the first object from the stack of traversed objects.
+  aStack.pop();
+  bStack.pop();
+
+  return result;
+}
+
+function keys(obj, isArray) {
+  // CUSTOM JEST CHANGE: don't consider undefined keys.
+  var allKeys = (function(o) {
+      var keys = [];
+      for (var key in o) {
+          if (has(o, key)) {
+              keys.push(key);
+          }
+      }
+      return keys;
+  })(obj);
+
+  if (!isArray) {
+    return allKeys;
+  }
+
+  var extraKeys = [];
+  if (allKeys.length === 0) {
+      return allKeys;
+  }
+
+  for (var x = 0; x < allKeys.length; x++) {
+      if (!allKeys[x].match(/^[0-9]+$/)) {
+          extraKeys.push(allKeys[x]);
+      }
+  }
+
+  return extraKeys;
+}
+
+function has(obj, key) {
+  // CUSTOM JEST CHANGE:
+  // TODO(cpojer): remove the `obj[key] !== undefined` check.
+  return Object.prototype.hasOwnProperty.call(obj, key) && obj[key] !== undefined;
+}
+
+function isFunction(obj) {
+  return typeof obj === 'function';
+}
+
+function isObjectConstructor(ctor) {
+  // aCtor instanceof aCtor is true for the Object and Function
+  // constructors (since a constructor is-a Function and a function is-a
+  // Object). We don't just compare ctor === Object because the constructor
+  // might come from a different frame with different globals.
+  return isFunction(ctor) && ctor instanceof ctor;
+}
+
+function isUndefined(obj) {
+  return obj === void 0;
+}
+
+function isA(typeName, value) {
+  return Object.prototype.toString.apply(value) === '[object ' + typeName + ']';
+}
+
+function isDomNode(obj) {
+  return obj.nodeType > 0;
+}
+
+module.exports = equals;

--- a/packages/jest-matcher-utils/src/index.js
+++ b/packages/jest-matcher-utils/src/index.js
@@ -12,6 +12,7 @@
 
 const chalk = require('chalk');
 const prettyFormat = require('pretty-format');
+const equals = require('./equals');
 
 export type ValueType =
   | 'array'
@@ -191,6 +192,7 @@ module.exports = {
   ensureExpectedIsNumber,
   ensureNoExpected,
   ensureNumbers,
+  equals,
   getType,
   matcherHint,
   pluralize,

--- a/packages/jest-matchers/src/matchers.js
+++ b/packages/jest-matchers/src/matchers.js
@@ -32,6 +32,7 @@ const {
   printReceived,
   printExpected,
   printWithType,
+  equals,
 } = require('jest-matcher-utils');
 
 type ContainIterable = (
@@ -43,7 +44,6 @@ type ContainIterable = (
 );
 
 const IteratorSymbol = Symbol.iterator;
-const equals = global.jasmine.matchersUtil.equals;
 
 const hasIterator = object => !!(object != null && object[IteratorSymbol]);
 const iterableEquality = (a, b) => {
@@ -66,7 +66,7 @@ const iterableEquality = (a, b) => {
     const nextB = bIterator.next();
     if (
       nextB.done ||
-      !global.jasmine.matchersUtil.equals(
+      !equals(
         aValue,
         nextB.value,
         [iterableEquality],
@@ -612,7 +612,7 @@ const matchers: MatchersObject = {
         }
 
         return expected.map((exp, i) => findMatchObject(exp, received[i]));
-        
+
       } else if (received instanceof Date) {
         return received;
       } else if (typeof received === 'object' && received !== null && typeof expected === 'object' && expected !== null) {

--- a/packages/jest-matchers/src/spyMatchers.js
+++ b/packages/jest-matchers/src/spyMatchers.js
@@ -24,14 +24,13 @@ const {
   printReceived,
   printWithType,
   RECEIVED_COLOR,
+  equals,
 } = require('jest-matcher-utils');
 
 const RECEIVED_NAME = {
   'mock function': 'jest.fn()',
   spy: 'spy',
 };
-
-const equals = global.jasmine.matchersUtil.equals;
 
 const createToBeCalledMatcher = matcherName => (received, expected) => {
   ensureNoExpected(expected, matcherName);

--- a/packages/jest-matchers/src/toThrowMatchers.js
+++ b/packages/jest-matchers/src/toThrowMatchers.js
@@ -24,9 +24,8 @@ const {
   matcherHint,
   printExpected,
   printWithType,
+  equals,
 } = require('jest-matcher-utils');
-
-const equals = global.jasmine.matchersUtil.equals;
 
 const createMatcher = matcherName =>
   (actual: Function, expected: string | Error | RegExp) => {


### PR DESCRIPTION
I brought equals from the checked in version of jasmine ( https://github.com/facebook/jest/blob/db0f3b4902ddb360020be8f737db1fae7a8508c4/packages/jest-jasmine2/vendor/jasmine-2.5.2.js#L2787-L3048 )

I did a few tweaks:
- Imported isUndefined, isA and isDomNode
- Moved all the functions that were defined inside of functions to the global "namespace"
- Disabled lint and flow