### PR TITLE
Correct summary message for flag --findRelatedTests.

### DIFF
--- a/integration_tests/__tests__/find_related_files.test.js
+++ b/integration_tests/__tests__/find_related_files.test.js
@@ -39,4 +39,7 @@ test('runs tests related to filename', () => {
 
   const {stderr} = runJest(DIR, ['--findRelatedTests', 'a.js']);
   expect(stderr).toMatch('PASS  __tests__/test.test.js');
+
+  const summaryMsg = 'Ran all test suites related to files matching /a.js/i.';
+  expect(stderr).toMatch(summaryMsg);
 });

--- a/packages/jest-cli/src/reporters/summary_reporter.js
+++ b/packages/jest-cli/src/reporters/summary_reporter.js
@@ -240,12 +240,20 @@ class SummaryReporter extends BaseReporter {
   }
 
   _getTestSummary(contexts: Set<Context>, globalConfig: GlobalConfig) {
+    const getMatchingTestsInfo = () => {
+      const prefix = globalConfig.findRelatedTests
+        ? ' related to files matching '
+        : ' matching ';
+
+      return (
+        chalk.dim(prefix) +
+        testPathPatternToRegExp(globalConfig.testPathPattern).toString()
+      );
+    };
+
     const testInfo = globalConfig.onlyChanged
       ? chalk.dim(' related to changed files')
-      : globalConfig.testPathPattern
-        ? chalk.dim(' matching ') +
-          testPathPatternToRegExp(globalConfig.testPathPattern).toString()
-        : '';
+      : globalConfig.testPathPattern ? getMatchingTestsInfo() : '';
 
     const nameInfo = globalConfig.testNamePattern
       ? chalk.dim(' with tests matching ') + `"${globalConfig.testNamePattern}"`


### PR DESCRIPTION
	* fixes #4247
	* added tests for findRelatedTests summary message

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
This fixes the summary message and was reported in 4247.

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
1. yarn run build && yarn run test was passing

**Assumptions**
1. findRelatedTests can be used only when path pattern  is present in args
2. if findRelatedTests is not present and path pattern is provided in args, then the summary message will always be like,
_Ran all test suites matching a.js_
3. findRelatedTests & onlyChanged can not be used together
4. onlyChanged can not be used when path pattern is present in command
