### PR TITLE
chore(vscode): ease flow usage

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,17 +1,18 @@
 {
-  "jest.pathToJest": "yarn jest --",
   "editor.rulers": [80],
   "files.exclude": {
     "**/.git": true,
     "**/node_modules": true,
     "**/build": true
   },
+  "editor.formatOnSave": true,
+  "flow.useNPMPackagedFlow": true,
+  "javascript.validate.enable": false,
+  "jest.pathToJest": "yarn jest --",
+  "prettier.eslintIntegration": true,
   "prettier.parser": "flow",
   "prettier.printWidth": 80,
-  "prettier.singleQuote": true,
-  "prettier.trailingComma": "all",
   "prettier.semi": true,
-  "editor.formatOnSave": true,
-  "prettier.eslintIntegration": true,
-  "javascript.validate.enable": false
+  "prettier.singleQuote": true,
+  "prettier.trailingComma": "all"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,5 +12,6 @@
   "prettier.trailingComma": "all",
   "prettier.semi": true,
   "editor.formatOnSave": true,
-  "prettier.eslintIntegration": true
+  "prettier.eslintIntegration": true,
+  "javascript.validate.enable": false
 }


### PR DESCRIPTION
**Summary**

![image](https://user-images.githubusercontent.com/123822/31045644-b041eee8-a5e8-11e7-932e-f9a659fe6747.png)

Following https://github.com/flowtype/flow-for-vscode#setup they recommend setting `"javascript.validate.enable": false` in workspace settings, otherwise I get errors like "... can only be used in a .ts file".

As I am new to flow and vscode I might be wrong, let me know vscode users contributing to Jest how it works for you today?

**Test plan**

None, it's an editor setting
