### PR TITLE
Add abbel-plugin for object spread syntax to babel-preset-jest

### DIFF
--- a/packages/babel-preset-jest/index.js
+++ b/packages/babel-preset-jest/index.js
@@ -10,5 +10,6 @@ module.exports = {
   plugins: [
     // Cannot be `import` as this file is not compiled
     require('babel-plugin-jest-hoist'),
+    require('babel-plugin-syntax-object-rest-spread'),
   ],
 };

--- a/packages/babel-preset-jest/package.json
+++ b/packages/babel-preset-jest/package.json
@@ -8,6 +8,7 @@
   "license": "BSD-3-Clause",
   "main": "index.js",
   "dependencies": {
-    "babel-plugin-jest-hoist": "^21.0.2"
+    "babel-plugin-jest-hoist": "^21.0.2",
+    "babel-plugin-syntax-object-rest-spread": "^6.13.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -518,7 +518,7 @@ babel-plugin-syntax-jsx@^6.3.13, babel-plugin-syntax-jsx@^6.5.0, babel-plugin-sy
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
 
-babel-plugin-syntax-object-rest-spread@^6.8.0:
+babel-plugin-syntax-object-rest-spread@^6.13.0, babel-plugin-syntax-object-rest-spread@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Seems like the easiest fix to #4248

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
Running this version makes tests using object spread on node 8 pass without manually including the babel plugin there. Note that this doesn't transpile the syntax, it only allows babel to parse it.
Not sure if a test in this repo makes sense as it already gets that syntax plugin transitively in its own `.babelrc`

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
