### PR TITLE
Update CLI options link

### DIFF
--- a/packages/jest-util/src/__tests__/__snapshots__/validate_cli_options.test.js.snap
+++ b/packages/jest-util/src/__tests__/__snapshots__/validate_cli_options.test.js.snap
@@ -7,7 +7,7 @@ exports[`fails for multiple unknown options 1`] = `
 <red>  <bold>[\\"jest\\", \\"test\\"]</></>
 <red></>
 <red>  <bold>CLI Options Documentation</>:</>
-<red>  http://facebook.github.io/jest/docs/cli.html</>
+<red>  https://facebook.github.io/jest/docs/en/cli.html</>
 <red></>"
 `;
 
@@ -17,6 +17,6 @@ exports[`fails for unknown option 1`] = `
 <red>  Unrecognized option <bold>\\"unknown\\"</>.</>
 <red></>
 <red>  <bold>CLI Options Documentation</>:</>
-<red>  http://facebook.github.io/jest/docs/cli.html</>
+<red>  https://facebook.github.io/jest/docs/en/cli.html</>
 <red></>"
 `;

--- a/packages/jest-util/src/validate_cli_options.js
+++ b/packages/jest-util/src/validate_cli_options.js
@@ -22,7 +22,7 @@ const createCLIValidationError = (
   let message;
   const comment =
     `  ${chalk.bold('CLI Options Documentation')}:\n` +
-    `  http://facebook.github.io/jest/docs/cli.html\n`;
+    `  https://facebook.github.io/jest/docs/en/cli.html\n`;
 
   if (unrecognizedOptions.length === 1) {
     const unrecognized = unrecognizedOptions[0];


### PR DESCRIPTION
**Summary**
Update link of CLI args documentation when a user types a wrong argument. For instance:

```
./node_modules/.bin/jest --timeout=10000

  Unrecognized option "timeout".

  CLI Options Documentation:
  http://facebook.github.io/jest/docs/cli.html
```

Link is currently broken (404).

**Test plan**

```
./jest --timeout=foo
```

And clicking on the link opens correct page. 