### PR TITLE
Ignore order on unordered Immutable.js structures, fixes #4618

### DIFF
--- a/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -2247,6 +2247,294 @@ Difference:
   Comparing two different types of values. Expected <green>array</> but received <red>number</>."
 `;
 
+exports[`.toEqual() {pass: false} expect(Immutable.List [1, 2]).not.toEqual(Immutable.List [1, 2]) 1`] = `
+"<dim>expect(</><red>received</><dim>).not.toEqual(</><green>expected</><dim>)</>
+
+Expected value to not equal:
+  <green>Immutable.List [1, 2]</>
+Received:
+  <red>Immutable.List [1, 2]</>"
+`;
+
+exports[`.toEqual() {pass: false} expect(Immutable.List [1, 2]).toEqual(Immutable.List [2, 1]) 1`] = `
+"<dim>expect(</><red>received</><dim>).toEqual(</><green>expected</><dim>)</>
+
+Expected value to equal:
+  <green>Immutable.List [2, 1]</>
+Received:
+  <red>Immutable.List [1, 2]</>
+
+Difference:
+
+<green>- Expected</>
+<red>+ Received</>
+
+<dim>  Immutable.List [</>
+<red>+   1,</>
+<dim>    2,</>
+<green>-   1,</>
+<dim>  ]</>"
+`;
+
+exports[`.toEqual() {pass: false} expect(Immutable.List [1]).not.toEqual(Immutable.List [1]) 1`] = `
+"<dim>expect(</><red>received</><dim>).not.toEqual(</><green>expected</><dim>)</>
+
+Expected value to not equal:
+  <green>Immutable.List [1]</>
+Received:
+  <red>Immutable.List [1]</>"
+`;
+
+exports[`.toEqual() {pass: false} expect(Immutable.List [1]).toEqual(Immutable.List [2]) 1`] = `
+"<dim>expect(</><red>received</><dim>).toEqual(</><green>expected</><dim>)</>
+
+Expected value to equal:
+  <green>Immutable.List [2]</>
+Received:
+  <red>Immutable.List [1]</>
+
+Difference:
+
+<green>- Expected</>
+<red>+ Received</>
+
+<dim>  Immutable.List [</>
+<green>-   2,</>
+<red>+   1,</>
+<dim>  ]</>"
+`;
+
+exports[`.toEqual() {pass: false} expect(Immutable.Map {"1": Immutable.Map {"2": {"a": 99}}}).not.toEqual(Immutable.Map {"1": Immutable.Map {"2": {"a": 99}}}) 1`] = `
+"<dim>expect(</><red>received</><dim>).not.toEqual(</><green>expected</><dim>)</>
+
+Expected value to not equal:
+  <green>Immutable.Map {\\"1\\": Immutable.Map {\\"2\\": {\\"a\\": 99}}}</>
+Received:
+  <red>Immutable.Map {\\"1\\": Immutable.Map {\\"2\\": {\\"a\\": 99}}}</>"
+`;
+
+exports[`.toEqual() {pass: false} expect(Immutable.Map {"1": Immutable.Map {"2": {"a": 99}}}).toEqual(Immutable.Map {"1": Immutable.Map {"2": {"a": 11}}}) 1`] = `
+"<dim>expect(</><red>received</><dim>).toEqual(</><green>expected</><dim>)</>
+
+Expected value to equal:
+  <green>Immutable.Map {\\"1\\": Immutable.Map {\\"2\\": {\\"a\\": 11}}}</>
+Received:
+  <red>Immutable.Map {\\"1\\": Immutable.Map {\\"2\\": {\\"a\\": 99}}}</>
+
+Difference:
+
+<green>- Expected</>
+<red>+ Received</>
+
+<dim>  Immutable.Map {</>
+<dim>    \\"1\\": Immutable.Map {</>
+<dim>      \\"2\\": Object {</>
+<green>-       \\"a\\": 11,</>
+<red>+       \\"a\\": 99,</>
+<dim>      },</>
+<dim>    },</>
+<dim>  }</>"
+`;
+
+exports[`.toEqual() {pass: false} expect(Immutable.Map {"a": 0}).toEqual(Immutable.Map {"b": 0}) 1`] = `
+"<dim>expect(</><red>received</><dim>).toEqual(</><green>expected</><dim>)</>
+
+Expected value to equal:
+  <green>Immutable.Map {\\"b\\": 0}</>
+Received:
+  <red>Immutable.Map {\\"a\\": 0}</>
+
+Difference:
+
+<green>- Expected</>
+<red>+ Received</>
+
+<dim>  Immutable.Map {</>
+<green>-   \\"b\\": 0,</>
+<red>+   \\"a\\": 0,</>
+<dim>  }</>"
+`;
+
+exports[`.toEqual() {pass: false} expect(Immutable.Map {"v": 1}).toEqual(Immutable.Map {"v": 2}) 1`] = `
+"<dim>expect(</><red>received</><dim>).toEqual(</><green>expected</><dim>)</>
+
+Expected value to equal:
+  <green>Immutable.Map {\\"v\\": 2}</>
+Received:
+  <red>Immutable.Map {\\"v\\": 1}</>
+
+Difference:
+
+<green>- Expected</>
+<red>+ Received</>
+
+<dim>  Immutable.Map {</>
+<green>-   \\"v\\": 2,</>
+<red>+   \\"v\\": 1,</>
+<dim>  }</>"
+`;
+
+exports[`.toEqual() {pass: false} expect(Immutable.Map {}).not.toEqual(Immutable.Map {}) 1`] = `
+"<dim>expect(</><red>received</><dim>).not.toEqual(</><green>expected</><dim>)</>
+
+Expected value to not equal:
+  <green>Immutable.Map {}</>
+Received:
+  <red>Immutable.Map {}</>"
+`;
+
+exports[`.toEqual() {pass: false} expect(Immutable.Map {1: "one", 2: "two"}).not.toEqual(Immutable.Map {1: "one", 2: "two"}) 1`] = `
+"<dim>expect(</><red>received</><dim>).not.toEqual(</><green>expected</><dim>)</>
+
+Expected value to not equal:
+  <green>Immutable.Map {1: \\"one\\", 2: \\"two\\"}</>
+Received:
+  <red>Immutable.Map {1: \\"one\\", 2: \\"two\\"}</>"
+`;
+
+exports[`.toEqual() {pass: false} expect(Immutable.Map {1: "one", 2: "two"}).not.toEqual(Immutable.Map {2: "two", 1: "one"}) 1`] = `
+"<dim>expect(</><red>received</><dim>).not.toEqual(</><green>expected</><dim>)</>
+
+Expected value to not equal:
+  <green>Immutable.Map {2: \\"two\\", 1: \\"one\\"}</>
+Received:
+  <red>Immutable.Map {1: \\"one\\", 2: \\"two\\"}</>"
+`;
+
+exports[`.toEqual() {pass: false} expect(Immutable.OrderedMap {1: "one", 2: "two"}).not.toEqual(Immutable.OrderedMap {1: "one", 2: "two"}) 1`] = `
+"<dim>expect(</><red>received</><dim>).not.toEqual(</><green>expected</><dim>)</>
+
+Expected value to not equal:
+  <green>Immutable.OrderedMap {1: \\"one\\", 2: \\"two\\"}</>
+Received:
+  <red>Immutable.OrderedMap {1: \\"one\\", 2: \\"two\\"}</>"
+`;
+
+exports[`.toEqual() {pass: false} expect(Immutable.OrderedMap {1: "one", 2: "two"}).toEqual(Immutable.OrderedMap {2: "two", 1: "one"}) 1`] = `
+"<dim>expect(</><red>received</><dim>).toEqual(</><green>expected</><dim>)</>
+
+Expected value to equal:
+  <green>Immutable.OrderedMap {2: \\"two\\", 1: \\"one\\"}</>
+Received:
+  <red>Immutable.OrderedMap {1: \\"one\\", 2: \\"two\\"}</>
+
+Difference:
+
+<green>- Expected</>
+<red>+ Received</>
+
+<dim>  Immutable.OrderedMap {</>
+<red>+   1: \\"one\\",</>
+<dim>    2: \\"two\\",</>
+<green>-   1: \\"one\\",</>
+<dim>  }</>"
+`;
+
+exports[`.toEqual() {pass: false} expect(Immutable.OrderedSet []).not.toEqual(Immutable.OrderedSet []) 1`] = `
+"<dim>expect(</><red>received</><dim>).not.toEqual(</><green>expected</><dim>)</>
+
+Expected value to not equal:
+  <green>Immutable.OrderedSet []</>
+Received:
+  <red>Immutable.OrderedSet []</>"
+`;
+
+exports[`.toEqual() {pass: false} expect(Immutable.OrderedSet [1, 2]).not.toEqual(Immutable.OrderedSet [1, 2]) 1`] = `
+"<dim>expect(</><red>received</><dim>).not.toEqual(</><green>expected</><dim>)</>
+
+Expected value to not equal:
+  <green>Immutable.OrderedSet [1, 2]</>
+Received:
+  <red>Immutable.OrderedSet [1, 2]</>"
+`;
+
+exports[`.toEqual() {pass: false} expect(Immutable.OrderedSet [1, 2]).toEqual(Immutable.OrderedSet [2, 1]) 1`] = `
+"<dim>expect(</><red>received</><dim>).toEqual(</><green>expected</><dim>)</>
+
+Expected value to equal:
+  <green>Immutable.OrderedSet [2, 1]</>
+Received:
+  <red>Immutable.OrderedSet [1, 2]</>
+
+Difference:
+
+<green>- Expected</>
+<red>+ Received</>
+
+<dim>  Immutable.OrderedSet [</>
+<red>+   1,</>
+<dim>    2,</>
+<green>-   1,</>
+<dim>  ]</>"
+`;
+
+exports[`.toEqual() {pass: false} expect(Immutable.Set []).not.toEqual(Immutable.Set []) 1`] = `
+"<dim>expect(</><red>received</><dim>).not.toEqual(</><green>expected</><dim>)</>
+
+Expected value to not equal:
+  <green>Immutable.Set []</>
+Received:
+  <red>Immutable.Set []</>"
+`;
+
+exports[`.toEqual() {pass: false} expect(Immutable.Set [1, 2]).not.toEqual(Immutable.Set [1, 2]) 1`] = `
+"<dim>expect(</><red>received</><dim>).not.toEqual(</><green>expected</><dim>)</>
+
+Expected value to not equal:
+  <green>Immutable.Set [1, 2]</>
+Received:
+  <red>Immutable.Set [1, 2]</>"
+`;
+
+exports[`.toEqual() {pass: false} expect(Immutable.Set [1, 2]).not.toEqual(Immutable.Set [2, 1]) 1`] = `
+"<dim>expect(</><red>received</><dim>).not.toEqual(</><green>expected</><dim>)</>
+
+Expected value to not equal:
+  <green>Immutable.Set [2, 1]</>
+Received:
+  <red>Immutable.Set [1, 2]</>"
+`;
+
+exports[`.toEqual() {pass: false} expect(Immutable.Set [1, 2]).toEqual(Immutable.Set []) 1`] = `
+"<dim>expect(</><red>received</><dim>).toEqual(</><green>expected</><dim>)</>
+
+Expected value to equal:
+  <green>Immutable.Set []</>
+Received:
+  <red>Immutable.Set [1, 2]</>
+
+Difference:
+
+<green>- Expected</>
+<red>+ Received</>
+
+<green>- Immutable.Set []</>
+<red>+ Immutable.Set [</>
+<red>+   1,</>
+<red>+   2,</>
+<red>+ ]</>"
+`;
+
+exports[`.toEqual() {pass: false} expect(Immutable.Set [1, 2]).toEqual(Immutable.Set [1, 2, 3]) 1`] = `
+"<dim>expect(</><red>received</><dim>).toEqual(</><green>expected</><dim>)</>
+
+Expected value to equal:
+  <green>Immutable.Set [1, 2, 3]</>
+Received:
+  <red>Immutable.Set [1, 2]</>
+
+Difference:
+
+<green>- Expected</>
+<red>+ Received</>
+
+<dim>  Immutable.Set [</>
+<dim>    1,</>
+<dim>    2,</>
+<green>-   3,</>
+<dim>  ]</>"
+`;
+
 exports[`.toEqual() {pass: false} expect(Map {"a" => 0}).toEqual(Map {"b" => 0}) 1`] = `
 "<dim>expect(</><red>received</><dim>).toEqual(</><green>expected</><dim>)</>
 

--- a/packages/expect/src/__tests__/matchers.test.js
+++ b/packages/expect/src/__tests__/matchers.test.js
@@ -8,6 +8,7 @@
 
 const {stringify} = require('jest-matcher-utils');
 const jestExpect = require('../');
+const Immutable = require('immutable');
 
 it('should throw if passed two arguments', () => {
   expect(() => jestExpect('foo', 'bar')).toThrow(
@@ -200,12 +201,31 @@ describe('.toEqual()', () => {
     [null, undefined],
     [[1], [2]],
     [[1, 2], [2, 1]],
+    [Immutable.List([1]), Immutable.List([2])],
+    [Immutable.List([1, 2]), Immutable.List([2, 1])],
     [new Map(), new Set()],
     [new Set([1, 2]), new Set()],
     [new Set([1, 2]), new Set([1, 2, 3])],
+    [Immutable.Set([1, 2]), Immutable.Set()],
+    [Immutable.Set([1, 2]), Immutable.Set([1, 2, 3])],
+    [Immutable.OrderedSet([1, 2]), Immutable.OrderedSet([2, 1])],
     [new Map([[1, 'one'], [2, 'two']]), new Map([[1, 'one']])],
     [new Map([['a', 0]]), new Map([['b', 0]])],
     [new Map([['v', 1]]), new Map([['v', 2]])],
+    [Immutable.Map({a: 0}), Immutable.Map({b: 0})],
+    [Immutable.Map({v: 1}), Immutable.Map({v: 2})],
+    [
+      Immutable.OrderedMap()
+        .set(1, 'one')
+        .set(2, 'two'),
+      Immutable.OrderedMap()
+        .set(2, 'two')
+        .set(1, 'one'),
+    ],
+    [
+      Immutable.Map({1: Immutable.Map({2: {a: 99}})}),
+      Immutable.Map({1: Immutable.Map({2: {a: 11}})}),
+    ],
     [{a: 1, b: 2}, jestExpect.objectContaining({a: 2})],
     [false, jestExpect.objectContaining({a: 2})],
     [[1, 3], jestExpect.arrayContaining([1, 2])],
@@ -236,14 +256,50 @@ describe('.toEqual()', () => {
     ['abc', 'abc'],
     [[1], [1]],
     [[1, 2], [1, 2]],
+    [Immutable.List([1]), Immutable.List([1])],
+    [Immutable.List([1, 2]), Immutable.List([1, 2])],
     [{}, {}],
     [{a: 99}, {a: 99}],
     [new Set(), new Set()],
     [new Set([1, 2]), new Set([1, 2])],
     [new Set([1, 2]), new Set([2, 1])],
+    [Immutable.Set(), Immutable.Set()],
+    [Immutable.Set([1, 2]), Immutable.Set([1, 2])],
+    [Immutable.Set([1, 2]), Immutable.Set([2, 1])],
+    [Immutable.OrderedSet(), Immutable.OrderedSet()],
+    [Immutable.OrderedSet([1, 2]), Immutable.OrderedSet([1, 2])],
     [new Map(), new Map()],
     [new Map([[1, 'one'], [2, 'two']]), new Map([[1, 'one'], [2, 'two']])],
     [new Map([[1, 'one'], [2, 'two']]), new Map([[2, 'two'], [1, 'one']])],
+    [Immutable.Map(), Immutable.Map()],
+    [
+      Immutable.Map()
+        .set(1, 'one')
+        .set(2, 'two'),
+      Immutable.Map()
+        .set(1, 'one')
+        .set(2, 'two'),
+    ],
+    [
+      Immutable.Map()
+        .set(1, 'one')
+        .set(2, 'two'),
+      Immutable.Map()
+        .set(2, 'two')
+        .set(1, 'one'),
+    ],
+    [
+      Immutable.OrderedMap()
+        .set(1, 'one')
+        .set(2, 'two'),
+      Immutable.OrderedMap()
+        .set(1, 'one')
+        .set(2, 'two'),
+    ],
+    [
+      Immutable.Map({1: Immutable.Map({2: {a: 99}})}),
+      Immutable.Map({1: Immutable.Map({2: {a: 99}})}),
+    ],
     [{a: 1, b: 2}, jestExpect.objectContaining({a: 1})],
     [[1, 2, 3], jestExpect.arrayContaining([2, 3])],
     ['abcd', jestExpect.stringContaining('bc')],

--- a/packages/expect/src/jasmine_utils.js
+++ b/packages/expect/src/jasmine_utils.js
@@ -275,3 +275,24 @@ export function hasProperty(obj: Object | null, property: string) {
 
   return hasProperty(getPrototype(obj), property);
 }
+
+// SENTINEL constants are from https://github.com/facebook/immutable-js
+const IS_KEYED_SENTINEL = '@@__IMMUTABLE_KEYED__@@';
+const IS_SET_SENTINEL = '@@__IMMUTABLE_SET__@@';
+const IS_ORDERED_SENTINEL = '@@__IMMUTABLE_ORDERED__@@';
+
+export function isImmutableUnorderedKeyed(maybeKeyed: any) {
+  return !!(
+    maybeKeyed &&
+    maybeKeyed[IS_KEYED_SENTINEL] &&
+    !maybeKeyed[IS_ORDERED_SENTINEL]
+  );
+}
+
+export function isImmutableUnorderedSet(maybeSet: any) {
+  return !!(
+    maybeSet &&
+    maybeSet[IS_SET_SENTINEL] &&
+    !maybeSet[IS_ORDERED_SENTINEL]
+  );
+}

--- a/packages/expect/src/utils.js
+++ b/packages/expect/src/utils.js
@@ -7,7 +7,12 @@
  * @flow
  */
 
-import {equals, isA} from './jasmine_utils';
+import {
+  equals,
+  isA,
+  isImmutableUnorderedKeyed,
+  isImmutableUnorderedSet,
+} from './jasmine_utils';
 
 type GetPath = {
   hasEndProp?: boolean,
@@ -119,7 +124,7 @@ export const iterableEquality = (a: any, b: any) => {
   if (a.size !== undefined) {
     if (a.size !== b.size) {
       return false;
-    } else if (isA('Set', a)) {
+    } else if (isA('Set', a) || isImmutableUnorderedSet(a)) {
       let allFound = true;
       for (const aValue of a) {
         if (!b.has(aValue)) {
@@ -130,7 +135,7 @@ export const iterableEquality = (a: any, b: any) => {
       if (allFound) {
         return true;
       }
-    } else if (isA('Map', a)) {
+    } else if (isA('Map', a) || isImmutableUnorderedKeyed(a)) {
       let allFound = true;
       for (const aEntry of a) {
         if (


### PR DESCRIPTION
## Summary
Immutable.js structures, that do not maintain order, should be equal regardless of the insertion order. This follows how native `Set` and `Map` are compared.

As `toEqual` should provide deep equality, `Immutable.is` (or `.equals` on a structure) cannot be used.

Sentinels are used for identifying the structures, as we do [in pretty-format](https://github.com/facebook/jest/blob/master/packages/pretty-format/src/plugins/immutable.js#L14).

Fixes #4618 (includes additional info and reasons)

## Test plan
Added most used Immutable.js structures to unit tests: `List`, `Map`, `OrdereMap`, `Set`, `OrderedSet`.
