### PR TITLE
Treat dumb terminals as noninteractive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Fixes
 
+* `[jest-cli]` Treat dumb terminals as noninteractive ([#5237](https://github.com/facebook/jest/pull/5237))
 * `[jest-cli]` `jest --onlyChanged --changedFilesWithAncestor` now also works
   with git. ([#5189](https://github.com/facebook/jest/pull/5189))
 * `[jest-config]` fix unexpected condition to avoid infinite recursion in

--- a/packages/jest-util/src/__tests__/is_interactive.test.js
+++ b/packages/jest-util/src/__tests__/is_interactive.test.js
@@ -1,17 +1,21 @@
 let oldIsTTY;
+let oldTERM;
 
 beforeEach(() => {
   oldIsTTY = process.stdout.isTTY;
+  oldTERM = process.env.TERM;
 });
 
 afterEach(() => {
   process.stdout.isTTY = oldIsTTY;
+  process.env.TERM = oldTERM;
   jest.resetModules();
 });
 
 it('Returns true when running on interactive environment', () => {
   jest.doMock('is-ci', () => false);
   process.stdout.isTTY = true;
+  process.env.TERM = 'xterm-256color';
 
   const isInteractive = require('../is_interative').default;
   expect(isInteractive).toBe(true);
@@ -24,6 +28,7 @@ it('Returns false when running on a non-interactive environment', () => {
   // Test with is-ci being true and isTTY false
   jest.doMock('is-ci', () => true);
   process.stdout.isTTY = false;
+  process.env.TERM = 'xterm-256color';
   isInteractive = require('../is_interative').default;
   expect(isInteractive).toBe(expectedResult);
 
@@ -31,6 +36,7 @@ it('Returns false when running on a non-interactive environment', () => {
   jest.resetModules();
   jest.doMock('is-ci', () => false);
   process.stdout.isTTY = false;
+  process.env.TERM = 'xterm-256color';
   isInteractive = require('../is_interative').default;
   expect(isInteractive).toBe(expectedResult);
 
@@ -38,6 +44,15 @@ it('Returns false when running on a non-interactive environment', () => {
   jest.resetModules();
   jest.doMock('is-ci', () => true);
   process.stdout.isTTY = true;
+  process.env.TERM = 'xterm-256color';
+  isInteractive = require('../is_interative').default;
+  expect(isInteractive).toBe(expectedResult);
+
+  // Test with dumb terminal
+  jest.resetModules();
+  jest.doMock('is-ci', () => false);
+  process.stdout.isTTY = false;
+  process.env.TERM = 'dumb';
   isInteractive = require('../is_interative').default;
   expect(isInteractive).toBe(expectedResult);
 });

--- a/packages/jest-util/src/is_interative.js
+++ b/packages/jest-util/src/is_interative.js
@@ -1,3 +1,3 @@
 import isCI from 'is-ci';
 
-export default process.stdout.isTTY && !isCI;
+export default process.stdout.isTTY && process.env.TERM !== 'dumb' && !isCI;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

**Summary**

Fixes #5236 and related issues outside of Emacs. Essentially, the issue is that `isInteractive` only checks `process.stdin.isTTY` and CI environment variables, but it should treat a shell with `TERM` set to `dumb` as noninteractive even if is has a TTY (not all TTYs support interactive escape codes). Note that while Emacs' Compilation mode supports interactive comint processes with a prefix argument, it is still not supported with this Jest patch (for example `jest --watch` will ignore input).

**Test plan**
- `yarn test packages/jest-util/src/__tests__/is_interactive.test.js` passes
- Running `yarn link` and `jest` in another project in Emacs successfully hides mode escape codes (though is an extra `[999D` right after the last `PASS` line that I can't figure out how to remove, I'd appreciate feedback)
  
  