### PR TITLE
Ability to fine-tune transform plugins via config

### DIFF
--- a/packages/jest-config/src/defaults.js
+++ b/packages/jest-config/src/defaults.js
@@ -63,6 +63,7 @@ module.exports = ({
   testURL: 'about:blank',
   timers: 'real',
   transformIgnorePatterns: [NODE_MODULES_REGEXP],
+  transformPlugins: [],
   useStderr: false,
   verbose: null,
   watch: false,

--- a/packages/jest-config/src/normalize.js
+++ b/packages/jest-config/src/normalize.js
@@ -430,6 +430,7 @@ function normalize(options: InitialOptions, argv: Argv) {
       case 'verbose':
       case 'watch':
       case 'watchman':
+      case 'transformPlugins':
         value = options[key];
         break;
     }

--- a/packages/jest-config/src/validConfig.js
+++ b/packages/jest-config/src/validConfig.js
@@ -85,6 +85,7 @@ module.exports = ({
     '^.+\\.js$': '<rootDir>/preprocessor.js',
   },
   transformIgnorePatterns: [NODE_MODULES_REGEXP],
+  transformPlugins: [],
   unmockedModulePathPatterns: ['mock'],
   updateSnapshot: true,
   useStderr: false,

--- a/packages/jest-runtime/src/ScriptTransformer.js
+++ b/packages/jest-runtime/src/ScriptTransformer.js
@@ -135,6 +135,13 @@ class ScriptTransformer {
 
       // $FlowFixMe
       transform = (require(transformPath): Transformer);
+
+      if (transform.createTransformer && this._config.transformPlugins) {
+        transform = transform.createTransformer(
+          {plugins: this._config.transformPlugins}
+        );
+      }
+
       if (typeof transform.process !== 'function') {
         throw new TypeError(
           'Jest: a transform must export a `process` function.',

--- a/types/Config.js
+++ b/types/Config.js
@@ -54,6 +54,7 @@ export type DefaultOptions = {|
   testURL: string,
   timers: 'real' | 'fake',
   transformIgnorePatterns: Array<Glob>,
+  transformPlugins?: Array<string>,
   useStderr: boolean,
   verbose: ?boolean,
   watch: boolean,
@@ -115,6 +116,7 @@ export type InitialOptions = {|
   timers?: 'real' | 'fake',
   transform?: {[key: string]: string},
   transformIgnorePatterns?: Array<Glob>,
+  transformPlugins?: Array<string>,
   unmockedModulePathPatterns?: Array<string>,
   updateSnapshot?: boolean,
   useStderr?: boolean,
@@ -187,5 +189,6 @@ export type ProjectConfig = {|
   timers: 'real' | 'fake',
   transform: Array<[string, Path]>,
   transformIgnorePatterns: Array<Glob>,
+  transformPlugins?: Array<string>,
   unmockedModulePathPatterns: ?Array<string>,
 |};


### PR DESCRIPTION
## Summary

If applied, this commit will enable to pass custom plugins to the babel transformer that jest uses internally. — The configuration is optional, therefore when the option is not present jest runtime will work as it was before.

## Why was this change made?

When I tried to use jest with a nested set of projects, I realized that some of the transformation that I defined on `.babelrc` (like, for example ` "plugins": [ "transform-flow-strip-types", "istanbul", "transform-es2015-modules-commonjs" ] ` were not being proppagated to the babel transformer that `jest` was using.

I set `transformIgnorePatterns`; however, that partially solved my problem since I wanted a different type of transformation for certain dependencies that I had.

So, to scratch my own itch, I extended to configuration to add that ability.

## Any side effects?

The patch is totally backwards-compatible: When the option is not present, the code works as it was before. And when the option is given, the code honors additional options.

I’ve run the whole test suite and everything is green.

## Example Configuration

package.json:

```json
  "jest": {
    "transformPlugins": [
      "transform-flow-strip-types",
      "istanbul",
      "transform-es2015-modules-commonjs"
    ]
  },
```

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
