### PR TITLE
Make matchers snapshot test consistent across node versions.

### DIFF
--- a/packages/jest-matchers/src/__tests__/matchers-test.js
+++ b/packages/jest-matchers/src/__tests__/matchers-test.js
@@ -89,7 +89,9 @@ describe('.toEqual()', () => {
     [undefined, jestExpect.anything()],
     [undefined, jestExpect.any(Function)],
     ['Eve', {
-      asymmetricMatch: who => who === 'Alice' || who === 'Bob',
+      asymmetricMatch: function asymmetricMatch(who) {
+        return who === 'Alice' || who === 'Bob';
+      },
     }],
   ].forEach(([a, b]) => {
     test(`expect(${stringify(a)}).toEqual(${stringify(b)})`, () => {
@@ -120,7 +122,9 @@ describe('.toEqual()', () => {
       c: jestExpect.anything(),
     }],
     ['Alice', {
-      asymmetricMatch: who => who === 'Alice' || who === 'Bob',
+      asymmetricMatch: function asymmetricMatch(who) {
+        return who === 'Alice' || who === 'Bob';
+      },
     }],
   ].forEach(([a, b]) => {
     test(`expect(${stringify(a)}).not.toEqual(${stringify(b)})`, () => {


### PR DESCRIPTION
**Summary**

This unbreaks node 4 on travis which doesn't have function name inference and therefore had outdated snapshots.

cc @bestander 

**Test plan**

yarn test on node 4.