### PR TITLE
Fix findConfig for `cd ../; jest --projects jest`.

### DIFF
--- a/integration_tests/__tests__/__snapshots__/jest.config.js-test.js.snap
+++ b/integration_tests/__tests__/__snapshots__/jest.config.js-test.js.snap
@@ -1,14 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`traverses directory tree up until it finds jest.config 1`] = `
-"  console.log __tests__/a-banana.js:3
+"  console.log ../../../__tests__/a-banana.js:3
 <<REPLACED>>/jest.config.js/some/nested/directory
 
 "
 `;
 
 exports[`traverses directory tree up until it finds jest.config 2`] = `
-" PASS  __tests__/a-banana.js
+" PASS  ../../../__tests__/a-banana.js
   ✓ banana
   ✓ abc
 

--- a/packages/jest-cli/src/runJest.js
+++ b/packages/jest-cli/src/runJest.js
@@ -194,10 +194,10 @@ const runJest = async (
   }
 
   // When using more than one context, make all printed paths relative to the
-  // current cwd.
-  if (contexts.length > 1) {
-    setConfig(contexts, {rootDir: process.cwd()});
-  }
+  // current cwd. rootDir is only used as a token during normalization and
+  // has no special meaning afterwards except for printing information to the
+  // CLI.
+  setConfig(contexts, {rootDir: process.cwd()});
 
   const results = await new TestRunner(globalConfig, {
     maxWorkers,

--- a/packages/jest-config/src/findConfig.js
+++ b/packages/jest-config/src/findConfig.js
@@ -56,14 +56,16 @@ const findConfig = (root: Path): InitialOptions => {
   }
 
   do {
-    const configJsFilePath = path.join(directory, JEST_CONFIG);
+    const configJsFilePath = path.resolve(path.join(directory, JEST_CONFIG));
     if (isFile(configJsFilePath)) {
       // $FlowFixMe
       options = require(configJsFilePath);
       break;
     }
 
-    const packageJsonFilePath = path.join(directory, PACKAGE_JSON);
+    const packageJsonFilePath = path.resolve(
+      path.join(directory, PACKAGE_JSON),
+    );
     if (isFile(packageJsonFilePath)) {
       // $FlowFixMe
       const pkg = require(packageJsonFilePath);
@@ -78,7 +80,7 @@ const findConfig = (root: Path): InitialOptions => {
 
   options.rootDir = options.rootDir
     ? path.resolve(root, options.rootDir)
-    : directory;
+    : path.resolve(directory);
 
   return options;
 };


### PR DESCRIPTION
**Summary**

This fixes configs, again. This is a can of worms, I'm unhappy about the new feature as much as I am happy about it :(

This has one behavior change:
* For running Jest in subfolders, it correctly prints the relative path for each test again.
* For running Jest in parent folders by traversing up the tree to find a package.json, it now shows relative paths for tests rather than the path from the root directory. I could argue both are ok and I may reconsider changing this again. Right now, I don't have enough time to find the one that makes the most sense, tbh.

**Test plan**

* `cd ../; jest --projects jest` works again.