### PR TITLE
Add the same version of 'react-test-renderer' as 'react'

### DIFF
--- a/examples/snapshot/package.json
+++ b/examples/snapshot/package.json
@@ -7,7 +7,7 @@
     "babel-preset-env": "*",
     "babel-preset-react": "*",
     "jest": "*",
-    "react-test-renderer": "*",
+    "react-test-renderer": "15.4.2",
     "regenerator-runtime": "*"
   },
   "scripts": {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->
<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
This **PR** is related to `facebook/jest/examples/snapshot`.
When there is default `"react-test-renderer": "*",` in `package,json` testing is brocken:

![image](https://user-images.githubusercontent.com/8372070/32569434-67d39ba0-c4c1-11e7-8784-4cc403e6b08f.png)

Installing the same version of `react-test-renderer` as `react` (_15.4.2_) solved this problem.

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Installed exact version:
![image](https://user-images.githubusercontent.com/8372070/32569599-d99f14a8-c4c1-11e7-8b02-0b9d1bf8ead3.png)

Testing is working:
![image](https://user-images.githubusercontent.com/8372070/32569633-ec1f7636-c4c1-11e7-8cc5-541ea1446f04.png)
