### PR TITLE
check for forceExit in the config

### DIFF
--- a/packages/jest-cli/src/cli/index.js
+++ b/packages/jest-cli/src/cli/index.js
@@ -15,6 +15,7 @@ import type {Path} from 'types/Config';
 const args = require('./args');
 const getJest = require('./getJest');
 const getPackageRoot = require('jest-util').getPackageRoot;
+const path = require('path');
 const validateCLIOptions = require('jest-util').validateCLIOptions;
 const yargs = require('yargs');
 
@@ -42,7 +43,9 @@ function run(argv?: Object, root?: Path) {
   getJest(root).runCLI(argv, root, result => {
     const code = !result || result.success ? 0 : 1;
     process.on('exit', () => process.exit(code));
-    if (argv && argv.forceExit) {
+    const packageJSONPath = path.join(root, 'package.json');
+    const packageJSON = require(packageJSONPath);
+    if (argv && argv.forceExit || packageJSON.jest && packageJSON.jest.forceExit) {
       process.exit(code);
     }
   });

--- a/packages/jest-cli/src/cli/index.js
+++ b/packages/jest-cli/src/cli/index.js
@@ -43,9 +43,11 @@ function run(argv?: Object, root?: Path) {
   getJest(root).runCLI(argv, root, result => {
     const code = !result || result.success ? 0 : 1;
     process.on('exit', () => process.exit(code));
-    const packageJSONPath = path.join(root, 'package.json');
+    const packageJSONPath = path.join(root || __dirname, 'package.json');
+    /* $FlowFixMe */
     const packageJSON = require(packageJSONPath);
-    if (argv && argv.forceExit || packageJSON.jest && packageJSON.jest.forceExit) {
+    if (argv && argv.forceExit ||
+      packageJSON.jest && packageJSON.jest.forceExit) {
       process.exit(code);
     }
   });


### PR DESCRIPTION
**Summary**

Problem
- You want to run a single test suite. The test needs a `forceExit`. In fact, all your tests need that. So, you use the CLI `jest fooTest --forceExit`. Now you don't have to waste your life typing `--forceExit` every single time.

**Test plan**

Open up a DB connection pool in a test.
Then run `jest`.
Watch how the process stays alive.
Now merge the PR.
add `"forceClose": true` to the package.json jest config object 
Watch how the process dies.
