### PR TITLE
[lifecycle hooks] Make afterAll hooks operate in the fashion as afterEach.

### DIFF
--- a/packages/jest-jasmine2/src/__tests__/integration/lifecycle-hooks-test.js
+++ b/packages/jest-jasmine2/src/__tests__/integration/lifecycle-hooks-test.js
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails oncall+jsinfra
+ */
+'use strict';
+
+describe('test lifecycle hooks', () => {
+  const actions = [];
+  function pushMessage(message) {
+    return () => {
+      actions.push(message);
+    };
+  }
+
+  // Validate in an afterAll to prevent previous hooks from firing again.
+  // Note that when operating correctly, this afterAll will be called last.
+  afterAll(() => {
+    const expected = [
+      'runner beforeAll1',
+      'runner beforeAll2',
+      'runner beforeEach1',
+      'runner beforeEach2',
+      'beforeEach1',
+      'beforeEach2',
+      'outer it 1',
+      'afterEach2',
+      'afterEach1',
+      'runner afterEach2',
+      'runner afterEach1',
+      'runner afterAll2',
+      'runner afterAll1',
+    ];
+
+    expect(actions).toEqual(expected);
+  });
+
+  beforeAll(pushMessage('runner beforeAll1'));
+  afterAll(pushMessage('runner afterAll1'));
+  beforeAll(pushMessage('runner beforeAll2'));
+  afterAll(pushMessage('runner afterAll2'));
+  beforeEach(pushMessage('runner beforeEach1'));
+  afterEach(pushMessage('runner afterEach1'));
+  beforeEach(pushMessage('runner beforeEach2'));
+  afterEach(pushMessage('runner afterEach2'));
+
+  describe('Something', () => {
+    beforeEach(pushMessage('beforeEach1'));
+    afterEach(pushMessage('afterEach1'));
+    beforeEach(pushMessage('beforeEach2'));
+    afterEach(pushMessage('afterEach2'));
+    it('does it 1', pushMessage('outer it 1'));
+  });
+});

--- a/packages/jest-jasmine2/src/jasmine/Suite.js
+++ b/packages/jest-jasmine2/src/jasmine/Suite.js
@@ -92,7 +92,7 @@ Suite.prototype.afterEach = function(fn) {
 };
 
 Suite.prototype.afterAll = function(fn) {
-  this.afterAllFns.push(fn);
+  this.afterAllFns.unshift(fn);
 };
 
 Suite.prototype.addChild = function(child) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

It was discovered that afterAll hooks run in the same order that you add them,
while afterEach hooks were running in reverse order.  This commit makes their
order consistent, and adds regression tests.

Relevant issue - #3268

Note that even if this test were failing, it occurs in an afterAll hook which doesn't currently fail w/ errors.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

I added tests in the relevant package and tested with a combination of `yarn run build` and `yarn run jest ./packages/jest-jasmine2/src/__tests__/integration`.

The new tests were adapted from a similar set of tests in Jasmine.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
