### PR TITLE
feat(jest-config): allow to use .js files in presets (#3564)

### DIFF
--- a/packages/jest-config/src/__tests__/normalize.test.js
+++ b/packages/jest-config/src/__tests__/normalize.test.js
@@ -937,6 +937,44 @@ describe('preset', () => {
   });
 });
 
+describe('preset with .js file', () => {
+  beforeEach(() => {
+    const Resolver = require('jest-resolve');
+    Resolver.findNodeModule = jest.fn(name => {
+      if (name === 'react-native/jest-preset.json') {
+        return '/node_modules/react-native/jest-preset-dont-exist.json';
+      }
+      if (name === 'react-native/jest-preset.js') {
+        return '/node_modules/react-native/jest-preset.js';
+      }
+      return '/node_modules/' + name;
+    });
+    jest.mock(
+      '/node_modules/react-native/jest-preset.js',
+      () => ({
+        moduleNameMapper: {b: 'b'},
+        modulePathIgnorePatterns: ['js'],
+        setupFiles: ['b'],
+      }),
+      {virtual: true},
+    );
+  });
+  afterEach(() => {
+    jest.unmock('/node_modules/react-native/jest-preset.js');
+  });
+
+  it('should resolve jest-preset.js file', () => {
+    const normalized = normalize(
+      {
+        preset: 'react-native',
+        rootDir: '/root/path/foo',
+      },
+      {},
+    );
+    expect(normalized.options.modulePathIgnorePatterns).toEqual(['js']);
+  });
+});
+
 describe('preset without setupFiles', () => {
   let Resolver;
   beforeEach(() => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

**Summary**
Allows to use a `jest-preset.js` instead of a `jest-preset.json` in presets, making it as flexible as `jest.config.js` and e.g. makes it possible to set config based on current environment. (https://github.com/facebook/jest/issues/3564#issuecomment-316185227)
The `.json` file takes precedence. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
Added a unit test and tried it in a local project. 
I can push that project and the necessary shell commands if necessary.
I'd like to know first, if you'd be interested at all in adding such a feature. 
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
