### PR TITLE
Add “GlobalConfig” type.

### DIFF
--- a/packages/jest-cli/src/TestRunner.js
+++ b/packages/jest-cli/src/TestRunner.js
@@ -14,7 +14,7 @@ import type {
   SerializableError as TestError,
   TestResult,
 } from 'types/TestResult';
-import type {Config} from 'types/Config';
+import type {GlobalConfig} from 'types/Config';
 import type {Context} from 'types/Context';
 import type {PathPattern} from './SearchSource';
 import type {Test, Tests} from 'types/TestRunner';
@@ -56,11 +56,11 @@ type OnTestSuccess = (test: Test, result: TestResult) => void;
 const TEST_WORKER_PATH = require.resolve('./TestWorker');
 
 class TestRunner {
-  _config: Config;
+  _config: GlobalConfig;
   _options: Options;
   _dispatcher: ReporterDispatcher;
 
-  constructor(config: Config, options: Options) {
+  constructor(config: GlobalConfig, options: Options) {
     this._config = config;
     this._dispatcher = new ReporterDispatcher();
     this._options = options;

--- a/packages/jest-cli/src/reporters/BaseReporter.js
+++ b/packages/jest-cli/src/reporters/BaseReporter.js
@@ -10,7 +10,7 @@
 'use strict';
 
 import type {AggregatedResult, TestResult} from 'types/TestResult';
-import type {Config} from 'types/Config';
+import type {GlobalConfig} from 'types/Config';
 import type {Context} from 'types/Context';
 import type {Test} from 'types/TestRunner';
 import type {ReporterOnStartOptions} from 'types/Reporters';
@@ -25,7 +25,7 @@ class BaseReporter {
   }
 
   onRunStart(
-    config: Config,
+    config: GlobalConfig,
     results: AggregatedResult,
     options: ReporterOnStartOptions,
   ) {
@@ -38,7 +38,7 @@ class BaseReporter {
 
   onRunComplete(
     contexts: Set<Context>,
-    config: Config,
+    config: GlobalConfig,
     aggregatedResults: AggregatedResult,
   ): ?Promise<any> {}
 

--- a/packages/jest-cli/src/reporters/CoverageReporter.js
+++ b/packages/jest-cli/src/reporters/CoverageReporter.js
@@ -10,7 +10,7 @@
 'use strict';
 
 import type {AggregatedResult, CoverageMap, TestResult} from 'types/TestResult';
-import type {Config} from 'types/Config';
+import type {GlobalConfig} from 'types/Config';
 import type {Context} from 'types/Context';
 import type {Test} from 'types/TestRunner';
 
@@ -61,7 +61,7 @@ class CoverageReporter extends BaseReporter {
 
   onRunComplete(
     contexts: Set<Context>,
-    config: Config,
+    config: GlobalConfig,
     aggregatedResults: AggregatedResult,
   ) {
     this._addUntestedFiles(contexts);
@@ -155,7 +155,7 @@ class CoverageReporter extends BaseReporter {
     }
   }
 
-  _checkThreshold(map: CoverageMap, config: Config) {
+  _checkThreshold(map: CoverageMap, config: GlobalConfig) {
     if (config.coverageThreshold) {
       const results = map.getCoverageSummary().toJSON();
 

--- a/packages/jest-cli/src/reporters/DefaultReporter.js
+++ b/packages/jest-cli/src/reporters/DefaultReporter.js
@@ -13,7 +13,7 @@
 'use strict';
 
 import type {AggregatedResult, TestResult} from 'types/TestResult';
-import type {Config, Path} from 'types/Config';
+import type {Config, GlobalConfig, Path} from 'types/Config';
 import type {Test} from 'types/TestRunner';
 import type {ReporterOnStartOptions} from 'types/Reporters';
 
@@ -106,7 +106,7 @@ class DefaultReporter extends BaseReporter {
   }
 
   onRunStart(
-    config: Config,
+    config: GlobalConfig,
     aggregatedResults: AggregatedResult,
     options: ReporterOnStartOptions,
   ) {

--- a/packages/jest-cli/src/reporters/NotifyReporter.js
+++ b/packages/jest-cli/src/reporters/NotifyReporter.js
@@ -10,7 +10,7 @@
 'use strict';
 
 import type {AggregatedResult} from 'types/TestResult';
-import type {Config} from 'types/Config';
+import type {GlobalConfig} from 'types/Config';
 import type {Context} from 'types/Context';
 
 const BaseReporter = require('./BaseReporter');
@@ -32,7 +32,7 @@ class NotifyReporter extends BaseReporter {
 
   onRunComplete(
     contexts: Set<Context>,
-    config: Config,
+    config: GlobalConfig,
     result: AggregatedResult,
   ): void {
     const success =

--- a/packages/jest-cli/src/reporters/SummaryReporter.js
+++ b/packages/jest-cli/src/reporters/SummaryReporter.js
@@ -10,7 +10,7 @@
 'use strict';
 
 import type {AggregatedResult, SnapshotSummary} from 'types/TestResult';
-import type {Config} from 'types/Config';
+import type {GlobalConfig} from 'types/Config';
 import type {Context} from 'types/Context';
 import type {Options as SummaryReporterOptions} from '../TestRunner';
 import type {PathPattern} from '../SearchSource';
@@ -80,7 +80,7 @@ class SummaryReporter extends BaseReporter {
   }
 
   onRunStart(
-    config: Config,
+    config: GlobalConfig,
     aggregatedResults: AggregatedResult,
     options: ReporterOnStartOptions,
   ) {
@@ -90,7 +90,7 @@ class SummaryReporter extends BaseReporter {
 
   onRunComplete(
     contexts: Set<Context>,
-    config: Config,
+    config: GlobalConfig,
     aggregatedResults: AggregatedResult,
   ) {
     const {numTotalTestSuites, testResults, wasInterrupted} = aggregatedResults;
@@ -130,7 +130,7 @@ class SummaryReporter extends BaseReporter {
     }
   }
 
-  _printSnapshotSummary(snapshots: SnapshotSummary, config: Config) {
+  _printSnapshotSummary(snapshots: SnapshotSummary, config: GlobalConfig) {
     if (
       snapshots.added ||
       snapshots.filesRemoved ||
@@ -215,7 +215,7 @@ class SummaryReporter extends BaseReporter {
     }
   }
 
-  _printSummary(aggregatedResults: AggregatedResult, config: Config) {
+  _printSummary(aggregatedResults: AggregatedResult, config: GlobalConfig) {
     // If there were any failing tests and there was a large number of tests
     // executed, re-print the failing results at the end of execution output.
     const failedTests = aggregatedResults.numFailedTests;

--- a/packages/jest-cli/src/reporters/getResultHeader.js
+++ b/packages/jest-cli/src/reporters/getResultHeader.js
@@ -9,8 +9,8 @@
  */
 'use strict';
 
+import type {Path} from 'types/Config';
 import type {TestResult} from 'types/TestResult';
-import type {Config} from 'types/Config';
 
 const {formatTestPath} = require('./utils');
 const chalk = require('chalk');
@@ -21,7 +21,7 @@ const LONG_TEST_COLOR = chalk.reset.bold.bgRed;
 const FAIL = chalk.reset.inverse.bold.red(' FAIL ');
 const PASS = chalk.reset.inverse.bold.green(' PASS ');
 
-module.exports = (result: TestResult, config: Config) => {
+module.exports = (result: TestResult, config: {rootDir: Path}) => {
   const testPath = result.testFilePath;
   const status = result.numFailingTests > 0 || result.testExecError
     ? FAIL

--- a/packages/jest-cli/src/reporters/utils.js
+++ b/packages/jest-cli/src/reporters/utils.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-import type {Config, Path} from 'types/Config';
+import type {Path} from 'types/Config';
 import type {AggregatedResult} from 'types/TestResult';
 
 const chalk = require('chalk');
@@ -27,7 +27,7 @@ const PROGRESS_BAR_WIDTH = 40;
 
 const trimAndFormatPath = (
   pad: number,
-  config: Config,
+  config: {rootDir: Path},
   testPath: Path,
   columns: number,
 ): string => {
@@ -62,12 +62,12 @@ const trimAndFormatPath = (
   );
 };
 
-const formatTestPath = (config: Config, testPath: Path) => {
+const formatTestPath = (config: {rootDir: Path}, testPath: Path) => {
   const {dirname, basename} = relativePath(config, testPath);
   return chalk.dim(dirname + path.sep) + chalk.bold(basename);
 };
 
-const relativePath = (config: Config, testPath: Path) => {
+const relativePath = (config: {rootDir: Path}, testPath: Path) => {
   testPath = path.relative(config.rootDir, testPath);
   const dirname = path.dirname(testPath);
   const basename = path.basename(testPath);

--- a/types/Config.js
+++ b/types/Config.js
@@ -21,6 +21,34 @@ export type HasteConfig = {|
 
 export type ConfigGlobals = Object;
 
+export type GlobalConfig = {
+  bail: boolean,
+  collectCoverage: boolean,
+  collectCoverageFrom: Array<Glob>,
+  collectCoverageOnlyFrom: {[key: string]: boolean},
+  coverageDirectory: string,
+  coveragePathIgnorePatterns: Array<string>,
+  coverageReporters: Array<string>,
+  coverageThreshold: {global: {[key: string]: number}},
+  expand: boolean,
+  forceExit: boolean,
+  mapCoverage: boolean,
+  logHeapUsage: boolean,
+  logTransformErrors: ?boolean,
+  noStackTrace: boolean,
+  notify: boolean,
+  replname: ?string,
+  rootDir: Path,
+  silent: boolean,
+  testNamePattern: string,
+  testResultsProcessor: ?string,
+  updateSnapshot: boolean,
+  useStderr: boolean,
+  verbose: ?boolean,
+  watch: boolean,
+  watchman: boolean,
+};
+
 export type DefaultConfig = {|
   automock: boolean,
   bail: boolean,


### PR DESCRIPTION
**Summary**

This adds a "GlobalConfig" type as a first step to separate configs into a "GlobalConfig" and "ProjectConfig". GlobalConfig works better than SharedConfig because it isn't actually shared – I think the two configs will end up having almost no overlap, if any at all, so that makes more sense.

Right now it is not an exact type yet and it is still exactly the same value as before, this diff only changes typings but I'd like to ship this incrementally in smaller PRs :)

**Test plan**

yarn typecheck