### PR TITLE
Avoid unnecessary function declarations and call in pretty-format

### DIFF
--- a/packages/pretty-format/src/__tests__/pretty_format.test.js
+++ b/packages/pretty-format/src/__tests__/pretty_format.test.js
@@ -329,6 +329,25 @@ describe('prettyFormat()', () => {
     expect(prettyFormat(val, options)).toEqual('');
   });
 
+  it('throws if plugin does not return a string', () => {
+    const val = 123;
+    const options = {
+      plugins: [
+        {
+          print(val) {
+            return val;
+          },
+          test() {
+            return true;
+          },
+        },
+      ],
+    };
+    expect(() => {
+      prettyFormat(val, options);
+    }).toThrow();
+  });
+
   it('supports plugins with deeply nested arrays (#24)', () => {
     const val = [[1, 2], [3, 4]];
     expect(

--- a/packages/pretty-format/src/index.js
+++ b/packages/pretty-format/src/index.js
@@ -726,6 +726,7 @@ function findPlugin(plugins: Plugins, val: any) {
       return plugins[p];
     }
   }
+
   return null;
 }
 
@@ -766,7 +767,7 @@ function print(
     );
     if (typeof pluginsResult !== 'string') {
       throw new Error(
-        `pretty-format: Plugin must return type string" but instead returned "${typeof pluginsResult}".`,
+        `pretty-format: Plugin must return type "string" but instead returned "${typeof pluginsResult}".`,
       );
     }
     return pluginsResult;
@@ -929,7 +930,7 @@ function prettyFormat(val: any, initialOptions?: InitialOptions): string {
       );
       if (typeof pluginsResult !== 'string') {
         throw new Error(
-          `pretty-format: Plugin must return type string" but instead returned "${typeof pluginsResult}".`,
+          `pretty-format: Plugin must return type "string" but instead returned "${typeof pluginsResult}".`,
         );
       }
       return pluginsResult;

--- a/packages/pretty-format/src/index.js
+++ b/packages/pretty-format/src/index.js
@@ -687,7 +687,7 @@ function printPlugin(
   printFunctionName: boolean,
   escapeRegex: boolean,
   colors: Colors,
-): StringOrNull {
+): string {
   function boundPrint(val) {
     return print(
       val,
@@ -717,7 +717,14 @@ function printPlugin(
     min,
     spacing,
   };
-  return plugin.print(val, boundPrint, boundIndent, opts, colors);
+
+  const printed = plugin.print(val, boundPrint, boundIndent, opts, colors);
+  if (typeof printed !== 'string') {
+    throw new Error(
+      `pretty-format: Plugin must return type "string" but instead returned "${typeof printed}".`,
+    );
+  }
+  return printed;
 }
 
 function findPlugin(plugins: Plugins, val: any) {
@@ -748,7 +755,7 @@ function print(
 ): string {
   const plugin = findPlugin(plugins, val);
   if (plugin !== null) {
-    const pluginsResult = printPlugin(
+    return printPlugin(
       plugin,
       val,
       indent,
@@ -765,12 +772,6 @@ function print(
       escapeRegex,
       colors,
     );
-    if (typeof pluginsResult !== 'string') {
-      throw new Error(
-        `pretty-format: Plugin must return type "string" but instead returned "${typeof pluginsResult}".`,
-      );
-    }
-    return pluginsResult;
   }
 
   const basicResult = printBasicValue(val, printFunctionName, escapeRegex);
@@ -911,7 +912,7 @@ function prettyFormat(val: any, initialOptions?: InitialOptions): string {
   if (opts && opts.plugins.length) {
     const plugin = findPlugin(opts.plugins, val);
     if (plugin !== null) {
-      const pluginsResult = printPlugin(
+      return printPlugin(
         plugin,
         val,
         createIndent(opts.indent),
@@ -928,12 +929,6 @@ function prettyFormat(val: any, initialOptions?: InitialOptions): string {
         opts.escapeRegex,
         colors,
       );
-      if (typeof pluginsResult !== 'string') {
-        throw new Error(
-          `pretty-format: Plugin must return type "string" but instead returned "${typeof pluginsResult}".`,
-        );
-      }
-      return pluginsResult;
     }
   }
 


### PR DESCRIPTION
**Summary**

Problem:

* `printPlugin` “hoists” the `boundPrint` and `boundIndent` declarations and therefore initializes the functions **whether or not** a plugin matches the value.
* `prettyFormat` calls `createIndent` if any plugins exist **instead of** if some plugin **matches** the value. Because plugins always exist in Jest, the conditional logic to avoid creating indentation for basic values doesn’t save any time.

Solution:

* Factor out a `findPlugin` function.
* Factor out `if` statement to call `printPlugin` only if a plugin matches the value.
* Call `createIndent` for arg in `printPlugin` and `printComplexValue` function calls.

Your review is especially wanted about the decision to throw an error if a plugin returns a non-string value. Am happy to revert that change if it’s a step in a wrong direction. Current logic quietly falls through to print the value as either basic or complex.

Interpretation of the following performance measurements:

* Big improvement for massive object with no plugins outside Jest.
* Almost as big improvement with default plugins (not called) inside Jest.
* Only slight change for small elements with default plugins (called) inside Jest.

| scenario | plugins | proposed | baseline | ratio |
| :--- | ---: | ---: | ---: | ---: |
| geo.json | 0 | 30693309 | 72540558 | 0.423 |
| geo.json | 10 | 70169013 | 127109022 | 0.552 |
| React elements | 10 | 1283359 | 1287893 | 0.996 |

P.S. The calls to `printPlugin` are nice example of not ignoring indentation in a diff, heh :)

**Test plan**

Jest