### PR TITLE
feat(jest-docblock): support multiple of the same @pragma

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * `[babel-jest]` Revert "Remove retainLines from babel-jest"
   ([#5496](https://github.com/facebook/jest/pull/5496))
+* `[jest-docblock]` Support multiple of the same `@pragma`.
+  ([#5154](https://github.com/facebook/jest/pull/5502))
 
 ### Features
 

--- a/packages/jest-docblock/README.md
+++ b/packages/jest-docblock/README.md
@@ -99,17 +99,17 @@ string (`""`).
 Strips the top docblock from a file and return the result. If a file does not
 have a docblock at the top, then return the file unchanged.
 
-### `parse(docblock: string): {[key: string]: string}`
+### `parse(docblock: string): {[key: string]: string | string[] }`
 
 Parses the pragmas in a docblock string into an object whose keys are the pragma
 tags and whose values are the arguments to those pragmas.
 
-### `parseWithComments(docblock: string): { comments: string, pragmas: {[key: string]: string} }`
+### `parseWithComments(docblock: string): { comments: string, pragmas: {[key: string]: string | string[]} }`
 
 Similar to `parse` except this method also returns the comments from the
 docblock. Useful when used with `print()`.
 
-### `print({ comments?: string, pragmas?: {[key: string]: string} }): string`
+### `print({ comments?: string, pragmas?: {[key: string]: string | string[]} }): string`
 
 Prints an object of key-value pairs back into a docblock. If `comments` are
 provided, they will be positioned on the top of the docblock.

--- a/packages/jest-docblock/src/__tests__/index.test.js
+++ b/packages/jest-docblock/src/__tests__/index.test.js
@@ -119,6 +119,27 @@ describe('docblock', () => {
     });
   });
 
+  it('parses multiple of the same directives out of a docblock', () => {
+    const code =
+      '/**' +
+      os.EOL +
+      '' +
+      ' * @x foo' +
+      os.EOL +
+      '' +
+      ' * @x bar' +
+      os.EOL +
+      '' +
+      ' * @y' +
+      os.EOL +
+      '' +
+      ' */';
+    expect(docblock.parse(code)).toEqual({
+      x: ['foo', 'bar'],
+      y: '',
+    });
+  });
+
   it('parses directives out of a docblock with comments', () => {
     const code =
       '/**' +
@@ -392,6 +413,24 @@ describe('docblock', () => {
     };
     expect(docblock.print({pragmas})).toEqual(
       '/**' + os.EOL + ' * @flow' + os.EOL + ' * @format' + os.EOL + ' */',
+    );
+  });
+
+  it('prints docblocks with multiple of the same pragma', () => {
+    const pragmas = {
+      x: ['a', 'b'],
+      y: 'c',
+    };
+    expect(docblock.print({pragmas})).toEqual(
+      '/**' +
+        os.EOL +
+        ' * @x a' +
+        os.EOL +
+        ' * @x b' +
+        os.EOL +
+        ' * @y c' +
+        os.EOL +
+        ' */',
     );
   });
 

--- a/packages/jest-docblock/src/__tests__/index.test.js
+++ b/packages/jest-docblock/src/__tests__/index.test.js
@@ -140,6 +140,26 @@ describe('docblock', () => {
     });
   });
 
+  it('parses >=3 of the same directives out of a docblock', () => {
+    const code =
+      '/**' +
+      os.EOL +
+      '' +
+      ' * @x foo' +
+      os.EOL +
+      '' +
+      ' * @x bar' +
+      os.EOL +
+      '' +
+      ' * @x baz' +
+      os.EOL +
+      '' +
+      ' */';
+    expect(docblock.parse(code)).toEqual({
+      x: ['foo', 'bar', 'baz'],
+    });
+  });
+
   it('parses directives out of a docblock with comments', () => {
     const code =
       '/**' +
@@ -433,7 +453,6 @@ describe('docblock', () => {
         ' */',
     );
   });
-
   it('prints docblocks with pragmas', () => {
     const pragmas = {
       flow: 'foo',

--- a/packages/jest-docblock/src/index.js
+++ b/packages/jest-docblock/src/index.js
@@ -10,6 +10,8 @@
 import detectNewline from 'detect-newline';
 import {EOL} from 'os';
 
+type Pragmas = {[key: string]: string | string[], __proto__: null};
+
 const commentEndRe = /\*\/$/;
 const commentStartRe = /^\/\*\*/;
 const docblockRe = /^\s*(\/\*\*?(.|\r?\n)*?\*\/)/;
@@ -31,15 +33,13 @@ export function strip(contents: string) {
   return match && match[0] ? contents.substring(match[0].length) : contents;
 }
 
-export function parse(
-  docblock: string,
-): {[key: string]: string, __proto__: null} {
+export function parse(docblock: string): Pragmas {
   return parseWithComments(docblock).pragmas;
 }
 
 export function parseWithComments(
   docblock: string,
-): {comments: string, pragmas: {[key: string]: string, __proto__: null}} {
+): {comments: string, pragmas: Pragmas} {
   const line = detectNewline(docblock) || EOL;
 
   docblock = docblock
@@ -82,7 +82,7 @@ export function print({
   pragmas = {},
 }: {
   comments?: string,
-  pragmas?: {[key: string]: string, __proto__: null},
+  pragmas?: Pragmas,
   __proto__: null,
 }): string {
   const line = detectNewline(comments) || EOL;
@@ -103,7 +103,8 @@ export function print({
       return '';
     }
     if (keys.length === 1 && !Array.isArray(pragmas[keys[0]])) {
-      return `${head} ${printKeyValues(keys[0], pragmas[keys[0]])}${tail}`;
+      const value = pragmas[keys[0]];
+      return `${head} ${printKeyValues(keys[0], value)[0]}${tail}`;
     }
   }
 

--- a/packages/jest-haste-map/src/worker.js
+++ b/packages/jest-haste-map/src/worker.js
@@ -37,7 +37,7 @@ export async function worker(data: WorkerMessage): Promise<WorkerMetadata> {
   const filePath = data.filePath;
   const content = fs.readFileSync(filePath, 'utf8');
   let module;
-  let id;
+  let id: ?string;
   let dependencies;
 
   if (filePath.endsWith(PACKAGE_JSON)) {
@@ -51,7 +51,8 @@ export async function worker(data: WorkerMessage): Promise<WorkerMetadata> {
       id = hasteImpl.getHasteName(filePath);
     } else {
       const doc = docblock.parse(docblock.extract(content));
-      id = doc.providesModule || doc.provides;
+      const idPragmas = [].concat(doc.providesModule || doc.provides);
+      id = idPragmas[0];
     }
     dependencies = extractRequires(content);
     if (id) {


### PR DESCRIPTION

## Summary

Currently, when `jest-docblock` parses:

```js
/**
 * @foo x
 * @foo y
 */
```
we get `{ foo: 'y' }`.

This PR changes it to `{ foo: ['x', 'y'] }` when there are multiple.

The PR also adds support for that in `docblock.print()`.


## Test plan

Unit tests added and passing.

cc @vjeux 