### PR TITLE
Call jest-diff and pretty-format more precisely in toHaveProperty matcher

### DIFF
--- a/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -2467,7 +2467,7 @@ To have a nested property:
 With a value of:
   <green>2</>
 Received:
-  <red>object</>.a.b.c: <red>{\\"d\\": 1}</>"
+  <red>1</>"
 `;
 
 exports[`.toHaveProperty() {pass: false} expect({"a": {"b": {"c": {"d": 1}}}}).toHaveProperty('a.b.ttt.d', 1) 1`] = `
@@ -2517,7 +2517,8 @@ To have a nested property:
 With a value of:
   <green>{\\"c\\": 4}</>
 Received:
-  <red>object</>.a: <red>{\\"b\\": {\\"c\\": 5}}</>
+  <red>{\\"c\\": 5}</>
+
 Difference:
 
 <green>- Expected</>
@@ -2539,7 +2540,8 @@ To have a nested property:
 With a value of:
   <green>undefined</>
 Received:
-  <red>object</>.a: <red>{\\"b\\": 3}</>
+  <red>3</>
+
 Difference:
 
   Comparing two different types of values. Expected <green>undefined</> but received <red>number</>."

--- a/packages/expect/src/matchers.js
+++ b/packages/expect/src/matchers.js
@@ -535,9 +535,7 @@ const matchers: MatchersObject = {
       : () => {
           const diffString =
             valuePassed && hasEndProp
-              ? diff(value, result.value, {
-                  expand: this.expand,
-                })
+              ? diff(value, result.value, {expand: this.expand})
               : '';
           return (
             matcherHint('.toHaveProperty', 'object', 'path', {

--- a/packages/expect/src/matchers.js
+++ b/packages/expect/src/matchers.js
@@ -27,7 +27,6 @@ import {
 import {
   getObjectSubset,
   getPath,
-  hasOwnProperty,
   iterableEquality,
   subsetEquality,
 } from './utils';
@@ -516,23 +515,10 @@ const matchers: MatchersObject = {
     const result = getPath(object, keyPath);
     const {lastTraversedObject, hasEndProp} = result;
 
-    let diffString;
-
-    if (valuePassed && hasOwnProperty(result, 'value')) {
-      diffString = diff(value, result.value, {
-        expand: this.expand,
-      });
-    }
-
     const pass = valuePassed
       ? equals(result.value, value, [iterableEquality])
       : hasEndProp;
 
-    if (hasOwnProperty(result, 'value')) {
-      // we don't diff numbers. So instead we'll show the object that contains the resulting value.
-      // And to get that object we need to go up a level.
-      result.traversedPath.pop();
-    }
     const traversedPath = result.traversedPath.join('.');
 
     const message = pass
@@ -546,22 +532,36 @@ const matchers: MatchersObject = {
           `Not to have a nested property:\n` +
           `  ${printExpected(keyPath)}\n` +
           (valuePassed ? `With a value of:\n  ${printExpected(value)}\n` : '')
-      : () =>
-          matcherHint('.toHaveProperty', 'object', 'path', {
-            secondArgument: valuePassed ? 'value' : null,
-          }) +
-          '\n\n' +
-          `Expected the object:\n` +
-          `  ${printReceived(object)}\n` +
-          `To have a nested property:\n` +
-          `  ${printExpected(keyPath)}\n` +
-          (valuePassed ? `With a value of:\n  ${printExpected(value)}\n` : '') +
-          (traversedPath
-            ? `Received:\n  ${RECEIVED_COLOR(
-                'object',
-              )}.${traversedPath}: ${printReceived(lastTraversedObject)}`
-            : '') +
-          (diffString ? `\nDifference:\n\n${diffString}` : '');
+      : () => {
+          const diffString =
+            valuePassed && hasEndProp
+              ? diff(value, result.value, {
+                  expand: this.expand,
+                })
+              : '';
+          return (
+            matcherHint('.toHaveProperty', 'object', 'path', {
+              secondArgument: valuePassed ? 'value' : null,
+            }) +
+            '\n\n' +
+            `Expected the object:\n` +
+            `  ${printReceived(object)}\n` +
+            `To have a nested property:\n` +
+            `  ${printExpected(keyPath)}\n` +
+            (valuePassed
+              ? `With a value of:\n  ${printExpected(value)}\n`
+              : '') +
+            (hasEndProp
+              ? `Received:\n` +
+                `  ${printReceived(result.value)}` +
+                (diffString ? `\n\nDifference:\n\n${diffString}` : '')
+              : traversedPath
+                ? `Received:\n  ${RECEIVED_COLOR(
+                    'object',
+                  )}.${traversedPath}: ${printReceived(lastTraversedObject)}`
+                : '')
+          );
+        };
     if (pass === undefined) {
       throw new Error('pass must be initialized');
     }


### PR DESCRIPTION
**Summary**

EDITED:

* Call `diff` **if and only if** `valuePassed && hasEndProp`
* Call `pretty-format` for received property value, **not** for its parent object
* Received is `lastTraversedObject` **if and only if** `traversedPath` non-empty and incomplete

**Test plan**

Updated 3 snapshots