### PR TITLE
[jest-docblock] remove leading newlines from parseWithComments().comm…

### DIFF
--- a/packages/jest-docblock/src/__tests__/index.test.js
+++ b/packages/jest-docblock/src/__tests__/index.test.js
@@ -254,6 +254,21 @@ describe('docblock', () => {
     );
   });
 
+  it('removes leading newlines in multiline comments from docblock', () => {
+    const code =
+      '/**' +
+      os.EOL +
+      ' * @snailcode' +
+      os.EOL +
+      ' *' +
+      os.EOL +
+      ' *  hello world' +
+      os.EOL +
+      ' */';
+
+    expect(docblock.parseWithComments(code).comments).toEqual(' hello world');
+  });
+
   it('extracts comments from beginning and end of docblock', () => {
     const code =
       '/**' +

--- a/packages/jest-docblock/src/index.js
+++ b/packages/jest-docblock/src/index.js
@@ -55,7 +55,10 @@ export function parseWithComments(
   docblock = docblock.replace(ltrimNewlineRe, '').replace(rtrimRe, '');
 
   const result = Object.create(null);
-  const comments = docblock.replace(propertyRe, '');
+  const comments = docblock
+    .replace(propertyRe, '')
+    .replace(ltrimNewlineRe, '')
+    .replace(rtrimRe, '');
 
   let match;
   while ((match = propertyRe.exec(docblock))) {


### PR DESCRIPTION
**Summary**

While working on `--prependPragma` option for prettier (https://github.com/prettier/prettier/pull/2865), I noticed that jest-docblock is keeping around more leading newlines than would be expected in the `comments` result of `parseWithComments()`.

Example:
```
/**
 * @snailcode
 * 
 * word words words
 */
```

Current result of `parseWithComments().comments` :
```
{
  pragmas: { snailcode: '' },
  comments: '\n\nwords words words'
}
```
Expected:
```
{
  pragmas: { snailcode: '' },
  comments: 'words words words'
}
```

cc @azz 