### PR TITLE
Make yarn silent.

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,20 +54,20 @@
     "clean-all": "rm -rf ./node_modules && rm -rf ./packages/*/node_modules && rm -rf ./integration_tests/*/*/node_modules && yarn run build-clean",
     "danger": "node ./danger/node_modules/.bin/danger",
     "jest": "node ./packages/jest-cli/bin/jest.js",
-    "jest-coverage": "yarn run jest -- --coverage",
-    "lint": "yarn run lint-prettier && eslint . --cache && yarn run lint-docs",
+    "jest-coverage": "yarn run jest --silent -- --coverage",
+    "lint": "yarn run lint-prettier --silent && eslint . --cache && yarn run lint-docs --silent",
     "lint-docs": "eslint --config ./.eslintrc-docs.json --no-ignore --ext md ./docs/*.md",
     "lint-prettier": "node scripts/prettier.js lint",
     "prettier": "node scripts/prettier.js write",
-    "postinstall": "node ./scripts/postinstall.js && yarn run build && (cd packages/eslint-plugin-jest && yarn link) && yarn link eslint-plugin-jest",
-    "publish": "yarn run build-clean && yarn run build && lerna publish",
-    "test-ci": "yarn run typecheck && yarn run lint && yarn run jest-coverage -- -i && yarn run test-examples && node scripts/mapCoverage.js && codecov",
-    "test-ci-partial": "yarn run jest -- -i && yarn run test-examples",
+    "postinstall": "node ./scripts/postinstall.js && yarn run build --silent && (cd packages/eslint-plugin-jest && yarn link --silent) && yarn link eslint-plugin-jest --silent",
+    "publish": "yarn run build-clean --silent && yarn run build --silent && lerna publish --silent",
+    "test-ci": "yarn run typecheck --silent && yarn run lint --silent && yarn run jest-coverage --silent -- -i && yarn run test-examples --silent && node scripts/mapCoverage.js && codecov",
+    "test-ci-partial": "yarn run jest --silent -- -i && yarn run test-examples --silent",
     "test-examples": "node scripts/test_examples.js",
     "test-pretty-format-perf": "node packages/pretty-format/perf/test.js",
-    "test": "yarn run typecheck && yarn run lint && yarn run jest && yarn run test-examples",
+    "test": "yarn run typecheck --silent && yarn run lint --silent && yarn run jest --silent && yarn run test-examples --silent",
     "typecheck": "flow check",
-    "watch": "yarn run build && node ./scripts/watch.js"
+    "watch": "yarn run build --silent && node ./scripts/watch.js"
   },
   "jest": {
     "modulePathIgnorePatterns": [


### PR DESCRIPTION
**Summary**

@jeanlauliac pointed out that it is confusing that yarn prints "Done in *time*" multiple times because all our scripts invoke Yarn. @bestander recommended adding `--silent`. It makes the `package.json` file bigger but the output more sane.

**Test plan**
* Run all the commands from scripts
* Wait for CI