### PR TITLE
remove `once` package

### DIFF
--- a/packages/jest-jasmine2/package.json
+++ b/packages/jest-jasmine2/package.json
@@ -15,7 +15,6 @@
     "jest-matchers": "^20.0.3",
     "jest-message-util": "^20.0.3",
     "jest-snapshot": "^20.0.3",
-    "once": "^1.4.0",
     "p-map": "^1.1.1"
   },
   "devDependencies": {

--- a/packages/jest-jasmine2/src/queueRunner.js
+++ b/packages/jest-jasmine2/src/queueRunner.js
@@ -8,7 +8,6 @@
  * @flow
  */
 
-const once = require('once');
 const pMap = require('p-map');
 const pTimeout = require('./p-timeout');
 
@@ -29,13 +28,12 @@ type QueueableFn = {
 function queueRunner(options: Options) {
   const mapper = ({fn, timeout}) => {
     const promise = new Promise(resolve => {
-      const next = once(resolve);
-      next.fail = function() {
+      resolve.fail = function() {
         options.fail.apply(null, arguments);
         resolve();
       };
       try {
-        fn.call(options.userContext, next);
+        fn.call(options.userContext, resolve);
       } catch (e) {
         options.onException(e);
         resolve();


### PR DESCRIPTION
`once` package is currently conflicting with one of the internal fb modules.
i think it's safe to remove it from here since we're only wrapping `resolve` and after a promise is fulfilled calling `resolve` results in noop.

cc @wtgtybhertgeghgtwtg 