### PR TITLE
Fix regression in mockReturnValueOnce

### DIFF
--- a/packages/jest-mock/src/__tests__/jest-mock-test.js
+++ b/packages/jest-mock/src/__tests__/jest-mock-test.js
@@ -362,6 +362,13 @@ describe('moduleMocker', () => {
 
       expect(obj.func()).not.toEqual('some text');
     });
+
+    it('mockReturnValueOnce mocks value just once', () => {
+      const fake = jest.fn(a => a + 2);
+      fake.mockReturnValueOnce(42);
+      expect(fake(2)).toEqual(42);
+      expect(fake(2)).toEqual(4);
+    });
   });
 
   describe('getMockImplementation', () => {

--- a/packages/jest-mock/src/index.js
+++ b/packages/jest-mock/src/index.js
@@ -262,18 +262,17 @@ class ModuleMockerClass {
           );
         }
 
-        let returnValue;
+        const returnValue = mockConfig.defaultReturnValue;
         // If return value is last set, either specific or default, i.e.
         // mockReturnValueOnce()/mockReturnValue() is called and no
         // mockImplementationOnce()/mockImplementation() is called after that.
         // use the set return value.
-        if (mockConfig.isReturnValueLastSet) {
-          returnValue = mockConfig.specificReturnValues.shift();
-          if (returnValue === undefined) {
-            returnValue = mockConfig.defaultReturnValue;
-          }
+        if (mockConfig.specificReturnValues.length) {
+          return mockConfig.specificReturnValues.shift();
+        }
 
-          return returnValue;
+        if (mockConfig.isReturnValueLastSet) {
+          return mockConfig.defaultReturnValue;
         }
 
         // If mockImplementationOnce()/mockImplementation() is last set,
@@ -324,7 +323,6 @@ class ModuleMockerClass {
       f.mockReturnValueOnce = value => {
         // next function call will return this value or default return value
         const mockConfig = this._ensureMockConfig(f);
-        mockConfig.isReturnValueLastSet = true;
         mockConfig.specificReturnValues.push(value);
         return f;
       };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Simplified the logic behind `mockReturnValueOnce` and `mockReturnValue` so that `isReturnValueLastSet` flag is only set by `mockReturnValue`.
Fixes https://github.com/facebook/jest/issues/3826

**Test plan**

Added test for that.
