### PR TITLE
Fix Broken Link to Webpack Guide

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -118,7 +118,7 @@ It will not use `development` section like Babel does by default when no `NODE_E
 
 ### Using webpack
 
-Jest can be used in projects that use [webpack](https://webpack.github.io/) to manage assets, styles, and compilation. webpack does offer some unique challenges over other tools. Refer to the [webpack guide](/jest/docs/webpack.html) to get started.
+Jest can be used in projects that use [webpack](https://webpack.github.io/) to manage assets, styles, and compilation. webpack does offer some unique challenges over other tools. Refer to the [webpack guide](Webpack.md) to get started.
 
 ### Using TypeScript
 


### PR DESCRIPTION
Fix broken link on Getting Started page to the Webpack guide.

I made the change by following the pattern of other links to docs in the same directory.  That is, I am referencing the Markdown file instead of the generated HTML which ends up with /en/ in the path (at least in my locale).

If this is not the correct way to do links in the documentation section, then please explain how.

Thanks.