### PR TITLE
Allow custom resolver to be used with[out] moduleNameMapper

### DIFF
--- a/docs/en/Configuration.md
+++ b/docs/en/Configuration.md
@@ -369,7 +369,8 @@ This option allows the use of a custom resolver. This resolver must be a node mo
   "browser": bool,
   "extensions": [string],
   "moduleDirectory": [string],
-  "paths": [string]
+  "paths": [string],
+  "rootDir": [string]
 }
 ```
 

--- a/integration_tests/__tests__/__snapshots__/module_name_mapper.test.js.snap
+++ b/integration_tests/__tests__/__snapshots__/module_name_mapper.test.js.snap
@@ -13,12 +13,14 @@ exports[`moduleNameMapper wrong configuration 1`] = `
 
     Configuration error:
     
-    Unknown module in configuration option moduleNameMapper
+    Could not locate module ./style.css (mapped as no-such-module)
+    
     Please check:
     
     \\"moduleNameMapper\\": {
       \\"/\\\\.(css|less)$/\\": \\"no-such-module\\"
-    }
+    },
+    \\"resolver\\": undefined
 
 "
 `;

--- a/packages/jest-cli/src/reporters/default_reporter.js
+++ b/packages/jest-cli/src/reporters/default_reporter.js
@@ -183,7 +183,7 @@ class DefaultReporter extends BaseReporter {
             TITLE_BULLET +
             'Console\n\n' +
             getConsoleOutput(
-              config.rootDir,
+              config.cwd,
               !!this._globalConfig.verbose,
               consoleBuffer,
             ),

--- a/packages/jest-cli/src/reporters/utils.js
+++ b/packages/jest-cli/src/reporters/utils.js
@@ -8,7 +8,7 @@
  * @flow
  */
 
-import type {Path, ProjectConfig} from 'types/Config';
+import type {Path, ProjectConfig, GlobalConfig} from 'types/Config';
 import type {AggregatedResult} from 'types/TestResult';
 
 import path from 'path';
@@ -37,7 +37,7 @@ const printDisplayName = (config: ProjectConfig) => {
 
 const trimAndFormatPath = (
   pad: number,
-  config: {rootDir: Path},
+  config: ProjectConfig | GlobalConfig,
   testPath: Path,
   columns: number,
 ): string => {
@@ -72,13 +72,19 @@ const trimAndFormatPath = (
   );
 };
 
-const formatTestPath = (config: {rootDir: Path}, testPath: Path) => {
+const formatTestPath = (
+  config: GlobalConfig | ProjectConfig,
+  testPath: Path,
+) => {
   const {dirname, basename} = relativePath(config, testPath);
   return chalk.dim(dirname + path.sep) + chalk.bold(basename);
 };
 
-const relativePath = (config: {rootDir: Path}, testPath: Path) => {
-  testPath = path.relative(config.rootDir, testPath);
+const relativePath = (config: GlobalConfig | ProjectConfig, testPath: Path) => {
+  // this function can be called with ProjectConfigs or GlobalConfigs. GlobalConfigs
+  // do not have config.cwd, only config.rootDir. Try using config.cwd, fallback
+  // to config.rootDir. (Also, some unit just use config.rootDir, which is ok)
+  testPath = path.relative(config.cwd || config.rootDir, testPath);
   const dirname = path.dirname(testPath);
   const basename = path.basename(testPath);
   return {basename, dirname};

--- a/packages/jest-cli/src/run_jest.js
+++ b/packages/jest-cli/src/run_jest.js
@@ -140,10 +140,13 @@ const runJest = async ({
   }
 
   // When using more than one context, make all printed paths relative to the
-  // current cwd. rootDir is only used as a token during normalization and
-  // has no special meaning afterwards except for printing information to the
-  // CLI.
-  setConfig(contexts, {rootDir: process.cwd()});
+  // current cwd. Do not modify rootDir, since will be used by custom resolvers.
+  // If --runInBand is true, the resolver saved a copy during initialization,
+  // however, if it is running on spawned processes, the initiation of the
+  // custom resolvers is done within each spawned process and it needs the
+  // original value of rootDir. Instead, use the {cwd: Path} property to resolve
+  // paths when printing.
+  setConfig(contexts, {cwd: process.cwd()});
 
   const results = await new TestScheduler(globalConfig, {
     startRun,

--- a/packages/jest-config/src/index.js
+++ b/packages/jest-config/src/index.js
@@ -120,6 +120,7 @@ const getConfigs = (
       cacheDirectory: options.cacheDirectory,
       clearMocks: options.clearMocks,
       coveragePathIgnorePatterns: options.coveragePathIgnorePatterns,
+      cwd: options.cwd,
       displayName: options.displayName,
       globals: options.globals,
       haste: options.haste,

--- a/packages/jest-resolve/src/__tests__/resolve.test.js
+++ b/packages/jest-resolve/src/__tests__/resolve.test.js
@@ -9,10 +9,17 @@
 
 'use strict';
 
+jest.mock('../__mocks__/userResolver');
+
 const fs = require('fs');
 const path = require('path');
 const ModuleMap = require('jest-haste-map').ModuleMap;
 const Resolver = require('../');
+const userResolver = require('../__mocks__/userResolver');
+
+beforeEach(() => {
+  userResolver.mockClear();
+});
 
 describe('isCoreModule', () => {
   it('returns false if `hasCoreModules` is false.', () => {
@@ -50,8 +57,6 @@ describe('findNodeModule', () => {
           .map(p => path.resolve(resolvedCwd, p))
       : null;
 
-    jest.mock('../__mocks__/userResolver');
-    const userResolver = require('../__mocks__/userResolver');
     userResolver.mockImplementation(() => 'module');
 
     const newPath = Resolver.findNodeModule('test', {
@@ -72,5 +77,35 @@ describe('findNodeModule', () => {
       moduleDirectory: ['node_modules'],
       paths: (nodePaths || []).concat(['/something']),
     });
+  });
+});
+
+describe('getMockModule', () => {
+  it('is possible to use custom resolver to resolve deps inside mock modules', () => {
+    userResolver.mockImplementation(() => 'module');
+
+    const moduleMap = new ModuleMap({
+      duplicates: [],
+      map: [],
+      mocks: [],
+    });
+    const resolver = new Resolver(moduleMap, {
+      moduleNameMapper: [
+        {
+          moduleName: '$1',
+          regex: /(.*)/,
+        },
+      ],
+      resolver: require.resolve('../__mocks__/userResolver'),
+    });
+    const src = require.resolve('../');
+    resolver.getMockModule(src, 'dependentModule');
+
+    expect(userResolver).toHaveBeenCalled();
+    expect(userResolver.mock.calls[0][0]).toBe('dependentModule');
+    expect(userResolver.mock.calls[0][1]).toHaveProperty(
+      'basedir',
+      path.dirname(src),
+    );
   });
 });

--- a/packages/jest-resolve/src/__tests__/resolve.test.js
+++ b/packages/jest-resolve/src/__tests__/resolve.test.js
@@ -81,7 +81,7 @@ describe('findNodeModule', () => {
 });
 
 describe('getMockModule', () => {
-  it('is possible to use custom resolver to resolve deps inside mock modules', () => {
+  it('is possible to use custom resolver to resolve deps inside mock modules with moduleNameMapper', () => {
     userResolver.mockImplementation(() => 'module');
 
     const moduleMap = new ModuleMap({
@@ -96,6 +96,27 @@ describe('getMockModule', () => {
           regex: /(.*)/,
         },
       ],
+      resolver: require.resolve('../__mocks__/userResolver'),
+    });
+    const src = require.resolve('../');
+    resolver.getMockModule(src, 'dependentModule');
+
+    expect(userResolver).toHaveBeenCalled();
+    expect(userResolver.mock.calls[0][0]).toBe('dependentModule');
+    expect(userResolver.mock.calls[0][1]).toHaveProperty(
+      'basedir',
+      path.dirname(src),
+    );
+  });
+  it('is possible to use custom resolver to resolve deps inside mock modules without moduleNameMapper', () => {
+    userResolver.mockImplementation(() => 'module');
+
+    const moduleMap = new ModuleMap({
+      duplicates: [],
+      map: [],
+      mocks: [],
+    });
+    const resolver = new Resolver(moduleMap, {
       resolver: require.resolve('../__mocks__/userResolver'),
     });
     const src = require.resolve('../');

--- a/packages/jest-resolve/src/default_resolver.js
+++ b/packages/jest-resolve/src/default_resolver.js
@@ -29,6 +29,7 @@ function defaultResolver(path: Path, options: ResolverOptions): Path {
     extensions: options.extensions,
     moduleDirectory: options.moduleDirectory,
     paths: options.paths,
+    rootDir: options.rootDir,
   });
 }
 

--- a/packages/jest-resolve/src/default_resolver.js
+++ b/packages/jest-resolve/src/default_resolver.js
@@ -18,6 +18,7 @@ type ResolverOptions = {|
   extensions?: Array<string>,
   moduleDirectory?: Array<string>,
   paths?: ?Array<Path>,
+  rootDir: ?Path,
 |};
 
 function defaultResolver(path: Path, options: ResolverOptions): Path {

--- a/packages/jest-resolve/src/index.js
+++ b/packages/jest-resolve/src/index.js
@@ -29,6 +29,7 @@ type ResolverConfig = {|
   modulePaths: Array<Path>,
   platforms?: Array<string>,
   resolver: ?Path,
+  rootDir: ?Path,
 |};
 
 type FindNodeModuleConfig = {|
@@ -38,6 +39,7 @@ type FindNodeModuleConfig = {|
   moduleDirectory?: Array<string>,
   paths?: Array<Path>,
   resolver?: ?Path,
+  rootDir?: ?Path,
 |};
 
 type ModuleNameMapperConfig = {|
@@ -368,7 +370,7 @@ Please check:
       }
     }
     if (resolver) {
-      // if moduleNameMapper didn't match anything, fallback to just the 
+      // if moduleNameMapper didn't match anything, fallback to just the
       // regular resolver
       const module =
         this.getModule(moduleName) ||

--- a/packages/jest-runner/src/run_test.js
+++ b/packages/jest-runner/src/run_test.js
@@ -70,7 +70,7 @@ function runTest(
   const consoleOut = globalConfig.useStderr ? process.stderr : process.stdout;
   const consoleFormatter = (type, message) =>
     getConsoleOutput(
-      config.rootDir,
+      config.cwd,
       !!globalConfig.verbose,
       // 4 = the console call is buried 4 stack frames deep
       BufferedConsole.write([], type, message, 4),

--- a/packages/jest-runtime/src/index.js
+++ b/packages/jest-runtime/src/index.js
@@ -259,6 +259,7 @@ class Runtime {
       modulePaths: config.modulePaths,
       platforms: config.haste.platforms,
       resolver: config.resolver,
+      rootDir: config.rootDir,
     });
   }
 

--- a/test_utils.js
+++ b/test_utils.js
@@ -60,6 +60,7 @@ const DEFAULT_PROJECT_CONFIG: ProjectConfig = {
   cacheDirectory: '/test_cache_dir/',
   clearMocks: false,
   coveragePathIgnorePatterns: [],
+  cwd: '/test_root_dir/',
   displayName: undefined,
   globals: {},
   haste: {

--- a/types/Config.js
+++ b/types/Config.js
@@ -188,6 +188,7 @@ export type ProjectConfig = {|
   cacheDirectory: Path,
   clearMocks: boolean,
   coveragePathIgnorePatterns: Array<string>,
+  cwd: Path,
   displayName: ?string,
   globals: ConfigGlobals,
   haste: HasteConfig,


### PR DESCRIPTION
Also, improve error message when moduleNameMapper doesn't resolve to a module.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
1. The existing moduleNameMapper implementation doesn't invoke the customer resolver with the custom resolver option. This makes it impossible to write custom resolvers that work in all cases. 
2. If a moduleNameMapper was _not_ specified, then the custom resolver would not be run at all. 
 
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This PR solves the two problems above. 
1) It passes through the resolver configuration option so that the custom resolver could be used after the moduleMapMapper mapped the module. Additionally, the error message was improved with exactly which moduleName (including the mapped version) was causing the problem. 
2) If the moduleNameMapper isn't specified, it sends everything through to the resolver, unmapped. Additionally, the rootDir is passed to the resolver, to help it aid resolution, in case it may be dependent on the rootDir config option. 

**Test plan**
Added 2 tests. Configuration documentation were updated with new argument passed to custom resolver. 
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
