### PR TITLE
Inherit stdio for jest-runner

### DIFF
--- a/packages/jest-runner/src/index.js
+++ b/packages/jest-runner/src/index.js
@@ -95,6 +95,7 @@ class TestRunner {
     // $FlowFixMe: class object is augmented with worker when instantiating.
     const worker: WorkerInterface = new Worker(TEST_WORKER_PATH, {
       exposedMethods: ['worker'],
+      forkOptions: {stdio: 'inherit'},
       maxRetries: 3,
       numWorkers: this._globalConfig.maxWorkers,
     });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

**Summary**

When locally running tests, the IO differs between children and parent workers, resulting in Travis-on-master-like failures caused by suppressed colors. Inheriting the stdio for `jest-runner` workers fixes the thing. 

**Test plan**

Tests run fine locally.
