### PR TITLE
Make --listTests return a new line separated list when not using --json

### DIFF
--- a/integration_tests/__tests__/__snapshots__/list_tests.test.js.snap
+++ b/integration_tests/__tests__/__snapshots__/list_tests.test.js.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`--listTests flag causes tests to be printed in different lines 1`] = `
+/MOCK_ABOLUTE_PATH/integration_tests/list_tests/__tests__/dummy.test.js
+/MOCK_ABOLUTE_PATH/integration_tests/list_tests/__tests__/other.test.js
+`;
+
+exports[`--listTests flag causes tests to be printed out as JSON when using the --json flag 1`] = `["/MOCK_ABOLUTE_PATH/integration_tests/list_tests/__tests__/dummy.test.js","/MOCK_ABOLUTE_PATH/integration_tests/list_tests/__tests__/other.test.js"]`;

--- a/integration_tests/__tests__/list_tests.test.js
+++ b/integration_tests/__tests__/list_tests.test.js
@@ -12,8 +12,15 @@
 const runJest = require('../runJest');
 
 describe('--listTests flag', () => {
-  it('causes tests to be printed out as JSON', () => {
+  it('causes tests to be printed in different lines', () => {
     const {status, stdout} = runJest('list_tests', ['--listTests']);
+
+    expect(status).toBe(0);
+    expect(() => JSON.parse(stdout)).not.toThrow();
+  });
+
+  it('causes tests to be printed out as JSON when using the --json flag', () => {
+    const {status, stdout} = runJest('list_tests', ['--listTests', '--json']);
 
     expect(status).toBe(0);
     expect(() => JSON.parse(stdout)).not.toThrow();

--- a/integration_tests/__tests__/list_tests.test.js
+++ b/integration_tests/__tests__/list_tests.test.js
@@ -10,19 +10,27 @@
 'use strict';
 
 const runJest = require('../runJest');
+const path = require('path');
+
+const testRootDir = path.resolve(__dirname, '..', '..');
+expect.addSnapshotSerializer({
+  print: val => val.replace(new RegExp(testRootDir, 'g'), '/MOCK_ABOLUTE_PATH'),
+  test: val => typeof val === 'string' && val.includes(testRootDir),
+});
 
 describe('--listTests flag', () => {
   it('causes tests to be printed in different lines', () => {
     const {status, stdout} = runJest('list_tests', ['--listTests']);
 
     expect(status).toBe(0);
-    expect(() => JSON.parse(stdout)).not.toThrow();
+    expect(stdout).toMatchSnapshot();
   });
 
   it('causes tests to be printed out as JSON when using the --json flag', () => {
-    const {status, stdout} = runJest('list_tests', ['--listTests', '--json']);
+    const {status, stderr} = runJest('list_tests', ['--listTests', '--json']);
 
     expect(status).toBe(0);
-    expect(() => JSON.parse(stdout)).not.toThrow();
+    expect(() => JSON.parse(stderr)).not.toThrow();
+    expect(stderr).toMatchSnapshot();
   });
 });

--- a/integration_tests/__tests__/list_tests.test.js
+++ b/integration_tests/__tests__/list_tests.test.js
@@ -23,7 +23,7 @@ describe('--listTests flag', () => {
     const {status, stdout} = runJest('list_tests', ['--listTests']);
 
     expect(status).toBe(0);
-    expect(stdout).toMatchSnapshot();
+    expect(stdout.split('\n').sort().join('\n')).toMatchSnapshot();
   });
 
   it('causes tests to be printed out as JSON when using the --json flag', () => {
@@ -31,6 +31,6 @@ describe('--listTests flag', () => {
 
     expect(status).toBe(0);
     expect(() => JSON.parse(stderr)).not.toThrow();
-    expect(stderr).toMatchSnapshot();
+    expect(JSON.stringify(JSON.parse(stderr).sort())).toMatchSnapshot();
   });
 });

--- a/integration_tests/list_tests/__tests__/other.test.js
+++ b/integration_tests/list_tests/__tests__/other.test.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+it("isn't actually run", () => {
+  // (because it is only used for --listTests)
+  expect(true).toBe(false);
+});

--- a/packages/jest-cli/src/run_jest.js
+++ b/packages/jest-cli/src/run_jest.js
@@ -167,7 +167,13 @@ const runJest = async ({
   allTests = sequencer.sort(allTests);
 
   if (globalConfig.listTests) {
-    console.log(JSON.stringify(allTests.map(test => test.path)));
+    const testsPaths = allTests.map(test => test.path);
+    if (globalConfig.json) {
+      outputStream.write(JSON.stringify(testsPaths));
+    } else {
+      outputStream.write(testsPaths.join('\n'));
+    }
+
     onComplete && onComplete(makeEmptyAggregatedTestResult());
     return null;
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

https://github.com/facebook/jest/issues/4214

This makes `--listTests` play better with tools like `grep`

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
![screen shot 2017-08-09 at 10 33 07 am](https://user-images.githubusercontent.com/574806/29136214-6db47fa2-7cf1-11e7-8428-6996ed825f5b.png)

