### PR TITLE
Updated Webpack config example on docs

### DIFF
--- a/docs/en/Webpack.md
+++ b/docs/en/Webpack.md
@@ -31,8 +31,12 @@ module.exports = {
       react: './vendor/react-master',
     },
     extensions: ['', 'js', 'jsx'],
-    modulesDirectories: ['node_modules', 'bower_components', 'shared'],
-    root: '/shared/vendor/modules',
+    modules: [
+      'node_modules', 
+      'bower_components', 
+      'shared',
+      '/shared/vendor/modules',
+    ],
   },
 };
 ```


### PR DESCRIPTION
The Webpack config example on the docs uses `resolve.modulesDirectories` and `resolve.root`, which were merged into `resolve.modules` in Webpack 2. I updated that snippet to avoid confusion.  

From the [Webpack docs](https://webpack.js.org/guides/migrating/#resolve-root-resolve-fallback-resolve-modulesdirectories) for migrating from v1 to v2:

> ### `resolve.root`, `resolve.fallback`, `resolve.modulesDirectories`
>
> These options were replaced by a single option `resolve.modules`. 
