### PR TITLE
prevent ENAMETOOLONG by hashing normalized name

### DIFF
--- a/packages/jest-config/src/normalize.js
+++ b/packages/jest-config/src/normalize.js
@@ -8,6 +8,8 @@
 
 'use strict';
 
+const crypto = require('crypto');
+
 const DEFAULT_CONFIG_VALUES = require('./defaults');
 const Resolver = require('jest-resolve');
 
@@ -159,7 +161,7 @@ function normalize(config, argv) {
   }
 
   if (!config.name) {
-    config.name = config.rootDir.replace(/[/\\]|\s/g, '-');
+    config.name = crypto.createHash('md5').update(config.rootDir).digest('hex');
   }
 
   if (!config.setupFiles) {


### PR DESCRIPTION
**Summary**

In certain edge cases a javascript file might be deeply nested in a verbose folder structure
(I am looking at you, Java) and therefore cause jests haste-map can cause an ENAMETOOLONG error.
By hashing the name we limit its max size to a length of 32 + additional parts for the cost of making
the cache actually readable.

fixes #2538

Again it might be wise to check for the actual length the normalizer would produce and then only fallback to hashing when the produces name looks too verbose. Therefore keeping the ability to have a human readable hash. (then again not sure if that is needed?)
