### PR TITLE
Add moduleNameMapper ordering note to the documentation

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -386,6 +386,9 @@ Example:
 }
 ```
 
+The order in which the mappings are defined matters. Patterns are checked one
+by one until one fits. The most specific rule should be listed first.
+
 _Note: If you provide module name without boundaries `^$` it may cause hard to
 spot errors. E.g. `relay` will replace all modules which contain `relay` as a
 substring in its name: `relay`, `react-relay` and `graphql-relay` will all be


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

**Summary**

Related to https://github.com/facebook/jest/issues/870#issuecomment-355652269 

> Just a note for future readers, **the `moduleNameMapper` ordering is important.**
> 
> I wanted to stub style imported in modules, something like:
> 
>     // module.js
>     import Style from '@/path/to/style.scss';
>     import App from './App';
> 
> So I created a style stub file:
> 
>     // test/unit/stubs/style.js
>     module.exports = '.style-stub{color:red;}';
> 
> After messing around with the following `jest.conf.js`:
> 
>     moduleNameMapper: {
>         '^@/(.*)$': '<rootDir>/src/$1', // '@' alias
>         '^.*\\.scss$': '<rootDir>/test/unit/stubs/style.js',
>     }
> 
> The `@` alias rule was resolving before my `.scss` rule, so the style file was loaded as a normal module and would crash the test.
> 
> The solution was to put specific rules first.
> 
>     moduleNameMapper: {
>         '^.*\\.scss$': '<rootDir>/test/unit/stubs/style.js',
>         '^@/(.*)$': '<rootDir>/src/$1',
>     }
>   
