### PR TITLE
Don’t escape html entities except for < and >.

### DIFF
--- a/examples/snapshot/__tests__/__snapshots__/Link.react-test.js.snap
+++ b/examples/snapshot/__tests__/__snapshots__/Link.react-test.js.snap
@@ -34,7 +34,7 @@ exports[`test properly escapes quotes 1`] = `
   href="#"
   onMouseEnter={[Function]}
   onMouseLeave={[Function]}>
-  &quot;Facebook&quot; \\&#039;is \\ &#039;awesome&#039;
+  "Facebook" \\'is \\ 'awesome'
 </a>
 `;
 

--- a/packages/pretty-format/src/__tests__/pretty-format-test.js
+++ b/packages/pretty-format/src/__tests__/pretty-format-test.js
@@ -467,7 +467,7 @@ describe('prettyFormat()', () => {
           React.createElement('Mouse'),
           '\\ \\\\'
         ),
-        '<Mouse>\n  &quot;-&quot;\n  <Mouse />\n  \\ \\\\\n</Mouse>'
+        '<Mouse>\n  "-"\n  <Mouse />\n  \\ \\\\\n</Mouse>'
       );
     });
 

--- a/packages/pretty-format/src/plugins/escapeHTML.js
+++ b/packages/pretty-format/src/plugins/escapeHTML.js
@@ -10,12 +10,7 @@
 'use strict';
 
 function escapeHTML(str: string): string {
-  return str
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#039;');
+  return str.replace(/</g, '&lt;').replace(/>/g, '&gt;');
 }
 
 module.exports = escapeHTML;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Snapshots with React are used in different contexts, not just on the web. We don't need to replace all html entities. It does make sense however for < and > because otherwise it would break the pretty-printed JSX.

cc @vjeux

**Test plan**
jest