### PR TITLE
Add a trailing slash to the root pattern

### DIFF
--- a/packages/jest-cli/src/__tests__/search_source.test.js
+++ b/packages/jest-cli/src/__tests__/search_source.test.js
@@ -463,5 +463,24 @@ describe('SearchSource', () => {
         path.join(rootDir, '__testtests__', 'test.jsx'),
       ]);
     });
+
+    it('does not mistake roots folders with prefix names', async () => {
+      const config = normalize(
+        {
+          name,
+          rootDir: '.',
+          roots: ['/foo/bar/prefix'],
+        },
+        {},
+      ).options;
+
+      searchSource = new SearchSource(
+        await Runtime.createContext(config, {maxWorkers}),
+      );
+
+      const input = ['/foo/bar/prefix-suffix/__tests__/my-test.test.js'];
+      const data = searchSource.findTestsByPaths(input);
+      expect(data.tests).toEqual([]);
+    });
   });
 });

--- a/packages/jest-cli/src/search_source.js
+++ b/packages/jest-cli/src/search_source.js
@@ -78,7 +78,7 @@ export default class SearchSource {
     const {config} = context;
     this._context = context;
     this._rootPattern = new RegExp(
-      config.roots.map(dir => escapePathForRegex(dir)).join('|'),
+      config.roots.map(dir => escapePathForRegex(dir + path.sep)).join('|'),
     );
 
     const ignorePattern = config.testPathIgnorePatterns;


### PR DESCRIPTION
When verifying if a test belongs to a particular project, the root of the project is part of the checks we perform (`roots` is checked against the filename via a regular expression). However, the regular expression did not include a trailing slash (either `/` or `\` for Windows), which causes to wrongly recognize tests as part of a pattern. For instance:

* Root A: `/foo/bar/folder`.
* Root B: `/foo/bar/folder-with-something`.

All tests inside B are executed also through config A, since B starts with A. This leads to tests getting executed twice if not crashing. Adding a trailing slash fixes the problem.