### PR TITLE
Remove existing throw

### DIFF
--- a/packages/jest-cli/src/cli/args.js
+++ b/packages/jest-cli/src/cli/args.js
@@ -21,14 +21,6 @@ const check = (argv: Argv) => {
     );
   }
 
-  if (argv.onlyChanged && argv._.length > 0) {
-    throw new Error(
-      'Both --onlyChanged and a path pattern were specified, but these ' +
-        'two options do not make sense together. Which is it? Do you want ' +
-        'to run tests for changed files? Or for a specific set of files?',
-    );
-  }
-
   if (argv.onlyChanged && argv.watchAll) {
     throw new Error(
       'Both --onlyChanged and --watchAll were specified, but these two ' +


### PR DESCRIPTION
**Summary**

The throw was added to clarify a complex behavior, like matching `--onlyChanged` with a pattern. However, this makes impossible to have a default to run tests related to the commit that can also be overridden via CLI with `--all`, or use a pattern. Which, in fact, [it already existed](https://github.com/facebook/jest/blob/master/packages/jest-config/src/normalize.js#L502-L504).

**Test plan**

Run `jest --onlyChanged foo`; and all `foo` tests should be run without throwing an exception. This is because the pattern will take precedence over `--onlyChanged`.