### PR TITLE
Make "weak" optional dependency and check it at runtime

### DIFF
--- a/packages/jest-leak-detector/package.json
+++ b/packages/jest-leak-detector/package.json
@@ -8,7 +8,9 @@
   "license": "MIT",
   "main": "build/index.js",
   "dependencies": {
-    "pretty-format": "^21.2.1",
+    "pretty-format": "^21.2.1"
+  },
+  "optionalDependencies": {
     "weak": "^1.0.1"
   }
 }

--- a/packages/jest-leak-detector/src/index.js
+++ b/packages/jest-leak-detector/src/index.js
@@ -40,8 +40,8 @@ export default class {
       weak = require('weak');
     } catch (err) {
       throw new Error(
-        'The leaking detection mechanism requires "weak" to work. ' +
-          'Please make sure that you can install the native dependency on your platform',
+        'The leaking detection mechanism requires the "weak" package to work. ' +
+          'Please make sure that you can install the native dependency on your platform.',
       );
     }
 

--- a/packages/jest-leak-detector/src/index.js
+++ b/packages/jest-leak-detector/src/index.js
@@ -12,7 +12,6 @@
 import prettyFormat from 'pretty-format';
 import v8 from 'v8';
 import vm from 'vm';
-import weak from 'weak';
 
 const PRIMITIVE_TYPES = new Set([
   'undefined',
@@ -32,6 +31,17 @@ export default class {
           'Primitives cannot leak memory.',
           'You passed a ' + typeof value + ': <' + prettyFormat(value) + '>',
         ].join(' '),
+      );
+    }
+
+    let weak;
+
+    try {
+      weak = require('weak');
+    } catch (err) {
+      throw new Error(
+        'The leaking detection mechanism requires "weak" to work. ' +
+          'Please make sure that you can install the native dependency on your platform',
       );
     }
 


### PR DESCRIPTION
On systems that do not support Node bindings, adding `weak` as a dependency will make it crash. Since most of the times `jest-leak-detector` is not used at all, making the dependency optional and delaying its instantiation will fix the issue.

Tested by running `./jest jest-leak-detector`.