### PR TITLE
add detail regarding manual mocks and node modules

### DIFF
--- a/docs/ManualMocks.md
+++ b/docs/ManualMocks.md
@@ -29,7 +29,7 @@ directory as the ``node_modules`` folder. Eg:
   config
 ```
 
-When a manual mock exists for a given module, Jest's module system will use that module when explicitly calling `jest.mock('moduleName')`.
+When a manual mock exists for a given module, Jest's module system will use that module when explicitly calling `jest.mock('moduleName')`. However, manual mocks will take precedence over node modules even if `jest.mock('moduleName')` is not called. To opt out of this behavior you will need to explicitly call `jest.unmock('moduleName')` in tests that should use the actual module implementation.
 
 Here's a contrived example where we have a module that provides a summary of
 all the files in a given directory.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Add documentation regarding the behavior of manual mocks when used with node modules - the mocks are given precedence even when `jest.mock('moduleName')` is not explicitly called.

This behavior is contrary to how manual mocks work with application modules. It appears to be a bug when it is actually an implementation detail. There are a few issues already reporting this behavior: #2355, #2354, #1927 

Hopefully the language I've used here is clear enough but I'm happy to revise if it's still confusing.

**Test plan**
n/a - documentation only
