### PR TITLE
Print errors after test structure in verbose mode

### DIFF
--- a/integration_tests/__tests__/__snapshots__/failures.test.js.snap
+++ b/integration_tests/__tests__/__snapshots__/failures.test.js.snap
@@ -30,6 +30,12 @@ exports[`not throwing Error objects 3`] = `
 
 exports[`not throwing Error objects 4`] = `
 "FAIL __tests__/assertion_count.test.js
+  .assertions()
+    ✕ throws
+    ✕ throws on redeclare of assertion count
+    ✕ throws on assertion
+  .hasAssertions()
+    ✕ throws when there are not assertions
   ● .assertions() › throws
     expect(received).toBeTruthy()
     Expected value to be truthy, instead received
@@ -49,17 +55,28 @@ exports[`not throwing Error objects 4`] = `
   ● .hasAssertions() › throws when there are not assertions
     expect.hasAssertions()
     Expected at least one assertion to be called but received none.
-  .assertions()
-    ✕ throws
-    ✕ throws on redeclare of assertion count
-    ✕ throws on assertion
-  .hasAssertions()
-    ✕ throws when there are not assertions
 "
 `;
 
 exports[`works with node assert 1`] = `
 "FAIL __tests__/node_assertion_error.test.js
+  ✕ assert
+  ✕ assert with a message
+  ✕ assert.ok
+  ✕ assert.ok with a message
+  ✕ assert.equal
+  ✕ assert.notEqual
+  ✕ assert.deepEqual
+  ✕ assert.deepEqual with a message
+  ✕ assert.notDeepEqual
+  ✕ assert.strictEqual
+  ✕ assert.notStrictEqual
+  ✕ assert.deepStrictEqual
+  ✕ assert.notDeepStrictEqual
+  ✕ assert.ifError
+  ✕ assert.doesNotThrow
+  ✕ assert.throws
+
   ● assert
 
     assert.equal(received, expected) or assert(received) 
@@ -298,23 +315,6 @@ exports[`works with node assert 1`] = `
       Missing expected exception.
       
       at __tests__/node_assertion_error.test.js:78:10
-
-  ✕ assert
-  ✕ assert with a message
-  ✕ assert.ok
-  ✕ assert.ok with a message
-  ✕ assert.equal
-  ✕ assert.notEqual
-  ✕ assert.deepEqual
-  ✕ assert.deepEqual with a message
-  ✕ assert.notDeepEqual
-  ✕ assert.strictEqual
-  ✕ assert.notStrictEqual
-  ✕ assert.deepStrictEqual
-  ✕ assert.notDeepStrictEqual
-  ✕ assert.ifError
-  ✕ assert.doesNotThrow
-  ✕ assert.throws
 
 "
 `;

--- a/packages/jest-cli/src/reporters/default_reporter.js
+++ b/packages/jest-cli/src/reporters/default_reporter.js
@@ -155,48 +155,65 @@ export default class DefaultReporter extends BaseReporter {
     testResult: TestResult,
     aggregatedResults: AggregatedResult,
   ) {
+    this.testFinished(
+      test,
+      testResult,
+      aggregatedResults,
+    );
+    if (!testResult.skipped) {
+      this.printTestFileHeader(
+        testResult.testFilePath,
+        test.context.config,
+        testResult,
+      );
+      this.printTestFileFailureMessage(
+        testResult.testFilePath,
+        test.context.config,
+        testResult,
+      );
+    }
+    this.forceFlushBufferedOutput();
+  }
+
+  testFinished(test, testResult, aggregatedResults) {
     this._status.testFinished(
       test.context.config,
       testResult,
       aggregatedResults,
     );
-    this._printTestFileSummary(
-      testResult.testFilePath,
-      test.context.config,
-      testResult,
-    );
-    this.forceFlushBufferedOutput();
   }
 
-  _printTestFileSummary(
+  printTestFileHeader(
     testPath: Path,
     config: ProjectConfig,
     result: TestResult,
   ) {
-    if (!result.skipped) {
-      this.log(getResultHeader(result, this._globalConfig, config));
-
-      const consoleBuffer = result.console;
-      if (consoleBuffer && consoleBuffer.length) {
-        this.log(
-          '  ' +
-            TITLE_BULLET +
-            'Console\n\n' +
-            getConsoleOutput(
-              config.cwd,
-              !!this._globalConfig.verbose,
-              consoleBuffer,
-            ),
-        );
-      }
-
-      if (result.failureMessage) {
-        this.log(result.failureMessage);
-      }
-
-      const didUpdate = this._globalConfig.updateSnapshot === 'all';
-      const snapshotStatuses = getSnapshotStatus(result.snapshot, didUpdate);
-      snapshotStatuses.forEach(this.log);
+    this.log(getResultHeader(result, this._globalConfig, config));
+    const consoleBuffer = result.console;
+    if (consoleBuffer && consoleBuffer.length) {
+      this.log(
+        '  ' +
+        TITLE_BULLET +
+        'Console\n\n' +
+        getConsoleOutput(
+          config.cwd,
+          !!this._globalConfig.verbose,
+          consoleBuffer,
+        ),
+      );
     }
+  }
+
+  printTestFileFailureMessage(
+    testPath: Path,
+    config: ProjectConfig,
+    result: TestResult,
+  ) {
+    if (result.failureMessage) {
+      this.log(result.failureMessage);
+    }
+    const didUpdate = this._globalConfig.updateSnapshot === 'all';
+    const snapshotStatuses = getSnapshotStatus(result.snapshot, didUpdate);
+    snapshotStatuses.forEach(this.log);
   }
 }

--- a/packages/jest-cli/src/reporters/verbose_reporter.js
+++ b/packages/jest-cli/src/reporters/verbose_reporter.js
@@ -59,10 +59,15 @@ export default class VerboseReporter extends DefaultReporter {
     result: TestResult,
     aggregatedResults: AggregatedResult,
   ) {
-    super.onTestResult(test, result, aggregatedResults);
-    if (!result.testExecError && !result.skipped) {
-      this._logTestResults(result.testResults);
+    super.testFinished(test, result, aggregatedResults);
+    if (!result.skipped) {
+      this.printTestFileHeader(result.testFilePath, test.context.config, result);
+      if (!result.testExecError && !result.skipped) {
+        this._logTestResults(result.testResults);
+      }
+      this.printTestFileFailureMessage(result.testFilePath, test.context.config, result);
     }
+    super.forceFlushBufferedOutput();
   }
 
   _logTestResults(testResults: Array<AssertionResult>) {


### PR DESCRIPTION
**Summary**

This is a fix for this issue https://github.com/facebook/jest/issues/4264

When running a single test that has many test cases the error messages are printed before the list of failing/passing tests which makes us to scroll up every time just to see the error message.

This Pull Request change the behavior of print error messages to put them after the list of tests

So the behavior is going to switch from the actual:

![image](https://user-images.githubusercontent.com/2551046/30560021-df3d9034-9cb6-11e7-904e-2d94418b2397.png)



to this:

![image](https://user-images.githubusercontent.com/2551046/30560057-fdefedec-9cb6-11e7-9401-f4843340b7a2.png)

