### PR TITLE
fix: absolute paths in `moduleDirectories` are invalid under Windows OS

### DIFF
--- a/packages/jest-resolve/src/node_modules_paths.js
+++ b/packages/jest-resolve/src/node_modules_paths.js
@@ -48,11 +48,11 @@ export default function nodeModulesPaths(
     .reduce((dirs, aPath) => {
       return dirs.concat(
         modules.map(moduleDir => {
-          return path.isAbsolute(moduleDir) ? ((aPath === basedirAbs) ? moduleDir : null) : path.join(prefix, aPath, moduleDir);
+          return path.isAbsolute(moduleDir) ? ((aPath === basedirAbs) ? moduleDir : '') : path.join(prefix, aPath, moduleDir);
         })
       );
     }, [])
-    .filter(dir => (dir !== null));
+    .filter(dir => (dir !== ''));
 
   return options.paths ? options.paths.concat(dirs) : dirs;
 }

--- a/packages/jest-resolve/src/node_modules_paths.js
+++ b/packages/jest-resolve/src/node_modules_paths.js
@@ -48,11 +48,13 @@ export default function nodeModulesPaths(
     .reduce((dirs, aPath) => {
       return dirs.concat(
         modules.map(moduleDir => {
-          return path.isAbsolute(moduleDir) ? ((aPath === basedirAbs) ? moduleDir : '') : path.join(prefix, aPath, moduleDir);
-        })
+          return path.isAbsolute(moduleDir)
+            ? (aPath === basedirAbs) ? moduleDir : ''
+            : path.join(prefix, aPath, moduleDir);
+        }),
       );
     }, [])
-    .filter(dir => (dir !== ''));
+    .filter(dir => dir !== '');
 
   return options.paths ? options.paths.concat(dirs) : dirs;
 }

--- a/packages/jest-resolve/src/node_modules_paths.js
+++ b/packages/jest-resolve/src/node_modules_paths.js
@@ -44,13 +44,15 @@ export default function nodeModulesPaths(
     parsed = path.parse(parsed.dir);
   }
 
-  const dirs = paths.reduce((dirs, aPath) => {
-    return dirs.concat(
-      modules.map(moduleDir => {
-        return path.join(prefix, aPath, moduleDir);
-      }),
-    );
-  }, []);
+  const dirs = paths
+    .reduce((dirs, aPath) => {
+      return dirs.concat(
+        modules.map(moduleDir => {
+          return path.isAbsolute(moduleDir) ? ((aPath === basedirAbs) ? moduleDir : null) : path.join(prefix, aPath, moduleDir);
+        })
+      );
+    }, [])
+    .filter(dir => (dir !== null));
 
   return options.paths ? options.paths.concat(dirs) : dirs;
 }

--- a/packages/jest-resolve/src/node_modules_paths.js
+++ b/packages/jest-resolve/src/node_modules_paths.js
@@ -49,7 +49,7 @@ export default function nodeModulesPaths(
       return dirs.concat(
         modules.map(moduleDir => {
           return path.isAbsolute(moduleDir)
-            ? (aPath === basedirAbs) ? moduleDir : ''
+            ? aPath === basedirAbs ? moduleDir : ''
             : path.join(prefix, aPath, moduleDir);
         }),
       );


### PR DESCRIPTION
closes Issue #5396