### PR TITLE
Add testPath to suite in jest-jasmine2 reporter callbacks

### DIFF
--- a/packages/jest-jasmine2/src/jasmine/Env.js
+++ b/packages/jest-jasmine2/src/jasmine/Env.js
@@ -172,6 +172,9 @@ export default function(j$) {
 
     const topSuite = new j$.Suite({
       id: getNextSuiteId(),
+      getTestPath() {
+        return j$.testPath;
+      },
     });
     defaultResourcesForRunnable(topSuite.id);
     currentDeclarationSuite = topSuite;

--- a/packages/jest-jasmine2/src/jasmine/Env.js
+++ b/packages/jest-jasmine2/src/jasmine/Env.js
@@ -52,7 +52,6 @@ export default function(j$) {
     const realClearTimeout = global.clearTimeout;
 
     const runnableResources = {};
-
     let currentSpec = null;
     const currentlyExecutingSuites = [];
     let currentDeclarationSuite = null;
@@ -291,6 +290,9 @@ export default function(j$) {
         description,
         parentSuite: currentDeclarationSuite,
         throwOnExpectationFailure,
+        getTestPath() {
+          return j$.testPath;
+        },
       });
 
       return suite;

--- a/packages/jest-jasmine2/src/jasmine/Suite.js
+++ b/packages/jest-jasmine2/src/jasmine/Suite.js
@@ -54,6 +54,7 @@ export default function Suite(attrs: Object) {
     description: this.description,
     fullName: this.getFullName(),
     failedExpectations: [],
+    testPath: attrs.getTestPath(),
   };
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Add `testPath` to `jest-jasmine2` reporter callbacks.

Before:
```
{
      id: 'suite0',
      description: 'tests',
      fullName: '',
      failedExpectations: [],
}
```

After
```
      id: 'suite0',
      description: 'tests',
      fullName: '',
      failedExpectations: [],
      testPath: '/src/__tests__/foo.test.js' 
```

**Test plan**
See #4594

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
