### PR TITLE
Remove gaps in the progress bar.

### DIFF
--- a/packages/jest-cli/src/reporters/utils.js
+++ b/packages/jest-cli/src/reporters/utils.js
@@ -181,8 +181,8 @@ const renderTime = (runTime, estimatedTime, width) => {
     if (availableWidth >= 2) {
       time +=
         '\n' +
-        chalk.green('█').repeat(length) +
-        chalk.white('█').repeat(availableWidth - length);
+        chalk.green.bgGreen('█').repeat(length) +
+        chalk.white.bgWhite('█').repeat(availableWidth - length);
     }
   }
   return time;


### PR DESCRIPTION
**Summary**

Since we changed the progress bar to improve accessibility we also added gaps in between the individual blocks. Adding a background color that is the same as the foreground color should get rid of those gaps.

Before:
<img width="962" alt="screen shot 2017-11-22 at 14 25 17" src="https://user-images.githubusercontent.com/13352/33132291-346086cc-cf91-11e7-8017-acc2fcbe1b54.png">

After:
<img width="962" alt="screen shot 2017-11-22 at 14 25 23" src="https://user-images.githubusercontent.com/13352/33132297-37ee93d8-cf91-11e7-954f-2266f2ab2c12.png">

This may not work if people have different background and foreground colors but I'd recommend just shipping this and then seeing if people run into this.

**Test plan**

Works on my terminal (iterm)