### PR TITLE
Fix broken link to Babel's plugin inline-requests in blog post 'JavaS…

### DIFF
--- a/blog/2016-03-11-javascript-unit-testing-performance.md
+++ b/blog/2016-03-11-javascript-unit-testing-performance.md
@@ -73,7 +73,7 @@ describe('sum', () => {
 });
 ```
 
-We built a babel transform called [inline-requires](https://github.com/facebook/fbjs/blob/master/scripts/babel-6/inline-requires.js) that removes top-level require statements and inlines them in code. For example, the line `const sum = require('sum');` will be removed from code, but every use of `sum` in the file will be replaced by `require('sum')`. With this transform we can write tests just like you'd expect in Jasmine and the code gets transformed into this:
+We built a babel transform called [inline-requires](https://github.com/facebook/fbjs/blob/master/packages/babel-preset-fbjs/plugins/inline-requires.js) that removes top-level require statements and inlines them in code. For example, the line `const sum = require('sum');` will be removed from code, but every use of `sum` in the file will be replaced by `require('sum')`. With this transform we can write tests just like you'd expect in Jasmine and the code gets transformed into this:
 
 ```js
 describe('sum', () => {


### PR DESCRIPTION
…cript Unit Testing Performance'

**Summary**

Fixes the broken link in [JavaScript Unit Testing Performance](https://facebook.github.io/jest/blog/2016/03/11/javascript-unit-testing-performance.html) to the plugin inline-requires

**Test plan**

![screenshot - 17-01-2017 - 16 04 35](https://cloud.githubusercontent.com/assets/6930700/22033272/00d0a8b0-dccf-11e6-9e42-34d241395eab.png)
![screenshot - 17-01-2017 - 16 05 39](https://cloud.githubusercontent.com/assets/6930700/22033282/09da7d32-dccf-11e6-93e9-c37627ea4995.png)

