### PR TITLE
Do not call toJSON recursively in pretty-format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Fixes
 
+* `[pretty-format]` Do not call toJSON recursively
+  ([#5044](https://github.com/facebook/jest/pull/5044))
 * `[pretty-format]` Fix errors when identity-obj-proxy mocks CSS Modules
   ([#4935](https://github.com/facebook/jest/pull/4935))
 * `[babel-jest]` Fix support for namespaced babel version 7
@@ -52,7 +54,7 @@
   ([#4730](https://github.com/facebook/jest/pull/4730))
 * `[jest-runtime]` Use realpath to match transformers
   ([#5000](https://github.com/facebook/jest/pull/5000))
-* `[expect]` [**BREAKING**] Replace identity equality with Object.is in toBe 
+* `[expect]` [**BREAKING**] Replace identity equality with Object.is in toBe
   matcher ([#4917](https://github.com/facebook/jest/pull/4917))
 
 ### Features
@@ -127,7 +129,7 @@
   environments ([#4958](https://github.com/facebook/jest/pull/4958))
 * `[jest-snapshot]` Promises support for `toThrowErrorMatchingSnapshot`
   ([#4946](https://github.com/facebook/jest/pull/4946))
-* `[jest-cli]` Explain which snapshots are obsolete 
+* `[jest-cli]` Explain which snapshots are obsolete
   ([#5005](https://github.com/facebook/jest/pull/5005))
 
 ### Chore & Maintenance

--- a/packages/pretty-format/src/__tests__/pretty_format.test.js
+++ b/packages/pretty-format/src/__tests__/pretty_format.test.js
@@ -687,13 +687,13 @@ describe('prettyFormat()', () => {
     ).toEqual('Object {\n  "toJSON": false,\n  "value": true,\n}');
   });
 
-  it('calls toJSON recursively', () => {
+  it('does not call toJSON recursively', () => {
     expect(
       prettyFormat({
         toJSON: () => ({toJSON: () => ({value: true})}),
         value: false,
       }),
-    ).toEqual('Object {\n  "value": true,\n}');
+    ).toEqual('Object {\n  "toJSON": [Function toJSON],\n}');
   });
 
   it('calls toJSON on Sets', () => {

--- a/packages/pretty-format/src/index.js
+++ b/packages/pretty-format/src/index.js
@@ -175,6 +175,7 @@ function printComplexValue(
   indentation: string,
   depth: number,
   refs: Refs,
+  hasCalledToJSON?: boolean,
 ): string {
   if (refs.indexOf(val) !== -1) {
     return '[Circular]';
@@ -189,9 +190,10 @@ function printComplexValue(
     config.callToJSON &&
     !hitMaxDepth &&
     val.toJSON &&
-    typeof val.toJSON === 'function'
+    typeof val.toJSON === 'function' &&
+    !hasCalledToJSON
   ) {
-    return printer(val.toJSON(), config, indentation, depth, refs);
+    return printer(val.toJSON(), config, indentation, depth, refs, true);
   }
 
   const toStringed = toString.call(val);
@@ -312,6 +314,7 @@ function printer(
   indentation: string,
   depth: number,
   refs: Refs,
+  hasCalledToJSON?: boolean,
 ): string {
   const plugin = findPlugin(config.plugins, val);
   if (plugin !== null) {
@@ -327,7 +330,14 @@ function printer(
     return basicResult;
   }
 
-  return printComplexValue(val, config, indentation, depth, refs);
+  return printComplexValue(
+    val,
+    config,
+    indentation,
+    depth,
+    refs,
+    hasCalledToJSON,
+  );
 }
 
 const DEFAULT_THEME: Theme = {

--- a/types/PrettyFormat.js
+++ b/types/PrettyFormat.js
@@ -78,6 +78,7 @@ export type Printer = (
   indentation: string,
   depth: number,
   refs: Refs,
+  hasCalledToJSON?: boolean,
 ) => string;
 
 export type Test = any => boolean;


### PR DESCRIPTION
Fixes #4956

If the returned value also has `toJSON` method:

* It can cause an error: Maximum call stack size exceeded
* It customizes stringification behavior beyond the contract with `JSON.stringify`: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#toJSON()_behavior

Can y’all think of another way to fix this?

I don’t think plugins need another arg. However, they can call printer with optional arg if needed.

**Test plan**

Updated title and expected result of existing test
