### PR TITLE
remove @emails directive using jest-docblock

### DIFF
--- a/packages/jest-cli/src/__tests__/search_source.test.js
+++ b/packages/jest-cli/src/__tests__/search_source.test.js
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @emails oncall+jsinfra
  */
+
 'use strict';
 
 jest.setTimeout(15000);

--- a/packages/jest-cli/src/__tests__/test_scheduler.test.js
+++ b/packages/jest-cli/src/__tests__/test_scheduler.test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @emails oncall+jsinfra
  */
 
 'use strict';

--- a/packages/jest-cli/src/__tests__/watch.test.js
+++ b/packages/jest-cli/src/__tests__/watch.test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @emails oncall+jsinfra
  */
 
 'use strict';

--- a/packages/jest-cli/src/__tests__/watch_filename_pattern_mode.test.js
+++ b/packages/jest-cli/src/__tests__/watch_filename_pattern_mode.test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @emails oncall+jsinfra
  */
 
 'use strict';

--- a/packages/jest-cli/src/__tests__/watch_test_name_pattern_mode.test.js
+++ b/packages/jest-cli/src/__tests__/watch_test_name_pattern_mode.test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @emails oncall+jsinfra
  */
 
 'use strict';

--- a/packages/jest-cli/src/reporters/__tests__/utils.test.js
+++ b/packages/jest-cli/src/reporters/__tests__/utils.test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @emails oncall+jsinfra
  */
 
 const path = require('path');

--- a/packages/jest-config/src/__tests__/validate_pattern.test.js
+++ b/packages/jest-config/src/__tests__/validate_pattern.test.js
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @emails oncall+jsinfra
  */
+
 'use strict';
 
 const validatePattern = require('../validate_pattern');

--- a/packages/jest-get-type/src/__tests__/index.test.js
+++ b/packages/jest-get-type/src/__tests__/index.test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @emails oncall+jsinfra
  */
 
 'use strict';

--- a/packages/jest-haste-map/src/__tests__/index.test.js
+++ b/packages/jest-haste-map/src/__tests__/index.test.js
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @emails oncall+jsinfra
  */
+
 'use strict';
 
 jest.mock('child_process', () => ({

--- a/packages/jest-haste-map/src/__tests__/worker.test.js
+++ b/packages/jest-haste-map/src/__tests__/worker.test.js
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @emails oncall+jsinfra
  */
+
 'use strict';
 
 const path = require('path');

--- a/packages/jest-haste-map/src/crawlers/__tests__/node.test.js
+++ b/packages/jest-haste-map/src/crawlers/__tests__/node.test.js
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @emails oncall+jsinfra
  */
+
 'use strict';
 
 const skipOnWindows = require('../../../../../scripts/skip_on_windows');

--- a/packages/jest-haste-map/src/crawlers/__tests__/watchman.test.js
+++ b/packages/jest-haste-map/src/crawlers/__tests__/watchman.test.js
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @emails oncall+jsinfra
  */
+
 'use strict';
 
 const skipOnWindows = require('../../../../../scripts/skip_on_windows');

--- a/packages/jest-haste-map/src/lib/__tests__/get_platform_extension.test.js
+++ b/packages/jest-haste-map/src/lib/__tests__/get_platform_extension.test.js
@@ -6,8 +6,8 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @emails oncall+jsinfra
  */
+
 'use strict';
 
 let getPlatformExtension;

--- a/packages/jest-haste-map/src/lib/__tests__/normalize_path_sep.test.js
+++ b/packages/jest-haste-map/src/lib/__tests__/normalize_path_sep.test.js
@@ -6,8 +6,8 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @emails oncall+jsinfra
  */
+
 'use strict';
 
 describe('normalizePathSep', () => {

--- a/packages/jest-jasmine2/src/__tests__/expectation_result_factory.test.js
+++ b/packages/jest-jasmine2/src/__tests__/expectation_result_factory.test.js
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @emails oncall+jsinfra
  */
+
 'use strict';
 
 const expectationResultFactory = require('../expectation_result_factory');

--- a/packages/jest-jasmine2/src/__tests__/integration/lifecycle_hooks_test.js
+++ b/packages/jest-jasmine2/src/__tests__/integration/lifecycle_hooks_test.js
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @emails oncall+jsinfra
  */
+
 'use strict';
 
 describe('test lifecycle hooks', () => {

--- a/packages/jest-jasmine2/src/__tests__/it_to_test_alias.test.js
+++ b/packages/jest-jasmine2/src/__tests__/it_to_test_alias.test.js
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @emails oncall+jsinfra
  */
+
 'use strict';
 
 test('global.test', () => {});

--- a/packages/jest-jasmine2/src/__tests__/iterators.test.js
+++ b/packages/jest-jasmine2/src/__tests__/iterators.test.js
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @emails oncall+jsinfra
  */
+
 'use strict';
 
 describe('iterators', () => {

--- a/packages/jest-jasmine2/src/__tests__/matchers.test.js
+++ b/packages/jest-jasmine2/src/__tests__/matchers.test.js
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @emails oncall+jsinfra
  */
+
 'use strict';
 
 describe('matchers', () => {

--- a/packages/jest-jasmine2/src/__tests__/p_timeout.test.js
+++ b/packages/jest-jasmine2/src/__tests__/p_timeout.test.js
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @emails oncall+jsinfra
  */
+
 'use strict';
 
 jest.useFakeTimers();

--- a/packages/jest-jasmine2/src/__tests__/queue_runner.test.js
+++ b/packages/jest-jasmine2/src/__tests__/queue_runner.test.js
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @emails oncall+jsinfra
  */
+
 'use strict';
 
 const queueRunner = require('../queue_runner');

--- a/packages/jest-jasmine2/src/__tests__/reporter.test.js
+++ b/packages/jest-jasmine2/src/__tests__/reporter.test.js
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @emails oncall+jsinfra
  */
+
 'use strict';
 
 const JasmineReporter = require('../reporter');

--- a/packages/jest-matcher-utils/src/__tests__/index.test.js
+++ b/packages/jest-matcher-utils/src/__tests__/index.test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @emails oncall+jsinfra
  */
 
 'use strict';

--- a/packages/jest-matchers/src/__tests__/assertion_counts.test.js
+++ b/packages/jest-matchers/src/__tests__/assertion_counts.test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @emails oncall+jsinfra
  */
 
 'use strict';

--- a/packages/jest-matchers/src/__tests__/asymmetric_matchers.test.js
+++ b/packages/jest-matchers/src/__tests__/asymmetric_matchers.test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @emails oncall+jsinfra
  */
 
 'use strict';

--- a/packages/jest-matchers/src/__tests__/extend.test.js
+++ b/packages/jest-matchers/src/__tests__/extend.test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @emails oncall+jsinfra
  */
 
 const matcherUtils = require('jest-matcher-utils');

--- a/packages/jest-matchers/src/__tests__/matchers.test.js
+++ b/packages/jest-matchers/src/__tests__/matchers.test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @emails oncall+jsinfra
  */
 
 const {stringify} = require('jest-matcher-utils');

--- a/packages/jest-matchers/src/__tests__/spy_matchers.test.js
+++ b/packages/jest-matchers/src/__tests__/spy_matchers.test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @emails oncall+jsinfra
  */
 
 const Immutable = require('immutable');

--- a/packages/jest-matchers/src/__tests__/symbol_in_objects.test.js
+++ b/packages/jest-matchers/src/__tests__/symbol_in_objects.test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @emails oncall+jsinfra
  */
 
 'use strict';

--- a/packages/jest-matchers/src/__tests__/to_throw_matchers.test.js
+++ b/packages/jest-matchers/src/__tests__/to_throw_matchers.test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @emails oncall+jsinfra
  */
 
 'use strict';

--- a/packages/jest-matchers/src/__tests__/utils.test.js
+++ b/packages/jest-matchers/src/__tests__/utils.test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @emails oncall+jsinfra
  */
 
 'use strict';

--- a/packages/jest-message-util/src/__tests__/messages.test.js
+++ b/packages/jest-message-util/src/__tests__/messages.test.js
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @emails oncall+jsinfra
  */
+
 'use strict';
 
 const {formatResultsErrors, formatExecError} = require('../');

--- a/packages/jest-mock/src/__tests__/jest_mock.test.js
+++ b/packages/jest-mock/src/__tests__/jest_mock.test.js
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @emails oncall+jsinfra
  */
+
 'use strict';
 
 const vm = require('vm');

--- a/packages/jest-resolve/src/__tests__/resolve.test.js
+++ b/packages/jest-resolve/src/__tests__/resolve.test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @emails oncall+jsinfra
  */
 
 'use strict';

--- a/packages/jest-runner/src/__tests__/test_runner.test.js
+++ b/packages/jest-runner/src/__tests__/test_runner.test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @emails oncall+jsinfra
  */
 
 'use strict';

--- a/packages/jest-runtime/src/__tests__/instrumentation.test.js
+++ b/packages/jest-runtime/src/__tests__/instrumentation.test.js
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @emails oncall+jsinfra
  */
+
 'use strict';
 
 jest.mock('vm');

--- a/packages/jest-runtime/src/__tests__/resolve_browser.test.js
+++ b/packages/jest-runtime/src/__tests__/resolve_browser.test.js
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @emails oncall+jsinfra
  */
+
 'use strict';
 
 let createRuntime;

--- a/packages/jest-runtime/src/__tests__/runtime_environment.test.js
+++ b/packages/jest-runtime/src/__tests__/runtime_environment.test.js
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @emails oncall+jsinfra
  */
+
 'use strict';
 
 let createRuntime;

--- a/packages/jest-runtime/src/__tests__/runtime_gen_mock_from_module.test.js
+++ b/packages/jest-runtime/src/__tests__/runtime_gen_mock_from_module.test.js
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @emails oncall+jsinfra
  */
+
 'use strict';
 
 let createRuntime;

--- a/packages/jest-runtime/src/__tests__/runtime_internal_module.test.js
+++ b/packages/jest-runtime/src/__tests__/runtime_internal_module.test.js
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @emails oncall+jsinfra
  */
+
 'use strict';
 
 const path = require('path');

--- a/packages/jest-runtime/src/__tests__/runtime_jest_fn.js
+++ b/packages/jest-runtime/src/__tests__/runtime_jest_fn.js
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @emails oncall+jsinfra
  */
+
 'use strict';
 
 let createRuntime;

--- a/packages/jest-runtime/src/__tests__/runtime_jest_spy_on.test.js
+++ b/packages/jest-runtime/src/__tests__/runtime_jest_spy_on.test.js
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @emails oncall+jsinfra
  */
+
 'use strict';
 
 let createRuntime;

--- a/packages/jest-runtime/src/__tests__/runtime_mock.test.js
+++ b/packages/jest-runtime/src/__tests__/runtime_mock.test.js
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @emails oncall+jsinfra
  */
+
 'use strict';
 
 const path = require('path');

--- a/packages/jest-runtime/src/__tests__/runtime_module_directories.test.js
+++ b/packages/jest-runtime/src/__tests__/runtime_module_directories.test.js
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @emails oncall+jsinfra
  */
+
 'use strict';
 
 const path = require('path');

--- a/packages/jest-runtime/src/__tests__/runtime_node_path.test.js
+++ b/packages/jest-runtime/src/__tests__/runtime_node_path.test.js
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @emails oncall+jsinfra
  */
+
 'use strict';
 
 const path = require('path');

--- a/packages/jest-runtime/src/__tests__/runtime_require_mock.test.js
+++ b/packages/jest-runtime/src/__tests__/runtime_require_mock.test.js
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @emails oncall+jsinfra
  */
+
 'use strict';
 
 const path = require('path');

--- a/packages/jest-runtime/src/__tests__/runtime_require_module.test.js
+++ b/packages/jest-runtime/src/__tests__/runtime_require_module.test.js
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @emails oncall+jsinfra
  */
+
 'use strict';
 
 const path = require('path');

--- a/packages/jest-runtime/src/__tests__/runtime_require_module_or_mock.test.js
+++ b/packages/jest-runtime/src/__tests__/runtime_require_module_or_mock.test.js
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @emails oncall+jsinfra
  */
+
 'use strict';
 
 const moduleNameMapper = {

--- a/packages/jest-runtime/src/__tests__/runtime_require_module_or_mock_transitive_deps.test.js
+++ b/packages/jest-runtime/src/__tests__/runtime_require_module_or_mock_transitive_deps.test.js
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @emails oncall+jsinfra
  */
+
 'use strict';
 
 let createRuntime;

--- a/packages/jest-runtime/src/__tests__/script_transformer.test.js
+++ b/packages/jest-runtime/src/__tests__/script_transformer.test.js
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @emails oncall+jsinfra
  */
+
 'use strict';
 
 const slash = require('slash');

--- a/packages/jest-util/src/__tests__/fake_timers.test.js
+++ b/packages/jest-util/src/__tests__/fake_timers.test.js
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @emails oncall+jsinfra
  */
+
 'use strict';
 
 const vm = require('vm');


### PR DESCRIPTION
these emails are from the old times when we used to have www as the main repo for jest.
removed using code in https://github.com/facebook/jest/pull/4267