### PR TITLE
Fix done.fail not passing arguments

### DIFF
--- a/packages/jest-jasmine2/src/__tests__/queueRunner-test.js
+++ b/packages/jest-jasmine2/src/__tests__/queueRunner-test.js
@@ -117,4 +117,17 @@ describe('queueRunner', () => {
     );
     expect(fnTwo).toHaveBeenCalled();
   });
+
+  it('calls `fail` with arguments', async () => {
+    const failFn = jest.fn(next => next.fail('miserably', 'failed'));
+    const options = {
+      clearTimeout,
+      fail: jest.fn(),
+      queueableFns: [{fn: failFn}],
+      setTimeout,
+    };
+    await queueRunner(options);
+
+    expect(options.fail).toHaveBeenCalledWith('miserably', 'failed');
+  });
 });

--- a/packages/jest-jasmine2/src/queueRunner.js
+++ b/packages/jest-jasmine2/src/queueRunner.js
@@ -31,7 +31,7 @@ function queueRunner(options: Options) {
   const mapper = ({fn, timeout}) => {
     const promise = new Promise(resolve => {
       const next = once(resolve);
-      next.fail = () => {
+      next.fail = function() {
         options.fail.apply(null, arguments);
         resolve();
       };

--- a/packages/jest-jasmine2/src/treeProcessor.js
+++ b/packages/jest-jasmine2/src/treeProcessor.js
@@ -74,7 +74,7 @@ function treeProcessor(options: Options) {
       throw new Error('`node.children` is not defined.');
     }
     const children = node.children.map(child => executeNode(child, enabled));
-    return [...node.beforeAllFns, ...children, ...node.afterAllFns];
+    return node.beforeAllFns.concat(children).concat(node.afterAllFns);
   }
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Fixes `done.fail()` not passing arguments. Arrow functions don't bind `arguments`, so I used a regular function instead. 
Thanks @jwbay.

**Test plan**

Added a test for that.
