### PR TITLE
Display outer element and trailing newline consistently in jest-diff

### DIFF
--- a/packages/jest-diff/src/__tests__/diff.test.js
+++ b/packages/jest-diff/src/__tests__/diff.test.js
@@ -619,7 +619,7 @@ describe('outer React element (non-snapshot)', () => {
   });
 });
 
-describe('trailing newline in multiline string', () => {
+describe('trailing newline in multiline string not enclosed in quotes', () => {
   const a = ['line 1', 'line 2', 'line 3'].join('\n');
   const b = a + '\n';
 

--- a/packages/jest-diff/src/__tests__/diff.test.js
+++ b/packages/jest-diff/src/__tests__/diff.test.js
@@ -600,7 +600,7 @@ describe('outer React element (non-snapshot)', () => {
   describe('from more to less', () => {
     const expected = [
       '- <header>',
-      // following 3 lines are unchanged, except for more indentation
+      // following 3 lines are unchanged, except for less indentation
       '  <h1>',
       '    Jest',
       '  </h1>',

--- a/packages/jest-diff/src/__tests__/diff.test.js
+++ b/packages/jest-diff/src/__tests__/diff.test.js
@@ -551,6 +551,101 @@ describe('indentation in React elements (snapshot)', () => {
   });
 });
 
+describe('outer React element (non-snapshot)', () => {
+  const a = {
+    $$typeof: elementSymbol,
+    props: {
+      children: 'Jest',
+    },
+    type: 'h1',
+  };
+  const b = {
+    $$typeof: elementSymbol,
+    props: {
+      children: [
+        a,
+        {
+          $$typeof: elementSymbol,
+          props: {
+            children: 'Delightful JavaScript Testing',
+          },
+          type: 'h2',
+        },
+      ],
+    },
+    type: 'header',
+  };
+
+  describe('from less to more', () => {
+    const expected = [
+      '+ <header>',
+      // following 3 lines are unchanged, except for more indentation
+      '    <h1>',
+      '      Jest',
+      '    </h1>',
+      '+   <h2>',
+      '+     Delightful JavaScript Testing',
+      '+   </h2>',
+      '+ </header>',
+    ].join('\n');
+
+    test('(unexpanded)', () => {
+      expect(stripped(a, b, unexpanded)).toMatch(expected);
+    });
+    test('(expanded)', () => {
+      expect(stripped(a, b, expanded)).toMatch(expected);
+    });
+  });
+
+  describe('from more to less', () => {
+    const expected = [
+      '- <header>',
+      // following 3 lines are unchanged, except for more indentation
+      '  <h1>',
+      '    Jest',
+      '  </h1>',
+      '-   <h2>',
+      '-     Delightful JavaScript Testing',
+      '-   </h2>',
+      '- </header>',
+    ].join('\n');
+
+    test('(unexpanded)', () => {
+      expect(stripped(b, a, unexpanded)).toMatch(expected);
+    });
+    test('(expanded)', () => {
+      expect(stripped(b, a, expanded)).toMatch(expected);
+    });
+  });
+});
+
+describe('trailing newline in multiline string', () => {
+  const a = ['line 1', 'line 2', 'line 3'].join('\n');
+  const b = a + '\n';
+
+  describe('from less to more', () => {
+    const expected = ['  line 1', '  line 2', '  line 3', '+ '].join('\n');
+
+    test('(unexpanded)', () => {
+      expect(stripped(a, b, unexpanded)).toMatch(expected);
+    });
+    test('(expanded)', () => {
+      expect(stripped(a, b, expanded)).toMatch(expected);
+    });
+  });
+
+  describe('from more to less', () => {
+    const expected = ['  line 1', '  line 2', '  line 3', '- '].join('\n');
+
+    test('(unexpanded)', () => {
+      expect(stripped(b, a, unexpanded)).toMatch(expected);
+    });
+    test('(expanded)', () => {
+      expect(stripped(b, a, expanded)).toMatch(expected);
+    });
+  });
+});
+
 describe('background color of spaces', () => {
   const baseline = {
     $$typeof: elementSymbol,

--- a/packages/jest-diff/src/diff_strings.js
+++ b/packages/jest-diff/src/diff_strings.js
@@ -223,13 +223,6 @@ const formatHunks = (
         ? contextLines
         : DIFF_CONTEXT_DEFAULT,
   };
-  // Make sure the strings end with a newline.
-  if (!a.endsWith('\n')) {
-    a += '\n';
-  }
-  if (!b.endsWith('\n')) {
-    b += '\n';
-  }
 
   const {hunks} = structuredPatch('', '', a, b, '', '', options);
   if (hunks.length === 0) {
@@ -260,6 +253,11 @@ export default function diffStrings(
   options: ?DiffOptions,
   original?: Original,
 ): string {
+  // Always append one trailing newline to both strings,
+  // because `formatHunks` and `formatChunks` always ignore one.
+  a += '\n';
+  b += '\n';
+
   // `diff` uses the Myers LCS diff algorithm which runs in O(n+d^2) time
   // (where "d" is the edit distance) and can get very slow for large edit
   // distances. Mitigate the cost by switching to a lower-resolution diff

--- a/packages/jest-diff/src/diff_strings.js
+++ b/packages/jest-diff/src/diff_strings.js
@@ -253,8 +253,8 @@ export default function diffStrings(
   options: ?DiffOptions,
   original?: Original,
 ): string {
-  // Always append newline to strings,
-  // because `formatHunks` and `formatChunks` ignore one trailing newline.
+  // Because `formatHunks` and `formatChunks` ignore one trailing newline,
+  // always append newline to strings:
   a += '\n';
   b += '\n';
 

--- a/packages/jest-diff/src/diff_strings.js
+++ b/packages/jest-diff/src/diff_strings.js
@@ -253,8 +253,8 @@ export default function diffStrings(
   options: ?DiffOptions,
   original?: Original,
 ): string {
-  // Always append one trailing newline to both strings,
-  // because `formatHunks` and `formatChunks` always ignore one.
+  // Always append newline to strings,
+  // because `formatHunks` and `formatChunks` ignore one trailing newline.
   a += '\n';
   b += '\n';
 


### PR DESCRIPTION
**Summary**

**Problem 1**: outer element

For example, if component changes to render a sibling element, it also returns an outer element in React 15 and earlier.

* For default **unexpanded** option, `formatHunks` function makes sure that strings **end with newline**. Therefore, it displays an inserted (or deleted) outer element **clearly**:

```diff
+ <header>
    <h1>
      Jest
    </h1>
+   <h2>
+     Delightful Javascript Testing
+   </h2>
+ </header>
```

* For **expand** option, `formatChunks` function **doesn’t**. Therefore it displays the `</h1>` end tag of the original outer element **unclearly** as a pair of deleted and inserted lines:

```diff
+ <header>
    <h1>
      Jest
- </h1>
+   </h1>
+   <h2>
+     Delightful Javascript Testing
+   </h2>
+ </header>
```

**Problem 2**: presence or absence of trailing newline

A multiline string not enclosed in quotes is hypothetical result from a plugin instead of default result from `pretty-format` package. It might become more important after #4183

* For default **unexpanded** option, `formatHunks` function makes sure that strings **end with newline**. Therefore, it displays **unclearly**:

```diff
Compared values have no visual difference.
```

* For **expand** option, `formatChunks` function **doesn’t**. Because it ignores trailing newlines at end of diffs, it displays even more **unclearly**:

```diff
  line 1
  line 2
- line 3
+ line 3
```

Correct and clear result for deleted (or inserted) newline:

```diff
  line 1
  line 2
  line 3
- 
```

**Solution**

Because `formatHunks` and `formatChunks` ignore one trailing newline **always append** newline to strings.

You would laugh at how much code I thought to write, before I saw that less is more :)

**Test plan**

Add tests to specify intended result and prevent regression:
* outside element: 2 **unexpanded** passed first, 2 **expanded** failed first
* multiline string without quotes: all 4 failed first
