### PR TITLE
fix console & buffered console assert behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
   ([#5560](https://github.com/facebook/jest/pull/5560))
 * `[jest-config]` Make it possible to merge `transform` option with preset
   ([#5505](https://github.com/facebook/jest/pull/5505))
+* `[jest-util]` Fix `console.assert` behavior in custom & buffered consoles
+  ([#5576](https://github.com/facebook/jest/pull/5576))
 
 ### Features
 

--- a/packages/jest-util/src/Console.js
+++ b/packages/jest-util/src/Console.js
@@ -50,7 +50,7 @@ export default class CustomConsole extends Console {
 
   assert(...args: Array<any>) {
     try {
-      assert(!!args[0], ...args.slice(1));
+      assert(...args);
     } catch (error) {
       this._log('assert', error.toString());
     }

--- a/packages/jest-util/src/Console.js
+++ b/packages/jest-util/src/Console.js
@@ -10,6 +10,7 @@
 
 import type {LogType, LogMessage, LogCounters, LogTimers} from 'types/Console';
 
+import assert from 'assert';
 import {format} from 'util';
 import {Console} from 'console';
 import chalk from 'chalk';
@@ -48,8 +49,10 @@ export default class CustomConsole extends Console {
   }
 
   assert(...args: Array<any>) {
-    if (args[0]) {
-      this._log('assert', format(...args.slice(1)));
+    try {
+      assert(!!args[0], ...args.slice(1));
+    } catch (error) {
+      this._log('assert', error.toString());
     }
   }
 

--- a/packages/jest-util/src/__tests__/buffered_console.test.js
+++ b/packages/jest-util/src/__tests__/buffered_console.test.js
@@ -23,16 +23,28 @@ describe('CustomConsole', () => {
   });
 
   describe('assert', () => {
-    test('log when the assertion is truthy', () => {
-      _console.assert(true, 'ok');
+    test('do not log when the assertion is truthy', () => {
+      _console.assert(true);
 
-      expect(stdout()).toMatch('ok');
+      expect(stdout()).toMatch('');
     });
 
-    test('do not log when the assertion is falsy', () => {
+    test('do not log when the assertion is truthy and there is a message', () => {
+      _console.assert(true, 'ok');
+
+      expect(stdout()).toMatch('');
+    });
+
+    test('log the assertion error when the assertion is falsy', () => {
+      _console.assert(false);
+
+      expect(stdout()).toEqual('AssertionError [ERR_ASSERTION]: false == true');
+    });
+
+    test('log the assertion error when the assertion is falsy with another message argument', () => {
       _console.assert(false, 'ok');
 
-      expect(stdout()).toEqual('');
+      expect(stdout()).toEqual('AssertionError [ERR_ASSERTION]: ok');
     });
   });
 

--- a/packages/jest-util/src/__tests__/buffered_console.test.js
+++ b/packages/jest-util/src/__tests__/buffered_console.test.js
@@ -38,13 +38,15 @@ describe('CustomConsole', () => {
     test('log the assertion error when the assertion is falsy', () => {
       _console.assert(false);
 
-      expect(stdout()).toEqual('AssertionError [ERR_ASSERTION]: false == true');
+      expect(stdout()).toMatch('AssertionError');
+      expect(stdout()).toMatch('false == true');
     });
 
     test('log the assertion error when the assertion is falsy with another message argument', () => {
       _console.assert(false, 'ok');
 
-      expect(stdout()).toEqual('AssertionError [ERR_ASSERTION]: ok');
+      expect(stdout()).toMatch('AssertionError');
+      expect(stdout()).toMatch('ok');
     });
   });
 

--- a/packages/jest-util/src/__tests__/console.test.js
+++ b/packages/jest-util/src/__tests__/console.test.js
@@ -39,15 +39,15 @@ describe('CustomConsole', () => {
     test('log the assertion error when the assertion is falsy', () => {
       _console.assert(false);
 
-      expect(_stdout).toEqual(
-        'AssertionError [ERR_ASSERTION]: false == true\n',
-      );
+      expect(_stdout).toMatch('AssertionError');
+      expect(_stdout).toMatch('false == true');
     });
 
     test('log the assertion error when the assertion is falsy with another message argument', () => {
       _console.assert(false, 'ok');
 
-      expect(_stdout).toEqual('AssertionError [ERR_ASSERTION]: ok\n');
+      expect(_stdout).toMatch('AssertionError');
+      expect(_stdout).toMatch('ok');
     });
   });
 

--- a/packages/jest-util/src/__tests__/console.test.js
+++ b/packages/jest-util/src/__tests__/console.test.js
@@ -24,16 +24,30 @@ describe('CustomConsole', () => {
   });
 
   describe('assert', () => {
-    test('log when the assertion is truthy', () => {
-      _console.assert(true, 'ok');
+    test('do not log when the assertion is truthy', () => {
+      _console.assert(true);
 
-      expect(_stdout).toMatch('ok');
+      expect(_stdout).toMatch('');
     });
 
-    test('do not log when the assertion is falsy', () => {
+    test('do not log when the assertion is truthy and there is a message', () => {
+      _console.assert(true, 'ok');
+
+      expect(_stdout).toMatch('');
+    });
+
+    test('log the assertion error when the assertion is falsy', () => {
+      _console.assert(false);
+
+      expect(_stdout).toEqual(
+        'AssertionError [ERR_ASSERTION]: false == true\n',
+      );
+    });
+
+    test('log the assertion error when the assertion is falsy with another message argument', () => {
       _console.assert(false, 'ok');
 
-      expect(_stdout).toEqual('');
+      expect(_stdout).toEqual('AssertionError [ERR_ASSERTION]: ok\n');
     });
   });
 

--- a/packages/jest-util/src/buffered_console.js
+++ b/packages/jest-util/src/buffered_console.js
@@ -15,6 +15,7 @@ import type {
   LogTimers,
 } from 'types/Console';
 
+import assert from 'assert';
 import {Console} from 'console';
 import {format} from 'util';
 import chalk from 'chalk';
@@ -63,8 +64,10 @@ export default class BufferedConsole extends Console {
   }
 
   assert(...args: Array<any>) {
-    if (args[0]) {
-      this._log('assert', format(...args.slice(1)));
+    try {
+      assert(!!args[0], ...args.slice(1));
+    } catch (error) {
+      this._log('assert', error.toString());
     }
   }
 

--- a/packages/jest-util/src/buffered_console.js
+++ b/packages/jest-util/src/buffered_console.js
@@ -65,7 +65,7 @@ export default class BufferedConsole extends Console {
 
   assert(...args: Array<any>) {
     try {
-      assert(!!args[0], ...args.slice(1));
+      assert(...args);
     } catch (error) {
       this._log('assert', error.toString());
     }


### PR DESCRIPTION
## Summary

This is a fix for #5574 

There was a mistake in #5514, where the `console.assert` behaviour was accidenitly implemented wrong.

Here there is a fix for the tests and the behaviour to use `assert` module and log when there is an assertion error.
