### PR TITLE
Support multiple testResultsProcessor

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -66,7 +66,7 @@ These options let you control Jest's behavior in your `package.json` file. The J
   - [`testPathDirs` [array<string>]](#testpathdirs-array-string)
   - [`testPathIgnorePatterns` [array<string>]](#testpathignorepatterns-array-string)
   - [`testRegex` [string]](#testregex-string)
-  - [`testResultsProcessor` [string]](#testresultsprocessor-string)
+  - [`testResultsProcessor` [string, array<string>]](#testresultsprocessor-string)
   - [`testRunner` [string]](#testrunner-string)
   - [`testURL` [string]](#testurl-string)
   - [`timers` [string]](#timers-string)
@@ -369,7 +369,7 @@ inside of `__tests__` folders, as well as any files with a suffix of `.test` or 
 (e.g. `Component.test.js` or `Component.spec.js`). It will also find files called `test.js`
 or `spec.js`.
 
-### `testResultsProcessor` [string]
+### `testResultsProcessor` [string, array<string>]
 (default: `undefined`)
 
 This option allows the use of a custom results processor. This processor must be a node module that exports a function expecting an object with the following structure as the first argument:
@@ -410,6 +410,8 @@ This option allows the use of a custom results processor. This processor must be
   ]
 }
 ```
+
+Multiple results processor can be specified via array of modules. Order of processor will affect process results, as each processor returns processed results back to jest.
 
 ### `testRunner` [string]
 (default: `jasmine2`)

--- a/integration_tests/__tests__/testResultsProcessor-test.js
+++ b/integration_tests/__tests__/testResultsProcessor-test.js
@@ -12,7 +12,7 @@ const skipOnWindows = require('skipOnWindows');
 
 skipOnWindows.suite();
 
-test('testNamePattern', () => {
+test('testResultsProcessor', () => {
   const path = require('path');
   const processorPath = path.resolve(
     __dirname,
@@ -24,4 +24,23 @@ test('testNamePattern', () => {
   ]);
   const json = result.json;
   expect(json.processed).toBe(true);
+});
+
+test('multiple testResultsProcessor', () => {
+  const path = require('path');
+  const processorPath = path.resolve(
+    __dirname,
+    '../testResultsProcessor/processor.js'
+  );
+  const secondProcessorPath = path.resolve(
+    __dirname,
+    '../testResultsProcessor/secondProcessor.js'
+  );
+  const result = runJest.json('testResultsProcessor', [
+    '--json',
+    `--testResultsProcessor=${processorPath},${secondProcessorPath}`,
+  ]);
+  const json = result.json;
+  expect(json.processed).toBe(true);
+  expect(json.count).toEqual(1);
 });

--- a/integration_tests/testResultsProcessor/secondProcessor.js
+++ b/integration_tests/testResultsProcessor/secondProcessor.js
@@ -9,7 +9,6 @@
 'use strict';
 
 module.exports = function(results) {
-  results.processed = true;
-  results.count = 0;
+  results.count += 1;
   return results;
 };

--- a/packages/jest-cli/src/cli/args.js
+++ b/packages/jest-cli/src/cli/args.js
@@ -214,7 +214,8 @@ const options = {
     description:
       'Allows the use of a custom results processor. ' +
       'This processor must be a node module that exports ' +
-      'a function expecting as the first argument the result object',
+      'a function expecting as the first argument the result object' +
+      'multiple processor can be specified via , separator.',
     type: 'string',
   },
   testRunner: {

--- a/packages/jest-cli/src/runJest.js
+++ b/packages/jest-cli/src/runJest.js
@@ -102,8 +102,11 @@ const runJest = (
       })
       .then(runResults => {
         if (config.testResultsProcessor) {
+          const resultsProcessor = Array.isArray(config.testResultsProcessor) ?
+            config.testResultsProcessor : [config.testResultsProcessor];
+
           /* $FlowFixMe */
-          runResults = require(config.testResultsProcessor)(runResults);
+          resultsProcessor.forEach(p => runResults = require(p)(runResults));
         }
         if (argv.json) {
           if (argv.outputFile) {

--- a/packages/jest-config/src/setFromArgv.js
+++ b/packages/jest-config/src/setFromArgv.js
@@ -74,7 +74,7 @@ function setFromArgv(config, argv) {
   }
 
   if (argv.testResultsProcessor) {
-    config.testResultsProcessor = argv.testResultsProcessor;
+    config.testResultsProcessor = argv.testResultsProcessor.split(',');
   }
 
   config.noStackTrace = argv.noStackTrace;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
This PR is proposal for `testResultsProcessor`, to support multiple processor if needed.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

While single testResultProcessor serves lot of usecases, there are some cases need multiple test results processor chained. For example, coverage processing via ts-jest(https://github.com/kulshekhar/ts-jest) then reporting those test results to CI via reporter (https://github.com/winterbe/jest-teamcity-reporter) both requires to specify test results processor. 

With this change, jest allows to specify multiple test results processors in case of cmd arg `,` separated path, and case of json config as array of module paths and synchronously execute those processor as ordered. Since result processor returns mutated results per each, user need to consider order of results processor.

This change is non-breaking change by supporting existing behavior as-is.

**Test plan**
- do not specify test results processor and confirm test executes without any failure.
- specify single test results processor and confirm results are processed.
- specify more than one test results processor and confirm results are processed.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
