### PR TITLE
remove `p-map` and fix jasmine promise chain

### DIFF
--- a/integration_tests/__tests__/iterator-to-null-test.js
+++ b/integration_tests/__tests__/iterator-to-null-test.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+Array.prototype[Symbol.iterator] = null;
+String.prototype[Symbol.iterator] = null;
+
+test('modifying global object does not affect test runner', () => {});

--- a/packages/jest-jasmine2/package.json
+++ b/packages/jest-jasmine2/package.json
@@ -14,8 +14,7 @@
     "jest-matcher-utils": "^20.0.3",
     "jest-matchers": "^20.0.3",
     "jest-message-util": "^20.0.3",
-    "jest-snapshot": "^20.0.3",
-    "p-map": "^1.1.1"
+    "jest-snapshot": "^20.0.3"
   },
   "devDependencies": {
     "jest-runtime": "^20.0.4"

--- a/packages/jest-jasmine2/src/index.js
+++ b/packages/jest-jasmine2/src/index.js
@@ -20,7 +20,7 @@ import jasmineAsync from './jasmine-async';
 
 const JASMINE = require.resolve('./jasmine/jasmine-light.js');
 
-function jasmine2(
+async function jasmine2(
   globalConfig: GlobalConfig,
   config: ProjectConfig,
   environment: Environment,
@@ -33,7 +33,7 @@ function jasmine2(
     environment,
     testPath,
   );
-  const jasmineFactory = runtime.requireInternalModule(JASMINE);
+  const jasmineFactory = require(JASMINE);
   const jasmine = jasmineFactory.create();
 
   const env = jasmine.getEnv();
@@ -92,8 +92,9 @@ function jasmine2(
     env.specFilter = spec => testNameRegex.test(spec.getFullName());
   }
 
+  runtime.requireModule(require.resolve('p-map'));
   runtime.requireModule(testPath);
-  env.execute();
+  await env.execute();
   return reporter
     .getResults()
     .then(results => addSnapshotData(results, snapshotState));

--- a/packages/jest-jasmine2/src/index.js
+++ b/packages/jest-jasmine2/src/index.js
@@ -33,7 +33,7 @@ async function jasmine2(
     environment,
     testPath,
   );
-  const jasmineFactory = require(JASMINE);
+  const jasmineFactory = runtime.requireInternalModule(JASMINE);
   const jasmine = jasmineFactory.create();
 
   const env = jasmine.getEnv();
@@ -92,7 +92,6 @@ async function jasmine2(
     env.specFilter = spec => testNameRegex.test(spec.getFullName());
   }
 
-  runtime.requireModule(require.resolve('p-map'));
   runtime.requireModule(testPath);
   await env.execute();
   return reporter

--- a/packages/jest-jasmine2/src/jasmine/Env.js
+++ b/packages/jest-jasmine2/src/jasmine/Env.js
@@ -161,7 +161,7 @@ module.exports = function(j$) {
       return seed;
     };
 
-    function queueRunnerFactory(options) {
+    async function queueRunnerFactory(options) {
       options.clearTimeout = realClearTimeout;
       options.fail = self.fail;
       options.setTimeout = realSetTimeout;
@@ -178,7 +178,7 @@ module.exports = function(j$) {
       return topSuite;
     };
 
-    this.execute = function(runnablesToRun) {
+    this.execute = async function(runnablesToRun) {
       if (!runnablesToRun) {
         if (focusedRunnables.length) {
           runnablesToRun = focusedRunnables;
@@ -193,7 +193,7 @@ module.exports = function(j$) {
 
       currentlyExecutingSuites.push(topSuite);
 
-      treeProcessor({
+      await treeProcessor({
         nodeComplete(suite) {
           if (!suite.disabled) {
             clearResourcesForRunnable(suite.id);
@@ -209,12 +209,11 @@ module.exports = function(j$) {
         queueRunnerFactory,
         runnableIds: runnablesToRun,
         tree: topSuite,
-      }).then(() => {
-        clearResourcesForRunnable(topSuite.id);
-        currentlyExecutingSuites.pop();
-        reporter.jasmineDone({
-          failedExpectations: topSuite.result.failedExpectations,
-        });
+      });
+      clearResourcesForRunnable(topSuite.id);
+      currentlyExecutingSuites.pop();
+      reporter.jasmineDone({
+        failedExpectations: topSuite.result.failedExpectations,
       });
     };
 

--- a/packages/jest-jasmine2/src/queueRunner.js
+++ b/packages/jest-jasmine2/src/queueRunner.js
@@ -25,10 +25,10 @@ type QueueableFn = {
   timeout?: () => number,
 };
 
-function queueRunner(options: Options) {
+async function queueRunner(options: Options) {
   const mapper = ({fn, timeout}) => {
     const promise = new Promise(resolve => {
-      const next = () =>  resolve();
+      const next = () => resolve();
       next.fail = function() {
         options.fail.apply(null, arguments);
         resolve();

--- a/packages/jest-jasmine2/src/queueRunner.js
+++ b/packages/jest-jasmine2/src/queueRunner.js
@@ -8,7 +8,6 @@
  * @flow
  */
 
-import pMap from 'p-map';
 import pTimeout from './p-timeout';
 
 type Options = {
@@ -57,7 +56,11 @@ async function queueRunner(options: Options) {
       },
     );
   };
-  return pMap(options.queueableFns, mapper, {concurrency: 1});
+
+  return options.queueableFns.reduce(
+    (promise, fn) => promise.then(() => mapper(fn)),
+    Promise.resolve(),
+  );
 }
 
 module.exports = queueRunner;


### PR DESCRIPTION
this PR fixes two problems:
1. Fixes the broken promise chain, that caused Jest process to stall with all errors swallowed (node <6)
2. Require Jasmine from the outer VM scope rather then inner, because modifying global object can break the runner (see https://github.com/facebook/jest/issues/3879) 

Taking jasmine out seems risky, but all tests seem to be passing