### PR TITLE
Hoist `jest-resolve` types to `types/Resolve`.

### DIFF
--- a/packages/jest-cli/package.json
+++ b/packages/jest-cli/package.json
@@ -17,7 +17,6 @@
     "jest-environment-jsdom": "^18.1.0",
     "jest-haste-map": "^18.1.0",
     "jest-jasmine2": "^18.1.0",
-    "jest-resolve": "^18.1.0",
     "jest-resolve-dependencies": "^18.1.0",
     "jest-runtime": "^18.1.0",
     "jest-snapshot": "^18.1.0",

--- a/packages/jest-cli/src/SearchSource.js
+++ b/packages/jest-cli/src/SearchSource.js
@@ -13,7 +13,7 @@
 import type {Config} from 'types/Config';
 import type {HasteContext} from 'types/HasteMap';
 import type {Glob, Path} from 'types/Config';
-import type {ResolveModuleConfig} from 'jest-resolve';
+import type {ResolveModuleConfig} from 'types/Resolve';
 
 const micromatch = require('micromatch');
 

--- a/packages/jest-cli/src/runTest.js
+++ b/packages/jest-cli/src/runTest.js
@@ -11,7 +11,7 @@
 
 import type {Path, Config} from 'types/Config';
 import type {TestResult} from 'types/TestResult';
-import type Resolver from 'jest-resolve';
+import type {Resolver} from 'types/Resolve';
 
 const BufferedConsole = require('./lib/BufferedConsole');
 const {

--- a/packages/jest-resolve-dependencies/package.json
+++ b/packages/jest-resolve-dependencies/package.json
@@ -8,7 +8,6 @@
   "license": "BSD-3-Clause",
   "main": "build/index.js",
   "dependencies": {
-    "jest-file-exists": "^17.0.0",
-    "jest-resolve": "^18.1.0"
+    "jest-file-exists": "^17.0.0"
   }
 }

--- a/packages/jest-resolve-dependencies/src/index.js
+++ b/packages/jest-resolve-dependencies/src/index.js
@@ -12,7 +12,7 @@
 
 import type {HasteFS} from 'types/HasteMap';
 import type {Path} from 'types/Config';
-import type Resolver, {ResolveModuleConfig} from 'jest-resolve';
+import type Resolver, {ResolveModuleConfig} from 'types/Resolve';
 
 const fileExists = require('jest-file-exists');
 

--- a/packages/jest-resolve-dependencies/src/index.js
+++ b/packages/jest-resolve-dependencies/src/index.js
@@ -12,7 +12,7 @@
 
 import type {HasteFS} from 'types/HasteMap';
 import type {Path} from 'types/Config';
-import type Resolver, {ResolveModuleConfig} from 'types/Resolve';
+import type {Resolver, ResolveModuleConfig} from 'types/Resolve';
 
 const fileExists = require('jest-file-exists');
 

--- a/types/Resolve.js
+++ b/types/Resolve.js
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+'use strict';
+
+import type _Resolver, { ResolveModuleConfig as _ResolveModuleConfig } from 'jest-resolve';
+
+export type Resolver = _Resolver;
+export type ResolveModuleConfig = _ResolveModuleConfig;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Hoists `Resolver` and `ResolveModuleConfig` from `jest-resolve` to `types/Resolve`.  This allows `jest-cli` and `jest-resolve-dependencies` to refer to `types/Resolve` for those types instead of requiring a runtime dependency of `jest-resolve`.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
Nothing should change.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
