### PR TITLE
fix: jest-util should not depend on jest-mock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,8 @@
 
 ### Chore & Maintenance
 
+* `[jest-util]` `jest-util` should not depend on `jest-mock`
+  ([#4992](https://github.com/facebook/jest/pull/4992))
 * `[*]` [**BREAKING**] Drop support for Node.js version 4
   ([#4769](https://github.com/facebook/jest/pull/4769))
 * `[docs]` Wrap code comments at 80 characters

--- a/packages/jest-util/package.json
+++ b/packages/jest-util/package.json
@@ -12,8 +12,10 @@
     "chalk": "^2.0.1",
     "graceful-fs": "^4.1.11",
     "jest-message-util": "^21.2.1",
-    "jest-mock": "^21.2.0",
     "jest-validate": "^21.2.1",
     "mkdirp": "^0.5.1"
+  },
+  "devDependencies": {
+    "jest-mock": "^21.2.0"
   }
 }

--- a/packages/jest-util/src/fake_timers.js
+++ b/packages/jest-util/src/fake_timers.js
@@ -9,7 +9,7 @@
 
 import type {ProjectConfig} from 'types/Config';
 import type {Global} from 'types/Global';
-import type {ModuleMocker} from 'jest-mock';
+import type {ModuleMocker} from 'types/Mock';
 
 import {formatStackTrace} from 'jest-message-util';
 import setGlobal from './set_global';


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

**Summary**
`jest-util` should not depend on `jest-mock`.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
Green CI
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
