### PR TITLE
Log stack when reporting errors in jest-runtime

### DIFF
--- a/packages/jest-runtime/src/cli/index.js
+++ b/packages/jest-runtime/src/cli/index.js
@@ -83,7 +83,7 @@ function run(cliArgv?: Argv, cliInfo?: Array<string>) {
       runtime.requireModule(filePath);
     })
     .catch(e => {
-      console.error(chalk.red(e));
+      console.error(chalk.red(e.stack || e));
       process.on('exit', () => process.exit(1));
     });
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Without this change `console.error` will only log the `message` property and the stack will look like this:

```
Error: Cannot find module '../build/Release/pty.node' from 'pty.js'
```

Makes it pretty impossible to debug where the errors are coming from.

**Test plan**

Made the change locally and it worked fine.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
