### PR TITLE
Rename TestRunner to TestScheduler

### DIFF
--- a/packages/jest-cli/src/__tests__/test_scheduler.test.js
+++ b/packages/jest-cli/src/__tests__/test_scheduler.test.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const TestRunner = require('../test_runner');
+const TestScheduler = require('../test_scheduler');
 const TestWatcher = require('../test_watcher');
 const SummaryReporter = require('../reporters/summary_reporter');
 
@@ -31,12 +31,12 @@ jest.mock('../test_worker', () => {});
 jest.mock('../reporters/default_reporter');
 
 test('.addReporter() .removeReporter()', () => {
-  const runner = new TestRunner({}, {});
+  const scheduler = new TestScheduler({}, {});
   const reporter = new SummaryReporter();
-  runner.addReporter(reporter);
-  expect(runner._dispatcher._reporters).toContain(reporter);
-  runner.removeReporter(SummaryReporter);
-  expect(runner._dispatcher._reporters).not.toContain(reporter);
+  scheduler.addReporter(reporter);
+  expect(scheduler._dispatcher._reporters).toContain(reporter);
+  scheduler.removeReporter(SummaryReporter);
+  expect(scheduler._dispatcher._reporters).not.toContain(reporter);
 });
 
 describe('_createInBandTestRun()', () => {
@@ -48,9 +48,9 @@ describe('_createInBandTestRun()', () => {
       config,
       moduleMap: {getRawModuleMap: () => rawModuleMap},
     };
-    const runner = new TestRunner(globalConfig, {});
+    const scheduler = new TestScheduler(globalConfig, {});
 
-    return runner
+    return scheduler
       ._createParallelTestRun(
         [{context, path: './file.test.js'}, {context, path: './file2.test.js'}],
         new TestWatcher({isWatchMode: globalConfig.watch}),
@@ -75,9 +75,9 @@ describe('_createInBandTestRun()', () => {
     const globalConfig = {maxWorkers: 1, watch: false};
     const config = {rootDir: '/path/'};
     const context = {config};
-    const runner = new TestRunner(globalConfig, {});
+    const scheduler = new TestScheduler(globalConfig, {});
 
-    return runner
+    return scheduler
       ._createParallelTestRun(
         [{context, path: './file.test.js'}, {context, path: './file2.test.js'}],
         new TestWatcher({isWatchMode: globalConfig.watch}),

--- a/packages/jest-cli/src/jest.js
+++ b/packages/jest-cli/src/jest.js
@@ -11,13 +11,13 @@
 import {version as VERSION} from '../package.json';
 
 import SearchSource from './search_source';
-import TestRunner from './test_runner';
+import TestScheduler from './test_scheduler';
 import TestWatcher from './test_watcher';
 import {run, runCLI} from './cli';
 
 module.exports = {
   SearchSource,
-  TestRunner,
+  TestScheduler,
   TestWatcher,
   getVersion: () => VERSION,
   run,

--- a/packages/jest-cli/src/run_jest.js
+++ b/packages/jest-cli/src/run_jest.js
@@ -19,7 +19,7 @@ import {Console, formatTestResults} from 'jest-util';
 import chalk from 'chalk';
 import fs from 'graceful-fs';
 import SearchSource from './search_source';
-import TestRunner from './test_runner';
+import TestScheduler from './test_scheduler';
 import TestSequencer from './test_sequencer';
 import {makeEmptyAggregatedTestResult} from './test_result_helpers';
 
@@ -192,7 +192,7 @@ const runJest = async ({
   // CLI.
   setConfig(contexts, {rootDir: process.cwd()});
 
-  const results = await new TestRunner(globalConfig, {
+  const results = await new TestScheduler(globalConfig, {
     startRun,
   }).runTests(allTests, testWatcher);
 

--- a/packages/jest-cli/src/test_scheduler.js
+++ b/packages/jest-cli/src/test_scheduler.js
@@ -45,7 +45,7 @@ class CancelRun extends Error {
   }
 }
 
-export type TestRunnerOptions = {|
+export type TestSchedulerOptions = {|
   startRun: (globalConfig: GlobalConfig) => *,
 |};
 
@@ -54,12 +54,12 @@ type OnTestSuccess = (test: Test, result: TestResult) => Promise<*>;
 
 const TEST_WORKER_PATH = require.resolve('./test_worker');
 
-class TestRunner {
+class TestScheduler {
   _globalConfig: GlobalConfig;
-  _options: TestRunnerOptions;
+  _options: TestSchedulerOptions;
   _dispatcher: ReporterDispatcher;
 
-  constructor(globalConfig: GlobalConfig, options: TestRunnerOptions) {
+  constructor(globalConfig: GlobalConfig, options: TestSchedulerOptions) {
     this._globalConfig = globalConfig;
     this._dispatcher = new ReporterDispatcher();
     this._options = options;
@@ -400,4 +400,4 @@ const getEstimatedTime = (timings, workers) => {
     : Math.max(timings.reduce((sum, time) => sum + time) / workers, max);
 };
 
-module.exports = TestRunner;
+module.exports = TestScheduler;


### PR DESCRIPTION
**Summary**

I'm refactoring some bits and pieces in the TestRunner and it makes more sense going forward to rename it to TestScheduler. It doesn't actually run the tests, it just tells other parts of Jests which ones to run, in which order and how (in-band or parallel).

**Test plan**

jest