### PR TITLE
[New] add `coverageDirectory` config to CLI options.

### DIFF
--- a/packages/jest-cli/src/cli/args.js
+++ b/packages/jest-cli/src/cli/args.js
@@ -96,6 +96,11 @@ const options = {
       'reported in the output.',
     type: 'boolean',
   },
+  coverageDirectory: {
+    default: undefined,
+    description: 'The directory where Jest should output its coverage files.',
+    type: 'string',
+  },
   debug: {
     description: 'Print debugging info about your jest config.',
     type: 'boolean',

--- a/packages/jest-config/src/setFromArgv.js
+++ b/packages/jest-config/src/setFromArgv.js
@@ -13,6 +13,10 @@ function setFromArgv(config, argv) {
     config.collectCoverage = true;
   }
 
+  if (argv.coverageDirectory) {
+    config.coverageDirectory = argv.coverageDirectory;
+  }
+
   if (argv.verbose) {
     config.verbose = argv.verbose;
   }


### PR DESCRIPTION
Fixes #2860.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
I want to configure the coverage directory per-invocation, not just per-project.

**Test plan**
There seem to be no CLI tests, and per #2864, tests fail on master already, so I'm not sure how to test this. If there are CLI tests and someone could point me to them, that'd be great.