### PR TITLE
Add "restoreAllMocks" to the API. Closes #3580

### DIFF
--- a/docs/en/JestObjectAPI.md
+++ b/docs/en/JestObjectAPI.md
@@ -24,6 +24,7 @@ The `jest` object is automatically in scope within every test file. The methods 
   - [`jest.dontMock(moduleName)`](#jestdontmockmodulename)
   - [`jest.clearAllMocks()`](#jestclearallmocks)
   - [`jest.resetAllMocks()`](#jestresetallmocks)
+  - [`jest.restoreAllMocks()`](#jestrestoreallmocks)
   - [`jest.resetModules()`](#jestresetmodules)
   - [`jest.runAllTicks()`](#jestrunallticks)
   - [`jest.runAllTimers()`](#jestrunalltimers)
@@ -179,8 +180,11 @@ Resets the state of all mocks. Equivalent to calling `.mockReset()` on every moc
 
 Returns the `jest` object for chaining.
 
-### `jest.resetModules()`
+### `jest.restoreAllMocks()`
+##### available in Jest **20.1.0+**
+Restores all mocks back to their original value. Equivalent to calling `.mockRestore` on every mocked function. Beware that `jest.restoreAllMocks()` only works when mock was created with `jest.spyOn`; other mocks will require you to manually restore them.
 
+### `jest.resetModules()`
 Resets the module registry - the cache of all required modules. This is useful to isolate modules where local state might conflict between tests.
 
 Example:

--- a/packages/jest-mock/src/__tests__/jest_mock.test.js
+++ b/packages/jest-mock/src/__tests__/jest_mock.test.js
@@ -488,5 +488,41 @@ describe('moduleMocker', () => {
         moduleMocker.spyOn({method: 10}, 'method');
       }).toThrow();
     });
+
+    it('supports restoring all spies', () => {
+      let methodOneCalls = 0;
+      let methodTwoCalls = 0;
+      const obj = {
+        methodOne() {
+          methodOneCalls++;
+        },
+        methodTwo() {
+          methodTwoCalls++;
+        },
+      };
+
+      const spy1 = moduleMocker.spyOn(obj, 'methodOne');
+      const spy2 = moduleMocker.spyOn(obj, 'methodTwo');
+
+      // First, we call with the spies: both spies and both original functions
+      // should be called.
+      obj.methodOne();
+      obj.methodTwo();
+      expect(methodOneCalls).toBe(1);
+      expect(methodTwoCalls).toBe(1);
+      expect(spy1.mock.calls.length).toBe(1);
+      expect(spy2.mock.calls.length).toBe(1);
+
+      moduleMocker.restoreAllMocks();
+
+      // Then, after resetting all mocks, we call methods again. Only the real
+      // methods should bump their count, not the spies.
+      obj.methodOne();
+      obj.methodTwo();
+      expect(methodOneCalls).toBe(2);
+      expect(methodTwoCalls).toBe(2);
+      expect(spy1.mock.calls.length).toBe(1);
+      expect(spy2.mock.calls.length).toBe(1);
+    });
   });
 });

--- a/packages/jest-runtime/src/index.js
+++ b/packages/jest-runtime/src/index.js
@@ -462,6 +462,10 @@ class Runtime {
     this._mockFactories[moduleID] = mockFactory;
   }
 
+  restoreAllMocks() {
+    this._moduleMocker.restoreAllMocks();
+  }
+
   resetAllMocks() {
     this._moduleMocker.resetAllMocks();
   }


### PR DESCRIPTION
**Summary**

A new `.spyOn` method was added in Jest 19.0 to allow spying on methods without skipping their original behavior. However, Jest lacked a method to clean all the spies at once, as opposed as other existing APIs for cleaning or resetting mocks. Further discussion can be found on #3580.

Now, all spies can be cleaned at once by calling `jest.restoreAllMocks`, which naming is consistent with other group resets.

**Test plan**

New tests were added, so running the whole suit of tests should be enough. This would also include running `flow` to check typing errors. If you can think about something else, let me know :)