### PR TITLE
jest-config: use UID for default cache folder

### DIFF
--- a/packages/jest-config/src/defaults.js
+++ b/packages/jest-config/src/defaults.js
@@ -23,7 +23,14 @@ module.exports = ({
   automock: false,
   bail: false,
   browser: false,
-  cacheDirectory: path.join(os.tmpdir(), 'jest'),
+  cacheDirectory: (() => {
+    if (process.getuid == null) {
+      return path.join(os.tmpdir(), 'jest');
+    }
+    // On some platforms tmpdir() is `/tmp`, causing conflicts between different users and
+    // permission issues. Adding an additional subdivision by UID can help.
+    return path.join(os.tmpdir(), 'jest', process.getuid().toString(36));
+  })(),
   clearMocks: false,
   coveragePathIgnorePatterns: [NODE_MODULES_REGEXP],
   coverageReporters: ['json', 'text', 'lcov', 'clover'],


### PR DESCRIPTION
**Summary**

It appears in some contexts, `os.tmpdir()` doesn't make a difference between different users. As a result, you can run some script that runs `jest-runtime` once using `root`, then later using a non-privileged user; this crashes because that user is unable to write files owned by `root`. Separating by UID helps avoiding permission conflicts on files created by the cache logic.

**Test plan**

Automated testing. Would you suggest a particular test plan for this?
