### PR TITLE
Bump flow to 0.47.0

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -12,7 +12,6 @@
 module.name_mapper='^pretty-format$' -> '<PROJECT_ROOT>/packages/pretty-format/src/index.js'
 module.name_mapper='^types/\(.*\)$' -> '<PROJECT_ROOT>/types/\1.js'
 module.name_mapper='\(jest-[^/]*\)' -> '<PROJECT_ROOT>/packages/\1/src/index.js'
-experimental.strict_call_arity=true
 
 [version]
-^0.46.0
+^0.47.0

--- a/.flowconfig
+++ b/.flowconfig
@@ -12,6 +12,7 @@
 module.name_mapper='^pretty-format$' -> '<PROJECT_ROOT>/packages/pretty-format/src/index.js'
 module.name_mapper='^types/\(.*\)$' -> '<PROJECT_ROOT>/types/\1.js'
 module.name_mapper='\(jest-[^/]*\)' -> '<PROJECT_ROOT>/packages/\1/src/index.js'
+experimental.strict_call_arity=true
 
 [version]
-^0.45.0
+^0.46.0

--- a/examples/react-native/.flowconfig
+++ b/examples/react-native/.flowconfig
@@ -38,4 +38,4 @@ suppress_comment=\\(.\\|\n\\)*\\$FlowIssue\\((\\(>=0\\.\\(2[0-7]\\|1[0-9]\\|[0-9
 suppress_comment=\\(.\\|\n\\)*\\$FlowFixedInNextDeploy
 
 [version]
-^0.27.0
+^0.47.0

--- a/flow-typed/resolve.js
+++ b/flow-typed/resolve.js
@@ -10,7 +10,7 @@
 
 declare module "resolve" {
   declare function isCore(moduleName: string): boolean;
-  declare function sync(path: string): string;
+  declare function sync(path: string, opts: Object): string;
 }
 
 declare module "resolve/lib/node-modules-paths" {

--- a/integration_tests/utils.js
+++ b/integration_tests/utils.js
@@ -130,16 +130,14 @@ const extractSummary = stdout => {
 // different versions of Node print different stack traces. This function
 // unifies their output to make it possible to snapshot them.
 const cleanupStackTrace = (output: string) => {
-  return (
-    output
-      .replace(/\n.*at.*timers\.js.*$/gm, '')
-      .replace(/\n.*at.*assert\.js.*$/gm, '')
-      .replace(/\n.*at.*node\.js.*$/gm, '')
-      .replace(/\n.*at.*next_tick\.js.*$/gm, '')
-      .replace(/\n.*at Promise \(<anonymous>\).*$/gm, '')
-      .replace(/\n.*at <anonymous>.*$/gm, '')
-      .replace(/^.*at.*[\s][\(]?(\S*\:\d*\:\d*).*$/gm, '      at $1')
-  );
+  return output
+    .replace(/\n.*at.*timers\.js.*$/gm, '')
+    .replace(/\n.*at.*assert\.js.*$/gm, '')
+    .replace(/\n.*at.*node\.js.*$/gm, '')
+    .replace(/\n.*at.*next_tick\.js.*$/gm, '')
+    .replace(/\n.*at Promise \(<anonymous>\).*$/gm, '')
+    .replace(/\n.*at <anonymous>.*$/gm, '')
+    .replace(/^.*at.*[\s][\(]?(\S*\:\d*\:\d*).*$/gm, '      at $1');
 };
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-markdown": "^1.0.0-beta.4",
     "eslint-plugin-react": "^6.7.1",
-    "flow-bin": "^0.46.0",
+    "flow-bin": "^0.47.0",
     "glob": "^7.1.1",
     "graceful-fs": "^4.1.11",
     "immutable": "^4.0.0-rc.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-markdown": "^1.0.0-beta.4",
     "eslint-plugin-react": "^6.7.1",
-    "flow-bin": "^0.45.0",
+    "flow-bin": "^0.46.0",
     "glob": "^7.1.1",
     "graceful-fs": "^4.1.11",
     "immutable": "^4.0.0-rc.1",

--- a/packages/jest-cli/src/reporters/CoverageReporter.js
+++ b/packages/jest-cli/src/reporters/CoverageReporter.js
@@ -45,7 +45,7 @@ class CoverageReporter extends BaseReporter {
   _maxWorkers: number;
 
   constructor(globalConfig: GlobalConfig, options: CoverageReporterOptions) {
-    super(globalConfig);
+    super();
     this._coverageMap = istanbulCoverage.createCoverageMap({});
     this._globalConfig = globalConfig;
     this._sourceMapStore = libSourceMaps.createSourceMapStore();

--- a/packages/jest-cli/src/reporters/SummaryReporter.js
+++ b/packages/jest-cli/src/reporters/SummaryReporter.js
@@ -68,7 +68,7 @@ class SummaryReporter extends BaseReporter {
   _options: SummaryReporterOptions;
 
   constructor(globalConfig: GlobalConfig, options: SummaryReporterOptions) {
-    super(globalConfig);
+    super();
     this._globalConfig = globalConfig;
     this._estimatedTime = 0;
     this._options = options;

--- a/packages/jest-cli/src/runTest.js
+++ b/packages/jest-cli/src/runTest.js
@@ -59,20 +59,20 @@ function runTest(
   >);
 
   const environment = new TestEnvironment(config);
-  const TestConsole = globalConfig.verbose
-    ? Console
-    : globalConfig.silent ? NullConsole : BufferedConsole;
-  const testConsole = new TestConsole(
-    globalConfig.useStderr ? process.stderr : process.stdout,
-    process.stderr,
-    (type, message) =>
-      getConsoleOutput(
-        config.rootDir,
-        !!globalConfig.verbose,
-        // 4 = the console call is buried 4 stack frames deep
-        BufferedConsole.write([], type, message, 4),
-      ),
-  );
+  const TestConsole = globalConfig.verbose ? Console : NullConsole;
+  const testConsole = globalConfig.silent
+    ? new TestConsole(
+        globalConfig.useStderr ? process.stderr : process.stdout,
+        process.stderr,
+        (type, message) =>
+          getConsoleOutput(
+            config.rootDir,
+            !!globalConfig.verbose,
+            // 4 = the console call is buried 4 stack frames deep
+            BufferedConsole.write([], type, message, 4),
+          ),
+      )
+    : new BufferedConsole();
   const cacheFS = {[path]: testSource};
   setGlobal(environment.global, 'console', testConsole);
   const runtime = new Runtime(config, environment, resolver, cacheFS, {

--- a/packages/jest-cli/src/runTest.js
+++ b/packages/jest-cli/src/runTest.js
@@ -59,20 +59,30 @@ function runTest(
   >);
 
   const environment = new TestEnvironment(config);
-  const TestConsole = globalConfig.verbose ? Console : NullConsole;
-  const testConsole = globalConfig.silent
-    ? new TestConsole(
-        globalConfig.useStderr ? process.stderr : process.stdout,
+  const consoleOut = globalConfig.useStderr ? process.stderr : process.stdout;
+  const consoleFormatter = (type, message) =>
+    getConsoleOutput(
+      config.rootDir,
+      !!globalConfig.verbose,
+      // 4 = the console call is buried 4 stack frames deep
+      BufferedConsole.write([], type, message, 4),
+    );
+
+  let testConsole;
+  if (globalConfig.verbose) {
+    testConsole = new Console(consoleOut, process.stderr, consoleFormatter);
+  } else {
+    if (globalConfig.silent) {
+      testConsole = new NullConsole(
+        consoleOut,
         process.stderr,
-        (type, message) =>
-          getConsoleOutput(
-            config.rootDir,
-            !!globalConfig.verbose,
-            // 4 = the console call is buried 4 stack frames deep
-            BufferedConsole.write([], type, message, 4),
-          ),
-      )
-    : new BufferedConsole();
+        consoleFormatter,
+      );
+    } else {
+      testConsole = new BufferedConsole();
+    }
+  }
+
   const cacheFS = {[path]: testSource};
   setGlobal(environment.global, 'console', testConsole);
   const runtime = new Runtime(config, environment, resolver, cacheFS, {

--- a/packages/jest-haste-map/src/index.js
+++ b/packages/jest-haste-map/src/index.js
@@ -227,11 +227,11 @@ class HasteMap extends EventEmitter {
     this._cachePath = HasteMap.getCacheFilePath(
       this._options.cacheDirectory,
       `haste-map-${this._options.name}`,
-      VERSION,
-      this._options.roots.join(':'),
-      this._options.extensions.join(':'),
-      this._options.platforms.join(':'),
-      options.mocksPattern || '',
+      VERSION +
+        this._options.roots.join(':') +
+        this._options.extensions.join(':') +
+        this._options.platforms.join(':') +
+        (options.mocksPattern || ''),
     );
     this._whitelist = getWhiteList(options.providesModuleNodeModules);
     this._buildPromise = null;
@@ -240,9 +240,8 @@ class HasteMap extends EventEmitter {
     this._watchers = [];
   }
 
-  static getCacheFilePath(tmpdir: Path, name: string): string {
-    const hash = crypto.createHash('md5');
-    Array.from(arguments).slice(1).forEach(arg => hash.update(arg));
+  static getCacheFilePath(tmpdir: Path, name: string, extra?: string): string {
+    const hash = crypto.createHash('md5').update(name + (extra || ''));
     return path.join(
       tmpdir,
       name.replace(/\W/g, '-') + '-' + hash.digest('hex'),

--- a/packages/jest-haste-map/src/index.js
+++ b/packages/jest-haste-map/src/index.js
@@ -245,7 +245,7 @@ class HasteMap extends EventEmitter {
     name: string,
     ...extra: Array<string>
   ): string {
-    const hash = crypto.createHash('md5').update(name + extra.join('') || '');
+    const hash = crypto.createHash('md5').update(name + extra.join(''));
     return path.join(
       tmpdir,
       name.replace(/\W/g, '-') + '-' + hash.digest('hex'),

--- a/packages/jest-haste-map/src/index.js
+++ b/packages/jest-haste-map/src/index.js
@@ -227,11 +227,11 @@ class HasteMap extends EventEmitter {
     this._cachePath = HasteMap.getCacheFilePath(
       this._options.cacheDirectory,
       `haste-map-${this._options.name}`,
-      VERSION +
-        this._options.roots.join(':') +
-        this._options.extensions.join(':') +
-        this._options.platforms.join(':') +
-        (options.mocksPattern || ''),
+      VERSION,
+      this._options.roots.join(':'),
+      this._options.extensions.join(':'),
+      this._options.platforms.join(':'),
+      options.mocksPattern || '',
     );
     this._whitelist = getWhiteList(options.providesModuleNodeModules);
     this._buildPromise = null;
@@ -240,8 +240,12 @@ class HasteMap extends EventEmitter {
     this._watchers = [];
   }
 
-  static getCacheFilePath(tmpdir: Path, name: string, extra?: string): string {
-    const hash = crypto.createHash('md5').update(name + (extra || ''));
+  static getCacheFilePath(
+    tmpdir: Path,
+    name: string,
+    ...extra: Array<string>
+  ): string {
+    const hash = crypto.createHash('md5').update(name + extra.join('') || '');
     return path.join(
       tmpdir,
       name.replace(/\W/g, '-') + '-' + hash.digest('hex'),

--- a/packages/jest-jasmine2/src/jasmine/SpyRegistry.js
+++ b/packages/jest-jasmine2/src/jasmine/SpyRegistry.js
@@ -37,7 +37,6 @@ const SpyStrategy = require('./SpyStrategy');
 
 const formatErrorMsg = (domain: string, usage?: string) => {
   const usageDefinition = usage ? '\nUsage: ' + usage : '';
-
   return msg => domain + ' : ' + msg + usageDefinition;
 };
 

--- a/packages/jest-jasmine2/src/jasmine/SpyRegistry.js
+++ b/packages/jest-jasmine2/src/jasmine/SpyRegistry.js
@@ -30,22 +30,15 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 /* @flow */
-/* eslint-disable sort-keys */
 
 const CallTracker = require('./CallTracker');
 const createSpy = require('./createSpy');
 const SpyStrategy = require('./SpyStrategy');
 
-const formatErrorMsg = function() {
-  function generateErrorMsg(domain, usage) {
-    const usageDefinition = usage ? '\nUsage: ' + usage : '';
+const formatErrorMsg = (domain: string, usage?: string) => {
+  const usageDefinition = usage ? '\nUsage: ' + usage : '';
 
-    return function errorMsg(msg) {
-      return domain + ' : ' + msg + usageDefinition;
-    };
-  }
-
-  return generateErrorMsg;
+  return msg => domain + ' : ' + msg + usageDefinition;
 };
 
 function isSpy(putativeSpy) {

--- a/packages/jest-jasmine2/src/jest-expect.js
+++ b/packages/jest-jasmine2/src/jest-expect.js
@@ -19,7 +19,7 @@ const {
 } = require('jest-snapshot');
 
 type JasmineMatcher = {
-  (): JasmineMatcher,
+  (matchersUtil: any, context: any): JasmineMatcher,
   compare: () => RawMatcherFn,
   negativeCompare: () => RawMatcherFn,
 };
@@ -27,9 +27,7 @@ type JasmineMatchersObject = {[id: string]: JasmineMatcher};
 
 module.exports = (config: {expand: boolean}) => {
   global.expect = expect;
-  expect.setState({
-    expand: config.expand,
-  });
+  expect.setState({expand: config.expand});
   expect.extend({toMatchSnapshot, toThrowErrorMatchingSnapshot});
   (expect: Object).addSnapshotSerializer = addSerializer;
 

--- a/packages/jest-jasmine2/src/queueRunner.js
+++ b/packages/jest-jasmine2/src/queueRunner.js
@@ -15,7 +15,7 @@ const pTimeout = require('./p-timeout');
 type Options = {
   clearTimeout: (timeoutID: number) => void,
   fail: () => void,
-  onException: () => void,
+  onException: (error: Error) => void,
   queueableFns: Array<QueueableFn>,
   setTimeout: (func: () => void, delay: number) => number,
   userContext: any,

--- a/packages/jest-jasmine2/src/treeProcessor.js
+++ b/packages/jest-jasmine2/src/treeProcessor.js
@@ -21,7 +21,7 @@ type TreeNode = {
   beforeAllFns: Array<any>,
   execute: (onComplete: () => void, enabled: boolean) => void,
   id: string,
-  onException: () => void,
+  onException: (error: Error) => void,
   sharedUserContext: () => any,
   children?: Array<TreeNode>,
 };

--- a/packages/jest-runtime/src/ScriptTransformer.js
+++ b/packages/jest-runtime/src/ScriptTransformer.js
@@ -62,7 +62,7 @@ class ScriptTransformer {
       configToJsonMap.set(this._config, stableStringify(this._config));
     }
     const configString = configToJsonMap.get(this._config) || '';
-    const transformer = this._getTransformer(filename, this._config);
+    const transformer = this._getTransformer(filename);
 
     if (transformer && typeof transformer.getCacheKey === 'function') {
       return transformer.getCacheKey(fileData, filename, configString, {

--- a/packages/jest-snapshot/src/utils.js
+++ b/packages/jest-snapshot/src/utils.js
@@ -105,6 +105,7 @@ const getSnapshotData = (snapshotPath: Path, update: SnapshotUpdateState) => {
       snapshotContents = fs.readFileSync(snapshotPath, 'utf8');
       // eslint-disable-next-line no-new-func
       const populate = new Function('exports', snapshotContents);
+      // $FlowFixMe
       populate(data);
     } catch (e) {}
   }

--- a/packages/jest-util/src/Console.js
+++ b/packages/jest-util/src/Console.js
@@ -36,19 +36,19 @@ class CustomConsole extends Console {
     super.log(this._formatBuffer(type, message));
   }
 
-  log() {
+  log(...args: Array<mixed>) {
     this._log('log', format.apply(null, arguments));
   }
 
-  info() {
+  info(...args: Array<mixed>) {
     this._log('info', format.apply(null, arguments));
   }
 
-  warn() {
+  warn(...args: Array<mixed>) {
     this._log('warn', format.apply(null, arguments));
   }
 
-  error() {
+  error(...args: Array<mixed>) {
     this._log('error', format.apply(null, arguments));
   }
 

--- a/packages/pretty-format/src/plugins/HTMLElement.js
+++ b/packages/pretty-format/src/plugins/HTMLElement.js
@@ -52,7 +52,7 @@ function printChildren(flatChildren, print, indent, colors, opts) {
   return flatChildren
     .map(node => {
       if (typeof node === 'object') {
-        return print(node, print, indent, colors, opts);
+        return print(node);
       } else if (typeof node === 'string') {
         return colors.content.open + escapeHTML(node) + colors.content.close;
       } else {

--- a/packages/pretty-format/src/plugins/ReactElement.js
+++ b/packages/pretty-format/src/plugins/ReactElement.js
@@ -26,7 +26,7 @@ function printChildren(flatChildren, print, indent, colors, opts) {
   return flatChildren
     .map(node => {
       if (typeof node === 'object') {
-        return print(node, print, indent, colors, opts);
+        return print(node);
       } else if (typeof node === 'string') {
         return colors.content.open + escapeHTML(node) + colors.content.close;
       } else {

--- a/packages/pretty-format/src/plugins/lib/printImmutable.js
+++ b/packages/pretty-format/src/plugins/lib/printImmutable.js
@@ -40,9 +40,7 @@ const printImmutable = (
   const immutableArray = [];
 
   const pushToImmutableArray = (item: any, key: string) => {
-    immutableArray.push(
-      indent(addKey(isMap, key) + print(item, print, indent, opts, colors)),
-    );
+    immutableArray.push(indent(addKey(isMap, key) + print(item)));
   };
 
   if (Array.isArray(val._keys)) {

--- a/types/Environment.js
+++ b/types/Environment.js
@@ -23,7 +23,7 @@ declare class $JestEnvironment {
     runAllImmediates(): void,
     runAllTicks(): void,
     runAllTimers(): void,
-    runTimersToTime(): void,
+    runTimersToTime(msToRun: number): void,
     runOnlyPendingTimers(): void,
     runWithRealTimers(callback: any): void,
     useFakeTimers(): void,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1866,9 +1866,9 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flow-bin@^0.46.0:
-  version "0.46.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.46.0.tgz#06ad7fe19dddb1042264438064a2a32fee12b872"
+flow-bin@^0.47.0:
+  version "0.47.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.47.0.tgz#a2a08ab3e0d1f1cb57d17e27b30b118b62fda367"
 
 flow-parser@0.45.0:
   version "0.45.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1866,9 +1866,9 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flow-bin@^0.45.0:
-  version "0.45.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.45.0.tgz#009dd0f577a3f665c74ca8be827ae8c2dd8fd6b5"
+flow-bin@^0.46.0:
+  version "0.46.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.46.0.tgz#06ad7fe19dddb1042264438064a2a32fee12b872"
 
 flow-parser@0.45.0:
   version "0.45.0"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Bump flow to latest version. Also turned on `strict_call_arity` to ease migration to 0.47.0 in the future (it will be turned on by default there). More details: https://github.com/facebook/flow/releases/tag/v0.46.0

**Test plan**

CI passes.
