### PR TITLE
Include fullName in formattedAssertion

### DIFF
--- a/packages/jest-util/src/__tests__/format_test_results_test.js
+++ b/packages/jest-util/src/__tests__/format_test_results_test.js
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+'use strict';
+
+const formatTestResults = require('../formatTestResults');
+
+describe('formatTestResults', () => {
+  const assertion = {
+    fullName: 'TestedModule#aMethod when some condition is met returns true',
+    status: 'passed',
+    title: 'returns true',
+  };
+
+  const results = {
+    testResults: [
+      {
+        numFailingTests: 0,
+        perfStats: {end: 2, start: 1},
+        testResults: [assertion],
+      },
+    ],
+  };
+
+  it('includes test full name', () => {
+    const result = formatTestResults(results, null, null);
+    expect(result.testResults[0].assertionResults[0].fullName).toEqual(
+      assertion.fullName,
+    );
+  });
+});

--- a/packages/jest-util/src/format_test_results.js
+++ b/packages/jest-util/src/format_test_results.js
@@ -61,6 +61,7 @@ function formatTestAssertion(
 ): FormattedAssertionResult {
   const result: FormattedAssertionResult = {
     failureMessages: null,
+    fullName: assertion.fullName,
     status: assertion.status,
     title: assertion.title,
   };

--- a/types/TestResult.js
+++ b/types/TestResult.js
@@ -94,9 +94,10 @@ export type AssertionResult = {|
 |};
 
 export type FormattedAssertionResult = {
+  failureMessages: Array<string> | null,
+  fullName: string,
   status: Status,
   title: string,
-  failureMessages: Array<string> | null,
 };
 
 export type AggregatedResultWithoutCoverage = {


### PR DESCRIPTION
**Summary**
Reinstate of https://github.com/facebook/jest/pull/3378 with added tests. 

> This PR adds an additional field fullName to FormattedAssertionResult.
>
> When we try to analyze the test result json, we find that two it test cases under different describe block in one test file are rendered the same in the json report. Including the full name help solving this issue.

**Test plan**
* [x] Unit test
* [x] Manual test output
```
...
    "testResults": [
        {
            "assertionResults": [
                {
                    "failureMessages": [],
                    "fullName": "Header renders",
                    "status": "passed",
                    "title": "renders"
                },
                {
                    "failureMessages": [],
                    "fullName": "Header renders <Element /> with right props",
                    "status": "passed",
                    "title": "renders <Element /> with right props"
                }
            ],
            "endTime": 1493233733071,
            "message": "",
            "name": "/path/to/the/test/file.js",
            "startTime": 1493233730480,
            "status": "passed",
            "summary": ""
        }
    ],
...
```