### PR TITLE
Revert "[jest-haste-map] Enable `nodeCrawl` tests for Windows."

### DIFF
--- a/packages/jest-haste-map/package.json
+++ b/packages/jest-haste-map/package.json
@@ -12,7 +12,6 @@
     "graceful-fs": "^4.1.6",
     "micromatch": "^2.3.11",
     "sane": "~1.5.0",
-    "slash": "^1.0.0",
     "worker-farm": "^1.3.1"
   }
 }

--- a/packages/jest-haste-map/src/crawlers/__tests__/node-test.js
+++ b/packages/jest-haste-map/src/crawlers/__tests__/node-test.js
@@ -9,6 +9,8 @@
  */
 'use strict';
 
+const skipOnWindows = require('skipOnWindows');
+
 jest.mock('child_process', () => ({
   spawn: jest.fn((cmd, args) => {
     let closeCallback;
@@ -67,6 +69,8 @@ let nodeCrawl;
 let childProcess;
 
 describe('node crawler', () => {
+  skipOnWindows.suite();
+
   beforeEach(() => {
     jest.resetModules();
 

--- a/packages/jest-haste-map/src/crawlers/node.js
+++ b/packages/jest-haste-map/src/crawlers/node.js
@@ -17,7 +17,6 @@ const H = require('../constants');
 const fs = require('fs');
 const path = require('path');
 const spawn = require('child_process').spawn;
-const slash = require('slash');
 
 type Callback = (result: Array<[/* id */ string, /* mtime */ number]>) => void;
 
@@ -36,7 +35,7 @@ function find(
       activeCalls--;
 
       names.forEach(file => {
-        file = slash(path.join(directory, file));
+        file = path.join(directory, file);
         if (ignore(file)) {
           return;
         }


### PR DESCRIPTION
It breaks stuff in `SearchSource`.