### PR TITLE
Use prettier 6/6.

### DIFF
--- a/integration_tests/__tests__/__snapshots__/coverage_report-test.js.snap
+++ b/integration_tests/__tests__/__snapshots__/coverage_report-test.js.snap
@@ -34,7 +34,7 @@ exports[`outputs coverage report 1`] = `
 File                           |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
 -------------------------------|----------|----------|----------|----------|----------------|
 All files                      |    45.45 |        0 |       50 |    45.45 |                |
- not-required-in-test-suite.js |        0 |        0 |        0 |        0 | 10,17,21,22,24 |
+ not-required-in-test-suite.js |        0 |        0 |        0 |        0 | 10,17,18,19,21 |
  other-file.js                 |      100 |      100 |      100 |      100 |                |
  sum.js                        |      100 |      100 |      100 |      100 |                |
  sum_dependency.js             |        0 |      100 |      100 |        0 |             10 |

--- a/integration_tests/__tests__/config-test.js
+++ b/integration_tests/__tests__/config-test.js
@@ -13,10 +13,11 @@ const runJest = require('../runJest');
 
 test('config as JSON', () => {
   const result = runJest('verbose_reporter', [
-    '--config=' + JSON.stringify({
-      testEnvironment: 'node',
-      testMatch: ['banana strawbery kiwi'],
-    }),
+    '--config=' +
+      JSON.stringify({
+        testEnvironment: 'node',
+        testMatch: ['banana strawbery kiwi'],
+      }),
   ]);
   const stdout = result.stdout.toString();
 
@@ -26,9 +27,10 @@ test('config as JSON', () => {
 
 test('works with sane config JSON', () => {
   const result = runJest('verbose_reporter', [
-    '--config=' + JSON.stringify({
-      testEnvironment: 'node',
-    }),
+    '--config=' +
+      JSON.stringify({
+        testEnvironment: 'node',
+      }),
   ]);
   const stderr = result.stderr.toString();
 
@@ -38,12 +40,13 @@ test('works with sane config JSON', () => {
 
 test('watchman config option is respected over default argv', () => {
   const {stdout} = runJest('verbose_reporter', [
-    '--config=' + JSON.stringify({
-      testEnvironment: 'node',
-      watchman: false,
-    }),
+    '--config=' +
+      JSON.stringify({
+        testEnvironment: 'node',
+        watchman: false,
+      }),
     '--debug',
   ]);
 
-  expect(stdout).toMatch('\"watchman\": false,');
+  expect(stdout).toMatch('"watchman": false,');
 });

--- a/integration_tests/__tests__/console-test.js
+++ b/integration_tests/__tests__/console-test.js
@@ -25,8 +25,10 @@ test('console printing', () => {
 });
 
 test('console printing with --verbose', () => {
-  const {stderr, stdout, status} =
-    runJest('console', ['--verbose', '--no-cache']);
+  const {stderr, stdout, status} = runJest('console', [
+    '--verbose',
+    '--no-cache',
+  ]);
   const {summary, rest} = extractSummary(stderr);
 
   expect(status).toBe(0);
@@ -36,15 +38,15 @@ test('console printing with --verbose', () => {
 });
 
 test('does not print to console with --silent', () => {
-  const {stderr, stdout, status} =
-    runJest('console', [
-      // Need to pass --config because console test specifies `verbose: false`
-      '--config=' + JSON.stringify({
+  const {stderr, stdout, status} = runJest('console', [
+    // Need to pass --config because console test specifies `verbose: false`
+    '--config=' +
+      JSON.stringify({
         testEnvironment: 'node',
       }),
-      '--silent',
-      '--no-cache',
-    ]);
+    '--silent',
+    '--no-cache',
+  ]);
   const {summary, rest} = extractSummary(stderr);
 
   expect(status).toBe(0);

--- a/integration_tests/__tests__/coverage-remapping-test.js
+++ b/integration_tests/__tests__/coverage-remapping-test.js
@@ -23,7 +23,7 @@ it('maps code coverage against original source', () => {
 
   const coverageMapFile = path.join(
     __dirname,
-    '../coverage-remapping/coverage/coverage-final.json'
+    '../coverage-remapping/coverage/coverage-final.json',
   );
   const coverageMap = JSON.parse(readFileSync(coverageMapFile, 'utf-8'));
 

--- a/integration_tests/__tests__/coverage_report-test.js
+++ b/integration_tests/__tests__/coverage_report-test.js
@@ -50,22 +50,19 @@ test('collects coverage only from specified files', () => {
   expect(stdout).toMatchSnapshot();
 });
 
-test(
-  'collects coverage only from specified files avoiding dependencies',
-  () => {
-    const {stdout} = runJest(DIR, [
-      '--no-cache',
-      '--coverage',
-      '--collectCoverageOnlyFrom',
-      'sum.js',
-      '--',
-      'sum-test.js',
-    ]);
+test('collects coverage only from specified files avoiding dependencies', () => {
+  const {stdout} = runJest(DIR, [
+    '--no-cache',
+    '--coverage',
+    '--collectCoverageOnlyFrom',
+    'sum.js',
+    '--',
+    'sum-test.js',
+  ]);
 
-    // Coverage report should only have `sum.js` coverage info
-    expect(stdout).toMatchSnapshot();
-  }
-);
+  // Coverage report should only have `sum.js` coverage info
+  expect(stdout).toMatchSnapshot();
+});
 
 test('json reporter printing with --coverage', () => {
   const {stderr, status} = runJest('json_reporter', ['--coverage']);
@@ -81,8 +78,6 @@ test('outputs coverage report as json', () => {
   try {
     JSON.parse(stdout);
   } catch (err) {
-    throw new Error(
-      'Can\'t parse the JSON result from stdout' + err.toString()
-    );
+    throw new Error("Can't parse the JSON result from stdout" + err.toString());
   }
 });

--- a/integration_tests/__tests__/empty_suite_error-test.js
+++ b/integration_tests/__tests__/empty_suite_error-test.js
@@ -21,8 +21,6 @@ describe('JSON Reporter', () => {
     const result = runJest(DIR, []);
     const stderr = result.stderr.toString();
     expect(stderr).toMatch('Test suite failed to run');
-    expect(stderr).toMatch(
-      'Your test suite must contain at least one test.'
-    );
+    expect(stderr).toMatch('Your test suite must contain at least one test.');
   });
 });

--- a/integration_tests/__tests__/env-test.js
+++ b/integration_tests/__tests__/env-test.js
@@ -39,5 +39,4 @@ describe('Environment override', () => {
     const result = runJest('env-test', ['--env=banana']);
     expect(result.status).toBe(1);
   });
-
 });

--- a/integration_tests/__tests__/jasmine_async-test.js
+++ b/integration_tests/__tests__/jasmine_async-test.js
@@ -15,10 +15,7 @@ describe('async jasmine', () => {
   skipOnWindows.suite();
 
   it('works with beforeAll', () => {
-    const result = runJest.json(
-      'jasmine_async',
-      ['promise_beforeAll-test.js'],
-    );
+    const result = runJest.json('jasmine_async', ['promise_beforeAll-test.js']);
     const json = result.json;
 
     expect(json.numTotalTests).toBe(2);
@@ -32,10 +29,9 @@ describe('async jasmine', () => {
   });
 
   it('works with beforeEach', () => {
-    const result = runJest.json(
-      'jasmine_async',
-      ['promise_beforeEach-test.js'],
-    );
+    const result = runJest.json('jasmine_async', [
+      'promise_beforeEach-test.js',
+    ]);
     const json = result.json;
 
     expect(json.numTotalTests).toBe(1);
@@ -55,9 +51,7 @@ describe('async jasmine', () => {
     expect(json.numPendingTests).toBe(0);
     expect(json.testResults[0].message).toBe('');
 
-    expect(
-      (result.stderr.match(/unset flag/g) || []).length
-    ).toBe(1);
+    expect((result.stderr.match(/unset flag/g) || []).length).toBe(1);
   });
 
   it('works with afterEach', () => {

--- a/integration_tests/__tests__/json_reporter-test.js
+++ b/integration_tests/__tests__/json_reporter-test.js
@@ -19,7 +19,7 @@ describe('JSON Reporter', () => {
   const outputFilePath = path.join(
     process.cwd(),
     'integration_tests/json_reporter/',
-    outputFileName
+    outputFileName,
   );
 
   afterAll(() => {
@@ -36,7 +36,7 @@ describe('JSON Reporter', () => {
       jsonResult = JSON.parse(testOutput);
     } catch (err) {
       throw new Error(
-        `Can't parse the JSON result from ${outputFileName}, ${err.toString()}`
+        `Can't parse the JSON result from ${outputFileName}, ${err.toString()}`,
       );
     }
 
@@ -61,7 +61,7 @@ describe('JSON Reporter', () => {
       jsonResult = JSON.parse(stdout);
     } catch (err) {
       throw new Error(
-        'Can\'t parse the JSON result from stdout' + err.toString()
+        "Can't parse the JSON result from stdout" + err.toString(),
       );
     }
 

--- a/integration_tests/__tests__/runtime-internal-module-registry-test.js
+++ b/integration_tests/__tests__/runtime-internal-module-registry-test.js
@@ -22,12 +22,10 @@ describe('Runtime Internal Module Registry', () => {
   // Jest to require any internal modules used when setting up the test
   // environment, and a "normal" module registry that's used by the actual test
   // code (and can safely be cleared after every test)
-  it('correctly makes use of internal module registry when requiring modules',
-    () => {
-      const {json} = runJest.json('runtime-internal-module-registry', []);
+  it('correctly makes use of internal module registry when requiring modules', () => {
+    const {json} = runJest.json('runtime-internal-module-registry', []);
 
-      expect(json.numTotalTests).toBe(1);
-      expect(json.numPassedTests).toBe(1);
-    }
-  );
+    expect(json.numTotalTests).toBe(1);
+    expect(json.numPassedTests).toBe(1);
+  });
 });

--- a/integration_tests/__tests__/snapshot-test.js
+++ b/integration_tests/__tests__/snapshot-test.js
@@ -15,31 +15,43 @@ const path = require('path');
 const runJest = require('../runJest');
 
 const emptyTest = 'describe("", () => {it("", () => {})})';
-const snapshotDir =
-  path.resolve(__dirname, '../snapshot/__tests__/__snapshots__');
+const snapshotDir = path.resolve(
+  __dirname,
+  '../snapshot/__tests__/__snapshots__',
+);
 const snapshotFile = path.resolve(snapshotDir, 'snapshot-test.js.snap');
 const secondSnapshotFile = path.resolve(
   snapshotDir,
-  'second-snapshot-test.js.snap'
+  'second-snapshot-test.js.snap',
 );
 const snapshotOfCopy = path.resolve(snapshotDir, 'snapshot-test_copy.js.snap');
 const originalTestPath = path.resolve(
   __dirname,
-  '../snapshot/__tests__/snapshot-test.js'
+  '../snapshot/__tests__/snapshot-test.js',
 );
 const originalTestContent = fs.readFileSync(originalTestPath, 'utf8');
 const copyOfTestPath = originalTestPath.replace('.js', '_copy.js');
 
-const snapshotEscapeDir =
-  path.resolve(__dirname, '../snapshot-escape/__tests__/');
-const snapshotEscapeTestFile =
-  path.resolve(snapshotEscapeDir, 'snapshot-test.js');
-const snapshotEscapeSnapshotDir =
-  path.resolve(snapshotEscapeDir, '__snapshots__');
-const snapshotEscapeFile =
-  path.resolve(snapshotEscapeSnapshotDir, 'snapshot-test.js.snap');
-const snapshotEscapeRegexFile =
-  path.resolve(snapshotEscapeSnapshotDir, 'snapshot-escape-regex.js.snap');
+const snapshotEscapeDir = path.resolve(
+  __dirname,
+  '../snapshot-escape/__tests__/',
+);
+const snapshotEscapeTestFile = path.resolve(
+  snapshotEscapeDir,
+  'snapshot-test.js',
+);
+const snapshotEscapeSnapshotDir = path.resolve(
+  snapshotEscapeDir,
+  '__snapshots__',
+);
+const snapshotEscapeFile = path.resolve(
+  snapshotEscapeSnapshotDir,
+  'snapshot-test.js.snap',
+);
+const snapshotEscapeRegexFile = path.resolve(
+  snapshotEscapeSnapshotDir,
+  'snapshot-escape-regex.js.snap',
+);
 const snapshotEscapeSubstitutionFile = path.resolve(
   snapshotEscapeSnapshotDir,
   'snapshot-escape-substitution-test.js.snap',
@@ -100,7 +112,7 @@ describe('Snapshot', () => {
 
     const content = require(snapshotFile);
     expect(
-      content['snapshot is not influenced by previous counter 1']
+      content['snapshot is not influenced by previous counter 1'],
     ).not.toBe(undefined);
 
     const info = result.stderr.toString();
@@ -118,8 +130,7 @@ describe('Snapshot', () => {
     expect(extractSummary(stderr).summary).toMatchSnapshot();
 
     // Write the second snapshot
-    const testData =
-      `test('escape strings two', () => expect('two: \\\'\"').` +
+    const testData = `test('escape strings two', () => expect('two: \\\'\"').` +
       `toMatchSnapshot());`;
     const newTestData = initialTestData + testData;
     fs.writeFileSync(snapshotEscapeTestFile, newTestData, 'utf8');
@@ -162,20 +173,18 @@ describe('Snapshot', () => {
 
   it('works with template literal subsitutions', () => {
     // Write the first snapshot
-    let result = runJest(
-      'snapshot-escape',
-      ['snapshot-escape-substitution-test.js'],
-    );
+    let result = runJest('snapshot-escape', [
+      'snapshot-escape-substitution-test.js',
+    ]);
     let stderr = result.stderr.toString();
 
     expect(stderr).toMatch('1 snapshot written');
     expect(result.status).toBe(0);
     expect(extractSummary(stderr).summary).toMatchSnapshot();
 
-    result = runJest(
-     'snapshot-escape',
-     ['snapshot-escape-substitution-test.js'],
-   );
+    result = runJest('snapshot-escape', [
+      'snapshot-escape-substitution-test.js',
+    ]);
     stderr = result.stderr.toString();
 
     // Make sure we aren't writing a snapshot this time which would
@@ -186,7 +195,6 @@ describe('Snapshot', () => {
   });
 
   describe('Validation', () => {
-
     beforeEach(() => {
       fs.writeFileSync(copyOfTestPath, originalTestContent);
     });
@@ -247,7 +255,6 @@ describe('Snapshot', () => {
       expect(infoSR).toMatch('1 obsolete snapshot file removed');
       expect(extractSummary(infoFR).summary).toMatchSnapshot();
       expect(extractSummary(infoSR).summary).toMatchSnapshot();
-
     });
 
     it('updates the snapshot when a test removes some snapshots', () => {
@@ -255,10 +262,13 @@ describe('Snapshot', () => {
       fs.unlinkSync(copyOfTestPath);
       const beforeRemovingSnapshot = getSnapshotOfCopy();
 
-      fs.writeFileSync(copyOfTestPath, originalTestContent.replace(
-        '.toMatchSnapshot()',
-        '.not.toBe(undefined)'
-      ));
+      fs.writeFileSync(
+        copyOfTestPath,
+        originalTestContent.replace(
+          '.toMatchSnapshot()',
+          '.not.toBe(undefined)',
+        ),
+      );
       const secondRun = runJest.json('snapshot', ['-u']);
       fs.unlinkSync(copyOfTestPath);
 
@@ -267,20 +277,13 @@ describe('Snapshot', () => {
       expect(fileExists(snapshotOfCopy)).toBe(true);
       const afterRemovingSnapshot = getSnapshotOfCopy();
 
-      expect(
-        Object.keys(beforeRemovingSnapshot).length - 1
-      ).toBe(
-        Object.keys(afterRemovingSnapshot).length
+      expect(Object.keys(beforeRemovingSnapshot).length - 1).toBe(
+        Object.keys(afterRemovingSnapshot).length,
       );
-      const keyToCheck =
-        'snapshot works with plain objects and the title has `escape` ' +
-        'characters 2';
-      expect(
-        beforeRemovingSnapshot[keyToCheck]
-      ).not.toBe(undefined);
-      expect(
-        afterRemovingSnapshot[keyToCheck]
-      ).toBe(undefined);
+      const keyToCheck = 'snapshot works with plain objects and the ' +
+        'title has `escape` characters 2';
+      expect(beforeRemovingSnapshot[keyToCheck]).not.toBe(undefined);
+      expect(afterRemovingSnapshot[keyToCheck]).toBe(undefined);
 
       const infoFR = firstRun.stderr.toString();
       const infoSR = secondRun.stderr.toString();

--- a/integration_tests/__tests__/stack_trace-test.js
+++ b/integration_tests/__tests__/stack_trace-test.js
@@ -22,10 +22,10 @@ describe('Stack Trace', () => {
 
     expect(result.status).toBe(1);
     expect(stderr).toMatch(
-      /ReferenceError: thisIsARuntimeError is not defined/
+      /ReferenceError: thisIsARuntimeError is not defined/,
     );
     expect(stderr).toMatch(
-      /\s+at\s(?:.+?)\s\(__tests__\/runtime-error-test\.js/
+      /\s+at\s(?:.+?)\s\(__tests__\/runtime-error-test\.js/,
     );
   });
 
@@ -40,10 +40,10 @@ describe('Stack Trace', () => {
     expect(result.status).toBe(1);
 
     expect(stderr).toMatch(
-      /ReferenceError: thisIsARuntimeError is not defined/
+      /ReferenceError: thisIsARuntimeError is not defined/,
     );
     expect(stderr).not.toMatch(
-      /\s+at\s(?:.+?)\s\(__tests__\/runtime-error-test\.js/
+      /\s+at\s(?:.+?)\s\(__tests__\/runtime-error-test\.js/,
     );
   });
 
@@ -54,9 +54,7 @@ describe('Stack Trace', () => {
     expect(extractSummary(stderr).summary).toMatchSnapshot();
     expect(result.status).toBe(1);
 
-    expect(stderr).toMatch(
-      /\s+at\s(?:.+?)\s\(__tests__\/stack-trace-test\.js/
-    );
+    expect(stderr).toMatch(/\s+at\s(?:.+?)\s\(__tests__\/stack-trace-test\.js/);
   });
 
   it('does not print a stack trace for matching errors when --noStackTrace is given', () => {
@@ -70,7 +68,7 @@ describe('Stack Trace', () => {
     expect(result.status).toBe(1);
 
     expect(stderr).not.toMatch(
-      /\s+at\s(?:.+?)\s\(__tests__\/stack-trace-test\.js/
+      /\s+at\s(?:.+?)\s\(__tests__\/stack-trace-test\.js/,
     );
   });
 
@@ -84,19 +82,17 @@ describe('Stack Trace', () => {
     expect(stderr).toMatch(/this is unexpected\./);
     expect(stderr).toMatch(/this is a string\. thrown/);
 
-    expect(stderr).toMatch(
-      /\s+at\s(?:.+?)\s\(__tests__\/test-error-test\.js/
-    );
+    expect(stderr).toMatch(/\s+at\s(?:.+?)\s\(__tests__\/test-error-test\.js/);
 
     // Make sure we show Jest's jest-resolve as part of the stack trace
     /* eslint-disable max-len */
     expect(stderr).toMatch(
-      /Cannot find module 'this-module-does-not-exist' from 'test-error-test\.js'/
+      /Cannot find module 'this-module-does-not-exist' from 'test-error-test\.js'/,
     );
     /* eslint-enable max-len */
 
     expect(stderr).toMatch(
-      /\s+at\s(?:.+?)\s\((?:.+?)jest-resolve\/build\/index\.js/
+      /\s+at\s(?:.+?)\s\((?:.+?)jest-resolve\/build\/index\.js/,
     );
   });
 
@@ -111,8 +107,7 @@ describe('Stack Trace', () => {
     expect(result.status).toBe(1);
 
     expect(stderr).not.toMatch(
-      /\s+at\s(?:.+?)\s\(__tests__\/test-error-test\.js/
+      /\s+at\s(?:.+?)\s\(__tests__\/test-error-test\.js/,
     );
   });
-
 });

--- a/integration_tests/__tests__/test-in-root-test.js
+++ b/integration_tests/__tests__/test-in-root-test.js
@@ -22,9 +22,9 @@ it('runs tests in only test.js and spec.js', () => {
   expect(result.numTotalTests).toBe(2);
 
   const testNames = result.testResults
-      .map(res => res.name)
-      .map(name => path.basename(name))
-      .sort();
+    .map(res => res.name)
+    .map(name => path.basename(name))
+    .sort();
 
   expect(testNames.length).toBe(2);
   expect(testNames[0]).toBe('spec.js');

--- a/integration_tests/__tests__/testNamePattern-test.js
+++ b/integration_tests/__tests__/testNamePattern-test.js
@@ -12,7 +12,8 @@ const runJest = require('../runJest');
 
 test('testNamePattern', () => {
   const {stderr, status} = runJest.json('testNamePattern', [
-    '--testNamePattern', 'should match',
+    '--testNamePattern',
+    'should match',
   ]);
   const {summary} = extractSummary(stderr);
 

--- a/integration_tests/__tests__/testResultsProcessor-test.js
+++ b/integration_tests/__tests__/testResultsProcessor-test.js
@@ -16,7 +16,7 @@ test('testNamePattern', () => {
   const path = require('path');
   const processorPath = path.resolve(
     __dirname,
-    '../testResultsProcessor/processor.js'
+    '../testResultsProcessor/processor.js',
   );
   const result = runJest.json('testResultsProcessor', [
     '--json',

--- a/integration_tests/__tests__/toMatchSnapshot-test.js
+++ b/integration_tests/__tests__/toMatchSnapshot-test.js
@@ -64,7 +64,6 @@ test('error thrown before snapshot', () => {
     });`,
   );
 
-
   {
     makeTests(TESTS_DIR, {[filename]: template(['true', '{a: "original"}'])});
     const {stderr, status} = runJest(DIR, [filename]);
@@ -77,7 +76,6 @@ test('error thrown before snapshot', () => {
     expect(stderr).toMatch('Snapshots:   1 passed, 1 total');
     expect(status).toBe(0);
   }
-
 
   {
     makeTests(TESTS_DIR, {[filename]: template(['false', '{a: "original"}'])});
@@ -153,9 +151,7 @@ test('accepts custom snapshot name', () => {
   {
     makeTests(TESTS_DIR, {[filename]: template()});
     const {stderr, status} = runJest(DIR, [filename]);
-    expect(stderr).toMatch(
-      '1 snapshot written in 1 test suite.'
-    );
+    expect(stderr).toMatch('1 snapshot written in 1 test suite.');
     expect(status).toBe(0);
   }
 });

--- a/integration_tests/__tests__/toThrowErrorMatchingSnapshot-test.js
+++ b/integration_tests/__tests__/toThrowErrorMatchingSnapshot-test.js
@@ -48,9 +48,7 @@ test(`throws the error if tested function didn't throw error`, () => {
   {
     makeTests(TESTS_DIR, {[filename]: template()});
     const {stderr, status} = runJest(DIR, [filename]);
-    expect(stderr).toMatch(
-      `Expected the function to throw an error.`,
-    );
+    expect(stderr).toMatch(`Expected the function to throw an error.`);
     expect(status).toBe(1);
   }
 });
@@ -68,9 +66,7 @@ test('does not accept arguments', () => {
   {
     makeTests(TESTS_DIR, {[filename]: template()});
     const {stderr, status} = runJest(DIR, [filename]);
-    expect(stderr).toMatch(
-      'Matcher does not accept any arguments.',
-    );
+    expect(stderr).toMatch('Matcher does not accept any arguments.');
     expect(status).toBe(1);
   }
 });

--- a/integration_tests/__tests__/transform-test.js
+++ b/integration_tests/__tests__/transform-test.js
@@ -63,7 +63,7 @@ describe('custom transformer', () => {
   const dir = path.resolve(
     __dirname,
     '..',
-    'transform/custom-instrumenting-preprocessor'
+    'transform/custom-instrumenting-preprocessor',
   );
 
   it('proprocesses files', () => {
@@ -84,11 +84,7 @@ describe('custom transformer', () => {
 });
 
 describe('multiple-transformers', () => {
-  const dir = path.resolve(
-    __dirname,
-    '..',
-    'transform/multiple-transformers',
-  );
+  const dir = path.resolve(__dirname, '..', 'transform/multiple-transformers');
 
   beforeEach(() => {
     if (process.platform !== 'win32') {

--- a/integration_tests/babel-plugin-jest-hoist/__tests__/integration-test.js
+++ b/integration_tests/babel-plugin-jest-hoist/__tests__/integration-test.js
@@ -27,9 +27,7 @@ const virtualModule = require('virtual-module');
 // These will all be hoisted above imports
 jest.unmock('react');
 jest.deepUnmock('../__test_modules__/Unmocked');
-jest
-  .unmock('../__test_modules__/c')
-  .unmock('../__test_modules__/d');
+jest.unmock('../__test_modules__/c').unmock('../__test_modules__/d');
 jest.mock('../__test_modules__/e', () => {
   if (!global.CALLS) {
     global.CALLS = 0;
@@ -49,8 +47,9 @@ jest.mock('../__test_modules__/e', () => {
 });
 jest.mock('virtual-module', () => 'kiwi', {virtual: true});
 // This has types that should be ignored by the out-of-scope variables check.
-jest.mock('has-flow-types', () =>
-  (props: {children: mixed}) => 3, {virtual: true});
+jest.mock('has-flow-types', () => (props: {children: mixed}) => 3, {
+  virtual: true,
+});
 
 // These will not be hoisted
 jest.unmock('../__test_modules__/a').dontMock('../__test_modules__/b');
@@ -62,7 +61,6 @@ const myObject = {mock: () => {}};
 myObject.mock('apple', 27);
 
 describe('babel-plugin-jest-hoist', () => {
-
   it('does not throw during transform', () => {
     const object = {};
     object.__defineGetter__('foo', () => 'bar');
@@ -76,7 +74,7 @@ describe('babel-plugin-jest-hoist', () => {
 
   it('hoists unmocked modules before imports', () => {
     expect(Unmocked._isMockFunction).toBe(undefined);
-    expect((new Unmocked()).isUnmocked).toEqual(true);
+    expect(new Unmocked().isUnmocked).toEqual(true);
 
     expect(c._isMockFunction).toBe(undefined);
     expect(c()).toEqual('unmocked');
@@ -110,7 +108,7 @@ describe('babel-plugin-jest-hoist', () => {
 
   it('does not hoist dontMock calls before imports', () => {
     expect(Mocked._isMockFunction).toBe(true);
-    expect((new Mocked()).isMocked).toEqual(undefined);
+    expect(new Mocked().isMocked).toEqual(undefined);
 
     expect(a._isMockFunction).toBe(true);
     expect(a()).toEqual(undefined);

--- a/integration_tests/babel-plugin-jest-hoist/banana.js
+++ b/integration_tests/babel-plugin-jest-hoist/banana.js
@@ -6,4 +6,4 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
- module.exports = 'banana';
+module.exports = 'banana';

--- a/integration_tests/coverage-remapping/typescript-preprocessor.js
+++ b/integration_tests/coverage-remapping/typescript-preprocessor.js
@@ -13,16 +13,13 @@ const tsc = require('typescript');
 module.exports = {
   process(src, path) {
     if (path.endsWith('.ts') || path.endsWith('.tsx')) {
-      const result = tsc.transpileModule(
-        src,
-        {
-          compilerOptions: {
-            module: tsc.ModuleKind.CommonJS,
-            sourceMap: true,
-          },
-          fileName: path,
-        }
-      );
+      const result = tsc.transpileModule(src, {
+        compilerOptions: {
+          module: tsc.ModuleKind.CommonJS,
+          sourceMap: true,
+        },
+        fileName: path,
+      });
       return {
         code: result.outputText,
         map: JSON.parse(result.sourceMapText),

--- a/integration_tests/coverage_report/__mocks__/sum_dependency.js
+++ b/integration_tests/coverage_report/__mocks__/sum_dependency.js
@@ -8,3 +8,4 @@
 'use strict';
 
 // This is mock that does nothing but used for coverage integration test
+

--- a/integration_tests/coverage_report/not-required-in-test-suite.js
+++ b/integration_tests/coverage_report/not-required-in-test-suite.js
@@ -7,17 +7,14 @@
  */
 'use strict';
 
-throw new Error(`
-  this error should not be a problem because
-  this file is never required or executed
-`);
+throw new Error(
+  `this error should not be a problem because` +
+  `this file is never required or executed`
+);
 
 // Flow annotations to make sure istanbul can instrument non ES6 source
 /* eslint-disable no-unreachable */
-module.exports = function(
-  j: string,
-  d: string
-): string {
+module.exports = function(j: string, d: string): string {
   if (j) {
     return d;
   } else {

--- a/integration_tests/jasmine_async/__tests__/promise_beforeAll-test.js
+++ b/integration_tests/jasmine_async/__tests__/promise_beforeAll-test.js
@@ -17,9 +17,12 @@ describe('promise beforeAll', () => {
     });
   });
 
-  beforeAll(() => {
-    return new Promise(resolve => setTimeout(resolve, 10));
-  }, 500);
+  beforeAll(
+    () => {
+      return new Promise(resolve => setTimeout(resolve, 10));
+    },
+    500
+  );
 
   // passing tests
   it('runs tests after beforeAll asynchronously completes', () => {
@@ -28,9 +31,12 @@ describe('promise beforeAll', () => {
 
   describe('with failing timeout', () => {
     // failing before hook
-    beforeAll(() => {
-      return new Promise(resolve => setTimeout(resolve, 100));
-    }, 10);
+    beforeAll(
+      () => {
+        return new Promise(resolve => setTimeout(resolve, 100));
+      },
+      10
+    );
 
     it('fails', () => {});
   });

--- a/integration_tests/jasmine_async/__tests__/promise_it-test.js
+++ b/integration_tests/jasmine_async/__tests__/promise_it-test.js
@@ -30,8 +30,7 @@ describe('promise it', () => {
     return new Promise(resolve => {
       if (this.someContextValue !== 'value') {
         throw new Error(
-          'expected this.someContextValue to be set: ' +
-          this.someContextValue
+          'expected this.someContextValue to be set: ' + this.someContextValue
         );
       }
       resolve();
@@ -51,12 +50,20 @@ describe('promise it', () => {
     expect('sync').toBe('failed');
   });
 
-  it('succeeds if the test finishes in time', () => {
-    return new Promise(resolve => setTimeout(resolve, 10));
-  }, 250);
+  it(
+    'succeeds if the test finishes in time',
+    () => {
+      return new Promise(resolve => setTimeout(resolve, 10));
+    },
+    250
+  );
 
   // failing tests
-  it('fails if a custom timeout is exceeded', () => {
-    return new Promise(resolve => setTimeout(resolve, 100));
-  }, 10);
+  it(
+    'fails if a custom timeout is exceeded',
+    () => {
+      return new Promise(resolve => setTimeout(resolve, 100));
+    },
+    10
+  );
 });

--- a/integration_tests/jasmine_async/__tests__/returning_values-test.js
+++ b/integration_tests/jasmine_async/__tests__/returning_values-test.js
@@ -6,13 +6,24 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
- 'use strict';
+'use strict';
 
- describe('returning values', () => {
-   [1, 'string', 0.1, null, NaN, Infinity, true, false, [1], {}, () => {}]
-     .forEach(val => {
-       it(`throws if '${val}:${typeof val}' is returned`, () => {
-         return val;
-       });
-     });
- });
+describe('returning values', () => {
+  [
+    1,
+    'string',
+    0.1,
+    null,
+    NaN,
+    Infinity,
+    true,
+    false,
+    [1],
+    {},
+    () => {},
+  ].forEach(val => {
+    it(`throws if '${val}:${typeof val}' is returned`, () => {
+      return val;
+    });
+  });
+});

--- a/integration_tests/runJest.js
+++ b/integration_tests/runJest.js
@@ -24,12 +24,14 @@ function runJest(dir, args) {
 
   const localPackageJson = path.resolve(dir, 'package.json');
   if (!fileExists(localPackageJson)) {
-    throw new Error(`
+    throw new Error(
+      `
       Make sure you have a local package.json file at
         "${localPackageJson}".
       Otherwise Jest will try to traverse the directory tree and find the
       the global package.json, which will send Jest into infinite loop.
-    `);
+    `,
+    );
   }
 
   const result = spawnSync(JEST_PATH, args || [], {
@@ -52,12 +54,14 @@ runJest.json = function(dir, args) {
   try {
     result.json = JSON.parse((result.stdout || '').toString());
   } catch (e) {
-    throw new Error(`
+    throw new Error(
+      `
       Can't parse JSON.
       ERROR: ${e.name} ${e.message}
       STDOUT: ${result.stdout}
       STDERR: ${result.stderr}
-    `);
+    `,
+    );
   }
   return result;
 };

--- a/integration_tests/snapshot-escape/__tests__/snapshot-test.js
+++ b/integration_tests/snapshot-escape/__tests__/snapshot-test.js
@@ -7,4 +7,5 @@
  */
 'use strict';
 
+// prettier-ignore
 test('escape strings', () => expect('one: \\\'').toMatchSnapshot());

--- a/integration_tests/snapshot/__tests__/second-snapshot-test.js
+++ b/integration_tests/snapshot/__tests__/second-snapshot-test.js
@@ -10,7 +10,6 @@
 'use strict';
 
 describe('snapshot', () => {
-
   it('works with plain objects and the title has `escape` characters', () => {
     const test = {
       a: 1,
@@ -20,5 +19,4 @@ describe('snapshot', () => {
     };
     expect(test).toMatchSnapshot();
   });
-
 });

--- a/integration_tests/snapshot/__tests__/snapshot-test.js
+++ b/integration_tests/snapshot/__tests__/snapshot-test.js
@@ -10,7 +10,6 @@
 'use strict';
 
 describe('snapshot', () => {
-
   it('works with plain objects and the title has `escape` characters', () => {
     const test = {
       a: 1,
@@ -24,9 +23,9 @@ describe('snapshot', () => {
 
   it('is not influenced by previous counter', () => {
     const test = {
-      a:43,
-      b:'43',
-      c:'fourtythree',
+      a: 43,
+      b: '43',
+      c: 'fourtythree',
     };
     expect(test).toMatchSnapshot();
   });

--- a/integration_tests/transform/custom-instrumenting-preprocessor/__tests__/custom-preprocessor-test.js
+++ b/integration_tests/transform/custom-instrumenting-preprocessor/__tests__/custom-preprocessor-test.js
@@ -8,7 +8,6 @@
 
 'use strict';
 
-
 require('../src');
 
 it('instruments by setting global.__INSTRUMENTED__', () => {

--- a/integration_tests/transform/multiple-transformers/__tests__/multiple-transformers-test.js
+++ b/integration_tests/transform/multiple-transformers/__tests__/multiple-transformers-test.js
@@ -12,8 +12,6 @@ import renderer from 'react-test-renderer';
 import App from '../src/App';
 
 it('generates a snapshot with correctly transformed dependencies', () => {
-  const tree = renderer.create(
-    <App/>
-  ).toJSON();
+  const tree = renderer.create(<App />).toJSON();
   expect(tree).toMatchSnapshot();
 });

--- a/integration_tests/transform/no-babel-jest/__tests__/fails-with-syntax-error-test.js
+++ b/integration_tests/transform/no-babel-jest/__tests__/fails-with-syntax-error-test.js
@@ -8,7 +8,6 @@
 
 'use strict';
 
-
 // fails because there is no `strip-flow-types` transform
 const thisFunctionIsNeverInstrumented = (a: string) => {
   return null;

--- a/integration_tests/utils.js
+++ b/integration_tests/utils.js
@@ -77,31 +77,30 @@ const createEmptyPackage = (directory, packageJson) => {
   packageJson || (packageJson = DEFAULT_PACKAGE_JSON);
   fs.writeFileSync(
     path.resolve(directory, 'package.json'),
-    JSON.stringify(packageJson, null, 2)
+    JSON.stringify(packageJson, null, 2),
   );
-
 };
 
 const extractSummary = stdout => {
   const match = stdout.match(
-    /Test Suites:.*\nTests.*\nSnapshots.*\nTime.*\nRan all test suites.*\n*$/gm
+    /Test Suites:.*\nTests.*\nSnapshots.*\nTime.*\nRan all test suites.*\n*$/gm,
   );
   if (!match) {
-    throw new Error(`
+    throw new Error(
+      `
       Could not find test summary in the output.
       OUTPUT:
         ${stdout}
-    `);
+    `,
+    );
   }
 
   const summary = match[0]
     .replace(/\d*\.?\d+m?s/g, '<<REPLACED>>')
     .replace(/, estimated <<REPLACED>>/g, '');
 
-  const rest = stdout
-    .slice(0, -match[0].length)
-    // remove all timestamps
-    .replace(/\s*\(.*ms\)/gm, '');
+  // remove all timestamps
+  const rest = stdout.slice(0, -match[0].length).replace(/\s*\(.*ms\)/gm, '');
 
   return {rest, summary};
 };

--- a/scripts/_runCommand.js
+++ b/scripts/_runCommand.js
@@ -14,20 +14,24 @@ module.exports = function runCommand(cmd, args, cwd) {
   if (!cwd) {
     cwd = __dirname;
   }
-  args = args.split(' ');
 
+  const callArgs = args.split(' ');
   console.log(
     chalk.dim('$ cd ' + cwd) +
       '\n' +
-      chalk.dim('  $ ' + cmd + ' ' + args.join(' ')) +
+      chalk.dim(
+        '  $ ' +
+          cmd +
+          ' ' +
+          (args.length > 1000 ? args.slice(0, 1000) + '...' : args)
+      ) +
       '\n'
   );
-  const result = spawn(cmd, args, {cwd});
+  const result = spawn(cmd, callArgs, {
+    cwd,
+    stdio: 'inherit',
+  });
   if (result.error || result.status !== 0) {
-    const stdout = result.stdout.toString();
-    const stderr = result.stderr.toString();
-    stdout && console.log(stdout);
-    stderr && console.log(chalk.red(stderr));
     const message = 'Error running command.';
     const error = new Error(message);
     error.stack = message;

--- a/scripts/prettier.js
+++ b/scripts/prettier.js
@@ -7,34 +7,63 @@
  */
 'use strict';
 
-const path = require('path');
 const chalk = require('chalk');
+const glob = require('glob');
+const path = require('path');
 const runCommand = require('./_runCommand');
 
 const shouldWrite = process.argv[2] === 'write';
 const isWindows = process.platform === 'win32';
 const prettier = isWindows ? 'prettier.cmd' : 'prettier';
 const prettierCmd = path.resolve(__dirname, '../node_modules/.bin/' + prettier);
-const args = [
-  `--${shouldWrite ? 'write' : 'l'} packages/*/src/**/*.js`,
-  `--single-quote`,
-  `--trailing-comma=all`,
-  `--bracket-spacing=false`,
-].join(' ');
+const defaultOptions = {
+  'bracket-spacing': 'false',
+  'single-quote': 'true',
+  'trailing-comma': 'all',
+};
+const config = {
+  default: {
+    patterns: [
+      'packages/*/src/**/',
+      'types/',
+      'integration_tests/',
+      'integration_tests/__tests__/',
+    ],
+  },
+  integrationTests: {
+    options: {
+      'trailing-comma': 'es5',
+    },
+    patterns: ['integration_tests/**/'],
+  },
+};
 
-try {
-  runCommand(prettierCmd, args, path.resolve(__dirname, '..'));
-} catch (e) {
-  console.log(e);
-  if (!shouldWrite) {
-    console.log(
-      chalk.red(
-        `  This project uses prettier to format all JavaScript code.\n`
-      ) +
-        chalk.dim(`    Please run `) +
-        chalk.reset('yarn prettier') +
-        chalk.dim(` and add changes to files listed above to your commit.`) +
-        `\n`
-    );
+Object.keys(config).forEach(key => {
+  const patterns = config[key].patterns;
+  const options = config[key].options;
+  const files = glob
+    .sync(`{${patterns.join(',')}}*.js`)
+    .filter(file => !file.includes(path.sep + 'node_modules' + path.sep));
+
+  const args = Object.keys(defaultOptions).map(
+    key => `--${key}=${(options && options[key]) || defaultOptions[key]}`
+  );
+  args.push(`--${shouldWrite ? 'write' : 'l'} {${files.join(' ')}}`);
+
+  try {
+    runCommand(prettierCmd, args.join(' '), path.resolve(__dirname, '..'));
+  } catch (e) {
+    console.log(e);
+    if (!shouldWrite) {
+      console.log(
+        chalk.red(
+          `  This project uses prettier to format all JavaScript code.\n`
+        ) +
+          chalk.dim(`    Please run `) +
+          chalk.reset('yarn prettier') +
+          chalk.dim(` and add changes to files listed above to your commit.`) +
+          `\n`
+      );
+    }
   }
-}
+});

--- a/types/Environment.js
+++ b/types/Environment.js
@@ -15,21 +15,21 @@ import type {Script} from 'vm';
 import type {ModuleMocker} from 'jest-mock';
 
 export type Environment = {|
-  constructor(config: Config): void;
-  dispose(): void;
-  runScript(script: Script): any;
-  global: Global;
+  constructor(config: Config): void,
+  dispose(): void,
+  runScript(script: Script): any,
+  global: Global,
   fakeTimers: {
-    clearAllTimers(): void;
-    runAllImmediates(): void;
-    runAllTicks(): void;
-    runAllTimers(): void;
-    runTimersToTime(): void;
-    runOnlyPendingTimers(): void;
-    runWithRealTimers(callback: any): void;
-    useFakeTimers(): void;
-    useRealTimers(): void;
-  };
-  testFilePath: string;
-  moduleMocker: ModuleMocker;
+    clearAllTimers(): void,
+    runAllImmediates(): void,
+    runAllTicks(): void,
+    runAllTimers(): void,
+    runTimersToTime(): void,
+    runOnlyPendingTimers(): void,
+    runWithRealTimers(callback: any): void,
+    useFakeTimers(): void,
+    useRealTimers(): void,
+  },
+  testFilePath: string,
+  moduleMocker: ModuleMocker,
 |};

--- a/types/HasteMap.js
+++ b/types/HasteMap.js
@@ -45,18 +45,16 @@ export type RawModuleMap = {|
   mocks: MockData,
 |};
 
+// prettier-ignore
 export type FileMetaData = [
   /* id */ string,
   /* mtime */ number,
-  /* visited */ 0|1,
+  /* visited */ 0 | 1,
   /* dependencies */ Array<string>,
 ];
 
 type ModuleMapItem = {[platform: string]: ModuleMetaData};
-export type ModuleMetaData = [
-  Path,
-  /* type */ number,
-];
+export type ModuleMetaData = [Path, /* type */ number];
 
 export type HType = {|
   ID: 0,

--- a/types/Matchers.js
+++ b/types/Matchers.js
@@ -13,7 +13,7 @@ import type {Path} from 'types/Config';
 
 export type ExpectationResult = {
   pass: boolean,
-  message: string | () => string,
+  message: string | (() => string),
 };
 
 export type RawMatcherFn = (
@@ -31,9 +31,10 @@ export type MatcherState = {
   currentTestName?: string,
   testPath?: Path,
 };
-export type MatchersObject = {[id:string]: RawMatcherFn};
+export type MatchersObject = {[id: string]: RawMatcherFn};
 export type Expect = (expected: any) => ExpectationObject;
 export type ExpectationObject = {
+  [id: string]: ThrowingMatcherFn,
   resolves: {
     [id: string]: PromiseMatcherFn,
     not: {[id: string]: PromiseMatcherFn},
@@ -42,6 +43,5 @@ export type ExpectationObject = {
     [id: string]: PromiseMatcherFn,
     not: {[id: string]: PromiseMatcherFn},
   },
-  [id: string]: ThrowingMatcherFn,
   not: {[id: string]: ThrowingMatcherFn},
 };

--- a/types/Mock.js
+++ b/types/Mock.js
@@ -9,7 +9,10 @@
  */
 'use strict';
 
-import type {MockFunctionMetadata as _MockFunctionMetadata, ModuleMocker as _ModuleMocker} from 'jest-mock';
+import type {
+  MockFunctionMetadata as _MockFunctionMetadata,
+  ModuleMocker as _ModuleMocker,
+} from 'jest-mock';
 
 export type MockFunctionMetadata = _MockFunctionMetadata;
 export type ModuleMocker = _ModuleMocker;

--- a/types/Process.js
+++ b/types/Process.js
@@ -10,6 +10,6 @@
 'use strict';
 
 export interface Process {
-  stdout : stream$Writable | tty$WriteStream;
-  exit(code? : number) : void;
-};
+  stdout: stream$Writable | tty$WriteStream,
+  exit(code?: number): void,
+}

--- a/types/Resolve.js
+++ b/types/Resolve.js
@@ -9,7 +9,9 @@
  */
 'use strict';
 
-import type _Resolver, { ResolveModuleConfig as _ResolveModuleConfig } from 'jest-resolve';
+import type _Resolver, {
+  ResolveModuleConfig as _ResolveModuleConfig,
+} from 'jest-resolve';
 
 export type Resolver = _Resolver;
 export type ResolveModuleConfig = _ResolveModuleConfig;

--- a/types/TestResult.js
+++ b/types/TestResult.js
@@ -13,13 +13,13 @@ import type {ConsoleBuffer} from './Console';
 
 export type RawFileCoverage = {|
   path: string,
-  s: { [statementId: number]: number },
-  b: { [branchId: number]: number },
-  f: { [functionId: number]: number },
-  l: { [lineId: number]: number },
-  fnMap: { [functionId: number]: any },
-  statementMap: { [statementId: number]: any },
-  branchMap: { [branchId: number]: any },
+  s: {[statementId: number]: number},
+  b: {[branchId: number]: number},
+  f: {[functionId: number]: number},
+  l: {[lineId: number]: number},
+  fnMap: {[functionId: number]: any},
+  statementMap: {[statementId: number]: any},
+  branchMap: {[branchId: number]: any},
   inputSourceMap?: Object,
 |};
 
@@ -50,7 +50,7 @@ export type FileCoverage = {|
   computeSimpleTotals: (property: string) => FileCoverageTotal,
   computeBranchTotals: () => FileCoverageTotal,
   resetHits: () => void,
-  toSummary: () => CoverageSummary
+  toSummary: () => CoverageSummary,
 |};
 
 export type CoverageMap = {|


### PR DESCRIPTION
**Summary**

This enables prettier for the types and integration tests folders. Unfortunately it isn't easy to exclude node_modules from the CLI when matching against the integration tests folder so I changed it to filter first and pass the entire list to the prettier CLI. At this point it occurs to me that we should probably just use the prettier API directly.

**Test plan**

yarn test