### PR TITLE
Add `--projects` option Jest CLI Options docs

### DIFF
--- a/docs/en/CLI.md
+++ b/docs/en/CLI.md
@@ -164,6 +164,10 @@ Activates notifications for test results. Good for when you don't want your cons
 
 Alias: `-o`. Attempts to identify which tests to run based on which files have changed in the current repository. Only works if you're running tests in a git/hg repository at the moment and requires a static dependency graph (ie. no dynamic requires).
 
+### `--projects <project1> ... <projectN>`
+
+Run tests from one or more projects.
+
 ### `--runInBand`
 
 Alias: `-i`. Run all tests serially in the current process, rather than creating a worker pool of child processes that run tests. This can be useful for debugging.


### PR DESCRIPTION
**Summary**

With Jest 20 there was new CLI option introduced `--projects`. This PR proposes documentation changes to include this new flag. It probably needs some rewording, but I wanted to open this PR to keep track of it.

**Test plan**

No tests required. Documentation change only.
