### PR TITLE
[Editor] Ensure that the check for settings always returns

### DIFF
--- a/packages/jest-editor-support/src/__tests__/Settings-test.js
+++ b/packages/jest-editor-support/src/__tests__/Settings-test.js
@@ -28,17 +28,38 @@ describe('Settings', () => {
       config,
       version: '19.0.0',
     };
-    const createProcess = () => ({stdout: new EventEmitter()});
+
+    const mockProcess: any = new EventEmitter();
+    mockProcess.stdout = new EventEmitter();
+    const createProcess = () => mockProcess;
     const buffer = makeBuffer(JSON.stringify(json));
     const settings = new Settings(workspace, {createProcess});
 
     settings.getConfig(completed);
-    settings.debugprocess.stdout.emit('data', buffer);
+    settings.getConfigProcess.stdout.emit('data', buffer);
+    settings.getConfigProcess.emit('close');
 
     expect(completed).toHaveBeenCalled();
     expect(settings.jestVersionMajor).toBe(19);
     expect(settings.settings).toEqual(config);
   });
+
+  it('calls callback even if no data is sent', () => {
+    const workspace = new ProjectWorkspace('root_path', 'path_to_jest');
+    const completed = jest.fn();
+    const config = {cacheDirectory: '/tmp/jest', name: '[md5 hash]'};
+  
+    const mockProcess: any = new EventEmitter();
+    mockProcess.stdout = new EventEmitter();
+    const createProcess = () => mockProcess;
+    const settings = new Settings(workspace, {createProcess});
+
+    settings.getConfig(completed);
+    settings.getConfigProcess.emit('close');
+
+    expect(completed).toHaveBeenCalled();
+  });
+
 });
 
 const makeBuffer = (content: string) => {


### PR DESCRIPTION
**Summary**

If there is no output from the process to check for settings, then this function never returns. In pre-Jest 20, it would close with errors so the callback never triggered. Now it will call it when the process is over instead.

**Test plan**

Has tests 👍 