### PR TITLE
Add a serializer for jest.fn to jest-snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@
 * `[jest-runtime]` Add `module.loaded`, and make `module.require` not enumerable ([#4623](https://github.com/facebook/jest/pull/4623))
 * `[jest-runtime]` Add `module.parent` ([#4614](https://github.com/facebook/jest/pull/4614))
 * `[jest-runtime]` Support sourcemaps in transformers ([#3458](https://github.com/facebook/jest/pull/3458))
-* `[jest-snapshot]` Add a serializer for `jest.fn` to allow a snapshot of a jest mock (TBD)
+* `[jest-snapshot]` Add a serializer for `jest.fn` to allow a snapshot of a jest mock ([#4668](https://github.com/facebook/jest/pull/4668))
 * `[jest-worker]` Initial version of parallel worker abstraction, say hello! ([#4497](https://github.com/facebook/jest/pull/4497))
 
 ### Chore & Maintenance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 * `[jest-runtime]` Add `module.loaded`, and make `module.require` not enumerable ([#4623](https://github.com/facebook/jest/pull/4623))
 * `[jest-runtime]` Add `module.parent` ([#4614](https://github.com/facebook/jest/pull/4614))
 * `[jest-runtime]` Support sourcemaps in transformers ([#3458](https://github.com/facebook/jest/pull/3458))
+* `[jest-snapshot]` Add a serializer for `jest.fn` to allow a snapshot of a jest mock (TBD)
 * `[jest-worker]` Initial version of parallel worker abstraction, say hello! ([#4497](https://github.com/facebook/jest/pull/4497))
 
 ### Chore & Maintenance

--- a/docs/MockFunctions.md
+++ b/docs/MockFunctions.md
@@ -239,7 +239,7 @@ expect(mockFunc).toBeCalledWith(arg1, arg2);
 // The last call to the mock function was called with the specified args
 expect(mockFunc).lastCalledWith(arg1, arg2);
 
-// All calls, instantiations and the name of the mock is written as a snapshot
+// All calls and the name of the mock is written as a snapshot
 expect(mockFunc).toMatchSnapshot();
 ```
 
@@ -266,7 +266,6 @@ expect(mockFunc.mock.calls[mockFunc.mock.calls.length - 1][0]).toBe(42);
 // A snapshot will check that a mock was invoked the same number of times,
 // in the same order, with the same arguments. It will also assert on the name. 
 expect(mockFunc.mock.calls).toEqual([[arg1, arg2]]);
-expect(mockFunc.mock.instances).toEqual([{name: 'some name'}]);
 expect(mockFunc.mock.getMockName()).toBe('a mock name');
 ```
 

--- a/docs/MockFunctions.md
+++ b/docs/MockFunctions.md
@@ -238,6 +238,9 @@ expect(mockFunc).toBeCalledWith(arg1, arg2);
 
 // The last call to the mock function was called with the specified args
 expect(mockFunc).lastCalledWith(arg1, arg2);
+
+// All calls, instantiations and the name of the mock is written as a snapshot
+expect(mockFunc).toMatchSnapshot();
 ```
 
 These matchers are really just sugar for common forms of inspecting the `.mock`
@@ -259,6 +262,12 @@ expect(mockFunc.mock.calls[mockFunc.mock.calls.length - 1]).toEqual(
 // The first arg of the last call to the mock function was `42`
 // (note that there is no sugar helper for this specific of an assertion)
 expect(mockFunc.mock.calls[mockFunc.mock.calls.length - 1][0]).toBe(42);
+
+// A snapshot will check that a mock was invoked the same number of times,
+// in the same order, with the same arguments. It will also assert on the name. 
+expect(mockFunc.mock.calls).toEqual([[arg1, arg2]]);
+expect(mockFunc.mock.instances).toEqual([{name: 'some name'}]);
+expect(mockFunc.mock.getMockName()).toBe('a mock name');
 ```
 
 For a complete list of matchers, check out the [reference docs](/jest/docs/en/expect.html).

--- a/packages/jest-snapshot/package.json
+++ b/packages/jest-snapshot/package.json
@@ -11,7 +11,6 @@
     "chalk": "^2.0.1",
     "jest-diff": "^21.2.1",
     "jest-matcher-utils": "^21.2.1",
-    "jest-mock": "^21.2.0",
     "mkdirp": "^0.5.1",
     "natural-compare": "^1.4.0",
     "pretty-format": "^21.2.1"

--- a/packages/jest-snapshot/package.json
+++ b/packages/jest-snapshot/package.json
@@ -11,6 +11,7 @@
     "chalk": "^2.0.1",
     "jest-diff": "^21.2.1",
     "jest-matcher-utils": "^21.2.1",
+    "jest-mock": "^21.2.0",
     "mkdirp": "^0.5.1",
     "natural-compare": "^1.4.0",
     "pretty-format": "^21.2.1"

--- a/packages/jest-snapshot/src/__tests__/__snapshots__/mock_serializer.test.js.snap
+++ b/packages/jest-snapshot/src/__tests__/__snapshots__/mock_serializer.test.js.snap
@@ -1,0 +1,42 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`empty with no calls mock 1`] = `
+Object {
+  "calls": Array [],
+  "name": "jest.fn()",
+}
+`;
+
+exports[`instantiated mock 1`] = `
+Object {
+  "calls": Array [
+    Array [
+      Object {
+        "name": "some fine name",
+      },
+    ],
+  ],
+  "name": "jest.fn()",
+}
+`;
+
+exports[`mock with calls 1`] = `
+Object {
+  "calls": Array [
+    Array [],
+    Array [
+      Object {
+        "foo": "bar",
+      },
+    ],
+  ],
+  "name": "jest.fn()",
+}
+`;
+
+exports[`mock with name 1`] = `
+Object {
+  "calls": Array [],
+  "name": "name of mock is nice",
+}
+`;

--- a/packages/jest-snapshot/src/__tests__/__snapshots__/mock_serializer.test.js.snap
+++ b/packages/jest-snapshot/src/__tests__/__snapshots__/mock_serializer.test.js.snap
@@ -3,6 +3,7 @@
 exports[`empty with no calls mock 1`] = `
 Object {
   "calls": Array [],
+  "instances": Array [],
   "name": "jest.fn()",
 }
 `;
@@ -16,6 +17,9 @@ Object {
       },
     ],
   ],
+  "instances": Array [
+    mockConstructor {},
+  ],
   "name": "jest.fn()",
 }
 `;
@@ -28,7 +32,12 @@ Object {
       Object {
         "foo": "bar",
       },
+      42,
     ],
+  ],
+  "instances": Array [
+    undefined,
+    undefined,
   ],
   "name": "jest.fn()",
 }
@@ -37,6 +46,7 @@ Object {
 exports[`mock with name 1`] = `
 Object {
   "calls": Array [],
+  "instances": Array [],
   "name": "name of mock is nice",
 }
 `;

--- a/packages/jest-snapshot/src/__tests__/__snapshots__/mock_serializer.test.js.snap
+++ b/packages/jest-snapshot/src/__tests__/__snapshots__/mock_serializer.test.js.snap
@@ -3,7 +3,6 @@
 exports[`empty with no calls mock 1`] = `
 Object {
   "calls": Array [],
-  "instances": Array [],
   "name": "jest.fn()",
 }
 `;
@@ -16,9 +15,6 @@ Object {
         "name": "some fine name",
       },
     ],
-  ],
-  "instances": Array [
-    mockConstructor {},
   ],
   "name": "jest.fn()",
 }
@@ -35,10 +31,6 @@ Object {
       42,
     ],
   ],
-  "instances": Array [
-    undefined,
-    undefined,
-  ],
   "name": "jest.fn()",
 }
 `;
@@ -46,7 +38,6 @@ Object {
 exports[`mock with name 1`] = `
 Object {
   "calls": Array [],
-  "instances": Array [],
   "name": "name of mock is nice",
 }
 `;

--- a/packages/jest-snapshot/src/__tests__/mock_serializer.test.js
+++ b/packages/jest-snapshot/src/__tests__/mock_serializer.test.js
@@ -24,7 +24,7 @@ test('instantiated mock', () => {
 
 test('mock with calls', () => {
   mock();
-  mock({foo: 'bar'});
+  mock({foo: 'bar'}, 42);
 
   expect(mock).toMatchSnapshot();
 });

--- a/packages/jest-snapshot/src/__tests__/mock_serializer.test.js
+++ b/packages/jest-snapshot/src/__tests__/mock_serializer.test.js
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+'use strict';
+
+const mock = jest.fn();
+
+afterEach(() => mock.mockReset());
+
+test('empty with no calls mock', () => {
+  expect(mock).toMatchSnapshot();
+});
+
+test('instantiated mock', () => {
+  // eslint-disable-next-line no-new
+  new mock({name: 'some fine name'});
+
+  expect(mock).toMatchSnapshot();
+});
+
+test('mock with calls', () => {
+  mock();
+  mock({foo: 'bar'});
+
+  expect(mock).toMatchSnapshot();
+});
+
+test('mock with name', () => {
+  const mockWithName = jest.fn().mockName('name of mock is nice');
+
+  expect(mockWithName).toMatchSnapshot();
+});

--- a/packages/jest-snapshot/src/__tests__/plugins.test.js
+++ b/packages/jest-snapshot/src/__tests__/plugins.test.js
@@ -31,7 +31,7 @@ const testPath = names => {
 it('gets plugins', () => {
   const {getSerializers} = require('../plugins');
   const plugins = getSerializers();
-  expect(plugins.length).toBe(4);
+  expect(plugins).toHaveLength(5);
 });
 
 it('adds plugins from an empty array', () => testPath([]));

--- a/packages/jest-snapshot/src/mock_serializer.js
+++ b/packages/jest-snapshot/src/mock_serializer.js
@@ -19,7 +19,6 @@ export const serialize = (
 ): string => {
   const mockObject = {
     calls: val.mock.calls,
-    instances: val.mock.instances,
     name: val.getMockName(),
   };
 

--- a/packages/jest-snapshot/src/mock_serializer.js
+++ b/packages/jest-snapshot/src/mock_serializer.js
@@ -9,8 +9,6 @@
 
 import type {Config, NewPlugin, Printer, Refs} from 'types/PrettyFormat';
 
-import jestMock from 'jest-mock';
-
 export const serialize = (
   val: any,
   config: Config,
@@ -28,6 +26,6 @@ export const serialize = (
   return printer(mockObject, config, indentation, depth, refs);
 };
 
-export const test = jestMock.isMockFunction;
+export const test = (val: any) => val && !!val._isMockFunction;
 
 export default ({serialize, test}: NewPlugin);

--- a/packages/jest-snapshot/src/mock_serializer.js
+++ b/packages/jest-snapshot/src/mock_serializer.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {Config, NewPlugin, Printer, Refs} from 'types/PrettyFormat';
+
+import jestMock from 'jest-mock';
+
+export const serialize = (
+  val: any,
+  config: Config,
+  indentation: string,
+  depth: number,
+  refs: Refs,
+  printer: Printer,
+): string => {
+  const mockObject = {
+    calls: val.mock.calls,
+    instances: val.mock.instances,
+    name: val.getMockName(),
+  };
+
+  return printer(mockObject, config, indentation, depth, refs);
+};
+
+export const test = jestMock.isMockFunction;
+
+export default ({serialize, test}: NewPlugin);

--- a/packages/jest-snapshot/src/plugins.js
+++ b/packages/jest-snapshot/src/plugins.js
@@ -10,6 +10,7 @@
 import type {Plugin} from 'types/PrettyFormat';
 
 import prettyFormat from 'pretty-format';
+import jestMockSerializer from './mock_serializer';
 
 const {
   DOMElement,
@@ -18,7 +19,13 @@ const {
   ReactTestComponent,
 } = prettyFormat.plugins;
 
-let PLUGINS = [ReactTestComponent, ReactElement, DOMElement, Immutable];
+let PLUGINS = [
+  ReactTestComponent,
+  ReactElement,
+  DOMElement,
+  Immutable,
+  jestMockSerializer,
+];
 
 // Prepend to list so the last added is the first tested.
 export const addSerializer = (plugin: Plugin) => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
This adds a serializer to be able to easily assert on the calls of a mock.

This is very easy to implement in userland, so I understand if it's not merged 🙂 But it's been useful for me, so maybe it'll be useful for others?

(I started creating a separate module for this, but I got annoyed that I couldn't use `mock.getMockName()`, so here's a PR)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
New tests added

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
