### PR TITLE
Add support for date in jest-get-type

### DIFF
--- a/packages/jest-get-type/src/__tests__/index.test.js
+++ b/packages/jest-get-type/src/__tests__/index.test.js
@@ -23,4 +23,5 @@ describe('.getType()', () => {
   test('regexp', () => expect(getType(/abc/)).toBe('regexp'));
   test('map', () => expect(getType(new Map())).toBe('map'));
   test('set', () => expect(getType(new Set())).toBe('set'));
+  test('date', () => expect(getType(new Date())).toBe('date'));
 });

--- a/packages/jest-get-type/src/index.js
+++ b/packages/jest-get-type/src/index.js
@@ -19,6 +19,7 @@ export type ValueType =
   | 'regexp'
   | 'map'
   | 'set'
+  | 'date'
   | 'string'
   | 'symbol'
   | 'undefined';
@@ -26,7 +27,7 @@ export type ValueType =
 // get the type of a value with handling the edge cases like `typeof []`
 // and `typeof null`
 const getType = (value: any): ValueType => {
-  if (typeof value === 'undefined') {
+  if (value === undefined) {
     return 'undefined';
   } else if (value === null) {
     return 'null';
@@ -47,6 +48,8 @@ const getType = (value: any): ValueType => {
       return 'map';
     } else if (value.constructor === Set) {
       return 'set';
+    } else if (value.constructor === Date) {
+      return 'date';
     }
     return 'object';
     // $FlowFixMe https://github.com/facebook/flow/issues/1015


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Add support for type `date` to `jest-get-type`.

Btw, any reason why `jest-get-type` exists, over just using [kindof](https://github.com/moll/js-kindof) (or some other module doing the same thing)?

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
New test added

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
