### PR TITLE
Fix anchor link for .toMatchSnapshot() in 'Writing assertions with expect' section

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -64,7 +64,7 @@ expect all the time. That's what you use `expect` for.
   - [`.toHaveLength(number)`](#tohavelengthnumber)
   - [`.toMatch(regexp)`](#tomatchregexp)
   - [`.toMatchObject(object)`](#tomatchobjectobject)
-  - [`.toMatchSnapshot()`](#tomatchsnapshot)
+  - [`.toMatchSnapshot()`](#tomatchsnapshotstring)
   - [`.toThrow()`](#tothrow)
   - [`.toThrowError(error)`](#tothrowerrorerror)
   - [`.toThrowErrorMatchingSnapshot()`](#tothrowerrormatchingsnapshot)


### PR DESCRIPTION
Hyperlink .toMatchSnapshot() from a list in [Writing assertions with expect](http://facebook.github.io/jest/docs/api.html#writing-assertions-with-expect) section in [jest/docs/api.html](http://facebook.github.io/jest/docs/api.html) doesn't work, because refers to a wrong anchor on a page — refers to ```#tomatchsnapshot``` but anchor has a name attribute ```#tomatchsnapshotstring```

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Simply changed the ref to an anchor for .toMatchSnapshot() menu item from ```#tomatchsnapshot``` to ```#tomatchsnapshotstring```

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Motivation**
.toMatchSnapshot() link from initial menu in [Writing assertions with expect](http://facebook.github.io/jest/docs/api.html#writing-assertions-with-expect) doesn't refer to a wrong anchor at the moment.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
