### PR TITLE
Make FUNCTION_NAME_RESERVED_PATTERN stateless

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,6 +22,7 @@ module.exports = {
       files: ['*.md'],
       rules: {
         'consistent-return': 0,
+        'flowtype/require-valid-file-annotation': 0,
         'import/no-extraneous-dependencies': 0,
         'import/no-unresolved': 0,
         'jest/no-focused-tests': 0,

--- a/packages/jest-mock/src/__tests__/jest_mock.test.js
+++ b/packages/jest-mock/src/__tests__/jest_mock.test.js
@@ -80,6 +80,12 @@ describe('moduleMocker', () => {
         getMockFnWithOriginalName('foo-bar').name === 'foo$bar',
       ).toBeTruthy();
       expect(
+        getMockFnWithOriginalName('foo-bar-2').name === 'foo$bar$2',
+      ).toBeTruthy();
+      expect(
+        getMockFnWithOriginalName('foo-bar-3').name === 'foo$bar$3',
+      ).toBeTruthy();
+      expect(
         getMockFnWithOriginalName('foo/bar').name === 'foo$bar',
       ).toBeTruthy();
       expect(

--- a/packages/jest-mock/src/index.js
+++ b/packages/jest-mock/src/index.js
@@ -37,7 +37,11 @@ type MockFunctionConfig = {
 
 const MOCK_CONSTRUCTOR_NAME = 'mockConstructor';
 
-const FUNCTION_NAME_RESERVED_PATTERN = /[\s!-\/:-@\[-`{-~]/g;
+const FUNCTION_NAME_RESERVED_PATTERN = /[\s!-\/:-@\[-`{-~]/;
+const FUNCTION_NAME_RESERVED_REPLACE = new RegExp(
+  FUNCTION_NAME_RESERVED_PATTERN.source,
+  'g',
+);
 
 // $FlowFixMe
 const RESERVED_KEYWORDS = Object.assign(Object.create(null), {
@@ -477,7 +481,7 @@ class ModuleMockerClass {
     // It's also a syntax error to define a function with a reserved character
     // as part of it's name.
     if (FUNCTION_NAME_RESERVED_PATTERN.test(name)) {
-      name = name.replace(FUNCTION_NAME_RESERVED_PATTERN, '$');
+      name = name.replace(FUNCTION_NAME_RESERVED_REPLACE, '$');
     }
 
     const body =


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
As per discussion [here](https://github.com/facebook/jest/pull/4464/files#r138264201).
This also fixes eslint by disabling `flowtype/require-valid-file-annotation` for `*.md` files

**Test plan**
Added a test for multiple reserved words
