### PR TITLE
Avoid loading files that we know are binary ahead of time

### DIFF
--- a/packages/jest-cli/src/search_source.js
+++ b/packages/jest-cli/src/search_source.js
@@ -12,7 +12,6 @@ import type {Glob, GlobalConfig, Path} from 'types/Config';
 import type {Test} from 'types/TestRunner';
 import type {ChangedFilesPromise} from 'types/ChangedFiles';
 
-import fs from 'fs';
 import path from 'path';
 import micromatch from 'micromatch';
 import DependencyResolver from 'jest-resolve-dependencies';

--- a/packages/jest-haste-map/src/blacklist.js
+++ b/packages/jest-haste-map/src/blacklist.js
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+// This list is compiled after the MDN list of the most common MIME types (see
+// https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/
+// Complete_list_of_MIME_types).
+//
+// Only MIME types starting with "image/", "video/", "audio/" and "font/" are
+// reflected in the list. Adding "application/" is too risky since some text
+// file formats (like ".js" and ".json") have an "application/" MIME type.
+//
+// Feel free to add any extensions that cannot contain any "@providesModule"
+// annotation.
+
+const extensions: Set<string> = new Set([
+  // JSONs are never haste modules, except for "package.json", which is handled.
+  '.json',
+
+  // Image extensions.
+  '.bmp',
+  '.gif',
+  '.ico',
+  '.jpeg',
+  '.jpg',
+  '.png',
+  '.svg',
+  '.tiff',
+  '.tif',
+  '.webp',
+
+  // Video extensions.
+  '.avi',
+  '.mp4',
+  '.mpeg',
+  '.mpg',
+  '.ogv',
+  '.webm',
+  '.3gp',
+  '.3g2',
+
+  // Audio extensions.
+  '.aac',
+  '.midi',
+  '.mid',
+  '.mp3',
+  '.oga',
+  '.wav',
+  '.3gp',
+  '.3g2',
+
+  // Font extensions.
+  '.eot',
+  '.otf',
+  '.ttf',
+  '.woff',
+  '.woff2',
+]);
+
+export default extensions;


### PR DESCRIPTION
Avoids `jest-haste-map` reading formats we know they are binary, even when requested to do so via `extensions`. This fixes a bug in Metro, where, in order to process assets, we need to pass Haste the corresponding extensions, but causes an OOM when opening a ~600 Mb video.