### PR TITLE
Update Homepage and More Resources

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,11 +21,11 @@ The core team will be monitoring for pull requests. When we get one, we'll run s
 *Before* submitting a pull request, please make sure the following is done…
 
 1. Fork the repo and create your branch from `master`.
-   
+
    ```sh
    git clone https://github.com/facebook/jest
    cd jest
-   git checkout -b my_branch 
+   git checkout -b my_branch
    ```
 
 2. Run `npm install`. It is recommended to use `npm3`.
@@ -41,7 +41,7 @@ The core team will be monitoring for pull requests. When we get one, we'll run s
    ```sh
    # in the background
    npm run watch
-   ``` 
+   ```
 
 4. If you've changed APIs, update the documentation.
 5. Ensure the test suite passes via `npm test`. To run the test suite you
@@ -83,7 +83,7 @@ Facebook has a [bounty program](https://www.facebook.com/whitehat/) for the safe
 * 2 spaces for indentation (no tabs).
 * 80 character line length strongly preferred.
 * Prefer `'` over `"`.
-* ES2015 syntax when possible.
+* ES6 syntax when possible.
 * `'use strict';`.
 * Use [Flow types](http://flowtype.org/).
 * Use semicolons;

--- a/docs/Babel.md
+++ b/docs/Babel.md
@@ -4,16 +4,12 @@ title: Babel Integration
 layout: docs
 category: Guides
 permalink: docs/babel.html
-next: webpack
+next: tutorial-async
 ---
-
-> **Note**: This is a placeholder.
-
-### Babel Integration
 
 If you'd like to use [Babel](http://babeljs.io/), it can easily be enabled: `npm install --save-dev babel-jest babel-polyfill`.
 
-Don't forget to add a [`.babelrc`](https://babeljs.io/docs/usage/babelrc/) file in your project's root folder. For example, if you are using ES2015 and [React.js](https://facebook.github.io/react/) with the [`babel-preset-es2015`](https://babeljs.io/docs/plugins/preset-es2015/) and [`babel-preset-react`](https://babeljs.io/docs/plugins/preset-react/) presets:
+Don't forget to add a [`.babelrc`](https://babeljs.io/docs/usage/babelrc/) file in your project's root folder. For example, if you are using ES6 and [React.js](https://facebook.github.io/react/) with the [`babel-preset-es2015`](https://babeljs.io/docs/plugins/preset-es2015/) and [`babel-preset-react`](https://babeljs.io/docs/plugins/preset-react/) presets:
 
 ```js
 {
@@ -21,7 +17,7 @@ Don't forget to add a [`.babelrc`](https://babeljs.io/docs/usage/babelrc/) file 
 }
 ```
 
-You are now set up to use all ES2015 features and React specific syntax.
+You are now set up to use all ES6 features and React specific syntax.
 
 *Note: If you are using a more complicated Babel configuration, using Babel's `env` option,
 keep in mind that Jest will automatically define `NODE_ENV` as `test`.

--- a/docs/MoreResources.md
+++ b/docs/MoreResources.md
@@ -4,13 +4,26 @@ title: More Resources
 layout: docs
 category: Introduction
 permalink: docs/more-resources.html
-next: tutorial-react
+next: snapshot-testing
 ---
 
-> **Note**: This is a placeholder.
+By now you should have a good idea of how Jest can make it easy to test your applications. If you're interested in learning more, here's some related stuff you might want to check out.
 
-* _some link to the first guide under Guides_
-* [API Reference](/jest/docs/api.html)
-* [Learn by example](https://github.com/facebook/jest/tree/master/examples).
-* See excellent examples of tests used by the [React](https://github.com/facebook/react/tree/master/src/renderers/shared/stack/reconciler/__tests__), [Relay](https://github.com/facebook/relay/tree/master/src/container/__tests__), and [React Native](https://github.com/facebook/react-native/tree/master/Libraries/Animated/src/__tests__) projects.
-* Migrate your existing tests to Jest by following our [migration guide](https://facebook.github.io/jest/docs/migration-guide.html).
+### Browse the docs
+
+- Learn about [Snapshot Testing](/jest/docs/snapshot-testing.html).
+- Migrate your existing tests to Jest by following our [migration guide](https://facebook.github.io/jest/docs/migration-guide.html).
+- Learn how to [configure Jest](/jest/docs/configuration.html).
+- Enable support for [Babel](/jest/docs/babel.html).
+- Look at the full [API Reference](/jest/docs/api.html).
+- [Troubleshoot](/jest/docs/troubleshooting.html) problems with Jest.
+
+### Learn by example
+
+You will find a number of example test cases in the [`examples`](https://github.com/facebook/jest/tree/master/examples) folder on GitHub. You can also learn from the excellent tests used by the [React](https://github.com/facebook/react/tree/master/src/renderers/shared/stack/reconciler/__tests__), [Relay](https://github.com/facebook/relay/tree/master/src/container/__tests__), and [React Native](https://github.com/facebook/react-native/tree/master/Libraries/Animated/src/__tests__) projects.
+
+### Join the community
+
+Ask questions and find answers from other Jest users like you. [Reactiflux](http://www.reactiflux.com/) is a Discord chat where a lot of Jest discussion happens. Check out the [#jest](https://discordapp.com/channels/102860784329052160/103622435865104384) channel.
+
+Follow the [Jest Twitter account](https://twitter.com/fbjest) and [blog](/jest/blog/) to find out what's happening in the world of Jest.

--- a/docs/TimerMocks.md
+++ b/docs/TimerMocks.md
@@ -4,7 +4,7 @@ title: Timer Mocks
 layout: docs
 category: Guides
 permalink: docs/timer-mocks.html
-next: tutorial-async
+next: babel
 ---
 
 The native timer functions (i.e., `setTimeout`, `setInterval`, `clearTimeout`,

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -108,7 +108,7 @@ jest.dontMock('foo');
 import foo from './foo';
 ```
 
-In ES2015, import statements get hoisted before all other
+In ES6, import statements get hoisted before all other
 
 ```js
 var foo = require('foo');

--- a/docs/TutorialAsync.md
+++ b/docs/TutorialAsync.md
@@ -4,7 +4,7 @@ title: An Async Example
 layout: docs
 category: Guides
 permalink: docs/tutorial-async.html
-next: babel
+next: webpack
 ---
 
 *Note: make sure to install `babel-jest` and the async/await feature for this

--- a/docs/Webpack.md
+++ b/docs/Webpack.md
@@ -73,7 +73,7 @@ module.exports = {};
 module.exports = 'test-file-stub';
 ```
 
-For CSS Modules, you can use an [ES2015 Proxy](https://github.com/keyanzhang/identity-obj-proxy)
+For CSS Modules, you can use an [ES6 Proxy](https://github.com/keyanzhang/identity-obj-proxy)
 (`npm install --save-dev identity-obj-proxy`) to mock
 [CSS Modules](https://github.com/css-modules/css-modules); then all your className
 lookups on the styles object will be returned as-is (e.g., `styles.foobar === 'foobar'`).

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -11,9 +11,8 @@ var siteConfig = {
   githubButton: githubButton,
   homepagePromos: [
     <div className="pluginRowBlock">
-      <Button href="#getting-started">Get Started</Button>
-      <Button href="/jest/docs/tutorial-react.html">React Testing</Button>
-      <Button href="/jest/docs/tutorial-react-native.html">React Native Testing</Button>
+      <Button href="/jest/docs/getting-started.html">Get Started</Button>
+      <Button href="/jest/docs/snapshot-testing.html">Snapshot Testing</Button>
       <Button href="/jest/docs/api.html">API Reference</Button>
       {githubButton}
     </div>,
@@ -21,18 +20,18 @@ var siteConfig = {
   features: [
     {
       image: "/jest/img/content/adaptable.svg",
-      title: "Turbocharged",
+      title: "Easy and Familiar",
       content: "Jest is a complete and easy to setup JavaScript testing solution."
     },
     {
       image: "/jest/img/content/sandboxed.svg",
-      title: "Fast and Sandboxed",
+      title: "Performance",
       content: "Jest virtualizes JavaScript environments and runs tests in parallel across worker processes."
     },
     {
       image: "/jest/img/content/snapshots.svg",
       title: "Snapshot Testing",
-      content: "Jest can [capture snapshots](/jest/docs/tutorial-react.html#snapshot-testing) of React trees or other serializable values to simplify UI testing."
+      content: "Jest can [capture snapshots](/jest/docs/snapshot-testing.html) of React trees or other serializable values to simplify UI testing."
     },
   ]
 };

--- a/website/src/jest/index.js
+++ b/website/src/jest/index.js
@@ -21,7 +21,7 @@ var index = React.createClass({
     var whyJest = [
       {content: 'Fast interactive mode with `--watch`.'},
       {content: 'Create coverage reports with `--coverage`. No additional setup or libraries needed!'},
-      {content: 'Automatically find tests related to changed files to execute in your project with `-o`.'},
+      {content: 'Automatically find tests related to changed files to execute in your project with `--onlyChanged`.'},
       {content: 'Error messages are helpful and color coded. Stack traces point to the source of problems quickly.'},
       {content: 'Jest runs previously failed tests first. Together with `--bail` it provides useful signal quickly.'},
       {content: 'Sandboxed test files and automatic global state resets for every test.'},
@@ -30,7 +30,7 @@ var index = React.createClass({
       {content: 'Run tests in parallel processes to minimize test runtime.'},
       {content: 'Jest works with any compile-to-JS language and integrates seamlessly with [Babel](https://babeljs.io).'},
       {content: 'Integrated [manual mocking library](/jest/docs/mock-functions.html).'},
-      {content: 'Can run [asynchronous code synchronously](/jest/docs/timer-mocks.html).'},
+      {content: 'Can run [asynchronous code synchronously](/jest/docs/asynchronous.html).'},
     ];
 
     return (


### PR DESCRIPTION
Expand the More Resources section.
Reduce number of CTAs on the home page.
Do not use single-character aliases in examples.

Fixes #2383