### PR TITLE
Revert setRawMode on --watch quit (fixes #5028)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Fixes
 
+* `[jest-cli]` Fix inability to quit watch mode while debugger is still attached
+  ([#5029](https://github.com/facebook/jest/pull/5029))
 * `[jest-haste-map]` Properly handle platform-specific file deletions
   ([#5534](https://github.com/facebook/jest/pull/5534))
 

--- a/packages/jest-cli/src/plugins/quit.js
+++ b/packages/jest-cli/src/plugins/quit.js
@@ -10,6 +10,9 @@ import WatchPlugin from '../watch_plugin';
 
 class QuitPlugin extends WatchPlugin {
   async showPrompt() {
+    if (typeof this._stdin.setRawMode === 'function') {
+      this._stdin.setRawMode(false);
+    }
     this._stdout.write('\n');
     process.exit(0);
   }

--- a/packages/jest-cli/src/watch.js
+++ b/packages/jest-cli/src/watch.js
@@ -230,6 +230,9 @@ export default function watch(
 
   const onKeypress = (key: string) => {
     if (key === KEYS.CONTROL_C || key === KEYS.CONTROL_D) {
+      if (typeof stdin.setRawMode === 'function') {
+        stdin.setRawMode(false);
+      }
       outputStream.write('\n');
       exit(0);
       return;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

**Summary**

The issue is detailed in #5028.  The summary is that it's not possible to force Jest to quite while the inspector is still open when the `--watch` parameter is provided.

**Test plan**

There currently aren't any tests (that I could see) for handling the `q` key or `Ctrl-C`/`Ctrl-D`, nor for the setup of `stdin.setRawMode(true)`, so I didn't add any for this either.  However, it's a simple 2 lines of code and only runs on quit, so it's unlikely to cause any unwanted side-effects.
