### PR TITLE
Fix colors for expected/stored snapshot message

### DIFF
--- a/packages/jest-snapshot/src/index.js
+++ b/packages/jest-snapshot/src/index.js
@@ -97,9 +97,9 @@ const toMatchSnapshot = function(received: any, testName?: string) {
       `${RECEIVED_COLOR('Received value')} does not match ` +
       `${EXPECTED_COLOR('stored snapshot ' + count)}.\n\n` +
       (diffMessage ||
-        RECEIVED_COLOR('- ' + (expected || '')) +
+        EXPECTED_COLOR('- ' + (expected || '')) +
           '\n' +
-          EXPECTED_COLOR('+ ' + actual));
+          RECEIVED_COLOR('+ ' + actual));
   }
   // Passing the the actual and expected objects so that a custom reporter
   // could access them, for example in order to display a custom visual diff,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Jest colors (expected/stored in snapshot) in single line strings in snapshots were reversed:

Before | After
------- | -----
![Before](https://github.com/duailibe/jest-snapshot-colors/blob/master/screens/actual.png?raw=true) | ![After](https://github.com/duailibe/jest-snapshot-colors/blob/master/screens/expected.png?raw=true)

**Test plan**

There's a repro case in http://github.com/duailibe/jest-snapshot-colors
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
