### PR TITLE
Delete confusing async keyword

### DIFF
--- a/docs/en/TestingAsyncCode.md
+++ b/docs/en/TestingAsyncCode.md
@@ -66,7 +66,7 @@ Be sure to return the promise - if you omit this `return` statement, your test w
 If you expect a promise to be rejected use the `.catch` method. Make sure to add `expect.assertions` to verify that a certain number of assertions are called. Otherwise a fulfilled promise would not fail the test.
 
 ```js
-test('the fetch fails with an error', async () => {
+test('the fetch fails with an error', () => {
   expect.assertions(1);
   return fetchData().catch(e =>
     expect(e).toMatch('error')


### PR DESCRIPTION
**Summary**

Async is used is only used in one of two similar promise examples.  The inconsistency threw me off, particularly since async is not necessary in this context.

Motivation: clarity 

**Test plan**

This is only a documentation change.
