### PR TITLE
Replace identity equality with Object.is in toBe matcher

### DIFF
--- a/docs/ExpectAPI.md
+++ b/docs/ExpectAPI.md
@@ -104,13 +104,13 @@ for the `toBe` matcher:
 const diff = require('jest-diff');
 expect.extend({
   toBe(received, expected) {
-    const pass = received === expected;
+    const pass = Object.is(received, expected);
 
     const message = pass
       ? () =>
           this.utils.matcherHint('.not.toBe') +
           '\n\n' +
-          `Expected value to not be (using ===):\n` +
+          `Expected value to not be (using Object.is):\n` +
           `  ${this.utils.printExpected(expected)}\n` +
           `Received:\n` +
           `  ${this.utils.printReceived(received)}`
@@ -121,7 +121,7 @@ expect.extend({
           return (
             this.utils.matcherHint('.toBe') +
             '\n\n' +
-            `Expected value to be (using ===):\n` +
+            `Expected value to be (using Object.is):\n` +
             `  ${this.utils.printExpected(expected)}\n` +
             `Received:\n` +
             `  ${this.utils.printReceived(received)}` +
@@ -139,7 +139,7 @@ This will print something like this:
 ```
   expect(received).toBe(expected)
 
-    Expected value to be (using ===):
+    Expected value to be (using Object.is):
       "banana"
     Received:
       "apple"
@@ -430,8 +430,8 @@ test('rejects to octopus', async () => {
 
 ### `.toBe(value)`
 
-`toBe` just checks that a value is what you expect. It uses `===` to check
-strict equality.
+`toBe` just checks that a value is what you expect. It uses `Object.is` to check
+exact equality.
 
 For example, this code will validate some properties of the `can` object:
 

--- a/docs/UsingMatchers.md
+++ b/docs/UsingMatchers.md
@@ -22,7 +22,7 @@ won't do much with these expectation objects except call matchers on them. In
 this code, `.toBe(4)` is the matcher. When Jest runs, it tracks all the failing
 matchers so that it can print out nice error messages for you.
 
-`toBe` uses `===` to test exact equality. If you want to check the value of an
+`toBe` uses `Object.is` to test exact equality. If you want to check the value of an
 object, use `toEqual` instead:
 
 ```js

--- a/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -141,7 +141,7 @@ Received: <red>undefined</>"
 exports[`.toBe() does not crash on circular references 1`] = `
 "<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>)</>
 
-Expected value to be (using ===):
+Expected value to be (using Object.is):
   <green>{}</>
 Received:
   <red>{\\"circular\\": [Circular]}</>
@@ -160,7 +160,7 @@ Difference:
 exports[`.toBe() fails for '"a"' with '.not' 1`] = `
 "<dim>expect(</><red>received</><dim>).not.toBe(</><green>expected</><dim>)</>
 
-Expected value to not be (using ===):
+Expected value to not be (using Object.is):
   <green>\\"a\\"</>
 Received:
   <red>\\"a\\"</>"
@@ -169,7 +169,7 @@ Received:
 exports[`.toBe() fails for '[]' with '.not' 1`] = `
 "<dim>expect(</><red>received</><dim>).not.toBe(</><green>expected</><dim>)</>
 
-Expected value to not be (using ===):
+Expected value to not be (using Object.is):
   <green>[]</>
 Received:
   <red>[]</>"
@@ -178,7 +178,7 @@ Received:
 exports[`.toBe() fails for '{}' with '.not' 1`] = `
 "<dim>expect(</><red>received</><dim>).not.toBe(</><green>expected</><dim>)</>
 
-Expected value to not be (using ===):
+Expected value to not be (using Object.is):
   <green>{}</>
 Received:
   <red>{}</>"
@@ -187,7 +187,7 @@ Received:
 exports[`.toBe() fails for '1' with '.not' 1`] = `
 "<dim>expect(</><red>received</><dim>).not.toBe(</><green>expected</><dim>)</>
 
-Expected value to not be (using ===):
+Expected value to not be (using Object.is):
   <green>1</>
 Received:
   <red>1</>"
@@ -196,7 +196,7 @@ Received:
 exports[`.toBe() fails for 'false' with '.not' 1`] = `
 "<dim>expect(</><red>received</><dim>).not.toBe(</><green>expected</><dim>)</>
 
-Expected value to not be (using ===):
+Expected value to not be (using Object.is):
   <green>false</>
 Received:
   <red>false</>"
@@ -205,7 +205,7 @@ Received:
 exports[`.toBe() fails for 'null' with '.not' 1`] = `
 "<dim>expect(</><red>received</><dim>).not.toBe(</><green>expected</><dim>)</>
 
-Expected value to not be (using ===):
+Expected value to not be (using Object.is):
   <green>null</>
 Received:
   <red>null</>"
@@ -214,7 +214,7 @@ Received:
 exports[`.toBe() fails for 'undefined' with '.not' 1`] = `
 "<dim>expect(</><red>received</><dim>).not.toBe(</><green>expected</><dim>)</>
 
-Expected value to not be (using ===):
+Expected value to not be (using Object.is):
   <green>undefined</>
 Received:
   <red>undefined</>"
@@ -223,7 +223,7 @@ Received:
 exports[`.toBe() fails for: "abc" and "cde" 1`] = `
 "<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>)</>
 
-Expected value to be (using ===):
+Expected value to be (using Object.is):
   <green>\\"cde\\"</>
 Received:
   <red>\\"abc\\"</>"
@@ -233,7 +233,7 @@ exports[`.toBe() fails for: "with
 trailing space" and "without trailing space" 1`] = `
 "<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>)</>
 
-Expected value to be (using ===):
+Expected value to be (using Object.is):
   <green>\\"without trailing space\\"</>
 Received:
   <red>\\"with<inverse> </></>
@@ -243,7 +243,7 @@ Received:
 exports[`.toBe() fails for: [] and [] 1`] = `
 "<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>)</>
 
-Expected value to be (using ===):
+Expected value to be (using Object.is):
   <green>[]</>
 Received:
   <red>[]</>
@@ -256,7 +256,7 @@ Difference:
 exports[`.toBe() fails for: {"a": 1} and {"a": 1} 1`] = `
 "<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>)</>
 
-Expected value to be (using ===):
+Expected value to be (using Object.is):
   <green>{\\"a\\": 1}</>
 Received:
   <red>{\\"a\\": 1}</>
@@ -269,7 +269,7 @@ Difference:
 exports[`.toBe() fails for: {"a": 1} and {"a": 5} 1`] = `
 "<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>)</>
 
-Expected value to be (using ===):
+Expected value to be (using Object.is):
   <green>{\\"a\\": 5}</>
 Received:
   <red>{\\"a\\": 1}</>
@@ -288,7 +288,7 @@ Difference:
 exports[`.toBe() fails for: {} and {} 1`] = `
 "<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>)</>
 
-Expected value to be (using ===):
+Expected value to be (using Object.is):
   <green>{}</>
 Received:
   <red>{}</>
@@ -298,10 +298,23 @@ Difference:
 <dim>Compared values have no visual difference.</> <dim>Looks like you wanted to test for object/array equality with strict \`toBe\` matcher. You probably need to use \`toEqual\` instead.</>"
 `;
 
+exports[`.toBe() fails for: -0 and 0 1`] = `
+"<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>)</>
+
+Expected value to be (using Object.is):
+  <green>0</>
+Received:
+  <red>-0</>
+
+Difference:
+
+<dim>Compared values have no visual difference.</>"
+`;
+
 exports[`.toBe() fails for: 1 and 2 1`] = `
 "<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>)</>
 
-Expected value to be (using ===):
+Expected value to be (using Object.is):
   <green>2</>
 Received:
   <red>1</>"
@@ -310,7 +323,7 @@ Received:
 exports[`.toBe() fails for: null and undefined 1`] = `
 "<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>)</>
 
-Expected value to be (using ===):
+Expected value to be (using Object.is):
   <green>undefined</>
 Received:
   <red>null</>
@@ -323,7 +336,7 @@ Difference:
 exports[`.toBe() fails for: true and false 1`] = `
 "<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>)</>
 
-Expected value to be (using ===):
+Expected value to be (using Object.is):
   <green>false</>
 Received:
   <red>true</>"

--- a/packages/expect/src/__tests__/matchers.test.js
+++ b/packages/expect/src/__tests__/matchers.test.js
@@ -105,6 +105,7 @@ describe('.resolves', () => {
     expect(error.message).toMatchSnapshot();
   });
 });
+
 describe('.toBe()', () => {
   it('does not throw', () => {
     jestExpect('a').not.toBe('b');
@@ -114,6 +115,7 @@ describe('.toBe()', () => {
     jestExpect(null).not.toBe(undefined);
     jestExpect(null).toBe(null);
     jestExpect(undefined).toBe(undefined);
+    jestExpect(NaN).toBe(NaN);
   });
 
   [
@@ -126,6 +128,7 @@ describe('.toBe()', () => {
     ['with \ntrailing space', 'without trailing space'],
     [[], []],
     [null, undefined],
+    [-0, +0],
   ].forEach(([a, b]) => {
     it(`fails for: ${stringify(a)} and ${stringify(b)}`, () => {
       expect(() => jestExpect(a).toBe(b)).toThrowErrorMatchingSnapshot();

--- a/packages/expect/src/matchers.js
+++ b/packages/expect/src/matchers.js
@@ -40,13 +40,13 @@ type ContainIterable =
 
 const matchers: MatchersObject = {
   toBe(received: any, expected: number) {
-    const pass = received === expected;
+    const pass = Object.is(received, expected);
 
     const message = pass
       ? () =>
           matcherHint('.not.toBe') +
           '\n\n' +
-          `Expected value to not be (using ===):\n` +
+          `Expected value to not be (using Object.is):\n` +
           `  ${printExpected(expected)}\n` +
           `Received:\n` +
           `  ${printReceived(received)}`
@@ -63,7 +63,7 @@ const matchers: MatchersObject = {
           return (
             matcherHint('.toBe') +
             '\n\n' +
-            `Expected value to be (using ===):\n` +
+            `Expected value to be (using Object.is):\n` +
             `  ${printExpected(expected)}\n` +
             `Received:\n` +
             `  ${printReceived(received)}` +

--- a/packages/jest-jasmine2/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/jest-jasmine2/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -3,7 +3,7 @@
 exports[`matchers proxies matchers to expect 1`] = `
 "<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>)</>
 
-Expected value to be (using ===):
+Expected value to be (using Object.is):
   <green>2</>
 Received:
   <red>1</>"


### PR DESCRIPTION
**Summary**

This replaces the strict equality (`===`) check with `Object.is` in the `toBe` matcher. `Object.is` works exactly the same as triple equals except:

```
> Object.is(NaN, NaN)
true
> NaN === NaN
false
```

```
> Object.is(-0, +0)
false
> -0 === +0
true
```

Hence, this allows us to fix #4907.

**Test plan**

Added two tests for `toBe` matcher. I couldn't test the docs due to #4911 and #4912, but changes are trivial.