### PR TITLE
Handle JSON modules encoded with a BOM

### DIFF
--- a/packages/jest-runtime/package.json
+++ b/packages/jest-runtime/package.json
@@ -22,6 +22,7 @@
     "jest-util": "^18.1.0",
     "json-stable-stringify": "^1.0.0",
     "micromatch": "^2.3.11",
+    "strip-bom": "3.0.0",
     "yargs": "^6.3.0"
   },
   "bin": {

--- a/packages/jest-runtime/src/__tests__/Runtime-requireModule-test.js
+++ b/packages/jest-runtime/src/__tests__/Runtime-requireModule-test.js
@@ -274,4 +274,24 @@ describe('Runtime requireModule', () => {
     ]),
   );
 
+  it('finds modules encoded in UTF-8 *with BOM*', () =>
+    createRuntime(__filename).then(runtime => {
+      const exports = runtime.requireModule(
+        runtime.__mockRootPath,
+        './UTF8WithBOM.js',
+      );
+      expect(exports).toBe('isModuleEncodedInUTF8WithBOM');
+    }),
+  );
+
+  it('finds and loads JSON files encoded in UTF-8 *with BOM*', () =>
+    createRuntime(__filename).then(runtime => {
+      const exports = runtime.requireModule(
+        runtime.__mockRootPath,
+        './UTF8WithBOM.json',
+      );
+      expect(exports.isJSONModuleEncodedInUTF8WithBOM).toBe(true);
+    }),
+  );
+
 });

--- a/packages/jest-runtime/src/__tests__/test_root/UTF8WithBOM.js
+++ b/packages/jest-runtime/src/__tests__/test_root/UTF8WithBOM.js
@@ -1,1 +1,11 @@
-﻿module.exports = 'isModuleEncodedInUTF8WithBOM';
+﻿/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+module.exports = 'isModuleEncodedInUTF8WithBOM';

--- a/packages/jest-runtime/src/__tests__/test_root/UTF8WithBOM.js
+++ b/packages/jest-runtime/src/__tests__/test_root/UTF8WithBOM.js
@@ -1,0 +1,1 @@
+﻿module.exports = 'isModuleEncodedInUTF8WithBOM';

--- a/packages/jest-runtime/src/__tests__/test_root/UTF8WithBOM.json
+++ b/packages/jest-runtime/src/__tests__/test_root/UTF8WithBOM.json
@@ -1,0 +1,1 @@
+﻿{"isJSONModuleEncodedInUTF8WithBOM": true}

--- a/packages/jest-runtime/src/index.js
+++ b/packages/jest-runtime/src/index.js
@@ -22,6 +22,7 @@ const Resolver = require('jest-resolve');
 
 const fs = require('graceful-fs');
 const path = require('path');
+const stripBOM = require('strip-bom');
 const shouldInstrument = require('./shouldInstrument');
 const transform = require('./transform');
 const {
@@ -292,7 +293,7 @@ class Runtime {
       moduleRegistry[modulePath] = localModule;
       if (path.extname(modulePath) === '.json') {
         localModule.exports = this._environment.global.JSON.parse(
-          fs.readFileSync(modulePath, 'utf8'),
+          stripBOM(fs.readFileSync(modulePath, 'utf8'))
         );
       } else if (path.extname(modulePath) === '.node') {
         // $FlowFixMe


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Currently `require`ing JSON encoded in utf-8 w/ BOM will error because the BOM isn't stripped before being passed to `JSON.parse`.

It looks although [Node core strips the BOM before parsing JSON](https://github.com/nodejs/node/blob/master/lib/module.js#L585) so I've done the same here.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

Includes unit tests to test json and js modules encoded in utf-8 w/ BOM.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

**NOTES**
- If [`strip-bom`](https://www.npmjs.com/package/strip-bom) is a bit too `left-pad`y I could just copy it from Node -- https://github.com/nodejs/node/blob/master/lib/internal/module.js#L47

