### PR TITLE
Mock process.on in test to prevent CI failure

### DIFF
--- a/packages/jest-cli/src/__tests__/watch-pattern-mode-test.js
+++ b/packages/jest-cli/src/__tests__/watch-pattern-mode-test.js
@@ -67,6 +67,14 @@ jest.doMock('../lib/terminalUtils', () => ({
 
 const watch = require('../watch');
 
+const processOn = process.on;
+
+process.on = jest.fn();
+
+afterAll(() => {
+  process.on = processOn;
+});
+
 afterEach(runJestMock.mockReset);
 
 describe('Watch mode flows', () => {


### PR DESCRIPTION
This was happening because we are mocking ansi-escapes.... Another possible solution is to also mock `cursorDown()`