### PR TITLE
Add "did you mean" to jest-validate

### DIFF
--- a/packages/jest-config/src/__tests__/__snapshots__/normalize-test.js.snap
+++ b/packages/jest-config/src/__tests__/__snapshots__/normalize-test.js.snap
@@ -1,7 +1,7 @@
 exports[`Upgrade help logs a warning when \`scriptPreprocessor\` and/or \`preprocessorIgnorePatterns\` are used 1`] = `
 "[33m[1m[1m●[1m Deprecation Warning[22m:
 
-  Option [1mpreprocessorIgnorePatterns[22m was replaced by [1mtransformIgnorePatterns[22m, which support multiple preprocessors.
+  Option [1m\"preprocessorIgnorePatterns\"[22m was replaced by [1m\"transformIgnorePatterns\"[22m, which support multiple preprocessors.
 
   Jest now treats your current configuration as:
   {

--- a/packages/jest-config/src/deprecated.js
+++ b/packages/jest-config/src/deprecated.js
@@ -16,7 +16,7 @@ const format = (value: string) => require('pretty-format')(value, {min: true});
 /* eslint-disable max-len */
 const deprecatedOptions = {
   preprocessorIgnorePatterns: (config: Object) =>
-  `  Option ${chalk.bold('preprocessorIgnorePatterns')} was replaced by ${chalk.bold('transformIgnorePatterns')}, which support multiple preprocessors.
+  `  Option ${chalk.bold('"preprocessorIgnorePatterns"')} was replaced by ${chalk.bold('"transformIgnorePatterns"')}, which support multiple preprocessors.
 
   Jest now treats your current configuration as:
   {
@@ -26,7 +26,7 @@ const deprecatedOptions = {
   Please update your configuration.`,
 
   scriptPreprocessor: (config: Object) =>
-  `  Option ${chalk.bold('scriptPreprocessor')} was replaced by ${chalk.bold('transform')}, which support multiple preprocessors.
+  `  Option ${chalk.bold('"scriptPreprocessor"')} was replaced by ${chalk.bold('"transform"')}, which support multiple preprocessors.
 
   Jest now treats your current configuration as:
   {

--- a/packages/jest-validate/README.md
+++ b/packages/jest-validate/README.md
@@ -39,6 +39,7 @@ type ValidationOptions = {
   title?: Title,
   unknown?: (
     config: Object,
+    exampleConfig: Object,
     option: string,
     options: ValidationOptions
   ) => void,

--- a/packages/jest-validate/package.json
+++ b/packages/jest-validate/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "chalk": "^1.1.1",
     "jest-matcher-utils": "^18.1.0",
+    "leven": "^2.0.0",
     "pretty-format": "^18.1.0"
   },
   "devDependencies": {

--- a/packages/jest-validate/src/__tests__/__snapshots__/validate-test.js.snap
+++ b/packages/jest-validate/src/__tests__/__snapshots__/validate-test.js.snap
@@ -16,7 +16,7 @@ exports[`test displays warning for unknown config options 1`] = `
 "[33m[1m[1m●[1m Validation Warning[22m:
 
   Unknown option [1m\"unkwon\"[22m with value [1m{}[22m was found. Did you mean [1m\"unknown\"[22m?
-  This is either a typing error or a user mistake. Fixing it will remove this message.
+  This is probably a typo. Fixing it will remove this message.
 [39m"
 `;
 
@@ -130,7 +130,7 @@ exports[`test works with custom warnings 1`] = `
 "[33m[1mMy Custom Warning[22m:
 
   Unknown option [1m\"unknown\"[22m with value [1m\"string\"[22m was found.
-  This is either a typing error or a user mistake. Fixing it will remove this message.
+  This is probably a typo. Fixing it will remove this message.
 
 My custom comment[39m"
 `;

--- a/packages/jest-validate/src/__tests__/__snapshots__/validate-test.js.snap
+++ b/packages/jest-validate/src/__tests__/__snapshots__/validate-test.js.snap
@@ -15,7 +15,7 @@ exports[`test displays warning for deprecated config options 1`] = `
 exports[`test displays warning for unknown config options 1`] = `
 "[33m[1m[1m●[1m Validation Warning[22m:
 
-  Unknown option [1munknown[22m with value [1m{}[22m was found.
+  Unknown option [1m\"unkwon\"[22m with value [1m{}[22m was found. Did you mean [1m\"unknown\"[22m?
   This is either a typing error or a user mistake. Fixing it will remove this message.
 [39m"
 `;
@@ -129,7 +129,7 @@ My custom comment[39m"
 exports[`test works with custom warnings 1`] = `
 "[33m[1mMy Custom Warning[22m:
 
-  Unknown option [1munknown[22m with value [1m\"string\"[22m was found.
+  Unknown option [1m\"unknown\"[22m with value [1m\"string\"[22m was found.
   This is either a typing error or a user mistake. Fixing it will remove this message.
 
 My custom comment[39m"

--- a/packages/jest-validate/src/__tests__/__snapshots__/validate-test.js.snap
+++ b/packages/jest-validate/src/__tests__/__snapshots__/validate-test.js.snap
@@ -1,7 +1,7 @@
 exports[`test displays warning for deprecated config options 1`] = `
 "[33m[1m[1m●[1m Deprecation Warning[22m:
 
-  Option [1mscriptPreprocessor[22m was replaced by [1mtransform[22m, which support multiple preprocessors.
+  Option [1m\"scriptPreprocessor\"[22m was replaced by [1m\"transform\"[22m, which support multiple preprocessors.
 
   Jest now treats your current configuration as:
   {
@@ -23,7 +23,7 @@ exports[`test displays warning for unknown config options 1`] = `
 exports[`test pretty prints valid config for Array 1`] = `
 "[31m[1m[1m●[1m Validation Error[22m:
 
-  Option [1mcoverageReporters[22m must be of type:
+  Option [1m\"coverageReporters\"[22m must be of type:
     [1m[32marray[31m[22m
   but instead received:
     [1m[31mobject[31m[22m
@@ -38,7 +38,7 @@ exports[`test pretty prints valid config for Array 1`] = `
 exports[`test pretty prints valid config for Boolean 1`] = `
 "[31m[1m[1m●[1m Validation Error[22m:
 
-  Option [1mautomock[22m must be of type:
+  Option [1m\"automock\"[22m must be of type:
     [1m[32mboolean[31m[22m
   but instead received:
     [1m[31marray[31m[22m
@@ -53,7 +53,7 @@ exports[`test pretty prints valid config for Boolean 1`] = `
 exports[`test pretty prints valid config for Function 1`] = `
 "[31m[1m[1m●[1m Validation Error[22m:
 
-  Option [1mfn[22m must be of type:
+  Option [1m\"fn\"[22m must be of type:
     [1m[32mfunction[31m[22m
   but instead received:
     [1m[31mstring[31m[22m
@@ -68,7 +68,7 @@ exports[`test pretty prints valid config for Function 1`] = `
 exports[`test pretty prints valid config for Object 1`] = `
 "[31m[1m[1m●[1m Validation Error[22m:
 
-  Option [1mhaste[22m must be of type:
+  Option [1m\"haste\"[22m must be of type:
     [1m[32mobject[31m[22m
   but instead received:
     [1m[31mnumber[31m[22m
@@ -83,7 +83,7 @@ exports[`test pretty prints valid config for Object 1`] = `
 exports[`test pretty prints valid config for String 1`] = `
 "[31m[1m[1m●[1m Validation Error[22m:
 
-  Option [1mpreset[22m must be of type:
+  Option [1m\"preset\"[22m must be of type:
     [1m[32mstring[31m[22m
   but instead received:
     [1m[31mnumber[31m[22m
@@ -98,7 +98,7 @@ exports[`test pretty prints valid config for String 1`] = `
 exports[`test works with custom deprecations 1`] = `
 "[33m[1mMy Custom Deprecation Warning[22m:
 
-  Option [1mscriptPreprocessor[22m was replaced by [1mtransform[22m, which support multiple preprocessors.
+  Option [1m\"scriptPreprocessor\"[22m was replaced by [1m\"transform\"[22m, which support multiple preprocessors.
 
   Jest now treats your current configuration as:
   {
@@ -113,7 +113,7 @@ My custom comment[39m"
 exports[`test works with custom errors 1`] = `
 "[31m[1mMy Custom Error[22m:
 
-  Option [1mtest[22m must be of type:
+  Option [1m\"test\"[22m must be of type:
     [1m[32marray[31m[22m
   but instead received:
     [1m[31mstring[31m[22m

--- a/packages/jest-validate/src/__tests__/validate-test.js
+++ b/packages/jest-validate/src/__tests__/validate-test.js
@@ -53,7 +53,8 @@ test('omits null and undefined config values', () => {
 });
 
 test('displays warning for unknown config options', () => {
-  const config = {unknown: {}};
+  const config = {unkwon: {}};
+  const validConfig = {unknown: 'string'};
   const warn = console.warn;
   console.warn = jest.fn();
 

--- a/packages/jest-validate/src/errors.js
+++ b/packages/jest-validate/src/errors.js
@@ -23,7 +23,7 @@ const errorMessage = (
   options: ValidationOptions,
 ): void => {
   const message =
-`  Option ${chalk.bold(option)} must be of type:
+`  Option ${chalk.bold(`"${option}"`)} must be of type:
     ${chalk.bold.green(getType(defaultValue))}
   but instead received:
     ${chalk.bold.red(getType(received))}

--- a/packages/jest-validate/src/index.js
+++ b/packages/jest-validate/src/index.js
@@ -12,6 +12,7 @@
 
 module.exports = {
   ValidationError: require('./errors').ValidationError,
+  createDidYouMeanMessage: require('./utils').createDidYouMeanMessage,
   logValidationWarning: require('./utils').logValidationWarning,
   validate: require('./validate'),
 };

--- a/packages/jest-validate/src/types.js
+++ b/packages/jest-validate/src/types.js
@@ -36,6 +36,7 @@ export type ValidationOptions = {
   title?: Title,
   unknown?: (
     config: Object,
+    exampleConfig: Object,
     option: string,
     options: ValidationOptions
   ) => void,

--- a/packages/jest-validate/src/utils.js
+++ b/packages/jest-validate/src/utils.js
@@ -48,22 +48,14 @@ const createDidYouMeanMessage = (
   allowedOptions: Array<string>,
 ) => {
   const leven = require('leven');
-  let suggestion;
-
-  allowedOptions.some(option => {
-    const steps = leven(option, unrecognized);
-    if (steps < 3) {
-      suggestion = option;
-      return true;
-    }
-    return false;
+  const suggestion = allowedOptions.find(option => {
+    const steps: number = leven(option, unrecognized);
+    return steps < 3;
   });
 
-  if (suggestion) {
-    return `Did you mean ${chalk.bold(format(suggestion))}?`;
-  }
-
-  return '';
+  return suggestion
+    ? `Did you mean ${chalk.bold(format(suggestion))}?`
+    : '';
 };
 
 module.exports = {

--- a/packages/jest-validate/src/utils.js
+++ b/packages/jest-validate/src/utils.js
@@ -54,9 +54,9 @@ const createDidYouMeanMessage = (
     const steps = leven(option, unrecognized);
     if (steps < 3) {
       suggestion = option;
-      return option;
+      return true;
     }
-    return null;
+    return false;
   });
 
   if (suggestion) {

--- a/packages/jest-validate/src/utils.js
+++ b/packages/jest-validate/src/utils.js
@@ -43,11 +43,35 @@ const logValidationWarning = (
   console.warn(chalk.yellow(chalk.bold(name) + ':\n\n' + message + comment));
 };
 
+const createDidYouMeanMessage = (
+  unrecognized: string,
+  allowedOptions: Array<string>,
+) => {
+  const leven = require('leven');
+  let suggestion;
+
+  allowedOptions.some(option => {
+    const steps = leven(option, unrecognized);
+    if (steps < 3) {
+      suggestion = option;
+      return option;
+    }
+    return null;
+  });
+
+  if (suggestion) {
+    return `Did you mean ${chalk.bold(format(suggestion))}?`;
+  }
+
+  return '';
+};
+
 module.exports = {
   DEPRECATION,
   ERROR,
   ValidationError,
   WARNING,
+  createDidYouMeanMessage,
   format,
   logValidationWarning,
 };

--- a/packages/jest-validate/src/validate.js
+++ b/packages/jest-validate/src/validate.js
@@ -31,7 +31,8 @@ const _validate = (config: Object, options: ValidationOptions) => {
     ) {
       options.deprecate(config, key, options.deprecatedConfig, options);
     } else {
-      options.unknown && options.unknown(config, key, options);
+      options.unknown &&
+        options.unknown(config, options.exampleConfig, key, options);
     }
   }
 };

--- a/packages/jest-validate/src/warnings.js
+++ b/packages/jest-validate/src/warnings.js
@@ -32,7 +32,7 @@ const unknownOptionWarning = (
   const message =
   `  Unknown option ${chalk.bold(`"${option}"`)} with value ${chalk.bold(format(config[option]))} was found.` +
   (didYouMean && ` ${didYouMean}`) +
-  `\n  This is either a typing error or a user mistake. Fixing it will remove this message.`;
+  `\n  This is probably a typo. Fixing it will remove this message.`;
   /* eslint-enable max-len */
 
   const comment = options.comment;

--- a/packages/jest-validate/src/warnings.js
+++ b/packages/jest-validate/src/warnings.js
@@ -13,17 +13,26 @@
 import type {ValidationOptions} from './types';
 
 const chalk = require('chalk');
-const {format, logValidationWarning, WARNING} = require('./utils');
+const {
+  format,
+  logValidationWarning,
+  createDidYouMeanMessage,
+  WARNING,
+} = require('./utils');
 
 const unknownOptionWarning = (
   config: Object,
+  exampleConfig: Object,
   option: string,
   options: ValidationOptions
 ): void => {
+  const didyoumean =
+    createDidYouMeanMessage(option, Object.keys(exampleConfig));
   /* eslint-disable max-len */
   const message =
-`  Unknown option ${chalk.bold(option)} with value ${chalk.bold(format(config[option]))} was found.
-  This is either a typing error or a user mistake. Fixing it will remove this message.`;
+  `  Unknown option ${chalk.bold(`"${option}"`)} with value ${chalk.bold(format(config[option]))} was found.` +
+  (didyoumean && ` ${didyoumean}`) +
+  `\n  This is either a typing error or a user mistake. Fixing it will remove this message.`;
   /* eslint-enable max-len */
 
   const comment = options.comment;

--- a/packages/jest-validate/src/warnings.js
+++ b/packages/jest-validate/src/warnings.js
@@ -26,12 +26,12 @@ const unknownOptionWarning = (
   option: string,
   options: ValidationOptions
 ): void => {
-  const didyoumean =
+  const didYouMean =
     createDidYouMeanMessage(option, Object.keys(exampleConfig));
   /* eslint-disable max-len */
   const message =
   `  Unknown option ${chalk.bold(`"${option}"`)} with value ${chalk.bold(format(config[option]))} was found.` +
-  (didyoumean && ` ${didyoumean}`) +
+  (didYouMean && ` ${didYouMean}`) +
   `\n  This is either a typing error or a user mistake. Fixing it will remove this message.`;
   /* eslint-enable max-len */
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Add "did you mean" to warnings with the help of Levenshtein. I'm also exporting a helper function to create that message, so it can be used in other warnings and errors (like CLI ones)

<img width="624" alt="screen shot 2017-01-18 at 22 44 27" src="https://cloud.githubusercontent.com/assets/5106466/22085138/1498e222-ddd3-11e6-8b67-98590401c856.png">

This PR also adds quotation marks around config keys, as I thought this is useful for terminals without bolding enabled:

<img width="434" alt="screen shot 2017-01-18 at 23 08 59" src="https://cloud.githubusercontent.com/assets/5106466/22085200/47d2e78c-ddd3-11e6-853c-3d1abb22a403.png">

**Test plan**

jest