### PR TITLE
[Feature] Add Summary Flag to reduce output

### DIFF
--- a/integration_tests/__tests__/__snapshots__/console-test.js.snap
+++ b/integration_tests/__tests__/__snapshots__/console-test.js.snap
@@ -24,6 +24,22 @@ Ran all test suites.
 "
 `;
 
+exports[`test console printing with --summary 1`] = `""`;
+
+exports[`test console printing with --summary 2`] = `
+"
+"
+`;
+
+exports[`test console printing with --summary 3`] = `
+"Test Suites: 1 passed, 1 total
+Tests:       1 passed, 1 total
+Snapshots:   0 total
+Time:        <<REPLACED>>
+Ran all test suites.
+"
+`;
+
 exports[`test console printing with --verbose 1`] = `
 "  console.log __tests__/console-test.js:11
     This is a log message.

--- a/integration_tests/__tests__/console-test.js
+++ b/integration_tests/__tests__/console-test.js
@@ -24,6 +24,17 @@ test('console printing', () => {
   expect(summary).toMatchSnapshot();
 });
 
+test('console printing with --summary', () => {
+  const {stderr, stdout, status} =
+    runJest('console', ['--summary', '--no-cache']);
+  const {summary, rest} = extractSummary(stderr);
+
+  expect(status).toBe(0);
+  expect(stdout).toMatchSnapshot();
+  expect(rest).toMatchSnapshot();
+  expect(summary).toMatchSnapshot();
+});
+
 test('console printing with --verbose', () => {
   const {stderr, stdout, status} =
     runJest('console', ['--verbose', '--no-cache']);

--- a/packages/jest-cli/src/TestRunner.js
+++ b/packages/jest-cli/src/TestRunner.js
@@ -382,11 +382,11 @@ class TestRunner {
   _setupReporters() {
     const config = this._config;
 
-    this.addReporter(
-      config.verbose
-        ? new VerboseReporter(config)
-        : new DefaultReporter(),
-    );
+    if (config.verbose) {
+      this.addReporter(new VerboseReporter(config));
+    } else if (!config.summary) {
+      this.addReporter(new DefaultReporter());
+    }
 
     if (config.collectCoverage) {
       // coverage reporter dependency graph is pretty big and we don't

--- a/packages/jest-cli/src/cli/args.js
+++ b/packages/jest-cli/src/cli/args.js
@@ -197,6 +197,11 @@ const options = {
     description: 'Prevent tests from printing messages through the console.',
     type: 'boolean',
   },
+  summary: {
+    default: false,
+    description: 'Limits console output to only the test summary.',
+    type: 'boolean',
+  },
   testNamePattern: {
     alias: 't',
     description:

--- a/packages/jest-cli/src/reporters/SummaryReporter.js
+++ b/packages/jest-cli/src/reporters/SummaryReporter.js
@@ -55,7 +55,7 @@ const NPM_EVENTS = new Set([
   'postrestart',
 ]);
 
-class SummareReporter extends BaseReporter {
+class SummaryReporter extends BaseReporter {
 
   _estimatedTime: number;
 
@@ -219,4 +219,4 @@ class SummareReporter extends BaseReporter {
   }
 }
 
-module.exports = SummareReporter;
+module.exports = SummaryReporter;

--- a/packages/jest-config/src/defaults.js
+++ b/packages/jest-config/src/defaults.js
@@ -47,6 +47,7 @@ module.exports = ({
   resetMocks: false,
   resetModules: false,
   snapshotSerializers: [],
+  summary: null,
   testEnvironment: 'jest-environment-jsdom',
   testPathDirs: ['<rootDir>'],
   testPathIgnorePatterns: [NODE_MODULES_REGEXP],

--- a/packages/jest-config/src/setFromArgv.js
+++ b/packages/jest-config/src/setFromArgv.js
@@ -17,6 +17,10 @@ function setFromArgv(config, argv) {
     config.verbose = argv.verbose;
   }
 
+  if (argv.summary) {
+    config.summary = argv.summary;
+  }
+
   if (argv.notify) {
     config.notify = argv.notify;
   }

--- a/packages/jest-config/src/validConfig.js
+++ b/packages/jest-config/src/validConfig.js
@@ -64,6 +64,7 @@ module.exports = ({
   setupTestFrameworkScriptFile: '<rootDir>/testSetupFile.js',
   silent: true,
   snapshotSerializers: ['my-serializer-module'],
+  summary: false,
   testEnvironment: 'jest-environment-jsdom',
   testNamePattern: 'test signature',
   testPathDirs: ['<rootDir>'],


### PR DESCRIPTION
In effort to address #1872 and the need for minimal output, I suggest using a `--summary` option. 

This will turn off the `DefaultReporter` leaving just the `SummaryReporter`. Error messages are maintained, this just removes the `RUN | FAIL | PASS` messages. 

Here is a sample output using the summary flag with the built in tests.
<img width="422" alt="screen shot 2017-01-26 at 12 08 28 am" src="https://cloud.githubusercontent.com/assets/1295580/22321588/adb79af6-e35b-11e6-825c-5d5326ee40f3.png">

I am not sure about those warnings, as I didn't touch any disconnect listeners I am unsure where that came from.
