### PR TITLE
Collect coverate from all packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,9 +55,10 @@
       "packages/jest-runtime/src/__tests__/test_root_with_dup_mocks"
     ],
     "collectCoverageFrom": [
-      "**/packages/{jest-runtime,jest-matchers,jest-haste-map,jest-file-exists,jest-diff,jest-changed-files}/**/*.js",
+      "**/packages/**/*.js",
       "!**/bin/**",
       "!**/cli/**",
+      "!**/perf/**",
       "!**/vendor/**",
       "!**/__mocks__/**",
       "!**/__tests__/**",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

As discussed with @cpojer, we should to track coverage for all packages we expose.
This dramatically lowers coverage, which imply we need to write more tests.