### PR TITLE
Reset context between test functions

### DIFF
--- a/packages/jest-jasmine2/src/jasmine-async.js
+++ b/packages/jest-jasmine2/src/jasmine-async.js
@@ -37,7 +37,7 @@ function promisifyLifeCycleFunction(originalFn, env) {
     // We make *all* functions async and run `done` right away if they
     // didn't return a promise.
     const asyncFn = function(done) {
-      const returnValue = fn.call(this);
+      const returnValue = fn.call({});
 
       if (isPromise(returnValue)) {
         returnValue.then(done, done.fail);
@@ -67,7 +67,7 @@ function promisifyIt(originalFn, env) {
     }
 
     const asyncFn = function(done) {
-      const returnValue = fn.call(this);
+      const returnValue = fn.call({});
 
       if (isPromise(returnValue)) {
         returnValue.then(done, done.fail);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Currently the `this` context we're passing in `before/after` (although here `this` is undefined, and I didn't even try to investigate why) and `it/test` functions is preserved across consequent `test` runs, which makes it confusing to use (see #3505). 

As a workaround I propose passing empty object as a context for each function. This way we can still use `this` in `test` but it will be unique for each test function.

Fixes #3505.

**Test plan**

I'll add an integration test later, after we agree this is the right solution.
