### PR TITLE
fix(babel): Handle ignored files in babel v7

### DIFF
--- a/packages/babel-jest/src/index.js
+++ b/packages/babel-jest/src/index.js
@@ -128,7 +128,7 @@ const createTransformer = (options: any) => {
       if (!babelResult) {
         return src;
       }
-    
+
       return babelResult.code;
     },
   };

--- a/packages/babel-jest/src/index.js
+++ b/packages/babel-jest/src/index.js
@@ -123,7 +123,13 @@ const createTransformer = (options: any) => {
         ]);
       }
 
-      return babelTransform(src, theseOptions).code;
+      // babel v7 might return null in the case when the file has been ignored.
+      const babelResult = babelTransform(src, theseOptions);
+      if (!babelResult) {
+        return src;
+      }
+    
+      return babelResult.code;
     },
   };
 };

--- a/packages/babel-jest/src/index.js
+++ b/packages/babel-jest/src/index.js
@@ -124,12 +124,8 @@ const createTransformer = (options: any) => {
       }
 
       // babel v7 might return null in the case when the file has been ignored.
-      const babelResult = babelTransform(src, theseOptions);
-      if (!babelResult) {
-        return src;
-      }
-
-      return babelResult.code;
+      const transformResult = babelTransform(src, theseOptions);
+      return transformResult ? transformResult.code : src;
     },
   };
 };


### PR DESCRIPTION
**Summary**

In babel v7 `babel-core.transform()` returns null if a file is ignored.
This change makes babel-jest not throw a TypeError in this case.

**Test plan**

Tested by modifying local installed babel-jest in babel, while trying to get jest running in babel itself.

