### PR TITLE
Enable: Russian, Ukrainian, and Chinese Simplified

### DIFF
--- a/website/languages.js
+++ b/website/languages.js
@@ -134,7 +134,7 @@ const languages = [
     tag: 'ro',
   },
   {
-    enabled: false,
+    enabled: true,
     name: 'Русский',
     tag: 'ru',
   },
@@ -159,7 +159,7 @@ const languages = [
     tag: 'tr',
   },
   {
-    enabled: false,
+    enabled: true,
     name: 'Українська',
     tag: 'uk',
   },
@@ -169,7 +169,7 @@ const languages = [
     tag: 'vi',
   },
   {
-    enabled: false,
+    enabled: true,
     name: '中文',
     tag: 'zh-Hans',
   },

--- a/website/translators.txt
+++ b/website/translators.txt
@@ -1,0 +1,61 @@
+Chinese, Simplified
+
+blackcater
+Chuan (chuanxie)
+Gorden Gao (jonishaso96)
+HuMoran
+J3n5en
+jiyongjia (skdream)
+joehecn
+Ma Cheng (mc-zone)
+pdslly
+popo1221
+Rambos
+Wei Gao (wgao19)
+Yixin Wan (yxwan99)
+Yuanzhong Xia (MewX)
+zheng (fuchao2012)
+宋昆达 (Songkunda)
+
+Portugese, Brazilian
+	
+Héctor Ramos (hramos)
+Adilson Schmitt Junior (sirgallifrey)
+Belchior Oliveira (belchior)
+Felipe Galvão (felipegalvao)
+Filipe W. Lima (filipewl)
+Guilherme Oderdenge (chiefGui)
+Henrick Mello (hmartins505)
+Marcelo Dapper (mdapper)
+
+Russian
+
+Alexander Chudesnov (chudesnov)
+Andrey Stukalin (apstukalin)
+Anuar Zhukenov (codalife)
+Galymzhan Abdugalimov (naffiq)
+Vladislav Dekhanov (asc0de)
+Вячеслав Павлутин (slavapavlutin)
+
+Spanish
+
+Héctor Ramos (hramos)
+aganglada
+Antonio Laguna (Belelros)
+David Atencia (datencia)
+Esteban GALICIA (bay007)
+Federico Miras (fmiras)
+Fidel Castro (fcfidel)
+Luis Merino (Rendez)
+Manolo Santos (manolo.santos)
+Marc Rivelles (MarkLeanJS)
+PepeFranco
+Rubén Moya (rubenmoya)
+
+Ukrainian
+
+Nikolay (mkozhukharenko)
+Oleksandr Kovpashko (okovpashko)
+Olena Sovyn (Kiwka)
+Pavel Polyakov (PavelPolyakov)
+


### PR DESCRIPTION
**Summary**

This PR will Enable Russian, Ukrainian and Chinese Simplified for the Jest website.

Our goal here is to inspire developers in these countries to contribute further and to reward our wonderful community for all their contributions.
