### PR TITLE
Remove plugins entry from karma tests

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -11,7 +11,6 @@ module.exports = config => {
     browsers: ['ChromeHeadless'],
     files: ['integration_tests/browser-support/browser-test.js'],
     frameworks: ['mocha', 'browserify'],
-    plugins: ['karma-browserify', 'karma-chrome-launcher', 'karma-mocha'],
     preprocessors: {
       'integration_tests/browser-support/browser-test.js': ['browserify'],
     },


### PR DESCRIPTION
All `karma-*` plugins are autoloaded (essentially same as webpack-contrib/karma-webpack#103)

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Without this change, one can't do `yarn test-ci-es5-build-in-browser -- --browsers PhantomJS`

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
Tests should still pass.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

/cc @skovhus 