### PR TITLE
Small polish to the plugins API

### DIFF
--- a/packages/jest-cli/src/__tests__/__snapshots__/watch.test.js.snap
+++ b/packages/jest-cli/src/__tests__/__snapshots__/watch.test.js.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Watch mode flows Pressing "u" reruns the tests in "update snapshot" mode 1`] = `2`;
+
 exports[`Watch mode flows Runs Jest in a non-interactive environment not showing usage 1`] = `
 Array [
   "

--- a/packages/jest-cli/src/__tests__/watch.test.js
+++ b/packages/jest-cli/src/__tests__/watch.test.js
@@ -10,6 +10,7 @@
 
 import chalk from 'chalk';
 import TestWatcher from '../test_watcher';
+import JestHooks from '../jest_hooks';
 import {KEYS} from '../constants';
 
 const runJestMock = jest.fn();
@@ -37,7 +38,7 @@ jest.doMock(
   watchPluginPath,
   () =>
     class WatchPlugin1 {
-      getUsageRow() {
+      getUsageData() {
         return {
           key: 's'.codePointAt(0),
           prompt: 'do nothing',
@@ -51,7 +52,7 @@ jest.doMock(
   watchPlugin2Path,
   () =>
     class WatchPlugin2 {
-      getUsageRow() {
+      getUsageData() {
         return {
           key: 'u'.codePointAt(0),
           prompt: 'do something else',
@@ -282,7 +283,7 @@ describe('Watch mode flows', () => {
           constructor() {
             this.showPrompt = showPrompt;
           }
-          getUsageRow() {
+          getUsageData() {
             return {
               key: 's'.codePointAt(0),
               prompt: 'do nothing',
@@ -324,7 +325,7 @@ describe('Watch mode flows', () => {
             this.showPrompt = showPrompt;
           }
           onData() {}
-          getUsageRow() {
+          getUsageData() {
             return {
               key: 's'.codePointAt(0),
               prompt: 'do nothing',
@@ -344,7 +345,7 @@ describe('Watch mode flows', () => {
             this.showPrompt = showPrompt2;
           }
           onData() {}
-          getUsageRow() {
+          getUsageData() {
             return {
               key: 'z'.codePointAt(0),
               prompt: 'also do nothing',
@@ -412,10 +413,14 @@ describe('Watch mode flows', () => {
   });
 
   it('Pressing "u" reruns the tests in "update snapshot" mode', async () => {
+    const hooks = new JestHooks();
+
     globalConfig.updateSnapshot = 'new';
 
-    watch(globalConfig, contexts, pipe, hasteMapInstances, stdin);
+    watch(globalConfig, contexts, pipe, hasteMapInstances, stdin, hooks);
     runJestMock.mockReset();
+
+    hooks.getEmitter().testRunComplete({snapshot: {failure: true}});
 
     stdin.emit(KEYS.U);
     await nextTick();
@@ -433,6 +438,7 @@ describe('Watch mode flows', () => {
       watch: false,
     });
   });
+
   it('passWithNoTest should be set to true in watch mode', () => {
     globalConfig.passWithNoTests = false;
     watch(globalConfig, contexts, pipe, hasteMapInstances, stdin);

--- a/packages/jest-cli/src/__tests__/watch.test.js
+++ b/packages/jest-cli/src/__tests__/watch.test.js
@@ -313,9 +313,7 @@ describe('Watch mode flows', () => {
 
   it('prevents Jest from handling keys when active and returns control when end is called', async () => {
     let resolveShowPrompt;
-    const run = jest.fn(
-      () => new Promise(res => (resolveShowPrompt = res)),
-    );
+    const run = jest.fn(() => new Promise(res => (resolveShowPrompt = res)));
     const pluginPath = `${__dirname}/__fixtures__/plugin_path_1`;
     jest.doMock(
       pluginPath,

--- a/packages/jest-cli/src/__tests__/watch.test.js
+++ b/packages/jest-cli/src/__tests__/watch.test.js
@@ -38,7 +38,7 @@ jest.doMock(
   watchPluginPath,
   () =>
     class WatchPlugin1 {
-      getUsageData() {
+      getUsageInfo() {
         return {
           key: 's'.codePointAt(0),
           prompt: 'do nothing',
@@ -52,7 +52,7 @@ jest.doMock(
   watchPlugin2Path,
   () =>
     class WatchPlugin2 {
-      getUsageData() {
+      getUsageInfo() {
         return {
           key: 'u'.codePointAt(0),
           prompt: 'do something else',
@@ -274,16 +274,16 @@ describe('Watch mode flows', () => {
   });
 
   it('triggers enter on a WatchPlugin when its key is pressed', async () => {
-    const runInteractive = jest.fn(() => Promise.resolve());
+    const run = jest.fn(() => Promise.resolve());
     const pluginPath = `${__dirname}/__fixtures__/plugin_path`;
     jest.doMock(
       pluginPath,
       () =>
         class WatchPlugin1 {
           constructor() {
-            this.runInteractive = runInteractive;
+            this.run = run;
           }
-          getUsageData() {
+          getUsageInfo() {
             return {
               key: 's'.codePointAt(0),
               prompt: 'do nothing',
@@ -308,12 +308,12 @@ describe('Watch mode flows', () => {
 
     await nextTick();
 
-    expect(runInteractive).toHaveBeenCalled();
+    expect(run).toHaveBeenCalled();
   });
 
   it('prevents Jest from handling keys when active and returns control when end is called', async () => {
     let resolveShowPrompt;
-    const runInteractive = jest.fn(
+    const run = jest.fn(
       () => new Promise(res => (resolveShowPrompt = res)),
     );
     const pluginPath = `${__dirname}/__fixtures__/plugin_path_1`;
@@ -322,10 +322,10 @@ describe('Watch mode flows', () => {
       () =>
         class WatchPlugin1 {
           constructor() {
-            this.runInteractive = runInteractive;
+            this.run = run;
           }
           onKey() {}
-          getUsageData() {
+          getUsageInfo() {
             return {
               key: 's'.codePointAt(0),
               prompt: 'do nothing',
@@ -342,10 +342,10 @@ describe('Watch mode flows', () => {
       () =>
         class WatchPlugin1 {
           constructor() {
-            this.runInteractive = showPrompt2;
+            this.run = showPrompt2;
           }
           onKey() {}
-          getUsageData() {
+          getUsageInfo() {
             return {
               key: 'z'.codePointAt(0),
               prompt: 'also do nothing',
@@ -368,7 +368,7 @@ describe('Watch mode flows', () => {
 
     stdin.emit(Number('s'.charCodeAt(0)).toString(16));
     await nextTick();
-    expect(runInteractive).toHaveBeenCalled();
+    expect(run).toHaveBeenCalled();
     stdin.emit(Number('z'.charCodeAt(0)).toString(16));
     await nextTick();
     expect(showPrompt2).not.toHaveBeenCalled();
@@ -414,6 +414,7 @@ describe('Watch mode flows', () => {
 
   it('Pressing "u" reruns the tests in "update snapshot" mode', async () => {
     const hooks = new JestHooks();
+    expect(2).toMatchSnapshot();
 
     globalConfig.updateSnapshot = 'new';
 

--- a/packages/jest-cli/src/__tests__/watch.test.js
+++ b/packages/jest-cli/src/__tests__/watch.test.js
@@ -244,14 +244,14 @@ describe('Watch mode flows', () => {
   });
 
   it('allows WatchPlugins to hook into JestHooks', async () => {
-    const registerHooks = jest.fn();
+    const apply = jest.fn();
     const pluginPath = `${__dirname}/__fixtures__/plugin_path_register`;
     jest.doMock(
       pluginPath,
       () =>
         class WatchPlugin {
           constructor() {
-            this.registerHooks = registerHooks;
+            this.apply = apply;
           }
         },
       {virtual: true},
@@ -270,18 +270,18 @@ describe('Watch mode flows', () => {
 
     await nextTick();
 
-    expect(registerHooks).toHaveBeenCalled();
+    expect(apply).toHaveBeenCalled();
   });
 
   it('triggers enter on a WatchPlugin when its key is pressed', async () => {
-    const showPrompt = jest.fn(() => Promise.resolve());
+    const runInteractive = jest.fn(() => Promise.resolve());
     const pluginPath = `${__dirname}/__fixtures__/plugin_path`;
     jest.doMock(
       pluginPath,
       () =>
         class WatchPlugin1 {
           constructor() {
-            this.showPrompt = showPrompt;
+            this.runInteractive = runInteractive;
           }
           getUsageData() {
             return {
@@ -308,12 +308,12 @@ describe('Watch mode flows', () => {
 
     await nextTick();
 
-    expect(showPrompt).toHaveBeenCalled();
+    expect(runInteractive).toHaveBeenCalled();
   });
 
   it('prevents Jest from handling keys when active and returns control when end is called', async () => {
     let resolveShowPrompt;
-    const showPrompt = jest.fn(
+    const runInteractive = jest.fn(
       () => new Promise(res => (resolveShowPrompt = res)),
     );
     const pluginPath = `${__dirname}/__fixtures__/plugin_path_1`;
@@ -322,9 +322,9 @@ describe('Watch mode flows', () => {
       () =>
         class WatchPlugin1 {
           constructor() {
-            this.showPrompt = showPrompt;
+            this.runInteractive = runInteractive;
           }
-          onData() {}
+          onKey() {}
           getUsageData() {
             return {
               key: 's'.codePointAt(0),
@@ -342,9 +342,9 @@ describe('Watch mode flows', () => {
       () =>
         class WatchPlugin1 {
           constructor() {
-            this.showPrompt = showPrompt2;
+            this.runInteractive = showPrompt2;
           }
-          onData() {}
+          onKey() {}
           getUsageData() {
             return {
               key: 'z'.codePointAt(0),
@@ -368,7 +368,7 @@ describe('Watch mode flows', () => {
 
     stdin.emit(Number('s'.charCodeAt(0)).toString(16));
     await nextTick();
-    expect(showPrompt).toHaveBeenCalled();
+    expect(runInteractive).toHaveBeenCalled();
     stdin.emit(Number('z'.charCodeAt(0)).toString(16));
     await nextTick();
     expect(showPrompt2).not.toHaveBeenCalled();

--- a/packages/jest-cli/src/__tests__/watch.test.js
+++ b/packages/jest-cli/src/__tests__/watch.test.js
@@ -242,6 +242,36 @@ describe('Watch mode flows', () => {
     expect(pipeMockCalls.slice(determiningTestsToRun + 1)).toMatchSnapshot();
   });
 
+  it('allows WatchPlugins to hook into JestHooks', async () => {
+    const registerHooks = jest.fn();
+    const pluginPath = `${__dirname}/__fixtures__/plugin_path_register`;
+    jest.doMock(
+      pluginPath,
+      () =>
+        class WatchPlugin {
+          constructor() {
+            this.registerHooks = registerHooks;
+          }
+        },
+      {virtual: true},
+    );
+
+    watch(
+      Object.assign({}, globalConfig, {
+        rootDir: __dirname,
+        watchPlugins: [pluginPath],
+      }),
+      contexts,
+      pipe,
+      hasteMapInstances,
+      stdin,
+    );
+
+    await nextTick();
+
+    expect(registerHooks).toHaveBeenCalled();
+  });
+
   it('triggers enter on a WatchPlugin when its key is pressed', async () => {
     const showPrompt = jest.fn(() => Promise.resolve());
     const pluginPath = `${__dirname}/__fixtures__/plugin_path`;

--- a/packages/jest-cli/src/base_watch_plugin.js
+++ b/packages/jest-cli/src/base_watch_plugin.js
@@ -26,13 +26,13 @@ class BaseWatchPlugin implements WatchPlugin {
 
   apply(hooks: JestHookSubscriber) {}
 
-  getUsageData(globalConfig: GlobalConfig): ?UsageData {
+  getUsageInfo(globalConfig: GlobalConfig): ?UsageData {
     return null;
   }
 
   onKey(value: string) {}
 
-  runInteractive(
+  run(
     globalConfig: GlobalConfig,
     updateConfigAndRun: Function,
   ): Promise<void | boolean> {

--- a/packages/jest-cli/src/base_watch_plugin.js
+++ b/packages/jest-cli/src/base_watch_plugin.js
@@ -8,9 +8,9 @@
  */
 import type {GlobalConfig} from 'types/Config';
 import type {JestHookSubscriber} from './jest_hooks';
-import type {UsageData} from './types';
+import type {WatchPlugin, UsageData} from './types';
 
-class BaseWatchPlugin {
+class BaseWatchPlugin implements WatchPlugin {
   _stdin: stream$Readable | tty$ReadStream;
   _stdout: stream$Writable | tty$WriteStream;
   constructor({

--- a/packages/jest-cli/src/base_watch_plugin.js
+++ b/packages/jest-cli/src/base_watch_plugin.js
@@ -24,15 +24,15 @@ class BaseWatchPlugin {
     this._stdout = stdout;
   }
 
-  registerHooks(hooks: JestHookSubscriber) {}
+  apply(hooks: JestHookSubscriber) {}
 
   getUsageData(globalConfig: GlobalConfig): ?UsageData {
     return null;
   }
 
-  onData(value: string) {}
+  onKey(value: string) {}
 
-  showPrompt(
+  runInteractive(
     globalConfig: GlobalConfig,
     updateConfigAndRun: Function,
   ): Promise<void | boolean> {

--- a/packages/jest-cli/src/base_watch_plugin.js
+++ b/packages/jest-cli/src/base_watch_plugin.js
@@ -10,7 +10,7 @@ import type {GlobalConfig} from 'types/Config';
 import type {JestHookSubscriber} from './jest_hooks';
 import type {UsageRow} from './types';
 
-class WatchPlugin {
+class BaseWatchPlugin {
   _stdin: stream$Readable | tty$ReadStream;
   _stdout: stream$Writable | tty$WriteStream;
   constructor({
@@ -40,4 +40,4 @@ class WatchPlugin {
   }
 }
 
-export default WatchPlugin;
+export default BaseWatchPlugin;

--- a/packages/jest-cli/src/base_watch_plugin.js
+++ b/packages/jest-cli/src/base_watch_plugin.js
@@ -8,7 +8,7 @@
  */
 import type {GlobalConfig} from 'types/Config';
 import type {JestHookSubscriber} from './jest_hooks';
-import type {UsageRow} from './types';
+import type {UsageData} from './types';
 
 class BaseWatchPlugin {
   _stdin: stream$Readable | tty$ReadStream;
@@ -26,8 +26,8 @@ class BaseWatchPlugin {
 
   registerHooks(hooks: JestHookSubscriber) {}
 
-  getUsageRow(globalConfig: GlobalConfig): UsageRow {
-    return {hide: true, key: 0, prompt: ''};
+  getUsageData(globalConfig: GlobalConfig): ?UsageData {
+    return null;
   }
 
   onData(value: string) {}

--- a/packages/jest-cli/src/plugins/quit.js
+++ b/packages/jest-cli/src/plugins/quit.js
@@ -17,7 +17,7 @@ class QuitPlugin extends BaseWatchPlugin {
     process.exit(0);
   }
 
-  getUsageRow() {
+  getUsageData() {
     return {
       key: 'q'.codePointAt(0),
       prompt: 'quit watch mode',

--- a/packages/jest-cli/src/plugins/quit.js
+++ b/packages/jest-cli/src/plugins/quit.js
@@ -9,7 +9,7 @@
 import BaseWatchPlugin from '../base_watch_plugin';
 
 class QuitPlugin extends BaseWatchPlugin {
-  async showPrompt() {
+  async runInteractive() {
     if (typeof this._stdin.setRawMode === 'function') {
       this._stdin.setRawMode(false);
     }

--- a/packages/jest-cli/src/plugins/quit.js
+++ b/packages/jest-cli/src/plugins/quit.js
@@ -9,7 +9,7 @@
 import BaseWatchPlugin from '../base_watch_plugin';
 
 class QuitPlugin extends BaseWatchPlugin {
-  async runInteractive() {
+  async run() {
     if (typeof this._stdin.setRawMode === 'function') {
       this._stdin.setRawMode(false);
     }
@@ -17,7 +17,7 @@ class QuitPlugin extends BaseWatchPlugin {
     process.exit(0);
   }
 
-  getUsageData() {
+  getUsageInfo() {
     return {
       key: 'q'.codePointAt(0),
       prompt: 'quit watch mode',

--- a/packages/jest-cli/src/plugins/quit.js
+++ b/packages/jest-cli/src/plugins/quit.js
@@ -6,9 +6,9 @@
  *
  * @flow
  */
-import WatchPlugin from '../watch_plugin';
+import BaseWatchPlugin from '../base_watch_plugin';
 
-class QuitPlugin extends WatchPlugin {
+class QuitPlugin extends BaseWatchPlugin {
   async showPrompt() {
     if (typeof this._stdin.setRawMode === 'function') {
       this._stdin.setRawMode(false);

--- a/packages/jest-cli/src/plugins/test_name_pattern.js
+++ b/packages/jest-cli/src/plugins/test_name_pattern.js
@@ -30,11 +30,11 @@ class TestNamePatternPlugin extends BaseWatchPlugin {
     };
   }
 
-  onData(key: string) {
+  onKey(key: string) {
     this._prompt.put(key);
   }
 
-  showPrompt(
+  runInteractive(
     globalConfig: GlobalConfig,
     updateConfigAndRun: Function,
   ): Promise<void> {

--- a/packages/jest-cli/src/plugins/test_name_pattern.js
+++ b/packages/jest-cli/src/plugins/test_name_pattern.js
@@ -7,12 +7,12 @@
  * @flow
  */
 import type {GlobalConfig} from 'types/Config';
-import WatchPlugin from '../watch_plugin';
+import BaseWatchPlugin from '../base_watch_plugin';
 import TestNamePatternPrompt from '../test_name_pattern_prompt';
 import activeFilters from '../lib/active_filters_message';
 import Prompt from '../lib/Prompt';
 
-class TestNamePatternPlugin extends WatchPlugin {
+class TestNamePatternPlugin extends BaseWatchPlugin {
   _prompt: Prompt;
 
   constructor(options: {

--- a/packages/jest-cli/src/plugins/test_name_pattern.js
+++ b/packages/jest-cli/src/plugins/test_name_pattern.js
@@ -23,7 +23,7 @@ class TestNamePatternPlugin extends BaseWatchPlugin {
     this._prompt = new Prompt();
   }
 
-  getUsageRow() {
+  getUsageData() {
     return {
       key: 't'.codePointAt(0),
       prompt: 'filter by a test name regex pattern',

--- a/packages/jest-cli/src/plugins/test_name_pattern.js
+++ b/packages/jest-cli/src/plugins/test_name_pattern.js
@@ -34,10 +34,7 @@ class TestNamePatternPlugin extends BaseWatchPlugin {
     this._prompt.put(key);
   }
 
-  run(
-    globalConfig: GlobalConfig,
-    updateConfigAndRun: Function,
-  ): Promise<void> {
+  run(globalConfig: GlobalConfig, updateConfigAndRun: Function): Promise<void> {
     return new Promise((res, rej) => {
       const testPathPatternPrompt = new TestNamePatternPrompt(
         this._stdout,

--- a/packages/jest-cli/src/plugins/test_name_pattern.js
+++ b/packages/jest-cli/src/plugins/test_name_pattern.js
@@ -23,7 +23,7 @@ class TestNamePatternPlugin extends BaseWatchPlugin {
     this._prompt = new Prompt();
   }
 
-  getUsageData() {
+  getUsageInfo() {
     return {
       key: 't'.codePointAt(0),
       prompt: 'filter by a test name regex pattern',
@@ -34,7 +34,7 @@ class TestNamePatternPlugin extends BaseWatchPlugin {
     this._prompt.put(key);
   }
 
-  runInteractive(
+  run(
     globalConfig: GlobalConfig,
     updateConfigAndRun: Function,
   ): Promise<void> {

--- a/packages/jest-cli/src/plugins/test_path_pattern.js
+++ b/packages/jest-cli/src/plugins/test_path_pattern.js
@@ -8,12 +8,12 @@
  */
 
 import type {GlobalConfig} from 'types/Config';
-import WatchPlugin from '../watch_plugin';
+import BaseWatchPlugin from '../base_watch_plugin';
 import TestPathPatternPrompt from '../test_path_pattern_prompt';
 import activeFilters from '../lib/active_filters_message';
 import Prompt from '../lib/Prompt';
 
-class TestPathPatternPlugin extends WatchPlugin {
+class TestPathPatternPlugin extends BaseWatchPlugin {
   _prompt: Prompt;
 
   constructor(options: {

--- a/packages/jest-cli/src/plugins/test_path_pattern.js
+++ b/packages/jest-cli/src/plugins/test_path_pattern.js
@@ -31,11 +31,11 @@ class TestPathPatternPlugin extends BaseWatchPlugin {
     };
   }
 
-  onData(key: string) {
+  onKey(key: string) {
     this._prompt.put(key);
   }
 
-  showPrompt(
+  runInteractive(
     globalConfig: GlobalConfig,
     updateConfigAndRun: Function,
   ): Promise<void> {

--- a/packages/jest-cli/src/plugins/test_path_pattern.js
+++ b/packages/jest-cli/src/plugins/test_path_pattern.js
@@ -24,7 +24,7 @@ class TestPathPatternPlugin extends BaseWatchPlugin {
     this._prompt = new Prompt();
   }
 
-  getUsageRow() {
+  getUsageData() {
     return {
       key: 'p'.codePointAt(0),
       prompt: 'filter by a filename regex pattern',

--- a/packages/jest-cli/src/plugins/test_path_pattern.js
+++ b/packages/jest-cli/src/plugins/test_path_pattern.js
@@ -24,7 +24,7 @@ class TestPathPatternPlugin extends BaseWatchPlugin {
     this._prompt = new Prompt();
   }
 
-  getUsageData() {
+  getUsageInfo() {
     return {
       key: 'p'.codePointAt(0),
       prompt: 'filter by a filename regex pattern',
@@ -35,7 +35,7 @@ class TestPathPatternPlugin extends BaseWatchPlugin {
     this._prompt.put(key);
   }
 
-  runInteractive(
+  run(
     globalConfig: GlobalConfig,
     updateConfigAndRun: Function,
   ): Promise<void> {

--- a/packages/jest-cli/src/plugins/test_path_pattern.js
+++ b/packages/jest-cli/src/plugins/test_path_pattern.js
@@ -35,10 +35,7 @@ class TestPathPatternPlugin extends BaseWatchPlugin {
     this._prompt.put(key);
   }
 
-  run(
-    globalConfig: GlobalConfig,
-    updateConfigAndRun: Function,
-  ): Promise<void> {
+  run(globalConfig: GlobalConfig, updateConfigAndRun: Function): Promise<void> {
     return new Promise((res, rej) => {
       const testPathPatternPrompt = new TestPathPatternPrompt(
         this._stdout,

--- a/packages/jest-cli/src/plugins/update_snapshots.js
+++ b/packages/jest-cli/src/plugins/update_snapshots.js
@@ -7,10 +7,10 @@
  * @flow
  */
 import type {GlobalConfig} from 'types/Config';
-import WatchPlugin from '../watch_plugin';
+import BaseWatchPlugin from '../base_watch_plugin';
 import type {JestHookSubscriber} from '../jest_hooks';
 
-class UpdateSnapshotsPlugin extends WatchPlugin {
+class UpdateSnapshotsPlugin extends BaseWatchPlugin {
   _hasSnapshotFailure: boolean;
   showPrompt(
     globalConfig: GlobalConfig,

--- a/packages/jest-cli/src/plugins/update_snapshots.js
+++ b/packages/jest-cli/src/plugins/update_snapshots.js
@@ -12,7 +12,7 @@ import type {JestHookSubscriber} from '../jest_hooks';
 
 class UpdateSnapshotsPlugin extends BaseWatchPlugin {
   _hasSnapshotFailure: boolean;
-  runInteractive(
+  run(
     globalConfig: GlobalConfig,
     updateConfigAndRun: Function,
   ): Promise<boolean> {
@@ -21,13 +21,12 @@ class UpdateSnapshotsPlugin extends BaseWatchPlugin {
   }
 
   apply(hooks: JestHookSubscriber) {
-    this._hasSnapshotFailure = true;
     hooks.testRunComplete(results => {
       this._hasSnapshotFailure = results.snapshot.failure;
     });
   }
 
-  getUsageData(globalConfig: GlobalConfig) {
+  getUsageInfo(globalConfig: GlobalConfig) {
     if (this._hasSnapshotFailure) {
       return {
         key: 'u'.codePointAt(0),

--- a/packages/jest-cli/src/plugins/update_snapshots.js
+++ b/packages/jest-cli/src/plugins/update_snapshots.js
@@ -21,17 +21,21 @@ class UpdateSnapshotsPlugin extends BaseWatchPlugin {
   }
 
   registerHooks(hooks: JestHookSubscriber) {
+    this._hasSnapshotFailure = true;
     hooks.testRunComplete(results => {
       this._hasSnapshotFailure = results.snapshot.failure;
     });
   }
 
-  getUsageRow(globalConfig: GlobalConfig) {
-    return {
-      hide: !this._hasSnapshotFailure,
-      key: 'u'.codePointAt(0),
-      prompt: 'update failing snapshots',
-    };
+  getUsageData(globalConfig: GlobalConfig) {
+    if (this._hasSnapshotFailure) {
+      return {
+        key: 'u'.codePointAt(0),
+        prompt: 'update failing snapshots',
+      };
+    }
+
+    return null;
   }
 }
 

--- a/packages/jest-cli/src/plugins/update_snapshots.js
+++ b/packages/jest-cli/src/plugins/update_snapshots.js
@@ -12,7 +12,7 @@ import type {JestHookSubscriber} from '../jest_hooks';
 
 class UpdateSnapshotsPlugin extends BaseWatchPlugin {
   _hasSnapshotFailure: boolean;
-  showPrompt(
+  runInteractive(
     globalConfig: GlobalConfig,
     updateConfigAndRun: Function,
   ): Promise<boolean> {
@@ -20,7 +20,7 @@ class UpdateSnapshotsPlugin extends BaseWatchPlugin {
     return Promise.resolve(false);
   }
 
-  registerHooks(hooks: JestHookSubscriber) {
+  apply(hooks: JestHookSubscriber) {
     this._hasSnapshotFailure = true;
     hooks.testRunComplete(results => {
       this._hasSnapshotFailure = results.snapshot.failure;

--- a/packages/jest-cli/src/plugins/update_snapshots_interactive.js
+++ b/packages/jest-cli/src/plugins/update_snapshots_interactive.js
@@ -39,10 +39,7 @@ class UpdateSnapshotInteractivePlugin extends BaseWatchPlugin {
     }
   }
 
-  run(
-    globalConfig: GlobalConfig,
-    updateConfigAndRun: Function,
-  ): Promise<void> {
+  run(globalConfig: GlobalConfig, updateConfigAndRun: Function): Promise<void> {
     if (this._failedSnapshotTestPaths.length) {
       return new Promise(res => {
         this._snapshotInteractiveMode.run(

--- a/packages/jest-cli/src/plugins/update_snapshots_interactive.js
+++ b/packages/jest-cli/src/plugins/update_snapshots_interactive.js
@@ -39,7 +39,7 @@ class UpdateSnapshotInteractivePlugin extends BaseWatchPlugin {
     }
   }
 
-  runInteractive(
+  run(
     globalConfig: GlobalConfig,
     updateConfigAndRun: Function,
   ): Promise<void> {
@@ -64,7 +64,7 @@ class UpdateSnapshotInteractivePlugin extends BaseWatchPlugin {
     }
   }
 
-  getUsageData(globalConfig: GlobalConfig) {
+  getUsageInfo(globalConfig: GlobalConfig) {
     if (
       this._failedSnapshotTestPaths &&
       this._failedSnapshotTestPaths.length > 0

--- a/packages/jest-cli/src/plugins/update_snapshots_interactive.js
+++ b/packages/jest-cli/src/plugins/update_snapshots_interactive.js
@@ -24,7 +24,7 @@ class UpdateSnapshotInteractivePlugin extends BaseWatchPlugin {
     this._snapshotInteractiveMode = new SnapshotInteractiveMode(this._stdout);
   }
 
-  registerHooks(hooks: JestHookSubscriber) {
+  apply(hooks: JestHookSubscriber) {
     hooks.testRunComplete(results => {
       this._failedSnapshotTestPaths = getFailedSnapshotTests(results);
       if (this._snapshotInteractiveMode.isActive()) {
@@ -33,13 +33,13 @@ class UpdateSnapshotInteractivePlugin extends BaseWatchPlugin {
     });
   }
 
-  onData(key: string) {
+  onKey(key: string) {
     if (this._snapshotInteractiveMode.isActive()) {
       this._snapshotInteractiveMode.put(key);
     }
   }
 
-  showPrompt(
+  runInteractive(
     globalConfig: GlobalConfig,
     updateConfigAndRun: Function,
   ): Promise<void> {

--- a/packages/jest-cli/src/plugins/update_snapshots_interactive.js
+++ b/packages/jest-cli/src/plugins/update_snapshots_interactive.js
@@ -8,11 +8,11 @@
  */
 import type {JestHookSubscriber} from '../jest_hooks';
 import type {GlobalConfig} from 'types/Config';
-import WatchPlugin from '../watch_plugin';
+import BaseWatchPlugin from '../base_watch_plugin';
 import {getFailedSnapshotTests} from 'jest-util';
 import SnapshotInteractiveMode from '../snapshot_interactive_mode';
 
-class UpdateSnapshotInteractivePlugin extends WatchPlugin {
+class UpdateSnapshotInteractivePlugin extends BaseWatchPlugin {
   _snapshotInteractiveMode: SnapshotInteractiveMode;
   _failedSnapshotTestPaths: Array<*>;
 

--- a/packages/jest-cli/src/plugins/update_snapshots_interactive.js
+++ b/packages/jest-cli/src/plugins/update_snapshots_interactive.js
@@ -64,14 +64,18 @@ class UpdateSnapshotInteractivePlugin extends BaseWatchPlugin {
     }
   }
 
-  getUsageRow(globalConfig: GlobalConfig) {
-    return {
-      hide:
-        !this._failedSnapshotTestPaths ||
-        this._failedSnapshotTestPaths.length === 0,
-      key: 'i'.codePointAt(0),
-      prompt: 'update failing snapshots interactively',
-    };
+  getUsageData(globalConfig: GlobalConfig) {
+    if (
+      this._failedSnapshotTestPaths &&
+      this._failedSnapshotTestPaths.length > 0
+    ) {
+      return {
+        key: 'i'.codePointAt(0),
+        prompt: 'update failing snapshots interactively',
+      };
+    }
+
+    return null;
   }
 }
 

--- a/packages/jest-cli/src/types.js
+++ b/packages/jest-cli/src/types.js
@@ -18,12 +18,12 @@ export type JestHooks = {
   testRunComplete: any,
 };
 
-export type WatchPlugin = {
-  apply?: (hooks: JestHookSubscriber) => void,
-  getUsageData?: (globalConfig: GlobalConfig) => ?UsageData,
-  onKey?: (value: string) => void,
-  runInteractive?: (
+export interface WatchPlugin {
+  +apply?: (hooks: JestHookSubscriber) => void;
+  +getUsageData?: (globalConfig: GlobalConfig) => ?UsageData;
+  +onKey?: (value: string) => void;
+  +runInteractive?: (
     globalConfig: GlobalConfig,
     updateConfigAndRun: Function,
-  ) => Promise<void | boolean>,
-};
+  ) => Promise<void | boolean>;
+}

--- a/packages/jest-cli/src/types.js
+++ b/packages/jest-cli/src/types.js
@@ -20,9 +20,9 @@ export type JestHooks = {
 
 export interface WatchPlugin {
   +apply?: (hooks: JestHookSubscriber) => void;
-  +getUsageData?: (globalConfig: GlobalConfig) => ?UsageData;
+  +getUsageInfo?: (globalConfig: GlobalConfig) => ?UsageData;
   +onKey?: (value: string) => void;
-  +runInteractive?: (
+  +run?: (
     globalConfig: GlobalConfig,
     updateConfigAndRun: Function,
   ) => Promise<void | boolean>;

--- a/packages/jest-cli/src/types.js
+++ b/packages/jest-cli/src/types.js
@@ -19,10 +19,10 @@ export type JestHooks = {
 };
 
 export type WatchPlugin = {
-  registerHooks?: (hooks: JestHookSubscriber) => void,
+  apply?: (hooks: JestHookSubscriber) => void,
   getUsageData?: (globalConfig: GlobalConfig) => ?UsageData,
-  onData?: (value: string) => void,
-  showPrompt?: (
+  onKey?: (value: string) => void,
+  runInteractive?: (
     globalConfig: GlobalConfig,
     updateConfigAndRun: Function,
   ) => Promise<void | boolean>,

--- a/packages/jest-cli/src/types.js
+++ b/packages/jest-cli/src/types.js
@@ -9,10 +9,9 @@
 import type {GlobalConfig} from 'types/Config';
 import type {JestHookSubscriber} from './jest_hooks';
 
-export type UsageRow = {
+export type UsageData = {
   key: number,
   prompt: string,
-  hide?: boolean,
 };
 
 export type JestHooks = {
@@ -21,7 +20,7 @@ export type JestHooks = {
 
 export type WatchPlugin = {
   registerHooks?: (hooks: JestHookSubscriber) => void,
-  getUsageRow?: (globalConfig: GlobalConfig) => UsageRow,
+  getUsageData?: (globalConfig: GlobalConfig) => ?UsageData,
   onData?: (value: string) => void,
   showPrompt?: (
     globalConfig: GlobalConfig,

--- a/packages/jest-cli/src/types.js
+++ b/packages/jest-cli/src/types.js
@@ -7,6 +7,7 @@
  * @flow
  */
 import type {GlobalConfig} from 'types/Config';
+import type {JestHookSubscriber} from './jest_hooks';
 
 export type UsageRow = {
   key: number,
@@ -19,18 +20,11 @@ export type JestHooks = {
 };
 
 export type WatchPlugin = {
-  key: number,
-  name: string,
-  prompt: string,
-  apply: (
-    jestHooks: JestHooks,
-    {
-      stdin: stream$Readable | tty$ReadStream,
-      stdout: stream$Writable | tty$WriteStream,
-    },
-  ) => void,
-  shouldShowUsage?: (
+  registerHooks?: (hooks: JestHookSubscriber) => void,
+  getUsageRow?: (globalConfig: GlobalConfig) => UsageRow,
+  onData?: (value: string) => void,
+  showPrompt?: (
     globalConfig: GlobalConfig,
-    hasSnapshotFailures: boolean,
-  ) => boolean,
+    updateConfigAndRun: Function,
+  ) => Promise<void | boolean>,
 };

--- a/packages/jest-cli/src/watch.js
+++ b/packages/jest-cli/src/watch.js
@@ -122,8 +122,8 @@ export default function watch(
 
   watchPlugins.forEach((plugin: WatchPlugin) => {
     const hookSubscriber = hooks.getSubscriber();
-    if (plugin.registerHooks) {
-      plugin.registerHooks(hookSubscriber);
+    if (plugin.apply) {
+      plugin.apply(hookSubscriber);
     }
   });
 
@@ -136,8 +136,8 @@ export default function watch(
         stdout: outputStream,
       });
       const hookSubscriber = hooks.getSubscriber();
-      if (plugin.registerHooks) {
-        plugin.registerHooks(hookSubscriber);
+      if (plugin.apply) {
+        plugin.apply(hookSubscriber);
       }
       watchPlugins.push(plugin);
     }
@@ -249,10 +249,10 @@ export default function watch(
       return;
     }
 
-    if (activePlugin != null && activePlugin.onData) {
+    if (activePlugin != null && activePlugin.onKey) {
       // if a plugin is activate, Jest should let it handle keystrokes, so ignore
       // them here
-      activePlugin.onData(key);
+      activePlugin.onKey(key);
       return;
     }
 
@@ -281,8 +281,8 @@ export default function watch(
       // "activate" the plugin, which has jest ignore keystrokes so the plugin
       // can handle them
       activePlugin = matchingWatchPlugin;
-      if (activePlugin.showPrompt) {
-        activePlugin.showPrompt(globalConfig, updateConfigAndRun).then(
+      if (activePlugin.runInteractive) {
+        activePlugin.runInteractive(globalConfig, updateConfigAndRun).then(
           shouldRerun => {
             activePlugin = null;
             if (shouldRerun) {

--- a/packages/jest-cli/src/watch.js
+++ b/packages/jest-cli/src/watch.js
@@ -51,12 +51,12 @@ const getSortedUsageRows = (
 ) => {
   const internalPlugins = watchPlugins
     .slice(0, INTERNAL_PLUGINS.length)
-    .map(p => p.getUsageData && p.getUsageData(globalConfig))
+    .map(p => p.getUsageInfo && p.getUsageInfo(globalConfig))
     .filter(Boolean);
 
   const thirdPartyPlugins = watchPlugins
     .slice(INTERNAL_PLUGINS.length)
-    .map(p => p.getUsageData && p.getUsageData(globalConfig))
+    .map(p => p.getUsageInfo && p.getUsageInfo(globalConfig))
     .filter(Boolean)
     .sort((a, b) => a.key - b.key);
 
@@ -271,17 +271,17 @@ export default function watch(
     }
 
     const matchingWatchPlugin = watchPlugins.find(plugin => {
-      const UsageData =
-        (plugin.getUsageData && plugin.getUsageData(globalConfig)) || {};
-      return UsageData.key === parseInt(key, 16);
+      const usageData =
+        (plugin.getUsageInfo && plugin.getUsageInfo(globalConfig)) || {};
+      return usageData.key === parseInt(key, 16);
     });
 
     if (matchingWatchPlugin != null) {
       // "activate" the plugin, which has jest ignore keystrokes so the plugin
       // can handle them
       activePlugin = matchingWatchPlugin;
-      if (activePlugin.runInteractive) {
-        activePlugin.runInteractive(globalConfig, updateConfigAndRun).then(
+      if (activePlugin.run) {
+        activePlugin.run(globalConfig, updateConfigAndRun).then(
           shouldRerun => {
             activePlugin = null;
             if (shouldRerun) {

--- a/packages/jest-cli/src/watch.js
+++ b/packages/jest-cli/src/watch.js
@@ -115,7 +115,6 @@ export default function watch(
     });
   };
 
-  // $FlowFixMe
   const watchPlugins: Array<WatchPlugin> = INTERNAL_PLUGINS.map(
     InternalPlugin => new InternalPlugin({stdin, stdout: outputStream}),
   );

--- a/packages/jest-cli/src/watch.js
+++ b/packages/jest-cli/src/watch.js
@@ -51,15 +51,13 @@ const getSortedUsageRows = (
 ) => {
   const internalPlugins = watchPlugins
     .slice(0, INTERNAL_PLUGINS.length)
-    .map(p => p.getUsageRow && p.getUsageRow(globalConfig))
-    .filter(Boolean)
-    .filter(usage => !usage.hide);
+    .map(p => p.getUsageData && p.getUsageData(globalConfig))
+    .filter(Boolean);
 
   const thirdPartyPlugins = watchPlugins
     .slice(INTERNAL_PLUGINS.length)
-    .map(p => p.getUsageRow && p.getUsageRow(globalConfig))
+    .map(p => p.getUsageData && p.getUsageData(globalConfig))
     .filter(Boolean)
-    .filter(usage => !usage.hide)
     .sort((a, b) => a.key - b.key);
 
   return internalPlugins.concat(thirdPartyPlugins);
@@ -71,6 +69,7 @@ export default function watch(
   outputStream: stream$Writable | tty$WriteStream,
   hasteMapInstances: Array<HasteMap>,
   stdin?: stream$Readable | tty$ReadStream = process.stdin,
+  hooks?: JestHooks = new JestHooks(),
 ): Promise<void> {
   // `globalConfig` will be constantly updated and reassigned as a result of
   // watch mode interactions.
@@ -81,8 +80,6 @@ export default function watch(
     mode: globalConfig.watch ? 'watch' : 'watchAll',
     passWithNoTests: true,
   });
-
-  const hooks = new JestHooks();
 
   const updateConfigAndRun = ({
     testNamePattern,
@@ -275,10 +272,9 @@ export default function watch(
     }
 
     const matchingWatchPlugin = watchPlugins.find(plugin => {
-      const usageRow =
-        (plugin.getUsageRow && plugin.getUsageRow(globalConfig)) || {};
-
-      return usageRow.key === parseInt(key, 16);
+      const UsageData =
+        (plugin.getUsageData && plugin.getUsageData(globalConfig)) || {};
+      return UsageData.key === parseInt(key, 16);
     });
 
     if (matchingWatchPlugin != null) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

This is one of the items of https://github.com/facebook/jest/issues/5478

This is the proposed API, feedback is MORE than welcome

```js
interface WatchPlugin {
  +apply?: (hooks: JestHookSubscriber) => void;
  +getUsageData?: (globalConfig: GlobalConfig) => ?UsageData;
  +onKey?: (value: string) => void;
  +runInteractive?: (
    globalConfig: GlobalConfig,
    updateConfigAndRun: Function,
  ) => Promise<void | boolean>;
}
```

* @rickhanlonii I changed `showPrompt` -> `run` -> `runInteractive` just because I felt it was a bit more explicit, thoughts?
* Right now the internal plugins use the `BaseWatchPlugin`, I find this a bit awkward. It would be nice to get rid of it. We currently inject `stdin` and `stdout` in the constructor(this is for handling stuff like `--useStderr`). What would be another good way of injecting this? 

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
