### PR TITLE
Remove `jest-mock` from `jest-cli` and `jest-config`.

### DIFF
--- a/packages/jest-cli/package.json
+++ b/packages/jest-cli/package.json
@@ -18,7 +18,6 @@
     "jest-file-exists": "^17.0.0",
     "jest-haste-map": "^18.1.0",
     "jest-jasmine2": "^18.1.0",
-    "jest-mock": "^18.0.0",
     "jest-resolve": "^18.1.0",
     "jest-resolve-dependencies": "^18.1.0",
     "jest-runtime": "^18.1.0",

--- a/packages/jest-config/package.json
+++ b/packages/jest-config/package.json
@@ -12,7 +12,6 @@
     "jest-environment-jsdom": "^18.1.0",
     "jest-environment-node": "^18.1.0",
     "jest-jasmine2": "^18.1.0",
-    "jest-mock": "^18.0.0",
     "jest-resolve": "^18.1.0",
     "jest-util": "^18.1.0",
     "jest-validate": "^18.1.0",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Drops `jest-mock` from `jest-cli` and `jest-config`.
Incidentally, `jest-mock` is also required by `jest-runtime`, but it is [only used for the type import](https://github.com/facebook/jest/blob/054f9c35a7733e785b2b615f3ccd62f32d8cbc1e/packages/jest-runtime/src/index.js#L18).  Would that mean that it could/should be a devDependency?
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
Nothing should change.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
