### PR TITLE
Replace print with serialize in AsymmetricMatcher plugin

### DIFF
--- a/packages/pretty-format/src/__tests__/asymmetric_matcher.test.js
+++ b/packages/pretty-format/src/__tests__/asymmetric_matcher.test.js
@@ -95,6 +95,17 @@ test(`stringMatching(regexp)`, () => {
   expect(result).toEqual('StringMatching /(jest|niema).*/');
 });
 
+test(`stringMatching(regexp) {escapeRegex: false}`, () => {
+  const result = prettyFormat(expect.stringMatching(/regexp\d/gi), options);
+  expect(result).toEqual('StringMatching /regexp\\d/gi');
+});
+
+test(`stringMatching(regexp) {escapeRegex: true}`, () => {
+  options.escapeRegex = true;
+  const result = prettyFormat(expect.stringMatching(/regexp\d/gi), options);
+  expect(result).toEqual('StringMatching /regexp\\\\d/gi');
+});
+
 test(`supports multiple nested asymmetric matchers`, () => {
   const result = prettyFormat(
     {
@@ -129,7 +140,132 @@ test(`supports multiple nested asymmetric matchers`, () => {
 }`);
 });
 
-test(`supports minified output`, () => {
+describe(`indent option`, () => {
+  const val = {
+    nested: expect.objectContaining({
+      a: expect.arrayContaining([1]),
+      b: expect.anything(),
+      c: expect.any(String),
+      d: expect.stringContaining('jest'),
+      e: expect.stringMatching('jest'),
+      f: expect.objectContaining({
+        composite: ['exact', 'match'],
+        primitive: 'string',
+      }),
+    }),
+  };
+  const result = `Object {
+  "nested": ObjectContaining {
+    "a": ArrayContaining [
+      1,
+    ],
+    "b": Anything,
+    "c": Any<String>,
+    "d": StringContaining "jest",
+    "e": StringMatching /jest/,
+    "f": ObjectContaining {
+      "composite": Array [
+        "exact",
+        "match",
+      ],
+      "primitive": "string",
+    },
+  },
+}`;
+
+  test(`default implicit: 2 spaces`, () => {
+    expect(prettyFormat(val, options)).toEqual(result);
+  });
+  test(`default explicit: 2 spaces`, () => {
+    options.indent = 2;
+    expect(prettyFormat(val, options)).toEqual(result);
+  });
+
+  // Tests assume that no strings in val contain multiple adjacent spaces!
+  test(`non-default: 0 spaces`, () => {
+    options.indent = 0;
+    expect(prettyFormat(val, options)).toEqual(result.replace(/ {2}/g, ''));
+  });
+  test('non-default: 4 spaces', () => {
+    options.indent = 4;
+    expect(prettyFormat(val, options)).toEqual(
+      result.replace(/ {2}/g, ' '.repeat(4)),
+    );
+  });
+});
+
+describe(`maxDepth option`, () => {
+  test(`matchers as leaf nodes`, () => {
+    options.maxDepth = 3;
+    const val = {
+      // ++depth === 1
+      nested: [
+        // ++depth === 2
+        expect.arrayContaining(
+          // ++depth === 3
+          [1],
+        ),
+        expect.objectContaining({
+          // ++depth === 3
+          composite: ['exact', 'match'],
+          primitive: 'string',
+        }),
+        expect.stringContaining('jest'),
+        expect.stringMatching('jest'),
+        expect.any(String),
+        expect.anything(),
+      ],
+    };
+    const result = prettyFormat(val, options);
+    expect(result).toEqual(`Object {
+  "nested": Array [
+    [ArrayContaining],
+    [ObjectContaining],
+    StringContaining "jest",
+    StringMatching /jest/,
+    Any<String>,
+    Anything,
+  ],
+}`);
+  });
+  test(`matchers as internal nodes`, () => {
+    options.maxDepth = 3;
+    const val = [
+      // ++depth === 1
+      expect.arrayContaining([
+        // ++depth === 2
+        'printed',
+        {
+          // ++depth === 3
+          properties: 'not printed',
+        },
+      ]),
+      expect.objectContaining({
+        // ++depth === 2
+        array: [
+          // ++depth === 3
+          'items',
+          'not',
+          'printed',
+        ],
+        primitive: 'printed',
+      }),
+    ];
+    const result = prettyFormat(val, options);
+    expect(result).toEqual(`Array [
+  ArrayContaining [
+    "printed",
+    [Object],
+  ],
+  ObjectContaining {
+    "array": [Array],
+    "primitive": "printed",
+  },
+]`);
+  });
+});
+
+test(`min option`, () => {
   options.min = true;
   const result = prettyFormat(
     {

--- a/packages/pretty-format/src/__tests__/pretty_format.test.js
+++ b/packages/pretty-format/src/__tests__/pretty_format.test.js
@@ -243,7 +243,12 @@ describe('prettyFormat()', () => {
     expect(prettyFormat(val)).toEqual('/regexp/gi');
   });
 
-  it('escapes regular expressions', () => {
+  it('prints regular expressions {escapeRegex: false}', () => {
+    const val = /regexp\d/gi;
+    expect(prettyFormat(val)).toEqual('/regexp\\d/gi');
+  });
+
+  it('prints regular expressions {escapeRegex: true}', () => {
     const val = /regexp\d/gi;
     expect(prettyFormat(val, {escapeRegex: true})).toEqual('/regexp\\\\d/gi');
   });


### PR DESCRIPTION
**Summary**

Please pace yourself, my friendly reviewer :)

* **Breaking change** for edge case: `++depth > config.maxDepth` like ordinary Array or Object
* Replace `opts.spacing === SPACE` with `config.min`

**Test plan**

Added 2 fail-first tests for new result: **maxDepth** option

Additional tests explicitly specify existing correct results:

* stringMatching(regexp) {escapeRegex: **false**}
* stringMatching(regexp) {escapeRegex: **true**}
* **indent** option
