### PR TITLE
Add API Reference to Navigation Header

### DIFF
--- a/website/core/nav/HeaderNav.js
+++ b/website/core/nav/HeaderNav.js
@@ -80,6 +80,7 @@ class HeaderNav extends React.Component {
 HeaderNav.defaultProps = {
   linksInternal: [
     {section: 'docs', href: '/jest/docs/getting-started.html', text: 'Docs'},
+    {section: 'api', href: '/jest/docs/api.html', text: 'API'},
     {section: 'help', href: '/jest/help.html', text: 'Help'},
     {section: 'blog', href: '/jest/blog/', text: 'Blog'},
   ],


### PR DESCRIPTION
Link to the API docs.

![screen shot 2016-12-21 at 6 19 32 pm](https://cloud.githubusercontent.com/assets/165856/21413156/2434db4e-c7aa-11e6-8d8d-cde460914c89.png)

