### PR TITLE
Update babylon plugins in BabylonParser, solves #3070

### DIFF
--- a/fixtures/global_its.example
+++ b/fixtures/global_its.example
@@ -11,6 +11,10 @@ it('works with flow functions', () => {
   function foo(x: string): string { return x; }
 });
 
+it('works with JSX', ()=> {
+  const foo = () => <div></div>;
+})
+
 it.only('works with it.only', () => {
 
 });

--- a/fixtures/parserTests.js
+++ b/fixtures/parserTests.js
@@ -24,7 +24,7 @@ function parserTests(parse: (file: string) => any) {
     it('For the simplest it cases', () => {
       const data = parse(`${fixtures}/global_its.example`);
 
-      expect(data.itBlocks.length).toEqual(7);
+      expect(data.itBlocks.length).toEqual(8);
 
       const firstIt = data.itBlocks[0];
       expect(firstIt.name).toEqual('works with old functions');
@@ -41,25 +41,30 @@ function parserTests(parse: (file: string) => any) {
       expect(thirdIt.start).toEqual({column: 1, line: 10});
       expect(thirdIt.end).toEqual({column: 3, line: 12});
 
-      const fourthIt = data.itBlocks[3];
-      expect(fourthIt.name).toEqual('works with it.only');
-      expect(fourthIt.start).toEqual({column: 1, line: 14});
-      expect(fourthIt.end).toEqual({column: 3, line: 16});
+      const fourthIt = data.itBlocks[2];
+      expect(fourthIt.name).toEqual('works with flow functions');
+      expect(fourthIt.start).toEqual({column: 1, line: 10});
+      expect(fourthIt.end).toEqual({column: 3, line: 12});
 
       const fifthIt = data.itBlocks[4];
-      expect(fifthIt.name).toEqual('works with fit');
+      expect(fifthIt.name).toEqual('works with it.only');
       expect(fifthIt.start).toEqual({column: 1, line: 18});
       expect(fifthIt.end).toEqual({column: 3, line: 20});
 
       const sixthIt = data.itBlocks[5];
-      expect(sixthIt.name).toEqual('works with test');
+      expect(sixthIt.name).toEqual('works with fit');
       expect(sixthIt.start).toEqual({column: 1, line: 22});
       expect(sixthIt.end).toEqual({column: 3, line: 24});
 
       const seventhIt = data.itBlocks[6];
-      expect(seventhIt.name).toEqual('works with test.only');
+      expect(seventhIt.name).toEqual('works with test');
       expect(seventhIt.start).toEqual({column: 1, line: 26});
       expect(seventhIt.end).toEqual({column: 3, line: 28});
+
+      const eigthIt = data.itBlocks[7];
+      expect(eigthIt.name).toEqual('works with test.only');
+      expect(eigthIt.start).toEqual({column: 1, line: 30});
+      expect(eigthIt.end).toEqual({column: 3, line: 32});
     });
 
     it('For its inside describes', () => {

--- a/packages/jest-editor-support/package.json
+++ b/packages/jest-editor-support/package.json
@@ -8,7 +8,7 @@
   "license": "BSD-3-Clause",
   "main": "build/index.js",
   "dependencies": {
-    "babylon": "^6.13.0"
+    "babylon": "^6.14.1"
   },
   "typings": "index.d.ts"
 }

--- a/packages/jest-editor-support/src/parsers/BabylonParser.js
+++ b/packages/jest-editor-support/src/parsers/BabylonParser.js
@@ -52,8 +52,8 @@ const parse = (file: string) => {
   const babel = JSON.parse(babelRC);
 
   const plugins = Array.isArray(babel.plugins)
-    ? babel.plugins.concat(['flow'])
-    : ['flow'];
+    ? babel.plugins.concat(['*'])
+    : ['*'];
 
   const config = {plugins, sourceType: 'module'};
   const ast = babylon.parse(data, config);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Solves #3070. Instead of including only the 'flow' babylon plugin, all available babylon plugins are included. As a result, parsing files containing JSX does not produce an error.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
Added a test case to `fixtures/global_its.example` and `fixtures/global_its.example`. The test checks whether parsing works with JSX:

```js
it('works with JSX', ()=> {
  const foo = () => <div></div>;
})
```

This test wouldn't pass without the change. It does pass with the change.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->