### PR TITLE
Allow rootDir option for jest projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@
   not generate additional (invalid) paths by prepending each ancestor of `cwd`
   to the absolute path. Additionally, this fixes functionality in Windows OS.
   ([#5398](https://github.com/facebook/jest/pull/5398))
+* `[jest-config]` Allow users to specify `rootDir` from within project configurations.
+  ([#5479](https://github.com/facebook/jest/pull/5479))
 
 ### Chore & Maintenance
 

--- a/packages/jest-config/src/index.js
+++ b/packages/jest-config/src/index.js
@@ -45,7 +45,7 @@ export function readConfig(
   if (typeof packageRootOrConfig !== 'string') {
     if (parentConfigPath) {
       rawOptions = packageRootOrConfig;
-      rawOptions.rootDir = path.dirname(parentConfigPath);
+      rawOptions.rootDir = rawOptions.rootDir || path.dirname(parentConfigPath);
     } else {
       throw new Error(
         'Jest: Cannot use configuration as an object without a file path.',


### PR DESCRIPTION
## Summary

If jest projects are specified as objects this will currently override the rootDir. This allows users to continue to define their own rootDir, allowing multiple project definitions to run tests in user-defined directories.

## Test plan
Given a jest project configuration as follows, allow the developer to specify their own rootDir.
```
  {
    projects: {
      jsdom: {
        rootDir: process.cwd(),
        displayName: 'browser',
        browser: true,
        testEnvironment: 'jsdom',
      },
      node: {
        rootDir: process.cwd(),
        displayName: 'node',
        browser: false,
        testEnvironment: 'node',
      },
    }
  }
```
