### PR TITLE
Remove retainLines from babel-jest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ### Fixes
 
+* `[babel-jest]` Remove retainLines from babel-jest
+  ([#5326](https://github.com/facebook/jest/issues/5326))
 * `[jest-cli]` Glob patterns ignore non-`require`-able files (e.g. `README.md`)
   ([#5199](https://github.com/facebook/jest/issues/5199))
 * `[jest-mock]` Add backticks support (\`\`) to `mock` a certain package via the

--- a/packages/babel-jest/src/index.js
+++ b/packages/babel-jest/src/index.js
@@ -69,7 +69,6 @@ const createTransformer = (options: any) => {
   options = Object.assign({}, options, {
     plugins: (options && options.plugins) || [],
     presets: ((options && options.presets) || []).concat([jestPreset]),
-    retainLines: true,
     sourceMaps: 'inline',
   });
   delete options.cacheDirectory;


### PR DESCRIPTION
**Summary**
Per https://github.com/facebook/jest/issues/5326, babel has an issue with retainLines that causes failures on decorators with async methods. Since babel already provides sourcemaps, we don't need to retainLines

**Test plan**
yarn test passed
