### PR TITLE
Initial version of jest-leak-detector

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,8 @@ jobs:
     steps:
       - checkout
       - restore-cache: *restore-cache
+      - run: |
+          apt-get update && apt-get install make g++ -y
       - *yarn-install-no-sudo
       - save-cache: *save-cache
       - run: yarn run test-ci-es5-build-in-browser

--- a/packages/jest-leak-detector/.npmignore
+++ b/packages/jest-leak-detector/.npmignore
@@ -1,0 +1,4 @@
+**/__mocks__/**
+**/__tests__/**
+**/__performance_tests__/**
+src

--- a/packages/jest-leak-detector/.npmignore
+++ b/packages/jest-leak-detector/.npmignore
@@ -1,4 +1,3 @@
 **/__mocks__/**
 **/__tests__/**
-**/__performance_tests__/**
 src

--- a/packages/jest-leak-detector/README.md
+++ b/packages/jest-leak-detector/README.md
@@ -1,0 +1,22 @@
+# jest-leak-detector
+
+Module for verifying whether an object has been garbage collected or not.
+
+Internally creates a weak reference to the object, and forces garbage collection to happen. If the reference is gone, it meant no one else was pointing to the object.
+
+## Example
+
+```javascript
+let reference = {};
+
+const detector = new LeakDetector(reference);
+
+// Reference is held in memory.
+console.log(detector.isLeaked()); // true
+
+// We destroy the only reference to the object.
+reference = null;
+
+// Reference is gone.
+console.log(detector.isLeaked()); // false
+```

--- a/packages/jest-leak-detector/package.json
+++ b/packages/jest-leak-detector/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "jest-leak-detector",
+  "version": "21.2.1",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/facebook/jest.git"
+  },
+  "license": "MIT",
+  "main": "build/index.js",
+  "dependencies": {
+    "weak": "^1.0.1"
+  }
+}

--- a/packages/jest-leak-detector/package.json
+++ b/packages/jest-leak-detector/package.json
@@ -8,6 +8,7 @@
   "license": "MIT",
   "main": "build/index.js",
   "dependencies": {
+    "pretty-format": "^21.2.1",
     "weak": "^1.0.1"
   }
 }

--- a/packages/jest-leak-detector/src/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/jest-leak-detector/src/__tests__/__snapshots__/index.test.js.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`complains if the value is a primitive 1`] = `"Primitives cannot leak memory. You passed a undefined: <undefined>"`;
+
+exports[`complains if the value is a primitive 2`] = `"Primitives cannot leak memory. You passed a object: <null>"`;
+
+exports[`complains if the value is a primitive 3`] = `"Primitives cannot leak memory. You passed a boolean: <false>"`;
+
+exports[`complains if the value is a primitive 4`] = `"Primitives cannot leak memory. You passed a number: <42>"`;
+
+exports[`complains if the value is a primitive 5`] = `"Primitives cannot leak memory. You passed a string: <\\"foo\\">"`;

--- a/packages/jest-leak-detector/src/__tests__/index.test.js
+++ b/packages/jest-leak-detector/src/__tests__/index.test.js
@@ -22,7 +22,7 @@ it('does not show the GC if hidden', () => {
   const detector = new LeakDetector({});
 
   global.gc = undefined;
-  detector.isLeaked();
+  detector.isLeaking();
   expect(global.gc).not.toBeDefined();
 });
 
@@ -30,7 +30,7 @@ it('does not hide the GC if visible', () => {
   const detector = new LeakDetector({});
 
   global.gc = () => {};
-  detector.isLeaked();
+  detector.isLeaking();
   expect(global.gc).toBeDefined();
 });
 
@@ -40,13 +40,13 @@ it('correctly checks simple leaks', () => {
   const detector = new LeakDetector(reference);
 
   // Reference is still held in memory.
-  expect(detector.isLeaked()).toBe(true);
+  expect(detector.isLeaking()).toBe(true);
 
   // We destroy the only reference to the object we had.
   reference = null;
 
   // Reference should be gone.
-  expect(detector.isLeaked()).toBe(false);
+  expect(detector.isLeaking()).toBe(false);
 });
 
 it('tests different objects', () => {
@@ -61,9 +61,9 @@ it('tests different objects', () => {
 
   const detectors = refs.map(ref => new LeakDetector(ref));
 
-  detectors.forEach(detector => expect(detector.isLeaked()).toBe(true));
+  detectors.forEach(detector => expect(detector.isLeaking()).toBe(true));
   refs.forEach((_, i) => (refs[i] = null));
-  detectors.forEach(detector => expect(detector.isLeaked()).toBe(false));
+  detectors.forEach(detector => expect(detector.isLeaking()).toBe(false));
 });
 
 it('correctly checks more complex leaks', () => {
@@ -78,20 +78,20 @@ it('correctly checks more complex leaks', () => {
   const detector2 = new LeakDetector(ref2);
 
   // References are still held in memory.
-  expect(detector1.isLeaked()).toBe(true);
-  expect(detector2.isLeaked()).toBe(true);
+  expect(detector1.isLeaking()).toBe(true);
+  expect(detector2.isLeaking()).toBe(true);
 
   // We destroy the reference to ref1.
   ref1 = null;
 
   // It will still be referenced by ref2, so both references are still leaking.
-  expect(detector1.isLeaked()).toBe(true);
-  expect(detector2.isLeaked()).toBe(true);
+  expect(detector1.isLeaking()).toBe(true);
+  expect(detector2.isLeaking()).toBe(true);
 
   // We destroy the reference to ref2.
   ref2 = null;
 
   // Now both references should be gone (yay mark & sweep!).
-  expect(detector1.isLeaked()).toBe(false);
-  expect(detector2.isLeaked()).toBe(false);
+  expect(detector1.isLeaking()).toBe(false);
+  expect(detector2.isLeaking()).toBe(false);
 });

--- a/packages/jest-leak-detector/src/__tests__/index.test.js
+++ b/packages/jest-leak-detector/src/__tests__/index.test.js
@@ -1,0 +1,73 @@
+'use strict';
+
+import LeakDetector from '../index';
+
+it('complains if the value is a primitive', () => {
+  expect(() => new LeakDetector(undefined)).toThrow(TypeError);
+  expect(() => new LeakDetector(null)).toThrow(TypeError);
+  expect(() => new LeakDetector(false)).toThrow(TypeError);
+  expect(() => new LeakDetector(42)).toThrow(TypeError);
+  expect(() => new LeakDetector('foo')).toThrow(TypeError);
+});
+
+it('correctly checks simple leaks', () => {
+  let reference = {};
+
+  const detector = new LeakDetector(reference);
+
+  // Reference is still held in memory.
+  expect(detector.isLeaked()).toBe(true);
+
+  // We destroy the only reference to the object we had.
+  reference = null;
+
+  // Reference should be gone.
+  expect(detector.isLeaked()).toBe(false);
+});
+
+it('tests different objects', () => {
+  const refs = [
+    function() {},
+    () => {},
+    Object.create(null),
+    [],
+    /foo/g,
+    new Date(1234),
+  ];
+
+  const detectors = refs.map(ref => new LeakDetector(ref));
+
+  detectors.forEach(detector => expect(detector.isLeaked()).toBe(true));
+  refs.forEach((_, i) => (refs[i] = null));
+  detectors.forEach(detector => expect(detector.isLeaked()).toBe(false));
+});
+
+it('correctly checks more complex leaks', () => {
+  let ref1 = {};
+  let ref2 = {};
+
+  // Create a circular dependency between ref1 and ref2.
+  ref1.ref2 = ref2;
+  ref2.ref1 = ref1;
+
+  const detector1 = new LeakDetector(ref1);
+  const detector2 = new LeakDetector(ref2);
+
+  // References are still held in memory.
+  expect(detector1.isLeaked()).toBe(true);
+  expect(detector2.isLeaked()).toBe(true);
+
+  // We destroy the reference to ref1.
+  ref1 = null;
+
+  // It will still be referenced by ref2, so both references are still leaking.
+  expect(detector1.isLeaked()).toBe(true);
+  expect(detector2.isLeaked()).toBe(true);
+
+  // We destroy the reference to ref2.
+  ref2 = null;
+
+  // Now both references should be gone (yay mark & sweep!).
+  expect(detector1.isLeaked()).toBe(false);
+  expect(detector2.isLeaked()).toBe(false);
+});

--- a/packages/jest-leak-detector/src/__tests__/index.test.js
+++ b/packages/jest-leak-detector/src/__tests__/index.test.js
@@ -2,12 +2,36 @@
 
 import LeakDetector from '../index';
 
+const gc = global.gc;
+
+// Some tests override the "gc" value. Let's make sure we roll it back to its
+// previous value after executing the test.
+afterEach(() => {
+  global.gc = gc;
+});
+
 it('complains if the value is a primitive', () => {
-  expect(() => new LeakDetector(undefined)).toThrow(TypeError);
-  expect(() => new LeakDetector(null)).toThrow(TypeError);
-  expect(() => new LeakDetector(false)).toThrow(TypeError);
-  expect(() => new LeakDetector(42)).toThrow(TypeError);
-  expect(() => new LeakDetector('foo')).toThrow(TypeError);
+  expect(() => new LeakDetector(undefined)).toThrowErrorMatchingSnapshot();
+  expect(() => new LeakDetector(null)).toThrowErrorMatchingSnapshot();
+  expect(() => new LeakDetector(false)).toThrowErrorMatchingSnapshot();
+  expect(() => new LeakDetector(42)).toThrowErrorMatchingSnapshot();
+  expect(() => new LeakDetector('foo')).toThrowErrorMatchingSnapshot();
+});
+
+it('does not show the GC if hidden', () => {
+  const detector = new LeakDetector({});
+
+  global.gc = undefined;
+  detector.isLeaked();
+  expect(global.gc).not.toBeDefined();
+});
+
+it('does not hide the GC if visible', () => {
+  const detector = new LeakDetector({});
+
+  global.gc = () => {};
+  detector.isLeaked();
+  expect(global.gc).toBeDefined();
 });
 
 it('correctly checks simple leaks', () => {

--- a/packages/jest-leak-detector/src/index.js
+++ b/packages/jest-leak-detector/src/index.js
@@ -42,7 +42,7 @@ export default class {
     value = null;
   }
 
-  isLeaked(): boolean {
+  isLeaking(): boolean {
     this._runGarbageCollector();
 
     return this._isReferenceBeingHeld;

--- a/packages/jest-leak-detector/src/index.js
+++ b/packages/jest-leak-detector/src/index.js
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+'use strict';
+
+const v8 = require('v8');
+const vm = require('vm');
+const weak = require('weak');
+
+// Setting the flag has no effect on the main context, but will allow new
+// contexts to access the garbage collector.
+v8.setFlagsFromString('--expose-gc');
+const gc = vm.runInNewContext('gc');
+
+const PRIMITIVE_TYPES = new Set([
+  'undefined',
+  'boolean',
+  'number',
+  'string',
+  'symbol',
+]);
+
+export default class {
+  _held: boolean;
+
+  constructor(value: ?Object) {
+    if (this._isPrimitive(value)) {
+      throw new TypeError('Primitives cannot leak memory');
+    }
+
+    weak(value, () => (this._held = false));
+    this._held = true;
+
+    // Ensure value is not leaked by the closure created by the "weak" callback.
+    value = null;
+  }
+
+  isLeaked(): boolean {
+    gc();
+
+    return this._held;
+  }
+
+  _isPrimitive(value: any): boolean {
+    return value === null || PRIMITIVE_TYPES.has(typeof value);
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -992,6 +992,10 @@ binary-extensions@^1.0.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.10.0.tgz#9aeb9a6c5e88638aad171e167f5900abe24835d0"
 
+bindings@^1.2.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.3.0.tgz#b346f6ecf6a95f5a815c5839fc7cdb22502f1ed7"
+
 bl@~0.8.1:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/bl/-/bl-0.8.2.tgz#c9b6bca08d1bc2ea00fc8afb4f1a5fd1e1c66e4e"
@@ -4305,7 +4309,7 @@ mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
 
-nan@^2.3.0:
+nan@^2.0.5, nan@^2.3.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.7.0.tgz#d95bf721ec877e08db276ed3fc6eb78f9083ad46"
 
@@ -6123,6 +6127,13 @@ wcwidth@^1.0.0:
   resolved "https://registry.yarnpkg.com/wcwidth/-/wcwidth-1.0.1.tgz#f0b0dcf915bc5ff1528afadb2c0e17b532da2fe8"
   dependencies:
     defaults "^1.0.3"
+
+weak@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/weak/-/weak-1.0.1.tgz#ab99aab30706959aa0200cb8cf545bb9cb33b99e"
+  dependencies:
+    bindings "^1.2.1"
+    nan "^2.0.5"
 
 webidl-conversions@^4.0.0, webidl-conversions@^4.0.1:
   version "4.0.2"


### PR DESCRIPTION
This PR introduces a new module, `jest-leak-detector` intended to verify that an object is garbage collectable after a set of operations. Its usage is done by creating a `LeakDetector` instance with the object we want to test; and later calling `LeakDetector.isLeaked()`, which will return a boolean indicating if the object has still references.

This is a second evolution of #4873, where we use `weak` to create the weak reference instead of using a `WeakSet`, which was a hack. Thanks to @arcanis for the suggestion!