### PR TITLE
Add link to the list of methods to go to spyOn accessType for Jest Object API doc

### DIFF
--- a/docs/JestObjectAPI.md
+++ b/docs/JestObjectAPI.md
@@ -32,6 +32,7 @@ behavior.
 * [`jest.useFakeTimers()`](#jestusefaketimers)
 * [`jest.useRealTimers()`](#jestuserealtimers)
 * [`jest.spyOn(object, methodName)`](#jestspyonobject-methodname)
+* [`jest.spyOn(object, methodName, accessType?)`](#jestspyonobject-methodname-accesstype)
 
 ---
 


### PR DESCRIPTION
**Summary**

Currently the API Doc doesn't have the link to go to jest.spyOn(object, methodName, accessType?). This PR makes the developers easy to navigate to jest.spyOn(object, methodName, accessType?) method description by clicking the link on the list of methods on the top of the API doc page.

**Test plan**

- Run `yarn start` in the website directory.
- Browse to `http://localhost:3000/jest/docs/en/jest-object.html` using any browsers
- Check if the list of methods contain `jest.spyOn(object, methodName, accessType?)`
- Click on the link `jest.spyOn(object, methodName, accessType?)` and see if it navigates correctly to the usage description of the method
