### PR TITLE
Updated util.js

### DIFF
--- a/packages/jest-snapshot/src/utils.js
+++ b/packages/jest-snapshot/src/utils.js
@@ -20,7 +20,7 @@ import prettyFormat from 'pretty-format';
 export const SNAPSHOT_EXTENSION = 'snap';
 export const SNAPSHOT_VERSION = '1';
 const SNAPSHOT_VERSION_REGEXP = /^\/\/ Jest Snapshot v(.+),/;
-export const SNAPSHOT_GUIDE_LINK = 'https://goo.gl/fbAQLP';
+export const SNAPSHOT_GUIDE_LINK = 'http://facebook.github.io/jest/docs/en/snapshot-testing.html';
 export const SNAPSHOT_VERSION_WARNING = chalk.yellow(
   `${chalk.bold('Warning')}: Before you upgrade snapshots, ` +
     `we recommend that you revert any local changes to tests or other code, ` +


### PR DESCRIPTION
Fixes #4663
**Summary**
SNAPSHOT_GUIDE_LINK was initially https://goo.gl/fbAQLP and redirected to a 404 page.
The path should be http://facebook.github.io/jest/docs/en/snapshot-testing.html according to the issue details and hence has been changed.
