### PR TITLE
Make jest-matcher-utils use ESM exports

### DIFF
--- a/packages/jest-circus/src/format_node_assert_errors.js
+++ b/packages/jest-circus/src/format_node_assert_errors.js
@@ -11,9 +11,9 @@
 import type {DiffOptions} from 'jest-diff/src/diff_strings.js';
 import type {Event, State} from 'types/Circus';
 
-const {printReceived, printExpected} = require('jest-matcher-utils');
-const chalk = require('chalk');
-const diff = require('jest-diff');
+import {printExpected, printReceived} from 'jest-matcher-utils';
+import chalk from 'chalk';
+import diff from 'jest-diff';
 
 type AssertionError = {|
   actual: ?string,

--- a/packages/jest-config/package.json
+++ b/packages/jest-config/package.json
@@ -14,7 +14,6 @@
     "jest-environment-node": "^20.0.3",
     "jest-get-type": "^20.0.3",
     "jest-jasmine2": "^20.0.4",
-    "jest-matcher-utils": "^20.0.3",
     "jest-regex-util": "^20.0.3",
     "jest-resolve": "^20.0.4",
     "jest-util": "^20.0.3",

--- a/packages/jest-diff/package.json
+++ b/packages/jest-diff/package.json
@@ -10,7 +10,6 @@
   "dependencies": {
     "chalk": "^2.0.1",
     "diff": "^3.2.0",
-    "jest-matcher-utils": "^20.0.3",
     "jest-get-type": "^20.0.3",
     "pretty-format": "^20.0.3"
   }

--- a/packages/jest-matcher-utils/src/index.js
+++ b/packages/jest-matcher-utils/src/index.js
@@ -27,10 +27,10 @@ const PLUGINS = [
   AsymmetricMatcher,
 ];
 
-const EXPECTED_COLOR = chalk.green;
-const EXPECTED_BG = chalk.bgGreen;
-const RECEIVED_COLOR = chalk.red;
-const RECEIVED_BG = chalk.bgRed;
+export const EXPECTED_COLOR = chalk.green;
+export const EXPECTED_BG = chalk.bgGreen;
+export const RECEIVED_COLOR = chalk.red;
+export const RECEIVED_BG = chalk.bgRed;
 
 const NUMBERS = [
   'zero',
@@ -49,11 +49,11 @@ const NUMBERS = [
   'thirteen',
 ];
 
-const SUGGEST_TO_EQUAL = chalk.dim(
+export const SUGGEST_TO_EQUAL = chalk.dim(
   'Looks like you wanted to test for object/array equality with strict `toBe` matcher. You probably need to use `toEqual` instead.',
 );
 
-const stringify = (object: any, maxDepth?: number = 10): string => {
+export const stringify = (object: any, maxDepth?: number = 10): string => {
   const MAX_LENGTH = 10000;
   let result;
 
@@ -77,15 +77,17 @@ const stringify = (object: any, maxDepth?: number = 10): string => {
     : result;
 };
 
-const highlightTrailingWhitespace = (text: string, bgColor: Function): string =>
-  text.replace(/\s+$/gm, bgColor('$&'));
+export const highlightTrailingWhitespace = (
+  text: string,
+  bgColor: Function,
+): string => text.replace(/\s+$/gm, bgColor('$&'));
 
-const printReceived = (object: any) =>
+export const printReceived = (object: any) =>
   highlightTrailingWhitespace(RECEIVED_COLOR(stringify(object)), RECEIVED_BG);
-const printExpected = (value: any) =>
+export const printExpected = (value: any) =>
   highlightTrailingWhitespace(EXPECTED_COLOR(stringify(value)), EXPECTED_BG);
 
-const printWithType = (
+export const printWithType = (
   name: string,
   received: any,
   print: (value: any) => string,
@@ -99,7 +101,7 @@ const printWithType = (
   );
 };
 
-const ensureNoExpected = (expected: any, matcherName: string) => {
+export const ensureNoExpected = (expected: any, matcherName: string) => {
   matcherName || (matcherName = 'This');
   if (typeof expected !== 'undefined') {
     throw new Error(
@@ -111,7 +113,7 @@ const ensureNoExpected = (expected: any, matcherName: string) => {
   }
 };
 
-const ensureActualIsNumber = (actual: any, matcherName: string) => {
+export const ensureActualIsNumber = (actual: any, matcherName: string) => {
   matcherName || (matcherName = 'This matcher');
   if (typeof actual !== 'number') {
     throw new Error(
@@ -123,7 +125,7 @@ const ensureActualIsNumber = (actual: any, matcherName: string) => {
   }
 };
 
-const ensureExpectedIsNumber = (expected: any, matcherName: string) => {
+export const ensureExpectedIsNumber = (expected: any, matcherName: string) => {
   matcherName || (matcherName = 'This matcher');
   if (typeof expected !== 'number') {
     throw new Error(
@@ -135,15 +137,19 @@ const ensureExpectedIsNumber = (expected: any, matcherName: string) => {
   }
 };
 
-const ensureNumbers = (actual: any, expected: any, matcherName: string) => {
+export const ensureNumbers = (
+  actual: any,
+  expected: any,
+  matcherName: string,
+) => {
   ensureActualIsNumber(actual, matcherName);
   ensureExpectedIsNumber(expected, matcherName);
 };
 
-const pluralize = (word: string, count: number) =>
+export const pluralize = (word: string, count: number) =>
   (NUMBERS[count] || count) + ' ' + word + (count === 1 ? '' : 's');
 
-const matcherHint = (
+export const matcherHint = (
   matcherName: string,
   received: string = 'received',
   expected: string = 'expected',
@@ -162,23 +168,4 @@ const matcherHint = (
     (secondArgument ? `, ${EXPECTED_COLOR(secondArgument)}` : '') +
     chalk.dim(')')
   );
-};
-
-module.exports = {
-  EXPECTED_BG,
-  EXPECTED_COLOR,
-  RECEIVED_BG,
-  RECEIVED_COLOR,
-  SUGGEST_TO_EQUAL,
-  ensureActualIsNumber,
-  ensureExpectedIsNumber,
-  ensureNoExpected,
-  ensureNumbers,
-  highlightTrailingWhitespace,
-  matcherHint,
-  pluralize,
-  printExpected,
-  printReceived,
-  printWithType,
-  stringify,
 };

--- a/packages/jest-matchers/src/index.js
+++ b/packages/jest-matchers/src/index.js
@@ -19,7 +19,7 @@ import type {
   PromiseMatcherFn,
 } from 'types/Matchers';
 
-import utils from 'jest-matcher-utils';
+import * as utils from 'jest-matcher-utils';
 import matchers from './matchers';
 import spyMatchers from './spy_matchers';
 import toThrowMatchers from './to_throw_matchers';


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Might help with intermittent ` 'default' is not exported by packages/jest-matcher-utils/build/index.js`

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
`jest`

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
