### PR TITLE
Editor support testReconciler: don't throw if missing line number.

### DIFF
--- a/packages/jest-editor-support/src/TestReconciler.js
+++ b/packages/jest-editor-support/src/TestReconciler.js
@@ -120,7 +120,7 @@ module.exports = class TestReconciler {
   lineOfError(message: string, filePath: string): ?number {
     const filename = path.basename(filePath);
     const restOfTrace = message.split(filename, 2)[1];
-    return parseInt(restOfTrace.split(':')[1], 10);
+    return restOfTrace? parseInt(restOfTrace.split(':')[1], 10): null;
   }
 
   statusToReconcilationState(status: string): TestReconciliationState {

--- a/packages/jest-editor-support/src/TestReconciler.js
+++ b/packages/jest-editor-support/src/TestReconciler.js
@@ -120,7 +120,7 @@ module.exports = class TestReconciler {
   lineOfError(message: string, filePath: string): ?number {
     const filename = path.basename(filePath);
     const restOfTrace = message.split(filename, 2)[1];
-    return restOfTrace? parseInt(restOfTrace.split(':')[1], 10): null;
+    return restOfTrace ? parseInt(restOfTrace.split(':')[1], 10) : null;
   }
 
   statusToReconcilationState(status: string): TestReconciliationState {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
In case of dynamically requiring describes the line of code doesn't exists as the filename will not be present on the stacktrace.

Test: change parserTests.js to fail, look at the `executableJSON` and see that both the `BabylonParser` and the `TypeScriptParser` test are failing but they are not in the message:
``` 
    expect(received).toBe(expected)
    
    Expected value to be (using ===):
      true
    Received:
      false
      
      at Object.<anonymous>.test (packages/jest-editor-support/src/__tests__/parsers/parserTests.js:178:30)
```


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
doesn't throw anymore.