### PR TITLE
Fix progress bar in windows

### DIFF
--- a/packages/jest-cli/src/reporters/utils.js
+++ b/packages/jest-cli/src/reporters/utils.js
@@ -160,8 +160,8 @@ const renderTime = (runTime, estimatedTime, width) => {
     if (availableWidth >= 2) {
       time +=
         '\n' +
-        chalk.green.inverse(' ').repeat(length) +
-        chalk.white.inverse(' ').repeat(availableWidth - length);
+        chalk.green('█').repeat(length) +
+        chalk.white('█').repeat(availableWidth - length);
     }
   }
   return time;


### PR DESCRIPTION
**Summary**

On windows (cmd, powershell, and cmder/conemu) the progress bar was broken. The issue is windows doesnt fully support inverse, and so just renders blank spaces. Changing it to a block character (ascii 219) and removing the inverse fixes this, and should still look the same across other terminals that worked before this change.

**Test plan**

Not needed(?)
