### PR TITLE
Mock Virtual Modules via Absolute Path

### DIFF
--- a/packages/jest-runtime/src/__mocks__/createRuntime.js
+++ b/packages/jest-runtime/src/__mocks__/createRuntime.js
@@ -31,6 +31,12 @@ module.exports = function createRuntime(filename, config) {
       );
 
       runtime.__mockRootPath = path.join(config.rootDir, 'root.js');
+      runtime.__mockSubdirPath = path.join(
+          config.rootDir,
+          'subdir2',
+          'module_dir',
+          'moduleDirModule.js'
+      );
       return runtime;
     });
 };

--- a/packages/jest-runtime/src/index.js
+++ b/packages/jest-runtime/src/index.js
@@ -548,7 +548,7 @@ class Runtime {
   }
 
   _getVirtualMockPath(from: Path, moduleName: string) {
-    if (moduleName[0] !== '.' && moduleName[0] !== '/') {
+    if (moduleName[0] !== '.' || path.isAbsolute(moduleName)) {
       return moduleName;
     }
     return path.normalize(path.dirname(from) + '/' + moduleName);


### PR DESCRIPTION
**Summary**

I'm working on a CLI package that takes in the path of a config file as an argument (e.g. `--config foo.config.js`). I then resolve the config file path to an absolute path (e.g. `/absolute/path/to/foo.config.js`) and dynamically `require` it.

When writing tests with Jest, I found that even after registering a virtual `jest.mock` for the absolute path of a config file, Jest was throwing `Cannot find module '/absolute/path/to/foo.config.js' from 'loadConfig.js'`

**`src/loadConfig.js`**

```js
import * as path from 'path';

export default function loadConfig(configPath) {
  return require(path.resolve(configPath));
}
```

**`src/__tests__/loadConfig-test.js`**

```js
import * as path from 'path';
import loadConfig from '../loadConfig';

const configPath = 'foo.config.js';

const mockConfig = {mockConfig: true};
jest.mock(path.resolve(configPath), () => mockConfig);

describe('loadConfig', () => {
  it('returns the config at the given path', () => {
    const config = loadConfig(configPath);

    expect(config).toEqual(mockConfig);
  });
});
```

The problem lies in the `_getVirtualMockPath` function of `jest-runtime`. When registering a virtual module mock, it incorrectly prefixes the absolute module path with the directory of the file in which the mock was registered rather than simply registering it under the given absolute path.

So calling `jest.mock` with an absolute path from `src/__tests__/loadConfig-test.js` will register the mock at `src/__tests__/absolute/path/to/foo.config.js`. Then when `src/loadConfig.js` tries to `require` the module `/absolute/path/to/foo.config.js` in a test, `jest-runtime` incorrectly fails to find the virtual mock in its registry as it checks for `src/absolute/path/to/foo.config.js`.

This PR updates `jest-runtime` to no longer prefix absolute paths for virtual modules with the directory from which they were required.

**Test plan**

Added a failing test case demonstrating that mocking a virtual module via absolute path fails when the module is subsequently required from a different directory:
![image](https://cloud.githubusercontent.com/assets/733696/21579723/6823315e-cf8c-11e6-8673-9ba4b7cbab91.png)

Updated `jest-runtime` to make the test pass:
![image](https://cloud.githubusercontent.com/assets/733696/21579730/fee7bf9c-cf8c-11e6-990a-028da5fb3671.png)