### PR TITLE
replace jsonOutputFile with outputFile

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -87,7 +87,7 @@ Show some helpful information, similar to this page.
 
 Prints the test results in JSON. This mode will send all other test output and user messages to stderr.
 
-### `--jsonOutputFile=<filename>`
+### `--outputFile=<filename>`
 
 Write test results to a file when the `--json` option is also specified.
 


### PR DESCRIPTION
**Summary**

The document at http://facebook.github.io/jest/docs/cli.html#jsonoutputfile-filename is wrong. According to jest --help, the correct option name is outputFile instead of jsonOutputFile

**Test plan**

Document change doesn't have a way to test it. Sorry about that..


BTW, this option name consumes me a hour to find correct name....:'(
