### PR TITLE
Replace unchanging args with one config arg within pretty-format

### DIFF
--- a/types/PrettyFormat.js
+++ b/types/PrettyFormat.js
@@ -20,6 +20,22 @@ export type Refs = Array<any>;
 export type Print = any => string;
 export type StringOrNull = string | null;
 
+export type Theme = {|
+  comment: string,
+  content: string,
+  prop: string,
+  tag: string,
+  value: string,
+|};
+
+export type ThemeReceived = {|
+  comment?: string,
+  content?: string,
+  prop?: string,
+  tag?: string,
+  value?: string,
+|};
+
 export type Options = {|
   callToJSON: boolean,
   escapeRegex: boolean,
@@ -29,13 +45,32 @@ export type Options = {|
   min: boolean,
   plugins: Plugins,
   printFunctionName: boolean,
-  theme: {|
-    comment: string,
-    content: string,
-    prop: string,
-    tag: string,
-    value: string,
-  |},
+  theme: Theme,
+|};
+
+export type OptionsReceived = {|
+  callToJSON?: boolean,
+  escapeRegex?: boolean,
+  highlight?: boolean,
+  indent?: number,
+  maxDepth?: number,
+  min?: boolean,
+  plugins?: Plugins,
+  printFunctionName?: boolean,
+  theme?: ThemeReceived,
+|};
+
+export type Config = {|
+  callToJSON: boolean,
+  colors: Colors,
+  escapeRegex: boolean,
+  indent: string,
+  maxDepth: number,
+  min: boolean,
+  plugins: Plugins,
+  printFunctionName: boolean,
+  spacingInner: string,
+  spacingOuter: string,
 |};
 
 export type PluginOptions = {|


### PR DESCRIPTION
**Summary**

Benefits of distinguishing config properties which **don’t change** (depend only on options and defaults) from arguments which **do change** during recursive descent through data structures:

* **concise clear** signature for core functions
* **correct complete consistent** API for plugins (but one step at a time :)

Converting from options to config in an even more functional lazy evaluation pattern solves a recent accidental performance regression (always iterating theme colors, even for top-level basic values).

Removed a readbump in `printList`, `printMap`, `printObject`, `printSet`: logic for final comma had been combined with edge spacing and indent instead of in parallel with logic for non-final comma.

Make yourself a cup of coffee or tea before you review this diff.

**Test plan**

Jest, if the Continuous Irritation system allows