### PR TITLE
Add "debug" method to console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Fixes
 
+* `[jest-util]` Add "debug" method to "console" implementations
+  ([#5350](https://github.com/facebook/jest/pull/5350))
 * `[jest-resolve]` Add condition to avoid infinite loop when node module package main is ".".
   ([#5344)](https://github.com/facebook/jest/pull/5344)
 

--- a/packages/jest-util/src/Console.js
+++ b/packages/jest-util/src/Console.js
@@ -34,6 +34,10 @@ export default class CustomConsole extends Console {
     super.log(this._formatBuffer(type, message));
   }
 
+  debug(...args: Array<mixed>) {
+    this._log('debug', format.apply(null, arguments));
+  }
+
   log(...args: Array<mixed>) {
     this._log('log', format.apply(null, arguments));
   }

--- a/packages/jest-util/src/buffered_console.js
+++ b/packages/jest-util/src/buffered_console.js
@@ -34,6 +34,10 @@ export default class BufferedConsole extends Console {
     return buffer;
   }
 
+  debug() {
+    BufferedConsole.write(this._buffer, 'debug', format.apply(null, arguments));
+  }
+
   log() {
     BufferedConsole.write(this._buffer, 'log', format.apply(null, arguments));
   }

--- a/packages/jest-util/src/null_console.js
+++ b/packages/jest-util/src/null_console.js
@@ -11,6 +11,7 @@ import Console from './Console';
 
 export default class NullConsole extends Console {
   assert() {}
+  debug() {}
   dir() {}
   error() {}
   info() {}

--- a/types/Console.js
+++ b/types/Console.js
@@ -13,5 +13,5 @@ export type LogEntry = {|
   origin: string,
   type: LogType,
 |};
-export type LogType = 'log' | 'info' | 'warn' | 'error';
+export type LogType = 'debug' | 'log' | 'info' | 'warn' | 'error';
 export type ConsoleBuffer = Array<LogEntry>;


### PR DESCRIPTION
The `console` global is overridden with a custom implementation in order to be able to buffer it per test. However, the "`debug`" method is missing in either of the implementations (`CustomConsole` and `BufferedConsole`), so when doing `console.debug` you end up calling the real implementation.

This causes troubles, and especially when using the `jsdom` environment, where an extra indirection layer is added via `VirtualConsole`, which re-wraps methods once again.