### PR TITLE
Don't print test summary in --silent

### DIFF
--- a/integration_tests/__tests__/__snapshots__/console.test.js.snap
+++ b/integration_tests/__tests__/__snapshots__/console.test.js.snap
@@ -71,6 +71,5 @@ exports[`does not print to console with --silent 3`] = `
 Tests:       1 passed, 1 total
 Snapshots:   0 total
 Time:        <<REPLACED>>
-Ran all test suites.
 "
 `;

--- a/integration_tests/utils.js
+++ b/integration_tests/utils.js
@@ -120,7 +120,7 @@ const createEmptyPackage = (directory, packageJson) => {
 
 const extractSummary = stdout => {
   const match = stdout.match(
-    /Test Suites:.*\nTests.*\nSnapshots.*\nTime.*\nRan all test suites.*\n*$/gm,
+    /Test Suites:.*\nTests.*\nSnapshots.*\nTime.*(\nRan all test suites)*.*\n*$/gm,
   );
   if (!match) {
     throw new Error(

--- a/packages/jest-cli/src/reporters/summary_reporter.js
+++ b/packages/jest-cli/src/reporters/summary_reporter.js
@@ -106,16 +106,18 @@ class SummaryReporter extends BaseReporter {
       );
 
       if (numTotalTestSuites) {
-        const testSummary = wasInterrupted
-          ? chalk.bold.red('Test run was interrupted.')
-          : this._getTestSummary(contexts, this._globalConfig);
-        this.log(
-          getSummary(aggregatedResults, {
-            estimatedTime: this._estimatedTime,
-          }) +
+        let message = getSummary(aggregatedResults, {
+          estimatedTime: this._estimatedTime,
+        });
+
+        if (!this._globalConfig.silent) {
+          message +=
             '\n' +
-            testSummary,
-        );
+            (wasInterrupted
+              ? chalk.bold.red('Test run was interrupted.')
+              : this._getTestSummary(contexts, this._globalConfig));
+        }
+        this.log(message);
       }
     }
   }


### PR DESCRIPTION
this is probably not the best solution. Because of the way we run test with `arc` in www, summary reporter prints a very long message at the end
```
ran all tests matching <VERY_LONG_STRING_WITH_ALL_FILES_CHANGED_IN_THIS_DIFF>
```