### PR TITLE
Preserve folder hierarchy when uploading documents to Crowd In

### DIFF
--- a/crowdin.yaml
+++ b/crowdin.yaml
@@ -1,6 +1,7 @@
 project_identifier_env: CROWDIN_PROJECT_ID
 api_key_env: CROWDIN_API_KEY
 base_path: "./"
+preserve_hierarchy: true
 
 files:
   -


### PR DESCRIPTION
**Summary**

A recent crowdin change removed folder hierarchy of files causing duplicate files to be uploaded. This setting enabled it so files are stored properly.
 
**Test plan**

Verified locally.