### PR TITLE
Throw Error When Using Nested It Specs

### DIFF
--- a/packages/jest-jasmine2/src/jasmine/Env.js
+++ b/packages/jest-jasmine2/src/jasmine/Env.js
@@ -388,6 +388,14 @@ module.exports = function(j$) {
       if (currentDeclarationSuite.markedPending) {
         spec.pend();
       }
+      if (currentSpec !== null) {
+        throw new Error(
+          'Test ' +
+            spec.description +
+            'cannot run because it is nested in ' +
+            currentSpec.description
+        );
+      }
       currentDeclarationSuite.addChild(spec);
       return spec;
     };

--- a/packages/jest-jasmine2/src/jasmine/Env.js
+++ b/packages/jest-jasmine2/src/jasmine/Env.js
@@ -388,6 +388,10 @@ module.exports = function(j$) {
       if (currentDeclarationSuite.markedPending) {
         spec.pend();
       }
+
+      /* When a test is defined inside another, jasmine will not run it
+        This check throws an error to warn the developer about
+        the edge-case */
       if (currentSpec !== null) {
         throw new Error(
           'Test ' +

--- a/packages/jest-jasmine2/src/jasmine/Env.js
+++ b/packages/jest-jasmine2/src/jasmine/Env.js
@@ -389,16 +389,15 @@ module.exports = function(j$) {
         spec.pend();
       }
 
-      /* When a test is defined inside another, jasmine will not run it
-        This check throws an error to warn the developer about
-        the edge-case */
+      // When a test is defined inside another, jasmine will not run it.
+      // This check throws an error to warn the user about the edge-case.
       if (currentSpec !== null) {
         throw new Error(
-          'Test `' +
+          'Tests cannot be nested. Test `' +
             spec.description +
-            '` cannot run because it is nested in `' +
+            '` cannot run because it is nested within `' +
             currentSpec.description +
-            '`',
+            '`.',
         );
       }
       currentDeclarationSuite.addChild(spec);

--- a/packages/jest-jasmine2/src/jasmine/Env.js
+++ b/packages/jest-jasmine2/src/jasmine/Env.js
@@ -394,10 +394,11 @@ module.exports = function(j$) {
         the edge-case */
       if (currentSpec !== null) {
         throw new Error(
-          'Test ' +
+          'Test `' +
             spec.description +
-            'cannot run because it is nested in ' +
-            currentSpec.description
+            '` cannot run because it is nested in `' +
+            currentSpec.description +
+            '`',
         );
       }
       currentDeclarationSuite.addChild(spec);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

I have recently started using Jest and I really like it. I tried adding nested it/test conditions, but I didn't realize that was not allowed, because both tests will succeed (nested test, however, never runs). I've added some changes to throw an error to let the devs know that such pattern is not allowed.

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

```javascript
test('make sure 2 equals 3', () => {
  test('nested test confuses the devs', () => {
    expect(2).toBe(3);
  })
});
```

```javascript
 FAIL  ./jest-it.test.js
  ● make sure 2 equals 3

    Test `nested test confuses the devs` cannot run because it is nested in `make sure 2 equals 3`

      at Env.it (../jest/packages/jest-jasmine2/build/jasmine/Env.js:396:15)
      at Object.<anonymous>.test (jest-it.test.js:4:3)
          at Promise (<anonymous>)
          at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:169:7)
```