### PR TITLE
- NodeJS Console initialization fix

### DIFF
--- a/packages/jest-cli/src/lib/buffered_console.js
+++ b/packages/jest-cli/src/lib/buffered_console.js
@@ -19,7 +19,7 @@ class BufferedConsole extends Console {
 
   constructor() {
     const buffer = [];
-    super({write: message => BufferedConsole.write(buffer, 'log', message)});
+    super(process.stdout, process.stderr);	
     this._buffer = buffer;
   }
 

--- a/packages/jest-cli/src/lib/buffered_console.js
+++ b/packages/jest-cli/src/lib/buffered_console.js
@@ -19,7 +19,7 @@ class BufferedConsole extends Console {
 
   constructor() {
     const buffer = [];
-    super(process.stdout, process.stderr);	
+    super(process.stdout, process.stderr);
     this._buffer = buffer;
   }
 


### PR DESCRIPTION
**Summary**
This is a fix for the problem when NodeJS is "swallowing" console output. 
BufferedConsole is initializing [Console ](https://nodejs.org/api/console.html) module with constructor parameters that don't match with the expected ones.
