### PR TITLE
Point contributing link in README to 'Good First Issue' label.

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,4 +162,4 @@ Show the world you're using *Jest* → [![tested with jest](https://img.shields.
 
 Send issues and pull requests with your ideas. For more information about contributing PRs and issues, see our [Contribution Guidelines](https://github.com/facebook/jest/blob/master/CONTRIBUTING.md).
 
-[Good First Task](https://github.com/facebook/jest/labels/Good%20First%20Task) is a great starting point for PRs.
+[Good First Issue](https://github.com/facebook/jest/labels/Good%20First%20Issue) is a great starting point for PRs.


### PR DESCRIPTION
**Summary**

The link in the 'Contributing' section of the README points to the [Good First Task](https://github.com/facebook/jest/labels/Good%20First%20Task) label. Following it shows 0 issues. Looks like the suggested label is [Good First Issue](https://github.com/facebook/jest/labels/Good%20First%20Issue) -- updating the link to point there instead.

**Test plan**

Verify following the link in the README shows good first issues.
