### PR TITLE
Escape Windows path separator in testPathPattern CLI arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Fixes
 
+* `[jest-config]` Escape Windows path separator in testPathPattern CLI arguments
+  ([#5054](https://github.com/facebook/jest/pull/5054)
 * `[jest-jasmine]` Register sourcemaps as node environment to improve performance with jsdom ([#5045](https://github.com/facebook/jest/pull/5045))
 * `[pretty-format]` Do not call toJSON recursively
   ([#5044](https://github.com/facebook/jest/pull/5044))

--- a/packages/jest-config/src/__tests__/__snapshots__/normalize.test.js.snap
+++ b/packages/jest-config/src/__tests__/__snapshots__/normalize.test.js.snap
@@ -67,3 +67,7 @@ exports[`testMatch throws if testRegex and testMatch are both specified 1`] = `
 <red>  https://facebook.github.io/jest/docs/configuration.html</>
 <red></>"
 `;
+
+exports[`testPathPattern <regexForTestFiles> ignores invalid regular expressions and logs a warning 1`] = `"<red>  Invalid testPattern a( supplied. Running all tests instead.</>"`;
+
+exports[`testPathPattern --testPathPattern ignores invalid regular expressions and logs a warning 1`] = `"<red>  Invalid testPattern a( supplied. Running all tests instead.</>"`;

--- a/packages/jest-config/src/__tests__/normalize.test.js
+++ b/packages/jest-config/src/__tests__/normalize.test.js
@@ -1041,7 +1041,7 @@ describe('testPathPattern', () => {
   }
 
   beforeEach(() => {
-    console.log = jest.fn()
+    console.log = jest.fn();
   });
 
   afterEach(() => {

--- a/packages/jest-config/src/__tests__/normalize.test.js
+++ b/packages/jest-config/src/__tests__/normalize.test.js
@@ -1031,6 +1031,15 @@ describe('testPathPattern', () => {
   const initialOptions = {rootDir: '/root'};
   const consoleLog = console.log;
 
+  function testWindowsPathSeparator(argv, expected) {
+    jest.resetModules();
+    jest.mock('path', () => require.requireActual('path').win32);
+    require('jest-resolve').findNodeModule = findNodeModule;
+
+    const {options} = require('../normalize').default(initialOptions, argv);
+    expect(options.testPathPattern).toBe(expected);
+  }
+
   beforeEach(() => {
     console.log = jest.fn()
   });
@@ -1046,8 +1055,8 @@ describe('testPathPattern', () => {
 
   describe('--testPathPattern', () => {
     it('uses testPathPattern if set', () => {
-      const {options} = normalize(initialOptions, {testPathPattern: 'a'});
-      expect(options.testPathPattern).toBe('a');
+      const {options} = normalize(initialOptions, {testPathPattern: 'a/b'});
+      expect(options.testPathPattern).toBe('a/b');
     });
 
     it('ignores invalid regular expressions and logs a warning', () => {
@@ -1057,17 +1066,14 @@ describe('testPathPattern', () => {
     });
 
     it('escapes Windows path separators', () => {
-      jest.resetModules()
-      jest.mock('path', () => require.requireActual('path').win32)
-      const {options} = require('../normalize').default(initialOptions, {testPathPattern: 'a\\b'});
-      expect(options.testPathPattern).toBe('a\\\\b');
+      testWindowsPathSeparator({testPathPattern: 'a\\b'}, 'a\\\\b');
     });
   });
 
   describe('<regexForTestFiles>', () => {
     it('uses <regexForTestFiles> if set', () => {
-      const {options} = normalize(initialOptions, {_: ['a']});
-      expect(options.testPathPattern).toBe('a');
+      const {options} = normalize(initialOptions, {_: ['a/b']});
+      expect(options.testPathPattern).toBe('a/b');
     });
 
     it('ignores invalid regular expressions and logs a warning', () => {
@@ -1076,19 +1082,17 @@ describe('testPathPattern', () => {
       expect(console.log.mock.calls[0][0]).toMatchSnapshot();
     });
 
-    it.skip('escapes Windows path separators ', () => {
-      const {options} = normalize(initialOptions, {testPathPattern: 'a\\b'});
-      expect(options.testPathPattern).toBe('a\\\\b');
+    it('escapes Windows path separators', () => {
+      testWindowsPathSeparator({_: ['a\\b']}, 'a\\\\b');
     });
 
     it('joins multiple <regexForTestFiles> if set', () => {
-      const {options} = normalize(initialOptions, {_: ['a', 'b']});
-      expect(options.testPathPattern).toBe('a|b');
+      const {options} = normalize(initialOptions, {_: ['a/b', 'c/d']});
+      expect(options.testPathPattern).toBe('a/b|c/d');
     });
 
-    it.skip('escapes Windows path separators in multiple args', () => {
-      const {options} = normalize(initialOptions, {_: ['a\\b', 'c\\d']});
-      expect(options.testPathPattern).toBe('a\\\\b|c\\\\d');
-    })
+    it('escapes Windows path separators in multiple args', () => {
+      testWindowsPathSeparator({_: ['a\\b', 'c\\d']}, 'a\\\\b|c\\\\d');
+    });
   });
 });

--- a/packages/jest-config/src/__tests__/normalize.test.js
+++ b/packages/jest-config/src/__tests__/normalize.test.js
@@ -1026,3 +1026,69 @@ describe('watchPlugins', () => {
     ]);
   });
 });
+
+describe('testPathPattern', () => {
+  const initialOptions = {rootDir: '/root'};
+  const consoleLog = console.log;
+
+  beforeEach(() => {
+    console.log = jest.fn()
+  });
+
+  afterEach(() => {
+    console.log = consoleLog;
+  });
+
+  it('defaults to empty', () => {
+    const {options} = normalize(initialOptions, {});
+    expect(options.testPathPattern).toBe('');
+  });
+
+  describe('--testPathPattern', () => {
+    it('uses testPathPattern if set', () => {
+      const {options} = normalize(initialOptions, {testPathPattern: 'a'});
+      expect(options.testPathPattern).toBe('a');
+    });
+
+    it('ignores invalid regular expressions and logs a warning', () => {
+      const {options} = normalize(initialOptions, {testPathPattern: 'a('});
+      expect(options.testPathPattern).toBe('');
+      expect(console.log.mock.calls[0][0]).toMatchSnapshot();
+    });
+
+    it('escapes Windows path separators', () => {
+      jest.resetModules()
+      jest.mock('path', () => require.requireActual('path').win32)
+      const {options} = require('../normalize').default(initialOptions, {testPathPattern: 'a\\b'});
+      expect(options.testPathPattern).toBe('a\\\\b');
+    });
+  });
+
+  describe('<regexForTestFiles>', () => {
+    it('uses <regexForTestFiles> if set', () => {
+      const {options} = normalize(initialOptions, {_: ['a']});
+      expect(options.testPathPattern).toBe('a');
+    });
+
+    it('ignores invalid regular expressions and logs a warning', () => {
+      const {options} = normalize(initialOptions, {_: ['a(']});
+      expect(options.testPathPattern).toBe('');
+      expect(console.log.mock.calls[0][0]).toMatchSnapshot();
+    });
+
+    it.skip('escapes Windows path separators ', () => {
+      const {options} = normalize(initialOptions, {testPathPattern: 'a\\b'});
+      expect(options.testPathPattern).toBe('a\\\\b');
+    });
+
+    it('joins multiple <regexForTestFiles> if set', () => {
+      const {options} = normalize(initialOptions, {_: ['a', 'b']});
+      expect(options.testPathPattern).toBe('a|b');
+    });
+
+    it.skip('escapes Windows path separators in multiple args', () => {
+      const {options} = normalize(initialOptions, {_: ['a\\b', 'c\\d']});
+      expect(options.testPathPattern).toBe('a\\\\b|c\\\\d');
+    })
+  });
+});

--- a/packages/jest-config/src/normalize.js
+++ b/packages/jest-config/src/normalize.js
@@ -281,14 +281,14 @@ const normalizeReporters = (options: InitialOptions, basedir) => {
 const buildTestPathPattern = (argv: Argv): string => {
   if (argv.testPathPattern) {
     if (validatePattern(argv.testPathPattern)) {
-      return argv.testPathPattern;
+      return replacePathSepForRegex(argv.testPathPattern);
     } else {
       showTestPathPatternError(argv.testPathPattern);
     }
   }
 
   if (argv._ && argv._.length) {
-    const testPathPattern = argv._.join('|');
+    const testPathPattern = argv._.map(replacePathSepForRegex).join('|');
 
     if (validatePattern(testPathPattern)) {
       return testPathPattern;


### PR DESCRIPTION
**Summary**

This fixes #3793 by adding the path separator escaping that is used in watch mode to the `--testPathPattern` and default `<regexForTestFiles>` command line arguments.
<br/>

**Test plan**

Since there were no existing tests for `testPathPattern`, this PR adds tests for the existing behavior as well as the fix for path separator escaping on Windows systems.

I have confirmed this works on my Windows setup:
```
yarn build
yarn jest jest-config/src/__tests__/normalize
```
This would previously fail with:
```
Pattern: jest-config/src/__tests__/normalize - 0 matches
```
But now runs the added tests:
```
Ran all test suites matching /jest-config\\src\\__tests__\\normalize/i.
```