### PR TITLE
Verify passed test path is a file before resolving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## master
 
+## jest 22.1.1
+
+### Fixes
+
+* `[jest-cli]` Fix `EISDIR` when a directory is passed as an argument to `jest`.
+  ([#5317](https://github.com/facebook/jest/pull/5317))
+
 ## jest 22.1.0
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
 ## master
 
-## jest 22.1.1
-
 ### Fixes
 
 * `[jest-cli]` Fix `EISDIR` when a directory is passed as an argument to `jest`.

--- a/integration-tests/__tests__/__snapshots__/cli-accepts-exact-filenames.test.js.snap
+++ b/integration-tests/__tests__/__snapshots__/cli-accepts-exact-filenames.test.js.snap
@@ -22,7 +22,7 @@ exports[`CLI accepts exact filenames 2`] = `
 Tests:       2 passed, 2 total
 Snapshots:   0 total
 Time:        <<REPLACED>>
-Ran all test suites matching /.\\\\/bar.js|.\\\\/foo\\\\/baz.js/i.
+Ran all test suites matching /.\\\\/bar.js|.\\\\/foo\\\\/baz.js|.\\\\/foo/i.
 "
 `;
 

--- a/integration-tests/__tests__/cli-accepts-exact-filenames.test.js
+++ b/integration-tests/__tests__/cli-accepts-exact-filenames.test.js
@@ -38,6 +38,7 @@ test('CLI accepts exact filenames', () => {
     '--forceExit',
     './bar.js',
     './foo/baz.js',
+    './foo',
   ]);
   const {rest, summary} = extractSummary(stderr);
   expect(status).toBe(0);

--- a/packages/jest-cli/src/search_source.js
+++ b/packages/jest-cli/src/search_source.js
@@ -211,7 +211,13 @@ export default class SearchSource {
     } else {
       const validTestPaths =
         paths &&
-        paths.filter(fs.existsSync).filter(name => fs.lstatSync(name).isFile());
+        paths.filter(name => {
+          try {
+            return fs.lstatSync(name).isFile();
+          } catch (e) {
+            return false;
+          }
+        });
 
       if (validTestPaths && validTestPaths.length) {
         return Promise.resolve({tests: toTests(this._context, validTestPaths)});

--- a/packages/jest-cli/src/search_source.js
+++ b/packages/jest-cli/src/search_source.js
@@ -209,7 +209,9 @@ export default class SearchSource {
     } else if (globalConfig.findRelatedTests && paths && paths.length) {
       return Promise.resolve(this.findRelatedTestsFromPattern(paths));
     } else {
-      const validTestPaths = paths && paths.filter(fs.existsSync);
+      const validTestPaths =
+        paths &&
+        paths.filter(fs.existsSync).filter(name => fs.lstatSync(name).isFile());
 
       if (validTestPaths && validTestPaths.length) {
         return Promise.resolve({tests: toTests(this._context, validTestPaths)});


### PR DESCRIPTION
**Summary**

This PR fixes #5272 by fixing the regression introduced in #3882.

#3882 allows directly specifying file names as arguments to the `jest` CLI but this unintentionally breaks existing behavior when a test directory is passed as the sole argument to `jest`.

**Fix details**

*Symptom*: When `*.test.js` files are stored in a directory e.g. `test`, invoking `jest test` on v22.0.5+ results in the following:

```
 FAIL  ./test
  ● Test suite failed to run

    EISDIR: illegal operation on a directory, read
      
      at Object.readSync (node_modules/graceful-fs/polyfills.js:138:28)

Test Suites: 1 failed, 1 total
Tests:       0 total
Snapshots:   0 total
Time:        0.03s
Ran all test suites matching /test/i.
```

*Root cause*: The change allowing directly running tests by file name does not ensure that the passed argument is not a directory (or, more generally, that the passed argument *is* a file).

*Remediation*: Filter out all valid test paths that aren't files before continuing existing logic.

**Test plan**

The test added by #3882 was updated to also pass a directory as an argument to the CLI. We observe that no errors are thrown; without this change, the test would fatally throw with `EISDIR` as shown in the example symptom above.

**Discussion**

1. Unclear if the performance impact by invoking `fs.lstatSync` on each valid test path is significant enough to explore alternatives.

2. After poking around with this for a bit, I actually believe this regression creates a desired interface change. If the client wants to recursively search a directory for tests to run, he/she *should* explicitly pass option `--testPathPattern` as stated [here](https://github.com/facebook/jest/issues/5272#issuecomment-357664584) as a workaround for the bug. Based on the [changeset](https://github.com/facebook/jest/pull/3882/files#diff-c53e4529a552a817e1fa7c27419db19bL210) in #3882 it seems like the fact that invoking the CLI as `jest dir-with-tests` works seems to be a coincidental side effect.

But anyway, that is a breaking interface change, so this PR just tries to fix the regression as-is.