### PR TITLE
Fix broken docs/en links

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 - **🏃🏽 Instant Feedback**: Failed tests run first. Fast interactive mode can switch between running all tests or only test files related to changed files.
 
-- **📸 Snapshot Testing**: Jest can [capture snapshots](http://facebook.github.io/jest/docs/snapshot-testing.html) of React trees or other serializable values to simplify UI testing.
+- **📸 Snapshot Testing**: Jest can [capture snapshots](http://facebook.github.io/jest/docs/en/snapshot-testing.html) of React trees or other serializable values to simplify UI testing.
 
 ## Getting Started
 
@@ -58,7 +58,7 @@ PASS  ./sum.test.js
 
 **You just successfully wrote your first test using Jest!**
 
-This test used `expect` and `toBe` to test that two values were exactly identical. To learn about the other things that Jest can test, see [Using Matchers](https://facebook.github.io/jest/docs/using-matchers.html).
+This test used `expect` and `toBe` to test that two values were exactly identical. To learn about the other things that Jest can test, see [Using Matchers](https://facebook.github.io/jest/docs/en/using-matchers.html).
 
 ## Running from command line
 
@@ -70,7 +70,7 @@ Here's how to run Jest on files matching `my-test`, using `config.json` as a con
 jest my-test --notify --config=config.json
 ```
 
-If you'd like to learn more about running `jest` through the command line, take a look at the [Jest CLI Options](https://facebook.github.io/jest/docs/cli.html) page.
+If you'd like to learn more about running `jest` through the command line, take a look at the [Jest CLI Options](https://facebook.github.io/jest/docs/en/cli.html) page.
 
 ## Additional Configuration
 
@@ -111,7 +111,7 @@ It will not use `development` section like Babel does by default when no `NODE_E
 
 ### Using webpack
 
-Jest can be used in projects that use [webpack](https://webpack.github.io/) to manage assets, styles, and compilation. webpack does offer some unique challenges over other tools. Refer to the [webpack guide](https://facebook.github.io/jest/docs/webpack.html) to get started.
+Jest can be used in projects that use [webpack](https://webpack.github.io/) to manage assets, styles, and compilation. webpack does offer some unique challenges over other tools. Refer to the [webpack guide](https://facebook.github.io/jest/docs/en/webpack.html) to get started.
 
 ### Using TypeScript
 
@@ -145,10 +145,10 @@ then modify your `package.json` so the `jest` section looks something like:
 
 Learn more about using Jest at http://facebook.github.io/jest
 
-* [Getting Started](http://facebook.github.io/jest/docs/getting-started.html)
-* [Guides](http://facebook.github.io/jest/docs/snapshot-testing.html)
-* [API Reference](http://facebook.github.io/jest/docs/api.html)
-* [Configuring Jest](http://facebook.github.io/jest/docs/configuration.html)
+* [Getting Started](http://facebook.github.io/jest/docs/en/getting-started.html)
+* [Guides](http://facebook.github.io/jest/docs/en/snapshot-testing.html)
+* [API Reference](http://facebook.github.io/jest/docs/en/api.html)
+* [Configuring Jest](http://facebook.github.io/jest/docs/en/configuration.html)
 
 ## Contributing
 

--- a/docs/en/MoreResources.md
+++ b/docs/en/MoreResources.md
@@ -12,11 +12,11 @@ By now you should have a good idea of how Jest can make it easy to test your app
 
 ### Browse the docs
 
-- Learn about [Snapshot Testing](/jest/docs/snapshot-testing.html), [Mock Functions](/jest/docs/mock-functions.html), and more in our in-depth guides.
-- Migrate your existing tests to Jest by following our [migration guide](https://facebook.github.io/jest/docs/migration-guide.html).
-- Learn how to [configure Jest](/jest/docs/configuration.html).
-- Look at the full [API Reference](/jest/docs/api.html).
-- [Troubleshoot](/jest/docs/troubleshooting.html) problems with Jest.
+- Learn about [Snapshot Testing](/jest/docs/en/snapshot-testing.html), [Mock Functions](/jest/docs/en/mock-functions.html), and more in our in-depth guides.
+- Migrate your existing tests to Jest by following our [migration guide](https://facebook.github.io/jest/docs/en/migration-guide.html).
+- Learn how to [configure Jest](/jest/docs/en/configuration.html).
+- Look at the full [API Reference](/jest/docs/en/api.html).
+- [Troubleshoot](/jest/docs/en/troubleshooting.html) problems with Jest.
 
 ### Learn by example
 

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -10,7 +10,7 @@
       "title": "Learn how to test JavaScript with "
     },
     "mocking": {
-      "content": "Powerful [mocking library](/jest/docs/mock-functions.html) for functions and modules. Mock React Native components using `jest-react-native`.",
+      "content": "Powerful [mocking library](/jest/docs/en/mock-functions.html) for functions and modules. Mock React Native components using `jest-react-native`.",
       "title": "Powerful mocking library"
     },
     "parallelized": {
@@ -109,7 +109,7 @@
   "repo": "facebook/jest",
   "support": {
     "browse": {
-      "content": "Find what you're looking for in our detailed documentation and guides.\n- Learn how to [get started](/jest/docs/getting-started.html) with Jest.\n- [Troubleshoot](/jest/docs/troubleshooting.html) problems with Jest.\n- Learn how to [configure Jest](/jest/docs/configuration.html).\n- Look at the full [API Reference](/jest/docs/api.html).\n",
+      "content": "Find what you're looking for in our detailed documentation and guides.\n- Learn how to [get started](/jest/docs/en/getting-started.html) with Jest.\n- [Troubleshoot](/jest/docs/en/troubleshooting.html) problems with Jest.\n- Learn how to [configure Jest](/jest/docs/en/configuration.html).\n- Look at the full [API Reference](/jest/docs/en/api.html).\n",
       "title": "Browse the docs"
     },
     "header": {

--- a/website/layout/ReferenceLayout.js
+++ b/website/layout/ReferenceLayout.js
@@ -27,7 +27,7 @@ const ReferenceLayout = React.createClass({
             language={this.props.language}
             metadata={metadata}
             title="API"
-            root="/jest/docs/api.html"
+            root={'/jest/docs/' + this.props.language + '/api.html'}
             layout="reference"
           />
           <Container className="mainContainer referenceContainer">


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
I have tried to edit an existing page in the documentation and landed on GitHub's 404 page because the edit link was missing the language code. This PR is adding those to problematic links.

_I have not touched any references in older blog posts or changelogs, but can also do this if you want._

As a side not it might be good to add canonical/hreflang tags to improve search engine indexing. At least a redirect from non-en to en might be helpful since these pages are now already indexed and users who come from there will still land on these pages _(the sidebar isn't fully rendered there for some reason)_.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
N/A

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->