### PR TITLE
Couple of small fixes for watchPlugins

### DIFF
--- a/packages/jest-cli/package.json
+++ b/packages/jest-cli/package.json
@@ -20,6 +20,7 @@
     "jest-haste-map": "^21.2.0",
     "jest-message-util": "^21.2.1",
     "jest-regex-util": "^21.2.0",
+    "jest-resolve": "^21.2.0",
     "jest-resolve-dependencies": "^21.2.0",
     "jest-runner": "^21.2.1",
     "jest-runtime": "^21.2.1",

--- a/packages/jest-cli/package.json
+++ b/packages/jest-cli/package.json
@@ -20,7 +20,6 @@
     "jest-haste-map": "^21.2.0",
     "jest-message-util": "^21.2.1",
     "jest-regex-util": "^21.2.0",
-    "jest-resolve": "^21.2.0",
     "jest-resolve-dependencies": "^21.2.0",
     "jest-runner": "^21.2.1",
     "jest-runtime": "^21.2.1",

--- a/packages/jest-cli/src/__tests__/watch.test.js
+++ b/packages/jest-cli/src/__tests__/watch.test.js
@@ -14,6 +14,9 @@ import {KEYS} from '../constants';
 
 const runJestMock = jest.fn();
 
+const watchPluginPath = `${__dirname}/__fixtures__/watch_plugin`;
+const watchPlugin2Path = `${__dirname}/__fixtures__/watch_plugin2`;
+
 jest.doMock('chalk', () => new chalk.constructor({enabled: false}));
 jest.doMock(
   '../run_jest',
@@ -30,17 +33,25 @@ jest.doMock(
     },
 );
 
-jest.doMock('./__fixtures__/watch_plugin', () => ({
-  enter: jest.fn(),
-  key: 's'.codePointAt(0),
-  prompt: 'do nothing',
-}));
+jest.doMock(
+  watchPluginPath,
+  () => ({
+    enter: jest.fn(),
+    key: 's'.codePointAt(0),
+    prompt: 'do nothing',
+  }),
+  {virtual: true},
+);
 
-jest.doMock('./__fixtures__/watch_plugin2', () => ({
-  enter: jest.fn(),
-  key: 'u'.codePointAt(0),
-  prompt: 'do something else',
-}));
+jest.doMock(
+  watchPlugin2Path,
+  () => ({
+    enter: jest.fn(),
+    key: 'u'.codePointAt(0),
+    prompt: 'do something else',
+  }),
+  {virtual: true},
+);
 
 const watch = require('../watch').default;
 afterEach(runJestMock.mockReset);
@@ -106,7 +117,7 @@ describe('Watch mode flows', () => {
       await watch(
         Object.assign({}, globalConfig, {
           rootDir: __dirname,
-          watchPlugins: ['./__fixtures__/watch_plugin'],
+          watchPlugins: [watchPluginPath],
         }),
         contexts,
         pipe,
@@ -120,10 +131,7 @@ describe('Watch mode flows', () => {
     watch(
       Object.assign({}, globalConfig, {
         rootDir: __dirname,
-        watchPlugins: [
-          './__fixtures__/watch_plugin2',
-          './__fixtures__/watch_plugin',
-        ],
+        watchPlugins: [watchPlugin2Path, watchPluginPath],
       }),
       contexts,
       pipe,
@@ -141,12 +149,12 @@ describe('Watch mode flows', () => {
   });
 
   it('triggers enter on a WatchPlugin when its key is pressed', () => {
-    const plugin = require('./__fixtures__/watch_plugin');
+    const plugin = require(watchPluginPath);
 
     watch(
       Object.assign({}, globalConfig, {
         rootDir: __dirname,
-        watchPlugins: ['./__fixtures__/watch_plugin'],
+        watchPlugins: [watchPluginPath],
       }),
       contexts,
       pipe,
@@ -160,8 +168,8 @@ describe('Watch mode flows', () => {
   });
 
   it('prevents Jest from handling keys when active and returns control when end is called', () => {
-    const plugin = require('./__fixtures__/watch_plugin');
-    const plugin2 = require('./__fixtures__/watch_plugin2');
+    const plugin = require(watchPluginPath);
+    const plugin2 = require(watchPlugin2Path);
 
     let pluginEnd;
     plugin.enter = jest.fn((globalConfig, end) => (pluginEnd = end));
@@ -169,10 +177,7 @@ describe('Watch mode flows', () => {
     watch(
       Object.assign({}, globalConfig, {
         rootDir: __dirname,
-        watchPlugins: [
-          './__fixtures__/watch_plugin',
-          './__fixtures__/watch_plugin2',
-        ],
+        watchPlugins: [watchPluginPath, watchPlugin2Path],
       }),
       contexts,
       pipe,

--- a/packages/jest-cli/src/__tests__/watch.test.js
+++ b/packages/jest-cli/src/__tests__/watch.test.js
@@ -131,7 +131,13 @@ describe('Watch mode flows', () => {
       stdin,
     );
 
-    expect(pipe.write.mock.calls).toMatchSnapshot();
+    const pipeMockCalls = pipe.write.mock.calls;
+
+    const determiningTestsToRun = pipeMockCalls.findIndex(
+      ([c]) => c === 'Determining test suites to run...',
+    );
+
+    expect(pipeMockCalls.slice(determiningTestsToRun + 1)).toMatchSnapshot();
   });
 
   it('triggers enter on a WatchPlugin when its key is pressed', () => {

--- a/packages/jest-cli/src/lib/watch_plugin_registry.js
+++ b/packages/jest-cli/src/lib/watch_plugin_registry.js
@@ -9,7 +9,7 @@
 
 import type {WatchPlugin} from '../types';
 import getType from 'jest-get-type';
-import defaultResolver from '../../../jest-resolve/src/default_resolver';
+import Resolver from 'jest-resolve';
 
 const RESERVED_KEYS = [
   0x03, // Jest should handle ctrl-c interrupt
@@ -27,7 +27,7 @@ export default class WatchPluginRegistry {
 
   loadPluginPath(pluginModulePath: string) {
     // $FlowFixMe dynamic require
-    const maybePlugin = require(defaultResolver(pluginModulePath, {
+    const maybePlugin = require(Resolver.findNodeModule(pluginModulePath, {
       basedir: this._rootDir,
     }));
 

--- a/packages/jest-cli/src/lib/watch_plugin_registry.js
+++ b/packages/jest-cli/src/lib/watch_plugin_registry.js
@@ -9,7 +9,6 @@
 
 import type {WatchPlugin} from '../types';
 import getType from 'jest-get-type';
-import Resolver from 'jest-resolve';
 
 const RESERVED_KEYS = [
   0x03, // Jest should handle ctrl-c interrupt
@@ -27,9 +26,7 @@ export default class WatchPluginRegistry {
 
   loadPluginPath(pluginModulePath: string) {
     // $FlowFixMe dynamic require
-    const maybePlugin = require(Resolver.findNodeModule(pluginModulePath, {
-      basedir: this._rootDir,
-    }));
+    const maybePlugin = require(pluginModulePath);
 
     // Since we're loading the module from a dynamic path, assert its shape
     // before assuming it's a valid watch plugin.

--- a/packages/jest-config/src/__tests__/normalize.test.js
+++ b/packages/jest-config/src/__tests__/normalize.test.js
@@ -7,6 +7,7 @@
  */
 
 import {escapeStrForRegex} from 'jest-regex-util';
+import Resolver from 'jest-resolve';
 import normalize from '../normalize';
 
 jest.mock('jest-resolve');
@@ -994,6 +995,17 @@ describe('preset without setupFiles', () => {
 });
 
 describe('watchPlugins', () => {
+  let Resolver;
+  beforeEach(() => {
+    Resolver = require('jest-resolve');
+    Resolver.findNodeModule = jest.fn(name => {
+      if (name.startsWith(path.sep)) {
+        return name;
+      }
+      return path.sep + 'node_modules' + path.sep + name;
+    });
+  });
+
   it('defaults to undefined', () => {
     const {options} = normalize({rootDir: '/root'}, {});
 
@@ -1003,14 +1015,14 @@ describe('watchPlugins', () => {
   it('normalizes watchPlugins', () => {
     const {options} = normalize(
       {
-        rootDir: '/root',
+        rootDir: '/root/',
         watchPlugins: ['my-watch-plugin', '<rootDir>/path/to/plugin'],
       },
       {},
     );
 
     expect(options.watchPlugins).toEqual([
-      'my-watch-plugin',
+      '/node_modules/my-watch-plugin',
       '/root/path/to/plugin',
     ]);
   });

--- a/packages/jest-config/src/__tests__/normalize.test.js
+++ b/packages/jest-config/src/__tests__/normalize.test.js
@@ -992,3 +992,26 @@ describe('preset without setupFiles', () => {
     );
   });
 });
+
+describe('watchPlugins', () => {
+  it('defaults to undefined', () => {
+    const {options} = normalize({rootDir: '/root'}, {});
+
+    expect(options.watchPlugins).toEqual(undefined);
+  });
+
+  it('normalizes watchPlugins', () => {
+    const {options} = normalize(
+      {
+        rootDir: '/root',
+        watchPlugins: ['my-watch-plugin', '<rootDir>/path/to/plugin'],
+      },
+      {},
+    );
+
+    expect(options.watchPlugins).toEqual([
+      'my-watch-plugin',
+      '/root/path/to/plugin',
+    ]);
+  });
+});

--- a/packages/jest-config/src/normalize.js
+++ b/packages/jest-config/src/normalize.js
@@ -492,6 +492,11 @@ export default function normalize(options: InitialOptions, argv: Argv) {
       case 'watchman':
         value = options[key];
         break;
+      case 'watchPlugins':
+        value = (options[key] || []).map(watchPlugin =>
+          _replaceRootDirTags(options.rootDir, watchPlugin),
+        );
+        break;
     }
     newOptions[key] = value;
     return newOptions;

--- a/packages/jest-config/src/normalize.js
+++ b/packages/jest-config/src/normalize.js
@@ -494,7 +494,7 @@ export default function normalize(options: InitialOptions, argv: Argv) {
         break;
       case 'watchPlugins':
         value = (options[key] || []).map(watchPlugin =>
-          _replaceRootDirTags(options.rootDir, watchPlugin),
+          resolve(options.rootDir, key, watchPlugin),
         );
         break;
     }


### PR DESCRIPTION
**Summary**

This PRs does a couple of small things

####  1. Normalizes `watchPlugins`
This was not being normalized and and it also adds more tests to it.

#### 2. Use jest-resolve as a package.

It was previously using a relative path to the src directory, which meant that it was never using the transpiled version, resulting in this error.
```
/Users/rogelioguzman/dev/jest/packages/jest-resolve/src/default_resolver.js:10
import type {Path} from 'types/Config';
^^^^^^

SyntaxError: Unexpected token import
    at createScript (vm.js:80:10)
    at Object.runInThisContext (vm.js:139:10)
    at Module._compile (module.js:588:28)
    at Object.Module._extensions..js (module.js:635:10)
    at Module.load (module.js:545:32)
    at tryModuleLoad (module.js:508:12)
    at Function.Module._load (module.js:500:3)
    at Module.require (module.js:568:17)
    at require (internal/module.js:11:18)
    at _load_default_resolver (/Users/rogelioguzman/dev/jest/packages/jest-cli/build/lib/watch_plugin_registry.js:12:86)
Please run `npm install` to use the version of Jest intended for this project.
```


#### 3. Fixes `shows prompts for WatchPlugins in alphabetical order` test
This was sometimes serializing `Determining test suites to run...` as part of the snapshot, causing the test to fail... See https://github.com/facebook/jest/pull/4841#issuecomment-343538731 for more details
