### PR TITLE
Hoist `jest-mock` types to `types/Mock`.

### DIFF
--- a/packages/jest-runtime/package.json
+++ b/packages/jest-runtime/package.json
@@ -16,7 +16,6 @@
     "jest-config": "^18.1.0",
     "jest-file-exists": "^17.0.0",
     "jest-haste-map": "^18.1.0",
-    "jest-mock": "^18.0.0",
     "jest-resolve": "^18.1.0",
     "jest-snapshot": "^18.1.0",
     "jest-util": "^18.1.0",

--- a/packages/jest-runtime/src/index.js
+++ b/packages/jest-runtime/src/index.js
@@ -15,7 +15,7 @@ import type {Console} from 'console';
 import type {Environment} from 'types/Environment';
 import type {HasteContext} from 'types/HasteMap';
 import type {ModuleMap} from 'jest-haste-map';
-import type {MockFunctionMetadata, ModuleMocker} from 'jest-mock';
+import type {MockFunctionMetadata, ModuleMocker} from 'types/Mock';
 
 const HasteMap = require('jest-haste-map');
 const Resolver = require('jest-resolve');

--- a/types/Mock.js
+++ b/types/Mock.js
@@ -1,6 +1,15 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
 'use strict';
 
-import type {_MockFunctionMetadata, _ModuleMocker} from 'jest-mock';
+import type {MockFunctionMetadata as _MockFunctionMetadata, ModuleMocker as _ModuleMocker} from 'jest-mock';
 
 export type MockFunctionMetadata = _MockFunctionMetadata;
 export type ModuleMocker = _ModuleMocker;

--- a/types/Mock.js
+++ b/types/Mock.js
@@ -1,0 +1,6 @@
+'use strict';
+
+import type {_MockFunctionMetadata, _ModuleMocker} from 'jest-mock';
+
+export type MockFunctionMetadata = _MockFunctionMetadata;
+export type ModuleMocker = _ModuleMocker;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Hoists `MockFunctionMetadata` and `ModuleMocker` from `jest-mock` to `types/Mock`.  This allows `jest-runtime` to reference `types/Mock` for those types instead of requiring a runtime dependency of `jest-mock`.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
Nothing should change.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
