### PR TITLE
Add a code owners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+
+# Pings orta when PRs are to this module
+packages/jest-editor-support/*  @orta


### PR DESCRIPTION
**Summary**

Adds a codeowner file, this was just introduced yesterday ( https://github.com/blog/2392-introducing-code-owners ) and it allows people to be pinged about specific areas of the codebase. This means that for the embedded packages we can ping individuals without manual intervention 🍡 

I'm sure there are more places this could be useful, but this is a good start.

**Test plan**

No tests