### PR TITLE
Improve documentation of `describe` and `test` ordering.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
 
 ### Chore & Maintenance
 
+* `[docs]` Describe the order of execution of describe and test blocks, and a note on using `test.concurrent`.
+  ([#5217](https://github.com/facebook/jest/pull/5217))
+
 ## jest 22.0.4
 
 ### Fixes

--- a/docs/SetupAndTeardown.md
+++ b/docs/SetupAndTeardown.md
@@ -7,6 +7,8 @@ Often while writing tests you have some setup work that needs to happen before
 tests run, and you have some finishing work that needs to happen after tests
 run. Jest provides helper functions to handle this.
 
+
+
 ### Repeating Setup For Many Tests
 
 If you have some work you need to do repeatedly for many tests, you can use
@@ -146,6 +148,59 @@ describe('Scoped / Nested block', () => {
 // 2 - afterAll
 // 1 - afterAll
 ```
+
+### Order of execution of describe and test blocks
+
+Jest executes all describe handlers in a test file *before* it executes any of the actual tests. This is an extra reason to use the `before*` and `after*` handlers rather than relying on closures. Once the describe blocks are complete, jest runs all the tests in the order they were encountered in the collection phase. Consider the following illustrative test file and output:
+
+```
+describe('outer', () => {
+
+  console.log(`describe outer`);
+
+  describe('describe inner 1', () => {
+    console.log(`describe inner 1`);
+    test('test 1', () => {
+      console.log(`test for describe inner 1`);
+      expect(true).toEqual(true);
+    });
+  });
+
+  test('test 1', () => {
+    console.log(`test for describe outer`);
+    expect(true).toEqual(true);
+  });
+
+  describe('describe inner 2', () => {
+    console.log(`describe inner 2`);
+    test('test for describe inner 2', () => {
+      console.log(`test for describe inner 2`);
+      expect(false).toEqual(false);
+    })
+  });
+});
+
+// describe outer
+// describe inner 1
+// describe inner 2
+// test for describe inner 1
+// test for describe outer
+// test for describe inner 2
+```
+
+### Concurrent tests
+
+If you have multiple tests in the same file that may take a long time and 
+are independent, then you can mark that they can be executed concurrently
+using `test.concurrent()`:
+
+```
+test.concurrent('long test', () => {
+  return new Promise(resolve => someLongFunction(resolve));
+});
+```
+
+Note that concurrent tests must return a promise.
 
 ### General Advice
 

--- a/docs/SetupAndTeardown.md
+++ b/docs/SetupAndTeardown.md
@@ -7,8 +7,6 @@ Often while writing tests you have some setup work that needs to happen before
 tests run, and you have some finishing work that needs to happen after tests
 run. Jest provides helper functions to handle this.
 
-
-
 ### Repeating Setup For Many Tests
 
 If you have some work you need to do repeatedly for many tests, you can use
@@ -151,7 +149,9 @@ describe('Scoped / Nested block', () => {
 
 ### Order of execution of describe and test blocks
 
-Jest executes all describe handlers in a test file *before* it executes any of the actual tests. This is an extra reason to use the `before*` and `after*` handlers rather than relying on closures. Once the describe blocks are complete, jest runs all the tests in the order they were encountered in the collection phase. Consider the following illustrative test file and output:
+Jest executes all describe handlers in a test file *before* it executes any of the actual tests. This is an extra reason to use the `before*` and `after*` handlers rather than relying on closures. Once the describe blocks are complete, by default jest runs all the tests serially in the order they were encountered in the collection phase, waiting for each to finish and be tidied up before moving on. 
+
+Consider the following illustrative test file and output:
 
 ```
 describe('outer', () => {

--- a/docs/SetupAndTeardown.md
+++ b/docs/SetupAndTeardown.md
@@ -149,40 +149,46 @@ describe('Scoped / Nested block', () => {
 
 ### Order of execution of describe and test blocks
 
-Jest executes all describe handlers in a test file *before* it executes any of the actual tests. This is an extra reason to use the `before*` and `after*` handlers rather than relying on closures. Once the describe blocks are complete, by default jest runs all the tests serially in the order they were encountered in the collection phase, waiting for each to finish and be tidied up before moving on. 
+Jest executes all describe handlers in a test file *before* it executes any of the actual tests. This is another reason to do setup and teardown in `before*` and `after*` handlers rather in the describe blocks. Once the describe blocks are complete, by default jest runs all the tests serially in the order they were encountered in the collection phase, waiting for each to finish and be tidied up before moving on. 
 
 Consider the following illustrative test file and output:
 
 ```
 describe('outer', () => {
 
-  console.log(`describe outer`);
+ console.log(`describe outer-a`);
+ 
+ describe('describe inner 1', () => {
+   console.log(`describe inner 1`);
+   test('test 1', () => {
+     console.log(`test for describe inner 1`);
+     expect(true).toEqual(true);
+   });
+ });
 
-  describe('describe inner 1', () => {
-    console.log(`describe inner 1`);
-    test('test 1', () => {
-      console.log(`test for describe inner 1`);
-      expect(true).toEqual(true);
-    });
-  });
+ console.log(`describe outer-b`);
+ 
+ test('test 1', () => {
+   console.log(`test for describe outer`);
+   expect(true).toEqual(true);
+ });
 
-  test('test 1', () => {
-    console.log(`test for describe outer`);
-    expect(true).toEqual(true);
-  });
-
-  describe('describe inner 2', () => {
-    console.log(`describe inner 2`);
-    test('test for describe inner 2', () => {
-      console.log(`test for describe inner 2`);
-      expect(false).toEqual(false);
-    })
-  });
+ describe('describe inner 2', () => {
+   console.log(`describe inner 2`);
+   test('test for describe inner 2', () => {
+     console.log(`test for describe inner 2`);
+     expect(false).toEqual(false);
+   })
+ });
+ 
+ console.log(`describe outer-c`);
 });
 
-// describe outer
+// describe outer-a
 // describe inner 1
+// describe outer-b
 // describe inner 2
+// describe outer-c
 // test for describe inner 1
 // test for describe outer
 // test for describe inner 2

--- a/docs/SetupAndTeardown.md
+++ b/docs/SetupAndTeardown.md
@@ -149,7 +149,7 @@ describe('Scoped / Nested block', () => {
 
 ### Order of execution of describe and test blocks
 
-Jest executes all describe handlers in a test file *before* it executes any of the actual tests. This is another reason to do setup and teardown in `before*` and `after*` handlers rather in the describe blocks. Once the describe blocks are complete, by default jest runs all the tests serially in the order they were encountered in the collection phase, waiting for each to finish and be tidied up before moving on. 
+Jest executes all describe handlers in a test file *before* it executes any of the actual tests. This is another reason to do setup and teardown in `before*` and `after*` handlers rather in the describe blocks. Once the describe blocks are complete, by default Jest runs all the tests serially in the order they were encountered in the collection phase, waiting for each to finish and be tidied up before moving on. 
 
 Consider the following illustrative test file and output:
 
@@ -193,20 +193,6 @@ describe('outer', () => {
 // test for describe outer
 // test for describe inner 2
 ```
-
-### Concurrent tests
-
-If you have multiple tests in the same file that may take a long time and 
-are independent, then you can mark that they can be executed concurrently
-using `test.concurrent()`:
-
-```
-test.concurrent('long test', () => {
-  return new Promise(resolve => someLongFunction(resolve));
-});
-```
-
-Note that concurrent tests must return a promise.
 
 ### General Advice
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

**Summary**

There is no documentation of the order in which `describe` and `test` handlers are run, nor any mention of any guarantees that jest makes about their synchronicity. I believe the intention is that tests within a single file are always run one after another unless `test.concurrent` is used, so I wanted to formalize that in the docs. 

Obviously if that's not true it would be good to see an explanation in the docs of why!

**Test plan**

Docs changes only and I've checked visually the markdown renders fine.
