### PR TITLE
Failure when coverage threshold not met

### DIFF
--- a/packages/jest-cli/src/ReporterDispatcher.js
+++ b/packages/jest-cli/src/ReporterDispatcher.js
@@ -59,10 +59,9 @@ class ReporterDispatcher {
   }
 
   async onRunComplete(contexts: Set<Context>, results: AggregatedResult) {
-    this._reporters.forEach(
-      reporter =>
-        reporter.onRunComplete && reporter.onRunComplete(contexts, results),
-    );
+    for (const reporter of this._reporters) {
+      reporter.onRunComplete && await reporter.onRunComplete(contexts, results);
+    }
   }
 
   // Return a list of last errors for every reporter

--- a/packages/jest-cli/src/ReporterDispatcher.js
+++ b/packages/jest-cli/src/ReporterDispatcher.js
@@ -60,7 +60,8 @@ class ReporterDispatcher {
 
   async onRunComplete(contexts: Set<Context>, results: AggregatedResult) {
     for (const reporter of this._reporters) {
-      reporter.onRunComplete && await reporter.onRunComplete(contexts, results);
+      reporter.onRunComplete &&
+        (await reporter.onRunComplete(contexts, results));
     }
   }
 


### PR DESCRIPTION
Fixes #3520

Fixed async calls to each reporter onRunComplete method

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Whenever the `coverage` is enabled, jest exits with 0 even if the threshold requirements are not met.

The Coverage reporter will not return a resolved promise when `collectCoverageFrom` matches files and consequently the Dispatcher will resolve the `onRunComplete` promise before collecting the result from reporter.
