### PR TITLE
Keep supporting undefined props in ReactTestComponent plugin

### DIFF
--- a/packages/pretty-format/src/plugins/ReactTestComponent.js
+++ b/packages/pretty-format/src/plugins/ReactTestComponent.js
@@ -41,12 +41,12 @@ function printInstance(instance, print, indent, colors, opts) {
   }
 
   let result = colors.tag.open + '<' + instance.type + colors.tag.close;
+  let closeInNewLine = false;
 
   if (instance.props) {
     result += printProps(instance.props, print, indent, colors, opts);
+    closeInNewLine = !!Object.keys(instance.props).length && !opts.min;
   }
-
-  const closeInNewLine = !!Object.keys(instance.props).length && !opts.min;
 
   if (instance.children) {
     const children = printChildren(instance.children, print, indent, colors, opts);


### PR DESCRIPTION
**Summary**

The excellent improvement in snapshot format causes a **regression** because `Object.keys(instance.props)` is outside `if (instance.props) { … }`

As part of work-in-progress on subset matching to ignore irrelevant details, a helper function transforms test-rendered elements by omitting empty props objects to improve the error diff message for `toMatchObject` assertion. Recently I used it for a `toMatchSnapshot` assertion.

Here is a minimal example to illustrate what is happening:

```js
test('omitted irrelevant props for toMatchObject', () => {
  expect({
    $$typeof: Symbol.for('react.test.json'),
    type: 'span',
    children: ['and used it for toMatchSnapshot'],
  }).toMatchSnapshot();
});
```
Jest 18.0.1 stores a snapshot:

```
exports[`omitted irrelevant props for toMatchObject 1`] = `
<span>
  and used it for toMatchSnapshot
</span>
`;
```

Current Jest build from master: `TypeError: Cannot convert undefined or null to object`

**Test plan**

Still passes tests.

P.S. I have thought about adding Flow type for the plugin. I think it would catch this problem.