### PR TITLE
Fix inconsistent name of complex values in pretty-format

### DIFF
--- a/packages/jest-matcher-utils/src/__tests__/index.test.js
+++ b/packages/jest-matcher-utils/src/__tests__/index.test.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const { stringify, ensureNumbers, pluralize, ensureNoExpected } = require('../');
+const {stringify, ensureNumbers, pluralize, ensureNoExpected} = require('../');
 
 describe('.stringify()', () => {
   [
@@ -46,11 +46,11 @@ describe('.stringify()', () => {
       },
     };
     expect(stringify(evil)).toBe('{"toJSON": [Function toJSON]}');
-    expect(stringify({ a: { b: { evil } } })).toBe(
+    expect(stringify({a: {b: {evil}}})).toBe(
       '{"a": {"b": {"evil": {"toJSON": [Function toJSON]}}}}',
     );
 
-    function Evil() { }
+    function Evil() {}
     Evil.toJSON = evil.toJSON;
     expect(stringify(Evil)).toBe('[Function Evil]');
   });
@@ -72,8 +72,8 @@ describe('.stringify()', () => {
   });
 
   test('reduces maxDepth if stringifying very large objects', () => {
-    const big = { a: 1, b: {} };
-    const small = { a: 1, b: {} };
+    const big = {a: 1, b: {}};
+    const small = {a: 1, b: {}};
     for (let i = 0; i < 10000; i += 1) {
       big.b[i] = 'test';
     }
@@ -116,13 +116,13 @@ describe('.ensureNoExpected()', () => {
 
   test('throws error when is not undefined', () => {
     expect(() => {
-      ensureNoExpected({ a: 1 });
+      ensureNoExpected({a: 1});
     }).toThrow('Matcher does not accept any arguments');
   });
 
   test('throws error when is not undefined with matcherName', () => {
     expect(() => {
-      ensureNoExpected({ a: 1 }, '.toBeDefined');
+      ensureNoExpected({a: 1}, '.toBeDefined');
     }).toThrow('Matcher does not accept any arguments');
   });
 });

--- a/packages/jest-matcher-utils/src/__tests__/index.test.js
+++ b/packages/jest-matcher-utils/src/__tests__/index.test.js
@@ -10,11 +10,11 @@
 
 'use strict';
 
-const {stringify, ensureNumbers, pluralize, ensureNoExpected} = require('../');
+const { stringify, ensureNumbers, pluralize, ensureNoExpected } = require('../');
 
 describe('.stringify()', () => {
   [
-    [[], 'Array []'],
+    [[], '[]'],
     [{}, '{}'],
     [1, '1'],
     [0, '0'],
@@ -46,11 +46,11 @@ describe('.stringify()', () => {
       },
     };
     expect(stringify(evil)).toBe('{"toJSON": [Function toJSON]}');
-    expect(stringify({a: {b: {evil}}})).toBe(
+    expect(stringify({ a: { b: { evil } } })).toBe(
       '{"a": {"b": {"evil": {"toJSON": [Function toJSON]}}}}',
     );
 
-    function Evil() {}
+    function Evil() { }
     Evil.toJSON = evil.toJSON;
     expect(stringify(Evil)).toBe('[Function Evil]');
   });
@@ -72,8 +72,8 @@ describe('.stringify()', () => {
   });
 
   test('reduces maxDepth if stringifying very large objects', () => {
-    const big = {a: 1, b: {}};
-    const small = {a: 1, b: {}};
+    const big = { a: 1, b: {} };
+    const small = { a: 1, b: {} };
     for (let i = 0; i < 10000; i += 1) {
       big.b[i] = 'test';
     }
@@ -116,13 +116,13 @@ describe('.ensureNoExpected()', () => {
 
   test('throws error when is not undefined', () => {
     expect(() => {
-      ensureNoExpected({a: 1});
+      ensureNoExpected({ a: 1 });
     }).toThrow('Matcher does not accept any arguments');
   });
 
   test('throws error when is not undefined with matcherName', () => {
     expect(() => {
-      ensureNoExpected({a: 1}, '.toBeDefined');
+      ensureNoExpected({ a: 1 }, '.toBeDefined');
     }).toThrow('Matcher does not accept any arguments');
   });
 });

--- a/packages/jest-matchers/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/jest-matchers/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -166,6 +166,15 @@ Received:
   <red>\\"a\\"</>"
 `;
 
+exports[`.toBe() fails for '[]' with '.not' 1`] = `
+"<dim>expect(<red>received</><dim>).not.toBe(<green>expected</><dim>)
+
+Expected value to not be (using ===):
+  <green>[]</>
+Received:
+  <red>[]</>"
+`;
+
 exports[`.toBe() fails for '{}' with '.not' 1`] = `
 "<dim>expect(<red>received</><dim>).not.toBe(<green>expected</><dim>)
 
@@ -182,15 +191,6 @@ Expected value to not be (using ===):
   <green>1</>
 Received:
   <red>1</>"
-`;
-
-exports[`.toBe() fails for 'Array []' with '.not' 1`] = `
-"<dim>expect(<red>received</><dim>).not.toBe(<green>expected</><dim>)
-
-Expected value to not be (using ===):
-  <green>Array []</>
-Received:
-  <red>Array []</>"
 `;
 
 exports[`.toBe() fails for 'false' with '.not' 1`] = `
@@ -227,6 +227,19 @@ Expected value to be (using ===):
   <green>\\"cde\\"</>
 Received:
   <red>\\"abc\\"</>"
+`;
+
+exports[`.toBe() fails for: [] and [] 1`] = `
+"<dim>expect(<red>received</><dim>).toBe(<green>expected</><dim>)
+
+Expected value to be (using ===):
+  <green>[]</>
+Received:
+  <red>[]</>
+
+Difference:
+
+<dim>Compared values have no visual difference."
 `;
 
 exports[`.toBe() fails for: {"a": 1} and {"a": 1} 1`] = `
@@ -281,19 +294,6 @@ Expected value to be (using ===):
   <green>2</>
 Received:
   <red>1</>"
-`;
-
-exports[`.toBe() fails for: Array [] and Array [] 1`] = `
-"<dim>expect(<red>received</><dim>).toBe(<green>expected</><dim>)
-
-Expected value to be (using ===):
-  <green>Array []</>
-Received:
-  <red>Array []</>
-
-Difference:
-
-<dim>Compared values have no visual difference."
 `;
 
 exports[`.toBe() fails for: null and undefined 1`] = `
@@ -440,6 +440,20 @@ Expected value to be undefined, instead received
   <red>\\"a\\"</>"
 `;
 
+exports[`.toBeDefined(), .toBeUndefined() '[]' is defined 1`] = `
+"<dim>expect(<red>received</><dim>).not.toBeDefined(<dim>)
+
+Expected value not to be defined, instead received
+  <red>[]</>"
+`;
+
+exports[`.toBeDefined(), .toBeUndefined() '[]' is defined 2`] = `
+"<dim>expect(<red>received</><dim>).toBeUndefined(<dim>)
+
+Expected value to be undefined, instead received
+  <red>[]</>"
+`;
+
 exports[`.toBeDefined(), .toBeUndefined() '[Function anonymous]' is defined 1`] = `
 "<dim>expect(<red>received</><dim>).not.toBeDefined(<dim>)
 
@@ -494,20 +508,6 @@ exports[`.toBeDefined(), .toBeUndefined() '1' is defined 2`] = `
 
 Expected value to be undefined, instead received
   <red>1</>"
-`;
-
-exports[`.toBeDefined(), .toBeUndefined() 'Array []' is defined 1`] = `
-"<dim>expect(<red>received</><dim>).not.toBeDefined(<dim>)
-
-Expected value not to be defined, instead received
-  <red>Array []</>"
-`;
-
-exports[`.toBeDefined(), .toBeUndefined() 'Array []' is defined 2`] = `
-"<dim>expect(<red>received</><dim>).toBeUndefined(<dim>)
-
-Expected value to be undefined, instead received
-  <red>Array []</>"
 `;
 
 exports[`.toBeDefined(), .toBeUndefined() 'Infinity' is defined 1`] = `
@@ -1215,6 +1215,16 @@ Constructor:
   <red>\\"Boolean\\"</>"
 `;
 
+exports[`.toBeInstanceOf() passing [] and [Function Array] 1`] = `
+"<dim>expect(<red>value</><dim>).not.toBeInstanceOf(<green>constructor</><dim>)
+
+Expected value not to be an instance of:
+  <green>\\"Array\\"</>
+Received:
+  <red>[]</>
+"
+`;
+
 exports[`.toBeInstanceOf() passing {} and [Function A] 1`] = `
 "<dim>expect(<red>value</><dim>).not.toBeInstanceOf(<green>constructor</><dim>)
 
@@ -1222,16 +1232,6 @@ Expected value not to be an instance of:
   <green>\\"A\\"</>
 Received:
   <red>{}</>
-"
-`;
-
-exports[`.toBeInstanceOf() passing Array [] and [Function Array] 1`] = `
-"<dim>expect(<red>value</><dim>).not.toBeInstanceOf(<green>constructor</><dim>)
-
-Expected value not to be an instance of:
-  <green>\\"Array\\"</>
-Received:
-  <red>Array []</>
 "
 `;
 
@@ -1319,7 +1319,7 @@ exports[`.toBeNaN() throws 6`] = `
 "<dim>expect(<red>received</><dim>).toBeNaN(<dim>)
 
 Expected value to be NaN, instead received
-  <red>Array []</>"
+  <red>[]</>"
 `;
 
 exports[`.toBeNaN() throws 7`] = `
@@ -1357,6 +1357,13 @@ Expected value to be null, instead received
   <red>\\"a\\"</>"
 `;
 
+exports[`.toBeNull() fails for '[]' with .not 1`] = `
+"<dim>expect(<red>received</><dim>).toBeNull(<dim>)
+
+Expected value to be null, instead received
+  <red>[]</>"
+`;
+
 exports[`.toBeNull() fails for '[Function anonymous]' with .not 1`] = `
 "<dim>expect(<red>received</><dim>).toBeNull(<dim>)
 
@@ -1383,13 +1390,6 @@ exports[`.toBeNull() fails for '1' with .not 1`] = `
 
 Expected value to be null, instead received
   <red>1</>"
-`;
-
-exports[`.toBeNull() fails for 'Array []' with .not 1`] = `
-"<dim>expect(<red>received</><dim>).toBeNull(<dim>)
-
-Expected value to be null, instead received
-  <red>Array []</>"
 `;
 
 exports[`.toBeNull() fails for 'Infinity' with .not 1`] = `
@@ -1446,6 +1446,20 @@ exports[`.toBeTruthy(), .toBeFalsy() '"a"' is truthy 2`] = `
 
 Expected value to be falsy, instead received
   <red>\\"a\\"</>"
+`;
+
+exports[`.toBeTruthy(), .toBeFalsy() '[]' is truthy 1`] = `
+"<dim>expect(<red>received</><dim>).not.toBeTruthy(<dim>)
+
+Expected value not to be truthy, instead received
+  <red>[]</>"
+`;
+
+exports[`.toBeTruthy(), .toBeFalsy() '[]' is truthy 2`] = `
+"<dim>expect(<red>received</><dim>).toBeFalsy(<dim>)
+
+Expected value to be falsy, instead received
+  <red>[]</>"
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() '[Function anonymous]' is truthy 1`] = `
@@ -1516,20 +1530,6 @@ exports[`.toBeTruthy(), .toBeFalsy() '1' is truthy 2`] = `
 
 Expected value to be falsy, instead received
   <red>1</>"
-`;
-
-exports[`.toBeTruthy(), .toBeFalsy() 'Array []' is truthy 1`] = `
-"<dim>expect(<red>received</><dim>).not.toBeTruthy(<dim>)
-
-Expected value not to be truthy, instead received
-  <red>Array []</>"
-`;
-
-exports[`.toBeTruthy(), .toBeFalsy() 'Array []' is truthy 2`] = `
-"<dim>expect(<red>received</><dim>).toBeFalsy(<dim>)
-
-Expected value to be falsy, instead received
-  <red>Array []</>"
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() 'Infinity' is truthy 1`] = `
@@ -1703,22 +1703,22 @@ To contain a value equal to:
   <green>{\\"a\\": \\"d\\"}</>"
 `;
 
-exports[`.toContain(), .toContainEqual() '[{}, Array []]' does not contain '{}' 1`] = `
+exports[`.toContain(), .toContainEqual() '[{}, []]' does not contain '[]' 1`] = `
 "<dim>expect(<red>array</><dim>).toContain(<green>value</><dim>)
 
 Expected array:
-  <red>[{}, Array []]</>
+  <red>[{}, []]</>
 To contain value:
-  <green>{}</>"
+  <green>[]</>"
 `;
 
-exports[`.toContain(), .toContainEqual() '[{}, Array []]' does not contain 'Array []' 1`] = `
+exports[`.toContain(), .toContainEqual() '[{}, []]' does not contain '{}' 1`] = `
 "<dim>expect(<red>array</><dim>).toContain(<green>value</><dim>)
 
 Expected array:
-  <red>[{}, Array []]</>
+  <red>[{}, []]</>
 To contain value:
-  <green>Array []</>"
+  <green>{}</>"
 `;
 
 exports[`.toContain(), .toContainEqual() '[0, 1]' contains '1' 1`] = `
@@ -2225,6 +2225,17 @@ received.length:
   <red>2</>"
 `;
 
+exports[`.toHaveLength {pass: false} expect([]).toHaveLength(1) 1`] = `
+"<dim>expect(<red>received</><dim>).toHaveLength(<green>length</><dim>)
+
+Expected value to have length:
+  <green>1</>
+Received:
+  <red>[]</>
+received.length:
+  <red>0</>"
+`;
+
 exports[`.toHaveLength {pass: false} expect([1, 2]).toHaveLength(3) 1`] = `
 "<dim>expect(<red>received</><dim>).toHaveLength(<green>length</><dim>)
 
@@ -2234,17 +2245,6 @@ Received:
   <red>[1, 2]</>
 received.length:
   <red>2</>"
-`;
-
-exports[`.toHaveLength {pass: false} expect(Array []).toHaveLength(1) 1`] = `
-"<dim>expect(<red>received</><dim>).toHaveLength(<green>length</><dim>)
-
-Expected value to have length:
-  <green>1</>
-Received:
-  <red>Array []</>
-received.length:
-  <red>0</>"
 `;
 
 exports[`.toHaveLength {pass: true} expect("").toHaveLength(0) 1`] = `
@@ -2280,6 +2280,17 @@ received.length:
   <red>2</>"
 `;
 
+exports[`.toHaveLength {pass: true} expect([]).toHaveLength(0) 1`] = `
+"<dim>expect(<red>received</><dim>).not.toHaveLength(<green>length</><dim>)
+
+Expected value to not have length:
+  <green>0</>
+Received:
+  <red>[]</>
+received.length:
+  <red>0</>"
+`;
+
 exports[`.toHaveLength {pass: true} expect([1, 2]).toHaveLength(2) 1`] = `
 "<dim>expect(<red>received</><dim>).not.toHaveLength(<green>length</><dim>)
 
@@ -2289,17 +2300,6 @@ Received:
   <red>[1, 2]</>
 received.length:
   <red>2</>"
-`;
-
-exports[`.toHaveLength {pass: true} expect(Array []).toHaveLength(0) 1`] = `
-"<dim>expect(<red>received</><dim>).not.toHaveLength(<green>length</><dim>)
-
-Expected value to not have length:
-  <green>0</>
-Received:
-  <red>Array []</>
-received.length:
-  <red>0</>"
 `;
 
 exports[`.toHaveLength error cases 1`] = `
@@ -2656,6 +2656,14 @@ Received:
   regexp: <red>/foo/i</>"
 `;
 
+exports[`.toMatch() throws if non String actual value passed: [[], "foo"] 1`] = `
+"<dim>expect(<red>string</><dim>)[.not].toMatch(<green>expected</><dim>)
+
+<red>string</> value must be a string.
+Received:
+  array: <red>[]</>"
+`;
+
 exports[`.toMatch() throws if non String actual value passed: [[Function anonymous], "foo"] 1`] = `
 "<dim>expect(<red>string</><dim>)[.not].toMatch(<green>expected</><dim>)
 
@@ -2680,14 +2688,6 @@ Received:
   number: <red>1</>"
 `;
 
-exports[`.toMatch() throws if non String actual value passed: [Array [], "foo"] 1`] = `
-"<dim>expect(<red>string</><dim>)[.not].toMatch(<green>expected</><dim>)
-
-<red>string</> value must be a string.
-Received:
-  array: <red>Array []</>"
-`;
-
 exports[`.toMatch() throws if non String actual value passed: [true, "foo"] 1`] = `
 "<dim>expect(<red>string</><dim>)[.not].toMatch(<green>expected</><dim>)
 
@@ -2701,6 +2701,14 @@ exports[`.toMatch() throws if non String actual value passed: [undefined, "foo"]
 
 <red>string</> value must be a string.
 Received: <red>undefined</>"
+`;
+
+exports[`.toMatch() throws if non String/RegExp expected value passed: ["foo", []] 1`] = `
+"<dim>expect(<red>string</><dim>)[.not].toMatch(<green>expected</><dim>)
+
+<green>expected</> value must be a string or a regular expression.
+Expected:
+  array: <green>[]</>"
 `;
 
 exports[`.toMatch() throws if non String/RegExp expected value passed: ["foo", [Function anonymous]] 1`] = `
@@ -2725,14 +2733,6 @@ exports[`.toMatch() throws if non String/RegExp expected value passed: ["foo", 1
 <green>expected</> value must be a string or a regular expression.
 Expected:
   number: <green>1</>"
-`;
-
-exports[`.toMatch() throws if non String/RegExp expected value passed: ["foo", Array []] 1`] = `
-"<dim>expect(<red>string</><dim>)[.not].toMatch(<green>expected</><dim>)
-
-<green>expected</> value must be a string or a regular expression.
-Expected:
-  array: <green>Array []</>"
 `;
 
 exports[`.toMatch() throws if non String/RegExp expected value passed: ["foo", true] 1`] = `
@@ -3198,6 +3198,15 @@ Difference:
 <dim>Compared values have no visual difference."
 `;
 
+exports[`toMatchObject() {pass: true} expect([]).toMatchObject([]) 1`] = `
+"<dim>expect(<red>received</><dim>).not.toMatchObject(<green>expected</><dim>)
+
+Expected value not to match object:
+  <green>[]</>
+Received:
+  <red>[]</>"
+`;
+
 exports[`toMatchObject() {pass: true} expect([1, 2]).toMatchObject([1, 2]) 1`] = `
 "<dim>expect(<red>received</><dim>).not.toMatchObject(<green>expected</><dim>)
 
@@ -3331,15 +3340,6 @@ Expected value not to match object:
   <green>2015-11-30T00:00:00.000Z</>
 Received:
   <red>2015-11-30T00:00:00.000Z</>"
-`;
-
-exports[`toMatchObject() {pass: true} expect(Array []).toMatchObject(Array []) 1`] = `
-"<dim>expect(<red>received</><dim>).not.toMatchObject(<green>expected</><dim>)
-
-Expected value not to match object:
-  <green>Array []</>
-Received:
-  <red>Array []</>"
 `;
 
 exports[`toMatchObject() {pass: true} expect(Set {1, 2}).toMatchObject(Set {1, 2}) 1`] = `

--- a/packages/jest-matchers/src/__tests__/__snapshots__/spy_matchers.test.js.snap
+++ b/packages/jest-matchers/src/__tests__/__snapshots__/spy_matchers.test.js.snap
@@ -97,7 +97,7 @@ exports[`toBeCalled works with jest.fn 2`] = `
 "<dim>expect(<red>jest.fn()</><dim>).not.toBeCalled(<dim>)
 
 Expected mock function not to be called but it was called with:
-  <red>Array []</>"
+  <red>[]</>"
 `;
 
 exports[`toBeCalled works with jest.fn 3`] = `
@@ -134,7 +134,7 @@ exports[`toHaveBeenCalled works with jest.fn 2`] = `
 "<dim>expect(<red>jest.fn()</><dim>).not.toHaveBeenCalled(<dim>)
 
 Expected mock function not to be called but it was called with:
-  <red>Array []</>"
+  <red>[]</>"
 `;
 
 exports[`toHaveBeenCalled works with jest.fn 3`] = `
@@ -158,7 +158,7 @@ exports[`toHaveBeenCalledTimes accepts only numbers 2`] = `
 
 Expected value must be a number.
 Got:
-  array: <green>Array []</>"
+  array: <green>[]</>"
 `;
 
 exports[`toHaveBeenCalledTimes accepts only numbers 3`] = `

--- a/packages/pretty-format/src/__tests__/pretty_format.test.js
+++ b/packages/pretty-format/src/__tests__/pretty_format.test.js
@@ -35,7 +35,12 @@ describe('prettyFormat()', () => {
     expect(prettyFormat(val)).toEqual('Array [\n  1,\n  2,\n  3,\n]');
   });
 
-  it('prints a typed array', () => {
+  it('prints a empty typed array', () => {
+    const val = new Uint32Array(0);
+    expect(prettyFormat(val)).toEqual('Uint32Array []');
+  });
+
+  it('prints a typed array with items', () => {
     const val = new Uint32Array(3);
     expect(prettyFormat(val)).toEqual('Uint32Array [\n  0,\n  0,\n  0,\n]');
   });

--- a/packages/pretty-format/src/index.js
+++ b/packages/pretty-format/src/index.js
@@ -488,9 +488,6 @@ function printComplexValue(
 
   const toStringed = toString.call(val);
   if (toStringed === '[object Arguments]') {
-    if (val.length === 0) {
-      return 'Arguments []';
-    }
     return hitMaxDepth
       ? '[Arguments]'
       : (min ? '' : 'Arguments ') +
@@ -513,11 +510,8 @@ function printComplexValue(
         ) +
         ']';
   } else if (isToStringedArrayType(toStringed)) {
-    if (val.length === 0) {
-      return val.constructor.name + ' []';
-    }
     return hitMaxDepth
-      ? '[Array]'
+      ? '[' + val.constructor.name + ']'
       : (min ? '' : val.constructor.name + ' ') +
         '[' +
         printList(
@@ -582,8 +576,8 @@ function printComplexValue(
   }
 
   return hitMaxDepth
-    ? '[Object]'
-    : (min ? '' : val.constructor ? val.constructor.name + ' ' : 'Object ') +
+    ? '[' + (val.constructor ? val.constructor.name : 'Object') + ']'
+    : (min ? '' : (val.constructor ? val.constructor.name : 'Object') + ' ') +
       '{' +
       printObject(
         val,


### PR DESCRIPTION
**Summary**

Give the `return` statements in `printComplexValue` a parallel structure.

* For `min: true` option, the previous formatted value `Array []` instead of `[]` for empty array (or arguments) was inconsistent with `{}` for empty object. The change doesn’t affect snapshots directly, but it does affect format of Expected/Received values in Jest output when a test fails.
* When `hitMaxDepth` is true, the change to return name of typed array or constructed object instead of generic `[Array]` or `[Object]` doesn’t affect snapshots because default `maxDepth` is `Infinity` but does affect Jest output when a test fails, because `maxDepth = 10` is default.

**Test plan**

Updated tests for `min: true` option in `jest-matchers` and `jest-matcher-utils`