### PR TITLE
[WebSite] Fix nav item word sank when using zh. (when more than 1024px width)

### DIFF
--- a/website/src/jest/css/jest.css
+++ b/website/src/jest/css/jest.css
@@ -1165,6 +1165,7 @@ ul#languages li {
     padding: 6px 10px;
     height: auto;
     font-size: 1em;
+    white-space: nowrap;
   }
   .navigationSlider .slidingNav ul li a:hover {
     color: #fff;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
when using zh_Hans, and more than 1024px width, the nav item word broken and sank.

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

before:
![image](https://cloud.githubusercontent.com/assets/4403937/26759302/ce7d871e-492c-11e7-9c59-aca53181761b.png)

after:
![image](https://cloud.githubusercontent.com/assets/4403937/26759305/db855626-492c-11e7-9890-b274c8f6ca64.png)

