### PR TITLE
Use `cross-spawn` for running Yarn in integration tests

### DIFF
--- a/integration-tests/__tests__/babel_plugin_jest_hoist.test.js
+++ b/integration-tests/__tests__/babel_plugin_jest_hoist.test.js
@@ -14,11 +14,9 @@ const runJest = require('../runJest');
 
 const DIR = path.resolve(__dirname, '..', 'babel-plugin-jest-hoist');
 
-if (process.platform !== 'win32') {
-  beforeEach(() => {
-    run('yarn', DIR);
-  });
-}
+beforeEach(() => {
+  run('yarn', DIR);
+});
 
 it('sucessfully runs the tests inside `babel-plugin-jest-hoist/`', () => {
   const {json} = runJest.json(DIR, ['--no-cache', '--coverage']);

--- a/integration-tests/__tests__/babel_plugin_jest_hoist.test.js
+++ b/integration-tests/__tests__/babel_plugin_jest_hoist.test.js
@@ -9,13 +9,10 @@
 'use strict';
 
 const path = require('path');
-const SkipOnWindows = require('../../scripts/SkipOnWindows');
 const {run} = require('../utils');
 const runJest = require('../runJest');
 
 const DIR = path.resolve(__dirname, '..', 'babel-plugin-jest-hoist');
-
-SkipOnWindows.suite();
 
 if (process.platform !== 'win32') {
   beforeEach(() => {

--- a/integration-tests/__tests__/coverage_remapping.test.js
+++ b/integration-tests/__tests__/coverage_remapping.test.js
@@ -11,11 +11,14 @@
 
 const {readFileSync} = require('fs');
 const path = require('path');
+const SkipOnWindows = require('../../scripts/SkipOnWindows');
 const {cleanup, run} = require('../utils');
 const runJest = require('../runJest');
 
 const dir = path.resolve(__dirname, '../coverage-remapping');
 const coverageDir = path.join(dir, 'coverage');
+
+SkipOnWindows.suite();
 
 beforeAll(() => {
   cleanup(coverageDir);

--- a/integration-tests/__tests__/coverage_remapping.test.js
+++ b/integration-tests/__tests__/coverage_remapping.test.js
@@ -11,14 +11,11 @@
 
 const {readFileSync} = require('fs');
 const path = require('path');
-const SkipOnWindows = require('../../scripts/SkipOnWindows');
 const {cleanup, run} = require('../utils');
 const runJest = require('../runJest');
 
 const dir = path.resolve(__dirname, '../coverage-remapping');
 const coverageDir = path.join(dir, 'coverage');
-
-SkipOnWindows.suite();
 
 beforeAll(() => {
   cleanup(coverageDir);

--- a/integration-tests/__tests__/native_async_mock.test.js
+++ b/integration-tests/__tests__/native_async_mock.test.js
@@ -10,20 +10,18 @@
 'use strict';
 
 const path = require('path');
-const SkipOnWindows = require('../../scripts/SkipOnWindows');
 const {run, extractSummary} = require('../utils');
 const runJest = require('../runJest');
 
-SkipOnWindows.suite();
 const dir = path.resolve(__dirname, '..', 'native-async-mock');
 
 test('mocks async functions', () => {
   if (process.versions.node < '7.6.0') {
     return;
   }
-  if (process.platform !== 'win32') {
-    run('yarn', dir);
-  }
+
+  run('yarn', dir);
+
   // --no-cache because babel can cache stuff and result in false green
   const {stderr} = runJest(dir, ['--no-cache']);
   expect(extractSummary(stderr).summary).toMatch(

--- a/integration-tests/__tests__/transform.test.js
+++ b/integration-tests/__tests__/transform.test.js
@@ -8,7 +8,6 @@
  */
 
 const path = require('path');
-const SkipOnWindows = require('../../scripts/SkipOnWindows');
 const {
   run,
   cleanup,
@@ -20,13 +19,10 @@ const runJest = require('../runJest');
 const os = require('os');
 
 describe('babel-jest', () => {
-  SkipOnWindows.suite();
   const dir = path.resolve(__dirname, '..', 'transform/babel-jest');
 
   beforeEach(() => {
-    if (process.platform !== 'win32') {
-      run('yarn', dir);
-    }
+    run('yarn', dir);
   });
 
   it('runs transpiled code', () => {

--- a/integration-tests/__tests__/transform.test.js
+++ b/integration-tests/__tests__/transform.test.js
@@ -103,9 +103,7 @@ describe('multiple-transformers', () => {
   const dir = path.resolve(__dirname, '..', 'transform/multiple-transformers');
 
   beforeEach(() => {
-    if (process.platform !== 'win32') {
-      run('yarn', dir);
-    }
+    run('yarn', dir);
   });
 
   it('transforms dependencies using specific transformers', () => {

--- a/integration-tests/__tests__/transform.test.js
+++ b/integration-tests/__tests__/transform.test.js
@@ -56,7 +56,7 @@ describe('no babel-jest', () => {
     linkJestPackage('babel-jest', tempDir);
   });
 
-  it('fails with syntax error on flow types', () => {
+  test('fails with syntax error on flow types', () => {
     const {stderr} = runJest(tempDir, ['--no-cache', '--no-watchman']);
     expect(stderr).toMatch(/FAIL.*fails_with_syntax_error/);
     expect(stderr).toMatch('Unexpected token');

--- a/integration-tests/__tests__/typescript_coverage.test.js
+++ b/integration-tests/__tests__/typescript_coverage.test.js
@@ -8,11 +8,8 @@
  */
 
 const path = require('path');
-const SkipOnWindows = require('../../scripts/SkipOnWindows');
 const {run} = require('../utils');
 const runJest = require('../runJest');
-
-SkipOnWindows.suite();
 
 it('instruments and collects coverage for typescript files', () => {
   const dir = path.resolve(__dirname, '../typescript-coverage');

--- a/integration-tests/utils.js
+++ b/integration-tests/utils.js
@@ -11,7 +11,7 @@
 
 import type {Path} from 'types/Config';
 
-const {spawnSync} = require('child_process');
+const {sync: spawnSync} = require('cross-spawn');
 const fs = require('fs');
 const path = require('path');
 const mkdirp = require('mkdirp');

--- a/integration-tests/utils.js
+++ b/integration-tests/utils.js
@@ -43,8 +43,9 @@ const linkJestPackage = (packageName: string, cwd: Path) => {
   const packagesDir = path.resolve(__dirname, '../packages');
   const packagePath = path.resolve(packagesDir, packageName);
   const destination = path.resolve(cwd, 'node_modules/');
-  run(`mkdir -p ${destination}`);
-  return run(`ln -sf ${packagePath} ${destination}`);
+  mkdirp.sync(destination);
+  rimraf.sync(destination);
+  fs.symlinkSync(packagePath, destination, 'dir');
 };
 
 const fileExists = (filePath: Path) => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Use `cross-spawn` for running Yarn in integration tests, which should unblock running some tests on Windows.

## Test plan

Observe AppVeyor
