### PR TITLE
Call consistent pretty-format plugins within Jest

### DIFF
--- a/packages/jest-diff/src/index.js
+++ b/packages/jest-diff/src/index.js
@@ -17,18 +17,18 @@ import diffStrings from './diffStrings';
 import {NO_DIFF_MESSAGE, SIMILAR_MESSAGE} from './constants';
 
 const {
-  ReactElement,
-  ReactTestComponent,
   AsymmetricMatcher,
   HTMLElement,
   Immutable,
+  ReactElement,
+  ReactTestComponent,
 } = prettyFormat.plugins;
 
 const PLUGINS = [
   ReactTestComponent,
   ReactElement,
-  AsymmetricMatcher,
   HTMLElement,
+  AsymmetricMatcher,
 ].concat(Immutable);
 const FORMAT_OPTIONS = {
   plugins: PLUGINS,

--- a/packages/jest-matcher-utils/src/index.js
+++ b/packages/jest-matcher-utils/src/index.js
@@ -13,14 +13,18 @@ import getType from 'jest-get-type';
 import prettyFormat from 'pretty-format';
 const {
   AsymmetricMatcher,
-  ReactElement,
   HTMLElement,
   Immutable,
+  ReactElement,
+  ReactTestComponent,
 } = prettyFormat.plugins;
 
-const PLUGINS = [AsymmetricMatcher, ReactElement, HTMLElement].concat(
-  Immutable,
-);
+const PLUGINS = [
+  ReactTestComponent,
+  ReactElement,
+  HTMLElement,
+  AsymmetricMatcher,
+].concat(Immutable);
 
 const EXPECTED_COLOR = chalk.green;
 const EXPECTED_BG = chalk.bgGreen;


### PR DESCRIPTION
**Summary**

* Add `ReactTestComponent` to `jest-matcher-utils`
* Call the most frequently used plugins first.

Please confirm that `AsymmetricMatcher` is for `jest-diff` and `jest-matcher-utils` but not `jest-snapshot`

**Test plan**

Jest