### PR TITLE
[jest-haste-map] Enable `nodeCrawl` tests for Windows.

### DIFF
--- a/packages/jest-haste-map/package.json
+++ b/packages/jest-haste-map/package.json
@@ -12,6 +12,7 @@
     "graceful-fs": "^4.1.6",
     "micromatch": "^2.3.11",
     "sane": "~1.5.0",
+    "slash": "^1.0.0",
     "worker-farm": "^1.3.1"
   }
 }

--- a/packages/jest-haste-map/src/crawlers/__tests__/node-test.js
+++ b/packages/jest-haste-map/src/crawlers/__tests__/node-test.js
@@ -9,8 +9,6 @@
  */
 'use strict';
 
-const skipOnWindows = require('skipOnWindows');
-
 jest.mock('child_process', () => ({
   spawn: jest.fn((cmd, args) => {
     let closeCallback;
@@ -69,8 +67,6 @@ let nodeCrawl;
 let childProcess;
 
 describe('node crawler', () => {
-  skipOnWindows.suite();
-
   beforeEach(() => {
     jest.resetModules();
 

--- a/packages/jest-haste-map/src/crawlers/node.js
+++ b/packages/jest-haste-map/src/crawlers/node.js
@@ -17,6 +17,7 @@ const H = require('../constants');
 const fs = require('fs');
 const path = require('path');
 const spawn = require('child_process').spawn;
+const slash = require('slash');
 
 type Callback = (result: Array<[/* id */ string, /* mtime */ number]>) => void;
 
@@ -35,7 +36,7 @@ function find(
       activeCalls--;
 
       names.forEach(file => {
-        file = path.join(directory, file);
+        file = slash(path.join(directory, file));
         if (ignore(file)) {
           return;
         }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Removes `skipOnWindows` calls for `nodeCrawl` in `jest-haste-map` and resolves the underlying issues.
 - Path is normalized through `slash`.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
Nothing should change.
Everything that passed Travis and AppVeyor before should pass now.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
