### PR TITLE
Remove always undefined snapshotState

### DIFF
--- a/packages/jest-snapshot/src/index.js
+++ b/packages/jest-snapshot/src/index.js
@@ -51,16 +51,12 @@ const cleanup = (hasteFS: HasteFS, update: boolean) => {
   };
 };
 
-let snapshotState;
-
 const initializeSnapshotState = (
   testFile: Path,
   update: boolean,
   testPath: string,
   expand: boolean,
 ) => new SnapshotState(testFile, update, testPath, expand);
-
-const getSnapshotState = () => snapshotState;
 
 const toMatchSnapshot = function(received: any, testName?: string) {
   this.dontThrow && this.dontThrow();
@@ -160,7 +156,6 @@ module.exports = {
   addPlugins,
   cleanup,
   getPlugins,
-  getSnapshotState,
   initializeSnapshotState,
   toMatchSnapshot,
   toThrowErrorMatchingSnapshot,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Removing `snapshotState` and `getSnapshotState` as they don't seem to do _anything_. The former is always `undefined`, and neither are ever used in the code base. Also, this removes the "shadowing" with the other `snapshotState` within `toMatchSnapshot`.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

Ran the tests, scanned through the code base. Couldn't find any use of these. The setup in `setup-jest-globals.js` relies on `initializeSnapshotState` which returns the initialized snapshot state but doesn't write to the `snapshotState` variable.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
