### PR TITLE
Set correct "thisArg" when calling nonAsync jasmine lifecycle hooks

### DIFF
--- a/packages/jest-jasmine2/src/__tests__/integration/lifecycle_hooks_test.js
+++ b/packages/jest-jasmine2/src/__tests__/integration/lifecycle_hooks_test.js
@@ -56,3 +56,34 @@ describe('test lifecycle hooks', () => {
     it('does it 1', pushMessage('outer it 1'));
   });
 });
+
+describe('shares this context between nested describe blocks', () => {
+  const actions = [];
+  function pushMessage(message) {
+    actions.push(message);
+  }
+
+  beforeEach(function() {
+    this.x = 42;
+    pushMessage('beforeEach1-' + this.x);
+  });
+
+  describe('Something', () => {
+    beforeEach(function() {
+      pushMessage('beforeEach2-' + this.x);
+    });
+
+    it('contains all actions', function() {
+      this.x = 42;
+      pushMessage('it-' + this.x);
+
+      const expected = [
+        'beforeEach1-42',
+        'beforeEach2-42',
+        'it-42',
+      ];
+
+      expect(actions).toEqual(expected);
+    });
+  });
+});

--- a/packages/jest-jasmine2/src/__tests__/integration/lifecycle_hooks_test.js
+++ b/packages/jest-jasmine2/src/__tests__/integration/lifecycle_hooks_test.js
@@ -74,7 +74,6 @@ describe('shares this context between nested describe blocks', () => {
     });
 
     it('contains all actions', function() {
-      this.x = 42;
       pushMessage('it-' + this.x);
 
       const expected = [

--- a/packages/jest-jasmine2/src/jasmine_async.js
+++ b/packages/jest-jasmine2/src/jasmine_async.js
@@ -35,7 +35,7 @@ function promisifyLifeCycleFunction(originalFn, env) {
     // We make *all* functions async and run `done` right away if they
     // didn't return a promise.
     const asyncFn = function(done) {
-      const returnValue = fn.call({});
+      const returnValue = fn.call(this);
 
       if (isPromise(returnValue)) {
         returnValue.then(done, done.fail);

--- a/packages/jest-jasmine2/src/jasmine_async.js
+++ b/packages/jest-jasmine2/src/jasmine_async.js
@@ -65,7 +65,7 @@ function promisifyIt(originalFn, env) {
     }
 
     const asyncFn = function(done) {
-      const returnValue = fn.call({});
+      const returnValue = fn.call(this);
 
       if (isPromise(returnValue)) {
         returnValue.then(done, done.fail);


### PR DESCRIPTION
**Summary**

In the latest version of Jest, the `thisArg` for `call` when calling functions in the jasmine-async file is set every time to a new object (`{}`).

I am not sure why this was done, but this caused a regression bug for us: https://github.com/facebook/jest/issues/3956

In the code for v19, the `thisArg` is set to `this`: 
https://github.com/facebook/jest/blob/v19.0.2/packages/jest-jasmine2/src/jasmine-async.js#L42

With this PR, I reverted back to the old code. I am not sure if the `arguments` parameter is needed either.

**Test plan**

My repo in https://github.com/facebook/jest/issues/3956 can help with reproducing this issue.

I'd love to add a unit test to this as well, but have no idea where to get started with that. I guess something similar to `lifecycle_hooks_test` would be needed?

**Edit:** I added a test in `jest-jasmine2/__tests__/integration/lifecycle_hooks_test.js` to test this case. However found 2 odd things:

- This test file is never executed as far as I could tell. Because the suffix is `_test` and not `.test`. On the other hand, maybe integration tests are run somewhere separately?
- The existing test in this file always seems to pass. The `  afterAll(() => {` doesn't seem to be executed. One can modify the expected array to anything and the test will pass (I ran it just by changing the file name to end in `.test.js`)