### PR TITLE
Remove 'only' from '...to be called but only received...' messages

### DIFF
--- a/integration_tests/__tests__/__snapshots__/failures.test.js.snap
+++ b/integration_tests/__tests__/__snapshots__/failures.test.js.snap
@@ -37,7 +37,7 @@ exports[`not throwing Error objects 4`] = `
       at __tests__/assertion_count.test.js:14:17
   ● .assertions() › throws
     expect.assertions(2)
-    Expected two assertions to be called but only received one assertion call.
+    Expected two assertions to be called but received one assertion call.
   ● .assertions() › throws on redeclare of assertion count
     expect(received).toBeTruthy()
     Expected value to be truthy, instead received
@@ -45,7 +45,7 @@ exports[`not throwing Error objects 4`] = `
       at __tests__/assertion_count.test.js:18:17
   ● .assertions() › throws on assertion
     expect.assertions(0)
-    Expected zero assertions to be called but only received one assertion call.
+    Expected zero assertions to be called but received one assertion call.
   ● .hasAssertions() › throws when there are not assertions
     expect.hasAssertions()
     Expected at least one assertion to be called but received none.

--- a/packages/jest-matchers/src/extract_expected_assertions_errors.js
+++ b/packages/jest-matchers/src/extract_expected_assertions_errors.js
@@ -39,7 +39,7 @@ const extractExpectedAssertionsErrors = () => {
         isDirectExpectCall: true,
       }) +
         '\n\n' +
-        `Expected ${numOfAssertionsExpected} to be called but only received ` +
+        `Expected ${numOfAssertionsExpected} to be called but received ` +
         RECEIVED_COLOR(pluralize('assertion call', assertionCalls || 0)) +
         '.',
     );


### PR DESCRIPTION
**Summary**

Only removed the `only` word from `expected n assertions but only received m`. Indeed in case of more assertions than expected and since the only performed comparison is `assertionCalls !== expectedAssertionsNumber`, it doesn't seem to make any sense to let the word stand here. It might be sometimes a bit frustrating :)