### PR TITLE
Update ManualMocks.md

### DIFF
--- a/docs/ManualMocks.md
+++ b/docs/ManualMocks.md
@@ -10,12 +10,7 @@ next: webpack
 
 Manual mocks are used to stub out functionality with mock data. For example, instead of accessing a remote resource like a website or a database, you might want to create a manual mock that allows you to use fake data. This ensures your tests will be fast and not flaky.
 
-Manual mocks are defined by writing a module in a `__mocks__/` subdirectory
-immediately adjacent to the module. For example, to mock a module called
-``user`` in the ``models`` directory, create a file called ``user.js`` and
-put it in the ``models/__mocks__`` directory. If the module you are mocking 
-is a node module (eg: `fs`), the mock should be placed in the ``__mocks__`` 
-folder adjacent to ``node_modules``. Eg:
+Manual mocks are defined by writing a module in a `__mocks__/` subdirectory immediately adjacent to the module. For example, to mock a module called `user` in the `models` directory, create a file called `user.js` and put it in the `models/__mocks__` directory. If the module you are mocking is a node module (eg: `fs`), the mock should be placed in the `__mocks__` folder adjacent to `node_modules`. Eg:
 
 ```bash
 .

--- a/docs/ManualMocks.md
+++ b/docs/ManualMocks.md
@@ -14,14 +14,14 @@ Manual mocks are defined by writing a module in a `__mocks__/` subdirectory
 immediately adjacent to the module. For example, to mock a module called
 ``user`` in the ``models`` directory, create a file called ``user.js`` and
 put it in the ``models/__mocks__`` directory. If the module you are mocking is
-a node module (eg: `fs`), the mock should be placed in the same parent
-directory as the ``node_modules`` folder. Eg:
+a node module (eg: `fs`), the it should be placed in a mock folder in the same 
+parent directory as the ``node_modules`` folder. Eg:
 
 ```bash
 .
 ├── config
-├── fs.js
 ├── __mocks__
+│   └── fs.js
 ├── models
 │   ├── __mocks__
 │   │   └── user.js

--- a/docs/ManualMocks.md
+++ b/docs/ManualMocks.md
@@ -10,7 +10,7 @@ next: webpack
 
 Manual mocks are used to stub out functionality with mock data. For example, instead of accessing a remote resource like a website or a database, you might want to create a manual mock that allows you to use fake data. This ensures your tests will be fast and not flaky.
 
-Manual mocks are defined by writing a module in a `__mocks__/` subdirectory immediately adjacent to the module. For example, to mock a module called `user` in the `models` directory, create a file called `user.js` and put it in the `models/__mocks__` directory. If the module you are mocking is a node module (eg: `fs`), the mock should be placed in the `__mocks__` folder adjacent to `node_modules`. Eg:
+Manual mocks are defined by writing a module in a `__mocks__/` subdirectory immediately adjacent to the module. For example, to mock a module called `user` in the `models` directory, create a file called `user.js` and put it in the `models/__mocks__` directory. If the module you are mocking is a node module (eg: `fs`), the mock should be placed in the `__mocks__` directory adjacent to `node_modules`. Eg:
 
 ```bash
 .

--- a/docs/ManualMocks.md
+++ b/docs/ManualMocks.md
@@ -13,9 +13,9 @@ Manual mocks are used to stub out functionality with mock data. For example, ins
 Manual mocks are defined by writing a module in a `__mocks__/` subdirectory
 immediately adjacent to the module. For example, to mock a module called
 ``user`` in the ``models`` directory, create a file called ``user.js`` and
-put it in the ``models/__mocks__`` directory. If the module you are mocking is
-a node module (eg: `fs`), the it should be placed in a mock folder in the same 
-parent directory as the ``node_modules`` folder. Eg:
+put it in the ``models/__mocks__`` directory. If the module you are mocking 
+is a node module (eg: `fs`), the mock should be placed in the ``__mocks__`` 
+folder adjacent to node_modules. Eg:
 
 ```bash
 .

--- a/docs/ManualMocks.md
+++ b/docs/ManualMocks.md
@@ -15,7 +15,7 @@ immediately adjacent to the module. For example, to mock a module called
 ``user`` in the ``models`` directory, create a file called ``user.js`` and
 put it in the ``models/__mocks__`` directory. If the module you are mocking 
 is a node module (eg: `fs`), the mock should be placed in the ``__mocks__`` 
-folder adjacent to node_modules. Eg:
+folder adjacent to ``node_modules``. Eg:
 
 ```bash
 .


### PR DESCRIPTION
**Summary**
In the code example, the fs.js mock file is described as being in ``__mocks__/fs.js``, but in the folder diagram, ``__mocks__`` appears to be empty, and `fs.js` is at the root level. This PR corrects that.

**Test plan**
Just documentation :)