### PR TITLE
[jest-docblock] Preserve leading whitespace in docblock comments

### DIFF
--- a/packages/jest-docblock/src/__tests__/index.test.js
+++ b/packages/jest-docblock/src/__tests__/index.test.js
@@ -245,6 +245,15 @@ describe('docblock', () => {
     });
   });
 
+  it('preserves leading whitespace in multiline comments from docblock', () => {
+    const code =
+      '/**' + os.EOL + ' *  hello' + os.EOL + ' *   world' + os.EOL + ' */';
+
+    expect(docblock.parseWithComments(code).comments).toEqual(
+      ' hello' + os.EOL + '  world',
+    );
+  });
+
   it('extracts comments from beginning and end of docblock', () => {
     const code =
       '/**' +


### PR DESCRIPTION
Follow-up to #4517.

**Summary**

I noticed the regular expressions used to trim down the docblock were trimming out some useful information: leading whitespace.

```js
/**
 * foo()
 *   .bar()
 */
```

`require('jest-docblock').parseWithComments(...).comments` was being producing

```js
foo()
.bar()
```

This PR preserves all **but the first, if present** space on each line, such that the output is:

```js
foo()
  .bar()
```


**Test plan**

Unit tests added and passing.