### PR TITLE
hasteImpl

### DIFF
--- a/packages/jest-config/src/__tests__/normalize-test.js
+++ b/packages/jest-config/src/__tests__/normalize-test.js
@@ -219,6 +219,28 @@ describe('transform', () => {
   });
 });
 
+describe('haste', () => {
+  let Resolver;
+  beforeEach(() => {
+    Resolver = require('jest-resolve');
+    Resolver.findNodeModule = jest.fn(name => name);
+  });
+
+  it('normalizes the path for hasteImplModulePath', () => {
+    const config = normalize({
+      haste: {
+        hasteImplModulePath: '<rootDir>/hasteImpl.js',
+      },
+      rootDir: '/root/',
+    });
+
+    expect(config.haste).toEqual({
+      hasteImplModulePath: '/root/hasteImpl.js',
+    });
+  });
+});
+
+
 describe('setupTestFrameworkScriptFile', () => {
   let Resolver;
   beforeEach(() => {

--- a/packages/jest-config/src/normalize.js
+++ b/packages/jest-config/src/normalize.js
@@ -322,6 +322,16 @@ function normalize(config: InitialConfig, argv: Object = {}) {
       case 'unmockedModulePathPatterns':
         value = normalizeUnmockedModulePathPatterns(config, key);
         break;
+      case 'haste':
+        value = Object.assign({}, config[key]);
+        if (value.hasteImplModulePath != null) {
+          value.hasteImplModulePath = resolve(
+            config.rootDir,
+            'haste.hasteImplModulePath',
+            value.hasteImplModulePath,
+          );
+        }
+        break;
       case 'automock':
       case 'bail':
       case 'browser':
@@ -332,7 +342,6 @@ function normalize(config: InitialConfig, argv: Object = {}) {
       case 'coverageReporters':
       case 'coverageThreshold':
       case 'globals':
-      case 'haste':
       case 'logHeapUsage':
       case 'logTransformErrors':
       case 'moduleDirectories':

--- a/packages/jest-haste-map/src/__tests__/hasteImpl.js
+++ b/packages/jest-haste-map/src/__tests__/hasteImpl.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
+module.exports = {
+  getHasteName(path) {
+    return path.substr(path.lastIndexOf('/') + 1).replace(/\.js$/, '');
+  },
+};

--- a/packages/jest-haste-map/src/__tests__/worker-test.js
+++ b/packages/jest-haste-map/src/__tests__/worker-test.js
@@ -14,6 +14,7 @@ const skipOnWindows = require('skipOnWindows');
 const worker = require('../worker');
 
 const fs = require('graceful-fs');
+const path = require('path');
 
 let createCallback;
 let mockFs;
@@ -99,6 +100,25 @@ describe('worker', () => {
       id: 'Strawberry',
       module: ['/fruits/strawberry.js', H.MODULE],
     });
+  });
+
+  it('delegates to hasteImplModulePath for getting the id', () => {
+    const callback = createCallback();
+    worker({
+      filePath: '/fruits/strawberry.js',
+      hasteImplModulePath: path.resolve(__dirname, 'hasteImpl.js'),
+    }, callback);
+
+    // Worker is synchronous. callback must have been called by now
+    expect(callback).toBeCalled();
+
+    expect(workerError).toBe(null);
+    expect(moduleData.id).toBe('strawberry');
+    expect(moduleData).toEqual(expect.objectContaining({
+      dependencies: expect.any(Array),
+      id: expect.any(String),
+      module: expect.any(Array),
+    }));
   });
 
   it('parses package.json files as haste packages', () => {

--- a/packages/jest-haste-map/src/index.js
+++ b/packages/jest-haste-map/src/index.js
@@ -42,6 +42,7 @@ type Options = {
   console?: Console,
   extensions: Array<string>,
   forceNodeFilesystemAPI?: boolean,
+  hasteImplModulePath?: string,
   ignorePattern: RegExp,
   maxWorkers: number,
   mocksPattern?: string,
@@ -60,6 +61,7 @@ type InternalOptions = {
   cacheDirectory: string,
   extensions: Array<string>,
   forceNodeFilesystemAPI: boolean,
+  hasteImplModulePath?: string,
   ignorePattern: RegExp,
   maxWorkers: number,
   mocksPattern: ?RegExp,
@@ -197,6 +199,7 @@ class HasteMap extends EventEmitter {
       cacheDirectory: options.cacheDirectory || os.tmpdir(),
       extensions: options.extensions,
       forceNodeFilesystemAPI: !!options.forceNodeFilesystemAPI,
+      hasteImplModulePath: options.hasteImplModulePath,
       ignorePattern: options.ignorePattern,
       maxWorkers: options.maxWorkers,
       mocksPattern:
@@ -354,7 +357,10 @@ class HasteMap extends EventEmitter {
       }
     }
 
-    return this._getWorker(workerOptions)({filePath}).then(
+    return this._getWorker(workerOptions)({
+      filePath,
+      hasteImplModulePath: this._options.hasteImplModulePath,
+    }).then(
       metadata => {
         // `1` for truthy values instead of `true` to save cache space.
         fileMetadata[H.VISITED] = 1;

--- a/packages/jest-haste-map/src/types.js
+++ b/packages/jest-haste-map/src/types.js
@@ -16,13 +16,17 @@ export type IgnoreMatcher = (item: string) => boolean;
 
 export type WorkerMessage = {
   filePath: string,
+  hasteImplModulePath?: string,
 };
 export type WorkerMetadata = {
   id: ?string,
   module: ?ModuleMetaData,
   dependencies: ?Array<string>,
 };
-export type WorkerCallback = (error: ?SerializableError, metaData: ?WorkerMetadata) => void;
+export type WorkerCallback = (
+  error: ?SerializableError,
+  metaData: ?WorkerMetadata,
+) => void;
 
 export type CrawlerOptions = {|
   data: InternalHasteMap,
@@ -31,3 +35,7 @@ export type CrawlerOptions = {|
   ignore: IgnoreMatcher,
   roots: Array<string>,
 |};
+
+export type HasteImpl = {
+  getHasteName(filePath: string): (string | void),
+}

--- a/packages/jest-runtime/src/index.js
+++ b/packages/jest-runtime/src/index.js
@@ -198,6 +198,7 @@ class Runtime {
       cacheDirectory: config.cacheDirectory,
       console: options && options.console,
       extensions: [SNAPSHOT_EXTENSION].concat(config.moduleFileExtensions),
+      hasteImplModulePath: config.haste.hasteImplModulePath,
       ignorePattern,
       maxWorkers: (options && options.maxWorkers) || 1,
       mocksPattern: escapePathForRegex(path.sep + '__mocks__' + path.sep),

--- a/types/Config.js
+++ b/types/Config.js
@@ -14,6 +14,7 @@ export type Glob = string;
 
 export type HasteConfig = {|
   defaultPlatform?: ?string,
+  hasteImplModulePath?: string,
   platforms?: Array<string>,
   providesModuleNodeModules: Array<string>,
 |};


### PR DESCRIPTION
**Summary**
Introducing an optional `HasteImpl` of type `{getHasteName(filePath: string): (string|void)}` that returns the haste name for a module at `filePath` if it is a haste module or `undefined` otherwise.

I'm going to add a similar injectable config to React Native Packager.

This allows us to inject a custom implementation of haste's module id resolution.

**Test plan**

`npm test`