### PR TITLE
Treat arrows as no-op while entering a pattern FIX #2427

### DIFF
--- a/packages/jest-cli/src/jest.js
+++ b/packages/jest-cli/src/jest.js
@@ -40,6 +40,10 @@ const WATCHER_DEBOUNCE = 200;
 const WATCHMAN_BIN = 'watchman';
 const KEYS = {
   A: '61',
+  ARROW_DOWN: '1b5b42',
+  ARROW_LEFT: '1b5b44',
+  ARROW_RIGHT: '1b5b43',
+  ARROW_UP: '1b5b41',
   BACKSPACE: process.platform === 'win32' ? '08' : '7f',
   CONTROL_C: '03',
   CONTROL_D: '04',
@@ -362,6 +366,11 @@ const runCLI = (
                 isEnteringPattern = false;
                 pipe.write(ansiEscapes.eraseLines(2));
                 currentPattern = argv._[0];
+                break;
+              case KEYS.ARROW_DOWN:
+              case KEYS.ARROW_LEFT:
+              case KEYS.ARROW_RIGHT:
+              case KEYS.ARROW_UP:
                 break;
               default:
                 const char = new Buffer(key, 'hex').toString();


### PR DESCRIPTION
#2427 for more info

This PR treats arrows as no-op to prevent Jest patterns to break in watch mode, but I think in the future we could do some cool stuff like:
* left/right arrows will actually move the cursor and allow you to add/remove text where the cursor is.
* up/down arrows could show some typeahead history, for example. If my last 3 patterns where `react.*dom`, `react` and `component` then using the up arrow while in "pattern mode" will set the current pattern to `component`, using it again will set it to `react`, etc.

**Before**
![arrows-before](https://cloud.githubusercontent.com/assets/574806/21415420/70199806-c7be-11e6-89ee-52b08b0c0fbf.gif)

**After**
![arrows-after](https://cloud.githubusercontent.com/assets/574806/21415440/c333fb30-c7be-11e6-8d1d-f8533c540718.gif)

