### PR TITLE
Support jest-preset.js files within Node modules.

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -425,7 +425,15 @@ Activates notifications for test results.
 Default: `undefined`
 
 A preset that is used as a base for Jest's configuration. A preset should point
-to an npm module that exports a `jest-preset.json` module on its top level.
+to an npm module that exports a `jest-preset.json` or `jest-preset.js` module at its top level.
+
+Presets may also be relative filesystem paths.
+
+```json
+{
+  "preset": "./node_modules/foo-bar/jest-preset.js"
+}
+```
 
 ### `projects` [array<string>]
 

--- a/packages/jest-config/src/__tests__/normalize.test.js
+++ b/packages/jest-config/src/__tests__/normalize.test.js
@@ -859,6 +859,24 @@ describe('preset', () => {
       }),
       {virtual: true},
     );
+    jest.mock(
+      '/node_modules/with-json-ext/jest-preset.json',
+      () => ({
+        moduleNameMapper: {
+          json: true,
+        },
+      }),
+      {virtual: true},
+    );
+    jest.mock(
+      '/node_modules/with-js-ext/jest-preset.js',
+      () => ({
+        moduleNameMapper: {
+          js: true,
+        },
+      }),
+      {virtual: true},
+    );
   });
 
   afterEach(() => {
@@ -903,6 +921,30 @@ describe('preset', () => {
         {},
       );
     }).not.toThrow();
+  });
+
+  test('supports .json preset files', () => {
+    const {options} = normalize(
+      {
+        preset: 'with-json-ext',
+        rootDir: '/root/path/foo',
+      },
+      {},
+    );
+
+    expect(options.moduleNameMapper).toEqual([['json', true]]);
+  });
+
+  test('supports .js preset files', () => {
+    const {options} = normalize(
+      {
+        preset: 'with-js-ext',
+        rootDir: '/root/path/foo',
+      },
+      {},
+    );
+
+    expect(options.moduleNameMapper).toEqual([['js', true]]);
   });
 
   test('merges with options', () => {

--- a/packages/jest-config/src/normalize.js
+++ b/packages/jest-config/src/normalize.js
@@ -73,7 +73,7 @@ const setupPreset = (
 
   try {
     // $FlowFixMe
-    preset = (require(presetModule): InitialOptions);
+    preset = (require(foundModule): InitialOptions);
   } catch (error) {
     if (error instanceof SyntaxError) {
       throw createConfigError(

--- a/packages/jest-config/src/normalize.js
+++ b/packages/jest-config/src/normalize.js
@@ -51,29 +51,39 @@ const setupPreset = (
 ): InitialOptions => {
   let preset;
   const presetPath = _replaceRootDirInPath(options.rootDir, optionsPreset);
-  const foundModule = PRESET_EXTENSIONS.some(ext => {
-    const presetModule = Resolver.findNodeModule(
-      presetPath.charAt(0) === '.' || presetPath.endsWith(ext)
-        ? presetPath
-        : path.join(presetPath, PRESET_NAME + ext),
-      {
-        basedir: options.rootDir,
-      },
-    );
+  const presetModule = Resolver.findNodeModule(
+    presetPath.charAt(0) === '.'
+      ? presetPath
+      : path.join(presetPath, PRESET_NAME),
+    {
+      basedir: options.rootDir,
+      extensions: PRESET_EXTENSIONS,
+    },
+  );
 
-    try {
-      // $FlowFixMe
-      preset = (require(presetModule): InitialOptions);
-    } catch (error) {
-      return false;
-    }
-
-    return true;
-  });
+  // const foundModule = PRESET_EXTENSIONS.some(ext => {
+  // const presetModule = Resolver.findNodeModule(
+  //   presetPath.charAt(0) === '.' || presetPath.endsWith(ext)
+  //     ? presetPath
+  //     : path.join(presetPath, PRESET_NAME + ext),
+  //   {
+  //     basedir: options.rootDir,
+  //   },
+  // );
+  //
+  //   try {
+  //     // $FlowFixMe
+  //     preset = (require(presetModule): InitialOptions);
+  //   } catch (error) {
+  //     return false;
+  //   }
+  //
+  //   return true;
+  // });
 
   try {
     // $FlowFixMe
-    preset = (require(foundModule): InitialOptions);
+    preset = (require(presetModule): InitialOptions);
   } catch (error) {
     if (error instanceof SyntaxError) {
       throw createConfigError(


### PR DESCRIPTION
**Summary**

Currently, Jest configuration may be a .json or .js file, but presets only support .json. This PR makes a change to also support jest-preset.js files within node modules.

This change would allow modules to make use of `process.env.NODE_ENV`.

**Test plan**

Unit tests.

```
[17:16:03] Miles:jest > yrun jest ./packages/jest-config/
yarn run v1.0.2
$ node ./packages/jest-cli/bin/jest.js "./packages/jest-config/"
 PASS  packages/jest-config/src/__tests__/normalize.test.js
 PASS  packages/jest-config/src/__tests__/resolve_config_path.test.js
 PASS  packages/jest-config/src/__tests__/set_from_argv.test.js
 PASS  packages/jest-config/src/__tests__/get_max_workers.test.js
 PASS  packages/jest-config/src/__tests__/validate_pattern.test.js

Test Suites: 5 passed, 5 total
Tests:       65 passed, 65 total
Snapshots:   5 passed, 5 total
Time:        0.776s, estimated 1s
Ran all test suites matching /.\/packages\/jest-config\//i.
```

And I've verified relative filesystem paths in another project of mine.

```json
"jest": {
  "preset": "./node_modules/@milesj/build-tool-config/jest-preset.json",
  "roots": [
    "./packages",
    "./tests"
  ],
  "testRegex": "./packages/([-a-z]+)?/tests/.*\\.test\\.js$"
},
```