### PR TITLE
support multiple glob patterns for collectCoverageFrom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,17 @@
   `assert`, `count`, `countReset`, `dir`, `dirxml`, `group`, `groupCollapsed`,
   `groupEnd`, `time`, `timeEnd`
   ([#5514](https://github.com/facebook/jest/pull/5514))
-* `[docs]` Add documentation for interactive snapshot mode ([#5291](https://github.com/facebook/jest/pull/5291))
-* `[jest-editor-support]` Add watchAll flag ([#5523](https://github.com/facebook/jest/pull/5523))
+* `[docs]` Add documentation for interactive snapshot mode
+  ([#5291](https://github.com/facebook/jest/pull/5291))
+* `[jest-editor-support]` Add watchAll flag
+  ([#5523](https://github.com/facebook/jest/pull/5523))
+* `[jest-cli]` Support multiple glob patterns for `collectCoverageFrom`
+  ([#5537](https://github.com/facebook/jest/pull/5537))
 
 ### Chore & Maintenance
 
-* `[jest-config]` Allow `<rootDir>` to be used with `collectCoverageFrom` ([#5524](https://github.com/facebook/jest/pull/5524))
+* `[jest-config]` Allow `<rootDir>` to be used with `collectCoverageFrom`
+  ([#5524](https://github.com/facebook/jest/pull/5524))
 
 ## jest 22.2.2
 
@@ -154,7 +159,8 @@
 * `[jest-cli]` Make Jest exit without an error when no tests are found in the
   case of `--lastCommit`, `--findRelatedTests`, or `--onlyChanged` options
   having been passed to the CLI
-* `[jest-cli]` Add interactive snapshot mode ([#3831](https://github.com/facebook/jest/pull/3831))
+* `[jest-cli]` Add interactive snapshot mode
+  ([#3831](https://github.com/facebook/jest/pull/3831))
 
 ### Fixes
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -134,7 +134,7 @@ directory. The default cache directory can be found by calling
 
 ### `--collectCoverageFrom=<glob>`
 
-Relative to the root directory, glob pattern matching the files that coverage
+An array of glob patterns relative to <rootDir> matching the files that coverage
 info needs to be collected from.
 
 ### `--colors`

--- a/integration-tests/__tests__/__snapshots__/coverage_report.test.js.snap
+++ b/integration-tests/__tests__/__snapshots__/coverage_report.test.js.snap
@@ -24,7 +24,7 @@ All files      |      100 |      100 |      100 |      100 |                |
 "
 `;
 
-exports[`collects coverage only from specified files 1`] = `
+exports[`collects coverage only from specified file 1`] = `
 "----------|----------|----------|----------|----------|----------------|
 File      |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
 ----------|----------|----------|----------|----------|----------------|

--- a/integration-tests/__tests__/__snapshots__/coverage_report.test.js.snap
+++ b/integration-tests/__tests__/__snapshots__/coverage_report.test.js.snap
@@ -13,6 +13,17 @@ All files      |      100 |      100 |      100 |      100 |                |
 "
 `;
 
+exports[`collects coverage only from multiple specified files 1`] = `
+"---------------|----------|----------|----------|----------|----------------|
+File           |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
+---------------|----------|----------|----------|----------|----------------|
+All files      |      100 |      100 |      100 |      100 |                |
+ other-file.js |      100 |      100 |      100 |      100 |                |
+ setup.js      |      100 |      100 |      100 |      100 |                |
+---------------|----------|----------|----------|----------|----------------|
+"
+`;
+
 exports[`collects coverage only from specified files 1`] = `
 "----------|----------|----------|----------|----------|----------------|
 File      |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |

--- a/integration-tests/__tests__/coverage_report.test.js
+++ b/integration-tests/__tests__/coverage_report.test.js
@@ -33,7 +33,7 @@ test('outputs coverage report', () => {
   expect(status).toBe(0);
 });
 
-test('collects coverage only from specified files', () => {
+test('collects coverage only from specified file', () => {
   const {stdout} = runJest(DIR, [
     '--no-cache',
     '--coverage',
@@ -42,6 +42,18 @@ test('collects coverage only from specified files', () => {
   ]);
 
   // Coverage report should only have `setup.js` coverage info
+  expect(stdout).toMatchSnapshot();
+});
+
+test('collects coverage only from multiple specified files', () => {
+  const {stdout} = runJest(DIR, [
+    '--no-cache',
+    '--coverage',
+    '--collectCoverageFrom', // overwrites the one in package.json
+    'setup.js',
+    'other-file.js',
+  ]);
+
   expect(stdout).toMatchSnapshot();
 });
 

--- a/packages/jest-cli/src/cli/args.js
+++ b/packages/jest-cli/src/cli/args.js
@@ -153,9 +153,9 @@ export const options = {
   },
   collectCoverageFrom: {
     description:
-      'relative to <rootDir> glob pattern matching the files ' +
+      'An array of glob patterns relative to <rootDir> matching the files ' +
       'that coverage info needs to be collected from.',
-    type: 'string',
+    type: 'array',
   },
   collectCoverageOnlyFrom: {
     description: 'Explicit list of paths coverage will be restricted to.',


### PR DESCRIPTION
This PR address issue #5198.

## Summary

Improves the behaviour of `collectCoverageFrom` CLI option by allowing passing multiple glob patterns.

For example:

```bash
jest --collectCoverageFrom foo/**/*.js bar/**/*.js
```

## Test plan

I added a simple integration test that covers this use case.
