### PR TITLE
Unescape serialized snapshots for diffing

### DIFF
--- a/packages/jest-snapshot/src/State.js
+++ b/packages/jest-snapshot/src/State.js
@@ -19,6 +19,7 @@ const {
   keyToTestName,
   serialize,
   testNameToKey,
+  unescape,
 } = require('./utils');
 const fileExists = require('jest-file-exists');
 const fs = require('fs');
@@ -158,9 +159,9 @@ class SnapshotState {
       if (!pass) {
         this.unmatched++;
         return {
-          actual: receivedSerialized,
+          actual: unescape(receivedSerialized),
           count,
-          expected,
+          expected: unescape(expected),
           pass: false,
         };
       } else {

--- a/packages/jest-snapshot/src/__tests__/utils-test.js
+++ b/packages/jest-snapshot/src/__tests__/utils-test.js
@@ -41,10 +41,21 @@ test('getSnapshotPath()', () => {
   );
 });
 
-test('saveSnapshotFile()', () => {
+test('saveSnapshotFile() works with \r\n', () => {
   const filename = path.join(__dirname, 'remove-newlines.snap');
   const data = {
     myKey: '<div>\r\n</div>',
+  };
+
+  saveSnapshotFile(data, filename);
+  expect(fs.writeFileSync)
+    .toBeCalledWith(filename, 'exports[`myKey`] = `<div>\n</div>`;\n');
+});
+
+test('saveSnapshotFile() works with \r', () => {
+  const filename = path.join(__dirname, 'remove-newlines.snap');
+  const data = {
+    myKey: '<div>\r</div>',
   };
 
   saveSnapshotFile(data, filename);

--- a/packages/jest-snapshot/src/utils.js
+++ b/packages/jest-snapshot/src/utils.js
@@ -83,7 +83,7 @@ const ensureDirectoryExists = (filePath: Path) => {
 };
 
 const normalizeNewlines =
-  string => string.replace(/\r\n/g, '\n');
+  string => string.replace(/\r\n|\r/g, '\n');
 
 const saveSnapshotFile = (
   snapshotData: {[key: string]: string},

--- a/packages/jest-snapshot/src/utils.js
+++ b/packages/jest-snapshot/src/utils.js
@@ -66,11 +66,8 @@ const serialize = (data: any): string => {
   }));
 };
 
-const unescape = (data: any): string => {
-  return data
-    .replace(/\\(")/g, '$1') // unescape double quotes
-    .replace(/\\([\\^$*+?.()|[\]{}])/g, '$1'); // then unescape RegExp
-};
+const unescape = (data: any): string =>
+  data.replace(/\\(")/g, '$1'); // unescape double quotes
 
 const printBacktickString = (str: string) => {
   return '`' + str.replace(/`|\\|\${/g, '\\$&') + '`';

--- a/packages/jest-snapshot/src/utils.js
+++ b/packages/jest-snapshot/src/utils.js
@@ -66,6 +66,12 @@ const serialize = (data: any): string => {
   }));
 };
 
+const unescape = (data: any): string => {
+  return data
+    .replace(/\\(")/g, '$1') // unescape double quotes
+    .replace(/\\([\\^$*+?.()|[\]{}])/g, '$1'); // then unescape RegExp
+};
+
 const printBacktickString = (str: string) => {
   return '`' + str.replace(/`|\\|\${/g, '\\$&') + '`';
 };
@@ -102,4 +108,5 @@ module.exports = {
   saveSnapshotFile,
   serialize,
   testNameToKey,
+  unescape,
 };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

This is a followup of https://github.com/facebook/jest/pull/2731.

I didn't want to alter serialisation improvements which @vjeux introduced, so I thought it would be safer to bring back an `unescape` in a little different form and use it only to generate un-escaped output to diff tool. Thanks to this we avoid having extra backslashes in console output.

Given test:
```js
test('snap', () => {
  expect('coca cola "yoko \\son (*)\d o".').toMatchSnapshot();
  expect(/some-regex('\"\))\\.x/).toMatchSnapshot();
});
```

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Before:

<img width="493" alt="screen shot 2017-02-09 at 18 30 47" src="https://cloud.githubusercontent.com/assets/5106466/22796220/dd259faa-eef9-11e6-8516-a62b59e45f0e.png">

After: 

<img width="488" alt="screen shot 2017-02-09 at 18 30 15" src="https://cloud.githubusercontent.com/assets/5106466/22796219/dd23be42-eef9-11e6-9594-ca9cb3251827.png">

**Test plan**

jest
cc: @cpojer @vjeux 
