### PR TITLE
mockImplemetation() resets the `returnValue` flag, but not the actual value

### DIFF
--- a/packages/jest-mock/src/__tests__/jest_mock.test.js
+++ b/packages/jest-mock/src/__tests__/jest_mock.test.js
@@ -422,6 +422,14 @@ describe('moduleMocker', () => {
     });
   });
 
+  test('mockImplementation resets the mock', () => {
+    const fn = jest.fn();
+    expect(fn()).toBeUndefined();
+    fn.mockReturnValue('returnValue');
+    fn.mockImplementation(() => 'foo');
+    expect(fn()).toBe('foo');
+  });
+
   it('should recognize a mocked function', () => {
     const mockFn = moduleMocker.fn();
 

--- a/packages/jest-mock/src/index.js
+++ b/packages/jest-mock/src/index.js
@@ -348,6 +348,7 @@ class ModuleMockerClass {
         // next function call will use mock implementation return value
         const mockConfig = this._ensureMockConfig(f);
         mockConfig.isReturnValueLastSet = false;
+        mockConfig.defaultReturnValue = undefined;
         mockConfig.mockImpl = fn;
         return f;
       };


### PR DESCRIPTION
fixes https://github.com/facebook/jest/issues/3928