### PR TITLE
Add jsx as valid extension in TypeScript example

### DIFF
--- a/docs/en/GettingStarted.md
+++ b/docs/en/GettingStarted.md
@@ -128,12 +128,13 @@ then modify your `package.json` so the `jest` section looks something like:
     "transform": {
       "^.+\\.tsx?$": "<rootDir>/node_modules/ts-jest/preprocessor.js"
     },
-    "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
+    "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(tsx?|jsx?)$",
     "moduleFileExtensions": [
       "ts",
       "tsx",
       "js",
-      "json"
+      "json",
+      "jsx"
     ]
   }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
The TypeScript example configuration will not find any tests with the .jsx extension.

**Test plan**
N/A. Documentation change only.