### PR TITLE
Specify watchPathIgnorePatterns will only be available in Jest 21+

### DIFF
--- a/docs/en/Configuration.md
+++ b/docs/en/Configuration.md
@@ -645,6 +645,8 @@ Indicates whether each individual test should be reported during the run. All er
 ### `watchPathIgnorePatterns` [array<string>]
 Default: `[]`
 
+##### available in Jest **21.0.0+**
+
 An array of RegExp patterns that are matched against all source file paths before re-running tests in watch mode. If the file path matches any of the patterns, when it is updated, it will not trigger a re-run of tests.
 
 These patterns match against the full path. Use the `<rootDir>` string token to include the path to your project's root directory to prevent it from accidentally ignoring all of your files in different environments that may have different root directories. Example: `["<rootDir>/node_modules/"]`.


### PR DESCRIPTION
**Summary**

Fixes: https://github.com/facebook/jest/issues/4394

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
