### PR TITLE
fix: correcting a mislabeled CHANGELOG.md entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Fixes
 
-* `[enzyme]` Allow matching of Errors against plain objects
+* `[expect]` Allow matching of Errors against plain objects
   ([#5611](https://github.com/facebook/jest/pull/5611))
 * `[jest-cli]` Don't skip matchers for exact files
   ([#5582](https://github.com/facebook/jest/pull/5582))


### PR DESCRIPTION
## Summary

#5611 introduced a mistake in CHANGELOG.md, attributing the PR to `enzyme` instead of `expect`. Duh.

## Test plan