### PR TITLE
Add combined coverage threshold for directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@
 
 ### Features
 
+* `[jest-cli]` Add combined coverage threshold for directories.
+  ([#4885](https://github.com/facebook/jest/pull/4885))
 * `[jest-mock]` Add `timestamps` to mock state.
   ([#4866](https://github.com/facebook/jest/pull/4866))
 * `[eslint-plugin-jest]` Add `prefer-to-have-length` lint rule.

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -165,20 +165,37 @@ _Note: Setting this option overwrites the default values. Add `"text"` or
 Default: `undefined`
 
 This will be used to configure minimum threshold enforcement for coverage
-results. If the thresholds are not met, jest will return failure. Thresholds,
-when specified as a positive number are taken to be the minimum percentage
-required. When a threshold is specified as a negative number it represents the
-maximum number of uncovered entities allowed. Thresholds can be specified as
-`global`, as `glob` paths or just paths. If globs or paths are specified
-alongside `global`, coverage data for matching paths will be subtracted from
-overall coverage and thresholds will be applied independently. Threshold for
-globs is applied to all files matching the glob. If the file specified by path
-is not found, error is returned.
+results. Thresholds can be specified as `global`, as
+a [glob](https://github.com/isaacs/node-glob#glob-primer), and as a directory or
+file path. If thresholds aren't met, jest will fail. Thresholds specified as a
+positive number are taken to be the minimum percentage required. Thresholds
+specified as a negative number represent the maximum number of uncovered
+entities allowed.
 
-For example, statements: 90 implies minimum statement coverage is 90%.
-statements: -10 implies that no more than 10 uncovered statements are allowed.
-`global` branch threshold 50 will be applied to all files minus matching
-`./src/components/**/*.js` and `./src/api/very-important-module.js`.
+For example, with the following configuration jest will fail if there is less than 80% branch, line, and function coverage, or if there are more than 10 uncovered statements:
+
+```json
+{
+  ...
+  "jest": {
+    "coverageThreshold": {
+      "global": {
+        "branches": 80,
+        "functions": 80,
+        "lines": 80,
+        "statements": -10
+      }
+    }
+  }
+}
+```
+
+If globs or paths are specified alongside `global`, coverage data for matching
+paths will be subtracted from overall coverage and thresholds will be applied
+independently. Thresholds for globs are applied to all files matching the
+glob. If the file specified by path is not found, error is returned.
+
+For example, with the following configuration:
 
 ```json
 {
@@ -191,9 +208,12 @@ statements: -10 implies that no more than 10 uncovered statements are allowed.
         "lines": 50,
         "statements": 50
       },
-      "./src/components/**/*.js": {
+      "./src/components/": {
         "branches": 40,
         "statements": 40
+      },
+      "./src/reducers/**/*.js": {
+        "statements": 90,
       },
       "./src/api/very-important-module.js": {
         "branches": 100,
@@ -205,6 +225,15 @@ statements: -10 implies that no more than 10 uncovered statements are allowed.
   }
 }
 ```
+
+Jest will fail if:
+
+ - The `./src/components` directory has less than 40% branch or statement coverage.
+ - One of the files matching the `./src/reducers/**/*.js` glob has less than 90%
+   statement coverage.
+ - The `./src/api/very-important-module.js` file has less than 100% coverage.
+ - Every remaining file combined has less than 50% coverage (`global`).
+
 
 ### `globals` [object]
 

--- a/packages/jest-cli/src/reporters/__tests__/coverage_reporter.test.js
+++ b/packages/jest-cli/src/reporters/__tests__/coverage_reporter.test.js
@@ -112,7 +112,7 @@ describe('onRunComplete', () => {
     });
   });
 
-  it('getLastError() returns an error when threshold is not met for global', () => {
+  test('getLastError() returns an error when threshold is not met for global', () => {
     const testReporter = new CoverageReporter(
       {
         collectCoverage: true,
@@ -134,7 +134,7 @@ describe('onRunComplete', () => {
       });
   });
 
-  it('getLastError() returns an error when threshold is not met for file', () => {
+  test('getLastError() returns an error when threshold is not met for file', () => {
     const covThreshold = {};
     [
       'global',
@@ -164,7 +164,7 @@ describe('onRunComplete', () => {
       });
   });
 
-  it('getLastError() returns `undefined` when threshold is met', () => {
+  test('getLastError() returns `undefined` when threshold is met', () => {
     const covThreshold = {};
     [
       'global',
@@ -194,13 +194,79 @@ describe('onRunComplete', () => {
       });
   });
 
-  it('getLastError() returns an error when threshold is for non-covered file', () => {
+  test('getLastError() returns an error when threshold is not met for non-covered file', () => {
     const testReporter = new CoverageReporter(
       {
         collectCoverage: true,
         coverageThreshold: {
           'path-test-files/non_covered_file.js': {
             statements: 100,
+          },
+        },
+      },
+      {
+        maxWorkers: 2,
+      },
+    );
+    testReporter.log = jest.fn();
+    return testReporter
+      .onRunComplete(new Set(), {}, mockAggResults)
+      .then(() => {
+        expect(testReporter.getLastError().message.split('\n')).toHaveLength(1);
+      });
+  });
+
+  test('getLastError() returns an error when threshold is not met for directory', () => {
+    const testReporter = new CoverageReporter(
+      {
+        collectCoverage: true,
+        coverageThreshold: {
+          './path-test-files/glob-path/': {
+            statements: 100,
+          },
+        },
+      },
+      {
+        maxWorkers: 2,
+      },
+    );
+    testReporter.log = jest.fn();
+    return testReporter
+      .onRunComplete(new Set(), {}, mockAggResults)
+      .then(() => {
+        expect(testReporter.getLastError().message.split('\n')).toHaveLength(1);
+      });
+  });
+
+  test('getLastError() returns `undefined` when threshold is met for directory', () => {
+    const testReporter = new CoverageReporter(
+      {
+        collectCoverage: true,
+        coverageThreshold: {
+          './path-test-files/glob-path/': {
+            statements: 40,
+          },
+        },
+      },
+      {
+        maxWorkers: 2,
+      },
+    );
+    testReporter.log = jest.fn();
+    return testReporter
+      .onRunComplete(new Set(), {}, mockAggResults)
+      .then(() => {
+        expect(testReporter.getLastError()).toBeUndefined();
+      });
+  });
+
+  test('getLastError() returns an error when there is no coverage data for a threshold', () => {
+    const testReporter = new CoverageReporter(
+      {
+        collectCoverage: true,
+        coverageThreshold: {
+          './path/doesnt/exist': {
+            statements: 40,
           },
         },
       },

--- a/packages/jest-cli/src/reporters/coverage_reporter.js
+++ b/packages/jest-cli/src/reporters/coverage_reporter.js
@@ -276,9 +276,9 @@ export default class CoverageReporter extends BaseReporter {
           // (rather than recalculating it for each covered file) we save a tonne
           // of execution time.
           if (filesByGlob[absoluteThresholdGroup] === undefined) {
-            filesByGlob[absoluteThresholdGroup] = glob.sync(
-              absoluteThresholdGroup,
-            );
+            filesByGlob[absoluteThresholdGroup] = glob
+              .sync(absoluteThresholdGroup)
+              .map(filePath => path.resolve(filePath));
           }
 
           if (filesByGlob[absoluteThresholdGroup].indexOf(file) > -1) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

**Summary**

Right now you can specify a global threshold in Jest and a threshold for files that match a glob pattern. But you can't specify a threshold for a given directory. This pull request adds that functionality without taking away any functionality from before. With this pull request there will be three possible ways to set a coverage threshold:

  1. `global` applies the threshold to every covered file.
  2. `path` applies the threshold to a path (either a directory or a file).
  3. `glob` applies the threshold to any file matching a glob pattern.

For example, before you could do:

```json
{
  "coverageThreshold": {
    "global": {
      "branches": 50,
      "functions": 50,
      "lines": 50,
      "statements": 50
    },
    "./src/components/**/*.js": {
      "branches": 40,
      "statements": 40
    },
    "./src/api/very-important-module.js": {
      "branches": 100,
      "functions": 100,
      "lines": 100,
      "statements": 100
    }
  }
}
```

And this would apply a threshold _separately_...
 - to every file matching the `"./src/components/**/*.js"` glob pattern
 - to the `"./src/api/very-important-module.js"` file
 - and any remaining covered files (under the `global` threshold).

But what if you want to set a threshold for the _entire_ components directory? That is, what if you don't care about the threshold of each individual `.js` file in the components directory, but you _do_ want to set a combined coverage threshold for all your components. Something like:

```json
{
  "coverageThreshold": {
    "global": {
      "branches": 50,
      "functions": 50,
      "lines": 50,
      "statements": 50
    },
    "./src/components/": {
      "branches": 40,
      "statements": 40
    },
    "./src/reducers/**/*.js": {
      "statements": 90,
    },
    "./src/api/very-important-module.js": {
      "branches": 100,
      "functions": 100,
      "lines": 100,
      "statements": 100
    }
  }
}
```

And this would apply a threshold _separately_...
 - to the entire`"./src/components"` directory (combined coverage for each file under the directory).
 - to every file matching the `"./src/reducers/**/*.js"` glob pattern.
 - to the `"./src/api/very-important-module.js"` file
 - and any remaining covered files (under the `global` threshold).

**Test plan**

I added a few unit tests that tests this new functionality. I left every other test in the test suite alone to demonstrate that there are no regressions in functionality. Let me know if you think we need to add some more tests, or if there are some integration test that I can create/update.

