### PR TITLE
Fixing a bug with crowdin-cli tool and yarn command not inheriting environment variables.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -43,6 +43,8 @@ deployment:
       - git config --global user.email "jest-bot@users.noreply.github.com"
       - git config --global user.name "Website Deployment Script"
       - echo "machine github.com login jest-bot password $GITHUB_TOKEN" > ~/.netrc
-      - cd website && yarn crowdin-upload
-      - cd website && yarn crowdin-download
+      # removed calls to "yarn crowdin-upload" and "yarn crowdin-download" because of an issue
+      # with yarn not inheriting environment variables
+      - cd website && crowdin-cli --config ../crowdin.yaml upload sources --auto-update -b master
+      - cd website && crowdin-cli --config ../crowdin.yaml download -b master
       - cd website && GIT_USER=jest-bot npm run gh-pages

--- a/crowdin.yaml
+++ b/crowdin.yaml
@@ -1,6 +1,6 @@
-project_identifier: jest
-api_key_env: CROWDIN_API_KEY
-base_path: ..
+project_identifier: 'jest'
+api_key_env: 'CROWDIN_API_KEY'
+base_path: '..'
 
 files:
   -


### PR DESCRIPTION
On last master build, crowdin-cli could not access the ENV variable CROWDIN_API_KEY. I was able to workaround this by replacing the two yarn commands ("yarn crowdin-upload" and "yarn crowdin-download") in circle.yml with their full commands.