### PR TITLE
findRelatedTests option doesn't use a `=`

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -71,9 +71,9 @@ The test environment used for all tests. This can point to any file or node modu
 
 Alias: `-e`. Use this flag to show full diffs instead of a patch.
 
-### `--findRelatedTests=<listOfSourceFiles>`
+### `--findRelatedTests <spaceSeparatedListOfSourceFiles>`
 
-Find the tests that cover a list of source files that were passed in as arguments. Useful for pre-commit hook integration to run the minimal amount of tests necessary.
+Find and run the tests that cover a space separated list of source files that were passed in as arguments. Useful for pre-commit hook integration to run the minimal amount of tests necessary.
 
 ### `--forceExit`
 


### PR DESCRIPTION
**Summary**

The documentation incorrectly stated that the `--findRelatedTests` cli option expected an `=` before the list of files.  It does not, and this corrects that documentation

**Test plan**

No testing necessary, documentation only.  However, it would likely be good to provide a usage example for this somewhere in the docs.  It took me a while to figure out what the usage was between the following:

```
jest --findRelatedTests='foo.bar, foo.baz'
jest --findRelatedTests='foo.bar foo.baz'
jest --findRelatedTests 'foo.bar, foo.baz'
jest --findRelatedTests 'foo.bar foo.baz'
jest --findRelatedTests foo.bar foo.baz
```

Admittedly, that was mostly due to the misleading doc.  
