### PR TITLE
Fixes bug in the parser throwing when finding an uninitialized variable

### DIFF
--- a/packages/jest-editor-support/src/__tests__/fixtures/declarationWithoutAssignment.example
+++ b/packages/jest-editor-support/src/__tests__/fixtures/declarationWithoutAssignment.example
@@ -1,0 +1,6 @@
+let foo;
+var bar;
+
+test('declaration without assignments should not throw', () => {
+  expect(true).toBe(true);
+});

--- a/packages/jest-editor-support/src/__tests__/parsers/parserTests.js
+++ b/packages/jest-editor-support/src/__tests__/parsers/parserTests.js
@@ -14,6 +14,14 @@ const path = require('path');
 const fixtures = path.resolve(__dirname, '../fixtures');
 
 function parserTests(parse: (file: string) => ParserReturn) {
+  describe('File parsing without throwing', () => {
+    it('Should not throw', () => {
+      expect(() => {
+        parse(`${fixtures}/declarationWithoutAssignment.example`);
+      }).not.toThrow();
+    });
+  });
+
   describe('File Parsing for it blocks', () => {
 
     it('For the simplest it cases', () => {

--- a/packages/jest-editor-support/src/parsers/BabylonParser.js
+++ b/packages/jest-editor-support/src/parsers/BabylonParser.js
@@ -160,7 +160,9 @@ const babylonParser = (file: string) => {
         foundExpectNode(element, file);
       } else if (element.type === 'VariableDeclaration') {
         element.declarations
-          .filter(declaration => isFunctionDeclaration(declaration.init.type))
+          .filter(declaration => (
+            declaration.init && isFunctionDeclaration(declaration.init.type))
+          )
           .forEach(declaration => searchNodes(declaration.init.body, file));
       } else if (
         element.type === 'ExpressionStatement' &&


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Fixes a bug preventing the babylon parser to correctly parse files with uninitialized variables:
**Test plan**
Add a test to reproduce the bug:
![screen shot 2017-02-21 at 11 48 23 am](https://cloud.githubusercontent.com/assets/87300/23163861/3bd02580-f82c-11e6-98c1-a0c741b21f97.png)
After the fix the test passes.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
