### PR TITLE
Make useRealTimers play well with timers: fake

### DIFF
--- a/integration_tests/__tests__/timer-useRealTimers-test.js
+++ b/integration_tests/__tests__/timer-useRealTimers-test.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails oncall+jsinfra
+ */
+'use strict';
+
+const runJest = require('../runJest');
+
+test('useRealTimers cancels "timers": "fake" for whole test file', () => {
+  const result = runJest('timer-useRealTimers');
+  expect(result.stdout).toMatch('API is not mocked with fake timers.');
+  expect(result.status).toBe(0);
+});

--- a/integration_tests/timer-useRealTimers/__tests__/use_real_timers.test.js
+++ b/integration_tests/timer-useRealTimers/__tests__/use_real_timers.test.js
@@ -1,0 +1,5 @@
+jest.useRealTimers();
+
+test('bar', () => {
+  jest.runAllTimers();
+});

--- a/integration_tests/timer-useRealTimers/package.json
+++ b/integration_tests/timer-useRealTimers/package.json
@@ -1,0 +1,6 @@
+{
+  "jest": {
+    "testEnvironment": "node",
+    "timers": "fake"
+  }
+}

--- a/packages/jest-jasmine2/src/index.js
+++ b/packages/jest-jasmine2/src/index.js
@@ -50,6 +50,10 @@ function jasmine2(
   environment.global.describe.skip = environment.global.xdescribe;
   environment.global.describe.only = environment.global.fdescribe;
 
+  if (config.timers === 'fake') {
+    environment.fakeTimers.useFakeTimers();
+  }
+
   env.beforeEach(() => {
     if (config.resetModules) {
       runtime.resetModules();
@@ -61,10 +65,10 @@ function jasmine2(
 
     if (config.resetMocks) {
       runtime.resetAllMocks();
-    }
 
-    if (config.timers === 'fake') {
-      environment.fakeTimers.useFakeTimers();
+      if (config.timers === 'fake') {
+        environment.fakeTimers.useFakeTimers();
+      }
     }
   });
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

We unnecessarily call `useFakeTimers` on every `beforeEach`, even though it's only needed when combined with `resetMocks`.
Fixes https://github.com/facebook/jest/issues/3815

**Test plan**

Added an integration test.