### PR TITLE
Refactor runner

### DIFF
--- a/packages/jest-cli/src/TestRunner.js
+++ b/packages/jest-cli/src/TestRunner.js
@@ -14,14 +14,14 @@ import type {
   SerializableError as TestError,
   TestResult,
 } from 'types/TestResult';
-import type {Config, Path} from 'types/Config';
+import type {Config} from 'types/Config';
 import type {HasteContext, HasteFS} from 'types/HasteMap';
 import type {RunnerContext} from 'types/Reporters';
+import type {Test, Tests} from 'types/TestRunner';
 import type BaseReporter from './reporters/BaseReporter';
 
 const {formatExecError} = require('jest-message-util');
-const fs = require('graceful-fs');
-const getCacheFilePath = require('jest-haste-map').getCacheFilePath;
+
 const DefaultReporter = require('./reporters/DefaultReporter');
 const NotifyReporter = require('./reporters/NotifyReporter');
 const SummaryReporter = require('./reporters/SummaryReporter');
@@ -33,9 +33,7 @@ const throat = require('throat');
 const workerFarm = require('worker-farm');
 const TestWatcher = require('./TestWatcher');
 
-const FAIL = 0;
 const SLOW_TEST_TIME = 3000;
-const SUCCESS = 1;
 
 class CancelRun extends Error {
   constructor(message: ?string) {
@@ -49,9 +47,8 @@ type Options = {|
   getTestSummary: () => string,
 |};
 
-type OnRunFailure = (path: string, err: TestError) => void;
-
-type OnTestResult = (path: string, result: TestResult) => void;
+type OnTestFailure = (test: Test, err: TestError) => void;
+type OnTestSuccess = (test: Test, result: TestResult) => void;
 
 const TEST_WORKER_PATH = require.resolve('./TestWorker');
 
@@ -61,7 +58,6 @@ class TestRunner {
   _options: Options;
   _startRun: () => *;
   _dispatcher: ReporterDispatcher;
-  _testPerformanceCache: Object;
 
   constructor(
     hasteContext: HasteContext,
@@ -78,10 +74,6 @@ class TestRunner {
     this._options = options;
     this._startRun = startRun;
     this._setupReporters();
-
-    // Map from testFilePath -> time it takes to run the test. Used to
-    // optimally schedule bigger test runs.
-    this._testPerformanceCache = {};
   }
 
   addReporter(reporter: BaseReporter) {
@@ -92,95 +84,26 @@ class TestRunner {
     this._dispatcher.unregister(ReporterClass);
   }
 
-  _getTestPerformanceCachePath() {
+  runTests(tests: Tests, watcher: TestWatcher) {
     const config = this._config;
-    return getCacheFilePath(config.cacheDirectory, 'perf-cache-' + config.name);
-  }
-
-  _sortTests(testPaths: Array<string>) {
-    // When running more tests than we have workers available, sort the tests
-    // by size - big test files usually take longer to complete, so we run
-    // them first in an effort to minimize worker idle time at the end of a
-    // long test run.
-    //
-    // After a test run we store the time it took to run a test and on
-    // subsequent runs we use that to run the slowest tests first, yielding the
-    // fastest results.
-    try {
-      if (this._config.cache) {
-        this._testPerformanceCache = JSON.parse(
-          fs.readFileSync(this._getTestPerformanceCachePath(), 'utf8'),
-        );
-      } else {
-        this._testPerformanceCache = {};
-      }
-    } catch (e) {
-      this._testPerformanceCache = {};
-    }
-
-    const cache = this._testPerformanceCache;
     const timings = [];
-    const stats = {};
-    const getFileSize = filePath =>
-      stats[filePath] || (stats[filePath] = fs.statSync(filePath).size);
-    const getTestRunTime = filePath => {
-      if (cache[filePath]) {
-        return cache[filePath][0] === FAIL ? Infinity : cache[filePath][1];
-      }
-      return null;
-    };
-
-    testPaths = testPaths.sort((pathA, pathB) => {
-      const timeA = getTestRunTime(pathA);
-      const timeB = getTestRunTime(pathB);
-      if (timeA != null && timeB != null) {
-        return timeA < timeB ? 1 : -1;
-      }
-      return getFileSize(pathA) < getFileSize(pathB) ? 1 : -1;
-    });
-
-    testPaths.forEach(filePath => {
-      const timing = cache[filePath] && cache[filePath][1];
-      if (timing) {
-        timings.push(timing);
+    tests.forEach(test => {
+      if (test.duration) {
+        timings.push(test.duration);
       }
     });
-
-    return {testPaths, timings};
-  }
-
-  _cacheTestResults(aggregatedResults: AggregatedResult) {
-    const cache = this._testPerformanceCache;
-    aggregatedResults.testResults.forEach(test => {
-      if (test && !test.skipped) {
-        const perf = test.perfStats;
-        cache[test.testFilePath] = [
-          test.numFailingTests ? FAIL : SUCCESS,
-          perf.end - perf.start || 0,
-        ];
-      }
-    });
-    fs.writeFileSync(
-      this._getTestPerformanceCachePath(),
-      JSON.stringify(cache),
-    );
-  }
-
-  runTests(paths: Array<string>, watcher: TestWatcher) {
-    const config = this._config;
-    const {testPaths, timings} = this._sortTests(paths);
-    const aggregatedResults = createAggregatedResults(testPaths.length);
+    const aggregatedResults = createAggregatedResults(tests.length);
     const estimatedTime = Math.ceil(
       getEstimatedTime(timings, this._options.maxWorkers) / 1000,
     );
 
-    const onResult = (testPath: Path, testResult: TestResult) => {
+    const onResult = (test: Test, testResult: TestResult) => {
       if (watcher.isInterrupted()) {
         return;
       }
       if (testResult.testResults.length === 0) {
         const message = 'Your test suite must contain at least one test.';
-        onFailure(testPath, {
+        onFailure(test, {
           message,
           stack: new Error(message).stack,
         });
@@ -191,12 +114,16 @@ class TestRunner {
       this._bailIfNeeded(aggregatedResults, watcher);
     };
 
-    const onFailure = (testPath: Path, error: TestError) => {
+    const onFailure = (test: Test, error: TestError) => {
       if (watcher.isInterrupted()) {
         return;
       }
-      const testResult = buildFailureTestResult(testPath, error);
-      testResult.failureMessage = formatExecError(testResult, config, testPath);
+      const testResult = buildFailureTestResult(test.path, error);
+      testResult.failureMessage = formatExecError(
+        testResult,
+        test.config,
+        test.path,
+      );
       addResult(aggregatedResults, testResult);
       this._dispatcher.onTestResult(config, testResult, aggregatedResults);
     };
@@ -206,8 +133,8 @@ class TestRunner {
     // we also run in band to reduce the overhead of spawning workers.
     const shouldRunInBand = () =>
       this._options.maxWorkers <= 1 ||
-      testPaths.length <= 1 ||
-      (testPaths.length <= 20 &&
+      tests.length <= 1 ||
+      (tests.length <= 20 &&
         timings.length > 0 &&
         timings.every(timing => timing < SLOW_TEST_TIME));
 
@@ -232,8 +159,8 @@ class TestRunner {
     });
 
     const testRun = runInBand
-      ? this._createInBandTestRun(testPaths, watcher, onResult, onFailure)
-      : this._createParallelTestRun(testPaths, watcher, onResult, onFailure);
+      ? this._createInBandTestRun(tests, watcher, onResult, onFailure)
+      : this._createParallelTestRun(tests, watcher, onResult, onFailure);
 
     return testRun
       .catch(error => {
@@ -255,43 +182,39 @@ class TestRunner {
           aggregatedResults.snapshot.failure ||
           anyReporterErrors);
 
-        this._cacheTestResults(aggregatedResults);
         return aggregatedResults;
       });
   }
 
   _createInBandTestRun(
-    testPaths: Array<Path>,
+    tests: Tests,
     watcher: TestWatcher,
-    onResult: OnTestResult,
-    onFailure: OnRunFailure,
+    onResult: OnTestSuccess,
+    onFailure: OnTestFailure,
   ) {
     const mutex = throat(1);
-    return testPaths.reduce(
-      (promise, path) =>
-        mutex(() =>
-          promise
-            .then(() => {
-              if (watcher.isInterrupted()) {
-                throw new CancelRun();
-              }
+    return tests.reduce(
+      (promise, test) => mutex(() => promise
+        .then(() => {
+          if (watcher.isInterrupted()) {
+            throw new CancelRun();
+          }
 
-              this._dispatcher.onTestStart(this._config, path);
-              return runTest(path, this._config, this._hasteContext.resolver);
-            })
-            .then(result => onResult(path, result))
-            .catch(err => onFailure(path, err))),
+          this._dispatcher.onTestStart(test.config, test.path);
+          return runTest(test.path, test.config, this._hasteContext.resolver);
+        })
+        .then(result => onResult(test, result))
+        .catch(err => onFailure(test, err))),
       Promise.resolve(),
     );
   }
 
   _createParallelTestRun(
-    testPaths: Array<Path>,
+    tests: Tests,
     watcher: TestWatcher,
-    onResult: OnTestResult,
-    onFailure: OnRunFailure,
+    onResult: OnTestSuccess,
+    onFailure: OnTestFailure,
   ) {
-    const config = this._config;
     const farm = workerFarm(
       {
         autoStart: true,
@@ -306,23 +229,22 @@ class TestRunner {
 
     // Send test suites to workers continuously instead of all at once to track
     // the start time of individual tests.
-    const runTestInWorker = ({config, path}) =>
-      mutex(() => {
-        if (watcher.isInterrupted()) {
-          return Promise.reject();
-        }
-        this._dispatcher.onTestStart(config, path);
-        return worker({
-          config,
-          path,
-          rawModuleMap: watcher.isWatchMode()
-            ? this._hasteContext.moduleMap.getRawModuleMap()
-            : null,
-        });
+    const runTestInWorker = ({config, path}) => mutex(() => {
+      if (watcher.isInterrupted()) {
+        return Promise.reject();
+      }
+      this._dispatcher.onTestStart(config, path);
+      return worker({
+        config,
+        path,
+        rawModuleMap: watcher.isWatchMode()
+          ? this._hasteContext.moduleMap.getRawModuleMap()
+          : null,
       });
+    });
 
-    const onError = (err, path) => {
-      onFailure(path, err);
+    const onError = (err, test) => {
+      onFailure(test, err);
       if (err.type === 'ProcessTerminatedError') {
         console.error(
           'A worker process has quit unexpectedly! ' +
@@ -341,10 +263,10 @@ class TestRunner {
     });
 
     const runAllTests = Promise.all(
-      testPaths.map(path => {
-        return runTestInWorker({config, path})
-          .then(testResult => onResult(path, testResult))
-          .catch(error => onError(error, path));
+      tests.map(test => {
+        return runTestInWorker(test)
+          .then(testResult => onResult(test, testResult))
+          .catch(error => onError(error, test));
       }),
     );
 

--- a/packages/jest-cli/src/TestSequencer.js
+++ b/packages/jest-cli/src/TestSequencer.js
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+'use strict';
+
+import type {AggregatedResult} from 'types/TestResult';
+import type {Config} from 'types/Config';
+import type {Tests} from 'types/TestRunner';
+
+const fs = require('fs');
+const getCacheFilePath = require('jest-haste-map').getCacheFilePath;
+
+const FAIL = 0;
+const SUCCESS = 1;
+
+class TestSequencer {
+  _config: Config;
+  _cache: Object;
+
+  constructor(config: Config) {
+    this._config = config;
+    this._cache = {};
+  }
+
+  _getTestPerformanceCachePath() {
+    return getCacheFilePath(
+      this._config.cacheDirectory,
+      'perf-cache-' + this._config.name,
+    );
+  }
+
+  // When running more tests than we have workers available, sort the tests
+  // by size - big test files usually take longer to complete, so we run
+  // them first in an effort to minimize worker idle time at the end of a
+  // long test run.
+  //
+  // After a test run we store the time it took to run a test and on
+  // subsequent runs we use that to run the slowest tests first, yielding the
+  // fastest results.
+  sort(testPaths: Array<string>): Tests {
+    const config = this._config;
+    const stats = {};
+    const getFileSize = filePath =>
+      stats[filePath] || (stats[filePath] = fs.statSync(filePath).size);
+    const getTestRunTime = filePath => {
+      if (this._cache[filePath]) {
+        return this._cache[filePath][0] === FAIL
+          ? Infinity
+          : this._cache[filePath][1];
+      }
+      return null;
+    };
+
+    this._cache = {};
+    try {
+      if (this._config.cache) {
+        this._cache = JSON.parse(
+          fs.readFileSync(this._getTestPerformanceCachePath(), 'utf8'),
+        );
+      }
+    } catch (e) {}
+
+    testPaths = testPaths.sort((pathA, pathB) => {
+      const timeA = getTestRunTime(pathA);
+      const timeB = getTestRunTime(pathB);
+      if (timeA != null && timeB != null) {
+        return timeA < timeB ? 1 : -1;
+      }
+      return getFileSize(pathA) < getFileSize(pathB) ? 1 : -1;
+    });
+
+    return testPaths.map(path => ({
+      config,
+      duration: this._cache[path] && this._cache[path][1],
+      path,
+    }));
+  }
+
+  cacheResults(results: AggregatedResult) {
+    const cache = this._cache;
+    results.testResults.forEach(test => {
+      if (test && !test.skipped) {
+        const perf = test.perfStats;
+        cache[test.testFilePath] = [
+          test.numFailingTests ? FAIL : SUCCESS,
+          perf.end - perf.start || 0,
+        ];
+      }
+    });
+    fs.writeFileSync(
+      this._getTestPerformanceCachePath(),
+      JSON.stringify(cache),
+    );
+  }
+}
+
+module.exports = TestSequencer;

--- a/packages/jest-cli/src/__tests__/TestRunner-test.js
+++ b/packages/jest-cli/src/__tests__/TestRunner-test.js
@@ -48,7 +48,7 @@ describe('_createInBandTestRun()', () => {
 
     return runner
       ._createParallelTestRun(
-        ['./file-test.js', './file2-test.js'],
+        [{config, path: './file-test.js'}, {config, path: './file2-test.js'}],
         new TestWatcher({isWatchMode: config.watch}),
         () => {},
         () => {},
@@ -75,7 +75,7 @@ describe('_createInBandTestRun()', () => {
 
     return runner
       ._createParallelTestRun(
-        ['./file-test.js', './file2-test.js'],
+        [{config, path: './file-test.js'}, {config, path: './file2-test.js'}],
         new TestWatcher({isWatchMode: config.watch}),
         () => {},
         () => {},

--- a/packages/jest-cli/src/__tests__/TestSequencer-test.js
+++ b/packages/jest-cli/src/__tests__/TestSequencer-test.js
@@ -1,0 +1,134 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
+jest.mock('fs');
+
+const TestSequencer = require('../TestSequencer');
+
+const fs = require('fs');
+
+const FAIL = 0;
+const SUCCESS = 1;
+
+let sequencer;
+
+const config = {
+  cache: true,
+  cacheDirectory: '/cache',
+  name: 'test',
+};
+
+beforeEach(() => {
+  sequencer = new TestSequencer(config);
+
+  fs.readFileSync = jest.fn(() => '{}');
+  fs.statSync = jest.fn(filePath => ({size: filePath.length}));
+});
+
+test('sorts by file size if there is no timing information', () => {
+  expect(sequencer.sort(['/test-a.js', '/test-ab.js'])).toEqual([
+    {config, duration: undefined, path: '/test-ab.js'},
+    {config, duration: undefined, path: '/test-a.js'},
+  ]);
+});
+
+test('sorts based on timing information', () => {
+  fs.readFileSync = jest.fn(() => JSON.stringify({
+    '/test-a.js': [SUCCESS, 5],
+    '/test-ab.js': [SUCCESS, 3],
+  }));
+  expect(sequencer.sort(['/test-a.js', '/test-ab.js'])).toEqual([
+    {config, duration: 5, path: '/test-a.js'},
+    {config, duration: 3, path: '/test-ab.js'},
+  ]);
+});
+
+test('sorts based on failures and timing information', () => {
+  fs.readFileSync = jest.fn(() => JSON.stringify({
+    '/test-a.js': [SUCCESS, 5],
+    '/test-ab.js': [FAIL, 0],
+    '/test-c.js': [FAIL, 6],
+    '/test-d.js': [SUCCESS, 2],
+  }));
+  expect(
+    sequencer.sort(['/test-a.js', '/test-ab.js', '/test-c.js', '/test-d.js']),
+  ).toEqual([
+    {config, duration: 6, path: '/test-c.js'},
+    {config, duration: 0, path: '/test-ab.js'},
+    {config, duration: 5, path: '/test-a.js'},
+    {config, duration: 2, path: '/test-d.js'},
+  ]);
+});
+
+test('sorts based on failures, timing information and file size', () => {
+  fs.readFileSync = jest.fn(() => JSON.stringify({
+    '/test-a.js': [SUCCESS, 5],
+    '/test-ab.js': [FAIL, 1],
+    '/test-c.js': [FAIL],
+    '/test-d.js': [SUCCESS, 2],
+    '/test-efg.js': [FAIL],
+  }));
+  expect(
+    sequencer.sort([
+      '/test-a.js',
+      '/test-ab.js',
+      '/test-c.js',
+      '/test-d.js',
+      '/test-efg.js',
+    ]),
+  ).toEqual([
+    {config, duration: undefined, path: '/test-efg.js'},
+    {config, duration: undefined, path: '/test-c.js'},
+    {config, duration: 1, path: '/test-ab.js'},
+    {config, duration: 5, path: '/test-a.js'},
+    {config, duration: 2, path: '/test-d.js'},
+  ]);
+});
+
+test('writes the cache based on the results', () => {
+  fs.readFileSync = jest.fn(() => JSON.stringify({
+    '/test-a.js': [SUCCESS, 5],
+    '/test-b.js': [FAIL, 1],
+    '/test-c.js': [FAIL],
+  }));
+
+  const testPaths = ['/test-a.js', '/test-b.js', '/test-c.js'];
+  const tests = sequencer.sort(testPaths);
+  sequencer.cacheResults(tests, {
+    testResults: [
+      {
+        numFailingTests: 0,
+        perfStats: {end: 2, start: 1},
+        testFilePath: '/test-a.js',
+      },
+      {
+        numFailingTests: 0,
+        perfStats: {end: 0, start: 0},
+        skipped: true,
+        testFilePath: '/test-b.js',
+      },
+      {
+        numFailingTests: 1,
+        perfStats: {end: 4, start: 1},
+        testFilePath: '/test-c.js',
+      },
+      {
+        numFailingTests: 1,
+        perfStats: {end: 2, start: 1},
+        testFilePath: '/test-x.js',
+      },
+    ],
+  });
+  const fileData = JSON.parse(fs.writeFileSync.mock.calls[0][1]);
+  expect(fileData).toEqual({
+    '/test-a.js': [SUCCESS, 1],
+    '/test-b.js': [FAIL, 1],
+    '/test-c.js': [FAIL, 3],
+  });
+});

--- a/packages/jest-cli/src/cli/index.js
+++ b/packages/jest-cli/src/cli/index.js
@@ -15,6 +15,7 @@ import type {Path} from 'types/Config';
 const args = require('./args');
 const getJest = require('./getJest');
 const pkgDir = require('pkg-dir');
+const runCLI = require('./runCLI');
 const validateCLIOptions = require('jest-util').validateCLIOptions;
 const yargs = require('yargs');
 
@@ -49,3 +50,4 @@ function run(argv?: Object, root?: Path) {
 }
 
 exports.run = run;
+exports.runCLI = runCLI;

--- a/packages/jest-cli/src/cli/runCLI.js
+++ b/packages/jest-cli/src/cli/runCLI.js
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+'use strict';
+
+import type {AggregatedResult} from 'types/TestResult';
+import type {Path} from 'types/Config';
+
+const Runtime = require('jest-runtime');
+
+const chalk = require('chalk');
+const {Console, clearLine} = require('jest-util');
+const {createDirectory} = require('jest-util');
+const createHasteContext = require('../lib/createHasteContext');
+const getMaxWorkers = require('../lib/getMaxWorkers');
+const logDebugMessages = require('../lib/logDebugMessages');
+const preRunMessage = require('../preRunMessage');
+const readConfig = require('jest-config').readConfig;
+const runJest = require('../runJest');
+const TestWatcher = require('../TestWatcher');
+const watch = require('../watch');
+
+const VERSION = require('../../package.json').version;
+
+module.exports = (
+  argv: Object,
+  root: Path,
+  onComplete: (results: ?AggregatedResult) => void,
+) => {
+  const realFs = require('fs');
+  const fs = require('graceful-fs');
+  fs.gracefulify(realFs);
+
+  const pipe = argv.json ? process.stderr : process.stdout;
+  argv = argv || {};
+  if (argv.version) {
+    pipe.write(`v${VERSION}\n`);
+    onComplete && onComplete();
+    return;
+  }
+
+  const _run = async ({config, hasDeprecationWarnings}) => {
+    if (argv.debug) {
+      logDebugMessages(config, pipe);
+    }
+
+    createDirectory(config.cacheDirectory);
+    const hasteMapInstance = Runtime.createHasteMap(config, {
+      console: new Console(pipe, pipe),
+      maxWorkers: getMaxWorkers(argv),
+      resetCache: !config.cache,
+      watch: config.watch,
+    });
+
+    const hasteMap = await hasteMapInstance.build();
+    const hasteContext = createHasteContext(config, hasteMap);
+    if (argv.watch || argv.watchAll) {
+      return watch(
+        config,
+        pipe,
+        argv,
+        hasteMapInstance,
+        hasteContext,
+        hasDeprecationWarnings,
+      );
+    } else {
+      const startRun = () => {
+        preRunMessage.print(pipe);
+        const testWatcher = new TestWatcher({isWatchMode: false});
+        return runJest(
+          hasteContext,
+          config,
+          argv,
+          pipe,
+          testWatcher,
+          startRun,
+          onComplete,
+        );
+      };
+      return startRun();
+    }
+  };
+
+  readConfig(argv, root).then(_run).catch(error => {
+    clearLine(process.stderr);
+    clearLine(process.stdout);
+    console.error(chalk.red(error.stack));
+    process.exit(1);
+  });
+};

--- a/packages/jest-cli/src/jest.js
+++ b/packages/jest-cli/src/jest.js
@@ -9,94 +9,13 @@
  */
 'use strict';
 
-import type {AggregatedResult} from 'types/TestResult';
-import type {Path} from 'types/Config';
-
-const realFs = require('fs');
-const fs = require('graceful-fs');
-fs.gracefulify(realFs);
-
-const Runtime = require('jest-runtime');
 const SearchSource = require('./SearchSource');
 const TestRunner = require('./TestRunner');
-
-const chalk = require('chalk');
-const {Console, clearLine} = require('jest-util');
-const {createDirectory} = require('jest-util');
-const createHasteContext = require('./lib/createHasteContext');
-const getMaxWorkers = require('./lib/getMaxWorkers');
-const logDebugMessages = require('./lib/logDebugMessages');
-const preRunMessage = require('./preRunMessage');
-const readConfig = require('jest-config').readConfig;
-const {run} = require('./cli');
-const runJest = require('./runJest');
 const TestWatcher = require('./TestWatcher');
-const watch = require('./watch');
+
+const {run, runCLI} = require('./cli');
 
 const VERSION = require('../package.json').version;
-
-const runCLI = (
-  argv: Object,
-  root: Path,
-  onComplete: (results: ?AggregatedResult) => void,
-) => {
-  const pipe = argv.json ? process.stderr : process.stdout;
-  argv = argv || {};
-  if (argv.version) {
-    pipe.write(`v${VERSION}\n`);
-    onComplete && onComplete();
-    return;
-  }
-
-  const _run = async ({config, hasDeprecationWarnings}) => {
-    if (argv.debug) {
-      logDebugMessages(config, pipe);
-    }
-
-    createDirectory(config.cacheDirectory);
-    const hasteMapInstance = Runtime.createHasteMap(config, {
-      console: new Console(pipe, pipe),
-      maxWorkers: getMaxWorkers(argv),
-      resetCache: !config.cache,
-      watch: config.watch,
-    });
-
-    const hasteMap = await hasteMapInstance.build();
-    const hasteContext = createHasteContext(config, hasteMap);
-    if (argv.watch || argv.watchAll) {
-      return watch(
-        config,
-        pipe,
-        argv,
-        hasteMapInstance,
-        hasteContext,
-        hasDeprecationWarnings,
-      );
-    } else {
-      const startRun = () => {
-        preRunMessage.print(pipe);
-        const testWatcher = new TestWatcher({isWatchMode: false});
-        return runJest(
-          hasteContext,
-          config,
-          argv,
-          pipe,
-          testWatcher,
-          startRun,
-          onComplete,
-        );
-      };
-      return startRun();
-    }
-  };
-
-  readConfig(argv, root).then(_run).catch(error => {
-    clearLine(process.stderr);
-    clearLine(process.stdout);
-    console.error(chalk.red(error.stack));
-    process.exit(1);
-  });
-};
 
 module.exports = {
   SearchSource,

--- a/packages/jest-cli/src/runJest.js
+++ b/packages/jest-cli/src/runJest.js
@@ -131,8 +131,9 @@ const runJest = async (
   const data = await source.getTestPaths(patternInfo);
   processTests(data);
   const sequencer = new TestSequencer(config);
-  const results = await runTests(sequencer.sort(data.paths));
-  sequencer.cacheResults(results);
+  const tests = sequencer.sort(data.paths);
+  const results = await runTests(tests);
+  sequencer.cacheResults(tests, results);
   return processResults(results);
 };
 

--- a/packages/jest-cli/src/runJest.js
+++ b/packages/jest-cli/src/runJest.js
@@ -41,7 +41,7 @@ const getTestSummary = (argv: Object, patternInfo: PatternInfo) => {
     chalk.dim('.');
 };
 
-const runJest = (
+const runJest = async (
   hasteContext: HasteContext,
   config: Config,
   argv: Object,
@@ -93,7 +93,7 @@ const runJest = (
     return data;
   };
 
-  const runTests = data => new TestRunner(
+  const runTests = async data => new TestRunner(
     hasteContext,
     config,
     {
@@ -127,14 +127,9 @@ const runJest = (
     return onComplete && onComplete(runResults);
   };
 
-  return source
-    .getTestPaths(patternInfo)
-    .then(processTests)
-    .then(runTests)
-    .then(processResults)
-    .catch(error => {
-      throw error;
-    });
+  const data = await source.getTestPaths(patternInfo);
+  processTests(data);
+  return processResults(await runTests(data));
 };
 
 module.exports = runJest;

--- a/types/TestRunner.js
+++ b/types/TestRunner.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+'use strict';
+
+import type {Config, Path} from './Config';
+
+export type Test = {
+  config: Config,
+  path: Path,
+  duration?: number,
+};
+
+export type Tests = Array<Test>;


### PR DESCRIPTION
**Summary**
This is the preparatory work I did for the multi-config runner. It splits up the test performance cache into a TestSequencer class, uses async/await and moves a few things around. No behavior changes expected. Before merging, I will add a test for the TestSequencer.

See #3156

**Test plan**
jest