### PR TITLE
use mercurial instead of hg

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ The core team will be monitoring for pull requests. When we get one, we'll run s
    using [homebrew](http://brew.sh/): `brew install hg`.
 
    ```sh
-   brew install hg # maybe
+   brew install mercurial
    yarn test
    ```
 


### PR DESCRIPTION
The commend `brew install hg` does not work.

**Summary**

use mercurial instead of hg in brew install command.

**Test plan**

Just document update, no test is needed.
