### PR TITLE
Eslint no skipped tests

### DIFF
--- a/packages/eslint-plugin-jest/README.md
+++ b/packages/eslint-plugin-jest/README.md
@@ -30,7 +30,7 @@ Then configure the rules you want to use under the rules section.
   "rules": {
     "jest/no-focused-tests": "error",
     "jest/no-identical-title": "error",
-    "jest/no-skipped-tests": "error"
+    "jest/no-skipped-tests": "warn"
   }
 }
 ```
@@ -51,6 +51,26 @@ You can also whitelist the environment variables provided by Jest by doing:
 - [no-identical-title](docs/rules/no-identical-title.md) - disallow identical titles.
 - [no-skipped-tests](docs/rules/no-skipped-tests.md) - disallow skipped tests.
 
+## Shareable configurations
+
+### Recommended
+
+This plugin exports a recommended configuration that enforces good testing practices.
+
+To enable this configuration use the `extends` property in your `.eslintrc` config file:
+
+```js
+{
+  "extends": ["plugin:jest/recommended"]
+}
+```
+
+See [ESLint documentation](http://eslint.org/docs/user-guide/configuring#extending-configuration-files) for more information about extending configuration files.
+
+The rules enabled in this configuration are:
+
+- [jest/no-focused-tests](docs/rules/no-focused-tests.md)
+- [jest/no-identical-title](docs/rules/no-identical-title.md)
 
 ## Credit
 

--- a/packages/eslint-plugin-jest/README.md
+++ b/packages/eslint-plugin-jest/README.md
@@ -29,7 +29,8 @@ Then configure the rules you want to use under the rules section.
 {
   "rules": {
     "jest/no-focused-tests": "error",
-    "jest/no-identical-title": "error"
+    "jest/no-identical-title": "error",
+    "jest/no-skipped-tests": "error"
   }
 }
 ```
@@ -48,6 +49,7 @@ You can also whitelist the environment variables provided by Jest by doing:
 
 - [no-focused-tests](docs/rules/no-focused-tests.md) - disallow focused tests.
 - [no-identical-title](docs/rules/no-identical-title.md) - disallow identical titles.
+- [no-skipped-tests](docs/rules/no-skipped-tests.md) - disallow skipped tests.
 
 
 ## Credit

--- a/packages/eslint-plugin-jest/docs/rules/no-skipped-tests.md
+++ b/packages/eslint-plugin-jest/docs/rules/no-skipped-tests.md
@@ -1,0 +1,33 @@
+# Disallow Skipped Tests (no-skipped-tests)
+
+Jest has a feature that allows you to skip tests by appending `.skip` or prepending `x` to a test-suite or a test-case.
+Sometimes tests are skipped as part of a debugging process, and aren't intended to be committed. This rule reminds you to remove .skip or the x prefix from your tests.
+
+## Rule Details
+
+This rule looks for every `describe.skip`, `it.skip`, `test.skip`, `xdescribe`, `xit` and `xtest` occurrences within the source code.
+
+The following patterns are considered warnings:
+
+```js
+describe.skip("foo", function () {});
+it.skip("foo", function () {});
+describe["skip"]("bar", function () {});
+it["skip"]("bar", function () {});
+test.skip("foo", function () {});
+test["skip"]("bar", function () {});
+xdescribe("foo", function () {});
+xit("foo", function () {});
+xtest("bar", function () {});
+```
+
+These patterns would not be considered warnings:
+
+```js
+describe("foo", function () {});
+it("foo", function () {});
+describe.only("bar", function () {});
+it.only("bar", function () {});
+test("foo", function () {});
+test.only("bar", function () {});
+```

--- a/packages/eslint-plugin-jest/docs/rules/no-skipped-tests.md
+++ b/packages/eslint-plugin-jest/docs/rules/no-skipped-tests.md
@@ -1,7 +1,7 @@
 # Disallow Skipped Tests (no-skipped-tests)
 
 Jest has a feature that allows you to skip tests by appending `.skip` or prepending `x` to a test-suite or a test-case.
-Sometimes tests are skipped as part of a debugging process, and aren't intended to be committed. This rule reminds you to remove .skip or the x prefix from your tests.
+Sometimes tests are skipped as part of a debugging process and aren't intended to be committed. This rule reminds you to remove .skip or the x prefix from your tests.
 
 ## Rule Details
 

--- a/packages/eslint-plugin-jest/src/index.js
+++ b/packages/eslint-plugin-jest/src/index.js
@@ -36,5 +36,6 @@ module.exports = {
   rules: {
     'no-focused-tests': require('./rules/no-focused-tests'),
     'no-identical-title': require('./rules/no-identical-title'),
+    'no-skipped-tests': require('./rules/no-skipped-tests'),
   },
 };

--- a/packages/eslint-plugin-jest/src/index.js
+++ b/packages/eslint-plugin-jest/src/index.js
@@ -11,6 +11,14 @@
 'use strict';
 
 module.exports = {
+  configs: {
+    recommended: {
+      rules: {
+        'jest/no-focused-tests': 'error',
+        'jest/no-identical-title': 'error',
+      },
+    },
+  },
   environments: {
     globals: {
       globals: {

--- a/packages/eslint-plugin-jest/src/rules/__tests__/no-skipped-tests-test.js
+++ b/packages/eslint-plugin-jest/src/rules/__tests__/no-skipped-tests-test.js
@@ -18,7 +18,7 @@ const rules = require('../../').rules;
 const ruleTester = new RuleTester();
 const expectedErrorMessage = 'Unexpected skipped test.';
 
-ruleTester.run('no-skipp-tests', rules['no-skipped-tests'], {
+ruleTester.run('no-skipped-tests', rules['no-skipped-tests'], {
   valid: [
     'describe()',
     'it()',

--- a/packages/eslint-plugin-jest/src/rules/__tests__/no-skipped-tests-test.js
+++ b/packages/eslint-plugin-jest/src/rules/__tests__/no-skipped-tests-test.js
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+
+/* eslint-disable sort-keys */
+
+'use strict';
+
+const RuleTester = require('eslint').RuleTester;
+const rules = require('../../').rules;
+
+const ruleTester = new RuleTester();
+const expectedErrorMessage = 'Unexpected skipped test.';
+
+ruleTester.run('no-skipp-tests', rules['no-skipped-tests'], {
+  valid: [
+    'describe()',
+    'it()',
+    'describe.only()',
+    'it.only()',
+    'test()',
+    'test.only()',
+    'var appliedSkip = describe.skip; appliedSkip.apply(describe)',
+    'var calledSkip = it.skip; calledSkip.call(it)',
+  ],
+
+  invalid: [
+    {
+      code: 'describe.skip()',
+      errors: [{message: expectedErrorMessage, column: 10, line: 1}],
+    },
+    {
+      code: 'describe["skip"]()',
+      errors: [{message: expectedErrorMessage, column: 10, line: 1}],
+    },
+    {
+      code: 'it.skip()',
+      errors: [{message: expectedErrorMessage, column: 4, line: 1}],
+    },
+    {
+      code: 'it["skip"]()',
+      errors: [{message: expectedErrorMessage, column: 4, line: 1}],
+    },
+    {
+      code: 'test.skip()',
+      errors: [{message: expectedErrorMessage, column: 6, line: 1}],
+    },
+    {
+      code: 'test["skip"]()',
+      errors: [{message: expectedErrorMessage, column: 6, line: 1}],
+    },
+    {
+      code: 'xdescribe()',
+      errors: [{message: expectedErrorMessage, column: 1, line: 1}],
+    },
+    {
+      code: 'xit()',
+      errors: [{message: expectedErrorMessage, column: 1, line: 1}],
+    },
+  ],
+});

--- a/packages/eslint-plugin-jest/src/rules/no-skipped-tests.js
+++ b/packages/eslint-plugin-jest/src/rules/no-skipped-tests.js
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+'use strict';
+
+import type {EslintContext, CallExpression} from './types';
+
+module.exports = function(context: EslintContext) {
+  const jestTestFunctions = [
+    'it',
+    'describe',
+    'test',
+  ];
+
+  function matchesTestFunction(object) {
+    return object && jestTestFunctions.indexOf(object.name) !== -1;
+  }
+
+  function matchesSkippedTestFunction(object) {
+    return (
+      object &&
+      object.name[0] === 'x' &&
+      jestTestFunctions.indexOf(object.name.substring(1)) !== -1
+    );
+  }
+
+  function isPropertyNamedSkip(property) {
+    return property && (property.name === 'skip' || property.value === 'skip');
+  }
+
+  function isCallToJestSkipFunction(callee) {
+    return (
+      matchesTestFunction(callee.object) && isPropertyNamedSkip(callee.property)
+    );
+  }
+
+  function isCallToSkippedJestFunction(callee) {
+    return matchesSkippedTestFunction(callee);
+  }
+
+  return {
+    CallExpression(node: CallExpression) {
+      const callee = node.callee;
+      if (!callee) {
+        return;
+      }
+
+      if (
+        callee.type === 'MemberExpression' &&
+        isCallToJestSkipFunction(callee)
+      ) {
+        context.report({
+          message: 'Unexpected skipped test.',
+          node: callee.property,
+        });
+        return;
+      }
+
+      if (
+        callee.type === 'Identifier' &&
+        isCallToSkippedJestFunction(callee)
+      ) {
+        context.report({
+          message: 'Unexpected skipped test.',
+          node: callee,
+        });
+        return;
+      }
+    },
+  };
+};


### PR DESCRIPTION
**Summary**

Adding a `no-skipped-tests` rule to `eslint-plugin-jest`. Also took the opportunity to add a recommended rule configuration.

**Test plan**

For `no-skipped-tests` rule, running the unit test suite should be sufficient. To check the recommend configuration create a test project with an `.eslintrc`:

```js
{
  "plugins": [
    "jest"
  ],
  "extends": ["plugin:jest/recommended"],
  "parser": "babel-eslint"
}
```

and eslint should error on:
```js
it.only('foo', () => {});
```