### PR TITLE
Improved the jest reporter with snapshot info per test.

### DIFF
--- a/packages/jest-cli/src/reporters/__tests__/__snapshots__/get_snapshot_status.test.js.snap
+++ b/packages/jest-cli/src/reporters/__tests__/__snapshots__/get_snapshot_status.test.js.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Retrieves the snapshot status 1`] = `
+Array [
+  "<bold><green> › 1 snapshot</> written.",
+  "<bold><green> › 1 snapshot</> updated.",
+  "<bold><red> › 1 obsolete snapshot</> found.",
+  "<bold><red> › 1 snapshot test</> failed.",
+]
+`;
+
+exports[`Retrieves the snapshot status after a snapshot update 1`] = `
+Array [
+  "<bold><green> › 2 snapshots</> written.",
+  "<bold><green> › 2 snapshots</> updated.",
+  "<bold><red> › 2 obsolete snapshots</> removed.",
+  "<bold><red> › Obsolete snapshot file</> removed.",
+  "<bold><red> › 2 snapshot tests</> failed.",
+]
+`;
+
+exports[`Shows no snapshot updates if all snapshots matched 1`] = `Array []`;

--- a/packages/jest-cli/src/reporters/__tests__/default_reporter.test.js
+++ b/packages/jest-cli/src/reporters/__tests__/default_reporter.test.js
@@ -16,6 +16,14 @@ const testCase = {
   path: '/foo',
 };
 const testResult = {
+  snapshot: {
+    added: 0,
+    fileDeleted: true,
+    matched: 1,
+    unchecked: 0,
+    unmatched: 0,
+    updated: 0,
+  },
   testFilePath: '/foo',
 };
 

--- a/packages/jest-cli/src/reporters/__tests__/get_snapshot_status.test.js
+++ b/packages/jest-cli/src/reporters/__tests__/get_snapshot_status.test.js
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+'use strict';
+
+const getSnapshotStatus = require('../get_snapshot_status');
+
+test('Retrieves the snapshot status', () => {
+  const snapshotResult = {
+    added: 1,
+    fileDeleted: false,
+    matched: 1,
+    unchecked: 1,
+    unmatched: 1,
+    updated: 1,
+  };
+
+  expect(getSnapshotStatus(snapshotResult, false)).toMatchSnapshot();
+});
+
+test('Shows no snapshot updates if all snapshots matched', () => {
+  const snapshotResult = {
+    added: 0,
+    fileDeleted: false,
+    matched: 1,
+    unchecked: 0,
+    unmatched: 0,
+    updated: 0,
+  };
+
+  expect(getSnapshotStatus(snapshotResult, true)).toMatchSnapshot();
+});
+
+test('Retrieves the snapshot status after a snapshot update', () => {
+  const snapshotResult = {
+    added: 2,
+    fileDeleted: true,
+    matched: 2,
+    unchecked: 2,
+    unmatched: 2,
+    updated: 2,
+  };
+
+  expect(getSnapshotStatus(snapshotResult, true)).toMatchSnapshot();
+});

--- a/packages/jest-cli/src/reporters/default_reporter.js
+++ b/packages/jest-cli/src/reporters/default_reporter.js
@@ -21,6 +21,7 @@ import isCI from 'is-ci';
 import BaseReporter from './base_reporter';
 import Status from './Status';
 import getResultHeader from './get_result_header';
+import getSnapshotStatus from './get_snapshot_status';
 
 type write = (chunk: string, enc?: any, cb?: () => void) => boolean;
 type FlushBufferedOutput = () => void;
@@ -192,6 +193,10 @@ class DefaultReporter extends BaseReporter {
       if (result.failureMessage) {
         this.log(result.failureMessage);
       }
+
+      const didUpdate = this._globalConfig.updateSnapshot === 'all';
+      const snapshotStatuses = getSnapshotStatus(result.snapshot, didUpdate);
+      snapshotStatuses.forEach(this.log);
     }
   }
 }

--- a/packages/jest-cli/src/reporters/get_snapshot_status.js
+++ b/packages/jest-cli/src/reporters/get_snapshot_status.js
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+
+import type {TestResult} from 'types/TestResult';
+
+const chalk = require('chalk');
+
+const {pluralize} = require('./utils');
+
+const ARROW = ' \u203A ';
+const FAIL_COLOR = chalk.bold.red;
+const SNAPSHOT_ADDED = chalk.bold.green;
+const SNAPSHOT_REMOVED = chalk.bold.red;
+const SNAPSHOT_UPDATED = chalk.bold.green;
+
+module.exports = (
+  snapshot: $PropertyType<TestResult, 'snapshot'>,
+  afterUpdate: boolean,
+): Array<string> => {
+  const statuses = [];
+
+  if (snapshot.added) {
+    statuses.push(
+      SNAPSHOT_ADDED(ARROW + pluralize('snapshot', snapshot.added)) +
+        ' written.',
+    );
+  }
+
+  if (snapshot.updated) {
+    statuses.push(
+      SNAPSHOT_UPDATED(ARROW + pluralize('snapshot', snapshot.updated)) +
+        ` updated.`,
+    );
+  }
+
+  if (snapshot.unchecked) {
+    statuses.push(
+      FAIL_COLOR(ARROW + pluralize('obsolete snapshot', snapshot.unchecked)) +
+        (afterUpdate ? ' removed' : ' found') +
+        '.',
+    );
+  }
+
+  if (snapshot.fileDeleted) {
+    statuses.push(
+      SNAPSHOT_REMOVED(ARROW + 'Obsolete snapshot file') + ` removed.`,
+    );
+  }
+
+  if (snapshot.unmatched) {
+    statuses.push(
+      FAIL_COLOR(ARROW + pluralize('snapshot test', snapshot.unmatched)) +
+        ' failed.',
+    );
+  }
+  return statuses;
+};


### PR DESCRIPTION
Improved the jest terminal reporter to show snapshot info per test. The snapshot summary shown at the end of the test run shows some generic info like *"2 snapshots written in 1 test suite"*, *"1 obsolete snapshot file found"*. However, it wasn't always immediately clear in what test suite these snapshot changes had occurred. This PR attempts to resolve this by showing all the snapshot changes per test file so that it is immediately clear what happened after a test run. I am curious to hear what you think!

This addresses issue #3581.

I was also thinking that it would be nice if the name of the snapshot which has been updated is shown in the terminal rather than simply stating *"2 snapshots written"* or *"2 obsolete snapshots found*". Adding the name to the output does not seem very trivial; the type `TestResult` used in the  jest-cli reporter doesn't export the names of the snapshots, it only exports the properties shown below. Therefore, adding the updated snapshot names would entail changing the structure in which the reporter gets its data. What do you guys think, is it worth adding the snapshot names to the output?

```
// the snapshot structure for type TestResult
snapshot: {|
    added: number,
    fileDeleted: boolean,
    matched: number,
    unchecked: number,
    unmatched: number,
    updated: number,
  |},
```

![jest-snapshot-demo 1](https://cloud.githubusercontent.com/assets/19558321/26486118/1754c932-41fa-11e7-872b-f279b540ce22.gif)

Let me know what you think!