### PR TITLE
Fix runOnlyPendingTimers for setTimeout inside setImmediate

### DIFF
--- a/packages/jest-util/src/__tests__/fake_timers.test.js
+++ b/packages/jest-util/src/__tests__/fake_timers.test.js
@@ -586,12 +586,18 @@ describe('FakeTimers', () => {
         runOrder.push('mock4');
       });
 
+      global.setImmediate(function cb() {
+        runOrder.push('mock5');
+        global.setTimeout(cb, 400);
+      });
+
       timers.runOnlyPendingTimers();
-      expect(runOrder).toEqual(['mock4', 'mock2', 'mock1', 'mock3']);
+      expect(runOrder).toEqual(['mock4', 'mock5', 'mock2', 'mock1', 'mock3']);
 
       timers.runOnlyPendingTimers();
       expect(runOrder).toEqual([
         'mock4',
+        'mock5',
         'mock2',
         'mock1',
         'mock3',
@@ -599,6 +605,7 @@ describe('FakeTimers', () => {
         'mock2',
         'mock1',
         'mock3',
+        'mock5',
       ]);
     });
 

--- a/packages/jest-util/src/fake_timers.js
+++ b/packages/jest-util/src/fake_timers.js
@@ -235,9 +235,9 @@ export default class FakeTimers {
   }
 
   runOnlyPendingTimers() {
+    const timers = Object.assign({}, this._timers);
     this._checkFakeTimers();
     this._immediates.forEach(this._runImmediate, this);
-    const timers = this._timers;
     Object.keys(timers)
       .sort((left, right) => timers[left].expiry - timers[right].expiry)
       .forEach(this._runTimerHandle, this);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Nested calls to timer mocks (`setTimeout`/`setInterval`) inside `setImmediate` were unreliable with `jest.runOnlyPendingTimers`.

To fix this, we need to store the timers object before executing immediates – simply clone timers (assigning will hold the reference) at the very beginning of `jest.runOnlyPendingTimers` so we're sure we're going to run only pending timers :D. Otherwise the timers object gets populated with timers that should not be there yet.

Fixes #3048

**Test plan**

Updated the existing test to support currently failing case