### PR TITLE
shortcuts for toHaveBeenCalledTimes - following up #2547

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -309,6 +309,20 @@ describe('drinkEach', () => {
 });
 ```
 
+You can use the following shortcut methods: toBeCalledOnce(), toBeCalledTwice(), toBeCalledThrice(), toBeCalledFourTimes() instead of the more verbose toHaveBeenCalledTimes(1), toHaveBeenCalledTimes(2), etc.
+
+For example:
+
+```js
+describe('drinkEach', () => {
+  it('drinks each drink', () => {
+    let drink = jest.fn();
+    drinkEach(drink, ['lemon', 'octopus']);
+    expect(drink).toBeCalledTwice();
+  });
+});
+```
+
 ### `.toHaveBeenCalledWith(arg1, arg2, ...)`
 
 Use `.toHaveBeenCalledWith` to ensure that a mock function was called with specific

--- a/packages/jest-matchers/src/__tests__/spyMatchers-test.js
+++ b/packages/jest-matchers/src/__tests__/spyMatchers-test.js
@@ -98,6 +98,37 @@ describe('toHaveBeenCalledTimes', () => {
   });
 });
 
+describe('toBeCalled*', () => {
+
+  it(`fails when called-times shortcuts receive expected value`, () => {
+    const fn = jasmine.createSpy('fn');
+
+    ['toBeCalledOnce',
+      'toBeCalledTwice',
+      'toBeCalledThrice',
+      'toBeCalledFourTimes'].forEach(matcherName =>
+      expect(() => jestExpect(fn)[matcherName](1))
+        .toThrowErrorMatchingSnapshot());
+  });
+
+  it(`passes when calls count match shortcut`, () => {
+    ['toBeCalledOnce',
+      'toBeCalledTwice',
+      'toBeCalledThrice',
+      'toBeCalledFourTimes'].forEach((matcherName, matcherIndx) => {
+
+        matcherIndx += 1;
+        const fn = jasmine.createSpy('fn');
+
+        for (let i = 0; i < matcherIndx; i++) {
+          fn();
+        }
+
+        jestExpect(fn)[matcherName]();
+      });
+  });
+});
+
 [
   'lastCalledWith',
   'toBeCalled',

--- a/packages/jest-matchers/src/spyMatchers.js
+++ b/packages/jest-matchers/src/spyMatchers.js
@@ -111,56 +111,55 @@ const createLastCalledWithMatcher = matcherName =>
   };
 
 const createCallTimesMatcher = (matcherName, times = null) =>
-	(
-		received: any,
-	  expected: number
-	) => {
+  (
+    received: any,
+    expected: number
+  ) => {
 
-		if (times){
-			ensureNoExpected(expected, matcherName);
-			expected = times;
-		}
+    if (times) {
+      ensureNoExpected(expected, matcherName);
+      expected = times;
+    }
 
-		ensureExpectedIsNumber(expected, matcherName);
-		ensureMock(received, matcherName);
+    ensureExpectedIsNumber(expected, matcherName);
+    ensureMock(received, matcherName);
 
-		const receivedIsSpy = isSpy(received);
-		const type = receivedIsSpy ? 'spy' : 'mock function';
-		const count = receivedIsSpy
-			? received.calls.count()
-			: received.mock.calls.length;
-		const pass = count === expected;
-		const message = pass
-			? () => matcherHint(
-				'.not' +
-				matcherName,
-				RECEIVED_NAME[type],
-				String(expected),
-			) +
-			`\n\n` +
-			`Expected ${type} not to be called ` +
-			`${EXPECTED_COLOR(pluralize('time', expected))}, but it was` +
-			` called exactly ${RECEIVED_COLOR(pluralize('time', count))}.`
-			: () => matcherHint(matcherName, RECEIVED_NAME[type], String(expected)) +
-			'\n\n' +
-			`Expected ${type} to have been called ` +
-			`${EXPECTED_COLOR(pluralize('time', expected))},` +
-			` but it was called ${RECEIVED_COLOR(pluralize('time', count))}.`;
+    const receivedIsSpy = isSpy(received);
+    const type = receivedIsSpy ? 'spy' : 'mock function';
+    const count = receivedIsSpy
+      ? received.calls.count()
+      : received.mock.calls.length;
+    const pass = count === expected;
+    const message = pass
+      ? () => matcherHint(
+        '.not' +
+        matcherName,
+        RECEIVED_NAME[type],
+        String(expected),
+      ) +
+      `\n\n` +
+      `Expected ${type} not to be called ` +
+      `${EXPECTED_COLOR(pluralize('time', expected))}, but it was` +
+      ` called exactly ${RECEIVED_COLOR(pluralize('time', count))}.`
+      : () => matcherHint(matcherName, RECEIVED_NAME[type], String(expected)) +
+      '\n\n' +
+      `Expected ${type} to have been called ` +
+      `${EXPECTED_COLOR(pluralize('time', expected))},` +
+      ` but it was called ${RECEIVED_COLOR(pluralize('time', count))}.`;
 
-		return {message, pass};
-	};
+    return {message, pass};
+  };
 
 const spyMatchers: MatchersObject = {
   lastCalledWith: createLastCalledWithMatcher('.lastCalledWith'),
   toBeCalled: createToBeCalledMatcher('.toBeCalled'),
+  toBeCalledFourTimes: createCallTimesMatcher('.toBeCalledFourTimes', 4),
+  toBeCalledOnce: createCallTimesMatcher('.toBeCalledOnce', 1),
+  toBeCalledThrice: createCallTimesMatcher('.toBeCalledThrice', 3),
+  toBeCalledTwice: createCallTimesMatcher('.toBeCalledTwice', 2),
   toBeCalledWith: createToBeCalledWithMatcher('.toBeCalledWith'),
   toHaveBeenCalled: createToBeCalledMatcher('.toHaveBeenCalled'),
   toHaveBeenCalledTimes: createCallTimesMatcher('.toHaveBeenCalledTimes'),
-	toHaveBeenCalledOnce: createCallTimesMatcher('.toHaveBeenCalledOnce', 1),
-	toHaveBeenCalledTwice: createCallTimesMatcher('.toHaveBeenCalledTwice', 2),
-	toHaveBeenCalledThrice: createCallTimesMatcher('.toHaveBeenCalledThrice', 3),
-	toHaveBeenCalledFourTimes:
-		createCallTimesMatcher('.toHaveBeenCalledFourTimes', 4),
   toHaveBeenCalledWith: createToBeCalledWithMatcher('.toHaveBeenCalledWith'),
   toHaveBeenLastCalledWith:
     createLastCalledWithMatcher('.toHaveBeenLastCalledWith'),

--- a/packages/jest-matchers/src/spyMatchers.js
+++ b/packages/jest-matchers/src/spyMatchers.js
@@ -110,41 +110,57 @@ const createLastCalledWithMatcher = matcherName =>
     return {message, pass};
   };
 
+const createCallTimesMatcher = (matcherName, times = null) =>
+	(
+		received: any,
+	  expected: number
+	) => {
+
+		if (times){
+			ensureNoExpected(expected, matcherName);
+			expected = times;
+		}
+
+		ensureExpectedIsNumber(expected, matcherName);
+		ensureMock(received, matcherName);
+
+		const receivedIsSpy = isSpy(received);
+		const type = receivedIsSpy ? 'spy' : 'mock function';
+		const count = receivedIsSpy
+			? received.calls.count()
+			: received.mock.calls.length;
+		const pass = count === expected;
+		const message = pass
+			? () => matcherHint(
+				'.not' +
+				matcherName,
+				RECEIVED_NAME[type],
+				String(expected),
+			) +
+			`\n\n` +
+			`Expected ${type} not to be called ` +
+			`${EXPECTED_COLOR(pluralize('time', expected))}, but it was` +
+			` called exactly ${RECEIVED_COLOR(pluralize('time', count))}.`
+			: () => matcherHint(matcherName, RECEIVED_NAME[type], String(expected)) +
+			'\n\n' +
+			`Expected ${type} to have been called ` +
+			`${EXPECTED_COLOR(pluralize('time', expected))},` +
+			` but it was called ${RECEIVED_COLOR(pluralize('time', count))}.`;
+
+		return {message, pass};
+	};
+
 const spyMatchers: MatchersObject = {
   lastCalledWith: createLastCalledWithMatcher('.lastCalledWith'),
   toBeCalled: createToBeCalledMatcher('.toBeCalled'),
   toBeCalledWith: createToBeCalledWithMatcher('.toBeCalledWith'),
   toHaveBeenCalled: createToBeCalledMatcher('.toHaveBeenCalled'),
-  toHaveBeenCalledTimes(received: any, expected: number) {
-    const matcherName = '.toHaveBeenCalledTimes';
-    ensureExpectedIsNumber(expected, matcherName);
-    ensureMock(received, matcherName);
-
-    const receivedIsSpy = isSpy(received);
-    const type = receivedIsSpy ? 'spy' : 'mock function';
-    const count = receivedIsSpy
-      ? received.calls.count()
-      : received.mock.calls.length;
-    const pass = count === expected;
-    const message = pass
-      ? () => matcherHint(
-          '.not' +
-          matcherName,
-          RECEIVED_NAME[type],
-          String(expected),
-        ) +
-        `\n\n` +
-        `Expected ${type} not to be called ` +
-        `${EXPECTED_COLOR(pluralize('time', expected))}, but it was` +
-        ` called exactly ${RECEIVED_COLOR(pluralize('time', count))}.`
-      : () => matcherHint(matcherName, RECEIVED_NAME[type], String(expected)) +
-        '\n\n' +
-        `Expected ${type} to have been called ` +
-        `${EXPECTED_COLOR(pluralize('time', expected))},` +
-        ` but it was called ${RECEIVED_COLOR(pluralize('time', count))}.`;
-
-    return {message, pass};
-  },
+  toHaveBeenCalledTimes: createCallTimesMatcher('.toHaveBeenCalledTimes'),
+	toHaveBeenCalledOnce: createCallTimesMatcher('.toHaveBeenCalledOnce', 1),
+	toHaveBeenCalledTwice: createCallTimesMatcher('.toHaveBeenCalledTwice', 2),
+	toHaveBeenCalledThrice: createCallTimesMatcher('.toHaveBeenCalledThrice', 3),
+	toHaveBeenCalledFourTimes:
+		createCallTimesMatcher('.toHaveBeenCalledFourTimes', 4),
   toHaveBeenCalledWith: createToBeCalledWithMatcher('.toHaveBeenCalledWith'),
   toHaveBeenLastCalledWith:
     createLastCalledWithMatcher('.toHaveBeenLastCalledWith'),


### PR DESCRIPTION
**Summary**

following up on the discussion made in #2547

added shortcut matchers to replace calls to toHaveBeenCalledTimes(1), toHaveBeenCalledTimes(2), toHaveBeenCalledTimes(3), toHaveBeenCalledTimes(4)

respectively, they are called: toBeCalledOnce(), toBeCalledTwice(), toBeCalledThrice(), toBeCalledFourTimes() 

**Test plan**

added tests in /jest-matchers/src/__tests__/spyMatchers-test.js

**Docs**

added explanation and example to the toHaveBeenCalledTimes section in the API.md doc