### PR TITLE
Use `mkdirp.sync` instead of `childProcess.spawnSync('mkdir', ['-p'])`.

### DIFF
--- a/packages/jest-changed-files/src/__tests__/git-test.js
+++ b/packages/jest-changed-files/src/__tests__/git-test.js
@@ -11,6 +11,7 @@ const os = require('os');
 const fs = require('fs');
 const path = require('path');
 const rimraf = require('rimraf');
+const mkdirp = require('mkdirp');
 const childProcess = require('child_process');
 
 const tmpdir = path.resolve(os.tmpdir(), 'jest-changed-files-git');
@@ -26,7 +27,7 @@ describe('git', () => {
 
   beforeEach(() => {
     git = require('../git');
-    childProcess.spawnSync('mkdir', ['-p', tmpdirNested]);
+    mkdirp.sync(tmpdirNested);
   });
 
   afterEach(() => rimraf.sync(tmpdir));

--- a/packages/jest-changed-files/src/__tests__/hg-test.js
+++ b/packages/jest-changed-files/src/__tests__/hg-test.js
@@ -11,6 +11,7 @@ const os = require('os');
 const fs = require('fs');
 const path = require('path');
 const rimraf = require('rimraf');
+const mkdirp = require('mkdirp');
 const childProcess = require('child_process');
 
 const tmpdir = path.resolve(os.tmpdir(), 'jest-changed-files-hg');
@@ -28,7 +29,7 @@ describe('hg', () => {
     jest.resetModules();
 
     hg = require('../hg');
-    childProcess.spawnSync('mkdir', ['-p', tmpdirNested]);
+    mkdirp.sync(tmpdirNested);
   });
 
   afterEach(() => rimraf.sync(tmpdir));


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Replaces the usage of `childProcess.spawnSync('mkdir', ['-p])` with `mkdirp.sync` in the `jest-changed-files` tests for `git` and `hg`.  This allows them to run on systems where `mkdir -p` is not recognized (i.e. Windows).
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
Nothing should change.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
