### PR TITLE
[jest-snapshot] Normalize line endings in `serialize` function

### DIFF
--- a/integration_tests/__tests__/__snapshots__/snapshot-test.js.snap
+++ b/integration_tests/__tests__/__snapshots__/snapshot-test.js.snap
@@ -2,8 +2,8 @@
 
 exports[`Snapshot Validation deletes a snapshot when a test does removes all the snapshots 1`] = `
 "Test Suites: 3 passed, 3 total
-Tests:       7 passed, 7 total
-Snapshots:   7 added, 7 total
+Tests:       9 passed, 9 total
+Snapshots:   9 added, 9 total
 Time:        <<REPLACED>>
 Ran all test suites.
 "
@@ -11,8 +11,8 @@ Ran all test suites.
 
 exports[`Snapshot Validation deletes a snapshot when a test does removes all the snapshots 2`] = `
 "Test Suites: 3 passed, 3 total
-Tests:       5 passed, 5 total
-Snapshots:   4 passed, 4 total
+Tests:       6 passed, 6 total
+Snapshots:   5 passed, 5 total
 Time:        <<REPLACED>>
 Ran all test suites.
 "
@@ -20,8 +20,8 @@ Ran all test suites.
 
 exports[`Snapshot Validation deletes the snapshot if the test suite has been removed 1`] = `
 "Test Suites: 3 passed, 3 total
-Tests:       7 passed, 7 total
-Snapshots:   7 added, 7 total
+Tests:       9 passed, 9 total
+Snapshots:   9 added, 9 total
 Time:        <<REPLACED>>
 Ran all test suites.
 "
@@ -29,8 +29,8 @@ Ran all test suites.
 
 exports[`Snapshot Validation deletes the snapshot if the test suite has been removed 2`] = `
 "Test Suites: 2 passed, 2 total
-Tests:       4 passed, 4 total
-Snapshots:   4 passed, 4 total
+Tests:       5 passed, 5 total
+Snapshots:   5 passed, 5 total
 Time:        <<REPLACED>>
 Ran all test suites.
 "
@@ -38,8 +38,8 @@ Ran all test suites.
 
 exports[`Snapshot Validation updates the snapshot when a test removes some snapshots 1`] = `
 "Test Suites: 3 passed, 3 total
-Tests:       7 passed, 7 total
-Snapshots:   7 added, 7 total
+Tests:       9 passed, 9 total
+Snapshots:   9 added, 9 total
 Time:        <<REPLACED>>
 Ran all test suites.
 "
@@ -47,8 +47,26 @@ Ran all test suites.
 
 exports[`Snapshot Validation updates the snapshot when a test removes some snapshots 2`] = `
 "Test Suites: 3 passed, 3 total
-Tests:       7 passed, 7 total
-Snapshots:   1 updated, 5 passed, 6 total
+Tests:       9 passed, 9 total
+Snapshots:   1 updated, 7 passed, 8 total
+Time:        <<REPLACED>>
+Ran all test suites.
+"
+`;
+
+exports[`Snapshot Validation works on subsequent runs without \`-u\` 1`] = `
+"Test Suites: 3 passed, 3 total
+Tests:       9 passed, 9 total
+Snapshots:   9 added, 9 total
+Time:        <<REPLACED>>
+Ran all test suites.
+"
+`;
+
+exports[`Snapshot Validation works on subsequent runs without \`-u\` 2`] = `
+"Test Suites: 3 passed, 3 total
+Tests:       9 passed, 9 total
+Snapshots:   9 passed, 9 total
 Time:        <<REPLACED>>
 Ran all test suites.
 "
@@ -56,8 +74,8 @@ Ran all test suites.
 
 exports[`Snapshot works as expected 1`] = `
 "Test Suites: 2 passed, 2 total
-Tests:       4 passed, 4 total
-Snapshots:   4 added, 4 total
+Tests:       5 passed, 5 total
+Snapshots:   5 added, 5 total
 Time:        <<REPLACED>>
 Ran all test suites.
 "

--- a/integration_tests/__tests__/snapshot-test.js
+++ b/integration_tests/__tests__/snapshot-test.js
@@ -95,8 +95,8 @@ describe('Snapshot', () => {
     const result = runJest.json('snapshot', []);
     const json = result.json;
 
-    expect(json.numTotalTests).toBe(4);
-    expect(json.numPassedTests).toBe(4);
+    expect(json.numTotalTests).toBe(5);
+    expect(json.numPassedTests).toBe(5);
     expect(json.numFailedTests).toBe(0);
     expect(json.numPendingTests).toBe(0);
     expect(result.status).toBe(0);
@@ -107,7 +107,7 @@ describe('Snapshot', () => {
     ).not.toBe(undefined);
 
     const info = result.stderr.toString();
-    expect(info).toMatch('4 snapshots written in 2 test suites');
+    expect(info).toMatch('5 snapshots written in 2 test suites');
     expect(extractSummary(info).summary).toMatchSnapshot();
   });
 
@@ -194,6 +194,25 @@ describe('Snapshot', () => {
       fs.writeFileSync(copyOfTestPath, originalTestContent);
     });
 
+    it('works on subsequent runs without `-u`', () => {
+      const firstRun = runJest.json('snapshot', []);
+
+      const content = require(snapshotOfCopy);
+      expect(content).not.toBe(undefined);
+      const secondRun = runJest.json('snapshot', []);
+
+      expect(firstRun.json.numTotalTests).toBe(9);
+      expect(secondRun.json.numTotalTests).toBe(9);
+      expect(secondRun.json.success).toBe(true);
+
+      const infoFR = firstRun.stderr.toString();
+      const infoSR = secondRun.stderr.toString();
+      expect(infoFR).toMatch('9 snapshots written in 3 test suites');
+      expect(infoSR).toMatch('9 passed, 9 total');
+      expect(extractSummary(infoFR).summary).toMatchSnapshot();
+      expect(extractSummary(infoSR).summary).toMatchSnapshot();
+    });
+
     it('deletes the snapshot if the test suite has been removed', () => {
       const firstRun = runJest.json('snapshot', []);
       fs.unlinkSync(copyOfTestPath);
@@ -202,13 +221,13 @@ describe('Snapshot', () => {
       expect(content).not.toBe(undefined);
       const secondRun = runJest.json('snapshot', ['-u']);
 
-      expect(firstRun.json.numTotalTests).toBe(7);
-      expect(secondRun.json.numTotalTests).toBe(4);
+      expect(firstRun.json.numTotalTests).toBe(9);
+      expect(secondRun.json.numTotalTests).toBe(5);
       expect(fileExists(snapshotOfCopy)).toBe(false);
 
       const infoFR = firstRun.stderr.toString();
       const infoSR = secondRun.stderr.toString();
-      expect(infoFR).toMatch('7 snapshots written in 3 test suites');
+      expect(infoFR).toMatch('9 snapshots written in 3 test suites');
       expect(infoSR).toMatch('1 obsolete snapshot file removed');
       expect(extractSummary(infoFR).summary).toMatchSnapshot();
       expect(extractSummary(infoSR).summary).toMatchSnapshot();
@@ -221,13 +240,13 @@ describe('Snapshot', () => {
       const secondRun = runJest.json('snapshot', ['-u']);
       fs.unlinkSync(copyOfTestPath);
 
-      expect(firstRun.json.numTotalTests).toBe(7);
-      expect(secondRun.json.numTotalTests).toBe(5);
+      expect(firstRun.json.numTotalTests).toBe(9);
+      expect(secondRun.json.numTotalTests).toBe(6);
 
       expect(fileExists(snapshotOfCopy)).toBe(false);
       const infoFR = firstRun.stderr.toString();
       const infoSR = secondRun.stderr.toString();
-      expect(infoFR).toMatch('7 snapshots written in 3 test suites');
+      expect(infoFR).toMatch('9 snapshots written in 3 test suites');
       expect(infoSR).toMatch('1 obsolete snapshot file removed');
       expect(extractSummary(infoFR).summary).toMatchSnapshot();
       expect(extractSummary(infoSR).summary).toMatchSnapshot();
@@ -246,8 +265,8 @@ describe('Snapshot', () => {
       const secondRun = runJest.json('snapshot', ['-u']);
       fs.unlinkSync(copyOfTestPath);
 
-      expect(firstRun.json.numTotalTests).toBe(7);
-      expect(secondRun.json.numTotalTests).toBe(7);
+      expect(firstRun.json.numTotalTests).toBe(9);
+      expect(secondRun.json.numTotalTests).toBe(9);
       expect(fileExists(snapshotOfCopy)).toBe(true);
       const afterRemovingSnapshot = getSnapshotOfCopy();
 
@@ -268,7 +287,7 @@ describe('Snapshot', () => {
 
       const infoFR = firstRun.stderr.toString();
       const infoSR = secondRun.stderr.toString();
-      expect(infoFR).toMatch('7 snapshots written in 3 test suites');
+      expect(infoFR).toMatch('9 snapshots written in 3 test suites');
       expect(extractSummary(infoFR).summary).toMatchSnapshot();
       expect(infoSR).toMatch('1 snapshot updated in 1 test suite');
       expect(infoSR).toMatch('1 obsolete snapshot removed');

--- a/integration_tests/snapshot/__tests__/snapshot-test.js
+++ b/integration_tests/snapshot/__tests__/snapshot-test.js
@@ -36,4 +36,9 @@ describe('snapshot', () => {
       'Jest: `.not` cannot be used with `.toMatchSnapshot()`.'
     );
   });
+
+  // Issue reported here: https://github.com/facebook/jest/issues/2969
+  it('works with \\r\\n', () => {
+    expect('<div>\r\n</div>').toMatchSnapshot();
+  });
 });

--- a/packages/jest-snapshot/src/__tests__/utils-test.js
+++ b/packages/jest-snapshot/src/__tests__/utils-test.js
@@ -13,6 +13,7 @@ const {
   getSnapshotPath,
   keyToTestName,
   saveSnapshotFile,
+  serialize,
   testNameToKey,
   SNAPSHOT_GUIDE_LINK,
   SNAPSHOT_VERSION,
@@ -194,4 +195,12 @@ test('escaping', () => {
   expect(readData).toEqual({key: data});
   const snapshotData = readData.key;
   expect(data).toEqual(snapshotData);
+});
+
+test('serialize handles \\r\\n', () => {
+  const data = '<div>\r\n</div>';
+  const serializedData = serialize(data);
+
+  expect(serializedData)
+    .toBe('\n\"<div>\n</div>\"\n');
 });

--- a/packages/jest-snapshot/src/utils.js
+++ b/packages/jest-snapshot/src/utils.js
@@ -133,11 +133,13 @@ const addExtraLineBreaks =
   string => string.includes('\n') ? `\n${string}\n` : string;
 
 const serialize = (data: any): string => {
-  return addExtraLineBreaks(prettyFormat(data, {
-    escapeRegex: true,
-    plugins: getSerializers(),
-    printFunctionName: false,
-  }));
+  return addExtraLineBreaks(normalizeNewlines(
+    prettyFormat(data, {
+      escapeRegex: true,
+      plugins: getSerializers(),
+      printFunctionName: false,
+    })
+  ));
 };
 
 const unescape = (data: any): string =>


### PR DESCRIPTION
**Summary**

This fixes #2969. When snapshot data is saved, it normalizes `\r\n` to `\n`, but on next runs when it receives the new snapshot data and serializes it, this normalization doesn't happen, so tests would fail without any changes to the data being snapshot tested.

**Test plan**

All tests pass and subsequent runs of snapshot tests containing `\r\n` will not fail without changes.
