### PR TITLE
windows doesn't exit node processes when it's supposed to

### DIFF
--- a/packages/jest-editor-support/src/Runner.js
+++ b/packages/jest-editor-support/src/Runner.js
@@ -32,6 +32,9 @@ module.exports = class Runner extends EventEmitter {
   }
 
   start() {
+    if (this.debugprocess) {
+      return;
+    }
     // Handle the arg change on v18
     const belowEighteen = this.workspace.localJestMajorVersion < 18;
     const outputArg = belowEighteen ? '--jsonOutputFile' : '--outputFile';
@@ -91,9 +94,10 @@ module.exports = class Runner extends EventEmitter {
   closeProcess() {
     if (process.platform === 'win32') {
       // because windows is stupid and doesn't exit when it should
-      spawn('taskkill', ['/pid', this.debugprocess.pid.toString(), '/T', '/F']);
+      spawn('taskkill', ['/pid', '' + this.debugprocess.pid, '/T', '/F']);
     } else {
       this.debugprocess.kill();
     }
+    delete this.debugprocess;
   }
 };

--- a/packages/jest-editor-support/src/Runner.js
+++ b/packages/jest-editor-support/src/Runner.js
@@ -93,7 +93,7 @@ module.exports = class Runner extends EventEmitter {
 
   closeProcess() {
     if (process.platform === 'win32') {
-      // because windows is stupid and doesn't exit when it should
+      // Windows doesn't exit the process when it should.
       spawn('taskkill', ['/pid', '' + this.debugprocess.pid, '/T', '/F']);
     } else {
       this.debugprocess.kill();

--- a/packages/jest-editor-support/src/Runner.js
+++ b/packages/jest-editor-support/src/Runner.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const {ChildProcess} = require('child_process');
+const {ChildProcess, spawn} = require('child_process');
 const {readFile} = require('fs');
 const {tmpdir} = require('os');
 const {EventEmitter} = require('events');
@@ -89,6 +89,11 @@ module.exports = class Runner extends EventEmitter {
   }
 
   closeProcess() {
-    this.debugprocess.kill();
+    if (process.platform === 'win32') {
+      // because windows is stupid and doesn't exit when it should
+      spawn('taskkill', ['/pid', this.debugprocess.pid.toString(), '/T', '/F']);
+    } else {
+      this.debugprocess.kill();
+    }
   }
 };


### PR DESCRIPTION
**Summary**

Node process wasn't exiting on editor termination.  Therefore even after closing the editor the process kept running on windows.

**Test plan**

Verified that the process was no longer running after closing the editor and calling `closeProcess`