### PR TITLE
Make passWithNoTests default to true in watch mode (#4722)

### DIFF
--- a/packages/jest-cli/src/__tests__/watch.test.js
+++ b/packages/jest-cli/src/__tests__/watch.test.js
@@ -142,6 +142,14 @@ describe('Watch mode flows', () => {
       watch: false,
     });
   });
+  it('passWithNoTest should be set to true in watch mode', () => {
+    globalConfig.passWithNoTests = false;
+    watch(globalConfig, contexts, pipe, hasteMapInstances, stdin);
+    globalConfig.passWithNoTests = true;
+    expect(runJestMock.mock.calls[0][0]).toMatchObject({
+      globalConfig,
+    });
+  });
 });
 
 class MockStdin {

--- a/packages/jest-cli/src/__tests__/watch_filename_pattern_mode.test.js
+++ b/packages/jest-cli/src/__tests__/watch_filename_pattern_mode.test.js
@@ -134,6 +134,7 @@ describe('Watch mode flows', () => {
     // globalConfig is updated with the current pattern
     expect(runJestMock.mock.calls[0][0].globalConfig).toEqual({
       onlyChanged: false,
+      passWithNoTests: true,
       testNamePattern: '',
       testPathPattern: 'p.*3',
       watch: true,

--- a/packages/jest-cli/src/lib/update_global_config.js
+++ b/packages/jest-cli/src/lib/update_global_config.js
@@ -15,6 +15,7 @@ type Options = {
   noSCM?: boolean,
   updateSnapshot?: SnapshotUpdateState,
   mode?: 'watch' | 'watchAll',
+  passWithNoTests?: boolean,
 };
 
 export default (globalConfig: GlobalConfig, options: Options): GlobalConfig => {
@@ -53,6 +54,10 @@ export default (globalConfig: GlobalConfig, options: Options): GlobalConfig => {
 
   if (options.noSCM) {
     newConfig.noSCM = true;
+  }
+
+  if (options.passWithNoTests) {
+    newConfig.passWithNoTests = true;
   }
 
   return Object.freeze(newConfig);

--- a/packages/jest-cli/src/watch.js
+++ b/packages/jest-cli/src/watch.js
@@ -44,6 +44,7 @@ export default function watch(
 
   globalConfig = updateGlobalConfig(globalConfig, {
     mode: globalConfig.watch ? 'watch' : 'watchAll',
+    passWithNoTests: true,
   });
 
   const prompt = new Prompt();


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**

This attempts to fix #4722  by making passWithNoTests default to true in watch mode

**Test plan**

Added new test in watch.test.js - 'passWithNoTest should be set to true in watch mode'
