### PR TITLE
Fix transformIgnorePatterns example

### DIFF
--- a/docs/TutorialReactNative.md
+++ b/docs/TutorialReactNative.md
@@ -156,7 +156,7 @@ By default the jest-react-native preset only processes the project's own source 
 
 ```json
 "transformIgnorePatterns": [
-  "node_modules/(?!react-native|my-project|react-native-button)"
+  "node_modules/(?!react-native|my-project|react-native-button)/"
 ]
 ```
 


### PR DESCRIPTION
Without the slash at the end `react-native-button` is still being ignored for some reason.
