### PR TITLE
Call chalk.inverse for trailing spaces in jest-matcher-utils

### DIFF
--- a/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -229,6 +229,17 @@ Received:
   <red>\\"abc\\"</>"
 `;
 
+exports[`.toBe() fails for: "with 
+trailing space" and "without trailing space" 1`] = `
+"<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>)</>
+
+Expected value to be (using ===):
+  <green>\\"without trailing space\\"</>
+Received:
+  <red>\\"with<inverse> </></>
+<red>trailing space\\"</>"
+`;
+
 exports[`.toBe() fails for: [] and [] 1`] = `
 "<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>)</>
 

--- a/packages/expect/src/__tests__/matchers.test.js
+++ b/packages/expect/src/__tests__/matchers.test.js
@@ -120,6 +120,7 @@ describe('.toBe()', () => {
     [{a: 1}, {a: 1}],
     [{a: 1}, {a: 5}],
     ['abc', 'cde'],
+    ['with \ntrailing space', 'without trailing space'],
     [[], []],
     [null, undefined],
   ].forEach(([a, b]) => {

--- a/packages/expect/src/to_throw_matchers.js
+++ b/packages/expect/src/to_throw_matchers.js
@@ -13,7 +13,6 @@ import getType from 'jest-get-type';
 import {escapeStrForRegex} from 'jest-regex-util';
 import {formatStackTrace, separateMessageFromStack} from 'jest-message-util';
 import {
-  RECEIVED_BG,
   RECEIVED_COLOR,
   highlightTrailingWhitespace,
   matcherHint,
@@ -173,7 +172,7 @@ const printActualErrorMessage = error => {
       `Instead, it threw:\n` +
       RECEIVED_COLOR(
         '  ' +
-          highlightTrailingWhitespace(message, RECEIVED_BG) +
+          highlightTrailingWhitespace(message) +
           formatStackTrace(
             stack,
             {

--- a/packages/jest-matcher-utils/src/index.js
+++ b/packages/jest-matcher-utils/src/index.js
@@ -27,9 +27,7 @@ const PLUGINS = [
 ];
 
 export const EXPECTED_COLOR = chalk.green;
-export const EXPECTED_BG = chalk.bgGreen;
 export const RECEIVED_COLOR = chalk.red;
-export const RECEIVED_BG = chalk.bgRed;
 
 const NUMBERS = [
   'zero',
@@ -76,15 +74,13 @@ export const stringify = (object: any, maxDepth?: number = 10): string => {
     : result;
 };
 
-export const highlightTrailingWhitespace = (
-  text: string,
-  bgColor: Function,
-): string => text.replace(/\s+$/gm, bgColor('$&'));
+export const highlightTrailingWhitespace = (text: string): string =>
+  text.replace(/\s+$/gm, chalk.inverse('$&'));
 
 export const printReceived = (object: any) =>
-  highlightTrailingWhitespace(RECEIVED_COLOR(stringify(object)), RECEIVED_BG);
+  RECEIVED_COLOR(highlightTrailingWhitespace(stringify(object)));
 export const printExpected = (value: any) =>
-  highlightTrailingWhitespace(EXPECTED_COLOR(stringify(value)), EXPECTED_BG);
+  EXPECTED_COLOR(highlightTrailingWhitespace(stringify(value)));
 
 export const printWithType = (
   name: string,


### PR DESCRIPTION
**Summary**

Reduce package coupling and eliminate potential inconsistency between fg and bg colors.

Make `printExpected` and `printReceived` follow example of `printActualErrorMessage` to color trailing spaces within the string **before** coloring the entire string, because closing escape sequence for foreground color preceding newline causes regex for background color not to match.

**Test plan**

* Added a snapshot (with wrong result at first) of improved behavior in `matchers.test.js`
* Attached screen shot to confirm no regression in `to-throw-matchers.js`
<img width="800" alt="2017-10-01 to-throw-error" src="https://user-images.githubusercontent.com/11862657/31058219-0633d822-a6be-11e7-8a7b-0c2f04094565.png">

P.S. Again to Yarn team: we who are about to test (package interdependencies) salute you!