### PR TITLE
let transformers adjust cache key based on mapCoverage

### DIFF
--- a/packages/jest-runtime/src/__tests__/__snapshots__/script_transformer.test.js.snap
+++ b/packages/jest-runtime/src/__tests__/__snapshots__/script_transformer.test.js.snap
@@ -1,5 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ScriptTransformer passes expected transform options to getCacheKey 1`] = `
+Object {
+  "instrument": true,
+  "mapCoverage": true,
+}
+`;
+
 exports[`ScriptTransformer transforms a file properly 1`] = `
 "({\\"Object.<anonymous>\\":function(module,exports,require,__dirname,__filename,global,jest){/* istanbul ignore next */var cov_25u22311x4 = function () {var path = \\"/fruits/banana.js\\",hash = \\"04636d4ae73b4b3e24bf6fba39e08c946fd0afb5\\",global = new Function('return this')(),gcv = \\"__coverage__\\",coverageData = { path: \\"/fruits/banana.js\\", statementMap: { \\"0\\": { start: { line: 1, column: 0 }, end: { line: 1, column: 26 } } }, fnMap: {}, branchMap: {}, s: { \\"0\\": 0 }, f: {}, b: {}, _coverageSchema: \\"332fd63041d2c1bcb487cc26dd0d5f7d97098a6c\\" },coverage = global[gcv] || (global[gcv] = {});if (coverage[path] && coverage[path].hash === hash) {return coverage[path];}coverageData.hash = hash;return coverage[path] = coverageData;}();++cov_25u22311x4.s[0];module.exports = \\"banana\\";
 }});"

--- a/packages/jest-runtime/src/__tests__/script_transformer.test.js
+++ b/packages/jest-runtime/src/__tests__/script_transformer.test.js
@@ -359,6 +359,21 @@ describe('ScriptTransformer', () => {
     expect(writeFileAtomic.sync).toHaveBeenCalledTimes(1);
   });
 
+  it('passes expected transform options to getCacheKey', () => {
+    config = Object.assign(config, {
+      transform: [['^.+\\.js$', 'test_preprocessor']],
+    });
+    const scriptTransformer = new ScriptTransformer(config);
+
+    scriptTransformer.transform('/fruits/banana.js', {
+      collectCoverage: true,
+      mapCoverage: true,
+    });
+
+    const {getCacheKey} = require('test_preprocessor');
+    expect(getCacheKey.mock.calls[0][3]).toMatchSnapshot();
+  });
+
   it('reads values from the cache', () => {
     const transformConfig = Object.assign(config, {
       transform: [['^.+\\.js$', 'test_preprocessor']],

--- a/packages/jest-runtime/src/script_transformer.js
+++ b/packages/jest-runtime/src/script_transformer.js
@@ -76,6 +76,7 @@ class ScriptTransformer {
         .update(
           transformer.getCacheKey(fileData, filename, configString, {
             instrument,
+            mapCoverage,
           }),
         )
         .update(CACHE_VERSION)

--- a/types/Transform.js
+++ b/types/Transform.js
@@ -25,6 +25,11 @@ export type TransformOptions = {|
   instrument: boolean,
 |};
 
+export type CacheKeyOptions = {|
+  instrument: boolean,
+  mapCoverage: boolean,
+|};
+
 export type Transformer = {|
   canInstrument?: boolean,
   createTransformer(options: any): Transformer,
@@ -33,7 +38,7 @@ export type Transformer = {|
     fileData: string,
     filePath: Path,
     configStr: string,
-    options: TransformOptions,
+    options: CacheKeyOptions,
   ) => string,
 
   process: (


### PR DESCRIPTION
**Summary**
The first time someone flips on mapCoverage, they'll have a bad time if their transformer implements a getCacheKey since the flag is not passed to it. There's a chance this PR would fix issues like #4163. I ran into something similar and nuking the cache manually fixed it.

**Test plan**
Test added