### PR TITLE
remove @providesModule from skipOnWindows

### DIFF
--- a/integration_tests/__tests__/babel_plugin_jest_hoist.test.js
+++ b/integration_tests/__tests__/babel_plugin_jest_hoist.test.js
@@ -10,7 +10,7 @@
 'use strict';
 
 const path = require('path');
-const skipOnWindows = require('skipOnWindows');
+const skipOnWindows = require('../../scripts/skip_on_windows');
 const {run} = require('../utils');
 const runJest = require('../runJest');
 

--- a/integration_tests/__tests__/compare_dom_nodes.test.js
+++ b/integration_tests/__tests__/compare_dom_nodes.test.js
@@ -9,7 +9,7 @@
  */
 'use strict';
 
-const skipOnWindows = require('skipOnWindows');
+const skipOnWindows = require('../../scripts/skip_on_windows');
 const runJest = require('../runJest');
 
 skipOnWindows.suite();

--- a/integration_tests/__tests__/console.test.js
+++ b/integration_tests/__tests__/console.test.js
@@ -9,7 +9,7 @@
  */
 'use strict';
 
-const skipOnWindows = require('skipOnWindows');
+const skipOnWindows = require('../../scripts/skip_on_windows');
 const {extractSummary} = require('../utils');
 const runJest = require('../runJest');
 

--- a/integration_tests/__tests__/console_log_output_when_run_in_band.test.js
+++ b/integration_tests/__tests__/console_log_output_when_run_in_band.test.js
@@ -9,7 +9,7 @@
 'use strict';
 
 const path = require('path');
-const skipOnWindows = require('skipOnWindows');
+const skipOnWindows = require('../../scripts/skip_on_windows');
 const {extractSummary, cleanup, writeFiles} = require('../utils');
 const runJest = require('../runJest');
 

--- a/integration_tests/__tests__/coverage_remapping.test.js
+++ b/integration_tests/__tests__/coverage_remapping.test.js
@@ -10,7 +10,7 @@
 
 const {readFileSync} = require('fs');
 const path = require('path');
-const skipOnWindows = require('skipOnWindows');
+const skipOnWindows = require('../../scripts/skip_on_windows');
 const {run} = require('../utils');
 const runJest = require('../runJest');
 

--- a/integration_tests/__tests__/coverage_report.test.js
+++ b/integration_tests/__tests__/coverage_report.test.js
@@ -11,7 +11,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const skipOnWindows = require('skipOnWindows');
+const skipOnWindows = require('../../scripts/skip_on_windows');
 const {extractSummary} = require('../utils');
 const runJest = require('../runJest');
 

--- a/integration_tests/__tests__/coverage_threshold.test.js
+++ b/integration_tests/__tests__/coverage_threshold.test.js
@@ -9,7 +9,7 @@
 'use strict';
 
 const path = require('path');
-const skipOnWindows = require('skipOnWindows');
+const skipOnWindows = require('../../scripts/skip_on_windows');
 const {cleanup, writeFiles} = require('../utils');
 const runJest = require('../runJest');
 

--- a/integration_tests/__tests__/custom_reporters.test.js
+++ b/integration_tests/__tests__/custom_reporters.test.js
@@ -7,7 +7,7 @@
  */
 'use strict';
 
-const skipOnWindows = require('skipOnWindows');
+const skipOnWindows = require('../../scripts/skip_on_windows');
 const {cleanup, extractSummary, writeFiles} = require('../utils');
 const runJest = require('../runJest');
 const os = require('os');

--- a/integration_tests/__tests__/debug.test.js
+++ b/integration_tests/__tests__/debug.test.js
@@ -7,7 +7,7 @@
  */
 
 const path = require('path');
-const skipOnWindows = require('skipOnWindows');
+const skipOnWindows = require('../../scripts/skip_on_windows');
 const runJest = require('../runJest');
 
 describe('jest --debug', () => {

--- a/integration_tests/__tests__/failures.test.js
+++ b/integration_tests/__tests__/failures.test.js
@@ -7,7 +7,7 @@
  */
 
 const path = require('path');
-const skipOnWindows = require('skipOnWindows');
+const skipOnWindows = require('../../scripts/skip_on_windows');
 const {extractSummary} = require('../utils');
 const runJest = require('../runJest');
 

--- a/integration_tests/__tests__/force_exit.test.js
+++ b/integration_tests/__tests__/force_exit.test.js
@@ -13,7 +13,7 @@ import {cleanup, extractSummary, writeFiles} from '../utils';
 import os from 'os';
 import path from 'path';
 
-const skipOnWindows = require('skipOnWindows');
+const skipOnWindows = require('../../scripts/skip_on_windows');
 const DIR = path.resolve(os.tmpdir(), 'force_exit_test');
 
 skipOnWindows.suite();

--- a/integration_tests/__tests__/globals.test.js
+++ b/integration_tests/__tests__/globals.test.js
@@ -10,7 +10,7 @@
 
 const path = require('path');
 const os = require('os');
-const skipOnWindows = require('skipOnWindows');
+const skipOnWindows = require('../../scripts/skip_on_windows');
 const runJest = require('../runJest');
 const {extractSummary} = require('../utils');
 const {createEmptyPackage, writeFiles, cleanup} = require('../utils');

--- a/integration_tests/__tests__/jest.config.js.test.js
+++ b/integration_tests/__tests__/jest.config.js.test.js
@@ -9,7 +9,7 @@
 'use strict';
 
 const path = require('path');
-const skipOnWindows = require('skipOnWindows');
+const skipOnWindows = require('../../scripts/skip_on_windows');
 const {extractSummary, cleanup, writeFiles} = require('../utils');
 const runJest = require('../runJest');
 

--- a/integration_tests/__tests__/jest_changed_files.test.js
+++ b/integration_tests/__tests__/jest_changed_files.test.js
@@ -16,7 +16,7 @@ import {
   getChangedFilesForRoots,
 } from '../../packages/jest-changed-files/src';
 
-const skipOnWindows = require('skipOnWindows');
+const skipOnWindows = require('../../scripts/skip_on_windows');
 skipOnWindows.suite();
 
 const DIR = path.resolve(os.tmpdir(), 'jest_changed_files_test_dir');

--- a/integration_tests/__tests__/module_name_mapper.test.js
+++ b/integration_tests/__tests__/module_name_mapper.test.js
@@ -9,7 +9,7 @@
 
 const runJest = require('../runJest');
 const {extractSummary} = require('../utils');
-const skipOnWindows = require('skipOnWindows');
+const skipOnWindows = require('../../scripts/skip_on_windows');
 
 // Works on windows, we just need to adjust snapshot test output
 skipOnWindows.suite();

--- a/integration_tests/__tests__/multi_project_runner.test.js
+++ b/integration_tests/__tests__/multi_project_runner.test.js
@@ -13,7 +13,7 @@ import {cleanup, extractSummary, writeFiles} from '../utils';
 import os from 'os';
 import path from 'path';
 
-const skipOnWindows = require('skipOnWindows');
+const skipOnWindows = require('../../scripts/skip_on_windows');
 const DIR = path.resolve(os.tmpdir(), 'multi_project_runner_test');
 
 skipOnWindows.suite();

--- a/integration_tests/__tests__/native_async_mock.test.js
+++ b/integration_tests/__tests__/native_async_mock.test.js
@@ -9,7 +9,7 @@
 'use strict';
 
 const path = require('path');
-const skipOnWindows = require('skipOnWindows');
+const skipOnWindows = require('../../scripts/skip_on_windows');
 const {run, extractSummary} = require('../utils');
 const runJest = require('../runJest');
 

--- a/integration_tests/__tests__/only_changed.test.js
+++ b/integration_tests/__tests__/only_changed.test.js
@@ -13,7 +13,7 @@ import {cleanup, run, writeFiles} from '../utils';
 import os from 'os';
 import path from 'path';
 
-const skipOnWindows = require('skipOnWindows');
+const skipOnWindows = require('../../scripts/skip_on_windows');
 const DIR = path.resolve(os.tmpdir(), 'jest_only_changed');
 const GIT = 'git -c user.name=jest_test -c user.email=jest_test@test.com';
 const HG = 'hg --config ui.username=jest_test';

--- a/integration_tests/__tests__/regex_(char_in_path.test.js
+++ b/integration_tests/__tests__/regex_(char_in_path.test.js
@@ -9,7 +9,7 @@
  */
 'use strict';
 
-const skipOnWindows = require('skipOnWindows');
+const skipOnWindows = require('../../scripts/skip_on_windows');
 const runJest = require('../runJest');
 
 describe('Regex Char In Path', () => {

--- a/integration_tests/__tests__/show_config.test.js
+++ b/integration_tests/__tests__/show_config.test.js
@@ -9,7 +9,7 @@
 'use strict';
 
 const path = require('path');
-const skipOnWindows = require('skipOnWindows');
+const skipOnWindows = require('../../scripts/skip_on_windows');
 const runJest = require('../runJest');
 const os = require('os');
 const {cleanup, writeFiles} = require('../utils');

--- a/integration_tests/__tests__/snapshot.test.js
+++ b/integration_tests/__tests__/snapshot.test.js
@@ -14,7 +14,7 @@ const path = require('path');
 const {extractSummary} = require('../utils');
 const runJest = require('../runJest');
 
-const skipOnWindows = require('skipOnWindows');
+const skipOnWindows = require('../../scripts/skip_on_windows');
 skipOnWindows.suite();
 
 const emptyTest = 'describe("", () => {it("", () => {})})';

--- a/integration_tests/__tests__/test_failure_exit_code.test.js
+++ b/integration_tests/__tests__/test_failure_exit_code.test.js
@@ -10,7 +10,7 @@
 
 const path = require('path');
 const os = require('os');
-const skipOnWindows = require('skipOnWindows');
+const skipOnWindows = require('../../scripts/skip_on_windows');
 const {cleanup, writeFiles} = require('../utils');
 const runJest = require('../runJest');
 

--- a/integration_tests/__tests__/test_path_pattern_reporter_message.test.js
+++ b/integration_tests/__tests__/test_path_pattern_reporter_message.test.js
@@ -13,7 +13,7 @@ import {cleanup, writeFiles} from '../utils';
 import os from 'os';
 import path from 'path';
 
-const skipOnWindows = require('skipOnWindows');
+const skipOnWindows = require('../../scripts/skip_on_windows');
 const DIR = path.resolve(os.tmpdir(), 'jest_path_pattern_reporter_message');
 
 skipOnWindows.suite();

--- a/integration_tests/__tests__/timeouts.test.js
+++ b/integration_tests/__tests__/timeouts.test.js
@@ -9,7 +9,7 @@
 'use strict';
 
 const path = require('path');
-const skipOnWindows = require('skipOnWindows');
+const skipOnWindows = require('../../scripts/skip_on_windows');
 const {extractSummary, cleanup, writeFiles} = require('../utils');
 const runJest = require('../runJest');
 

--- a/integration_tests/__tests__/transform.test.js
+++ b/integration_tests/__tests__/transform.test.js
@@ -7,7 +7,7 @@
  */
 
 const path = require('path');
-const skipOnWindows = require('skipOnWindows');
+const skipOnWindows = require('../../scripts/skip_on_windows');
 const {
   run,
   cleanup,

--- a/integration_tests/__tests__/typescript_coverage.test.js
+++ b/integration_tests/__tests__/typescript_coverage.test.js
@@ -7,7 +7,7 @@
  */
 
 const path = require('path');
-const skipOnWindows = require('skipOnWindows');
+const skipOnWindows = require('../../scripts/skip_on_windows');
 const {run} = require('../utils');
 const runJest = require('../runJest');
 

--- a/integration_tests/__tests__/use_stderr.test.js
+++ b/integration_tests/__tests__/use_stderr.test.js
@@ -13,7 +13,7 @@ import {cleanup, writeFiles} from '../utils';
 import os from 'os';
 import path from 'path';
 
-const skipOnWindows = require('skipOnWindows');
+const skipOnWindows = require('../../scripts/skip_on_windows');
 const DIR = path.resolve(os.tmpdir(), 'use_stderr_test');
 
 skipOnWindows.suite();

--- a/integration_tests/__tests__/version.test.js
+++ b/integration_tests/__tests__/version.test.js
@@ -4,13 +4,15 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
  */
 
 'use strict';
 
 const path = require('path');
 const os = require('os');
-const skipOnWindows = require('skipOnWindows');
+const skipOnWindows = require('../../scripts/skip_on_windows');
 const {cleanup, writeFiles} = require('../utils');
 const runJest = require('../runJest');
 

--- a/packages/jest-cli/src/__tests__/search_source.test.js
+++ b/packages/jest-cli/src/__tests__/search_source.test.js
@@ -12,7 +12,7 @@
 jest.setTimeout(15000);
 
 const path = require('path');
-const skipOnWindows = require('skipOnWindows');
+const skipOnWindows = require('../../../../scripts/skip_on_windows');
 
 const rootDir = path.resolve(__dirname, 'test_root');
 const testRegex = path.sep + '__testtests__' + path.sep;

--- a/packages/jest-haste-map/src/__tests__/index.test.js
+++ b/packages/jest-haste-map/src/__tests__/index.test.js
@@ -88,7 +88,7 @@ jest.mock('graceful-fs', () => ({
 }));
 jest.mock('fs', () => require('graceful-fs'));
 
-const skipOnWindows = require('skipOnWindows');
+const skipOnWindows = require('../../../../scripts/skip_on_windows');
 
 const cacheFilePath = '/cache-file';
 let consoleWarn;

--- a/packages/jest-haste-map/src/__tests__/worker.test.js
+++ b/packages/jest-haste-map/src/__tests__/worker.test.js
@@ -11,7 +11,7 @@
 
 const path = require('path');
 const fs = require('graceful-fs');
-const skipOnWindows = require('skipOnWindows');
+const skipOnWindows = require('../../../../scripts/skip_on_windows');
 
 const H = require('../constants');
 const worker = require('../worker');

--- a/packages/jest-haste-map/src/crawlers/__tests__/node.test.js
+++ b/packages/jest-haste-map/src/crawlers/__tests__/node.test.js
@@ -9,7 +9,7 @@
  */
 'use strict';
 
-const skipOnWindows = require('skipOnWindows');
+const skipOnWindows = require('../../../../../scripts/skip_on_windows');
 
 jest.mock('child_process', () => ({
   spawn: jest.fn((cmd, args) => {

--- a/packages/jest-haste-map/src/crawlers/__tests__/watchman.test.js
+++ b/packages/jest-haste-map/src/crawlers/__tests__/watchman.test.js
@@ -9,7 +9,7 @@
  */
 'use strict';
 
-const skipOnWindows = require('skipOnWindows');
+const skipOnWindows = require('../../../../../scripts/skip_on_windows');
 
 jest.mock('fb-watchman', () => {
   const Client = jest.fn();

--- a/packages/jest-repl/src/__tests__/jest_repl.test.js
+++ b/packages/jest-repl/src/__tests__/jest_repl.test.js
@@ -5,13 +5,12 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @emails oncall+jsinfra
  */
 'use strict';
 
 const {spawnSync} = require('child_process');
 const path = require('path');
-const skipOnWindows = require('skipOnWindows');
+const skipOnWindows = require('../../../../scripts/skip_on_windows');
 
 const JEST_RUNTIME = path.resolve(__dirname, '../../bin/jest-repl.js');
 

--- a/scripts/skip_on_windows.js
+++ b/scripts/skip_on_windows.js
@@ -6,7 +6,6 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  *
  * @flow
- * @providesModule skipOnWindows
  */
 
 /* eslint-disable jest/no-focused-tests */


### PR DESCRIPTION
i started looking into flow + mocking system and how to make jest more flow compatible.
I'm going to try to flowtype jest codebase first. This file is the only one that uses @providesModule and removing it will greatly simplify flow configuration