### PR TITLE
Add space to "received snapshot" message

### DIFF
--- a/packages/jest-snapshot/src/index.js
+++ b/packages/jest-snapshot/src/index.js
@@ -79,7 +79,7 @@ const toMatchSnapshot = function(received: any, testName?: string) {
       `must be explicitly passed to write a new snapshot.\n\n` +
       `This is likely because this test is run in a continuous integration ` +
       `(CI) environment in which snapshots are not written by default.\n\n` +
-      `${RECEIVED_COLOR('Received value')}` +
+      `${RECEIVED_COLOR('Received value')} ` +
       `${actual}`;
   } else {
     expected = (expected || '').trim();


### PR DESCRIPTION
**Summary**

The value after "Received value" is missing a space

#### Before
<img width="1029" alt="screen shot 2018-01-15 at 10 23 37 am" src="https://user-images.githubusercontent.com/574806/34956613-cf671ee8-f9de-11e7-9648-1503a6bd7169.png">

#### After
<img width="1004" alt="screen shot 2018-01-15 at 10 27 01 am" src="https://user-images.githubusercontent.com/574806/34956612-cf50d890-f9de-11e7-82c5-b1bd6b3487ec.png">



**Test plan**
@SimenB  Do we need to update the CHANGELOG.md for this?
