### PR TITLE
Add an extra option to inform that a module is a core NodeJS module

### DIFF
--- a/packages/jest-runtime/src/__tests__/script_transformer.test.js
+++ b/packages/jest-runtime/src/__tests__/script_transformer.test.js
@@ -167,6 +167,7 @@ describe('ScriptTransformer', () => {
   };
 
   beforeEach(reset);
+  afterEach(() => jest.unmock('../should_instrument'));
 
   it('transforms a file properly', () => {
     const scriptTransformer = new ScriptTransformer(config);
@@ -201,6 +202,26 @@ describe('ScriptTransformer', () => {
     // If we disable coverage, we get a different result.
     scriptTransformer.transform('/fruits/kiwi.js', {collectCoverage: false});
     expect(vm.Script.mock.calls[1][0]).toEqual(snapshot);
+  });
+
+  it('does not transform Node core modules', () => {
+    jest.mock('../should_instrument');
+
+    const shouldInstrument = require('../should_instrument').default;
+    const scriptTransformer = new ScriptTransformer(config);
+    const fsSourceCode = process.binding('natives').fs;
+
+    const response = scriptTransformer.transform(
+      'fs',
+      {isCoreModule: true},
+      fsSourceCode,
+    ).script;
+
+    expect(response instanceof vm.Script).toBe(true);
+    expect(vm.Script.mock.calls[0][0]).toContain(fsSourceCode);
+
+    // Native files should never be transformed.
+    expect(shouldInstrument.mock.calls.length).toBe(0);
   });
 
   it(


### PR DESCRIPTION
This PR adds an extra, optional parameter, into the `Options` object passed to `transform`. The option is named `isCoreModule`, and it is intended to be used later by the re-injection of native modules inside the contexts.

It is required to ensure that modules are never transformed or instrumented, but that they are wrapped and returned as a `vm.Script` instance.