### PR TITLE
Update Troubleshooting.md

### DIFF
--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -94,6 +94,28 @@ following configuration:
 }
 ```
 
+or the following for Windows:
+
+```json
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug Jest Tests",
+      "type": "node",
+      "request": "launch",
+      "runtimeArgs": [
+        "--inspect-brk",
+        "${workspaceRoot}/node_modules/jest/bin/jest.js",
+        "--runInBand"
+      ],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen"
+    }
+  ]
+}
+```
+
 If you are using Facebook's
 [`create-react-app`](https://github.com/facebookincubator/create-react-app), you
 can debug your Jest tests with the following configuration:


### PR DESCRIPTION
Instructions for automatic launching of debugger are for Linux only. Added one more block for Windows.

**Summary**

Since the documentation was suggesting to do either the manual or the automatic launching, I decided to go with automatic and just pasted the suggested configuration in my launch.json file. However that configuration works on linux only.