### PR TITLE
Emphasise required return

### DIFF
--- a/docs/ExpectAPI.md
+++ b/docs/ExpectAPI.md
@@ -395,6 +395,8 @@ test('resolves to lemon', () => {
 });
 ```
 
+Note that, since you are still testing promises, the test is still asynchronous. Hence, you will need to [tell Jest to wait](TestingAsyncCode.md#promises) by returning the unwrapped assertion.
+
 Alternatively, you can use `async/await` in combination with `.resolves`:
 
 ```js
@@ -421,6 +423,8 @@ test('rejects to octopus', () => {
   );
 });
 ```
+
+Note that, since you are still testing promises, the test is still asynchronous. Hence, you will need to [tell Jest to wait](TestingAsyncCode.md#promises) by returning the unwrapped assertion.
 
 Alternatively, you can use `async/await` in combination with `.rejects`.
 


### PR DESCRIPTION
**Summary**

Emphasise that `.rejects` and `.resolves` still require the assertion to be returned, in response to #4997.

**Test plan**

Validated output was valid at least [in GitHub's Markdown renderer](https://github.com/Vinnl/jest/blob/08a7a8505716fc85270ea78abb940d124336ed15/docs/ExpectAPI.md#resolves).
