### PR TITLE
[jest-config] Use `read-pkg` to read `package.json`.

### DIFF
--- a/packages/jest-config/package.json
+++ b/packages/jest-config/package.json
@@ -15,6 +15,7 @@
     "jest-regex-util": "^19.0.0",
     "jest-resolve": "^19.0.2",
     "jest-validate": "^19.0.2",
-    "pretty-format": "^19.0.0"
+    "pretty-format": "^19.0.0",
+    "read-pkg": "^1.0.0"
   }
 }

--- a/packages/jest-config/src/__mocks__/read-pkg.js
+++ b/packages/jest-config/src/__mocks__/read-pkg.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+const mockFiles = new Map();
+function __setMockFiles(newMockFiles) {
+  mockFiles.clear();
+  Object.keys(newMockFiles).forEach(fileName => {
+    mockFiles.set(fileName, newMockFiles[fileName]);
+  });
+}
+
+function readPkg(file) {
+  const mockFile = mockFiles.get(file);
+  try {
+    const json = JSON.parse(mockFile);
+    return Promise.resolve(json);
+  } catch(err) {
+    return Promise.reject(`${file} is not valid JSON.`);
+  }
+}
+
+module.exports = readPkg;
+module.exports.__setMockFiles = __setMockFiles;

--- a/packages/jest-config/src/__mocks__/read-pkg.js
+++ b/packages/jest-config/src/__mocks__/read-pkg.js
@@ -21,7 +21,7 @@ function readPkg(file) {
   try {
     const json = JSON.parse(mockFile);
     return Promise.resolve(json);
-  } catch(err) {
+  } catch (err) {
     return Promise.reject(`${file} is not valid JSON.`);
   }
 }

--- a/packages/jest-config/src/__tests__/loadFromPackage-test.js
+++ b/packages/jest-config/src/__tests__/loadFromPackage-test.js
@@ -25,12 +25,12 @@ describe('loadFromPackage', () => {
         "testMatch": ["match.js"
       }
     }`,
-    'withoutJest': `{
-    }`,
     'withRootDir': `{
       "jest": {
         "rootDir": "testDir"
       }
+    }`,
+    'withoutJest': `{
     }`,
   };
 

--- a/packages/jest-config/src/__tests__/loadFromPackage-test.js
+++ b/packages/jest-config/src/__tests__/loadFromPackage-test.js
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+'use strict';
+
+jest.mock('read-pkg');
+
+const path = require('path');
+const loadFromPackage = require('../loadFromPackage');
+
+describe('loadFromPackage', () => {
+  const MOCK_FILE_INFO = {
+    'broken': `{
+      "jest": {
+        "testMatch": ["match.js"
+      }
+    }`,
+    'withoutJest': `{
+    }`,
+    '.': `{
+      "jest": {
+        "testMatch": ["match.js"]
+      }
+    }`,
+    'withRootDir': `{
+      "jest": {
+        "rootDir": "testDir"
+      }
+    }`,
+  };
+
+  beforeEach(() => {
+    require('read-pkg').__setMockFiles(MOCK_FILE_INFO);
+  });
+
+  it('loads configuration from a `package.json` at `root`', async () => {
+    const {config} = await loadFromPackage('.', {});
+    expect(config.testMatch).toEqual(['match.js']);
+  });
+
+  it('returns a config object even if `jest` is not defined in `package.json`.', async () => {
+    const {config} = await loadFromPackage('withoutJest', {});
+    expect(config).toEqual(expect.anything());
+  });
+
+  it('returns null if the `package.json` at `root` cannot be parsed.', async () => {
+    const result = await loadFromPackage('broken', {});
+    expect(result).toBeNull();
+  });
+
+  it('resolves `rootDir` if defined.', async () => {
+    const {config} = await loadFromPackage('withRootDir', {});
+    expect(path.basename(config.rootDir)).toEqual('testDir');
+  });
+});

--- a/packages/jest-config/src/__tests__/loadFromPackage-test.js
+++ b/packages/jest-config/src/__tests__/loadFromPackage-test.js
@@ -15,17 +15,17 @@ const loadFromPackage = require('../loadFromPackage');
 
 describe('loadFromPackage', () => {
   const MOCK_FILE_INFO = {
+    '.': `{
+      "jest": {
+        "testMatch": ["match.js"]
+      }
+    }`,
     'broken': `{
       "jest": {
         "testMatch": ["match.js"
       }
     }`,
     'withoutJest': `{
-    }`,
-    '.': `{
-      "jest": {
-        "testMatch": ["match.js"]
-      }
     }`,
     'withRootDir': `{
       "jest": {

--- a/packages/jest-config/src/index.js
+++ b/packages/jest-config/src/index.js
@@ -46,7 +46,7 @@ const readRawConfig = (argv, root) => {
     return Promise.resolve(normalize(config, argv));
   }
 
-  return loadFromPackage(path.join(root, 'package.json'), argv)
+  return loadFromPackage(root, argv)
     .then(({config, hasDeprecationWarnings}) => {
       if (config) {
         return {

--- a/packages/jest-config/src/loadFromPackage.js
+++ b/packages/jest-config/src/loadFromPackage.js
@@ -12,18 +12,14 @@
 
 import type {Path} from 'types/Config';
 
-const fs = require('fs');
 const normalize = require('./normalize');
 const path = require('path');
-const promisify = require('./lib/promisify');
+const readPkg = require('read-pkg');
 
-function loadFromPackage(filePath: Path, argv: Object) {
-  return promisify(fs.access)(filePath, fs.R_OK).then(
-    () => {
-      // $FlowFixMe
-      const packageData = require(filePath);
+function loadFromPackage(root: Path, argv: Object) {
+  return readPkg(root).then(
+    (packageData) => {
       const config = packageData.jest || {};
-      const root = path.dirname(filePath);
       config.rootDir = config.rootDir
         ? path.resolve(root, config.rootDir)
         : root;

--- a/packages/jest-config/src/loadFromPackage.js
+++ b/packages/jest-config/src/loadFromPackage.js
@@ -18,7 +18,7 @@ const readPkg = require('read-pkg');
 
 function loadFromPackage(root: Path, argv: Object) {
   return readPkg(root).then(
-    (packageData) => {
+    packageData => {
       const config = packageData.jest || {};
       config.rootDir = config.rootDir
         ? path.resolve(root, config.rootDir)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Uses `read-pkg` to read `package.json` instead of `require`'ing `package.json` directly.  `read-pkg` is already in the dependency tree, (not specifically in `jest-config`'s, but the only packages that require `jest-config` are `jest-runtime`, `jest-cli`, and `ts-jest`, which also has `read-pkg` in its dependency tree) so it reduces code duplication.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
Writing tests for `loadFromPackage`
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
