### PR TITLE
[RFC] Multi project runner

### DIFF
--- a/packages/jest-cli/src/SearchSource.js
+++ b/packages/jest-cli/src/SearchSource.js
@@ -10,7 +10,6 @@
 
 'use strict';
 
-import type {Config} from 'types/Config';
 import type {Context} from 'types/Context';
 import type {Glob, Path} from 'types/Config';
 import type {ResolveModuleConfig} from 'types/Resolve';
@@ -19,7 +18,6 @@ const micromatch = require('micromatch');
 
 const DependencyResolver = require('jest-resolve-dependencies');
 
-const chalk = require('chalk');
 const changedFiles = require('jest-changed-files');
 const path = require('path');
 const {
@@ -64,8 +62,6 @@ const hg = changedFiles.hg;
 const determineSCM = path =>
   Promise.all([git.isGitRepository(path), hg.isHGRepository(path)]);
 const pathToRegex = p => replacePathSepForRegex(p);
-const pluralize = (word: string, count: number, ending: string) =>
-  `${count} ${word}${count === 1 ? '' : ending}`;
 
 const globsToMatcher = (globs: ?Array<Glob>) => {
   if (globs == null || globs.length === 0) {
@@ -221,48 +217,6 @@ class SearchSource {
           new Set(Array.prototype.concat.apply([], changedPathSets)),
         ));
     });
-  }
-
-  getNoTestsFoundMessage(
-    patternInfo: PatternInfo,
-    config: Config,
-    data: SearchResult,
-  ): string {
-    if (patternInfo.onlyChanged) {
-      return chalk.bold(
-        'No tests found related to files changed since last commit.\n',
-      ) +
-        chalk.dim(
-          patternInfo.watch
-            ? 'Press `a` to run all tests, or run Jest with `--watchAll`.'
-            : 'Run Jest without `-o` to run all tests.',
-        );
-    }
-
-    const testPathPattern = SearchSource.getTestPathPattern(patternInfo);
-    const stats = data.stats || {};
-    const statsMessage = Object.keys(stats)
-      .map(key => {
-        const value = key === 'testPathPattern' ? testPathPattern : config[key];
-        if (value) {
-          const matches = pluralize('match', stats[key], 'es');
-          return `  ${key}: ${chalk.yellow(value)} - ${matches}`;
-        }
-        return null;
-      })
-      .filter(line => line)
-      .join('\n');
-
-    return chalk.bold('No tests found') +
-      '\n' +
-      (data.total
-        ? `  ${pluralize('file', data.total || 0, 's')} checked.\n` +
-            statsMessage
-        : `No files found in ${config.rootDir}.\n` +
-            `Make sure Jest's configuration does not exclude this directory.` +
-            `\nTo set up Jest, make sure a package.json file exists.\n` +
-            `Jest Documentation: ` +
-            `facebook.github.io/jest/docs/configuration.html`);
   }
 
   getTestPaths(patternInfo: PatternInfo): Promise<SearchResult> {

--- a/packages/jest-cli/src/SearchSource.js
+++ b/packages/jest-cli/src/SearchSource.js
@@ -25,13 +25,6 @@ const {
   replacePathSepForRegex,
 } = require('jest-regex-util');
 
-type SearchSourceConfig = {
-  roots: Array<Path>,
-  testMatch: Array<Glob>,
-  testRegex: string,
-  testPathIgnorePatterns: Array<string>,
-};
-
 type SearchResult = {|
   noSCM?: boolean,
   paths: Array<Path>,
@@ -83,7 +76,6 @@ const regexToMatcher = (testRegex: string) => {
 
 class SearchSource {
   _context: Context;
-  _config: SearchSourceConfig;
   _options: ResolveModuleConfig;
   _rootPattern: RegExp;
   _testIgnorePattern: ?RegExp;
@@ -94,13 +86,9 @@ class SearchSource {
     testPathIgnorePatterns: (path: Path) => boolean,
   };
 
-  constructor(
-    context: Context,
-    config: SearchSourceConfig,
-    options?: ResolveModuleConfig,
-  ) {
+  constructor(context: Context, options?: ResolveModuleConfig) {
+    const {config} = context;
     this._context = context;
-    this._config = config;
     this._options = options || {
       skipNodeResolution: false,
     };
@@ -199,7 +187,9 @@ class SearchSource {
   }
 
   findChangedTests(options: Options): Promise<SearchResult> {
-    return Promise.all(this._config.roots.map(determineSCM)).then(repos => {
+    return Promise.all(
+      this._context.config.roots.map(determineSCM),
+    ).then(repos => {
       if (!repos.every(([gitRepo, hgRepo]) => gitRepo || hgRepo)) {
         return {
           noSCM: true,

--- a/packages/jest-cli/src/SearchSource.js
+++ b/packages/jest-cli/src/SearchSource.js
@@ -45,7 +45,7 @@ type Options = {|
   lastCommit?: boolean,
 |};
 
-export type PatternInfo = {|
+export type PathPattern = {|
   input?: string,
   findRelatedTests?: boolean,
   lastCommit?: boolean,
@@ -219,30 +219,16 @@ class SearchSource {
     });
   }
 
-  getTestPaths(patternInfo: PatternInfo): Promise<SearchResult> {
-    if (patternInfo.onlyChanged) {
-      return this.findChangedTests({lastCommit: patternInfo.lastCommit});
-    } else if (patternInfo.findRelatedTests && patternInfo.paths) {
-      return Promise.resolve(
-        this.findRelatedTestsFromPattern(patternInfo.paths),
-      );
-    } else if (patternInfo.testPathPattern != null) {
-      return Promise.resolve(
-        this.findMatchingTests(patternInfo.testPathPattern),
-      );
+  getTestPaths(pattern: PathPattern): Promise<SearchResult> {
+    if (pattern.onlyChanged) {
+      return this.findChangedTests({lastCommit: pattern.lastCommit});
+    } else if (pattern.findRelatedTests && pattern.paths) {
+      return Promise.resolve(this.findRelatedTestsFromPattern(pattern.paths));
+    } else if (pattern.testPathPattern != null) {
+      return Promise.resolve(this.findMatchingTests(pattern.testPathPattern));
     } else {
       return Promise.resolve({paths: []});
     }
-  }
-
-  static getTestPathPattern(patternInfo: PatternInfo): string {
-    const pattern = patternInfo.testPathPattern;
-    const input = patternInfo.input;
-    const formattedPattern = `/${pattern || ''}/`;
-    const formattedInput = patternInfo.shouldTreatInputAsPattern
-      ? `/${input || ''}/`
-      : `"${input || ''}"`;
-    return input === pattern ? formattedInput : formattedPattern;
   }
 }
 

--- a/packages/jest-cli/src/TestPathPatternPrompt.js
+++ b/packages/jest-cli/src/TestPathPatternPrompt.js
@@ -64,21 +64,16 @@ module.exports = class TestPathPatternPrompt {
       regex = new RegExp(pattern, 'i');
     } catch (e) {}
 
-    let paths = [];
+    let tests = [];
     if (regex) {
       this._searchSources.forEach(({searchSource, context}) => {
-        paths = paths.concat(
-          searchSource.findMatchingTests(pattern).paths.map(path => ({
-            context,
-            path,
-          })),
-        );
+        tests = tests.concat(searchSource.findMatchingTests(pattern).tests);
       });
     }
 
     this._pipe.write(ansiEscapes.eraseLine);
     this._pipe.write(ansiEscapes.cursorLeft);
-    this._printTypeahead(pattern, paths, 10);
+    this._printTypeahead(pattern, tests, 10);
   }
 
   _printTypeahead(pattern: string, allResults: Array<Test>, max: number) {

--- a/packages/jest-cli/src/TestPathPatternPrompt.js
+++ b/packages/jest-cli/src/TestPathPatternPrompt.js
@@ -11,7 +11,8 @@
 'use strict';
 
 import type {Context} from 'types/Context';
-import type {Config, Path} from 'types/Config';
+import type {Test} from 'types/TestRunner';
+import type SearchSource from './SearchSource';
 
 const ansiEscapes = require('ansi-escapes');
 const chalk = require('chalk');
@@ -19,8 +20,12 @@ const {getTerminalWidth} = require('./lib/terminalUtils');
 const highlight = require('./lib/highlight');
 const stringLength = require('string-length');
 const {trimAndFormatPath} = require('./reporters/utils');
-const SearchSource = require('./SearchSource');
 const Prompt = require('./lib/Prompt');
+
+type SearchSources = Array<{|
+  context: Context,
+  searchSource: SearchSource,
+|}>;
 
 const pluralizeFile = (total: number) => total === 1 ? 'file' : 'files';
 
@@ -34,17 +39,11 @@ const usage = () =>
 const usageRows = usage().split('\n').length;
 
 module.exports = class TestPathPatternPrompt {
-  _config: Config;
   _pipe: stream$Writable | tty$WriteStream;
   _prompt: Prompt;
-  _searchSource: SearchSource;
+  _searchSources: SearchSources;
 
-  constructor(
-    config: Config,
-    pipe: stream$Writable | tty$WriteStream,
-    prompt: Prompt,
-  ) {
-    this._config = config;
+  constructor(pipe: stream$Writable | tty$WriteStream, prompt: Prompt) {
     this._pipe = pipe;
     this._prompt = prompt;
   }
@@ -65,16 +64,24 @@ module.exports = class TestPathPatternPrompt {
       regex = new RegExp(pattern, 'i');
     } catch (e) {}
 
-    const paths = regex
-      ? this._searchSource.findMatchingTests(pattern).paths
-      : [];
+    let paths = [];
+    if (regex) {
+      this._searchSources.forEach(({searchSource, context}) => {
+        paths = paths.concat(
+          searchSource.findMatchingTests(pattern).paths.map(path => ({
+            context,
+            path,
+          })),
+        );
+      });
+    }
 
     this._pipe.write(ansiEscapes.eraseLine);
     this._pipe.write(ansiEscapes.cursorLeft);
     this._printTypeahead(pattern, paths, 10);
   }
 
-  _printTypeahead(pattern: string, allResults: Array<Path>, max: number) {
+  _printTypeahead(pattern: string, allResults: Array<Test>, max: number) {
     const total = allResults.length;
     const results = allResults.slice(0, max);
     const inputText = `${chalk.dim(' pattern \u203A')} ${pattern}`;
@@ -97,14 +104,14 @@ module.exports = class TestPathPatternPrompt {
       const padding = stringLength(prefix) + 2;
 
       results
-        .map(rawPath => {
+        .map(({path, context}) => {
           const filePath = trimAndFormatPath(
             padding,
-            this._config,
-            rawPath,
+            context.config,
+            path,
             width,
           );
-          return highlight(rawPath, filePath, pattern, this._config.rootDir);
+          return highlight(path, filePath, pattern, context.config.rootDir);
         })
         .forEach(filePath =>
           this._pipe.write(`\n  ${chalk.dim('\u203A')} ${filePath}`));
@@ -129,7 +136,7 @@ module.exports = class TestPathPatternPrompt {
     this._pipe.write(ansiEscapes.cursorRestorePosition);
   }
 
-  updateSearchSource(context: Context) {
-    this._searchSource = new SearchSource(context, this._config);
+  updateSearchSources(searchSources: SearchSources) {
+    this._searchSources = searchSources;
   }
 };

--- a/packages/jest-cli/src/TestRunner.js
+++ b/packages/jest-cli/src/TestRunner.js
@@ -61,17 +61,17 @@ class TestRunner {
   _dispatcher: ReporterDispatcher;
 
   constructor(
-    hasteContext: Context,
+    context: Context,
     config: Config,
     options: Options,
     startRun: () => *,
   ) {
     this._config = config;
     this._dispatcher = new ReporterDispatcher(
-      hasteContext.hasteFS,
+      context.hasteFS,
       options.getTestSummary,
     );
-    this._context = hasteContext;
+    this._context = context;
     this._options = options;
     this._startRun = startRun;
     this._setupReporters();
@@ -93,7 +93,6 @@ class TestRunner {
       }
     });
 
-    const config = this._config;
     const aggregatedResults = createAggregatedResults(tests.length);
     const estimatedTime = Math.ceil(
       getEstimatedTime(timings, this._options.maxWorkers) / 1000,
@@ -140,6 +139,7 @@ class TestRunner {
     };
 
     const updateSnapshotState = () => {
+      const config = this._config;
       const status = snapshot.cleanup(
         this._context.hasteFS,
         config.updateSnapshot,
@@ -152,7 +152,7 @@ class TestRunner {
           aggregatedResults.snapshot.filesRemoved));
     };
 
-    this._dispatcher.onRunStart(config, aggregatedResults, {
+    this._dispatcher.onRunStart(this._config, aggregatedResults, {
       estimatedTime,
       showStatus: !runInBand,
     });
@@ -170,7 +170,7 @@ class TestRunner {
     updateSnapshotState();
     aggregatedResults.wasInterrupted = watcher.isInterrupted();
 
-    this._dispatcher.onRunComplete(config, aggregatedResults);
+    this._dispatcher.onRunComplete(this._config, aggregatedResults);
 
     const anyTestFailures = !(aggregatedResults.numFailedTests === 0 &&
       aggregatedResults.numRuntimeErrorTestSuites === 0);

--- a/packages/jest-cli/src/TestRunner.js
+++ b/packages/jest-cli/src/TestRunner.js
@@ -284,9 +284,11 @@ class TestRunner {
       this.addReporter(new CoverageReporter());
     }
 
-    this.addReporter(new SummaryReporter({
-      getTestSummary: this._options.getTestSummary,
-    }));
+    this.addReporter(
+      new SummaryReporter({
+        getTestSummary: this._options.getTestSummary,
+      }),
+    );
     if (config.notify) {
       this.addReporter(new NotifyReporter(this._startRun));
     }

--- a/packages/jest-cli/src/__tests__/SearchSource-test.js
+++ b/packages/jest-cli/src/__tests__/SearchSource-test.js
@@ -94,8 +94,7 @@ describe('SearchSource', () => {
       findMatchingTests = config =>
         Runtime.createContext(config, {
           maxWorkers,
-        }).then(context =>
-          new SearchSource(context).findMatchingTests());
+        }).then(context => new SearchSource(context).findMatchingTests());
     });
 
     it('finds tests matching a pattern via testRegex', () => {

--- a/packages/jest-cli/src/__tests__/SearchSource-test.js
+++ b/packages/jest-cli/src/__tests__/SearchSource-test.js
@@ -45,15 +45,14 @@ describe('SearchSource', () => {
         rootDir: '.',
         roots: [],
       }).config;
-      return Runtime.createContext(config, {maxWorkers}).then(hasteMap => {
-        searchSource = new SearchSource(hasteMap, config);
+      return Runtime.createContext(config, {maxWorkers}).then(context => {
+        searchSource = new SearchSource(context);
       });
     });
 
     // micromatch doesn't support '..' through the globstar ('**') to avoid
     // infinite recursion.
-
-    it('supports ../ paths and unix separators via textRegex', () => {
+    it('supports ../ paths and unix separators via testRegex', () => {
       if (process.platform !== 'win32') {
         config = normalizeConfig({
           name,
@@ -64,8 +63,8 @@ describe('SearchSource', () => {
         }).config;
         return Runtime.createContext(config, {
           maxWorkers,
-        }).then(hasteMap => {
-          searchSource = new SearchSource(hasteMap, config);
+        }).then(context => {
+          searchSource = new SearchSource(context);
 
           const path = '/path/to/__tests__/foo/bar/baz/../../../test.js';
           expect(searchSource.isTestFilePath(path)).toEqual(true);
@@ -95,8 +94,8 @@ describe('SearchSource', () => {
       findMatchingTests = config =>
         Runtime.createContext(config, {
           maxWorkers,
-        }).then(hasteMap =>
-          new SearchSource(hasteMap, config).findMatchingTests());
+        }).then(context =>
+          new SearchSource(context).findMatchingTests());
     });
 
     it('finds tests matching a pattern via testRegex', () => {
@@ -309,8 +308,8 @@ describe('SearchSource', () => {
         name: 'SearchSource-findRelatedTests-tests',
         rootDir,
       });
-      Runtime.createContext(config, {maxWorkers}).then(hasteMap => {
-        searchSource = new SearchSource(hasteMap, config);
+      Runtime.createContext(config, {maxWorkers}).then(context => {
+        searchSource = new SearchSource(context);
         done();
       });
     });
@@ -342,8 +341,8 @@ describe('SearchSource', () => {
         rootDir,
         testMatch,
       });
-      Runtime.createContext(config, {maxWorkers}).then(hasteMap => {
-        searchSource = new SearchSource(hasteMap, config);
+      Runtime.createContext(config, {maxWorkers}).then(context => {
+        searchSource = new SearchSource(context);
         done();
       });
     });

--- a/packages/jest-cli/src/__tests__/SearchSource-test.js
+++ b/packages/jest-cli/src/__tests__/SearchSource-test.js
@@ -19,6 +19,8 @@ const testRegex = path.sep + '__testtests__' + path.sep;
 const testMatch = ['**/__testtests__/**/*'];
 const maxWorkers = 1;
 
+const toPaths = tests => tests.map(({path}) => path);
+
 let findMatchingTests;
 let normalizeConfig;
 
@@ -106,7 +108,7 @@ describe('SearchSource', () => {
         testRegex: 'not-really-a-test',
       });
       return findMatchingTests(config).then(data => {
-        const relPaths = data.paths
+        const relPaths = toPaths(data.tests)
           .map(absPath => path.relative(rootDir, absPath))
           .sort();
         expect(relPaths).toEqual(
@@ -127,7 +129,7 @@ describe('SearchSource', () => {
         testRegex: '',
       });
       return findMatchingTests(config).then(data => {
-        const relPaths = data.paths
+        const relPaths = toPaths(data.tests)
           .map(absPath => path.relative(rootDir, absPath))
           .sort();
         expect(relPaths).toEqual(
@@ -148,7 +150,7 @@ describe('SearchSource', () => {
         testRegex: 'test\.jsx?',
       });
       return findMatchingTests(config).then(data => {
-        const relPaths = data.paths.map(absPath =>
+        const relPaths = toPaths(data.tests).map(absPath =>
           path.relative(rootDir, absPath));
         expect(relPaths.sort()).toEqual([
           path.normalize('__testtests__/test.js'),
@@ -166,7 +168,7 @@ describe('SearchSource', () => {
         testRegex: '',
       });
       return findMatchingTests(config).then(data => {
-        const relPaths = data.paths.map(absPath =>
+        const relPaths = toPaths(data.tests).map(absPath =>
           path.relative(rootDir, absPath));
         expect(relPaths.sort()).toEqual([
           path.normalize('__testtests__/test.js'),
@@ -183,7 +185,7 @@ describe('SearchSource', () => {
         testRegex,
       });
       return findMatchingTests(config).then(data => {
-        const relPaths = data.paths.map(absPath =>
+        const relPaths = toPaths(data.tests).map(absPath =>
           path.relative(rootDir, absPath));
         expect(relPaths.sort()).toEqual([
           path.normalize('__testtests__/test.js'),
@@ -200,7 +202,7 @@ describe('SearchSource', () => {
         testRegex: '',
       });
       return findMatchingTests(config).then(data => {
-        const relPaths = data.paths.map(absPath =>
+        const relPaths = toPaths(data.tests).map(absPath =>
           path.relative(rootDir, absPath));
         expect(relPaths.sort()).toEqual([
           path.normalize('__testtests__/test.js'),
@@ -217,7 +219,7 @@ describe('SearchSource', () => {
         testMatch,
       });
       return findMatchingTests(config).then(data => {
-        const relPaths = data.paths.map(absPath =>
+        const relPaths = toPaths(data.tests).map(absPath =>
           path.relative(rootDir, absPath));
         expect(relPaths).toEqual([path.normalize('__testtests__/test.jsx')]);
       });
@@ -231,7 +233,7 @@ describe('SearchSource', () => {
         testMatch,
       });
       return findMatchingTests(config).then(data => {
-        const relPaths = data.paths.map(absPath =>
+        const relPaths = toPaths(data.tests).map(absPath =>
           path.relative(rootDir, absPath));
         expect(relPaths).toEqual([path.normalize('__testtests__/test.foobar')]);
       });
@@ -245,7 +247,7 @@ describe('SearchSource', () => {
         testMatch,
       });
       return findMatchingTests(config).then(data => {
-        const relPaths = data.paths.map(absPath =>
+        const relPaths = toPaths(data.tests).map(absPath =>
           path.relative(rootDir, absPath));
         expect(relPaths.sort()).toEqual([
           path.normalize('__testtests__/test.js'),
@@ -262,7 +264,7 @@ describe('SearchSource', () => {
         testRegex,
       });
       return findMatchingTests(config).then(data => {
-        const relPaths = data.paths.map(absPath =>
+        const relPaths = toPaths(data.tests).map(absPath =>
           path.relative(rootDir, absPath));
         expect(relPaths.sort()).toEqual([
           path.normalize('__testtests__/test.js'),
@@ -279,7 +281,7 @@ describe('SearchSource', () => {
         testRegex: '',
       });
       return findMatchingTests(config).then(data => {
-        const relPaths = data.paths.map(absPath =>
+        const relPaths = toPaths(data.tests).map(absPath =>
           path.relative(rootDir, absPath));
         expect(relPaths.sort()).toEqual([
           path.normalize('__testtests__/test.js'),
@@ -315,7 +317,7 @@ describe('SearchSource', () => {
 
     it('makes sure a file is related to itself', () => {
       const data = searchSource.findRelatedTests(new Set([rootPath]));
-      expect(data.paths).toEqual([rootPath]);
+      expect(toPaths(data.tests)).toEqual([rootPath]);
     });
 
     it('finds tests that depend directly on the path', () => {
@@ -323,7 +325,7 @@ describe('SearchSource', () => {
       const loggingDep = path.join(rootDir, 'logging.js');
       const parentDep = path.join(rootDir, 'ModuleWithSideEffects.js');
       const data = searchSource.findRelatedTests(new Set([filePath]));
-      expect(data.paths.sort()).toEqual([
+      expect(toPaths(data.tests).sort()).toEqual([
         parentDep,
         filePath,
         loggingDep,
@@ -349,25 +351,25 @@ describe('SearchSource', () => {
     it('returns empty search result for empty input', () => {
       const input = [];
       const data = searchSource.findRelatedTestsFromPattern(input);
-      expect(data.paths).toEqual([]);
+      expect(data.tests).toEqual([]);
     });
 
     it('returns empty search result for invalid input', () => {
       const input = ['non-existend.js'];
       const data = searchSource.findRelatedTestsFromPattern(input);
-      expect(data.paths).toEqual([]);
+      expect(data.tests).toEqual([]);
     });
 
     it('returns empty search result if no related tests were found', () => {
       const input = ['no tests.js'];
       const data = searchSource.findRelatedTestsFromPattern(input);
-      expect(data.paths).toEqual([]);
+      expect(data.tests).toEqual([]);
     });
 
     it('finds tests for a single file', () => {
       const input = ['packages/jest-cli/src/__tests__/test_root/module.jsx'];
       const data = searchSource.findRelatedTestsFromPattern(input);
-      expect(data.paths.sort()).toEqual([
+      expect(toPaths(data.tests).sort()).toEqual([
         path.join(rootDir, '__testtests__', 'test.js'),
         path.join(rootDir, '__testtests__', 'test.jsx'),
       ]);
@@ -379,7 +381,7 @@ describe('SearchSource', () => {
         'packages/jest-cli/src/__tests__/test_root/module.foobar',
       ];
       const data = searchSource.findRelatedTestsFromPattern(input);
-      expect(data.paths.sort()).toEqual([
+      expect(toPaths(data.tests).sort()).toEqual([
         path.join(rootDir, '__testtests__', 'test.foobar'),
         path.join(rootDir, '__testtests__', 'test.js'),
         path.join(rootDir, '__testtests__', 'test.jsx'),

--- a/packages/jest-cli/src/__tests__/TestRunner-test.js
+++ b/packages/jest-cli/src/__tests__/TestRunner-test.js
@@ -30,7 +30,7 @@ jest.mock('../TestWorker', () => {});
 jest.mock('../reporters/DefaultReporter');
 
 test('.addReporter() .removeReporter()', () => {
-  const runner = new TestRunner({}, {}, {});
+  const runner = new TestRunner({}, {});
   const reporter = new SummaryReporter();
   runner.addReporter(reporter);
   expect(runner._dispatcher._reporters).toContain(reporter);
@@ -43,7 +43,7 @@ describe('_createInBandTestRun()', () => {
     const config = {watch: true};
     const rawModuleMap = jest.fn();
     const context = {config, moduleMap: {getRawModuleMap: () => rawModuleMap}};
-    const runner = new TestRunner(context, config, {maxWorkers: 2});
+    const runner = new TestRunner(config, {maxWorkers: 2});
 
     return runner
       ._createParallelTestRun(
@@ -70,7 +70,7 @@ describe('_createInBandTestRun()', () => {
   test('does not inject the rawModuleMap in non watch mode', () => {
     const config = {watch: false};
     const context = {config};
-    const runner = new TestRunner(context, config, {maxWorkers: 1});
+    const runner = new TestRunner(config, {maxWorkers: 1});
 
     return runner
       ._createParallelTestRun(

--- a/packages/jest-cli/src/__tests__/TestSequencer-test.js
+++ b/packages/jest-cli/src/__tests__/TestSequencer-test.js
@@ -26,6 +26,13 @@ const context = {
   },
 };
 
+const toTests = paths =>
+  paths.map(path => ({
+    context,
+    duration: undefined,
+    path,
+  }));
+
 beforeEach(() => {
   sequencer = new TestSequencer(context);
 
@@ -34,7 +41,7 @@ beforeEach(() => {
 });
 
 test('sorts by file size if there is no timing information', () => {
-  expect(sequencer.sort(['/test-a.js', '/test-ab.js'])).toEqual([
+  expect(sequencer.sort(toTests(['/test-a.js', '/test-ab.js']))).toEqual([
     {context, duration: undefined, path: '/test-ab.js'},
     {context, duration: undefined, path: '/test-a.js'},
   ]);
@@ -46,7 +53,7 @@ test('sorts based on timing information', () => {
       '/test-a.js': [SUCCESS, 5],
       '/test-ab.js': [SUCCESS, 3],
     }));
-  expect(sequencer.sort(['/test-a.js', '/test-ab.js'])).toEqual([
+  expect(sequencer.sort(toTests(['/test-a.js', '/test-ab.js']))).toEqual([
     {context, duration: 5, path: '/test-a.js'},
     {context, duration: 3, path: '/test-ab.js'},
   ]);
@@ -61,7 +68,9 @@ test('sorts based on failures and timing information', () => {
       '/test-d.js': [SUCCESS, 2],
     }));
   expect(
-    sequencer.sort(['/test-a.js', '/test-ab.js', '/test-c.js', '/test-d.js']),
+    sequencer.sort(
+      toTests(['/test-a.js', '/test-ab.js', '/test-c.js', '/test-d.js']),
+    ),
   ).toEqual([
     {context, duration: 6, path: '/test-c.js'},
     {context, duration: 0, path: '/test-ab.js'},
@@ -80,13 +89,15 @@ test('sorts based on failures, timing information and file size', () => {
       '/test-efg.js': [FAIL],
     }));
   expect(
-    sequencer.sort([
-      '/test-a.js',
-      '/test-ab.js',
-      '/test-c.js',
-      '/test-d.js',
-      '/test-efg.js',
-    ]),
+    sequencer.sort(
+      toTests([
+        '/test-a.js',
+        '/test-ab.js',
+        '/test-c.js',
+        '/test-d.js',
+        '/test-efg.js',
+      ]),
+    ),
   ).toEqual([
     {context, duration: undefined, path: '/test-efg.js'},
     {context, duration: undefined, path: '/test-c.js'},
@@ -105,7 +116,7 @@ test('writes the cache based on the results', () => {
     }));
 
   const testPaths = ['/test-a.js', '/test-b.js', '/test-c.js'];
-  const tests = sequencer.sort(testPaths);
+  const tests = sequencer.sort(toTests(testPaths));
   sequencer.cacheResults(tests, {
     testResults: [
       {

--- a/packages/jest-cli/src/__tests__/TestSequencer-test.js
+++ b/packages/jest-cli/src/__tests__/TestSequencer-test.js
@@ -12,6 +12,7 @@ jest.mock('fs');
 const TestSequencer = require('../TestSequencer');
 
 const fs = require('fs');
+const path = require('path');
 
 const FAIL = 0;
 const SUCCESS = 1;
@@ -162,7 +163,7 @@ test('writes the cache based on the results', () => {
 test('works with multiple contexts', () => {
   fs.readFileSync = jest.fn(
     cacheName =>
-      cacheName.startsWith('/cache/')
+      cacheName.startsWith(path.sep + 'cache' + path.sep)
         ? JSON.stringify({
             '/test-a.js': [SUCCESS, 5],
             '/test-b.js': [FAIL, 1],

--- a/packages/jest-cli/src/__tests__/watch-filename-pattern-mode-test.js
+++ b/packages/jest-cli/src/__tests__/watch-filename-pattern-mode-test.js
@@ -80,25 +80,23 @@ afterEach(runJestMock.mockReset);
 
 describe('Watch mode flows', () => {
   let pipe;
-  let hasteMap;
+  let hasteMapInstances;
   let argv;
-  let context;
-  let config;
+  let contexts;
   let stdin;
 
   beforeEach(() => {
     terminalWidth = 80;
     pipe = {write: jest.fn()};
-    hasteMap = {on: () => {}};
+    hasteMapInstances = [{on: () => {}}];
     argv = {};
-    context = {};
-    config = {};
+    contexts = [{config: {}}];
     stdin = new MockStdin();
   });
 
   it('Pressing "P" enters pattern mode', () => {
-    config = {rootDir: ''};
-    watch(config, pipe, argv, hasteMap, context, stdin);
+    contexts[0].config = {rootDir: ''};
+    watch(contexts, argv, pipe, hasteMapInstances, stdin);
 
     // Write a enter pattern mode
     stdin.emit(KEYS.P);
@@ -134,8 +132,8 @@ describe('Watch mode flows', () => {
   });
 
   it('Results in pattern mode get truncated appropriately', () => {
-    config = {rootDir: ''};
-    watch(config, pipe, argv, hasteMap, context, stdin);
+    contexts[0].config = {rootDir: ''};
+    watch(contexts, argv, pipe, hasteMapInstances, stdin);
 
     stdin.emit(KEYS.P);
 

--- a/packages/jest-cli/src/__tests__/watch-filename-pattern-mode-test.js
+++ b/packages/jest-cli/src/__tests__/watch-filename-pattern-mode-test.js
@@ -31,6 +31,10 @@ jest.mock(
   '../SearchSource',
   () =>
     class {
+      constructor(context) {
+        this._context = context;
+      }
+
       findMatchingTests(pattern) {
         const paths = [
           './path/to/file1-test.js',
@@ -46,7 +50,13 @@ jest.mock(
           './path/to/file11-test.js',
         ].filter(path => path.match(pattern));
 
-        return {paths};
+        return {
+          tests: paths.map(path => ({
+            context: this._context,
+            duration: null,
+            path,
+          })),
+        };
       }
     },
 );

--- a/packages/jest-cli/src/__tests__/watch-filename-pattern-mode-test.js
+++ b/packages/jest-cli/src/__tests__/watch-filename-pattern-mode-test.js
@@ -84,7 +84,6 @@ describe('Watch mode flows', () => {
   let argv;
   let context;
   let config;
-  let hasDeprecationWarnings;
   let stdin;
 
   beforeEach(() => {
@@ -94,13 +93,12 @@ describe('Watch mode flows', () => {
     argv = {};
     context = {};
     config = {};
-    hasDeprecationWarnings = false;
     stdin = new MockStdin();
   });
 
   it('Pressing "P" enters pattern mode', () => {
     config = {rootDir: ''};
-    watch(config, pipe, argv, hasteMap, context, hasDeprecationWarnings, stdin);
+    watch(config, pipe, argv, hasteMap, context, stdin);
 
     // Write a enter pattern mode
     stdin.emit(KEYS.P);
@@ -137,7 +135,7 @@ describe('Watch mode flows', () => {
 
   it('Results in pattern mode get truncated appropriately', () => {
     config = {rootDir: ''};
-    watch(config, pipe, argv, hasteMap, context, hasDeprecationWarnings, stdin);
+    watch(config, pipe, argv, hasteMap, context, stdin);
 
     stdin.emit(KEYS.P);
 

--- a/packages/jest-cli/src/__tests__/watch-filename-pattern-mode-test.js
+++ b/packages/jest-cli/src/__tests__/watch-filename-pattern-mode-test.js
@@ -82,7 +82,7 @@ describe('Watch mode flows', () => {
   let pipe;
   let hasteMap;
   let argv;
-  let hasteContext;
+  let context;
   let config;
   let hasDeprecationWarnings;
   let stdin;
@@ -92,7 +92,7 @@ describe('Watch mode flows', () => {
     pipe = {write: jest.fn()};
     hasteMap = {on: () => {}};
     argv = {};
-    hasteContext = {};
+    context = {};
     config = {};
     hasDeprecationWarnings = false;
     stdin = new MockStdin();
@@ -100,15 +100,7 @@ describe('Watch mode flows', () => {
 
   it('Pressing "P" enters pattern mode', () => {
     config = {rootDir: ''};
-    watch(
-      config,
-      pipe,
-      argv,
-      hasteMap,
-      hasteContext,
-      hasDeprecationWarnings,
-      stdin,
-    );
+    watch(config, pipe, argv, hasteMap, context, hasDeprecationWarnings, stdin);
 
     // Write a enter pattern mode
     stdin.emit(KEYS.P);
@@ -145,15 +137,7 @@ describe('Watch mode flows', () => {
 
   it('Results in pattern mode get truncated appropriately', () => {
     config = {rootDir: ''};
-    watch(
-      config,
-      pipe,
-      argv,
-      hasteMap,
-      hasteContext,
-      hasDeprecationWarnings,
-      stdin,
-    );
+    watch(config, pipe, argv, hasteMap, context, hasDeprecationWarnings, stdin);
 
     stdin.emit(KEYS.P);
 

--- a/packages/jest-cli/src/__tests__/watch-test-name-pattern-mode-test.js
+++ b/packages/jest-cli/src/__tests__/watch-test-name-pattern-mode-test.js
@@ -108,7 +108,6 @@ describe('Watch mode flows', () => {
   let argv;
   let context;
   let config;
-  let hasDeprecationWarnings;
   let stdin;
 
   beforeEach(() => {
@@ -118,13 +117,12 @@ describe('Watch mode flows', () => {
     argv = {};
     context = {};
     config = {};
-    hasDeprecationWarnings = false;
     stdin = new MockStdin();
   });
 
   it('Pressing "T" enters pattern mode', () => {
     config = {rootDir: ''};
-    watch(config, pipe, argv, hasteMap, context, hasDeprecationWarnings, stdin);
+    watch(config, pipe, argv, hasteMap, context, stdin);
 
     // Write a enter pattern mode
     stdin.emit(KEYS.T);
@@ -161,7 +159,7 @@ describe('Watch mode flows', () => {
 
   it('Results in pattern mode get truncated appropriately', () => {
     config = {rootDir: ''};
-    watch(config, pipe, argv, hasteMap, context, hasDeprecationWarnings, stdin);
+    watch(config, pipe, argv, hasteMap, context, stdin);
 
     stdin.emit(KEYS.T);
 

--- a/packages/jest-cli/src/__tests__/watch-test-name-pattern-mode-test.js
+++ b/packages/jest-cli/src/__tests__/watch-test-name-pattern-mode-test.js
@@ -104,25 +104,23 @@ afterEach(runJestMock.mockReset);
 
 describe('Watch mode flows', () => {
   let pipe;
-  let hasteMap;
+  let hasteMapInstances;
   let argv;
-  let context;
-  let config;
+  let contexts;
   let stdin;
 
   beforeEach(() => {
     terminalWidth = 80;
     pipe = {write: jest.fn()};
-    hasteMap = {on: () => {}};
+    hasteMapInstances = [{on: () => {}}];
     argv = {};
-    context = {};
-    config = {};
+    contexts = [{config: {}}];
     stdin = new MockStdin();
   });
 
   it('Pressing "T" enters pattern mode', () => {
-    config = {rootDir: ''};
-    watch(config, pipe, argv, hasteMap, context, stdin);
+    contexts[0].config = {rootDir: ''};
+    watch(contexts, argv, pipe, hasteMapInstances, stdin);
 
     // Write a enter pattern mode
     stdin.emit(KEYS.T);
@@ -158,8 +156,8 @@ describe('Watch mode flows', () => {
   });
 
   it('Results in pattern mode get truncated appropriately', () => {
-    config = {rootDir: ''};
-    watch(config, pipe, argv, hasteMap, context, stdin);
+    contexts[0].config = {rootDir: ''};
+    watch(contexts, argv, pipe, hasteMapInstances, stdin);
 
     stdin.emit(KEYS.T);
 

--- a/packages/jest-cli/src/__tests__/watch-test-name-pattern-mode-test.js
+++ b/packages/jest-cli/src/__tests__/watch-test-name-pattern-mode-test.js
@@ -106,7 +106,7 @@ describe('Watch mode flows', () => {
   let pipe;
   let hasteMap;
   let argv;
-  let hasteContext;
+  let context;
   let config;
   let hasDeprecationWarnings;
   let stdin;
@@ -116,7 +116,7 @@ describe('Watch mode flows', () => {
     pipe = {write: jest.fn()};
     hasteMap = {on: () => {}};
     argv = {};
-    hasteContext = {};
+    context = {};
     config = {};
     hasDeprecationWarnings = false;
     stdin = new MockStdin();
@@ -124,15 +124,7 @@ describe('Watch mode flows', () => {
 
   it('Pressing "T" enters pattern mode', () => {
     config = {rootDir: ''};
-    watch(
-      config,
-      pipe,
-      argv,
-      hasteMap,
-      hasteContext,
-      hasDeprecationWarnings,
-      stdin,
-    );
+    watch(config, pipe, argv, hasteMap, context, hasDeprecationWarnings, stdin);
 
     // Write a enter pattern mode
     stdin.emit(KEYS.T);
@@ -169,15 +161,7 @@ describe('Watch mode flows', () => {
 
   it('Results in pattern mode get truncated appropriately', () => {
     config = {rootDir: ''};
-    watch(
-      config,
-      pipe,
-      argv,
-      hasteMap,
-      hasteContext,
-      hasDeprecationWarnings,
-      stdin,
-    );
+    watch(config, pipe, argv, hasteMap, context, hasDeprecationWarnings, stdin);
 
     stdin.emit(KEYS.T);
 

--- a/packages/jest-cli/src/__tests__/watch-test.js
+++ b/packages/jest-cli/src/__tests__/watch-test.js
@@ -41,7 +41,6 @@ describe('Watch mode flows', () => {
   let argv;
   let context;
   let config;
-  let hasDeprecationWarnings;
   let stdin;
 
   beforeEach(() => {
@@ -50,7 +49,6 @@ describe('Watch mode flows', () => {
     argv = {};
     context = {};
     config = {roots: [], testPathIgnorePatterns: [], testRegex: ''};
-    hasDeprecationWarnings = false;
     stdin = new MockStdin();
   });
 
@@ -58,7 +56,7 @@ describe('Watch mode flows', () => {
     argv.testPathPattern = 'test-*';
     config.testPathPattern = 'test-*';
 
-    watch(config, pipe, argv, hasteMap, context, hasDeprecationWarnings, stdin);
+    watch(config, pipe, argv, hasteMap, context, stdin);
 
     expect(runJestMock).toBeCalledWith(
       [context],
@@ -74,7 +72,7 @@ describe('Watch mode flows', () => {
     argv.testNamePattern = 'test-*';
     config.testNamePattern = 'test-*';
 
-    watch(config, pipe, argv, hasteMap, context, hasDeprecationWarnings, stdin);
+    watch(config, pipe, argv, hasteMap, context, stdin);
 
     expect(runJestMock).toBeCalledWith(
       [context],
@@ -87,7 +85,7 @@ describe('Watch mode flows', () => {
   });
 
   it('Runs Jest once by default and shows usage', () => {
-    watch(config, pipe, argv, hasteMap, context, hasDeprecationWarnings, stdin);
+    watch(config, pipe, argv, hasteMap, context, stdin);
     expect(runJestMock).toBeCalledWith(
       [context],
       argv,
@@ -100,7 +98,7 @@ describe('Watch mode flows', () => {
   });
 
   it('Pressing "o" runs test in "only changed files" mode', () => {
-    watch(config, pipe, argv, hasteMap, context, hasDeprecationWarnings, stdin);
+    watch(config, pipe, argv, hasteMap, context, stdin);
     runJestMock.mockReset();
 
     stdin.emit(KEYS.O);
@@ -114,7 +112,7 @@ describe('Watch mode flows', () => {
   });
 
   it('Pressing "a" runs test in "watch all" mode', () => {
-    watch(config, pipe, argv, hasteMap, context, hasDeprecationWarnings, stdin);
+    watch(config, pipe, argv, hasteMap, context, stdin);
     runJestMock.mockReset();
 
     stdin.emit(KEYS.A);
@@ -128,14 +126,14 @@ describe('Watch mode flows', () => {
   });
 
   it('Pressing "ENTER" reruns the tests', () => {
-    watch(config, pipe, argv, hasteMap, context, hasDeprecationWarnings, stdin);
+    watch(config, pipe, argv, hasteMap, context, stdin);
     expect(runJestMock).toHaveBeenCalledTimes(1);
     stdin.emit(KEYS.ENTER);
     expect(runJestMock).toHaveBeenCalledTimes(2);
   });
 
   it('Pressing "u" reruns the tests in "update snapshot" mode', () => {
-    watch(config, pipe, argv, hasteMap, context, hasDeprecationWarnings, stdin);
+    watch(config, pipe, argv, hasteMap, context, stdin);
     runJestMock.mockReset();
 
     stdin.emit(KEYS.U);

--- a/packages/jest-cli/src/__tests__/watch-test.js
+++ b/packages/jest-cli/src/__tests__/watch-test.js
@@ -39,7 +39,7 @@ describe('Watch mode flows', () => {
   let pipe;
   let hasteMap;
   let argv;
-  let hasteContext;
+  let context;
   let config;
   let hasDeprecationWarnings;
   let stdin;
@@ -48,7 +48,7 @@ describe('Watch mode flows', () => {
     pipe = {write: jest.fn()};
     hasteMap = {on: () => {}};
     argv = {};
-    hasteContext = {};
+    context = {};
     config = {roots: [], testPathIgnorePatterns: [], testRegex: ''};
     hasDeprecationWarnings = false;
     stdin = new MockStdin();
@@ -58,19 +58,10 @@ describe('Watch mode flows', () => {
     argv.testPathPattern = 'test-*';
     config.testPathPattern = 'test-*';
 
-    watch(
-      config,
-      pipe,
-      argv,
-      hasteMap,
-      hasteContext,
-      hasDeprecationWarnings,
-      stdin,
-    );
+    watch(config, pipe, argv, hasteMap, context, hasDeprecationWarnings, stdin);
 
     expect(runJestMock).toBeCalledWith(
-      hasteContext,
-      config,
+      [context],
       argv,
       pipe,
       new TestWatcher({isWatchMode: true}),
@@ -83,19 +74,10 @@ describe('Watch mode flows', () => {
     argv.testNamePattern = 'test-*';
     config.testNamePattern = 'test-*';
 
-    watch(
-      config,
-      pipe,
-      argv,
-      hasteMap,
-      hasteContext,
-      hasDeprecationWarnings,
-      stdin,
-    );
+    watch(config, pipe, argv, hasteMap, context, hasDeprecationWarnings, stdin);
 
     expect(runJestMock).toBeCalledWith(
-      hasteContext,
-      config,
+      [context],
       argv,
       pipe,
       new TestWatcher({isWatchMode: true}),
@@ -105,18 +87,9 @@ describe('Watch mode flows', () => {
   });
 
   it('Runs Jest once by default and shows usage', () => {
-    watch(
-      config,
-      pipe,
-      argv,
-      hasteMap,
-      hasteContext,
-      hasDeprecationWarnings,
-      stdin,
-    );
+    watch(config, pipe, argv, hasteMap, context, hasDeprecationWarnings, stdin);
     expect(runJestMock).toBeCalledWith(
-      hasteContext,
-      config,
+      [context],
       argv,
       pipe,
       new TestWatcher({isWatchMode: true}),
@@ -127,15 +100,7 @@ describe('Watch mode flows', () => {
   });
 
   it('Pressing "o" runs test in "only changed files" mode', () => {
-    watch(
-      config,
-      pipe,
-      argv,
-      hasteMap,
-      hasteContext,
-      hasDeprecationWarnings,
-      stdin,
-    );
+    watch(config, pipe, argv, hasteMap, context, hasDeprecationWarnings, stdin);
     runJestMock.mockReset();
 
     stdin.emit(KEYS.O);
@@ -149,15 +114,7 @@ describe('Watch mode flows', () => {
   });
 
   it('Pressing "a" runs test in "watch all" mode', () => {
-    watch(
-      config,
-      pipe,
-      argv,
-      hasteMap,
-      hasteContext,
-      hasDeprecationWarnings,
-      stdin,
-    );
+    watch(config, pipe, argv, hasteMap, context, hasDeprecationWarnings, stdin);
     runJestMock.mockReset();
 
     stdin.emit(KEYS.A);
@@ -171,35 +128,19 @@ describe('Watch mode flows', () => {
   });
 
   it('Pressing "ENTER" reruns the tests', () => {
-    watch(
-      config,
-      pipe,
-      argv,
-      hasteMap,
-      hasteContext,
-      hasDeprecationWarnings,
-      stdin,
-    );
+    watch(config, pipe, argv, hasteMap, context, hasDeprecationWarnings, stdin);
     expect(runJestMock).toHaveBeenCalledTimes(1);
     stdin.emit(KEYS.ENTER);
     expect(runJestMock).toHaveBeenCalledTimes(2);
   });
 
   it('Pressing "u" reruns the tests in "update snapshot" mode', () => {
-    watch(
-      config,
-      pipe,
-      argv,
-      hasteMap,
-      hasteContext,
-      hasDeprecationWarnings,
-      stdin,
-    );
+    watch(config, pipe, argv, hasteMap, context, hasDeprecationWarnings, stdin);
     runJestMock.mockReset();
 
     stdin.emit(KEYS.U);
 
-    expect(runJestMock.mock.calls[0][1]).toEqual({
+    expect(runJestMock.mock.calls[0][0][0].config).toEqual({
       roots: [],
       testPathIgnorePatterns: [],
       testRegex: '',

--- a/packages/jest-cli/src/__tests__/watch-test.js
+++ b/packages/jest-cli/src/__tests__/watch-test.js
@@ -37,29 +37,28 @@ afterEach(runJestMock.mockReset);
 
 describe('Watch mode flows', () => {
   let pipe;
-  let hasteMap;
+  let hasteMapInstances;
   let argv;
-  let context;
-  let config;
+  let contexts;
   let stdin;
 
   beforeEach(() => {
+    const config = {roots: [], testPathIgnorePatterns: [], testRegex: ''};
     pipe = {write: jest.fn()};
-    hasteMap = {on: () => {}};
+    hasteMapInstances = [{on: () => {}}];
     argv = {};
-    context = {};
-    config = {roots: [], testPathIgnorePatterns: [], testRegex: ''};
+    contexts = [{config}];
     stdin = new MockStdin();
   });
 
   it('Correctly passing test path pattern', () => {
     argv.testPathPattern = 'test-*';
-    config.testPathPattern = 'test-*';
+    contexts[0].config.testPathPattern = 'test-*';
 
-    watch(config, pipe, argv, hasteMap, context, stdin);
+    watch(contexts, argv, pipe, hasteMapInstances, stdin);
 
     expect(runJestMock).toBeCalledWith(
-      [context],
+      contexts,
       argv,
       pipe,
       new TestWatcher({isWatchMode: true}),
@@ -70,12 +69,12 @@ describe('Watch mode flows', () => {
 
   it('Correctly passing test name pattern', () => {
     argv.testNamePattern = 'test-*';
-    config.testNamePattern = 'test-*';
+    contexts[0].config.testNamePattern = 'test-*';
 
-    watch(config, pipe, argv, hasteMap, context, stdin);
+    watch(contexts, argv, pipe, hasteMapInstances, stdin);
 
     expect(runJestMock).toBeCalledWith(
-      [context],
+      contexts,
       argv,
       pipe,
       new TestWatcher({isWatchMode: true}),
@@ -85,9 +84,9 @@ describe('Watch mode flows', () => {
   });
 
   it('Runs Jest once by default and shows usage', () => {
-    watch(config, pipe, argv, hasteMap, context, stdin);
+    watch(contexts, argv, pipe, hasteMapInstances, stdin);
     expect(runJestMock).toBeCalledWith(
-      [context],
+      contexts,
       argv,
       pipe,
       new TestWatcher({isWatchMode: true}),
@@ -98,7 +97,7 @@ describe('Watch mode flows', () => {
   });
 
   it('Pressing "o" runs test in "only changed files" mode', () => {
-    watch(config, pipe, argv, hasteMap, context, stdin);
+    watch(contexts, argv, pipe, hasteMapInstances, stdin);
     runJestMock.mockReset();
 
     stdin.emit(KEYS.O);
@@ -112,7 +111,7 @@ describe('Watch mode flows', () => {
   });
 
   it('Pressing "a" runs test in "watch all" mode', () => {
-    watch(config, pipe, argv, hasteMap, context, stdin);
+    watch(contexts, argv, pipe, hasteMapInstances, stdin);
     runJestMock.mockReset();
 
     stdin.emit(KEYS.A);
@@ -126,14 +125,14 @@ describe('Watch mode flows', () => {
   });
 
   it('Pressing "ENTER" reruns the tests', () => {
-    watch(config, pipe, argv, hasteMap, context, stdin);
+    watch(contexts, argv, pipe, hasteMapInstances, stdin);
     expect(runJestMock).toHaveBeenCalledTimes(1);
     stdin.emit(KEYS.ENTER);
     expect(runJestMock).toHaveBeenCalledTimes(2);
   });
 
   it('Pressing "u" reruns the tests in "update snapshot" mode', () => {
-    watch(config, pipe, argv, hasteMap, context, stdin);
+    watch(contexts, argv, pipe, hasteMapInstances, stdin);
     runJestMock.mockReset();
 
     stdin.emit(KEYS.U);

--- a/packages/jest-cli/src/cli/args.js
+++ b/packages/jest-cli/src/cli/args.js
@@ -113,6 +113,11 @@ const options = {
     description: 'Use this flag to show full diffs instead of a patch.',
     type: 'boolean',
   },
+  experimentalProjects: {
+    description: 'A list of projects that use Jest to run all tests in a ' +
+      'single run.',
+    type: 'array',
+  },
   findRelatedTests: {
     description: 'Find related tests for a list of source files that were ' +
       'passed in as arguments. Useful for pre-commit hook integration to run ' +

--- a/packages/jest-cli/src/cli/index.js
+++ b/packages/jest-cli/src/cli/index.js
@@ -40,7 +40,13 @@ function run(argv?: Object, root?: Path) {
     root = pkgDir.sync();
   }
 
-  getJest(root).runCLI(argv, root, result => {
+  argv.projects = argv.experimentalProjects;
+  if (!argv.projects) {
+    argv.projects = [root];
+  }
+
+  const execute = argv.projects.length === 1 ? getJest(root).runCLI : runCLI;
+  execute(argv, argv.projects, result => {
     const code = !result || result.success ? 0 : 1;
     process.on('exit', () => process.exit(code));
     if (argv && argv.forceExit) {

--- a/packages/jest-cli/src/cli/runCLI.js
+++ b/packages/jest-cli/src/cli/runCLI.js
@@ -10,7 +10,7 @@
 'use strict';
 
 import type {AggregatedResult} from 'types/TestResult';
-import type {Path} from 'types/Config';
+import type {Config, Path} from 'types/Config';
 
 const Runtime = require('jest-runtime');
 
@@ -28,9 +28,9 @@ const watch = require('../watch');
 
 const VERSION = require('../../package.json').version;
 
-module.exports = (
+module.exports = async (
   argv: Object,
-  root: Path,
+  roots: Array<Path>,
   onComplete: (results: ?AggregatedResult) => void,
 ) => {
   const realFs = require('fs');
@@ -38,51 +38,67 @@ module.exports = (
   fs.gracefulify(realFs);
 
   const pipe = argv.json ? process.stderr : process.stdout;
-  argv = argv || {};
   if (argv.version) {
     pipe.write(`v${VERSION}\n`);
     onComplete && onComplete();
     return;
   }
 
-  const _run = async ({config, hasDeprecationWarnings}) => {
+  const _run = async (
+    configs: Array<{config: Config, hasDeprecationWarnings: boolean}>,
+  ) => {
     if (argv.debug || argv.showConfig) {
-      logDebugMessages(config, pipe);
+      logDebugMessages(configs[0].config, pipe);
     }
 
     if (argv.showConfig) {
       process.exit(0);
     }
 
-    createDirectory(config.cacheDirectory);
-    const hasteMapInstance = Runtime.createHasteMap(config, {
-      console: new Console(pipe, pipe),
-      maxWorkers: getMaxWorkers(argv),
-      resetCache: !config.cache,
-      watch: config.watch,
-    });
-
-    const hasteMap = await hasteMapInstance.build();
-    const context = createContext(config, hasteMap);
     if (argv.watch || argv.watchAll) {
+      const {config} = configs[0];
+      createDirectory(config.cacheDirectory);
+      const hasteMapInstance = Runtime.createHasteMap(config, {
+        console: new Console(pipe, pipe),
+        maxWorkers: getMaxWorkers(argv),
+        resetCache: !config.cache,
+        watch: config.watch,
+      });
+
+      const hasteMap = await hasteMapInstance.build();
+      const context = createContext(config, hasteMap);
       return watch(
         config,
         pipe,
         argv,
         hasteMapInstance,
         context,
-        hasDeprecationWarnings,
+        // TODO
+        configs[0].hasDeprecationWarnings,
       );
     } else {
+      const contexts = await Promise.all(
+        configs.map(async ({config}) => {
+          createDirectory(config.cacheDirectory);
+          return createContext(
+            config,
+            await Runtime.createHasteMap(config, {
+              console: new Console(pipe, pipe),
+              maxWorkers: getMaxWorkers(argv),
+              resetCache: !config.cache,
+              watch: config.watch,
+            }).build(),
+          );
+        }),
+      );
+
       const startRun = () => {
         preRunMessage.print(pipe);
-        const testWatcher = new TestWatcher({isWatchMode: false});
-        return runJest(
-          context,
-          config,
+        runJest(
+          contexts,
           argv,
           pipe,
-          testWatcher,
+          new TestWatcher({isWatchMode: false}),
           startRun,
           onComplete,
         );
@@ -91,10 +107,12 @@ module.exports = (
     }
   };
 
-  readConfig(argv, root).then(_run).catch(error => {
+  try {
+    await _run(await Promise.all(roots.map(root => readConfig(argv, root))));
+  } catch (error) {
     clearLine(process.stderr);
     clearLine(process.stdout);
     console.error(chalk.red(error.stack));
     process.exit(1);
-  });
+  }
 };

--- a/packages/jest-cli/src/lib/getTestPathPattern.js
+++ b/packages/jest-cli/src/lib/getTestPathPattern.js
@@ -9,7 +9,7 @@
  */
 'use strict';
 
-import type {PatternInfo} from '../SearchSource';
+import type {PathPattern} from '../SearchSource';
 
 const {clearLine} = require('jest-util');
 const chalk = require('chalk');
@@ -33,7 +33,7 @@ const showTestPathPatternError = (testPathPattern: string) => {
   );
 };
 
-module.exports = (argv: Object): PatternInfo => {
+module.exports = (argv: Object): PathPattern => {
   if (argv.onlyChanged) {
     return {
       input: '',

--- a/packages/jest-cli/src/lib/handleDeprecationWarnings.js
+++ b/packages/jest-cli/src/lib/handleDeprecationWarnings.js
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+'use strict';
+
+const chalk = require('chalk');
+const {KEYS} = require('../constants');
+
+module.exports = (
+  pipe: stream$Writable | tty$WriteStream,
+  stdin: stream$Readable | tty$ReadStream = process.stdin,
+) => {
+  return new Promise((resolve, reject) => {
+    if (typeof stdin.setRawMode === 'function') {
+      const messages = [
+        chalk.red('There are deprecation warnings.\n'),
+        chalk.dim(' \u203A Press ') + 'Enter' + chalk.dim(' to continue.'),
+        chalk.dim(' \u203A Press ') + 'Esc' + chalk.dim(' to exit.'),
+      ];
+
+      pipe.write(messages.join('\n'));
+
+      // $FlowFixMe
+      stdin.setRawMode(true);
+      stdin.resume();
+      stdin.setEncoding('hex');
+      stdin.on('data', (key: string) => {
+        if (key === KEYS.ENTER) {
+          resolve();
+        } else if (
+          [KEYS.ESCAPE, KEYS.CONTROL_C, KEYS.CONTROL_D].indexOf(key) !== -1
+        ) {
+          reject();
+        }
+      });
+    } else {
+      resolve();
+    }
+  });
+};

--- a/packages/jest-cli/src/lib/setState.js
+++ b/packages/jest-cli/src/lib/setState.js
@@ -9,7 +9,7 @@
  */
 'use strict';
 
-const getTestPathPatternInfo = require('./getTestPathPatternInfo');
+const getTestPathPattern = require('./getTestPathPattern');
 
 module.exports = (argv: Object, mode: 'watch' | 'watchAll', options?: {}) => {
   options = options || {};
@@ -36,7 +36,7 @@ module.exports = (argv: Object, mode: 'watch' | 'watchAll', options?: {}) => {
   }
 
   argv.onlyChanged = false;
-  argv.onlyChanged = getTestPathPatternInfo(argv).input === '' &&
+  argv.onlyChanged = getTestPathPattern(argv).input === '' &&
     !argv.watchAll &&
     !argv.testNamePattern;
 

--- a/packages/jest-cli/src/reporters/BaseReporter.js
+++ b/packages/jest-cli/src/reporters/BaseReporter.js
@@ -11,8 +11,9 @@
 
 import type {AggregatedResult, TestResult} from 'types/TestResult';
 import type {Config} from 'types/Config';
+import type {Context} from 'types/Context';
 import type {Test} from 'types/TestRunner';
-import type {ReporterOnStartOptions, RunnerContext} from 'types/Reporters';
+import type {ReporterOnStartOptions} from 'types/Reporters';
 
 const preRunMessage = require('../preRunMessage');
 
@@ -26,7 +27,6 @@ class BaseReporter {
   onRunStart(
     config: Config,
     results: AggregatedResult,
-    runnerContext: RunnerContext,
     options: ReporterOnStartOptions,
   ) {
     preRunMessage.remove(process.stderr);
@@ -37,9 +37,9 @@ class BaseReporter {
   onTestStart(test: Test) {}
 
   onRunComplete(
+    contexts: Set<Context>,
     config: Config,
     aggregatedResults: AggregatedResult,
-    runnerContext: RunnerContext,
   ): ?Promise<any> {}
 
   _setError(error: Error) {

--- a/packages/jest-cli/src/reporters/CoverageReporter.js
+++ b/packages/jest-cli/src/reporters/CoverageReporter.js
@@ -11,8 +11,8 @@
 
 import type {AggregatedResult, CoverageMap, TestResult} from 'types/TestResult';
 import type {Config} from 'types/Config';
+import type {Context} from 'types/Context';
 import type {Test} from 'types/TestRunner';
-import type {RunnerContext} from 'types/Reporters';
 
 const BaseReporter = require('./BaseReporter');
 
@@ -60,11 +60,11 @@ class CoverageReporter extends BaseReporter {
   }
 
   onRunComplete(
+    contexts: Set<Context>,
     config: Config,
     aggregatedResults: AggregatedResult,
-    runnerContext: RunnerContext,
   ) {
-    this._addUntestedFiles(config, runnerContext);
+    this._addUntestedFiles(contexts);
     let map = this._coverageMap;
     let sourceFinder: Object;
     if (config.mapCoverage) {
@@ -104,37 +104,42 @@ class CoverageReporter extends BaseReporter {
     this._checkThreshold(map, config);
   }
 
-  _addUntestedFiles(config: Config, runnerContext: RunnerContext) {
-    if (config.collectCoverageFrom && config.collectCoverageFrom.length) {
+  _addUntestedFiles(contexts: Set<Context>) {
+    const files = [];
+    contexts.forEach(context => {
+      const config = context.config;
+      if (config.collectCoverageFrom && config.collectCoverageFrom.length) {
+        context.hasteFS
+          .matchFilesWithGlob(config.collectCoverageFrom, config.rootDir)
+          .forEach(filePath =>
+            files.push({
+              config,
+              path: filePath,
+            }));
+      }
+    });
+    if (files.length) {
       if (isInteractive) {
         process.stderr.write(
           RUNNING_TEST_COLOR('Running coverage on untested files...'),
         );
       }
-      const files = runnerContext.hasteFS.matchFilesWithGlob(
-        config.collectCoverageFrom,
-        config.rootDir,
-      );
-
-      files.forEach(filename => {
-        if (!this._coverageMap.data[filename]) {
+      files.forEach(({config, path}) => {
+        if (!this._coverageMap.data[path]) {
           try {
-            const source = fs.readFileSync(filename).toString();
-            const result = generateEmptyCoverage(source, filename, config);
+            const source = fs.readFileSync(path).toString();
+            const result = generateEmptyCoverage(source, path, config);
             if (result) {
               this._coverageMap.addFileCoverage(result.coverage);
               if (result.sourceMapPath) {
-                this._sourceMapStore.registerURL(
-                  filename,
-                  result.sourceMapPath,
-                );
+                this._sourceMapStore.registerURL(path, result.sourceMapPath);
               }
             }
           } catch (e) {
             console.error(
               chalk.red(
                 `
-              Failed to collect coverage from ${filename}
+              Failed to collect coverage from ${path}
               ERROR: ${e}
               STACK: ${e.stack}
             `,

--- a/packages/jest-cli/src/reporters/DefaultReporter.js
+++ b/packages/jest-cli/src/reporters/DefaultReporter.js
@@ -34,10 +34,7 @@ const isInteractive = process.stdin.isTTY && !isCI;
 
 class DefaultReporter extends BaseReporter {
   _clear: string; // ANSI clear sequence for the last printed status
-  _currentlyRunning: Map<Path, Config>;
-  _currentStatusHeight: number;
   _err: write;
-  _lastAggregatedResults: AggregatedResult;
   _out: write;
   _status: Status;
 

--- a/packages/jest-cli/src/reporters/DefaultReporter.js
+++ b/packages/jest-cli/src/reporters/DefaultReporter.js
@@ -15,7 +15,7 @@
 import type {AggregatedResult, TestResult} from 'types/TestResult';
 import type {Config, Path} from 'types/Config';
 import type {Test} from 'types/TestRunner';
-import type {ReporterOnStartOptions, RunnerContext} from 'types/Reporters';
+import type {ReporterOnStartOptions} from 'types/Reporters';
 
 const BaseReporter = require('./BaseReporter');
 const Status = require('./Status');
@@ -114,7 +114,6 @@ class DefaultReporter extends BaseReporter {
   onRunStart(
     config: Config,
     aggregatedResults: AggregatedResult,
-    runnerContext: RunnerContext,
     options: ReporterOnStartOptions,
   ) {
     this._status.runStarted(aggregatedResults, options);

--- a/packages/jest-cli/src/reporters/NotifyReporter.js
+++ b/packages/jest-cli/src/reporters/NotifyReporter.js
@@ -11,6 +11,7 @@
 
 import type {AggregatedResult} from 'types/TestResult';
 import type {Config} from 'types/Config';
+import type {Context} from 'types/Context';
 
 const BaseReporter = require('./BaseReporter');
 const notifier = require('node-notifier');
@@ -29,7 +30,11 @@ class NotifyReporter extends BaseReporter {
     this._startRun = startRun;
   }
 
-  onRunComplete(config: Config, result: AggregatedResult): void {
+  onRunComplete(
+    contexts: Set<Context>,
+    config: Config,
+    result: AggregatedResult,
+  ): void {
     const success = result.numFailedTests === 0 &&
       result.numRuntimeErrorTestSuites === 0;
 

--- a/packages/jest-cli/src/reporters/__tests__/CoverageReporter-test.js
+++ b/packages/jest-cli/src/reporters/__tests__/CoverageReporter-test.js
@@ -83,6 +83,7 @@ describe('onRunComplete', () => {
 
   it('getLastError() returns an error when threshold is not met', () => {
     testReporter.onRunComplete(
+      new Set(),
       {
         collectCoverage: true,
         coverageThreshold: {
@@ -99,6 +100,7 @@ describe('onRunComplete', () => {
 
   it('getLastError() returns `undefined` when threshold is met', () => {
     testReporter.onRunComplete(
+      new Set(),
       {
         collectCoverage: true,
         coverageThreshold: {

--- a/packages/jest-cli/src/runJest.js
+++ b/packages/jest-cli/src/runJest.js
@@ -94,7 +94,7 @@ const getNoTestsFoundMessage = (testRunData, pattern) => {
 const getTestPaths = async (context, pattern, argv, pipe) => {
   const source = new SearchSource(context);
   let data = await source.getTestPaths(pattern);
-  if (!data.paths.length) {
+  if (!data.tests.length) {
     if (pattern.onlyChanged && data.noSCM) {
       if (context.config.watch) {
         // Run all the tests
@@ -156,7 +156,7 @@ const runJest = async (
     contexts.map(async context => {
       const matches = await getTestPaths(context, pattern, argv, pipe);
       const sequencer = new TestSequencer(context);
-      const tests = sequencer.sort(matches.paths);
+      const tests = sequencer.sort(matches.tests);
       return {context, matches, sequencer, tests};
     }),
   );

--- a/packages/jest-cli/src/runJest.js
+++ b/packages/jest-cli/src/runJest.js
@@ -113,7 +113,7 @@ const getNoTestsFoundMessage = (testRunData, pattern) => {
 };
 
 const getTestPaths = async (context, pattern, argv, pipe) => {
-  const source = new SearchSource(context, context.config);
+  const source = new SearchSource(context);
   let data = await source.getTestPaths(pattern);
   if (!data.paths.length) {
     const localConsole = new Console(pipe, pipe);

--- a/packages/jest-cli/src/watch.js
+++ b/packages/jest-cli/src/watch.js
@@ -34,17 +34,8 @@ const watch = (
   argv: Object,
   hasteMap: HasteMap,
   context: Context,
-  hasDeprecationWarnings?: boolean,
   stdin?: stream$Readable | tty$ReadStream = process.stdin,
 ) => {
-  if (hasDeprecationWarnings) {
-    return handleDeprecatedWarnings(pipe, stdin)
-      .then(() => {
-        watch(config, pipe, argv, hasteMap, context);
-      })
-      .catch(() => process.exit(0));
-  }
-
   setState(argv, argv.watch ? 'watch' : 'watchAll', {
     testNamePattern: argv.testNamePattern,
     testPathPattern: argv.testPathPattern ||
@@ -225,39 +216,6 @@ const watch = (
 
   startRun();
   return Promise.resolve();
-};
-
-const handleDeprecatedWarnings = (
-  pipe: stream$Writable | tty$WriteStream,
-  stdin: stream$Readable | tty$ReadStream = process.stdin,
-) => {
-  return new Promise((resolve, reject) => {
-    if (typeof stdin.setRawMode === 'function') {
-      const messages = [
-        chalk.red('There are deprecation warnings.\n'),
-        chalk.dim(' \u203A Press ') + 'Enter' + chalk.dim(' to continue.'),
-        chalk.dim(' \u203A Press ') + 'Esc' + chalk.dim(' to exit.'),
-      ];
-
-      pipe.write(messages.join('\n'));
-
-      // $FlowFixMe
-      stdin.setRawMode(true);
-      stdin.resume();
-      stdin.setEncoding('hex');
-      stdin.on('data', (key: string) => {
-        if (key === KEYS.ENTER) {
-          resolve();
-        } else if (
-          [KEYS.ESCAPE, KEYS.CONTROL_C, KEYS.CONTROL_D].indexOf(key) !== -1
-        ) {
-          reject();
-        }
-      });
-    } else {
-      resolve();
-    }
-  });
 };
 
 const usage = (argv, snapshotFailure, delimiter = '\n') => {

--- a/types/Reporters.js
+++ b/types/Reporters.js
@@ -11,11 +11,6 @@
 
 import type {FS} from 'jest-haste-map';
 
-export type RunnerContext = {|
-  hasteFS: FS,
-  getTestSummary: () => string,
-|};
-
 export type ReporterOnStartOptions = {|
   estimatedTime: number,
   showStatus: boolean,

--- a/types/TestRunner.js
+++ b/types/TestRunner.js
@@ -12,10 +12,10 @@
 import type {Context} from './Context';
 import type {Path} from './Config';
 
-export type Test = {
+export type Test = {|
   context: Context,
   path: Path,
   duration?: number,
-};
+|};
 
 export type Tests = Array<Test>;

--- a/types/TestRunner.js
+++ b/types/TestRunner.js
@@ -15,7 +15,7 @@ import type {Path} from './Config';
 export type Test = {|
   context: Context,
   path: Path,
-  duration?: number,
+  duration: ?number,
 |};
 
 export type Tests = Array<Test>;


### PR DESCRIPTION
**Summary**

Context: #2970 

This diff is the initial RFC for the multi-project runner. This is the proposal that merges all functionality into jest-cli which will make Facebook's internal multi-runner obsolete. The initial draft changes the Jest CLI to operate on a list of `TestContext`s, which is a new name for HasteContexts with the configuration object added to it. This is basically the entire extent of the added complexity to make this work, the rest is refactors that should be made regardless.

The refactoring of the TestSequencer, runCLI and usage of async/await alone make the codebase actually easier to understand and concerns are separated better with this diff applied. These changes were already landed as part of this PR.

![20-multi-runner](https://cloud.githubusercontent.com/assets/13352/23987088/ff3b9ec8-0a6a-11e7-8e36-bf4e04ec6a49.gif)

**TODO**
* We need to make it so that there is an overall config that is used for the multi-runner. Currently this is the first one it finds but I believe the right way to go about it is an entirely separate configuration object that only defines behavior rather than tests to run.
* Make watch mode work with this. I wanted to get to a MVP asap, so I left this one alone for now.
* The printed information on the CLI doesn't show the proper paths to tests because it uses the wrong config object to determine the root. It should be the working directory or the root of the fake configuration.
* We need a customization option for the reporter output per test so that we know which project/config a test belongs to. Not sure yet how to best customize it and what information to show, given that we only have one line.
* I left a few TODOs in the code.

**Test plan**

* `cd examples`
* `jest --experimentalProjects */ --no-cache`
