### PR TITLE
Fix #4588 error text inline function

### DIFF
--- a/packages/babel-plugin-jest-hoist/src/index.js
+++ b/packages/babel-plugin-jest-hoist/src/index.js
@@ -83,7 +83,7 @@ FUNCTIONS.mock = args => {
     const moduleFactory = args[1];
     invariant(
       moduleFactory.isFunction(),
-      'The second argument of `jest.mock` must be a function.',
+      'The second argument of `jest.mock` must be an inline function.',
     );
 
     const ids = new Set();


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Update error message in `babel-plugin-jest-hoist` to specify only inline functions are accepted as a second parameter to `jest.mock` (explicit automock).

We spent some time troubleshooting because it refused to accept any function we gave to it, until I read the code and saw that previously declared functions get seen as "identifiers", only inline/arrow functions are seen as "function".

**Test plan**

Not familiar with test strategy for error messages, if the builds fail I will modify whatever tests assert on that error message.
