### PR TITLE
Add watchPathIgnorePatterns to exclude paths to trigger test re-run in watch mode

### DIFF
--- a/integration_tests/__tests__/__snapshots__/show_config.test.js.snap
+++ b/integration_tests/__tests__/__snapshots__/show_config.test.js.snap
@@ -51,7 +51,8 @@ exports[`--showConfig outputs config info and exits 1`] = `
       \\"timers\\": \\"real\\",
       \\"transformIgnorePatterns\\": [
         \\"/node_modules/\\"
-      ]
+      ],
+      \\"watchPathIgnorePatterns\\": []
     }
   ],
   \\"globalConfig\\": {

--- a/packages/jest-cli/src/cli/args.js
+++ b/packages/jest-cli/src/cli/args.js
@@ -549,6 +549,13 @@ const options = {
       '--no-watchman.',
     type: 'boolean',
   },
+  watchPathIgnorePatterns: {
+    description:
+      'An array of regexp pattern strings that are matched ' +
+      'against all paths before trigger test re-run in watch mode. ' +
+      'If the test path matches any of the patterns, it will be skipped.',
+    type: 'array',
+  },
 };
 
 module.exports = {

--- a/packages/jest-cli/src/cli/args.js
+++ b/packages/jest-cli/src/cli/args.js
@@ -542,19 +542,19 @@ const options = {
       '`--watch` option.',
     type: 'boolean',
   },
-  watchman: {
-    default: undefined,
-    description:
-      'Whether to use watchman for file crawling. Disable using ' +
-      '--no-watchman.',
-    type: 'boolean',
-  },
   watchPathIgnorePatterns: {
     description:
       'An array of regexp pattern strings that are matched ' +
       'against all paths before trigger test re-run in watch mode. ' +
       'If the test path matches any of the patterns, it will be skipped.',
     type: 'array',
+  },
+  watchman: {
+    default: undefined,
+    description:
+      'Whether to use watchman for file crawling. Disable using ' +
+      '--no-watchman.',
+    type: 'boolean',
   },
 };
 

--- a/packages/jest-cli/src/lib/__tests__/is_valid_path.test.js
+++ b/packages/jest-cli/src/lib/__tests__/is_valid_path.test.js
@@ -20,6 +20,7 @@ const rootDir = path.resolve(path.sep, 'root');
 const config = makeProjectConfig({
   rootDir,
   roots: [path.resolve(rootDir, 'src'), path.resolve(rootDir, 'lib')],
+  watchPathIgnorePatterns: ['pacts/']
 });
 
 it('is valid when it is a file inside roots', () => {
@@ -84,6 +85,16 @@ it('is not valid when it is a file in the coverage dir', () => {
       makeGlobalConfig({coverageDirectory: 'cov-dir'}),
       config,
       path.resolve(rootDir, 'src', 'cov-dir', 'lib', 'index.js'),
+    ),
+  ).toBe(false);
+});
+
+it('is not valid when it is a file match one of the watchPathIgnorePatterns', () => {
+  expect(
+    isValidPath(
+      makeGlobalConfig({rootDir}),
+      config,
+      path.resolve(rootDir, 'pacts', 'todoapp-todoservice.json'),
     ),
   ).toBe(false);
 });

--- a/packages/jest-cli/src/lib/__tests__/is_valid_path.test.js
+++ b/packages/jest-cli/src/lib/__tests__/is_valid_path.test.js
@@ -20,7 +20,7 @@ const rootDir = path.resolve(path.sep, 'root');
 const config = makeProjectConfig({
   rootDir,
   roots: [path.resolve(rootDir, 'src'), path.resolve(rootDir, 'lib')],
-  watchPathIgnorePatterns: ['pacts/']
+  watchPathIgnorePatterns: ['pacts/'],
 });
 
 it('is valid when it is a file inside roots', () => {

--- a/packages/jest-cli/src/lib/is_valid_path.js
+++ b/packages/jest-cli/src/lib/is_valid_path.js
@@ -19,6 +19,7 @@ function isValidPath(
 ) {
   return (
     !filePath.includes(globalConfig.coverageDirectory) &&
+    !config.watchPathIgnorePatterns.some(pattern => filePath.match(pattern)) &&
     !filePath.endsWith(`.${SNAPSHOT_EXTENSION}`)
   );
 }

--- a/packages/jest-config/src/__tests__/normalize.test.js
+++ b/packages/jest-config/src/__tests__/normalize.test.js
@@ -383,6 +383,57 @@ describe('coveragePathIgnorePatterns', () => {
   });
 });
 
+describe('watchPathIgnorePatterns', () => {
+  it('does not normalize paths relative to rootDir', () => {
+    // This is a list of patterns, so we can't assume any of them are
+    // directories
+    const {options} = normalize(
+      {
+        rootDir: '/root/path/foo',
+        watchPathIgnorePatterns: ['bar/baz', 'qux/quux'],
+      },
+      {},
+    );
+
+    expect(options.watchPathIgnorePatterns).toEqual([
+      joinForPattern('bar', 'baz'),
+      joinForPattern('qux', 'quux'),
+    ]);
+  });
+
+  it('does not normalize trailing slashes', () => {
+    // This is a list of patterns, so we can't assume any of them are
+    // directories
+    const {options} = normalize(
+      {
+        rootDir: '/root/path/foo',
+        watchPathIgnorePatterns: ['bar/baz', 'qux/quux/'],
+      },
+      {},
+    );
+
+    expect(options.watchPathIgnorePatterns).toEqual([
+      joinForPattern('bar', 'baz'),
+      joinForPattern('qux', 'quux', ''),
+    ]);
+  });
+
+  it('substitutes <rootDir> tokens', () => {
+    const {options} = normalize(
+      {
+        rootDir: '/root/path/foo',
+        watchPathIgnorePatterns: ['hasNoToken', '<rootDir>/hasAToken'],
+      },
+      {},
+    );
+
+    expect(options.watchPathIgnorePatterns).toEqual([
+      'hasNoToken',
+      joinForPattern('', 'root', 'path', 'foo', 'hasAToken'),
+    ]);
+  });
+});
+
 describe('testPathIgnorePatterns', () => {
   it('does not normalize paths relative to rootDir', () => {
     // This is a list of patterns, so we can't assume any of them are

--- a/packages/jest-config/src/defaults.js
+++ b/packages/jest-config/src/defaults.js
@@ -63,9 +63,9 @@ module.exports = ({
   testURL: 'about:blank',
   timers: 'real',
   transformIgnorePatterns: [NODE_MODULES_REGEXP],
-  watchPathIgnorePatterns: [],
   useStderr: false,
   verbose: null,
   watch: false,
+  watchPathIgnorePatterns: [],
   watchman: true,
 }: DefaultOptions);

--- a/packages/jest-config/src/defaults.js
+++ b/packages/jest-config/src/defaults.js
@@ -63,6 +63,7 @@ module.exports = ({
   testURL: 'about:blank',
   timers: 'real',
   transformIgnorePatterns: [NODE_MODULES_REGEXP],
+  watchPathIgnorePatterns: [],
   useStderr: false,
   verbose: null,
   watch: false,

--- a/packages/jest-config/src/index.js
+++ b/packages/jest-config/src/index.js
@@ -148,6 +148,7 @@ const getConfigs = (
       timers: options.timers,
       transform: options.transform,
       transformIgnorePatterns: options.transformIgnorePatterns,
+      watchPathIgnorePatterns: options.watchPathIgnorePatterns,
       unmockedModulePathPatterns: options.unmockedModulePathPatterns,
     }),
   };

--- a/packages/jest-config/src/index.js
+++ b/packages/jest-config/src/index.js
@@ -148,8 +148,8 @@ const getConfigs = (
       timers: options.timers,
       transform: options.transform,
       transformIgnorePatterns: options.transformIgnorePatterns,
-      watchPathIgnorePatterns: options.watchPathIgnorePatterns,
       unmockedModulePathPatterns: options.unmockedModulePathPatterns,
+      watchPathIgnorePatterns: options.watchPathIgnorePatterns,
     }),
   };
 };

--- a/packages/jest-config/src/normalize.js
+++ b/packages/jest-config/src/normalize.js
@@ -415,6 +415,7 @@ function normalize(options: InitialOptions, argv: Argv) {
       case 'modulePathIgnorePatterns':
       case 'testPathIgnorePatterns':
       case 'transformIgnorePatterns':
+      case 'watchPathIgnorePatterns':
       case 'unmockedModulePathPatterns':
         value = normalizeUnmockedModulePathPatterns(options, key);
         break;

--- a/packages/jest-config/src/valid_config.js
+++ b/packages/jest-config/src/valid_config.js
@@ -89,6 +89,7 @@ module.exports = ({
     '^.+\\.js$': '<rootDir>/preprocessor.js',
   },
   transformIgnorePatterns: [NODE_MODULES_REGEXP],
+  watchPathIgnorePatterns: [],
   unmockedModulePathPatterns: ['mock'],
   updateSnapshot: true,
   useStderr: false,

--- a/packages/jest-config/src/valid_config.js
+++ b/packages/jest-config/src/valid_config.js
@@ -89,11 +89,11 @@ module.exports = ({
     '^.+\\.js$': '<rootDir>/preprocessor.js',
   },
   transformIgnorePatterns: [NODE_MODULES_REGEXP],
-  watchPathIgnorePatterns: [],
   unmockedModulePathPatterns: ['mock'],
   updateSnapshot: true,
   useStderr: false,
   verbose: false,
   watch: false,
+  watchPathIgnorePatterns: [],
   watchman: true,
 }: InitialOptions);

--- a/packages/jest-validate/src/__tests__/fixtures/jest_config.js
+++ b/packages/jest-validate/src/__tests__/fixtures/jest_config.js
@@ -52,6 +52,7 @@ const defaultConfig = {
   testURL: 'about:blank',
   timers: 'real',
   transformIgnorePatterns: [NODE_MODULES_REGEXP],
+  watchPathIgnorePatterns: [],
   useStderr: false,
   verbose: null,
   watch: false,

--- a/packages/jest-validate/src/__tests__/fixtures/jest_config.js
+++ b/packages/jest-validate/src/__tests__/fixtures/jest_config.js
@@ -52,10 +52,10 @@ const defaultConfig = {
   testURL: 'about:blank',
   timers: 'real',
   transformIgnorePatterns: [NODE_MODULES_REGEXP],
-  watchPathIgnorePatterns: [],
   useStderr: false,
   verbose: null,
   watch: false,
+  watchPathIgnorePatterns: [],
 };
 
 const validConfig = {

--- a/test_utils.js
+++ b/test_utils.js
@@ -90,6 +90,7 @@ const DEFAULT_PROJECT_CONFIG: ProjectConfig = {
   timers: 'real',
   transform: [],
   transformIgnorePatterns: [],
+  watchPathIgnorePatterns: [],
   unmockedModulePathPatterns: null,
 };
 

--- a/test_utils.js
+++ b/test_utils.js
@@ -90,8 +90,8 @@ const DEFAULT_PROJECT_CONFIG: ProjectConfig = {
   timers: 'real',
   transform: [],
   transformIgnorePatterns: [],
-  watchPathIgnorePatterns: [],
   unmockedModulePathPatterns: null,
+  watchPathIgnorePatterns: [],
 };
 
 const makeGlobalConfig = (overrides: Object = {}): GlobalConfig => {

--- a/types/Argv.js
+++ b/types/Argv.js
@@ -78,6 +78,7 @@ export type Argv = {|
   timers: 'real' | 'fake',
   transform: string,
   transformIgnorePatterns: Array<string>,
+  watchPathIgnorePatterns: Array<string>,
   unmockedModulePathPatterns: ?Array<string>,
   updateSnapshot: boolean,
   useStderr: boolean,

--- a/types/Config.js
+++ b/types/Config.js
@@ -55,6 +55,7 @@ export type DefaultOptions = {|
   testURL: string,
   timers: 'real' | 'fake',
   transformIgnorePatterns: Array<Glob>,
+  watchPathIgnorePatterns: Array<string>,
   useStderr: boolean,
   verbose: ?boolean,
   watch: boolean,
@@ -126,6 +127,7 @@ export type InitialOptions = {
   timers?: 'real' | 'fake',
   transform?: {[key: string]: string},
   transformIgnorePatterns?: Array<Glob>,
+  watchPathIgnorePatterns?: Array<string>,
   unmockedModulePathPatterns?: Array<string>,
   updateSnapshot?: boolean,
   useStderr?: boolean,
@@ -213,5 +215,6 @@ export type ProjectConfig = {|
   timers: 'real' | 'fake',
   transform: Array<[string, Path]>,
   transformIgnorePatterns: Array<Glob>,
+  watchPathIgnorePatterns: Array<string>,
   unmockedModulePathPatterns: ?Array<string>,
 |};


### PR DESCRIPTION
**Summary**

Add a configure argument `watchPathIgnorePatterns` to exclude patterns which should not trigger test re-run in watch mode.

**Test plan**

* Add test in `packages/jest-cli/src/lib/__tests__/is_valid_path.test.js` for testing the new exclude patterns.
* Add test in `packages/jest-config/src/__tests__/normalize.test.js` for testing the normalize path for the new arguments.
* Change snapshot in `integration_tests/__tests__/__snapshots__/show_config.test.js.snap` for new snapshot with the arguments.
