### PR TITLE
Update the jest-editor babylon parser to return an empty JSON object + CRA changes

### DIFF
--- a/packages/jest-editor-support/src/parsers/BabylonParser.js
+++ b/packages/jest-editor-support/src/parsers/BabylonParser.js
@@ -20,9 +20,12 @@ const fs = require('fs');
 const BABELRC_FILENAME = '.babelrc';
 const cache = Object.create(null);
 
-// This is an exact copy of babel-jest's parser
+// This is a copy of babel-jest's parser, but it takes create-react-app
+// into account, and will return an empty JSON object instead of "".
 const getBabelRC = (filename, {useCache}) => {
-  const paths = [];
+
+  // Special case for create-react-app, which hides the .babelrc
+  const paths: string[] = ['node_modules/react-scripts/'];
   let directory = filename;
   while (directory !== (directory = path.dirname(directory))) {
     if (useCache && cache[directory]) {
@@ -40,7 +43,8 @@ const getBabelRC = (filename, {useCache}) => {
     cache[directoryPath] = cache[directory];
   });
 
-  return cache[directory] || '';
+  // return an empy JSON parse compatible string
+  return cache[directory] || '{}';
 };
 
 const parse = (file: string) => {


### PR DESCRIPTION
**Summary**

Took a look at https://github.com/orta/vscode-jest/issues/85

The `getBabelRC` currently returns `""` as it was based on the original, but really, the results get thrown directly into `JSON.parse` in the `parse` function. Which raises. We don't want that.

**Test plan**

Kinda hoping everything greens, I couldn't get a working set up locally :D