### PR TITLE
Fix behavior of `--silent` flag

### DIFF
--- a/integration_tests/__tests__/__snapshots__/console-test.js.snap
+++ b/integration_tests/__tests__/__snapshots__/console-test.js.snap
@@ -57,3 +57,20 @@ Time:        <<REPLACED>>
 Ran all test suites.
 "
 `;
+
+exports[`does not print to console with --silent 1`] = `""`;
+
+exports[`does not print to console with --silent 2`] = `
+" PASS  __tests__/console-test.js
+
+"
+`;
+
+exports[`does not print to console with --silent 3`] = `
+"Test Suites: 1 passed, 1 total
+Tests:       1 passed, 1 total
+Snapshots:   0 total
+Time:        <<REPLACED>>
+Ran all test suites.
+"
+`;

--- a/integration_tests/__tests__/console-test.js
+++ b/integration_tests/__tests__/console-test.js
@@ -34,3 +34,21 @@ test('console printing with --verbose', () => {
   expect(rest).toMatchSnapshot();
   expect(summary).toMatchSnapshot();
 });
+
+test('does not print to console with --silent', () => {
+  const {stderr, stdout, status} =
+    runJest('console', [
+      // Need to pass --config because console test specifies `verbose: false`
+      '--config=' + JSON.stringify({
+        testEnvironment: 'node',
+      }),
+      '--silent',
+      '--no-cache',
+    ]);
+  const {summary, rest} = extractSummary(stderr);
+
+  expect(status).toBe(0);
+  expect(stdout).toMatchSnapshot();
+  expect(rest).toMatchSnapshot();
+  expect(summary).toMatchSnapshot();
+});

--- a/packages/jest-cli/src/runJest.js
+++ b/packages/jest-cli/src/runJest.js
@@ -86,9 +86,11 @@ const runJest = (
         }
         return data;
       }).then(data => {
-        if (data.paths.length === 1 && config.verbose !== false) {
-          // $FlowFixMe
-          config = Object.assign({}, config, {verbose: true});
+        if (data.paths.length === 1) {
+          if (config.silent !== true && config.verbose !== false) {
+            // $FlowFixMe
+            config = Object.assign({}, config, {verbose: true});
+          }
         }
 
         return new TestRunner(


### PR DESCRIPTION
**Summary**

This fixes #2987. The issue was if `verbose` option wasn't specifically set to `false`, then it would be set to `true`, so when jest was determining which `Console` class to use, it would always go into the truth part of the first ternary.

```js
  const TestConsole =
    config.verbose
      ? Console
      : (config.silent
        ? NullConsole
        : BufferedConsole
      );
```

This fix makes sure we didn't explicitly set `silent: true` before changing the value of `verbose`.

**Test plan**

All tests pass and `verbose` is no longer set to `true` when `silent` is passed.
