### PR TITLE
Update: disable `no-console` lint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -104,6 +104,7 @@ module.exports = {
     // This has to be disabled until all type and module imports are combined
     // https://github.com/benmosher/eslint-plugin-import/issues/645
     'import/order': 0,
+    'no-console': 0,
     'prettier/prettier': [
       2,
       {


### PR DESCRIPTION
**Summary**

We have 63 warnings from `no-console` rule and since this is a command-line tool, we'll likely have more usage for `console.log`. Disabling the rule to cut the noise.

**Test plan**

Run `yarn lint` and make sure you see no errors nor warnings.