### PR TITLE
jest --changedFilesToContributeTo=origin/master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
   ([#5289](https://github.com/facebook/jest/pull/5289))
 * `[docs]` Update mention of the minimal version of node supported [#4947](https://github.com/facebook/jest/issues/4947)
 * `[jest-cli]` Fix missing newline in console message ([#5308](https://github.com/facebook/jest/pull/5308))
+* `[jest-cli]` `--lastCommit` and `--changedFilesWithAncestor` now take effect
+  even when `--onlyChanged` is not specified. ([#5307](https://github.com/facebook/jest/pull/5307))
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * `[jest-cli]` Make Jest exit without an error when no tests are found in the
   case of `--lastCommit`, `--findRelatedTests`, or `--onlyChanged` options
   having been passed to the CLI
+* `[jest-cli]` Allow selectively running tests for code changed since arbitrary
+  revisions. ([#5188](https://github.com/facebook/jest/pull/5188))
 
 ### Fixes
 * `[jest-cli]` Use `import-local` to support global Jest installations.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -105,8 +105,8 @@ If you want to inspect the cache, use `--showConfig` and look at the
 
 ### `--changedFilesWithAncestor`
 
-When used together with `--onlyChanged` or `--watch`, it runs tests related to
-the current changes and the changes made in the last commit.
+Runs tests related to the current changes and the changes made in the last
+commit. Behaves similarly to `--onlyChanged`.
 
 ### `--ci`
 
@@ -188,8 +188,8 @@ Write test results to a file when the `--json` option is also specified.
 
 ### `--lastCommit`
 
-When used together with `--onlyChanged`, it will run all tests affected by file
-changes in the last commit made.
+Run all tests affected by file changes in the last commit made. Behaves
+similarly to `--onlyChanged`.
 
 ### `--listTests`
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -103,6 +103,12 @@ two times slower._
 If you want to inspect the cache, use `--showConfig` and look at the
 `cacheDirectory` value. If you need to clear the cache, use `--clearCache`.
 
+### `--changedFilesToContributeTo`
+
+When used together with `--onlyChanged` or `--watch`, it runs tests related the
+changes since the provided revision. If the current branch is not a child of the
+given commit, then only changes made locally will be tested.
+
 ### `--changedFilesWithAncestor`
 
 Runs tests related to the current changes and the changes made in the last

--- a/packages/jest-changed-files/src/git.js
+++ b/packages/jest-changed-files/src/git.js
@@ -13,7 +13,10 @@ import type {Options, SCMAdapter} from 'types/ChangedFiles';
 import path from 'path';
 import childProcess from 'child_process';
 
-const findChangedFilesUsingCommand = async (args, cwd) => {
+const findChangedFilesUsingCommand = async (
+  args: Array<string>,
+  cwd: Path,
+): Promise<Array<Path>> => {
   return new Promise((resolve, reject) => {
     const child = childProcess.spawn('git', args, {cwd});
     let stdout = '';
@@ -30,6 +33,7 @@ const findChangedFilesUsingCommand = async (args, cwd) => {
           resolve(
             stdout
               .split('\n')
+              .filter(s => s !== '')
               .map(changedPath => path.resolve(cwd, changedPath)),
           );
         }
@@ -45,21 +49,28 @@ const adapter: SCMAdapter = {
     cwd: string,
     options?: Options,
   ): Promise<Array<Path>> => {
+    const toContributeTo: ?string =
+      options && (options.withAncestor ? 'HEAD^' : options.toContributeTo);
+
     if (options && options.lastCommit) {
       return await findChangedFilesUsingCommand(
         ['show', '--name-only', '--pretty=%b', 'HEAD'],
         cwd,
       );
-    } else if (options && options.withAncestor) {
-      const changed = await findChangedFilesUsingCommand(
-        ['diff', '--name-only', 'HEAD^'],
+    } else if (toContributeTo) {
+      const committed = await findChangedFilesUsingCommand(
+        ['log', '--name-only', '--pretty=%b', 'HEAD', `^${toContributeTo}`],
         cwd,
       );
-      const untracked = await findChangedFilesUsingCommand(
-        ['ls-files', '--other', '--exclude-standard'],
+      const staged = await findChangedFilesUsingCommand(
+        ['diff', '--cached', '--name-only'],
         cwd,
       );
-      return changed.concat(untracked);
+      const unstaged = await findChangedFilesUsingCommand(
+        ['ls-files', '--other', '--modified', '--exclude-standard'],
+        cwd,
+      );
+      return [...committed, ...staged, ...unstaged];
     } else {
       return await findChangedFilesUsingCommand(
         ['ls-files', '--other', '--modified', '--exclude-standard'],

--- a/packages/jest-changed-files/src/hg.js
+++ b/packages/jest-changed-files/src/hg.js
@@ -26,6 +26,8 @@ const adapter: SCMAdapter = {
       let args = ['status', '-amnu'];
       if (options && options.withAncestor) {
         args.push('--rev', 'ancestor(.^)');
+      } else if (options && options.toContributeTo) {
+        args.push('--rev', `ancestor(., ${options.toContributeTo})`);
       } else if (options && options.lastCommit === true) {
         args = ['tip', '--template', '{files%"{file}\n"}'];
       }

--- a/packages/jest-cli/src/__tests__/cli/args.test.js
+++ b/packages/jest-cli/src/__tests__/cli/args.test.js
@@ -31,6 +31,19 @@ describe('check', () => {
     );
   });
 
+  it('raises an exception when lastCommit and watchAll are both specified', () => {
+    const argv: Argv = {lastCommit: true, watchAll: true};
+    expect(() => check(argv)).toThrow(
+      'Both --lastCommit and --watchAll were specified',
+    );
+  });
+
+  it('sets onlyChanged if lastCommit is specified', () => {
+    const argv: Argv = {lastCommit: true};
+    check(argv);
+    expect(argv.onlyChanged).toBe(true);
+  });
+
   it('raises an exception if findRelatedTests is specified with no file paths', () => {
     const argv: Argv = {_: [], findRelatedTests: true};
     expect(() => check(argv)).toThrow(

--- a/packages/jest-cli/src/cli/args.js
+++ b/packages/jest-cli/src/cli/args.js
@@ -20,12 +20,17 @@ export const check = (argv: Argv) => {
     );
   }
 
-  if (argv.onlyChanged && argv.watchAll) {
-    throw new Error(
-      'Both --onlyChanged and --watchAll were specified, but these two ' +
-        'options do not make sense together. Try the --watch option which ' +
-        'reruns only tests related to changed files.',
-    );
+  for (const key of ['onlyChanged', 'lastCommit', 'changedFilesWithAncestor']) {
+    if (argv[key]) {
+      argv.onlyChanged = true;
+    }
+    if (argv[key] && argv.watchAll) {
+      throw new Error(
+        `Both --${key} and --watchAll were specified, but these two ` +
+          'options do not make sense together. Try the --watch option which ' +
+          'reruns only tests related to changed files.',
+      );
+    }
   }
 
   if (argv.findRelatedTests && argv._.length === 0) {
@@ -104,8 +109,8 @@ export const options = {
   },
   changedFilesWithAncestor: {
     description:
-      'When used together with `--onlyChanged` or `--watch`, it runs tests ' +
-      'related to the current changes and the changes made in the last commit. ',
+      'Runs tests related to the current changes and the changes made in the ' +
+      'last commit. Behaves similarly to `--onlyChanged`.',
     type: 'boolean',
   },
   ci: {
@@ -267,8 +272,8 @@ export const options = {
   lastCommit: {
     default: undefined,
     description:
-      'When used together with `--onlyChanged`, it will run all tests ' +
-      'affected by file changes in the last commit made.',
+      'Run all tests affected by file changes in the last commit made. ' +
+      'Behaves similarly to `--onlyChanged`.',
     type: 'boolean',
   },
   listTests: {
@@ -353,7 +358,7 @@ export const options = {
     description:
       'Attempts to identify which tests to run based on which ' +
       "files have changed in the current repository. Only works if you're " +
-      'running tests in a git repository at the moment.',
+      'running tests in a git or hg repository at the moment.',
     type: 'boolean',
   },
   onlyFailures: {

--- a/packages/jest-cli/src/cli/args.js
+++ b/packages/jest-cli/src/cli/args.js
@@ -20,7 +20,12 @@ export const check = (argv: Argv) => {
     );
   }
 
-  for (const key of ['onlyChanged', 'lastCommit', 'changedFilesWithAncestor']) {
+  for (const key of [
+    'onlyChanged',
+    'lastCommit',
+    'changedFilesWithAncestor',
+    'changedFilesToContributeTo',
+  ]) {
     if (argv[key]) {
       argv.onlyChanged = true;
     }
@@ -105,6 +110,14 @@ export const options = {
     description:
       'The directory where Jest should store its cached ' +
       ' dependency information.',
+    type: 'string',
+  },
+  changedFilesToContributeTo: {
+    description:
+      'Runs tests related the changes since the provided branch. If the ' +
+      'current branch has diverged from the given branch, then only changes ' +
+      'made locally will be tested. Behaves similarly to `--onlyChanged`.',
+    nargs: 1,
     type: 'string',
   },
   changedFilesWithAncestor: {

--- a/packages/jest-cli/src/get_changed_files_promise.js
+++ b/packages/jest-cli/src/get_changed_files_promise.js
@@ -22,6 +22,7 @@ export default (
     );
     return getChangedFilesForRoots(allRootsForAllProjects, {
       lastCommit: globalConfig.lastCommit,
+      toContributeTo: globalConfig.changedFilesToContributeTo,
       withAncestor: globalConfig.changedFilesWithAncestor,
     });
   }

--- a/packages/jest-config/src/index.js
+++ b/packages/jest-config/src/index.js
@@ -93,6 +93,7 @@ const getConfigs = (
   return {
     globalConfig: Object.freeze({
       bail: options.bail,
+      changedFilesToContributeTo: options.changedFilesToContributeTo,
       changedFilesWithAncestor: options.changedFilesWithAncestor,
       collectCoverage: options.collectCoverage,
       collectCoverageFrom: options.collectCoverageFrom,

--- a/packages/jest-config/src/normalize.js
+++ b/packages/jest-config/src/normalize.js
@@ -461,6 +461,7 @@ export default function normalize(options: InitialOptions, argv: Argv) {
       case 'bail':
       case 'browser':
       case 'cache':
+      case 'changedFilesToContributeTo':
       case 'changedFilesWithAncestor':
       case 'clearMocks':
       case 'collectCoverage':

--- a/packages/jest-config/src/valid_config.js
+++ b/packages/jest-config/src/valid_config.js
@@ -20,6 +20,7 @@ export default ({
   browser: false,
   cache: true,
   cacheDirectory: '/tmp/user/jest',
+  changedFilesToContributeTo: '',
   changedFilesWithAncestor: false,
   clearMocks: false,
   collectCoverage: true,

--- a/test_utils.js
+++ b/test_utils.js
@@ -13,6 +13,7 @@ import type {GlobalConfig, ProjectConfig} from 'types/Config';
 
 const DEFAULT_GLOBAL_CONFIG: GlobalConfig = {
   bail: false,
+  changedFilesToContributeTo: '',
   changedFilesWithAncestor: false,
   collectCoverage: false,
   collectCoverageFrom: [],

--- a/types/Argv.js
+++ b/types/Argv.js
@@ -17,6 +17,7 @@ export type Argv = {|
   browser: boolean,
   cache: boolean,
   cacheDirectory: string,
+  changedFilesToContributeTo: string,
   changedFilesWithAncestor: boolean,
   clearMocks: boolean,
   ci: boolean,

--- a/types/ChangedFiles.js
+++ b/types/ChangedFiles.js
@@ -12,6 +12,7 @@ import type {Path} from 'types/Config';
 export type Options = {|
   lastCommit?: boolean,
   withAncestor?: boolean,
+  toContributeTo?: string,
 |};
 
 export type ChangedFiles = Set<Path>;

--- a/types/Config.js
+++ b/types/Config.js
@@ -76,6 +76,7 @@ export type InitialOptions = {
   cacheDirectory?: Path,
   clearMocks?: boolean,
   changedFilesWithAncestor?: boolean,
+  changedFilesToContributeTo?: string,
   collectCoverage?: boolean,
   collectCoverageFrom?: Array<Glob>,
   collectCoverageOnlyFrom?: {[key: string]: boolean},
@@ -157,6 +158,7 @@ export type SnapshotUpdateState = 'all' | 'new' | 'none';
 
 export type GlobalConfig = {|
   bail: boolean,
+  changedFilesToContributeTo: string,
   changedFilesWithAncestor: boolean,
   collectCoverage: boolean,
   collectCoverageFrom: Array<Glob>,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

I often have `jest --watch` running in a window, but sometimes I forget to look at it before committing, or I stage a bunch of changes that break tests, and it hides them from the test runner. This means that I often get surprised by CI test failures when I come to open pull requests.

This change allows you to write `jest --watch --changedFilesSinceCommit=$LAST_MERGE_COMMIT` to test your entire feature branch, but not the whole project.

`LAST_MERGE_COMMIT` can be written as `HEAD^{/^Merge}` or ``` `git log --date-order --merges -1 --format=%H` ``` on projects that use merge commits. On projects like jest that use linearised history, you might be able to get away with something like ``` `git log --oneline --cherry --format=%H origin/master...HEAD | tail -n1`^``` but I don't work on them often enough to know.

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

I still need to write some integration tests for this (see TODO below) but I wanted to float the idea and get feedback before I got too invested in it.

To test this against the jest repo on my local machine, I have been running `yarn run watch` in one window, and `yarn jest -- --onlyChanged --changedFilesSinceCommit=HEAD^^^^^^^^^` (if I add more `^`s then I get more test suites run in my `Test Suites: n passed, n total` output.


TODO (feel free to add more):
- [x] integration test coverage
- [x] hg support (although git support didn't stop --changedFilesWithAncestor from being merged, by the look of it. Is this a requirement for merging, or is it enough to just explode gracefully?)
- [x] find a better name than --changedFilesSinceCommit (--changedFilesSinceRevision or something else?)
- [x] find a better name than findChangedFilesUsingCommand()?
