### PR TITLE
beforeAll/afterAll hooks validations

### DIFF
--- a/packages/jest-jasmine2/src/__tests__/integration/lifecycle_hooks_test.js
+++ b/packages/jest-jasmine2/src/__tests__/integration/lifecycle_hooks_test.js
@@ -55,4 +55,12 @@ describe('test lifecycle hooks', () => {
     afterEach(pushMessage('afterEach2'));
     it('does it 1', pushMessage('outer it 1'));
   });
+
+  describe('Hooks validatios', () => {
+    it('throw an error when the first element is an string', () => {
+      expect(beforeAll('setup')).toThrowError(
+        "First argument in the beforeAll hook can't be a string",
+      );
+    });
+  });
 });

--- a/packages/jest-jasmine2/src/__tests__/integration/lifecycle_hooks_test.js
+++ b/packages/jest-jasmine2/src/__tests__/integration/lifecycle_hooks_test.js
@@ -56,10 +56,10 @@ describe('test lifecycle hooks', () => {
     it('does it 1', pushMessage('outer it 1'));
   });
 
-  describe('Hooks validatios', () => {
-    it('throw an error when the first element is an string', () => {
+  describe('Hooks validation', () => {
+    it('throws when the first element is not a function', () => {
       expect(beforeAll('setup')).toThrowError(
-        "First argument in the beforeAll hook can't be a string",
+        'First argument in the beforeAll hook must be a function',
       );
     });
   });

--- a/packages/jest-jasmine2/src/jasmine/Suite.js
+++ b/packages/jest-jasmine2/src/jasmine/Suite.js
@@ -85,7 +85,8 @@ Suite.prototype.beforeEach = function(fn) {
 };
 
 Suite.prototype.beforeAll = function(fn) {
-  this.beforeAllFns.push(isFunction(fn, 'beforeAll'));
+  validateFunction(fn, 'beforeAll');
+  this.beforeAllFns.push(fn);
 };
 
 Suite.prototype.afterEach = function(fn) {
@@ -93,7 +94,8 @@ Suite.prototype.afterEach = function(fn) {
 };
 
 Suite.prototype.afterAll = function(fn) {
-  this.afterAllFns.unshift(isFunction(fn, 'afterAll'));
+  validateFunction(fn, 'afterAll');
+  this.afterAllFns.unshift(fn);
 };
 
 Suite.prototype.addChild = function(child) {
@@ -190,11 +192,9 @@ function isFailure(args) {
   return !args[0];
 }
 
-function isFunction(fn, fnName) {
-  if (typeof fn.fn === 'string') {
-    throw new Error(`First argument in the ${fnName} hook cant't be a string`);
-  } else {
-    return fn;
+function validateFunction(fn, fnName) {
+  if (typeof fn.fn !== 'function') {
+    throw new Error(`First argument in the ${fnName} hook must be a function`);
   }
 }
 

--- a/packages/jest-jasmine2/src/jasmine/Suite.js
+++ b/packages/jest-jasmine2/src/jasmine/Suite.js
@@ -85,7 +85,7 @@ Suite.prototype.beforeEach = function(fn) {
 };
 
 Suite.prototype.beforeAll = function(fn) {
-  this.beforeAllFns.push(fn);
+  this.beforeAllFns.push(isFunction(fn, 'beforeAll'));
 };
 
 Suite.prototype.afterEach = function(fn) {
@@ -93,7 +93,7 @@ Suite.prototype.afterEach = function(fn) {
 };
 
 Suite.prototype.afterAll = function(fn) {
-  this.afterAllFns.unshift(fn);
+  this.afterAllFns.unshift(isFunction(fn, 'afterAll'));
 };
 
 Suite.prototype.addChild = function(child) {
@@ -188,6 +188,14 @@ function isAfterAll(children) {
 
 function isFailure(args) {
   return !args[0];
+}
+
+function isFunction(fn, fnName) {
+  if (typeof fn.fn === 'string') {
+    throw new Error(`First argument in the ${fnName} hook cant't be a string`);
+  } else {
+    return fn;
+  }
 }
 
 module.exports = Suite;


### PR DESCRIPTION
Throw an error when in the beforeAll/afterAll hook, the first
argument is an string

Code related to issue [4266](https://github.com/facebook/jest/issues/4266)

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
Add a berforAll method like this.

    beforeAll('setup', () => setupCode());

excepted result

    $ jest
    FAIL  ./sum.test.js
    ● Test suite failed to run

    First argument in the afterAll hook cant't be a string


<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
