### PR TITLE
Update link to react docs.

### DIFF
--- a/docs/en/TutorialReact.md
+++ b/docs/en/TutorialReact.md
@@ -8,7 +8,7 @@ previous: cli
 next: tutorial-react-native
 ---
 
-At Facebook, we use Jest to test [React](http://facebook.github.io/react/)
+At Facebook, we use Jest to test [React](https://reactjs.org/)
 applications.
 
 ## Setup


### PR DESCRIPTION
Small update to the current link of the react documents

Update link to react docs 

**Summary**

The react docs are on a different link  I updated the current one to that 

**Test plan**
The new link points to the current react documentation

