### PR TITLE
Update Configuration.md

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -297,7 +297,7 @@ Note that, if you specify a global reference value (like an object or array)
 here, and some code mutates that value in the midst of running a test, that
 mutation will _not_ be persisted across test runs for other test files. In
 addition the `globals` object must be json-seriazable, so it can't be used
-to specify global functions. For that you should use setup module.
+to specify global functions. For that you should use `setupFiles`.
 
 ### `globalSetup` [string]
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -295,7 +295,9 @@ For example, the following would create a global `__DEV__` variable set to
 
 Note that, if you specify a global reference value (like an object or array)
 here, and some code mutates that value in the midst of running a test, that
-mutation will _not_ be persisted across test runs for other test files.
+mutation will _not_ be persisted across test runs for other test files. In
+addition the `globals` object must be json-seriazable, so it can't be used
+to specify global functions. For that you should use setup module.
 
 ### `globalSetup` [string]
 
@@ -330,7 +332,7 @@ Both inline source maps and source maps returned directly from a transformer are
 supported. Source map URLs are not supported because Jest may not be able to
 locate them. To return source maps from a transformer, the `process` function
 can return an object like the following. The `map` property may either be the
-source map object, or the source map object as a JSON string.
+source map object, or the source map object as a string.
 
 ```js
 return {


### PR DESCRIPTION
**Summary**

This PR adds note to `globals` setting that its contents need to be json serializable, and thus its not supporting functions for its values. This is something that originally has bitten me once I've moved to  parallelized tests execution and it feels to me that this should be documented somewhere.

**Test plan**

This is documentation's change.
