### PR TITLE
Fix pipe.write regression introduced after #2362

### DIFF
--- a/packages/jest-cli/src/__tests__/__snapshots__/watch-test.js.snap
+++ b/packages/jest-cli/src/__tests__/__snapshots__/watch-test.js.snap
@@ -1,0 +1,11 @@
+exports[`Watch mode flows Runs Jest once by default and shows usage 1`] = `
+Array [
+  "
+Watch Usage
+ › Press o to only run tests related to changed files.
+ › Press p to filter by a filename regex pattern.
+ › Press q to quit watch mode.
+ › Press Enter to trigger a test run.
+",
+]
+`;

--- a/packages/jest-cli/src/__tests__/watch-test.js
+++ b/packages/jest-cli/src/__tests__/watch-test.js
@@ -30,13 +30,6 @@ jest.doMock('../runJest', () => (...args) => {
 
 const watch = require('../watch');
 
-const USAGE_MESSAGE = `
-Watch Usage
- › Press o to only run tests related to changed files.
- › Press p to filter by a filename regex pattern.
- › Press q to quit watch mode.
- › Press Enter to trigger a test run.`;
-
 afterEach(runJestMock.mockReset);
 
 describe('Watch mode flows', () => {
@@ -60,7 +53,7 @@ describe('Watch mode flows', () => {
     watch(config, pipe, argv, hasteMap, hasteContext, stdin);
     expect(runJestMock).toBeCalledWith(hasteContext, config, argv, pipe,
       new TestWatcher({isWatchMode: true}), jasmine.any(Function));
-    expect(pipe.write).toBeCalledWith(USAGE_MESSAGE);
+    expect(pipe.write.mock.calls.reverse()[0]).toMatchSnapshot();
   });
 
   it('Pressing "o" runs test in "only changed files" mode', () => {

--- a/packages/jest-cli/src/watch.js
+++ b/packages/jest-cli/src/watch.js
@@ -195,7 +195,7 @@ const usage = (
     chalk.dim(' \u203A Press ') + 'Enter' + chalk.dim(' to trigger a test run.'),
   ];
   /* eslint-enable max-len */
-  return messages.filter(message => !!message).join(delimiter);
+  return messages.filter(message => !!message).join(delimiter) + '\n';
 };
 
 module.exports = watch;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

In the extract watch mode PR I changed some `console.log` to `pipe.write` https://github.com/facebook/jest/pull/2362#discussion_r95072873 which causes a small regression in watch mode when entering and leaving 'pattern' mode...


**Before**
![cli-before](https://cloud.githubusercontent.com/assets/574806/21759002/6dcd23c8-d606-11e6-927e-9960226dbf0c.gif)

**After**

![cli-after](https://cloud.githubusercontent.com/assets/574806/21759003/6dcd997a-d606-11e6-9805-3ba87bc27f61.gif)
**Test plan**

I added a test to cover this case and moved some of the implementation of the test to use snapshots