### PR TITLE
Fix bug with watchers on macOS causing test to crash

### DIFF
--- a/packages/jest-haste-map/package.json
+++ b/packages/jest-haste-map/package.json
@@ -12,7 +12,7 @@
     "graceful-fs": "^4.1.6",
     "jest-docblock": "^19.0.2",
     "micromatch": "^2.3.11",
-    "sane": "~1.5.0",
+    "sane": "~1.6.0",
     "worker-farm": "^1.3.1"
   }
 }

--- a/packages/jest-haste-map/src/index.js
+++ b/packages/jest-haste-map/src/index.js
@@ -52,7 +52,6 @@ type Options = {
   resetCache?: boolean,
   retainAllFiles: boolean,
   roots: Array<string>,
-  testPathIgnorePattern: RegExp | null,
   throwOnModuleCollision?: boolean,
   useWatchman?: boolean,
   watch?: boolean,
@@ -71,7 +70,6 @@ type InternalOptions = {
   resetCache: ?boolean,
   retainAllFiles: boolean,
   roots: Array<string>,
-  testPathIgnorePattern: RegExp | null,
   throwOnModuleCollision: boolean,
   useWatchman: boolean,
   watch: boolean,
@@ -212,7 +210,6 @@ class HasteMap extends EventEmitter {
       resetCache: options.resetCache,
       retainAllFiles: options.retainAllFiles,
       roots: Array.from(new Set(options.roots)),
-      testPathIgnorePattern: options.testPathIgnorePattern,
       throwOnModuleCollision: !!options.throwOnModuleCollision,
       useWatchman: options.useWatchman == null ? true : options.useWatchman,
       watch: !!options.watch,
@@ -536,7 +533,7 @@ class HasteMap extends EventEmitter {
       ? sane.WatchmanWatcher
       : sane.NodeWatcher;
     const extensions = this._options.extensions;
-    const ignorePattern = this._options.testPathIgnorePattern;
+    const ignorePattern = this._options.ignorePattern;
     let changeQueue = Promise.resolve();
     let eventsQueue = [];
     // We only need to copy the entire haste map once on every "frame".

--- a/packages/jest-haste-map/src/index.js
+++ b/packages/jest-haste-map/src/index.js
@@ -52,6 +52,7 @@ type Options = {
   resetCache?: boolean,
   retainAllFiles: boolean,
   roots: Array<string>,
+  testPathIgnorePattern: RegExp | null,
   throwOnModuleCollision?: boolean,
   useWatchman?: boolean,
   watch?: boolean,
@@ -70,6 +71,7 @@ type InternalOptions = {
   resetCache: ?boolean,
   retainAllFiles: boolean,
   roots: Array<string>,
+  testPathIgnorePattern: RegExp | null,
   throwOnModuleCollision: boolean,
   useWatchman: boolean,
   watch: boolean,
@@ -210,6 +212,7 @@ class HasteMap extends EventEmitter {
       resetCache: options.resetCache,
       retainAllFiles: options.retainAllFiles,
       roots: Array.from(new Set(options.roots)),
+      testPathIgnorePattern: options.testPathIgnorePattern,
       throwOnModuleCollision: !!options.throwOnModuleCollision,
       useWatchman: options.useWatchman == null ? true : options.useWatchman,
       watch: !!options.watch,
@@ -533,6 +536,7 @@ class HasteMap extends EventEmitter {
       ? sane.WatchmanWatcher
       : sane.NodeWatcher;
     const extensions = this._options.extensions;
+    const ignorePattern = this._options.testPathIgnorePattern;
     let changeQueue = Promise.resolve();
     let eventsQueue = [];
     // We only need to copy the entire haste map once on every "frame".
@@ -544,6 +548,7 @@ class HasteMap extends EventEmitter {
       const watcher = new Watcher(root, {
         dot: false,
         glob: extensions.map(extension => '**/*.' + extension),
+        ignored: ignorePattern,
       });
 
       return new Promise((resolve, reject) => {

--- a/packages/jest-haste-map/src/index.js
+++ b/packages/jest-haste-map/src/index.js
@@ -43,7 +43,7 @@ type Options = {
   extensions: Array<string>,
   forceNodeFilesystemAPI?: boolean,
   hasteImplModulePath?: string,
-  ignorePattern: RegExp,
+  ignorePattern: RegExp | Function,
   maxWorkers: number,
   mocksPattern?: string,
   name: string,
@@ -62,7 +62,7 @@ type InternalOptions = {
   extensions: Array<string>,
   forceNodeFilesystemAPI: boolean,
   hasteImplModulePath?: string,
-  ignorePattern: RegExp,
+  ignorePattern: RegExp | Function,
   maxWorkers: number,
   mocksPattern: ?RegExp,
   name: string,
@@ -688,7 +688,13 @@ class HasteMap extends EventEmitter {
    * Helpers
    */
   _ignore(filePath: Path): boolean {
-    return this._options.ignorePattern.test(filePath) ||
+    const ignorePattern = this._options.ignorePattern;
+    const ignoreMatched =
+      Object.prototype.toString.call(ignorePattern) === '[object RegExp]'
+      ? ignorePattern.test(filePath) // $FlowFixMe
+      : ignorePattern(filePath);
+
+    return ignoreMatched ||
       (!this._options.retainAllFiles && this._isNodeModulesDir(filePath));
   }
 

--- a/packages/jest-runtime/src/index.js
+++ b/packages/jest-runtime/src/index.js
@@ -188,6 +188,10 @@ class Runtime {
     config: Config,
     options?: HasteMapOptions,
   ): HasteMap {
+    const testPathIgnorePattern =
+      config.testPathIgnorePatterns.length 
+      ? new RegExp(config.testPathIgnorePatterns.join('|'))
+      : null;
     const ignorePattern = new RegExp(
       [config.cacheDirectory].concat(config.modulePathIgnorePatterns).join('|'),
     );
@@ -206,6 +210,7 @@ class Runtime {
       resetCache: options && options.resetCache,
       retainAllFiles: false,
       roots: config.roots,
+      testPathIgnorePattern,
       useWatchman: config.watchman,
       watch: options && options.watch,
     });

--- a/packages/jest-runtime/src/index.js
+++ b/packages/jest-runtime/src/index.js
@@ -188,10 +188,6 @@ class Runtime {
     config: Config,
     options?: HasteMapOptions,
   ): HasteMap {
-    const testPathIgnorePattern =
-      config.testPathIgnorePatterns.length 
-      ? new RegExp(config.testPathIgnorePatterns.join('|'))
-      : null;
     const ignorePattern = new RegExp(
       [config.cacheDirectory].concat(config.modulePathIgnorePatterns).join('|'),
     );
@@ -210,7 +206,6 @@ class Runtime {
       resetCache: options && options.resetCache,
       retainAllFiles: false,
       roots: config.roots,
-      testPathIgnorePattern,
       useWatchman: config.watchman,
       watch: options && options.watch,
     });


### PR DESCRIPTION
## Summary
This fixes an issue on OS X when there are too many files/folders to watch that causes the test to crash with error 
`2016-09-22 10:49 node[79167] (FSEvents.framework) FSEventStreamStart: register_with_server: ERROR: f2d_register_rpc() => (null) (-22)`

See Issue #1767

This solve the issue by updating [sane](https://github.com/amasad/sane) to 1.6.0 and passing a regular expression passed on the the `testPathIgnorePatterns` config option. This allows `sane` to never apply the watchers.

**_Currently there are no defaults. Maybe it should default to ignoring `.git|node_modules` if nothing is passed? Or else people may still encounter the error._**

The error is caused by some mixture node/OSX. (See joyent/node/issues/5463), where node/osx can't handle the amount of watchers.

## Reproduction
On macOS Sierra, uninstall watchman (if installed), run test in watch mode on a sufficiently large app. Jest exits with exception.

## Test plan
I am unsure how to test this change. Feedback welcome.

## Questions
I was unsure of the best way to handle the typing.

I went with `testPathIgnorePattern: RegExp | null,` with allows us to pass null if no test patterns have been supplied.

The other option was to pass a RegExp of `/(?:)/` that matches everything, and then expect only type RegExp.

## Help wanted
I have tested this on my machine and it working (linking to my project that fails usually). It has also passed the the test suite.

It would be great to have it tested by others to make sure that it solves the problem for everyone. Any who encountered the issue in the past and solve by installing `watchman` will need to uninstall (`brew uninstall watchman`) and try run the tests.

**Steps to test:**
`brew uninstall watchman`
`git clone https://github.com/ro-savage/jest.git`
`git checkout fix-watcher-bug-osx`
`yarn install`
`yarn build`
`cd packages/jest-cli`
`yarn link`

Then go to your project that you had crashing tests in a run
`yarn link "jest-cli"`

Make sure you have `testPathIgnorePatterns` config set to include`node_modules`
Run your tests as usual.

## Feedback
This is a minor code change, but took me a long time to track down and fix (and its now 430am).  Any feedback, suggestions are very welcome.