### PR TITLE
jest-haste-map: add test to check duplicate modules are broken

### DIFF
--- a/packages/jest-runtime/src/__tests__/Runtime-requireModuleOrMock-test.js
+++ b/packages/jest-runtime/src/__tests__/Runtime-requireModuleOrMock-test.js
@@ -169,9 +169,10 @@ it('unmocks modules in config.unmockedModulePathPatterns for tests with automock
   }).then(runtime => {
     const root = runtime.requireModule(runtime.__mockRootPath);
     root.jest.enableAutomock();
-    const nodeModule = runtime.requireModuleOrMock(runtime.__mockRootPath, 'npm3-main-dep');
+    const nodeModule = runtime.requireModuleOrMock(
+      runtime.__mockRootPath,
+      'npm3-main-dep',
+    );
     const moduleData = nodeModule();
     expect(moduleData.isUnmocked()).toBe(true);
-  })
-);
-
+  }));

--- a/packages/jest-runtime/src/index.js
+++ b/packages/jest-runtime/src/index.js
@@ -144,10 +144,7 @@ class Runtime {
     this._transitiveShouldMock = Object.create(null);
 
     this._unmockList = unmockRegExpCache.get(config);
-    if (
-      !this._unmockList &&
-      config.unmockedModulePathPatterns
-    ) {
+    if (!this._unmockList && config.unmockedModulePathPatterns) {
       this._unmockList = new RegExp(
         config.unmockedModulePathPatterns.join('|'),
       );


### PR DESCRIPTION
The way duplicate module IDs are handled is broken right now. `jest-haste-map` doesn't recover from duplicate module IDs, because it systematically loose track of one of the duplicates, unable to recover it ever after. This changeset adds the structure of the test to show that it's broken, and put comment where we'll want to change the lines once it's fixed.

**Test plan**

Unit test, no logic change.
