### PR TITLE
fixed bug in example code expect.stringMatching

### DIFF
--- a/docs/ExpectAPI.md
+++ b/docs/ExpectAPI.md
@@ -217,8 +217,11 @@ test('randomCoolNames only returns cool names', () => {
   // A reasonable proxy for whether a name is cool or not
   let coolRegex = /^Kevin/;
 
-  expect(randomCoolNames).toEqual(
-    expect.arrayContaining(expect.stringMatching(coolRegex)));
+  expect(randomCoolNames()).toEqual(
+    expect.arrayContaining([
+      expect.stringMatching(coolRegex)
+    ])
+  );
 });
 ```
 


### PR DESCRIPTION
see #2813 

```
I think it's a bug in a code example in the documentation
https://facebook.github.io/jest/docs/expect.html#expectstringmatchingregexp
```