### PR TITLE
Support custom platforms on jest-haste-map

### DIFF
--- a/packages/jest-haste-map/src/index.js
+++ b/packages/jest-haste-map/src/index.js
@@ -305,8 +305,10 @@ class HasteMap extends EventEmitter {
         map[id] = Object.create(null);
       }
       const moduleMap = map[id];
-      const platform = getPlatformExtension(module[H.PATH], this._options.platforms) ||
-        H.GENERIC_PLATFORM;
+      const platform = getPlatformExtension(
+        module[H.PATH],
+        this._options.platforms,
+      ) || H.GENERIC_PLATFORM;
       const existingModule = moduleMap[platform];
       if (existingModule && existingModule[H.PATH] !== module[H.PATH]) {
         const message = `jest-haste-map: @providesModule naming collision:\n` +

--- a/packages/jest-haste-map/src/index.js
+++ b/packages/jest-haste-map/src/index.js
@@ -305,7 +305,7 @@ class HasteMap extends EventEmitter {
         map[id] = Object.create(null);
       }
       const moduleMap = map[id];
-      const platform = getPlatformExtension(module[H.PATH]) ||
+      const platform = getPlatformExtension(module[H.PATH], this._options.platforms) ||
         H.GENERIC_PLATFORM;
       const existingModule = moduleMap[platform];
       if (existingModule && existingModule[H.PATH] !== module[H.PATH]) {

--- a/packages/jest-haste-map/src/lib/getPlatformExtension.js
+++ b/packages/jest-haste-map/src/lib/getPlatformExtension.js
@@ -17,13 +17,17 @@ const SUPPORTED_PLATFORM_EXTS = {
 };
 
 // Extract platform extension: index.ios.js -> ios
-function getPlatformExtension(file: string): ?string {
+function getPlatformExtension(file: string, platforms?: Array<string>): ?string {
   const last = file.lastIndexOf('.');
   const secondToLast = file.lastIndexOf('.', last - 1);
   if (secondToLast === -1) {
     return null;
   }
   const platform = file.substring(secondToLast + 1, last);
+  // If an overriding platform array is passed, check that first
+  if (platforms && platforms.includes(platform)) {
+    return platform;
+  }
   return SUPPORTED_PLATFORM_EXTS[platform] ? platform : null;
 }
 

--- a/packages/jest-haste-map/src/lib/getPlatformExtension.js
+++ b/packages/jest-haste-map/src/lib/getPlatformExtension.js
@@ -17,7 +17,10 @@ const SUPPORTED_PLATFORM_EXTS = {
 };
 
 // Extract platform extension: index.ios.js -> ios
-function getPlatformExtension(file: string, platforms?: Array<string>): ?string {
+function getPlatformExtension(
+  file: string,
+  platforms?: Array<string>,
+): ?string {
   const last = file.lastIndexOf('.');
   const secondToLast = file.lastIndexOf('.', last - 1);
   if (secondToLast === -1) {

--- a/packages/jest-jasmine2/src/jasmine-light.js
+++ b/packages/jest-jasmine2/src/jasmine-light.js
@@ -1654,12 +1654,7 @@ exports.TreeProcessor = function() {
       return executableIndex === undefined ? defaultMax : executableIndex;
     }
 
-    function segmentChildren(
-      node,
-      children,
-      nodeStats,
-      executableIndex,
-    ) {
+    function segmentChildren(node, children, nodeStats, executableIndex) {
       let currentSegment = {
         index: 0,
         owner: node,

--- a/packages/jest-matchers/src/asymmetric-matchers.js
+++ b/packages/jest-matchers/src/asymmetric-matchers.js
@@ -130,8 +130,10 @@ class ArrayContaining extends AsymmetricMatcher {
       );
     }
 
-    return this.sample.length === 0 || Array.isArray(other) &&
-      this.sample.every(item => other.some(another => equals(item, another)));
+    return this.sample.length === 0 ||
+      (Array.isArray(other) &&
+        this.sample.every(item =>
+          other.some(another => equals(item, another))));
   }
 
   toString() {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

The options object allows specification of custom platforms, but jest-haste-map doesn't use this when checking for duplicates, which leads to a lot of unnecessary warning messages on custom platforms.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

Ran these changes on a project with the following package.json configuration:
```
// ...
  "jest": {
    "haste": {
      "platforms": ["vr"],
// ...
```

And two files: `MyModule.js` and `MyModule.vr.js`, both of which contain `@providesModule MyModule`

Without these changes, jest-haste-map produces a warning. With these changes, no warnings occur.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
