### PR TITLE
jest-config: UID needs to be part of top-level folder

### DIFF
--- a/packages/jest-config/src/defaults.js
+++ b/packages/jest-config/src/defaults.js
@@ -29,7 +29,7 @@ const cacheDirectory = (() => {
   // help.
   return path.join(
     os.tmpdir(),
-    'jest_' + getuid().toString(36),
+    'jest_' + getuid.call(process).toString(36),
   );
 })();
 

--- a/packages/jest-config/src/defaults.js
+++ b/packages/jest-config/src/defaults.js
@@ -20,7 +20,8 @@ const {replacePathSepForRegex} = require('jest-regex-util');
 const NODE_MODULES_REGEXP = replacePathSepForRegex(constants.NODE_MODULES);
 
 const cacheDirectory = (() => {
-  if (process.getuid == null) {
+  const {getuid} = process;
+  if (getuid == null) {
     return path.join(os.tmpdir(), 'jest');
   }
   // On some platforms tmpdir() is `/tmp`, causing conflicts between different
@@ -28,8 +29,7 @@ const cacheDirectory = (() => {
   // help.
   return path.join(
     os.tmpdir(),
-    'jest',
-    (process.getuid && process.getuid().toString(36)) || '',
+    'jest_' + getuid().toString(36),
   );
 })();
 


### PR DESCRIPTION
**Summary**

If `jest` runs first as `root`, then as non-`root`, then the top-level `/tmp/jest` folder will be owned by root and will not allow write permissions for the non-`root` instance. So we need to use completely different top-level folders for each user. We assume that we always have write permissions on the top-level `/tmp` or whichever `os.tmpdir()` returns.

**Test plan**

Automated testing.