### PR TITLE
testMatch should find tests in .folders

### DIFF
--- a/packages/jest-cli/src/SearchSource.js
+++ b/packages/jest-cli/src/SearchSource.js
@@ -77,7 +77,7 @@ const globsToMatcher = (globs: ?Array<Glob>) => {
     return () => true;
   }
 
-  const matchers = globs.map(each => micromatch.matcher(each));
+  const matchers = globs.map(each => micromatch.matcher(each, {dot: true}));
   return (path: Path) => matchers.some(each => each(path));
 };
 

--- a/packages/jest-cli/src/__tests__/SearchSource-test.js
+++ b/packages/jest-cli/src/__tests__/SearchSource-test.js
@@ -108,11 +108,11 @@ describe('SearchSource', () => {
       return findMatchingTests(config).then(data => {
         const relPaths = data.paths.map(absPath => (
           path.relative(rootDir, absPath)
-        ));
+        )).sort();
         expect(relPaths).toEqual([
           path.normalize('.hiddenFolder/not-really-a-test.txt'),
           path.normalize('__testtests__/not-really-a-test.txt'),
-        ]);
+        ].sort());
       });
     });
 
@@ -127,11 +127,11 @@ describe('SearchSource', () => {
       return findMatchingTests(config).then(data => {
         const relPaths = data.paths.map(absPath => (
           path.relative(rootDir, absPath)
-        ));
+        )).sort();
         expect(relPaths).toEqual([
           path.normalize('.hiddenFolder/not-really-a-test.txt'),
           path.normalize('__testtests__/not-really-a-test.txt'),
-        ]);
+        ].sort());
       });
     });
 

--- a/packages/jest-cli/src/__tests__/SearchSource-test.js
+++ b/packages/jest-cli/src/__tests__/SearchSource-test.js
@@ -110,6 +110,7 @@ describe('SearchSource', () => {
           path.relative(rootDir, absPath)
         ));
         expect(relPaths).toEqual([
+          path.normalize('.hiddenFolder/not-really-a-test.txt'),
           path.normalize('__testtests__/not-really-a-test.txt'),
         ]);
       });
@@ -128,6 +129,7 @@ describe('SearchSource', () => {
           path.relative(rootDir, absPath)
         ));
         expect(relPaths).toEqual([
+          path.normalize('.hiddenFolder/not-really-a-test.txt'),
           path.normalize('__testtests__/not-really-a-test.txt'),
         ]);
       });

--- a/packages/jest-cli/src/__tests__/test_root/.hiddenFolder/not-really-a-test.txt
+++ b/packages/jest-cli/src/__tests__/test_root/.hiddenFolder/not-really-a-test.txt
@@ -1,0 +1,3 @@
+// not-really-a-test.txt
+
+require('../module.txt');


### PR DESCRIPTION
**Summary**

When a test is inside a folder that's name starts with `.`, they are ignored by `testMatch` but are correctly found by `testRegex`. It's even more obscure if the entire project is checked out below a dot-folder, in which case *all* tests are ignored by `testMatch` which is now the default way of finding tests.

**Test plan**

`yarn test`
