### PR TITLE
Do not overwrite existing module mocks

### DIFF
--- a/packages/jest-resolve/src/index.js
+++ b/packages/jest-resolve/src/index.js
@@ -24,7 +24,7 @@ type ResolverConfig = {|
   extensions: Array<string>,
   hasCoreModules: boolean,
   moduleDirectories: Array<string>,
-  moduleNameMapper: ?{[key: string]: RegExp},
+  moduleNameMapper: ?Array<ModuleNameMapperConfig>,
   modulePaths: Array<Path>,
   platforms?: Array<string>,
 |};
@@ -35,6 +35,11 @@ type FindNodeModuleConfig = {|
   extensions: Array<string>,
   moduleDirectory: Array<string>,
   paths?: Array<Path>,
+|};
+
+type ModuleNameMapperConfig = {|
+  regex: RegExp,
+  moduleName: string
 |};
 
 export type ResolveModuleConfig = {|
@@ -215,8 +220,7 @@ class Resolver {
 
     const moduleNameMapper = this._options.moduleNameMapper;
     if (moduleNameMapper) {
-      for (const mappedModuleName in moduleNameMapper) {
-        const regex = moduleNameMapper[mappedModuleName];
+      for (const {moduleName: mappedModuleName, regex} of moduleNameMapper) {
         if (regex.test(moduleName)) {
           const matches = moduleName.match(regex);
           if (!matches) {

--- a/packages/jest-runtime/src/index.js
+++ b/packages/jest-runtime/src/index.js
@@ -55,11 +55,9 @@ const SNAPSHOT_EXTENSION = 'snap';
 
 const getModuleNameMapper = (config: Config) => {
   if (config.moduleNameMapper.length) {
-    const moduleNameMapper = Object.create(null);
-    config.moduleNameMapper.forEach(
-      map => moduleNameMapper[map[1]] = new RegExp(map[0]),
-    );
-    return moduleNameMapper;
+    return config.moduleNameMapper.map(([regex, moduleName]) => {
+      return {moduleName, regex: new RegExp(regex)};
+    });
   }
   return null;
 };


### PR DESCRIPTION
**Summary**

I am trying to fix a bug

**Test plan**

I have the following configuration

```json
{
 "moduleNameMapper": {
   "\\.css$": "identity-obj-proxy",
   "\\.sass$": "identity-obj-proxy"
 }
}
```

When I run tests, only latest pattern will be applied, the first `\\.css$` regexp is totally ignored because current implementation uses mapper path as a unique key, which is not always correct.