### PR TITLE
Complain if expect is passed multiple arguments

### DIFF
--- a/packages/jest-matchers/src/__tests__/matchers.test.js
+++ b/packages/jest-matchers/src/__tests__/matchers.test.js
@@ -11,6 +11,12 @@
 const {stringify} = require('jest-matcher-utils');
 const jestExpect = require('../');
 
+it('should throw if passed two arguments', () => {
+  expect(() => jestExpect('foo', 'bar')).toThrow(
+    new Error('Expect takes at most one argument.'),
+  );
+});
+
 describe('.rejects', () => {
   it('should reject', async () => {
     await jestExpect(Promise.reject(4)).rejects.toBe(4);

--- a/packages/jest-matchers/src/index.js
+++ b/packages/jest-matchers/src/index.js
@@ -52,7 +52,11 @@ const isPromise = obj => {
   );
 };
 
-const expect = (actual: any): ExpectationObject => {
+const expect = (actual: any, ...rest): ExpectationObject => {
+  if (rest.length !== 0) {
+    throw new Error('Expect takes at most one argument.');
+  }
+
   const allMatchers = getMatchers();
   const expectation = {
     not: {},


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

When using [unexpected](http://unexpected.js.org/) it's common to import it under the name `expect`. Consider this case:

```js
import expect from 'unexpected';

it('should be unexpected', () => {
  expect(true, 'to be false');
});
``` 

If a user by accident forgets to import unexpected, they will not immediately notice, as the builtin expect in jest will ignore any further arguments passed to it. Which will result in a passing test instead of the failure you would expect.

This PR adds a check to the expect method, so that it will throw an error if it is called with more than one argument.

@Munter already discussed a solution to this with @cpojer. The solution I implemented here is a bit different. Instead of using a check on `arguments.length` I opted to use `...rest` and check that it has a length of 0. The expect method was implemented as an arrow function, and arrow functions do not expose `arguments`, so it was either refactoring it into a normal function or using the `...rest` alternative. From my humble benchmarking I didn't observe any significant difference, so I opted for the least invasive change, that also happens to be following the [Code Conventions](https://github.com/facebook/jest/blob/master/CONTRIBUTING.md#code-conventions) the closest - prefering es6 syntax where possible.

To further enhance the check one could add a check for the case of expect being called with no arguments. It's less likely to cause users to shoot themselves in the feet, so I left it out.

**Test plan**

The test implemented covers the case that the check is implementing.

All tests in the project is passing. I ran `yarn test` in the root of the repo to verify that the change had no unintended side effects.
