### PR TITLE
Throw errors with descriptive message about theme option of pretty-fo…

### DIFF
--- a/packages/pretty-format/src/__tests__/__snapshots__/pretty-format-test.js.snap
+++ b/packages/pretty-format/src/__tests__/__snapshots__/pretty-format-test.js.snap
@@ -13,6 +13,14 @@ exports[`prettyFormat() ReactTestComponent and ReactElement plugins ReactElement
 />[39m"
 `;
 
+exports[`prettyFormat() ReactTestComponent and ReactElement plugins ReactElement plugin highlights syntax with color from theme option 1`] = `
+"[36m<Mouse[39m
+  [33mstyle[39m=[31m\\"color:red\\"[39m[36m
+>[39m
+  [0mHello, Mouse![0m
+[36m</Mouse>[39m"
+`;
+
 exports[`prettyFormat() ReactTestComponent and ReactElement plugins ReactTestComponent plugin highlights syntax 1`] = `
 "[36m<Mouse[39m
   [33mprop[39m=[32m{
@@ -24,4 +32,12 @@ exports[`prettyFormat() ReactTestComponent and ReactElement plugins ReactTestCom
     [36m</div>[39m
   }[39m[36m
 />[39m"
+`;
+
+exports[`prettyFormat() ReactTestComponent and ReactElement plugins ReactTestComponent plugin highlights syntax with color from theme option 1`] = `
+"[36m<Mouse[39m
+  [33mstyle[39m=[31m\\"color:red\\"[39m[36m
+>[39m
+  [0mHello, Mouse![0m
+[36m</Mouse>[39m"
 `;

--- a/packages/pretty-format/src/__tests__/pretty-format-test.js
+++ b/packages/pretty-format/src/__tests__/pretty-format-test.js
@@ -661,5 +661,69 @@ describe('prettyFormat()', () => {
         })
       ).toMatchSnapshot();
     });
+
+    it('throws if theme option is null', () => {
+      const jsx = React.createElement('Mouse', {style: 'color:red'}, 'Hello, Mouse!');
+      expect(() => {
+        prettyFormat(jsx, {
+          highlight: true,
+          plugins: [ReactElement],
+          theme: null,
+        });
+      }).toThrow('pretty-format: Option "theme" must not be null');
+    });
+
+    it('throws if theme option is not of type "object"', () => {
+      expect(() => {
+        const jsx = React.createElement('Mouse', {style: 'color:red'}, 'Hello, Mouse!');
+        prettyFormat(jsx, {
+          highlight: true,
+          plugins: [ReactElement],
+          theme: 'beautiful',
+        });
+      }).toThrow('pretty-format: Option "theme" must be of type object but instead received string');
+    });
+
+    it('throws if theme option has value that is undefined in ansi-styles', () => {
+      expect(() => {
+        const jsx = React.createElement('Mouse', {style: 'color:red'}, 'Hello, Mouse!');
+        prettyFormat(jsx, {
+          highlight: true,
+          plugins: [ReactElement],
+          theme: {
+            content: 'unknown',
+            prop: 'yellow',
+            tag: 'cyan',
+            value: 'green',
+          },
+        });
+      }).toThrow('pretty-format: Option "theme" has a key "content" whose value "unknown" is undefined in ansi-styles');
+    });
+
+    it('ReactElement plugin highlights syntax with color from theme option', () => {
+      const jsx = React.createElement('Mouse', {style: 'color:red'}, 'Hello, Mouse!');
+      expect(
+        prettyFormat(jsx, {
+          highlight: true,
+          plugins: [ReactElement],
+          theme: {
+            value: 'red',
+          },
+        })
+      ).toMatchSnapshot();
+    });
+
+    it('ReactTestComponent plugin highlights syntax with color from theme option', () => {
+      const jsx = React.createElement('Mouse', {style: 'color:red'}, 'Hello, Mouse!');
+      expect(
+        prettyFormat(renderer.create(jsx).toJSON(), {
+          highlight: true,
+          plugins: [ReactTestComponent, ReactElement],
+          theme: {
+            value: 'red',
+          },
+        })
+      ).toMatchSnapshot();
+    });
   });
 });

--- a/packages/pretty-format/src/__tests__/pretty-format-test.js
+++ b/packages/pretty-format/src/__tests__/pretty-format-test.js
@@ -670,7 +670,7 @@ describe('prettyFormat()', () => {
           plugins: [ReactElement],
           theme: null,
         });
-      }).toThrow('pretty-format: Option "theme" must not be null');
+      }).toThrow('pretty-format: Option "theme" must not be null.');
     });
 
     it('throws if theme option is not of type "object"', () => {
@@ -681,7 +681,7 @@ describe('prettyFormat()', () => {
           plugins: [ReactElement],
           theme: 'beautiful',
         });
-      }).toThrow('pretty-format: Option "theme" must be of type object but instead received string');
+      }).toThrow('pretty-format: Option "theme" must be of type "object" but instead received "string".');
     });
 
     it('throws if theme option has value that is undefined in ansi-styles', () => {
@@ -697,7 +697,7 @@ describe('prettyFormat()', () => {
             value: 'green',
           },
         });
-      }).toThrow('pretty-format: Option "theme" has a key "content" whose value "unknown" is undefined in ansi-styles');
+      }).toThrow('pretty-format: Option "theme" has a key "content" whose value "unknown" is undefined in ansi-styles.');
     });
 
     it('ReactElement plugin highlights syntax with color from theme option', () => {

--- a/packages/pretty-format/src/index.js
+++ b/packages/pretty-format/src/index.js
@@ -353,10 +353,10 @@ type InitialOptions = {|
   plugins?: Plugins,
   printFunctionName?: boolean,
   theme?: {
-    content: string,
-    prop: string,
-    tag: string,
-    value: string,
+    content?: string,
+    prop?: string,
+    tag?: string,
+    value?: string,
   },
 |};
 
@@ -397,32 +397,13 @@ const DEFAULTS: Options = {
 function validateOptions(opts: InitialOptions) {
   Object.keys(opts).forEach(key => {
     if (!DEFAULTS.hasOwnProperty(key)) {
-      throw new Error(`pretty-format: Unknown option "${key}"`);
+      throw new Error(`pretty-format: Unknown option "${key}".`);
     }
   });
 
   if (opts.min && opts.indent !== undefined && opts.indent !== 0) {
-    throw new Error('pretty-format: Options "min" and "indent" cannot be used together');
+    throw new Error('pretty-format: Options "min" and "indent" cannot be used together.');
   }
-}
-
-function normalizeTheme(themeOption: mixed) {
-  if (themeOption === null) {
-    throw new Error(`pretty-format: Option "theme" must not be null`);
-  }
-  if (typeof themeOption !== 'object') {
-    throw new Error(`pretty-format: Option "theme" must be of type object but instead received ${typeof themeOption}`);
-  }
-
-  const themeDefaults = DEFAULTS.theme;
-  return Object.keys(themeDefaults).reduce((theme, key) => {
-    // $FlowFixMe Method cannot be called on mixed
-    theme[key] = themeOption.hasOwnProperty(key)
-      // $FlowFixMe Computed property/element cannot be accessed on mixed
-      ? themeOption[key]
-      : themeDefaults[key];
-    return theme;
-  }, {});
 }
 
 function normalizeOptions(opts: InitialOptions): Options {
@@ -447,6 +428,26 @@ function normalizeOptions(opts: InitialOptions): Options {
   return (result: Options);
 }
 
+function normalizeTheme(themeOption: ?Object) {
+  if (themeOption === null) {
+    throw new Error(`pretty-format: Option "theme" must not be null.`);
+  }
+  if (typeof themeOption !== 'object') {
+    throw new Error(`pretty-format: Option "theme" must be of type "object" but instead received "${typeof themeOption}".`);
+  }
+
+  // Silently ignore any keys in `theme` that are not in defaults.
+  const themeDefaults = DEFAULTS.theme;
+  return Object.keys(themeDefaults).reduce((theme, key) => {
+    // Avoid Flow error Method cannot be called on possibly null or undefined value
+    theme[key] = Object.prototype.hasOwnProperty.call(themeOption, key)
+      // $FlowFixMe Computed property/element cannot be accessed on mixed
+      ? themeOption[key]
+      : themeDefaults[key];
+    return theme;
+  }, {});
+}
+
 function createIndent(indent: number): string {
   return new Array(indent + 1).join(' ');
 }
@@ -465,7 +466,7 @@ function prettyFormat(val: any, initialOptions?: InitialOptions): string {
     if (opts.highlight) {
       const color = colors[key] = style[opts.theme[key]];
       if (!color || typeof color.close !== 'string' || typeof color.open !== 'string') {
-        throw new Error(`pretty-format: Option "theme" has a key "${key}" whose value "${opts.theme[key]}" is undefined in ansi-styles`);
+        throw new Error(`pretty-format: Option "theme" has a key "${key}" whose value "${opts.theme[key]}" is undefined in ansi-styles.`);
       }
     } else {
       colors[key] = {close: '', open: ''};

--- a/packages/pretty-format/src/index.js
+++ b/packages/pretty-format/src/index.js
@@ -417,12 +417,12 @@ function normalizeTheme(themeOption: mixed) {
   const themeDefaults = DEFAULTS.theme;
   return Object.keys(themeDefaults).reduce((theme, key) => {
     // $FlowFixMe Method cannot be called on mixed
-    if (themeOption.hasOwnProperty(key)) {
+    theme[key] = themeOption.hasOwnProperty(key)
       // $FlowFixMe Computed property/element cannot be accessed on mixed
-      theme[key] = themeOption[key];
-    }
+      ? themeOption[key]
+      : themeDefaults[key];
     return theme;
-  }, Object.assign({}, themeDefaults)); // override a copy of default theme
+  }, {});
 }
 
 function normalizeOptions(opts: InitialOptions): Options {


### PR DESCRIPTION
**Summary**

One more thing: make the code support the Flow type. This `theme` has 3 variations.

* If the `theme` option isn’t an **object**:

  ```js
  pretty(element, {
    highlight: true,
    plugins: [ReactElement],
    theme: null,
  }); // TypeError: Cannot convert undefined or null to object at Function.keys

  pretty(element, {
    highlight: true,
    plugins: [ReactElement],
    theme: 'beautiful',
  }); // TypeError: Cannot read property 'open' of undefined
  ```

* If the `theme` option doesn’t specify **all properties**:

  ```js
  pretty(element, {
    highlight: true,
    plugins: [ReactElement],
    theme: {
      value: 'red',
    },
  }); // TypeError: Cannot read property 'open' of undefined
  ```

* If the `theme` option specifies a value that’s **undefined in ansi-styles**:

  ```js
  pretty(element, {
    highlight: true,
    plugins: [ReactElement],
    theme: {
      content: 'unknown',
      prop: 'yellow',
      tag: 'cyan',
      value: 'green',
    },
  }); // TypeError: Cannot read property 'open' of undefined
  ```

Solutions:

* descriptive message if the `theme` option is `null` or isn’t of type `"object"`
* instead of replace defaults, **override** them with properties from `theme` option
* descriptive message if a value is undefined in `ansi-styles`

As we batch up several minor breaking changes, revise existing messages:

* Imitate wording from `jest-validate`
* Replace prettyFormat with **pretty-format** to maximize chance to find the dependency

Gave an argument `mixed` type for practice, but 2 `$FlowFixMe` really :(

**Test plan**

5 new tests including 2 new snapshots

Jest never uses `theme` option, so this change doesn’t affect its performance.