### PR TITLE
jest-circus Timeouts

### DIFF
--- a/docs/en/JestObjectAPI.md
+++ b/docs/en/JestObjectAPI.md
@@ -27,7 +27,7 @@ The `jest` object is automatically in scope within every test file. The methods 
   - [`jest.runTimersToTime(msToRun)`](#jestruntimerstotimemstorun)
   - [`jest.runOnlyPendingTimers()`](#jestrunonlypendingtimers)
   - [`jest.setMock(moduleName, moduleExports)`](#jestsetmockmodulename-moduleexports)
-  - [`jest.setTestTimeout(timeout)`](#jestsettesttimeouttimeout)
+  - [`jest.setTimeout(timeout)`](#jestsettimeouttimeout)
   - [`jest.unmock(moduleName)`](#jestunmockmodulename)
   - [`jest.useFakeTimers()`](#jestusefaketimers)
   - [`jest.useRealTimers()`](#jestuserealtimers)
@@ -205,16 +205,16 @@ Returns the `jest` object for chaining.
 
 *Note It is recommended to use [`jest.mock()`](#jestmockmodulename-factory-options) instead. The `jest.mock` API's second argument is a module factory instead of the expected exported module object.*
 
-### `jest.setTestTimeout(timeout)`
+### `jest.setTimeout(timeout)`
 
-Set the default timeout interval for tests in milliseconds.
+Set the default timeout interval for tests and before/after hooks in milliseconds.
 
 *Note: The default timeout interval is 5 seconds if this method is not called.*
 
 Example:
 
 ```js
-jest.setTestTimeout(1000); // 1 second
+jest.setTimeout(1000); // 1 second
 ```
 
 ### `jest.unmock(moduleName)`

--- a/docs/en/Troubleshooting.md
+++ b/docs/en/Troubleshooting.md
@@ -64,10 +64,10 @@ Consider replacing the global promise implementation with your own, for example
 used Promise libraries to a single one.
 
 If your test is long running, you may want to consider to increase the timeout
-by calling  `jest.setTestTimeout`
+by calling  `jest.setTimeout`
 
 ```
-jest.setTestTimeout(10000); // 10 second timeout
+jest.setTimeout(10000); // 10 second timeout
 ```
 
 ### Watchman Issues

--- a/integration_tests/__tests__/__snapshots__/timeouts-test.js.snap
+++ b/integration_tests/__tests__/__snapshots__/timeouts-test.js.snap
@@ -17,19 +17,6 @@ Ran all test suites.
 `;
 
 exports[`exceeds the timeout 1`] = `
-" FAIL  __tests__/a-banana.js
-  ● banana
-
-    Timeout - Async callback was not invoked within timeout specified by jasmine.DEFAULT_TIMEOUT_INTERVAL.
-      
-      at ../../packages/jest-jasmine2/build/queueRunner.js:53:21
-
-  ✕ banana
-
-"
-`;
-
-exports[`exceeds the timeout 2`] = `
 "Test Suites: 1 failed, 1 total
 Tests:       1 failed, 1 total
 Snapshots:   0 total

--- a/integration_tests/__tests__/timeouts-test.js
+++ b/integration_tests/__tests__/timeouts-test.js
@@ -23,7 +23,7 @@ afterAll(() => cleanup(DIR));
 test('exceeds the timeout', () => {
   writeFiles(DIR, {
     '__tests__/a-banana.js': `
-      jest.setTestTimeout(20);
+      jest.setTimeout(20);
 
       test('banana', () => {
         return new Promise(resolve => {
@@ -44,7 +44,7 @@ test('exceeds the timeout', () => {
 test('does not exceed the timeout', () => {
   writeFiles(DIR, {
     '__tests__/a-banana.js': `
-      jest.setTestTimeout(100);
+      jest.setTimeout(100);
 
       test('banana', () => {
         return new Promise(resolve => {

--- a/integration_tests/__tests__/timeouts-test.js
+++ b/integration_tests/__tests__/timeouts-test.js
@@ -36,9 +36,9 @@ test('exceeds the timeout', () => {
 
   const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false']);
   const {rest, summary} = extractSummary(stderr);
-  expect(status).toBe(1);
-  expect(rest).toMatchSnapshot();
+  expect(rest).toMatch(/(jasmine\.DEFAULT_TIMEOUT_INTERVAL|Exceeded timeout)/);
   expect(summary).toMatchSnapshot();
+  expect(status).toBe(1);
 });
 
 test('does not exceed the timeout', () => {
@@ -57,7 +57,7 @@ test('does not exceed the timeout', () => {
 
   const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false']);
   const {rest, summary} = extractSummary(stderr);
-  expect(status).toBe(0);
   expect(rest).toMatchSnapshot();
   expect(summary).toMatchSnapshot();
+  expect(status).toBe(0);
 });

--- a/packages/jest-circus/src/state.js
+++ b/packages/jest-circus/src/state.js
@@ -10,7 +10,6 @@
 
 import type {Event, State, EventHandler} from '../types';
 
-
 const {makeDescribe} = require('./utils');
 const eventHandler = require('./eventHandler');
 

--- a/packages/jest-circus/src/utils.js
+++ b/packages/jest-circus/src/utils.js
@@ -110,19 +110,19 @@ const getEachHooksForTest = (
   return result;
 };
 
-const _makeTimeoutMessage = (timeout, isHook) => {
-  const message = `Exceeded timeout of ${timeout}ms for a ${isHook ? 'hook' : 'test'}.`;
-  return new Error(message);
-};
+const _makeTimeoutMessage = (timeout, isHook) =>
+  new Error(
+    `Exceeded timeout of ${timeout}ms for a ${isHook ? 'hook' : 'test'}.\nUse jest.setTimeout(newTimeout) to increase the timeout value, if this is a long-running test.`,
+  );
 
 const callAsyncFn = (
   fn: AsyncFn,
   testContext: ?TestContext,
   {
     isHook,
-    timeout,
     test,
-  }: {isHook?: ?boolean, timeout: number, test?: TestEntry},
+    timeout,
+  }: {isHook?: ?boolean, test?: TestEntry, timeout: number},
 ): Promise<any> => {
   return new Promise((resolve, reject) => {
     setTimeout(() => reject(_makeTimeoutMessage(timeout, isHook)), timeout);
@@ -145,7 +145,7 @@ const callAsyncFn = (
 
     // If it's a Promise, return it.
     if (returnedValue instanceof Promise) {
-      return returnedValue.then(resolve).catch(reject);
+      return returnedValue.then(resolve, reject);
     }
 
     if (!isHook && returnedValue !== void 0) {

--- a/packages/jest-cli/src/__tests__/SearchSource-test.js
+++ b/packages/jest-cli/src/__tests__/SearchSource-test.js
@@ -9,7 +9,7 @@
  */
 'use strict';
 
-jest.setTestTimeout(15000);
+jest.setTimeout(15000);
 
 const path = require('path');
 const skipOnWindows = require('skipOnWindows');

--- a/packages/jest-runtime/src/index.js
+++ b/packages/jest-runtime/src/index.js
@@ -715,7 +715,7 @@ class Runtime {
     const fn = this._moduleMocker.fn.bind(this._moduleMocker);
     const spyOn = this._moduleMocker.spyOn.bind(this._moduleMocker);
 
-    const setTestTimeout = (timeout: number) => {
+    const setTimeout = (timeout: number) => {
       this._environment.global.jasmine
         ? (this._environment.global.jasmine.DEFAULT_TIMEOUT_INTERVAL = timeout)
         : (this._environment.global[
@@ -758,7 +758,7 @@ class Runtime {
 
       setMock: (moduleName: string, mock: Object) =>
         setMockFactory(moduleName, () => mock),
-      setTestTimeout,
+      setTimeout,
       spyOn,
 
       unmock,

--- a/testSetupFile.js
+++ b/testSetupFile.js
@@ -10,7 +10,7 @@ const jasmineReporters = require('jasmine-reporters');
 
 // Some of the `jest-runtime` tests are very slow and cause
 // timeouts on travis
-jest.setTestTimeout(70000);
+jest.setTimeout(70000);
 
 if (global.jasmine && process.env.APPVEYOR_API_URL) {
   // Running on AppVeyor, add the custom reporter.


### PR DESCRIPTION
`jest.setTestTimeout` will actually set a timeout per async fn.
So if there's a timeout of `20ms` and there's a `beforeEach` hook defined, the total timeout for a test will be `40ms` (20ms for `beforeEach` and 20ms for the test itself).

i think this is reasonable, but maybe we'll need to rename `setTestTimeout` to `setTimeout` as @cpojer suggested earlier