### PR TITLE
Force message in matchers to always be a function

### DIFF
--- a/packages/jest-matchers/src/__tests__/extend.test.js
+++ b/packages/jest-matchers/src/__tests__/extend.test.js
@@ -16,8 +16,8 @@ jestExpect.extend({
   toBeDivisibleBy(actual, expected) {
     const pass = actual % expected === 0;
     const message = pass
-      ? `expected ${actual} not to be divisible by ${expected}`
-      : `expected ${actual} to be divisible by ${expected}`;
+      ? () => `expected ${actual} not to be divisible by ${expected}`
+      : () => `expected ${actual} to be divisible by ${expected}`;
 
     return {message, pass};
   },
@@ -38,8 +38,8 @@ it('exposes matcherUtils in context', () => {
     _shouldNotError(actual, expected) {
       const pass = this.utils === matcherUtils;
       const message = pass
-        ? `expected this.utils to be defined in an extend call`
-        : `expected this.utils not to be defined in an extend call`;
+        ? () => `expected this.utils to be defined in an extend call`
+        : () => `expected this.utils not to be defined in an extend call`;
 
       return {message, pass};
     },

--- a/packages/jest-matchers/src/index.js
+++ b/packages/jest-matchers/src/index.js
@@ -98,19 +98,11 @@ const expect = (actual: any): ExpectationObject => {
   return expectation;
 };
 
-const getMessage = message => {
-  // for performance reasons some of the messages are evaluated
-  // lazily
-  if (typeof message === 'function') {
-    message = message();
-  }
-
-  if (!message) {
-    message = utils.RECEIVED_COLOR(
-      'No message was specified for this matcher.',
-    );
-  }
-  return message;
+const getMessage = messageFn => {
+  return (
+    (messageFn && messageFn()) ||
+    utils.RECEIVED_COLOR('No message was specified for this matcher.')
+  );
 };
 
 const makeResolveMatcher = (

--- a/packages/jest-matchers/src/index.js
+++ b/packages/jest-matchers/src/index.js
@@ -98,9 +98,9 @@ const expect = (actual: any): ExpectationObject => {
   return expectation;
 };
 
-const getMessage = messageFn => {
+const getMessage = message => {
   return (
-    (messageFn && messageFn()) ||
+    (message && message()) ||
     utils.RECEIVED_COLOR('No message was specified for this matcher.')
   );
 };

--- a/packages/jest-matchers/src/matchers.js
+++ b/packages/jest-matchers/src/matchers.js
@@ -543,7 +543,8 @@ const matchers: MatchersObject = {
     const traversedPath = result.traversedPath.join('.');
 
     const message = pass
-      ? matcherHint('.not.toHaveProperty', 'object', 'path', {
+      ? () =>
+        matcherHint('.not.toHaveProperty', 'object', 'path', {
           secondArgument: valuePassed ? 'value' : null,
         }) +
         '\n\n' +
@@ -552,7 +553,8 @@ const matchers: MatchersObject = {
         `Not to have a nested property:\n` +
         `  ${printExpected(keyPath)}\n` +
         (valuePassed ? `With a value of:\n  ${printExpected(value)}\n` : '')
-      : matcherHint('.toHaveProperty', 'object', 'path', {
+      : () =>
+        matcherHint('.toHaveProperty', 'object', 'path', {
           secondArgument: valuePassed ? 'value' : null,
         }) +
         '\n\n' +

--- a/types/Matchers.js
+++ b/types/Matchers.js
@@ -13,7 +13,7 @@ import type {SnapshotState} from 'jest-snapshot';
 
 export type ExpectationResult = {
   pass: boolean,
-  message: string | (() => string),
+  message: () => string,
 };
 
 export type RawMatcherFn = (


### PR DESCRIPTION
**Summary**

https://github.com/facebook/jest/issues/3921

* Update `getMessage` function
* Found three cases in the code base where still a `string` was being returned, instead of a `function`
* Updated the type

Checked the documentation, which already says:
> provides a function with no arguments that returns an error message in case of failure.

**Test plan**

All tests pass.

Did not add any new test. Perhaps a test should be added for when we still pass a `string` ? Basically, it should throw an error: `VM189:1 Uncaught TypeError: message is not a function`

Additionally we could `try/catch` and default to `No message was specified for this matcher.` if a wrong type is supplied for `message`.