### PR TITLE
Define non-enumerable props for serializer when toMatchObject fails

### DIFF
--- a/packages/jest-matchers/src/__tests__/__snapshots__/matchers-test.js.snap
+++ b/packages/jest-matchers/src/__tests__/__snapshots__/matchers-test.js.snap
@@ -2583,6 +2583,52 @@ Difference:
 [2m ][22m"
 `;
 
+exports[`toMatchObject() {pass: false} expect({"$$typeof": Symbol(react.test.json), "children": ["received enum"], "props": {"style": {"color": "green", "textDecoration": "line-through"}}, "type": "li"}).toMatchObject({"$$typeof": Symbol(react.test.json), "children": ["expected enum"], "props": {"style": {"textDecoration": "none"}}, "type": "li"}) 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).toMatchObject([22m[32mexpected[39m[2m)[22m
+
+Expected value to match object:
+  [32m{\"$$typeof\": Symbol(react.test.json), \"children\": [\"expected enum\"], \"props\": {\"style\": {\"textDecoration\": \"none\"}}, \"type\": \"li\"}[39m
+Received:
+  [31m{\"$$typeof\": Symbol(react.test.json), \"children\": [\"received enum\"], \"props\": {\"style\": {\"color\": \"green\", \"textDecoration\": \"line-through\"}}, \"type\": \"li\"}[39m
+Difference:
+[32m- Expected[39m
+[31m+ Received[39m
+
+[2m <li[22m
+[2m   style={[22m
+[2m     Object {[22m
+[32m-      \"textDecoration\": \"none\",[39m
+[31m+      \"textDecoration\": \"line-through\",[39m
+[2m     }[22m
+[2m   }>[22m
+[32m-  expected enum[39m
+[31m+  received enum[39m
+[2m </li>[22m"
+`;
+
+exports[`toMatchObject() {pass: false} expect({"$$typeof": Symbol(react.test.json), "children": ["received enum"], "props": {"style": {"color": "green", "textDecoration": "line-through"}}, "type": "li"}).toMatchObject({"children": ["expected non-enum"], "props": {"style": {"textDecoration": "none"}}, "type": "li"}) 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).toMatchObject([22m[32mexpected[39m[2m)[22m
+
+Expected value to match object:
+  [32m{\"children\": [\"expected non-enum\"], \"props\": {\"style\": {\"textDecoration\": \"none\"}}, \"type\": \"li\"}[39m
+Received:
+  [31m{\"$$typeof\": Symbol(react.test.json), \"children\": [\"received enum\"], \"props\": {\"style\": {\"color\": \"green\", \"textDecoration\": \"line-through\"}}, \"type\": \"li\"}[39m
+Difference:
+[32m- Expected[39m
+[31m+ Received[39m
+
+[2m <li[22m
+[2m   style={[22m
+[2m     Object {[22m
+[32m-      \"textDecoration\": \"none\",[39m
+[31m+      \"textDecoration\": \"line-through\",[39m
+[2m     }[22m
+[2m   }>[22m
+[32m-  expected non-enum[39m
+[31m+  received enum[39m
+[2m </li>[22m"
+`;
+
 exports[`toMatchObject() {pass: false} expect({"a": "b", "c": "d"}).toMatchObject({"a": "b!", "c": "d"}) 1`] = `
 "[2mexpect([22m[31mreceived[39m[2m).toMatchObject([22m[32mexpected[39m[2m)[22m
 
@@ -2855,6 +2901,52 @@ Difference:
 [32m-  \"a\": null,[39m
 [31m+  \"a\": undefined,[39m
 [2m }[22m"
+`;
+
+exports[`toMatchObject() {pass: false} expect({"children": ["received non-enum"], "props": {"style": {"color": "green", "textDecoration": "line-through"}}, "type": "li"}).toMatchObject({"$$typeof": Symbol(react.test.json), "children": ["expected enum"], "props": {"style": {"textDecoration": "none"}}, "type": "li"}) 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).toMatchObject([22m[32mexpected[39m[2m)[22m
+
+Expected value to match object:
+  [32m{\"$$typeof\": Symbol(react.test.json), \"children\": [\"expected enum\"], \"props\": {\"style\": {\"textDecoration\": \"none\"}}, \"type\": \"li\"}[39m
+Received:
+  [31m{\"children\": [\"received non-enum\"], \"props\": {\"style\": {\"color\": \"green\", \"textDecoration\": \"line-through\"}}, \"type\": \"li\"}[39m
+Difference:
+[32m- Expected[39m
+[31m+ Received[39m
+
+[2m <li[22m
+[2m   style={[22m
+[2m     Object {[22m
+[32m-      \"textDecoration\": \"none\",[39m
+[31m+      \"textDecoration\": \"line-through\",[39m
+[2m     }[22m
+[2m   }>[22m
+[32m-  expected enum[39m
+[31m+  received non-enum[39m
+[2m </li>[22m"
+`;
+
+exports[`toMatchObject() {pass: false} expect({"children": ["received non-enum"], "props": {"style": {"color": "green", "textDecoration": "line-through"}}, "type": "li"}).toMatchObject({"children": ["expected non-enum"], "props": {"style": {"textDecoration": "none"}}, "type": "li"}) 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).toMatchObject([22m[32mexpected[39m[2m)[22m
+
+Expected value to match object:
+  [32m{\"children\": [\"expected non-enum\"], \"props\": {\"style\": {\"textDecoration\": \"none\"}}, \"type\": \"li\"}[39m
+Received:
+  [31m{\"children\": [\"received non-enum\"], \"props\": {\"style\": {\"color\": \"green\", \"textDecoration\": \"line-through\"}}, \"type\": \"li\"}[39m
+Difference:
+[32m- Expected[39m
+[31m+ Received[39m
+
+[2m <li[22m
+[2m   style={[22m
+[2m     Object {[22m
+[32m-      \"textDecoration\": \"none\",[39m
+[31m+      \"textDecoration\": \"line-through\",[39m
+[2m     }[22m
+[2m   }>[22m
+[32m-  expected non-enum[39m
+[31m+  received non-enum[39m
+[2m </li>[22m"
 `;
 
 exports[`toMatchObject() {pass: false} expect({}).toMatchObject({"a": undefined}) 1`] = `

--- a/packages/jest-matchers/src/__tests__/matchers-test.js
+++ b/packages/jest-matchers/src/__tests__/matchers-test.js
@@ -693,6 +693,41 @@ describe('toMatchObject()', () => {
     });
   });
 
+  const reactTestInstance = Symbol.for('react.test.json');
+  const expectedNonEnum = {
+    children: ['expected non-enum'],
+    props: {
+      style: {
+        textDecoration: 'none',
+      },
+    },
+    type: 'li',
+  };
+  Object.defineProperty(expectedNonEnum, '$$typeof', {
+    value: reactTestInstance,
+  });
+  const expectedEnum = Object.assign({}, expectedNonEnum, {
+    $$typeof: reactTestInstance,
+    children: ['expected enum'],
+  });
+  const receivedNonEnum = {
+    children: ['received non-enum'],
+    props: {
+      style: {
+        color: 'green',
+        textDecoration: 'line-through',
+      },
+    },
+    type: 'li',
+  };
+  Object.defineProperty(receivedNonEnum, '$$typeof', {
+    value: reactTestInstance,
+  });
+  const receivedEnum = Object.assign({}, receivedNonEnum, {
+    $$typeof: reactTestInstance,
+    children: ['received enum'],
+  });
+
   [
      [{a: 'b', c: 'd'}, {e: 'b'}],
      [{a: 'b', c: 'd'}, {a: 'b!', c: 'd'}],
@@ -713,6 +748,10 @@ describe('toMatchObject()', () => {
      [{}, {a: undefined}],
      [[1, 2, 3], [2, 3, 1]],
      [[1, 2, 3], [1, 2, 2]],
+     [receivedEnum, expectedEnum],
+     [receivedEnum, expectedNonEnum],
+     [receivedNonEnum, expectedEnum],
+     [receivedNonEnum, expectedNonEnum],
   ].forEach(([n1, n2]) => {
     it(`{pass: false} expect(${stringify(n1)}).toMatchObject(${stringify(n2)})`, () => {
       jestExpect(n1).not.toMatchObject(n2);


### PR DESCRIPTION
**Summary**

Fixes https://github.com/facebook/jest/issues/2351

Please forgive me for submitting a pull request before the issue is accepted

* No hard feelings if the issue is unacceptable
* Because this is my first code contribution to Jest, it might take a while to make it acceptable :)
* An implementation might make clear anything lacking in problem description and analysis

**Test plan**

* Added 4 tests to `matchers-test.js` and glad for advice how to improve or add to them
* Existing tests for `toMatchObject` still pass with the new code