### PR TITLE
Return UNDEFINED if type neither string nor function in ReactElement plugin

### DIFF
--- a/packages/pretty-format/src/__tests__/react.test.js
+++ b/packages/pretty-format/src/__tests__/react.test.js
@@ -298,7 +298,9 @@ test('supports Unknown element', () => {
   // Suppress React.createElement(undefined) console error
   const consoleError = console.error;
   (console: Object).error = jest.fn();
-  expect(formatElement(React.createElement(undefined))).toEqual('<Unknown />');
+  expect(formatElement(React.createElement(undefined))).toEqual(
+    '<UNDEFINED />',
+  );
   (console: Object).error = consoleError;
 });
 

--- a/packages/pretty-format/src/plugins/react_element.js
+++ b/packages/pretty-format/src/plugins/react_element.js
@@ -39,7 +39,7 @@ const getType = element => {
   if (typeof element.type === 'function') {
     return element.type.displayName || element.type.name || 'Unknown';
   }
-  return 'Unknown';
+  return 'UNDEFINED';
 };
 
 export const serialize = (


### PR DESCRIPTION
**Summary**

Fixes #3823

The same “tag name” for anonymous function and undefined type seems confusing, therefore:
* `<Unknown>` if type is anonymous function as it has been
* `<UNDEFINED>` if type is neither string nor function

We think it seems easier to see and solve the problem if tests make it obvious (assuming that people review snapshots before committing :) than if the plugin throws an error.

**Test plan**

Updated the existing test for this case