### PR TITLE
Fully remove weak and check only in runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Fixes
 
+* `[jest-leak-detector]` Removed the reference to `weak`. Now, parent projects
+  must install it by hand for the module to work.
 * `[expect]` Fail test when the types of `stringContaining` and `stringMatching`
   matchers do not match. ([#5069](https://github.com/facebook/jest/pull/5069))
 * `[jest-cli]` Treat dumb terminals as noninteractive

--- a/packages/jest-leak-detector/package.json
+++ b/packages/jest-leak-detector/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "pretty-format": "^22.0.3"
   },
-  "optionalDependencies": {
+  "devDependencies": {
     "weak": "^1.0.1"
   }
 }

--- a/packages/jest-leak-detector/src/index.js
+++ b/packages/jest-leak-detector/src/index.js
@@ -37,7 +37,7 @@ export default class {
     let weak;
 
     try {
-      // eslint-disable-next-line
+      // eslint-disable-next-line import/no-extraneous-dependencies
       weak = require('weak');
     } catch (err) {
       if (!err || err.code !== 'MODULE_NOT_FOUND') {

--- a/packages/jest-leak-detector/src/index.js
+++ b/packages/jest-leak-detector/src/index.js
@@ -37,6 +37,7 @@ export default class {
     let weak;
 
     try {
+      // eslint-disable-next-line
       weak = require('weak');
     } catch (err) {
       if (!err || err.code !== 'MODULE_NOT_FOUND') {
@@ -44,8 +45,8 @@ export default class {
       }
 
       throw new Error(
-        'The leaking detection mechanism requires the "weak" package to work. ' +
-          'Please make sure that you can install the native dependency on your platform.',
+        'The leaking detection mechanism requires the "weak" package to be installed and work. ' +
+          'Please install it as a dependency on your main project',
       );
     }
 


### PR DESCRIPTION
Fully remove the module from the package, and leave the developer willing to use it to install it on the parent package. This way we will avoid crashing or waiting for a timeout if the machine cannot compile it or has no internet connection.

Keeping it as an optional dependency means that the network timeout has to be triggered; which can take a lot of time depending on the setup.