### PR TITLE
Use v8.serialize when available.

### DIFF
--- a/packages/jest-haste-map/src/index.js
+++ b/packages/jest-haste-map/src/index.js
@@ -7,6 +7,30 @@
  * @flow
  */
 
+import {execSync} from 'child_process';
+import {version as VERSION} from '../package.json';
+import {worker} from './worker';
+import crypto from 'crypto';
+import EventEmitter from 'events';
+import fs from 'graceful-fs';
+import getMockName from './get_mock_name';
+import getPlatformExtension from './lib/get_platform_extension';
+// eslint-disable-next-line import/no-duplicates
+import H from './constants';
+import HasteFS from './haste_fs';
+import HasteModuleMap from './module_map';
+// eslint-disable-next-line import/default
+import nodeCrawl from './crawlers/node';
+import normalizePathSep from './lib/normalize_path_sep';
+import os from 'os';
+import path from 'path';
+import sane from 'sane';
+import v8 from 'v8';
+// eslint-disable-next-line import/default
+import watchmanCrawl from './crawlers/watchman';
+import WatchmanWatcher from './lib/watchman_watcher';
+import Worker from 'jest-worker';
+
 import type {Console} from 'console';
 import type {Path} from 'types/Config';
 import type {
@@ -18,33 +42,8 @@ import type {
   MockData,
 } from 'types/HasteMap';
 
-import {worker} from './worker';
-
 // eslint-disable-next-line import/no-duplicates
 import typeof HType from './constants';
-
-import EventEmitter from 'events';
-import os from 'os';
-import path from 'path';
-import crypto from 'crypto';
-import {execSync} from 'child_process';
-import fs from 'graceful-fs';
-import sane from 'sane';
-import {version as VERSION} from '../package.json';
-// eslint-disable-next-line import/no-duplicates
-import H from './constants';
-import HasteFS from './haste_fs';
-import HasteModuleMap from './module_map';
-import getMockName from './get_mock_name';
-import getPlatformExtension from './lib/get_platform_extension';
-import normalizePathSep from './lib/normalize_path_sep';
-import Worker from 'jest-worker';
-import WatchmanWatcher from './lib/watchman_watcher';
-
-// eslint-disable-next-line import/default
-import nodeCrawl from './crawlers/node';
-// eslint-disable-next-line import/default
-import watchmanCrawl from './crawlers/watchman';
 
 type Options = {
   cacheDirectory?: string,
@@ -291,7 +290,21 @@ class HasteMap extends EventEmitter {
    * 1. read data from the cache or create an empty structure.
    */
   read(): InternalHasteMap {
-    return this._parse(fs.readFileSync(this._cachePath, 'utf8'));
+    if (v8.deserialize) {
+      // This may throw. `_buildFileMap` will catch it and create a new map.
+      const {version, hasteMap} = v8.deserialize(
+        fs.readFileSync(this._cachePath),
+      );
+      if (version !== process.versions.v8) {
+        throw new Error('jest-haste-map: v8 versions do not match.');
+      }
+      return removePrototypes(hasteMap);
+    } else {
+      const hasteMap = (JSON.parse(
+        fs.readFileSync(this._cachePath, 'utf8'),
+      ): InternalHasteMap);
+      return removePrototypes(hasteMap);
+    }
   }
 
   readModuleMap(): ModuleMap {
@@ -520,8 +533,18 @@ class HasteMap extends EventEmitter {
   /**
    * 4. serialize the new `HasteMap` in a cache file.
    */
-  _persist(hasteMap: InternalHasteMap): void {
-    fs.writeFileSync(this._cachePath, JSON.stringify(hasteMap), 'utf8');
+  _persist(hasteMap: InternalHasteMap) {
+    if (v8.serialize) {
+      fs.writeFileSync(
+        this._cachePath,
+        v8.serialize({
+          hasteMap,
+          version: process.versions.v8,
+        }),
+      );
+    } else {
+      fs.writeFileSync(this._cachePath, JSON.stringify(hasteMap), 'utf8');
+    }
   }
 
   /**
@@ -542,14 +565,6 @@ class HasteMap extends EventEmitter {
     }
 
     return this._worker;
-  }
-
-  _parse(hasteMapPath: string): InternalHasteMap {
-    const hasteMap = (JSON.parse(hasteMapPath): InternalHasteMap);
-    for (const key in hasteMap) {
-      Object.setPrototypeOf(hasteMap[key], null);
-    }
-    return hasteMap;
   }
 
   _crawl(hasteMap: InternalHasteMap): Promise<InternalHasteMap> {
@@ -898,6 +913,12 @@ class HasteMap extends EventEmitter {
 }
 
 const copy = object => Object.assign(Object.create(null), object);
+const removePrototypes = object => {
+  for (const key in object) {
+    Object.setPrototypeOf(object[key], null);
+  }
+  return object;
+};
 
 HasteMap.H = H;
 HasteMap.ModuleMap = HasteModuleMap;


### PR DESCRIPTION
## Summary

v8 (in Node 8+) has a new function called [`v8.serialize`](https://nodejs.org/api/v8.html#v8_v8_serialize_value) which can be used to encode/decode JavaScript data structures faster than JSON. This diff changes `jest-haste-map` to use the new function in newer versions of Node and falls back to JSON if the serializer/deserializer aren't available. It also does a v8 version check to ensure we aren't trying to read a possible outdated binary blob. Making the cache work across node versions is a non goal and will be broken by this feature. If a user upgrades node, the function will throw and recreate the haste map.

I benchmarked this on a 73mb haste map and got the following results averaged over 10 runs:
* v8.deserialize: 1621.34
* JSON.parse: 1810.15
* v8.serialize: 608.28
* JSON.stringify: 1177.84

Reading is ~200ms faster and writing is 500ms faster. I suspect this is because of less validation work and less GC (*edit: it's not GC*). Since during startup we read the haste map once, write updates and then read it once per worker, this means that on a gigantic repo, this saves 500+200+(200*workers) time, or close to a second of actual time. On most repos out there in the world, there is likely no visible performance difference.

Next steps (up for grabs):
* Create a `jest-serialize` package that uses either v8 serialize or JSON.
* Use `jest-serialize` across Jest (`jest-worker`, `jest-haste-map`) and Metro.
* Use more efficient data structures for Jest's haste map to save space and time (this is a large project).

## Test plan

I updated some of the tests to pass on either node 8+ or node versions below that.