### PR TITLE
no-weak-types and require-valid-file-annotation rules were added to e…

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,7 +3,7 @@
   "parser": "babel-eslint",
   "rules": {
     "no-multiple-empty-lines": 1,
-    "require-valid-file-annotation": 1
+    "flowtype/require-valid-file-annotation": 2
   },
   "plugins": [
     "markdown"

--- a/.eslintrc
+++ b/.eslintrc
@@ -2,7 +2,8 @@
   "extends": "./packages/eslint-config-fb-strict/index.js",
   "parser": "babel-eslint",
   "rules": {
-    "no-multiple-empty-lines": 1
+    "no-multiple-empty-lines": 1,
+    "require-valid-file-annotation": 1
   },
   "plugins": [
     "markdown"

--- a/packages/eslint-config-fb-strict/index.js
+++ b/packages/eslint-config-fb-strict/index.js
@@ -38,6 +38,7 @@ module.exports = Object.assign({}, fbjsConfig, {
     'comma-style': [2, 'last'],
     'computed-property-spacing': [2, 'never'],
     'eol-last': [2],
+    'flowtype/no-weak-types': [2],
     'flowtype/object-type-delimiter': [2, 'comma'],
     'indent': [0],
     'jest/no-focused-tests': [2],

--- a/packages/eslint-config-fb-strict/index.js
+++ b/packages/eslint-config-fb-strict/index.js
@@ -38,7 +38,6 @@ module.exports = Object.assign({}, fbjsConfig, {
     'comma-style': [2, 'last'],
     'computed-property-spacing': [2, 'never'],
     'eol-last': [2],
-    'flowtype/no-weak-types': [2],
     'flowtype/object-type-delimiter': [2, 'comma'],
     'indent': [0],
     'jest/no-focused-tests': [2],


### PR DESCRIPTION
eslint-plugin-flowtype configuration updates

**Summary**

[require-valid-file-annotation](https://github.com/gajus/eslint-plugin-flowtype#require-valid-file-annotation) rule was added. The rule produces warnings.

**Test plan**
yarn install
./node_modules/.bin/eslint .
