### PR TITLE
Check whether we should output to stdout or stderr

### DIFF
--- a/packages/jest-cli/src/reporters/__tests__/default_reporter.test.js
+++ b/packages/jest-cli/src/reporters/__tests__/default_reporter.test.js
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+const aggregatedResults = {};
+const options = {};
+const testCase = {
+  context: {config: {rootDir: '/'}},
+  duration: 0,
+  path: '/foo',
+};
+const testResult = {
+  testFilePath: '/foo',
+};
+
+let DefaultReporter;
+let stdout;
+
+let oldIsTTY;
+let oldStderr;
+let oldStdout;
+
+beforeEach(() => {
+  jest.resetModules();
+  jest.useFakeTimers();
+
+  // This is not a CI environment, which removes all output by default.
+  jest.mock('is-ci', () => false);
+
+  oldIsTTY = process.stdin.isTTY;
+  oldStdout = process.stdout.write;
+  oldStderr = process.stderr.write;
+
+  // We mock stderr (even if we do not use it right now on the tests) to avoid
+  // fake reporters created while testing to mess with the real output of the
+  // tests itself.
+  process.stdin.isTTY = true;
+  process.stderr.write = jest.fn();
+  stdout = process.stdout.write = jest.fn();
+
+  DefaultReporter = require('../default_reporter');
+});
+
+afterEach(() => {
+  process.stdin.isTTY = oldIsTTY;
+  process.stderr.write = oldStderr;
+  process.stdout.write = oldStdout;
+});
+
+test('normal output, everything goes to stdout', () => {
+  const reporter = new DefaultReporter({useStderr: false});
+
+  reporter.onRunStart(aggregatedResults, options);
+  reporter.onTestStart(testCase);
+  reporter.onTestResult(testCase, testResult, aggregatedResults);
+  reporter.onRunComplete();
+
+  jest.runAllTimers();
+
+  expect(stdout).toHaveBeenCalled();
+});
+
+test('when using stderr as output, no stdout call is made', () => {
+  const reporter = new DefaultReporter({useStderr: true});
+
+  reporter.onRunStart(aggregatedResults, options);
+  reporter.onTestStart(testCase);
+  reporter.onTestResult(testCase, testResult, aggregatedResults);
+  reporter.onRunComplete();
+
+  jest.runAllTimers();
+
+  expect(stdout).not.toHaveBeenCalled();
+});

--- a/packages/jest-cli/src/reporters/default_reporter.js
+++ b/packages/jest-cli/src/reporters/default_reporter.js
@@ -63,10 +63,14 @@ class DefaultReporter extends BaseReporter {
     const flushBufferedOutput = () => {
       const string = buffer.join('');
       buffer = [];
+
       // This is to avoid conflicts between random output and status text
       this._clearStatus();
-      originalWrite.call(stream, string);
+      if (string) {
+        originalWrite.call(stream, string);
+      }
       this._printStatus();
+
       this._bufferedOutput.delete(flushBufferedOutput);
     };
 
@@ -105,7 +109,11 @@ class DefaultReporter extends BaseReporter {
 
   _clearStatus() {
     if (isInteractive) {
-      this._out(this._clear);
+      if (this._globalConfig.useStderr) {
+        this._err(this._clear);
+      } else {
+        this._out(this._clear);
+      }
     }
   }
 
@@ -113,7 +121,11 @@ class DefaultReporter extends BaseReporter {
     const {content, clear} = this._status.get();
     this._clear = clear;
     if (isInteractive) {
-      this._out(content);
+      if (this._globalConfig.useStderr) {
+        this._err(content);
+      } else {
+        this._out(content);
+      }
     }
   }
 

--- a/packages/jest-resolve/yarn.lock
+++ b/packages/jest-resolve/yarn.lock
@@ -2,6 +2,14 @@
 # yarn lockfile v1
 
 
+ansi-regex@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
+
+ansi-styles@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
+
 browser-resolve@^1.11.2:
   version "1.11.2"
   resolved "https://registry.yarnpkg.com/browser-resolve/-/browser-resolve-1.11.2.tgz#8ff09b0a2c421718a1051c260b32e48f442938ce"
@@ -11,6 +19,26 @@ browser-resolve@^1.11.2:
 builtin-modules@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
+
+chalk@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
+  dependencies:
+    ansi-styles "^2.2.1"
+    escape-string-regexp "^1.0.2"
+    has-ansi "^2.0.0"
+    strip-ansi "^3.0.0"
+    supports-color "^2.0.0"
+
+escape-string-regexp@^1.0.2:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
+
+has-ansi@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
+  dependencies:
+    ansi-regex "^2.0.0"
 
 is-builtin-module@^1.0.0:
   version "1.0.0"
@@ -31,3 +59,13 @@ resolve@^1.3.2:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.3.3.tgz#655907c3469a8680dc2de3a275a8fdd69691f0e5"
   dependencies:
     path-parse "^1.0.5"
+
+strip-ansi@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
+  dependencies:
+    ansi-regex "^2.0.0"
+
+supports-color@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"

--- a/types/TestRunner.js
+++ b/types/TestRunner.js
@@ -17,8 +17,8 @@ import type Runtime from 'jest-runtime';
 
 export type Test = {|
   context: Context,
-  path: Path,
   duration: ?number,
+  path: Path,
 |};
 
 export type Reporter = {


### PR DESCRIPTION
This PR is related to another two changes deployed this morning: #3945 and #3946. These two had to be rolled back because they were causing issues in CI, however they were working locally.

The cause of the breakage in CI is due to the fact that the `is-ci` module was not being mocked. Since CI sessions are considered non-interactive, the reporter was not outputting anything and the test failed. After adding a mock to the module (`jest.mock('is-ci', () => false)`) tests are passing now.

Code for the reporter itself has not been changed when comparing it with the two earlier PRs, so the release done in-between (`jest@20.1-alpha.3`) is safe in that sense.