### PR TITLE
Delete redundant branch in ReactElement and HTMLElement plugins

### DIFF
--- a/packages/pretty-format/src/plugins/HTMLElement.js
+++ b/packages/pretty-format/src/plugins/HTMLElement.js
@@ -51,9 +51,7 @@ function isHTMLElement(value: any) {
 function printChildren(flatChildren, print, indent, colors, opts) {
   return flatChildren
     .map(node => {
-      if (typeof node === 'object') {
-        return print(node);
-      } else if (typeof node === 'string') {
+      if (typeof node === 'string') {
         return colors.content.open + escapeHTML(node) + colors.content.close;
       } else {
         return print(node);

--- a/packages/pretty-format/src/plugins/ReactElement.js
+++ b/packages/pretty-format/src/plugins/ReactElement.js
@@ -25,9 +25,7 @@ function traverseChildren(opaqueChildren, cb) {
 function printChildren(flatChildren, print, indent, colors, opts) {
   return flatChildren
     .map(node => {
-      if (typeof node === 'object') {
-        return print(node);
-      } else if (typeof node === 'string') {
+      if (typeof node === 'string') {
         return colors.content.open + escapeHTML(node) + colors.content.close;
       } else {
         return print(node);


### PR DESCRIPTION
**Summary**

The changes because of excellent Flow `strict_call_arity` in #3568 make it clear that `if else if else` statements can become `if else` in two plugins of `pretty-format` package.

**Test plan**

Jest