### PR TITLE
[jest-editor-support] update TypeScript definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ### Fixes
 
-* `[jest-editor-support]` Update TypeScript definitions ([]())
+* `[jest-editor-support]` Update TypeScript definitions
+  ([#5625](https://github.com/facebook/jest/pull/5625))
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## master
 
+### Fixes
+
+* `[jest-editor-support]` Update TypeScript definitions ([]())
+
 ### Features
 
 * `[jest-runtime]` Provide `require.main` property set to module with test suite

--- a/packages/jest-editor-support/index.d.ts
+++ b/packages/jest-editor-support/index.d.ts
@@ -8,15 +8,19 @@
 import {EventEmitter} from 'events';
 import {ChildProcess} from 'child_process';
 
+export interface SpawnOption {
+  shell?: boolean;
+};
+
 export interface Options {
   createProcess?(
     workspace: ProjectWorkspace,
     args: string[],
-    debugPort?: number,
+    options?: SpawnOptions,
   ): ChildProcess;
-  debugPort?: number;
   testNamePattern?: string;
   testFileNamePattern?: string;
+  shell?: boolean;
 }
 
 export class Runner extends EventEmitter {
@@ -84,19 +88,32 @@ export class TestReconciler {
   updateFileWithJestStatus(data: any): TestFileAssertionStatus[];
 }
 
+/**
+ *  Did the thing pass, fail or was it not run?
+ */
 export type TestReconcilationState =
-  | 'Unknown'
-  | 'KnownSuccess'
-  | 'KnownFail'
-  | 'KnownSkip';
+  | 'Unknown' // The file has not changed, so the watcher didn't hit it
+  | 'KnownFail' // Definitely failed
+  | 'KnownSuccess' // Definitely passed
+  | 'KnownSkip'; // Definitely skipped
 
+/**
+ * The Jest Extension's version of a status for
+ * whether the file passed or not
+ *
+ */
 export interface TestFileAssertionStatus {
   file: string;
   message: string;
   status: TestReconcilationState;
-  assertions: Array<TestAssertionStatus>;
+  assertions: Array<TestAssertionStatus> | null;
 }
 
+/**
+ * The Jest Extension's version of a status for
+ * individual assertion fails
+ *
+ */
 export interface TestAssertionStatus {
   title: string;
   status: TestReconcilationState;
@@ -140,7 +157,7 @@ export interface JestTotalResultsMeta {
   noTestsFound: boolean;
 }
 
-export enum MessageTypes {
+export enum messageTypes {
   noTests = 1,
   unknown = 0,
   watchUsage = 2,

--- a/packages/jest-editor-support/index.d.ts
+++ b/packages/jest-editor-support/index.d.ts
@@ -177,5 +177,4 @@ export interface SnapshotMetadata {
 export class Snapshot {
   constructor(parser: any, customMatchers?: string[]);
   getMetadata(filepath: string): SnapshotMetadata[];
-
 }

--- a/packages/jest-editor-support/index.d.ts
+++ b/packages/jest-editor-support/index.d.ts
@@ -165,12 +165,12 @@ export enum messageTypes {
 
 export type MessageType = number;
 
-export type Node = any;
-
 export interface SnapshotMetadata {
   exists: boolean;
   name: string;
-  node: Node;
+  node: {
+    loc: editor.Node
+  };
   content?: string;
 }
 

--- a/packages/jest-editor-support/index.d.ts
+++ b/packages/jest-editor-support/index.d.ts
@@ -150,6 +150,7 @@ export interface JestTotalResults {
   numPassedTests: number;
   numFailedTests: number;
   numPendingTests: number;
+  coverageMap: any;
   testResults: Array<JestFileResults>;
 }
 

--- a/packages/jest-editor-support/index.d.ts
+++ b/packages/jest-editor-support/index.d.ts
@@ -10,7 +10,7 @@ import {ChildProcess} from 'child_process';
 
 export interface SpawnOptions {
   shell?: boolean;
-};
+}
 
 export interface Options {
   createProcess?(
@@ -172,7 +172,7 @@ export interface SnapshotMetadata {
   name: string;
   node: Node;
   content?: string;
-};
+}
 
 export class Snapshot {
   constructor(parser: any, customMatchers?: string[]);

--- a/packages/jest-editor-support/index.d.ts
+++ b/packages/jest-editor-support/index.d.ts
@@ -164,3 +164,18 @@ export enum messageTypes {
 }
 
 export type MessageType = number;
+
+export type Node = any;
+
+export interface SnapshotMetadata {
+  exists: boolean;
+  name: string;
+  node: Node;
+  content?: string;
+};
+
+export class Snapshot {
+  constructor(parser: any, customMatchers?: string[]);
+  getMetadata(filepath: string): SnapshotMetadata[];
+
+}

--- a/packages/jest-editor-support/index.d.ts
+++ b/packages/jest-editor-support/index.d.ts
@@ -8,7 +8,7 @@
 import {EventEmitter} from 'events';
 import {ChildProcess} from 'child_process';
 
-export interface SpawnOption {
+export interface SpawnOptions {
   shell?: boolean;
 };
 


### PR DESCRIPTION
## Summary

The TypeScript definition within `jest-editor-support` was outdated. I have updated it based on the Flow type files.

## Test plan

There shouldn't be necessary any tests as I copied them from the existing code. The only non-backward-compatible change is replacing `**M**essageTypes` by `**m**essageTypes` in order to keep it consistent to the Flow type file.