### PR TITLE
Fix new jest.config.js behavior.

### DIFF
--- a/packages/jest-config/src/findConfig.js
+++ b/packages/jest-config/src/findConfig.js
@@ -35,13 +35,15 @@ const findConfig = (root: Path): InitialOptions => {
       const pkg = require(packageJsonFilePath);
       if (pkg.jest) {
         options = pkg.jest;
-        break;
       }
+      // Even if there is no configuration, we stop traveling up the
+      // tree if we hit a `package.json` file.
+      break;
     }
   } while (directory !== (directory = path.dirname(directory)));
-  if (!options.rootDir) {
-    options.rootDir = root;
-  }
+  options.rootDir = options.rootDir
+    ? path.resolve(root, options.rootDir)
+    : root;
   return options;
 };
 


### PR DESCRIPTION
**Summary**

This fixes `yarn test-examples` on master. Previously, it traversed up the tree until it found a jest config in package.json, now it stops when it finds a `package.json` as that can be considered the root of an app.

**Test plan**

`yarn test` works again.