### PR TITLE
Remove unavailable link from docs/testing-frameworks

### DIFF
--- a/docs/en/TestingFrameworks.md
+++ b/docs/en/TestingFrameworks.md
@@ -31,7 +31,3 @@ Although Jest may be considered a React-specific test runner, in fact it is a un
 ## Redux
 
 * [Writing Tests](http://redux.js.org/docs/recipes/WritingTests.html) by Redux docs
-
-## WebComponents
-
-* [Testing WebComponents with Jest and Webpack](https://stackoverflow.com/documentation/web-component/10057/testing-web-components/30849/webpack-and-jest#t=201705260237509850601) by Rafał Lorenz ([@vardius](http://rafallorenz.com))


### PR DESCRIPTION
**Summary**

The Web Components example is pointing to a Stack Overflow Documentation page, a service that was discontinued.
Since no other information is provided besides the link, I removed this from the documentation.
Ideally a new resource should be added, but I don't have any suggestions.

**Test plan**

I was unable to build the website (a package is incompatible with my system), but since this is a simple documentation change, I decided to submit it anyway.
