### PR TITLE
--onlyChanged + testPathPattern

### DIFF
--- a/integration_tests/__tests__/only_changed.test.js
+++ b/integration_tests/__tests__/only_changed.test.js
@@ -74,7 +74,7 @@ test('run only changed files', () => {
   expect(stderr).toMatch('PASS  __tests__/file3.test.js');
 });
 
-test('onlyChanged in config is overwritten by --all', () => {
+test('onlyChanged in config is overwritten by --all or testPathPattern', () => {
   writeFiles(DIR, {
     '.watchmanconfig': '',
     '__tests__/file1.test.js': `require('../file1'); test('file1', () => {});`,
@@ -118,6 +118,11 @@ test('onlyChanged in config is overwritten by --all', () => {
 
   ({stderr} = runJest(DIR));
   expect(stdout).toMatch('No tests found related to files');
+
+  ({stderr, stdout} = runJest(DIR, ['file2.test.js']));
+  expect(stdout).not.toMatch('No tests found related to files');
+  expect(stderr).toMatch('PASS  __tests__/file2.test.js');
+  expect(stderr).toMatch('1 total');
 
   writeFiles(DIR, {
     'file2.js': 'module.exports = {modified: true}',

--- a/packages/jest-config/src/normalize.js
+++ b/packages/jest-config/src/normalize.js
@@ -492,7 +492,7 @@ function normalize(options: InitialOptions, argv: Argv) {
   newOptions.json = argv.json;
   newOptions.lastCommit = argv.lastCommit;
 
-  if (argv.all) {
+  if (argv.all || newOptions.testPathPattern) {
     newOptions.onlyChanged = false;
   }
 


### PR DESCRIPTION
it seems like right now when you run `jest -o my_test_file.test.js`, jest will ignore the test pattern and will still try to run tests related to changed files.
that was my bad, i think there was some nested condition in TestSelectionConfig that i killed