### PR TITLE
Fix showConfig test not to include the current Jest version

### DIFF
--- a/integration_tests/__tests__/__snapshots__/showConfig-test.js.snap
+++ b/integration_tests/__tests__/__snapshots__/showConfig-test.js.snap
@@ -84,7 +84,7 @@ exports[`jest --showConfig outputs config info and exits 1`] = `
     "watch": false,
     "watchman": true
   },
-  "version": "20.0.0"
+  "version": "[version]"
 }
 
 `;

--- a/integration_tests/__tests__/showConfig-test.js
+++ b/integration_tests/__tests__/showConfig-test.js
@@ -29,9 +29,10 @@ describe('jest --showConfig', () => {
     expect.addSnapshotSerializer({
       print: val =>
         val
-          .replace(new RegExp(root, 'g'), '/mocked/root/path')
-          .replace(/"name": "(.+)"/, '"name": "[md5 hash]"')
-          .replace(/"cacheDirectory": "(.+)"/, '"cacheDirectory": "/tmp/jest"'),
+          .replace(/"cacheDirectory": "(.+)"/g, '"cacheDirectory": "/tmp/jest"')
+          .replace(/"name": "(.+)"/g, '"name": "[md5 hash]"')
+          .replace(/"version": "(.+)"/g, '"version": "[version]"')
+          .replace(new RegExp(root, 'g'), '/mocked/root/path'),
       test: val => typeof val === 'string',
     });
     const {stdout} = runJest(dir, [


### PR DESCRIPTION
**Summary**

When publishing Jest 20, this was quite the funny error on CI ;)

**Test plan**

jest + when a version is published, this test won't fail.