### PR TITLE
Add note for matching files via CLI

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -89,6 +89,8 @@ picked up and executed. Depending on your terminal, you may need to quote this
 argument: `jest "my.*(complex)?pattern"`. On Windows, you will need to use `/`
 as a path separator or escape `\` as `\\`.
 
+*Note: Jest 22+ will test any files matched, including those that would normally not be matched based on other [configurations](Configuration.md).*
+
 ### `--bail`
 
 Alias: `-b`. Exit the test suite immediately upon the first failing test suite.


### PR DESCRIPTION
## Summary
Starting in [this change](https://github.com/facebook/jest/pull/3882) we've started to ignore matchers for files passed in via the CLI

This PR adds a note that files passed this way will be tested even though they may normally not be included

Closes https://github.com/facebook/jest/issues/5527 

## Test plan
- N/A

## Screen
![](http://dp.hanlon.io/1W31351P1W12/Image%202018-02-12%20at%2011.11.19%20PM.png)