### PR TITLE
add inverse expect asymmetric matchers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
   promises ([#5670](https://github.com/facebook/jest/pull/5670))
 * `[expect]` Add isError to utils
   ([#5670](https://github.com/facebook/jest/pull/5670))
+* `[expect]` Add inverse matchers (`expect.not.arrayContaining`, etc.,
+  [#5517](https://github.com/facebook/jest/pull/5517))
 
 ### Fixes
 

--- a/docs/ExpectAPI.md
+++ b/docs/ExpectAPI.md
@@ -223,14 +223,6 @@ describe('Beware of a misunderstanding! A sequence of dice rolls', () => {
 });
 ```
 
-### `expect.arrayNotContaining(array)`
-
-`expect.arrayNotContaining(array)` matches a received array which contains none of
-the elements in the expected array. That is, the expected array **is not a subset**
-of the received array.
-
-It is the inverse of `expect.arrayContaining`.
-
 ### `expect.assertions(number)`
 
 `expect.assertions(number)` verifies that a certain number of assertions are
@@ -281,6 +273,36 @@ test('prepareState prepares a valid state', () => {
 The `expect.hasAssertions()` call ensures that the `prepareState` callback
 actually gets called.
 
+### `expect.not.arrayContaining(array)`
+
+`expect.not.arrayContaining(array)` matches a received array which contains none of
+the elements in the expected array. That is, the expected array **is not a subset**
+of the received array.
+
+It is the inverse of `expect.arrayContaining`.
+
+### `expect.not.objectContaining(object)`
+
+`expect.not.objectContaining(object)` matches any received object that does not recursively
+match the expected properties. That is, the expected object **is not a subset** of
+the received object. Therefore, it matches a received object which contains
+properties that are **not** in the expected object.
+
+It is the inverse of `expect.objectContaining`.
+
+### `expect.not.stringContaining(string)`
+
+`expect.not.stringContaining(string)` matches any received string that does not contain the
+exact expected string.
+
+It is the inverse of `expect.stringContaining`.
+
+### `expect.not.stringMatching(regexp)`
+
+`expect.not.stringMatching(regexp)` matches any received string that does not match the
+expected regexp.
+
+It is the inverse of `expect.stringMatching`.
 
 ### `expect.objectContaining(object)`
 
@@ -309,26 +331,10 @@ test('onPress gets called with the right thing', () => {
 });
 ```
 
-### `expect.objectNotContaining(object)`
-
-`expect.objectNotContaining(object)` matches any received object that does not recursively
-match the expected properties. That is, the expected object **is not a subset** of
-the received object. Therefore, it matches a received object which contains
-properties that are **not** in the expected object.
-
-It is the inverse of `expect.objectContaining`.
-
 ### `expect.stringContaining(string)`
 
 `expect.stringContaining(string)` matches any received string that contains the
 exact expected string.
-
-### `expect.stringNotContaining(string)`
-
-`expect.stringNotContaining(string)` matches any received string that does not contain the
-exact expected string.
-
-It is the inverse of `expect.stringContaining`.
 
 ### `expect.stringMatching(regexp)`
 
@@ -362,13 +368,6 @@ describe('stringMatching in arrayContaining', () => {
   });
 });
 ```
-
-### `expect.stringNotMatching(regexp)`
-
-`expect.stringNotMatching(regexp)` matches any received string that does not match the
-expected regexp.
-
-It is the inverse of `expect.stringMatching`.
 
 ### `expect.addSnapshotSerializer(serializer)`
 

--- a/docs/ExpectAPI.md
+++ b/docs/ExpectAPI.md
@@ -223,6 +223,14 @@ describe('Beware of a misunderstanding! A sequence of dice rolls', () => {
 });
 ```
 
+### `expect.arrayNotContaining(array)`
+
+`expect.arrayNotContaining(array)` matches a received array which contains none of
+the elements in the expected array. That is, the expected array **is not a subset**
+of the received array.
+
+It is the inverse of `expect.arrayContaining`.
+
 ### `expect.assertions(number)`
 
 `expect.assertions(number)` verifies that a certain number of assertions are
@@ -273,6 +281,7 @@ test('prepareState prepares a valid state', () => {
 The `expect.hasAssertions()` call ensures that the `prepareState` callback
 actually gets called.
 
+
 ### `expect.objectContaining(object)`
 
 `expect.objectContaining(object)` matches any received object that recursively
@@ -300,12 +309,26 @@ test('onPress gets called with the right thing', () => {
 });
 ```
 
-### `expect.stringContaining(string)`
+### `expect.objectNotContaining(object)`
 
-##### available in Jest **19.0.0+**
+`expect.objectNotContaining(object)` matches any received object that does not recursively
+match the expected properties. That is, the expected object **is not a subset** of
+the received object. Therefore, it matches a received object which contains
+properties that are **not** in the expected object.
+
+It is the inverse of `expect.objectContaining`.
+
+### `expect.stringContaining(string)`
 
 `expect.stringContaining(string)` matches any received string that contains the
 exact expected string.
+
+### `expect.stringNotContaining(string)`
+
+`expect.stringNotContaining(string)` matches any received string that does not contain the
+exact expected string.
+
+It is the inverse of `expect.stringContaining`.
 
 ### `expect.stringMatching(regexp)`
 
@@ -339,6 +362,13 @@ describe('stringMatching in arrayContaining', () => {
   });
 });
 ```
+
+### `expect.stringNotMatching(regexp)`
+
+`expect.stringNotMatching(regexp)` matches any received string that does not match the
+expected regexp.
+
+It is the inverse of `expect.stringMatching`.
 
 ### `expect.addSnapshotSerializer(serializer)`
 

--- a/docs/ExpectAPI.md
+++ b/docs/ExpectAPI.md
@@ -275,32 +275,32 @@ actually gets called.
 
 ### `expect.not.arrayContaining(array)`
 
-`expect.not.arrayContaining(array)` matches a received array which contains none of
-the elements in the expected array. That is, the expected array **is not a subset**
-of the received array.
+`expect.not.arrayContaining(array)` matches a received array which contains none
+of the elements in the expected array. That is, the expected array **is not a
+subset** of the received array.
 
 It is the inverse of `expect.arrayContaining`.
 
 ### `expect.not.objectContaining(object)`
 
-`expect.not.objectContaining(object)` matches any received object that does not recursively
-match the expected properties. That is, the expected object **is not a subset** of
-the received object. Therefore, it matches a received object which contains
-properties that are **not** in the expected object.
+`expect.not.objectContaining(object)` matches any received object that does not
+recursively match the expected properties. That is, the expected object **is not
+a subset** of the received object. Therefore, it matches a received object which
+contains properties that are **not** in the expected object.
 
 It is the inverse of `expect.objectContaining`.
 
 ### `expect.not.stringContaining(string)`
 
-`expect.not.stringContaining(string)` matches any received string that does not contain the
-exact expected string.
+`expect.not.stringContaining(string)` matches any received string that does not
+contain the exact expected string.
 
 It is the inverse of `expect.stringContaining`.
 
 ### `expect.not.stringMatching(regexp)`
 
-`expect.not.stringMatching(regexp)` matches any received string that does not match the
-expected regexp.
+`expect.not.stringMatching(regexp)` matches any received string that does not
+match the expected regexp.
 
 It is the inverse of `expect.stringMatching`.
 

--- a/integration-tests/toThrowErrorMatchingSnapshot/__tests__/accept-custom-snapshot-name.test.js
+++ b/integration-tests/toThrowErrorMatchingSnapshot/__tests__/accept-custom-snapshot-name.test.js
@@ -1,5 +1,0 @@
-test('accepts custom snapshot name', () => {
-  expect(() => {
-    throw new Error('apple');
-  }).toThrowErrorMatchingSnapshot('custom-name');
-});

--- a/integration-tests/toThrowErrorMatchingSnapshot/__tests__/accept-custom-snapshot-name.test.js
+++ b/integration-tests/toThrowErrorMatchingSnapshot/__tests__/accept-custom-snapshot-name.test.js
@@ -1,0 +1,5 @@
+test('accepts custom snapshot name', () => {
+  expect(() => {
+    throw new Error('apple');
+  }).toThrowErrorMatchingSnapshot('custom-name');
+});

--- a/packages/expect/src/__tests__/asymmetric_matchers.test.js
+++ b/packages/expect/src/__tests__/asymmetric_matchers.test.js
@@ -13,9 +13,13 @@ const {
   any,
   anything,
   arrayContaining,
+  arrayNotContaining,
   objectContaining,
+  objectNotContaining,
   stringContaining,
+  stringNotContaining,
   stringMatching,
+  stringNotMatching,
 } = require('../asymmetric_matchers');
 
 test('Any.asymmetricMatch()', () => {
@@ -55,15 +59,6 @@ test('Anything matches any type', () => {
   });
 });
 
-test('Anything does not match null and undefined', () => {
-  [
-    anything().asymmetricMatch(null),
-    anything().asymmetricMatch(undefined),
-  ].forEach(test => {
-    jestExpect(test).toBe(false);
-  });
-});
-
 test('Anything.toAsymmetricMatcher()', () => {
   jestExpect(anything().toAsymmetricMatcher()).toBe('Anything');
 });
@@ -86,6 +81,27 @@ test('ArrayContaining does not match', () => {
 test('ArrayContaining throws for non-arrays', () => {
   jestExpect(() => {
     arrayContaining('foo').asymmetricMatch([]);
+  }).toThrow();
+});
+
+test('ArrayNotContaining matches', () => {
+  jestExpect(arrayNotContaining(['foo']).asymmetricMatch(['bar'])).toBe(true);
+});
+
+test('ArrayNotContaining does not match', () => {
+  [
+    arrayNotContaining([]).asymmetricMatch('jest'),
+    arrayNotContaining(['foo']).asymmetricMatch(['foo']),
+    arrayNotContaining(['foo']).asymmetricMatch(['foo', 'bar']),
+    arrayNotContaining([]).asymmetricMatch({}),
+  ].forEach(test => {
+    jestExpect(test).toEqual(false);
+  });
+});
+
+test('ArrayNotContaining throws for non-arrays', () => {
+  jestExpect(() => {
+    arrayNotContaining('foo').asymmetricMatch([]);
   }).toThrow();
 });
 
@@ -139,6 +155,36 @@ test('ObjectContaining throws for non-objects', () => {
   jestExpect(() => objectContaining(1337).asymmetricMatch()).toThrow();
 });
 
+test('ObjectNotContaining matches', () => {
+  [
+    objectNotContaining({}).asymmetricMatch('jest'),
+    objectNotContaining({foo: 'foo'}).asymmetricMatch({bar: 'bar'}),
+    objectNotContaining({foo: 'foo'}).asymmetricMatch({foo: 'foox'}),
+    objectNotContaining({foo: undefined}).asymmetricMatch({}),
+  ].forEach(test => {
+    jestExpect(test).toEqual(true);
+  });
+});
+
+test('ObjectNotContaining does not match', () => {
+  [
+    objectNotContaining({foo: 'foo'}).asymmetricMatch({
+      foo: 'foo',
+      jest: 'jest',
+    }),
+    objectNotContaining({foo: undefined}).asymmetricMatch({foo: undefined}),
+    objectNotContaining({
+      first: objectNotContaining({second: {}}),
+    }).asymmetricMatch({first: {second: {}}}),
+  ].forEach(test => {
+    jestExpect(test).toEqual(false);
+  });
+});
+
+test('ObjectNotContaining throws for non-objects', () => {
+  jestExpect(() => objectNotContaining(1337).asymmetricMatch()).toThrow();
+});
+
 test('StringContaining matches string against string', () => {
   jestExpect(stringContaining('en*').asymmetricMatch('queen*')).toBe(true);
   jestExpect(stringContaining('en').asymmetricMatch('queue')).toBe(false);
@@ -148,6 +194,18 @@ test('StringContaining matches string against string', () => {
 test('StringContaining throws for non-strings', () => {
   jestExpect(() => {
     stringContaining([1]).asymmetricMatch('queen');
+  }).toThrow();
+});
+
+test('StringNotContaining matches string against string', () => {
+  jestExpect(stringNotContaining('en*').asymmetricMatch('queen*')).toBe(false);
+  jestExpect(stringNotContaining('en').asymmetricMatch('queue')).toBe(true);
+  jestExpect(stringNotContaining('en').asymmetricMatch({})).toBe(true);
+});
+
+test('StringNotContaining throws for non-strings', () => {
+  jestExpect(() => {
+    stringNotContaining([1]).asymmetricMatch('queen');
   }).toThrow();
 });
 
@@ -166,5 +224,23 @@ test('StringMatching matches string against string', () => {
 test('StringMatching throws for non-strings and non-regexps', () => {
   jestExpect(() => {
     stringMatching([1]).asymmetricMatch('queen');
+  }).toThrow();
+});
+
+test('StringNotMatching matches string against regexp', () => {
+  jestExpect(stringNotMatching(/en/).asymmetricMatch('queen')).toBe(false);
+  jestExpect(stringNotMatching(/en/).asymmetricMatch('queue')).toBe(true);
+  jestExpect(stringNotMatching(/en/).asymmetricMatch({})).toBe(true);
+});
+
+test('StringNotMatching matches string against string', () => {
+  jestExpect(stringNotMatching('en').asymmetricMatch('queen')).toBe(false);
+  jestExpect(stringNotMatching('en').asymmetricMatch('queue')).toBe(true);
+  jestExpect(stringNotMatching('en').asymmetricMatch({})).toBe(true);
+});
+
+test('StringNotMatching throws for non-strings and non-regexps', () => {
+  jestExpect(() => {
+    stringNotMatching([1]).asymmetricMatch('queen');
   }).toThrow();
 });

--- a/packages/expect/src/__tests__/asymmetric_matchers.test.js
+++ b/packages/expect/src/__tests__/asymmetric_matchers.test.js
@@ -188,37 +188,41 @@ test('ObjectNotContaining throws for non-objects', () => {
 test('StringContaining matches string against string', () => {
   jestExpect(stringContaining('en*').asymmetricMatch('queen*')).toBe(true);
   jestExpect(stringContaining('en').asymmetricMatch('queue')).toBe(false);
-  jestExpect(stringContaining('en').asymmetricMatch({})).toBe(false);
 });
 
 test('StringContaining throws for non-strings', () => {
   jestExpect(() => {
     stringContaining([1]).asymmetricMatch('queen');
   }).toThrow();
+
+  jestExpect(() => {
+    stringContaining('en*').asymmetricMatch(1);
+  }).toThrow();
 });
 
 test('StringNotContaining matches string against string', () => {
   jestExpect(stringNotContaining('en*').asymmetricMatch('queen*')).toBe(false);
   jestExpect(stringNotContaining('en').asymmetricMatch('queue')).toBe(true);
-  jestExpect(stringNotContaining('en').asymmetricMatch({})).toBe(true);
 });
 
 test('StringNotContaining throws for non-strings', () => {
   jestExpect(() => {
     stringNotContaining([1]).asymmetricMatch('queen');
   }).toThrow();
+
+  jestExpect(() => {
+    stringNotContaining('en*').asymmetricMatch(1);
+  }).toThrow();
 });
 
 test('StringMatching matches string against regexp', () => {
   jestExpect(stringMatching(/en/).asymmetricMatch('queen')).toBe(true);
   jestExpect(stringMatching(/en/).asymmetricMatch('queue')).toBe(false);
-  jestExpect(stringMatching(/en/).asymmetricMatch({})).toBe(false);
 });
 
 test('StringMatching matches string against string', () => {
   jestExpect(stringMatching('en').asymmetricMatch('queen')).toBe(true);
   jestExpect(stringMatching('en').asymmetricMatch('queue')).toBe(false);
-  jestExpect(stringMatching('en').asymmetricMatch({})).toBe(false);
 });
 
 test('StringMatching throws for non-strings and non-regexps', () => {
@@ -227,20 +231,30 @@ test('StringMatching throws for non-strings and non-regexps', () => {
   }).toThrow();
 });
 
+test('StringMatching throws for non-string actual values', () => {
+  jestExpect(() => {
+    stringMatching('en').asymmetricMatch(1);
+  }).toThrow();
+});
+
 test('StringNotMatching matches string against regexp', () => {
   jestExpect(stringNotMatching(/en/).asymmetricMatch('queen')).toBe(false);
   jestExpect(stringNotMatching(/en/).asymmetricMatch('queue')).toBe(true);
-  jestExpect(stringNotMatching(/en/).asymmetricMatch({})).toBe(true);
 });
 
 test('StringNotMatching matches string against string', () => {
   jestExpect(stringNotMatching('en').asymmetricMatch('queen')).toBe(false);
   jestExpect(stringNotMatching('en').asymmetricMatch('queue')).toBe(true);
-  jestExpect(stringNotMatching('en').asymmetricMatch({})).toBe(true);
 });
 
 test('StringNotMatching throws for non-strings and non-regexps', () => {
   jestExpect(() => {
     stringNotMatching([1]).asymmetricMatch('queen');
+  }).toThrow();
+});
+
+test('StringNotMatching throws for non-string actual values', () => {
+  jestExpect(() => {
+    stringNotMatching('en').asymmetricMatch(1);
   }).toThrow();
 });

--- a/packages/expect/src/__tests__/asymmetric_matchers.test.js
+++ b/packages/expect/src/__tests__/asymmetric_matchers.test.js
@@ -59,6 +59,15 @@ test('Anything matches any type', () => {
   });
 });
 
+test('Anything does not match null and undefined', () => {
+  [
+    anything().asymmetricMatch(null),
+    anything().asymmetricMatch(undefined),
+  ].forEach(test => {
+    jestExpect(test).toBe(false);
+  });
+});
+
 test('Anything.toAsymmetricMatcher()', () => {
   jestExpect(anything().toAsymmetricMatcher()).toBe('Anything');
 });

--- a/packages/expect/src/__tests__/utils.test.js
+++ b/packages/expect/src/__tests__/utils.test.js
@@ -9,7 +9,7 @@
 'use strict';
 
 const {stringify} = require('jest-matcher-utils');
-const {getObjectSubset, getPath} = require('../utils');
+const {emptyObject, getObjectSubset, getPath} = require('../utils');
 
 describe('getPath()', () => {
   test('property exists', () => {
@@ -105,5 +105,20 @@ describe('getObjectSubset()', () => {
         expect(getObjectSubset(object, subset)).toEqual(expected);
       },
     );
+  });
+});
+
+describe('emptyObject()', () => {
+  test('matches an empty object', () => {
+    expect(emptyObject({})).toBe(true);
+  });
+
+  test('does not match an object with keys', () => {
+    expect(emptyObject({foo: undefined})).toBe(false);
+  });
+
+  test('does not match a non-object', () => {
+    expect(emptyObject(null)).toBe(false);
+    expect(emptyObject(34)).toBe(false);
   });
 });

--- a/packages/expect/src/asymmetric_matchers.js
+++ b/packages/expect/src/asymmetric_matchers.js
@@ -15,6 +15,8 @@ import {
   isUndefined,
 } from './jasmine_utils';
 
+import {emptyObject} from './utils';
+
 class AsymmetricMatcher {
   $$typeof: Symbol;
 
@@ -121,7 +123,7 @@ class ArrayContaining extends AsymmetricMatcher {
   asymmetricMatch(other: Array<any>) {
     if (!Array.isArray(this.sample)) {
       throw new Error(
-        "You must provide an array to ArrayContaining, not '" +
+        `You must provide an array to ${this.toString()}, not '` +
           typeof this.sample +
           "'.",
       );
@@ -143,6 +145,16 @@ class ArrayContaining extends AsymmetricMatcher {
   }
 }
 
+class ArrayNotContaining extends ArrayContaining {
+  asymmetricMatch(other: Array<any>) {
+    return !super.asymmetricMatch(other);
+  }
+
+  toString() {
+    return 'ArrayNotContaining';
+  }
+}
+
 class ObjectContaining extends AsymmetricMatcher {
   sample: Object;
 
@@ -154,7 +166,7 @@ class ObjectContaining extends AsymmetricMatcher {
   asymmetricMatch(other: Object) {
     if (typeof this.sample !== 'object') {
       throw new Error(
-        "You must provide an object to ObjectContaining, not '" +
+        `You must provide an object to ${this.toString()}, not '` +
           typeof this.sample +
           "'.",
       );
@@ -178,6 +190,35 @@ class ObjectContaining extends AsymmetricMatcher {
 
   getExpectedType() {
     return 'object';
+  }
+}
+
+class ObjectNotContaining extends ObjectContaining {
+  asymmetricMatch(other: Object) {
+    if (typeof this.sample !== 'object') {
+      throw new Error(
+        `You must provide an object to ${this.toString()}, not '` +
+          typeof this.sample +
+          "'.",
+      );
+    }
+
+    for (const property in this.sample) {
+      if (
+        hasProperty(other, property) &&
+        equals(this.sample[property], other[property]) &&
+        !emptyObject(this.sample[property]) &&
+        !emptyObject(other[property])
+      ) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  toString() {
+    return 'ObjectNotContaining';
   }
 }
 
@@ -206,6 +247,16 @@ class StringContaining extends AsymmetricMatcher {
 
   getExpectedType() {
     return 'string';
+  }
+}
+
+class StringNotContaining extends StringContaining {
+  asymmetricMatch(other: string) {
+    return !super.asymmetricMatch(other);
+  }
+
+  toString() {
+    return 'StringNotContaining';
   }
 }
 
@@ -238,13 +289,27 @@ class StringMatching extends AsymmetricMatcher {
   }
 }
 
+class StringNotMatching extends StringMatching {
+  asymmetricMatch(other: string) {
+    return !super.asymmetricMatch(other);
+  }
+}
+
 export const any = (expectedObject: any) => new Any(expectedObject);
 export const anything = () => new Anything();
 export const arrayContaining = (sample: Array<any>) =>
   new ArrayContaining(sample);
+export const arrayNotContaining = (sample: Array<any>) =>
+  new ArrayNotContaining(sample);
 export const objectContaining = (sample: Object) =>
   new ObjectContaining(sample);
+export const objectNotContaining = (sample: Object) =>
+  new ObjectNotContaining(sample);
 export const stringContaining = (expected: string) =>
   new StringContaining(expected);
+export const stringNotContaining = (expected: string) =>
+  new StringNotContaining(expected);
 export const stringMatching = (expected: string | RegExp) =>
   new StringMatching(expected);
+export const stringNotMatching = (expected: string | RegExp) =>
+  new StringNotMatching(expected);

--- a/packages/expect/src/index.js
+++ b/packages/expect/src/index.js
@@ -29,9 +29,13 @@ import {
   any,
   anything,
   arrayContaining,
+  arrayNotContaining,
   objectContaining,
+  objectNotContaining,
   stringContaining,
+  stringNotContaining,
   stringMatching,
+  stringNotMatching,
 } from './asymmetric_matchers';
 import {
   INTERNAL_MATCHER_FLAG,
@@ -259,9 +263,13 @@ expect.extend = (matchers: MatchersObject): void =>
 expect.anything = anything;
 expect.any = any;
 expect.objectContaining = objectContaining;
+expect.objectNotContaining = objectNotContaining;
 expect.arrayContaining = arrayContaining;
+expect.arrayNotContaining = arrayNotContaining;
 expect.stringContaining = stringContaining;
+expect.stringNotContaining = stringNotContaining;
 expect.stringMatching = stringMatching;
+expect.stringNotMatching = stringNotMatching;
 
 const _validateResult = result => {
   if (

--- a/packages/expect/src/index.js
+++ b/packages/expect/src/index.js
@@ -262,14 +262,18 @@ expect.extend = (matchers: MatchersObject): void =>
 
 expect.anything = anything;
 expect.any = any;
+
+expect.not = {
+  arrayContaining: arrayNotContaining,
+  objectContaining: objectNotContaining,
+  stringContaining: stringNotContaining,
+  stringMatching: stringNotMatching,
+};
+
 expect.objectContaining = objectContaining;
-expect.objectNotContaining = objectNotContaining;
 expect.arrayContaining = arrayContaining;
-expect.arrayNotContaining = arrayNotContaining;
 expect.stringContaining = stringContaining;
-expect.stringNotContaining = stringNotContaining;
 expect.stringMatching = stringMatching;
-expect.stringNotMatching = stringNotMatching;
 
 const _validateResult = result => {
   if (

--- a/packages/expect/src/utils.js
+++ b/packages/expect/src/utils.js
@@ -209,3 +209,7 @@ export const isError = (value: any) => {
       return value instanceof Error;
   }
 };
+
+export function emptyObject(obj: any) {
+  return obj && typeof obj === 'object' ? !Object.keys(obj).length : false;
+}


### PR DESCRIPTION
## Summary

Closes #5510 

Add inverse asymmetric matchers for `arrayContaining`, `objectContaining`, `stringContaining`, and `stringMatching`.

## Test plan

Added unit tests.

~~Should I add inverse matchers for `.any` and `.anything`?~~