### PR TITLE
Assert only known matchers are used

### DIFF
--- a/packages/eslint-plugin-jest/package.json
+++ b/packages/eslint-plugin-jest/package.json
@@ -17,6 +17,9 @@
     "url": "https://github.com/facebook/jest.git"
   },
   "main": "build/index.js",
+  "dependencies": {
+    "jest-matchers": "^19.0.0"
+  },
   "peerDependencies": {
     "eslint": ">=3.6"
   },

--- a/packages/eslint-plugin-jest/src/rules/__tests__/valid-expect-test.js
+++ b/packages/eslint-plugin-jest/src/rules/__tests__/valid-expect-test.js
@@ -77,5 +77,13 @@ ruleTester.run('valid-expect', rules['valid-expect'], {
         },
       ],
     },
+    {
+      code: 'expect(true).not.toBeDefined;',
+      errors: [
+        {
+          message: '"toBeDefined" was not called.',
+        },
+      ],
+    },
   ],
 });

--- a/packages/eslint-plugin-jest/src/rules/__tests__/valid-expect-test.js
+++ b/packages/eslint-plugin-jest/src/rules/__tests__/valid-expect-test.js
@@ -85,5 +85,13 @@ ruleTester.run('valid-expect', rules['valid-expect'], {
         },
       ],
     },
+    {
+      code: 'expect(true).nope.toBeDefined;',
+      errors: [
+        {
+          message: '"nope" is not a valid property of expect.',
+        },
+      ],
+    },
   ],
 });

--- a/packages/eslint-plugin-jest/src/rules/__tests__/valid-expect-test.js
+++ b/packages/eslint-plugin-jest/src/rules/__tests__/valid-expect-test.js
@@ -23,6 +23,14 @@ ruleTester.run('valid-expect', rules['valid-expect'], {
     'expect(true).toBeDefined();',
     'expect([1, 2, 3]).toEqual([1, 2, 3]);',
     'expect(undefined).not.toBeDefined();',
+    {
+      code: 'expect(true).toBeSomethingWeird();',
+      options: [{extraMatchers: ['toBeSomethingWeird']}],
+    },
+    {
+      code: 'expect(true).not.toBeSomethingWeird();',
+      options: [{extraMatchers: ['toBeSomethingWeird']}],
+    },
   ],
 
   invalid: [
@@ -91,7 +99,52 @@ ruleTester.run('valid-expect', rules['valid-expect'], {
         {
           message: '"nope" is not a valid property of expect.',
         },
+        {
+          message: '"toBeDefined" was not called.',
+        },
       ],
+    },
+    {
+      code: 'expect(true).nope.toBeDefined();',
+      errors: [
+        {
+          message: '"nope" is not a valid property of expect.',
+        },
+      ],
+    },
+    {
+      code: 'expect(true).toBeSomethingWeird();',
+      errors: [
+        {
+          message: '"toBeSomethingWeird" is not a known matcher.',
+        },
+      ],
+    },
+    {
+      code: 'expect(true).not.toBeSomethingWeird();',
+      errors: [
+        {
+          message: '"toBeSomethingWeird" is not a known matcher.',
+        },
+      ],
+    },
+    {
+      code: 'expect(true).not.toBeSomethingElseWeird();',
+      errors: [
+        {
+          message: '"toBeSomethingElseWeird" is not a known matcher.',
+        },
+      ],
+      options: [{extraMatchers: ['toBeSomethingWeird']}],
+    },
+    {
+      code: 'expect(true).not.toBeSomethingWeird();',
+      errors: [
+        {
+          message: '"toBeSomethingWeird" is not a known matcher.',
+        },
+      ],
+      options: [{extraTypos: ['toBeSomethingWeird']}],
     },
   ],
 });

--- a/packages/eslint-plugin-jest/src/rules/valid-expect.js
+++ b/packages/eslint-plugin-jest/src/rules/valid-expect.js
@@ -42,12 +42,19 @@ module.exports = (context: EslintContext) => {
           let propertyName = node.parent.property.name;
           let grandParentType = node.parent.parent.type;
 
-          // `not` is used, get the next property
-          if (
-            propertyName === 'not' && grandParentType === 'MemberExpression'
-          ) {
-            propertyName = node.parent.parent.property.name;
-            grandParentType = node.parent.parent.parent.type;
+          // a property is accessed, get the next node
+          if (grandParentType === 'MemberExpression') {
+            // `not` is used, just get the next one
+            if (propertyName === 'not') {
+              propertyName = node.parent.parent.property.name;
+              grandParentType = node.parent.parent.parent.type;
+            } else {
+              // only `not` is allowed
+              context.report({
+                message: `"${propertyName}" is not a valid property of expect.`,
+                node,
+              });
+            }
           }
 
           // matcher was not called

--- a/packages/eslint-plugin-jest/src/rules/valid-expect.js
+++ b/packages/eslint-plugin-jest/src/rules/valid-expect.js
@@ -33,17 +33,30 @@ module.exports = (context: EslintContext) => {
           });
         }
 
-        // matcher was not called
+        // something was called on `expect()`
         if (
           node.parent &&
           node.parent.type === 'MemberExpression' &&
-          node.parent.parent &&
-          node.parent.parent.type === 'ExpressionStatement'
+          node.parent.parent
         ) {
-          context.report({
-            message: `"${node.parent.property.name}" was not called.`,
-            node,
-          });
+          let propertyName = node.parent.property.name;
+          let grandParentType = node.parent.parent.type;
+
+          // `not` is used, get the next property
+          if (
+            propertyName === 'not' && grandParentType === 'MemberExpression'
+          ) {
+            propertyName = node.parent.parent.property.name;
+            grandParentType = node.parent.parent.parent.type;
+          }
+
+          // matcher was not called
+          if (grandParentType === 'ExpressionStatement') {
+            context.report({
+              message: `"${propertyName}" was not called.`,
+              node,
+            });
+          }
         }
       }
     },


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
While the runtime might say something like `toBeDefind() is not a function`, I think it's cleaner to warn before tests are run at all.

This PR also includes actually warning if you do `expect(something).not.toEqual;`, which previously wasn't picked up. In addition, we check that if you have a middle property, it's called `not`, and not something else.

I can split this into separate PRs if you want?
This is missing docs, if you want the last change (checking for matchers) I can add them. The two other changes are bug fixes which don't need doc changes, IMO.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
I think the tests are enough?