### PR TITLE
Point out you can use matchers in .toMatchObject

### DIFF
--- a/docs/en/ExpectAPI.md
+++ b/docs/en/ExpectAPI.md
@@ -707,7 +707,7 @@ describe('grapefruits are healthy', () => {
 
 ### `.toMatchObject(object)`
 
-Use `.toMatchObject` to check that a JavaScript object matches a subset of the properties of an object.
+Use `.toMatchObject` to check that a JavaScript object matches a subset of the properties of an object. You can match properties against values or against matchers.
 
 ```js
 const houseForSale = {
@@ -723,7 +723,7 @@ const desiredHouse = {
   bath: true,
   kitchen: {
     amenities: ['oven', 'stove', 'washer'],
-    wallColor: 'white',
+    wallColor: expect.stringMatching(/white|yellow/),
   },
 };
 


### PR DESCRIPTION
This is sufficiently non-obvious that [some](https://medium.com/@boriscoder/the-hidden-power-of-jest-matchers-f3d86d8101b0) recommend over-using the more cumbersome `.toEqual(expect.objectContaining({ ... }))`.