### PR TITLE
Support absolute path to custom extension through haste package

### DIFF
--- a/integration_tests/resolve/__tests__/resolve-test.js
+++ b/integration_tests/resolve/__tests__/resolve-test.js
@@ -38,6 +38,11 @@ test('should resolve filename.<platform>.js', () => {
   expect(platform.extension).toBe('android.js');
 });
 
+test('should resolve filename.<platform>.js from haste package', () => {
+  expect(testRequire('custom-resolve/test1')).not.toThrow();
+  expect(platform.extension).toBe('android.js');
+});
+
 test('should resolve filename.native.js', () => {
   expect(testRequire('../test2')).not.toThrow();
   expect(platform.extension).toBe('native.js');

--- a/integration_tests/resolve/package.json
+++ b/integration_tests/resolve/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "custom-resolve",
   "jest": {
     "haste": {
       "platforms": ["native"],


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

This PR adds support for absolute resolution of files with custom extension in haste packages.

Jest support so-called "haste packages" which allow to place `package.json` with a `name` property providing a custom namespace for modules inside directory it resides. Since resolution for these haste packages use `require.resolve`, it doesn't support absolutely resolving custom extensions, like `.ios.js` or `.android.js`, it's just working with `.js` files. 
Such resolution mechanism works in React Native, I think it would be nice for Jest to support it.

Fixes #3342.

**Test plan**

Integration test.
