### PR TITLE
Improve printing of `expect.assertions` error.

### DIFF
--- a/integration_tests/__tests__/__snapshots__/failures-test.js.snap
+++ b/integration_tests/__tests__/__snapshots__/failures-test.js.snap
@@ -66,11 +66,11 @@ Object {
 
   ● .assertions() › throws
 
-    Error
-      expect.assertions(2)
+    expect.assertions(2)
+    
+    Expected two assertions to be called but only received one assertion call.
       
-      Expected: two assertions
-      Received: one assertion
+      at addAssertionErrors (../../packages/jest-jasmine2/build/setup-jest-globals.js:56:21)
 
   ● .assertions() › throws on redeclare of assertion count
 
@@ -83,11 +83,11 @@ Object {
 
   ● .assertions() › throws on assertion
 
-    Error
-      expect.assertions(0)
+    expect.assertions(0)
+    
+    Expected zero assertions to be called but only received one assertion call.
       
-      Expected: zero assertions
-      Received: one assertion
+      at addAssertionErrors (../../packages/jest-jasmine2/build/setup-jest-globals.js:56:21)
 
   .assertions()
     ✕ throws

--- a/integration_tests/failures/__tests__/assertion-count-test.js
+++ b/integration_tests/failures/__tests__/assertion-count-test.js
@@ -29,4 +29,3 @@ describe('.assertions()', () => {
   it('throws on redeclare of assertion count', redeclare);
   it('throws on assertion', noAssertions);
 });
-

--- a/packages/jest-jasmine2/src/setup-jest-globals.js
+++ b/packages/jest-jasmine2/src/setup-jest-globals.js
@@ -43,22 +43,29 @@ const addSuppressedErrors = result => {
 };
 
 const addAssertionErrors = result => {
-  const {assertionsMade, assertionsExpected} = getState();
-  setState({assertionsExpected: null, assertionsMade: 0});
+  const {assertionCalls, assertionsExpected} = getState();
+  setState({
+    assertionCalls: 0,
+    assertionsExpected: null,
+  });
   if (
     typeof assertionsExpected === 'number' &&
-    assertionsMade !== assertionsExpected
+    assertionCalls !== assertionsExpected
   ) {
     const expected = EXPECTED_COLOR(pluralize('assertion', assertionsExpected));
+    const message = new Error(
+      matcherHint('.assertions', '', assertionsExpected, {
+        isDirectExpectCall: true,
+      }) +
+      '\n\n' +
+      `Expected ${expected} to be called but only received ` +
+      `${RECEIVED_COLOR(pluralize('assertion call', assertionCalls))}.`,
+    ).stack;
     result.status = 'failed';
     result.failedExpectations.push({
-      actual: assertionsMade,
+      actual: assertionCalls,
       expected: assertionsExpected,
-      message: matcherHint('.assertions', '', assertionsExpected, {
-        isDirectExpectCall: true,
-      }) + '\n\n' +
-        `Expected: ${expected}\n` +
-        `Received: ${RECEIVED_COLOR(pluralize('assertion', assertionsMade))}`,
+      message,
       passed: false,
     });
   }

--- a/packages/jest-matchers/src/index.js
+++ b/packages/jest-matchers/src/index.js
@@ -48,8 +48,8 @@ if (!global[GLOBAL_STATE]) {
     {value: {
       matchers: Object.create(null),
       state: {
+        assertionCalls: 0,
         assertionsExpected: null,
-        assertionsMade: 0,
         suppressedErrors: [],
       },
     }},
@@ -119,7 +119,7 @@ const makeThrowingMatcher = (
 
     _validateResult(result);
 
-    global[GLOBAL_STATE].state.assertionsMade++;
+    global[GLOBAL_STATE].state.assertionCalls++;
 
     if ((result.pass && isNot) || (!result.pass && !isNot)) { // XOR
       const message = getMessage(result.message);

--- a/types/Matchers.js
+++ b/types/Matchers.js
@@ -25,8 +25,8 @@ export type RawMatcherFn = (
 export type ThrowingMatcherFn = (actual: any) => void;
 export type MatcherContext = {isNot: boolean};
 export type MatcherState = {
+  assertionCalls?: number,
   assertionsExpected?: ?number,
-  assertionsMade?: number,
   currentTestName?: string,
   testPath?: Path,
 };


### PR DESCRIPTION
**Summary**

This was pretty bad before and didn't integrate properly with Jest.

Before:
<img width="962" alt="screen shot 2017-03-01 at 3 06 05 pm" src="https://cloud.githubusercontent.com/assets/13352/23465607/acb5caa6-fe90-11e6-99b2-a48a4938c8ed.png">

After:
<img width="962" alt="screen shot 2017-03-01 at 3 04 26 pm" src="https://cloud.githubusercontent.com/assets/13352/23465609/aeb50e16-fe90-11e6-81ac-430857342471.png">


**Test plan**

jest