### PR TITLE
Fix memory leak from snapshot printing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ### Fixes
 
-* `[jest-jasmine2]` Fix memory leak in obsolete snapshot reporting ([#5279](https://github.com/facebook/jest/pull/5279))
+* `[jest-jasmine2]` Fix memory leak in snapshot reporting ([#5279](https://github.com/facebook/jest/pull/5279))
 
 ## jest 22.0.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## master
+## jest 22.0.6
+
+### Fixes
+
+* `[jest-jasmine2]` Fix memory leak in obsolete snapshot reporting.
 
 ## jest 22.0.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ### Fixes
 
-* `[jest-jasmine2]` Fix memory leak in obsolete snapshot reporting.
+* `[jest-jasmine2]` Fix memory leak in obsolete snapshot reporting ([#5279](https://github.com/facebook/jest/pull/5279))
 
 ## jest 22.0.5
 

--- a/packages/jest-jasmine2/src/index.js
+++ b/packages/jest-jasmine2/src/index.js
@@ -174,6 +174,7 @@ const addSnapshotData = (results, snapshotState) => {
   results.snapshot.unmatched = snapshotState.unmatched;
   results.snapshot.updated = snapshotState.updated;
   results.snapshot.unchecked = !status.deleted ? uncheckedCount : 0;
+  // Copy the array to prevent memory leaks
   results.snapshot.uncheckedKeys = Array.from(uncheckedKeys);
 
   return results;

--- a/packages/jest-jasmine2/src/index.js
+++ b/packages/jest-jasmine2/src/index.js
@@ -174,7 +174,7 @@ const addSnapshotData = (results, snapshotState) => {
   results.snapshot.unmatched = snapshotState.unmatched;
   results.snapshot.updated = snapshotState.updated;
   results.snapshot.unchecked = !status.deleted ? uncheckedCount : 0;
-  results.snapshot.uncheckedKeys = uncheckedKeys;
+  results.snapshot.uncheckedKeys = Array.from(uncheckedKeys);
 
   return results;
 };


### PR DESCRIPTION
## Summary

This PR fixes a memory leak introduced in https://github.com/facebook/jest/pull/5020

Fixes https://github.com/facebook/jest/issues/5234
Fixes https://github.com/facebook/jest/issues/5239
Fixes https://github.com/facebook/jest/issues/5157

## Details

I initially confirmed that `--detectLeaks` is broken for all tests. The next step was to figure out if this was a bug in the way we detect leaks or if it's a legit leak. Using [this repo](https://github.com/kand/jest-22-mem-leak), I walked the commits backward to find the last passing test.

That lead me to [this commit](https://github.com/facebook/jest/commit/3d2eb37e757c2e3e0e10d6fd079f81dc020cbb58). Nothing there is related to the leak detection, so I figured it must be a legit leak. From there I commented out lines until I could prove which line would fix the tests, then inspected the line.

It looks like we were keeping around references to the whole snapshot state. The fix is to remove the dependency using Array.from.

I'm not entirely sure how this is failing the environment leak detection, maybe the Snapshot State somehow keeps a reference to the environment?

## Test plan
There are a couple of ways to test/demonstrate this.

### 1. via `--detectLeaks`
Considering [this test repo](https://github.com/kand/jest-22-mem-leak), running `yarn test` from master will fail:

![](http://dp.hanlon.io/231y0J0t0j0p/Image%202018-01-10%20at%208.01.21%20PM.png)

With this change they pass:

![](http://dp.hanlon.io/110H0d0A1E32/Image%202018-01-10%20at%207.59.38%20PM.png)

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos if the pull request changes UI. -->

### 2. via React
This fix also fixes the memory issue @gaearon found in React for this command:

```bash
yarn test --coverage --runInBand --logHeapUsage
```

Result of Jest master (OOM at 1.5GB):

![](http://dp.hanlon.io/1o023e2b2R2E/Image%202018-01-10%20at%208.04.18%20PM.png)

With this fix (capped at 500MB):

![](http://dp.hanlon.io/420K1n2B0h3S/Image%202018-01-10%20at%208.13.19%20PM.png)

