### PR TITLE
Use Node 8 on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-  - "7"
+  - "8"
 
 sudo: false
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,6 @@
 environment:
   matrix:
-    #- nodejs_version: "4"
-    - nodejs_version: "6"
+    - nodejs_version: "8"
 
 install:
   - ps: Install-Product node $env:nodejs_version x64

--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,7 @@ machine:
     YARN_VERSION: 0.20.3
     PATH: "${PATH}:${HOME}/.yarn/bin:${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin"
   node:
-    version: 7
+    version: 8
 dependencies:
   pre:
     - |
@@ -28,7 +28,7 @@ test:
     - yarn run test-ci
     - nvm alias default 4
     - yarn run test-ci-partial
-    - nvm alias default 7
+    - nvm alias default 8
     - yarn run test-ci-partial
     - DANGER_GITHUB_API_TOKEN="ab0c4d396c935d3abce""fc213176da6bb7b2996ff" yarn run danger
     - cd website && yarn run test

--- a/integration_tests/__tests__/__snapshots__/failures-test.js.snap
+++ b/integration_tests/__tests__/__snapshots__/failures-test.js.snap
@@ -1,60 +1,35 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`not throwing Error objects 1`] = `
-Object {
-  "rest": " FAIL  __tests__/throw-number-test.js
+" FAIL  __tests__/throw-number-test.js
   ● Test suite failed to run
 
     Expected an Error, but \\"1\\" was thrown
 
-",
-  "summary": "Test Suites: 1 failed, 1 total
-Tests:       0 total
-Snapshots:   0 total
-Time:        <<REPLACED>>
-Ran all test suites matching \\"throw-number-test.js\\".
-",
-}
+"
 `;
 
 exports[`not throwing Error objects 2`] = `
-Object {
-  "rest": " FAIL  __tests__/throw-string-test.js
+" FAIL  __tests__/throw-string-test.js
   ● Test suite failed to run
 
     Error
       banana
 
-",
-  "summary": "Test Suites: 1 failed, 1 total
-Tests:       0 total
-Snapshots:   0 total
-Time:        <<REPLACED>>
-Ran all test suites matching \\"throw-string-test.js\\".
-",
-}
+"
 `;
 
 exports[`not throwing Error objects 3`] = `
-Object {
-  "rest": " FAIL  __tests__/throw-object-test.js
+" FAIL  __tests__/throw-object-test.js
   ● Test suite failed to run
 
     Error: No message was provided
 
-",
-  "summary": "Test Suites: 1 failed, 1 total
-Tests:       0 total
-Snapshots:   0 total
-Time:        <<REPLACED>>
-Ran all test suites matching \\"throw-object-test.js\\".
-",
-}
+"
 `;
 
 exports[`not throwing Error objects 4`] = `
-Object {
-  "rest": " FAIL  __tests__/assertion-count-test.js
+" FAIL  __tests__/assertion-count-test.js
   ● .assertions() › throws
 
     expect(received).toBeTruthy()
@@ -104,19 +79,11 @@ Object {
   .hasAssertions()
     ✕ throws when there are not assertions
 
-",
-  "summary": "Test Suites: 1 failed, 1 total
-Tests:       4 failed, 4 total
-Snapshots:   0 total
-Time:        <<REPLACED>>
-Ran all test suites matching \\"assertion-count-test.js\\".
-",
-}
+"
 `;
 
 exports[`works with node assert 1`] = `
-Object {
-  "rest": " FAIL  __tests__/node-assertion-error-test.js
+" FAIL  __tests__/node-assertion-error-test.js
   ● assert
 
     assert.equal(received, expected) or assert(received) 
@@ -340,7 +307,7 @@ Object {
       [Error: err!]
     
     Message:
-      Got unwanted exception..
+      Got unwanted exception.
       
       at __tests__/node-assertion-error-test.js:72:10
 
@@ -352,7 +319,7 @@ Object {
     But it didn't throw anything.
     
     Message:
-      Missing expected exception..
+      Missing expected exception.
       
       at __tests__/node-assertion-error-test.js:78:10
 
@@ -373,12 +340,5 @@ Object {
   ✕ assert.doesNotThrow
   ✕ assert.throws
 
-",
-  "summary": "Test Suites: 1 failed, 1 total
-Tests:       16 failed, 16 total
-Snapshots:   0 total
-Time:        <<REPLACED>>
-Ran all test suites matching \\"node-assertion-error-test.js\\".
-",
-}
+"
 `;

--- a/integration_tests/__tests__/babel-plugin-jest-hoist-test.js
+++ b/integration_tests/__tests__/babel-plugin-jest-hoist-test.js
@@ -20,7 +20,7 @@ skipOnWindows.suite();
 
 if (process.platform !== 'win32') {
   beforeEach(() => {
-    run('npm i', DIR);
+    run('yarn', DIR);
     linkJestPackage('babel-plugin-jest-hoist', DIR);
     linkJestPackage('babel-jest', DIR);
   });

--- a/integration_tests/__tests__/failures-test.js
+++ b/integration_tests/__tests__/failures-test.js
@@ -13,7 +13,7 @@ const runJest = require('../runJest');
 
 const dir = path.resolve(__dirname, '../failures');
 
-const normalizeDots = text => text.replace(/\.{2,}$/m, '.');
+const normalizeDots = text => text.replace(/\.{1,}$/gm, '.');
 
 skipOnWindows.suite();
 

--- a/integration_tests/__tests__/failures-test.js
+++ b/integration_tests/__tests__/failures-test.js
@@ -13,21 +13,23 @@ const runJest = require('../runJest');
 
 const dir = path.resolve(__dirname, '../failures');
 
+const normalizeDots = text => text.replace(/\.{2,}$/m, '.');
+
 skipOnWindows.suite();
 
 test('not throwing Error objects', () => {
   let stderr;
   stderr = runJest(dir, ['throw-number-test.js']).stderr;
-  expect(extractSummary(stderr)).toMatchSnapshot();
+  expect(extractSummary(stderr).rest).toMatchSnapshot();
   stderr = runJest(dir, ['throw-string-test.js']).stderr;
-  expect(extractSummary(stderr)).toMatchSnapshot();
+  expect(extractSummary(stderr).rest).toMatchSnapshot();
   stderr = runJest(dir, ['throw-object-test.js']).stderr;
-  expect(extractSummary(stderr)).toMatchSnapshot();
+  expect(extractSummary(stderr).rest).toMatchSnapshot();
   stderr = runJest(dir, ['assertion-count-test.js']).stderr;
-  expect(extractSummary(stderr)).toMatchSnapshot();
+  expect(extractSummary(stderr).rest).toMatchSnapshot();
 });
 
 test('works with node assert', () => {
   const {stderr} = runJest(dir, ['node-assertion-error-test.js']);
-  expect(extractSummary(stderr)).toMatchSnapshot();
+  expect(normalizeDots(extractSummary(stderr).rest)).toMatchSnapshot();
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Switch from Node 7 to Node 8 on all of our CIs.
I took the opportunity to refactor our failure tests to only include failure messages (`assert.doesNotThrow` now throws extra message without additional dot, they probably fixed a typo).

**Test plan**

CI green