### PR TITLE
Include missing dependency in TestEnvironment sample code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,7 @@
   ([#4578](https://github.com/facebook/jest/pull/4578))
 * `[jest-runtime]` Add `.advanceTimersByTime`; keep `.runTimersToTime()` as an
   alias.
+* `[docs]` Include missing dependency in TestEnvironment sample code  
 
 ## jest 21.2.1
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -672,6 +672,8 @@ in their own TestEnvironment._
 Example:
 
 ```js
+const NodeEnvironment = require('jest-environment-node');
+
 class CustomEnvironment extends NodeEnvironment {
   constructor(config) {
     super(config);


### PR DESCRIPTION
**Summary**
The Sample code for using a custom environment in testEnvironment doesn't show where the NodeEnvironment is coming from. This PR includes this missing dependency.

**Test plan**

Using jest@test with similar sample code resulted in this error message:
ReferenceError: NodeEnvironment is not defined. 

Including jest-environment-node@test solved the issue and using a custom environment worked as expected.