### PR TITLE
Fix local eslint setup.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,4 @@ cache:
     - ".eslintcache"
     - "node_modules"
 
-script:
-  - (cd packages/eslint-plugin-jest && yarn link)
-  - yarn link eslint-plugin-jest
-  - yarn run test-ci
+script: yarn run test-ci

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "jest": "node ./packages/jest-cli/bin/jest.js",
     "jest-coverage": "yarn run jest -- --coverage",
     "lint": "eslint . --cache",
-    "postinstall": "node ./scripts/postinstall.js && node ./scripts/build.js",
+    "postinstall": "node ./scripts/postinstall.js && node ./scripts/build.js && (cd packages/eslint-plugin-jest && yarn link) && yarn link eslint-plugin-jest",
     "publish": "yarn run build-clean && yarn run build && lerna publish",
     "test": "yarn run typecheck && yarn run lint && yarn run build && yarn run jest && yarn run test-examples",
     "test-ci": "yarn run typecheck && yarn run lint && yarn run build && yarn run jest-coverage -- -i && yarn run test-examples && node scripts/mapCoverage.js && codecov",


### PR DESCRIPTION
**Summary**
I messed around with the setup a lot and had trouble with yarn install so I moved travis to use yarn link. I had a cached version of node_modules locally and didn't realize the new code doesn't set up eslint properly for local development. This fixes it for both travis and local development.

**Test plan**
yarn lint works locally