### PR TITLE
Use modern HTML5 <!DOCTYPE>, as discussed in #3299

### DIFF
--- a/packages/jest-environment-jsdom/src/index.js
+++ b/packages/jest-environment-jsdom/src/index.js
@@ -24,7 +24,7 @@ class JSDOMEnvironment {
 
   constructor(config: ProjectConfig): void {
     // lazy require
-    this.document = JSDom.jsdom(/* markup */ undefined, {
+    this.document = JSDom.jsdom('<!DOCTYPE html>', {
       url: config.testURL,
     });
     const global = (this.global = this.document.defaultView);


### PR DESCRIPTION
**Summary**

As discussed in #3299, existing tests use an old-style HTML DOCTYPE, which makes it hard to test some modern web tools such as [KaTeX](https://github.com/Khan/KaTeX); see https://github.com/Khan/KaTeX/issues/664.  This small tweak uses the recommended HTML5 DOCTYPE, which is probably a better default.  Other issues such as #2460 could deal with the more general problem of making this configurable, but a reasonable default seems like a good start.

**Test plan**

We've tested over on the KaTeX side that it removes our warning about being in quirks mode. See https://github.com/Khan/KaTeX/pull/747#issuecomment-312021303