### PR TITLE
[jest-resolve] Prevent default resolver failure when potential resolution directory does not exist

### DIFF
--- a/packages/jest-resolve/src/default_resolver.js
+++ b/packages/jest-resolve/src/default_resolver.js
@@ -163,7 +163,7 @@ function isDirectory(dir: Path): boolean {
     const stat = fs.statSync(dir);
     result = stat.isDirectory();
   } catch (e) {
-    if (!(e && e.code === 'ENOENT')) {
+    if (!(e && (e.code === 'ENOENT' || e.code === 'ENOTDIR'))) {
       throw e;
     }
     result = false;


### PR DESCRIPTION
**Summary**

A recent change to take precedence of NODE_PATH for module resolution (https://github.com/facebook/jest/pull/4453) made this issue more likely to occur since NODE_PATH could contain non-existent directories. While this could have occurred prior to the change, it was less likely since it is more common that modules are in local `node_modules`.

Either way, non-existent directories should be treated the same way as non-existent files during module resolution. The equivalent case for `statSync` returning `ENOENT` for files is `ENOTDIR` for directories. We may want to add `ENOTDIR` to `isFile` as well.

**Test plan**

1. `yarn test`
2. Link cli into another project, export NODE_PATH environment variable as a non-existent directory, no longer see cryptic `Cannot find module` error. Instead, it now resolves to a potential path further down the path list.

**Additional Context**

One other potential fix would be to propagate these exceptions up to the `Resolver.findNodeModule` callsites. Currently, this method absorbs all exceptions though, and since it is used externally by jest-config, I figured keeping the existing non-throwing API was preferable.