### PR TITLE
Fix unofficial Node.js 4 support

### DIFF
--- a/packages/jest-config/src/normalize.js
+++ b/packages/jest-config/src/normalize.js
@@ -282,10 +282,10 @@ const buildTestPathPattern = (argv: Argv): string => {
   const patterns = [];
 
   if (argv._) {
-    patterns.push(...argv._);
+    patterns.push.apply(patterns, argv._);
   }
   if (argv.testPathPattern) {
-    patterns.push(...argv.testPathPattern);
+    patterns.push.apply(patterns, argv.testPathPattern);
   }
 
   const testPathPattern = patterns.map(replacePathSepForRegex).join('|');

--- a/packages/jest-editor-support/src/Runner.js
+++ b/packages/jest-editor-support/src/Runner.js
@@ -99,10 +99,10 @@ export default class Runner extends EventEmitter {
 
   runJestWithUpdateForSnapshots(completion: any, args: string[]) {
     const defaultArgs = ['--updateSnapshot'];
-    const updateProcess = this._createProcess(this.workspace, [
-      ...defaultArgs,
-      ...(args ? args : []),
-    ]);
+    const updateProcess = this._createProcess(
+      this.workspace,
+      [].concat(defaultArgs).concat(args ? args : []),
+    );
     updateProcess.on('close', () => {
       completion();
     });

--- a/packages/jest-resolve/src/index.js
+++ b/packages/jest-resolve/src/index.js
@@ -119,13 +119,15 @@ class Resolver {
     const defaultPlatform = this._options.defaultPlatform;
     const extensions = this._options.extensions.slice();
     if (this._supportsNativePlatform()) {
-      extensions.unshift(
-        ...this._options.extensions.map(ext => '.' + NATIVE_PLATFORM + ext),
+      extensions.unshift.apply(
+        extensions,
+        this._options.extensions.map(ext => '.' + NATIVE_PLATFORM + ext),
       );
     }
     if (defaultPlatform) {
-      extensions.unshift(
-        ...this._options.extensions.map(ext => '.' + defaultPlatform + ext),
+      extensions.unshift.apply(
+        extensions,
+        this._options.extensions.map(ext => '.' + defaultPlatform + ext),
       );
     }
 


### PR DESCRIPTION
> Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

Do I need to update `CHANGELOG.md` for unofficial fixes?

**Summary**

I fixed Node.js 4 support to use Jest 22 in PostCSS, Autoprefixer, and Browserslist according to our plan in https://github.com/facebook/jest/issues/5122

**Test plan**

I didn’t fix `...` in tests since Node.js 4 support is unofficial