### PR TITLE
Addresses babel config in package.json. If we don't find .babelrc or …

### DIFF
--- a/packages/babel-jest/src/index.js
+++ b/packages/babel-jest/src/index.js
@@ -20,6 +20,8 @@ const path = require('path');
 
 const BABELRC_FILENAME = '.babelrc';
 const BABELRC_JS_FILENAME = '.babelrc.js';
+const BABEL_CONFIG_KEY = 'babel';
+const PACAKAGE_JSON = 'package.json';
 const THIS_FILE = fs.readFileSync(__filename);
 
 const cache = Object.create(null);
@@ -45,6 +47,15 @@ const getBabelRC = (filename, {useCache}) => {
       // $FlowFixMe
       cache[directory] = JSON.stringify(require(configJsFilePath));
       break;
+    }
+    const packageJsonFilePath = path.join(directory, PACAKAGE_JSON);
+    if (fs.existsSync(packageJsonFilePath)) {
+      // $FlowFixMe
+      const packageJsonFileContents = require(packageJsonFilePath);
+      if (packageJsonFileContents[BABEL_CONFIG_KEY]) {
+        cache[directory] = JSON.stringify(packageJsonFileContents[BABEL_CONFIG_KEY]);
+        break;
+      }
     }
   }
   paths.forEach(directoryPath => {


### PR DESCRIPTION
 If we don't find `.babelrc` or `babelrc.js` we look for `babel` config in `package.json`

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Currently, babel configurations inside `package.json` is not considered when we don't find `.babelrc` or `.babelrc.js`. Fixes #3348 
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
