### PR TITLE
Added a new category called Framework Guides

### DIFF
--- a/docs/en/CLI.md
+++ b/docs/en/CLI.md
@@ -5,7 +5,7 @@ layout: docs
 category: API Reference
 permalink: docs/en/cli.html
 previous: configuration
-next: snapshot-testing
+next: tutorial-react
 ---
 
 The `jest` command line runner has a number of useful options. You can run `jest --help` to view all available options. Many of the options shown below can also be used together to run tests exactly the way you want. Every one of Jest's [Configuration](/jest/docs/configuration.html) options can also be specified through the CLI.

--- a/docs/en/MigrationGuide.md
+++ b/docs/en/MigrationGuide.md
@@ -5,7 +5,7 @@ layout: docs
 category: Guides
 permalink: docs/en/migration-guide.html
 previous: webpack
-next: testing-frameworks
+next: troubleshooting
 ---
 
 If you'd like to try out Jest with an existing codebase, there are a number of ways to convert to Jest:

--- a/docs/en/SnapshotTesting.md
+++ b/docs/en/SnapshotTesting.md
@@ -4,7 +4,8 @@ title: Snapshot Testing
 layout: docs
 category: Guides
 permalink: docs/en/snapshot-testing.html
-next: tutorial-react
+previous: testing-frameworks
+next: tutorial-async
 ---
 
 Snapshot tests are a very useful tool whenever you want to make sure your UI does not change unexpectedly.

--- a/docs/en/TestingFrameworks.md
+++ b/docs/en/TestingFrameworks.md
@@ -1,11 +1,11 @@
 ---
 id: testing-frameworks
-title: Testing other frameworks
+title: Testing web frameworks
 layout: docs
-category: Guides
+category: Framework Guides
 permalink: docs/en/testing-frameworks.html
-previous: migration-guide
-next: troubleshooting
+previous: tutorial-react-native
+next: snapshot-testing
 ---
 
 Although Jest may be considered a React-specific test runner, in fact it is a universal testing platform, with the ability to adapt to any JavaScript library or framework. In this section we'd like to link to community posts and articles about integrating Jest into other popular JS libraries.

--- a/docs/en/Troubleshooting.md
+++ b/docs/en/Troubleshooting.md
@@ -4,7 +4,7 @@ title: Troubleshooting
 layout: docs
 category: Guides
 permalink: docs/en/troubleshooting.html
-previous: testing-frameworks
+previous: migration-guide
 ---
 
 Uh oh, something went wrong? Use this guide to resolve issues with Jest.

--- a/docs/en/TutorialAsync.md
+++ b/docs/en/TutorialAsync.md
@@ -4,7 +4,7 @@ title: An Async Example
 layout: docs
 category: Guides
 permalink: docs/en/tutorial-async.html
-previous: tutorial-react-native
+previous: snapshot-testing
 next: timer-mocks
 ---
 

--- a/docs/en/TutorialReact.md
+++ b/docs/en/TutorialReact.md
@@ -2,9 +2,9 @@
 id: tutorial-react
 title: Testing React Apps
 layout: docs
-category: Guides
+category: Framework Guides
 permalink: docs/en/tutorial-react.html
-previous: snapshot-testing
+previous: cli
 next: tutorial-react-native
 ---
 

--- a/docs/en/TutorialReactNative.md
+++ b/docs/en/TutorialReactNative.md
@@ -2,10 +2,10 @@
 id: tutorial-react-native
 title: Testing React Native Apps
 layout: docs
-category: Guides
+category: Framework Guides
 permalink: docs/en/tutorial-react-native.html
 previous: tutorial-react
-next: tutorial-async
+next: testing-frameworks
 ---
 
 At Facebook, we use Jest to test [React Native](http://facebook.github.io/react-native/)

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -89,7 +89,7 @@
     "setup-teardown": "Setup and Teardown",
     "snapshot-testing": "Snapshot Testing",
     "timer-mocks": "Timer Mocks",
-    "testing-frameworks": "Testing Other Frameworks",
+    "testing-frameworks": "Testing Web Frameworks",
     "troubleshooting": "Troubleshooting",
     "tutorial-async": "An Async Example",
     "tutorial-jquery": "DOM Manipulation",


### PR DESCRIPTION
Pull request related to issue #4638 

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

This modification creates a new category called "Framework Guides" whose intent is to group all guides related to testing web frameworks with Jest.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

As mentioned in the issue #4638, this modification minimize the feeling that React is "the framework" and everything else is branded as "other".

**Test plan**

**Set up:**

- Clone the repo
- run: yarn install
- cd into the website folder
- run: npm ./server/generate.js
- run: yarn start

**Check:**

- [ ] That "Framework Guides" section appears on the left menu before the "Guides" section.

- [ ] That "Framework Guides" section contains only the following 3 links: 
- Testing React Apps
- Testing React Native Apps
- Testing Web Frameworks

The menu content before this change is as follows:
![captura de tela 2017-10-10 as 23 30 08](https://user-images.githubusercontent.com/1257133/31411787-03e01bba-ae13-11e7-8158-7d938715a870.png)

The menu content after this change:
![captura de tela 2017-10-10 as 23 29 41](https://user-images.githubusercontent.com/1257133/31411801-0e91930e-ae13-11e7-9d36-125ae6c0cb33.png)


<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
