### PR TITLE
Fix watchAll not running tests on save

### DIFF
--- a/packages/jest-cli/src/cli/index.js
+++ b/packages/jest-cli/src/cli/index.js
@@ -270,7 +270,7 @@ const _buildContextsAndHasteMaps = async (
         console: new Console(outputStream, outputStream),
         maxWorkers: globalConfig.maxWorkers,
         resetCache: !config.cache,
-        watch: globalConfig.watch,
+        watch: globalConfig.watch || globalConfig.watchAll,
         watchman: globalConfig.watchman,
       });
       hasteMapInstances[index] = hasteMapInstance;


### PR DESCRIPTION
**Summary**

This fixes #4448.  The change in #4254 caused `createHasteMap` to get false for watch.  To not have to change watch logic elsewhere, I just added an or condition when we pass watch to the `createHasteMap` call.

**Test plan**

I'm open to options on testing this.  It doesn't appear it was tested before and not really sure the best way for catch this in a test.