### PR TITLE
chore: update to newer version of istanbul-api, removing deprecation warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "flow-bin": "^0.37.0",
     "glob": "^7.1.1",
     "graceful-fs": "^4.1.11",
-    "istanbul-api": "^1.1.0-alpha.1",
+    "istanbul-api": "^1.1.0",
     "istanbul-lib-coverage": "^1.0.0",
     "jasmine-reporters": "^2.2.0",
     "jsdom": "^9.9.1",


### PR DESCRIPTION
see discussion in: https://github.com/facebook/jest/issues/2356

this update should remove the warning:

`npm WARN deprecated minimatch@2.0.10: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue`