### PR TITLE
Revert "Remove retainLines from babel-jest (#5439)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## master
 
+* `[babel-jest]` Revert "Remove retainLines from babel-jest"
+  ([#5496](https://github.com/facebook/jest/pull/5496))
+
 ## jest 22.2.1
 
 ### Fixes
@@ -34,7 +37,7 @@
 * `[jest-cli]` Hide interactive mode if there are no failed snapshot tests
   ([#5450](https://github.com/facebook/jest/pull/5450))
 * `[babel-jest]` Remove retainLines from babel-jest
-  ([#5326](https://github.com/facebook/jest/pull/5439))
+  ([#5439](https://github.com/facebook/jest/pull/5439))
 * `[jest-cli]` Glob patterns ignore non-`require`-able files (e.g. `README.md`)
   ([#5199](https://github.com/facebook/jest/issues/5199))
 * `[jest-mock]` Add backticks support (\`\`) to `mock` a certain package via the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## master
 
+### Fixes
+
 * `[babel-jest]` Revert "Remove retainLines from babel-jest"
   ([#5496](https://github.com/facebook/jest/pull/5496))
 

--- a/packages/babel-jest/src/index.js
+++ b/packages/babel-jest/src/index.js
@@ -69,6 +69,7 @@ const createTransformer = (options: any) => {
   options = Object.assign({}, options, {
     plugins: (options && options.plugins) || [],
     presets: ((options && options.presets) || []).concat([jestPreset]),
+    retainLines: true,
     sourceMaps: 'inline',
   });
   delete options.cacheDirectory;


### PR DESCRIPTION


<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary
This reverts commit 6635d93fc3813d386af73ff226db0bffd30a753d.

This change unfortunately broke the stacktraces. We need #5177 before we can safely remove it.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan
Since the jest repo has `retainLines` in its own babelrc, there is in practice no change in this repo.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
