### PR TITLE
(docs): Add sentence to clarify `jest.mock` is per file.

### DIFF
--- a/docs/en/JestObjectAPI.md
+++ b/docs/en/JestObjectAPI.md
@@ -123,6 +123,8 @@ jest.mock('../moduleName', () => {
 
 *Warning: Importing a module in a setup file (as specified by `setupTestFrameworkScriptFile`) will prevent mocking for the module in question, as well as all the modules that it imports.*
 
+Modules that are mocked with `jest.mock` are mocked only for the file that calls `jest.mock`. Another file that imports the module will get the original implementation even if run after the test file that mocks the module.
+
 Returns the `jest` object for chaining.
 
 ### `jest.clearAllMocks()`


### PR DESCRIPTION
I tweeted Christoph to clarify if `jest.mock` was per file or in the scope of the entire test suite, and thought that this might be a question others have so no harm in adding to the docs :)