### PR TITLE
Migrate jest-haste-map to jest-worker

### DIFF
--- a/packages/jest-haste-map/package.json
+++ b/packages/jest-haste-map/package.json
@@ -11,7 +11,7 @@
     "fb-watchman": "^2.0.0",
     "graceful-fs": "^4.1.11",
     "jest-docblock": "^21.2.0",
-    "jest-worker": "^21.2.0",
+    "jest-worker": "^21.2.1",
     "micromatch": "^2.3.11",
     "sane": "^2.0.0"
   }

--- a/packages/jest-haste-map/package.json
+++ b/packages/jest-haste-map/package.json
@@ -11,8 +11,8 @@
     "fb-watchman": "^2.0.0",
     "graceful-fs": "^4.1.11",
     "jest-docblock": "^21.2.0",
+    "jest-worker": "^21.2.0",
     "micromatch": "^2.3.11",
-    "sane": "^2.0.0",
-    "worker-farm": "^1.5.1"
+    "sane": "^2.0.0"
   }
 }

--- a/packages/jest-haste-map/src/__tests__/index.test.js
+++ b/packages/jest-haste-map/src/__tests__/index.test.js
@@ -14,13 +14,13 @@ jest.mock('child_process', () => ({
 }));
 
 jest.mock('jest-worker', () => {
-  return jest.fn((worker) => {
+  return jest.fn(worker => {
     mockWorker = jest.fn((...args) => require(worker).worker(...args));
     mockEnd = jest.fn();
 
     return {
-      worker: mockWorker,
       end: mockEnd,
+      worker: mockWorker,
     };
   });
 });

--- a/packages/jest-haste-map/src/index.js
+++ b/packages/jest-haste-map/src/index.js
@@ -17,7 +17,9 @@ import type {
   HasteRegExp,
   MockData,
 } from 'types/HasteMap';
-import type {WorkerMessage, WorkerMetadata, WorkerCallback} from './types';
+
+import typeof {worker} from './worker';
+
 // eslint-disable-next-line import/no-duplicates
 import typeof HType from './constants';
 
@@ -28,7 +30,6 @@ import crypto from 'crypto';
 import {execSync} from 'child_process';
 import fs from 'graceful-fs';
 import sane from 'sane';
-import workerFarm from 'worker-farm';
 import {version as VERSION} from '../package.json';
 // eslint-disable-next-line import/no-duplicates
 import H from './constants';
@@ -37,13 +38,12 @@ import HasteModuleMap from './module_map';
 import getMockName from './get_mock_name';
 import getPlatformExtension from './lib/get_platform_extension';
 import normalizePathSep from './lib/normalize_path_sep';
+import Worker from 'jest-worker';
 
 // eslint-disable-next-line import/default
 import nodeCrawl from './crawlers/node';
 // eslint-disable-next-line import/default
 import watchmanCrawl from './crawlers/watchman';
-// eslint-disable-next-line import/default
-import worker from './worker';
 
 type Options = {
   cacheDirectory?: string,
@@ -86,6 +86,8 @@ type InternalOptions = {
 type Watcher = {
   close(callback: () => void): void,
 };
+
+type WorkerInterface = {worker: worker};
 
 export type ModuleMap = HasteModuleMap;
 export type FS = HasteFS;
@@ -202,8 +204,7 @@ class HasteMap extends EventEmitter {
   _options: InternalOptions;
   _watchers: Array<Watcher>;
   _whitelist: ?RegExp;
-  _workerFarm: ?(data: WorkerMessage, callback: WorkerCallback) => void;
-  _workerPromise: ?(message: WorkerMessage) => Promise<WorkerMetadata>;
+  _worker: ?WorkerInterface;
 
   constructor(options: Options) {
     super();
@@ -245,9 +246,8 @@ class HasteMap extends EventEmitter {
     );
     this._whitelist = getWhiteList(options.providesModuleNodeModules);
     this._buildPromise = null;
-    this._workerPromise = null;
-    this._workerFarm = null;
     this._watchers = [];
+    this._worker = null;
   }
 
   static getCacheFilePath(
@@ -427,30 +427,32 @@ class HasteMap extends EventEmitter {
       }
     }
 
-    return this._getWorker(workerOptions)({
-      filePath,
-      hasteImplModulePath: this._options.hasteImplModulePath,
-    }).then(
-      metadata => {
-        // `1` for truthy values instead of `true` to save cache space.
-        fileMetadata[H.VISITED] = 1;
-        const metadataId = metadata.id;
-        const metadataModule = metadata.module;
-        if (metadataId && metadataModule) {
-          fileMetadata[H.ID] = metadataId;
-          setModule(metadataId, metadataModule);
-        }
-        fileMetadata[H.DEPENDENCIES] = metadata.dependencies || [];
-      },
-      error => {
-        if (['ENOENT', 'EACCES'].indexOf(error.code) < 0) {
-          throw error;
-        }
-        // If a file cannot be read we remove it from the file list and
-        // ignore the failure silently.
-        delete hasteMap.files[filePath];
-      },
-    );
+    return this._getWorker(workerOptions)
+      .worker({
+        filePath,
+        hasteImplModulePath: this._options.hasteImplModulePath,
+      })
+      .then(
+        metadata => {
+          // `1` for truthy values instead of `true` to save cache space.
+          fileMetadata[H.VISITED] = 1;
+          const metadataId = metadata.id;
+          const metadataModule = metadata.module;
+          if (metadataId && metadataModule) {
+            fileMetadata[H.ID] = metadataId;
+            setModule(metadataId, metadataModule);
+          }
+          fileMetadata[H.DEPENDENCIES] = metadata.dependencies || [];
+        },
+        error => {
+          if (['ENOENT', 'EACCES'].indexOf(error.code) < 0) {
+            throw error;
+          }
+          // If a file cannot be read we remove it from the file list and
+          // ignore the failure silently.
+          delete hasteMap.files[filePath];
+        },
+      );
   }
 
   _buildHasteMap(data: {
@@ -474,25 +476,27 @@ class HasteMap extends EventEmitter {
       }
     }
 
-    const cleanup = () => {
-      if (this._workerFarm) {
-        workerFarm.end(this._workerFarm);
-      }
-      this._workerFarm = null;
-      this._workerPromise = null;
-    };
-
     return Promise.all(promises)
-      .then(cleanup)
       .then(() => {
+        this._cleanup();
         hasteMap.map = map;
         hasteMap.mocks = mocks;
         return hasteMap;
       })
       .catch(error => {
-        cleanup();
+        this._cleanup();
         return Promise.reject(error);
       });
+  }
+
+  _cleanup() {
+    const worker = this._worker;
+
+    if (worker && typeof worker.end === 'function') {
+      worker.end();
+    }
+
+    this._worker = null;
   }
 
   /**
@@ -505,36 +509,23 @@ class HasteMap extends EventEmitter {
   /**
    * Creates workers or parses files and extracts metadata in-process.
    */
-  _getWorker(
-    options: ?{forceInBand: boolean},
-  ): (message: WorkerMessage) => Promise<WorkerMetadata> {
-    if (!this._workerPromise) {
-      let workerFn;
-      if ((options && options.forceInBand) || this._options.maxWorkers <= 1) {
-        workerFn = worker;
-      } else {
-        this._workerFarm = workerFarm(
-          {
-            maxConcurrentWorkers: this._options.maxWorkers,
-          },
-          require.resolve('./worker'),
-        );
-        workerFn = this._workerFarm;
-      }
+  _getWorker(options: ?{forceInBand: boolean}): WorkerInterface {
+    if (!this._worker) {
+      const workerOptions = {
+        exposedMethods: ['worker'],
+        maxRetries: 3,
+        numWorkers: this._options.maxWorkers,
+      };
 
-      this._workerPromise = (message: WorkerMessage) =>
-        new Promise((resolve, reject) =>
-          workerFn(message, (error, metadata) => {
-            if (error || !metadata) {
-              reject(error);
-            } else {
-              resolve(metadata);
-            }
-          }),
-        );
+      if ((options && options.forceInBand) || this._options.maxWorkers <= 1) {
+        this._worker = require('./worker');
+      } else {
+        // $FlowFixMe: assignment of a worker with custom properties.
+        this._worker = new Worker(require.resolve('./worker'), workerOptions);
+      }
     }
 
-    return this._workerPromise;
+    return this._worker;
   }
 
   _parse(hasteMapPath: string): InternalHasteMap {
@@ -749,7 +740,7 @@ class HasteMap extends EventEmitter {
               },
             );
             // Cleanup
-            this._workerPromise = null;
+            this._cleanup();
             if (promise) {
               return promise.then(add);
             } else {

--- a/packages/jest-haste-map/src/index.js
+++ b/packages/jest-haste-map/src/index.js
@@ -445,9 +445,9 @@ class HasteMap extends EventEmitter {
           fileMetadata[H.DEPENDENCIES] = metadata.dependencies || [];
         },
         error => {
-          if (!(error instanceof Error)) {
+          if (typeof error !== 'object' || !error.message || !error.stack) {
             error = new Error(error);
-            error.stack = ''; // So it does not confuse people.
+            error.stack = ''; // Remove stack for stack-less errors.
           }
 
           // $FlowFixMe: checking error code is OK if error comes from "fs".

--- a/packages/jest-haste-map/src/types.js
+++ b/packages/jest-haste-map/src/types.js
@@ -7,7 +7,6 @@
  * @flow
  */
 
-import type {SerializableError} from 'types/TestResult';
 import type {InternalHasteMap, ModuleMetaData} from 'types/HasteMap';
 
 export type IgnoreMatcher = (item: string) => boolean;
@@ -16,15 +15,12 @@ export type WorkerMessage = {
   filePath: string,
   hasteImplModulePath?: string,
 };
+
 export type WorkerMetadata = {
   id: ?string,
   module: ?ModuleMetaData,
   dependencies: ?Array<string>,
 };
-export type WorkerCallback = (
-  error: ?SerializableError,
-  metaData: ?WorkerMetadata,
-) => void;
 
 export type CrawlerOptions = {|
   data: InternalHasteMap,

--- a/packages/jest-haste-map/src/worker.js
+++ b/packages/jest-haste-map/src/worker.js
@@ -7,8 +7,7 @@
  * @flow
  */
 
-import type {SerializableError} from 'types/TestResult';
-import type {HasteImpl, WorkerMessage, WorkerCallback} from './types';
+import type {HasteImpl, WorkerMessage, WorkerMetadata} from './types';
 
 import path from 'path';
 import * as docblock from 'jest-docblock';
@@ -22,25 +21,7 @@ const PACKAGE_JSON = path.sep + 'package' + JSON_EXTENSION;
 let hasteImpl: ?HasteImpl = null;
 let hasteImplModulePath: ?string = null;
 
-const formatError = (error: string | Error): SerializableError => {
-  if (typeof error === 'string') {
-    return {
-      message: error,
-      stack: null,
-      type: 'Error',
-    };
-  }
-
-  return {
-    code: error.code || undefined,
-    message: error.message,
-    stack: error.stack,
-    type: 'Error',
-  };
-};
-
-// Cannot be ESM export or worker-farm is confused
-module.exports = (data: WorkerMessage, callback: WorkerCallback): void => {
+export async function worker(data: WorkerMessage): Promise<WorkerMetadata> {
   if (
     data.hasteImplModulePath &&
     data.hasteImplModulePath !== hasteImplModulePath
@@ -49,39 +30,34 @@ module.exports = (data: WorkerMessage, callback: WorkerCallback): void => {
       throw new Error('jest-haste-map: hasteImplModulePath changed');
     }
     hasteImplModulePath = data.hasteImplModulePath;
-    hasteImpl =
-      // $FlowFixMe: dynamic require
-      (require(hasteImplModulePath): HasteImpl);
+    // $FlowFixMe: dynamic require
+    hasteImpl = (require(hasteImplModulePath): HasteImpl);
   }
 
-  try {
-    const filePath = data.filePath;
-    const content = fs.readFileSync(filePath, 'utf8');
-    let module;
-    let id;
-    let dependencies;
+  const filePath = data.filePath;
+  const content = fs.readFileSync(filePath, 'utf8');
+  let module;
+  let id;
+  let dependencies;
 
-    if (filePath.endsWith(PACKAGE_JSON)) {
-      const fileData = JSON.parse(content);
-      if (fileData.name) {
-        id = fileData.name;
-        module = [filePath, H.PACKAGE];
-      }
-    } else if (!filePath.endsWith(JSON_EXTENSION)) {
-      if (hasteImpl) {
-        id = hasteImpl.getHasteName(filePath);
-      } else {
-        const doc = docblock.parse(docblock.extract(content));
-        id = doc.providesModule || doc.provides;
-      }
-      dependencies = extractRequires(content);
-      if (id) {
-        module = [filePath, H.MODULE];
-      }
+  if (filePath.endsWith(PACKAGE_JSON)) {
+    const fileData = JSON.parse(content);
+    if (fileData.name) {
+      id = fileData.name;
+      module = [filePath, H.PACKAGE];
     }
-
-    callback(null, {dependencies, id, module});
-  } catch (error) {
-    callback(formatError(error));
+  } else if (!filePath.endsWith(JSON_EXTENSION)) {
+    if (hasteImpl) {
+      id = hasteImpl.getHasteName(filePath);
+    } else {
+      const doc = docblock.parse(docblock.extract(content));
+      id = doc.providesModule || doc.provides;
+    }
+    dependencies = extractRequires(content);
+    if (id) {
+      module = [filePath, H.MODULE];
+    }
   }
-};
+
+  return {dependencies, id, module};
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3557,6 +3557,12 @@ jest-docblock@^20.0.1:
   version "20.0.3"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-20.0.3.tgz#17bea984342cc33d83c50fbe1545ea0efaa44712"
 
+jest-worker@^21.2.0:
+  version "21.3.0-beta.4"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-21.3.0-beta.4.tgz#be04b3cc77e8eecddeb9fba66a863d2ba1012f15"
+  dependencies:
+    merge-stream "^1.0.1"
+
 jquery@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.2.1.tgz#5c4d9de652af6cd0a770154a631bba12b015c787"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3557,12 +3557,6 @@ jest-docblock@^20.0.1:
   version "20.0.3"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-20.0.3.tgz#17bea984342cc33d83c50fbe1545ea0efaa44712"
 
-jest-worker@^21.2.0:
-  version "21.3.0-beta.4"
-  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-21.3.0-beta.4.tgz#be04b3cc77e8eecddeb9fba66a863d2ba1012f15"
-  dependencies:
-    merge-stream "^1.0.1"
-
 jquery@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.2.1.tgz#5c4d9de652af6cd0a770154a631bba12b015c787"


### PR DESCRIPTION
Move all the `jest-haste-map` logic from `worker-farm` to `jest-worker`. Tests also needed some updates (mostly because mocking is a bit different now).

The best thing is that Flow types can now be shared! So the parent file imports the type of the callback, and uses it for typing the interface that the worker exposes.

No more callbacks, no more `Promise` wrapping... feels good 😄 