### PR TITLE
jest-haste-map: watch-mode recover from duplicate modules

### DIFF
--- a/packages/jest-haste-map/src/__tests__/__snapshots__/index-test.js.snap
+++ b/packages/jest-haste-map/src/__tests__/__snapshots__/index-test.js.snap
@@ -1,11 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`HasteMap throws on duplicate module ids if "throwOnModuleCollision" is set to true 1`] = `
+exports[`HasteMap throws on duplicate module ids 1`] = `
 [Error: jest-haste-map: @providesModule naming collision:
   Duplicate module name: Strawberry
   Paths: /fruits/raspberry.js collides with /fruits/strawberry.js
 
-This error is caused by a @providesModule declaration with the same name across two different files.]
+This error is caused by a @providesModule declaration with the same name across several different files.]
 `;
 
 exports[`HasteMap tries to crawl using node as a fallback 1`] = `
@@ -26,12 +26,4 @@ Jest will use the mock file found in:
 /fruits2/__mocks__/subdir/blueberry.js
 
 "
-`;
-
-exports[`HasteMap warns on duplicate module ids 1`] = `
-"jest-haste-map: @providesModule naming collision:
-  Duplicate module name: Strawberry
-  Paths: /fruits/raspberry.js collides with /fruits/strawberry.js
-
-This warning is caused by a @providesModule declaration with the same name across two different files."
 `;


### PR DESCRIPTION
Also, remove the throwOnModuleCollision option.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

When duplicate modules happen and are later fixed, the watch mode does not handle it properly. See the new unit test this PR adds. Without the changes, the test does not pass successfully.

I made the choice to remove duplicated modules from the `moduleMap` altogether. That avoids being able to resolve modules if there is any ambiguity, something that I think is the saner option ("fail fast" philosophy). Indeed, otherwise, people may be executing the wrong code without realising it.

A problem that probably still need addressing in this PR is how duplicates are reporter to `jest-haste-map` consumers. My proposal is that we could expose a third structure through the `change` event that contains a list of duplicated IDs. (In my opinion, the best option would be to make `getModule` return an array instead of a single element, and let consumers decide what to do about duplicates. But I understand this would be a breaking change, so I think the second-best option is a remove the ID form the map completely, and provide another mean for consumers to know of ID duplication.)

**Test plan**

The automated tests demonstrate the fix.
