### PR TITLE
Fix coverage for untested files.

### DIFF
--- a/packages/jest-cli/src/reporters/CoverageWorker.js
+++ b/packages/jest-cli/src/reporters/CoverageWorker.js
@@ -18,7 +18,7 @@ const generateEmptyCoverage = require('../generateEmptyCoverage');
 type CoverageWorkerData = {|
   globalConfig: GlobalConfig,
   config: ProjectConfig,
-  untestedFilePath: Path,
+  path: Path,
 |};
 
 type WorkerCallback = (error: ?SerializableError, result: ?Object) => void;
@@ -44,19 +44,14 @@ process.on('uncaughtException', err => {
 });
 
 module.exports = (
-  {globalConfig, config, untestedFilePath}: CoverageWorkerData,
+  {config, globalConfig, path}: CoverageWorkerData,
   callback: WorkerCallback,
 ) => {
   try {
-    const source = fs.readFileSync(untestedFilePath).toString();
-    const result = generateEmptyCoverage(
-      source,
-      untestedFilePath,
-      globalConfig,
-      config,
-    );
+    const source = fs.readFileSync(path, 'utf8');
+    const result = generateEmptyCoverage(source, path, globalConfig, config);
     callback(null, result);
-  } catch (e) {
-    callback(formatCoverageError(e, untestedFilePath), undefined);
+  } catch (error) {
+    callback(formatCoverageError(error, path), undefined);
   }
 };

--- a/packages/jest-cli/src/reporters/__tests__/CoverageReporter-test.js
+++ b/packages/jest-cli/src/reporters/__tests__/CoverageReporter-test.js
@@ -77,7 +77,7 @@ describe('onRunComplete', () => {
       };
     });
 
-    testReporter = new CoverageReporter();
+    testReporter = new CoverageReporter({});
     testReporter.log = jest.fn();
   });
 


### PR DESCRIPTION
**Summary**

This is a follow-up to @dmitriiabramov's PR from an open source contributor.

* `onRunComplete` has to be run sequentially, not concurrently so that we always print messages in the same order.
* Add ability to run untested coverage in-band when workers is <= 1.
* `--bail` also has to wait for the response from reporters before continuing with the test run, otherwise tests will run while it tries to clean up.
* Fixed up code style.

**Test plan**
jest