### PR TITLE
Include fullName in formattedAssertion

### DIFF
--- a/packages/jest-runtime/yarn.lock
+++ b/packages/jest-runtime/yarn.lock
@@ -80,14 +80,6 @@ babel-helpers@^6.23.0:
     babel-runtime "^6.22.0"
     babel-template "^6.23.0"
 
-babel-jest@^19.0.0:
-  version "19.0.0"
-  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-19.0.0.tgz#59323ced99a3a84d359da219ca881074ffc6ce3f"
-  dependencies:
-    babel-core "^6.0.0"
-    babel-plugin-istanbul "^4.0.0"
-    babel-preset-jest "^19.0.0"
-
 babel-messages@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-messages/-/babel-messages-6.23.0.tgz#f3cdf4703858035b2a2951c6ec5edf6c62f2630e"
@@ -101,16 +93,6 @@ babel-plugin-istanbul@^4.0.0:
     find-up "^2.1.0"
     istanbul-lib-instrument "^1.4.2"
     test-exclude "^4.0.0"
-
-babel-plugin-jest-hoist@^19.0.0:
-  version "19.0.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-19.0.0.tgz#4ae2a04ea612a6e73651f3fde52c178991304bea"
-
-babel-preset-jest@^19.0.0:
-  version "19.0.0"
-  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-19.0.0.tgz#22d67201d02324a195811288eb38294bb3cac396"
-  dependencies:
-    babel-plugin-jest-hoist "^19.0.0"
 
 babel-register@^6.24.0:
   version "6.24.0"
@@ -195,7 +177,7 @@ camelcase@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-3.0.0.tgz#32fc4b9fcdaf845fcdf7e73bb97cac2261f0ab0a"
 
-chalk@^1.1.0:
+chalk@^1.1.0, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   dependencies:
@@ -221,7 +203,7 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-convert-source-map@^1.1.0:
+convert-source-map@^1.1.0, convert-source-map@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.4.0.tgz#e3dad195bf61bfe13a7a3c73e9876ec14a0268f3"
 
@@ -335,7 +317,7 @@ globals@^9.0.0:
   version "9.16.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.16.0.tgz#63e903658171ec2d9f51b1d31de5e2b8dc01fb80"
 
-graceful-fs@^4.1.2:
+graceful-fs@^4.1.11, graceful-fs@^4.1.2:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 

--- a/packages/jest-util/src/formatTestResults.js
+++ b/packages/jest-util/src/formatTestResults.js
@@ -63,6 +63,7 @@ function formatTestAssertion(
 ): FormattedAssertionResult {
   const result: FormattedAssertionResult = {
     failureMessages: null,
+    fullName: assertion.fullName,
     status: assertion.status,
     title: assertion.title,
   };

--- a/types/TestResult.js
+++ b/types/TestResult.js
@@ -94,9 +94,10 @@ export type AssertionResult = {|
 |};
 
 export type FormattedAssertionResult = {
+  failureMessages: Array<string> | null,
+  fullName: string,
   status: Status,
   title: string,
-  failureMessages: Array<string> | null,
 };
 
 export type AggregatedResult = {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
This PR adds an additional field `fullName` to `FormattedAssertionResult`. 

When we try to analyze the test result json, we find that two `it` test cases under different `describe` block in one test file are rendered the same in the json report. Including the full name help solving this issue.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

The function I touched doesn't have a test. It was added here in https://github.com/facebook/jest/pull/1988. 

Sample json from my test run:
```
...
    "testResults": [
        {
            "assertionResults": [
                {
                    "failureMessages": [],
                    "status": "passed",
                    "title": "Header renders"
                },
                {
                    "failureMessages": [],
                    "status": "passed",
                    "title": "Header renders <Element /> with right props"
                }
            ],
            "endTime": 1493233733071,
            "message": "",
            "name": "/path/to/the/test/file.js",
            "startTime": 1493233730480,
            "status": "passed",
            "summary": ""
        }
    ],
...
```
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
