### PR TITLE
Preserve module identity for symlinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * `[jest-message-util]` Always remove node internals from stacktraces ([#4695](https://github.com/facebook/jest/pull/4695))
 * `[jest-resolve]` changes method of determining builtin modules to include missing builtins ([#4740](https://github.com/facebook/jest/pull/4740))
 * `[pretty-format]` Prevent error in pretty-format for window in jsdom test env ([#4750](https://github.com/facebook/jest/pull/4750))
+* `[jest-resolve]` Preserve module identity for symlinks ([#4761](https://github.com/facebook/jest/pull/4761))
 
 ### Features
 * `[jest-environment-*]` [**BREAKING**] Add Async Test Environment APIs, dispose is now teardown ([#4506](https://github.com/facebook/jest/pull/4506))

--- a/integration_tests/__tests__/resolve.test.js
+++ b/integration_tests/__tests__/resolve.test.js
@@ -12,5 +12,9 @@ const runJest = require('../runJest');
 
 test('resolve platform modules', () => {
   const result = runJest('resolve');
-  expect(result.status).toBe(0);
+  const didFail = result.status !== 0;
+  if (didFail) {
+    console.log(result.stderr);
+  }
+  expect(didFail).toBe(false);
 });

--- a/integration_tests/__tests__/resolve.test.js
+++ b/integration_tests/__tests__/resolve.test.js
@@ -12,9 +12,5 @@ const runJest = require('../runJest');
 
 test('resolve platform modules', () => {
   const result = runJest('resolve');
-  const didFail = result.status !== 0;
-  if (didFail) {
-    console.log(result.stderr);
-  }
-  expect(didFail).toBe(false);
+  expect(result.status).toBe(0);
 });

--- a/integration_tests/resolve/__tests__/resolve.test.js
+++ b/integration_tests/resolve/__tests__/resolve.test.js
@@ -56,3 +56,9 @@ test('should resolve filename.json', () => {
   expect(testRequire('../test4')).not.toThrow();
   expect(platform.extension).toBe('json');
 });
+
+test('should preserve identity for symlinks', () => {
+  expect(require('../../../packages/jest-resolve')).toBe(
+    require('jest-resolve')
+  );
+});

--- a/packages/jest-resolve/src/default_resolver.js
+++ b/packages/jest-resolve/src/default_resolver.js
@@ -25,6 +25,7 @@ export default function defaultResolver(
   options: ResolverOptions,
 ): Path {
   const resolve = options.browser ? browserResolve.sync : resolveSync;
+
   return resolve(path, {
     basedir: options.basedir,
     extensions: options.extensions,

--- a/packages/jest-resolve/src/default_resolver.js
+++ b/packages/jest-resolve/src/default_resolver.js
@@ -25,7 +25,6 @@ export default function defaultResolver(
   options: ResolverOptions,
 ): Path {
   const resolve = options.browser ? browserResolve.sync : resolveSync;
-
   return resolve(path, {
     basedir: options.basedir,
     extensions: options.extensions,
@@ -93,6 +92,11 @@ function resolveSync(target: Path, options: ResolverOptions): Path {
     let result;
     if (isDirectory(dir)) {
       result = resolveAsFile(name) || resolveAsDirectory(name);
+    }
+    if (result) {
+      // Dereference symlinks to ensure we don't create a separate
+      // module instance depending on how it was referenced.
+      result = fs.realpathSync(result);
     }
     return result;
   }


### PR DESCRIPTION
**Summary**

We bumped into a problem trying to use Yarn Workspaces with Jest in the React repo.
It is the same issue as described in https://github.com/facebook/jest/issues/3830.

In our case, we had `packages/*` symlinked through `node_modules`.

We noticed that importing the same file with the path `root/packages/react/module` from a test in `root/packages/react/folder/__tests__` produced a different instantiation depending on how it is imported:

* Through the `react/folder/module` symlink.
* Or by the relative `../module` path.

This is because the old resolving mechanism established resolved paths as:

* `react/folder/module` => `repo/node_modules/react/folder/module.js`
* `../module` => `repo/packages/react/folder/module.js`

So Jest treated them as two different modules. This created very subtle and hard-to-debug errors (such as duplicate caches in arbitrary module branches depending on the initial imports that "forked" them).

With this fix, the resolving mechanism resolves both cases to `repo/packages/react/folder/module.js`.

It also fixes a [different problem we experienced with Jest/Yarn together not compiling modules](https://github.com/facebook/jest/pull/4761#issuecomment-339419335).

**Test plan**

Tests pass in React repo with relative paths, whereas they would fail before.

The reproducing case in https://github.com/tmeasday/jest-symlink-repro used to print twice:

<img width="333" alt="screen shot 2017-10-25 at 4 43 41 pm" src="https://user-images.githubusercontent.com/810438/32008640-a17a0e98-b9a4-11e7-8e19-fd3e69dc4724.png">

Now it prints once, as expected in its README:

<img width="362" alt="screen shot 2017-10-25 at 4 43 43 pm" src="https://user-images.githubusercontent.com/810438/32008648-a7e33ad4-b9a4-11e7-933a-918361c996db.png">

I added a new integration test and verified it fails on master.

<s>I also added some logging to the test runner for this integration test because when it failed, there used to be no indication at all as to the reasons why it was failing.</s> Removed per feedback.

Locally, I see a test failure in `packages/jest-worker/src/__tests__/child.test.js` but it also happens in master so is unrelated.