### PR TITLE
Fix filter input when using Terminal.app

### DIFF
--- a/packages/jest-cli/src/TestNamePatternPrompt.js
+++ b/packages/jest-cli/src/TestNamePatternPrompt.js
@@ -34,17 +34,22 @@ module.exports = class TestNamePatternPrompt {
   _cachedTestResults: Array<TestResult>;
   _pipe: stream$Writable | tty$WriteStream;
   _prompt: Prompt;
+  _currentUsageRows: number;
 
   constructor(pipe: stream$Writable | tty$WriteStream, prompt: Prompt) {
     this._pipe = pipe;
     this._prompt = prompt;
+    this._currentUsageRows = usageRows;
   }
 
   run(onSuccess: Function, onCancel: Function, options?: {header: string}) {
     this._pipe.write(ansiEscapes.cursorHide);
     this._pipe.write(ansiEscapes.clearScreen);
     if (options && options.header) {
-      this._pipe.write(options.header);
+      this._pipe.write(options.header + '\n');
+      this._currentUsageRows = usageRows + options.header.split('\n').length;
+    } else {
+      this._currentUsageRows = usageRows;
     }
     this._pipe.write(usage());
     this._pipe.write(ansiEscapes.cursorShow);
@@ -103,7 +108,7 @@ module.exports = class TestNamePatternPrompt {
     }
 
     this._pipe.write(
-      ansiEscapes.cursorTo(stringLength(inputText), usageRows - 1),
+      ansiEscapes.cursorTo(stringLength(inputText), this._currentUsageRows - 1),
     );
     this._pipe.write(ansiEscapes.cursorRestorePosition);
   }

--- a/packages/jest-cli/src/TestPathPatternPrompt.js
+++ b/packages/jest-cli/src/TestPathPatternPrompt.js
@@ -42,17 +42,22 @@ module.exports = class TestPathPatternPrompt {
   _pipe: stream$Writable | tty$WriteStream;
   _prompt: Prompt;
   _searchSources: SearchSources;
+  _currentUsageRows: number;
 
   constructor(pipe: stream$Writable | tty$WriteStream, prompt: Prompt) {
     this._pipe = pipe;
     this._prompt = prompt;
+    this._currentUsageRows = usageRows;
   }
 
   run(onSuccess: Function, onCancel: Function, options?: {header: string}) {
     this._pipe.write(ansiEscapes.cursorHide);
     this._pipe.write(ansiEscapes.clearScreen);
     if (options && options.header) {
-      this._pipe.write(options.header);
+      this._pipe.write(options.header + '\n');
+      this._currentUsageRows = usageRows + options.header.split('\n').length;
+    } else {
+      this._currentUsageRows = usageRows;
     }
     this._pipe.write(usage());
     this._pipe.write(ansiEscapes.cursorShow);
@@ -130,7 +135,7 @@ module.exports = class TestPathPatternPrompt {
     }
 
     this._pipe.write(
-      ansiEscapes.cursorTo(stringLength(inputText), usageRows - 1),
+      ansiEscapes.cursorTo(stringLength(inputText), this._currentUsageRows - 1),
     );
     this._pipe.write(ansiEscapes.cursorRestorePosition);
   }

--- a/packages/jest-cli/src/__tests__/__snapshots__/watch-filename-pattern-mode-test.js.snap
+++ b/packages/jest-cli/src/__tests__/__snapshots__/watch-filename-pattern-mode-test.js.snap
@@ -212,8 +212,6 @@ exports[`Watch mode flows Pressing "c" clears the filters 1`] = `
 "[MOCK - cursorHide]
 [MOCK - clearScreen]
 
-
-
 Pattern Mode Usage
  › Press Esc to exit pattern mode.
  › Press Enter to apply pattern to all filenames.
@@ -358,7 +356,7 @@ Pattern Mode Usage
 
 
  Start typing to filter by a test name regex pattern.
-[MOCK - cursorTo(11, 5)]
+[MOCK - cursorTo(11, 7)]
 [MOCK - cursorRestorePosition]"
 `;
 
@@ -383,7 +381,7 @@ Pattern Mode Usage
 
 
  Start typing to filter by a filename regex pattern.
-[MOCK - cursorTo(11, 5)]
+[MOCK - cursorTo(11, 7)]
 [MOCK - cursorRestorePosition]"
 `;
 
@@ -408,7 +406,7 @@ Pattern Mode Usage
 
 
  Start typing to filter by a filename regex pattern.
-[MOCK - cursorTo(11, 5)]
+[MOCK - cursorTo(11, 7)]
 [MOCK - cursorRestorePosition]"
 `;
 
@@ -433,7 +431,7 @@ Pattern Mode Usage
 
 
  Start typing to filter by a test name regex pattern.
-[MOCK - cursorTo(11, 5)]
+[MOCK - cursorTo(11, 7)]
 [MOCK - cursorRestorePosition]"
 `;
 
@@ -458,6 +456,6 @@ Pattern Mode Usage
 
 
  Start typing to filter by a test name regex pattern.
-[MOCK - cursorTo(11, 5)]
+[MOCK - cursorTo(11, 7)]
 [MOCK - cursorRestorePosition]"
 `;

--- a/packages/jest-cli/src/watch.js
+++ b/packages/jest-cli/src/watch.js
@@ -210,7 +210,7 @@ const watch = (
             startRun();
           },
           onCancelPatternPrompt,
-          {header: activeFilters(argv) + '\n'},
+          {header: activeFilters(argv)},
         );
         break;
       case KEYS.T:
@@ -224,7 +224,7 @@ const watch = (
             startRun();
           },
           onCancelPatternPrompt,
-          {header: activeFilters(argv) + '\n'},
+          {header: activeFilters(argv)},
         );
         break;
       case KEYS.QUESTION_MARK:


### PR DESCRIPTION
This issue got introduced by #3327 

**Summary**

The position of the cursor is wrong in some terminals like Terminal.app, but not in other terminals that do support clearScreen

**Test plan**

Here is the before and after
![filters-issue](https://cloud.githubusercontent.com/assets/574806/25506777/2a124a80-2b5d-11e7-8d93-69ffabd00d13.gif)
