### PR TITLE
Improve description line when assertion fails: part 1

### DIFF
--- a/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -201,7 +201,7 @@ Received: <red>undefined</>"
 `;
 
 exports[`.toBe() does not crash on circular references 1`] = `
-"<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>) // using Object.is</>
+"<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>) // Object.is equality</>
 
 Expected value to be:
   <green>{}</>
@@ -220,7 +220,7 @@ Difference:
 `;
 
 exports[`.toBe() fails for '"a"' with '.not' 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toBe(</><green>expected</><dim>) // using Object.is</>
+"<dim>expect(</><red>received</><dim>).not.toBe(</><green>expected</><dim>) // Object.is equality</>
 
 Expected value to not be:
   <green>\\"a\\"</>
@@ -229,7 +229,7 @@ Received:
 `;
 
 exports[`.toBe() fails for '[]' with '.not' 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toBe(</><green>expected</><dim>) // using Object.is</>
+"<dim>expect(</><red>received</><dim>).not.toBe(</><green>expected</><dim>) // Object.is equality</>
 
 Expected value to not be:
   <green>[]</>
@@ -238,7 +238,7 @@ Received:
 `;
 
 exports[`.toBe() fails for '{}' with '.not' 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toBe(</><green>expected</><dim>) // using Object.is</>
+"<dim>expect(</><red>received</><dim>).not.toBe(</><green>expected</><dim>) // Object.is equality</>
 
 Expected value to not be:
   <green>{}</>
@@ -247,7 +247,7 @@ Received:
 `;
 
 exports[`.toBe() fails for '1' with '.not' 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toBe(</><green>expected</><dim>) // using Object.is</>
+"<dim>expect(</><red>received</><dim>).not.toBe(</><green>expected</><dim>) // Object.is equality</>
 
 Expected value to not be:
   <green>1</>
@@ -256,7 +256,7 @@ Received:
 `;
 
 exports[`.toBe() fails for 'false' with '.not' 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toBe(</><green>expected</><dim>) // using Object.is</>
+"<dim>expect(</><red>received</><dim>).not.toBe(</><green>expected</><dim>) // Object.is equality</>
 
 Expected value to not be:
   <green>false</>
@@ -265,7 +265,7 @@ Received:
 `;
 
 exports[`.toBe() fails for 'null' with '.not' 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toBe(</><green>expected</><dim>) // using Object.is</>
+"<dim>expect(</><red>received</><dim>).not.toBe(</><green>expected</><dim>) // Object.is equality</>
 
 Expected value to not be:
   <green>null</>
@@ -274,7 +274,7 @@ Received:
 `;
 
 exports[`.toBe() fails for 'undefined' with '.not' 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toBe(</><green>expected</><dim>) // using Object.is</>
+"<dim>expect(</><red>received</><dim>).not.toBe(</><green>expected</><dim>) // Object.is equality</>
 
 Expected value to not be:
   <green>undefined</>
@@ -283,7 +283,7 @@ Received:
 `;
 
 exports[`.toBe() fails for: "abc" and "cde" 1`] = `
-"<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>) // using Object.is</>
+"<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>) // Object.is equality</>
 
 Expected value to be:
   <green>\\"cde\\"</>
@@ -293,7 +293,7 @@ Received:
 
 exports[`.toBe() fails for: "with 
 trailing space" and "without trailing space" 1`] = `
-"<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>) // using Object.is</>
+"<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>) // Object.is equality</>
 
 Expected value to be:
   <green>\\"without trailing space\\"</>
@@ -303,7 +303,7 @@ Received:
 `;
 
 exports[`.toBe() fails for: [] and [] 1`] = `
-"<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>) // using Object.is</>
+"<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>) // Object.is equality</>
 
 Expected value to be:
   <green>[]</>
@@ -316,7 +316,7 @@ Difference:
 `;
 
 exports[`.toBe() fails for: {"a": 1} and {"a": 1} 1`] = `
-"<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>) // using Object.is</>
+"<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>) // Object.is equality</>
 
 Expected value to be:
   <green>{\\"a\\": 1}</>
@@ -329,7 +329,7 @@ Difference:
 `;
 
 exports[`.toBe() fails for: {"a": 1} and {"a": 5} 1`] = `
-"<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>) // using Object.is</>
+"<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>) // Object.is equality</>
 
 Expected value to be:
   <green>{\\"a\\": 5}</>
@@ -348,7 +348,7 @@ Difference:
 `;
 
 exports[`.toBe() fails for: {} and {} 1`] = `
-"<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>) // using Object.is</>
+"<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>) // Object.is equality</>
 
 Expected value to be:
   <green>{}</>
@@ -361,7 +361,7 @@ Difference:
 `;
 
 exports[`.toBe() fails for: -0 and 0 1`] = `
-"<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>) // using Object.is</>
+"<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>) // Object.is equality</>
 
 Expected value to be:
   <green>0</>
@@ -374,7 +374,7 @@ Difference:
 `;
 
 exports[`.toBe() fails for: 1 and 2 1`] = `
-"<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>) // using Object.is</>
+"<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>) // Object.is equality</>
 
 Expected value to be:
   <green>2</>
@@ -383,7 +383,7 @@ Received:
 `;
 
 exports[`.toBe() fails for: null and undefined 1`] = `
-"<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>) // using Object.is</>
+"<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>) // Object.is equality</>
 
 Expected value to be:
   <green>undefined</>
@@ -396,7 +396,7 @@ Difference:
 `;
 
 exports[`.toBe() fails for: true and false 1`] = `
-"<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>) // using Object.is</>
+"<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>) // Object.is equality</>
 
 Expected value to be:
   <green>false</>

--- a/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -201,9 +201,9 @@ Received: <red>undefined</>"
 `;
 
 exports[`.toBe() does not crash on circular references 1`] = `
-"<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>) // using Object.is</>
 
-Expected value to be (using Object.is):
+Expected value to be:
   <green>{}</>
 Received:
   <red>{\\"circular\\": [Circular]}</>
@@ -220,72 +220,72 @@ Difference:
 `;
 
 exports[`.toBe() fails for '"a"' with '.not' 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toBe(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).not.toBe(</><green>expected</><dim>) // using Object.is</>
 
-Expected value to not be (using Object.is):
+Expected value to not be:
   <green>\\"a\\"</>
 Received:
   <red>\\"a\\"</>"
 `;
 
 exports[`.toBe() fails for '[]' with '.not' 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toBe(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).not.toBe(</><green>expected</><dim>) // using Object.is</>
 
-Expected value to not be (using Object.is):
+Expected value to not be:
   <green>[]</>
 Received:
   <red>[]</>"
 `;
 
 exports[`.toBe() fails for '{}' with '.not' 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toBe(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).not.toBe(</><green>expected</><dim>) // using Object.is</>
 
-Expected value to not be (using Object.is):
+Expected value to not be:
   <green>{}</>
 Received:
   <red>{}</>"
 `;
 
 exports[`.toBe() fails for '1' with '.not' 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toBe(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).not.toBe(</><green>expected</><dim>) // using Object.is</>
 
-Expected value to not be (using Object.is):
+Expected value to not be:
   <green>1</>
 Received:
   <red>1</>"
 `;
 
 exports[`.toBe() fails for 'false' with '.not' 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toBe(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).not.toBe(</><green>expected</><dim>) // using Object.is</>
 
-Expected value to not be (using Object.is):
+Expected value to not be:
   <green>false</>
 Received:
   <red>false</>"
 `;
 
 exports[`.toBe() fails for 'null' with '.not' 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toBe(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).not.toBe(</><green>expected</><dim>) // using Object.is</>
 
-Expected value to not be (using Object.is):
+Expected value to not be:
   <green>null</>
 Received:
   <red>null</>"
 `;
 
 exports[`.toBe() fails for 'undefined' with '.not' 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toBe(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).not.toBe(</><green>expected</><dim>) // using Object.is</>
 
-Expected value to not be (using Object.is):
+Expected value to not be:
   <green>undefined</>
 Received:
   <red>undefined</>"
 `;
 
 exports[`.toBe() fails for: "abc" and "cde" 1`] = `
-"<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>) // using Object.is</>
 
-Expected value to be (using Object.is):
+Expected value to be:
   <green>\\"cde\\"</>
 Received:
   <red>\\"abc\\"</>"
@@ -293,9 +293,9 @@ Received:
 
 exports[`.toBe() fails for: "with 
 trailing space" and "without trailing space" 1`] = `
-"<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>) // using Object.is</>
 
-Expected value to be (using Object.is):
+Expected value to be:
   <green>\\"without trailing space\\"</>
 Received:
   <red>\\"with<inverse> </></>
@@ -303,9 +303,9 @@ Received:
 `;
 
 exports[`.toBe() fails for: [] and [] 1`] = `
-"<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>) // using Object.is</>
 
-Expected value to be (using Object.is):
+Expected value to be:
   <green>[]</>
 Received:
   <red>[]</>
@@ -316,9 +316,9 @@ Difference:
 `;
 
 exports[`.toBe() fails for: {"a": 1} and {"a": 1} 1`] = `
-"<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>) // using Object.is</>
 
-Expected value to be (using Object.is):
+Expected value to be:
   <green>{\\"a\\": 1}</>
 Received:
   <red>{\\"a\\": 1}</>
@@ -329,9 +329,9 @@ Difference:
 `;
 
 exports[`.toBe() fails for: {"a": 1} and {"a": 5} 1`] = `
-"<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>) // using Object.is</>
 
-Expected value to be (using Object.is):
+Expected value to be:
   <green>{\\"a\\": 5}</>
 Received:
   <red>{\\"a\\": 1}</>
@@ -348,9 +348,9 @@ Difference:
 `;
 
 exports[`.toBe() fails for: {} and {} 1`] = `
-"<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>) // using Object.is</>
 
-Expected value to be (using Object.is):
+Expected value to be:
   <green>{}</>
 Received:
   <red>{}</>
@@ -361,9 +361,9 @@ Difference:
 `;
 
 exports[`.toBe() fails for: -0 and 0 1`] = `
-"<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>) // using Object.is</>
 
-Expected value to be (using Object.is):
+Expected value to be:
   <green>0</>
 Received:
   <red>-0</>
@@ -374,18 +374,18 @@ Difference:
 `;
 
 exports[`.toBe() fails for: 1 and 2 1`] = `
-"<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>) // using Object.is</>
 
-Expected value to be (using Object.is):
+Expected value to be:
   <green>2</>
 Received:
   <red>1</>"
 `;
 
 exports[`.toBe() fails for: null and undefined 1`] = `
-"<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>) // using Object.is</>
 
-Expected value to be (using Object.is):
+Expected value to be:
   <green>undefined</>
 Received:
   <red>null</>
@@ -396,16 +396,16 @@ Difference:
 `;
 
 exports[`.toBe() fails for: true and false 1`] = `
-"<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>) // using Object.is</>
 
-Expected value to be (using Object.is):
+Expected value to be:
   <green>false</>
 Received:
   <red>true</>"
 `;
 
 exports[`.toBeCloseTo() {pass: true} expect(0)toBeCloseTo( 0) 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toBeCloseTo(</><green>expected, precision</><dim>)</>
+"<dim>expect(</><red>received</><dim>).not.toBeCloseTo(</><green>expected</><dim>)</>
 
 Expected value not to be close to (with <green>2</>-digit precision):
   <green>0</>
@@ -414,7 +414,7 @@ Received:
 `;
 
 exports[`.toBeCloseTo() {pass: true} expect(0)toBeCloseTo( 0.001) 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toBeCloseTo(</><green>expected, precision</><dim>)</>
+"<dim>expect(</><red>received</><dim>).not.toBeCloseTo(</><green>expected</><dim>)</>
 
 Expected value not to be close to (with <green>2</>-digit precision):
   <green>0.001</>
@@ -423,7 +423,7 @@ Received:
 `;
 
 exports[`.toBeCloseTo() {pass: true} expect(1.23)toBeCloseTo( 1.225) 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toBeCloseTo(</><green>expected, precision</><dim>)</>
+"<dim>expect(</><red>received</><dim>).not.toBeCloseTo(</><green>expected</><dim>)</>
 
 Expected value not to be close to (with <green>2</>-digit precision):
   <green>1.225</>
@@ -432,7 +432,7 @@ Received:
 `;
 
 exports[`.toBeCloseTo() {pass: true} expect(1.23)toBeCloseTo( 1.226) 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toBeCloseTo(</><green>expected, precision</><dim>)</>
+"<dim>expect(</><red>received</><dim>).not.toBeCloseTo(</><green>expected</><dim>)</>
 
 Expected value not to be close to (with <green>2</>-digit precision):
   <green>1.226</>
@@ -441,7 +441,7 @@ Received:
 `;
 
 exports[`.toBeCloseTo() {pass: true} expect(1.23)toBeCloseTo( 1.229) 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toBeCloseTo(</><green>expected, precision</><dim>)</>
+"<dim>expect(</><red>received</><dim>).not.toBeCloseTo(</><green>expected</><dim>)</>
 
 Expected value not to be close to (with <green>2</>-digit precision):
   <green>1.229</>
@@ -450,7 +450,7 @@ Received:
 `;
 
 exports[`.toBeCloseTo() {pass: true} expect(1.23)toBeCloseTo( 1.234) 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toBeCloseTo(</><green>expected, precision</><dim>)</>
+"<dim>expect(</><red>received</><dim>).not.toBeCloseTo(</><green>expected</><dim>)</>
 
 Expected value not to be close to (with <green>2</>-digit precision):
   <green>1.234</>
@@ -459,7 +459,7 @@ Received:
 `;
 
 exports[`.toBeCloseTo() accepts an optional precision argument: [0, 0.000004, 5] 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toBeCloseTo(</><green>expected, precision</><dim>)</>
+"<dim>expect(</><red>received</><dim>).not.toBeCloseTo(</><green>expected</><dim>, </><green>precision</><dim>)</>
 
 Expected value not to be close to (with <green>5</>-digit precision):
   <green>0.000004</>
@@ -468,7 +468,7 @@ Received:
 `;
 
 exports[`.toBeCloseTo() accepts an optional precision argument: [0, 0.0001, 3] 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toBeCloseTo(</><green>expected, precision</><dim>)</>
+"<dim>expect(</><red>received</><dim>).not.toBeCloseTo(</><green>expected</><dim>, </><green>precision</><dim>)</>
 
 Expected value not to be close to (with <green>3</>-digit precision):
   <green>0.0001</>
@@ -477,7 +477,7 @@ Received:
 `;
 
 exports[`.toBeCloseTo() accepts an optional precision argument: [0, 0.1, 0] 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toBeCloseTo(</><green>expected, precision</><dim>)</>
+"<dim>expect(</><red>received</><dim>).not.toBeCloseTo(</><green>expected</><dim>, </><green>precision</><dim>)</>
 
 Expected value not to be close to (with <green>0</>-digit precision):
   <green>0.1</>
@@ -486,7 +486,7 @@ Received:
 `;
 
 exports[`.toBeCloseTo() throws: [0, 0.01] 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeCloseTo(</><green>expected, precision</><dim>)</>
+"<dim>expect(</><red>received</><dim>).toBeCloseTo(</><green>expected</><dim>)</>
 
 Expected value to be close to (with <green>2</>-digit precision):
   <green>0.01</>
@@ -495,7 +495,7 @@ Received:
 `;
 
 exports[`.toBeCloseTo() throws: [1, 1.23] 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeCloseTo(</><green>expected, precision</><dim>)</>
+"<dim>expect(</><red>received</><dim>).toBeCloseTo(</><green>expected</><dim>)</>
 
 Expected value to be close to (with <green>2</>-digit precision):
   <green>1.23</>
@@ -504,7 +504,7 @@ Received:
 `;
 
 exports[`.toBeCloseTo() throws: [1.23, 1.2249999] 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeCloseTo(</><green>expected, precision</><dim>)</>
+"<dim>expect(</><red>received</><dim>).toBeCloseTo(</><green>expected</><dim>)</>
 
 Expected value to be close to (with <green>2</>-digit precision):
   <green>1.2249999</>
@@ -2667,7 +2667,7 @@ To have a nested property:
 `;
 
 exports[`.toHaveProperty() {pass: false} expect("abc").toHaveProperty('a.b.c', {"a": 5}) 1`] = `
-"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</>, <green>value</><dim>)</>
+"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</><dim>, </><green>value</><dim>)</>
 
 Expected the object:
   <red>\\"abc\\"</>
@@ -2679,7 +2679,7 @@ With a value of:
 `;
 
 exports[`.toHaveProperty() {pass: false} expect({"a": {"b": {"c": {"d": 1}}}}).toHaveProperty('a,b,c,d', 2) 1`] = `
-"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</>, <green>value</><dim>)</>
+"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</><dim>, </><green>value</><dim>)</>
 
 Expected the object:
   <red>{\\"a\\": {\\"b\\": {\\"c\\": {\\"d\\": 1}}}}</>
@@ -2692,7 +2692,7 @@ Received:
 `;
 
 exports[`.toHaveProperty() {pass: false} expect({"a": {"b": {"c": {"d": 1}}}}).toHaveProperty('a.b.c.d', 2) 1`] = `
-"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</>, <green>value</><dim>)</>
+"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</><dim>, </><green>value</><dim>)</>
 
 Expected the object:
   <red>{\\"a\\": {\\"b\\": {\\"c\\": {\\"d\\": 1}}}}</>
@@ -2705,7 +2705,7 @@ Received:
 `;
 
 exports[`.toHaveProperty() {pass: false} expect({"a": {"b": {"c": {"d": 1}}}}).toHaveProperty('a.b.ttt.d', 1) 1`] = `
-"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</>, <green>value</><dim>)</>
+"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</><dim>, </><green>value</><dim>)</>
 
 Expected the object:
   <red>{\\"a\\": {\\"b\\": {\\"c\\": {\\"d\\": 1}}}}</>
@@ -2729,7 +2729,7 @@ Received:
 `;
 
 exports[`.toHaveProperty() {pass: false} expect({"a": {"b": {"c": {}}}}).toHaveProperty('a.b.c.d', 1) 1`] = `
-"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</>, <green>value</><dim>)</>
+"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</><dim>, </><green>value</><dim>)</>
 
 Expected the object:
   <red>{\\"a\\": {\\"b\\": {\\"c\\": {}}}}</>
@@ -2742,7 +2742,7 @@ Received:
 `;
 
 exports[`.toHaveProperty() {pass: false} expect({"a": {"b": {"c": 5}}}).toHaveProperty('a.b', {"c": 4}) 1`] = `
-"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</>, <green>value</><dim>)</>
+"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</><dim>, </><green>value</><dim>)</>
 
 Expected the object:
   <red>{\\"a\\": {\\"b\\": {\\"c\\": 5}}}</>
@@ -2765,7 +2765,7 @@ Difference:
 `;
 
 exports[`.toHaveProperty() {pass: false} expect({"a": {"b": 3}}).toHaveProperty('a.b', undefined) 1`] = `
-"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</>, <green>value</><dim>)</>
+"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</><dim>, </><green>value</><dim>)</>
 
 Expected the object:
   <red>{\\"a\\": {\\"b\\": 3}}</>
@@ -2793,7 +2793,7 @@ Received:
 `;
 
 exports[`.toHaveProperty() {pass: false} expect({"a": 1}).toHaveProperty('a.b.c.d', 5) 1`] = `
-"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</>, <green>value</><dim>)</>
+"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</><dim>, </><green>value</><dim>)</>
 
 Expected the object:
   <red>{\\"a\\": 1}</>
@@ -2806,7 +2806,7 @@ Received:
 `;
 
 exports[`.toHaveProperty() {pass: false} expect({"a.b.c.d": 1}).toHaveProperty('a.b.c.d', 2) 1`] = `
-"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</>, <green>value</><dim>)</>
+"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</><dim>, </><green>value</><dim>)</>
 
 Expected the object:
   <red>{\\"a.b.c.d\\": 1}</>
@@ -2818,7 +2818,7 @@ With a value of:
 `;
 
 exports[`.toHaveProperty() {pass: false} expect({"a.b.c.d": 1}).toHaveProperty('a.b.c.d', 2) 2`] = `
-"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</>, <green>value</><dim>)</>
+"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</><dim>, </><green>value</><dim>)</>
 
 Expected the object:
   <red>{\\"a.b.c.d\\": 1}</>
@@ -2841,7 +2841,7 @@ To have a nested property:
 `;
 
 exports[`.toHaveProperty() {pass: false} expect({}).toHaveProperty('a', "a") 1`] = `
-"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</>, <green>value</><dim>)</>
+"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</><dim>, </><green>value</><dim>)</>
 
 Expected the object:
   <red>{}</>
@@ -2858,7 +2858,7 @@ Difference:
 `;
 
 exports[`.toHaveProperty() {pass: false} expect({}).toHaveProperty('a', "test") 1`] = `
-"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</>, <green>value</><dim>)</>
+"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</><dim>, </><green>value</><dim>)</>
 
 Expected the object:
   <red>{}</>
@@ -2870,7 +2870,7 @@ With a value of:
 `;
 
 exports[`.toHaveProperty() {pass: false} expect({}).toHaveProperty('b', undefined) 1`] = `
-"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</>, <green>value</><dim>)</>
+"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</><dim>, </><green>value</><dim>)</>
 
 Expected the object:
   <red>{}</>
@@ -2897,7 +2897,7 @@ To have a nested property:
 `;
 
 exports[`.toHaveProperty() {pass: false} expect(1).toHaveProperty('a.b.c', "test") 1`] = `
-"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</>, <green>value</><dim>)</>
+"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</><dim>, </><green>value</><dim>)</>
 
 Expected the object:
   <red>1</>
@@ -2919,7 +2919,7 @@ Not to have a nested property:
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({"a": {"b": [1, 2, 3]}}).toHaveProperty('a,b,1', 2) 1`] = `
-"<dim>expect(</><red>object</><dim>).not.toHaveProperty(</><green>path</>, <green>value</><dim>)</>
+"<dim>expect(</><red>object</><dim>).not.toHaveProperty(</><green>path</><dim>, </><green>value</><dim>)</>
 
 Expected the object:
   <red>{\\"a\\": {\\"b\\": [1, 2, 3]}}</>
@@ -2941,7 +2941,7 @@ Not to have a nested property:
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({"a": {"b": {"c": {"d": 1}}}}).toHaveProperty('a,b,c,d', 1) 1`] = `
-"<dim>expect(</><red>object</><dim>).not.toHaveProperty(</><green>path</>, <green>value</><dim>)</>
+"<dim>expect(</><red>object</><dim>).not.toHaveProperty(</><green>path</><dim>, </><green>value</><dim>)</>
 
 Expected the object:
   <red>{\\"a\\": {\\"b\\": {\\"c\\": {\\"d\\": 1}}}}</>
@@ -2963,7 +2963,7 @@ Not to have a nested property:
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({"a": {"b": {"c": {"d": 1}}}}).toHaveProperty('a.b.c.d', 1) 1`] = `
-"<dim>expect(</><red>object</><dim>).not.toHaveProperty(</><green>path</>, <green>value</><dim>)</>
+"<dim>expect(</><red>object</><dim>).not.toHaveProperty(</><green>path</><dim>, </><green>value</><dim>)</>
 
 Expected the object:
   <red>{\\"a\\": {\\"b\\": {\\"c\\": {\\"d\\": 1}}}}</>
@@ -2975,7 +2975,7 @@ With a value of:
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({"a": {"b": {"c": 5}}}).toHaveProperty('a.b', {"c": 5}) 1`] = `
-"<dim>expect(</><red>object</><dim>).not.toHaveProperty(</><green>path</>, <green>value</><dim>)</>
+"<dim>expect(</><red>object</><dim>).not.toHaveProperty(</><green>path</><dim>, </><green>value</><dim>)</>
 
 Expected the object:
   <red>{\\"a\\": {\\"b\\": {\\"c\\": 5}}}</>
@@ -2997,7 +2997,7 @@ Not to have a nested property:
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({"a": {"b": undefined}}).toHaveProperty('a.b', undefined) 1`] = `
-"<dim>expect(</><red>object</><dim>).not.toHaveProperty(</><green>path</>, <green>value</><dim>)</>
+"<dim>expect(</><red>object</><dim>).not.toHaveProperty(</><green>path</><dim>, </><green>value</><dim>)</>
 
 Expected the object:
   <red>{\\"a\\": {\\"b\\": undefined}}</>
@@ -3019,7 +3019,7 @@ Not to have a nested property:
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({"a": 0}).toHaveProperty('a', 0) 1`] = `
-"<dim>expect(</><red>object</><dim>).not.toHaveProperty(</><green>path</>, <green>value</><dim>)</>
+"<dim>expect(</><red>object</><dim>).not.toHaveProperty(</><green>path</><dim>, </><green>value</><dim>)</>
 
 Expected the object:
   <red>{\\"a\\": 0}</>
@@ -3041,7 +3041,7 @@ Not to have a nested property:
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({"a.b.c.d": 1}).toHaveProperty('a.b.c.d', 1) 1`] = `
-"<dim>expect(</><red>object</><dim>).not.toHaveProperty(</><green>path</>, <green>value</><dim>)</>
+"<dim>expect(</><red>object</><dim>).not.toHaveProperty(</><green>path</><dim>, </><green>value</><dim>)</>
 
 Expected the object:
   <red>{\\"a.b.c.d\\": 1}</>
@@ -3053,7 +3053,7 @@ With a value of:
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({"property": 1}).toHaveProperty('property', 1) 1`] = `
-"<dim>expect(</><red>object</><dim>).not.toHaveProperty(</><green>path</>, <green>value</><dim>)</>
+"<dim>expect(</><red>object</><dim>).not.toHaveProperty(</><green>path</><dim>, </><green>value</><dim>)</>
 
 Expected the object:
   <red>{\\"property\\": 1}</>
@@ -3065,7 +3065,7 @@ With a value of:
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({}).toHaveProperty('a', undefined) 1`] = `
-"<dim>expect(</><red>object</><dim>).not.toHaveProperty(</><green>path</>, <green>value</><dim>)</>
+"<dim>expect(</><red>object</><dim>).not.toHaveProperty(</><green>path</><dim>, </><green>value</><dim>)</>
 
 Expected the object:
   <red>{}</>
@@ -3077,7 +3077,7 @@ With a value of:
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({}).toHaveProperty('b', "b") 1`] = `
-"<dim>expect(</><red>object</><dim>).not.toHaveProperty(</><green>path</>, <green>value</><dim>)</>
+"<dim>expect(</><red>object</><dim>).not.toHaveProperty(</><green>path</><dim>, </><green>value</><dim>)</>
 
 Expected the object:
   <red>{}</>

--- a/packages/expect/src/matchers.js
+++ b/packages/expect/src/matchers.js
@@ -40,12 +40,13 @@ type ContainIterable =
 
 const matchers: MatchersObject = {
   toBe(received: any, expected: number) {
+    const comment = 'Object.is equality';
     const pass = Object.is(received, expected);
 
     const message = pass
       ? () =>
           matcherHint('.not.toBe', undefined, undefined, {
-            comment: 'using Object.is',
+            comment,
           }) +
           '\n\n' +
           `Expected value to not be:\n` +
@@ -64,7 +65,7 @@ const matchers: MatchersObject = {
 
           return (
             matcherHint('.toBe', undefined, undefined, {
-              comment: 'using Object.is',
+              comment,
             }) +
             '\n\n' +
             `Expected value to be:\n` +

--- a/packages/expect/src/matchers.js
+++ b/packages/expect/src/matchers.js
@@ -44,9 +44,11 @@ const matchers: MatchersObject = {
 
     const message = pass
       ? () =>
-          matcherHint('.not.toBe') +
+          matcherHint('.not.toBe', undefined, undefined, {
+            comment: 'using Object.is',
+          }) +
           '\n\n' +
-          `Expected value to not be (using Object.is):\n` +
+          `Expected value to not be:\n` +
           `  ${printExpected(expected)}\n` +
           `Received:\n` +
           `  ${printReceived(received)}`
@@ -61,9 +63,11 @@ const matchers: MatchersObject = {
           });
 
           return (
-            matcherHint('.toBe') +
+            matcherHint('.toBe', undefined, undefined, {
+              comment: 'using Object.is',
+            }) +
             '\n\n' +
-            `Expected value to be (using Object.is):\n` +
+            `Expected value to be:\n` +
             `  ${printExpected(expected)}\n` +
             `Received:\n` +
             `  ${printReceived(received)}` +
@@ -79,11 +83,14 @@ const matchers: MatchersObject = {
   },
 
   toBeCloseTo(actual: number, expected: number, precision?: number = 2) {
+    const secondArgument = arguments.length === 3 ? 'precision' : null;
     ensureNumbers(actual, expected, '.toBeCloseTo');
     const pass = Math.abs(expected - actual) < Math.pow(10, -precision) / 2;
     const message = pass
       ? () =>
-          matcherHint('.not.toBeCloseTo', 'received', 'expected, precision') +
+          matcherHint('.not.toBeCloseTo', undefined, undefined, {
+            secondArgument,
+          }) +
           '\n\n' +
           `Expected value not to be close to (with ${printExpected(
             precision,
@@ -92,7 +99,9 @@ const matchers: MatchersObject = {
           `Received:\n` +
           `  ${printReceived(actual)}`
       : () =>
-          matcherHint('.toBeCloseTo', 'received', 'expected, precision') +
+          matcherHint('.toBeCloseTo', undefined, undefined, {
+            secondArgument,
+          }) +
           '\n\n' +
           `Expected value to be close to (with ${printExpected(
             precision,
@@ -488,11 +497,12 @@ const matchers: MatchersObject = {
 
   toHaveProperty(object: Object, keyPath: string | Array<any>, value?: any) {
     const valuePassed = arguments.length === 3;
+    const secondArgument = valuePassed ? 'value' : null;
 
     if (!object && typeof object !== 'string' && typeof object !== 'number') {
       throw new Error(
         matcherHint('[.not].toHaveProperty', 'object', 'path', {
-          secondArgument: valuePassed ? 'value' : null,
+          secondArgument,
         }) +
           '\n\n' +
           `Expected ${RECEIVED_COLOR('object')} to be an object. Received:\n` +
@@ -505,7 +515,7 @@ const matchers: MatchersObject = {
     if (keyPathType !== 'string' && keyPathType !== 'array') {
       throw new Error(
         matcherHint('[.not].toHaveProperty', 'object', 'path', {
-          secondArgument: valuePassed ? 'value' : null,
+          secondArgument,
         }) +
           '\n\n' +
           `Expected ${EXPECTED_COLOR(
@@ -527,7 +537,7 @@ const matchers: MatchersObject = {
     const message = pass
       ? () =>
           matcherHint('.not.toHaveProperty', 'object', 'path', {
-            secondArgument: valuePassed ? 'value' : null,
+            secondArgument,
           }) +
           '\n\n' +
           `Expected the object:\n` +
@@ -542,7 +552,7 @@ const matchers: MatchersObject = {
               : '';
           return (
             matcherHint('.toHaveProperty', 'object', 'path', {
-              secondArgument: valuePassed ? 'value' : null,
+              secondArgument,
             }) +
             '\n\n' +
             `Expected the object:\n` +

--- a/packages/jest-jasmine2/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/jest-jasmine2/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`matchers proxies matchers to expect 1`] = `
-"<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>) // using Object.is</>
 
-Expected value to be (using Object.is):
+Expected value to be:
   <green>2</>
 Received:
   <red>1</>"

--- a/packages/jest-jasmine2/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/jest-jasmine2/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`matchers proxies matchers to expect 1`] = `
-"<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>) // using Object.is</>
+"<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>) // Object.is equality</>
 
 Expected value to be:
   <green>2</>

--- a/packages/jest-matcher-utils/src/index.js
+++ b/packages/jest-matcher-utils/src/index.js
@@ -150,15 +150,13 @@ export const matcherHint = (
   matcherName: string,
   received: string = 'received',
   expected: string = 'expected',
-  options: ?{
+  options: {
     comment?: string,
     isDirectExpectCall?: boolean,
     secondArgument?: ?string,
-  },
+  } = {},
 ) => {
-  const comment = options && options.comment ? ` // ${options.comment}` : '';
-  const isDirectExpectCall = options && options.isDirectExpectCall;
-  const secondArgument = options && options.secondArgument;
+  const {comment, isDirectExpectCall, secondArgument} = options;
   return (
     chalk.dim('expect' + (isDirectExpectCall ? '' : '(')) +
     RECEIVED_COLOR(received) +
@@ -167,6 +165,6 @@ export const matcherHint = (
     (secondArgument
       ? `${chalk.dim(', ')}${EXPECTED_COLOR(secondArgument)}`
       : '') +
-    chalk.dim(`)${comment}`)
+    chalk.dim(`)${comment ? ` // ${comment}` : ''}`)
   );
 };

--- a/packages/jest-matcher-utils/src/index.js
+++ b/packages/jest-matcher-utils/src/index.js
@@ -151,18 +151,22 @@ export const matcherHint = (
   received: string = 'received',
   expected: string = 'expected',
   options: ?{
-    secondArgument?: ?string,
+    comment?: string,
     isDirectExpectCall?: boolean,
+    secondArgument?: ?string,
   },
 ) => {
-  const secondArgument = options && options.secondArgument;
+  const comment = options && options.comment ? ` // ${options.comment}` : '';
   const isDirectExpectCall = options && options.isDirectExpectCall;
+  const secondArgument = options && options.secondArgument;
   return (
     chalk.dim('expect' + (isDirectExpectCall ? '' : '(')) +
     RECEIVED_COLOR(received) +
     chalk.dim((isDirectExpectCall ? '' : ')') + matcherName + '(') +
     EXPECTED_COLOR(expected) +
-    (secondArgument ? `, ${EXPECTED_COLOR(secondArgument)}` : '') +
-    chalk.dim(')')
+    (secondArgument
+      ? `${chalk.dim(', ')}${EXPECTED_COLOR(secondArgument)}`
+      : '') +
+    chalk.dim(`)${comment}`)
   );
 };


### PR DESCRIPTION
**Summary**

First in series of pull requests for clearer shorter report when assertion fails.

To warm up, let’s sweat some small stuff :) //cc @thymikee @rickhanlonii

Apply two principles from *The Non-Designer’s Design Book* by Robin Williams:

1. **Contrast**: Format comma separating primary and secondary argument as **dim** instead of regular for `toHaveProperty` assertion.

<img width="900" alt="compare_tohaveproperty" src="https://user-images.githubusercontent.com/11862657/35711256-0d622acc-078a-11e8-9324-19db27b10ba7.png">

2. **Contrast**: Format comma separating primary and secondary argument as **dim** instead of green for `toBeCloseTo` which concatenated names instead of providing secondary as option.

<img width="900" alt="compare_tobecloseto" src="https://user-images.githubusercontent.com/11862657/35711274-20922110-078a-11e8-8695-0bcd0733a658.png">

3. **Proximity**: Format supplementary information as **dim comment** [EDIT on 2018-02-05: `// Object.is equality` to be parallel with `// strict equality` and `// deep equality` in next PR] at end of line instead labels in label `Expected value to be (using Object.is)` of values, which a future pull request will omit when there is a diff.

<img width="900" alt="5437_3_tobe" src="https://user-images.githubusercontent.com/11862657/35822585-c11ab988-0a7a-11e8-8645-bf90d5b2299d.png">

**Test plan**

1. Updated 24 snapshot tests in 1 test suite.
2. Updated 12 snapshot tests in 1 test suite. Most of snapshots omit the option because arg is omitted (for a more accurate description) following example of formatting for `toHaveProperty` assertion.
3. Updated 19 snapshot tests in 2 test suites.
