### PR TITLE
Fix trailling comma

### DIFF
--- a/packages/eslint-plugin-jest/README.md
+++ b/packages/eslint-plugin-jest/README.md
@@ -31,7 +31,7 @@ Then configure the rules you want to use under the rules section.
     "jest/no-disabled-tests": "warn",
     "jest/no-focused-tests": "error",
     "jest/no-identical-title": "error",
-    "jest/valid-expect": "error",
+    "jest/valid-expect": "error"
   }
 }
 ```


### PR DESCRIPTION
Remove extra trailing at the last line of rules

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Trailing comma or any other violations are causing .json files stop working
