### PR TITLE
Fixed links in JestObjectAPI docs

### DIFF
--- a/docs/JestObjectAPI.md
+++ b/docs/JestObjectAPI.md
@@ -60,7 +60,7 @@ Returns the `jest` object for chaining.
 *Note: this method was previously called `autoMockOn`. When using `babel-jest`, calls to `enableAutomock` will automatically be hoisted to the top of the code block. Use `autoMockOn` if you want to explicitly avoid this behavior.*
 
 ### `jest.fn(implementation)`
-Returns a new, unused [mock function](#mock-functions). Optionally takes a mock implementation.
+Returns a new, unused [mock function](/jest/docs/mock-function-api.html). Optionally takes a mock implementation.
 
 ```js
   const mockFn = jest.fn();
@@ -187,7 +187,7 @@ In these rare scenarios you can use this API to manually fill the slot in the mo
 
 Returns the `jest` object for chaining.
 
-*Note It is recommended to use [`jest.mock()`](#jest-mock-modulename-factory) instead. The `jest.mock` API's second argument is a module factory instead of the expected exported module object.*
+*Note It is recommended to use [`jest.mock()`](#jestmockmodulename-factory-options) instead. The `jest.mock` API's second argument is a module factory instead of the expected exported module object.*
 
 ### `jest.unmock(moduleName)`
 Indicates that the module system should never return a mocked version of the specified module from `require()` (e.g. that it should always return the real module).


### PR DESCRIPTION
**Summary**

There were 2 links in `JestObjectAPI.md` that pointed to the wrong place (I assume left unchecked from the redesign).

I've changed these to where I believe they are supposed to go.

**Test plan**

Since these are only docs changes, the only things I thought to were check the docs locally with the server running from `npm start` and running `npm test`. Everything rendered properly in the browser test, and no tests failed.

![jan-31-2017 20-45-28](https://cloud.githubusercontent.com/assets/9259509/22492158/58eae0d8-e7f6-11e6-8e7b-5fe08de6e6fc.gif)
