### PR TITLE
removed media query padding rule that placed navToggler too close to …

### DIFF
--- a/website/src/jest/css/jest.css
+++ b/website/src/jest/css/jest.css
@@ -1373,10 +1373,6 @@ nav.toc .toggleNav .navBreadcrumb h2 {
 }
 
 @media only screen and (min-width: 900px) {
-  .docsNavContainer nav.toc .navBreadcrumb {
-    padding: 5px 0;
-  }
-
   nav.toc section .navGroups {
     padding: 40px 0 0;
   }


### PR DESCRIPTION
**Summary**

The div#navToggler was too close to the wall because of a min-width 900px media query. I removed the media query all together to make it look better. 

**Test plan**

Checked the div in my browser to make sure it looks as it was intended to--it looks just like it does on screens smaller screens now.

Before:
<img width="150" alt="previous" src="https://cloud.githubusercontent.com/assets/3302126/23498160/26aab6e2-fedb-11e6-8150-42d1db37111d.png">

After:
<img width="135" alt="now" src="https://cloud.githubusercontent.com/assets/3302126/23498197/4c6c1862-fedb-11e6-855c-e80c0d0a076f.png">

