### PR TITLE
[jest-docblock] add strip

### DIFF
--- a/packages/jest-docblock/README.md
+++ b/packages/jest-docblock/README.md
@@ -57,10 +57,13 @@ const code = `
  }
 `;
 
-const { extract, parse, parseWithComments, print } = require("jest-docblock");
+const { extract, strip, parse, parseWithComments, print } = require("jest-docblock");
 
 const docblock = extract(code);
 console.log(docblock); // "/**\n * Everything is awesome!\n * \n * @everything is:awesome\n * @flow\n */"
+
+const stripped = strip(code);
+console.log(stripped); // "export const everything = Object.create(null);\n export default function isAwesome(something) {\n return something === everything;\n }"
 
 const pragmas = parse(docblock);
 console.log(pragmas); // { everything: "is:awesome", flow: "" }
@@ -75,6 +78,9 @@ console.log(print({pragmas, comments: "hi!"})) // /**\n * hi!\n *\n * @everythin
 
 ### `extract(contents: string): string`
 Extracts a docblock from some file contents. Returns the docblock contained in `contents`. If `contents` did not contain a docblock, it will return the empty string (`""`).
+
+### `strip(contents: string): string`
+Strips the top docblock from a file and return the result. If a file does not have a docblock at the top, then return the file unchanged.
 
 ### `parse(docblock: string): {[key: string]: string}`
 Parses the pragmas in a docblock string into an object whose keys are the pragma tags and whose values are the arguments to those pragmas.

--- a/packages/jest-docblock/src/__tests__/index.test.js
+++ b/packages/jest-docblock/src/__tests__/index.test.js
@@ -282,7 +282,7 @@ describe('docblock', () => {
 
   it('strips the docblock out of a file that contains a top docblock', () => {
     const code = '/**\n * foo\n * bar\n*/\nthe rest';
-    expect(docblock.strip(code)).toEqual('the rest');
+    expect(docblock.strip(code)).toEqual('\nthe rest');
   });
 
   it('returns a file unchanged if there is no top docblock to strip', () => {

--- a/packages/jest-docblock/src/__tests__/index.test.js
+++ b/packages/jest-docblock/src/__tests__/index.test.js
@@ -280,6 +280,16 @@ describe('docblock', () => {
     });
   });
 
+  it('strips the docblock out of a file that contains a top docblock', () => {
+    const code = '/**\n * foo\n * bar\n*/\nthe rest';
+    expect(docblock.strip(code)).toEqual('the rest');
+  });
+
+  it('returns a file unchanged if there is no top docblock to strip', () => {
+    const code = 'someCodeAtTheTop();\n/** docblock */';
+    expect(docblock.strip(code)).toEqual(code);
+  });
+
   it('prints docblocks with no pragmas as empty string', () => {
     const pragmas = {};
     expect(docblock.print({pragmas})).toEqual('');

--- a/packages/jest-docblock/src/index.js
+++ b/packages/jest-docblock/src/index.js
@@ -28,8 +28,7 @@ export function extract(contents: string): string {
 
 export function strip(contents: string) {
   const match = contents.match(docblockRe);
-  const docblockLength = match && match[0] ? match[0].length : 0;
-  return contents.substring(docblockLength);
+  return match && match[0] ? contents.substring(match[0].length) : contents;
 }
 
 export function parse(docblock: string): {[key: string]: string} {

--- a/packages/jest-docblock/src/index.js
+++ b/packages/jest-docblock/src/index.js
@@ -28,7 +28,7 @@ export function extract(contents: string): string {
 
 export function strip(contents: string) {
   const match = contents.match(docblockRe);
-  const docblockLength = match && match[0] ? match[0].length : 0;
+  const docblockLength = match && match[0] ? match[0].length + 1 : 0;
   return contents.substring(docblockLength);
 }
 

--- a/packages/jest-docblock/src/index.js
+++ b/packages/jest-docblock/src/index.js
@@ -26,6 +26,12 @@ export function extract(contents: string): string {
   return match ? match[0].replace(ltrimRe, '') || '' : '';
 }
 
+export function strip(contents: string) {
+  const match = contents.match(docblockRe);
+  const docblockLength = match && match[0] ? match[0].length : 0;
+  return contents.substring(docblockLength);
+}
+
 export function parse(docblock: string): {[key: string]: string} {
   return parseWithComments(docblock).pragmas;
 }

--- a/packages/jest-docblock/src/index.js
+++ b/packages/jest-docblock/src/index.js
@@ -28,7 +28,7 @@ export function extract(contents: string): string {
 
 export function strip(contents: string) {
   const match = contents.match(docblockRe);
-  const docblockLength = match && match[0] ? match[0].length + 1 : 0;
+  const docblockLength = match && match[0] ? match[0].length : 0;
   return contents.substring(docblockLength);
 }
 


### PR DESCRIPTION
**Summary**
Prettier is implementing a `--insertPragma` flag to insert a `@format` pragma to the top of files.
During implementation it became apparent that a `stripDocblock` function would be helpful for replacing docblocks.  E.g.:

```js
const newFileContents = newDocblock + '\n' + stripDocblock(oldFileContents);
```

This PR introduces a new function, `strip(contents: string)` for returning the whole file _except_ the top docblock.

**Test Plan**
Basic unit tests