### PR TITLE
Update node_modules_path to resolve symlinks to real paths

### DIFF
--- a/packages/jest-resolve/src/node_modules_paths.js
+++ b/packages/jest-resolve/src/node_modules_paths.js
@@ -11,6 +11,7 @@
 
 import type {Path} from 'types/Config';
 import path from 'path';
+import * as fs from 'fs';
 
 type NodeModulesPathsOptions = {|
   moduleDirectory?: Array<string>,
@@ -37,11 +38,16 @@ export default function nodeModulesPaths(
     prefix = '\\\\';
   }
 
-  const paths = [basedirAbs];
-  let parsed = path.parse(basedirAbs);
+  // we need to work with physical paths (i.e. follow symlinks to their
+  // true location), which is what the node resolution algorithm does
+  const physicalBasedir: string = fs.realpathSync(basedirAbs);
+  
+  const paths = [physicalBasedir];
+  let parsed = path.parse(physicalBasedir);
   while (parsed.dir !== paths[paths.length - 1]) {
-    paths.push(parsed.dir);
-    parsed = path.parse(parsed.dir);
+    const realParsedDir: string = fs.realpathSync(parsed.dir);
+    paths.push(realParsedDir);
+    parsed = path.parse(realParsedDir);
   }
 
   const dirs = paths.reduce((dirs, aPath) => {


### PR DESCRIPTION
**Summary**

We are using `pnpm` as our package manager, which creates the dependency graph using symlinks in the node_modules folder. NodeJS's resolution algorithm currently resolves basedir to real path before resolving the module, it does not preserve symlinks by default. Right now, Jest cannot be used with `pnpm` and also does not resolve packages the same was as NodeJS does, which is problematic.

**Test plan**

Updated this code in our repo, everything continued to build successfully when using `npm`, but now also builds correctly when using `pnpm`.


