### PR TITLE
Normalise all version of react

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "react": "15.4.2",
     "react-addons-test-utils": "15.4.2",
     "react-dom": "15.4.2",
-    "react-test-renderer": "^15.5.4",
+    "react-test-renderer": "15.4.2",
     "regenerator-runtime": "^0.10.3",
     "rimraf": "^2.5.4",
     "slash": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3357,11 +3357,11 @@ react-proxy@^1.1.7:
     lodash "^4.6.1"
     react-deep-force-update "^1.0.0"
 
-react-test-renderer@^15.5.4:
-  version "15.5.4"
-  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-15.5.4.tgz#d4ebb23f613d685ea8f5390109c2d20fbf7c83bc"
+react-test-renderer@15.4.2:
+  version "15.4.2"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-15.4.2.tgz#27e1dff5d26d0e830f99614c487622bc831416f3"
   dependencies:
-    fbjs "^0.8.9"
+    fbjs "^0.8.4"
     object-assign "^4.1.0"
 
 react-transform-hmr@^1.0.4:


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Currently running `yarn` in the jest repo prints `warning "react-test-renderer@15.5.4" has incorrect peer dependency "react@^15.5.0".`.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
Running `yarn` in the jest repo should produce no peer dep warnings.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
