### PR TITLE
Fix jest-circus setup logic

### DIFF
--- a/packages/jest-circus/src/legacy_code_todo_rewrite/jest_adapter.js
+++ b/packages/jest-circus/src/legacy_code_todo_rewrite/jest_adapter.js
@@ -28,9 +28,11 @@ const jestAdapter = async (
     runAndTransformResultsToJestFormat,
   } = runtime.requireInternalModule(FRAMEWORK_INITIALIZER);
 
-  runtime.requireInternalModule(path.resolve(__dirname, './jest_expect.js'))({
-    expand: globalConfig.expand,
-  });
+  runtime
+    .requireInternalModule(path.resolve(__dirname, './jest_expect.js'))
+    .default({
+      expand: globalConfig.expand,
+    });
 
   const {globals, snapshotState} = initialize({
     config,


### PR DESCRIPTION
I want to try and see what it takes to get `jest-circus` to feature parity with jasmine.
It seems like there's only  11 tests that are failing in jest master if i switch default framework to use `jest-circus`
<img width="901" alt="screen shot 2018-02-13 at 10 24 46 pm" src="https://user-images.githubusercontent.com/940133/36190459-530ebd9c-110d-11e8-91cc-7bf7c4a50a5d.png">

we moved to using `imports` since the last time i ran it, this PR fixes the integration to properly require `expect` module into runtime