### PR TITLE
Fix Good First Issue link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,5 +200,5 @@ Send issues and pull requests with your ideas. For more information about
 contributing PRs and issues, see our
 [Contribution Guidelines](https://github.com/facebook/jest/blob/master/CONTRIBUTING.md).
 
-[Good First Issue](https://github.com/facebook/jest/labels/Good%20First%20Issue)
+[Good First Issue](https://github.com/facebook/jest/labels/Good%20First%20Issue%20%3Awave%3A)
 is a great starting point for PRs.


### PR DESCRIPTION
## Summary

The README.md points to the wrong "Good First Issue" link, there should be a 👋 in the link.

## Test plan

Not applicable.