### PR TITLE
Adding default locale as `en`. Addresses #3900

### DIFF
--- a/website/core/Doc.js
+++ b/website/core/Doc.js
@@ -13,7 +13,7 @@ class Doc extends React.Component {
         className="edit-page-link button"
         href={
           'https://github.com/facebook/jest/edit/master/docs/' +
-            this.props.language +
+            (this.props.language || 'en') +
             '/' +
             this.props.source
         }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Currently, we are reading `locale` information from `language` prop in Docs. When we don't pass the prop it treats as empty resulting in `404`. I defaulted language to `en` when prop is not passed. Addresses #3900 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
