### PR TITLE
Add relative paths to eslint-plugin-jest docs

### DIFF
--- a/packages/eslint-plugin-jest/README.md
+++ b/packages/eslint-plugin-jest/README.md
@@ -47,9 +47,9 @@ You can also whitelist the environment variables provided by Jest by doing:
 
 ## Supported Rules
 
-- [no-disabled-tests](docs/rules/no-disabled-tests.md) - disallow disabled tests.
-- [no-focused-tests](docs/rules/no-focused-tests.md) - disallow focused tests.
-- [no-identical-title](docs/rules/no-identical-title.md) - disallow identical titles.
+- [no-disabled-tests](/packages/eslint-plugin-jest/docs/rules/no-disabled-tests.md) - disallow disabled tests.
+- [no-focused-tests](/packages/eslint-plugin-jest/docs/rules/no-focused-tests.md) - disallow focused tests.
+- [no-identical-title](/packages/eslint-plugin-jest/docs/rules/no-identical-title.md) - disallow identical titles.
 
 ## Shareable configurations
 
@@ -69,9 +69,9 @@ See [ESLint documentation](http://eslint.org/docs/user-guide/configuring#extendi
 
 The rules enabled in this configuration are:
 
-- [jest/no-disabled-tests](docs/rules/no-disabled-tests.md)
-- [jest/no-focused-tests](docs/rules/no-focused-tests.md)
-- [jest/no-identical-title](docs/rules/no-identical-title.md)
+- [jest/no-disabled-tests](/packages/eslint-plugin-jest/docs/rules/no-disabled-tests.md)
+- [jest/no-focused-tests](/packages/eslint-plugin-jest/docs/rules/no-focused-tests.md)
+- [jest/no-identical-title](/packages/eslint-plugin-jest/docs/rules/no-identical-title.md)
 
 ## Credit
 


### PR DESCRIPTION
**Summary**
This Pull Request is intended to resolve the broken links to the eslint-plugin-jest rule definitions on the NPM documentation page, whilst also still working through GitHub. Resolves #3036.

**Test plan**
This PR is a little difficult to test, as I don't have access to the NPM page. I've tested that the new links work in GitHub, but some help on testing them on NPM would be great.
