### PR TITLE
Rename `getMockFn` to `fn` in `jest-mock`.

### DIFF
--- a/packages/jest-mock/README.md
+++ b/packages/jest-mock/README.md
@@ -12,7 +12,7 @@ environment with the given global object.
 Generates a mock based on the given metadata (Metadata for the mock in
 the schema returned by the getMetadata method of this module). Mocks treat
 functions specially, and all mock functions have additional members, described
-in the documentation for getMockFunction in this module.
+in the documentation for `fn` in this module.
 
 
 One important note: function prototypes are handled specially by this
@@ -72,7 +72,7 @@ For instance, this metadata blob:
 
 defines an object with a slot named `self` that refers back to the object.
 
-### `getMockFunction`
+### `fn`
 
 Generates a stand-alone function with members that help drive unit tests or
 confirm expectations. Specifically, functions returned by this method have

--- a/packages/jest-mock/src/__tests__/jest-mock-test.js
+++ b/packages/jest-mock/src/__tests__/jest-mock-test.js
@@ -171,7 +171,7 @@ describe('moduleMocker', () => {
 
     describe('mocked functions', () => {
       it('tracks calls to mocks', () => {
-        const fn = moduleMocker.getMockFunction();
+        const fn = moduleMocker.fn();
         expect(fn.mock.calls).toEqual([]);
 
         fn(1, 2, 3);
@@ -182,7 +182,7 @@ describe('moduleMocker', () => {
       });
 
       it('tracks instances made by mocks', () => {
-        const fn = moduleMocker.getMockFunction();
+        const fn = moduleMocker.fn();
         expect(fn.mock.instances).toEqual([]);
 
         const instance1 = new fn();
@@ -193,7 +193,7 @@ describe('moduleMocker', () => {
       });
 
       it('supports clearing mock calls', () => {
-        const fn = moduleMocker.getMockFunction();
+        const fn = moduleMocker.fn();
         expect(fn.mock.calls).toEqual([]);
 
         fn(1, 2, 3);
@@ -211,7 +211,7 @@ describe('moduleMocker', () => {
       });
 
       it('supports clearing mocks', () => {
-        const fn = moduleMocker.getMockFunction();
+        const fn = moduleMocker.fn();
         expect(fn.mock.calls).toEqual([]);
 
         fn(1, 2, 3);
@@ -225,7 +225,7 @@ describe('moduleMocker', () => {
       });
 
       it('supports resetting mock return values', () => {
-        const fn = moduleMocker.getMockFunction();
+        const fn = moduleMocker.fn();
         fn.mockReturnValue('abcd');
 
         const before = fn();
@@ -238,7 +238,7 @@ describe('moduleMocker', () => {
       });
 
       it('supports resetting single use mock return values', () => {
-        const fn = moduleMocker.getMockFunction();
+        const fn = moduleMocker.fn();
         fn.mockReturnValueOnce('abcd');
 
         fn.mockReset();
@@ -248,7 +248,7 @@ describe('moduleMocker', () => {
       });
 
       it('supports resetting mock implementations', () => {
-        const fn = moduleMocker.getMockFunction();
+        const fn = moduleMocker.fn();
         fn.mockImplementation(() => 'abcd');
 
         const before = fn();
@@ -261,7 +261,7 @@ describe('moduleMocker', () => {
       });
 
       it('supports resetting single use mock implementations', () => {
-        const fn = moduleMocker.getMockFunction();
+        const fn = moduleMocker.fn();
         fn.mockImplementationOnce(() => 'abcd');
 
         fn.mockReset();
@@ -271,12 +271,12 @@ describe('moduleMocker', () => {
       });
 
       it('supports resetting all mocks', () => {
-        const fn1 = moduleMocker.getMockFunction();
+        const fn1 = moduleMocker.fn();
         fn1.mockImplementation(() => 'abcd');
         fn1(1, 2, 3);
         expect(fn1.mock.calls).toEqual([[1, 2, 3]]);
 
-        const fn2 = moduleMocker.getMockFunction();
+        const fn2 = moduleMocker.fn();
         fn2.mockReturnValue('abcd');
         fn2('a', 'b', 'c');
         expect(fn2.mock.calls).toEqual([['a', 'b', 'c']]);
@@ -292,7 +292,7 @@ describe('moduleMocker', () => {
 
   describe('getMockImplementation', () => {
     it('should mock calls to a mock function', () => {
-      const mockFn = moduleMocker.getMockFunction();
+      const mockFn = moduleMocker.fn();
 
       mockFn.mockImplementation(() => {
         return 'Foo';
@@ -305,7 +305,7 @@ describe('moduleMocker', () => {
 
   describe('mockImplementationOnce', () => {
     it('should mock single call to a mock function', () => {
-      const mockFn = moduleMocker.getMockFunction();
+      const mockFn = moduleMocker.fn();
 
       mockFn.mockImplementationOnce(() => {
         return 'Foo';
@@ -319,7 +319,7 @@ describe('moduleMocker', () => {
     });
 
     it('should fallback to default mock function when no specific mock is available', () => {
-      const mockFn = moduleMocker.getMockFunction();
+      const mockFn = moduleMocker.fn();
 
       mockFn.mockImplementationOnce(() => {
         return 'Foo';
@@ -337,7 +337,7 @@ describe('moduleMocker', () => {
   });
 
   it('should recognize a mocked function', () => {
-    const mockFn = moduleMocker.getMockFunction();
+    const mockFn = moduleMocker.fn();
 
     expect(moduleMocker.isMockFunction(() => {})).toBe(false);
     expect(moduleMocker.isMockFunction(mockFn)).toBe(true);

--- a/packages/jest-mock/src/index.js
+++ b/packages/jest-mock/src/index.js
@@ -551,6 +551,14 @@ class ModuleMockerClass {
     return !!fn._isMockFunction;
   }
 
+  fn(implementation?: any): any {
+    const fn = this._makeComponent({type: 'function'});
+    if (implementation) {
+      fn.mockImplementation(implementation);
+    }
+    return fn;
+  }
+
   spyOn(object: any, methodName: any): any {
     const original = object[methodName];
 
@@ -567,18 +575,6 @@ class ModuleMockerClass {
     }
 
     return object[methodName];
-  }
-
-  /**
-   * @see README.md
-   */
-  getMockFunction(): any {
-    return this._makeComponent({type: 'function'});
-  }
-
-  // Just a short-hand alias
-  getMockFn(): any {
-    return this.getMockFunction();
   }
 
   resetAllMocks() {

--- a/packages/jest-runtime/src/index.js
+++ b/packages/jest-runtime/src/index.js
@@ -692,6 +692,7 @@ class Runtime {
       this.resetModules();
       return runtime;
     };
+    const fn = this._moduleMocker.fn.bind(this._moduleMocker);
 
     const runtime = {
       addMatchers:
@@ -706,18 +707,11 @@ class Runtime {
       doMock: mock,
       dontMock: unmock,
       enableAutomock,
-      fn: (impl: ?Function) => {
-        const fn = this._moduleMocker.getMockFunction();
-        if (impl) {
-          return fn.mockImplementation(impl);
-        }
-        return fn;
-      },
-      genMockFn: this._moduleMocker.getMockFunction.bind(this._moduleMocker),
+      fn,
+      genMockFn: fn,
       genMockFromModule:
         (moduleName: string) => this._generateMock(from, moduleName),
-      genMockFunction:
-        this._moduleMocker.getMockFunction.bind(this._moduleMocker),
+      genMockFunction: fn,
       isMockFunction: this._moduleMocker.isMockFunction,
 
       mock,

--- a/packages/jest-util/src/FakeTimers.js
+++ b/packages/jest-util/src/FakeTimers.js
@@ -328,7 +328,7 @@ class FakeTimers {
   }
 
   _createMocks() {
-    const fn = impl => this._moduleMocker.getMockFn().mockImplementation(impl);
+    const fn = impl => this._moduleMocker.fn().mockImplementation(impl);
 
     this._fakeTimerAPIs = {
       clearImmediate: fn(this._fakeClearImmediate.bind(this)),


### PR DESCRIPTION
**Summary**

jest-mock now has the same `fn` API as the `jest` object. cc @vjeux please merge :)
**Test plan**
yarn test