### PR TITLE
Add displayName to TestResult

### DIFF
--- a/packages/jest-circus/src/legacy_code_todo_rewrite/jest_adapter_init.js
+++ b/packages/jest-circus/src/legacy_code_todo_rewrite/jest_adapter_init.js
@@ -124,6 +124,7 @@ const runAndTransformResultsToJestFormat = async ({
 
   return {
     console: null,
+    displayName: config.displayName,
     failureMessage,
     numFailingTests,
     numPassingTests,

--- a/packages/jest-cli/src/test_result_helpers.js
+++ b/packages/jest-cli/src/test_result_helpers.js
@@ -53,6 +53,7 @@ const buildFailureTestResult = (
 ): TestResult => {
   return {
     console: null,
+    displayName: '',
     failureMessage: null,
     numFailingTests: 0,
     numPassingTests: 0,

--- a/packages/jest-runner/src/run_test.js
+++ b/packages/jest-runner/src/run_test.js
@@ -112,6 +112,7 @@ function runTest(
       result.sourceMaps = runtime.getSourceMapInfo();
       result.console = testConsole.getBuffer();
       result.skipped = testCount === result.numPendingTests;
+      result.displayName = config.displayName;
       return result;
     })
     .then(

--- a/types/TestResult.js
+++ b/types/TestResult.js
@@ -131,6 +131,7 @@ export type Suite = {|
 export type TestResult = {|
   console: ?ConsoleBuffer,
   coverage?: RawCoverage,
+  displayName: ?string,
   memoryUsage?: Bytes,
   failureMessage: ?string,
   numFailingTests: number,


### PR DESCRIPTION
**Summary**

Adds project [displayName](https://github.com/facebook/jest/pull/4327) to TestResult type and ensures the value is propagated through to testResultsProcessor.

Resolves https://github.com/facebook/jest/issues/4406

[Sample testResultsProcessor output](https://gist.githubusercontent.com/palmerj3/6bbc332f5f25173941796eae2a1c278a/raw/61f6180154c7d8b93fb14241dba33b64fc484131/gistfile1.txt) in a multi-project environment where one project has a displayName defined and one does not.

**Test plan**

Run tests locally