### PR TITLE
Remove async/await extra step

### DIFF
--- a/docs/TutorialAsync.md
+++ b/docs/TutorialAsync.md
@@ -99,11 +99,6 @@ it('works with async/await', async () => {
 });
 ```
 
-To enable async/await in your project, install
-[`babel-plugin-transform-async-to-generator`](http://babeljs.io/docs/plugins/transform-async-to-generator/) or
-[`babel-preset-stage-3`](http://babeljs.io/docs/plugins/preset-stage-3/)
-and enable the feature in your `.babelrc` file.
-
 ### Error handling
 
 Errors can be handled in the standard JavaScript way: Either using `.catch()`


### PR DESCRIPTION
Removes the text that explains an extra step that is no longer necessary in order to make jest work with async/await syntax.


IDK how it become unecessary over time so it might worth keeping it a bit more? I really don't know the answer. 
What I know is that I was having trouble making it work and that paragraph made me lose quite some time since it isn't really necessary anymore (I had another project running flawlessly without such plugin)