### PR TITLE
Update Timeout error message to `jest.timeout` and display current timeout value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@
 
 ### Features
 
+* `[jest-jasmine2]` Update Timeout error message to `jest.timeout` and display current timeout value
+  ([#4990](https://github.com/facebook/jest/pull/4990))
 * `[jest-runner]` Enable experimental detection of leaked contexts
   ([#4895](https://github.com/facebook/jest/pull/4895))
 * `[jest-cli]` Add combined coverage threshold for directories.

--- a/integration_tests/__tests__/jasmine_async.test.js
+++ b/integration_tests/__tests__/jasmine_async.test.js
@@ -25,7 +25,7 @@ describe('async jasmine', () => {
 
     const {message} = json.testResults[0];
     expect(message).toMatch('with failing timeout');
-    expect(message).toMatch('Async callback was not invoked within timeout');
+    expect(message).toMatch('Async callback was not invoked within');
     expect(message).toMatch('done - with error thrown');
     expect(message).toMatch('done - with error called back');
   });

--- a/integration_tests/__tests__/timeouts.test.js
+++ b/integration_tests/__tests__/timeouts.test.js
@@ -36,7 +36,9 @@ test('exceeds the timeout', () => {
 
   const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false']);
   const {rest, summary} = extractSummary(stderr);
-  expect(rest).toMatch(/(jasmine\.DEFAULT_TIMEOUT_INTERVAL|Exceeded timeout)/);
+  expect(rest).toMatch(
+    /(jest\.setTimeout|jasmine\.DEFAULT_TIMEOUT_INTERVAL|Exceeded timeout)/,
+  );
   expect(summary).toMatchSnapshot();
   expect(status).toBe(1);
 });

--- a/packages/jest-jasmine2/src/__tests__/queue_runner.test.js
+++ b/packages/jest-jasmine2/src/__tests__/queue_runner.test.js
@@ -112,7 +112,7 @@ describe('queueRunner', () => {
     // i.e. the `message` of the error passed to `onException`.
     expect(onException.mock.calls[0][0].message).toEqual(
       'Timeout - Async callback was not invoked within timeout specified ' +
-        'by jasmine.DEFAULT_TIMEOUT_INTERVAL.',
+        'by jest.setTimeout: 0ms.',
     );
     expect(fnTwo).toHaveBeenCalled();
   });

--- a/packages/jest-jasmine2/src/__tests__/queue_runner.test.js
+++ b/packages/jest-jasmine2/src/__tests__/queue_runner.test.js
@@ -111,8 +111,8 @@ describe('queueRunner', () => {
     expect(onException).toHaveBeenCalled();
     // i.e. the `message` of the error passed to `onException`.
     expect(onException.mock.calls[0][0].message).toEqual(
-      'Timeout - Async callback was not invoked within timeout specified ' +
-        'by jest.setTimeout: 0ms.',
+      'Timeout - Async callback was not invoked within the 0ms timeout ' +
+        'specified by jest.setTimeout.',
     );
     expect(fnTwo).toHaveBeenCalled();
   });

--- a/packages/jest-jasmine2/src/queue_runner.js
+++ b/packages/jest-jasmine2/src/queue_runner.js
@@ -55,15 +55,17 @@ export default function queueRunner(options: Options) {
     if (!timeout) {
       return promise;
     }
+    const timeoutMs: number = timeout();
     return pTimeout(
       promise,
-      timeout(),
+      timeoutMs,
       options.clearTimeout,
       options.setTimeout,
       () => {
         const error = new Error(
-          'Timeout - Async callback was not invoked within timeout specified ' +
-            'by jasmine.DEFAULT_TIMEOUT_INTERVAL.',
+          'Timeout - Async callback was not invoked within timeout specified by jest.setTimeout: ' +
+            timeoutMs +
+            'ms.',
         );
         options.onException(error);
       },

--- a/packages/jest-jasmine2/src/queue_runner.js
+++ b/packages/jest-jasmine2/src/queue_runner.js
@@ -63,9 +63,9 @@ export default function queueRunner(options: Options) {
       options.setTimeout,
       () => {
         const error = new Error(
-          'Timeout - Async callback was not invoked within timeout specified by jest.setTimeout: ' +
+          'Timeout - Async callback was not invoked within the ' +
             timeoutMs +
-            'ms.',
+            'ms timeout specified by jest.setTimeout.',
         );
         options.onException(error);
       },


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

### Current timeout message
> Timeout - Async callback was not invoked within timeout specified by jasmine.DEFAULT_TIMEOUT_INTERVAL.

* Using old `jasmine.DEFAULT_TIMEOUT_INTERVAL` api.
* Does not say how long the timeout is.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

### New timeout message
> Timeout - Async callback was not invoked within the 5000ms timeout specified by jest.setTimeout.

Improved developer usability and understanding.

* Updated API method `jest.setTimeout`.
* Shows the value of `timeout` used.

## Test plan

Updated test in `queue_runner`.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
