### PR TITLE
Add a few tests to increase coverage in pretty-format

### DIFF
--- a/packages/pretty-format/src/__tests__/pretty_format.test.js
+++ b/packages/pretty-format/src/__tests__/pretty_format.test.js
@@ -76,10 +76,21 @@ describe('prettyFormat()', () => {
     /* eslint-disable no-new-func */
     const val = new Function();
     /* eslint-enable no-new-func */
+    // In Node 8.1.4: val.name === 'anonymous'
     expect(prettyFormat(val)).toEqual('[Function anonymous]');
   });
 
-  it('prints an anonymous function', () => {
+  it('prints an anonymous callback function', () => {
+    let val;
+    function f(cb) {
+      val = cb;
+    }
+    f(() => {});
+    // In Node 8.1.4: val.name === ''
+    expect(prettyFormat(val)).toEqual('[Function anonymous]');
+  });
+
+  it('prints an anonymous assigned function', () => {
     const val = () => {};
     const formatted = prettyFormat(val);
     // Node 6.5 infers function names
@@ -91,6 +102,15 @@ describe('prettyFormat()', () => {
   it('prints a named function', () => {
     const val = function named() {};
     expect(prettyFormat(val)).toEqual('[Function named]');
+  });
+
+  it('prints a named generator function', () => {
+    const val = function* generate() {
+      yield 1;
+      yield 2;
+      yield 3;
+    };
+    expect(prettyFormat(val)).toEqual('[Function generate]');
   });
 
   it('can customize function names', () => {
@@ -144,9 +164,24 @@ describe('prettyFormat()', () => {
     expect(prettyFormat(val)).toEqual('null');
   });
 
-  it('prints a number', () => {
+  it('prints a positive number', () => {
     const val = 123;
     expect(prettyFormat(val)).toEqual('123');
+  });
+
+  it('prints a negative number', () => {
+    const val = -123;
+    expect(prettyFormat(val)).toEqual('-123');
+  });
+
+  it('prints zero', () => {
+    const val = 0;
+    expect(prettyFormat(val)).toEqual('0');
+  });
+
+  it('prints negative zero', () => {
+    const val = -0;
+    expect(prettyFormat(val)).toEqual('-0');
   });
 
   it('prints a date', () => {


### PR DESCRIPTION
**Summary**

Here’s the residue that I doubt we’ll be able to cover:

* const getSymbols = Object.getOwnPropertySymbols || **(obj => [])**;
* `if (toStringed === '[object Function]' || toStringed === '[object GeneratorFunction]')` because preceded by `typeOf === 'function'`
* `if (toStringed === '[object Symbol]')` because preceded by `typeOf === 'symbol'`
* `if (val instanceof Error)` because preceded by `if (toStringed === '[object Error]')`

**Test plan**

Tests that increase coverage:
* anonymous callback function
* negative zero

Tests that increase peace of mind:
* named generator function (version 4 has basic functionality according to node.green)
* negative number
* zero