### PR TITLE
Add missing space before "Did you mean"

### DIFF
--- a/packages/jest-util/src/validateCLIOptions.js
+++ b/packages/jest-util/src/validateCLIOptions.js
@@ -31,7 +31,7 @@ const createCLIValidationError = (
 
   if (unrecognizedOptions.length === 1) {
     const unrecognized = unrecognizedOptions[0];
-    message = `  Unrecognized option ${chalk.bold(format(unrecognized))}.` +
+    message = `  Unrecognized option ${chalk.bold(format(unrecognized))}. ` +
       createDidYouMeanMessage(unrecognized, Array.from(allowedOptions));
   } else {
     title += 's';

--- a/packages/jest-util/src/validateCLIOptions.js
+++ b/packages/jest-util/src/validateCLIOptions.js
@@ -31,8 +31,12 @@ const createCLIValidationError = (
 
   if (unrecognizedOptions.length === 1) {
     const unrecognized = unrecognizedOptions[0];
-    message = `  Unrecognized option ${chalk.bold(format(unrecognized))}. ` +
-      createDidYouMeanMessage(unrecognized, Array.from(allowedOptions));
+    const didYouMeanMessage = createDidYouMeanMessage(
+      unrecognized,
+      Array.from(allowedOptions)
+    );
+    message = `  Unrecognized option ${chalk.bold(format(unrecognized))}.` +
+      (didYouMeanMessage ? ` ${didYouMeanMessage}` : '');
   } else {
     title += 's';
     message =


### PR DESCRIPTION
Just noticed a missing space.

![](https://scontent-lhr3-1.xx.fbcdn.net/v/t34.0-12/16839640_375810699456622_1347584771_n.jpg?_nc_log=1&oh=0812ac6ac93753dd5af615c193e7fc6f&oe=58AF613D)

This should fix it.
Another occurrence of the message in `warnings.js` is not affected because it already has the space.