### PR TITLE
use Plugin type for pretty-format plugins

### DIFF
--- a/packages/pretty-format/src/index.js
+++ b/packages/pretty-format/src/index.js
@@ -25,12 +25,14 @@ type Theme = {|
 type InitialOptions = {|
   callToJSON?: boolean,
   escapeRegex?: boolean,
+  edgeSpacing?: string,
   highlight?: boolean,
   indent?: number,
   maxDepth?: number,
   min?: boolean,
   plugins?: Plugins,
   printFunctionName?: boolean,
+  spacing?: string,
   theme?: Theme,
 |};
 
@@ -770,6 +772,7 @@ function print(
 
 const DEFAULTS: Options = {
   callToJSON: true,
+  edgeSpacing: '\n',
   escapeRegex: false,
   highlight: false,
   indent: 2,
@@ -777,6 +780,7 @@ const DEFAULTS: Options = {
   min: false,
   plugins: [],
   printFunctionName: true,
+  spacing: '\n',
   theme: {
     content: 'reset',
     prop: 'yellow',

--- a/packages/pretty-format/src/plugins/AsymmetricMatcher.js
+++ b/packages/pretty-format/src/plugins/AsymmetricMatcher.js
@@ -9,18 +9,20 @@
 
 'use strict';
 
+import type {Colors, Indent, Options, Print, Plugin} from '../types.js';
+
 const asymmetricMatcher = Symbol.for('jest.asymmetricMatcher');
 const SPACE = ' ';
 
 class ArrayContaining extends Array {}
 class ObjectContaining extends Object {}
 
-const printAsymmetricMatcher = (
+const print = (
   val: any,
-  print: Function,
-  indent: Function,
-  opts: Object,
-  colors: Object,
+  print: Print,
+  indent: Indent,
+  opts: Options,
+  colors: Colors,
 ) => {
   const stringedValue = val.toString();
 
@@ -49,7 +51,6 @@ const printAsymmetricMatcher = (
   return val.toAsymmetricMatcher();
 };
 
-module.exports = {
-  print: printAsymmetricMatcher,
-  test: (object: any) => object && object.$$typeof === asymmetricMatcher,
-};
+const test = (object: any) => object && object.$$typeof === asymmetricMatcher;
+
+module.exports = ({print, test}: Plugin);

--- a/packages/pretty-format/src/plugins/ImmutableList.js
+++ b/packages/pretty-format/src/plugins/ImmutableList.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-import type {Colors, Indent, Options, Print} from '../types.js';
+import type {Colors, Indent, Options, Print, Plugin} from '../types.js';
 
 const printImmutable = require('./lib/printImmutable');
 
@@ -25,4 +25,4 @@ const print = (
   colors: Colors,
 ) => printImmutable(val, print, indent, opts, colors, 'List', false);
 
-module.exports = {print, test};
+module.exports = ({print, test}: Plugin);

--- a/packages/pretty-format/src/plugins/ImmutableMap.js
+++ b/packages/pretty-format/src/plugins/ImmutableMap.js
@@ -10,12 +10,17 @@
 
 'use strict';
 
-import type {Colors, Indent, Options, Print} from '../types.js';
+import type {Colors, Indent, Options, Print, Plugin} from '../types.js';
 
 const printImmutable = require('./lib/printImmutable');
 
 const IS_MAP = '@@__IMMUTABLE_MAP__@@';
-const test = (maybeMap: any) => !!(maybeMap && maybeMap[IS_MAP]);
+const IS_ORDERED = '@@__IMMUTABLE_ORDERED__@@';
+const isMap = (maybeMap: any) => !!maybeMap[IS_MAP];
+const isNotOrdered = (maybeOrdered: any) => !maybeOrdered[IS_ORDERED];
+
+const test = (maybeMap: any) => 
+  !!(maybeMap && isMap(maybeMap) && isNotOrdered(maybeMap));
 
 const print = (
   val: any,
@@ -25,4 +30,4 @@ const print = (
   colors: Colors,
 ) => printImmutable(val, print, indent, opts, colors, 'Map', true);
 
-module.exports = {print, test};
+module.exports = ({print, test}: Plugin);

--- a/packages/pretty-format/src/plugins/ImmutableMap.js
+++ b/packages/pretty-format/src/plugins/ImmutableMap.js
@@ -16,11 +16,8 @@ const printImmutable = require('./lib/printImmutable');
 
 const IS_MAP = '@@__IMMUTABLE_MAP__@@';
 const IS_ORDERED = '@@__IMMUTABLE_ORDERED__@@';
-const isMap = (maybeMap: any) => !!maybeMap[IS_MAP];
-const isNotOrdered = (maybeOrdered: any) => !maybeOrdered[IS_ORDERED];
-
 const test = (maybeMap: any) => 
-  !!(maybeMap && isMap(maybeMap) && isNotOrdered(maybeMap));
+  !!(maybeMap && maybeMap[IS_MAP] && !maybeMap[IS_ORDERED]);
 
 const print = (
   val: any,

--- a/packages/pretty-format/src/plugins/ImmutableOrderedMap.js
+++ b/packages/pretty-format/src/plugins/ImmutableOrderedMap.js
@@ -16,11 +16,8 @@ const printImmutable = require('./lib/printImmutable');
 
 const IS_MAP = '@@__IMMUTABLE_MAP__@@';
 const IS_ORDERED = '@@__IMMUTABLE_ORDERED__@@';
-const isMap = (maybeMap: any) => !!maybeMap[IS_MAP];
-const isOrdered = (maybeOrdered: any) => !!maybeOrdered[IS_ORDERED];
-
 const test = (maybeOrderedMap: any) =>
-  maybeOrderedMap && isMap(maybeOrderedMap) && isOrdered(maybeOrderedMap);
+  maybeOrderedMap && maybeOrderedMap[IS_MAP] && maybeOrderedMap[IS_ORDERED];
 
 const print = (
   val: any,

--- a/packages/pretty-format/src/plugins/ImmutableOrderedMap.js
+++ b/packages/pretty-format/src/plugins/ImmutableOrderedMap.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-import type {Colors, Indent, Options, Print} from '../types.js';
+import type {Colors, Indent, Options, Print, Plugin} from '../types.js';
 
 const printImmutable = require('./lib/printImmutable');
 
@@ -30,4 +30,4 @@ const print = (
   colors: Colors,
 ) => printImmutable(val, print, indent, opts, colors, 'OrderedMap', true);
 
-module.exports = {print, test};
+module.exports = ({print, test}: Plugin);

--- a/packages/pretty-format/src/plugins/ImmutableOrderedSet.js
+++ b/packages/pretty-format/src/plugins/ImmutableOrderedSet.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-import type {Colors, Indent, Options, Print} from '../types.js';
+import type {Colors, Indent, Options, Print, Plugin} from '../types.js';
 
 const printImmutable = require('./lib/printImmutable');
 
@@ -30,4 +30,4 @@ const print = (
   colors: Colors,
 ) => printImmutable(val, print, indent, opts, colors, 'OrderedSet', false);
 
-module.exports = {print, test};
+module.exports = ({print, test}: Plugin);

--- a/packages/pretty-format/src/plugins/ImmutableOrderedSet.js
+++ b/packages/pretty-format/src/plugins/ImmutableOrderedSet.js
@@ -16,11 +16,8 @@ const printImmutable = require('./lib/printImmutable');
 
 const IS_SET = '@@__IMMUTABLE_SET__@@';
 const IS_ORDERED = '@@__IMMUTABLE_ORDERED__@@';
-const isSet = (maybeSet: any) => !!maybeSet[IS_SET];
-const isOrdered = (maybeOrdered: any) => !!maybeOrdered[IS_ORDERED];
-
 const test = (maybeOrderedSet: any) =>
-  maybeOrderedSet && isSet(maybeOrderedSet) && isOrdered(maybeOrderedSet);
+  maybeOrderedSet && maybeOrderedSet[IS_SET] && maybeOrderedSet[IS_ORDERED];
 
 const print = (
   val: any,

--- a/packages/pretty-format/src/plugins/ImmutablePlugins.js
+++ b/packages/pretty-format/src/plugins/ImmutablePlugins.js
@@ -11,10 +11,10 @@
 'use strict';
 
 module.exports = [
-  require('./ImmutableOrderedSet'),
-  require('./ImmutableOrderedMap'),
   require('./ImmutableList'),
   require('./ImmutableSet'),
   require('./ImmutableMap'),
   require('./ImmutableStack'),
+  require('./ImmutableOrderedSet'),
+  require('./ImmutableOrderedMap'),
 ];

--- a/packages/pretty-format/src/plugins/ImmutableSet.js
+++ b/packages/pretty-format/src/plugins/ImmutableSet.js
@@ -16,11 +16,8 @@ const printImmutable = require('./lib/printImmutable');
 
 const IS_SET = '@@__IMMUTABLE_SET__@@';
 const IS_ORDERED = '@@__IMMUTABLE_ORDERED__@@';
-const isSet = (maybeSet: any) => !!maybeSet[IS_SET];
-const isNotOrdered = (maybeOrdered: any) => !maybeOrdered[IS_ORDERED];
-
 const test = (maybeSet: any) => 
-  !!(maybeSet && isSet(maybeSet) && isNotOrdered(maybeSet));
+  !!(maybeSet && maybeSet[IS_SET] && !maybeSet[IS_ORDERED]);
 
 const print = (
   val: any,

--- a/packages/pretty-format/src/plugins/ImmutableSet.js
+++ b/packages/pretty-format/src/plugins/ImmutableSet.js
@@ -10,12 +10,17 @@
 
 'use strict';
 
-import type {Colors, Indent, Options, Print} from '../types.js';
+import type {Colors, Indent, Options, Print, Plugin} from '../types.js';
 
 const printImmutable = require('./lib/printImmutable');
 
 const IS_SET = '@@__IMMUTABLE_SET__@@';
-const test = (maybeSet: any) => !!(maybeSet && maybeSet[IS_SET]);
+const IS_ORDERED = '@@__IMMUTABLE_ORDERED__@@';
+const isSet = (maybeSet: any) => !!maybeSet[IS_SET];
+const isNotOrdered = (maybeOrdered: any) => !maybeOrdered[IS_ORDERED];
+
+const test = (maybeSet: any) => 
+  !!(maybeSet && isSet(maybeSet) && isNotOrdered(maybeSet));
 
 const print = (
   val: any,
@@ -25,4 +30,4 @@ const print = (
   colors: Colors,
 ) => printImmutable(val, print, indent, opts, colors, 'Set', false);
 
-module.exports = {print, test};
+module.exports = ({print, test}: Plugin);

--- a/packages/pretty-format/src/plugins/ImmutableStack.js
+++ b/packages/pretty-format/src/plugins/ImmutableStack.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-import type {Colors, Indent, Options, Print} from '../types.js';
+import type {Colors, Indent, Options, Print, Plugin} from '../types.js';
 
 const printImmutable = require('./lib/printImmutable');
 
@@ -25,4 +25,4 @@ const print = (
   colors: Colors,
 ) => printImmutable(val, print, indent, opts, colors, 'Stack', false);
 
-module.exports = {print, test};
+module.exports = ({print, test}: Plugin);

--- a/packages/pretty-format/src/plugins/ReactElement.js
+++ b/packages/pretty-format/src/plugins/ReactElement.js
@@ -8,6 +8,8 @@
 /* eslint-disable max-len */
 'use strict';
 
+import type {Colors, Indent, Options, Print, Plugin} from '../types.js';
+
 const escapeHTML = require('./lib/escapeHTML');
 
 const reactElement = Symbol.for('react.element');
@@ -24,7 +26,7 @@ function printChildren(flatChildren, print, indent, colors, opts) {
   return flatChildren
     .map(node => {
       if (typeof node === 'object') {
-        return printElement(node, print, indent, colors, opts);
+        return print(node, print, indent, colors, opts);
       } else if (typeof node === 'string') {
         return colors.content.open + escapeHTML(node) + colors.content.close;
       } else {
@@ -64,7 +66,13 @@ function printProps(props, print, indent, colors, opts) {
     .join('');
 }
 
-function printElement(element, print, indent, colors, opts) {
+const print = (
+  element: any,
+  print: Print,
+  indent: Indent,
+  opts: Options,
+  colors: Colors,
+) => {
   let result = colors.tag.open + '<';
   let elementName;
   if (typeof element.type === 'string') {
@@ -109,13 +117,8 @@ function printElement(element, print, indent, colors, opts) {
   }
 
   return result;
-}
-
-module.exports = {
-  print(val, print, indent, opts, colors) {
-    return printElement(val, print, indent, colors, opts);
-  },
-  test(object) {
-    return object && object.$$typeof === reactElement;
-  },
 };
+
+const test = (object: any) => object && object.$$typeof === reactElement;
+
+module.exports = ({print, test}: Plugin);

--- a/packages/pretty-format/src/plugins/ReactTestComponent.js
+++ b/packages/pretty-format/src/plugins/ReactTestComponent.js
@@ -10,18 +10,19 @@
 /* eslint-disable max-len */
 'use strict';
 
+import type {
+  Colors, 
+  Indent, 
+  Options, 
+  Print, 
+  Plugin, 
+  ReactTestObject, 
+  ReactTestChild,
+} from '../types.js';
+
 const escapeHTML = require('./lib/escapeHTML');
 
 const reactTestInstance = Symbol.for('react.test.json');
-
-type ReactTestObject = {|
-  $$typeof: Symbol,
-  type: string,
-  props?: Object,
-  children?: null | Array<ReactTestChild>,
-|};
-// Child can be `number` in Stack renderer but not in Fiber renderer.
-type ReactTestChild = ReactTestObject | string | number;
 
 function printChildren(
   children: Array<ReactTestChild>,
@@ -108,17 +109,15 @@ function printInstance(instance: ReactTestChild, print, indent, colors, opts) {
   return result;
 }
 
-module.exports = {
-  print(
-    val: ReactTestObject,
-    print: (val: any) => string,
-    indent: (str: string) => string,
-    opts: Object,
-    colors: Object,
-  ) {
-    return printInstance(val, print, indent, colors, opts);
-  },
-  test(object: Object) {
-    return object && object.$$typeof === reactTestInstance;
-  },
-};
+const print = (
+  val: ReactTestObject,
+  print: Print,
+  indent: Indent,
+  opts: Options,
+  colors: Colors,
+) => printInstance(val, print, indent, colors, opts);
+
+const test = (object: Object) => 
+  object && object.$$typeof === reactTestInstance;
+
+module.exports = ({print, test}: Plugin);

--- a/packages/pretty-format/src/plugins/lib/printImmutable.js
+++ b/packages/pretty-format/src/plugins/lib/printImmutable.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+import type {Colors, Indent, Options, Print} from '../../types.js';
+
 const IMMUTABLE_NAMESPACE = 'Immutable.';
 const SPACE = ' ';
 
@@ -19,11 +21,11 @@ const addFinalEdgeSpacing = (length: number, edgeSpacing: string) =>
   length > 0 ? edgeSpacing : '';
 
 const printImmutable = (
-  val: Object,
-  print: Function,
-  indent: Function,
-  opts: Object,
-  colors: Object,
+  val: any,
+  print: Print,
+  indent: Indent,
+  opts: Options,
+  colors: Colors,
   immutableDataStructureName: string,
   isMap: boolean,
 ): string => {

--- a/packages/pretty-format/src/types.js
+++ b/packages/pretty-format/src/types.js
@@ -17,6 +17,7 @@ export type StringOrNull = string | null;
 
 export type Options = {|
   callToJSON: boolean,
+  edgeSpacing: string,
   escapeRegex: boolean,
   highlight: boolean,
   indent: number,
@@ -24,6 +25,7 @@ export type Options = {|
   min: boolean,
   plugins: Plugins,
   printFunctionName: boolean,
+  spacing: string,
   theme: {|
     content: string,
     prop: string,
@@ -44,3 +46,13 @@ export type Plugin = {
 };
 
 export type Plugins = Array<Plugin>;
+
+export type ReactTestObject = {|
+  $$typeof: Symbol,
+  type: string,
+  props?: Object,
+  children?: null | Array<ReactTestChild>,
+|};
+
+// Child can be `number` in Stack renderer but not in Fiber renderer.
+export type ReactTestChild = ReactTestObject | string | number;


### PR DESCRIPTION
**Summary**

Unifying the use of `types` in all the pretty-format plugins.
Also, in `ImmutableMap` and `ImmutableSet` making sure they don't have the `@@__IMMUTABLE_ORDERED__@@` field. That way, the order in `ImmutablePlugins` won't matter

**Test plan**

yarn test
