### PR TITLE
Remove .dim from displayName for better readability

### DIFF
--- a/packages/jest-cli/src/reporters/utils.js
+++ b/packages/jest-cli/src/reporters/utils.js
@@ -28,7 +28,7 @@ const printDisplayName = (config: ProjectConfig) => {
 
   if (displayName) {
     return chalk.supportsColor
-      ? chalk.reset.inverse.white.dim(` ${displayName} `)
+      ? chalk.reset.inverse.white(` ${displayName} `)
       : displayName;
   }
 


### PR DESCRIPTION
**Summary**

Display name is hard to read in white terminals

**Test plan**

### Before
<img width="1148" alt="screen shot 2017-08-27 at 12 43 54 pm" src="https://user-images.githubusercontent.com/574806/29753404-996ab264-8b25-11e7-8032-9a2cd1d81799.png">

### After
<img width="1155" alt="screen shot 2017-08-27 at 12 44 12 pm" src="https://user-images.githubusercontent.com/574806/29753401-9214487c-8b25-11e7-92f7-62d2b6d892dc.png">
