### PR TITLE
Move from "process.exit" to "exit

### DIFF
--- a/packages/jest-cli/package.json
+++ b/packages/jest-cli/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "ansi-escapes": "^3.0.0",
     "chalk": "^2.0.1",
+    "exit": "^0.1.2",
     "glob": "^7.1.2",
     "graceful-fs": "^4.1.11",
     "import-local": "^1.0.0",

--- a/packages/jest-cli/src/cli/index.js
+++ b/packages/jest-cli/src/cli/index.js
@@ -22,6 +22,7 @@ import {version as VERSION} from '../../package.json';
 import * as args from './args';
 import chalk from 'chalk';
 import createContext from '../lib/create_context';
+import exit from 'exit';
 import getChangedFilesPromise from '../get_changed_files_promise';
 import handleDeprecationWarnings from '../lib/handle_deprecation_warnings';
 import logDebugMessages from '../lib/log_debug_messages';
@@ -45,7 +46,7 @@ export async function run(maybeArgv?: Argv, project?: Path) {
     clearLine(process.stderr);
     clearLine(process.stdout);
     console.error(chalk.red(error.stack));
-    process.exit(1);
+    exit(1);
     throw error;
   }
 }
@@ -79,7 +80,7 @@ export const runCLI = async (
       process.stdout.write(`Cleared ${config.cacheDirectory}\n`);
     });
 
-    process.exit(0);
+    exit(0);
   }
 
   await _run(
@@ -111,9 +112,11 @@ const readResultsAndExit = (
   globalConfig: GlobalConfig,
 ) => {
   const code = !result || result.success ? 0 : globalConfig.testFailureExitCode;
-  process.on('exit', () => process.exit(code));
+
+  process.on('exit', () => exit(code));
+
   if (globalConfig.forceExit) {
-    process.exit(code);
+    exit(code);
   }
 };
 
@@ -164,13 +167,13 @@ const printDebugInfoAndExitIfNeeded = (
     logDebugMessages(globalConfig, configs, outputStream);
   }
   if (argv.showConfig) {
-    process.exit(0);
+    exit(0);
   }
 };
 
 const printVersionAndExit = outputStream => {
   outputStream.write(`v${VERSION}\n`);
-  process.exit(0);
+  exit(0);
 };
 
 const ensureNoDuplicateConfigs = (parsedConfigs, projects) => {
@@ -346,7 +349,7 @@ const runWatch = async (
       await handleDeprecationWarnings(outputStream, process.stdin);
       return watch(globalConfig, contexts, outputStream, hasteMapInstances);
     } catch (e) {
-      process.exit(0);
+      exit(0);
     }
   }
 

--- a/packages/jest-cli/src/reporters/coverage_worker.js
+++ b/packages/jest-cli/src/reporters/coverage_worker.js
@@ -9,6 +9,7 @@
 
 import type {GlobalConfig, ProjectConfig, Path} from 'types/Config';
 
+import exit from 'exit';
 import fs from 'fs';
 import generateEmptyCoverage from '../generate_empty_coverage';
 import type {CoverageWorkerResult} from '../generate_empty_coverage';
@@ -24,7 +25,7 @@ export type {CoverageWorkerResult};
 // Make sure uncaught errors are logged before we exit.
 process.on('uncaughtException', err => {
   console.error(err.stack);
-  process.exit(1);
+  exit(1);
 });
 
 export function worker({

--- a/packages/jest-cli/src/reporters/notify_reporter.js
+++ b/packages/jest-cli/src/reporters/notify_reporter.js
@@ -11,6 +11,7 @@ import type {GlobalConfig} from 'types/Config';
 import type {AggregatedResult} from 'types/TestResult';
 import type {Context} from 'types/Context';
 
+import exit from 'exit';
 import path from 'path';
 import util from 'util';
 import notifier from 'node-notifier';
@@ -73,7 +74,7 @@ export default class NotifyReporter extends BaseReporter {
             return;
           }
           if (metadata.activationValue === quitAnswer) {
-            process.exit(0);
+            exit(0);
             return;
           }
           if (metadata.activationValue === restartAnswer) {

--- a/packages/jest-cli/src/run_jest.js
+++ b/packages/jest-cli/src/run_jest.js
@@ -16,6 +16,7 @@ import type TestWatcher from './test_watcher';
 import chalk from 'chalk';
 import path from 'path';
 import {Console, formatTestResults} from 'jest-util';
+import exit from 'exit';
 import fs from 'graceful-fs';
 import getNoTestsFoundMessage from './get_no_test_found_message';
 import SearchSource from './search_source';
@@ -111,7 +112,7 @@ export default (async function runJest({
           ' is not supported without git/hg, please use --watchAll ' +
           '\n',
       );
-      process.exit(1);
+      exit(1);
     }
   }
 
@@ -163,7 +164,7 @@ export default (async function runJest({
     } else {
       new Console(outputStream, outputStream).error(noTestsFoundMessage);
 
-      process.exit(1);
+      exit(1);
     }
   } else if (
     allTests.length === 1 &&

--- a/packages/jest-cli/src/test_scheduler.js
+++ b/packages/jest-cli/src/test_scheduler.js
@@ -21,6 +21,7 @@ import {
 } from './test_result_helpers';
 import CoverageReporter from './reporters/coverage_reporter';
 import DefaultReporter from './reporters/default_reporter';
+import exit from 'exit';
 import NotifyReporter from './reporters/notify_reporter';
 import ReporterDispatcher from './reporter_dispatcher';
 import snapshot from 'jest-snapshot';
@@ -324,11 +325,12 @@ export default class TestScheduler {
       if (watcher.isWatchMode()) {
         watcher.setState({interrupted: true});
       } else {
-        const exit = () => process.exit(1);
+        const failureExit = () => exit(1);
+
         return this._dispatcher
           .onRunComplete(contexts, aggregatedResults)
-          .then(exit)
-          .catch(exit);
+          .then(failureExit)
+          .catch(failureExit);
       }
     }
     return Promise.resolve();

--- a/packages/jest-cli/src/watch.js
+++ b/packages/jest-cli/src/watch.js
@@ -14,6 +14,7 @@ import type {WatchPlugin} from './types';
 import ansiEscapes from 'ansi-escapes';
 import chalk from 'chalk';
 import getChangedFilesPromise from './get_changed_files_promise';
+import exit from 'exit';
 import {replacePathSepForRegex} from 'jest-regex-util';
 import HasteMap from 'jest-haste-map';
 import isValidPath from './lib/is_valid_path';
@@ -173,7 +174,7 @@ export default function watch(
   const onKeypress = (key: string) => {
     if (key === KEYS.CONTROL_C || key === KEYS.CONTROL_D) {
       outputStream.write('\n');
-      process.exit(0);
+      exit(0);
       return;
     }
 
@@ -222,7 +223,7 @@ export default function watch(
     switch (key) {
       case KEYS.Q:
         outputStream.write('\n');
-        process.exit(0);
+        exit(0);
         return;
       case KEYS.ENTER:
         startRun(globalConfig);

--- a/packages/jest-runner/package.json
+++ b/packages/jest-runner/package.json
@@ -8,6 +8,7 @@
   "license": "MIT",
   "main": "build/index.js",
   "dependencies": {
+    "exit": "^0.1.2",
     "jest-config": "^22.1.0",
     "jest-docblock": "^22.1.0",
     "jest-haste-map": "^22.1.0",

--- a/packages/jest-runner/src/index.js
+++ b/packages/jest-runner/src/index.js
@@ -19,6 +19,7 @@ import type {
 
 import typeof {worker} from './test_worker';
 
+import exit from 'exit';
 import runTest from './run_test';
 import throat from 'throat';
 import Worker from 'jest-worker';
@@ -129,7 +130,7 @@ class TestRunner {
           'A worker process has quit unexpectedly! ' +
             'Most likely this is an initialization error.',
         );
-        process.exit(1);
+        exit(1);
       }
     };
 

--- a/packages/jest-runner/src/test_worker.js
+++ b/packages/jest-runner/src/test_worker.js
@@ -11,12 +11,7 @@ import type {GlobalConfig, Path, ProjectConfig} from 'types/Config';
 import type {SerializableError, TestResult} from 'types/TestResult';
 import type {RawModuleMap} from 'types/HasteMap';
 
-// Make sure uncaught errors are logged before we exit.
-process.on('uncaughtException', err => {
-  console.error(err.stack);
-  process.exit(1);
-});
-
+import exit from 'exit';
 import HasteMap from 'jest-haste-map';
 import {separateMessageFromStack} from 'jest-message-util';
 import Runtime from 'jest-runtime';
@@ -28,6 +23,12 @@ export type WorkerData = {|
   path: Path,
   rawModuleMap: ?RawModuleMap,
 |};
+
+// Make sure uncaught errors are logged before we exit.
+process.on('uncaughtException', err => {
+  console.error(err.stack);
+  exit(1);
+});
 
 const formatError = (error: string | Error): SerializableError => {
   if (typeof error === 'string') {

--- a/packages/jest-runtime/package.json
+++ b/packages/jest-runtime/package.json
@@ -13,6 +13,7 @@
     "babel-plugin-istanbul": "^4.1.5",
     "chalk": "^2.0.1",
     "convert-source-map": "^1.4.0",
+    "exit": "^0.1.2",
     "graceful-fs": "^4.1.11",
     "jest-config": "^22.1.0",
     "jest-haste-map": "^22.1.0",

--- a/packages/jest-runtime/src/cli/index.js
+++ b/packages/jest-runtime/src/cli/index.js
@@ -10,9 +10,10 @@
 import type {Argv} from 'types/Argv';
 import type {EnvironmentClass} from 'types/Environment';
 
+import chalk from 'chalk';
+import exit from 'exit';
 import os from 'os';
 import path from 'path';
-import chalk from 'chalk';
 import yargs from 'yargs';
 import {Console, setGlobal, validateCLIOptions} from 'jest-util';
 import {readConfig} from 'jest-config';
@@ -42,7 +43,7 @@ export function run(cliArgv?: Argv, cliInfo?: Array<string>) {
 
   if (argv.help) {
     yargs.showHelp();
-    process.on('exit', () => process.exit(1));
+    process.on('exit', () => exit(1));
     return;
   }
 
@@ -53,7 +54,7 @@ export function run(cliArgv?: Argv, cliInfo?: Array<string>) {
 
   if (!argv._.length) {
     console.log('Please provide a path to a script. (See --help for details)');
-    process.on('exit', () => process.exit(1));
+    process.on('exit', () => exit(1));
     return;
   }
 
@@ -92,6 +93,6 @@ export function run(cliArgv?: Argv, cliInfo?: Array<string>) {
     })
     .catch(e => {
       console.error(chalk.red(e.stack || e));
-      process.on('exit', () => process.exit(1));
+      process.on('exit', () => exit(1));
     });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3065,6 +3065,10 @@ execa@^0.8.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
+exit@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
+
 expand-braces@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/expand-braces/-/expand-braces-0.1.2.tgz#488b1d1d2451cb3d3a6b192cfc030f44c5855fea"


### PR DESCRIPTION
Changing all `process.exit` to `exit`. This prevents sudden truncation of Jest output when finishing test execution, if the output information is too big (I've seen issues when the JSON output is above 256 KiB). As per the Node docs, `process.exit()` will not wait up until all buffers are flushed, and will try to quit as soon as possible.

Tests are still passing since `exit` uses `process.exit` underneath.