### PR TITLE
Fix typo in snapshotSerializers docs

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -329,7 +329,7 @@ test(() => {
     foo: {x: 1, y: 2}
   };
 
-  expect(foo).toMatchSnapshot();
+  expect(bar).toMatchSnapshot();
 });
 ```
 


### PR DESCRIPTION
**Summary**

There was a typo in `snapshotSerializers` docs.
