### PR TITLE
refactor: strip <rootDir> from collectCoverageFrom values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 *~
 /examples/*/node_modules/
 
+/.idea
+
 /integration-tests/*/node_modules
 /integration-tests/transform/*/coverage
 /integration-tests/transform/*/node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,6 @@
 *~
 /examples/*/node_modules/
 
-/.idea
-
 /integration-tests/*/node_modules
 /integration-tests/transform/*/coverage
 /integration-tests/transform/*/node_modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 * `[docs]` Add documentation for interactive snapshot mode ([#5291](https://github.com/facebook/jest/pull/5291))
 * `[jest-editor-support]` Add watchAll flag ([#5523](https://github.com/facebook/jest/pull/5523))
 
+### Chore & Maintenance
+
+* `[jest-config]` Allow `<rootDir>` to be used with `collectCoverageFrom` ([#5524](https://github.com/facebook/jest/pull/5524))
+
 ## jest 22.2.2
 
 ### Fixes

--- a/packages/jest-config/src/__tests__/normalize.test.js
+++ b/packages/jest-config/src/__tests__/normalize.test.js
@@ -186,6 +186,31 @@ describe('collectCoverageOnlyFrom', () => {
   });
 });
 
+describe('collectCoverageFrom', () => {
+  it('substitutes <rootDir> tokens', () => {
+    const barBaz = 'bar/baz';
+    const quxQuux = 'qux/quux/';
+    const notQuxQuux = `!${quxQuux}`;
+
+    const {options} = normalize(
+      {
+        collectCoverageFrom: [
+          barBaz,
+          notQuxQuux,
+          `<rootDir>/${barBaz}`,
+          `!<rootDir>/${quxQuux}`,
+        ],
+        rootDir: '/root/path/foo/',
+      },
+      {},
+    );
+
+    const expected = [barBaz, notQuxQuux, barBaz, notQuxQuux];
+
+    expect(options.collectCoverageFrom).toEqual(expected);
+  });
+});
+
 function testPathArray(key) {
   it('normalizes all paths relative to rootDir', () => {
     const {options} = normalize(

--- a/packages/jest-config/src/normalize.js
+++ b/packages/jest-config/src/normalize.js
@@ -160,9 +160,11 @@ const normalizeCollectCoverageFrom = (options: InitialOptions, key: string) => {
     value = options[key];
   }
 
-  value = value.map(filePath => {
-    return filePath.replace(/^(!?)(<rootDir>\/)(.*)/, '$1$3');
-  });
+  if (value) {
+    value = value.map(filePath => {
+      return filePath.replace(/^(!?)(<rootDir>\/)(.*)/, '$1$3');
+    });
+  }
 
   return value;
 };

--- a/packages/jest-config/src/normalize.js
+++ b/packages/jest-config/src/normalize.js
@@ -160,6 +160,10 @@ const normalizeCollectCoverageFrom = (options: InitialOptions, key: string) => {
     value = options[key];
   }
 
+  value = value.map(filePath => {
+    return filePath.replace(/^(!?)(<rootDir>\/)(.*)/, '$1$3');
+  });
+
   return value;
 };
 


### PR DESCRIPTION
## Summary
All values given to `collectCoverageFrom` are relative to the root directory, so usage of `<rootDir>` results in invalid file paths. With these changes, `<rootDir>` will be silently replaced.

I ran into this issue because I did not read the docs and expected `<rootDir>` to be usable within all paths. When I realized using `<rootDir>` in `collectCoverageFrom` did not work, I raised an issue (https://github.com/facebook/jest/issues/5499).

A contributor (@SimenB) suggested silently replacing the `<rootDir>` values, allowing it to be used. I took a look at the code that handles the configuration, found the place to patch it in and here we have the pull request!

## Test plan
I added a unit test that asserts the old and new behaviour. They work properly in tandem. :-)
