### PR TITLE
Call print for non-string children in ReactTestComponent plugin

### DIFF
--- a/packages/jest-snapshot/src/plugins.js
+++ b/packages/jest-snapshot/src/plugins.js
@@ -17,7 +17,7 @@ const {
   ReactTestComponent,
 } = require('pretty-format').plugins;
 
-let PLUGINS = [HTMLElement, ReactElement, ReactTestComponent].concat(Immutable);
+let PLUGINS = [ReactTestComponent, ReactElement, HTMLElement].concat(Immutable);
 
 // Prepend to list so the last added is the first tested.
 exports.addSerializer = (plugin: Plugin) => {

--- a/packages/pretty-format/src/plugins/ReactTestComponent.js
+++ b/packages/pretty-format/src/plugins/ReactTestComponent.js
@@ -30,7 +30,13 @@ function printChildren(
   opts,
 ) {
   return children
-    .map(child => printInstance(child, print, indent, colors, opts))
+    .map(node => {
+      if (typeof node === 'string') {
+        return colors.content.open + escapeHTML(node) + colors.content.close;
+      } else {
+        return print(node);
+      }
+    })
     .join(opts.edgeSpacing);
 }
 
@@ -63,13 +69,13 @@ function printProps(props: Object, print, indent, colors, opts) {
     .join('');
 }
 
-function printInstance(instance: ReactTestChild, print, indent, colors, opts) {
-  if (typeof instance == 'number') {
-    return print(instance);
-  } else if (typeof instance === 'string') {
-    return colors.content.open + escapeHTML(instance) + colors.content.close;
-  }
-
+const print = (
+  instance: ReactTestObject,
+  print: Print,
+  indent: Indent,
+  opts: Options,
+  colors: Colors,
+) => {
   let closeInNewLine = false;
   let result = colors.tag.open + '<' + instance.type + colors.tag.close;
 
@@ -105,15 +111,7 @@ function printInstance(instance: ReactTestChild, print, indent, colors, opts) {
   }
 
   return result;
-}
-
-const print = (
-  val: ReactTestObject,
-  print: Print,
-  indent: Indent,
-  opts: Options,
-  colors: Colors,
-) => printInstance(val, print, indent, colors, opts);
+};
 
 const test = (object: Object) =>
   object && object.$$typeof === reactTestInstance;


### PR DESCRIPTION
**Summary**

The most likely reason for the redundant branches deleted in #3731 was an unsuccessful attempt at a shortcut as in `ReactTestComponent` plugin to call itself directly for children, instead of calling the generic `print` serializer argument.

When the plugin was written a year ago, that optimization made sense, but now since #3017 `pretty-format` runs plugins before serializing nested **basic** values, it is more consistent:

* to handle child test objects like prop values and other non-string children (that is, numbers :)
* to maximize similarity of `printChildren` in `ReactTestComponent`, `ReactElement`, and `HTMLElement`

This pull request has a small optimization to make up some lost time. Reorder the plugins in `jest-snapshot` to what seems like decreasing frequency of occurrence:
* `ReactTestComponent` moves to first place
* `ReactElement` stays in second place
* `HTMLElement` moves to third place
* `Immutable` plugins stay in last place, mainly because of `concat` method

Here are some measurements for 22 tests adapted from `React-test.js`:

| plugins order | `ReactTestComponent` original | `ReactTestComponent` proposed | `ReactElement` |
| :--- | ---: | ---: | ---: |
| original | 708388 | 721070 | 789576 |
| improved | 679633 | 702370 | 786811 |

Interpretation:

* The proposed code change to `ReactTestComponent` with the improved plugins order is less time than original `ReactTestComponent` and plugins order.
* Preliminary measurements of solutions to #3518 suggest that future code will run in even less time than original code of `ReactTestComponent` with improved plugins order.
* Because the order of `ReactElement` plugin stays the same, its test time is within the timing precision, although the test logic for `ReactTestComponent` is indeed less than `HTMLElement`.
* I think that `ReactElement` is slower because it distinguishes `children` from rest of props and flattens children.

**Test plan**

Jest

**Residue**

This PR will make `PLUGINS` order in `jest-snapshot` consistent with `jest-diff` **but** can y’all explain why `jest-matcher-utils` doesn’t include `ReactTestComponent` and what is the purpose of its `serialize` function?

* `jest-diff` https://github.com/facebook/jest/blame/master/packages/jest-diff/src/index.js#L28-L33

    ```js
    const PLUGINS = [
      ReactTestComponent,
      ReactElement,
      AsymmetricMatcher,
      HTMLElement,
    ].concat(Immutable);
    ```

* `jest-matcher-utils` https://github.com/facebook/jest/blob/master/packages/jest-matcher-utils/src/index.js#L21-L23

    ```js
    const PLUGINS = [AsymmetricMatcher, ReactElement, HTMLElement].concat(
      Immutable,
    );
    ```

* `jest-snapshot` https://github.com/facebook/jest/blob/master/packages/jest-snapshot/src/plugins.js#L20

    ```js
    let PLUGINS = [HTMLElement, ReactElement, ReactTestComponent].concat(Immutable);
    ```
