### PR TITLE
Replace match with test and omit redundant String conversion in jest-diff

### DIFF
--- a/packages/jest-diff/src/__tests__/diff.test.js
+++ b/packages/jest-diff/src/__tests__/diff.test.js
@@ -80,9 +80,12 @@ describe('no visual difference', () => {
 
 test('oneline strings', () => {
   // oneline strings don't produce a diff currently.
-  expect(stripAnsi(diff('ab', 'aa'))).toBe(null);
+  expect(diff('ab', 'aa')).toBe(null);
   expect(diff('a', 'a')).toMatch(/no visual difference/);
-  expect(stripAnsi(diff('123456789', '234567890'))).toBe(null);
+  expect(diff('123456789', '234567890')).toBe(null);
+  // if either string is oneline
+  expect(diff('oneline', 'multi\nline')).toBe(null);
+  expect(diff('multi\nline', 'oneline')).toBe(null);
 });
 
 test('falls back to not call toJSON if objects look identical', () => {

--- a/packages/jest-diff/src/index.js
+++ b/packages/jest-diff/src/index.js
@@ -40,6 +40,8 @@ const FALLBACK_FORMAT_OPTIONS = {
   plugins: PLUGINS,
 };
 
+const MULTILINE_REGEXP = /[\r\n]/;
+
 // Generate a string that will highlight the difference between two values
 // with green and red. (similar to how github does code diffing)
 function diff(a: any, b: any, options: ?DiffOptions): ?string {
@@ -79,9 +81,9 @@ function diff(a: any, b: any, options: ?DiffOptions): ?string {
 
   switch (aType) {
     case 'string':
-      const multiline = a.match(/[\r\n]/) !== -1 && b.indexOf('\n') !== -1;
+      const multiline = MULTILINE_REGEXP.test(a) && b.indexOf('\n') !== -1;
       if (multiline) {
-        return diffStrings(String(a), String(b), options);
+        return diffStrings(a, b, options);
       }
       return null;
     case 'number':


### PR DESCRIPTION
**Summary**

* Rewrote condition with `RegExp.test` because `String.match` is equivalent to `RegExp.exec` which returns either `null` or an array, therefore first condition was always false.
* Removed explicit conversion with `String` constructor, because `switch (aType) case 'string'` and have already returned if `expectedType !== getType(b)` or string asymmetric matcher.

**Test plan**

* Deleted `stripAnsi` from 2 existing tests with `toBe(null)` assertion
* Added 2 tests for either a or b is one line. The test for a one line and b multi line failed first.