### PR TITLE
use slash when creating integration test folders

### DIFF
--- a/integration_tests/utils.js
+++ b/integration_tests/utils.js
@@ -11,6 +11,7 @@ const fs = require('fs');
 const mkdirp = require('mkdirp');
 const path = require('path');
 const rimraf = require('rimraf');
+const slash = require('slash');
 
 const run = (cmd, cwd) => {
   const args = cmd.split(/\s/).slice(1);
@@ -59,9 +60,9 @@ const makeTemplate = string => {
 const cleanup = (directory: string) => rimraf.sync(directory);
 
 const makeTests = (directory: string, tests: {[filename: string]: string}) => {
-  mkdirp.sync(directory);
+  mkdirp.sync(slash(directory));
   Object.keys(tests).forEach(filename => {
-    fs.writeFileSync(path.resolve(directory, filename), tests[filename]);
+    fs.writeFileSync(slash(path.resolve(directory, filename)), tests[filename]);
   });
 };
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

Currently in master, test `integration_tests\__tests__\toThrowErrorMatchingSnapshot-test.js` is failing on windows. This small change leverages [slash](https://github.com/sindresorhus/slash) to normalize the directories before handing off to `mkdirp`. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

My test plan was very simple. Just running `yarn run jest` to confirm that the failing test is now passing.

This is my first pull request (of hopefully many 😄 ) so please let me know if there is any changes you would like. 

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
