### PR TITLE
Hash directory used as name to prevent enametoolong

### DIFF
--- a/packages/jest-config/src/__tests__/normalize-test.js
+++ b/packages/jest-config/src/__tests__/normalize-test.js
@@ -12,6 +12,7 @@ jest.mock('jest-resolve');
 
 jest.mock('path', () => require.requireActual('path').posix);
 
+const crypto = require('crypto');
 const path = require('path');
 const utils = require('jest-util');
 const normalize = require('../normalize');
@@ -61,9 +62,13 @@ it('errors when an invalid config option is passed in', () => {
 });
 
 it('picks a name based on the rootDir', () => {
+  const rootDir = '/root/path/foo';
+  const expected = crypto.createHash('md5')
+    .update('/root/path/foo')
+    .digest('hex');
   expect(normalize({
-    rootDir: '/root/path/foo',
-  }).name).toBe('-root-path-foo');
+    rootDir,
+  }).name).toBe(expected);
 });
 
 it('keeps custom names based on the rootDir', () => {

--- a/packages/jest-config/src/normalize.js
+++ b/packages/jest-config/src/normalize.js
@@ -9,6 +9,8 @@
 
 'use strict';
 
+const crypto = require('crypto');
+
 const DEFAULT_CONFIG_VALUES = require('./defaults');
 const Resolver = require('jest-resolve');
 
@@ -223,7 +225,7 @@ function normalize(config, argv) {
   delete config.preprocessorIgnorePatterns;
 
   if (!config.name) {
-    config.name = config.rootDir.replace(/[/\\]|\s/g, '-');
+    config.name = crypto.createHash('md5').update(config.rootDir).digest('hex');
   }
 
   if (!config.setupFiles) {


### PR DESCRIPTION
Summary

In certain edge cases a javascript file might be deeply nested in a verbose folder structure
(I am looking at you, Java) and therefore cause jests haste-map can cause an ENAMETOOLONG error.
By hashing the name we limit its max size to a length of 32 + additional parts for the cost of making
the cache actually readable.

fixes #2538

Again it might be wise to check for the actual length the normalizer would produce and then only fallback to hashing when the produces name looks too verbose. Therefore keeping the ability to have a human readable hash. (then again not sure if that is needed?)