### PR TITLE
Fix errors when identity-obj-proxy mocks CSS Modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Fixes
 
+* `[pretty-format]` Fix errors when identity-obj-proxy mocks CSS Modules
+  ([#4935](https://github.com/facebook/jest/pull/4935))
 * `[babel-jest]` Fix support for namespaced babel version 7
   ([#4918](https://github.com/facebook/jest/pull/4918))
 * `[expect]` fix .toThrow for promises

--- a/packages/pretty-format/src/__tests__/immutable.test.js
+++ b/packages/pretty-format/src/__tests__/immutable.test.js
@@ -21,6 +21,15 @@ const toPrettyPrintTo = getPrettyPrint([ReactElement, ImmutablePlugin]);
 const expect = global.expect;
 expect.extend({toPrettyPrintTo});
 
+it('does not incorrectly match identity-obj-proxy as Immutable object', () => {
+  // SENTINEL constant is from https://github.com/facebook/immutable-js
+  const IS_ITERABLE_SENTINEL = '@@__IMMUTABLE_ITERABLE__@@';
+  const val = {};
+  val[IS_ITERABLE_SENTINEL] = IS_ITERABLE_SENTINEL; // mock the mock object :)
+  const expected = `{"${IS_ITERABLE_SENTINEL}": "${IS_ITERABLE_SENTINEL}"}`;
+  expect(val).toPrettyPrintTo(expected, {min: true});
+});
+
 describe('Immutable.OrderedSet', () => {
   it('supports an empty collection {min: true}', () => {
     expect(Immutable.OrderedSet([])).toPrettyPrintTo(

--- a/packages/pretty-format/src/__tests__/pretty_format.test.js
+++ b/packages/pretty-format/src/__tests__/pretty_format.test.js
@@ -649,6 +649,17 @@ describe('prettyFormat()', () => {
     expect(prettyFormat(Object.create(null))).toEqual('Object {}');
   });
 
+  it('prints identity-obj-proxy with string constructor', () => {
+    const val = Object.create(null);
+    val.constructor = 'constructor'; // mock the mock object :)
+    const expected = [
+      'Object {', // Object instead of undefined
+      '  "constructor": "constructor",',
+      '}',
+    ].join('\n');
+    expect(prettyFormat(val)).toEqual(expected);
+  });
+
   it('calls toJSON and prints its return value', () => {
     expect(
       prettyFormat({

--- a/packages/pretty-format/src/index.js
+++ b/packages/pretty-format/src/index.js
@@ -41,6 +41,11 @@ const errorToString = Error.prototype.toString;
 const regExpToString = RegExp.prototype.toString;
 const symbolToString = Symbol.prototype.toString;
 
+// Explicitly comparing typeof constructor to function avoids undefined as name
+// when mock identity-obj-proxy returns the key as the value for any key.
+const getConstructorName = val =>
+  (typeof val.constructor === 'function' && val.constructor.name) || 'Object';
+
 // Is val is equal to global window object? Works even if it does not exist :)
 /* global window */
 const isWindow = val => typeof window !== 'undefined' && val === window;
@@ -239,8 +244,8 @@ function printComplexValue(
   // Avoid failure to serialize global window object in jsdom test environment.
   // For example, not even relevant if window is prop of React element.
   return hitMaxDepth || isWindow(val)
-    ? '[' + (val.constructor ? val.constructor.name : 'Object') + ']'
-    : (min ? '' : (val.constructor ? val.constructor.name : 'Object') + ' ') +
+    ? '[' + getConstructorName(val) + ']'
+    : (min ? '' : getConstructorName(val) + ' ') +
         '{' +
         printObjectProperties(val, config, indentation, depth, refs, printer) +
         '}';

--- a/packages/pretty-format/src/plugins/immutable.js
+++ b/packages/pretty-format/src/plugins/immutable.js
@@ -235,7 +235,10 @@ export const serialize = (
   return printImmutableRecord(val, config, indentation, depth, refs, printer);
 };
 
+// Explicitly comparing sentinel properties to true avoids false positive
+// when mock identity-obj-proxy returns the key as the value for any key.
 export const test = (val: any) =>
-  val && (val[IS_ITERABLE_SENTINEL] || val[IS_RECORD_SENTINEL]);
+  val &&
+  (val[IS_ITERABLE_SENTINEL] === true || val[IS_RECORD_SENTINEL] === true);
 
 export default ({serialize, test}: NewPlugin);


### PR DESCRIPTION
**Summary**

Fixes #4580 and #4922

Because the mock identity object for CSS Modules returns the key as the value for **any** key:

* Comparing sentinel properties to `true` avoids **false positive** in `Immutable` plugin `test` method
* Comparing `val.constructor === 'function'` avoids **undefined** as name of object

See [Mocking CSS Modules](http://facebook.github.io/jest/docs/en/webpack.html#mocking-css-modules)

**Test plan**

Added 2 tests which failed before changes to code, and then fixed them to fail for right reason :)