### PR TITLE
Fix NODE_PATH resolving for relative paths

### DIFF
--- a/integration_tests/__tests__/node_path-test.js
+++ b/integration_tests/__tests__/node_path-test.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails oncall+jsinfra
+ */
+'use strict';
+
+const runJest = require('../runJest');
+
+test('supports NODE_PATH', () => {
+  const result = runJest('node_path', [], {
+    nodePath: ['../node_path/src'],
+  });
+  expect(result.status).toBe(0);
+});

--- a/integration_tests/node_path/__tests__/node_path-test.js
+++ b/integration_tests/node_path/__tests__/node_path-test.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
+test('can require by absolute path', () => {
+  expect(require('path/file.js')).toBe(42);
+});

--- a/integration_tests/node_path/package.json
+++ b/integration_tests/node_path/package.json
@@ -1,0 +1,8 @@
+{
+  "jest": {
+    "testEnvironment": "node",
+    "transform": {
+      "^.+\\.jsx?$": "../../packages/babel-jest"
+    }
+  }
+}

--- a/integration_tests/node_path/src/path/file.js
+++ b/integration_tests/node_path/src/path/file.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
+module.exports = 42;

--- a/integration_tests/runJest.js
+++ b/integration_tests/runJest.js
@@ -17,6 +17,7 @@ const JEST_PATH = path.resolve(__dirname, '../packages/jest-cli/bin/jest.js');
 
 type RunJestOptions = {
   skipPkgJsonCheck?: boolean, // don't complain if can't find package.json
+  nodePath?: string,
 };
 
 // return the result of the spawned process:
@@ -45,7 +46,15 @@ function runJest(
     );
   }
 
-  const result = spawnSync(JEST_PATH, args || [], {cwd: dir});
+  const env = options.nodePath
+    ? Object.assign({}, process.env, {
+        NODE_PATH: options.nodePath,
+      })
+    : process.env;
+  const result = spawnSync(JEST_PATH, args || [], {
+    cwd: dir,
+    env,
+  });
 
   result.stdout = result.stdout && result.stdout.toString();
   result.stderr = result.stderr && result.stderr.toString();

--- a/integration_tests/runJest.js
+++ b/integration_tests/runJest.js
@@ -16,8 +16,8 @@ const {fileExists} = require('./utils');
 const JEST_PATH = path.resolve(__dirname, '../packages/jest-cli/bin/jest.js');
 
 type RunJestOptions = {
-  skipPkgJsonCheck?: boolean, // don't complain if can't find package.json
   nodePath?: string,
+  skipPkgJsonCheck?: boolean, // don't complain if can't find package.json
 };
 
 // return the result of the spawned process:

--- a/packages/jest-resolve/src/__tests__/resolve-test.js
+++ b/packages/jest-resolve/src/__tests__/resolve-test.js
@@ -42,7 +42,8 @@ describe('isCoreModule', () => {
 
 describe('findNodeModule', () => {
   it('is possible to override the default resolver', () => {
-    const resolvedCwd = fs.realpathSync(process.cwd());
+    const cwd = process.cwd();
+    const resolvedCwd = fs.realpathSync(cwd) || cwd;
     const nodePaths = process.env.NODE_PATH
       ? process.env.NODE_PATH
           .split(path.delimiter)

--- a/packages/jest-resolve/src/__tests__/resolve-test.js
+++ b/packages/jest-resolve/src/__tests__/resolve-test.js
@@ -10,6 +10,7 @@
 
 'use strict';
 
+const fs = require('fs');
 const path = require('path');
 const ModuleMap = require('jest-haste-map').ModuleMap;
 const Resolver = require('../');
@@ -41,8 +42,11 @@ describe('isCoreModule', () => {
 
 describe('findNodeModule', () => {
   it('is possible to override the default resolver', () => {
+    const resolvedCwd = fs.realpathSync(process.cwd());
     const nodePaths = process.env.NODE_PATH
-      ? process.env.NODE_PATH.split(path.delimiter)
+      ? process.env.NODE_PATH
+          .split(path.delimiter)
+          .map(p => path.resolve(resolvedCwd, p))
       : null;
 
     jest.mock('../__mocks__/userResolver');

--- a/packages/jest-resolve/src/__tests__/resolve-test.js
+++ b/packages/jest-resolve/src/__tests__/resolve-test.js
@@ -46,6 +46,7 @@ describe('findNodeModule', () => {
     const nodePaths = process.env.NODE_PATH
       ? process.env.NODE_PATH
           .split(path.delimiter)
+          .filter(Boolean)
           .map(p => path.resolve(resolvedCwd, p))
       : null;
 

--- a/packages/jest-resolve/src/index.js
+++ b/packages/jest-resolve/src/index.js
@@ -11,6 +11,7 @@
 import type {Path} from 'types/Config';
 import type {ModuleMap} from 'types/HasteMap';
 
+const fs = require('fs');
 const path = require('path');
 const nodeModulesPaths = require('resolve/lib/node-modules-paths');
 const isBuiltinModule = require('is-builtin-module');
@@ -49,8 +50,13 @@ export type ResolveModuleConfig = {|
 
 const NATIVE_PLATFORM = 'native';
 
+// We might be inside a symlink.
+const resolvedCwd = fs.realpathSync(process.cwd());
 const nodePaths = process.env.NODE_PATH
-  ? process.env.NODE_PATH.split(path.delimiter)
+  ? process.env.NODE_PATH
+      .split(path.delimiter)
+      // The resolver expects absolute paths.
+      .map(p => path.resolve(resolvedCwd, p))
   : null;
 
 class Resolver {

--- a/packages/jest-resolve/src/index.js
+++ b/packages/jest-resolve/src/index.js
@@ -55,6 +55,7 @@ const resolvedCwd = fs.realpathSync(process.cwd());
 const nodePaths = process.env.NODE_PATH
   ? process.env.NODE_PATH
       .split(path.delimiter)
+      .filter(Boolean)
       // The resolver expects absolute paths.
       .map(p => path.resolve(resolvedCwd, p))
   : null;

--- a/packages/jest-resolve/src/index.js
+++ b/packages/jest-resolve/src/index.js
@@ -51,7 +51,8 @@ export type ResolveModuleConfig = {|
 const NATIVE_PLATFORM = 'native';
 
 // We might be inside a symlink.
-const resolvedCwd = fs.realpathSync(process.cwd());
+const cwd = process.cwd();
+const resolvedCwd = fs.realpathSync(cwd) || cwd;
 const nodePaths = process.env.NODE_PATH
   ? process.env.NODE_PATH
       .split(path.delimiter)


### PR DESCRIPTION
The downstream issue was reported in https://github.com/facebookincubator/create-react-app/issues/2230#issuecomment-302673174. The reproducing case is in https://github.com/ingro/cra-test-bug.

Babel Jest transform started climbing directories searching for `package.json`. People who run Jest with `NODE_PATH=src` and then import `App` expecting it to resolve to `src/App.js` started getting this error:

```
 ● Test suite failed to run

    Cannot find module 'package.json'

      at Function.Module._resolveFilename (module.js:470:15)
      at Function.Module._load (module.js:418:25)
      at Module.require (module.js:498:17)
      at require (internal/module.js:20:19)
```

This is because the `filename` argument to `getCacheKey` is a relative path in this case. However the function expects it to be absolute, and all other cases I logged showed absolute paths being passed. Even the [`modulePaths`](http://facebook.github.io/jest/docs/en/configuration.html#modulepaths-array-string) option (which is equivalent to `NODE_PATH`) gets resolved to absolute paths.

So to fix this, I just make `NODE_PATH` handling consistent with all other cases in the resolver. They are turned to absolute paths as early as possible. To do this, I use the same code that we’ve been using in Create React App itself for many months.