### PR TITLE
Add missing dependency

### DIFF
--- a/packages/jest-config/package.json
+++ b/packages/jest-config/package.json
@@ -13,6 +13,7 @@
     "jest-environment-jsdom": "^20.0.0",
     "jest-environment-node": "^20.0.0",
     "jest-jasmine2": "^20.0.0",
+    "jest-matcher-utils": "^20.0.0",
     "jest-regex-util": "^20.0.0",
     "jest-resolve": "^20.0.0",
     "jest-validate": "^20.0.0",


### PR DESCRIPTION
The `jest-config` package [depends](https://github.com/facebook/jest/blob/master/packages/jest-config/src/reporterValidationErrors.js#L18) on `jest-matcher-utils`, which isn't listed into its dependencies. It breaks the installation when running a package manager with no hoisting mechanism :)