### PR TITLE
Force haste map regeneration on deserialization error

### DIFF
--- a/packages/jest-haste-map/src/index.js
+++ b/packages/jest-haste-map/src/index.js
@@ -289,8 +289,13 @@ class HasteMap extends EventEmitter {
    * 1. read data from the cache or create an empty structure.
    */
   read(): InternalHasteMap {
-    // This may throw. `_buildFileMap` will catch it and create a new map.
-    const hasteMap: InternalHasteMap = serializer.readFileSync(this._cachePath);
+    let hasteMap: InternalHasteMap;
+
+    try {
+      hasteMap = serializer.readFileSync(this._cachePath);
+    } catch (err) {
+      hasteMap = this._createEmptyMap();
+    }
 
     for (const key in hasteMap) {
       Object.setPrototypeOf(hasteMap[key], null);


### PR DESCRIPTION
Despite `_buildFileMap` has a `try`/`catch`, and can catch the error, there are more places from where `read()` is called, like `readModuleMap`, where the call is not guarded. Thus, we have to implement a full guard *inside*, in order to be sure that we do not crash.