### PR TITLE
Always remove node internals from stacktraces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@
 * `[jest-editor-support]` Fix editor support test for node 4 ([#4640](https://github.com/facebook/jest/pull/4640))
 * `[jest-mock]` Support mocking constructor in `mockImplementationOnce` ([#4599](https://github.com/facebook/jest/pull/4599))
 * `[jest-runtime]` Fix manual user mocks not working with custom resolver ([#4489](https://github.com/facebook/jest/pull/4489))
-* `[jest-runtime]` Move `babel-core` to peer dependenies so it works with Babel 7 ([#4557](https://github.com/facebook/jest/pull/4557))
+* `[jest-runtime]` Move `babel-core` to peer dependencies so it works with Babel 7 ([#4557](https://github.com/facebook/jest/pull/4557))
 * `[jest-util]` Fix `runOnlyPendingTimers` for `setTimeout` inside `setImmediate` ([#4608](https://github.com/facebook/jest/pull/4608))
+* `[jest-message-util]` Always remove node internals from stacktraces (TBD)
 
 ### Features
 * `[jest-environment-*]` [**BREAKING**] Add Async Test Environment APIs, dispose is now teardown ([#4506](https://github.com/facebook/jest/pull/4506))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 * `[jest-runtime]` Fix manual user mocks not working with custom resolver ([#4489](https://github.com/facebook/jest/pull/4489))
 * `[jest-runtime]` Move `babel-core` to peer dependencies so it works with Babel 7 ([#4557](https://github.com/facebook/jest/pull/4557))
 * `[jest-util]` Fix `runOnlyPendingTimers` for `setTimeout` inside `setImmediate` ([#4608](https://github.com/facebook/jest/pull/4608))
-* `[jest-message-util]` Always remove node internals from stacktraces (TBD)
+* `[jest-message-util]` Always remove node internals from stacktraces ([#4695](https://github.com/facebook/jest/pull/4695))
 
 ### Features
 * `[jest-environment-*]` [**BREAKING**] Add Async Test Environment APIs, dispose is now teardown ([#4506](https://github.com/facebook/jest/pull/4506))

--- a/integration_tests/utils.js
+++ b/integration_tests/utils.js
@@ -157,15 +157,7 @@ const extractSummary = (stdout: string) => {
 // different versions of Node print different stack traces. This function
 // unifies their output to make it possible to snapshot them.
 const cleanupStackTrace = (output: string) => {
-  return output
-    .replace(/\n.*at.*timers\.js.*$/gm, '')
-    .replace(/\n.*at.*assert\.js.*$/gm, '')
-    .replace(/\n.*at.*node\.js.*$/gm, '')
-    .replace(/\n.*at.*next_tick\.js.*$/gm, '')
-    .replace(/\n.*at (new )?Promise \(<anonymous>\).*$/gm, '')
-    .replace(/\n.*at <anonymous>.*$/gm, '')
-    .replace(/\n.*at Generator.next \(<anonymous>\).*$/gm, '')
-    .replace(/^.*at.*[\s][\(]?(\S*\:\d*\:\d*).*$/gm, '      at $1');
+  return output.replace(/^.*at.*[\s][\(]?(\S*\:\d*\:\d*).*$/gm, '      at $1');
 };
 
 module.exports = {

--- a/integration_tests/utils.js
+++ b/integration_tests/utils.js
@@ -156,6 +156,7 @@ const extractSummary = (stdout: string) => {
 
 // different versions of Node print different stack traces. This function
 // unifies their output to make it possible to snapshot them.
+// TODO: Remove when we drop support for node 4
 const cleanupStackTrace = (output: string) => {
   return output.replace(/^.*at.*[\s][\(]?(\S*\:\d*\:\d*).*$/gm, '      at $1');
 };

--- a/integration_tests/utils.js
+++ b/integration_tests/utils.js
@@ -157,13 +157,12 @@ const extractSummary = (stdout: string) => {
 // different versions of Node print different stack traces. This function
 // unifies their output to make it possible to snapshot them.
 const cleanupStackTrace = (output: string) => {
-  return output
-    .replace(/\n.*at.*next_tick\.js.*$/gm, '')
-    .replace(/^.*at.*[\s][\(]?(\S*\:\d*\:\d*).*$/gm, '      at $1');
+  return output.replace(/^.*at.*[\s][\(]?(\S*\:\d*\:\d*).*$/gm, '      at $1');
 };
 
 module.exports = {
   cleanup,
+  cleanupStackTrace,
   copyDir,
   createEmptyPackage,
   extractSummary,

--- a/integration_tests/utils.js
+++ b/integration_tests/utils.js
@@ -157,12 +157,13 @@ const extractSummary = (stdout: string) => {
 // different versions of Node print different stack traces. This function
 // unifies their output to make it possible to snapshot them.
 const cleanupStackTrace = (output: string) => {
-  return output.replace(/^.*at.*[\s][\(]?(\S*\:\d*\:\d*).*$/gm, '      at $1');
+  return output
+    .replace(/\n.*at.*next_tick\.js.*$/gm, '')
+    .replace(/^.*at.*[\s][\(]?(\S*\:\d*\:\d*).*$/gm, '      at $1');
 };
 
 module.exports = {
   cleanup,
-  cleanupStackTrace,
   copyDir,
   createEmptyPackage,
   extractSummary,

--- a/packages/jest-message-util/package.json
+++ b/packages/jest-message-util/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "chalk": "^2.0.1",
     "micromatch": "^2.3.11",
-    "slash": "^1.0.0"
+    "slash": "^1.0.0",
+    "stack-utils": "^1.0.1"
   }
 }

--- a/packages/jest-message-util/src/__tests__/__snapshots__/messages.test.js.snap
+++ b/packages/jest-message-util/src/__tests__/__snapshots__/messages.test.js.snap
@@ -7,6 +7,23 @@ exports[`.formatExecError() 1`] = `
 "
 `;
 
+exports[`formatStackTrace should strip node internals 1`] = `
+"<bold><red>  <bold>● <bold>Unix test</></>
+
+      
+        Expected value to be of type:
+          \\"number\\"
+        Received:
+          \\"\\"
+        type:
+          \\"string\\"
+<dim>      </>
+<dim>      </>
+<dim>      <dim>at Object.it (<dim>__tests__/test.js<dim>:8:14)<dim></>
+<dim>      </>
+"
+`;
+
 exports[`should exclude jasmine from stack trace for Unix paths. 1`] = `
 "<bold><red>  <bold>● <bold>Unix test</></>
 

--- a/packages/jest-message-util/src/__tests__/messages.test.js
+++ b/packages/jest-message-util/src/__tests__/messages.test.js
@@ -8,7 +8,7 @@
 
 'use strict';
 
-const {formatResultsErrors, formatExecError} = require('../');
+const {formatResultsErrors, formatExecError} = require('..');
 
 const unixStackTrace =
   `  ` +
@@ -22,6 +22,27 @@ const unixStackTrace =
   at Object.it (build/__tests__/messages-test.js:45:41)
   at Object.<anonymous> (../jest-jasmine2/build/jasmine-pit.js:35:32)
   at attemptAsync (../jest-jasmine2/build/jasmine-2.4.1.js:1919:24)`;
+
+const assertionStack =
+  '  ' +
+  `
+    Expected value to be of type:
+      "number"
+    Received:
+      ""
+    type:
+      "string"
+
+      at Object.it (__tests__/test.js:8:14)
+      at Object.asyncFn (node_modules/jest-jasmine2/build/jasmine_async.js:124:345)
+      at resolve (node_modules/jest-jasmine2/build/queue_runner.js:46:12)
+          at Promise (<anonymous>)
+      at mapper (node_modules/jest-jasmine2/build/queue_runner.js:34:499)
+      at promise.then (node_modules/jest-jasmine2/build/queue_runner.js:74:39)
+          at <anonymous>
+      at process._tickCallback (internal/process/next_tick.js:188:7)
+      at internal/process/next_tick.js:188:7
+`;
 
 it('should exclude jasmine from stack trace for Unix paths.', () => {
   const messages = formatResultsErrors(
@@ -61,4 +82,24 @@ it('.formatExecError()', () => {
   );
 
   expect(message).toMatchSnapshot();
+});
+
+it('formatStackTrace should strip node internals', () => {
+  const messages = formatResultsErrors(
+    [
+      {
+        ancestorTitles: [],
+        failureMessages: [assertionStack],
+        title: 'Unix test',
+      },
+    ],
+    {
+      rootDir: '',
+    },
+    {
+      noStackTrace: false,
+    },
+  );
+
+  expect(messages).toMatchSnapshot();
 });

--- a/packages/jest-message-util/src/__tests__/messages.test.js
+++ b/packages/jest-message-util/src/__tests__/messages.test.js
@@ -41,6 +41,7 @@ const assertionStack =
       at promise.then (node_modules/jest-jasmine2/build/queue_runner.js:74:39)
           at <anonymous>
       at process._tickCallback (internal/process/next_tick.js:188:7)
+      at internal/process/next_tick.js:188:7
 `;
 
 it('should exclude jasmine from stack trace for Unix paths.', () => {

--- a/packages/jest-message-util/src/__tests__/messages.test.js
+++ b/packages/jest-message-util/src/__tests__/messages.test.js
@@ -41,7 +41,6 @@ const assertionStack =
       at promise.then (node_modules/jest-jasmine2/build/queue_runner.js:74:39)
           at <anonymous>
       at process._tickCallback (internal/process/next_tick.js:188:7)
-      at internal/process/next_tick.js:188:7
 `;
 
 it('should exclude jasmine from stack trace for Unix paths.', () => {

--- a/packages/jest-message-util/src/index.js
+++ b/packages/jest-message-util/src/index.js
@@ -19,9 +19,7 @@ import StackUtils from 'stack-utils';
 let nodeInternals = [];
 
 try {
-  nodeInternals = StackUtils.nodeInternals()
-    // Somehow we get a trace without the `process._tickCallback` part
-    .concat(new RegExp('internal/process/next_tick.js'));
+  nodeInternals = StackUtils.nodeInternals();
 } catch (e) {
   // `StackUtils.nodeInternals()` fails in browsers. We don't need to remove
   // node internals in the browser though, so no issue.

--- a/packages/jest-message-util/src/index.js
+++ b/packages/jest-message-util/src/index.js
@@ -36,8 +36,8 @@ type StackTraceOptions = {
 
 // filter for noisy stack trace lines
 const JASMINE_IGNORE = /^\s+at(?:(?:.*?vendor\/|jasmine\-)|\s+jasmine\.buildExpectationResult)/;
-const STACK_TRACE_IGNORE = /^\s+at.*?jest(-.*?)?(\/|\\)(build|node_modules|packages)(\/|\\)/;
-const ANONYMOUS_TRACE_IGNORE = /^\s+at <anonymous>.*$/;
+const JEST_INTERNALS_IGNORE = /^\s+at.*?jest(-.*?)?(\/|\\)(build|node_modules|packages)(\/|\\)/;
+const ANONYMOUS_FN_IGNORE = /^\s+at <anonymous>.*$/;
 const ANONYMOUS_PROMISE_IGNORE = /^\s+at (new )?Promise \(<anonymous>\).*$/;
 const ANONYMOUS_GENERATOR_IGNORE = /^\s+at Generator.next \(<anonymous>\).*$/;
 const TITLE_INDENT = '  ';
@@ -119,7 +119,7 @@ const removeInternalStackEntries = (lines, options: StackTraceOptions) => {
   let pathCounter = 0;
 
   return lines.filter(line => {
-    if (ANONYMOUS_TRACE_IGNORE.test(line)) {
+    if (ANONYMOUS_FN_IGNORE.test(line)) {
       return false;
     }
 
@@ -151,7 +151,7 @@ const removeInternalStackEntries = (lines, options: StackTraceOptions) => {
       return false;
     }
 
-    if (STACK_TRACE_IGNORE.test(line)) {
+    if (JEST_INTERNALS_IGNORE.test(line)) {
       return false;
     }
 

--- a/packages/jest-message-util/src/index.js
+++ b/packages/jest-message-util/src/index.js
@@ -20,7 +20,8 @@ let nodeInternals = [];
 
 try {
   nodeInternals = StackUtils.nodeInternals()
-    // Somehow we get a trace without the `process._tickCallback` part
+    // this is to have the tests be the same in node 4 and node 6.
+    // TODO: Remove when we drop support for node 4
     .concat(new RegExp('internal/process/next_tick.js'));
 } catch (e) {
   // `StackUtils.nodeInternals()` fails in browsers. We don't need to remove

--- a/packages/jest-message-util/src/index.js
+++ b/packages/jest-message-util/src/index.js
@@ -19,7 +19,9 @@ import StackUtils from 'stack-utils';
 let nodeInternals = [];
 
 try {
-  nodeInternals = StackUtils.nodeInternals();
+  nodeInternals = StackUtils.nodeInternals()
+    // Somehow we get a trace without the `process._tickCallback` part
+    .concat(new RegExp('internal/process/next_tick.js'));
 } catch (e) {
   // `StackUtils.nodeInternals()` fails in browsers. We don't need to remove
   // node internals in the browser though, so no issue.

--- a/packages/jest-message-util/src/index.js
+++ b/packages/jest-message-util/src/index.js
@@ -16,9 +16,16 @@ import micromatch from 'micromatch';
 import slash from 'slash';
 import StackUtils from 'stack-utils';
 
-const nodeInternals = StackUtils.nodeInternals()
-  // Somehow we get a trace without the `process._tickCallback` part
-  .concat(new RegExp('internal/process/next_tick.js'));
+let nodeInternals = [];
+
+try {
+  nodeInternals = StackUtils.nodeInternals()
+    // Somehow we get a trace without the `process._tickCallback` part
+    .concat(new RegExp('internal/process/next_tick.js'));
+} catch (e) {
+  // `StackUtils.nodeInternals()` fails in browsers. We don't need to remove
+  // node internals in the browser though, so no issue.
+}
 
 type StackTraceConfig = {
   rootDir: string,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5444,6 +5444,10 @@ sshpk@^1.7.0:
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
 
+stack-utils@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.1.tgz#d4f33ab54e8e38778b0ca5cfd3b3afb12db68620"
+
 state-toggle@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/state-toggle/-/state-toggle-1.0.0.tgz#d20f9a616bb4f0c3b98b91922d25b640aa2bc425"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
As discussed in #4686, this removes node core stuff from the stacktraces we present to the user, not just from our own tests.

Stack trace with this PR:
![image](https://user-images.githubusercontent.com/1404810/31574818-ce8aaf26-b0d7-11e7-99b1-db46a53a4a47.png)

Without this PR:
![image](https://user-images.githubusercontent.com/1404810/31306142-f86c3c9e-ab49-11e7-8b7e-eba8916b063e.png)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
New test added

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
