### PR TITLE
fix: add global setup/teardown to valid_config

### DIFF
--- a/packages/jest-config/src/valid_config.js
+++ b/packages/jest-config/src/valid_config.js
@@ -38,6 +38,8 @@ export default ({
   displayName: 'project-name',
   expand: false,
   forceExit: false,
+  globalSetup: 'setup.js',
+  globalTeardown: 'teardown.js',
   globals: {},
   haste: {
     providesModuleNodeModules: ['react', 'react-native'],


### PR DESCRIPTION
This will fix the false warnings on using the Global Setup/Teardown options

![screen shot 2017-12-17 at 8 02 25 am](https://user-images.githubusercontent.com/12194969/34075396-ba90386e-e300-11e7-8125-10486685a6d7.png)

