### PR TITLE
Executing globalConfig only when there are tests available to be exec…

### DIFF
--- a/packages/jest-cli/src/run_jest.js
+++ b/packages/jest-cli/src/run_jest.js
@@ -95,10 +95,6 @@ export default (async function runJest({
   onComplete: (testResults: AggregatedResult) => any,
   failedTestsCache: ?FailedTestsCache,
 }) {
-  if (globalConfig.globalSetup) {
-    // $FlowFixMe
-    await require(globalConfig.globalSetup)();
-  }
   const sequencer = new TestSequencer();
   let allTests = [];
 
@@ -184,7 +180,10 @@ export default (async function runJest({
   // original value of rootDir. Instead, use the {cwd: Path} property to resolve
   // paths when printing.
   setConfig(contexts, {cwd: process.cwd()});
-
+  if (globalConfig.globalSetup) {
+    // $FlowFixMe
+    await require(globalConfig.globalSetup)();
+  }
   const results = await new TestScheduler(globalConfig, {
     startRun,
   }).scheduleTests(allTests, testWatcher);


### PR DESCRIPTION
…uted

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

**Summary**
Currently, we execute `globalConfig` module even when there are no tests available for execution. Fixes #5315 
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
Currently, we should not see "determining test suites to run" when there are no available tests.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
