### PR TITLE
Make `rejects` and `resolves` synchronous

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
   ([#5367](https://github.com/facebook/jest/pull/5367))
 * `[jest-cli]` Fix npm update command for snapshot summary.
   ([#5376](https://github.com/facebook/jest/pull/5376))
-* `[expect]` Make `rejects` and `resolves` synchronous.
+* `[expect]` Make `rejects` and `resolves` synchronously validate its argument.
   ([#5364](https://github.com/facebook/jest/pull/5364))
 
 ## jest 22.1.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
   ([#5367](https://github.com/facebook/jest/pull/5367))
 * `[jest-cli]` Fix npm update command for snapshot summary.
   ([#5376](https://github.com/facebook/jest/pull/5376))
-* `[expect]` Make `rejects` and `resolves` synchronizable.
+* `[expect]` Make `rejects` and `resolves` synchronous.
   ([#5364](https://github.com/facebook/jest/pull/5364))
 
 ## jest 22.1.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,15 @@
 
 ### features
 
-* `[jest-mock]` Add util methods to create async functions. 
-  ([#5318](https://github.com/facebook/jest/pull/5318)) 
+* `[jest-mock]` Add util methods to create async functions.
+  ([#5318](https://github.com/facebook/jest/pull/5318))
 
 ### Fixes
 
 * `[jest]` Add `import-local` to `jest` package.
   ([#5353](https://github.com/facebook/jest/pull/5353))
+* `[expect]` Make `makeRejectMatcher` synchronizable.
+  ([#5364](https://github.com/facebook/jest/pull/5364))
 
 ## jest 22.1.4
 

--- a/integration-tests/__tests__/__snapshots__/failures.test.js.snap
+++ b/integration-tests/__tests__/__snapshots__/failures.test.js.snap
@@ -118,7 +118,7 @@ exports[`works with async failures 1`] = `
     +   \\"foo\\": \\"bar\\",
       }
       
-      at ../../packages/expect/build/index.js:156:54
+      at ../../packages/expect/build/index.js:145:57
 
 "
 `;

--- a/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -84,7 +84,23 @@ Received:
   string: <red>\\"a\\"</>"
 `;
 
+exports[`.resolves fails non-promise value "a" synchronously 1`] = `
+"<dim>expect(</><red>received</><dim>).resolves.toBeDefined(</><dim>)</>
+
+<red>received</> value must be a Promise.
+Received:
+  string: <red>\\"a\\"</>"
+`;
+
 exports[`.resolves fails non-promise value [1] 1`] = `
+"<dim>expect(</><red>received</><dim>).resolves.toBeDefined(</><dim>)</>
+
+<red>received</> value must be a Promise.
+Received:
+  array: <red>[1]</>"
+`;
+
+exports[`.resolves fails non-promise value [1] synchronously 1`] = `
 "<dim>expect(</><red>received</><dim>).resolves.toBeDefined(</><dim>)</>
 
 <red>received</> value must be a Promise.
@@ -100,7 +116,23 @@ Received:
   function: <red>[Function anonymous]</>"
 `;
 
+exports[`.resolves fails non-promise value [Function anonymous] synchronously 1`] = `
+"<dim>expect(</><red>received</><dim>).resolves.toBeDefined(</><dim>)</>
+
+<red>received</> value must be a Promise.
+Received:
+  function: <red>[Function anonymous]</>"
+`;
+
 exports[`.resolves fails non-promise value {"a": 1} 1`] = `
+"<dim>expect(</><red>received</><dim>).resolves.toBeDefined(</><dim>)</>
+
+<red>received</> value must be a Promise.
+Received:
+  object: <red>{\\"a\\": 1}</>"
+`;
+
+exports[`.resolves fails non-promise value {"a": 1} synchronously 1`] = `
 "<dim>expect(</><red>received</><dim>).resolves.toBeDefined(</><dim>)</>
 
 <red>received</> value must be a Promise.
@@ -116,7 +148,22 @@ Received:
   number: <red>4</>"
 `;
 
+exports[`.resolves fails non-promise value 4 synchronously 1`] = `
+"<dim>expect(</><red>received</><dim>).resolves.toBeDefined(</><dim>)</>
+
+<red>received</> value must be a Promise.
+Received:
+  number: <red>4</>"
+`;
+
 exports[`.resolves fails non-promise value null 1`] = `
+"<dim>expect(</><red>received</><dim>).resolves.toBeDefined(</><dim>)</>
+
+<red>received</> value must be a Promise.
+Received: <red>null</>"
+`;
+
+exports[`.resolves fails non-promise value null synchronously 1`] = `
 "<dim>expect(</><red>received</><dim>).resolves.toBeDefined(</><dim>)</>
 
 <red>received</> value must be a Promise.
@@ -131,7 +178,22 @@ Received:
   boolean: <red>true</>"
 `;
 
+exports[`.resolves fails non-promise value true synchronously 1`] = `
+"<dim>expect(</><red>received</><dim>).resolves.toBeDefined(</><dim>)</>
+
+<red>received</> value must be a Promise.
+Received:
+  boolean: <red>true</>"
+`;
+
 exports[`.resolves fails non-promise value undefined 1`] = `
+"<dim>expect(</><red>received</><dim>).resolves.toBeDefined(</><dim>)</>
+
+<red>received</> value must be a Promise.
+Received: <red>undefined</>"
+`;
+
+exports[`.resolves fails non-promise value undefined synchronously 1`] = `
 "<dim>expect(</><red>received</><dim>).resolves.toBeDefined(</><dim>)</>
 
 <red>received</> value must be a Promise.

--- a/packages/expect/src/__tests__/matchers.test.js
+++ b/packages/expect/src/__tests__/matchers.test.js
@@ -38,6 +38,18 @@ describe('.rejects', () => {
   });
 
   [4, [1], {a: 1}, 'a', true, null, undefined, () => {}].forEach(value => {
+    it(`fails non-promise value ${stringify(value)} synchronously`, () => {
+      let error;
+      try {
+        jestExpect(value).rejects.toBe(111);
+      } catch (e) {
+        error = e;
+      }
+      expect(error).toBeDefined();
+    });
+  });
+
+  [4, [1], {a: 1}, 'a', true, null, undefined, () => {}].forEach(value => {
     it(`fails non-promise value ${stringify(value)}`, async () => {
       let error;
       try {

--- a/packages/expect/src/__tests__/matchers.test.js
+++ b/packages/expect/src/__tests__/matchers.test.js
@@ -94,6 +94,19 @@ describe('.resolves', () => {
   });
 
   [4, [1], {a: 1}, 'a', true, null, undefined, () => {}].forEach(value => {
+    it(`fails non-promise value ${stringify(value)} synchronously`, () => {
+      let error;
+      try {
+        jestExpect(value).resolves.toBeDefined();
+      } catch (e) {
+        error = e;
+      }
+      expect(error).toBeDefined();
+      expect(error.message).toMatchSnapshot();
+    });
+  });
+
+  [4, [1], {a: 1}, 'a', true, null, undefined, () => {}].forEach(value => {
     it(`fails non-promise value ${stringify(value)}`, async () => {
       let error;
       try {

--- a/packages/expect/src/index.js
+++ b/packages/expect/src/index.js
@@ -161,7 +161,7 @@ const makeRejectMatcher = (
   matcher: RawMatcherFn,
   isNot: boolean,
   actual: Promise<any>,
-): PromiseMatcherFn => async (...args) => {
+): PromiseMatcherFn => (...args) => {
   const matcherStatement = `.rejects.${isNot ? 'not.' : ''}${matcherName}`;
   if (!isPromise(actual)) {
     throw new JestAssertionError(
@@ -172,20 +172,22 @@ const makeRejectMatcher = (
     );
   }
 
-  let result;
-  try {
-    result = await actual;
-  } catch (e) {
-    return makeThrowingMatcher(matcher, isNot, e).apply(null, args);
-  }
+  return (async () => {
+    let result;
+    try {
+      result = await actual;
+    } catch (e) {
+      return makeThrowingMatcher(matcher, isNot, e).apply(null, args);
+    }
 
-  throw new JestAssertionError(
-    utils.matcherHint(matcherStatement, 'received', '') +
-      '\n\n' +
-      `Expected ${utils.RECEIVED_COLOR('received')} Promise to reject, ` +
-      'instead it resolved to value\n' +
-      `  ${utils.printReceived(result)}`,
-  );
+    throw new JestAssertionError(
+      utils.matcherHint(matcherStatement, 'received', '') +
+        '\n\n' +
+        `Expected ${utils.RECEIVED_COLOR('received')} Promise to reject, ` +
+        'instead it resolved to value\n' +
+        `  ${utils.printReceived(result)}`,
+    );
+  })();
 };
 
 const makeThrowingMatcher = (

--- a/packages/expect/src/index.js
+++ b/packages/expect/src/index.js
@@ -172,18 +172,19 @@ const makeRejectMatcher = (
     );
   }
 
-  return actual
-    .then(v => {
+  return actual.then(
+    result => {
       const err = new JestAssertionError(
         utils.matcherHint(matcherStatement, 'received', '') +
           '\n\n' +
           `Expected ${utils.RECEIVED_COLOR('received')} Promise to reject, ` +
           'instead it resolved to value\n' +
-          `  ${utils.printReceived(v)}`,
+          `  ${utils.printReceived(result)}`,
       );
       return Promise.reject(err);
-    })
-    .catch(e => makeThrowingMatcher(matcher, isNot, e).apply(null, args));
+    },
+    reason => makeThrowingMatcher(matcher, isNot, reason).apply(null, args),
+  );
 };
 
 const makeThrowingMatcher = (

--- a/packages/expect/src/index.js
+++ b/packages/expect/src/index.js
@@ -172,22 +172,18 @@ const makeRejectMatcher = (
     );
   }
 
-  return (async () => {
-    let result;
-    try {
-      result = await actual;
-    } catch (e) {
-      return makeThrowingMatcher(matcher, isNot, e).apply(null, args);
-    }
-
-    throw new JestAssertionError(
-      utils.matcherHint(matcherStatement, 'received', '') +
-        '\n\n' +
-        `Expected ${utils.RECEIVED_COLOR('received')} Promise to reject, ` +
-        'instead it resolved to value\n' +
-        `  ${utils.printReceived(result)}`,
-    );
-  })();
+  return actual
+    .then(v => {
+      const err = new JestAssertionError(
+        utils.matcherHint(matcherStatement, 'received', '') +
+          '\n\n' +
+          `Expected ${utils.RECEIVED_COLOR('received')} Promise to reject, ` +
+          'instead it resolved to value\n' +
+          `  ${utils.printReceived(v)}`,
+      );
+      return Promise.reject(err);
+    })
+    .catch(e => makeThrowingMatcher(matcher, isNot, e).apply(null, args));
 };
 
 const makeThrowingMatcher = (


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

**Summary**
Fix #5361 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
Pass non-promise values into reject matchers synchronously

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
