### PR TITLE
Use preinstalled Yarn on Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,17 +10,16 @@ init:
 install:
   - ps: Install-Product node $env:nodejs_version x64
   - node --version
-  - curl -fsSL -o yarn.js https://github.com/yarnpkg/yarn/releases/download/v1.3.2/yarn-1.3.2.js
-  - node ./yarn.js --version
-  - node ./yarn.js install
-  - node ./yarn.js run build
+  - yarn install
+  - yarn run build
 
 cache:
   - node_modules
   - .eslintcache
+  - "%LOCALAPPDATA%\\Yarn"
 
 test_script:
-  - node ./yarn.js run jest --color
+  - yarn run jest --color
 
 # Don't actually build.
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,8 +10,7 @@ init:
 install:
   - ps: Install-Product node $env:nodejs_version x64
   - node --version
-  - yarn install
-  - yarn run build
+  - yarn
 
 cache:
   - node_modules
@@ -19,7 +18,7 @@ cache:
   - "%LOCALAPPDATA%\\Yarn"
 
 test_script:
-  - yarn run jest --color
+  - yarn jest --color
 
 # Don't actually build.
 build: off


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Based on https://yarnpkg.com/lang/en/docs/install-ci/#appveyor-tab AppVeyor should have Yarn preinstalled. This should speedup the builds.

## Test plan

AppVeyor green
