### PR TITLE
Fix symlinking babel-jest to examples

### DIFF
--- a/scripts/_runCommand.js
+++ b/scripts/_runCommand.js
@@ -16,17 +16,10 @@ module.exports = function runCommand(cmd, args, cwd) {
   }
 
   const callArgs = typeof args === 'string' ? args.split(' ') : args;
-  console.log(
-    chalk.dim('$ cd ' + cwd) +
-      '\n' +
-      chalk.dim(
-        '  $ ' +
-          cmd +
-          ' ' +
-          (args.length > 1000 ? args.slice(0, 1000) + '...' : args)
-      ) +
-      '\n'
-  );
+  const displayArgs = args.length > 1000
+    ? args.slice(0, 1000) + '...'
+    : callArgs.join(' ');
+  console.log(chalk.dim('$ cd ' + cwd + `\n$ ${cmd} ${displayArgs}\n`));
   const result = spawn(cmd, callArgs, {
     cwd,
     stdio: 'inherit',

--- a/scripts/test_examples.js
+++ b/scripts/test_examples.js
@@ -29,10 +29,13 @@ const examples = fs
   .filter(f => fs.lstatSync(path.resolve(f)).isDirectory());
 
 const link = (exampleDirectory, from) => {
-  const nodeModules =
-    exampleDirectory + path.sep + 'node_modules' + path.sep + '*';
+  const nodeModules = exampleDirectory + path.sep + 'node_modules' + path.sep;
   mkdirp.sync(nodeModules);
-  runCommand('ln', ['-fs', from, nodeModules], exampleDirectory);
+  try {
+    runCommand('ln', ['-fs', from, nodeModules], exampleDirectory);
+  } catch (error) {
+    // directory already exists
+  }
 };
 
 examples.forEach(exampleDirectory => {

--- a/scripts/test_examples.js
+++ b/scripts/test_examples.js
@@ -13,6 +13,7 @@ const fs = require('graceful-fs');
 const path = require('path');
 const chalk = require('chalk');
 const mkdirp = require('mkdirp');
+const rimraf = require('rimraf');
 
 const ROOT = path.resolve(__dirname, '..');
 const BABEL_JEST_PATH = path.resolve(ROOT, 'packages/babel-jest');
@@ -30,12 +31,10 @@ const examples = fs
 
 const link = (exampleDirectory, from) => {
   const nodeModules = exampleDirectory + path.sep + 'node_modules' + path.sep;
+  const localBabelJest = path.join(nodeModules, 'babel-jest');
   mkdirp.sync(nodeModules);
-  try {
-    runCommand('ln', ['-fs', from, nodeModules], exampleDirectory);
-  } catch (error) {
-    // directory already exists
-  }
+  rimraf.sync(localBabelJest);
+  runCommand('ln', ['-fs', from, nodeModules], exampleDirectory);
 };
 
 examples.forEach(exampleDirectory => {

--- a/scripts/test_examples.js
+++ b/scripts/test_examples.js
@@ -29,15 +29,16 @@ const examples = fs
   .filter(f => fs.lstatSync(path.resolve(f)).isDirectory());
 
 const link = (exampleDirectory, from) => {
-  const nodeModules = exampleDirectory + path.sep + 'node_modules' + path.sep;
+  const nodeModules =
+    exampleDirectory + path.sep + 'node_modules' + path.sep + '*';
   mkdirp.sync(nodeModules);
   runCommand('ln', ['-fs', from, nodeModules], exampleDirectory);
 };
 
 examples.forEach(exampleDirectory => {
-  console.log(chalk.bold(chalk.cyan('Testing example: ') + exampleDirectory));
-
   const exampleName = path.basename(exampleDirectory);
+  console.log(chalk.bold(chalk.cyan('Testing example: ') + exampleName));
+
   if (NODE_VERSION < 6 && SKIP_ON_OLD_NODE.indexOf(exampleName) !== -1) {
     console.log(`Skipping ${exampleName} on node ${process.version}.`);
     return;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Fixes [failing CircleCI](https://circleci.com/gh/facebook/jest/947?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link) by linking to `.../node_modules/*` instead of `.../node_modules/`. This prevents permission issues while linking existing packages.
I've also adjusted the console output a little (display only example name and get rid of extra indentation for command after `cd`, it's just easier to read it this way):

<img width="875" alt="screen shot 2017-04-18 at 19 45 44" src="https://cloud.githubusercontent.com/assets/5106466/25161252/a930c23c-246f-11e7-8e1f-a06f88f78884.png">


**Test plan**
`yarn test-examples` pass on all CI servers
