### PR TITLE
Add support for Immutable.Record in pretty-format

### DIFF
--- a/packages/jest-snapshot/src/__tests__/plugins-test.js
+++ b/packages/jest-snapshot/src/__tests__/plugins-test.js
@@ -29,7 +29,7 @@ const testPath = names => {
 it('gets plugins', () => {
   const {getSerializers} = require('../plugins');
   const plugins = getSerializers();
-  expect(plugins.length).toBe(9);
+  expect(plugins.length).toBe(10);
 });
 
 it('adds plugins from an empty array', () => testPath([]));

--- a/packages/pretty-format/src/__tests__/Immutable-test.js
+++ b/packages/pretty-format/src/__tests__/Immutable-test.js
@@ -445,3 +445,82 @@ describe('Immutable.OrderedMap plugin', () => {
     );
   });
 });
+
+describe('Immutable.Record plugin', () => {
+  it('supports an empty record', () => {
+    const ABRecord = Immutable.Record({a: 1, b: 2}, 'ABRecord');
+
+    expect(new ABRecord()).toPrettyPrintTo('Immutable.ABRecord {a: 1, b: 2}', {
+      min: true,
+    });
+  });
+
+  it('supports a record without descriptive name', () => {
+    const ABRecord = Immutable.Record({a: 1, b: 2});
+
+    expect(new ABRecord()).toPrettyPrintTo('Immutable.Record {a: 1, b: 2}', {
+      min: true,
+    });
+  });
+
+  it('supports a record with values {min: true}', () => {
+    const ABRecord = Immutable.Record({a: 1, b: 2}, 'ABRecord');
+
+    expect(
+      new ABRecord({a: 3, b: 4}),
+    ).toPrettyPrintTo('Immutable.ABRecord {a: 3, b: 4}', {min: true});
+  });
+
+  it('supports a record with values {min: false}', () => {
+    const ABRecord = Immutable.Record({a: 1, b: 2}, 'ABRecord');
+
+    expect(new ABRecord({a: 3, b: 4})).toPrettyPrintTo(
+      'Immutable.ABRecord {\n  a: 3,\n  b: 4,\n}',
+    );
+  });
+
+  it('supports a record with Map value {min: true}', () => {
+    const ABRecord = Immutable.Record(
+      {a: Immutable.Map({c: 1}), b: 2},
+      'ABRecord',
+    );
+
+    expect(
+      new ABRecord(),
+    ).toPrettyPrintTo('Immutable.ABRecord {a: Immutable.Map {c: 1}, b: 2}', {
+      min: true,
+    });
+  });
+
+  it('supports a record with Map value {min: false}', () => {
+    const ABRecord = Immutable.Record(
+      {a: Immutable.Map({c: 1}), b: 2},
+      'ABRecord',
+    );
+
+    expect(new ABRecord()).toPrettyPrintTo(
+      'Immutable.ABRecord {\n  a: Immutable.Map {\n    c: 1,\n  },\n  b: 2,\n}',
+    );
+  });
+
+  it('supports imbricated Record {min: true}', () => {
+    const CDRecord = Immutable.Record({c: 3, d: 4}, 'CDRecord');
+    const ABRecord = Immutable.Record({a: new CDRecord(), b: 2}, 'ABRecord');
+
+    expect(
+      new ABRecord(),
+    ).toPrettyPrintTo(
+      'Immutable.ABRecord {a: Immutable.CDRecord {c: 3, d: 4}, b: 2}',
+      {min: true},
+    );
+  });
+
+  it('supports imbricated Record {min: false}', () => {
+    const CDRecord = Immutable.Record({c: 3, d: 4}, 'CDRecord');
+    const ABRecord = Immutable.Record({a: new CDRecord(), b: 2}, 'ABRecord');
+
+    expect(new ABRecord()).toPrettyPrintTo(
+      'Immutable.ABRecord {\n  a: Immutable.CDRecord {\n    c: 3,\n    d: 4,\n  },\n  b: 2,\n}',
+    );
+  });
+});

--- a/packages/pretty-format/src/plugins/ImmutablePlugins.js
+++ b/packages/pretty-format/src/plugins/ImmutablePlugins.js
@@ -15,4 +15,5 @@ module.exports = [
   require('./ImmutableStack'),
   require('./ImmutableOrderedSet'),
   require('./ImmutableOrderedMap'),
+  require('./ImmutableRecord'),
 ];

--- a/packages/pretty-format/src/plugins/ImmutableRecord.js
+++ b/packages/pretty-format/src/plugins/ImmutableRecord.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+
+import type {Colors, Indent, Options, Print, Plugin} from 'types/PrettyFormat';
+
+const printImmutable = require('./lib/printImmutable');
+
+const IS_RECORD = '@@__IMMUTABLE_RECORD__@@';
+const test = (maybeRecord: any) => !!(maybeRecord && maybeRecord[IS_RECORD]);
+
+const print = (
+  val: any,
+  print: Print,
+  indent: Indent,
+  opts: Options,
+  colors: Colors,
+) => printImmutable(val, print, indent, opts, colors, 'Record', true);
+
+module.exports = ({print, test}: Plugin);

--- a/packages/pretty-format/src/plugins/lib/printImmutable.js
+++ b/packages/pretty-format/src/plugins/lib/printImmutable.js
@@ -39,21 +39,17 @@ const printImmutable = (
 
   const immutableArray = [];
 
+  const pushToImmutableArray = (item: any, key: string) => {
+    immutableArray.push(
+      indent(addKey(isMap, key) + print(item, print, indent, opts, colors)),
+    );
+  };
+
   if (Array.isArray(val._keys)) {
     // if we have a record, we can not iterate on it directly
-    val._keys.forEach(key =>
-      immutableArray.push(
-        indent(
-          addKey(isMap, key) + print(val.get(key), print, indent, opts, colors),
-        ),
-      ),
-    );
+    val._keys.forEach(key => pushToImmutableArray(val.get(key), key));
   } else {
-    val.forEach((item, key) =>
-      immutableArray.push(
-        indent(addKey(isMap, key) + print(item, print, indent, opts, colors)),
-      ),
-    );
+    val.forEach((item, key) => pushToImmutableArray(item, key));
   }
 
   result += immutableArray.join(',' + opts.spacing);

--- a/packages/pretty-format/src/plugins/lib/printImmutable.js
+++ b/packages/pretty-format/src/plugins/lib/printImmutable.js
@@ -28,19 +28,33 @@ const printImmutable = (
   isMap: boolean,
 ): string => {
   const [openTag, closeTag] = isMap ? ['{', '}'] : ['[', ']'];
+  const fullStructureName = val._name || immutableDataStructureName;
+
   let result =
     IMMUTABLE_NAMESPACE +
-    immutableDataStructureName +
+    fullStructureName +
     SPACE +
     openTag +
     opts.edgeSpacing;
 
   const immutableArray = [];
-  val.forEach((item, key) =>
-    immutableArray.push(
-      indent(addKey(isMap, key) + print(item, print, indent, opts, colors)),
-    ),
-  );
+
+  if (Array.isArray(val._keys)) {
+    // if we have a record, we can not iterate on it directly
+    val._keys.forEach(key =>
+      immutableArray.push(
+        indent(
+          addKey(isMap, key) + print(val.get(key), print, indent, opts, colors),
+        ),
+      ),
+    );
+  } else {
+    val.forEach((item, key) =>
+      immutableArray.push(
+        indent(addKey(isMap, key) + print(item, print, indent, opts, colors)),
+      ),
+    );
+  }
 
   result += immutableArray.join(',' + opts.spacing);
   if (!opts.min && immutableArray.length > 0) {


### PR DESCRIPTION
**Summary**

`Immutable.Record` are not handled by `pretty-print`, but other Immutable.js structures are. `Record` are often used in Redux states for example, and Redux reducers tested using snapshots. This will allow the snapshots to be more precise, referencing proper `Immutable.Record` and not plain JS objects.

**Test plan**

I added tests for the various usecases I had in mind. 

This fixes #3677

@thymikee can you review it? I tried to not add anything Record-specific in `lib/printImmutable.js` and rely on `val._keys` and `val._name`.

`val._name` is only used for `Record`, but `Immutable.Seq` (which is not supported by `pretty-print`) also has `._keys`. Maybe I should check if `val.forEach` is defined and fallback to `val._keys`? Or should I specificaly check if a record is passed?