### PR TITLE
Improve Jest phabricator plugin

### DIFF
--- a/packages/jest-phabricator/example/JestUnitTestEngine.php
+++ b/packages/jest-phabricator/example/JestUnitTestEngine.php
@@ -28,7 +28,7 @@ class JestUnitTestEngine extends ArcanistBaseUnitTestEngine {
       $raw_results = json_decode(
         Filesystem::readFile($output_JSON),
         true
-      )['phabricatorReport'];
+      )['coverageMap'];
       Filesystem::remove($output_JSON);
     } else {
       $raw_results = json_decode($stdout, true);

--- a/types/TestResult.js
+++ b/types/TestResult.js
@@ -99,8 +99,7 @@ export type FormattedAssertionResult = {
   failureMessages: Array<string> | null,
 };
 
-export type AggregatedResult = {
-  coverageMap?: ?CoverageMap,
+export type AggregatedResultWithoutCoverage = {
   numFailedTests: number,
   numFailedTestSuites: number,
   numPassedTests: number,
@@ -115,6 +114,10 @@ export type AggregatedResult = {
   success: boolean,
   testResults: Array<TestResult>,
   wasInterrupted: boolean,
+};
+
+export type AggregatedResult = AggregatedResultWithoutCoverage & {
+  coverageMap?: ?CoverageMap,
 };
 
 export type Suite = {|


### PR DESCRIPTION
Some changes were done to the `jest-phabricator` result processor; both for optimizing the size of the resulting JSON and for making the results shape more consistent. This is a summary on how the changes affect the current way of working of the plugin:

1. The additional level of indirection where all the results were copied inside `aggregatedResult` is gone. This way, the resulting data format is the same whether you use `jest-phabricator` or not.

2. Now we override `coverageMap` to place the coverage there. The standard coverage format is huge, and although the code said [we will not include it in the final result for performance reasons](https://github.com/facebook/jest/blob/dec54a3/packages/jest-phabricator/src/index.js#L56-L57), it was getting preserved inside `aggregatedResult.coverageMap`.

3. Coverage is not copied in each of the test results anymore, **saving a lot of space**. Together with the previous point, this means a decrease from 4.57 MiB to 763.75 KiB for the resulting JSON size on a ~800 tests run. **That's 6x smaller!**

4. One might argue that overriding `coverageMap` is bad, because we lose the original coverage information; however:
    * It was intentionally `null`-ified before on the main object to save space (which was not, because it was still in the `aggregatedResult` sublevel), but still, its value was `null` at the root.
    * Being at a non-standard place, no one complained for a lot of time, so probably it was not getting used.
    * If a custom reporter is being used for coverage purposes, probably you're not looking for the default way of reporting coverage either, so putting it where the usual coverage is, sounds reasonable to me.

5. Code is simpler. Yay!