### PR TITLE
Enable prettier eslint integration for vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,6 @@
 {
   "jest.pathToJest": "yarn jest --",
-  "editor.rulers": [
-    80
-  ],
+  "editor.rulers": [80],
   "files.exclude": {
     "**/.git": true,
     "**/node_modules": true,
@@ -13,5 +11,6 @@
   "prettier.singleQuote": true,
   "prettier.trailingComma": "all",
   "prettier.semi": true,
-  "editor.formatOnSave": true
+  "editor.formatOnSave": true,
+  "prettier.eslintIntegration": true
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Updates VSCode config to enable ESLint support. Makes working on different prettier configs easier (e.g. editing a file in `scripts` without the option enabled would result in adding a trailing comma to function params).
Fixes #4031.

**Test plan**

works for me
