### PR TITLE
fix: Reset local state of assertions when using hasAssertions

### DIFF
--- a/packages/expect/src/__tests__/assertion_counts.test.js
+++ b/packages/expect/src/__tests__/assertion_counts.test.js
@@ -38,6 +38,8 @@ describe('.hasAssertions()', () => {
   it('throws if passed parameters', () => {
     jestExpect(() => {
       jestExpect.hasAssertions(2);
-    }).toThrow();
+    }).toThrow(/does not accept any arguments/);
   });
+
+  it('hasAssertions not leaking to global state', () => {});
 });

--- a/packages/expect/src/extract_expected_assertions_errors.js
+++ b/packages/expect/src/extract_expected_assertions_errors.js
@@ -17,6 +17,14 @@ import {
 
 import {getState, setState} from './jest_matchers_object';
 
+const resetAssertionsLocalState = () => {
+  setState({
+    assertionCalls: 0,
+    expectedAssertionsNumber: null,
+    isExpectingAssertions: false,
+  });
+};
+
 // Create and format all errors related to the mismatched number of `expect`
 // calls and reset the matchers state.
 const extractExpectedAssertionsErrors = () => {
@@ -26,7 +34,9 @@ const extractExpectedAssertionsErrors = () => {
     expectedAssertionsNumber,
     isExpectingAssertions,
   } = getState();
-  setState({assertionCalls: 0, expectedAssertionsNumber: null});
+
+  resetAssertionsLocalState();
+
   if (
     typeof expectedAssertionsNumber === 'number' &&
     assertionCalls !== expectedAssertionsNumber


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

`.hasAssertions` leaked to every `test` case following the one it was declared in.
Also decided to extract `setState` call to a function named `resetAssertionsState` so it's easier to understand what it does.
Fixes #4496.

**Test plan**

Empty test without assertions. Fails on current master.
