### PR TITLE
Add 'color' as valid cli option, remove from config

### DIFF
--- a/packages/jest-cli/src/cli/args.js
+++ b/packages/jest-cli/src/cli/args.js
@@ -78,7 +78,7 @@ const options = {
   },
   colors: {
     description:
-      'The same as color',
+      'Alias for `--color`.',
     type: 'boolean',
   },
   config: {

--- a/packages/jest-cli/src/cli/args.js
+++ b/packages/jest-cli/src/cli/args.js
@@ -70,9 +70,15 @@ const options = {
     description: 'List of paths coverage will be restricted to.',
     type: 'array',
   },
+  color: {
+    description:
+      'Forces test results output color highlighting (even if stdout is not ' +
+      'a TTY). Set to false if you would like to have no colors.',
+    type: 'boolean',
+  },
   colors: {
     description:
-      'Forces test results output highlighting (even if stdout is not a TTY)',
+      'The same as color',
     type: 'boolean',
   },
   config: {

--- a/packages/jest-config/src/normalize.js
+++ b/packages/jest-config/src/normalize.js
@@ -401,7 +401,6 @@ function normalize(config, argv) {
       case 'browser':
       case 'cache':
       case 'collectCoverage':
-      case 'colors':
       case 'coverageCollector':
       case 'coverageReporters':
       case 'coverageThreshold':


### PR DESCRIPTION
**Summary**

Fixes #2501. I've also removed `colors` from `normalize.js`, because it's not a valid config option and added a note about switching colors off. This may need linguistic adjustments though.

**Test plan**

works on my machine
