### PR TITLE
Preset without setupFiles fix

### DIFF
--- a/packages/jest-config/src/__tests__/normalize-test.js
+++ b/packages/jest-config/src/__tests__/normalize-test.js
@@ -572,15 +572,21 @@ describe('Upgrade help', () => {
 });
 
 describe('preset', () => {
-  jest.mock(
-    '/node_modules/react-native/jest-preset.json',
-    () => ({
-      moduleNameMapper: {b: 'b'},
-      modulePathIgnorePatterns: ['b'],
-      setupFiles: ['b'],
-    }),
-    {virtual: true}
-  );
+  beforeAll(() => {
+    jest.mock(
+      '/node_modules/react-native/jest-preset.json',
+      () => ({
+        moduleNameMapper: {b: 'b'},
+        modulePathIgnorePatterns: ['b'],
+        setupFiles: ['b'],
+      }),
+      {virtual: true}
+    );
+  });
+
+  afterAll(() => {
+    jest.unmock('/node_modules/react-native/jest-preset.json');
+  });
 
   test('throws when preset not found', () => {
     expect(() => {
@@ -614,6 +620,33 @@ describe('preset', () => {
       setupFiles: expect.arrayContaining(
         ['/node_modules/a', '/node_modules/b']
       ),
+    }));
+  });
+});
+
+describe('preset without setupFiles', () => {
+  beforeAll(() => {
+    jest.mock(
+      '/node_modules/react-native/jest-preset.json',
+      () => {
+        return {
+          moduleNameMapper: {b: 'b'},
+          modulePathIgnorePatterns: ['b'],
+        };
+      },
+      {virtual: true}
+    );
+  });
+
+  it('should normalize setupFiles correctly', () => {
+    const config = normalize({
+      preset: 'react-native',
+      rootDir: '/root/path/foo',
+      setupFiles: ['a'],
+    });
+
+    expect(config).toEqual(expect.objectContaining({
+      setupFiles: expect.arrayContaining(['/node_modules/a']),
     }));
   });
 });

--- a/packages/jest-config/src/normalize.js
+++ b/packages/jest-config/src/normalize.js
@@ -58,7 +58,7 @@ const setupPreset = (config: InitialConfig, configPreset: string) => {
   }
 
   if (config.setupFiles) {
-    config.setupFiles = preset.setupFiles.concat(config.setupFiles);
+    config.setupFiles = (preset.setupFiles || []).concat(config.setupFiles);
   }
   if (config.modulePathIgnorePatterns) {
     config.modulePathIgnorePatterns = preset.modulePathIgnorePatterns


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

When you have preset file without `setupFiles` property and you try to extend it with config that has `setupFiles` property, `jest` throws an exception;

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

1. Create preset file without `setupFiles`
2. Create config with `setupFiles`
3. Run `jest`

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
