### PR TITLE
align jest resolve error to nodejs

### DIFF
--- a/packages/jest-resolve/src/index.js
+++ b/packages/jest-resolve/src/index.js
@@ -185,7 +185,7 @@ class Resolver {
     //    current module name available.
     const relativePath = path.relative(dirname, from);
     const err = new Error(
-      `Cannot find module '${moduleName}' from '${relativePath || '.'}'`,
+      `Cannot find module '${moduleName}'`,
     );
     (err: Error & {code?: string}).code = 'MODULE_NOT_FOUND';
     throw err;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

There are certain libraries (swagger's bagpipes for one) that use the message thrown by the module resolver. Jest changes the standard nodejs resolver message to have more information. https://github.com/nodejs/node/blob/master/lib/module.js#L489

It is (probably) best if the resolver message is identical to node's standard one to reduce noise.

**Test plan**

CI test