### PR TITLE
Add an option to spawn command in a shell

### DIFF
--- a/packages/jest-editor-support/src/Process.js
+++ b/packages/jest-editor-support/src/Process.js
@@ -31,10 +31,9 @@ export const createProcess = (
   const runtimeArgs = [].concat(initialArgs, args);
 
   // If a path to configuration file was defined, push it to runtimeArgs
-  const configPath = workspace.pathToConfig;
-  if (configPath !== '') {
+  if (workspace.pathToConfig) {
     runtimeArgs.push('--config');
-    runtimeArgs.push(configPath);
+    runtimeArgs.push(workspace.pathToConfig);
   }
 
   // To use our own commands in create-react, we need to tell the command that

--- a/packages/jest-editor-support/src/Process.js
+++ b/packages/jest-editor-support/src/Process.js
@@ -8,8 +8,8 @@
  */
 
 import {ChildProcess, spawn} from 'child_process';
-
 import ProjectWorkspace from './project_workspace';
+import type {SpawnOptions} from './types';
 
 /**
  * Spawns and returns a Jest process with specific args
@@ -20,6 +20,7 @@ import ProjectWorkspace from './project_workspace';
 export const createProcess = (
   workspace: ProjectWorkspace,
   args: Array<string>,
+  options?: SpawnOptions = {},
 ): ChildProcess => {
   // A command could look like `npm run test`, which we cannot use as a command
   // as they can only be the first command, so take out the command, and add
@@ -41,5 +42,10 @@ export const createProcess = (
   const env = process.env;
   env['CI'] = 'true';
 
-  return spawn(command, runtimeArgs, {cwd: workspace.rootPath, env});
+  const spawnOptions = {
+    cwd: workspace.rootPath,
+    env,
+    ...options,
+  };
+  return spawn(command, runtimeArgs, spawnOptions);
 };

--- a/packages/jest-editor-support/src/__tests__/process.test.js
+++ b/packages/jest-editor-support/src/__tests__/process.test.js
@@ -116,4 +116,14 @@ describe('createProcess', () => {
 
     expect(spawn.mock.calls[0][2].shell).not.toBeDefined();
   });
+
+  it('should set the "shell" property when "options" are provided', () => {
+    const expected = {};
+    const workspace: any = {pathToJest: ''};
+    const args = [];
+    const options: any = {shell: expected};
+    createProcess(workspace, args, options);
+
+    expect(spawn.mock.calls[0][2].shell).toBe(expected);
+  });
 });

--- a/packages/jest-editor-support/src/__tests__/process.test.js
+++ b/packages/jest-editor-support/src/__tests__/process.test.js
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+'use strict';
+
+jest.mock('child_process');
+
+import {createProcess} from '../Process';
+import {spawn} from 'child_process';
+
+describe('createProcess', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('spawns the process', () => {
+    const workspace: any = {pathToJest: ''};
+    const args = [];
+    createProcess(workspace, args);
+
+    expect(spawn).toBeCalled();
+  });
+
+  it('spawns the command from workspace.pathToJest', () => {
+    const workspace: any = {pathToJest: 'jest'};
+    const args = [];
+    createProcess(workspace, args);
+
+    expect(spawn.mock.calls[0][0]).toBe('jest');
+    expect(spawn.mock.calls[0][1]).toEqual([]);
+  });
+
+  it('spawns the first arg from workspace.pathToJest split on " "', () => {
+    const workspace: any = {pathToJest: 'npm test --'};
+    const args = [];
+    createProcess(workspace, args);
+
+    expect(spawn.mock.calls[0][0]).toBe('npm');
+    expect(spawn.mock.calls[0][1]).toEqual(['test', '--']);
+  });
+
+  it('fails to spawn the first quoted arg from workspace.pathToJest', () => {
+    const workspace: any = {
+      pathToJest:
+        '"../build scripts/test" --coverageDirectory="../code coverage"',
+    };
+    const args = [];
+    createProcess(workspace, args);
+
+    expect(spawn.mock.calls[0][0]).not.toBe('"../build scripts/test"');
+    expect(spawn.mock.calls[0][1]).not.toEqual([
+      '--coverageDirectory="../code coverage"',
+    ]);
+  });
+
+  it('appends args', () => {
+    const workspace: any = {pathToJest: 'npm test --'};
+    const args = ['--option', 'value', '--another'];
+    createProcess(workspace, args);
+
+    expect(spawn.mock.calls[0][1]).toEqual(['test', '--', ...args]);
+  });
+
+  it('sets the --config arg to workspace.pathToConfig', () => {
+    const workspace: any = {
+      pathToConfig: 'non-standard.jest.js',
+      pathToJest: 'npm test --',
+    };
+    const args = ['--option', 'value'];
+    createProcess(workspace, args);
+
+    expect(spawn.mock.calls[0][1]).toEqual([
+      'test',
+      '--',
+      '--option',
+      'value',
+      '--config',
+      'non-standard.jest.js',
+    ]);
+  });
+
+  it('defines the "CI" environment variable', () => {
+    const expected = {
+      ...process.env,
+      CI: 'true',
+    };
+
+    const workspace: any = {pathToJest: ''};
+    const args = [];
+    createProcess(workspace, args);
+
+    expect(spawn.mock.calls[0][2].env).toEqual(expected);
+  });
+
+  it('sets the current working directory of the child process', () => {
+    const workspace: any = {
+      pathToJest: '',
+      rootPath: 'root directory',
+    };
+    const args = [];
+    createProcess(workspace, args);
+
+    expect(spawn.mock.calls[0][2].cwd).toBe(workspace.rootPath);
+  });
+
+  it('should not set the "shell" property when "options" are not provided', () => {
+    const workspace: any = {pathToJest: ''};
+    const args = [];
+    createProcess(workspace, args);
+
+    expect(spawn.mock.calls[0][2].shell).not.toBeDefined();
+  });
+});

--- a/packages/jest-editor-support/src/__tests__/runner.test.js
+++ b/packages/jest-editor-support/src/__tests__/runner.test.js
@@ -14,7 +14,7 @@ jest.mock('child_process', () => ({spawn: jest.fn()}));
 jest.mock('os', () => ({tmpdir: jest.fn()}));
 jest.mock('fs', () => {
   const readFileSync = require.requireActual('fs').readFileSync;
-// Replace `readFile` with `readFileSync` so we don't get multiple threads
+  // Replace `readFile` with `readFileSync` so we don't get multiple threads
   return {
     readFile: (path, type, closure) => {
       const data = readFileSync(path);
@@ -182,6 +182,15 @@ describe('Runner', () => {
 
       expect((createProcess: any).mock.calls[0][1]).toContain(expected);
     });
+
+    it('calls createProcess with the shell option when provided', () => {
+      const workspace: any = {};
+      const options = {shell: true};
+      const sut = new Runner(workspace, options);
+      sut.start(false);
+
+      expect((createProcess: any).mock.calls[0][2]).toEqual({shell: true});
+    });
   });
 
   describe('closeProcess', () => {
@@ -226,7 +235,7 @@ describe('Runner', () => {
       sut.closeProcess();
 
       expect(kill).toBeCalledWith();
-});
+    });
 
     it('clears the debugprocess property', () => {
       const workspace: any = {};

--- a/packages/jest-editor-support/src/types.js
+++ b/packages/jest-editor-support/src/types.js
@@ -12,6 +12,10 @@ export type Location = {
   line: number,
 };
 
+export type SpawnOptions = {
+  shell?: boolean,
+};
+
 import type {ChildProcess} from 'child_process';
 import type ProjectWorkspace from './project_workspace';
 

--- a/packages/jest-editor-support/src/types.js
+++ b/packages/jest-editor-support/src/types.js
@@ -23,9 +23,11 @@ export type Options = {
   createProcess?: (
     workspace: ProjectWorkspace,
     args: Array<string>,
+    options?: SpawnOptions,
   ) => ChildProcess,
   testNamePattern?: string,
   testFileNamePattern?: string,
+  shell?: boolean,
 };
 
 /**


### PR DESCRIPTION
**Summary**
This adds the option to spawn a Jest command in a shell from `jest-editor-support`. On Windows, using the `shell` option will handle adding the `.cmd` and `.bat` extensions to the `pathToJest`.

The issue is discussed in jest-community/vscode-jest#98.
<br/>

**Test plan**
Unit tests have been added.