### PR TITLE
Collapse Watch Usage prompt after first run

### DIFF
--- a/packages/jest-cli/src/constants.js
+++ b/packages/jest-cli/src/constants.js
@@ -31,6 +31,7 @@ const KEYS = {
   QUESTION_MARK: '3f',
   T: '74',
   U: '75',
+  W: '77',
 };
 
 const ICONS = {

--- a/packages/jest-cli/src/watch.js
+++ b/packages/jest-cli/src/watch.js
@@ -55,7 +55,8 @@ const watch = (
   let hasSnapshotFailure = false;
   let isRunning = false;
   let testWatcher;
-  let displayHelp = true;
+  let shouldDisplayWatchUsage = true;
+  let isWatchUsageDisplayed = false;
 
   testPathPatternPrompt.updateSearchSource(hasteContext);
 
@@ -113,9 +114,14 @@ const watch = (
         // The old instance that was passed to Jest will still be interrupted
         // and prevent test runs from the previous run.
         testWatcher = new TestWatcher({isWatchMode: true});
-        if (displayHelp) {
+        if (shouldDisplayWatchUsage) {
           pipe.write(usage(argv, hasSnapshotFailure));
-          displayHelp = !process.env.JEST_HIDE_USAGE;
+          shouldDisplayWatchUsage = false; // hide Watch Usage after first run
+          isWatchUsageDisplayed = true;
+        } else {
+          pipe.write(showToggleUsagePrompt());
+          shouldDisplayWatchUsage = false;
+          isWatchUsageDisplayed = false;
         }
 
         testNamePatternPrompt.updateCachedTestResults(results.testResults);
@@ -195,8 +201,14 @@ const watch = (
         );
         break;
       case KEYS.QUESTION_MARK:
-        if (process.env.JEST_HIDE_USAGE) {
+        break;
+      case KEYS.W:
+        if (!shouldDisplayWatchUsage && !isWatchUsageDisplayed) {
+          pipe.write(ansiEscapes.cursorUp());
+          pipe.write(ansiEscapes.eraseDown);
           pipe.write(usage(argv, hasSnapshotFailure));
+          isWatchUsageDisplayed = true;
+          shouldDisplayWatchUsage = false;
         }
         break;
     }
@@ -285,5 +297,12 @@ const usage = (argv, snapshotFailure, delimiter = '\n') => {
   /* eslint-enable max-len */
   return messages.filter(message => !!message).join(delimiter) + '\n';
 };
+
+const showToggleUsagePrompt = () =>
+  '\n' +
+  chalk.bold('Watch Usage: ') +
+  chalk.dim('Press ') +
+  'w' +
+  chalk.dim(' to show more.');
 
 module.exports = watch;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

This PR makes watch mode collapsed after first run, so it doesn't occupy so much of vertical space. It's possible to show the usage when pressing "w".

Here's a preview:

![watch](https://cloud.githubusercontent.com/assets/5106466/23612076/dc40306a-0271-11e7-8561-242a137fcc9b.gif)


**Test plan**

Need to write a test for that
