### PR TITLE
tests(chalk): Force chalk to on in matcher tests for consistency

### DIFF
--- a/packages/expect/src/__tests__/matchers.test.js
+++ b/packages/expect/src/__tests__/matchers.test.js
@@ -9,6 +9,16 @@
 const {stringify} = require('jest-matcher-utils');
 const jestExpect = require('../');
 const Immutable = require('immutable');
+const chalk = require('chalk');
+let chalkEnabled = chalk.enabled;
+
+beforeAll(() => {
+  chalk.enabled = true;
+});
+
+afterAll(() => {
+  chalk.enabled = chalkEnabled;
+});
 
 it('should throw if passed two arguments', () => {
   expect(() => jestExpect('foo', 'bar')).toThrow(

--- a/packages/expect/src/__tests__/matchers.test.js
+++ b/packages/expect/src/__tests__/matchers.test.js
@@ -10,7 +10,7 @@ const {stringify} = require('jest-matcher-utils');
 const jestExpect = require('../');
 const Immutable = require('immutable');
 const chalk = require('chalk');
-let chalkEnabled = chalk.enabled;
+const chalkEnabled = chalk.enabled;
 
 beforeAll(() => {
   chalk.enabled = true;


### PR DESCRIPTION
## Summary

Follow up to #5646. Forces `chalk` to be turned on in matcher tests for
consistent snapshot output. Should fix tests on TravisCI.

## Test plan

Existing tests should pass. TravisCI should pass.