### PR TITLE
Unify promisify of test and lifecycle functions

### DIFF
--- a/examples/jquery/__tests__/fetchCurrentUser-test.js
+++ b/examples/jquery/__tests__/fetchCurrentUser-test.js
@@ -2,7 +2,9 @@
 
 jest.mock('jquery');
 
-beforeEach(() => jest.resetModules());
+beforeEach(() => {
+  jest.resetModules();
+});
 
 it('calls into $.ajax with the correct params', () => {
   const $ = require('jquery');

--- a/integration_tests/__tests__/coverage_report-test.js
+++ b/integration_tests/__tests__/coverage_report-test.js
@@ -18,7 +18,9 @@ const skipOnWindows = require('skipOnWindows');
 const DIR = path.resolve(__dirname, '../coverage_report');
 
 if (process.platform !== 'win32') {
-  beforeEach(() => linkJestPackage('babel-jest', DIR));
+  beforeEach(() => {
+    linkJestPackage('babel-jest', DIR);
+  });
 }
 
 skipOnWindows.suite();

--- a/packages/jest-snapshot/src/__tests__/plugins-test.js
+++ b/packages/jest-snapshot/src/__tests__/plugins-test.js
@@ -8,7 +8,9 @@
  */
 'use strict';
 
-beforeEach(() => jest.resetModules());
+beforeEach(() => {
+  jest.resetModules();
+});
 
 const testPath = names => {
   const {addSerializer, getSerializers} = require('../plugins');


### PR DESCRIPTION
**Summary**

Jest allows functions passed to both `it` (`fit`, `test` etc.) and lifecycle functions (`beforeAll`, `afterAll`, `beforeEach`, and `afterEach`) to return a promise. The promise is then updated to run Jasmine native `done` callback.

The implementations for the two differ even though they fundamentally do the same. This PR unifies it by abstracting the update of the original function (i.e. the one which might or might not return a promise).

As a consequence **lifecycle functions now require to return a promise or `undefined`**. That means sometimes they need to be changed like this ([jest.resetModules](https://facebook.github.io/jest/docs/jest-object.html#jestresetmodules) returns the `jest` object for chaining):

```diff
- beforeEach(() => jest.resetModules());
+ beforeEach(() => {jest.resetModules();});
```

I understand that this change is potentially **controversial** (and breaking). However, I do not know any reason why `test` should be stricter in this. Moreover, I believe that this makes the code safer and easier to update in the future. Alternatively, I propose `test` to match the less strict implementation.

*Questions:*
  * What is better in the error message?
    * `beforeAll`, `afterAll`, `beforeEach`, and `afterEach`
    * `before/after All/Each`
    * lifecycle functions
  * I preserved the current functionality regarding missing function (i.e. checked only for `test`). Should this be updated, too?
  * There are no specific tests for promisify. Should they be added?

**Test plan**

`yarn test` passes. This means that all current tests in this project work after this change; so should all user's tests. 
