### PR TITLE
Fix website's yarn start on Windows

### DIFF
--- a/website/server/convert.js
+++ b/website/server/convert.js
@@ -12,6 +12,7 @@ const fs = require('fs');
 const glob = require('glob');
 const mkdirp = require('mkdirp');
 const optimist = require('optimist');
+const os = require('os');
 const path = require('path');
 const toSlug = require('../core/toSlug');
 
@@ -20,7 +21,7 @@ const languages = require('../languages.js');
 const argv = optimist.argv;
 
 function splitHeader(content) {
-  const lines = content.split('\n');
+  const lines = content.split(os.EOL);
   let i = 1;
   for (; i < lines.length - 1; ++i) {
     if (lines[i] === '---') {

--- a/website/server/feed.js
+++ b/website/server/feed.js
@@ -3,6 +3,7 @@
 const fs = require('fs');
 const path = require('path');
 const Feed = require('feed');
+const os = require('os');
 
 const blogFolder = path.resolve('../blog/');
 const blogRootURL = 'https://facebook.github.io/jest/blog/';
@@ -31,7 +32,7 @@ const retrieveMetaData = file => {
     ? post.replace(/\n\r/g, '\n').split('.\n\n')[0]
     : post.substring(0, indexOfTruncate);
 
-  return header.split('\n').filter(x => x).reduce((metadata, str) => {
+  return header.split(os.EOL).filter(x => x).reduce((metadata, str) => {
     const matches = /(.*?): (.*)/.exec(str);
     metadata[matches[1]] = matches[2];
     return metadata;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
This PR fixes a problem with the website's launching sequence on Windows when running `yarn start`. In some cases it seems to be necessary to replace the `\n` character with the OS' specific one through node's `os.EOL` constant because the `\r` character remains if just `\n` gets replaced on a Windows (10) machine.

The change in `feed.js` (`TypeError: Cannot read property '1' of null`) actually brings the site back up whereas the change in `convert.js` displays the blog post preview texts (not displayed without the change).

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
N/A, only clicked it through on a Windows and Mac.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
