### PR TITLE
change error message to ensureActualIsNumber

### DIFF
--- a/packages/jest-matcher-utils/src/index.js
+++ b/packages/jest-matcher-utils/src/index.js
@@ -153,7 +153,7 @@ const ensureActualIsNumber = (actual: any, matcherName: string) => {
   if (typeof actual !== 'number') {
     throw new Error(
       matcherHint('[.not]' + matcherName) + '\n\n' +
-      `Actual value must be a number.\n` +
+      `Received value must be a number.\n` +
       printWithType('Received', actual, printReceived),
     );
   }


### PR DESCRIPTION
**Summary**

Fixes #3020 

**Test plan**
Given
```javascript
it('test .toBeGreaterThan message', () => {
  expect("222").toBeGreaterThan(344444)
})
```
It prints
![image](https://cloud.githubusercontent.com/assets/1692542/23384364/701c1204-fcff-11e6-96b1-a637203d1d24.png)

