### PR TITLE
Make typeahead play better with different terminals

### DIFF
--- a/packages/jest-cli/package.json
+++ b/packages/jest-cli/package.json
@@ -27,6 +27,7 @@
     "json-stable-stringify": "^1.0.0",
     "node-notifier": "^4.6.1",
     "sane": "~1.4.1",
+    "string-length": "^1.0.1",
     "strip-ansi": "^3.0.1",
     "throat": "^3.0.0",
     "which": "^1.1.1",

--- a/packages/jest-cli/src/__tests__/__snapshots__/watch-pattern-mode-test.js.snap
+++ b/packages/jest-cli/src/__tests__/__snapshots__/watch-pattern-mode-test.js.snap
@@ -1,9 +1,5 @@
 exports[`Watch mode flows Pressing "P" enters pattern mode 1`] = `
-"[MOCK - cursorHide]
-[MOCK - clearScreen]
-
- Pattern Mode Usage
- › Press ESC to exit pattern mode.
+"
 
 
  pattern › p
@@ -33,16 +29,12 @@ exports[`Watch mode flows Pressing "P" enters pattern mode 1`] = `
   › path/to/file10-test.js
 
   › and 1 more file
-[MOCK - cursorRestorePosition]
-[MOCK - cursorShow]"
+[MOCK - cursorTo(12, 4)]
+[MOCK - cursorRestorePosition]"
 `;
 
 exports[`Watch mode flows Pressing "P" enters pattern mode 2`] = `
-"[MOCK - cursorHide]
-[MOCK - clearScreen]
-
- Pattern Mode Usage
- › Press ESC to exit pattern mode.
+"
 
 
  pattern › p.
@@ -72,16 +64,12 @@ exports[`Watch mode flows Pressing "P" enters pattern mode 2`] = `
   › path/to/file10-test.js
 
   › and 1 more file
-[MOCK - cursorRestorePosition]
-[MOCK - cursorShow]"
+[MOCK - cursorTo(13, 4)]
+[MOCK - cursorRestorePosition]"
 `;
 
 exports[`Watch mode flows Pressing "P" enters pattern mode 3`] = `
-"[MOCK - cursorHide]
-[MOCK - clearScreen]
-
- Pattern Mode Usage
- › Press ESC to exit pattern mode.
+"
 
 
  pattern › p.*
@@ -111,16 +99,12 @@ exports[`Watch mode flows Pressing "P" enters pattern mode 3`] = `
   › path/to/file10-test.js
 
   › and 1 more file
-[MOCK - cursorRestorePosition]
-[MOCK - cursorShow]"
+[MOCK - cursorTo(14, 4)]
+[MOCK - cursorRestorePosition]"
 `;
 
 exports[`Watch mode flows Pressing "P" enters pattern mode 4`] = `
-"[MOCK - cursorHide]
-[MOCK - clearScreen]
-
- Pattern Mode Usage
- › Press ESC to exit pattern mode.
+"
 
 
  pattern › p.*1
@@ -134,16 +118,12 @@ exports[`Watch mode flows Pressing "P" enters pattern mode 4`] = `
   › path/to/file10-test.js
 
   › path/to/file11-test.js
-[MOCK - cursorRestorePosition]
-[MOCK - cursorShow]"
+[MOCK - cursorTo(15, 4)]
+[MOCK - cursorRestorePosition]"
 `;
 
 exports[`Watch mode flows Pressing "P" enters pattern mode 5`] = `
-"[MOCK - cursorHide]
-[MOCK - clearScreen]
-
- Pattern Mode Usage
- › Press ESC to exit pattern mode.
+"
 
 
  pattern › p.*10
@@ -153,16 +133,12 @@ exports[`Watch mode flows Pressing "P" enters pattern mode 5`] = `
  Pattern matches 1 file.
 
   › path/to/file10-test.js
-[MOCK - cursorRestorePosition]
-[MOCK - cursorShow]"
+[MOCK - cursorTo(16, 4)]
+[MOCK - cursorRestorePosition]"
 `;
 
 exports[`Watch mode flows Pressing "P" enters pattern mode 6`] = `
-"[MOCK - cursorHide]
-[MOCK - clearScreen]
-
- Pattern Mode Usage
- › Press ESC to exit pattern mode.
+"
 
 
  pattern › p.*1
@@ -176,16 +152,12 @@ exports[`Watch mode flows Pressing "P" enters pattern mode 6`] = `
   › path/to/file10-test.js
 
   › path/to/file11-test.js
-[MOCK - cursorRestorePosition]
-[MOCK - cursorShow]"
+[MOCK - cursorTo(15, 4)]
+[MOCK - cursorRestorePosition]"
 `;
 
 exports[`Watch mode flows Pressing "P" enters pattern mode 7`] = `
-"[MOCK - cursorHide]
-[MOCK - clearScreen]
-
- Pattern Mode Usage
- › Press ESC to exit pattern mode.
+"
 
 
  pattern › p.*
@@ -215,16 +187,12 @@ exports[`Watch mode flows Pressing "P" enters pattern mode 7`] = `
   › path/to/file10-test.js
 
   › and 1 more file
-[MOCK - cursorRestorePosition]
-[MOCK - cursorShow]"
+[MOCK - cursorTo(14, 4)]
+[MOCK - cursorRestorePosition]"
 `;
 
 exports[`Watch mode flows Pressing "P" enters pattern mode 8`] = `
-"[MOCK - cursorHide]
-[MOCK - clearScreen]
-
- Pattern Mode Usage
- › Press ESC to exit pattern mode.
+"
 
 
  pattern › p.*3
@@ -234,6 +202,6 @@ exports[`Watch mode flows Pressing "P" enters pattern mode 8`] = `
  Pattern matches 1 file.
 
   › path/to/file3-test.js
-[MOCK - cursorRestorePosition]
-[MOCK - cursorShow]"
+[MOCK - cursorTo(15, 4)]
+[MOCK - cursorRestorePosition]"
 `;

--- a/packages/jest-cli/src/__tests__/watch-pattern-mode-test.js
+++ b/packages/jest-cli/src/__tests__/watch-pattern-mode-test.js
@@ -17,10 +17,11 @@ const runJestMock = jest.fn();
 
 jest.mock('ansi-escapes', () => ({
   clearScreen: '[MOCK - clearScreen]',
-  cursorHide: '[MOCK - cursorHide]',
+  cursorHide: '[MOCK - ucursorHide]',
   cursorRestorePosition: '[MOCK - cursorRestorePosition]',
   cursorSavePosition: '[MOCK - cursorSavePosition]',
   cursorShow: '[MOCK - cursorShow]',
+  cursorTo: (x, y) => `[MOCK - cursorTo(${x}, ${y})]`,
 }));
 
 jest.mock('../SearchSource', () => class {

--- a/packages/jest-cli/src/__tests__/watch-pattern-mode-test.js
+++ b/packages/jest-cli/src/__tests__/watch-pattern-mode-test.js
@@ -17,7 +17,7 @@ const runJestMock = jest.fn();
 
 jest.mock('ansi-escapes', () => ({
   clearScreen: '[MOCK - clearScreen]',
-  cursorHide: '[MOCK - ucursorHide]',
+  cursorHide: '[MOCK - cursorHide]',
   cursorRestorePosition: '[MOCK - cursorRestorePosition]',
   cursorSavePosition: '[MOCK - cursorSavePosition]',
   cursorShow: '[MOCK - cursorShow]',

--- a/packages/jest-cli/src/patternMode.js
+++ b/packages/jest-cli/src/patternMode.js
@@ -14,11 +14,23 @@ import type {Config, Path} from 'types/Config';
 
 const {relativePath} = require('./reporters/utils');
 const ansiEscapes = require('ansi-escapes');
+const stringLength = require('string-length');
 const chalk = require('chalk');
 const highlight = require('./lib/highlight');
 const path = require('path');
 
 const pluralizeFile = (total: number) => total === 1 ? 'file' : 'files';
+
+const usage = (delimiter = '\n') => {
+  const messages = [
+    `\n ${chalk.bold('Pattern Mode Usage')}`,
+    ` ${chalk.dim('\u203A Press')} ESC ${chalk.dim('to exit pattern mode.')}\n`,
+  ];
+
+  return messages.filter(message => !!message).join(delimiter) + '\n';
+};
+
+const usageRows = usage().split('\n').length;
 
 const printTypeahead = (
   config: Config,
@@ -29,8 +41,10 @@ const printTypeahead = (
 ) => {
   const total = allResults.length;
   const results = allResults.slice(0, max);
+  const inputText = `${chalk.dim(' pattern \u203A')} ${pattern}`;
 
-  pipe.write(`${chalk.dim(' pattern \u203A')} ${pattern}`);
+  pipe.write(ansiEscapes.eraseDown);
+  pipe.write(inputText);
   pipe.write(ansiEscapes.cursorSavePosition);
 
   if (pattern) {
@@ -55,7 +69,11 @@ const printTypeahead = (
     pipe.write(`\n\n ${chalk.italic.yellow('Start typing to filter by a filename regex pattern.')}`);
   }
 
+  pipe.write(ansiEscapes.cursorTo(stringLength(inputText), usageRows - 1));
   pipe.write(ansiEscapes.cursorRestorePosition);
 };
 
-module.exports = printTypeahead;
+module.exports = {
+  printTypeahead,
+  usage,
+};

--- a/packages/jest-cli/src/patternMode.js
+++ b/packages/jest-cli/src/patternMode.js
@@ -21,7 +21,7 @@ const path = require('path');
 
 const pluralizeFile = (total: number) => total === 1 ? 'file' : 'files';
 
-const usage = (delimiter = '\n') => {
+const usage = (delimiter: string = '\n') => {
   const messages = [
     `\n ${chalk.bold('Pattern Mode Usage')}`,
     ` ${chalk.dim('\u203A Press')} ESC ${chalk.dim('to exit pattern mode.')}\n`,

--- a/packages/jest-cli/src/watch.js
+++ b/packages/jest-cli/src/watch.js
@@ -51,6 +51,13 @@ const watch = (
     startRun();
   });
 
+  process.on('exit', () => {
+    if (isEnteringPattern) {
+      pipe.write(ansiEscapes.cursorDown());
+      pipe.write(ansiEscapes.eraseDown);
+    }
+  });
+
   const writeCurrentPattern = () => {
     let regex;
 

--- a/packages/jest-cli/src/watch.js
+++ b/packages/jest-cli/src/watch.js
@@ -17,7 +17,7 @@ const chalk = require('chalk');
 const createHasteContext = require('./lib/createHasteContext');
 const HasteMap = require('jest-haste-map');
 const preRunMessage = require('./preRunMessage');
-const printTypeahead = require('./printTypeahead');
+const patternMode = require('./patternMode');
 const runJest = require('./runJest');
 const setWatchMode = require('./lib/setWatchMode');
 const SearchSource = require('./SearchSource');
@@ -61,11 +61,9 @@ const watch = (
     const paths = regex ?
       searchSource.findMatchingTests(currentPattern).paths : [];
 
-    pipe.write(ansiEscapes.cursorHide);
-    pipe.write(ansiEscapes.clearScreen);
-    pipe.write(patternUsage());
-    printTypeahead(config, pipe, currentPattern, paths);
-    pipe.write(ansiEscapes.cursorShow);
+    pipe.write(ansiEscapes.eraseLine);
+    pipe.write(ansiEscapes.cursorLeft);
+    patternMode.printTypeahead(config, pipe, currentPattern, paths);
   };
 
   const startRun = (overrideConfig: Object = {}) => {
@@ -171,6 +169,10 @@ const watch = (
       case KEYS.P:
         isEnteringPattern = true;
         currentPattern = '';
+        pipe.write(ansiEscapes.cursorHide);
+        pipe.write(ansiEscapes.clearScreen);
+        pipe.write(patternMode.usage());
+        pipe.write(ansiEscapes.cursorShow);
         writeCurrentPattern();
         break;
       case KEYS.QUESTION_MARK:
@@ -190,15 +192,6 @@ const watch = (
 
   startRun();
   return Promise.resolve();
-};
-
-const patternUsage = (delimiter = '\n') => {
-  const messages = [
-    `\n ${chalk.bold('Pattern Mode Usage')}`,
-    ` ${chalk.dim('\u203A Press')} ESC ${chalk.dim('to exit pattern mode.')}\n`,
-  ];
-
-  return messages.filter(message => !!message).join(delimiter) + '\n';
 };
 
 const usage = (


### PR DESCRIPTION
There are a some issues when using typeahead in different terminals mainly (xterm vs screen)

## Issues that this PR fixes

### 1) The cursor is in weird positions when using Terminal.app

See https://github.com/sindresorhus/ansi-escapes/issues/1 for more info about why this happens

To fix this instead of clearing the whole screen every time we are only clearing it then the user goes into pattern mode.
* For terminals that do not support `ansiEscapes.cursorRestorePosition` we use `ansiEscapes.cursorTo` as a fallback
* For terminals that do support `ansiEscapes.cursorRestorePosition` we use that.

##### NOTE: This also fixes an issue where the cursor in iTerm2 jumps around

![terminal-app-issue-before-and-after](https://cloud.githubusercontent.com/assets/574806/21948982/42ebae5c-d9b4-11e6-96b9-6ab441f6d2aa.gif)

### 2) Killing the process while the typeahead is active leaves some ghost characters.

**Before**
![kill-typeahead-issue](https://cloud.githubusercontent.com/assets/574806/21949007/85a05374-d9b4-11e6-8d36-8d41bce88b0e.gif)
**After**
![kill-typeahead-issue-after](https://cloud.githubusercontent.com/assets/574806/21949008/85a0bce2-d9b4-11e6-8e51-4ecacddeaa72.gif)

I've been testing typeahead mode in the following environments and it seems fine.

- iTerm2
  - with zsh
  - with bash
- Hyper
- Terminal.app
  - with tmux
  - with a Docker container
  - with sh
  - with bash
  - with zsh

Here is a mega gif how it works in each and every env
NOTE: I had some weird issues with my terminal half way through the video, feel free to either ignore it or troll me.

![mega-gif](https://cloud.githubusercontent.com/assets/574806/21949168/94f05b52-d9b5-11e6-8e4f-134a47dc95ef.gif)


## Final Notes
* I haven't test this in a **Windows** machine.
* I added https://github.com/sindresorhus/string-length as a dependency, just FWI let me know if that is fine :) 