### PR TITLE
Improve error messaging from "spyOn"

### DIFF
--- a/packages/jest-mock/src/index.js
+++ b/packages/jest-mock/src/index.js
@@ -629,7 +629,7 @@ class ModuleMockerClass {
   }
 
   isMockFunction(fn: any): boolean {
-    return !!fn._isMockFunction;
+    return !!(fn && fn._isMockFunction);
   }
 
   fn(implementation?: any): any {
@@ -642,12 +642,22 @@ class ModuleMockerClass {
   }
 
   spyOn(object: any, methodName: any): any {
+    if (typeof object !== 'object' && typeof object !== 'function') {
+      throw new Error(
+        'Cannot spyOn on a primitive value; ' + this._typeOf(object) + ' given',
+      );
+    }
+
     const original = object[methodName];
 
     if (!this.isMockFunction(original)) {
       if (typeof original !== 'function') {
         throw new Error(
-          'Cannot spyOn the ' + methodName + ' property; it is not a function',
+          'Cannot spy the ' +
+            methodName +
+            ' property because it is not a function; ' +
+            this._typeOf(original) +
+            ' given instead',
         );
       }
 
@@ -675,6 +685,10 @@ class ModuleMockerClass {
   restoreAllMocks() {
     this._spyState.forEach(restore => restore());
     this._spyState = new Set();
+  }
+
+  _typeOf(value: any): string {
+    return value == null ? '' + value : typeof value;
   }
 }
 


### PR DESCRIPTION
While developing, I found annoying that an invalid `spyOn` returns a very cryptic error, caused by the lack of checking on `fn`; it calls `fn._isMockFunction` without checking first if `fn` is actually something. 

![](https://user-images.githubusercontent.com/829269/32233199-c1e14e42-be51-11e7-838c-296bc54b26c1.png)

This PR improves the messaging we give when we find these kind of errors.

## Passing something that is not an `object` or a `function`:

![](https://user-images.githubusercontent.com/829269/32233322-078754be-be52-11e7-8c4e-82b649149d1b.png)

Primitive keys cannot be spied because of how they work, see the [ECMA-262 specification](https://www.ecma-international.org/ecma-262/8.0/index.html#sec-getv) for more info:

>  If the value is not an object, the property lookup is performed using a wrapper object appropriate for the type of the value [...]

## Obtaining something that is not a `function`:

![](https://user-images.githubusercontent.com/829269/32233690-e23a3b3a-be52-11e7-9d9e-0a7fb1567a3f.png)