### PR TITLE
Fix for windows platform dependent modules resolution

### DIFF
--- a/packages/jest-haste-map/src/lib/getPlatformExtension.js
+++ b/packages/jest-haste-map/src/lib/getPlatformExtension.js
@@ -13,7 +13,7 @@ const SUPPORTED_PLATFORM_EXTS = {
   ios: true,
   native: true,
   web: true,
-  windows: true
+  windows: true,
 };
 
 // Extract platform extension: index.ios.js -> ios

--- a/packages/jest-haste-map/src/lib/getPlatformExtension.js
+++ b/packages/jest-haste-map/src/lib/getPlatformExtension.js
@@ -13,6 +13,7 @@ const SUPPORTED_PLATFORM_EXTS = {
   ios: true,
   native: true,
   web: true,
+  windows: true
 };
 
 // Extract platform extension: index.ios.js -> ios


### PR DESCRIPTION
**Summary**

According to this issue: https://github.com/facebook/react-native/issues/14053 here is the problems with windows platform dependent modules...

**Test plan**

copy/paste from the referenced issue for convenience:

### Description

If react-native and react-native-windows installed together - the modules from latter considered being generic(g) by the packager(jest-haste-map). As result, we have broken app.

the initial discussion was started here: https://github.com/facebook/react-native/issues/13925

### Reproduction Steps and Sample Code

1. react-native init test
2. cd test && yarn add react-native-windows
3. in the generated index.ios.js make a small modification so the render method of default exported component will look like that:

```javascript
render() {
    return (
      <View style={styles.container}>
        <Text style={styles.welcome}>
          <Text style={styles.instructions}>
            To get started, edit index.ios.js
          </Text>
        </Text>
      </View>
    );
  }
```
4. react-native run-ios
5. ㅠㅠ
<img width="389" alt="2017-05-19 16 10 22" src="https://cloud.githubusercontent.com/assets/823168/26237868/c629b22c-3cb1-11e7-8ca8-868b3a3b4345.png">


### Solution

During investigating this, read a lot of code and eventually come to jest-haste-map - the one which required by react-native.

In the react-native packager **defaults.js** here is **platforms** array exported, looks like dat:
```javascript
exports.platforms = ['ios', 'android', 'windows', 'web'];
```
at the same time, in jest-haste-map's  **lib/getPlatformExtension.js** we have:
```javascript
const SUPPORTED_PLATFORM_EXTS = {
  android: true,
  ios: true,
  native: true,
  web: true };
```
adding **windows: true**, to SUPPORTED_PLATFORM_EXTS dict will give us a fix:

<img width="386" alt="2017-05-19 16 30 54" src="https://cloud.githubusercontent.com/assets/823168/26237872/cf1ba5e8-3cb1-11e7-8784-a8b5463dae9b.png">



