### PR TITLE
Fix typo in rootDir section of Configuration Page

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -268,7 +268,7 @@ The root directory that Jest should scan for tests and modules within. If you pu
 
 Oftentimes, you'll want to set this to `'src'` or `'lib'`, corresponding to where in your repository the code is stored.
 
-*Note that using `'<rootDir>'` as a string token in any other path-based config settings to refer back to this value. So, for example, if you want your [`setupFiles`](#setupfiles-array) config entry to point at the `env-setup.js` file at the root of your project, you could set its value to `["<rootDir>/env-setup.js"]`.*
+*Note that using `'<rootDir>'` as a string token in any other path-based config settings will refer back to this value. So, for example, if you want your [`setupFiles`](#setupfiles-array) config entry to point at the `env-setup.js` file at the root of your project, you could set its value to `["<rootDir>/env-setup.js"]`.*
 
 ### `setupFiles` [array]
 (default: `[]`)


### PR DESCRIPTION
```
[...] using `'<rootDir>'` as a string token in any other path-based config settings to refer back to this value.
```

Changed to:

```
[...] using `'<rootDir>'` as a string token in any other path-based config settings will refer back to this value.
```

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
