### PR TITLE
Add availability note for advanceTimersByTime

### DIFF
--- a/docs/TimerMocks.md
+++ b/docs/TimerMocks.md
@@ -128,6 +128,7 @@ describe('infiniteTimerGame', () => {
 ```
 
 ## Advance Timers by Time
+##### renamed from `runTimersToTime` to `advanceTimersByTime` in Jest **21.3.0**
 
 Another possibility is use `jest.advanceTimersByTime(msToRun)`. When this API is called, all timers are advanced by `msToRun` milliseconds. All pending "macro-tasks" that have been queued via setTimeout() or setInterval(), and would be executed during this timeframe, will be executed. Additionally if those macro-tasks schedule new macro-tasks that would be executed within the same time frame, those will be executed until there are no more macro-tasks remaining in the queue that should be run within msToRun milliseconds.
 


### PR DESCRIPTION
**Summary**
`runTimersToTime` was renamed to `advanceTimersByTime` in 21.3.0. This updates the docs to show the functionality exists in previous versions.

