### PR TITLE
Use realpath to match transformers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@
   issue. ([#4669](https://github.com/facebook/jest/pull/4669))
 * `[jest-cli]` Fix `--onlyChanged` path case sensitivity on Windows platform
   ([#4730](https://github.com/facebook/jest/pull/4730))
+* `[jest-runtime]` Use realpath to match transformers
+  ([#5000](https://github.com/facebook/jest/pull/5000))
 
 ### Features
 

--- a/integration_tests/__tests__/transform-linked-modules.test.js
+++ b/integration_tests/__tests__/transform-linked-modules.test.js
@@ -1,0 +1,12 @@
+// @flow
+
+'use strict';
+
+const runJest = require('../runJest');
+
+it('should transform linked modules', () => {
+  const result = runJest.json('transform-linked-modules', ['--no-cache']).json;
+
+  expect(result.success).toBe(true);
+  expect(result.numTotalTests).toBe(2);
+});

--- a/integration_tests/transform-linked-modules/__tests__/linked-modules.test.js
+++ b/integration_tests/transform-linked-modules/__tests__/linked-modules.test.js
@@ -1,0 +1,9 @@
+test('normal file', () => {
+  const normal = require('../ignored/normal');
+  expect(normal).toEqual('ignored/normal');
+});
+
+test('symlink', () => {
+  const symlink = require('../ignored/symlink');
+  expect(symlink).toEqual('transformed');
+});

--- a/integration_tests/transform-linked-modules/ignored/normal.js
+++ b/integration_tests/transform-linked-modules/ignored/normal.js
@@ -1,0 +1,1 @@
+module.exports = 'ignored/normal';

--- a/integration_tests/transform-linked-modules/ignored/symlink.js
+++ b/integration_tests/transform-linked-modules/ignored/symlink.js
@@ -1,0 +1,1 @@
+../package/index.js

--- a/integration_tests/transform-linked-modules/package.json
+++ b/integration_tests/transform-linked-modules/package.json
@@ -1,0 +1,13 @@
+{
+  "jest": {
+    "testEnvironment": "node",
+    "transformIgnorePatterns": [
+      "/node_modules/",
+      "<rootDir>/__tests__",
+      "<rootDir>/ignored/"
+    ],
+    "transform": {
+      "^.+\\.js$": "<rootDir>/preprocessor.js"
+    }
+  }
+}

--- a/integration_tests/transform-linked-modules/package/index.js
+++ b/integration_tests/transform-linked-modules/package/index.js
@@ -1,0 +1,1 @@
+module.exports = 'package/index';

--- a/integration_tests/transform-linked-modules/preprocessor.js
+++ b/integration_tests/transform-linked-modules/preprocessor.js
@@ -1,0 +1,5 @@
+module.exports = {
+  process() {
+    return 'module.exports = "transformed"';
+  },
+};

--- a/packages/jest-runtime/src/script_transformer.js
+++ b/packages/jest-runtime/src/script_transformer.js
@@ -19,6 +19,7 @@ import path from 'path';
 import vm from 'vm';
 import {createDirectory} from 'jest-util';
 import fs from 'graceful-fs';
+import nodeFS from 'fs';
 import {transform as babelTransform} from 'babel-core';
 import babelPluginIstanbul from 'babel-plugin-istanbul';
 import convertSourceMap from 'convert-source-map';
@@ -182,13 +183,22 @@ export default class ScriptTransformer {
     }).code;
   }
 
+  _getRealPath(filepath: Path): Path {
+    try {
+      // $FlowFixMe
+      return process.binding('fs').realpath(filepath) || filepath;
+    } catch (err) {
+      return filepath;
+    }
+  }
+
   transformSource(
     filepath: Path,
     content: string,
     instrument: boolean,
     mapCoverage: boolean,
   ) {
-    const filename = fs.realpathSync(filepath) || filepath;
+    const filename = this._getRealPath(filepath);
     const transform = this._getTransformer(filename);
     const cacheFilePath = this._getFileCachePath(
       filename,

--- a/packages/jest-runtime/src/script_transformer.js
+++ b/packages/jest-runtime/src/script_transformer.js
@@ -19,7 +19,6 @@ import path from 'path';
 import vm from 'vm';
 import {createDirectory} from 'jest-util';
 import fs from 'graceful-fs';
-import nodeFS from 'fs';
 import {transform as babelTransform} from 'babel-core';
 import babelPluginIstanbul from 'babel-plugin-istanbul';
 import convertSourceMap from 'convert-source-map';

--- a/packages/jest-runtime/src/script_transformer.js
+++ b/packages/jest-runtime/src/script_transformer.js
@@ -183,11 +183,12 @@ export default class ScriptTransformer {
   }
 
   transformSource(
-    filename: Path,
+    filepath: Path,
     content: string,
     instrument: boolean,
     mapCoverage: boolean,
   ) {
+    const filename = fs.realpathSync(filepath) || filepath;
     const transform = this._getTransformer(filename);
     const cacheFilePath = this._getFileCachePath(
       filename,


### PR DESCRIPTION
**Summary**

This will use the realpath to match the transformers in case the path
is a symlink. This will solve an issue where files which are linked by
lerna or npm link are not transformed.

Currently a solution for this problem would be a configuration like:
```json
{
  "transformIgnorePatterns": [
    "<rootDir>/node_modules/"
  ]
}
```