### PR TITLE
tests(colors): Force-disable colors on tests for consistent snapshots

### DIFF
--- a/integration-tests/runJest.js
+++ b/integration-tests/runJest.js
@@ -47,6 +47,7 @@ function runJest(
 
   const env = options.nodePath
     ? Object.assign({}, process.env, {
+        FORCE_COLOR: 0,
         NODE_PATH: options.nodePath,
       })
     : process.env;
@@ -66,7 +67,7 @@ function runJest(
 //   'numRuntimeErrorTestSuites', 'numPassedTests', 'numFailedTests',
 //   'numPendingTests', 'testResults'
 runJest.json = function(dir: string, args?: Array<string>) {
-  args = Array.prototype.concat(args || [], '--json');
+  args = [...(args || []), '--json'];
   const result = runJest(dir, args);
   try {
     result.json = JSON.parse((result.stdout || '').toString());


### PR DESCRIPTION
## Summary

We are having test failures due to mismatched snapshots on TravisCI
and on some other systems since colors are not consistently used
during tests. This patch forces colors to be off during tests via
`runJest` so they are always consistent.

## Test plan

Existing tests should pass. TravisCI builds should also be fixed.