### PR TITLE
Add advanceTimersByTime(), keep runTimersToTime() as alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@
 * `[jest-diff]` Simplify highlight for leading and trailing spaces ([#4553](https://github.com/facebook/jest/pull/4553))
 * `[jest-get-type]` Add support for date ([#4621](https://github.com/facebook/jest/pull/4621))
 * `[jest-matcher-utils]` Call `chalk.inverse` for trailing spaces ([#4578](https://github.com/facebook/jest/pull/4578))
-* `[jest-runtime]` Add `.advanceTimersByTime`; keep `.runTimersByTime()` as an alias.
+* `[jest-runtime]` Add `.advanceTimersByTime`; keep `.runTimersToTime()` as an alias.
 
 ## jest 21.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 * `[jest-diff]` Simplify highlight for leading and trailing spaces ([#4553](https://github.com/facebook/jest/pull/4553))
 * `[jest-get-type]` Add support for date ([#4621](https://github.com/facebook/jest/pull/4621))
 * `[jest-matcher-utils]` Call `chalk.inverse` for trailing spaces ([#4578](https://github.com/facebook/jest/pull/4578))
+* `[jest-runtime]` Add `.advanceTimersByTime`; keep `.runTimersByTime()` as an alias.
 
 ## jest 21.2.1
 

--- a/docs/JestObjectAPI.md
+++ b/docs/JestObjectAPI.md
@@ -225,6 +225,7 @@ This is often useful for synchronously executing setTimeouts during a test in or
 Exhausts all tasks queued by `setImmediate()`.
 
 ### `jest.advanceTimersByTime(msToRun)`
+##### renamed in Jest **21.3.0+**
 Also under the alias: `.runTimersToTime()`
 
 Executes only the macro task queue (i.e. all tasks queued by `setTimeout()` or `setInterval()` and `setImmediate()`).

--- a/docs/JestObjectAPI.md
+++ b/docs/JestObjectAPI.md
@@ -23,7 +23,7 @@ The `jest` object is automatically in scope within every test file. The methods 
   - [`jest.resetModules()`](#jestresetmodules)
   - [`jest.runAllTicks()`](#jestrunallticks)
   - [`jest.runAllTimers()`](#jestrunalltimers)
-  - [`jest.runTimersToTime(msToRun)`](#jestruntimerstotimemstorun)
+  - [`jest.advanceTimersByTime(msToRun)`](#jestadvancetimersbytimemstorun)
   - [`jest.runOnlyPendingTimers()`](#jestrunonlypendingtimers)
   - [`jest.setMock(moduleName, moduleExports)`](#jestsetmockmodulename-moduleexports)
   - [`jest.setTimeout(timeout)`](#jestsettimeouttimeout)
@@ -224,7 +224,9 @@ This is often useful for synchronously executing setTimeouts during a test in or
 ### `jest.runAllImmediates()`
 Exhausts all tasks queued by `setImmediate()`.
 
-### `jest.runTimersToTime(msToRun)`
+### `jest.advanceTimersByTime(msToRun)`
+Also under the alias: `.runTimersToTime()`
+
 Executes only the macro task queue (i.e. all tasks queued by `setTimeout()` or `setInterval()` and `setImmediate()`).
 
 When this API is called, all timers are advanced by `msToRun` milliseconds. All pending "macro-tasks" that have been queued via `setTimeout()` or `setInterval()`, and would be executed within this timeframe will be executed. Additionally if those macro-tasks schedule new macro-tasks that would be executed within the same time frame, those will be executed until there are no more macro-tasks remaining in the queue, that should be run within `msToRun` milliseconds.

--- a/docs/TimerMocks.md
+++ b/docs/TimerMocks.md
@@ -127,9 +127,9 @@ describe('infiniteTimerGame', () => {
 });
 ```
 
-## Run Timers to Time
+## Advance Timers by Time
 
-Another possibility is use `jest.runTimersToTime(msToRun)`. When this API is called, all timers are advanced by `msToRun` milliseconds. All pending "macro-tasks" that have been queued via setTimeout() or setInterval(), and would be executed during this timeframe, will be executed. Additionally if those macro-tasks schedule new macro-tasks that would be executed within the same time frame, those will be executed until there are no more macro-tasks remaining in the queue that should be run within msToRun milliseconds.
+Another possibility is use `jest.advanceTimersByTime(msToRun)`. When this API is called, all timers are advanced by `msToRun` milliseconds. All pending "macro-tasks" that have been queued via setTimeout() or setInterval(), and would be executed during this timeframe, will be executed. Additionally if those macro-tasks schedule new macro-tasks that would be executed within the same time frame, those will be executed until there are no more macro-tasks remaining in the queue that should be run within msToRun milliseconds.
 
 ```javascript
 // timerGame.js
@@ -147,7 +147,7 @@ module.exports = timerGame;
 ```
 
 ```javascript
-it('calls the callback after 1 second via runTimersToTime', () => {
+it('calls the callback after 1 second via advanceTimersByTime', () => {
   const timerGame = require('../timerGame');
   const callback = jest.fn();
 
@@ -157,7 +157,7 @@ it('calls the callback after 1 second via runTimersToTime', () => {
   expect(callback).not.toBeCalled();
 
   // Fast-forward until all timers have been executed
-  jest.runTimersToTime(1000);
+  jest.advanceTimersByTime(1000);
 
   // Now our callback should have been called!
   expect(callback).toBeCalled();

--- a/examples/timer/__tests__/timer_game.test.js
+++ b/examples/timer/__tests__/timer_game.test.js
@@ -30,7 +30,7 @@ describe('timerGame', () => {
     expect(callback.mock.calls.length).toBe(1);
   });
 
-  it('calls the callback after 1 second via runTimersToTime', () => {
+  it('calls the callback after 1 second via advanceTimersByTime', () => {
     const timerGame = require('../timerGame');
     const callback = jest.fn();
 
@@ -40,7 +40,7 @@ describe('timerGame', () => {
     expect(callback).not.toBeCalled();
 
     // Fast-forward until all timers have been executed
-    jest.runTimersToTime(1000);
+    jest.advanceTimersByTime(1000);
 
     // Now our callback should have been called!
     expect(callback).toBeCalled();

--- a/flow-typed/npm/jest_v20.x.x.js
+++ b/flow-typed/npm/jest_v20.x.x.js
@@ -370,8 +370,11 @@ type JestObjectType = {
   /**
    * Executes only the macro task queue (i.e. all tasks queued by setTimeout()
    * or setInterval() and setImmediate()).
+   * 
+   * Alias: .runTimersByTime
    */
   advanceTimersByTime(msToRun: number): void,
+  runTimersByTime(msToRun: number): void,
   /**
    * Executes only the macro-tasks that are currently pending (i.e., only the
    * tasks that have been queued by setTimeout() or setInterval() up to this

--- a/flow-typed/npm/jest_v20.x.x.js
+++ b/flow-typed/npm/jest_v20.x.x.js
@@ -371,10 +371,10 @@ type JestObjectType = {
    * Executes only the macro task queue (i.e. all tasks queued by setTimeout()
    * or setInterval() and setImmediate()).
    * 
-   * Alias: .runTimersByTime
+   * Alias: .runTimersToTime
    */
   advanceTimersByTime(msToRun: number): void,
-  runTimersByTime(msToRun: number): void,
+  runTimersToTime(msToRun: number): void,
   /**
    * Executes only the macro-tasks that are currently pending (i.e., only the
    * tasks that have been queued by setTimeout() or setInterval() up to this

--- a/flow-typed/npm/jest_v20.x.x.js
+++ b/flow-typed/npm/jest_v20.x.x.js
@@ -371,7 +371,7 @@ type JestObjectType = {
    * Executes only the macro task queue (i.e. all tasks queued by setTimeout()
    * or setInterval() and setImmediate()).
    */
-  runTimersToTime(msToRun: number): void,
+  advanceTimersByTime(msToRun: number): void,
   /**
    * Executes only the macro-tasks that are currently pending (i.e., only the
    * tasks that have been queued by setTimeout() or setInterval() up to this

--- a/packages/jest-runtime/src/index.js
+++ b/packages/jest-runtime/src/index.js
@@ -797,7 +797,7 @@ class Runtime {
         this._environment.fakeTimers.runOnlyPendingTimers(),
       advanceTimersByTime: (msToRun: number) =>
         this._environment.fakeTimers.advanceTimersByTime(msToRun),
-      runTimersByTime: (msToRun: number) =>
+      runTimersToTime: (msToRun: number) =>
         this._environment.fakeTimers.advanceTimersByTime(msToRun),
       setMock: (moduleName: string, mock: Object) =>
         setMockFactory(moduleName, () => mock),

--- a/packages/jest-runtime/src/index.js
+++ b/packages/jest-runtime/src/index.js
@@ -797,6 +797,8 @@ class Runtime {
         this._environment.fakeTimers.runOnlyPendingTimers(),
       advanceTimersByTime: (msToRun: number) =>
         this._environment.fakeTimers.advanceTimersByTime(msToRun),
+      runTimersByTime: (msToRun: number) =>
+        this._environment.fakeTimers.advanceTimersByTime(msToRun),
       setMock: (moduleName: string, mock: Object) =>
         setMockFactory(moduleName, () => mock),
       setTimeout,

--- a/packages/jest-runtime/src/index.js
+++ b/packages/jest-runtime/src/index.js
@@ -795,8 +795,8 @@ class Runtime {
       runAllTimers: () => this._environment.fakeTimers.runAllTimers(),
       runOnlyPendingTimers: () =>
         this._environment.fakeTimers.runOnlyPendingTimers(),
-      runTimersToTime: (msToRun: number) =>
-        this._environment.fakeTimers.runTimersToTime(msToRun),
+      advanceTimersByTime: (msToRun: number) =>
+        this._environment.fakeTimers.advanceTimersByTime(msToRun),
       setMock: (moduleName: string, mock: Object) =>
         setMockFactory(moduleName, () => mock),
       setTimeout,

--- a/packages/jest-runtime/src/index.js
+++ b/packages/jest-runtime/src/index.js
@@ -768,6 +768,8 @@ class Runtime {
     const jestObject = {
       addMatchers: (matchers: Object) =>
         this._environment.global.jasmine.addMatchers(matchers),
+      advanceTimersByTime: (msToRun: number) =>
+        this._environment.fakeTimers.advanceTimersByTime(msToRun),
       autoMockOff: disableAutomock,
       autoMockOn: enableAutomock,
       clearAllMocks,
@@ -795,8 +797,6 @@ class Runtime {
       runAllTimers: () => this._environment.fakeTimers.runAllTimers(),
       runOnlyPendingTimers: () =>
         this._environment.fakeTimers.runOnlyPendingTimers(),
-      advanceTimersByTime: (msToRun: number) =>
-        this._environment.fakeTimers.advanceTimersByTime(msToRun),
       runTimersToTime: (msToRun: number) =>
         this._environment.fakeTimers.advanceTimersByTime(msToRun),
       setMock: (moduleName: string, mock: Object) =>

--- a/packages/jest-util/src/__tests__/fake_timers.test.js
+++ b/packages/jest-util/src/__tests__/fake_timers.test.js
@@ -445,7 +445,7 @@ describe('FakeTimers', () => {
     });
   });
 
-  describe('runTimersToTime', () => {
+  describe('advanceTimersByTime', () => {
     it('runs timers in order', () => {
       const global = {process};
       const timers = new FakeTimers({global, moduleMocker, timerConfig});
@@ -465,23 +465,23 @@ describe('FakeTimers', () => {
       }, 200);
 
       // Move forward to t=50
-      timers.runTimersToTime(50);
+      timers.advanceTimersByTime(50);
       expect(runOrder).toEqual(['mock2', 'mock3']);
 
       // Move forward to t=60
-      timers.runTimersToTime(10);
+      timers.advanceTimersByTime(10);
       expect(runOrder).toEqual(['mock2', 'mock3']);
 
       // Move forward to t=100
-      timers.runTimersToTime(40);
+      timers.advanceTimersByTime(40);
       expect(runOrder).toEqual(['mock2', 'mock3', 'mock1']);
 
       // Move forward to t=200
-      timers.runTimersToTime(100);
+      timers.advanceTimersByTime(100);
       expect(runOrder).toEqual(['mock2', 'mock3', 'mock1', 'mock4']);
 
       // Move forward to t=400
-      timers.runTimersToTime(200);
+      timers.advanceTimersByTime(200);
       expect(runOrder).toEqual(['mock2', 'mock3', 'mock1', 'mock4', 'mock4']);
     });
 
@@ -490,7 +490,7 @@ describe('FakeTimers', () => {
       const timers = new FakeTimers({global, moduleMocker, timerConfig});
       timers.useFakeTimers();
 
-      timers.runTimersToTime(100);
+      timers.advanceTimersByTime(100);
     });
 
     it('throws before allowing infinite recursion', () => {
@@ -508,7 +508,7 @@ describe('FakeTimers', () => {
       }, 0);
 
       expect(() => {
-        timers.runTimersToTime(50);
+        timers.advanceTimersByTime(50);
       }).toThrow(
         new Error(
           "Ran 100 timers, and there are still more! Assuming we've hit an " +
@@ -565,19 +565,19 @@ describe('FakeTimers', () => {
       expect(mock1.mock.calls.length).toBe(0);
     });
 
-    it('resets current runTimersToTime time cursor', () => {
+    it('resets current advanceTimersByTime time cursor', () => {
       const global = {process};
       const timers = new FakeTimers({global, moduleMocker, timerConfig});
       timers.useFakeTimers();
 
       const mock1 = jest.genMockFn();
       global.setTimeout(mock1, 100);
-      timers.runTimersToTime(50);
+      timers.advanceTimersByTime(50);
 
       timers.reset();
       global.setTimeout(mock1, 100);
 
-      timers.runTimersToTime(50);
+      timers.advanceTimersByTime(50);
       expect(mock1.mock.calls.length).toBe(0);
     });
   });

--- a/packages/jest-util/src/fake_timers.js
+++ b/packages/jest-util/src/fake_timers.js
@@ -120,7 +120,7 @@ export default class FakeTimers<TimerRef> {
     // Instead, use the versions available on the `jest` object
     global.mockRunTicksRepeatedly = this.runAllTicks.bind(this);
     global.mockRunTimersOnce = this.runOnlyPendingTimers.bind(this);
-    global.mockRunTimersToTime = this.runTimersToTime.bind(this);
+    global.mockAdvanceTimersByTime = this.advanceTimersByTime.bind(this);
     global.mockRunTimersRepeatedly = this.runAllTimers.bind(this);
     global.mockClearTimers = this.clearAllTimers.bind(this);
     global.mockGetTimersCount = () => Object.keys(this._timers).length;
@@ -257,7 +257,7 @@ export default class FakeTimers<TimerRef> {
       .forEach(this._runTimerHandle, this);
   }
 
-  runTimersToTime(msToRun: number) {
+  advanceTimersByTime(msToRun: number) {
     this._checkFakeTimers();
     // Only run a generous number of timers and then bail.
     // This is just to help avoid recursive loops

--- a/types/Environment.js
+++ b/types/Environment.js
@@ -21,7 +21,7 @@ declare class $JestEnvironment {
     runAllImmediates(): void,
     runAllTicks(): void,
     runAllTimers(): void,
-    runTimersToTime(msToRun: number): void,
+    advanceTimersByTime(msToRun: number): void,
     runOnlyPendingTimers(): void,
     runWithRealTimers(callback: any): void,
     useFakeTimers(): void,

--- a/types/Jest.js
+++ b/types/Jest.js
@@ -39,7 +39,7 @@ export type Jest = {|
   runAllTicks(): void,
   runAllTimers(): void,
   runOnlyPendingTimers(): void,
-  runTimersToTime(msToRun: number): void,
+  advanceTimersByTime(msToRun: number): void,
   setMock(moduleName: string, moduleExports: any): Jest,
   setTimeout(timeout: number): Jest,
   spyOn(object: Object, methodName: string): JestMockFn,

--- a/types/Jest.js
+++ b/types/Jest.js
@@ -40,6 +40,7 @@ export type Jest = {|
   runAllTimers(): void,
   runOnlyPendingTimers(): void,
   advanceTimersByTime(msToRun: number): void,
+  runTimersToTime(msToRun: number): void,
   setMock(moduleName: string, moduleExports: any): Jest,
   setTimeout(timeout: number): Jest,
   spyOn(object: Object, methodName: string): JestMockFn,


### PR DESCRIPTION
**Summary**

As per #4723: added an alias for runTimersToTime, using the name suggested in the original issue.

I decided to make `runTimersToTime` the alias of `advanceTimersByTime`, on the assumption that the old name might be dropped in future.

**Test plan**

Does this need to be tested, as it's just an alias of an existing function?