### PR TITLE
install react-test-render to  fix Enzyme console warning

### DIFF
--- a/docs/TutorialReact.md
+++ b/docs/TutorialReact.md
@@ -178,7 +178,7 @@ The code for this example is available at
 
 If you'd like to assert, and manipulate your rendered components you can use [Enzyme](http://airbnb.io/enzyme/) or React's [TestUtils](http://facebook.github.io/react/docs/test-utils.html). We use Enzyme for this example.
 
-You have to run `npm install --save-dev enzyme react-addons-test-utils` to use Enzyme (`react-addons-test-utils` is a peer dependency).
+You have to run `npm install --save-dev enzyme react-addons-test-utils` to use Enzyme (`react-addons-test-utils` is a peer dependency). If your react version is above 15.5+, run `npm install --save-dev enzyme react-test-render` to use Enzyme instead.
 
 Let's implement a simple checkbox which swaps between two labels:
 

--- a/docs/TutorialReact.md
+++ b/docs/TutorialReact.md
@@ -178,7 +178,7 @@ The code for this example is available at
 
 If you'd like to assert, and manipulate your rendered components you can use [Enzyme](http://airbnb.io/enzyme/) or React's [TestUtils](http://facebook.github.io/react/docs/test-utils.html). We use Enzyme for this example.
 
-You have to run `npm install --save-dev enzyme react-addons-test-utils` to use Enzyme (`react-addons-test-utils` is a peer dependency). If your react version is above 15.5+, run `npm install --save-dev enzyme react-test-render` to use Enzyme instead.
+You have to run `npm install --save-dev enzyme` to use Enzyme. If you are using a React below version 15.5.0, you will also need to install `react-addons-test-utils`.
 
 Let's implement a simple checkbox which swaps between two labels:
 


### PR DESCRIPTION
Enzyme recently made a fix for console warning if we use React v15.5+ , See issue here: https://github.com/airbnb/enzyme/pull/876

To fix that, we have to install react-test-render instead of react-addons-test-utils

Warning:
``` 
 console.error node_modules/fbjs/lib/warning.js:36
    Warning: ReactTestUtils has been moved to react-dom/test-utils. Update references to remove this warning.

  console.error node_modules/fbjs/lib/warning.js:36
    Warning: Shallow renderer has been moved to react-test-renderer/shallow. Update references to remove this warning.
```

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
