### PR TITLE
Revise the snapshot version warning

### DIFF
--- a/packages/jest-snapshot/src/utils.js
+++ b/packages/jest-snapshot/src/utils.js
@@ -26,9 +26,9 @@ const SNAPSHOT_VERSION = '1';
 const SNAPSHOT_VERSION_REGEXP = /^\/\/ Jest Snapshot v(.+),/;
 const SNAPSHOT_GUIDE_LINK = 'https://goo.gl/fbAQLP';
 const SNAPSHOT_VERSION_WARNING = chalk.yellow(
-  `${chalk.bold('Warning')}: It is advised to revert any local changes to ` +
-  `tests or other code during this upgrade to ensure that no invalid state ` +
-  `is stored as a snapshot.`
+  `${chalk.bold('Warning')}: Before you upgrade snapshots, ` +
+  `we recommend that you revert any local changes to tests or other code, ` +
+  `to ensure that you do not store invalid state.`
 );
 
 const writeSnapshotVersion = () =>


### PR DESCRIPTION
**Summary**

I had to think hard to understand **what** I need to do and **when** and **why**.

* Move **when** to the front: Before you upgrade snapshots [instead of while upgrading]
* Change **what** from passive to active: We recommend that you [instead of it is advised to]
* Change **why** from passive to active: you do not store [instead of no…is stored]

This applies guidelines from Microsoft Manual of Style:

* active “We recommend…” instead of passive wording as a rare exception to the guideline to avoid the first person
* active “you” instead of third person wording for actions

**Test plan**

Second opinion about whether revised wording helps someone who didn’t expect this and doesn’t read English as first language.

I’m not sure the last words “invalid state” is clear enough, but don’t have a specific suggestion :(