### PR TITLE
Fix prettier error in jest-runner

### DIFF
--- a/packages/jest-runner/src/run_test.js
+++ b/packages/jest-runner/src/run_test.js
@@ -78,11 +78,7 @@ export default function runTest(
 
   let testConsole;
   if (globalConfig.silent) {
-    testConsole = new NullConsole(
-      consoleOut,
-      process.stderr,
-      consoleFormatter,
-    );
+    testConsole = new NullConsole(consoleOut, process.stderr, consoleFormatter);
   } else {
     if (globalConfig.verbose) {
       testConsole = new Console(consoleOut, process.stderr, consoleFormatter);


### PR DESCRIPTION
**Summary**

Local `yarn test` fails

**Test plan**

CI green for `ci/circleci: test-node-6`
Don’t know about `continuous-integration/appveyor/pr` though