### PR TITLE
Fix bug: MPR executes tests multiple times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Fixes
 
+* `[jest-cli]` Check if the file belongs to the checked project before adding it
+  to the list ([#5335](https://github.com/facebook/jest/pull/5335))
 * `[jest-cli]` Fix `EISDIR` when a directory is passed as an argument to `jest`.
   ([#5317](https://github.com/facebook/jest/pull/5317))
 * `[jest-config]` Added restoreMocks config option.

--- a/integration-tests/__tests__/__snapshots__/execute-tests-once-in-mpr.js.snap
+++ b/integration-tests/__tests__/__snapshots__/execute-tests-once-in-mpr.js.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Tests are executed only once even in an MPR 1`] = `
+"PASS foo/folder/my-test-bar.js
+  ✓ bar
+
+"
+`;

--- a/integration-tests/__tests__/cli-accepts-exact-filenames.test.js
+++ b/integration-tests/__tests__/cli-accepts-exact-filenames.test.js
@@ -40,8 +40,11 @@ test('CLI accepts exact filenames', () => {
     './foo/baz.js',
     './foo',
   ]);
-  const {rest, summary} = extractSummary(stderr);
+
   expect(status).toBe(0);
+
+  const {rest, summary} = extractSummary(stderr);
+
   expect(rest).toMatchSnapshot();
   expect(summary).toMatchSnapshot();
   expect(stdout).toMatchSnapshot();

--- a/integration-tests/__tests__/execute-tests-once-in-mpr.js
+++ b/integration-tests/__tests__/execute-tests-once-in-mpr.js
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+'use strict';
+
+const path = require('path');
+const skipOnWindows = require('../../scripts/skip_on_windows');
+const {extractSummary, cleanup, writeFiles} = require('../utils');
+const runJest = require('../runJest');
+
+const DIR = path.resolve(__dirname, '../execute-tests-once-in-mpr');
+
+skipOnWindows.suite();
+
+beforeEach(() => cleanup(DIR));
+afterAll(() => cleanup(DIR));
+
+test('Tests are executed only once even in an MPR', () => {
+  // Make a global config that ignores all sub-projects.
+  const config = {
+    jest: {
+      projects: ['<rootDir>/foo/*/'],
+      testPathIgnorePatterns: ['/foo/'],
+    },
+  };
+
+  // Make a child config with a special regexp to ensure we execute the tests.
+  const childConfig = {
+    jest: {
+      testRegex: /my-test-.*\.js/.source,
+    },
+  };
+
+  /* eslint-disable sort-keys */
+  writeFiles(DIR, {
+    'foo/folder/my-test-bar.js': `test('bar', () => console.log('Bar!'));`,
+    'foo/folder/package.json': JSON.stringify(childConfig, null, 2),
+
+    'foo/directory/my-test-baz.js': `test('baz', () => console.log('Baz!'));`,
+    'foo/directory/package.json': JSON.stringify(childConfig, null, 2),
+
+    'foo/whatever/my-test-qux.js': `test('qux', () => console.log('Qux!'));`,
+    'foo/whatever/package.json': JSON.stringify(childConfig, null, 2),
+
+    'package.json': JSON.stringify(config, null, 2),
+  });
+  /* eslint-enable sort-keys */
+
+  const {stderr, status} = runJest(DIR, ['foo/folder/my-test-bar.js']);
+
+  expect(status).toBe(0);
+
+  const {rest, summary} = extractSummary(stderr);
+
+  // We have only one test passed, so total should equal to one, despite we have
+  // three projects.
+  expect(rest).toMatchSnapshot();
+  expect(summary).toMatch(/1 total/);
+});

--- a/packages/jest-cli/src/search_source.js
+++ b/packages/jest-cli/src/search_source.js
@@ -209,14 +209,22 @@ export default class SearchSource {
     } else if (globalConfig.findRelatedTests && paths && paths.length) {
       return Promise.resolve(this.findRelatedTestsFromPattern(paths));
     } else {
+      const allFiles = this._context.hasteFS.getAllFiles();
       const validTestPaths =
         paths &&
         paths.filter(name => {
           try {
-            return fs.lstatSync(name).isFile();
+            if (!fs.lstatSync(name).isFile()) {
+              // It exists, but it is not a file; return false.
+              return false;
+            }
           } catch (e) {
+            // It does not exist; return false.
             return false;
           }
+
+          // It exists and it is a file; return true if it's in the project.
+          return allFiles.includes(path.resolve(name));
         });
 
       if (validTestPaths && validTestPaths.length) {

--- a/packages/jest-cli/src/search_source.js
+++ b/packages/jest-cli/src/search_source.js
@@ -209,7 +209,7 @@ export default class SearchSource {
     } else if (globalConfig.findRelatedTests && paths && paths.length) {
       return Promise.resolve(this.findRelatedTestsFromPattern(paths));
     } else {
-      const allFiles = this._context.hasteFS.getAllFiles();
+      const allFiles = new Set(this._context.hasteFS.getAllFiles());
       const validTestPaths =
         paths &&
         paths.filter(name => {
@@ -224,7 +224,7 @@ export default class SearchSource {
           }
 
           // It exists and it is a file; return true if it's in the project.
-          return allFiles.includes(path.resolve(name));
+          return allFiles.has(path.resolve(name));
         });
 
       if (validTestPaths && validTestPaths.length) {


### PR DESCRIPTION
When executing a test by path (not sure why this is a thing?) we were returning `true` for each call in a project configured. This is because as soon as a test is a file, we returned `true`, not checking if the file actually belongs to the project being tested.

This has popped up multiple times (e.g. #5332).