### PR TITLE
Use "inputSourceMap" for coverage re-mapping.

### DIFF
--- a/packages/jest-cli/src/reporters/coverage_reporter.js
+++ b/packages/jest-cli/src/reporters/coverage_reporter.js
@@ -63,17 +63,22 @@ class CoverageReporter extends BaseReporter {
       delete testResult.coverage;
 
       Object.keys(testResult.sourceMaps).forEach(sourcePath => {
-        var coverage = this._coverageMap.fileCoverageFor(sourcePath);
-        if (coverage.data.inputSourceMap) {
-          this._sourceMapStore.registerMap(
-            sourcePath,
-            coverage.data.inputSourceMap,
-          );
-        } else {
-          this._sourceMapStore.registerURL(
-            sourcePath,
-            testResult.sourceMaps[sourcePath],
-          );
+        let coverage;
+        try {
+          coverage = this._coverageMap.fileCoverageFor(sourcePath);
+        } finally {
+          let { data: { inputSourceMap } = {} } = coverage;
+          if (inputSourceMap) {
+            this._sourceMapStore.registerMap(
+              sourcePath,
+              inputSourceMap,
+            );
+          } else {
+            this._sourceMapStore.registerURL(
+              sourcePath,
+              testResult.sourceMaps[sourcePath],
+            );
+          }
         }
       });
     }

--- a/packages/jest-cli/src/reporters/coverage_reporter.js
+++ b/packages/jest-cli/src/reporters/coverage_reporter.js
@@ -67,13 +67,10 @@ class CoverageReporter extends BaseReporter {
         let coverage: FileCoverage, inputSourceMap: ?Object;
         try {
           coverage = this._coverageMap.fileCoverageFor(sourcePath);
-          ({ inputSourceMap } = coverage.toJSON());
+          ({inputSourceMap} = coverage.toJSON());
         } finally {
           if (inputSourceMap) {
-            this._sourceMapStore.registerMap(
-              sourcePath,
-              inputSourceMap,
-            );
+            this._sourceMapStore.registerMap(sourcePath, inputSourceMap);
           } else {
             this._sourceMapStore.registerURL(
               sourcePath,

--- a/packages/jest-cli/src/reporters/coverage_reporter.js
+++ b/packages/jest-cli/src/reporters/coverage_reporter.js
@@ -63,10 +63,18 @@ class CoverageReporter extends BaseReporter {
       delete testResult.coverage;
 
       Object.keys(testResult.sourceMaps).forEach(sourcePath => {
-        this._sourceMapStore.registerURL(
-          sourcePath,
-          testResult.sourceMaps[sourcePath],
-        );
+        var coverage = this._coverageMap.fileCoverageFor(sourcePath);
+        if (coverage.data.inputSourceMap) {
+          this._sourceMapStore.registerMap(
+            sourcePath,
+            coverage.data.inputSourceMap,
+          );
+        } else {
+          this._sourceMapStore.registerURL(
+            sourcePath,
+            testResult.sourceMaps[sourcePath],
+          );
+        }
       });
     }
   }

--- a/packages/jest-cli/src/reporters/coverage_reporter.js
+++ b/packages/jest-cli/src/reporters/coverage_reporter.js
@@ -63,7 +63,7 @@ class CoverageReporter extends BaseReporter {
       delete testResult.coverage;
 
       Object.keys(testResult.sourceMaps).forEach(sourcePath => {
-        let coverage;
+        let coverage: CoverageMap;
         try {
           coverage = this._coverageMap.fileCoverageFor(sourcePath);
         } finally {

--- a/packages/jest-cli/src/reporters/coverage_reporter.js
+++ b/packages/jest-cli/src/reporters/coverage_reporter.js
@@ -11,6 +11,7 @@
 import type {
   AggregatedResult,
   CoverageMap,
+  FileCoverage,
   SerializableError,
   TestResult,
 } from 'types/TestResult';
@@ -63,11 +64,11 @@ class CoverageReporter extends BaseReporter {
       delete testResult.coverage;
 
       Object.keys(testResult.sourceMaps).forEach(sourcePath => {
-        let coverage: CoverageMap;
+        let coverage?: FileCoverage, inputSourceMap?: Object;
         try {
           coverage = this._coverageMap.fileCoverageFor(sourcePath);
+          ({ inputSourceMap } = coverage.toJSON());
         } finally {
-          let { data: { inputSourceMap } = {} } = coverage;
           if (inputSourceMap) {
             this._sourceMapStore.registerMap(
               sourcePath,

--- a/packages/jest-cli/src/reporters/coverage_reporter.js
+++ b/packages/jest-cli/src/reporters/coverage_reporter.js
@@ -64,7 +64,7 @@ class CoverageReporter extends BaseReporter {
       delete testResult.coverage;
 
       Object.keys(testResult.sourceMaps).forEach(sourcePath => {
-        let coverage: FileCoverage, inputSourceMap: Object;
+        let coverage: FileCoverage, inputSourceMap: ?Object;
         try {
           coverage = this._coverageMap.fileCoverageFor(sourcePath);
           ({ inputSourceMap } = coverage.toJSON());

--- a/packages/jest-cli/src/reporters/coverage_reporter.js
+++ b/packages/jest-cli/src/reporters/coverage_reporter.js
@@ -64,7 +64,7 @@ class CoverageReporter extends BaseReporter {
       delete testResult.coverage;
 
       Object.keys(testResult.sourceMaps).forEach(sourcePath => {
-        let coverage?: FileCoverage, inputSourceMap?: Object;
+        let coverage: FileCoverage, inputSourceMap: Object;
         try {
           coverage = this._coverageMap.fileCoverageFor(sourcePath);
           ({ inputSourceMap } = coverage.toJSON());


### PR DESCRIPTION
**Summary**

Use "inputSourceMap" instead of read from file.
The "babel-plugin-istanbul" can use the input source map from "inputSourceMap" or "inlineSourceMap".
The final source map from babel is not suitable for the coverage re-mapping.
The "istanbul" will ignore the "inputSourceMap", if it already registered.

