### PR TITLE
[WIP] Fix Console Logging in jsdom Env

### DIFF
--- a/integration_tests/__tests__/__snapshots__/console-test.js.snap
+++ b/integration_tests/__tests__/__snapshots__/console-test.js.snap
@@ -55,3 +55,35 @@ Time:        <<REPLACED>>
 Ran all test suites.
 "
 `;
+
+exports[`test console printing with jsdom env 1`] = `
+"  console.log __tests__/console-test.js:11
+    This is a log message.
+
+  console.info __tests__/console-test.js:13
+    This is an info message.
+
+  console.warn __tests__/console-test.js:15
+    This is a warning message.
+
+  console.error __tests__/console-test.js:17
+    This is an error message.
+
+"
+`;
+
+exports[`test console printing with jsdom env 2`] = `
+" PASS  __tests__/console-test.js
+  ✓ works just fine
+
+"
+`;
+
+exports[`test console printing with jsdom env 3`] = `
+"Test Suites: 1 passed, 1 total
+Tests:       1 passed, 1 total
+Snapshots:   0 total
+Time:        <<REPLACED>>
+Ran all test suites.
+"
+`;

--- a/integration_tests/__tests__/console-test.js
+++ b/integration_tests/__tests__/console-test.js
@@ -34,3 +34,14 @@ test('console printing with --verbose', () => {
   expect(rest).toMatchSnapshot();
   expect(summary).toMatchSnapshot();
 });
+
+test('console printing with jsdom env', () => {
+  const {stderr, stdout, status} =
+        runJest('console', ['--verbose', '--env=jsdom']);
+  const {summary, rest} = extractSummary(stderr);
+
+  expect(status).toBe(0);
+  expect(stdout).toMatchSnapshot();
+  expect(rest).toMatchSnapshot();
+  expect(summary).toMatchSnapshot();
+});

--- a/packages/jest-environment-node/src/index.js
+++ b/packages/jest-environment-node/src/index.js
@@ -9,6 +9,7 @@
  */
 'use strict';
 
+import type {Console} from 'console';
 import type {Config} from 'types/Config';
 import type {Global} from 'types/Global';
 import type {Script} from 'vm';
@@ -20,14 +21,16 @@ const vm = require('vm');
 
 class NodeEnvironment {
 
+  console: ?Console;
   context: ?vm$Context;
   fakeTimers: ?FakeTimers;
   global: ?Global;
   moduleMocker: ?ModuleMocker;
 
-  constructor(config: Config) {
+  constructor(config: Config, createCustomConsole: (x: number) => Console) {
     this.context = vm.createContext();
     const global = this.global = vm.runInContext('this', this.context);
+    global.console = this.console = createCustomConsole(4);
     global.global = global;
     global.clearInterval = clearInterval;
     global.clearTimeout = clearTimeout;
@@ -43,6 +46,7 @@ class NodeEnvironment {
     if (this.fakeTimers) {
       this.fakeTimers.dispose();
     }
+    this.console = null;
     this.context = null;
     this.fakeTimers = null;
   }


### PR DESCRIPTION
**Summary**
Jest currently supports great buffered output for printing to console (`console.log`, `console.warn`, etc) but this only works in the official `node` env. This PR aims to add this functionality to jsdom env too (very useful when debugging tests).

Current master monkey patches in the jest console with this line, but this does not work on the jsdom object for whatever reason:
`const testConsole = env.global.console = new TestConsole(`

This PR consists of two commits, the first being a (broken) test demonstrating the desired behavior with jsdom env. The second commit is a proposed solution which fixes the failing test.

I have changed it so the test environment is responsible for constructing the console rather than the higher context with the above assignment. I have provided a factory function to the test environment's constructor since it seemed unreasonable to me for the environment to know how to and to duplicate this configuration logic. I was looking for some design input on this since this would break existing API, which probably wouldn't be a big deal except that its currently a supported use case for user to configure their own test environment.

**Test plan**
I have broken a boatload of tests because of the API change but I didn't want to waste time fixing them all if there are disagreements on the design.