### PR TITLE
Prevent babelrc package import failure on relative current path

### DIFF
--- a/packages/babel-jest/src/index.js
+++ b/packages/babel-jest/src/index.js
@@ -47,7 +47,10 @@ const createTransformer = (options: any) => {
         cache[directory] = JSON.stringify(require(configJsFilePath));
         break;
       }
-      const packageJsonFilePath = path.join(directory, PACKAGE_JSON);
+      const resolvedJsonFilePath = path.join(directory, PACKAGE_JSON);
+      const packageJsonFilePath = resolvedJsonFilePath === PACKAGE_JSON
+        ? path.resolve(directory, PACKAGE_JSON)
+        : resolvedJsonFilePath;
       if (fs.existsSync(packageJsonFilePath)) {
         // $FlowFixMe
         const packageJsonFileContents = require(packageJsonFilePath);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Relates to https://github.com/danger/danger-js/issues/261 .

This PR attempts to fix cases of reading babelrc via `package.json`. Using current code path, below case is possible:

```js
//directory is '.', relative current
const packageJsonFilePath = path.join(directory, PACKAGE_JSON); 
//now packageJsonFilePath === PACKAGE_JSON, plain filename only as 'package.json'
//fs can check file exists
if (fs.existsSync(packageJsonFilePath)) { 
  //node module resolution failure cause it doesn't have paths, 
  //node try to resolve it as node_modules -> exception thrown
  const packageJsonFileContents = require(packageJsonFilePath);
...
```

I thought of using different mechanics to detect relative current (i.e `path.relative(directory, '.')`, `path.resolve(directory, __dirname)`..) but took simplest comparison instead.

**Test plan**
I've verified by replacing this module uses it as dependency (https://github.com/danger/danger-js/issues/261)

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
