### PR TITLE
supprots-color@4.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "slash": "^1.0.0",
     "string-length": "^1.0.1",
     "strip-ansi": "^4.0.0",
+    "supports-color": "^4.2.1",
     "typescript": "^2.2.2"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5700,6 +5700,12 @@ supports-color@^4.0.0:
   dependencies:
     has-flag "^2.0.0"
 
+supports-color@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.2.1.tgz#65a4bb2631e90e02420dba5554c375a4754bb836"
+  dependencies:
+    has-flag "^2.0.0"
+
 symbol-tree@^3.2.1:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"


### PR DESCRIPTION
i want to try this before https://github.com/facebook/jest/pull/4145
it seems like master resolves to an older version of chalk, which did not have CI support