### PR TITLE
Document testNamePattern example (#4732)

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -187,7 +187,7 @@ Prevent tests from printing messages through the console.
 
 ### `--testNamePattern=<regex>`
 
-Alias: `-t`. Run only tests with a name that matches the regex.
+Alias: `-t`. Run only tests and test suites with a name that matches the regex.  For example, suppose you want to run only tests related to authorization which will have names like `"GET /api/posts with auth"`, then you can use `jest -t=auth`. 
 
 ### `--testPathPattern=<regex>`
 


### PR DESCRIPTION
Resolve #4732 

**Summary**

Despite the name, I got confused with exactly what `--testNamePattern` was used for and found I wasn't alone [StackOverflow](https://stackoverflow.com/questions/45913349/using-jest-testnamepattern-regex-or-t-option-in-package-json/)

**Test plan**

To resolve it I added an example in the docs CLI section. I ran the docs server locally and was satisfied. It's a simple change so I do not expect there should be no issue with publishing.