### PR TITLE
[toMatchObject] Check different Error objects  (#3864)

### DIFF
--- a/packages/jest-matchers/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/jest-matchers/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -2841,6 +2841,21 @@ Difference:
 <dim> ]"
 `;
 
+exports[`toMatchObject() {pass: false} expect([Error: foo]).toMatchObject([Error: bar]) 1`] = `
+"<dim>expect(<red>received</><dim>).toMatchObject(<green>expected</><dim>)
+
+Expected value to match object:
+  <green>[Error: bar]</>
+Received:
+  <red>[Error: foo]</>
+Difference:
+<green>- Expected</>
+<red>+ Received</>
+
+<green>-[Error: bar]</>
+<red>+[Error: foo]</>"
+`;
+
 exports[`toMatchObject() {pass: false} expect({"a": "a", "c": "d"}).toMatchObject({"a": Any<Number>}) 1`] = `
 "<dim>expect(<red>received</><dim>).toMatchObject(<green>expected</><dim>)
 
@@ -3205,6 +3220,15 @@ Expected value not to match object:
   <green>[1, 2]</>
 Received:
   <red>[1, 2]</>"
+`;
+
+exports[`toMatchObject() {pass: true} expect([Error: foo]).toMatchObject([Error: foo]) 1`] = `
+"<dim>expect(<red>received</><dim>).not.toMatchObject(<green>expected</><dim>)
+
+Expected value not to match object:
+  <green>[Error: foo]</>
+Received:
+  <red>[Error: foo]</>"
 `;
 
 exports[`toMatchObject() {pass: true} expect({"a": "b", "c": "d"}).toMatchObject({"a": "b", "c": "d"}) 1`] = `

--- a/packages/jest-matchers/src/__tests__/matchers.test.js
+++ b/packages/jest-matchers/src/__tests__/matchers.test.js
@@ -815,6 +815,7 @@ describe('toMatchObject()', () => {
     [[1, 2], [1, 2]],
     [{a: undefined}, {a: undefined}],
     [[], []],
+    [new Error('foo'), new Error('foo')],
   ].forEach(([n1, n2]) => {
     it(`{pass: true} expect(${stringify(n1)}).toMatchObject(${stringify(n2)})`, () => {
       jestExpect(n1).toMatchObject(n2);
@@ -848,6 +849,7 @@ describe('toMatchObject()', () => {
     [{}, {a: undefined}],
     [[1, 2, 3], [2, 3, 1]],
     [[1, 2, 3], [1, 2, 2]],
+    [new Error('foo'), new Error('bar')],
   ].forEach(([n1, n2]) => {
     it(`{pass: false} expect(${stringify(n1)}).toMatchObject(${stringify(n2)})`, () => {
       jestExpect(n1).not.toMatchObject(n2);

--- a/packages/jest-matchers/src/jasmine_utils.js
+++ b/packages/jest-matchers/src/jasmine_utils.js
@@ -63,6 +63,10 @@ function eq(a, b, aStack, bStack, customTesters): boolean {
     return asymmetricResult;
   }
 
+  if (a instanceof Error && b instanceof Error) {
+    return a.message == b.message;
+  }
+
   for (var i = 0; i < customTesters.length; i++) {
     var customTesterResult = customTesters[i](a, b);
     if (customTesterResult !== undefined) {
@@ -70,9 +74,6 @@ function eq(a, b, aStack, bStack, customTesters): boolean {
     }
   }
 
-  if (a instanceof Error && b instanceof Error) {
-    return a.message == b.message;
-  }
 
   // Identical objects are equal. `0 === -0`, but they aren't identical.
   // See the [Harmony `egal` proposal](http://wiki.ecmascript.org/doku.php?id=harmony:egal).


### PR DESCRIPTION
**Summary**

Fixes #3859.  Similar to PR https://github.com/facebook/jest/pull/3864 but fixes the issue further up the chain.

**Test Plan**

`yarn jest` after adding to `matchers-test.js`
