### PR TITLE
jasmine globals + skipped->pending

### DIFF
--- a/integration_tests/__tests__/globals-test.js
+++ b/integration_tests/__tests__/globals-test.js
@@ -72,11 +72,11 @@ test('skips', () => {
 
   writeFiles(TEST_DIR, {[filename]: content});
   const {stderr, status} = runJest(DIR);
-  expect(status).toBe(0);
 
   const {summary, rest} = extractSummary(stderr);
   expect(rest).toMatchSnapshot();
   expect(summary).toMatchSnapshot();
+  expect(status).toBe(0);
 });
 
 test('only', () => {

--- a/packages/jest-circus/src/legacy_code_todo_rewrite/jest-adapter-init.js
+++ b/packages/jest-circus/src/legacy_code_todo_rewrite/jest-adapter-init.js
@@ -33,6 +33,12 @@ const initialize = ({
 }) => {
   Object.assign(global, globals);
 
+  global.xit = global.it.skip;
+  global.xtest = global.it.skip;
+  global.xdescribe = global.describe.skip;
+  global.fit = global.it.only;
+  global.fdescribe = global.describe.only;
+
   addEventHandler(eventHandler);
 
   // Jest tests snapshotSerializers in order preceding built-in serializers.
@@ -88,7 +94,7 @@ const runAndTransformResultsToJestFormat = async ({
         status = 'passed';
         break;
       case 'skip':
-        status = 'skipped';
+        status = 'pending';
         break;
     }
 


### PR DESCRIPTION
a few inconsistencies.

are we going to support `xit`, `fdescribe` globals in the future?
I aliased them in the legacy/adapter part of the framework, since i'm not sure if we want to bring them in natively