### PR TITLE
expose --collectCoverageOnlyFrom

### DIFF
--- a/integration_tests/__tests__/__snapshots__/coverage_report-test.js.snap
+++ b/integration_tests/__tests__/__snapshots__/coverage_report-test.js.snap
@@ -8,6 +8,16 @@ All files |      100 |      100 |      100 |      100 |                |
 "
 `;
 
+exports[`test collects coverage only from specified files avoiding dependencies 1`] = `
+"----------|----------|----------|----------|----------|----------------|
+File      |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
+----------|----------|----------|----------|----------|----------------|
+All files |      100 |      100 |      100 |      100 |                |
+ sum.js   |      100 |      100 |      100 |      100 |                |
+----------|----------|----------|----------|----------|----------------|
+"
+`;
+
 exports[`test json reporter printing with --coverage 1`] = `
 "Test Suites: 1 failed, 1 total
 Tests:       1 failed, 1 passed, 2 total

--- a/integration_tests/__tests__/coverage_report-test.js
+++ b/integration_tests/__tests__/coverage_report-test.js
@@ -50,6 +50,23 @@ test('collects coverage only from specified files', () => {
   expect(stdout).toMatchSnapshot();
 });
 
+test(
+  'collects coverage only from specified files avoiding dependencies',
+  () => {
+    const {stdout} = runJest(DIR, [
+      '--no-cache',
+      '--coverage',
+      '--collectCoverageOnlyFrom',
+      'sum.js',
+      '--',
+      'sum-test.js',
+    ]);
+
+    // Coverage report should only have `sum.js` coverage info
+    expect(stdout).toMatchSnapshot();
+  }
+);
+
 test('json reporter printing with --coverage', () => {
   const {stderr, status} = runJest('json_reporter', ['--coverage']);
   const {summary} = extractSummary(stderr);

--- a/packages/jest-cli/src/cli/args.js
+++ b/packages/jest-cli/src/cli/args.js
@@ -66,6 +66,10 @@ const options = {
       'info needs to be collected from.',
     type: 'string',
   },
+  collectCoverageOnlyFrom: {
+    description: 'List of paths coverage will be restricted to.',
+    type: 'array',
+  },
   colors: {
     description:
       'Forces test results output highlighting (even if stdout is not a TTY)',

--- a/packages/jest-config/src/normalize.js
+++ b/packages/jest-config/src/normalize.js
@@ -238,6 +238,14 @@ function normalize(config, argv) {
     config.collectCoverageFrom = argv.collectCoverageFrom;
   }
 
+  if (argv.collectCoverageOnlyFrom) {
+    const collectCoverageOnlyFrom = Object.create(null);
+    argv.collectCoverageOnlyFrom.forEach(
+      path => collectCoverageOnlyFrom[path] = true
+    );
+    config.collectCoverageOnlyFrom = collectCoverageOnlyFrom;
+  }
+
   if (!config.testRunner || config.testRunner === 'jasmine2') {
     config.testRunner = require.resolve('jest-jasmine2');
   } else {
@@ -302,7 +310,7 @@ function normalize(config, argv) {
           );
           normObj[filePath] = true;
           return normObj;
-        }, {});
+        }, {__proto__: null});
         break;
 
       case 'setupFiles':

--- a/packages/jest-config/src/normalize.js
+++ b/packages/jest-config/src/normalize.js
@@ -310,7 +310,7 @@ function normalize(config, argv) {
           );
           normObj[filePath] = true;
           return normObj;
-        }, {__proto__: null});
+        }, Object.create(null));
         break;
 
       case 'setupFiles':


### PR DESCRIPTION
Expose the `collectCoverageOnlyFrom` option on the cli
==

The option was already available through configuration,
I've exposed it and add an integration test for testing it.

The option accept an array, so it can be called in multiple ways:
`jest <...> --coverage --collectCoverageOnlyFrom fileA.js fileB.js -- <testPattern>`
if we don't like using the `--` delimeter it's possible to use the coverage flag _after_ collectCoverageOnlyFrom:
`jest <...> --collectCoverageOnlyFrom fileA.js fileB.js --coverage <testPattern>`

**Test plan**
I've add an integration test.
`yarn test`

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
