### PR TITLE
Better error for invalid transform config

### DIFF
--- a/packages/jest-config/src/__tests__/__snapshots__/normalize-test.js.snap
+++ b/packages/jest-config/src/__tests__/__snapshots__/normalize-test.js.snap
@@ -14,3 +14,31 @@ exports[`Upgrade help logs a warning when \`scriptPreprocessor\` and/or \`prepro
   [1mJest Issue Tracker:[22m https://github.com/facebook/jest/issues
 [39m"
 `;
+
+exports[`transform throws for invalid value 1`] = `
+"[31mConfiguration option \`[1mtransform[22m\` must be an object. Use it like this:
+
+[1m  \"transform\": {
+    \"^.+\\\\.js$\": \"string\"
+  }[22m
+
+  Jest changed the default configuration for tests.
+
+  [1mConfiguration Documentation:[22m https://facebook.github.io/jest/docs/configuration.html
+  [1mJest Issue Tracker:[22m https://github.com/facebook/jest/issues
+[39m"
+`;
+
+exports[`transform throws for invalid value 2`] = `
+"[31mConfiguration option \`[1mtransform[22m\` must be an object. Use it like this:
+
+[1m  \"transform\": {
+    \"^.+\\\\.js$\": \"<rootDir>/node_modules/babel-jest\"
+  }[22m
+
+  Jest changed the default configuration for tests.
+
+  [1mConfiguration Documentation:[22m https://facebook.github.io/jest/docs/configuration.html
+  [1mJest Issue Tracker:[22m https://github.com/facebook/jest/issues
+[39m"
+`;

--- a/packages/jest-config/src/__tests__/normalize-test.js
+++ b/packages/jest-config/src/__tests__/normalize-test.js
@@ -236,14 +236,14 @@ describe('transform', () => {
         rootDir: '/root/',
         transform: 'string',
       }, '/root/path');
-    }).toThrow();
+    }).toThrowErrorMatchingSnapshot();
 
     expect(() => {
       normalize({
         rootDir: '/root/',
         transform: ['string'],
       }, '/root/path');
-    }).toThrow();
+    }).toThrowErrorMatchingSnapshot();
   });
 });
 

--- a/packages/jest-config/src/__tests__/normalize-test.js
+++ b/packages/jest-config/src/__tests__/normalize-test.js
@@ -229,6 +229,22 @@ describe('transform', () => {
       ['abs-path', '/qux/quux'],
     ]);
   });
+
+  it('throws for invalid value', () => {
+    expect(() => {
+      normalize({
+        rootDir: '/root/',
+        transform: 'string',
+      }, '/root/path');
+    }).toThrow();
+
+    expect(() => {
+      normalize({
+        rootDir: '/root/',
+        transform: ['string'],
+      }, '/root/path');
+    }).toThrow();
+  });
 });
 
 describe('setupTestFrameworkScriptFile', () => {

--- a/packages/jest-config/src/normalize.js
+++ b/packages/jest-config/src/normalize.js
@@ -270,7 +270,7 @@ function normalize(config, argv) {
         : '<rootDir>/node_modules/babel-jest';
       throwConfigurationError(
         `Configuration option \`${chalk.bold('transform')}\` ` +
-        'should be an Object. Use it like this:\n\n' +
+        'must be an object. Use it like this:\n\n' +
         chalk.bold(
           '  "transform": {\n' +
           `    "^.+\\\\.js$": "${exampleTransform}"\n` +

--- a/packages/jest-config/src/normalize.js
+++ b/packages/jest-config/src/normalize.js
@@ -262,6 +262,23 @@ function normalize(config, argv) {
 
   let babelJest;
   if (config.transform) {
+    const toString = Object.prototype.toString;
+    if (toString.call(config.transform) !== '[object Object]') {
+      const isString = typeof config.transform === 'string';
+      const exampleTransform = isString
+        ? config.transform
+        : '<rootDir>/node_modules/babel-jest';
+      throwConfigurationError(
+        `Configuration option \`${chalk.bold('transform')}\` ` +
+        'should be an Object. Use it like this:\n\n' +
+        chalk.bold(
+          '  "transform": {\n' +
+          `    "^.+\\\\.js$": "${exampleTransform}"\n` +
+          '  }'
+        )
+      );
+    }
+
     const customJSPattern = Object.keys(config.transform).find(pattern => {
       const regex = new RegExp(pattern);
       return regex.test('a.js') || regex.test('a.jsx');


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Provides a better error for invalid `transform` config option. Fixes https://github.com/facebook/jest/issues/2228

<img width="659" alt="screen shot 2017-01-03 at 22 48 13" src="https://cloud.githubusercontent.com/assets/5106466/21625152/914fb16c-d20a-11e6-8e97-d6aace11b37e.png">

**Test plan**
jest
