### PR TITLE
improve pretty-format coverage

### DIFF
--- a/packages/pretty-format/src/__tests__/ConvertAnsi-test.js
+++ b/packages/pretty-format/src/__tests__/ConvertAnsi-test.js
@@ -48,7 +48,7 @@ describe('ConvertAnsi plugin', () => {
       .toEqual('\"<dim> foo content\"');
   });
 
-  it('don\'t support other colors', () => {
+  it('does not support other colors', () => {
     expect(prettyFormatResult(`${ansiStyle.cyan.open}`))
       .toEqual('\"\"');
   });

--- a/packages/pretty-format/src/__tests__/ConvertAnsi-test.js
+++ b/packages/pretty-format/src/__tests__/ConvertAnsi-test.js
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+/* eslint-disable max-len */
+
+'use strict';
+
+const prettyFormat = require('../');
+const ansiStyle = require('ansi-styles');
+const ConvertAnsiPlugin = require('../plugins/ConvertAnsi');
+
+const prettyFormatResult = (val: string) => {
+  return prettyFormat(
+    val,
+    {
+      plugins: [ConvertAnsiPlugin],
+    },
+  );
+};
+
+describe('ConvertAnsi plugin', () => {
+  it('supports style.red', () => {
+    expect(prettyFormatResult(`${ansiStyle.red.open} foo content ${ansiStyle.red.close}`))
+      .toEqual('\"<red> foo content </>\"');
+  });
+
+  it('supports style.green', () => {
+    expect(prettyFormatResult(`${ansiStyle.green.open} foo content ${ansiStyle.green.close}`))
+      .toEqual('\"<green> foo content </>\"');
+  });
+
+  it('supports style.reset', () => {
+    expect(prettyFormatResult(`${ansiStyle.reset.open} foo content ${ansiStyle.reset.close}`))
+      .toEqual('\"</> foo content </>\"');
+  });
+
+  it('supports style.bold', () => {
+    expect(prettyFormatResult(`${ansiStyle.bold.open} foo content`))
+      .toEqual('\"<bold> foo content\"');
+  });
+
+  it('supports style.dim', () => {
+    expect(prettyFormatResult(`${ansiStyle.dim.open} foo content`))
+      .toEqual('\"<dim> foo content\"');
+  });
+
+  it('don\'t support other colors', () => {
+    expect(prettyFormatResult(`${ansiStyle.cyan.open}`))
+      .toEqual('\"\"');
+  });
+});

--- a/packages/pretty-format/src/__tests__/ConvertAnsi-test.js
+++ b/packages/pretty-format/src/__tests__/ConvertAnsi-test.js
@@ -14,42 +14,49 @@ const ansiStyle = require('ansi-styles');
 const ConvertAnsiPlugin = require('../plugins/ConvertAnsi');
 
 const prettyFormatResult = (val: string) => {
-  return prettyFormat(
-    val,
-    {
-      plugins: [ConvertAnsiPlugin],
-    },
-  );
+  return prettyFormat(val, {
+    plugins: [ConvertAnsiPlugin],
+  });
 };
 
 describe('ConvertAnsi plugin', () => {
   it('supports style.red', () => {
-    expect(prettyFormatResult(`${ansiStyle.red.open} foo content ${ansiStyle.red.close}`))
-      .toEqual('\"<red> foo content </>\"');
+    expect(
+      prettyFormatResult(
+        `${ansiStyle.red.open} foo content ${ansiStyle.red.close}`,
+      ),
+    ).toEqual('"<red> foo content </>"');
   });
 
   it('supports style.green', () => {
-    expect(prettyFormatResult(`${ansiStyle.green.open} foo content ${ansiStyle.green.close}`))
-      .toEqual('\"<green> foo content </>\"');
+    expect(
+      prettyFormatResult(
+        `${ansiStyle.green.open} foo content ${ansiStyle.green.close}`,
+      ),
+    ).toEqual('"<green> foo content </>"');
   });
 
   it('supports style.reset', () => {
-    expect(prettyFormatResult(`${ansiStyle.reset.open} foo content ${ansiStyle.reset.close}`))
-      .toEqual('\"</> foo content </>\"');
+    expect(
+      prettyFormatResult(
+        `${ansiStyle.reset.open} foo content ${ansiStyle.reset.close}`,
+      ),
+    ).toEqual('"</> foo content </>"');
   });
 
   it('supports style.bold', () => {
-    expect(prettyFormatResult(`${ansiStyle.bold.open} foo content`))
-      .toEqual('\"<bold> foo content\"');
+    expect(prettyFormatResult(`${ansiStyle.bold.open} foo content`)).toEqual(
+      '"<bold> foo content"',
+    );
   });
 
   it('supports style.dim', () => {
-    expect(prettyFormatResult(`${ansiStyle.dim.open} foo content`))
-      .toEqual('\"<dim> foo content\"');
+    expect(prettyFormatResult(`${ansiStyle.dim.open} foo content`)).toEqual(
+      '"<dim> foo content"',
+    );
   });
 
   it('does not support other colors', () => {
-    expect(prettyFormatResult(`${ansiStyle.cyan.open}`))
-      .toEqual('\"\"');
+    expect(prettyFormatResult(`${ansiStyle.cyan.open}`)).toEqual('""');
   });
 });

--- a/packages/pretty-format/src/__tests__/pretty-format-test.js
+++ b/packages/pretty-format/src/__tests__/pretty-format-test.js
@@ -640,7 +640,9 @@ describe('prettyFormat()', () => {
     });
 
     it('supports a single element with custom React elements with props', () => {
-      const Cat = () => React.createElement('div');
+      function Cat() {
+        return React.createElement('div');
+      }
       assertPrintedJSX(
         React.createElement('Mouse', {
           prop: React.createElement(Cat, {foo: 'bar'}),
@@ -650,7 +652,9 @@ describe('prettyFormat()', () => {
     });
 
     it('supports a single element with custom React elements with props (using displayName)', () => {
-      const Cat = () => React.createElement('div');
+      function Cat() {
+        return React.createElement('div');
+      }
       Cat.displayName = 'CatDisplayName';
       assertPrintedJSX(
         React.createElement('Mouse', {
@@ -663,14 +667,18 @@ describe('prettyFormat()', () => {
     it('supports a single element with custom React elements with props (using anonymous function)', () => {
       assertPrintedJSX(
         React.createElement('Mouse', {
-          prop: React.createElement(() => React.createElement('div'), {foo: 'bar'}),
+          /* eslint-disable prefer-arrow-callback */
+          prop: React.createElement(function() { React.createElement('div'); }, {foo: 'bar'}),
+          /* eslint-enable prefer-arrow-callback */
         }),
         '<Mouse\n  prop={\n    <Unknown\n      foo="bar"\n    />\n  }\n/>',
       );
     });
 
     it('supports a single element with custom React elements with a child', () => {
-      const Cat = (props: Object) => React.createElement('div', props);
+      function Cat(props) {
+        return React.createElement('div', props);
+      }
       assertPrintedJSX(
         React.createElement('Mouse', {
           prop: React.createElement(Cat, {}, React.createElement('div')),

--- a/packages/pretty-format/src/__tests__/pretty-format-test.js
+++ b/packages/pretty-format/src/__tests__/pretty-format-test.js
@@ -640,9 +640,7 @@ describe('prettyFormat()', () => {
     });
 
     it('supports a single element with custom React elements with props', () => {
-      function Cat() {
-        return React.createElement('div');
-      }
+      const Cat = () => React.createElement('div');
       assertPrintedJSX(
         React.createElement('Mouse', {
           prop: React.createElement(Cat, {foo: 'bar'}),
@@ -651,16 +649,42 @@ describe('prettyFormat()', () => {
       );
     });
 
+    it('supports a single element with custom React elements with props (using displayName)', () => {
+      const Cat = () => React.createElement('div');
+      Cat.displayName = 'CatDisplayName';
+      assertPrintedJSX(
+        React.createElement('Mouse', {
+          prop: React.createElement(Cat, {foo: 'bar'}),
+        }),
+        '<Mouse\n  prop={\n    <CatDisplayName\n      foo="bar"\n    />\n  }\n/>',
+      );
+    });
+
+    it('supports a single element with custom React elements with props (using anonymous function)', () => {
+      assertPrintedJSX(
+        React.createElement('Mouse', {
+          prop: React.createElement(() => React.createElement('div'), {foo: 'bar'}),
+        }),
+        '<Mouse\n  prop={\n    <Unknown\n      foo="bar"\n    />\n  }\n/>',
+      );
+    });
+
     it('supports a single element with custom React elements with a child', () => {
-      function Cat(props) {
-        return React.createElement('div', props);
-      }
+      const Cat = (props: Object) => React.createElement('div', props);
       assertPrintedJSX(
         React.createElement('Mouse', {
           prop: React.createElement(Cat, {}, React.createElement('div')),
         }),
         '<Mouse\n  prop={\n    <Cat>\n      <div />\n    </Cat>\n  }\n/>',
       );
+    });
+
+    it('supports Unknown element', () => {
+      expect(
+        prettyFormat(React.createElement(undefined), {
+          plugins: [ReactElement],
+        })
+      ).toEqual('<Unknown />');
     });
 
     it('supports a single element with React elements with a child', () => {

--- a/packages/pretty-format/src/__tests__/pretty-format-test.js
+++ b/packages/pretty-format/src/__tests__/pretty-format-test.js
@@ -668,7 +668,12 @@ describe('prettyFormat()', () => {
       assertPrintedJSX(
         React.createElement('Mouse', {
           /* eslint-disable prefer-arrow-callback */
-          prop: React.createElement(function() { React.createElement('div'); }, {foo: 'bar'}),
+          prop: React.createElement(
+            function() {
+              React.createElement('div');
+            },
+            {foo: 'bar'},
+          ),
           /* eslint-enable prefer-arrow-callback */
         }),
         '<Mouse\n  prop={\n    <Unknown\n      foo="bar"\n    />\n  }\n/>',
@@ -691,7 +696,7 @@ describe('prettyFormat()', () => {
       expect(
         prettyFormat(React.createElement(undefined), {
           plugins: [ReactElement],
-        })
+        }),
       ).toEqual('<Unknown />');
     });
 


### PR DESCRIPTION
**Summary**

The motivation of this PR is to improve `pretty-format` package test coverage.
Old coverage:
![image](https://cloud.githubusercontent.com/assets/1692542/24027752/141bb546-0a87-11e7-8c17-46ba7a525a0f.png)

New coverage:
![image](https://cloud.githubusercontent.com/assets/1692542/24027733/f73c38ec-0a86-11e7-838c-7860411e9316.png)


**Test plan**
`yarn test-ci`
