### PR TITLE
 fix .toThrow for promises

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Fixes
 
+* `[expect]` fix .toThrow for promises
+  ([#4884](https://github.com/facebook/jest/pull/4884))
 * `[jest-docblock]` pragmas should preserve urls
   ([#4837](https://github.com/facebook/jest/pull/4629))
 * `[jest-cli]` Check if `npm_lifecycle_script` calls Jest directly

--- a/docs/ExpectAPI.md
+++ b/docs/ExpectAPI.md
@@ -416,7 +416,7 @@ For example, this code tests that the promise rejects with reason `'octopus'`:
 ```js
 test('rejects to octopus', () => {
   // make sure to add a return statement
-  return expect(Promise.reject('octopus')).rejects.toBe('octopus');
+  return expect(Promise.reject(new Error('octopus'))).rejects.toThrow('octopus');
 });
 ```
 
@@ -424,7 +424,7 @@ Alternatively, you can use `async/await` in combination with `.rejects`.
 
 ```js
 test('rejects to octopus', async () => {
-  await expect(Promise.reject('octopus')).rejects.toBe('octopus');
+  await expect(Promise.reject(new Error('octopus'))).rejects.toThrow('octopus');
 });
 ```
 

--- a/packages/expect/src/__tests__/matchers.test.js
+++ b/packages/expect/src/__tests__/matchers.test.js
@@ -27,11 +27,14 @@ describe('.rejects', () => {
     await jestExpect(Promise.reject({a: 1, b: 2})).rejects.not.toMatchObject({
       c: 1,
     });
-    await jestExpect(
-      Promise.reject(() => {
-        throw new Error();
-      }),
-    ).rejects.toThrow();
+    await jestExpect(Promise.reject(new Error())).rejects.toThrow();
+  });
+
+  it('should reject with toThrow', async () => {
+    async function fn() {
+      throw new Error('some error');
+    }
+    await jestExpect(fn()).rejects.toThrow('some error');
   });
 
   [4, [1], {a: 1}, 'a', true, null, undefined, () => {}].forEach(value => {

--- a/packages/expect/src/index.js
+++ b/packages/expect/src/index.js
@@ -51,6 +51,13 @@ const isPromise = obj => {
   );
 };
 
+const getPromiseMatcher = name => {
+  if (name === 'toThrow' || name === 'toThrowError') {
+    return 'toThrowFromPromise';
+  }
+  return name;
+};
+
 const expect = (actual: any, ...rest): ExpectationObject => {
   if (rest.length !== 0) {
     throw new Error('Expect takes at most one argument.');
@@ -64,7 +71,12 @@ const expect = (actual: any, ...rest): ExpectationObject => {
   };
 
   Object.keys(allMatchers).forEach(name => {
-    expectation[name] = makeThrowingMatcher(allMatchers[name], false, actual);
+    const targetName = getPromiseMatcher(name);
+    expectation[name] = makeThrowingMatcher(
+      allMatchers[targetName],
+      false,
+      actual,
+    );
     expectation.not[name] = makeThrowingMatcher(
       allMatchers[name],
       true,
@@ -73,26 +85,26 @@ const expect = (actual: any, ...rest): ExpectationObject => {
 
     expectation.resolves[name] = makeResolveMatcher(
       name,
-      allMatchers[name],
+      allMatchers[targetName],
       false,
       actual,
     );
     expectation.resolves.not[name] = makeResolveMatcher(
       name,
-      allMatchers[name],
+      allMatchers[targetName],
       true,
       actual,
     );
 
     expectation.rejects[name] = makeRejectMatcher(
       name,
-      allMatchers[name],
+      allMatchers[targetName],
       false,
       actual,
     );
     expectation.rejects.not[name] = makeRejectMatcher(
       name,
-      allMatchers[name],
+      allMatchers[targetName],
       true,
       actual,
     );

--- a/packages/expect/src/to_throw_matchers.js
+++ b/packages/expect/src/to_throw_matchers.js
@@ -21,7 +21,7 @@ import {
 } from 'jest-matcher-utils';
 import {equals} from './jasmine_utils';
 
-export const createMatcher = (matcherName, fromPromise) => (
+export const createMatcher = (matcherName: string, fromPromise?: boolean) => (
   actual: Function,
   expected: string | Error | RegExp,
 ) => {

--- a/packages/expect/src/to_throw_matchers.js
+++ b/packages/expect/src/to_throw_matchers.js
@@ -21,26 +21,29 @@ import {
 } from 'jest-matcher-utils';
 import {equals} from './jasmine_utils';
 
-const createMatcher = matcherName => (
+const createMatcher = (matcherName, fromPromise) => (
   actual: Function,
   expected: string | Error | RegExp,
 ) => {
   const value = expected;
   let error;
 
-  if (typeof actual !== 'function') {
-    throw new Error(
-      matcherHint(matcherName, 'function', getType(value)) +
-        '\n\n' +
-        'Received value must be a function, but instead ' +
-        `"${getType(actual)}" was found`,
-    );
-  }
-
-  try {
-    actual();
-  } catch (e) {
-    error = e;
+  if (fromPromise) {
+    error = actual;
+  } else {
+    if (typeof actual !== 'function') {
+      throw new Error(
+        matcherHint(matcherName, 'function', getType(value)) +
+          '\n\n' +
+          'Received value must be a function, but instead ' +
+          `"${getType(actual)}" was found`,
+      );
+    }
+    try {
+      actual();
+    } catch (e) {
+      error = e;
+    }
   }
 
   if (typeof expected === 'string') {
@@ -85,6 +88,7 @@ const createMatcher = matcherName => (
 const matchers: MatchersObject = {
   toThrow: createMatcher('.toThrow'),
   toThrowError: createMatcher('.toThrowError'),
+  toThrowFromPromise: createMatcher('.toThrowFromPromise', true),
 };
 
 const toThrowMatchingStringOrRegexp = (

--- a/packages/expect/src/to_throw_matchers.js
+++ b/packages/expect/src/to_throw_matchers.js
@@ -21,7 +21,7 @@ import {
 } from 'jest-matcher-utils';
 import {equals} from './jasmine_utils';
 
-const createMatcher = (matcherName, fromPromise) => (
+export const createMatcher = (matcherName, fromPromise) => (
   actual: Function,
   expected: string | Error | RegExp,
 ) => {
@@ -88,7 +88,6 @@ const createMatcher = (matcherName, fromPromise) => (
 const matchers: MatchersObject = {
   toThrow: createMatcher('.toThrow'),
   toThrowError: createMatcher('.toThrowError'),
-  toThrowFromPromise: createMatcher('.toThrowFromPromise', true),
 };
 
 const toThrowMatchingStringOrRegexp = (


### PR DESCRIPTION
fixes #3601

From docs
```js
return expect(Promise.reject('octopus')).rejects.toBe('octopus');
```
In real app, an `Error` object must be rejected.  
Fixed to
```js
return expect(Promise.reject(new Error('octopus'))).rejects.toThrow('octopus');
```