### PR TITLE
Fix bad link to jest cli docs

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -65,7 +65,7 @@ Here's how to run Jest on files matching `my-test`, using `config.json` as a con
 jest my-test --notify --config=config.json
 ```
 
-If you'd like to learn more about running `jest` through the command line, take a look at the [Jest CLI Options](https://facebook.github.io/jest/docs/cli.html) page.
+If you'd like to learn more about running `jest` through the command line, take a look at the [Jest CLI Options](https://facebook.github.io/jest/docs/en/cli.html) page.
 
 ## Additional Configuration
 


### PR DESCRIPTION
[MAY BE DUPE OF #4663 ]

Looks like you recently internationalized without fixing this link.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Ahhh, just a broken link in the docs.  

**Test plan**

No code, just a URL.  

Bad❌  https://facebook.github.io/jest/docs/cli.html
Good ✅ https://facebook.github.io/jest/docs/en/cli.html

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
