### PR TITLE
Website: Fix npm start from failing

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -12,7 +12,7 @@ Then, run the server via
 
 ```
 npm start
-Open http://localhost:8080/jest/index.html
+Open http://localhost:3000
 ```
 
 Anytime you change the contents, just refresh the page and it's going to be

--- a/website/package.json
+++ b/website/package.json
@@ -12,7 +12,7 @@
     "rename-version": "docusaurus-rename-version"
   },
   "dependencies": {
-    "docusaurus": "^1.0.0-beta.4"
+    "docusaurus": "1.0.0-beta.4"
   },
   "devDependencies": {
     "crowdin-cli": "^0.3.0"


### PR DESCRIPTION
Running `npm i` installs `docusaurus 1.0.0-beta.13`, and that makes `npm start` and `npm run build` to fail. This PR fixes the issue by keeping docusaurus at 1.0.0-beta.4.  
I also updated the instructions on how to run the server. They're right now. 