### PR TITLE
install yarn on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ node_js:
 
 sudo: false
 
+before_install:
+  - curl -o- -L https://yarnpkg.com/install.sh | bash
+  - export PATH="$HOME/.yarn/bin:$PATH"
+
 cache:
   yarn: true
   directories:


### PR DESCRIPTION
this is some CI madness this week.
looks like Travis changed the way we run builds today and now the default preinstalled version of yarn is `0.17`

<img width="1257" alt="screen shot 2017-07-28 at 10 59 32 am" src="https://user-images.githubusercontent.com/940133/28730221-f9f02fa6-7383-11e7-8bf3-9e09a5ddb636.png">
