### PR TITLE
Clarifying path declaration in 'foo' code example

### DIFF
--- a/docs/troubleshooting.html
+++ b/docs/troubleshooting.html
@@ -34,7 +34,7 @@ jest<span class="token punctuation">.</span><span class="token function">dontMoc
 <span class="token keyword">const</span> foo <span class="token operator">=</span> <span class="token function">require</span><span class="token punctuation">(</span><span class="token string">&#x27;foo&#x27;</span><span class="token punctuation">)</span><span class="token punctuation">;</span>
 jest<span class="token punctuation">.</span><span class="token function">dontMock</span><span class="token punctuation">(</span><span class="token string">&#x27;foo&#x27;</span><span class="token punctuation">)</span><span class="token punctuation">;</span> <span spellcheck="true" class="token comment">// Oops!</span></pre><p>In Jest 0.9.0, a new API <code>jest.unmock</code> was introduced. Together with a plugin
 for babel, this will now work properly when using <code>babel-jest</code>:</p><pre class="prism language-javascript">
-jest<span class="token punctuation">.</span><span class="token function">unmock</span><span class="token punctuation">(</span><span class="token string">&#x27;foo&#x27;</span><span class="token punctuation">)</span><span class="token punctuation">;</span> <span spellcheck="true" class="token comment">// Use unmock!</span>
+jest<span class="token punctuation">.</span><span class="token function">unmock</span><span class="token punctuation">(</span><span class="token string">&#x27;./foo&#x27;</span><span class="token punctuation">)</span><span class="token punctuation">;</span> <span spellcheck="true" class="token comment">// Use unmock!</span>
 
 <span class="token keyword">import</span> foo <span class="token keyword">from</span> <span class="token string">&#x27;./foo&#x27;</span><span class="token punctuation">;</span>
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
The example used in troubleshooting unmock (`jest.unmock('foo'); // Use unmock!` ) is ambiguous and it isn't clear that you have to type the file path. I've changed the 'foo' to './foo' so that it matches the import code line below it. 

I figured out how to make this work in my own project through trial and error. A more explicit example in the documentation will help others avoid the same errors.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
