### PR TITLE
jest-haste-map: recover from duplicate IDs

### DIFF
--- a/packages/jest-haste-map/src/__tests__/index-test.js
+++ b/packages/jest-haste-map/src/__tests__/index-test.js
@@ -761,7 +761,7 @@ describe('HasteMap', () => {
       },
     );
 
-    describe('recovery from duplicate module IDs (broken right now)', () => {
+    describe('recovery from duplicate module IDs', () => {
       async function setupDuplicates(hm) {
         mockFs['/fruits/pear.js'] = [
           '/**',
@@ -793,8 +793,7 @@ describe('HasteMap', () => {
           const e = mockEmitters['/fruits'];
           e.emit('all', 'change', 'pear.js', '/fruits', MOCK_STAT);
           const {moduleMap} = await waitForItToChange(hm);
-          // should be "/fruits/blueberry.js"
-          expect(moduleMap.getModule('Pear')).toBe(null);
+          expect(moduleMap.getModule('Pear')).toBe('/fruits/blueberry.js');
           expect(moduleMap.getModule('OldPear')).toBe('/fruits/pear.js');
           expect(moduleMap.getModule('Blueberry')).toBe(null);
         },
@@ -810,8 +809,7 @@ describe('HasteMap', () => {
         const e = mockEmitters['/fruits'];
         e.emit('all', 'change', 'blueberry.js', '/fruits', MOCK_STAT);
         const {moduleMap} = await waitForItToChange(hm);
-        // should be "/fruits/pear.js"
-        expect(moduleMap.getModule('Pear')).toBe(null);
+        expect(moduleMap.getModule('Pear')).toBe('/fruits/pear.js');
         expect(moduleMap.getModule('Blueberry')).toBe('/fruits/blueberry.js');
       });
     });

--- a/packages/jest-haste-map/src/__tests__/index-test.js
+++ b/packages/jest-haste-map/src/__tests__/index-test.js
@@ -353,7 +353,7 @@ describe('HasteMap', () => {
     return new HasteMap(defaultConfig)
       .build()
       .then(({__hasteMapForTest: data}) => {
-        // duplicate modules are removed so that it doesn't cause
+        // Duplicate modules are removed so that it doesn't cause
         // non-determinism later on.
         expect(data.map.Strawberry[H.GENERIC_PLATFORM]).not.toBeDefined();
 

--- a/packages/jest-haste-map/src/__tests__/index-test.js
+++ b/packages/jest-haste-map/src/__tests__/index-test.js
@@ -355,7 +355,7 @@ describe('HasteMap', () => {
       .then(({__hasteMapForTest: data}) => {
         // duplicate modules are removed so that it doesn't cause
         // non-determinism later on.
-        expect(data.map.Strawberry[H.GENERIC_PLATFORM]).toBe(null);
+        expect(data.map.Strawberry[H.GENERIC_PLATFORM]).not.toBeDefined();
 
         expect(console.warn.mock.calls[0][0]).toMatchSnapshot();
       });

--- a/packages/jest-haste-map/src/__tests__/index-test.js
+++ b/packages/jest-haste-map/src/__tests__/index-test.js
@@ -353,9 +353,9 @@ describe('HasteMap', () => {
     return new HasteMap(defaultConfig)
       .build()
       .then(({__hasteMapForTest: data}) => {
-        expect(data.map.Strawberry[H.GENERIC_PLATFORM][0]).toEqual(
-          '/fruits/raspberry.js',
-        );
+        // duplicate modules are removed so that it doesn't cause
+        // non-determinism later on.
+        expect(data.map.Strawberry[H.GENERIC_PLATFORM]).toBe(null);
 
         expect(console.warn.mock.calls[0][0]).toMatchSnapshot();
       });
@@ -778,8 +778,7 @@ describe('HasteMap', () => {
         e.emit('all', 'add', 'blueberry.js', '/fruits', MOCK_STAT);
         const {hasteFS, moduleMap} = await waitForItToChange(hm);
         expect(hasteFS.exists('/fruits/blueberry.js')).toBe(true);
-        // should be `null`
-        expect(moduleMap.getModule('Pear')).not.toBe(null);
+        expect(moduleMap.getModule('Pear')).toBe(null);
       }
 
       hm_it(

--- a/packages/jest-haste-map/src/index.js
+++ b/packages/jest-haste-map/src/index.js
@@ -325,6 +325,8 @@ class HasteMap extends EventEmitter {
           throw new Error(message);
         }
         this._console.warn(message);
+        moduleMap[platform] = null;
+        return;
       }
 
       moduleMap[platform] = module;

--- a/packages/jest-haste-map/src/index.js
+++ b/packages/jest-haste-map/src/index.js
@@ -331,7 +331,7 @@ class HasteMap extends EventEmitter {
         if (dupsByPl == null) {
           dupsByPl = hasteMap.duplicates[id] = Object.create(null);
         }
-        const dups = dupsByPl[platform] = Object.create(null);
+        const dups = (dupsByPl[platform] = Object.create(null));
         dups[module[H.PATH]] = module[H.TYPE];
         dups[existingModule[H.PATH]] = existingModule[H.TYPE];
         return;
@@ -689,7 +689,9 @@ class HasteMap extends EventEmitter {
           return null;
         })
         .catch(error => {
-          this._console.error(`jest-haste-map: watch error:\n  ${error.stack}\n`);
+          this._console.error(
+            `jest-haste-map: watch error:\n  ${error.stack}\n`,
+          );
         });
     };
 

--- a/packages/jest-haste-map/src/index.js
+++ b/packages/jest-haste-map/src/index.js
@@ -330,19 +330,19 @@ class HasteMap extends EventEmitter {
         if (Object.keys(moduleMap).length === 1) {
           delete map[id];
         }
-        let dupsByPl = hasteMap.duplicates[id];
-        if (dupsByPl == null) {
-          dupsByPl = hasteMap.duplicates[id] = (Object.create(null): any);
+        let dupsByPlatform = hasteMap.duplicates[id];
+        if (dupsByPlatform == null) {
+          dupsByPlatform = hasteMap.duplicates[id] = (Object.create(null): any);
         }
-        const dups = (dupsByPl[platform] = (Object.create(null): any));
+        const dups = (dupsByPlatform[platform] = (Object.create(null): any));
         dups[module[H.PATH]] = module[H.TYPE];
         dups[existingModule[H.PATH]] = existingModule[H.TYPE];
         return;
       }
 
-      const dupsByPl = hasteMap.duplicates[id];
-      if (dupsByPl != null) {
-        const dups = dupsByPl[platform];
+      const dupsByPlatform = hasteMap.duplicates[id];
+      if (dupsByPlatform != null) {
+        const dups = dupsByPlatform[platform];
         if (dups != null) {
           dups[module[H.PATH]] = module[H.TYPE];
         }
@@ -719,19 +719,21 @@ class HasteMap extends EventEmitter {
     filePath: string,
     moduleName: string,
   ) {
-    let dupsByPl = hasteMap.duplicates[moduleName];
-    if (dupsByPl == null) {
+    let dupsByPlatform = hasteMap.duplicates[moduleName];
+    if (dupsByPlatform == null) {
       return;
     }
     const platform =
       getPlatformExtension(filePath, this._options.platforms) ||
       H.GENERIC_PLATFORM;
-    let dups = dupsByPl[platform];
+    let dups = dupsByPlatform[platform];
     if (dups == null) {
       return;
     }
-    dupsByPl = hasteMap.duplicates[moduleName] = (copy(dupsByPl): any);
-    dups = dupsByPl[platform] = (copy(dups): any);
+    dupsByPlatform = hasteMap.duplicates[moduleName] = (copy(
+      dupsByPlatform,
+    ): any);
+    dups = dupsByPlatform[platform] = (copy(dups): any);
     const dedupType = dups[filePath];
     delete dups[filePath];
     const filePaths = Object.keys(dups);
@@ -743,8 +745,8 @@ class HasteMap extends EventEmitter {
       dedupMap = hasteMap.map[moduleName] = (Object.create(null): any);
     }
     dedupMap[platform] = [filePaths[0], dedupType];
-    delete dupsByPl[platform];
-    if (Object.keys(dupsByPl).length === 0) {
+    delete dupsByPlatform[platform];
+    if (Object.keys(dupsByPlatform).length === 0) {
       delete hasteMap.duplicates[moduleName];
     }
   }

--- a/packages/jest-haste-map/src/index.js
+++ b/packages/jest-haste-map/src/index.js
@@ -326,20 +326,23 @@ class HasteMap extends EventEmitter {
         }
         this._console.warn(message);
         // We do NOT want consumers to use a module that is ambiguous.
-        moduleMap[platform] = null;
+        delete moduleMap[platform];
+        if (Object.keys(moduleMap).length === 1) {
+          delete map[id];
+        }
         let dupsByPl = hasteMap.duplicates[id];
         if (dupsByPl == null) {
-          dupsByPl = hasteMap.duplicates[id] = Object.create(null);
+          dupsByPl = hasteMap.duplicates[id] = (Object.create(null): any);
         }
-        const dups = (dupsByPl[platform] = Object.create(null));
+        const dups = (dupsByPl[platform] = (Object.create(null): any));
         dups[module[H.PATH]] = module[H.TYPE];
         dups[existingModule[H.PATH]] = existingModule[H.TYPE];
         return;
       }
 
-      let dupsByPl = hasteMap.duplicates[id];
+      const dupsByPl = hasteMap.duplicates[id];
       if (dupsByPl != null) {
-        let dups = dupsByPl[platform];
+        const dups = dupsByPl[platform];
         if (dups != null) {
           dups[module[H.PATH]] = module[H.TYPE];
         }
@@ -635,8 +638,8 @@ class HasteMap extends EventEmitter {
           if (mustCopy) {
             mustCopy = false;
             hasteMap = {
-              duplicates: copy(hasteMap.duplicates),
               clocks: copy(hasteMap.clocks),
+              duplicates: copy(hasteMap.duplicates),
               files: copy(hasteMap.files),
               map: copy(hasteMap.map),
               mocks: copy(hasteMap.mocks),
@@ -727,8 +730,8 @@ class HasteMap extends EventEmitter {
     if (dups == null) {
       return;
     }
-    dupsByPl = hasteMap.duplicates[moduleName] = copy(dupsByPl);
-    dups = dupsByPl[platform] = copy(dups);
+    dupsByPl = hasteMap.duplicates[moduleName] = (copy(dupsByPl): any);
+    dups = dupsByPl[platform] = (copy(dups): any);
     const dedupType = dups[filePath];
     delete dups[filePath];
     const filePaths = Object.keys(dups);
@@ -737,7 +740,7 @@ class HasteMap extends EventEmitter {
     }
     let dedupMap = hasteMap.map[moduleName];
     if (dedupMap == null) {
-      dedupMap = hasteMap.map[moduleName] = Object.create(null);
+      dedupMap = hasteMap.map[moduleName] = (Object.create(null): any);
     }
     dedupMap[platform] = [filePaths[0], dedupType];
     delete dupsByPl[platform];
@@ -789,8 +792,8 @@ class HasteMap extends EventEmitter {
 
   _createEmptyMap(): InternalHasteMap {
     return {
-      duplicates: Object.create(null),
       clocks: Object.create(null),
+      duplicates: Object.create(null),
       files: Object.create(null),
       map: Object.create(null),
       mocks: Object.create(null),

--- a/packages/jest-haste-map/src/index.js
+++ b/packages/jest-haste-map/src/index.js
@@ -325,7 +325,24 @@ class HasteMap extends EventEmitter {
           throw new Error(message);
         }
         this._console.warn(message);
+        // We do NOT want consumers to use a module that is ambiguous.
         moduleMap[platform] = null;
+        let dupsByPl = hasteMap.duplicates[id];
+        if (dupsByPl == null) {
+          dupsByPl = hasteMap.duplicates[id] = Object.create(null);
+        }
+        const dups = dupsByPl[platform] = Object.create(null);
+        dups[module[H.PATH]] = true;
+        dups[existingModule[H.PATH]] = true;
+        return;
+      }
+
+      let dupsByPl = hasteMap.duplicates[id];
+      if (dupsByPl != null) {
+        let dups = dupsByPl[platform];
+        if (dups != null) {
+          dups[module[H.PATH]] = true;
+        }
         return;
       }
 
@@ -620,6 +637,7 @@ class HasteMap extends EventEmitter {
           if (mustCopy) {
             mustCopy = false;
             hasteMap = {
+              duplicates: copy(hasteMap.duplicates),
               clocks: copy(hasteMap.clocks),
               files: copy(hasteMap.files),
               map: copy(hasteMap.map),
@@ -726,6 +744,7 @@ class HasteMap extends EventEmitter {
 
   _createEmptyMap(): InternalHasteMap {
     return {
+      duplicates: Object.create(null),
       clocks: Object.create(null),
       files: Object.create(null),
       map: Object.create(null),

--- a/types/HasteMap.js
+++ b/types/HasteMap.js
@@ -21,8 +21,15 @@ export type ModuleMapData = {[id: string]: ModuleMapItem};
 export type WatchmanClocks = {[filepath: Path]: string};
 export type HasteRegExp = RegExp | ((str: string) => boolean);
 
+export type DuplicatesIndex = {
+  [id: string]: {
+    [platform: string]: {[filePath: string]: /* type */ number},
+  },
+};
+
 export type InternalHasteMap = {|
   clocks: WatchmanClocks,
+  duplicates: DuplicatesIndex,
   files: FileData,
   map: ModuleMapData,
   mocks: MockData,


### PR DESCRIPTION
This supersedes #3107. This changeset adds a new top-level structure to the "HasteMap" object kept internally. This structure keeps track of duplicated modules. We cannot keep track of these in the existing `map` field, that accepts only a single resolution per module name/ID. An alternative solution would have been to change the structure of `map`, for example to keep an array of file paths for each module name/ID. However, this would incur significant overhead persisting the whole "HasteMap". By adding a separate index structure, that only contains the strict necessary, we ensure minimum overhead is added for persistence.

**Test plan**

Unit tests. As you can see, I fixed the unit tests that were testing the broken behavior, that is now correct.

