### PR TITLE
Bump node-notifier version

### DIFF
--- a/packages/jest-cli/package.json
+++ b/packages/jest-cli/package.json
@@ -25,7 +25,7 @@
     "jest-snapshot": "^21.2.1",
     "jest-util": "^21.2.1",
     "micromatch": "^2.3.11",
-    "node-notifier": "^5.0.2",
+    "node-notifier": "^5.1.2",
     "pify": "^3.0.0",
     "slash": "^1.0.0",
     "string-length": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4311,7 +4311,7 @@ node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
 
-node-notifier@^5.0.2:
+node-notifier@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-5.1.2.tgz#2fa9e12605fa10009d44549d6fcd8a63dde0e4ff"
   dependencies:


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Jest currently resolves to the version of `node-notifier` with the fix, but let's make it explicit.
Fixes #3177

**Test plan**

#yolo
