### PR TITLE
Fix stack trace for errors thrown by snapshot serializers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 * `[jest-resolve]` Preserve module identity for symlinks ([#4761](https://github.com/facebook/jest/pull/4761))
 * `[jest-config]` Include error message for `preset` json ([#4766](https://github.com/facebook/jest/pull/4766))
 * `[pretty-format]` Throw `PrettyFormatPluginError` if a plugin halts with an exception ([#4787](https://github.com/facebook/jest/pull/4787))
-* `[expect]` Keep the stack trace unchanged when `PrettyFormatPluginError` is thrown by pretty-format
+* `[expect]` Keep the stack trace unchanged when `PrettyFormatPluginError` is thrown by pretty-format ([#4787](https://github.com/facebook/jest/pull/4787))
 
 ### Features
 * `[jest-environment-jsdom]` [**BREAKING**] Upgrade to JSDOM@11 ([#4770](https://github.com/facebook/jest/pull/4770))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 * `[pretty-format]` Prevent error in pretty-format for window in jsdom test env ([#4750](https://github.com/facebook/jest/pull/4750))
 * `[jest-resolve]` Preserve module identity for symlinks ([#4761](https://github.com/facebook/jest/pull/4761))
 * `[jest-config]` Include error message for `preset` json ([#4766](https://github.com/facebook/jest/pull/4766))
+* `[pretty-format]` Throw `PrettyFormatPluginError` if a plugin halts with an exception ([#4787](https://github.com/facebook/jest/pull/4787))
+* `[expect]` Keep the stack trace unchanged when `PrettyFormatPluginError` is thrown by pretty-format
 
 ### Features
 * `[jest-environment-jsdom]` [**BREAKING**] Upgrade to JSDOM@11 ([#4770](https://github.com/facebook/jest/pull/4770))

--- a/packages/expect/src/index.js
+++ b/packages/expect/src/index.js
@@ -199,7 +199,7 @@ const makeThrowingMatcher = (
     } catch (error) {
       if (
         !(error instanceof JestAssertionError) &&
-        error.name != 'PrettyFormatPluginError' &&
+        error.name !== 'PrettyFormatPluginError' &&
         // Guard for some environments (browsers) that do not support this feature.
         Error.captureStackTrace
       ) {

--- a/packages/expect/src/index.js
+++ b/packages/expect/src/index.js
@@ -197,12 +197,14 @@ const makeThrowingMatcher = (
     try {
       result = matcher.apply(matcherContext, [actual].concat(args));
     } catch (error) {
-      if (!(error instanceof JestAssertionError)) {
-        // Try to remove this and deeper functions from the stack trace frame.
+      if (
+        !(error instanceof JestAssertionError) &&
+        error.name != 'PrettyFormatPluginError' &&
         // Guard for some environments (browsers) that do not support this feature.
-        if (Error.captureStackTrace) {
-          Error.captureStackTrace(error, throwingMatcher);
-        }
+        Error.captureStackTrace
+      ) {
+        // Try to remove this and deeper functions from the stack trace frame.
+        Error.captureStackTrace(error, throwingMatcher);
       }
       throw error;
     }

--- a/packages/pretty-format/src/__tests__/pretty_format.test.js
+++ b/packages/pretty-format/src/__tests__/pretty_format.test.js
@@ -550,6 +550,7 @@ describe('prettyFormat()', () => {
   });
 
   it('throws PrettyFormatPluginError if test throws an error', () => {
+    expect.hasAssertions();
     const options = {
       plugins: [
         {
@@ -569,6 +570,7 @@ describe('prettyFormat()', () => {
   });
 
   it('throws PrettyFormatPluginError if print throws an error', () => {
+    expect.hasAssertions();
     const options = {
       plugins: [
         {
@@ -588,6 +590,7 @@ describe('prettyFormat()', () => {
   });
 
   it('throws PrettyFormatPluginError if serialize throws an error', () => {
+    expect.hasAssertions();
     const options = {
       plugins: [
         {

--- a/packages/pretty-format/src/__tests__/pretty_format.test.js
+++ b/packages/pretty-format/src/__tests__/pretty_format.test.js
@@ -549,6 +549,63 @@ describe('prettyFormat()', () => {
     }).toThrow();
   });
 
+  it('throws PrettyFormatPluginError if test throws an error', () => {
+    const options = {
+      plugins: [
+        {
+          print: () => '',
+          test() {
+            throw new Error('Where is the error?');
+          },
+        },
+      ],
+    };
+
+    try {
+      prettyFormat('', options);
+    } catch (error) {
+      expect(error.name).toBe('PrettyFormatPluginError');
+    }
+  });
+
+  it('throws PrettyFormatPluginError if print throws an error', () => {
+    const options = {
+      plugins: [
+        {
+          print: () => {
+            throw new Error('Where is the error?');
+          },
+          test: () => true,
+        },
+      ],
+    };
+
+    try {
+      prettyFormat('', options);
+    } catch (error) {
+      expect(error.name).toBe('PrettyFormatPluginError');
+    }
+  });
+
+  it('throws PrettyFormatPluginError if serialize throws an error', () => {
+    const options = {
+      plugins: [
+        {
+          serialize: () => {
+            throw new Error('Where is the error?');
+          },
+          test: () => true,
+        },
+      ],
+    };
+
+    try {
+      prettyFormat('', options);
+    } catch (error) {
+      expect(error.name).toBe('PrettyFormatPluginError');
+    }
+  });
+
   it('supports plugins with deeply nested arrays (#24)', () => {
     const val = [[1, 2], [3, 4]];
     expect(


### PR DESCRIPTION
**Summary**

In this commit, we are creating a new custom error called `PrettyFormatPluginError`, this error is thrown by `prettyFormat` function when a serializer throws an error.

In the `expect` module, we skip `Error.captureStackTrace` if the error name is `PrettyFormatPluginError`, this way the stack trace stays intact.

Fixes #3302

**Test plan**

Given a test file `foo.test.js`:

```js
test("should match the snapshot", () => {
  const bar = {
    foo: {
      x: 1,
      y: 2
    }
  };

  expect(bar).toMatchSnapshot();
});
```

And a custom snapshot serializer `my-serializer-module.js`

```js
module.exports = {
  test: val => {
    throw new Error("Where is this error?");
  },
  print: val => ""
};
```

And a `package.json`:

```json
{
  "jest": {
    "snapshotSerializers": ["./my-serializer-module"]
  }
}
```

When `jest` is run, with the current implementation, the failure message has no trace of the error thrown by the custom serializer:

![screen shot 2017-10-29 at 12 00 50 pm](https://user-images.githubusercontent.com/208312/32142879-d6fc3628-bca0-11e7-9cbd-bcfd0844cb71.png)

With the new implementation we have a failure message that includes a trace from the error thrown by the custom serializer:

![screen shot 2017-10-29 at 12 02 12 pm](https://user-images.githubusercontent.com/208312/32142888-0babfe1c-bca1-11e7-8b1b-d9db203c42da.png)


