### PR TITLE
fix reporter test in TestRunner-test.js

### DIFF
--- a/packages/jest-cli/src/__tests__/TestRunner-test.js
+++ b/packages/jest-cli/src/__tests__/TestRunner-test.js
@@ -31,8 +31,6 @@ jest.mock('../reporters/DefaultReporter');
 
 test('.addReporter() .removeReporter()', () => {
   const runner = new TestRunner({}, {}, {});
-  runner._dispatcher._reporters = [];
-
   const reporter = new SummaryReporter();
 
   expect(runner._dispatcher._reporters).toHaveLength(2);

--- a/packages/jest-cli/src/__tests__/TestRunner-test.js
+++ b/packages/jest-cli/src/__tests__/TestRunner-test.js
@@ -35,10 +35,15 @@ test('.addReporter() .removeReporter()', () => {
 
   const reporter = new SummaryReporter();
 
+  expect(runner._dispatcher._reporters).toHaveLength(2);
   runner.addReporter(reporter);
+
   expect(runner._dispatcher._reporters).toContain(reporter);
-  
+  expect(runner._dispatcher._reporters).toHaveLength(3);  
+
   runner.removeReporter(SummaryReporter);
+
+  expect(runner._dispatcher._reporters).toHaveLength(2);
   expect(runner._dispatcher._reporters).not.toContain(reporter);
 });
 

--- a/packages/jest-cli/src/__tests__/TestRunner-test.js
+++ b/packages/jest-cli/src/__tests__/TestRunner-test.js
@@ -31,9 +31,13 @@ jest.mock('../reporters/DefaultReporter');
 
 test('.addReporter() .removeReporter()', () => {
   const runner = new TestRunner({}, {}, {});
+  runner._dispatcher._reporters = [];
+
   const reporter = new SummaryReporter();
+
   runner.addReporter(reporter);
   expect(runner._dispatcher._reporters).toContain(reporter);
+  
   runner.removeReporter(SummaryReporter);
   expect(runner._dispatcher._reporters).not.toContain(reporter);
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
This PR fixes the `.addReporter .removeReporter` test in TestRunner-test.js which was not right in it's .addReporter test implementation. 

Whenever the TestRunner.js is called two default reporters are automatically right now `DefaultReporter` and `SummaryReporter`, we can't test the add reporter on the reporters that are there by default. 

I set the `_reporters` to an empty array for truly testing if `.addReporter` works fine.  
