### PR TITLE
fix: get builtin modules from node core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,9 @@
 * `[docs]` Add tutorial page for ES6 class mocks.
   ([#5383]https://github.com/facebook/jest/pull/5383))
 * `[jest-resolve]` Search required modules in node_modules and then in custom
-  paths.
-  ([#5403](https://github.com/facebook/jest/pull/5403))
+  paths. ([#5403](https://github.com/facebook/jest/pull/5403))
+* `[jest-resolve]` Get builtin modules from node core.
+  ([#5411](https://github.com/facebook/jest/pull/5411))
 
 ## jest 22.1.4
 

--- a/packages/jest-resolve/src/is_builtin_module.js
+++ b/packages/jest-resolve/src/is_builtin_module.js
@@ -7,18 +7,20 @@
  * @flow
  */
 
+// $FlowFixMe: Flow doesn't know about the `module` module
+import {builtinModules} from 'module';
+
 // https://github.com/facebook/flow/pull/5160
 declare var process: {
   binding(type: string): {},
 };
 
 const BUILTIN_MODULES =
-  module.builtinModules ||
+  builtinModules ||
   Object.keys(process.binding('natives')).filter(
     (module: string) => !/^internal\//.test(module),
   );
 
 export default function isBuiltinModule(module: string): boolean {
-  // $FlowFixMe: module.builtinModules is not added to the flow type definitions yet
   return BUILTIN_MODULES.indexOf(module) !== -1;
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

**Summary**
We don't currently get the list of builtins from node core, as we use the wrong API. See https://nodejs.org/api/modules.html#modules_module_builtinmodules

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Test plan**
Tested using `console.log` locally on node 9.4.0 that the list exists.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
