### PR TITLE
Docs: capitalization and cross-reference in Configuration.md

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -252,7 +252,7 @@ Default: `[]`
 A list of paths to snapshot serializer modules Jest should use for snapshot
 testing.
 
-Jest has default serializers for built-in javascript types and for react
+Jest has default serializers for built-in JavaScript types and for React
 elements. See [snapshot test tutorial](/jest/docs/tutorial-react-native.html#snapshot-test) for more information.
 
 Example serializer module:
@@ -303,6 +303,8 @@ Pretty foo: Object {
   "y": 2,
 }
 ```
+
+To make a dependency explicit instead of implicit, you can call [`expect.addSnapshotSerializer`](/jest/docs/expect.html#expectaddsnapshotserializerserializer) to add a module for an individual test file instead of adding its path to `snapshotSerializers` in Jest configuration.
 
 ### `testEnvironment` [string]
 Default: `"jsdom"`

--- a/docs/ExpectAPI.md
+++ b/docs/ExpectAPI.md
@@ -257,7 +257,6 @@ If you add a snapshot serializer in individual test files instead of to adding i
 * You make the dependency explicit instead of implicit.
 * You avoid limits to configuration that might cause you to eject from [create-react-app](https://github.com/facebookincubator/create-react-app).
 
-
 See [configuring package.json](/jest/docs/configuration.html#snapshotserializers-array-string) for more information.
 
 ### `.not`


### PR DESCRIPTION
**Summary**

Configuration.md

* capitalization: noticed these are the only all-lowercase occurrences of JavaScript and React in prose content of docs.
* cross-reference: readers need the other direction with brief contrasting explanation

ExpectAPI.md

* removed an extra empty line from when I moved the code example

**Test plan**

Review by a second pair of eyes, thank you :)

P.S. Do we have a doc convention to tell people which version of Jest, as discussed in http://facebook.github.io/jest/docs/expect.html#expectaddsnapshotserializerserializer