### PR TITLE
Fixes snapshot rendering not to show backslashes

### DIFF
--- a/packages/jest-snapshot/src/State.js
+++ b/packages/jest-snapshot/src/State.js
@@ -158,7 +158,7 @@ class SnapshotState {
       if (!pass) {
         this.unmatched++;
         return {
-          actual: receivedSerialized,
+          actual: receivedSerialized.replace(/\\"/g, '"'),
           count,
           expected,
           pass: false,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Back to normal snapshot rendering in terminal, without altering new snapshots escaping method.

<img width="602" alt="screen shot 2017-01-29 at 01 08 51" src="https://cloud.githubusercontent.com/assets/5106466/22400815/0b4de4de-e5c0-11e6-882e-f5b40929112f.png">

**Test plan**

jest