### PR TITLE
Add watchAll flag to jest-editor-support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   `groupEnd`, `time`, `timeEnd`
   ([#5514](https://github.com/facebook/jest/pull/5514))
 * `[docs]` Add documentation for interactive snapshot mode ([#5291](https://github.com/facebook/jest/pull/5291))
+* `[jest-editor-support]` Add watchAll flag ([#5523](https://github.com/facebook/jest/pull/5523))
 
 ## jest 22.2.2
 

--- a/packages/jest-editor-support/index.d.ts
+++ b/packages/jest-editor-support/index.d.ts
@@ -22,7 +22,8 @@ export interface Options {
 export class Runner extends EventEmitter {
   constructor(workspace: ProjectWorkspace, options?: Options);
   watchMode: boolean;
-  start(watchMode?: boolean): void;
+  watchAll: boolean;
+  start(watchMode?: boolean, watchAll?: boolean): void;
   closeProcess(): void;
   runJestWithUpdateForSnapshots(completion: any): void;
 }

--- a/packages/jest-editor-support/src/Runner.js
+++ b/packages/jest-editor-support/src/Runner.js
@@ -30,6 +30,7 @@ export default class Runner extends EventEmitter {
     options?: SpawnOptions,
   ) => ChildProcess;
   watchMode: boolean;
+  watchAll: boolean;
   options: Options;
   prevMessageTypes: MessageType[];
 
@@ -43,12 +44,13 @@ export default class Runner extends EventEmitter {
     this.prevMessageTypes = [];
   }
 
-  start(watchMode: boolean = true) {
+  start(watchMode: boolean = true, watchAll: boolean = false) {
     if (this.debugprocess) {
       return;
     }
 
     this.watchMode = watchMode;
+    this.watchAll = watchAll;
 
     // Handle the arg change on v18
     const belowEighteen = this.workspace.localJestMajorVersion < 18;
@@ -56,7 +58,7 @@ export default class Runner extends EventEmitter {
 
     const args = ['--json', '--useStderr', outputArg, this.outputPath];
     if (this.watchMode) {
-      args.push('--watch');
+      args.push(this.watchAll ? '--watchAll' : '--watch');
     }
     if (this.options.testNamePattern) {
       args.push('--testNamePattern', this.options.testNamePattern);

--- a/packages/jest-editor-support/src/__tests__/runner.test.js
+++ b/packages/jest-editor-support/src/__tests__/runner.test.js
@@ -48,6 +48,13 @@ describe('Runner', () => {
       expect(sut.watchMode).not.toBeDefined();
     });
 
+    it('does not set watchAll', () => {
+      const workspace: any = {};
+      const sut = new Runner(workspace);
+
+      expect(sut.watchAll).not.toBeDefined();
+    });
+
     it('sets the output filepath', () => {
       tmpdir.mockReturnValueOnce('tmpdir');
 
@@ -105,6 +112,18 @@ describe('Runner', () => {
       sut.start(expected);
 
       expect(sut.watchMode).toBe(expected);
+    });
+
+    it('sets watchAll', () => {
+      const watchMode = true;
+      const watchAll = true;
+
+      const workspace: any = {};
+      const sut = new Runner(workspace);
+      sut.start(watchMode, watchAll);
+
+      expect(sut.watchMode).toBe(watchMode);
+      expect(sut.watchAll).toBe(watchAll);
     });
 
     it('calls createProcess', () => {


### PR DESCRIPTION

## Summary


I am trying to integrate jest-editor-support into a project which does not have source controll. AFAIK the watch mode of jest needs to run in a git repository to work. This PR will add a watchAll flag which will work in other projects as well.