### PR TITLE
Throw if actual value of toThrowMatchers is not a function

### DIFF
--- a/packages/jest-matchers/src/__tests__/__snapshots__/toThrowMatchers-test.js.snap
+++ b/packages/jest-matchers/src/__tests__/__snapshots__/toThrowMatchers-test.js.snap
@@ -28,6 +28,12 @@ Instead, it threw:
       [2mat jestExpect ([22mpackages/jest-matchers/src/__tests__/toThrowMatchers-test.js[2m:24:74)[22m[39m"
 `;
 
+exports[`.toThrow() invalid actual 1`] = `
+"[2mexpect([22m[31mfunction[39m[2m).toThrow([22m[32mundefined[39m[2m)[22m
+
+Expected the matcher to call a function, but instead \\"string\\" was found"
+`;
+
 exports[`.toThrow() invalid arguments 1`] = `
 "[2mexpect([22m[31mfunction[39m[2m).not.toThrow([22m[32mnumber[39m[2m)[22m
 
@@ -119,6 +125,12 @@ Expected the function not to throw an error of type:
 Instead, it threw:
 [31m  Error      
       [2mat jestExpect ([22mpackages/jest-matchers/src/__tests__/toThrowMatchers-test.js[2m:24:74)[22m[39m"
+`;
+
+exports[`.toThrowError() invalid actual 1`] = `
+"[2mexpect([22m[31mfunction[39m[2m).toThrowError([22m[32mundefined[39m[2m)[22m
+
+Expected the matcher to call a function, but instead \\"string\\" was found"
 `;
 
 exports[`.toThrowError() invalid arguments 1`] = `

--- a/packages/jest-matchers/src/__tests__/__snapshots__/toThrowMatchers-test.js.snap
+++ b/packages/jest-matchers/src/__tests__/__snapshots__/toThrowMatchers-test.js.snap
@@ -31,7 +31,7 @@ Instead, it threw:
 exports[`.toThrow() invalid actual 1`] = `
 "[2mexpect([22m[31mfunction[39m[2m).toThrow([22m[32mundefined[39m[2m)[22m
 
-Expected the matcher to call a function, but instead \\"string\\" was found"
+Received value must be a function, but instead \\"string\\" was found"
 `;
 
 exports[`.toThrow() invalid arguments 1`] = `
@@ -130,7 +130,7 @@ Instead, it threw:
 exports[`.toThrowError() invalid actual 1`] = `
 "[2mexpect([22m[31mfunction[39m[2m).toThrowError([22m[32mundefined[39m[2m)[22m
 
-Expected the matcher to call a function, but instead \\"string\\" was found"
+Received value must be a function, but instead \\"string\\" was found"
 `;
 
 exports[`.toThrowError() invalid arguments 1`] = `

--- a/packages/jest-matchers/src/__tests__/toThrowMatchers-test.js
+++ b/packages/jest-matchers/src/__tests__/toThrowMatchers-test.js
@@ -140,6 +140,11 @@ class Error {
       expect(() => jestExpect(() => {})[toThrow](111))
         .toThrowErrorMatchingSnapshot();
     });
+
+    test('invalid actual', () => {
+      expect(() => jestExpect('a string')[toThrow]())
+        .toThrowErrorMatchingSnapshot();
+    });
   });
 
 });

--- a/packages/jest-matchers/src/toThrowMatchers.js
+++ b/packages/jest-matchers/src/toThrowMatchers.js
@@ -42,7 +42,7 @@ const createMatcher = matcherName =>
       throw new Error(
         matcherHint(matcherName, 'function', getType(value)) +
           '\n\n' +
-          'Expected the matcher to call a function, but instead ' +
+          'Received value must be a function, but instead ' +
           `"${getType(actual)}" was found`
       );
     }

--- a/packages/jest-matchers/src/toThrowMatchers.js
+++ b/packages/jest-matchers/src/toThrowMatchers.js
@@ -38,6 +38,10 @@ const createMatcher = matcherName =>
     const value = expected;
     let error;
 
+    if (typeof actual !== 'function') {
+      throw createNotAFunctionError(matcherName, value, actual);
+    }
+
     try {
       actual();
     } catch (e) {
@@ -79,6 +83,15 @@ const createMatcher = matcherName =>
 const matchers: MatchersObject = {
   toThrow: createMatcher('.toThrow'),
   toThrowError: createMatcher('.toThrowError'),
+};
+
+const createNotAFunctionError = (matcherName, value, actual) => {
+  return new Error(
+    matcherHint(matcherName, 'function', getType(value)) +
+      '\n\n' +
+      'Expected the matcher to call a function, but instead ' +
+      `"${getType(actual)}" was found`
+  );
 };
 
 const toThrowMatchingStringOrRegexp = (

--- a/packages/jest-matchers/src/toThrowMatchers.js
+++ b/packages/jest-matchers/src/toThrowMatchers.js
@@ -39,7 +39,12 @@ const createMatcher = matcherName =>
     let error;
 
     if (typeof actual !== 'function') {
-      throw createNotAFunctionError(matcherName, value, actual);
+      throw new Error(
+        matcherHint(matcherName, 'function', getType(value)) +
+          '\n\n' +
+          'Expected the matcher to call a function, but instead ' +
+          `"${getType(actual)}" was found`
+      );
     }
 
     try {
@@ -83,15 +88,6 @@ const createMatcher = matcherName =>
 const matchers: MatchersObject = {
   toThrow: createMatcher('.toThrow'),
   toThrowError: createMatcher('.toThrowError'),
-};
-
-const createNotAFunctionError = (matcherName, value, actual) => {
-  return new Error(
-    matcherHint(matcherName, 'function', getType(value)) +
-      '\n\n' +
-      'Expected the matcher to call a function, but instead ' +
-      `"${getType(actual)}" was found`
-  );
 };
 
 const toThrowMatchingStringOrRegexp = (


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Fixes #2946.
We should warn if an `actual` value of any of `toThrowMatchers` is not a function, as `toThrow()` matcher can pass a supposed-to-be-failing test because of Jest's internal error (in the issue attached it's a TypeError when trying to call `actual()` on a string).

Here's a screenshot of what it looks like:

<img width="546" alt="screen shot 2017-02-27 at 22 09 32" src="https://cloud.githubusercontent.com/assets/5106466/23380017/763f56ac-fd39-11e6-8287-4986ad8dd457.png">

**Test plan**

jest
