### PR TITLE
Add JSON to the list of recommended moduleFileExtensions for TS users

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -115,7 +115,8 @@ then modify your `package.json` so the `jest` section looks something like:
     "moduleFileExtensions": [
       "ts",
       "tsx",
-      "js"
+      "js",
+      "json"
     ]
   }
 }


### PR DESCRIPTION
Fixes #3282 

As the default is `moduleFileExtensions: ['js', 'json', 'jsx', 'node'],` I think it makes sense to add the `".json"`. Should we add the `"node"` -  I've never seen the filetype before?