### PR TITLE
Update Snapshot Guide Link

### DIFF
--- a/packages/jest-snapshot/src/utils.js
+++ b/packages/jest-snapshot/src/utils.js
@@ -20,7 +20,7 @@ import prettyFormat from 'pretty-format';
 export const SNAPSHOT_EXTENSION = 'snap';
 export const SNAPSHOT_VERSION = '1';
 const SNAPSHOT_VERSION_REGEXP = /^\/\/ Jest Snapshot v(.+),/;
-export const SNAPSHOT_GUIDE_LINK = 'https://goo.gl/fbAQLP';
+export const SNAPSHOT_GUIDE_LINK = 'goo.gl/TX8axi';
 export const SNAPSHOT_VERSION_WARNING = chalk.yellow(
   `${chalk.bold('Warning')}: Before you upgrade snapshots, ` +
     `we recommend that you revert any local changes to tests or other code, ` +


### PR DESCRIPTION
Old one points here: http://facebook.github.io/jest/docs/snapshot-testing.html which currently returns a `404`

I made a new goo.gl link that points to the current guide location: http://facebook.github.io/jest/docs/en/snapshot-testing.html and changed it, but I don't know if that's the correct approach.

Hoping this is useful.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
