### PR TITLE
Migrate jest-runner to jest-worker

### DIFF
--- a/packages/jest-runner/package.json
+++ b/packages/jest-runner/package.json
@@ -15,8 +15,7 @@
     "jest-message-util": "^21.2.1",
     "jest-runtime": "^21.2.1",
     "jest-util": "^21.2.1",
-    "pify": "^3.0.0",
-    "throat": "^4.0.0",
-    "worker-farm": "^1.5.1"
+    "jest-worker": "^21.2.1",
+    "throat": "^4.0.0"
   }
 }

--- a/packages/jest-runner/src/test_worker.js
+++ b/packages/jest-runner/src/test_worker.js
@@ -22,14 +22,12 @@ import {separateMessageFromStack} from 'jest-message-util';
 import Runtime from 'jest-runtime';
 import runTest from './run_test';
 
-type WorkerData = {|
+export type WorkerData = {|
   config: ProjectConfig,
   globalConfig: GlobalConfig,
   path: Path,
   rawModuleMap?: RawModuleMap,
 |};
-
-type WorkerCallback = (error: ?SerializableError, result?: TestResult) => void;
 
 const formatError = (error: string | Error): SerializableError => {
   if (typeof error === 'string') {
@@ -69,33 +67,20 @@ const getResolver = (config, rawModuleMap) => {
   }
 };
 
-// Cannot be ESM export because of worker-farm
-module.exports = (
-  {config, globalConfig, path, rawModuleMap}: WorkerData,
-  callback: WorkerCallback,
-) => {
-  let parentExited = false;
-  const disconnectCallback = () => (parentExited = true);
-  const removeListener = () =>
-    process.removeListener('disconnect', disconnectCallback);
-  process.on('disconnect', disconnectCallback);
-
+export async function worker({
+  config,
+  globalConfig,
+  path,
+  rawModuleMap,
+}: WorkerData): Promise<TestResult> {
   try {
-    runTest(path, globalConfig, config, getResolver(config, rawModuleMap)).then(
-      result => {
-        removeListener();
-        if (!parentExited) {
-          callback(null, result);
-        }
-      },
-      error => {
-        removeListener();
-        if (!parentExited) {
-          callback(formatError(error));
-        }
-      },
+    return await runTest(
+      path,
+      globalConfig,
+      config,
+      getResolver(config, rawModuleMap),
     );
   } catch (error) {
-    callback(formatError(error));
+    throw formatError(error);
   }
-};
+}

--- a/packages/jest-runner/src/test_worker.js
+++ b/packages/jest-runner/src/test_worker.js
@@ -26,7 +26,7 @@ export type WorkerData = {|
   config: ProjectConfig,
   globalConfig: GlobalConfig,
   path: Path,
-  rawModuleMap?: RawModuleMap,
+  rawModuleMap: ?RawModuleMap,
 |};
 
 const formatError = (error: string | Error): SerializableError => {


### PR DESCRIPTION
This PR migrates `jest-runner` to use `jest-worker`, instead of `worker-farm`. As a consequence of this, some additional changes were done:

* `pify` is not needed anymore as well.
*  Interfaces are now shared between parent and child processes, so we ensure they stay in sync.
* Tests needed small adjustments as well.