### PR TITLE
Skip node resolution only for non-relative requires.

### DIFF
--- a/packages/jest-resolve/src/index.js
+++ b/packages/jest-resolve/src/index.js
@@ -127,7 +127,16 @@ class Resolver {
 
     // 2. Check if the module is a node module and resolve it based on
     //    the node module resolution algorithm.
-    if (!options || !options.skipNodeResolution) {
+    // If skipNodeResolution is given we ignore all modules that look like
+    // node modules (ie. are not relative requires). This enables us to speed
+    // up resolution when we build a dependency graph because we don't have
+    // to look at modules that may not exist and aren't mocked.
+    const skipResolution =
+      options &&
+      options.skipNodeResolution &&
+      !moduleName.includes(path.sep);
+
+    if (!skipResolution) {
       module = Resolver.findNodeModule(moduleName, {
         basedir: dirname,
         browser: this._options.browser,


### PR DESCRIPTION
**Summary**

@voideanvalue and I talked about this about six months ago but I never got to it. Basically we have a lot of "missing" modules because of our PHP JS modules at FB and every resolution of "MyModule" is really slow (there are thousands). However, we can still resolve relative requires quickly. This change skips likely node modules but keeps resolving relative requires without a noticeable performance hit.

**Test plan**

At FB, this now takes 5 seconds instead of 70.