### PR TITLE
jest-haste-map: add test case for broken handling of ignore pattern

### DIFF
--- a/packages/jest-haste-map/src/__tests__/index.test.js
+++ b/packages/jest-haste-map/src/__tests__/index.test.js
@@ -548,6 +548,36 @@ describe('HasteMap', () => {
       });
   });
 
+  it('discards the cache when configuration changes (broken)', () => {
+    return new HasteMap(defaultConfig)
+      .build()
+      .then(() => {
+        fs.readFileSync.mockClear();
+
+        // Explicitly mock that no files have changed.
+        mockChangedFiles = Object.create(null);
+
+        // Watchman would give us different clocks.
+        mockClocks = object({
+          '/fruits': 'c:fake-clock:3',
+          '/vegetables': 'c:fake-clock:4',
+        });
+
+        const config = Object.assign(
+          {},
+          defaultConfig,
+          {ignorePattern: /kiwi|pear/},
+        );
+        return new HasteMap(config)
+          .build()
+          .then(({moduleMap}) => {
+            // `getModule` should actually return `null` here, because Pear
+            // should get ignored by the pattern.
+            expect(typeof moduleMap.getModule('Pear')).toBe('string');
+          });
+      });
+  });
+
   it('ignores files that do not exist', () => {
     const watchman = require('../crawlers/watchman');
     const mockImpl = watchman.getMockImplementation();


### PR DESCRIPTION
This adds a test to keep track of the broken behavior for when `ignorePattern` is changed. Normally, the new ignore pattern should be applied, that means new files may now have to be included, and that others may now have to be ignored. However this is not properly handled at the moment, the `ignorePattern` is ignored when there's already a cache.

By adding this test now, we can simply switch the "expect" line when this is fixed.

**Test plan**

    yarn run jest packages/jest-haste-map/src/__tests__/index.test.js