### PR TITLE
Use a better console-clearing string on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
   custom matchers. ([#5162](https://github.com/facebook/jest/pull/5162))
 * `[pretty-format]` Pretty format for DOMStringMap and NamedNodeMap
   ([#5233](https://github.com/facebook/jest/pull/5233))
+* `[jest-cli]` Use a better console-clearing string on Windows
+  ([#5251](https://github.com/facebook/jest/pull/5251))
 
 ### Features
 

--- a/packages/jest-cli/src/constants.js
+++ b/packages/jest-cli/src/constants.js
@@ -9,7 +9,7 @@
 
 const isWindows = process.platform === 'win32';
 
-export const CLEAR = isWindows ? '\x1Bc' : '\x1B[2J\x1B[3J\x1B[H';
+export const CLEAR = isWindows ? '\x1B[2J\x1B[0f' : '\x1B[2J\x1B[3J\x1B[H';
 
 export const KEYS = {
   A: '61',


### PR DESCRIPTION
This is pretty much the same as https://github.com/facebookincubator/create-react-app/pull/2071.

It seems to work better for more recent Windows versions (according to my testing in https://github.com/facebookincubator/create-react-app/pull/2071#issuecomment-311741543 which I did a few months ago). I haven't verified this again but I can re-test with a Windows laptop in a few days.