### PR TITLE
Rewrite some read bumps in pretty-format

### DIFF
--- a/packages/pretty-format/src/index.js
+++ b/packages/pretty-format/src/index.js
@@ -152,7 +152,7 @@ function printBasicValue(
   return null;
 }
 
-function printList(
+function printListItems(
   list: any,
   config: Config,
   indentation: string,
@@ -183,7 +183,7 @@ function printList(
   return result;
 }
 
-function printMap(
+function printMapEntries(
   val: Map<any, any>,
   config: Config,
   indentation: string,
@@ -232,7 +232,7 @@ function printMap(
   return result;
 }
 
-function printObject(
+function printObjectProperties(
   val: Object,
   config: Config,
   indentation: string,
@@ -272,7 +272,7 @@ function printObject(
   return result;
 }
 
-function printSet(
+function printSetValues(
   val: Set<any>,
   config: Config,
   indentation: string,
@@ -339,7 +339,7 @@ function printComplexValue(
       ? '[Arguments]'
       : (min ? '' : 'Arguments ') +
         '[' +
-        printList(val, config, indentation, depth, refs) +
+        printListItems(val, config, indentation, depth, refs) +
         ']';
   }
   if (isToStringedArrayType(toStringed)) {
@@ -347,25 +347,25 @@ function printComplexValue(
       ? '[' + val.constructor.name + ']'
       : (min ? '' : val.constructor.name + ' ') +
         '[' +
-        printList(val, config, indentation, depth, refs) +
+        printListItems(val, config, indentation, depth, refs) +
         ']';
   }
   if (toStringed === '[object Map]') {
     return hitMaxDepth
       ? '[Map]'
-      : 'Map {' + printMap(val, config, indentation, depth, refs) + '}';
+      : 'Map {' + printMapEntries(val, config, indentation, depth, refs) + '}';
   }
   if (toStringed === '[object Set]') {
     return hitMaxDepth
       ? '[Set]'
-      : 'Set {' + printSet(val, config, indentation, depth, refs) + '}';
+      : 'Set {' + printSetValues(val, config, indentation, depth, refs) + '}';
   }
 
   return hitMaxDepth
     ? '[' + (val.constructor ? val.constructor.name : 'Object') + ']'
     : (min ? '' : (val.constructor ? val.constructor.name : 'Object') + ' ') +
       '{' +
-      printObject(val, config, indentation, depth, refs) +
+      printObjectProperties(val, config, indentation, depth, refs) +
       '}';
 }
 

--- a/packages/pretty-format/src/index.js
+++ b/packages/pretty-format/src/index.js
@@ -73,7 +73,7 @@ function printFunction(val: Function, printFunctionName: boolean): string {
   if (!printFunctionName) {
     return '[Function]';
   }
-  return '[Function ' + (val.name ? val.name : 'anonymous') + ']';
+  return '[Function ' + (val.name || 'anonymous') + ']';
 }
 
 function printSymbol(val: Symbol): string {


### PR DESCRIPTION
**Summary**

Rewrite some small bumps that have distracted me from understanding the big picture:

* Restructure the minority of exceptions to [no-else-return](http://eslint.org/docs/rules/no-else-return) rule (and `else if return` structure) to follow same pattern as the majority of conditional returns. Thinking forward to future code changes, the simple `if return` structure provides a **minimal diff** like trailing comma.
* Replace `key` with `name` in `printMap` to be parallel with `printObject`
* Replace `entries` with `values` iterator in `printSet`
* Replace `refs.indexOf(val) > -1` with `refs.indexOf(val) !== -1` in `printComplexValue`
* Move `refs.slice()` after `if return` in `printComplexValue`

To help future readers understand the recently refactored helper functions:

* Replace `printList` with `printListItems`
* Replace `printMap` with `printMapEntries`
* Replace `printObject` with `printObjectProperties`
* Replace `printSet` with `printSetValues`

For your info: **goals for next week**

* Provide alternative plugin `serialize` API which includes `indentation`, `depth`, and `refs` args
* Convert standard plugins to alternative `serialize` API
* Factor out common code in `HTMLElement`, `ReactElement`, and `ReactTestComponent`
* Improve test coverage of plugins, if needed

**Test plan**

Jest