### PR TITLE
Setup custom reporters after default reporters

### DIFF
--- a/packages/jest-cli/src/test_runner.js
+++ b/packages/jest-cli/src/test_runner.js
@@ -297,10 +297,6 @@ class TestRunner {
       this._setupDefaultReporters();
     }
 
-    if (reporters && Array.isArray(reporters)) {
-      this._addCustomReporters(reporters);
-    }
-
     if (collectCoverage) {
       this.addReporter(new CoverageReporter(this._globalConfig));
     }
@@ -309,6 +305,10 @@ class TestRunner {
       this.addReporter(
         new NotifyReporter(this._globalConfig, this._options.startRun),
       );
+    }
+
+    if (reporters && Array.isArray(reporters)) {
+      this._addCustomReporters(reporters);
     }
   }
 


### PR DESCRIPTION
Custom reporter experience is not great right now and it's pretty hard to customize.
Right now even if we pass this to config:
```js
{reporters: ['custom1.js', 'default', 'custom2.js']}
```
the order will be:
- default reporters
- custom reporters
- coverage/notify reporters

and that makes it hard to customize reporters that interact with coverage data. (coverage data is never available in custom reporters, because `CoverageReporter` is always last in the queue).

This requires a better fix (https://github.com/facebook/jest/issues/4052), but for now i want to move custom reporters to the very end, so they're run after all default reporters are done