### PR TITLE
Adds an 'any' to the typedef for updateFileWithJestStatus in editor support

### DIFF
--- a/packages/jest-editor-support/index.d.ts
+++ b/packages/jest-editor-support/index.d.ts
@@ -67,7 +67,7 @@ export class TestReconciler {
     file: string,
     name: string,
   ): TestFileAssertionStatus | null;
-  updateFileWithJestStatus(data): TestFileAssertionStatus[];
+  updateFileWithJestStatus(data: any): TestFileAssertionStatus[];
 }
 
 export type TestReconcilationState =


### PR DESCRIPTION
**Summary**

If you have the typescript compiler with "no implict anys" turned on, then importing jest-editor-support will fail.

**Test plan**

None, this should be fine.