### PR TITLE
fix: make Errors match with ordinary objects (fixes #5359)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Fixes
 
+* `[enzyme]` Allow matching of Errors against plain objects
+  ([#5611](https://github.com/facebook/jest/pull/5611))
 * `[jest-cli]` Don't skip matchers for exact files
   ([#5582](https://github.com/facebook/jest/pull/5582))
 * `[docs]` Update discord links

--- a/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -3983,6 +3983,15 @@ Received:
   <red>[1, 2]</>"
 `;
 
+exports[`toMatchObject() {pass: true} expect([Error: bar]).toMatchObject({"message": "bar"}) 1`] = `
+"<dim>expect(</><red>received</><dim>).not.toMatchObject(</><green>expected</><dim>)</>
+
+Expected value not to match object:
+  <green>{\\"message\\": \\"bar\\"}</>
+Received:
+  <red>[Error: bar]</>"
+`;
+
 exports[`toMatchObject() {pass: true} expect([Error: foo]).toMatchObject([Error: foo]) 1`] = `
 "<dim>expect(</><red>received</><dim>).not.toMatchObject(</><green>expected</><dim>)</>
 

--- a/packages/expect/src/__tests__/matchers.test.js
+++ b/packages/expect/src/__tests__/matchers.test.js
@@ -28,6 +28,9 @@ describe('.rejects', () => {
     await jestExpect(Promise.reject({a: 1, b: 2})).rejects.not.toMatchObject({
       c: 1,
     });
+    await jestExpect(
+      Promise.reject(new Error('rejectMessage')),
+    ).rejects.toMatchObject({message: 'rejectMessage'});
     await jestExpect(Promise.reject(new Error())).rejects.toThrow();
   });
 
@@ -960,6 +963,7 @@ describe('toMatchObject()', () => {
     [{a: undefined}, {a: undefined}],
     [[], []],
     [new Error('foo'), new Error('foo')],
+    [new Error('bar'), {message: 'bar'}],
   ].forEach(([n1, n2]) => {
     it(`{pass: true} expect(${stringify(n1)}).toMatchObject(${stringify(
       n2,

--- a/packages/expect/src/utils.js
+++ b/packages/expect/src/utils.js
@@ -174,7 +174,7 @@ const isObjectWithKeys = a =>
   !(a instanceof Date);
 
 export const subsetEquality = (object: Object, subset: Object) => {
-  if (!isObjectWithKeys(object) || !isObjectWithKeys(subset)) {
+  if (!isObjectWithKeys(subset)) {
     return undefined;
   }
 


### PR DESCRIPTION
## Summary

Fixes #5359 -- makes toMatchObject work when comparing `Error`s with ordinary objects. This is accomplished by extending subset matching algorithm to include prototype properties of the object under test.

## Test plan

Added two test cases in `matchers.test.js`. No other tests were modified.
However, `yarn test` fails with the following error:
```FAIL  integration-tests/__tests__/timeouts.test.js (9.407s)
  ● exceeds the timeout

    expect(received).toMatch(expected)
    
    Expected value to match:
      /(jest\.setTimeout|jasmine\.DEFAULT_TIMEOUT_INTERVAL|Exceeded timeout)/
    Received:
      "PASS __tests__/a-banana.js
      ✓ banana
    
    "
```

Bonkers. Let's see if CI catches that one too.