### PR TITLE
jest-haste-map: watchman crawler: normalize paths

### DIFF
--- a/packages/jest-haste-map/src/crawlers/__tests__/watchman.test.js
+++ b/packages/jest-haste-map/src/crawlers/__tests__/watchman.test.js
@@ -56,6 +56,16 @@ describe('watchman watch', () => {
             mtime_ms: {toNumber: () => 32},
             name: 'pear.js',
           },
+          {
+            exists: true,
+            mtime_ms: {toNumber: () => 34},
+            /**
+             * This is to check the crawler normalizes paths. Indeed, on the
+             * Window OS, some versions of watchman use slashes, others uses
+             * backslashes. But they represent the same path.
+             */
+            name: 'some///////lemon.js',
+          },
         ],
         is_fresh_instance: true,
         version: '4.5.0',
@@ -77,6 +87,7 @@ describe('watchman watch', () => {
     mockFiles = Object.assign(Object.create(null), {
       '/fruits/strawberry.js': ['', 30, 0, []],
       '/fruits/tomato.js': ['', 31, 0, []],
+      '/fruits/some/lemon.js': ['', 34, 0, []],
       '/vegetables/melon.json': ['', 33, 0, []],
     });
   });
@@ -196,6 +207,7 @@ describe('watchman watch', () => {
       expect(data.files).toEqual({
         '/fruits/kiwi.js': ['', 42, 0, []],
         '/fruits/strawberry.js': ['', 30, 0, []],
+        '/fruits/some/lemon.js': ['', 34, 0, []],
         '/vegetables/melon.json': ['', 33, 0, []],
       });
     });

--- a/packages/jest-haste-map/src/crawlers/__tests__/watchman.test.js
+++ b/packages/jest-haste-map/src/crawlers/__tests__/watchman.test.js
@@ -56,16 +56,6 @@ describe('watchman watch', () => {
             mtime_ms: {toNumber: () => 32},
             name: 'pear.js',
           },
-          {
-            exists: true,
-            mtime_ms: {toNumber: () => 34},
-            /**
-             * This is to check the crawler normalizes paths. Indeed, on the
-             * Window OS, some versions of watchman use slashes, others uses
-             * backslashes. But they represent the same path.
-             */
-            name: 'some///////lemon.js',
-          },
         ],
         is_fresh_instance: true,
         version: '4.5.0',
@@ -87,7 +77,6 @@ describe('watchman watch', () => {
     mockFiles = Object.assign(Object.create(null), {
       '/fruits/strawberry.js': ['', 30, 0, []],
       '/fruits/tomato.js': ['', 31, 0, []],
-      '/fruits/some/lemon.js': ['', 34, 0, []],
       '/vegetables/melon.json': ['', 33, 0, []],
     });
   });
@@ -207,7 +196,6 @@ describe('watchman watch', () => {
       expect(data.files).toEqual({
         '/fruits/kiwi.js': ['', 42, 0, []],
         '/fruits/strawberry.js': ['', 30, 0, []],
-        '/fruits/some/lemon.js': ['', 34, 0, []],
         '/vegetables/melon.json': ['', 33, 0, []],
       });
     });

--- a/packages/jest-haste-map/src/crawlers/watchman.js
+++ b/packages/jest-haste-map/src/crawlers/watchman.js
@@ -104,7 +104,7 @@ module.exports = function watchmanCrawl(
 
             clocks[root] = response.clock;
             response.files.forEach(fileData => {
-              const name = root + path.sep + fileData.name;
+              const name = path.normalize(path.join(root, fileData.name));
               if (!fileData.exists) {
                 delete files[name];
               } else if (!ignore(name)) {

--- a/packages/jest-haste-map/src/crawlers/watchman.js
+++ b/packages/jest-haste-map/src/crawlers/watchman.js
@@ -11,6 +11,7 @@
 import type {InternalHasteMap} from 'types/HasteMap';
 import type {CrawlerOptions} from '../types';
 
+import normalizePathSep from '../lib/normalize_path_sep';
 import path from 'path';
 import watchman from 'fb-watchman';
 import H from '../constants';
@@ -104,7 +105,7 @@ module.exports = function watchmanCrawl(
 
             clocks[root] = response.clock;
             response.files.forEach(fileData => {
-              const name = path.normalize(path.join(root, fileData.name));
+              const name = root + path.sep + normalizePathSep(fileData.name);
               if (!fileData.exists) {
                 delete files[name];
               } else if (!ignore(name)) {

--- a/packages/jest-haste-map/src/index.js
+++ b/packages/jest-haste-map/src/index.js
@@ -38,6 +38,7 @@ import HasteModuleMap from './module_map';
 import getMockName from './get_mock_name';
 import getPlatformExtension from './lib/get_platform_extension';
 import nodeCrawl from './crawlers/node';
+import normalizePathSep from './lib/normalize_path_sep';
 import watchmanCrawl from './crawlers/watchman';
 import worker from './worker';
 
@@ -616,7 +617,7 @@ class HasteMap extends EventEmitter {
       root: Path,
       stat: {mtime: Date},
     ) => {
-      filePath = path.normalize(path.join(root, filePath));
+      filePath = path.join(root, normalizePathSep(filePath));
       if (
         this._ignore(filePath) ||
         !extensions.some(extension => filePath.endsWith(extension))

--- a/packages/jest-haste-map/src/index.js
+++ b/packages/jest-haste-map/src/index.js
@@ -616,7 +616,7 @@ class HasteMap extends EventEmitter {
       root: Path,
       stat: {mtime: Date},
     ) => {
-      filePath = path.join(root, filePath);
+      filePath = path.normalize(path.join(root, filePath));
       if (
         this._ignore(filePath) ||
         !extensions.some(extension => filePath.endsWith(extension))

--- a/packages/jest-haste-map/src/lib/__tests__/normalize_path_sep.test.js
+++ b/packages/jest-haste-map/src/lib/__tests__/normalize_path_sep.test.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @emails oncall+jsinfra
+ */
+'use strict';
+
+describe('normalizePathSep', () => {
+  it('replace slashes on windows', () => {
+    jest.mock('path', require.requireActual('path').win32);
+    const normalizePathSep = require('../normalize_path_sep');
+    expect(normalizePathSep('foo/bar/baz.js')).toEqual('foo\\bar\\baz.js');
+  });
+});

--- a/packages/jest-haste-map/src/lib/__tests__/normalize_path_sep.test.js
+++ b/packages/jest-haste-map/src/lib/__tests__/normalize_path_sep.test.js
@@ -11,8 +11,16 @@
 'use strict';
 
 describe('normalizePathSep', () => {
+  it('does nothing on posix', () => {
+    jest.resetModules();
+    jest.mock('path', () => require.requireActual('path').posix);
+    const normalizePathSep = require('../normalize_path_sep');
+    expect(normalizePathSep('foo/bar/baz.js')).toEqual('foo/bar/baz.js');
+  });
+
   it('replace slashes on windows', () => {
-    jest.mock('path', require.requireActual('path').win32);
+    jest.resetModules();
+    jest.mock('path', () => require.requireActual('path').win32);
     const normalizePathSep = require('../normalize_path_sep');
     expect(normalizePathSep('foo/bar/baz.js')).toEqual('foo\\bar\\baz.js');
   });

--- a/packages/jest-haste-map/src/lib/normalize_path_sep.js
+++ b/packages/jest-haste-map/src/lib/normalize_path_sep.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+
+const path = require('path');
+
+let normalizePathSep;
+if (path.sep == '/') {
+  normalizePathSep = (filePath: string) => filePath;
+} else {
+  normalizePathSep = (filePath: string) => filePath.replace(/\//g, path.sep);
+}
+
+module.exports = normalizePathSep;


### PR DESCRIPTION
See the inline comment. New versions of Watchman on Window are now returning paths using forward slashes, but consumers of `jest-haste-map` use to work and assume backslashes would be used (because they rely on `path.sep`, that is backslash on win32, along the other path functions).

This changeset make it so we `path.normalize` the paths we read from watchman. On POSIX systems this should not make any difference, but on Window this will have the effect of replacing forward slashes by the usual backslashes.
