### PR TITLE
Fix Jest Runtime mock test

### DIFF
--- a/packages/jest-runtime/src/__tests__/Runtime-mock-test.js
+++ b/packages/jest-runtime/src/__tests__/Runtime-mock-test.js
@@ -33,7 +33,7 @@ describe('Runtime', () => {
         ).toEqual(mockReference);
 
         expect(
-          runtime.requireModuleOrMock(runtime.__mockRootPath, 'RegularModule'),
+          runtime.requireModuleOrMock(runtime.__mockRootPath, 'ManuallyMocked'),
         ).toEqual(mockReference);
       }),
     );
@@ -82,7 +82,7 @@ describe('Runtime', () => {
         ).toBe(mockReference);
 
         expect(
-          runtime.requireModuleOrMock(runtime.__mockRootPath, 'RegularModule'),
+          runtime.requireModuleOrMock(runtime.__mockRootPath, 'ManuallyMocked'),
         ).toBe(mockReference);
       }),
     );


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

I was looking into the Jest Runtime folder and I found out that two tests were duplicated.
Both are running expectations on "RegularModule" while the second one should check "ManuallyMocked".

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

I made the change, ran `npm test` and tests are still green.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
