### PR TITLE
[docs] Fix Markdown syntax typo in Webpack docs.

### DIFF
--- a/docs/Webpack.md
+++ b/docs/Webpack.md
@@ -180,9 +180,10 @@ direct analogs in Jest's `moduleDirectories` and `moduleFileExtensions` options.
 }
 ```
 
-> Note: <rootDir> is a special token that gets replaced by Jest with the root of
-> your project. Most of the time this will be the folder where your package.json
-> is located unless you specify a custom `rootDir` option in your configuration.
+> Note: `<rootDir>` is a special token that gets replaced by Jest with the root
+> of your project. Most of the time this will be the folder where your
+> `package.json` is located unless you specify a custom `rootDir` option in your
+> configuration.
 
 Similarly webpack's `resolve.root` option functions like setting the `NODE_PATH`
 env variable, which you can set, or make use of the `modulePaths` option.


### PR DESCRIPTION
**Summary**
A un-escaped reference to `<rootDir>` in a blockquote was being interpreted as an HTML tag, causing it not to appear in the rendered docs — the result of which is  a slightly confusing read. This PR surrounds the tag in `backticks` to ensure it's rendered correctly. (See screenshots below)

**Test plan**

I've verified this fix by running the docs website locally, e.g.:
```bash
$ yarn && yarn build
$ cd website && yarn start # Verify regression exists in `master` (see screenshot #1)
$ cd -
$ nvim docs/Webpack.md  # Fix typo
$ cd website && yarn start # Verify regression is fixed (see screenshot #2)
```

#### Screenshot #1
![image](https://user-images.githubusercontent.com/583147/34808601-e13f4264-f65d-11e7-9eca-788feb8985ef.png)

#### Screenshot #2  
![image](https://user-images.githubusercontent.com/583147/34808609-f12dd79e-f65d-11e7-8530-e6813cca2b58.png)
