### PR TITLE
Fix findMatchingTests for directories

### DIFF
--- a/packages/jest-cli/src/SearchSource.js
+++ b/packages/jest-cli/src/SearchSource.js
@@ -19,7 +19,6 @@ const DependencyResolver = require('jest-resolve-dependencies');
 
 const chalk = require('chalk');
 const changedFiles = require('jest-changed-files');
-const fileExists = require('jest-file-exists');
 const path = require('path');
 const {
   escapePathForRegex,
@@ -162,13 +161,6 @@ class SearchSource {
   findMatchingTests(
     testPathPattern: StrOrRegExpPattern,
   ): SearchResult {
-    if (testPathPattern && !(testPathPattern instanceof RegExp)) {
-      const maybeFile = path.resolve(process.cwd(), testPathPattern);
-      if (fileExists(maybeFile, this._hasteContext.hasteFS)) {
-        return this._filterTestPathsWithStats([maybeFile]);
-      }
-    }
-
     return this._getAllTestPaths(testPathPattern);
   }
 


### PR DESCRIPTION
Jest was not matching any tests when the pattern was a directory

![pattern-match](https://cloud.githubusercontent.com/assets/574806/22187848/12130fe0-e0c2-11e6-8e9e-7eb07063f943.gif)
