### PR TITLE
Remove unnecessary test commands from packages. They don’t work anymore.

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,9 +43,10 @@
     "lint": "eslint . --cache",
     "postinstall": "node ./scripts/postinstall.js && node ./scripts/build.js && (cd packages/eslint-plugin-jest && yarn link) && yarn link eslint-plugin-jest",
     "publish": "yarn run build-clean && yarn run build && lerna publish",
-    "test": "yarn run typecheck && yarn run lint && yarn run build && yarn run jest && yarn run test-examples",
     "test-ci": "yarn run typecheck && yarn run lint && yarn run build && yarn run jest-coverage -- -i && yarn run test-examples && node scripts/mapCoverage.js && codecov",
     "test-examples": "node scripts/test_examples.js",
+    "test-pretty-format-perf": "node packages/pretty-format/perf/test.js",
+    "test": "yarn run typecheck && yarn run lint && yarn run build && yarn run jest && yarn run test-examples",
     "typecheck": "flow check",
     "watch": "yarn run build; node ./scripts/watch.js"
   },

--- a/packages/babel-plugin-jest-hoist/package.json
+++ b/packages/babel-plugin-jest-hoist/package.json
@@ -6,8 +6,5 @@
     "url": "https://github.com/facebook/jest.git"
   },
   "license": "BSD-3-Clause",
-  "main": "build/index.js",
-  "scripts": {
-    "test": "../../packages/jest-cli/bin/jest.js"
-  }
+  "main": "build/index.js"
 }

--- a/packages/jest-changed-files/package.json
+++ b/packages/jest-changed-files/package.json
@@ -6,8 +6,5 @@
     "url": "https://github.com/facebook/jest.git"
   },
   "license": "BSD-3-Clause",
-  "main": "build/index.js",
-  "scripts": {
-    "test": "../../packages/jest-cli/bin/jest.js"
-  }
+  "main": "build/index.js"
 }

--- a/packages/jest-cli/package.json
+++ b/packages/jest-cli/package.json
@@ -44,9 +44,6 @@
     "type": "git",
     "url": "https://github.com/facebook/jest"
   },
-  "scripts": {
-    "test": "./bin/jest.js"
-  },
   "bugs": {
     "url": "https://github.com/facebook/jest/issues"
   },

--- a/packages/jest-config/package.json
+++ b/packages/jest-config/package.json
@@ -16,8 +16,5 @@
     "jest-resolve": "^18.1.0",
     "jest-util": "^18.1.0",
     "json-stable-stringify": "^1.0.0"
-  },
-  "scripts": {
-    "test": "../../packages/jest-cli/bin/jest.js"
   }
 }

--- a/packages/jest-diff/package.json
+++ b/packages/jest-diff/package.json
@@ -12,8 +12,5 @@
     "diff": "^3.0.0",
     "jest-matcher-utils": "^18.1.0",
     "pretty-format": "^18.1.0"
-  },
-  "scripts": {
-    "test": "../../packages/jest-cli/bin/jest.js"
   }
 }

--- a/packages/jest-editor-support/package.json
+++ b/packages/jest-editor-support/package.json
@@ -7,9 +7,6 @@
   },
   "license": "BSD-3-Clause",
   "main": "build/index.js",
-  "scripts": {
-    "test": "../../packages/jest-cli/bin/jest.js"
-  },
   "optionalDependencies": {
     "typescript": "^2.0.10"
   },

--- a/packages/jest-environment-node/package.json
+++ b/packages/jest-environment-node/package.json
@@ -10,8 +10,5 @@
   "dependencies": {
     "jest-mock": "^18.0.0",
     "jest-util": "^18.1.0"
-  },
-  "scripts": {
-    "test": "../../packages/jest-cli/bin/jest.js"
   }
 }

--- a/packages/jest-file-exists/package.json
+++ b/packages/jest-file-exists/package.json
@@ -6,8 +6,5 @@
     "url": "https://github.com/facebook/jest.git"
   },
   "license": "BSD-3-Clause",
-  "main": "build/index.js",
-  "scripts": {
-    "test": "../../packages/jest-cli/bin/jest.js"
-  }
+  "main": "build/index.js"
 }

--- a/packages/jest-haste-map/package.json
+++ b/packages/jest-haste-map/package.json
@@ -13,8 +13,5 @@
     "micromatch": "^2.3.11",
     "sane": "~1.4.1",
     "worker-farm": "^1.3.1"
-  },
-  "scripts": {
-    "test": "../../packages/jest-cli/bin/jest.js"
   }
 }

--- a/packages/jest-jasmine2/package.json
+++ b/packages/jest-jasmine2/package.json
@@ -13,8 +13,5 @@
     "jest-matchers": "^18.1.0",
     "jest-snapshot": "^18.1.0",
     "jest-util": "^18.1.0"
-  },
-  "scripts": {
-    "test": "../../packages/jest-cli/bin/jest.js"
   }
 }

--- a/packages/jest-matcher-utils/package.json
+++ b/packages/jest-matcher-utils/package.json
@@ -8,9 +8,6 @@
   },
   "license": "BSD-3-Clause",
   "main": "build/index.js",
-  "scripts": {
-    "test": "../../packages/jest-cli/bin/jest.js"
-  },
   "dependencies": {
     "chalk": "^1.1.3",
     "pretty-format": "^18.1.0"

--- a/packages/jest-matchers/package.json
+++ b/packages/jest-matchers/package.json
@@ -12,8 +12,5 @@
     "jest-matcher-utils": "^18.1.0",
     "jest-util": "^18.1.0",
     "pretty-format": "^18.1.0"
-  },
-  "scripts": {
-    "test": "../../packages/jest-cli/bin/jest.js"
   }
 }

--- a/packages/jest-mock/package.json
+++ b/packages/jest-mock/package.json
@@ -6,8 +6,5 @@
     "url": "https://github.com/facebook/jest.git"
   },
   "license": "BSD-3-Clause",
-  "main": "build/index.js",
-  "scripts": {
-    "test": "../../packages/jest-cli/bin/jest.js"
-  }
+  "main": "build/index.js"
 }

--- a/packages/jest-repl/package.json
+++ b/packages/jest-repl/package.json
@@ -15,8 +15,5 @@
   },
   "bin": {
     "jest-repl": "./bin/jest-repl.js"
-  },
-  "scripts": {
-    "test": "../../packages/jest-cli/bin/jest.js"
   }
 }

--- a/packages/jest-resolve-dependencies/package.json
+++ b/packages/jest-resolve-dependencies/package.json
@@ -10,8 +10,5 @@
   "dependencies": {
     "jest-file-exists": "^17.0.0",
     "jest-resolve": "^18.1.0"
-  },
-  "scripts": {
-    "test": "../../packages/jest-cli/bin/jest.js"
   }
 }

--- a/packages/jest-resolve/package.json
+++ b/packages/jest-resolve/package.json
@@ -12,8 +12,5 @@
     "jest-file-exists": "^17.0.0",
     "jest-haste-map": "^18.1.0",
     "resolve": "^1.2.0"
-  },
-  "scripts": {
-    "test": "../../packages/jest-cli/bin/jest.js"
   }
 }

--- a/packages/jest-runtime/package.json
+++ b/packages/jest-runtime/package.json
@@ -25,15 +25,12 @@
     "strip-bom": "3.0.0",
     "yargs": "^6.3.0"
   },
-  "bin": {
-    "jest-runtime": "./bin/jest-runtime.js"
-  },
   "devDependencies": {
     "jest-config": "^18.1.0",
     "jest-environment-node": "^18.1.0",
     "jest-environment-jsdom": "^18.1.0"
   },
-  "scripts": {
-    "test": "../../packages/jest-cli/bin/jest.js"
+  "bin": {
+    "jest-runtime": "./bin/jest-runtime.js"
   }
 }

--- a/packages/jest-snapshot/package.json
+++ b/packages/jest-snapshot/package.json
@@ -14,8 +14,5 @@
     "jest-util": "^18.1.0",
     "natural-compare": "^1.4.0",
     "pretty-format": "^18.1.0"
-  },
-  "scripts": {
-    "test": "../jest-cli/bin/jest.js"
   }
 }

--- a/packages/jest-util/package.json
+++ b/packages/jest-util/package.json
@@ -14,8 +14,5 @@
     "jest-file-exists": "^17.0.0",
     "jest-mock": "^18.0.0",
     "mkdirp": "^0.5.1"
-  },
-  "scripts": {
-    "test": "../../packages/jest-cli/bin/jest.js"
   }
 }

--- a/packages/pretty-format/package.json
+++ b/packages/pretty-format/package.json
@@ -9,10 +9,6 @@
   "description": "Stringify any JavaScript value.",
   "main": "build/index.js",
   "author": "James Kyle <me@thejameskyle.com>",
-  "scripts": {
-    "test": "../../packages/jest-cli/bin/jest.js",
-    "perf": "node perf/test.js"
-  },
   "dependencies": {
     "ansi-styles": "^2.2.1"
   }

--- a/packages/pretty-format/perf/test.js
+++ b/packages/pretty-format/perf/test.js
@@ -14,7 +14,7 @@ const chalk = require('chalk');
 const leftPad = require('left-pad');
 const worldGeoJson = require('./world.geo.json');
 const React = require('react');
-const ReactTestRenderer = require('react/lib/ReactTestRenderer');
+const ReactTestRenderer = require('react-test-renderer');
 const ReactTestComponent = require('../build/plugins/ReactTestComponent');
 
 const NANOSECONDS = 1000000000;
@@ -54,7 +54,7 @@ function testCase(name, fn) {
 function test(name, value, ignoreResult, prettyFormatOpts) {
   const formatted = testCase(
     'prettyFormat()  ',
-    () => prettyFormat(value, prettyFormatOpts),
+    () => prettyFormat(value, prettyFormatOpts)
   );
 
   const inspected = testCase('util.inspect()  ', () => {
@@ -73,7 +73,7 @@ function test(name, value, ignoreResult, prettyFormatOpts) {
   });
 
   const winner = results[0];
-  
+
   results.forEach((item, index) => {
     item.isWinner = index === 0;
     item.isLoser  = index === results.length - 1;
@@ -202,9 +202,9 @@ const element = React.createElement(
   React.createElement('div'),
   React.createElement('div', {prop: {a: 1, b: 2}},
     React.createElement('div', null,
-      React.createElement('div'),
-    ),
-  ),
+      React.createElement('div')
+    )
+  )
 );
 
 test('react', ReactTestRenderer.create(element).toJSON(), false, {


### PR DESCRIPTION
We only support testing on the top level of the repo.