### PR TITLE
Update contributing docs to use yarn

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,31 +28,37 @@ The core team will be monitoring for pull requests. When we get one, we'll run s
    git checkout -b my_branch
    ```
 
-2. Run `npm install`. We recommend that you use `npm` version 3 or later.
+2. Jest uses [Yarn](https://code.facebook.com/posts/1840075619545360)
+   for running development scripts. If you haven't already done so,
+   please [install yarn](https://yarnpkg.com/en/docs/install).
+
+3. Run `yarn install`.
 
     ```sh
-    npm install
+    yarn install
     ```
 
-3. If you've added code that should be tested, add tests. You
+4. If you've added code that should be tested, add tests. You
    can use watch mode that continuously transforms changed files
    to make your life easier.
 
    ```sh
    # in the background
-   npm run watch
+   yarn run watch
    ```
 
-4. If you've changed APIs, update the documentation.
-5. Ensure the test suite passes via `npm test`. To run the test suite you
+5. If you've changed APIs, update the documentation.
+
+6. Ensure the test suite passes via `yarn test`. To run the test suite you
    may need to install Mercurial (`hg`). On macOS, this can be done
    using [homebrew](http://brew.sh/): `brew install hg`.
 
    ```sh
    brew install hg # maybe
-   npm test
+   yarn test
    ```
-6. If you haven't already, complete the CLA.
+
+7. If you haven't already, complete the CLA.
 
 ### Contributor License Agreement (CLA)
 
@@ -66,7 +72,7 @@ To link `jest` on the command line to `jest-cli/bin/jest.js` in a development bu
 
 ```sh
 cd /path/to/your/Jest_clone/packages/jest-cli
-npm link
+yarn link
 ```
 
 To build Jest:
@@ -77,10 +83,10 @@ cd /path/to/your/Jest_clone
 # Do one of the following:
 
 # Check out a commit from another contributor, and then
-npm run build
+yarn run build
 
-# Save your changes to Jest, and then
-npm test # which also builds Jest
+# Or, save your changes to Jest, and then
+yarn test # which also builds Jest
 ```
 
 To run tests in another project with the development build of Jest:
@@ -95,7 +101,7 @@ jest [options] # run jest-cli/bin/jest.js in the development build
 To unlink `jest` on the command line from `jest-cli/bin/jest.js` in a development build:
 
 ```sh
-npm unlink --global jest-cli
+yarn unlink jest-cli
 ```
 
 ## Bugs


### PR DESCRIPTION
**Summary**
I updated the contributing docs to use `yarn` instead of `npm`.

**Motivation**
I was just going through the contributing doc when working on #2489. I didn't have `yarn` installed globally, and `npm install` failed...I noticed that many of the scripts use `yarn`...so I figured I'd update the doc to reflect that.

**Test Plan**
No tests required, it's just a change to the docs.