### PR TITLE
Custom resolver wasn't used in all scenarios.

### DIFF
--- a/docs/en/Configuration.md
+++ b/docs/en/Configuration.md
@@ -359,7 +359,8 @@ This option allows the use of a custom resolver. This resolver must be a node mo
   "browser": bool,
   "extensions": [string],
   "moduleDirectory": [string],
-  "paths": [string]
+  "paths": [string],
+  "rootDir": [string]
 }
 ```
 

--- a/integration_tests/__tests__/__snapshots__/module_name_mapper.test.js.snap
+++ b/integration_tests/__tests__/__snapshots__/module_name_mapper.test.js.snap
@@ -13,12 +13,14 @@ exports[`moduleNameMapper wrong configuration 1`] = `
 
     Configuration error:
     
-    Unknown module in configuration option moduleNameMapper
+    Could not locate module ./style.css (mapped as no-such-module)
+    
     Please check:
     
     \\"moduleNameMapper\\": {
       \\"/\\\\.(css|less)$/\\": \\"no-such-module\\"
-    }
+    },
+    \\"resolver\\": undefined
 
 "
 `;

--- a/packages/jest-runtime/src/index.js
+++ b/packages/jest-runtime/src/index.js
@@ -257,6 +257,7 @@ class Runtime {
       modulePaths: config.modulePaths,
       platforms: config.haste.platforms,
       resolver: config.resolver,
+      rootDir: config.rootDir,
     });
   }
 


### PR DESCRIPTION

Was trying to use the custom resolver to locate testing modules in a custom framework that has a framework-specific directory layout. The custom resolver could be used to resolve modules in this custom directory layout. 

The PR will use the custom resolver for resolution of imported modules from within a code under tests. 
