### PR TITLE
jest-haste-map: only file IO errors should be silently ignored

### DIFF
--- a/packages/jest-cli/src/TestWorker.js
+++ b/packages/jest-cli/src/TestWorker.js
@@ -44,6 +44,7 @@ const formatError = (error: string | Error): SerializableError => {
   }
 
   return {
+    code: error.code || undefined,
     message: error.message,
     stack: error.stack,
     type: 'Error',

--- a/packages/jest-cli/src/reporters/CoverageWorker.js
+++ b/packages/jest-cli/src/reporters/CoverageWorker.js
@@ -30,6 +30,7 @@ function formatCoverageError(error, filename: Path): SerializableError {
   `;
 
   return {
+    code: error.code || undefined,
     message,
     stack: error.stack,
     type: 'ERROR',

--- a/packages/jest-haste-map/src/__tests__/index-test.js
+++ b/packages/jest-haste-map/src/__tests__/index-test.js
@@ -136,7 +136,6 @@ describe('HasteMap', () => {
         return mockFs[path];
       }
 
-
       const error = new Error(`Cannot read path '${path}'.`);
       error.code = 'ENOENT';
       throw error;

--- a/packages/jest-haste-map/src/__tests__/index-test.js
+++ b/packages/jest-haste-map/src/__tests__/index-test.js
@@ -136,7 +136,10 @@ describe('HasteMap', () => {
         return mockFs[path];
       }
 
-      throw new Error(`Cannot read path '${path}'.`);
+
+      const error = new Error(`Cannot read path '${path}'.`);
+      error.code = 'ENOENT';
+      throw error;
     });
     fs.writeFileSync = jest.fn((path, data, options) => {
       expect(options).toBe('utf8');

--- a/packages/jest-haste-map/src/index.js
+++ b/packages/jest-haste-map/src/index.js
@@ -407,6 +407,9 @@ class HasteMap extends EventEmitter {
         fileMetadata[H.DEPENDENCIES] = metadata.dependencies || [];
       },
       error => {
+        if (['ENOENT', 'EACCES'].indexOf(error.code) < 0) {
+          throw error;
+        }
         // If a file cannot be read we remove it from the file list and
         // ignore the failure silently.
         delete hasteMap.files[filePath];

--- a/packages/jest-haste-map/src/worker.js
+++ b/packages/jest-haste-map/src/worker.js
@@ -33,6 +33,7 @@ const formatError = (error: string | Error): SerializableError => {
   }
 
   return {
+    code: error.code || undefined,
     message: error.message,
     stack: error.stack,
     type: 'Error',

--- a/types/TestResult.js
+++ b/types/TestResult.js
@@ -62,6 +62,7 @@ export type CoverageMap = {|
 |};
 
 export type SerializableError = {|
+  code?: mixed,
   message: string,
   stack: ?string,
   type?: string,


### PR DESCRIPTION
It is not proper to put all the errors in the same basket, because some types of errors, such as `SyntaxError`, should definitely not be let ignored, and should instead crash the program right away.

What I propose is that we reduce the errors we handle here to a very specific and reduced set, and that we progressively add more codes or kind of errors if really necessary.

This follows up #3812.


**Test plan**

Automated tests.
