### PR TITLE
Enable manual mocks with nested folders

### DIFF
--- a/packages/jest-haste-map/src/__tests__/__snapshots__/index-test.js.snap
+++ b/packages/jest-haste-map/src/__tests__/__snapshots__/index-test.js.snap
@@ -14,14 +14,14 @@ exports[`HasteMap tries to crawl using node as a fallback 1`] = `
 
 exports[`HasteMap warns on duplicate mock files 1`] = `
 "jest-haste-map: duplicate manual mock found:
-  Module name: blueberry
-  Duplicate Mock path: /fruits/__mocks__/subdir2/blueberry.js
+  Module name: subdir/blueberry
+  Duplicate Mock path: /fruits2/__mocks__/subdir/blueberry.js
 This warning is caused by two manual mock files with the same file name.
 Jest will use the mock file found in: 
-/fruits/__mocks__/subdir2/blueberry.js
+/fruits2/__mocks__/subdir/blueberry.js
  Please delete one of the following two files: 
- /fruits/__mocks__/subdir1/blueberry.js
-/fruits/__mocks__/subdir2/blueberry.js
+ /fruits1/__mocks__/subdir/blueberry.js
+/fruits2/__mocks__/subdir/blueberry.js
 
 "
 `;

--- a/packages/jest-haste-map/src/__tests__/getMockName-test.js
+++ b/packages/jest-haste-map/src/__tests__/getMockName-test.js
@@ -4,19 +4,11 @@ const getMockName = require('../getMockName');
 describe('getMockName', () => {
   it('extracts mock name from file path', () => {
     expect(
-      getMockName(path.join('a', '__b__', 'c.js'), /__b__/)
+      getMockName(path.join('a', '__mocks__', 'c.js'))
     ).toBe('c');
 
     expect(
-      getMockName(path.join('a', '__b__', 'index.js'), /__b__/)
-    ).toBe('index');
-
-    expect(
-      getMockName(path.join('a', '__b__', 'c', 'd.js'), /__b__/)
-    ).toBe(path.join('c', 'd'));
-
-    expect(
-      getMockName(path.join('a', '__b__', 'c', 'd', 'index.js'), /__b__/)
+      getMockName(path.join('a', '__mocks__', 'c', 'd.js'))
     ).toBe(path.join('c', 'd'));
   });
 });

--- a/packages/jest-haste-map/src/__tests__/getMockName-test.js
+++ b/packages/jest-haste-map/src/__tests__/getMockName-test.js
@@ -1,0 +1,22 @@
+const path = require('path');
+const getMockName = require('../getMockName');
+
+describe('getMockName', () => {
+  it('extracts mock name from file path', () => {
+    expect(
+      getMockName(path.join('a', '__b__', 'c.js'), /__b__/)
+    ).toBe('c');
+
+    expect(
+      getMockName(path.join('a', '__b__', 'index.js'), /__b__/)
+    ).toBe('index');
+
+    expect(
+      getMockName(path.join('a', '__b__', 'c', 'd.js'), /__b__/)
+    ).toBe(path.join('c', 'd'));
+
+    expect(
+      getMockName(path.join('a', '__b__', 'c', 'd', 'index.js'), /__b__/)
+    ).toBe(path.join('c', 'd'));
+  });
+});

--- a/packages/jest-haste-map/src/__tests__/getMockName-test.js
+++ b/packages/jest-haste-map/src/__tests__/getMockName-test.js
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+'use strict';
+
 const path = require('path');
 const getMockName = require('../getMockName');
 

--- a/packages/jest-haste-map/src/__tests__/index-test.js
+++ b/packages/jest-haste-map/src/__tests__/index-test.js
@@ -80,18 +80,6 @@ let readFileSync;
 let workerFarmMock;
 let writeFileSync;
 
-describe('getMockName', () => {
-  it('extracts mock name from file path', () => {
-    HasteMap = require('../');
-    const {getMockName} = HasteMap;
-
-    expect(getMockName('a/__b__/c.js', /__b__/)).toBe('c');
-    expect(getMockName('a/__b__/index.js', /__b__/)).toBe('index');
-    expect(getMockName('a/__b__/c/d.js', /__b__/)).toBe('c/d');
-    expect(getMockName('a/__b__/c/d/index.js', /__b__/)).toBe('c/d');
-  });
-});
-
 describe('HasteMap', () => {
   skipOnWindows.suite();
 

--- a/packages/jest-haste-map/src/__tests__/index-test.js
+++ b/packages/jest-haste-map/src/__tests__/index-test.js
@@ -80,6 +80,18 @@ let readFileSync;
 let workerFarmMock;
 let writeFileSync;
 
+describe('getMockName', () => {
+  it('extracts mock name from file path', () => {
+    HasteMap = require('../');
+    const {getMockName} = HasteMap;
+
+    expect(getMockName('a/__b__/c.js', /__b__/)).toBe('c');
+    expect(getMockName('a/__b__/index.js', /__b__/)).toBe('index');
+    expect(getMockName('a/__b__/c/d.js', /__b__/)).toBe('c/d');
+    expect(getMockName('a/__b__/c/d/index.js', /__b__/)).toBe('c/d');
+  });
+});
+
 describe('HasteMap', () => {
   skipOnWindows.suite();
 
@@ -322,12 +334,12 @@ describe('HasteMap', () => {
 
   it('warns on duplicate mock files', () => {
     // Duplicate mock files for blueberry
-    mockFs['/fruits/__mocks__/subdir1/blueberry.js'] = [
+    mockFs['/fruits1/__mocks__/subdir/blueberry.js'] = [
       '/**',
       ' * @providesModule Blueberry1',
       ' */',
     ].join('\n');
-    mockFs['/fruits/__mocks__/subdir2/blueberry.js'] = [
+    mockFs['/fruits2/__mocks__/subdir/blueberry.js'] = [
       '/**',
       ' * @providesModule Blueberry2',
       ' */',

--- a/packages/jest-haste-map/src/getMockName.js
+++ b/packages/jest-haste-map/src/getMockName.js
@@ -1,13 +1,10 @@
 const path = require('path');
 
-const getMockName = (filePath, mocksPattern) => {
-  const modulePath = filePath.split(mocksPattern)[1];
+const mocksPattern = '__mocks__';
 
-  const extractMockName = new RegExp(
-    `^\\${path.sep}?(.*?)(\\${path.sep}index)?\\${path.extname(modulePath)}$`
-  );
-
-  return extractMockName.exec(modulePath)[1];
+const getMockName = (filePath: string) => {
+  const mockPath = filePath.split(mocksPattern)[1];
+  return mockPath.substring(1, mockPath.lastIndexOf(path.extname(mockPath)));
 };
 
 module.exports = getMockName;

--- a/packages/jest-haste-map/src/getMockName.js
+++ b/packages/jest-haste-map/src/getMockName.js
@@ -1,0 +1,13 @@
+const path = require('path');
+
+const getMockName = (filePath, mocksPattern) => {
+  const modulePath = filePath.split(mocksPattern)[1];
+
+  const extractMockName = new RegExp(
+    `^\\${path.sep}?(.*?)(\\${path.sep}index)?\\${path.extname(modulePath)}$`
+  );
+
+  return extractMockName.exec(modulePath)[1];
+};
+
+module.exports = getMockName;

--- a/packages/jest-haste-map/src/getMockName.js
+++ b/packages/jest-haste-map/src/getMockName.js
@@ -1,3 +1,14 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+'use strict';
+
 const path = require('path');
 
 const mocksPattern = '__mocks__';

--- a/packages/jest-haste-map/src/index.js
+++ b/packages/jest-haste-map/src/index.js
@@ -95,7 +95,14 @@ const canUseWatchman = ((): boolean => {
 const escapePathSeparator =
   string => (path.sep === '\\') ? string.replace(/(\/|\\)/g, '\\\\') : string;
 
-const getMockName = filePath => path.basename(filePath, path.extname(filePath));
+const getMockName = (filePath, mocksPattern) => {
+  const modulePath = filePath.split(mocksPattern)[1];
+  const extractMockName = new RegExp(
+    `^\\${path.sep}?(.*?)(\\${path.sep}index)?\\${path.extname(modulePath)}$`
+  );
+  return extractMockName.exec(modulePath)[1];
+};
+
 const getWhiteList = (list: ?Array<string>): ?RegExp => {
   if (list && list.length) {
     return new RegExp(
@@ -327,7 +334,7 @@ class HasteMap extends EventEmitter {
       this._options.mocksPattern &&
       this._options.mocksPattern.test(filePath)
     ) {
-      const mockPath = getMockName(filePath);
+      const mockPath = getMockName(filePath, this._options.mocksPattern);
       if (mocks[mockPath]) {
         this._console.warn(
           `jest-haste-map: duplicate manual mock found:\n` +
@@ -617,7 +624,7 @@ class HasteMap extends EventEmitter {
           this._options.mocksPattern &&
           this._options.mocksPattern.test(filePath)
         ) {
-          const mockName = getMockName(filePath);
+          const mockName = getMockName(filePath, this._options.mocksPattern);
           delete hasteMap.mocks[mockName];
         }
 
@@ -701,8 +708,11 @@ class HasteMap extends EventEmitter {
   }
 
   static H: HType;
+
+  static getMockName;
 }
 
 HasteMap.H = H;
+HasteMap.getMockName = getMockName;
 
 module.exports = HasteMap;

--- a/packages/jest-haste-map/src/index.js
+++ b/packages/jest-haste-map/src/index.js
@@ -23,6 +23,7 @@ const {EventEmitter} = require('events');
 const H = require('./constants');
 const HasteFS = require('./HasteFS');
 const HasteModuleMap = require('./ModuleMap');
+const getMockName = require('./getMockName');
 
 const crypto = require('crypto');
 const execSync = require('child_process').execSync;
@@ -94,14 +95,6 @@ const canUseWatchman = ((): boolean => {
 
 const escapePathSeparator =
   string => (path.sep === '\\') ? string.replace(/(\/|\\)/g, '\\\\') : string;
-
-const getMockName = (filePath, mocksPattern) => {
-  const modulePath = filePath.split(mocksPattern)[1];
-  const extractMockName = new RegExp(
-    `^\\${path.sep}?(.*?)(\\${path.sep}index)?\\${path.extname(modulePath)}$`
-  );
-  return extractMockName.exec(modulePath)[1];
-};
 
 const getWhiteList = (list: ?Array<string>): ?RegExp => {
   if (list && list.length) {
@@ -708,11 +701,8 @@ class HasteMap extends EventEmitter {
   }
 
   static H: HType;
-
-  static getMockName;
 }
 
 HasteMap.H = H;
-HasteMap.getMockName = getMockName;
 
 module.exports = HasteMap;

--- a/packages/jest-haste-map/src/index.js
+++ b/packages/jest-haste-map/src/index.js
@@ -327,7 +327,7 @@ class HasteMap extends EventEmitter {
       this._options.mocksPattern &&
       this._options.mocksPattern.test(filePath)
     ) {
-      const mockPath = getMockName(filePath, this._options.mocksPattern);
+      const mockPath = getMockName(filePath);
       if (mocks[mockPath]) {
         this._console.warn(
           `jest-haste-map: duplicate manual mock found:\n` +
@@ -617,7 +617,7 @@ class HasteMap extends EventEmitter {
           this._options.mocksPattern &&
           this._options.mocksPattern.test(filePath)
         ) {
-          const mockName = getMockName(filePath, this._options.mocksPattern);
+          const mockName = getMockName(filePath);
           delete hasteMap.mocks[mockName];
         }
 

--- a/packages/jest-runtime/src/__tests__/Runtime-mock-test.js
+++ b/packages/jest-runtime/src/__tests__/Runtime-mock-test.js
@@ -9,6 +9,8 @@
  */
 'use strict';
 
+const path = require('path');
+
 let createRuntime;
 
 describe('Runtime', () => {
@@ -27,6 +29,7 @@ describe('Runtime', () => {
 
         root.jest.mock('RegularModule', () => mockReference);
         root.jest.mock('ManuallyMocked', () => mockReference);
+        root.jest.mock(path.join('nested1', 'nested2', 'nested3'));
 
         expect(
           runtime.requireModuleOrMock(runtime.__mockRootPath, 'RegularModule'),
@@ -34,6 +37,12 @@ describe('Runtime', () => {
 
         expect(
           runtime.requireModuleOrMock(runtime.__mockRootPath, 'RegularModule'),
+        ).toEqual(mockReference);
+
+        expect(
+          runtime.requireModuleOrMock(
+            runtime.__mockRootPath, path.join('nested1', 'nested2', 'nested3')
+          ),
         ).toEqual(mockReference);
       }),
     );

--- a/packages/jest-runtime/src/__tests__/test_root/__mocks__/nested1/nested2/nested3.js
+++ b/packages/jest-runtime/src/__tests__/test_root/__mocks__/nested1/nested2/nested3.js
@@ -1,0 +1,3 @@
+'use strict';
+
+exports.isMock = true;

--- a/packages/jest-runtime/src/__tests__/test_root/nested1/nested2/nested3.js
+++ b/packages/jest-runtime/src/__tests__/test_root/nested1/nested2/nested3.js
@@ -1,0 +1,3 @@
+'use strict';
+
+exports.isMock = false;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Following #2475 this PR enables manual mocks with nested folders.

You can now mock dependencies with nested folders like:
`jest.mock('react-styleguidist/src/rsg-components/Playground/PlaygroundRenderer')`

Where the manual mock directory structure is the following:
<img width="247" alt="screen shot 2016-12-31 at 07 20 06" src="https://cloud.githubusercontent.com/assets/1308971/21576487/9d682968-cf29-11e6-9aa6-eb642e37bc80.png">

This PR exists mostly to get an early feedback from the team and it could be improved.
For example, I attached the `getMockName` function to the `HasteMap` class to make testing easier but we can find a better solution (transforming it to an instance method?).

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

I tried it on a [project](https://github.com/MicheleBertoli/snapguidist) where I actually need it, and it worked.

Before (Jest loads the actual package):
<img width="1086" alt="screen shot 2016-12-31 at 07 21 56" src="https://cloud.githubusercontent.com/assets/1308971/21576494/eba1a8e8-cf29-11e6-9cb7-63b6be4639ce.png">

After (It works):
<img width="377" alt="screen shot 2016-12-31 at 07 22 54" src="https://cloud.githubusercontent.com/assets/1308971/21576497/fb5cbffc-cf29-11e6-9f33-f1fe1a5cf0fa.png">


<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
