### PR TITLE
[CoverageReporter] Parallelize instrumentation of untested files.

### DIFF
--- a/packages/jest-cli/src/TestRunner.js
+++ b/packages/jest-cli/src/TestRunner.js
@@ -163,8 +163,11 @@ class TestRunner {
 
     updateSnapshotState();
     aggregatedResults.wasInterrupted = watcher.isInterrupted();
-
-    this._dispatcher.onRunComplete(contexts, this._config, aggregatedResults);
+    await this._dispatcher.onRunComplete(
+      contexts,
+      this._config,
+      aggregatedResults,
+    );
 
     const anyTestFailures = !(aggregatedResults.numFailedTests === 0 &&
       aggregatedResults.numRuntimeErrorTestSuites === 0);
@@ -286,7 +289,7 @@ class TestRunner {
       // coverage reporter dependency graph is pretty big and we don't
       // want to require it if we're not in the `--coverage` mode
       const CoverageReporter = require('./reporters/CoverageReporter');
-      this.addReporter(new CoverageReporter());
+      this.addReporter(new CoverageReporter(this._options.maxWorkers));
     }
 
     this.addReporter(new SummaryReporter(this._options));
@@ -304,12 +307,11 @@ class TestRunner {
       if (watcher.isWatchMode()) {
         watcher.setState({interrupted: true});
       } else {
-        this._dispatcher.onRunComplete(
-          contexts,
-          this._config,
-          aggregatedResults,
-        );
-        process.exit(1);
+        const exit = () => process.exit(1);
+        this._dispatcher
+          .onRunComplete(contexts, this._config, aggregatedResults)
+          .then(exit)
+          .catch(exit);
       }
     }
   }
@@ -463,9 +465,11 @@ class ReporterDispatcher {
     );
   }
 
-  onRunComplete(contexts, config, results) {
-    this._reporters.forEach(reporter =>
-      reporter.onRunComplete(contexts, config, results),
+  onRunComplete(contexts, config, results): Promise<Array<any>> {
+    return Promise.all(
+      this._reporters.map(reporter =>
+        reporter.onRunComplete(contexts, config, results),
+      ),
     );
   }
 

--- a/packages/jest-cli/src/reporters/CoverageReporter.js
+++ b/packages/jest-cli/src/reporters/CoverageReporter.js
@@ -9,7 +9,12 @@
 */
 'use strict';
 
-import type {AggregatedResult, CoverageMap, TestResult} from 'types/TestResult';
+import type {
+  AggregatedResult,
+  CoverageMap,
+  SerializableError,
+  TestResult,
+} from 'types/TestResult';
 import type {GlobalConfig} from 'types/Config';
 import type {Context} from 'types/Context';
 import type {Test} from 'types/TestRunner';
@@ -19,11 +24,11 @@ const BaseReporter = require('./BaseReporter');
 const {clearLine} = require('jest-util');
 const {createReporter} = require('istanbul-api');
 const chalk = require('chalk');
-const fs = require('fs');
-const generateEmptyCoverage = require('../generateEmptyCoverage');
 const isCI = require('is-ci');
 const istanbulCoverage = require('istanbul-lib-coverage');
 const libSourceMaps = require('istanbul-lib-source-maps');
+const workerFarm = require('worker-farm');
+const pify = require('pify');
 
 const FAIL_COLOR = chalk.bold.red;
 const RUNNING_TEST_COLOR = chalk.bold.dim;
@@ -32,10 +37,12 @@ const isInteractive = process.stdout.isTTY && !isCI;
 
 class CoverageReporter extends BaseReporter {
   _coverageMap: CoverageMap;
+  _maxWorkers: number;
   _sourceMapStore: any;
 
-  constructor() {
+  constructor(maxWorkers: number) {
     super();
+    this._maxWorkers = maxWorkers;
     this._coverageMap = istanbulCoverage.createCoverageMap({});
     this._sourceMapStore = libSourceMaps.createSourceMapStore();
   }
@@ -59,12 +66,12 @@ class CoverageReporter extends BaseReporter {
     }
   }
 
-  onRunComplete(
+  async onRunComplete(
     contexts: Set<Context>,
     config: GlobalConfig,
     aggregatedResults: AggregatedResult,
   ) {
-    this._addUntestedFiles(contexts);
+    await this._addUntestedFiles(contexts);
     let map = this._coverageMap;
     let sourceFinder: Object;
     if (config.mapCoverage) {
@@ -125,34 +132,61 @@ class CoverageReporter extends BaseReporter {
           RUNNING_TEST_COLOR('Running coverage on untested files...'),
         );
       }
-      files.forEach(({config, path}) => {
-        if (!this._coverageMap.data[path]) {
-          try {
-            const source = fs.readFileSync(path).toString();
-            const result = generateEmptyCoverage(source, path, config);
-            if (result) {
-              this._coverageMap.addFileCoverage(result.coverage);
-              if (result.sourceMapPath) {
-                this._sourceMapStore.registerURL(path, result.sourceMapPath);
+
+      const farm = workerFarm(
+        {
+          autoStart: true,
+          maxConcurrentCallsPerWorker: 1,
+          maxConcurrentWorkers: this._maxWorkers,
+          maxRetries: 2, // Allow for a couple of transient errors.
+        },
+        require.resolve('./CoverageWorker'),
+      );
+
+      const worker = pify(farm);
+      const instrumentation = [];
+
+      files.forEach(fileObj => {
+        const filename = fileObj.path;
+        const config = fileObj.config;
+        if (!this._coverageMap.data[filename]) {
+          const prom = worker({
+            config,
+            untestedFilePath: filename,
+          })
+            .then(result => {
+              if (result) {
+                this._coverageMap.addFileCoverage(result.coverage);
+                if (result.sourceMapPath) {
+                  this._sourceMapStore.registerURL(
+                    filename,
+                    result.sourceMapPath,
+                  );
+                }
               }
-            }
-          } catch (e) {
-            console.error(
-              chalk.red(
-                `
-              Failed to collect coverage from ${path}
-              ERROR: ${e}
-              STACK: ${e.stack}
-            `,
-              ),
-            );
-          }
+            })
+            .catch((error: SerializableError) => {
+              console.error(chalk.red(error.message));
+            });
+          instrumentation.push(prom);
         }
       });
-      if (isInteractive) {
-        clearLine(process.stderr);
-      }
+
+      const instrumentAllFiles = Promise.all(instrumentation);
+
+      const afterInstrumentation = () => {
+        if (isInteractive) {
+          clearLine(process.stderr);
+        }
+        workerFarm.end(farm);
+      };
+
+      return instrumentAllFiles
+        .then(afterInstrumentation)
+        .catch(afterInstrumentation);
     }
+
+    return Promise.resolve();
   }
 
   _checkThreshold(map: CoverageMap, config: GlobalConfig) {

--- a/packages/jest-cli/src/reporters/CoverageWorker.js
+++ b/packages/jest-cli/src/reporters/CoverageWorker.js
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+'use strict';
+
+import type {Config, Path} from 'types/Config';
+import type {SerializableError} from 'types/TestResult';
+
+const fs = require('fs');
+const generateEmptyCoverage = require('../generateEmptyCoverage');
+
+type CoverageWorkerData = {|
+  config: Config,
+  untestedFilePath: Path,
+|};
+
+type WorkerCallback = (error: ?SerializableError, result: ?Object) => void;
+
+function formatCoverageError(error, filename: Path): SerializableError {
+  const message = `
+    Failed to collect coverage from ${filename}
+    ERROR: ${error}
+    STACK: ${error.stack}
+  `;
+
+  return {
+    message,
+    stack: error.stack,
+    type: 'ERROR',
+  };
+}
+
+// Make sure uncaught errors are logged before we exit.
+process.on('uncaughtException', err => {
+  console.error(err.stack);
+  process.exit(1);
+});
+
+module.exports = (
+  {config, untestedFilePath}: CoverageWorkerData,
+  callback: WorkerCallback,
+) => {
+  try {
+    const source = fs.readFileSync(untestedFilePath).toString();
+    const result = generateEmptyCoverage(source, untestedFilePath, config);
+    callback(null, result);
+  } catch (e) {
+    callback(formatCoverageError(e, untestedFilePath), undefined);
+  }
+};

--- a/packages/jest-cli/src/reporters/__tests__/CoverageReporter-test.js
+++ b/packages/jest-cli/src/reporters/__tests__/CoverageReporter-test.js
@@ -82,36 +82,40 @@ describe('onRunComplete', () => {
   });
 
   it('getLastError() returns an error when threshold is not met', () => {
-    testReporter.onRunComplete(
-      new Set(),
-      {
-        collectCoverage: true,
-        coverageThreshold: {
-          global: {
-            statements: 100,
+    return testReporter
+      .onRunComplete(
+        new Set(),
+        {
+          collectCoverage: true,
+          coverageThreshold: {
+            global: {
+              statements: 100,
+            },
           },
         },
-      },
-      mockAggResults,
-    );
-
-    expect(testReporter.getLastError()).toBeTruthy();
+        mockAggResults,
+      )
+      .then(() => {
+        expect(testReporter.getLastError()).toBeTruthy();
+      });
   });
 
   it('getLastError() returns `undefined` when threshold is met', () => {
-    testReporter.onRunComplete(
-      new Set(),
-      {
-        collectCoverage: true,
-        coverageThreshold: {
-          global: {
-            statements: 50,
+    return testReporter
+      .onRunComplete(
+        new Set(),
+        {
+          collectCoverage: true,
+          coverageThreshold: {
+            global: {
+              statements: 50,
+            },
           },
         },
-      },
-      mockAggResults,
-    );
-
-    expect(testReporter.getLastError()).toBeUndefined();
+        mockAggResults,
+      )
+      .then(() => {
+        expect(testReporter.getLastError()).toBeUndefined();
+      });
   });
 });

--- a/packages/jest-cli/src/reporters/__tests__/CoverageWorker-test.js
+++ b/packages/jest-cli/src/reporters/__tests__/CoverageWorker-test.js
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+jest.mock('fs').mock('../../generateEmptyCoverage');
+
+const fs = require('fs');
+const generateEmptyCoverage = require('../../generateEmptyCoverage');
+
+const config = {collectCoverage: true};
+const worker = require('../CoverageWorker');
+const workerOptions = {config, untestedFilePath: 'asdf'};
+
+describe('CoverageWorker', () => {
+  it('resolves to the result of generateEmptyCoverage upon success', () => {
+    const validJS = 'function(){}';
+    fs.readFileSync.mockImplementation(() => validJS);
+    generateEmptyCoverage.mockImplementation(() => 42);
+    return new Promise(resolve => {
+      worker(workerOptions, (err, result) => {
+        expect(generateEmptyCoverage).toBeCalledWith(validJS, 'asdf', config);
+        expect(result).toEqual(42);
+        resolve();
+      });
+    });
+  });
+
+  it('surfaces a serializable error', () => {
+    fs.readFileSync.mockImplementation(() => 'invalidJs');
+    return new Promise(resolve => {
+      worker(workerOptions, (err, result) => {
+        expect(err).toEqual(JSON.parse(JSON.stringify(err)));
+        expect(result).toEqual(undefined);
+        resolve();
+      });
+    });
+  });
+});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

This changes the coverage reporter's _addUntestedFiles function to be
parallelized. This speeds up coverage collection on machines with multiple
cores for test suites with many untested files.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

Wrote tests for the new worker file, `npm link`d jest-cli and tested against a large local repo, tested entire repo via `yarn test`.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
