### PR TITLE
Provide more info about using custom transforms

### DIFF
--- a/docs/TutorialReact.md
+++ b/docs/TutorialReact.md
@@ -267,6 +267,8 @@ Don't forget to install the `babel-core` and `babel-preset-jest` packages for th
 
 To make this work with Jest you need to update your Jest configuration with this: `"transform": {"\\.js$": "path/to/custom-transformer.js"}`.
 
+Introducing custom transform rules this way will disable the default babel-jest implementation and disable support for ES6 syntax. Please see [the documentation for transform](https://facebook.github.io/jest/docs/configuration.html#transform-object-string-string) for more information.
+
 If you'd like to build a transformer with babel support, you can also use babel-jest to compose one and pass in your custom configuration options:
 
 ```javascript


### PR DESCRIPTION
Introducing a custom transform block into the config disables the default-provided ES6 transform and can lead to errors about invalid syntax. Even though this is explained in the API section on configuration I think it's worth to point out in the example too.

Alternatively the transform block can be merged with default - is the case of disabling ES6 support something people do?