### PR TITLE
Benchmarking the jest script

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "react-test-renderer": "^15.4.1",
     "rimraf": "^2.5.4",
     "strip-ansi": "^3.0.1",
+    "timing-stats-cli": "^0.5.7",
     "typescript": "^2.1.4"
   },
   "scripts": {
@@ -43,7 +44,7 @@
     "lint": "eslint . --cache",
     "postinstall": "node ./scripts/postinstall.js && node ./scripts/build.js && (cd packages/eslint-plugin-jest && yarn link) && yarn link eslint-plugin-jest",
     "publish": "yarn run build-clean && yarn run build && lerna publish",
-    "test-ci": "yarn run typecheck && yarn run lint && yarn run build && yarn run jest-coverage -- -i && yarn run test-examples && node scripts/mapCoverage.js && codecov",
+    "test-ci": "yarn run typecheck && yarn run lint && yarn run build && benchmark jest yarn run jest-coverage -- -i && add-temp-timing-to-json build_times.json && yarn run test-examples && node scripts/mapCoverage.js && codecov",
     "test-examples": "node scripts/test_examples.js",
     "test-pretty-format-perf": "node packages/pretty-format/perf/test.js",
     "test": "yarn run typecheck && yarn run lint && yarn run build && yarn run jest && yarn run test-examples",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "react-test-renderer": "^15.4.1",
     "rimraf": "^2.5.4",
     "strip-ansi": "^3.0.1",
-    "timing-stats-cli": "^0.5.7",
+    "timing-stats-cli": "^0.6.0",
     "typescript": "^2.1.4"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2221,6 +2221,10 @@ through@^2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
+timing-stats-cli@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/timing-stats-cli/-/timing-stats-cli-0.6.0.tgz#8174b50bc9335386405f9a9af3b6aae5358d0d5f"
+
 to-fast-properties@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.2.tgz#f3f5c0c3ba7299a7ef99427e44633257ade43320"


### PR DESCRIPTION
The goal is to benchmark the jest script to monitor and analyze the test suite run time over time using https://github.com/TheSavior/timing-stats.

At the end of the build, there will be a file called `build_times.json`. This is specified in the package.json file. It will append the current results to whatever the content of that file is. If CI pushes back to master this is trivial. In order to push to a different branch, we'll need to check out the other branch before running `add-temp-timing-to-json` and then pushing.