### PR TITLE
docs: replace es2015 with env

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,12 +116,12 @@ _Note: Explicitly installing `regenerator-runtime` is not needed if you use
 Don't forget to add a [`.babelrc`](https://babeljs.io/docs/usage/babelrc/) file
 in your project's root folder. For example, if you are using ES6 and
 [React.js](https://facebook.github.io/react/) with the
-[`babel-preset-es2015`](https://babeljs.io/docs/plugins/preset-es2015/) and
+[`babel-preset-env`](https://babeljs.io/docs/plugins/preset-env/) and
 [`babel-preset-react`](https://babeljs.io/docs/plugins/preset-react/) presets:
 
 ```json
 {
-  "presets": ["es2015", "react"]
+  "presets": ["env", "react"]
 }
 ```
 
@@ -132,16 +132,16 @@ You are now set up to use all ES6 features and React specific syntax.
 > `test`. It will not use `development` section like Babel does by default when
 > no `NODE_ENV` is set.
 
-> Note: If you've turned off transpilation of ES2015 modules with the option
+> Note: If you've turned off transpilation of ES modules with the option
 > `{ "modules": false }`, you have to make sure to turn this on in your test
 > environment.
 
 ```json
 {
-  "presets": [["es2015", {"modules": false}], "react"],
+  "presets": [["env", {"modules": false}], "react"],
   "env": {
     "test": {
-      "presets": [["es2015"], "react"]
+      "presets": [["env"], "react"]
     }
   }
 }

--- a/docs/TutorialReact.md
+++ b/docs/TutorialReact.md
@@ -27,7 +27,7 @@ Also see [using babel](GettingStarted.md#using-babel).
 Run
 
 ```bash
-npm install --save-dev jest babel-jest babel-preset-es2015 babel-preset-react react-test-renderer
+npm install --save-dev jest babel-jest babel-preset-env babel-preset-react react-test-renderer
 ```
 
 Your `package.json` should look something like this (where `<current-version>`
@@ -42,7 +42,7 @@ jest configuration entries:
   },
   "devDependencies": {
     "babel-jest": "<current-version>",
-    "babel-preset-es2015": "<current-version>",
+    "babel-preset-env": "<current-version>",
     "babel-preset-react": "<current-version>",
     "jest": "<current-version>",
     "react-test-renderer": "<current-version>"
@@ -55,7 +55,7 @@ jest configuration entries:
 ```json
 // .babelrc
 {
-  "presets": ["es2015", "react"]
+  "presets": ["env", "react"]
 }
 ```
 


### PR DESCRIPTION
Because `babel-preset-es2015` is deprecated and `babel-preset-env` is a drop-in replacement.

**Summary**

Replace es2015 with env because `babel-preset-es2015` is deprecated and `babel-preset-env` is a drop-in replacement.

**Test plan**

N/A