### PR TITLE
Adding ancestorTitles property to JSON test output

### DIFF
--- a/integration_tests/__tests__/__snapshots__/coverage_report.test.js.snap
+++ b/integration_tests/__tests__/__snapshots__/coverage_report.test.js.snap
@@ -22,7 +22,7 @@ All files |    85.71 |      100 |       50 |    85.71 |                |
 
 exports[`json reporter printing with --coverage 1`] = `
 "Test Suites: 1 failed, 1 total
-Tests:       1 failed, 1 passed, 2 total
+Tests:       1 failed, 2 passed, 3 total
 Snapshots:   0 total
 Time:        <<REPLACED>>
 Ran all test suites.

--- a/integration_tests/__tests__/json_reporter.test.js
+++ b/integration_tests/__tests__/json_reporter.test.js
@@ -39,12 +39,30 @@ describe('JSON Reporter', () => {
       );
     }
 
-    expect(jsonResult.numTotalTests).toBe(2);
+    expect(jsonResult.numTotalTests).toBe(3);
     expect(jsonResult.numTotalTestSuites).toBe(1);
     expect(jsonResult.numRuntimeErrorTestSuites).toBe(0);
-    expect(jsonResult.numPassedTests).toBe(1);
+    expect(jsonResult.numPassedTests).toBe(2);
     expect(jsonResult.numFailedTests).toBe(1);
     expect(jsonResult.numPendingTests).toBe(0);
+
+    const noAncestors = jsonResult.testResults[0].assertionResults.find(
+      item => item.title == 'no ancestors',
+    );
+    let expected = {ancestorTitles: []};
+    expect(noAncestors).toEqual(expect.objectContaining(expected));
+
+    const addsNumbers = jsonResult.testResults[0].assertionResults.find(
+      item => item.title == 'adds numbers',
+    );
+    expected = {ancestorTitles: ['sum']};
+    expect(addsNumbers).toEqual(expect.objectContaining(expected));
+
+    const failsTheTest = jsonResult.testResults[0].assertionResults.find(
+      item => item.title == 'fails the test',
+    );
+    expected = {ancestorTitles: ['sum', 'failing tests']};
+    expect(failsTheTest).toEqual(expect.objectContaining(expected));
   });
 
   it('outputs coverage report', () => {
@@ -53,7 +71,7 @@ describe('JSON Reporter', () => {
     const stderr = result.stderr.toString();
     let jsonResult;
 
-    expect(stderr).toMatch(/1 failed, 1 passed/);
+    expect(stderr).toMatch(/1 failed, 2 passed/);
     expect(result.status).toBe(1);
 
     try {
@@ -64,11 +82,29 @@ describe('JSON Reporter', () => {
       );
     }
 
-    expect(jsonResult.numTotalTests).toBe(2);
+    expect(jsonResult.numTotalTests).toBe(3);
     expect(jsonResult.numTotalTestSuites).toBe(1);
     expect(jsonResult.numRuntimeErrorTestSuites).toBe(0);
-    expect(jsonResult.numPassedTests).toBe(1);
+    expect(jsonResult.numPassedTests).toBe(2);
     expect(jsonResult.numFailedTests).toBe(1);
     expect(jsonResult.numPendingTests).toBe(0);
+
+    const noAncestors = jsonResult.testResults[0].assertionResults.find(
+      item => item.title == 'no ancestors',
+    );
+    let expected = {ancestorTitles: []};
+    expect(noAncestors).toEqual(expect.objectContaining(expected));
+
+    const addsNumbers = jsonResult.testResults[0].assertionResults.find(
+      item => item.title == 'adds numbers',
+    );
+    expected = {ancestorTitles: ['sum']};
+    expect(addsNumbers).toEqual(expect.objectContaining(expected));
+
+    const failsTheTest = jsonResult.testResults[0].assertionResults.find(
+      item => item.title == 'fails the test',
+    );
+    expected = {ancestorTitles: ['sum', 'failing tests']};
+    expect(failsTheTest).toEqual(expect.objectContaining(expected));
   });
 });

--- a/integration_tests/json_reporter/__tests__/sum.test.js
+++ b/integration_tests/json_reporter/__tests__/sum.test.js
@@ -9,12 +9,18 @@
 
 const sum = require('../sum');
 
+it('no ancestors', () => {
+  expect(true).toBeTruthy();
+});
+
 describe('sum', () => {
   it('adds numbers', () => {
     expect(sum(1, 2)).toEqual(3);
   });
 
-  it('fails the test', () => {
-    expect(sum(1, 2)).toEqual(4);
+  describe('failing tests', () => {
+    it('fails the test', () => {
+      expect(sum(1, 2)).toEqual(4);
+    });
   });
 });

--- a/packages/jest-util/src/format_test_results.js
+++ b/packages/jest-util/src/format_test_results.js
@@ -60,6 +60,7 @@ function formatTestAssertion(
   assertion: AssertionResult,
 ): FormattedAssertionResult {
   const result: FormattedAssertionResult = {
+    ancestorTitles: assertion.ancestorTitles,
     failureMessages: null,
     fullName: assertion.fullName,
     status: assertion.status,


### PR DESCRIPTION
**Summary**
This addresses the need brought up in #2479 

The motivation I have is that in order to properly report our test runs to regulatory agencies, we are planning on using the JSON output to feed reports.  But our unit tests can be nested a couple of layers deep in 'describe' and 'in' blocks.  Currently, the JSON output only includes the title of the nearest test block, thus, losing the context of its parents.
For example, we want to see:
- passwords
  - size
    - too short
    - too long
and not just:
- too long

**Test plan**
I've altered the sum.test.js file to create tests with zero, one, and many ancestors, and added checks for the new ancestorTitles property.
