### PR TITLE
jest-haste-map: add test to demo broken duplicates behavior

### DIFF
--- a/packages/jest-haste-map/src/__tests__/index.test.js
+++ b/packages/jest-haste-map/src/__tests__/index.test.js
@@ -557,9 +557,11 @@ describe('HasteMap', () => {
     ].join('\n');
 
     let {__hasteMapForTest: data} = await new HasteMap(defaultConfig).build();
-    expect(data.duplicates).toEqual(
-      {"Strawberry": {"g": {"/fruits/another_strawberry.js": 0, "/fruits/strawberry.js": 0}}}
-    );
+    expect(data.duplicates).toEqual({
+      Strawberry: {
+        g: {'/fruits/another_strawberry.js': 0, '/fruits/strawberry.js': 0},
+      },
+    });
     expect(data.map['Strawberry']).toEqual({});
 
     delete mockFs['/fruits/another_strawberry.js'];
@@ -573,9 +575,11 @@ describe('HasteMap', () => {
 
     ({__hasteMapForTest: data} = await new HasteMap(defaultConfig).build());
     // This is broken, there should not be duplicates anymore.
-    expect(data.duplicates).toEqual(
-      {"Strawberry": {"g": {"/fruits/another_strawberry.js": 0, "/fruits/strawberry.js": 0}}}
-    );
+    expect(data.duplicates).toEqual({
+      Strawberry: {
+        g: {'/fruits/another_strawberry.js': 0, '/fruits/strawberry.js': 0},
+      },
+    });
     // This is broken, Strawberry should now resolve to "/fruits/strawberry.js"
     expect(data.map['Strawberry']).toEqual({});
   });


### PR DESCRIPTION

**Summary**

`jest-haste-map` doesn't properly recover from duplicates when such state is stored in the cache (on the other hand, processing of duplicate by the watching mode is already correct and covered by tests). This changeset adds a test that demonstrate the brokeness. Next step will be to fix the behavior, and we can then switch the test to the correct values.

**Test plan**

    yarn jest packages/jest-haste-map/src/__tests__/index.test.js
