### PR TITLE
Fix links to other documentation pages

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -3,7 +3,7 @@ id: cli
 title: Jest CLI Options
 ---
 
-The `jest` command line runner has a number of useful options. You can run `jest --help` to view all available options. Many of the options shown below can also be used together to run tests exactly the way you want. Every one of Jest's [Configuration](/jest/docs/configuration.html) options can also be specified through the CLI.
+The `jest` command line runner has a number of useful options. You can run `jest --help` to view all available options. Many of the options shown below can also be used together to run tests exactly the way you want. Every one of Jest's [Configuration](Configuration.md) options can also be specified through the CLI.
 
 Here is a brief overview:
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -65,7 +65,7 @@ Here's how to run Jest on files matching `my-test`, using `config.json` as a con
 jest my-test --notify --config=config.json
 ```
 
-If you'd like to learn more about running `jest` through the command line, take a look at the [Jest CLI Options](https://facebook.github.io/jest/docs/en/cli.html) page.
+If you'd like to learn more about running `jest` through the command line, take a look at the [Jest CLI Options](CLI.md) page.
 
 ## Additional Configuration
 

--- a/docs/GlobalAPI.md
+++ b/docs/GlobalAPI.md
@@ -285,7 +285,7 @@ test('did not rain', () => {
 The first argument is the test name; the second argument is a function that contains the expectations to test.
 
 > Note: If a **promise is returned** from `test`, Jest will wait for the promise to resolve before letting the test complete.
-Jest will also wait if you **provide an argument to the test function**, usually called `done`. This could be handy when you want to test callbacks. See how to test async code [here](http://facebook.github.io/jest/docs/en/asynchronous.html#callbacks).
+Jest will also wait if you **provide an argument to the test function**, usually called `done`. This could be handy when you want to test callbacks. See how to test async code [here](TestingAsyncCode.md#callbacks).
 
 For example, let's say `fetchBeverageList()` returns a promise that is supposed to resolve to a list that has `lemon` in it. You can test this with:
 

--- a/docs/ManualMocks.md
+++ b/docs/ManualMocks.md
@@ -5,7 +5,7 @@ title: Manual Mocks
 
 Manual mocks are used to stub out functionality with mock data. For example, instead of accessing a remote resource like a website or a database, you might want to create a manual mock that allows you to use fake data. This ensures your tests will be fast and not flaky.
 
-Manual mocks are defined by writing a module in a `__mocks__/` subdirectory immediately adjacent to the module. For example, to mock a module called `user` in the `models` directory, create a file called `user.js` and put it in the `models/__mocks__` directory. Note that the `__mocks__` folder is case-sensitive, so naming the directory `__MOCKS__` will break on some systems. If the module you are mocking is a node module (eg: `fs`), the mock should be placed in the `__mocks__` directory adjacent to `node_modules` (unless you configured [`roots`](/jest/docs/en/configuration.html#roots-array-string) to point to a folder other than the project root). Eg:
+Manual mocks are defined by writing a module in a `__mocks__/` subdirectory immediately adjacent to the module. For example, to mock a module called `user` in the `models` directory, create a file called `user.js` and put it in the `models/__mocks__` directory. Note that the `__mocks__` folder is case-sensitive, so naming the directory `__MOCKS__` will break on some systems. If the module you are mocking is a node module (eg: `fs`), the mock should be placed in the `__mocks__` directory adjacent to `node_modules` (unless you configured [`roots`](Configuration.md#roots-array-string) to point to a folder other than the project root). Eg:
 
 ```bash
 .

--- a/docs/MockFunctions.md
+++ b/docs/MockFunctions.md
@@ -10,7 +10,7 @@ when instantiated with `new`, and allowing test-time configuration of return
 values.
 
 There are two ways to mock functions: Either by creating a mock function to
-use in test code, or writing a [`manual mock`](/jest/docs/en/manual-mocks.html#content)
+use in test code, or writing a [`manual mock`](ManualMocks.md)
 to override a module dependency.
 
 ## Using a mock function
@@ -269,4 +269,4 @@ expect(mockFunc.mock.calls).toEqual([[arg1, arg2]]);
 expect(mockFunc.mock.getMockName()).toBe('a mock name');
 ```
 
-For a complete list of matchers, check out the [reference docs](/jest/docs/en/expect.html).
+For a complete list of matchers, check out the [reference docs](ExpectAPI.md).

--- a/docs/MoreResources.md
+++ b/docs/MoreResources.md
@@ -7,11 +7,11 @@ By now you should have a good idea of how Jest can make it easy to test your app
 
 ### Browse the docs
 
-- Learn about [Snapshot Testing](/jest/docs/en/snapshot-testing.html), [Mock Functions](/jest/docs/en/mock-functions.html), and more in our in-depth guides.
-- Migrate your existing tests to Jest by following our [migration guide](https://facebook.github.io/jest/docs/en/migration-guide.html).
-- Learn how to [configure Jest](/jest/docs/en/configuration.html).
-- Look at the full [API Reference](/jest/docs/en/api.html).
-- [Troubleshoot](/jest/docs/en/troubleshooting.html) problems with Jest.
+- Learn about [Snapshot Testing](SnapshotTesting.md), [Mock Functions](MockFunctions.md), and more in our in-depth guides.
+- Migrate your existing tests to Jest by following our [migration guide](MigrationGuide.md).
+- Learn how to [configure Jest](Configuration.md).
+- Look at the full [API Reference](GlobalAPI.md).
+- [Troubleshoot](Troubleshooting.md) problems with Jest.
 
 ### Learn by example
 

--- a/docs/UsingMatchers.md
+++ b/docs/UsingMatchers.md
@@ -156,6 +156,6 @@ test('compiling android goes as expected', () => {
 
 ### And More
 
-This is just a taste. For a complete list of matchers, check out the [reference docs](/jest/docs/en/expect.html).
+This is just a taste. For a complete list of matchers, check out the [reference docs](ExpectAPI.md).
 
-Once you've learned about the matchers that are available, a good next step is to check out how Jest lets you [test asynchronous code](/jest/docs/en/asynchronous.html).
+Once you've learned about the matchers that are available, a good next step is to check out how Jest lets you [test asynchronous code](TestingAsyncCode.md).


### PR DESCRIPTION
Fix applied like specified in Docusaurus documentation about linking to other docs: https://docusaurus.io/docs/en/doc-markdown.html#linking-other-documents

Fixes #4674

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
