### PR TITLE
fix missing console.log messages

### DIFF
--- a/integration_tests/__tests__/__snapshots__/console_log_output_when_run_in_band.test.js.snap
+++ b/integration_tests/__tests__/__snapshots__/console_log_output_when_run_in_band.test.js.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`prints console.logs when run with forceExit 1`] = `
+" PASS  __tests__/a-banana.js
+  ✓ banana
+
+"
+`;
+
+exports[`prints console.logs when run with forceExit 2`] = `
+"Test Suites: 1 passed, 1 total
+Tests:       1 passed, 1 total
+Snapshots:   0 total
+Time:        <<REPLACED>>
+Ran all test suites.
+"
+`;
+
+exports[`prints console.logs when run with forceExit 3`] = `
+"  console.log __tests__/a-banana.js:2
+    Hey
+
+"
+`;

--- a/integration_tests/__tests__/console_log_output_when_run_in_band.test.js
+++ b/integration_tests/__tests__/console_log_output_when_run_in_band.test.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+const path = require('path');
+const skipOnWindows = require('skipOnWindows');
+const {extractSummary, cleanup, writeFiles} = require('../utils');
+const runJest = require('../runJest');
+
+const DIR = path.resolve(__dirname, '../console_log_output_when_run_in_band');
+
+skipOnWindows.suite();
+
+beforeEach(() => cleanup(DIR));
+afterAll(() => cleanup(DIR));
+
+test('prints console.logs when run with forceExit', () => {
+  writeFiles(DIR, {
+    '__tests__/a-banana.js': `
+      test('banana', () => console.log('Hey'));
+    `,
+    'package.json': '{}',
+  });
+
+  const {stderr, stdout, status} = runJest(DIR, [
+    '-i',
+    '--ci=false',
+    '--forceExit',
+  ]);
+  const {rest, summary} = extractSummary(stderr);
+  expect(status).toBe(0);
+  expect(rest).toMatchSnapshot();
+  expect(summary).toMatchSnapshot();
+  expect(stdout).toMatchSnapshot();
+});


### PR DESCRIPTION
this is a split from https://github.com/facebook/jest/pull/3882

thanks @valerybugakov for finding this.
Console mesasges weren't being printed because we debounce the output for concurrent reporter, and some of the messages didn't have enough time to print before the process exits