### PR TITLE
[Breaking change] Properly escape snapshots

### DIFF
--- a/integration_tests/__tests__/__snapshots__/failures-test.js.snap
+++ b/integration_tests/__tests__/__snapshots__/failures-test.js.snap
@@ -3,14 +3,14 @@ Object {
   "rest": " FAIL  __tests__/throw-number-test.js
   ● Test suite failed to run
 
-    Expected an Error, but \"1\" was thrown
+    Expected an Error, but \\"1\\" was thrown
 
 ",
   "summary": "Test Suites: 1 failed, 1 total
 Tests:       0 total
 Snapshots:   0 total
 Time:        <<REPLACED>>
-Ran all test suites matching \"throw-number-test.js\".
+Ran all test suites matching \\"throw-number-test.js\\".
 ",
 }
 `;
@@ -28,7 +28,7 @@ Object {
 Tests:       0 total
 Snapshots:   0 total
 Time:        <<REPLACED>>
-Ran all test suites matching \"throw-string-test.js\".
+Ran all test suites matching \\"throw-string-test.js\\".
 ",
 }
 `;
@@ -45,7 +45,7 @@ Object {
 Tests:       0 total
 Snapshots:   0 total
 Time:        <<REPLACED>>
-Ran all test suites matching \"throw-object-test.js\".
+Ran all test suites matching \\"throw-object-test.js\\".
 ",
 }
 `;
@@ -97,7 +97,7 @@ Object {
 Tests:       3 failed, 3 total
 Snapshots:   0 total
 Time:        <<REPLACED>>
-Ran all test suites matching \"assertion-count-test.js\".
+Ran all test suites matching \\"assertion-count-test.js\\".
 ",
 }
 `;

--- a/integration_tests/__tests__/__snapshots__/snapshot-serializers-test.js.snap
+++ b/integration_tests/__tests__/__snapshots__/snapshot-serializers-test.js.snap
@@ -2,7 +2,7 @@ exports[`Snapshot serializers renders snapshot 1`] = `
 Object {
   "snapshot serializers works with default serializers 1": "
 <div
-  id="foo" />
+  id=\\"foo\\" />
 ",
   "snapshot serializers works with first plugin 1": "foo: 1",
   "snapshot serializers works with nested serializable objects 1": "foo: bar: 2",
@@ -10,7 +10,7 @@ Object {
 <div
   aProp={
     Object {
-      "a": 6,
+      \\"a\\": 6,
     }
   }
   bProp={foo: 8} />

--- a/integration_tests/__tests__/__snapshots__/snapshot-test.js.snap
+++ b/integration_tests/__tests__/__snapshots__/snapshot-test.js.snap
@@ -66,7 +66,7 @@ exports[`Snapshot works with escaped characters 1`] = `
 Tests:       1 passed, 1 total
 Snapshots:   1 added, 1 total
 Time:        <<REPLACED>>
-Ran all test suites matching \"snapshot-test.js\".
+Ran all test suites matching \\"snapshot-test.js\\".
 "
 `;
 
@@ -75,7 +75,7 @@ exports[`Snapshot works with escaped characters 2`] = `
 Tests:       2 passed, 2 total
 Snapshots:   1 added, 1 passed, 2 total
 Time:        <<REPLACED>>
-Ran all test suites matching \"snapshot-test.js\".
+Ran all test suites matching \\"snapshot-test.js\\".
 "
 `;
 
@@ -84,7 +84,7 @@ exports[`Snapshot works with escaped characters 3`] = `
 Tests:       2 passed, 2 total
 Snapshots:   2 passed, 2 total
 Time:        <<REPLACED>>
-Ran all test suites matching \"snapshot-test.js\".
+Ran all test suites matching \\"snapshot-test.js\\".
 "
 `;
 
@@ -93,7 +93,7 @@ exports[`Snapshot works with escaped regex 1`] = `
 Tests:       2 passed, 2 total
 Snapshots:   2 added, 2 total
 Time:        <<REPLACED>>
-Ran all test suites matching \"snapshot-escape-regex.js\".
+Ran all test suites matching \\"snapshot-escape-regex.js\\".
 "
 `;
 
@@ -102,7 +102,7 @@ exports[`Snapshot works with escaped regex 2`] = `
 Tests:       2 passed, 2 total
 Snapshots:   2 passed, 2 total
 Time:        <<REPLACED>>
-Ran all test suites matching \"snapshot-escape-regex.js\".
+Ran all test suites matching \\"snapshot-escape-regex.js\\".
 "
 `;
 
@@ -111,7 +111,7 @@ exports[`Snapshot works with template literal subsitutions 1`] = `
 Tests:       1 passed, 1 total
 Snapshots:   1 added, 1 total
 Time:        <<REPLACED>>
-Ran all test suites matching \"snapshot-escape-substitution-test.js\".
+Ran all test suites matching \\"snapshot-escape-substitution-test.js\\".
 "
 `;
 
@@ -120,6 +120,6 @@ exports[`Snapshot works with template literal subsitutions 2`] = `
 Tests:       1 passed, 1 total
 Snapshots:   1 passed, 1 total
 Time:        <<REPLACED>>
-Ran all test suites matching \"snapshot-escape-substitution-test.js\".
+Ran all test suites matching \\"snapshot-escape-substitution-test.js\\".
 "
 `;

--- a/integration_tests/__tests__/__snapshots__/stack_trace-test.js.snap
+++ b/integration_tests/__tests__/__snapshots__/stack_trace-test.js.snap
@@ -3,7 +3,7 @@ exports[`Stack Trace does not print a stack trace for errors when --noStackTrace
 Tests:       3 failed, 3 total
 Snapshots:   0 total
 Time:        <<REPLACED>>
-Ran all test suites matching \"test-error-test.js\".
+Ran all test suites matching \\"test-error-test.js\\".
 "
 `;
 
@@ -12,7 +12,7 @@ exports[`Stack Trace does not print a stack trace for matching errors when --noS
 Tests:       1 failed, 1 total
 Snapshots:   0 total
 Time:        <<REPLACED>>
-Ran all test suites matching \"stack-trace-test.js\".
+Ran all test suites matching \\"stack-trace-test.js\\".
 "
 `;
 
@@ -21,7 +21,7 @@ exports[`Stack Trace does not print a stack trace for runtime errors when --noSt
 Tests:       0 total
 Snapshots:   0 total
 Time:        <<REPLACED>>
-Ran all test suites matching \"runtime-error-test.js\".
+Ran all test suites matching \\"runtime-error-test.js\\".
 "
 `;
 
@@ -30,7 +30,7 @@ exports[`Stack Trace prints a stack trace for errors 1`] = `
 Tests:       3 failed, 3 total
 Snapshots:   0 total
 Time:        <<REPLACED>>
-Ran all test suites matching \"test-error-test.js\".
+Ran all test suites matching \\"test-error-test.js\\".
 "
 `;
 
@@ -39,7 +39,7 @@ exports[`Stack Trace prints a stack trace for matching errors 1`] = `
 Tests:       1 failed, 1 total
 Snapshots:   0 total
 Time:        <<REPLACED>>
-Ran all test suites matching \"stack-trace-test.js\".
+Ran all test suites matching \\"stack-trace-test.js\\".
 "
 `;
 
@@ -48,6 +48,6 @@ exports[`Stack Trace prints a stack trace for runtime errors 1`] = `
 Tests:       0 total
 Snapshots:   0 total
 Time:        <<REPLACED>>
-Ran all test suites matching \"runtime-error-test.js\".
+Ran all test suites matching \\"runtime-error-test.js\\".
 "
 `;

--- a/integration_tests/__tests__/__snapshots__/testNamePattern-test.js.snap
+++ b/integration_tests/__tests__/__snapshots__/testNamePattern-test.js.snap
@@ -3,6 +3,6 @@ exports[`test testNamePattern 1`] = `
 Tests:       2 skipped, 2 passed, 4 total
 Snapshots:   0 total
 Time:        <<REPLACED>>
-Ran all test suites with tests matching \"should match\".
+Ran all test suites with tests matching \\"should match\\".
 "
 `;

--- a/packages/jest-config/src/__tests__/__snapshots__/normalize-test.js.snap
+++ b/packages/jest-config/src/__tests__/__snapshots__/normalize-test.js.snap
@@ -1,11 +1,11 @@
 exports[`Upgrade help logs a warning when \`scriptPreprocessor\` and/or \`preprocessorIgnorePatterns\` are used 1`] = `
 "[33m[1m[1m●[1m Deprecation Warning[22m:
 
-  Option [1m\"preprocessorIgnorePatterns\"[22m was replaced by [1m\"transformIgnorePatterns\"[22m, which support multiple preprocessors.
+  Option [1m\\"preprocessorIgnorePatterns\\"[22m was replaced by [1m\\"transformIgnorePatterns\\"[22m, which support multiple preprocessors.
 
   Jest now treats your current configuration as:
   {
-    [1m\"transformIgnorePatterns\"[22m: [1m[\"bar/baz\", \"qux/quux\"][22m
+    [1m\\"transformIgnorePatterns\\"[22m: [1m[\\"bar/baz\\", \\"qux/quux\\"][22m
   }
 
   Please update your configuration.

--- a/packages/jest-diff/src/__tests__/__snapshots__/diff-test.js.snap
+++ b/packages/jest-diff/src/__tests__/__snapshots__/diff-test.js.snap
@@ -23,9 +23,9 @@ Printing internal object structure without calling \`toJSON\` instead.[22m
 [31m+ Received[39m
 
 [2m [22m [2mObject {[22m
-[32m-[39m [32m  \"line\": 1,[39m
-[31m+[39m [31m  \"line\": 2,[39m
-[2m [22m [2m  \"toJSON\": [Function toJSON],[22m
+[32m-[39m [32m  \\"line\\": 1,[39m
+[31m+[39m [31m  \\"line\\": 2,[39m
+[2m [22m [2m  \\"toJSON\\": [Function toJSON],[22m
 [2m [22m [2m}[22m"
 `;
 

--- a/packages/jest-matcher-utils/src/__tests__/__snapshots__/index-test.js.snap
+++ b/packages/jest-matcher-utils/src/__tests__/__snapshots__/index-test.js.snap
@@ -1,14 +1,14 @@
-exports[`.stringify() reduces maxDepth if stringifying very large objects 1`] = `"{\"a\": 1, \"b\": [Object]}"`;
+exports[`.stringify() reduces maxDepth if stringifying very large objects 1`] = `"{\\"a\\": 1, \\"b\\": [Object]}"`;
 
-exports[`.stringify() reduces maxDepth if stringifying very large objects 2`] = `"{\"a\": 1, \"b\": {\"0\": \"test\", \"1\": \"test\", \"2\": \"test\", \"3\": \"test\", \"4\": \"test\", \"5\": \"test\", \"6\": \"test\", \"7\": \"test\", \"8\": \"test\", \"9\": \"test\"}}"`;
+exports[`.stringify() reduces maxDepth if stringifying very large objects 2`] = `"{\\"a\\": 1, \\"b\\": {\\"0\\": \\"test\\", \\"1\\": \\"test\\", \\"2\\": \\"test\\", \\"3\\": \\"test\\", \\"4\\": \\"test\\", \\"5\\": \\"test\\", \\"6\\": \\"test\\", \\"7\\": \\"test\\", \\"8\\": \\"test\\", \\"9\\": \\"test\\"}}"`;
 
 exports[`.stringify() toJSON errors when comparing two objects 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).toEqual([22m[32mexpected[39m[2m)[22m
 
 Expected value to equal:
-  [32m{\"b\": 1, \"toJSON\": [Function toJSON]}[39m
+  [32m{\\"b\\": 1, \\"toJSON\\": [Function toJSON]}[39m
 Received:
-  [31m{\"a\": 1, \"toJSON\": [Function toJSON]}[39m
+  [31m{\\"a\\": 1, \\"toJSON\\": [Function toJSON]}[39m
 
 Difference:
 
@@ -16,8 +16,8 @@ Difference:
 [31m+ Received[39m
 
 [2m Object {[22m
-[32m-  \"b\": 1,[39m
-[31m+  \"a\": 1,[39m
-[2m   \"toJSON\": [Function toJSON],[22m
+[32m-  \\"b\\": 1,[39m
+[31m+  \\"a\\": 1,[39m
+[2m   \\"toJSON\\": [Function toJSON],[22m
 [2m }[22m"
 `;

--- a/packages/jest-matchers/src/__tests__/__snapshots__/matchers-test.js.snap
+++ b/packages/jest-matchers/src/__tests__/__snapshots__/matchers-test.js.snap
@@ -4,7 +4,7 @@ exports[`.toBe() does not crash on circular references 1`] = `
 Expected value to be (using ===):
   [32m{}[39m
 Received:
-  [31m{\"circular\": [Circular]}[39m
+  [31m{\\"circular\\": [Circular]}[39m
 
 Difference:
 
@@ -13,7 +13,7 @@ Difference:
 
 [32m-Object {}[39m
 [31m+Object {[39m
-[31m+  \"circular\": [Circular],[39m
+[31m+  \\"circular\\": [Circular],[39m
 [31m+}[39m"
 `;
 
@@ -21,9 +21,9 @@ exports[`.toBe() fails for '"a"' with '.not' 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).not.toBe([22m[32mexpected[39m[2m)[22m
 
 Expected value to not be (using ===):
-  [32m\"a\"[39m
+  [32m\\"a\\"[39m
 Received:
-  [31m\"a\"[39m"
+  [31m\\"a\\"[39m"
 `;
 
 exports[`.toBe() fails for '{}' with '.not' 1`] = `
@@ -84,18 +84,18 @@ exports[`.toBe() fails for: "abc" and "cde" 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).toBe([22m[32mexpected[39m[2m)[22m
 
 Expected value to be (using ===):
-  [32m\"cde\"[39m
+  [32m\\"cde\\"[39m
 Received:
-  [31m\"abc\"[39m"
+  [31m\\"abc\\"[39m"
 `;
 
 exports[`.toBe() fails for: {"a": 1} and {"a": 1} 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).toBe([22m[32mexpected[39m[2m)[22m
 
 Expected value to be (using ===):
-  [32m{\"a\": 1}[39m
+  [32m{\\"a\\": 1}[39m
 Received:
-  [31m{\"a\": 1}[39m
+  [31m{\\"a\\": 1}[39m
 
 Difference:
 
@@ -106,9 +106,9 @@ exports[`.toBe() fails for: {"a": 1} and {"a": 5} 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).toBe([22m[32mexpected[39m[2m)[22m
 
 Expected value to be (using ===):
-  [32m{\"a\": 5}[39m
+  [32m{\\"a\\": 5}[39m
 Received:
-  [31m{\"a\": 1}[39m
+  [31m{\\"a\\": 1}[39m
 
 Difference:
 
@@ -116,8 +116,8 @@ Difference:
 [31m+ Received[39m
 
 [2m Object {[22m
-[32m-  \"a\": 5,[39m
-[31m+  \"a\": 1,[39m
+[32m-  \\"a\\": 5,[39m
+[31m+  \\"a\\": 1,[39m
 [2m }[22m"
 `;
 
@@ -290,14 +290,14 @@ exports[`.toBeDefined(), .toBeUndefined() '"a"' is defined 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).not.toBeDefined([22m[2m)[22m
 
 Expected value not to be defined, instead received
-  [31m\"a\"[39m"
+  [31m\\"a\\"[39m"
 `;
 
 exports[`.toBeDefined(), .toBeUndefined() '"a"' is defined 2`] = `
 "[2mexpect([22m[31mreceived[39m[2m).toBeUndefined([22m[2m)[22m
 
 Expected value to be undefined, instead received
-  [31m\"a\"[39m"
+  [31m\\"a\\"[39m"
 `;
 
 exports[`.toBeDefined(), .toBeUndefined() '[Function anonymous]' is defined 1`] = `
@@ -1024,18 +1024,18 @@ exports[`.toBeInstanceOf() failing "a" and [Function String] 1`] = `
 "[2mexpect([22m[31mvalue[39m[2m).toBeInstanceOf([22m[32mconstructor[39m[2m)[22m
 
 Expected value to be an instance of:
-  [32m\"String\"[39m
+  [32m\\"String\\"[39m
 Received:
-  [31m\"a\"[39m
+  [31m\\"a\\"[39m
 Constructor:
-  [31m\"String\"[39m"
+  [31m\\"String\\"[39m"
 `;
 
 exports[`.toBeInstanceOf() failing {} and [Function A] 1`] = `
 "[2mexpect([22m[31mvalue[39m[2m).toBeInstanceOf([22m[32mconstructor[39m[2m)[22m
 
 Expected value to be an instance of:
-  [32m\"A\"[39m
+  [32m\\"A\\"[39m
 Received:
   [31m{}[39m
 Constructor:
@@ -1046,40 +1046,40 @@ exports[`.toBeInstanceOf() failing {} and [Function B] 1`] = `
 "[2mexpect([22m[31mvalue[39m[2m).toBeInstanceOf([22m[32mconstructor[39m[2m)[22m
 
 Expected value to be an instance of:
-  [32m\"B\"[39m
+  [32m\\"B\\"[39m
 Received:
   [31m{}[39m
 Constructor:
-  [31m\"A\"[39m"
+  [31m\\"A\\"[39m"
 `;
 
 exports[`.toBeInstanceOf() failing 1 and [Function Number] 1`] = `
 "[2mexpect([22m[31mvalue[39m[2m).toBeInstanceOf([22m[32mconstructor[39m[2m)[22m
 
 Expected value to be an instance of:
-  [32m\"Number\"[39m
+  [32m\\"Number\\"[39m
 Received:
   [31m1[39m
 Constructor:
-  [31m\"Number\"[39m"
+  [31m\\"Number\\"[39m"
 `;
 
 exports[`.toBeInstanceOf() failing true and [Function Boolean] 1`] = `
 "[2mexpect([22m[31mvalue[39m[2m).toBeInstanceOf([22m[32mconstructor[39m[2m)[22m
 
 Expected value to be an instance of:
-  [32m\"Boolean\"[39m
+  [32m\\"Boolean\\"[39m
 Received:
   [31mtrue[39m
 Constructor:
-  [31m\"Boolean\"[39m"
+  [31m\\"Boolean\\"[39m"
 `;
 
 exports[`.toBeInstanceOf() passing {} and [Function A] 1`] = `
 "[2mexpect([22m[31mvalue[39m[2m).not.toBeInstanceOf([22m[32mconstructor[39m[2m)[22m
 
 Expected value not to be an instance of:
-  [32m\"A\"[39m
+  [32m\\"A\\"[39m
 Received:
   [31m{}[39m
 "
@@ -1089,7 +1089,7 @@ exports[`.toBeInstanceOf() passing Array [] and [Function Array] 1`] = `
 "[2mexpect([22m[31mvalue[39m[2m).not.toBeInstanceOf([22m[32mconstructor[39m[2m)[22m
 
 Expected value not to be an instance of:
-  [32m\"Array\"[39m
+  [32m\\"Array\\"[39m
 Received:
   [31mArray [][39m
 "
@@ -1099,7 +1099,7 @@ exports[`.toBeInstanceOf() passing Map {} and [Function Map] 1`] = `
 "[2mexpect([22m[31mvalue[39m[2m).not.toBeInstanceOf([22m[32mconstructor[39m[2m)[22m
 
 Expected value not to be an instance of:
-  [32m\"Map\"[39m
+  [32m\\"Map\\"[39m
 Received:
   [31mMap {}[39m
 "
@@ -1109,7 +1109,7 @@ exports[`.toBeInstanceOf() throws if constructor is not a function 1`] = `
 "[2mexpect([22m[31mvalue[39m[2m)[.not].toBeInstanceOf([22m[32mconstructor[39m[2m)[22m
 
 Expected constructor to be a function. Instead got:
-  [32m\"number\"[39m"
+  [32m\\"number\\"[39m"
 `;
 
 exports[`.toBeNaN() passes 1`] = `
@@ -1151,7 +1151,7 @@ exports[`.toBeNaN() throws 2`] = `
 "[2mexpect([22m[31mreceived[39m[2m).toBeNaN([22m[2m)[22m
 
 Expected value to be NaN, instead received
-  [31m\"\"[39m"
+  [31m\\"\\"[39m"
 `;
 
 exports[`.toBeNaN() throws 3`] = `
@@ -1214,7 +1214,7 @@ exports[`.toBeNull() fails for '"a"' with .not 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).toBeNull([22m[2m)[22m
 
 Expected value to be null, instead received
-  [31m\"a\"[39m"
+  [31m\\"a\\"[39m"
 `;
 
 exports[`.toBeNull() fails for '[Function anonymous]' with .not 1`] = `
@@ -1284,28 +1284,28 @@ exports[`.toBeTruthy(), .toBeFalsy() '""' is falsy 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).toBeTruthy([22m[2m)[22m
 
 Expected value to be truthy, instead received
-  [31m\"\"[39m"
+  [31m\\"\\"[39m"
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() '""' is falsy 2`] = `
 "[2mexpect([22m[31mreceived[39m[2m).not.toBeFalsy([22m[2m)[22m
 
 Expected value not to be falsy, instead received
-  [31m\"\"[39m"
+  [31m\\"\\"[39m"
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() '"a"' is truthy 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).not.toBeTruthy([22m[2m)[22m
 
 Expected value not to be truthy, instead received
-  [31m\"a\"[39m"
+  [31m\\"a\\"[39m"
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() '"a"' is truthy 2`] = `
 "[2mexpect([22m[31mreceived[39m[2m).toBeFalsy([22m[2m)[22m
 
 Expected value to be falsy, instead received
-  [31m\"a\"[39m"
+  [31m\\"a\\"[39m"
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() '[Function anonymous]' is truthy 1`] = `
@@ -1508,9 +1508,9 @@ exports[`.toContain(), .toContainEqual() '"11112111"' contains '"2"' 1`] = `
 "[2mexpect([22m[31mstring[39m[2m).not.toContain([22m[32mvalue[39m[2m)[22m
 
 Expected string:
-  [31m\"11112111\"[39m
+  [31m\\"11112111\\"[39m
 Not to contain value:
-  [32m\"2\"[39m
+  [32m\\"2\\"[39m
 "
 `;
 
@@ -1518,9 +1518,9 @@ exports[`.toContain(), .toContainEqual() '"abcdef"' contains '"abc"' 1`] = `
 "[2mexpect([22m[31mstring[39m[2m).not.toContain([22m[32mvalue[39m[2m)[22m
 
 Expected string:
-  [31m\"abcdef\"[39m
+  [31m\\"abcdef\\"[39m
 Not to contain value:
-  [32m\"abc\"[39m
+  [32m\\"abc\\"[39m
 "
 `;
 
@@ -1528,9 +1528,9 @@ exports[`.toContain(), .toContainEqual() '["a", "b", "c", "d"]' contains '"a"' 1
 "[2mexpect([22m[31marray[39m[2m).not.toContain([22m[32mvalue[39m[2m)[22m
 
 Expected array:
-  [31m[\"a\", \"b\", \"c\", \"d\"][39m
+  [31m[\\"a\\", \\"b\\", \\"c\\", \\"d\\"][39m
 Not to contain value:
-  [32m\"a\"[39m
+  [32m\\"a\\"[39m
 "
 `;
 
@@ -1538,9 +1538,9 @@ exports[`.toContain(), .toContainEqual() '["a", "b", "c", "d"]' contains a value
 "[2mexpect([22m[31marray[39m[2m).not.toContainEqual([22m[32mvalue[39m[2m)[22m
 
 Expected array:
-  [31m[\"a\", \"b\", \"c\", \"d\"][39m
+  [31m[\\"a\\", \\"b\\", \\"c\\", \\"d\\"][39m
 Not to contain a value equal to:
-  [32m\"a\"[39m
+  [32m\\"a\\"[39m
 "
 `;
 
@@ -1548,9 +1548,9 @@ exports[`.toContain(), .toContainEqual() '[{"a": "b"}, {"a": "c"}]' contains a v
 "[2mexpect([22m[31marray[39m[2m).not.toContainEqual([22m[32mvalue[39m[2m)[22m
 
 Expected array:
-  [31m[{\"a\": \"b\"}, {\"a\": \"c\"}][39m
+  [31m[{\\"a\\": \\"b\\"}, {\\"a\\": \\"c\\"}][39m
 Not to contain a value equal to:
-  [32m{\"a\": \"b\"}[39m
+  [32m{\\"a\\": \\"b\\"}[39m
 "
 `;
 
@@ -1558,9 +1558,9 @@ exports[`.toContain(), .toContainEqual() '[{"a": "b"}, {"a": "c"}]' does not con
 "[2mexpect([22m[31marray[39m[2m).toContainEqual([22m[32mvalue[39m[2m)[22m
 
 Expected array:
-  [31m[{\"a\": \"b\"}, {\"a\": \"c\"}][39m
+  [31m[{\\"a\\": \\"b\\"}, {\\"a\\": \\"c\\"}][39m
 To contain a value equal to:
-  [32m{\"a\": \"d\"}[39m"
+  [32m{\\"a\\": \\"d\\"}[39m"
 `;
 
 exports[`.toContain(), .toContainEqual() '[{}, Array []]' does not contain '{}' 1`] = `
@@ -1703,9 +1703,9 @@ exports[`.toContain(), .toContainEqual() 'Set {"abc", "def"}' contains '"abc"' 1
 "[2mexpect([22m[31mset[39m[2m).not.toContain([22m[32mvalue[39m[2m)[22m
 
 Expected set:
-  [31mSet {\"abc\", \"def\"}[39m
+  [31mSet {\\"abc\\", \\"def\\"}[39m
 Not to contain value:
-  [32m\"abc\"[39m
+  [32m\\"abc\\"[39m
 "
 `;
 
@@ -1737,18 +1737,18 @@ exports[`.toEqual() expect("abc").not.toEqual("abc") 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).not.toEqual([22m[32mexpected[39m[2m)[22m
 
 Expected value to not equal:
-  [32m\"abc\"[39m
+  [32m\\"abc\\"[39m
 Received:
-  [31m\"abc\"[39m"
+  [31m\\"abc\\"[39m"
 `;
 
 exports[`.toEqual() expect("abcd").not.toEqual(StringContaining "bc") 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).not.toEqual([22m[32mexpected[39m[2m)[22m
 
 Expected value to not equal:
-  [32mStringContaining \"bc\"[39m
+  [32mStringContaining \\"bc\\"[39m
 Received:
-  [31m\"abcd\"[39m"
+  [31m\\"abcd\\"[39m"
 `;
 
 exports[`.toEqual() expect("abcd").not.toEqual(StringMatching /bc/) 1`] = `
@@ -1757,16 +1757,16 @@ exports[`.toEqual() expect("abcd").not.toEqual(StringMatching /bc/) 1`] = `
 Expected value to not equal:
   [32mStringMatching /bc/[39m
 Received:
-  [31m\"abcd\"[39m"
+  [31m\\"abcd\\"[39m"
 `;
 
 exports[`.toEqual() expect("abd").toEqual(StringContaining "bc") 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).toEqual([22m[32mexpected[39m[2m)[22m
 
 Expected value to equal:
-  [32mStringContaining \"bc\"[39m
+  [32mStringContaining \\"bc\\"[39m
 Received:
-  [31m\"abd\"[39m
+  [31m\\"abd\\"[39m
 
 Difference:
 
@@ -1779,7 +1779,7 @@ exports[`.toEqual() expect("abd").toEqual(StringMatching /bc/i) 1`] = `
 Expected value to equal:
   [32mStringMatching /bc/i[39m
 Received:
-  [31m\"abd\"[39m
+  [31m\\"abd\\"[39m
 
 Difference:
 
@@ -1790,9 +1790,9 @@ exports[`.toEqual() expect("banana").toEqual("apple") 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).toEqual([22m[32mexpected[39m[2m)[22m
 
 Expected value to equal:
-  [32m\"apple\"[39m
+  [32m\\"apple\\"[39m
 Received:
-  [31m\"banana\"[39m"
+  [31m\\"banana\\"[39m"
 `;
 
 exports[`.toEqual() expect([1, 2, 3]).not.toEqual(ArrayContaining [2, 3]) 1`] = `
@@ -1838,27 +1838,27 @@ exports[`.toEqual() expect({"a": 1, "b": [Function b], "c": true}).not.toEqual({
 "[2mexpect([22m[31mreceived[39m[2m).not.toEqual([22m[32mexpected[39m[2m)[22m
 
 Expected value to not equal:
-  [32m{\"a\": 1, \"b\": Any<Function>, \"c\": Anything}[39m
+  [32m{\\"a\\": 1, \\"b\\": Any<Function>, \\"c\\": Anything}[39m
 Received:
-  [31m{\"a\": 1, \"b\": [Function b], \"c\": true}[39m"
+  [31m{\\"a\\": 1, \\"b\\": [Function b], \\"c\\": true}[39m"
 `;
 
 exports[`.toEqual() expect({"a": 1, "b": 2}).not.toEqual(ObjectContaining {"a": 1}) 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).not.toEqual([22m[32mexpected[39m[2m)[22m
 
 Expected value to not equal:
-  [32mObjectContaining {\"a\": 1}[39m
+  [32mObjectContaining {\\"a\\": 1}[39m
 Received:
-  [31m{\"a\": 1, \"b\": 2}[39m"
+  [31m{\\"a\\": 1, \\"b\\": 2}[39m"
 `;
 
 exports[`.toEqual() expect({"a": 1, "b": 2}).toEqual(ObjectContaining {"a": 2}) 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).toEqual([22m[32mexpected[39m[2m)[22m
 
 Expected value to equal:
-  [32mObjectContaining {\"a\": 2}[39m
+  [32mObjectContaining {\\"a\\": 2}[39m
 Received:
-  [31m{\"a\": 1, \"b\": 2}[39m
+  [31m{\\"a\\": 1, \\"b\\": 2}[39m
 
 Difference:
 
@@ -1866,10 +1866,10 @@ Difference:
 [31m+ Received[39m
 
 [32m-ObjectContaining {[39m
-[32m-  \"a\": 2,[39m
+[32m-  \\"a\\": 2,[39m
 [31m+Object {[39m
-[31m+  \"a\": 1,[39m
-[31m+  \"b\": 2,[39m
+[31m+  \\"a\\": 1,[39m
+[31m+  \\"b\\": 2,[39m
 [2m }[22m"
 `;
 
@@ -1877,9 +1877,9 @@ exports[`.toEqual() expect({"a": 5}).toEqual({"b": 6}) 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).toEqual([22m[32mexpected[39m[2m)[22m
 
 Expected value to equal:
-  [32m{\"b\": 6}[39m
+  [32m{\\"b\\": 6}[39m
 Received:
-  [31m{\"a\": 5}[39m
+  [31m{\\"a\\": 5}[39m
 
 Difference:
 
@@ -1887,8 +1887,8 @@ Difference:
 [31m+ Received[39m
 
 [2m Object {[22m
-[32m-  \"b\": 6,[39m
-[31m+  \"a\": 5,[39m
+[32m-  \\"b\\": 6,[39m
+[31m+  \\"a\\": 5,[39m
 [2m }[22m"
 `;
 
@@ -1896,9 +1896,9 @@ exports[`.toEqual() expect({"a": 99}).not.toEqual({"a": 99}) 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).not.toEqual([22m[32mexpected[39m[2m)[22m
 
 Expected value to not equal:
-  [32m{\"a\": 99}[39m
+  [32m{\\"a\\": 99}[39m
 Received:
-  [31m{\"a\": 99}[39m"
+  [31m{\\"a\\": 99}[39m"
 `;
 
 exports[`.toEqual() expect(1).not.toEqual(1) 1`] = `
@@ -1988,8 +1988,8 @@ Difference:
 exports[`.toHaveLength error cases 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m)[.not].toHaveLength([22m[32mlength[39m[2m)[22m
 
-Expected value to have a \'length\' property that is a number. Received:
-  [31m{\"a\": 9}[39m
+Expected value to have a 'length' property that is a number. Received:
+  [31m{\\"a\\": 9}[39m
 received.length:
   [31mundefined[39m"
 `;
@@ -1997,7 +1997,7 @@ received.length:
 exports[`.toHaveLength error cases 2`] = `
 "[2mexpect([22m[31mreceived[39m[2m)[.not].toHaveLength([22m[32mlength[39m[2m)[22m
 
-Expected value to have a \'length\' property that is a number. Received:
+Expected value to have a 'length' property that is a number. Received:
   [31m0[39m
 "
 `;
@@ -2005,7 +2005,7 @@ Expected value to have a \'length\' property that is a number. Received:
 exports[`.toHaveLength error cases 3`] = `
 "[2mexpect([22m[31mreceived[39m[2m)[.not].toHaveLength([22m[32mlength[39m[2m)[22m
 
-Expected value to have a \'length\' property that is a number. Received:
+Expected value to have a 'length' property that is a number. Received:
   [31mundefined[39m
 "
 `;
@@ -2016,7 +2016,7 @@ exports[`.toHaveLength expect("").toHaveLength(0) 1`] = `
 Expected value to not have length:
   [32m0[39m
 Received:
-  [31m\"\"[39m
+  [31m\\"\\"[39m
 received.length:
   [31m0[39m"
 `;
@@ -2027,7 +2027,7 @@ exports[`.toHaveLength expect("").toHaveLength(1) 1`] = `
 Expected value to have length:
   [32m1[39m
 Received:
-  [31m\"\"[39m
+  [31m\\"\\"[39m
 received.length:
   [31m0[39m"
 `;
@@ -2038,7 +2038,7 @@ exports[`.toHaveLength expect("abc").toHaveLength(3) 1`] = `
 Expected value to not have length:
   [32m3[39m
 Received:
-  [31m\"abc\"[39m
+  [31m\\"abc\\"[39m
 received.length:
   [31m3[39m"
 `;
@@ -2049,7 +2049,7 @@ exports[`.toHaveLength expect("abc").toHaveLength(66) 1`] = `
 Expected value to have length:
   [32m66[39m
 Received:
-  [31m\"abc\"[39m
+  [31m\\"abc\\"[39m
 received.length:
   [31m3[39m"
 `;
@@ -2060,7 +2060,7 @@ exports[`.toHaveLength expect(["a", "b"]).toHaveLength(2) 1`] = `
 Expected value to not have length:
   [32m2[39m
 Received:
-  [31m[\"a\", \"b\"][39m
+  [31m[\\"a\\", \\"b\\"][39m
 received.length:
   [31m2[39m"
 `;
@@ -2071,7 +2071,7 @@ exports[`.toHaveLength expect(["a", "b"]).toHaveLength(99) 1`] = `
 Expected value to have length:
   [32m99[39m
 Received:
-  [31m[\"a\", \"b\"][39m
+  [31m[\\"a\\", \\"b\\"][39m
 received.length:
   [31m2[39m"
 `;
@@ -2159,9 +2159,9 @@ exports[`.toHaveProperty() {pass: false} expect("abc").toHaveProperty('a.b.c') 1
 "[2mexpect([22m[31mobject[39m[2m).toHaveProperty([22m[32mpath[39m[2m)[22m
 
 Expected the object:
-  [31m\"abc\"[39m
+  [31m\\"abc\\"[39m
 To have a nested property:
-  [32m\"a.b.c\"[39m
+  [32m\\"a.b.c\\"[39m
 "
 `;
 
@@ -2169,11 +2169,11 @@ exports[`.toHaveProperty() {pass: false} expect("abc").toHaveProperty('a.b.c', {
 "[2mexpect([22m[31mobject[39m[2m).toHaveProperty([22m[32mpath[39m, [32mvalue[39m[2m)[22m
 
 Expected the object:
-  [31m\"abc\"[39m
+  [31m\\"abc\\"[39m
 To have a nested property:
-  [32m\"a.b.c\"[39m
+  [32m\\"a.b.c\\"[39m
 With a value of:
-  [32m{\"a\": 5}[39m
+  [32m{\\"a\\": 5}[39m
 "
 `;
 
@@ -2181,35 +2181,35 @@ exports[`.toHaveProperty() {pass: false} expect({"a": {"b": {"c": {"d": 1}}}}).t
 "[2mexpect([22m[31mobject[39m[2m).toHaveProperty([22m[32mpath[39m, [32mvalue[39m[2m)[22m
 
 Expected the object:
-  [31m{\"a\": {\"b\": {\"c\": {\"d\": 1}}}}[39m
+  [31m{\\"a\\": {\\"b\\": {\\"c\\": {\\"d\\": 1}}}}[39m
 To have a nested property:
-  [32m\"a.b.c.d\"[39m
+  [32m\\"a.b.c.d\\"[39m
 With a value of:
   [32m2[39m
 Received:
-  [31mobject[39m.a.b.c: [31m{\"d\": 1}[39m"
+  [31mobject[39m.a.b.c: [31m{\\"d\\": 1}[39m"
 `;
 
 exports[`.toHaveProperty() {pass: false} expect({"a": {"b": {"c": {"d": 1}}}}).toHaveProperty('a.b.ttt.d', 1) 1`] = `
 "[2mexpect([22m[31mobject[39m[2m).toHaveProperty([22m[32mpath[39m, [32mvalue[39m[2m)[22m
 
 Expected the object:
-  [31m{\"a\": {\"b\": {\"c\": {\"d\": 1}}}}[39m
+  [31m{\\"a\\": {\\"b\\": {\\"c\\": {\\"d\\": 1}}}}[39m
 To have a nested property:
-  [32m\"a.b.ttt.d\"[39m
+  [32m\\"a.b.ttt.d\\"[39m
 With a value of:
   [32m1[39m
 Received:
-  [31mobject[39m.a.b: [31m{\"c\": {\"d\": 1}}[39m"
+  [31mobject[39m.a.b: [31m{\\"c\\": {\\"d\\": 1}}[39m"
 `;
 
 exports[`.toHaveProperty() {pass: false} expect({"a": {"b": {"c": {}}}}).toHaveProperty('a.b.c.d') 1`] = `
 "[2mexpect([22m[31mobject[39m[2m).toHaveProperty([22m[32mpath[39m[2m)[22m
 
 Expected the object:
-  [31m{\"a\": {\"b\": {\"c\": {}}}}[39m
+  [31m{\\"a\\": {\\"b\\": {\\"c\\": {}}}}[39m
 To have a nested property:
-  [32m\"a.b.c.d\"[39m
+  [32m\\"a.b.c.d\\"[39m
 Received:
   [31mobject[39m.a.b.c: [31m{}[39m"
 `;
@@ -2218,9 +2218,9 @@ exports[`.toHaveProperty() {pass: false} expect({"a": {"b": {"c": {}}}}).toHaveP
 "[2mexpect([22m[31mobject[39m[2m).toHaveProperty([22m[32mpath[39m, [32mvalue[39m[2m)[22m
 
 Expected the object:
-  [31m{\"a\": {\"b\": {\"c\": {}}}}[39m
+  [31m{\\"a\\": {\\"b\\": {\\"c\\": {}}}}[39m
 To have a nested property:
-  [32m\"a.b.c.d\"[39m
+  [32m\\"a.b.c.d\\"[39m
 With a value of:
   [32m1[39m
 Received:
@@ -2231,21 +2231,21 @@ exports[`.toHaveProperty() {pass: false} expect({"a": {"b": {"c": 5}}}).toHavePr
 "[2mexpect([22m[31mobject[39m[2m).toHaveProperty([22m[32mpath[39m, [32mvalue[39m[2m)[22m
 
 Expected the object:
-  [31m{\"a\": {\"b\": {\"c\": 5}}}[39m
+  [31m{\\"a\\": {\\"b\\": {\\"c\\": 5}}}[39m
 To have a nested property:
-  [32m\"a.b\"[39m
+  [32m\\"a.b\\"[39m
 With a value of:
-  [32m{\"c\": 4}[39m
+  [32m{\\"c\\": 4}[39m
 Received:
-  [31mobject[39m.a: [31m{\"b\": {\"c\": 5}}[39m
+  [31mobject[39m.a: [31m{\\"b\\": {\\"c\\": 5}}[39m
 Difference:
 
 [32m- Expected[39m
 [31m+ Received[39m
 
 [2m Object {[22m
-[32m-  \"c\": 4,[39m
-[31m+  \"c\": 5,[39m
+[32m-  \\"c\\": 4,[39m
+[31m+  \\"c\\": 5,[39m
 [2m }[22m"
 `;
 
@@ -2253,13 +2253,13 @@ exports[`.toHaveProperty() {pass: false} expect({"a": {"b": 3}}).toHaveProperty(
 "[2mexpect([22m[31mobject[39m[2m).toHaveProperty([22m[32mpath[39m, [32mvalue[39m[2m)[22m
 
 Expected the object:
-  [31m{\"a\": {\"b\": 3}}[39m
+  [31m{\\"a\\": {\\"b\\": 3}}[39m
 To have a nested property:
-  [32m\"a.b\"[39m
+  [32m\\"a.b\\"[39m
 With a value of:
   [32mundefined[39m
 Received:
-  [31mobject[39m.a: [31m{\"b\": 3}[39m
+  [31mobject[39m.a: [31m{\\"b\\": 3}[39m
 Difference:
 
   Comparing two different types of values. Expected [32mundefined[39m but received [31mnumber[39m."
@@ -2269,9 +2269,9 @@ exports[`.toHaveProperty() {pass: false} expect({"a": 1}).toHaveProperty('a.b.c.
 "[2mexpect([22m[31mobject[39m[2m).toHaveProperty([22m[32mpath[39m[2m)[22m
 
 Expected the object:
-  [31m{\"a\": 1}[39m
+  [31m{\\"a\\": 1}[39m
 To have a nested property:
-  [32m\"a.b.c.d\"[39m
+  [32m\\"a.b.c.d\\"[39m
 Received:
   [31mobject[39m.a: [31m1[39m"
 `;
@@ -2280,9 +2280,9 @@ exports[`.toHaveProperty() {pass: false} expect({"a": 1}).toHaveProperty('a.b.c.
 "[2mexpect([22m[31mobject[39m[2m).toHaveProperty([22m[32mpath[39m, [32mvalue[39m[2m)[22m
 
 Expected the object:
-  [31m{\"a\": 1}[39m
+  [31m{\\"a\\": 1}[39m
 To have a nested property:
-  [32m\"a.b.c.d\"[39m
+  [32m\\"a.b.c.d\\"[39m
 With a value of:
   [32m5[39m
 Received:
@@ -2295,7 +2295,7 @@ exports[`.toHaveProperty() {pass: false} expect({}).toHaveProperty('a') 1`] = `
 Expected the object:
   [31m{}[39m
 To have a nested property:
-  [32m\"a\"[39m
+  [32m\\"a\\"[39m
 "
 `;
 
@@ -2305,9 +2305,9 @@ exports[`.toHaveProperty() {pass: false} expect({}).toHaveProperty('a', "test") 
 Expected the object:
   [31m{}[39m
 To have a nested property:
-  [32m\"a\"[39m
+  [32m\\"a\\"[39m
 With a value of:
-  [32m\"test\"[39m
+  [32m\\"test\\"[39m
 "
 `;
 
@@ -2317,7 +2317,7 @@ exports[`.toHaveProperty() {pass: false} expect(1).toHaveProperty('a.b.c') 1`] =
 Expected the object:
   [31m1[39m
 To have a nested property:
-  [32m\"a.b.c\"[39m
+  [32m\\"a.b.c\\"[39m
 "
 `;
 
@@ -2327,9 +2327,9 @@ exports[`.toHaveProperty() {pass: false} expect(1).toHaveProperty('a.b.c', "test
 Expected the object:
   [31m1[39m
 To have a nested property:
-  [32m\"a.b.c\"[39m
+  [32m\\"a.b.c\\"[39m
 With a value of:
-  [32m\"test\"[39m
+  [32m\\"test\\"[39m
 "
 `;
 
@@ -2337,9 +2337,9 @@ exports[`.toHaveProperty() {pass: true} expect({"a": {"b": {"c": {"d": 1}}}}).to
 "[2mexpect([22m[31mobject[39m[2m).not.toHaveProperty([22m[32mpath[39m[2m)[22m
 
 Expected the object:
-  [31m{\"a\": {\"b\": {\"c\": {\"d\": 1}}}}[39m
+  [31m{\\"a\\": {\\"b\\": {\\"c\\": {\\"d\\": 1}}}}[39m
 Not to have a nested property:
-  [32m\"a.b.c.d\"[39m
+  [32m\\"a.b.c.d\\"[39m
 "
 `;
 
@@ -2347,9 +2347,9 @@ exports[`.toHaveProperty() {pass: true} expect({"a": {"b": {"c": {"d": 1}}}}).to
 "[2mexpect([22m[31mobject[39m[2m).not.toHaveProperty([22m[32mpath[39m, [32mvalue[39m[2m)[22m
 
 Expected the object:
-  [31m{\"a\": {\"b\": {\"c\": {\"d\": 1}}}}[39m
+  [31m{\\"a\\": {\\"b\\": {\\"c\\": {\\"d\\": 1}}}}[39m
 Not to have a nested property:
-  [32m\"a.b.c.d\"[39m
+  [32m\\"a.b.c.d\\"[39m
 With a value of:
   [32m1[39m
 "
@@ -2359,11 +2359,11 @@ exports[`.toHaveProperty() {pass: true} expect({"a": {"b": {"c": 5}}}).toHavePro
 "[2mexpect([22m[31mobject[39m[2m).not.toHaveProperty([22m[32mpath[39m, [32mvalue[39m[2m)[22m
 
 Expected the object:
-  [31m{\"a\": {\"b\": {\"c\": 5}}}[39m
+  [31m{\\"a\\": {\\"b\\": {\\"c\\": 5}}}[39m
 Not to have a nested property:
-  [32m\"a.b\"[39m
+  [32m\\"a.b\\"[39m
 With a value of:
-  [32m{\"c\": 5}[39m
+  [32m{\\"c\\": 5}[39m
 "
 `;
 
@@ -2371,9 +2371,9 @@ exports[`.toHaveProperty() {pass: true} expect({"a": {"b": undefined}}).toHavePr
 "[2mexpect([22m[31mobject[39m[2m).not.toHaveProperty([22m[32mpath[39m[2m)[22m
 
 Expected the object:
-  [31m{\"a\": {\"b\": undefined}}[39m
+  [31m{\\"a\\": {\\"b\\": undefined}}[39m
 Not to have a nested property:
-  [32m\"a.b\"[39m
+  [32m\\"a.b\\"[39m
 "
 `;
 
@@ -2381,9 +2381,9 @@ exports[`.toHaveProperty() {pass: true} expect({"a": {"b": undefined}}).toHavePr
 "[2mexpect([22m[31mobject[39m[2m).not.toHaveProperty([22m[32mpath[39m, [32mvalue[39m[2m)[22m
 
 Expected the object:
-  [31m{\"a\": {\"b\": undefined}}[39m
+  [31m{\\"a\\": {\\"b\\": undefined}}[39m
 Not to have a nested property:
-  [32m\"a.b\"[39m
+  [32m\\"a.b\\"[39m
 With a value of:
   [32mundefined[39m
 "
@@ -2393,9 +2393,9 @@ exports[`.toHaveProperty() {pass: true} expect({"a": 0}).toHaveProperty('a')' 1`
 "[2mexpect([22m[31mobject[39m[2m).not.toHaveProperty([22m[32mpath[39m[2m)[22m
 
 Expected the object:
-  [31m{\"a\": 0}[39m
+  [31m{\\"a\\": 0}[39m
 Not to have a nested property:
-  [32m\"a\"[39m
+  [32m\\"a\\"[39m
 "
 `;
 
@@ -2403,9 +2403,9 @@ exports[`.toHaveProperty() {pass: true} expect({"a": 0}).toHaveProperty('a', 0) 
 "[2mexpect([22m[31mobject[39m[2m).not.toHaveProperty([22m[32mpath[39m, [32mvalue[39m[2m)[22m
 
 Expected the object:
-  [31m{\"a\": 0}[39m
+  [31m{\\"a\\": 0}[39m
 Not to have a nested property:
-  [32m\"a\"[39m
+  [32m\\"a\\"[39m
 With a value of:
   [32m0[39m
 "
@@ -2417,16 +2417,16 @@ exports[`.toMatch() passes: [Foo bar, /^foo/i] 1`] = `
 Expected value not to match:
   [32m/^foo/i[39m
 Received:
-  [31m\"Foo bar\"[39m"
+  [31m\\"Foo bar\\"[39m"
 `;
 
 exports[`.toMatch() passes: [foo, foo] 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).not.toMatch([22m[32mexpected[39m[2m)[22m
 
 Expected value not to match:
-  [32m\"foo\"[39m
+  [32m\\"foo\\"[39m
 Received:
-  [31m\"foo\"[39m"
+  [31m\\"foo\\"[39m"
 `;
 
 exports[`.toMatch() throws if non String actual value passed: [/foo/i, "foo"] 1`] = `
@@ -2537,16 +2537,16 @@ exports[`.toMatch() throws: [bar, /foo/] 1`] = `
 Expected value to match:
   [32m/foo/[39m
 Received:
-  [31m\"bar\"[39m"
+  [31m\\"bar\\"[39m"
 `;
 
 exports[`.toMatch() throws: [bar, foo] 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).toMatch([22m[32mexpected[39m[2m)[22m
 
 Expected value to match:
-  [32m\"foo\"[39m
+  [32m\\"foo\\"[39m
 Received:
-  [31m\"bar\"[39m"
+  [31m\\"bar\\"[39m"
 `;
 
 exports[`toMatchObject() {pass: false} expect([1, 2, 3]).toMatchObject([1, 2, 2]) 1`] = `
@@ -2609,17 +2609,17 @@ exports[`toMatchObject() {pass: false} expect({"a": "b", "c": "d"}).toMatchObjec
 "[2mexpect([22m[31mreceived[39m[2m).toMatchObject([22m[32mexpected[39m[2m)[22m
 
 Expected value to match object:
-  [32m{\"a\": \"b!\", \"c\": \"d\"}[39m
+  [32m{\\"a\\": \\"b!\\", \\"c\\": \\"d\\"}[39m
 Received:
-  [31m{\"a\": \"b\", \"c\": \"d\"}[39m
+  [31m{\\"a\\": \\"b\\", \\"c\\": \\"d\\"}[39m
 Difference:
 [32m- Expected[39m
 [31m+ Received[39m
 
 [2m Object {[22m
-[32m-  \"a\": \"b!\",[39m
-[31m+  \"a\": \"b\",[39m
-[2m   \"c\": \"d\",[22m
+[32m-  \\"a\\": \\"b!\\",[39m
+[31m+  \\"a\\": \\"b\\",[39m
+[2m   \\"c\\": \\"d\\",[22m
 [2m }[22m"
 `;
 
@@ -2627,17 +2627,17 @@ exports[`toMatchObject() {pass: false} expect({"a": "b", "c": "d"}).toMatchObjec
 "[2mexpect([22m[31mreceived[39m[2m).toMatchObject([22m[32mexpected[39m[2m)[22m
 
 Expected value to match object:
-  [32m{\"e\": \"b\"}[39m
+  [32m{\\"e\\": \\"b\\"}[39m
 Received:
-  [31m{\"a\": \"b\", \"c\": \"d\"}[39m
+  [31m{\\"a\\": \\"b\\", \\"c\\": \\"d\\"}[39m
 Difference:
 [32m- Expected[39m
 [31m+ Received[39m
 
 [2m Object {[22m
-[32m-  \"e\": \"b\",[39m
-[31m+  \"a\": \"b\",[39m
-[31m+  \"c\": \"d\",[39m
+[32m-  \\"e\\": \\"b\\",[39m
+[31m+  \\"a\\": \\"b\\",[39m
+[31m+  \\"c\\": \\"d\\",[39m
 [2m }[22m"
 `;
 
@@ -2645,20 +2645,20 @@ exports[`toMatchObject() {pass: false} expect({"a": "b", "t": {"x": {"r": "r"}, 
 "[2mexpect([22m[31mreceived[39m[2m).toMatchObject([22m[32mexpected[39m[2m)[22m
 
 Expected value to match object:
-  [32m{\"a\": \"b\", \"t\": {\"z\": [3]}}[39m
+  [32m{\\"a\\": \\"b\\", \\"t\\": {\\"z\\": [3]}}[39m
 Received:
-  [31m{\"a\": \"b\", \"t\": {\"x\": {\"r\": \"r\"}, \"z\": \"z\"}}[39m
+  [31m{\\"a\\": \\"b\\", \\"t\\": {\\"x\\": {\\"r\\": \\"r\\"}, \\"z\\": \\"z\\"}}[39m
 Difference:
 [32m- Expected[39m
 [31m+ Received[39m
 
 [2m Object {[22m
-[2m   \"a\": \"b\",[22m
-[2m   \"t\": Object {[22m
-[32m-    \"z\": Array [[39m
+[2m   \\"a\\": \\"b\\",[22m
+[2m   \\"t\\": Object {[22m
+[32m-    \\"z\\": Array [[39m
 [32m-      3,[39m
 [32m-    ],[39m
-[31m+    \"z\": \"z\",[39m
+[31m+    \\"z\\": \\"z\\",[39m
 [2m   },[22m
 [2m }[22m"
 `;
@@ -2667,20 +2667,20 @@ exports[`toMatchObject() {pass: false} expect({"a": "b", "t": {"x": {"r": "r"}, 
 "[2mexpect([22m[31mreceived[39m[2m).toMatchObject([22m[32mexpected[39m[2m)[22m
 
 Expected value to match object:
-  [32m{\"t\": {\"l\": {\"r\": \"r\"}}}[39m
+  [32m{\\"t\\": {\\"l\\": {\\"r\\": \\"r\\"}}}[39m
 Received:
-  [31m{\"a\": \"b\", \"t\": {\"x\": {\"r\": \"r\"}, \"z\": \"z\"}}[39m
+  [31m{\\"a\\": \\"b\\", \\"t\\": {\\"x\\": {\\"r\\": \\"r\\"}, \\"z\\": \\"z\\"}}[39m
 Difference:
 [32m- Expected[39m
 [31m+ Received[39m
 
 [2m Object {[22m
-[2m   \"t\": Object {[22m
-[32m-    \"l\": Object {[39m
-[31m+    \"x\": Object {[39m
-[2m       \"r\": \"r\",[22m
+[2m   \\"t\\": Object {[22m
+[32m-    \\"l\\": Object {[39m
+[31m+    \\"x\\": Object {[39m
+[2m       \\"r\\": \\"r\\",[22m
 [2m     },[22m
-[31m+    \"z\": \"z\",[39m
+[31m+    \\"z\\": \\"z\\",[39m
 [2m   },[22m
 [2m }[22m"
 `;
@@ -2689,18 +2689,18 @@ exports[`toMatchObject() {pass: false} expect({"a": [{"a": "a", "b": "b"}]}).toM
 "[2mexpect([22m[31mreceived[39m[2m).toMatchObject([22m[32mexpected[39m[2m)[22m
 
 Expected value to match object:
-  [32m{\"a\": [{\"a\": \"c\"}]}[39m
+  [32m{\\"a\\": [{\\"a\\": \\"c\\"}]}[39m
 Received:
-  [31m{\"a\": [{\"a\": \"a\", \"b\": \"b\"}]}[39m
+  [31m{\\"a\\": [{\\"a\\": \\"a\\", \\"b\\": \\"b\\"}]}[39m
 Difference:
 [32m- Expected[39m
 [31m+ Received[39m
 
 [2m Object {[22m
-[2m   \"a\": Array [[22m
+[2m   \\"a\\": Array [[22m
 [2m     Object {[22m
-[32m-      \"a\": \"c\",[39m
-[31m+      \"a\": \"a\",[39m
+[32m-      \\"a\\": \\"c\\",[39m
+[31m+      \\"a\\": \\"a\\",[39m
 [2m     },[22m
 [2m   ],[22m
 [2m }[22m"
@@ -2710,18 +2710,18 @@ exports[`toMatchObject() {pass: false} expect({"a": [3, 4, "v"], "b": "b"}).toMa
 "[2mexpect([22m[31mreceived[39m[2m).toMatchObject([22m[32mexpected[39m[2m)[22m
 
 Expected value to match object:
-  [32m{\"a\": [\"v\"]}[39m
+  [32m{\\"a\\": [\\"v\\"]}[39m
 Received:
-  [31m{\"a\": [3, 4, \"v\"], \"b\": \"b\"}[39m
+  [31m{\\"a\\": [3, 4, \\"v\\"], \\"b\\": \\"b\\"}[39m
 Difference:
 [32m- Expected[39m
 [31m+ Received[39m
 
 [2m Object {[22m
-[2m   \"a\": Array [[22m
+[2m   \\"a\\": Array [[22m
 [31m+    3,[39m
 [31m+    4,[39m
-[2m     \"v\",[22m
+[2m     \\"v\\",[22m
 [2m   ],[22m
 [2m }[22m"
 `;
@@ -2730,15 +2730,15 @@ exports[`toMatchObject() {pass: false} expect({"a": [3, 4, 5], "b": "b"}).toMatc
 "[2mexpect([22m[31mreceived[39m[2m).toMatchObject([22m[32mexpected[39m[2m)[22m
 
 Expected value to match object:
-  [32m{\"a\": [3, 4, 5, 6]}[39m
+  [32m{\\"a\\": [3, 4, 5, 6]}[39m
 Received:
-  [31m{\"a\": [3, 4, 5], \"b\": \"b\"}[39m
+  [31m{\\"a\\": [3, 4, 5], \\"b\\": \\"b\\"}[39m
 Difference:
 [32m- Expected[39m
 [31m+ Received[39m
 
 [2m Object {[22m
-[2m   \"a\": Array [[22m
+[2m   \\"a\\": Array [[22m
 [2m     3,[22m
 [2m     4,[22m
 [2m     5,[22m
@@ -2751,15 +2751,15 @@ exports[`toMatchObject() {pass: false} expect({"a": [3, 4, 5], "b": "b"}).toMatc
 "[2mexpect([22m[31mreceived[39m[2m).toMatchObject([22m[32mexpected[39m[2m)[22m
 
 Expected value to match object:
-  [32m{\"a\": [3, 4]}[39m
+  [32m{\\"a\\": [3, 4]}[39m
 Received:
-  [31m{\"a\": [3, 4, 5], \"b\": \"b\"}[39m
+  [31m{\\"a\\": [3, 4, 5], \\"b\\": \\"b\\"}[39m
 Difference:
 [32m- Expected[39m
 [31m+ Received[39m
 
 [2m Object {[22m
-[2m   \"a\": Array [[22m
+[2m   \\"a\\": Array [[22m
 [2m     3,[22m
 [2m     4,[22m
 [31m+    5,[39m
@@ -2771,18 +2771,18 @@ exports[`toMatchObject() {pass: false} expect({"a": [3, 4, 5], "b": "b"}).toMatc
 "[2mexpect([22m[31mreceived[39m[2m).toMatchObject([22m[32mexpected[39m[2m)[22m
 
 Expected value to match object:
-  [32m{\"a\": {\"b\": 4}}[39m
+  [32m{\\"a\\": {\\"b\\": 4}}[39m
 Received:
-  [31m{\"a\": [3, 4, 5], \"b\": \"b\"}[39m
+  [31m{\\"a\\": [3, 4, 5], \\"b\\": \\"b\\"}[39m
 Difference:
 [32m- Expected[39m
 [31m+ Received[39m
 
 [2m Object {[22m
-[32m-  \"a\": Object {[39m
-[32m-    \"b\": 4,[39m
+[32m-  \\"a\\": Object {[39m
+[32m-    \\"b\\": 4,[39m
 [32m-  },[39m
-[31m+  \"a\": Array [[39m
+[31m+  \\"a\\": Array [[39m
 [31m+    3,[39m
 [31m+    4,[39m
 [31m+    5,[39m
@@ -2794,18 +2794,18 @@ exports[`toMatchObject() {pass: false} expect({"a": 1, "b": 1, "c": 1, "d": {"e"
 "[2mexpect([22m[31mreceived[39m[2m).toMatchObject([22m[32mexpected[39m[2m)[22m
 
 Expected value to match object:
-  [32m{\"d\": {\"e\": {\"f\": 222}}}[39m
+  [32m{\\"d\\": {\\"e\\": {\\"f\\": 222}}}[39m
 Received:
-  [31m{\"a\": 1, \"b\": 1, \"c\": 1, \"d\": {\"e\": {\"f\": 555}}}[39m
+  [31m{\\"a\\": 1, \\"b\\": 1, \\"c\\": 1, \\"d\\": {\\"e\\": {\\"f\\": 555}}}[39m
 Difference:
 [32m- Expected[39m
 [31m+ Received[39m
 
 [2m Object {[22m
-[2m   \"d\": Object {[22m
-[2m     \"e\": Object {[22m
-[32m-      \"f\": 222,[39m
-[31m+      \"f\": 555,[39m
+[2m   \\"d\\": Object {[22m
+[2m     \\"e\\": Object {[22m
+[32m-      \\"f\\": 222,[39m
+[31m+      \\"f\\": 555,[39m
 [2m     },[22m
 [2m   },[22m
 [2m }[22m"
@@ -2815,16 +2815,16 @@ exports[`toMatchObject() {pass: false} expect({"a": 2015-11-30T00:00:00.000Z, "b
 "[2mexpect([22m[31mreceived[39m[2m).toMatchObject([22m[32mexpected[39m[2m)[22m
 
 Expected value to match object:
-  [32m{\"a\": 2015-10-10T00:00:00.000Z}[39m
+  [32m{\\"a\\": 2015-10-10T00:00:00.000Z}[39m
 Received:
-  [31m{\"a\": 2015-11-30T00:00:00.000Z, \"b\": \"b\"}[39m
+  [31m{\\"a\\": 2015-11-30T00:00:00.000Z, \\"b\\": \\"b\\"}[39m
 Difference:
 [32m- Expected[39m
 [31m+ Received[39m
 
 [2m Object {[22m
-[32m-  \"a\": 2015-10-10T00:00:00.000Z,[39m
-[31m+  \"a\": 2015-11-30T00:00:00.000Z,[39m
+[32m-  \\"a\\": 2015-10-10T00:00:00.000Z,[39m
+[31m+  \\"a\\": 2015-11-30T00:00:00.000Z,[39m
 [2m }[22m"
 `;
 
@@ -2832,16 +2832,16 @@ exports[`toMatchObject() {pass: false} expect({"a": null, "b": "b"}).toMatchObje
 "[2mexpect([22m[31mreceived[39m[2m).toMatchObject([22m[32mexpected[39m[2m)[22m
 
 Expected value to match object:
-  [32m{\"a\": \"4\"}[39m
+  [32m{\\"a\\": \\"4\\"}[39m
 Received:
-  [31m{\"a\": null, \"b\": \"b\"}[39m
+  [31m{\\"a\\": null, \\"b\\": \\"b\\"}[39m
 Difference:
 [32m- Expected[39m
 [31m+ Received[39m
 
 [2m Object {[22m
-[32m-  \"a\": \"4\",[39m
-[31m+  \"a\": null,[39m
+[32m-  \\"a\\": \\"4\\",[39m
+[31m+  \\"a\\": null,[39m
 [2m }[22m"
 `;
 
@@ -2849,16 +2849,16 @@ exports[`toMatchObject() {pass: false} expect({"a": null, "b": "b"}).toMatchObje
 "[2mexpect([22m[31mreceived[39m[2m).toMatchObject([22m[32mexpected[39m[2m)[22m
 
 Expected value to match object:
-  [32m{\"a\": undefined}[39m
+  [32m{\\"a\\": undefined}[39m
 Received:
-  [31m{\"a\": null, \"b\": \"b\"}[39m
+  [31m{\\"a\\": null, \\"b\\": \\"b\\"}[39m
 Difference:
 [32m- Expected[39m
 [31m+ Received[39m
 
 [2m Object {[22m
-[32m-  \"a\": undefined,[39m
-[31m+  \"a\": null,[39m
+[32m-  \\"a\\": undefined,[39m
+[31m+  \\"a\\": null,[39m
 [2m }[22m"
 `;
 
@@ -2866,16 +2866,16 @@ exports[`toMatchObject() {pass: false} expect({"a": undefined}).toMatchObject({"
 "[2mexpect([22m[31mreceived[39m[2m).toMatchObject([22m[32mexpected[39m[2m)[22m
 
 Expected value to match object:
-  [32m{\"a\": null}[39m
+  [32m{\\"a\\": null}[39m
 Received:
-  [31m{\"a\": undefined}[39m
+  [31m{\\"a\\": undefined}[39m
 Difference:
 [32m- Expected[39m
 [31m+ Received[39m
 
 [2m Object {[22m
-[32m-  \"a\": null,[39m
-[31m+  \"a\": undefined,[39m
+[32m-  \\"a\\": null,[39m
+[31m+  \\"a\\": undefined,[39m
 [2m }[22m"
 `;
 
@@ -2883,7 +2883,7 @@ exports[`toMatchObject() {pass: false} expect({}).toMatchObject({"a": undefined}
 "[2mexpect([22m[31mreceived[39m[2m).toMatchObject([22m[32mexpected[39m[2m)[22m
 
 Expected value to match object:
-  [32m{\"a\": undefined}[39m
+  [32m{\\"a\\": undefined}[39m
 Received:
   [31m{}[39m
 Difference:
@@ -2891,7 +2891,7 @@ Difference:
 [31m+ Received[39m
 
 [32m-Object {[39m
-[32m-  \"a\": undefined,[39m
+[32m-  \\"a\\": undefined,[39m
 [32m-}[39m
 [31m+Object {}[39m"
 `;
@@ -2924,99 +2924,99 @@ exports[`toMatchObject() {pass: true} expect({"a": "b", "c": "d"}).toMatchObject
 "[2mexpect([22m[31mreceived[39m[2m).not.toMatchObject([22m[32mexpected[39m[2m)[22m
 
 Expected value not to match object:
-  [32m{\"a\": \"b\", \"c\": \"d\"}[39m
+  [32m{\\"a\\": \\"b\\", \\"c\\": \\"d\\"}[39m
 Received:
-  [31m{\"a\": \"b\", \"c\": \"d\"}[39m"
+  [31m{\\"a\\": \\"b\\", \\"c\\": \\"d\\"}[39m"
 `;
 
 exports[`toMatchObject() {pass: true} expect({"a": "b", "c": "d"}).toMatchObject({"a": "b"}) 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).not.toMatchObject([22m[32mexpected[39m[2m)[22m
 
 Expected value not to match object:
-  [32m{\"a\": \"b\"}[39m
+  [32m{\\"a\\": \\"b\\"}[39m
 Received:
-  [31m{\"a\": \"b\", \"c\": \"d\"}[39m"
+  [31m{\\"a\\": \\"b\\", \\"c\\": \\"d\\"}[39m"
 `;
 
 exports[`toMatchObject() {pass: true} expect({"a": "b", "t": {"x": {"r": "r"}, "z": "z"}}).toMatchObject({"a": "b", "t": {"z": "z"}}) 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).not.toMatchObject([22m[32mexpected[39m[2m)[22m
 
 Expected value not to match object:
-  [32m{\"a\": \"b\", \"t\": {\"z\": \"z\"}}[39m
+  [32m{\\"a\\": \\"b\\", \\"t\\": {\\"z\\": \\"z\\"}}[39m
 Received:
-  [31m{\"a\": \"b\", \"t\": {\"x\": {\"r\": \"r\"}, \"z\": \"z\"}}[39m"
+  [31m{\\"a\\": \\"b\\", \\"t\\": {\\"x\\": {\\"r\\": \\"r\\"}, \\"z\\": \\"z\\"}}[39m"
 `;
 
 exports[`toMatchObject() {pass: true} expect({"a": "b", "t": {"x": {"r": "r"}, "z": "z"}}).toMatchObject({"t": {"x": {"r": "r"}}}) 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).not.toMatchObject([22m[32mexpected[39m[2m)[22m
 
 Expected value not to match object:
-  [32m{\"t\": {\"x\": {\"r\": \"r\"}}}[39m
+  [32m{\\"t\\": {\\"x\\": {\\"r\\": \\"r\\"}}}[39m
 Received:
-  [31m{\"a\": \"b\", \"t\": {\"x\": {\"r\": \"r\"}, \"z\": \"z\"}}[39m"
+  [31m{\\"a\\": \\"b\\", \\"t\\": {\\"x\\": {\\"r\\": \\"r\\"}, \\"z\\": \\"z\\"}}[39m"
 `;
 
 exports[`toMatchObject() {pass: true} expect({"a": [{"a": "a", "b": "b"}]}).toMatchObject({"a": [{"a": "a"}]}) 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).not.toMatchObject([22m[32mexpected[39m[2m)[22m
 
 Expected value not to match object:
-  [32m{\"a\": [{\"a\": \"a\"}]}[39m
+  [32m{\\"a\\": [{\\"a\\": \\"a\\"}]}[39m
 Received:
-  [31m{\"a\": [{\"a\": \"a\", \"b\": \"b\"}]}[39m"
+  [31m{\\"a\\": [{\\"a\\": \\"a\\", \\"b\\": \\"b\\"}]}[39m"
 `;
 
 exports[`toMatchObject() {pass: true} expect({"a": [3, 4, 5, "v"], "b": "b"}).toMatchObject({"a": [3, 4, 5, "v"]}) 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).not.toMatchObject([22m[32mexpected[39m[2m)[22m
 
 Expected value not to match object:
-  [32m{\"a\": [3, 4, 5, \"v\"]}[39m
+  [32m{\\"a\\": [3, 4, 5, \\"v\\"]}[39m
 Received:
-  [31m{\"a\": [3, 4, 5, \"v\"], \"b\": \"b\"}[39m"
+  [31m{\\"a\\": [3, 4, 5, \\"v\\"], \\"b\\": \\"b\\"}[39m"
 `;
 
 exports[`toMatchObject() {pass: true} expect({"a": [3, 4, 5], "b": "b"}).toMatchObject({"a": [3, 4, 5]}) 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).not.toMatchObject([22m[32mexpected[39m[2m)[22m
 
 Expected value not to match object:
-  [32m{\"a\": [3, 4, 5]}[39m
+  [32m{\\"a\\": [3, 4, 5]}[39m
 Received:
-  [31m{\"a\": [3, 4, 5], \"b\": \"b\"}[39m"
+  [31m{\\"a\\": [3, 4, 5], \\"b\\": \\"b\\"}[39m"
 `;
 
 exports[`toMatchObject() {pass: true} expect({"a": 2015-11-30T00:00:00.000Z, "b": "b"}).toMatchObject({"a": 2015-11-30T00:00:00.000Z}) 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).not.toMatchObject([22m[32mexpected[39m[2m)[22m
 
 Expected value not to match object:
-  [32m{\"a\": 2015-11-30T00:00:00.000Z}[39m
+  [32m{\\"a\\": 2015-11-30T00:00:00.000Z}[39m
 Received:
-  [31m{\"a\": 2015-11-30T00:00:00.000Z, \"b\": \"b\"}[39m"
+  [31m{\\"a\\": 2015-11-30T00:00:00.000Z, \\"b\\": \\"b\\"}[39m"
 `;
 
 exports[`toMatchObject() {pass: true} expect({"a": null, "b": "b"}).toMatchObject({"a": null}) 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).not.toMatchObject([22m[32mexpected[39m[2m)[22m
 
 Expected value not to match object:
-  [32m{\"a\": null}[39m
+  [32m{\\"a\\": null}[39m
 Received:
-  [31m{\"a\": null, \"b\": \"b\"}[39m"
+  [31m{\\"a\\": null, \\"b\\": \\"b\\"}[39m"
 `;
 
 exports[`toMatchObject() {pass: true} expect({"a": undefined, "b": "b"}).toMatchObject({"a": undefined}) 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).not.toMatchObject([22m[32mexpected[39m[2m)[22m
 
 Expected value not to match object:
-  [32m{\"a\": undefined}[39m
+  [32m{\\"a\\": undefined}[39m
 Received:
-  [31m{\"a\": undefined, \"b\": \"b\"}[39m"
+  [31m{\\"a\\": undefined, \\"b\\": \\"b\\"}[39m"
 `;
 
 exports[`toMatchObject() {pass: true} expect({"a": undefined}).toMatchObject({"a": undefined}) 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).not.toMatchObject([22m[32mexpected[39m[2m)[22m
 
 Expected value not to match object:
-  [32m{\"a\": undefined}[39m
+  [32m{\\"a\\": undefined}[39m
 Received:
-  [31m{\"a\": undefined}[39m"
+  [31m{\\"a\\": undefined}[39m"
 `;
 
 exports[`toMatchObject() {pass: true} expect(2015-11-30T00:00:00.000Z).toMatchObject(2015-11-30T00:00:00.000Z) 1`] = `
@@ -3042,7 +3042,7 @@ exports[`toMatchObject() throws expect("44").toMatchObject({}) 1`] = `
 
 [31mreceived[39m value must be an object.
 Received:
-  string: [31m\"44\"[39m"
+  string: [31m\\"44\\"[39m"
 `;
 
 exports[`toMatchObject() throws expect({}).toMatchObject("some string") 1`] = `
@@ -3050,7 +3050,7 @@ exports[`toMatchObject() throws expect({}).toMatchObject("some string") 1`] = `
 
 [32mexpected[39m value must be an object.
 Expected:
-  string: [32m\"some string\"[39m"
+  string: [32m\\"some string\\"[39m"
 `;
 
 exports[`toMatchObject() throws expect({}).toMatchObject(4) 1`] = `

--- a/packages/jest-matchers/src/__tests__/__snapshots__/spyMatchers-test.js.snap
+++ b/packages/jest-matchers/src/__tests__/__snapshots__/spyMatchers-test.js.snap
@@ -10,32 +10,32 @@ exports[`test lastCalledWith works with jest.fn and arguments that don't match 1
 "[2mexpect([22m[31mjest.fn()[39m[2m).lastCalledWith([22m[32mexpected[39m[2m)[22m
 
 Expected mock function to have been last called with:
-  [32m[\"foo\", \"bar\"][39m
+  [32m[\\"foo\\", \\"bar\\"][39m
 But it was last called with:
-  [31m[\"foo\", \"bar1\"][39m"
+  [31m[\\"foo\\", \\"bar1\\"][39m"
 `;
 
 exports[`test lastCalledWith works with jest.fn and arguments that match 1`] = `
 "[2mexpect([22m[31mjest.fn()[39m[2m).not.lastCalledWith([22m[32mexpected[39m[2m)[22m
 
 Expected mock function to not have been last called with:
-  [32m[\"foo\", \"bar\"][39m"
+  [32m[\\"foo\\", \\"bar\\"][39m"
 `;
 
 exports[`test lastCalledWith works with jest.fn and many arguments 1`] = `
 "[2mexpect([22m[31mjest.fn()[39m[2m).not.lastCalledWith([22m[32mexpected[39m[2m)[22m
 
 Expected mock function to not have been last called with:
-  [32m[\"foo\", \"bar\"][39m"
+  [32m[\\"foo\\", \\"bar\\"][39m"
 `;
 
 exports[`test lastCalledWith works with jest.fn and many arguments that don't match 1`] = `
 "[2mexpect([22m[31mjest.fn()[39m[2m).lastCalledWith([22m[32mexpected[39m[2m)[22m
 
 Expected mock function to have been last called with:
-  [32m[\"foo\", \"bar\"][39m
+  [32m[\\"foo\\", \\"bar\\"][39m
 But it was last called with:
-  [31m[\"foo\", \"bar3\"][39m
+  [31m[\\"foo\\", \\"bar3\\"][39m
 and [31mtwo more calls[39m."
 `;
 
@@ -43,7 +43,7 @@ exports[`test lastCalledWith works with jest.fn when not called 1`] = `
 "[2mexpect([22m[31mjest.fn()[39m[2m).lastCalledWith([22m[32mexpected[39m[2m)[22m
 
 Expected mock function to have been last called with:
-  [32m[\"foo\", \"bar\"][39m
+  [32m[\\"foo\\", \\"bar\\"][39m
 But it was [31mnot called[39m."
 `;
 
@@ -109,39 +109,39 @@ exports[`test toBeCalledWith works with jest.fn and arguments that don't match 1
 "[2mexpect([22m[31mjest.fn()[39m[2m).toBeCalledWith([22m[32mexpected[39m[2m)[22m
 
 Expected mock function to have been called with:
-  [32m[\"foo\", \"bar\"][39m
+  [32m[\\"foo\\", \\"bar\\"][39m
 But it was called with:
-  [31m[\"foo\", \"bar1\"][39m"
+  [31m[\\"foo\\", \\"bar1\\"][39m"
 `;
 
 exports[`test toBeCalledWith works with jest.fn and arguments that match 1`] = `
 "[2mexpect([22m[31mjest.fn()[39m[2m).not.toBeCalledWith([22m[32mexpected[39m[2m)[22m
 
 Expected mock function not to have been called with:
-  [32m[\"foo\", \"bar\"][39m"
+  [32m[\\"foo\\", \\"bar\\"][39m"
 `;
 
 exports[`test toBeCalledWith works with jest.fn and many arguments 1`] = `
 "[2mexpect([22m[31mjest.fn()[39m[2m).not.toBeCalledWith([22m[32mexpected[39m[2m)[22m
 
 Expected mock function not to have been called with:
-  [32m[\"foo\", \"bar\"][39m"
+  [32m[\\"foo\\", \\"bar\\"][39m"
 `;
 
 exports[`test toBeCalledWith works with jest.fn and many arguments that don't match 1`] = `
 "[2mexpect([22m[31mjest.fn()[39m[2m).toBeCalledWith([22m[32mexpected[39m[2m)[22m
 
 Expected mock function to have been called with:
-  [32m[\"foo\", \"bar\"][39m
+  [32m[\\"foo\\", \\"bar\\"][39m
 But it was called with:
-  [31m[\"foo\", \"bar3\"][39m, [31m[\"foo\", \"bar2\"][39m, [31m[\"foo\", \"bar1\"][39m"
+  [31m[\\"foo\\", \\"bar3\\"][39m, [31m[\\"foo\\", \\"bar2\\"][39m, [31m[\\"foo\\", \\"bar1\\"][39m"
 `;
 
 exports[`test toBeCalledWith works with jest.fn when not called 1`] = `
 "[2mexpect([22m[31mjest.fn()[39m[2m).toBeCalledWith([22m[32mexpected[39m[2m)[22m
 
 Expected mock function to have been called with:
-  [32m[\"foo\", \"bar\"][39m
+  [32m[\\"foo\\", \\"bar\\"][39m
 But it was [31mnot called[39m."
 `;
 
@@ -207,39 +207,39 @@ exports[`test toHaveBeenCalledWith works with jasmine.createSpy and arguments th
 "[2mexpect([22m[31mspy[39m[2m).toHaveBeenCalledWith([22m[32mexpected[39m[2m)[22m
 
 Expected spy to have been called with:
-  [32m[\"foo\", \"bar\"][39m
+  [32m[\\"foo\\", \\"bar\\"][39m
 But it was called with:
-  [31m[\"foo\", \"bar1\"][39m"
+  [31m[\\"foo\\", \\"bar1\\"][39m"
 `;
 
 exports[`test toHaveBeenCalledWith works with jasmine.createSpy and arguments that match 1`] = `
 "[2mexpect([22m[31mspy[39m[2m).not.toHaveBeenCalledWith([22m[32mexpected[39m[2m)[22m
 
 Expected spy not to have been called with:
-  [32m[\"foo\", \"bar\"][39m"
+  [32m[\\"foo\\", \\"bar\\"][39m"
 `;
 
 exports[`test toHaveBeenCalledWith works with jasmine.createSpy and many arguments 1`] = `
 "[2mexpect([22m[31mspy[39m[2m).not.toHaveBeenCalledWith([22m[32mexpected[39m[2m)[22m
 
 Expected spy not to have been called with:
-  [32m[\"foo\", \"bar\"][39m"
+  [32m[\\"foo\\", \\"bar\\"][39m"
 `;
 
 exports[`test toHaveBeenCalledWith works with jasmine.createSpy and many arguments that don't match 1`] = `
 "[2mexpect([22m[31mspy[39m[2m).toHaveBeenCalledWith([22m[32mexpected[39m[2m)[22m
 
 Expected spy to have been called with:
-  [32m[\"foo\", \"bar\"][39m
+  [32m[\\"foo\\", \\"bar\\"][39m
 But it was called with:
-  [31m[\"foo\", \"bar3\"][39m, [31m[\"foo\", \"bar2\"][39m, [31m[\"foo\", \"bar1\"][39m"
+  [31m[\\"foo\\", \\"bar3\\"][39m, [31m[\\"foo\\", \\"bar2\\"][39m, [31m[\\"foo\\", \\"bar1\\"][39m"
 `;
 
 exports[`test toHaveBeenCalledWith works with jasmine.createSpy when not called 1`] = `
 "[2mexpect([22m[31mspy[39m[2m).toHaveBeenCalledWith([22m[32mexpected[39m[2m)[22m
 
 Expected spy to have been called with:
-  [32m[\"foo\", \"bar\"][39m
+  [32m[\\"foo\\", \\"bar\\"][39m
 But it was [31mnot called[39m."
 `;
 
@@ -247,39 +247,39 @@ exports[`test toHaveBeenCalledWith works with jest.fn and arguments that don't m
 "[2mexpect([22m[31mjest.fn()[39m[2m).toHaveBeenCalledWith([22m[32mexpected[39m[2m)[22m
 
 Expected mock function to have been called with:
-  [32m[\"foo\", \"bar\"][39m
+  [32m[\\"foo\\", \\"bar\\"][39m
 But it was called with:
-  [31m[\"foo\", \"bar1\"][39m"
+  [31m[\\"foo\\", \\"bar1\\"][39m"
 `;
 
 exports[`test toHaveBeenCalledWith works with jest.fn and arguments that match 1`] = `
 "[2mexpect([22m[31mjest.fn()[39m[2m).not.toHaveBeenCalledWith([22m[32mexpected[39m[2m)[22m
 
 Expected mock function not to have been called with:
-  [32m[\"foo\", \"bar\"][39m"
+  [32m[\\"foo\\", \\"bar\\"][39m"
 `;
 
 exports[`test toHaveBeenCalledWith works with jest.fn and many arguments 1`] = `
 "[2mexpect([22m[31mjest.fn()[39m[2m).not.toHaveBeenCalledWith([22m[32mexpected[39m[2m)[22m
 
 Expected mock function not to have been called with:
-  [32m[\"foo\", \"bar\"][39m"
+  [32m[\\"foo\\", \\"bar\\"][39m"
 `;
 
 exports[`test toHaveBeenCalledWith works with jest.fn and many arguments that don't match 1`] = `
 "[2mexpect([22m[31mjest.fn()[39m[2m).toHaveBeenCalledWith([22m[32mexpected[39m[2m)[22m
 
 Expected mock function to have been called with:
-  [32m[\"foo\", \"bar\"][39m
+  [32m[\\"foo\\", \\"bar\\"][39m
 But it was called with:
-  [31m[\"foo\", \"bar3\"][39m, [31m[\"foo\", \"bar2\"][39m, [31m[\"foo\", \"bar1\"][39m"
+  [31m[\\"foo\\", \\"bar3\\"][39m, [31m[\\"foo\\", \\"bar2\\"][39m, [31m[\\"foo\\", \\"bar1\\"][39m"
 `;
 
 exports[`test toHaveBeenCalledWith works with jest.fn when not called 1`] = `
 "[2mexpect([22m[31mjest.fn()[39m[2m).toHaveBeenCalledWith([22m[32mexpected[39m[2m)[22m
 
 Expected mock function to have been called with:
-  [32m[\"foo\", \"bar\"][39m
+  [32m[\\"foo\\", \\"bar\\"][39m
 But it was [31mnot called[39m."
 `;
 
@@ -295,32 +295,32 @@ exports[`test toHaveBeenLastCalledWith works with jasmine.createSpy and argument
 "[2mexpect([22m[31mspy[39m[2m).toHaveBeenLastCalledWith([22m[32mexpected[39m[2m)[22m
 
 Expected spy to have been last called with:
-  [32m[\"foo\", \"bar\"][39m
+  [32m[\\"foo\\", \\"bar\\"][39m
 But it was last called with:
-  [31m[\"foo\", \"bar1\"][39m"
+  [31m[\\"foo\\", \\"bar1\\"][39m"
 `;
 
 exports[`test toHaveBeenLastCalledWith works with jasmine.createSpy and arguments that match 1`] = `
 "[2mexpect([22m[31mspy[39m[2m).not.toHaveBeenLastCalledWith([22m[32mexpected[39m[2m)[22m
 
 Expected spy to not have been last called with:
-  [32m[\"foo\", \"bar\"][39m"
+  [32m[\\"foo\\", \\"bar\\"][39m"
 `;
 
 exports[`test toHaveBeenLastCalledWith works with jasmine.createSpy and many arguments 1`] = `
 "[2mexpect([22m[31mspy[39m[2m).not.toHaveBeenLastCalledWith([22m[32mexpected[39m[2m)[22m
 
 Expected spy to not have been last called with:
-  [32m[\"foo\", \"bar\"][39m"
+  [32m[\\"foo\\", \\"bar\\"][39m"
 `;
 
 exports[`test toHaveBeenLastCalledWith works with jasmine.createSpy and many arguments that don't match 1`] = `
 "[2mexpect([22m[31mspy[39m[2m).toHaveBeenLastCalledWith([22m[32mexpected[39m[2m)[22m
 
 Expected spy to have been last called with:
-  [32m[\"foo\", \"bar\"][39m
+  [32m[\\"foo\\", \\"bar\\"][39m
 But it was last called with:
-  [31m[\"foo\", \"bar3\"][39m
+  [31m[\\"foo\\", \\"bar3\\"][39m
 and [31mtwo more calls[39m."
 `;
 
@@ -328,7 +328,7 @@ exports[`test toHaveBeenLastCalledWith works with jasmine.createSpy when not cal
 "[2mexpect([22m[31mspy[39m[2m).toHaveBeenLastCalledWith([22m[32mexpected[39m[2m)[22m
 
 Expected spy to have been last called with:
-  [32m[\"foo\", \"bar\"][39m
+  [32m[\\"foo\\", \\"bar\\"][39m
 But it was [31mnot called[39m."
 `;
 
@@ -336,32 +336,32 @@ exports[`test toHaveBeenLastCalledWith works with jest.fn and arguments that don
 "[2mexpect([22m[31mjest.fn()[39m[2m).toHaveBeenLastCalledWith([22m[32mexpected[39m[2m)[22m
 
 Expected mock function to have been last called with:
-  [32m[\"foo\", \"bar\"][39m
+  [32m[\\"foo\\", \\"bar\\"][39m
 But it was last called with:
-  [31m[\"foo\", \"bar1\"][39m"
+  [31m[\\"foo\\", \\"bar1\\"][39m"
 `;
 
 exports[`test toHaveBeenLastCalledWith works with jest.fn and arguments that match 1`] = `
 "[2mexpect([22m[31mjest.fn()[39m[2m).not.toHaveBeenLastCalledWith([22m[32mexpected[39m[2m)[22m
 
 Expected mock function to not have been last called with:
-  [32m[\"foo\", \"bar\"][39m"
+  [32m[\\"foo\\", \\"bar\\"][39m"
 `;
 
 exports[`test toHaveBeenLastCalledWith works with jest.fn and many arguments 1`] = `
 "[2mexpect([22m[31mjest.fn()[39m[2m).not.toHaveBeenLastCalledWith([22m[32mexpected[39m[2m)[22m
 
 Expected mock function to not have been last called with:
-  [32m[\"foo\", \"bar\"][39m"
+  [32m[\\"foo\\", \\"bar\\"][39m"
 `;
 
 exports[`test toHaveBeenLastCalledWith works with jest.fn and many arguments that don't match 1`] = `
 "[2mexpect([22m[31mjest.fn()[39m[2m).toHaveBeenLastCalledWith([22m[32mexpected[39m[2m)[22m
 
 Expected mock function to have been last called with:
-  [32m[\"foo\", \"bar\"][39m
+  [32m[\\"foo\\", \\"bar\\"][39m
 But it was last called with:
-  [31m[\"foo\", \"bar3\"][39m
+  [31m[\\"foo\\", \\"bar3\\"][39m
 and [31mtwo more calls[39m."
 `;
 
@@ -369,7 +369,7 @@ exports[`test toHaveBeenLastCalledWith works with jest.fn when not called 1`] = 
 "[2mexpect([22m[31mjest.fn()[39m[2m).toHaveBeenLastCalledWith([22m[32mexpected[39m[2m)[22m
 
 Expected mock function to have been last called with:
-  [32m[\"foo\", \"bar\"][39m
+  [32m[\\"foo\\", \\"bar\\"][39m
 But it was [31mnot called[39m."
 `;
 
@@ -402,7 +402,7 @@ exports[`toHaveBeenCalledTimes accepts only numbers 4`] = `
 
 Expected value must be a number.
 Got:
-  string: [32m\"a\"[39m"
+  string: [32m\\"a\\"[39m"
 `;
 
 exports[`toHaveBeenCalledTimes accepts only numbers 5`] = `

--- a/packages/jest-matchers/src/__tests__/__snapshots__/toThrowMatchers-test.js.snap
+++ b/packages/jest-matchers/src/__tests__/__snapshots__/toThrowMatchers-test.js.snap
@@ -2,15 +2,15 @@ exports[`.toThrow() error class did not throw at all 1`] = `
 "[2mexpect([22m[31mfunction[39m[2m).toThrow([22m[32mtype[39m[2m)[22m
 
 Expected the function to throw an error of type:
-  [32m\"Err\"[39m
-But it didn\'t throw anything."
+  [32m\\"Err\\"[39m
+But it didn't throw anything."
 `;
 
 exports[`.toThrow() error class threw, but class did not match 1`] = `
 "[2mexpect([22m[31mfunction[39m[2m).toThrow([22m[32mtype[39m[2m)[22m
 
 Expected the function to throw an error of type:
-  [32m\"Err2\"[39m
+  [32m\\"Err2\\"[39m
 Instead, it threw:
 [31m  Error      
       [2mat jestExpect ([22mpackages/jest-matchers/src/__tests__/toThrowMatchers-test.js[2m:24:74)[22m[39m"
@@ -20,7 +20,7 @@ exports[`.toThrow() error class threw, but should not have 1`] = `
 "[2mexpect([22m[31mfunction[39m[2m).not.toThrow([22m[32mtype[39m[2m)[22m
 
 Expected the function not to throw an error of type:
-  [32m\"Err\"[39m
+  [32m\\"Err\\"[39m
 Instead, it threw:
 [31m  Error      
       [2mat jestExpect ([22mpackages/jest-matchers/src/__tests__/toThrowMatchers-test.js[2m:24:74)[22m[39m"
@@ -30,9 +30,9 @@ exports[`.toThrow() invalid arguments 1`] = `
 "[2mexpect([22m[31mfunction[39m[2m).not.toThrow([22m[32mnumber[39m[2m)[22m
 
 Unexpected argument passed.
-Expected: [32m\"string\"[39m, [32m\"Error (type)\"[39m or [32m\"regexp\"[39m.
+Expected: [32m\\"string\\"[39m, [32m\\"Error (type)\\"[39m or [32m\\"regexp\\"[39m.
 Got:
-  string: [32m\"111\"[39m"
+  string: [32m\\"111\\"[39m"
 `;
 
 exports[`.toThrow() regexp did not throw at all 1`] = `
@@ -40,7 +40,7 @@ exports[`.toThrow() regexp did not throw at all 1`] = `
 
 Expected the function to throw an error matching:
   [32m/apple/[39m
-But it didn\'t throw anything."
+But it didn't throw anything."
 `;
 
 exports[`.toThrow() regexp threw, but message did not match 1`] = `
@@ -67,15 +67,15 @@ exports[`.toThrow() strings did not throw at all 1`] = `
 "[2mexpect([22m[31mfunction[39m[2m).toThrow([22m[32mstring[39m[2m)[22m
 
 Expected the function to throw an error matching:
-  [32m\"apple\"[39m
-But it didn\'t throw anything."
+  [32m\\"apple\\"[39m
+But it didn't throw anything."
 `;
 
 exports[`.toThrow() strings threw, but message did not match 1`] = `
 "[2mexpect([22m[31mfunction[39m[2m).toThrow([22m[32mstring[39m[2m)[22m
 
 Expected the function to throw an error matching:
-  [32m\"banana\"[39m
+  [32m\\"banana\\"[39m
 Instead, it threw:
 [31m  Error      
       [2mat jestExpect ([22mpackages/jest-matchers/src/__tests__/toThrowMatchers-test.js[2m:24:74)[22m[39m"
@@ -85,7 +85,7 @@ exports[`.toThrow() strings threw, but should not have 1`] = `
 "[2mexpect([22m[31mfunction[39m[2m).not.toThrow([22m[32mstring[39m[2m)[22m
 
 Expected the function not to throw an error matching:
-  [32m\"apple\"[39m
+  [32m\\"apple\\"[39m
 Instead, it threw:
 [31m  Error      
       [2mat jestExpect ([22mpackages/jest-matchers/src/__tests__/toThrowMatchers-test.js[2m:24:74)[22m[39m"
@@ -95,15 +95,15 @@ exports[`.toThrowError() error class did not throw at all 1`] = `
 "[2mexpect([22m[31mfunction[39m[2m).toThrowError([22m[32mtype[39m[2m)[22m
 
 Expected the function to throw an error of type:
-  [32m\"Err\"[39m
-But it didn\'t throw anything."
+  [32m\\"Err\\"[39m
+But it didn't throw anything."
 `;
 
 exports[`.toThrowError() error class threw, but class did not match 1`] = `
 "[2mexpect([22m[31mfunction[39m[2m).toThrowError([22m[32mtype[39m[2m)[22m
 
 Expected the function to throw an error of type:
-  [32m\"Err2\"[39m
+  [32m\\"Err2\\"[39m
 Instead, it threw:
 [31m  Error      
       [2mat jestExpect ([22mpackages/jest-matchers/src/__tests__/toThrowMatchers-test.js[2m:24:74)[22m[39m"
@@ -113,7 +113,7 @@ exports[`.toThrowError() error class threw, but should not have 1`] = `
 "[2mexpect([22m[31mfunction[39m[2m).not.toThrowError([22m[32mtype[39m[2m)[22m
 
 Expected the function not to throw an error of type:
-  [32m\"Err\"[39m
+  [32m\\"Err\\"[39m
 Instead, it threw:
 [31m  Error      
       [2mat jestExpect ([22mpackages/jest-matchers/src/__tests__/toThrowMatchers-test.js[2m:24:74)[22m[39m"
@@ -123,9 +123,9 @@ exports[`.toThrowError() invalid arguments 1`] = `
 "[2mexpect([22m[31mfunction[39m[2m).not.toThrowError([22m[32mnumber[39m[2m)[22m
 
 Unexpected argument passed.
-Expected: [32m\"string\"[39m, [32m\"Error (type)\"[39m or [32m\"regexp\"[39m.
+Expected: [32m\\"string\\"[39m, [32m\\"Error (type)\\"[39m or [32m\\"regexp\\"[39m.
 Got:
-  string: [32m\"111\"[39m"
+  string: [32m\\"111\\"[39m"
 `;
 
 exports[`.toThrowError() regexp did not throw at all 1`] = `
@@ -133,7 +133,7 @@ exports[`.toThrowError() regexp did not throw at all 1`] = `
 
 Expected the function to throw an error matching:
   [32m/apple/[39m
-But it didn\'t throw anything."
+But it didn't throw anything."
 `;
 
 exports[`.toThrowError() regexp threw, but message did not match 1`] = `
@@ -160,15 +160,15 @@ exports[`.toThrowError() strings did not throw at all 1`] = `
 "[2mexpect([22m[31mfunction[39m[2m).toThrowError([22m[32mstring[39m[2m)[22m
 
 Expected the function to throw an error matching:
-  [32m\"apple\"[39m
-But it didn\'t throw anything."
+  [32m\\"apple\\"[39m
+But it didn't throw anything."
 `;
 
 exports[`.toThrowError() strings threw, but message did not match 1`] = `
 "[2mexpect([22m[31mfunction[39m[2m).toThrowError([22m[32mstring[39m[2m)[22m
 
 Expected the function to throw an error matching:
-  [32m\"banana\"[39m
+  [32m\\"banana\\"[39m
 Instead, it threw:
 [31m  Error      
       [2mat jestExpect ([22mpackages/jest-matchers/src/__tests__/toThrowMatchers-test.js[2m:24:74)[22m[39m"
@@ -178,7 +178,7 @@ exports[`.toThrowError() strings threw, but should not have 1`] = `
 "[2mexpect([22m[31mfunction[39m[2m).not.toThrowError([22m[32mstring[39m[2m)[22m
 
 Expected the function not to throw an error matching:
-  [32m\"apple\"[39m
+  [32m\\"apple\\"[39m
 Instead, it threw:
 [31m  Error      
       [2mat jestExpect ([22mpackages/jest-matchers/src/__tests__/toThrowMatchers-test.js[2m:24:74)[22m[39m"

--- a/packages/jest-runtime/src/__tests__/__snapshots__/transform-test.js.snap
+++ b/packages/jest-runtime/src/__tests__/__snapshots__/transform-test.js.snap
@@ -1,26 +1,26 @@
 exports[`transform transforms a file properly 1`] = `
-"({\"Object.<anonymous>\":function(module,exports,require,__dirname,__filename,global,jest){/* istanbul ignore next */var cov_25u22311x4 = function () {var path = \"/fruits/banana.js\",hash = \"04636d4ae73b4b3e24bf6fba39e08c946fd0afb5\",global = new Function(\'return this\')(),gcv = \"__coverage__\",coverageData = { path: \"/fruits/banana.js\", statementMap: { \"0\": { start: { line: 1, column: 0 }, end: { line: 1, column: 26 } } }, fnMap: {}, branchMap: {}, s: { \"0\": 0 }, f: {}, b: {}, _coverageSchema: \"332fd63041d2c1bcb487cc26dd0d5f7d97098a6c\" },coverage = global[gcv] || (global[gcv] = {});if (coverage[path] && coverage[path].hash === hash) {return coverage[path];}coverageData.hash = hash;return coverage[path] = coverageData;}();++cov_25u22311x4.s[0];module.exports = \"banana\";
+"({\\"Object.<anonymous>\\":function(module,exports,require,__dirname,__filename,global,jest){/* istanbul ignore next */var cov_25u22311x4 = function () {var path = \\"/fruits/banana.js\\",hash = \\"04636d4ae73b4b3e24bf6fba39e08c946fd0afb5\\",global = new Function('return this')(),gcv = \\"__coverage__\\",coverageData = { path: \\"/fruits/banana.js\\", statementMap: { \\"0\\": { start: { line: 1, column: 0 }, end: { line: 1, column: 26 } } }, fnMap: {}, branchMap: {}, s: { \\"0\\": 0 }, f: {}, b: {}, _coverageSchema: \\"332fd63041d2c1bcb487cc26dd0d5f7d97098a6c\\" },coverage = global[gcv] || (global[gcv] = {});if (coverage[path] && coverage[path].hash === hash) {return coverage[path];}coverageData.hash = hash;return coverage[path] = coverageData;}();++cov_25u22311x4.s[0];module.exports = \\"banana\\";
 }});"
 `;
 
 exports[`transform transforms a file properly 2`] = `
-"({\"Object.<anonymous>\":function(module,exports,require,__dirname,__filename,global,jest){/* istanbul ignore next */var cov_23yvu8etmu = function () {var path = \"/fruits/kiwi.js\",hash = \"fd689b0dc8cb036f0f2381fc209940f4138ade51\",global = new Function(\'return this\')(),gcv = \"__coverage__\",coverageData = { path: \"/fruits/kiwi.js\", statementMap: { \"0\": { start: { line: 1, column: 0 }, end: { line: 1, column: 30 } }, \"1\": { start: { line: 1, column: 23 }, end: { line: 1, column: 29 } } }, fnMap: { \"0\": { name: \"(anonymous_0)\", decl: { start: { line: 1, column: 17 }, end: { line: 1, column: 18 } }, loc: { start: { line: 1, column: 23 }, end: { line: 1, column: 29 } } } }, branchMap: {}, s: { \"0\": 0, \"1\": 0 }, f: { \"0\": 0 }, b: {}, _coverageSchema: \"332fd63041d2c1bcb487cc26dd0d5f7d97098a6c\" },coverage = global[gcv] || (global[gcv] = {});if (coverage[path] && coverage[path].hash === hash) {return coverage[path];}coverageData.hash = hash;return coverage[path] = coverageData;}();++cov_23yvu8etmu.s[0];module.exports = () => {/* istanbul ignore next */++cov_23yvu8etmu.f[0];++cov_23yvu8etmu.s[1];return \"kiwi\";};
+"({\\"Object.<anonymous>\\":function(module,exports,require,__dirname,__filename,global,jest){/* istanbul ignore next */var cov_23yvu8etmu = function () {var path = \\"/fruits/kiwi.js\\",hash = \\"fd689b0dc8cb036f0f2381fc209940f4138ade51\\",global = new Function('return this')(),gcv = \\"__coverage__\\",coverageData = { path: \\"/fruits/kiwi.js\\", statementMap: { \\"0\\": { start: { line: 1, column: 0 }, end: { line: 1, column: 30 } }, \\"1\\": { start: { line: 1, column: 23 }, end: { line: 1, column: 29 } } }, fnMap: { \\"0\\": { name: \\"(anonymous_0)\\", decl: { start: { line: 1, column: 17 }, end: { line: 1, column: 18 } }, loc: { start: { line: 1, column: 23 }, end: { line: 1, column: 29 } } } }, branchMap: {}, s: { \\"0\\": 0, \\"1\\": 0 }, f: { \\"0\\": 0 }, b: {}, _coverageSchema: \\"332fd63041d2c1bcb487cc26dd0d5f7d97098a6c\\" },coverage = global[gcv] || (global[gcv] = {});if (coverage[path] && coverage[path].hash === hash) {return coverage[path];}coverageData.hash = hash;return coverage[path] = coverageData;}();++cov_23yvu8etmu.s[0];module.exports = () => {/* istanbul ignore next */++cov_23yvu8etmu.f[0];++cov_23yvu8etmu.s[1];return \\"kiwi\\";};
 }});"
 `;
 
 exports[`transform uses multiple preprocessors 1`] = `
-"({\"Object.<anonymous>\":function(module,exports,require,__dirname,__filename,global,jest){
+"({\\"Object.<anonymous>\\":function(module,exports,require,__dirname,__filename,global,jest){
           const TRANSFORMED = {
-            filename: \'/fruits/banana.js\',
-            script: \'module.exports = \"banana\";\',
-            config: \'{\"cache\":true,\"cacheDirectory\":\"/cache/\",\"name\":\"test\",\"rootDir\":\"/\",\"transformIgnorePatterns\":[\"/node_modules/\"],\"transform\":[[\"^.+\\\\.js$\",\"test-preprocessor\"],[\"^.+\\\\.css$\",\"css-preprocessor\"]]}\',
+            filename: '/fruits/banana.js',
+            script: 'module.exports = \\"banana\\";',
+            config: '{\\"cache\\":true,\\"cacheDirectory\\":\\"/cache/\\",\\"name\\":\\"test\\",\\"rootDir\\":\\"/\\",\\"transformIgnorePatterns\\":[\\"/node_modules/\\"],\\"transform\\":[[\\"^.+\\\\\\\\.js$\\",\\"test-preprocessor\\"],[\\"^.+\\\\\\\\.css$\\",\\"css-preprocessor\\"]]}',
           };
         
 }});"
 `;
 
 exports[`transform uses multiple preprocessors 2`] = `
-"({\"Object.<anonymous>\":function(module,exports,require,__dirname,__filename,global,jest){
+"({\\"Object.<anonymous>\\":function(module,exports,require,__dirname,__filename,global,jest){
           module.exports = {
             filename: /styles/App.css,
             rawFirstLine: root {,
@@ -30,22 +30,22 @@ exports[`transform uses multiple preprocessors 2`] = `
 `;
 
 exports[`transform uses multiple preprocessors 3`] = `
-"({\"Object.<anonymous>\":function(module,exports,require,__dirname,__filename,global,jest){module.exports = \"react\";
+"({\\"Object.<anonymous>\\":function(module,exports,require,__dirname,__filename,global,jest){module.exports = \\"react\\";
 }});"
 `;
 
 exports[`transform uses the supplied preprocessor 1`] = `
-"({\"Object.<anonymous>\":function(module,exports,require,__dirname,__filename,global,jest){
+"({\\"Object.<anonymous>\\":function(module,exports,require,__dirname,__filename,global,jest){
           const TRANSFORMED = {
-            filename: \'/fruits/banana.js\',
-            script: \'module.exports = \"banana\";\',
-            config: \'{\"cache\":true,\"cacheDirectory\":\"/cache/\",\"name\":\"test\",\"rootDir\":\"/\",\"transformIgnorePatterns\":[\"/node_modules/\"],\"transform\":[[\"^.+\\\\.js$\",\"test-preprocessor\"]]}\',
+            filename: '/fruits/banana.js',
+            script: 'module.exports = \\"banana\\";',
+            config: '{\\"cache\\":true,\\"cacheDirectory\\":\\"/cache/\\",\\"name\\":\\"test\\",\\"rootDir\\":\\"/\\",\\"transformIgnorePatterns\\":[\\"/node_modules/\\"],\\"transform\\":[[\\"^.+\\\\\\\\.js$\\",\\"test-preprocessor\\"]]}',
           };
         
 }});"
 `;
 
 exports[`transform uses the supplied preprocessor 2`] = `
-"({\"Object.<anonymous>\":function(module,exports,require,__dirname,__filename,global,jest){module.exports = \"react\";
+"({\\"Object.<anonymous>\\":function(module,exports,require,__dirname,__filename,global,jest){module.exports = \\"react\\";
 }});"
 `;

--- a/packages/jest-snapshot/src/State.js
+++ b/packages/jest-snapshot/src/State.js
@@ -19,7 +19,6 @@ const {
   keyToTestName,
   serialize,
   testNameToKey,
-  unescape,
 } = require('./utils');
 const fileExists = require('jest-file-exists');
 const fs = require('fs');
@@ -119,9 +118,8 @@ class SnapshotState {
     this._uncheckedKeys.delete(key);
 
     const receivedSerialized = serialize(received);
-    const receivedUnescaped = unescape(receivedSerialized);
     const expected = this._snapshotData[key];
-    const pass = expected === receivedUnescaped;
+    const pass = expected === receivedSerialized;
     const hasSnapshot = this._snapshotData[key] !== undefined;
 
     if (pass) {
@@ -160,7 +158,7 @@ class SnapshotState {
       if (!pass) {
         this.unmatched++;
         return {
-          actual: receivedUnescaped,
+          actual: receivedSerialized,
           count,
           expected,
           pass: false,

--- a/packages/jest-snapshot/src/__tests__/utils-test.js
+++ b/packages/jest-snapshot/src/__tests__/utils-test.js
@@ -44,10 +44,26 @@ test('getSnapshotPath()', () => {
 test('saveSnapshotFile()', () => {
   const filename = path.join(__dirname, 'remove-newlines.snap');
   const data = {
-    myKey: '<div>\r\n</div>', 
+    myKey: '<div>\r\n</div>',
   };
 
   saveSnapshotFile(data, filename);
   expect(fs.writeFileSync)
     .toBeCalledWith(filename, 'exports[`myKey`] = `<div>\n</div>`;\n');
+});
+
+test('escaping', () => {
+  const filename = path.join(__dirname, 'escaping.snap');
+  const data = '"\'\\';
+  saveSnapshotFile({key: data}, filename);
+  const writtenData = fs.writeFileSync.mock.calls[0][1];
+  expect(writtenData).toBe("exports[`key`] = `\"'\\\\`;\n");
+
+  // eslint-disable-next-line no-unused-vars
+  const exports = {};
+  // eslint-disable-next-line no-eval
+  const readData = eval('var exports = {}; ' + writtenData + ' exports');
+  expect(readData).toEqual({key: data});
+  const snapshotData = readData.key;
+  expect(data).toEqual(snapshotData);
 });

--- a/packages/jest-snapshot/src/utils.js
+++ b/packages/jest-snapshot/src/utils.js
@@ -66,8 +66,9 @@ const serialize = (data: any): string => {
   }));
 };
 
-const escape = (string: string) => string.replace(/(\`|\${)/g, '\\$1');
-const unescape = (string: string) => string.replace(/\\(\"|\\|\'|\${)/g, '$1');
+const printBacktickString = (str: string) => {
+  return '`' + str.replace(/`|\\|\${/g, '\\$&') + '`';
+};
 
 const ensureDirectoryExists = (filePath: Path) => {
   try {
@@ -84,8 +85,8 @@ const saveSnapshotFile = (
 ) => {
   const snapshots = Object.keys(snapshotData).sort(naturalCompare)
     .map(key =>
-      'exports[`' + escape(key) + '`] = `' +
-      normalizeNewlines(escape(snapshotData[key])) + '`;',
+      'exports[' + printBacktickString(key) + '] = ' +
+        printBacktickString(normalizeNewlines(snapshotData[key])) + ';',
     );
 
   ensureDirectoryExists(snapshotPath);
@@ -95,12 +96,10 @@ const saveSnapshotFile = (
 module.exports = {
   SNAPSHOT_EXTENSION,
   ensureDirectoryExists,
-  escape,
   getSnapshotData,
   getSnapshotPath,
   keyToTestName,
   saveSnapshotFile,
   serialize,
   testNameToKey,
-  unescape,
 };

--- a/packages/jest-util/src/__tests__/__snapshots__/FakeTimers-test.js.snap
+++ b/packages/jest-util/src/__tests__/__snapshots__/FakeTimers-test.js.snap
@@ -1,5 +1,5 @@
 exports[`FakeTimers runAllTimers warns when trying to advance timers while real timers are used 1`] = `
-"A function to advance timers was called but the timers API is not mocked with fake timers. Call \`jest.useFakeTimers()\` in this test or enable fake timers globally by setting \`\"timers\": \"fake\"\` in the configuration file. This warning is likely a result of a default configuration change in Jest 15.
+"A function to advance timers was called but the timers API is not mocked with fake timers. Call \`jest.useFakeTimers()\` in this test or enable fake timers globally by setting \`\\"timers\\": \\"fake\\"\` in the configuration file. This warning is likely a result of a default configuration change in Jest 15.
 
 Release Blog Post: https://facebook.github.io/jest/blog/2016/09/01/jest-15.html"
 `;

--- a/packages/jest-util/src/__tests__/__snapshots__/messages-test.js.snap
+++ b/packages/jest-util/src/__tests__/__snapshots__/messages-test.js.snap
@@ -1,9 +1,9 @@
 exports[`test should exclude jasmine from stack trace for windows paths 1`] = `
 "[1m[31m  [1m● [1mwindows test[39m[22m
 
-      at stack (..\\jest-jasmine2\\vendor\\jasmine-2.4.1.js:1580:17)
+      at stack (..\\\\jest-jasmine2\\\\vendor\\\\jasmine-2.4.1.js:1580:17)
 [2m      
-      [2mat Object.addResult ([2m..\\jest-jasmine2\\vendor\\jasmine-2.4.1.js[2m:1550:14)[2m
-      [2mat Object.it ([2mbuild\\__tests__\\messages-test.js[2m:45:41)[2m[22m
+      [2mat Object.addResult ([2m..\\\\jest-jasmine2\\\\vendor\\\\jasmine-2.4.1.js[2m:1550:14)[2m
+      [2mat Object.it ([2mbuild\\\\__tests__\\\\messages-test.js[2m:45:41)[2m[22m
 "
 `;

--- a/packages/pretty-format/src/__tests__/pretty-format-test.js
+++ b/packages/pretty-format/src/__tests__/pretty-format-test.js
@@ -227,6 +227,11 @@ describe('prettyFormat()', () => {
     expect(prettyFormat(val)).toEqual('"string"');
   });
 
+  it('prints and escape a string', () => {
+    const val = '"\'\\';
+    expect(prettyFormat(val)).toEqual('"\\"\'\\\\"');
+  });
+
   it('prints a string with escapes', () => {
     expect(prettyFormat('\"-\"'), '"\\"-\\""');
     expect(prettyFormat('\\ \\\\'), '"\\\\ \\\\\\\\"');
@@ -462,7 +467,7 @@ describe('prettyFormat()', () => {
           React.createElement('Mouse'),
           '\\ \\\\'
         ),
-        '<Mouse>\n  \\"-\\"\n  <Mouse />\n  \\\\ \\\\\\\\\n</Mouse>'
+        '<Mouse>\n  &quot;-&quot;\n  <Mouse />\n  \\ \\\\\n</Mouse>'
       );
     });
 

--- a/packages/pretty-format/src/index.js
+++ b/packages/pretty-format/src/index.js
@@ -10,7 +10,6 @@
 'use strict';
 
 const style = require('ansi-styles');
-const printString = require('./printString');
 
 const toString = Object.prototype.toString;
 const toISOString = Date.prototype.toISOString;
@@ -83,7 +82,7 @@ function printBasicValue(val, printFunctionName, escapeRegex) {
     return printNumber(val);
   }
   if (typeOf === 'string') {
-    return '"' + printString(val) + '"';
+    return '"' + val.replace(/"|\\/g, '\\$&') + '"';
   }
   if (typeOf === 'function') {
     return printFunction(val, printFunctionName);
@@ -114,7 +113,8 @@ function printBasicValue(val, printFunctionName, escapeRegex) {
   }
   if (toStringed === '[object RegExp]') {
     if (escapeRegex) {
-      return printString(regExpToString.call(val));
+      // https://github.com/benjamingr/RegExp.escape/blob/master/polyfill.js
+      return regExpToString.call(val).replace(/[\\^$*+?.()|[\]{}]/g, '\\$&');
     }
     return regExpToString.call(val);
   }

--- a/packages/pretty-format/src/plugins/ReactElement.js
+++ b/packages/pretty-format/src/plugins/ReactElement.js
@@ -8,7 +8,7 @@
 /* eslint-disable max-len */
 'use strict';
 
-const printString = require('../printString');
+const escapeHTML = require('./escapeHTML');
 
 const reactElement = Symbol.for('react.element');
 
@@ -25,7 +25,7 @@ function printChildren(flatChildren, print, indent, colors, opts) {
     if (typeof node === 'object') {
       return printElement(node, print, indent, colors, opts);
     } else if (typeof node === 'string') {
-      return printString(colors.content.open + node + colors.content.close);
+      return colors.content.open + escapeHTML(node) + colors.content.close;
     } else {
       return print(node);
     }

--- a/packages/pretty-format/src/plugins/ReactTestComponent.js
+++ b/packages/pretty-format/src/plugins/ReactTestComponent.js
@@ -8,7 +8,7 @@
 /* eslint-disable max-len */
 'use strict';
 
-const printString = require('../printString');
+const escapeHTML = require('./escapeHTML');
 
 const reactTestInstance = Symbol.for('react.test.json');
 
@@ -37,7 +37,7 @@ function printInstance(instance, print, indent, colors, opts) {
   if (typeof instance == 'number') {
     return print(instance);
   } else if (typeof instance === 'string') {
-    return printString(colors.content.open + instance + colors.content.close);
+    return colors.content.open + escapeHTML(instance) + colors.content.close;
   }
 
   let result = colors.tag.open + '<' + instance.type + colors.tag.close;

--- a/packages/pretty-format/src/plugins/escapeHTML.js
+++ b/packages/pretty-format/src/plugins/escapeHTML.js
@@ -4,10 +4,18 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
  */
-
 'use strict';
 
-const ESCAPED_CHARACTERS = /(\\|\"|\')/g;
+function escapeHTML(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
 
-module.exports = val => val.replace(ESCAPED_CHARACTERS, '\\$1');
+module.exports = escapeHTML;


### PR DESCRIPTION
There were many issues with snapshot test escaping:
 - When escaping backtick, it didn't escape backslash
 - Double quote escaping was overzealous and also escaped single quotes
 - JSX text didn't use HTML escaping
 - Regex escaping didn't escape all the control characters that should be

Because of the first one, you couldn't do eval(snapshot) and get the correct value, in order to make it kind of work, an unescape function was created that did ... something. Now that escaping is done properly we don't need it anymore.

This is a breaking change as all the double quotes now need to be escaped which triggers a ton of failures.

Fixes #1789