### PR TITLE
Move expect.addSnapshotSerializer to jest-jasmine2

### DIFF
--- a/packages/jest-jasmine2/src/jest-expect.js
+++ b/packages/jest-jasmine2/src/jest-expect.js
@@ -15,6 +15,7 @@ import type {RawMatcherFn} from 'types/Matchers';
 const expect = require('jest-matchers');
 
 const {
+  addSerializer,
   toMatchSnapshot,
   toThrowErrorMatchingSnapshot,
 } = require('jest-snapshot');
@@ -32,6 +33,8 @@ module.exports = (config: Config) => {
     expand: config.expand,
   });
   expect.extend({toMatchSnapshot, toThrowErrorMatchingSnapshot});
+
+  expect.addSnapshotSerializer = addSerializer;
 
   const jasmine = global.jasmine;
   jasmine.addMatchers = (jasmineMatchersObject: JasmineMatchersObject) => {

--- a/packages/jest-matchers/src/index.js
+++ b/packages/jest-matchers/src/index.js
@@ -34,9 +34,6 @@ const {
   stringContaining,
   stringMatching,
 } = require('./asymmetric-matchers');
-const {
-  addSerializer,
-} = require('jest-snapshot');
 
 const GLOBAL_STATE = Symbol.for('$$jest-matchers-object');
 
@@ -153,8 +150,6 @@ expect.objectContaining = objectContaining;
 expect.arrayContaining = arrayContaining;
 expect.stringContaining = stringContaining;
 expect.stringMatching = stringMatching;
-
-expect.addSnapshotSerializer = addSerializer;
 
 const _validateResult = result => {
   if (


### PR DESCRIPTION
**Summary**

Does first bullet point in https://github.com/facebook/jest/pull/2746#issuecomment-276344253

Move `expect.addSnapshotSerializer = addSerializer;`

* from `packages/jest-matchers/src/index.js`
* to `packages/jest-jasmine2/src/jest-expect.js`

Thank you for your patience. Not sure why test seemed to fail when I tried to do it in #2746

**Test plan**

`integration_tests/snapshot-serializers/__tests__/snapshot-test.js` now [still] passes
