### PR TITLE
Respect `watchman` config setting

### DIFF
--- a/integration_tests/__tests__/config-test.js
+++ b/integration_tests/__tests__/config-test.js
@@ -38,3 +38,15 @@ test('works with sane config JSON', () => {
   expect(result.status).toBe(1);
   expect(stderr).toMatch('works just fine');
 });
+
+test('watchman config option is respected over default argv', () => {
+  const {stdout} = runJest('verbose_reporter', [
+    '--config=' + JSON.stringify({
+      testEnvironment: 'node',
+      watchman: false,
+    }),
+    '--debug',
+  ]);
+
+  expect(stdout).toMatch('\"watchman\": false,');
+});

--- a/packages/jest-config/src/setFromArgv.js
+++ b/packages/jest-config/src/setFromArgv.js
@@ -33,7 +33,7 @@ function setFromArgv(config, argv) {
     config.cache = argv.cache;
   }
 
-  if (argv.watchman !== null) {
+  if (config.watchman === undefined && argv.watchman !== null) {
     config.watchman = argv.watchman;
   }
 


### PR DESCRIPTION
**Summary**

This PR aims to solve #2847. The default CLI setting for `watchman` is `true` so the existing check would always set it to true and would never take into account the config setting. I modified the check to only look at the `argv` setting if the config option wasn't set.

**Test plan**

All tests should pass and you can now set `watchman: false` in config and see it is disabled with `--debug` output.

**Note**

I thought about unit testing this under `jest-config` package, but felt that adding to the integration test was more robust to see it grab the value from config instead of `argv`. If you think I should add a unit test for `setFromArgv` function, I am more than willing to do that as well.
