### PR TITLE
Add unique id for each worker and pass it to the child process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## master
 
+### Features
+
+* `[jest-worker]` Assign a unique id for each worker and pass it to the child
+  process. It will be available via `process.env.JEST_WORKER_ID`
+  ([#5494](https://github.com/facebook/jest/pull/5494))
+
 ## jest 22.2.1
 
 ### Fixes

--- a/packages/jest-worker/README.md
+++ b/packages/jest-worker/README.md
@@ -130,6 +130,9 @@ overriding options through `forkOptions`.
 Finishes the workers by killing all workers. No further calls can be done to the
 `Worker` instance.
 
+**Note:** Each worker has a unique id (index that starts with `1`) which is
+available on `process.env.JEST_WORKER_ID`
+
 # More examples
 
 ## Standard usage

--- a/packages/jest-worker/README.md
+++ b/packages/jest-worker/README.md
@@ -146,12 +146,13 @@ import Worker from 'jest-worker';
 
 async function main() {
   const myWorker = new Worker(require.resolve('./worker'), {
-    exposedMethods: ['foo', 'bar'],
+    exposedMethods: ['foo', 'bar', 'getWorkerId'],
     numWorkers: 4,
   });
 
   console.log(await myWorker.foo('Alice')); // "Hello from foo: Alice"
   console.log(await myWorker.bar('Bob')); // "Hello from bar: Bob"
+  console.log(await myWorker.getWorkerId()); // "3" -> this message has sent from the 3rd worker
 
   myWorker.end();
 }
@@ -168,6 +169,10 @@ export function foo(param) {
 
 export function bar(param) {
   return 'Hello from bar: ' + param;
+}
+
+export function getWorkerId() {
+  return process.env.JEST_WORKER_ID;
 }
 ```
 

--- a/packages/jest-worker/src/__tests__/index.test.js
+++ b/packages/jest-worker/src/__tests__/index.test.js
@@ -122,8 +122,24 @@ it('tries instantiating workers with the right options', () => {
   expect(Worker.mock.calls[0][0]).toEqual({
     forkOptions: {execArgv: []},
     maxRetries: 6,
+    workerId: 1,
     workerPath: '/tmp/baz.js',
   });
+});
+
+it('create multiple workers with unique worker ids', () => {
+  // eslint-disable-next-line no-new
+  new Farm('/tmp/baz.js', {
+    exposedMethods: ['foo', 'bar'],
+    forkOptions: {execArgv: []},
+    maxRetries: 6,
+    numWorkers: 3,
+  });
+
+  expect(Worker).toHaveBeenCalledTimes(3);
+  expect(Worker.mock.calls[0][0].workerId).toEqual(1);
+  expect(Worker.mock.calls[1][0].workerId).toEqual(2);
+  expect(Worker.mock.calls[2][0].workerId).toEqual(3);
 });
 
 it('makes a non-existing relative worker throw', () => {

--- a/packages/jest-worker/src/__tests__/worker.test.js
+++ b/packages/jest-worker/src/__tests__/worker.test.js
@@ -57,6 +57,7 @@ it('passes fork options down to child_process.fork, adding the defaults', () => 
       execPath: 'hello',
     },
     maxRetries: 3,
+    workerId: process.env.JEST_WORKER_ID,
     workerPath: '/tmp/foo/bar/baz.js',
   });
 
@@ -68,6 +69,17 @@ it('passes fork options down to child_process.fork, adding the defaults', () => 
     execPath: 'hello', // Added option.
     silent: true, // Default option.
   });
+});
+
+it('passes workerId to the child process and assign it to env.JEST_WORKER_ID', () => {
+  new Worker({
+    forkOptions: {},
+    maxRetries: 3,
+    workerId: 2,
+    workerPath: '/tmp/foo',
+  });
+
+  expect(childProcess.fork.mock.calls[0][1].env.JEST_WORKER_ID).toEqual(2);
 });
 
 it('initializes the child process with the given workerPath', () => {

--- a/packages/jest-worker/src/index.js
+++ b/packages/jest-worker/src/index.js
@@ -66,7 +66,6 @@ export default class {
       workerPath = require.resolve(workerPath);
     }
 
-    // Build the options once for all workers to avoid allocating extra objects.
     const sharedWorkerOptions = {
       forkOptions: options.forkOptions || {},
       maxRetries: options.maxRetries || 3,

--- a/packages/jest-worker/src/index.js
+++ b/packages/jest-worker/src/index.js
@@ -67,13 +67,16 @@ export default class {
     }
 
     // Build the options once for all workers to avoid allocating extra objects.
-    const workerOptions = {
+    const sharedWorkerOptions = {
       forkOptions: options.forkOptions || {},
       maxRetries: options.maxRetries || 3,
       workerPath,
     };
 
     for (let i = 0; i < numWorkers; i++) {
+      const workerOptions = Object.assign({}, sharedWorkerOptions, {
+        workerId: i + 1,
+      });
       const worker = new Worker(workerOptions);
       const workerStdout = worker.getStdout();
       const workerStderr = worker.getStderr();

--- a/packages/jest-worker/src/types.js
+++ b/packages/jest-worker/src/types.js
@@ -47,6 +47,7 @@ export type WorkerOptions = {|
   forkOptions: ForkOptions,
   maxRetries: number,
   workerPath: string,
+  workerId: number,
 |};
 
 // Messages passed from the parent to the children.

--- a/packages/jest-worker/src/types.js
+++ b/packages/jest-worker/src/types.js
@@ -46,8 +46,8 @@ export type FarmOptions = {
 export type WorkerOptions = {|
   forkOptions: ForkOptions,
   maxRetries: number,
-  workerPath: string,
   workerId: number,
+  workerPath: string,
 |};
 
 // Messages passed from the parent to the children.

--- a/packages/jest-worker/src/worker.js
+++ b/packages/jest-worker/src/worker.js
@@ -79,7 +79,9 @@ export default class {
       Object.assign(
         {
           cwd: process.cwd(),
-          env: process.env,
+          env: Object.assign({}, process.env, {
+            JEST_WORKER_ID: this._options.workerId,
+          }),
           // suppress --debug / --inspect flags while preserving others (like --harmony)
           execArgv: process.execArgv.filter(v => !/^--(debug|inspect)/.test(v)),
           silent: true,


### PR DESCRIPTION
This PR is related to issue #2284 

## The Problem
When trying to run integration tests in parallel, there could be a race of conditions.
For example when two tests are trying to modify the same record in a database at the same time.

To get full isolation, the user can choose one of two solutions:
   1. Run the test serially.  -> _slow..._ 😞 
   2. Create a different DB/server for each worker. -> _unlocks the full potential of the machine_ 😉 

But in order to use the second, you need unique identifiers for each worker, so you could assign each test to a different server.

For example:
```js
const port = 3000 + process.env.JEST_WORKER_ID
```

## Summary

Assign a unique id for each worker and pass it to the child process. It will be available via `process.env.JEST_WORKER_ID`.

* The first index would be `1`.
* We store the id as a `number` and it is being cast to `string` only when passed to the newly forked process.
* A test that verifies the `options` that passes to each worker needed to be modified with the new `workerId` option.
* A test that checks that the options have passed to the child uses `process.env`, lucky enough, jest uses itself for testing, so we could use the same `JEST_WORKER_ID` 😄 

## Test plan

1. Test that each individual worker gets its own unique id from the farm.
2. Verify that the worker assigns the `workerId` to the `env.JEST_WORKER_ID`.

## Questions
* should we update the readme with this new feature?