### PR TITLE
Change test summary to use stdout instead of stderr

### DIFF
--- a/packages/jest-cli/src/reporters/base_reporter.js
+++ b/packages/jest-cli/src/reporters/base_reporter.js
@@ -21,6 +21,10 @@ export default class BaseReporter {
     process.stderr.write(message + '\n');
   }
 
+  info(message: string) {
+    process.stdout.write(message + '\n');
+  }
+
   onRunStart(results: AggregatedResult, options: ReporterOnStartOptions) {
     preRunMessageRemove(process.stderr);
   }

--- a/packages/jest-cli/src/reporters/summary_reporter.js
+++ b/packages/jest-cli/src/reporters/summary_reporter.js
@@ -89,7 +89,7 @@ export default class SummaryReporter extends BaseReporter {
         !lastResult.numFailingTests &&
         !lastResult.testExecError
       ) {
-        this.log('');
+        this.info('');
       }
 
       this._printSummary(aggregatedResults, this._globalConfig);
@@ -110,7 +110,7 @@ export default class SummaryReporter extends BaseReporter {
               ? chalk.bold.red('Test run was interrupted.')
               : this._getTestSummary(contexts, this._globalConfig));
         }
-        this.log(message);
+        this.info(message);
       }
     }
   }


### PR DESCRIPTION
**Summary**

Test summary is actually for providing information to the developers, therefore it's not supposed to be defined as error output. 
This PR will help developers who are using maven build to have better logging level because maven takes all stderr streams and marks them with log level ERROR. It is not error but information.

**Test plan**
- Create a React project using CLI
- Download this pom file and add it to your project root: https://drive.google.com/file/d/1doQO4oMoDJlU2P4XweIwcX3cL7CP4ET6/view?usp=sharing
- Run command `mvn clean install`
- Check if at the line of test result summary, maven says `[INFO]`