### PR TITLE
Match link to content for 'toMatchSnapshotString'

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -64,7 +64,7 @@ expect all the time. That's what you use `expect` for.
   - [`.toHaveLength(number)`](#tohavelengthnumber)
   - [`.toMatch(regexp)`](#tomatchregexp)
   - [`.toMatchObject(object)`](#tomatchobjectobject)
-  - [`.toMatchSnapshot()`](#tomatchsnapshot)
+  - [`.toMatchSnapshot()`](#tomatchsnapshotstring)
   - [`.toThrow()`](#tothrow)
   - [`.toThrowError(error)`](#tothrowerrorerror)
   - [`.toThrowErrorMatchingSnapshot()`](#tothrowerrormatchingsnapshot)


### PR DESCRIPTION
**Summary**

TOC link seems to not be linked correctly.  Content header pulls in the parameters as the name.  Just updating the link.