### PR TITLE
s/jasmine.any/expect.any/

### DIFF
--- a/examples/jquery/__tests__/fetchCurrentUser-test.js
+++ b/examples/jquery/__tests__/fetchCurrentUser-test.js
@@ -15,7 +15,7 @@ it('calls into $.ajax with the correct params', () => {
   // Now make sure that $.ajax was properly called during the previous
   // 2 lines
   expect($.ajax).toBeCalledWith({
-    success: jasmine.any(Function),
+    success: expect.any(Function),
     type: 'GET',
     url: 'http://example.com/currentUser',
   });

--- a/packages/jest-cli/src/__tests__/TestRunner-test.js
+++ b/packages/jest-cli/src/__tests__/TestRunner-test.js
@@ -58,11 +58,11 @@ describe('_createInBandTestRun()', () => {
         expect(workerFarmMock.mock.calls).toEqual([
           [
             {config, globalConfig, path: './file-test.js', rawModuleMap},
-            jasmine.any(Function),
+            expect.any(Function),
           ],
           [
             {config, globalConfig, path: './file2-test.js', rawModuleMap},
-            jasmine.any(Function),
+            expect.any(Function),
           ],
         ]);
       });
@@ -85,11 +85,11 @@ describe('_createInBandTestRun()', () => {
         expect(workerFarmMock.mock.calls).toEqual([
           [
             {config, globalConfig, path: './file-test.js', rawModuleMap: null},
-            jasmine.any(Function),
+            expect.any(Function),
           ],
           [
             {config, globalConfig, path: './file2-test.js', rawModuleMap: null},
-            jasmine.any(Function),
+            expect.any(Function),
           ],
         ]);
       });

--- a/packages/jest-cli/src/__tests__/watch-test.js
+++ b/packages/jest-cli/src/__tests__/watch-test.js
@@ -64,8 +64,8 @@ describe('Watch mode flows', () => {
       argv,
       pipe,
       new TestWatcher({isWatchMode: true}),
-      jasmine.any(Function),
-      jasmine.any(Function),
+      expect.any(Function),
+      expect.any(Function),
     );
   });
 
@@ -81,8 +81,8 @@ describe('Watch mode flows', () => {
       argv,
       pipe,
       new TestWatcher({isWatchMode: true}),
-      jasmine.any(Function),
-      jasmine.any(Function),
+      expect.any(Function),
+      expect.any(Function),
     );
   });
 
@@ -94,8 +94,8 @@ describe('Watch mode flows', () => {
       argv,
       pipe,
       new TestWatcher({isWatchMode: true}),
-      jasmine.any(Function),
-      jasmine.any(Function),
+      expect.any(Function),
+      expect.any(Function),
     );
     expect(pipe.write.mock.calls.reverse()[0]).toMatchSnapshot();
   });

--- a/packages/jest-haste-map/src/__tests__/index-test.js
+++ b/packages/jest-haste-map/src/__tests__/index-test.js
@@ -571,11 +571,11 @@ describe('HasteMap', () => {
         expect(workerFarmMock.mock.calls.length).toBe(5);
 
         expect(workerFarmMock.mock.calls).toEqual([
-          [{filePath: '/fruits/__mocks__/Pear.js'}, jasmine.any(Function)],
-          [{filePath: '/fruits/banana.js'}, jasmine.any(Function)],
-          [{filePath: '/fruits/pear.js'}, jasmine.any(Function)],
-          [{filePath: '/fruits/strawberry.js'}, jasmine.any(Function)],
-          [{filePath: '/vegetables/melon.js'}, jasmine.any(Function)],
+          [{filePath: '/fruits/__mocks__/Pear.js'}, expect.any(Function)],
+          [{filePath: '/fruits/banana.js'}, expect.any(Function)],
+          [{filePath: '/fruits/pear.js'}, expect.any(Function)],
+          [{filePath: '/fruits/strawberry.js'}, expect.any(Function)],
+          [{filePath: '/vegetables/melon.js'}, expect.any(Function)],
         ]);
 
         expect(workerFarm.end).toBeCalledWith(workerFarmMock);

--- a/packages/jest-haste-map/src/crawlers/__tests__/watchman-test.js
+++ b/packages/jest-haste-map/src/crawlers/__tests__/watchman-test.js
@@ -101,7 +101,7 @@ describe('watchman watch', () => {
       const calls = client.command.mock.calls;
 
       expect(client.on).toBeCalled();
-      expect(client.on).toBeCalledWith('error', jasmine.any(Function));
+      expect(client.on).toBeCalledWith('error', expect.any(Function));
 
       // Call 0 and 1 are for ['watch-project']
       expect(calls[0][0][0]).toEqual('watch-project');


### PR DESCRIPTION
using `expect` api directly rather than through the jasmine alias 