### PR TITLE
Add tests for jest-resolve-dependencies

### DIFF
--- a/packages/jest-resolve-dependencies/package.json
+++ b/packages/jest-resolve-dependencies/package.json
@@ -8,9 +8,7 @@
   "license": "BSD-3-Clause",
   "main": "build/index.js",
   "dependencies": {
-    "jest-file-exists": "^19.0.0"
-  },
-  "devDependencies": {
-    "slash": "^1.0.0"
+    "jest-file-exists": "^19.0.0",
+    "jest-regex-util": "^19.0.0"
   }
 }

--- a/packages/jest-resolve-dependencies/package.json
+++ b/packages/jest-resolve-dependencies/package.json
@@ -9,5 +9,8 @@
   "main": "build/index.js",
   "dependencies": {
     "jest-file-exists": "^19.0.0"
+  },
+  "devDependencies": {
+    "slash": "^1.0.0"
   }
 }

--- a/packages/jest-resolve-dependencies/src/__tests__/DependencyResolver-test.js
+++ b/packages/jest-resolve-dependencies/src/__tests__/DependencyResolver-test.js
@@ -11,6 +11,8 @@
 const DependencyResolver = require('../index');
 const normalizeConfig = require('jest-config').normalize;
 const path = require('path');
+const slash = require('slash');
+
 const maxWorkers = 1;
 let dependencyResolver;
 let Runtime;
@@ -68,7 +70,7 @@ test('resolves inverse dependencies for existing path', () => {
   const paths = new Set([path.resolve(__dirname, '__fixtures__/file.js')]);
   const resolved = dependencyResolver.resolveInverse(paths, filter);
   expect(resolved).toEqual([
-    expect.stringContaining('__tests__/__fixtures__/file-test.js'),
+    expect.stringContaining(slash('__tests__/__fixtures__/file-test.js')),
   ]);
 });
 
@@ -80,8 +82,8 @@ test('resolves inverse dependencies from available snapshot', () => {
   const resolved = dependencyResolver.resolveInverse(paths, filter);
   expect(resolved).toEqual(
     expect.arrayContaining([
-      expect.stringContaining('__tests__/__fixtures__/file-test.js'),
-      expect.stringContaining('__tests__/__fixtures__/related-test.js'),
+      expect.stringContaining(slash('__tests__/__fixtures__/file-test.js')),
+      expect.stringContaining(slash('__tests__/__fixtures__/related-test.js')),
     ]),
   );
 });

--- a/packages/jest-resolve-dependencies/src/__tests__/DependencyResolver-test.js
+++ b/packages/jest-resolve-dependencies/src/__tests__/DependencyResolver-test.js
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+'use strict';
+
+const DependencyResolver = require('../index');
+const normalizeConfig = require('jest-config').normalize;
+const path = require('path');
+const maxWorkers = 1;
+let dependencyResolver;
+let Runtime;
+let config;
+const cases = {
+  fancyCondition: jest.fn(path => path.length > 10),
+  testRegex: jest.fn(path => /-test.js$/.test(path)),
+};
+const filter = path => {
+  return Object.keys(cases).every(key => cases[key](path));
+};
+
+beforeEach(() => {
+  Runtime = require('jest-runtime');
+  config = normalizeConfig({
+    rootDir: '.',
+    roots: ['./packages/jest-resolve-dependencies'],
+  }).config;
+  return Runtime.createHasteContext(config, {maxWorkers}).then(hasteMap => {
+    dependencyResolver = new DependencyResolver(
+      hasteMap.resolver,
+      hasteMap.hasteFS,
+    );
+  });
+});
+
+test('resolves no dependencies for non-existent path', () => {
+  const resolved = dependencyResolver.resolve('/non/existent/path');
+  expect(resolved.length).toEqual(0);
+});
+
+test('resolves dependencies for existing path', () => {
+  const resolved = dependencyResolver.resolve(
+    path.resolve(__dirname, '__fixtures__', 'file.js'),
+  );
+  expect(resolved).toEqual([
+    expect.stringContaining('jest-resolve-dependencies'),
+    expect.stringContaining('jest-file-exists'),
+  ]);
+});
+
+test('resolves no inverse dependencies for empty paths set', () => {
+  const paths = new Set();
+  const resolved = dependencyResolver.resolveInverse(paths, filter);
+  expect(resolved.length).toEqual(0);
+});
+
+test('resolves no inverse dependencies for set of non-existent paths', () => {
+  const paths = new Set(['/non/existent/path', '/another/one']);
+  const resolved = dependencyResolver.resolveInverse(paths, filter);
+  expect(resolved.length).toEqual(0);
+});
+
+test('resolves inverse dependencies for existing path', () => {
+  const paths = new Set([path.resolve(__dirname, '__fixtures__/file.js')]);
+  const resolved = dependencyResolver.resolveInverse(paths, filter);
+  expect(resolved).toEqual([
+    expect.stringContaining('__tests__/__fixtures__/file-test.js'),
+  ]);
+});
+
+test('resolves inverse dependencies from available snapshot', () => {
+  const paths = new Set([
+    path.resolve(__dirname, '__fixtures__/file.js'),
+    path.resolve(__dirname, '__fixtures__/__snapshots__/related-test.js.snap'),
+  ]);
+  const resolved = dependencyResolver.resolveInverse(paths, filter);
+  expect(resolved).toEqual(
+    expect.arrayContaining([
+      expect.stringContaining('__tests__/__fixtures__/file-test.js'),
+      expect.stringContaining('__tests__/__fixtures__/related-test.js'),
+    ]),
+  );
+});

--- a/packages/jest-resolve-dependencies/src/__tests__/DependencyResolver-test.js
+++ b/packages/jest-resolve-dependencies/src/__tests__/DependencyResolver-test.js
@@ -11,7 +11,6 @@
 const DependencyResolver = require('../index');
 const normalizeConfig = require('jest-config').normalize;
 const path = require('path');
-const slash = require('slash');
 
 const maxWorkers = 1;
 let dependencyResolver;
@@ -70,7 +69,9 @@ test('resolves inverse dependencies for existing path', () => {
   const paths = new Set([path.resolve(__dirname, '__fixtures__/file.js')]);
   const resolved = dependencyResolver.resolveInverse(paths, filter);
   expect(resolved).toEqual([
-    expect.stringContaining(slash('__tests__/__fixtures__/file-test.js')),
+    expect.stringContaining(
+      path.join('__tests__', '__fixtures__', 'file-test.js'),
+    ),
   ]);
 });
 
@@ -82,8 +83,12 @@ test('resolves inverse dependencies from available snapshot', () => {
   const resolved = dependencyResolver.resolveInverse(paths, filter);
   expect(resolved).toEqual(
     expect.arrayContaining([
-      expect.stringContaining(slash('__tests__/__fixtures__/file-test.js')),
-      expect.stringContaining(slash('__tests__/__fixtures__/related-test.js')),
+      expect.stringContaining(
+        path.join('__tests__', '__fixtures__', 'file-test.js'),
+      ),
+      expect.stringContaining(
+        path.join('__tests__', '__fixtures__', 'related-test.js'),
+      ),
     ]),
   );
 });

--- a/packages/jest-resolve-dependencies/src/__tests__/__fixtures__/__snapshots__/related-test.js.snap
+++ b/packages/jest-resolve-dependencies/src/__tests__/__fixtures__/__snapshots__/related-test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`sample 1`] = `Object {}`;

--- a/packages/jest-resolve-dependencies/src/__tests__/__fixtures__/file-test.js
+++ b/packages/jest-resolve-dependencies/src/__tests__/__fixtures__/file-test.js
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+'use strict';
+
 const fileTest = require('./file');
 
 test('sample', () => {

--- a/packages/jest-resolve-dependencies/src/__tests__/__fixtures__/file-test.js
+++ b/packages/jest-resolve-dependencies/src/__tests__/__fixtures__/file-test.js
@@ -1,0 +1,5 @@
+const fileTest = require('./file');
+
+test('sample', () => {
+  expect(fileTest).toBeTruthy();
+});

--- a/packages/jest-resolve-dependencies/src/__tests__/__fixtures__/file.js
+++ b/packages/jest-resolve-dependencies/src/__tests__/__fixtures__/file.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+'use strict';
+
+require('jest-resolve-dependencies');
+require('jest-file-exists');

--- a/packages/jest-resolve-dependencies/src/__tests__/__fixtures__/related-test.js
+++ b/packages/jest-resolve-dependencies/src/__tests__/__fixtures__/related-test.js
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+'use strict';
+
+test('sample', () => {
+  expect({}).toMatchSnapshot();
+});

--- a/packages/jest-resolve-dependencies/src/index.js
+++ b/packages/jest-resolve-dependencies/src/index.js
@@ -15,9 +15,16 @@ import type {Path} from 'types/Config';
 import type {Resolver, ResolveModuleConfig} from 'types/Resolve';
 
 const fileExists = require('jest-file-exists');
+const {replacePathSepForRegex} = require('jest-regex-util');
 
+const snapshotDirRegex = new RegExp(
+  replacePathSepForRegex('\/__snapshots__\/'),
+);
+const snapshotFileRegex = new RegExp(
+  replacePathSepForRegex('__snapshots__\/(.*)\.snap'),
+);
 const isSnapshotPath = (path: string): boolean =>
-  !!path.match(/\/__snapshots__\//);
+  !!path.match(snapshotDirRegex);
 
 function compact(array: Array<?Path>): Array<Path> {
   const result = [];
@@ -97,7 +104,7 @@ class DependencyResolver {
           // /path/to/__snapshots__/test.js.snap is always adjacent to
           // /path/to/test.js
           const modulePath = isSnapshotPath(path)
-            ? path.replace(/__snapshots__\/(.*)\.snap/, '$1')
+            ? path.replace(snapshotFileRegex, '$1')
             : path;
           changed.add(modulePath);
           if (filter(modulePath)) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Review highly appreciated. I use real files from `__fixtures__` instead of mocks, because it was easier for me this way (behaves more like integration test though). 

**Test plan**

jest
