### PR TITLE
Fix React PropTypes warning in tests for Immutable plugin

### DIFF
--- a/packages/pretty-format/src/__tests__/immutable.test.js
+++ b/packages/pretty-format/src/__tests__/immutable.test.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-import * as React from 'react';
+import React from 'react';
 import Immutable from 'immutable';
 import prettyFormat from '../';
 const {Immutable: ImmutablePlugin, ReactElement} = prettyFormat.plugins;


### PR DESCRIPTION
**Summary**

After changes for upgrade to Flow 0.53.1, `immutable.test.js` had 2 occurrences of:

>console.warn node_modules/react/lib/lowPriorityWarning.js:40
>    Warning: Accessing PropTypes via the main React package is deprecated, and will be removed in  React v16.0. Use the latest available v15.* prop-types package from npm instead. For info on usage, compatibility, migration and more, see https://fb.me/prop-types-docs

After reading [https://flow.org/en/docs/react/types/](https://flow.org/en/docs/react/types/)

> If you want to access them [utility types] then you should import React as a namespace `import * as React from 'react'`

> if you import React with: `import React from 'react'` you will be able to access `React.createElement()`

These tests depend only on `React.createElement()` not on any utility types.

**Test plan**

Check console in CI