### PR TITLE
Prevent jest-hoist from erroring on identifiers in type annotations

### DIFF
--- a/integration_tests/babel-plugin-jest-hoist/.babelrc
+++ b/integration_tests/babel-plugin-jest-hoist/.babelrc
@@ -1,4 +1,12 @@
 {
-  "presets": ["es2015", {"plugins": ["jest-hoist" ]}],
+  "presets": [
+    "es2015",
+    {
+      "plugins": [
+        "jest-hoist",
+        "transform-flow-strip-types"
+      ]
+    }
+  ],
   "retainLines": true
 }

--- a/integration_tests/babel-plugin-jest-hoist/__tests__/integration-test.js
+++ b/integration_tests/babel-plugin-jest-hoist/__tests__/integration-test.js
@@ -48,6 +48,9 @@ jest.mock('../__test_modules__/e', () => {
   };
 });
 jest.mock('virtual-module', () => 'kiwi', {virtual: true});
+// This has types that should be ignored by the out-of-scope variables check.
+jest.mock('has-flow-types', () =>
+  (props: {children: mixed}) => 3, {virtual: true});
 
 // These will not be hoisted
 jest.unmock('../__test_modules__/a').dontMock('../__test_modules__/b');

--- a/integration_tests/babel-plugin-jest-hoist/package.json
+++ b/integration_tests/babel-plugin-jest-hoist/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "babel-plugin-transform-flow-strip-types": "^6.22.0",
     "babel-preset-es2015": "^6.9.0",
     "react": "^15.2.1"
   },

--- a/packages/babel-plugin-jest-hoist/src/index.js
+++ b/packages/babel-plugin-jest-hoist/src/index.js
@@ -73,6 +73,7 @@ const IDVisitor = {
   ReferencedIdentifier(path) {
     this.ids.add(path);
   },
+  blacklist: ['TypeAnnotation'],
 };
 
 const FUNCTIONS = Object.create(null);


### PR DESCRIPTION
Fixes #2790


