### PR TITLE
toMatchObject check for different Error objects

### DIFF
--- a/packages/jest-matchers/src/__tests__/__snapshots__/matchers-test.js.snap
+++ b/packages/jest-matchers/src/__tests__/__snapshots__/matchers-test.js.snap
@@ -2841,6 +2841,21 @@ Difference:
 <dim> ]"
 `;
 
+exports[`toMatchObject() {pass: false} expect([Error: foo]).toMatchObject([Error: bar]) 1`] = `
+"<dim>expect(<red>received</><dim>).toMatchObject(<green>expected</><dim>)
+
+Expected value to match object:
+  <green>[Error: bar]</>
+Received:
+  <red>[Error: foo]</>
+Difference:
+<green>- Expected</>
+<red>+ Received</>
+
+<green>-[Error: bar]</>
+<red>+[Error: foo]</>"
+`;
+
 exports[`toMatchObject() {pass: false} expect({"a": "a", "c": "d"}).toMatchObject({"a": Any<Number>}) 1`] = `
 "<dim>expect(<red>received</><dim>).toMatchObject(<green>expected</><dim>)
 

--- a/packages/jest-matchers/src/__tests__/matchers-test.js
+++ b/packages/jest-matchers/src/__tests__/matchers-test.js
@@ -848,6 +848,7 @@ describe('toMatchObject()', () => {
     [{}, {a: undefined}],
     [[1, 2, 3], [2, 3, 1]],
     [[1, 2, 3], [1, 2, 2]],
+    [new Error('foo'), new Error('bar')],
   ].forEach(([n1, n2]) => {
     it(`{pass: false} expect(${stringify(n1)}).toMatchObject(${stringify(n2)})`, () => {
       jestExpect(n1).not.toMatchObject(n2);

--- a/packages/jest-matchers/src/matchers.js
+++ b/packages/jest-matchers/src/matchers.js
@@ -645,10 +645,18 @@ const matchers: MatchersObject = {
       );
     }
 
-    const pass = equals(receivedObject, expectedObject, [
+    let pass = equals(receivedObject, expectedObject, [
       iterableEquality,
       subsetEquality,
     ]);
+
+    if (
+      receivedObject.constructor.name === 'Error' &&
+      expectedObject.constructor.name === 'Error' &&
+      receivedObject.message != expectedObject.message
+    ) {
+      pass = false;
+    }
 
     const message = pass
       ? () =>


### PR DESCRIPTION
**Summary**

To fix issue #3859. Not sure if my approach is right, feel free to correct me. 

**Test plan**

Added this test case to `matchers-test.js` group `{pass: false}`
