### PR TITLE
Update docs to clarify runTimersToTime

### DIFF
--- a/docs/JestObjectAPI.md
+++ b/docs/JestObjectAPI.md
@@ -227,7 +227,7 @@ Exhausts all tasks queued by `setImmediate()`.
 ### `jest.runTimersToTime(msToRun)`
 Executes only the macro task queue (i.e. all tasks queued by `setTimeout()` or `setInterval()` and `setImmediate()`).
 
-When this API is called, all pending "macro-tasks" that have been queued via `setTimeout()` or `setInterval()`, and would be executed within `msToRun` milliseconds will be executed. Additionally if those macro-tasks schedule new macro-tasks that would be executed within the same time frame, those will be executed until there are no more macro-tasks remaining in the queue, that should be run within `msToRun` milliseconds.
+When this API is called, all timers are advanced by `msToRun` milliseconds. All pending "macro-tasks" that have been queued via `setTimeout()` or `setInterval()`, and would be executed within this timeframe will be executed. Additionally if those macro-tasks schedule new macro-tasks that would be executed within the same time frame, those will be executed until there are no more macro-tasks remaining in the queue, that should be run within `msToRun` milliseconds.
 
 ### `jest.runOnlyPendingTimers()`
 Executes only the macro-tasks that are currently pending (i.e., only the tasks that have been queued by `setTimeout()` or `setInterval()` up to this point). If any of the currently pending macro-tasks schedule new macro-tasks, those new tasks will not be executed by this call.

--- a/docs/TimerMocks.md
+++ b/docs/TimerMocks.md
@@ -129,7 +129,7 @@ describe('infiniteTimerGame', () => {
 
 ## Run Timers to Time
 
-Another possibility is use `jest.runTimersToTime(msToRun)`. When this API is called, all pending "macro-tasks" that have been queued via setTimeout() or setInterval(), and would be executed within msToRun milliseconds, will be executed. Additionally if those macro-tasks schedule new macro-tasks that would be executed within the same time frame, those will be executed until there are no more macro-tasks remaining in the queue that should be run within msToRun milliseconds.
+Another possibility is use `jest.runTimersToTime(msToRun)`. When this API is called, all timers are advanced by `msToRun` milliseconds. All pending "macro-tasks" that have been queued via setTimeout() or setInterval(), and would be executed during this timeframe, will be executed. Additionally if those macro-tasks schedule new macro-tasks that would be executed within the same time frame, those will be executed until there are no more macro-tasks remaining in the queue that should be run within msToRun milliseconds.
 
 ```javascript
 // timerGame.js

--- a/packages/jest-util/src/fake_timers.js
+++ b/packages/jest-util/src/fake_timers.js
@@ -260,7 +260,7 @@ export default class FakeTimers<TimerRef> {
   runTimersToTime(msToRun: number) {
     this._checkFakeTimers();
     // Only run a generous number of timers and then bail.
-    // This is jsut to help avoid recursive loops
+    // This is just to help avoid recursive loops
     let i;
     for (i = 0; i < this._maxLoops; i++) {
       const timerHandle = this._getNextTimerHandle();


### PR DESCRIPTION
**Summary**

Updated docs to clarify confusing behaviour of `runTimersToTime()` (see #4723).

I've noted that the function actually advances fake timers *by* a given time (as opposed to advancing *to* a given time).