### PR TITLE
Fix typos in documentation

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -296,7 +296,7 @@ For example, the following would create a global `__DEV__` variable set to
 Note that, if you specify a global reference value (like an object or array)
 here, and some code mutates that value in the midst of running a test, that
 mutation will _not_ be persisted across test runs for other test files. In
-addition the `globals` object must be json-seriazable, so it can't be used
+addition the `globals` object must be json-serializable, so it can't be used
 to specify global functions. For that you should use `setupFiles`.
 
 ### `globalSetup` [string]

--- a/docs/JestObjectAPI.md
+++ b/docs/JestObjectAPI.md
@@ -310,7 +310,7 @@ Executes only the macro task queue (i.e. all tasks queued by `setTimeout()` or
 
 When this API is called, all timers are advanced by `msToRun` milliseconds. All
 pending "macro-tasks" that have been queued via `setTimeout()` or
-`setInterval()`, and would be executed within this timeframe will be executed.
+`setInterval()`, and would be executed within this time frame will be executed.
 Additionally if those macro-tasks schedule new macro-tasks that would be
 executed within the same time frame, those will be executed until there are no
 more macro-tasks remaining in the queue, that should be run within `msToRun`

--- a/docs/JestPlatform.md
+++ b/docs/JestPlatform.md
@@ -157,7 +157,7 @@ module.exports = {
 async function main() {
   const worker = new Worker(require.resolve('./heavy-task.js'));
 
-  // run 2 tasks in parellel with different arguments
+  // run 2 tasks in parallel with different arguments
   const results = await Promise.all([
     worker.myHeavyTask({foo: 'bar'}),
     worker.myHeavyTask({bar: 'foo'}),

--- a/docs/SnapshotTesting.md
+++ b/docs/SnapshotTesting.md
@@ -166,7 +166,7 @@ which reviewers can study your changes better.
 
 ### Does snapshot testing only work with React components?
 
-[React](TutorialReacte.md) and [React Native](TutorialReactNative.md) components
+[React](TutorialReact.md) and [React Native](TutorialReactNative.md) components
 are a good use case for snapshot testing. However, snapshots can capture any
 serializable value and should be used anytime the goal is testing whether the
 output is correct. The Jest repository contains many examples of testing the

--- a/docs/TimerMocks.md
+++ b/docs/TimerMocks.md
@@ -135,7 +135,7 @@ describe('infiniteTimerGame', () => {
 Another possibility is use `jest.advanceTimersByTime(msToRun)`. When this API is
 called, all timers are advanced by `msToRun` milliseconds. All pending
 "macro-tasks" that have been queued via setTimeout() or setInterval(), and would
-be executed during this timeframe, will be executed. Additionally if those
+be executed during this time frame, will be executed. Additionally if those
 macro-tasks schedule new macro-tasks that would be executed within the same time
 frame, those will be executed until there are no more macro-tasks remaining in
 the queue that should be run within msToRun milliseconds.


### PR DESCRIPTION
## Summary

Fixes a few typos and a broken link

## Test plan

Fixes this link:

![](http://dp.hanlon.io/391M1Q422V1O/Screen%20Recording%202018-01-13%20at%2004.13%20PM.gif)
