### PR TITLE
Fix wrong highlighting for the matches in pattern mode

### DIFF
--- a/packages/jest-cli/src/lib/__tests__/__snapshots__/highlight-test.js.snap
+++ b/packages/jest-cli/src/lib/__tests__/__snapshots__/highlight-test.js.snap
@@ -12,6 +12,8 @@ exports[`test dims everything when there is no match 6`] = `"[2m...-test.js[22
 
 exports[`test dims everything when there is no match 7`] = `"[2m....js[22m"`;
 
+exports[`test dims everything when there is no match 8`] = `"[2m./watch-test.js[22m"`;
+
 exports[`test highlight the trimmed part when there is only a rootDir match 1`] = `"[2mjest-cli/__tests__/watch-test.js[22m"`;
 
 exports[`test highlight the trimmed part when there is only a rootDir match 2`] = `"[0m...[0m[2mt-cli/__tests__/watch-test.js[22m"`;
@@ -26,6 +28,8 @@ exports[`test highlight the trimmed part when there is only a rootDir match 6`] 
 
 exports[`test highlight the trimmed part when there is only a rootDir match 7`] = `"[0m...[0m[2m.js[22m"`;
 
+exports[`test highlight the trimmed part when there is only a rootDir match 8`] = `"[0m./[0m[2mwatch-test.js[22m"`;
+
 exports[`test highlights everything when there is a full match 1`] = `"[0mjest-cli/__tests__/watch-test.js[0m"`;
 
 exports[`test highlights everything when there is a full match 2`] = `"[0m...t-cli/__tests__/watch-test.js[0m"`;
@@ -39,6 +43,24 @@ exports[`test highlights everything when there is a full match 5`] = `"[0m...wa
 exports[`test highlights everything when there is a full match 6`] = `"[0m...-test.js[0m"`;
 
 exports[`test highlights everything when there is a full match 7`] = `"[0m....js[0m"`;
+
+exports[`test highlights everything when there is a full match 8`] = `"[0m./watch-test.js[0m"`;
+
+exports[`test highlights part of file name when there is a partially match of the file name 1`] = `"[2mjest-cli/__tests__/[22m[0mwatch[0m[2m-test.js[22m"`;
+
+exports[`test highlights part of file name when there is a partially match of the file name 2`] = `"[2m...t-cli/__tests__/[22m[0mwatch[0m[2m-test.js[22m"`;
+
+exports[`test highlights part of file name when there is a partially match of the file name 3`] = `"[2m.../__tests__/[22m[0mwatch[0m[2m-test.js[22m"`;
+
+exports[`test highlights part of file name when there is a partially match of the file name 4`] = `"[2m...sts__/[22m[0mwatch[0m[2m-test.js[22m"`;
+
+exports[`test highlights part of file name when there is a partially match of the file name 5`] = `"[2m...[22m[0mwatch[0m[2m-test.js[22m"`;
+
+exports[`test highlights part of file name when there is a partially match of the file name 6`] = `"[0m...[0m[2m-test.js[22m"`;
+
+exports[`test highlights part of file name when there is a partially match of the file name 7`] = `"[0m...[0m[2m.js[22m"`;
+
+exports[`test highlights part of file name when there is a partially match of the file name 8`] = `"[2m./[22m[0mwatch[0m[2m-test.js[22m"`;
 
 exports[`test highlights the trimmed part there is a non visible match 1`] = `"[0m...t-cli[0m[2m/__tests__/watch-test.js[22m"`;
 

--- a/packages/jest-cli/src/lib/__tests__/highlight-test.js
+++ b/packages/jest-cli/src/lib/__tests__/highlight-test.js
@@ -22,6 +22,7 @@ const relativePaths = [
   '...watch-test.js',
   '...-test.js',
   '....js',
+  './watch-test.js',
 ];
 
 it('highlight the trimmed part when there is only a rootDir match', () => {
@@ -46,5 +47,11 @@ it('dims everything when there is no match', () => {
 it('highlights everything when there is a full match', () => {
   relativePaths
   .map(trimmed => highlight(rawPath, trimmed, 'User.*js', rootDir))
+  .forEach(output => expect(output).toMatchSnapshot());
+});
+
+it('highlights part of file name when there is a partially match of the file name', () => {
+  relativePaths
+  .map(trimmed => highlight(rawPath, trimmed, 'watch', rootDir))
   .forEach(output => expect(output).toMatchSnapshot());
 });

--- a/packages/jest-cli/src/lib/highlight.js
+++ b/packages/jest-cli/src/lib/highlight.js
@@ -17,7 +17,7 @@ const hit = chalk.reset;
 const miss = chalk.dim;
 
 const trim = '...';
-const relativePathHead = './';
+const relativePathHead = `.${path.sep}`;
 
 const colorize = (str: string, start: number, end: number) => (
   miss(str.slice(0, start)) +

--- a/packages/jest-cli/src/lib/highlight.js
+++ b/packages/jest-cli/src/lib/highlight.js
@@ -17,6 +17,7 @@ const hit = chalk.reset;
 const miss = chalk.dim;
 
 const trim = '...';
+const relativePathHead = './';
 
 const colorize = (str: string, start: number, end: number) => (
   miss(str.slice(0, start)) +
@@ -53,6 +54,9 @@ const highlight = (
   if (filePath.startsWith(trim)) {
     offset = rawPath.length - filePath.length;
     trimLength = trim.length;
+  } else if (filePath.startsWith(relativePathHead)) {
+    offset = rawPath.length - filePath.length;
+    trimLength = relativePathHead.length;
   } else {
     offset = rootDir.length + path.sep.length;
     trimLength = 0;


### PR DESCRIPTION
**Summary**

Now, highlight in pattern mode working wrong on relative paths starts with `./`:

![jan-29-2017 21-16-05](https://cloud.githubusercontent.com/assets/9217163/22406675/36133f54-e668-11e6-9210-2ad7d44e2c8d.gif)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

After fix, it is look like this:

![jan-29-2017 21-16-13](https://cloud.githubusercontent.com/assets/9217163/22406678/3c283ff2-e668-11e6-9dc0-3ce08db11d98.gif)