### PR TITLE
Additional arguments to runJestWithUpdateForSnapshots

### DIFF
--- a/packages/jest-editor-support/src/Runner.js
+++ b/packages/jest-editor-support/src/Runner.js
@@ -101,7 +101,7 @@ export default class Runner extends EventEmitter {
     const defaultArgs = ['--updateSnapshot'];
     const updateProcess = this._createProcess(this.workspace, [
       ...defaultArgs,
-      ...args,
+      ...(args ? args : []),
     ]);
     updateProcess.on('close', () => {
       completion();

--- a/packages/jest-editor-support/src/Runner.js
+++ b/packages/jest-editor-support/src/Runner.js
@@ -97,9 +97,12 @@ export default class Runner extends EventEmitter {
     });
   }
 
-  runJestWithUpdateForSnapshots(completion: any) {
-    const args = ['--updateSnapshot'];
-    const updateProcess = this._createProcess(this.workspace, args);
+  runJestWithUpdateForSnapshots(completion: any, args: string[]) {
+    const defaultArgs = ['--updateSnapshot'];
+    const updateProcess = this._createProcess(this.workspace, [
+      ...defaultArgs,
+      ...args,
+    ]);
     updateProcess.on('close', () => {
       completion();
     });


### PR DESCRIPTION
* Allow additional arguments to runJestWithUpdateForSnapshots method

**Summary**
This allows passing custom parameters to the `runJestWithUpdateForSnapshots` method allowing to update specific snapshots by a test name pattern.

