### PR TITLE
Fix link to babel setup doc from webpack doc

### DIFF
--- a/docs/Webpack.md
+++ b/docs/Webpack.md
@@ -42,7 +42,7 @@ module.exports = {
 ```
 
 If you have JavaScript files that are transformed by Babel, you can
-[enable support for Babel](GettingStarted.md#using-babel-with-jest) by
+[enable support for Babel](GettingStarted.md#using-babel) by
 installing the `babel-jest` plugin. Non-Babel JavaScript transformations can be
 handled with Jest's
 [`transform`](Configuration.md#transform-object-string-string) config option.


### PR DESCRIPTION
**Summary**
Found a broken link while browsing webpack setup page. This pull request fixes that link.

**Test plan**
If there's some way to resolve deep markdown links with the static site generator then broken links like this would never make it past the build step.