### PR TITLE
Make cleanupStackTrace work on older and newer Node 8 version

### DIFF
--- a/integration_tests/utils.js
+++ b/integration_tests/utils.js
@@ -162,7 +162,7 @@ const cleanupStackTrace = (output: string) => {
     .replace(/\n.*at.*assert\.js.*$/gm, '')
     .replace(/\n.*at.*node\.js.*$/gm, '')
     .replace(/\n.*at.*next_tick\.js.*$/gm, '')
-    .replace(/\n.*at (new)? Promise \(<anonymous>\).*$/gm, '')
+    .replace(/\n.*at (new )?Promise \(<anonymous>\).*$/gm, '')
     .replace(/\n.*at <anonymous>.*$/gm, '')
     .replace(/\n.*at Generator.next \(<anonymous>\).*$/gm, '')
     .replace(/^.*at.*[\s][\(]?(\S*\:\d*\:\d*).*$/gm, '      at $1');


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

As @SimenB pointed out in https://github.com/facebook/jest/pull/4680#discussion_r144473570 the regex should be updated, so it works on older and newer versions of Node 8

**Test plan**

Make sure all CI pass.
