### PR TITLE
custom reporters error handling

### DIFF
--- a/packages/jest-cli/src/cli/index.js
+++ b/packages/jest-cli/src/cli/index.js
@@ -258,7 +258,7 @@ const _run = async (
   );
 
   globalConfig.watch || globalConfig.watchAll
-    ? _runWatch(
+    ? await _runWatch(
         contexts,
         configs,
         hasDeprecationWarnings,
@@ -267,7 +267,7 @@ const _run = async (
         hasteMapInstances,
         changedFilesPromise,
       )
-    : _runWithoutWatch(
+    : await _runWithoutWatch(
         globalConfig,
         contexts,
         outputStream,
@@ -304,11 +304,11 @@ const _runWithoutWatch = async (
   onComplete,
   changedFilesPromise,
 ) => {
-  const startRun = () => {
+  const startRun = async () => {
     if (!globalConfig.listTests) {
       preRunMessage.print(outputStream);
     }
-    runJest({
+    return await runJest({
       changedFilesPromise,
       contexts,
       globalConfig,
@@ -318,7 +318,7 @@ const _runWithoutWatch = async (
       testWatcher: new TestWatcher({isWatchMode: false}),
     });
   };
-  return startRun();
+  return await startRun();
 };
 
 module.exports = {

--- a/packages/jest-cli/src/reporter_dispatcher.js
+++ b/packages/jest-cli/src/reporter_dispatcher.js
@@ -36,24 +36,27 @@ class ReporterDispatcher {
     );
   }
 
-  onTestResult(test: Test, testResult: TestResult, results: AggregatedResult) {
-    this._reporters.forEach(
-      reporter =>
-        reporter.onTestResult &&
-        reporter.onTestResult(test, testResult, results),
-    );
+  async onTestResult(
+    test: Test,
+    testResult: TestResult,
+    results: AggregatedResult,
+  ) {
+    for (const reporter of this._reporters) {
+      reporter.onTestResult &&
+        (await reporter.onTestResult(test, testResult, results));
+    }
   }
 
-  onTestStart(test: Test) {
-    this._reporters.forEach(
-      reporter => reporter.onTestStart && reporter.onTestStart(test),
-    );
+  async onTestStart(test: Test) {
+    for (const reporter of this._reporters) {
+      reporter.onTestStart && (await reporter.onTestStart(test));
+    }
   }
 
-  onRunStart(results: AggregatedResult, options: ReporterOnStartOptions) {
-    this._reporters.forEach(
-      reporter => reporter.onRunStart && reporter.onRunStart(results, options),
-    );
+  async onRunStart(results: AggregatedResult, options: ReporterOnStartOptions) {
+    for (const reporter of this._reporters) {
+      reporter.onRunStart && (await reporter.onRunStart(results, options));
+    }
   }
 
   async onRunComplete(contexts: Set<Context>, results: AggregatedResult) {

--- a/types/TestRunner.js
+++ b/types/TestRunner.js
@@ -26,12 +26,12 @@ export type Reporter = {
     test: Test,
     testResult: TestResult,
     aggregatedResult: AggregatedResult,
-  ) => void,
+  ) => ?Promise<void>,
   +onRunStart: (
     results: AggregatedResult,
     options: ReporterOnStartOptions,
-  ) => void,
-  +onTestStart: (test: Test) => void,
+  ) => ?Promise<void>,
+  +onTestStart: (test: Test) => ?Promise<void>,
   +onRunComplete: (
     contexts: Set<Context>,
     results: AggregatedResult,


### PR DESCRIPTION
there was a broken promise chain (again 😔) and all errors throw in custom reporter code would make `jest` hang forever.
Also the way we call reporter methods was inconsistent (`onRunComplete` was async, and all others were sync)