### PR TITLE
Fix CI.

### DIFF
--- a/packages/jest-runtime/src/__tests__/test_root/logging.js
+++ b/packages/jest-runtime/src/__tests__/test_root/logging.js
@@ -8,7 +8,7 @@
 
 'use strict';
 
-if (require('RegularModule').getModuleStateValue()) {
+if (require('./RegularModule').getModuleStateValue()) {
   console.log('Hello, world!');
 } else {
   console.log('Automocking is not properly disabled in jest-runtime.');


### PR DESCRIPTION
**Summary**
I changed the package.json to exclude all the modules from the test_root without realizing one of the tests was relying on them. I changed `logging` to use a relative require instead of requiring a haste module, which makes the test pass.

**Test plan**
jest