### PR TITLE
Fixes dangerfile

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -31,14 +31,14 @@ const toSentence = (array: Array<string>) : string => {
 };
 
 // ("/href/thing", "name") to "<a href="/href/thing">name</a>"
-const createLink = (href: string, text: string): string => 
+const createLink = (href: string, text: string): string =>
   `<a href='${href}'>${text}</a>`;
 
 const newJsFiles = danger.git.created_files.filter(path => path.endsWith('js'));
 
 // New JS files should have the FB copyright header + flow
 const facebookLicenseHeaderComponents = [
-  'Copyright \(c\) .*, Facebook, Inc. All rights reserved.',
+  'Copyright \\(c\\) .*, Facebook, Inc. All rights reserved.',
   'This source code is licensed under the BSD-style license found in the',
   'LICENSE file in the root directory of this source tree. An additional grant',
   'of patent rights can be found in the PATENTS file in the same directory.',
@@ -62,7 +62,7 @@ if (noFBCopyrightFiles.length > 0) {
 // Ensure the use of Flow and 'use strict';
 const noFlowFiles = newJsFiles.filter(filepath => {
   const content = fs.readFileSync(filepath).toString();
-  return includes(content, '@flow') && includes(content, 'use strict');
+  return !(includes(content, '@flow') && includes(content, 'use strict'));
 });
 
 if (noFlowFiles.length > 0) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Danger was checking for files without copyright, but when creating the regular expression from a string the initial escape for `(` and `)` was already evaluated, so it wouldn't match.

Also the flow+strict check was filling an array with filter, but that array contains correct files instead of wrong files.

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
I ran the code manually to check the result of the regex before and after, 
also looked at the code filtering.