### PR TITLE
#2463 - fix for jest-runtime _normalizeID doesnt provide determinstic results for all mocks

### DIFF
--- a/packages/jest-runtime/src/__tests__/Runtime-requireModuleOrMock-transitive-deps-test.js
+++ b/packages/jest-runtime/src/__tests__/Runtime-requireModuleOrMock-transitive-deps-test.js
@@ -36,21 +36,23 @@ describe('transitive dependencies', () => {
   };
 
   it('mocks a manually mocked and mapped module', () =>
-      createRuntime(__filename, {
-        automock: false,
-        moduleNameMapper,
-      })
-        .then(runtime => {
-          runtime.setMock(__filename,  './test_root/mapped_dir/moduleInMapped',
-           () => ('mocked_in_mapped'));
+    createRuntime(__filename, {
+      automock: false,
+      moduleNameMapper,
+    }).then(runtime => {
+      runtime.setMock(
+        __filename,
+        './test_root/mapped_dir/moduleInMapped',
+        () => 'mocked_in_mapped',
+      );
 
-          const parentDep = runtime.requireModule(
-              runtime.__mockRootPath,
-                './depOnMappedModule.js',
-             );
-
-          expect(parentDep).toEqual({result: 'mocked_in_mapped'});
-        }));
+      const parentDep = runtime.requireModule(
+        runtime.__mockRootPath,
+        './depOnMappedModule.js',
+      );
+      expect(parentDep).toEqual({result: 'mocked_in_mapped'});
+    }),
+  );
 
   it('unmocks transitive dependencies in node_modules by default', () =>
     createRuntime(__filename, {

--- a/packages/jest-runtime/src/__tests__/Runtime-requireModuleOrMock-transitive-deps-test.js
+++ b/packages/jest-runtime/src/__tests__/Runtime-requireModuleOrMock-transitive-deps-test.js
@@ -14,6 +14,7 @@ let createRuntime;
 const moduleNameMapper = {
   '^[./a-zA-Z0-9$_-]+\.png$': 'RelativeImageStub',
   '^image![a-zA-Z0-9$_-]+$': 'GlobalImageStub',
+  '^testMapped/(.*)': '<rootDir>/mapped_dir/$1',
   'mappedToDirectory': '<rootDir>/MyDirectoryModule',
   'mappedToPath': '<rootDir>/GlobalImageStub.js',
   'module/name/(.*)': '<rootDir>/mapped_module_$1.js',
@@ -33,6 +34,23 @@ describe('transitive dependencies', () => {
     expect(moduleData.internalImplementation())
       .toEqual('internal-module-code');
   };
+
+  it('mocks a manually mocked and mapped module', () =>
+      createRuntime(__filename, {
+        automock: false,
+        moduleNameMapper,
+      })
+        .then(runtime => {
+          runtime.setMock(__filename,  './test_root/mapped_dir/moduleInMapped',
+           () => ('mocked_in_mapped'));
+
+          const parentDep = runtime.requireModule(
+              runtime.__mockRootPath,
+                './depOnMappedModule.js',
+             );
+
+          expect(parentDep).toEqual({result: 'mocked_in_mapped'});
+        }));
 
   it('unmocks transitive dependencies in node_modules by default', () =>
     createRuntime(__filename, {

--- a/packages/jest-runtime/src/__tests__/test_root/depOnMappedModule.js
+++ b/packages/jest-runtime/src/__tests__/test_root/depOnMappedModule.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const mappedTest = require('testMapped/moduleInMapped');
+
+exports.result = mappedTest;

--- a/packages/jest-runtime/src/__tests__/test_root/mapped_dir/moduleInMapped.js
+++ b/packages/jest-runtime/src/__tests__/test_root/mapped_dir/moduleInMapped.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = `in_mapped`;

--- a/packages/jest-runtime/src/index.js
+++ b/packages/jest-runtime/src/index.js
@@ -543,7 +543,9 @@ class Runtime {
     }
 
     const sep = path.delimiter;
-    const id = moduleType + sep + (absolutePath || '') + sep + (mockPath || '');
+    const id = (moduleType + sep + (absolutePath ? (absolutePath + sep) : '') +
+      (mockPath ? (mockPath + sep) : ''));
+
     return normalizedIDCache[key] = id;
   }
 


### PR DESCRIPTION
**Summary**

fixes #2463 
adds support for testing jspm/system-js based apps that often use aliases for modules or for module paths.

**Test plan**

Added test to: packages/jest-runtime/src/__tests__/Runtime-requireModuleOrMock-transitive-deps-test.js 
test requires a module that in turn requires a mapped module (aliased) using moduleNameMapper configuration. 
Before the fix, trying to mock the aliased module would silently fail