### PR TITLE
Fix snapshot guide link

### DIFF
--- a/packages/jest-snapshot/src/utils.js
+++ b/packages/jest-snapshot/src/utils.js
@@ -20,7 +20,8 @@ import prettyFormat from 'pretty-format';
 export const SNAPSHOT_EXTENSION = 'snap';
 export const SNAPSHOT_VERSION = '1';
 const SNAPSHOT_VERSION_REGEXP = /^\/\/ Jest Snapshot v(.+),/;
-export const SNAPSHOT_GUIDE_LINK = 'https://goo.gl/fbAQLP';
+export const SNAPSHOT_GUIDE_LINK =
+  'http://facebook.github.io/jest/docs/en/snapshot-testing.html';
 export const SNAPSHOT_VERSION_WARNING = chalk.yellow(
   `${chalk.bold('Warning')}: Before you upgrade snapshots, ` +
     `we recommend that you revert any local changes to tests or other code, ` +


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Since Jest's website now have translations, the old snapshot guide link is broken. The old shortened link redirects to: http://facebook.github.io/jest/docs/snapshot-testing.html.

I fixed using http://facebook.github.io/jest/docs/en/snapshot-testing.html instead.
