### PR TITLE
Simplify highlight for leading and trailing spaces in jest-diff

### DIFF
--- a/packages/jest-diff/src/__tests__/__snapshots__/diff.test.js.snap
+++ b/packages/jest-diff/src/__tests__/__snapshots__/diff.test.js.snap
@@ -8,10 +8,10 @@ exports[`background color of spaces cyan for inchanged (expanded) 1`] = `
 <red>+   <p></>
 <cyan>      <span></>
 <cyan>        following string consists of a space:</>
-<cyan>        <bgCyan> </></>
-<cyan>        <bgCyan> </>line has preceding space only</>
-<cyan>        <bgCyan> </>line has both preceding and following space<bgCyan> </></>
-<cyan>        line has following space only<bgCyan> </></>
+<cyan>        <inverse> </></>
+<cyan>        <inverse> </>line has preceding space only</>
+<cyan>        <inverse> </>line has both preceding and following space<inverse> </></>
+<cyan>        line has following space only<inverse> </></>
 <cyan>      </span></>
 <red>+   </p></>
 <dim>  </div></>"
@@ -24,29 +24,12 @@ exports[`background color of spaces green for removed (expanded) 1`] = `
 <dim>  <div></>
 <dim>    <span></>
 <green>-     following string consists of a space:</>
-<green>-     <bgGreen> </></>
-<green>-     <bgGreen> </>line has preceding space only</>
-<green>-     <bgGreen> </>line has both preceding and following space<bgGreen> </></>
-<green>-     line has following space only<bgGreen> </></>
+<green>-     <inverse> </></>
+<green>-     <inverse> </>line has preceding space only</>
+<green>-     <inverse> </>line has both preceding and following space<inverse> </></>
+<green>-     line has following space only<inverse> </></>
 <red>+     </>
 <dim>    </span></>
-<dim>  </div></>"
-`;
-
-exports[`background color of spaces no color for unchanged (expanded) 1`] = `
-"<green>- Expected</>
-<red>+ Received</>
-
-<dim>  <div></>
-<green>-   <span></>
-<red>+   <p></>
-<dim>      following string consists of a space:</>
-<dim>       </>
-<dim>       line has preceding space only</>
-<dim>       line has both preceding and following space </>
-<dim>      line has following space only </>
-<green>-   </span></>
-<red>+   </p></>
 <dim>  </div></>"
 `;
 
@@ -58,11 +41,28 @@ exports[`background color of spaces red for added (expanded) 1`] = `
 <dim>    <span></>
 <green>-     </>
 <red>+     following string consists of a space:</>
-<red>+     <bgRed> </></>
-<red>+     <bgRed> </>line has preceding space only</>
-<red>+     <bgRed> </>line has both preceding and following space<bgRed> </></>
-<red>+     line has following space only<bgRed> </></>
+<red>+     <inverse> </></>
+<red>+     <inverse> </>line has preceding space only</>
+<red>+     <inverse> </>line has both preceding and following space<inverse> </></>
+<red>+     line has following space only<inverse> </></>
 <dim>    </span></>
+<dim>  </div></>"
+`;
+
+exports[`background color of spaces yellow for unchanged (expanded) 1`] = `
+"<green>- Expected</>
+<red>+ Received</>
+
+<dim>  <div></>
+<green>-   <span></>
+<red>+   <p></>
+<dim>      following string consists of a space:</>
+<dim>      <bgYellow> </></>
+<dim>      <bgYellow> </>line has preceding space only</>
+<dim>      <bgYellow> </>line has both preceding and following space<bgYellow> </></>
+<dim>      line has following space only<bgYellow> </></>
+<green>-   </span></>
+<red>+   </p></>
 <dim>  </div></>"
 `;
 

--- a/packages/jest-diff/src/__tests__/diff.test.js
+++ b/packages/jest-diff/src/__tests__/diff.test.js
@@ -741,15 +741,6 @@ describe('background color of spaces', () => {
       expect(diff(examples, baseline, unexpanded)).toBe(received);
     });
   });
-  describe('no color for unchanged', () => {
-    const received = diff(examples, unchanged, expanded);
-    test('(expanded)', () => {
-      expect(received).toMatchSnapshot();
-    });
-    test('(unexpanded)', () => {
-      expect(diff(examples, unchanged, unexpanded)).toBe(received);
-    });
-  });
   describe('red for added', () => {
     const received = diff(baseline, examples, expanded);
     test('(expanded)', () => {
@@ -757,6 +748,15 @@ describe('background color of spaces', () => {
     });
     test('(unexpanded)', () => {
       expect(diff(baseline, examples, unexpanded)).toBe(received);
+    });
+  });
+  describe('yellow for unchanged', () => {
+    const received = diff(examples, unchanged, expanded);
+    test('(expanded)', () => {
+      expect(received).toMatchSnapshot();
+    });
+    test('(unexpanded)', () => {
+      expect(diff(examples, unchanged, unexpanded)).toBe(received);
     });
   });
 });

--- a/packages/jest-diff/src/diff_strings.js
+++ b/packages/jest-diff/src/diff_strings.js
@@ -64,23 +64,19 @@ const getColor = (digit: DIFF_DIGIT, onlyIndentationChanged?: boolean) => {
 // Do NOT color leading or trailing spaces if original lines are equal:
 
 // Background color for leading or trailing spaces.
-const getBgColor = (digit: DIFF_DIGIT) => {
-  if (digit === -1) {
-    return chalk.bgGreen; // removed
-  }
-  if (digit === 1) {
-    return chalk.bgRed; // added
-  }
-  return chalk.bgCyan; // only indentation changed
-};
+const getBgColor = (digit: DIFF_DIGIT, onlyIndentationChanged?: boolean) =>
+  digit === 0 && !onlyIndentationChanged ? chalk.bgYellow : chalk.inverse;
 
 // ONLY trailing if expected value is snapshot or multiline string.
-const highlightTrailingWhitespace = (line: string, bgColor: Function): string =>
+const highlightTrailingSpaces = (line: string, bgColor: Function): string =>
   line.replace(/\s+$/, bgColor('$&'));
 
 // BOTH leading AND trailing if expected value is data structure.
-const highlightWhitespace = (line: string, bgColor: Function): string =>
-  highlightTrailingWhitespace(line.replace(/^\s+/, bgColor('$&')), bgColor);
+const highlightLeadingTrailingSpaces = (
+  line: string,
+  bgColor: Function,
+): string =>
+  highlightTrailingSpaces(line.replace(/^\s+/, bgColor('$&')), bgColor);
 
 const getAnnotation = (options: ?DiffOptions): string =>
   chalk.green('- ' + ((options && options.aAnnotation) || 'Expected')) +
@@ -119,19 +115,16 @@ const formatLine = (
         ' ' +
         // Prepend indentation spaces from original to compared line.
         lineOriginal.slice(0, lineOriginal.length - lineCompared.length) +
-        (digit !== 0 || onlyIndentationChanged
-          ? highlightWhitespace(lineCompared, getBgColor(digit))
-          : lineCompared),
+        highlightLeadingTrailingSpaces(
+          lineCompared,
+          getBgColor(digit, onlyIndentationChanged),
+        ),
     );
   }
 
   // Format compared line when expected is snapshot or multiline string.
   return getColor(digit)(
-    char +
-      ' ' +
-      (digit !== 0
-        ? highlightTrailingWhitespace(lineCompared, getBgColor(digit))
-        : lineCompared),
+    char + ' ' + highlightTrailingSpaces(lineCompared, getBgColor(digit)),
   );
 };
 

--- a/packages/pretty-format/src/plugins/convert_ansi.js
+++ b/packages/pretty-format/src/plugins/convert_ansi.js
@@ -23,7 +23,7 @@ const toHumanReadableAnsi = text => {
       case style.yellow.close:
       case style.bgRed.close:
       case style.bgGreen.close:
-      case style.bgCyan.close:
+      case style.bgYellow.close:
       case style.inverse.close:
       case style.dim.close:
       case style.bold.close:
@@ -46,8 +46,8 @@ const toHumanReadableAnsi = text => {
         return '<bgRed>';
       case style.bgGreen.open:
         return '<bgGreen>';
-      case style.bgCyan.open:
-        return '<bgCyan>';
+      case style.bgYellow.open:
+        return '<bgYellow>';
       case style.inverse.open:
         return '<inverse>';
       case style.dim.open:


### PR DESCRIPTION
**Summary**

* Replace explicit background colors with `inverse` for removed, added, in-changed lines.
* Mid-course change: add `bgYellow` for unchanged lines which didn’t have highlight. The dim stack trace and gray lines caused a perceptual conflict instead of a contrast. Also as Scott said, gray was not light enough. I think yellow looks better on Windows. It looks like pollen on the following illustrations from MacOS Terminal. Also better not to churn snapshots of diffs.

Removed lines are **bgGreen** at left and **inverse** of green at right, that is the same:
<img width="800" alt="deleted" src="https://user-images.githubusercontent.com/11862657/30943387-b12d36b8-a3be-11e7-8260-0446316456fa.png">

Added lines are **bgRed** at left and **inverse** of red at right, that is the same:
<img width="800" alt="inserted" src="https://user-images.githubusercontent.com/11862657/30943397-c5cd1d72-a3be-11e7-8f7d-c68d84ceb7d7.png">

Indentation-changed lines are **bgCyan** at left and **inverse** of cyan at right, that is the same:
<img width="800" alt="inchanged" src="https://user-images.githubusercontent.com/11862657/30943402-ccc6231c-a3be-11e7-9e45-9995732a213b.png">

Unchanged lines are unhighlighted at left and **bgYellow** at right:
<img width="800" alt="unchanged" src="https://user-images.githubusercontent.com/11862657/30943405-d0a26522-a3be-11e7-9449-042d28cb008f.png">

Thank y’all for reviewing incremental improvements even when urgent problems need solutions.

**Next**: similar change in `jest-matcher-utils` but a few things puzzled me in `expect`

**Test plan**

Updated 4 snapshot in 1 test suite (renamed one of them)

P.S. Give my thanks to the Yarn team for improved links so previous PR passed AppVeyor CI