### PR TITLE
Hide interactive mode if there are no failed snapshot tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixes
 
+* `[jest-cli]` Hide interactive mode if there are no failed snapshot tests ([#5450](https://github.com/facebook/jest/pull/5450))
 * `[babel-jest]` Remove retainLines from babel-jest
   ([#5326](https://github.com/facebook/jest/pull/5439))
 * `[jest-cli]` Glob patterns ignore non-`require`-able files (e.g. `README.md`)
@@ -25,7 +26,7 @@
 * `[expect]` Make `rejects` and `resolves` synchronously validate its argument.
   ([#5364](https://github.com/facebook/jest/pull/5364))
 * `[docs]` Add tutorial page for ES6 class mocks.
-  ([#5383]https://github.com/facebook/jest/pull/5383))
+  ([#5383](https://github.com/facebook/jest/pull/5383))
 * `[jest-resolve]` Search required modules in node_modules and then in custom
   paths. ([#5403](https://github.com/facebook/jest/pull/5403))
 * `[jest-resolve]` Get builtin modules from node core.

--- a/packages/jest-cli/src/__tests__/__snapshots__/watch.test.js.snap
+++ b/packages/jest-cli/src/__tests__/__snapshots__/watch.test.js.snap
@@ -38,3 +38,38 @@ Watch Usage
   ],
 ]
 `;
+
+exports[`Watch mode flows shows update snapshot prompt (with interactive) 1`] = `
+Array [
+  Array [
+    "
+Watch Usage
+ › Press a to run all tests.
+ › Press f to run only failed tests.
+ › Press u to update failing snapshots.
+ › Press i to update failing snapshots interactively.
+ › Press p to filter by a filename regex pattern.
+ › Press t to filter by a test name regex pattern.
+ › Press q to quit watch mode.
+ › Press Enter to trigger a test run.
+",
+  ],
+]
+`;
+
+exports[`Watch mode flows shows update snapshot prompt (without interactive) 1`] = `
+Array [
+  Array [
+    "
+Watch Usage
+ › Press a to run all tests.
+ › Press f to run only failed tests.
+ › Press u to update failing snapshots.
+ › Press p to filter by a filename regex pattern.
+ › Press t to filter by a test name regex pattern.
+ › Press q to quit watch mode.
+ › Press Enter to trigger a test run.
+",
+  ],
+]
+`;

--- a/packages/jest-cli/src/__tests__/watch.test.js
+++ b/packages/jest-cli/src/__tests__/watch.test.js
@@ -13,9 +13,9 @@ import TestWatcher from '../test_watcher';
 import {KEYS} from '../constants';
 
 const runJestMock = jest.fn();
-
 const watchPluginPath = `${__dirname}/__fixtures__/watch_plugin`;
 const watchPlugin2Path = `${__dirname}/__fixtures__/watch_plugin2`;
+let results;
 
 jest.doMock('chalk', () => new chalk.constructor({enabled: false}));
 jest.doMock(
@@ -27,7 +27,7 @@ jest.doMock(
       runJestMock.apply(null, args);
 
       // Call the callback
-      onComplete({snapshot: {}});
+      onComplete(results);
 
       return Promise.resolve();
     },
@@ -70,6 +70,7 @@ describe('Watch mode flows', () => {
     hasteMapInstances = [{on: () => {}}];
     contexts = [{config}];
     stdin = new MockStdin();
+    results = {snapshot: {}};
   });
 
   it('Correctly passing test path pattern', () => {
@@ -159,6 +160,61 @@ describe('Watch mode flows', () => {
       Object.assign({}, globalConfig, {
         rootDir: __dirname,
         watchPlugins: [watchPlugin2Path, watchPluginPath],
+      }),
+      contexts,
+      pipe,
+      hasteMapInstances,
+      stdin,
+    );
+
+    const pipeMockCalls = pipe.write.mock.calls;
+
+    const determiningTestsToRun = pipeMockCalls.findIndex(
+      ([c]) => c === 'Determining test suites to run...',
+    );
+
+    expect(pipeMockCalls.slice(determiningTestsToRun + 1)).toMatchSnapshot();
+  });
+
+  it('shows update snapshot prompt (without interactive)', async () => {
+    jest.unmock('jest-util');
+    const util = require('jest-util');
+    util.isInteractive = true;
+    results = {snapshot: {failure: true}};
+
+    const ci_watch = require('../watch').default;
+    ci_watch(
+      Object.assign({}, globalConfig, {
+        rootDir: __dirname,
+        watchPlugins: [],
+      }),
+      contexts,
+      pipe,
+      hasteMapInstances,
+      stdin,
+    );
+
+    const pipeMockCalls = pipe.write.mock.calls;
+
+    const determiningTestsToRun = pipeMockCalls.findIndex(
+      ([c]) => c === 'Determining test suites to run...',
+    );
+
+    expect(pipeMockCalls.slice(determiningTestsToRun + 1)).toMatchSnapshot();
+  });
+
+  it('shows update snapshot prompt (with interactive)', async () => {
+    jest.unmock('jest-util');
+    const util = require('jest-util');
+    util.isInteractive = true;
+    util.getFailedSnapshotTests = jest.fn(() => ['test.js']);
+    results = {snapshot: {failure: true}};
+
+    const ci_watch = require('../watch').default;
+    ci_watch(
+      Object.assign({}, globalConfig, {
+        rootDir: __dirname,
+        watchPlugins: [],
       }),
       contexts,
       pipe,


### PR DESCRIPTION
## Summary
This PR will not show the interactive option in watch mode if there are no failed snapshot tests. This can happen if one or more test descriptions have changed.

Fixes https://github.com/facebook/jest/issues/5444

## Test plan
I added tests for the `u` option as well as `i` in watch mode

## Screenshots
#### Before
![](http://dp.hanlon.io/161v3w2O0r1B/[7f181cd540edee3e1333a4ae47ab9187]_Image%202018-02-02%20at%2010.22.23%20PM.png)

#### After
![](http://dp.hanlon.io/2K3S3n253r19/[07df488f671252e62f2ff652aa704a11]_Image%202018-02-02%20at%2010.21.04%20PM.png)