### PR TITLE
Remove circular dependency from jest-validate

### DIFF
--- a/packages/jest-config/src/index.js
+++ b/packages/jest-config/src/index.js
@@ -14,9 +14,6 @@ const path = require('path');
 const loadFromFile = require('./loadFromFile');
 const loadFromPackage = require('./loadFromPackage');
 const normalize = require('./normalize');
-const defaults = require('./defaults');
-const validConfig = require('./validConfig');
-const deprecatedConfig = require('./deprecated');
 const setFromArgv = require('./setFromArgv');
 
 const readConfig = (argv: Object, packageRoot: string) =>
@@ -51,9 +48,6 @@ const readRawConfig = (argv, root) => {
 };
 
 module.exports = {
-  defaults,
-  deprecatedConfig,
   normalize,
   readConfig,
-  validConfig,
 };

--- a/packages/jest-validate/package.json
+++ b/packages/jest-validate/package.json
@@ -11,8 +11,5 @@
     "chalk": "^1.1.1",
     "jest-matcher-utils": "^18.1.0",
     "pretty-format": "^18.1.0"
-  },
-  "devDependencies": {
-    "jest-config": "^18.1.0"
   }
 }

--- a/packages/jest-validate/src/__tests__/fixtures/jestConfig.js
+++ b/packages/jest-validate/src/__tests__/fixtures/jestConfig.js
@@ -10,8 +10,6 @@
 
 'use strict';
 
-import type {DefaultConfig, Config} from 'types/Config';
-
 const chalk = require('chalk');
 const os = require('os');
 const path = require('path');
@@ -25,7 +23,7 @@ const replacePathSepForRegex = (string: string) => {
 
 const NODE_MODULES_REGEXP = replacePathSepForRegex(NODE_MODULES);
 
-const defaultConfig: DefaultConfig = {
+const defaultConfig = {
   automock: false,
   bail: false,
   browser: false,
@@ -66,7 +64,7 @@ const defaultConfig: DefaultConfig = {
   watch: false,
 };
 
-const validConfig: Config = {
+const validConfig = {
   automock: false,
   bail: false,
   browser: false,
@@ -122,7 +120,6 @@ const validConfig: Config = {
   testRunner: 'jasmine2',
   testURL: 'about:blank',
   timers: 'real',
-  // $FlowFixMe – transform is further normalized into Array<[string, string]>
   transform: {
     '^.+\\.js$': '<rootDir>/preprocessor.js',
   },

--- a/packages/jest-validate/src/__tests__/fixtures/jestConfig.js
+++ b/packages/jest-validate/src/__tests__/fixtures/jestConfig.js
@@ -1,0 +1,168 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+
+'use strict';
+
+import type {DefaultConfig, Config} from 'types/Config';
+
+const chalk = require('chalk');
+const os = require('os');
+const path = require('path');
+const NODE_MODULES = path.sep + 'node_modules' + path.sep;
+const replacePathSepForRegex = (string: string) => {
+  if (path.sep === '\\') {
+    return string.replace(/(\/|\\(?!\.))/g, '\\\\');
+  }
+  return string;
+};
+
+const NODE_MODULES_REGEXP = replacePathSepForRegex(NODE_MODULES);
+
+const defaultConfig: DefaultConfig = {
+  automock: false,
+  bail: false,
+  browser: false,
+  cacheDirectory: path.join(os.tmpdir(), 'jest'),
+  coveragePathIgnorePatterns: [NODE_MODULES_REGEXP],
+  coverageReporters: ['json', 'text', 'lcov', 'clover'],
+  expand: false,
+  globals: {},
+  haste: {
+    providesModuleNodeModules: [],
+  },
+  mocksPattern: '__mocks__',
+  moduleDirectories: ['node_modules'],
+  moduleFileExtensions: [
+    'js',
+    'json',
+    'jsx',
+    'node',
+  ],
+  moduleNameMapper: {},
+  modulePathIgnorePatterns: [],
+  noStackTrace: false,
+  notify: false,
+  preset: null,
+  resetMocks: false,
+  resetModules: false,
+  snapshotSerializers: [],
+  testEnvironment: 'jest-environment-jsdom',
+  testPathDirs: ['<rootDir>'],
+  testPathIgnorePatterns: [NODE_MODULES_REGEXP],
+  testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.jsx?$',
+  testResultsProcessor: null,
+  testURL: 'about:blank',
+  timers: 'real',
+  transformIgnorePatterns: [NODE_MODULES_REGEXP],
+  useStderr: false,
+  verbose: null,
+  watch: false,
+};
+
+const validConfig: Config = {
+  automock: false,
+  bail: false,
+  browser: false,
+  cache: true,
+  cacheDirectory: '/tmp/user/jest',
+  collectCoverage: true,
+  collectCoverageFrom: ['src', '!public'],
+  collectCoverageOnlyFrom: {
+    '<rootDir>/this-directory-is-covered/covered.js': true,
+  },
+  coverageDirectory: 'coverage',
+  coveragePathIgnorePatterns: [NODE_MODULES_REGEXP],
+  coverageReporters: ['json', 'text', 'lcov', 'clover'],
+  coverageThreshold: {
+    global: {
+      branches: 50,
+    },
+  },
+  expand: false,
+  forceExit: false,
+  globals: {},
+  haste: {
+    providesModuleNodeModules: ['react', 'react-native'],
+  },
+  logHeapUsage: true,
+  logTransformErrors: true,
+  mocksPattern: '__mocks__',
+  moduleDirectories: ['node_modules'],
+  moduleFileExtensions: ['js', 'json', 'jsx', 'node'],
+  moduleLoader: '<rootDir>',
+  moduleNameMapper: {
+    '^React$': '<rootDir>/node_modules/react',
+  },
+  modulePathIgnorePatterns: ['<rootDir>/build/'],
+  modulePaths: ['/shared/vendor/modules'],
+  name: 'string',
+  noStackTrace: false,
+  notify: false,
+  preset: 'react-native',
+  resetMocks: false,
+  resetModules: false,
+  rootDir: '/',
+  setupFiles: ['<rootDir>/setup.js'],
+  setupTestFrameworkScriptFile: '<rootDir>/testSetupFile.js',
+  silent: true,
+  snapshotSerializers: ['my-serializer-module'],
+  testEnvironment: 'jest-environment-jsdom',
+  testNamePattern: 'test signature',
+  testPathDirs: ['<rootDir>'],
+  testPathIgnorePatterns: [NODE_MODULES_REGEXP],
+  testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.jsx?$',
+  testResultsProcessor: 'processor-node-module',
+  testRunner: 'jasmine2',
+  testURL: 'about:blank',
+  timers: 'real',
+  // $FlowFixMe – transform is further normalized into Array<[string, string]>
+  transform: {
+    '^.+\\.js$': '<rootDir>/preprocessor.js',
+  },
+  transformIgnorePatterns: [NODE_MODULES_REGEXP],
+  unmockedModulePathPatterns: ['mock'],
+  updateSnapshot: true,
+  useStderr: false,
+  verbose: false,
+  watch: false,
+  watchman: true,
+};
+
+const format = (value: string) => require('pretty-format')(value, {min: true});
+
+/* eslint-disable max-len */
+const deprecatedConfig = {
+  preprocessorIgnorePatterns: (config: Object) =>
+  `  Option ${chalk.bold('preprocessorIgnorePatterns')} was replaced by ${chalk.bold('transformIgnorePatterns')}, which support multiple preprocessors.
+
+  Jest now treats your current configuration as:
+  {
+    ${chalk.bold('"transformIgnorePatterns"')}: ${chalk.bold(`${format(config.preprocessorIgnorePatterns)}`)}
+  }
+
+  Please update your configuration.`,
+
+  scriptPreprocessor: (config: Object) =>
+  `  Option ${chalk.bold('scriptPreprocessor')} was replaced by ${chalk.bold('transform')}, which support multiple preprocessors.
+
+  Jest now treats your current configuration as:
+  {
+    ${chalk.bold('"transform"')}: ${chalk.bold(`{".*": ${format(config.scriptPreprocessor)}}`)}
+  }
+
+  Please update your configuration.`,
+};
+/* eslint-enable max-len */
+
+module.exports = {
+  defaultConfig,
+  deprecatedConfig,
+  validConfig,
+};

--- a/packages/jest-validate/src/__tests__/validate-test.js
+++ b/packages/jest-validate/src/__tests__/validate-test.js
@@ -10,8 +10,11 @@
 'use strict';
 
 const validate = require('../validate');
-const defaultConfig = require('jest-config').defaults;
-const {validConfig, deprecatedConfig} = require('jest-config');
+const {
+  defaultConfig,
+  validConfig,
+  deprecatedConfig,
+} = require('./fixtures/jestConfig');
 const jestValidateExampleConfig = require('../exampleConfig');
 const jestValidateDefaultConfig = require('../defaultConfig');
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

`jest-validate` had a circular dev dependency of `jest-config` for testing purposes. Removed this in favour of fixtures.

**Test plan**

jest
