### PR TITLE
[docs] Clarify where `__mocks__` should live when using `roots`

### DIFF
--- a/docs/en/Configuration.md
+++ b/docs/en/Configuration.md
@@ -392,9 +392,9 @@ A list of paths to directories that Jest should use to search for files in.
 
 There are times where you only want Jest to search in a single sub-directory (such as cases where you have a `src/` directory in your repo), but prevent it from accessing the rest of the repo.
 
-*Note: While `rootDir` is mostly used as a token to be re-used in other configuration options, `roots` is used by the internals of Jest to locate **test files and source files**. This applies also when searching for manual mocks for modules from `node_modules` (`__mocks__` will need to live in one of the directories from `roots`).*
+*Note: While `rootDir` is mostly used as a token to be re-used in other configuration options, `roots` is used by the internals of Jest to locate **test files and source files**. This applies also when searching for manual mocks for modules from `node_modules` (`__mocks__` will need to live in one of the `roots`).*
 
-*Node: By default, `roots` has a single entry `<rootDir>` but there are cases where you want to have multiple roots within one project, for example `roots: ["<rootDir>/src/", "<rootDir>/tests/"]`.*
+*Note: By default, `roots` has a single entry `<rootDir>` but there are cases where you may want to have multiple roots within one project, for example `roots: ["<rootDir>/src/", "<rootDir>/tests/"]`.*
 
 ### `setupFiles` [array]
 Default: `[]`

--- a/docs/en/Configuration.md
+++ b/docs/en/Configuration.md
@@ -392,7 +392,9 @@ A list of paths to directories that Jest should use to search for files in.
 
 There are times where you only want Jest to search in a single sub-directory (such as cases where you have a `src/` directory in your repo), but prevent it from accessing the rest of the repo.
 
-*Note: While `rootDir` is mostly used as a token to be re-used in other configuration options, `roots` is used by the internals of Jest to locate **test files and source files**. By default, `roots` has a single entry `<rootDir>` but there are cases where you want to have multiple roots within one project, for example `roots: ["<rootDir>/src/", "<rootDir>/tests/"]`.*
+*Note: While `rootDir` is mostly used as a token to be re-used in other configuration options, `roots` is used by the internals of Jest to locate **test files and source files**. This applies also when searching for manual mocks for modules from `node_modules` (`__mocks__` will need to live in one of the directories from `roots`).*
+
+*Node: By default, `roots` has a single entry `<rootDir>` but there are cases where you want to have multiple roots within one project, for example `roots: ["<rootDir>/src/", "<rootDir>/tests/"]`.*
 
 ### `setupFiles` [array]
 Default: `[]`

--- a/docs/en/ManualMocks.md
+++ b/docs/en/ManualMocks.md
@@ -10,7 +10,7 @@ next: webpack
 
 Manual mocks are used to stub out functionality with mock data. For example, instead of accessing a remote resource like a website or a database, you might want to create a manual mock that allows you to use fake data. This ensures your tests will be fast and not flaky.
 
-Manual mocks are defined by writing a module in a `__mocks__/` subdirectory immediately adjacent to the module. For example, to mock a module called `user` in the `models` directory, create a file called `user.js` and put it in the `models/__mocks__` directory. If the module you are mocking is a node module (eg: `fs`), the mock should be placed in the `__mocks__` directory adjacent to `node_modules`. Eg:
+Manual mocks are defined by writing a module in a `__mocks__/` subdirectory immediately adjacent to the module. For example, to mock a module called `user` in the `models` directory, create a file called `user.js` and put it in the `models/__mocks__` directory. If the module you are mocking is a node module (eg: `fs`), the mock should be placed in the `__mocks__` directory adjacent to `node_modules` (unless you have configured [`root`](/jest/docs/en/configuration.html#roots-array-string) to point to another folders than the project root). Eg:
 
 ```bash
 .

--- a/docs/en/ManualMocks.md
+++ b/docs/en/ManualMocks.md
@@ -10,7 +10,7 @@ next: webpack
 
 Manual mocks are used to stub out functionality with mock data. For example, instead of accessing a remote resource like a website or a database, you might want to create a manual mock that allows you to use fake data. This ensures your tests will be fast and not flaky.
 
-Manual mocks are defined by writing a module in a `__mocks__/` subdirectory immediately adjacent to the module. For example, to mock a module called `user` in the `models` directory, create a file called `user.js` and put it in the `models/__mocks__` directory. If the module you are mocking is a node module (eg: `fs`), the mock should be placed in the `__mocks__` directory adjacent to `node_modules` (unless you have configured [`root`](/jest/docs/en/configuration.html#roots-array-string) to point to another folders than the project root). Eg:
+Manual mocks are defined by writing a module in a `__mocks__/` subdirectory immediately adjacent to the module. For example, to mock a module called `user` in the `models` directory, create a file called `user.js` and put it in the `models/__mocks__` directory. If the module you are mocking is a node module (eg: `fs`), the mock should be placed in the `__mocks__` directory adjacent to `node_modules` (unless you configured [`roots`](/jest/docs/en/configuration.html#roots-array-string) to point to a folder other than the project root). Eg:
 
 ```bash
 .


### PR DESCRIPTION
**Summary**

A clearer explanation for where `__mocks__` should live in order to mock modules from `node_modules` when a config is using `roots` to point to another directoy than the root directory.

**Test plan**

Docs only.