### PR TITLE
Update UsingMatchers.md to fix broken links

### DIFF
--- a/docs/UsingMatchers.md
+++ b/docs/UsingMatchers.md
@@ -156,6 +156,6 @@ test('compiling android goes as expected', () => {
 
 ### And More
 
-This is just a taste. For a complete list of matchers, check out the [reference docs](/jest/docs/expect.html).
+This is just a taste. For a complete list of matchers, check out the [reference docs](/jest/docs/en/expect.html).
 
-Once you've learned about the matchers that are available, a good next step is to check out how Jest lets you [test asynchronous code](/jest/docs/asynchronous.html).
+Once you've learned about the matchers that are available, a good next step is to check out how Jest lets you [test asynchronous code](/jest/docs/en/asynchronous.html).


### PR DESCRIPTION
## Done

Adding a missing `/en/` to two links at the bottom of the '[Using matchers](https://facebook.github.io/jest/docs/en/using-matchers.html)' doc page as they are currently 404ing on production.

## Testing

Review the two text snippets reproduced below and verify the links now go to the correct page.

**Link 1:**
"This is just a taste. For a complete list of matchers, check out the [reference docs](https://facebook.github.io/jest/docs/en/expect.html)."

**Link 2:**
"Once you've learned about the matchers that are available, a good next step is to check out how Jest lets you [test asynchronous code](https://facebook.github.io/jest/docs/en/asynchronous.html)."