### PR TITLE
Don't report errors errors as unhandled if there is an existing "error" event handler

### DIFF
--- a/integration_tests/__tests__/nested_event_loop.test.js
+++ b/integration_tests/__tests__/nested_event_loop.test.js
@@ -12,6 +12,5 @@ const runJest = require('../runJest');
 
 test('works with nested event loops', () => {
   const result = runJest('nested_event_loop');
-  console.log(result.stderr)
   expect(result.status).toBe(0);
 });

--- a/integration_tests/__tests__/nested_event_loop.test.js
+++ b/integration_tests/__tests__/nested_event_loop.test.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+'use strict';
+
+const runJest = require('../runJest');
+
+test('works with nested event loops', () => {
+  const result = runJest('nested_event_loop');
+  console.log(result.stderr)
+  expect(result.status).toBe(0);
+});

--- a/integration_tests/nested_event_loop/__tests__/nested_event_loop.test.js
+++ b/integration_tests/nested_event_loop/__tests__/nested_event_loop.test.js
@@ -7,8 +7,7 @@
  * @jest-environment jsdom
  */
 
-/* global document */
-/* global window */
+/* eslint-env browser */
 
 'use strict';
 

--- a/integration_tests/nested_event_loop/__tests__/nested_event_loop.test.js
+++ b/integration_tests/nested_event_loop/__tests__/nested_event_loop.test.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @jest-environment jsdom
+ */
+
+'use strict';
+
+it('can assert on errors across nested event loops', () => {
+  const el = document.createElement('div');
+  el.addEventListener('fake', () => {
+    throw new Error('This should be caught.');
+  });
+  let caught = null;
+  window.addEventListener('error', e => {
+    caught = e.error;
+  });
+  expect(() => {
+    const evt = document.createEvent('Event');
+    evt.initEvent('fake', false, false);
+    el.dispatchEvent(evt);
+    if (caught) {
+      throw caught;
+    }
+  }).toThrow();
+});

--- a/integration_tests/nested_event_loop/__tests__/nested_event_loop.test.js
+++ b/integration_tests/nested_event_loop/__tests__/nested_event_loop.test.js
@@ -7,6 +7,9 @@
  * @jest-environment jsdom
  */
 
+/* global document */
+/* global window */
+
 'use strict';
 
 it('can assert on errors across nested event loops', () => {

--- a/integration_tests/nested_event_loop/package.json
+++ b/integration_tests/nested_event_loop/package.json
@@ -1,0 +1,5 @@
+{
+  "jest": {
+    "testEnvironment": "jsdom"
+  }
+}

--- a/packages/jest-environment-jsdom/src/index.js
+++ b/packages/jest-environment-jsdom/src/index.js
@@ -57,13 +57,13 @@ class JSDOMEnvironment {
     const originalAddListener = global.addEventListener;
     const originalRemoveListener = global.removeEventListener;
     let userErrorListenerCount = 0;
-    global.addEventListener = (name) => {
+    global.addEventListener = function(name) {
       if (name === 'error') {
         userErrorListenerCount++;
       }
       return originalAddListener.apply(this, arguments);
     };
-    global.removeEventListener = (name) => {
+    global.removeEventListener = function(name) {
       if (name === 'error') {
         userErrorListenerCount--;
       }

--- a/packages/jest-environment-jsdom/src/index.js
+++ b/packages/jest-environment-jsdom/src/index.js
@@ -57,17 +57,17 @@ class JSDOMEnvironment {
     const originalAddListener = global.addEventListener;
     const originalRemoveListener = global.removeEventListener;
     let userErrorListenerCount = 0;
-    global.addEventListener = (name, ...args) => {
+    global.addEventListener = (name) => {
       if (name === 'error') {
         userErrorListenerCount++;
       }
-      return originalAddListener(name, ...args);
+      return originalAddListener.apply(this, arguments);
     };
-    global.removeEventListener = (name, ...args) => {
+    global.removeEventListener = (name) => {
       if (name === 'error') {
         userErrorListenerCount--;
       }
-      return originalRemoveListener(name, ...args);
+      return originalRemoveListener.apply(this, arguments);
     };
 
     this.moduleMocker = new mock.ModuleMocker(global);

--- a/packages/jest-environment-jsdom/src/index.js
+++ b/packages/jest-environment-jsdom/src/index.js
@@ -50,6 +50,15 @@ class JSDOMEnvironment {
       }
     };
     global.addEventListener('error', this.errorEventListener);
+    const originalAddListener = global.addEventListener;
+
+    global.addEventListener = (name, ...args) => {
+      if (name === 'error') {
+        global.removeEventListener('error', this.errorEventListener);
+      }
+
+      return originalAddListener(name, ...args);
+    };
 
     this.moduleMocker = new mock.ModuleMocker(global);
 


### PR DESCRIPTION
This add a failing integration test for behavior React relies on.
It passes before https://github.com/facebook/jest/pull/4669, but now fails.

<s>Demonstrates</s> Fixes https://github.com/facebook/jest/issues/4764.