### PR TITLE
Revert "jest-runtime: move babel-core to peer dependenies (#4557)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,6 @@
   ([#4599](https://github.com/facebook/jest/pull/4599))
 * `[jest-runtime]` Fix manual user mocks not working with custom resolver
   ([#4489](https://github.com/facebook/jest/pull/4489))
-* `[jest-runtime]` Move `babel-core` to peer dependencies so it works with Babel
-  7 ([#4557](https://github.com/facebook/jest/pull/4557))
 * `[jest-util]` Fix `runOnlyPendingTimers` for `setTimeout` inside
   `setImmediate` ([#4608](https://github.com/facebook/jest/pull/4608))
 * `[jest-message-util]` Always remove node internals from stacktraces

--- a/packages/jest-runtime/package.json
+++ b/packages/jest-runtime/package.json
@@ -8,6 +8,7 @@
   "license": "MIT",
   "main": "build/index.js",
   "dependencies": {
+    "babel-core": "^6.0.0",
     "babel-jest": "^21.2.0",
     "babel-plugin-istanbul": "^4.1.5",
     "chalk": "^2.0.1",
@@ -26,12 +27,8 @@
     "yargs": "^9.0.0"
   },
   "devDependencies": {
-    "babel-core": "^6.0.0",
     "jest-environment-jsdom": "^21.2.1",
     "jest-environment-node": "^21.2.1"
-  },
-  "peerDependencies": {
-    "babel-core": "^6.0.0 || ^7.0.0-alpha || ^7.0.0-beta || ^7.0.0"
   },
   "bin": {
     "jest-runtime": "./bin/jest-runtime.js"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

**Summary**
This reverts commit 1fcffab0b86e16e84ce66d2321e03a4744268f74.

As discussed in #4557

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
