### PR TITLE
Allow module field

### DIFF
--- a/packages/jest-resolve/src/default_resolver.js
+++ b/packages/jest-resolve/src/default_resolver.js
@@ -126,7 +126,8 @@ function resolveSync(target: Path, options: ResolverOptions): Path {
     let pkgmain;
     try {
       const body = fs.readFileSync(pkgfile, 'utf8');
-      pkgmain = JSON.parse(body).main;
+      const parsedBody = JSON.parse(body);
+      pkgmain = parsedBody.module || parsedBody.main;
     } catch (e) {}
 
     if (pkgmain && pkgmain !== '.') {


### PR DESCRIPTION
At the moment `jest` always resolves dependencies through the `main` field in the `package.json`. This PR will allow packages to also be imported through the `module` field.

## Why is this needed?

According to the new [`module` field proposal](https://github.com/dherman/defense-of-dot-js/blob/master/proposal.md) `node.js` will start preferring `module` to `main`.

## Real world example

I have a project where I depend heavily on yarn workspaces. I use the `module` and the `main` field to distinguish between compiled and non-compiled files. So the `module` field actually refers to the actual source code of the required dependency. When it would just `require` the `main` field it would load the compiled files, which would make it harder to debug around different packages.