### PR TITLE
Add `module.loaded`, and `module.require` should not be enumerable

### DIFF
--- a/packages/jest-runtime/src/__tests__/runtime_require_module.test.js
+++ b/packages/jest-runtime/src/__tests__/runtime_require_module.test.js
@@ -27,6 +27,22 @@ describe('Runtime requireModule', () => {
       expect(exports.isRealModule).toBe(true);
     }));
 
+  it('provides `module` to modules', () =>
+    createRuntime(__filename).then(runtime => {
+      const exports = runtime.requireModule(
+        runtime.__mockRootPath,
+        'RegularModule',
+      );
+      expect(Object.keys(exports.module)).toEqual([
+        'exports',
+        'filename',
+        'id',
+        'children',
+        'parent',
+        'paths',
+      ]);
+    }));
+
   it('provides `module.parent` to modules', () =>
     createRuntime(__filename).then(runtime => {
       const exports = runtime.requireModule(

--- a/packages/jest-runtime/src/__tests__/runtime_require_module.test.js
+++ b/packages/jest-runtime/src/__tests__/runtime_require_module.test.js
@@ -37,6 +37,7 @@ describe('Runtime requireModule', () => {
         'exports',
         'filename',
         'id',
+        'loaded',
         'children',
         'parent',
         'paths',
@@ -53,10 +54,10 @@ describe('Runtime requireModule', () => {
         'exports',
         'filename',
         'id',
+        'loaded',
         'children',
         'parent',
         'paths',
-        'require',
       ]);
     }));
 
@@ -88,6 +89,19 @@ describe('Runtime requireModule', () => {
       expect(slash(exports.parentFileName.replace(__dirname, ''))).toEqual(
         '/test_root/inner_parent_module.js',
       );
+    }));
+
+  it('provides `module.loaded` to modules', () =>
+    createRuntime(__filename).then(runtime => {
+      const exports = runtime.requireModule(
+        runtime.__mockRootPath,
+        'RegularModule',
+      );
+
+      // `exports.loaded` is set while the module is loaded, so should be `false`
+      expect(exports.loaded).toEqual(false);
+      // After the module is loaded we can query `module.loaded` again, at which point it should be `true`
+      expect(exports.isLoaded()).toEqual(true);
     }));
 
   it('provides `module.filename` to modules', () =>

--- a/packages/jest-runtime/src/__tests__/runtime_require_module.test.js
+++ b/packages/jest-runtime/src/__tests__/runtime_require_module.test.js
@@ -34,11 +34,11 @@ describe('Runtime requireModule', () => {
         'RegularModule',
       );
       expect(Object.keys(exports.module)).toEqual([
+        'children',
         'exports',
         'filename',
         'id',
         'loaded',
-        'children',
         'parent',
         'paths',
       ]);
@@ -51,11 +51,11 @@ describe('Runtime requireModule', () => {
         'RequireRegularModule',
       );
       expect(Object.keys(exports.parent)).toEqual([
+        'children',
         'exports',
         'filename',
         'id',
         'loaded',
-        'children',
         'parent',
         'paths',
       ]);

--- a/packages/jest-runtime/src/__tests__/test_root/RegularModule.js
+++ b/packages/jest-runtime/src/__tests__/test_root/RegularModule.js
@@ -39,3 +39,4 @@ exports.object = {};
 exports.parent = module.parent;
 exports.paths = module.paths;
 exports.setModuleStateValue = setModuleStateValue;
+exports.module = module;

--- a/packages/jest-runtime/src/__tests__/test_root/RegularModule.js
+++ b/packages/jest-runtime/src/__tests__/test_root/RegularModule.js
@@ -40,3 +40,5 @@ exports.parent = module.parent;
 exports.paths = module.paths;
 exports.setModuleStateValue = setModuleStateValue;
 exports.module = module;
+exports.loaded = module.loaded;
+exports.isLoaded = () => module.loaded;

--- a/packages/jest-runtime/src/index.js
+++ b/packages/jest-runtime/src/index.js
@@ -29,14 +29,14 @@ import {run as cilRun} from './cli';
 import {options as cliOptions} from './cli/args';
 
 type Module = {|
-  children?: Array<any>,
+  children: Array<Module>,
   exports: any,
   filename: string,
   id: string,
   loaded: boolean,
   parent?: Module,
   paths?: Array<Path>,
-  require?: Function,
+  require?: (id: string) => any,
 |};
 
 type HasteMapOptions = {|
@@ -313,6 +313,7 @@ class Runtime {
       // circular dependencies that may arise while evaluating the module can
       // be satisfied.
       const localModule: Module = {
+        children: [],
         exports: {},
         filename: modulePath,
         id: modulePath,
@@ -386,6 +387,7 @@ class Runtime {
 
     if (manualMock) {
       const localModule: Module = {
+        children: [],
         exports: {},
         filename: modulePath,
         id: modulePath,

--- a/packages/jest-runtime/src/index.js
+++ b/packages/jest-runtime/src/index.js
@@ -508,7 +508,9 @@ class Runtime {
     );
 
     localModule.paths = this._resolver.getModulePaths(dirname);
-    localModule.require = this._createRequireImplementation(filename, options);
+    Object.defineProperty(localModule, 'require', {
+      value: this._createRequireImplementation(filename, options),
+    });
 
     const transformedFile = this._scriptTransformer.transform(
       filename,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
As mentioned in https://github.com/facebook/jest/pull/4614#issuecomment-334922559 there are 2 ways that `module` in normal node and `module` in jest diverge (at the top level, #4614 addresses `module.parent` being faked).

1. `module.require`should not be enumerable.
1. `module.loaded` is missing in jest's implementation. (https://nodejs.org/api/modules.html#modules_module_loaded)

This PR fixes both of those issues.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
New test added

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
