### PR TITLE
Truncate results in typeahead

### DIFF
--- a/packages/jest-cli/src/__tests__/__snapshots__/watch-pattern-mode-test.js.snap
+++ b/packages/jest-cli/src/__tests__/__snapshots__/watch-pattern-mode-test.js.snap
@@ -205,3 +205,108 @@ exports[`Watch mode flows Pressing "P" enters pattern mode 8`] = `
 [MOCK - cursorTo(15, 4)]
 [MOCK - cursorRestorePosition]"
 `;
+
+exports[`Watch mode flows Results in pattern mode get truncated appropriately 1`] = `
+"
+
+
+ pattern › a
+[MOCK - cursorSavePosition]
+
+
+ Pattern matches 11 files.
+
+  › path/to/file1-test.js
+
+  › path/to/file2-test.js
+
+  › path/to/file3-test.js
+
+  › path/to/file4-test.js
+
+  › path/to/file5-test.js
+
+  › path/to/file6-test.js
+
+  › path/to/file7-test.js
+
+  › path/to/file8-test.js
+
+  › path/to/file9-test.js
+
+  › path/to/file10-test.js
+
+  › and 1 more file
+[MOCK - cursorTo(12, 4)]
+[MOCK - cursorRestorePosition]"
+`;
+
+exports[`Watch mode flows Results in pattern mode get truncated appropriately 2`] = `
+"
+
+
+ pattern › a
+[MOCK - cursorSavePosition]
+
+
+ Pattern matches 11 files.
+
+  › ...to/file1-test.js
+
+  › ...to/file2-test.js
+
+  › ...to/file3-test.js
+
+  › ...to/file4-test.js
+
+  › ...to/file5-test.js
+
+  › ...to/file6-test.js
+
+  › ...to/file7-test.js
+
+  › ...to/file8-test.js
+
+  › ...to/file9-test.js
+
+  › ...o/file10-test.js
+
+  › and 1 more file
+[MOCK - cursorTo(12, 4)]
+[MOCK - cursorRestorePosition]"
+`;
+
+exports[`Watch mode flows Results in pattern mode get truncated appropriately 3`] = `
+"
+
+
+ pattern › a
+[MOCK - cursorSavePosition]
+
+
+ Pattern matches 11 files.
+
+  › ...st.js
+
+  › ...st.js
+
+  › ...st.js
+
+  › ...st.js
+
+  › ...st.js
+
+  › ...st.js
+
+  › ...st.js
+
+  › ...st.js
+
+  › ...st.js
+
+  › ...t.js
+
+  › and 1 more file
+[MOCK - cursorTo(12, 4)]
+[MOCK - cursorRestorePosition]"
+`;

--- a/packages/jest-cli/src/__tests__/watch-pattern-mode-test.js
+++ b/packages/jest-cli/src/__tests__/watch-pattern-mode-test.js
@@ -44,7 +44,11 @@ jest.mock('../SearchSource', () => class {
   }
 });
 
-jest.doMock('chalk', () => new chalk.constructor({enabled: false}));
+jest.doMock('chalk', () => Object.assign(
+  new chalk.constructor({enabled: false}),
+  {stripColor: str => str},
+));
+
 jest.doMock('../runJest', () => function() {
   const args = Array.from(arguments);
   runJestMock.apply(null, args);

--- a/packages/jest-cli/src/__tests__/watch-pattern-mode-test.js
+++ b/packages/jest-cli/src/__tests__/watch-pattern-mode-test.js
@@ -15,6 +15,8 @@ const {KEYS} = require('../constants');
 
 const runJestMock = jest.fn();
 
+let terminalWidth;
+
 jest.mock('ansi-escapes', () => ({
   clearScreen: '[MOCK - clearScreen]',
   cursorHide: '[MOCK - cursorHide]',
@@ -59,6 +61,10 @@ jest.doMock('../runJest', () => function() {
   return Promise.resolve();
 });
 
+jest.doMock('../lib/terminalUtils', () => ({
+  getTerminalWidth: () => terminalWidth,
+}));
+
 const watch = require('../watch');
 
 afterEach(runJestMock.mockReset);
@@ -72,6 +78,7 @@ describe('Watch mode flows', () => {
   let stdin;
 
   beforeEach(() => {
+    terminalWidth = 80;
     pipe = {write: jest.fn()};
     hasteMap = {on: () => {}};
     argv = {};
@@ -119,6 +126,21 @@ describe('Watch mode flows', () => {
       onlyChanged: false,
       watch: true,
       watchAll: false,
+    });
+  });
+
+  it('Results in pattern mode get truncated appropriately', () => {
+    config = {rootDir: ''};
+    watch(config, pipe, argv, hasteMap, hasteContext, stdin);
+
+    stdin.emit(KEYS.P);
+
+    [30, 25, 20].forEach(width => {
+      terminalWidth = width;
+      stdin.emit(KEYS.BACKSPACE);
+      pipe.write.mockReset();
+      stdin.emit(KEYS.A);
+      expect(pipe.write.mock.calls.join('\n')).toMatchSnapshot();
     });
   });
 });

--- a/packages/jest-cli/src/lib/__tests__/__snapshots__/highlight-test.js.snap
+++ b/packages/jest-cli/src/lib/__tests__/__snapshots__/highlight-test.js.snap
@@ -1,0 +1,53 @@
+exports[`test dims everything when there is no match 1`] = `"[2mjest-cli/__tests__/watch-test.js[22m"`;
+
+exports[`test dims everything when there is no match 2`] = `"[2m...t-cli/__tests__/watch-test.js[22m"`;
+
+exports[`test dims everything when there is no match 3`] = `"[2m.../__tests__/watch-test.js[22m"`;
+
+exports[`test dims everything when there is no match 4`] = `"[2m...sts__/watch-test.js[22m"`;
+
+exports[`test dims everything when there is no match 5`] = `"[2m...watch-test.js[22m"`;
+
+exports[`test dims everything when there is no match 6`] = `"[2m...-test.js[22m"`;
+
+exports[`test dims everything when there is no match 7`] = `"[2m....js[22m"`;
+
+exports[`test highlight the trimmed part when there is only a rootDir match 1`] = `"[2mjest-cli/__tests__/watch-test.js[22m"`;
+
+exports[`test highlight the trimmed part when there is only a rootDir match 2`] = `"[0m...[0m[2mt-cli/__tests__/watch-test.js[22m"`;
+
+exports[`test highlight the trimmed part when there is only a rootDir match 3`] = `"[0m...[0m[2m/__tests__/watch-test.js[22m"`;
+
+exports[`test highlight the trimmed part when there is only a rootDir match 4`] = `"[0m...[0m[2msts__/watch-test.js[22m"`;
+
+exports[`test highlight the trimmed part when there is only a rootDir match 5`] = `"[0m...[0m[2mwatch-test.js[22m"`;
+
+exports[`test highlight the trimmed part when there is only a rootDir match 6`] = `"[0m...[0m[2m-test.js[22m"`;
+
+exports[`test highlight the trimmed part when there is only a rootDir match 7`] = `"[0m...[0m[2m.js[22m"`;
+
+exports[`test highlights everything when there is a full match 1`] = `"[0mjest-cli/__tests__/watch-test.js[0m"`;
+
+exports[`test highlights everything when there is a full match 2`] = `"[0m...t-cli/__tests__/watch-test.js[0m"`;
+
+exports[`test highlights everything when there is a full match 3`] = `"[0m.../__tests__/watch-test.js[0m"`;
+
+exports[`test highlights everything when there is a full match 4`] = `"[0m...sts__/watch-test.js[0m"`;
+
+exports[`test highlights everything when there is a full match 5`] = `"[0m...watch-test.js[0m"`;
+
+exports[`test highlights everything when there is a full match 6`] = `"[0m...-test.js[0m"`;
+
+exports[`test highlights everything when there is a full match 7`] = `"[0m....js[0m"`;
+
+exports[`test highlights the trimmed part there is a non visible match 1`] = `"[0m...t-cli[0m[2m/__tests__/watch-test.js[22m"`;
+
+exports[`test highlights the trimmed part there is a non visible match 2`] = `"[0m...[0m[2m/__tests__/watch-test.js[22m"`;
+
+exports[`test highlights the trimmed part there is a non visible match 3`] = `"[0m...[0m[2msts__/watch-test.js[22m"`;
+
+exports[`test highlights the trimmed part there is a non visible match 4`] = `"[0m...[0m[2mwatch-test.js[22m"`;
+
+exports[`test highlights the trimmed part there is a non visible match 5`] = `"[0m...[0m[2m-test.js[22m"`;
+
+exports[`test highlights the trimmed part there is a non visible match 6`] = `"[0m...[0m[2m.js[22m"`;

--- a/packages/jest-cli/src/lib/__tests__/highlight-test.js
+++ b/packages/jest-cli/src/lib/__tests__/highlight-test.js
@@ -10,19 +10,41 @@
 
 'use strict';
 
-const {dim, reset} = require('chalk');
 const highlight = require('../highlight');
 
-it('Highlight only the matching part and dims the rest', () => {
-  let highlighted = `${dim('pa')}${reset('th/to/tes')}${dim('t')}`;
-  expect(highlight('path/to/test', 't.*s') === highlighted).toBeTruthy();
+const rootDir = '/Users/foo/dev/jest';
+const rawPath = rootDir + '/jest-cli/__tests__/watch-test.js';
+const relativePaths = [
+  'jest-cli/__tests__/watch-test.js',
+  '...t-cli/__tests__/watch-test.js',
+  '.../__tests__/watch-test.js',
+  '...sts__/watch-test.js',
+  '...watch-test.js',
+  '...-test.js',
+  '....js',
+];
 
-  highlighted = reset(`path/to/test`);
-  expect(highlight('path/to/test', 'path/to/test') === highlighted)
-    .toBeTruthy();
+it('highlight the trimmed part when there is only a rootDir match', () => {
+  relativePaths
+  .map(trimmed => highlight(rawPath, trimmed, 'Users/foo', rootDir))
+  .forEach(output => expect(output).toMatchSnapshot());
 });
 
-it('Returns the a dimmed string when nothing matches', () => {
-  expect(highlight('path/to/test', 'other'))
-    .toEqual(dim('path/to/test'));
+it('highlights the trimmed part there is a non visible match', () => {
+  relativePaths
+  .filter(filePath => filePath.startsWith('...'))
+  .map(trimmed => highlight(rawPath, trimmed, 'jest-cli', rootDir))
+  .forEach(output => expect(output).toMatchSnapshot());
+});
+
+it('dims everything when there is no match', () => {
+  relativePaths
+  .map(trimmed => highlight(rawPath, trimmed, 'nomatch', rootDir))
+  .forEach(output => expect(output).toMatchSnapshot());
+});
+
+it('highlights everything when there is a full match', () => {
+  relativePaths
+  .map(trimmed => highlight(rawPath, trimmed, 'User.*js', rootDir))
+  .forEach(output => expect(output).toMatchSnapshot());
 });

--- a/packages/jest-cli/src/lib/highlight.js
+++ b/packages/jest-cli/src/lib/highlight.js
@@ -11,33 +11,55 @@
 'use strict';
 
 const chalk = require('chalk');
+const path = require('path');
 
 const hit = chalk.reset;
 const miss = chalk.dim;
 
-const highlight = (str: string, pattern: string) => {
+const trim = '...';
+
+const colorize = (str: string, start: number, end: number) => (
+  miss(str.slice(0, start)) +
+  hit(str.slice(start, end)) +
+  miss(str.slice(end))
+);
+
+const highlight = (
+  rawPath: string,
+  filePath: string,
+  pattern: string,
+  rootDir: string) => {
+
   let regexp;
 
   try {
     regexp = new RegExp(pattern, 'i');
   } catch (e) {
-    return miss(str);
+    return miss(filePath);
   }
 
-  const match = regexp.exec(str);
+  rawPath = chalk.stripColor(rawPath);
+  filePath = chalk.stripColor(filePath);
+  const match = rawPath.match(regexp);
+
   if (!match) {
-    return miss(str);
+    return miss(filePath);
   }
 
-  const {index} = match;
-  const startMatch = match.index;
-  const endMatch = startMatch + match[0].length;
+  let offset;
+  let trimLength;
 
-  return (
-    miss(str.slice(0, index)) +
-    hit(str.slice(startMatch, endMatch)) +
-    miss(str.slice(endMatch))
-  );
+  if (filePath.startsWith(trim)) {
+    offset = rawPath.length - filePath.length;
+    trimLength = trim.length;
+  } else {
+    offset = rootDir.length + path.sep.length;
+    trimLength = 0;
+  }
+
+  const start = match.index - offset;
+  const end = start + match[0].length;
+  return colorize(filePath, Math.max(start, 0), Math.max(end, trimLength));
 };
 
 module.exports = highlight;

--- a/packages/jest-cli/src/lib/highlight.js
+++ b/packages/jest-cli/src/lib/highlight.js
@@ -28,7 +28,8 @@ const highlight = (
   rawPath: string,
   filePath: string,
   pattern: string,
-  rootDir: string) => {
+  rootDir: string,
+) => {
 
   let regexp;
 

--- a/packages/jest-cli/src/lib/terminalUtils.js
+++ b/packages/jest-cli/src/lib/terminalUtils.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+
+'use strict';
+
+/* $FlowFixMe */
+const getTerminalWidth = (): nubmer => process.stdout.columns;
+
+
+module.exports = {
+  getTerminalWidth,
+};

--- a/packages/jest-cli/src/patternMode.js
+++ b/packages/jest-cli/src/patternMode.js
@@ -14,6 +14,7 @@ import type {Config, Path} from 'types/Config';
 
 const ansiEscapes = require('ansi-escapes');
 const chalk = require('chalk');
+const {getTerminalWidth} = require('./lib/terminalUtils');
 const highlight = require('./lib/highlight');
 const stringLength = require('string-length');
 const {trimAndFormatPath} = require('./reporters/utils');
@@ -53,8 +54,7 @@ const printTypeahead = (
       pipe.write(`\n\n Pattern matches no files.`);
     }
 
-    // $FlowFixMe
-    const width: number = process.stdout.columns;
+    const width = getTerminalWidth();
     const prefix = `  ${chalk.dim('\u203A')} `;
     const padding = stringLength(prefix) + 2;
 

--- a/packages/jest-cli/src/patternMode.js
+++ b/packages/jest-cli/src/patternMode.js
@@ -59,11 +59,11 @@ const printTypeahead = (
     const padding = stringLength(prefix) + 2;
 
     results
-    .map(rawPath => {
-      const filePath = trimAndFormatPath(padding, config, rawPath, width);
-      return highlight(rawPath, filePath, pattern, config.rootDir);
-    })
-    .forEach(filePath => pipe.write(`\n  ${chalk.dim('\u203A')} ${filePath}`));
+      .map(rawPath => {
+        const filePath = trimAndFormatPath(padding, config, rawPath, width);
+        return highlight(rawPath, filePath, pattern, config.rootDir);
+      })
+      .forEach(filePath => pipe.write(`\n  ${chalk.dim('\u203A')} ${filePath}`));
 
     if (total > max) {
       const more = total - max;


### PR DESCRIPTION
**Summary**

Fixes: #2597 

![truncate](https://cloud.githubusercontent.com/assets/574806/22047846/39effbb4-dcde-11e6-8759-59b8a5ab9566.gif)

This truncates the results when there is not enough space and adds highlighting for several non trivial cases. I needed to do some extra parsing because the string that is used for filtering all the files and the one that we output is not the same_(full path vs formatted relative path)_
1. Highlight only the `...` when the pattern only matches something in the `rootDir`
1. Highlight the `...` and the beginning of the file path when the pattern matches something in the `rootDir` + something else. For example this regex `/Users/myuser/.*packages`

**Test plan**

* I'm still curious how all of this works in Windows 
* There is still one case that I know of that doesn't get highlighted. This is when the pattern matches only something in the `rootDir` and the result is not truncated, for example this pattern `Users`... If we want highlight something for this case we should first thing of how the UI would look for it.
