### PR TITLE
[docs] Fix regex for ReactNative transformIgnorePatterns

### DIFF
--- a/docs/en/TutorialReactNative.md
+++ b/docs/en/TutorialReactNative.md
@@ -156,7 +156,7 @@ By default the jest-react-native preset only processes the project's own source 
 
 ```json
 "transformIgnorePatterns": [
-  "node_modules/(?!react-native|my-project|react-native-button)/"
+  "node_modules/(?!react-native/|my-project/|react-native-button/)"
 ]
 ```
 

--- a/docs/en/TutorialReactNative.md
+++ b/docs/en/TutorialReactNative.md
@@ -156,7 +156,7 @@ By default the jest-react-native preset only processes the project's own source 
 
 ```json
 "transformIgnorePatterns": [
-  "node_modules/(?!react-native/|my-project/|react-native-button/)"
+  "node_modules/(?!(react-native|my-project|react-native-button)/)"
 ]
 ```
 


### PR DESCRIPTION
The current example for using `transformIgnorePatterns` to test ReactNative apps doesn't matches anything because the `/` is at the end.

```
new RegExp("node_modules/(?!react-native|my-project|react-native-button)/").test('node_modules/')
false
new RegExp("node_modules/(?!react-native|my-project|react-native-button)/").test('node_modules/react-native/')
false
new RegExp("node_modules/(?!react-native|my-project|react-native-button)/").test('node_modules/my-project/')
false
new RegExp("node_modules/(?!react-native|my-project|react-native-button)/").test('node_modules/my-project-foo/')
false
```

When we put the slash inside the parens, it does what I believe we expect.

```
new RegExp("node_modules/(?!(react-native|my-project|react-native-button)/)").test('node_modules/')
true
new RegExp("node_modules/(?!(react-native|my-project|react-native-button)/)").test('node_modules/react-native/')
false
new RegExp("node_modules/(?!(react-native|my-project|react-native-button)/)").test('node_modules/my-project/')
false
new RegExp("node_modules/(?!(react-native|my-project|react-native-button)/)").test('node_modules/my-project-foo/')
true
```