### PR TITLE
[Website] Fix help layout grid

### DIFF
--- a/website/core/JestHelp.js
+++ b/website/core/JestHelp.js
@@ -36,7 +36,7 @@ const JestHelp = React.createClass({
               <p>
                 {siteConfig[this.props.language].support.header.content}
               </p>
-              <GridBlock contents={supportLinks} layout="threeColumn" />
+              <GridBlock contents={supportLinks} layout="fourColumn" />
             </div>
           </Container>
         </div>

--- a/website/core/JestHelp.js
+++ b/website/core/JestHelp.js
@@ -36,7 +36,7 @@ const JestHelp = React.createClass({
               <p>
                 {siteConfig[this.props.language].support.header.content}
               </p>
-              <GridBlock contents={supportLinks} layout="fourColumn" />
+              <GridBlock contents={supportLinks} layout="threeColumn" />
             </div>
           </Container>
         </div>

--- a/website/src/jest/css/jest.css
+++ b/website/src/jest/css/jest.css
@@ -759,10 +759,12 @@ a:hover code {
   padding: 0;
 }
 .gridBlock .twoByGridBlock,
+.gridBlock .threeByGridBlock,
 .gridBlock .fourByGridBlock {
   padding: 5px 0;
 }
 .gridBlock .twoByGridBlock img,
+.gridBlock .threeByGridBlock img,
 .gridBlock .fourByGridBlock img {
   max-width: 100%;
 }
@@ -897,6 +899,11 @@ a:hover code {
   .gridBlock .twoByGridBlock {
     box-sizing: border-box;
     flex: 1 0 50%;
+    padding: 10px;
+  }
+  .gridBlock .threeByGridBlock {
+    box-sizing: border-box;
+    flex: 1 0 26%;
     padding: 10px;
   }
   .gridBlock .fourByGridBlock {


### PR DESCRIPTION
At some point, the CSS file lost these threeColumn styles. This restores the threeColumn layout used by GridBlock, specifically in `core/JestHelp.js`'s use case.