### PR TITLE
Array key path to have property

### DIFF
--- a/docs/ExpectAPI.md
+++ b/docs/ExpectAPI.md
@@ -903,9 +903,10 @@ describe('toMatchObject applied to arrays arrays', () => {
 ### `.toHaveProperty(keyPath, value)`
 
 Use `.toHaveProperty` to check if property at provided reference `keyPath`
-exists for an object. For checking deeply nested properties in an object use
+exists for an object. For checking deeply nested properties in an object you may
+use
 [dot notation](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Operators/Property_accessors)
-for deep references.
+or an array containing the keyPath for deep references.
 
 Optionally, you can provide a `value` to check if it's equal to the value
 present at `keyPath` on the target object. This matcher uses 'deep equality'
@@ -941,6 +942,16 @@ test('this house has my desired features', () => {
     'stove',
     'washer',
   ]);
+
+  expect(houseForSale).not.toHaveProperty('kitchen.open');
+
+  // Deep referencing using an array containing the keyPath
+  expect(houseForSale).toHaveProperty(['kitchen', 'area'], 20);
+  expect(houseForSale).toHaveProperty(
+    ['kitchen', 'amenities'],
+    ['oven', 'stove', 'washer'],
+  );
+  expect(houseForSale).toHaveProperty(['kitchen', 'amenities', 0], 'oven');
 
   expect(houseForSale).not.toHaveProperty('kitchen.open');
 });

--- a/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -2562,21 +2562,21 @@ Expected value to have a 'length' property that is a number. Received:
 exports[`.toHaveProperty() {error} expect({"a": {"b": {}}}).toHaveProperty('1') 1`] = `
 "<dim>expect(</><red>object</><dim>)[.not].toHaveProperty(</><green>path</><dim>)</>
 
-Expected <green>path</> to be a string. Received:
+Expected <green>path</> to be a string or an array. Received:
   number: <red>1</>"
 `;
 
 exports[`.toHaveProperty() {error} expect({"a": {"b": {}}}).toHaveProperty('null') 1`] = `
 "<dim>expect(</><red>object</><dim>)[.not].toHaveProperty(</><green>path</><dim>)</>
 
-Expected <green>path</> to be a string. Received:
+Expected <green>path</> to be a string or an array. Received:
   null: <red>null</>"
 `;
 
 exports[`.toHaveProperty() {error} expect({"a": {"b": {}}}).toHaveProperty('undefined') 1`] = `
 "<dim>expect(</><red>object</><dim>)[.not].toHaveProperty(</><green>path</><dim>)</>
 
-Expected <green>path</> to be a string. Received:
+Expected <green>path</> to be a string or an array. Received:
   undefined: <red>undefined</>"
 `;
 
@@ -2614,6 +2614,19 @@ To have a nested property:
 With a value of:
   <green>{\\"a\\": 5}</>
 "
+`;
+
+exports[`.toHaveProperty() {pass: false} expect({"a": {"b": {"c": {"d": 1}}}}).toHaveProperty('a,b,c,d', 2) 1`] = `
+"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</>, <green>value</><dim>)</>
+
+Expected the object:
+  <red>{\\"a\\": {\\"b\\": {\\"c\\": {\\"d\\": 1}}}}</>
+To have a nested property:
+  <green>[\\"a\\", \\"b\\", \\"c\\", \\"d\\"]</>
+With a value of:
+  <green>2</>
+Received:
+  <red>1</>"
 `;
 
 exports[`.toHaveProperty() {pass: false} expect({"a": {"b": {"c": {"d": 1}}}}).toHaveProperty('a.b.c.d', 2) 1`] = `
@@ -2730,6 +2743,31 @@ Received:
   <red>object</>.a: <red>1</>"
 `;
 
+exports[`.toHaveProperty() {pass: false} expect({"a.b.c.d": 1}).toHaveProperty('a.b.c.d', 2) 1`] = `
+"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</>, <green>value</><dim>)</>
+
+Expected the object:
+  <red>{\\"a.b.c.d\\": 1}</>
+To have a nested property:
+  <green>\\"a.b.c.d\\"</>
+With a value of:
+  <green>2</>
+"
+`;
+
+exports[`.toHaveProperty() {pass: false} expect({"a.b.c.d": 1}).toHaveProperty('a.b.c.d', 2) 2`] = `
+"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</>, <green>value</><dim>)</>
+
+Expected the object:
+  <red>{\\"a.b.c.d\\": 1}</>
+To have a nested property:
+  <green>[\\"a.b.c.d\\"]</>
+With a value of:
+  <green>2</>
+Received:
+  <red>1</>"
+`;
+
 exports[`.toHaveProperty() {pass: false} expect({}).toHaveProperty('a') 1`] = `
 "<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</><dim>)</>
 
@@ -2771,6 +2809,50 @@ To have a nested property:
   <green>\\"a.b.c\\"</>
 With a value of:
   <green>\\"test\\"</>
+"
+`;
+
+exports[`.toHaveProperty() {pass: true} expect({"a": {"b": [1, 2, 3]}}).toHaveProperty('a,b,1')' 1`] = `
+"<dim>expect(</><red>object</><dim>).not.toHaveProperty(</><green>path</><dim>)</>
+
+Expected the object:
+  <red>{\\"a\\": {\\"b\\": [1, 2, 3]}}</>
+Not to have a nested property:
+  <green>[\\"a\\", \\"b\\", 1]</>
+"
+`;
+
+exports[`.toHaveProperty() {pass: true} expect({"a": {"b": [1, 2, 3]}}).toHaveProperty('a,b,1', 2) 1`] = `
+"<dim>expect(</><red>object</><dim>).not.toHaveProperty(</><green>path</>, <green>value</><dim>)</>
+
+Expected the object:
+  <red>{\\"a\\": {\\"b\\": [1, 2, 3]}}</>
+Not to have a nested property:
+  <green>[\\"a\\", \\"b\\", 1]</>
+With a value of:
+  <green>2</>
+"
+`;
+
+exports[`.toHaveProperty() {pass: true} expect({"a": {"b": {"c": {"d": 1}}}}).toHaveProperty('a,b,c,d')' 1`] = `
+"<dim>expect(</><red>object</><dim>).not.toHaveProperty(</><green>path</><dim>)</>
+
+Expected the object:
+  <red>{\\"a\\": {\\"b\\": {\\"c\\": {\\"d\\": 1}}}}</>
+Not to have a nested property:
+  <green>[\\"a\\", \\"b\\", \\"c\\", \\"d\\"]</>
+"
+`;
+
+exports[`.toHaveProperty() {pass: true} expect({"a": {"b": {"c": {"d": 1}}}}).toHaveProperty('a,b,c,d', 1) 1`] = `
+"<dim>expect(</><red>object</><dim>).not.toHaveProperty(</><green>path</>, <green>value</><dim>)</>
+
+Expected the object:
+  <red>{\\"a\\": {\\"b\\": {\\"c\\": {\\"d\\": 1}}}}</>
+Not to have a nested property:
+  <green>[\\"a\\", \\"b\\", \\"c\\", \\"d\\"]</>
+With a value of:
+  <green>1</>
 "
 `;
 
@@ -2849,6 +2931,28 @@ Not to have a nested property:
   <green>\\"a\\"</>
 With a value of:
   <green>0</>
+"
+`;
+
+exports[`.toHaveProperty() {pass: true} expect({"a.b.c.d": 1}).toHaveProperty('a.b.c.d')' 1`] = `
+"<dim>expect(</><red>object</><dim>).not.toHaveProperty(</><green>path</><dim>)</>
+
+Expected the object:
+  <red>{\\"a.b.c.d\\": 1}</>
+Not to have a nested property:
+  <green>[\\"a.b.c.d\\"]</>
+"
+`;
+
+exports[`.toHaveProperty() {pass: true} expect({"a.b.c.d": 1}).toHaveProperty('a.b.c.d', 1) 1`] = `
+"<dim>expect(</><red>object</><dim>).not.toHaveProperty(</><green>path</>, <green>value</><dim>)</>
+
+Expected the object:
+  <red>{\\"a.b.c.d\\": 1}</>
+Not to have a nested property:
+  <green>[\\"a.b.c.d\\"]</>
+With a value of:
+  <green>1</>
 "
 `;
 

--- a/packages/expect/src/__tests__/matchers.test.js
+++ b/packages/expect/src/__tests__/matchers.test.js
@@ -751,6 +751,9 @@ describe('.toHaveLength', () => {
 describe('.toHaveProperty()', () => {
   [
     [{a: {b: {c: {d: 1}}}}, 'a.b.c.d', 1],
+    [{a: {b: {c: {d: 1}}}}, ['a', 'b', 'c', 'd'], 1],
+    [{'a.b.c.d': 1}, ['a.b.c.d'], 1],
+    [{a: {b: [1, 2, 3]}}, ['a', 'b', 1], 2],
     [{a: 0}, 'a', 0],
     [{a: {b: undefined}}, 'a.b', undefined],
     [{a: {b: {c: 5}}}, 'a.b', {c: 5}],
@@ -769,6 +772,9 @@ describe('.toHaveProperty()', () => {
   [
     [{a: {b: {c: {d: 1}}}}, 'a.b.ttt.d', 1],
     [{a: {b: {c: {d: 1}}}}, 'a.b.c.d', 2],
+    [{'a.b.c.d': 1}, 'a.b.c.d', 2],
+    [{'a.b.c.d': 1}, ['a.b.c.d'], 2],
+    [{a: {b: {c: {d: 1}}}}, ['a', 'b', 'c', 'd'], 2],
     [{a: {b: {c: {}}}}, 'a.b.c.d', 1],
     [{a: 1}, 'a.b.c.d', 5],
     [{}, 'a', 'test'],
@@ -789,6 +795,9 @@ describe('.toHaveProperty()', () => {
 
   [
     [{a: {b: {c: {d: 1}}}}, 'a.b.c.d'],
+    [{a: {b: {c: {d: 1}}}}, ['a', 'b', 'c', 'd']],
+    [{'a.b.c.d': 1}, ['a.b.c.d']],
+    [{a: {b: [1, 2, 3]}}, ['a', 'b', 1]],
     [{a: 0}, 'a'],
     [{a: {b: undefined}}, 'a.b'],
   ].forEach(([obj, keyPath]) => {

--- a/packages/expect/src/matchers.js
+++ b/packages/expect/src/matchers.js
@@ -486,7 +486,7 @@ const matchers: MatchersObject = {
     return {message, pass};
   },
 
-  toHaveProperty(object: Object, keyPath: string, value?: any) {
+  toHaveProperty(object: Object, keyPath: string | Array<any>, value?: any) {
     const valuePassed = arguments.length === 3;
 
     if (!object && typeof object !== 'string' && typeof object !== 'number') {
@@ -500,13 +500,17 @@ const matchers: MatchersObject = {
       );
     }
 
-    if (getType(keyPath) !== 'string') {
+    const keyPathType = getType(keyPath);
+
+    if (keyPathType !== 'string' && keyPathType !== 'array') {
       throw new Error(
         matcherHint('[.not].toHaveProperty', 'object', 'path', {
           secondArgument: valuePassed ? 'value' : null,
         }) +
           '\n\n' +
-          `Expected ${EXPECTED_COLOR('path')} to be a string. Received:\n` +
+          `Expected ${EXPECTED_COLOR(
+            'path',
+          )} to be a string or an array. Received:\n` +
           `  ${getType(keyPath)}: ${printReceived(keyPath)}`,
       );
     }


### PR DESCRIPTION
**Summary**

Add support to `.toHaveProperty` matcher to accept the keyPath argument as an array of properties/indices.

Discussion can be found at #3873

**Test plan**

Update the `.toHaveProperty` tests to test against array as the keyPath argument.  Include test for testing that an object as a flattened property like: `{'a.b.c.d': 1}` and against array indices like:  
