### PR TITLE
Optimize getting stack trace in message-util

### DIFF
--- a/packages/jest-message-util/src/index.js
+++ b/packages/jest-message-util/src/index.js
@@ -266,9 +266,11 @@ export const formatStackTrace = (
   }
 
   const stacktrace = lines
-    .map(trimPaths)
-    .map(formatPaths.bind(null, config, options, relativeTestPath))
-    .map(line => STACK_INDENT + line)
+    .map(
+      line =>
+        STACK_INDENT +
+        formatPaths(config, options, relativeTestPath, trimPaths(line)),
+    )
     .join('\n');
 
   return renderedCallsite + stacktrace;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary
Minor optimize getting stack trace.
- Used 1 `map` instead of 3 `maps`
- Get rid of `bind`
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
