### PR TITLE
Change Promise detection code in jest-circus to support non-global Promise implementations

### DIFF
--- a/packages/jest-circus/src/utils.js
+++ b/packages/jest-circus/src/utils.js
@@ -154,8 +154,14 @@ const callAsyncFn = (
       return reject(error);
     }
 
-    // If it's a Promise, return it.
-    if (returnedValue instanceof Promise) {
+    // If it's a Promise, return it. Test for an object with a `then` function
+    // on it to support Promise implementations that aren't global.Promise, so
+    // users can use bluebird, Q, etc.
+    if (
+      typeof returnedValue === 'object' &&
+      returnedValue !== null &&
+      typeof returnedValue.then === 'function'
+    ) {
       return returnedValue.then(resolve, reject);
     }
 

--- a/packages/jest-circus/src/utils.js
+++ b/packages/jest-circus/src/utils.js
@@ -155,8 +155,7 @@ const callAsyncFn = (
     }
 
     // If it's a Promise, return it. Test for an object with a `then` function
-    // on it to support Promise implementations that aren't global.Promise, so
-    // users can use bluebird, Q, etc.
+    // to support custom Promise implementations.
     if (
       typeof returnedValue === 'object' &&
       returnedValue !== null &&


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This isn't related to any particular open issue with jest-circus, but I noticed it while reading through the code to familiarize myself with it, and so decided to submit it on the side as a small improvement.

To provide better interop for Promise libraries such as bluebird and Q, this changes
the part of jest-circus that detects a returned Promise from a test or hook to only
check that the value is an object with a then method on it, rather than checking that
the value is instanceof Promise. This is considered the standard way of checking for
a Promises/A+-compliant Promise. As an added bonus, this check works cross-realm.

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

I think we should add an integration test to this that pulls in bluebird, Q, or jQuery deferred, and verifies that the test runs as expected, but I'm not sure how to add an integration test that has a dependency like that. Should it be a dev dependency of the whole project?
