### PR TITLE
Ensure thrown error is related to module not found

### DIFF
--- a/packages/jest-leak-detector/src/index.js
+++ b/packages/jest-leak-detector/src/index.js
@@ -39,6 +39,10 @@ export default class {
     try {
       weak = require('weak');
     } catch (err) {
+      if (!err || (err.code !== 'MODULE_NOT_FOUND')) {
+        throw err;
+      }
+
       throw new Error(
         'The leaking detection mechanism requires the "weak" package to work. ' +
           'Please make sure that you can install the native dependency on your platform.',


### PR DESCRIPTION
Make sure that the error we got is related to `MODULE_NOT_FOUND` to show a meaningful message. If not, throw the error as-is.