### PR TITLE
Fix function name sanitization in jest-mock

### DIFF
--- a/packages/jest-mock/src/__tests__/jest_mock.test.js
+++ b/packages/jest-mock/src/__tests__/jest_mock.test.js
@@ -69,14 +69,22 @@ describe('moduleMocker', () => {
     });
 
     it('escapes illegal characters in function name property', () => {
-      const foo = {
-        'foo-bar': () => {},
-      };
+      function getMockFnWithOriginalName(name) {
+        const fn = () => {};
+        Object.defineProperty(fn, 'name', {value: name});
 
-      const mock = moduleMocker.generateFromMetadata(
-        moduleMocker.getMetadata(foo['foo-bar']),
-      );
-      expect(!mock.name || mock.name === 'foo$bar').toBeTruthy();
+        return moduleMocker.generateFromMetadata(moduleMocker.getMetadata(fn));
+      }
+
+      expect(
+        getMockFnWithOriginalName('foo-bar').name === 'foo$bar',
+      ).toBeTruthy();
+      expect(
+        getMockFnWithOriginalName('foo/bar').name === 'foo$bar',
+      ).toBeTruthy();
+      expect(
+        getMockFnWithOriginalName('foo𠮷bar').name === 'foo𠮷bar',
+      ).toBeTruthy();
     });
 
     it('special cases the mockConstructor name', () => {

--- a/packages/jest-mock/src/index.js
+++ b/packages/jest-mock/src/index.js
@@ -37,6 +37,8 @@ type MockFunctionConfig = {
 
 const MOCK_CONSTRUCTOR_NAME = 'mockConstructor';
 
+const FUNCTION_NAME_RESERVED_PATTERN = /[\s!-\/:-@\[-`{-~]/g;
+
 // $FlowFixMe
 const RESERVED_KEYWORDS = Object.assign(Object.create(null), {
   arguments: true,
@@ -474,8 +476,8 @@ class ModuleMockerClass {
 
     // It's also a syntax error to define a function with a reserved character
     // as part of it's name.
-    if (/[\s-]/.test(name)) {
-      name = name.replace(/[\s-]/g, '$');
+    if (FUNCTION_NAME_RESERVED_PATTERN.test(name)) {
+      name = name.replace(FUNCTION_NAME_RESERVED_PATTERN, '$');
     }
 
     const body =


### PR DESCRIPTION
**Summary**
When creating mock functions, jest-mock attempts to copy over the existing name of the function being mocked. However, it creates the mock functions using `Function()` (a form of eval), using string interpolation to specify the function name in the code being evaluated. This means that only function names consisting of valid characters for JS identifiers can be used.

Currently there is some code which attempts to sanitize function names so they are valid, but it only replaces spaces and hypens. Other invalid characters remain.

I've expanded the regex used to include other special characters in the ASCII space, while leaving ASCII chars which are valid for identifiers, as well as unicode characters (for people coding in non-Latin alphabets, for example).

**Test plan**

- yarn test

I've expanded the relevant test case in `packages/jest-mock/src/__tests__/jest_mock.test.js` to include more cases. I also changed the test to use `defineProperty` to ensure the input function has a name, so the existing special case where function.name is null can be removed.