### PR TITLE
Add method to store arguments by value (#3809)

### DIFF
--- a/docs/MockFunctionAPI.md
+++ b/docs/MockFunctionAPI.md
@@ -190,3 +190,24 @@ const myMockFn = jest.fn()
 console.log(myMockFn(), myMockFn(), myMockFn(), myMockFn());
 > 'first call', 'second call', 'default', 'default'
 ```
+
+### `mockFn.storeArgumentsByValue()`
+##### available in Jest **21.3.0+**
+Configures the mock to store arguments by value instead of by reference. This is
+useful when you are intentionally mutating an argument passed to your mock
+function after it was called.
+
+```js
+const myMockFn = jest.fn().mockStoreArgumentsByValue();
+const myOtherMockFn = jest.fn();
+
+const someObject = {};
+
+myMockFn(someObject);
+myOtherMockFn(someObject);
+
+someObject.newProperty = 'I am new';
+
+expect(myMockFn).toHaveBeenCalledWith({}); // passes.
+expect(myOtherMockFn).toHaveBeenCalledWith({ newProperty: 'I am new' }); // also passes.
+```

--- a/packages/jest-mock/README.md
+++ b/packages/jest-mock/README.md
@@ -104,6 +104,12 @@ implementations for the function.
 
 Sets the default mock implementation for the function.
 
+##### `.mockStoreArgumentsByValue()`
+
+Configures the mock to store arguments by value instead of by reference. This is
+useful when you are intentionally mutating an argument passed to your mock
+function after it was called.
+
 ##### `.mockReturnThis()`
 
 Syntactic sugar for .mockImplementation(function() {return this;})

--- a/packages/jest-mock/src/__tests__/jest_mock.test.js
+++ b/packages/jest-mock/src/__tests__/jest_mock.test.js
@@ -600,4 +600,19 @@ describe('moduleMocker', () => {
       expect(spy2.mock.calls.length).toBe(1);
     });
   });
+
+  test('mockStoreArgumentsByValue causes arguments to be stored by value', () => {
+    const myMockFn = moduleMocker.fn().mockStoreArgumentsByValue();
+    const myOtherMockFn = moduleMocker.fn();
+
+    const someObject = {};
+
+    myMockFn(someObject);
+    myOtherMockFn(someObject);
+
+    someObject.newProperty = 'I am new';
+
+    expect(myMockFn).toHaveBeenCalledWith({});
+    expect(myOtherMockFn).toHaveBeenCalledWith({newProperty: 'I am new'});
+  });
 });

--- a/packages/jest-mock/src/index.js
+++ b/packages/jest-mock/src/index.js
@@ -28,6 +28,7 @@ type MockFunctionState = {
 
 type MockFunctionConfig = {
   isReturnValueLastSet: boolean,
+  storeArgumentsByValue: boolean,
   defaultReturnValue: any,
   mockImpl: any,
   mockName: string,
@@ -273,6 +274,7 @@ class ModuleMockerClass {
       mockName: 'jest.fn()',
       specificMockImpls: [],
       specificReturnValues: [],
+      storeArgumentsByValue: false,
     };
   }
 
@@ -313,7 +315,11 @@ class ModuleMockerClass {
         const mockState = mocker._ensureMockState(f);
         const mockConfig = mocker._ensureMockConfig(f);
         mockState.instances.push(this);
-        mockState.calls.push(Array.prototype.slice.call(arguments));
+        let argumentsArray = Array.prototype.slice.call(arguments);
+        if (mockConfig.storeArgumentsByValue) {
+          argumentsArray = JSON.parse(JSON.stringify(argumentsArray));
+        }
+        mockState.calls.push(argumentsArray);
         if (this instanceof f) {
           // This is probably being called as a constructor
           prototypeSlots.forEach(slot => {
@@ -428,6 +434,12 @@ class ModuleMockerClass {
         mockConfig.isReturnValueLastSet = false;
         mockConfig.defaultReturnValue = undefined;
         mockConfig.mockImpl = fn;
+        return f;
+      };
+
+      f.mockStoreArgumentsByValue = fn => {
+        const mockConfig = this._ensureMockConfig(f);
+        mockConfig.storeArgumentsByValue = true;
         return f;
       };
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

Adds a method to mock functions which allows them to store arguments by value instead of by reference. This allows you to expect arguments to be what they were when the mock function was called, even when you intentionally modified them afterward. See https://github.com/facebook/jest/issues/3809#issuecomment-336410194.

**Test plan**

I wrote a test for the new method which passed. Simply run `yarn test`. I did have some tests which failed for me locally, but it seemed unrelated to this feature and perhaps environmental.
