### PR TITLE
Issue #5197: Add descriptive error to Expect CalledWith methods when missing optional arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+* `[expect]` Add descriptive error message to CalledWith methods when missing
+  optional agruments ([#5547](https://github.com/facebook/jest/pull/5547))
 * `[jest-cli]` Fix inability to quit watch mode while debugger is still attached
   ([#5029](https://github.com/facebook/jest/pull/5029))
 * `[jest-haste-map]` Properly handle platform-specific file deletions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixes
 
 * `[expect]` Add descriptive error message to CalledWith methods when missing
-  optional agruments ([#5547](https://github.com/facebook/jest/pull/5547))
+  optional arguments ([#5547](https://github.com/facebook/jest/pull/5547))
 * `[jest-cli]` Fix inability to quit watch mode while debugger is still attached
   ([#5029](https://github.com/facebook/jest/pull/5029))
 * `[jest-haste-map]` Properly handle platform-specific file deletions

--- a/packages/expect/src/__tests__/__snapshots__/spy_matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/spy_matchers.test.js.snap
@@ -79,6 +79,13 @@ Expected mock function to have been last called with:
   <green>\\"bar\\"</> as argument 2, but it was called with <red>\\"bar3\\"</>."
 `;
 
+exports[`lastCalledWith works with trailing undefined arguments 1`] = `
+"<dim>expect(</><red>jest.fn()</><dim>).lastCalledWith(</><green>expected</><dim>)</>
+
+Expected mock function to have been last called with:
+  Did not expect argument 2 but it was called with <red>undefined</>."
+`;
+
 exports[`toBeCalled works only on spies or jest.fn 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>)[.not].toBeCalled(</><dim>)</>
 
@@ -302,6 +309,13 @@ Expected mock function to have been called with:
   <green>\\"bar\\"</> as argument 2, but it was called with <red>\\"bar1\\"</>."
 `;
 
+exports[`toHaveBeenCalledWith works with trailing undefined arguments 1`] = `
+"<dim>expect(</><red>jest.fn()</><dim>).toHaveBeenCalledWith(</><green>expected</><dim>)</>
+
+Expected mock function to have been called with:
+  Did not expect argument 2 but it was called with <red>undefined</>."
+`;
+
 exports[`toHaveBeenLastCalledWith works only on spies or jest.fn 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>)[.not].toHaveBeenLastCalledWith(</><dim>)</>
 
@@ -379,4 +393,11 @@ exports[`toHaveBeenLastCalledWith works with many arguments that don't match 1`]
 
 Expected mock function to have been last called with:
   <green>\\"bar\\"</> as argument 2, but it was called with <red>\\"bar3\\"</>."
+`;
+
+exports[`toHaveBeenLastCalledWith works with trailing undefined arguments 1`] = `
+"<dim>expect(</><red>jest.fn()</><dim>).toHaveBeenLastCalledWith(</><green>expected</><dim>)</>
+
+Expected mock function to have been last called with:
+  Did not expect argument 2 but it was called with <red>undefined</>."
 `;

--- a/packages/expect/src/__tests__/spy_matchers.test.js
+++ b/packages/expect/src/__tests__/spy_matchers.test.js
@@ -168,10 +168,8 @@ describe('toHaveBeenCalledTimes', () => {
       const fn = jest.fn();
       fn('foo', undefined);
 
-      jestExpect(fn)[calledWith]('foo');
-
       expect(() =>
-        jestExpect(fn).not[calledWith]('foo'),
+        jestExpect(fn)[calledWith]('foo'),
       ).toThrowErrorMatchingSnapshot();
     });
 

--- a/packages/expect/src/__tests__/spy_matchers.test.js
+++ b/packages/expect/src/__tests__/spy_matchers.test.js
@@ -164,6 +164,17 @@ describe('toHaveBeenCalledTimes', () => {
       ).toThrowErrorMatchingSnapshot();
     });
 
+    test(`${calledWith} works with trailing undefined arguments`, () => {
+      const fn = jest.fn();
+      fn('foo', undefined);
+
+      jestExpect(fn)[calledWith]('foo');
+
+      expect(() =>
+        jestExpect(fn).not[calledWith]('foo'),
+      ).toThrowErrorMatchingSnapshot();
+    });
+
     test(`${calledWith} works with Map`, () => {
       const fn = jest.fn();
 

--- a/packages/expect/src/spy_matchers.js
+++ b/packages/expect/src/spy_matchers.js
@@ -219,8 +219,14 @@ const formatMismatchedArgs = (expected, received) => {
         `  ${printExpected(expected[i])} as argument ${i + 1}, ` +
           `but it was called with ${printReceived(received[i])}.`,
       );
+    } else if (i >= expected.length) {
+      printedArgs.push(
+        `  Did not expect argument ${i + 1} ` +
+          `but it was called with ${printReceived(received[i])}.`,
+      );
     }
   }
+
   return printedArgs.join('\n');
 };
 


### PR DESCRIPTION
## Summary
Issue: https://github.com/facebook/jest/issues/5197
Specifically, formatMismatchedArgs will not add an error message when the received array gets extra argument(s) w/ undefined value since expected[i] and received[i] will both equal undefined (where received[i] is explicitly set to undefined whereas expected[i] is not in the array)

## Test plan
Tested using @mrfunkycold repo: https://github.com/mrfunkycold/jest-demo.  New error message:

  ● testFile › 1. when invoked › 1. fails to print the error line
    expect(jest.fn()).toHaveBeenCalledWith(expected)
    
    Expected mock function to have been called with:
      Did not expect argument 2 but it was called with undefined.
      11 | 
      12 |     it('1. fails to print the error line', () => {
    > 13 |       expect(logger).toHaveBeenCalledWith('errorMsg');
      14 |     });
      15 |   });
      16 | 
      
      at Object.it (src/typescript_version/testFile.test.ts:13:22)