### PR TITLE
Fix snapshot tests on Windows.

### DIFF
--- a/packages/jest-cli/src/lib/highlight.js
+++ b/packages/jest-cli/src/lib/highlight.js
@@ -50,7 +50,6 @@ const highlight = (
     offset = rawPath.length - filePath.length;
     trimLength = relativePathHead.length;
   } else {
-    // Will always be `rootDir.length` + 1.
     offset = rootDir.length + path.sep.length;
     trimLength = 0;
   }

--- a/packages/jest-cli/src/lib/highlight.js
+++ b/packages/jest-cli/src/lib/highlight.js
@@ -15,7 +15,7 @@ const path = require('path');
 const colorize = require('./colorize');
 
 const trim = '...';
-const relativePathHead = `.${path.sep}`;
+const relativePathHead = './';
 
 const highlight = (
   rawPath: string,
@@ -50,6 +50,7 @@ const highlight = (
     offset = rawPath.length - filePath.length;
     trimLength = relativePathHead.length;
   } else {
+    // Will always be `rootDir.length` + 1.
     offset = rootDir.length + path.sep.length;
     trimLength = 0;
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Makes `relativePathHead` always be `./` instead of `.\\` on Windows.  Since `filePath` [is already normalized](https://github.com/facebook/jest/blob/master/packages/jest-cli/src/reporters/utils.js), it will never be `.\\`.  This was what was causing snapshot tests to fail on Windows.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
Nothing should change.
Look at [the AppVeyor output of another PR](https://ci.appveyor.com/project/Daniel15/jest/build/2305#L435) and see that 2 snapshots are being updated.  The AppVeyor output for this PR should have 0.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
