### PR TITLE
Add how to mock scoped modules to Manual Mocks doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
   ([#5622](https://github.com/facebook/jest/pull/5622))
 * `[docs]` Update to use yarn
   ([#5624](https://github.com/facebook/jest/pull/5624))
+* `[docs]` Add how to mock scoped modules to Manual Mocks doc
+  ([#5638](https://github.com/facebook/jest/pull/5638))
 
 ## 22.4.0
 

--- a/docs/ManualMocks.md
+++ b/docs/ManualMocks.md
@@ -27,6 +27,12 @@ configured [`roots`](Configuration.md#roots-array-string) to point to a folder
 other than the project root) and will be **automatically** mocked. There's no
 need to explicitly call `jest.mock('module_name')`.
 
+Scoped modules can be mocked by creating a file in a directory structure that
+matches the name of the scoped module.  For example, to mock a scoped module
+called `@scope/project-name`, create a file at
+`__mocks__/@scope/project-name.js`, creating the `@scope/` directory
+accordingly.
+
 > Warning: If we want to mock Node's core modules (e.g.: `fs` or `path`), then
 > explicitly calling e.g. `jest.mock('path')` is **required**, because core Node
 > modules are not mocked by default.


### PR DESCRIPTION
This adds info on how to mock scoped modules to the Manual Mocks docs page as it wasn't clear how this process would work.  

~~(changelog modification pushing shortly once I have a PR ID)~~