### PR TITLE
Create new array if parsed babel file does not have the plugin section.

### DIFF
--- a/packages/jest-editor-support/src/parsers/BabylonParser.js
+++ b/packages/jest-editor-support/src/parsers/BabylonParser.js
@@ -51,7 +51,7 @@ const babylonParser = (file: string) => {
   const babelRC = getBabelRC(file, {useCache: true});
   const babel = JSON.parse(babelRC);
 
-  const plugins = babel.plugins.concat(['flow']);
+  const plugins = Array.isArray(babel.plugins) ? babel.plugins.concat(['flow']) : ['flow'];
   const config = {plugins, sourceType: 'module'};
   const ast = babylon.parse(data, config);
 


### PR DESCRIPTION
Fixing the "babylonParser" expects that "plugins" is set in error #2819
