### PR TITLE
Fix unhandled promise rejection in worker when parent has exited

### DIFF
--- a/packages/jest-cli/src/TestWorker.js
+++ b/packages/jest-cli/src/TestWorker.js
@@ -77,11 +77,15 @@ module.exports = (
   {config, path, rawModuleMap}: WorkerData,
   callback: WorkerCallback,
 ) => {
+  let parentExited = false;
+
+  process.on('disconnect', () => parentExited = true);
+
   try {
     runTest(path, config, getResolver(config, rawModuleMap))
       .then(
-        result => callback(null, result),
-        error => callback(formatError(error)),
+        result => !parentExited && callback(null, result),
+        error => !parentExited && callback(formatError(error)),
       );
   } catch (error) {
     callback(formatError(error));


### PR DESCRIPTION
Killing the main process while the tests are still running causes this error in the workers

```
(node:56445) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): Error: channel closed
```

**Before**

![interruption-before](https://cloud.githubusercontent.com/assets/574806/21596604/cb80a87c-d102-11e6-8e94-7858481db09e.gif)

**After**

![interruption-after](https://cloud.githubusercontent.com/assets/574806/21596603/cb7a3e24-d102-11e6-814c-99b2c79388d8.gif)

* @cpojer Does this look like enough to fix #2385?
* Is there a more appropriate way of fixing this?

**Test plan**

I'm not sure what is the best way to add tests to this type of issues.