### PR TITLE
Allow for imports when path includes a query string. Fixes #4181

### DIFF
--- a/packages/jest-resolve/src/__tests__/resolve.test.js
+++ b/packages/jest-resolve/src/__tests__/resolve.test.js
@@ -78,6 +78,36 @@ describe('findNodeModule', () => {
       paths: (nodePaths || []).concat(['/something']),
     });
   });
+
+  it('removes query strings from path before resolving', () => {
+    const cwd = process.cwd();
+    const resolvedCwd = fs.realpathSync(cwd) || cwd;
+    const nodePaths = process.env.NODE_PATH
+      ? process.env.NODE_PATH
+          .split(path.delimiter)
+          .filter(Boolean)
+          .map(p => path.resolve(resolvedCwd, p))
+      : null;
+
+    const newPath = Resolver.findNodeModule('./test.jpg?sizes=300', {
+      basedir: '/',
+      browser: true,
+      extensions: ['js'],
+      moduleDirectory: ['node_modules'],
+      paths: ['/something'],
+      resolver: require.resolve('../__mocks__/userResolver'),
+    });
+
+    expect(newPath).toBe('module');
+    expect(userResolver.mock.calls[0][0]).toBe('./test.jpg');
+    expect(userResolver.mock.calls[0][1]).toEqual({
+      basedir: '/',
+      browser: true,
+      extensions: ['js'],
+      moduleDirectory: ['node_modules'],
+      paths: (nodePaths || []).concat(['/something']),
+    });
+  });
 });
 
 describe('getMockModule', () => {

--- a/packages/jest-resolve/src/index.js
+++ b/packages/jest-resolve/src/index.js
@@ -95,9 +95,10 @@ class Resolver {
         require(options.resolver)
       : defaultResolver;
     const paths = options.paths;
+    const pathWithoutQuery = path.replace(/\?.*$/, '');
 
     try {
-      return resolver(path, {
+      return resolver(pathWithoutQuery, {
         basedir: options.basedir,
         browser: options.browser,
         extensions: options.extensions,


### PR DESCRIPTION
Fixes #4181

**Summary**

Jest fails to apply a transform to a file if the import path includes query parameters. A detailed description can be found [here](https://github.com/facebook/jest/issues/4181).

**Test plan**
Added tests to ensure this is functioning properly.
