### PR TITLE
Remove duplicate 'or' in docs.

### DIFF
--- a/docs/en/Configuration.md
+++ b/docs/en/Configuration.md
@@ -9,7 +9,7 @@ next: cli
 ---
 
 Jest's configuration can be defined in the `package.json` file of your project, through a `jest.config.js` file or
-or through the `--config <path/to/js|json>` option. If you'd like to use
+through the `--config <path/to/js|json>` option. If you'd like to use
 your `package.json` to store Jest's config, the "jest" key should be used on the
 top level so Jest will know how to find your settings:
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

before:
 through a jest.config.js file **or or** through the --config <path/to/js|json> option.

after:
 through a jest.config.js file **or** through the --config <path/to/js|json> option.