### PR TITLE
Add max retries per call, defaulting to 3

### DIFF
--- a/packages/jest-worker/README.md
+++ b/packages/jest-worker/README.md
@@ -61,7 +61,7 @@ Amount of workers to spwan. Defaults to the number of CPUs minus 1.
 
 #### `maxRetries: number` (optional)
 
-Maximum amount of times that a dead child can be re-spawned, per call. Defaults to `5`, pass `Infinity` to allow endless retries.
+Maximum amount of times that a dead child can be re-spawned, per call. Defaults to `3`, pass `Infinity` to allow endless retries.
 
 #### `forkOptions: Object` (optional)
 

--- a/packages/jest-worker/README.md
+++ b/packages/jest-worker/README.md
@@ -59,6 +59,10 @@ List of method names that can be called on the child processes from the parent p
 
 Amount of workers to spwan. Defaults to the number of CPUs minus 1.
 
+#### `maxRetries: number` (optional)
+
+Maximum amount of times that a dead child can be re-spawned. Defaults to `5`, pass `Infinity` to allow endless retries.
+
 #### `forkOptions: Object` (optional)
 
 Allow customizing all options passed to `childProcess.fork`. By default, some values are set (`cwd` and `env`), but you can override them and customize the rest. For a list of valid values, check [the Node documentation](https://nodejs.org/api/child_process.html#child_process_child_process_fork_modulepath_args_options).

--- a/packages/jest-worker/README.md
+++ b/packages/jest-worker/README.md
@@ -61,7 +61,7 @@ Amount of workers to spwan. Defaults to the number of CPUs minus 1.
 
 #### `maxRetries: number` (optional)
 
-Maximum amount of times that a dead child can be re-spawned. Defaults to `5`, pass `Infinity` to allow endless retries.
+Maximum amount of times that a dead child can be re-spawned, per call. Defaults to `5`, pass `Infinity` to allow endless retries.
 
 #### `forkOptions: Object` (optional)
 

--- a/packages/jest-worker/src/__tests__/child.test.js
+++ b/packages/jest-worker/src/__tests__/child.test.js
@@ -203,7 +203,7 @@ it('returns results immediately when function is synchronous', () => {
     '"null" or "undefined" thrown',
   );
 
-  expect(process.send.mock.calls.length).toBe(5);
+  expect(process.send).toHaveBeenCalledTimes(5);
 });
 
 it('returns results when it gets resolved if function is asynchronous', async () => {
@@ -243,7 +243,7 @@ it('returns results when it gets resolved if function is asynchronous', async ()
     {},
   ]);
 
-  expect(process.send.mock.calls.length).toBe(2);
+  expect(process.send).toHaveBeenCalledTimes(2);
 });
 
 it('calls the main module if the method call is "default"', () => {

--- a/packages/jest-worker/src/__tests__/index.test.js
+++ b/packages/jest-worker/src/__tests__/index.test.js
@@ -114,12 +114,14 @@ it('tries instantiating workers with the right options', () => {
   new Farm('/tmp/baz.js', {
     exposedMethods: ['foo', 'bar'],
     forkOptions: {execArgv: []},
+    maxRetries: 6,
     numWorkers: 4,
   });
 
   expect(Worker.mock.calls.length).toBe(4);
   expect(Worker.mock.calls[0][0]).toEqual({
     forkOptions: {execArgv: []},
+    maxRetries: 6,
     workerPath: '/tmp/baz.js',
   });
 });

--- a/packages/jest-worker/src/__tests__/index.test.js
+++ b/packages/jest-worker/src/__tests__/index.test.js
@@ -98,7 +98,7 @@ it('works with minimal options', () => {
   // eslint-disable-next-line no-new
   const farm1 = new Farm('/fake-worker.js');
 
-  expect(Worker.mock.calls.length).toBe(require('os').cpus().length - 1);
+  expect(Worker).toHaveBeenCalledTimes(require('os').cpus().length - 1);
   expect(typeof farm1.methodA).toBe('function');
   expect(typeof farm1.methodB).toBe('function');
   expect(typeof farm1._shouldNotExist).not.toBe('function');
@@ -118,7 +118,7 @@ it('tries instantiating workers with the right options', () => {
     numWorkers: 4,
   });
 
-  expect(Worker.mock.calls.length).toBe(4);
+  expect(Worker).toHaveBeenCalledTimes(4);
   expect(Worker.mock.calls[0][0]).toEqual({
     forkOptions: {execArgv: []},
     maxRetries: 6,
@@ -259,9 +259,9 @@ it('sends non-sticked tasks to all workers', () => {
 
   farm.foo('car', 'plane');
 
-  expect(mockWorkers[0].send.mock.calls.length).toBe(1);
-  expect(mockWorkers[1].send.mock.calls.length).toBe(1);
-  expect(mockWorkers[2].send.mock.calls.length).toBe(1);
+  expect(mockWorkers[0].send).toHaveBeenCalledTimes(1);
+  expect(mockWorkers[1].send).toHaveBeenCalledTimes(1);
+  expect(mockWorkers[2].send).toHaveBeenCalledTimes(1);
 });
 
 it('sends first-time sticked tasks to all workers', () => {
@@ -273,9 +273,9 @@ it('sends first-time sticked tasks to all workers', () => {
 
   farm.foo('car', 'plane');
 
-  expect(mockWorkers[0].send.mock.calls.length).toBe(1);
-  expect(mockWorkers[1].send.mock.calls.length).toBe(1);
-  expect(mockWorkers[2].send.mock.calls.length).toBe(1);
+  expect(mockWorkers[0].send).toHaveBeenCalledTimes(1);
+  expect(mockWorkers[1].send).toHaveBeenCalledTimes(1);
+  expect(mockWorkers[2].send).toHaveBeenCalledTimes(1);
 });
 
 it('checks that once a sticked task finishes, next time is sent to that worker', async () => {
@@ -300,9 +300,9 @@ it('checks that once a sticked task finishes, next time is sent to that worker',
   // earlier ("foo" call), so it got queued to all workers. Later, since the one
   // that resolved the call was the one in position 1, all subsequent calls are
   // only redirected to that worker.
-  expect(mockWorkers[0].send.mock.calls.length).toBe(1); // Only "foo".
-  expect(mockWorkers[1].send.mock.calls.length).toBe(2); // "foo" + "bar".
-  expect(mockWorkers[2].send.mock.calls.length).toBe(1); // Only "foo".
+  expect(mockWorkers[0].send).toHaveBeenCalledTimes(1); // Only "foo".
+  expect(mockWorkers[1].send).toHaveBeenCalledTimes(2); // "foo" + "bar".
+  expect(mockWorkers[2].send).toHaveBeenCalledTimes(1); // Only "foo".
 });
 
 it('checks that once a non-sticked task finishes, next time is sent to all workers', async () => {
@@ -321,7 +321,7 @@ it('checks that once a non-sticked task finishes, next time is sent to all worke
 
   // Since "computeWorkerKey" does not return anything, new jobs are sent again to
   // all existing workers.
-  expect(mockWorkers[0].send.mock.calls.length).toBe(2);
-  expect(mockWorkers[1].send.mock.calls.length).toBe(2);
-  expect(mockWorkers[2].send.mock.calls.length).toBe(2);
+  expect(mockWorkers[0].send).toHaveBeenCalledTimes(2);
+  expect(mockWorkers[1].send).toHaveBeenCalledTimes(2);
+  expect(mockWorkers[2].send).toHaveBeenCalledTimes(2);
 });

--- a/packages/jest-worker/src/__tests__/worker.test.js
+++ b/packages/jest-worker/src/__tests__/worker.test.js
@@ -26,14 +26,15 @@ beforeEach(() => {
   jest.mock('child_process');
 
   childProcess = require('child_process');
-  childProcess.fork.mockImplementation(
-    () =>
-      (forkInterface = Object.assign(new EventEmitter(), {
-        send: jest.fn(),
-        stderr: {},
-        stdout: {},
-      })),
-  );
+  childProcess.fork.mockImplementation(() => {
+    forkInterface = Object.assign(new EventEmitter(), {
+      send: jest.fn(),
+      stderr: {},
+      stdout: {},
+    });
+
+    return forkInterface;
+  });
 
   Worker = require('../worker').default;
 });

--- a/packages/jest-worker/src/__tests__/worker.test.js
+++ b/packages/jest-worker/src/__tests__/worker.test.js
@@ -91,13 +91,13 @@ it('stops initializing the worker after the amount of retries is exceeded', () =
   forkInterface.emit('exit');
 
   // 3 retries + the initial load = 4.
-  expect(childProcess.fork.mock.calls.length).toBe(4);
-  expect(emit.mock.calls.length).toBe(0);
+  expect(childProcess.fork).toHaveBeenCalledTimes(4);
+  expect(emit).toHaveBeenCalledTimes(0);
 
   // The fourth should fail! (so no more calls to "childProcess.fork").
   forkInterface.emit('exit');
 
-  expect(childProcess.fork.mock.calls.length).toBe(4);
+  expect(childProcess.fork).toHaveBeenCalledTimes(4);
   expect(emit.mock.calls[0][0]).toBe('error');
 });
 
@@ -269,9 +269,9 @@ it('does not restart the child if it cleanly exited', () => {
     workerPath: '/tmp/foo',
   });
 
-  expect(childProcess.fork.mock.calls.length).toBe(1);
+  expect(childProcess.fork).toHaveBeenCalledTimes(1);
   forkInterface.emit('exit', 0);
-  expect(childProcess.fork.mock.calls.length).toBe(1);
+  expect(childProcess.fork).toHaveBeenCalledTimes(1);
 });
 
 it('restarts the child when the child process dies', () => {
@@ -279,7 +279,7 @@ it('restarts the child when the child process dies', () => {
     workerPath: '/tmp/foo',
   });
 
-  expect(childProcess.fork.mock.calls.length).toBe(1);
+  expect(childProcess.fork).toHaveBeenCalledTimes(1);
   forkInterface.emit('exit', 1);
-  expect(childProcess.fork.mock.calls.length).toBe(2);
+  expect(childProcess.fork).toHaveBeenCalledTimes(2);
 });

--- a/packages/jest-worker/src/__tests__/worker.test.js
+++ b/packages/jest-worker/src/__tests__/worker.test.js
@@ -97,6 +97,7 @@ it('stops initializing the worker after the amount of retries is exceeded', () =
 
   expect(childProcess.fork).toHaveBeenCalledTimes(5);
   expect(callback.mock.calls[0][0]).toBeInstanceOf(Error);
+  expect(callback.mock.calls[0][0].type).toBe('WorkerError');
   expect(callback.mock.calls[0][1]).toBe(null);
 });
 

--- a/packages/jest-worker/src/__tests__/worker.test.js
+++ b/packages/jest-worker/src/__tests__/worker.test.js
@@ -84,22 +84,20 @@ it('stops initializing the worker after the amount of retries is exceeded', () =
     workerPath: '/tmp/foo/bar/baz.js',
   });
 
-  const emit = jest.spyOn(worker, 'emit').mockImplementation(() => {});
+  const request = [CHILD_MESSAGE_CALL, false, 'foo', []];
+  const callback = jest.fn();
 
-  // Three retries.
+  worker.send(request, callback);
+
+  // We fail four times (initial + three retries).
   forkInterface.emit('exit');
   forkInterface.emit('exit');
   forkInterface.emit('exit');
-
-  // 3 retries + the initial load = 4.
-  expect(childProcess.fork).toHaveBeenCalledTimes(4);
-  expect(emit).toHaveBeenCalledTimes(0);
-
-  // The fourth should fail! (so no more calls to "childProcess.fork").
   forkInterface.emit('exit');
 
-  expect(childProcess.fork).toHaveBeenCalledTimes(4);
-  expect(emit.mock.calls[0][0]).toBe('error');
+  expect(childProcess.fork).toHaveBeenCalledTimes(5);
+  expect(callback.mock.calls[0][0]).toBeInstanceOf(Error);
+  expect(callback.mock.calls[0][1]).toBe(null);
 });
 
 it('provides stdout and stderr fields from the child process', () => {

--- a/packages/jest-worker/src/index.js
+++ b/packages/jest-worker/src/index.js
@@ -68,6 +68,7 @@ export default class {
     // Build the options once for all workers to avoid allocating extra objects.
     const workerOptions = {
       forkOptions: options.forkOptions || {},
+      maxRetries: options.maxRetries || Infinity,
       workerPath,
     };
 

--- a/packages/jest-worker/src/index.js
+++ b/packages/jest-worker/src/index.js
@@ -68,7 +68,7 @@ export default class {
     // Build the options once for all workers to avoid allocating extra objects.
     const workerOptions = {
       forkOptions: options.forkOptions || {},
-      maxRetries: options.maxRetries || Infinity,
+      maxRetries: options.maxRetries || 5,
       workerPath,
     };
 

--- a/packages/jest-worker/src/index.js
+++ b/packages/jest-worker/src/index.js
@@ -68,7 +68,7 @@ export default class {
     // Build the options once for all workers to avoid allocating extra objects.
     const workerOptions = {
       forkOptions: options.forkOptions || {},
-      maxRetries: options.maxRetries || 5,
+      maxRetries: options.maxRetries || 3,
       workerPath,
     };
 

--- a/packages/jest-worker/src/types.js
+++ b/packages/jest-worker/src/types.js
@@ -39,11 +39,13 @@ export type FarmOptions = {
   computeWorkerKey?: (string, ...Array<any>) => ?string,
   exposedMethods?: $ReadOnlyArray<string>,
   forkOptions?: ForkOptions,
+  maxRetries?: number,
   numWorkers?: number,
 };
 
 export type WorkerOptions = {|
-  forkOptions?: ForkOptions,
+  forkOptions: ForkOptions,
+  maxRetries: number,
   workerPath: string,
 |};
 

--- a/packages/jest-worker/src/worker.js
+++ b/packages/jest-worker/src/worker.js
@@ -51,14 +51,14 @@ export default class extends EventEmitter {
   _child: ChildProcess;
   _options: WorkerOptions;
   _queue: Array<QueueChildMessage>;
-  _startedTimes: number;
+  _retries: number;
 
   constructor(options: WorkerOptions) {
     super();
 
     this._options = options;
     this._queue = [];
-    this._startedTimes = 0;
+    this._retries = 0;
 
     this._initialize();
   }
@@ -77,7 +77,7 @@ export default class extends EventEmitter {
   }
 
   _initialize() {
-    if (this._startedTimes > this._options.maxRetries) {
+    if (this._retries > this._options.maxRetries) {
       this.emit('error', new Error('Process failed too many times!'));
       return;
     }
@@ -101,7 +101,7 @@ export default class extends EventEmitter {
     // $FlowFixMe: wrong "ChildProcess.send" signature.
     child.send([CHILD_MESSAGE_INITIALIZE, false, this._options.workerPath]);
 
-    this._startedTimes++;
+    this._retries++;
     this._child = child;
     this._busy = false;
   }

--- a/packages/jest-worker/src/worker.js
+++ b/packages/jest-worker/src/worker.js
@@ -107,7 +107,7 @@ export default class {
         error.name,
         error.message,
         error.stack,
-        {},
+        {type: 'WorkerError'},
       ]);
     }
   }


### PR DESCRIPTION
One of the requirements of the API was that we needed a way of ending childs that unexpectedly leave. We introduce the `maxRetries` variable; which measures how many times a child can be restarted (per call), before emitting an `error` event.

Tests were added so that a 100% coverage is still ensured on the module, as it was before. Also, `WorkerOptions` type was made stricter by making required the `forkOptions` property (which was anyway always passed).