### PR TITLE
Replace a map method with reduce in jest-diff

### DIFF
--- a/packages/jest-diff/src/__tests__/__snapshots__/diff.test.js.snap
+++ b/packages/jest-diff/src/__tests__/__snapshots__/diff.test.js.snap
@@ -71,7 +71,7 @@ exports[`collapses big diffs to patch format 1`] = `
 <red>+ Received</>
 
 @@ -6,9 +6,9 @@</>
-</><dim>      4,
+<dim>      4,
 <dim>      5,
 <dim>      6,
 <dim>      7,
@@ -104,7 +104,7 @@ exports[`context number of lines: -1 (5 default) 1`] = `
 <red>+ Received</>
 
 @@ -6,9 +6,9 @@</>
-</><dim>      4,
+<dim>      4,
 <dim>      5,
 <dim>      6,
 <dim>      7,
@@ -121,9 +121,9 @@ exports[`context number of lines: 0  1`] = `
 <red>+ Received</>
 
 @@ -11,0 +11,1 @@</>
-</><red>+     10,</>
+<red>+     10,</>
 @@ -12,1 +13,0 @@</>
-</><green>-     10,</>"
+<green>-     10,</>"
 `;
 
 exports[`context number of lines: 1  1`] = `
@@ -131,7 +131,7 @@ exports[`context number of lines: 1  1`] = `
 <red>+ Received</>
 
 @@ -10,4 +10,4 @@</>
-</><dim>      8,
+<dim>      8,
 <red>+     10,</>
 <dim>      9,
 <green>-     10,</>
@@ -143,7 +143,7 @@ exports[`context number of lines: 2  1`] = `
 <red>+ Received</>
 
 @@ -9,6 +9,6 @@</>
-</><dim>      7,
+<dim>      7,
 <dim>      8,
 <red>+     10,</>
 <dim>      9,
@@ -157,7 +157,7 @@ exports[`context number of lines: null (5 default) 1`] = `
 <red>+ Received</>
 
 @@ -6,9 +6,9 @@</>
-</><dim>      4,
+<dim>      4,
 <dim>      5,
 <dim>      6,
 <dim>      7,


### PR DESCRIPTION
**Summary**

Improve in a small way now and mainly reduce complexity of code diff in the next pull request:

In `formatHunks` replace `map` with `reduce` to eliminate some string concatenation and mainly be able to display more detail via `diffChars` within **adjacent sequences** of removed and added lines.

**Test plan**

Updated 6 snapshots in which replacing newline in `createPatchMark` function with `join('\n')` in `formatHunks` got rid of escape sequences to reopen and immediately close yellow on the next line.