### PR TITLE
Fix spacing in test name pattern typeahead

### DIFF
--- a/packages/jest-cli/src/TestNamePatternPrompt.js
+++ b/packages/jest-cli/src/TestNamePatternPrompt.js
@@ -89,7 +89,7 @@ module.exports = class TestNamePatternPrompt {
         const more = total - max;
         this._pipe.write(
           // eslint-disable-next-line max-len
-          `\n  ${chalk.dim(`\u203A and ${more} more ${pluralizeTest(more)}`)}`,
+          `\n ${chalk.dim(`\u203A and ${more} more ${pluralizeTest(more)}`)}`,
         );
       }
     } else {


### PR DESCRIPTION
Really small polish on the footer of the typeahed


**Before**
<img width="510" alt="screen shot 2017-04-18 at 9 59 18 am" src="https://cloud.githubusercontent.com/assets/574806/25143134/2bdc9c58-241e-11e7-9a6c-037b93dd3a01.png">

**After**
<img width="616" alt="screen shot 2017-04-18 at 10 00 52 am" src="https://cloud.githubusercontent.com/assets/574806/25143133/2bd8bb4c-241e-11e7-8f20-9068b066b1da.png">
