### PR TITLE
fix(jest-cli): fix typo in options when spawning workers

### DIFF
--- a/packages/jest-cli/src/reporters/coverage_reporter.js
+++ b/packages/jest-cli/src/reporters/coverage_reporter.js
@@ -158,7 +158,7 @@ export default class CoverageReporter extends BaseReporter {
     } else {
       // $FlowFixMe: assignment of a worker with custom properties.
       worker = new Worker(require.resolve('./coverage_worker'), {
-        exposeMethods: ['worker'],
+        exposedMethods: ['worker'],
         maxRetries: 2,
         numWorkers: this._globalConfig.maxWorkers,
       });


### PR DESCRIPTION
**Summary**
Fixes a typo in the options when spawning coverage workers. This change does not change the behaviour of the code as there is a fallback in `jest-worker` that resolves to the same method. https://github.com/facebook/jest/blob/master/packages/jest-worker/src/index.js#L95

**Test plan**
[Matches the expected option in `jest-worker`.](https://github.com/facebook/jest/blob/master/packages/jest-worker/src/index.js#L92)