### PR TITLE
[Website] Reorganize sidebar

### DIFF
--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -9,19 +9,6 @@
       "jest-platform",
       "more-resources"
     ],
-    "API Reference": [
-      "api",
-      "expect",
-      "mock-function-api",
-      "jest-object",
-      "configuration",
-      "cli"
-    ],
-    "Framework Guides": [
-      "tutorial-react",
-      "tutorial-react-native",
-      "testing-frameworks"
-    ],
     "Guides": [
       "snapshot-testing",
       "tutorial-async",
@@ -31,6 +18,19 @@
       "puppeteer",
       "migration-guide",
       "troubleshooting"
+    ],
+    "Framework Guides": [
+      "tutorial-react",
+      "tutorial-react-native",
+      "testing-frameworks"
+    ],
+    "API Reference": [
+      "api",
+      "expect",
+      "mock-function-api",
+      "jest-object",
+      "configuration",
+      "cli"
     ]
   }
 }


### PR DESCRIPTION
Moves the API Reference to the bottom, and places regular Guides above Framework guides.

# Test Plan

Run docusaurus in `website/` folder:

![screen shot 2017-12-21 at 10 27 46 am](https://user-images.githubusercontent.com/165856/34269620-ef4d0398-e639-11e7-9cbc-c0e133edb7eb.png)
