### PR TITLE
docs: add warning about uppercase __MOCKS__ folders

### DIFF
--- a/docs/en/ManualMocks.md
+++ b/docs/en/ManualMocks.md
@@ -10,7 +10,7 @@ next: webpack
 
 Manual mocks are used to stub out functionality with mock data. For example, instead of accessing a remote resource like a website or a database, you might want to create a manual mock that allows you to use fake data. This ensures your tests will be fast and not flaky.
 
-Manual mocks are defined by writing a module in a `__mocks__/` subdirectory immediately adjacent to the module. For example, to mock a module called `user` in the `models` directory, create a file called `user.js` and put it in the `models/__mocks__` directory. If the module you are mocking is a node module (eg: `fs`), the mock should be placed in the `__mocks__` directory adjacent to `node_modules` (unless you configured [`roots`](/jest/docs/en/configuration.html#roots-array-string) to point to a folder other than the project root). Eg:
+Manual mocks are defined by writing a module in a `__mocks__/` subdirectory immediately adjacent to the module. For example, to mock a module called `user` in the `models` directory, create a file called `user.js` and put it in the `models/__mocks__` directory. Note that the `__mocks__` folder is case-sensitive, so naming the directory `__MOCKS__` will break on some systems. If the module you are mocking is a node module (eg: `fs`), the mock should be placed in the `__mocks__` directory adjacent to `node_modules` (unless you configured [`roots`](/jest/docs/en/configuration.html#roots-array-string) to point to a folder other than the project root). Eg:
 
 ```bash
 .

--- a/docs/en/TutorialAsync.md
+++ b/docs/en/TutorialAsync.md
@@ -46,7 +46,7 @@ export default function request(url) {
 ```
 
 Because we don't want to go to the network in our test, we are going to create
-a manual mock for our `request.js` module in the `__mocks__` folder.
+a manual mock for our `request.js` module in the `__mocks__` folder (the folder is case-sensitive, `__MOCKS__` will not work).
 It could look something like this:
 
 ```js


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
I just spent 5 hours trying to figure out why my tests were passing on all developer's computers, but were failing on CI. It turns out we had named our `__mocks__` folders in all uppercase, `__MOCKS__`, instead of the correct lowercase name. Apparently this is not a problem on Windows or macOS, but breaks on other Unix systems like Ubuntu or Debian. At least that was my reasoning.

I don't think this is a rare mistake to make, as many boilerplates and tutorials set up jest to look for `__TESTS__` folders (and `.spec` and `.test` files of course), which makes it natural to name the mock folders uppercase as well. (this i purely speculation though)

To make sure this doesn't happen for others in the future, I thought it would be wise to call this out explicitly in the docs. Another fix would be to actually change the implementation so the name of the folder was case-insensitive, however I think that a member of the core team should decide if that is the way to go. I guess this is a good first step.

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

I ran `yarn test` and `yarn start` in the `website` folder, and everything looked fine. This is a minor update to the documentation, so no special testing should be needed.