### PR TITLE
Always enforce the usage of the original Promise

### DIFF
--- a/integration_tests/__tests__/override-globals.test.js
+++ b/integration_tests/__tests__/override-globals.test.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+'use strict';
+
+import runJest from '../runJest';
+
+test('overriding native promise does not freeze Jest', () => {
+  const run = runJest('override-globals');
+  expect(run.stderr).toMatch(/PASS __tests__(\/|\\)index.js/);
+});

--- a/integration_tests/override-globals/__tests__/index.js
+++ b/integration_tests/override-globals/__tests__/index.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+import _unusedRequireOverridingPromise from '..';
+
+describe('parent', () => {
+  beforeEach(() => {
+    console.log('Promise is: ' + Promise.toString());
+  });
+
+  describe('child', () => {
+    it('works well', () => {
+      expect(() => new Promise()).toThrow('Booo');
+    });
+  });
+});

--- a/integration_tests/override-globals/index.js
+++ b/integration_tests/override-globals/index.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+global.Promise = function() {
+  throw new Error('Booo');
+};

--- a/integration_tests/override-globals/package.json
+++ b/integration_tests/override-globals/package.json
@@ -1,0 +1,5 @@
+{
+  "jest": {
+    "testEnvironment": "node"
+  }
+}

--- a/packages/jest-jasmine2/package.json
+++ b/packages/jest-jasmine2/package.json
@@ -16,7 +16,6 @@
     "jest-matcher-utils": "^21.2.1",
     "jest-message-util": "^21.2.1",
     "jest-snapshot": "^21.2.1",
-    "p-cancelable": "^0.3.0",
     "source-map-support": "^0.5.0"
   },
   "devDependencies": {

--- a/packages/jest-jasmine2/src/jasmine/Env.js
+++ b/packages/jest-jasmine2/src/jasmine/Env.js
@@ -36,9 +36,7 @@ import treeProcessor from '../tree_processor';
 // Try getting the real promise object from the context, if available. Someone
 // could have overridden it in a test. Async functions return it implicitly.
 // eslint-disable-next-line no-unused-vars
-const Promise =
-  (global.__originalGlobals__ && global.__originalGlobals__.Promise) ||
-  global.Promise;
+const Promise = global[Symbol.for('jest-native-promise')] || global.Promise;
 
 export default function(j$) {
   function Env(options) {

--- a/packages/jest-jasmine2/src/jasmine/Env.js
+++ b/packages/jest-jasmine2/src/jasmine/Env.js
@@ -31,8 +31,14 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 /* eslint-disable sort-keys */
 
 import queueRunner from '../queue_runner';
-
 import treeProcessor from '../tree_processor';
+
+// Try getting the real promise object from the context, if available. Someone
+// could have overridden it in a test. Async functions return it implicitly.
+// eslint-disable-next-line no-unused-vars
+const Promise =
+  (global.__originalGlobals__ && global.__originalGlobals__.Promise) ||
+  global.Promise;
 
 export default function(j$) {
   function Env(options) {

--- a/packages/jest-jasmine2/src/p_cancelable.js
+++ b/packages/jest-jasmine2/src/p_cancelable.js
@@ -2,9 +2,7 @@
 
 // Try getting the real promise object from the context, if available. Someone
 // could have overridden it in a test.
-const Promise =
-  (global.__originalGlobals__ && global.__originalGlobals__.Promise) ||
-  global.Promise;
+const Promise = global[Symbol.for('jest-native-promise')] || global.Promise;
 
 class CancelError extends Error {
   constructor() {

--- a/packages/jest-jasmine2/src/p_cancelable.js
+++ b/packages/jest-jasmine2/src/p_cancelable.js
@@ -1,0 +1,83 @@
+'use strict';
+
+// Try getting the real promise object from the context, if available. Someone
+// could have overridden it in a test.
+const Promise =
+  (global.__originalGlobals__ && global.__originalGlobals__.Promise) ||
+  global.Promise;
+
+class CancelError extends Error {
+  constructor() {
+    super('Promise was canceled');
+    this.name = 'CancelError';
+  }
+}
+
+class PCancelable {
+  static fn(fn) {
+    return function() {
+      const args = [].slice.apply(arguments);
+      return new PCancelable((onCancel, resolve, reject) => {
+        args.unshift(onCancel);
+        fn.apply(null, args).then(resolve, reject);
+      });
+    };
+  }
+
+  constructor(executor) {
+    this._pending = true;
+    this._canceled = false;
+
+    this._promise = new Promise((resolve, reject) => {
+      this._reject = reject;
+
+      return executor(
+        fn => {
+          this._cancel = fn;
+        },
+        val => {
+          this._pending = false;
+          resolve(val);
+        },
+        err => {
+          this._pending = false;
+          reject(err);
+        },
+      );
+    });
+  }
+
+  then() {
+    return this._promise.then.apply(this._promise, arguments);
+  }
+
+  catch() {
+    return this._promise.catch.apply(this._promise, arguments);
+  }
+
+  cancel() {
+    if (!this._pending || this._canceled) {
+      return;
+    }
+
+    if (typeof this._cancel === 'function') {
+      try {
+        this._cancel();
+      } catch (err) {
+        this._reject(err);
+      }
+    }
+
+    this._canceled = true;
+    this._reject(new CancelError());
+  }
+
+  get canceled() {
+    return this._canceled;
+  }
+}
+
+Object.setPrototypeOf(PCancelable.prototype, Promise.prototype);
+
+module.exports = PCancelable;
+module.exports.CancelError = CancelError;

--- a/packages/jest-jasmine2/src/p_timeout.js
+++ b/packages/jest-jasmine2/src/p_timeout.js
@@ -9,9 +9,7 @@
 
 // Try getting the real promise object from the context, if available. Someone
 // could have overridden it in a test.
-const Promise =
-  (global.__originalGlobals__ && global.__originalGlobals__.Promise) ||
-  global.Promise;
+const Promise = global[Symbol.for('jest-native-promise')] || global.Promise;
 
 // A specialized version of `p-timeout` that does not touch globals.
 // It does not throw on timeout.

--- a/packages/jest-jasmine2/src/p_timeout.js
+++ b/packages/jest-jasmine2/src/p_timeout.js
@@ -7,6 +7,12 @@
  * @flow
  */
 
+// Try getting the real promise object from the context, if available. Someone
+// could have overridden it in a test.
+const Promise =
+  (global.__originalGlobals__ && global.__originalGlobals__.Promise) ||
+  global.Promise;
+
 // A specialized version of `p-timeout` that does not touch globals.
 // It does not throw on timeout.
 export default function pTimeout(

--- a/packages/jest-jasmine2/src/queue_runner.js
+++ b/packages/jest-jasmine2/src/queue_runner.js
@@ -7,7 +7,13 @@
  * @flow
  */
 
-import PCancelable from 'p-cancelable';
+// Try getting the real promise object from the context, if available. Someone
+// could have overridden it in a test.
+const Promise: Class<Promise> =
+  (global.__originalGlobals__ && global.__originalGlobals__.Promise) ||
+  global.Promise;
+
+import PCancelable from './p_cancelable';
 import pTimeout from './p_timeout';
 
 type Options = {
@@ -55,7 +61,9 @@ export default function queueRunner(options: Options) {
     if (!timeout) {
       return promise;
     }
+
     const timeoutMs: number = timeout();
+
     return pTimeout(
       promise,
       timeoutMs,

--- a/packages/jest-jasmine2/src/queue_runner.js
+++ b/packages/jest-jasmine2/src/queue_runner.js
@@ -10,8 +10,7 @@
 // Try getting the real promise object from the context, if available. Someone
 // could have overridden it in a test.
 const Promise: Class<Promise> =
-  (global.__originalGlobals__ && global.__originalGlobals__.Promise) ||
-  global.Promise;
+  global[Symbol.for('jest-native-promise')] || global.Promise;
 
 import PCancelable from './p_cancelable';
 import pTimeout from './p_timeout';

--- a/packages/jest-jasmine2/src/reporter.js
+++ b/packages/jest-jasmine2/src/reporter.js
@@ -17,6 +17,12 @@ import type {
   TestResult,
 } from 'types/TestResult';
 
+// Try getting the real promise object from the context, if available. Someone
+// could have overridden it in a test.
+const Promise =
+  (global.__originalGlobals__ && global.__originalGlobals__.Promise) ||
+  global.Promise;
+
 import {formatResultsErrors} from 'jest-message-util';
 
 type Suite = {

--- a/packages/jest-jasmine2/src/reporter.js
+++ b/packages/jest-jasmine2/src/reporter.js
@@ -19,9 +19,7 @@ import type {
 
 // Try getting the real promise object from the context, if available. Someone
 // could have overridden it in a test.
-const Promise =
-  (global.__originalGlobals__ && global.__originalGlobals__.Promise) ||
-  global.Promise;
+const Promise = global[Symbol.for('jest-native-promise')] || global.Promise;
 
 import {formatResultsErrors} from 'jest-message-util';
 

--- a/packages/jest-jasmine2/src/tree_processor.js
+++ b/packages/jest-jasmine2/src/tree_processor.js
@@ -28,9 +28,7 @@ type TreeNode = {
 // Try getting the real promise object from the context, if available. Someone
 // could have overridden it in a test. Async functions return it implicitly.
 // eslint-disable-next-line no-unused-vars
-const Promise =
-  (global.__originalGlobals__ && global.__originalGlobals__.Promise) ||
-  global.Promise;
+const Promise = global[Symbol.for('jest-native-promise')] || global.Promise;
 
 export default function treeProcessor(options: Options) {
   const {

--- a/packages/jest-jasmine2/src/tree_processor.js
+++ b/packages/jest-jasmine2/src/tree_processor.js
@@ -25,6 +25,13 @@ type TreeNode = {
   children?: Array<TreeNode>,
 };
 
+// Try getting the real promise object from the context, if available. Someone
+// could have overridden it in a test. Async functions return it implicitly.
+// eslint-disable-next-line no-unused-vars
+const Promise =
+  (global.__originalGlobals__ && global.__originalGlobals__.Promise) ||
+  global.Promise;
+
 export default function treeProcessor(options: Options) {
   const {
     nodeComplete,

--- a/packages/jest-util/src/install_common_globals.js
+++ b/packages/jest-util/src/install_common_globals.js
@@ -18,6 +18,14 @@ const DTRACE = Object.keys(global).filter(key => key.startsWith('DTRACE'));
 export default function(globalObject: Global, globals: ConfigGlobals) {
   globalObject.process = createProcesObject();
 
+  // Deep copy all the original global values so that if a test overrides them,
+  // we can still get them back.
+  if (typeof global.__originalGlobals__ === 'undefined') {
+    Object.defineProperty(global, '__originalGlobals__', {
+      value: Object.freeze(deepCyclicCopy(global)),
+    });
+  }
+
   // Forward some APIs.
   DTRACE.forEach(dtrace => {
     globalObject[dtrace] = function(...args) {

--- a/packages/jest-util/src/install_common_globals.js
+++ b/packages/jest-util/src/install_common_globals.js
@@ -18,13 +18,8 @@ const DTRACE = Object.keys(global).filter(key => key.startsWith('DTRACE'));
 export default function(globalObject: Global, globals: ConfigGlobals) {
   globalObject.process = createProcesObject();
 
-  // Deep copy all the original global values so that if a test overrides them,
-  // we can still get them back.
-  if (typeof global.__originalGlobals__ === 'undefined') {
-    Object.defineProperty(global, '__originalGlobals__', {
-      value: Object.freeze(deepCyclicCopy(global)),
-    });
-  }
+  // Keep a reference to "Promise", since "jasmine_light.js" needs it.
+  global[global.Symbol.for('jest-native-promise')] = Promise;
 
   // Forward some APIs.
   DTRACE.forEach(dtrace => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5475,10 +5475,6 @@ outpipe@^1.1.0:
   dependencies:
     shell-quote "^1.4.2"
 
-p-cancelable@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-0.3.0.tgz#b9e123800bcebb7ac13a479be195b507b98d30fa"
-
 p-finally@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"


### PR DESCRIPTION
The new version of Jasmine (i.e. `jasmine_light.js`) uses `Promise`s in its core. Since this file (plus all its transitive dependencies) are injected into the context, they end up using the **child context `Promise`**, which could be overridden, thus freezing Jest forever. This did not happen before, essentially because the old `vendor/jasmine` did not use them.

The solution proposed here is to add a non-writable, non-enumerable, non-configurable global property called `__originalGlobals__`, where these ones are stored; then force use them inside `jest-jasmine2`. A test was also added to verify the code actually works, although this approach is not 100% correct still, since code like `Promise.prototype.then = () => 'banana'` would still make Jest crash.

_A proper solution is to not inject anything inside the context except for core testing functions, like `describe`, `it`, `beforeEach`, etc. However this one requires bigger architectural changes._