### PR TITLE
pretty-format should run plugins before serializing nested basic values

### DIFF
--- a/packages/pretty-format/src/__tests__/pretty-format-test.js
+++ b/packages/pretty-format/src/__tests__/pretty-format-test.js
@@ -317,6 +317,20 @@ describe('prettyFormat()', () => {
     })).toEqual('1 - 2 - 3 - 4');
   });
 
+  it('should call plugins on nested basic values', () => {
+    const val = {prop: 42};
+    expect(prettyFormat(val, {
+      plugins: [{
+        print(val, print) {
+          return '[called]';
+        },
+        test(val) {
+          return typeof val === 'string' || typeof val === 'number';
+        },
+      }],
+    })).toEqual('Object {\n  [called]: [called],\n}');
+  });
+
   it('prints objects with no constructor', () => {
     expect(prettyFormat(Object.create(null))).toEqual('Object {}');
   });

--- a/packages/pretty-format/src/index.js
+++ b/packages/pretty-format/src/index.js
@@ -317,14 +317,14 @@ function printPlugin(val, indent, prevIndent, spacing, edgeSpacing, refs, maxDep
 }
 
 function print(val, indent, prevIndent, spacing, edgeSpacing, refs, maxDepth, currentDepth, plugins, min, callToJSON, printFunctionName, escapeRegex, colors) {
-  const basic = printBasicValue(val, printFunctionName, escapeRegex);
-  if (basic) {
-    return basic;
-  }
-
   const plugin = printPlugin(val, indent, prevIndent, spacing, edgeSpacing, refs, maxDepth, currentDepth, plugins, min, callToJSON, printFunctionName, escapeRegex, colors);
   if (plugin) {
     return plugin;
+  }
+
+  const basic = printBasicValue(val, printFunctionName, escapeRegex);
+  if (basic) {
+    return basic;
   }
 
   return printComplexValue(val, indent, prevIndent, spacing, edgeSpacing, refs, maxDepth, currentDepth, plugins, min, callToJSON, printFunctionName, escapeRegex, colors);


### PR DESCRIPTION
Pulling out from #3007