### PR TITLE
Upgrade "jsdom" to the latest version (11.5.1)

### DIFF
--- a/packages/jest-environment-jsdom/package.json
+++ b/packages/jest-environment-jsdom/package.json
@@ -10,6 +10,6 @@
   "dependencies": {
     "jest-mock": "^21.2.0",
     "jest-util": "^21.2.1",
-    "jsdom": "^11.4.0"
+    "jsdom": "^11.5.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3789,9 +3789,9 @@ jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
 
-jsdom@^11.4.0:
-  version "11.4.0"
-  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-11.4.0.tgz#a3941a9699cbb0d61f8ab86f6f28f4ad5ea60d04"
+jsdom@^11.5.1:
+  version "11.5.1"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-11.5.1.tgz#5df753b8d0bca20142ce21f4f6c039f99a992929"
   dependencies:
     abab "^1.0.3"
     acorn "^5.1.2"
@@ -3804,6 +3804,7 @@ jsdom@^11.4.0:
     domexception "^1.0.0"
     escodegen "^1.9.0"
     html-encoding-sniffer "^1.0.1"
+    left-pad "^1.2.0"
     nwmatcher "^1.4.3"
     parse5 "^3.0.2"
     pn "^1.0.0"
@@ -3986,7 +3987,7 @@ lcid@^1.0.0:
   dependencies:
     invert-kv "^1.0.0"
 
-left-pad@^1.1.1:
+left-pad@^1.1.1, left-pad@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.2.0.tgz#d30a73c6b8201d8f7d8e7956ba9616087a68e0ee"
 


### PR DESCRIPTION
`jsdom` in `11.4.0` has a bug related to how the `files` property is treated in `<input type="file">`'s. This got fixed by the awesome JSDOM folks in https://github.com/tmpvar/jsdom/issues/2063; so upgrading will fix the issue for us as well.