### PR TITLE
Update troubleshooting documentation

### DIFF
--- a/docs/en/Troubleshooting.md
+++ b/docs/en/Troubleshooting.md
@@ -96,6 +96,17 @@ jest --runInBand
 npm test -- --runInBand
 ```
 
+Another alternative to expediting test execution time on Continuous Integration Servers such as Travis-CI is to set the max
+worker pool to ~_4_.  Specifically on Travis-CI, this can reduce test execution time in half.  
+
+```bash
+# Using Jest CLI
+jest --maxWorkers=4
+
+# Using npm test (e.g. with create-react-app)
+npm test -- --maxWorkers=4
+```
+
 ### Tests are slow when leveraging automocking
 Whether via [`automock: true`](configuration.html#automock-boolean) in config or lots of [`jest.mock('my-module')`](jest-object.html#jestmockmodulename-factory-options) calls in tests, automocking has a performance cost that can add up in large projects. The more dependencies a module has, the more work Jest has to do to mock it. Something that can offset this performance cost significantly is adding a code transformer that moves `import` or `require` calls from the top of a module, where they are always executed, down into the body of the module, where they are usually not executed. This can lower the number of modules Jest has to load when running your tests by a considerable amount.
 


### PR DESCRIPTION
- The troubleshooting documentation, specifically for when tests
  are executing very slowly on Continuous Integration Servers, was
  updated to reflect an alternative to runInBand which involves setting
  the max worker pool to a value of 4.
- There is nothing magical around the value of 4 and it largely depends
  on the number of tests running(A larger number of tests can have issues
  with a larger worker pool).  The reason a value of 4 is used in the
  example is to add color to what other developers can start with and
  adjust accordingly to improve their CI feedback loop.

Related #3855

Motivation:  There are other developers that may come across this and it would be super helpful to see this in the troubleshooting documentation.