### PR TITLE
Mention that .babelrc might by cached

### DIFF
--- a/docs/en/Webpack.md
+++ b/docs/en/Webpack.md
@@ -227,6 +227,8 @@ ES modules to CommonJS modules only in the `test` environment.
 }
 ```
 
+> Note: Jest caches files to speed up test execution. If you updated .babelrc and Jest is still not working, try running Jest with `--no-cache`.
+
 If you use dynamic imports (`import('some-file.js').then(module => ...)`), you
 need to enable the `dynamic-import-node` plugin.
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

A common issue for developers using Webpack 2 is Jest's caching of .babelrc. @cpojer mentioned it on Mar 5, 2016: https://github.com/facebook/jest/issues/770#issuecomment-192813963
This PR adds a short note explaining how to disable the cache.

**Test plan**

I copied the new markup into Dilinger's online markdown editor to ensure it is formatted correctly.
