### PR TITLE
Adding resetModule to clear cache for single module

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -96,6 +96,7 @@ These methods help create mocks and let you control Jest's overall behavior.
   - [`jest.genMockFromModule(moduleName)`](#jestgenmockfrommodulemodulename)
   - [`jest.mock(moduleName, ?factory, ?options)`](#jestmockmodulename-factory-options)
   - [`jest.resetModules()`](#jestresetmodules)
+  - [`jest.resetModule(moduleName)`](#jestresetmodule)
   - [`jest.runAllTicks()`](#jestrunallticks)
   - [`jest.runAllTimers()`](#jestrunalltimers)
   - [`jest.runTimersToTime(msToRun)`](#jestruntimerstotimemstorun)
@@ -1122,6 +1123,39 @@ it('works', () => {
 it('works too', () => {
   const sum = require('../sum');
   // sum is a different copy of the sum module from the previous test.
+});
+```
+
+Returns the `jest` object for chaining.
+
+
+### `jest.resetModule(moduleName)`
+
+Resets the module registry for a specified module This is useful to isolate a module where local state might conflict between tests.
+
+Example:
+```js
+const sum1 = require('../sum');
+jest.resetModule('../sum');
+const sum2 = require('../sum');
+sum1 === sum2 // false! Both sum modules are separate "instances" of the sum module.
+```
+
+Example in a test:
+```js
+let sum;
+beforeEach(() => {
+  jest.resetModule('../sum');
+  sum = require('../sum');
+});
+
+it('works', () => {
+  sum(1, 2);
+});
+
+it('works too', () => {
+  // sum is a different copy of the sum module from the previous test.
+  sum(1, 2);
 });
 ```
 

--- a/packages/jest-runtime/src/index.js
+++ b/packages/jest-runtime/src/index.js
@@ -370,6 +370,11 @@ class Runtime {
     }
   }
 
+  resetModule(from: Path, moduleName: String) {
+    const moduleID = this._normalizeID(from, moduleName);
+    delete this._moduleRegistry[moduleID];
+  }
+
   resetModules() {
     this._mockRegistry = Object.create(null);
     this._moduleRegistry = Object.create(null);
@@ -691,6 +696,10 @@ class Runtime {
       this.resetModules();
       return runtime;
     };
+    const resetModule = (moduleName: string) => {
+      this.resetModule(from, moduleName);
+      return runtime;
+    };
     const fn = this._moduleMocker.fn.bind(this._moduleMocker);
     const spyOn = this._moduleMocker.spyOn.bind(this._moduleMocker);
 
@@ -718,6 +727,7 @@ class Runtime {
       resetAllMocks,
       resetModuleRegistry: resetModules,
       resetModules,
+      resetModule,
 
       runAllImmediates: () => this._environment.fakeTimers.runAllImmediates(),
       runAllTicks: () => this._environment.fakeTimers.runAllTicks(),


### PR DESCRIPTION
**Summary**

This adds a `resetModule` function to the jest runtime, which can be used to clear the module cache for a single module.

**Test plan**

This is based on the existing code for resetModules, but just for a single module. I'll expand this PR to add test cases for clearing a single module.
