### PR TITLE
Clarify docs: resolves is introduced in v20

### DIFF
--- a/docs/TestingAsyncCode.md
+++ b/docs/TestingAsyncCode.md
@@ -48,6 +48,8 @@ If `done()` is never called, the test will fail, which is what you want to happe
 
 ### Promises
 
+##### available in Jest **20.0.0+**
+
 If your code uses promises, there is a simpler way to handle asynchronous tests. Just use the `resolves` keyword in your expect statement, and Jest will wait for that promise to resolve. If the promise is rejected, the test will automatically fail.
 
 For example, let's say that `fetchData`, instead of using a callback, returns a promise that is supposed to resolve to the string `"peanut butter"`. We could test it with:

--- a/docs/TutorialAsync.md
+++ b/docs/TutorialAsync.md
@@ -68,7 +68,7 @@ export default function request(url) {
 }
 ```
 
-Now let's write a test for our async functionality. Using the `resolves` keyword
+Now let's write a test for our async functionality. Using the `resolves` keyword (available in Jest **20.0.0+**)
 ```js
 // __tests__/user-test.js
 jest.mock('../request');


### PR DESCRIPTION
The [Testing Asynchronous Code](http://facebook.github.io/jest/docs/asynchronous.html) and [Async Example](http://facebook.github.io/jest/docs/tutorial-async.html) in the docs currently make no mention of the fact that `expect.resolves()` will not be available until v20.0+.

A [similar caveat was added](https://github.com/facebook/jest/pull/3172/commits/797af540890e6ea4f906beb3f1fb7f9169edb711) to the [Expect API ](http://facebook.github.io/jest/docs/expect.html) page.
