### PR TITLE
Fix test and improve process sandboxing

### DIFF
--- a/packages/jest-util/src/create_process_object.js
+++ b/packages/jest-util/src/create_process_object.js
@@ -9,7 +9,7 @@
 
 import deepCyclicCopy from './deep_cyclic_copy';
 
-const BLACKLIST = new Set(['mainModule']);
+const BLACKLIST = new Set(['mainModule', '_events']);
 
 export default function() {
   const process = require('process');


### PR DESCRIPTION
The native `EventEmitter` module will not create an `_events` collection, if there is already an existing one ([see code here](https://github.com/nodejs/node/blob/master/lib/events.js#L66-L69)).

This causes that the existing listeners are not re-initialized in the deep copied `process` object, so tests triggering listeners will also trigger the original Jest listeners. The fix is simple: avoid copying the `_events` property so the object gets re-initialized.

Also fixes the `./child` test from `jest-worker` when running in parallel mode.