### PR TITLE
Support rootDir tag in testEnvironment

### DIFF
--- a/packages/jest-config/src/__tests__/normalize.test.js
+++ b/packages/jest-config/src/__tests__/normalize.test.js
@@ -583,6 +583,9 @@ describe('testEnvironment', () => {
       if (name === 'jest-environment-jsdom') {
         return 'node_modules/jest-environment-jsdom';
       }
+      if (name.startsWith('/root')) {
+        return name;
+      }
       return findNodeModule(name);
     });
   });
@@ -611,6 +614,18 @@ describe('testEnvironment', () => {
         {},
       ),
     ).toThrowErrorMatchingSnapshot();
+  });
+
+  it('works with rootDir', () => {
+    const {options} = normalize(
+      {
+        rootDir: '/root',
+        testEnvironment: '<rootDir>/testEnvironment.js',
+      },
+      {},
+    );
+
+    expect(options.testEnvironment).toEqual('/root/testEnvironment.js');
   });
 });
 

--- a/packages/jest-config/src/utils.js
+++ b/packages/jest-config/src/utils.js
@@ -100,7 +100,7 @@ export const _replaceRootDirTags = (rootDir: string, config: any) => {
  * 1. looks for <name> relative to Jest.
  */
 export const getTestEnvironment = (config: Object) => {
-  const env = config.testEnvironment;
+  const env = _replaceRootDirInPath(config.rootDir, config.testEnvironment);
   let module = Resolver.findNodeModule(`jest-environment-${env}`, {
     basedir: config.rootDir,
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5837,7 +5837,7 @@ typedarray@^0.0.6, typedarray@~0.0.5:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@^2.5.3:
+typescript@^2.2.2, typescript@^2.5.3:
   version "2.5.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.5.3.tgz#df3dcdc38f3beb800d4bc322646b04a3f6ca7f0d"
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

`rootDir` was not replaced in custom `testEnvironment`, so it was harder to use custom unpublished environments. This PR fixes it.

**Test plan**

Added a test.
