### PR TITLE
Fix options.moduleNameMapper override order with preset (#3565)

### DIFF
--- a/packages/jest-config/src/__tests__/normalize.test.js
+++ b/packages/jest-config/src/__tests__/normalize.test.js
@@ -837,6 +837,7 @@ describe('preset', () => {
   });
 
   test('merges with options and moduleNameMapper preset is overridden by options', () => {
+    /* eslint-disable sort-keys */
     // prettier-ignore
     const {options} = normalize(
       {
@@ -846,6 +847,7 @@ describe('preset', () => {
       },
       {},
     );
+    /* eslint-enable sort-keys */
 
     expect(options.moduleNameMapper).toEqual([
       ['e', 'ee'],

--- a/packages/jest-config/src/__tests__/normalize.test.js
+++ b/packages/jest-config/src/__tests__/normalize.test.js
@@ -837,22 +837,27 @@ describe('preset', () => {
   });
 
   test('merges with options and moduleNameMapper preset is overridden by options', () => {
-    /* eslint-disable sort-keys */
-    // prettier-ignore
+    // Object initializer not used for properties as a workaround for 
+    //  sort-keys eslint rule while specifing properties in 
+    //  non-alphabetical order for a better test
+    const moduleNameMapper = {};
+    moduleNameMapper.e = 'ee';
+    moduleNameMapper.b = 'bb';
+    moduleNameMapper.c = 'cc';
+    moduleNameMapper.a = 'aa';
     const {options} = normalize(
       {
-        moduleNameMapper: {e: 'ee', c: 'cc', b: 'bb', a: 'aa'},
+        moduleNameMapper,
         preset: 'react-native',
         rootDir: '/root/path/foo',
       },
       {},
     );
-    /* eslint-enable sort-keys */
 
     expect(options.moduleNameMapper).toEqual([
       ['e', 'ee'],
-      ['c', 'cc'],
       ['b', 'bb'],
+      ['c', 'cc'],
       ['a', 'aa'],
     ]);
   });

--- a/packages/jest-config/src/__tests__/normalize.test.js
+++ b/packages/jest-config/src/__tests__/normalize.test.js
@@ -827,12 +827,30 @@ describe('preset', () => {
       {},
     );
 
-    expect(options.moduleNameMapper).toEqual([['b', 'b'], ['a', 'a']]);
+    expect(options.moduleNameMapper).toEqual([['a', 'a'], ['b', 'b']]);
     expect(options.modulePathIgnorePatterns).toEqual(['b', 'a']);
     expect(options.setupFiles.sort()).toEqual([
       '/node_modules/a',
       '/node_modules/b',
       '/node_modules/regenerator-runtime/runtime',
+    ]);
+  });
+
+  test('merges with options and moduleNameMapper preset is overridden by options', () => {
+    const {options} = normalize(
+      {
+        moduleNameMapper: { e: 'ee', c: 'cc', b: 'bb', a: 'aa' },
+        preset: 'react-native',
+        rootDir: '/root/path/foo',
+      },
+      {},
+    );
+
+    expect(options.moduleNameMapper).toEqual([
+      ['e', 'ee'],
+      ['c', 'cc'],
+      ['b', 'bb'],
+      ['a', 'aa'],
     ]);
   });
 });

--- a/packages/jest-config/src/__tests__/normalize.test.js
+++ b/packages/jest-config/src/__tests__/normalize.test.js
@@ -837,9 +837,10 @@ describe('preset', () => {
   });
 
   test('merges with options and moduleNameMapper preset is overridden by options', () => {
+    // prettier-ignore
     const {options} = normalize(
       {
-        moduleNameMapper: { e: 'ee', c: 'cc', b: 'bb', a: 'aa' },
+        moduleNameMapper: {e: 'ee', c: 'cc', b: 'bb', a: 'aa'},
         preset: 'react-native',
         rootDir: '/root/path/foo',
       },

--- a/packages/jest-config/src/normalize.js
+++ b/packages/jest-config/src/normalize.js
@@ -76,6 +76,7 @@ const setupPreset = (
   if (options.moduleNameMapper && preset.moduleNameMapper) {
     options.moduleNameMapper = Object.assign(
       {},
+      options.moduleNameMapper,
       preset.moduleNameMapper,
       options.moduleNameMapper,
     );


### PR DESCRIPTION
**Summary**

Adjusted the order so that the options mappings are checked first and then the preset mappings are checked.
The preset mappings can be overridden by the options mappings.
Fixes #3565 

**Test plan**

Modified existing test and added a new test.
Tests passed after making the necessary code changes. TDD FTW ;) !