### PR TITLE
Move asymetric matchers from jasmine to jest

### DIFF
--- a/packages/jest-jasmine2/src/jest-expect.js
+++ b/packages/jest-jasmine2/src/jest-expect.js
@@ -48,6 +48,14 @@ module.exports = (config: Config) => {
       };
     });
 
-    global.expect.extend(jestMatchersObject);
+    const expect = global.expect;
+
+    jasmine.anything = expect.anything;
+    jasmine.any = expect.any;
+    jasmine.objectContaining = expect.objectContaining;
+    jasmine.arrayContaining = expect.arrayContaining;
+    jasmine.stringMatching = expect.stringMatching;
+
+    expect.extend(jestMatchersObject);
   };
 };

--- a/packages/jest-matcher-utils/src/index.js
+++ b/packages/jest-matcher-utils/src/index.js
@@ -12,7 +12,6 @@
 
 const chalk = require('chalk');
 const prettyFormat = require('pretty-format');
-const equals = require('./equals');
 
 export type ValueType =
   | 'array'
@@ -192,7 +191,6 @@ module.exports = {
   ensureExpectedIsNumber,
   ensureNoExpected,
   ensureNumbers,
-  equals,
   getType,
   matcherHint,
   pluralize,

--- a/packages/jest-matchers/package.json
+++ b/packages/jest-matchers/package.json
@@ -10,7 +10,8 @@
   "dependencies": {
     "jest-diff": "^18.0.0",
     "jest-matcher-utils": "^18.0.0",
-    "jest-util": "^18.0.0"
+    "jest-util": "^18.0.0",
+    "pretty-format": "^18.0.0"
   },
   "scripts": {
     "test": "../../packages/jest-cli/bin/jest.js"

--- a/packages/jest-matchers/src/index.js
+++ b/packages/jest-matchers/src/index.js
@@ -26,6 +26,13 @@ const spyMatchers = require('./spyMatchers');
 const toThrowMatchers = require('./toThrowMatchers');
 
 const utils = require('jest-matcher-utils');
+const {
+  any,
+  anything,
+  arrayContaining,
+  objectContaining,
+  stringMatching,
+} = require('./jasmine-utils');
 
 const GLOBAL_STATE = Symbol.for('$$jest-matchers-object');
 
@@ -136,11 +143,11 @@ expect.extend = (matchersObj: MatchersObject): void => {
   Object.assign(global[GLOBAL_STATE].matchers, matchersObj);
 };
 
-expect.anything = global.jasmine.anything;
-expect.any = global.jasmine.any;
-expect.objectContaining = global.jasmine.objectContaining;
-expect.arrayContaining = global.jasmine.arrayContaining;
-expect.stringMatching = global.jasmine.stringMatching;
+expect.anything = anything;
+expect.any = any;
+expect.objectContaining = objectContaining;
+expect.arrayContaining = arrayContaining;
+expect.stringMatching = stringMatching;
 
 const _validateResult = result => {
   if (

--- a/packages/jest-matchers/src/matchers.js
+++ b/packages/jest-matchers/src/matchers.js
@@ -28,8 +28,10 @@ const {
   printReceived,
   printExpected,
   printWithType,
-  equals,
 } = require('jest-matcher-utils');
+const {
+  equals,
+} = require('./jasmine-utils');
 
 type ContainIterable = (
   Array<any> |

--- a/packages/jest-matchers/src/spyMatchers.js
+++ b/packages/jest-matchers/src/spyMatchers.js
@@ -24,8 +24,10 @@ const {
   printReceived,
   printWithType,
   RECEIVED_COLOR,
-  equals,
 } = require('jest-matcher-utils');
+const {
+  equals,
+} = require('./jasmine-utils');
 
 const RECEIVED_NAME = {
   'mock function': 'jest.fn()',

--- a/packages/jest-matchers/src/toThrowMatchers.js
+++ b/packages/jest-matchers/src/toThrowMatchers.js
@@ -24,8 +24,10 @@ const {
   matcherHint,
   printExpected,
   printWithType,
-  equals,
 } = require('jest-matcher-utils');
+const {
+  equals,
+} = require('./jasmine-utils');
 
 const createMatcher = matcherName =>
   (actual: Function, expected: string | Error | RegExp) => {


### PR DESCRIPTION
In #2389 I moved equals but it turns out there are more!

I renamed the file `expect.js` to `jasmine-utils` and moved it to `jest-matchers` instead of `jest-matcher-utils`.

This is the big thing, otherwise it's been pretty much copy and pasted from jasmine.