### PR TITLE
docs: link to full list of matchers in opening paragraph

### DIFF
--- a/docs/UsingMatchers.md
+++ b/docs/UsingMatchers.md
@@ -3,9 +3,9 @@ id: using-matchers
 title: Using Matchers
 ---
 
-Jest uses "matchers" to let you test values in different ways. There are too
-many different matchers to memorize them all, so this document will only try to
-introduce the most useful ones.
+Jest uses "matchers" to let you test values in different ways. This document 
+will introduce some commonly used matchers. For the full list,
+see the [`expect` API doc](ExpectAPI.md).
 
 ### Common Matchers
 


### PR DESCRIPTION
⚠️ I have not added an entry to the changelog for this, as it seems perhaps too minor a change to log. However if that is the protocol on this project, I will add one.

## Summary

This change makes it easier to jump right to the full list of available matchers. There's already a link at the bottom of the page, but this brings it to the fore to make it easier to find.

## Test plan

This is a simple docs amendment. No tests changed.