### PR TITLE
add documentation around inline require transforms

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -48,6 +48,8 @@ This option is disabled by default. If you are introducing Jest to a large organ
 
 *Note: Core modules, like `fs`, are not mocked by default. They can be mocked explicitly, like `jest.mock('fs')`.*
 
+*Note: Automocking has a performance cost most noticeable in large projects. See [here](troubleshooting.html#tests-are-slow-when-leveraging-automocking) for details and a workaround.*
+
 ### `browser` [boolean]
 Default: `false`
 

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -96,6 +96,11 @@ jest --runInBand
 npm test -- --runInBand
 ```
 
+### Tests are slow when leveraging automocking
+Whether via [`automock: true`](configuration.html#automock-boolean) in config or lots of [`jest.mock('my-module')`](jest-object.html#jestmockmodulename-factory-options) calls in tests, automocking has a performance cost that can add up in large projects. The more dependencies a module has, the more work Jest has to do to mock it. Something that can offset this performance cost significantly is adding a code transformer that moves `import` or `require` calls from the top of a module, where they are always executed, down into the body of the module, where they are usually not executed. This can lower the number of modules Jest has to load when running your tests by a considerable amount.
+
+To transform `import` statements, there is [babel-plugin-transform-inline-imports-commonjs](https://github.com/zertosh/babel-plugin-transform-inline-imports-commonjs), and to transform `require` statements, there is [Facebook's `inline-requires` babel plugin](https://github.com/facebook/fbjs/blob/master/packages/babel-preset-fbjs/plugins/inline-requires.js), which is part of the `babel-preset-fbjs` package.
+
 ### I'm using npm3 and my node_modules aren't properly loading.
 
 Upgrade `jest-cli` to `0.9.0` or above.


### PR DESCRIPTION
I got a ~70% speed boost in test suite run times after adding a babel plugin that inlines require calls to an automocked codebase. This adds documentation so other users can discover this. Ref: #3084