### PR TITLE
Update snapshots to new format

### DIFF
--- a/packages/jest-util/src/__tests__/__snapshots__/validateCLIOptions-test.js.snap
+++ b/packages/jest-util/src/__tests__/__snapshots__/validateCLIOptions-test.js.snap
@@ -2,7 +2,7 @@ exports[`test fails for multiple unknown options 1`] = `
 "[31m[1m[1m●[1m Unrecognized CLI Parameters[22m:
 
   Following options were not recognized:
-  [1m[\"jest\", \"test\"][22m
+  [1m[\\"jest\\", \\"test\\"][22m
 
   [1mCLI Options Documentation[22m:
   http://facebook.github.io/jest/docs/cli.html
@@ -12,7 +12,7 @@ exports[`test fails for multiple unknown options 1`] = `
 exports[`test fails for unknown option 1`] = `
 "[31m[1m[1m●[1m Unrecognized CLI Parameter[22m:
 
-  Unrecognized option [1m\"unknown\"[22m.
+  Unrecognized option [1m\\"unknown\\"[22m.
 
   [1mCLI Options Documentation[22m:
   http://facebook.github.io/jest/docs/cli.html

--- a/packages/jest-validate/src/__tests__/__snapshots__/validate-test.js.snap
+++ b/packages/jest-validate/src/__tests__/__snapshots__/validate-test.js.snap
@@ -5,7 +5,7 @@ exports[`test displays warning for deprecated config options 1`] = `
 
   Jest now treats your current configuration as:
   {
-    [1m\"transform\"[22m: [1m{\".*\": \"test\"}[22m
+    [1m\\"transform\\"[22m: [1m{\\".*\\": \\"test\\"}[22m
   }
 
   Please update your configuration.
@@ -15,7 +15,7 @@ exports[`test displays warning for deprecated config options 1`] = `
 exports[`test displays warning for unknown config options 1`] = `
 "[33m[1m[1m●[1m Validation Warning[22m:
 
-  Unknown option [1m\"unkwon\"[22m with value [1m{}[22m was found. Did you mean [1m\"unknown\"[22m?
+  Unknown option [1m\\"unkwon\\"[22m with value [1m{}[22m was found. Did you mean [1m\\"unknown\\"[22m?
   This is probably a typing mistake. Fixing it will remove this message.
 [39m"
 `;
@@ -23,14 +23,14 @@ exports[`test displays warning for unknown config options 1`] = `
 exports[`test pretty prints valid config for Array 1`] = `
 "[31m[1m[1m●[1m Validation Error[22m:
 
-  Option [1m\"coverageReporters\"[22m must be of type:
+  Option [1m\\"coverageReporters\\"[22m must be of type:
     [1m[32marray[31m[22m
   but instead received:
     [1m[31mobject[31m[22m
 
   Example:
   {
-    [1m\"coverageReporters\"[22m: [1m[\"json\", \"text\", \"lcov\", \"clover\"][22m
+    [1m\\"coverageReporters\\"[22m: [1m[\\"json\\", \\"text\\", \\"lcov\\", \\"clover\\"][22m
   }
 [39m"
 `;
@@ -38,14 +38,14 @@ exports[`test pretty prints valid config for Array 1`] = `
 exports[`test pretty prints valid config for Boolean 1`] = `
 "[31m[1m[1m●[1m Validation Error[22m:
 
-  Option [1m\"automock\"[22m must be of type:
+  Option [1m\\"automock\\"[22m must be of type:
     [1m[32mboolean[31m[22m
   but instead received:
     [1m[31marray[31m[22m
 
   Example:
   {
-    [1m\"automock\"[22m: [1mfalse[22m
+    [1m\\"automock\\"[22m: [1mfalse[22m
   }
 [39m"
 `;
@@ -53,14 +53,14 @@ exports[`test pretty prints valid config for Boolean 1`] = `
 exports[`test pretty prints valid config for Function 1`] = `
 "[31m[1m[1m●[1m Validation Error[22m:
 
-  Option [1m\"fn\"[22m must be of type:
+  Option [1m\\"fn\\"[22m must be of type:
     [1m[32mfunction[31m[22m
   but instead received:
     [1m[31mstring[31m[22m
 
   Example:
   {
-    [1m\"fn\"[22m: [1m(config, option, deprecatedOptions) => true[22m
+    [1m\\"fn\\"[22m: [1m(config, option, deprecatedOptions) => true[22m
   }
 [39m"
 `;
@@ -68,14 +68,14 @@ exports[`test pretty prints valid config for Function 1`] = `
 exports[`test pretty prints valid config for Object 1`] = `
 "[31m[1m[1m●[1m Validation Error[22m:
 
-  Option [1m\"haste\"[22m must be of type:
+  Option [1m\\"haste\\"[22m must be of type:
     [1m[32mobject[31m[22m
   but instead received:
     [1m[31mnumber[31m[22m
 
   Example:
   {
-    [1m\"haste\"[22m: [1m{\"providesModuleNodeModules\": [\"react\", \"react-native\"]}[22m
+    [1m\\"haste\\"[22m: [1m{\\"providesModuleNodeModules\\": [\\"react\\", \\"react-native\\"]}[22m
   }
 [39m"
 `;
@@ -83,14 +83,14 @@ exports[`test pretty prints valid config for Object 1`] = `
 exports[`test pretty prints valid config for String 1`] = `
 "[31m[1m[1m●[1m Validation Error[22m:
 
-  Option [1m\"preset\"[22m must be of type:
+  Option [1m\\"preset\\"[22m must be of type:
     [1m[32mstring[31m[22m
   but instead received:
     [1m[31mnumber[31m[22m
 
   Example:
   {
-    [1m\"preset\"[22m: [1m\"react-native\"[22m
+    [1m\\"preset\\"[22m: [1m\\"react-native\\"[22m
   }
 [39m"
 `;
@@ -102,7 +102,7 @@ exports[`test works with custom deprecations 1`] = `
 
   Jest now treats your current configuration as:
   {
-    [1m\"transform\"[22m: [1m{\".*\": \"test\"}[22m
+    [1m\\"transform\\"[22m: [1m{\\".*\\": \\"test\\"}[22m
   }
 
   Please update your configuration.
@@ -113,14 +113,14 @@ My custom comment[39m"
 exports[`test works with custom errors 1`] = `
 "[31m[1mMy Custom Error[22m:
 
-  Option [1m\"test\"[22m must be of type:
+  Option [1m\\"test\\"[22m must be of type:
     [1m[32marray[31m[22m
   but instead received:
     [1m[31mstring[31m[22m
 
   Example:
   {
-    [1m\"test\"[22m: [1m[1, 2][22m
+    [1m\\"test\\"[22m: [1m[1, 2][22m
   }
 
 My custom comment[39m"
@@ -129,7 +129,7 @@ My custom comment[39m"
 exports[`test works with custom warnings 1`] = `
 "[33m[1mMy Custom Warning[22m:
 
-  Unknown option [1m\"unknown\"[22m with value [1m\"string\"[22m was found.
+  Unknown option [1m\\"unknown\\"[22m with value [1m\\"string\\"[22m was found.
   This is probably a typing mistake. Fixing it will remove this message.
 
 My custom comment[39m"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Fixes Travis.
Btw, this looks a bit weird with "unescaped" backslash now, when comparing old/new snapshot

<img width="600" alt="screen shot 2017-01-29 at 00 33 41" src="https://cloud.githubusercontent.com/assets/5106466/22400633/ae07fe04-e5ba-11e6-9c1b-55ca6787b6b1.png">

