### PR TITLE
Remove all usage of `jest-file-exists`.

### DIFF
--- a/packages/jest-runtime/package.json
+++ b/packages/jest-runtime/package.json
@@ -15,7 +15,6 @@
     "convert-source-map": "^1.3.0",
     "graceful-fs": "^4.1.6",
     "jest-config": "^19.0.2",
-    "jest-file-exists": "^19.0.0",
     "jest-haste-map": "^19.0.0",
     "jest-regex-util": "^19.0.0",
     "jest-resolve": "^19.0.2",

--- a/packages/jest-runtime/src/__tests__/transform-test.js
+++ b/packages/jest-runtime/src/__tests__/transform-test.js
@@ -13,7 +13,6 @@ const slash = require('slash');
 
 jest
   .mock('graceful-fs')
-  .mock('jest-file-exists')
   .mock('jest-haste-map', () => ({
     getCacheFilePath: (cacheDir, baseDir, version) => cacheDir + baseDir,
   }))
@@ -131,7 +130,7 @@ describe('transform', () => {
       mtime: {getTime: () => 42},
     }));
 
-    require('jest-file-exists').mockImplementation(path => !!mockFs[path]);
+    fs.existsSync = jest.fn(path => !!mockFs[path]);
 
     config = {
       cache: true,

--- a/packages/jest-runtime/src/transform.js
+++ b/packages/jest-runtime/src/transform.js
@@ -17,7 +17,6 @@ import type {
 } from 'types/Transform';
 const createDirectory = require('jest-util').createDirectory;
 const crypto = require('crypto');
-const fileExists = require('jest-file-exists');
 const fs = require('graceful-fs');
 const getCacheFilePath = require('jest-haste-map').getCacheFilePath;
 const path = require('path');
@@ -111,7 +110,7 @@ const wrap = content =>
   '\n}});';
 
 const readCacheFile = (filename: Path, cachePath: Path): ?string => {
-  if (!fileExists(cachePath)) {
+  if (!fs.existsSync(cachePath)) {
     return null;
   }
 

--- a/packages/jest-snapshot/package.json
+++ b/packages/jest-snapshot/package.json
@@ -10,7 +10,6 @@
   "dependencies": {
     "chalk": "^1.1.3",
     "jest-diff": "^19.0.0",
-    "jest-file-exists": "^19.0.0",
     "jest-matcher-utils": "^19.0.0",
     "jest-util": "^19.0.2",
     "natural-compare": "^1.4.0",

--- a/packages/jest-snapshot/src/State.js
+++ b/packages/jest-snapshot/src/State.js
@@ -21,7 +21,6 @@ const {
   testNameToKey,
   unescape,
 } = require('./utils');
-const fileExists = require('jest-file-exists');
 const fs = require('fs');
 
 class SnapshotState {
@@ -87,7 +86,7 @@ class SnapshotState {
     if ((this._dirty || this._uncheckedKeys.size) && !isEmpty) {
       saveSnapshotFile(this._snapshotData, this._snapshotPath);
       status.saved = true;
-    } else if (isEmpty && fileExists(this._snapshotPath)) {
+    } else if (isEmpty && fs.existsSync(this._snapshotPath)) {
       if (update) {
         fs.unlinkSync(this._snapshotPath);
       }
@@ -135,7 +134,7 @@ class SnapshotState {
     }
 
     if (
-      !fileExists(this._snapshotPath) || // there's no snapshot file
+      !fs.existsSync(this._snapshotPath) || // there's no snapshot file
       (hasSnapshot && this.update) || // there is a file, but we're updating
       !hasSnapshot // there is a file, but it doesn't have this snaphsot
     ) {

--- a/packages/jest-snapshot/src/__tests__/utils-test.js
+++ b/packages/jest-snapshot/src/__tests__/utils-test.js
@@ -25,16 +25,17 @@ const path = require('path');
 
 const writeFileSync = fs.writeFileSync;
 const readFileSync = fs.readFileSync;
+const existsSync = fs.existsSync;
 beforeEach(() => {
   fs.writeFileSync = jest.fn();
   fs.readFileSync = jest.fn();
+  fs.existsSync = jest.fn(() => true);
 });
 afterEach(() => {
   fs.writeFileSync = writeFileSync;
   fs.readFileSync = readFileSync;
+  fs.existsSync = existsSync;
 });
-
-jest.mock('jest-file-exists', () => () => true);
 
 test('keyToTestName()', () => {
   expect(keyToTestName('abc cde 12')).toBe('abc cde');

--- a/packages/jest-snapshot/src/index.js
+++ b/packages/jest-snapshot/src/index.js
@@ -13,7 +13,6 @@ import type {HasteFS} from 'types/HasteMap';
 import type {Path} from 'types/Config';
 
 const diff = require('jest-diff');
-const fileExists = require('jest-file-exists');
 const fs = require('fs');
 const path = require('path');
 const SnapshotState = require('./State');
@@ -26,6 +25,9 @@ const {
   RECEIVED_COLOR,
 } = require('jest-matcher-utils');
 const {SNAPSHOT_EXTENSION} = require('./utils');
+
+const fileExists = (filePath: Path, hasteFS: HasteFS): boolean =>
+  hasteFS.exists(filePath) || fs.existsSync(filePath);
 
 const cleanup = (hasteFS: HasteFS, update: boolean) => {
   const pattern = '\\.' + SNAPSHOT_EXTENSION + '$';

--- a/packages/jest-snapshot/src/utils.js
+++ b/packages/jest-snapshot/src/utils.js
@@ -14,7 +14,6 @@ import type {Path} from 'types/Config';
 
 const chalk = require('chalk');
 const createDirectory = require('jest-util').createDirectory;
-const fileExists = require('jest-file-exists');
 const path = require('path');
 const prettyFormat = require('pretty-format');
 const fs = require('fs');
@@ -103,7 +102,7 @@ const getSnapshotData = (snapshotPath: Path, update: boolean) => {
   let snapshotContents = '';
   let dirty = false;
 
-  if (fileExists(snapshotPath)) {
+  if (fs.existsSync(snapshotPath)) {
     try {
       snapshotContents = fs.readFileSync(snapshotPath, 'utf8');
       // eslint-disable-next-line no-new-func

--- a/packages/jest-util/package.json
+++ b/packages/jest-util/package.json
@@ -10,7 +10,6 @@
   "dependencies": {
     "chalk": "^1.1.1",
     "graceful-fs": "^4.1.6",
-    "jest-file-exists": "^19.0.0",
     "jest-mock": "^19.0.0",
     "jest-validate": "^19.0.2",
     "jest-message-util": "^19.0.0",

--- a/packages/jest-util/src/index.js
+++ b/packages/jest-util/src/index.js
@@ -15,11 +15,11 @@ const FakeTimers = require('./FakeTimers');
 const NullConsole = require('./NullConsole');
 
 const clearLine = require('./clearLine');
-const fileExists = require('jest-file-exists');
 const formatTestResults = require('./formatTestResults');
 const installCommonGlobals = require('./installCommonGlobals');
 const mkdirp = require('mkdirp');
 const path = require('path');
+const fs = require('fs');
 const setGlobal = require('./setGlobal');
 const validateCLIOptions = require('./validateCLIOptions');
 
@@ -38,7 +38,7 @@ const getPackageRoot = () => {
 
   // Is the cwd somewhere within an npm package?
   let root = cwd;
-  while (!fileExists(path.join(root, 'package.json'))) {
+  while (!fs.existsSync(path.join(root, 'package.json'))) {
     if (root === '/' || root.match(/^[A-Z]:\\/)) {
       root = cwd;
       break;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Removes all usage of the `jest-file-exist` package.  With [one exception](https://github.com/facebook/jest/blob/master/packages/jest-snapshot/src/index.js#L34-L40), it was just a wrapper around `fs.existsSync`.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
Nothing should change.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
