### PR TITLE
Add testPath to jest-jasmine2 reporter callbacks

### DIFF
--- a/packages/jest-jasmine2/src/index.js
+++ b/packages/jest-jasmine2/src/index.js
@@ -34,7 +34,9 @@ async function jasmine2(
     testPath,
   );
   const jasmineFactory = runtime.requireInternalModule(JASMINE);
-  const jasmine = jasmineFactory.create();
+  const jasmine = jasmineFactory.create({
+    testPath,
+  });
 
   const env = jasmine.getEnv();
   const jasmineInterface = jasmineFactory.interface(jasmine, env);

--- a/packages/jest-jasmine2/src/jasmine/Env.js
+++ b/packages/jest-jasmine2/src/jasmine/Env.js
@@ -377,6 +377,9 @@ export default function(j$) {
         getSpecName(spec) {
           return getSpecName(spec, suite);
         },
+        getTestPath() {
+          return j$.testPath;
+        },
         onStart: specStarted,
         description,
         queueRunnerFactory,

--- a/packages/jest-jasmine2/src/jasmine/Spec.js
+++ b/packages/jest-jasmine2/src/jasmine/Spec.js
@@ -66,6 +66,7 @@ export default function Spec(attrs: Object) {
     failedExpectations: [],
     passedExpectations: [],
     pendingReason: '',
+    testPath: attrs.getTestPath(),
   };
 }
 

--- a/packages/jest-jasmine2/src/jasmine/jasmine_light.js
+++ b/packages/jest-jasmine2/src/jasmine/jasmine_light.js
@@ -42,8 +42,8 @@ import SpyRegistry from './spy_registry';
 import Suite from './Suite';
 import Timer from './Timer';
 
-export const create = function() {
-  const j$ = {};
+export const create = function(createOptions: Object) {
+  const j$ = Object.assign({}, createOptions);
 
   j$.DEFAULT_TIMEOUT_INTERVAL = 5000;
 


### PR DESCRIPTION
**Summary**

Adds testPath to jest-jasmine2 reporter callbacks.
For jest reporter callbacks such as onTestStart we are provided with the associated file path of the test being reported on. This adds this functionality to jest-jasmine2 reporters.

My personal (and organizational) need for this is that I need a jasmine reporter that is capable of properly uniquely identifying a particular test block. I do this by utilizing both the fullName and the relative file path of the test.

For large projects it is not at all unheard of for fullName (e.g. nested test description + it block description) to not be unique.

Before (specStarted):
```
{
      id: 'spec0',
      description: 'should play',
      fullName: 'playlist should play',
      failedExpectations: [],
      passedExpectations: [],
      pendingReason: ''
}
```

After (specStarted):
```
{
      id: 'spec0',
      description: 'should play',
      fullName: 'playlist should play',
      failedExpectations: [],
      passedExpectations: [],
      pendingReason: '',
      testPath: '/Users/jpalmer/Desktop/test/__tests__/foo.test.js' 
}
```

**Test plan**

Ran all tests

I see there is not much in the way of tests for jasmine reporters. An integration test might be nice in this case at the top level. Let me know if you'd like me to try adding that.