### PR TITLE
Remove `jest-util` from `jest-snapshot`.

### DIFF
--- a/packages/jest-snapshot/package.json
+++ b/packages/jest-snapshot/package.json
@@ -11,7 +11,7 @@
     "chalk": "^2.0.1",
     "jest-diff": "^20.0.3",
     "jest-matcher-utils": "^20.0.3",
-    "jest-util": "^20.0.3",
+    "mkdirp": "^0.5.1",
     "natural-compare": "^1.4.0",
     "pretty-format": "^20.0.3"
   }

--- a/packages/jest-snapshot/src/utils.js
+++ b/packages/jest-snapshot/src/utils.js
@@ -10,13 +10,13 @@
 
 import type {Path, SnapshotUpdateState} from 'types/Config';
 
-import fs from 'fs';
-import path from 'path';
-import chalk from 'chalk';
-import {createDirectory} from 'jest-util';
-import prettyFormat from 'pretty-format';
-import naturalCompare from 'natural-compare';
 import {getSerializers} from './plugins';
+import chalk from 'chalk';
+import fs from 'fs';
+import mkdirp from 'mkdirp';
+import naturalCompare from 'natural-compare';
+import path from 'path';
+import prettyFormat from 'pretty-format';
 
 const SNAPSHOT_EXTENSION = 'snap';
 const SNAPSHOT_VERSION = '1';
@@ -150,7 +150,7 @@ const printBacktickString = (str: string) => {
 
 const ensureDirectoryExists = (filePath: Path) => {
   try {
-    createDirectory(path.join(path.dirname(filePath)));
+    mkdirp.sync(path.join(path.dirname(filePath)), '777');
   } catch (e) {}
 };
 


### PR DESCRIPTION
**Summary**

We are using `jest-util` to create the snapshot folder, but it pulls in loads of code and `jest-validate` into vm contexts, which shouldn't be there…

**Test plan**

jest + manual logging for presence of these modules in the contexts.
