### PR TITLE
fix: Support class instances in .toHaveProperty() matcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,15 @@
 
 ### features
 
-* `[jest-mock]` Add util methods to create async functions. 
-  ([#5318](https://github.com/facebook/jest/pull/5318)) 
+* `[jest-mock]` Add util methods to create async functions.
+  ([#5318](https://github.com/facebook/jest/pull/5318))
 
 ### Fixes
 
 * `[jest]` Add `import-local` to `jest` package.
   ([#5353](https://github.com/facebook/jest/pull/5353))
+* `[expect]` Support class instances in `.toHaveProperty()` matcher.
+  ([#5367](https://github.com/facebook/jest/pull/5367))
 
 ## jest 22.1.4
 

--- a/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -2778,6 +2778,23 @@ To have a nested property:
 "
 `;
 
+exports[`.toHaveProperty() {pass: false} expect({}).toHaveProperty('a', "a") 1`] = `
+"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</>, <green>value</><dim>)</>
+
+Expected the object:
+  <red>{}</>
+To have a nested property:
+  <green>\\"a\\"</>
+With a value of:
+  <green>\\"a\\"</>
+Received:
+  <red>undefined</>
+
+Difference:
+
+  Comparing two different types of values. Expected <green>string</> but received <red>undefined</>."
+`;
+
 exports[`.toHaveProperty() {pass: false} expect({}).toHaveProperty('a', "test") 1`] = `
 "<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</>, <green>value</><dim>)</>
 
@@ -2788,6 +2805,23 @@ To have a nested property:
 With a value of:
   <green>\\"test\\"</>
 "
+`;
+
+exports[`.toHaveProperty() {pass: false} expect({}).toHaveProperty('b', undefined) 1`] = `
+"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</>, <green>value</><dim>)</>
+
+Expected the object:
+  <red>{}</>
+To have a nested property:
+  <green>\\"b\\"</>
+With a value of:
+  <green>undefined</>
+Received:
+  <red>\\"b\\"</>
+
+Difference:
+
+  Comparing two different types of values. Expected <green>undefined</> but received <red>string</>."
 `;
 
 exports[`.toHaveProperty() {pass: false} expect(1).toHaveProperty('a.b.c') 1`] = `
@@ -2965,6 +2999,30 @@ Not to have a nested property:
   <green>\\"property\\"</>
 With a value of:
   <green>1</>
+"
+`;
+
+exports[`.toHaveProperty() {pass: true} expect({}).toHaveProperty('a', undefined) 1`] = `
+"<dim>expect(</><red>object</><dim>).not.toHaveProperty(</><green>path</>, <green>value</><dim>)</>
+
+Expected the object:
+  <red>{}</>
+Not to have a nested property:
+  <green>\\"a\\"</>
+With a value of:
+  <green>undefined</>
+"
+`;
+
+exports[`.toHaveProperty() {pass: true} expect({}).toHaveProperty('b', "b") 1`] = `
+"<dim>expect(</><red>object</><dim>).not.toHaveProperty(</><green>path</>, <green>value</><dim>)</>
+
+Expected the object:
+  <red>{}</>
+Not to have a nested property:
+  <green>\\"b\\"</>
+With a value of:
+  <green>\\"b\\"</>
 "
 `;
 

--- a/packages/expect/src/__tests__/matchers.test.js
+++ b/packages/expect/src/__tests__/matchers.test.js
@@ -749,6 +749,15 @@ describe('.toHaveLength', () => {
 });
 
 describe('.toHaveProperty()', () => {
+  class Foo {
+    get a() {
+      return undefined;
+    }
+    get b() {
+      return 'b';
+    }
+  }
+
   [
     [{a: {b: {c: {d: 1}}}}, 'a.b.c.d', 1],
     [{a: {b: {c: {d: 1}}}}, ['a', 'b', 'c', 'd'], 1],
@@ -758,6 +767,8 @@ describe('.toHaveProperty()', () => {
     [{a: {b: undefined}}, 'a.b', undefined],
     [{a: {b: {c: 5}}}, 'a.b', {c: 5}],
     [Object.assign(Object.create(null), {property: 1}), 'property', 1],
+    [new Foo(), 'a', undefined],
+    [new Foo(), 'b', 'b'],
   ].forEach(([obj, keyPath, value]) => {
     test(`{pass: true} expect(${stringify(
       obj,
@@ -782,6 +793,8 @@ describe('.toHaveProperty()', () => {
     [1, 'a.b.c', 'test'],
     ['abc', 'a.b.c', {a: 5}],
     [{a: {b: {c: 5}}}, 'a.b', {c: 4}],
+    [new Foo(), 'a', 'a'],
+    [new Foo(), 'b', undefined],
   ].forEach(([obj, keyPath, value]) => {
     test(`{pass: false} expect(${stringify(
       obj,

--- a/packages/expect/src/__tests__/utils.test.js
+++ b/packages/expect/src/__tests__/utils.test.js
@@ -46,6 +46,30 @@ describe('getPath()', () => {
     });
   });
 
+  test('property is a getter on class instance', () => {
+    class A {
+      get a() {
+        return 'a';
+      }
+      get b() {
+        return {c: 'c'};
+      }
+    }
+
+    expect(getPath(new A(), 'a')).toEqual({
+      hasEndProp: true,
+      lastTraversedObject: new A(),
+      traversedPath: ['a'],
+      value: 'a',
+    });
+    expect(getPath(new A(), 'b.c')).toEqual({
+      hasEndProp: true,
+      lastTraversedObject: {c: 'c'},
+      traversedPath: ['b', 'c'],
+      value: 'c',
+    });
+  });
+
   test('path breaks', () => {
     expect(getPath({a: {}}, 'a.b.c')).toEqual({
       hasEndProp: false,
@@ -55,11 +79,12 @@ describe('getPath()', () => {
     });
   });
 
-  test('empry object at the end', () => {
+  test('empty object at the end', () => {
     expect(getPath({a: {b: {c: {}}}}, 'a.b.c.d')).toEqual({
       hasEndProp: false,
       lastTraversedObject: {},
       traversedPath: ['a', 'b', 'c'],
+      value: undefined,
     });
   });
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

**Summary**

Checking for object own property with `Object.prototype.hasOwnProperty.call(object, value)` won't work on class instance getters. To support that, we can fall back to checking `object.constructor.prototype`, because we know `object` is an Object so we can actually get its class prototype which stores the getter.

Also refactored the code a bit for perf (remove unnecessary `delete`) and readability (flattened if/else branching, use `?w=1` to review)

Resolves https://github.com/facebook/jest/issues/5339

**Test plan**

Added a test or two.
