### PR TITLE
Make it possible to merge `transform` option with preset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * `[jest-runtime]` Align handling of testRegex on Windows between searching for
   tests and instrumentation checks
   ([#5560](https://github.com/facebook/jest/pull/5560))
+* `[jest-config]` Make it possible to merge `transform` option with preset ([#5505](https://github.com/facebook/jest/pull/5505))
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,15 @@
 
 ### Fixes
 
-* `[jest-cli]` Don't skip matchers for exact files ([#5582](https://github.com/facebook/jest/pull/5582))
-* `[docs]` Update discord links ([#5586](https://github.com/facebook/jest/pull/5586))
+* `[jest-cli]` Don't skip matchers for exact files
+  ([#5582](https://github.com/facebook/jest/pull/5582))
+* `[docs]` Update discord links
+  ([#5586](https://github.com/facebook/jest/pull/5586))
 * `[jest-runtime]` Align handling of testRegex on Windows between searching for
   tests and instrumentation checks
   ([#5560](https://github.com/facebook/jest/pull/5560))
-* `[jest-config]` Make it possible to merge `transform` option with preset ([#5505](https://github.com/facebook/jest/pull/5505))
+* `[jest-config]` Make it possible to merge `transform` option with preset
+  ([#5505](https://github.com/facebook/jest/pull/5505))
 
 ### Features
 

--- a/packages/jest-config/src/__tests__/normalize.test.js
+++ b/packages/jest-config/src/__tests__/normalize.test.js
@@ -875,7 +875,7 @@ describe('preset', () => {
       }
       return '/node_modules/' + name;
     });
-    jest.mock(
+    jest.doMock(
       '/node_modules/react-native/jest-preset.json',
       () => ({
         moduleNameMapper: {b: 'b'},
@@ -888,7 +888,7 @@ describe('preset', () => {
   });
 
   afterEach(() => {
-    jest.unmock('/node_modules/react-native/jest-preset.json');
+    jest.dontMock('/node_modules/react-native/jest-preset.json');
   });
 
   test('throws when preset not found', () => {
@@ -904,7 +904,7 @@ describe('preset', () => {
   });
 
   test('throws when preset is invalid', () => {
-    jest.mock('/node_modules/react-native/jest-preset.json', () =>
+    jest.doMock('/node_modules/react-native/jest-preset.json', () =>
       require.requireActual('./jest-preset.json'),
     );
 
@@ -983,14 +983,14 @@ describe('preset', () => {
   });
 
   test('merges with options and transform preset is overridden by options', () => {
-    // Object initializer not used for properties as a workaround for
-    //  sort-keys eslint rule while specifying properties in
-    //  non-alphabetical order for a better test
-    const transform = {};
-    transform.e = 'ee';
-    transform.b = 'bb';
-    transform.c = 'cc';
-    transform.a = 'aa';
+    /* eslint-disable sort-keys */
+    const transform = {
+      e: 'ee',
+      b: 'bb',
+      c: 'cc',
+      a: 'aa',
+    };
+    /* eslint-disable sort-keys */
     const {options} = normalize(
       {
         preset: 'react-native',
@@ -1019,7 +1019,7 @@ describe('preset without setupFiles', () => {
   });
 
   beforeAll(() => {
-    jest.mock(
+    jest.doMock(
       '/node_modules/react-foo/jest-preset.json',
       () => {
         return {
@@ -1029,6 +1029,10 @@ describe('preset without setupFiles', () => {
       },
       {virtual: true},
     );
+  });
+
+  afterAll(() => {
+    jest.dontMock('/node_modules/react-foo/jest-preset.json');
   });
 
   it('should normalize setupFiles correctly', () => {

--- a/packages/jest-config/src/__tests__/normalize.test.js
+++ b/packages/jest-config/src/__tests__/normalize.test.js
@@ -881,6 +881,7 @@ describe('preset', () => {
         moduleNameMapper: {b: 'b'},
         modulePathIgnorePatterns: ['b'],
         setupFiles: ['b'],
+        transform: {b: 'b'},
       }),
       {virtual: true},
     );
@@ -938,6 +939,7 @@ describe('preset', () => {
         preset: 'react-native',
         rootDir: '/root/path/foo',
         setupFiles: ['a'],
+        transform: {a: 'a'},
       },
       {},
     );
@@ -947,7 +949,10 @@ describe('preset', () => {
     expect(options.setupFiles.sort()).toEqual([
       '/node_modules/a',
       '/node_modules/b',
-      '/node_modules/regenerator-runtime/runtime',
+    ]);
+    expect(options.transform).toEqual([
+      ['a', '/node_modules/a'],
+      ['b', '/node_modules/b'],
     ]);
   });
 
@@ -976,6 +981,32 @@ describe('preset', () => {
       ['a', 'aa'],
     ]);
   });
+
+  test('merges with options and transform preset is overridden by options', () => {
+    // Object initializer not used for properties as a workaround for
+    //  sort-keys eslint rule while specifying properties in
+    //  non-alphabetical order for a better test
+    const transform = {};
+    transform.e = 'ee';
+    transform.b = 'bb';
+    transform.c = 'cc';
+    transform.a = 'aa';
+    const {options} = normalize(
+      {
+        preset: 'react-native',
+        rootDir: '/root/path/foo',
+        transform,
+      },
+      {},
+    );
+
+    expect(options.transform).toEqual([
+      ['e', '/node_modules/ee'],
+      ['b', '/node_modules/bb'],
+      ['c', '/node_modules/cc'],
+      ['a', '/node_modules/aa'],
+    ]);
+  });
 });
 
 describe('preset without setupFiles', () => {
@@ -989,7 +1020,7 @@ describe('preset without setupFiles', () => {
 
   beforeAll(() => {
     jest.mock(
-      '/node_modules/react-native/jest-preset.json',
+      '/node_modules/react-foo/jest-preset.json',
       () => {
         return {
           moduleNameMapper: {b: 'b'},
@@ -1003,7 +1034,7 @@ describe('preset without setupFiles', () => {
   it('should normalize setupFiles correctly', () => {
     const {options} = normalize(
       {
-        preset: 'react-native',
+        preset: 'react-foo',
         rootDir: '/root/path/foo',
         setupFiles: ['a'],
       },
@@ -1012,7 +1043,10 @@ describe('preset without setupFiles', () => {
 
     expect(options).toEqual(
       expect.objectContaining({
-        setupFiles: expect.arrayContaining(['/node_modules/a']),
+        setupFiles: [
+          '/node_modules/regenerator-runtime/runtime',
+          '/node_modules/a',
+        ],
       }),
     );
   });

--- a/packages/jest-config/src/normalize.js
+++ b/packages/jest-config/src/normalize.js
@@ -46,6 +46,21 @@ const PRESET_NAME = 'jest-preset' + JSON_EXTENSION;
 const createConfigError = message =>
   new ValidationError(ERROR, message, DOCUMENTATION_NOTE);
 
+const mergeOptionWithPreset = (
+  options: InitialOptions,
+  preset: InitialOptions,
+  optionName: string,
+) => {
+  if (options[optionName] && preset[optionName]) {
+    options[optionName] = Object.assign(
+      {},
+      options[optionName],
+      preset[optionName],
+      options[optionName],
+    );
+  }
+};
+
 const setupPreset = (
   options: InitialOptions,
   optionsPreset: string,
@@ -81,14 +96,8 @@ const setupPreset = (
       options.modulePathIgnorePatterns,
     );
   }
-  if (options.moduleNameMapper && preset.moduleNameMapper) {
-    options.moduleNameMapper = Object.assign(
-      {},
-      options.moduleNameMapper,
-      preset.moduleNameMapper,
-      options.moduleNameMapper,
-    );
-  }
+  mergeOptionWithPreset(options, preset, 'moduleNameMapper');
+  mergeOptionWithPreset(options, preset, 'transform');
 
   return Object.assign({}, preset, options);
 };


### PR DESCRIPTION
## Summary

I discovered that `transform` option set in Jest preset is completely overridden when the same option is provided in the Jest config that extends such preset. I run into this issue when working on the preset for WordPress core: https://github.com/WordPress/gutenberg/pull/4705. It turned out that behavior differs from another option that uses `object` as data representations: `moduleNameMapper`. This PR tries to introduce consistency in the code and allow to merge values from `transform` option set in both config and preset.

### Example

`@wordpress/jest-preset-default`:
```json
{
  "transform": {
    "^.+\\.jsx?$": "babel-jest",
    "\\.pegjs$": "<rootDir>/node_modules/@wordpress/jest-preset-default/scripts/pegjs-transform.js
  } 
}
```

`jest.config.js`:
```json
{
  "preset": "@wordpress/jest-preset-default",
  "transform": {
    "\\.pegjs$": "<rootDir>/test/unit/pegjs-transform.js"
  }
}
```

Expected output:
```json
{
  "transform": {
    "^.+\\.jsx?$": "babel-jest",
    "\\.pegjs$": "<rootDir>/test/unit/pegjs-transform.js"
  }
}
```

## Test plan

This change is limited to `jest-config. This is how it was tested:

`yarn test packages/jest-config`