### PR TITLE
Move Mock Functions to Introduction

### DIFF
--- a/docs/ManualMocks.md
+++ b/docs/ManualMocks.md
@@ -4,7 +4,7 @@ title: Manual Mocks
 layout: docs
 category: Guides
 permalink: docs/manual-mocks.html
-next: timer-mocks
+next: webpack
 ---
 
 Manual mocks are used to stub out functionality with mock data. For example, instead of accessing a remote resource like a website or a database, you might want to create a manual mock that allows you to use fake data. This ensures your tests will be fast and not flaky.

--- a/docs/MigrationGuide.md
+++ b/docs/MigrationGuide.md
@@ -15,7 +15,7 @@ If you'd like to try out Jest with an existing codebase, there are a number of w
 
 ### jest-codemods
 
-If you are using [Mocha](https://mochajs.org)), [AVA](https://github.com/avajs/ava), [chai](http://chaijs.com/) or [Tape](https://github.com/substack/tape), you can use the third-party [jest-codemods](https://github.com/skovhus/jest-codemods) to do most of the dirty migration work. It runs a code transformation on your codebase using [jscodeshift](https://github.com/facebook/jscodeshift).
+If you are using [Mocha](https://mochajs.org), [AVA](https://github.com/avajs/ava), [chai](http://chaijs.com/) or [Tape](https://github.com/substack/tape), you can use the third-party [jest-codemods](https://github.com/skovhus/jest-codemods) to do most of the dirty migration work. It runs a code transformation on your codebase using [jscodeshift](https://github.com/facebook/jscodeshift).
 
 Install Jest Codemods with `npm` by running:
 

--- a/docs/MockFunctions.md
+++ b/docs/MockFunctions.md
@@ -2,9 +2,9 @@
 id: mock-functions
 title: Mock Functions
 layout: docs
-category: Guides
+category: Introduction
 permalink: docs/mock-functions.html
-next: manual-mocks
+next: more-resources
 ---
 
 Mock functions make it easy to test the links between code by erasing the actual

--- a/docs/SetupAndTeardown.md
+++ b/docs/SetupAndTeardown.md
@@ -4,7 +4,7 @@ title: Setup and Teardown
 layout: docs
 category: Introduction
 permalink: docs/setup-teardown.html
-next: mocking
+next: mock-functions
 ---
 
 Often while writing tests you have some setup work that needs to happen before tests run, and you have some finishing work that needs to happen after tests run. Jest provides helper functions to handle this.

--- a/docs/TimerMocks.md
+++ b/docs/TimerMocks.md
@@ -4,7 +4,7 @@ title: Timer Mocks
 layout: docs
 category: Guides
 permalink: docs/timer-mocks.html
-next: webpack
+next: manual-mocks
 ---
 
 The native timer functions (i.e., `setTimeout`, `setInterval`, `clearTimeout`,

--- a/docs/TutorialAsync.md
+++ b/docs/TutorialAsync.md
@@ -4,7 +4,7 @@ title: An Async Example
 layout: docs
 category: Guides
 permalink: docs/tutorial-async.html
-next: mock-functions
+next: timer-mocks
 ---
 
 First, enable Babel support in Jest as documented in the [Getting Started](/jest/docs/getting-started.html#using-babel) guide.


### PR DESCRIPTION
After some thought, this guide serves as a good intro to mocking. I've moved it to Introduction, and moved things around in Guides to fix the sequence of links.