### PR TITLE
added support for calling single test in single file in debug mode

### DIFF
--- a/packages/jest-editor-support/index.d.ts
+++ b/packages/jest-editor-support/index.d.ts
@@ -6,9 +6,21 @@
  */
 
 import { EventEmitter } from 'events';
+import { ChildProcess } from 'child_process';
+
+export interface Options {
+  createProcess?(
+    workspace: ProjectWorkspace, 
+    args: string[], 
+    debugPort?: number,
+  ): ChildProcess;
+  debugPort?: number;
+  testNamePattern?: string;
+  testFileNamePattern?: string;
+}
 
 export class Runner extends EventEmitter {
-  constructor(workspace: ProjectWorkspace);
+  constructor(workspace: ProjectWorkspace, options?: Options);
   watchMode: boolean;
   start(watchMode?: boolean): void;
   closeProcess(): void;
@@ -107,6 +119,7 @@ export interface JestAssertionResults {
   title: string;
   status: 'failed' | 'passed';
   failureMessages: string[];
+  fullName: string;
 }
 
 export interface JestTotalResults {

--- a/packages/jest-editor-support/src/Process.js
+++ b/packages/jest-editor-support/src/Process.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import { ChildProcess, spawn } from 'child_process';
+import {ChildProcess, spawn} from 'child_process';
 
 import ProjectWorkspace from './project_workspace';
 
@@ -40,9 +40,8 @@ export const createProcess = (
       // debug is enabled by adding --debug-brk as first argumemt of node
       // eg: `node --debug=123 node_modules/jest-cli/bin/jest.js [...args]`
       // and thersefore `pathToJest` must point to javascript
-      throw new Error('To enable debugging specify path to ' +
-        'jest-cli/bin/jest.js in pathToJest.');
-      }
+      throw new Error('To enable debugging specify path to jest.js in pathToJest.');
+    }
   }
 
   // If a path to configuration file was defined, push it to runtimeArgs

--- a/packages/jest-editor-support/src/Process.js
+++ b/packages/jest-editor-support/src/Process.js
@@ -30,20 +30,23 @@ export const createProcess = (
   let command = parameters[0];
   const initialArgs = parameters.slice(1);
   const runtimeArgs = [].concat(initialArgs, args);
-
+  
+  if (command.endsWith('jest.js')) {
+    runtimeArgs.unshift(command);
+    command = 'node';
+  }
+  
   // prepare process for debugging
   if (typeof debugPort === 'number') {
-    if (command.endsWith('jest.js')) {
-      runtimeArgs.unshift('--debug=' + debugPort, command);
-      command = 'node';
-    } else {
+    if (command !== 'node') {
       // debug is enabled by adding --debug-brk as first argumemt of node
       // eg: `node --debug=123 node_modules/jest-cli/bin/jest.js [...args]`
-      // and thersefore `pathToJest` must point to javascript
       throw new Error(
         'To enable debugging specify path to jest.js in pathToJest.',
       );
     }
+    
+    runtimeArgs.unshift('--debug=' + debugPort);
   }
 
   // If a path to configuration file was defined, push it to runtimeArgs

--- a/packages/jest-editor-support/src/Process.js
+++ b/packages/jest-editor-support/src/Process.js
@@ -30,12 +30,12 @@ export const createProcess = (
   let command = parameters[0];
   const initialArgs = parameters.slice(1);
   const runtimeArgs = [].concat(initialArgs, args);
-  
+
   if (command.endsWith('jest.js')) {
     runtimeArgs.unshift(command);
     command = 'node';
   }
-  
+
   // prepare process for debugging
   if (typeof debugPort === 'number') {
     if (command !== 'node') {
@@ -45,7 +45,7 @@ export const createProcess = (
         'To enable debugging specify path to jest.js in pathToJest.',
       );
     }
-    
+
     runtimeArgs.unshift('--debug=' + debugPort);
   }
 

--- a/packages/jest-editor-support/src/Process.js
+++ b/packages/jest-editor-support/src/Process.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import {ChildProcess, spawn} from 'child_process';
+import { ChildProcess, spawn } from 'child_process';
 
 import ProjectWorkspace from './project_workspace';
 
@@ -20,15 +20,30 @@ import ProjectWorkspace from './project_workspace';
 export const createProcess = (
   workspace: ProjectWorkspace,
   args: Array<string>,
+  debugPort?: number,
 ): ChildProcess => {
   // A command could look like `npm run test`, which we cannot use as a command
   // as they can only be the first command, so take out the command, and add
   // any other bits into the args
   const runtimeExecutable = workspace.pathToJest;
   const parameters = runtimeExecutable.split(' ');
-  const command = parameters[0];
+  let command = parameters[0];
   const initialArgs = parameters.slice(1);
   const runtimeArgs = [].concat(initialArgs, args);
+
+  // prepare process for debugging
+  if (typeof debugPort === 'number') {
+    if (command.endsWith('jest.js')) {
+      runtimeArgs.unshift('--debug=' + debugPort, command);
+      command = 'node';
+    } else {
+      // debug is enabled by adding --debug-brk as first argumemt of node
+      // eg: `node --debug=123 node_modules/jest-cli/bin/jest.js [...args]`
+      // and thersefore `pathToJest` must point to javascript
+      throw new Error('To enable debugging specify path to ' +
+        'jest-cli/bin/jest.js in pathToJest.');
+      }
+  }
 
   // If a path to configuration file was defined, push it to runtimeArgs
   const configPath = workspace.pathToConfig;

--- a/packages/jest-editor-support/src/Process.js
+++ b/packages/jest-editor-support/src/Process.js
@@ -40,7 +40,9 @@ export const createProcess = (
       // debug is enabled by adding --debug-brk as first argumemt of node
       // eg: `node --debug=123 node_modules/jest-cli/bin/jest.js [...args]`
       // and thersefore `pathToJest` must point to javascript
-      throw new Error('To enable debugging specify path to jest.js in pathToJest.');
+      throw new Error(
+        'To enable debugging specify path to jest.js in pathToJest.',
+      );
     }
   }
 

--- a/packages/jest-editor-support/src/Runner.js
+++ b/packages/jest-editor-support/src/Runner.js
@@ -60,8 +60,8 @@ export default class Runner extends EventEmitter {
     }
 
     this.debugprocess = this._createProcess(
-      this.workspace, 
-      args, 
+      this.workspace,
+      args,
       this.options.debugPort,
     );
     this.debugprocess.stdout.on('data', (data: Buffer) => {

--- a/packages/jest-editor-support/src/Runner.js
+++ b/packages/jest-editor-support/src/Runner.js
@@ -59,7 +59,11 @@ export default class Runner extends EventEmitter {
       args.push(this.options.testFileNamePattern);
     }
 
-    this.debugprocess = this._createProcess(this.workspace, args, this.options.debugPort);
+    this.debugprocess = this._createProcess(
+      this.workspace, 
+      args, 
+      this.options.debugPort,
+    );
     this.debugprocess.stdout.on('data', (data: Buffer) => {
       // Make jest save to a file, otherwise we get chunked data
       // and it can be hard to put it back together.

--- a/packages/jest-editor-support/src/Runner.js
+++ b/packages/jest-editor-support/src/Runner.js
@@ -26,12 +26,15 @@ export default class Runner extends EventEmitter {
   _createProcess: (
     workspace: ProjectWorkspace,
     args: Array<string>,
+    debugPort?: number,
   ) => ChildProcess;
   watchMode: boolean;
+  options: Options;
 
   constructor(workspace: ProjectWorkspace, options?: Options) {
     super();
     this._createProcess = (options && options.createProcess) || createProcess;
+    this.options = options || {};
     this.workspace = workspace;
     this.outputPath = tmpdir() + '/jest_runner.json';
   }
@@ -49,8 +52,14 @@ export default class Runner extends EventEmitter {
 
     const args = ['--json', '--useStderr', outputArg, this.outputPath];
     if (this.watchMode) args.push('--watch');
+    if (this.options.testNamePattern) {
+      args.push('--testNamePattern', this.options.testNamePattern);
+    }
+    if (this.options.testFileNamePattern) {
+      args.push(this.options.testFileNamePattern);
+    }
 
-    this.debugprocess = this._createProcess(this.workspace, args);
+    this.debugprocess = this._createProcess(this.workspace, args, this.options.debugPort);
     this.debugprocess.stdout.on('data', (data: Buffer) => {
       // Make jest save to a file, otherwise we get chunked data
       // and it can be hard to put it back together.
@@ -98,6 +107,9 @@ export default class Runner extends EventEmitter {
   }
 
   closeProcess() {
+    if (!this.debugprocess) {
+      return;
+    }
     if (process.platform === 'win32') {
       // Windows doesn't exit the process when it should.
       spawn('taskkill', ['/pid', '' + this.debugprocess.pid, '/T', '/F']);

--- a/packages/jest-editor-support/src/types.js
+++ b/packages/jest-editor-support/src/types.js
@@ -20,6 +20,9 @@ export type Options = {
     workspace: ProjectWorkspace,
     args: Array<string>,
   ) => ChildProcess,
+  debugPort ? : number,
+  testNamePattern ? : string,
+  testFileNamePattern ? : string,
 };
 
 /**

--- a/packages/jest-editor-support/src/types.js
+++ b/packages/jest-editor-support/src/types.js
@@ -20,9 +20,9 @@ export type Options = {
     workspace: ProjectWorkspace,
     args: Array<string>,
   ) => ChildProcess,
-  debugPort ? : number,
-  testNamePattern ? : string,
-  testFileNamePattern ? : string,
+  debugPort?: number,
+  testNamePattern?: string,
+  testFileNamePattern?: string,
 };
 
 /**


### PR DESCRIPTION
**Summary**

Im creating my own vscode extension and need to be able start specific test in specific file and attach debugger to it...

**Test plan**

Added 3 new options: 
- debugPort:
   - if present parameter `--debug=$debugPort` will be added as first argument of process
   - requires, that `pathToJest` points to javascript file  - command is called like `node --debug=123 path/to/jest.js --rest_or_args_here`)
   - it up to caller to attach debugger on port `$debugPort`
- testNamePattern
   - if present process arguments `--testNamePattern $testNamePattern` will be added (see [doc](https://facebook.github.io/jest/docs/en/cli.html#testnamepattern-regex))
- testFileNamePattern
   - if present its value will be added as process argument (to filter test files)
