### PR TITLE
Add some docs on using `jest.mock(...)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 ### Features
 
 * `[jest-jasmine2]` Adds error throwing and descriptive errors to `it`/ `test`
-  for invalid arguements. `[jest-circus]` Adds error throwing and descriptive
-  errors to `it`/ `test` for invalid arguements.
+  for invalid arguments. `[jest-circus]` Adds error throwing and descriptive
+  errors to `it`/ `test` for invalid arguments
+  ([#5558](https://github.com/facebook/jest/pull/5558))
 * `[jest-matcher-utils]` Add `isNot` option to `matcherHint` function
   ([#5512](https://github.com/facebook/jest/pull/5512))
 
@@ -20,6 +21,11 @@
   ([#5692](https://github.com/facebook/jest/pull/5692))
 * `[jest-cli]` Fix update snapshot issue when using watchAll
   ([#5696](https://github.com/facebook/jest/pull/5696))
+
+### Chore & Maintenance
+
+* `[docs]` Add docs on using `jest.mock(...)`
+  ([#5648](https://github.com/facebook/jest/pull/5648))
 
 ## 22.4.2
 

--- a/docs/MockFunctions.md
+++ b/docs/MockFunctions.md
@@ -129,41 +129,48 @@ function that's not directly being tested.
 
 ## Mocking Modules
 
-Suppose we have a class that fetches users from our API. The class uses [axios](https://github.com/axios/axios) to call the API then returns the `data` attribute which contains all the users:
+Suppose we have a class that fetches users from our API. The class uses
+[axios](https://github.com/axios/axios) to call the API then returns the `data`
+attribute which contains all the users:
 
 ```js
 // users.js
-import axios from 'axios'
+import axios from 'axios';
 
 class Users {
   static all() {
-    return axios.get('/users.json').then(resp => resp.data)
+    return axios.get('/users.json').then(resp => resp.data);
   }
 }
 
-export default Users
+export default Users;
 ```
 
-Now, in order to test this method without actually hitting the API (and thus creating slow and fragile tests), we can use the `jest.mock(...)` function to automatically mock the axios module.
+Now, in order to test this method without actually hitting the API (and thus
+creating slow and fragile tests), we can use the `jest.mock(...)` function to
+automatically mock the axios module.
 
-Once we mock the module we can spy on the `.get` method and provide a `mockImplementation` that returns the data we want our test to assert against. In effect, we are saying that we want axios.get('/users.json') to return a fake response.
+Once we mock the module we can spy on the `.get` method and provide a
+`mockImplementation` that returns the data we want our test to assert against.
+In effect, we are saying that we want axios.get('/users.json') to return a fake
+response.
 
 ```js
 // users.test.js
-import axios from 'axios'
-import Users from './users'
+import axios from 'axios';
+import Users from './users';
 
-jest.mock('axios')
+jest.mock('axios');
 
 test('should fetch users', () => {
-  const resp = Promise.resolve({ data: [{ name: 'Bob' }] })
-  axios.get.mockReturnValue(resp)
+  const resp = Promise.resolve({data: [{name: 'Bob'}]});
+  axios.get.mockReturnValue(resp);
 
-  // or you could use the follwing depending on your use case: 
+  // or you could use the follwing depending on your use case:
   // axios.get.mockImpementation(() => resp)
 
-  return Users.all().then(users => expect(users).toEqual(resp.data))
-})
+  return Users.all().then(users => expect(users).toEqual(resp.data));
+});
 ```
 
 ## Mock Implementations

--- a/docs/MockFunctions.md
+++ b/docs/MockFunctions.md
@@ -162,8 +162,8 @@ import Users from './users';
 jest.mock('axios');
 
 test('should fetch users', () => {
-  const resp = { data: [{ name: 'Bob' }] }
-  axios.get.mockReturnValue(Promise.resolve(resp)
+  const resp = {data: [{name: 'Bob'}]};
+  axios.get.mockReturnValue(Promise.resolve(resp));
 
   // or you could use the follwing depending on your use case:
   // axios.get.mockImpementation(() => Promise.resolve(resp))

--- a/docs/MockFunctions.md
+++ b/docs/MockFunctions.md
@@ -157,7 +157,10 @@ jest.mock('axios')
 
 test('should fetch users', () => {
   const resp = Promise.resolve({ data: [{ name: 'Bob' }] })
-  jest.spyOn(axios, 'get').mockImplementationOnce(() => resp)
+  axios.get.mockReturnValue(resp)
+
+  // or you could use the follwing depending on your use case: 
+  // axios.get.mockImpementation(() => resp)
 
   return Users.all().then(users => expect(users).toEqual(resp.data))
 })

--- a/docs/MockFunctions.md
+++ b/docs/MockFunctions.md
@@ -127,6 +127,42 @@ dependent component and configuring that, but the technique is the same. In
 these cases, try to avoid the temptation to implement logic inside of any
 function that's not directly being tested.
 
+## Mocking Modules
+
+Suppose we have a class that fetches users from our API. The class uses [axios](https://github.com/axios/axios) to call the API then returns the `data` attribute which contains all the users:
+
+```js
+// users.js
+import axios from 'axios'
+
+class Users {
+  static all() {
+    return axios.get('/users.json').then(resp => resp.data)
+  }
+}
+
+export default Users
+```
+
+Now, in order to test this method without actually hitting the API (and thus creating slow and fragile tests), we can use the `jest.mock(...)` function to automatically mock the axios module.
+
+Once we mock the module we can spy on the `.get` method and provide a `mockImplementation` that returns the data we want our test to assert against. In effect, we are saying that we want axios.get('/users.json') to return a fake response.
+
+```js
+// users.test.js
+import axios from 'axios'
+import Users from './users'
+
+jest.mock('axios')
+
+test('should fetch users', () => {
+  const resp = Promise.resolve({ data: [{ name: 'Bob' }] })
+  jest.spyOn(axios, 'get').mockImplementationOnce(() => resp)
+
+  return Users.all().then(users => expect(users).toEqual(resp.data))
+})
+```
+
 ## Mock Implementations
 
 Still, there are cases where it's useful to go beyond the ability to specify

--- a/docs/MockFunctions.md
+++ b/docs/MockFunctions.md
@@ -150,10 +150,9 @@ Now, in order to test this method without actually hitting the API (and thus
 creating slow and fragile tests), we can use the `jest.mock(...)` function to
 automatically mock the axios module.
 
-Once we mock the module we can spy on the `.get` method and provide a
-`mockImplementation` that returns the data we want our test to assert against.
-In effect, we are saying that we want axios.get('/users.json') to return a fake
-response.
+Once we mock the module we can provide a `mockReturnValue` for `.get` that
+returns the data we want our test to assert against. In effect, we are saying
+that we want axios.get('/users.json') to return a fake response.
 
 ```js
 // users.test.js
@@ -163,11 +162,11 @@ import Users from './users';
 jest.mock('axios');
 
 test('should fetch users', () => {
-  const resp = Promise.resolve({data: [{name: 'Bob'}]});
-  axios.get.mockReturnValue(resp);
+  const resp = { data: [{ name: 'Bob' }] }
+  axios.get.mockReturnValue(Promise.resolve(resp)
 
   // or you could use the follwing depending on your use case:
-  // axios.get.mockImpementation(() => resp)
+  // axios.get.mockImpementation(() => Promise.resolve(resp))
 
   return Users.all().then(users => expect(users).toEqual(resp.data));
 });

--- a/docs/MockFunctions.md
+++ b/docs/MockFunctions.md
@@ -163,7 +163,7 @@ jest.mock('axios');
 
 test('should fetch users', () => {
   const resp = {data: [{name: 'Bob'}]};
-  axios.get.mockReturnValue(Promise.resolve(resp));
+  axios.get.mockResolvedValue(resp);
 
   // or you could use the follwing depending on your use case:
   // axios.get.mockImpementation(() => Promise.resolve(resp))


### PR DESCRIPTION
## Summary

I find the current docs on mocking lacking in the area of mocking an existing module. The hope is this example will show people a simple, real-world way to mock node modules (whether from npm or in their own projects). 

I looked through all the docs and couldn't find a clear example like this so I hope it is helpful to others!

## Test plan

Not relevant
