### PR TITLE
Fix typo in docs for CLI

### DIFF
--- a/docs/en/CLI.md
+++ b/docs/en/CLI.md
@@ -74,7 +74,7 @@ CLI options take precedence over values from the [Configuration](/jest/docs/conf
 
 ### `jest <regexForTestFiles>`
 
-When you run `jest` with an argument, that argument is treated as a regular expression to match against files in your project. It is possible to run test suites by providing a pattern. Only the files that the pattern matches will be picked up and executed. Note: depending on your terminal, you may need to quote this argument: `jest "my.*(complex)?pattern`.
+When you run `jest` with an argument, that argument is treated as a regular expression to match against files in your project. It is possible to run test suites by providing a pattern. Only the files that the pattern matches will be picked up and executed. Note: depending on your terminal, you may need to quote this argument: `jest "my.*(complex)?pattern"`.
 
 ### `--bail`
 


### PR DESCRIPTION
**Summary**

Added the missing closing quote.

**Test plan**

Try executing the example command in your shell:

```
➜  my-project git:(master) jest "my.*(complex)?pattern
dquote>
```

Obviously, the shell expects the quote to be closed. That's what I did in this PR.