### PR TITLE
Handle deprecation warnings in watch mode

### DIFF
--- a/packages/jest-cli/src/__tests__/SearchSource-test.js
+++ b/packages/jest-cli/src/__tests__/SearchSource-test.js
@@ -44,7 +44,7 @@ describe('SearchSource', () => {
         name,
         rootDir: '.',
         roots: [],
-      });
+      }).config;
       return Runtime.createHasteContext(config, {maxWorkers}).then(hasteMap => {
         searchSource = new SearchSource(hasteMap, config);
       });
@@ -61,7 +61,7 @@ describe('SearchSource', () => {
           roots: [],
           testMatch: null,
           testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.jsx?$',
-        });
+        }).config;
         return Runtime.createHasteContext(config, {maxWorkers})
           .then(hasteMap => {
             searchSource = new SearchSource(hasteMap, config);
@@ -98,7 +98,7 @@ describe('SearchSource', () => {
     });
 
     it('finds tests matching a pattern via testRegex', () => {
-      const config = normalizeConfig({
+      const {config} = normalizeConfig({
         moduleFileExtensions: ['js', 'jsx', 'txt'],
         name,
         rootDir,
@@ -116,7 +116,7 @@ describe('SearchSource', () => {
     });
 
     it('finds tests matching a pattern via testMatch', () => {
-      const config = normalizeConfig({
+      const {config} = normalizeConfig({
         moduleFileExtensions: ['js', 'jsx', 'txt'],
         name,
         rootDir,
@@ -134,7 +134,7 @@ describe('SearchSource', () => {
     });
 
     it('finds tests matching a JS regex pattern', () => {
-      const config = normalizeConfig({
+      const {config} = normalizeConfig({
         moduleFileExtensions: ['js', 'jsx'],
         name,
         rootDir,
@@ -153,7 +153,7 @@ describe('SearchSource', () => {
     });
 
     it('finds tests matching a JS glob pattern', () => {
-      const config = normalizeConfig({
+      const {config} = normalizeConfig({
         moduleFileExtensions: ['js', 'jsx'],
         name,
         rootDir,
@@ -172,7 +172,7 @@ describe('SearchSource', () => {
     });
 
     it('finds tests with default file extensions using testRegex', () => {
-      const config = normalizeConfig({
+      const {config} = normalizeConfig({
         name,
         rootDir,
         testMatch: null,
@@ -190,7 +190,7 @@ describe('SearchSource', () => {
     });
 
     it('finds tests with default file extensions using testMatch', () => {
-      const config = normalizeConfig({
+      const {config} = normalizeConfig({
         name,
         rootDir,
         testMatch,
@@ -208,7 +208,7 @@ describe('SearchSource', () => {
     });
 
     it('finds tests with similar but custom file extensions', () => {
-      const config = normalizeConfig({
+      const {config} = normalizeConfig({
         moduleFileExtensions: ['jsx'],
         name,
         rootDir,
@@ -225,7 +225,7 @@ describe('SearchSource', () => {
     });
 
     it('finds tests with totally custom foobar file extensions', () => {
-      const config = normalizeConfig({
+      const {config} = normalizeConfig({
         moduleFileExtensions: ['foobar'],
         name,
         rootDir,
@@ -242,7 +242,7 @@ describe('SearchSource', () => {
     });
 
     it('finds tests with many kinds of file extensions', () => {
-      const config = normalizeConfig({
+      const {config} = normalizeConfig({
         moduleFileExtensions: ['js', 'jsx'],
         name,
         rootDir,
@@ -260,7 +260,7 @@ describe('SearchSource', () => {
     });
 
     it('finds tests using a regex only', () => {
-      const config = normalizeConfig({
+      const {config} = normalizeConfig({
         name,
         rootDir,
         testMatch: null,
@@ -278,7 +278,7 @@ describe('SearchSource', () => {
     });
 
     it('finds tests using a glob only', () => {
-      const config = normalizeConfig({
+      const {config} = normalizeConfig({
         name,
         rootDir,
         testMatch,
@@ -310,7 +310,7 @@ describe('SearchSource', () => {
     const rootPath = path.join(rootDir, 'root.js');
 
     beforeEach(done => {
-      const config = normalizeConfig({
+      const {config} = normalizeConfig({
         name: 'SearchSource-findRelatedTests-tests',
         rootDir,
       });
@@ -341,7 +341,7 @@ describe('SearchSource', () => {
 
   describe('findRelatedTestsFromPattern', () => {
     beforeEach(done => {
-      const config = normalizeConfig({
+      const {config} = normalizeConfig({
         moduleFileExtensions: ['js', 'jsx', 'foobar'],
         name,
         rootDir,

--- a/packages/jest-cli/src/__tests__/watch-filename-pattern-mode-test.js
+++ b/packages/jest-cli/src/__tests__/watch-filename-pattern-mode-test.js
@@ -76,6 +76,7 @@ describe('Watch mode flows', () => {
   let argv;
   let hasteContext;
   let config;
+  let hasDeprecationWarnings;
   let stdin;
 
   beforeEach(() => {
@@ -85,12 +86,21 @@ describe('Watch mode flows', () => {
     argv = {};
     hasteContext = {};
     config = {};
+    hasDeprecationWarnings = false;
     stdin = new MockStdin();
   });
 
   it('Pressing "P" enters pattern mode', () => {
     config = {rootDir: ''};
-    watch(config, pipe, argv, hasteMap, hasteContext, stdin);
+    watch(
+      config,
+      pipe,
+      argv,
+      hasteMap,
+      hasteContext,
+      hasDeprecationWarnings,
+      stdin,
+    );
 
     // Write a enter pattern mode
     stdin.emit(KEYS.P);
@@ -132,7 +142,15 @@ describe('Watch mode flows', () => {
 
   it('Results in pattern mode get truncated appropriately', () => {
     config = {rootDir: ''};
-    watch(config, pipe, argv, hasteMap, hasteContext, stdin);
+    watch(
+      config,
+      pipe,
+      argv,
+      hasteMap,
+      hasteContext,
+      hasDeprecationWarnings,
+      stdin,
+    );
 
     stdin.emit(KEYS.P);
 

--- a/packages/jest-cli/src/__tests__/watch-test-name-pattern-mode-test.js
+++ b/packages/jest-cli/src/__tests__/watch-test-name-pattern-mode-test.js
@@ -96,6 +96,7 @@ describe('Watch mode flows', () => {
   let argv;
   let hasteContext;
   let config;
+  let hasDeprecationWarnings;
   let stdin;
 
   beforeEach(() => {
@@ -105,12 +106,21 @@ describe('Watch mode flows', () => {
     argv = {};
     hasteContext = {};
     config = {};
+    hasDeprecationWarnings = false;
     stdin = new MockStdin();
   });
 
   it('Pressing "T" enters pattern mode', () => {
     config = {rootDir: ''};
-    watch(config, pipe, argv, hasteMap, hasteContext, stdin);
+    watch(
+      config,
+      pipe,
+      argv,
+      hasteMap,
+      hasteContext,
+      hasDeprecationWarnings,
+      stdin,
+    );
 
     // Write a enter pattern mode
     stdin.emit(KEYS.T);
@@ -152,7 +162,15 @@ describe('Watch mode flows', () => {
 
   it('Results in pattern mode get truncated appropriately', () => {
     config = {rootDir: ''};
-    watch(config, pipe, argv, hasteMap, hasteContext, stdin);
+    watch(
+      config,
+      pipe,
+      argv,
+      hasteMap,
+      hasteContext,
+      hasDeprecationWarnings,
+      stdin,
+    );
 
     stdin.emit(KEYS.T);
 

--- a/packages/jest-cli/src/__tests__/watch-test.js
+++ b/packages/jest-cli/src/__tests__/watch-test.js
@@ -37,6 +37,7 @@ describe('Watch mode flows', () => {
   let argv;
   let hasteContext;
   let config;
+  let hasDeprecationWarnings;
   let stdin;
 
   beforeEach(() => {
@@ -45,6 +46,7 @@ describe('Watch mode flows', () => {
     argv = {};
     hasteContext = {};
     config = {roots: [], testPathIgnorePatterns: [], testRegex: ''};
+    hasDeprecationWarnings = false;
     stdin = new MockStdin();
   });
 
@@ -52,7 +54,15 @@ describe('Watch mode flows', () => {
     argv.testPathPattern = 'test-*';
     config.testPathPattern = 'test-*';
 
-    watch(config, pipe, argv, hasteMap, hasteContext, stdin);
+    watch(
+      config,
+      pipe,
+      argv,
+      hasteMap,
+      hasteContext,
+      hasDeprecationWarnings,
+      stdin,
+    );
 
     expect(runJestMock).toBeCalledWith(
       hasteContext,
@@ -69,7 +79,15 @@ describe('Watch mode flows', () => {
     argv.testNamePattern = 'test-*';
     config.testNamePattern = 'test-*';
 
-    watch(config, pipe, argv, hasteMap, hasteContext, stdin);
+    watch(
+      config,
+      pipe,
+      argv,
+      hasteMap,
+      hasteContext,
+      hasDeprecationWarnings,
+      stdin,
+    );
 
     expect(runJestMock).toBeCalledWith(
       hasteContext,
@@ -83,7 +101,15 @@ describe('Watch mode flows', () => {
   });
 
   it('Runs Jest once by default and shows usage', () => {
-    watch(config, pipe, argv, hasteMap, hasteContext, stdin);
+    watch(
+      config,
+      pipe,
+      argv,
+      hasteMap,
+      hasteContext,
+      hasDeprecationWarnings,
+      stdin,
+    );
     expect(runJestMock).toBeCalledWith(
       hasteContext,
       config,
@@ -97,7 +123,15 @@ describe('Watch mode flows', () => {
   });
 
   it('Pressing "o" runs test in "only changed files" mode', () => {
-    watch(config, pipe, argv, hasteMap, hasteContext, stdin);
+    watch(
+      config,
+      pipe,
+      argv,
+      hasteMap,
+      hasteContext,
+      hasDeprecationWarnings,
+      stdin,
+    );
     runJestMock.mockReset();
 
     stdin.emit(KEYS.O);
@@ -111,7 +145,15 @@ describe('Watch mode flows', () => {
   });
 
   it('Pressing "a" runs test in "watch all" mode', () => {
-    watch(config, pipe, argv, hasteMap, hasteContext, stdin);
+    watch(
+      config,
+      pipe,
+      argv,
+      hasteMap,
+      hasteContext,
+      hasDeprecationWarnings,
+      stdin,
+    );
     runJestMock.mockReset();
 
     stdin.emit(KEYS.A);
@@ -125,14 +167,30 @@ describe('Watch mode flows', () => {
   });
 
   it('Pressing "ENTER" reruns the tests', () => {
-    watch(config, pipe, argv, hasteMap, hasteContext, stdin);
+    watch(
+      config,
+      pipe,
+      argv,
+      hasteMap,
+      hasteContext,
+      hasDeprecationWarnings,
+      stdin,
+    );
     expect(runJestMock).toHaveBeenCalledTimes(1);
     stdin.emit(KEYS.ENTER);
     expect(runJestMock).toHaveBeenCalledTimes(2);
   });
 
   it('Pressing "u" reruns the tests in "update snapshot" mode', () => {
-    watch(config, pipe, argv, hasteMap, hasteContext, stdin);
+    watch(
+      config,
+      pipe,
+      argv,
+      hasteMap,
+      hasteContext,
+      hasDeprecationWarnings,
+      stdin,
+    );
     runJestMock.mockReset();
 
     stdin.emit(KEYS.U);

--- a/packages/jest-cli/src/jest.js
+++ b/packages/jest-cli/src/jest.js
@@ -52,7 +52,7 @@ const runCLI = (
     .then(({
       config,
       hasDeprecationWarnings,
-    }:{
+    } : {
       config: Config,
       hasDeprecationWarnings: boolean,
     }) => {

--- a/packages/jest-cli/src/jest.js
+++ b/packages/jest-cli/src/jest.js
@@ -49,7 +49,13 @@ const runCLI = (
   }
 
   readConfig(argv, root)
-    .then((config: Config) => {
+    .then(({
+      config,
+      hasDeprecationWarnings,
+    }:{
+      config: Config,
+      hasDeprecationWarnings: boolean,
+    }) => {
       if (argv.debug) {
         logDebugMessages(config, pipe);
       }
@@ -70,7 +76,14 @@ const runCLI = (
       )
       .then(hasteContext => {
         if (argv.watch || argv.watchAll) {
-          return watch(config, pipe, argv, jestHasteMap, hasteContext);
+          return watch(
+            config,
+            pipe,
+            argv,
+            jestHasteMap,
+            hasteContext,
+            hasDeprecationWarnings,
+          );
         } else {
           const startRun = () => {
             preRunMessage.print(pipe);

--- a/packages/jest-cli/src/watch.js
+++ b/packages/jest-cli/src/watch.js
@@ -33,13 +33,12 @@ const watch = (
   argv: Object,
   hasteMap: HasteMap,
   hasteContext: HasteContext,
-  stdin?: stream$Readable | tty$ReadStream = process.stdin
+  hasDeprecationWarnings?: boolean,
+  stdin?: stream$Readable | tty$ReadStream = process.stdin,
 ) => {
-  if (global.hasDeprecationWarnings) {
-    return handleDeprecationWarnings(pipe, stdin)
+  if (hasDeprecationWarnings) {
+    return handleDeprecatedWarnings(pipe, stdin)
       .then(() => {
-        global.hasDeprecationWarnings = false;
-
         watch(config, pipe, argv, hasteMap, hasteContext);
       })
       .catch(() => process.exit(0));
@@ -232,7 +231,7 @@ const watch = (
   return Promise.resolve();
 };
 
-const handleDeprecationWarnings = (
+const handleDeprecatedWarnings = (
   pipe: stream$Writable | tty$WriteStream,
   stdin: stream$Readable | tty$ReadStream = process.stdin,
 ) => {

--- a/packages/jest-cli/src/watch.js
+++ b/packages/jest-cli/src/watch.js
@@ -35,6 +35,16 @@ const watch = (
   hasteContext: HasteContext,
   stdin?: stream$Readable | tty$ReadStream = process.stdin
 ) => {
+  if (global.hasDeprecationWarnings) {
+    return handleDeprecationWarnings(pipe, stdin)
+      .then(() => {
+        global.hasDeprecationWarnings = false;
+
+        watch(config, pipe, argv, hasteMap, hasteContext);
+      })
+      .catch(() => process.exit(0));
+  }
+
   setState(argv, argv.watch ? 'watch' : 'watchAll', {
     testNamePattern: argv.testNamePattern,
     testPathPattern: argv.testPathPattern || (Array.isArray(argv._)
@@ -220,6 +230,41 @@ const watch = (
 
   startRun();
   return Promise.resolve();
+};
+
+const handleDeprecationWarnings = (
+  pipe: stream$Writable | tty$WriteStream,
+  stdin: stream$Readable | tty$ReadStream = process.stdin,
+) => {
+  return new Promise((resolve, reject) => {
+    if (typeof stdin.setRawMode === 'function') {
+      const messages = [
+        chalk.red('There are deprecation warnings.\n'),
+        chalk.dim(' \u203A Press ') + 'Enter' + chalk.dim(' to continue.'),
+        chalk.dim(' \u203A Press ') + 'Esc' + chalk.dim(' to exit.'),
+      ];
+
+      pipe.write(messages.join('\n'));
+
+      // $FlowFixMe
+      stdin.setRawMode(true);
+      stdin.resume();
+      stdin.setEncoding('hex');
+      stdin.on('data', (key: string) => {
+        if (key === KEYS.ENTER) {
+          resolve();
+        } else if ([
+          KEYS.ESCAPE,
+          KEYS.CONTROL_C,
+          KEYS.CONTROL_D,
+        ].indexOf(key) !== -1) {
+          reject();
+        }
+      });
+    } else {
+      resolve();
+    }
+  });
 };
 
 const usage = (

--- a/packages/jest-config/src/__tests__/normalize-test.js
+++ b/packages/jest-config/src/__tests__/normalize-test.js
@@ -51,20 +51,26 @@ it('picks a name based on the rootDir', () => {
     .digest('hex');
   expect(normalize({
     rootDir,
-  }).name).toBe(expected);
+  }).config.name).toBe(expected);
 });
 
 it('keeps custom names based on the rootDir', () => {
   expect(normalize({
     name: 'custom-name',
     rootDir: '/root/path/foo',
-  }).name).toBe('custom-name');
+  }).config.name).toBe('custom-name');
 });
 
 it('sets coverageReporters correctly when argv.json is set', () => {
   expect(normalize({
     rootDir: '/root/path/foo',
-  }, {json: true}).coverageReporters).toEqual(['json', 'lcov', 'clover']);
+  }, {
+    json: true,
+  }).config.coverageReporters).toEqual([
+    'json',
+    'lcov',
+    'clover',
+  ]);
 });
 
 describe('rootDir', () => {
@@ -79,7 +85,7 @@ describe('automock', () => {
   it('falsy automock is not overwritten', () => {
     const consoleWarn = console.warn;
     console.warn = jest.fn();
-    const config = normalize({
+    const {config} = normalize({
       automock: false,
       rootDir: '/root/path/foo',
     });
@@ -92,7 +98,7 @@ describe('automock', () => {
 
 describe('browser', () => {
   it('falsy browser is not overwritten', () => {
-    const config = normalize({
+    const {config} = normalize({
       browser: true,
       rootDir: '/root/path/foo',
     });
@@ -103,7 +109,7 @@ describe('browser', () => {
 
 describe('collectCoverageOnlyFrom', () => {
   it('normalizes all paths relative to rootDir', () => {
-    const config = normalize({
+    const {config} = normalize({
       collectCoverageOnlyFrom: {
         'bar/baz': true,
         'qux/quux/': true,
@@ -119,7 +125,7 @@ describe('collectCoverageOnlyFrom', () => {
   });
 
   it('does not change absolute paths', () => {
-    const config = normalize({
+    const {config} = normalize({
       collectCoverageOnlyFrom: {
         '/an/abs/path': true,
         '/another/abs/path': true,
@@ -135,7 +141,7 @@ describe('collectCoverageOnlyFrom', () => {
   });
 
   it('substitutes <rootDir> tokens', () => {
-    const config = normalize({
+    const {config} = normalize({
       collectCoverageOnlyFrom: {
         '<rootDir>/bar/baz': true,
       },
@@ -151,7 +157,7 @@ describe('collectCoverageOnlyFrom', () => {
 
 function testPathArray(key) {
   it('normalizes all paths relative to rootDir', () => {
-    const config = normalize({
+    const {config} = normalize({
       [key]: [
         'bar/baz',
         'qux/quux/',
@@ -165,7 +171,7 @@ function testPathArray(key) {
   });
 
   it('does not change absolute paths', () => {
-    const config = normalize({
+    const {config} = normalize({
       [key]: [
         '/an/abs/path',
         '/another/abs/path',
@@ -179,7 +185,7 @@ function testPathArray(key) {
   });
 
   it('substitutes <rootDir> tokens', () => {
-    const config = normalize({
+    const {config} = normalize({
       [key]: [
         '<rootDir>/bar/baz',
       ],
@@ -202,7 +208,7 @@ describe('transform', () => {
   });
 
   it('normalizes the path', () => {
-    const config = normalize({
+    const {config} = normalize({
       rootDir: '/root/',
       transform: {
         [DEFAULT_CSS_PATTERN]: '<rootDir>/node_modules/jest-regex-util',
@@ -227,7 +233,7 @@ describe('haste', () => {
   });
 
   it('normalizes the path for hasteImplModulePath', () => {
-    const config = normalize({
+    const {config} = normalize({
       haste: {
         hasteImplModulePath: '<rootDir>/hasteImpl.js',
       },
@@ -240,7 +246,6 @@ describe('haste', () => {
   });
 });
 
-
 describe('setupTestFrameworkScriptFile', () => {
   let Resolver;
   beforeEach(() => {
@@ -251,7 +256,7 @@ describe('setupTestFrameworkScriptFile', () => {
   });
 
   it('normalizes the path according to rootDir', () => {
-    const config = normalize({
+    const {config} = normalize({
       rootDir: '/root/path/foo',
       setupTestFrameworkScriptFile: 'bar/baz',
     }, '/root/path');
@@ -260,7 +265,7 @@ describe('setupTestFrameworkScriptFile', () => {
   });
 
   it('does not change absolute paths', () => {
-    const config = normalize({
+    const {config} = normalize({
       rootDir: '/root/path/foo',
       setupTestFrameworkScriptFile: '/an/abs/path',
     });
@@ -269,7 +274,7 @@ describe('setupTestFrameworkScriptFile', () => {
   });
 
   it('substitutes <rootDir> tokens', () => {
-    const config = normalize({
+    const {config} = normalize({
       rootDir: '/root/path/foo',
       setupTestFrameworkScriptFile: '<rootDir>/bar/baz',
     });
@@ -282,7 +287,7 @@ describe('coveragePathIgnorePatterns', () => {
   it('does not normalize paths relative to rootDir', () => {
     // This is a list of patterns, so we can't assume any of them are
     // directories
-    const config = normalize({
+    const {config} = normalize({
       coveragePathIgnorePatterns: [
         'bar/baz',
         'qux/quux',
@@ -299,7 +304,7 @@ describe('coveragePathIgnorePatterns', () => {
   it('does not normalize trailing slashes', () => {
     // This is a list of patterns, so we can't assume any of them are
     // directories
-    const config = normalize({
+    const {config} = normalize({
       coveragePathIgnorePatterns: [
         'bar/baz',
         'qux/quux/',
@@ -314,7 +319,7 @@ describe('coveragePathIgnorePatterns', () => {
   });
 
   it('substitutes <rootDir> tokens', () => {
-    const config = normalize({
+    const {config} = normalize({
       coveragePathIgnorePatterns: [
         'hasNoToken',
         '<rootDir>/hasAToken',
@@ -333,7 +338,7 @@ describe('testPathIgnorePatterns', () => {
   it('does not normalize paths relative to rootDir', () => {
     // This is a list of patterns, so we can't assume any of them are
     // directories
-    const config = normalize({
+    const {config} = normalize({
       rootDir: '/root/path/foo',
       testPathIgnorePatterns: [
         'bar/baz',
@@ -350,7 +355,7 @@ describe('testPathIgnorePatterns', () => {
   it('does not normalize trailing slashes', () => {
     // This is a list of patterns, so we can't assume any of them are
     // directories
-    const config = normalize({
+    const {config} = normalize({
       rootDir: '/root/path/foo',
       testPathIgnorePatterns: [
         'bar/baz',
@@ -365,7 +370,7 @@ describe('testPathIgnorePatterns', () => {
   });
 
   it('substitutes <rootDir> tokens', () => {
-    const config = normalize({
+    const {config} = normalize({
       rootDir: '/root/path/foo',
       testPathIgnorePatterns: [
         'hasNoToken',
@@ -384,7 +389,7 @@ describe('modulePathIgnorePatterns', () => {
   it('does not normalize paths relative to rootDir', () => {
     // This is a list of patterns, so we can't assume any of them are
     // directories
-    const config = normalize({
+    const {config} = normalize({
       modulePathIgnorePatterns: [
         'bar/baz',
         'qux/quux',
@@ -401,7 +406,7 @@ describe('modulePathIgnorePatterns', () => {
   it('does not normalize trailing slashes', () => {
     // This is a list of patterns, so we can't assume any of them are
     // directories
-    const config = normalize({
+    const {config} = normalize({
       modulePathIgnorePatterns: [
         'bar/baz',
         'qux/quux/',
@@ -416,7 +421,7 @@ describe('modulePathIgnorePatterns', () => {
   });
 
   it('substitutes <rootDir> tokens', () => {
-    const config = normalize({
+    const {config} = normalize({
       modulePathIgnorePatterns: [
         'hasNoToken',
         '<rootDir>/hasAToken',
@@ -433,7 +438,7 @@ describe('modulePathIgnorePatterns', () => {
 
 describe('testRunner', () => {
   it('defaults to Jasmine 2', () => {
-    const config = normalize({
+    const {config} = normalize({
       rootDir: '/root/path/foo',
     });
 
@@ -441,7 +446,7 @@ describe('testRunner', () => {
   });
 
   it('can be changed to jasmine1', () => {
-    const config = normalize({
+    const {config} = normalize({
       rootDir: '/root/path/foo',
       testRunner: 'jasmine1',
     });
@@ -450,7 +455,7 @@ describe('testRunner', () => {
   });
 
   it('is overwritten by argv', () => {
-    const config = normalize(
+    const {config} = normalize(
       {
         rootDir: '/root/path/foo',
       },
@@ -479,7 +484,7 @@ describe('testEnvironment', () => {
   });
 
   it('resolves to an environment and prefers jest-environment-`name`', () => {
-    const config = normalize({
+    const {config} = normalize({
       rootDir: '/root',
       testEnvironment: 'jsdom',
     });
@@ -506,7 +511,7 @@ describe('babel-jest', () => {
   });
 
   it('correctly identifies and uses babel-jest', () => {
-    const config = normalize({
+    const {config} = normalize({
       rootDir: '/root',
     });
 
@@ -519,7 +524,7 @@ describe('babel-jest', () => {
 
   it('uses babel-jest if babel-jest is explicitly specified in a custom transform config', () => {
     const customJSPattern = '^.+\\.js$';
-    const config = normalize({
+    const {config} = normalize({
       rootDir: '/root',
       transform: {
         [customJSPattern]: 'babel-jest',
@@ -535,7 +540,7 @@ describe('babel-jest', () => {
   it(`doesn't use babel-jest if its not available`, () => {
     Resolver.findNodeModule.mockImplementation(() => null);
 
-    const config = normalize({
+    const {config} = normalize({
       rootDir: '/root',
     });
 
@@ -546,7 +551,7 @@ describe('babel-jest', () => {
   it('uses polyfills if babel-jest is explicitly specified', () => {
     const ROOT_DIR = '<rootDir>' + path.sep;
 
-    const config = normalize({
+    const {config} = normalize({
       rootDir: '/root',
       transform: {
         [DEFAULT_JS_PATTERN]: ROOT_DIR + Resolver.findNodeModule(
@@ -574,7 +579,7 @@ describe('Upgrade help', () => {
   });
 
   it('logs a warning when `scriptPreprocessor` and/or `preprocessorIgnorePatterns` are used', () => {
-    const config = normalize({
+    const {config, hasDeprecationWarnings} = normalize({
       preprocessorIgnorePatterns: ['bar/baz', 'qux/quux'],
       rootDir: '/root/path/foo',
       scriptPreprocessor: 'bar/baz',
@@ -588,6 +593,7 @@ describe('Upgrade help', () => {
 
     expect(config.scriptPreprocessor).toBe(undefined);
     expect(config.preprocessorIgnorePatterns).toBe(undefined);
+    expect(hasDeprecationWarnings).toBeTruthy();
 
     expect(console.warn.mock.calls[0][0]).toMatchSnapshot();
   });
@@ -595,7 +601,7 @@ describe('Upgrade help', () => {
 
 describe('testMatch', () => {
   it('testMatch default not applied if testRegex is set', () => {
-    const config = normalize({
+    const {config} = normalize({
       rootDir: '/root',
       testRegex: '.*',
     });
@@ -604,7 +610,7 @@ describe('testMatch', () => {
   });
 
   it('testRegex default not applied if testMatch is set', () => {
-    const config = normalize({
+    const {config} = normalize({
       rootDir: '/root',
       testMatch: ['**/*.js'],
     });
@@ -659,7 +665,7 @@ describe('preset', () => {
   });
 
   test('merges with config', () => {
-    const config = normalize({
+    const {config} = normalize({
       moduleNameMapper: {a: 'a'},
       modulePathIgnorePatterns: ['a'],
       preset: 'react-native',
@@ -699,7 +705,7 @@ describe('preset without setupFiles', () => {
   });
 
   it('should normalize setupFiles correctly', () => {
-    const config = normalize({
+    const {config} = normalize({
       preset: 'react-native',
       rootDir: '/root/path/foo',
       setupFiles: ['a'],

--- a/packages/jest-config/src/index.js
+++ b/packages/jest-config/src/index.js
@@ -18,7 +18,10 @@ const setFromArgv = require('./setFromArgv');
 
 const readConfig = (argv: Object, packageRoot: string) =>
   readRawConfig(argv, packageRoot)
-    .then(config => Object.freeze(setFromArgv(config, argv)));
+    .then(({config, hasDeprecationWarnings}) => ({
+      config: Object.freeze(setFromArgv(config, argv)),
+      hasDeprecationWarnings,
+    }));
 
 const parseConfig = argv => {
   if (argv.config && typeof argv.config === 'string') {
@@ -44,7 +47,16 @@ const readRawConfig = (argv, root) => {
   }
 
   return loadFromPackage(path.join(root, 'package.json'), argv)
-    .then(config => config || normalize({rootDir: root}, argv));
+    .then(({config, hasDeprecationWarnings}) => {
+      if (config) {
+        return {
+          config,
+          hasDeprecationWarnings,
+        };
+      }
+
+      return normalize({rootDir: root}, argv);
+    });
 };
 
 module.exports = {

--- a/packages/jest-config/src/normalize.js
+++ b/packages/jest-config/src/normalize.js
@@ -241,7 +241,7 @@ const normalizeArgv = (config: InitialConfig, argv: Object) => {
 };
 
 function normalize(config: InitialConfig, argv: Object = {}) {
-  validate(config, {
+  const {hasDeprecationWarnings} = validate(config, {
     comment: DOCUMENTATION_NOTE,
     deprecatedConfig: DEPRECATED_CONFIG,
     exampleConfig: VALID_CONFIG,
@@ -403,7 +403,10 @@ function normalize(config: InitialConfig, argv: Object = {}) {
       .filter(reporter => reporter !== 'text');
   }
 
-  return _replaceRootDirTags(newConfig.rootDir, newConfig);
+  return {
+    config: _replaceRootDirTags(newConfig.rootDir, newConfig),
+    hasDeprecationWarnings,
+  };
 }
 
 module.exports = normalize;

--- a/packages/jest-runtime/src/__mocks__/createRuntime.js
+++ b/packages/jest-runtime/src/__mocks__/createRuntime.js
@@ -17,7 +17,7 @@ module.exports = function createRuntime(filename, config) {
   config = normalize(Object.assign({
     name: 'Runtime-' + filename.replace(/\W/, '-') + '-tests',
     rootDir: path.resolve(path.dirname(filename), 'test_root'),
-  }, config));
+  }, config)).config;
 
   const environment = new NodeEnvironment(config);
   environment.global.console = console;

--- a/packages/jest-runtime/src/cli/index.js
+++ b/packages/jest-runtime/src/cli/index.js
@@ -65,7 +65,7 @@ function run(cliArgv?: Object, cliInfo?: Array<string>) {
     console.log(`Using Jest Runtime v${VERSION}${info}`);
   }
   readConfig(argv, root)
-    .then(config => {
+    .then(({config}) => {
       // Always disable automocking in scripts.
       config = Object.assign({}, config, {
         automock: false,

--- a/packages/jest-validate/README.md
+++ b/packages/jest-validate/README.md
@@ -14,7 +14,7 @@ import {validate} from 'jest-validate';
 validate(
   config: Object,
   options: ValidationOptions,
-);
+); // => {hasDeprecationWarnings: boolean, isValid: boolean}
 ```
 
 Where `ValidationOptions` are:
@@ -27,7 +27,7 @@ type ValidationOptions = {
     option: string,
     deprecatedOptions: Object,
     options: ValidationOptions
-  ) => void,
+  ) => true,
   deprecatedConfig?: {[key: string]: Function},
   error?: (
     option: string,

--- a/packages/jest-validate/src/__tests__/validate-test.js
+++ b/packages/jest-validate/src/__tests__/validate-test.js
@@ -19,13 +19,21 @@ const jestValidateExampleConfig = require('../exampleConfig');
 const jestValidateDefaultConfig = require('../defaultConfig');
 
 test('validates default Jest config', () => {
-  expect(validate(defaultConfig, {exampleConfig: validConfig})).toBe(true);
+  expect(validate(defaultConfig, {
+    exampleConfig: validConfig,
+  })).toEqual({
+    hasDeprecationWarnings: false,
+    isValid: true,
+  });
 });
 
 test('validates default jest-validate config', () => {
   expect(validate(jestValidateDefaultConfig, {
     exampleConfig: jestValidateExampleConfig,
-  })).toBe(true);
+  })).toEqual({
+    hasDeprecationWarnings: false,
+    isValid: true,
+  });
 });
 
 [
@@ -52,7 +60,10 @@ test('omits null and undefined config values', () => {
     haste: undefined,
     preset: null,
   };
-  expect(validate(config, {exampleConfig: validConfig})).toBe(true);
+  expect(validate(config, {exampleConfig: validConfig})).toEqual({
+    hasDeprecationWarnings: false,
+    isValid: true,
+  });
 });
 
 test('displays warning for unknown config options', () => {
@@ -72,7 +83,13 @@ test('displays warning for deprecated config options', () => {
   const warn = console.warn;
   console.warn = jest.fn();
 
-  validate(config, {deprecatedConfig, exampleConfig: validConfig});
+  expect(validate(config, {
+    deprecatedConfig,
+    exampleConfig: validConfig,
+  })).toEqual({
+    hasDeprecationWarnings: true,
+    isValid: true,
+  });
 
   expect(console.warn.mock.calls[0][0]).toMatchSnapshot();
   console.warn = warn;

--- a/packages/jest-validate/src/deprecated.js
+++ b/packages/jest-validate/src/deprecated.js
@@ -29,6 +29,8 @@ const deprecationWarning = (
 ): void => {
   if (option in deprecatedOptions) {
     deprecationMessage(deprecatedOptions[option](config), options);
+
+    global.hasDeprecationWarnings = true;
   }
 };
 

--- a/packages/jest-validate/src/deprecated.js
+++ b/packages/jest-validate/src/deprecated.js
@@ -26,12 +26,14 @@ const deprecationWarning = (
   option: string,
   deprecatedOptions: Object,
   options: ValidationOptions
-): void => {
+): boolean => {
   if (option in deprecatedOptions) {
     deprecationMessage(deprecatedOptions[option](config), options);
 
-    global.hasDeprecationWarnings = true;
+    return true;
   }
+
+  return false;
 };
 
 module.exports = {

--- a/packages/jest-validate/src/exampleConfig.js
+++ b/packages/jest-validate/src/exampleConfig.js
@@ -15,7 +15,7 @@ import type {ValidationOptions} from './types';
 const config: ValidationOptions = {
   comment: '  A comment',
   condition: (option, validOption) => true,
-  deprecate: (config, option, deprecatedOptions, options) => {},
+  deprecate: (config, option, deprecatedOptions, options) => false,
   deprecatedConfig: {
     key: config => {},
   },

--- a/packages/jest-validate/src/types.js
+++ b/packages/jest-validate/src/types.js
@@ -24,7 +24,7 @@ export type ValidationOptions = {
     option: string,
     deprecatedOptions: Object,
     options: ValidationOptions
-  ) => void,
+  ) => boolean,
   deprecatedConfig?: {[key: string]: Function},
   error?: (
     option: string,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Resolve #2916. Using hack with global variable, but for get better solution we need rewrite jest-validate for get deprecation warnings in jest-cli. I'm really may try to do it after release, but now its best solution.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

![feb-18-2017 20-39-56](https://cloud.githubusercontent.com/assets/9217163/23095399/73cbc7e6-f61a-11e6-80dd-7412937d029a.gif)

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
