### PR TITLE
expect.hasAssertions should throw when passed arguments

### DIFF
--- a/packages/jest-matchers/src/__tests__/assertion-counts-test.js
+++ b/packages/jest-matchers/src/__tests__/assertion-counts-test.js
@@ -35,4 +35,10 @@ describe('.hasAssertions()', () => {
     jestExpect.hasAssertions();
     jestExpect('a').toBe('a');
   });
+
+  it('throws if passed parameters', () => {
+    jestExpect(() => {
+      jestExpect.hasAssertions(2);
+    }).toThrow();
+  });
 });

--- a/packages/jest-matchers/src/index.js
+++ b/packages/jest-matchers/src/index.js
@@ -280,7 +280,8 @@ expect.addSnapshotSerializer = () => void 0;
 expect.assertions = (expected: number) => {
   global[GLOBAL_STATE].state.expectedAssertionsNumber = expected;
 };
-expect.hasAssertions = () => {
+expect.hasAssertions = expected => {
+  utils.ensureNoExpected(expected, '.hasAssertions');
   global[GLOBAL_STATE].state.isExpectingAssertions = true;
 };
 expect.setState = (state: Object) => {


### PR DESCRIPTION
* `expect.hasAssertions()` should not allow useless parameters to limit confusion with `expect.assertions(<n>)`.

Fixes #3517

**Summary**

`expect.hasAssertions` now throws an exception when is passed parameters which clarifies its difference from the similar matcher, `expect.assertions(<n>)`.

**Test plan**

* `yarn test`
