### PR TITLE
Provide printText and printComment in markup.js for HTMLElement plugin

### DIFF
--- a/packages/pretty-format/src/plugins/html_element.js
+++ b/packages/pretty-format/src/plugins/html_element.js
@@ -10,12 +10,13 @@
 
 import type {Config, NewPlugin, Printer, Refs} from 'types/PrettyFormat';
 
-import escapeHTML from './lib/escape_html';
 import {
   printChildren,
+  printComment,
   printElement,
   printElementAsLeaf,
   printProps,
+  printText,
 } from './lib/markup';
 
 type Attribute = {
@@ -70,19 +71,12 @@ export const serialize = (
   refs: Refs,
   printer: Printer,
 ): string => {
-  const colors = config.colors;
   if (node.nodeType === TEXT_NODE) {
-    return colors.content.open + escapeHTML(node.data) + colors.content.close;
+    return printText(node.data, config);
   }
 
   if (node.nodeType === COMMENT_NODE) {
-    return (
-      colors.comment.open +
-      '<!--' +
-      escapeHTML(node.data) +
-      '-->' +
-      colors.comment.close
-    );
+    return printComment(node.data, config);
   }
 
   const type = node.tagName.toLowerCase();

--- a/packages/pretty-format/src/plugins/lib/markup.js
+++ b/packages/pretty-format/src/plugins/lib/markup.js
@@ -72,10 +72,26 @@ export const printChildren = (
         config.spacingOuter +
         indentation +
         (typeof child === 'string'
-          ? colors.content.open + escapeHTML(child) + colors.content.close
+          ? printText(child, config)
           : printer(child, config, indentation, depth, refs)),
     )
     .join('');
+};
+
+export const printText = (text: string, config: Config): string => {
+  const contentColor = config.colors.content;
+  return contentColor.open + escapeHTML(text) + contentColor.close;
+};
+
+export const printComment = (comment: string, config: Config): string => {
+  const commentColor = config.colors.comment;
+  return (
+    commentColor.open +
+    '<!--' +
+    escapeHTML(comment) +
+    '-->' +
+    commentColor.close
+  );
 };
 
 // Separate the functions to format props, children, and element,


### PR DESCRIPTION
**Summary**

* Decided against any special case for indentation “problem” of multiline strings, but found duplicate code for text nodes, therefore…
* Refactor to encapsulate all formatting details in `markup.js` so the 3 plugins become adaptors for data structure of React elements, React test objects, and DOM elements.

**Test plan**

Existing tests