### PR TITLE
Fix jest-worker when `silent: false`

### DIFF
--- a/packages/jest-worker/src/__tests__/index.test.js
+++ b/packages/jest-worker/src/__tests__/index.test.js
@@ -182,6 +182,26 @@ it('aggregates all stdouts and stderrs from all workers', () => {
   expect(stderr.mock.calls[1][0].toString()).toBe('tree');
 });
 
+it('works when stdout and stderr are not piped to the parent', () => {
+  Worker.mockImplementation(() => ({
+    getStderr: () => null,
+    getStdout: () => null,
+    send: () => null,
+  }));
+
+  const farm = new Farm('/tmp/baz.js', {
+    exposedMethods: ['foo', 'bar'],
+    forkOptions: {
+      silent: false,
+      stdio: 'inherit',
+    },
+    numWorkers: 2,
+  });
+
+  expect(() => farm.foo()).not.toThrow();
+  expect(() => farm.bar()).not.toThrow();
+});
+
 it('does not let make calls after the farm is ended', () => {
   const farm = new Farm('/tmp/baz.js', {
     exposedMethods: ['foo', 'bar'],

--- a/packages/jest-worker/src/index.js
+++ b/packages/jest-worker/src/index.js
@@ -76,8 +76,13 @@ export default class {
     for (let i = 0; i < numWorkers; i++) {
       const worker = new Worker(workerOptions);
 
-      stdout.add(worker.getStdout());
-      stderr.add(worker.getStderr());
+      if (worker.getStdout()) {
+        stdout.add(worker.getStdout());
+      }
+
+      if (worker.getStderr()) {
+        stderr.add(worker.getStderr());
+      }
 
       workers[i] = worker;
     }

--- a/packages/jest-worker/src/index.js
+++ b/packages/jest-worker/src/index.js
@@ -75,13 +75,15 @@ export default class {
 
     for (let i = 0; i < numWorkers; i++) {
       const worker = new Worker(workerOptions);
+      const workerStdout = worker.getStdout();
+      const workerStderr = worker.getStderr();
 
-      if (worker.getStdout()) {
-        stdout.add(worker.getStdout());
+      if (workerStdout) {
+        stdout.add(workerStdout);
       }
 
-      if (worker.getStderr()) {
-        stderr.add(worker.getStderr());
+      if (workerStderr) {
+        stderr.add(workerStderr);
       }
 
       workers[i] = worker;


### PR DESCRIPTION
As mentioned in https://github.com/facebook/jest/issues/4897#issuecomment-344918711, jest-worker runs in `silent` mode by default to be able to pipe everything to a stream.

Overriding the forkOptions with `silent: false` causes it to fail because the stream is not piped. This PR fixes this small issue, while keeping the same default behavior.

https://github.com/facebook/jest/issues/4897

```
TypeError: Cannot read property 'once' of null
    at PassThrough.add (/Users/rogelioguzman/dev/jest/node_modules/merge-stream/index.js:27:11)
    at new exports.default (/Users/rogelioguzman/dev/jest/packages/jest-worker/build/index.js:80:14)
    at BaseTestRunner.runTests (/Users/rogelioguzman/dev/create-jest-runner/build/createJestRunner.js:44:22)
    at /Users/rogelioguzman/dev/jest/packages/jest-cli/build/test_scheduler.js:157:39
    at Generator.next (<anonymous>)
    at step (/Users/rogelioguzman/dev/jest/packages/jest-cli/build/test_scheduler.js:29:405)
    at /Users/rogelioguzman/dev/jest/packages/jest-cli/build/test_scheduler.js:29:565
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7)
```

cc: @keplersj once this(or another fix for the issue) gets merged and published, I'll publish a new version of `create-jest-runner`, which should unblock https://github.com/keplersj/jest-runner-prettier