### PR TITLE
Fix TestSequencer to use proper cache object.

### DIFF
--- a/packages/jest-cli/src/TestSequencer.js
+++ b/packages/jest-cli/src/TestSequencer.js
@@ -38,15 +38,24 @@ class TestSequencer {
   _getCache(test: Test) {
     const {context} = test;
     if (!this._cache.has(context) && context.config.cache) {
-      try {
-        this._cache.set(
-          context,
-          JSON.parse(fs.readFileSync(this._getCachePath(context), 'utf8')),
-        );
-      } catch (e) {}
+      const cachePath = this._getCachePath(context);
+      if (fs.existsSync(cachePath)) {
+        try {
+          this._cache.set(
+            context,
+            JSON.parse(fs.readFileSync(cachePath, 'utf8')),
+          );
+        } catch (e) {}
+      }
     }
 
-    return this._cache.get(context) || {};
+    let cache = this._cache.get(context);
+    if (!cache) {
+      cache = {};
+      this._cache.set(context, cache);
+    }
+
+    return cache;
   }
 
   // When running more tests than we have workers available, sort the tests

--- a/packages/jest-cli/src/__tests__/TestSequencer-test.js
+++ b/packages/jest-cli/src/__tests__/TestSequencer-test.js
@@ -46,6 +46,7 @@ beforeEach(() => {
   sequencer = new TestSequencer();
 
   fs.readFileSync = jest.fn(() => '{}');
+  fs.existsSync = () => true;
   fs.statSync = jest.fn(filePath => ({size: filePath.length}));
   fs.writeFileSync = jest.fn();
 });
@@ -118,6 +119,45 @@ test('sorts based on failures, timing information and file size', () => {
     {context, duration: 5, path: '/test-a.js'},
     {context, duration: 2, path: '/test-d.js'},
   ]);
+});
+
+test('writes the cache based on results without existing cache', () => {
+  fs.readFileSync = jest.fn(() => {
+    throw new Error('File does not exist.');
+  });
+
+  const testPaths = ['/test-a.js', '/test-b.js', '/test-c.js'];
+  const tests = sequencer.sort(toTests(testPaths));
+  sequencer.cacheResults(tests, {
+    testResults: [
+      {
+        numFailingTests: 0,
+        perfStats: {end: 2, start: 1},
+        testFilePath: '/test-a.js',
+      },
+      {
+        numFailingTests: 0,
+        perfStats: {end: 0, start: 0},
+        skipped: true,
+        testFilePath: '/test-b.js',
+      },
+      {
+        numFailingTests: 1,
+        perfStats: {end: 4, start: 1},
+        testFilePath: '/test-c.js',
+      },
+      {
+        numFailingTests: 1,
+        perfStats: {end: 2, start: 1},
+        testFilePath: '/test-x.js',
+      },
+    ],
+  });
+  const fileData = JSON.parse(fs.writeFileSync.mock.calls[0][1]);
+  expect(fileData).toEqual({
+    '/test-a.js': [SUCCESS, 1],
+    '/test-c.js': [FAIL, 3],
+  });
 });
 
 test('writes the cache based on the results', () => {


### PR DESCRIPTION
**Summary**

When there was no cache, we failed to create a new cache object and instead created a new object for every call to `getCache` which means we'll never end up with a proper cache file. I didn't notice probably because when I built this, I had a valid cache file.

**Test plan**

* See newly added test