### PR TITLE
[jest-matchers] Simplify `asymmetricMatch` of `ArrayContaining`.

### DIFF
--- a/packages/jest-matchers/src/asymmetric-matchers.js
+++ b/packages/jest-matchers/src/asymmetric-matchers.js
@@ -11,7 +11,6 @@
 'use strict';
 
 const {
-  contains,
   equals,
   fnNameFor,
   hasProperty,
@@ -131,14 +130,8 @@ class ArrayContaining extends AsymmetricMatcher {
       );
     }
 
-    for (let i = 0; i < this.sample.length; i++) {
-      const item = this.sample[i];
-      if (!contains(other, item)) {
-        return false;
-      }
-    }
-
-    return true;
+    return this.sample.length === 0 || Array.isArray(other) &&
+      this.sample.every(item => other.some(another => equals(item, another)));
   }
 
   toString() {

--- a/packages/jest-matchers/src/jasmine-utils.js
+++ b/packages/jest-matchers/src/jasmine-utils.js
@@ -31,24 +31,6 @@ function equals(a, b, customTesters) {
   return eq(a, b, [], [], customTesters);
 }
 
-function contains(haystack, needle, customTesters) {
-  customTesters = customTesters || [];
-
-  if (
-    Object.prototype.toString.apply(haystack) === '[object Array]' ||
-    (!!haystack && !haystack.indexOf)
-  ) {
-    for (var i = 0; i < haystack.length; i++) {
-      if (eq(haystack[i], needle, [], [], customTesters)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  return !!haystack && haystack.indexOf(needle) >= 0;
-}
-
 function isAsymmetric(obj) {
   return obj && isA('Function', obj.asymmetricMatch);
 }
@@ -303,7 +285,6 @@ function hasProperty(obj, property) {
 }
 
 module.exports = {
-  contains,
   equals,
   fnNameFor,
   hasProperty,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Since `jasmine-utils` was mostly yanked from `underscore`, it had to deal with some specific cases (i.e. IE8 support).  This simplifies the implementation of `contains` and pulls it into `asymmetricMatch`, allowing the `Array.isArray` equivalent to be hoisted.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
Nothing should change.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
