### PR TITLE
Documentation: Update code to match the screenshot

### DIFF
--- a/docs/SnapshotTesting.md
+++ b/docs/SnapshotTesting.md
@@ -56,7 +56,7 @@ One such situation can arise if we intentionally change the address the Link com
 // Updated test case with a Link to a different address
 it('renders correctly', () => {
   const tree = renderer.create(
-    <Link page="https://facebook.github.io/jest/">Jest</Link>
+    <Link page="http://www.instagram.com">Instagram</Link>
   ).toJSON();
   expect(tree).toMatchSnapshot();
 });


### PR DESCRIPTION
**Summary**

The example code in *SnapshotTesting* doesn't match the screenshot and it may cause confusion:

![screenshot](https://facebook.github.io/jest/img/content/failedSnapshotTest.png)

```html
<Link page="https://facebook.github.io/jest/">Jest</Link>
```

should be

```html
<Link page="http://www.instagram.com">Instagram</Link>
```

**Test plan**

N/A
