### PR TITLE
improve code coverage

### DIFF
--- a/packages/jest-matcher-utils/src/__tests__/index-test.js
+++ b/packages/jest-matcher-utils/src/__tests__/index-test.js
@@ -10,7 +10,13 @@
 
 'use strict';
 
-const {stringify, getType} = require('../');
+const {
+  stringify,
+  getType,
+  ensureNumbers,
+  pluralize,
+  ensureNoExpected,
+} = require('../');
 
 describe('.stringify()', () => {
   [
@@ -99,4 +105,51 @@ describe('.getType()', () => {
   test('symbol', () => expect(getType(Symbol.for('a'))).toBe('symbol'));
   test('regexp', () => expect(getType(/abc/)).toBe('regexp'));
   test('map', () => expect(getType(new Map())).toBe('map'));
+  test('set', () => expect(getType(new Set())).toBe('set'));
+});
+
+describe('.ensureNumbers()', () => {
+  test('dont throw error when variables are numbers', () => {
+    expect(() => {
+      ensureNumbers(1, 2);
+    }).not.toThrow();
+  });
+
+  test('throws error when expected is not a number', () => {
+    expect(() => {
+      ensureNumbers(1, 'not_a_number');
+    }).toThrow('Expected value must be a number');
+  });
+
+  test('throws error when actual is not a number', () => {
+    expect(() => {
+      ensureNumbers('not_a_number', 3);
+    }).toThrow('Received value must be a number');
+  });
+});
+
+describe('.ensureNoExpected()', () => {
+  test('dont throw error when undefined', () => {
+    expect(() => {
+      ensureNoExpected(undefined);
+    }).not.toThrow();
+  });
+
+  test('throws error when is not undefined', () => {
+    expect(() => {
+      ensureNoExpected({a: 1});
+    }).toThrow('Matcher does not accept any arguments');
+  });
+
+  test('throws error when is not undefined with matcherName', () => {
+    expect(() => {
+      ensureNoExpected({a: 1}, '.toBeDefined');
+    }).toThrow('Matcher does not accept any arguments');
+  });
+});
+
+describe('.pluralize()', () => {
+  test('one', () => expect(pluralize('apple', 1)).toEqual('one apple'));
+  test('two', () => expect(pluralize('apple', 2)).toEqual('two apples'));
+  test('20', () => expect(pluralize('apple', 20)).toEqual('20 apples'));
 });

--- a/packages/jest-message-util/src/__tests__/__snapshots__/messages-test.js.snap
+++ b/packages/jest-message-util/src/__tests__/__snapshots__/messages-test.js.snap
@@ -1,5 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`.formatExecError() 1`] = `
+"  <bold>● Test suite failed to run
+
+    Whoops!
+"
+`;
+
 exports[`should exclude jasmine from stack trace for Unix paths. 1`] = `
 "<bold><red>  <bold>● <bold>Unix test</>
 

--- a/packages/jest-message-util/src/__tests__/messages-test.js
+++ b/packages/jest-message-util/src/__tests__/messages-test.js
@@ -9,7 +9,7 @@
  */
 'use strict';
 
-const {formatResultsErrors} = require('../messages');
+const {formatResultsErrors, formatExecError} = require('../');
 
 const unixStackTrace = `  ` +
   `at stack (../jest-jasmine2/build/jasmine-2.4.1.js:1580:17)
@@ -38,4 +38,21 @@ it('should exclude jasmine from stack trace for Unix paths.', () => {
   );
 
   expect(messages).toMatchSnapshot();
+});
+
+it('.formatExecError()', () => {
+  const message = formatExecError(
+    {
+      testExecError: {
+        message: 'Whoops!',
+      },
+      testFilePath: '/test/error/file/path',
+    },
+    {
+      noStackTrace: false,
+    },
+    'path_test',
+  );
+
+  expect(message).toMatchSnapshot();
 });

--- a/packages/jest-mock/src/__tests__/jest-mock-test.js
+++ b/packages/jest-mock/src/__tests__/jest-mock-test.js
@@ -35,6 +35,28 @@ describe('moduleMocker', () => {
       expect(moduleMocker.getMetadata(27).value).toEqual(27);
       expect(moduleMocker.getMetadata(false).value).toEqual(false);
     });
+
+    it('does not retrieve metadata for arrays', () => {
+      const array = [1, 2, 3];
+      const metadata = moduleMocker.getMetadata(array);
+      expect(metadata.value).toBeUndefined();
+      expect(metadata.members).toBeUndefined();
+      expect(metadata.type).toEqual('array');
+    });
+
+    it('does not retrieve metadata for undefined', () => {
+      const metadata = moduleMocker.getMetadata(undefined);
+      expect(metadata.value).toBeUndefined();
+      expect(metadata.members).toBeUndefined();
+      expect(metadata.type).toEqual('undefined');
+    });
+
+    it('does not retrieve metadata for null', () => {
+      const metadata = moduleMocker.getMetadata(null);
+      expect(metadata.value).toBeNull();
+      expect(metadata.members).toBeUndefined();
+      expect(metadata.type).toEqual('null');
+    });
   });
 
   describe('generateFromMetadata', () => {


### PR DESCRIPTION
**Summary**
improve some code coverage for the packages `jest-message-util`, `jest-mock` and `jest-matcher-utils`

![image](https://cloud.githubusercontent.com/assets/1692542/24695283/0ae410a0-199a-11e7-8e3b-b745463d3b7f.png)
![image](https://cloud.githubusercontent.com/assets/1692542/24695290/0fdd5ddc-199a-11e7-9520-c365f4cb103b.png)
![image](https://cloud.githubusercontent.com/assets/1692542/24695318/28f88b16-199a-11e7-8436-d683d97992de.png)


**Test plan**
`yarn test`
