### PR TITLE
Remove redundant yarn.lock entry in npmignores

### DIFF
--- a/packages/babel-jest/.npmignore
+++ b/packages/babel-jest/.npmignore
@@ -1,4 +1,3 @@
 **/__mocks__/**
 **/__tests__/**
 src
-yarn.lock

--- a/packages/babel-plugin-jest-hoist/.npmignore
+++ b/packages/babel-plugin-jest-hoist/.npmignore
@@ -1,4 +1,3 @@
 **/__mocks__/**
 **/__tests__/**
 src
-yarn.lock

--- a/packages/babel-preset-jest/.npmignore
+++ b/packages/babel-preset-jest/.npmignore
@@ -1,4 +1,3 @@
 **/__mocks__/**
 **/__tests__/**
 src
-yarn.lock

--- a/packages/eslint-plugin-jest/.npmignore
+++ b/packages/eslint-plugin-jest/.npmignore
@@ -1,4 +1,3 @@
 **/__mocks__/**
 **/__tests__/**
 src
-yarn.lock

--- a/packages/expect/.npmignore
+++ b/packages/expect/.npmignore
@@ -1,4 +1,3 @@
 **/__mocks__/**
 **/__tests__/**
 src
-yarn.lock

--- a/packages/jest-changed-files/.npmignore
+++ b/packages/jest-changed-files/.npmignore
@@ -1,4 +1,3 @@
 **/__mocks__/**
 **/__tests__/**
 src
-yarn.lock

--- a/packages/jest-cli/.npmignore
+++ b/packages/jest-cli/.npmignore
@@ -1,4 +1,3 @@
 **/__mocks__/**
 **/__tests__/**
 src
-yarn.lock

--- a/packages/jest-config/.npmignore
+++ b/packages/jest-config/.npmignore
@@ -1,4 +1,3 @@
 **/__mocks__/**
 **/__tests__/**
 src
-yarn.lock

--- a/packages/jest-diff/.npmignore
+++ b/packages/jest-diff/.npmignore
@@ -1,4 +1,3 @@
 **/__mocks__/**
 **/__tests__/**
 src
-yarn.lock

--- a/packages/jest-docblock/.npmignore
+++ b/packages/jest-docblock/.npmignore
@@ -1,4 +1,3 @@
 **/__mocks__/**
 **/__tests__/**
 src
-yarn.lock

--- a/packages/jest-editor-support/.npmignore
+++ b/packages/jest-editor-support/.npmignore
@@ -1,4 +1,3 @@
 **/__mocks__/**
 **/__tests__/**
 src
-yarn.lock

--- a/packages/jest-environment-jsdom/.npmignore
+++ b/packages/jest-environment-jsdom/.npmignore
@@ -1,4 +1,3 @@
 **/__mocks__/**
 **/__tests__/**
 src
-yarn.lock

--- a/packages/jest-environment-node/.npmignore
+++ b/packages/jest-environment-node/.npmignore
@@ -1,4 +1,3 @@
 **/__mocks__/**
 **/__tests__/**
 src
-yarn.lock

--- a/packages/jest-get-type/.npmignore
+++ b/packages/jest-get-type/.npmignore
@@ -1,4 +1,3 @@
 **/__mocks__/**
 **/__tests__/**
 src
-yarn.lock

--- a/packages/jest-haste-map/.npmignore
+++ b/packages/jest-haste-map/.npmignore
@@ -1,4 +1,3 @@
 **/__mocks__/**
 **/__tests__/**
 src
-yarn.lock

--- a/packages/jest-jasmine2/.npmignore
+++ b/packages/jest-jasmine2/.npmignore
@@ -1,4 +1,3 @@
 **/__mocks__/**
 **/__tests__/**
 src
-yarn.lock

--- a/packages/jest-matcher-utils/.npmignore
+++ b/packages/jest-matcher-utils/.npmignore
@@ -1,4 +1,3 @@
 **/__mocks__/**
 **/__tests__/**
 src
-yarn.lock

--- a/packages/jest-message-util/.npmignore
+++ b/packages/jest-message-util/.npmignore
@@ -1,4 +1,3 @@
 **/__mocks__/**
 **/__tests__/**
 src
-yarn.lock

--- a/packages/jest-mock/.npmignore
+++ b/packages/jest-mock/.npmignore
@@ -1,4 +1,3 @@
 **/__mocks__/**
 **/__tests__/**
 src
-yarn.lock

--- a/packages/jest-phabricator/.npmignore
+++ b/packages/jest-phabricator/.npmignore
@@ -1,4 +1,3 @@
 **/__mocks__/**
 **/__tests__/**
 src
-yarn.lock

--- a/packages/jest-regex-util/.npmignore
+++ b/packages/jest-regex-util/.npmignore
@@ -1,4 +1,3 @@
 **/__mocks__/**
 **/__tests__/**
 src
-yarn.lock

--- a/packages/jest-repl/.npmignore
+++ b/packages/jest-repl/.npmignore
@@ -1,4 +1,3 @@
 **/__mocks__/**
 **/__tests__/**
 src
-yarn.lock

--- a/packages/jest-resolve-dependencies/.npmignore
+++ b/packages/jest-resolve-dependencies/.npmignore
@@ -1,4 +1,3 @@
 **/__mocks__/**
 **/__tests__/**
 src
-yarn.lock

--- a/packages/jest-resolve/.npmignore
+++ b/packages/jest-resolve/.npmignore
@@ -1,4 +1,3 @@
 **/__mocks__/**
 **/__tests__/**
 src
-yarn.lock

--- a/packages/jest-runner/.npmignore
+++ b/packages/jest-runner/.npmignore
@@ -1,4 +1,3 @@
 **/__mocks__/**
 **/__tests__/**
 src
-yarn.lock

--- a/packages/jest-runtime/.npmignore
+++ b/packages/jest-runtime/.npmignore
@@ -1,4 +1,3 @@
 **/__mocks__/**
 **/__tests__/**
 src
-yarn.lock

--- a/packages/jest-snapshot/.npmignore
+++ b/packages/jest-snapshot/.npmignore
@@ -1,4 +1,3 @@
 **/__mocks__/**
 **/__tests__/**
 src
-yarn.lock

--- a/packages/jest-test-typescript-parser/.npmignore
+++ b/packages/jest-test-typescript-parser/.npmignore
@@ -1,4 +1,3 @@
 **/__mocks__/**
 **/__tests__/**
 src
-yarn.lock

--- a/packages/jest-util/.npmignore
+++ b/packages/jest-util/.npmignore
@@ -1,4 +1,3 @@
 **/__mocks__/**
 **/__tests__/**
 src
-yarn.lock

--- a/packages/jest-validate/.npmignore
+++ b/packages/jest-validate/.npmignore
@@ -1,4 +1,3 @@
 **/__mocks__/**
 **/__tests__/**
 src
-yarn.lock

--- a/packages/jest/.npmignore
+++ b/packages/jest/.npmignore
@@ -1,4 +1,3 @@
 **/__mocks__/**
 **/__tests__/**
 src
-yarn.lock

--- a/packages/pretty-format/.npmignore
+++ b/packages/pretty-format/.npmignore
@@ -1,4 +1,3 @@
 **/__mocks__/**
 **/__tests__/**
 src
-yarn.lock


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
As we just have a yarn.lock in root now, this entry is redundant

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
N/A

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
