### PR TITLE
Fix watch mode when a pattern is passed

### DIFF
--- a/packages/jest-config/src/normalize.js
+++ b/packages/jest-config/src/normalize.js
@@ -513,9 +513,8 @@ export default function normalize(options: InitialOptions, argv: Argv) {
   if (argv.all) {
     newOptions.onlyChanged = false;
   } else if (newOptions.testPathPattern) {
-    // If you pass a test path pattern, you probably don't want to only monitor
-    // changed files; unless you are also passing "--watch". That's why the
-    // "onlyChanged" value has to equal the one in "watch".
+    // When passing a test path pattern we don't want to only monitor changed
+    // files unless `--watch` is also passed.
     newOptions.onlyChanged = newOptions.watch;
   }
 

--- a/packages/jest-config/src/normalize.js
+++ b/packages/jest-config/src/normalize.js
@@ -510,8 +510,13 @@ export default function normalize(options: InitialOptions, argv: Argv) {
 
   newOptions.testFailureExitCode = parseInt(newOptions.testFailureExitCode, 10);
 
-  if (argv.all || newOptions.testPathPattern) {
+  if (argv.all) {
     newOptions.onlyChanged = false;
+  } else if (newOptions.testPathPattern) {
+    // If you pass a test path pattern, you probably don't want to only monitor
+    // changed files; unless you are also passing "--watch". That's why the
+    // "onlyChanged" value has to equal the one in "watch".
+    newOptions.onlyChanged = newOptions.watch;
   }
 
   newOptions.updateSnapshot =


### PR DESCRIPTION
It makes sense to have `onlyChanged` set to false when we pass `all`; but when passing a `testPathPattern`, `onlyChanged` has to acquire the value of `watch`. This is needed so that `get_changed_files_promise.js` actually creates and returns the corresponding promise.