### PR TITLE
jest-runtime: move babel-core to peer dependencies

### DIFF
--- a/packages/jest-runtime/package.json
+++ b/packages/jest-runtime/package.json
@@ -8,7 +8,6 @@
   "license": "MIT",
   "main": "build/index.js",
   "dependencies": {
-    "babel-core": "^6.0.0",
     "babel-jest": "^21.2.0",
     "babel-plugin-istanbul": "^4.0.0",
     "chalk": "^2.0.1",
@@ -27,8 +26,12 @@
     "yargs": "^9.0.0"
   },
   "devDependencies": {
+    "babel-core": "^6.0.0",
     "jest-environment-jsdom": "^21.2.1",
     "jest-environment-node": "^21.2.1"
+  },
+  "peerDependencies": {
+    "babel-core": "^6.0.0 || ^7.0.0-alpha || ^7.0.0-beta || ^7.0.0"
   },
   "bin": {
     "jest-runtime": "./bin/jest-runtime.js"


### PR DESCRIPTION
**Summary**

It's still not possible to use Jest with Babel 7 due to some kind of a conflict between Babel versions because `jest-runtime` requires `babel-core@^6`. Moving `babel-core` to peer dependencies such as in `babel-jest` resolves the problem.

**Test plan**

Existing tests should pass.
