### PR TITLE
Fix updateSnapshot resetting after updating snapshots in watch mode

### DIFF
--- a/packages/jest-cli/src/__tests__/watch.test.js
+++ b/packages/jest-cli/src/__tests__/watch.test.js
@@ -257,6 +257,8 @@ describe('Watch mode flows', () => {
   });
 
   it('Pressing "u" reruns the tests in "update snapshot" mode', () => {
+    globalConfig.updateSnapshot = 'new';
+
     watch(globalConfig, contexts, pipe, hasteMapInstances, stdin);
     runJestMock.mockReset();
 
@@ -270,7 +272,7 @@ describe('Watch mode flows', () => {
     stdin.emit(KEYS.A);
     // updateSnapshot is not sticky after a run.
     expect(runJestMock.mock.calls[1][0].globalConfig).toMatchObject({
-      updateSnapshot: 'none',
+      updateSnapshot: 'new',
       watch: false,
     });
   });

--- a/packages/jest-cli/src/watch.js
+++ b/packages/jest-cli/src/watch.js
@@ -212,13 +212,15 @@ export default function watch(
         startRun(globalConfig);
         break;
       case KEYS.U:
+        const previousUpdateSnapshot = globalConfig.updateSnapshot;
+
         globalConfig = updateGlobalConfig(globalConfig, {
           updateSnapshot: 'all',
         });
         startRun(globalConfig);
         globalConfig = updateGlobalConfig(globalConfig, {
           // updateSnapshot is not sticky after a run.
-          updateSnapshot: 'none',
+          updateSnapshot: previousUpdateSnapshot,
         });
         break;
       case KEYS.A:


### PR DESCRIPTION
Fixes #4869

I'm not sure if current behavior was intended, but this fix works for me.
Also I wonder if it'd be enough to always reset to `new` instead of `none`, since it runs in the watch mode?