### PR TITLE
Adjust flow type for accessType parameter in spyOn function

### DIFF
--- a/types/Jest.js
+++ b/types/Jest.js
@@ -43,7 +43,11 @@ export type Jest = {|
   runTimersToTime(msToRun: number): void,
   setMock(moduleName: string, moduleExports: any): Jest,
   setTimeout(timeout: number): Jest,
-  spyOn(object: Object, methodName: string, accessType?: string): JestMockFn,
+  spyOn(
+    object: Object,
+    methodName: string,
+    accessType?: 'get' | 'set',
+  ): JestMockFn,
   unmock(moduleName: string): Jest,
   useFakeTimers(): Jest,
   useRealTimers(): Jest,


### PR DESCRIPTION
**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Stricter type for flow type checking, it helps developers to know exactly what are the values expected by the function.
This PR makes clear the value of `accessType` input parameter of `spyOn` function is either `get` or `set`

**Test plan**
**NA** (not a bug)

