### PR TITLE
Avoid unnecessary call to getMockModule

### DIFF
--- a/packages/jest-runtime/src/index.js
+++ b/packages/jest-runtime/src/index.js
@@ -586,11 +586,11 @@ class Runtime {
       return this._shouldMockModuleCache[moduleID];
     }
 
-    const manualMock = this._resolver.getMockModule(from, moduleName);
     let modulePath;
     try {
       modulePath = this._resolveModule(from, moduleName);
     } catch (e) {
+      const manualMock = this._resolver.getMockModule(from, moduleName);
       if (manualMock) {
         this._shouldMockModuleCache[moduleID] = true;
         return true;


### PR DESCRIPTION
**Summary**

`getMockModule` is called even when it is not used. After this patch `yarn test` is running ~2 seconds faster in my computer. I am not familiar with the code to estimate the impact, but it worth to be fixed anyway.

**Test plan**

`yarn test`


Before:
<img width="1436" alt="screen shot 2017-01-22 at 10 33 18 pm" src="https://cloud.githubusercontent.com/assets/88476/22193930/dafe3d22-e0f3-11e6-881b-c5181c380494.png">

After:
<img width="1436" alt="screen shot 2017-01-22 at 10 35 32 pm" src="https://cloud.githubusercontent.com/assets/88476/22193933/e121a8d8-e0f3-11e6-95ee-d01aeb0e1907.png">

