### PR TITLE
Put JSX closing brackets in new line in snapshots

### DIFF
--- a/examples/react-native/__tests__/__snapshots__/Intro-test.js.snap
+++ b/examples/react-native/__tests__/__snapshots__/Intro-test.js.snap
@@ -7,7 +7,8 @@ exports[`test renders correctly 1`] = `
       "flex": 1,
       "justifyContent": "center",
     }
-  }>
+  }
+>
   <Text
     accessible={true}
     allowFontScaling={true}
@@ -18,7 +19,8 @@ exports[`test renders correctly 1`] = `
         "margin": 10,
         "textAlign": "center",
       }
-    }>
+    }
+  >
     Welcome to React Native!
   </Text>
   <Text
@@ -31,7 +33,8 @@ exports[`test renders correctly 1`] = `
         "marginBottom": 5,
         "textAlign": "center",
       }
-    }>
+    }
+  >
     This is a React Native snapshot test.
   </Text>
 </View>
@@ -42,7 +45,8 @@ exports[`test renders the ActivityIndicator component 1`] = `
   animating={true}
   color="#999999"
   hidesWhenStopped={true}
-  size="small" />
+  size="small"
+/>
 `;
 
 exports[`test renders the Image component 1`] = `
@@ -52,7 +56,8 @@ exports[`test renders the Image component 1`] = `
       "height": 240,
       "width": 320,
     }
-  } />
+  }
+/>
 `;
 
 exports[`test renders the ListView component 1`] = `
@@ -76,23 +81,27 @@ exports[`test renders the ListView component 1`] = `
   renderRow={[Function]}
   scrollEventThrottle={50}
   scrollRenderAheadDistance={1000}
-  stickyHeaderIndices={Array []}>
+  stickyHeaderIndices={Array []}
+>
   <Text
     accessible={true}
     allowFontScaling={true}
-    ellipsizeMode="tail">
+    ellipsizeMode="tail"
+  >
     apple
   </Text>
   <Text
     accessible={true}
     allowFontScaling={true}
-    ellipsizeMode="tail">
+    ellipsizeMode="tail"
+  >
     banana
   </Text>
   <Text
     accessible={true}
     allowFontScaling={true}
-    ellipsizeMode="tail">
+    ellipsizeMode="tail"
+  >
     kiwi
   </Text>
 </ScrollView>
@@ -101,5 +110,6 @@ exports[`test renders the ListView component 1`] = `
 exports[`test renders the TextInput component 1`] = `
 <TextInput
   autoCorrect={false}
-  value="apple banana kiwi" />
+  value="apple banana kiwi"
+/>
 `;

--- a/examples/snapshot/__tests__/__snapshots__/Link.react-test.js.snap
+++ b/examples/snapshot/__tests__/__snapshots__/Link.react-test.js.snap
@@ -3,7 +3,8 @@ exports[`test changes the class when hovered 1`] = `
   className="normal"
   href="http://www.facebook.com"
   onMouseEnter={[Function]}
-  onMouseLeave={[Function]}>
+  onMouseLeave={[Function]}
+>
   Facebook
 </a>
 `;
@@ -13,7 +14,8 @@ exports[`test changes the class when hovered 2`] = `
   className="hovered"
   href="http://www.facebook.com"
   onMouseEnter={[Function]}
-  onMouseLeave={[Function]}>
+  onMouseLeave={[Function]}
+>
   Facebook
 </a>
 `;
@@ -23,7 +25,8 @@ exports[`test changes the class when hovered 3`] = `
   className="normal"
   href="http://www.facebook.com"
   onMouseEnter={[Function]}
-  onMouseLeave={[Function]}>
+  onMouseLeave={[Function]}
+>
   Facebook
 </a>
 `;
@@ -33,7 +36,8 @@ exports[`test properly escapes quotes 1`] = `
   className="normal"
   href="#"
   onMouseEnter={[Function]}
-  onMouseLeave={[Function]}>
+  onMouseLeave={[Function]}
+>
   "Facebook" \\'is \\ 'awesome'
 </a>
 `;
@@ -43,7 +47,8 @@ exports[`test renders as an anchor when no page is set 1`] = `
   className="normal"
   href="#"
   onMouseEnter={[Function]}
-  onMouseLeave={[Function]}>
+  onMouseLeave={[Function]}
+>
   Facebook
 </a>
 `;
@@ -53,7 +58,8 @@ exports[`test renders correctly 1`] = `
   className="normal"
   href="http://www.facebook.com"
   onMouseEnter={[Function]}
-  onMouseLeave={[Function]}>
+  onMouseLeave={[Function]}
+>
   Facebook
 </a>
 `;

--- a/integration_tests/__tests__/__snapshots__/snapshot-serializers-test.js.snap
+++ b/integration_tests/__tests__/__snapshots__/snapshot-serializers-test.js.snap
@@ -2,7 +2,8 @@ exports[`Snapshot serializers renders snapshot 1`] = `
 Object {
   "snapshot serializers works with default serializers 1": "
 <div
-  id=\\"foo\\" />
+  id=\\"foo\\"
+/>
 ",
   "snapshot serializers works with first plugin 1": "foo: 1",
   "snapshot serializers works with nested serializable objects 1": "foo: bar: 2",
@@ -13,7 +14,8 @@ Object {
       \\"a\\": 6,
     }
   }
-  bProp={foo: 8} />
+  bProp={foo: 8}
+/>
 ",
   "snapshot serializers works with prepended plugins from expect method called once 1": "
 <div
@@ -22,7 +24,8 @@ Object {
       \\"a\\": 6,
     }
   }
-  bProp={Foo: 8} />
+  bProp={Foo: 8}
+/>
 ",
   "snapshot serializers works with prepended plugins from expect method called twice 1": "
 <div
@@ -31,7 +34,8 @@ Object {
       \\"a\\": 6,
     }
   }
-  bProp={FOO: 8} />
+  bProp={FOO: 8}
+/>
 ",
   "snapshot serializers works with second plugin 1": "bar: 2",
 }

--- a/integration_tests/transform/multiple-transformers/__tests__/__snapshots__/multiple-transformers-test.js.snap
+++ b/integration_tests/transform/multiple-transformers/__tests__/__snapshots__/multiple-transformers-test.js.snap
@@ -1,19 +1,24 @@
 exports[`test generates a snapshot with correctly transformed dependencies 1`] = `
 <div
-  className="App-root">
+  className="App-root"
+>
   <div
-    className="App-header">
+    className="App-header"
+  >
     <img
       alt="logo"
       className="App-logo"
-      src="logo.svg" />
+      src="logo.svg"
+    />
     <h2
-      className={undefined}>
+      className={undefined}
+    >
       Welcome to React
     </h2>
   </div>
   <p
-    className="App-intro">
+    className="App-intro"
+  >
     To get started, edit 
     <code>
       src/App.js

--- a/packages/jest-diff/src/__tests__/diff-test.js
+++ b/packages/jest-diff/src/__tests__/diff-test.js
@@ -150,7 +150,9 @@ test('React elements', () => {
     },
     type: 'div',
   });
-  expect(stripAnsi(result)).toMatch(/<div[\s\S]+className="fun">/);
+  expect(stripAnsi(result)).toMatch(/<div\n/);
+  expect(stripAnsi(result)).toMatch(/[\s\S]+className="fun"\n/);
+  expect(stripAnsi(result)).toMatch(/>/);
   expect(stripAnsi(result)).toMatch(/\-\s+Hello/);
   expect(stripAnsi(result)).toMatch(/\+\s+Goodbye/);
 });

--- a/packages/pretty-format/src/__tests__/__snapshots__/pretty-format-test.js.snap
+++ b/packages/pretty-format/src/__tests__/__snapshots__/pretty-format-test.js.snap
@@ -7,7 +7,8 @@ exports[`prettyFormat() ReactTestComponent and ReactElement plugins ReactElement
         [0mrat[0m
       [36m</span>[39m
     [36m</div>[39m
-  }[39m[36m />[39m"
+  }[39m[36m
+/>[39m"
 `;
 
 exports[`prettyFormat() ReactTestComponent and ReactElement plugins ReactTestComponent plugin highlights syntax 1`] = `
@@ -19,5 +20,6 @@ exports[`prettyFormat() ReactTestComponent and ReactElement plugins ReactTestCom
         [0mrat[0m
       [36m</span>[39m
     [36m</div>[39m
-  }[39m[36m />[39m"
+  }[39m[36m
+/>[39m"
 `;

--- a/packages/pretty-format/src/__tests__/pretty-format-test.js
+++ b/packages/pretty-format/src/__tests__/pretty-format-test.js
@@ -416,28 +416,28 @@ describe('prettyFormat()', () => {
     it('supports props with strings', () => {
       assertPrintedJSX(
         React.createElement('Mouse', {style: 'color:red'}),
-        '<Mouse\n  style="color:red" />'
+        '<Mouse\n  style="color:red"\n/>'
       );
     });
 
     it('supports props with numbers', () => {
       assertPrintedJSX(
         React.createElement('Mouse', {size: 5}),
-        '<Mouse\n  size={5} />'
+        '<Mouse\n  size={5}\n/>'
       );
     });
 
     it('supports a single element with a function prop', () => {
       assertPrintedJSX(
         React.createElement('Mouse', {onclick: function onclick() {}}),
-        '<Mouse\n  onclick={[Function onclick]} />'
+        '<Mouse\n  onclick={[Function onclick]}\n/>'
       );
     });
 
     it('supports a single element with a object prop', () => {
       assertPrintedJSX(
         React.createElement('Mouse', {customProp: {one: '1', two: 2}}),
-        '<Mouse\n  customProp={\n    Object {\n      "one": "1",\n      "two": 2,\n    }\n  } />'
+        '<Mouse\n  customProp={\n    Object {\n      "one": "1",\n      "two": 2,\n    }\n  }\n/>'
       );
     });
 
@@ -446,7 +446,7 @@ describe('prettyFormat()', () => {
         React.createElement('Mouse', {customProp: {one: '1', two: 2}},
           React.createElement('Mouse')
         ),
-        '<Mouse\n  customProp={\n    Object {\n      "one": "1",\n      "two": 2,\n    }\n  }>\n  <Mouse />\n</Mouse>'
+        '<Mouse\n  customProp={\n    Object {\n      "one": "1",\n      "two": 2,\n    }\n  }\n>\n  <Mouse />\n</Mouse>'
       );
     });
 
@@ -456,7 +456,7 @@ describe('prettyFormat()', () => {
           'HELLO',
           React.createElement('Mouse'), 'CIAO'
         ),
-        '<Mouse\n  customProp={\n    Object {\n      "one": "1",\n      "two": 2,\n    }\n  }\n  onclick={[Function onclick]}>\n  HELLO\n  <Mouse />\n  CIAO\n</Mouse>'
+        '<Mouse\n  customProp={\n    Object {\n      "one": "1",\n      "two": 2,\n    }\n  }\n  onclick={[Function onclick]}\n>\n  HELLO\n  <Mouse />\n  CIAO\n</Mouse>'
       );
     });
 
@@ -482,7 +482,7 @@ describe('prettyFormat()', () => {
           ),
           'CIAO'
         ),
-        '<Mouse\n  customProp={\n    Object {\n      "one": "1",\n      "two": 2,\n    }\n  }\n  onclick={[Function onclick]}>\n  HELLO\n  <Mouse\n    customProp={\n      Object {\n        "one": "1",\n        "two": 2,\n      }\n    }\n    onclick={[Function onclick]}>\n    HELLO\n    <Mouse />\n    CIAO\n  </Mouse>\n  CIAO\n</Mouse>'
+        '<Mouse\n  customProp={\n    Object {\n      "one": "1",\n      "two": 2,\n    }\n  }\n  onclick={[Function onclick]}\n>\n  HELLO\n  <Mouse\n    customProp={\n      Object {\n        "one": "1",\n        "two": 2,\n      }\n    }\n    onclick={[Function onclick]}\n  >\n    HELLO\n    <Mouse />\n    CIAO\n  </Mouse>\n  CIAO\n</Mouse>'
       );
     });
 
@@ -510,7 +510,7 @@ describe('prettyFormat()', () => {
             'NESTED'
           )
         ),
-        '<Mouse\n  abc={\n    Object {\n      "one": "1",\n      "two": 2,\n    }\n  }\n  zeus="kentaromiura watched me fix this">\n  <Mouse\n    acbd={\n      Object {\n        "one": "1",\n        "two": 2,\n      }\n    }\n    xyz={123}>\n    NESTED\n  </Mouse>\n</Mouse>'
+        '<Mouse\n  abc={\n    Object {\n      "one": "1",\n      "two": 2,\n    }\n  }\n  zeus="kentaromiura watched me fix this"\n>\n  <Mouse\n    acbd={\n      Object {\n        "one": "1",\n        "two": 2,\n      }\n    }\n    xyz={123}\n  >\n    NESTED\n  </Mouse>\n</Mouse>'
       );
       /* eslint-enable sort-keys */
     });
@@ -520,7 +520,7 @@ describe('prettyFormat()', () => {
         React.createElement('Mouse', {
           prop: React.createElement('div'),
         }),
-        '<Mouse\n  prop={<div />} />'
+        '<Mouse\n  prop={<div />}\n/>'
       );
     });
 
@@ -529,7 +529,7 @@ describe('prettyFormat()', () => {
         React.createElement('Mouse', {
           prop: React.createElement('div', {foo: 'bar'}),
         }),
-        '<Mouse\n  prop={\n    <div\n      foo="bar" />\n  } />'
+        '<Mouse\n  prop={\n    <div\n      foo="bar"\n    />\n  }\n/>'
       );
     });
 
@@ -541,7 +541,7 @@ describe('prettyFormat()', () => {
         React.createElement('Mouse', {
           prop: React.createElement(Cat, {foo: 'bar'}),
         }),
-        '<Mouse\n  prop={\n    <Cat\n      foo="bar" />\n  } />'
+        '<Mouse\n  prop={\n    <Cat\n      foo="bar"\n    />\n  }\n/>'
       );
     });
 
@@ -553,7 +553,7 @@ describe('prettyFormat()', () => {
         React.createElement('Mouse', {
           prop: React.createElement(Cat, {}, React.createElement('div')),
         }),
-        '<Mouse\n  prop={\n    <Cat>\n      <div />\n    </Cat>\n  } />'
+        '<Mouse\n  prop={\n    <Cat>\n      <div />\n    </Cat>\n  }\n/>'
       );
     });
 
@@ -562,7 +562,7 @@ describe('prettyFormat()', () => {
         React.createElement('Mouse', {
           prop: React.createElement('div', null, 'mouse'),
         }),
-        '<Mouse\n  prop={\n    <div>\n      mouse\n    </div>\n  } />'
+        '<Mouse\n  prop={\n    <div>\n      mouse\n    </div>\n  }\n/>'
       );
     });
 
@@ -571,7 +571,7 @@ describe('prettyFormat()', () => {
         React.createElement('Mouse', {
           prop: React.createElement('div', null, 'mouse', React.createElement('span', null, 'rat')),
         }),
-        '<Mouse\n  prop={\n    <div>\n      mouse\n      <span>\n        rat\n      </span>\n    </div>\n  } />'
+        '<Mouse\n  prop={\n    <div>\n      mouse\n      <span>\n        rat\n      </span>\n    </div>\n  }\n/>'
       );
     });
 
@@ -586,7 +586,7 @@ describe('prettyFormat()', () => {
             ],
           ),
         }),
-        '<Mouse\n  prop={\n    <div>\n      mouse\n      <span>\n        rat\n      </span>\n      <span>\n        cat\n      </span>\n    </div>\n  } />'
+        '<Mouse\n  prop={\n    <div>\n      mouse\n      <span>\n        rat\n      </span>\n      <span>\n        cat\n      </span>\n    </div>\n  }\n/>'
       );
     });
 

--- a/packages/pretty-format/src/index.js
+++ b/packages/pretty-format/src/index.js
@@ -310,6 +310,7 @@ function printPlugin(val, indent, prevIndent, spacing, edgeSpacing, refs, maxDep
 
   const opts = {
     edgeSpacing,
+    min,
     spacing,
   };
   return plugin.print(val, boundPrint, boundIndent, opts, colors);

--- a/packages/pretty-format/src/plugins/ReactElement.js
+++ b/packages/pretty-format/src/plugins/ReactElement.js
@@ -67,15 +67,20 @@ function printElement(element, print, indent, colors, opts) {
   result += printProps(element.props, print, indent, colors, opts);
 
   const opaqueChildren = element.props.children;
+  const hasProps = !!Object.keys(element.props)
+    .filter(propName => propName !== 'children')
+    .length;
+  const closeInNewLine = hasProps && !opts.min;
+
   if (opaqueChildren) {
     const flatChildren = [];
     traverseChildren(opaqueChildren, child => {
       flatChildren.push(child);
     });
     const children = printChildren(flatChildren, print, indent, colors, opts);
-    result += colors.tag.open + '>' + colors.tag.close + opts.edgeSpacing + indent(children) + opts.edgeSpacing + colors.tag.open + '</' + elementName + '>' + colors.tag.close;
+    result += colors.tag.open + (closeInNewLine ? '\n' : '') + '>' + colors.tag.close + opts.edgeSpacing + indent(children) + opts.edgeSpacing + colors.tag.open + '</' + elementName + '>' + colors.tag.close;
   } else {
-    result += colors.tag.open + ' />' + colors.tag.close;
+    result += colors.tag.open + (closeInNewLine ? '\n' : ' ') + '/>' + colors.tag.close;
   }
 
   return result;

--- a/packages/pretty-format/src/plugins/ReactTestComponent.js
+++ b/packages/pretty-format/src/plugins/ReactTestComponent.js
@@ -46,11 +46,13 @@ function printInstance(instance, print, indent, colors, opts) {
     result += printProps(instance.props, print, indent, colors, opts);
   }
 
+  const closeInNewLine = !!Object.keys(instance.props).length && !opts.min;
+
   if (instance.children) {
     const children = printChildren(instance.children, print, indent, colors, opts);
-    result += colors.tag.open + '>' + colors.tag.close + opts.edgeSpacing + indent(children) + opts.edgeSpacing + colors.tag.open + '</' + instance.type + '>' + colors.tag.close;
+    result += colors.tag.open + (closeInNewLine ? '\n' : '') + '>' + colors.tag.close + opts.edgeSpacing + indent(children) + opts.edgeSpacing + colors.tag.open + '</' + instance.type + '>' + colors.tag.close;
   } else {
-    result += colors.tag.open + ' />' + colors.tag.close;
+    result += colors.tag.open + (closeInNewLine ? '\n' : ' ') + '/>' + colors.tag.close;
   }
 
   return result;


### PR DESCRIPTION
Improves clarity of snapshot diffs by placing closing brackets below the last prop in element.

**Note**: In case of element without props, closing bracket remains in the same line as opening tag - the same way as default `tag-aligned` location in ESLint ([react/jsx-closing-bracket-location](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-closing-bracket-location.md#location)) - recommended in [Airbnb React/JSX Style guide](https://github.com/airbnb/javascript/blob/master/react/README.md#alignment), so it will print:
```jsx
<Foo />
```
instead of:
```jsx
<Foo
/>
```

I have no strong opinion whether it should remain in the same line or go to next line in the same way as with multiline elements, so please let me know if I should change that.

Fixes #2830.

