### PR TITLE
Fix DOMElement plugin to format SVG in jsdom 11

### DIFF
--- a/packages/pretty-format/src/__tests__/dom_element.test.js
+++ b/packages/pretty-format/src/__tests__/dom_element.test.js
@@ -301,38 +301,62 @@ Testing.`;
     );
   });
 
-  it('matches constructor name of SVG elements', () => {
+  describe('matches constructor name of SVG elements', () => {
     // Too bad, so sad, element.constructor.name of SVG elements
-    // is HTMLUnknownElement in jsdom v9
+    // is HTMLUnknownElement in jsdom v9 and v10
+    // is Element in jsdom v11
     // instead of SVG…Element in browser DOM
-    // Mock element objects to make sure the plugin really matches them.
-    function SVGSVGElement(attributes, ...children) {
-      this.nodeType = 1;
-      this.tagName = 'svg'; // lower case
-      this.attributes = attributes;
-      this.childNodes = children;
-    }
-    function SVGTitleElement(title) {
-      this.nodeType = 1;
-      this.tagName = 'title'; // lower case
-      this.attributes = [];
-      this.childNodes = [document.createTextNode(title)];
-    }
+    const expected = [
+      '<svg',
+      '  viewBox="0 0 1 1"',
+      '>',
+      '  <title>',
+      '    JS community logo',
+      '  </title>',
+      '</svg>',
+    ].join('\n');
 
-    const title = new SVGTitleElement('JS community logo');
-    const svg = new SVGSVGElement([{name: 'viewBox', value: '0 0 1 1'}], title);
+    test('jsdom 9 and 10', () => {
+      // Mock element objects to make sure the plugin really matches them.
+      function SVGSVGElement(attributes, ...children) {
+        this.nodeType = 1;
+        this.tagName = 'svg'; // lower case
+        this.attributes = attributes;
+        this.childNodes = children;
+      }
+      function SVGTitleElement(title) {
+        this.nodeType = 1;
+        this.tagName = 'title'; // lower case
+        this.attributes = [];
+        this.childNodes = [document.createTextNode(title)];
+      }
 
-    expect(svg).toPrettyPrintTo(
-      [
-        '<svg',
-        '  viewBox="0 0 1 1"',
-        '>',
-        '  <title>',
-        '    JS community logo',
-        '  </title>',
-        '</svg>',
-      ].join('\n'),
-    );
+      const title = new SVGTitleElement('JS community logo');
+      const svg = new SVGSVGElement(
+        [{name: 'viewBox', value: '0 0 1 1'}],
+        title,
+      );
+
+      expect(svg).toPrettyPrintTo(expected);
+    });
+    test('jsdom 11', () => {
+      // Mock element objects to make sure the plugin really matches them.
+      function Element(tagName, attributes, ...children) {
+        this.nodeType = 1;
+        this.tagName = tagName; // lower case
+        this.attributes = attributes;
+        this.childNodes = children;
+      }
+
+      const title = new Element('title', [], 'JS community logo');
+      const svg = new Element(
+        'svg',
+        [{name: 'viewBox', value: '0 0 1 1'}],
+        title,
+      );
+
+      expect(svg).toPrettyPrintTo(expected);
+    });
   });
 
   it('supports SVG elements', () => {

--- a/packages/pretty-format/src/plugins/dom_element.js
+++ b/packages/pretty-format/src/plugins/dom_element.js
@@ -42,7 +42,7 @@ const ELEMENT_NODE = 1;
 const TEXT_NODE = 3;
 const COMMENT_NODE = 8;
 
-const ELEMENT_REGEXP = /^(HTML|SVG)\w*?Element$/;
+const ELEMENT_REGEXP = /^((HTML|SVG)\w*)?Element$/;
 
 const testNode = (nodeType: any, name: any) =>
   (nodeType === ELEMENT_NODE && ELEMENT_REGEXP.test(name)) ||


### PR DESCRIPTION
**Summary**

Fixes #4645

An SVG element has constructor name:
* `HTMLUnknownElement` in jsdom 9 and jsdom 10
* `Element` in jsdom 11

The regexp has always had `?` but it didn’t work as intended without parentheses.

Therefore `pretty-format` attempted to serialize SVG elements as ordinary objects.

**Test plan**

Added a test (which failed first) to match `Element` as `val.constructor.name`

@SimenB Thank you for outstanding example of repro repo!

For your info, I rewrote `{ plugins: prettyFormat.plugins }` because `plugins` option value needs to be an array but `plugins` prop value is an object :)