### PR TITLE
Implement 'jest.requireMock'

### DIFF
--- a/integration_tests/__tests__/jest_require_mock.test.js
+++ b/integration_tests/__tests__/jest_require_mock.test.js
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+
+'use strict';
+
+const path = require('path');
+const os = require('os');
+const skipOnWindows = require('../../scripts/skip_on_windows');
+const {cleanup, writeFiles} = require('../utils');
+const runJest = require('../runJest');
+
+const DIR = path.resolve(os.tmpdir(), 'jest_require_mock_test');
+
+skipOnWindows.suite();
+
+beforeEach(() => cleanup(DIR));
+afterAll(() => cleanup(DIR));
+
+test('understands dependencies using require.requireMock', () => {
+  writeFiles(DIR, {
+    '.watchmanconfig': '',
+    '__tests__/a.test.js': `
+      const a = require.requireMock('../a');
+
+      test('a', () => {});
+    `,
+    '__tests__/b.test.js': `test('b', () => {});`,
+    'a.js': `module.exports = {}`,
+    'package.json': JSON.stringify({jest: {}}),
+  });
+
+  let stdout;
+  let stderr;
+  ({stdout, stderr} = runJest(DIR, ['--findRelatedTests', 'a.js']));
+
+  expect(stdout).not.toMatch('No tests found');
+  expect(stderr).toMatch('PASS  __tests__/a.test.js');
+  expect(stderr).not.toMatch('PASS  __tests__/b.test.js');
+
+  // change to jest.requireMock
+  writeFiles(DIR, {
+    '__tests__/a.test.js': `
+      const a = jest.requireMock('../a');
+
+      test('a', () => {});
+    `,
+  });
+
+  ({stderr, stdout} = runJest(DIR, ['--findRelatedTests', 'a.js']));
+  expect(stdout).not.toMatch('No tests found');
+  expect(stderr).toMatch('PASS  __tests__/a.test.js');
+  expect(stderr).not.toMatch('PASS  __tests__/b.test.js');
+});

--- a/packages/jest-haste-map/src/lib/__tests__/extract_requires.test.js
+++ b/packages/jest-haste-map/src/lib/__tests__/extract_requires.test.js
@@ -111,3 +111,13 @@ it('understands jest.requireActual', () => {
   const code = `jest.requireActual('whiskey');`;
   expect(extractRequires(code)).toEqual(['whiskey']);
 });
+
+it('understands require.requireMock', () => {
+  const code = `require.requireMock('cheeseburger');`;
+  expect(extractRequires(code)).toEqual(['cheeseburger']);
+});
+
+it('understands jest.requireMock', () => {
+  const code = `jest.requireMock('scotch');`;
+  expect(extractRequires(code)).toEqual(['scotch']);
+});

--- a/packages/jest-haste-map/src/lib/extract_requires.js
+++ b/packages/jest-haste-map/src/lib/extract_requires.js
@@ -14,7 +14,7 @@ const lineCommentRe = /\/\/.*/g;
 const replacePatterns = {
   EXPORT_RE: /(\bexport\s+(?!type )(?:[^'"]+\s+from\s+)??)(['"])([^'"]+)(\2)/g,
   IMPORT_RE: /(\bimport\s+(?!type )(?:[^'"]+\s+from\s+)??)(['"])([^'"]+)(\2)/g,
-  REQUIRE_EXTENSIONS_PATTERN: /(?:^|[^.]\s*)(\b(?:require\s*?\.\s*?(?:requireActual|requireMock)|jest\s*?\.\s*?(?:requireActual|genMockFromModule))\s*?\(\s*?)([`'"])([^`'"]+)(\2\s*?\))/g,
+  REQUIRE_EXTENSIONS_PATTERN: /(?:^|[^.]\s*)(\b(?:require\s*?\.\s*?(?:requireActual|requireMock)|jest\s*?\.\s*?(?:requireActual|requireMock|genMockFromModule))\s*?\(\s*?)([`'"])([^`'"]+)(\2\s*?\))/g,
   REQUIRE_RE: /(?:^|[^.]\s*)(\brequire\s*?\(\s*?)([`'"])([^`'"]+)(\2\s*?\))/g,
 };
 

--- a/packages/jest-runtime/src/index.js
+++ b/packages/jest-runtime/src/index.js
@@ -761,6 +761,7 @@ class Runtime {
 
       mock,
       requireActual: localRequire.requireActual,
+      requireMock: localRequire.requireMock,
       resetAllMocks,
       resetModuleRegistry: resetModules,
       resetModules,

--- a/types/Jest.js
+++ b/types/Jest.js
@@ -31,6 +31,7 @@ export type Jest = {|
   isMockFunction(fn: Function): boolean,
   mock(moduleName: string, moduleFactory?: any, options?: Object): Jest,
   requireActual: LocalModuleRequire,
+  requireMock: LocalModuleRequire,
   resetAllMocks(): Jest,
   resetModuleRegistry(): Jest,
   resetModules(): Jest,


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Implements jest.requireMock
Similar to #4260

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Added jest_require_mock.test.js, and added to extract_requires.test.js for testing. Ran yarn test, partial output below

`jeffreylai-mbp:jest jeffreylai$ yarn test
Using globally installed version of Yarn
yarn test v0.28.1
$ yarn run typecheck --silent && yarn run lint --silent && yarn run jest --silent && yarn run test-examples --silent
Using globally installed version of Yarn
Found 0 errors
Using globally installed version of Yarn
Using globally installed version of Yarn
...
<Test outputs>
...
Test Suites: 162 passed, 162 total
Tests:       1502 passed, 1502 total
Snapshots:   671 passed, 671 total
Time:        100.887s
Ran all test suites.
Using globally installed version of Yarn
$ cd /Users/jeffreylai/Documents/jest/examples/react-native
$ yarn --production

Using globally installed version of Yarn
warning package.json: No license field
warning jest-rn@1.0.0: No license field
$ cd /Users/jeffreylai/Documents/jest/scripts
$ /Users/jeffreylai/Documents/jest/packages/jest-cli/bin/jest.js --projects /Users/jeffreylai/Documents/jest/examples/async /Users/jeffreylai/Documents/jest/examples/enzyme /Users/jeffreylai/Documents/jest/examples/getting_started /Users/jeffreylai/Documents/jest/examples/jquery /Users/jeffreylai/Documents/jest/examples/manual_mocks/package.json /Users/jeffreylai/Documents/jest/examples/module_mock/package.json /Users/jeffreylai/Documents/jest/examples/react/package.json /Users/jeffreylai/Documents/jest/examples/react-native/package.json /Users/jeffreylai/Documents/jest/examples/snapshot/package.json /Users/jeffreylai/Documents/jest/examples/timer/package.json /Users/jeffreylai/Documents/jest/examples/typescript/package.json

 ...
<Test outputs>
...


Test Suites: 19 passed, 19 total
Tests:       39 passed, 39 total
Snapshots:   12 passed, 12 total
Time:        3.358s, estimated 6s
Ran all test suites in 11 projects.
✨  Done in 123.80s.`