### PR TITLE
Git support for --changedFilesWithAncestor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Fixes
 
+* `[jest-cli]` `jest --onlyChanged --changedFilesWithAncestor` now also works
+  with git. ([#5189](https://github.com/facebook/jest/pull/5189))
 * `[jest-config]` fix unexpected condition to avoid infinite recursion in
   Windows platform. ([#5161](https://github.com/facebook/jest/pull/5161))
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -104,8 +104,8 @@ If you want to inspect the cache, use `--showConfig` and look at the
 
 ### `--changedFilesWithAncestor`
 
-When used together with `--onlyChanged`, it runs tests related to the current
-changes and the changes made in the last commit.
+When used together with `--onlyChanged` or `--watch`, it runs tests related to
+the current changes and the changes made in the last commit.
 
 ### `--ci`
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -102,6 +102,11 @@ two times slower._
 If you want to inspect the cache, use `--showConfig` and look at the
 `cacheDirectory` value. If you need to clear the cache, use `--clearCache`.
 
+### `--changedFilesWithAncestor`
+
+When used together with `--onlyChanged`, it runs tests related to the current
+changes and the changes made in the last commit.
+
 ### `--ci`
 
 When this option is provided, Jest will assume it is running in a CI
@@ -182,7 +187,8 @@ Write test results to a file when the `--json` option is also specified.
 
 ### `--lastCommit`
 
-Will run all tests affected by file changes in the last commit made.
+When used together with `--onlyChanged`, it will run all tests affected by file
+changes in the last commit made.
 
 ### `--listTests`
 

--- a/integration_tests/__tests__/jest_changed_files.test.js
+++ b/integration_tests/__tests__/jest_changed_files.test.js
@@ -175,6 +175,22 @@ test('gets changed files for git', async () => {
       .map(filePath => path.basename(filePath))
       .sort(),
   ).toEqual(['file1.txt']);
+
+  run(`${GIT} commit -am "test2"`, DIR);
+
+  writeFiles(DIR, {
+    'file4.txt': 'file4',
+  });
+
+  ({changedFiles: files} = await getChangedFilesForRoots(roots, {
+    withAncestor: true,
+  }));
+  // Returns files from current uncommitted state + the last commit
+  expect(
+    Array.from(files)
+      .map(filePath => path.basename(filePath))
+      .sort(),
+  ).toEqual(['file1.txt', 'file4.txt']);
 });
 
 test('gets changed files for hg', async () => {

--- a/packages/jest-changed-files/src/git.js
+++ b/packages/jest-changed-files/src/git.js
@@ -47,7 +47,7 @@ const adapter: SCMAdapter = {
   ): Promise<Array<Path>> => {
     if (options && options.lastCommit) {
       return await findChangedFilesUsingCommand(
-        ['diff', '--name-only', 'HEAD^', 'HEAD'],
+        ['show', '--name-only', '--pretty=%b', 'HEAD'],
         cwd,
       );
     } else if (options && options.withAncestor) {

--- a/packages/jest-cli/src/cli/args.js
+++ b/packages/jest-cli/src/cli/args.js
@@ -267,8 +267,8 @@ export const options = {
   lastCommit: {
     default: undefined,
     description:
-      'Will run all tests affected by file changes in the last ' +
-      'commit made.',
+      'When used together with `--onlyChanged`, it will run all tests ' +
+      'affected by file changes in the last commit made.',
     type: 'boolean',
   },
   listTests: {

--- a/packages/jest-cli/src/cli/args.js
+++ b/packages/jest-cli/src/cli/args.js
@@ -104,7 +104,7 @@ export const options = {
   },
   changedFilesWithAncestor: {
     description:
-      'When used together with `--onlyChanged`, it runs tests ' +
+      'When used together with `--onlyChanged` or `--watch`, it runs tests ' +
       'related to the current changes and the changes made in the last commit. ',
     type: 'boolean',
   },

--- a/packages/jest-cli/src/cli/args.js
+++ b/packages/jest-cli/src/cli/args.js
@@ -105,8 +105,7 @@ export const options = {
   changedFilesWithAncestor: {
     description:
       'When used together with `--onlyChanged`, it runs tests ' +
-      'related to the current changes and the changes made in the last commit. ' +
-      '(NOTE: this only works for hg repos)',
+      'related to the current changes and the changes made in the last commit. ',
     type: 'boolean',
   },
   ci: {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

**Summary**

as requested in https://github.com/facebook/jest/pull/5188, this PR adds git support for the `--changedFilesWithAncestor` flag.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

If this is working, you should be able to do this in the jest repo:
`yarn jest -- --onlyChanged --changedFilesWithAncestor`

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
