### PR TITLE
Ignore dot dirs default

### DIFF
--- a/integration_tests/__tests__/__snapshots__/show_config.test.js.snap
+++ b/integration_tests/__tests__/__snapshots__/show_config.test.js.snap
@@ -9,7 +9,8 @@ exports[`jest --showConfig outputs config info and exits 1`] = `
     "cacheDirectory": "/tmp/jest",
     "clearMocks": false,
     "coveragePathIgnorePatterns": [
-      "/node_modules/"
+      "/node_modules/",
+      "/\\\\.[^\\\\.]+/"
     ],
     "globals": {},
     "haste": {
@@ -43,7 +44,8 @@ exports[`jest --showConfig outputs config info and exits 1`] = `
       "**/?(*.)(spec|test).js?(x)"
     ],
     "testPathIgnorePatterns": [
-      "/node_modules/"
+      "/node_modules/",
+      "/\\\\.[^\\\\.]+/"
     ],
     "testRegex": "",
     "testRunner": "/mocked/root/path/jest/packages/jest-jasmine2/build/index.js",
@@ -56,7 +58,8 @@ exports[`jest --showConfig outputs config info and exits 1`] = `
       ]
     ],
     "transformIgnorePatterns": [
-      "/node_modules/"
+      "/node_modules/",
+      "/\\\\.[^\\\\.]+/"
     ]
   },
   "framework": "jasmine2",

--- a/packages/jest-cli/src/__tests__/search_source.test.js
+++ b/packages/jest-cli/src/__tests__/search_source.test.js
@@ -332,6 +332,30 @@ describe('SearchSource', () => {
     });
   });
 
+  describe('ignores tests', () => {
+    it('node_modules', () => {
+      const testPath =
+        path.sep +
+        path.join('node_modules', 'module-name', '__tests__', 'test.js');
+      expect(searchSource.isTestFilePath(testPath)).toEqual(false);
+    });
+
+    it('dot directories', () => {
+      const testPath =
+        path.sep +
+        path.join(
+          '.cache',
+          'yarn',
+          'v1',
+          'module-name',
+          'to',
+          '__tests__',
+          'test.js',
+        );
+      expect(searchSource.isTestFilePath(testPath)).toEqual(false);
+    });
+  });
+
   describe('findRelatedTests', () => {
     const rootDir = path.join(
       __dirname,

--- a/packages/jest-cli/src/__tests__/search_source.test.js
+++ b/packages/jest-cli/src/__tests__/search_source.test.js
@@ -73,7 +73,6 @@ describe('SearchSource', () => {
           maxWorkers,
         }).then(context => {
           searchSource = new SearchSource(context);
-
           const path = '/path/to/__tests__/foo/bar/baz/../../../test.js';
           expect(searchSource.isTestFilePath(path)).toEqual(true);
         });
@@ -120,12 +119,9 @@ describe('SearchSource', () => {
         const relPaths = toPaths(data.tests)
           .map(absPath => path.relative(rootDir, absPath))
           .sort();
-        expect(relPaths).toEqual(
-          [
-            path.normalize('.hiddenFolder/not-really-a-test.txt'),
-            path.normalize('__testtests__/not-really-a-test.txt'),
-          ].sort(),
-        );
+        expect(relPaths).toEqual([
+          path.normalize('__testtests__/not-really-a-test.txt'),
+        ]);
       });
     });
 
@@ -144,12 +140,9 @@ describe('SearchSource', () => {
         const relPaths = toPaths(data.tests)
           .map(absPath => path.relative(rootDir, absPath))
           .sort();
-        expect(relPaths).toEqual(
-          [
-            path.normalize('.hiddenFolder/not-really-a-test.txt'),
-            path.normalize('__testtests__/not-really-a-test.txt'),
-          ].sort(),
-        );
+        expect(relPaths).toEqual([
+          path.normalize('__testtests__/not-really-a-test.txt'),
+        ]);
       });
     });
 

--- a/packages/jest-config/src/constants.js
+++ b/packages/jest-config/src/constants.js
@@ -11,5 +11,6 @@
 import path from 'path';
 
 exports.NODE_MODULES = path.sep + 'node_modules' + path.sep;
+exports.DOT_DIRECTORIES = path.sep + '\\.[^\\.]+' + path.sep;
 exports.DEFAULT_JS_PATTERN = '^.+\\.jsx?$';
 exports.DEFAULT_REPORTER_LABEL = 'default';

--- a/packages/jest-config/src/defaults.js
+++ b/packages/jest-config/src/defaults.js
@@ -16,6 +16,9 @@ import {replacePathSepForRegex} from 'jest-regex-util';
 import constants from './constants';
 
 const NODE_MODULES_REGEXP = replacePathSepForRegex(constants.NODE_MODULES);
+const DOT_DIRECTORIES_REGEXP = replacePathSepForRegex(
+  constants.DOT_DIRECTORIES,
+);
 
 const cacheDirectory = (() => {
   const {getuid} = process;
@@ -35,7 +38,7 @@ module.exports = ({
   cache: true,
   cacheDirectory,
   clearMocks: false,
-  coveragePathIgnorePatterns: [NODE_MODULES_REGEXP],
+  coveragePathIgnorePatterns: [NODE_MODULES_REGEXP, DOT_DIRECTORIES_REGEXP],
   coverageReporters: ['json', 'text', 'lcov', 'clover'],
   expand: false,
   globals: {},
@@ -55,12 +58,12 @@ module.exports = ({
   snapshotSerializers: [],
   testEnvironment: 'jest-environment-jsdom',
   testMatch: ['**/__tests__/**/*.js?(x)', '**/?(*.)(spec|test).js?(x)'],
-  testPathIgnorePatterns: [NODE_MODULES_REGEXP],
+  testPathIgnorePatterns: [NODE_MODULES_REGEXP, DOT_DIRECTORIES_REGEXP],
   testRegex: '',
   testResultsProcessor: null,
   testURL: 'about:blank',
   timers: 'real',
-  transformIgnorePatterns: [NODE_MODULES_REGEXP],
+  transformIgnorePatterns: [NODE_MODULES_REGEXP, DOT_DIRECTORIES_REGEXP],
   useStderr: false,
   verbose: null,
   watch: false,

--- a/packages/jest-config/src/valid_config.js
+++ b/packages/jest-config/src/valid_config.js
@@ -14,6 +14,9 @@ import {replacePathSepForRegex} from 'jest-regex-util';
 import constants from './constants';
 
 const NODE_MODULES_REGEXP = replacePathSepForRegex(constants.NODE_MODULES);
+const DOT_DIRECTORIES_REGEXP = replacePathSepForRegex(
+  constants.DOT_DIRECTORIES,
+);
 
 module.exports = ({
   automock: false,
@@ -28,7 +31,7 @@ module.exports = ({
     '<rootDir>/this-directory-is-covered/covered.js': true,
   },
   coverageDirectory: 'coverage',
-  coveragePathIgnorePatterns: [NODE_MODULES_REGEXP],
+  coveragePathIgnorePatterns: [NODE_MODULES_REGEXP, DOT_DIRECTORIES_REGEXP],
   coverageReporters: ['json', 'text', 'lcov', 'clover'],
   coverageThreshold: {
     global: {
@@ -73,7 +76,7 @@ module.exports = ({
   testEnvironment: 'jest-environment-jsdom',
   testMatch: ['**/__tests__/**/*.js?(x)', '**/?(*.)(spec|test).js?(x)'],
   testNamePattern: 'test signature',
-  testPathIgnorePatterns: [NODE_MODULES_REGEXP],
+  testPathIgnorePatterns: [NODE_MODULES_REGEXP, DOT_DIRECTORIES_REGEXP],
   testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.jsx?$',
   testResultsProcessor: 'processor-node-module',
   testRunner: 'jasmine2',
@@ -82,7 +85,7 @@ module.exports = ({
   transform: {
     '^.+\\.js$': '<rootDir>/preprocessor.js',
   },
-  transformIgnorePatterns: [NODE_MODULES_REGEXP],
+  transformIgnorePatterns: [NODE_MODULES_REGEXP, DOT_DIRECTORIES_REGEXP],
   unmockedModulePathPatterns: ['mock'],
   updateSnapshot: true,
   useStderr: false,

--- a/packages/jest-validate/src/__tests__/fixtures/jest_config.js
+++ b/packages/jest-validate/src/__tests__/fixtures/jest_config.js
@@ -12,6 +12,7 @@ const os = require('os');
 const path = require('path');
 const chalk = require('chalk');
 const NODE_MODULES = path.sep + 'node_modules' + path.sep;
+const DOT_DIRECTORIES = path.sep + '\\.[^\\.]+' + path.sep;
 const replacePathSepForRegex = (string: string) => {
   if (path.sep === '\\') {
     return string.replace(/(\/|\\(?!\.))/g, '\\\\');
@@ -20,6 +21,7 @@ const replacePathSepForRegex = (string: string) => {
 };
 
 const NODE_MODULES_REGEXP = replacePathSepForRegex(NODE_MODULES);
+const DOT_DIRECTORIES_REGEXP = replacePathSepForRegex(DOT_DIRECTORIES);
 
 const defaultConfig = {
   automock: false,
@@ -27,7 +29,7 @@ const defaultConfig = {
   browser: false,
   cacheDirectory: path.join(os.tmpdir(), 'jest'),
   clearMocks: false,
-  coveragePathIgnorePatterns: [NODE_MODULES_REGEXP],
+  coveragePathIgnorePatterns: [NODE_MODULES_REGEXP, DOT_DIRECTORIES_REGEXP],
   coverageReporters: ['json', 'text', 'lcov', 'clover'],
   expand: false,
   globals: {},
@@ -46,12 +48,12 @@ const defaultConfig = {
   roots: ['<rootDir>'],
   snapshotSerializers: [],
   testEnvironment: 'jest-environment-jsdom',
-  testPathIgnorePatterns: [NODE_MODULES_REGEXP],
+  testPathIgnorePatterns: [NODE_MODULES_REGEXP, DOT_DIRECTORIES_REGEXP],
   testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.jsx?$',
   testResultsProcessor: null,
   testURL: 'about:blank',
   timers: 'real',
-  transformIgnorePatterns: [NODE_MODULES_REGEXP],
+  transformIgnorePatterns: [NODE_MODULES_REGEXP, DOT_DIRECTORIES_REGEXP],
   useStderr: false,
   verbose: null,
   watch: false,
@@ -70,7 +72,7 @@ const validConfig = {
     '<rootDir>/this-directory-is-covered/covered.js': true,
   },
   coverageDirectory: 'coverage',
-  coveragePathIgnorePatterns: [NODE_MODULES_REGEXP],
+  coveragePathIgnorePatterns: [NODE_MODULES_REGEXP, DOT_DIRECTORIES_REGEXP],
   coverageReporters: ['json', 'text', 'lcov', 'clover'],
   coverageThreshold: {
     global: {
@@ -106,7 +108,7 @@ const validConfig = {
   snapshotSerializers: ['my-serializer-module'],
   testEnvironment: 'jest-environment-jsdom',
   testNamePattern: 'test signature',
-  testPathIgnorePatterns: [NODE_MODULES_REGEXP],
+  testPathIgnorePatterns: [NODE_MODULES_REGEXP, DOT_DIRECTORIES_REGEXP],
   testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.jsx?$',
   testResultsProcessor: 'processor-node-module',
   testRunner: 'jasmine2',
@@ -115,7 +117,7 @@ const validConfig = {
   transform: {
     '^.+\\.js$': '<rootDir>/preprocessor.js',
   },
-  transformIgnorePatterns: [NODE_MODULES_REGEXP],
+  transformIgnorePatterns: [NODE_MODULES_REGEXP, DOT_DIRECTORIES_REGEXP],
   unmockedModulePathPatterns: ['mock'],
   updateSnapshot: true,
   useStderr: false,


### PR DESCRIPTION
Fixes: #3827 

**Summary**

Makes jest ignore directories that start with a `.` by default in addition to ignoring `node_modules`. Ex: `.cache`

**Motivation**
When `$HOME` is the same as the application directory yarn will default to putting its cache directory at `$APP_DIR/.cache/yarn/v1/...` and Jest will pick up tests in dependencies.

This happens to users trying to use Jest with Heroku CI, where `$HOME` is `/app`. Currently any user using both yarn and jest will hit this issue in that environment.

**Test plan**
- Added unit tests 
- `yarn test`
