### PR TITLE
Avoid mutating contexts when updating snapshots in watch mode

### DIFF
--- a/packages/jest-cli/src/watch.js
+++ b/packages/jest-cli/src/watch.js
@@ -103,21 +103,23 @@ const watch = (
     isInteractive && pipe.write(CLEAR);
     preRunMessage.print(pipe);
     isRunning = true;
-    contexts.forEach(context => {
-      // $FlowFixMe
-      context.config = Object.freeze(
+    const newContexts = contexts.map(context =>
+      Object.assign({}, context, {
         // $FlowFixMe
-        Object.assign(
-          {
-            testNamePattern: argv.testNamePattern,
-            testPathPattern: argv.testPathPattern,
-          },
-          context.config,
-          overrideConfig,
+        config: Object.freeze(
+          // $FlowFixMe
+          Object.assign(
+            {
+              testNamePattern: argv.testNamePattern,
+              testPathPattern: argv.testPathPattern,
+            },
+            context.config,
+            overrideConfig,
+          ),
         ),
-      );
-    });
-    return runJest(contexts, argv, pipe, testWatcher, startRun, results => {
+      }),
+    );
+    return runJest(newContexts, argv, pipe, testWatcher, startRun, results => {
       isRunning = false;
       hasSnapshotFailure = !!results.snapshot.failure;
       // Create a new testWatcher instance so that re-runs won't be blocked.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Fixes #3330 and #3316. 
Mutation of `contexts.config` object causes some unexpected behaviors, such as retaining `updateSnapshots` flag. Removing mutation resolves the issue, so that `overrideConfig` only overrides the config for following run.

**Test plan**

jest
