### PR TITLE
Take precedence of NODE_PATH when resolving node_modules directories

### DIFF
--- a/packages/jest-resolve/src/node_modules_paths.js
+++ b/packages/jest-resolve/src/node_modules_paths.js
@@ -53,7 +53,7 @@ function nodeModulesPaths(
     );
   }, []);
 
-  return options.paths ? dirs.concat(options.paths) : dirs;
+  return options.paths ? options.paths.concat(dirs) : dirs;
 }
 
 module.exports = nodeModulesPaths;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This aligns Jest with the behaviour of Node where it takes precedence of `NODE_PATH` over resolving modules relative to `node_modules`.

**Test plan**

yolo

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
