### PR TITLE
Update migration guide with jest-codemods transformers

### DIFF
--- a/docs/en/MigrationGuide.md
+++ b/docs/en/MigrationGuide.md
@@ -11,12 +11,21 @@ next: testing-frameworks
 If you'd like to try out Jest with an existing codebase, there are a number of ways to convert to Jest:
 
 * If you are using Jasmine, or a Jasmine like API (for example [Mocha](https://mochajs.org)), Jest should be mostly compatible and easy to migrate to.
-* If you are using Mocha, AVA or Tape, you can automatically migrate with Jest Codemods (see below).
+* If you are using AVA, Expect.js (by Automattic), Jasmine, Mocha, proxyquire, Should.js or Tape you can automatically migrate with Jest Codemods (see below).
 * If you like [chai](http://chaijs.com/), you can upgrade to Jest and continue using chai. However, we recommend trying out Jest's assertions and their failure messages. Jest Codemods can migrate from chai (see below).
 
 ### jest-codemods
 
-If you are using [Mocha](https://mochajs.org), [AVA](https://github.com/avajs/ava), [chai](http://chaijs.com/) or [Tape](https://github.com/substack/tape), you can use the third-party [jest-codemods](https://github.com/skovhus/jest-codemods) to do most of the dirty migration work. It runs a code transformation on your codebase using [jscodeshift](https://github.com/facebook/jscodeshift).
+If you are using
+[AVA](https://github.com/avajs/ava),
+[Chai](https://github.com/chaijs/chai),
+[Expect.js (by Automattic)](https://github.com/Automattic/expect.js),
+[Jasmine](https://github.com/jasmine/jasmine),
+[Mocha](https://github.com/mochajs/mocha),
+[proxyquire](https://github.com/thlorenz/proxyquire),
+[Should.js](https://github.com/tj/should.js/)
+or [Tape](https://github.com/substack/tape)
+you can use the third-party [jest-codemods](https://github.com/skovhus/jest-codemods) to do most of the dirty migration work. It runs a code transformation on your codebase using [jscodeshift](https://github.com/facebook/jscodeshift).
 
 Install Jest Codemods with `npm` by running:
 

--- a/packages/jest-cli/package.json
+++ b/packages/jest-cli/package.json
@@ -19,7 +19,7 @@
     "jest-message-util": "^20.0.3",
     "jest-regex-util": "^20.0.3",
     "jest-resolve-dependencies": "^20.0.3",
-    "jest-runner": "^20.0.4",
+    "jest-runner": "test",
     "jest-runtime": "^20.0.4",
     "jest-snapshot": "^20.0.3",
     "jest-util": "^20.0.3",

--- a/packages/jest-cli/package.json
+++ b/packages/jest-cli/package.json
@@ -19,7 +19,7 @@
     "jest-message-util": "^20.0.3",
     "jest-regex-util": "^20.0.3",
     "jest-resolve-dependencies": "^20.0.3",
-    "jest-runner": "test",
+    "jest-runner": "^20.0.4",
     "jest-runtime": "^20.0.4",
     "jest-snapshot": "^20.0.3",
     "jest-util": "^20.0.3",


### PR DESCRIPTION
**Summary**

The migration-guide documentation hasn't been updated for some time and [jest-codemods](https://github.com/skovhus/jest-codemods) now supports upgrading from even more test frameworks to Jest.

**Test plan**

Before:
![screenshot 2017-08-20 18 47 47](https://user-images.githubusercontent.com/1260305/29496708-a026f402-85d8-11e7-9109-0bda197ca656.png)

After:
![screenshot 2017-08-20 18 47 32](https://user-images.githubusercontent.com/1260305/29496707-9c97b682-85d8-11e7-8cad-628d0a3b6d32.png)
