### PR TITLE
Add promise support to all the matchers

### DIFF
--- a/packages/jest-matchers/src/__tests__/__snapshots__/matchers-test.js.snap
+++ b/packages/jest-matchers/src/__tests__/__snapshots__/matchers-test.js.snap
@@ -1,5 +1,143 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`.rejects fails for promise that resolves 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).rejects.toBe([22m[2m)[22m
+
+Expected [31mreceived[39m Promise to reject, instead it resolved to value
+  [31m4[39m"
+`;
+
+exports[`.rejects fails non-promise value "a" 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).rejects.toBeDefined([22m[2m)[22m
+
+[31mreceived[39m value must be a Promise.
+Received:
+  string: [31m\\"a\\"[39m"
+`;
+
+exports[`.rejects fails non-promise value [1] 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).rejects.toBeDefined([22m[2m)[22m
+
+[31mreceived[39m value must be a Promise.
+Received:
+  array: [31m[1][39m"
+`;
+
+exports[`.rejects fails non-promise value [Function anonymous] 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).rejects.toBeDefined([22m[2m)[22m
+
+[31mreceived[39m value must be a Promise.
+Received:
+  function: [31m[Function anonymous][39m"
+`;
+
+exports[`.rejects fails non-promise value {"a": 1} 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).rejects.toBeDefined([22m[2m)[22m
+
+[31mreceived[39m value must be a Promise.
+Received:
+  object: [31m{\\"a\\": 1}[39m"
+`;
+
+exports[`.rejects fails non-promise value 4 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).rejects.toBeDefined([22m[2m)[22m
+
+[31mreceived[39m value must be a Promise.
+Received:
+  number: [31m4[39m"
+`;
+
+exports[`.rejects fails non-promise value null 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).rejects.toBeDefined([22m[2m)[22m
+
+[31mreceived[39m value must be a Promise.
+Received: [31mnull[39m"
+`;
+
+exports[`.rejects fails non-promise value true 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).rejects.toBeDefined([22m[2m)[22m
+
+[31mreceived[39m value must be a Promise.
+Received:
+  boolean: [31mtrue[39m"
+`;
+
+exports[`.rejects fails non-promise value undefined 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).rejects.toBeDefined([22m[2m)[22m
+
+[31mreceived[39m value must be a Promise.
+Received: [31mundefined[39m"
+`;
+
+exports[`.resolves fails for promise that rejects 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).resolves.toBe([22m[2m)[22m
+
+Expected [31mreceived[39m Promise to resolve, instead it rejected to value
+  [31mundefined[39m"
+`;
+
+exports[`.resolves fails non-promise value "a" 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).resolves.toBeDefined([22m[2m)[22m
+
+[31mreceived[39m value must be a Promise.
+Received:
+  string: [31m\\"a\\"[39m"
+`;
+
+exports[`.resolves fails non-promise value [1] 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).resolves.toBeDefined([22m[2m)[22m
+
+[31mreceived[39m value must be a Promise.
+Received:
+  array: [31m[1][39m"
+`;
+
+exports[`.resolves fails non-promise value [Function anonymous] 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).resolves.toBeDefined([22m[2m)[22m
+
+[31mreceived[39m value must be a Promise.
+Received:
+  function: [31m[Function anonymous][39m"
+`;
+
+exports[`.resolves fails non-promise value {"a": 1} 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).resolves.toBeDefined([22m[2m)[22m
+
+[31mreceived[39m value must be a Promise.
+Received:
+  object: [31m{\\"a\\": 1}[39m"
+`;
+
+exports[`.resolves fails non-promise value 4 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).resolves.toBeDefined([22m[2m)[22m
+
+[31mreceived[39m value must be a Promise.
+Received:
+  number: [31m4[39m"
+`;
+
+exports[`.resolves fails non-promise value null 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).resolves.toBeDefined([22m[2m)[22m
+
+[31mreceived[39m value must be a Promise.
+Received: [31mnull[39m"
+`;
+
+exports[`.resolves fails non-promise value true 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).resolves.toBeDefined([22m[2m)[22m
+
+[31mreceived[39m value must be a Promise.
+Received:
+  boolean: [31mtrue[39m"
+`;
+
+exports[`.resolves fails non-promise value undefined 1`] = `
+"[2mexpect([22m[31mreceived[39m[2m).resolves.toBeDefined([22m[2m)[22m
+
+[31mreceived[39m value must be a Promise.
+Received: [31mundefined[39m"
+`;
+
 exports[`.toBe() does not crash on circular references 1`] = `
 "<dim>expect(<red>received</><dim>).toBe(<green>expected</><dim>)
 

--- a/packages/jest-matchers/src/__tests__/__snapshots__/matchers-test.js.snap
+++ b/packages/jest-matchers/src/__tests__/__snapshots__/matchers-test.js.snap
@@ -1,141 +1,141 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.rejects fails for promise that resolves 1`] = `
-"[2mexpect([22m[31mreceived[39m[2m).rejects.toBe([22m[2m)[22m
+"<dim>expect(<red>received</><dim>).rejects.toBe(<dim>)
 
-Expected [31mreceived[39m Promise to reject, instead it resolved to value
-  [31m4[39m"
+Expected <red>received</> Promise to reject, instead it resolved to value
+  <red>4</>"
 `;
 
 exports[`.rejects fails non-promise value "a" 1`] = `
-"[2mexpect([22m[31mreceived[39m[2m).rejects.toBeDefined([22m[2m)[22m
+"<dim>expect(<red>received</><dim>).rejects.toBeDefined(<dim>)
 
-[31mreceived[39m value must be a Promise.
+<red>received</> value must be a Promise.
 Received:
-  string: [31m\\"a\\"[39m"
+  string: <red>\\"a\\"</>"
 `;
 
 exports[`.rejects fails non-promise value [1] 1`] = `
-"[2mexpect([22m[31mreceived[39m[2m).rejects.toBeDefined([22m[2m)[22m
+"<dim>expect(<red>received</><dim>).rejects.toBeDefined(<dim>)
 
-[31mreceived[39m value must be a Promise.
+<red>received</> value must be a Promise.
 Received:
-  array: [31m[1][39m"
+  array: <red>[1]</>"
 `;
 
 exports[`.rejects fails non-promise value [Function anonymous] 1`] = `
-"[2mexpect([22m[31mreceived[39m[2m).rejects.toBeDefined([22m[2m)[22m
+"<dim>expect(<red>received</><dim>).rejects.toBeDefined(<dim>)
 
-[31mreceived[39m value must be a Promise.
+<red>received</> value must be a Promise.
 Received:
-  function: [31m[Function anonymous][39m"
+  function: <red>[Function anonymous]</>"
 `;
 
 exports[`.rejects fails non-promise value {"a": 1} 1`] = `
-"[2mexpect([22m[31mreceived[39m[2m).rejects.toBeDefined([22m[2m)[22m
+"<dim>expect(<red>received</><dim>).rejects.toBeDefined(<dim>)
 
-[31mreceived[39m value must be a Promise.
+<red>received</> value must be a Promise.
 Received:
-  object: [31m{\\"a\\": 1}[39m"
+  object: <red>{\\"a\\": 1}</>"
 `;
 
 exports[`.rejects fails non-promise value 4 1`] = `
-"[2mexpect([22m[31mreceived[39m[2m).rejects.toBeDefined([22m[2m)[22m
+"<dim>expect(<red>received</><dim>).rejects.toBeDefined(<dim>)
 
-[31mreceived[39m value must be a Promise.
+<red>received</> value must be a Promise.
 Received:
-  number: [31m4[39m"
+  number: <red>4</>"
 `;
 
 exports[`.rejects fails non-promise value null 1`] = `
-"[2mexpect([22m[31mreceived[39m[2m).rejects.toBeDefined([22m[2m)[22m
+"<dim>expect(<red>received</><dim>).rejects.toBeDefined(<dim>)
 
-[31mreceived[39m value must be a Promise.
-Received: [31mnull[39m"
+<red>received</> value must be a Promise.
+Received: <red>null</>"
 `;
 
 exports[`.rejects fails non-promise value true 1`] = `
-"[2mexpect([22m[31mreceived[39m[2m).rejects.toBeDefined([22m[2m)[22m
+"<dim>expect(<red>received</><dim>).rejects.toBeDefined(<dim>)
 
-[31mreceived[39m value must be a Promise.
+<red>received</> value must be a Promise.
 Received:
-  boolean: [31mtrue[39m"
+  boolean: <red>true</>"
 `;
 
 exports[`.rejects fails non-promise value undefined 1`] = `
-"[2mexpect([22m[31mreceived[39m[2m).rejects.toBeDefined([22m[2m)[22m
+"<dim>expect(<red>received</><dim>).rejects.toBeDefined(<dim>)
 
-[31mreceived[39m value must be a Promise.
-Received: [31mundefined[39m"
+<red>received</> value must be a Promise.
+Received: <red>undefined</>"
 `;
 
 exports[`.resolves fails for promise that rejects 1`] = `
-"[2mexpect([22m[31mreceived[39m[2m).resolves.toBe([22m[2m)[22m
+"<dim>expect(<red>received</><dim>).resolves.toBe(<dim>)
 
-Expected [31mreceived[39m Promise to resolve, instead it rejected to value
-  [31mundefined[39m"
+Expected <red>received</> Promise to resolve, instead it rejected to value
+  <red>undefined</>"
 `;
 
 exports[`.resolves fails non-promise value "a" 1`] = `
-"[2mexpect([22m[31mreceived[39m[2m).resolves.toBeDefined([22m[2m)[22m
+"<dim>expect(<red>received</><dim>).resolves.toBeDefined(<dim>)
 
-[31mreceived[39m value must be a Promise.
+<red>received</> value must be a Promise.
 Received:
-  string: [31m\\"a\\"[39m"
+  string: <red>\\"a\\"</>"
 `;
 
 exports[`.resolves fails non-promise value [1] 1`] = `
-"[2mexpect([22m[31mreceived[39m[2m).resolves.toBeDefined([22m[2m)[22m
+"<dim>expect(<red>received</><dim>).resolves.toBeDefined(<dim>)
 
-[31mreceived[39m value must be a Promise.
+<red>received</> value must be a Promise.
 Received:
-  array: [31m[1][39m"
+  array: <red>[1]</>"
 `;
 
 exports[`.resolves fails non-promise value [Function anonymous] 1`] = `
-"[2mexpect([22m[31mreceived[39m[2m).resolves.toBeDefined([22m[2m)[22m
+"<dim>expect(<red>received</><dim>).resolves.toBeDefined(<dim>)
 
-[31mreceived[39m value must be a Promise.
+<red>received</> value must be a Promise.
 Received:
-  function: [31m[Function anonymous][39m"
+  function: <red>[Function anonymous]</>"
 `;
 
 exports[`.resolves fails non-promise value {"a": 1} 1`] = `
-"[2mexpect([22m[31mreceived[39m[2m).resolves.toBeDefined([22m[2m)[22m
+"<dim>expect(<red>received</><dim>).resolves.toBeDefined(<dim>)
 
-[31mreceived[39m value must be a Promise.
+<red>received</> value must be a Promise.
 Received:
-  object: [31m{\\"a\\": 1}[39m"
+  object: <red>{\\"a\\": 1}</>"
 `;
 
 exports[`.resolves fails non-promise value 4 1`] = `
-"[2mexpect([22m[31mreceived[39m[2m).resolves.toBeDefined([22m[2m)[22m
+"<dim>expect(<red>received</><dim>).resolves.toBeDefined(<dim>)
 
-[31mreceived[39m value must be a Promise.
+<red>received</> value must be a Promise.
 Received:
-  number: [31m4[39m"
+  number: <red>4</>"
 `;
 
 exports[`.resolves fails non-promise value null 1`] = `
-"[2mexpect([22m[31mreceived[39m[2m).resolves.toBeDefined([22m[2m)[22m
+"<dim>expect(<red>received</><dim>).resolves.toBeDefined(<dim>)
 
-[31mreceived[39m value must be a Promise.
-Received: [31mnull[39m"
+<red>received</> value must be a Promise.
+Received: <red>null</>"
 `;
 
 exports[`.resolves fails non-promise value true 1`] = `
-"[2mexpect([22m[31mreceived[39m[2m).resolves.toBeDefined([22m[2m)[22m
+"<dim>expect(<red>received</><dim>).resolves.toBeDefined(<dim>)
 
-[31mreceived[39m value must be a Promise.
+<red>received</> value must be a Promise.
 Received:
-  boolean: [31mtrue[39m"
+  boolean: <red>true</>"
 `;
 
 exports[`.resolves fails non-promise value undefined 1`] = `
-"[2mexpect([22m[31mreceived[39m[2m).resolves.toBeDefined([22m[2m)[22m
+"<dim>expect(<red>received</><dim>).resolves.toBeDefined(<dim>)
 
-[31mreceived[39m value must be a Promise.
-Received: [31mundefined[39m"
+<red>received</> value must be a Promise.
+Received: <red>undefined</>"
 `;
 
 exports[`.toBe() does not crash on circular references 1`] = `

--- a/packages/jest-matchers/src/__tests__/matchers-test.js
+++ b/packages/jest-matchers/src/__tests__/matchers-test.js
@@ -14,6 +14,91 @@
 const jestExpect = require('../');
 const {stringify} = require('jest-matcher-utils');
 
+describe('.rejects', () => {
+  it('should reject', async () => {
+    await jestExpect(Promise.reject(4)).rejects.toBe(4);
+    await jestExpect(Promise.reject(4)).rejects.not.toBe(5);
+    await jestExpect(Promise.reject({a: 1, b: 2})).rejects.toMatchObject({a: 1});
+    await jestExpect(Promise.reject({a: 1, b: 2})).rejects.not.toMatchObject({c: 1});
+    await jestExpect(Promise.reject(() => {throw new Error();})).rejects.toThrow();
+  });
+
+  [
+    4,
+    [1],
+    {a: 1},
+    'a',
+    true,
+    null,
+    undefined,
+    () => {},
+  ].forEach(value => {
+    it(`fails non-promise value ${stringify(value)}`, async () => {
+      let error;
+      try {
+        await jestExpect(value).rejects.toBeDefined();
+      } catch (e) {
+        error = e;
+      }
+      expect(error).toBeDefined();
+      expect(error.message).toMatchSnapshot();
+    });
+  });
+
+  it('fails for promise that resolves', async () => {
+    let error;
+    try {
+      await jestExpect(Promise.resolve(4)).rejects.toBe(4);
+    } catch (e) {
+      error = e;
+    }
+    expect(error).toBeDefined();
+    expect(error.message).toMatchSnapshot();
+  });
+});
+
+describe('.resolves', () => {
+  it('should resolve', async () => {
+    await jestExpect(Promise.resolve(4)).resolves.toBe(4);
+    await jestExpect(Promise.resolve(4)).resolves.not.toBe(5);
+    await jestExpect(Promise.resolve({a: 1, b: 2})).resolves.toMatchObject({a: 1});
+    await jestExpect(Promise.resolve({a: 1, b: 2})).resolves.not.toMatchObject({c: 1});
+    await jestExpect(Promise.resolve(() => {throw new Error();})).resolves.toThrow();
+  });
+
+  [
+    4,
+    [1],
+    {a: 1},
+    'a',
+    true,
+    null,
+    undefined,
+    () => {},
+  ].forEach(value => {
+    it(`fails non-promise value ${stringify(value)}`, async () => {
+      let error;
+      try {
+        await jestExpect(value).resolves.toBeDefined();
+      } catch (e) {
+        error = e;
+      }
+      expect(error).toBeDefined();
+      expect(error.message).toMatchSnapshot();
+    });
+  });
+
+  it('fails for promise that rejects', async () => {
+    let error;
+    try {
+      await jestExpect(Promise.reject(4)).resolves.toBe(4);
+    } catch (e) {
+      error = e;
+    }
+    expect(error).toBeDefined();
+    expect(error.message).toMatchSnapshot();
+  });
+});
 describe('.toBe()', () => {
   it('does not throw', () => {
     jestExpect('a').not.toBe('b');

--- a/packages/jest-matchers/src/__tests__/matchers-test.js
+++ b/packages/jest-matchers/src/__tests__/matchers-test.js
@@ -18,6 +18,8 @@ describe('.rejects', () => {
   it('should reject', async () => {
     await jestExpect(Promise.reject(4)).rejects.toBe(4);
     await jestExpect(Promise.reject(4)).rejects.not.toBe(5);
+    await jestExpect(Promise.reject(4.2)).rejects.toBeCloseTo(4.2, 5);
+    await jestExpect(Promise.reject((3))).rejects.not.toBeCloseTo(4.2, 5);
     await jestExpect(Promise.reject({a: 1, b: 2})).rejects.toMatchObject({a: 1});
     await jestExpect(Promise.reject({a: 1, b: 2})).rejects.not.toMatchObject({c: 1});
     await jestExpect(Promise.reject(() => {throw new Error();})).rejects.toThrow();
@@ -61,6 +63,8 @@ describe('.resolves', () => {
   it('should resolve', async () => {
     await jestExpect(Promise.resolve(4)).resolves.toBe(4);
     await jestExpect(Promise.resolve(4)).resolves.not.toBe(5);
+    await jestExpect(Promise.resolve(4.2)).resolves.toBeCloseTo(4.2, 5);
+    await jestExpect(Promise.resolve((3))).resolves.not.toBeCloseTo(4.2, 5);
     await jestExpect(Promise.resolve({a: 1, b: 2})).resolves.toMatchObject({a: 1});
     await jestExpect(Promise.resolve({a: 1, b: 2})).resolves.not.toMatchObject({c: 1});
     await jestExpect(Promise.resolve(() => {throw new Error();})).resolves.toThrow();

--- a/packages/jest-matchers/src/index.js
+++ b/packages/jest-matchers/src/index.js
@@ -132,7 +132,7 @@ const makeResolveMatcher = (
       `  ${utils.printReceived(result)}`
     );
   }
-  return makeThrowingMatcher(matcher, isNot, result)(...args);
+  return makeThrowingMatcher(matcher, isNot, result).apply(null, args);
 };
 
 const makeRejectMatcher = (
@@ -154,7 +154,7 @@ const makeRejectMatcher = (
   try {
     result = await actual;
   } catch (e) {
-    return makeThrowingMatcher(matcher, isNot, e)(...args);
+    return makeThrowingMatcher(matcher, isNot, e).apply(null, args);
   }
 
   throw new JestAssertionError(

--- a/packages/jest-matchers/src/index.js
+++ b/packages/jest-matchers/src/index.js
@@ -19,6 +19,7 @@ import type {
   MatchersObject,
   RawMatcherFn,
   ThrowingMatcherFn,
+  PromiseMatcherFn,
 } from 'types/Matchers';
 
 const matchers = require('./matchers');
@@ -41,6 +42,12 @@ class JestAssertionError extends Error {
   matcherResult: any;
 }
 
+const isPromise = obj => {
+  return !!obj &&
+    (typeof obj === 'object' || typeof obj === 'function') &&
+    typeof obj.then === 'function';
+};
+
 if (!global[GLOBAL_STATE]) {
   Object.defineProperty(global, GLOBAL_STATE, {
     value: {
@@ -56,7 +63,12 @@ if (!global[GLOBAL_STATE]) {
 
 const expect: Expect = (actual: any): ExpectationObject => {
   const allMatchers = global[GLOBAL_STATE].matchers;
-  const expectation = {not: {}};
+  const expectation = {
+    not: {},
+    rejects: {not: {}},
+    resolves: {not: {}},
+  };
+
   Object.keys(allMatchers).forEach(name => {
     expectation[name] = makeThrowingMatcher(allMatchers[name], false, actual);
     expectation.not[name] = makeThrowingMatcher(
@@ -65,6 +77,24 @@ const expect: Expect = (actual: any): ExpectationObject => {
       actual,
     );
   });
+
+  const resolveExpectation = {not: {}};
+  Object.keys(allMatchers).forEach(name => {
+    resolveExpectation[name] =
+      makeResolveMatcher(name, allMatchers[name], false, actual);
+    resolveExpectation.not[name] =
+      makeResolveMatcher(name, allMatchers[name], true, actual);
+  });
+  expectation.resolves = resolveExpectation;
+
+  const rejectExpectation = {not: {}};
+  Object.keys(allMatchers).forEach(name => {
+    rejectExpectation[name] =
+      makeRejectMatcher(name, allMatchers[name], false, actual);
+    rejectExpectation.not[name] =
+      makeRejectMatcher(name, allMatchers[name], true, actual);
+  });
+  expectation.rejects = rejectExpectation;
 
   return expectation;
 };
@@ -82,6 +112,65 @@ const getMessage = message => {
     );
   }
   return message;
+};
+
+const makeResolveMatcher = (
+  matcherName: string,
+  matcher: RawMatcherFn,
+  isNot: boolean,
+  actual: Promise<any>
+): PromiseMatcherFn => async (...args) => {
+  const matcherStatement = `.resolves.${isNot ? 'not.' : ''}${matcherName}`;
+  if (!isPromise(actual)) {
+    throw new JestAssertionError(
+      utils.matcherHint(matcherStatement, 'received', '') + '\n\n' +
+      `${utils.RECEIVED_COLOR('received')} value must be a Promise.\n` +
+      utils.printWithType('Received', actual, utils.printReceived),
+    );
+  }
+
+  let result;
+  try {
+    result = await actual;
+  } catch (e) {
+    throw new JestAssertionError(
+      utils.matcherHint(matcherStatement, 'received', '') + '\n\n' +
+      `Expected ${utils.RECEIVED_COLOR('received')} Promise to resolve, ` +
+      'instead it rejected to value\n' +
+      `  ${utils.printReceived(result)}`
+    );
+  }
+  return makeThrowingMatcher(matcher, isNot, result)(...args);
+};
+
+const makeRejectMatcher = (
+  matcherName: string,
+  matcher: RawMatcherFn,
+  isNot: boolean,
+  actual: Promise<any>
+): PromiseMatcherFn => async (...args) => {
+  const matcherStatement = `.rejects.${isNot ? 'not.' : ''}${matcherName}`;
+  if (!isPromise(actual)) {
+    throw new JestAssertionError(
+      utils.matcherHint(matcherStatement, 'received', '') + '\n\n' +
+      `${utils.RECEIVED_COLOR('received')} value must be a Promise.\n` +
+      utils.printWithType('Received', actual, utils.printReceived),
+    );
+  }
+
+  let result;
+  try {
+    result = await actual;
+  } catch (e) {
+    return makeThrowingMatcher(matcher, isNot, e)(...args);
+  }
+
+  throw new JestAssertionError(
+    utils.matcherHint(matcherStatement, 'received', '') + '\n\n' +
+    `Expected ${utils.RECEIVED_COLOR('received')} Promise to reject, ` +
+    'instead it resolved to value\n' +
+    `  ${utils.printReceived(result)}`
+  );
 };
 
 const makeThrowingMatcher = (

--- a/packages/jest-matchers/src/index.js
+++ b/packages/jest-matchers/src/index.js
@@ -76,25 +76,17 @@ const expect: Expect = (actual: any): ExpectationObject => {
       true,
       actual,
     );
-  });
 
-  const resolveExpectation = {not: {}};
-  Object.keys(allMatchers).forEach(name => {
-    resolveExpectation[name] =
+    expectation.resolves[name] =
       makeResolveMatcher(name, allMatchers[name], false, actual);
-    resolveExpectation.not[name] =
+    expectation.resolves.not[name] =
       makeResolveMatcher(name, allMatchers[name], true, actual);
-  });
-  expectation.resolves = resolveExpectation;
 
-  const rejectExpectation = {not: {}};
-  Object.keys(allMatchers).forEach(name => {
-    rejectExpectation[name] =
+    expectation.rejects[name] =
       makeRejectMatcher(name, allMatchers[name], false, actual);
-    rejectExpectation.not[name] =
+    expectation.rejects.not[name] =
       makeRejectMatcher(name, allMatchers[name], true, actual);
   });
-  expectation.rejects = rejectExpectation;
 
   return expectation;
 };

--- a/types/Matchers.js
+++ b/types/Matchers.js
@@ -23,6 +23,7 @@ export type RawMatcherFn = (
 ) => ExpectationResult;
 
 export type ThrowingMatcherFn = (actual: any) => void;
+export type PromiseMatcherFn = (actual: any) => Promise<void>;
 export type MatcherContext = {isNot: boolean};
 export type MatcherState = {
   assertionCalls?: number,
@@ -33,6 +34,14 @@ export type MatcherState = {
 export type MatchersObject = {[id:string]: RawMatcherFn};
 export type Expect = (expected: any) => ExpectationObject;
 export type ExpectationObject = {
+  resolves: {
+    [id: string]: PromiseMatcherFn,
+    not: {[id: string]: PromiseMatcherFn},
+  },
+  rejects: {
+    [id: string]: PromiseMatcherFn,
+    not: {[id: string]: PromiseMatcherFn},
+  },
   [id: string]: ThrowingMatcherFn,
   not: {[id: string]: ThrowingMatcherFn},
 };


### PR DESCRIPTION
This PR addresses issue #1377 and adds promise support to **all the existing matchers** in jest. 

This allows us to run assertions on promises by adding the keywords `resolves` and `rejects` after the expect statement as follows:

```js
it('should reject', () => {
    return expect(Promise.reject(4)).rejects.toBe(4);
});
it('should resolve', () => {
   return expect(Promise.resolve(4)).resolves.toBe(4);
});
```

It can also easily be used in combination with `async/await`:

```js
it('should reject', async () => {
   await expect(Promise.reject(4)).rejects.toBe(4);
   await expect(Promise.reject(4)).rejects.not.toBe(5);
});
it('should resolve', async () => {
   await expect(Promise.resolve(4)).resolves.toBe(4);
   await expect(Promise.resolve(4)).resolves.not.toBe(5);
});
```

I would love to hear some feedback on this API!

**Other API Design Choices**

@julien-f I also considered the proposal you made in your [gist](https://gist.github.com/julien-f/ef8a268a8190c79ef8b8b52e03de7376#file-readme-md). You proposed the following API: 

```js
it('should resolve', async () => {
   await expect(Promise.resolve(4)).toResolve().toBe(4);
});
```

As far as I can tell the API in your proposal doesn't work unfortunately, we must first `await` for the `toResolve()`  before we can run assertions on it. When I tried to implement it I found that the API would look as follows in reality:

```js
it('should resolve', async () => {
   (await expect(Promise.resolve(4)).toResolve()).toBe(4);
});
```

The above code snippet seemed less intuitive and clean to me. That is why I decided to go with the API I proposed above.

**TBD: Add a matcher for checking if promise rejects/resolve**:

I think there is a place for a matcher that simply checks whether a promise resolves/rejects similar to the one proposed by @julien-f! This is not something that I implemented in this PR, but just an idea.

```js
it('should resolve', () => {
   return expect(Promise.resolve(4)).toResolve();
});
```

```js
it('should reject', () => {
   return expect(Promise.reject(4)).toReject();
});
```

**Docs**

I have not updated the docs yet. First I would like to get some feedback on the API:)