### PR TITLE
Use diff-match-patch for string diffing

### DIFF
--- a/packages/jest-diff/package.json
+++ b/packages/jest-diff/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "chalk": "^1.1.3",
     "diff": "^3.2.0",
+    "diff-match-patch": "^1.0.0",
     "jest-matcher-utils": "^19.0.0",
     "pretty-format": "^19.0.0"
   }

--- a/packages/jest-diff/src/diffStrings.js
+++ b/packages/jest-diff/src/diffStrings.js
@@ -12,6 +12,7 @@
 
 const chalk = require('chalk');
 const diff = require('diff');
+const DiffMatchPatch = require('diff-match-patch');
 
 const {NO_DIFF_MESSAGE} = require('./constants.js');
 const DIFF_CONTEXT = 5;
@@ -46,15 +47,17 @@ const getAnnotation = (options: ?DiffOptions): string =>
   '\n' +
   chalk.red('+ ' + ((options && options.bAnnotation) || 'Received')) +
   '\n\n';
-
+const diffMatchPatch = new DiffMatchPatch();
+diffMatchPatch.Diff_Timeout = 0;
 const diffLines = (a: string, b: string): Diff => {
   let isDifferent = false;
+  const diffs = diffMatchPatch.diff_main(a, b);
   return {
-    diff: diff
-      .diffLines(a, b)
+    diff: diffs
       .map(part => {
-        const {added, removed} = part;
-        const value = part.value;
+        const added = part[0] === 1;
+        const removed = part[0] === -1;
+        const value = part[1];
 
         if (added || removed) {
           isDifferent = true;

--- a/packages/jest-diff/src/diffStrings.js
+++ b/packages/jest-diff/src/diffStrings.js
@@ -54,11 +54,13 @@ const diffLines = (a: string, b: string): Diff => {
       .diffLines(a, b)
       .map(part => {
         const {added, removed} = part;
-        if (part.added || part.removed) {
+        const value = part.value;
+
+        if (added || removed) {
           isDifferent = true;
         }
 
-        const lines = part.value.split('\n');
+        const lines = value.split('\n');
         const color = getColor(added, removed);
         const bgColor = getBgColor(added, removed);
 
@@ -69,7 +71,7 @@ const diffLines = (a: string, b: string): Diff => {
         return lines
           .map(line => {
             const highlightedLine = highlightTrailingWhitespace(line, bgColor);
-            const mark = color(part.added ? '+' : part.removed ? '-' : ' ');
+            const mark = color(added ? '+' : removed ? '-' : ' ');
             return mark + ' ' + color(highlightedLine) + '\n';
           })
           .join('');

--- a/packages/jest-diff/src/diffStrings.js
+++ b/packages/jest-diff/src/diffStrings.js
@@ -52,6 +52,8 @@ diffMatchPatch.Diff_Timeout = 0;
 const diffLines = (a: string, b: string): Diff => {
   let isDifferent = false;
   const diffs = diffMatchPatch.diff_main(a, b);
+  // the following step likely needs changing
+  diffMatchPatch.diff_cleanupSemantic(diffs);
   return {
     diff: diffs
       .map(part => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
I did not dive _that_ deep into the issue yet. Although swapping the `diff` lib is the suggested solution correct me if I'm wrong in assuming it _is_ the full solution. I could see about adding a test that currently hangs jest as described in a couple of comments on the issue.

It's hard to share some of the test output because the highlighting in it is essential. I'd be happy to provide some screens if you prefer this to grabbing my branch!

To be done:
* [ ] Figure out what seems to be different diffing for some whitespace

Decisions made:
* Set diff timeout to 0 (meaning none)

Thanks go to @cpojer for giving me the little encouragement for which I'd hoped!
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
* [ ] Pass all current tests
* [ ] Add a test that currently grinds `diff` to a halt if desired.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

**Sidenotes**
* The API docs for diff-merge-patch are no longer available, find the web.archive [here](https://web.archive.org/web/20160922004754/https://code.google.com/p/google-diff-match-patch/wiki/API).
* Took a peak at [how AVA does it](https://github.com/avajs/ava/blob/146c3e25df31d39165b4ad99f4d523e7806c30fb/lib/format-assert-error.js#L73). Interestingly they opt for the default 1s timeout if I'm reading things right. Maybe that makes more sense. Do share your thoughts.

---
Fixes #1772.