### PR TITLE
Adding async versions of mockReturnValue & mockreturnValueOnce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## master
 
+### features
+
+* `[jest-mock]` Add util methods to create async functions. 
+  ([#5318](https://github.com/facebook/jest/pull/5318)) 
+
 ### Fixes
 
 * `[jest]` Add `import-local` to `jest` package.

--- a/docs/MockFunctionAPI.md
+++ b/docs/MockFunctionAPI.md
@@ -241,3 +241,76 @@ const myMockFn = jest.fn()
 console.log(myMockFn(), myMockFn(), myMockFn(), myMockFn());
 > 'first call', 'second call', 'default', 'default'
 ```
+
+### `mockFn.mockResolvedValue(value)`
+
+Simple sugar function for:
+
+```js
+jest.fn().mockReturnValue(Promise.resolve(value));
+```
+
+Useful to mock async functions in async tests:
+
+```js
+const asyncMock = jest.fn().mockResolvedValue(43);
+
+await asyncMock(); // 43
+```
+
+### `mockFn.mockRejectedValueOnce(value)`
+
+Simple sugar function for:
+
+```js
+jest.fn().mockReturnValueOnce(Promise.resolve(value));
+```
+
+Useful to resolve different values over multiple async calls:
+
+```
+const asyncMock = jest.fn()
+  .mockResolvedValue('default')
+  .mockResolvedValueOnce('first call')
+  .mockResolvedValueOnce('second call');
+
+await asyncMock(); // first call
+await asyncMock(); // second call
+await asyncMock(); // default
+await asyncMock(); // default
+```
+
+### `mockFn.mockRejectedValue(value)`
+
+Simple sugar function for:
+
+```js
+jest.fn().mockReturnValue(Promise.reject(value));
+```
+
+Useful to create async mock functions that will always reject:
+
+```js
+const asyncMock = jest.fn().mockRejectedValue(new Error('Async error'));
+
+await asyncMock(); // throws "Async error"
+```
+
+### `mockFn.mockRejectedValueOnce(value)`
+
+Simple sugar function for:
+
+```js
+jest.fn().mockReturnValueOnce(Promise.reject(value));
+```
+
+Example usage:
+
+```js
+const asyncMock = jest.fn()
+  .mockResolvedValueOnce('first call')
+  .mockRejectedValueOnce(new Error('Async error'));
+
+await asyncMock(); // first call
+await asyncMock(); // throws "Async error"
+```

--- a/docs/MockFunctionAPI.md
+++ b/docs/MockFunctionAPI.md
@@ -253,9 +253,11 @@ jest.fn().mockReturnValue(Promise.resolve(value));
 Useful to mock async functions in async tests:
 
 ```js
-const asyncMock = jest.fn().mockResolvedValue(43);
-
-await asyncMock(); // 43
+test('async test', async () => {
+  const asyncMock = jest.fn().mockResolvedValue(43);
+  
+  await asyncMock(); // 43
+});
 ```
 
 ### `mockFn.mockRejectedValueOnce(value)`
@@ -268,16 +270,18 @@ jest.fn().mockReturnValueOnce(Promise.resolve(value));
 
 Useful to resolve different values over multiple async calls:
 
-```
-const asyncMock = jest.fn()
-  .mockResolvedValue('default')
-  .mockResolvedValueOnce('first call')
-  .mockResolvedValueOnce('second call');
-
-await asyncMock(); // first call
-await asyncMock(); // second call
-await asyncMock(); // default
-await asyncMock(); // default
+```js
+test('async test', async () => {
+  const asyncMock = jest.fn()
+    .mockResolvedValue('default')
+    .mockResolvedValueOnce('first call')
+    .mockResolvedValueOnce('second call');
+  
+  await asyncMock(); // first call
+  await asyncMock(); // second call
+  await asyncMock(); // default
+  await asyncMock(); // default
+});
 ```
 
 ### `mockFn.mockRejectedValue(value)`
@@ -291,9 +295,11 @@ jest.fn().mockReturnValue(Promise.reject(value));
 Useful to create async mock functions that will always reject:
 
 ```js
-const asyncMock = jest.fn().mockRejectedValue(new Error('Async error'));
-
-await asyncMock(); // throws "Async error"
+test('async test', async () => {
+  const asyncMock = jest.fn().mockRejectedValue(new Error('Async error'));
+  
+  await asyncMock(); // throws "Async error"
+});
 ```
 
 ### `mockFn.mockRejectedValueOnce(value)`
@@ -307,10 +313,12 @@ jest.fn().mockReturnValueOnce(Promise.reject(value));
 Example usage:
 
 ```js
-const asyncMock = jest.fn()
-  .mockResolvedValueOnce('first call')
-  .mockRejectedValueOnce(new Error('Async error'));
-
-await asyncMock(); // first call
-await asyncMock(); // throws "Async error"
+test('async test', async () => {
+  const asyncMock = jest.fn()
+    .mockResolvedValueOnce('first call')
+    .mockRejectedValueOnce(new Error('Async error'));
+  
+  await asyncMock(); // first call
+  await asyncMock(); // throws "Async error"
+});
 ```

--- a/packages/jest-mock/src/__tests__/jest_mock.test.js
+++ b/packages/jest-mock/src/__tests__/jest_mock.test.js
@@ -399,7 +399,7 @@ describe('moduleMocker', () => {
 
       expect(promise).toBeInstanceOf(Promise);
 
-      return promise.then(value => expect(value).toBe('abcd'));
+      return expect(promise).resolves.toBe('abcd');
     });
 
     it('supports mocking resolvable async functions only once', () => {
@@ -407,10 +407,10 @@ describe('moduleMocker', () => {
       fn.mockResolvedValue('abcd');
       fn.mockResolvedValueOnce('abcde');
 
-      const promise1 = fn().then(value => expect(value).toBe('abcde'));
-      const promise2 = fn().then(value => expect(value).toBe('abcd'));
-
-      return Promise.all([promise1, promise2]);
+      return Promise.all([
+        expect(fn()).resolves.toBe('abcde'),
+        expect(fn()).resolves.toBe('abcd'),
+      ]);
     });
 
     it('supports mocking rejectable async functions', () => {
@@ -422,9 +422,7 @@ describe('moduleMocker', () => {
 
       expect(promise).toBeInstanceOf(Promise);
 
-      return promise
-        .then(() => Promise.reject(new Error('did not reject')))
-        .catch(rejection => expect(rejection).toBe(err));
+      return expect(promise).rejects.toBe(err);
     });
 
     it('supports mocking rejectable async functions only once', () => {
@@ -434,14 +432,10 @@ describe('moduleMocker', () => {
       fn.mockRejectedValue(defaultErr);
       fn.mockRejectedValueOnce(err);
 
-      const promise1 = fn()
-        .then(() => Promise.reject(new Error('did not reject')))
-        .catch(rejection => expect(rejection).toBe(err));
-      const promise2 = fn()
-        .then(() => Promise.reject(new Error('did not reject')))
-        .catch(rejection => expect(rejection).toBe(defaultErr));
-
-      return Promise.all([promise1, promise2]);
+      return Promise.all([
+        expect(fn()).rejects.toBe(err),
+        expect(fn()).rejects.toBe(defaultErr),
+      ]);
     });
 
     describe('timestamps', () => {

--- a/packages/jest-mock/src/__tests__/jest_mock.test.js
+++ b/packages/jest-mock/src/__tests__/jest_mock.test.js
@@ -391,6 +391,55 @@ describe('moduleMocker', () => {
       expect(fake(2)).toEqual(4);
     });
 
+    it('supports mocking resolvable async functions', () => {
+      const fn = moduleMocker.fn();
+      fn.mockResolvedValue('abcd');
+
+      const promise = fn();
+
+      expect(promise).toBeInstanceOf(Promise);
+
+      return promise.then(value => expect(value).toBe('abcd'));
+    });
+
+    it('supports mocking resolvable async functions only once', () => {
+      const fn = moduleMocker.fn();
+      fn.mockResolvedValue('abcd');
+      fn.mockResolvedValueOnce('abcde');
+
+      const promise1 = fn().then(value => expect(value).toBe('abcde'));
+      const promise2 = fn().then(value => expect(value).toBe('abcd'));
+
+      return Promise.all([promise1, promise2]);
+    });
+
+    it('supports mocking rejectable async functions', () => {
+      const err = new Error('rejected');
+      const fn = moduleMocker.fn();
+      fn.mockRejectedValue(err);
+
+      const promise = fn();
+
+      expect(promise).toBeInstanceOf(Promise);
+
+      return promise.catch(rejection => expect(rejection).toBe(err));
+    });
+
+    it('supports mocking rejectable async functions only once', () => {
+      const defaultErr = new Error('default rejected');
+      const err = new Error('rejected');
+      const fn = moduleMocker.fn();
+      fn.mockRejectedValue(defaultErr);
+      fn.mockRejectedValueOnce(err);
+
+      const promise1 = fn().catch(rejection => expect(rejection).toBe(err));
+      const promise2 = fn().catch(rejection =>
+        expect(rejection).toBe(defaultErr),
+      );
+
+      return Promise.all([promise1, promise2]);
+    });
+
     describe('timestamps', () => {
       const RealDate = Date;
 

--- a/packages/jest-mock/src/__tests__/jest_mock.test.js
+++ b/packages/jest-mock/src/__tests__/jest_mock.test.js
@@ -422,7 +422,9 @@ describe('moduleMocker', () => {
 
       expect(promise).toBeInstanceOf(Promise);
 
-      return promise.catch(rejection => expect(rejection).toBe(err));
+      return promise
+        .then(() => Promise.reject(new Error('did not reject')))
+        .catch(rejection => expect(rejection).toBe(err));
     });
 
     it('supports mocking rejectable async functions only once', () => {
@@ -432,10 +434,12 @@ describe('moduleMocker', () => {
       fn.mockRejectedValue(defaultErr);
       fn.mockRejectedValueOnce(err);
 
-      const promise1 = fn().catch(rejection => expect(rejection).toBe(err));
-      const promise2 = fn().catch(rejection =>
-        expect(rejection).toBe(defaultErr),
-      );
+      const promise1 = fn()
+        .then(() => Promise.reject(new Error('did not reject')))
+        .catch(rejection => expect(rejection).toBe(err));
+      const promise2 = fn()
+        .then(() => Promise.reject(new Error('did not reject')))
+        .catch(rejection => expect(rejection).toBe(defaultErr));
 
       return Promise.all([promise1, promise2]);
     });


### PR DESCRIPTION
**Summary**

I find myself doing the following very often when testing async code:

```js
// ...
const asyncFn = jest.fn().mockReturnValue(Promise.resolve(result)):

// or...

const asyncFn = jest.fn().mockReturnValue(Promise.reject(err)):
// ...
```

This PR adds four utility methods to `MockInstance`, automating the creation of async mock functions:

```js
// ...
const asyncFn = jest.fn().mockResolvedValue(result):

// and...

const asyncFn = jest.fn().mockResolvedValueOnce(result):

// and...

const asyncFn = jest.fn().mockRejectedValue(result):

// and...

const asyncFn = jest.fn().mockRejectedValueOnce(result):

// ...
```

**Test plan**

**NA** (Not a bug)

---

This PR means to gather info on usage first, if people find this useful I'll continue to add the docs to this feature and updating the changelog as needed.

Thanks!
