### PR TITLE
console.log never prints in failed test suites

### DIFF
--- a/integration_tests/__tests__/__snapshots__/console-test.js.snap
+++ b/integration_tests/__tests__/__snapshots__/console-test.js.snap
@@ -20,7 +20,7 @@ exports[`test console printing 2`] = `
 Tests:       1 passed, 1 total
 Snapshots:   0 total
 Time:        <<REPLACED>>
-Ran all test suites.
+Ran all test suites matching \\"console-test.js\\".
 "
 `;
 
@@ -52,6 +52,6 @@ exports[`test console printing with --verbose 3`] = `
 Tests:       1 passed, 1 total
 Snapshots:   0 total
 Time:        <<REPLACED>>
-Ran all test suites.
+Ran all test suites matching \\"console-test.js\\".
 "
 `;

--- a/integration_tests/__tests__/console-test.js
+++ b/integration_tests/__tests__/console-test.js
@@ -16,7 +16,7 @@ const skipOnWindows = require('skipOnWindows');
 skipOnWindows.suite();
 
 test('console printing', () => {
-  const {stderr, status} = runJest('console');
+  const {stderr, status} = runJest('console', ['console-test.js']);
   const {summary, rest} = extractSummary(stderr);
 
   expect(status).toBe(0);
@@ -26,11 +26,21 @@ test('console printing', () => {
 
 test('console printing with --verbose', () => {
   const {stderr, stdout, status} =
-    runJest('console', ['--verbose', '--no-cache']);
+    runJest('console', ['console-test.js', '--verbose', '--no-cache']);
   const {summary, rest} = extractSummary(stderr);
 
   expect(status).toBe(0);
   expect(stdout).toMatchSnapshot();
   expect(rest).toMatchSnapshot();
   expect(summary).toMatchSnapshot();
+});
+
+test('prints console messages if test suite fails to run', () => {
+  const {stdout} = runJest('console', ['error-outside']);
+  expect(stdout).toMatch('HEY, I SHOULD BE PRINTED');
+});
+
+test('prints console messages if test suite fails to run --verbose', () => {
+  const {stdout} = runJest('console', ['error-outside', '--verbose']);
+  expect(stdout).toMatch('HEY, I SHOULD BE PRINTED');
 });

--- a/integration_tests/console/__tests__/error-outside-test.js
+++ b/integration_tests/console/__tests__/error-outside-test.js
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
+console.log('HEY, I SHOULD BE PRINTED');
+
+throw new Error('will crash before even running tests');
+
+/* eslint-disable no-unreachable */
+test(`let's not go there`, () => {});


### PR DESCRIPTION
just ran into this issue on www.

in a test like
```js
console.log('TEST');
throw 'error';
test(() => /* ... */);
```

`console.log` never prints unless jest is run with `--verbose` mode. That can be very confusing when trying to debug a failing suite.
I added a repro and failing test case.

@wanderley do you want to look into it?