### PR TITLE
Whitelist the `runner` option in valid_config.

### DIFF
--- a/packages/jest-config/src/valid_config.js
+++ b/packages/jest-config/src/valid_config.js
@@ -69,6 +69,7 @@ module.exports = ({
   resolver: '<rootDir>/resolver.js',
   rootDir: '/',
   roots: ['<rootDir>'],
+  runner: 'jest-runner',
   setupFiles: ['<rootDir>/setup.js'],
   setupTestFrameworkScriptFile: '<rootDir>/test_setup_file.js',
   silent: true,


### PR DESCRIPTION
**Summary**

This was missing and giving me a few confusing validation messages.

**Test plan**

When runner is specified, no warning is printed.