### PR TITLE
New line before quitting watch mode

### DIFF
--- a/packages/jest-cli/src/watch.js
+++ b/packages/jest-cli/src/watch.js
@@ -161,6 +161,7 @@ export default function watch(
   let activePlugin: ?WatchPlugin;
   const onKeypress = (key: string) => {
     if (key === KEYS.CONTROL_C || key === KEYS.CONTROL_D) {
+      outputStream.write("\n");
       process.exit(0);
       return;
     }
@@ -204,6 +205,7 @@ export default function watch(
 
     switch (key) {
       case KEYS.Q:
+        outputStream.write("\n");
         process.exit(0);
         return;
       case KEYS.ENTER:

--- a/packages/jest-cli/src/watch.js
+++ b/packages/jest-cli/src/watch.js
@@ -161,7 +161,7 @@ export default function watch(
   let activePlugin: ?WatchPlugin;
   const onKeypress = (key: string) => {
     if (key === KEYS.CONTROL_C || key === KEYS.CONTROL_D) {
-      outputStream.write("\n");
+      outputStream.write('\n');
       process.exit(0);
       return;
     }
@@ -205,7 +205,7 @@ export default function watch(
 
     switch (key) {
       case KEYS.Q:
-        outputStream.write("\n");
+        outputStream.write('\n');
         process.exit(0);
         return;
       case KEYS.ENTER:


### PR DESCRIPTION
Prints a new line before quitting watch mode, to prevent mid-line shell prompts. More details in #5150.