### PR TITLE
jest-runtime: atomic cache write, and check validity of data

### DIFF
--- a/packages/jest-runtime/package.json
+++ b/packages/jest-runtime/package.json
@@ -22,6 +22,7 @@
     "json-stable-stringify": "^1.0.1",
     "micromatch": "^2.3.11",
     "strip-bom": "3.0.0",
+    "write-file-atomic": "^2.1.0",
     "yargs": "^7.0.2"
   },
   "devDependencies": {

--- a/packages/jest-runtime/src/__tests__/script_transformer.test.js
+++ b/packages/jest-runtime/src/__tests__/script_transformer.test.js
@@ -9,9 +9,11 @@
  */
 'use strict';
 
+const crypto = require('crypto');
 const slash = require('slash');
 
 jest
+  .mock('fs')
   .mock('graceful-fs')
   .mock('jest-haste-map', () => ({
     getCacheFilePath: (cacheDir, baseDir, version) => cacheDir + baseDir,
@@ -100,6 +102,14 @@ let fs;
 let mockFs;
 let object;
 let vm;
+let writeFileAtomic;
+
+jest.mock('write-file-atomic', () => ({
+  sync: jest.fn().mockImplementation((filePath, data) => {
+    const normalizedPath = require('slash')(filePath);
+    mockFs[normalizedPath] = data;
+  }),
+}));
 
 describe('ScriptTransformer', () => {
   const reset = () => {
@@ -144,6 +154,8 @@ describe('ScriptTransformer', () => {
     }));
 
     fs.existsSync = jest.fn(path => !!mockFs[path]);
+
+    writeFileAtomic = require('write-file-atomic');
 
     config = {
       cache: true,
@@ -290,11 +302,10 @@ describe('ScriptTransformer', () => {
       mapCoverage: true,
     });
     expect(result.sourceMapPath).toEqual(expect.any(String));
-    expect(fs.writeFileSync).toBeCalledWith(
-      result.sourceMapPath,
-      JSON.stringify(map),
-      'utf8',
-    );
+    const mapStr = JSON.stringify(map);
+    expect(writeFileAtomic.sync).toBeCalledWith(result.sourceMapPath, mapStr, {
+      encoding: 'utf8',
+    });
   });
 
   it('writes source map if preprocessor inlines it', () => {
@@ -320,11 +331,9 @@ describe('ScriptTransformer', () => {
       mapCoverage: true,
     });
     expect(result.sourceMapPath).toEqual(expect.any(String));
-    expect(fs.writeFileSync).toBeCalledWith(
-      result.sourceMapPath,
-      sourceMap,
-      'utf8',
-    );
+    expect(
+      writeFileAtomic.sync,
+    ).toBeCalledWith(result.sourceMapPath, sourceMap, {encoding: 'utf8'});
   });
 
   it('does not write source map if mapCoverage option is false', () => {
@@ -348,7 +357,7 @@ describe('ScriptTransformer', () => {
       mapCoverage: false,
     });
     expect(result.sourceMapPath).toBeFalsy();
-    expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
+    expect(writeFileAtomic.sync).toHaveBeenCalledTimes(1);
   });
 
   it('reads values from the cache', () => {
@@ -359,8 +368,8 @@ describe('ScriptTransformer', () => {
     scriptTransformer.transform('/fruits/banana.js', {});
 
     const cachePath = getCachePath(mockFs, config);
-    expect(fs.writeFileSync).toBeCalled();
-    expect(fs.writeFileSync.mock.calls[0][0]).toBe(cachePath);
+    expect(writeFileAtomic.sync).toBeCalled();
+    expect(writeFileAtomic.sync.mock.calls[0][0]).toBe(cachePath);
 
     // Cache the state in `mockFsCopy`
     const mockFsCopy = mockFs;
@@ -375,7 +384,7 @@ describe('ScriptTransformer', () => {
     expect(fs.readFileSync.mock.calls.length).toBe(2);
     expect(fs.readFileSync).toBeCalledWith('/fruits/banana.js', 'utf8');
     expect(fs.readFileSync).toBeCalledWith(cachePath, 'utf8');
-    expect(fs.writeFileSync).not.toBeCalled();
+    expect(writeFileAtomic.sync).not.toBeCalled();
 
     // Don't read from the cache when `config.cache` is false.
     jest.resetModuleRegistry();
@@ -388,6 +397,6 @@ describe('ScriptTransformer', () => {
     expect(fs.readFileSync.mock.calls.length).toBe(1);
     expect(fs.readFileSync).toBeCalledWith('/fruits/banana.js', 'utf8');
     expect(fs.readFileSync).not.toBeCalledWith(cachePath, 'utf8');
-    expect(fs.writeFileSync).toBeCalled();
+    expect(writeFileAtomic.sync).toBeCalled();
   });
 });


### PR DESCRIPTION
This change tries to address what may be a cause for #1874, where I posted some details on the approach. By doing atomic writes we ensure there's no cache file ending up being a mix of two transformed code files, and we limit the concurrency issues of having a file read and written at the same time. A prior PR #3561 tries to address the problem using a lock, but locks bring additional complexity that this change tries to avoid (ex. deadlocks).

This change also adds a checksum, because there can be other processes still writing non-atomically to cache files. Additional, not all filesystems may support atomic renames (what `atomic-write-file` relies on).

This change incurs a slight performance cost that is the additional I/O call to rename the files. However I believe it is less costly than a lock solution. I don't think this should have much effect even on processing several thousands of files.

**Test plan**

It is quite challenging to test for concurrency issues, so this change relies on the knowledge that `writeFileSync` is not atomic and that corruption could have the observed effects. I rely on the existing automated testing to ensure that the caching behaviour and `jest-runtime` in general is working as expected.
