### PR TITLE
Provide `require.main` property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## master
 
+### Features
+
+* `[jest-runtime]` Provide `require.main` property set to module with test suite
+  ([#5618](https://github.com/facebook/jest/pull/5618))
+
 ## 22.4.0
 
 ### Fixes

--- a/integration-tests/__tests__/require_main.test.js
+++ b/integration-tests/__tests__/require_main.test.js
@@ -18,5 +18,5 @@ const runJest = require('../runJest');
 test('provides `require.main` set to test suite module', () => {
   const {stderr, stdout} = runJest('require-main');
   expect(stdout).not.toMatch('No tests found');
-  expect(stderr).toMatch('PASS __tests__/loader.test.js');
+  expect(stderr).toMatch(/PASS __tests__(\/|\\+)loader\.test\.js/);
 });

--- a/integration-tests/__tests__/require_main.test.js
+++ b/integration-tests/__tests__/require_main.test.js
@@ -9,10 +9,6 @@
 
 'use strict';
 
-const path = require('path');
-const os = require('os');
-const SkipOnWindows = require('../../scripts/SkipOnWindows');
-const {cleanup, writeFiles} = require('../Utils');
 const runJest = require('../runJest');
 
 test('provides `require.main` set to test suite module', () => {

--- a/integration-tests/__tests__/require_main.test.js
+++ b/integration-tests/__tests__/require_main.test.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+'use strict';
+
+const path = require('path');
+const os = require('os');
+const SkipOnWindows = require('../../scripts/SkipOnWindows');
+const {cleanup, writeFiles} = require('../Utils');
+const runJest = require('../runJest');
+
+test('provides `require.main` set to test suite module', () => {
+  const {stderr, stdout} = runJest('require-main');
+  expect(stdout).not.toMatch('No tests found');
+  expect(stderr).toMatch('PASS __tests__/loader.test.js');
+});

--- a/integration-tests/require-main/__tests__/loader.test.js
+++ b/integration-tests/require-main/__tests__/loader.test.js
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+'use strict';
+
+const loader = require('../loader');
+
+test('loader should load a module', () => {
+  expect(loader('../example.js')).toBeTruthy();
+});

--- a/integration-tests/require-main/example.js
+++ b/integration-tests/require-main/example.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+module.exports = true;

--- a/integration-tests/require-main/loader.js
+++ b/integration-tests/require-main/loader.js
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const path = require('path');
+
+module.exports = function load(moduleId) {
+  return require(path.join(path.dirname(require.main.filename), moduleId));
+};

--- a/integration-tests/require-main/package.json
+++ b/integration-tests/require-main/package.json
@@ -1,0 +1,5 @@
+{
+  "jest": {
+    "testEnvironment": "node"
+  }
+}

--- a/packages/jest-runtime/src/__tests__/runtime_require_mock.test.js
+++ b/packages/jest-runtime/src/__tests__/runtime_require_mock.test.js
@@ -173,5 +173,14 @@ describe('Runtime', () => {
         expect(exports.isManualMockModule).toBe(true);
       });
     });
+    it('provides `require.main` in mock', () =>
+      createRuntime(__filename).then(runtime => {
+        runtime._moduleRegistry[__filename] = module;
+        runtime.setMock(__filename, 'export_main', () => require.main, {
+          virtual: true,
+        });
+        const mainModule = runtime.requireMock(__filename, 'export_main');
+        expect(mainModule).toBe(module);
+      }));
   });
 });

--- a/packages/jest-runtime/src/__tests__/runtime_require_module.test.js
+++ b/packages/jest-runtime/src/__tests__/runtime_require_module.test.js
@@ -130,6 +130,17 @@ describe('Runtime requireModule', () => {
       });
     });
   });
+  it('provides `require.main` to modules', () =>
+    createRuntime(__filename).then(runtime => {
+      runtime._moduleRegistry[__filename] = module;
+      [
+        './test_root/modules_with_main/export_main.js',
+        './test_root/modules_with_main/re_export_main.js',
+      ].forEach(modulePath => {
+        const mainModule = runtime.requireModule(__filename, modulePath);
+        expect(mainModule).toBe(module);
+      });
+    }));
 
   it('throws on non-existent @providesModule modules', () =>
     createRuntime(__filename).then(runtime => {

--- a/packages/jest-runtime/src/__tests__/test_root/modules_with_main/export_main.js
+++ b/packages/jest-runtime/src/__tests__/test_root/modules_with_main/export_main.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+module.exports = require.main;

--- a/packages/jest-runtime/src/__tests__/test_root/modules_with_main/re_export_main.js
+++ b/packages/jest-runtime/src/__tests__/test_root/modules_with_main/re_export_main.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+module.exports = require('./export_main');


### PR DESCRIPTION
Closes #2150 

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Expose property `require.main` when testing and set it to module from which the tests are being executed. Currently this property is not set, which is inconsistent with default Node behaviour ([Node ref](https://nodejs.org/api/modules.html#modules_accessing_the_main_module)) and the use case was present in #2150.

## Test plan

Appropriate unit and integration test cases were added to test if the property is provided in concrete modules and mocks.

Note 1: Module with test suite has to be manually added to `_moduleRegistry`, since the runtime is created manually instead of using the one from the `jest-runtime` in which the test are being run.

Note 2: This implementation assumes, that `module.parent` is set correctly and in order to find `main` module it traverse parents until `module.id` and `module.parent.id` are equal, in which case it would be test suite module.
