### PR TITLE
jest-haste-map - updated typecheck for regex and remove FlowFixMe

### DIFF
--- a/packages/jest-haste-map/src/index.js
+++ b/packages/jest-haste-map/src/index.js
@@ -689,9 +689,8 @@ class HasteMap extends EventEmitter {
    */
   _ignore(filePath: Path): boolean {
     const ignorePattern = this._options.ignorePattern;
-    const ignoreMatched =
-      Object.prototype.toString.call(ignorePattern) === '[object RegExp]'
-      ? ignorePattern.test(filePath) // $FlowFixMe
+    const ignoreMatched = ignorePattern instanceof RegExp
+      ? ignorePattern.test(filePath)
       : ignorePattern(filePath);
 
     return ignoreMatched ||


### PR DESCRIPTION
@cpojer  

Following on from the jest-haste-map PR #2957 (exception with MacOS and watchers), @SimenB suggested an [alternative way to typecheck regex](https://github.com/facebook/jest/pull/2957/files#r104211008) that flow understands. Tested and passing flow.
