### PR TITLE
Check if npm_lifecycle_script calls jest directly

### DIFF
--- a/packages/jest-cli/src/reporters/summary_reporter.js
+++ b/packages/jest-cli/src/reporters/summary_reporter.js
@@ -134,13 +134,13 @@ export default class SummaryReporter extends BaseReporter {
         process.env.npm_config_user_agent.match('yarn') !== null
           ? 'yarn'
           : 'npm';
-      const script_uses_jest =
+      const scriptUsesJest =
         typeof process.env.npm_lifecycle_script === 'string' &&
-        process.env.npm_lifecycle_script.match('jest') !== null;
+        process.env.npm_lifecycle_script.indexOf('jest') !== -1;
 
       if (globalConfig.watch) {
         updateCommand = 'press `u`';
-      } else if (event && script_uses_jest) {
+      } else if (event && scriptUsesJest) {
         updateCommand = `run \`${client + ' ' + prefix + event} -u\``;
       } else {
         updateCommand = 're-run jest with `-u`';

--- a/packages/jest-cli/src/reporters/summary_reporter.js
+++ b/packages/jest-cli/src/reporters/summary_reporter.js
@@ -134,12 +134,16 @@ export default class SummaryReporter extends BaseReporter {
         process.env.npm_config_user_agent.match('yarn') !== null
           ? 'yarn'
           : 'npm';
+      const script_uses_jest =
+        typeof process.env.npm_lifecycle_script === 'string' &&
+        process.env.npm_lifecycle_script.match('jest') !== null;
+
       if (globalConfig.watch) {
         updateCommand = 'press `u`';
-      } else if (event) {
-        updateCommand = `run with \`${client + ' ' + prefix + event} -- -u\``;
+      } else if (event && script_uses_jest) {
+        updateCommand = `run \`${client + ' ' + prefix + event} -u\``;
       } else {
-        updateCommand = 're-run with `-u`';
+        updateCommand = 're-run jest with `-u`';
       }
 
       const snapshotSummary = getSnapshotSummary(snapshots, updateCommand);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Fixes #4440. Check if `npm_lifecycle_script` calls `jest` directly because it's possible that projects wrap the invocation of jest with some script. If jest is called directly, the snapshot update command is something like `yarn test -u` (note: the `--` has been removed). Else suggest people "re-run jest with `-u`".

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

I `yarn link`'ed `jest-cli` to `my-app` which has this `package.json`:
```
➜  my-app cat package.json
{
  "name": "my-app",
  "version": "0.1.0",
  "private": true,
  "dependencies": {
    "react": "^16.0.0",
    "react-dom": "^16.0.0"
  },
  "scripts": {
    "test-call-jest-indirectly": "./run-tests.sh",
    "test-call-jest-directly": "jest"
  },
  "devDependencies": {
    "babel-preset-es2015": "^6.24.1",
    "babel-preset-react": "^6.24.1",
    "jest": "^21.2.1",
    "react-test-renderer": "^16.0.0"
  }
}
```
where `run-tests.sh` is:
```sh
#!/usr/bin/env bash
jest
```
Running `yarn test-call-jest-directly` with failing snapshot tests yields:
```
...
 › 1 snapshot test failed in 1 test suite. Inspect your code changes or run `yarn run test-call-jest-directly -u` to update them.
...
```
Running `yarn test-call-jest-indirectly` with failing snapshot tests yields:
```
...
 › 1 snapshot test failed in 1 test suite. Inspect your code changes or re-run jest with `-u` to update them.
...
```