### PR TITLE
Show reject reason when expecting resolve

### DIFF
--- a/packages/jest-matchers/src/__tests__/__snapshots__/matchers-test.js.snap
+++ b/packages/jest-matchers/src/__tests__/__snapshots__/matchers-test.js.snap
@@ -73,7 +73,7 @@ exports[`.resolves fails for promise that rejects 1`] = `
 "<dim>expect(<red>received</><dim>).resolves.toBe(<dim>)
 
 Expected <red>received</> Promise to resolve, instead it rejected to value
-  <red>undefined</>"
+  <red>4</>"
 `;
 
 exports[`.resolves fails non-promise value "a" 1`] = `

--- a/packages/jest-matchers/src/index.js
+++ b/packages/jest-matchers/src/index.js
@@ -148,7 +148,7 @@ const makeResolveMatcher = (
           '\n\n' +
           `Expected ${utils.RECEIVED_COLOR('received')} Promise to resolve, ` +
           'instead it rejected to value\n' +
-          `  ${utils.printReceived(result)}`,
+          `  ${utils.printReceived(e)}`,
       );
     }
     return makeThrowingMatcher(matcher, isNot, result).apply(null, args);


### PR DESCRIPTION
**Summary**

Fixes the message when a promise was expected to be fulfilled but was rejected.

```js
await jestExpect(Promise.reject(4)).resolves.toBe(4);
```

```diff
- Expected received Promise to resolve, instead it rejected to value undefined
+ Expected received Promise to resolve, instead it rejected to value 4
```

This was overlooked in #3068.

**Test plan**

The snapshot covers this.
