### PR TITLE
Filter snap file changes in watch mode

### DIFF
--- a/packages/jest-cli/src/watch.js
+++ b/packages/jest-cli/src/watch.js
@@ -46,11 +46,11 @@ const watch = (
   let searchSource = new SearchSource(hasteContext, config);
 
   hasteMap.on('change', ({eventsQueue, hasteFS, moduleMap}) => {
-    const onlySnapFileEvents = eventsQueue.every(({filePath}) => {
+    const hasOnlySnapshotChanges = eventsQueue.every(({filePath}) => {
       return filePath.endsWith(`.${SNAPSHOT_EXTENSION}`);
     });
 
-    if (!onlySnapFileEvents) {
+    if (!hasOnlySnapshotChanges) {
       hasteContext =  createHasteContext(config, {hasteFS, moduleMap});
       currentPattern = '';
       isEnteringPattern = false;


### PR DESCRIPTION
Fixes #2760

It does not rerun the tests when the the 'change' event was caused only by `.snap` files

I still want to verify some things tomorrow before moving forward with this 😄 