### PR TITLE
Expose JestAssertionError to custom matchers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 ## master
 
-None for now
-
 ### Fixes
 
 ### Features
+
+* Expose `expect.JestAssertionError` to enable custom matchers to throw errors
+  with the call stack preserved.
+  ([#5138](https://github.com/facebook/jest/pull/5138))
 
 ### Chore & Maintenance
 

--- a/integration_tests/__tests__/__snapshots__/failures.test.js.snap
+++ b/integration_tests/__tests__/__snapshots__/failures.test.js.snap
@@ -123,6 +123,47 @@ exports[`works with async failures 1`] = `
 "
 `;
 
+exports[`works with custom matchers 1`] = `
+"FAIL __tests__/custom_matcher.test.js
+  Custom matcher
+    ✓ passes
+    ✕ fails
+    ✕ preserves error stack
+
+  ● Custom matcher › fails
+
+    Expected \\"bar\\" but got \\"foo\\"
+
+      43 |   // This test should fail
+      44 |   it('fails', () => {
+    > 45 |     expect(() => 'foo').toCustomMatch('bar');
+      46 |   });
+      47 | 
+      48 |   // This test fails due to an unrelated/unexpected error
+      
+      at __tests__/custom_matcher.test.js:45:25
+
+  ● Custom matcher › preserves error stack
+
+    ReferenceError: qux is not defined
+
+      52 |     const bar = () => baz();
+      53 |     // eslint-disable-next-line no-undef
+    > 54 |     const baz = () => qux();
+      55 | 
+      56 |     expect(() => {
+      57 |       foo();
+      
+      at __tests__/custom_matcher.test.js:54:23
+      at __tests__/custom_matcher.test.js:52:23
+      at __tests__/custom_matcher.test.js:51:23
+      at __tests__/custom_matcher.test.js:57:7
+      at __tests__/custom_matcher.test.js:13:20
+      at __tests__/custom_matcher.test.js:58:8
+
+"
+`;
+
 exports[`works with node assert 1`] = `
 "FAIL __tests__/node_assertion_error.test.js
   ✕ assert

--- a/integration_tests/__tests__/failures.test.js
+++ b/integration_tests/__tests__/failures.test.js
@@ -119,3 +119,9 @@ test('works with snapshot failures', () => {
     result.substring(0, result.indexOf('Snapshot Summary')),
   ).toMatchSnapshot();
 });
+
+test('works with custom matchers', () => {
+  const {stderr} = runJest(dir, ['custom_matcher.test.js']);
+
+  expect(normalizeDots(extractSummary(stderr).rest)).toMatchSnapshot();
+});

--- a/integration_tests/failures/__tests__/custom_matcher.test.js
+++ b/integration_tests/failures/__tests__/custom_matcher.test.js
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails oncall+jsinfra
+ */
+'use strict';
+
+function toCustomMatch(callback, expectation) {
+  try {
+    const actual = callback();
+
+    if (actual !== expectation) {
+      return {
+        message: () => `Expected "${expectation}" but got "${actual}"`,
+        pass: false,
+      };
+    }
+  } catch (error) {
+    // Explicitly wrap caught errors to preserve their stack
+    // Without this, Jest will override stack to point to the matcher
+    const assertionError = new expect.JestAssertionError();
+    assertionError.message = error.message;
+    assertionError.stack = error.stack;
+    throw assertionError;
+  }
+
+  return {pass: true};
+}
+
+expect.extend({
+  toCustomMatch,
+});
+
+describe('Custom matcher', () => {
+  // This test will pass
+  it('passes', () => {
+    expect(() => 'foo').toCustomMatch('foo');
+  });
+
+  // This test should fail
+  it('fails', () => {
+    expect(() => 'foo').toCustomMatch('bar');
+  });
+
+  // This test fails due to an unrelated/unexpected error
+  // It will show a helpful stack trace though
+  it('preserves error stack', () => {
+    const foo = () => bar();
+    const bar = () => baz();
+    // eslint-disable-next-line no-undef
+    const baz = () => qux();
+
+    expect(() => {
+      foo();
+    }).toCustomMatch('test');
+  });
+});

--- a/packages/expect/src/index.js
+++ b/packages/expect/src/index.js
@@ -296,4 +296,8 @@ expect.getState = getState;
 expect.setState = setState;
 expect.extractExpectedAssertionsErrors = extractExpectedAssertionsErrors;
 
+// Expose JestAssertionError for custom matchers
+// This enables them to preserve the stack for specific errors
+expect.JestAssertionError = JestAssertionError;
+
 module.exports = (expect: Expect);


### PR DESCRIPTION
Resolves #5136

Expose `JestAssertionError` to custom matchers as `expect.JestAssertionError`. The motivation for this is described in more detail in issue #5136, along with alternate solutions.

It's unclear to me if the current Jest behavior is the right default. (I don't have sufficient context to have an opinion about this.) I assume for now that it is, and so propose the smallest change to enable custom matchers to throw errors that will not have the stack overridden.

I didn't update website/documentation yet since I'm unsure if this PR will be accepted. I would be happy to make that change as well though.

## Summary

With this change, it is possible to write custom matchers that preserve the original error stack, eg:
```js
function toCustomMatch(callback, expectation) {
  try {
    const actual = callback();

    if (actual !== expectation) {
      return {
        pass: false,
        message: () => `Expected "${expectation}" but got "${actual}"`
      };
    }
  } catch (error) {
    // Explicitly wrap caught errors to preserve their stack
    // Without this, Jest will override stack to point to the matcher
    const assertionError = new expect.JestAssertionError();
    assertionError.message = error.message;
    assertionError.stack = error.stack;
    throw assertionError;
  }

  return {pass: true};
}

expect.extend({
  toCustomMatch,
});

describe('Custom matcher', () => {
  // This test will pass
  it('passes', () => {
    expect(() => 'foo').toCustomMatch('foo');
  });

  // This test should fail
  it('fails', () => {
    expect(() => 'foo').toCustomMatch('bar');
  });

  // This test fails due to an unrelated/unexpected error
  // It will show a helpful stack trace though
  it('preserves error stack', () => {
    const foo = () => bar();
    const bar = () => baz();
    const baz = () => qux();

    expect(() => {
      foo();
    }).toCustomMatch('test');
  });
});
```

Running the above test would result in the following output:
```sh
FAIL  path/to/test.js
  Custom matcher
    ✓ passes (3ms)
    ✕ fails (10ms)
    ✕ preserves error stack

  ● Custom matcher › fails

    Expected "bar" but got "foo"

      at Object.<anonymous> (path/to/test.js:35:41)

  ● Custom matcher › preserves error stack

    ReferenceError: qux is not defined

      at baz (path/to/test.js:43:28) # This stack is important
      at bar (path/to/test.js:42:35)
      at foo (path/to/test.js:41:35)
      at path/to/test.js:46:7
      at Object.toCustomMatch (path/to/test.js:3:18)
      at Object.throwingMatcher [as toCustomMatch] (node_modules/expect/build/index.js:198:24)
      at Object.<anonymous> (path/to/test.js:47:8)

Test Suites: 1 failed, 1 total
Tests:       2 failed, 1 passed, 3 total
```

## Test plan

Above results are shown for a custom matcher I've written locally that uses this newly-exposed property. I would be happy to contribute automated test(s) as well if it's desired.