### PR TITLE
Add AngularJS article to Testing Frameworks docs

### DIFF
--- a/docs/TestingFrameworks.md
+++ b/docs/TestingFrameworks.md
@@ -21,6 +21,7 @@ about integrating Jest into other popular JS libraries.
   by Matthieu Lux ([@Swiip](https://twitter.com/Swiip))
 * [Running AngularJS Tests with Jest](https://engineering.talentpair.com/running-angularjs-tests-with-jest-49d0cc9c6d26)
   by Ben Brandt ([@benjaminbrandt](https://twitter.com/benjaminbrandt))
+* [AngularJs with Jest Unit Testing](https://curtistimson.co.uk/post/angularjs/angularjs-jest-unit-testing/) by Curtis Timson ([@curty_](https://twitter.com/curty_))
 
 ## Angular
 

--- a/docs/TestingFrameworks.md
+++ b/docs/TestingFrameworks.md
@@ -21,7 +21,7 @@ about integrating Jest into other popular JS libraries.
   by Matthieu Lux ([@Swiip](https://twitter.com/Swiip))
 * [Running AngularJS Tests with Jest](https://engineering.talentpair.com/running-angularjs-tests-with-jest-49d0cc9c6d26)
   by Ben Brandt ([@benjaminbrandt](https://twitter.com/benjaminbrandt))
-* [AngularJs with Jest Unit Testing](https://curtistimson.co.uk/post/angularjs/angularjs-jest-unit-testing/) by Curtis Timson ([@curty_](https://twitter.com/curty_))
+* [AngularJS with Jest Unit Testing](https://curtistimson.co.uk/post/angularjs/angularjs-jest-unit-testing/) by Curtis Timson ([@curty_](https://twitter.com/curty_))
 
 ## Angular
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

**Summary**

This change adds an additional article reference regarding how to use Jest with AngularJS.

**Test plan**

```
cd website
yarn
yarn test
yarn start
```

Then navigated to:

http://localhost:3000/jest/docs/en/testing-frameworks.html