### PR TITLE
Added flowtype typing to constructor arguments

### DIFF
--- a/packages/jest-util/src/Console.js
+++ b/packages/jest-util/src/Console.js
@@ -23,7 +23,8 @@ class CustomConsole extends Console {
   _stdout: stream$Writable;
   _formatBuffer: Formatter;
 
-  constructor(stdout: Object, stderr: Object, formatBuffer: ?Formatter) {
+  constructor(stdout: stream$Writable, stderr: stream$Writable, 
+              formatBuffer: ?Formatter) {
     super(stdout, stderr);
     this._formatBuffer = formatBuffer || ((type, message) => message);
   }

--- a/packages/jest-util/src/Console.js
+++ b/packages/jest-util/src/Console.js
@@ -23,8 +23,11 @@ class CustomConsole extends Console {
   _stdout: stream$Writable;
   _formatBuffer: Formatter;
 
-  constructor(stdout: stream$Writable, stderr: stream$Writable, 
-              formatBuffer: ?Formatter) {
+  constructor(
+    stdout: stream$Writable,
+    stderr: stream$Writable, 
+    formatBuffer: ?Formatter,
+  ) {
     super(stdout, stderr);
     this._formatBuffer = formatBuffer || ((type, message) => message);
   }


### PR DESCRIPTION
Summary: This is task 17383791. The goal was to modify a single file (Console.js) so that it passes the lint checks.

Test Plan: yarn eslint [path]/Console.js passes when we check for weak typing in .eslintrc file. yarn test passes when we disable check for weak typing.

Reviewers: adr

Subscribers: adr