### PR TITLE
Use `declare module.exports` syntax for flow libdefs

### DIFF
--- a/flow-typed/resolve.js
+++ b/flow-typed/resolve.js
@@ -17,8 +17,8 @@ declare module "resolve/lib/node-modules-paths" {
     moduleDirectory: Array<string>,
   };
 
-  declare function exports(
+  declare module.exports: (
     path: string,
     options: NodeModulesPathsOptions,
-  ): Array<string>;
+  ) => Array<string>;
 }


### PR DESCRIPTION
**Summary**

We added this to Flow in v0.25 (about 2 years ago), but never actually
deprecated the legacy `declare var exports` syntax. Hoping to do that
soon, so clearing up uses that I can find.

**Test plan**

flow