### PR TITLE
Fix Watchman on windows

### DIFF
--- a/packages/jest-haste-map/src/crawlers/watchman.js
+++ b/packages/jest-haste-map/src/crawlers/watchman.js
@@ -97,7 +97,7 @@ module.exports = function watchmanCrawl(
           }
 
           pairs.forEach(pair => {
-            const root = pair.root;
+            const root = normalizePathSep(pair.root);
             const response = pair.response;
             if ('warning' in response) {
               console.warn('watchman warning: ', response.warning);


### PR DESCRIPTION
Watchman returns `/` separated paths, but `jest-haste-map` uses `path.sep` which on windows equals `\`.

**Summary**

Addresses the issue finding tests on Windows with the latest watchman and Jest.
As a follow-up to https://github.com/facebook/jest/pull/3887