### PR TITLE
jest-haste-map: properly recover duplicates when files change

### DIFF
--- a/packages/jest-haste-map/src/__tests__/index.test.js
+++ b/packages/jest-haste-map/src/__tests__/index.test.js
@@ -548,7 +548,7 @@ describe('HasteMap', () => {
       });
   });
 
-  it('recovers from duplicate modules (broken)', async () => {
+  it('recovers from duplicate modules', async () => {
     mockFs['/fruits/another_strawberry.js'] = [
       '/**',
       ' * @providesModule Strawberry',
@@ -574,14 +574,8 @@ describe('HasteMap', () => {
     });
 
     ({__hasteMapForTest: data} = await new HasteMap(defaultConfig).build());
-    // This is broken, there should not be duplicates anymore.
-    expect(data.duplicates).toEqual({
-      Strawberry: {
-        g: {'/fruits/another_strawberry.js': 0, '/fruits/strawberry.js': 0},
-      },
-    });
-    // This is broken, Strawberry should now resolve to "/fruits/strawberry.js"
-    expect(data.map['Strawberry']).toEqual({});
+    expect(data.duplicates).toEqual({});
+    expect(data.map['Strawberry']).toEqual({g: ['/fruits/strawberry.js', 0]});
   });
 
   it('discards the cache when configuration changes', () => {

--- a/packages/jest-haste-map/src/index.js
+++ b/packages/jest-haste-map/src/index.js
@@ -322,7 +322,7 @@ class HasteMap extends EventEmitter {
         return this._crawl(cachedHasteMap).then(hasteMap => {
           const deprecatedFiles = cachedFiles.filter(file => {
             const fileData = hasteMap.files[file.path];
-            return fileData == null || file.moduleName != fileData[H.ID];
+            return fileData == null || file.moduleName !== fileData[H.ID];
           });
           return {deprecatedFiles, hasteMap};
         });

--- a/packages/jest-haste-map/src/index.js
+++ b/packages/jest-haste-map/src/index.js
@@ -316,20 +316,15 @@ class HasteMap extends EventEmitter {
       .catch(() => this._createEmptyMap())
       .then(cachedHasteMap => {
         const cachedFiles = Object.keys(cachedHasteMap.files).map(filePath => {
-          return {
-            moduleName: cachedHasteMap.files[filePath][H.ID],
-            path: filePath,
-          };
+          const moduleName = cachedHasteMap.files[filePath][H.ID];
+          return {moduleName, path: filePath};
         });
         return this._crawl(cachedHasteMap).then(hasteMap => {
-          return {
-            deprecatedFiles: cachedFiles.filter(
-              file =>
-                !(file.path in hasteMap.files) ||
-                file.moduleName != hasteMap.files[file.path][H.ID],
-            ),
-            hasteMap,
-          };
+          const deprecatedFiles = cachedFiles.filter(file => {
+            const fileData = hasteMap.files[file.path];
+            return fileData == null || file.moduleName != fileData[H.ID];
+          });
+          return {deprecatedFiles, hasteMap};
         });
       });
   }


### PR DESCRIPTION
**Summary**

When we load the haste map from the cache, we need to keep track of all the files that were removed, or even which module name changed, so that we can recover other modules with which there were potentially sharing names before. For example, if we delete a module "Strawberry", maybe this allows another module that's the legitimate Strawberry to be available. Or, if we renamed a module's name from "Strawberry" to "Blackberry", maybe this allows another module to be deduplicated the same way.

**Test plan**

Unit test. However, I must add another test case to test file renames (not just deletion) before I land. Opening the PR to get a first feedback on the code.