### PR TITLE
--useStderr

### DIFF
--- a/integration_tests/__tests__/use_stderr.test.js
+++ b/integration_tests/__tests__/use_stderr.test.js
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+import runJest from '../runJest';
+import {cleanup, writeFiles} from '../utils';
+import os from 'os';
+import path from 'path';
+
+const skipOnWindows = require('skipOnWindows');
+const DIR = path.resolve(os.tmpdir(), 'use_stderr_test');
+
+skipOnWindows.suite();
+
+beforeEach(() => cleanup(DIR));
+afterEach(() => cleanup(DIR));
+
+test('no tests found message is redirected to stderr', () => {
+  writeFiles(DIR, {
+    '.watchmanconfig': '',
+    'file1.js': 'module.exports = {}',
+    'package.json': JSON.stringify({jest: {testEnvironment: 'node'}}),
+  });
+  let stderr;
+  let stdout;
+
+  ({stdout, stderr} = runJest(DIR, ['--useStderr']));
+  expect(stdout.trim()).toBe('');
+  expect(stderr).toMatch('No tests found');
+
+  writeFiles(DIR, {
+    '__tests__/test.test.js': `require('../file1'); test('file1', () => {});`,
+  });
+
+  ({stdout, stderr} = runJest(DIR, ['--useStderr']));
+  expect(stdout.trim()).toBe('');
+  expect(stderr).toMatch(/PASS.*test\.test\.js/);
+});

--- a/packages/jest-cli/src/cli/index.js
+++ b/packages/jest-cli/src/cli/index.js
@@ -54,7 +54,8 @@ const runCLI = async (
 
   // If we output a JSON object, we can't write anything to stdout, since
   // it'll break the JSON structure and it won't be valid.
-  const outputStream = argv.json ? process.stderr : process.stdout;
+  const outputStream =
+    argv.json || argv.useStderr ? process.stderr : process.stdout;
 
   argv.version && _printVersionAndExit(outputStream, onComplete);
 


### PR DESCRIPTION
seems like this one was a noop for a long time (www used it, but it had a custom --printUserMessagesToStderr flag and internal runner didn't use any printing parts of OSS project, which is not passible today with MPR changes)