### PR TITLE
don't build ghost packages

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -82,6 +82,10 @@ function buildBrowserPackage(p) {
   const srcDir = path.resolve(p, SRC_DIR);
   const pkgJsonPath = path.resolve(p, 'package.json');
 
+  if (!fs.existsSync(pkgJsonPath)) {
+    return;
+  }
+
   const {browser} = require(pkgJsonPath);
   if (browser) {
     if (browser.indexOf(BUILD_ES5_DIR) !== 0) {


### PR DESCRIPTION
often when we work on a new package and switch between branches, git leaves a lot of empty directories in the directory tree.
Browser build will always crash on empty directories, this condition will make it ignore empty dirs and only build the ones that have `package.json`