### PR TITLE
Add `contextLines` option to jest-diff

### DIFF
--- a/packages/jest-diff/src/__tests__/__snapshots__/diff.test.js.snap
+++ b/packages/jest-diff/src/__tests__/__snapshots__/diff.test.js.snap
@@ -17,6 +17,76 @@ exports[`collapses big diffs to patch format 1`] = `
 <dim> }"
 `;
 
+exports[`context number of lines: -1 (5 default) 1`] = `
+"<green>- Expected</>
+<red>+ Received</>
+
+@@ -6,9 +6,9 @@</>
+</><dim>     4,
+<dim>     5,
+<dim>     6,
+<dim>     7,
+<dim>     8,
+<red>+    10,</>
+<dim>     9,
+<green>-    10,</>
+<dim>   ],
+<dim> }"
+`;
+
+exports[`context number of lines: 0  1`] = `
+"<green>- Expected</>
+<red>+ Received</>
+
+@@ -11,0 +11,1 @@</>
+</><red>+    10,</>
+@@ -12,1 +13,0 @@</>
+</><green>-    10,</>"
+`;
+
+exports[`context number of lines: 1  1`] = `
+"<green>- Expected</>
+<red>+ Received</>
+
+@@ -10,4 +10,4 @@</>
+</><dim>     8,
+<red>+    10,</>
+<dim>     9,
+<green>-    10,</>
+<dim>   ],"
+`;
+
+exports[`context number of lines: 2  1`] = `
+"<green>- Expected</>
+<red>+ Received</>
+
+@@ -9,6 +9,6 @@</>
+</><dim>     7,
+<dim>     8,
+<red>+    10,</>
+<dim>     9,
+<green>-    10,</>
+<dim>   ],
+<dim> }"
+`;
+
+exports[`context number of lines: null (5 default) 1`] = `
+"<green>- Expected</>
+<red>+ Received</>
+
+@@ -6,9 +6,9 @@</>
+</><dim>     4,
+<dim>     5,
+<dim>     6,
+<dim>     7,
+<dim>     8,
+<red>+    10,</>
+<dim>     9,
+<green>-    10,</>
+<dim>   ],
+<dim> }"
+`;
+
 exports[`falls back to not call toJSON if objects look identical 1`] = `
 "<dim>Compared values serialize to the same structure.
 <dim>Printing internal object structure without calling \`toJSON\` instead.

--- a/packages/jest-diff/src/__tests__/diff.test.js
+++ b/packages/jest-diff/src/__tests__/diff.test.js
@@ -166,7 +166,7 @@ test('collapses big diffs to patch format', () => {
 });
 
 describe('context', () => {
-  const _test = (contextLines?: number) => {
+  const testDiffContextLines = (contextLines?: number) => {
     test(`number of lines: ${typeof contextLines === 'number'
       ? contextLines
       : 'null'} ${typeof contextLines !== 'number' || contextLines < 0
@@ -184,9 +184,9 @@ describe('context', () => {
     });
   };
 
-  _test(); // 5 by default
-  _test(2);
-  _test(1);
-  _test(0);
-  _test(-1); // Will use default
+  testDiffContextLines(); // 5 by default
+  testDiffContextLines(2);
+  testDiffContextLines(1);
+  testDiffContextLines(0);
+  testDiffContextLines(-1); // Will use default
 });

--- a/packages/jest-diff/src/__tests__/diff.test.js
+++ b/packages/jest-diff/src/__tests__/diff.test.js
@@ -164,3 +164,29 @@ test('collapses big diffs to patch format', () => {
 
   expect(result).toMatchSnapshot();
 });
+
+describe('context', () => {
+  const _test = (contextLines?: number) => {
+    test(`number of lines: ${typeof contextLines === 'number'
+      ? contextLines
+      : 'null'} ${typeof contextLines !== 'number' || contextLines < 0
+      ? '(5 default)'
+      : ''}`, () => {
+      const result = diff(
+        {test: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]},
+        {test: [1, 2, 3, 4, 5, 6, 7, 8, 10, 9]},
+        {
+          contextLines,
+          expand: false,
+        },
+      );
+      expect(result).toMatchSnapshot();
+    });
+  };
+
+  _test(); // 5 by default
+  _test(2);
+  _test(1);
+  _test(0);
+  _test(-1); // Will use default
+});

--- a/packages/jest-diff/src/diff_strings.js
+++ b/packages/jest-diff/src/diff_strings.js
@@ -15,12 +15,13 @@ import {
 } from 'diff';
 
 import {NO_DIFF_MESSAGE} from './constants.js';
-const DIFF_CONTEXT = 5;
+const DIFF_CONTEXT_DEFAULT = 5;
 
 export type DiffOptions = {|
   aAnnotation?: string,
   bAnnotation?: string,
   expand?: boolean,
+  contextLines?: number,
 |};
 
 type Diff = {diff: string, isDifferent: boolean};
@@ -94,8 +95,13 @@ const createPatchMark = (hunk: Hunk): string => {
   return chalk.yellow(`@@ ${markOld} ${markNew} @@\n`);
 };
 
-const structuredPatch = (a: string, b: string): Diff => {
-  const options = {context: DIFF_CONTEXT};
+const structuredPatch = (a: string, b: string, contextLines?: number): Diff => {
+  const options = {
+    context:
+      typeof contextLines === 'number' && contextLines >= 0
+        ? contextLines
+        : DIFF_CONTEXT_DEFAULT,
+  };
   let isDifferent = false;
   // Make sure the strings end with a newline.
   if (!a.endsWith('\n')) {
@@ -141,7 +147,7 @@ function diffStrings(a: string, b: string, options: ?DiffOptions): string {
   // whenever linebreaks are involved.
   const result =
     options && options.expand === false
-      ? structuredPatch(a, b)
+      ? structuredPatch(a, b, options && options.contextLines)
       : diffLines(a, b);
 
   if (result.isDifferent) {


### PR DESCRIPTION
**Summary**

Fixes #4147. This will be useful for libraries like https://github.com/thymikee/snapshot-diff.

**Test plan**

Added several test cases (with snapshots) in `diff.test.js`.
