### PR TITLE
Do not write cache directory and files when disable

### DIFF
--- a/packages/jest-runtime/src/script_transformer.js
+++ b/packages/jest-runtime/src/script_transformer.js
@@ -119,7 +119,7 @@ class ScriptTransformer {
         path.basename(filename, path.extname(filename)) + '_' + cacheKey,
       ),
     );
-    createDirectory(cacheDir);
+    this._config.cache && createDirectory(cacheDir);
 
     return cachePath;
   }
@@ -257,12 +257,12 @@ class ScriptTransformer {
         typeof transformed.map === 'string'
           ? transformed.map
           : JSON.stringify(transformed.map);
-      writeCacheFile(sourceMapPath, sourceMapContent);
+      this._config.cache && writeCacheFile(sourceMapPath, sourceMapContent);
     } else {
       sourceMapPath = null;
     }
 
-    writeCodeCacheFile(cacheFilePath, code);
+    this._config.cache && writeCodeCacheFile(cacheFilePath, code);
 
     return {
       code,


### PR DESCRIPTION
**Summary**
If `--no-cache` option is specified, cache directory and files are stored on the storage anyway. Which is unnecessary, because they are not used in the test process.

Also, it can lead to unwanted behaviour with disk usage in CI, if the cache files are not cleaned automatically.

**Test plan**
added unit test
