### PR TITLE
Slight dangerfile tweak

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -94,8 +94,8 @@ const esModuleRegex = /^(import|export)\s(?!type(of\s|\s)(?!from)).*?$/gm;
 
 // Ensure the use of 'use strict' on all non-ES module files
 const noStrictFiles = newJsFiles.filter(filepath => {
-  const content = fs.readFileSync(filepath).toString();
-  return !esModuleRegex.test(content) && !includes(content, 'use strict');
+  const content = fs.readFileSync(filepath, 'utf8');
+  return !content.match(esModuleRegex) && !includes(content, 'use strict');
 });
 
 raiseIssueAboutPaths(fail, noStrictFiles, "'use strict'");


### PR DESCRIPTION
I tested the regex thoroughly, so I think it's just a matter of usage. Regex.test() has some weird semantics if its run over the same string twice... so switched to match() instead.

This is an extracted commit from https://github.com/facebook/jest/pull/2704