### PR TITLE
docs: add info about `coveragePathIgnorePatterns`

### DIFF
--- a/docs/en/Troubleshooting.md
+++ b/docs/en/Troubleshooting.md
@@ -247,6 +247,10 @@ Jest takes advantage of new features added to Node 4. We recommend that you
 upgrade to the latest stable release of Node. The minimum supported version is
 `v4.0.0`. Versions `0.x.x` are not supported.
 
+### `coveragePathIgnorePatterns` seems to not have any effect.
+
+Make sure you are not using the `babel-plugin-istanbul` plugin. Jest wraps Istanbul, and therefore also tells Istanbul what files to instrument with coverage collection. When using `babel-plugin-istanbul`, every file that is processed by Babel will have coverage collection code, hence it is not being ignored by `coveragePathIgnorePatterns`.
+
 ### Still unresolved?
 
 See [Help](/jest/help.html).


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

I had an issue where `coveragePathIgnorePatterns` didn't have any effect, which was caused by some leftover config in my `.babelrc` from when I was using Mocha + Nyc. I documented the cause and fix to help others facing the same issue.

**Test plan**

This is just documentation, no test plan needed.
