### PR TITLE
Change the exports of jest-matcher to be just expect

### DIFF
--- a/packages/jest-jasmine2/src/jest-expect.js
+++ b/packages/jest-jasmine2/src/jest-expect.js
@@ -12,7 +12,7 @@
 import type {Config} from 'types/Config';
 import type {RawMatcherFn} from 'types/Matchers';
 
-const {expect, setState} = require('jest-matchers');
+const expect = require('jest-matchers');
 
 const {
   toMatchSnapshot,
@@ -28,7 +28,7 @@ type JasmineMatchersObject = {[id: string]: JasmineMatcher};
 
 module.exports = (config: Config) => {
   global.expect = expect;
-  setState({
+  expect.setState({
     expand: config.expand,
   });
   expect.extend({toMatchSnapshot, toThrowErrorMatchingSnapshot});

--- a/packages/jest-matchers/src/__tests__/assertion-counts-test.js
+++ b/packages/jest-matchers/src/__tests__/assertion-counts-test.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const jestExpect = require('../').expect;
+const jestExpect = require('../');
 
 describe('.assertions()', () => {
   it('does not throw', () => {

--- a/packages/jest-matchers/src/__tests__/extend-test.js
+++ b/packages/jest-matchers/src/__tests__/extend-test.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const jestExpect = require('../').expect;
+const jestExpect = require('../');
 const matcherUtils = require('jest-matcher-utils');
 
 jestExpect.extend({

--- a/packages/jest-matchers/src/__tests__/matchers-test.js
+++ b/packages/jest-matchers/src/__tests__/matchers-test.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-const jestExpect = require('../').expect;
+const jestExpect = require('../');
 const {stringify} = require('jest-matcher-utils');
 
 describe('.toBe()', () => {

--- a/packages/jest-matchers/src/__tests__/spyMatchers-test.js
+++ b/packages/jest-matchers/src/__tests__/spyMatchers-test.js
@@ -10,7 +10,7 @@
 /* eslint-disable max-len */
 'use strict';
 
-const jestExpect = require('../').expect;
+const jestExpect = require('../');
 
 [
   ['toHaveBeenCalled', 'jasmine.createSpy'],

--- a/packages/jest-matchers/src/__tests__/toThrowMatchers-test.js
+++ b/packages/jest-matchers/src/__tests__/toThrowMatchers-test.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const jestExpect = require('../').expect;
+const jestExpect = require('../');
 const skipOnWindows = require('skipOnWindows');
 
 // Custom Error class because node versions have different stack trace strings.

--- a/packages/jest-matchers/src/index.js
+++ b/packages/jest-matchers/src/index.js
@@ -164,12 +164,6 @@ const _validateResult = result => {
   }
 };
 
-const setState = (state: MatcherState) => {
-  Object.assign(global[GLOBAL_STATE].state, state);
-};
-
-const getState = () => global[GLOBAL_STATE].state;
-
 // add default jest matchers
 expect.extend(matchers);
 expect.extend(spyMatchers);
@@ -179,8 +173,10 @@ expect.assertions = (expected: number) => (
   global[GLOBAL_STATE].state.assertionsExpected = expected
 );
 
-module.exports = {
-  expect,
-  getState,
-  setState,
+expect.setState = (state: MatcherState) => {
+  Object.assign(global[GLOBAL_STATE].state, state);
 };
+
+expect.getState = () => global[GLOBAL_STATE].state;
+
+module.exports = expect;


### PR DESCRIPTION
This way we can have the same top level api as expect npm module:

```js
const expect = require('jest-matchers');
```