### PR TITLE
Move getType from jest-matcher-utils to separate package

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,6 +1,7 @@
 [ignore]
 .*/node_modules/conventional-changelog-core/.*
 .*/node_modules/fbjs/.*
+.*/node_modules/jest-validate/.*
 .*/node_modules/react-native/.*
 .*/vendor/jsonlint/.*
 .*/examples/.*

--- a/packages/jest-config/package.json
+++ b/packages/jest-config/package.json
@@ -12,6 +12,7 @@
     "glob": "^7.1.1",
     "jest-environment-jsdom": "^20.0.3",
     "jest-environment-node": "^20.0.3",
+    "jest-get-type": "^20.0.3",
     "jest-jasmine2": "^20.0.4",
     "jest-matcher-utils": "^20.0.3",
     "jest-regex-util": "^20.0.3",

--- a/packages/jest-config/src/reporterValidationErrors.js
+++ b/packages/jest-config/src/reporterValidationErrors.js
@@ -12,7 +12,7 @@ import type {ReporterConfig} from 'types/Config';
 const {ValidationError} = require('jest-validate');
 
 const chalk = require('chalk');
-const {getType} = require('jest-matcher-utils');
+const getType = require('jest-get-type');
 const {DOCUMENTATION_NOTE, BULLET} = require('./utils');
 
 const validReporterTypes = ['array', 'string'];

--- a/packages/jest-diff/package.json
+++ b/packages/jest-diff/package.json
@@ -12,6 +12,7 @@
     "chalk": "^1.1.3",
     "diff": "^3.2.0",
     "jest-matcher-utils": "^20.0.3",
+    "jest-get-type": "^20.0.3",
     "pretty-format": "^20.0.3"
   }
 }

--- a/packages/jest-diff/src/index.js
+++ b/packages/jest-diff/src/index.js
@@ -19,7 +19,7 @@ const {
 } = require('pretty-format').plugins;
 
 const chalk = require('chalk');
-const {getType} = require('jest-matcher-utils');
+const getType = require('jest-get-type');
 const prettyFormat = require('pretty-format');
 const diffStrings = require('./diffStrings');
 

--- a/packages/jest-get-type/.npmignore
+++ b/packages/jest-get-type/.npmignore
@@ -1,0 +1,4 @@
+**/__mocks__/**
+**/__tests__/**
+src
+yarn.lock

--- a/packages/jest-get-type/package.json
+++ b/packages/jest-get-type/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "jest-get-type",
+  "description": "A utility function to get the type of a value",
+  "version": "20.0.3",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/facebook/jest.git"
+  },
+  "license": "BSD-3-Clause",
+  "main": "build/index.js",
+  "browser": "build-es5/index.js"
+}

--- a/packages/jest-get-type/src/__tests__/index-test.js
+++ b/packages/jest-get-type/src/__tests__/index-test.js
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2014, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails oncall+jsinfra
+ */
+
+'use strict';
+
+const getType = require('..');
+
+describe('.getType()', () => {
+  test('null', () => expect(getType(null)).toBe('null'));
+  test('undefined', () => expect(getType(undefined)).toBe('undefined'));
+  test('object', () => expect(getType({})).toBe('object'));
+  test('array', () => expect(getType([])).toBe('array'));
+  test('number', () => expect(getType(1)).toBe('number'));
+  test('string', () => expect(getType('oi')).toBe('string'));
+  test('function', () => expect(getType(() => {})).toBe('function'));
+  test('boolean', () => expect(getType(true)).toBe('boolean'));
+  test('symbol', () => expect(getType(Symbol.for('a'))).toBe('symbol'));
+  test('regexp', () => expect(getType(/abc/)).toBe('regexp'));
+  test('map', () => expect(getType(new Map())).toBe('map'));
+  test('set', () => expect(getType(new Set())).toBe('set'));
+});

--- a/packages/jest-get-type/src/index.js
+++ b/packages/jest-get-type/src/index.js
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2014, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+
+'use strict';
+
+export type ValueType =
+  | 'array'
+  | 'boolean'
+  | 'function'
+  | 'null'
+  | 'number'
+  | 'object'
+  | 'regexp'
+  | 'map'
+  | 'set'
+  | 'string'
+  | 'symbol'
+  | 'undefined';
+
+// get the type of a value with handling the edge cases like `typeof []`
+// and `typeof null`
+const getType = (value: any): ValueType => {
+  if (typeof value === 'undefined') {
+    return 'undefined';
+  } else if (value === null) {
+    return 'null';
+  } else if (Array.isArray(value)) {
+    return 'array';
+  } else if (typeof value === 'boolean') {
+    return 'boolean';
+  } else if (typeof value === 'function') {
+    return 'function';
+  } else if (typeof value === 'number') {
+    return 'number';
+  } else if (typeof value === 'string') {
+    return 'string';
+  } else if (typeof value === 'object') {
+    if (value.constructor === RegExp) {
+      return 'regexp';
+    } else if (value.constructor === Map) {
+      return 'map';
+    } else if (value.constructor === Set) {
+      return 'set';
+    }
+    return 'object';
+    // $FlowFixMe https://github.com/facebook/flow/issues/1015
+  } else if (typeof value === 'symbol') {
+    return 'symbol';
+  }
+
+  throw new Error(`value of unknown type: ${value}`);
+};
+
+module.exports = getType;

--- a/packages/jest-matcher-utils/package.json
+++ b/packages/jest-matcher-utils/package.json
@@ -11,6 +11,7 @@
   "browser": "build-es5/index.js",
   "dependencies": {
     "chalk": "^1.1.3",
+    "jest-get-type": "^20.0.3",
     "pretty-format": "^20.0.3"
   }
 }

--- a/packages/jest-matcher-utils/src/__tests__/index-test.js
+++ b/packages/jest-matcher-utils/src/__tests__/index-test.js
@@ -10,13 +10,7 @@
 
 'use strict';
 
-const {
-  stringify,
-  getType,
-  ensureNumbers,
-  pluralize,
-  ensureNoExpected,
-} = require('../');
+const {stringify, ensureNumbers, pluralize, ensureNoExpected} = require('../');
 
 describe('.stringify()', () => {
   [
@@ -91,21 +85,6 @@ describe('.stringify()', () => {
     expect(stringify(big)).toMatchSnapshot();
     expect(stringify(small)).toMatchSnapshot();
   });
-});
-
-describe('.getType()', () => {
-  test('null', () => expect(getType(null)).toBe('null'));
-  test('undefined', () => expect(getType(undefined)).toBe('undefined'));
-  test('object', () => expect(getType({})).toBe('object'));
-  test('array', () => expect(getType([])).toBe('array'));
-  test('number', () => expect(getType(1)).toBe('number'));
-  test('string', () => expect(getType('oi')).toBe('string'));
-  test('function', () => expect(getType(() => {})).toBe('function'));
-  test('boolean', () => expect(getType(true)).toBe('boolean'));
-  test('symbol', () => expect(getType(Symbol.for('a'))).toBe('symbol'));
-  test('regexp', () => expect(getType(/abc/)).toBe('regexp'));
-  test('map', () => expect(getType(new Map())).toBe('map'));
-  test('set', () => expect(getType(new Set())).toBe('set'));
 });
 
 describe('.ensureNumbers()', () => {

--- a/packages/jest-matcher-utils/src/index.js
+++ b/packages/jest-matcher-utils/src/index.js
@@ -9,6 +9,7 @@
  */
 
 const chalk = require('chalk');
+const getType = require('jest-get-type');
 const prettyFormat = require('pretty-format');
 const {
   AsymmetricMatcher,
@@ -20,20 +21,6 @@ const {
 const PLUGINS = [AsymmetricMatcher, ReactElement, HTMLElement].concat(
   Immutable,
 );
-
-export type ValueType =
-  | 'array'
-  | 'boolean'
-  | 'function'
-  | 'null'
-  | 'number'
-  | 'object'
-  | 'regexp'
-  | 'map'
-  | 'set'
-  | 'string'
-  | 'symbol'
-  | 'undefined';
 
 const EXPECTED_COLOR = chalk.green;
 const EXPECTED_BG = chalk.bgGreen;
@@ -56,40 +43,6 @@ const NUMBERS = [
   'twelve',
   'thirteen',
 ];
-
-// get the type of a value with handling the edge cases like `typeof []`
-// and `typeof null`
-const getType = (value: any): ValueType => {
-  if (typeof value === 'undefined') {
-    return 'undefined';
-  } else if (value === null) {
-    return 'null';
-  } else if (Array.isArray(value)) {
-    return 'array';
-  } else if (typeof value === 'boolean') {
-    return 'boolean';
-  } else if (typeof value === 'function') {
-    return 'function';
-  } else if (typeof value === 'number') {
-    return 'number';
-  } else if (typeof value === 'string') {
-    return 'string';
-  } else if (typeof value === 'object') {
-    if (value.constructor === RegExp) {
-      return 'regexp';
-    } else if (value.constructor === Map) {
-      return 'map';
-    } else if (value.constructor === Set) {
-      return 'set';
-    }
-    return 'object';
-    // $FlowFixMe https://github.com/facebook/flow/issues/1015
-  } else if (typeof value === 'symbol') {
-    return 'symbol';
-  }
-
-  throw new Error(`value of unknown type: ${value}`);
-};
 
 const stringify = (object: any, maxDepth?: number = 10): string => {
   const MAX_LENGTH = 10000;
@@ -211,7 +164,6 @@ module.exports = {
   ensureExpectedIsNumber,
   ensureNoExpected,
   ensureNumbers,
-  getType,
   highlightTrailingWhitespace,
   matcherHint,
   pluralize,

--- a/packages/jest-matchers/package.json
+++ b/packages/jest-matchers/package.json
@@ -10,6 +10,7 @@
   "browser": "build-es5/index.js",
   "dependencies": {
     "jest-diff": "^20.0.3",
+    "jest-get-type": "^20.0.3",
     "jest-matcher-utils": "^20.0.3",
     "jest-message-util": "^20.0.3",
     "jest-regex-util": "^20.0.3"

--- a/packages/jest-matchers/src/matchers.js
+++ b/packages/jest-matchers/src/matchers.js
@@ -11,13 +11,13 @@
 import type {MatchersObject} from 'types/Matchers';
 
 const diff = require('jest-diff');
+const getType = require('jest-get-type');
 const {escapeStrForRegex} = require('jest-regex-util');
 const {
   EXPECTED_COLOR,
   RECEIVED_COLOR,
   ensureNoExpected,
   ensureNumbers,
-  getType,
   matcherHint,
   printReceived,
   printExpected,

--- a/packages/jest-matchers/src/toThrowMatchers.js
+++ b/packages/jest-matchers/src/toThrowMatchers.js
@@ -10,6 +10,7 @@
 
 import type {MatchersObject} from 'types/Matchers';
 
+const getType = require('jest-get-type');
 const {escapeStrForRegex} = require('jest-regex-util');
 const {
   formatStackTrace,
@@ -18,7 +19,6 @@ const {
 const {
   RECEIVED_BG,
   RECEIVED_COLOR,
-  getType,
   highlightTrailingWhitespace,
   matcherHint,
   printExpected,

--- a/packages/jest-validate/package.json
+++ b/packages/jest-validate/package.json
@@ -10,7 +10,7 @@
   "browser": "build-es5/index.js",
   "dependencies": {
     "chalk": "^1.1.3",
-    "jest-matcher-utils": "^20.0.3",
+    "jest-get-type": "^20.0.3",
     "leven": "^2.1.0",
     "pretty-format": "^20.0.3"
   }

--- a/packages/jest-validate/src/errors.js
+++ b/packages/jest-validate/src/errors.js
@@ -11,7 +11,7 @@
 import type {ValidationOptions} from './types';
 
 const chalk = require('chalk');
-const {getType} = require('jest-matcher-utils');
+const getType = require('jest-get-type');
 const {format, ValidationError, ERROR} = require('./utils');
 
 const errorMessage = (


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

This resolves #3528. Move the `getType` utility function from `jest-matcher-utils` to standalone package. This way `jest-config` and other packages don't need to depend on `jest-matcher-utils` for just one function.

**Test plan**

All tests still pass.

---

~~_**Note:** When I ran `yarn test` locally, It failed to typecheck inside `node_modules/jest-validate` as it was looking for `getType` function that I just removed. This comes from `prettier` depending on `jest-validate`. I assumed it was safe to just ignore that typecheck since it is inside node_modules._~~