### PR TITLE
basic test utilities

### DIFF
--- a/packages/jest-cli/src/__tests__/generate_empty_coverage.test.js
+++ b/packages/jest-cli/src/__tests__/generate_empty_coverage.test.js
@@ -5,15 +5,17 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @emails oncall+jsinfra
+ * @flow
  */
 'use strict';
 
 const os = require('os');
 
 const generateEmptyCoverage = require('../generate_empty_coverage');
+const {makeGlobalConfig, makeProjectConfig} = require('../../../../test_utils');
 
 jest.mock('jest-runtime', () => {
+  // $FlowFixMe requireActual
   const realRuntime = require.requireActual('jest-runtime');
   realRuntime.shouldInstrument = () => true;
   return realRuntime;
@@ -35,15 +37,14 @@ module.exports = {
 };`;
 
 it('generates an empty coverage object for a file without running it', () => {
-  expect(
-    generateEmptyCoverage(
-      src,
-      '/sum.js',
-      {},
-      {
-        cacheDirectory: os.tmpdir(),
-        rootDir: os.tmpdir(),
-      },
-    ).coverage,
-  ).toMatchSnapshot();
+  const emptyCoverage = generateEmptyCoverage(
+    src,
+    '/sum.js',
+    makeGlobalConfig(),
+    makeProjectConfig({
+      cacheDirectory: os.tmpdir(),
+      rootDir: os.tmpdir(),
+    }),
+  );
+  expect(emptyCoverage && emptyCoverage.coverage).toMatchSnapshot();
 });

--- a/packages/jest-cli/src/__tests__/globals.test.js
+++ b/packages/jest-cli/src/__tests__/globals.test.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @emails oncall+jsinfra
+ * @flow
  */
 'use strict';
 

--- a/packages/jest-cli/src/lib/__tests__/format_test_name_by_pattern.test.js
+++ b/packages/jest-cli/src/lib/__tests__/format_test_name_by_pattern.test.js
@@ -5,7 +5,7 @@
 * LICENSE file in the root directory of this source tree. An additional grant
 * of patent rights can be found in the PATENTS file in the same directory.
 *
-* @emails oncall+jsinfra
+* @flow
 */
 
 'use strict';

--- a/packages/jest-cli/src/lib/__tests__/highlight.test.js
+++ b/packages/jest-cli/src/lib/__tests__/highlight.test.js
@@ -5,7 +5,7 @@
 * LICENSE file in the root directory of this source tree. An additional grant
 * of patent rights can be found in the PATENTS file in the same directory.
 *
-* @emails oncall+jsinfra
+* @flow
 */
 
 'use strict';

--- a/packages/jest-cli/src/lib/__tests__/is_valid_path.test.js
+++ b/packages/jest-cli/src/lib/__tests__/is_valid_path.test.js
@@ -5,34 +5,41 @@
 * LICENSE file in the root directory of this source tree. An additional grant
 * of patent rights can be found in the PATENTS file in the same directory.
 *
-* @emails oncall+jsinfra
+* @flow
 */
 
 const path = require('path');
 const isValidPath = require('../is_valid_path');
-const {normalize} = require('jest-config');
+const {
+  makeGlobalConfig,
+  makeProjectConfig,
+} = require('../../../../../test_utils');
 
 const rootDir = path.resolve(path.sep, 'root');
 
-const config = {
+const config = makeProjectConfig({
   rootDir,
   roots: [path.resolve(rootDir, 'src'), path.resolve(rootDir, 'lib')],
-};
+});
 
 it('is valid when it is a file inside roots', () => {
   expect(
-    isValidPath({}, config, path.resolve(rootDir, 'src', 'index.js')),
+    isValidPath(
+      makeGlobalConfig(),
+      config,
+      path.resolve(rootDir, 'src', 'index.js'),
+    ),
   ).toBe(true);
   expect(
     isValidPath(
-      {},
+      makeGlobalConfig(),
       config,
       path.resolve(rootDir, 'src', 'components', 'Link.js'),
     ),
   ).toBe(true);
   expect(
     isValidPath(
-      {},
+      makeGlobalConfig(),
       config,
       path.resolve(rootDir, 'src', 'lib', 'something.js'),
     ),
@@ -41,18 +48,22 @@ it('is valid when it is a file inside roots', () => {
 
 it('is not valid when it is a snapshot file', () => {
   expect(
-    isValidPath({}, config, path.resolve(rootDir, 'src', 'index.js.snap')),
+    isValidPath(
+      makeGlobalConfig(),
+      config,
+      path.resolve(rootDir, 'src', 'index.js.snap'),
+    ),
   ).toBe(false);
   expect(
     isValidPath(
-      {},
+      makeGlobalConfig(),
       config,
       path.resolve(rootDir, 'src', 'components', 'Link.js.snap'),
     ),
   ).toBe(false);
   expect(
     isValidPath(
-      {},
+      makeGlobalConfig(),
       config,
       path.resolve(rootDir, 'src', 'lib', 'something.js.snap'),
     ),
@@ -62,7 +73,7 @@ it('is not valid when it is a snapshot file', () => {
 it('is not valid when it is a file in the coverage dir', () => {
   expect(
     isValidPath(
-      normalize({rootDir}, {}).options,
+      makeGlobalConfig({rootDir}),
       config,
       path.resolve(rootDir, 'coverage', 'lib', 'index.js'),
     ),
@@ -70,7 +81,7 @@ it('is not valid when it is a file in the coverage dir', () => {
 
   expect(
     isValidPath(
-      {coverageDirectory: 'cov-dir'},
+      makeGlobalConfig({coverageDirectory: 'cov-dir'}),
       config,
       path.resolve(rootDir, 'src', 'cov-dir', 'lib', 'index.js'),
     ),

--- a/test_utils.js
+++ b/test_utils.js
@@ -1,0 +1,127 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+
+'use strict';
+
+import type {GlobalConfig, ProjectConfig} from 'types/Config';
+
+const DEFAULT_GLOBAL_CONFIG: GlobalConfig = {
+  bail: false,
+  changedFilesWithAncestor: false,
+  collectCoverage: false,
+  collectCoverageFrom: [],
+  collectCoverageOnlyFrom: null,
+  coverageDirectory: 'coverage',
+  coverageReporters: [],
+  coverageThreshold: {global: {}},
+  expand: false,
+  forceExit: false,
+  json: false,
+  lastCommit: false,
+  listTests: false,
+  logHeapUsage: false,
+  mapCoverage: false,
+  maxWorkers: 2,
+  noSCM: null,
+  noStackTrace: false,
+  nonFlagArgs: [],
+  notify: false,
+  onlyChanged: false,
+  outputFile: null,
+  projects: [],
+  replname: null,
+  reporters: [],
+  rootDir: '/test_root_dir/',
+  silent: false,
+  testFailureExitCode: 1,
+  testNamePattern: '',
+  testPathPattern: '',
+  testResultsProcessor: null,
+  updateSnapshot: 'none',
+  useStderr: false,
+  verbose: false,
+  watch: false,
+  watchAll: false,
+  watchman: false,
+};
+
+const DEFAULT_PROJECT_CONFIG: ProjectConfig = {
+  automock: false,
+  browser: false,
+  cache: false,
+  cacheDirectory: '/test_cache_dir/',
+  clearMocks: false,
+  coveragePathIgnorePatterns: [],
+  globals: {},
+  haste: {
+    providesModuleNodeModules: [],
+  },
+  moduleDirectories: [],
+  moduleFileExtensions: ['js'],
+  moduleLoader: '/test_module_loader_path',
+  moduleNameMapper: [],
+  modulePathIgnorePatterns: [],
+  modulePaths: [],
+  name: 'test_name',
+  resetMocks: false,
+  resetModules: false,
+  resolver: null,
+  rootDir: '/test_root_dir/',
+  roots: [],
+  setupFiles: [],
+  setupTestFrameworkScriptFile: null,
+  skipNodeResolution: false,
+  snapshotSerializers: [],
+  testEnvironment: 'node',
+  testMatch: [],
+  testPathIgnorePatterns: [],
+  testRegex: '.test.js$',
+  testRunner: 'jest-jasmine2',
+  testURL: '',
+  timers: 'real',
+  transform: [],
+  transformIgnorePatterns: [],
+  unmockedModulePathPatterns: null,
+};
+
+const makeGlobalConfig = (overrides: Object = {}): GlobalConfig => {
+  const overridesKeys = new Set(Object.keys(overrides));
+  Object.keys(DEFAULT_GLOBAL_CONFIG).forEach(key => overridesKeys.delete(key));
+
+  if (overridesKeys.size > 0) {
+    throw new Error(`
+      Properties that are not part of GlobalConfig type were passed:
+      ${JSON.stringify(Array.from(overridesKeys))}
+    `);
+  }
+
+  // $FlowFixMe Object.assign
+  return Object.assign({}, DEFAULT_GLOBAL_CONFIG, overrides);
+};
+
+const makeProjectConfig = (overrides: Object = {}): ProjectConfig => {
+  const overridesKeys = new Set(Object.keys(overrides));
+  Object.keys(DEFAULT_PROJECT_CONFIG).forEach(key => overridesKeys.delete(key));
+
+  if (overridesKeys.size > 0) {
+    throw new Error(`
+      Properties that are not part of ProjectConfig type were passed:
+      ${JSON.stringify(Array.from(overridesKeys))}
+    `);
+  }
+
+  // $FlowFixMe Object.assign
+  return Object.assign({}, DEFAULT_PROJECT_CONFIG, overrides);
+};
+
+module.exports = {
+  makeGlobalConfig,
+  makeProjectConfig,
+};

--- a/types/Config.js
+++ b/types/Config.js
@@ -196,7 +196,7 @@ export type ProjectConfig = {|
   rootDir: Path,
   roots: Array<Path>,
   setupFiles: Array<Path>,
-  setupTestFrameworkScriptFile: Path,
+  setupTestFrameworkScriptFile: ?Path,
   skipNodeResolution: boolean,
   snapshotSerializers: Array<Path>,
   testEnvironment: string,


### PR DESCRIPTION
a lot of times we test our modules using data structures incompatible with what the module is expecting.
for example we often pass `{rootDir: 'test'}` into a function that expects full `globalConfig` object with all it's values set.

most of the time it is ok, but
1. We can't flowtype those tests and with that we lose a lot of signal that can prevent bugs.
2. this is not a real world scenario, and potentially it can result in a green test that would never pass in the real world

this set of test utils provides two methods for generating a default project/global config with default values that can be overwritten