### PR TITLE
Provide better error checking for transformed content

### DIFF
--- a/packages/jest-mock/src/__tests__/jest-mock-test.js
+++ b/packages/jest-mock/src/__tests__/jest-mock-test.js
@@ -187,7 +187,7 @@ describe('moduleMocker', () => {
       expect(typeof multipleBoundFuncMock).toBe('function');
     });
 
-   it('mocks methods that are bound after mocking', () => {
+    it('mocks methods that are bound after mocking', () => {
       const fooMock = moduleMocker.generateFromMetadata(
         moduleMocker.getMetadata(() => {}),
       );

--- a/packages/jest-runtime/src/ScriptTransformer.js
+++ b/packages/jest-runtime/src/ScriptTransformer.js
@@ -208,8 +208,13 @@ class ScriptTransformer {
 
       if (typeof processed === 'string') {
         transformed.code = processed;
-      } else {
+      } else if (processed != null && typeof processed.code === 'string') {
         transformed = processed;
+      } else {
+        throw new TypeError(
+          "Jest: a transform's `process` function must return a string, " +
+            'or an object with `code` key containing this string.',
+        );
       }
     }
 


### PR DESCRIPTION
**Summary**

Let use know when `transform` function doesn't return required type of content.
Resolves: https://github.com/facebook/jest/issues/3779

**Test plan**

Added necessary tests to the suite itself.