### PR TITLE
Implement node Timer api when running in node environment.

### DIFF
--- a/packages/jest-environment-jsdom/src/__tests__/jsdom_environment.test.js
+++ b/packages/jest-environment-jsdom/src/__tests__/jsdom_environment.test.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+'use strict';
+
+const JSDomEnvironment = require.requireActual('../');
+
+describe('JSDomEnvironment', () => {
+  it('should configure setTimeout/setInterval to use the browser api', () => {
+    const env1 = new JSDomEnvironment({});
+
+    env1.fakeTimers.useFakeTimers();
+
+    const timer1 = env1.global.setTimeout(() => {}, 0);
+    const timer2 = env1.global.setInterval(() => {}, 0);
+
+    [timer1, timer2].forEach(timer => {
+      expect(typeof timer === 'number').toBe(true);
+    });
+  });
+});

--- a/packages/jest-environment-jsdom/src/__tests__/jsdom_environment.test.js
+++ b/packages/jest-environment-jsdom/src/__tests__/jsdom_environment.test.js
@@ -18,7 +18,7 @@ describe('JSDomEnvironment', () => {
     const timer2 = env1.global.setInterval(() => {}, 0);
 
     [timer1, timer2].forEach(timer => {
-      expect(typeof timer === 'number').toBe(true);
+      expect(typeof timer).toBe('number');
     });
   });
 });

--- a/packages/jest-environment-jsdom/src/index.js
+++ b/packages/jest-environment-jsdom/src/index.js
@@ -17,7 +17,7 @@ import JSDom from 'jsdom';
 
 class JSDOMEnvironment {
   document: ?Object;
-  fakeTimers: ?FakeTimers;
+  fakeTimers: ?FakeTimers<number>;
   global: ?Global;
   moduleMocker: ?ModuleMocker;
 
@@ -44,7 +44,18 @@ class JSDOMEnvironment {
     }
 
     this.moduleMocker = new mock.ModuleMocker(global);
-    this.fakeTimers = new FakeTimers(global, this.moduleMocker, config);
+
+    const timerConfig = {
+      idToRef: (id: number) => id,
+      refToId: (ref: number) => ref,
+    };
+
+    this.fakeTimers = new FakeTimers(
+      global,
+      this.moduleMocker,
+      timerConfig,
+      config,
+    );
   }
 
   dispose(): void {

--- a/packages/jest-environment-jsdom/src/index.js
+++ b/packages/jest-environment-jsdom/src/index.js
@@ -50,12 +50,12 @@ class JSDOMEnvironment {
       refToId: (ref: number) => ref,
     };
 
-    this.fakeTimers = new FakeTimers(
-      global,
-      this.moduleMocker,
-      timerConfig,
+    this.fakeTimers = new FakeTimers({
       config,
-    );
+      global,
+      moduleMocker: this.moduleMocker,
+      timerConfig,
+    });
   }
 
   dispose(): void {

--- a/packages/jest-environment-node/src/__tests__/node_environment.test.js
+++ b/packages/jest-environment-node/src/__tests__/node_environment.test.js
@@ -27,4 +27,19 @@ describe('NodeEnvironment', () => {
 
     expect(env1.global.global).toBe(env1.global);
   });
+
+  it('should configure setTimeout/setInterval to use the node api', () => {
+    const env1 = new NodeEnvironment({});
+
+    env1.fakeTimers.useFakeTimers();
+
+    const timer1 = env1.global.setTimeout(() => {}, 0);
+    const timer2 = env1.global.setInterval(() => {}, 0);
+
+    [timer1, timer2].forEach(timer => {
+      expect(timer.id).not.toBe(undefined);
+      expect(timer.ref).not.toBe(undefined);
+      expect(timer.unref).not.toBe(undefined);
+    });
+  });
 });

--- a/packages/jest-environment-node/src/__tests__/node_environment.test.js
+++ b/packages/jest-environment-node/src/__tests__/node_environment.test.js
@@ -38,8 +38,8 @@ describe('NodeEnvironment', () => {
 
     [timer1, timer2].forEach(timer => {
       expect(timer.id).not.toBeUndefined();
-      expect(timer.ref).not.toBeUndefined();
-      expect(timer.unref).not.toBeUndefined();
+      expect(typeof timer.ref).toBe('function');
+      expect(typeof timer.unref).toBe('function');
     });
   });
 });

--- a/packages/jest-environment-node/src/__tests__/node_environment.test.js
+++ b/packages/jest-environment-node/src/__tests__/node_environment.test.js
@@ -37,9 +37,9 @@ describe('NodeEnvironment', () => {
     const timer2 = env1.global.setInterval(() => {}, 0);
 
     [timer1, timer2].forEach(timer => {
-      expect(timer.id).not.toBe(undefined);
-      expect(timer.ref).not.toBe(undefined);
-      expect(timer.unref).not.toBe(undefined);
+      expect(timer.id).not.toBeUndefined();
+      expect(timer.ref).not.toBeUndefined();
+      expect(timer.unref).not.toBeUndefined();
     });
   });
 });

--- a/packages/jest-environment-node/src/index.js
+++ b/packages/jest-environment-node/src/index.js
@@ -57,12 +57,12 @@ class NodeEnvironment {
       refToId: timerRefToId,
     };
 
-    this.fakeTimers = new FakeTimers(
-      global,
-      this.moduleMocker,
-      timerConfig,
+    this.fakeTimers = new FakeTimers({
       config,
-    );
+      global,
+      moduleMocker: this.moduleMocker,
+      timerConfig,
+    });
   }
 
   dispose() {

--- a/packages/jest-environment-node/src/index.js
+++ b/packages/jest-environment-node/src/index.js
@@ -16,9 +16,15 @@ import vm from 'vm';
 import {FakeTimers, installCommonGlobals} from 'jest-util';
 import mock from 'jest-mock';
 
+type Timer = {|
+  id: number,
+  ref: () => Timer,
+  unref: () => Timer,
+|};
+
 class NodeEnvironment {
   context: ?vm$Context;
-  fakeTimers: ?FakeTimers;
+  fakeTimers: ?FakeTimers<Timer>;
   global: ?Global;
   moduleMocker: ?ModuleMocker;
 
@@ -33,7 +39,30 @@ class NodeEnvironment {
     global.setTimeout = setTimeout;
     installCommonGlobals(global, config.globals);
     this.moduleMocker = new mock.ModuleMocker(global);
-    this.fakeTimers = new FakeTimers(global, this.moduleMocker, config);
+
+    const timerIdToRef = (id: number) => ({
+      id,
+      ref() {
+        return this;
+      },
+      unref() {
+        return this;
+      },
+    });
+
+    const timerRefToId = (timer: Timer) => timer.id;
+
+    const timerConfig = {
+      idToRef: timerIdToRef,
+      refToId: timerRefToId,
+    };
+
+    this.fakeTimers = new FakeTimers(
+      global,
+      this.moduleMocker,
+      timerConfig,
+      config,
+    );
   }
 
   dispose() {

--- a/packages/jest-util/src/__tests__/fake_timers.test.js
+++ b/packages/jest-util/src/__tests__/fake_timers.test.js
@@ -11,41 +11,46 @@
 const vm = require('vm');
 
 describe('FakeTimers', () => {
-  let FakeTimers, moduleMocker;
+  let FakeTimers, moduleMocker, timerConfig;
 
   beforeEach(() => {
     FakeTimers = require('../fake_timers').default;
     const mock = require('jest-mock');
     const global = vm.runInNewContext('this');
     moduleMocker = new mock.ModuleMocker(global);
+
+    timerConfig = {
+      idToRef: (id: number) => id,
+      refToId: (ref: number) => ref,
+    };
   });
 
   describe('construction', () => {
     /* eslint-disable no-new */
     it('installs setTimeout mock', () => {
       const global = {process};
-      const timers = new FakeTimers(global, moduleMocker);
+      const timers = new FakeTimers(global, moduleMocker, timerConfig);
       timers.useFakeTimers();
       expect(global.setTimeout).not.toBe(undefined);
     });
 
     it('installs clearTimeout mock', () => {
       const global = {process};
-      const timers = new FakeTimers(global, moduleMocker);
+      const timers = new FakeTimers(global, moduleMocker, timerConfig);
       timers.useFakeTimers();
       expect(global.clearTimeout).not.toBe(undefined);
     });
 
     it('installs setInterval mock', () => {
       const global = {process};
-      const timers = new FakeTimers(global, moduleMocker);
+      const timers = new FakeTimers(global, moduleMocker, timerConfig);
       timers.useFakeTimers();
       expect(global.setInterval).not.toBe(undefined);
     });
 
     it('installs clearInterval mock', () => {
       const global = {process};
-      const timers = new FakeTimers(global, moduleMocker);
+      const timers = new FakeTimers(global, moduleMocker, timerConfig);
       timers.useFakeTimers();
       expect(global.clearInterval).not.toBe(undefined);
     });
@@ -57,7 +62,7 @@ describe('FakeTimers', () => {
           nextTick: origNextTick,
         },
       };
-      const timers = new FakeTimers(global, moduleMocker);
+      const timers = new FakeTimers(global, moduleMocker, timerConfig);
       timers.useFakeTimers();
       expect(global.process.nextTick).not.toBe(origNextTick);
     });
@@ -68,7 +73,7 @@ describe('FakeTimers', () => {
         process,
         setImmediate: origSetImmediate,
       };
-      const timers = new FakeTimers(global, moduleMocker);
+      const timers = new FakeTimers(global, moduleMocker, timerConfig);
       timers.useFakeTimers();
       expect(global.setImmediate).not.toBe(origSetImmediate);
     });
@@ -81,7 +86,7 @@ describe('FakeTimers', () => {
         process,
         setImmediate: origSetImmediate,
       };
-      const timers = new FakeTimers(global, moduleMocker);
+      const timers = new FakeTimers(global, moduleMocker, timerConfig);
       timers.useFakeTimers();
       expect(global.clearImmediate).not.toBe(origClearImmediate);
     });
@@ -95,7 +100,7 @@ describe('FakeTimers', () => {
         },
       };
 
-      const timers = new FakeTimers(global, moduleMocker);
+      const timers = new FakeTimers(global, moduleMocker, timerConfig);
       timers.useFakeTimers();
 
       const runOrder = [];
@@ -123,7 +128,7 @@ describe('FakeTimers', () => {
         },
       };
 
-      const timers = new FakeTimers(global, moduleMocker);
+      const timers = new FakeTimers(global, moduleMocker, timerConfig);
       timers.useFakeTimers();
       timers.runAllTicks();
 
@@ -137,7 +142,7 @@ describe('FakeTimers', () => {
         },
       };
 
-      const timers = new FakeTimers(global, moduleMocker);
+      const timers = new FakeTimers(global, moduleMocker, timerConfig);
       timers.useFakeTimers();
 
       const mock1 = jest.genMockFn();
@@ -160,7 +165,7 @@ describe('FakeTimers', () => {
         },
       };
 
-      const timers = new FakeTimers(global, moduleMocker);
+      const timers = new FakeTimers(global, moduleMocker, timerConfig);
       timers.useFakeTimers();
 
       const mock1 = jest.genMockFn();
@@ -183,7 +188,7 @@ describe('FakeTimers', () => {
         setImmediate: nativeSetImmediate,
       };
 
-      const timers = new FakeTimers(global, moduleMocker);
+      const timers = new FakeTimers(global, moduleMocker, timerConfig);
       timers.useFakeTimers();
 
       const mock1 = jest.genMockFn();
@@ -206,7 +211,7 @@ describe('FakeTimers', () => {
         },
       };
 
-      const timers = new FakeTimers(global, moduleMocker);
+      const timers = new FakeTimers(global, moduleMocker, timerConfig);
       timers.useFakeTimers();
 
       const mock1 = jest.genMockFn();
@@ -229,7 +234,7 @@ describe('FakeTimers', () => {
         setImmediate: nativeSetImmediate,
       };
 
-      const timers = new FakeTimers(global, moduleMocker);
+      const timers = new FakeTimers(global, moduleMocker, timerConfig);
       timers.useFakeTimers();
 
       const mock1 = jest.genMockFn();
@@ -252,7 +257,7 @@ describe('FakeTimers', () => {
         setImmediate: nativeSetImmediate,
       };
 
-      const timers = new FakeTimers(global, moduleMocker);
+      const timers = new FakeTimers(global, moduleMocker, timerConfig);
       timers.useFakeTimers();
 
       const mock1 = jest.genMockFn();
@@ -275,7 +280,14 @@ describe('FakeTimers', () => {
         },
       };
 
-      const timers = new FakeTimers(global, moduleMocker, null, 100);
+      const timers = new FakeTimers(
+        global,
+        moduleMocker,
+        timerConfig,
+        null,
+        100,
+      );
+
       timers.useFakeTimers();
 
       global.process.nextTick(function infinitelyRecursingCallback() {
@@ -296,7 +308,7 @@ describe('FakeTimers', () => {
   describe('runAllTimers', () => {
     it('runs all timers in order', () => {
       const global = {process};
-      const timers = new FakeTimers(global, moduleMocker);
+      const timers = new FakeTimers(global, moduleMocker, timerConfig);
       timers.useFakeTimers();
 
       const runOrder = [];
@@ -320,7 +332,9 @@ describe('FakeTimers', () => {
     it('warns when trying to advance timers while real timers are used', () => {
       const consoleWarn = console.warn;
       console.warn = jest.fn();
-      const timers = new FakeTimers(global, moduleMocker, {rootDir: __dirname});
+      const timers = new FakeTimers(global, moduleMocker, timerConfig, {
+        rootDir: __dirname,
+      });
       timers.runAllTimers();
       expect(
         console.warn.mock.calls[0][0].split('\nStack Trace')[0],
@@ -335,14 +349,14 @@ describe('FakeTimers', () => {
         setTimeout: nativeSetTimeout,
       };
 
-      const timers = new FakeTimers(global, moduleMocker);
+      const timers = new FakeTimers(global, moduleMocker, timerConfig);
       timers.useFakeTimers();
       timers.runAllTimers();
     });
 
     it('only runs a setTimeout callback once (ever)', () => {
       const global = {process};
-      const timers = new FakeTimers(global, moduleMocker);
+      const timers = new FakeTimers(global, moduleMocker, timerConfig);
       timers.useFakeTimers();
 
       const fn = jest.genMockFn();
@@ -358,7 +372,7 @@ describe('FakeTimers', () => {
 
     it('runs callbacks with arguments after the interval', () => {
       const global = {process};
-      const timers = new FakeTimers(global, moduleMocker);
+      const timers = new FakeTimers(global, moduleMocker, timerConfig);
       timers.useFakeTimers();
 
       const fn = jest.genMockFn();
@@ -376,7 +390,7 @@ describe('FakeTimers', () => {
         setTimeout: nativeSetTimeout,
       };
 
-      const timers = new FakeTimers(global, moduleMocker);
+      const timers = new FakeTimers(global, moduleMocker, timerConfig);
       timers.useFakeTimers();
 
       const mock1 = jest.genMockFn();
@@ -389,7 +403,13 @@ describe('FakeTimers', () => {
 
     it('throws before allowing infinite recursion', () => {
       const global = {process};
-      const timers = new FakeTimers(global, moduleMocker, null, 100);
+      const timers = new FakeTimers(
+        global,
+        moduleMocker,
+        timerConfig,
+        null,
+        100,
+      );
       timers.useFakeTimers();
 
       global.setTimeout(function infinitelyRecursingCallback() {
@@ -408,7 +428,7 @@ describe('FakeTimers', () => {
 
     it('also clears ticks', () => {
       const global = {process};
-      const timers = new FakeTimers(global, moduleMocker);
+      const timers = new FakeTimers(global, moduleMocker, timerConfig);
       timers.useFakeTimers();
 
       const fn = jest.genMockFn();
@@ -425,7 +445,7 @@ describe('FakeTimers', () => {
   describe('runTimersToTime', () => {
     it('runs timers in order', () => {
       const global = {process};
-      const timers = new FakeTimers(global, moduleMocker);
+      const timers = new FakeTimers(global, moduleMocker, timerConfig);
       timers.useFakeTimers();
 
       const runOrder = [];
@@ -464,7 +484,7 @@ describe('FakeTimers', () => {
 
     it('does nothing when no timers have been scheduled', () => {
       const global = {process};
-      const timers = new FakeTimers(global, moduleMocker);
+      const timers = new FakeTimers(global, moduleMocker, timerConfig);
       timers.useFakeTimers();
 
       timers.runTimersToTime(100);
@@ -472,7 +492,13 @@ describe('FakeTimers', () => {
 
     it('throws before allowing infinite recursion', () => {
       const global = {process};
-      const timers = new FakeTimers(global, moduleMocker, null, 100);
+      const timers = new FakeTimers(
+        global,
+        moduleMocker,
+        timerConfig,
+        null,
+        100,
+      );
       timers.useFakeTimers();
 
       global.setTimeout(function infinitelyRecursingCallback() {
@@ -493,7 +519,7 @@ describe('FakeTimers', () => {
   describe('reset', () => {
     it('resets all pending setTimeouts', () => {
       const global = {process};
-      const timers = new FakeTimers(global, moduleMocker);
+      const timers = new FakeTimers(global, moduleMocker, timerConfig);
       timers.useFakeTimers();
 
       const mock1 = jest.genMockFn();
@@ -506,7 +532,7 @@ describe('FakeTimers', () => {
 
     it('resets all pending setIntervals', () => {
       const global = {process};
-      const timers = new FakeTimers(global, moduleMocker);
+      const timers = new FakeTimers(global, moduleMocker, timerConfig);
       timers.useFakeTimers();
 
       const mock1 = jest.genMockFn();
@@ -524,7 +550,7 @@ describe('FakeTimers', () => {
         },
         setImmediate: () => {},
       };
-      const timers = new FakeTimers(global, moduleMocker);
+      const timers = new FakeTimers(global, moduleMocker, timerConfig);
       timers.useFakeTimers();
 
       const mock1 = jest.genMockFn();
@@ -539,7 +565,7 @@ describe('FakeTimers', () => {
 
     it('resets current runTimersToTime time cursor', () => {
       const global = {process};
-      const timers = new FakeTimers(global, moduleMocker);
+      const timers = new FakeTimers(global, moduleMocker, timerConfig);
       timers.useFakeTimers();
 
       const mock1 = jest.genMockFn();
@@ -563,7 +589,7 @@ describe('FakeTimers', () => {
         setImmediate: nativeSetImmediate,
       };
 
-      const timers = new FakeTimers(global, moduleMocker);
+      const timers = new FakeTimers(global, moduleMocker, timerConfig);
       timers.useFakeTimers();
 
       const runOrder = [];
@@ -611,7 +637,7 @@ describe('FakeTimers', () => {
 
     it('does not run timers that were cleared in another timer', () => {
       const global = {process};
-      const timers = new FakeTimers(global, moduleMocker);
+      const timers = new FakeTimers(global, moduleMocker, timerConfig);
       timers.useFakeTimers();
 
       const fn = jest.genMockFn();
@@ -639,7 +665,7 @@ describe('FakeTimers', () => {
         setInterval: nativeSetInterval,
         setTimeout: nativeSetTimeout,
       };
-      const timers = new FakeTimers(global, moduleMocker);
+      const timers = new FakeTimers(global, moduleMocker, timerConfig);
       timers.useFakeTimers();
 
       // clearInterval()
@@ -684,7 +710,7 @@ describe('FakeTimers', () => {
         setInterval: nativeSetInterval,
         setTimeout: nativeSetTimeout,
       };
-      const timers = new FakeTimers(global, moduleMocker);
+      const timers = new FakeTimers(global, moduleMocker, timerConfig);
       timers.useFakeTimers();
 
       // clearInterval()
@@ -738,7 +764,7 @@ describe('FakeTimers', () => {
         process,
         setTimeout: nativeSetTimeout,
       };
-      const timers = new FakeTimers(global, moduleMocker);
+      const timers = new FakeTimers(global, moduleMocker, timerConfig);
       timers.useFakeTimers();
 
       expect(() => {
@@ -770,7 +796,7 @@ describe('FakeTimers', () => {
         setInterval: nativeSetInterval,
         setTimeout: nativeSetTimeout,
       };
-      const timers = new FakeTimers(global, moduleMocker);
+      const timers = new FakeTimers(global, moduleMocker, timerConfig);
       timers.useFakeTimers();
 
       // Ensure that timers has overridden the native timer APIs
@@ -794,7 +820,7 @@ describe('FakeTimers', () => {
       const global = {
         process: {nextTick: nativeProcessNextTick},
       };
-      const timers = new FakeTimers(global, moduleMocker);
+      const timers = new FakeTimers(global, moduleMocker, timerConfig);
       timers.useFakeTimers();
 
       // Ensure that timers has overridden the native timer APIs
@@ -815,7 +841,7 @@ describe('FakeTimers', () => {
         process,
         setImmediate: nativeSetImmediate,
       };
-      const timers = new FakeTimers(global, moduleMocker);
+      const timers = new FakeTimers(global, moduleMocker, timerConfig);
       timers.useFakeTimers();
 
       // Ensure that timers has overridden the native timer APIs
@@ -844,7 +870,7 @@ describe('FakeTimers', () => {
         setInterval: nativeSetInterval,
         setTimeout: nativeSetTimeout,
       };
-      const timers = new FakeTimers(global, moduleMocker);
+      const timers = new FakeTimers(global, moduleMocker, timerConfig);
       timers.useRealTimers();
 
       // Ensure that the real timers are installed at this point
@@ -868,7 +894,7 @@ describe('FakeTimers', () => {
       const global = {
         process: {nextTick: nativeProcessNextTick},
       };
-      const timers = new FakeTimers(global, moduleMocker);
+      const timers = new FakeTimers(global, moduleMocker, timerConfig);
       timers.useRealTimers();
 
       // Ensure that the real timers are installed at this point
@@ -889,7 +915,7 @@ describe('FakeTimers', () => {
         process,
         setImmediate: nativeSetImmediate,
       };
-      const fakeTimers = new FakeTimers(global, moduleMocker);
+      const fakeTimers = new FakeTimers(global, moduleMocker, timerConfig);
       fakeTimers.useRealTimers();
 
       // Ensure that the real timers are installed at this point

--- a/packages/jest-util/src/__tests__/fake_timers.test.js
+++ b/packages/jest-util/src/__tests__/fake_timers.test.js
@@ -29,28 +29,28 @@ describe('FakeTimers', () => {
     /* eslint-disable no-new */
     it('installs setTimeout mock', () => {
       const global = {process};
-      const timers = new FakeTimers(global, moduleMocker, timerConfig);
+      const timers = new FakeTimers({global, moduleMocker, timerConfig});
       timers.useFakeTimers();
       expect(global.setTimeout).not.toBe(undefined);
     });
 
     it('installs clearTimeout mock', () => {
       const global = {process};
-      const timers = new FakeTimers(global, moduleMocker, timerConfig);
+      const timers = new FakeTimers({global, moduleMocker, timerConfig});
       timers.useFakeTimers();
       expect(global.clearTimeout).not.toBe(undefined);
     });
 
     it('installs setInterval mock', () => {
       const global = {process};
-      const timers = new FakeTimers(global, moduleMocker, timerConfig);
+      const timers = new FakeTimers({global, moduleMocker, timerConfig});
       timers.useFakeTimers();
       expect(global.setInterval).not.toBe(undefined);
     });
 
     it('installs clearInterval mock', () => {
       const global = {process};
-      const timers = new FakeTimers(global, moduleMocker, timerConfig);
+      const timers = new FakeTimers({global, moduleMocker, timerConfig});
       timers.useFakeTimers();
       expect(global.clearInterval).not.toBe(undefined);
     });
@@ -62,7 +62,7 @@ describe('FakeTimers', () => {
           nextTick: origNextTick,
         },
       };
-      const timers = new FakeTimers(global, moduleMocker, timerConfig);
+      const timers = new FakeTimers({global, moduleMocker, timerConfig});
       timers.useFakeTimers();
       expect(global.process.nextTick).not.toBe(origNextTick);
     });
@@ -73,7 +73,7 @@ describe('FakeTimers', () => {
         process,
         setImmediate: origSetImmediate,
       };
-      const timers = new FakeTimers(global, moduleMocker, timerConfig);
+      const timers = new FakeTimers({global, moduleMocker, timerConfig});
       timers.useFakeTimers();
       expect(global.setImmediate).not.toBe(origSetImmediate);
     });
@@ -86,7 +86,7 @@ describe('FakeTimers', () => {
         process,
         setImmediate: origSetImmediate,
       };
-      const timers = new FakeTimers(global, moduleMocker, timerConfig);
+      const timers = new FakeTimers({global, moduleMocker, timerConfig});
       timers.useFakeTimers();
       expect(global.clearImmediate).not.toBe(origClearImmediate);
     });
@@ -100,7 +100,7 @@ describe('FakeTimers', () => {
         },
       };
 
-      const timers = new FakeTimers(global, moduleMocker, timerConfig);
+      const timers = new FakeTimers({global, moduleMocker, timerConfig});
       timers.useFakeTimers();
 
       const runOrder = [];
@@ -128,7 +128,7 @@ describe('FakeTimers', () => {
         },
       };
 
-      const timers = new FakeTimers(global, moduleMocker, timerConfig);
+      const timers = new FakeTimers({global, moduleMocker, timerConfig});
       timers.useFakeTimers();
       timers.runAllTicks();
 
@@ -142,7 +142,7 @@ describe('FakeTimers', () => {
         },
       };
 
-      const timers = new FakeTimers(global, moduleMocker, timerConfig);
+      const timers = new FakeTimers({global, moduleMocker, timerConfig});
       timers.useFakeTimers();
 
       const mock1 = jest.genMockFn();
@@ -165,7 +165,7 @@ describe('FakeTimers', () => {
         },
       };
 
-      const timers = new FakeTimers(global, moduleMocker, timerConfig);
+      const timers = new FakeTimers({global, moduleMocker, timerConfig});
       timers.useFakeTimers();
 
       const mock1 = jest.genMockFn();
@@ -188,7 +188,7 @@ describe('FakeTimers', () => {
         setImmediate: nativeSetImmediate,
       };
 
-      const timers = new FakeTimers(global, moduleMocker, timerConfig);
+      const timers = new FakeTimers({global, moduleMocker, timerConfig});
       timers.useFakeTimers();
 
       const mock1 = jest.genMockFn();
@@ -211,7 +211,7 @@ describe('FakeTimers', () => {
         },
       };
 
-      const timers = new FakeTimers(global, moduleMocker, timerConfig);
+      const timers = new FakeTimers({global, moduleMocker, timerConfig});
       timers.useFakeTimers();
 
       const mock1 = jest.genMockFn();
@@ -234,7 +234,7 @@ describe('FakeTimers', () => {
         setImmediate: nativeSetImmediate,
       };
 
-      const timers = new FakeTimers(global, moduleMocker, timerConfig);
+      const timers = new FakeTimers({global, moduleMocker, timerConfig});
       timers.useFakeTimers();
 
       const mock1 = jest.genMockFn();
@@ -257,7 +257,7 @@ describe('FakeTimers', () => {
         setImmediate: nativeSetImmediate,
       };
 
-      const timers = new FakeTimers(global, moduleMocker, timerConfig);
+      const timers = new FakeTimers({global, moduleMocker, timerConfig});
       timers.useFakeTimers();
 
       const mock1 = jest.genMockFn();
@@ -280,13 +280,12 @@ describe('FakeTimers', () => {
         },
       };
 
-      const timers = new FakeTimers(
+      const timers = new FakeTimers({
         global,
+        maxLoops: 100,
         moduleMocker,
         timerConfig,
-        null,
-        100,
-      );
+      });
 
       timers.useFakeTimers();
 
@@ -308,7 +307,7 @@ describe('FakeTimers', () => {
   describe('runAllTimers', () => {
     it('runs all timers in order', () => {
       const global = {process};
-      const timers = new FakeTimers(global, moduleMocker, timerConfig);
+      const timers = new FakeTimers({global, moduleMocker, timerConfig});
       timers.useFakeTimers();
 
       const runOrder = [];
@@ -332,8 +331,13 @@ describe('FakeTimers', () => {
     it('warns when trying to advance timers while real timers are used', () => {
       const consoleWarn = console.warn;
       console.warn = jest.fn();
-      const timers = new FakeTimers(global, moduleMocker, timerConfig, {
-        rootDir: __dirname,
+      const timers = new FakeTimers({
+        config: {
+          rootDir: __dirname,
+        },
+        global,
+        moduleMocker,
+        timerConfig,
       });
       timers.runAllTimers();
       expect(
@@ -349,14 +353,14 @@ describe('FakeTimers', () => {
         setTimeout: nativeSetTimeout,
       };
 
-      const timers = new FakeTimers(global, moduleMocker, timerConfig);
+      const timers = new FakeTimers({global, moduleMocker, timerConfig});
       timers.useFakeTimers();
       timers.runAllTimers();
     });
 
     it('only runs a setTimeout callback once (ever)', () => {
       const global = {process};
-      const timers = new FakeTimers(global, moduleMocker, timerConfig);
+      const timers = new FakeTimers({global, moduleMocker, timerConfig});
       timers.useFakeTimers();
 
       const fn = jest.genMockFn();
@@ -372,7 +376,7 @@ describe('FakeTimers', () => {
 
     it('runs callbacks with arguments after the interval', () => {
       const global = {process};
-      const timers = new FakeTimers(global, moduleMocker, timerConfig);
+      const timers = new FakeTimers({global, moduleMocker, timerConfig});
       timers.useFakeTimers();
 
       const fn = jest.genMockFn();
@@ -390,7 +394,7 @@ describe('FakeTimers', () => {
         setTimeout: nativeSetTimeout,
       };
 
-      const timers = new FakeTimers(global, moduleMocker, timerConfig);
+      const timers = new FakeTimers({global, moduleMocker, timerConfig});
       timers.useFakeTimers();
 
       const mock1 = jest.genMockFn();
@@ -403,13 +407,12 @@ describe('FakeTimers', () => {
 
     it('throws before allowing infinite recursion', () => {
       const global = {process};
-      const timers = new FakeTimers(
+      const timers = new FakeTimers({
         global,
+        maxLoops: 100,
         moduleMocker,
         timerConfig,
-        null,
-        100,
-      );
+      });
       timers.useFakeTimers();
 
       global.setTimeout(function infinitelyRecursingCallback() {
@@ -428,7 +431,7 @@ describe('FakeTimers', () => {
 
     it('also clears ticks', () => {
       const global = {process};
-      const timers = new FakeTimers(global, moduleMocker, timerConfig);
+      const timers = new FakeTimers({global, moduleMocker, timerConfig});
       timers.useFakeTimers();
 
       const fn = jest.genMockFn();
@@ -445,7 +448,7 @@ describe('FakeTimers', () => {
   describe('runTimersToTime', () => {
     it('runs timers in order', () => {
       const global = {process};
-      const timers = new FakeTimers(global, moduleMocker, timerConfig);
+      const timers = new FakeTimers({global, moduleMocker, timerConfig});
       timers.useFakeTimers();
 
       const runOrder = [];
@@ -484,7 +487,7 @@ describe('FakeTimers', () => {
 
     it('does nothing when no timers have been scheduled', () => {
       const global = {process};
-      const timers = new FakeTimers(global, moduleMocker, timerConfig);
+      const timers = new FakeTimers({global, moduleMocker, timerConfig});
       timers.useFakeTimers();
 
       timers.runTimersToTime(100);
@@ -492,13 +495,12 @@ describe('FakeTimers', () => {
 
     it('throws before allowing infinite recursion', () => {
       const global = {process};
-      const timers = new FakeTimers(
+      const timers = new FakeTimers({
         global,
+        maxLoops: 100,
         moduleMocker,
         timerConfig,
-        null,
-        100,
-      );
+      });
       timers.useFakeTimers();
 
       global.setTimeout(function infinitelyRecursingCallback() {
@@ -519,7 +521,7 @@ describe('FakeTimers', () => {
   describe('reset', () => {
     it('resets all pending setTimeouts', () => {
       const global = {process};
-      const timers = new FakeTimers(global, moduleMocker, timerConfig);
+      const timers = new FakeTimers({global, moduleMocker, timerConfig});
       timers.useFakeTimers();
 
       const mock1 = jest.genMockFn();
@@ -532,7 +534,7 @@ describe('FakeTimers', () => {
 
     it('resets all pending setIntervals', () => {
       const global = {process};
-      const timers = new FakeTimers(global, moduleMocker, timerConfig);
+      const timers = new FakeTimers({global, moduleMocker, timerConfig});
       timers.useFakeTimers();
 
       const mock1 = jest.genMockFn();
@@ -550,7 +552,7 @@ describe('FakeTimers', () => {
         },
         setImmediate: () => {},
       };
-      const timers = new FakeTimers(global, moduleMocker, timerConfig);
+      const timers = new FakeTimers({global, moduleMocker, timerConfig});
       timers.useFakeTimers();
 
       const mock1 = jest.genMockFn();
@@ -565,7 +567,7 @@ describe('FakeTimers', () => {
 
     it('resets current runTimersToTime time cursor', () => {
       const global = {process};
-      const timers = new FakeTimers(global, moduleMocker, timerConfig);
+      const timers = new FakeTimers({global, moduleMocker, timerConfig});
       timers.useFakeTimers();
 
       const mock1 = jest.genMockFn();
@@ -589,7 +591,7 @@ describe('FakeTimers', () => {
         setImmediate: nativeSetImmediate,
       };
 
-      const timers = new FakeTimers(global, moduleMocker, timerConfig);
+      const timers = new FakeTimers({global, moduleMocker, timerConfig});
       timers.useFakeTimers();
 
       const runOrder = [];
@@ -637,7 +639,7 @@ describe('FakeTimers', () => {
 
     it('does not run timers that were cleared in another timer', () => {
       const global = {process};
-      const timers = new FakeTimers(global, moduleMocker, timerConfig);
+      const timers = new FakeTimers({global, moduleMocker, timerConfig});
       timers.useFakeTimers();
 
       const fn = jest.genMockFn();
@@ -665,7 +667,7 @@ describe('FakeTimers', () => {
         setInterval: nativeSetInterval,
         setTimeout: nativeSetTimeout,
       };
-      const timers = new FakeTimers(global, moduleMocker, timerConfig);
+      const timers = new FakeTimers({global, moduleMocker, timerConfig});
       timers.useFakeTimers();
 
       // clearInterval()
@@ -710,7 +712,7 @@ describe('FakeTimers', () => {
         setInterval: nativeSetInterval,
         setTimeout: nativeSetTimeout,
       };
-      const timers = new FakeTimers(global, moduleMocker, timerConfig);
+      const timers = new FakeTimers({global, moduleMocker, timerConfig});
       timers.useFakeTimers();
 
       // clearInterval()
@@ -764,7 +766,7 @@ describe('FakeTimers', () => {
         process,
         setTimeout: nativeSetTimeout,
       };
-      const timers = new FakeTimers(global, moduleMocker, timerConfig);
+      const timers = new FakeTimers({global, moduleMocker, timerConfig});
       timers.useFakeTimers();
 
       expect(() => {
@@ -796,7 +798,7 @@ describe('FakeTimers', () => {
         setInterval: nativeSetInterval,
         setTimeout: nativeSetTimeout,
       };
-      const timers = new FakeTimers(global, moduleMocker, timerConfig);
+      const timers = new FakeTimers({global, moduleMocker, timerConfig});
       timers.useFakeTimers();
 
       // Ensure that timers has overridden the native timer APIs
@@ -820,7 +822,7 @@ describe('FakeTimers', () => {
       const global = {
         process: {nextTick: nativeProcessNextTick},
       };
-      const timers = new FakeTimers(global, moduleMocker, timerConfig);
+      const timers = new FakeTimers({global, moduleMocker, timerConfig});
       timers.useFakeTimers();
 
       // Ensure that timers has overridden the native timer APIs
@@ -841,7 +843,7 @@ describe('FakeTimers', () => {
         process,
         setImmediate: nativeSetImmediate,
       };
-      const timers = new FakeTimers(global, moduleMocker, timerConfig);
+      const timers = new FakeTimers({global, moduleMocker, timerConfig});
       timers.useFakeTimers();
 
       // Ensure that timers has overridden the native timer APIs
@@ -870,7 +872,7 @@ describe('FakeTimers', () => {
         setInterval: nativeSetInterval,
         setTimeout: nativeSetTimeout,
       };
-      const timers = new FakeTimers(global, moduleMocker, timerConfig);
+      const timers = new FakeTimers({global, moduleMocker, timerConfig});
       timers.useRealTimers();
 
       // Ensure that the real timers are installed at this point
@@ -894,7 +896,7 @@ describe('FakeTimers', () => {
       const global = {
         process: {nextTick: nativeProcessNextTick},
       };
-      const timers = new FakeTimers(global, moduleMocker, timerConfig);
+      const timers = new FakeTimers({global, moduleMocker, timerConfig});
       timers.useRealTimers();
 
       // Ensure that the real timers are installed at this point
@@ -915,7 +917,7 @@ describe('FakeTimers', () => {
         process,
         setImmediate: nativeSetImmediate,
       };
-      const fakeTimers = new FakeTimers(global, moduleMocker, timerConfig);
+      const fakeTimers = new FakeTimers({global, moduleMocker, timerConfig});
       fakeTimers.useRealTimers();
 
       // Ensure that the real timers are installed at this point

--- a/packages/jest-util/src/fake_timers.js
+++ b/packages/jest-util/src/fake_timers.js
@@ -81,13 +81,19 @@ export default class FakeTimers<TimerRef> {
   _uuidCounter: number;
   _timerConfig: TimerConfig<TimerRef>;
 
-  constructor(
+  constructor({
+    global,
+    moduleMocker,
+    timerConfig,
+    config,
+    maxLoops,
+  }: {
     global: Global,
     moduleMocker: ModuleMocker,
     timerConfig: TimerConfig<TimerRef>,
     config: ProjectConfig,
     maxLoops?: number,
-  ) {
+  }) {
     this._global = global;
     this._timerConfig = timerConfig;
     this._config = config;


### PR DESCRIPTION
Fixes #4559. Not entirely sure if this is the right approach. Let me know if there's a better way!

Some thoughts:
- I'm a little unsure about the name TimerRef (I consider it to be a reference to the timer that is used to clear it)
-  ~~we might want to assert if ref/unref are really functions but I noticed this isn't always done in other places in the codebase~~
- maybe we also need to verify the return values of ref/unref?
- ~~I had to shuffle the FakeTimer constructor args a little bit since some are optional. I considered making timerConfig an optional arg with a default implementation but given that FakeTimer is generic about TimerRef, I couldn't get Flow to typecheck it properly~~.

Any feedback is more then welcome.

Thanks!