### PR TITLE
Fix test on node 4.

### DIFF
--- a/packages/jest-cli/src/__tests__/watch-test.js
+++ b/packages/jest-cli/src/__tests__/watch-test.js
@@ -19,8 +19,9 @@ const runJestMock = jest.fn();
 jest.mock('jest-util', () => ({clearLine: () => {}}));
 jest.doMock('chalk', () => new chalk.constructor({enabled: false}));
 jest.doMock('../constants', () => ({CLEAR: '', KEYS}));
-jest.doMock('../runJest', () => (...args) => {
-  runJestMock(...args);
+jest.doMock('../runJest', () => function() {
+  const args = Array.from(arguments);
+  runJestMock.apply(null, args);
 
   // Call the callback
   args[args.length - 1]({snapshot: {}});


### PR DESCRIPTION
**Summary**
Node 4 doesn't support `...`. cc @rogeliog 

**Test plan**
`jest watch` on node 4.