### PR TITLE
Update `jest-editor-support` `Settings` to use spawn in shell option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 
 * `[jest-resolve]` Update node module resolution algorithm to correctly handle
   symlinked paths ([#5085](https://github.com/facebook/jest/pull/5085))
-* `[jest-editor-support]` Update `Settings` to use spawn in shell option ([#5658](https://github.com/facebook/jest/pull/5658))
+* `[jest-editor-support]` Update `Settings` to use spawn in shell option
+  ([#5658](https://github.com/facebook/jest/pull/5658))
 
 ## 22.4.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 * `[jest-resolve]` Update node module resolution algorithm to correctly handle
   symlinked paths ([#5085](https://github.com/facebook/jest/pull/5085))
+* `[jest-editor-support]` Update `Settings` to use spawn in shell option ([#5658](https://github.com/facebook/jest/pull/5658))
 
 ## 22.4.2
 

--- a/packages/jest-editor-support/index.d.ts
+++ b/packages/jest-editor-support/index.d.ts
@@ -170,7 +170,7 @@ export interface SnapshotMetadata {
   exists: boolean;
   name: string;
   node: {
-    loc: editor.Node
+    loc: Node
   };
   content?: string;
 }

--- a/packages/jest-editor-support/src/Settings.js
+++ b/packages/jest-editor-support/src/Settings.js
@@ -7,13 +7,12 @@
  * @flow
  */
 
-import type {Options} from './types';
+import type {Options, SpawnOptions} from './types';
 
 import {ChildProcess} from 'child_process';
 import EventEmitter from 'events';
 import ProjectWorkspace from './project_workspace';
 import {createProcess} from './Process';
-import {SpawnOptions} from './types';
 
 // This class represents the the configuration of Jest's process
 // we want to start with the defaults then override whatever they output
@@ -41,6 +40,7 @@ export default class Settings extends EventEmitter {
   _createProcess: (
     workspace: ProjectWorkspace,
     args: Array<string>,
+    options: SpawnOptions,
   ) => ChildProcess;
   configs: ConfigRepresentations;
   settings: ConfigRepresentation;
@@ -51,7 +51,7 @@ export default class Settings extends EventEmitter {
     super();
     this.workspace = workspace;
     this._createProcess = (options && options.createProcess) || createProcess;
-    this.spawnOptions = {shell: options.shell};
+    this.spawnOptions = {shell: options && options.shell};
 
     // Defaults for a Jest project
     this.settings = {
@@ -63,8 +63,6 @@ export default class Settings extends EventEmitter {
   }
 
   getConfigs(completed: any) {
-    const args = ['--showConfig'];
-    const options = this.spawnOptions;
     this.getConfigProcess = this._createProcess(
       this.workspace,
       ['--showConfig'],

--- a/packages/jest-editor-support/src/Settings.js
+++ b/packages/jest-editor-support/src/Settings.js
@@ -13,6 +13,7 @@ import {ChildProcess} from 'child_process';
 import EventEmitter from 'events';
 import ProjectWorkspace from './project_workspace';
 import {createProcess} from './Process';
+import {SpawnOptions} from './types';
 
 // This class represents the the configuration of Jest's process
 // we want to start with the defaults then override whatever they output
@@ -44,11 +45,13 @@ export default class Settings extends EventEmitter {
   configs: ConfigRepresentations;
   settings: ConfigRepresentation;
   workspace: ProjectWorkspace;
+  spawnOptions: SpawnOptions;
 
   constructor(workspace: ProjectWorkspace, options?: Options) {
     super();
     this.workspace = workspace;
     this._createProcess = (options && options.createProcess) || createProcess;
+    this.spawnOptions = {shell: options.shell};
 
     // Defaults for a Jest project
     this.settings = {
@@ -60,9 +63,13 @@ export default class Settings extends EventEmitter {
   }
 
   getConfigs(completed: any) {
-    this.getConfigProcess = this._createProcess(this.workspace, [
-      '--showConfig',
-    ]);
+    const args = ['--showConfig'];
+    const options = this.spawnOptions;
+    this.getConfigProcess = this._createProcess(
+      this.workspace,
+      ['--showConfig'],
+      this.spawnOptions,
+    );
 
     this.getConfigProcess.stdout.on('data', (data: Buffer) => {
       const settings = JSON.parse(data.toString());

--- a/packages/jest-editor-support/src/__tests__/settings.test.js
+++ b/packages/jest-editor-support/src/__tests__/settings.test.js
@@ -152,7 +152,11 @@ describe('Settings', () => {
       stdout: new EventEmitter(),
     });
     const spawnOptions = {shell: true};
-    const settings = new Settings(workspace, {createProcess, ...spawnOptions});
+    const options: any = {
+      createProcess,
+      ...spawnOptions,
+    };
+    const settings = new Settings(workspace, options);
     settings.getConfig(() => {});
 
     expect(createProcess).toBeCalledWith(

--- a/packages/jest-editor-support/src/__tests__/settings.test.js
+++ b/packages/jest-editor-support/src/__tests__/settings.test.js
@@ -21,9 +21,11 @@ describe('Settings', () => {
       'test',
       1000,
     );
-    const settings = new Settings(workspace);
+    const options = {shell: true};
+    const settings = new Settings(workspace, options);
     expect(settings.workspace).toEqual(workspace);
     expect(settings.settings).toEqual(expect.any(Object));
+    expect(settings.spawnOptions).toEqual(options);
   });
 
   it('[jest 20] reads and parses the config', () => {
@@ -131,6 +133,38 @@ describe('Settings', () => {
     settings.getConfigProcess.emit('close');
 
     expect(completed).toHaveBeenCalled();
+  });
+
+  it('passes command, args, and options to createProcess', () => {
+    const localJestMajorVersion = 1000;
+    const pathToConfig = 'test';
+    const pathToJest = 'path_to_jest';
+    const rootPath = 'root_path';
+
+    const workspace = new ProjectWorkspace(
+      rootPath,
+      pathToJest,
+      pathToConfig,
+      localJestMajorVersion,
+    );
+    const createProcess = jest.fn().mockReturnValue({
+      on: () => {},
+      stdout: new EventEmitter(),
+    });
+    const spawnOptions = {shell: true};
+    const settings = new Settings(workspace, {createProcess, ...spawnOptions});
+    settings.getConfig(() => {});
+
+    expect(createProcess).toBeCalledWith(
+      {
+        localJestMajorVersion,
+        pathToConfig,
+        pathToJest,
+        rootPath,
+      },
+      ['--showConfig'],
+      spawnOptions,
+    );
   });
 });
 

--- a/packages/jest-editor-support/src/__tests__/settings.test.js
+++ b/packages/jest-editor-support/src/__tests__/settings.test.js
@@ -152,10 +152,7 @@ describe('Settings', () => {
       stdout: new EventEmitter(),
     });
     const spawnOptions = {shell: true};
-    const options: any = {
-      createProcess,
-      ...spawnOptions,
-    };
+    const options: any = Object.assign({}, createProcess, spawnOptions);
     const settings = new Settings(workspace, options);
     settings.getConfig(() => {});
 


### PR DESCRIPTION
## Summary

We recently added support to the `jest-editor-support` Runner to spawn the process in a shell. This made it a bit easier to support Windows binaries in `node_modules/.bin`. Unfortunately we missed the other call in Settings. 

The other change to `index.d.ts` is a small change to fix a TypeScript error. You'll notice that the `editor` namespace is not defined anywhere in the file.


## Test plan

Tests have been added.