### PR TITLE
Remove testMatch from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,9 +139,6 @@
       "\\.snap$",
       "/packages/.*/build",
       "/packages/.*/build-es5"
-    ],
-    "testMatch": [
-      "**/*.test.js"
     ]
   },
   "prettier": {

--- a/package.json
+++ b/package.json
@@ -138,7 +138,19 @@
       "/integration_tests/.*/__tests__",
       "\\.snap$",
       "/packages/.*/build",
-      "/packages/.*/build-es5"
+      "/packages/.*/build-es5",
+      "/packages/.*/src/__tests__/expect_util.js",
+      "/packages/jest-cli/src/__tests__/test_root",
+      "/packages/jest-cli/src/__tests__/__fixtures__/",
+      "/packages/jest-haste-map/src/__tests__/haste_impl.js",
+      "/packages/jest-resolve-dependencies/src/__tests__/__fixtures__/",
+      "/packages/jest-runtime/src/__tests__/defaultResolver.js",
+      "/packages/jest-runtime/src/__tests__/module_dir/",
+      "/packages/jest-runtime/src/__tests__/NODE_PATH_dir",
+      "/packages/jest-snapshot/src/__tests__/plugins",
+      "/packages/jest-validate/src/__tests__/fixtures/",
+      "/packages/jest-worker/src/__performance_tests__",
+      "/packages/pretty-format/perf/test.js"
     ]
   },
   "prettier": {

--- a/package.json
+++ b/package.json
@@ -150,7 +150,8 @@
       "/packages/jest-snapshot/src/__tests__/plugins",
       "/packages/jest-validate/src/__tests__/fixtures/",
       "/packages/jest-worker/src/__performance_tests__",
-      "/packages/pretty-format/perf/test.js"
+      "/packages/pretty-format/perf/test.js",
+      "/integration_tests/__tests__/iterator-to-null-test.js"
     ]
   },
   "prettier": {

--- a/packages/jest-runtime/src/__tests__/runtime_jest_fn.js
+++ b/packages/jest-runtime/src/__tests__/runtime_jest_fn.js
@@ -60,7 +60,7 @@ describe('Runtime', () => {
         expect(mock1).toBeCalled();
         expect(mock2).toBeCalled();
 
-        jest.clearAllMocks();
+        runtime.clearAllMocks();
 
         expect(mock1).not.toBeCalled();
         expect(mock2).not.toBeCalled();


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
I discovered that the `testMatch` in the root package.json meant that a few test suites did not run.

One was simply old, so I deleted it. Then a bunch of extra files in `__tests__` tried to run, so I ignored them.

But it still leaves 3 tests which fails.

![image](https://user-images.githubusercontent.com/1404810/31320293-a66d48aa-ac72-11e7-89aa-03ede46148f6.png)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
Green CI (eventually)

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
