### PR TITLE
Remove dead reference

### DIFF
--- a/packages/jest-jasmine2/src/jest-expect.js
+++ b/packages/jest-jasmine2/src/jest-expect.js
@@ -41,7 +41,8 @@ module.exports = (config: {expand: boolean}) => {
     const jestMatchersObject = Object.create(null);
     Object.keys(jasmineMatchersObject).forEach(name => {
       jestMatchersObject[name] = function(): RawMatcherFn {
-        const result = jasmineMatchersObject[name](jasmine.matchersUtil, null);
+        // use "expect.extend" if you need to use equality testers (via this.equal)
+        const result = jasmineMatchersObject[name](null, null);
         // if there is no 'negativeCompare', both should be handled by `compare`
         const negativeCompare = result.negativeCompare || result.compare;
 


### PR DESCRIPTION
**Summary**

`jasmine.matchersUtil` is not included on this fork of jasmine, so `undefined` is being passed to the custom matcher. We make sure we remove that dead reference and we add a comment on top, so if people looks why they are not getting the matching utilities passed, they get a hint on how to proceed and don't get confused.