### PR TITLE
Fix notify reporter on Linux

### DIFF
--- a/packages/jest-cli/src/reporters/NotifyReporter.js
+++ b/packages/jest-cli/src/reporters/NotifyReporter.js
@@ -63,7 +63,7 @@ class NotifyReporter extends BaseReporter {
         message,
         title,
       }, (err, _, metadata) => {
-        if (err) {
+        if (err || !metadata) {
           return;
         }
         if (metadata.activationValue === quitAnswer) {


### PR DESCRIPTION
**Summary**

Notify reporter crashes on Linux. `metadata` argument is only defined on macOS. The bug has been introduced with adding possibility to rerun tasks #2727.

https://github.com/facebook/jest/commit/07a6cfeafb1a89396d2434035bc7d67a677edc81#diff-f58da94b31399922b8177b3871db25e3R69

```
.../node_modules/jest-cli/build/reporters/NotifyReporter.js:69
        if (metadata.activationValue === quitAnswer) {
                    ^

TypeError: Cannot read property 'activationValue' of undefined
```
