### PR TITLE
Factor out common code for markup in React plugins

### DIFF
--- a/packages/pretty-format/src/__tests__/react.test.js
+++ b/packages/pretty-format/src/__tests__/react.test.js
@@ -381,9 +381,7 @@ describe('test object for subset match', () => {
       children: ['undefined props'],
       type: 'span',
     };
-    expect(formatTestObject(val)).toEqual(
-      '<span>\n  undefined props\n</span>',
-    );
+    expect(formatTestObject(val)).toEqual('<span>\n  undefined props\n</span>');
   });
   test('undefined children', () => {
     const val = {

--- a/packages/pretty-format/src/__tests__/react.test.js
+++ b/packages/pretty-format/src/__tests__/react.test.js
@@ -13,6 +13,8 @@ import type {OptionsReceived} from 'types/PrettyFormat';
 const React = require('react');
 const renderer = require('react-test-renderer');
 
+const testSymbol = Symbol.for('react.test.json');
+
 const prettyFormat = require('../');
 const {ReactElement, ReactTestComponent} = prettyFormat.plugins;
 
@@ -368,6 +370,33 @@ test('supports array of elements', () => {
   expect(
     formatTestObject(val.map(element => renderer.create(element).toJSON())),
   ).toEqual(expected);
+});
+
+describe('test object for subset match', () => {
+  // Although test object returned by renderer.create(element).toJSON()
+  // has both props and children, make sure plugin allows them to be undefined.
+  test('undefined props', () => {
+    const val = {
+      $$typeof: testSymbol,
+      children: ['undefined', 'props'],
+      type: 'span',
+    };
+    expect(formatTestObject(val)).toEqual(
+      '<span>\n  undefined\n  props\n</span>',
+    );
+  });
+  test('undefined children', () => {
+    const val = {
+      $$typeof: testSymbol,
+      props: {
+        className: 'undefined children',
+      },
+      type: 'span',
+    };
+    expect(formatTestObject(val)).toEqual(
+      '<span\n  className="undefined children"\n/>',
+    );
+  });
 });
 
 describe('indent option', () => {

--- a/packages/pretty-format/src/__tests__/react.test.js
+++ b/packages/pretty-format/src/__tests__/react.test.js
@@ -378,11 +378,11 @@ describe('test object for subset match', () => {
   test('undefined props', () => {
     const val = {
       $$typeof: testSymbol,
-      children: ['undefined', 'props'],
+      children: ['undefined props'],
       type: 'span',
     };
     expect(formatTestObject(val)).toEqual(
-      '<span>\n  undefined\n  props\n</span>',
+      '<span>\n  undefined props\n</span>',
     );
   });
   test('undefined children', () => {

--- a/packages/pretty-format/src/plugins/lib/markup.js
+++ b/packages/pretty-format/src/plugins/lib/markup.js
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+
+import type {Config, Printer, Refs} from 'types/PrettyFormat';
+
+import escapeHTML from './escape_html';
+
+// Return spacing and indentation that precedes the property.
+const printProp = (
+  key: string,
+  value: any,
+  config: Config,
+  printer: Printer,
+  indentation: string,
+  depth: number,
+  refs: Refs,
+): string => {
+  const indentationNext = indentation + config.indent;
+  let printed = printer(value, indentationNext, depth, refs);
+
+  if (typeof value !== 'string') {
+    if (printed.indexOf('\n') !== -1) {
+      printed =
+        config.spacingOuter +
+        indentationNext +
+        printed +
+        config.spacingOuter +
+        indentation;
+    }
+    printed = '{' + printed + '}';
+  }
+
+  const colors = config.colors;
+  return (
+    config.spacingInner +
+    indentation +
+    colors.prop.open +
+    key +
+    colors.prop.close +
+    '=' +
+    colors.value.open +
+    printed +
+    colors.value.close
+  );
+};
+
+// Return empty string if keys is empty.
+export const printProps = (
+  keys: Array<string>,
+  props: Object,
+  config: Config,
+  printer: Printer,
+  indentation: string,
+  depth: number,
+  refs: Refs,
+): string =>
+  keys
+    .map(key =>
+      printProp(key, props[key], config, printer, indentation, depth, refs),
+    )
+    .join('');
+
+// Return empty string if children is empty.
+export const printChildren = (
+  children: Array<any>,
+  config: Config,
+  printer: Printer,
+  indentation: string,
+  depth: number,
+  refs: Refs,
+): string => {
+  const colors = config.colors;
+  return children
+    .map(
+      child =>
+        config.spacingOuter +
+        indentation +
+        (typeof child === 'string'
+          ? colors.content.open + escapeHTML(child) + colors.content.close
+          : printer(child, indentation, depth, refs)),
+    )
+    .join('');
+};
+
+// Separate the functions to format props, children, and element,
+// so a plugin could override a particular function, if needed.
+// Too bad, so sad: the traditional (but unnecessary) space
+// in a self-closing tag requires a second test of printedProps.
+export const printElement = (
+  type: string,
+  printedProps: string,
+  printedChildren: string,
+  config: Config,
+  indentation: string,
+): string => {
+  const tag = config.colors.tag;
+  return (
+    tag.open +
+    '<' +
+    type +
+    (printedProps &&
+      tag.close + printedProps + config.spacingOuter + indentation + tag.open) +
+    (printedChildren
+      ? '>' +
+        tag.close +
+        printedChildren +
+        config.spacingOuter +
+        indentation +
+        tag.open +
+        '</' +
+        type
+      : (printedProps && !config.min ? '' : ' ') + '/') +
+    '>' +
+    tag.close
+  );
+};

--- a/packages/pretty-format/src/plugins/lib/markup.js
+++ b/packages/pretty-format/src/plugins/lib/markup.js
@@ -92,7 +92,7 @@ export const printChildren = (
 // Separate the functions to format props, children, and element,
 // so a plugin could override a particular function, if needed.
 // Too bad, so sad: the traditional (but unnecessary) space
-// in a self-closing tag requires a second test of printedProps.
+// in a self-closing tagColor requires a second test of printedProps.
 export const printElement = (
   type: string,
   printedProps: string,
@@ -100,24 +100,28 @@ export const printElement = (
   config: Config,
   indentation: string,
 ): string => {
-  const tag = config.colors.tag;
+  const tagColor = config.colors.tag;
   return (
-    tag.open +
+    tagColor.open +
     '<' +
     type +
     (printedProps &&
-      tag.close + printedProps + config.spacingOuter + indentation + tag.open) +
+      tagColor.close +
+        printedProps +
+        config.spacingOuter +
+        indentation +
+        tagColor.open) +
     (printedChildren
       ? '>' +
-        tag.close +
+        tagColor.close +
         printedChildren +
         config.spacingOuter +
         indentation +
-        tag.open +
+        tagColor.open +
         '</' +
         type
       : (printedProps && !config.min ? '' : ' ') + '/') +
     '>' +
-    tag.close
+    tagColor.close
   );
 };

--- a/packages/pretty-format/src/plugins/react_element.js
+++ b/packages/pretty-format/src/plugins/react_element.js
@@ -37,7 +37,7 @@ const getChildren = (arg, children = []) => {
   return children;
 };
 
-const serialize = (
+export const serialize = (
   element: React$Element<*>,
   config: Config,
   printer: Printer,

--- a/packages/pretty-format/src/plugins/react_element.js
+++ b/packages/pretty-format/src/plugins/react_element.js
@@ -14,16 +14,6 @@ import {printChildren, printElement, printProps} from './lib/markup';
 
 const elementSymbol = Symbol.for('react.element');
 
-const getType = element => {
-  if (typeof element.type === 'string') {
-    return element.type;
-  }
-  if (typeof element.type === 'function') {
-    return element.type.displayName || element.type.name || 'Unknown';
-  }
-  return 'Unknown';
-};
-
 // Given element.props.children, or subtree during recursive traversal,
 // return flattened array of children.
 const getChildren = (arg, children = []) => {
@@ -35,6 +25,16 @@ const getChildren = (arg, children = []) => {
     children.push(arg);
   }
   return children;
+};
+
+const getType = element => {
+  if (typeof element.type === 'string') {
+    return element.type;
+  }
+  if (typeof element.type === 'function') {
+    return element.type.displayName || element.type.name || 'Unknown';
+  }
+  return 'Unknown';
 };
 
 export const serialize = (

--- a/packages/pretty-format/src/plugins/react_test_component.js
+++ b/packages/pretty-format/src/plugins/react_test_component.js
@@ -13,137 +13,50 @@ import type {
   Printer,
   NewPlugin,
   ReactTestObject,
-  ReactTestChild,
   Refs,
 } from 'types/PrettyFormat';
 
-import escapeHTML from './lib/escape_html';
+import {printChildren, printElement, printProps} from './lib/markup';
 
 const testSymbol = Symbol.for('react.test.json');
 
-function printChildren(
-  children: Array<ReactTestChild>,
-  config: Config,
-  printer: Printer,
-  indentation: string,
-  depth: number,
-  refs: Refs,
-): string {
-  const colors = config.colors;
-  return children
-    .map(
-      child =>
-        config.spacingOuter +
-        indentation +
-        (typeof child === 'string'
-          ? colors.content.open + escapeHTML(child) + colors.content.close
-          : printer(child, indentation, depth, refs)),
-    )
-    .join('');
-}
-
-function printProps(
-  keys: Array<string>,
-  props: Object,
-  config: Config,
-  printer: Printer,
-  indentation: string,
-  depth: number,
-  refs: Refs,
-): string {
-  const indentationNext = indentation + config.indent;
-  const colors = config.colors;
-  return keys
-    .sort()
-    .map(key => {
-      const value = props[key];
-      let printed = printer(value, indentationNext, depth, refs);
-
-      if (typeof value !== 'string') {
-        if (printed.indexOf('\n') !== -1) {
-          printed =
-            config.spacingOuter +
-            indentationNext +
-            printed +
-            config.spacingOuter +
-            indentation;
-        }
-        printed = '{' + printed + '}';
-      }
-
-      return (
-        config.spacingInner +
-        indentation +
-        colors.prop.open +
-        key +
-        colors.prop.close +
-        '=' +
-        colors.value.open +
-        printed +
-        colors.value.close
-      );
-    })
-    .join('');
-}
-
 export const serialize = (
-  instance: ReactTestObject,
+  object: ReactTestObject,
   config: Config,
   printer: Printer,
   indentation: string,
   depth: number,
   refs: Refs,
-): string => {
-  const tag = config.colors.tag;
-  let result = tag.open + '<' + instance.type;
-
-  let hasProps = false;
-  if (instance.props) {
-    const keys = Object.keys(instance.props);
-    hasProps = keys.length !== 0;
-    if (hasProps) {
-      result +=
-        tag.close +
-        printProps(
-          keys,
-          instance.props,
+): string =>
+  printElement(
+    object.type,
+    object.props
+      ? printProps(
+          Object.keys(object.props).sort(),
+          // Despite ternary expression, Flow 0.51.0 found incorrect error:
+          // undefined is incompatible with the expected param type of Object
+          // $FlowFixMe
+          object.props,
           config,
           printer,
           indentation + config.indent,
           depth,
           refs,
-        ) +
-        config.spacingOuter +
-        indentation +
-        tag.open;
-    }
-  }
-
-  if (instance.children) {
-    result +=
-      '>' +
-      tag.close +
-      printChildren(
-        instance.children,
-        config,
-        printer,
-        indentation + config.indent,
-        depth,
-        refs,
-      ) +
-      config.spacingOuter +
-      indentation +
-      tag.open +
-      '</' +
-      instance.type +
-      '>' +
-      tag.close;
-  } else {
-    result += (hasProps && !config.min ? '' : ' ') + '/>' + tag.close;
-  }
-
-  return result;
-};
+        )
+      : '',
+    object.children
+      ? printChildren(
+          object.children,
+          config,
+          printer,
+          indentation + config.indent,
+          depth,
+          refs,
+        )
+      : '',
+    config,
+    indentation,
+  );
 
 export const test = (val: any) => val && val.$$typeof === testSymbol;
 


### PR DESCRIPTION
**Summary**

Enforce consistency, reduce code. Like the TV advert: looks pretty, less filling :)

We will probably be able to factor out common code in HTMLElement too.

Analogy to react-redux as you review this diff:

* React plugins like **container** components?
* markup functions like **presentation** components?

**Test plan**

Added 2 tests to prevent regression related to test object for subset match, especially because of the incorrect Flow error.