### PR TITLE
Changed syntax on 'yarn run watch' script so it is Windows friendly, …

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,10 +95,5 @@
     "testMatch": [
       "**/*-test.js"
     ]
-  },
-  "dependencies": {
-    "ansi-styles": "^3.0.0",
-    "babel-plugin-istanbul": "^4.0.0",
-    "pretty-format": "^19.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "scripts": {
     "build-clean": "rm -rf ./packages/*/build",
     "build": "node ./scripts/build.js",
-    "clean-all": "rm -rf ./node_modules; rm -rf ./packages/*/node_modules; rm -rf ./integration_tests/*/*/node_modules; yarn run build-clean",
+    "clean-all": "rm -rf ./node_modules && rm -rf ./packages/*/node_modules && rm -rf ./integration_tests/*/*/node_modules && yarn run build-clean",
     "danger": "node ./danger/node_modules/.bin/danger",
     "jest": "node ./packages/jest-cli/bin/jest.js",
     "jest-coverage": "yarn run jest -- --coverage",
@@ -55,7 +55,7 @@
     "test-pretty-format-perf": "node packages/pretty-format/perf/test.js",
     "test": "yarn run typecheck && yarn run lint && yarn run build && yarn run jest && yarn run test-examples",
     "typecheck": "flow check",
-    "watch": "yarn run build; node ./scripts/watch.js"
+    "watch": "yarn run build && node ./scripts/watch.js"
   },
   "jest": {
     "modulePathIgnorePatterns": [
@@ -95,5 +95,10 @@
     "testMatch": [
       "**/*-test.js"
     ]
+  },
+  "dependencies": {
+    "ansi-styles": "^3.0.0",
+    "babel-plugin-istanbul": "^4.0.0",
+    "pretty-format": "^19.0.0"
   }
 }


### PR DESCRIPTION
…Fixes #3104

As per the issue I've made the change to make the script command for "yarn run watch" run on Windows as the command line syntax for running multiple commands in a one liner differs to that used. Should now be cross platform.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Screen shot of it "working" as expected on Windows 10, cmd running as admin.

![image](https://cloud.githubusercontent.com/assets/1674590/23707151/2e74a9f4-0409-11e7-8427-0f87d5bd36ad.png)

