### PR TITLE
jest-runtime: expose inner error when it fails to write cache

### DIFF
--- a/packages/jest-runtime/package.json
+++ b/packages/jest-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-runtime",
-  "version": "19.0.2",
+  "version": "19.0.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/facebook/jest.git"

--- a/packages/jest-runtime/src/transform.js
+++ b/packages/jest-runtime/src/transform.js
@@ -98,7 +98,8 @@ const writeCacheFile = (cachePath: Path, fileData: string) => {
   try {
     fs.writeFileSync(cachePath, fileData, 'utf8');
   } catch (e) {
-    e.message = 'jest: failed to cache transform results in: ' + cachePath;
+    e.message = 'jest: failed to cache transform results in: ' + cachePath +
+      '\nInner error: ' + e.message;
     removeFile(cachePath);
     throw e;
   }

--- a/packages/jest-runtime/src/transform.js
+++ b/packages/jest-runtime/src/transform.js
@@ -99,7 +99,7 @@ const writeCacheFile = (cachePath: Path, fileData: string) => {
     fs.writeFileSync(cachePath, fileData, 'utf8');
   } catch (e) {
     e.message = 'jest: failed to cache transform results in: ' + cachePath +
-      '\nInner error: ' + e.message;
+      '\nFailure message: ' + e.message;
     removeFile(cachePath);
     throw e;
   }


### PR DESCRIPTION
**Summary**

We are encountering some errors on our CI machines, but the error message is not clear about the exact reason making it impossible to write the cache file. This changeset aims to expose the inner error message, that includes the errno code, that could be for example EACCESS or ENOENT.

**Test plan**

Automated testing.
