### PR TITLE
Increase coverage in jest-diff

### DIFF
--- a/packages/jest-diff/src/__tests__/__snapshots__/diff.test.js.snap
+++ b/packages/jest-diff/src/__tests__/__snapshots__/diff.test.js.snap
@@ -169,7 +169,18 @@ exports[`context number of lines: null (5 default) 1`] = `
 <dim>  }</>"
 `;
 
-exports[`falls back to not call toJSON if objects look identical 1`] = `
+exports[`falls back to not call toJSON if it throws and then objects have differences 1`] = `
+"<green>- Expected</>
+<red>+ Received</>
+
+<dim>  Object {</>
+<green>-   \\"line\\": 1,</>
+<red>+   \\"line\\": 2,</>
+<dim>    \\"toJSON\\": [Function toJSON],</>
+<dim>  }</>"
+`;
+
+exports[`falls back to not call toJSON if serialization has no differences but then objects have differences 1`] = `
 "<dim>Compared values serialize to the same structure.</>
 <dim>Printing internal object structure without calling \`toJSON\` instead.</>
 
@@ -197,5 +208,3 @@ exports[`highlight only the last in odd length of leading spaces (expanded) 1`] 
 <red>+ }, {});</>
 <dim>  </pre></>"
 `;
-
-exports[`prints a fallback message if two objects truly look identical 1`] = `"<dim>Compared values have no visual difference.</>"`;

--- a/packages/jest-diff/src/__tests__/diff.test.js
+++ b/packages/jest-diff/src/__tests__/diff.test.js
@@ -93,7 +93,7 @@ test('oneline strings', () => {
 describe('falls back to not call toJSON', () => {
   describe('if serialization has no differences', () => {
     const toJSON = function toJSON() {
-      return 'apple';
+      return 'it’s all the same to me';
     };
 
     test('but then objects have differences', () => {
@@ -109,7 +109,7 @@ describe('falls back to not call toJSON', () => {
   });
   describe('if it throws', () => {
     const toJSON = function toJSON() {
-      throw new Error('');
+      throw new Error('catch me if you can');
     };
 
     test('and then objects have differences', () => {

--- a/packages/jest-diff/src/__tests__/diff.test.js
+++ b/packages/jest-diff/src/__tests__/diff.test.js
@@ -10,16 +10,14 @@
 const stripAnsi = require('strip-ansi');
 const diff = require('../');
 
+const NO_DIFF_MESSAGE = 'Compared values have no visual difference.';
+
 const stripped = (a, b, options) => stripAnsi(diff(a, b, options));
 
 const unexpanded = {expand: false};
 const expanded = {expand: true};
 
 const elementSymbol = Symbol.for('react.element');
-
-const toJSON = function toJSON() {
-  return 'apple';
-};
 
 describe('different types', () => {
   [
@@ -58,10 +56,13 @@ describe('no visual difference', () => {
   ].forEach(values => {
     test(`'${JSON.stringify(values[0])}' and '${JSON.stringify(
       values[1],
-    )}'`, () => {
-      expect(stripped(values[0], values[1])).toBe(
-        'Compared values have no visual difference.',
-      );
+    )}' (unexpanded)`, () => {
+      expect(stripped(values[0], values[1], unexpanded)).toBe(NO_DIFF_MESSAGE);
+    });
+    test(`'${JSON.stringify(values[0])}' and '${JSON.stringify(
+      values[1],
+    )}' (expanded)`, () => {
+      expect(stripped(values[0], values[1], expanded)).toBe(NO_DIFF_MESSAGE);
     });
   });
 
@@ -69,41 +70,59 @@ describe('no visual difference', () => {
     const arg1 = new Map([[1, 'foo'], [2, 'bar']]);
     const arg2 = new Map([[2, 'bar'], [1, 'foo']]);
 
-    expect(stripped(arg1, arg2)).toBe(
-      'Compared values have no visual difference.',
-    );
+    expect(stripped(arg1, arg2)).toBe(NO_DIFF_MESSAGE);
   });
 
   test('Set value order should be irrelevant', () => {
     const arg1 = new Set([1, 2]);
     const arg2 = new Set([2, 1]);
 
-    expect(stripped(arg1, arg2)).toBe(
-      'Compared values have no visual difference.',
-    );
+    expect(stripped(arg1, arg2)).toBe(NO_DIFF_MESSAGE);
   });
 });
 
 test('oneline strings', () => {
   // oneline strings don't produce a diff currently.
   expect(diff('ab', 'aa')).toBe(null);
-  expect(diff('a', 'a')).toMatch(/no visual difference/);
   expect(diff('123456789', '234567890')).toBe(null);
   // if either string is oneline
   expect(diff('oneline', 'multi\nline')).toBe(null);
   expect(diff('multi\nline', 'oneline')).toBe(null);
 });
 
-test('falls back to not call toJSON if objects look identical', () => {
-  const a = {line: 1, toJSON};
-  const b = {line: 2, toJSON};
-  expect(diff(a, b)).toMatchSnapshot();
-});
+describe('falls back to not call toJSON', () => {
+  describe('if serialization has no differences', () => {
+    const toJSON = function toJSON() {
+      return 'apple';
+    };
 
-test('prints a fallback message if two objects truly look identical', () => {
-  const a = {line: 2, toJSON};
-  const b = {line: 2, toJSON};
-  expect(diff(a, b)).toMatchSnapshot();
+    test('but then objects have differences', () => {
+      const a = {line: 1, toJSON};
+      const b = {line: 2, toJSON};
+      expect(diff(a, b)).toMatchSnapshot();
+    });
+    test('and then objects have no differences', () => {
+      const a = {line: 2, toJSON};
+      const b = {line: 2, toJSON};
+      expect(stripped(a, b)).toBe(NO_DIFF_MESSAGE);
+    });
+  });
+  describe('if it throws', () => {
+    const toJSON = function toJSON() {
+      throw new Error('');
+    };
+
+    test('and then objects have differences', () => {
+      const a = {line: 1, toJSON};
+      const b = {line: 2, toJSON};
+      expect(diff(a, b)).toMatchSnapshot();
+    });
+    test('and then objects have no differences', () => {
+      const a = {line: 2, toJSON};
+      const b = {line: 2, toJSON};
+      expect(stripped(a, b)).toBe(NO_DIFF_MESSAGE);
+    });
+  });
 });
 
 // Some of the following assertions seem complex, but compare to alternatives:


### PR DESCRIPTION
**Summary**

Before designing new tests for char diff:
* cover last uncovered line in `diff_strings.js`
* cover one additional line in `index.js` but leave 6 related to asymmetric matcher

In `diff.test.js`
* Factored out `const NO_DIFF_MESSAGE = 'Compared values have no visual difference.';`
* Moved `toJSON` function from module scope to `describe` block where it is used

**Test plan**

* Added **unexpanded** tests under **no visual difference** to hit `if (hunks.length === 0) { return null; }` in `diff_strings.js`
* Deleted one test under **oneline strings** that is redundant with **no visual difference**
* Added tests under refactored **falls back to not call toJSON** to hit `catch (e) { hasThrown = true; }` in `index.js`