### PR TITLE
Add yarn-error.log to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ coverage
 lerna-debug.log
 npm-debug.log
 npm-debug.log*
+yarn-error.log*


### PR DESCRIPTION
**Summary**

Because there were some errors when I tried `yarn clean-all && yarn` when I forgot the computer was offline yesterday, there were some untracked files when I checked `git status` today:

```sh
packages/jest-runtime/yarn-error.log
yarn-error.log
```

After I added a line to the `.gitignore` file, `git` does not consider those files untracked.

By the way, here are two alternative concise solutions from other repositories:
* `*.log*` at https://github.com/facebook/react/blob/master/.gitignore#L23
* `*.log` at https://github.com/airbnb/enzyme/blob/master/.gitignore#L3

**Test plan**

Review by human, and thank you for it.