### PR TITLE
fixes typo to make ci green

### DIFF
--- a/packages/jest-cli/src/watch.js
+++ b/packages/jest-cli/src/watch.js
@@ -53,7 +53,7 @@ const watch = (
 
   process.on('exit', () => {
     if (isEnteringPattern) {
-      pipe.write(ansiEscapes.cursorDown());
+      pipe.write(ansiEscapes.cursorDown);
       pipe.write(ansiEscapes.eraseDown);
     }
   });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Seems that `cursorDown` should be passed without being called.

https://ci.appveyor.com/project/Daniel15/jest/build/1598#L422
```C:\projects\jest\packages\jest-cli\src\watch.js:56
      pipe.write(ansiEscapes.cursorDown());
                             ^
TypeError: ansiEscapes.cursorDown is not a function
    at process.on (C:\projects\jest\packages\jest-cli\src\watch.js:56:30)
    at emitOne (events.js:101:20)
    at process.emit (events.js:188:7)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```
**Test plan**
#YOLO 
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
