### PR TITLE
Fix recursive process.exit calls

### DIFF
--- a/packages/jest-cli/src/cli/index.js
+++ b/packages/jest-cli/src/cli/index.js
@@ -113,7 +113,7 @@ const readResultsAndExit = (
 ) => {
   const code = !result || result.success ? 0 : globalConfig.testFailureExitCode;
 
-  process.on('exit', () => exit(code));
+  process.on('exit', () => (process.exitCode = code));
 
   if (globalConfig.forceExit) {
     exit(code);

--- a/packages/jest-runtime/src/cli/index.js
+++ b/packages/jest-runtime/src/cli/index.js
@@ -11,7 +11,6 @@ import type {Argv} from 'types/Argv';
 import type {EnvironmentClass} from 'types/Environment';
 
 import chalk from 'chalk';
-import exit from 'exit';
 import os from 'os';
 import path from 'path';
 import yargs from 'yargs';
@@ -43,7 +42,7 @@ export function run(cliArgv?: Argv, cliInfo?: Array<string>) {
 
   if (argv.help) {
     yargs.showHelp();
-    process.on('exit', () => exit(1));
+    process.on('exit', () => (process.exitCode = 1));
     return;
   }
 
@@ -54,7 +53,7 @@ export function run(cliArgv?: Argv, cliInfo?: Array<string>) {
 
   if (!argv._.length) {
     console.log('Please provide a path to a script. (See --help for details)');
-    process.on('exit', () => exit(1));
+    process.on('exit', () => (process.exitCode = 1));
     return;
   }
 
@@ -93,6 +92,6 @@ export function run(cliArgv?: Argv, cliInfo?: Array<string>) {
     })
     .catch(e => {
       console.error(chalk.red(e.stack || e));
-      process.on('exit', () => exit(1));
+      process.on('exit', () => (process.exitCode = 1));
     });
 }


### PR DESCRIPTION
Use `process.exitCode` instead of recursively calling `process.exit()` on a `exit` event.

Fixes #5332. The reason why it stopped working when merged #5313 is because on every single call to `process.exit()`, the `process.exitCode` is checked just before exiting. However the `exit` module implementation does not do that, so the code was never set.

In turn, looking at [the `process.exit` implementation](https://github.com/nodejs/node/blob/master/lib/internal/process.js#L141-L150), it is clear that calling `process.exit()` from an `exit` event will have no effect but changing the exit code. Thus we can safely remove the second `exit()` call and only modify the exit code, so that the native method picks it. A bit confusing, I know.