### PR TITLE
fixes bug with enableAutomock when automock is set to false

### DIFF
--- a/packages/jest-runtime/src/__tests__/Runtime-requireModuleOrMock-test.js
+++ b/packages/jest-runtime/src/__tests__/Runtime-requireModuleOrMock-test.js
@@ -160,3 +160,18 @@ it('automocking is disabled by default', () =>
     );
     expect(exports.setModuleStateValue._isMockFunction).toBe(undefined);
   }));
+
+it('unmocks modules in config.unmockedModulePathPatterns for tests with automock enabled when automock is false', () =>
+  createRuntime(__filename, {
+    automock: false,
+    moduleNameMapper,
+    unmockedModulePathPatterns: ['npm3-main-dep'],
+  }).then(runtime => {
+    const root = runtime.requireModule(runtime.__mockRootPath);
+    root.jest.enableAutomock();
+    const nodeModule = runtime.requireModuleOrMock(runtime.__mockRootPath, 'npm3-main-dep');
+    const moduleData = nodeModule();
+    expect(moduleData.isUnmocked()).toBe(true);
+  })
+);
+

--- a/packages/jest-runtime/src/index.js
+++ b/packages/jest-runtime/src/index.js
@@ -146,7 +146,6 @@ class Runtime {
     this._unmockList = unmockRegExpCache.get(config);
     if (
       !this._unmockList &&
-      config.automock &&
       config.unmockedModulePathPatterns
     ) {
       this._unmockList = new RegExp(


### PR DESCRIPTION

**Summary**
This PR causes the jest-runtime to build out the unmocked module list even when automock is set to false. This makes it possible for jest tests to enableAutomock and still keep certain modules unmocked as expected.


**Test plan**

`yarn test` comes back clean.

Plus, I added a test to verify the module was built. Running the test before the change fails. Running after passes.