### PR TITLE
docs(restoreAllMocks): available in Jest 21.1.0+

### DIFF
--- a/docs/en/JestObjectAPI.md
+++ b/docs/en/JestObjectAPI.md
@@ -181,7 +181,7 @@ Resets the state of all mocks. Equivalent to calling `.mockReset()` on every moc
 Returns the `jest` object for chaining.
 
 ### `jest.restoreAllMocks()`
-##### available in Jest **20.1.0+**
+##### available in Jest **21.1.0+**
 Restores all mocks back to their original value. Equivalent to calling `.mockRestore` on every mocked function. Beware that `jest.restoreAllMocks()` only works when mock was created with `jest.spyOn`; other mocks will require you to manually restore them.
 
 ### `jest.resetModules()`


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

The `restoreAllMocks` function was added in `v20.1.0` but exposed in `v21.1.0`, i.e. people will get `jest.restoreAllMocks is not a function` error before `v21.1.0`, the actual available version should be `v21.1.0+`.

[CHANGLOG v21.1.0](https://github.com/facebook/jest/blob/master/CHANGELOG.md#jest-211): Expose restoreAllMocks to object (#4463)

**Test plan**

docs only

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
