### PR TITLE
Fix canUseWatchman freeze @ jest-haste-map 

### DIFF
--- a/packages/jest-haste-map/src/index.js
+++ b/packages/jest-haste-map/src/index.js
@@ -89,7 +89,7 @@ const VERSION = require('../package.json').version;
 
 const canUseWatchman = ((): boolean => {
   try {
-    execSync('watchman version', {stdio: ['ignore']});
+    execSync('watchman --version', {stdio: ['ignore']});
     return true;
   } catch (e) {}
   return false;


### PR DESCRIPTION
**Summary**
If watchman was installed globally, jest couldn't run at all.