### PR TITLE
Update index.d.ts

### DIFF
--- a/packages/jest-editor-support/index.d.ts
+++ b/packages/jest-editor-support/index.d.ts
@@ -6,114 +6,112 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-declare module 'jest-editor-support' {
-  import {EventEmitter} from 'events';
+import {EventEmitter} from 'events';
 
-  export class Runner extends EventEmitter {
-    constructor(workspace: ProjectWorkspace);
-    start(): void;
-    closeProcess(): void;
-    runJestWithUpdateForSnapshots(completion: any): void;
-  }
+export class Runner extends EventEmitter {
+  constructor(workspace: ProjectWorkspace);
+  start(): void;
+  closeProcess(): void;
+  runJestWithUpdateForSnapshots(completion: any): void;
+}
 
-  export class Settings extends EventEmitter {
-    constructor(workspace: ProjectWorkspace);
-    getConfig(completed: Function): void;
-    jestVersionMajor: number | null;
-    settings: {
-      testRegex: string;
-    };
-  }
-
-  export class ProjectWorkspace {
-    constructor(
-      rootPath: string,
-      pathToJest: string,
-      pathToConfig: string,
-      localJestMajorVersin: number
-    );
-    pathToJest: string;
-    rootPath: string;
-    localJestMajorVersion: number;
-  }
-
-  export interface IParseResults {
-    expects: Expect[];
-    itBlocks: ItBlock[];
-  }
-
-  export function parse(file: string): IParseResults;
-
-  type Location = {
-    column: number,
-    line: number,
+export class Settings extends EventEmitter {
+  constructor(workspace: ProjectWorkspace);
+  getConfig(completed: Function): void;
+  jestVersionMajor: number | null;
+  settings: {
+    testRegex: string;
   };
+}
 
-  class Node {
-    start: Location;
-    end: Location;
-    file: string;
-  }
+export class ProjectWorkspace {
+  constructor(
+    rootPath: string,
+    pathToJest: string,
+    pathToConfig: string,
+    localJestMajorVersin: number
+  );
+  pathToJest: string;
+  rootPath: string;
+  localJestMajorVersion: number;
+}
 
-  export class ItBlock extends Node {
-    name: string;
-  }
+export interface IParseResults {
+  expects: Expect[];
+  itBlocks: ItBlock[];
+}
 
-  export type Expect = Node;
+export function parse(file: string): IParseResults;
 
-  export class TestReconciler {
-    stateForTestFile(file: string): TestReconcilationState;
-    stateForTestAssertion(file: string, name: string): TestFileAssertionStatus | null;
-    failedStatuses(): Array<TestFileAssertionStatus>;
-    updateFileWithJestStatus(data): void;
-  }
+export interface Location {
+  column: number;
+  line: number;
+}
 
-  type TestReconcilationState = "Unknown" |
-    "KnownSuccess" |
-    "KnownFail";
+export class Node {
+  start: Location;
+  end: Location;
+  file: string;
+}
 
-  export type TestFileAssertionStatus = {
-    file: string,
-    message: string,
-    status: TestReconcilationState,
-    assertions: Array<TestAssertionStatus>,
-  }
+export class ItBlock extends Node {
+  name: string;
+}
 
-  export type TestAssertionStatus = {
-    title: string,
-    status: TestReconcilationState,
-    message: string,
-    shortMessage?: string,
-    terseMessage?: string,
-    line?: number,
-  }
+export class Expect extends Node {}
 
-  export type JestFileResults = {
-    name: string,
-    summary: string,
-    message: string,
-    status: "failed" | "passed",
-    startTime: number,
-    endTime: number,
-    assertionResults: Array<JestAssertionResults>,
-  }
+export class TestReconciler {
+  stateForTestFile(file: string): TestReconcilationState;
+  stateForTestAssertion(file: string, name: string): TestFileAssertionStatus | null;
+  failedStatuses(): Array<TestFileAssertionStatus>;
+  updateFileWithJestStatus(data): void;
+}
 
-  export type JestAssertionResults = {
-    name: string,
-    title: string,
-    status: "failed" | "passed",
-    failureMessages: string[],
-  }
+export type TestReconcilationState = "Unknown" |
+  "KnownSuccess" |
+  "KnownFail";
 
-  export type JestTotalResults = {
-    success: boolean,
-    startTime: number,
-    numTotalTests: number,
-    numTotalTestSuites: number,
-    numRuntimeErrorTestSuites: number,
-    numPassedTests: number,
-    numFailedTests: number,
-    numPendingTests: number,
-    testResults: Array<JestFileResults>,
-  }
+export interface TestFileAssertionStatus {
+  file: string;
+  message: string;
+  status: TestReconcilationState;
+  assertions: Array<TestAssertionStatus>;
+}
+
+export interface TestAssertionStatus {
+  title: string;
+  status: TestReconcilationState;
+  message: string;
+  shortMessage?: string;
+  terseMessage?: string;
+  line?: number;
+}
+
+export interface JestFileResults {
+  name: string;
+  summary: string;
+  message: string;
+  status: "failed" | "passed";
+  startTime: number;
+  endTime: number;
+  assertionResults: Array<JestAssertionResults>;
+}
+
+export interface JestAssertionResults {
+  name: string;
+  title: string;
+  status: "failed" | "passed";
+  failureMessages: string[];
+}
+
+export interface JestTotalResults {
+  success: boolean;
+  startTime: number;
+  numTotalTests: number;
+  numTotalTestSuites: number;
+  numRuntimeErrorTestSuites: number;
+  numPassedTests: number;
+  numFailedTests: number;
+  numPendingTests: number;
+  testResults: Array<JestFileResults>;
 }


### PR DESCRIPTION
Related to https://github.com/facebook/jest/commit/d070b2f7c40a75d9ccf41f4b44751aa8f6b5cb6f#commitcomment-20317429.

Main changes:

* Use an external module definition - TypeScript can only automatically use an external module definition from `package.json`
  * In "global" mode where you declare your own module name it can create conflicts
* Moved from type expressions to interfaces where it made sense
* Fixed the exported class `Expect` - it now matches runtime, whereas the previous version exported the "type" of the class instance instead of the class constructor