### PR TITLE
Bring back some of the Jest homepage changes for mobile

### DIFF
--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -4,3 +4,56 @@
 	margin-bottom: -20px;
 	margin-right: -20px;
 }
+
+div.jest-repl {
+  margin: 0 5%;
+  position: relative;
+  width: 600px;
+}
+div.jest-repl iframe {
+  display: block;
+  margin: 0 auto 10px;
+  min-height: 420px;
+  width: 100%;
+}
+@media only screen and (min-device-width: 360px) and (max-device-width: 736px) {
+  div.jest-repl {
+    display: none;
+  }
+}
+@media only screen and (min-device-width: 768px) and (max-device-width: 1024px) {
+  div.jest-repl {
+    display: none;
+  }
+}
+@media only screen and (max-width: 1023px) {
+  div.jest-repl {
+    display: none;
+  }
+}
+
+div.video {
+  margin: 0 5%;
+  position: relative;
+  width: 100%;
+  min-width: 300px;
+  max-width: 600px;
+}
+
+div.video iframe {
+  display: block;
+  margin: 0 auto 10px;
+  min-height: 340px;
+  width: 100%;
+}
+
+@media only screen and (min-device-width: 360px) and (max-device-width: 736px) {
+  div.video {
+    display: none;
+  }
+}
+@media only screen and (max-width: 1023px) {
+  div.video {
+    display: none;
+  }
+}


### PR DESCRIPTION
This fixes the layout of the video on the homepage for both web and mobile ( e.g. [here](https://github.com/facebook/jest/blob/dfdca8b1/website/src/jest/css/jest.css#L1721-L1746) )

Before:

![screen shot 2018-01-15 at 1 37 06 pm](https://user-images.githubusercontent.com/49038/34956909-38a5a518-f9f9-11e7-919d-7551415a9271.png)

After:

![screen shot 2018-01-15 at 1 37 39 pm](https://user-images.githubusercontent.com/49038/34956919-443302c2-f9f9-11e7-9bc9-ef931e5e7fb4.png)