### PR TITLE
Add Flow type annotations to ReactTestComponent plugin

### DIFF
--- a/packages/pretty-format/src/plugins/ReactTestComponent.js
+++ b/packages/pretty-format/src/plugins/ReactTestComponent.js
@@ -4,6 +4,8 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
  */
 /* eslint-disable max-len */
 'use strict';
@@ -12,11 +14,20 @@ const escapeHTML = require('./escapeHTML');
 
 const reactTestInstance = Symbol.for('react.test.json');
 
-function printChildren(children, print, indent, colors, opts) {
+type ReactTestObject = {|
+  $$typeof: Symbol,
+  type: string,
+  props?: Object,
+  children?: null | Array<ReactTestChild>,
+|};
+// Child can be `number` in Stack renderer but not in Fiber renderer.
+type ReactTestChild = ReactTestObject | string | number;
+
+function printChildren(children: Array<ReactTestChild>, print, indent, colors, opts) {
   return children.map(child => printInstance(child, print, indent, colors, opts)).join(opts.edgeSpacing);
 }
 
-function printProps(props, print, indent, colors, opts) {
+function printProps(props: Object, print, indent, colors, opts) {
   return Object.keys(props).sort().map(name => {
     const prop = props[name];
     let printed = print(prop);
@@ -33,19 +44,21 @@ function printProps(props, print, indent, colors, opts) {
   }).join('');
 }
 
-function printInstance(instance, print, indent, colors, opts) {
+function printInstance(instance: ReactTestChild, print, indent, colors, opts) {
   if (typeof instance == 'number') {
     return print(instance);
   } else if (typeof instance === 'string') {
     return colors.content.open + escapeHTML(instance) + colors.content.close;
   }
 
-  let result = colors.tag.open + '<' + instance.type + colors.tag.close;
   let closeInNewLine = false;
+  let result = colors.tag.open + '<' + instance.type + colors.tag.close;
 
   if (instance.props) {
-    result += printProps(instance.props, print, indent, colors, opts);
+    // If assignments are in opposite order, Flow 0.39.0 finds incorrect error:
+    // element of Object.keys. Expected object instead of possibly undefined value
     closeInNewLine = !!Object.keys(instance.props).length && !opts.min;
+    result += printProps(instance.props, print, indent, colors, opts);
   }
 
   if (instance.children) {
@@ -59,10 +72,10 @@ function printInstance(instance, print, indent, colors, opts) {
 }
 
 module.exports = {
-  print(val, print, indent, opts, colors) {
+  print(val: ReactTestObject, print: (val: any) => string, indent: (str: string) => string, opts: Object, colors: Object) {
     return printInstance(val, print, indent, colors, opts);
   },
-  test(object) {
+  test(object: Object) {
     return object && object.$$typeof === reactTestInstance;
   },
 };


### PR DESCRIPTION
**Summary**

Given the problem solved in #2943 these Flow type annotations find the following error:

element of Object.keys. Expected object instead of possibly undefined value

As a Flow newbie, I am especially glad for your guidance whether this is enough, or to add more.

**Test plan**

The new type checks pass. But not without a fight: if you enjoy irony, see comment in code :)