### PR TITLE
Bump flow to 0.45

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -11,4 +11,4 @@ module.name_mapper='^types/\(.*\)$' -> '<PROJECT_ROOT>/types/\1.js'
 module.name_mapper='\(jest-[^/]*\)' -> '<PROJECT_ROOT>/packages/\1/src/index.js'
 
 [version]
-^0.43.0
+^0.45.0

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "eslint-plugin-flowtype": "^2.30.3",
     "eslint-plugin-markdown": "^1.0.0-beta.4",
     "eslint-plugin-react": "^6.7.1",
-    "flow-bin": "^0.43.0",
+    "flow-bin": "^0.45.0",
     "glob": "^7.1.1",
     "graceful-fs": "^4.1.11",
     "immutable": "^4.0.0-rc.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1581,9 +1581,9 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flow-bin@^0.43.0:
-  version "0.43.1"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.43.1.tgz#0733958b448fb8ad4b1576add7e87c31794c81bc"
+flow-bin@^0.45.0:
+  version "0.45.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.45.0.tgz#009dd0f577a3f665c74ca8be827ae8c2dd8fd6b5"
 
 flow-parser@0.43.0:
   version "0.43.0"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Bumps flow to the latest version.
They said something about perf wins in 0.43.1 and 0.44, but it actually takes 2s more for `flow check` now :(

**Test plan**

flow
