### PR TITLE
[jest-resolve] Move `jest-haste-map` to `devDependencies`.

### DIFF
--- a/packages/jest-resolve/package.json
+++ b/packages/jest-resolve/package.json
@@ -10,7 +10,9 @@
   "dependencies": {
     "browser-resolve": "^1.11.2",
     "is-builtin-module": "^1.0.0",
-    "jest-haste-map": "^19.0.0",
     "resolve": "^1.2.0"
+  },
+  "devDependencies": {
+    "jest-haste-map": "^19.0.0"
   }
 }

--- a/packages/jest-resolve/src/index.js
+++ b/packages/jest-resolve/src/index.js
@@ -11,7 +11,7 @@
 'use strict';
 
 import type {Path} from 'types/Config';
-import type {ModuleMap} from 'jest-haste-map';
+import type {ModuleMap} from 'types/HasteMap';
 
 const nodeModulesPaths = require('resolve/lib/node-modules-paths');
 const path = require('path');


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Moves `jest-haste-map` from `dependencies` to `devDependencies` for `jest-resolve`.  It's only used in tests and as a type import.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
Nothing should change.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
