### PR TITLE
Make providesModuleNodeModules ignore nested node_modules directories

### DIFF
--- a/packages/jest-haste-map/src/__tests__/index.test.js
+++ b/packages/jest-haste-map/src/__tests__/index.test.js
@@ -225,6 +225,16 @@ describe('HasteMap', () => {
       ' * @providesModule mapObject',
       ' */',
     ].join('\n');
+    mockFs['/fruits/node_modules/react/node_modules/dummy/merge.js'] = [
+      '/**',
+      ' * @providesModule merge',
+      ' */',
+    ].join('\n');
+    mockFs['/fruits/node_modules/react/node_modules/merge/package.json'] = [
+      '{',
+      '  "name": "merge"',
+      '}',
+    ].join('\n');
     mockFs['/fruits/node_modules/jest/jest.js'] = [
       '/**',
       ' * @providesModule Jest',

--- a/packages/jest-haste-map/src/index.js
+++ b/packages/jest-haste-map/src/index.js
@@ -820,8 +820,17 @@ class HasteMap extends EventEmitter {
     }
 
     if (this._whitelist) {
-      const match = filePath.match(this._whitelist);
-      return !match || match.length > 1;
+      const whitelist = this._whitelist;
+      const match = whitelist.exec(filePath);
+      const matchEndIndex = whitelist.lastIndex;
+      whitelist.lastIndex = 0;
+
+      if (!match) {
+        return true;
+      }
+      
+      const filePathInPackage = filePath.substr(matchEndIndex);
+      return filePathInPackage.startsWith(NODE_MODULES);
     }
 
     return true;


### PR DESCRIPTION
Updates the `_isNodeModules` function so that nested `node_modules` subdirectories of whitelisted npm packages are not whitelisted. This is causing problems because arbitrary npm packages that aren't explicitly whitelisted can cause Haste map collisions.

Test plan: Added unit tests that were failing before and ensure that they are passing now in addition to older unit tests.