### PR TITLE
Add 'available since' to docs

### DIFF
--- a/docs/ExpectAPI.md
+++ b/docs/ExpectAPI.md
@@ -186,6 +186,8 @@ The `expect.assertions(1)` call ensures that the `prepareState` callback actuall
 
 ### `expect.stringContaining(string)`
 
+##### available since: **v19.0.0**
+
 `expect.stringContaining(string)` matches any string that contains the exact provided string.
 
 

--- a/website/src/jest/css/jest.css
+++ b/website/src/jest/css/jest.css
@@ -279,6 +279,13 @@ header h2 {
 .mainContainer .wrapper .post h3 {
   font-size: 110%;
 }
+.mainContainer .wrapper .post h5 {
+  font-weight: 300;
+  font-style: italic;
+}
+.mainContainer .wrapper .post h5 strong {
+  font-weight: 400;
+}
 .mainContainer .wrapper .post ol {
   list-style: decimal outside none;
 }


### PR DESCRIPTION


<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Currently only for `expect.stringContaining`.

<img width="768" alt="screen shot 2017-02-04 at 09 22 40" src="https://cloud.githubusercontent.com/assets/5106466/22617116/cc25eac0-eabc-11e6-9285-aa96628db25d.png">
