### PR TITLE
docs(api): fix anchor link to `toMatchSnapshot`

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -64,7 +64,7 @@ expect all the time. That's what you use `expect` for.
   - [`.toHaveLength(number)`](#tohavelengthnumber)
   - [`.toMatch(regexp)`](#tomatchregexp)
   - [`.toMatchObject(object)`](#tomatchobjectobject)
-  - [`.toMatchSnapshot()`](#tomatchsnapshot)
+  - [`.toMatchSnapshot()`](#tomatchsnapshotstring)
   - [`.toThrow()`](#tothrow)
   - [`.toThrowError(error)`](#tothrowerrorerror)
   - [`.toThrowErrorMatchingSnapshot()`](#tothrowerrormatchingsnapshot)


### PR DESCRIPTION
**Summary**

I'm guessing the added `?string` to the title of the section was not applied to the link.

**Test plan**

N/A