### PR TITLE
fix concurrent test failure

### DIFF
--- a/integration_tests/__tests__/find_related_files.test.js
+++ b/integration_tests/__tests__/find_related_files.test.js
@@ -16,7 +16,7 @@ import os from 'os';
 import path from 'path';
 
 const skipOnWindows = require('../../scripts/skip_on_windows');
-const DIR = path.resolve(os.tmpdir(), 'force_exit_test');
+const DIR = path.resolve(os.tmpdir(), 'find_related_tests_test');
 
 skipOnWindows.suite();
 

--- a/integration_tests/__tests__/force_exit.test.js
+++ b/integration_tests/__tests__/force_exit.test.js
@@ -35,7 +35,9 @@ test('exits the process after test are done but before timers complete', () => {
   });
 
   let stdout;
-  ({stdout} = runJest(DIR));
+  let stderr;
+  ({stdout, stderr} = runJest(DIR));
+  expect(stderr).toMatch(/PASS.*test\.test\.js/);
   expect(stdout).toMatch(/TIMER_DONE/);
   writeFiles(DIR, {
     'package.json': JSON.stringify({
@@ -43,6 +45,7 @@ test('exits the process after test are done but before timers complete', () => {
     }),
   });
 
-  ({stdout} = runJest(DIR));
+  ({stdout, stderr} = runJest(DIR));
+  expect(stderr).toMatch(/PASS.*test\.test\.js/);
   expect(stdout).not.toMatch(/TIMER_DONE/);
 });


### PR DESCRIPTION
i think this got copypasted from another test and was causing random failures when run concurrently (the shared directory was getting cleaned up).

i'll come up with a better solution that will automatically generate a test_dir name