### PR TITLE
Better error handling for --config

### DIFF
--- a/packages/jest-cli/src/cli/args.js
+++ b/packages/jest-cli/src/cli/args.js
@@ -45,7 +45,11 @@ const check = (argv: Argv) => {
     );
   }
 
-  if (!isJSONString(argv.config) && !argv.config.match(/\.js(on)?$/)) {
+  if (
+    argv.config &&
+    !isJSONString(argv.config) &&
+    !argv.config.match(/\.js(on)?$/)
+  ) {
     throw new Error(
       'The --config option requires a JSON string literal, or a file path with a .js or .json extension.\n' +
         'Example usage: jest --config ./jest.config.js',

--- a/packages/jest-cli/src/cli/args.js
+++ b/packages/jest-cli/src/cli/args.js
@@ -10,6 +10,7 @@
 
 import type {Argv} from 'types/Argv';
 
+import {isJSONString} from 'jest-config';
 import isCI from 'is-ci';
 
 const check = (argv: Argv) => {
@@ -41,6 +42,13 @@ const check = (argv: Argv) => {
       'The --findRelatedTests option requires file paths to be specified.\n' +
         'Example usage: jest --findRelatedTests ./src/source.js ' +
         './src/index.js.',
+    );
+  }
+
+  if (!isJSONString(argv.config) && !argv.config.match(/\.js(on)?$/)) {
+    throw new Error(
+      'The --config option requires a JSON string literal, or a file path with a .js or .json extension.\n' +
+        'Example usage: jest --config ./jest.config.js',
     );
   }
 

--- a/packages/jest-config/src/index.js
+++ b/packages/jest-config/src/index.js
@@ -41,7 +41,7 @@ function readConfig(
       config = JSON.parse(argv.config);
     } catch (e) {
       throw new Error(
-        'There was an error while parsing the `--config` argument as a JSON string',
+        'There was an error while parsing the `--config` argument as a JSON string.',
       );
     }
 

--- a/packages/jest-config/src/index.js
+++ b/packages/jest-config/src/index.js
@@ -36,7 +36,15 @@ function readConfig(
   // A JSON string was passed to `--config` argument and we can parse it
   // and use as is.
   if (isJSONString(argv.config)) {
-    const config = JSON.parse(argv.config);
+    let config;
+    try {
+      config = JSON.parse(argv.config);
+    } catch (e) {
+      throw new Error(
+        'There was an error while parsing the `--config` argument as a JSON string',
+      );
+    }
+
     // NOTE: we might need to resolve this dir to an absolute path in the future
     config.rootDir = config.rootDir || packageRoot;
     rawOptions = config;
@@ -146,6 +154,7 @@ const getConfigs = (
 
 module.exports = {
   getTestEnvironment,
+  isJSONString,
   normalize,
   readConfig,
 };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

https://github.com/facebook/jest/issues/4194

Adds error handling for the `--config` argument.
- Handles error for invalid JSON object
- Handles error for invalid files that are not `.js` or `.json`

**Test plan**

![config-errors](https://user-images.githubusercontent.com/574806/29143162-108f63c4-7d09-11e7-8960-f2a9db391b57.gif)

Quick question: Is there a place that I can add some tests for this?


