### PR TITLE
Wrap `Error.captureStackTrace` in a try

### DIFF
--- a/integration_tests/__tests__/stack_trace_no_captureStackTrace.test.js
+++ b/integration_tests/__tests__/stack_trace_no_captureStackTrace.test.js
@@ -14,8 +14,19 @@ describe('Stack Trace', () => {
     const result = runJest('stack_trace_no_captureStackTrace');
     const stderr = result.stderr.toString();
 
+    const assertErrorLines = stderr
+      .split('\n')
+      .slice(3, 9)
+      .filter(s => s.trim());
+
     expect(result.status).toBe(1);
 
-    expect(stderr).toMatch(/\s+at\sJestAssertionError\s.*/);
+    expect(assertErrorLines).toEqual([
+      '    expect(received).toBe(expected)',
+      '    Expected value to be (using ===):',
+      '      2',
+      '    Received:',
+      '      1',
+    ]);
   });
 });

--- a/integration_tests/__tests__/stack_trace_no_captureStackTrace.test.js
+++ b/integration_tests/__tests__/stack_trace_no_captureStackTrace.test.js
@@ -21,6 +21,8 @@ describe('Stack Trace', () => {
 
     expect(result.status).toBe(1);
 
+    expect(stderr).toMatch(/\s+at\sJestAssertionError\s.*/);
+
     expect(assertErrorLines).toEqual([
       '    expect(received).toBe(expected)',
       '    Expected value to be (using ===):',

--- a/integration_tests/__tests__/stack_trace_no_captureStackTrace.test.js
+++ b/integration_tests/__tests__/stack_trace_no_captureStackTrace.test.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
+const runJest = require('../runJest');
+
+describe('Stack Trace', () => {
+  it('prints a usable stack trace even if no Error.captureStackTrace', () => {
+    const result = runJest('stack_trace_no_captureStackTrace');
+    const stderr = result.stderr.toString();
+
+    expect(result.status).toBe(1);
+
+    console.log(stderr);
+
+    expect(stderr).toMatch(/\s+at\sJestAssertionError\s.*/);
+  });
+});

--- a/integration_tests/__tests__/stack_trace_no_captureStackTrace.test.js
+++ b/integration_tests/__tests__/stack_trace_no_captureStackTrace.test.js
@@ -16,8 +16,6 @@ describe('Stack Trace', () => {
 
     expect(result.status).toBe(1);
 
-    console.log(stderr);
-
     expect(stderr).toMatch(/\s+at\sJestAssertionError\s.*/);
   });
 });

--- a/integration_tests/__tests__/stack_trace_no_captureStackTrace.test.js
+++ b/integration_tests/__tests__/stack_trace_no_captureStackTrace.test.js
@@ -14,10 +14,7 @@ describe('Stack Trace', () => {
     const result = runJest('stack_trace_no_captureStackTrace');
     const stderr = result.stderr.toString();
 
-    const assertErrorLines = stderr
-      .split('\n')
-      .slice(3, 9)
-      .filter(s => s.trim());
+    const assertErrorLines = stderr.split('\n').slice(3, 9);
 
     expect(result.status).toBe(1);
 
@@ -25,6 +22,7 @@ describe('Stack Trace', () => {
 
     expect(assertErrorLines).toEqual([
       '    expect(received).toBe(expected)',
+      '    ',
       '    Expected value to be (using ===):',
       '      2',
       '    Received:',

--- a/integration_tests/stack_trace_no_captureStackTrace/__tests__/runtime_error.test.js
+++ b/integration_tests/stack_trace_no_captureStackTrace/__tests__/runtime_error.test.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+'use strict';
+
+Error.captureStackTrace = undefined;
+
+test('some test', () => {
+  expect(1).toBe(2);
+});

--- a/integration_tests/stack_trace_no_captureStackTrace/package.json
+++ b/integration_tests/stack_trace_no_captureStackTrace/package.json
@@ -1,0 +1,5 @@
+{
+  "jest": {
+    "testEnvironment": "node"
+  }
+}

--- a/packages/jest-matchers/src/index.js
+++ b/packages/jest-matchers/src/index.js
@@ -194,8 +194,10 @@ const makeThrowingMatcher = (
     try {
       result = matcher.apply(matcherContext, [actual].concat(args));
     } catch (error) {
-      // Remove this and deeper functions from the stack trace frame.
-      Error.captureStackTrace(error, throwingMatcher);
+      // Try to remove this and deeper functions from the stack trace frame.
+      if (Error.captureStackTrace) {
+        Error.captureStackTrace(error, throwingMatcher);
+      }
       throw error;
     }
 
@@ -211,8 +213,10 @@ const makeThrowingMatcher = (
       // reporter could access the actual and expected objects of the result
       // for example in order to display a custom visual diff
       error.matcherResult = result;
-      // Remove this function from the stack trace frame.
-      Error.captureStackTrace(error, throwingMatcher);
+      // Try to remove this function from the stack trace frame.
+      if (Error.captureStackTrace) {
+        Error.captureStackTrace(error, throwingMatcher);
+      }
 
       if (throws) {
         throw error;

--- a/packages/jest-matchers/src/index.js
+++ b/packages/jest-matchers/src/index.js
@@ -195,6 +195,7 @@ const makeThrowingMatcher = (
       result = matcher.apply(matcherContext, [actual].concat(args));
     } catch (error) {
       // Try to remove this and deeper functions from the stack trace frame.
+      // Guard for some environments (browsers) that do not support this feature.
       if (Error.captureStackTrace) {
         Error.captureStackTrace(error, throwingMatcher);
       }
@@ -214,6 +215,7 @@ const makeThrowingMatcher = (
       // for example in order to display a custom visual diff
       error.matcherResult = result;
       // Try to remove this function from the stack trace frame.
+      // Guard for some environments (browsers) that do not support this feature.
       if (Error.captureStackTrace) {
         Error.captureStackTrace(error, throwingMatcher);
       }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Ref #4027

This is a poor-man's version, but it works OK. Not sure we really need to fix it more?

Could put the logic to remove `JestAssertionError` along with the rest of the stack trace cleanup and avoid `Error.captureStackTrace` all together?

/cc @skovhus 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
Tests running in browsers should show assertion errors.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
