### PR TITLE
added support for calling single test in single file

### DIFF
--- a/packages/jest-editor-support/index.d.ts
+++ b/packages/jest-editor-support/index.d.ts
@@ -6,9 +6,21 @@
  */
 
 import { EventEmitter } from 'events';
+import { ChildProcess } from 'child_process';
+
+export interface Options {
+  createProcess?(
+    workspace: ProjectWorkspace, 
+    args: string[], 
+    debugPort?: number,
+  ): ChildProcess;
+  debugPort?: number;
+  testNamePattern?: string;
+  testFileNamePattern?: string;
+}
 
 export class Runner extends EventEmitter {
-  constructor(workspace: ProjectWorkspace);
+  constructor(workspace: ProjectWorkspace, options?: Options);
   watchMode: boolean;
   start(watchMode?: boolean): void;
   closeProcess(): void;
@@ -32,6 +44,7 @@ export class ProjectWorkspace {
     localJestMajorVersin: number,
   );
   pathToJest: string;
+  pathToConfig: string;
   rootPath: string;
   localJestMajorVersion: number;
 }
@@ -107,6 +120,7 @@ export interface JestAssertionResults {
   title: string;
   status: 'failed' | 'passed';
   failureMessages: string[];
+  fullName: string;
 }
 
 export interface JestTotalResults {

--- a/packages/jest-editor-support/src/types.js
+++ b/packages/jest-editor-support/src/types.js
@@ -20,6 +20,8 @@ export type Options = {
     workspace: ProjectWorkspace,
     args: Array<string>,
   ) => ChildProcess,
+  testNamePattern?: string,
+  testFileNamePattern?: string,
 };
 
 /**


### PR DESCRIPTION
**Summary**

Im creating my own vscode extension and need to be able start specific test in specific file and attach debugger to it...

**Test plan**

Added 2 new options:

- testNamePattern
if present process arguments --testNamePattern $testNamePattern will be added (see doc)
- testFileNamePattern
if present its value will be added as process argument (to filter test files)

---
Basically same as my previous PR #4712 except debugger part, because that would break backward-compatibility... (and new PR because i nuked my prev fork and created new one to clean up my commits)