### PR TITLE
Remove redundant eslint max-len overrides

### DIFF
--- a/integration_tests/__tests__/stack_trace-test.js
+++ b/integration_tests/__tests__/stack_trace-test.js
@@ -82,11 +82,9 @@ describe('Stack Trace', () => {
     expect(stderr).toMatch(/\s+at\s(?:.+?)\s\(__tests__\/test-error-test\.js/);
 
     // Make sure we show Jest's jest-resolve as part of the stack trace
-    /* eslint-disable max-len */
     expect(stderr).toMatch(
       /Cannot find module 'this-module-does-not-exist' from 'test-error-test\.js'/,
     );
-    /* eslint-enable max-len */
 
     expect(stderr).toMatch(
       /\s+at\s(?:.+?)\s\((?:.+?)jest-resolve\/build\/index\.js/,

--- a/packages/eslint-plugin-jest/src/rules/__tests__/no-identical-title-test.js
+++ b/packages/eslint-plugin-jest/src/rules/__tests__/no-identical-title-test.js
@@ -8,7 +8,7 @@
  * @flow
  */
 
-/* eslint-disable sort-keys, max-len */
+/* eslint-disable sort-keys */
 
 'use strict';
 

--- a/packages/jest-cli/src/lib/__tests__/isValidPath-test.js
+++ b/packages/jest-cli/src/lib/__tests__/isValidPath-test.js
@@ -10,8 +10,6 @@
 
 'use strict';
 
-/* eslint-disable max-len */
-
 const path = require('path');
 const isValidPath = require('../isValidPath');
 

--- a/packages/jest-cli/src/lib/getTestPathPattern.js
+++ b/packages/jest-cli/src/lib/getTestPathPattern.js
@@ -25,7 +25,6 @@ const DEFAULT_PATTERN_INFO = {
 const showTestPathPatternError = (testPathPattern: string) => {
   clearLine(process.stdout);
 
-  // eslint-disable-next-line max-len
   console.log(
     chalk.red(
       `  Invalid testPattern ${testPathPattern} supplied. ` +

--- a/packages/jest-config/src/normalize.js
+++ b/packages/jest-config/src/normalize.js
@@ -176,7 +176,6 @@ const normalizeUnmockedModulePathPatterns = (
 };
 
 const normalizePreprocessor = (options: InitialOptions): InitialOptions => {
-  /* eslint-disable max-len */
   if (options.scriptPreprocessor && options.transform) {
     throw createConfigError(
       `  Options: ${chalk.bold('scriptPreprocessor')} and ${chalk.bold('transform')} cannot be used together.
@@ -190,7 +189,6 @@ const normalizePreprocessor = (options: InitialOptions): InitialOptions => {
   Please change your configuration to only use ${chalk.bold('transformIgnorePatterns')}.`,
     );
   }
-  /* eslint-enable max-len */
 
   if (options.scriptPreprocessor) {
     options.transform = {

--- a/packages/jest-config/src/utils.js
+++ b/packages/jest-config/src/utils.js
@@ -38,11 +38,9 @@ const resolve = (rootDir: string, key: string, filePath: Path) => {
   );
 
   if (!module) {
-    /* eslint-disable max-len */
     throw createValidationError(
       `  Module ${chalk.bold(filePath)} in the ${chalk.bold(key)} option was not found.`,
     );
-    /* eslint-disable max-len */
   }
 
   return module;
@@ -118,11 +116,9 @@ const getTestEnvironment = (config: Object) => {
     return require.resolve(env);
   } catch (e) {}
 
-  /* eslint-disable max-len */
   throw createValidationError(
     `  Test environment ${chalk.bold(env)} cannot be found. Make sure the ${chalk.bold('testEnvironment')} configuration option points to an existing node module.`,
   );
-  /* eslint-disable max-len */
 };
 
 const isJSONString = (text: ?string) =>

--- a/packages/jest-docblock/src/index.js
+++ b/packages/jest-docblock/src/index.js
@@ -14,7 +14,6 @@ const commentStartRe = /^\/\*\*/;
 const docblockRe = /^\s*(\/\*\*?(.|\r?\n)*?\*\/)/;
 const lineCommentRe = /\/\/([^\r\n]*)/g;
 const ltrimRe = /^\s*/;
-// eslint-disable-next-line max-len
 const multilineRe = /(?:^|\r?\n) *(@[^\r\n]*?) *\r?\n *([^@\r\n\s][^@\r\n]+?) *\r?\n/g;
 const propertyRe = /(?:^|\r?\n) *@(\S+) *([^\r\n]*)/g;
 const stringStartRe = /(\r?\n|^) *\*/g;

--- a/packages/jest-haste-map/src/lib/extractRequires.js
+++ b/packages/jest-haste-map/src/lib/extractRequires.js
@@ -12,14 +12,12 @@
 const blockCommentRe = /\/\*[^]*?\*\//g;
 const lineCommentRe = /\/\/.*/g;
 
-/* eslint-disable max-len */
 const replacePatterns = {
   EXPORT_RE: /(\bexport\s+(?:[^'"]+\s+from\s+)??)(['"])([^'"]+)(\2)/g,
   IMPORT_RE: /(\bimport\s+(?:[^'"]+\s+from\s+)??)(['"])([^'"]+)(\2)/g,
   REQUIRE_EXTENSIONS_PATTERN: /(\b(?:require\s*?\.\s*?(?:requireActual|requireMock)|jest\s*?\.\s*?genMockFromModule)\s*?\(\s*?)([`'"])([^`'"]+)(\2\s*?\))/g,
   REQUIRE_RE: /(\brequire\s*?\(\s*?)([`'"])([^`'"]+)(\2\s*?\))/g,
 };
-/* eslint-enable max-len */
 
 function extractRequires(code: string): Array<string> {
   const dependencies = new Set();

--- a/packages/jest-matchers/src/__tests__/asymmetric-matchers-test.js
+++ b/packages/jest-matchers/src/__tests__/asymmetric-matchers-test.js
@@ -7,7 +7,6 @@
  *
  * @emails oncall+jsinfra
  */
-/* eslint-disable max-len */
 
 'use strict';
 

--- a/packages/jest-matchers/src/__tests__/matchers-test.js
+++ b/packages/jest-matchers/src/__tests__/matchers-test.js
@@ -7,7 +7,6 @@
  *
  * @emails oncall+jsinfra
  */
-/* eslint-disable max-len */
 
 'use strict';
 

--- a/packages/jest-matchers/src/__tests__/spyMatchers-test.js
+++ b/packages/jest-matchers/src/__tests__/spyMatchers-test.js
@@ -7,7 +7,6 @@
  *
  * @emails oncall+jsinfra
  */
-/* eslint-disable max-len */
 'use strict';
 
 const jestExpect = require('../');

--- a/packages/jest-matchers/src/matchers.js
+++ b/packages/jest-matchers/src/matchers.js
@@ -7,7 +7,6 @@
  *
  * @flow
  */
-/* eslint-disable max-len */
 
 'use strict';
 

--- a/packages/jest-matchers/src/toThrowMatchers.js
+++ b/packages/jest-matchers/src/toThrowMatchers.js
@@ -7,7 +7,6 @@
  *
  * @flow
  */
-/* eslint-disable max-len */
 
 'use strict';
 

--- a/packages/jest-message-util/src/index.js
+++ b/packages/jest-message-util/src/index.js
@@ -28,10 +28,8 @@ type StackTraceOptions = {
 };
 
 // filter for noisy stack trace lines
-/* eslint-disable max-len */
 const JASMINE_IGNORE = /^\s+at(?:(?:.*?vendor\/|jasmine\-)|\s+jasmine\.buildExpectationResult)/;
 const STACK_TRACE_IGNORE = /^\s+at.*?jest(-.*?)?(\/|\\)(build|node_modules|packages)(\/|\\)/;
-/* eslint-enable max-len */
 const TITLE_INDENT = '  ';
 const MESSAGE_INDENT = '    ';
 const STACK_INDENT = '      ';

--- a/packages/jest-runtime/src/__tests__/Runtime-environment-test.js
+++ b/packages/jest-runtime/src/__tests__/Runtime-environment-test.js
@@ -41,7 +41,6 @@ describe('Runtime', () => {
           sum();
         } catch (err) {
           hasThrown = true;
-          /* eslint-disable max-len */
           if (process.platform === 'win32') {
             expect(err.stack).toMatch(
               /^Error: throwing fn\s+at sum.+\\__tests__\\test_root\\throwing-fn.js:12:9/,
@@ -51,7 +50,6 @@ describe('Runtime', () => {
               /^Error: throwing fn\s+at sum.+\/__tests__\/test_root\/throwing-fn.js:12:9/,
             );
           }
-          /* eslint-enable max-len */
         }
         expect(hasThrown).toBe(true);
       }));

--- a/packages/jest-validate/src/__tests__/fixtures/jestConfig.js
+++ b/packages/jest-validate/src/__tests__/fixtures/jestConfig.js
@@ -128,7 +128,6 @@ const validConfig = {
 
 const format = (value: string) => require('pretty-format')(value, {min: true});
 
-/* eslint-disable max-len */
 const deprecatedConfig = {
   preprocessorIgnorePatterns: (config: Object) =>
     `  Option ${chalk.bold('preprocessorIgnorePatterns')} was replaced by ${chalk.bold('transformIgnorePatterns')}, which support multiple preprocessors.
@@ -150,7 +149,6 @@ const deprecatedConfig = {
 
   Please update your configuration.`,
 };
-/* eslint-enable max-len */
 
 module.exports = {
   defaultConfig,

--- a/packages/jest-validate/src/warnings.js
+++ b/packages/jest-validate/src/warnings.js
@@ -30,12 +30,10 @@ const unknownOptionWarning = (
     option,
     Object.keys(exampleConfig),
   );
-  /* eslint-disable max-len */
   const message =
     `  Unknown option ${chalk.bold(`"${option}"`)} with value ${chalk.bold(format(config[option]))} was found.` +
     (didYouMean && ` ${didYouMean}`) +
     `\n  This is probably a typing mistake. Fixing it will remove this message.`;
-  /* eslint-enable max-len */
 
   const comment = options.comment;
   const name = (options.title && options.title.warning) || WARNING;

--- a/packages/pretty-format/src/__tests__/AsymmetricMatcher-test.js
+++ b/packages/pretty-format/src/__tests__/AsymmetricMatcher-test.js
@@ -6,8 +6,6 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-/* eslint-disable max-len */
-
 'use strict';
 
 const prettyFormat = require('../');

--- a/packages/pretty-format/src/__tests__/ConvertAnsi-test.js
+++ b/packages/pretty-format/src/__tests__/ConvertAnsi-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-/* eslint-disable max-len */
 
 'use strict';
 

--- a/packages/pretty-format/src/__tests__/Immutable-test.js
+++ b/packages/pretty-format/src/__tests__/Immutable-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-/* eslint-disable max-len */
 
 'use strict';
 

--- a/packages/pretty-format/src/__tests__/React-test.js
+++ b/packages/pretty-format/src/__tests__/React-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-/* eslint-disable max-len */
 
 'use strict';
 

--- a/packages/pretty-format/src/__tests__/pretty-format-test.js
+++ b/packages/pretty-format/src/__tests__/pretty-format-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-/* eslint-disable max-len */
 
 'use strict';
 

--- a/packages/pretty-format/src/index.js
+++ b/packages/pretty-format/src/index.js
@@ -7,7 +7,6 @@
  *
  * @flow
  */
-/* eslint-disable max-len */
 
 'use strict';
 

--- a/website/core/Head.js
+++ b/website/core/Head.js
@@ -2,7 +2,6 @@
  * @providesModule Head
  * @jsx React.DOM
  */
- /* eslint-disable max-len */
 
 const React = require('React');
 

--- a/website/core/JestHelp.js
+++ b/website/core/JestHelp.js
@@ -5,7 +5,7 @@
  * @jsx React.DOM
  */
 
-/* eslint-disable sort-keys, max-len, no-multi-str */
+/* eslint-disable sort-keys, no-multi-str */
 
 'use strict';
 

--- a/website/core/JestIndex.js
+++ b/website/core/JestIndex.js
@@ -5,7 +5,6 @@
  * @jsx React.DOM
  */
 
-/* eslint-disable max-len */
 
 const React = require('React');
 const Site = require('Site');

--- a/website/core/Marked.js
+++ b/website/core/Marked.js
@@ -7,7 +7,7 @@
  * @jsx React.DOM
  */
 
- /* eslint-disable max-len, sort-keys */
+ /* eslint-disable sort-keys */
 
 const React = require('React');
 const Prism = require('Prism');

--- a/website/core/OpenSourceGlyph.js
+++ b/website/core/OpenSourceGlyph.js
@@ -2,7 +2,6 @@
  * @providesModule OpenSourceGlyph
  * @jsx React.DOM
  */
- /* eslint-disable max-len */
 
 const React = require('React');
 

--- a/website/core/Site.js
+++ b/website/core/Site.js
@@ -3,8 +3,6 @@
  * @jsx React.DOM
  */
 
-/* eslint-disable max-len */
-
 const React = require('React');
 const HeaderNav = require('HeaderNav');
 const Head = require('Head');

--- a/website/core/Thing.js
+++ b/website/core/Thing.js
@@ -4,8 +4,6 @@
  * @jsx React.DOM
  */
 
-/* eslint-disable max-len */
-
 const React = require('React');
 const Site = require('Site');
 const Marked = require('Marked');

--- a/website/layout/BlogPageLayout.js
+++ b/website/layout/BlogPageLayout.js
@@ -5,8 +5,6 @@
  * @jsx React.DOM
  */
 
-/* eslint-disable max-len */
-
 const BlogPost = require('BlogPost');
 const BlogSidebar = require('BlogSidebar');
 const Container = require('Container');

--- a/website/layout/BlogPostLayout.js
+++ b/website/layout/BlogPostLayout.js
@@ -4,7 +4,6 @@
  * @providesModule BlogPostLayout
  * @jsx React.DOM
  */
-/* eslint-disable max-len */
 
 const BlogPost = require('BlogPost');
 const BlogSidebar = require('BlogSidebar');

--- a/website/layout/DocsLayout.js
+++ b/website/layout/DocsLayout.js
@@ -2,7 +2,6 @@
  * @providesModule DocsLayout
  * @jsx React.DOM
  */
-/* eslint-disable max-len */
 
 const React = require('React');
 const Site = require('Site');

--- a/website/layout/PageLayout.js
+++ b/website/layout/PageLayout.js
@@ -2,7 +2,6 @@
  * @providesModule PageLayout
  * @jsx React.DOM
  */
-/* eslint-disable max-len */
 
 const React = require('React');
 const Site = require('Site');

--- a/website/layout/RedirectLayout.js
+++ b/website/layout/RedirectLayout.js
@@ -2,7 +2,6 @@
  * @providesModule RedirectLayout
  * @jsx React.DOM
  */
-/* eslint-disable max-len */
 
 const React = require('React');
 

--- a/website/layout/ReferenceLayout.js
+++ b/website/layout/ReferenceLayout.js
@@ -2,7 +2,6 @@
  * @providesModule ReferenceLayout
  * @jsx React.DOM
  */
-/* eslint-disable max-len */
 
 const React = require('React');
 const Site = require('Site');

--- a/website/server/server.js
+++ b/website/server/server.js
@@ -1,4 +1,4 @@
-/* eslint-disable max-len, sort-keys */
+/* eslint-disable sort-keys */
 
 'use strict';
 const http = require('http');

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -1,4 +1,4 @@
-/* eslint-disable sort-keys, max-len */
+/* eslint-disable sort-keys */
 
 const React = require('React');
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
The `max-len` eslint rule was disabled in #3444. No reason to keep around the inline disables of it.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
`yarn lint`

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
