### PR TITLE
End worker farm when tests get interrupted

### DIFF
--- a/packages/jest-cli/src/TestRunner.js
+++ b/packages/jest-cli/src/TestRunner.js
@@ -371,10 +371,12 @@ class TestRunner {
         .catch(error => onError(error, path));
     }));
 
+    const cleanup = () => workerFarm.end(farm);
+
     return Promise.race([
       runAllTests,
       onInterrupt,
-    ]).then(() => workerFarm.end(farm));
+    ]).then(cleanup, cleanup);
   }
 
   _setupReporters() {


### PR DESCRIPTION
This change ends the worker farm when tests get interrupted...

**Before**
![workers-before](https://cloud.githubusercontent.com/assets/574806/21755220/dbeafe24-d5d5-11e6-8d11-4c91782ad18b.gif)

**After**
![workers-after](https://cloud.githubusercontent.com/assets/574806/21755221/dbebdb28-d5d5-11e6-83c7-7e03169e6917.gif)

Test plan: I didn't add a test for this since it required a lot of extra mocks, let me know if I should add it 😄 