### PR TITLE
Make jest-mock return an object

### DIFF
--- a/packages/jest-environment-jsdom/src/index.js
+++ b/packages/jest-environment-jsdom/src/index.js
@@ -11,10 +11,11 @@
 import type {Config} from 'types/Config';
 import type {Global} from 'types/Global';
 import type {Script} from 'vm';
+import type {ModuleMocker} from 'jest-mock';
 
 const FakeTimers = require('jest-util').FakeTimers;
 const installCommonGlobals = require('jest-util').installCommonGlobals;
-const ModuleMocker = require('jest-mock');
+const mock = require('jest-mock');
 
 class JSDOMEnvironment {
 
@@ -34,7 +35,7 @@ class JSDOMEnvironment {
     this.global.Error.stackTraceLimit = 100;
     installCommonGlobals(global, config.globals);
 
-    this.moduleMocker = new ModuleMocker(global);
+    this.moduleMocker = new mock.ModuleMocker(global);
     this.fakeTimers = new FakeTimers(global, this.moduleMocker, config);
   }
 

--- a/packages/jest-environment-node/src/index.js
+++ b/packages/jest-environment-node/src/index.js
@@ -12,10 +12,11 @@
 import type {Config} from 'types/Config';
 import type {Global} from 'types/Global';
 import type {Script} from 'vm';
+import type {ModuleMocker} from 'jest-mock';
 
 const FakeTimers = require('jest-util').FakeTimers;
 const installCommonGlobals = require('jest-util').installCommonGlobals;
-const ModuleMocker = require('jest-mock');
+const mock = require('jest-mock');
 const vm = require('vm');
 
 class NodeEnvironment {
@@ -35,7 +36,7 @@ class NodeEnvironment {
     global.setInterval = setInterval;
     global.setTimeout = setTimeout;
     installCommonGlobals(global, config.globals);
-    this.moduleMocker = new ModuleMocker(global);
+    this.moduleMocker = new mock.ModuleMocker(global);
     this.fakeTimers = new FakeTimers(global, this.moduleMocker, config);
   }
 

--- a/packages/jest-mock/src/__tests__/jest-mock-test.js
+++ b/packages/jest-mock/src/__tests__/jest-mock-test.js
@@ -15,9 +15,9 @@ describe('moduleMocker', () => {
   let moduleMocker;
 
   beforeEach(() => {
-    const ModuleMocker = require('../');
+    const mock = require('../');
     const global = vm.runInNewContext('this');
-    moduleMocker = new ModuleMocker(global);
+    moduleMocker = new mock.ModuleMocker(global);
   });
 
   describe('getMetadata', () => {

--- a/packages/jest-mock/src/index.js
+++ b/packages/jest-mock/src/index.js
@@ -173,9 +173,10 @@ function getSlots(object?: Object): Array<string> {
 }
 
 
-class ModuleMocker {
+class ModuleMockerClass {
   _environmentGlobal: Global;
   _mockRegistry: WeakMap<Function, MockFunctionState>;
+  ModuleMocker: Class<ModuleMockerClass>;
 
   /**
    * @see README.md
@@ -185,6 +186,7 @@ class ModuleMocker {
   constructor(global: Global) {
     this._environmentGlobal = global;
     this._mockRegistry = new WeakMap();
+    this.ModuleMocker = ModuleMockerClass;
   }
 
   _ensureMock(f: Mock): MockFunctionState {
@@ -564,4 +566,5 @@ class ModuleMocker {
   }
 }
 
-module.exports = ModuleMocker;
+export type ModuleMocker = ModuleMockerClass;
+module.exports = new ModuleMockerClass(global);

--- a/packages/jest-runtime/src/index.js
+++ b/packages/jest-runtime/src/index.js
@@ -15,7 +15,7 @@ import type {Console} from 'console';
 import type {Environment} from 'types/Environment';
 import type {HasteContext} from 'types/HasteMap';
 import type {ModuleMap} from 'jest-haste-map';
-import type ModuleMocker, {MockFunctionMetadata} from 'jest-mock';
+import type {MockFunctionMetadata, ModuleMocker} from 'jest-mock';
 
 const HasteMap = require('jest-haste-map');
 const Resolver = require('jest-resolve');

--- a/packages/jest-util/src/FakeTimers.js
+++ b/packages/jest-util/src/FakeTimers.js
@@ -11,7 +11,7 @@
 
 import type {Config} from 'types/Config';
 import type {Global} from 'types/Global';
-import type ModuleMocker from 'jest-mock';
+import type {ModuleMocker} from 'jest-mock';
 
 const {formatStackTrace} = require('./messages');
 

--- a/packages/jest-util/src/__tests__/FakeTimers-test.js
+++ b/packages/jest-util/src/__tests__/FakeTimers-test.js
@@ -17,9 +17,9 @@ describe('FakeTimers', () => {
 
   beforeEach(() => {
     FakeTimers = require('../FakeTimers');
-    const ModuleMocker = require('jest-mock');
+    const mock = require('jest-mock');
     const global = vm.runInNewContext('this');
-    moduleMocker = new ModuleMocker(global);
+    moduleMocker = new mock.ModuleMocker(global);
   });
 
   describe('construction', () => {

--- a/types/Environment.js
+++ b/types/Environment.js
@@ -12,7 +12,7 @@
 import type {Config} from './Config';
 import type {Global} from './Global';
 import type {Script} from 'vm';
-import type ModuleMocker from 'jest-mock';
+import type {ModuleMocker} from 'jest-mock';
 
 export type Environment = {|
   constructor(config: Config): void;


### PR DESCRIPTION
Right now it returns a class that you've got to instantiate which is not the API we want. This PR makes it return an instance and adds the ModuleMocker class as an attribute.

Test Plan:
Make sure tests are passing

Also make sure that we can write this :)
```js
var mock = require('jest-mock');
const fn = mock.getMockFn();
```
