### PR TITLE
Separated the snapshot summary creation from the printing to improve testability.

### DIFF
--- a/packages/jest-cli/src/reporters/__tests__/__snapshots__/get_snapshot_summary.test.js.snap
+++ b/packages/jest-cli/src/reporters/__tests__/__snapshots__/get_snapshot_summary.test.js.snap
@@ -1,0 +1,40 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`creates a snapshot summary 1`] = `
+Array [
+  "<bold>Snapshot Summary",
+  "<bold><green> › 1 snapshot</> written in 1 test suite.",
+  "<bold><red> › 1 snapshot test</> failed in 1 test suite. <dim>Inspect your code changes or press --u to update them.",
+  "<bold><green> › 1 snapshot</> updated in 1 test suite.",
+  "<bold><red> › 1 obsolete snapshot file</> found, press --u to remove it.",
+  "<bold><red> › 1 obsolete snapshot</> found, press --u to remove it.",
+]
+`;
+
+exports[`creates a snapshot summary after an update 1`] = `
+Array [
+  "<bold>Snapshot Summary",
+  "<bold><green> › 1 snapshot</> written in 1 test suite.",
+  "<bold><red> › 1 snapshot test</> failed in 1 test suite. <dim>Inspect your code changes or press --u to update them.",
+  "<bold><green> › 1 snapshot</> updated in 1 test suite.",
+  "<bold><red> › 1 obsolete snapshot file</> removed.",
+  "<bold><red> › 1 obsolete snapshot</> removed.",
+]
+`;
+
+exports[`creates a snapshot summary with multiple snapshot being written/updated 1`] = `
+Array [
+  "<bold>Snapshot Summary",
+  "<bold><green> › 2 snapshots</> written in 2 test suites.",
+  "<bold><red> › 2 snapshot tests</> failed in 2 test suites. <dim>Inspect your code changes or press --u to update them.",
+  "<bold><green> › 2 snapshots</> updated in 2 test suites.",
+  "<bold><red> › 2 obsolete snapshot files</> found, press --u to remove them..",
+  "<bold><red> › 2 obsolete snapshots</> found, press --u to remove them.",
+]
+`;
+
+exports[`returns nothing if there are no updates 1`] = `
+Array [
+  "<bold>Snapshot Summary",
+]
+`;

--- a/packages/jest-cli/src/reporters/__tests__/get_snapshot_summary.test.js
+++ b/packages/jest-cli/src/reporters/__tests__/get_snapshot_summary.test.js
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+'use strict';
+
+import getSnapshotSummary from '../get_snapshot_summary';
+
+const UPDATE_COMMAND = 'press --u';
+
+test('creates a snapshot summary', () => {
+  const snapshots = {
+    added: 1,
+    didUpdate: false,
+    filesAdded: 1,
+    filesRemoved: 1,
+    filesUnmatched: 1,
+    filesUpdated: 1,
+    matched: 2,
+    total: 2,
+    unchecked: 1,
+    unmatched: 1,
+    updated: 1,
+  };
+
+  expect(getSnapshotSummary(snapshots, UPDATE_COMMAND)).toMatchSnapshot();
+});
+
+test('creates a snapshot summary after an update', () => {
+  const snapshots = {
+    added: 1,
+    didUpdate: true,
+    filesAdded: 1,
+    filesRemoved: 1,
+    filesUnmatched: 1,
+    filesUpdated: 1,
+    unchecked: 1,
+    unmatched: 1,
+    updated: 1,
+  };
+
+  expect(getSnapshotSummary(snapshots, UPDATE_COMMAND)).toMatchSnapshot();
+});
+
+it('creates a snapshot summary with multiple snapshot being written/updated', () => {
+  const snapshots = {
+    added: 2,
+    didUpdate: false,
+    filesAdded: 2,
+    filesRemoved: 2,
+    filesUnmatched: 2,
+    filesUpdated: 2,
+    unchecked: 2,
+    unmatched: 2,
+    updated: 2,
+  };
+
+  expect(getSnapshotSummary(snapshots, UPDATE_COMMAND)).toMatchSnapshot();
+});
+
+it('returns nothing if there are no updates', () => {
+  const snapshots = {
+    added: 0,
+    didUpdate: false,
+    filesAdded: 0,
+    filesRemoved: 0,
+    filesUnmatched: 0,
+    filesUpdated: 0,
+    unchecked: 0,
+    unmatched: 0,
+    updated: 0,
+  };
+  expect(getSnapshotSummary(snapshots, UPDATE_COMMAND)).toMatchSnapshot();
+});

--- a/packages/jest-cli/src/reporters/get_snapshot_summary.js
+++ b/packages/jest-cli/src/reporters/get_snapshot_summary.js
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+
+import type {SnapshotSummary} from 'types/TestResult';
+
+import chalk from 'chalk';
+import {pluralize} from './utils';
+
+const ARROW = ' \u203A ';
+const FAIL_COLOR = chalk.bold.red;
+const SNAPSHOT_ADDED = chalk.bold.green;
+const SNAPSHOT_NOTE = chalk.dim;
+const SNAPSHOT_REMOVED = chalk.bold.red;
+const SNAPSHOT_SUMMARY = chalk.bold;
+const SNAPSHOT_UPDATED = chalk.bold.green;
+
+module.exports = (
+  snapshots: SnapshotSummary,
+  updateCommand: string,
+): Array<string> => {
+  const summary = [];
+  summary.push(SNAPSHOT_SUMMARY('Snapshot Summary'));
+  if (snapshots.added) {
+    summary.push(
+      SNAPSHOT_ADDED(ARROW + pluralize('snapshot', snapshots.added)) +
+        ` written in ${pluralize('test suite', snapshots.filesAdded)}.`,
+    );
+  }
+
+  if (snapshots.unmatched) {
+    summary.push(
+      FAIL_COLOR(ARROW + pluralize('snapshot test', snapshots.unmatched)) +
+        ` failed in ` +
+        `${pluralize('test suite', snapshots.filesUnmatched)}. ` +
+        SNAPSHOT_NOTE(
+          'Inspect your code changes or ' + updateCommand + ' to update them.',
+        ),
+    );
+  }
+
+  if (snapshots.updated) {
+    summary.push(
+      SNAPSHOT_UPDATED(ARROW + pluralize('snapshot', snapshots.updated)) +
+        ` updated in ${pluralize('test suite', snapshots.filesUpdated)}.`,
+    );
+  }
+
+  if (snapshots.filesRemoved) {
+    summary.push(
+      SNAPSHOT_REMOVED(
+        ARROW + pluralize('obsolete snapshot file', snapshots.filesRemoved),
+      ) +
+        (snapshots.didUpdate
+          ? ' removed.'
+          : ' found, ' +
+            updateCommand +
+            ' to remove ' +
+            (snapshots.filesRemoved === 1 ? 'it' : 'them.') +
+            '.'),
+    );
+  }
+
+  if (snapshots.unchecked) {
+    summary.push(
+      FAIL_COLOR(ARROW + pluralize('obsolete snapshot', snapshots.unchecked)) +
+        (snapshots.didUpdate
+          ? ' removed.'
+          : ' found, ' +
+            updateCommand +
+            ' to remove ' +
+            (snapshots.filesRemoved === 1 ? 'it' : 'them') +
+            '.'),
+    );
+  }
+
+  return summary;
+};

--- a/packages/jest-cli/src/reporters/summary_reporter.js
+++ b/packages/jest-cli/src/reporters/summary_reporter.js
@@ -15,17 +15,11 @@ import type {ReporterOnStartOptions} from 'types/Reporters';
 
 import chalk from 'chalk';
 import BaseReporter from './base_reporter';
-import {getSummary, pluralize} from './utils';
+import {getSummary} from './utils';
 import getResultHeader from './get_result_header';
+import getSnapshotSummary from './get_snapshot_summary';
 import testPathPatternToRegExp from '../test_path_pattern_to_regexp';
 
-const ARROW = ' \u203A ';
-const FAIL_COLOR = chalk.bold.red;
-const SNAPSHOT_ADDED = chalk.bold.green;
-const SNAPSHOT_NOTE = chalk.dim;
-const SNAPSHOT_REMOVED = chalk.bold.red;
-const SNAPSHOT_SUMMARY = chalk.bold;
-const SNAPSHOT_UPDATED = chalk.bold.green;
 const TEST_SUMMARY_THRESHOLD = 20;
 
 const NPM_EVENTS = new Set([
@@ -149,63 +143,8 @@ class SummaryReporter extends BaseReporter {
         updateCommand = 're-run with `-u`';
       }
 
-      this.log(SNAPSHOT_SUMMARY('Snapshot Summary'));
-      if (snapshots.added) {
-        this.log(
-          SNAPSHOT_ADDED(ARROW + pluralize('snapshot', snapshots.added)) +
-            ` written in ${pluralize('test suite', snapshots.filesAdded)}.`,
-        );
-      }
-
-      if (snapshots.unmatched) {
-        this.log(
-          FAIL_COLOR(ARROW + pluralize('snapshot test', snapshots.unmatched)) +
-            ` failed in ` +
-            `${pluralize('test suite', snapshots.filesUnmatched)}. ` +
-            SNAPSHOT_NOTE(
-              'Inspect your code changes or ' +
-                updateCommand +
-                ' to update them.',
-            ),
-        );
-      }
-
-      if (snapshots.updated) {
-        this.log(
-          SNAPSHOT_UPDATED(ARROW + pluralize('snapshot', snapshots.updated)) +
-            ` updated in ${pluralize('test suite', snapshots.filesUpdated)}.`,
-        );
-      }
-
-      if (snapshots.filesRemoved) {
-        this.log(
-          SNAPSHOT_REMOVED(
-            ARROW + pluralize('obsolete snapshot file', snapshots.filesRemoved),
-          ) +
-            (snapshots.didUpdate
-              ? ' removed.'
-              : ' found, ' +
-                updateCommand +
-                ' to remove ' +
-                (snapshots.filesRemoved === 1 ? 'it' : 'them.') +
-                '.'),
-        );
-      }
-
-      if (snapshots.unchecked) {
-        this.log(
-          FAIL_COLOR(
-            ARROW + pluralize('obsolete snapshot', snapshots.unchecked),
-          ) +
-            (snapshots.didUpdate
-              ? ' removed.'
-              : ' found, ' +
-                updateCommand +
-                ' to remove ' +
-                (snapshots.filesRemoved === 1 ? 'it' : 'them') +
-                '.'),
-        );
-      }
+      const snapshotSummary = getSnapshotSummary(snapshots, updateCommand);
+      snapshotSummary.forEach(this.log);
 
       this.log(''); // print empty line
     }


### PR DESCRIPTION
I noticed that the coverage for the jest-cli reporters was not very high so I decided I could add some value by writing some tests for it:)

I split the creation of the snapshot summary to a separate file (`get_snapshot_summary.js`). 

I wanted to write a test for the snapshot summary text printed in the console at the end of a text. However, the `summary_reporter.js` in which the snapshot summary creation is contained requires a lot of overhead to set up making focused testing difficult. This is why I split the creation of the snapshot summary from the reporting about it.

I am hoping that test coverage of the reporters can be gradually improved by splitting them up into smaller units with well defined and focused responsibilities that are easily testable. 

Let me know what you think!