### PR TITLE
Adds possibility to rerun tasks from NotifyReporter

### DIFF
--- a/packages/jest-cli/src/TestRunner.js
+++ b/packages/jest-cli/src/TestRunner.js
@@ -65,6 +65,7 @@ class TestRunner {
   _hasteContext: HasteContext;
   _config: Config;
   _options: Options;
+  _startRun: () => *;
   _dispatcher: ReporterDispatcher;
   _testPerformanceCache: Object;
 
@@ -72,6 +73,7 @@ class TestRunner {
     hasteContext: HasteContext,
     config: Config,
     options: Options,
+    startRun: () => *
   ) {
     this._config = config;
     this._dispatcher = new ReporterDispatcher(
@@ -80,6 +82,7 @@ class TestRunner {
     );
     this._hasteContext = hasteContext;
     this._options = options;
+    this._startRun = startRun;
     this._setupReporters();
 
     // Map from testFilePath -> time it takes to run the test. Used to
@@ -397,7 +400,7 @@ class TestRunner {
 
     this.addReporter(new SummaryReporter());
     if (config.notify) {
-      this.addReporter(new NotifyReporter());
+      this.addReporter(new NotifyReporter(this._startRun));
     }
   }
 

--- a/packages/jest-cli/src/__tests__/watch-test.js
+++ b/packages/jest-cli/src/__tests__/watch-test.js
@@ -51,7 +51,8 @@ describe('Watch mode flows', () => {
   it('Runs Jest once by default and shows usage', () => {
     watch(config, pipe, argv, hasteMap, hasteContext, stdin);
     expect(runJestMock).toBeCalledWith(hasteContext, config, argv, pipe,
-      new TestWatcher({isWatchMode: true}), jasmine.any(Function));
+      new TestWatcher({isWatchMode: true}), jasmine.any(Function),
+      jasmine.any(Function));
     expect(pipe.write.mock.calls.reverse()[0]).toMatchSnapshot();
   });
 

--- a/packages/jest-cli/src/__tests__/watch-test.js
+++ b/packages/jest-cli/src/__tests__/watch-test.js
@@ -50,7 +50,11 @@ describe('Watch mode flows', () => {
 
   it('Runs Jest once by default and shows usage', () => {
     watch(config, pipe, argv, hasteMap, hasteContext, stdin);
-    expect(runJestMock).toBeCalledWith(hasteContext, config, argv, pipe,
+    expect(runJestMock).toBeCalledWith(
+      hasteContext,
+      config,
+      argv,
+      pipe,
       new TestWatcher({isWatchMode: true}),
       jasmine.any(Function),
       jasmine.any(Function),

--- a/packages/jest-cli/src/__tests__/watch-test.js
+++ b/packages/jest-cli/src/__tests__/watch-test.js
@@ -51,8 +51,10 @@ describe('Watch mode flows', () => {
   it('Runs Jest once by default and shows usage', () => {
     watch(config, pipe, argv, hasteMap, hasteContext, stdin);
     expect(runJestMock).toBeCalledWith(hasteContext, config, argv, pipe,
-      new TestWatcher({isWatchMode: true}), jasmine.any(Function),
-      jasmine.any(Function));
+      new TestWatcher({isWatchMode: true}),
+      jasmine.any(Function),
+      jasmine.any(Function),
+    );
     expect(pipe.write.mock.calls.reverse()[0]).toMatchSnapshot();
   });
 

--- a/packages/jest-cli/src/jest.js
+++ b/packages/jest-cli/src/jest.js
@@ -75,8 +75,15 @@ const runCLI = (
           const startRun = () => {
             preRunMessage.print(pipe);
             const testWatcher = new TestWatcher({isWatchMode: false});
-            return runJest(hasteContext, config, argv, pipe, testWatcher,
-              startRun, onComplete);
+            return runJest(
+              hasteContext,
+              config,
+              argv,
+              pipe,
+              testWatcher,
+              startRun,
+              onComplete,
+            );
           };
           return startRun();
         }

--- a/packages/jest-cli/src/jest.js
+++ b/packages/jest-cli/src/jest.js
@@ -72,10 +72,13 @@ const runCLI = (
         if (argv.watch || argv.watchAll) {
           return watch(config, pipe, argv, jestHasteMap, hasteContext);
         } else {
-          preRunMessage.print(pipe);
-          const testWatcher = new TestWatcher({isWatchMode: false});
-          return runJest(hasteContext, config, argv, pipe, testWatcher,
-            onComplete);
+          const startRun = () => {
+            preRunMessage.print(pipe);
+            const testWatcher = new TestWatcher({isWatchMode: false});
+            return runJest(hasteContext, config, argv, pipe, testWatcher,
+              startRun, onComplete);
+          };
+          return startRun();
         }
       });
     })

--- a/packages/jest-cli/src/reporters/NotifyReporter.js
+++ b/packages/jest-cli/src/reporters/NotifyReporter.js
@@ -22,33 +22,57 @@ const isDarwin = process.platform === 'darwin';
 const icon = path.resolve(__dirname, '../assets/jest_logo.png');
 
 class NotifyReporter extends BaseReporter {
+  _startRun: () => *;
+
+  constructor(startRun: () => *) {
+    super();
+    this._startRun = startRun;
+  }
+
   onRunComplete(config: Config, result: AggregatedResult): void {
-    let title;
-    let message;
     const success = result.numFailedTests === 0 &&
       result.numRuntimeErrorTestSuites === 0;
 
     if (success) {
-      title = util.format('%d%% Passed', 100);
-      message = util.format(
+      const title = util.format('%d%% Passed', 100);
+      const message = util.format(
         (isDarwin ? '\u2705 ' : '') + '%d tests passed',
         result.numPassedTests,
       );
+
+      notifier.notify({icon, message, title});
     } else {
       const failed = result.numFailedTests / result.numTotalTests;
 
-      title = util.format(
+      const title = util.format(
         '%d%% Failed',
         Math.ceil(Number.isNaN(failed) ? 0 : failed * 100),
       );
-      message = util.format(
+      const message = util.format(
         (isDarwin ? '\u26D4\uFE0F ' : '') + '%d of %d tests failed',
         result.numFailedTests,
         result.numTotalTests,
       );
-    }
 
-    notifier.notify({icon, message, title});
+      const restartAnswer = 'Run again';
+      const quitAnswer = 'Exit tests';
+      notifier.notify({
+        actions: [restartAnswer, quitAnswer],
+        closeLabel: 'Close',
+        icon,
+        message,
+        title,
+      }, (err, _, metadata) => {
+        if (err) { return; }
+        if (metadata.activationValue === quitAnswer) {
+          process.exit(0);
+          return;
+        }
+        if (metadata.activationValue === restartAnswer) {
+          this._startRun();
+        }
+      });
+    }
   }
 }
 

--- a/packages/jest-cli/src/reporters/NotifyReporter.js
+++ b/packages/jest-cli/src/reporters/NotifyReporter.js
@@ -63,7 +63,9 @@ class NotifyReporter extends BaseReporter {
         message,
         title,
       }, (err, _, metadata) => {
-        if (err) { return; }
+        if (err) {
+          return;
+        }
         if (metadata.activationValue === quitAnswer) {
           process.exit(0);
           return;

--- a/packages/jest-cli/src/runJest.js
+++ b/packages/jest-cli/src/runJest.js
@@ -54,6 +54,7 @@ const runJest = (
   argv: Object,
   pipe: stream$Writable | tty$WriteStream,
   testWatcher: any,
+  startRun: () => *,
   onComplete: (testResults: any) => void,
 ) => {
   const maxWorkers = getMaxWorkers(argv);
@@ -100,6 +101,7 @@ const runJest = (
             getTestSummary: () => getTestSummary(argv, patternInfo),
             maxWorkers,
           },
+          startRun
         ).runTests(data.paths, testWatcher);
       })
       .then(runResults => {

--- a/packages/jest-cli/src/watch.js
+++ b/packages/jest-cli/src/watch.js
@@ -89,6 +89,7 @@ const watch = (
       argv,
       pipe,
       testWatcher,
+      startRun,
       results => {
         isRunning = false;
         hasSnapshotFailure = !!results.snapshot.failure;


### PR DESCRIPTION
This PR opens the discussion around input buttons for notify reporter in jest-cli. As far as I could see, there were no way to restart running from reporters. This PR passes `startJest` to the NotifyReporter for it to use on user interaction. I don't know if this is the best way to do it, but I thought it's better to open a PR to start the discussion and get some feedback.

With this change, you get possibility to re-run tests (in current mode for watching) from macOS notifications. See video: https://youtu.be/YvmdM4id7zU