### PR TITLE
Removed `.mockComponent`

### DIFF
--- a/docs/TutorialReactNative.md
+++ b/docs/TutorialReactNative.md
@@ -192,8 +192,8 @@ Sometimes you need to provide a more complex manual mock. For example if you'd l
 
 ```js
 jest.mock('path/to/MyNativeComponent', () => {
-  const jestReactNative = require('react-native/jest/mockComponent');
-  return jestReactNative('path/to/MyNativeComponent');
+  const mockComponent = require('react-native/jest/mockComponent');
+  return mockComponent('path/to/MyNativeComponent');
 });
 ```
 

--- a/docs/TutorialReactNative.md
+++ b/docs/TutorialReactNative.md
@@ -193,7 +193,7 @@ Sometimes you need to provide a more complex manual mock. For example if you'd l
 ```js
 jest.mock('path/to/MyNativeComponent', () => {
   const jestReactNative = require('jest-react-native');
-  return jestReactNative.mockComponent('path/to/MyNativeComponent');
+  return jestReactNative('path/to/MyNativeComponent');
 });
 ```
 

--- a/docs/TutorialReactNative.md
+++ b/docs/TutorialReactNative.md
@@ -192,7 +192,7 @@ Sometimes you need to provide a more complex manual mock. For example if you'd l
 
 ```js
 jest.mock('path/to/MyNativeComponent', () => {
-  const jestReactNative = require('jest-react-native');
+  const jestReactNative = require('react-native/jest/mockComponent');
   return jestReactNative('path/to/MyNativeComponent');
 });
 ```


### PR DESCRIPTION


<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
It looks like the default function exported from 'jest-react-native' is the `mockComponent` function. When I was running `jestReactNative.mockComponent`, I would get `TypeError: jestReactNative.mockComponent is not a function`. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
In my code, removing that and just running `jestReactNative('TouchableHighlight')` worked so I just removed it from the documentation to reflect that.

Side Note: I'm running `jest@18.0.0`.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
