### PR TITLE
Bump minimal version of babel-plugin-istanbul

### DIFF
--- a/packages/babel-jest/package.json
+++ b/packages/babel-jest/package.json
@@ -9,7 +9,7 @@
   "main": "build/index.js",
   "dependencies": {
     "babel-core": "^6.0.0",
-    "babel-plugin-istanbul": "^3.0.0",
+    "babel-plugin-istanbul": "^3.1.2",
     "babel-preset-jest": "^18.0.0"
   }
 }


### PR DESCRIPTION
Normally semver takes care of this but I'd like to ensure that existing Create React App users will get this bugfix update next time they update CRA (and thus Jest). It fixes `displayName` inference for functional components when coverage is enabled: https://github.com/facebookincubator/create-react-app/issues/1010#issuecomment-270907699.