### PR TITLE
[jest-resolve-dependencies] Remove `jest-file-exists`.

### DIFF
--- a/packages/jest-resolve-dependencies/package.json
+++ b/packages/jest-resolve-dependencies/package.json
@@ -8,7 +8,6 @@
   "license": "BSD-3-Clause",
   "main": "build/index.js",
   "dependencies": {
-    "jest-file-exists": "^19.0.0",
     "jest-regex-util": "^19.0.0"
   }
 }

--- a/packages/jest-resolve-dependencies/src/__tests__/DependencyResolver-test.js
+++ b/packages/jest-resolve-dependencies/src/__tests__/DependencyResolver-test.js
@@ -49,7 +49,7 @@ test('resolves dependencies for existing path', () => {
   );
   expect(resolved).toEqual([
     expect.stringContaining('jest-resolve-dependencies'),
-    expect.stringContaining('jest-file-exists'),
+    expect.stringContaining('jest-regex-util'),
   ]);
 });
 

--- a/packages/jest-resolve-dependencies/src/__tests__/__fixtures__/file.js
+++ b/packages/jest-resolve-dependencies/src/__tests__/__fixtures__/file.js
@@ -9,4 +9,4 @@
 'use strict';
 
 require('jest-resolve-dependencies');
-require('jest-file-exists');
+require('jest-regex-util');

--- a/packages/jest-resolve-dependencies/src/index.js
+++ b/packages/jest-resolve-dependencies/src/index.js
@@ -14,7 +14,6 @@ import type {HasteFS} from 'types/HasteMap';
 import type {Path} from 'types/Config';
 import type {Resolver, ResolveModuleConfig} from 'types/Resolve';
 
-const fileExists = require('jest-file-exists');
 const {replacePathSepForRegex} = require('jest-regex-util');
 
 const snapshotDirRegex = new RegExp(
@@ -103,18 +102,15 @@ class DependencyResolver {
     const relatedPaths = new Set();
     const changed = new Set();
     for (const path of paths) {
-      if (fileExists(path, this._hasteFS)) {
-        const module = this._hasteFS.exists(path);
-        if (module) {
-          // /path/to/__snapshots__/test.js.snap is always adjacent to
-          // /path/to/test.js
-          const modulePath = isSnapshotPath(path)
-            ? path.replace(snapshotFileRegex, '$1')
-            : path;
-          changed.add(modulePath);
-          if (filter(modulePath)) {
-            relatedPaths.add(modulePath);
-          }
+      if (this._hasteFS.exists(path)) {
+        // /path/to/__snapshots__/test.js.snap is always adjacent to
+        // /path/to/test.js
+        const modulePath = isSnapshotPath(path)
+          ? path.replace(snapshotFileRegex, '$1')
+          : path;
+        changed.add(modulePath);
+        if (filter(modulePath)) {
+          relatedPaths.add(modulePath);
         }
       }
     }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Drops `jest-file-exists` from `jest-resolve-dependencies` and removes it's usage.  ~~The check was redundant.~~
Strictly speaking, it wasn't redundant, just wasteful.  Expanded, it was
```
// `(AB+C)B` is the same as just `B` (since `A` is given to be true)
((hasteFS && hasteFS.exists(filePath)) || fs.existsSync(filePath)) && hasteFS.exists(filePath)
```

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
Nothing should change.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
