### PR TITLE
s/Error/SerializableError

### DIFF
--- a/packages/jest-cli/src/TestRunner.js
+++ b/packages/jest-cli/src/TestRunner.js
@@ -11,7 +11,7 @@
 
 import type {
   AggregatedResult,
-  Error as TestError,
+  SerializableError as TestError,
   TestResult,
 } from 'types/TestResult';
 import type {Config, Path} from 'types/Config';

--- a/packages/jest-cli/src/TestWorker.js
+++ b/packages/jest-cli/src/TestWorker.js
@@ -10,7 +10,7 @@
 'use strict';
 
 import type {Config, Path} from 'types/Config';
-import type {Error, TestResult} from 'types/TestResult';
+import type {SerializableError, TestResult} from 'types/TestResult';
 import type {RawModuleMap} from 'types/HasteMap';
 
 // Make sure uncaught errors are logged before we exit.
@@ -31,9 +31,9 @@ type WorkerData = {|
   rawModuleMap?: RawModuleMap,
 |};
 
-type WorkerCallback = (error: ?Error, result?: TestResult) => void;
+type WorkerCallback = (error: ?SerializableError, result?: TestResult) => void;
 
-const formatError = error => {
+const formatError = (error: string|Error): SerializableError => {
   if (typeof error === 'string') {
     const {message, stack} = separateMessageFromStack(error);
     return {
@@ -46,7 +46,7 @@ const formatError = error => {
   return {
     message: error.message,
     stack: error.stack,
-    type: error.type || 'Error',
+    type: 'Error',
   };
 };
 

--- a/packages/jest-haste-map/src/types.js
+++ b/packages/jest-haste-map/src/types.js
@@ -9,7 +9,7 @@
  */
 'use strict';
 
-import type {Error} from 'types/TestResult';
+import type {SerializableError} from 'types/TestResult';
 import type {InternalHasteMap, ModuleMetaData} from 'types/HasteMap';
 
 export type IgnoreMatcher = (item: string) => boolean;
@@ -22,7 +22,7 @@ export type WorkerMetadata = {
   module: ?ModuleMetaData,
   dependencies: ?Array<string>,
 };
-export type WorkerCallback = (error: ?Error, metaData: ?WorkerMetadata) => void;
+export type WorkerCallback = (error: ?SerializableError, metaData: ?WorkerMetadata) => void;
 
 export type CrawlerOptions = {|
   data: InternalHasteMap,

--- a/packages/jest-haste-map/src/worker.js
+++ b/packages/jest-haste-map/src/worker.js
@@ -9,7 +9,7 @@
  */
 'use strict';
 
-import type {Error} from 'types/TestResult';
+import type {SerializableError} from 'types/TestResult';
 import type {
   WorkerMessage,
   WorkerCallback,
@@ -25,7 +25,7 @@ const path = require('path');
 const JSON_EXTENSION = '.json';
 const PACKAGE_JSON = path.sep + 'package' + JSON_EXTENSION;
 
-const formatError = (error: string|Error): Error => {
+const formatError = (error: string|Error): SerializableError => {
   if (typeof error === 'string') {
     return {
       message: error,
@@ -37,7 +37,7 @@ const formatError = (error: string|Error): Error => {
   return {
     message: error.message,
     stack: error.stack,
-    type: error.type || 'Error',
+    type: 'Error',
   };
 };
 

--- a/types/TestResult.js
+++ b/types/TestResult.js
@@ -52,10 +52,10 @@ export type CoverageMap = {|
   fileCoverageFor: (file: string) => FileCoverage,
 |};
 
-export type Error = {|
+export type SerializableError = {|
   message: string,
   stack: ?string,
-  type?: ?string,
+  type?: string,
 |};
 
 export type FailedAssertion = {|
@@ -134,7 +134,7 @@ export type TestResult = {|
     unmatched: number,
     updated: number,
   |},
-  testExecError?: Error,
+  testExecError?: SerializableError,
   testFilePath: string,
   testResults: Array<AssertionResult>,
 |};


### PR DESCRIPTION
Renaming the Flow type `Error` to `SerializableError` so as to not shadow global `Error` and signify the purpose of having a different type.