### PR TITLE
Update Docusaurus to fix rerouting broken links in docs

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -12,7 +12,7 @@
     "rename-version": "docusaurus-rename-version"
   },
   "dependencies": {
-    "docusaurus": "^1.0.0-beta.1"
+    "docusaurus": "^1.0.0-beta.4"
   },
   "devDependencies": {
     "crowdin-cli": "^0.3.0"


### PR DESCRIPTION

**Summary**

I've added fixes to Docusaurus to create a file at base of /docs folder that routes people to /docs/en/file.html