### PR TITLE
Migrate jest-cli to jest-worker

### DIFF
--- a/packages/jest-cli/package.json
+++ b/packages/jest-cli/package.json
@@ -24,15 +24,14 @@
     "jest-runtime": "^21.2.1",
     "jest-snapshot": "^21.2.1",
     "jest-util": "^21.2.1",
+    "jest-worker": "^21.2.1",
     "micromatch": "^2.3.11",
     "node-notifier": "^5.1.2",
-    "pify": "^3.0.0",
     "rimraf": "^2.5.4",
     "slash": "^1.0.0",
     "string-length": "^2.0.0",
     "strip-ansi": "^4.0.0",
     "which": "^1.2.12",
-    "worker-farm": "^1.5.1",
     "yargs": "^9.0.0"
   },
   "bin": {

--- a/packages/jest-cli/src/generate_empty_coverage.js
+++ b/packages/jest-cli/src/generate_empty_coverage.js
@@ -12,12 +12,17 @@ import type {GlobalConfig, ProjectConfig, Path} from 'types/Config';
 import {createInstrumenter} from 'istanbul-lib-instrument';
 import Runtime from 'jest-runtime';
 
+export type CoverageWorkerResult = {|
+  coverage: any,
+  sourceMapPath: ?string,
+|};
+
 export default function(
   source: string,
   filename: Path,
   globalConfig: GlobalConfig,
   config: ProjectConfig,
-) {
+): ?CoverageWorkerResult {
   const coverageOptions = {
     collectCoverage: globalConfig.collectCoverage,
     collectCoverageFrom: globalConfig.collectCoverageFrom,

--- a/packages/jest-cli/src/reporters/__tests__/coverage_worker.test.js
+++ b/packages/jest-cli/src/reporters/__tests__/coverage_worker.test.js
@@ -52,13 +52,10 @@ test('throws errors on invalid JavaScript', async () => {
     throw new Error('SyntaxError');
   });
 
-  let error = null;
-
+  // We intentionally expect the worker to fail!
   try {
     await worker(workerOptions);
-  } catch (err) {
-    error = err;
+  } catch (error) {
+    expect(error).toBeInstanceOf(Error);
   }
-
-  expect(error).toBeInstanceOf(Error);
 });

--- a/packages/jest-cli/src/reporters/__tests__/coverage_worker.test.js
+++ b/packages/jest-cli/src/reporters/__tests__/coverage_worker.test.js
@@ -22,49 +22,43 @@ beforeEach(() => {
 
   fs = require('fs');
   generateEmptyCoverage = require('../../generate_empty_coverage').default;
-  worker = require('../coverage_worker');
+  worker = require('../coverage_worker').worker;
 });
 
-test('resolves to the result of generateEmptyCoverage upon success', () => {
+test('resolves to the result of generateEmptyCoverage upon success', async () => {
   expect.assertions(2);
+
   const validJS = 'function(){}';
+
   fs.readFileSync.mockImplementation(() => validJS);
   generateEmptyCoverage.mockImplementation(() => 42);
-  return new Promise((resolve, reject) => {
-    worker(workerOptions, (error, result) => {
-      if (error) {
-        reject(error);
-        return;
-      }
-      expect(generateEmptyCoverage).toBeCalledWith(
-        validJS,
-        'banana.js',
-        globalConfig,
-        config,
-      );
-      expect(result).toEqual(42);
-      resolve();
-    });
-  });
+
+  const result = await worker(workerOptions);
+
+  expect(generateEmptyCoverage).toBeCalledWith(
+    validJS,
+    'banana.js',
+    globalConfig,
+    config,
+  );
+
+  expect(result).toEqual(42);
 });
 
-test('throws errors on invalid JavaScript', () => {
-  expect.assertions(2);
+test('throws errors on invalid JavaScript', async () => {
+  expect.assertions(1);
+
   generateEmptyCoverage.mockImplementation(() => {
     throw new Error('SyntaxError');
   });
-  return new Promise((resolve, reject) => {
-    worker(workerOptions, (error, result) => {
-      if (!error) {
-        reject(result);
-        return;
-      }
 
-      expect(error.message).toMatch(
-        'Failed to collect coverage from banana.js',
-      );
-      expect(result).toEqual(undefined);
-      resolve();
-    });
-  });
+  let error = null;
+
+  try {
+    await worker(workerOptions);
+  } catch (err) {
+    error = err;
+  }
+
+  expect(error).toBeInstanceOf(Error);
 });

--- a/packages/jest-cli/src/reporters/coverage_worker.js
+++ b/packages/jest-cli/src/reporters/coverage_worker.js
@@ -27,11 +27,11 @@ process.on('uncaughtException', err => {
   process.exit(1);
 });
 
-export async function worker({
+export function worker({
   config,
   globalConfig,
   path,
-}: CoverageWorkerData): Promise<?CoverageWorkerResult> {
+}: CoverageWorkerData): ?CoverageWorkerResult {
   return generateEmptyCoverage(
     fs.readFileSync(path, 'utf8'),
     path,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4732,10 +4732,6 @@ pify@^2.0.0, pify@^2.2.0, pify@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
 
-pify@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
-
 pinkie-promise@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz#2135d6dfa7a358c069ac9b178776288228450ffa"


### PR DESCRIPTION
This PR migrates `jest-cli` to use `jest-worker`, instead of `worker-farm`. As a consequence of this, some additional changes were done:

* `pify` is not needed anymore as well.
*  Interfaces are now shared between parent and child processes, so we ensure they stay in sync.
* Tests needed small adjustments as well.

Although it increases the scope of the diff, I found convenient to migrate `_addUntestedFiles`, from a `Promise`-based approach to an `async`/`await` approach. The reasoning behind it is that I also moved the logic for printing the error from the worker to the parent and simplified it.