### PR TITLE
Bring json-stable-stringify back to jest-runtime

### DIFF
--- a/packages/jest-runtime/package.json
+++ b/packages/jest-runtime/package.json
@@ -19,13 +19,14 @@
     "jest-regex-util": "^18.1.0",
     "jest-resolve": "^18.1.0",
     "jest-util": "^18.1.0",
+    "json-stable-stringify": "^1.0.1",
     "micromatch": "^2.3.11",
     "strip-bom": "3.0.0",
     "yargs": "^6.3.0"
   },
   "devDependencies": {
-    "jest-environment-node": "^18.1.0",
-    "jest-environment-jsdom": "^18.1.0"
+    "jest-environment-jsdom": "^18.1.0",
+    "jest-environment-node": "^18.1.0"
   },
   "bin": {
     "jest-runtime": "./bin/jest-runtime.js"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

It was removed from `jest-runtime`, but it's actually used there: https://github.com/facebook/jest/blob/master/packages/jest-runtime/src/transform.js#L22

Fixes https://github.com/facebook/jest/issues/2935

**Test plan**

clean install 
