### PR TITLE
Fix npm update command for snapshot summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 * `[jest]` Add `import-local` to `jest` package.
   ([#5353](https://github.com/facebook/jest/pull/5353))
+* `[jest-cli]` Fix npm update command for snapshot summary.
+([#5376](https://github.com/facebook/jest/pull/5376))
 
 ## jest 22.1.4
 

--- a/packages/jest-cli/src/reporters/summary_reporter.js
+++ b/packages/jest-cli/src/reporters/summary_reporter.js
@@ -129,11 +129,10 @@ export default class SummaryReporter extends BaseReporter {
       let updateCommand;
       const event = process.env.npm_lifecycle_event;
       const prefix = NPM_EVENTS.has(event) ? '' : 'run ';
-      const client =
+      const isYarn =
         typeof process.env.npm_config_user_agent === 'string' &&
-        process.env.npm_config_user_agent.match('yarn') !== null
-          ? 'yarn'
-          : 'npm';
+        process.env.npm_config_user_agent.match('yarn') !== null;
+      const client = isYarn ? 'yarn' : 'npm';
       const scriptUsesJest =
         typeof process.env.npm_lifecycle_script === 'string' &&
         process.env.npm_lifecycle_script.indexOf('jest') !== -1;
@@ -141,7 +140,11 @@ export default class SummaryReporter extends BaseReporter {
       if (globalConfig.watch) {
         updateCommand = 'press `u`';
       } else if (event && scriptUsesJest) {
-        updateCommand = `run \`${client + ' ' + prefix + event} -u\``;
+        updateCommand = `run \`${client +
+          ' ' +
+          prefix +
+          event +
+          (isYarn ? '' : ' --')} -u\``;
       } else {
         updateCommand = 're-run jest with `-u`';
       }


### PR DESCRIPTION
**Summary**

The snapshot summary told me to use `npm test -u` but it didn't work and needs special option -- to update snapshot.
This fix tells the correct command to update snapshot for npm.

**Test plan**

With `npm test`, I got this summary.
<img width="488" alt="2018-01-24 2 14 37" src="https://user-images.githubusercontent.com/5971361/35290138-a3bb4524-00ac-11e8-9ed6-df337a0112da.png">

With `yarn test`.
<img width="487" alt="2018-01-24 2 15 05" src="https://user-images.githubusercontent.com/5971361/35290139-a3e2083a-00ac-11e8-986e-211744b98166.png">

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
