### PR TITLE
jest-haste-map: fix bug where platform-specific files are removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## master
 
+### Fixes
+
+* `[jest-haste-map]` Properly handle platform-specific file deletions
+  ([#5534](https://github.com/facebook/jest/pull/5534))
+
 ### Features
 
 * `[jest-util]` Add the following methods to the "console" implementations:

--- a/packages/jest-haste-map/src/__tests__/index.test.js
+++ b/packages/jest-haste-map/src/__tests__/index.test.js
@@ -586,7 +586,7 @@ describe('HasteMap', () => {
     });
   });
 
-  it('correctly handles platform-specific file deletions (broken)', async () => {
+  it('correctly handles platform-specific file deletions', async () => {
     mockFs = Object.create(null);
     mockFs['/fruits/strawberry.js'] = [
       '/**',
@@ -613,8 +613,6 @@ describe('HasteMap', () => {
     ({__hasteMapForTest: data} = await new HasteMap(defaultConfig).build());
     expect(data.map['Strawberry']).toEqual({
       g: ['/fruits/strawberry.js', 0],
-      // FIXME: this file should NOT exist anymore!
-      ios: ['/fruits/strawberry.ios.js', 0],
     });
   });
 

--- a/packages/jest-haste-map/src/index.js
+++ b/packages/jest-haste-map/src/index.js
@@ -422,8 +422,18 @@ class HasteMap extends EventEmitter {
     if (fileMetadata[H.VISITED]) {
       if (!fileMetadata[H.ID]) {
         return null;
-      } else if (fileMetadata[H.ID] && moduleMetadata) {
-        map[fileMetadata[H.ID]] = moduleMetadata;
+      }
+      if (moduleMetadata != null) {
+        const platform =
+          getPlatformExtension(filePath, this._options.platforms) ||
+          H.GENERIC_PLATFORM;
+        const module = moduleMetadata[platform];
+        if (module == null) {
+          return null;
+        }
+        const modulesByPlatform =
+          map[fileMetadata[H.ID]] || (map[fileMetadata[H.ID]] = {});
+        modulesByPlatform[platform] = module;
         return null;
       }
     }

--- a/website/pages/en/videos.js
+++ b/website/pages/en/videos.js
@@ -36,7 +36,9 @@ class Videos extends React.Component {
       ({title, description, type, url}, index) => {
         const textMarkup = (
           <div className="blockContent">
-            <h2><a href={url}>{title}</a></h2>
+            <h2>
+              <a href={url}>{title}</a>
+            </h2>
             <div>
               <MarkdownBlock>{description}</MarkdownBlock>
             </div>


### PR DESCRIPTION
Another fix for `jest-haste-map` 😁 
This changeset fixes the bug that was reproduced by the test I added a few days ago, where platform-specific file removals aren't taken into account. I traced this back to the fact the logic just copies the entire module metadata for a particular Haste name, without discriminating between platforms. That means if any of the files for that Haste name is still here, all the platforms already cached are included in the new map, even if some of these files were deleted. With the new logic, we only copy over the data for the platform of the file being processed.

I didn't check how that behaves for the watch mode but I suspect this fixes the bug for it as well. I can follow up with another test for that.