### PR TITLE
Fix infinite loop issue when running watch with --coverage

### DIFF
--- a/packages/jest-cli/src/lib/__tests__/isValidPath-test.js
+++ b/packages/jest-cli/src/lib/__tests__/isValidPath-test.js
@@ -1,0 +1,41 @@
+/**
+* Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+*
+* This source code is licensed under the BSD-style license found in the
+* LICENSE file in the root directory of this source tree. An additional grant
+* of patent rights can be found in the PATENTS file in the same directory.
+*
+* @emails oncall+jsinfra
+*/
+
+'use strict';
+
+const isValidPath = require('../isValidPath');
+
+const config = {
+  rootDir: '/root',
+  roots: ['/root/src', '/root/lib'],
+};
+
+it('is valid when it is a file inside roots', () => {
+  expect(isValidPath(config, '/root/src/index.js')).toBe(true);
+  expect(isValidPath(config, '/root/src/components/Link.js')).toBe(true);
+  expect(isValidPath(config, '/root/src/lib/something.js')).toBe(true);
+});
+
+it('is not valid when it is a file .snap', () => {
+  expect(isValidPath(config, '/root/src/index.js.snap')).toBe(false);
+  expect(isValidPath(config, '/root/src/components/Link.js.snap')).toBe(false);
+  expect(isValidPath(config, '/root/src/lib/something.js.snap')).toBe(false);
+});
+
+it('is not valid when it is a file in the coverage dir', () => {
+  expect(isValidPath(config, '/root/coverage/lib/index.js')).toBe(false);
+  
+  const configWithCoverage = Object.assign({}, config, {
+    coverageDirectory: 'cov-dir',
+  });
+  
+  expect(isValidPath(configWithCoverage, '/root/src/cov-dir/lib/index.js'))
+    .toBe(false);
+});

--- a/packages/jest-cli/src/lib/__tests__/isValidPath-test.js
+++ b/packages/jest-cli/src/lib/__tests__/isValidPath-test.js
@@ -23,7 +23,7 @@ it('is valid when it is a file inside roots', () => {
   expect(isValidPath(config, '/root/src/lib/something.js')).toBe(true);
 });
 
-it('is not valid when it is a file .snap', () => {
+it('is not valid when it is a snapshot file', () => {
   expect(isValidPath(config, '/root/src/index.js.snap')).toBe(false);
   expect(isValidPath(config, '/root/src/components/Link.js.snap')).toBe(false);
   expect(isValidPath(config, '/root/src/lib/something.js.snap')).toBe(false);

--- a/packages/jest-cli/src/lib/isValidPath.js
+++ b/packages/jest-cli/src/lib/isValidPath.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+'use strict';
+
+import type {Config} from 'types/Config';
+
+const path = require('path');
+
+const SNAPSHOT_EXTENSION = 'snap';
+
+function isValidPath(config: Config, filePath: string) {
+  const coverageDirectory = config.coverageDirectory ||
+    path.resolve(config.rootDir, 'coverage');
+    
+  return config.roots.some(dir => filePath.startsWith(dir)) &&
+    !filePath.includes(coverageDirectory) &&
+    !filePath.endsWith(`.${SNAPSHOT_EXTENSION}`);
+}
+
+module.exports = isValidPath;

--- a/packages/jest-cli/src/lib/isValidPath.js
+++ b/packages/jest-cli/src/lib/isValidPath.js
@@ -19,8 +19,7 @@ function isValidPath(config: Config, filePath: string) {
   const coverageDirectory = config.coverageDirectory ||
     path.resolve(config.rootDir, 'coverage');
     
-  return config.roots.some(dir => filePath.startsWith(dir)) &&
-    !filePath.includes(coverageDirectory) &&
+  return !filePath.includes(coverageDirectory) &&
     !filePath.endsWith(`.${SNAPSHOT_EXTENSION}`);
 }
 

--- a/packages/jest-cli/src/watch.js
+++ b/packages/jest-cli/src/watch.js
@@ -16,6 +16,7 @@ const ansiEscapes = require('ansi-escapes');
 const chalk = require('chalk');
 const createHasteContext = require('./lib/createHasteContext');
 const HasteMap = require('jest-haste-map');
+const isValidPath = require('./lib/isValidPath');
 const preRunMessage = require('./preRunMessage');
 const runJest = require('./runJest');
 const setState = require('./lib/setState');
@@ -25,7 +26,6 @@ const TestPathPatternPrompt = require('./TestPathPatternPrompt');
 const TestNamePatternPrompt = require('./TestNamePatternPrompt');
 const {KEYS, CLEAR} = require('./constants');
 
-const SNAPSHOT_EXTENSION = 'snap';
 
 const watch = (
   config: Config,
@@ -73,11 +73,11 @@ const watch = (
   );
 
   hasteMap.on('change', ({eventsQueue, hasteFS, moduleMap}) => {
-    const hasOnlySnapshotChanges = eventsQueue.every(({filePath}) => {
-      return filePath.endsWith(`.${SNAPSHOT_EXTENSION}`);
+    const validPaths = eventsQueue.filter(({filePath}) => {
+      return isValidPath(config, filePath);
     });
 
-    if (!hasOnlySnapshotChanges) {
+    if (validPaths.length) {
       hasteContext =  createHasteContext(config, {hasteFS, moduleMap});
       prompt.abort();
       testPathPatternPrompt.updateSearchSource(hasteContext);


### PR DESCRIPTION
This fixes #2960 

The bug was introduced while rewriting watch mode... In the previous version it was filtering out `coverage` files and files not in `config.roots`

This PR adds back this logic: https://github.com/facebook/jest/blob/v18.1.0/packages/jest-cli/src/jest.js#L428

Test plan:
Running `--watch --coverage`, also added unit tests
