### PR TITLE
jest-haste-map: Emit change events if a file in node_modules has changed

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "modulePathIgnorePatterns": [
       "examples/.*",
       "packages/.*/build",
-      "packages/jest-runtime/src/__tests__/test_root_with_dup_mocks"
+      "packages/jest-runtime/src/__tests__/test_root.*",
+      "website/.*"
     ],
     "collectCoverageFrom": [
       "**/packages/jest-*/**/*.js",

--- a/packages/jest-haste-map/src/__tests__/index-test.js
+++ b/packages/jest-haste-map/src/__tests__/index-test.js
@@ -676,6 +676,7 @@ describe('HasteMap', () => {
         const statObject = {mtime: {getTime: () => 45}};
         const tests = [
           () => {
+            // Tests that the change event works correctly.
             mockEmitters['/fruits'].emit(
               'all',
               'delete',
@@ -713,6 +714,7 @@ describe('HasteMap', () => {
             );
           },
           () => {
+            // Ensures the event queue can receive multiple events.
             mockFs['/fruits/tomato.js'] = [
               '/**',
               ' * @providesModule Tomato',
@@ -765,6 +767,7 @@ describe('HasteMap', () => {
             );
           },
           () => {
+            // Does not emit duplicate change events.
             mockEmitters['/fruits'].emit(
               'all',
               'change',
@@ -783,6 +786,31 @@ describe('HasteMap', () => {
               'change',
               addErrorHandler(({eventsQueue, hasteFS, moduleMap}) => {
                 expect(eventsQueue).toHaveLength(1);
+                next();
+              }),
+            );
+          },
+          () => {
+            // Emits a change even if a file in node_modules has changed.
+            mockEmitters['/fruits'].emit(
+              'all',
+              'add',
+              'apple.js',
+              '/fruits/node_modules/',
+              statObject,
+            );
+            hasteMap.once(
+              'change',
+              addErrorHandler(({eventsQueue, hasteFS, moduleMap}) => {
+                const filePath = '/fruits/node_modules/apple.js';
+                expect(eventsQueue).toHaveLength(1);
+                expect(eventsQueue).toEqual([{
+                  filePath,
+                  stat: statObject,
+                  type: 'add',
+                }]);
+
+                expect(hasteFS.getModuleName(filePath)).toBeDefined();
                 next();
               }),
             );

--- a/packages/jest-haste-map/src/index.js
+++ b/packages/jest-haste-map/src/index.js
@@ -518,8 +518,10 @@ class HasteMap extends EventEmitter {
       return Promise.resolve();
     }
 
-    // In watch mode, we'll only warn about module collisions.
+    // In watch mode, we'll only warn about module collisions and we'll retain
+    // all files, even changes to node_modules.
     this._options.throwOnModuleCollision = false;
+    this._options.retainAllFiles = true;
 
     const Watcher = (canUseWatchman && this._options.useWatchman)
       ? sane.WatchmanWatcher
@@ -638,6 +640,9 @@ class HasteMap extends EventEmitter {
           this._workerPromise = null;
           if (promise) {
             return promise.then(add);
+          } else {
+            // If a file in node_modules has changed, emit an event regardless.
+            add();
           }
         } else {
           add();


### PR DESCRIPTION
**Summary**

Fixes #2592 and will fix https://github.com/facebook/react-native/issues/11301 once Jest 19 is out.

Explanation: since we don't store the haste map in watch mode, it is ok to "retain all files". This will issue change events when files in node_modules have changed, which will make the watch mode in Jest 19 behave more like Jest 18 (where changes to node_modules would re-run Jest), as well as fix something in react-native-packager.

Related, I kinda feel like retainAllFiles has to go. It makes things faster on our giant codebase but gives a bunch of trouble.

**Test plan**
* Manual testing
* Added a test