### PR TITLE
Use watchAll fallback for non git/hq projects

### DIFF
--- a/integration_tests/__tests__/watch_requires_hq_or_git.test.js
+++ b/integration_tests/__tests__/watch_requires_hq_or_git.test.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import runJest from '../runJest';
+
+describe('watch requires hq or git', () => {
+  let stderr, status;
+  beforeEach(() => {
+    ({stderr, status} = runJest('watch_requires_hq_or_git', ['--watch']));
+  });
+
+  test('given a non git/hq project, when running jest with --watch, then an error is printed', () => {
+    expect(stderr).toBe(
+      '--watch is not supported without git/hg, please use --watchAll',
+    );
+  });
+
+  test('given a non git/hq project, when running jest with --watch, then there is an error return status', () => {
+    expect(status).toBe(1);
+  });
+});

--- a/integration_tests/watch_requires_hq_or_git/__tests__/example.test.js
+++ b/integration_tests/watch_requires_hq_or_git/__tests__/example.test.js
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+test('test', () => {
+  expect(true).toBe(true);
+});

--- a/integration_tests/watch_requires_hq_or_git/package.json
+++ b/integration_tests/watch_requires_hq_or_git/package.json
@@ -1,0 +1,5 @@
+{
+  "jest": {
+    "testEnvironment": "node"
+  }
+}

--- a/packages/jest-cli/src/cli/index.js
+++ b/packages/jest-cli/src/cli/index.js
@@ -300,7 +300,7 @@ const _run = async (
   const changedFilesPromise = getChangedFilesPromise(globalConfig, configs);
 
   if (globalConfig.watch && !changedFilesPromise) {
-    console.log(
+    process.stdout.write(
       'The project folder is no git and no mercurial project. ' +
         chalk.bold('Watching all files') +
         ' instead...',

--- a/packages/jest-cli/src/cli/index.js
+++ b/packages/jest-cli/src/cli/index.js
@@ -30,6 +30,7 @@ import {print as preRunMessagePrint} from '../pre_run_message';
 import runJest from '../run_jest';
 import Runtime from 'jest-runtime';
 import TestWatcher from '../test_watcher';
+import updateGlobalConfig from '../lib/update_global_config';
 import watch from '../watch';
 import yargs from 'yargs';
 import rimraf from 'rimraf';
@@ -297,6 +298,18 @@ const _run = async (
   // Queries to hg/git can take a while, so we need to start the process
   // as soon as possible, so by the time we need the result it's already there.
   const changedFilesPromise = getChangedFilesPromise(globalConfig, configs);
+
+  if (globalConfig.watch && !changedFilesPromise) {
+    console.log(
+      'The project folder is no git and no mercurial project. ' +
+        chalk.bold('Watching all files') +
+        ' instead...',
+    );
+    globalConfig = updateGlobalConfig(globalConfig, {
+      mode: 'watchAll',
+    });
+  }
+
   const {contexts, hasteMapInstances} = await buildContextsAndHasteMaps(
     configs,
     globalConfig,

--- a/packages/jest-cli/src/cli/index.js
+++ b/packages/jest-cli/src/cli/index.js
@@ -300,14 +300,11 @@ const _run = async (
   const changedFilesPromise = getChangedFilesPromise(globalConfig, configs);
 
   if (globalConfig.watch && !changedFilesPromise) {
-    process.stdout.write(
-      'The project folder is no git and no mercurial project. ' +
-        chalk.bold('Watching all files') +
-        ' instead...',
+    process.stderr.write(
+      chalk.bold('--watch') +
+        ' is not supported without git/hg, please use --watchAll',
     );
-    globalConfig = updateGlobalConfig(globalConfig, {
-      mode: 'watchAll',
-    });
+    process.exit(1);
   }
 
   const {contexts, hasteMapInstances} = await buildContextsAndHasteMaps(


### PR DESCRIPTION
**Summary**

Whenever you run `jest --watch` in a non git/hq repository you will see the following error:

```
Determining test suites to run...Error: This promise must be present when running with -o.
    at /path/to/node_modules/jest-cli/build/search_source.js:192:17
    at next (native)
    at step (/path/to/node_modules/jest-cli/build/search_source.js:20:362)
    at /path/to/node_modules/jest-cli/build/search_source.js:20:592
    at /path/to/node_modules/jest-cli/build/search_source.js:20:273
    at SearchSource.getTestPaths (/path/to/node_modules/jest-cli/build/search_source.js:204:10)
    at /path/to/node_modules/jest-cli/build/run_jest.js:45:31
    at next (native)
    at step (/path/to/node_modules/jest-cli/build/run_jest.js:24:380)
    at /path/to/node_modules/jest-cli/build/run_jest.js:24:540
```

To make it work I would like to do the following:

1. Warn that there is an issue for non git/hq projects
2. Execute watchAll instead

Unfortunately the `cli/index.js` is not tested yet. It's hard to test without restructuring a lot of code to increase testability.

If this solution is not favored I can adapt the change to just update the error message to mention the problem explicit.

There is already a bug report: #4419 

**Test plan**

1. Create a new node project
2. Create a simple test file
3. Run jest --watch
4. An error occurs
