### PR TITLE
Support custom platforms on jest-haste-map

### DIFF
--- a/packages/jest-haste-map/src/index.js
+++ b/packages/jest-haste-map/src/index.js
@@ -299,8 +299,10 @@ class HasteMap extends EventEmitter {
         map[id] = Object.create(null);
       }
       const moduleMap = map[id];
-      const platform =
-        getPlatformExtension(module[H.PATH]) || H.GENERIC_PLATFORM;
+      const platform = getPlatformExtension(
+        module[H.PATH],
+        this._options.platforms,
+      ) || H.GENERIC_PLATFORM;
       const existingModule = moduleMap[platform];
       if (existingModule && existingModule[H.PATH] !== module[H.PATH]) {
         const message =

--- a/packages/jest-haste-map/src/lib/getPlatformExtension.js
+++ b/packages/jest-haste-map/src/lib/getPlatformExtension.js
@@ -17,13 +17,20 @@ const SUPPORTED_PLATFORM_EXTS = {
 };
 
 // Extract platform extension: index.ios.js -> ios
-function getPlatformExtension(file: string): ?string {
+function getPlatformExtension(
+  file: string,
+  platforms?: Array<string>,
+): ?string {
   const last = file.lastIndexOf('.');
   const secondToLast = file.lastIndexOf('.', last - 1);
   if (secondToLast === -1) {
     return null;
   }
   const platform = file.substring(secondToLast + 1, last);
+  // If an overriding platform array is passed, check that first
+  if (platforms && platforms.indexOf(platform) !== -1) {
+    return platform;
+  }
   return SUPPORTED_PLATFORM_EXTS[platform] ? platform : null;
 }
 


### PR DESCRIPTION
Applying custom platform changes on top of the 19.0.0 release, so we can bundle 19.0.1