### PR TITLE
[Website] Remove several react-warning-keys warnings.

### DIFF
--- a/website/core/home/GridBlock.js
+++ b/website/core/home/GridBlock.js
@@ -31,7 +31,7 @@ class GridBlock extends React.Component {
       this.renderBlockImage(block.image);
 
     return (
-      <div className={blockClasses}>
+      <div className={blockClasses} key={block.title}>
         {topLeftImage}
         <div className="blockContent">
           {this.renderBlockTitle(block.title)}

--- a/website/core/home/HomeSplash.js
+++ b/website/core/home/HomeSplash.js
@@ -8,9 +8,9 @@ const React = require('React');
 const siteConfig = require('../../siteConfig.js');
 
 class HomeSplash extends React.Component {
-  makePromoElements(promoEl) {
+  makePromoElements(promoEl, index) {
     return (
-      <div className="promoRow">
+      <div className="promoRow" key={index}>
         {promoEl}
       </div>
     );

--- a/website/core/nav/SideNav.js
+++ b/website/core/nav/SideNav.js
@@ -69,7 +69,7 @@ class SideNav extends React.Component {
       'navItemActive': (link.id === this.props.current.id),
     });
     return (
-      <li className={itemClasses}>
+      <li className={itemClasses} key={link.id}>
         <a
           className={linkClasses}
           href={this.getLink(link)}>

--- a/website/layout/BlogPageLayout.js
+++ b/website/layout/BlogPageLayout.js
@@ -44,6 +44,7 @@ const BlogPageLayout = React.createClass({
                       post={post}
                       content={post.content}
                       truncate={true}
+                      key={post.path + post.title}
                     />
                   );
                 })

--- a/website/src/jest/index.js
+++ b/website/src/jest/index.js
@@ -20,7 +20,7 @@ const index = React.createClass({
     const showcase = siteConfig.users.filter(user => {
       return user.pinned;
     }).map(user => {
-      return <a href={user.infoLink}><img src={user.image} title={user.caption}/></a>;
+      return <a href={user.infoLink} key={user.image}><img src={user.image} title={user.caption}/></a>;
     });
 
     return (

--- a/website/src/jest/users.js
+++ b/website/src/jest/users.js
@@ -11,7 +11,7 @@ class UserShowcase extends React.Component {
   render() {
     const showcase = siteConfig.users.map(user => {
       return (
-        <a href={user.infoLink}>
+        <a href={user.infoLink} key={user.image}>
           <img src={user.image} title={user.caption}/>
         </a>
       );


### PR DESCRIPTION
The following warning is shown for several components when the website is built:

> Warning: Each child in an array or iterator should have a unique "key" prop. Check the render method of Marked. See https://fb.me/react-warning-keys for more information.

I've addressed the cause of this warning for several components:

- `GridBlock`
- `HomeSplash`
- `SideNav`
- `BlogPageLayout`
- `index.js`
- `users.js`

## Test Plan

Ran `node server/generate.js` and `npm start` to verify the warnings go away, as well as to make sure the website is rendered properly.

## Future Work

There is one remaining component that causes this warning to show up, `Marked`. Addressing this would require updating the markdown parser to automatically insert keys props when needed.