### PR TITLE
Add missing escape sequences to ConvertAnsi plugin

### DIFF
--- a/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -1,14 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.rejects fails for promise that resolves 1`] = `
-"<dim>expect(<red>received</><dim>).rejects.toBe(<dim>)
+"<dim>expect(</><red>received</><dim>).rejects.toBe(</><dim>)</>
 
 Expected <red>received</> Promise to reject, instead it resolved to value
   <red>4</>"
 `;
 
 exports[`.rejects fails non-promise value "a" 1`] = `
-"<dim>expect(<red>received</><dim>).rejects.toBeDefined(<dim>)
+"<dim>expect(</><red>received</><dim>).rejects.toBeDefined(</><dim>)</>
 
 <red>received</> value must be a Promise.
 Received:
@@ -16,7 +16,7 @@ Received:
 `;
 
 exports[`.rejects fails non-promise value [1] 1`] = `
-"<dim>expect(<red>received</><dim>).rejects.toBeDefined(<dim>)
+"<dim>expect(</><red>received</><dim>).rejects.toBeDefined(</><dim>)</>
 
 <red>received</> value must be a Promise.
 Received:
@@ -24,7 +24,7 @@ Received:
 `;
 
 exports[`.rejects fails non-promise value [Function anonymous] 1`] = `
-"<dim>expect(<red>received</><dim>).rejects.toBeDefined(<dim>)
+"<dim>expect(</><red>received</><dim>).rejects.toBeDefined(</><dim>)</>
 
 <red>received</> value must be a Promise.
 Received:
@@ -32,7 +32,7 @@ Received:
 `;
 
 exports[`.rejects fails non-promise value {"a": 1} 1`] = `
-"<dim>expect(<red>received</><dim>).rejects.toBeDefined(<dim>)
+"<dim>expect(</><red>received</><dim>).rejects.toBeDefined(</><dim>)</>
 
 <red>received</> value must be a Promise.
 Received:
@@ -40,7 +40,7 @@ Received:
 `;
 
 exports[`.rejects fails non-promise value 4 1`] = `
-"<dim>expect(<red>received</><dim>).rejects.toBeDefined(<dim>)
+"<dim>expect(</><red>received</><dim>).rejects.toBeDefined(</><dim>)</>
 
 <red>received</> value must be a Promise.
 Received:
@@ -48,14 +48,14 @@ Received:
 `;
 
 exports[`.rejects fails non-promise value null 1`] = `
-"<dim>expect(<red>received</><dim>).rejects.toBeDefined(<dim>)
+"<dim>expect(</><red>received</><dim>).rejects.toBeDefined(</><dim>)</>
 
 <red>received</> value must be a Promise.
 Received: <red>null</>"
 `;
 
 exports[`.rejects fails non-promise value true 1`] = `
-"<dim>expect(<red>received</><dim>).rejects.toBeDefined(<dim>)
+"<dim>expect(</><red>received</><dim>).rejects.toBeDefined(</><dim>)</>
 
 <red>received</> value must be a Promise.
 Received:
@@ -63,21 +63,21 @@ Received:
 `;
 
 exports[`.rejects fails non-promise value undefined 1`] = `
-"<dim>expect(<red>received</><dim>).rejects.toBeDefined(<dim>)
+"<dim>expect(</><red>received</><dim>).rejects.toBeDefined(</><dim>)</>
 
 <red>received</> value must be a Promise.
 Received: <red>undefined</>"
 `;
 
 exports[`.resolves fails for promise that rejects 1`] = `
-"<dim>expect(<red>received</><dim>).resolves.toBe(<dim>)
+"<dim>expect(</><red>received</><dim>).resolves.toBe(</><dim>)</>
 
 Expected <red>received</> Promise to resolve, instead it rejected to value
   <red>4</>"
 `;
 
 exports[`.resolves fails non-promise value "a" 1`] = `
-"<dim>expect(<red>received</><dim>).resolves.toBeDefined(<dim>)
+"<dim>expect(</><red>received</><dim>).resolves.toBeDefined(</><dim>)</>
 
 <red>received</> value must be a Promise.
 Received:
@@ -85,7 +85,7 @@ Received:
 `;
 
 exports[`.resolves fails non-promise value [1] 1`] = `
-"<dim>expect(<red>received</><dim>).resolves.toBeDefined(<dim>)
+"<dim>expect(</><red>received</><dim>).resolves.toBeDefined(</><dim>)</>
 
 <red>received</> value must be a Promise.
 Received:
@@ -93,7 +93,7 @@ Received:
 `;
 
 exports[`.resolves fails non-promise value [Function anonymous] 1`] = `
-"<dim>expect(<red>received</><dim>).resolves.toBeDefined(<dim>)
+"<dim>expect(</><red>received</><dim>).resolves.toBeDefined(</><dim>)</>
 
 <red>received</> value must be a Promise.
 Received:
@@ -101,7 +101,7 @@ Received:
 `;
 
 exports[`.resolves fails non-promise value {"a": 1} 1`] = `
-"<dim>expect(<red>received</><dim>).resolves.toBeDefined(<dim>)
+"<dim>expect(</><red>received</><dim>).resolves.toBeDefined(</><dim>)</>
 
 <red>received</> value must be a Promise.
 Received:
@@ -109,7 +109,7 @@ Received:
 `;
 
 exports[`.resolves fails non-promise value 4 1`] = `
-"<dim>expect(<red>received</><dim>).resolves.toBeDefined(<dim>)
+"<dim>expect(</><red>received</><dim>).resolves.toBeDefined(</><dim>)</>
 
 <red>received</> value must be a Promise.
 Received:
@@ -117,14 +117,14 @@ Received:
 `;
 
 exports[`.resolves fails non-promise value null 1`] = `
-"<dim>expect(<red>received</><dim>).resolves.toBeDefined(<dim>)
+"<dim>expect(</><red>received</><dim>).resolves.toBeDefined(</><dim>)</>
 
 <red>received</> value must be a Promise.
 Received: <red>null</>"
 `;
 
 exports[`.resolves fails non-promise value true 1`] = `
-"<dim>expect(<red>received</><dim>).resolves.toBeDefined(<dim>)
+"<dim>expect(</><red>received</><dim>).resolves.toBeDefined(</><dim>)</>
 
 <red>received</> value must be a Promise.
 Received:
@@ -132,14 +132,14 @@ Received:
 `;
 
 exports[`.resolves fails non-promise value undefined 1`] = `
-"<dim>expect(<red>received</><dim>).resolves.toBeDefined(<dim>)
+"<dim>expect(</><red>received</><dim>).resolves.toBeDefined(</><dim>)</>
 
 <red>received</> value must be a Promise.
 Received: <red>undefined</>"
 `;
 
 exports[`.toBe() does not crash on circular references 1`] = `
-"<dim>expect(<red>received</><dim>).toBe(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>)</>
 
 Expected value to be (using ===):
   <green>{}</>
@@ -158,7 +158,7 @@ Difference:
 `;
 
 exports[`.toBe() fails for '"a"' with '.not' 1`] = `
-"<dim>expect(<red>received</><dim>).not.toBe(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toBe(</><green>expected</><dim>)</>
 
 Expected value to not be (using ===):
   <green>\\"a\\"</>
@@ -167,7 +167,7 @@ Received:
 `;
 
 exports[`.toBe() fails for '[]' with '.not' 1`] = `
-"<dim>expect(<red>received</><dim>).not.toBe(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toBe(</><green>expected</><dim>)</>
 
 Expected value to not be (using ===):
   <green>[]</>
@@ -176,7 +176,7 @@ Received:
 `;
 
 exports[`.toBe() fails for '{}' with '.not' 1`] = `
-"<dim>expect(<red>received</><dim>).not.toBe(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toBe(</><green>expected</><dim>)</>
 
 Expected value to not be (using ===):
   <green>{}</>
@@ -185,7 +185,7 @@ Received:
 `;
 
 exports[`.toBe() fails for '1' with '.not' 1`] = `
-"<dim>expect(<red>received</><dim>).not.toBe(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toBe(</><green>expected</><dim>)</>
 
 Expected value to not be (using ===):
   <green>1</>
@@ -194,7 +194,7 @@ Received:
 `;
 
 exports[`.toBe() fails for 'false' with '.not' 1`] = `
-"<dim>expect(<red>received</><dim>).not.toBe(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toBe(</><green>expected</><dim>)</>
 
 Expected value to not be (using ===):
   <green>false</>
@@ -203,7 +203,7 @@ Received:
 `;
 
 exports[`.toBe() fails for 'null' with '.not' 1`] = `
-"<dim>expect(<red>received</><dim>).not.toBe(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toBe(</><green>expected</><dim>)</>
 
 Expected value to not be (using ===):
   <green>null</>
@@ -212,7 +212,7 @@ Received:
 `;
 
 exports[`.toBe() fails for 'undefined' with '.not' 1`] = `
-"<dim>expect(<red>received</><dim>).not.toBe(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toBe(</><green>expected</><dim>)</>
 
 Expected value to not be (using ===):
   <green>undefined</>
@@ -221,7 +221,7 @@ Received:
 `;
 
 exports[`.toBe() fails for: "abc" and "cde" 1`] = `
-"<dim>expect(<red>received</><dim>).toBe(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>)</>
 
 Expected value to be (using ===):
   <green>\\"cde\\"</>
@@ -230,7 +230,7 @@ Received:
 `;
 
 exports[`.toBe() fails for: [] and [] 1`] = `
-"<dim>expect(<red>received</><dim>).toBe(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>)</>
 
 Expected value to be (using ===):
   <green>[]</>
@@ -239,11 +239,11 @@ Received:
 
 Difference:
 
-<dim>Compared values have no visual difference. <dim>Looks like you wanted to test for object/array equality with strict \`toBe\` matcher. You probably need to use \`toEqual\` instead."
+<dim>Compared values have no visual difference.</> <dim>Looks like you wanted to test for object/array equality with strict \`toBe\` matcher. You probably need to use \`toEqual\` instead.</>"
 `;
 
 exports[`.toBe() fails for: {"a": 1} and {"a": 1} 1`] = `
-"<dim>expect(<red>received</><dim>).toBe(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>)</>
 
 Expected value to be (using ===):
   <green>{\\"a\\": 1}</>
@@ -252,11 +252,11 @@ Received:
 
 Difference:
 
-<dim>Compared values have no visual difference. <dim>Looks like you wanted to test for object/array equality with strict \`toBe\` matcher. You probably need to use \`toEqual\` instead."
+<dim>Compared values have no visual difference.</> <dim>Looks like you wanted to test for object/array equality with strict \`toBe\` matcher. You probably need to use \`toEqual\` instead.</>"
 `;
 
 exports[`.toBe() fails for: {"a": 1} and {"a": 5} 1`] = `
-"<dim>expect(<red>received</><dim>).toBe(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>)</>
 
 Expected value to be (using ===):
   <green>{\\"a\\": 5}</>
@@ -268,14 +268,14 @@ Difference:
 <green>- Expected</>
 <red>+ Received</>
 
-<dim>  Object {
+<dim>  Object {</>
 <green>-   \\"a\\": 5,</>
 <red>+   \\"a\\": 1,</>
-<dim>  }"
+<dim>  }</>"
 `;
 
 exports[`.toBe() fails for: {} and {} 1`] = `
-"<dim>expect(<red>received</><dim>).toBe(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>)</>
 
 Expected value to be (using ===):
   <green>{}</>
@@ -284,11 +284,11 @@ Received:
 
 Difference:
 
-<dim>Compared values have no visual difference. <dim>Looks like you wanted to test for object/array equality with strict \`toBe\` matcher. You probably need to use \`toEqual\` instead."
+<dim>Compared values have no visual difference.</> <dim>Looks like you wanted to test for object/array equality with strict \`toBe\` matcher. You probably need to use \`toEqual\` instead.</>"
 `;
 
 exports[`.toBe() fails for: 1 and 2 1`] = `
-"<dim>expect(<red>received</><dim>).toBe(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>)</>
 
 Expected value to be (using ===):
   <green>2</>
@@ -297,7 +297,7 @@ Received:
 `;
 
 exports[`.toBe() fails for: null and undefined 1`] = `
-"<dim>expect(<red>received</><dim>).toBe(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>)</>
 
 Expected value to be (using ===):
   <green>undefined</>
@@ -310,7 +310,7 @@ Difference:
 `;
 
 exports[`.toBe() fails for: true and false 1`] = `
-"<dim>expect(<red>received</><dim>).toBe(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>)</>
 
 Expected value to be (using ===):
   <green>false</>
@@ -319,7 +319,7 @@ Received:
 `;
 
 exports[`.toBeCloseTo() {pass: true} expect(0)toBeCloseTo( 0) 1`] = `
-"<dim>expect(<red>received</><dim>).not.toBeCloseTo(<green>expected, precision</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeCloseTo(</><green>expected, precision</><dim>)</>
 
 Expected value not to be close to (with <green>2</>-digit precision):
   <green>0</>
@@ -328,7 +328,7 @@ Received:
 `;
 
 exports[`.toBeCloseTo() {pass: true} expect(0)toBeCloseTo( 0.001) 1`] = `
-"<dim>expect(<red>received</><dim>).not.toBeCloseTo(<green>expected, precision</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeCloseTo(</><green>expected, precision</><dim>)</>
 
 Expected value not to be close to (with <green>2</>-digit precision):
   <green>0.001</>
@@ -337,7 +337,7 @@ Received:
 `;
 
 exports[`.toBeCloseTo() {pass: true} expect(1.23)toBeCloseTo( 1.225) 1`] = `
-"<dim>expect(<red>received</><dim>).not.toBeCloseTo(<green>expected, precision</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeCloseTo(</><green>expected, precision</><dim>)</>
 
 Expected value not to be close to (with <green>2</>-digit precision):
   <green>1.225</>
@@ -346,7 +346,7 @@ Received:
 `;
 
 exports[`.toBeCloseTo() {pass: true} expect(1.23)toBeCloseTo( 1.226) 1`] = `
-"<dim>expect(<red>received</><dim>).not.toBeCloseTo(<green>expected, precision</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeCloseTo(</><green>expected, precision</><dim>)</>
 
 Expected value not to be close to (with <green>2</>-digit precision):
   <green>1.226</>
@@ -355,7 +355,7 @@ Received:
 `;
 
 exports[`.toBeCloseTo() {pass: true} expect(1.23)toBeCloseTo( 1.229) 1`] = `
-"<dim>expect(<red>received</><dim>).not.toBeCloseTo(<green>expected, precision</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeCloseTo(</><green>expected, precision</><dim>)</>
 
 Expected value not to be close to (with <green>2</>-digit precision):
   <green>1.229</>
@@ -364,7 +364,7 @@ Received:
 `;
 
 exports[`.toBeCloseTo() {pass: true} expect(1.23)toBeCloseTo( 1.234) 1`] = `
-"<dim>expect(<red>received</><dim>).not.toBeCloseTo(<green>expected, precision</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeCloseTo(</><green>expected, precision</><dim>)</>
 
 Expected value not to be close to (with <green>2</>-digit precision):
   <green>1.234</>
@@ -373,7 +373,7 @@ Received:
 `;
 
 exports[`.toBeCloseTo() accepts an optional precision argument: [0, 0.000004, 5] 1`] = `
-"<dim>expect(<red>received</><dim>).not.toBeCloseTo(<green>expected, precision</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeCloseTo(</><green>expected, precision</><dim>)</>
 
 Expected value not to be close to (with <green>5</>-digit precision):
   <green>0.000004</>
@@ -382,7 +382,7 @@ Received:
 `;
 
 exports[`.toBeCloseTo() accepts an optional precision argument: [0, 0.0001, 3] 1`] = `
-"<dim>expect(<red>received</><dim>).not.toBeCloseTo(<green>expected, precision</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeCloseTo(</><green>expected, precision</><dim>)</>
 
 Expected value not to be close to (with <green>3</>-digit precision):
   <green>0.0001</>
@@ -391,7 +391,7 @@ Received:
 `;
 
 exports[`.toBeCloseTo() accepts an optional precision argument: [0, 0.1, 0] 1`] = `
-"<dim>expect(<red>received</><dim>).not.toBeCloseTo(<green>expected, precision</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeCloseTo(</><green>expected, precision</><dim>)</>
 
 Expected value not to be close to (with <green>0</>-digit precision):
   <green>0.1</>
@@ -400,7 +400,7 @@ Received:
 `;
 
 exports[`.toBeCloseTo() throws: [0, 0.01] 1`] = `
-"<dim>expect(<red>received</><dim>).toBeCloseTo(<green>expected, precision</><dim>)
+"<dim>expect(</><red>received</><dim>).toBeCloseTo(</><green>expected, precision</><dim>)</>
 
 Expected value to be close to (with <green>2</>-digit precision):
   <green>0.01</>
@@ -409,7 +409,7 @@ Received:
 `;
 
 exports[`.toBeCloseTo() throws: [1, 1.23] 1`] = `
-"<dim>expect(<red>received</><dim>).toBeCloseTo(<green>expected, precision</><dim>)
+"<dim>expect(</><red>received</><dim>).toBeCloseTo(</><green>expected, precision</><dim>)</>
 
 Expected value to be close to (with <green>2</>-digit precision):
   <green>1.23</>
@@ -418,7 +418,7 @@ Received:
 `;
 
 exports[`.toBeCloseTo() throws: [1.23, 1.2249999] 1`] = `
-"<dim>expect(<red>received</><dim>).toBeCloseTo(<green>expected, precision</><dim>)
+"<dim>expect(</><red>received</><dim>).toBeCloseTo(</><green>expected, precision</><dim>)</>
 
 Expected value to be close to (with <green>2</>-digit precision):
   <green>1.2249999</>
@@ -427,147 +427,147 @@ Received:
 `;
 
 exports[`.toBeDefined(), .toBeUndefined() '"a"' is defined 1`] = `
-"<dim>expect(<red>received</><dim>).not.toBeDefined(<dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeDefined(</><dim>)</>
 
 Expected value not to be defined, instead received
   <red>\\"a\\"</>"
 `;
 
 exports[`.toBeDefined(), .toBeUndefined() '"a"' is defined 2`] = `
-"<dim>expect(<red>received</><dim>).toBeUndefined(<dim>)
+"<dim>expect(</><red>received</><dim>).toBeUndefined(</><dim>)</>
 
 Expected value to be undefined, instead received
   <red>\\"a\\"</>"
 `;
 
 exports[`.toBeDefined(), .toBeUndefined() '[]' is defined 1`] = `
-"<dim>expect(<red>received</><dim>).not.toBeDefined(<dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeDefined(</><dim>)</>
 
 Expected value not to be defined, instead received
   <red>[]</>"
 `;
 
 exports[`.toBeDefined(), .toBeUndefined() '[]' is defined 2`] = `
-"<dim>expect(<red>received</><dim>).toBeUndefined(<dim>)
+"<dim>expect(</><red>received</><dim>).toBeUndefined(</><dim>)</>
 
 Expected value to be undefined, instead received
   <red>[]</>"
 `;
 
 exports[`.toBeDefined(), .toBeUndefined() '[Function anonymous]' is defined 1`] = `
-"<dim>expect(<red>received</><dim>).not.toBeDefined(<dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeDefined(</><dim>)</>
 
 Expected value not to be defined, instead received
   <red>[Function anonymous]</>"
 `;
 
 exports[`.toBeDefined(), .toBeUndefined() '[Function anonymous]' is defined 2`] = `
-"<dim>expect(<red>received</><dim>).toBeUndefined(<dim>)
+"<dim>expect(</><red>received</><dim>).toBeUndefined(</><dim>)</>
 
 Expected value to be undefined, instead received
   <red>[Function anonymous]</>"
 `;
 
 exports[`.toBeDefined(), .toBeUndefined() '{}' is defined 1`] = `
-"<dim>expect(<red>received</><dim>).not.toBeDefined(<dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeDefined(</><dim>)</>
 
 Expected value not to be defined, instead received
   <red>{}</>"
 `;
 
 exports[`.toBeDefined(), .toBeUndefined() '{}' is defined 2`] = `
-"<dim>expect(<red>received</><dim>).toBeUndefined(<dim>)
+"<dim>expect(</><red>received</><dim>).toBeUndefined(</><dim>)</>
 
 Expected value to be undefined, instead received
   <red>{}</>"
 `;
 
 exports[`.toBeDefined(), .toBeUndefined() '0.5' is defined 1`] = `
-"<dim>expect(<red>received</><dim>).not.toBeDefined(<dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeDefined(</><dim>)</>
 
 Expected value not to be defined, instead received
   <red>0.5</>"
 `;
 
 exports[`.toBeDefined(), .toBeUndefined() '0.5' is defined 2`] = `
-"<dim>expect(<red>received</><dim>).toBeUndefined(<dim>)
+"<dim>expect(</><red>received</><dim>).toBeUndefined(</><dim>)</>
 
 Expected value to be undefined, instead received
   <red>0.5</>"
 `;
 
 exports[`.toBeDefined(), .toBeUndefined() '1' is defined 1`] = `
-"<dim>expect(<red>received</><dim>).not.toBeDefined(<dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeDefined(</><dim>)</>
 
 Expected value not to be defined, instead received
   <red>1</>"
 `;
 
 exports[`.toBeDefined(), .toBeUndefined() '1' is defined 2`] = `
-"<dim>expect(<red>received</><dim>).toBeUndefined(<dim>)
+"<dim>expect(</><red>received</><dim>).toBeUndefined(</><dim>)</>
 
 Expected value to be undefined, instead received
   <red>1</>"
 `;
 
 exports[`.toBeDefined(), .toBeUndefined() 'Infinity' is defined 1`] = `
-"<dim>expect(<red>received</><dim>).not.toBeDefined(<dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeDefined(</><dim>)</>
 
 Expected value not to be defined, instead received
   <red>Infinity</>"
 `;
 
 exports[`.toBeDefined(), .toBeUndefined() 'Infinity' is defined 2`] = `
-"<dim>expect(<red>received</><dim>).toBeUndefined(<dim>)
+"<dim>expect(</><red>received</><dim>).toBeUndefined(</><dim>)</>
 
 Expected value to be undefined, instead received
   <red>Infinity</>"
 `;
 
 exports[`.toBeDefined(), .toBeUndefined() 'Map {}' is defined 1`] = `
-"<dim>expect(<red>received</><dim>).not.toBeDefined(<dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeDefined(</><dim>)</>
 
 Expected value not to be defined, instead received
   <red>Map {}</>"
 `;
 
 exports[`.toBeDefined(), .toBeUndefined() 'Map {}' is defined 2`] = `
-"<dim>expect(<red>received</><dim>).toBeUndefined(<dim>)
+"<dim>expect(</><red>received</><dim>).toBeUndefined(</><dim>)</>
 
 Expected value to be undefined, instead received
   <red>Map {}</>"
 `;
 
 exports[`.toBeDefined(), .toBeUndefined() 'true' is defined 1`] = `
-"<dim>expect(<red>received</><dim>).not.toBeDefined(<dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeDefined(</><dim>)</>
 
 Expected value not to be defined, instead received
   <red>true</>"
 `;
 
 exports[`.toBeDefined(), .toBeUndefined() 'true' is defined 2`] = `
-"<dim>expect(<red>received</><dim>).toBeUndefined(<dim>)
+"<dim>expect(</><red>received</><dim>).toBeUndefined(</><dim>)</>
 
 Expected value to be undefined, instead received
   <red>true</>"
 `;
 
 exports[`.toBeDefined(), .toBeUndefined() undefined is undefined 1`] = `
-"<dim>expect(<red>received</><dim>).toBeDefined(<dim>)
+"<dim>expect(</><red>received</><dim>).toBeDefined(</><dim>)</>
 
 Expected value to be defined, instead received
   <red>undefined</>"
 `;
 
 exports[`.toBeDefined(), .toBeUndefined() undefined is undefined 2`] = `
-"<dim>expect(<red>received</><dim>).not.toBeUndefined(<dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeUndefined(</><dim>)</>
 
 Expected value not to be undefined, instead received
   <red>undefined</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() equal numbers: [-Infinity, -Infinity] 1`] = `
-"<dim>expect(<red>received</><dim>).not.toBeGreaterThanOrEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeGreaterThanOrEqual(</><green>expected</><dim>)</>
 
 Expected value not to be greater than or equal:
   <green>-Infinity</>
@@ -576,7 +576,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() equal numbers: [-Infinity, -Infinity] 2`] = `
-"<dim>expect(<red>received</><dim>).not.toBeLessThanOrEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeLessThanOrEqual(</><green>expected</><dim>)</>
 
 Expected value not to be less than or equal:
   <green>-Infinity</>
@@ -585,7 +585,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() equal numbers: [1, 1] 1`] = `
-"<dim>expect(<red>received</><dim>).not.toBeGreaterThanOrEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeGreaterThanOrEqual(</><green>expected</><dim>)</>
 
 Expected value not to be greater than or equal:
   <green>1</>
@@ -594,7 +594,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() equal numbers: [1, 1] 2`] = `
-"<dim>expect(<red>received</><dim>).not.toBeLessThanOrEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeLessThanOrEqual(</><green>expected</><dim>)</>
 
 Expected value not to be less than or equal:
   <green>1</>
@@ -603,7 +603,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() equal numbers: [1.7976931348623157e+308, 1.7976931348623157e+308] 1`] = `
-"<dim>expect(<red>received</><dim>).not.toBeGreaterThanOrEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeGreaterThanOrEqual(</><green>expected</><dim>)</>
 
 Expected value not to be greater than or equal:
   <green>1.7976931348623157e+308</>
@@ -612,7 +612,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() equal numbers: [1.7976931348623157e+308, 1.7976931348623157e+308] 2`] = `
-"<dim>expect(<red>received</><dim>).not.toBeLessThanOrEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeLessThanOrEqual(</><green>expected</><dim>)</>
 
 Expected value not to be less than or equal:
   <green>1.7976931348623157e+308</>
@@ -621,7 +621,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() equal numbers: [5e-324, 5e-324] 1`] = `
-"<dim>expect(<red>received</><dim>).not.toBeGreaterThanOrEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeGreaterThanOrEqual(</><green>expected</><dim>)</>
 
 Expected value not to be greater than or equal:
   <green>5e-324</>
@@ -630,7 +630,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() equal numbers: [5e-324, 5e-324] 2`] = `
-"<dim>expect(<red>received</><dim>).not.toBeLessThanOrEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeLessThanOrEqual(</><green>expected</><dim>)</>
 
 Expected value not to be less than or equal:
   <green>5e-324</>
@@ -639,7 +639,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() equal numbers: [Infinity, Infinity] 1`] = `
-"<dim>expect(<red>received</><dim>).not.toBeGreaterThanOrEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeGreaterThanOrEqual(</><green>expected</><dim>)</>
 
 Expected value not to be greater than or equal:
   <green>Infinity</>
@@ -648,7 +648,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() equal numbers: [Infinity, Infinity] 2`] = `
-"<dim>expect(<red>received</><dim>).not.toBeLessThanOrEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeLessThanOrEqual(</><green>expected</><dim>)</>
 
 Expected value not to be less than or equal:
   <green>Infinity</>
@@ -657,7 +657,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [-Infinity, Infinity] 1`] = `
-"<dim>expect(<red>received</><dim>).toBeGreaterThan(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toBeGreaterThan(</><green>expected</><dim>)</>
 
 Expected value to be greater than:
   <green>Infinity</>
@@ -666,7 +666,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [-Infinity, Infinity] 2`] = `
-"<dim>expect(<red>received</><dim>).not.toBeLessThan(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeLessThan(</><green>expected</><dim>)</>
 
 Expected value not to be less than:
   <green>Infinity</>
@@ -675,7 +675,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [-Infinity, Infinity] 3`] = `
-"<dim>expect(<red>received</><dim>).not.toBeGreaterThan(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeGreaterThan(</><green>expected</><dim>)</>
 
 Expected value not to be greater than:
   <green>-Infinity</>
@@ -684,7 +684,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [-Infinity, Infinity] 4`] = `
-"<dim>expect(<red>received</><dim>).toBeLessThan(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toBeLessThan(</><green>expected</><dim>)</>
 
 Expected value to be less than:
   <green>-Infinity</>
@@ -693,7 +693,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [-Infinity, Infinity] 5`] = `
-"<dim>expect(<red>received</><dim>).toBeGreaterThanOrEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toBeGreaterThanOrEqual(</><green>expected</><dim>)</>
 
 Expected value to be greater than or equal:
   <green>Infinity</>
@@ -702,7 +702,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [-Infinity, Infinity] 6`] = `
-"<dim>expect(<red>received</><dim>).not.toBeLessThanOrEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeLessThanOrEqual(</><green>expected</><dim>)</>
 
 Expected value not to be less than or equal:
   <green>Infinity</>
@@ -711,7 +711,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [-Infinity, Infinity] 7`] = `
-"<dim>expect(<red>received</><dim>).not.toBeGreaterThanOrEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeGreaterThanOrEqual(</><green>expected</><dim>)</>
 
 Expected value not to be greater than or equal:
   <green>-Infinity</>
@@ -720,7 +720,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [-Infinity, Infinity] 8`] = `
-"<dim>expect(<red>received</><dim>).toBeLessThanOrEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toBeLessThanOrEqual(</><green>expected</><dim>)</>
 
 Expected value to be less than or equal:
   <green>-Infinity</>
@@ -729,7 +729,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [0.1, 0.2] 1`] = `
-"<dim>expect(<red>received</><dim>).toBeGreaterThan(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toBeGreaterThan(</><green>expected</><dim>)</>
 
 Expected value to be greater than:
   <green>0.2</>
@@ -738,7 +738,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [0.1, 0.2] 2`] = `
-"<dim>expect(<red>received</><dim>).not.toBeLessThan(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeLessThan(</><green>expected</><dim>)</>
 
 Expected value not to be less than:
   <green>0.2</>
@@ -747,7 +747,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [0.1, 0.2] 3`] = `
-"<dim>expect(<red>received</><dim>).not.toBeGreaterThan(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeGreaterThan(</><green>expected</><dim>)</>
 
 Expected value not to be greater than:
   <green>0.1</>
@@ -756,7 +756,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [0.1, 0.2] 4`] = `
-"<dim>expect(<red>received</><dim>).toBeLessThan(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toBeLessThan(</><green>expected</><dim>)</>
 
 Expected value to be less than:
   <green>0.1</>
@@ -765,7 +765,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [0.1, 0.2] 5`] = `
-"<dim>expect(<red>received</><dim>).toBeGreaterThanOrEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toBeGreaterThanOrEqual(</><green>expected</><dim>)</>
 
 Expected value to be greater than or equal:
   <green>0.2</>
@@ -774,7 +774,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [0.1, 0.2] 6`] = `
-"<dim>expect(<red>received</><dim>).not.toBeLessThanOrEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeLessThanOrEqual(</><green>expected</><dim>)</>
 
 Expected value not to be less than or equal:
   <green>0.2</>
@@ -783,7 +783,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [0.1, 0.2] 7`] = `
-"<dim>expect(<red>received</><dim>).not.toBeGreaterThanOrEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeGreaterThanOrEqual(</><green>expected</><dim>)</>
 
 Expected value not to be greater than or equal:
   <green>0.1</>
@@ -792,7 +792,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [0.1, 0.2] 8`] = `
-"<dim>expect(<red>received</><dim>).toBeLessThanOrEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toBeLessThanOrEqual(</><green>expected</><dim>)</>
 
 Expected value to be less than or equal:
   <green>0.1</>
@@ -801,7 +801,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [1, 2] 1`] = `
-"<dim>expect(<red>received</><dim>).toBeGreaterThan(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toBeGreaterThan(</><green>expected</><dim>)</>
 
 Expected value to be greater than:
   <green>2</>
@@ -810,7 +810,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [1, 2] 2`] = `
-"<dim>expect(<red>received</><dim>).not.toBeLessThan(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeLessThan(</><green>expected</><dim>)</>
 
 Expected value not to be less than:
   <green>2</>
@@ -819,7 +819,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [1, 2] 3`] = `
-"<dim>expect(<red>received</><dim>).not.toBeGreaterThan(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeGreaterThan(</><green>expected</><dim>)</>
 
 Expected value not to be greater than:
   <green>1</>
@@ -828,7 +828,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [1, 2] 4`] = `
-"<dim>expect(<red>received</><dim>).toBeLessThan(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toBeLessThan(</><green>expected</><dim>)</>
 
 Expected value to be less than:
   <green>1</>
@@ -837,7 +837,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [1, 2] 5`] = `
-"<dim>expect(<red>received</><dim>).toBeGreaterThanOrEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toBeGreaterThanOrEqual(</><green>expected</><dim>)</>
 
 Expected value to be greater than or equal:
   <green>2</>
@@ -846,7 +846,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [1, 2] 6`] = `
-"<dim>expect(<red>received</><dim>).not.toBeLessThanOrEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeLessThanOrEqual(</><green>expected</><dim>)</>
 
 Expected value not to be less than or equal:
   <green>2</>
@@ -855,7 +855,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [1, 2] 7`] = `
-"<dim>expect(<red>received</><dim>).not.toBeGreaterThanOrEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeGreaterThanOrEqual(</><green>expected</><dim>)</>
 
 Expected value not to be greater than or equal:
   <green>1</>
@@ -864,7 +864,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [1, 2] 8`] = `
-"<dim>expect(<red>received</><dim>).toBeLessThanOrEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toBeLessThanOrEqual(</><green>expected</><dim>)</>
 
 Expected value to be less than or equal:
   <green>1</>
@@ -873,7 +873,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [3, 7] 1`] = `
-"<dim>expect(<red>received</><dim>).toBeGreaterThan(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toBeGreaterThan(</><green>expected</><dim>)</>
 
 Expected value to be greater than:
   <green>7</>
@@ -882,7 +882,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [3, 7] 2`] = `
-"<dim>expect(<red>received</><dim>).not.toBeLessThan(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeLessThan(</><green>expected</><dim>)</>
 
 Expected value not to be less than:
   <green>7</>
@@ -891,7 +891,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [3, 7] 3`] = `
-"<dim>expect(<red>received</><dim>).not.toBeGreaterThan(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeGreaterThan(</><green>expected</><dim>)</>
 
 Expected value not to be greater than:
   <green>3</>
@@ -900,7 +900,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [3, 7] 4`] = `
-"<dim>expect(<red>received</><dim>).toBeLessThan(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toBeLessThan(</><green>expected</><dim>)</>
 
 Expected value to be less than:
   <green>3</>
@@ -909,7 +909,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [3, 7] 5`] = `
-"<dim>expect(<red>received</><dim>).toBeGreaterThanOrEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toBeGreaterThanOrEqual(</><green>expected</><dim>)</>
 
 Expected value to be greater than or equal:
   <green>7</>
@@ -918,7 +918,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [3, 7] 6`] = `
-"<dim>expect(<red>received</><dim>).not.toBeLessThanOrEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeLessThanOrEqual(</><green>expected</><dim>)</>
 
 Expected value not to be less than or equal:
   <green>7</>
@@ -927,7 +927,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [3, 7] 7`] = `
-"<dim>expect(<red>received</><dim>).not.toBeGreaterThanOrEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeGreaterThanOrEqual(</><green>expected</><dim>)</>
 
 Expected value not to be greater than or equal:
   <green>3</>
@@ -936,7 +936,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [3, 7] 8`] = `
-"<dim>expect(<red>received</><dim>).toBeLessThanOrEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toBeLessThanOrEqual(</><green>expected</><dim>)</>
 
 Expected value to be less than or equal:
   <green>3</>
@@ -945,7 +945,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [5e-324, 1.7976931348623157e+308] 1`] = `
-"<dim>expect(<red>received</><dim>).toBeGreaterThan(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toBeGreaterThan(</><green>expected</><dim>)</>
 
 Expected value to be greater than:
   <green>1.7976931348623157e+308</>
@@ -954,7 +954,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [5e-324, 1.7976931348623157e+308] 2`] = `
-"<dim>expect(<red>received</><dim>).not.toBeLessThan(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeLessThan(</><green>expected</><dim>)</>
 
 Expected value not to be less than:
   <green>1.7976931348623157e+308</>
@@ -963,7 +963,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [5e-324, 1.7976931348623157e+308] 3`] = `
-"<dim>expect(<red>received</><dim>).not.toBeGreaterThan(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeGreaterThan(</><green>expected</><dim>)</>
 
 Expected value not to be greater than:
   <green>5e-324</>
@@ -972,7 +972,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [5e-324, 1.7976931348623157e+308] 4`] = `
-"<dim>expect(<red>received</><dim>).toBeLessThan(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toBeLessThan(</><green>expected</><dim>)</>
 
 Expected value to be less than:
   <green>5e-324</>
@@ -981,7 +981,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [5e-324, 1.7976931348623157e+308] 5`] = `
-"<dim>expect(<red>received</><dim>).toBeGreaterThanOrEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toBeGreaterThanOrEqual(</><green>expected</><dim>)</>
 
 Expected value to be greater than or equal:
   <green>1.7976931348623157e+308</>
@@ -990,7 +990,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [5e-324, 1.7976931348623157e+308] 6`] = `
-"<dim>expect(<red>received</><dim>).not.toBeLessThanOrEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeLessThanOrEqual(</><green>expected</><dim>)</>
 
 Expected value not to be less than or equal:
   <green>1.7976931348623157e+308</>
@@ -999,7 +999,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [5e-324, 1.7976931348623157e+308] 7`] = `
-"<dim>expect(<red>received</><dim>).not.toBeGreaterThanOrEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeGreaterThanOrEqual(</><green>expected</><dim>)</>
 
 Expected value not to be greater than or equal:
   <green>5e-324</>
@@ -1008,7 +1008,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [5e-324, 1.7976931348623157e+308] 8`] = `
-"<dim>expect(<red>received</><dim>).toBeLessThanOrEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toBeLessThanOrEqual(</><green>expected</><dim>)</>
 
 Expected value to be less than or equal:
   <green>5e-324</>
@@ -1017,7 +1017,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [9, 18] 1`] = `
-"<dim>expect(<red>received</><dim>).toBeGreaterThan(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toBeGreaterThan(</><green>expected</><dim>)</>
 
 Expected value to be greater than:
   <green>18</>
@@ -1026,7 +1026,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [9, 18] 2`] = `
-"<dim>expect(<red>received</><dim>).not.toBeLessThan(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeLessThan(</><green>expected</><dim>)</>
 
 Expected value not to be less than:
   <green>18</>
@@ -1035,7 +1035,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [9, 18] 3`] = `
-"<dim>expect(<red>received</><dim>).not.toBeGreaterThan(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeGreaterThan(</><green>expected</><dim>)</>
 
 Expected value not to be greater than:
   <green>9</>
@@ -1044,7 +1044,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [9, 18] 4`] = `
-"<dim>expect(<red>received</><dim>).toBeLessThan(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toBeLessThan(</><green>expected</><dim>)</>
 
 Expected value to be less than:
   <green>9</>
@@ -1053,7 +1053,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [9, 18] 5`] = `
-"<dim>expect(<red>received</><dim>).toBeGreaterThanOrEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toBeGreaterThanOrEqual(</><green>expected</><dim>)</>
 
 Expected value to be greater than or equal:
   <green>18</>
@@ -1062,7 +1062,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [9, 18] 6`] = `
-"<dim>expect(<red>received</><dim>).not.toBeLessThanOrEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeLessThanOrEqual(</><green>expected</><dim>)</>
 
 Expected value not to be less than or equal:
   <green>18</>
@@ -1071,7 +1071,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [9, 18] 7`] = `
-"<dim>expect(<red>received</><dim>).not.toBeGreaterThanOrEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeGreaterThanOrEqual(</><green>expected</><dim>)</>
 
 Expected value not to be greater than or equal:
   <green>9</>
@@ -1080,7 +1080,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [9, 18] 8`] = `
-"<dim>expect(<red>received</><dim>).toBeLessThanOrEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toBeLessThanOrEqual(</><green>expected</><dim>)</>
 
 Expected value to be less than or equal:
   <green>9</>
@@ -1089,7 +1089,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [17, 34] 1`] = `
-"<dim>expect(<red>received</><dim>).toBeGreaterThan(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toBeGreaterThan(</><green>expected</><dim>)</>
 
 Expected value to be greater than:
   <green>34</>
@@ -1098,7 +1098,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [17, 34] 2`] = `
-"<dim>expect(<red>received</><dim>).not.toBeLessThan(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeLessThan(</><green>expected</><dim>)</>
 
 Expected value not to be less than:
   <green>34</>
@@ -1107,7 +1107,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [17, 34] 3`] = `
-"<dim>expect(<red>received</><dim>).not.toBeGreaterThan(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeGreaterThan(</><green>expected</><dim>)</>
 
 Expected value not to be greater than:
   <green>17</>
@@ -1116,7 +1116,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [17, 34] 4`] = `
-"<dim>expect(<red>received</><dim>).toBeLessThan(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toBeLessThan(</><green>expected</><dim>)</>
 
 Expected value to be less than:
   <green>17</>
@@ -1125,7 +1125,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [17, 34] 5`] = `
-"<dim>expect(<red>received</><dim>).toBeGreaterThanOrEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toBeGreaterThanOrEqual(</><green>expected</><dim>)</>
 
 Expected value to be greater than or equal:
   <green>34</>
@@ -1134,7 +1134,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [17, 34] 6`] = `
-"<dim>expect(<red>received</><dim>).not.toBeLessThanOrEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeLessThanOrEqual(</><green>expected</><dim>)</>
 
 Expected value not to be less than or equal:
   <green>34</>
@@ -1143,7 +1143,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [17, 34] 7`] = `
-"<dim>expect(<red>received</><dim>).not.toBeGreaterThanOrEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeGreaterThanOrEqual(</><green>expected</><dim>)</>
 
 Expected value not to be greater than or equal:
   <green>17</>
@@ -1152,7 +1152,7 @@ Received:
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [17, 34] 8`] = `
-"<dim>expect(<red>received</><dim>).toBeLessThanOrEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toBeLessThanOrEqual(</><green>expected</><dim>)</>
 
 Expected value to be less than or equal:
   <green>17</>
@@ -1161,7 +1161,7 @@ Received:
 `;
 
 exports[`.toBeInstanceOf() failing "a" and [Function String] 1`] = `
-"<dim>expect(<red>value</><dim>).toBeInstanceOf(<green>constructor</><dim>)
+"<dim>expect(</><red>value</><dim>).toBeInstanceOf(</><green>constructor</><dim>)</>
 
 Expected value to be an instance of:
   <green>\\"String\\"</>
@@ -1172,7 +1172,7 @@ Constructor:
 `;
 
 exports[`.toBeInstanceOf() failing {} and [Function A] 1`] = `
-"<dim>expect(<red>value</><dim>).toBeInstanceOf(<green>constructor</><dim>)
+"<dim>expect(</><red>value</><dim>).toBeInstanceOf(</><green>constructor</><dim>)</>
 
 Expected value to be an instance of:
   <green>\\"A\\"</>
@@ -1183,7 +1183,7 @@ Constructor:
 `;
 
 exports[`.toBeInstanceOf() failing {} and [Function B] 1`] = `
-"<dim>expect(<red>value</><dim>).toBeInstanceOf(<green>constructor</><dim>)
+"<dim>expect(</><red>value</><dim>).toBeInstanceOf(</><green>constructor</><dim>)</>
 
 Expected value to be an instance of:
   <green>\\"B\\"</>
@@ -1194,7 +1194,7 @@ Constructor:
 `;
 
 exports[`.toBeInstanceOf() failing 1 and [Function Number] 1`] = `
-"<dim>expect(<red>value</><dim>).toBeInstanceOf(<green>constructor</><dim>)
+"<dim>expect(</><red>value</><dim>).toBeInstanceOf(</><green>constructor</><dim>)</>
 
 Expected value to be an instance of:
   <green>\\"Number\\"</>
@@ -1205,7 +1205,7 @@ Constructor:
 `;
 
 exports[`.toBeInstanceOf() failing true and [Function Boolean] 1`] = `
-"<dim>expect(<red>value</><dim>).toBeInstanceOf(<green>constructor</><dim>)
+"<dim>expect(</><red>value</><dim>).toBeInstanceOf(</><green>constructor</><dim>)</>
 
 Expected value to be an instance of:
   <green>\\"Boolean\\"</>
@@ -1216,7 +1216,7 @@ Constructor:
 `;
 
 exports[`.toBeInstanceOf() passing [] and [Function Array] 1`] = `
-"<dim>expect(<red>value</><dim>).not.toBeInstanceOf(<green>constructor</><dim>)
+"<dim>expect(</><red>value</><dim>).not.toBeInstanceOf(</><green>constructor</><dim>)</>
 
 Expected value not to be an instance of:
   <green>\\"Array\\"</>
@@ -1226,7 +1226,7 @@ Received:
 `;
 
 exports[`.toBeInstanceOf() passing {} and [Function A] 1`] = `
-"<dim>expect(<red>value</><dim>).not.toBeInstanceOf(<green>constructor</><dim>)
+"<dim>expect(</><red>value</><dim>).not.toBeInstanceOf(</><green>constructor</><dim>)</>
 
 Expected value not to be an instance of:
   <green>\\"A\\"</>
@@ -1236,7 +1236,7 @@ Received:
 `;
 
 exports[`.toBeInstanceOf() passing Map {} and [Function Map] 1`] = `
-"<dim>expect(<red>value</><dim>).not.toBeInstanceOf(<green>constructor</><dim>)
+"<dim>expect(</><red>value</><dim>).not.toBeInstanceOf(</><green>constructor</><dim>)</>
 
 Expected value not to be an instance of:
   <green>\\"Map\\"</>
@@ -1246,406 +1246,406 @@ Received:
 `;
 
 exports[`.toBeInstanceOf() throws if constructor is not a function 1`] = `
-"<dim>expect(<red>value</><dim>)[.not].toBeInstanceOf(<green>constructor</><dim>)
+"<dim>expect(</><red>value</><dim>)[.not].toBeInstanceOf(</><green>constructor</><dim>)</>
 
 Expected constructor to be a function. Instead got:
   <green>\\"number\\"</>"
 `;
 
 exports[`.toBeNaN() {pass: true} expect(NaN).toBeNaN() 1`] = `
-"<dim>expect(<red>received</><dim>).not.toBeNaN(<dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeNaN(</><dim>)</>
 
 Expected value not to be NaN, instead received
   <red>NaN</>"
 `;
 
 exports[`.toBeNaN() {pass: true} expect(NaN).toBeNaN() 2`] = `
-"<dim>expect(<red>received</><dim>).not.toBeNaN(<dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeNaN(</><dim>)</>
 
 Expected value not to be NaN, instead received
   <red>NaN</>"
 `;
 
 exports[`.toBeNaN() {pass: true} expect(NaN).toBeNaN() 3`] = `
-"<dim>expect(<red>received</><dim>).not.toBeNaN(<dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeNaN(</><dim>)</>
 
 Expected value not to be NaN, instead received
   <red>NaN</>"
 `;
 
 exports[`.toBeNaN() {pass: true} expect(NaN).toBeNaN() 4`] = `
-"<dim>expect(<red>received</><dim>).not.toBeNaN(<dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeNaN(</><dim>)</>
 
 Expected value not to be NaN, instead received
   <red>NaN</>"
 `;
 
 exports[`.toBeNaN() throws 1`] = `
-"<dim>expect(<red>received</><dim>).toBeNaN(<dim>)
+"<dim>expect(</><red>received</><dim>).toBeNaN(</><dim>)</>
 
 Expected value to be NaN, instead received
   <red>1</>"
 `;
 
 exports[`.toBeNaN() throws 2`] = `
-"<dim>expect(<red>received</><dim>).toBeNaN(<dim>)
+"<dim>expect(</><red>received</><dim>).toBeNaN(</><dim>)</>
 
 Expected value to be NaN, instead received
   <red>\\"\\"</>"
 `;
 
 exports[`.toBeNaN() throws 3`] = `
-"<dim>expect(<red>received</><dim>).toBeNaN(<dim>)
+"<dim>expect(</><red>received</><dim>).toBeNaN(</><dim>)</>
 
 Expected value to be NaN, instead received
   <red>null</>"
 `;
 
 exports[`.toBeNaN() throws 4`] = `
-"<dim>expect(<red>received</><dim>).toBeNaN(<dim>)
+"<dim>expect(</><red>received</><dim>).toBeNaN(</><dim>)</>
 
 Expected value to be NaN, instead received
   <red>undefined</>"
 `;
 
 exports[`.toBeNaN() throws 5`] = `
-"<dim>expect(<red>received</><dim>).toBeNaN(<dim>)
+"<dim>expect(</><red>received</><dim>).toBeNaN(</><dim>)</>
 
 Expected value to be NaN, instead received
   <red>{}</>"
 `;
 
 exports[`.toBeNaN() throws 6`] = `
-"<dim>expect(<red>received</><dim>).toBeNaN(<dim>)
+"<dim>expect(</><red>received</><dim>).toBeNaN(</><dim>)</>
 
 Expected value to be NaN, instead received
   <red>[]</>"
 `;
 
 exports[`.toBeNaN() throws 7`] = `
-"<dim>expect(<red>received</><dim>).toBeNaN(<dim>)
+"<dim>expect(</><red>received</><dim>).toBeNaN(</><dim>)</>
 
 Expected value to be NaN, instead received
   <red>0.2</>"
 `;
 
 exports[`.toBeNaN() throws 8`] = `
-"<dim>expect(<red>received</><dim>).toBeNaN(<dim>)
+"<dim>expect(</><red>received</><dim>).toBeNaN(</><dim>)</>
 
 Expected value to be NaN, instead received
   <red>0</>"
 `;
 
 exports[`.toBeNaN() throws 9`] = `
-"<dim>expect(<red>received</><dim>).toBeNaN(<dim>)
+"<dim>expect(</><red>received</><dim>).toBeNaN(</><dim>)</>
 
 Expected value to be NaN, instead received
   <red>Infinity</>"
 `;
 
 exports[`.toBeNaN() throws 10`] = `
-"<dim>expect(<red>received</><dim>).toBeNaN(<dim>)
+"<dim>expect(</><red>received</><dim>).toBeNaN(</><dim>)</>
 
 Expected value to be NaN, instead received
   <red>-Infinity</>"
 `;
 
 exports[`.toBeNull() fails for '"a"' with .not 1`] = `
-"<dim>expect(<red>received</><dim>).toBeNull(<dim>)
+"<dim>expect(</><red>received</><dim>).toBeNull(</><dim>)</>
 
 Expected value to be null, instead received
   <red>\\"a\\"</>"
 `;
 
 exports[`.toBeNull() fails for '[]' with .not 1`] = `
-"<dim>expect(<red>received</><dim>).toBeNull(<dim>)
+"<dim>expect(</><red>received</><dim>).toBeNull(</><dim>)</>
 
 Expected value to be null, instead received
   <red>[]</>"
 `;
 
 exports[`.toBeNull() fails for '[Function anonymous]' with .not 1`] = `
-"<dim>expect(<red>received</><dim>).toBeNull(<dim>)
+"<dim>expect(</><red>received</><dim>).toBeNull(</><dim>)</>
 
 Expected value to be null, instead received
   <red>[Function anonymous]</>"
 `;
 
 exports[`.toBeNull() fails for '{}' with .not 1`] = `
-"<dim>expect(<red>received</><dim>).toBeNull(<dim>)
+"<dim>expect(</><red>received</><dim>).toBeNull(</><dim>)</>
 
 Expected value to be null, instead received
   <red>{}</>"
 `;
 
 exports[`.toBeNull() fails for '0.5' with .not 1`] = `
-"<dim>expect(<red>received</><dim>).toBeNull(<dim>)
+"<dim>expect(</><red>received</><dim>).toBeNull(</><dim>)</>
 
 Expected value to be null, instead received
   <red>0.5</>"
 `;
 
 exports[`.toBeNull() fails for '1' with .not 1`] = `
-"<dim>expect(<red>received</><dim>).toBeNull(<dim>)
+"<dim>expect(</><red>received</><dim>).toBeNull(</><dim>)</>
 
 Expected value to be null, instead received
   <red>1</>"
 `;
 
 exports[`.toBeNull() fails for 'Infinity' with .not 1`] = `
-"<dim>expect(<red>received</><dim>).toBeNull(<dim>)
+"<dim>expect(</><red>received</><dim>).toBeNull(</><dim>)</>
 
 Expected value to be null, instead received
   <red>Infinity</>"
 `;
 
 exports[`.toBeNull() fails for 'Map {}' with .not 1`] = `
-"<dim>expect(<red>received</><dim>).toBeNull(<dim>)
+"<dim>expect(</><red>received</><dim>).toBeNull(</><dim>)</>
 
 Expected value to be null, instead received
   <red>Map {}</>"
 `;
 
 exports[`.toBeNull() fails for 'true' with .not 1`] = `
-"<dim>expect(<red>received</><dim>).toBeNull(<dim>)
+"<dim>expect(</><red>received</><dim>).toBeNull(</><dim>)</>
 
 Expected value to be null, instead received
   <red>true</>"
 `;
 
 exports[`.toBeNull() pass for null 1`] = `
-"<dim>expect(<red>received</><dim>).not.toBeNull(<dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeNull(</><dim>)</>
 
 Expected value not to be null, instead received
   <red>null</>"
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() '""' is falsy 1`] = `
-"<dim>expect(<red>received</><dim>).toBeTruthy(<dim>)
+"<dim>expect(</><red>received</><dim>).toBeTruthy(</><dim>)</>
 
 Expected value to be truthy, instead received
   <red>\\"\\"</>"
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() '""' is falsy 2`] = `
-"<dim>expect(<red>received</><dim>).not.toBeFalsy(<dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeFalsy(</><dim>)</>
 
 Expected value not to be falsy, instead received
   <red>\\"\\"</>"
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() '"a"' is truthy 1`] = `
-"<dim>expect(<red>received</><dim>).not.toBeTruthy(<dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeTruthy(</><dim>)</>
 
 Expected value not to be truthy, instead received
   <red>\\"a\\"</>"
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() '"a"' is truthy 2`] = `
-"<dim>expect(<red>received</><dim>).toBeFalsy(<dim>)
+"<dim>expect(</><red>received</><dim>).toBeFalsy(</><dim>)</>
 
 Expected value to be falsy, instead received
   <red>\\"a\\"</>"
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() '[]' is truthy 1`] = `
-"<dim>expect(<red>received</><dim>).not.toBeTruthy(<dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeTruthy(</><dim>)</>
 
 Expected value not to be truthy, instead received
   <red>[]</>"
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() '[]' is truthy 2`] = `
-"<dim>expect(<red>received</><dim>).toBeFalsy(<dim>)
+"<dim>expect(</><red>received</><dim>).toBeFalsy(</><dim>)</>
 
 Expected value to be falsy, instead received
   <red>[]</>"
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() '[Function anonymous]' is truthy 1`] = `
-"<dim>expect(<red>received</><dim>).not.toBeTruthy(<dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeTruthy(</><dim>)</>
 
 Expected value not to be truthy, instead received
   <red>[Function anonymous]</>"
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() '[Function anonymous]' is truthy 2`] = `
-"<dim>expect(<red>received</><dim>).toBeFalsy(<dim>)
+"<dim>expect(</><red>received</><dim>).toBeFalsy(</><dim>)</>
 
 Expected value to be falsy, instead received
   <red>[Function anonymous]</>"
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() '{}' is truthy 1`] = `
-"<dim>expect(<red>received</><dim>).not.toBeTruthy(<dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeTruthy(</><dim>)</>
 
 Expected value not to be truthy, instead received
   <red>{}</>"
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() '{}' is truthy 2`] = `
-"<dim>expect(<red>received</><dim>).toBeFalsy(<dim>)
+"<dim>expect(</><red>received</><dim>).toBeFalsy(</><dim>)</>
 
 Expected value to be falsy, instead received
   <red>{}</>"
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() '0' is falsy 1`] = `
-"<dim>expect(<red>received</><dim>).toBeTruthy(<dim>)
+"<dim>expect(</><red>received</><dim>).toBeTruthy(</><dim>)</>
 
 Expected value to be truthy, instead received
   <red>0</>"
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() '0' is falsy 2`] = `
-"<dim>expect(<red>received</><dim>).not.toBeFalsy(<dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeFalsy(</><dim>)</>
 
 Expected value not to be falsy, instead received
   <red>0</>"
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() '0.5' is truthy 1`] = `
-"<dim>expect(<red>received</><dim>).not.toBeTruthy(<dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeTruthy(</><dim>)</>
 
 Expected value not to be truthy, instead received
   <red>0.5</>"
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() '0.5' is truthy 2`] = `
-"<dim>expect(<red>received</><dim>).toBeFalsy(<dim>)
+"<dim>expect(</><red>received</><dim>).toBeFalsy(</><dim>)</>
 
 Expected value to be falsy, instead received
   <red>0.5</>"
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() '1' is truthy 1`] = `
-"<dim>expect(<red>received</><dim>).not.toBeTruthy(<dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeTruthy(</><dim>)</>
 
 Expected value not to be truthy, instead received
   <red>1</>"
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() '1' is truthy 2`] = `
-"<dim>expect(<red>received</><dim>).toBeFalsy(<dim>)
+"<dim>expect(</><red>received</><dim>).toBeFalsy(</><dim>)</>
 
 Expected value to be falsy, instead received
   <red>1</>"
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() 'Infinity' is truthy 1`] = `
-"<dim>expect(<red>received</><dim>).not.toBeTruthy(<dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeTruthy(</><dim>)</>
 
 Expected value not to be truthy, instead received
   <red>Infinity</>"
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() 'Infinity' is truthy 2`] = `
-"<dim>expect(<red>received</><dim>).toBeFalsy(<dim>)
+"<dim>expect(</><red>received</><dim>).toBeFalsy(</><dim>)</>
 
 Expected value to be falsy, instead received
   <red>Infinity</>"
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() 'Map {}' is truthy 1`] = `
-"<dim>expect(<red>received</><dim>).not.toBeTruthy(<dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeTruthy(</><dim>)</>
 
 Expected value not to be truthy, instead received
   <red>Map {}</>"
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() 'Map {}' is truthy 2`] = `
-"<dim>expect(<red>received</><dim>).toBeFalsy(<dim>)
+"<dim>expect(</><red>received</><dim>).toBeFalsy(</><dim>)</>
 
 Expected value to be falsy, instead received
   <red>Map {}</>"
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() 'NaN' is falsy 1`] = `
-"<dim>expect(<red>received</><dim>).toBeTruthy(<dim>)
+"<dim>expect(</><red>received</><dim>).toBeTruthy(</><dim>)</>
 
 Expected value to be truthy, instead received
   <red>NaN</>"
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() 'NaN' is falsy 2`] = `
-"<dim>expect(<red>received</><dim>).not.toBeFalsy(<dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeFalsy(</><dim>)</>
 
 Expected value not to be falsy, instead received
   <red>NaN</>"
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() 'false' is falsy 1`] = `
-"<dim>expect(<red>received</><dim>).toBeTruthy(<dim>)
+"<dim>expect(</><red>received</><dim>).toBeTruthy(</><dim>)</>
 
 Expected value to be truthy, instead received
   <red>false</>"
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() 'false' is falsy 2`] = `
-"<dim>expect(<red>received</><dim>).not.toBeFalsy(<dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeFalsy(</><dim>)</>
 
 Expected value not to be falsy, instead received
   <red>false</>"
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() 'null' is falsy 1`] = `
-"<dim>expect(<red>received</><dim>).toBeTruthy(<dim>)
+"<dim>expect(</><red>received</><dim>).toBeTruthy(</><dim>)</>
 
 Expected value to be truthy, instead received
   <red>null</>"
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() 'null' is falsy 2`] = `
-"<dim>expect(<red>received</><dim>).not.toBeFalsy(<dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeFalsy(</><dim>)</>
 
 Expected value not to be falsy, instead received
   <red>null</>"
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() 'true' is truthy 1`] = `
-"<dim>expect(<red>received</><dim>).not.toBeTruthy(<dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeTruthy(</><dim>)</>
 
 Expected value not to be truthy, instead received
   <red>true</>"
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() 'true' is truthy 2`] = `
-"<dim>expect(<red>received</><dim>).toBeFalsy(<dim>)
+"<dim>expect(</><red>received</><dim>).toBeFalsy(</><dim>)</>
 
 Expected value to be falsy, instead received
   <red>true</>"
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() 'undefined' is falsy 1`] = `
-"<dim>expect(<red>received</><dim>).toBeTruthy(<dim>)
+"<dim>expect(</><red>received</><dim>).toBeTruthy(</><dim>)</>
 
 Expected value to be truthy, instead received
   <red>undefined</>"
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() 'undefined' is falsy 2`] = `
-"<dim>expect(<red>received</><dim>).not.toBeFalsy(<dim>)
+"<dim>expect(</><red>received</><dim>).not.toBeFalsy(</><dim>)</>
 
 Expected value not to be falsy, instead received
   <red>undefined</>"
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() does not accept arguments 1`] = `
-"<dim>expect(<red>received</><dim>)[.not].toBeTruthy(<dim>)
+"<dim>expect(</><red>received</><dim>)[.not].toBeTruthy(</><dim>)</>
 
 Matcher does not accept any arguments.
 Got: <green>null</>"
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() does not accept arguments 2`] = `
-"<dim>expect(<red>received</><dim>)[.not].toBeFalsy(<dim>)
+"<dim>expect(</><red>received</><dim>)[.not].toBeFalsy(</><dim>)</>
 
 Matcher does not accept any arguments.
 Got: <green>null</>"
 `;
 
 exports[`.toContain(), .toContainEqual() '"11112111"' contains '"2"' 1`] = `
-"<dim>expect(<red>string</><dim>).not.toContain(<green>value</><dim>)
+"<dim>expect(</><red>string</><dim>).not.toContain(</><green>value</><dim>)</>
 
 Expected string:
   <red>\\"11112111\\"</>
@@ -1655,7 +1655,7 @@ Not to contain value:
 `;
 
 exports[`.toContain(), .toContainEqual() '"abcdef"' contains '"abc"' 1`] = `
-"<dim>expect(<red>string</><dim>).not.toContain(<green>value</><dim>)
+"<dim>expect(</><red>string</><dim>).not.toContain(</><green>value</><dim>)</>
 
 Expected string:
   <red>\\"abcdef\\"</>
@@ -1665,7 +1665,7 @@ Not to contain value:
 `;
 
 exports[`.toContain(), .toContainEqual() '["a", "b", "c", "d"]' contains '"a"' 1`] = `
-"<dim>expect(<red>array</><dim>).not.toContain(<green>value</><dim>)
+"<dim>expect(</><red>array</><dim>).not.toContain(</><green>value</><dim>)</>
 
 Expected array:
   <red>[\\"a\\", \\"b\\", \\"c\\", \\"d\\"]</>
@@ -1675,7 +1675,7 @@ Not to contain value:
 `;
 
 exports[`.toContain(), .toContainEqual() '["a", "b", "c", "d"]' contains a value equal to '"a"' 1`] = `
-"<dim>expect(<red>array</><dim>).not.toContainEqual(<green>value</><dim>)
+"<dim>expect(</><red>array</><dim>).not.toContainEqual(</><green>value</><dim>)</>
 
 Expected array:
   <red>[\\"a\\", \\"b\\", \\"c\\", \\"d\\"]</>
@@ -1685,7 +1685,7 @@ Not to contain a value equal to:
 `;
 
 exports[`.toContain(), .toContainEqual() '[{"a": "b"}, {"a": "c"}]' contains a value equal to '{"a": "b"}' 1`] = `
-"<dim>expect(<red>array</><dim>).not.toContainEqual(<green>value</><dim>)
+"<dim>expect(</><red>array</><dim>).not.toContainEqual(</><green>value</><dim>)</>
 
 Expected array:
   <red>[{\\"a\\": \\"b\\"}, {\\"a\\": \\"c\\"}]</>
@@ -1695,7 +1695,7 @@ Not to contain a value equal to:
 `;
 
 exports[`.toContain(), .toContainEqual() '[{"a": "b"}, {"a": "c"}]' does not contain a value equal to'{"a": "d"}' 1`] = `
-"<dim>expect(<red>array</><dim>).toContainEqual(<green>value</><dim>)
+"<dim>expect(</><red>array</><dim>).toContainEqual(</><green>value</><dim>)</>
 
 Expected array:
   <red>[{\\"a\\": \\"b\\"}, {\\"a\\": \\"c\\"}]</>
@@ -1704,7 +1704,7 @@ To contain a value equal to:
 `;
 
 exports[`.toContain(), .toContainEqual() '[{}, []]' does not contain '[]' 1`] = `
-"<dim>expect(<red>array</><dim>).toContain(<green>value</><dim>)
+"<dim>expect(</><red>array</><dim>).toContain(</><green>value</><dim>)</>
 
 Expected array:
   <red>[{}, []]</>
@@ -1713,7 +1713,7 @@ To contain value:
 `;
 
 exports[`.toContain(), .toContainEqual() '[{}, []]' does not contain '{}' 1`] = `
-"<dim>expect(<red>array</><dim>).toContain(<green>value</><dim>)
+"<dim>expect(</><red>array</><dim>).toContain(</><green>value</><dim>)</>
 
 Expected array:
   <red>[{}, []]</>
@@ -1722,7 +1722,7 @@ To contain value:
 `;
 
 exports[`.toContain(), .toContainEqual() '[0, 1]' contains '1' 1`] = `
-"<dim>expect(<red>object</><dim>).not.toContain(<green>value</><dim>)
+"<dim>expect(</><red>object</><dim>).not.toContain(</><green>value</><dim>)</>
 
 Expected object:
   <red>[0, 1]</>
@@ -1732,7 +1732,7 @@ Not to contain value:
 `;
 
 exports[`.toContain(), .toContainEqual() '[0, 1]' contains a value equal to '1' 1`] = `
-"<dim>expect(<red>object</><dim>).not.toContainEqual(<green>value</><dim>)
+"<dim>expect(</><red>object</><dim>).not.toContainEqual(</><green>value</><dim>)</>
 
 Expected object:
   <red>[0, 1]</>
@@ -1742,7 +1742,7 @@ Not to contain a value equal to:
 `;
 
 exports[`.toContain(), .toContainEqual() '[1, 2, 3, 4]' contains '1' 1`] = `
-"<dim>expect(<red>array</><dim>).not.toContain(<green>value</><dim>)
+"<dim>expect(</><red>array</><dim>).not.toContain(</><green>value</><dim>)</>
 
 Expected array:
   <red>[1, 2, 3, 4]</>
@@ -1752,7 +1752,7 @@ Not to contain value:
 `;
 
 exports[`.toContain(), .toContainEqual() '[1, 2, 3, 4]' contains a value equal to '1' 1`] = `
-"<dim>expect(<red>array</><dim>).not.toContainEqual(<green>value</><dim>)
+"<dim>expect(</><red>array</><dim>).not.toContainEqual(</><green>value</><dim>)</>
 
 Expected array:
   <red>[1, 2, 3, 4]</>
@@ -1762,7 +1762,7 @@ Not to contain a value equal to:
 `;
 
 exports[`.toContain(), .toContainEqual() '[1, 2, 3]' does not contain '4' 1`] = `
-"<dim>expect(<red>array</><dim>).toContain(<green>value</><dim>)
+"<dim>expect(</><red>array</><dim>).toContain(</><green>value</><dim>)</>
 
 Expected array:
   <red>[1, 2, 3]</>
@@ -1771,7 +1771,7 @@ To contain value:
 `;
 
 exports[`.toContain(), .toContainEqual() '[Symbol(a)]' contains 'Symbol(a)' 1`] = `
-"<dim>expect(<red>array</><dim>).not.toContain(<green>value</><dim>)
+"<dim>expect(</><red>array</><dim>).not.toContain(</><green>value</><dim>)</>
 
 Expected array:
   <red>[Symbol(a)]</>
@@ -1781,7 +1781,7 @@ Not to contain value:
 `;
 
 exports[`.toContain(), .toContainEqual() '[Symbol(a)]' contains a value equal to 'Symbol(a)' 1`] = `
-"<dim>expect(<red>array</><dim>).not.toContainEqual(<green>value</><dim>)
+"<dim>expect(</><red>array</><dim>).not.toContainEqual(</><green>value</><dim>)</>
 
 Expected array:
   <red>[Symbol(a)]</>
@@ -1791,7 +1791,7 @@ Not to contain a value equal to:
 `;
 
 exports[`.toContain(), .toContainEqual() '[null, undefined]' does not contain '1' 1`] = `
-"<dim>expect(<red>array</><dim>).toContain(<green>value</><dim>)
+"<dim>expect(</><red>array</><dim>).toContain(</><green>value</><dim>)</>
 
 Expected array:
   <red>[null, undefined]</>
@@ -1800,7 +1800,7 @@ To contain value:
 `;
 
 exports[`.toContain(), .toContainEqual() '[undefined, null]' contains 'null' 1`] = `
-"<dim>expect(<red>array</><dim>).not.toContain(<green>value</><dim>)
+"<dim>expect(</><red>array</><dim>).not.toContain(</><green>value</><dim>)</>
 
 Expected array:
   <red>[undefined, null]</>
@@ -1810,7 +1810,7 @@ Not to contain value:
 `;
 
 exports[`.toContain(), .toContainEqual() '[undefined, null]' contains 'undefined' 1`] = `
-"<dim>expect(<red>array</><dim>).not.toContain(<green>value</><dim>)
+"<dim>expect(</><red>array</><dim>).not.toContain(</><green>value</><dim>)</>
 
 Expected array:
   <red>[undefined, null]</>
@@ -1820,7 +1820,7 @@ Not to contain value:
 `;
 
 exports[`.toContain(), .toContainEqual() '[undefined, null]' contains a value equal to 'null' 1`] = `
-"<dim>expect(<red>array</><dim>).not.toContainEqual(<green>value</><dim>)
+"<dim>expect(</><red>array</><dim>).not.toContainEqual(</><green>value</><dim>)</>
 
 Expected array:
   <red>[undefined, null]</>
@@ -1830,7 +1830,7 @@ Not to contain a value equal to:
 `;
 
 exports[`.toContain(), .toContainEqual() '[undefined, null]' contains a value equal to 'undefined' 1`] = `
-"<dim>expect(<red>array</><dim>).not.toContainEqual(<green>value</><dim>)
+"<dim>expect(</><red>array</><dim>).not.toContainEqual(</><green>value</><dim>)</>
 
 Expected array:
   <red>[undefined, null]</>
@@ -1840,7 +1840,7 @@ Not to contain a value equal to:
 `;
 
 exports[`.toContain(), .toContainEqual() 'Set {"abc", "def"}' contains '"abc"' 1`] = `
-"<dim>expect(<red>set</><dim>).not.toContain(<green>value</><dim>)
+"<dim>expect(</><red>set</><dim>).not.toContain(</><green>value</><dim>)</>
 
 Expected set:
   <red>Set {\\"abc\\", \\"def\\"}</>
@@ -1850,7 +1850,7 @@ Not to contain value:
 `;
 
 exports[`.toContain(), .toContainEqual() 'Set {1, 2, 3, 4}' contains a value equal to '1' 1`] = `
-"<dim>expect(<red>set</><dim>).not.toContainEqual(<green>value</><dim>)
+"<dim>expect(</><red>set</><dim>).not.toContainEqual(</><green>value</><dim>)</>
 
 Expected set:
   <red>Set {1, 2, 3, 4}</>
@@ -1860,21 +1860,21 @@ Not to contain a value equal to:
 `;
 
 exports[`.toContain(), .toContainEqual() error cases 1`] = `
-"<dim>expect(<red>collection</><dim>)[.not].toContainEqual(<green>value</><dim>)
+"<dim>expect(</><red>collection</><dim>)[.not].toContainEqual(</><green>value</><dim>)</>
 
 Expected <red>collection</> to be an array-like structure.
 Received: <red>null</>"
 `;
 
 exports[`.toContain(), .toContainEqual() error cases for toContainEqual 1`] = `
-"<dim>expect(<red>collection</><dim>)[.not].toContainEqual(<green>value</><dim>)
+"<dim>expect(</><red>collection</><dim>)[.not].toContainEqual(</><green>value</><dim>)</>
 
 Expected <red>collection</> to be an array-like structure.
 Received: <red>null</>"
 `;
 
 exports[`.toEqual() {pass: false} expect("Alice").not.toEqual({"asymmetricMatch": [Function asymmetricMatch]}) 1`] = `
-"<dim>expect(<red>received</><dim>).not.toEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toEqual(</><green>expected</><dim>)</>
 
 Expected value to not equal:
   <green>{\\"asymmetricMatch\\": [Function asymmetricMatch]}</>
@@ -1883,7 +1883,7 @@ Received:
 `;
 
 exports[`.toEqual() {pass: false} expect("Eve").toEqual({"asymmetricMatch": [Function asymmetricMatch]}) 1`] = `
-"<dim>expect(<red>received</><dim>).toEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toEqual(</><green>expected</><dim>)</>
 
 Expected value to equal:
   <green>{\\"asymmetricMatch\\": [Function asymmetricMatch]}</>
@@ -1892,7 +1892,7 @@ Received:
 `;
 
 exports[`.toEqual() {pass: false} expect("abc").not.toEqual("abc") 1`] = `
-"<dim>expect(<red>received</><dim>).not.toEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toEqual(</><green>expected</><dim>)</>
 
 Expected value to not equal:
   <green>\\"abc\\"</>
@@ -1901,7 +1901,7 @@ Received:
 `;
 
 exports[`.toEqual() {pass: false} expect("abcd").not.toEqual(StringContaining "bc") 1`] = `
-"<dim>expect(<red>received</><dim>).not.toEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toEqual(</><green>expected</><dim>)</>
 
 Expected value to not equal:
   <green>StringContaining \\"bc\\"</>
@@ -1910,7 +1910,7 @@ Received:
 `;
 
 exports[`.toEqual() {pass: false} expect("abcd").not.toEqual(StringMatching /bc/) 1`] = `
-"<dim>expect(<red>received</><dim>).not.toEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toEqual(</><green>expected</><dim>)</>
 
 Expected value to not equal:
   <green>StringMatching /bc/</>
@@ -1919,7 +1919,7 @@ Received:
 `;
 
 exports[`.toEqual() {pass: false} expect("abd").toEqual(StringContaining "bc") 1`] = `
-"<dim>expect(<red>received</><dim>).toEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toEqual(</><green>expected</><dim>)</>
 
 Expected value to equal:
   <green>StringContaining \\"bc\\"</>
@@ -1928,7 +1928,7 @@ Received:
 `;
 
 exports[`.toEqual() {pass: false} expect("abd").toEqual(StringMatching /bc/i) 1`] = `
-"<dim>expect(<red>received</><dim>).toEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toEqual(</><green>expected</><dim>)</>
 
 Expected value to equal:
   <green>StringMatching /bc/i</>
@@ -1937,7 +1937,7 @@ Received:
 `;
 
 exports[`.toEqual() {pass: false} expect("banana").toEqual("apple") 1`] = `
-"<dim>expect(<red>received</><dim>).toEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toEqual(</><green>expected</><dim>)</>
 
 Expected value to equal:
   <green>\\"apple\\"</>
@@ -1946,7 +1946,7 @@ Received:
 `;
 
 exports[`.toEqual() {pass: false} expect([1, 2, 3]).not.toEqual(ArrayContaining [2, 3]) 1`] = `
-"<dim>expect(<red>received</><dim>).not.toEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toEqual(</><green>expected</><dim>)</>
 
 Expected value to not equal:
   <green>ArrayContaining [2, 3]</>
@@ -1955,7 +1955,7 @@ Received:
 `;
 
 exports[`.toEqual() {pass: false} expect([1, 2]).not.toEqual([1, 2]) 1`] = `
-"<dim>expect(<red>received</><dim>).not.toEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toEqual(</><green>expected</><dim>)</>
 
 Expected value to not equal:
   <green>[1, 2]</>
@@ -1964,7 +1964,7 @@ Received:
 `;
 
 exports[`.toEqual() {pass: false} expect([1, 2]).toEqual([2, 1]) 1`] = `
-"<dim>expect(<red>received</><dim>).toEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toEqual(</><green>expected</><dim>)</>
 
 Expected value to equal:
   <green>[2, 1]</>
@@ -1976,15 +1976,15 @@ Difference:
 <green>- Expected</>
 <red>+ Received</>
 
-<dim>  Array [
+<dim>  Array [</>
 <red>+   1,</>
-<dim>    2,
+<dim>    2,</>
 <green>-   1,</>
-<dim>  ]"
+<dim>  ]</>"
 `;
 
 exports[`.toEqual() {pass: false} expect([1, 3]).toEqual(ArrayContaining [1, 2]) 1`] = `
-"<dim>expect(<red>received</><dim>).toEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toEqual(</><green>expected</><dim>)</>
 
 Expected value to equal:
   <green>ArrayContaining [1, 2]</>
@@ -1998,14 +1998,14 @@ Difference:
 
 <green>- ArrayContaining [</>
 <red>+ Array [</>
-<dim>    1,
+<dim>    1,</>
 <green>-   2,</>
 <red>+   3,</>
-<dim>  ]"
+<dim>  ]</>"
 `;
 
 exports[`.toEqual() {pass: false} expect([1]).not.toEqual([1]) 1`] = `
-"<dim>expect(<red>received</><dim>).not.toEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toEqual(</><green>expected</><dim>)</>
 
 Expected value to not equal:
   <green>[1]</>
@@ -2014,7 +2014,7 @@ Received:
 `;
 
 exports[`.toEqual() {pass: false} expect([1]).toEqual([2]) 1`] = `
-"<dim>expect(<red>received</><dim>).toEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toEqual(</><green>expected</><dim>)</>
 
 Expected value to equal:
   <green>[2]</>
@@ -2026,14 +2026,14 @@ Difference:
 <green>- Expected</>
 <red>+ Received</>
 
-<dim>  Array [
+<dim>  Array [</>
 <green>-   2,</>
 <red>+   1,</>
-<dim>  ]"
+<dim>  ]</>"
 `;
 
 exports[`.toEqual() {pass: false} expect([Function anonymous]).not.toEqual(Any<Function>) 1`] = `
-"<dim>expect(<red>received</><dim>).not.toEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toEqual(</><green>expected</><dim>)</>
 
 Expected value to not equal:
   <green>Any<Function></>
@@ -2042,7 +2042,7 @@ Received:
 `;
 
 exports[`.toEqual() {pass: false} expect({"a": 1, "b": [Function b], "c": true}).not.toEqual({"a": 1, "b": Any<Function>, "c": Anything}) 1`] = `
-"<dim>expect(<red>received</><dim>).not.toEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toEqual(</><green>expected</><dim>)</>
 
 Expected value to not equal:
   <green>{\\"a\\": 1, \\"b\\": Any<Function>, \\"c\\": Anything}</>
@@ -2051,7 +2051,7 @@ Received:
 `;
 
 exports[`.toEqual() {pass: false} expect({"a": 1, "b": 2}).not.toEqual(ObjectContaining {"a": 1}) 1`] = `
-"<dim>expect(<red>received</><dim>).not.toEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toEqual(</><green>expected</><dim>)</>
 
 Expected value to not equal:
   <green>ObjectContaining {\\"a\\": 1}</>
@@ -2060,7 +2060,7 @@ Received:
 `;
 
 exports[`.toEqual() {pass: false} expect({"a": 1, "b": 2}).toEqual(ObjectContaining {"a": 2}) 1`] = `
-"<dim>expect(<red>received</><dim>).toEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toEqual(</><green>expected</><dim>)</>
 
 Expected value to equal:
   <green>ObjectContaining {\\"a\\": 2}</>
@@ -2077,11 +2077,11 @@ Difference:
 <red>+ Object {</>
 <red>+   \\"a\\": 1,</>
 <red>+   \\"b\\": 2,</>
-<dim>  }"
+<dim>  }</>"
 `;
 
 exports[`.toEqual() {pass: false} expect({"a": 5}).toEqual({"b": 6}) 1`] = `
-"<dim>expect(<red>received</><dim>).toEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toEqual(</><green>expected</><dim>)</>
 
 Expected value to equal:
   <green>{\\"b\\": 6}</>
@@ -2093,14 +2093,14 @@ Difference:
 <green>- Expected</>
 <red>+ Received</>
 
-<dim>  Object {
+<dim>  Object {</>
 <green>-   \\"b\\": 6,</>
 <red>+   \\"a\\": 5,</>
-<dim>  }"
+<dim>  }</>"
 `;
 
 exports[`.toEqual() {pass: false} expect({"a": 99}).not.toEqual({"a": 99}) 1`] = `
-"<dim>expect(<red>received</><dim>).not.toEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toEqual(</><green>expected</><dim>)</>
 
 Expected value to not equal:
   <green>{\\"a\\": 99}</>
@@ -2109,7 +2109,7 @@ Received:
 `;
 
 exports[`.toEqual() {pass: false} expect({}).not.toEqual({}) 1`] = `
-"<dim>expect(<red>received</><dim>).not.toEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toEqual(</><green>expected</><dim>)</>
 
 Expected value to not equal:
   <green>{}</>
@@ -2118,7 +2118,7 @@ Received:
 `;
 
 exports[`.toEqual() {pass: false} expect(0).toEqual(-0) 1`] = `
-"<dim>expect(<red>received</><dim>).toEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toEqual(</><green>expected</><dim>)</>
 
 Expected value to equal:
   <green>-0</>
@@ -2127,11 +2127,11 @@ Received:
 
 Difference:
 
-<dim>Compared values have no visual difference."
+<dim>Compared values have no visual difference.</>"
 `;
 
 exports[`.toEqual() {pass: false} expect(1).not.toEqual(1) 1`] = `
-"<dim>expect(<red>received</><dim>).not.toEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toEqual(</><green>expected</><dim>)</>
 
 Expected value to not equal:
   <green>1</>
@@ -2140,7 +2140,7 @@ Received:
 `;
 
 exports[`.toEqual() {pass: false} expect(1).toEqual(2) 1`] = `
-"<dim>expect(<red>received</><dim>).toEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toEqual(</><green>expected</><dim>)</>
 
 Expected value to equal:
   <green>2</>
@@ -2149,7 +2149,7 @@ Received:
 `;
 
 exports[`.toEqual() {pass: false} expect(1).toEqual(ArrayContaining [1, 2]) 1`] = `
-"<dim>expect(<red>received</><dim>).toEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toEqual(</><green>expected</><dim>)</>
 
 Expected value to equal:
   <green>ArrayContaining [1, 2]</>
@@ -2162,7 +2162,7 @@ Difference:
 `;
 
 exports[`.toEqual() {pass: false} expect(Map {"a" => 0}).toEqual(Map {"b" => 0}) 1`] = `
-"<dim>expect(<red>received</><dim>).toEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toEqual(</><green>expected</><dim>)</>
 
 Expected value to equal:
   <green>Map {\\"b\\" => 0}</>
@@ -2174,14 +2174,14 @@ Difference:
 <green>- Expected</>
 <red>+ Received</>
 
-<dim>  Map {
+<dim>  Map {</>
 <green>-   \\"b\\" => 0,</>
 <red>+   \\"a\\" => 0,</>
-<dim>  }"
+<dim>  }</>"
 `;
 
 exports[`.toEqual() {pass: false} expect(Map {"v" => 1}).toEqual(Map {"v" => 2}) 1`] = `
-"<dim>expect(<red>received</><dim>).toEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toEqual(</><green>expected</><dim>)</>
 
 Expected value to equal:
   <green>Map {\\"v\\" => 2}</>
@@ -2193,14 +2193,14 @@ Difference:
 <green>- Expected</>
 <red>+ Received</>
 
-<dim>  Map {
+<dim>  Map {</>
 <green>-   \\"v\\" => 2,</>
 <red>+   \\"v\\" => 1,</>
-<dim>  }"
+<dim>  }</>"
 `;
 
 exports[`.toEqual() {pass: false} expect(Map {}).not.toEqual(Map {}) 1`] = `
-"<dim>expect(<red>received</><dim>).not.toEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toEqual(</><green>expected</><dim>)</>
 
 Expected value to not equal:
   <green>Map {}</>
@@ -2209,7 +2209,7 @@ Received:
 `;
 
 exports[`.toEqual() {pass: false} expect(Map {}).toEqual(Set {}) 1`] = `
-"<dim>expect(<red>received</><dim>).toEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toEqual(</><green>expected</><dim>)</>
 
 Expected value to equal:
   <green>Set {}</>
@@ -2222,7 +2222,7 @@ Difference:
 `;
 
 exports[`.toEqual() {pass: false} expect(Map {1 => "one", 2 => "two"}).not.toEqual(Map {1 => "one", 2 => "two"}) 1`] = `
-"<dim>expect(<red>received</><dim>).not.toEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toEqual(</><green>expected</><dim>)</>
 
 Expected value to not equal:
   <green>Map {1 => \\"one\\", 2 => \\"two\\"}</>
@@ -2231,7 +2231,7 @@ Received:
 `;
 
 exports[`.toEqual() {pass: false} expect(Map {1 => "one", 2 => "two"}).not.toEqual(Map {2 => "two", 1 => "one"}) 1`] = `
-"<dim>expect(<red>received</><dim>).not.toEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toEqual(</><green>expected</><dim>)</>
 
 Expected value to not equal:
   <green>Map {2 => \\"two\\", 1 => \\"one\\"}</>
@@ -2240,7 +2240,7 @@ Received:
 `;
 
 exports[`.toEqual() {pass: false} expect(Map {1 => "one", 2 => "two"}).toEqual(Map {1 => "one"}) 1`] = `
-"<dim>expect(<red>received</><dim>).toEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toEqual(</><green>expected</><dim>)</>
 
 Expected value to equal:
   <green>Map {1 => \\"one\\"}</>
@@ -2252,14 +2252,14 @@ Difference:
 <green>- Expected</>
 <red>+ Received</>
 
-<dim>  Map {
-<dim>    1 => \\"one\\",
+<dim>  Map {</>
+<dim>    1 => \\"one\\",</>
 <red>+   2 => \\"two\\",</>
-<dim>  }"
+<dim>  }</>"
 `;
 
 exports[`.toEqual() {pass: false} expect(Set {}).not.toEqual(Set {}) 1`] = `
-"<dim>expect(<red>received</><dim>).not.toEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toEqual(</><green>expected</><dim>)</>
 
 Expected value to not equal:
   <green>Set {}</>
@@ -2268,7 +2268,7 @@ Received:
 `;
 
 exports[`.toEqual() {pass: false} expect(Set {1, 2}).not.toEqual(Set {1, 2}) 1`] = `
-"<dim>expect(<red>received</><dim>).not.toEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toEqual(</><green>expected</><dim>)</>
 
 Expected value to not equal:
   <green>Set {1, 2}</>
@@ -2277,7 +2277,7 @@ Received:
 `;
 
 exports[`.toEqual() {pass: false} expect(Set {1, 2}).not.toEqual(Set {2, 1}) 1`] = `
-"<dim>expect(<red>received</><dim>).not.toEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toEqual(</><green>expected</><dim>)</>
 
 Expected value to not equal:
   <green>Set {2, 1}</>
@@ -2286,7 +2286,7 @@ Received:
 `;
 
 exports[`.toEqual() {pass: false} expect(Set {1, 2}).toEqual(Set {}) 1`] = `
-"<dim>expect(<red>received</><dim>).toEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toEqual(</><green>expected</><dim>)</>
 
 Expected value to equal:
   <green>Set {}</>
@@ -2306,7 +2306,7 @@ Difference:
 `;
 
 exports[`.toEqual() {pass: false} expect(Set {1, 2}).toEqual(Set {1, 2, 3}) 1`] = `
-"<dim>expect(<red>received</><dim>).toEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toEqual(</><green>expected</><dim>)</>
 
 Expected value to equal:
   <green>Set {1, 2, 3}</>
@@ -2318,15 +2318,15 @@ Difference:
 <green>- Expected</>
 <red>+ Received</>
 
-<dim>  Set {
-<dim>    1,
-<dim>    2,
+<dim>  Set {</>
+<dim>    1,</>
+<dim>    2,</>
 <green>-   3,</>
-<dim>  }"
+<dim>  }</>"
 `;
 
 exports[`.toEqual() {pass: false} expect(false).toEqual(ObjectContaining {"a": 2}) 1`] = `
-"<dim>expect(<red>received</><dim>).toEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toEqual(</><green>expected</><dim>)</>
 
 Expected value to equal:
   <green>ObjectContaining {\\"a\\": 2}</>
@@ -2339,7 +2339,7 @@ Difference:
 `;
 
 exports[`.toEqual() {pass: false} expect(null).toEqual(undefined) 1`] = `
-"<dim>expect(<red>received</><dim>).toEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toEqual(</><green>expected</><dim>)</>
 
 Expected value to equal:
   <green>undefined</>
@@ -2352,7 +2352,7 @@ Difference:
 `;
 
 exports[`.toEqual() {pass: false} expect(true).not.toEqual(Anything) 1`] = `
-"<dim>expect(<red>received</><dim>).not.toEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toEqual(</><green>expected</><dim>)</>
 
 Expected value to not equal:
   <green>Anything</>
@@ -2361,7 +2361,7 @@ Received:
 `;
 
 exports[`.toEqual() {pass: false} expect(true).not.toEqual(true) 1`] = `
-"<dim>expect(<red>received</><dim>).not.toEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toEqual(</><green>expected</><dim>)</>
 
 Expected value to not equal:
   <green>true</>
@@ -2370,7 +2370,7 @@ Received:
 `;
 
 exports[`.toEqual() {pass: false} expect(true).toEqual(false) 1`] = `
-"<dim>expect(<red>received</><dim>).toEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toEqual(</><green>expected</><dim>)</>
 
 Expected value to equal:
   <green>false</>
@@ -2379,7 +2379,7 @@ Received:
 `;
 
 exports[`.toEqual() {pass: false} expect(undefined).toEqual(Any<Function>) 1`] = `
-"<dim>expect(<red>received</><dim>).toEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toEqual(</><green>expected</><dim>)</>
 
 Expected value to equal:
   <green>Any<Function></>
@@ -2392,7 +2392,7 @@ Difference:
 `;
 
 exports[`.toEqual() {pass: false} expect(undefined).toEqual(Anything) 1`] = `
-"<dim>expect(<red>received</><dim>).toEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toEqual(</><green>expected</><dim>)</>
 
 Expected value to equal:
   <green>Anything</>
@@ -2401,7 +2401,7 @@ Received:
 `;
 
 exports[`.toHaveLength {pass: false} expect("").toHaveLength(1) 1`] = `
-"<dim>expect(<red>received</><dim>).toHaveLength(<green>length</><dim>)
+"<dim>expect(</><red>received</><dim>).toHaveLength(</><green>length</><dim>)</>
 
 Expected value to have length:
   <green>1</>
@@ -2412,7 +2412,7 @@ received.length:
 `;
 
 exports[`.toHaveLength {pass: false} expect("abc").toHaveLength(66) 1`] = `
-"<dim>expect(<red>received</><dim>).toHaveLength(<green>length</><dim>)
+"<dim>expect(</><red>received</><dim>).toHaveLength(</><green>length</><dim>)</>
 
 Expected value to have length:
   <green>66</>
@@ -2423,7 +2423,7 @@ received.length:
 `;
 
 exports[`.toHaveLength {pass: false} expect(["a", "b"]).toHaveLength(99) 1`] = `
-"<dim>expect(<red>received</><dim>).toHaveLength(<green>length</><dim>)
+"<dim>expect(</><red>received</><dim>).toHaveLength(</><green>length</><dim>)</>
 
 Expected value to have length:
   <green>99</>
@@ -2434,7 +2434,7 @@ received.length:
 `;
 
 exports[`.toHaveLength {pass: false} expect([]).toHaveLength(1) 1`] = `
-"<dim>expect(<red>received</><dim>).toHaveLength(<green>length</><dim>)
+"<dim>expect(</><red>received</><dim>).toHaveLength(</><green>length</><dim>)</>
 
 Expected value to have length:
   <green>1</>
@@ -2445,7 +2445,7 @@ received.length:
 `;
 
 exports[`.toHaveLength {pass: false} expect([1, 2]).toHaveLength(3) 1`] = `
-"<dim>expect(<red>received</><dim>).toHaveLength(<green>length</><dim>)
+"<dim>expect(</><red>received</><dim>).toHaveLength(</><green>length</><dim>)</>
 
 Expected value to have length:
   <green>3</>
@@ -2456,7 +2456,7 @@ received.length:
 `;
 
 exports[`.toHaveLength {pass: true} expect("").toHaveLength(0) 1`] = `
-"<dim>expect(<red>received</><dim>).not.toHaveLength(<green>length</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toHaveLength(</><green>length</><dim>)</>
 
 Expected value to not have length:
   <green>0</>
@@ -2467,7 +2467,7 @@ received.length:
 `;
 
 exports[`.toHaveLength {pass: true} expect("abc").toHaveLength(3) 1`] = `
-"<dim>expect(<red>received</><dim>).not.toHaveLength(<green>length</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toHaveLength(</><green>length</><dim>)</>
 
 Expected value to not have length:
   <green>3</>
@@ -2478,7 +2478,7 @@ received.length:
 `;
 
 exports[`.toHaveLength {pass: true} expect(["a", "b"]).toHaveLength(2) 1`] = `
-"<dim>expect(<red>received</><dim>).not.toHaveLength(<green>length</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toHaveLength(</><green>length</><dim>)</>
 
 Expected value to not have length:
   <green>2</>
@@ -2489,7 +2489,7 @@ received.length:
 `;
 
 exports[`.toHaveLength {pass: true} expect([]).toHaveLength(0) 1`] = `
-"<dim>expect(<red>received</><dim>).not.toHaveLength(<green>length</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toHaveLength(</><green>length</><dim>)</>
 
 Expected value to not have length:
   <green>0</>
@@ -2500,7 +2500,7 @@ received.length:
 `;
 
 exports[`.toHaveLength {pass: true} expect([1, 2]).toHaveLength(2) 1`] = `
-"<dim>expect(<red>received</><dim>).not.toHaveLength(<green>length</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toHaveLength(</><green>length</><dim>)</>
 
 Expected value to not have length:
   <green>2</>
@@ -2511,7 +2511,7 @@ received.length:
 `;
 
 exports[`.toHaveLength error cases 1`] = `
-"<dim>expect(<red>received</><dim>)[.not].toHaveLength(<green>length</><dim>)
+"<dim>expect(</><red>received</><dim>)[.not].toHaveLength(</><green>length</><dim>)</>
 
 Expected value to have a 'length' property that is a number. Received:
   <red>{\\"a\\": 9}</>
@@ -2520,7 +2520,7 @@ received.length:
 `;
 
 exports[`.toHaveLength error cases 2`] = `
-"<dim>expect(<red>received</><dim>)[.not].toHaveLength(<green>length</><dim>)
+"<dim>expect(</><red>received</><dim>)[.not].toHaveLength(</><green>length</><dim>)</>
 
 Expected value to have a 'length' property that is a number. Received:
   <red>0</>
@@ -2528,7 +2528,7 @@ Expected value to have a 'length' property that is a number. Received:
 `;
 
 exports[`.toHaveLength error cases 3`] = `
-"<dim>expect(<red>received</><dim>)[.not].toHaveLength(<green>length</><dim>)
+"<dim>expect(</><red>received</><dim>)[.not].toHaveLength(</><green>length</><dim>)</>
 
 Expected value to have a 'length' property that is a number. Received:
   <red>undefined</>
@@ -2536,42 +2536,42 @@ Expected value to have a 'length' property that is a number. Received:
 `;
 
 exports[`.toHaveProperty() {error} expect({"a": {"b": {}}}).toHaveProperty('1') 1`] = `
-"<dim>expect(<red>object</><dim>)[.not].toHaveProperty(<green>path</><dim>)
+"<dim>expect(</><red>object</><dim>)[.not].toHaveProperty(</><green>path</><dim>)</>
 
 Expected <green>path</> to be a string. Received:
   number: <red>1</>"
 `;
 
 exports[`.toHaveProperty() {error} expect({"a": {"b": {}}}).toHaveProperty('null') 1`] = `
-"<dim>expect(<red>object</><dim>)[.not].toHaveProperty(<green>path</><dim>)
+"<dim>expect(</><red>object</><dim>)[.not].toHaveProperty(</><green>path</><dim>)</>
 
 Expected <green>path</> to be a string. Received:
   null: <red>null</>"
 `;
 
 exports[`.toHaveProperty() {error} expect({"a": {"b": {}}}).toHaveProperty('undefined') 1`] = `
-"<dim>expect(<red>object</><dim>)[.not].toHaveProperty(<green>path</><dim>)
+"<dim>expect(</><red>object</><dim>)[.not].toHaveProperty(</><green>path</><dim>)</>
 
 Expected <green>path</> to be a string. Received:
   undefined: <red>undefined</>"
 `;
 
 exports[`.toHaveProperty() {error} expect(null).toHaveProperty('a.b') 1`] = `
-"<dim>expect(<red>object</><dim>)[.not].toHaveProperty(<green>path</><dim>)
+"<dim>expect(</><red>object</><dim>)[.not].toHaveProperty(</><green>path</><dim>)</>
 
 Expected <red>object</> to be an object. Received:
   null: <red>null</>"
 `;
 
 exports[`.toHaveProperty() {error} expect(undefined).toHaveProperty('a') 1`] = `
-"<dim>expect(<red>object</><dim>)[.not].toHaveProperty(<green>path</><dim>)
+"<dim>expect(</><red>object</><dim>)[.not].toHaveProperty(</><green>path</><dim>)</>
 
 Expected <red>object</> to be an object. Received:
   undefined: <red>undefined</>"
 `;
 
 exports[`.toHaveProperty() {pass: false} expect("abc").toHaveProperty('a.b.c') 1`] = `
-"<dim>expect(<red>object</><dim>).toHaveProperty(<green>path</><dim>)
+"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</><dim>)</>
 
 Expected the object:
   <red>\\"abc\\"</>
@@ -2581,7 +2581,7 @@ To have a nested property:
 `;
 
 exports[`.toHaveProperty() {pass: false} expect("abc").toHaveProperty('a.b.c', {"a": 5}) 1`] = `
-"<dim>expect(<red>object</><dim>).toHaveProperty(<green>path</>, <green>value</><dim>)
+"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</>, <green>value</><dim>)</>
 
 Expected the object:
   <red>\\"abc\\"</>
@@ -2593,7 +2593,7 @@ With a value of:
 `;
 
 exports[`.toHaveProperty() {pass: false} expect({"a": {"b": {"c": {"d": 1}}}}).toHaveProperty('a.b.c.d', 2) 1`] = `
-"<dim>expect(<red>object</><dim>).toHaveProperty(<green>path</>, <green>value</><dim>)
+"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</>, <green>value</><dim>)</>
 
 Expected the object:
   <red>{\\"a\\": {\\"b\\": {\\"c\\": {\\"d\\": 1}}}}</>
@@ -2606,7 +2606,7 @@ Received:
 `;
 
 exports[`.toHaveProperty() {pass: false} expect({"a": {"b": {"c": {"d": 1}}}}).toHaveProperty('a.b.ttt.d', 1) 1`] = `
-"<dim>expect(<red>object</><dim>).toHaveProperty(<green>path</>, <green>value</><dim>)
+"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</>, <green>value</><dim>)</>
 
 Expected the object:
   <red>{\\"a\\": {\\"b\\": {\\"c\\": {\\"d\\": 1}}}}</>
@@ -2619,7 +2619,7 @@ Received:
 `;
 
 exports[`.toHaveProperty() {pass: false} expect({"a": {"b": {"c": {}}}}).toHaveProperty('a.b.c.d') 1`] = `
-"<dim>expect(<red>object</><dim>).toHaveProperty(<green>path</><dim>)
+"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</><dim>)</>
 
 Expected the object:
   <red>{\\"a\\": {\\"b\\": {\\"c\\": {}}}}</>
@@ -2630,7 +2630,7 @@ Received:
 `;
 
 exports[`.toHaveProperty() {pass: false} expect({"a": {"b": {"c": {}}}}).toHaveProperty('a.b.c.d', 1) 1`] = `
-"<dim>expect(<red>object</><dim>).toHaveProperty(<green>path</>, <green>value</><dim>)
+"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</>, <green>value</><dim>)</>
 
 Expected the object:
   <red>{\\"a\\": {\\"b\\": {\\"c\\": {}}}}</>
@@ -2643,7 +2643,7 @@ Received:
 `;
 
 exports[`.toHaveProperty() {pass: false} expect({"a": {"b": {"c": 5}}}).toHaveProperty('a.b', {"c": 4}) 1`] = `
-"<dim>expect(<red>object</><dim>).toHaveProperty(<green>path</>, <green>value</><dim>)
+"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</>, <green>value</><dim>)</>
 
 Expected the object:
   <red>{\\"a\\": {\\"b\\": {\\"c\\": 5}}}</>
@@ -2659,14 +2659,14 @@ Difference:
 <green>- Expected</>
 <red>+ Received</>
 
-<dim>  Object {
+<dim>  Object {</>
 <green>-   \\"c\\": 4,</>
 <red>+   \\"c\\": 5,</>
-<dim>  }"
+<dim>  }</>"
 `;
 
 exports[`.toHaveProperty() {pass: false} expect({"a": {"b": 3}}).toHaveProperty('a.b', undefined) 1`] = `
-"<dim>expect(<red>object</><dim>).toHaveProperty(<green>path</>, <green>value</><dim>)
+"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</>, <green>value</><dim>)</>
 
 Expected the object:
   <red>{\\"a\\": {\\"b\\": 3}}</>
@@ -2683,7 +2683,7 @@ Difference:
 `;
 
 exports[`.toHaveProperty() {pass: false} expect({"a": 1}).toHaveProperty('a.b.c.d') 1`] = `
-"<dim>expect(<red>object</><dim>).toHaveProperty(<green>path</><dim>)
+"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</><dim>)</>
 
 Expected the object:
   <red>{\\"a\\": 1}</>
@@ -2694,7 +2694,7 @@ Received:
 `;
 
 exports[`.toHaveProperty() {pass: false} expect({"a": 1}).toHaveProperty('a.b.c.d', 5) 1`] = `
-"<dim>expect(<red>object</><dim>).toHaveProperty(<green>path</>, <green>value</><dim>)
+"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</>, <green>value</><dim>)</>
 
 Expected the object:
   <red>{\\"a\\": 1}</>
@@ -2707,7 +2707,7 @@ Received:
 `;
 
 exports[`.toHaveProperty() {pass: false} expect({}).toHaveProperty('a') 1`] = `
-"<dim>expect(<red>object</><dim>).toHaveProperty(<green>path</><dim>)
+"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</><dim>)</>
 
 Expected the object:
   <red>{}</>
@@ -2717,7 +2717,7 @@ To have a nested property:
 `;
 
 exports[`.toHaveProperty() {pass: false} expect({}).toHaveProperty('a', "test") 1`] = `
-"<dim>expect(<red>object</><dim>).toHaveProperty(<green>path</>, <green>value</><dim>)
+"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</>, <green>value</><dim>)</>
 
 Expected the object:
   <red>{}</>
@@ -2729,7 +2729,7 @@ With a value of:
 `;
 
 exports[`.toHaveProperty() {pass: false} expect(1).toHaveProperty('a.b.c') 1`] = `
-"<dim>expect(<red>object</><dim>).toHaveProperty(<green>path</><dim>)
+"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</><dim>)</>
 
 Expected the object:
   <red>1</>
@@ -2739,7 +2739,7 @@ To have a nested property:
 `;
 
 exports[`.toHaveProperty() {pass: false} expect(1).toHaveProperty('a.b.c', "test") 1`] = `
-"<dim>expect(<red>object</><dim>).toHaveProperty(<green>path</>, <green>value</><dim>)
+"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</>, <green>value</><dim>)</>
 
 Expected the object:
   <red>1</>
@@ -2751,7 +2751,7 @@ With a value of:
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({"a": {"b": {"c": {"d": 1}}}}).toHaveProperty('a.b.c.d')' 1`] = `
-"<dim>expect(<red>object</><dim>).not.toHaveProperty(<green>path</><dim>)
+"<dim>expect(</><red>object</><dim>).not.toHaveProperty(</><green>path</><dim>)</>
 
 Expected the object:
   <red>{\\"a\\": {\\"b\\": {\\"c\\": {\\"d\\": 1}}}}</>
@@ -2761,7 +2761,7 @@ Not to have a nested property:
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({"a": {"b": {"c": {"d": 1}}}}).toHaveProperty('a.b.c.d', 1) 1`] = `
-"<dim>expect(<red>object</><dim>).not.toHaveProperty(<green>path</>, <green>value</><dim>)
+"<dim>expect(</><red>object</><dim>).not.toHaveProperty(</><green>path</>, <green>value</><dim>)</>
 
 Expected the object:
   <red>{\\"a\\": {\\"b\\": {\\"c\\": {\\"d\\": 1}}}}</>
@@ -2773,7 +2773,7 @@ With a value of:
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({"a": {"b": {"c": 5}}}).toHaveProperty('a.b', {"c": 5}) 1`] = `
-"<dim>expect(<red>object</><dim>).not.toHaveProperty(<green>path</>, <green>value</><dim>)
+"<dim>expect(</><red>object</><dim>).not.toHaveProperty(</><green>path</>, <green>value</><dim>)</>
 
 Expected the object:
   <red>{\\"a\\": {\\"b\\": {\\"c\\": 5}}}</>
@@ -2785,7 +2785,7 @@ With a value of:
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({"a": {"b": undefined}}).toHaveProperty('a.b')' 1`] = `
-"<dim>expect(<red>object</><dim>).not.toHaveProperty(<green>path</><dim>)
+"<dim>expect(</><red>object</><dim>).not.toHaveProperty(</><green>path</><dim>)</>
 
 Expected the object:
   <red>{\\"a\\": {\\"b\\": undefined}}</>
@@ -2795,7 +2795,7 @@ Not to have a nested property:
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({"a": {"b": undefined}}).toHaveProperty('a.b', undefined) 1`] = `
-"<dim>expect(<red>object</><dim>).not.toHaveProperty(<green>path</>, <green>value</><dim>)
+"<dim>expect(</><red>object</><dim>).not.toHaveProperty(</><green>path</>, <green>value</><dim>)</>
 
 Expected the object:
   <red>{\\"a\\": {\\"b\\": undefined}}</>
@@ -2807,7 +2807,7 @@ With a value of:
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({"a": 0}).toHaveProperty('a')' 1`] = `
-"<dim>expect(<red>object</><dim>).not.toHaveProperty(<green>path</><dim>)
+"<dim>expect(</><red>object</><dim>).not.toHaveProperty(</><green>path</><dim>)</>
 
 Expected the object:
   <red>{\\"a\\": 0}</>
@@ -2817,7 +2817,7 @@ Not to have a nested property:
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({"a": 0}).toHaveProperty('a', 0) 1`] = `
-"<dim>expect(<red>object</><dim>).not.toHaveProperty(<green>path</>, <green>value</><dim>)
+"<dim>expect(</><red>object</><dim>).not.toHaveProperty(</><green>path</>, <green>value</><dim>)</>
 
 Expected the object:
   <red>{\\"a\\": 0}</>
@@ -2829,7 +2829,7 @@ With a value of:
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({"property": 1}).toHaveProperty('property', 1) 1`] = `
-"<dim>expect(<red>object</><dim>).not.toHaveProperty(<green>path</>, <green>value</><dim>)
+"<dim>expect(</><red>object</><dim>).not.toHaveProperty(</><green>path</>, <green>value</><dim>)</>
 
 Expected the object:
   <red>{\\"property\\": 1}</>
@@ -2841,7 +2841,7 @@ With a value of:
 `;
 
 exports[`.toMatch() {pass: true} expect(Foo bar).toMatch(/^foo/i) 1`] = `
-"<dim>expect(<red>received</><dim>).not.toMatch(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toMatch(</><green>expected</><dim>)</>
 
 Expected value not to match:
   <green>/^foo/i</>
@@ -2850,7 +2850,7 @@ Received:
 `;
 
 exports[`.toMatch() {pass: true} expect(foo).toMatch(foo) 1`] = `
-"<dim>expect(<red>received</><dim>).not.toMatch(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toMatch(</><green>expected</><dim>)</>
 
 Expected value not to match:
   <green>\\"foo\\"</>
@@ -2859,7 +2859,7 @@ Received:
 `;
 
 exports[`.toMatch() throws if non String actual value passed: [/foo/i, "foo"] 1`] = `
-"<dim>expect(<red>string</><dim>)[.not].toMatch(<green>expected</><dim>)
+"<dim>expect(</><red>string</><dim>)[.not].toMatch(</><green>expected</><dim>)</>
 
 <red>string</> value must be a string.
 Received:
@@ -2867,7 +2867,7 @@ Received:
 `;
 
 exports[`.toMatch() throws if non String actual value passed: [[], "foo"] 1`] = `
-"<dim>expect(<red>string</><dim>)[.not].toMatch(<green>expected</><dim>)
+"<dim>expect(</><red>string</><dim>)[.not].toMatch(</><green>expected</><dim>)</>
 
 <red>string</> value must be a string.
 Received:
@@ -2875,7 +2875,7 @@ Received:
 `;
 
 exports[`.toMatch() throws if non String actual value passed: [[Function anonymous], "foo"] 1`] = `
-"<dim>expect(<red>string</><dim>)[.not].toMatch(<green>expected</><dim>)
+"<dim>expect(</><red>string</><dim>)[.not].toMatch(</><green>expected</><dim>)</>
 
 <red>string</> value must be a string.
 Received:
@@ -2883,7 +2883,7 @@ Received:
 `;
 
 exports[`.toMatch() throws if non String actual value passed: [{}, "foo"] 1`] = `
-"<dim>expect(<red>string</><dim>)[.not].toMatch(<green>expected</><dim>)
+"<dim>expect(</><red>string</><dim>)[.not].toMatch(</><green>expected</><dim>)</>
 
 <red>string</> value must be a string.
 Received:
@@ -2891,7 +2891,7 @@ Received:
 `;
 
 exports[`.toMatch() throws if non String actual value passed: [1, "foo"] 1`] = `
-"<dim>expect(<red>string</><dim>)[.not].toMatch(<green>expected</><dim>)
+"<dim>expect(</><red>string</><dim>)[.not].toMatch(</><green>expected</><dim>)</>
 
 <red>string</> value must be a string.
 Received:
@@ -2899,7 +2899,7 @@ Received:
 `;
 
 exports[`.toMatch() throws if non String actual value passed: [true, "foo"] 1`] = `
-"<dim>expect(<red>string</><dim>)[.not].toMatch(<green>expected</><dim>)
+"<dim>expect(</><red>string</><dim>)[.not].toMatch(</><green>expected</><dim>)</>
 
 <red>string</> value must be a string.
 Received:
@@ -2907,14 +2907,14 @@ Received:
 `;
 
 exports[`.toMatch() throws if non String actual value passed: [undefined, "foo"] 1`] = `
-"<dim>expect(<red>string</><dim>)[.not].toMatch(<green>expected</><dim>)
+"<dim>expect(</><red>string</><dim>)[.not].toMatch(</><green>expected</><dim>)</>
 
 <red>string</> value must be a string.
 Received: <red>undefined</>"
 `;
 
 exports[`.toMatch() throws if non String/RegExp expected value passed: ["foo", []] 1`] = `
-"<dim>expect(<red>string</><dim>)[.not].toMatch(<green>expected</><dim>)
+"<dim>expect(</><red>string</><dim>)[.not].toMatch(</><green>expected</><dim>)</>
 
 <green>expected</> value must be a string or a regular expression.
 Expected:
@@ -2922,7 +2922,7 @@ Expected:
 `;
 
 exports[`.toMatch() throws if non String/RegExp expected value passed: ["foo", [Function anonymous]] 1`] = `
-"<dim>expect(<red>string</><dim>)[.not].toMatch(<green>expected</><dim>)
+"<dim>expect(</><red>string</><dim>)[.not].toMatch(</><green>expected</><dim>)</>
 
 <green>expected</> value must be a string or a regular expression.
 Expected:
@@ -2930,7 +2930,7 @@ Expected:
 `;
 
 exports[`.toMatch() throws if non String/RegExp expected value passed: ["foo", {}] 1`] = `
-"<dim>expect(<red>string</><dim>)[.not].toMatch(<green>expected</><dim>)
+"<dim>expect(</><red>string</><dim>)[.not].toMatch(</><green>expected</><dim>)</>
 
 <green>expected</> value must be a string or a regular expression.
 Expected:
@@ -2938,7 +2938,7 @@ Expected:
 `;
 
 exports[`.toMatch() throws if non String/RegExp expected value passed: ["foo", 1] 1`] = `
-"<dim>expect(<red>string</><dim>)[.not].toMatch(<green>expected</><dim>)
+"<dim>expect(</><red>string</><dim>)[.not].toMatch(</><green>expected</><dim>)</>
 
 <green>expected</> value must be a string or a regular expression.
 Expected:
@@ -2946,7 +2946,7 @@ Expected:
 `;
 
 exports[`.toMatch() throws if non String/RegExp expected value passed: ["foo", true] 1`] = `
-"<dim>expect(<red>string</><dim>)[.not].toMatch(<green>expected</><dim>)
+"<dim>expect(</><red>string</><dim>)[.not].toMatch(</><green>expected</><dim>)</>
 
 <green>expected</> value must be a string or a regular expression.
 Expected:
@@ -2954,14 +2954,14 @@ Expected:
 `;
 
 exports[`.toMatch() throws if non String/RegExp expected value passed: ["foo", undefined] 1`] = `
-"<dim>expect(<red>string</><dim>)[.not].toMatch(<green>expected</><dim>)
+"<dim>expect(</><red>string</><dim>)[.not].toMatch(</><green>expected</><dim>)</>
 
 <green>expected</> value must be a string or a regular expression.
 Expected: <green>undefined</>"
 `;
 
 exports[`.toMatch() throws: [bar, /foo/] 1`] = `
-"<dim>expect(<red>received</><dim>).toMatch(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toMatch(</><green>expected</><dim>)</>
 
 Expected value to match:
   <green>/foo/</>
@@ -2970,7 +2970,7 @@ Received:
 `;
 
 exports[`.toMatch() throws: [bar, foo] 1`] = `
-"<dim>expect(<red>received</><dim>).toMatch(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toMatch(</><green>expected</><dim>)</>
 
 Expected value to match:
   <green>\\"foo\\"</>
@@ -2979,7 +2979,7 @@ Received:
 `;
 
 exports[`toMatchObject() {pass: false} expect([0]).toMatchObject([-0]) 1`] = `
-"<dim>expect(<red>received</><dim>).toMatchObject(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toMatchObject(</><green>expected</><dim>)</>
 
 Expected value to match object:
   <green>[-0]</>
@@ -2989,14 +2989,14 @@ Difference:
 <green>- Expected</>
 <red>+ Received</>
 
-<dim>  Array [
+<dim>  Array [</>
 <green>-   -0,</>
 <red>+   0,</>
-<dim>  ]"
+<dim>  ]</>"
 `;
 
 exports[`toMatchObject() {pass: false} expect([1, 2, 3]).toMatchObject([1, 2, 2]) 1`] = `
-"<dim>expect(<red>received</><dim>).toMatchObject(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toMatchObject(</><green>expected</><dim>)</>
 
 Expected value to match object:
   <green>[1, 2, 2]</>
@@ -3006,16 +3006,16 @@ Difference:
 <green>- Expected</>
 <red>+ Received</>
 
-<dim>  Array [
-<dim>    1,
-<dim>    2,
+<dim>  Array [</>
+<dim>    1,</>
+<dim>    2,</>
 <green>-   2,</>
 <red>+   3,</>
-<dim>  ]"
+<dim>  ]</>"
 `;
 
 exports[`toMatchObject() {pass: false} expect([1, 2, 3]).toMatchObject([2, 3, 1]) 1`] = `
-"<dim>expect(<red>received</><dim>).toMatchObject(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toMatchObject(</><green>expected</><dim>)</>
 
 Expected value to match object:
   <green>[2, 3, 1]</>
@@ -3025,16 +3025,16 @@ Difference:
 <green>- Expected</>
 <red>+ Received</>
 
-<dim>  Array [
+<dim>  Array [</>
 <red>+   1,</>
-<dim>    2,
-<dim>    3,
+<dim>    2,</>
+<dim>    3,</>
 <green>-   1,</>
-<dim>  ]"
+<dim>  ]</>"
 `;
 
 exports[`toMatchObject() {pass: false} expect([1, 2]).toMatchObject([1, 3]) 1`] = `
-"<dim>expect(<red>received</><dim>).toMatchObject(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toMatchObject(</><green>expected</><dim>)</>
 
 Expected value to match object:
   <green>[1, 3]</>
@@ -3044,15 +3044,15 @@ Difference:
 <green>- Expected</>
 <red>+ Received</>
 
-<dim>  Array [
-<dim>    1,
+<dim>  Array [</>
+<dim>    1,</>
 <green>-   3,</>
 <red>+   2,</>
-<dim>  ]"
+<dim>  ]</>"
 `;
 
 exports[`toMatchObject() {pass: false} expect([Error: foo]).toMatchObject([Error: bar]) 1`] = `
-"<dim>expect(<red>received</><dim>).toMatchObject(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toMatchObject(</><green>expected</><dim>)</>
 
 Expected value to match object:
   <green>[Error: bar]</>
@@ -3067,7 +3067,7 @@ Difference:
 `;
 
 exports[`toMatchObject() {pass: false} expect({"a": "a", "c": "d"}).toMatchObject({"a": Any<Number>}) 1`] = `
-"<dim>expect(<red>received</><dim>).toMatchObject(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toMatchObject(</><green>expected</><dim>)</>
 
 Expected value to match object:
   <green>{\\"a\\": Any<Number>}</>
@@ -3077,14 +3077,14 @@ Difference:
 <green>- Expected</>
 <red>+ Received</>
 
-<dim>  Object {
+<dim>  Object {</>
 <green>-   \\"a\\": Any<Number>,</>
 <red>+   \\"a\\": \\"a\\",</>
-<dim>  }"
+<dim>  }</>"
 `;
 
 exports[`toMatchObject() {pass: false} expect({"a": "b", "c": "d"}).toMatchObject({"a": "b!", "c": "d"}) 1`] = `
-"<dim>expect(<red>received</><dim>).toMatchObject(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toMatchObject(</><green>expected</><dim>)</>
 
 Expected value to match object:
   <green>{\\"a\\": \\"b!\\", \\"c\\": \\"d\\"}</>
@@ -3094,15 +3094,15 @@ Difference:
 <green>- Expected</>
 <red>+ Received</>
 
-<dim>  Object {
+<dim>  Object {</>
 <green>-   \\"a\\": \\"b!\\",</>
 <red>+   \\"a\\": \\"b\\",</>
-<dim>    \\"c\\": \\"d\\",
-<dim>  }"
+<dim>    \\"c\\": \\"d\\",</>
+<dim>  }</>"
 `;
 
 exports[`toMatchObject() {pass: false} expect({"a": "b", "c": "d"}).toMatchObject({"e": "b"}) 1`] = `
-"<dim>expect(<red>received</><dim>).toMatchObject(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toMatchObject(</><green>expected</><dim>)</>
 
 Expected value to match object:
   <green>{\\"e\\": \\"b\\"}</>
@@ -3112,15 +3112,15 @@ Difference:
 <green>- Expected</>
 <red>+ Received</>
 
-<dim>  Object {
+<dim>  Object {</>
 <green>-   \\"e\\": \\"b\\",</>
 <red>+   \\"a\\": \\"b\\",</>
 <red>+   \\"c\\": \\"d\\",</>
-<dim>  }"
+<dim>  }</>"
 `;
 
 exports[`toMatchObject() {pass: false} expect({"a": "b", "t": {"x": {"r": "r"}, "z": "z"}}).toMatchObject({"a": "b", "t": {"z": [3]}}) 1`] = `
-"<dim>expect(<red>received</><dim>).toMatchObject(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toMatchObject(</><green>expected</><dim>)</>
 
 Expected value to match object:
   <green>{\\"a\\": \\"b\\", \\"t\\": {\\"z\\": [3]}}</>
@@ -3130,19 +3130,19 @@ Difference:
 <green>- Expected</>
 <red>+ Received</>
 
-<dim>  Object {
-<dim>    \\"a\\": \\"b\\",
-<dim>    \\"t\\": Object {
+<dim>  Object {</>
+<dim>    \\"a\\": \\"b\\",</>
+<dim>    \\"t\\": Object {</>
 <green>-     \\"z\\": Array [</>
 <green>-       3,</>
 <green>-     ],</>
 <red>+     \\"z\\": \\"z\\",</>
-<dim>    },
-<dim>  }"
+<dim>    },</>
+<dim>  }</>"
 `;
 
 exports[`toMatchObject() {pass: false} expect({"a": "b", "t": {"x": {"r": "r"}, "z": "z"}}).toMatchObject({"t": {"l": {"r": "r"}}}) 1`] = `
-"<dim>expect(<red>received</><dim>).toMatchObject(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toMatchObject(</><green>expected</><dim>)</>
 
 Expected value to match object:
   <green>{\\"t\\": {\\"l\\": {\\"r\\": \\"r\\"}}}</>
@@ -3152,19 +3152,19 @@ Difference:
 <green>- Expected</>
 <red>+ Received</>
 
-<dim>  Object {
-<dim>    \\"t\\": Object {
+<dim>  Object {</>
+<dim>    \\"t\\": Object {</>
 <green>-     \\"l\\": Object {</>
 <red>+     \\"x\\": Object {</>
-<dim>        \\"r\\": \\"r\\",
-<dim>      },
+<dim>        \\"r\\": \\"r\\",</>
+<dim>      },</>
 <red>+     \\"z\\": \\"z\\",</>
-<dim>    },
-<dim>  }"
+<dim>    },</>
+<dim>  }</>"
 `;
 
 exports[`toMatchObject() {pass: false} expect({"a": [{"a": "a", "b": "b"}]}).toMatchObject({"a": [{"a": "c"}]}) 1`] = `
-"<dim>expect(<red>received</><dim>).toMatchObject(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toMatchObject(</><green>expected</><dim>)</>
 
 Expected value to match object:
   <green>{\\"a\\": [{\\"a\\": \\"c\\"}]}</>
@@ -3174,18 +3174,18 @@ Difference:
 <green>- Expected</>
 <red>+ Received</>
 
-<dim>  Object {
-<dim>    \\"a\\": Array [
-<dim>      Object {
+<dim>  Object {</>
+<dim>    \\"a\\": Array [</>
+<dim>      Object {</>
 <green>-       \\"a\\": \\"c\\",</>
 <red>+       \\"a\\": \\"a\\",</>
-<dim>      },
-<dim>    ],
-<dim>  }"
+<dim>      },</>
+<dim>    ],</>
+<dim>  }</>"
 `;
 
 exports[`toMatchObject() {pass: false} expect({"a": [3, 4, "v"], "b": "b"}).toMatchObject({"a": ["v"]}) 1`] = `
-"<dim>expect(<red>received</><dim>).toMatchObject(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toMatchObject(</><green>expected</><dim>)</>
 
 Expected value to match object:
   <green>{\\"a\\": [\\"v\\"]}</>
@@ -3195,17 +3195,17 @@ Difference:
 <green>- Expected</>
 <red>+ Received</>
 
-<dim>  Object {
-<dim>    \\"a\\": Array [
+<dim>  Object {</>
+<dim>    \\"a\\": Array [</>
 <red>+     3,</>
 <red>+     4,</>
-<dim>      \\"v\\",
-<dim>    ],
-<dim>  }"
+<dim>      \\"v\\",</>
+<dim>    ],</>
+<dim>  }</>"
 `;
 
 exports[`toMatchObject() {pass: false} expect({"a": [3, 4, 5], "b": "b"}).toMatchObject({"a": [3, 4, 5, 6]}) 1`] = `
-"<dim>expect(<red>received</><dim>).toMatchObject(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toMatchObject(</><green>expected</><dim>)</>
 
 Expected value to match object:
   <green>{\\"a\\": [3, 4, 5, 6]}</>
@@ -3215,18 +3215,18 @@ Difference:
 <green>- Expected</>
 <red>+ Received</>
 
-<dim>  Object {
-<dim>    \\"a\\": Array [
-<dim>      3,
-<dim>      4,
-<dim>      5,
+<dim>  Object {</>
+<dim>    \\"a\\": Array [</>
+<dim>      3,</>
+<dim>      4,</>
+<dim>      5,</>
 <green>-     6,</>
-<dim>    ],
-<dim>  }"
+<dim>    ],</>
+<dim>  }</>"
 `;
 
 exports[`toMatchObject() {pass: false} expect({"a": [3, 4, 5], "b": "b"}).toMatchObject({"a": [3, 4]}) 1`] = `
-"<dim>expect(<red>received</><dim>).toMatchObject(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toMatchObject(</><green>expected</><dim>)</>
 
 Expected value to match object:
   <green>{\\"a\\": [3, 4]}</>
@@ -3236,17 +3236,17 @@ Difference:
 <green>- Expected</>
 <red>+ Received</>
 
-<dim>  Object {
-<dim>    \\"a\\": Array [
-<dim>      3,
-<dim>      4,
+<dim>  Object {</>
+<dim>    \\"a\\": Array [</>
+<dim>      3,</>
+<dim>      4,</>
 <red>+     5,</>
-<dim>    ],
-<dim>  }"
+<dim>    ],</>
+<dim>  }</>"
 `;
 
 exports[`toMatchObject() {pass: false} expect({"a": [3, 4, 5], "b": "b"}).toMatchObject({"a": {"b": 4}}) 1`] = `
-"<dim>expect(<red>received</><dim>).toMatchObject(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toMatchObject(</><green>expected</><dim>)</>
 
 Expected value to match object:
   <green>{\\"a\\": {\\"b\\": 4}}</>
@@ -3256,7 +3256,7 @@ Difference:
 <green>- Expected</>
 <red>+ Received</>
 
-<dim>  Object {
+<dim>  Object {</>
 <green>-   \\"a\\": Object {</>
 <green>-     \\"b\\": 4,</>
 <green>-   },</>
@@ -3265,11 +3265,11 @@ Difference:
 <red>+     4,</>
 <red>+     5,</>
 <red>+   ],</>
-<dim>  }"
+<dim>  }</>"
 `;
 
 exports[`toMatchObject() {pass: false} expect({"a": [3, 4, 5], "b": "b"}).toMatchObject({"a": {"b": Any<String>}}) 1`] = `
-"<dim>expect(<red>received</><dim>).toMatchObject(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toMatchObject(</><green>expected</><dim>)</>
 
 Expected value to match object:
   <green>{\\"a\\": {\\"b\\": Any<String>}}</>
@@ -3279,7 +3279,7 @@ Difference:
 <green>- Expected</>
 <red>+ Received</>
 
-<dim>  Object {
+<dim>  Object {</>
 <green>-   \\"a\\": Object {</>
 <green>-     \\"b\\": Any<String>,</>
 <green>-   },</>
@@ -3288,11 +3288,11 @@ Difference:
 <red>+     4,</>
 <red>+     5,</>
 <red>+   ],</>
-<dim>  }"
+<dim>  }</>"
 `;
 
 exports[`toMatchObject() {pass: false} expect({"a": 1, "b": 1, "c": 1, "d": {"e": {"f": 555}}}).toMatchObject({"d": {"e": {"f": 222}}}) 1`] = `
-"<dim>expect(<red>received</><dim>).toMatchObject(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toMatchObject(</><green>expected</><dim>)</>
 
 Expected value to match object:
   <green>{\\"d\\": {\\"e\\": {\\"f\\": 222}}}</>
@@ -3302,18 +3302,18 @@ Difference:
 <green>- Expected</>
 <red>+ Received</>
 
-<dim>  Object {
-<dim>    \\"d\\": Object {
-<dim>      \\"e\\": Object {
+<dim>  Object {</>
+<dim>    \\"d\\": Object {</>
+<dim>      \\"e\\": Object {</>
 <green>-       \\"f\\": 222,</>
 <red>+       \\"f\\": 555,</>
-<dim>      },
-<dim>    },
-<dim>  }"
+<dim>      },</>
+<dim>    },</>
+<dim>  }</>"
 `;
 
 exports[`toMatchObject() {pass: false} expect({"a": 2015-11-30T00:00:00.000Z, "b": "b"}).toMatchObject({"a": 2015-10-10T00:00:00.000Z}) 1`] = `
-"<dim>expect(<red>received</><dim>).toMatchObject(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toMatchObject(</><green>expected</><dim>)</>
 
 Expected value to match object:
   <green>{\\"a\\": 2015-10-10T00:00:00.000Z}</>
@@ -3323,14 +3323,14 @@ Difference:
 <green>- Expected</>
 <red>+ Received</>
 
-<dim>  Object {
+<dim>  Object {</>
 <green>-   \\"a\\": 2015-10-10T00:00:00.000Z,</>
 <red>+   \\"a\\": 2015-11-30T00:00:00.000Z,</>
-<dim>  }"
+<dim>  }</>"
 `;
 
 exports[`toMatchObject() {pass: false} expect({"a": null, "b": "b"}).toMatchObject({"a": "4"}) 1`] = `
-"<dim>expect(<red>received</><dim>).toMatchObject(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toMatchObject(</><green>expected</><dim>)</>
 
 Expected value to match object:
   <green>{\\"a\\": \\"4\\"}</>
@@ -3340,14 +3340,14 @@ Difference:
 <green>- Expected</>
 <red>+ Received</>
 
-<dim>  Object {
+<dim>  Object {</>
 <green>-   \\"a\\": \\"4\\",</>
 <red>+   \\"a\\": null,</>
-<dim>  }"
+<dim>  }</>"
 `;
 
 exports[`toMatchObject() {pass: false} expect({"a": null, "b": "b"}).toMatchObject({"a": undefined}) 1`] = `
-"<dim>expect(<red>received</><dim>).toMatchObject(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toMatchObject(</><green>expected</><dim>)</>
 
 Expected value to match object:
   <green>{\\"a\\": undefined}</>
@@ -3357,14 +3357,14 @@ Difference:
 <green>- Expected</>
 <red>+ Received</>
 
-<dim>  Object {
+<dim>  Object {</>
 <green>-   \\"a\\": undefined,</>
 <red>+   \\"a\\": null,</>
-<dim>  }"
+<dim>  }</>"
 `;
 
 exports[`toMatchObject() {pass: false} expect({"a": undefined}).toMatchObject({"a": null}) 1`] = `
-"<dim>expect(<red>received</><dim>).toMatchObject(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toMatchObject(</><green>expected</><dim>)</>
 
 Expected value to match object:
   <green>{\\"a\\": null}</>
@@ -3374,14 +3374,14 @@ Difference:
 <green>- Expected</>
 <red>+ Received</>
 
-<dim>  Object {
+<dim>  Object {</>
 <green>-   \\"a\\": null,</>
 <red>+   \\"a\\": undefined,</>
-<dim>  }"
+<dim>  }</>"
 `;
 
 exports[`toMatchObject() {pass: false} expect({}).toMatchObject({"a": undefined}) 1`] = `
-"<dim>expect(<red>received</><dim>).toMatchObject(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toMatchObject(</><green>expected</><dim>)</>
 
 Expected value to match object:
   <green>{\\"a\\": undefined}</>
@@ -3398,7 +3398,7 @@ Difference:
 `;
 
 exports[`toMatchObject() {pass: false} expect(2015-11-30T00:00:00.000Z).toMatchObject(2015-10-10T00:00:00.000Z) 1`] = `
-"<dim>expect(<red>received</><dim>).toMatchObject(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toMatchObject(</><green>expected</><dim>)</>
 
 Expected value to match object:
   <green>2015-10-10T00:00:00.000Z</>
@@ -3413,7 +3413,7 @@ Difference:
 `;
 
 exports[`toMatchObject() {pass: false} expect(Set {1, 2}).toMatchObject(Set {2}) 1`] = `
-"<dim>expect(<red>received</><dim>).toMatchObject(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toMatchObject(</><green>expected</><dim>)</>
 
 Expected value to match object:
   <green>Set {2}</>
@@ -3423,14 +3423,14 @@ Difference:
 <green>- Expected</>
 <red>+ Received</>
 
-<dim>  Set {
+<dim>  Set {</>
 <red>+   1,</>
-<dim>    2,
-<dim>  }"
+<dim>    2,</>
+<dim>  }</>"
 `;
 
 exports[`toMatchObject() {pass: true} expect([]).toMatchObject([]) 1`] = `
-"<dim>expect(<red>received</><dim>).not.toMatchObject(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toMatchObject(</><green>expected</><dim>)</>
 
 Expected value not to match object:
   <green>[]</>
@@ -3439,7 +3439,7 @@ Received:
 `;
 
 exports[`toMatchObject() {pass: true} expect([1, 2]).toMatchObject([1, 2]) 1`] = `
-"<dim>expect(<red>received</><dim>).not.toMatchObject(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toMatchObject(</><green>expected</><dim>)</>
 
 Expected value not to match object:
   <green>[1, 2]</>
@@ -3448,7 +3448,7 @@ Received:
 `;
 
 exports[`toMatchObject() {pass: true} expect([Error: foo]).toMatchObject([Error: foo]) 1`] = `
-"<dim>expect(<red>received</><dim>).not.toMatchObject(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toMatchObject(</><green>expected</><dim>)</>
 
 Expected value not to match object:
   <green>[Error: foo]</>
@@ -3457,7 +3457,7 @@ Received:
 `;
 
 exports[`toMatchObject() {pass: true} expect({"a": "b", "c": "d"}).toMatchObject({"a": "b", "c": "d"}) 1`] = `
-"<dim>expect(<red>received</><dim>).not.toMatchObject(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toMatchObject(</><green>expected</><dim>)</>
 
 Expected value not to match object:
   <green>{\\"a\\": \\"b\\", \\"c\\": \\"d\\"}</>
@@ -3466,7 +3466,7 @@ Received:
 `;
 
 exports[`toMatchObject() {pass: true} expect({"a": "b", "c": "d"}).toMatchObject({"a": "b"}) 1`] = `
-"<dim>expect(<red>received</><dim>).not.toMatchObject(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toMatchObject(</><green>expected</><dim>)</>
 
 Expected value not to match object:
   <green>{\\"a\\": \\"b\\"}</>
@@ -3475,7 +3475,7 @@ Received:
 `;
 
 exports[`toMatchObject() {pass: true} expect({"a": "b", "t": {"x": {"r": "r"}, "z": "z"}}).toMatchObject({"a": "b", "t": {"z": "z"}}) 1`] = `
-"<dim>expect(<red>received</><dim>).not.toMatchObject(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toMatchObject(</><green>expected</><dim>)</>
 
 Expected value not to match object:
   <green>{\\"a\\": \\"b\\", \\"t\\": {\\"z\\": \\"z\\"}}</>
@@ -3484,7 +3484,7 @@ Received:
 `;
 
 exports[`toMatchObject() {pass: true} expect({"a": "b", "t": {"x": {"r": "r"}, "z": "z"}}).toMatchObject({"t": {"x": {"r": "r"}}}) 1`] = `
-"<dim>expect(<red>received</><dim>).not.toMatchObject(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toMatchObject(</><green>expected</><dim>)</>
 
 Expected value not to match object:
   <green>{\\"t\\": {\\"x\\": {\\"r\\": \\"r\\"}}}</>
@@ -3493,7 +3493,7 @@ Received:
 `;
 
 exports[`toMatchObject() {pass: true} expect({"a": [{"a": "a", "b": "b"}]}).toMatchObject({"a": [{"a": "a"}]}) 1`] = `
-"<dim>expect(<red>received</><dim>).not.toMatchObject(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toMatchObject(</><green>expected</><dim>)</>
 
 Expected value not to match object:
   <green>{\\"a\\": [{\\"a\\": \\"a\\"}]}</>
@@ -3502,7 +3502,7 @@ Received:
 `;
 
 exports[`toMatchObject() {pass: true} expect({"a": [3, 4, 5, "v"], "b": "b"}).toMatchObject({"a": [3, 4, 5, "v"]}) 1`] = `
-"<dim>expect(<red>received</><dim>).not.toMatchObject(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toMatchObject(</><green>expected</><dim>)</>
 
 Expected value not to match object:
   <green>{\\"a\\": [3, 4, 5, \\"v\\"]}</>
@@ -3511,7 +3511,7 @@ Received:
 `;
 
 exports[`toMatchObject() {pass: true} expect({"a": [3, 4, 5], "b": "b"}).toMatchObject({"a": [3, 4, 5]}) 1`] = `
-"<dim>expect(<red>received</><dim>).not.toMatchObject(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toMatchObject(</><green>expected</><dim>)</>
 
 Expected value not to match object:
   <green>{\\"a\\": [3, 4, 5]}</>
@@ -3520,7 +3520,7 @@ Received:
 `;
 
 exports[`toMatchObject() {pass: true} expect({"a": {"x": "x", "y": "y"}}).toMatchObject({"a": {"x": Any<String>}}) 1`] = `
-"<dim>expect(<red>received</><dim>).not.toMatchObject(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toMatchObject(</><green>expected</><dim>)</>
 
 Expected value not to match object:
   <green>{\\"a\\": {\\"x\\": Any<String>}}</>
@@ -3529,7 +3529,7 @@ Received:
 `;
 
 exports[`toMatchObject() {pass: true} expect({"a": 1, "c": 2}).toMatchObject({"a": Any<Number>}) 1`] = `
-"<dim>expect(<red>received</><dim>).not.toMatchObject(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toMatchObject(</><green>expected</><dim>)</>
 
 Expected value not to match object:
   <green>{\\"a\\": Any<Number>}</>
@@ -3538,7 +3538,7 @@ Received:
 `;
 
 exports[`toMatchObject() {pass: true} expect({"a": 2015-11-30T00:00:00.000Z, "b": "b"}).toMatchObject({"a": 2015-11-30T00:00:00.000Z}) 1`] = `
-"<dim>expect(<red>received</><dim>).not.toMatchObject(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toMatchObject(</><green>expected</><dim>)</>
 
 Expected value not to match object:
   <green>{\\"a\\": 2015-11-30T00:00:00.000Z}</>
@@ -3547,7 +3547,7 @@ Received:
 `;
 
 exports[`toMatchObject() {pass: true} expect({"a": null, "b": "b"}).toMatchObject({"a": null}) 1`] = `
-"<dim>expect(<red>received</><dim>).not.toMatchObject(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toMatchObject(</><green>expected</><dim>)</>
 
 Expected value not to match object:
   <green>{\\"a\\": null}</>
@@ -3556,7 +3556,7 @@ Received:
 `;
 
 exports[`toMatchObject() {pass: true} expect({"a": undefined, "b": "b"}).toMatchObject({"a": undefined}) 1`] = `
-"<dim>expect(<red>received</><dim>).not.toMatchObject(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toMatchObject(</><green>expected</><dim>)</>
 
 Expected value not to match object:
   <green>{\\"a\\": undefined}</>
@@ -3565,7 +3565,7 @@ Received:
 `;
 
 exports[`toMatchObject() {pass: true} expect({"a": undefined}).toMatchObject({"a": undefined}) 1`] = `
-"<dim>expect(<red>received</><dim>).not.toMatchObject(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toMatchObject(</><green>expected</><dim>)</>
 
 Expected value not to match object:
   <green>{\\"a\\": undefined}</>
@@ -3574,7 +3574,7 @@ Received:
 `;
 
 exports[`toMatchObject() {pass: true} expect(2015-11-30T00:00:00.000Z).toMatchObject(2015-11-30T00:00:00.000Z) 1`] = `
-"<dim>expect(<red>received</><dim>).not.toMatchObject(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toMatchObject(</><green>expected</><dim>)</>
 
 Expected value not to match object:
   <green>2015-11-30T00:00:00.000Z</>
@@ -3583,7 +3583,7 @@ Received:
 `;
 
 exports[`toMatchObject() {pass: true} expect(Set {1, 2}).toMatchObject(Set {1, 2}) 1`] = `
-"<dim>expect(<red>received</><dim>).not.toMatchObject(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toMatchObject(</><green>expected</><dim>)</>
 
 Expected value not to match object:
   <green>Set {1, 2}</>
@@ -3592,7 +3592,7 @@ Received:
 `;
 
 exports[`toMatchObject() {pass: true} expect(Set {1, 2}).toMatchObject(Set {2, 1}) 1`] = `
-"<dim>expect(<red>received</><dim>).not.toMatchObject(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).not.toMatchObject(</><green>expected</><dim>)</>
 
 Expected value not to match object:
   <green>Set {2, 1}</>
@@ -3601,7 +3601,7 @@ Received:
 `;
 
 exports[`toMatchObject() throws expect("44").toMatchObject({}) 1`] = `
-"<dim>expect(<red>object</><dim>)[.not].toMatchObject(<green>expected</><dim>)
+"<dim>expect(</><red>object</><dim>)[.not].toMatchObject(</><green>expected</><dim>)</>
 
 <red>received</> value must be an object.
 Received:
@@ -3609,7 +3609,7 @@ Received:
 `;
 
 exports[`toMatchObject() throws expect({}).toMatchObject("some string") 1`] = `
-"<dim>expect(<red>object</><dim>)[.not].toMatchObject(<green>expected</><dim>)
+"<dim>expect(</><red>object</><dim>)[.not].toMatchObject(</><green>expected</><dim>)</>
 
 <green>expected</> value must be an object.
 Expected:
@@ -3617,7 +3617,7 @@ Expected:
 `;
 
 exports[`toMatchObject() throws expect({}).toMatchObject(4) 1`] = `
-"<dim>expect(<red>object</><dim>)[.not].toMatchObject(<green>expected</><dim>)
+"<dim>expect(</><red>object</><dim>)[.not].toMatchObject(</><green>expected</><dim>)</>
 
 <green>expected</> value must be an object.
 Expected:
@@ -3625,14 +3625,14 @@ Expected:
 `;
 
 exports[`toMatchObject() throws expect({}).toMatchObject(null) 1`] = `
-"<dim>expect(<red>object</><dim>)[.not].toMatchObject(<green>expected</><dim>)
+"<dim>expect(</><red>object</><dim>)[.not].toMatchObject(</><green>expected</><dim>)</>
 
 <green>expected</> value must be an object.
 Expected: <green>null</>"
 `;
 
 exports[`toMatchObject() throws expect({}).toMatchObject(true) 1`] = `
-"<dim>expect(<red>object</><dim>)[.not].toMatchObject(<green>expected</><dim>)
+"<dim>expect(</><red>object</><dim>)[.not].toMatchObject(</><green>expected</><dim>)</>
 
 <green>expected</> value must be an object.
 Expected:
@@ -3640,14 +3640,14 @@ Expected:
 `;
 
 exports[`toMatchObject() throws expect({}).toMatchObject(undefined) 1`] = `
-"<dim>expect(<red>object</><dim>)[.not].toMatchObject(<green>expected</><dim>)
+"<dim>expect(</><red>object</><dim>)[.not].toMatchObject(</><green>expected</><dim>)</>
 
 <green>expected</> value must be an object.
 Expected: <green>undefined</>"
 `;
 
 exports[`toMatchObject() throws expect(4).toMatchObject({}) 1`] = `
-"<dim>expect(<red>object</><dim>)[.not].toMatchObject(<green>expected</><dim>)
+"<dim>expect(</><red>object</><dim>)[.not].toMatchObject(</><green>expected</><dim>)</>
 
 <red>received</> value must be an object.
 Received:
@@ -3655,14 +3655,14 @@ Received:
 `;
 
 exports[`toMatchObject() throws expect(null).toMatchObject({}) 1`] = `
-"<dim>expect(<red>object</><dim>)[.not].toMatchObject(<green>expected</><dim>)
+"<dim>expect(</><red>object</><dim>)[.not].toMatchObject(</><green>expected</><dim>)</>
 
 <red>received</> value must be an object.
 Received: <red>null</>"
 `;
 
 exports[`toMatchObject() throws expect(true).toMatchObject({}) 1`] = `
-"<dim>expect(<red>object</><dim>)[.not].toMatchObject(<green>expected</><dim>)
+"<dim>expect(</><red>object</><dim>)[.not].toMatchObject(</><green>expected</><dim>)</>
 
 <red>received</> value must be an object.
 Received:
@@ -3670,7 +3670,7 @@ Received:
 `;
 
 exports[`toMatchObject() throws expect(undefined).toMatchObject({}) 1`] = `
-"<dim>expect(<red>object</><dim>)[.not].toMatchObject(<green>expected</><dim>)
+"<dim>expect(</><red>object</><dim>)[.not].toMatchObject(</><green>expected</><dim>)</>
 
 <red>received</> value must be an object.
 Received: <red>undefined</>"

--- a/packages/expect/src/__tests__/__snapshots__/spy_matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/spy_matchers.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`lastCalledWith works only on spies or jest.fn 1`] = `
-"<dim>expect(<red>jest.fn()</><dim>)[.not].lastCalledWith(<dim>)
+"<dim>expect(</><red>jest.fn()</><dim>)[.not].lastCalledWith(</><dim>)</>
 
 <red>jest.fn()</> value must be a mock function or spy.
 Received:
@@ -9,7 +9,7 @@ Received:
 `;
 
 exports[`lastCalledWith works when not called 1`] = `
-"<dim>expect(<red>jest.fn()</><dim>).lastCalledWith(<green>expected</><dim>)
+"<dim>expect(</><red>jest.fn()</><dim>).lastCalledWith(</><green>expected</><dim>)</>
 
 Expected mock function to have been last called with:
   <green>[\\"foo\\", \\"bar\\"]</>
@@ -17,70 +17,70 @@ But it was <red>not called</>."
 `;
 
 exports[`lastCalledWith works with Immutable.js objects 1`] = `
-"<dim>expect(<red>jest.fn()</><dim>).not.lastCalledWith(<green>expected</><dim>)
+"<dim>expect(</><red>jest.fn()</><dim>).not.lastCalledWith(</><green>expected</><dim>)</>
 
 Expected mock function to not have been last called with:
   <green>[Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}, Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}]</>"
 `;
 
 exports[`lastCalledWith works with Map 1`] = `
-"<dim>expect(<red>jest.fn()</><dim>).not.lastCalledWith(<green>expected</><dim>)
+"<dim>expect(</><red>jest.fn()</><dim>).not.lastCalledWith(</><green>expected</><dim>)</>
 
 Expected mock function to not have been last called with:
   <green>[Map {1 => 2, 2 => 1}]</>"
 `;
 
 exports[`lastCalledWith works with Map 2`] = `
-"<dim>expect(<red>jest.fn()</><dim>).lastCalledWith(<green>expected</><dim>)
+"<dim>expect(</><red>jest.fn()</><dim>).lastCalledWith(</><green>expected</><dim>)</>
 
 Expected mock function to have been last called with:
   <green>Map {\\"a\\" => \\"b\\", \\"b\\" => \\"a\\"}</> as argument 1, but it was called with <red>Map {1 => 2, 2 => 1}</>."
 `;
 
 exports[`lastCalledWith works with Set 1`] = `
-"<dim>expect(<red>jest.fn()</><dim>).not.lastCalledWith(<green>expected</><dim>)
+"<dim>expect(</><red>jest.fn()</><dim>).not.lastCalledWith(</><green>expected</><dim>)</>
 
 Expected mock function to not have been last called with:
   <green>[Set {1, 2}]</>"
 `;
 
 exports[`lastCalledWith works with Set 2`] = `
-"<dim>expect(<red>jest.fn()</><dim>).lastCalledWith(<green>expected</><dim>)
+"<dim>expect(</><red>jest.fn()</><dim>).lastCalledWith(</><green>expected</><dim>)</>
 
 Expected mock function to have been last called with:
   <green>Set {3, 4}</> as argument 1, but it was called with <red>Set {1, 2}</>."
 `;
 
 exports[`lastCalledWith works with arguments that don't match 1`] = `
-"<dim>expect(<red>jest.fn()</><dim>).lastCalledWith(<green>expected</><dim>)
+"<dim>expect(</><red>jest.fn()</><dim>).lastCalledWith(</><green>expected</><dim>)</>
 
 Expected mock function to have been last called with:
   <green>\\"bar\\"</> as argument 2, but it was called with <red>\\"bar1\\"</>."
 `;
 
 exports[`lastCalledWith works with arguments that match 1`] = `
-"<dim>expect(<red>jest.fn()</><dim>).not.lastCalledWith(<green>expected</><dim>)
+"<dim>expect(</><red>jest.fn()</><dim>).not.lastCalledWith(</><green>expected</><dim>)</>
 
 Expected mock function to not have been last called with:
   <green>[\\"foo\\", \\"bar\\"]</>"
 `;
 
 exports[`lastCalledWith works with many arguments 1`] = `
-"<dim>expect(<red>jest.fn()</><dim>).not.lastCalledWith(<green>expected</><dim>)
+"<dim>expect(</><red>jest.fn()</><dim>).not.lastCalledWith(</><green>expected</><dim>)</>
 
 Expected mock function to not have been last called with:
   <green>[\\"foo\\", \\"bar\\"]</>"
 `;
 
 exports[`lastCalledWith works with many arguments that don't match 1`] = `
-"<dim>expect(<red>jest.fn()</><dim>).lastCalledWith(<green>expected</><dim>)
+"<dim>expect(</><red>jest.fn()</><dim>).lastCalledWith(</><green>expected</><dim>)</>
 
 Expected mock function to have been last called with:
   <green>\\"bar\\"</> as argument 2, but it was called with <red>\\"bar3\\"</>."
 `;
 
 exports[`toBeCalled works only on spies or jest.fn 1`] = `
-"<dim>expect(<red>jest.fn()</><dim>)[.not].toBeCalled(<dim>)
+"<dim>expect(</><red>jest.fn()</><dim>)[.not].toBeCalled(</><dim>)</>
 
 <red>jest.fn()</> value must be a mock function or spy.
 Received:
@@ -88,20 +88,20 @@ Received:
 `;
 
 exports[`toBeCalled works with jest.fn 1`] = `
-"<dim>expect(<red>jest.fn()</><dim>).toBeCalled(<dim>)
+"<dim>expect(</><red>jest.fn()</><dim>).toBeCalled(</><dim>)</>
 
 Expected mock function to have been called."
 `;
 
 exports[`toBeCalled works with jest.fn 2`] = `
-"<dim>expect(<red>jest.fn()</><dim>).not.toBeCalled(<dim>)
+"<dim>expect(</><red>jest.fn()</><dim>).not.toBeCalled(</><dim>)</>
 
 Expected mock function not to be called but it was called with:
   <red>[]</>"
 `;
 
 exports[`toBeCalled works with jest.fn 3`] = `
-"<dim>expect(<red>received</><dim>)[.not].toBeCalled(<dim>)
+"<dim>expect(</><red>received</><dim>)[.not].toBeCalled(</><dim>)</>
 
 Matcher does not accept any arguments.
 Got:
@@ -109,7 +109,7 @@ Got:
 `;
 
 exports[`toBeCalledWith works only on spies or jest.fn 1`] = `
-"<dim>expect(<red>jest.fn()</><dim>)[.not].toBeCalledWith(<dim>)
+"<dim>expect(</><red>jest.fn()</><dim>)[.not].toBeCalledWith(</><dim>)</>
 
 <red>jest.fn()</> value must be a mock function or spy.
 Received:
@@ -117,7 +117,7 @@ Received:
 `;
 
 exports[`toHaveBeenCalled works only on spies or jest.fn 1`] = `
-"<dim>expect(<red>jest.fn()</><dim>)[.not].toHaveBeenCalled(<dim>)
+"<dim>expect(</><red>jest.fn()</><dim>)[.not].toHaveBeenCalled(</><dim>)</>
 
 <red>jest.fn()</> value must be a mock function or spy.
 Received:
@@ -125,20 +125,20 @@ Received:
 `;
 
 exports[`toHaveBeenCalled works with jest.fn 1`] = `
-"<dim>expect(<red>jest.fn()</><dim>).toHaveBeenCalled(<dim>)
+"<dim>expect(</><red>jest.fn()</><dim>).toHaveBeenCalled(</><dim>)</>
 
 Expected mock function to have been called."
 `;
 
 exports[`toHaveBeenCalled works with jest.fn 2`] = `
-"<dim>expect(<red>jest.fn()</><dim>).not.toHaveBeenCalled(<dim>)
+"<dim>expect(</><red>jest.fn()</><dim>).not.toHaveBeenCalled(</><dim>)</>
 
 Expected mock function not to be called but it was called with:
   <red>[]</>"
 `;
 
 exports[`toHaveBeenCalled works with jest.fn 3`] = `
-"<dim>expect(<red>received</><dim>)[.not].toHaveBeenCalled(<dim>)
+"<dim>expect(</><red>received</><dim>)[.not].toHaveBeenCalled(</><dim>)</>
 
 Matcher does not accept any arguments.
 Got:
@@ -146,7 +146,7 @@ Got:
 `;
 
 exports[`toHaveBeenCalledTimes accepts only numbers 1`] = `
-"<dim>expect(<red>received</><dim>)[.not].toHaveBeenCalledTimes(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>)[.not].toHaveBeenCalledTimes(</><green>expected</><dim>)</>
 
 Expected value must be a number.
 Got:
@@ -154,7 +154,7 @@ Got:
 `;
 
 exports[`toHaveBeenCalledTimes accepts only numbers 2`] = `
-"<dim>expect(<red>received</><dim>)[.not].toHaveBeenCalledTimes(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>)[.not].toHaveBeenCalledTimes(</><green>expected</><dim>)</>
 
 Expected value must be a number.
 Got:
@@ -162,7 +162,7 @@ Got:
 `;
 
 exports[`toHaveBeenCalledTimes accepts only numbers 3`] = `
-"<dim>expect(<red>received</><dim>)[.not].toHaveBeenCalledTimes(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>)[.not].toHaveBeenCalledTimes(</><green>expected</><dim>)</>
 
 Expected value must be a number.
 Got:
@@ -170,7 +170,7 @@ Got:
 `;
 
 exports[`toHaveBeenCalledTimes accepts only numbers 4`] = `
-"<dim>expect(<red>received</><dim>)[.not].toHaveBeenCalledTimes(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>)[.not].toHaveBeenCalledTimes(</><green>expected</><dim>)</>
 
 Expected value must be a number.
 Got:
@@ -178,7 +178,7 @@ Got:
 `;
 
 exports[`toHaveBeenCalledTimes accepts only numbers 5`] = `
-"<dim>expect(<red>received</><dim>)[.not].toHaveBeenCalledTimes(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>)[.not].toHaveBeenCalledTimes(</><green>expected</><dim>)</>
 
 Expected value must be a number.
 Got:
@@ -186,7 +186,7 @@ Got:
 `;
 
 exports[`toHaveBeenCalledTimes accepts only numbers 6`] = `
-"<dim>expect(<red>received</><dim>)[.not].toHaveBeenCalledTimes(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>)[.not].toHaveBeenCalledTimes(</><green>expected</><dim>)</>
 
 Expected value must be a number.
 Got:
@@ -194,25 +194,25 @@ Got:
 `;
 
 exports[`toHaveBeenCalledTimes fails if function called less than expected times 1`] = `
-"<dim>expect(<red>jest.fn()</><dim>).toHaveBeenCalledTimes(<green>2</><dim>)
+"<dim>expect(</><red>jest.fn()</><dim>).toHaveBeenCalledTimes(</><green>2</><dim>)</>
 
 Expected mock function to have been called <green>two times</>, but it was called <red>one time</>."
 `;
 
 exports[`toHaveBeenCalledTimes fails if function called more than expected times 1`] = `
-"<dim>expect(<red>jest.fn()</><dim>).toHaveBeenCalledTimes(<green>2</><dim>)
+"<dim>expect(</><red>jest.fn()</><dim>).toHaveBeenCalledTimes(</><green>2</><dim>)</>
 
 Expected mock function to have been called <green>two times</>, but it was called <red>three times</>."
 `;
 
 exports[`toHaveBeenCalledTimes passes if function called equal to expected times 1`] = `
-"<dim>expect(<red>jest.fn()</><dim>).not.toHaveBeenCalledTimes(<green>2</><dim>)
+"<dim>expect(</><red>jest.fn()</><dim>).not.toHaveBeenCalledTimes(</><green>2</><dim>)</>
 
 Expected mock function not to be called <green>two times</>, but it was called exactly <red>two times</>."
 `;
 
 exports[`toHaveBeenCalledTimes verifies that actual is a Spy 1`] = `
-"<dim>expect(<red>jest.fn()</><dim>)[.not].toHaveBeenCalledTimes(<dim>)
+"<dim>expect(</><red>jest.fn()</><dim>)[.not].toHaveBeenCalledTimes(</><dim>)</>
 
 <red>jest.fn()</> value must be a mock function or spy.
 Received:
@@ -220,7 +220,7 @@ Received:
 `;
 
 exports[`toHaveBeenCalledWith works only on spies or jest.fn 1`] = `
-"<dim>expect(<red>jest.fn()</><dim>)[.not].toHaveBeenCalledWith(<dim>)
+"<dim>expect(</><red>jest.fn()</><dim>)[.not].toHaveBeenCalledWith(</><dim>)</>
 
 <red>jest.fn()</> value must be a mock function or spy.
 Received:
@@ -228,7 +228,7 @@ Received:
 `;
 
 exports[`toHaveBeenCalledWith works when not called 1`] = `
-"<dim>expect(<red>jest.fn()</><dim>).toHaveBeenCalledWith(<green>expected</><dim>)
+"<dim>expect(</><red>jest.fn()</><dim>).toHaveBeenCalledWith(</><green>expected</><dim>)</>
 
 Expected mock function to have been called with:
   <green>[\\"foo\\", \\"bar\\"]</>
@@ -236,63 +236,63 @@ But it was <red>not called</>."
 `;
 
 exports[`toHaveBeenCalledWith works with Immutable.js objects 1`] = `
-"<dim>expect(<red>jest.fn()</><dim>).not.toHaveBeenCalledWith(<green>expected</><dim>)
+"<dim>expect(</><red>jest.fn()</><dim>).not.toHaveBeenCalledWith(</><green>expected</><dim>)</>
 
 Expected mock function not to have been called with:
   <green>[Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}, Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}]</>"
 `;
 
 exports[`toHaveBeenCalledWith works with Map 1`] = `
-"<dim>expect(<red>jest.fn()</><dim>).not.toHaveBeenCalledWith(<green>expected</><dim>)
+"<dim>expect(</><red>jest.fn()</><dim>).not.toHaveBeenCalledWith(</><green>expected</><dim>)</>
 
 Expected mock function not to have been called with:
   <green>[Map {1 => 2, 2 => 1}]</>"
 `;
 
 exports[`toHaveBeenCalledWith works with Map 2`] = `
-"<dim>expect(<red>jest.fn()</><dim>).toHaveBeenCalledWith(<green>expected</><dim>)
+"<dim>expect(</><red>jest.fn()</><dim>).toHaveBeenCalledWith(</><green>expected</><dim>)</>
 
 Expected mock function to have been called with:
   <green>Map {\\"a\\" => \\"b\\", \\"b\\" => \\"a\\"}</> as argument 1, but it was called with <red>Map {1 => 2, 2 => 1}</>."
 `;
 
 exports[`toHaveBeenCalledWith works with Set 1`] = `
-"<dim>expect(<red>jest.fn()</><dim>).not.toHaveBeenCalledWith(<green>expected</><dim>)
+"<dim>expect(</><red>jest.fn()</><dim>).not.toHaveBeenCalledWith(</><green>expected</><dim>)</>
 
 Expected mock function not to have been called with:
   <green>[Set {1, 2}]</>"
 `;
 
 exports[`toHaveBeenCalledWith works with Set 2`] = `
-"<dim>expect(<red>jest.fn()</><dim>).toHaveBeenCalledWith(<green>expected</><dim>)
+"<dim>expect(</><red>jest.fn()</><dim>).toHaveBeenCalledWith(</><green>expected</><dim>)</>
 
 Expected mock function to have been called with:
   <green>Set {3, 4}</> as argument 1, but it was called with <red>Set {1, 2}</>."
 `;
 
 exports[`toHaveBeenCalledWith works with arguments that don't match 1`] = `
-"<dim>expect(<red>jest.fn()</><dim>).toHaveBeenCalledWith(<green>expected</><dim>)
+"<dim>expect(</><red>jest.fn()</><dim>).toHaveBeenCalledWith(</><green>expected</><dim>)</>
 
 Expected mock function to have been called with:
   <green>\\"bar\\"</> as argument 2, but it was called with <red>\\"bar1\\"</>."
 `;
 
 exports[`toHaveBeenCalledWith works with arguments that match 1`] = `
-"<dim>expect(<red>jest.fn()</><dim>).not.toHaveBeenCalledWith(<green>expected</><dim>)
+"<dim>expect(</><red>jest.fn()</><dim>).not.toHaveBeenCalledWith(</><green>expected</><dim>)</>
 
 Expected mock function not to have been called with:
   <green>[\\"foo\\", \\"bar\\"]</>"
 `;
 
 exports[`toHaveBeenCalledWith works with many arguments 1`] = `
-"<dim>expect(<red>jest.fn()</><dim>).not.toHaveBeenCalledWith(<green>expected</><dim>)
+"<dim>expect(</><red>jest.fn()</><dim>).not.toHaveBeenCalledWith(</><green>expected</><dim>)</>
 
 Expected mock function not to have been called with:
   <green>[\\"foo\\", \\"bar\\"]</>"
 `;
 
 exports[`toHaveBeenCalledWith works with many arguments that don't match 1`] = `
-"<dim>expect(<red>jest.fn()</><dim>).toHaveBeenCalledWith(<green>expected</><dim>)
+"<dim>expect(</><red>jest.fn()</><dim>).toHaveBeenCalledWith(</><green>expected</><dim>)</>
 
 Expected mock function to have been called with:
   <green>\\"bar\\"</> as argument 2, but it was called with <red>\\"bar3\\"</>.
@@ -303,7 +303,7 @@ Expected mock function to have been called with:
 `;
 
 exports[`toHaveBeenLastCalledWith works only on spies or jest.fn 1`] = `
-"<dim>expect(<red>jest.fn()</><dim>)[.not].toHaveBeenLastCalledWith(<dim>)
+"<dim>expect(</><red>jest.fn()</><dim>)[.not].toHaveBeenLastCalledWith(</><dim>)</>
 
 <red>jest.fn()</> value must be a mock function or spy.
 Received:
@@ -311,7 +311,7 @@ Received:
 `;
 
 exports[`toHaveBeenLastCalledWith works when not called 1`] = `
-"<dim>expect(<red>jest.fn()</><dim>).toHaveBeenLastCalledWith(<green>expected</><dim>)
+"<dim>expect(</><red>jest.fn()</><dim>).toHaveBeenLastCalledWith(</><green>expected</><dim>)</>
 
 Expected mock function to have been last called with:
   <green>[\\"foo\\", \\"bar\\"]</>
@@ -319,63 +319,63 @@ But it was <red>not called</>."
 `;
 
 exports[`toHaveBeenLastCalledWith works with Immutable.js objects 1`] = `
-"<dim>expect(<red>jest.fn()</><dim>).not.toHaveBeenLastCalledWith(<green>expected</><dim>)
+"<dim>expect(</><red>jest.fn()</><dim>).not.toHaveBeenLastCalledWith(</><green>expected</><dim>)</>
 
 Expected mock function to not have been last called with:
   <green>[Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}, Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}]</>"
 `;
 
 exports[`toHaveBeenLastCalledWith works with Map 1`] = `
-"<dim>expect(<red>jest.fn()</><dim>).not.toHaveBeenLastCalledWith(<green>expected</><dim>)
+"<dim>expect(</><red>jest.fn()</><dim>).not.toHaveBeenLastCalledWith(</><green>expected</><dim>)</>
 
 Expected mock function to not have been last called with:
   <green>[Map {1 => 2, 2 => 1}]</>"
 `;
 
 exports[`toHaveBeenLastCalledWith works with Map 2`] = `
-"<dim>expect(<red>jest.fn()</><dim>).toHaveBeenLastCalledWith(<green>expected</><dim>)
+"<dim>expect(</><red>jest.fn()</><dim>).toHaveBeenLastCalledWith(</><green>expected</><dim>)</>
 
 Expected mock function to have been last called with:
   <green>Map {\\"a\\" => \\"b\\", \\"b\\" => \\"a\\"}</> as argument 1, but it was called with <red>Map {1 => 2, 2 => 1}</>."
 `;
 
 exports[`toHaveBeenLastCalledWith works with Set 1`] = `
-"<dim>expect(<red>jest.fn()</><dim>).not.toHaveBeenLastCalledWith(<green>expected</><dim>)
+"<dim>expect(</><red>jest.fn()</><dim>).not.toHaveBeenLastCalledWith(</><green>expected</><dim>)</>
 
 Expected mock function to not have been last called with:
   <green>[Set {1, 2}]</>"
 `;
 
 exports[`toHaveBeenLastCalledWith works with Set 2`] = `
-"<dim>expect(<red>jest.fn()</><dim>).toHaveBeenLastCalledWith(<green>expected</><dim>)
+"<dim>expect(</><red>jest.fn()</><dim>).toHaveBeenLastCalledWith(</><green>expected</><dim>)</>
 
 Expected mock function to have been last called with:
   <green>Set {3, 4}</> as argument 1, but it was called with <red>Set {1, 2}</>."
 `;
 
 exports[`toHaveBeenLastCalledWith works with arguments that don't match 1`] = `
-"<dim>expect(<red>jest.fn()</><dim>).toHaveBeenLastCalledWith(<green>expected</><dim>)
+"<dim>expect(</><red>jest.fn()</><dim>).toHaveBeenLastCalledWith(</><green>expected</><dim>)</>
 
 Expected mock function to have been last called with:
   <green>\\"bar\\"</> as argument 2, but it was called with <red>\\"bar1\\"</>."
 `;
 
 exports[`toHaveBeenLastCalledWith works with arguments that match 1`] = `
-"<dim>expect(<red>jest.fn()</><dim>).not.toHaveBeenLastCalledWith(<green>expected</><dim>)
+"<dim>expect(</><red>jest.fn()</><dim>).not.toHaveBeenLastCalledWith(</><green>expected</><dim>)</>
 
 Expected mock function to not have been last called with:
   <green>[\\"foo\\", \\"bar\\"]</>"
 `;
 
 exports[`toHaveBeenLastCalledWith works with many arguments 1`] = `
-"<dim>expect(<red>jest.fn()</><dim>).not.toHaveBeenLastCalledWith(<green>expected</><dim>)
+"<dim>expect(</><red>jest.fn()</><dim>).not.toHaveBeenLastCalledWith(</><green>expected</><dim>)</>
 
 Expected mock function to not have been last called with:
   <green>[\\"foo\\", \\"bar\\"]</>"
 `;
 
 exports[`toHaveBeenLastCalledWith works with many arguments that don't match 1`] = `
-"<dim>expect(<red>jest.fn()</><dim>).toHaveBeenLastCalledWith(<green>expected</><dim>)
+"<dim>expect(</><red>jest.fn()</><dim>).toHaveBeenLastCalledWith(</><green>expected</><dim>)</>
 
 Expected mock function to have been last called with:
   <green>\\"bar\\"</> as argument 2, but it was called with <red>\\"bar3\\"</>."

--- a/packages/expect/src/__tests__/__snapshots__/to_throw_matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/to_throw_matchers.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.toThrow() error class did not throw at all 1`] = `
-"<dim>expect(<red>function</><dim>).toThrow(<green>type</><dim>)
+"<dim>expect(</><red>function</><dim>).toThrow(</><green>type</><dim>)</>
 
 Expected the function to throw an error of type:
   <green>\\"Err\\"</>
@@ -9,33 +9,33 @@ But it didn't throw anything."
 `;
 
 exports[`.toThrow() error class threw, but class did not match 1`] = `
-"<dim>expect(<red>function</><dim>).toThrow(<green>type</><dim>)
+"<dim>expect(</><red>function</><dim>).toThrow(</><green>type</><dim>)</>
 
 Expected the function to throw an error of type:
   <green>\\"Err2\\"</>
 Instead, it threw:
 <red>  Error      </>
-<red>      <dim>at jestExpect (packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+<red>      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</></>"
 `;
 
 exports[`.toThrow() error class threw, but should not have 1`] = `
-"<dim>expect(<red>function</><dim>).not.toThrow(<green>type</><dim>)
+"<dim>expect(</><red>function</><dim>).not.toThrow(</><green>type</><dim>)</>
 
 Expected the function not to throw an error of type:
   <green>\\"Err\\"</>
 Instead, it threw:
 <red>  Error      </>
-<red>      <dim>at jestExpect (packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+<red>      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</></>"
 `;
 
 exports[`.toThrow() invalid actual 1`] = `
-"<dim>expect(<red>function</><dim>).toThrow(<green>undefined</><dim>)
+"<dim>expect(</><red>function</><dim>).toThrow(</><green>undefined</><dim>)</>
 
 Received value must be a function, but instead \\"string\\" was found"
 `;
 
 exports[`.toThrow() invalid arguments 1`] = `
-"<dim>expect(<red>function</><dim>).not.toThrow(<green>number</><dim>)
+"<dim>expect(</><red>function</><dim>).not.toThrow(</><green>number</><dim>)</>
 
 Unexpected argument passed.
 Expected: <green>\\"string\\"</>, <green>\\"Error (type)\\"</> or <green>\\"regexp\\"</>.
@@ -44,7 +44,7 @@ Got:
 `;
 
 exports[`.toThrow() regexp did not throw at all 1`] = `
-"<dim>expect(<red>function</><dim>).toThrow(<green>regexp</><dim>)
+"<dim>expect(</><red>function</><dim>).toThrow(</><green>regexp</><dim>)</>
 
 Expected the function to throw an error matching:
   <green>/apple/</>
@@ -52,27 +52,27 @@ But it didn't throw anything."
 `;
 
 exports[`.toThrow() regexp threw, but message did not match 1`] = `
-"<dim>expect(<red>function</><dim>).toThrow(<green>regexp</><dim>)
+"<dim>expect(</><red>function</><dim>).toThrow(</><green>regexp</><dim>)</>
 
 Expected the function to throw an error matching:
   <green>/banana/</>
 Instead, it threw:
 <red>  Error      </>
-<red>      <dim>at jestExpect (packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+<red>      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</></>"
 `;
 
 exports[`.toThrow() regexp threw, but should not have 1`] = `
-"<dim>expect(<red>function</><dim>).not.toThrow(<green>regexp</><dim>)
+"<dim>expect(</><red>function</><dim>).not.toThrow(</><green>regexp</><dim>)</>
 
 Expected the function not to throw an error matching:
   <green>/apple/</>
 Instead, it threw:
 <red>  Error      </>
-<red>      <dim>at jestExpect (packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+<red>      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</></>"
 `;
 
 exports[`.toThrow() strings did not throw at all 1`] = `
-"<dim>expect(<red>function</><dim>).toThrow(<green>string</><dim>)
+"<dim>expect(</><red>function</><dim>).toThrow(</><green>string</><dim>)</>
 
 Expected the function to throw an error matching:
   <green>\\"apple\\"</>
@@ -80,27 +80,27 @@ But it didn't throw anything."
 `;
 
 exports[`.toThrow() strings threw, but message did not match 1`] = `
-"<dim>expect(<red>function</><dim>).toThrow(<green>string</><dim>)
+"<dim>expect(</><red>function</><dim>).toThrow(</><green>string</><dim>)</>
 
 Expected the function to throw an error matching:
   <green>\\"banana\\"</>
 Instead, it threw:
 <red>  Error      </>
-<red>      <dim>at jestExpect (packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+<red>      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</></>"
 `;
 
 exports[`.toThrow() strings threw, but should not have 1`] = `
-"<dim>expect(<red>function</><dim>).not.toThrow(<green>string</><dim>)
+"<dim>expect(</><red>function</><dim>).not.toThrow(</><green>string</><dim>)</>
 
 Expected the function not to throw an error matching:
   <green>\\"apple\\"</>
 Instead, it threw:
 <red>  Error      </>
-<red>      <dim>at jestExpect (packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+<red>      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</></>"
 `;
 
 exports[`.toThrowError() error class did not throw at all 1`] = `
-"<dim>expect(<red>function</><dim>).toThrowError(<green>type</><dim>)
+"<dim>expect(</><red>function</><dim>).toThrowError(</><green>type</><dim>)</>
 
 Expected the function to throw an error of type:
   <green>\\"Err\\"</>
@@ -108,33 +108,33 @@ But it didn't throw anything."
 `;
 
 exports[`.toThrowError() error class threw, but class did not match 1`] = `
-"<dim>expect(<red>function</><dim>).toThrowError(<green>type</><dim>)
+"<dim>expect(</><red>function</><dim>).toThrowError(</><green>type</><dim>)</>
 
 Expected the function to throw an error of type:
   <green>\\"Err2\\"</>
 Instead, it threw:
 <red>  Error      </>
-<red>      <dim>at jestExpect (packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+<red>      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</></>"
 `;
 
 exports[`.toThrowError() error class threw, but should not have 1`] = `
-"<dim>expect(<red>function</><dim>).not.toThrowError(<green>type</><dim>)
+"<dim>expect(</><red>function</><dim>).not.toThrowError(</><green>type</><dim>)</>
 
 Expected the function not to throw an error of type:
   <green>\\"Err\\"</>
 Instead, it threw:
 <red>  Error      </>
-<red>      <dim>at jestExpect (packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+<red>      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</></>"
 `;
 
 exports[`.toThrowError() invalid actual 1`] = `
-"<dim>expect(<red>function</><dim>).toThrowError(<green>undefined</><dim>)
+"<dim>expect(</><red>function</><dim>).toThrowError(</><green>undefined</><dim>)</>
 
 Received value must be a function, but instead \\"string\\" was found"
 `;
 
 exports[`.toThrowError() invalid arguments 1`] = `
-"<dim>expect(<red>function</><dim>).not.toThrowError(<green>number</><dim>)
+"<dim>expect(</><red>function</><dim>).not.toThrowError(</><green>number</><dim>)</>
 
 Unexpected argument passed.
 Expected: <green>\\"string\\"</>, <green>\\"Error (type)\\"</> or <green>\\"regexp\\"</>.
@@ -143,7 +143,7 @@ Got:
 `;
 
 exports[`.toThrowError() regexp did not throw at all 1`] = `
-"<dim>expect(<red>function</><dim>).toThrowError(<green>regexp</><dim>)
+"<dim>expect(</><red>function</><dim>).toThrowError(</><green>regexp</><dim>)</>
 
 Expected the function to throw an error matching:
   <green>/apple/</>
@@ -151,27 +151,27 @@ But it didn't throw anything."
 `;
 
 exports[`.toThrowError() regexp threw, but message did not match 1`] = `
-"<dim>expect(<red>function</><dim>).toThrowError(<green>regexp</><dim>)
+"<dim>expect(</><red>function</><dim>).toThrowError(</><green>regexp</><dim>)</>
 
 Expected the function to throw an error matching:
   <green>/banana/</>
 Instead, it threw:
 <red>  Error      </>
-<red>      <dim>at jestExpect (packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+<red>      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</></>"
 `;
 
 exports[`.toThrowError() regexp threw, but should not have 1`] = `
-"<dim>expect(<red>function</><dim>).not.toThrowError(<green>regexp</><dim>)
+"<dim>expect(</><red>function</><dim>).not.toThrowError(</><green>regexp</><dim>)</>
 
 Expected the function not to throw an error matching:
   <green>/apple/</>
 Instead, it threw:
 <red>  Error      </>
-<red>      <dim>at jestExpect (packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+<red>      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</></>"
 `;
 
 exports[`.toThrowError() strings did not throw at all 1`] = `
-"<dim>expect(<red>function</><dim>).toThrowError(<green>string</><dim>)
+"<dim>expect(</><red>function</><dim>).toThrowError(</><green>string</><dim>)</>
 
 Expected the function to throw an error matching:
   <green>\\"apple\\"</>
@@ -179,21 +179,21 @@ But it didn't throw anything."
 `;
 
 exports[`.toThrowError() strings threw, but message did not match 1`] = `
-"<dim>expect(<red>function</><dim>).toThrowError(<green>string</><dim>)
+"<dim>expect(</><red>function</><dim>).toThrowError(</><green>string</><dim>)</>
 
 Expected the function to throw an error matching:
   <green>\\"banana\\"</>
 Instead, it threw:
 <red>  Error      </>
-<red>      <dim>at jestExpect (packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+<red>      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</></>"
 `;
 
 exports[`.toThrowError() strings threw, but should not have 1`] = `
-"<dim>expect(<red>function</><dim>).not.toThrowError(<green>string</><dim>)
+"<dim>expect(</><red>function</><dim>).not.toThrowError(</><green>string</><dim>)</>
 
 Expected the function not to throw an error matching:
   <green>\\"apple\\"</>
 Instead, it threw:
 <red>  Error      </>
-<red>      <dim>at jestExpect (packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+<red>      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</></>"
 `;

--- a/packages/jest-cli/src/lib/__tests__/__snapshots__/format_test_name_by_pattern.test.js.snap
+++ b/packages/jest-cli/src/lib/__tests__/__snapshots__/format_test_name_by_pattern.test.js.snap
@@ -1,27 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`for multiline test name returns test name with highlighted pattern and replaced line breaks 1`] = `"<dim>should⏎ </>name</><dim> the ⏎function you at..."`;
+exports[`for multiline test name returns test name with highlighted pattern and replaced line breaks 1`] = `"<dim>should⏎ </></>name</><dim> the ⏎function you at...</>"`;
 
-exports[`for multiline test name returns test name with highlighted pattern and replaced line breaks 2`] = `"<dim>should⏎ </>name</><dim> the ⏎function you at..."`;
+exports[`for multiline test name returns test name with highlighted pattern and replaced line breaks 2`] = `"<dim>should⏎ </></>name</><dim> the ⏎function you at...</>"`;
 
-exports[`for multiline test name returns test name with highlighted pattern and replaced line breaks 3`] = `"<dim>should⏎ </>name</><dim> the ⏎function you at..."`;
+exports[`for multiline test name returns test name with highlighted pattern and replaced line breaks 3`] = `"<dim>should⏎ </></>name</><dim> the ⏎function you at...</>"`;
 
-exports[`for one line test name pattern in the middle test name with cutted tail and cutted highlighted pattern 1`] = `"<dim>should </>nam...</>"`;
+exports[`for one line test name pattern in the middle test name with cutted tail and cutted highlighted pattern 1`] = `"<dim>should </></>nam...</>"`;
 
-exports[`for one line test name pattern in the middle test name with cutted tail and highlighted pattern 1`] = `"<dim>should </>name</><dim> the functi..."`;
+exports[`for one line test name pattern in the middle test name with cutted tail and highlighted pattern 1`] = `"<dim>should </></>name</><dim> the functi...</>"`;
 
-exports[`for one line test name pattern in the middle test name with highlighted cutted 1`] = `"<dim>sho</>...</>"`;
+exports[`for one line test name pattern in the middle test name with highlighted cutted 1`] = `"<dim>sho</></>...</>"`;
 
-exports[`for one line test name pattern in the middle test name with highlighted pattern returns 1`] = `"<dim>should </>name</><dim> the function you attach"`;
+exports[`for one line test name pattern in the middle test name with highlighted pattern returns 1`] = `"<dim>should </></>name</><dim> the function you attach</>"`;
 
-exports[`for one line test name pattern in the tail returns test name with cutted tail and cutted highlighted pattern 1`] = `"<dim>should name the function you </>a...</>"`;
+exports[`for one line test name pattern in the tail returns test name with cutted tail and cutted highlighted pattern 1`] = `"<dim>should name the function you </></>a...</>"`;
 
-exports[`for one line test name pattern in the tail returns test name with highlighted cutted 1`] = `"<dim>sho</>...</>"`;
+exports[`for one line test name pattern in the tail returns test name with highlighted cutted 1`] = `"<dim>sho</></>...</>"`;
 
-exports[`for one line test name pattern in the tail returns test name with highlighted pattern 1`] = `"<dim>should name the function you </>attach</>"`;
+exports[`for one line test name pattern in the tail returns test name with highlighted pattern 1`] = `"<dim>should name the function you </></>attach</>"`;
 
 exports[`for one line test name with pattern in the head returns test name with cutted tail and cutted highlighted pattern 1`] = `"</>shoul...</>"`;
 
-exports[`for one line test name with pattern in the head returns test name with cutted tail and highlighted pattern 1`] = `"</>should</><dim> name the function yo..."`;
+exports[`for one line test name with pattern in the head returns test name with cutted tail and highlighted pattern 1`] = `"</>should</><dim> name the function yo...</>"`;
 
-exports[`for one line test name with pattern in the head returns test name with highlighted pattern 1`] = `"</>should</><dim> name the function you attach"`;
+exports[`for one line test name with pattern in the head returns test name with highlighted pattern 1`] = `"</>should</><dim> name the function you attach</>"`;

--- a/packages/jest-cli/src/reporters/__tests__/__snapshots__/get_snapshot_status.test.js.snap
+++ b/packages/jest-cli/src/reporters/__tests__/__snapshots__/get_snapshot_status.test.js.snap
@@ -2,20 +2,20 @@
 
 exports[`Retrieves the snapshot status 1`] = `
 Array [
-  "<bold><green> › 1 snapshot</> written.",
-  "<bold><green> › 1 snapshot</> updated.",
-  "<bold><red> › 1 obsolete snapshot</> found.",
-  "<bold><red> › 1 snapshot test</> failed.",
+  "<bold><green> › 1 snapshot</></> written.",
+  "<bold><green> › 1 snapshot</></> updated.",
+  "<bold><red> › 1 obsolete snapshot</></> found.",
+  "<bold><red> › 1 snapshot test</></> failed.",
 ]
 `;
 
 exports[`Retrieves the snapshot status after a snapshot update 1`] = `
 Array [
-  "<bold><green> › 2 snapshots</> written.",
-  "<bold><green> › 2 snapshots</> updated.",
-  "<bold><red> › 2 obsolete snapshots</> removed.",
-  "<bold><red> › Obsolete snapshot file</> removed.",
-  "<bold><red> › 2 snapshot tests</> failed.",
+  "<bold><green> › 2 snapshots</></> written.",
+  "<bold><green> › 2 snapshots</></> updated.",
+  "<bold><red> › 2 obsolete snapshots</></> removed.",
+  "<bold><red> › Obsolete snapshot file</></> removed.",
+  "<bold><red> › 2 snapshot tests</></> failed.",
 ]
 `;
 

--- a/packages/jest-cli/src/reporters/__tests__/__snapshots__/get_snapshot_summary.test.js.snap
+++ b/packages/jest-cli/src/reporters/__tests__/__snapshots__/get_snapshot_summary.test.js.snap
@@ -2,39 +2,39 @@
 
 exports[`creates a snapshot summary 1`] = `
 Array [
-  "<bold>Snapshot Summary",
-  "<bold><green> › 1 snapshot</> written in 1 test suite.",
-  "<bold><red> › 1 snapshot test</> failed in 1 test suite. <dim>Inspect your code changes or press --u to update them.",
-  "<bold><green> › 1 snapshot</> updated in 1 test suite.",
-  "<bold><red> › 1 obsolete snapshot file</> found, press --u to remove it.",
-  "<bold><red> › 1 obsolete snapshot</> found, press --u to remove it.",
+  "<bold>Snapshot Summary</>",
+  "<bold><green> › 1 snapshot</></> written in 1 test suite.",
+  "<bold><red> › 1 snapshot test</></> failed in 1 test suite. <dim>Inspect your code changes or press --u to update them.</>",
+  "<bold><green> › 1 snapshot</></> updated in 1 test suite.",
+  "<bold><red> › 1 obsolete snapshot file</></> found, press --u to remove it.",
+  "<bold><red> › 1 obsolete snapshot</></> found, press --u to remove it.",
 ]
 `;
 
 exports[`creates a snapshot summary after an update 1`] = `
 Array [
-  "<bold>Snapshot Summary",
-  "<bold><green> › 1 snapshot</> written in 1 test suite.",
-  "<bold><red> › 1 snapshot test</> failed in 1 test suite. <dim>Inspect your code changes or press --u to update them.",
-  "<bold><green> › 1 snapshot</> updated in 1 test suite.",
-  "<bold><red> › 1 obsolete snapshot file</> removed.",
-  "<bold><red> › 1 obsolete snapshot</> removed.",
+  "<bold>Snapshot Summary</>",
+  "<bold><green> › 1 snapshot</></> written in 1 test suite.",
+  "<bold><red> › 1 snapshot test</></> failed in 1 test suite. <dim>Inspect your code changes or press --u to update them.</>",
+  "<bold><green> › 1 snapshot</></> updated in 1 test suite.",
+  "<bold><red> › 1 obsolete snapshot file</></> removed.",
+  "<bold><red> › 1 obsolete snapshot</></> removed.",
 ]
 `;
 
 exports[`creates a snapshot summary with multiple snapshot being written/updated 1`] = `
 Array [
-  "<bold>Snapshot Summary",
-  "<bold><green> › 2 snapshots</> written in 2 test suites.",
-  "<bold><red> › 2 snapshot tests</> failed in 2 test suites. <dim>Inspect your code changes or press --u to update them.",
-  "<bold><green> › 2 snapshots</> updated in 2 test suites.",
-  "<bold><red> › 2 obsolete snapshot files</> found, press --u to remove them..",
-  "<bold><red> › 2 obsolete snapshots</> found, press --u to remove them.",
+  "<bold>Snapshot Summary</>",
+  "<bold><green> › 2 snapshots</></> written in 2 test suites.",
+  "<bold><red> › 2 snapshot tests</></> failed in 2 test suites. <dim>Inspect your code changes or press --u to update them.</>",
+  "<bold><green> › 2 snapshots</></> updated in 2 test suites.",
+  "<bold><red> › 2 obsolete snapshot files</></> found, press --u to remove them..",
+  "<bold><red> › 2 obsolete snapshots</></> found, press --u to remove them.",
 ]
 `;
 
 exports[`returns nothing if there are no updates 1`] = `
 Array [
-  "<bold>Snapshot Summary",
+  "<bold>Snapshot Summary</>",
 ]
 `;

--- a/packages/jest-cli/src/reporters/__tests__/__snapshots__/utils.test.js.snap
+++ b/packages/jest-cli/src/reporters/__tests__/__snapshots__/utils.test.js.snap
@@ -1,14 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`trimAndFormatPath() does not trim anything 1`] = `"<dim>1234567890/1234567890/<bold>1234.js"`;
+exports[`trimAndFormatPath() does not trim anything 1`] = `"<dim>1234567890/1234567890/</><bold>1234.js</>"`;
 
-exports[`trimAndFormatPath() split at the path.sep index 1`] = `"<dim>.../<bold>1234.js"`;
+exports[`trimAndFormatPath() split at the path.sep index 1`] = `"<dim>.../</><bold>1234.js</>"`;
 
-exports[`trimAndFormatPath() trims dirname (longer line width) 1`] = `"<dim>...890/1234567890/<bold>1234.js"`;
+exports[`trimAndFormatPath() trims dirname (longer line width) 1`] = `"<dim>...890/1234567890/</><bold>1234.js</>"`;
 
-exports[`trimAndFormatPath() trims dirname 1`] = `"<dim>...234567890/<bold>1234.js"`;
+exports[`trimAndFormatPath() trims dirname 1`] = `"<dim>...234567890/</><bold>1234.js</>"`;
 
-exports[`trimAndFormatPath() trims dirname and basename 1`] = `"<bold>...1234.js"`;
+exports[`trimAndFormatPath() trims dirname and basename 1`] = `"<bold>...1234.js</>"`;
 
 exports[`wrapAnsiString() returns the string unaltered if given a terminal width of zero 1`] = `"This string shouldn't cause you any trouble"`;
 
@@ -16,8 +16,8 @@ exports[`wrapAnsiString() returns the string unaltered if given a terminal width
 
 exports[`wrapAnsiString() wraps a long string containing ansi chars 1`] = `
 "abcde <red><bold>red-
-bold</> 12344
-56<dim>bcd 123t
+bold</></> 12344
+56<dim>bcd</> 123t
 tttttththt
 hththththt
 hththththt
@@ -26,7 +26,7 @@ hthththtet
 etetetette
 tetetetete
 tetete<bold>stnh
-snthsnthss
+snthsnth</>ss
 ot"
 `;
 

--- a/packages/jest-config/src/__tests__/__snapshots__/normalize.test.js.snap
+++ b/packages/jest-config/src/__tests__/__snapshots__/normalize.test.js.snap
@@ -1,58 +1,58 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Upgrade help logs a warning when \`scriptPreprocessor\` and/or \`preprocessorIgnorePatterns\` are used 1`] = `
-"<bold><bold>●<bold> Deprecation Warning:</>
-</>
-  Option <bold>\\"preprocessorIgnorePatterns\\" was replaced by <bold>\\"transformIgnorePatterns\\", which support multiple preprocessors.</>
-</>
-  Jest now treats your current configuration as:</>
-  {</>
-    <bold>\\"transformIgnorePatterns\\": <bold>[\\"bar/baz\\", \\"qux/quux\\"]</>
-  }</>
-</>
-  Please update your configuration.</>
-</>
-  <bold>Configuration Documentation:</>
-  https://facebook.github.io/jest/docs/configuration.html</>
-</>"
+"yellow<bold><bold>●<bold> Deprecation Warning</>:</>
+yellow</>
+yellow  Option <bold>\\"preprocessorIgnorePatterns\\"</> was replaced by <bold>\\"transformIgnorePatterns\\"</>, which support multiple preprocessors.</>
+yellow</>
+yellow  Jest now treats your current configuration as:</>
+yellow  {</>
+yellow    <bold>\\"transformIgnorePatterns\\"</>: <bold>[\\"bar/baz\\", \\"qux/quux\\"]</></>
+yellow  }</>
+yellow</>
+yellow  Please update your configuration.</>
+yellow</>
+yellow  <bold>Configuration Documentation:</></>
+yellow  https://facebook.github.io/jest/docs/configuration.html</>
+yellow</>"
 `;
 
 exports[`preset throws when preset not found 1`] = `
-"<red><bold><bold>● <bold>Validation Error:</>
+"<red><bold><bold>● <bold>Validation Error</>:</>
 <red></>
-<red>  Preset <bold>doesnt-exist not found.</>
+<red>  Preset <bold>doesnt-exist</> not found.</>
 <red></>
-<red>  <bold>Configuration Documentation:</>
+<red>  <bold>Configuration Documentation:</></>
 <red>  https://facebook.github.io/jest/docs/configuration.html</>
 <red></>"
 `;
 
 exports[`rootDir throws if the options is missing a rootDir property 1`] = `
-"<red><bold><bold>● <bold>Validation Error:</>
+"<red><bold><bold>● <bold>Validation Error</>:</>
 <red></>
-<red>  Configuration option <bold>rootDir must be specified.</>
+<red>  Configuration option <bold>rootDir</> must be specified.</>
 <red></>
-<red>  <bold>Configuration Documentation:</>
+<red>  <bold>Configuration Documentation:</></>
 <red>  https://facebook.github.io/jest/docs/configuration.html</>
 <red></>"
 `;
 
 exports[`testEnvironment throws on invalid environment names 1`] = `
-"<red><bold><bold>● <bold>Validation Error:</>
+"<red><bold><bold>● <bold>Validation Error</>:</>
 <red></>
-<red>  Test environment <bold>phantom cannot be found. Make sure the <bold>testEnvironment configuration option points to an existing node module.</>
+<red>  Test environment <bold>phantom</> cannot be found. Make sure the <bold>testEnvironment</> configuration option points to an existing node module.</>
 <red></>
-<red>  <bold>Configuration Documentation:</>
+<red>  <bold>Configuration Documentation:</></>
 <red>  https://facebook.github.io/jest/docs/configuration.html</>
 <red></>"
 `;
 
 exports[`testMatch throws if testRegex and testMatch are both specified 1`] = `
-"<red><bold><bold>● <bold>Validation Error:</>
+"<red><bold><bold>● <bold>Validation Error</>:</>
 <red></>
-<red>  Configuration options <bold>testMatch and <bold>testRegex cannot be used together.</>
+<red>  Configuration options <bold>testMatch</> and <bold>testRegex</> cannot be used together.</>
 <red></>
-<red>  <bold>Configuration Documentation:</>
+<red>  <bold>Configuration Documentation:</></>
 <red>  https://facebook.github.io/jest/docs/configuration.html</>
 <red></>"
 `;

--- a/packages/jest-config/src/__tests__/__snapshots__/normalize.test.js.snap
+++ b/packages/jest-config/src/__tests__/__snapshots__/normalize.test.js.snap
@@ -1,20 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Upgrade help logs a warning when \`scriptPreprocessor\` and/or \`preprocessorIgnorePatterns\` are used 1`] = `
-"yellow<bold><bold>●<bold> Deprecation Warning</>:</>
-yellow</>
-yellow  Option <bold>\\"preprocessorIgnorePatterns\\"</> was replaced by <bold>\\"transformIgnorePatterns\\"</>, which support multiple preprocessors.</>
-yellow</>
-yellow  Jest now treats your current configuration as:</>
-yellow  {</>
-yellow    <bold>\\"transformIgnorePatterns\\"</>: <bold>[\\"bar/baz\\", \\"qux/quux\\"]</></>
-yellow  }</>
-yellow</>
-yellow  Please update your configuration.</>
-yellow</>
-yellow  <bold>Configuration Documentation:</></>
-yellow  https://facebook.github.io/jest/docs/configuration.html</>
-yellow</>"
+"<yellow><bold><bold>●<bold> Deprecation Warning</>:</>
+<yellow></>
+<yellow>  Option <bold>\\"preprocessorIgnorePatterns\\"</> was replaced by <bold>\\"transformIgnorePatterns\\"</>, which support multiple preprocessors.</>
+<yellow></>
+<yellow>  Jest now treats your current configuration as:</>
+<yellow>  {</>
+<yellow>    <bold>\\"transformIgnorePatterns\\"</>: <bold>[\\"bar/baz\\", \\"qux/quux\\"]</></>
+<yellow>  }</>
+<yellow></>
+<yellow>  Please update your configuration.</>
+<yellow></>
+<yellow>  <bold>Configuration Documentation:</></>
+<yellow>  https://facebook.github.io/jest/docs/configuration.html</>
+<yellow></>"
 `;
 
 exports[`preset throws when preset not found 1`] = `

--- a/packages/jest-diff/src/__tests__/__snapshots__/diff.test.js.snap
+++ b/packages/jest-diff/src/__tests__/__snapshots__/diff.test.js.snap
@@ -70,7 +70,7 @@ exports[`collapses big diffs to patch format 1`] = `
 "<green>- Expected</>
 <red>+ Received</>
 
-yellow@@ -6,9 +6,9 @@</>
+<yellow>@@ -6,9 +6,9 @@</>
 <dim>      4,</>
 <dim>      5,</>
 <dim>      6,</>
@@ -103,7 +103,7 @@ exports[`context number of lines: -1 (5 default) 1`] = `
 "<green>- Expected</>
 <red>+ Received</>
 
-yellow@@ -6,9 +6,9 @@</>
+<yellow>@@ -6,9 +6,9 @@</>
 <dim>      4,</>
 <dim>      5,</>
 <dim>      6,</>
@@ -120,9 +120,9 @@ exports[`context number of lines: 0  1`] = `
 "<green>- Expected</>
 <red>+ Received</>
 
-yellow@@ -11,0 +11,1 @@</>
+<yellow>@@ -11,0 +11,1 @@</>
 <red>+     10,</>
-yellow@@ -12,1 +13,0 @@</>
+<yellow>@@ -12,1 +13,0 @@</>
 <green>-     10,</>"
 `;
 
@@ -130,7 +130,7 @@ exports[`context number of lines: 1  1`] = `
 "<green>- Expected</>
 <red>+ Received</>
 
-yellow@@ -10,4 +10,4 @@</>
+<yellow>@@ -10,4 +10,4 @@</>
 <dim>      8,</>
 <red>+     10,</>
 <dim>      9,</>
@@ -142,7 +142,7 @@ exports[`context number of lines: 2  1`] = `
 "<green>- Expected</>
 <red>+ Received</>
 
-yellow@@ -9,6 +9,6 @@</>
+<yellow>@@ -9,6 +9,6 @@</>
 <dim>      7,</>
 <dim>      8,</>
 <red>+     10,</>
@@ -156,7 +156,7 @@ exports[`context number of lines: null (5 default) 1`] = `
 "<green>- Expected</>
 <red>+ Received</>
 
-yellow@@ -6,9 +6,9 @@</>
+<yellow>@@ -6,9 +6,9 @@</>
 <dim>      4,</>
 <dim>      5,</>
 <dim>      6,</>

--- a/packages/jest-diff/src/__tests__/__snapshots__/diff.test.js.snap
+++ b/packages/jest-diff/src/__tests__/__snapshots__/diff.test.js.snap
@@ -4,7 +4,7 @@ exports[`background color of spaces cyan for inchanged (expanded) 1`] = `
 "<green>- Expected</>
 <red>+ Received</>
 
-<dim>  <div>
+<dim>  <div></>
 <red>+   <p></>
 <cyan>      <span></>
 <cyan>        following string consists of a space:</>
@@ -14,81 +14,81 @@ exports[`background color of spaces cyan for inchanged (expanded) 1`] = `
 <cyan>        line has following space only<bgCyan> </></>
 <cyan>      </span></>
 <red>+   </p></>
-<dim>  </div>"
+<dim>  </div></>"
 `;
 
 exports[`background color of spaces green for removed (expanded) 1`] = `
 "<green>- Expected</>
 <red>+ Received</>
 
-<dim>  <div>
-<dim>    <span>
+<dim>  <div></>
+<dim>    <span></>
 <green>-     following string consists of a space:</>
 <green>-     <bgGreen> </></>
 <green>-     <bgGreen> </>line has preceding space only</>
 <green>-     <bgGreen> </>line has both preceding and following space<bgGreen> </></>
 <green>-     line has following space only<bgGreen> </></>
 <red>+     </>
-<dim>    </span>
-<dim>  </div>"
+<dim>    </span></>
+<dim>  </div></>"
 `;
 
 exports[`background color of spaces no color for unchanged (expanded) 1`] = `
 "<green>- Expected</>
 <red>+ Received</>
 
-<dim>  <div>
+<dim>  <div></>
 <green>-   <span></>
 <red>+   <p></>
-<dim>      following string consists of a space:
-<dim>       
-<dim>       line has preceding space only
-<dim>       line has both preceding and following space 
-<dim>      line has following space only 
+<dim>      following string consists of a space:</>
+<dim>       </>
+<dim>       line has preceding space only</>
+<dim>       line has both preceding and following space </>
+<dim>      line has following space only </>
 <green>-   </span></>
 <red>+   </p></>
-<dim>  </div>"
+<dim>  </div></>"
 `;
 
 exports[`background color of spaces red for added (expanded) 1`] = `
 "<green>- Expected</>
 <red>+ Received</>
 
-<dim>  <div>
-<dim>    <span>
+<dim>  <div></>
+<dim>    <span></>
 <green>-     </>
 <red>+     following string consists of a space:</>
 <red>+     <bgRed> </></>
 <red>+     <bgRed> </>line has preceding space only</>
 <red>+     <bgRed> </>line has both preceding and following space<bgRed> </></>
 <red>+     line has following space only<bgRed> </></>
-<dim>    </span>
-<dim>  </div>"
+<dim>    </span></>
+<dim>  </div></>"
 `;
 
 exports[`collapses big diffs to patch format 1`] = `
 "<green>- Expected</>
 <red>+ Received</>
 
-@@ -6,9 +6,9 @@</>
-<dim>      4,
-<dim>      5,
-<dim>      6,
-<dim>      7,
-<dim>      8,
+yellow@@ -6,9 +6,9 @@</>
+<dim>      4,</>
+<dim>      5,</>
+<dim>      6,</>
+<dim>      7,</>
+<dim>      8,</>
 <red>+     10,</>
-<dim>      9,
+<dim>      9,</>
 <green>-     10,</>
-<dim>    ],
-<dim>  }"
+<dim>    ],</>
+<dim>  }</>"
 `;
 
 exports[`color of text (expanded) 1`] = `
 "<green>- Expected</>
 <red>+ Received</>
 
-<dim>  Object {
-<dim>    \\"searching\\": \\"\\",
+<dim>  Object {</>
+<dim>    \\"searching\\": \\"\\",</>
 <green>-   \\"sorting\\": Object {</>
 <red>+   \\"sorting\\": Array [</>
 <red>+     Object {</>
@@ -96,33 +96,33 @@ exports[`color of text (expanded) 1`] = `
 <cyan>        \\"fieldKey\\": \\"what\\",</>
 <cyan>      },</>
 <red>+   ],</>
-<dim>  }"
+<dim>  }</>"
 `;
 
 exports[`context number of lines: -1 (5 default) 1`] = `
 "<green>- Expected</>
 <red>+ Received</>
 
-@@ -6,9 +6,9 @@</>
-<dim>      4,
-<dim>      5,
-<dim>      6,
-<dim>      7,
-<dim>      8,
+yellow@@ -6,9 +6,9 @@</>
+<dim>      4,</>
+<dim>      5,</>
+<dim>      6,</>
+<dim>      7,</>
+<dim>      8,</>
 <red>+     10,</>
-<dim>      9,
+<dim>      9,</>
 <green>-     10,</>
-<dim>    ],
-<dim>  }"
+<dim>    ],</>
+<dim>  }</>"
 `;
 
 exports[`context number of lines: 0  1`] = `
 "<green>- Expected</>
 <red>+ Received</>
 
-@@ -11,0 +11,1 @@</>
+yellow@@ -11,0 +11,1 @@</>
 <red>+     10,</>
-@@ -12,1 +13,0 @@</>
+yellow@@ -12,1 +13,0 @@</>
 <green>-     10,</>"
 `;
 
@@ -130,57 +130,57 @@ exports[`context number of lines: 1  1`] = `
 "<green>- Expected</>
 <red>+ Received</>
 
-@@ -10,4 +10,4 @@</>
-<dim>      8,
+yellow@@ -10,4 +10,4 @@</>
+<dim>      8,</>
 <red>+     10,</>
-<dim>      9,
+<dim>      9,</>
 <green>-     10,</>
-<dim>    ],"
+<dim>    ],</>"
 `;
 
 exports[`context number of lines: 2  1`] = `
 "<green>- Expected</>
 <red>+ Received</>
 
-@@ -9,6 +9,6 @@</>
-<dim>      7,
-<dim>      8,
+yellow@@ -9,6 +9,6 @@</>
+<dim>      7,</>
+<dim>      8,</>
 <red>+     10,</>
-<dim>      9,
+<dim>      9,</>
 <green>-     10,</>
-<dim>    ],
-<dim>  }"
+<dim>    ],</>
+<dim>  }</>"
 `;
 
 exports[`context number of lines: null (5 default) 1`] = `
 "<green>- Expected</>
 <red>+ Received</>
 
-@@ -6,9 +6,9 @@</>
-<dim>      4,
-<dim>      5,
-<dim>      6,
-<dim>      7,
-<dim>      8,
+yellow@@ -6,9 +6,9 @@</>
+<dim>      4,</>
+<dim>      5,</>
+<dim>      6,</>
+<dim>      7,</>
+<dim>      8,</>
 <red>+     10,</>
-<dim>      9,
+<dim>      9,</>
 <green>-     10,</>
-<dim>    ],
-<dim>  }"
+<dim>    ],</>
+<dim>  }</>"
 `;
 
 exports[`falls back to not call toJSON if objects look identical 1`] = `
-"<dim>Compared values serialize to the same structure.
-<dim>Printing internal object structure without calling \`toJSON\` instead.
+"<dim>Compared values serialize to the same structure.</>
+<dim>Printing internal object structure without calling \`toJSON\` instead.</>
 
 <green>- Expected</>
 <red>+ Received</>
 
-<dim>  Object {
+<dim>  Object {</>
 <green>-   \\"line\\": 1,</>
 <red>+   \\"line\\": 2,</>
-<dim>    \\"toJSON\\": [Function toJSON],
-<dim>  }"
+<dim>    \\"toJSON\\": [Function toJSON],</>
+<dim>  }</>"
 `;
 
-exports[`prints a fallback message if two objects truly look identical 1`] = `"<dim>Compared values have no visual difference."`;
+exports[`prints a fallback message if two objects truly look identical 1`] = `"<dim>Compared values have no visual difference.</>"`;

--- a/packages/jest-jasmine2/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/jest-jasmine2/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`matchers proxies matchers to expect 1`] = `
-"<dim>expect(<red>received</><dim>).toBe(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>)</>
 
 Expected value to be (using ===):
   <green>2</>

--- a/packages/jest-matcher-utils/src/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/jest-matcher-utils/src/__tests__/__snapshots__/index.test.js.snap
@@ -5,7 +5,7 @@ exports[`.stringify() reduces maxDepth if stringifying very large objects 1`] = 
 exports[`.stringify() reduces maxDepth if stringifying very large objects 2`] = `"{\\"a\\": 1, \\"b\\": {\\"0\\": \\"test\\", \\"1\\": \\"test\\", \\"2\\": \\"test\\", \\"3\\": \\"test\\", \\"4\\": \\"test\\", \\"5\\": \\"test\\", \\"6\\": \\"test\\", \\"7\\": \\"test\\", \\"8\\": \\"test\\", \\"9\\": \\"test\\"}}"`;
 
 exports[`.stringify() toJSON errors when comparing two objects 1`] = `
-"<dim>expect(<red>received</><dim>).toEqual(<green>expected</><dim>)
+"<dim>expect(</><red>received</><dim>).toEqual(</><green>expected</><dim>)</>
 
 Expected value to equal:
   <green>{\\"b\\": 1, \\"toJSON\\": [Function toJSON]}</>
@@ -17,9 +17,9 @@ Difference:
 <green>- Expected</>
 <red>+ Received</>
 
-<dim>  Object {
+<dim>  Object {</>
 <green>-   \\"b\\": 1,</>
 <red>+   \\"a\\": 1,</>
-<dim>    \\"toJSON\\": [Function toJSON],
-<dim>  }"
+<dim>    \\"toJSON\\": [Function toJSON],</>
+<dim>  }</>"
 `;

--- a/packages/jest-message-util/src/__tests__/__snapshots__/messages.test.js.snap
+++ b/packages/jest-message-util/src/__tests__/__snapshots__/messages.test.js.snap
@@ -1,18 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.formatExecError() 1`] = `
-"  <bold>● Test suite failed to run
+"  <bold>● </>Test suite failed to run
 
     Whoops!
 "
 `;
 
 exports[`should exclude jasmine from stack trace for Unix paths. 1`] = `
-"<bold><red>  <bold>● <bold>Unix test</>
+"<bold><red>  <bold>● <bold>Unix test</></>
 
       at stack (../jest-jasmine2/build/jasmine-2.4.1.js:1580:17)
-<dim>      
-<dim>      <dim>at Object.addResult (<dim>../jest-jasmine2/build/jasmine-2.4.1.js<dim>:1550:14)<dim>
-<dim>      <dim>at Object.it (<dim>build/__tests__/messages-test.js<dim>:45:41)<dim>
+<dim>      </>
+<dim>      <dim>at Object.addResult (<dim>../jest-jasmine2/build/jasmine-2.4.1.js<dim>:1550:14)<dim></>
+<dim>      <dim>at Object.it (<dim>build/__tests__/messages-test.js<dim>:45:41)<dim></>
 "
 `;

--- a/packages/jest-util/src/__tests__/__snapshots__/validate_cli_options.test.js.snap
+++ b/packages/jest-util/src/__tests__/__snapshots__/validate_cli_options.test.js.snap
@@ -1,22 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`fails for multiple unknown options 1`] = `
-"<red><bold><bold>●<bold> Unrecognized CLI Parameters:</>
+"<red><bold><bold>●<bold> Unrecognized CLI Parameters</>:</>
 <red></>
 <red>  Following options were not recognized:</>
-<red>  <bold>[\\"jest\\", \\"test\\"]</>
+<red>  <bold>[\\"jest\\", \\"test\\"]</></>
 <red></>
-<red>  <bold>CLI Options Documentation:</>
+<red>  <bold>CLI Options Documentation</>:</>
 <red>  http://facebook.github.io/jest/docs/cli.html</>
 <red></>"
 `;
 
 exports[`fails for unknown option 1`] = `
-"<red><bold><bold>●<bold> Unrecognized CLI Parameter:</>
+"<red><bold><bold>●<bold> Unrecognized CLI Parameter</>:</>
 <red></>
-<red>  Unrecognized option <bold>\\"unknown\\".</>
+<red>  Unrecognized option <bold>\\"unknown\\"</>.</>
 <red></>
-<red>  <bold>CLI Options Documentation:</>
+<red>  <bold>CLI Options Documentation</>:</>
 <red>  http://facebook.github.io/jest/docs/cli.html</>
 <red></>"
 `;

--- a/packages/jest-validate/src/__tests__/__snapshots__/validate.test.js.snap
+++ b/packages/jest-validate/src/__tests__/__snapshots__/validate.test.js.snap
@@ -1,25 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`displays warning for deprecated config options 1`] = `
-"yellow<bold><bold>●<bold> Deprecation Warning</>:</>
-yellow</>
-yellow  Option <bold>scriptPreprocessor</> was replaced by <bold>transform</>, which support multiple preprocessors.</>
-yellow</>
-yellow  Jest now treats your current configuration as:</>
-yellow  {</>
-yellow    <bold>\\"transform\\"</>: <bold>{\\".*\\": \\"test\\"}</></>
-yellow  }</>
-yellow</>
-yellow  Please update your configuration.</>
-yellow</>"
+"<yellow><bold><bold>●<bold> Deprecation Warning</>:</>
+<yellow></>
+<yellow>  Option <bold>scriptPreprocessor</> was replaced by <bold>transform</>, which support multiple preprocessors.</>
+<yellow></>
+<yellow>  Jest now treats your current configuration as:</>
+<yellow>  {</>
+<yellow>    <bold>\\"transform\\"</>: <bold>{\\".*\\": \\"test\\"}</></>
+<yellow>  }</>
+<yellow></>
+<yellow>  Please update your configuration.</>
+<yellow></>"
 `;
 
 exports[`displays warning for unknown config options 1`] = `
-"yellow<bold><bold>●<bold> Validation Warning</>:</>
-yellow</>
-yellow  Unknown option <bold>\\"unkwon\\"</> with value <bold>{}</> was found. Did you mean <bold>\\"unknown\\"</>?</>
-yellow  This is probably a typing mistake. Fixing it will remove this message.</>
-yellow</>"
+"<yellow><bold><bold>●<bold> Validation Warning</>:</>
+<yellow></>
+<yellow>  Unknown option <bold>\\"unkwon\\"</> with value <bold>{}</> was found. Did you mean <bold>\\"unknown\\"</>?</>
+<yellow>  This is probably a typing mistake. Fixing it will remove this message.</>
+<yellow></>"
 `;
 
 exports[`pretty prints valid config for Array 1`] = `
@@ -98,18 +98,18 @@ exports[`pretty prints valid config for String 1`] = `
 `;
 
 exports[`works with custom deprecations 1`] = `
-"yellow<bold>My Custom Deprecation Warning</>:</>
-yellow</>
-yellow  Option <bold>scriptPreprocessor</> was replaced by <bold>transform</>, which support multiple preprocessors.</>
-yellow</>
-yellow  Jest now treats your current configuration as:</>
-yellow  {</>
-yellow    <bold>\\"transform\\"</>: <bold>{\\".*\\": \\"test\\"}</></>
-yellow  }</>
-yellow</>
-yellow  Please update your configuration.</>
-yellow</>
-yellowMy custom comment</>"
+"<yellow><bold>My Custom Deprecation Warning</>:</>
+<yellow></>
+<yellow>  Option <bold>scriptPreprocessor</> was replaced by <bold>transform</>, which support multiple preprocessors.</>
+<yellow></>
+<yellow>  Jest now treats your current configuration as:</>
+<yellow>  {</>
+<yellow>    <bold>\\"transform\\"</>: <bold>{\\".*\\": \\"test\\"}</></>
+<yellow>  }</>
+<yellow></>
+<yellow>  Please update your configuration.</>
+<yellow></>
+<yellow>My custom comment</>"
 `;
 
 exports[`works with custom errors 1`] = `
@@ -129,10 +129,10 @@ exports[`works with custom errors 1`] = `
 `;
 
 exports[`works with custom warnings 1`] = `
-"yellow<bold>My Custom Warning</>:</>
-yellow</>
-yellow  Unknown option <bold>\\"unknown\\"</> with value <bold>\\"string\\"</> was found.</>
-yellow  This is probably a typing mistake. Fixing it will remove this message.</>
-yellow</>
-yellowMy custom comment</>"
+"<yellow><bold>My Custom Warning</>:</>
+<yellow></>
+<yellow>  Unknown option <bold>\\"unknown\\"</> with value <bold>\\"string\\"</> was found.</>
+<yellow>  This is probably a typing mistake. Fixing it will remove this message.</>
+<yellow></>
+<yellow>My custom comment</>"
 `;

--- a/packages/jest-validate/src/__tests__/__snapshots__/validate.test.js.snap
+++ b/packages/jest-validate/src/__tests__/__snapshots__/validate.test.js.snap
@@ -1,138 +1,138 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`displays warning for deprecated config options 1`] = `
-"<bold><bold>●<bold> Deprecation Warning:</>
-</>
-  Option <bold>scriptPreprocessor was replaced by <bold>transform, which support multiple preprocessors.</>
-</>
-  Jest now treats your current configuration as:</>
-  {</>
-    <bold>\\"transform\\": <bold>{\\".*\\": \\"test\\"}</>
-  }</>
-</>
-  Please update your configuration.</>
-</>"
+"yellow<bold><bold>●<bold> Deprecation Warning</>:</>
+yellow</>
+yellow  Option <bold>scriptPreprocessor</> was replaced by <bold>transform</>, which support multiple preprocessors.</>
+yellow</>
+yellow  Jest now treats your current configuration as:</>
+yellow  {</>
+yellow    <bold>\\"transform\\"</>: <bold>{\\".*\\": \\"test\\"}</></>
+yellow  }</>
+yellow</>
+yellow  Please update your configuration.</>
+yellow</>"
 `;
 
 exports[`displays warning for unknown config options 1`] = `
-"<bold><bold>●<bold> Validation Warning:</>
-</>
-  Unknown option <bold>\\"unkwon\\" with value <bold>{} was found. Did you mean <bold>\\"unknown\\"?</>
-  This is probably a typing mistake. Fixing it will remove this message.</>
-</>"
+"yellow<bold><bold>●<bold> Validation Warning</>:</>
+yellow</>
+yellow  Unknown option <bold>\\"unkwon\\"</> with value <bold>{}</> was found. Did you mean <bold>\\"unknown\\"</>?</>
+yellow  This is probably a typing mistake. Fixing it will remove this message.</>
+yellow</>"
 `;
 
 exports[`pretty prints valid config for Array 1`] = `
-"<red><bold><bold>●<bold> Validation Error:</>
+"<red><bold><bold>●<bold> Validation Error</>:</>
 <red></>
-<red>  Option <bold>\\"coverageReporters\\" must be of type:</>
-<red>    <bold><green>array<red></>
+<red>  Option <bold>\\"coverageReporters\\"</> must be of type:</>
+<red>    <bold><green>array<red></></>
 <red>  but instead received:</>
-<red>    <bold><red>object<red></>
+<red>    <bold><red>object<red></></>
 <red></>
 <red>  Example:</>
 <red>  {</>
-<red>    <bold>\\"coverageReporters\\": <bold>[\\"json\\", \\"text\\", \\"lcov\\", \\"clover\\"]</>
+<red>    <bold>\\"coverageReporters\\"</>: <bold>[\\"json\\", \\"text\\", \\"lcov\\", \\"clover\\"]</></>
 <red>  }</>
 <red></>"
 `;
 
 exports[`pretty prints valid config for Boolean 1`] = `
-"<red><bold><bold>●<bold> Validation Error:</>
+"<red><bold><bold>●<bold> Validation Error</>:</>
 <red></>
-<red>  Option <bold>\\"automock\\" must be of type:</>
-<red>    <bold><green>boolean<red></>
+<red>  Option <bold>\\"automock\\"</> must be of type:</>
+<red>    <bold><green>boolean<red></></>
 <red>  but instead received:</>
-<red>    <bold><red>array<red></>
+<red>    <bold><red>array<red></></>
 <red></>
 <red>  Example:</>
 <red>  {</>
-<red>    <bold>\\"automock\\": <bold>false</>
+<red>    <bold>\\"automock\\"</>: <bold>false</></>
 <red>  }</>
 <red></>"
 `;
 
 exports[`pretty prints valid config for Function 1`] = `
-"<red><bold><bold>●<bold> Validation Error:</>
+"<red><bold><bold>●<bold> Validation Error</>:</>
 <red></>
-<red>  Option <bold>\\"fn\\" must be of type:</>
-<red>    <bold><green>function<red></>
+<red>  Option <bold>\\"fn\\"</> must be of type:</>
+<red>    <bold><green>function<red></></>
 <red>  but instead received:</>
-<red>    <bold><red>string<red></>
+<red>    <bold><red>string<red></></>
 <red></>
 <red>  Example:</>
 <red>  {</>
-<red>    <bold>\\"fn\\": <bold>(config, option, deprecatedOptions) => true</>
+<red>    <bold>\\"fn\\"</>: <bold>(config, option, deprecatedOptions) => true</></>
 <red>  }</>
 <red></>"
 `;
 
 exports[`pretty prints valid config for Object 1`] = `
-"<red><bold><bold>●<bold> Validation Error:</>
+"<red><bold><bold>●<bold> Validation Error</>:</>
 <red></>
-<red>  Option <bold>\\"haste\\" must be of type:</>
-<red>    <bold><green>object<red></>
+<red>  Option <bold>\\"haste\\"</> must be of type:</>
+<red>    <bold><green>object<red></></>
 <red>  but instead received:</>
-<red>    <bold><red>number<red></>
+<red>    <bold><red>number<red></></>
 <red></>
 <red>  Example:</>
 <red>  {</>
-<red>    <bold>\\"haste\\": <bold>{\\"providesModuleNodeModules\\": [\\"react\\", \\"react-native\\"]}</>
+<red>    <bold>\\"haste\\"</>: <bold>{\\"providesModuleNodeModules\\": [\\"react\\", \\"react-native\\"]}</></>
 <red>  }</>
 <red></>"
 `;
 
 exports[`pretty prints valid config for String 1`] = `
-"<red><bold><bold>●<bold> Validation Error:</>
+"<red><bold><bold>●<bold> Validation Error</>:</>
 <red></>
-<red>  Option <bold>\\"preset\\" must be of type:</>
-<red>    <bold><green>string<red></>
+<red>  Option <bold>\\"preset\\"</> must be of type:</>
+<red>    <bold><green>string<red></></>
 <red>  but instead received:</>
-<red>    <bold><red>number<red></>
+<red>    <bold><red>number<red></></>
 <red></>
 <red>  Example:</>
 <red>  {</>
-<red>    <bold>\\"preset\\": <bold>\\"react-native\\"</>
+<red>    <bold>\\"preset\\"</>: <bold>\\"react-native\\"</></>
 <red>  }</>
 <red></>"
 `;
 
 exports[`works with custom deprecations 1`] = `
-"<bold>My Custom Deprecation Warning:</>
-</>
-  Option <bold>scriptPreprocessor was replaced by <bold>transform, which support multiple preprocessors.</>
-</>
-  Jest now treats your current configuration as:</>
-  {</>
-    <bold>\\"transform\\": <bold>{\\".*\\": \\"test\\"}</>
-  }</>
-</>
-  Please update your configuration.</>
-</>
-My custom comment</>"
+"yellow<bold>My Custom Deprecation Warning</>:</>
+yellow</>
+yellow  Option <bold>scriptPreprocessor</> was replaced by <bold>transform</>, which support multiple preprocessors.</>
+yellow</>
+yellow  Jest now treats your current configuration as:</>
+yellow  {</>
+yellow    <bold>\\"transform\\"</>: <bold>{\\".*\\": \\"test\\"}</></>
+yellow  }</>
+yellow</>
+yellow  Please update your configuration.</>
+yellow</>
+yellowMy custom comment</>"
 `;
 
 exports[`works with custom errors 1`] = `
-"<red><bold>My Custom Error:</>
+"<red><bold>My Custom Error</>:</>
 <red></>
-<red>  Option <bold>\\"test\\" must be of type:</>
-<red>    <bold><green>array<red></>
+<red>  Option <bold>\\"test\\"</> must be of type:</>
+<red>    <bold><green>array<red></></>
 <red>  but instead received:</>
-<red>    <bold><red>string<red></>
+<red>    <bold><red>string<red></></>
 <red></>
 <red>  Example:</>
 <red>  {</>
-<red>    <bold>\\"test\\": <bold>[1, 2]</>
+<red>    <bold>\\"test\\"</>: <bold>[1, 2]</></>
 <red>  }</>
 <red></>
 <red>My custom comment</>"
 `;
 
 exports[`works with custom warnings 1`] = `
-"<bold>My Custom Warning:</>
-</>
-  Unknown option <bold>\\"unknown\\" with value <bold>\\"string\\" was found.</>
-  This is probably a typing mistake. Fixing it will remove this message.</>
-</>
-My custom comment</>"
+"yellow<bold>My Custom Warning</>:</>
+yellow</>
+yellow  Unknown option <bold>\\"unknown\\"</> with value <bold>\\"string\\"</> was found.</>
+yellow  This is probably a typing mistake. Fixing it will remove this message.</>
+yellow</>
+yellowMy custom comment</>"
 `;

--- a/packages/pretty-format/src/__tests__/__snapshots__/react.test.js.snap
+++ b/packages/pretty-format/src/__tests__/__snapshots__/react.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`ReactElement plugin highlights syntax 1`] = `
 "<cyan><Mouse</>
-  yellowprop</>=<green>{
+  <yellow>prop</>=<green>{
     <cyan><div></>
       </>mouse</>
       <cyan><span></>
@@ -15,7 +15,7 @@ exports[`ReactElement plugin highlights syntax 1`] = `
 
 exports[`ReactElement plugin highlights syntax with color from theme option 1`] = `
 "<cyan><Mouse</>
-  yellowstyle</>=<red>\\"color:red\\"</>
+  <yellow>style</>=<red>\\"color:red\\"</>
 <cyan>></>
   </>Hello, Mouse!</>
 <cyan></Mouse></>"
@@ -23,7 +23,7 @@ exports[`ReactElement plugin highlights syntax with color from theme option 1`] 
 
 exports[`ReactTestComponent plugin highlights syntax 1`] = `
 "<cyan><Mouse</>
-  yellowprop</>=<green>{
+  <yellow>prop</>=<green>{
     <cyan><div></>
       </>mouse</>
       <cyan><span></>
@@ -36,7 +36,7 @@ exports[`ReactTestComponent plugin highlights syntax 1`] = `
 
 exports[`ReactTestComponent plugin highlights syntax with color from theme option 1`] = `
 "<cyan><Mouse</>
-  yellowstyle</>=<red>\\"color:red\\"</>
+  <yellow>style</>=<red>\\"color:red\\"</>
 <cyan>></>
   </>Hello, Mouse!</>
 <cyan></Mouse></>"

--- a/packages/pretty-format/src/__tests__/__snapshots__/react.test.js.snap
+++ b/packages/pretty-format/src/__tests__/__snapshots__/react.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`ReactElement plugin highlights syntax 1`] = `
 "<cyan><Mouse</>
-  prop</>=<green>{
+  yellowprop</>=<green>{
     <cyan><div></>
       </>mouse</>
       <cyan><span></>
@@ -15,7 +15,7 @@ exports[`ReactElement plugin highlights syntax 1`] = `
 
 exports[`ReactElement plugin highlights syntax with color from theme option 1`] = `
 "<cyan><Mouse</>
-  style</>=<red>\\"color:red\\"</>
+  yellowstyle</>=<red>\\"color:red\\"</>
 <cyan>></>
   </>Hello, Mouse!</>
 <cyan></Mouse></>"
@@ -23,7 +23,7 @@ exports[`ReactElement plugin highlights syntax with color from theme option 1`] 
 
 exports[`ReactTestComponent plugin highlights syntax 1`] = `
 "<cyan><Mouse</>
-  prop</>=<green>{
+  yellowprop</>=<green>{
     <cyan><div></>
       </>mouse</>
       <cyan><span></>
@@ -36,7 +36,7 @@ exports[`ReactTestComponent plugin highlights syntax 1`] = `
 
 exports[`ReactTestComponent plugin highlights syntax with color from theme option 1`] = `
 "<cyan><Mouse</>
-  style</>=<red>\\"color:red\\"</>
+  yellowstyle</>=<red>\\"color:red\\"</>
 <cyan>></>
   </>Hello, Mouse!</>
 <cyan></Mouse></>"

--- a/packages/pretty-format/src/plugins/convert_ansi.js
+++ b/packages/pretty-format/src/plugins/convert_ansi.js
@@ -18,9 +18,15 @@ const toHumanReadableAnsi = text => {
       case style.red.close:
       case style.green.close:
       case style.cyan.close:
+      case style.gray.close:
+      case style.white.close:
+      case style.yellow.close:
       case style.bgRed.close:
       case style.bgGreen.close:
       case style.bgCyan.close:
+      case style.inverse.close:
+      case style.dim.close:
+      case style.bold.close:
       case style.reset.open:
       case style.reset.close:
         return '</>';
@@ -30,12 +36,20 @@ const toHumanReadableAnsi = text => {
         return '<green>';
       case style.cyan.open:
         return '<cyan>';
+      case style.gray.open:
+        return '<gray';
+      case style.white.open:
+        return '<white>';
+      case style.yellow.open:
+        return 'yellow';
       case style.bgRed.open:
         return '<bgRed>';
       case style.bgGreen.open:
         return '<bgGreen>';
       case style.bgCyan.open:
         return '<bgCyan>';
+      case style.inverse.open:
+        return '<inverse>';
       case style.dim.open:
         return '<dim>';
       case style.bold.open:

--- a/packages/pretty-format/src/plugins/convert_ansi.js
+++ b/packages/pretty-format/src/plugins/convert_ansi.js
@@ -37,11 +37,11 @@ const toHumanReadableAnsi = text => {
       case style.cyan.open:
         return '<cyan>';
       case style.gray.open:
-        return '<gray';
+        return '<gray>';
       case style.white.open:
         return '<white>';
       case style.yellow.open:
-        return 'yellow';
+        return '<yellow>';
       case style.bgRed.open:
         return '<bgRed>';
       case style.bgGreen.open:


### PR DESCRIPTION
**Summary**

* Because colors share same `close` sequences, some closing tags didn’t match opening tags
* Without `close` sequences (which are shared, by the way) for `bold` and `dim` their opening tags didn’t match closing tags

The mismatches confused me a bit in the beginning.
Adding the missing `cyan` theme color confused us when we reviewed #3429 

Additional colors:
* `gray` (also known as bright black) in default theme for `pretty-format` plugin
* `yellow` in default theme for `pretty-format` plugin also in `jest-diff`
* `white` in `jest-cli`

Additional modifier:
* `inverse` is used in `jest-cli` also will be useful in `jest-diff` and `jest-matcher-utils`

Additional `close` sequences:
* `bold`
* `dim`

**Residue**: While reviewing the snapshots, a few mismatched `</>` confused me because `reset.open` and `reset.close` share the same escape sequence.

**Test plan**

**Ouch**: 511 snapshots updated in 15 test suites