### PR TITLE
[jest-cli] Lift `Objecy.keys` call from loop.

### DIFF
--- a/packages/jest-cli/src/SearchSource.js
+++ b/packages/jest-cli/src/SearchSource.js
@@ -150,8 +150,10 @@ class SearchSource {
       testCases.testPathPattern = path => regex.test(path);
     }
 
+    const testCasesKeys = Object.keys(testCases);
+
     data.paths = allPaths.filter(path => {
-      return Object.keys(testCases).reduce((flag, key) => {
+      return testCasesKeys.reduce((flag, key) => {
         if (testCases[key](path)) {
           data.stats[key] = ++data.stats[key] || 1;
           return flag && true;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Lifts an `Object.keys` call in `jest-cli` out of a loop.  It should save a little over 500 calls when running `yarn run jest`; not really a noticeable difference.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
Nothing should change.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
