### PR TITLE
Fix incorrect toHaveProperty() documentation

### DIFF
--- a/docs/en/ExpectAPI.md
+++ b/docs/en/ExpectAPI.md
@@ -737,8 +737,7 @@ test('the house has my desired features', () => {
 Use `.toHaveProperty` to check if property at provided reference `keyPath` exists for an object.
 For checking deeply nested properties in an object use [dot notation](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Operators/Property_accessors) for deep references.
 
-Optionally, you can provide a value to check if it's strictly equal to the `value` present
-at `keyPath` on the target object.
+Optionally, you can provide a `value` to check if it's equal to the value present at `keyPath` on the target object. This matcher uses 'deep equality' (like `toEqual()`) and recursively checks the equality of all fields.
 
 The following example contains a `houseForSale` object with nested properties. We are using `toHaveProperty`
 to check for the existence and values of various properties in the object.


### PR DESCRIPTION
`toHaveProperty()` documentation incorrectly states value is be checked with strict equality (i.e. `===` like `toBe()`). It's actually checked with deep equality like `toEqual()`.

I've corrected the ExpectAPI documentation page to reflect this, and have made it absolutely clear which type of equality is used for this matcher.

Further suggestions: The page is quite inconsistent in how it talks about equality. It'd also be convenient to have an object property matcher that did use strict equality (e.g. `toHaveStrictProperty()` etc).

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
