### PR TITLE
Use yarn v1.3.2 for AppVeyor CI build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ init:
 install:
   - ps: Install-Product node $env:nodejs_version x64
   - node --version
-  - curl -fsSL -o yarn.js https://github.com/yarnpkg/yarn/releases/download/v1.1.0/yarn-1.1.0.js
+  - curl -fsSL -o yarn.js https://github.com/yarnpkg/yarn/releases/download/v1.3.2/yarn-1.3.2.js
   - node ./yarn.js --version
   - node ./yarn.js install
   - node ./yarn.js run build


### PR DESCRIPTION
**Summary**

It's better to keep yarn up-to-date for CI build. This PR replaces yarn v1.1 with yarn v1.3.2 for AppVeyor.

**Test plan**

**N.A.**