### PR TITLE
Remove debug snapshot

### DIFF
--- a/packages/jest-cli/src/__tests__/__snapshots__/watch.test.js.snap
+++ b/packages/jest-cli/src/__tests__/__snapshots__/watch.test.js.snap
@@ -1,7 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Watch mode flows Pressing "u" reruns the tests in "update snapshot" mode 1`] = `2`;
-
 exports[`Watch mode flows Runs Jest in a non-interactive environment not showing usage 1`] = `
 Array [
   "

--- a/packages/jest-cli/src/__tests__/watch.test.js
+++ b/packages/jest-cli/src/__tests__/watch.test.js
@@ -412,7 +412,6 @@ describe('Watch mode flows', () => {
 
   it('Pressing "u" reruns the tests in "update snapshot" mode', async () => {
     const hooks = new JestHooks();
-    expect(2).toMatchSnapshot();
 
     globalConfig.updateSnapshot = 'new';
 

--- a/packages/jest-cli/src/plugins/update_snapshots_interactive.js
+++ b/packages/jest-cli/src/plugins/update_snapshots_interactive.js
@@ -21,6 +21,7 @@ class UpdateSnapshotInteractivePlugin extends BaseWatchPlugin {
     stdout: stream$Writable | tty$WriteStream,
   }) {
     super(options);
+    this._failedSnapshotTestPaths = [];
     this._snapshotInteractiveMode = new SnapshotInteractiveMode(this._stdout);
   }
 


### PR DESCRIPTION
Removes an accidental snapshot that I left while debugging #5572 

It also ensure that `_failedSnapshotTestPaths` is initialized to match its type _(`Array<*>`)_