### PR TITLE
Use "verbose" no test found message when there is only one project

### DIFF
--- a/packages/jest-cli/src/get_no_test_found_message.js
+++ b/packages/jest-cli/src/get_no_test_found_message.js
@@ -6,7 +6,7 @@ const getNoTestsFoundMessage = (testRunData, globalConfig): string => {
   if (globalConfig.onlyChanged) {
     return getNoTestFoundRelatedToChangedFiles(globalConfig);
   }
-  return globalConfig.verbose
+  return testRunData.length === 1 || globalConfig.verbose
     ? getNoTestFoundVerbose(testRunData, globalConfig)
     : getNoTestFound(testRunData, globalConfig);
 };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

#4354 Did a great job on providing a better "no test found" message for MPR.
 
I feel that we should show the "verbose" message when there is only one project or when the user is not trying to specify a project at all.

**Test plan**

### Before
<img width="639" alt="screen shot 2017-08-27 at 1 28 11 pm" src="https://user-images.githubusercontent.com/574806/29753682-a3f4014e-8b2b-11e7-9aee-0158c2ef347f.png">

### After
<img width="646" alt="screen shot 2017-08-27 at 1 28 22 pm" src="https://user-images.githubusercontent.com/574806/29753681-a3f2cdc4-8b2b-11e7-9e07-5b731dfee6f7.png">

