### PR TITLE
Remove example folder from package

### DIFF
--- a/packages/jest-phabricator/.npmignore
+++ b/packages/jest-phabricator/.npmignore
@@ -1,3 +1,4 @@
 **/__mocks__/**
 **/__tests__/**
+example
 src


### PR DESCRIPTION
Remove unneeded `example` folder in the resulting NPM package.