### PR TITLE
Move coverage worker into jest-worker

### DIFF
--- a/packages/jest-runner/package.json
+++ b/packages/jest-runner/package.json
@@ -15,8 +15,7 @@
     "jest-message-util": "^21.2.1",
     "jest-runtime": "^21.2.1",
     "jest-util": "^21.2.1",
-    "pify": "^3.0.0",
-    "throat": "^4.0.0",
-    "worker-farm": "^1.3.1"
+    "jest-worker": "^21.2.1",
+    "throat": "^4.0.0"
   }
 }

--- a/packages/jest-runner/src/__tests__/test_runner.test.js
+++ b/packages/jest-runner/src/__tests__/test_runner.test.js
@@ -11,17 +11,17 @@
 const TestRunner = require('../index');
 const {TestWatcher} = require('jest-cli');
 
-let workerFarmMock;
+let mockWorkerFarm;
 
-jest.mock('worker-farm', () => {
-  const mock = jest.fn(
-    (options, worker) =>
-      (workerFarmMock = jest.fn((data, callback) =>
-        require(worker)(data, callback),
-      )),
-  );
-  mock.end = jest.fn();
-  return mock;
+jest.mock('jest-worker', () => {
+  return jest.fn(worker => {
+    return (mockWorkerFarm = {
+      default: jest.fn((data, callback) => require(worker)(data, callback)),
+      end: jest.fn(),
+      getStderr: jest.fn(),
+      getStdout: jest.fn(),
+    });
+  });
 });
 
 jest.mock('../test_worker', () => {});
@@ -44,15 +44,9 @@ test('injects the rawModuleMap into each worker in watch mode', () => {
       {serial: false},
     )
     .then(() => {
-      expect(workerFarmMock.mock.calls).toEqual([
-        [
-          {config, globalConfig, path: './file.test.js', rawModuleMap},
-          expect.any(Function),
-        ],
-        [
-          {config, globalConfig, path: './file2.test.js', rawModuleMap},
-          expect.any(Function),
-        ],
+      expect(mockWorkerFarm.default.mock.calls).toEqual([
+        [{config, globalConfig, path: './file.test.js', rawModuleMap}],
+        [{config, globalConfig, path: './file2.test.js', rawModuleMap}],
       ]);
     });
 });
@@ -72,7 +66,7 @@ test('does not inject the rawModuleMap in serial mode', () => {
       {serial: false},
     )
     .then(() => {
-      expect(workerFarmMock.mock.calls).toEqual([
+      expect(mockWorkerFarm.default.mock.calls).toEqual([
         [
           {
             config,
@@ -80,7 +74,6 @@ test('does not inject the rawModuleMap in serial mode', () => {
             path: './file.test.js',
             rawModuleMap: null,
           },
-          expect.any(Function),
         ],
         [
           {
@@ -89,7 +82,6 @@ test('does not inject the rawModuleMap in serial mode', () => {
             path: './file2.test.js',
             rawModuleMap: null,
           },
-          expect.any(Function),
         ],
       ]);
     });

--- a/packages/jest-worker/package.json
+++ b/packages/jest-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-worker",
-  "version": "21.1.0",
+  "version": "21.2.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/facebook/jest.git"


### PR DESCRIPTION
This PR moves the coverage workers into the new `jest-worker` module; which also allows to use typed arguments and results on both sides. Tests were updated to match the new APIs.