### PR TITLE
Fix Node.js 4 support with Proxy

### DIFF
--- a/packages/jest-util/src/create_process_object.js
+++ b/packages/jest-util/src/create_process_object.js
@@ -17,6 +17,10 @@ const BLACKLIST = new Set(['env', 'mainModule', '_events']);
 // mimic it (see https://nodejs.org/api/process.html#process_process_env).
 
 function createProcessEnv() {
+  if (typeof Proxy === 'undefined') {
+    return deepCyclicCopy(process.env);
+  }
+
   // $FlowFixMe: Apparently Flow does not understand that this is a prototype.
   const proto: Object = Object.getPrototypeOf(process.env);
   const real = Object.create(proto);


### PR DESCRIPTION
## Summary

Because many projects must support Node.js 4 until LTS end (August 2018) we decided for silent support of Node.js. For example, big projects like Autoprefixer and PostCSS must support Node.js 4, so we run tests on Travis CI with Node.js 4.

`Proxy` is used for a small win32 fix. Maybe it could be fixed even without Proxy, but I made a small `if` to be clean.

## Test plan

Since it is silent support of Node.js 4 I didn’t add tests.
