### PR TITLE
correct the example webpack regex's

### DIFF
--- a/docs/en/Webpack.md
+++ b/docs/en/Webpack.md
@@ -19,10 +19,10 @@ Let's start with a common sort of webpack config file and translate it to a Jest
 module.exports = {
   module: {
     loaders: [
-      {exclude: ['node_modules'], loader: 'babel', test: /\\.jsx?$/},
-      {loader: 'style-loader!css-loader', test: /\\.css$/},
-      {loader: 'url-loader', test: /\\.gif$/},
-      {loader: 'file-loader', test: /\\.(ttf|eot|svg)$/},
+      {exclude: ['node_modules'], loader: 'babel', test: /\.jsx?$/},
+      {loader: 'style-loader!css-loader', test: /\.css$/},
+      {loader: 'url-loader', test: /\.gif$/},
+      {loader: 'file-loader', test: /\.(ttf|eot|svg)$/},
     ],
   },
   resolve: {


### PR DESCRIPTION
**Summary**

These are written like string-based regex's for JSON, but are actually regex literals.

This image shows the error pretty clearly. These regex patterns are taken from a JSON config where they are strings, but, being literals, the slashes do not need to be escaped.

![image](https://cloud.githubusercontent.com/assets/4755785/26386955/4d6b408c-408d-11e7-8a74-4bec9a465693.png)


**Test plan**

N/A. It's documentation.
