### PR TITLE
“typo” -> “typing mistake”

### DIFF
--- a/packages/jest-validate/src/__tests__/__snapshots__/validate-test.js.snap
+++ b/packages/jest-validate/src/__tests__/__snapshots__/validate-test.js.snap
@@ -16,7 +16,7 @@ exports[`test displays warning for unknown config options 1`] = `
 "[33m[1m[1m●[1m Validation Warning[22m:
 
   Unknown option [1m\"unkwon\"[22m with value [1m{}[22m was found. Did you mean [1m\"unknown\"[22m?
-  This is probably a typo. Fixing it will remove this message.
+  This is probably a typing mistake. Fixing it will remove this message.
 [39m"
 `;
 
@@ -130,7 +130,7 @@ exports[`test works with custom warnings 1`] = `
 "[33m[1mMy Custom Warning[22m:
 
   Unknown option [1m\"unknown\"[22m with value [1m\"string\"[22m was found.
-  This is probably a typo. Fixing it will remove this message.
+  This is probably a typing mistake. Fixing it will remove this message.
 
 My custom comment[39m"
 `;

--- a/packages/jest-validate/src/warnings.js
+++ b/packages/jest-validate/src/warnings.js
@@ -32,7 +32,7 @@ const unknownOptionWarning = (
   const message =
   `  Unknown option ${chalk.bold(`"${option}"`)} with value ${chalk.bold(format(config[option]))} was found.` +
   (didYouMean && ` ${didYouMean}`) +
-  `\n  This is probably a typo. Fixing it will remove this message.`;
+  `\n  This is probably a typing mistake. Fixing it will remove this message.`;
   /* eslint-enable max-len */
 
   const comment = options.comment;


### PR DESCRIPTION
I think "typing mistake" is better use of language for a tool like Jest (or jest-validate). @thymikee it's your decision: approve or request changes on this. After that, we can tag jest-validate 18.2.