### PR TITLE
To throw matchers

### DIFF
--- a/packages/expect/src/__tests__/__snapshots__/to_throw_matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/to_throw_matchers.test.js.snap
@@ -79,6 +79,16 @@ Expected the function to throw an error matching:
 But it didn't throw anything."
 `;
 
+exports[`.toThrow() strings threw, but expected message is substring of error message 1`] = `
+"<dim>expect(</><red>function</><dim>).toThrow(</><green>string</><dim>)</>
+
+Expected the function to throw an error matching:
+  <green>\\"apple\\"</>
+Instead, it threw:
+<red>  Error      </>
+<red>      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</></>"
+`;
+
 exports[`.toThrow() strings threw, but message did not match 1`] = `
 "<dim>expect(</><red>function</><dim>).toThrow(</><green>string</><dim>)</>
 
@@ -176,6 +186,16 @@ exports[`.toThrowError() strings did not throw at all 1`] = `
 Expected the function to throw an error matching:
   <green>\\"apple\\"</>
 But it didn't throw anything."
+`;
+
+exports[`.toThrowError() strings threw, but expected message is substring of error message 1`] = `
+"<dim>expect(</><red>function</><dim>).toThrowError(</><green>string</><dim>)</>
+
+Expected the function to throw an error matching:
+  <green>\\"apple\\"</>
+Instead, it threw:
+<red>  Error      </>
+<red>      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</></>"
 `;
 
 exports[`.toThrowError() strings threw, but message did not match 1`] = `

--- a/packages/expect/src/__tests__/matchers.test.js
+++ b/packages/expect/src/__tests__/matchers.test.js
@@ -623,10 +623,10 @@ describe('.toContain(), .toContainEqual()', () => {
     jestExpect(iterable).toContain(2);
     jestExpect(iterable).toContainEqual(2);
     expect(() => jestExpect(iterable).not.toContain(1)).toThrowError(
-      'toContain',
+      /toContain/,
     );
     expect(() => jestExpect(iterable).not.toContainEqual(1)).toThrowError(
-      'toContainEqual',
+      /toContainEqual/,
     );
   });
 

--- a/packages/expect/src/__tests__/to_throw_matchers.test.js
+++ b/packages/expect/src/__tests__/to_throw_matchers.test.js
@@ -59,6 +59,14 @@ class Error {
         }).toThrowErrorMatchingSnapshot();
       });
 
+      test('threw, but expected message is substring of error message', () => {
+        expect(() => {
+          jestExpect(() => {
+            throw new Error('banana and apple');
+          })[toThrow]('apple');
+        }).toThrowErrorMatchingSnapshot();
+      });
+
       it('properly escapes strings when matching against errors', () => {
         jestExpect(() => {
           throw new TypeError('"this"? throws.');

--- a/packages/expect/src/to_throw_matchers.js
+++ b/packages/expect/src/to_throw_matchers.js
@@ -47,7 +47,9 @@ export const createMatcher = (matcherName: string, fromPromise?: boolean) => (
   }
 
   if (typeof expected === 'string') {
-    expected = new RegExp(escapeStrForRegex(expected));
+    // should match the exact string
+    const regExStr = `^${escapeStrForRegex(expected)}$`;
+    expected = new RegExp(regExStr);
   }
 
   if (typeof expected === 'function') {

--- a/packages/jest-runtime/src/__tests__/script_transformer.test.js
+++ b/packages/jest-runtime/src/__tests__/script_transformer.test.js
@@ -226,7 +226,7 @@ describe('ScriptTransformer', () => {
 
   it(
     "throws an error if `process` doesn't return a string or an object" +
-      'containing `code` key with processed string',
+      ' containing `code` key with processed string',
     () => {
       config = Object.assign(config, {
         transform: [['^.+\\.js$', 'passthrough-preprocessor']],

--- a/packages/jest-runtime/src/__tests__/script_transformer.test.js
+++ b/packages/jest-runtime/src/__tests__/script_transformer.test.js
@@ -244,7 +244,7 @@ describe('ScriptTransformer', () => {
           returnValue,
         );
         expect(() => scriptTransformer.transform(filePath, {})).toThrow(
-          'must return a string',
+          /must return a string/,
         );
       });
 


### PR DESCRIPTION
## Summary

This PR closes #4974 I submitted in November. It is a fix for `toThrow` matching if the expected string is a substring of the error message.

## Test plan

Added a new test case that will ensure this error is not re-introduced. 
