### PR TITLE
don't let source-map-support use xhr - 25-75% speed improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Fixes
 
+* `[jest-jasmine]` Register sourcemaps as node environment to improve performance with jsdom ([#5045](https://github.com/facebook/jest/pull/5045))
 * `[pretty-format]` Do not call toJSON recursively
   ([#5044](https://github.com/facebook/jest/pull/5044))
 * `[pretty-format]` Fix errors when identity-obj-proxy mocks CSS Modules
@@ -56,6 +57,7 @@
   ([#5000](https://github.com/facebook/jest/pull/5000))
 * `[expect]` [**BREAKING**] Replace identity equality with Object.is in toBe
   matcher ([#4917](https://github.com/facebook/jest/pull/4917))
+
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,6 @@
 * `[expect]` [**BREAKING**] Replace identity equality with Object.is in toBe
   matcher ([#4917](https://github.com/facebook/jest/pull/4917))
 
-
 ### Features
 
 * `[jest-config]` Add `testEnvironmentOptions` to apply to jsdom options or node context.

--- a/packages/jest-jasmine2/src/index.js
+++ b/packages/jest-jasmine2/src/index.js
@@ -115,6 +115,7 @@ async function jasmine2(
   runtime
     .requireModule(require.resolve('source-map-support'), 'source-map-support')
     .install({
+      environment: 'node',
       handleUncaughtExceptions: false,
       retrieveSourceMap: source => {
         if (runtime._sourceMapRegistry[source]) {


### PR DESCRIPTION

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

**Summary**

When jsdom is installed, source-map-support does this:
https://github.com/evanw/node-source-map-support/blob/master/source-map-support.js#L110

Which for me caused a massive slowdown. With this patch my tests go from 99s to 74s to run and an individual test suite 16s to 4s.

**Test plan**

Jest can only run in node - I am not sure this needs tests?