### PR TITLE
Add jest-cli dependency to documentation

### DIFF
--- a/docs/en/TutorialReact.md
+++ b/docs/en/TutorialReact.md
@@ -24,7 +24,7 @@ If you have an existing application you'll need to install a few packages to mak
 Run
 
 ```bash
-npm install --save-dev jest babel-jest babel-preset-es2015 babel-preset-react react-test-renderer
+npm install --save-dev jest babel-jest babel-preset-es2015 babel-preset-react react-test-renderer jest-cli
 ```
 
 Your `package.json` should look something like this (where `<current-version>` is the actual latest version number for the package). Please add the scripts and jest configuration entries:


### PR DESCRIPTION
If a user is coming to this tutorial after creating a `create-react-app` React app, `npm test` will fail with a missing dependency: `jest-cli`. This updates the documentation to reflect this required dependency.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
