### PR TITLE
Fix asynchronous test will fail due to timeout issue.

### DIFF
--- a/integration_tests/__tests__/jasmine_async.test.js
+++ b/integration_tests/__tests__/jasmine_async.test.js
@@ -132,4 +132,12 @@ describe('async jasmine', () => {
     expect(json.numPendingTests).toBe(1);
     expect(json.testResults[0].message).toMatch(/concurrent test fails/);
   });
+
+  it('async test fails', () => {
+    const result = runJest.json('jasmine_async', ['async_test_fails.test.js']);
+    const stdout = result.stdout;
+
+    const expected = 'Expected value to be truthy, instead received';
+    expect(stdout).toEqual(expect.stringContaining(expected));
+  });
 });

--- a/integration_tests/__tests__/jasmine_async.test.js
+++ b/integration_tests/__tests__/jasmine_async.test.js
@@ -135,9 +135,10 @@ describe('async jasmine', () => {
 
   it('async test fails', () => {
     const result = runJest.json('jasmine_async', ['async_test_fails.test.js']);
-    const stdout = result.stdout;
 
-    const expected = 'Expected value to be truthy, instead received';
-    expect(stdout).toEqual(expect.stringContaining(expected));
+    expect(result.status).toBe(1);
+    expect(result.json.testResults[0].message).toEqual(
+      expect.stringContaining('Expected value to be truthy, instead received'),
+    );
   });
 });

--- a/integration_tests/jasmine_async/__tests__/async_test_fails.test.js
+++ b/integration_tests/jasmine_async/__tests__/async_test_fails.test.js
@@ -3,6 +3,8 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
+ *
+ * @jest-environment jsdom
  */
 
 'use strict';

--- a/integration_tests/jasmine_async/__tests__/async_test_fails.test.js
+++ b/integration_tests/jasmine_async/__tests__/async_test_fails.test.js
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+it('async test fails', done => {
+  setTimeout(() => {
+    expect(false).toBeTruthy();
+    done();
+  }, 1 * 1000);
+});


### PR DESCRIPTION
* Send error event to Node.js process.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Execute following asynchronous test.

```js
it('asynchronous test', (done) => {
  setTimeout(function() {
    expect(false).toBeTruthy();
    done();
  }, 1 * 1000);
});
```

Expect:
```
    expect(received).toBeTruthy()

    Expected value to be truthy, instead received
      false
```
Actual:
```
Timeout - Async callback was not invoked within timeout specified by jasmine.DEFAULT_TIMEOUT_INTERVAL.
```

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Above test result as expected.
```
  ● describe ? asynchronous test

    expect(received).toBeTruthy()

    Expected value to be truthy, instead received
      false

      at __tests__/test.spec.js:23:21
      at Timeout.callback [as _onTimeout] (node_modules/jsdom/lib/jsdom/browser/Window.js:523:19)
      at ontimeout (timers.js:365:14)
      at tryOnTimeout (timers.js:237:5)
      at Timer.listOnTimeout (timers.js:207:5)
```