### PR TITLE
Update configuration docs about @jest-environment

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -365,7 +365,7 @@ To make a dependency explicit instead of implicit, you can call [`expect.addSnap
 ### `testEnvironment` [string]
 Default: `"jsdom"`
 
-The test environment that will be used for testing. The default environment in Jest is a browser-like environment through [jsdom](https://github.com/tmpvar/jsdom). If you are building a node service, you can use the `node` option to use a node-like environment instead. If some tests require another environment, you can add a `@jest-environment` docblock.
+The test environment that will be used for testing. The default environment in Jest is a browser-like environment through [jsdom](https://github.com/tmpvar/jsdom). If you are building a node service, you can use the `node` option to use a node-like environment instead. If some tests require another environment, you can add a `@jest-environment` docblock (available in Jest **20.0.0+**).
 
 ```js
 /**

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -365,7 +365,10 @@ To make a dependency explicit instead of implicit, you can call [`expect.addSnap
 ### `testEnvironment` [string]
 Default: `"jsdom"`
 
-The test environment that will be used for testing. The default environment in Jest is a browser-like environment through [jsdom](https://github.com/tmpvar/jsdom). If you are building a node service, you can use the `node` option to use a node-like environment instead. If some tests require another environment, you can add a `@jest-environment` docblock (available in Jest **20.0.0+**).
+The test environment that will be used for testing. The default environment in Jest is a browser-like environment through [jsdom](https://github.com/tmpvar/jsdom). If you are building a node service, you can use the `node` option to use a node-like environment instead. 
+
+If some tests require another environment, you can add a `@jest-environment` docblock.
+##### available in Jest **19.0.0+**
 
 ```js
 /**


### PR DESCRIPTION
The @jest-environment docblock is a feature that's coming in Jest version 20.0.0.
This commit adds this information to the documentation.