### PR TITLE
Pretty-print asymmetric matchers

### DIFF
--- a/packages/jest-diff/src/index.js
+++ b/packages/jest-diff/src/index.js
@@ -14,6 +14,7 @@ import type {DiffOptions} from './diffStrings';
 
 const ReactElementPlugin = require('pretty-format/build/plugins/ReactElement');
 const ReactTestComponentPlugin = require('pretty-format/build/plugins/ReactTestComponent');
+const AsymmetricMatcherPlugin = require('pretty-format/build/plugins/AsymmetricMatcher');
 
 const chalk = require('chalk');
 const diffStrings = require('./diffStrings');
@@ -25,7 +26,11 @@ const {
   SIMILAR_MESSAGE,
 } = require('./constants');
 
-const PLUGINS = [ReactTestComponentPlugin, ReactElementPlugin];
+const PLUGINS = [
+  ReactTestComponentPlugin,
+  ReactElementPlugin,
+  AsymmetricMatcherPlugin,
+];
 const FORMAT_OPTIONS = {
   plugins: PLUGINS,
 };
@@ -83,9 +88,7 @@ function compareObjects(a: Object, b: Object, options: ?DiffOptions) {
 
   try {
     diffMessage = diffStrings(
-      a.jasmineToPrettyString
-        ? a.jasmineToPrettyString(FORMAT_OPTIONS)
-        : prettyFormat(a, FORMAT_OPTIONS),
+      prettyFormat(a, FORMAT_OPTIONS),
       prettyFormat(b, FORMAT_OPTIONS),
       options,
     );
@@ -97,9 +100,7 @@ function compareObjects(a: Object, b: Object, options: ?DiffOptions) {
   // without calling `toJSON`. It's also possible that toJSON might throw.
   if (!diffMessage || diffMessage === NO_DIFF_MESSAGE) {
     diffMessage = diffStrings(
-      a.jasmineToPrettyString
-        ? a.jasmineToPrettyString(FALLBACK_FORMAT_OPTIONS)
-        : prettyFormat(a, FALLBACK_FORMAT_OPTIONS),
+      prettyFormat(a, FALLBACK_FORMAT_OPTIONS),
       prettyFormat(b, FALLBACK_FORMAT_OPTIONS),
       options,
     );

--- a/packages/jest-diff/src/index.js
+++ b/packages/jest-diff/src/index.js
@@ -83,7 +83,9 @@ function compareObjects(a: Object, b: Object, options: ?DiffOptions) {
 
   try {
     diffMessage = diffStrings(
-      prettyFormat(a, FORMAT_OPTIONS),
+      a.jasmineToPrettyString
+        ? a.jasmineToPrettyString(FORMAT_OPTIONS)
+        : prettyFormat(a, FORMAT_OPTIONS),
       prettyFormat(b, FORMAT_OPTIONS),
       options,
     );
@@ -95,7 +97,9 @@ function compareObjects(a: Object, b: Object, options: ?DiffOptions) {
   // without calling `toJSON`. It's also possible that toJSON might throw.
   if (!diffMessage || diffMessage === NO_DIFF_MESSAGE) {
     diffMessage = diffStrings(
-      prettyFormat(a, FALLBACK_FORMAT_OPTIONS),
+      a.jasmineToPrettyString
+        ? a.jasmineToPrettyString(FALLBACK_FORMAT_OPTIONS)
+        : prettyFormat(a, FALLBACK_FORMAT_OPTIONS),
       prettyFormat(b, FALLBACK_FORMAT_OPTIONS),
       options,
     );

--- a/packages/jest-matcher-utils/src/__tests__/__snapshots__/index-test.js.snap
+++ b/packages/jest-matcher-utils/src/__tests__/__snapshots__/index-test.js.snap
@@ -1,23 +1,24 @@
-exports[`.stringify() reduces maxDepth if stringifying very large objects 1`] = `"{\"a\": 1, \"b\": [Object]}"`;
+exports[`.stringify() reduces maxDepth if stringifying very large objects 1`] = `"{"a": 1, "b": [Object]}"`;
 
-exports[`.stringify() reduces maxDepth if stringifying very large objects 2`] = `"{\"a\": 1, \"b\": {\"0\": \"test\", \"1\": \"test\", \"2\": \"test\", \"3\": \"test\", \"4\": \"test\", \"5\": \"test\", \"6\": \"test\", \"7\": \"test\", \"8\": \"test\", \"9\": \"test\"}}"`;
+exports[`.stringify() reduces maxDepth if stringifying very large objects 2`] = `"{"a": 1, "b": {"0": "test", "1": "test", "2": "test", "3": "test", "4": "test", "5": "test", "6": "test", "7": "test", "8": "test", "9": "test"}}"`;
 
 exports[`.stringify() toJSON errors when comparing two objects 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).toEqual([22m[32mexpected[39m[2m)[22m
 
 Expected value to equal:
-  [32m{\"b\": 1, \"toJSON\": [Function toJSON]}[39m
+  [32m{"b": 1, "toJSON": [Function toJSON]}[39m
 Received:
-  [31m{\"a\": 1, \"toJSON\": [Function toJSON]}[39m
+  [31m{"a": 1, "toJSON": [Function toJSON]}[39m
 
 Difference:
 
 [32m- Expected[39m
 [31m+ Received[39m
 
-[2m Object {[22m
-[32m-  \"b\": 1,[39m
-[31m+  \"a\": 1,[39m
-[2m   \"toJSON\": [Function toJSON],[22m
+[33m@@ -1,4 +1,4 @@
+[39m[2m Object {[22m
+[32m-  "b": 1,[39m
+[31m+  "a": 1,[39m
+[2m   "toJSON": [Function toJSON],[22m
 [2m }[22m"
 `;

--- a/packages/jest-matcher-utils/src/__tests__/__snapshots__/index-test.js.snap
+++ b/packages/jest-matcher-utils/src/__tests__/__snapshots__/index-test.js.snap
@@ -1,24 +1,23 @@
-exports[`.stringify() reduces maxDepth if stringifying very large objects 1`] = `"{"a": 1, "b": [Object]}"`;
+exports[`.stringify() reduces maxDepth if stringifying very large objects 1`] = `"{\"a\": 1, \"b\": [Object]}"`;
 
-exports[`.stringify() reduces maxDepth if stringifying very large objects 2`] = `"{"a": 1, "b": {"0": "test", "1": "test", "2": "test", "3": "test", "4": "test", "5": "test", "6": "test", "7": "test", "8": "test", "9": "test"}}"`;
+exports[`.stringify() reduces maxDepth if stringifying very large objects 2`] = `"{\"a\": 1, \"b\": {\"0\": \"test\", \"1\": \"test\", \"2\": \"test\", \"3\": \"test\", \"4\": \"test\", \"5\": \"test\", \"6\": \"test\", \"7\": \"test\", \"8\": \"test\", \"9\": \"test\"}}"`;
 
 exports[`.stringify() toJSON errors when comparing two objects 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).toEqual([22m[32mexpected[39m[2m)[22m
 
 Expected value to equal:
-  [32m{"b": 1, "toJSON": [Function toJSON]}[39m
+  [32m{\"b\": 1, \"toJSON\": [Function toJSON]}[39m
 Received:
-  [31m{"a": 1, "toJSON": [Function toJSON]}[39m
+  [31m{\"a\": 1, \"toJSON\": [Function toJSON]}[39m
 
 Difference:
 
 [32m- Expected[39m
 [31m+ Received[39m
 
-[33m@@ -1,4 +1,4 @@
-[39m[2m Object {[22m
-[32m-  "b": 1,[39m
-[31m+  "a": 1,[39m
-[2m   "toJSON": [Function toJSON],[22m
+[2m Object {[22m
+[32m-  \"b\": 1,[39m
+[31m+  \"a\": 1,[39m
+[2m   \"toJSON\": [Function toJSON],[22m
 [2m }[22m"
 `;

--- a/packages/jest-matcher-utils/src/index.js
+++ b/packages/jest-matcher-utils/src/index.js
@@ -50,6 +50,7 @@ const NUMBERS = [
 // get the type of a value with handling the edge cases like `typeof []`
 // and `typeof null`
 const getType = (value: any): ValueType => {
+  console.log(value, typeof value);
   if (typeof value === 'undefined') {
     return 'undefined';
   } else if (value === null) {
@@ -71,6 +72,8 @@ const getType = (value: any): ValueType => {
       return 'map';
     } else if (value.constructor === Set) {
       return 'set';
+    } else if (value.toString() === 'ArrayContaining') {
+      return 'array';
     }
     return 'object';
   // $FlowFixMe https://github.com/facebook/flow/issues/1015
@@ -96,6 +99,10 @@ const stringify = (object: any, maxDepth?: number = 10): string => {
       maxDepth,
       min: true,
     });
+  }
+
+  if (object && object.jasmineToString) {
+    result = object.jasmineToString();
   }
 
   return result.length >= MAX_LENGTH && maxDepth > 1

--- a/packages/jest-matcher-utils/src/index.js
+++ b/packages/jest-matcher-utils/src/index.js
@@ -12,6 +12,9 @@
 
 const chalk = require('chalk');
 const prettyFormat = require('pretty-format');
+const AsymmetricMatcherPlugin = require('pretty-format/build/plugins/AsymmetricMatcher');
+
+const PLUGINS = [AsymmetricMatcherPlugin];
 
 export type ValueType =
   | 'array'
@@ -91,17 +94,15 @@ const stringify = (object: any, maxDepth?: number = 10): string => {
     result = prettyFormat(object, {
       maxDepth,
       min: true,
+      plugins: PLUGINS,
     });
   } catch (e) {
     result = prettyFormat(object, {
       callToJSON: false,
       maxDepth,
       min: true,
+      plugins: PLUGINS,
     });
-  }
-
-  if (object && object.jasmineToString) {
-    result = object.jasmineToString();
   }
 
   return result.length >= MAX_LENGTH && maxDepth > 1

--- a/packages/jest-matcher-utils/src/index.js
+++ b/packages/jest-matcher-utils/src/index.js
@@ -50,7 +50,6 @@ const NUMBERS = [
 // get the type of a value with handling the edge cases like `typeof []`
 // and `typeof null`
 const getType = (value: any): ValueType => {
-  console.log(value, typeof value);
   if (typeof value === 'undefined') {
     return 'undefined';
   } else if (value === null) {

--- a/packages/jest-matchers/src/__tests__/__snapshots__/matchers-test.js.snap
+++ b/packages/jest-matchers/src/__tests__/__snapshots__/matchers-test.js.snap
@@ -1795,8 +1795,7 @@ Difference:
 [32m- Expected[39m
 [31m+ Received[39m
 
-[33m@@ -1,4 +1,4 @@
-[39m[32m-<arrayContaining(Array [[39m
+[32m-<arrayContaining(Array [[39m
 [31m+Array [[39m
 [2m   1,[22m
 [32m-  2,[39m
@@ -1845,8 +1844,7 @@ Difference:
 [32m- Expected[39m
 [31m+ Received[39m
 
-[33m@@ -1,3 +1,4 @@
-[39m[32m-<objectContaining(Object {[39m
+[32m-<objectContaining(Object {[39m
 [32m-  \"a\": 2,[39m
 [32m-})>[39m
 [31m+Object {[39m

--- a/packages/jest-matchers/src/__tests__/__snapshots__/matchers-test.js.snap
+++ b/packages/jest-matchers/src/__tests__/__snapshots__/matchers-test.js.snap
@@ -1742,20 +1742,20 @@ Received:
   [31m\"abc\"[39m"
 `;
 
-exports[`.toEqual() expect("abcd").not.toEqual(<stringMatching(/bc/)>) 1`] = `
+exports[`.toEqual() expect("abcd").not.toEqual(StringMatching /bc/) 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).not.toEqual([22m[32mexpected[39m[2m)[22m
 
 Expected value to not equal:
-  [32m<stringMatching(/bc/)>[39m
+  [32mStringMatching /bc/[39m
 Received:
   [31m\"abcd\"[39m"
 `;
 
-exports[`.toEqual() expect("abd").toEqual(<stringMatching(/bc/i)>) 1`] = `
+exports[`.toEqual() expect("abd").toEqual(StringMatching /bc/i) 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).toEqual([22m[32mexpected[39m[2m)[22m
 
 Expected value to equal:
-  [32m<stringMatching(/bc/i)>[39m
+  [32mStringMatching /bc/i[39m
 Received:
   [31m\"abd\"[39m
 
@@ -1773,20 +1773,20 @@ Received:
   [31m\"banana\"[39m"
 `;
 
-exports[`.toEqual() expect([1, 2, 3]).not.toEqual(<arrayContaining([2, 3])>) 1`] = `
+exports[`.toEqual() expect([1, 2, 3]).not.toEqual(ArrayContaining [2, 3]) 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).not.toEqual([22m[32mexpected[39m[2m)[22m
 
 Expected value to not equal:
-  [32m<arrayContaining([2, 3])>[39m
+  [32mArrayContaining [2, 3][39m
 Received:
   [31m[1, 2, 3][39m"
 `;
 
-exports[`.toEqual() expect([1, 3]).toEqual(<arrayContaining([1, 2])>) 1`] = `
+exports[`.toEqual() expect([1, 3]).toEqual(ArrayContaining [1, 2]) 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).toEqual([22m[32mexpected[39m[2m)[22m
 
 Expected value to equal:
-  [32m<arrayContaining([1, 2])>[39m
+  [32mArrayContaining [1, 2][39m
 Received:
   [31m[1, 3][39m
 
@@ -1795,47 +1795,46 @@ Difference:
 [32m- Expected[39m
 [31m+ Received[39m
 
-[32m-<arrayContaining(Array [[39m
+[32m-ArrayContaining [[39m
 [31m+Array [[39m
 [2m   1,[22m
 [32m-  2,[39m
-[32m-])>[39m
 [31m+  3,[39m
-[31m+][39m"
+[2m ][22m"
 `;
 
-exports[`.toEqual() expect([Function anonymous]).not.toEqual(<any(Function)>) 1`] = `
+exports[`.toEqual() expect([Function anonymous]).not.toEqual(Any<Function>) 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).not.toEqual([22m[32mexpected[39m[2m)[22m
 
 Expected value to not equal:
-  [32m<any(Function)>[39m
+  [32mAny<Function>[39m
 Received:
   [31m[Function anonymous][39m"
 `;
 
-exports[`.toEqual() expect({"a": 1, "b": [Function b], "c": true}).not.toEqual({"a": 1, "b": <any(Function)>, "c": <anything>}) 1`] = `
+exports[`.toEqual() expect({"a": 1, "b": [Function b], "c": true}).not.toEqual({"a": 1, "b": Any<Function>, "c": Anything}) 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).not.toEqual([22m[32mexpected[39m[2m)[22m
 
 Expected value to not equal:
-  [32m{\"a\": 1, \"b\": <any(Function)>, \"c\": <anything>}[39m
+  [32m{\"a\": 1, \"b\": Any<Function>, \"c\": Anything}[39m
 Received:
   [31m{\"a\": 1, \"b\": [Function b], \"c\": true}[39m"
 `;
 
-exports[`.toEqual() expect({"a": 1, "b": 2}).not.toEqual(<objectContaining({"a": 1})>) 1`] = `
+exports[`.toEqual() expect({"a": 1, "b": 2}).not.toEqual(ObjectContaining {"a": 1}) 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).not.toEqual([22m[32mexpected[39m[2m)[22m
 
 Expected value to not equal:
-  [32m<objectContaining({\"a\": 1})>[39m
+  [32mObjectContaining {\"a\": 1}[39m
 Received:
   [31m{\"a\": 1, \"b\": 2}[39m"
 `;
 
-exports[`.toEqual() expect({"a": 1, "b": 2}).toEqual(<objectContaining({"a": 2})>) 1`] = `
+exports[`.toEqual() expect({"a": 1, "b": 2}).toEqual(ObjectContaining {"a": 2}) 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).toEqual([22m[32mexpected[39m[2m)[22m
 
 Expected value to equal:
-  [32m<objectContaining({\"a\": 2})>[39m
+  [32mObjectContaining {\"a\": 2}[39m
 Received:
   [31m{\"a\": 1, \"b\": 2}[39m
 
@@ -1844,13 +1843,12 @@ Difference:
 [32m- Expected[39m
 [31m+ Received[39m
 
-[32m-<objectContaining(Object {[39m
+[32m-ObjectContaining {[39m
 [32m-  \"a\": 2,[39m
-[32m-})>[39m
 [31m+Object {[39m
 [31m+  \"a\": 1,[39m
 [31m+  \"b\": 2,[39m
-[31m+}[39m"
+[2m }[22m"
 `;
 
 exports[`.toEqual() expect({"a": 5}).toEqual({"b": 6}) 1`] = `
@@ -1912,11 +1910,11 @@ Difference:
   Comparing two different types of values. Expected [32mundefined[39m but received [31mnull[39m."
 `;
 
-exports[`.toEqual() expect(true).not.toEqual(<anything>) 1`] = `
+exports[`.toEqual() expect(true).not.toEqual(Anything) 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).not.toEqual([22m[32mexpected[39m[2m)[22m
 
 Expected value to not equal:
-  [32m<anything>[39m
+  [32mAnything[39m
 Received:
   [31mtrue[39m"
 `;
@@ -1939,11 +1937,11 @@ Received:
   [31mtrue[39m"
 `;
 
-exports[`.toEqual() expect(undefined).toEqual(<any(Function)>) 1`] = `
+exports[`.toEqual() expect(undefined).toEqual(Any<Function>) 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).toEqual([22m[32mexpected[39m[2m)[22m
 
 Expected value to equal:
-  [32m<any(Function)>[39m
+  [32mAny<Function>[39m
 Received:
   [31mundefined[39m
 
@@ -1952,11 +1950,11 @@ Difference:
   Comparing two different types of values. Expected [32mobject[39m but received [31mundefined[39m."
 `;
 
-exports[`.toEqual() expect(undefined).toEqual(<anything>) 1`] = `
+exports[`.toEqual() expect(undefined).toEqual(Anything) 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).toEqual([22m[32mexpected[39m[2m)[22m
 
 Expected value to equal:
-  [32m<anything>[39m
+  [32mAnything[39m
 Received:
   [31mundefined[39m
 

--- a/packages/jest-matchers/src/__tests__/__snapshots__/matchers-test.js.snap
+++ b/packages/jest-matchers/src/__tests__/__snapshots__/matchers-test.js.snap
@@ -1814,11 +1814,11 @@ Received:
   [31m[Function anonymous][39m"
 `;
 
-exports[`.toEqual() expect({"a": 1, "b": [Function b], "c": true}).not.toEqual({"a": 1, "b": {"expectedObject": [Function Function]}, "c": {}}) 1`] = `
+exports[`.toEqual() expect({"a": 1, "b": [Function b], "c": true}).not.toEqual({"a": 1, "b": <any(Function)>, "c": <anything>}) 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).not.toEqual([22m[32mexpected[39m[2m)[22m
 
 Expected value to not equal:
-  [32m{\"a\": 1, \"b\": {\"expectedObject\": [Function Function]}, \"c\": {}}[39m
+  [32m{\"a\": 1, \"b\": <any(Function)>, \"c\": <anything>}[39m
 Received:
   [31m{\"a\": 1, \"b\": [Function b], \"c\": true}[39m"
 `;

--- a/packages/jest-matchers/src/__tests__/__snapshots__/matchers-test.js.snap
+++ b/packages/jest-matchers/src/__tests__/__snapshots__/matchers-test.js.snap
@@ -183,7 +183,7 @@ exports[`.toBeCloseTo() accepts an optional precision argument: [0, 0.000004, 5]
 
 Expected value not to be close to (with [32m5[39m-digit precision):
   [32m0.000004[39m
-Received: 
+Received:
   [31m0[39m"
 `;
 
@@ -192,7 +192,7 @@ exports[`.toBeCloseTo() accepts an optional precision argument: [0, 0.0001, 3] 1
 
 Expected value not to be close to (with [32m3[39m-digit precision):
   [32m0.0001[39m
-Received: 
+Received:
   [31m0[39m"
 `;
 
@@ -201,7 +201,7 @@ exports[`.toBeCloseTo() accepts an optional precision argument: [0, 0.1, 0] 1`] 
 
 Expected value not to be close to (with [32m0[39m-digit precision):
   [32m0.1[39m
-Received: 
+Received:
   [31m0[39m"
 `;
 
@@ -210,7 +210,7 @@ exports[`.toBeCloseTo() passes: [0, 0.001] 1`] = `
 
 Expected value not to be close to (with [32m2[39m-digit precision):
   [32m0.001[39m
-Received: 
+Received:
   [31m0[39m"
 `;
 
@@ -219,7 +219,7 @@ exports[`.toBeCloseTo() passes: [0, 0] 1`] = `
 
 Expected value not to be close to (with [32m2[39m-digit precision):
   [32m0[39m
-Received: 
+Received:
   [31m0[39m"
 `;
 
@@ -228,7 +228,7 @@ exports[`.toBeCloseTo() passes: [1.23, 1.225] 1`] = `
 
 Expected value not to be close to (with [32m2[39m-digit precision):
   [32m1.225[39m
-Received: 
+Received:
   [31m1.23[39m"
 `;
 
@@ -237,7 +237,7 @@ exports[`.toBeCloseTo() passes: [1.23, 1.226] 1`] = `
 
 Expected value not to be close to (with [32m2[39m-digit precision):
   [32m1.226[39m
-Received: 
+Received:
   [31m1.23[39m"
 `;
 
@@ -246,7 +246,7 @@ exports[`.toBeCloseTo() passes: [1.23, 1.229] 1`] = `
 
 Expected value not to be close to (with [32m2[39m-digit precision):
   [32m1.229[39m
-Received: 
+Received:
   [31m1.23[39m"
 `;
 
@@ -255,7 +255,7 @@ exports[`.toBeCloseTo() passes: [1.23, 1.234] 1`] = `
 
 Expected value not to be close to (with [32m2[39m-digit precision):
   [32m1.234[39m
-Received: 
+Received:
   [31m1.23[39m"
 `;
 
@@ -264,7 +264,7 @@ exports[`.toBeCloseTo() throws: [0, 0.01] 1`] = `
 
 Expected value to be close to (with [32m2[39m-digit precision):
   [32m0.01[39m
-Received: 
+Received:
   [31m0[39m"
 `;
 
@@ -273,7 +273,7 @@ exports[`.toBeCloseTo() throws: [1, 1.23] 1`] = `
 
 Expected value to be close to (with [32m2[39m-digit precision):
   [32m1.23[39m
-Received: 
+Received:
   [31m1[39m"
 `;
 
@@ -282,7 +282,7 @@ exports[`.toBeCloseTo() throws: [1.23, 1.2249999] 1`] = `
 
 Expected value to be close to (with [32m2[39m-digit precision):
   [32m1.2249999[39m
-Received: 
+Received:
   [31m1.23[39m"
 `;
 
@@ -1742,20 +1742,20 @@ Received:
   [31m\"abc\"[39m"
 `;
 
-exports[`.toEqual() expect("abcd").not.toEqual({"regexp": /bc/}) 1`] = `
+exports[`.toEqual() expect("abcd").not.toEqual(<stringMatching(/bc/)>) 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).not.toEqual([22m[32mexpected[39m[2m)[22m
 
 Expected value to not equal:
-  [32m{\"regexp\": /bc/}[39m
+  [32m<stringMatching(/bc/)>[39m
 Received:
   [31m\"abcd\"[39m"
 `;
 
-exports[`.toEqual() expect("abd").toEqual({"regexp": /bc/i}) 1`] = `
+exports[`.toEqual() expect("abd").toEqual(<stringMatching(/bc/i)>) 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).toEqual([22m[32mexpected[39m[2m)[22m
 
 Expected value to equal:
-  [32m{\"regexp\": /bc/i}[39m
+  [32m<stringMatching(/bc/i)>[39m
 Received:
   [31m\"abd\"[39m
 
@@ -1773,33 +1773,43 @@ Received:
   [31m\"banana\"[39m"
 `;
 
-exports[`.toEqual() expect([1, 2, 3]).not.toEqual({"sample": [2, 3]}) 1`] = `
+exports[`.toEqual() expect([1, 2, 3]).not.toEqual(<arrayContaining([2, 3])>) 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).not.toEqual([22m[32mexpected[39m[2m)[22m
 
 Expected value to not equal:
-  [32m{\"sample\": [2, 3]}[39m
+  [32m<arrayContaining([2, 3])>[39m
 Received:
   [31m[1, 2, 3][39m"
 `;
 
-exports[`.toEqual() expect([1, 3]).toEqual({"sample": [1, 2]}) 1`] = `
+exports[`.toEqual() expect([1, 3]).toEqual(<arrayContaining([1, 2])>) 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).toEqual([22m[32mexpected[39m[2m)[22m
 
 Expected value to equal:
-  [32m{\"sample\": [1, 2]}[39m
+  [32m<arrayContaining([1, 2])>[39m
 Received:
   [31m[1, 3][39m
 
 Difference:
 
-  Comparing two different types of values. Expected [32mobject[39m but received [31marray[39m."
+[32m- Expected[39m
+[31m+ Received[39m
+
+[33m@@ -1,4 +1,4 @@
+[39m[32m-<arrayContaining(Array [[39m
+[31m+Array [[39m
+[2m   1,[22m
+[32m-  2,[39m
+[32m-])>[39m
+[31m+  3,[39m
+[31m+][39m"
 `;
 
-exports[`.toEqual() expect([Function anonymous]).not.toEqual({"expectedObject": [Function Function]}) 1`] = `
+exports[`.toEqual() expect([Function anonymous]).not.toEqual(<any(Function)>) 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).not.toEqual([22m[32mexpected[39m[2m)[22m
 
 Expected value to not equal:
-  [32m{\"expectedObject\": [Function Function]}[39m
+  [32m<any(Function)>[39m
 Received:
   [31m[Function anonymous][39m"
 `;
@@ -1813,20 +1823,20 @@ Received:
   [31m{\"a\": 1, \"b\": [Function b], \"c\": true}[39m"
 `;
 
-exports[`.toEqual() expect({"a": 1, "b": 2}).not.toEqual({"sample": {"a": 1}}) 1`] = `
+exports[`.toEqual() expect({"a": 1, "b": 2}).not.toEqual(<objectContaining({"a": 1})>) 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).not.toEqual([22m[32mexpected[39m[2m)[22m
 
 Expected value to not equal:
-  [32m{\"sample\": {\"a\": 1}}[39m
+  [32m<objectContaining({\"a\": 1})>[39m
 Received:
   [31m{\"a\": 1, \"b\": 2}[39m"
 `;
 
-exports[`.toEqual() expect({"a": 1, "b": 2}).toEqual({"sample": {"a": 2}}) 1`] = `
+exports[`.toEqual() expect({"a": 1, "b": 2}).toEqual(<objectContaining({"a": 2})>) 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).toEqual([22m[32mexpected[39m[2m)[22m
 
 Expected value to equal:
-  [32m{\"sample\": {\"a\": 2}}[39m
+  [32m<objectContaining({\"a\": 2})>[39m
 Received:
   [31m{\"a\": 1, \"b\": 2}[39m
 
@@ -1835,14 +1845,14 @@ Difference:
 [32m- Expected[39m
 [31m+ Received[39m
 
-[32m-ObjectContaining {[39m
-[32m-  \"sample\": Object {[39m
-[32m-    \"a\": 2,[39m
-[32m-  },[39m
+[33m@@ -1,3 +1,4 @@
+[39m[32m-<objectContaining(Object {[39m
+[32m-  \"a\": 2,[39m
+[32m-})>[39m
 [31m+Object {[39m
 [31m+  \"a\": 1,[39m
 [31m+  \"b\": 2,[39m
-[2m }[22m"
+[31m+}[39m"
 `;
 
 exports[`.toEqual() expect({"a": 5}).toEqual({"b": 6}) 1`] = `
@@ -1904,11 +1914,11 @@ Difference:
   Comparing two different types of values. Expected [32mundefined[39m but received [31mnull[39m."
 `;
 
-exports[`.toEqual() expect(true).not.toEqual({}) 1`] = `
+exports[`.toEqual() expect(true).not.toEqual(<anything>) 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).not.toEqual([22m[32mexpected[39m[2m)[22m
 
 Expected value to not equal:
-  [32m{}[39m
+  [32m<anything>[39m
 Received:
   [31mtrue[39m"
 `;
@@ -1931,11 +1941,11 @@ Received:
   [31mtrue[39m"
 `;
 
-exports[`.toEqual() expect(undefined).toEqual({"expectedObject": [Function Function]}) 1`] = `
+exports[`.toEqual() expect(undefined).toEqual(<any(Function)>) 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).toEqual([22m[32mexpected[39m[2m)[22m
 
 Expected value to equal:
-  [32m{\"expectedObject\": [Function Function]}[39m
+  [32m<any(Function)>[39m
 Received:
   [31mundefined[39m
 
@@ -1944,11 +1954,11 @@ Difference:
   Comparing two different types of values. Expected [32mobject[39m but received [31mundefined[39m."
 `;
 
-exports[`.toEqual() expect(undefined).toEqual({}) 1`] = `
+exports[`.toEqual() expect(undefined).toEqual(<anything>) 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).toEqual([22m[32mexpected[39m[2m)[22m
 
 Expected value to equal:
-  [32m{}[39m
+  [32m<anything>[39m
 Received:
   [31mundefined[39m
 

--- a/packages/jest-matchers/src/__tests__/asymmetric-matchers-test.js
+++ b/packages/jest-matchers/src/__tests__/asymmetric-matchers-test.js
@@ -40,11 +40,11 @@ test('Any.asymmetricMatch()', () => {
 });
 
 test('Any.toAsymmetricMatcher()', () => {
-  jestExpect(any(Number).toAsymmetricMatcher()).toBe('<any(Number)>');
+  jestExpect(any(Number).toAsymmetricMatcher()).toBe('Any<Number>');
 });
 
 test('Any throws when called with empty constructor', () => {
-  expect(() => any()).toThrow();
+  jestExpect(() => any()).toThrow();
 });
 
 test('Anything matches any type', () => {
@@ -70,7 +70,7 @@ test('Anything does not match null and undefined', () => {
 });
 
 test('Anything.toAsymmetricMatcher()', () => {
-  jestExpect(anything().toAsymmetricMatcher()).toBe('<anything>');
+  jestExpect(anything().toAsymmetricMatcher()).toBe('Anything');
 });
 
 test('ArrayContaining matches', () => {
@@ -96,7 +96,7 @@ test('ArrayContaining throws for non-arrays', () => {
 
 test('ArrayContaining.toAsymmetricMatcher()', () => {
   jestExpect(arrayContaining(['foo', 'bar']).toAsymmetricMatcher(print))
-    .toBe('<arrayContaining(["foo", "bar"])>');
+    .toBe('ArrayContaining ["foo", "bar"]');
 });
 
 test('ObjectContaining matches', () => {
@@ -123,7 +123,7 @@ test('ObjectContaining does not match', () => {
 test('ObjectContaining matches defined properties', () => {
   const definedPropertyObject = {};
   Object.defineProperty(definedPropertyObject, 'foo', {get: () => 'bar'});
-  expect(objectContaining({foo: 'bar'}).asymmetricMatch(definedPropertyObject)).toBe(true);
+  jestExpect(objectContaining({foo: 'bar'}).asymmetricMatch(definedPropertyObject)).toBe(true);
 });
 
 test('ObjectContaining matches prototype properties', () => {
@@ -138,7 +138,7 @@ test('ObjectContaining matches prototype properties', () => {
     Foo.prototype.constructor = Foo;
     obj = new Foo();
   }
-  expect(objectContaining({foo: 'bar'}).asymmetricMatch(obj)).toBe(true);
+  jestExpect(objectContaining({foo: 'bar'}).asymmetricMatch(obj)).toBe(true);
 });
 
 test('ObjectContaining throws for non-objects', () => {
@@ -147,7 +147,7 @@ test('ObjectContaining throws for non-objects', () => {
 
 test('ObjectContaining.toAsymmetricMatcher()', () => {
   jestExpect(objectContaining({super: 'trooper'}).toAsymmetricMatcher(print))
-    .toBe('<objectContaining({"super": "trooper"})>');
+    .toBe('ObjectContaining {"super": "trooper"}');
 });
 
 test('StringMatching matches string against regexp', () => {
@@ -168,5 +168,5 @@ test('StringMatching throws for non-strings and non-regexps', () => {
 
 test('StringMatching.toAsymmetricMatcher()', () => {
   jestExpect(stringMatching(/(foo|bar)/).toAsymmetricMatcher(print))
-    .toBe('<stringMatching(/(foo|bar)/)>');
+    .toBe('StringMatching /(foo|bar)/');
 });

--- a/packages/jest-matchers/src/__tests__/asymmetric-matchers-test.js
+++ b/packages/jest-matchers/src/__tests__/asymmetric-matchers-test.js
@@ -1,0 +1,172 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails oncall+jsinfra
+ */
+ /* eslint-disable max-len */
+
+'use strict';
+
+const jestExpect = require('../');
+const {
+  any,
+  anything,
+  arrayContaining,
+  objectContaining,
+  stringMatching,
+} = require('../asymmetric-matchers');
+const prettyFormat = require('pretty-format');
+
+const print = string => prettyFormat(string, {min: true});
+
+test('Any.asymmetricMatch()', () => {
+  const Thing = function() {};
+
+  [
+    any(String).asymmetricMatch('jest'),
+    any(Number).asymmetricMatch(1),
+    any(Function).asymmetricMatch(() => {}),
+    any(Boolean).asymmetricMatch(true),
+    any(Object).asymmetricMatch({}),
+    any(Array).asymmetricMatch([]),
+    any(Thing).asymmetricMatch(new Thing()),
+  ].forEach(test => {
+    jestExpect(test).toBe(true);
+  });
+});
+
+test('Any.toAsymmetricMatcher()', () => {
+  jestExpect(any(Number).toAsymmetricMatcher()).toBe('<any(Number)>');
+});
+
+test('Any throws when called with empty constructor', () => {
+  expect(() => any()).toThrow();
+});
+
+test('Anything matches any type', () => {
+  [
+    anything().asymmetricMatch('jest'),
+    anything().asymmetricMatch(1),
+    anything().asymmetricMatch(() => {}),
+    anything().asymmetricMatch(true),
+    anything().asymmetricMatch({}),
+    anything().asymmetricMatch([]),
+  ].forEach(test => {
+    jestExpect(test).toBe(true);
+  });
+});
+
+test('Anything does not match null and undefined', () => {
+  [
+    anything().asymmetricMatch(null),
+    anything().asymmetricMatch(undefined),
+  ].forEach(test => {
+    jestExpect(test).toBe(false);
+  });
+});
+
+test('Anything.toAsymmetricMatcher()', () => {
+  jestExpect(anything().toAsymmetricMatcher()).toBe('<anything>');
+});
+
+test('ArrayContaining matches', () => {
+  [
+    arrayContaining([]).asymmetricMatch('jest'),
+    arrayContaining(['foo']).asymmetricMatch(['foo']),
+    arrayContaining(['foo']).asymmetricMatch(['foo', 'bar']),
+    arrayContaining([]).asymmetricMatch({}),
+  ].forEach(test => {
+    jestExpect(test).toEqual(true);
+  });
+});
+
+test('ArrayContaining does not match', () => {
+  jestExpect(arrayContaining(['foo']).asymmetricMatch(['bar'])).toBe(false);
+});
+
+test('ArrayContaining throws for non-arrays', () => {
+  jestExpect(() => {
+    arrayContaining('foo').asymmetricMatch([]);
+  }).toThrow();
+});
+
+test('ArrayContaining.toAsymmetricMatcher()', () => {
+  jestExpect(arrayContaining(['foo', 'bar']).toAsymmetricMatcher(print))
+    .toBe('<arrayContaining(["foo", "bar"])>');
+});
+
+test('ObjectContaining matches', () => {
+  [
+    objectContaining({}).asymmetricMatch('jest'),
+    objectContaining({foo: 'foo'}).asymmetricMatch({foo: 'foo', jest: 'jest'}),
+    objectContaining({foo: undefined}).asymmetricMatch({foo: undefined}),
+    objectContaining({first: objectContaining({second: {}})}).asymmetricMatch({first: {second: {}}}),
+  ].forEach(test => {
+    jestExpect(test).toEqual(true);
+  });
+});
+
+test('ObjectContaining does not match', () => {
+  [
+    objectContaining({foo: 'foo'}).asymmetricMatch({bar: 'bar'}),
+    objectContaining({foo: 'foo'}).asymmetricMatch({foo: 'foox'}),
+    objectContaining({foo: undefined}).asymmetricMatch({}),
+  ].forEach(test => {
+    jestExpect(test).toEqual(false);
+  });
+});
+
+test('ObjectContaining matches defined properties', () => {
+  const definedPropertyObject = {};
+  Object.defineProperty(definedPropertyObject, 'foo', {get: () => 'bar'});
+  expect(objectContaining({foo: 'bar'}).asymmetricMatch(definedPropertyObject)).toBe(true);
+});
+
+test('ObjectContaining matches prototype properties', () => {
+  const prototypeObject = {foo: 'bar'};
+  let obj;
+
+  if (Object.create) {
+    obj = Object.create(prototypeObject);
+  } else {
+    function Foo() {}
+    Foo.prototype = prototypeObject;
+    Foo.prototype.constructor = Foo;
+    obj = new Foo();
+  }
+  expect(objectContaining({foo: 'bar'}).asymmetricMatch(obj)).toBe(true);
+});
+
+test('ObjectContaining throws for non-objects', () => {
+  jestExpect(() => objectContaining(1337).asymmetricMatch()).toThrow();
+});
+
+test('ObjectContaining.toAsymmetricMatcher()', () => {
+  jestExpect(objectContaining({super: 'trooper'}).toAsymmetricMatcher(print))
+    .toBe('<objectContaining({"super": "trooper"})>');
+});
+
+test('StringMatching matches string against regexp', () => {
+  jestExpect(stringMatching(/en/).asymmetricMatch('queen')).toBe(true);
+  jestExpect(stringMatching(/en/).asymmetricMatch('queue')).toBe(false);
+});
+
+test('StringMatching matches string against string', () => {
+  jestExpect(stringMatching('en').asymmetricMatch('queen')).toBe(true);
+  jestExpect(stringMatching('en').asymmetricMatch('queue')).toBe(false);
+});
+
+test('StringMatching throws for non-strings and non-regexps', () => {
+  jestExpect(() => {
+    stringMatching([1]).asymmetricMatch('queen');
+  }).toThrow();
+});
+
+test('StringMatching.toAsymmetricMatcher()', () => {
+  jestExpect(stringMatching(/(foo|bar)/).toAsymmetricMatcher(print))
+    .toBe('<stringMatching(/(foo|bar)/)>');
+});

--- a/packages/jest-matchers/src/__tests__/asymmetric-matchers-test.js
+++ b/packages/jest-matchers/src/__tests__/asymmetric-matchers-test.js
@@ -94,11 +94,6 @@ test('ArrayContaining throws for non-arrays', () => {
   }).toThrow();
 });
 
-test('ArrayContaining.toAsymmetricMatcher()', () => {
-  jestExpect(arrayContaining(['foo', 'bar']).toAsymmetricMatcher(print))
-    .toBe('ArrayContaining ["foo", "bar"]');
-});
-
 test('ObjectContaining matches', () => {
   [
     objectContaining({}).asymmetricMatch('jest'),
@@ -145,11 +140,6 @@ test('ObjectContaining throws for non-objects', () => {
   jestExpect(() => objectContaining(1337).asymmetricMatch()).toThrow();
 });
 
-test('ObjectContaining.toAsymmetricMatcher()', () => {
-  jestExpect(objectContaining({super: 'trooper'}).toAsymmetricMatcher(print))
-    .toBe('ObjectContaining {"super": "trooper"}');
-});
-
 test('StringMatching matches string against regexp', () => {
   jestExpect(stringMatching(/en/).asymmetricMatch('queen')).toBe(true);
   jestExpect(stringMatching(/en/).asymmetricMatch('queue')).toBe(false);
@@ -164,9 +154,4 @@ test('StringMatching throws for non-strings and non-regexps', () => {
   jestExpect(() => {
     stringMatching([1]).asymmetricMatch('queen');
   }).toThrow();
-});
-
-test('StringMatching.toAsymmetricMatcher()', () => {
-  jestExpect(stringMatching(/(foo|bar)/).toAsymmetricMatcher(print))
-    .toBe('StringMatching /(foo|bar)/');
 });

--- a/packages/jest-matchers/src/asymmetric-matchers.js
+++ b/packages/jest-matchers/src/asymmetric-matchers.js
@@ -70,7 +70,7 @@ class Any extends AsymmetricMatcher {
   }
 
   toAsymmetricMatcher() {
-    return '<any(' + fnNameFor(this.sample) + ')>';
+    return 'Any<' + fnNameFor(this.sample) + '>';
   }
 }
 
@@ -84,7 +84,7 @@ class Anything extends AsymmetricMatcher {
   }
 
   toAsymmetricMatcher() {
-    return '<anything>';
+    return 'Anything';
   }
 }
 
@@ -97,10 +97,9 @@ class ArrayContaining extends AsymmetricMatcher {
   }
 
   asymmetricMatch(other: Array<any>) {
-    const className = Object.prototype.toString.call(this.sample);
-    if (className !== '[object Array]') {
+    if (!Array.isArray(this.sample)) {
       throw new Error(
-        'You must provide an array to arrayContaining, not \'' +
+        'You must provide an array to ArrayContaining, not \'' +
         typeof this.sample + '\'.'
        );
     }
@@ -120,9 +119,9 @@ class ArrayContaining extends AsymmetricMatcher {
   }
 
   toAsymmetricMatcher(print: Function) {
-    return '<arrayContaining(' + print(this.sample) + ')>';
+    return 'ArrayContaining ' + print(this.sample).replace(/Array\s+/, '');
   }
- }
+}
 
 class ObjectContaining extends AsymmetricMatcher {
   sample: Object;
@@ -135,7 +134,7 @@ class ObjectContaining extends AsymmetricMatcher {
   asymmetricMatch(other: Object) {
     if (typeof this.sample !== 'object') {
       throw new Error(
-        'You must provide an object to objectContaining, not \'' +
+        'You must provide an object to ObjectContaining, not \'' +
         typeof this.sample + '\'.'
        );
     }
@@ -157,7 +156,7 @@ class ObjectContaining extends AsymmetricMatcher {
   }
 
   toAsymmetricMatcher(print: Function) {
-    return '<objectContaining(' + print(this.sample) + ')>';
+    return 'ObjectContaining ' + print(this.sample).replace(/Object\s+/, '');
   }
 }
 
@@ -182,7 +181,7 @@ class StringMatching extends AsymmetricMatcher {
   }
 
   toAsymmetricMatcher(print: Function) {
-    return '<stringMatching(' + print(this.sample) + ')>';
+    return 'StringMatching ' + print(this.sample).replace(/Object/, '');
   }
 }
 

--- a/packages/jest-matchers/src/asymmetric-matchers.js
+++ b/packages/jest-matchers/src/asymmetric-matchers.js
@@ -10,7 +10,6 @@
 
 'use strict';
 
-const prettyFormat = require('pretty-format');
 const {
   contains,
   equals,

--- a/packages/jest-matchers/src/asymmetric-matchers.js
+++ b/packages/jest-matchers/src/asymmetric-matchers.js
@@ -1,0 +1,180 @@
+/**
+ * Copyright (c) 2014, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+
+'use strict';
+
+const prettyFormat = require('pretty-format');
+const {
+  contains,
+  equals,
+  fnNameFor,
+  hasProperty,
+  isA,
+  isUndefined,
+} = require('./jasmine-utils');
+
+class Any {
+  expectedObject: any;
+
+  constructor(expectedObject: any) {
+    if (typeof expectedObject === 'undefined') {
+      throw new TypeError(
+         'jasmine.any() expects to be passed a constructor function. ' +
+         'Please pass one or use jasmine.anything() to match any object.'
+       );
+    }
+    this.expectedObject = expectedObject;
+  }
+
+  asymmetricMatch(other: any) {
+    if (this.expectedObject == String) {
+      return typeof other == 'string' || other instanceof String;
+    }
+
+    if (this.expectedObject == Number) {
+      return typeof other == 'number' || other instanceof Number;
+    }
+
+    if (this.expectedObject == Function) {
+      return typeof other == 'function' || other instanceof Function;
+    }
+
+    if (this.expectedObject == Object) {
+      return typeof other == 'object';
+    }
+
+    if (this.expectedObject == Boolean) {
+      return typeof other == 'boolean';
+    }
+
+    return other instanceof this.expectedObject;
+  }
+
+  jasmineToString() {
+    return '<jasmine.any(' + fnNameFor(this.expectedObject) + ')>';
+  }
+}
+
+class Anything {
+  asymmetricMatch(other: any) {
+    return !isUndefined(other) && other !== null;
+  }
+
+  jasmineToString() {
+    return '<jasmine.anything>';
+  }
+}
+
+class ArrayContaining {
+  sample: Array<any>;
+
+  constructor(sample: Array<any>) {
+    this.sample = sample;
+  }
+
+  asymmetricMatch(other: Array<any>) {
+    const className = Object.prototype.toString.call(this.sample);
+    if (className !== '[object Array]') {
+      throw new Error(
+        'You must provide an array to arrayContaining, not \'' +
+        typeof this.sample + '\'.'
+       );
+    }
+
+    for (let i = 0; i < this.sample.length; i++) {
+      const item = this.sample[i];
+      if (!contains(other, item)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  toString() {
+    return 'ArrayContaining';
+  }
+
+  jasmineToString() {
+    return '<arrayContaining(' + prettyFormat(this.sample, {min: true}) + ')>';
+  }
+
+  jasmineToPrettyString(options: Object) {
+    return '<arrayContaining(' + prettyFormat(this.sample, options) + ')>';
+  }
+ }
+
+class ObjectContaining {
+  sample: Object;
+
+  constructor(sample: Object) {
+    this.sample = sample;
+  }
+
+  asymmetricMatch(other: Object) {
+    if (typeof this.sample !== 'object') {
+      throw new Error(
+        'You must provide an object to objectContaining, not \'' +
+        typeof this.sample + '\'.'
+       );
+    }
+
+    for (const property in this.sample) {
+      if (
+        !hasProperty(other, property) ||
+        !equals(this.sample[property], other[property])
+      ) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  toString() {
+    return 'ObjectContaining';
+  }
+
+  jasmineToString() {
+    return '<objectContaining(' + prettyFormat(this.sample, {min: true}) + ')>';
+  }
+
+  jasmineToPrettyString(options: Object) {
+    return '<objectContaining(' + prettyFormat(this.sample, options) + ')>';
+  }
+}
+
+class StringMatching {
+  regexp: RegExp;
+
+  constructor(expected: string | RegExp) {
+    if (!isA('String', expected) && !isA('RegExp', expected)) {
+      throw new Error('Expected is not a String or a RegExp');
+    }
+
+    this.regexp = new RegExp(expected);
+  }
+
+  asymmetricMatch(other: string) {
+    return this.regexp.test(other);
+  }
+
+  jasmineToString() {
+    return '<stringMatching(' + prettyFormat(this.regexp, {min: true}) + ')>';
+  }
+}
+
+module.exports = {
+  any: (expectedObject: any) => new Any(expectedObject),
+  anything: () => new Anything(),
+  arrayContaining: (sample: Array<any>) => new ArrayContaining(sample),
+  objectContaining: (sample: Object) => new ObjectContaining(sample),
+  stringMatching: (expected: string | RegExp) => new StringMatching(expected),
+};

--- a/packages/jest-matchers/src/asymmetric-matchers.js
+++ b/packages/jest-matchers/src/asymmetric-matchers.js
@@ -117,10 +117,6 @@ class ArrayContaining extends AsymmetricMatcher {
   toString() {
     return 'ArrayContaining';
   }
-
-  toAsymmetricMatcher(print: Function) {
-    return 'ArrayContaining ' + print(this.sample).replace(/Array\s+/, '');
-  }
 }
 
 class ObjectContaining extends AsymmetricMatcher {
@@ -154,10 +150,6 @@ class ObjectContaining extends AsymmetricMatcher {
   toString() {
     return 'ObjectContaining';
   }
-
-  toAsymmetricMatcher(print: Function) {
-    return 'ObjectContaining ' + print(this.sample).replace(/Object\s+/, '');
-  }
 }
 
 class StringMatching extends AsymmetricMatcher {
@@ -178,10 +170,6 @@ class StringMatching extends AsymmetricMatcher {
 
   toString() {
     return 'StringMatching';
-  }
-
-  toAsymmetricMatcher(print: Function) {
-    return 'StringMatching ' + print(this.sample).replace(/Object/, '');
   }
 }
 

--- a/packages/jest-matchers/src/asymmetric-matchers.js
+++ b/packages/jest-matchers/src/asymmetric-matchers.js
@@ -26,8 +26,8 @@ class Any {
   constructor(expectedObject: any) {
     if (typeof expectedObject === 'undefined') {
       throw new TypeError(
-         'jasmine.any() expects to be passed a constructor function. ' +
-         'Please pass one or use jasmine.anything() to match any object.'
+         'any() expects to be passed a constructor function. ' +
+         'Please pass one or use anything() to match any object.'
        );
     }
     this.expectedObject = expectedObject;
@@ -58,7 +58,7 @@ class Any {
   }
 
   jasmineToString() {
-    return '<jasmine.any(' + fnNameFor(this.expectedObject) + ')>';
+    return '<any(' + fnNameFor(this.expectedObject) + ')>';
   }
 }
 
@@ -68,7 +68,7 @@ class Anything {
   }
 
   jasmineToString() {
-    return '<jasmine.anything>';
+    return '<anything>';
   }
 }
 

--- a/packages/jest-matchers/src/asymmetric-matchers.js
+++ b/packages/jest-matchers/src/asymmetric-matchers.js
@@ -20,62 +20,80 @@ const {
   isUndefined,
 } = require('./jasmine-utils');
 
-class Any {
-  expectedObject: any;
+class AsymmetricMatcher {
+  $$typeof: Symbol;
 
-  constructor(expectedObject: any) {
-    if (typeof expectedObject === 'undefined') {
+  constructor() {
+    this.$$typeof = Symbol.for('jest.asymmetricMatcher');
+  }
+}
+
+class Any extends AsymmetricMatcher {
+  sample: any;
+
+  constructor(sample: any) {
+    super();
+    if (typeof sample === 'undefined') {
       throw new TypeError(
          'any() expects to be passed a constructor function. ' +
          'Please pass one or use anything() to match any object.'
        );
     }
-    this.expectedObject = expectedObject;
+    this.sample = sample;
   }
 
   asymmetricMatch(other: any) {
-    if (this.expectedObject == String) {
+    if (this.sample == String) {
       return typeof other == 'string' || other instanceof String;
     }
 
-    if (this.expectedObject == Number) {
+    if (this.sample == Number) {
       return typeof other == 'number' || other instanceof Number;
     }
 
-    if (this.expectedObject == Function) {
+    if (this.sample == Function) {
       return typeof other == 'function' || other instanceof Function;
     }
 
-    if (this.expectedObject == Object) {
+    if (this.sample == Object) {
       return typeof other == 'object';
     }
 
-    if (this.expectedObject == Boolean) {
+    if (this.sample == Boolean) {
       return typeof other == 'boolean';
     }
 
-    return other instanceof this.expectedObject;
+    return other instanceof this.sample;
   }
 
-  jasmineToString() {
-    return '<any(' + fnNameFor(this.expectedObject) + ')>';
+  toString() {
+    return 'Any';
+  }
+
+  toAsymmetricMatcher() {
+    return '<any(' + fnNameFor(this.sample) + ')>';
   }
 }
 
-class Anything {
+class Anything extends AsymmetricMatcher {
   asymmetricMatch(other: any) {
     return !isUndefined(other) && other !== null;
   }
 
-  jasmineToString() {
+  toString() {
+    return 'Anything';
+  }
+
+  toAsymmetricMatcher() {
     return '<anything>';
   }
 }
 
-class ArrayContaining {
+class ArrayContaining extends AsymmetricMatcher {
   sample: Array<any>;
 
   constructor(sample: Array<any>) {
+    super();
     this.sample = sample;
   }
 
@@ -102,19 +120,16 @@ class ArrayContaining {
     return 'ArrayContaining';
   }
 
-  jasmineToString() {
-    return '<arrayContaining(' + prettyFormat(this.sample, {min: true}) + ')>';
-  }
-
-  jasmineToPrettyString(options: Object) {
-    return '<arrayContaining(' + prettyFormat(this.sample, options) + ')>';
+  toAsymmetricMatcher(print: Function) {
+    return '<arrayContaining(' + print(this.sample) + ')>';
   }
  }
 
-class ObjectContaining {
+class ObjectContaining extends AsymmetricMatcher {
   sample: Object;
 
   constructor(sample: Object) {
+    super();
     this.sample = sample;
   }
 
@@ -142,32 +157,33 @@ class ObjectContaining {
     return 'ObjectContaining';
   }
 
-  jasmineToString() {
-    return '<objectContaining(' + prettyFormat(this.sample, {min: true}) + ')>';
-  }
-
-  jasmineToPrettyString(options: Object) {
-    return '<objectContaining(' + prettyFormat(this.sample, options) + ')>';
+  toAsymmetricMatcher(print: Function) {
+    return '<objectContaining(' + print(this.sample) + ')>';
   }
 }
 
-class StringMatching {
-  regexp: RegExp;
+class StringMatching extends AsymmetricMatcher {
+  sample: RegExp;
 
-  constructor(expected: string | RegExp) {
-    if (!isA('String', expected) && !isA('RegExp', expected)) {
+  constructor(sample: string | RegExp) {
+    super();
+    if (!isA('String', sample) && !isA('RegExp', sample)) {
       throw new Error('Expected is not a String or a RegExp');
     }
 
-    this.regexp = new RegExp(expected);
+    this.sample = new RegExp(sample);
   }
 
   asymmetricMatch(other: string) {
-    return this.regexp.test(other);
+    return this.sample.test(other);
   }
 
-  jasmineToString() {
-    return '<stringMatching(' + prettyFormat(this.regexp, {min: true}) + ')>';
+  toString() {
+    return 'StringMatching';
+  }
+
+  toAsymmetricMatcher(print: Function) {
+    return '<stringMatching(' + print(this.sample) + ')>';
   }
 }
 

--- a/packages/jest-matchers/src/index.js
+++ b/packages/jest-matchers/src/index.js
@@ -32,7 +32,7 @@ const {
   arrayContaining,
   objectContaining,
   stringMatching,
-} = require('./jasmine-utils');
+} = require('./asymmetric-matchers');
 
 const GLOBAL_STATE = Symbol.for('$$jest-matchers-object');
 

--- a/packages/jest-matchers/src/jasmine-utils.js
+++ b/packages/jest-matchers/src/jasmine-utils.js
@@ -25,8 +25,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
 
-const prettyFormat = require('pretty-format');
-
 // Extracted out of jasmine 2.5.2
 function equals(a, b, customTesters) {
   customTesters = customTesters || [];
@@ -247,22 +245,6 @@ function has(obj, key) {
   return Object.prototype.hasOwnProperty.call(obj, key) && obj[key] !== undefined;
 }
 
-function isFunction(obj) {
-  return typeof obj === 'function';
-}
-
-function isObjectConstructor(ctor) {
-  // aCtor instanceof aCtor is true for the Object and Function
-  // constructors (since a constructor is-a Function and a function is-a
-  // Object). We don't just compare ctor === Object because the constructor
-  // might come from a different frame with different globals.
-  return isFunction(ctor) && ctor instanceof ctor;
-}
-
-function isUndefined(obj) {
-  return obj === void 0;
-}
-
 function isA(typeName, value) {
   return Object.prototype.toString.apply(value) === '[object ' + typeName + ']';
 }
@@ -276,109 +258,12 @@ function fnNameFor(func) {
     return func.name;
   }
 
-  var matches = func.toString().match(/^\s*function\s*(\w*)\s*\(/);
+  const matches = func.toString().match(/^\s*function\s*(\w*)\s*\(/);
   return matches ? matches[1] : '<anonymous>';
 }
 
-
-function Any(expectedObject) {
-  if (typeof expectedObject === 'undefined') {
-    throw new TypeError(
-      'jasmine.any() expects to be passed a constructor function. ' +
-      'Please pass one or use jasmine.anything() to match any object.'
-    );
-  }
-  this.expectedObject = expectedObject;
-}
-
-function any(expectedObject) {
-  return new Any(expectedObject);
-}
-
-Any.prototype.asymmetricMatch = function(other) {
-  if (this.expectedObject == String) {
-    return typeof other == 'string' || other instanceof String;
-  }
-
-  if (this.expectedObject == Number) {
-    return typeof other == 'number' || other instanceof Number;
-  }
-
-  if (this.expectedObject == Function) {
-    return typeof other == 'function' || other instanceof Function;
-  }
-
-  if (this.expectedObject == Object) {
-    return typeof other == 'object';
-  }
-
-  if (this.expectedObject == Boolean) {
-    return typeof other == 'boolean';
-  }
-
-  return other instanceof this.expectedObject;
-};
-
-Any.prototype.jasmineToString = function() {
-  return '<jasmine.any(' + fnNameFor(this.expectedObject) + ')>';
-};
-
-
-function Anything() {}
-
-function anything() {
-  return new Anything();
-}
-
-Anything.prototype.asymmetricMatch = function(other) {
-  return !isUndefined(other) && other !== null;
-};
-
-Anything.prototype.jasmineToString = function() {
-  return '<jasmine.anything>';
-};
-
-
-function ArrayContaining(sample) {
-  this.sample = sample;
-}
-
-function arrayContaining(sample) {
-  return new ArrayContaining(sample);
-}
-
-ArrayContaining.prototype.asymmetricMatch = function(other) {
-  var className = Object.prototype.toString.call(this.sample);
-  if (className !== '[object Array]') { throw new Error('You must provide an array to arrayContaining, not \'' + this.sample + '\'.'); }
-
-  for (var i = 0; i < this.sample.length; i++) {
-    var item = this.sample[i];
-    if (!contains(other, item)) {
-      return false;
-    }
-  }
-
-  return true;
-};
-
-ArrayContaining.prototype.toString = function () {
-  return 'ArrayContaining';
-};
-
-ArrayContaining.prototype.jasmineToString = function () {
-  return '<jasmine.arrayContaining(' + prettyFormat(this.sample, {min: true}) +')>';
-};
-
-ArrayContaining.prototype.jasmineToPrettyString = function (options) {
-  return '<jasmine.arrayContaining(' + prettyFormat(this.sample, options) +')>';
-};
-
-function ObjectContaining(sample) {
-  this.sample = sample;
-}
-
-function objectContaining(sample) {
-  return new ObjectContaining(sample);
+function isUndefined(obj) {
+  return obj === void 0;
 }
 
 function getPrototype(obj) {
@@ -405,56 +290,11 @@ function hasProperty(obj, property) {
   return hasProperty(getPrototype(obj), property);
 }
 
-ObjectContaining.prototype.asymmetricMatch = function(other) {
-  if (typeof(this.sample) !== 'object') { throw new Error('You must provide an object to objectContaining, not \''+this.sample+'\'.'); }
-
-  for (var property in this.sample) {
-    if (!hasProperty(other, property) ||
-        !equals(this.sample[property], other[property])) {
-      return false;
-    }
-  }
-
-  return true;
-};
-
-ObjectContaining.prototype.toString = function() {
-  return 'ObjectContaining';
-};
-
-ObjectContaining.prototype.jasmineToString = function() {
-  return '<jasmine.objectContaining(' + prettyFormat(this.sample, {min: true}) + ')>';
-};
-
-ObjectContaining.prototype.jasmineToPrettyString = function(options) {
-  return '<jasmine.objectContaining(' + prettyFormat(this.sample, options) + ')>';
-};
-
-function StringMatching(expected) {
-  if (!isA('String', expected) && !isA('RegExp', expected)) {
-    throw new Error('Expected is not a String or a RegExp');
-  }
-
-  this.regexp = new RegExp(expected);
-}
-
-function stringMatching(expected) {
-  return new StringMatching(expected);
-}
-
-StringMatching.prototype.asymmetricMatch = function(other) {
-  return this.regexp.test(other);
-};
-
-StringMatching.prototype.jasmineToString = function() {
-  return '<jasmine.stringMatching(' + prettyFormat(this.regexp, {min: true}) + ')>';
-};
-
 module.exports = {
-  any,
-  anything,
-  arrayContaining,
+  contains,
   equals,
-  objectContaining,
-  stringMatching,
+  fnNameFor,
+  hasProperty,
+  isA,
+  isUndefined,
 };

--- a/packages/jest-matchers/src/jasmine-utils.js
+++ b/packages/jest-matchers/src/jasmine-utils.js
@@ -361,10 +361,17 @@ ArrayContaining.prototype.asymmetricMatch = function(other) {
   return true;
 };
 
-ArrayContaining.prototype.jasmineToString = function () {
-  return '<jasmine.arrayContaining(' + prettyFormat(this.sample) +')>';
+ArrayContaining.prototype.toString = function () {
+  return 'ArrayContaining';
 };
 
+ArrayContaining.prototype.jasmineToString = function () {
+  return '<jasmine.arrayContaining(' + prettyFormat(this.sample, {min: true}) +')>';
+};
+
+ArrayContaining.prototype.jasmineToPrettyString = function (options) {
+  return '<jasmine.arrayContaining(' + prettyFormat(this.sample, options) +')>';
+};
 
 function ObjectContaining(sample) {
   this.sample = sample;
@@ -411,10 +418,17 @@ ObjectContaining.prototype.asymmetricMatch = function(other) {
   return true;
 };
 
-ObjectContaining.prototype.jasmineToString = function() {
-  return '<jasmine.objectContaining(' + prettyFormat(this.sample) + ')>';
+ObjectContaining.prototype.toString = function() {
+  return 'ObjectContaining';
 };
 
+ObjectContaining.prototype.jasmineToString = function() {
+  return '<jasmine.objectContaining(' + prettyFormat(this.sample, {min: true}) + ')>';
+};
+
+ObjectContaining.prototype.jasmineToPrettyString = function(options) {
+  return '<jasmine.objectContaining(' + prettyFormat(this.sample, options) + ')>';
+};
 
 function StringMatching(expected) {
   if (!isA('String', expected) && !isA('RegExp', expected)) {
@@ -433,7 +447,7 @@ StringMatching.prototype.asymmetricMatch = function(other) {
 };
 
 StringMatching.prototype.jasmineToString = function() {
-  return '<jasmine.stringMatching(' + this.regexp + ')>';
+  return '<jasmine.stringMatching(' + prettyFormat(this.regexp, {min: true}) + ')>';
 };
 
 module.exports = {

--- a/packages/jest-matchers/src/matchers.js
+++ b/packages/jest-matchers/src/matchers.js
@@ -118,12 +118,12 @@ const matchers: MatchersObject = {
       ? () => matcherHint('.not.toBeCloseTo', 'received', 'expected, precision') + '\n\n' +
         `Expected value not to be close to (with ${printExpected(precision)}-digit precision):\n` +
         `  ${printExpected(expected)}\n` +
-        `Received: \n` +
+        `Received:\n` +
         `  ${printReceived(actual)}`
       : () => matcherHint('.toBeCloseTo', 'received', 'expected, precision') + '\n\n' +
         `Expected value to be close to (with ${printExpected(precision)}-digit precision):\n` +
         `  ${printExpected(expected)}\n` +
-        `Received: \n` +
+        `Received:\n` +
         `  ${printReceived(actual)}`;
 
     return {message, pass};

--- a/packages/pretty-format/src/__tests__/AsymmetricMatcher-test.js
+++ b/packages/pretty-format/src/__tests__/AsymmetricMatcher-test.js
@@ -1,0 +1,138 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+/* eslint-disable max-len */
+
+'use strict';
+
+const prettyFormat = require('../');
+const AsymmetricMatcher = require('../plugins/AsymmetricMatcher');
+const jestExpect = require('jest-matchers');
+let options;
+
+function fnNameFor(func) {
+  if (func.name) {
+    return func.name;
+  }
+
+  const matches = func.toString().match(/^\s*function\s*(\w*)\s*\(/);
+  return matches ? matches[1] : '<anonymous>';
+}
+
+beforeEach(() => {
+  options = {plugins: [AsymmetricMatcher]};
+});
+
+[
+  String,
+  Function,
+  Array,
+  Object,
+  RegExp,
+  Symbol,
+  Function,
+  () => {},
+  function namedFuntction() {},
+].forEach(type => {
+  test(`supports any(${fnNameFor(type)})`, () => {
+    const result = prettyFormat(jestExpect.any(type), options);
+    expect(result).toEqual(`<any(${fnNameFor(type)})>`);
+  });
+
+  test(`supports nested any(${fnNameFor(type)})`, () => {
+    const result = prettyFormat({
+      test: {
+        nested: jestExpect.any(type),
+      },
+    }, options);
+    expect(result).toEqual(`Object {\n  "test": Object {\n    "nested": <any(${fnNameFor(type)})>,\n  },\n}`);
+  });
+});
+
+test(`anything()`, () => {
+  const result = prettyFormat(jestExpect.anything(), options);
+  expect(result).toEqual('<anything>');
+});
+
+test(`arrayContaining()`, () => {
+  const result = prettyFormat(jestExpect.arrayContaining([1, 2]), options);
+  expect(result).toEqual(
+`<arrayContaining(Array [
+  1,
+  2,
+])>`
+  );
+});
+
+test(`objectContaining()`, () => {
+  const result = prettyFormat(jestExpect.objectContaining({a: 'test'}), options);
+  expect(result).toEqual(
+`<objectContaining(Object {
+  "a": "test",
+})>`
+  );
+});
+
+test(`stringMatching(string)`, () => {
+  const result = prettyFormat(jestExpect.stringMatching('jest'), options);
+  expect(result).toEqual('<stringMatching(/jest/)>');
+});
+
+test(`stringMatching(regexp)`, () => {
+  const result = prettyFormat(jestExpect.stringMatching(/(jest|niema).*/), options);
+  expect(result).toEqual('<stringMatching(/(jest|niema).*/)>');
+});
+
+test(`supports multiple nested asymmetric matchers`, () => {
+  const result = prettyFormat({
+    test: {
+      nested: jestExpect.objectContaining({
+        a: jestExpect.arrayContaining([1]),
+        b: jestExpect.anything(),
+        c: jestExpect.any(String),
+        d: jestExpect.stringMatching('jest'),
+        e: jestExpect.objectContaining({test: 'case'}),
+      }),
+    },
+  }, options);
+  expect(result).toEqual(
+`Object {
+  "test": Object {
+    "nested": <objectContaining(Object {
+      "a": <arrayContaining(Array [
+        1,
+      ])>,
+      "b": <anything>,
+      "c": <any(String)>,
+      "d": <stringMatching(/jest/)>,
+      "e": <objectContaining(Object {
+        "test": "case",
+      })>,
+    })>,
+  },
+}`
+  );
+});
+
+test(`supports minified output`, () => {
+  options.min = true;
+  const result = prettyFormat({
+    test: {
+      nested: jestExpect.objectContaining({
+        a: jestExpect.arrayContaining([1]),
+        b: jestExpect.anything(),
+        c: jestExpect.any(String),
+        d: jestExpect.stringMatching('jest'),
+        e: jestExpect.objectContaining({test: 'case'}),
+      }),
+    },
+  }, options);
+  expect(result).toEqual(
+`{"test": {"nested": <objectContaining({"a": <arrayContaining([1])>, "b": <anything>, "c": <any(String)>, "d": <stringMatching(/jest/)>, "e": <objectContaining({"test": "case"})>})>}}`
+  );
+});

--- a/packages/pretty-format/src/__tests__/AsymmetricMatcher-test.js
+++ b/packages/pretty-format/src/__tests__/AsymmetricMatcher-test.js
@@ -12,7 +12,6 @@
 
 const prettyFormat = require('../');
 const AsymmetricMatcher = require('../plugins/AsymmetricMatcher');
-const jestExpect = require('jest-matchers');
 let options;
 
 function fnNameFor(func) {
@@ -40,80 +39,80 @@ beforeEach(() => {
   function namedFuntction() {},
 ].forEach(type => {
   test(`supports any(${fnNameFor(type)})`, () => {
-    const result = prettyFormat(jestExpect.any(type), options);
-    expect(result).toEqual(`<any(${fnNameFor(type)})>`);
+    const result = prettyFormat(expect.any(type), options);
+    expect(result).toEqual(`Any<${fnNameFor(type)}>`);
   });
 
   test(`supports nested any(${fnNameFor(type)})`, () => {
     const result = prettyFormat({
       test: {
-        nested: jestExpect.any(type),
+        nested: expect.any(type),
       },
     }, options);
-    expect(result).toEqual(`Object {\n  "test": Object {\n    "nested": <any(${fnNameFor(type)})>,\n  },\n}`);
+    expect(result).toEqual(`Object {\n  "test": Object {\n    "nested": Any<${fnNameFor(type)}>,\n  },\n}`);
   });
 });
 
 test(`anything()`, () => {
-  const result = prettyFormat(jestExpect.anything(), options);
-  expect(result).toEqual('<anything>');
+  const result = prettyFormat(expect.anything(), options);
+  expect(result).toEqual('Anything');
 });
 
 test(`arrayContaining()`, () => {
-  const result = prettyFormat(jestExpect.arrayContaining([1, 2]), options);
+  const result = prettyFormat(expect.arrayContaining([1, 2]), options);
   expect(result).toEqual(
-`<arrayContaining(Array [
+`ArrayContaining [
   1,
   2,
-])>`
+]`
   );
 });
 
 test(`objectContaining()`, () => {
-  const result = prettyFormat(jestExpect.objectContaining({a: 'test'}), options);
+  const result = prettyFormat(expect.objectContaining({a: 'test'}), options);
   expect(result).toEqual(
-`<objectContaining(Object {
+`ObjectContaining {
   "a": "test",
-})>`
+}`
   );
 });
 
 test(`stringMatching(string)`, () => {
-  const result = prettyFormat(jestExpect.stringMatching('jest'), options);
-  expect(result).toEqual('<stringMatching(/jest/)>');
+  const result = prettyFormat(expect.stringMatching('jest'), options);
+  expect(result).toEqual('StringMatching /jest/');
 });
 
 test(`stringMatching(regexp)`, () => {
-  const result = prettyFormat(jestExpect.stringMatching(/(jest|niema).*/), options);
-  expect(result).toEqual('<stringMatching(/(jest|niema).*/)>');
+  const result = prettyFormat(expect.stringMatching(/(jest|niema).*/), options);
+  expect(result).toEqual('StringMatching /(jest|niema).*/');
 });
 
 test(`supports multiple nested asymmetric matchers`, () => {
   const result = prettyFormat({
     test: {
-      nested: jestExpect.objectContaining({
-        a: jestExpect.arrayContaining([1]),
-        b: jestExpect.anything(),
-        c: jestExpect.any(String),
-        d: jestExpect.stringMatching('jest'),
-        e: jestExpect.objectContaining({test: 'case'}),
+      nested: expect.objectContaining({
+        a: expect.arrayContaining([1]),
+        b: expect.anything(),
+        c: expect.any(String),
+        d: expect.stringMatching('jest'),
+        e: expect.objectContaining({test: 'case'}),
       }),
     },
   }, options);
   expect(result).toEqual(
 `Object {
   "test": Object {
-    "nested": <objectContaining(Object {
-      "a": <arrayContaining(Array [
+    "nested": ObjectContaining {
+      "a": ArrayContaining [
         1,
-      ])>,
-      "b": <anything>,
-      "c": <any(String)>,
-      "d": <stringMatching(/jest/)>,
-      "e": <objectContaining(Object {
+      ],
+      "b": Anything,
+      "c": Any<String>,
+      "d": StringMatching /jest/,
+      "e": ObjectContaining {
         "test": "case",
-      })>,
-    })>,
+      },
+    },
   },
 }`
   );
@@ -123,16 +122,16 @@ test(`supports minified output`, () => {
   options.min = true;
   const result = prettyFormat({
     test: {
-      nested: jestExpect.objectContaining({
-        a: jestExpect.arrayContaining([1]),
-        b: jestExpect.anything(),
-        c: jestExpect.any(String),
-        d: jestExpect.stringMatching('jest'),
-        e: jestExpect.objectContaining({test: 'case'}),
+      nested: expect.objectContaining({
+        a: expect.arrayContaining([1]),
+        b: expect.anything(),
+        c: expect.any(String),
+        d: expect.stringMatching('jest'),
+        e: expect.objectContaining({test: 'case'}),
       }),
     },
   }, options);
   expect(result).toEqual(
-`{"test": {"nested": <objectContaining({"a": <arrayContaining([1])>, "b": <anything>, "c": <any(String)>, "d": <stringMatching(/jest/)>, "e": <objectContaining({"test": "case"})>})>}}`
+`{"test": {"nested": ObjectContaining {"a": ArrayContaining [1], "b": Anything, "c": Any<String>, "d": StringMatching /jest/, "e": ObjectContaining {"test": "case"}}}}`
   );
 });

--- a/packages/pretty-format/src/plugins/AsymmetricMatcher.js
+++ b/packages/pretty-format/src/plugins/AsymmetricMatcher.js
@@ -10,14 +10,42 @@
 'use strict';
 
 const asymmetricMatcher = Symbol.for('jest.asymmetricMatcher');
+const SPACE = ' ';
+
+class ArrayContaining extends Array {}
+class ObjectContaining extends Object {}
+
+const printAsymmetricMatcher = (
+  val: any,
+  print: Function,
+  indent: Function,
+  opts: Object,
+  colors: Object
+) => {
+  const stringedValue = val.toString();
+
+  if (stringedValue === 'ArrayContaining') {
+    const array = ArrayContaining.from(val.sample);
+    return opts.spacing === SPACE
+      ? stringedValue + SPACE + print(array)
+      : print(array);
+  }
+
+  if (stringedValue === 'ObjectContaining') {
+    const object = Object.assign(new ObjectContaining(), val.sample);
+    return opts.spacing === SPACE
+      ? stringedValue + SPACE + print(object)
+      : print(object);
+  }
+
+  if (stringedValue === 'StringMatching') {
+    return stringedValue + SPACE + print(val.sample);
+  }
+
+  return val.toAsymmetricMatcher();
+};
 
 module.exports = {
-  print: (
-    val: any,
-    print: Function,
-    indent: Function,
-    opts: Object,
-    colors: Object
-  ) => val.toAsymmetricMatcher(print),
+  print: printAsymmetricMatcher,
   test: (object: any) => object && object.$$typeof === asymmetricMatcher,
 };

--- a/packages/pretty-format/src/plugins/AsymmetricMatcher.js
+++ b/packages/pretty-format/src/plugins/AsymmetricMatcher.js
@@ -19,5 +19,5 @@ module.exports = {
     opts: Object,
     colors: Object
   ) => val.toAsymmetricMatcher(print),
-  test: (object: any) => object.$$typeof === asymmetricMatcher,
+  test: (object: any) => object && object.$$typeof === asymmetricMatcher,
 };

--- a/packages/pretty-format/src/plugins/AsymmetricMatcher.js
+++ b/packages/pretty-format/src/plugins/AsymmetricMatcher.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ * @flow
+ */
+
+'use strict';
+
+const asymmetricMatcher = Symbol.for('jest.asymmetricMatcher');
+
+module.exports = {
+  print: (
+    val: any,
+    print: Function,
+    indent: Function,
+    opts: Object,
+    colors: Object
+  ) => val.toAsymmetricMatcher(print),
+  test: (object: any) => object.$$typeof === asymmetricMatcher,
+};


### PR DESCRIPTION
**Summary**

- [x] Provide a basic proof of concept
- [x] Extract asymmetric-matchers: `any`, `anything`, `arrayContaining`, `objectContaining`, `stringMatching` from `jasmine-utils` into separate module
- [x] Rename `<jasmine.asymmetricMatcherName>` to just `<asymmetricMatcherName>`
- [x] Refactor `asymmetric-matchers`
- [x] Improve Flow coverage
- [x] Create `AsymmetricMatchers` plugin for `pretty-format`
- [x] Use the plugin instead of basic proof of concept
- [x] Tests

Fixes https://github.com/facebook/jest/issues/2397
