### PR TITLE
chore: make no-unused-vars eslint rule error

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -132,6 +132,7 @@ module.exports = {
     // https://github.com/benmosher/eslint-plugin-import/issues/645
     'import/order': 0,
     'no-console': 0,
+    'no-unused-vars': 2,
     'prettier/prettier': [
       2,
       {

--- a/packages/jest-cli/src/search_source.js
+++ b/packages/jest-cli/src/search_source.js
@@ -12,7 +12,6 @@ import type {Glob, GlobalConfig, Path} from 'types/Config';
 import type {Test} from 'types/TestRunner';
 import type {ChangedFilesPromise} from 'types/ChangedFiles';
 
-import fs from 'fs';
 import path from 'path';
 import micromatch from 'micromatch';
 import DependencyResolver from 'jest-resolve-dependencies';


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary
Noticed the lint warning on CI (it's set to warn for some reason in the underlying fb config: https://github.com/facebook/fbjs/blob/4369c7dfeb1ab0de27feb3e9245f599c8edd6a5c/packages/eslint-config-fbjs/index.js#L264). Any reason not to error here?

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan
No lint errors

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
