### PR TITLE
Move jest-runtime/_normalizeID to jest-resolve/getModuleID

### DIFF
--- a/packages/jest-resolve/src/index.js
+++ b/packages/jest-resolve/src/index.js
@@ -275,7 +275,7 @@ class Resolver {
     moduleName: string,
   ): Path {
     const virtualMockPath = this.getModulePath(from, moduleName);
-    return virtualMockPath in virtualMocks
+    return virtualMocks[virtualMockPath]
       ? virtualMockPath
       : moduleName ? this.resolveModule(from, moduleName) : from;
   }

--- a/packages/jest-resolve/src/index.js
+++ b/packages/jest-resolve/src/index.js
@@ -42,6 +42,8 @@ type ModuleNameMapperConfig = {|
   moduleName: string
 |};
 
+type BooleanObject = {[key: string]: boolean};
+
 export type ResolveModuleConfig = {|
   skipNodeResolution?: boolean,
 |};
@@ -54,6 +56,7 @@ const nodePaths =
 class Resolver {
   _options: ResolverConfig;
   _moduleMap: ModuleMap;
+  _moduleIDCache : {[key: string]: string};
   _moduleNameCache: {[name: string]: Path};
   _modulePathCache: {[path: Path]: Array<Path>};
 
@@ -70,6 +73,7 @@ class Resolver {
       platforms: options.platforms,
     };
     this._moduleMap = moduleMap;
+    this._moduleIDCache  = Object.create(null);
     this._moduleNameCache = Object.create(null);
     this._modulePathCache = Object.create(null);
   }
@@ -178,6 +182,13 @@ class Resolver {
     );
   }
 
+  getModulePath(from: Path, moduleName: string) {
+    if (moduleName[0] !== '.' || path.isAbsolute(moduleName)) {
+      return moduleName;
+    }
+    return path.normalize(path.dirname(from) + '/' + moduleName);
+  }
+
   getPackage(name: string): ?Path {
     return this._moduleMap.getPackage(
       name,
@@ -210,6 +221,70 @@ class Resolver {
       this._modulePathCache[from] = paths;
     }
     return this._modulePathCache[from];
+  }
+
+  getModuleID(
+    virtualMocks: BooleanObject,
+    from: Path,
+    _moduleName?: ?string,
+  ): string {
+    const moduleName = _moduleName || '';
+
+    const key = from + path.delimiter + moduleName;
+    if (this._moduleIDCache[key]) {
+      return this._moduleIDCache[key];
+    }
+
+    const moduleType = this._getModuleType(moduleName);
+    const absolutePath = this._getAbsolutPath(virtualMocks, from, moduleName);
+    const mockPath = this._getMockPath(from, moduleName);
+
+    const sep = path.delimiter;
+    const id = (moduleType + sep + (absolutePath ? (absolutePath + sep) : '') +
+      (mockPath ? (mockPath + sep) : ''));
+
+    return this._moduleIDCache[key] = id;
+  }
+
+  _getModuleType(moduleName: string): 'node' | 'user' {
+    return this.isCoreModule(moduleName) ? 'node' : 'user';
+  }
+
+  _getAbsolutPath(
+    virtualMocks: BooleanObject,
+    from: Path,
+    moduleName: string,
+  ): ?string {
+    if (this.isCoreModule(moduleName)) {
+      return moduleName;
+    }
+    return this._isModuleResolved(from, moduleName)
+      ? this.getModule(moduleName)
+      : this._getVirtualMockPath(virtualMocks, from, moduleName);
+  }
+
+  _getMockPath(from: Path, moduleName: string): ?string {
+    return !this.isCoreModule(moduleName)
+      ? this.getMockModule(from, moduleName)
+      : null;
+  }
+
+  _getVirtualMockPath(
+    virtualMocks: BooleanObject,
+    from: Path,
+    moduleName: string,
+  ): Path {
+    const virtualMockPath = this.getModulePath(from, moduleName);
+    return virtualMockPath in virtualMocks
+      ? virtualMockPath
+      : moduleName ? this.resolveModule(from, moduleName) : from;
+  }
+
+  _isModuleResolved(from: Path, moduleName: string): boolean {
+    return !!(
+      this.getModule(moduleName) ||
+      this.getMockModule(from, moduleName)
+    );
   }
 
   _resolveStubModuleName(from: Path, moduleName: string): ?Path {

--- a/packages/jest-runtime/src/index.js
+++ b/packages/jest-runtime/src/index.js
@@ -69,7 +69,6 @@ const mockParentModule = {
   id: 'mockParent',
 };
 
-const normalizedIDCache = Object.create(null);
 const unmockRegExpCache = new WeakMap();
 
 type BooleanObject = {[key: string]: boolean};
@@ -138,7 +137,8 @@ class Runtime {
     if (config.automock) {
       config.setupFiles.forEach(filePath => {
         if (filePath && filePath.includes(NODE_MODULES)) {
-          const moduleID = this._normalizeID(filePath);
+          const moduleID =
+            this._resolver.getModuleID(this._virtualMocks, filePath);
           this._transitiveShouldMock[moduleID] = false;
         }
       });
@@ -248,7 +248,8 @@ class Runtime {
     moduleName?: string,
     options: ?InternalModuleOptions,
   ) {
-    const moduleID = this._normalizeID(from, moduleName);
+    const moduleID =
+      this._resolver.getModuleID(this._virtualMocks, from, moduleName);
     let modulePath;
 
     const moduleRegistry = (!options || !options.isInternalModule) ?
@@ -308,7 +309,8 @@ class Runtime {
   }
 
   requireMock(from: Path, moduleName: string) {
-    const moduleID = this._normalizeID(from, moduleName);
+    const moduleID =
+      this._resolver.getModuleID(this._virtualMocks, from, moduleName);
 
     if (this._mockRegistry[moduleID]) {
       return this._mockRegistry[moduleID];
@@ -403,10 +405,11 @@ class Runtime {
     options?: {virtual: boolean},
   ) {
     if (options && options.virtual) {
-      const mockPath = this._getVirtualMockPath(from, moduleName);
+      const mockPath = this._resolver.getModulePath(from, moduleName);
       this._virtualMocks[mockPath] = true;
     }
-    const moduleID = this._normalizeID(from, moduleName);
+    const moduleID =
+      this._resolver.getModuleID(this._virtualMocks, from, moduleName);
     this._explicitShouldMock[moduleID] = true;
     this._mockFactories[moduleID] = mockFactory;
   }
@@ -496,78 +499,15 @@ class Runtime {
     );
   }
 
-  _normalizeID(from: Path, moduleName?: ?string) {
-    if (!moduleName) {
-      moduleName = '';
-    }
-
-    const key = from + path.delimiter + moduleName;
-    if (normalizedIDCache[key]) {
-      return normalizedIDCache[key];
-    }
-
-    let moduleType;
-    let mockPath = null;
-    let absolutePath = null;
-
-    if (this._resolver.isCoreModule(moduleName)) {
-      moduleType = 'node';
-      absolutePath = moduleName;
-    } else {
-      moduleType = 'user';
-      if (
-        !this._resolver.getModule(moduleName) &&
-        !this._resolver.getMockModule(from, moduleName)
-      ) {
-        if (moduleName) {
-          const virtualMockPath = this._getVirtualMockPath(from, moduleName);
-          if (virtualMockPath in this._virtualMocks) {
-            absolutePath = virtualMockPath;
-          }
-        }
-
-        if (absolutePath === null) {
-          absolutePath = this._resolveModule(from, moduleName);
-        }
-      }
-
-      if (absolutePath === null) {
-        const moduleResource = this._resolver.getModule(moduleName);
-        if (moduleResource) {
-          absolutePath = moduleResource;
-        }
-      }
-
-      if (mockPath === null) {
-        const mockResource = this._resolver.getMockModule(from, moduleName);
-        if (mockResource) {
-          mockPath = mockResource;
-        }
-      }
-    }
-
-    const sep = path.delimiter;
-    const id = (moduleType + sep + (absolutePath ? (absolutePath + sep) : '') +
-      (mockPath ? (mockPath + sep) : ''));
-
-    return normalizedIDCache[key] = id;
-  }
-
-  _getVirtualMockPath(from: Path, moduleName: string) {
-    if (moduleName[0] !== '.' || path.isAbsolute(moduleName)) {
-      return moduleName;
-    }
-    return path.normalize(path.dirname(from) + '/' + moduleName);
-  }
-
   _shouldMock(from: Path, moduleName: string) {
-    const mockPath = this._getVirtualMockPath(from, moduleName);
+    const mockPath = this._resolver.getModulePath(from, moduleName);
     if (mockPath in this._virtualMocks) {
       return true;
     }
 
     const explicitShouldMock = this._explicitShouldMock;
-    const moduleID = this._normalizeID(from, moduleName);
+    const moduleID =
+      this._resolver.getModuleID(this._virtualMocks, from, moduleName);
     const key = from + path.delimiter + moduleID;
 
     if (moduleID in explicitShouldMock) {
@@ -604,7 +544,8 @@ class Runtime {
     }
 
     // transitive unmocking for package managers that store flat packages (npm3)
-    const currentModuleID = this._normalizeID(from);
+    const currentModuleID =
+      this._resolver.getModuleID(this._virtualMocks, from);
     if (
       this._transitiveShouldMock[currentModuleID] === false || (
         from.includes(NODE_MODULES) &&
@@ -648,12 +589,14 @@ class Runtime {
       return runtime;
     };
     const unmock = (moduleName: string) => {
-      const moduleID = this._normalizeID(from, moduleName);
+      const moduleID =
+        this._resolver.getModuleID(this._virtualMocks, from, moduleName);
       this._explicitShouldMock[moduleID] = false;
       return runtime;
     };
     const deepUnmock = (moduleName: string) => {
-      const moduleID = this._normalizeID(from, moduleName);
+      const moduleID =
+        this._resolver.getModuleID(this._virtualMocks, from, moduleName);
       this._explicitShouldMock[moduleID] = false;
       this._transitiveShouldMock[moduleID] = false;
       return runtime;
@@ -667,7 +610,8 @@ class Runtime {
         return setMockFactory(moduleName, mockFactory, options);
       }
 
-      const moduleID = this._normalizeID(from, moduleName);
+      const moduleID =
+        this._resolver.getModuleID(this._virtualMocks, from, moduleName);
       this._explicitShouldMock[moduleID] = true;
       return runtime;
     };

--- a/packages/jest-util/src/index.js
+++ b/packages/jest-util/src/index.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+import type {Path} from 'types/Config';
+
 const Console = require('./Console');
 const FakeTimers = require('./FakeTimers');
 const NullConsole = require('./NullConsole');

--- a/packages/jest-util/src/index.js
+++ b/packages/jest-util/src/index.js
@@ -10,8 +10,6 @@
 
 'use strict';
 
-import type {Path} from 'types/Config';
-
 const Console = require('./Console');
 const FakeTimers = require('./FakeTimers');
 const NullConsole = require('./NullConsole');


### PR DESCRIPTION
**Summary**

Almost all methods and functions used by `_normalizeID` are from `resolver`. Because of that, it makes much more sense to move it to `resolver` and pass `virtualMocks` from `runtime` since it is the only `runtime`'s data required. Besides that, this patch includes a refactor of use of `this._getVirtualMockPath` to `getModulePath`.

I want to contribute with the project but I am not familiar with the code. I will read it and refactor everything that would help to understand the code. Right now, my focus is in `jest-runtime` package and I intend to move to other packages as well.

If you guys don't want to receive patches where the purpose is only refactor the code to improve design and readability, you can let me know and I won't bother you guys anymore.

**Test plan**

I am not adding any new test because the code refactored is already covered by tests. Let me know if you need any extra tests.

I used `yarn watch` to re-build `yarn flow && yarn lint && yarn jest` to test after each time that I saved a file. Before send the PR, I've run `yarn test` to make sure that I am not breaking any test.
