### PR TITLE
Rewrite how common globals are installed in "global"

### DIFF
--- a/packages/jest-jasmine2/src/index.js
+++ b/packages/jest-jasmine2/src/index.js
@@ -37,6 +37,7 @@ async function jasmine2(
   );
   const jasmineFactory = runtime.requireInternalModule(JASMINE);
   const jasmine = jasmineFactory.create({
+    process,
     testPath,
   });
 

--- a/packages/jest-jasmine2/src/jasmine/Env.js
+++ b/packages/jest-jasmine2/src/jasmine/Env.js
@@ -204,11 +204,11 @@ export default function(j$) {
         .listeners('unhandledRejection')
         .slice();
 
-      process.removeAllListeners('uncaughtException');
-      process.removeAllListeners('unhandledRejection');
+      j$.process.removeAllListeners('uncaughtException');
+      j$.process.removeAllListeners('unhandledRejection');
 
-      process.on('uncaughtException', uncaught);
-      process.on('unhandledRejection', uncaught);
+      j$.process.on('uncaughtException', uncaught);
+      j$.process.on('unhandledRejection', uncaught);
 
       reporter.jasmineStarted({totalSpecsDefined});
 
@@ -237,16 +237,16 @@ export default function(j$) {
         failedExpectations: topSuite.result.failedExpectations,
       });
 
-      process.removeListener('uncaughtException', uncaught);
-      process.removeListener('unhandledRejection', uncaught);
+      j$.process.removeListener('uncaughtException', uncaught);
+      j$.process.removeListener('unhandledRejection', uncaught);
 
       // restore previous exception handlers
       oldListenersException.forEach(listener => {
-        process.on('uncaughtException', listener);
+        j$.process.on('uncaughtException', listener);
       });
 
       oldListenersRejection.forEach(listener => {
-        process.on('unhandledRejection', listener);
+        j$.process.on('unhandledRejection', listener);
       });
     };
 

--- a/packages/jest-runtime/src/index.js
+++ b/packages/jest-runtime/src/index.js
@@ -300,8 +300,7 @@ class Runtime {
     }
 
     if (moduleName && this._resolver.isCoreModule(moduleName)) {
-      // $FlowFixMe
-      return require(moduleName);
+      return this._requireCoreModule(moduleName);
     }
 
     if (!modulePath) {
@@ -556,6 +555,15 @@ class Runtime {
 
     this._isCurrentlyExecutingManualMock = origCurrExecutingManualMock;
     this._currentlyExecutingModulePath = lastExecutingModulePath;
+  }
+
+  _requireCoreModule(moduleName: string) {
+    if (moduleName === 'process') {
+      return this._environment.global.process;
+    }
+
+    // $FlowFixMe
+    return require(moduleName);
   }
 
   _generateMock(from: Path, moduleName: string) {

--- a/packages/jest-util/src/__tests__/create_process_object.test.js
+++ b/packages/jest-util/src/__tests__/create_process_object.test.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import EventEmitter from 'events';
+import createProcessObject from '../create_process_object';
+
+it('creates a process object that looks like the original one', () => {
+  const fakeProcess = createProcessObject();
+
+  // "process" inherits from EventEmitter through the prototype chain.
+  expect(fakeProcess instanceof EventEmitter).toBe(true);
+
+  // They look the same, but they are NOT the same (deep copied object). The
+  // "_events" property is checked to ensure event emitter properties are
+  // properly copied.
+  ['argv', 'env', '_events'].forEach(key => {
+    expect(fakeProcess[key]).toEqual(process[key]);
+    expect(fakeProcess[key]).not.toBe(process[key]);
+  });
+
+  // Check that process.stdout/stderr are the same.
+  expect(process.stdout).toBe(fakeProcess.stdout);
+  expect(process.stderr).toBe(fakeProcess.stderr);
+});
+
+it('fakes require("process") so it is equal to "global.process"', () => {
+  expect(require('process') === process).toBe(true);
+});

--- a/packages/jest-util/src/__tests__/deep_cyclic_copy.test.js
+++ b/packages/jest-util/src/__tests__/deep_cyclic_copy.test.js
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import deepCyclicCopy from '../deep_cyclic_copy';
+
+it('returns the same value for primitive or function values', () => {
+  const fn = () => {};
+
+  expect(deepCyclicCopy(undefined)).toBe(undefined);
+  expect(deepCyclicCopy(null)).toBe(null);
+  expect(deepCyclicCopy(true)).toBe(true);
+  expect(deepCyclicCopy(42)).toBe(42);
+  expect(Number.isNaN(deepCyclicCopy(NaN))).toBe(true);
+  expect(deepCyclicCopy('foo')).toBe('foo');
+  expect(deepCyclicCopy(fn)).toBe(fn);
+});
+
+it('does not execute getters/setters, but copies them', () => {
+  const fn = jest.fn();
+  const obj = {
+    get foo() {
+      fn();
+    },
+  };
+  const copy = deepCyclicCopy(obj);
+
+  expect(Object.getOwnPropertyDescriptor(copy, 'foo')).toBeDefined();
+  expect(fn).not.toBeCalled();
+});
+
+it('copies symbols', () => {
+  const symbol = Symbol('foo');
+  const obj = {[symbol]: 42};
+
+  expect(deepCyclicCopy(obj)[symbol]).toBe(42);
+});
+
+it('copies arrays as array objects', () => {
+  const array = [null, 42, 'foo', 'bar', [], {}];
+
+  expect(deepCyclicCopy(array)).toEqual(array);
+  expect(Array.isArray(deepCyclicCopy(array))).toBe(true);
+});
+
+it('handles cyclic dependencies', () => {
+  const cyclic = {a: 42, subcycle: {}};
+
+  cyclic.subcycle.baz = cyclic;
+  cyclic.bar = cyclic;
+
+  expect(() => deepCyclicCopy(cyclic)).not.toThrow();
+
+  const copy = deepCyclicCopy(cyclic);
+
+  expect(copy.a).toBe(42);
+  expect(copy.bar).toEqual(copy);
+  expect(copy.subcycle.baz).toEqual(copy);
+});

--- a/packages/jest-util/src/create_process_object.js
+++ b/packages/jest-util/src/create_process_object.js
@@ -19,7 +19,7 @@ export default function() {
   // Sequentially execute all constructors over the object.
   let proto = process;
 
-  while (proto = Object.getPrototypeOf(proto)) {
+  while ((proto = Object.getPrototypeOf(proto))) {
     if (typeof proto.constructor === 'function') {
       proto.constructor.call(newProcess);
     }

--- a/packages/jest-util/src/create_process_object.js
+++ b/packages/jest-util/src/create_process_object.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import deepCyclicCopy from './deep_cyclic_copy';
+
+export default function() {
+  const process = require('process');
+  const newProcess = deepCyclicCopy(process);
+
+  // $FlowFixMe: Add the symbol for toString objects.
+  newProcess[Symbol.toStringTag] = 'process';
+
+  // Sequentially execute all constructors over the object.
+  let proto = process;
+
+  while (proto = Object.getPrototypeOf(proto)) {
+    if (typeof proto.constructor === 'function') {
+      proto.constructor.call(newProcess);
+    }
+  }
+
+  return newProcess;
+}

--- a/packages/jest-util/src/deep_cyclic_copy.js
+++ b/packages/jest-util/src/deep_cyclic_copy.js
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+export default function deepCyclicCopy(
+  object: any,
+  cycles: WeakMap<any, any> = new WeakMap(),
+) {
+  if (typeof object !== 'object' || object === null) {
+    return object;
+  }
+
+  let newObject;
+
+  if (Array.isArray(object)) {
+    newObject = [];
+  } else {
+    newObject = Object.create(Object.getPrototypeOf(object));
+  }
+
+  cycles.set(object, newObject);
+
+  // Copying helper function. Checks into the weak map passed to manage cycles.
+  const copy = (key: string | Symbol) => {
+    const descriptor = Object.getOwnPropertyDescriptor(object, key);
+    const value = descriptor.value;
+
+    if (descriptor.hasOwnProperty('value')) {
+      if (cycles.has(value)) {
+        descriptor.value = cycles.get(value);
+      } else {
+        descriptor.value = deepCyclicCopy(value, cycles);
+      }
+
+      // Allow tests to override whatever they need.
+      descriptor.writable = true;
+    }
+
+    // Allow tests to override whatever they need.
+    descriptor.configurable = true;
+
+    try {
+      Object.defineProperty(newObject, key, descriptor);
+    } catch (err) {
+      // Do nothing; this usually fails because a non-configurable property is
+      // tried to be overridden with a configurable one (e.g. "length").
+    }
+  };
+
+  // Copy string and symbol keys!
+  Object.getOwnPropertyNames(object).forEach(copy);
+  Object.getOwnPropertySymbols(object).forEach(copy);
+
+  return newObject;
+}


### PR DESCRIPTION
This diff rewrites how the fake `process` variable is created and injected; in order to better mimic the way it looks and improve sandboxing. Now, `process` is built from `Process.prototype`, then all the constructors on the prototype chain are executed (i.e. `Process`, `EventEmitter`, and `Object`); and finally the remaining properties are copied as before.

This gives as a result an object that can independently handle events added via `process.on`, but also passes validations like `Object.getPrototypeOf(process) !== Object.prototype`.

The risk is that someone is already using `process.on` to try attaching to the **real** `process`; and this will make the test break. But I think it's fine.