### PR TITLE
make --lastCommit and --changedFilesWithAncestor work without --onlyChanged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
   ([#5289](https://github.com/facebook/jest/pull/5289))
 * `[docs]` Update mention of the minimal version of node supported [#4947](https://github.com/facebook/jest/issues/4947)
 * `[jest-cli]` Fix missing newline in console message ([#5308](https://github.com/facebook/jest/pull/5308))
+* `[jest-cli]` `--lastCommit` and `--changedFilesWithAncestor` now take effect
+  even when `--onlyChanged` is not specified. ([#5307](https://github.com/facebook/jest/pull/5307))
 
 ### Chore & Maintenance
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -105,8 +105,8 @@ If you want to inspect the cache, use `--showConfig` and look at the
 
 ### `--changedFilesWithAncestor`
 
-When used together with `--onlyChanged` or `--watch`, it runs tests related to
-the current changes and the changes made in the last commit.
+Runs tests related to the current changes and the changes made in the last
+commit. Behaves similarly to `--onlyChanged`.
 
 ### `--ci`
 
@@ -188,8 +188,8 @@ Write test results to a file when the `--json` option is also specified.
 
 ### `--lastCommit`
 
-When used together with `--onlyChanged`, it will run all tests affected by file
-changes in the last commit made.
+Run all tests affected by file changes in the last commit made. Behaves
+similarly to `--onlyChanged`.
 
 ### `--listTests`
 

--- a/packages/jest-cli/src/__tests__/cli/args.test.js
+++ b/packages/jest-cli/src/__tests__/cli/args.test.js
@@ -31,6 +31,19 @@ describe('check', () => {
     );
   });
 
+  it('raises an exception when lastCommit and watchAll are both specified', () => {
+    const argv: Argv = {lastCommit: true, watchAll: true};
+    expect(() => check(argv)).toThrow(
+      'Both --lastCommit and --watchAll were specified',
+    );
+  });
+
+  it('sets onlyChanged if lastCommit is specified', () => {
+    const argv: Argv = {lastCommit: true};
+    check(argv);
+    expect(argv.onlyChanged).toBe(true);
+  });
+
   it('raises an exception if findRelatedTests is specified with no file paths', () => {
     const argv: Argv = {_: [], findRelatedTests: true};
     expect(() => check(argv)).toThrow(

--- a/packages/jest-cli/src/cli/args.js
+++ b/packages/jest-cli/src/cli/args.js
@@ -20,12 +20,17 @@ export const check = (argv: Argv) => {
     );
   }
 
-  if (argv.onlyChanged && argv.watchAll) {
-    throw new Error(
-      'Both --onlyChanged and --watchAll were specified, but these two ' +
-        'options do not make sense together. Try the --watch option which ' +
-        'reruns only tests related to changed files.',
-    );
+  for (const key of ['onlyChanged', 'lastCommit', 'changedFilesWithAncestor']) {
+    if (argv[key]) {
+      argv.onlyChanged = true;
+    }
+    if (argv[key] && argv.watchAll) {
+      throw new Error(
+        `Both --${key} and --watchAll were specified, but these two ` +
+          'options do not make sense together. Try the --watch option which ' +
+          'reruns only tests related to changed files.',
+      );
+    }
   }
 
   if (argv.findRelatedTests && argv._.length === 0) {
@@ -104,8 +109,8 @@ export const options = {
   },
   changedFilesWithAncestor: {
     description:
-      'When used together with `--onlyChanged` or `--watch`, it runs tests ' +
-      'related to the current changes and the changes made in the last commit. ',
+      'Runs tests related to the current changes and the changes made in the ' +
+      'last commit. Behaves similarly to `--onlyChanged`.',
     type: 'boolean',
   },
   ci: {
@@ -267,8 +272,8 @@ export const options = {
   lastCommit: {
     default: undefined,
     description:
-      'When used together with `--onlyChanged`, it will run all tests ' +
-      'affected by file changes in the last commit made.',
+      'Run all tests affected by file changes in the last commit made. ' +
+      'Behaves similarly to `--onlyChanged`.',
     type: 'boolean',
   },
   listTests: {
@@ -353,7 +358,7 @@ export const options = {
     description:
       'Attempts to identify which tests to run based on which ' +
       "files have changed in the current repository. Only works if you're " +
-      'running tests in a git repository at the moment.',
+      'running tests in a git or hg repository at the moment.',
     type: 'boolean',
   },
   onlyFailures: {


### PR DESCRIPTION


<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
This came up in a discussion on another PR of mine, so I decided to fix it: https://github.com/facebook/jest/pull/5189#discussion_r158933030


**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

```
~/src/jest$ yarn jest --listTests | wc -l
     220
~/src/jest$ yarn jest --listTests --lastCommit | wc -l
       4
~/src/jest$ yarn jest --listTests --changedFilesWithAncestor | wc -l
       4
```

before this change, all 3 commands would output `220`