### PR TITLE
Refactor names and delimiters of complex values in pretty-format

### DIFF
--- a/packages/jest-haste-map/src/index.js
+++ b/packages/jest-haste-map/src/index.js
@@ -828,7 +828,7 @@ class HasteMap extends EventEmitter {
       if (!match) {
         return true;
       }
-      
+
       const filePathInPackage = filePath.substr(matchEndIndex);
       return filePathInPackage.startsWith(NODE_MODULES);
     }

--- a/packages/pretty-format/src/index.js
+++ b/packages/pretty-format/src/index.js
@@ -164,12 +164,6 @@ function printBasicValue(
     }
     return regExpToString.call(val);
   }
-  if (toStringed === '[object Arguments]' && val.length === 0) {
-    return 'Arguments []';
-  }
-  if (isToStringedArrayType(toStringed) && val.length === 0) {
-    return val.constructor.name + ' []';
-  }
 
   if (val instanceof Error) {
     return printError(val);
@@ -229,81 +223,7 @@ function printList(
     body += (min ? '' : ',') + edgeSpacing + prevIndent;
   }
 
-  return '[' + body + ']';
-}
-
-function printArguments(
-  val: any,
-  indent: string,
-  prevIndent: string,
-  spacing: string,
-  edgeSpacing: string,
-  refs: Refs,
-  maxDepth: number,
-  currentDepth: number,
-  plugins: Plugins,
-  min: boolean,
-  callToJSON: boolean,
-  printFunctionName: boolean,
-  escapeRegex: boolean,
-  colors: Colors,
-): string {
-  return (
-    (min ? '' : 'Arguments ') +
-    printList(
-      val,
-      indent,
-      prevIndent,
-      spacing,
-      edgeSpacing,
-      refs,
-      maxDepth,
-      currentDepth,
-      plugins,
-      min,
-      callToJSON,
-      printFunctionName,
-      escapeRegex,
-      colors,
-    )
-  );
-}
-
-function printArray(
-  val: any,
-  indent: string,
-  prevIndent: string,
-  spacing: string,
-  edgeSpacing: string,
-  refs: Refs,
-  maxDepth: number,
-  currentDepth: number,
-  plugins: Plugins,
-  min: boolean,
-  callToJSON: boolean,
-  printFunctionName: boolean,
-  escapeRegex: boolean,
-  colors: Colors,
-): string {
-  return (
-    (min ? '' : val.constructor.name + ' ') +
-    printList(
-      val,
-      indent,
-      prevIndent,
-      spacing,
-      edgeSpacing,
-      refs,
-      maxDepth,
-      currentDepth,
-      plugins,
-      min,
-      callToJSON,
-      printFunctionName,
-      escapeRegex,
-      colors,
-    )
-  );
+  return body;
 }
 
 function printMap(
@@ -322,7 +242,7 @@ function printMap(
   escapeRegex: boolean,
   colors: Colors,
 ): string {
-  let result = 'Map {';
+  let result = '';
   const iterator = val.entries();
   let current = iterator.next();
 
@@ -377,7 +297,7 @@ function printMap(
     result += (min ? '' : ',') + edgeSpacing + prevIndent;
   }
 
-  return result + '}';
+  return result;
 }
 
 function printObject(
@@ -396,10 +316,7 @@ function printObject(
   escapeRegex: boolean,
   colors: Colors,
 ): string {
-  const constructor = min
-    ? ''
-    : val.constructor ? val.constructor.name + ' ' : 'Object ';
-  let result = constructor + '{';
+  let result = '';
   let keys = Object.keys(val).sort();
   const symbols = getSymbols(val);
 
@@ -457,7 +374,7 @@ function printObject(
     result += (min ? '' : ',') + edgeSpacing + prevIndent;
   }
 
-  return result + '}';
+  return result;
 }
 
 function printSet(
@@ -476,7 +393,7 @@ function printSet(
   escapeRegex: boolean,
   colors: Colors,
 ): string {
-  let result = 'Set {';
+  let result = '';
   const iterator = val.entries();
   let current = iterator.next();
 
@@ -515,7 +432,7 @@ function printSet(
     result += (min ? '' : ',') + edgeSpacing + prevIndent;
   }
 
-  return result + '}';
+  return result;
 }
 
 function printComplexValue(
@@ -571,9 +488,14 @@ function printComplexValue(
 
   const toStringed = toString.call(val);
   if (toStringed === '[object Arguments]') {
+    if (val.length === 0) {
+      return 'Arguments []';
+    }
     return hitMaxDepth
       ? '[Arguments]'
-      : printArguments(
+      : (min ? '' : 'Arguments ') +
+        '[' +
+        printList(
           val,
           indent,
           prevIndent,
@@ -588,11 +510,17 @@ function printComplexValue(
           printFunctionName,
           escapeRegex,
           colors,
-        );
+        ) +
+        ']';
   } else if (isToStringedArrayType(toStringed)) {
+    if (val.length === 0) {
+      return val.constructor.name + ' []';
+    }
     return hitMaxDepth
       ? '[Array]'
-      : printArray(
+      : (min ? '' : val.constructor.name + ' ') +
+        '[' +
+        printList(
           val,
           indent,
           prevIndent,
@@ -607,11 +535,13 @@ function printComplexValue(
           printFunctionName,
           escapeRegex,
           colors,
-        );
+        ) +
+        ']';
   } else if (toStringed === '[object Map]') {
     return hitMaxDepth
       ? '[Map]'
-      : printMap(
+      : 'Map {' +
+        printMap(
           val,
           indent,
           prevIndent,
@@ -626,11 +556,13 @@ function printComplexValue(
           printFunctionName,
           escapeRegex,
           colors,
-        );
+        ) +
+        '}';
   } else if (toStringed === '[object Set]') {
     return hitMaxDepth
       ? '[Set]'
-      : printSet(
+      : 'Set {' +
+        printSet(
           val,
           indent,
           prevIndent,
@@ -645,12 +577,15 @@ function printComplexValue(
           printFunctionName,
           escapeRegex,
           colors,
-        );
+        ) +
+        '}';
   }
 
   return hitMaxDepth
     ? '[Object]'
-    : printObject(
+    : (min ? '' : val.constructor ? val.constructor.name + ' ' : 'Object ') +
+      '{' +
+      printObject(
         val,
         indent,
         prevIndent,
@@ -665,7 +600,8 @@ function printComplexValue(
         printFunctionName,
         escapeRegex,
         colors,
-      );
+      ) +
+      '}';
 }
 
 function printPlugin(


### PR DESCRIPTION
**Summary**

There are some inconsistencies in names of complex types for various options:

* specific case for empty list is `Arguments []` but general case with `min: true` is `[]`
* specific case for empty array is `Array []` and so on, but general case with `min: true` is `[]`
* when `hitMaxDepth` for typed array is `[Array]` instead of `[Uint32Array]` and so on
* when `hitMaxDepth` for constructed object is `[Object]` instead of `'[' + (val.constructor ? val.constructor.name : 'Object') + ']'` and I’m not sure tests cover this case

If y’all are willing to approve breaking changes to edge cases, I can submit an additional PR.

Whether or not, this PR applies advice from Kent Beck: move similar elements closer together.

* Move empty arguments and array from `printBasicValue` to `printComplexValue`
* Move complex value name and delimiters from helpers to `printComplexValue`
* Therefore delete redundant helpers `printArguments` and `printArray`

Effect of refactoring on performance:

* Time to print empty arguments or array increases similar to empty object. I think the reason for the original logic is to avoid computing `indent` when it isn’t used for those values. It has been confusing to me that the special cases in `printBasicValue` (where I don’t expect to find arguments or arrays) are inconsistent with the general cases in `printCompexValue` :(
* Time saving from evaluating `isToStringedArrayType` only 1 time instead of 2 and calling `printList` directly for arguments and array is subtle, within the precision of measurement.

**Test plan**

Jest