### PR TITLE
Updates node-notifier dep of jest-cli to v5

### DIFF
--- a/packages/jest-cli/package.json
+++ b/packages/jest-cli/package.json
@@ -25,7 +25,7 @@
     "jest-snapshot": "^18.1.0",
     "jest-util": "^18.1.0",
     "json-stable-stringify": "^1.0.0",
-    "node-notifier": "^4.6.1",
+    "node-notifier": "^5.0.1",
     "sane": "~1.4.1",
     "string-length": "^1.0.1",
     "strip-ansi": "^3.0.1",


### PR DESCRIPTION
Updates the dependency of `node-notifier` to the latest [newly released `v5.0.1`](https://github.com/mikaelbr/node-notifier/blob/master/CHANGELOG.md#v500).

With this change there are a lot fewer dependencies as the built in CLI is removed, and other dependencies are trimmed. 

No change in the way it's used in `jest-cli`. Tested on macOS and Windows where it works as expected.

---

As an aside:
With the new `node-notifier` input on macOS is possible. Could be possible to add buttons to rerun the tests. Don't know if this is interesting, but something to think about.