### PR TITLE
Add --offline flag which restricts network access in tests

### DIFF
--- a/packages/jest-cli/package.json
+++ b/packages/jest-cli/package.json
@@ -25,6 +25,7 @@
     "jest-snapshot": "^18.1.0",
     "jest-util": "^18.1.0",
     "json-stable-stringify": "^1.0.0",
+    "mitm": "^1.3.2",
     "node-notifier": "^4.6.1",
     "sane": "~1.4.1",
     "strip-ansi": "^3.0.1",

--- a/packages/jest-cli/src/cli/args.js
+++ b/packages/jest-cli/src/cli/args.js
@@ -164,6 +164,11 @@ const options = {
     description: 'Activates notifications for test results.',
     type: 'boolean',
   },
+  offline: {
+    default: false,
+    description: 'Restricts network access during test run',
+    type: 'boolean',
+  },
   onlyChanged: {
     alias: 'o',
     description:

--- a/packages/jest-cli/src/runTest.js
+++ b/packages/jest-cli/src/runTest.js
@@ -22,6 +22,20 @@ const {
 const getConsoleOutput = require('./reporters/getConsoleOutput');
 
 function runTest(path: Path, config: Config, resolver: Resolver) {
+  if (config.offline === true) {
+    // Intercept all network requests for offline mode
+    const Mitm = require('mitm');
+    const mitm = Mitm();
+
+    mitm.on('request', (req, res) => {
+      res.statusCode = 502;
+      res.end(
+        'Jest is in offline mode and this response is mocked. ' +
+        'Please mock your network requests or disable offline mode.'
+      );
+    });
+  }
+
   /* $FlowFixMe */
   const TestEnvironment = require(config.testEnvironment);
   /* $FlowFixMe */

--- a/packages/jest-config/src/normalize.js
+++ b/packages/jest-config/src/normalize.js
@@ -416,6 +416,7 @@ function normalize(config, argv) {
       case 'name':
       case 'noStackTrace':
       case 'notify':
+      case 'offline':
       case 'persistModuleRegistryBetweenSpecs':
       case 'preset':
       case 'replname':

--- a/packages/jest-config/src/setFromArgv.js
+++ b/packages/jest-config/src/setFromArgv.js
@@ -21,6 +21,10 @@ function setFromArgv(config, argv) {
     config.notify = argv.notify;
   }
 
+  if (argv.offline) {
+    config.offline = argv.offline;
+  }
+
   if (argv.bail) {
     config.bail = argv.bail;
   }

--- a/types/Config.js
+++ b/types/Config.js
@@ -70,6 +70,7 @@ export type Config = DefaultConfig & {|
   moduleNameMapper: Array<string>,
   modulePaths: Array<string>,
   name: string,
+  offline: boolean,
   rootDir: Path,
   setupFiles: Array<Path>,
   setupTestFrameworkScriptFile: Path,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1643,6 +1643,12 @@ minimist@^1.1.3:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
+mitm@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/mitm/-/mitm-1.3.2.tgz#188d8620601a1569133d9e7085fcf011e799265d"
+  dependencies:
+    underscore ">= 1.1.6 < 1.6"
+
 mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
@@ -2281,6 +2287,10 @@ uglify-js@^2.6:
 uglify-to-browserify@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz#6e0924d6bda6b5afe349e39a6d632850a0f882b7"
+
+"underscore@>= 1.1.6 < 1.6":
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.5.2.tgz#1335c5e4f5e6d33bbb4b006ba8c86a00f556de08"
 
 urlgrey@>=0.4.0:
   version "0.4.4"


### PR DESCRIPTION
**Summary**

This adds a new boolean command line configuration option named "offline" which, when set, restricts network access to the tests being run. Any tests that make network requests will get a status code 502 and a body message telling them this is a mocked response.

The reason for adding this is that I think it's a great feature and a very nice thing to enforce or at least periodically check for in unit tests. Unit tests should not make network requests. They should be mocked. And Jest provides AWESOME utilities for doing this. Offline mode can help people easily identify which of their tests are still hitting the network.


**Test plan**

* Ran the test suite
* yarn link'ed jest-cli and ran this against a local test suite that made network requests