### PR TITLE
Fix master, add back retainLines to ./.babelrc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -8,5 +8,6 @@
     "transform-async-to-generator",
     "transform-strict-mode",
     ["transform-es2015-modules-commonjs", {"allowTopLevelThis": true}]
-  ]
+  ],
+  "retainLines": true
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

This PR fixes master by rolling back the `retainLines` change

It looks like removing the retainLines gave the integration tests the wrong line number. For example in this test (and the rest from what I could tell), the snapshot is correct:

![](http://dp.hanlon.io/010l3v3J3L40/Image%202018-02-02%20at%203.28.01%20PM.png)
