### PR TITLE
Fix mocking for modules with folders on windows

### DIFF
--- a/packages/jest-haste-map/src/get_mock_name.js
+++ b/packages/jest-haste-map/src/get_mock_name.js
@@ -14,7 +14,9 @@ const MOCKS_PATTERN = path.sep + '__mocks__' + path.sep;
 
 const getMockName = (filePath: string) => {
   const mockPath = filePath.split(MOCKS_PATTERN)[1];
-  return mockPath.substring(0, mockPath.lastIndexOf(path.extname(mockPath)));
+  return mockPath
+    .substring(0, mockPath.lastIndexOf(path.extname(mockPath)))
+    .replace(/\\/g, '/');
 };
 
 module.exports = getMockName;


### PR DESCRIPTION
**Summary**

Fixing #4014: mocks for packages with folders (like `lodash/fp/sum`) on Windows. 

**Questions** 
1) what is the better way to write tests for that? 
2) Is this change enough? Doesn't it break something else on windows? There are not a lot for tests

