### PR TITLE
Fix toBeDivisibleBy braces

### DIFF
--- a/docs/ExpectAPI.md
+++ b/docs/ExpectAPI.md
@@ -80,11 +80,11 @@ expect.extend({
         pass: true,
         message: () => `expected ${received} not to be divisible by ${argument}`,
       }
-    }
-  } else {
-    return {
-      pass: false,
-      message: () => `expected ${received} to be divisible by ${argument}`,
+    } else {
+      return {
+        pass: false,
+        message: () => `expected ${received} to be divisible by ${argument}`,
+      }
     }
   }
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Fix them braces in `toBeDivisibleBy` example
