### PR TITLE
Support mocking constructor in mockImplementationOnce

### DIFF
--- a/packages/jest-mock/src/__tests__/jest_mock.test.js
+++ b/packages/jest-mock/src/__tests__/jest_mock.test.js
@@ -406,6 +406,20 @@ describe('moduleMocker', () => {
   });
 
   describe('mockImplementationOnce', () => {
+    it('should mock constructor', () => {
+      const mock = jest.fn();
+      const Module = jest.fn();
+      const testFn = function() {
+        const m = new Module();
+        m.someFn();
+      };
+
+      Module.mockImplementationOnce(() => ({someFn: mock}));
+      testFn();
+
+      expect(mock).toHaveBeenCalled();
+    });
+
     it('should mock single call to a mock function', () => {
       const mockFn = moduleMocker.fn();
 

--- a/packages/jest-mock/src/__tests__/jest_mock.test.js
+++ b/packages/jest-mock/src/__tests__/jest_mock.test.js
@@ -407,17 +407,21 @@ describe('moduleMocker', () => {
 
   describe('mockImplementationOnce', () => {
     it('should mock constructor', () => {
-      const mock = jest.fn();
-      const Module = jest.fn();
+      const mock1 = jest.fn();
+      const mock2 = jest.fn();
+      const Module = jest.fn(() => ({someFn: mock1}));
       const testFn = function() {
         const m = new Module();
         m.someFn();
       };
 
-      Module.mockImplementationOnce(() => ({someFn: mock}));
-      testFn();
+      Module.mockImplementationOnce(() => ({someFn: mock2}));
 
-      expect(mock).toHaveBeenCalled();
+      testFn();
+      expect(mock2).toHaveBeenCalled();
+      expect(mock1).not.toHaveBeenCalled();
+      testFn();
+      expect(mock1).toHaveBeenCalled();
     });
 
     it('should mock single call to a mock function', () => {

--- a/packages/jest-mock/src/index.js
+++ b/packages/jest-mock/src/index.js
@@ -326,9 +326,10 @@ class ModuleMockerClass {
           });
 
           // Run the mock constructor implementation
-          return (
-            mockConfig.mockImpl && mockConfig.mockImpl.apply(this, arguments)
-          );
+          const mockImpl = mockConfig.specificMockImpls.length
+            ? mockConfig.specificMockImpls.shift()
+            : mockConfig.mockImpl;
+          return mockImpl && mockImpl.apply(this, arguments);
         }
 
         const returnValue = mockConfig.defaultReturnValue;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Mocking constructor wasn't supported inside `mockImplementationOnce`. 
Fixes #4595.

**Test plan**

Added a test with mocking constructor.
