### PR TITLE
Make listTests always print to console.log

### DIFF
--- a/integration_tests/__tests__/__snapshots__/list_tests.test.js.snap
+++ b/integration_tests/__tests__/__snapshots__/list_tests.test.js.snap
@@ -2,7 +2,8 @@
 
 exports[`--listTests flag causes tests to be printed in different lines 1`] = `
 "/MOCK_ABOLUTE_PATH/integration_tests/list_tests/__tests__/dummy.test.js
-/MOCK_ABOLUTE_PATH/integration_tests/list_tests/__tests__/other.test.js"
+/MOCK_ABOLUTE_PATH/integration_tests/list_tests/__tests__/other.test.js
+"
 `;
 
 exports[`--listTests flag causes tests to be printed out as JSON when using the --json flag 1`] = `"[\\"/MOCK_ABOLUTE_PATH/integration_tests/list_tests/__tests__/dummy.test.js\\",\\"/MOCK_ABOLUTE_PATH/integration_tests/list_tests/__tests__/other.test.js\\"]"`;

--- a/integration_tests/__tests__/__snapshots__/list_tests.test.js.snap
+++ b/integration_tests/__tests__/__snapshots__/list_tests.test.js.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`--listTests flag causes tests to be printed in different lines 1`] = `
-"/MOCK_ABOLUTE_PATH/integration_tests/list_tests/__tests__/dummy.test.js
-/MOCK_ABOLUTE_PATH/integration_tests/list_tests/__tests__/other.test.js
 "
+/MOCK_ABOLUTE_PATH/integration_tests/list_tests/__tests__/dummy.test.js
+/MOCK_ABOLUTE_PATH/integration_tests/list_tests/__tests__/other.test.js"
 `;
 
 exports[`--listTests flag causes tests to be printed out as JSON when using the --json flag 1`] = `"[\\"/MOCK_ABOLUTE_PATH/integration_tests/list_tests/__tests__/dummy.test.js\\",\\"/MOCK_ABOLUTE_PATH/integration_tests/list_tests/__tests__/other.test.js\\"]"`;

--- a/integration_tests/__tests__/__snapshots__/list_tests.test.js.snap
+++ b/integration_tests/__tests__/__snapshots__/list_tests.test.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`--listTests flag causes tests to be printed in different lines 1`] = `
-"/Users/joachimseminck/Projects/jest/integration_tests/list_tests/__tests__/other.test.js
-/Users/joachimseminck/Projects/jest/integration_tests/list_tests/__tests__/dummy.test.js
+"/MOCK_ABOLUTE_PATH/integration_tests/list_tests/__tests__/other.test.js
+/MOCK_ABOLUTE_PATH/integration_tests/list_tests/__tests__/dummy.test.js
 "
 `;
 

--- a/integration_tests/__tests__/__snapshots__/list_tests.test.js.snap
+++ b/integration_tests/__tests__/__snapshots__/list_tests.test.js.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`--listTests flag causes tests to be printed in different lines 1`] = `
+"/Users/joachimseminck/Projects/jest/integration_tests/list_tests/__tests__/other.test.js
+/Users/joachimseminck/Projects/jest/integration_tests/list_tests/__tests__/dummy.test.js
 "
-/MOCK_ABOLUTE_PATH/integration_tests/list_tests/__tests__/dummy.test.js
-/MOCK_ABOLUTE_PATH/integration_tests/list_tests/__tests__/other.test.js"
 `;
 
 exports[`--listTests flag causes tests to be printed out as JSON when using the --json flag 1`] = `"[\\"/MOCK_ABOLUTE_PATH/integration_tests/list_tests/__tests__/dummy.test.js\\",\\"/MOCK_ABOLUTE_PATH/integration_tests/list_tests/__tests__/other.test.js\\"]"`;

--- a/integration_tests/__tests__/__snapshots__/list_tests.test.js.snap
+++ b/integration_tests/__tests__/__snapshots__/list_tests.test.js.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`--listTests flag causes tests to be printed in different lines 1`] = `
-"/MOCK_ABOLUTE_PATH/integration_tests/list_tests/__tests__/other.test.js
-/MOCK_ABOLUTE_PATH/integration_tests/list_tests/__tests__/dummy.test.js
 "
+/MOCK_ABOLUTE_PATH/integration_tests/list_tests/__tests__/dummy.test.js
+/MOCK_ABOLUTE_PATH/integration_tests/list_tests/__tests__/other.test.js"
 `;
 
 exports[`--listTests flag causes tests to be printed out as JSON when using the --json flag 1`] = `"[\\"/MOCK_ABOLUTE_PATH/integration_tests/list_tests/__tests__/dummy.test.js\\",\\"/MOCK_ABOLUTE_PATH/integration_tests/list_tests/__tests__/other.test.js\\"]"`;

--- a/integration_tests/__tests__/list_tests.test.js
+++ b/integration_tests/__tests__/list_tests.test.js
@@ -11,7 +11,6 @@
 
 const runJest = require('../runJest');
 const path = require('path');
-const {EOL} = require('os');
 
 const testRootDir = path.resolve(__dirname, '..', '..');
 
@@ -27,7 +26,9 @@ describe('--listTests flag', () => {
     const {status, stdout} = runJest('list_tests', ['--listTests']);
 
     expect(status).toBe(0);
-    expect(normalizePaths(stdout)).toMatchSnapshot();
+    expect(
+      normalizePaths(stdout).split('\n').sort().join('\n'),
+    ).toMatchSnapshot();
   });
 
   it('causes tests to be printed out as JSON when using the --json flag', () => {

--- a/integration_tests/__tests__/list_tests.test.js
+++ b/integration_tests/__tests__/list_tests.test.js
@@ -27,7 +27,7 @@ describe('--listTests flag', () => {
     const {status, stdout} = runJest('list_tests', ['--listTests']);
 
     expect(status).toBe(0);
-    expect(stdout).toMatchSnapshot();
+    expect(normalizePaths(stdout)).toMatchSnapshot();
   });
 
   it('causes tests to be printed out as JSON when using the --json flag', () => {

--- a/integration_tests/__tests__/list_tests.test.js
+++ b/integration_tests/__tests__/list_tests.test.js
@@ -27,9 +27,7 @@ describe('--listTests flag', () => {
     const {status, stdout} = runJest('list_tests', ['--listTests']);
 
     expect(status).toBe(0);
-    expect(
-      normalizePaths(stdout).split(EOL).sort().join(EOL),
-    ).toMatchSnapshot();
+    expect(stdout).toMatchSnapshot();
   });
 
   it('causes tests to be printed out as JSON when using the --json flag', () => {

--- a/integration_tests/__tests__/list_tests.test.js
+++ b/integration_tests/__tests__/list_tests.test.js
@@ -33,12 +33,12 @@ describe('--listTests flag', () => {
   });
 
   it('causes tests to be printed out as JSON when using the --json flag', () => {
-    const {status, stderr} = runJest('list_tests', ['--listTests', '--json']);
+    const {status, stdout} = runJest('list_tests', ['--listTests', '--json']);
 
     expect(status).toBe(0);
-    expect(() => JSON.parse(stderr)).not.toThrow();
+    expect(() => JSON.parse(stdout)).not.toThrow();
     expect(
-      JSON.stringify(JSON.parse(stderr).map(normalizePaths).sort()),
+      JSON.stringify(JSON.parse(stdout).map(normalizePaths).sort()),
     ).toMatchSnapshot();
   });
 });

--- a/packages/jest-cli/src/run_jest.js
+++ b/packages/jest-cli/src/run_jest.js
@@ -116,9 +116,9 @@ const runJest = async ({
   if (globalConfig.listTests) {
     const testsPaths = allTests.map(test => test.path);
     if (globalConfig.json) {
-      outputStream.write(JSON.stringify(testsPaths));
+      console.log(JSON.stringify(testsPaths));
     } else {
-      outputStream.write(testsPaths.join('\n'));
+      console.log(testsPaths.join('\n'));
     }
 
     onComplete && onComplete(makeEmptyAggregatedTestResult());


### PR DESCRIPTION
**Summary**
Always print the output of the `--listTests` option to console.log, even when using `--json` flag (which is otherwise redirected to stderr) or the `--stdErr` flag.

See issue: https://github.com/facebook/jest/issues/4388

**Test plan**
Updated the existing test