### PR TITLE
[jest-resolve] Use `is-builtin-module` instead of `resolve.isCore`.

### DIFF
--- a/packages/jest-resolve/package.json
+++ b/packages/jest-resolve/package.json
@@ -9,6 +9,7 @@
   "main": "build/index.js",
   "dependencies": {
     "browser-resolve": "^1.11.2",
+    "is-builtin-module": "^1.0.0",
     "jest-haste-map": "^19.0.0",
     "resolve": "^1.2.0"
   }

--- a/packages/jest-resolve/src/__test__/resolve-test.js
+++ b/packages/jest-resolve/src/__test__/resolve-test.js
@@ -24,7 +24,7 @@ describe('isCoreModule', () => {
     expect(isCore).toEqual(false);
   });
 
-  it('returns true if `hasCoreModules` is false and `moduleName` is a core module.', () => {
+  it('returns true if `hasCoreModules` is true and `moduleName` is a core module.', () => {
     const moduleMap = new ModuleMap();
     const resolver = new Resolver(moduleMap, {
       browser: false,
@@ -33,7 +33,7 @@ describe('isCoreModule', () => {
     expect(isCore).toEqual(true);
   });
 
-  it('returns false if `hasCoreModules` is false and `moduleName` is not a core module.', () => {
+  it('returns false if `hasCoreModules` is true and `moduleName` is not a core module.', () => {
     const moduleMap = new ModuleMap();
     const resolver = new Resolver(moduleMap, {
       browser: false,

--- a/packages/jest-resolve/src/__test__/resolve-test.js
+++ b/packages/jest-resolve/src/__test__/resolve-test.js
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails oncall+jsinfra
+ */
+
+'use strict';
+
+const ModuleMap = require('jest-haste-map').ModuleMap;
+const Resolver = require('../');
+
+describe('isCoreModule', () => {
+  it('returns false if `hasCoreModules` is false.', () => {
+    const moduleMap = new ModuleMap();
+    const resolver = new Resolver(moduleMap, {
+      browser: false,
+      hasCoreModules: false,
+    });
+    const isCore = resolver.isCoreModule('assert');
+    expect(isCore).toEqual(false);
+  });
+
+  it('returns true if `hasCoreModules` is false and `moduleName` is a core module.', () => {
+    const moduleMap = new ModuleMap();
+    const resolver = new Resolver(moduleMap, {
+      browser: false,
+    });
+    const isCore = resolver.isCoreModule('assert');
+    expect(isCore).toEqual(true);
+  });
+
+  it('returns false if `hasCoreModules` is false and `moduleName` is not a core module.', () => {
+    const moduleMap = new ModuleMap();
+    const resolver = new Resolver(moduleMap, {
+      browser: false,
+    });
+    const isCore = resolver.isCoreModule('not-a-core-module');
+    expect(isCore).toEqual(false);
+  });
+});

--- a/packages/jest-resolve/src/__test__/resolve-test.js
+++ b/packages/jest-resolve/src/__test__/resolve-test.js
@@ -17,7 +17,6 @@ describe('isCoreModule', () => {
   it('returns false if `hasCoreModules` is false.', () => {
     const moduleMap = new ModuleMap();
     const resolver = new Resolver(moduleMap, {
-      browser: false,
       hasCoreModules: false,
     });
     const isCore = resolver.isCoreModule('assert');
@@ -26,18 +25,14 @@ describe('isCoreModule', () => {
 
   it('returns true if `hasCoreModules` is true and `moduleName` is a core module.', () => {
     const moduleMap = new ModuleMap();
-    const resolver = new Resolver(moduleMap, {
-      browser: false,
-    });
+    const resolver = new Resolver(moduleMap, {});
     const isCore = resolver.isCoreModule('assert');
     expect(isCore).toEqual(true);
   });
 
   it('returns false if `hasCoreModules` is true and `moduleName` is not a core module.', () => {
     const moduleMap = new ModuleMap();
-    const resolver = new Resolver(moduleMap, {
-      browser: false,
-    });
+    const resolver = new Resolver(moduleMap, {});
     const isCore = resolver.isCoreModule('not-a-core-module');
     expect(isCore).toEqual(false);
   });

--- a/packages/jest-resolve/src/index.js
+++ b/packages/jest-resolve/src/index.js
@@ -17,6 +17,7 @@ const nodeModulesPaths = require('resolve/lib/node-modules-paths');
 const path = require('path');
 const resolve = require('resolve');
 const browserResolve = require('browser-resolve');
+const isBuiltinModule = require('is-builtin-module');
 
 type ResolverConfig = {|
   browser?: boolean,
@@ -177,10 +178,7 @@ class Resolver {
   isCoreModule(moduleName: string): boolean {
     return (
       this._options.hasCoreModules &&
-      (
-        resolve.isCore(moduleName) ||
-        moduleName === 'v8'
-      )
+      isBuiltinModule(moduleName)
     );
   }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Uses `is-builtin-module` to determine if a module is a core module instead of `resolve.isCore`.  `resolve` is going away with #2925 and `is-builtin-module` is already in the dependency tree (not specifically of `jest-resolve`).
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
Write tests for `Resolver.isCore`.  
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
