### PR TITLE
Pass CLI args when loading config from file

### DIFF
--- a/packages/jest-config/src/index.js
+++ b/packages/jest-config/src/index.js
@@ -34,7 +34,7 @@ const readRawConfig = (argv, root) => {
   const rawConfig = parseConfig(argv);
 
   if (typeof rawConfig === 'string') {
-    return loadFromFile(path.resolve(process.cwd(), rawConfig));
+    return loadFromFile(path.resolve(process.cwd(), rawConfig), argv);
   }
 
   if (typeof rawConfig === 'object') {

--- a/packages/jest-config/src/loadFromFile.js
+++ b/packages/jest-config/src/loadFromFile.js
@@ -4,9 +4,13 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
  */
 
 'use strict';
+
+import type {Path} from 'types/Config';
 
 const fs = require('fs');
 const normalize = require('./normalize');
@@ -14,7 +18,7 @@ const jsonlint = require('./vendor/jsonlint');
 const path = require('path');
 const promisify = require('./lib/promisify');
 
-function loadFromFile(filePath, argv) {
+function loadFromFile(filePath: Path, argv: Object) {
   return promisify(fs.readFile)(filePath).then(data => {
     const parse = () => {
       try {

--- a/packages/jest-config/src/loadFromPackage.js
+++ b/packages/jest-config/src/loadFromPackage.js
@@ -4,18 +4,23 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
  */
 
 'use strict';
+
+import type {Path} from 'types/Config';
 
 const fs = require('fs');
 const normalize = require('./normalize');
 const path = require('path');
 const promisify = require('./lib/promisify');
 
-function loadFromPackage(filePath, argv) {
+function loadFromPackage(filePath: Path, argv: Object) {
   return promisify(fs.access)(filePath, fs.R_OK).then(
     () => {
+      // $FlowFixMe
       const packageData = require(filePath);
       const config = packageData.jest || {};
       const root = path.dirname(filePath);


### PR DESCRIPTION
Pass CLI arguments when loading config from file.

Fixes #2472. 

Expected env should be `node`:
```
jest --config path-to-config --env node
```