### PR TITLE
Improve TS instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ then modify your `package.json` so the `jest` section looks something like:
 {
   "jest": {
     "transform": {
-      ".(ts|tsx)": "<rootDir>/node_modules/ts-jest/preprocessor.js"
+      "^.+\\.tsx?$": "<rootDir>/node_modules/ts-jest/preprocessor.js"
     },
     "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
     "moduleFileExtensions": [

--- a/docs/en/GettingStarted.md
+++ b/docs/en/GettingStarted.md
@@ -120,7 +120,7 @@ then modify your `package.json` so the `jest` section looks something like:
 {
   "jest": {
     "transform": {
-      ".(ts|tsx)": "<rootDir>/node_modules/ts-jest/preprocessor.js"
+      "^.+\\.tsx?$": "<rootDir>/node_modules/ts-jest/preprocessor.js"
     },
     "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
     "moduleFileExtensions": [


### PR DESCRIPTION


<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Suggest a small change to the match pattern for TS transformer.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

The regex for TS transformer in the doc is too broad. For example, I set
the regex to `".(ts|tsx)"` as recommended in the docs and my test would
fail. The reason is that  one of my tested file imports the file `isArguments.js`
from `lodash-es` (ES 2015 build of lodash). Because `isArguments.js` matches the pattern
`.(ts|tsx)`, this file is not transpiled by babel (even after I've set
`transformIgnorePatterns` to `"<rootDir>/node_modules/(?!lodash-es)"`.
Changing the pattern to `"^.+\\.tsx?$"` fixes this problem. I think this will help others avoid the same problem.

**Test plan**

```js
// sample.ts
import sortBy from 'lodash-es/sortBy';
export function sample() {
// 
}
```

```js
// sample.test.js
import {
  sample,
} from './sample';

// assertions
```
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
