### PR TITLE
Add meta-data arg to JSON event

### DIFF
--- a/packages/jest-editor-support/index.d.ts
+++ b/packages/jest-editor-support/index.d.ts
@@ -5,13 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { EventEmitter } from 'events';
-import { ChildProcess } from 'child_process';
+import {EventEmitter} from 'events';
+import {ChildProcess} from 'child_process';
 
 export interface Options {
   createProcess?(
-    workspace: ProjectWorkspace, 
-    args: string[], 
+    workspace: ProjectWorkspace,
+    args: string[],
     debugPort?: number,
   ): ChildProcess;
   debugPort?: number;
@@ -133,4 +133,8 @@ export interface JestTotalResults {
   numFailedTests: number;
   numPendingTests: number;
   testResults: Array<JestFileResults>;
+}
+
+export interface JestTotalResultsMeta {
+  noTestsFound: boolean;
 }

--- a/packages/jest-editor-support/src/types.js
+++ b/packages/jest-editor-support/src/types.js
@@ -58,3 +58,7 @@ export type TestAssertionStatus = {
   terseMessage: ?string,
   line: ?number,
 };
+
+export type JestTotalResultsMeta = {
+  noTestsFound: boolean,
+};


### PR DESCRIPTION
**Summary**
When running Jest in watch mode, the test results that follow the "No tests found related to files changed since last commit" message will be empty. This PR adds detection for this message, and emits this info with the JSON test results. This behavior is required for jest-community/vscode-jest#213.

**Test plan**
Tests have been added, and I've confirmed the expected behavior debugging `vscode-jest`.

/cc @orta 
