### PR TITLE
test: handle both `ms` and `s` in test timings

### DIFF
--- a/integration_tests/utils.js
+++ b/integration_tests/utils.js
@@ -148,7 +148,7 @@ const extractSummary = (stdout: string) => {
 
   const rest = cleanupStackTrace(
     // remove all timestamps
-    stdout.slice(0, -match[0].length).replace(/\s*\(\d*\.?\d+m?s\)/gm, ''),
+    stdout.slice(0, -match[0].length).replace(/\s*\(\d*\.?\d+m?s\)$/gm, ''),
   );
 
   return {rest, summary};

--- a/integration_tests/utils.js
+++ b/integration_tests/utils.js
@@ -148,7 +148,7 @@ const extractSummary = (stdout: string) => {
 
   const rest = cleanupStackTrace(
     // remove all timestamps
-    stdout.slice(0, -match[0].length).replace(/\s*\(.*ms\)/gm, ''),
+    stdout.slice(0, -match[0].length).replace(/\s*\(\d*\.?\d+m?s\)/gm, ''),
   );
 
   return {rest, summary};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

**Summary**
We're seeing some errors from slow running tests in seconds instead of millis. This strips them out from test results in integration tests.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
Green CI

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
