### PR TITLE
Parallelized `scripts/build.js`

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "lerna": "2.0.0-rc.4",
     "micromatch": "^2.3.11",
     "mkdirp": "^0.5.1",
+    "pify": "^3.0.0",
     "prettier": "1.3.1",
     "progress": "^1.1.8",
     "react": "15.4.2",
@@ -49,7 +50,8 @@
     "rimraf": "^2.5.4",
     "slash": "^1.0.0",
     "strip-ansi": "^3.0.1",
-    "typescript": "^2.2.2"
+    "typescript": "^2.2.2",
+    "worker-farm": "^1.3.1"
   },
   "scripts": {
     "build-clean": "rm -rf ./packages/*/build ./packages/*/build-es5",

--- a/scripts/_build_worker.js
+++ b/scripts/_build_worker.js
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2014, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const mkdirp = require('mkdirp');
+
+const babel = require('babel-core');
+const chalk = require('chalk');
+const micromatch = require('micromatch');
+
+const SRC_DIR = 'src';
+const BUILD_DIR = 'build';
+const BUILD_ES5_DIR = 'build-es5';
+const JS_FILES_PATTERN = '**/*.js';
+const IGNORE_PATTERN = '**/__tests__/**';
+const PACKAGES_DIR = path.resolve(__dirname, '../packages');
+
+const babelNodeOptions = JSON.parse(
+  fs.readFileSync(path.resolve(__dirname, '..', '.babelrc'), 'utf8')
+);
+babelNodeOptions.babelrc = false;
+const babelEs5Options = Object.assign(
+  {},
+  babelNodeOptions,
+  {presets: 'env'},
+  {plugins: [...babelNodeOptions.plugins, 'transform-runtime']}
+);
+
+function getPackageName(file) {
+  return path.relative(PACKAGES_DIR, file).split(path.sep)[0];
+}
+
+function getBuildPath(file, pkgName, buildFolder) {
+  const pkgSrcPath = path.resolve(PACKAGES_DIR, pkgName, SRC_DIR);
+  const pkgBuildPath = path.resolve(PACKAGES_DIR, pkgName, buildFolder);
+  const relativeToSrcPath = path.relative(pkgSrcPath, file);
+  return path.resolve(pkgBuildPath, relativeToSrcPath);
+}
+
+function buildFileFor(file, pkgName, silent, env) {
+  const buildDir = env === 'es5' ? BUILD_ES5_DIR : BUILD_DIR;
+  const destPath = getBuildPath(file, pkgName, buildDir);
+  const babelOptions = env === 'es5' ? babelEs5Options : babelNodeOptions;
+
+  mkdirp.sync(path.dirname(destPath));
+  if (micromatch.isMatch(file, IGNORE_PATTERN)) {
+    silent ||
+      process.stdout.write(
+        chalk.dim('  \u2022 ') +
+          path.relative(PACKAGES_DIR, file) +
+          ' (ignore)\n'
+      );
+  } else if (!micromatch.isMatch(file, JS_FILES_PATTERN)) {
+    fs.createReadStream(file).pipe(fs.createWriteStream(destPath));
+    silent ||
+      process.stdout.write(
+        chalk.red('  \u2022 ') +
+          path.relative(PACKAGES_DIR, file) +
+          chalk.red(' \u21D2 ') +
+          path.relative(PACKAGES_DIR, destPath) +
+          ' (copy)' +
+          '\n'
+      );
+  } else {
+    const transformed = babel.transformFileSync(file, babelOptions).code;
+    fs.writeFileSync(destPath, transformed);
+    silent ||
+      process.stdout.write(
+        chalk.green('  \u2022 ') +
+          path.relative(PACKAGES_DIR, file) +
+          chalk.green(' \u21D2 ') +
+          path.relative(PACKAGES_DIR, destPath) +
+          '\n'
+      );
+  }
+}
+
+module.exports = ({file, silent}, callback) => {
+  try {
+    const packageName = getPackageName(file);
+    buildFileFor(file, packageName, silent, 'node');
+
+    const pkgJsonPath = path.resolve(PACKAGES_DIR, packageName, 'package.json');
+    const {browser} = require(pkgJsonPath);
+    if (browser) {
+      if (browser.indexOf(BUILD_ES5_DIR) !== 0) {
+        throw new Error(
+          `browser field for ${pkgJsonPath} should start with "${BUILD_ES5_DIR}"`
+        );
+      }
+      buildFileFor(file, packageName, silent, 'es5');
+    }
+    callback();
+  } catch (err) {
+    callback(err);
+  }
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1485,6 +1485,12 @@ enzyme@^2.8.2:
     prop-types "^15.5.4"
     uuid "^2.0.3"
 
+"errno@>=0.1.1 <0.2.0-0":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.4.tgz#b896e23a9e5e8ba33871fc996abd3635fc9a1c7d"
+  dependencies:
+    prr "~0.0.0"
+
 error-ex@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.1.tgz#f855a86ce61adc4e8621c3cda21e7a7612c3a8dc"
@@ -3225,6 +3231,10 @@ pify@^2.0.0, pify@^2.2.0, pify@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
 
+pify@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
+
 pinkie-promise@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz#2135d6dfa7a358c069ac9b178776288228450ffa"
@@ -3307,6 +3317,10 @@ prop-types@^15.5.4:
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.8.tgz#6b7b2e141083be38c8595aa51fc55775c7199394"
   dependencies:
     fbjs "^0.8.9"
+
+prr@~0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/prr/-/prr-0.0.0.tgz#1a84b85908325501411853d0081ee3fa86e2926a"
 
 pseudomap@^1.0.1:
   version "1.0.2"
@@ -4154,6 +4168,13 @@ wordwrap@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
 
+worker-farm@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/worker-farm/-/worker-farm-1.3.1.tgz#4333112bb49b17aa050b87895ca6b2cacf40e5ff"
+  dependencies:
+    errno ">=0.1.1 <0.2.0-0"
+    xtend ">=4.0.0 <4.1.0-0"
+
 wrap-ansi@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-2.1.0.tgz#d8fc3d284dd05794fe84973caecdd1cf824fdd85"
@@ -4204,7 +4225,7 @@ xmldom@^0.1.22:
   version "0.1.27"
   resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.1.27.tgz#d501f97b3bdb403af8ef9ecc20573187aadac0e9"
 
-xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
+"xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Fixes #3891.
Added `worker-farm` to parallelize Jest build script. Reduced build time on my laptop approximately by 2 seconds.


