### PR TITLE
Add docs showing nested describe() usage

### DIFF
--- a/docs/en/GlobalAPI.md
+++ b/docs/en/GlobalAPI.md
@@ -188,6 +188,36 @@ describe('my beverage', () => {
 
 This isn't required - you can just write the `test` blocks directly at the top level. But this can be handy if you prefer your tests to be organized into groups.
 
+You can also nest `describe` blocks if you have a hierarchy of tests:
+
+```js
+const binaryStringToNumber = binString => {
+  if (!/^[01]+$/.test(binString)) {
+    throw new CustomError("not a binary number!");
+  }
+
+  return parseInt(binString, 2);
+};
+
+describe("binaryStringToNumber", () => {
+  describe("given an invalid binary string", () => {
+    test("composed of non-numbers throws CustomError", () => {
+      expect(() => binaryStringToNumber("abc")).toThrowError(CustomError);
+    });
+
+    test("with extra whitespace throws CustomError", () => {
+      expect(() => binaryStringToNumber("  100")).toThrowError(CustomError);
+    });
+  });
+
+  describe("given a valid binary string", () => {
+    test("returns the correct number", () => {
+      expect(binaryStringToNumber("100")).toBe(4);
+    });
+  });
+});
+```
+
 ### `describe.only(name, fn)`
 
 Also under the alias: `fdescribe(name, fn)`

--- a/docs/en/GlobalAPI.md
+++ b/docs/en/GlobalAPI.md
@@ -193,26 +193,26 @@ You can also nest `describe` blocks if you have a hierarchy of tests:
 ```js
 const binaryStringToNumber = binString => {
   if (!/^[01]+$/.test(binString)) {
-    throw new CustomError("not a binary number!");
+    throw new CustomError('Not a binary number.');
   }
 
   return parseInt(binString, 2);
 };
 
-describe("binaryStringToNumber", () => {
-  describe("given an invalid binary string", () => {
-    test("composed of non-numbers throws CustomError", () => {
-      expect(() => binaryStringToNumber("abc")).toThrowError(CustomError);
+describe('binaryStringToNumber', () => {
+  describe('given an invalid binary string', () => {
+    test('composed of non-numbers throws CustomError', () => {
+      expect(() => binaryStringToNumber('abc')).toThrowError(CustomError);
     });
 
-    test("with extra whitespace throws CustomError", () => {
-      expect(() => binaryStringToNumber("  100")).toThrowError(CustomError);
+    test('with extra whitespace throws CustomError', () => {
+      expect(() => binaryStringToNumber('  100')).toThrowError(CustomError);
     });
   });
 
-  describe("given a valid binary string", () => {
-    test("returns the correct number", () => {
-      expect(binaryStringToNumber("100")).toBe(4);
+  describe('given a valid binary string', () => {
+    test('returns the correct number', () => {
+      expect(binaryStringToNumber('100')).toBe(4);
     });
   });
 });


### PR DESCRIPTION
**Summary**

Adds documentation, including an example, of how to use `describe()` blocks in a nested fashion. I use them this way and it appears to be well-supported, but I didn't see documentation for it.

The example is a little longer than I'd like, but I think it illustrates a common use case of testing fast exits followed by green path testing.

**Test plan**

I regenerated the website locally and the document showed up fine. I also ran the test example locally in jest and confirmed that the code works. I omitted the definition of `CustomError` in the example to keep it from being too long.
