### PR TITLE
Add clarification for hook execution order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,7 @@
 * `[jest-runtime]` Add `.advanceTimersByTime`; keep `.runTimersToTime()` as an
   alias.
 * `[docs]` Include missing dependency in TestEnvironment sample code  
+* `[docs]` Add clarification for hook execution order
 
 ## jest 21.2.1
 

--- a/docs/SetupAndTeardown.md
+++ b/docs/SetupAndTeardown.md
@@ -115,6 +115,38 @@ describe('matching cities to foods', () => {
 });
 ```
 
+Note that the top-level `beforeEach` is executed before the `beforeEach` inside
+the `describe` block. It may help to illustrate the order of execution of all
+hooks.
+
+```js
+beforeAll(() => console.log("1 - beforeAll"));
+afterAll(() => console.log("1 - afterAll"));
+beforeEach(() => console.log("1 - beforeEach"));
+afterEach(() => console.log("1 - afterEach"));
+test('', () => console.log("1 - test"));
+describe('Scoped / Nested block', () => {
+  beforeAll(() => console.log("2 - beforeAll"));
+  afterAll(() => console.log("2 - afterAll"));
+  beforeEach(() => console.log("2 - beforeEach"));
+  afterEach(() => console.log("2 - afterEach"));
+  test('', () => console.log("2 - test"));
+});
+
+// 1 - beforeAll
+// 1 - beforeEach
+// 1 - test
+// 1 - afterEach
+// 2 - beforeAll
+// 1 - beforeEach
+// 2 - beforeEach
+// 2 - test
+// 2 - afterEach
+// 1 - afterEach
+// 2 - afterAll
+// 1 - afterAll
+```
+
 ### General Advice
 
 If a test is failing, one of the first things to check should be whether the


### PR DESCRIPTION
**Summary**
Add clarification for hook execution order. Existing problem may include:

* Misconception that the top-level `before` hooks are ran before each `describe` _or_ `test` block, and not necessarily every `test` block (although this is addressed in the docs with the sentence "By default, the `before` and `after` blocks apply to every test in a file.", this illustration makes it more explicit)
* Confusion about the execution order of nested `beforeAll` hook in relation to top-level `beforeEach`
* Likewise, confusion about the execution order of nested `afterAll` hook in relation to top-level `afterEach`

**Test plan**
I could not test the website / formatting is correct due to #4911 and #4912, but it is valid Markdown and fits within 80 character line-length limit.