### PR TITLE
Update default transform for babel-jest

### DIFF
--- a/packages/babel-jest/README.md
+++ b/packages/babel-jest/README.md
@@ -20,6 +20,6 @@ To explicitly define `babel-jest` as a transformer for your JavaScript code, map
 
 ```json
 "transform": {
-  "^.+\\.js$": "<rootDir>/node_modules/babel-jest"
+  "^.+\\.jsx?$": "babel-jest"
 },
 ```


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
The path for the transform did not work.
`<rootDir>/node_modules/babel-jest` did result in `TypeError: Object.values is not a function`.
After digging in `jest-config` I found the transform provided by default is:
```
"transform": {
  "^.+\\.jsx?$": "babel-jest"
}
```

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

I wanted to save other developers time when setting up custom `transform`s and want to continue using `babel-jest`.
