### PR TITLE
Add changelog for asymmetric matchers types PR #5069

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Fixes
 
+* `[expect]` Fail test when the types of `stringContaining` and `stringMatching` matchers do not match.
 * `[jest-cli]` Treat dumb terminals as noninteractive ([#5237](https://github.com/facebook/jest/pull/5237))
 * `[jest-cli]` `jest --onlyChanged --changedFilesWithAncestor` now also works
   with git. ([#5189](https://github.com/facebook/jest/pull/5189))


### PR DESCRIPTION
@SimenB should if be a "breaking" instead of "fixes"?