### PR TITLE
Add support for Babel 7 in babel-jest

### DIFF
--- a/packages/babel-jest/src/index.js
+++ b/packages/babel-jest/src/index.js
@@ -42,7 +42,8 @@ const getBabelRC = (filename, {useCache}) => {
     }
     const configJsFilePath = path.join(directory, BABELRC_JS_FILENAME);
     if (fs.existsSync(configJsFilePath)) {
-      cache[directory] = JSON.stringify((require : any)(configJsFilePath));
+      // $FlowFixMe
+      cache[directory] = JSON.stringify(require(configJsFilePath));
       break;
     }
   }

--- a/packages/babel-jest/src/index.js
+++ b/packages/babel-jest/src/index.js
@@ -19,6 +19,7 @@ const jestPreset = require('babel-preset-jest');
 const path = require('path');
 
 const BABELRC_FILENAME = '.babelrc';
+const BABELRC_JS_FILENAME = '.babelrc.js';
 const THIS_FILE = fs.readFileSync(__filename);
 
 const cache = Object.create(null);
@@ -37,6 +38,11 @@ const getBabelRC = (filename, {useCache}) => {
     const configFilePath = path.join(directory, BABELRC_FILENAME);
     if (fs.existsSync(configFilePath)) {
       cache[directory] = fs.readFileSync(configFilePath, 'utf8');
+      break;
+    }
+    const configJsFilePath = path.join(directory, BABELRC_JS_FILENAME);
+    if (fs.existsSync(configJsFilePath)) {
+      cache[directory] = JSON.stringify(require(configJsFilePath));
       break;
     }
   }
@@ -91,7 +97,7 @@ const createTransformer = (options: any) => {
         babel = require('babel-core');
       }
 
-      if (!babel.util.canCompile(filename)) {
+      if (babel.util && !babel.util.canCompile(filename)) {
         return src;
       }
 

--- a/packages/babel-jest/src/index.js
+++ b/packages/babel-jest/src/index.js
@@ -42,7 +42,7 @@ const getBabelRC = (filename, {useCache}) => {
     }
     const configJsFilePath = path.join(directory, BABELRC_JS_FILENAME);
     if (fs.existsSync(configJsFilePath)) {
-      cache[directory] = JSON.stringify(require(configJsFilePath));
+      cache[directory] = JSON.stringify((require : any)(configJsFilePath));
       break;
     }
   }


### PR DESCRIPTION
**Summary**

Adds support for Babel 7:
- loading from `.babelrc.js` file
- babel deprecated and removed `babel.util` (no need for it, [apparently](https://github.com/babel/babel/pull/5487))

**Test plan**

I've tested this locally and it works well. The changes are pretty minimal.

The question I have is why was the `canCompile` call there in the first place? Here's the PR to Babel that removed the util: https://github.com/babel/babel/pull/5487. It recommends simply calling `.transform` instead (which is currently being done anyway.