### PR TITLE
Clears screen during watch mode correctly.

### DIFF
--- a/packages/jest-cli/src/watch.js
+++ b/packages/jest-cli/src/watch.js
@@ -16,6 +16,8 @@ const ansiEscapes = require('ansi-escapes');
 const chalk = require('chalk');
 const createContext = require('./lib/createContext');
 const HasteMap = require('jest-haste-map');
+const isCI = require('is-ci');
+const isInteractive = process.stdout.isTTY && !isCI;
 const isValidPath = require('./lib/isValidPath');
 const preRunMessage = require('./preRunMessage');
 const runJest = require('./runJest');
@@ -86,7 +88,7 @@ const watch = (
     }
 
     testWatcher = new TestWatcher({isWatchMode: true});
-    pipe.write(CLEAR);
+    isInteractive && pipe.write(CLEAR);
     preRunMessage.print(pipe);
     isRunning = true;
     return runJest(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
This change is to prevent the screen from clearing when building for Continuous Integration systems. While the `--watch` flag typically wouldn't be used on a CI system, this change gives us a hook into disabling the clear feature that can prevent other processes' output from being seen during a typical development workflow.

**Test plan**
I was able to verify this worked using the `CI=true jest --watchAll` npm-script in my project. Without the `CI` value set, the standard behavior of the screen clearing between watch runs, occurs.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Fixes #2959.