### PR TITLE
Update docs for jest-changed-files

### DIFF
--- a/packages/jest-changed-files/README.md
+++ b/packages/jest-changed-files/README.md
@@ -11,38 +11,50 @@ $ npm install --save jest-changed-files
 
 ## API
 
-### `hg.isHGRepository(cwd: string): Promise<?string>`
+### `getChangedFilesForRoots(roots: <Array<string>>, options: ?object): Promise<?object>`
 
-Get the root of the mercurial repository containing `cwd` or return `null` if
-`cwd` is not inside a mercurial repository.
+Get the list of files and repos that have changed since the last commit.
 
-### `git.isGitRepository(cwd: string): Promise<?string>`
+#### Parameters
+roots: Array of string paths gathered from [jest roots](https://facebook.github.io/jest/docs/configuration.html#roots-array-string).
 
-Get the root of the git repository containing `cwd` or return `null` if
-`cwd` is not inside a git repository.
+options: Object literal with keys
+* lastCommit: boolean
+* withAncestor: boolean
 
-### `hg.findChangedFiles / git.findChangedFiles (root: string): Promise<Array<string>>`
+### findRepos(roots: <Array<string>>): Promise<?object>
 
-Get the list of files in a git/mecurial repository that have changed since the
-last commit.
+Get a set of git and hg repositories.
+#### Parameters
+roots: Array of string paths gathered from [jest roots](https://facebook.github.io/jest/docs/configuration.html#roots-array-string).
 
 ## Usage
 
 ```javascript
-import {git, hg} from 'jest-changed-files';
+import {getChangedFilesForRoots} from 'jest-changed-files';
 
-function changedFiles(cwd) {
-  return Promise.all([
-    git.isGitRepository(cwd),
-    hg.isHGRepository(cwd),
-  ]).then(([gitRoot, hgRoot]) => {
-    if (gitRoot !== null) {
-      return git.findChangedFiles(gitRoot);
-    } else if (hgRoot !== null) {
-      return hg.findChangedFiles(hgRoot);
-    } else {
-      throw new Error('Not in a git or hg repo');
-    }
-  });
-}
+getChangedFilesForRoots(['/path/to/test'], {
+  lastCommit: true,
+  withAncestor: true,
+}).then((files) => {
+  /*
+  {
+    repos: [],
+    changedFiles: []
+  }
+  */
+});
+```
+
+```javascript
+import {findRepos} from 'jest-changed-files';
+
+findRepos(['/path/to/test']).then((repos) => {
+  /*
+  {
+    git: Set<Path>,
+    hg: Set<Path>
+  }
+  */
+});
 ```


### PR DESCRIPTION
**Summary**

Updates the docs for jest-changed-files package to match what is the main export.
Issue referenced here https://github.com/facebook/jest/issues/4182

**Test plan**

No tests, just documentation updates.