### PR TITLE
Add babel-transform-runtime to browser builds

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -41,7 +41,12 @@ const babelNodeOptions = JSON.parse(
   fs.readFileSync(path.resolve(__dirname, '..', '.babelrc'), 'utf8')
 );
 babelNodeOptions.babelrc = false;
-const babelEs5Options = Object.assign({}, babelNodeOptions, {presets: 'env'});
+const babelEs5Options = Object.assign(
+  {},
+  babelNodeOptions,
+  {presets: 'env'},
+  {plugins: [...babelNodeOptions.plugins, 'transform-runtime']}
+);
 
 const fixedWidth = str => {
   const WIDTH = 80;


### PR DESCRIPTION
**Summary**

Related to #3360.

https://github.com/facebook/jest/pull/3421 introduced additional es5 builds of speciic Jest packages meant for use in browsers. But as `async/await` is used some places (and possibly other ES6 feature), the transpilation was missing `transform-runtime` in order to work for consumers.

Alternatives to this solution
- stop using `async/await` (and possibly other es6 features) in packages like `jest-matchers`
- make consumers provide the babel global runtime (but gives a pretty bad DX)

Should be noted that this proposed solution needs the consumer to install `babel-runtime`. This should be documented when browser support is made public.

**Test plan**

Do a beta build and test on https://github.com/ReactTraining/react-media/pull/61