### PR TITLE
Improve process object creation

### DIFF
--- a/packages/jest-haste-map/src/crawlers/__tests__/node.test.js
+++ b/packages/jest-haste-map/src/crawlers/__tests__/node.test.js
@@ -77,6 +77,9 @@ describe('node crawler', () => {
   beforeEach(() => {
     jest.resetModules();
 
+    // Remove the "process.platform" property descriptor so it can be writable.
+    delete process.platform;
+
     mockResponse = [
       '/fruits/pear.js',
       '/fruits/strawberry.js',

--- a/packages/jest-util/src/__tests__/deep_cyclic_copy.test.js
+++ b/packages/jest-util/src/__tests__/deep_cyclic_copy.test.js
@@ -61,3 +61,18 @@ it('handles cyclic dependencies', () => {
   expect(copy.bar).toEqual(copy);
   expect(copy.subcycle.baz).toEqual(copy);
 });
+
+it('uses the blacklist to avoid copying properties on the first level', () => {
+  const obj = {
+    blacklisted: 41,
+    subObj: {
+      blacklisted: 42,
+    },
+  };
+
+  expect(deepCyclicCopy(obj, new Set(['blacklisted']))).toEqual({
+    subObj: {
+      blacklisted: 42,
+    },
+  });
+});

--- a/packages/jest-util/src/create_process_object.js
+++ b/packages/jest-util/src/create_process_object.js
@@ -9,11 +9,12 @@
 
 import deepCyclicCopy from './deep_cyclic_copy';
 
+const BLACKLIST = new Set(['mainModule']);
+
 export default function() {
   const process = require('process');
-  const newProcess = deepCyclicCopy(process);
+  const newProcess = deepCyclicCopy(process, BLACKLIST);
 
-  // $FlowFixMe: Add the symbol for toString objects.
   newProcess[Symbol.toStringTag] = 'process';
 
   // Sequentially execute all constructors over the object.

--- a/packages/jest-util/src/deep_cyclic_copy.js
+++ b/packages/jest-util/src/deep_cyclic_copy.js
@@ -7,54 +7,81 @@
  * @flow
  */
 
+const EMPTY = new Set();
+
+// Node 6 does not have gOPDs, so we define a simple polyfill for it.
+if (!Object.getOwnPropertyDescriptors) {
+  // $FlowFixMe: polyfill
+  Object.getOwnPropertyDescriptors = obj => {
+    const list = {};
+
+    Object.getOwnPropertyNames(obj)
+      .concat(Object.getOwnPropertySymbols(obj))
+      // $FlowFixMe: assignment with a Symbol is OK.
+      .forEach(key => (list[key] = Object.getOwnPropertyDescriptor(obj, key)));
+
+    return list;
+  };
+}
+
 export default function deepCyclicCopy(
-  object: any,
+  value: any,
+  blacklist: Set<string> = EMPTY,
   cycles: WeakMap<any, any> = new WeakMap(),
-) {
-  if (typeof object !== 'object' || object === null) {
-    return object;
-  }
-
-  let newObject;
-
-  if (Array.isArray(object)) {
-    newObject = [];
+): any {
+  if (typeof value !== 'object' || value === null) {
+    return value;
+  } else if (cycles.has(value)) {
+    return cycles.get(value);
+  } else if (Array.isArray(value)) {
+    return deepCyclicCopyArray(value, blacklist, cycles);
   } else {
-    newObject = Object.create(Object.getPrototypeOf(object));
+    return deepCyclicCopyObject(value, blacklist, cycles);
   }
+}
+
+function deepCyclicCopyObject(
+  object: Object,
+  blacklist: Set<string>,
+  cycles: WeakMap<any, any>,
+): Object {
+  const newObject = Object.create(Object.getPrototypeOf(object));
+  // $FlowFixMe: Object.getOwnPropertyDescriptors is polyfilled above.
+  const descriptors = Object.getOwnPropertyDescriptors(object);
 
   cycles.set(object, newObject);
 
-  // Copying helper function. Checks into the weak map passed to manage cycles.
-  const copy = (key: string | Symbol) => {
-    const descriptor = Object.getOwnPropertyDescriptor(object, key);
-    const value = descriptor.value;
-
-    if (descriptor.hasOwnProperty('value')) {
-      if (cycles.has(value)) {
-        descriptor.value = cycles.get(value);
-      } else {
-        descriptor.value = deepCyclicCopy(value, cycles);
-      }
-
-      // Allow tests to override whatever they need.
-      descriptor.writable = true;
+  Object.keys(descriptors).forEach(key => {
+    if (blacklist.has(key)) {
+      delete descriptors[key];
+      return;
     }
 
-    // Allow tests to override whatever they need.
+    const descriptor = descriptors[key];
+
+    if (typeof descriptor.value !== 'undefined') {
+      descriptor.value = deepCyclicCopy(descriptor.value, EMPTY, cycles);
+    }
+
     descriptor.configurable = true;
+  });
 
-    try {
-      Object.defineProperty(newObject, key, descriptor);
-    } catch (err) {
-      // Do nothing; this usually fails because a non-configurable property is
-      // tried to be overridden with a configurable one (e.g. "length").
-    }
-  };
+  return Object.defineProperties(newObject, descriptors);
+}
 
-  // Copy string and symbol keys!
-  Object.getOwnPropertyNames(object).forEach(copy);
-  Object.getOwnPropertySymbols(object).forEach(copy);
+function deepCyclicCopyArray(
+  array: Array<any>,
+  blacklist: Set<string>,
+  cycles: WeakMap<any, any>,
+): Array<any> {
+  const newArray = [];
+  const length = array.length;
 
-  return newObject;
+  cycles.set(array, newArray);
+
+  for (let i = 0; i < length; i++) {
+    newArray[i] = deepCyclicCopy(array[i], EMPTY, cycles);
+  }
+
+  return newArray;
 }


### PR DESCRIPTION
This PR improves the way the `process` object is created in two ways:

1. It aims to rewrite the way deep cyclic cloning is done:
    1. It uses a specialized method for `Array`s.
    2. It copies properties by using `getOwnPropertyDescriptors` and `defineProperties`.
    3. It gives a blacklist argument for the root level object.
​
2. Using the blacklist, it avoids copying `mainModule`, which contains a reference to the main module, plus all of the other modules loaded so far in memory.

The total improvement on a raw Node instance is approximately of 40%; but the improvement grows as the amount of previously loaded modules also grows. In my case, I've been able to observe up to 20x performance by artificially loading a bunch of modules before calling `createProcessObject`.