### PR TITLE
Add #5269 to docs and change log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Fixes
 
 * `[jest-jasmine2]` Fix memory leak in snapshot reporting ([#5279](https://github.com/facebook/jest/pull/5279))
+* `[jest-config]` Fix breaking change in `--testPathPattern` ([#5269](https://github.com/facebook/jest/pull/5269))
 
 ## jest 22.0.5
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -85,8 +85,9 @@ CLI options take precedence over values from the
 When you run `jest` with an argument, that argument is treated as a regular
 expression to match against files in your project. It is possible to run test
 suites by providing a pattern. Only the files that the pattern matches will be
-picked up and executed. Note: depending on your terminal, you may need to quote
-this argument: `jest "my.*(complex)?pattern"`.
+picked up and executed. Depending on your terminal, you may need to quote this
+argument: `jest "my.*(complex)?pattern"`. On Windows, you will need to use `/`
+as a path separator or escape `\` as `\\`.
 
 ### `--bail`
 
@@ -276,7 +277,8 @@ Note that `column` is 0-indexed while `line` is not.
 ### `--testPathPattern=<regex>`
 
 A regexp pattern string that is matched against all tests paths before executing
-the test.
+the test. On Windows, you will need to use `/` as a path separator or escape `\`
+as `\\`.
 
 ### `--testRunner=<path>`
 


### PR DESCRIPTION
**Summary**
Adds missing change log entry from #5269 for @SimenB.

Also adds a note to the CLI docs for `jest <regexForTestFiles>` and `jest --testPathPattern` that Windows users can use `/` as a path separator, or should escape `\` as `\\`.

**Test plan**
N/A

**Change log**:
This one's a chore -- we don't need an entry.

cc @SimenB