### PR TITLE
[WIP] feat: option to not escape strings in diff messages

### DIFF
--- a/packages/pretty-format/README.md
+++ b/packages/pretty-format/README.md
@@ -82,6 +82,7 @@ console.log(prettyFormat(onClick, options));
 | :------------------ | :-------- | :--------- | :------------------------------------------------------ |
 | `callToJSON`        | `boolean` | `true`     | call `toJSON` method (if it exists) on objects          |
 | `escapeRegex`       | `boolean` | `false`    | escape special characters in regular expressions        |
+| `escapeString`      | `boolean` | `true`     | escape special characters in strings                    |
 | `highlight`         | `boolean` | `false`    | highlight syntax with colors in terminal (some plugins) |
 | `indent`            | `number`  | `2`        | spaces in each level of indentation                     |
 | `maxDepth`          | `number`  | `Infinity` | levels to print in arrays, objects, elements, and so on |
@@ -232,6 +233,7 @@ Write `serialize` to return a string, given the arguments:
 | `callToJSON`        | `boolean` | call `toJSON` method (if it exists) on objects          |
 | `colors`            | `Object`  | escape codes for colors to highlight syntax             |
 | `escapeRegex`       | `boolean` | escape special characters in regular expressions        |
+| `escapeString`      | `boolean` | escape special characters in strings                    |
 | `indent`            | `string`  | spaces in each level of indentation                     |
 | `maxDepth`          | `number`  | levels to print in arrays, objects, elements, and so on |
 | `min`               | `boolean` | minimize added space: no indentation nor line breaks    |

--- a/packages/pretty-format/src/__tests__/pretty_format.test.js
+++ b/packages/pretty-format/src/__tests__/pretty_format.test.js
@@ -312,6 +312,11 @@ describe('prettyFormat()', () => {
     expect(prettyFormat(val)).toEqual('"\\"\'\\\\"');
   });
 
+  it("doesn't escape string with {excapeString: false}", () => {
+    const val = '"\'\\n';
+    expect(prettyFormat(val, {escapeString: false})).toEqual('""\'\\n"');
+  });
+
   it('prints a string with escapes', () => {
     expect(prettyFormat('"-"')).toEqual('"\\"-\\""');
     expect(prettyFormat('\\ \\\\')).toEqual('"\\\\ \\\\\\\\"');

--- a/packages/pretty-format/src/index.js
+++ b/packages/pretty-format/src/index.js
@@ -102,6 +102,7 @@ function printBasicValue(
   val: any,
   printFunctionName: boolean,
   escapeRegex: boolean,
+  escapeString: boolean,
 ): StringOrNull {
   if (val === true || val === false) {
     return '' + val;
@@ -119,7 +120,10 @@ function printBasicValue(
     return printNumber(val);
   }
   if (typeOf === 'string') {
-    return '"' + val.replace(/"|\\/g, '\\$&') + '"';
+    if (escapeString) {
+      return '"' + val.replace(/"|\\/g, '\\$&') + '"';
+    }
+    return '"' + val + '"';
   }
   if (typeOf === 'function') {
     return printFunction(val, printFunctionName);
@@ -322,6 +326,7 @@ function printer(
     val,
     config.printFunctionName,
     config.escapeRegex,
+    config.escapeString,
   );
   if (basicResult !== null) {
     return basicResult;
@@ -350,6 +355,7 @@ const DEFAULT_THEME_KEYS = Object.keys(DEFAULT_THEME);
 const DEFAULT_OPTIONS: Options = {
   callToJSON: true,
   escapeRegex: false,
+  escapeString: true,
   highlight: false,
   indent: 2,
   maxDepth: Infinity,
@@ -424,6 +430,11 @@ const getEscapeRegex = (options?: OptionsReceived) =>
     ? options.escapeRegex
     : DEFAULT_OPTIONS.escapeRegex;
 
+const getEscapeString = (options?: OptionsReceived) =>
+  options && options.escapeString !== undefined
+    ? options.escapeString
+    : DEFAULT_OPTIONS.escapeString;
+
 const getConfig = (options?: OptionsReceived): Config => ({
   callToJSON:
     options && options.callToJSON !== undefined
@@ -434,6 +445,7 @@ const getConfig = (options?: OptionsReceived): Config => ({
       ? getColorsHighlight(options)
       : getColorsEmpty(),
   escapeRegex: getEscapeRegex(options),
+  escapeString: getEscapeString(options),
   indent:
     options && options.min
       ? ''
@@ -475,6 +487,7 @@ function prettyFormat(val: any, options?: OptionsReceived): string {
     val,
     getPrintFunctionName(options),
     getEscapeRegex(options),
+    getEscapeString(options),
   );
   if (basicResult !== null) {
     return basicResult;

--- a/types/PrettyFormat.js
+++ b/types/PrettyFormat.js
@@ -38,6 +38,7 @@ export type ThemeReceived = {|
 export type Options = {|
   callToJSON: boolean,
   escapeRegex: boolean,
+  escapeString: boolean,
   highlight: boolean,
   indent: number,
   maxDepth: number,
@@ -50,6 +51,7 @@ export type Options = {|
 export type OptionsReceived = {|
   callToJSON?: boolean,
   escapeRegex?: boolean,
+  escapeString?: boolean,
   highlight?: boolean,
   indent?: number,
   maxDepth?: number,
@@ -63,6 +65,7 @@ export type Config = {|
   callToJSON: boolean,
   colors: Colors,
   escapeRegex: boolean,
+  escapeString: boolean,
   indent: string,
   maxDepth: number,
   min: boolean,


### PR DESCRIPTION
#5660 

This MR adds an option to disable special chars escaping in prettyFormat `prettyFormat(val, {escapeString: false})`.

But in order to solve #5660 I would need a way to set `escapeString` option in jest and pass it to [prettyFormat invocation](https://github.com/facebook/jest/blob/master/packages/jest-matcher-utils/src/index.js#L60). I would need a help, how to pass that config option there.

Adding a "prettyFormatOptions" parameter to a stack of methods is one way, but ... perhaps there is some singleton access to the Jest config?