### PR TITLE
[Help Page] Change to four column layout

### DIFF
--- a/website/core/JestHelp.js
+++ b/website/core/JestHelp.js
@@ -36,7 +36,7 @@ const JestHelp = React.createClass({
               <p>
                 {siteConfig[this.props.language].support.header.content}
               </p>
-              <GridBlock contents={supportLinks} layout="threeColumn" />
+              <GridBlock contents={supportLinks} layout="fourColumn" />
             </div>
           </Container>
         </div>


### PR DESCRIPTION
The theeColumn layout is not supported by Jest's current CSS. Switching to four column allows us to get the intended layout.