### PR TITLE
Fixing broken link for relay tests

### DIFF
--- a/docs/en/MoreResources.md
+++ b/docs/en/MoreResources.md
@@ -20,7 +20,7 @@ By now you should have a good idea of how Jest can make it easy to test your app
 
 ### Learn by example
 
-You will find a number of example test cases in the [`examples`](https://github.com/facebook/jest/tree/master/examples) folder on GitHub. You can also learn from the excellent tests used by the [React](https://github.com/facebook/react/tree/master/src/renderers/shared/stack/reconciler/__tests__), [Relay](https://github.com/facebook/relay/tree/master/src/container/__tests__), and [React Native](https://github.com/facebook/react-native/tree/master/Libraries/Animated/src/__tests__) projects.
+You will find a number of example test cases in the [`examples`](https://github.com/facebook/jest/tree/master/examples) folder on GitHub. You can also learn from the excellent tests used by the [React](https://github.com/facebook/react/tree/master/src/renderers/shared/stack/reconciler/__tests__), [Relay](https://github.com/facebook/relay/tree/master/packages/react-relay/modern/__tests__), and [React Native](https://github.com/facebook/react-native/tree/master/Libraries/Animated/src/__tests__) projects.
 
 ### Join the community
 


### PR DESCRIPTION
**Summary**

The link to Relay was previously broken by linking to a non-existent page.

**Test plan**

Clicking on the relay link, now takes you to:

![image](https://user-images.githubusercontent.com/1730684/29260795-06f364f0-80c4-11e7-8d6c-fccb016354f6.png)

