### PR TITLE
Revert setting stack to empty string

### DIFF
--- a/packages/jest-validate/src/utils.js
+++ b/packages/jest-validate/src/utils.js
@@ -27,7 +27,6 @@ class ValidationError extends Error {
     super();
     comment = comment ? '\n\n' + comment : '\n';
     this.name = '';
-    this.stack = '';
     this.message = chalk.red(chalk.bold(name) + ':\n\n' + message + comment);
     Error.captureStackTrace(this, () => {});
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Setting `this.stack = '';` breaks some tests Node 6. I still need to figure out what's the case with some errors having duplicated message [like this](https://github.com/facebook/jest/pull/3567/files#diff-0454b3bf8e9e55c3655f3be2ff46cf28R22)
