### PR TITLE
Check if the maxWorkers has a value and raises an exception otherwise

### DIFF
--- a/packages/jest-cli/src/__tests__/cli/args.test.js
+++ b/packages/jest-cli/src/__tests__/cli/args.test.js
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+import type {Argv} from 'types/Argv';
+import {check} from '../../cli/args';
+
+describe('check', () => {
+  it('returns true if the arguments are valid', () => {
+    const argv: Argv = {};
+    expect(check(argv)).toBe(true);
+  });
+
+  it('raises an exception if runInBand and maxWorkers are both specified', () => {
+    const argv: Argv = {maxWorkers: 2, runInBand: true};
+    expect(() => check(argv)).toThrow();
+  });
+
+  it('raises an exception if onlyChanged and watchAll are both specified', () => {
+    const argv: Argv = {onlyChanged: true, watchAll: true};
+    expect(() => check(argv)).toThrow();
+  });
+
+  it('raises an exception if findRelatedTests is specified with no file paths', () => {
+    const argv: Argv = {findRelatedTests: true};
+    expect(() => check(argv)).toThrow();
+  });
+
+  it('raises an exception if maxWorkers is specified with no number', () => {
+    const argv: Argv = {maxWorkers: undefined};
+    expect(() => check(argv)).toThrow();
+  });
+
+  it('raises an exception if config is not a valid JSON string', () => {
+    const argv: Argv = {config: 'x:1'};
+    expect(() => check(argv)).toThrow();
+  });
+});

--- a/packages/jest-cli/src/__tests__/cli/args.test.js
+++ b/packages/jest-cli/src/__tests__/cli/args.test.js
@@ -41,7 +41,7 @@ describe('check', () => {
   it('raises an exception if maxWorkers is specified with no number', () => {
     const argv: Argv = {maxWorkers: undefined};
     expect(() => check(argv)).toThrow(
-      'The --maxWorkers option requires a number to be specified',
+      'The --maxWorkers (-w) option requires a number to be specified',
     );
   });
 

--- a/packages/jest-cli/src/__tests__/cli/args.test.js
+++ b/packages/jest-cli/src/__tests__/cli/args.test.js
@@ -19,26 +19,36 @@ describe('check', () => {
 
   it('raises an exception if runInBand and maxWorkers are both specified', () => {
     const argv: Argv = {maxWorkers: 2, runInBand: true};
-    expect(() => check(argv)).toThrow();
+    expect(() => check(argv)).toThrow(
+      'Both --runInBand and --maxWorkers were specified',
+    );
   });
 
   it('raises an exception if onlyChanged and watchAll are both specified', () => {
     const argv: Argv = {onlyChanged: true, watchAll: true};
-    expect(() => check(argv)).toThrow();
+    expect(() => check(argv)).toThrow(
+      'Both --onlyChanged and --watchAll were specified',
+    );
   });
 
   it('raises an exception if findRelatedTests is specified with no file paths', () => {
-    const argv: Argv = {findRelatedTests: true};
-    expect(() => check(argv)).toThrow();
+    const argv: Argv = {_: [], findRelatedTests: true};
+    expect(() => check(argv)).toThrow(
+      'The --findRelatedTests option requires file paths to be specified',
+    );
   });
 
   it('raises an exception if maxWorkers is specified with no number', () => {
     const argv: Argv = {maxWorkers: undefined};
-    expect(() => check(argv)).toThrow();
+    expect(() => check(argv)).toThrow(
+      'The --maxWorkers option requires a number to be specified',
+    );
   });
 
   it('raises an exception if config is not a valid JSON string', () => {
     const argv: Argv = {config: 'x:1'};
-    expect(() => check(argv)).toThrow();
+    expect(() => check(argv)).toThrow(
+      'The --config option requires a JSON string literal, or a file path with a .js or .json extension',
+    );
   });
 });

--- a/packages/jest-cli/src/cli/args.js
+++ b/packages/jest-cli/src/cli/args.js
@@ -38,9 +38,9 @@ export const check = (argv: Argv) => {
 
   if (argv.hasOwnProperty('maxWorkers') && argv.maxWorkers === undefined) {
     throw new Error(
-      'The --maxWorkers option requires a number to be specified.\n' +
+      'The --maxWorkers (-w) option requires a number to be specified.\n' +
         'Example usage: jest --maxWorkers 2\n' +
-        'Or did you mean --watch ?',
+        'Or did you mean --watch?',
     );
   }
 

--- a/packages/jest-cli/src/cli/args.js
+++ b/packages/jest-cli/src/cli/args.js
@@ -36,6 +36,14 @@ export const check = (argv: Argv) => {
     );
   }
 
+  if (argv.hasOwnProperty('maxWorkers') && argv.maxWorkers === undefined) {
+    throw new Error(
+      'The --maxWorkers option requires a number to be specified.\n' +
+        'Example usage: jest --maxWorkers 2\n' +
+        'Or did you mean --watch ?',
+    );
+  }
+
   if (
     argv.config &&
     !isJSONString(argv.config) &&


### PR DESCRIPTION
**Summary**

In this commit, we are adding a new validation in the `check` method of the `jest-cli` package, so we raise an exception if the user tries to run Jest with undefined `maxWorkers`

Some users were confusing `-w` as an alias to `--watch`, but in fact, `-w` is an alias to `--maxWorkers`. This change will also make this distinction clearer.

Also, a new test file was added to the `jest-cli` package, in order to unit test the `check` method.

Fixes issue #4577 

**Test plan**

```shell
jest --maxWorkers
# raises an exception
jest --maxWorkers 2
# runs the tests
```

![jest](https://user-images.githubusercontent.com/208312/31118294-3a694878-a82d-11e7-9d5f-fccc50909d06.gif)
