### PR TITLE
Docs: Ensure consistency of example in SnapshotTesting.md

### DIFF
--- a/docs/SnapshotTesting.md
+++ b/docs/SnapshotTesting.md
@@ -30,13 +30,14 @@ it('renders correctly', () => {
 
 The first time this test is run, Jest creates a [snapshot file](https://github.com/facebook/jest/blob/master/examples/snapshot/__tests__/__snapshots__/Link.react-test.js.snap) that looks like this:
 
-```json
-exports[`Link renders correctly 1`] = `
+```javascript
+exports[`renders correctly 1`] = `
 <a
   className="normal"
   href="http://www.facebook.com"
   onMouseEnter={[Function]}
-  onMouseLeave={[Function]}>
+  onMouseLeave={[Function]}
+>
   Facebook
 </a>
 `;


### PR DESCRIPTION
**Summary**

Ensures consistency of [snapshot example](https://github.com/facebook/jest/blob/master/examples/snapshot/__tests__/__snapshots__/Link.react-test.js.snap#L58-L67) in `docs/SnapshotTesting.md`.

**Test plan**

Modification of documentation.