### PR TITLE
fix typescript jest test crash

### DIFF
--- a/fixtures/callExpressionWithoutText.example
+++ b/fixtures/callExpressionWithoutText.example
@@ -1,0 +1,5 @@
+it("invoke forEach directly on array", () => {
+    [0, 1000, 777, Math.pow(10, 12)].forEach(n => {
+        expect(n).toEqual(n);
+    });
+});

--- a/fixtures/parser_tests.js
+++ b/fixtures/parser_tests.js
@@ -118,6 +118,11 @@ function parserTests(parse: (file: string) => BabylonParserResult) {
       const data = parse(`${fixtures}/metaphysics/partner_show.example`);
       expect(data.itBlocks.length).toEqual(8);
     });
+
+    it('For a call expression without text test file', () => {
+      const data = parse(`${fixtures}/callExpressionWithoutText.example`);
+      expect(data.itBlocks.length).toEqual(1);
+    });
   });
 
   describe('File Parsing for expects', () => {
@@ -142,6 +147,11 @@ function parserTests(parse: (file: string) => BabylonParserResult) {
     it('finds Expects in a metaphysics test file', () => {
       const data = parse(`${fixtures}/metaphysics/partner_show.example`);
       expect(data.expects.length).toEqual(10);
+    });
+
+    it('finds Expects in a call expression without text test file', () => {
+      const data = parse(`${fixtures}/callExpressionWithoutText.example`);
+      expect(data.expects.length).toEqual(1);
     });
   });
 }

--- a/packages/jest-test-typescript-parser/src/type_script_parser.js
+++ b/packages/jest-test-typescript-parser/src/type_script_parser.js
@@ -36,7 +36,7 @@ function parse(file: string) {
       } else {
         let element = node.expression;
         let expectText = '';
-        while (!expectText) {
+        while (element && !expectText) {
           expectText = element.text;
           element = element.expression;
         }


### PR DESCRIPTION

**Summary**

vscode-jest failed to highlight failed jest tests on editor, due to the `packages/jest-test-typescript-parser/test_script_parser.js` crash:

> TypeError: Cannot read property 'text' of undefined

Basically, `test_script_parser.js` @line 40 failed to check if `element` is null before calling `element.text`.

```
while (!expectText) {
          expectText = element.text;
          element = element.expression;
}
```

This would crash if the callable node doesn't have the text portion:

```
[1,2,3].forEach(n => {...});
```
Fix is easy and minimal, also added a test case, see below.

**Test plan**

- no UI change. 
- added new parser test example: `fixures/CallExpressionWithoutText.example` 
- added 2 new test cases in `fixures/parser_tests.js`
