### PR TITLE
Fix issue mocking bound method

### DIFF
--- a/packages/jest-mock/src/__tests__/jest-mock-test.js
+++ b/packages/jest-mock/src/__tests__/jest-mock-test.js
@@ -187,6 +187,18 @@ describe('moduleMocker', () => {
       expect(typeof multipleBoundFuncMock).toBe('function');
     });
 
+   it('mocks methods that are bound after mocking', () => {
+      const fooMock = moduleMocker.generateFromMetadata(
+        moduleMocker.getMetadata(() => {}),
+      );
+
+      const barMock = moduleMocker.generateFromMetadata(
+        moduleMocker.getMetadata(fooMock.bind(null)),
+      );
+
+      expect(barMock).not.toThrow();
+    });
+
     it('mocks regexp instances', () => {
       expect(() =>
         moduleMocker.generateFromMetadata(moduleMocker.getMetadata(/a/)),

--- a/packages/jest-mock/src/index.js
+++ b/packages/jest-mock/src/index.js
@@ -377,9 +377,7 @@ class ModuleMockerClass {
     mockConstructor: () => any,
   ): any {
     let name = metadata.name;
-    // Special case functions named `mockConstructor` to guard for infinite
-    // loops.
-    if (!name || name === MOCK_CONSTRUCTOR_NAME) {
+    if (!name) {
       return mockConstructor;
     }
 
@@ -393,6 +391,12 @@ class ModuleMockerClass {
         // Call bind() just to alter the function name.
         bindCall = '.bind(null)';
       } while (name && name.startsWith(boundFunctionPrefix));
+    }
+
+    // Special case functions named `mockConstructor` to guard for infinite
+    // loops.
+    if (name === MOCK_CONSTRUCTOR_NAME) {
+      return mockConstructor;
     }
 
     // It's a syntax error to define functions with a reserved keyword


### PR DESCRIPTION
Binding and mocking methods in a specific order causes a `Maximum call stack size exceeded` error when the mocked method is called. 

**Summary**
`_createMockFunction` normally detects functions that have already been mocked by checking if they are named `"mockConstructor"`. However, calling `bind` on the mocked function changes the function name and causes the check to fail.

`_createMockFunction` already has code to strip out the `"bound "` prefix, but the check to look for `"mockConstructor"` was happening too early. This PR moves delays checking for `"mockConstructor"` until after `"bound "` has already been stripped out.

Repro steps:
1. Mock an anonymous function (fn is now named `"mockConstructor"`)
2. Bind the mocked function (fn is now named name `"bound mockConstructor"`)
3. Mock the bound function  (fn fails check `"bound mockConstructor" === "mockConstructor"` and gets into an infinite loop)

**Test plan**

- `yarn test`
- `cd ~/www; jest --all` ;)
