### PR TITLE
Test Title Unification for matchers-test.js in jest-matchers package

### DIFF
--- a/packages/jest-matchers/src/__tests__/__snapshots__/matchers-test.js.snap
+++ b/packages/jest-matchers/src/__tests__/__snapshots__/matchers-test.js.snap
@@ -318,6 +318,60 @@ Received:
   <red>true</>"
 `;
 
+exports[`.toBeCloseTo() {pass: true} expect(0)toBeCloseTo( 0) 1`] = `
+"<dim>expect(<red>received</><dim>).not.toBeCloseTo(<green>expected, precision</><dim>)
+
+Expected value not to be close to (with <green>2</>-digit precision):
+  <green>0</>
+Received:
+  <red>0</>"
+`;
+
+exports[`.toBeCloseTo() {pass: true} expect(0)toBeCloseTo( 0.001) 1`] = `
+"<dim>expect(<red>received</><dim>).not.toBeCloseTo(<green>expected, precision</><dim>)
+
+Expected value not to be close to (with <green>2</>-digit precision):
+  <green>0.001</>
+Received:
+  <red>0</>"
+`;
+
+exports[`.toBeCloseTo() {pass: true} expect(1.23)toBeCloseTo( 1.225) 1`] = `
+"<dim>expect(<red>received</><dim>).not.toBeCloseTo(<green>expected, precision</><dim>)
+
+Expected value not to be close to (with <green>2</>-digit precision):
+  <green>1.225</>
+Received:
+  <red>1.23</>"
+`;
+
+exports[`.toBeCloseTo() {pass: true} expect(1.23)toBeCloseTo( 1.226) 1`] = `
+"<dim>expect(<red>received</><dim>).not.toBeCloseTo(<green>expected, precision</><dim>)
+
+Expected value not to be close to (with <green>2</>-digit precision):
+  <green>1.226</>
+Received:
+  <red>1.23</>"
+`;
+
+exports[`.toBeCloseTo() {pass: true} expect(1.23)toBeCloseTo( 1.229) 1`] = `
+"<dim>expect(<red>received</><dim>).not.toBeCloseTo(<green>expected, precision</><dim>)
+
+Expected value not to be close to (with <green>2</>-digit precision):
+  <green>1.229</>
+Received:
+  <red>1.23</>"
+`;
+
+exports[`.toBeCloseTo() {pass: true} expect(1.23)toBeCloseTo( 1.234) 1`] = `
+"<dim>expect(<red>received</><dim>).not.toBeCloseTo(<green>expected, precision</><dim>)
+
+Expected value not to be close to (with <green>2</>-digit precision):
+  <green>1.234</>
+Received:
+  <red>1.23</>"
+`;
+
 exports[`.toBeCloseTo() accepts an optional precision argument: [0, 0.000004, 5] 1`] = `
 "<dim>expect(<red>received</><dim>).not.toBeCloseTo(<green>expected, precision</><dim>)
 
@@ -343,60 +397,6 @@ Expected value not to be close to (with <green>0</>-digit precision):
   <green>0.1</>
 Received:
   <red>0</>"
-`;
-
-exports[`.toBeCloseTo() passes: [0, 0.001] 1`] = `
-"<dim>expect(<red>received</><dim>).not.toBeCloseTo(<green>expected, precision</><dim>)
-
-Expected value not to be close to (with <green>2</>-digit precision):
-  <green>0.001</>
-Received:
-  <red>0</>"
-`;
-
-exports[`.toBeCloseTo() passes: [0, 0] 1`] = `
-"<dim>expect(<red>received</><dim>).not.toBeCloseTo(<green>expected, precision</><dim>)
-
-Expected value not to be close to (with <green>2</>-digit precision):
-  <green>0</>
-Received:
-  <red>0</>"
-`;
-
-exports[`.toBeCloseTo() passes: [1.23, 1.225] 1`] = `
-"<dim>expect(<red>received</><dim>).not.toBeCloseTo(<green>expected, precision</><dim>)
-
-Expected value not to be close to (with <green>2</>-digit precision):
-  <green>1.225</>
-Received:
-  <red>1.23</>"
-`;
-
-exports[`.toBeCloseTo() passes: [1.23, 1.226] 1`] = `
-"<dim>expect(<red>received</><dim>).not.toBeCloseTo(<green>expected, precision</><dim>)
-
-Expected value not to be close to (with <green>2</>-digit precision):
-  <green>1.226</>
-Received:
-  <red>1.23</>"
-`;
-
-exports[`.toBeCloseTo() passes: [1.23, 1.229] 1`] = `
-"<dim>expect(<red>received</><dim>).not.toBeCloseTo(<green>expected, precision</><dim>)
-
-Expected value not to be close to (with <green>2</>-digit precision):
-  <green>1.229</>
-Received:
-  <red>1.23</>"
-`;
-
-exports[`.toBeCloseTo() passes: [1.23, 1.234] 1`] = `
-"<dim>expect(<red>received</><dim>).not.toBeCloseTo(<green>expected, precision</><dim>)
-
-Expected value not to be close to (with <green>2</>-digit precision):
-  <green>1.234</>
-Received:
-  <red>1.23</>"
 `;
 
 exports[`.toBeCloseTo() throws: [0, 0.01] 1`] = `
@@ -1252,28 +1252,28 @@ Expected constructor to be a function. Instead got:
   <green>\\"number\\"</>"
 `;
 
-exports[`.toBeNaN() passes 1`] = `
+exports[`.toBeNaN() {pass: true} expect(NaN).toBeNaN() 1`] = `
 "<dim>expect(<red>received</><dim>).not.toBeNaN(<dim>)
 
 Expected value not to be NaN, instead received
   <red>NaN</>"
 `;
 
-exports[`.toBeNaN() passes 2`] = `
+exports[`.toBeNaN() {pass: true} expect(NaN).toBeNaN() 2`] = `
 "<dim>expect(<red>received</><dim>).not.toBeNaN(<dim>)
 
 Expected value not to be NaN, instead received
   <red>NaN</>"
 `;
 
-exports[`.toBeNaN() passes 3`] = `
+exports[`.toBeNaN() {pass: true} expect(NaN).toBeNaN() 3`] = `
 "<dim>expect(<red>received</><dim>).not.toBeNaN(<dim>)
 
 Expected value not to be NaN, instead received
   <red>NaN</>"
 `;
 
-exports[`.toBeNaN() passes 4`] = `
+exports[`.toBeNaN() {pass: true} expect(NaN).toBeNaN() 4`] = `
 "<dim>expect(<red>received</><dim>).not.toBeNaN(<dim>)
 
 Expected value not to be NaN, instead received
@@ -1873,7 +1873,7 @@ Expected <red>collection</> to be an array-like structure.
 Received: <red>null</>"
 `;
 
-exports[`.toEqual() expect("Alice").not.toEqual({"asymmetricMatch": [Function asymmetricMatch]}) 1`] = `
+exports[`.toEqual() {pass: false} expect("Alice").not.toEqual({"asymmetricMatch": [Function asymmetricMatch]}) 1`] = `
 "<dim>expect(<red>received</><dim>).not.toEqual(<green>expected</><dim>)
 
 Expected value to not equal:
@@ -1882,7 +1882,7 @@ Received:
   <red>\\"Alice\\"</>"
 `;
 
-exports[`.toEqual() expect("Eve").toEqual({"asymmetricMatch": [Function asymmetricMatch]}) 1`] = `
+exports[`.toEqual() {pass: false} expect("Eve").toEqual({"asymmetricMatch": [Function asymmetricMatch]}) 1`] = `
 "<dim>expect(<red>received</><dim>).toEqual(<green>expected</><dim>)
 
 Expected value to equal:
@@ -1891,7 +1891,7 @@ Received:
   <red>\\"Eve\\"</>"
 `;
 
-exports[`.toEqual() expect("abc").not.toEqual("abc") 1`] = `
+exports[`.toEqual() {pass: false} expect("abc").not.toEqual("abc") 1`] = `
 "<dim>expect(<red>received</><dim>).not.toEqual(<green>expected</><dim>)
 
 Expected value to not equal:
@@ -1900,7 +1900,7 @@ Received:
   <red>\\"abc\\"</>"
 `;
 
-exports[`.toEqual() expect("abcd").not.toEqual(StringContaining "bc") 1`] = `
+exports[`.toEqual() {pass: false} expect("abcd").not.toEqual(StringContaining "bc") 1`] = `
 "<dim>expect(<red>received</><dim>).not.toEqual(<green>expected</><dim>)
 
 Expected value to not equal:
@@ -1909,7 +1909,7 @@ Received:
   <red>\\"abcd\\"</>"
 `;
 
-exports[`.toEqual() expect("abcd").not.toEqual(StringMatching /bc/) 1`] = `
+exports[`.toEqual() {pass: false} expect("abcd").not.toEqual(StringMatching /bc/) 1`] = `
 "<dim>expect(<red>received</><dim>).not.toEqual(<green>expected</><dim>)
 
 Expected value to not equal:
@@ -1918,7 +1918,7 @@ Received:
   <red>\\"abcd\\"</>"
 `;
 
-exports[`.toEqual() expect("abd").toEqual(StringContaining "bc") 1`] = `
+exports[`.toEqual() {pass: false} expect("abd").toEqual(StringContaining "bc") 1`] = `
 "<dim>expect(<red>received</><dim>).toEqual(<green>expected</><dim>)
 
 Expected value to equal:
@@ -1927,7 +1927,7 @@ Received:
   <red>\\"abd\\"</>"
 `;
 
-exports[`.toEqual() expect("abd").toEqual(StringMatching /bc/i) 1`] = `
+exports[`.toEqual() {pass: false} expect("abd").toEqual(StringMatching /bc/i) 1`] = `
 "<dim>expect(<red>received</><dim>).toEqual(<green>expected</><dim>)
 
 Expected value to equal:
@@ -1936,7 +1936,7 @@ Received:
   <red>\\"abd\\"</>"
 `;
 
-exports[`.toEqual() expect("banana").toEqual("apple") 1`] = `
+exports[`.toEqual() {pass: false} expect("banana").toEqual("apple") 1`] = `
 "<dim>expect(<red>received</><dim>).toEqual(<green>expected</><dim>)
 
 Expected value to equal:
@@ -1945,7 +1945,7 @@ Received:
   <red>\\"banana\\"</>"
 `;
 
-exports[`.toEqual() expect([1, 2, 3]).not.toEqual(ArrayContaining [2, 3]) 1`] = `
+exports[`.toEqual() {pass: false} expect([1, 2, 3]).not.toEqual(ArrayContaining [2, 3]) 1`] = `
 "<dim>expect(<red>received</><dim>).not.toEqual(<green>expected</><dim>)
 
 Expected value to not equal:
@@ -1954,7 +1954,7 @@ Received:
   <red>[1, 2, 3]</>"
 `;
 
-exports[`.toEqual() expect([1, 3]).toEqual(ArrayContaining [1, 2]) 1`] = `
+exports[`.toEqual() {pass: false} expect([1, 3]).toEqual(ArrayContaining [1, 2]) 1`] = `
 "<dim>expect(<red>received</><dim>).toEqual(<green>expected</><dim>)
 
 Expected value to equal:
@@ -1975,7 +1975,7 @@ Difference:
 <dim> ]"
 `;
 
-exports[`.toEqual() expect([Function anonymous]).not.toEqual(Any<Function>) 1`] = `
+exports[`.toEqual() {pass: false} expect([Function anonymous]).not.toEqual(Any<Function>) 1`] = `
 "<dim>expect(<red>received</><dim>).not.toEqual(<green>expected</><dim>)
 
 Expected value to not equal:
@@ -1984,7 +1984,7 @@ Received:
   <red>[Function anonymous]</>"
 `;
 
-exports[`.toEqual() expect({"a": 1, "b": [Function b], "c": true}).not.toEqual({"a": 1, "b": Any<Function>, "c": Anything}) 1`] = `
+exports[`.toEqual() {pass: false} expect({"a": 1, "b": [Function b], "c": true}).not.toEqual({"a": 1, "b": Any<Function>, "c": Anything}) 1`] = `
 "<dim>expect(<red>received</><dim>).not.toEqual(<green>expected</><dim>)
 
 Expected value to not equal:
@@ -1993,7 +1993,7 @@ Received:
   <red>{\\"a\\": 1, \\"b\\": [Function b], \\"c\\": true}</>"
 `;
 
-exports[`.toEqual() expect({"a": 1, "b": 2}).not.toEqual(ObjectContaining {"a": 1}) 1`] = `
+exports[`.toEqual() {pass: false} expect({"a": 1, "b": 2}).not.toEqual(ObjectContaining {"a": 1}) 1`] = `
 "<dim>expect(<red>received</><dim>).not.toEqual(<green>expected</><dim>)
 
 Expected value to not equal:
@@ -2002,7 +2002,7 @@ Received:
   <red>{\\"a\\": 1, \\"b\\": 2}</>"
 `;
 
-exports[`.toEqual() expect({"a": 1, "b": 2}).toEqual(ObjectContaining {"a": 2}) 1`] = `
+exports[`.toEqual() {pass: false} expect({"a": 1, "b": 2}).toEqual(ObjectContaining {"a": 2}) 1`] = `
 "<dim>expect(<red>received</><dim>).toEqual(<green>expected</><dim>)
 
 Expected value to equal:
@@ -2023,7 +2023,7 @@ Difference:
 <dim> }"
 `;
 
-exports[`.toEqual() expect({"a": 5}).toEqual({"b": 6}) 1`] = `
+exports[`.toEqual() {pass: false} expect({"a": 5}).toEqual({"b": 6}) 1`] = `
 "<dim>expect(<red>received</><dim>).toEqual(<green>expected</><dim>)
 
 Expected value to equal:
@@ -2042,7 +2042,7 @@ Difference:
 <dim> }"
 `;
 
-exports[`.toEqual() expect({"a": 99}).not.toEqual({"a": 99}) 1`] = `
+exports[`.toEqual() {pass: false} expect({"a": 99}).not.toEqual({"a": 99}) 1`] = `
 "<dim>expect(<red>received</><dim>).not.toEqual(<green>expected</><dim>)
 
 Expected value to not equal:
@@ -2051,7 +2051,7 @@ Received:
   <red>{\\"a\\": 99}</>"
 `;
 
-exports[`.toEqual() expect(0).toEqual(-0) 1`] = `
+exports[`.toEqual() {pass: false} expect(0).toEqual(-0) 1`] = `
 "<dim>expect(<red>received</><dim>).toEqual(<green>expected</><dim>)
 
 Expected value to equal:
@@ -2064,7 +2064,7 @@ Difference:
 <dim>Compared values have no visual difference."
 `;
 
-exports[`.toEqual() expect(1).not.toEqual(1) 1`] = `
+exports[`.toEqual() {pass: false} expect(1).not.toEqual(1) 1`] = `
 "<dim>expect(<red>received</><dim>).not.toEqual(<green>expected</><dim>)
 
 Expected value to not equal:
@@ -2073,7 +2073,7 @@ Received:
   <red>1</>"
 `;
 
-exports[`.toEqual() expect(1).toEqual(2) 1`] = `
+exports[`.toEqual() {pass: false} expect(1).toEqual(2) 1`] = `
 "<dim>expect(<red>received</><dim>).toEqual(<green>expected</><dim>)
 
 Expected value to equal:
@@ -2082,7 +2082,7 @@ Received:
   <red>1</>"
 `;
 
-exports[`.toEqual() expect(1).toEqual(ArrayContaining [1, 2]) 1`] = `
+exports[`.toEqual() {pass: false} expect(1).toEqual(ArrayContaining [1, 2]) 1`] = `
 "<dim>expect(<red>received</><dim>).toEqual(<green>expected</><dim>)
 
 Expected value to equal:
@@ -2095,7 +2095,7 @@ Difference:
   Comparing two different types of values. Expected <green>array</> but received <red>number</>."
 `;
 
-exports[`.toEqual() expect(Set {1, 2}).not.toEqual(Set {1, 2}) 1`] = `
+exports[`.toEqual() {pass: false} expect(Set {1, 2}).not.toEqual(Set {1, 2}) 1`] = `
 "<dim>expect(<red>received</><dim>).not.toEqual(<green>expected</><dim>)
 
 Expected value to not equal:
@@ -2104,7 +2104,7 @@ Received:
   <red>Set {1, 2}</>"
 `;
 
-exports[`.toEqual() expect(Set {1, 2}).toEqual(Set {2, 1}) 1`] = `
+exports[`.toEqual() {pass: false} expect(Set {1, 2}).toEqual(Set {2, 1}) 1`] = `
 "<dim>expect(<red>received</><dim>).toEqual(<green>expected</><dim>)
 
 Expected value to equal:
@@ -2117,7 +2117,7 @@ Difference:
 <dim>Compared values have no visual difference."
 `;
 
-exports[`.toEqual() expect(false).toEqual(ObjectContaining {"a": 2}) 1`] = `
+exports[`.toEqual() {pass: false} expect(false).toEqual(ObjectContaining {"a": 2}) 1`] = `
 "<dim>expect(<red>received</><dim>).toEqual(<green>expected</><dim>)
 
 Expected value to equal:
@@ -2130,7 +2130,7 @@ Difference:
   Comparing two different types of values. Expected <green>object</> but received <red>boolean</>."
 `;
 
-exports[`.toEqual() expect(null).toEqual(undefined) 1`] = `
+exports[`.toEqual() {pass: false} expect(null).toEqual(undefined) 1`] = `
 "<dim>expect(<red>received</><dim>).toEqual(<green>expected</><dim>)
 
 Expected value to equal:
@@ -2143,7 +2143,7 @@ Difference:
   Comparing two different types of values. Expected <green>undefined</> but received <red>null</>."
 `;
 
-exports[`.toEqual() expect(true).not.toEqual(Anything) 1`] = `
+exports[`.toEqual() {pass: false} expect(true).not.toEqual(Anything) 1`] = `
 "<dim>expect(<red>received</><dim>).not.toEqual(<green>expected</><dim>)
 
 Expected value to not equal:
@@ -2152,7 +2152,7 @@ Received:
   <red>true</>"
 `;
 
-exports[`.toEqual() expect(true).not.toEqual(true) 1`] = `
+exports[`.toEqual() {pass: false} expect(true).not.toEqual(true) 1`] = `
 "<dim>expect(<red>received</><dim>).not.toEqual(<green>expected</><dim>)
 
 Expected value to not equal:
@@ -2161,7 +2161,7 @@ Received:
   <red>true</>"
 `;
 
-exports[`.toEqual() expect(true).toEqual(false) 1`] = `
+exports[`.toEqual() {pass: false} expect(true).toEqual(false) 1`] = `
 "<dim>expect(<red>received</><dim>).toEqual(<green>expected</><dim>)
 
 Expected value to equal:
@@ -2170,7 +2170,7 @@ Received:
   <red>true</>"
 `;
 
-exports[`.toEqual() expect(undefined).toEqual(Any<Function>) 1`] = `
+exports[`.toEqual() {pass: false} expect(undefined).toEqual(Any<Function>) 1`] = `
 "<dim>expect(<red>received</><dim>).toEqual(<green>expected</><dim>)
 
 Expected value to equal:
@@ -2183,13 +2183,123 @@ Difference:
   Comparing two different types of values. Expected <green>function</> but received <red>undefined</>."
 `;
 
-exports[`.toEqual() expect(undefined).toEqual(Anything) 1`] = `
+exports[`.toEqual() {pass: false} expect(undefined).toEqual(Anything) 1`] = `
 "<dim>expect(<red>received</><dim>).toEqual(<green>expected</><dim>)
 
 Expected value to equal:
   <green>Anything</>
 Received:
   <red>undefined</>"
+`;
+
+exports[`.toHaveLength {pass: false} expect("").toHaveLength(1) 1`] = `
+"<dim>expect(<red>received</><dim>).toHaveLength(<green>length</><dim>)
+
+Expected value to have length:
+  <green>1</>
+Received:
+  <red>\\"\\"</>
+received.length:
+  <red>0</>"
+`;
+
+exports[`.toHaveLength {pass: false} expect("abc").toHaveLength(66) 1`] = `
+"<dim>expect(<red>received</><dim>).toHaveLength(<green>length</><dim>)
+
+Expected value to have length:
+  <green>66</>
+Received:
+  <red>\\"abc\\"</>
+received.length:
+  <red>3</>"
+`;
+
+exports[`.toHaveLength {pass: false} expect(["a", "b"]).toHaveLength(99) 1`] = `
+"<dim>expect(<red>received</><dim>).toHaveLength(<green>length</><dim>)
+
+Expected value to have length:
+  <green>99</>
+Received:
+  <red>[\\"a\\", \\"b\\"]</>
+received.length:
+  <red>2</>"
+`;
+
+exports[`.toHaveLength {pass: false} expect([1, 2]).toHaveLength(3) 1`] = `
+"<dim>expect(<red>received</><dim>).toHaveLength(<green>length</><dim>)
+
+Expected value to have length:
+  <green>3</>
+Received:
+  <red>[1, 2]</>
+received.length:
+  <red>2</>"
+`;
+
+exports[`.toHaveLength {pass: false} expect(Array []).toHaveLength(1) 1`] = `
+"<dim>expect(<red>received</><dim>).toHaveLength(<green>length</><dim>)
+
+Expected value to have length:
+  <green>1</>
+Received:
+  <red>Array []</>
+received.length:
+  <red>0</>"
+`;
+
+exports[`.toHaveLength {pass: true} expect("").toHaveLength(0) 1`] = `
+"<dim>expect(<red>received</><dim>).not.toHaveLength(<green>length</><dim>)
+
+Expected value to not have length:
+  <green>0</>
+Received:
+  <red>\\"\\"</>
+received.length:
+  <red>0</>"
+`;
+
+exports[`.toHaveLength {pass: true} expect("abc").toHaveLength(3) 1`] = `
+"<dim>expect(<red>received</><dim>).not.toHaveLength(<green>length</><dim>)
+
+Expected value to not have length:
+  <green>3</>
+Received:
+  <red>\\"abc\\"</>
+received.length:
+  <red>3</>"
+`;
+
+exports[`.toHaveLength {pass: true} expect(["a", "b"]).toHaveLength(2) 1`] = `
+"<dim>expect(<red>received</><dim>).not.toHaveLength(<green>length</><dim>)
+
+Expected value to not have length:
+  <green>2</>
+Received:
+  <red>[\\"a\\", \\"b\\"]</>
+received.length:
+  <red>2</>"
+`;
+
+exports[`.toHaveLength {pass: true} expect([1, 2]).toHaveLength(2) 1`] = `
+"<dim>expect(<red>received</><dim>).not.toHaveLength(<green>length</><dim>)
+
+Expected value to not have length:
+  <green>2</>
+Received:
+  <red>[1, 2]</>
+received.length:
+  <red>2</>"
+`;
+
+exports[`.toHaveLength {pass: true} expect(Array []).toHaveLength(0) 1`] = `
+"<dim>expect(<red>received</><dim>).not.toHaveLength(<green>length</><dim>)
+
+Expected value to not have length:
+  <green>0</>
+Received:
+  <red>Array []</>
+received.length:
+  <red>0</>"
 `;
 
 exports[`.toHaveLength error cases 1`] = `
@@ -2215,116 +2325,6 @@ exports[`.toHaveLength error cases 3`] = `
 Expected value to have a 'length' property that is a number. Received:
   <red>undefined</>
 "
-`;
-
-exports[`.toHaveLength expect("").toHaveLength(0) 1`] = `
-"<dim>expect(<red>received</><dim>).not.toHaveLength(<green>length</><dim>)
-
-Expected value to not have length:
-  <green>0</>
-Received:
-  <red>\\"\\"</>
-received.length:
-  <red>0</>"
-`;
-
-exports[`.toHaveLength expect("").toHaveLength(1) 1`] = `
-"<dim>expect(<red>received</><dim>).toHaveLength(<green>length</><dim>)
-
-Expected value to have length:
-  <green>1</>
-Received:
-  <red>\\"\\"</>
-received.length:
-  <red>0</>"
-`;
-
-exports[`.toHaveLength expect("abc").toHaveLength(3) 1`] = `
-"<dim>expect(<red>received</><dim>).not.toHaveLength(<green>length</><dim>)
-
-Expected value to not have length:
-  <green>3</>
-Received:
-  <red>\\"abc\\"</>
-received.length:
-  <red>3</>"
-`;
-
-exports[`.toHaveLength expect("abc").toHaveLength(66) 1`] = `
-"<dim>expect(<red>received</><dim>).toHaveLength(<green>length</><dim>)
-
-Expected value to have length:
-  <green>66</>
-Received:
-  <red>\\"abc\\"</>
-received.length:
-  <red>3</>"
-`;
-
-exports[`.toHaveLength expect(["a", "b"]).toHaveLength(2) 1`] = `
-"<dim>expect(<red>received</><dim>).not.toHaveLength(<green>length</><dim>)
-
-Expected value to not have length:
-  <green>2</>
-Received:
-  <red>[\\"a\\", \\"b\\"]</>
-received.length:
-  <red>2</>"
-`;
-
-exports[`.toHaveLength expect(["a", "b"]).toHaveLength(99) 1`] = `
-"<dim>expect(<red>received</><dim>).toHaveLength(<green>length</><dim>)
-
-Expected value to have length:
-  <green>99</>
-Received:
-  <red>[\\"a\\", \\"b\\"]</>
-received.length:
-  <red>2</>"
-`;
-
-exports[`.toHaveLength expect([1, 2]).toHaveLength(2) 1`] = `
-"<dim>expect(<red>received</><dim>).not.toHaveLength(<green>length</><dim>)
-
-Expected value to not have length:
-  <green>2</>
-Received:
-  <red>[1, 2]</>
-received.length:
-  <red>2</>"
-`;
-
-exports[`.toHaveLength expect([1, 2]).toHaveLength(3) 1`] = `
-"<dim>expect(<red>received</><dim>).toHaveLength(<green>length</><dim>)
-
-Expected value to have length:
-  <green>3</>
-Received:
-  <red>[1, 2]</>
-received.length:
-  <red>2</>"
-`;
-
-exports[`.toHaveLength expect(Array []).toHaveLength(0) 1`] = `
-"<dim>expect(<red>received</><dim>).not.toHaveLength(<green>length</><dim>)
-
-Expected value to not have length:
-  <green>0</>
-Received:
-  <red>Array []</>
-received.length:
-  <red>0</>"
-`;
-
-exports[`.toHaveLength expect(Array []).toHaveLength(1) 1`] = `
-"<dim>expect(<red>received</><dim>).toHaveLength(<green>length</><dim>)
-
-Expected value to have length:
-  <green>1</>
-Received:
-  <red>Array []</>
-received.length:
-  <red>0</>"
 `;
 
 exports[`.toHaveProperty() {error} expect({"a": {"b": {}}}).toHaveProperty('1') 1`] = `
@@ -2618,7 +2618,7 @@ With a value of:
 "
 `;
 
-exports[`.toMatch() passes: [Foo bar, /^foo/i] 1`] = `
+exports[`.toMatch() {pass: true} expect(Foo bar).toMatch(/^foo/i) 1`] = `
 "<dim>expect(<red>received</><dim>).not.toMatch(<green>expected</><dim>)
 
 Expected value not to match:
@@ -2627,7 +2627,7 @@ Received:
   <red>\\"Foo bar\\"</>"
 `;
 
-exports[`.toMatch() passes: [foo, foo] 1`] = `
+exports[`.toMatch() {pass: true} expect(foo).toMatch(foo) 1`] = `
 "<dim>expect(<red>received</><dim>).not.toMatch(<green>expected</><dim>)
 
 Expected value not to match:

--- a/packages/jest-matchers/src/__tests__/matchers-test.js
+++ b/packages/jest-matchers/src/__tests__/matchers-test.js
@@ -183,7 +183,7 @@ describe('.toEqual()', () => {
       },
     ],
   ].forEach(([a, b]) => {
-    test(`expect(${stringify(a)}).toEqual(${stringify(b)})`, () => {
+    test(`{pass: false} expect(${stringify(a)}).toEqual(${stringify(b)})`, () => {
       expect(() => jestExpect(a).toEqual(b)).toThrowErrorMatchingSnapshot();
     });
   });
@@ -221,7 +221,7 @@ describe('.toEqual()', () => {
       },
     ],
   ].forEach(([a, b]) => {
-    test(`expect(${stringify(a)}).not.toEqual(${stringify(b)})`, () => {
+    test(`{pass: false} expect(${stringify(a)}).not.toEqual(${stringify(b)})`, () => {
       expect(() => jestExpect(a).not.toEqual(b)).toThrowErrorMatchingSnapshot();
     });
   });
@@ -310,7 +310,7 @@ describe('.toBeTruthy(), .toBeFalsy()', () => {
 });
 
 describe('.toBeNaN()', () => {
-  it('passes', () => {
+  it('{pass: true} expect(NaN).toBeNaN()', () => {
     [NaN, Math.sqrt(-1), Infinity - Infinity, 0 / 0].forEach(v => {
       jestExpect(v).toBeNaN();
 
@@ -383,16 +383,36 @@ describe(
       [0o11, 0o22],
       [0.1, 0.2],
     ].forEach(([small, big]) => {
-      it(`passes: [${small}, ${big}]`, () => {
+      it(`{pass: true} expect(${small}).toBeLessThan(${big})`, () => {
         jestExpect(small).toBeLessThan(big);
-        jestExpect(small).not.toBeGreaterThan(big);
-        jestExpect(big).toBeGreaterThan(small);
-        jestExpect(big).not.toBeLessThan(small);
+      });
 
+      it(`{pass: false} expect(${big}).toBeLessThan(${small})`, () => {
+        jestExpect(big).not.toBeLessThan(small);
+      });
+
+      it(`{pass: true} expect(${big}).toBeGreaterThan(${small})`, () => {
+        jestExpect(big).toBeGreaterThan(small);
+      });
+
+      it(`{pass: false} expect(${small}).toBeGreaterThan(${big})`, () => {
+        jestExpect(small).not.toBeGreaterThan(big);
+      });
+
+      it(`{pass: true} expect(${small}).toBeLessThanOrEqual(${big})`, () => {
         jestExpect(small).toBeLessThanOrEqual(big);
-        jestExpect(small).not.toBeGreaterThanOrEqual(big);
-        jestExpect(big).toBeGreaterThanOrEqual(small);
+      });
+
+      it(`{pass: false} expect(${big}).toBeLessThanOrEqual(${small})`, () => {
         jestExpect(big).not.toBeLessThanOrEqual(small);
+      });
+
+      it(`{pass: true} expect(${big}).toBeGreaterThanOrEqual(${small})`, () => {
+        jestExpect(big).toBeGreaterThanOrEqual(small);
+      });
+
+      it(`{pass: false} expect(${small}).toBeGreaterThanOrEqual(${big})`, () => {
+        jestExpect(small).not.toBeGreaterThanOrEqual(big);
       });
 
       it(`throws: [${small}, ${big}]`, () => {
@@ -565,7 +585,7 @@ describe('.toBeCloseTo()', () => {
     [1.23, 1.225],
     [1.23, 1.234],
   ].forEach(([n1, n2]) => {
-    it(`passes: [${n1}, ${n2}]`, () => {
+    it(`{pass: true} expect(${n1})toBeCloseTo( ${n2})`, () => {
       jestExpect(n1).toBeCloseTo(n2);
 
       expect(() =>
@@ -594,7 +614,7 @@ describe('.toBeCloseTo()', () => {
 
 describe('.toMatch()', () => {
   [['foo', 'foo'], ['Foo bar', /^foo/i]].forEach(([n1, n2]) => {
-    it(`passes: [${n1}, ${n2}]`, () => {
+    it(`{pass: true} expect(${n1}).toMatch(${n2})`, () => {
       jestExpect(n1).toMatch(n2);
 
       expect(() =>
@@ -653,7 +673,7 @@ describe('.toHaveLength', () => {
     received,
     length,
   ]) => {
-    test(`expect(${stringify(received)}).toHaveLength(${length})`, () => {
+    test(`{pass: true} expect(${stringify(received)}).toHaveLength(${length})`, () => {
       jestExpect(received).toHaveLength(length);
       expect(() =>
         jestExpect(received).not.toHaveLength(
@@ -666,7 +686,7 @@ describe('.toHaveLength', () => {
     received,
     length,
   ]) => {
-    test(`expect(${stringify(received)}).toHaveLength(${length})`, () => {
+    test(`{pass: false} expect(${stringify(received)}).toHaveLength(${length})`, () => {
       jestExpect(received).not.toHaveLength(length);
       expect(() =>
         jestExpect(received).toHaveLength(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
The test file for the matchers has many test titles in different formats.  The purpose of this change is to unify the test titles into a consistent format.  @dmitriiabramov 

Test Titles Before:
![image](https://cloud.githubusercontent.com/assets/14934866/23978992/12ea65c4-09b4-11e7-8959-8b2d4a0be3f5.png)

Test Titles After:
![image](https://cloud.githubusercontent.com/assets/14934866/23979010/36911590-09b4-11e7-8b82-89bf680729e8.png)

**Test plan**
`jest ./packages/jest-matchers/src/__tests__/matchers-test.js`
`yarn test`

