### PR TITLE
replace preset-es2015 with preset-env

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -97,12 +97,12 @@ _Note: Explicitly installing `regenerator-runtime` is not needed if you use
 Don't forget to add a [`.babelrc`](https://babeljs.io/docs/usage/babelrc/) file
 in your project's root folder. For example, if you are using ES6 and
 [React.js](https://facebook.github.io/react/) with the
-[`babel-preset-es2015`](https://babeljs.io/docs/plugins/preset-es2015/) and
+[`babel-preset-env`](https://babeljs.io/docs/plugins/preset-env/) and
 [`babel-preset-react`](https://babeljs.io/docs/plugins/preset-react/) presets:
 
 ```json
 {
-  "presets": ["es2015", "react"]
+  "presets": ["env", "react"]
 }
 ```
 
@@ -113,16 +113,16 @@ You are now set up to use all ES6 features and React specific syntax.
 > `test`. It will not use `development` section like Babel does by default when
 > no `NODE_ENV` is set.
 
-> Note: If you've turned off transpilation of ES2015 modules with the option
+> Note: If you've turned off transpilation of ES6 modules with the option
 > `{ "modules": false }`, you have to make sure to turn this on in your test
 > environment.
 
 ```json
 {
-  "presets": [["es2015", {"modules": false}], "react"],
+  "presets": [["env", {"modules": false}], "react"],
   "env": {
     "test": {
-      "presets": [["es2015"], "react"]
+      "presets": [["env"], "react"]
     }
   }
 }


### PR DESCRIPTION
preset-es2015 was already deprecated and should be replaced by preset-env
you will see this info when installing preset-es2015


> We're super 😸 excited that you're trying to use ES2015 syntax, but instead of making more yearly presets 😭 , Babel now has a ?better preset that we recommend you use instead: npm install babel-preset-env --save-dev. preset-env without options will compile ES2015+ down to ES5 just like using all the presets together and thus is more future proof. It also allows you to target specific browsers so that Babel can do less work and you can ship native ES2015+ to user 😎 ! We are also in the process of releasing v7, so please give http://babeljs.io/blog/2017/09/12/planning-for-7.0 a read and help test it out in beta! Thanks so much for using Babel 🙏, please give us a follow on Twitter @babeljs for news on Babel, join slack.babeljs.io for discussion/development and help support the project at opencollective.com/babel


<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
