### PR TITLE
Empty stack for ValidateError

### DIFF
--- a/integration_tests/__tests__/__snapshots__/custom-reporters-test.js.snap
+++ b/integration_tests/__tests__/__snapshots__/custom-reporters-test.js.snap
@@ -106,14 +106,14 @@ Object {
 `;
 
 exports[`Custom Reporters Integration invalid format for adding reporters 1`] = `
-"●  Reporter Validation Error:
+"● Reporter Validation Error:
 
-Unexpected value for Path at index 0 of reporter at index 0
- Expected:
-   string
- Got:
-   number
- Reporter configuration:
+  Unexpected value for Path at index 0 of reporter at index 0
+  Expected:
+    string
+  Got:
+    number
+  Reporter configuration:
     [
       3243242
     ]

--- a/packages/jest-config/src/reporterValidationErrors.js
+++ b/packages/jest-config/src/reporterValidationErrors.js
@@ -16,7 +16,7 @@ const {getType} = require('jest-matcher-utils');
 const {DOCUMENTATION_NOTE, BULLET} = require('./utils');
 
 const validReporterTypes = ['array', 'string'];
-const ERROR = `${BULLET} Reporter Validation Error`;
+const ERROR = `${BULLET}Reporter Validation Error`;
 
 /**
  * Reporter Vaidation Error is thrown if the given arguments
@@ -31,10 +31,10 @@ function createReporterError(
   reporterValue: Array<ReporterConfig> | string,
 ): ValidationError {
   const errorMessage =
-    `Reporter at index ${reporterIndex} must be of type:\n` +
-    `   ${chalk.bold.green(validReporterTypes.join(' or '))}\n` +
-    ` but instead received:\n` +
-    `   ${chalk.bold.red(getType(reporterValue))}`;
+    `  Reporter at index ${reporterIndex} must be of type:\n` +
+    `    ${chalk.bold.green(validReporterTypes.join(' or '))}\n` +
+    `  but instead received:\n` +
+    `    ${chalk.bold.red(getType(reporterValue))}`;
 
   return new ValidationError(ERROR, errorMessage, DOCUMENTATION_NOTE);
 }
@@ -48,13 +48,13 @@ function createArrayReporterError(
   valueName: string,
 ): ValidationError {
   const errorMessage =
-    `Unexpected value for ${valueName} ` +
+    `  Unexpected value for ${valueName} ` +
     `at index ${valueIndex} of reporter at index ${reporterIndex}\n` +
-    ' Expected:\n' +
-    `   ${chalk.bold.red(expectedType)}\n` +
-    ' Got:\n' +
-    `   ${chalk.bold.green(getType(value))}\n` +
-    ` Reporter configuration:\n` +
+    '  Expected:\n' +
+    `    ${chalk.bold.red(expectedType)}\n` +
+    '  Got:\n' +
+    `    ${chalk.bold.green(getType(value))}\n` +
+    `  Reporter configuration:\n` +
     `    ${chalk.bold.green(JSON.stringify(arrayReporter, null, 2)
         .split('\n')
         .join('\n    '))}`;

--- a/packages/jest-validate/src/utils.js
+++ b/packages/jest-validate/src/utils.js
@@ -27,6 +27,7 @@ class ValidationError extends Error {
     super();
     comment = comment ? '\n\n' + comment : '\n';
     this.name = '';
+    this.stack = '';
     this.message = chalk.red(chalk.bold(name) + ':\n\n' + message + comment);
     Error.captureStackTrace(this, () => {});
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Fixes double error message like this [here](https://github.com/facebook/jest/pull/3567/files#diff-0454b3bf8e9e55c3655f3be2ff46cf28R14).
Also adjusted indentation in reporter errors messages

**Test plan**

Doesn't break anything, works with https://github.com/facebook/jest/pull/3567