### PR TITLE
Standarize file matching regexp

### DIFF
--- a/docs/TutorialReact.md
+++ b/docs/TutorialReact.md
@@ -265,7 +265,7 @@ module.exports = {
 
 Don't forget to install the `babel-core` and `babel-preset-jest` packages for this example to work.
 
-To make this work with Jest you need to update your Jest configuration with this: `"transform": {"^.+\\.js$": "path/to/custom-transformer.js"}`.
+To make this work with Jest you need to update your Jest configuration with this: `"transform": {"\\.js$": "path/to/custom-transformer.js"}`.
 
 If you'd like to build a transformer with babel support, you can also use babel-jest to compose one and pass in your custom configuration options:
 


### PR DESCRIPTION
The regexp used in `"transform"` (`"^.+\\.js"`) in the example was different than one used in [Webpack tutorial](https://github.com/facebook/jest/blob/new-docs/docs/Webpack.md) (`"\\.js"`) but matched the same file (everything ending with string `.js`). 

This one introduces less space for error. Or is there an edge case it doesn't cover?

**Explain the motivation for making this change. What existing problem does the pull request solve?**

1. Keep regexp with same effect consistent across examples
2. Reduce chance of error being introduced