### PR TITLE
[jest-docblock] pragmas should preserve urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## master
 
 ### Fixes
+* `[jest-docblock]` pragmas should preserve urls ([#4837](https://github.com/facebook/jest/pull/4629))
 * `[jest-cli]` Check if `npm_lifecycle_script` calls Jest directly ([#4629](https://github.com/facebook/jest/pull/4629))
 * `[jest-cli]` Fix --showConfig to show all configs ([#4494](https://github.com/facebook/jest/pull/4494))
 * `[jest-cli]` Throw if `maxWorkers` doesn't have a value ([#4591](https://github.com/facebook/jest/pull/4591))

--- a/packages/jest-docblock/src/__tests__/index.test.js
+++ b/packages/jest-docblock/src/__tests__/index.test.js
@@ -288,12 +288,12 @@ describe('docblock', () => {
     });
   });
 
-  it('preserves pragmas containing urls', () => {
+  it("preserves urls within a pragma's values", () => {
     const code =
-      '/**' + os.EOL + ' * @see: https://examples-for-chickens.com */';
+      '/**' + os.EOL + ' * @see: https://example.com' + os.EOL + ' */';
     expect(docblock.parseWithComments(code)).toEqual({
       comments: '',
-      pragmas: {'see:': 'https://examples-for-chickens.com'},
+      pragmas: {'see:': 'https://example.com'},
     });
   });
 

--- a/packages/jest-docblock/src/__tests__/index.test.js
+++ b/packages/jest-docblock/src/__tests__/index.test.js
@@ -162,8 +162,9 @@ describe('docblock', () => {
       os.EOL +
       '' +
       ' */';
-    expect(docblock.parse(code)).toEqual({
-      providesModule: 'foo',
+    expect(docblock.parseWithComments(code)).toEqual({
+      comments: '// TODO: test',
+      pragmas: {providesModule: 'foo'},
     });
   });
 
@@ -196,6 +197,48 @@ describe('docblock', () => {
         'A long declaration of a class goes here, ' +
         'so we can read it and enjoy',
       'preserve-whitespace': '',
+    });
+  });
+
+  it('parses multiline directives even if there are linecomments within the docblock', () => {
+    const code =
+      '/**' +
+      os.EOL +
+      '' +
+      ' * Copyright 2004-present Facebook. All Rights Reserved.' +
+      os.EOL +
+      '' +
+      ' * @class A long declaration of a class' +
+      os.EOL +
+      '' +
+      ' *        goes here, so we can read it and enjoy' +
+      os.EOL +
+      '' +
+      ' *' +
+      os.EOL +
+      '' +
+      ' * And some license here' +
+      os.EOL +
+      '' +
+      ' * @preserve-whitespace' +
+      os.EOL +
+      '' +
+      '// heres a comment' +
+      ' */';
+    expect(docblock.parseWithComments(code)).toEqual({
+      comments:
+        'Copyright 2004-present Facebook. All Rights Reserved.' +
+        os.EOL +
+        os.EOL +
+        'And some license here' +
+        os.EOL +
+        '// heres a comment',
+      pragmas: {
+        class:
+          'A long declaration of a class goes here, ' +
+          'so we can read it and enjoy',
+        'preserve-whitespace': '',
+      },
     });
   });
 

--- a/packages/jest-docblock/src/__tests__/index.test.js
+++ b/packages/jest-docblock/src/__tests__/index.test.js
@@ -157,10 +157,8 @@ describe('docblock', () => {
       '' +
       ' * @providesModule foo' +
       os.EOL +
-      '' +
       ' * // TODO: test' +
       os.EOL +
-      '' +
       ' */';
     expect(docblock.parse(code)).toEqual({
       providesModule: 'foo',
@@ -288,12 +286,21 @@ describe('docblock', () => {
     });
   });
 
-  it("preserves urls within a pragma's values", () => {
+  it("preserve urls within a pragma's values", () => {
     const code =
       '/**' + os.EOL + ' * @see: https://example.com' + os.EOL + ' */';
     expect(docblock.parseWithComments(code)).toEqual({
       comments: '',
       pragmas: {'see:': 'https://example.com'},
+    });
+  });
+
+  it('strip linecomments from pragmas but preserve for comments', () => {
+    const code =
+      '/**' + os.EOL + ' * @format: everything' + os.EOL + '// keep me' + ' */';
+    expect(docblock.parseWithComments(code)).toEqual({
+      comments: '// keep me',
+      pragmas: {'format:': 'everything'},
     });
   });
 

--- a/packages/jest-docblock/src/__tests__/index.test.js
+++ b/packages/jest-docblock/src/__tests__/index.test.js
@@ -288,6 +288,15 @@ describe('docblock', () => {
     });
   });
 
+  it('preserves pragmas containing urls', () => {
+    const code =
+      '/**' + os.EOL + ' * @see: https://examples-for-chickens.com */';
+    expect(docblock.parseWithComments(code)).toEqual({
+      comments: '',
+      pragmas: {'see:': 'https://examples-for-chickens.com'},
+    });
+  });
+
   it('extracts docblock comments as CRLF when docblock contains CRLF', () => {
     const code = '/**\r\n * foo\r\n * bar\r\n*/';
     expect(docblock.parseWithComments(code)).toEqual({

--- a/packages/jest-docblock/src/__tests__/index.test.js
+++ b/packages/jest-docblock/src/__tests__/index.test.js
@@ -157,8 +157,10 @@ describe('docblock', () => {
       '' +
       ' * @providesModule foo' +
       os.EOL +
+      '' +
       ' * // TODO: test' +
       os.EOL +
+      '' +
       ' */';
     expect(docblock.parse(code)).toEqual({
       providesModule: 'foo',

--- a/packages/jest-docblock/src/index.js
+++ b/packages/jest-docblock/src/index.js
@@ -17,7 +17,7 @@ const lineCommentRe = /(^|\s+)\/\/([^\r\n]*)/g;
 const ltrimRe = /^\s*/;
 const rtrimRe = /\s*$/;
 const ltrimNewlineRe = /^(\r?\n)+/;
-const multilineRe = /(?:^|\r?\n) *(@[^\r\n]*?) *\r?\n *(?![^@\r\n]*\/\/[^]*)([^@\r\n\s][^@\r\n]+?) *\r?\n/;
+const multilineRe = /(?:^|\r?\n) *(@[^\r\n]*?) *\r?\n *(?![^@\r\n]*\/\/[^]*)([^@\r\n\s][^@\r\n]+?) *\r?\n/g;
 const propertyRe = /(?:^|\r?\n) *@(\S+) *([^\r\n]*)/g;
 const stringStartRe = /(\r?\n|^) *\* ?/g;
 

--- a/packages/jest-docblock/src/index.js
+++ b/packages/jest-docblock/src/index.js
@@ -13,7 +13,7 @@ import {EOL} from 'os';
 const commentEndRe = /\*\/$/;
 const commentStartRe = /^\/\*\*/;
 const docblockRe = /^\s*(\/\*\*?(.|\r?\n)*?\*\/)/;
-const lineCommentRe = /\/\/([^\r\n]*)/g;
+const lineCommentRe = /(^|\s+)\/\/([^\r\n]*)/g;
 const ltrimRe = /^\s*/;
 const rtrimRe = /\s*$/;
 const ltrimNewlineRe = /^(\r?\n)+/;
@@ -45,7 +45,6 @@ export function parseWithComments(
   docblock = docblock
     .replace(commentStartRe, '')
     .replace(commentEndRe, '')
-    .replace(lineCommentRe, '')
     .replace(stringStartRe, '$1');
 
   // Normalize multi-line directives
@@ -64,7 +63,8 @@ export function parseWithComments(
 
   let match;
   while ((match = propertyRe.exec(docblock))) {
-    result[match[1]] = match[2];
+    // strip linecomments from pragmas
+    result[match[1]] = match[2].replace(lineCommentRe, '');
   }
   return {comments, pragmas: result};
 }

--- a/packages/jest-docblock/src/index.js
+++ b/packages/jest-docblock/src/index.js
@@ -17,7 +17,7 @@ const lineCommentRe = /(^|\s+)\/\/([^\r\n]*)/g;
 const ltrimRe = /^\s*/;
 const rtrimRe = /\s*$/;
 const ltrimNewlineRe = /^(\r?\n)+/;
-const multilineRe = /(?:^|\r?\n) *(@[^\r\n]*?) *\r?\n *([^@\r\n\s][^@\r\n]+?) *\r?\n/g;
+const multilineRe = /(?:^|\r?\n) *(@[^\r\n]*?) *\r?\n *(?![^@\r\n]*\/\/[^]*)([^@\r\n\s][^@\r\n]+?) *\r?\n/;
 const propertyRe = /(?:^|\r?\n) *@(\S+) *([^\r\n]*)/g;
 const stringStartRe = /(\r?\n|^) *\* ?/g;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2208,7 +2208,7 @@ enzyme@^2.8.2:
     prop-types "^15.5.10"
     uuid "^3.0.1"
 
-errno@^0.1.1, errno@^0.1.4, errno@~0.1.1:
+errno@^0.1.1, errno@~0.1.1:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.4.tgz#b896e23a9e5e8ba33871fc996abd3635fc9a1c7d"
   dependencies:
@@ -6177,13 +6177,6 @@ wordwrap@~0.0.2:
 wordwrap@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
-
-worker-farm@^1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/worker-farm/-/worker-farm-1.5.1.tgz#8e9f4a7da4f3c595aa600903051b969390423fa1"
-  dependencies:
-    errno "^0.1.4"
-    xtend "^4.0.1"
 
 wrap-ansi@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
**summary**
I recently [discovered](https://github.com/Automattic/wp-calypso/pull/18726/files#r144200619) that the `parseWithComments` function is stripping away links from pragmas.  I've created a failing test case to illustrate the issue.

Is this intentional?
If not I can update the pull-request with a fix

---

Example In:
```js
/**
 * @see: https://example.com
 */
```
Example Out:
```js
/**
 * @see:
 */
```