### PR TITLE
Output created snapshot when using --ci option

### DIFF
--- a/packages/jest-snapshot/src/index.js
+++ b/packages/jest-snapshot/src/index.js
@@ -83,7 +83,9 @@ const toMatchSnapshot = function(received: any, testName?: string) {
       `New snapshot was ${RECEIVED_COLOR('not written')}. The update flag ` +
       `must be explicitly passed to write a new snapshot.\n\n` +
       `This is likely because this test is run in a continuous integration ` +
-      `(CI) environment in which snapshots are not written by default.`;
+      `(CI) environment in which snapshots are not written by default.\n\n` +
+      `${RECEIVED_COLOR('Received value')}` +
+      `${actual}`;
   } else {
     expected = (expected || '').trim();
     actual = (actual || '').trim();


### PR DESCRIPTION
**Summary**

I need to review created snapshots. By default, it just creates a new snapshot without any information and to do the review I must find this snapshot manually in test.snap.
When I use the `--ci` flag, I can review the snapshot, and when it looks ok, I can just press `u`.

**Test plan**
Added "Received value" + snapshot content.
![image](https://cloud.githubusercontent.com/assets/4478684/26596471/142f06a0-456f-11e7-854d-a4ec071acf4b.png)
