### PR TITLE
Ignore import type for extract_requires

### DIFF
--- a/packages/jest-haste-map/src/lib/__tests__/extract_requires.test.js
+++ b/packages/jest-haste-map/src/lib/__tests__/extract_requires.test.js
@@ -80,4 +80,16 @@ describe('extractRequires', () => {
 
     expect(extractRequires(code)).toEqual(['module1']);
   });
+
+  it('ignores type imports', () => {
+    const code = [
+      "import type foo from 'bar';",
+      "import type {",
+      "  bar,",
+      "  baz,",
+      "} from 'wham'",
+    ].join('\r\n');
+
+    expect(extractRequires(code)).toEqual([]);
+  });
 });

--- a/packages/jest-haste-map/src/lib/extract_requires.js
+++ b/packages/jest-haste-map/src/lib/extract_requires.js
@@ -12,8 +12,8 @@ const blockCommentRe = /\/\*[^]*?\*\//g;
 const lineCommentRe = /\/\/.*/g;
 
 const replacePatterns = {
-  EXPORT_RE: /(\bexport\s+(?:[^'"]+\s+from\s+)??)(['"])([^'"]+)(\2)/g,
-  IMPORT_RE: /(\bimport\s+(?:[^'"]+\s+from\s+)??)(['"])([^'"]+)(\2)/g,
+  EXPORT_RE: /(\bexport\s+(?!type )(?:[^'"]+\s+from\s+)??)(['"])([^'"]+)(\2)/g,
+  IMPORT_RE: /(\bimport\s+(?!type )(?:[^'"]+\s+from\s+)??)(['"])([^'"]+)(\2)/g,
   REQUIRE_EXTENSIONS_PATTERN: /(?:^|[^.]\s*)(\b(?:require\s*?\.\s*?(?:requireActual|requireMock)|jest\s*?\.\s*?genMockFromModule)\s*?\(\s*?)([`'"])([^`'"]+)(\2\s*?\))/g,
   REQUIRE_RE: /(?:^|[^.]\s*)(\brequire\s*?\(\s*?)([`'"])([^`'"]+)(\2\s*?\))/g,
 };


### PR DESCRIPTION
extract_requires shouldn't be looking at dependencies only used for flow types.

**Test plan**

Unit tests
