### PR TITLE
Add support for custom summary reporter

### DIFF
--- a/packages/jest-cli/src/TestRunner.js
+++ b/packages/jest-cli/src/TestRunner.js
@@ -356,11 +356,12 @@ class TestRunner {
     if (typeof reporter === 'string') {
       return {path: reporter};
     } else if (Array.isArray(reporter)) {
-      const [path, options] = reporter;
+      let [path, options] = reporter;
+      options = Object.assign({}, this._options, options)
       return {options, path};
     }
 
-    throw new Error('Reproter should be either a string or an array');
+    throw new Error('Reporter should be either a string or an array');
   }
 
   _bailIfNeeded(

--- a/packages/jest-cli/src/TestRunner.js
+++ b/packages/jest-cli/src/TestRunner.js
@@ -354,10 +354,11 @@ class TestRunner {
     reporter: ReporterConfig,
   ): {path: string, options?: Object} {
     if (typeof reporter === 'string') {
-      return {path: reporter, options: this._options};
+      return {options: this._options, path: reporter};
     } else if (Array.isArray(reporter)) {
-      let [path, options] = reporter;
-      options = Object.assign({}, this._options, options)
+      const [path] = reporter;
+      let [, options] = reporter;
+      options = Object.assign({}, this._options, options);
       return {options, path};
     }
 

--- a/packages/jest-cli/src/TestRunner.js
+++ b/packages/jest-cli/src/TestRunner.js
@@ -354,7 +354,7 @@ class TestRunner {
     reporter: ReporterConfig,
   ): {path: string, options?: Object} {
     if (typeof reporter === 'string') {
-      return {path: reporter};
+      return {path: reporter, options: this._options};
     } else if (Array.isArray(reporter)) {
       let [path, options] = reporter;
       options = Object.assign({}, this._options, options)


### PR DESCRIPTION
**Summary**

The default summary reporter contains this line:

`this._write(getResultHeader(testResult, globalConfig) + '\n' + failureMessage + '\n');`

By replacing it with this:

`this._write(getResultHeader(testResult, globalConfig) + '\n');`

My tests run in 6 seconds instead of 30 (terminal seems to slow down when continuously printing lots of errors). I don't need the duplicate error messages in the summary because I can scroll up.

I decided the best solution would be to replace the default SummaryReporter. It looks like you're passing an object with `pattern`, `testNamePattern` & `testPathPattern` defined to the default SummaryReporter, but not to custom reporters & there's no way to access these variables.

**Test plan**

I don't have enough time available for adding tests - my apologies!