### PR TITLE
put npm install command within quotes in the doc

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -88,7 +88,7 @@ npm install --save-dev babel-jest babel-core regenerator-runtime
 > with the following command:
 >
 > ```
-> npm install --save-dev babel-jest babel-core@^7.0.0-0 @babel/core regenerator-runtime
+> npm install --save-dev babel-jest 'babel-core@^7.0.0-0' @babel/core regenerator-runtime
 > ```
 
 _Note: Explicitly installing `regenerator-runtime` is not needed if you use


### PR DESCRIPTION
In some shells like zsh, copying and pasting 
```
npm install --save-dev babel-jest babel-core@^7.0.0-0 @babel/core
```

Might produce:

```
zsh: no matches found: babel-core@^7.0.0-0
```

Which can lead to confusion, so placing it under quotes might help
