### PR TITLE
jest-haste-map: add test to demonstrate broken behavior for platform-specific files

### DIFF
--- a/packages/jest-haste-map/src/__tests__/index.test.js
+++ b/packages/jest-haste-map/src/__tests__/index.test.js
@@ -555,6 +555,100 @@ describe('HasteMap', () => {
       });
   });
 
+  it('correctly handles platform-specific file additions', async () => {
+    mockFs = Object.create(null);
+    mockFs['/fruits/strawberry.js'] = [
+      '/**',
+      ' * @providesModule Strawberry',
+      ' */',
+      'const Banana = require("Banana");',
+    ].join('\n');
+    let data;
+    ({__hasteMapForTest: data} = await new HasteMap(defaultConfig).build());
+    expect(data.map['Strawberry']).toEqual({
+      g: ['/fruits/strawberry.js', 0],
+    });
+
+    delete mockFs['/fruits/strawberry.ios.js'];
+    mockChangedFiles = object({
+      '/fruits/strawberry.ios.js': [
+        '/**',
+        ' * @providesModule Strawberry',
+        ' */',
+        'const Raspberry = require("Raspberry");',
+      ].join('\n'),
+    });
+    mockClocks = object({'/fruits': 'c:fake-clock:3'});
+    ({__hasteMapForTest: data} = await new HasteMap(defaultConfig).build());
+    expect(data.map['Strawberry']).toEqual({
+      g: ['/fruits/strawberry.js', 0],
+      ios: ['/fruits/strawberry.ios.js', 0],
+    });
+  });
+
+  it('correctly handles platform-specific file deletions (broken)', async () => {
+    mockFs = Object.create(null);
+    mockFs['/fruits/strawberry.js'] = [
+      '/**',
+      ' * @providesModule Strawberry',
+      ' */',
+      'const Banana = require("Banana");',
+    ].join('\n');
+    mockFs['/fruits/strawberry.ios.js'] = [
+      '/**',
+      ' * @providesModule Strawberry',
+      ' */',
+      'const Raspberry = require("Raspberry");',
+    ].join('\n');
+    let data;
+    ({__hasteMapForTest: data} = await new HasteMap(defaultConfig).build());
+    expect(data.map['Strawberry']).toEqual({
+      g: ['/fruits/strawberry.js', 0],
+      ios: ['/fruits/strawberry.ios.js', 0],
+    });
+
+    delete mockFs['/fruits/strawberry.ios.js'];
+    mockChangedFiles = object({'/fruits/strawberry.ios.js': null});
+    mockClocks = object({'/fruits': 'c:fake-clock:3'});
+    ({__hasteMapForTest: data} = await new HasteMap(defaultConfig).build());
+    expect(data.map['Strawberry']).toEqual({
+      g: ['/fruits/strawberry.js', 0],
+      // FIXME: this file should NOT exist anymore!
+      ios: ['/fruits/strawberry.ios.js', 0],
+    });
+  });
+
+  it('correctly handles platform-specific file renames', async () => {
+    mockFs = Object.create(null);
+    mockFs['/fruits/strawberry.ios.js'] = [
+      '/**',
+      ' * @providesModule Strawberry',
+      ' */',
+      'const Raspberry = require("Raspberry");',
+    ].join('\n');
+    let data;
+    ({__hasteMapForTest: data} = await new HasteMap(defaultConfig).build());
+    expect(data.map['Strawberry']).toEqual({
+      ios: ['/fruits/strawberry.ios.js', 0],
+    });
+
+    delete mockFs['/fruits/strawberry.ios.js'];
+    mockChangedFiles = object({
+      '/fruits/strawberry.ios.js': null,
+      '/fruits/strawberry.js': [
+        '/**',
+        ' * @providesModule Strawberry',
+        ' */',
+        'const Banana = require("Banana");',
+      ].join('\n'),
+    });
+    mockClocks = object({'/fruits': 'c:fake-clock:3'});
+    ({__hasteMapForTest: data} = await new HasteMap(defaultConfig).build());
+    expect(data.map['Strawberry']).toEqual({
+      g: ['/fruits/strawberry.js', 0],
+    });
+  });
+
   describe('duplicate modules', () => {
     beforeEach(async () => {
       mockFs['/fruits/another_strawberry.js'] = [


### PR DESCRIPTION
When you have two files `A.js` and `A.ios.js`, removing the second one will not properly update `jest-haste-map` cache. This causes `jest` or dependents to crash, as they try to access a now non-existent path. This changeset adds a test that reproduce the issue, along with complementary tests to verify other variations on the theme are not broken. These tests try to ensure that the follow-up fix will not break the platform-specific files handling in other ways.
