### PR TITLE
Docs: Fix link to Webpack guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ You are now set up to use all ES6 features and React specific syntax.
 
 Jest can be used in projects that use [webpack](https://webpack.github.io/) to
 manage assets, styles, and compilation. webpack does offer some unique
-challenges over other tools. Refer to the [webpack guide](Webpack.md) to get
+challenges over other tools. Refer to the [webpack guide](docs/Webpack.md) to get
 started.
 
 ### Using TypeScript


### PR DESCRIPTION
## Summary

Minor fix: update link to Webpack guide as the current one is broken.