### PR TITLE
Join lines with newline in jest-diff

### DIFF
--- a/integration_tests/__tests__/__snapshots__/failures.test.js.snap
+++ b/integration_tests/__tests__/__snapshots__/failures.test.js.snap
@@ -150,7 +150,7 @@ exports[`works with node assert 1`] = `
     - Expected
     + Received
     
-    Object {
+      Object {
         \\"a\\": Object {
           \\"b\\": Object {
     -       \\"c\\": 6,
@@ -178,7 +178,7 @@ exports[`works with node assert 1`] = `
     - Expected
     + Received
     
-    Object {
+      Object {
         \\"a\\": Object {
           \\"b\\": Object {
     -       \\"c\\": 7,
@@ -247,7 +247,7 @@ exports[`works with node assert 1`] = `
     - Expected
     + Received
     
-    Object {
+      Object {
     -   \\"a\\": 2,
     +   \\"a\\": 1,
       }

--- a/packages/jest-diff/src/diff_strings.js
+++ b/packages/jest-diff/src/diff_strings.js
@@ -75,8 +75,7 @@ const diffLines = (a: string, b: string): Diff => {
           })
           .join('\n');
       })
-      .join('\n')
-      .trim(),
+      .join('\n'),
     isDifferent,
   };
 };
@@ -134,8 +133,7 @@ const structuredPatch = (a: string, b: string, contextLines?: number): Diff => {
           ? createPatchMark(hunk) + lines
           : lines;
       })
-      .join('\n')
-      .trim(),
+      .join('\n'),
     isDifferent,
   };
 };

--- a/packages/jest-diff/src/diff_strings.js
+++ b/packages/jest-diff/src/diff_strings.js
@@ -71,11 +71,11 @@ const diffLines = (a: string, b: string): Diff => {
           .map(line => {
             const highlightedLine = highlightTrailingWhitespace(line, bgColor);
             const mark = color(part.added ? '+' : part.removed ? '-' : ' ');
-            return mark + ' ' + color(highlightedLine) + '\n';
+            return mark + ' ' + color(highlightedLine);
           })
-          .join('');
+          .join('\n');
       })
-      .join('')
+      .join('\n')
       .trim(),
     isDifferent,
   };
@@ -125,16 +125,16 @@ const structuredPatch = (a: string, b: string, contextLines?: number): Diff => {
             const bgColor = getBgColor(added, removed);
 
             const highlightedLine = highlightTrailingWhitespace(line, bgColor);
-            return color(highlightedLine) + '\n';
+            return color(highlightedLine);
           })
-          .join('');
+          .join('\n');
 
         isDifferent = true;
         return shouldShowPatchMarks(hunk, oldLinesCount)
           ? createPatchMark(hunk) + lines
           : lines;
       })
-      .join('')
+      .join('\n')
       .trim(),
     isDifferent,
   };


### PR DESCRIPTION
**Summary**

Join lines with newline instead of concatenating newline to each line, and then trimming result.

Is the `trim` method redundant? What about leading spaces? Glad you asked:

* For default `--colors` option, ansi codes “protect” leading space if first line is unchanged.
* For `--no-colors` option, leading space is trimmed. Inconsistent and seems like a bug.

**Test plan**

If you approve, I will update this PR:
* delete 2 occurrences of `trim` method
* update snapshot `works with node assert` in `integration_tests/__tests__/failures.test.js`

```diff
-    Object {
+      Object {
         "a": Object {
           "b": Object {
     -       "c": 6,
     +       "c": 5,
           },

-    Object {
+      Object {
         "a": Object {
           "b": Object {
     -       "c": 7,
     +       "c": 5,
           },

-    Object {
+      Object {
     -   "a": 2,
     +   "a": 1,
       }
```