### PR TITLE
Add warning about setup file and mocking

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -159,7 +159,7 @@ Alias: `-i`. Run all tests serially in the current process, rather than creating
 
 ### `--setupTestFrameworkScriptFile=<file>`
 
-The path to a module that runs some code to configure or set up the testing framework before each test.
+The path to a module that runs some code to configure or set up the testing framework before each test. Beware that files imported by the setup script will not be mocked during testing.
 
 ### `--showConfig`
 

--- a/docs/JestObjectAPI.md
+++ b/docs/JestObjectAPI.md
@@ -121,6 +121,8 @@ jest.mock('../moduleName', () => {
 
 *Note: When using `babel-jest`, calls to `mock` will automatically be hoisted to the top of the code block. Use `doMock` if you want to explicitly avoid this behavior.*
 
+*Warning: Importing a module in a setup file (as specified by `setupTestFrameworkScriptFile`) will prevent mocking for the module in question, as well as all the modules that it imports.*
+
 Returns the `jest` object for chaining.
 
 ### `jest.clearAllMocks()`


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

As discussed in #3364 

Update docs to include a warning about how importing modules in a setup file will circumvent the mocking system.