### PR TITLE
Update Repl.it urls to use direct Url

### DIFF
--- a/website/blog/2017-01-30-a-great-developer-experience.md
+++ b/website/blog/2017-01-30-a-great-developer-experience.md
@@ -68,7 +68,7 @@ installing it, you can easily do so below or directly from the Jest homepage. Go
 ahead and give it a try!
 
 <div class="jest-repl">
-  <iframe src="https://repl.it/languages/jest?lite=true"></iframe>
+  <iframe src="https://repl.it/@amasad/try-jest?lite=true"></iframe>
 </div>
 
 ## Get involved

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -277,7 +277,7 @@ class Index extends React.Component {
                 </div>
               </div>
               <div className="jest-repl">
-                <iframe src="https://repl.it/languages/jest?lite=true" />
+                <iframe src="https://repl.it/@amasad/try-jest?lite=true" />
               </div>
             </div>
           </Container>


### PR DESCRIPTION
We recently [changed Repl.it](https://repl.it/site/blog/new_repls) so that repls are auto-saved. That also means that we create a repl every time someone goes to `repl.it/languages/<language>`.

So right now every time the Jest homepage is loaded we're creating a new repl. Instead I'm changing this to link to a pre-existing one I created. Folks who click "open in repl.it" will then be able to fork it and do whatever with it.