### PR TITLE
Use `slash` to normalize paths in Windows.

### DIFF
--- a/packages/jest-cli/package.json
+++ b/packages/jest-cli/package.json
@@ -25,6 +25,7 @@
     "jest-util": "^19.0.0",
     "node-notifier": "^5.0.1",
     "micromatch": "^2.3.11",
+    "slash": "^1.0.0",
     "string-length": "^1.0.1",
     "throat": "^3.0.0",
     "which": "^1.1.1",

--- a/packages/jest-cli/src/reporters/utils.js
+++ b/packages/jest-cli/src/reporters/utils.js
@@ -15,6 +15,7 @@ import type {AggregatedResult} from 'types/TestResult';
 
 const chalk = require('chalk');
 const path = require('path');
+const slash = require('slash');
 
 type SummaryOptions = {|
   estimatedTime?: number,
@@ -37,7 +38,7 @@ const trimAndFormatPath = (
 
   // length is ok
   if ((dirname + path.sep + basename).length <= maxLength) {
-    return chalk.dim(dirname + path.sep) + chalk.bold(basename);
+    return slash(chalk.dim(dirname + path.sep) + chalk.bold(basename));
   }
 
   // we can fit trimmed dirname and full basename
@@ -46,18 +47,18 @@ const trimAndFormatPath = (
     const dirnameLength = maxLength - 4 - basenameLength;
     dirname = '...' +
       dirname.slice(dirname.length - dirnameLength, dirname.length);
-    return chalk.dim(dirname + path.sep) + chalk.bold(basename);
+    return slash(chalk.dim(dirname + path.sep) + chalk.bold(basename));
   }
 
   if (basenameLength + 4 === maxLength) {
-    return chalk.dim('...' + path.sep) + chalk.bold(basename);
+    return slash(chalk.dim('...' + path.sep) + chalk.bold(basename));
   }
 
   // can't fit dirname, but can fit trimmed basename
-  return chalk.bold(
+  return slash(chalk.bold(
     '...' +
     basename.slice(basename.length - maxLength - 4, basename.length),
-  );
+  ));
 };
 
 const formatTestPath = (config: Config, testPath: Path) => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
`node` manages paths differently in Windows in that it uses `\\` instead of `/`; this causes some snapshot tests to fail with something like
```
   -  › path/to/file1-test.js
   +  › path\\to\\file1-test.js
```
To get around that, `jest` has AppVeyor [overwrite snapshots that do not pass](https://github.com/facebook/jest/blob/master/appveyor.yml#L18-L22); consequently, all snapshot tests pass on AppVeyor unconditionally.
This PR uses the `slash` package (already in the dependency tree [via `babel-core`](https://github.com/babel/babel/blob/master/packages/babel-core/package.json#L46)) to normalize the output of `trimAndFormatPath`, replacing `\\` with `/`.  This makes 14 out of the 16 failing snapshot tests pass.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
Nothing should change.
Look at [the AppVeyor output of another PR](https://ci.appveyor.com/project/Daniel15/jest/build/2203#L428) and see that 16 snapshots are being updated.  The AppVeyor output for this PR should have only 2.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
