### PR TITLE
Enable all `jest-runtime` tests on Windows.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "babel-plugin-transform-flow-strip-types": "^6.18.0",
     "chalk": "^1.1.3",
     "codecov": "^1.0.1",
+    "cross-spawn": "^5.1.0",
     "eslint": "^3.11.1",
     "eslint-plugin-babel": "^4.0.0",
     "eslint-plugin-flowtype": "^2.28.2",
@@ -29,11 +30,12 @@
     "react": "^15.4.1",
     "react-test-renderer": "^15.4.1",
     "rimraf": "^2.5.4",
+    "slash": "^1.0.0",
     "strip-ansi": "^3.0.1",
     "typescript": "^2.1.4"
   },
   "scripts": {
-    "build-clean": "rm -rf ./packages/*/build",
+    "build-clean": "rimraf ./packages/*/build",
     "build": "node ./scripts/build.js",
     "clean-all": "rm -rf ./node_modules; rm -rf ./packages/*/node_modules; rm -rf ./integration_tests/*/*/node_modules; yarn run build-clean",
     "danger": "node ./danger/node_modules/.bin/danger",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "typescript": "^2.1.4"
   },
   "scripts": {
-    "build-clean": "rimraf ./packages/*/build",
+    "build-clean": "rm -rf ./packages/*/build",
     "build": "node ./scripts/build.js",
     "clean-all": "rm -rf ./node_modules; rm -rf ./packages/*/node_modules; rm -rf ./integration_tests/*/*/node_modules; yarn run build-clean",
     "danger": "node ./danger/node_modules/.bin/danger",

--- a/packages/jest-runtime/src/__tests__/Runtime-cli-test.js
+++ b/packages/jest-runtime/src/__tests__/Runtime-cli-test.js
@@ -9,8 +9,7 @@
  */
 'use strict';
 
-const skipOnWindows = require('skipOnWindows');
-const spawnSync = require('child_process').spawnSync;
+const spawnSync = require('cross-spawn').sync;
 const path = require('path');
 
 const JEST_RUNTIME = path.resolve(__dirname, '../../bin/jest-runtime.js');
@@ -22,8 +21,6 @@ const run = args => spawnSync(JEST_RUNTIME, args, {
 });
 
 describe('Runtime', () => {
-  skipOnWindows.suite();
-
   describe('cli', () => {
     it('fails with no path', () => {
       const expectedOutput =

--- a/packages/jest-runtime/src/__tests__/transform-test.js
+++ b/packages/jest-runtime/src/__tests__/transform-test.js
@@ -10,6 +10,7 @@
 'use strict';
 
 const skipOnWindows = require('skipOnWindows');
+const slash = require('slash');
 
 jest
   .mock('graceful-fs')
@@ -116,7 +117,8 @@ describe('transform', () => {
     });
     fs.writeFileSync = jest.fn((path, data, options) => {
       expect(options).toBe('utf8');
-      mockFs[path] = data;
+      const normalizedPath = slash(path);
+      mockFs[normalizedPath] = data;
     });
 
     fs.unlinkSync = jest.fn();
@@ -213,9 +215,9 @@ describe('transform', () => {
   });
 
   it('reads values from the cache', () => {
-    if (skipOnWindows.test()) {
-      return;
-    }
+    // if (skipOnWindows.test()) {
+    //   return;
+    // }
     const transformConfig = Object.assign(config, {
       transform: [['^.+\\.js$', 'test-preprocessor']],
     });

--- a/packages/jest-runtime/src/__tests__/transform-test.js
+++ b/packages/jest-runtime/src/__tests__/transform-test.js
@@ -9,7 +9,6 @@
  */
 'use strict';
 
-const skipOnWindows = require('skipOnWindows');
 const slash = require('slash');
 
 jest
@@ -215,9 +214,6 @@ describe('transform', () => {
   });
 
   it('reads values from the cache', () => {
-    // if (skipOnWindows.test()) {
-    //   return;
-    // }
     const transformConfig = Object.assign(config, {
       transform: [['^.+\\.js$', 'test-preprocessor']],
     });

--- a/packages/jest-runtime/src/transform.js
+++ b/packages/jest-runtime/src/transform.js
@@ -21,6 +21,7 @@ const path = require('path');
 const shouldInstrument = require('./shouldInstrument');
 const stableStringify = require('json-stable-stringify');
 const vm = require('vm');
+const slash = require('slash');
 
 const VERSION = require('../package.json').version;
 
@@ -172,10 +173,10 @@ const getFileCachePath = (
   // Create sub folders based on the cacheKey to avoid creating one
   // directory with many files.
   const cacheDir = path.join(baseCacheDir, cacheKey[0] + cacheKey[1]);
-  const cachePath = path.join(
+  const cachePath = slash(path.join(
     cacheDir,
     path.basename(filename, path.extname(filename)) + '_' + cacheKey,
-  );
+  ));
   createDirectory(cacheDir);
 
   return cachePath;

--- a/yarn.lock
+++ b/yarn.lock
@@ -565,6 +565,14 @@ cross-spawn@^4.0.0:
     lru-cache "^4.0.1"
     which "^1.2.9"
 
+cross-spawn@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
+  dependencies:
+    lru-cache "^4.0.1"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
+
 cryptiles@2.x.x:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-2.0.5.tgz#3bdfecdc608147c1c67202fa291e7dca59eaa3b8"
@@ -2146,6 +2154,16 @@ sax@^1.2.1:
 setimmediate@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
+
+shebang-command@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
+  dependencies:
+    shebang-regex "^1.0.0"
+
+shebang-regex@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
 
 shelljs@^0.7.5:
   version "0.7.6"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Removes `skipOnWindows` calls for `jest-runtime` tests and resolves the underlying issues.

- `require('child_process').spawnSync` has been replaced with `require('cross-spawn').sync`.
- `cachePath` is now normalized through `slash`.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
Nothing should change.
Everything that passed Travis and AppVeyor before should pass now.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
