### PR TITLE
Fixed object matcher

### DIFF
--- a/packages/jest-matchers/src/utils.js
+++ b/packages/jest-matchers/src/utils.js
@@ -79,7 +79,7 @@ const getObjectSubset = (object: Object, subset: Object) => {
   ) {
     const trimmed = {};
     Object.keys(subset)
-      .filter(key => object.hasOwnProperty(key))
+      .filter(key => hasOwnProperty(object, key))
       .forEach(
         key => (trimmed[key] = getObjectSubset(object[key], subset[key])),
       );


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Updated the object matcher utility to use hasOwnProperty independent of the object passed.
Before, `expect(Object.create(null)).toMatchObject(someObject)` would throw an error, as Object.create(null) lacks the object prototype.

It appears that you all had already noticed this as you had created a helper for it, but weren't actually using it.

**Test plan**

yarn run jest --silent && yarn run test-examples --silent

<img width="237" alt="screen shot 2017-06-12 at 12 18 08 pm" src="https://user-images.githubusercontent.com/3687954/27046285-800faa7e-4f69-11e7-8faf-64378cf85f40.png">
<img width="249" alt="screen shot 2017-06-12 at 12 17 56 pm" src="https://user-images.githubusercontent.com/3687954/27046286-8014cd60-4f69-11e7-8023-b5a4d27c6bf9.png">

