### PR TITLE
Use all --testPathPattern and <regexForTestFiles> args in testPathPattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Fixes
 
+* `[jest-config]` Use all `--testPathPattern` and `<regexForTestFiles>` args in
+  `testPathPattern`([#5066](https://github.com/facebook/jest/pull/5066))
 * `[jest-cli]` Do not support `--watch` inside non-version-controlled environments
   ([#5060](https://github.com/facebook/jest/pull/5060))
 * `[jest-config]` Escape Windows path separator in testPathPattern CLI arguments

--- a/packages/jest-cli/src/cli/args.js
+++ b/packages/jest-cli/src/cli/args.js
@@ -484,7 +484,7 @@ export const options = {
     description:
       'A regexp pattern string that is matched against all tests ' +
       'paths before executing the test.',
-    type: 'string',
+    type: 'array',
   },
   testRegex: {
     description: 'The regexp pattern Jest uses to detect test files.',

--- a/packages/jest-config/src/__tests__/normalize.test.js
+++ b/packages/jest-config/src/__tests__/normalize.test.js
@@ -1055,18 +1055,32 @@ describe('testPathPattern', () => {
 
   describe('--testPathPattern', () => {
     it('uses testPathPattern if set', () => {
-      const {options} = normalize(initialOptions, {testPathPattern: 'a/b'});
+      const {options} = normalize(initialOptions, {testPathPattern: ['a/b']});
       expect(options.testPathPattern).toBe('a/b');
     });
 
     it('ignores invalid regular expressions and logs a warning', () => {
-      const {options} = normalize(initialOptions, {testPathPattern: 'a('});
+      const {options} = normalize(initialOptions, {testPathPattern: ['a(']});
       expect(options.testPathPattern).toBe('');
       expect(console.log.mock.calls[0][0]).toMatchSnapshot();
     });
 
     it('escapes Windows path separators', () => {
-      testWindowsPathSeparator({testPathPattern: 'a\\b'}, 'a\\\\b');
+      testWindowsPathSeparator({testPathPattern: ['a\\b']}, 'a\\\\b');
+    });
+
+    it('joins multiple --testPathPatterns if set', () => {
+      const {options} = normalize(initialOptions, {
+        testPathPattern: ['a/b', 'c/d'],
+      });
+      expect(options.testPathPattern).toBe('a/b|c/d');
+    });
+
+    it('escapes Windows path separators in multiple args', () => {
+      testWindowsPathSeparator(
+        {testPathPattern: ['a\\b', 'c\\d']},
+        'a\\\\b|c\\\\d',
+      );
     });
   });
 
@@ -1094,5 +1108,13 @@ describe('testPathPattern', () => {
     it('escapes Windows path separators in multiple args', () => {
       testWindowsPathSeparator({_: ['a\\b', 'c\\d']}, 'a\\\\b|c\\\\d');
     });
+  });
+
+  it('joins multiple --testPathPatterns and <regexForTestFiles>', () => {
+    const {options} = normalize(initialOptions, {
+      _: ['a', 'b'],
+      testPathPattern: ['c', 'd'],
+    });
+    expect(options.testPathPattern).toBe('a|b|c|d');
   });
 });

--- a/packages/jest-config/src/normalize.js
+++ b/packages/jest-config/src/normalize.js
@@ -279,25 +279,22 @@ const normalizeReporters = (options: InitialOptions, basedir) => {
 };
 
 const buildTestPathPattern = (argv: Argv): string => {
+  const patterns = [];
+
+  if (argv._) {
+    patterns.push(...argv._);
+  }
   if (argv.testPathPattern) {
-    if (validatePattern(argv.testPathPattern)) {
-      return replacePathSepForRegex(argv.testPathPattern);
-    } else {
-      showTestPathPatternError(argv.testPathPattern);
-    }
+    patterns.push(...argv.testPathPattern);
   }
 
-  if (argv._ && argv._.length) {
-    const testPathPattern = argv._.map(replacePathSepForRegex).join('|');
-
-    if (validatePattern(testPathPattern)) {
-      return testPathPattern;
-    } else {
-      showTestPathPatternError(testPathPattern);
-    }
+  const testPathPattern = patterns.map(replacePathSepForRegex).join('|');
+  if (validatePattern(testPathPattern)) {
+    return testPathPattern;
+  } else {
+    showTestPathPatternError(testPathPattern);
+    return '';
   }
-
-  return '';
 };
 
 const showTestPathPatternError = (testPathPattern: string) => {

--- a/types/Argv.js
+++ b/types/Argv.js
@@ -69,7 +69,7 @@ export type Argv = {|
   testMatch: Array<string>,
   testNamePattern: string,
   testPathIgnorePatterns: Array<string>,
-  testPathPattern: string,
+  testPathPattern: Array<string>,
   testRegex: string,
   testResultsProcessor: ?string,
   testRunner: string,


### PR DESCRIPTION
**Summary**

This PR changes:
* the type of the `--testPathPattern` arg to match the multiple allowed values
* the way multiple `--testPathPattern` args are joined to form a valid regular expression
* the way `--testPathPattern` args are joined with the default `<regexForTestFiles>` args

This closes #5037.
<br/>

**Test plan**

Tests have been added to check the way the args are joined.
Evaluating the two test cases from #5037 also produce expected patterns:

```
> jest --testPathPattern=aa --testPathPattern=bb
...
WAS: Pattern: aa,bb
NOW: Pattern: aa|bb

> jest aa --testPathPattern=bb
...
WAS: Pattern: bb
NOW: Pattern: aa|bb
```