### PR TITLE
Escape glob characters in rootDir before interpolating into testMatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * `[jest-config]` fix unexpected condition to avoid infinite recursion in
   Windows platform. ([#5161](https://github.com/facebook/jest/pull/5161))
+* `[jest-config]` Escape parentheses and other glob characters in `rootDir` before interpolating with `testMatch`. ([#4838](https://github.com/facebook/jest/issues/4838))
 
 ### Features
 

--- a/packages/jest-cli/src/__tests__/search_source.test.js
+++ b/packages/jest-cli/src/__tests__/search_source.test.js
@@ -239,6 +239,26 @@ describe('SearchSource', () => {
       });
     });
 
+    it('finds tests with parentheses in their rootDir when using testMatch', () => {
+      const {options: config} = normalize(
+        {
+          name,
+          rootDir: path.resolve(__dirname, 'test_root_with_(parentheses)'),
+          testMatch: ['<rootDir>**/__testtests__/**/*'],
+          testRegex: null,
+        },
+        {},
+      );
+      return findMatchingTests(config).then(data => {
+        const relPaths = toPaths(data.tests).map(absPath =>
+          path.relative(rootDir, absPath),
+        );
+        expect(relPaths.sort()).toEqual([
+          expect.stringContaining(path.normalize('__testtests__/test.js')),
+        ]);
+      });
+    });
+
     it('finds tests with similar but custom file extensions', () => {
       const {options: config} = normalize(
         {

--- a/packages/jest-cli/src/__tests__/test_root_with_(parentheses)/__testtests__/test.js
+++ b/packages/jest-cli/src/__tests__/test_root_with_(parentheses)/__testtests__/test.js
@@ -1,0 +1,5 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+// test.js
+
+require('../module.jsx');

--- a/packages/jest-cli/src/__tests__/test_root_with_(parentheses)/module.jsx
+++ b/packages/jest-cli/src/__tests__/test_root_with_(parentheses)/module.jsx
@@ -1,0 +1,1 @@
+// module.jsx

--- a/packages/jest-config/src/normalize.js
+++ b/packages/jest-config/src/normalize.js
@@ -25,6 +25,7 @@ import {
   DOCUMENTATION_NOTE,
   _replaceRootDirInPath,
   _replaceRootDirTags,
+  escapeGlobCharacters,
   getTestEnvironment,
   resolve,
 } from './utils';
@@ -444,7 +445,10 @@ export default function normalize(options: InitialOptions, argv: Argv) {
         break;
       case 'moduleDirectories':
       case 'testMatch':
-        value = _replaceRootDirTags(options.rootDir, options[key]);
+        value = _replaceRootDirTags(
+          escapeGlobCharacters(options.rootDir),
+          options[key],
+        );
         break;
       case 'automock':
       case 'bail':

--- a/packages/jest-config/src/utils.js
+++ b/packages/jest-config/src/utils.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import type {Path} from 'types/Config';
+import type {Path, Glob} from 'types/Config';
 
 import path from 'path';
 import {ValidationError} from 'jest-validate';
@@ -45,6 +45,10 @@ export const resolve = (rootDir: string, key: string, filePath: Path) => {
   }
 
   return module;
+};
+
+export const escapeGlobCharacters = (path: Path): Glob => {
+  return path.replace(/([()*{}\[\]!?\\])/g, '\\$1');
 };
 
 export const _replaceRootDirInPath = (


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

**Summary**

This is an attempt to address https://github.com/facebook/jest/issues/4838 and https://github.com/facebookincubator/create-react-app/issues/3404. Currently, some tests aren't found when the user is running Jest in a project where the path contains parentheses *and* they have the `<rootDir>` token in one of the `testMatch` strings. This seems to be because `testMatch` is treated as an array of Globs, but rootDir is dropped into those Globs unaltered.

For an example, given this configuration:
```json
{
  "rootDir": "/(parens)/",
  "testMatch": [
    "<rootDir>**/*.test.js"
  ]
}
```
Jest will end up with `/(parens)/**/*.test.js` as a `testMatch` pattern. This will match the file at `/parens/src/index.test.js`, rather than file `/(parens)/src/index.test.js`, since micromatch will treat the parens as a designating a regex group containing a single pattern.

It looks like this is also a problem in every other place in the configuration where `<rootDir>` would be used in a glob pattern. I tried addressing the issue in those places too, but this ended up causing some new test failures, so I'm just pushing up my attempt at fixing the immediate problem. It would be nice if there were a way to address the other cases here too. Is there a use-case for having a rootDir glob pattern instead of just a single path?

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

I added an additional failing test before beginning, though I had trouble finding a place for it that seemed suitable and ended up just putting it near some tests that seemed to be checking for similar things inside jest-cli.

This is how I checked to see if the changes addressed #4838:

1. Build Jest from this branch.
2. `yarn link` inside packages/jest-cli.
2. Clone my example project (https://github.com/rimunroe/jest-parentheses-in-rootDir) into some directory.
3. cd into to that directory, and then into `./with-(parens)`.
4. Run `yarn` to install the un-linked Jest.
5. Run `yarn test` and note that no tests were found.
6. Run `yarn link jest-cli` to use the new build of Jest instead.
7. Run `yarn test` again, which should result in a test being found.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->



  