### PR TITLE
--showConfig to show all project configs

### DIFF
--- a/integration_tests/__tests__/__snapshots__/show_config.test.js.snap
+++ b/integration_tests/__tests__/__snapshots__/show_config.test.js.snap
@@ -2,56 +2,57 @@
 
 exports[`--showConfig outputs config info and exits 1`] = `
 "{
-  \\"config\\": {
-    \\"automock\\": false,
-    \\"browser\\": false,
-    \\"cache\\": false,
-    \\"cacheDirectory\\": \\"/tmp/jest\\",
-    \\"clearMocks\\": false,
-    \\"coveragePathIgnorePatterns\\": [
-      \\"/node_modules/\\"
-    ],
-    \\"globals\\": {},
-    \\"haste\\": {
-      \\"providesModuleNodeModules\\": []
-    },
-    \\"moduleDirectories\\": [
-      \\"node_modules\\"
-    ],
-    \\"moduleFileExtensions\\": [
-      \\"js\\",
-      \\"json\\",
-      \\"jsx\\",
-      \\"node\\"
-    ],
-    \\"moduleNameMapper\\": {},
-    \\"modulePathIgnorePatterns\\": [],
-    \\"name\\": \\"[md5 hash]\\",
-    \\"resetMocks\\": false,
-    \\"resetModules\\": false,
-    \\"rootDir\\": \\"<<REPLACED_ROOT_DIR>>\\",
-    \\"roots\\": [
-      \\"<<REPLACED_ROOT_DIR>>\\"
-    ],
-    \\"setupFiles\\": [],
-    \\"snapshotSerializers\\": [],
-    \\"testEnvironment\\": \\"jest-environment-jsdom\\",
-    \\"testMatch\\": [
-      \\"**/__tests__/**/*.js?(x)\\",
-      \\"**/?(*.)(spec|test).js?(x)\\"
-    ],
-    \\"testPathIgnorePatterns\\": [
-      \\"/node_modules/\\"
-    ],
-    \\"testRegex\\": \\"\\",
-    \\"testRunner\\": \\"<<REPLACED_JEST_PACKAGES_DIR>>/jest-jasmine2/build/index.js\\",
-    \\"testURL\\": \\"about:blank\\",
-    \\"timers\\": \\"real\\",
-    \\"transformIgnorePatterns\\": [
-      \\"/node_modules/\\"
-    ]
-  },
-  \\"framework\\": \\"jasmine2\\",
+  \\"configs\\": [
+    {
+      \\"automock\\": false,
+      \\"browser\\": false,
+      \\"cache\\": false,
+      \\"cacheDirectory\\": \\"/tmp/jest\\",
+      \\"clearMocks\\": false,
+      \\"coveragePathIgnorePatterns\\": [
+        \\"/node_modules/\\"
+      ],
+      \\"globals\\": {},
+      \\"haste\\": {
+        \\"providesModuleNodeModules\\": []
+      },
+      \\"moduleDirectories\\": [
+        \\"node_modules\\"
+      ],
+      \\"moduleFileExtensions\\": [
+        \\"js\\",
+        \\"json\\",
+        \\"jsx\\",
+        \\"node\\"
+      ],
+      \\"moduleNameMapper\\": {},
+      \\"modulePathIgnorePatterns\\": [],
+      \\"name\\": \\"[md5 hash]\\",
+      \\"resetMocks\\": false,
+      \\"resetModules\\": false,
+      \\"rootDir\\": \\"<<REPLACED_ROOT_DIR>>\\",
+      \\"roots\\": [
+        \\"<<REPLACED_ROOT_DIR>>\\"
+      ],
+      \\"setupFiles\\": [],
+      \\"snapshotSerializers\\": [],
+      \\"testEnvironment\\": \\"jest-environment-jsdom\\",
+      \\"testMatch\\": [
+        \\"**/__tests__/**/*.js?(x)\\",
+        \\"**/?(*.)(spec|test).js?(x)\\"
+      ],
+      \\"testPathIgnorePatterns\\": [
+        \\"/node_modules/\\"
+      ],
+      \\"testRegex\\": \\"\\",
+      \\"testRunner\\": \\"<<REPLACED_JEST_PACKAGES_DIR>>/jest-jasmine2/build/index.js\\",
+      \\"testURL\\": \\"about:blank\\",
+      \\"timers\\": \\"real\\",
+      \\"transformIgnorePatterns\\": [
+        \\"/node_modules/\\"
+      ]
+    }
+  ],
   \\"globalConfig\\": {
     \\"bail\\": false,
     \\"changedFilesWithAncestor\\": false,

--- a/integration_tests/__tests__/debug.test.js
+++ b/integration_tests/__tests__/debug.test.js
@@ -18,8 +18,7 @@ describe('jest --debug', () => {
   it('outputs debugging info before running the test', () => {
     const {stdout} = runJest(dir, ['--debug', '--no-cache']);
     expect(stdout).toMatch('"version": "');
-    expect(stdout).toMatch('"framework": "jasmine2",');
-    expect(stdout).toMatch('"config": {');
+    expect(stdout).toMatch('"configs": [');
     // config contains many file paths so we cannot do snapshot test
   });
 });

--- a/packages/jest-cli/src/cli/index.js
+++ b/packages/jest-cli/src/cli/index.js
@@ -137,11 +137,11 @@ const _getRunCLIFn = (projects: Array<Path>) =>
 const _printDebugInfoAndExitIfNeeded = (
   argv,
   globalConfig,
-  config,
+  configs,
   outputStream,
 ) => {
   if (argv.debug || argv.showConfig) {
-    logDebugMessages(globalConfig, config, outputStream);
+    logDebugMessages(globalConfig, configs, outputStream);
   }
   if (argv.showConfig) {
     process.exit(0);
@@ -213,7 +213,7 @@ const _getConfigs = (
     throw new Error('jest: No configuration found for any project.');
   }
 
-  _printDebugInfoAndExitIfNeeded(argv, globalConfig, configs[0], outputStream);
+  _printDebugInfoAndExitIfNeeded(argv, globalConfig, configs, outputStream);
 
   return {
     configs,

--- a/packages/jest-cli/src/lib/__tests__/__snapshots__/log_debug_messages.test.js.snap
+++ b/packages/jest-cli/src/lib/__tests__/__snapshots__/log_debug_messages.test.js.snap
@@ -1,0 +1,45 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`prints the config object 1`] = `
+"{
+  \\"configs\\": {
+    \\"rootDir\\": \\"/path/to/dir\\",
+    \\"roots\\": [
+      \\"path/to/dir/test\\"
+    ],
+    \\"testRunner\\": \\"myRunner\\"
+  },
+  \\"globalConfig\\": {
+    \\"automock\\": false,
+    \\"watch\\": true
+  },
+  \\"version\\": 123
+}
+"
+`;
+
+exports[`prints the jest version 1`] = `
+"{
+  \\"configs\\": {
+    \\"testRunner\\": \\"myRunner\\"
+  },
+  \\"globalConfig\\": {
+    \\"watch\\": true
+  },
+  \\"version\\": 123
+}
+"
+`;
+
+exports[`prints the test framework name 1`] = `
+"{
+  \\"configs\\": {
+    \\"testRunner\\": \\"myRunner\\"
+  },
+  \\"globalConfig\\": {
+    \\"watch\\": true
+  },
+  \\"version\\": 123
+}
+"
+`;

--- a/packages/jest-cli/src/lib/__tests__/log_debug_messages.test.js
+++ b/packages/jest-cli/src/lib/__tests__/log_debug_messages.test.js
@@ -4,8 +4,6 @@
 * This source code is licensed under the BSD-style license found in the
 * LICENSE file in the root directory of this source tree. An additional grant
 * of patent rights can be found in the PATENTS file in the same directory.
-*
-* @emails oncall+jsinfra
 */
 
 'use strict';
@@ -16,47 +14,32 @@ jest.mock('../../../package.json', () => ({version: 123}));
 
 jest.mock('myRunner', () => ({name: 'My Runner'}), {virtual: true});
 
-const getPipe = () => ({write: jest.fn()});
-const print = (
-  globalConfig = {watch: true},
-  config = {testRunner: 'myRunner'},
-) =>
-  JSON.stringify(
-    {
-      config,
-      framework: 'My Runner',
-      globalConfig,
-      version: 123,
-    },
-    null,
-    '  ',
-  );
+const getOutputStream = () => ({
+  write(message) {
+    expect(message).toMatchSnapshot();
+  },
+});
 
-describe('logDebugMessages', () => {
-  it('Prints the jest version', () => {
-    const pipe = getPipe();
-    logDebugMessages({watch: true}, {testRunner: 'myRunner'}, pipe);
-    expect(pipe.write).toHaveBeenCalledWith(print() + '\n');
-  });
+it('prints the jest version', () => {
+  expect.assertions(1);
+  logDebugMessages({watch: true}, {testRunner: 'myRunner'}, getOutputStream());
+});
 
-  it('Prints the test framework name', () => {
-    const pipe = getPipe();
-    logDebugMessages({watch: true}, {testRunner: 'myRunner'}, pipe);
-    expect(pipe.write).toHaveBeenCalledWith(print() + '\n');
-  });
+it('prints the test framework name', () => {
+  expect.assertions(1);
+  logDebugMessages({watch: true}, {testRunner: 'myRunner'}, getOutputStream());
+});
 
-  it('Prints the config object', () => {
-    const pipe = getPipe();
-    const globalConfig = {
-      automock: false,
-      watch: true,
-    };
-    const config = {
-      rootDir: '/path/to/dir',
-      roots: ['path/to/dir/test'],
-      testRunner: 'myRunner',
-    };
-    logDebugMessages(globalConfig, config, pipe);
-    expect(pipe.write).toHaveBeenCalledWith(print(globalConfig, config) + '\n');
-  });
+it('prints the config object', () => {
+  expect.assertions(1);
+  const globalConfig = {
+    automock: false,
+    watch: true,
+  };
+  const config = {
+    rootDir: '/path/to/dir',
+    roots: ['path/to/dir/test'],
+    testRunner: 'myRunner',
+  };
+  logDebugMessages(globalConfig, config, getOutputStream());
 });

--- a/packages/jest-cli/src/lib/log_debug_messages.js
+++ b/packages/jest-cli/src/lib/log_debug_messages.js
@@ -9,20 +9,16 @@
  */
 
 import type {GlobalConfig, ProjectConfig} from 'types/Config';
-import type {TestFramework} from 'types/TestRunner';
 
 import {version as VERSION} from '../../package.json';
 
 const logDebugMessages = (
   globalConfig: GlobalConfig,
-  config: ProjectConfig,
+  configs: Array<ProjectConfig>,
   outputStream: stream$Writable | tty$WriteStream,
 ): void => {
-  /* $FlowFixMe */
-  const testFramework = (require(config.testRunner): TestFramework);
   const output = {
-    config,
-    framework: testFramework.name,
+    configs,
     globalConfig,
     version: VERSION,
   };


### PR DESCRIPTION
when running `jest --showConfig` with MPR we only show the first config.
this PR makes it log all project configs