### PR TITLE
Remove jest-snapshot dependency from jest-matchers

### DIFF
--- a/packages/jest-matchers/src/matchers.js
+++ b/packages/jest-matchers/src/matchers.js
@@ -15,10 +15,6 @@ import type {
   MatchersObject,
 } from 'types/Matchers';
 
-const {
-  toMatchSnapshot,
-} = require('jest-snapshot');
-
 const diff = require('jest-diff');
 const {escapeStrForRegex} = require('jest-util');
 const {getPath} = require('./utils');
@@ -667,9 +663,6 @@ const matchers: MatchersObject = {
 
     return {message, pass};
   },
-
-  toMatchSnapshot,
-
 };
 
 module.exports = matchers;


### PR DESCRIPTION
Apparently it's already injected from somewhere else (@cpojer told me!) and this passes all the tests so that sounds good.