### PR TITLE
fix(jest): `import-local` should be used in main jest pakage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## master
 
+* `[jest]` Add `import-local` to `jest` package.
+
 ## jest 22.1.4
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## master
 
+### Fixes
+
 * `[jest]` Add `import-local` to `jest` package.
   ([#5353](https://github.com/facebook/jest/pull/5353))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## master
 
 * `[jest]` Add `import-local` to `jest` package.
+  ([#5353](https://github.com/facebook/jest/pull/5353))
 
 ## jest 22.1.4
 
@@ -8,10 +9,11 @@
 
 * `[jest-util]` Add "debug" method to "console" implementations
   ([#5350](https://github.com/facebook/jest/pull/5350))
-* `[jest-resolve]` Add condition to avoid infinite loop when node module package main is ".".
-  ([#5344)](https://github.com/facebook/jest/pull/5344)
+* `[jest-resolve]` Add condition to avoid infinite loop when node module package
+  main is ".". ([#5344)](https://github.com/facebook/jest/pull/5344)
 
 ### Features
+
 * `[jest-cli]` `--changedSince`: allow selectively running tests for code
   changed since arbitrary revisions.
   ([#5312](https://github.com/facebook/jest/pull/5312))

--- a/packages/jest/bin/jest.js
+++ b/packages/jest/bin/jest.js
@@ -6,4 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-require('jest-cli/bin/jest');
+const importLocal = require('import-local');
+
+if (!importLocal(__filename)) {
+  require('jest-cli/bin/jest');
+}

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -4,6 +4,7 @@
   "version": "22.1.4",
   "main": "build/jest.js",
   "dependencies": {
+    "import-local": "^1.0.0",
     "jest-cli": "^22.1.4"
   },
   "bin": {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

**Summary**
Related to #5304. I didn't test it well enough. That changed worked with a globally installed `jest-cli` and a local installation of `jest-cli`. It did _not_ work for a global `jest` install and a local `jest` install if `jest-cli` is within `node_modules/jest/jest-cli` instead of at the top level.

This change fixes that.

(I want to point out that the original code before #5304 didn't work in the same case (as it hardcoded a `node_modules/jest-clil` path) - and why I think so many projects have both `jest` and `jest-cli` in their dependencies.)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
Local testing with a globally installed `jest` (with this change applied) and a local `node_modules/jest/jest-cli` installation.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
