### PR TITLE
adds missing node builtin modules to jest-resolve package

### DIFF
--- a/packages/jest-resolve/package.json
+++ b/packages/jest-resolve/package.json
@@ -9,8 +9,7 @@
   "main": "build/index.js",
   "dependencies": {
     "browser-resolve": "^1.11.2",
-    "chalk": "^2.0.1",
-    "is-builtin-module": "^1.0.0"
+    "chalk": "^2.0.1"
   },
   "devDependencies": {
     "jest-haste-map": "^21.2.0"

--- a/packages/jest-resolve/src/__tests__/is_builtin_module.test.js
+++ b/packages/jest-resolve/src/__tests__/is_builtin_module.test.js
@@ -1,0 +1,19 @@
+const isBuiltinModule = require('../is_builtin_module');
+
+describe('isBuiltinModule', () => {
+  it('should return true for the `path` module', () => {
+    expect(isBuiltinModule('path')).toBe(true);
+  });
+
+  it('should return false for the `chalk` module', () => {
+    expect(isBuiltinModule('chalk')).toBe(false);
+  });
+
+  it('should return true for the `_http_common` module', () => {
+    expect(isBuiltinModule('_http_common')).toBe(true);
+  });
+
+  it('should return false for any internal node builtins', () => {
+    expect(isBuiltinModule('internal/http')).toBe(false);
+  });
+});

--- a/packages/jest-resolve/src/default_resolver.js
+++ b/packages/jest-resolve/src/default_resolver.js
@@ -42,7 +42,7 @@ type ErrorWithCode = Error & {code?: string};
 
 import fs from 'fs';
 import path from 'path';
-import isBuiltinModule from 'is-builtin-module';
+import isBuiltinModule from './is_builtin_module';
 
 import nodeModulesPaths from './node_modules_paths';
 

--- a/packages/jest-resolve/src/index.js
+++ b/packages/jest-resolve/src/index.js
@@ -14,7 +14,7 @@ import type {ResolveModuleConfig} from 'types/Resolve';
 import fs from 'fs';
 import path from 'path';
 import nodeModulesPaths from './node_modules_paths';
-import isBuiltinModule from 'is-builtin-module';
+import isBuiltinModule from './is_builtin_module';
 import defaultResolver from './default_resolver.js';
 import chalk from 'chalk';
 

--- a/packages/jest-resolve/src/is_builtin_module.js
+++ b/packages/jest-resolve/src/is_builtin_module.js
@@ -1,0 +1,11 @@
+declare var process: {
+  binding(type: string): {},
+};
+
+const BUILTIN_MODULES = Object.keys(process.binding('natives')).filter(
+  (module: string) => !/^internal\//.test(module),
+);
+
+module.exports = function isBuiltinModule(module: string): boolean {
+  return BUILTIN_MODULES.indexOf(module) !== -1;
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

This removes the usage of the `is-builtin-module` dependency in the `jest-resolve` package to utilize a less strict method of checking for builtin node dependencies.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

The change is to fix #4677 which causes jest to break when any node package is making use of a builtin filtered out by the `is-builtin-module` package. [The author has made clear that they will not include the packages](https://github.com/sindresorhus/builtin-modules/issues/2) so jest should not be utilizing this package any longer.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Using the [following repo to test for the issue](https://github.com/CNDW/mock-couch-jest)

**Before**
```
travis@travis-XPS-15-9560:~/Projects/bugreport$ yarn test
yarn test v1.0.1
$ jest
 FAIL  ./test.spec.js
  Some thing :
    ✕ should be true (26ms)

  ● Some thing : › should be true

    Cannot find module '_http_common' from 'stream.js'

      at Resolver.resolveModule (node_modules/jest-resolve/build/index.js:191:17)
      at Object.<anonymous> (node_modules/spdy/lib/spdy/stream.js:13:20)

Test Suites: 1 failed, 1 total
Tests:       1 failed, 1 total
Snapshots:   0 total
Time:        0.235s
Ran all test suites.
error Command failed with exit code 1.
```

**After the fix is in place**
```
travis@travis-XPS-15-9560:~/Projects/bugreport$ yarn test
yarn test v1.0.1
$ jest
 PASS  ./test.spec.js
  Some thing :
    ✓ should be true (65ms)

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        0.301s, estimated 1s
Ran all test suites.
Done in 0.56s.
```