### PR TITLE
Add --showConfig argument

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -161,6 +161,10 @@ Alias: `-i`. Run all tests serially in the current process, rather than creating
 
 The path to a module that runs some code to configure or set up the testing framework before each test.
 
+### `--showConfig`
+
+Print your jest config and then exits.
+
 ### `--silent`
 
 Prevent tests from printing messages through the console.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -163,7 +163,7 @@ The path to a module that runs some code to configure or set up the testing fram
 
 ### `--showConfig`
 
-Print your jest config and then exits.
+Print your Jest config and then exits.
 
 ### `--silent`
 

--- a/integration_tests/__tests__/__snapshots__/showConfig-test.js.snap
+++ b/integration_tests/__tests__/__snapshots__/showConfig-test.js.snap
@@ -1,0 +1,83 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`jest --showConfig outputs config info and exits 1`] = `
+{
+  "version": "19.0.2",
+  "framework": "jasmine2",
+  "config": {
+    "automock": false,
+    "bail": false,
+    "browser": false,
+    "cacheDirectory": "/tmp/jest",
+    "clearMocks": false,
+    "coveragePathIgnorePatterns": [
+      "/node_modules/"
+    ],
+    "coverageReporters": [
+      "json",
+      "text",
+      "lcov",
+      "clover"
+    ],
+    "expand": false,
+    "globals": {},
+    "haste": {
+      "providesModuleNodeModules": []
+    },
+    "mapCoverage": false,
+    "moduleDirectories": [
+      "node_modules"
+    ],
+    "moduleFileExtensions": [
+      "js",
+      "json",
+      "jsx",
+      "node"
+    ],
+    "moduleNameMapper": {},
+    "modulePathIgnorePatterns": [],
+    "noStackTrace": false,
+    "notify": false,
+    "preset": null,
+    "resetMocks": false,
+    "resetModules": false,
+    "roots": [
+      "/mocked/root/path/jest/integration_tests/verbose_reporter"
+    ],
+    "snapshotSerializers": [],
+    "testEnvironment": "/mocked/root/path/jest/packages/jest-environment-node/build/index.js",
+    "testMatch": [
+      "**/__tests__/**/*.js?(x)",
+      "**/?(*.)(spec|test).js?(x)"
+    ],
+    "testPathIgnorePatterns": [
+      "/node_modules/"
+    ],
+    "testRegex": "",
+    "testResultsProcessor": null,
+    "testURL": "about:blank",
+    "timers": "real",
+    "transformIgnorePatterns": [
+      "/node_modules/"
+    ],
+    "useStderr": false,
+    "verbose": null,
+    "watch": false,
+    "rootDir": "/mocked/root/path/jest/integration_tests/verbose_reporter",
+    "name": "[md5 hash]",
+    "setupFiles": [
+      "/mocked/root/path/jest/node_modules/regenerator-runtime/runtime.js"
+    ],
+    "testRunner": "/mocked/root/path/jest/packages/jest-jasmine2/build/index.js",
+    "transform": [
+      [
+        "^.+\\\\.jsx?$",
+        "/mocked/root/path/jest/integration_tests/verbose_reporter/node_modules/babel-jest/build/index.js"
+      ]
+    ],
+    "cache": false,
+    "watchman": true
+  }
+}
+
+`;

--- a/integration_tests/__tests__/showConfig-test.js
+++ b/integration_tests/__tests__/showConfig-test.js
@@ -13,7 +13,7 @@ const path = require('path');
 const runJest = require('../runJest');
 const skipOnWindows = require('skipOnWindows');
 
-describe('jest --debug', () => {
+describe('jest --showConfig', () => {
   skipOnWindows.suite();
 
   const dir = path.resolve(__dirname, '..', 'verbose_reporter');
@@ -24,11 +24,16 @@ describe('jest --debug', () => {
     }
   });
 
-  it('outputs debugging info before running the test', () => {
-    const {stdout} = runJest(dir, ['--debug', '--no-cache']);
-    expect(stdout).toMatch('"version": "');
-    expect(stdout).toMatch('"framework": "jasmine2",');
-    expect(stdout).toMatch('"config": {');
-    // config contains many file paths so we cannot do snapshot test
+  it('outputs config info and exits', () => {
+    const root = path.join(__dirname, '..', '..', '..');
+    expect.addSnapshotSerializer({
+      print: val => val
+        .replace(new RegExp(root, 'g'), '/mocked/root/path')
+        .replace(/"name": "(.+)"/, '"name": "[md5 hash]"')
+        .replace(/"cacheDirectory": "(.+)"/, '"cacheDirectory": "/tmp/jest"'),
+      test: val => typeof val === 'string',
+    });
+    const {stdout} = runJest(dir, ['--showConfig', '--no-cache']);
+    expect(stdout).toMatchSnapshot();
   });
 });

--- a/packages/jest-cli/src/cli/args.js
+++ b/packages/jest-cli/src/cli/args.js
@@ -189,6 +189,10 @@ const options = {
       'set up the testing framework before each test.',
     type: 'string',
   },
+  showConfig: {
+    description: 'Print your jest config and then exits.',
+    type: 'boolean',
+  },
   silent: {
     default: false,
     description: 'Prevent tests from printing messages through the console.',

--- a/packages/jest-cli/src/cli/runCLI.js
+++ b/packages/jest-cli/src/cli/runCLI.js
@@ -46,8 +46,12 @@ module.exports = (
   }
 
   const _run = async ({config, hasDeprecationWarnings}) => {
-    if (argv.debug) {
+    if (argv.debug || argv.showConfig) {
       logDebugMessages(config, pipe);
+    }
+
+    if (argv.showConfig) {
+      process.exit(0);
     }
 
     createDirectory(config.cacheDirectory);

--- a/packages/jest-cli/src/lib/__tests__/logDebugMessages-test.js
+++ b/packages/jest-cli/src/lib/__tests__/logDebugMessages-test.js
@@ -8,6 +8,8 @@
 * @emails oncall+jsinfra
 */
 
+'use strict';
+
 const logDebugMessages = require('../logDebugMessages');
 
 jest.mock('../../../package.json', () => ({version: 123}));
@@ -15,42 +17,42 @@ jest.mock('../../../package.json', () => ({version: 123}));
 jest.mock('myRunner', () => ({name: 'My Runner'}), {virtual: true});
 
 const getPipe = () => ({write: jest.fn()});
+/* eslint-disable */
+const makeOutput = (config = {testRunner: 'myRunner'}) =>
+  JSON.stringify(
+    {
+      version: 123,
+      framework: 'My Runner',
+      config,
+    },
+    null,
+    '  ',
+  );
+/* eslint-enable */
 
 describe('logDebugMessages', () => {
   it('Prints the jest version', () => {
     const pipe = getPipe();
     logDebugMessages({testRunner: 'myRunner'}, pipe);
-    expect(pipe.write).toHaveBeenCalledWith('jest version = 123\n');
+    expect(pipe.write).toHaveBeenCalledWith(makeOutput() + '\n');
   });
 
   it('Prints the test framework name', () => {
     const pipe = getPipe();
     logDebugMessages({testRunner: 'myRunner'}, pipe);
-    expect(pipe.write).toHaveBeenCalledWith('test framework = My Runner\n');
+    expect(pipe.write).toHaveBeenCalledWith(makeOutput() + '\n');
   });
 
   it('Prints the config object', () => {
     const pipe = getPipe();
-    logDebugMessages(
-      {
-        automock: false,
-        rootDir: '/path/to/dir',
-        roots: ['path/to/dir/test'],
-        testRunner: 'myRunner',
-        watch: true,
-      },
-      pipe,
-    );
-    expect(pipe.write).toHaveBeenCalledWith(
-      `config = {
-  "automock": false,
-  "rootDir": "/path/to/dir",
-  "roots": [
-    "path/to/dir/test"
-  ],
-  "testRunner": "myRunner",
-  "watch": true
-}\n`,
-    );
+    const config = {
+      automock: false,
+      rootDir: '/path/to/dir',
+      roots: ['path/to/dir/test'],
+      testRunner: 'myRunner',
+      watch: true,
+    };
+    logDebugMessages(config, pipe);
+    expect(pipe.write).toHaveBeenCalledWith(makeOutput(config) + '\n');
   });
 });

--- a/packages/jest-cli/src/lib/logDebugMessages.js
+++ b/packages/jest-cli/src/lib/logDebugMessages.js
@@ -20,9 +20,14 @@ const logDebugMessages = (
 ): void => {
   /* $FlowFixMe */
   const testFramework = require(config.testRunner);
-  pipe.write('jest version = ' + VERSION + '\n');
-  pipe.write('test framework = ' + testFramework.name + '\n');
-  pipe.write('config = ' + JSON.stringify(config, null, '  ') + '\n');
+  /* eslint-disable sort-keys */
+  const output = {
+    version: VERSION,
+    framework: testFramework.name,
+    config,
+  };
+  /* eslint-enable sort-keys */
+  pipe.write(JSON.stringify(output, null, '  ') + '\n');
 };
 
 module.exports = logDebugMessages;

--- a/packages/jest-editor-support/src/__tests__/Settings-test.js
+++ b/packages/jest-editor-support/src/__tests__/Settings-test.js
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+const {EventEmitter} = require('events');
+const ProjectWorkspace = require('../ProjectWorkspace');
+const Settings = require('../Settings');
+
+describe('Settings', () => {
+  it('sets itself up fom the constructor', () => {
+    const workspace = new ProjectWorkspace('root_path', 'path_to_jest');
+    const settings = new Settings(workspace);
+    expect(settings.workspace).toEqual(workspace);
+    expect(settings.settings).toEqual(expect.any(Object));
+  });
+
+  it('reads and parses the config', () => {
+    const workspace = new ProjectWorkspace('root_path', 'path_to_jest');
+    const completed = jest.fn();
+    const config = {cacheDirectory: '/tmp/jest', name: '[md5 hash]'};
+    const json = {
+      config,
+      version: '19.0.0',
+    };
+    const createProcess = () => ({stdout: new EventEmitter()});
+    const buffer = makeBuffer(JSON.stringify(json));
+    const settings = new Settings(workspace, {createProcess});
+
+    settings.getConfig(completed);
+    settings.debugprocess.stdout.emit('data', buffer);
+
+    expect(completed).toHaveBeenCalled();
+    expect(settings.jestVersionMajor).toBe(19);
+    expect(settings.settings).toEqual(config);
+  });
+});
+
+const makeBuffer = (content: string) => {
+  // Buffer.from is not supported in < Node 5.10
+  if (typeof Buffer.from === 'function') {
+    return Buffer.from(content);
+  }
+
+  return new Buffer(content);
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

This solves #3288. It adds a JSON output of the config and then exits.

- Adds a `--showConfig` argument.
- Updates the `--debug` output to be JSON.
- Updates the `jest-editor-support` package to use `--showConfig`.

**Test plan**

- Integration tests pass.
- `jest --showConfig` outputs config and exits.
