### PR TITLE
Update Troubleshooting.md

### DIFF
--- a/docs/en/Troubleshooting.md
+++ b/docs/en/Troubleshooting.md
@@ -128,7 +128,7 @@ In Jest 0.9.0, a new API `jest.unmock` was introduced. Together with a plugin
 for babel, this will now work properly when using `babel-jest`:
 
 ```js
-jest.unmock('foo'); // Use unmock!
+jest.unmock('./foo'); // Use unmock!
 
 import foo from './foo';
 


### PR DESCRIPTION
Clarified file path usage for unmock

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
The example used in troubleshooting unmock (jest.unmock('foo'); // Use unmock! ) is ambiguous and it isn't clear that you have to type the file path. I've changed the 'foo' to './foo' so that it matches the import code line below it.

I figured out how to make this work in my own project through trial and error. A more explicit example in the documentation will help others avoid the same errors.

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
n/a
