### PR TITLE
Fix typo in test sample

### DIFF
--- a/docs/TutorialReactNative.md
+++ b/docs/TutorialReactNative.md
@@ -89,7 +89,7 @@ import Intro from '../Intro';
 // Note: test renderer must be required after react-native.
 import renderer from 'react-test-renderer';
 
-test('renders correctly', () => {
+it('renders correctly', () => {
   const tree = renderer.create(
     <Intro />
   ).toJSON();


### PR DESCRIPTION
`it` is wrongly written as `test`  in the doc

```// __tests__/Intro-test.js
import 'react-native';
import React from 'react';
import Intro from '../Intro';

// Note: test renderer must be required after react-native.
import renderer from 'react-test-renderer';

test('renders correctly', () => {
  const tree = renderer.create(
    <Intro />
  ).toJSON();
  expect(tree).toMatchSnapshot();
});```

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
