### PR TITLE
lint all examples using eslint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,7 +3,6 @@
 **/vendor/**
 bin/
 docs/
-examples/react-native
 flow-typed/**
 packages/*/build/**
 types/**

--- a/examples/react-native/Intro.js
+++ b/examples/react-native/Intro.js
@@ -3,45 +3,45 @@
  * https://github.com/facebook/react-native
  * @flow
  */
- 'use strict';
+'use strict';
 
- import React, {Component} from 'react';
- import {
+import React, {Component} from 'react';
+import {
   StyleSheet,
   Text,
   View,
 } from 'react-native';
 
- const styles = StyleSheet.create({
-   container: {
-     alignItems: 'center',
-     backgroundColor: '#F5FCFF',
-     flex: 1,
-     justifyContent: 'center',
-   },
-   instructions: {
-     color: '#333333',
-     marginBottom: 5,
-     textAlign: 'center',
-   },
-   welcome: {
-     fontSize: 20,
-     margin: 10,
-     textAlign: 'center',
-   },
- });
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    backgroundColor: '#F5FCFF',
+    flex: 1,
+    justifyContent: 'center',
+  },
+  instructions: {
+    color: '#333333',
+    marginBottom: 5,
+    textAlign: 'center',
+  },
+  welcome: {
+    fontSize: 20,
+    margin: 10,
+    textAlign: 'center',
+  },
+});
 
- export default class Intro extends Component {
-   render() {
-     return (
-      <View style={styles.container}>
-        <Text style={styles.welcome}>
-          Welcome to React Native!
-        </Text>
-        <Text style={styles.instructions}>
-          This is a React Native snapshot test.
-        </Text>
-      </View>
-     );
-   }
+export default class Intro extends Component {
+  render() {
+    return (
+    <View style={styles.container}>
+      <Text style={styles.welcome}>
+        Welcome to React Native!
+      </Text>
+      <Text style={styles.instructions}>
+        This is a React Native snapshot test.
+      </Text>
+    </View>
+    );
+  }
 }

--- a/examples/react-native/Intro.js
+++ b/examples/react-native/Intro.js
@@ -5,35 +5,35 @@
  */
  'use strict';
 
-import React, {Component} from 'react';
-import {
+ import React, {Component} from 'react';
+ import {
   StyleSheet,
   Text,
-  View
+  View,
 } from 'react-native';
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    backgroundColor: '#F5FCFF',
-  },
-  welcome: {
-    fontSize: 20,
-    textAlign: 'center',
-    margin: 10,
-  },
-  instructions: {
-    textAlign: 'center',
-    color: '#333333',
-    marginBottom: 5,
-  },
-});
+ const styles = StyleSheet.create({
+   container: {
+     alignItems: 'center',
+     backgroundColor: '#F5FCFF',
+     flex: 1,
+     justifyContent: 'center',
+   },
+   instructions: {
+     color: '#333333',
+     marginBottom: 5,
+     textAlign: 'center',
+   },
+   welcome: {
+     fontSize: 20,
+     margin: 10,
+     textAlign: 'center',
+   },
+ });
 
-export default class Intro extends Component {
-  render() {
-    return (
+ export default class Intro extends Component {
+   render() {
+     return (
       <View style={styles.container}>
         <Text style={styles.welcome}>
           Welcome to React Native!
@@ -42,6 +42,6 @@ export default class Intro extends Component {
           This is a React Native snapshot test.
         </Text>
       </View>
-    );
-  }
+     );
+   }
 }

--- a/examples/react-native/__tests__/Intro-test.js
+++ b/examples/react-native/__tests__/Intro-test.js
@@ -30,7 +30,7 @@ it('renders the Image component', done => {
   const Image = require('Image');
   Image.getSize('path.jpg', (width, height) => {
     const tree = renderer.create(
-      <Image style={{width, height}} />
+      <Image style={{height, width}} />
     ).toJSON();
     expect(tree).toMatchSnapshot();
     done();
@@ -59,7 +59,7 @@ it('renders the ListView component', () => {
   const tree = renderer.create(
     <ListView
       dataSource={dataSource}
-      renderRow={(rowData) => <Text>{rowData}</Text>}
+      renderRow={rowData => <Text>{rowData}</Text>}
     />
   ).toJSON();
   expect(tree).toMatchSnapshot();


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Lint all the examples including `examples/react-native`. For some reason, `examples/react-native` was added in `.eslintignore` and wasn't being linted. I have removed it from `.eslintignore` and fixed all the lint errors thrown out by examples/react-native. Now all the examples are guaranteed linted, as there are no remaining example folder in `.eslintignore`. 

This emerged from the discuss here https://github.com/facebook/jest/pull/3047#issuecomment-284344520 with @cpojer

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
`yarn run lint` works 