### PR TITLE
Add eslint rule `valid-expect`

### DIFF
--- a/docs/ExpectAPI.md
+++ b/docs/ExpectAPI.md
@@ -654,7 +654,7 @@ test('the house has my desired features', () => {
 
 ### `toHaveProperty(keyPath, value)`
 
-Use `.toHaveProperty` to check if property at provided reference `keyPath` exists for an object. 
+Use `.toHaveProperty` to check if property at provided reference `keyPath` exists for an object.
 For checking deeply nested properties in an object use [dot notation](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Operators/Property_accessors) for deep references.
 
 Optionally, you can provide a value to check if it's strictly equal to the `value` present
@@ -666,17 +666,17 @@ to check for the existence and values of various properties in the object.
 ```js
 // Object containing house features to be tested
 const houseForSale = {
-	bath: true,
-	kitchen: {
-		amenities: ['oven', 'stove', 'washer'],
-		area: 20,
-		wallColor: 'white'
-	},
+  bath: true,
   bedrooms: 4,
+  kitchen: {
+    amenities: ['oven', 'stove', 'washer'],
+    area: 20,
+    wallColor: 'white',
+  },
 };
 
 test('this house has my desired features', () => {
-  // Simple Referencing 
+  // Simple Referencing
   expect(houseForSale).toHaveProperty('bath');
   expect(houseForSale).toHaveProperty('bedrooms', 4);
 
@@ -684,7 +684,11 @@ test('this house has my desired features', () => {
 
   // Deep referencing using dot notation
   expect(houseForSale).toHaveProperty('kitchen.area', 20);
-  expect(houseForSale).toHaveProperty('kitchen.amenities', ['oven', 'stove', 'washer']);
+  expect(houseForSale).toHaveProperty('kitchen.amenities', [
+    'oven',
+    'stove',
+    'washer',
+  ]);
 
   expect(hosueForSale).not.toHaveProperty('kitchen.open');
 });

--- a/docs/SetupAndTeardown.md
+++ b/docs/SetupAndTeardown.md
@@ -93,11 +93,11 @@ describe('matching cities to foods', () => {
   });
 
   test('Vienna <3 sausage', () => {
-    expect(isValidCityFoodPair('Vienna', 'Wiener Schnitzel'));
+    expect(isValidCityFoodPair('Vienna', 'Wiener Schnitzel')).toBe(true);
   });
 
   test('San Juan <3 plantains', () => {
-    expect(isValidCityFoodPair('San Juan', 'Mofongo'));
+    expect(isValidCityFoodPair('San Juan', 'Mofongo')).toBe(true);
   });
 });
 ```

--- a/packages/eslint-config-fb-strict/index.js
+++ b/packages/eslint-config-fb-strict/index.js
@@ -41,6 +41,7 @@ module.exports = Object.assign({}, fbjsConfig, {
     'flowtype/object-type-delimiter': [2, 'comma'],
     'jest/no-focused-tests': [2],
     'jest/no-identical-title': [2],
+    'jest/valid-expect': [2],
     'max-len': [2, {
       'code': 80,
       'ignorePattern': maxLenIgnorePattern,

--- a/packages/eslint-plugin-jest/README.md
+++ b/packages/eslint-plugin-jest/README.md
@@ -31,6 +31,7 @@ Then configure the rules you want to use under the rules section.
     "jest/no-disabled-tests": "warn",
     "jest/no-focused-tests": "error",
     "jest/no-identical-title": "error",
+    "jest/valid-expect": "error",
   }
 }
 ```
@@ -50,6 +51,7 @@ You can also whitelist the environment variables provided by Jest by doing:
 - [no-disabled-tests](/packages/eslint-plugin-jest/docs/rules/no-disabled-tests.md) - disallow disabled tests.
 - [no-focused-tests](/packages/eslint-plugin-jest/docs/rules/no-focused-tests.md) - disallow focused tests.
 - [no-identical-title](/packages/eslint-plugin-jest/docs/rules/no-identical-title.md) - disallow identical titles.
+- [valid-expect](/packages/eslint-plugin-jest/docs/rules/valid-expect.md) - disallow identical titles.
 
 ## Shareable configurations
 
@@ -72,6 +74,7 @@ The rules enabled in this configuration are:
 - [jest/no-disabled-tests](/packages/eslint-plugin-jest/docs/rules/no-disabled-tests.md)
 - [jest/no-focused-tests](/packages/eslint-plugin-jest/docs/rules/no-focused-tests.md)
 - [jest/no-identical-title](/packages/eslint-plugin-jest/docs/rules/no-identical-title.md)
+- [jest/valid-expect](/packages/eslint-plugin-jest/docs/rules/valid-expect.md)
 
 ## Credit
 

--- a/packages/eslint-plugin-jest/README.md
+++ b/packages/eslint-plugin-jest/README.md
@@ -51,7 +51,7 @@ You can also whitelist the environment variables provided by Jest by doing:
 - [no-disabled-tests](/packages/eslint-plugin-jest/docs/rules/no-disabled-tests.md) - disallow disabled tests.
 - [no-focused-tests](/packages/eslint-plugin-jest/docs/rules/no-focused-tests.md) - disallow focused tests.
 - [no-identical-title](/packages/eslint-plugin-jest/docs/rules/no-identical-title.md) - disallow identical titles.
-- [valid-expect](/packages/eslint-plugin-jest/docs/rules/valid-expect.md) - disallow identical titles.
+- [valid-expect](/packages/eslint-plugin-jest/docs/rules/valid-expect.md) - ensure expect is called correctly.
 
 ## Shareable configurations
 

--- a/packages/eslint-plugin-jest/docs/rules/valid-expect.md
+++ b/packages/eslint-plugin-jest/docs/rules/valid-expect.md
@@ -1,0 +1,41 @@
+# Enforce valid `expect()` usage (valid-expect)
+
+Ensure `expect()` is called with a single argument and there is an actual expectation made.
+
+## Rule details
+
+This rule triggers a warning if `expect()` is called with more than one argument or without arguments. 
+It would also issue a warning if there is nothing called on `expect()`, e.g.:
+
+```js
+expect();
+expect("something");
+```
+
+or when a matcher function was not called, e.g.:
+
+```js
+expect(true).toBeDefined
+```
+
+This rule is enabled by default.
+
+### Default configuration
+
+The following patterns are considered warnings:
+
+```js
+expect();
+expect().toEqual("something");
+expect("something", "else");
+expect("something");
+expect(true).toBeDefined;
+```
+
+The following patterns are not warnings:
+
+```js
+expect("something").toEqual("something");
+expect([1, 2, 3]).toEqual([1, 2, 3]);
+expect(true).toBeDefined();
+```

--- a/packages/eslint-plugin-jest/docs/rules/valid-expect.md
+++ b/packages/eslint-plugin-jest/docs/rules/valid-expect.md
@@ -9,7 +9,7 @@ It would also issue a warning if there is nothing called on `expect()`, e.g.:
 
 ```js
 expect();
-expect("something");
+expect('something');
 ```
 
 or when a matcher function was not called, e.g.:
@@ -26,16 +26,16 @@ The following patterns are considered warnings:
 
 ```js
 expect();
-expect().toEqual("something");
-expect("something", "else");
-expect("something");
+expect().toEqual('something');
+expect('something', 'else');
+expect('something');
 expect(true).toBeDefined;
 ```
 
 The following patterns are not warnings:
 
 ```js
-expect("something").toEqual("something");
+expect('something').toEqual('something');
 expect([1, 2, 3]).toEqual([1, 2, 3]);
 expect(true).toBeDefined();
 ```

--- a/packages/eslint-plugin-jest/src/index.js
+++ b/packages/eslint-plugin-jest/src/index.js
@@ -17,6 +17,7 @@ module.exports = {
         'jest/no-disabled-tests': 'warn',
         'jest/no-focused-tests': 'error',
         'jest/no-identical-title': 'error',
+        'jest/valid-expect': 'error',
       },
     },
   },
@@ -46,5 +47,6 @@ module.exports = {
     'no-disabled-tests': require('./rules/no-disabled-tests'),
     'no-focused-tests': require('./rules/no-focused-tests'),
     'no-identical-title': require('./rules/no-identical-title'),
+    'valid-expect': require('./rules/valid-expect'),
   },
 };

--- a/packages/eslint-plugin-jest/src/rules/__tests__/valid-expect-test.js
+++ b/packages/eslint-plugin-jest/src/rules/__tests__/valid-expect-test.js
@@ -30,7 +30,7 @@ ruleTester.run('valid-expect', rules['valid-expect'], {
       code: 'expect().toBe(true);',
       errors: [
         {
-          message: 'No arguments passed to expect()',
+          message: 'No arguments were passed to expect().',
         },
       ],
     },
@@ -38,7 +38,7 @@ ruleTester.run('valid-expect', rules['valid-expect'], {
       code: 'expect().toEqual("something");',
       errors: [
         {
-          message: 'No arguments passed to expect()',
+          message: 'No arguments were passed to expect().',
         },
       ],
     },
@@ -46,7 +46,7 @@ ruleTester.run('valid-expect', rules['valid-expect'], {
       code: 'expect("something", "else").toEqual("something");',
       errors: [
         {
-          message: 'More than one argument passed to expect()',
+          message: 'More than one argument was passed to expect().',
         },
       ],
     },
@@ -54,10 +54,7 @@ ruleTester.run('valid-expect', rules['valid-expect'], {
       code: 'expect("something");',
       errors: [
         {
-          message: 'Matcher was not called',
-        },
-        {
-          message: 'Nothing called on expect()',
+          message: 'No assertion was called on expect().',
         },
       ],
     },
@@ -65,13 +62,10 @@ ruleTester.run('valid-expect', rules['valid-expect'], {
       code: 'expect();',
       errors: [
         {
-          message: 'No arguments passed to expect()',
+          message: 'No arguments were passed to expect().',
         },
         {
-          message: 'Matcher was not called',
-        },
-        {
-          message: 'Nothing called on expect()',
+          message: 'No assertion was called on expect().',
         },
       ],
     },
@@ -79,7 +73,7 @@ ruleTester.run('valid-expect', rules['valid-expect'], {
       code: 'expect(true).toBeDefined;',
       errors: [
         {
-          message: 'Matcher was not called',
+          message: '"toBeDefined" was not called.',
         },
       ],
     },

--- a/packages/eslint-plugin-jest/src/rules/__tests__/valid-expect-test.js
+++ b/packages/eslint-plugin-jest/src/rules/__tests__/valid-expect-test.js
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+
+// This implementation is copied from eslint-plugin-jasmine.
+// Credits goes to Alexander Afanasyev
+// TODO: Should license at the top be MIT, as that's what the code in
+// eslint-plugin-jasmine is?
+
+/* eslint-disable sort-keys */
+
+'use strict';
+
+const RuleTester = require('eslint').RuleTester;
+const rules = require('../../').rules;
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('valid-expect', rules['valid-expect'], {
+  valid: [
+    'expect("something").toEqual("else");',
+    'expect(true).toBeDefined();',
+    'expect([1, 2, 3]).toEqual([1, 2, 3]);',
+    'expect(undefined).not.toBeDefined();',
+  ],
+
+  invalid: [
+    {
+      code: 'expect().toBe(true);',
+      errors: [
+        {
+          message: 'No arguments passed to expect()',
+        },
+      ],
+    },
+    {
+      code: 'expect().toEqual("something");',
+      errors: [
+        {
+          message: 'No arguments passed to expect()',
+        },
+      ],
+    },
+    {
+      code: 'expect("something", "else").toEqual("something");',
+      errors: [
+        {
+          message: 'More than one argument passed to expect()',
+        },
+      ],
+    },
+    {
+      code: 'expect("something");',
+      errors: [
+        {
+          message: 'Matcher was not called',
+        },
+        {
+          message: 'Nothing called on expect()',
+        },
+      ],
+    },
+    {
+      code: 'expect();',
+      errors: [
+        {
+          message: 'No arguments passed to expect()',
+        },
+        {
+          message: 'Matcher was not called',
+        },
+        {
+          message: 'Nothing called on expect()',
+        },
+      ],
+    },
+    {
+      code: 'expect(true).toBeDefined;',
+      errors: [
+        {
+          message: 'Matcher was not called',
+        },
+      ],
+    },
+  ],
+});

--- a/packages/eslint-plugin-jest/src/rules/__tests__/valid-expect-test.js
+++ b/packages/eslint-plugin-jest/src/rules/__tests__/valid-expect-test.js
@@ -8,11 +8,6 @@
  * @flow
  */
 
-/*
- * This implementation is ported from from eslint-plugin-jasmine.
- * MIT license, Tom Vincent.
- */
-
 /* eslint-disable sort-keys */
 
 'use strict';

--- a/packages/eslint-plugin-jest/src/rules/__tests__/valid-expect-test.js
+++ b/packages/eslint-plugin-jest/src/rules/__tests__/valid-expect-test.js
@@ -8,10 +8,10 @@
  * @flow
  */
 
-// This implementation is copied from eslint-plugin-jasmine.
-// Credits goes to Alexander Afanasyev
-// TODO: Should license at the top be MIT, as that's what the code in
-// eslint-plugin-jasmine is?
+/*
+ * This implementation is ported from from eslint-plugin-jasmine.
+ * MIT license, Tom Vincent.
+ */
 
 /* eslint-disable sort-keys */
 

--- a/packages/eslint-plugin-jest/src/rules/types.js
+++ b/packages/eslint-plugin-jest/src/rules/types.js
@@ -32,6 +32,7 @@ export type CallExpression = {|
   type: 'CallExpression',
   arguments: [Literal],
   callee: Identifier | MemberExpression,
+  parent: any,
 |};
 
 export type EslintContext = {|

--- a/packages/eslint-plugin-jest/src/rules/types.js
+++ b/packages/eslint-plugin-jest/src/rules/types.js
@@ -8,32 +8,37 @@
  * @flow
  */
 
-export type Identifier = {|
+type Node = MemberExpression | CallExpression;
+
+export type Identifier = {
   type: 'Identifier',
   name: string,
   value: string,
-|};
+  parent: Node,
+};
 
-export type MemberExpression = {|
+export type MemberExpression = {
   type: 'MemberExpression',
   name: string,
   expression: CallExpression,
   property: Identifier,
   object: Identifier,
-|};
+  parent: Node,
+};
 
-export type Literal = {|
+export type Literal = {
   type: 'Literal',
   value?: string,
   rawValue?: string,
-|};
+  parent: Node,
+};
 
-export type CallExpression = {|
+export type CallExpression = {
   type: 'CallExpression',
   arguments: [Literal],
   callee: Identifier | MemberExpression,
-  parent: any,
-|};
+  parent: Node,
+};
 
 export type EslintContext = {|
   report: ({message: string, node: any}) => void

--- a/packages/eslint-plugin-jest/src/rules/valid-expect.js
+++ b/packages/eslint-plugin-jest/src/rules/valid-expect.js
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+'use strict';
+
+// This implementation is copied from eslint-plugin-jasmine.
+// Credits goes to Alexander Afanasyev
+// TODO: Should license at the top be MIT, as that's what the code in
+// eslint-plugin-jasmine is?
+
+import type {EslintContext, CallExpression} from './types';
+
+module.exports = (context: EslintContext) => {
+  return {
+    CallExpression(node: CallExpression) {
+      if (node.callee.name === 'expect') {
+        // checking "expect()" arguments
+        if (node.arguments.length > 1) {
+          context.report({
+            message: 'More than one argument passed to expect()',
+            node,
+          });
+        } else if (node.arguments.length === 0) {
+          context.report({message: 'No arguments passed to expect()', node});
+        }
+
+        // matcher was not called
+        if (
+          node.parent &&
+          node.parent.parent &&
+          node.parent.parent.type !== 'CallExpression' &&
+          node.parent.parent.type !== 'MemberExpression'
+        ) {
+          context.report({message: 'Matcher was not called', node});
+        }
+      }
+    },
+
+    // nothing called on "expect()"
+    'CallExpression:exit'(node: CallExpression) {
+      if (
+        node.callee.name === 'expect' &&
+        node.parent.type === 'ExpressionStatement'
+      ) {
+        context.report({message: 'Nothing called on expect()', node});
+      }
+    },
+  };
+};

--- a/packages/eslint-plugin-jest/src/rules/valid-expect.js
+++ b/packages/eslint-plugin-jest/src/rules/valid-expect.js
@@ -23,21 +23,27 @@ module.exports = (context: EslintContext) => {
         // checking "expect()" arguments
         if (node.arguments.length > 1) {
           context.report({
-            message: 'More than one argument passed to expect()',
+            message: 'More than one argument was passed to expect().',
             node,
           });
         } else if (node.arguments.length === 0) {
-          context.report({message: 'No arguments passed to expect()', node});
+          context.report({
+            message: 'No arguments were passed to expect().',
+            node,
+          });
         }
 
         // matcher was not called
         if (
           node.parent &&
+          node.parent.type === 'MemberExpression' &&
           node.parent.parent &&
-          node.parent.parent.type !== 'CallExpression' &&
-          node.parent.parent.type !== 'MemberExpression'
+          node.parent.parent.type === 'ExpressionStatement'
         ) {
-          context.report({message: 'Matcher was not called', node});
+          context.report({
+            message: `"${node.parent.property.name}" was not called.`,
+            node,
+          });
         }
       }
     },
@@ -48,7 +54,7 @@ module.exports = (context: EslintContext) => {
         node.callee.name === 'expect' &&
         node.parent.type === 'ExpressionStatement'
       ) {
-        context.report({message: 'Nothing called on expect()', node});
+        context.report({message: 'No assertion was called on expect().', node});
       }
     },
   };

--- a/packages/eslint-plugin-jest/src/rules/valid-expect.js
+++ b/packages/eslint-plugin-jest/src/rules/valid-expect.js
@@ -9,10 +9,10 @@
  */
 'use strict';
 
-// This implementation is copied from eslint-plugin-jasmine.
-// Credits goes to Alexander Afanasyev
-// TODO: Should license at the top be MIT, as that's what the code in
-// eslint-plugin-jasmine is?
+/*
+ * This implementation is ported from from eslint-plugin-jasmine.
+ * MIT license, Tom Vincent.
+ */
 
 import type {EslintContext, CallExpression} from './types';
 

--- a/packages/pretty-format/src/__tests__/pretty-format-test.js
+++ b/packages/pretty-format/src/__tests__/pretty-format-test.js
@@ -234,8 +234,8 @@ describe('prettyFormat()', () => {
   });
 
   it('prints a string with escapes', () => {
-    expect(prettyFormat('\"-\"'), '"\\"-\\""');
-    expect(prettyFormat('\\ \\\\'), '"\\\\ \\\\\\\\"');
+    expect(prettyFormat('\"-\"')).toEqual('"\\"-\\""');
+    expect(prettyFormat('\\ \\\\')).toEqual('"\\\\ \\\\\\\\"');
   });
 
   it('prints a symbol', () => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Adds a new eslint rule to pick up invalid usage of `expect`.

All credits goes to @tlvince and @alecxe, this code is 100% copy paste, including docs and tests (only change is how `context.report` is called, but it's called with the same args). Open question is how to credit them in the source code, and what should be done about the license header?
https://github.com/tlvince/eslint-plugin-jasmine/blob/master/lib/rules/valid-expect.js

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Motivation: Especially when converting tests from other assertions libs, it's easy to miss something. Jest reports false positives for some misuse of the api.

**Test plan**
Run `yarn lint` on some code that uses `expect` in an invalid way. There actually was a test in the jest code base giving a false positive.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
The diff from `pretty-format-test.js` is a good example of the errors this rule picks up.
