### PR TITLE
Allow toMatchObject to match recursively on any depth of an object

### DIFF
--- a/docs/ExpectAPI.md
+++ b/docs/ExpectAPI.md
@@ -679,7 +679,7 @@ describe('grapefruits are healthy', () => {
 
 ### `.toMatchObject(object)`
 
-Use `.toMatchObject` to check that a JavaScript object matches a subset of the properties of an object.
+Use `.toMatchObject` to check that a JavaScript object matches a subset of the properties of an object. Works recursively, looking for a match no matter how deep in the object it lives.
 
 ```js
 const houseForSale = {
@@ -697,6 +697,34 @@ const desiredHouse = {
     amenities: ['oven', 'stove', 'washer'],
     wallColor: 'white',
   },
+};
+
+test('the house has my desired features', () => {
+  expect(houseForSale).toMatchObject(desiredHouse);
+});
+```
+
+or
+
+
+```js
+const houseForSale = {
+  bath: true,
+  bedrooms: 4,
+  kitchen: {
+    amenities: ['oven', 'stove', 'washer'],
+    area: {
+      width: 20,
+      height: 30,
+    },
+    wallColor: 'white',
+  },
+};
+const desiredHouse = {
+  area: {
+    width: 20,
+    height: 30,
+  }
 };
 
 test('the house has my desired features', () => {

--- a/packages/jest-matchers/src/__tests__/__snapshots__/matchers-test.js.snap
+++ b/packages/jest-matchers/src/__tests__/__snapshots__/matchers-test.js.snap
@@ -3054,6 +3054,28 @@ Difference:
 <dim> }"
 `;
 
+exports[`toMatchObject() {pass: false} expect({"a": {"b": {"c": "c"}}}).toMatchObject({"b": {"d": "d"}}) 1`] = `
+"<dim>expect(<red>received</><dim>).toMatchObject(<green>expected</><dim>)
+
+Expected value to match object:
+  <green>{\\"b\\": {\\"d\\": \\"d\\"}}</>
+Received:
+  <red>{\\"a\\": {\\"b\\": {\\"c\\": \\"c\\"}}}</>
+Difference:
+<green>- Expected</>
+<red>+ Received</>
+
+<dim> Object {
+<green>-  \\"b\\": Object {</>
+<green>-    \\"d\\": \\"d\\",</>
+<red>+  \\"a\\": Object {</>
+<red>+    \\"b\\": Object {</>
+<red>+      \\"c\\": \\"c\\",</>
+<red>+    },</>
+<dim>   },
+<dim> }"
+`;
+
 exports[`toMatchObject() {pass: false} expect({"a": 1, "b": 1, "c": 1, "d": {"e": {"f": 555}}}).toMatchObject({"d": {"e": {"f": 222}}}) 1`] = `
 "<dim>expect(<red>received</><dim>).toMatchObject(<green>expected</><dim>)
 
@@ -3256,6 +3278,24 @@ Expected value not to match object:
   <green>{\\"a\\": [3, 4, 5]}</>
 Received:
   <red>{\\"a\\": [3, 4, 5], \\"b\\": \\"b\\"}</>"
+`;
+
+exports[`toMatchObject() {pass: true} expect({"a": {"b": {"c": "c"}}}).toMatchObject({"b": {"c": "c"}}) 1`] = `
+"<dim>expect(<red>received</><dim>).not.toMatchObject(<green>expected</><dim>)
+
+Expected value not to match object:
+  <green>{\\"b\\": {\\"c\\": \\"c\\"}}</>
+Received:
+  <red>{\\"a\\": {\\"b\\": {\\"c\\": \\"c\\"}}}</>"
+`;
+
+exports[`toMatchObject() {pass: true} expect({"a": {"b": {"c": {"d": "d"}, "e": "e"}}}).toMatchObject({"c": {"d": "d"}}) 1`] = `
+"<dim>expect(<red>received</><dim>).not.toMatchObject(<green>expected</><dim>)
+
+Expected value not to match object:
+  <green>{\\"c\\": {\\"d\\": \\"d\\"}}</>
+Received:
+  <red>{\\"a\\": {\\"b\\": {\\"c\\": {\\"d\\": \\"d\\"}, \\"e\\": \\"e\\"}}}</>"
 `;
 
 exports[`toMatchObject() {pass: true} expect({"a": {"x": "x", "y": "y"}}).toMatchObject({"a": {"x": Any<String>}}) 1`] = `

--- a/packages/jest-matchers/src/__tests__/matchers-test.js
+++ b/packages/jest-matchers/src/__tests__/matchers-test.js
@@ -811,6 +811,8 @@ describe('toMatchObject()', () => {
     [[1, 2], [1, 2]],
     [{a: undefined}, {a: undefined}],
     [[], []],
+    [{a: {b: {c: 'c'}}}, {b: {c: 'c'}}],
+    [{a: {b: {c: { d: 'd' }, e: 'e' }}}, {c: {d: 'd'}}],
   ].forEach(([n1, n2]) => {
     it(`{pass: true} expect(${stringify(n1)}).toMatchObject(${stringify(n2)})`, () => {
       jestExpect(n1).toMatchObject(n2);
@@ -844,6 +846,7 @@ describe('toMatchObject()', () => {
     [{}, {a: undefined}],
     [[1, 2, 3], [2, 3, 1]],
     [[1, 2, 3], [1, 2, 2]],
+    [{a: {b: {c: 'c'}}}, {b: {d: 'd'}}],
   ].forEach(([n1, n2]) => {
     it(`{pass: false} expect(${stringify(n1)}).toMatchObject(${stringify(n2)})`, () => {
       jestExpect(n1).not.toMatchObject(n2);

--- a/packages/jest-matchers/src/matchers.js
+++ b/packages/jest-matchers/src/matchers.js
@@ -75,10 +75,20 @@ const subsetEquality = (object, subset) => {
   if (!isObjectWithKeys(object) || !isObjectWithKeys(subset)) {
     return undefined;
   }
+
+  return shallowSubsetEquality(object, subset) || Object.keys(object).some((key) => {
+    return subsetEquality(object[key], subset)
+  });
+}
+const shallowSubsetEquality = (object, subset) => {
+  if (!isObjectWithKeys(object) || !isObjectWithKeys(subset)) {
+    return undefined;
+  }
+
   return Object.keys(subset).every(
     key =>
       object.hasOwnProperty(key) &&
-      equals(object[key], subset[key], [iterableEquality, subsetEquality]),
+      equals(object[key], subset[key], [iterableEquality, shallowSubsetEquality]),
   );
 };
 


### PR DESCRIPTION
**Summary**

Allow the user to recursively match a subset of an object, no matter where it lives in the base object.

For example:

```js
const houseForSale = {
  bath: true,
  bedrooms: 4,
  kitchen: {
    amenities: ['oven', 'stove', 'washer'],
    area: {
      width: 20,
      height: 30,
    },
    wallColor: 'white',
  },
};
const desiredHouse = {
  area: {
    width: 20,
    height: 30,
  }
};

test('the house has my desired features', () => {
  expect(houseForSale).toMatchObject(desiredHouse);
});
```

Resolves https://github.com/facebook/jest/issues/2506

**Test plan**

```
✓ {pass: true} expect({"a": {"b": {"c": "c"}}}).toMatchObject({"b": {"c": "c"}}) (1ms)
✓ {pass: true} expect({"a": {"b": {"c": {"d": "d"}, "e": "e"}}}).toMatchObject({"c": {"d": "d"}}) (2ms)
✓ {pass: false} expect({"a": {"b": {"c": "c"}}}).toMatchObject({"b": {"d": "d"}}) (3ms)
```