### PR TITLE
[WIP] Make toThrow matcher pass only if Error-like object is returned from promises

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   errors to `it`/ `test` for invalid arguements.
 * `[jest-matcher-utils]` Add `isNot` option to `matcherHint` function
   ([#5512](https://github.com/facebook/jest/pull/5512))
+* `[expect]` Make toThrow matcher pass only if Error object is returned from
+  promises ([#5670](https://github.com/facebook/jest/pull/5670))
 
 ### Fixes
 
@@ -20,6 +22,8 @@
   ([#5692](https://github.com/facebook/jest/pull/5692))
 * `[jest-cli]` Fix update snapshot issue when using watchAll
   ([#5696](https://github.com/facebook/jest/pull/5696))
+* `[expect]` Fix rejects.not matcher
+  ([#5670](https://github.com/facebook/jest/pull/5670))
 
 ## 22.4.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
   ([#5512](https://github.com/facebook/jest/pull/5512))
 * `[expect]` Make toThrow matcher pass only if Error object is returned from
   promises ([#5670](https://github.com/facebook/jest/pull/5670))
+* `[expect]` Add isError to utils
+  ([#5670](https://github.com/facebook/jest/pull/5670))
 
 ### Fixes
 

--- a/packages/expect/src/__tests__/__snapshots__/to_throw_matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/to_throw_matchers.test.js.snap
@@ -43,6 +43,32 @@ Got:
   string: <green>\\"111\\"</>"
 `;
 
+exports[`.toThrow() promises/async did not throw at all 1`] = `
+[Error: [2mexpect([22m[31mfunction[39m[2m).toThrow([22m[32mundefined[39m[2m)[22m
+
+Expected the function to throw an error.
+But it didn't throw anything.]
+`;
+
+exports[`.toThrow() promises/async threw, but class did not match 1`] = `
+[Error: [2mexpect([22m[31mfunction[39m[2m).toThrow([22m[32mtype[39m[2m)[22m
+
+Expected the function to throw an error of type:
+  [32m"Err2"[39m
+Instead, it threw:
+[31m  Error      [39m
+[31m      [2mat jestExpect ([22mpackages/expect/src/__tests__/toThrowMatchers-test.js[2m:24:74)[22m[39m]
+`;
+
+exports[`.toThrow() promises/async threw, but should not have 1`] = `
+[Error: [2mexpect([22m[31mfunction[39m[2m).not.toThrow([22m[2m)[22m
+
+Expected the function not to throw an error.
+Instead, it threw:
+[31m  Error      [39m
+[31m      [2mat jestExpect ([22mpackages/expect/src/__tests__/toThrowMatchers-test.js[2m:24:74)[22m[39m]
+`;
+
 exports[`.toThrow() regexp did not throw at all 1`] = `
 "<dim>expect(</><red>function</><dim>).toThrow(</><green>regexp</><dim>)</>
 
@@ -140,6 +166,32 @@ Unexpected argument passed.
 Expected: <green>\\"string\\"</>, <green>\\"Error (type)\\"</> or <green>\\"regexp\\"</>.
 Got:
   string: <green>\\"111\\"</>"
+`;
+
+exports[`.toThrowError() promises/async did not throw at all 1`] = `
+[Error: [2mexpect([22m[31mfunction[39m[2m).toThrow([22m[32mundefined[39m[2m)[22m
+
+Expected the function to throw an error.
+But it didn't throw anything.]
+`;
+
+exports[`.toThrowError() promises/async threw, but class did not match 1`] = `
+[Error: [2mexpect([22m[31mfunction[39m[2m).toThrow([22m[32mtype[39m[2m)[22m
+
+Expected the function to throw an error of type:
+  [32m"Err2"[39m
+Instead, it threw:
+[31m  Error      [39m
+[31m      [2mat jestExpect ([22mpackages/expect/src/__tests__/toThrowMatchers-test.js[2m:24:74)[22m[39m]
+`;
+
+exports[`.toThrowError() promises/async threw, but should not have 1`] = `
+[Error: [2mexpect([22m[31mfunction[39m[2m).not.toThrow([22m[2m)[22m
+
+Expected the function not to throw an error.
+Instead, it threw:
+[31m  Error      [39m
+[31m      [2mat jestExpect ([22mpackages/expect/src/__tests__/toThrowMatchers-test.js[2m:24:74)[22m[39m]
 `;
 
 exports[`.toThrowError() regexp did not throw at all 1`] = `

--- a/packages/expect/src/__tests__/__snapshots__/to_throw_matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/to_throw_matchers.test.js.snap
@@ -43,14 +43,14 @@ Got:
   string: <green>\\"111\\"</>"
 `;
 
-exports[`.toThrow() promises/async did not throw at all 1`] = `
+exports[`.toThrow() promise/async throws if Error-like object is returned did not throw at all 1`] = `
 [Error: [2mexpect([22m[31mfunction[39m[2m).toThrow([22m[32mundefined[39m[2m)[22m
 
 Expected the function to throw an error.
 But it didn't throw anything.]
 `;
 
-exports[`.toThrow() promises/async threw, but class did not match 1`] = `
+exports[`.toThrow() promise/async throws if Error-like object is returned threw, but class did not match 1`] = `
 [Error: [2mexpect([22m[31mfunction[39m[2m).toThrow([22m[32mtype[39m[2m)[22m
 
 Expected the function to throw an error of type:
@@ -60,7 +60,7 @@ Instead, it threw:
 [31m      [2mat jestExpect ([22mpackages/expect/src/__tests__/toThrowMatchers-test.js[2m:24:74)[22m[39m]
 `;
 
-exports[`.toThrow() promises/async threw, but should not have 1`] = `
+exports[`.toThrow() promise/async throws if Error-like object is returned threw, but should not have 1`] = `
 [Error: [2mexpect([22m[31mfunction[39m[2m).not.toThrow([22m[2m)[22m
 
 Expected the function not to throw an error.
@@ -168,14 +168,14 @@ Got:
   string: <green>\\"111\\"</>"
 `;
 
-exports[`.toThrowError() promises/async did not throw at all 1`] = `
+exports[`.toThrowError() promise/async throws if Error-like object is returned did not throw at all 1`] = `
 [Error: [2mexpect([22m[31mfunction[39m[2m).toThrow([22m[32mundefined[39m[2m)[22m
 
 Expected the function to throw an error.
 But it didn't throw anything.]
 `;
 
-exports[`.toThrowError() promises/async threw, but class did not match 1`] = `
+exports[`.toThrowError() promise/async throws if Error-like object is returned threw, but class did not match 1`] = `
 [Error: [2mexpect([22m[31mfunction[39m[2m).toThrow([22m[32mtype[39m[2m)[22m
 
 Expected the function to throw an error of type:
@@ -185,7 +185,7 @@ Instead, it threw:
 [31m      [2mat jestExpect ([22mpackages/expect/src/__tests__/toThrowMatchers-test.js[2m:24:74)[22m[39m]
 `;
 
-exports[`.toThrowError() promises/async threw, but should not have 1`] = `
+exports[`.toThrowError() promise/async throws if Error-like object is returned threw, but should not have 1`] = `
 [Error: [2mexpect([22m[31mfunction[39m[2m).not.toThrow([22m[2m)[22m
 
 Expected the function not to throw an error.

--- a/packages/expect/src/__tests__/is_error.test.js
+++ b/packages/expect/src/__tests__/is_error.test.js
@@ -1,0 +1,45 @@
+/**
+ * @jest-environment jsdom
+ */
+/* eslint-env browser */
+
+import {isError} from '../utils';
+
+// Copied from https://github.com/graingert/angular.js/blob/a43574052e9775cbc1d7dd8a086752c979b0f020/test/AngularSpec.js#L1883
+describe('isError', () => {
+  function testErrorFromDifferentContext(createError) {
+    const iframe = document.createElement('iframe');
+    document.body.appendChild(iframe);
+    try {
+      const error = createError(iframe.contentWindow);
+      expect(isError(error)).toBe(true);
+    } finally {
+      iframe.parentElement.removeChild(iframe);
+    }
+  }
+
+  it('should not assume objects are errors', () => {
+    const fakeError = {message: 'A fake error', stack: 'no stack here'};
+    expect(isError(fakeError)).toBe(false);
+  });
+
+  it('should detect simple error instances', () => {
+    expect(isError(new Error())).toBe(true);
+  });
+
+  it('should detect errors from another context', () => {
+    testErrorFromDifferentContext(win => {
+      return new win.Error();
+    });
+  });
+
+  it('should detect DOMException errors from another context', () => {
+    testErrorFromDifferentContext(win => {
+      try {
+        win.document.querySelectorAll('');
+      } catch (e) {
+        return e;
+      }
+    });
+  });
+});

--- a/packages/expect/src/__tests__/to_throw_matchers.test.js
+++ b/packages/expect/src/__tests__/to_throw_matchers.test.js
@@ -146,11 +146,11 @@ class customError extends Error {
       });
     });
 
-    describe('promises/async', () => {
+    describe('promise/async throws if Error-like object is returned', () => {
       const asyncFn = async (shouldThrow?: boolean, resolve?: boolean) => {
         let err;
         if (shouldThrow) {
-          err = new Err('async apple');
+          err = new Err('apple');
         }
         if (resolve) {
           return await Promise.resolve(err || 'apple');
@@ -160,16 +160,20 @@ class customError extends Error {
       };
 
       test('passes', async () => {
-        expect.assertions(22);
+        expect.assertions(24);
+        await jestExpect(Promise.reject(new Error())).rejects[toThrow]();
+
         await jestExpect(asyncFn(true)).rejects[toThrow]();
         await jestExpect(asyncFn(true)).rejects[toThrow](Err);
         await jestExpect(asyncFn(true)).rejects[toThrow](Error);
         await jestExpect(asyncFn(true)).rejects[toThrow]('apple');
-        await jestExpect(asyncFn(true)).rejects[toThrow](/apple/);
+        await jestExpect(asyncFn(true)).rejects[toThrow](/app/);
 
         await jestExpect(asyncFn(true)).rejects.not[toThrow](Err2);
         await jestExpect(asyncFn(true)).rejects.not[toThrow]('banana');
         await jestExpect(asyncFn(true)).rejects.not[toThrow](/banana/);
+
+        await jestExpect(asyncFn(true, true)).resolves[toThrow]();
 
         await jestExpect(asyncFn(false, true)).resolves.not[toThrow]();
         await jestExpect(asyncFn(false, true)).resolves.not[toThrow](Error);

--- a/packages/expect/src/__tests__/to_throw_matchers.test.js
+++ b/packages/expect/src/__tests__/to_throw_matchers.test.js
@@ -150,7 +150,7 @@ class customError extends Error {
       const asyncFn = async (shouldThrow?: boolean, resolve?: boolean) => {
         let err;
         if (shouldThrow) {
-          err = new Err('apple');
+          err = new Err('async apple');
         }
         if (resolve) {
           return await Promise.resolve(err || 'apple');

--- a/packages/expect/src/__tests__/to_throw_matchers.test.js
+++ b/packages/expect/src/__tests__/to_throw_matchers.test.js
@@ -11,8 +11,9 @@
 const jestExpect = require('../');
 
 // Custom Error class because node versions have different stack trace strings.
-class Error {
+class customError extends Error {
   constructor(message) {
+    super();
     this.message = message;
     this.name = 'Error';
     this.stack =
@@ -24,12 +25,12 @@ class Error {
 
 ['toThrowError', 'toThrow'].forEach(toThrow => {
   describe('.' + toThrow + '()', () => {
-    class Err extends Error {}
-    class Err2 extends Error {}
+    class Err extends customError {}
+    class Err2 extends customError {}
 
     test('to throw or not to throw', () => {
       jestExpect(() => {
-        throw new Error('apple');
+        throw new customError('apple');
       })[toThrow]();
       jestExpect(() => {}).not[toThrow]();
     });
@@ -37,10 +38,10 @@ class Error {
     describe('strings', () => {
       it('passes', () => {
         jestExpect(() => {
-          throw new Error('apple');
+          throw new customError('apple');
         })[toThrow]('apple');
         jestExpect(() => {
-          throw new Error('banana');
+          throw new customError('banana');
         }).not[toThrow]('apple');
         jestExpect(() => {}).not[toThrow]('apple');
       });
@@ -54,7 +55,7 @@ class Error {
       test('threw, but message did not match', () => {
         expect(() => {
           jestExpect(() => {
-            throw new Error('apple');
+            throw new customError('apple');
           })[toThrow]('banana');
         }).toThrowErrorMatchingSnapshot();
       });
@@ -68,7 +69,7 @@ class Error {
       test('threw, but should not have', () => {
         expect(() => {
           jestExpect(() => {
-            throw new Error('apple');
+            throw new customError('apple');
           }).not[toThrow]('apple');
         }).toThrowErrorMatchingSnapshot();
       });
@@ -77,10 +78,10 @@ class Error {
     describe('regexp', () => {
       it('passes', () => {
         expect(() => {
-          throw new Error('apple');
+          throw new customError('apple');
         })[toThrow](/apple/);
         expect(() => {
-          throw new Error('banana');
+          throw new customError('banana');
         }).not[toThrow](/apple/);
         expect(() => {}).not[toThrow](/apple/);
       });
@@ -94,7 +95,7 @@ class Error {
       test('threw, but message did not match', () => {
         expect(() => {
           jestExpect(() => {
-            throw new Error('apple');
+            throw new customError('apple');
           })[toThrow](/banana/);
         }).toThrowErrorMatchingSnapshot();
       });
@@ -102,7 +103,7 @@ class Error {
       test('threw, but should not have', () => {
         expect(() => {
           jestExpect(() => {
-            throw new Error('apple');
+            throw new customError('apple');
           }).not[toThrow](/apple/);
         }).toThrowErrorMatchingSnapshot();
       });
@@ -115,7 +116,7 @@ class Error {
         })[toThrow](Err);
         jestExpect(() => {
           throw new Err();
-        })[toThrow](Error);
+        })[toThrow](customError);
         jestExpect(() => {
           throw new Err();
         }).not[toThrow](Err2);
@@ -142,6 +143,85 @@ class Error {
             throw new Err('apple');
           }).not[toThrow](Err);
         }).toThrowErrorMatchingSnapshot();
+      });
+    });
+
+    describe('promises/async', () => {
+      const asyncFn = async (shouldThrow?: boolean, resolve?: boolean) => {
+        let err;
+        if (shouldThrow) {
+          err = new Err('async apple');
+        }
+        if (resolve) {
+          return await Promise.resolve(err || 'apple');
+        } else {
+          return await Promise.reject(err || 'apple');
+        }
+      };
+
+      test('passes', async () => {
+        expect.assertions(22);
+        await jestExpect(asyncFn(true)).rejects[toThrow]();
+        await jestExpect(asyncFn(true)).rejects[toThrow](Err);
+        await jestExpect(asyncFn(true)).rejects[toThrow](Error);
+        await jestExpect(asyncFn(true)).rejects[toThrow]('apple');
+        await jestExpect(asyncFn(true)).rejects[toThrow](/apple/);
+
+        await jestExpect(asyncFn(true)).rejects.not[toThrow](Err2);
+        await jestExpect(asyncFn(true)).rejects.not[toThrow]('banana');
+        await jestExpect(asyncFn(true)).rejects.not[toThrow](/banana/);
+
+        await jestExpect(asyncFn(false, true)).resolves.not[toThrow]();
+        await jestExpect(asyncFn(false, true)).resolves.not[toThrow](Error);
+        await jestExpect(asyncFn(false, true)).resolves.not[toThrow]('apple');
+        await jestExpect(asyncFn(false, true)).resolves.not[toThrow](/apple/);
+        await jestExpect(asyncFn(false, true)).resolves.not[toThrow]('banana');
+        await jestExpect(asyncFn(false, true)).resolves.not[toThrow](/banana/);
+
+        await jestExpect(asyncFn()).rejects.not[toThrow]();
+        await jestExpect(asyncFn()).rejects.not[toThrow](Error);
+        await jestExpect(asyncFn()).rejects.not[toThrow]('apple');
+        await jestExpect(asyncFn()).rejects.not[toThrow](/apple/);
+        await jestExpect(asyncFn()).rejects.not[toThrow]('banana');
+        await jestExpect(asyncFn()).rejects.not[toThrow](/banana/);
+
+        // Works with nested functions inside promises
+        await jestExpect(
+          Promise.reject(() => {
+            throw new Error();
+          }),
+        ).rejects[toThrow]();
+        await jestExpect(Promise.reject(() => {})).rejects.not[toThrow]();
+      });
+
+      test('did not throw at all', async () => {
+        let err;
+        try {
+          await jestExpect(asyncFn()).rejects.toThrow();
+        } catch (error) {
+          err = error;
+        }
+        expect(err).toMatchSnapshot();
+      });
+
+      test('threw, but class did not match', async () => {
+        let err;
+        try {
+          await jestExpect(asyncFn(true)).rejects.toThrow(Err2);
+        } catch (error) {
+          err = error;
+        }
+        expect(err).toMatchSnapshot();
+      });
+
+      test('threw, but should not have', async () => {
+        let err;
+        try {
+          await jestExpect(asyncFn(true)).rejects.not.toThrow();
+        } catch (error) {
+          err = error;
+        }
+        expect(err).toMatchSnapshot();
       });
     });
 

--- a/packages/expect/src/index.js
+++ b/packages/expect/src/index.js
@@ -109,7 +109,7 @@ const expect = (actual: any, ...rest): ExpectationObject => {
     );
     expectation.rejects.not[name] = makeRejectMatcher(
       name,
-      matcher,
+      promiseMatcher,
       true,
       actual,
     );

--- a/packages/expect/src/to_throw_matchers.js
+++ b/packages/expect/src/to_throw_matchers.js
@@ -28,21 +28,24 @@ export const createMatcher = (matcherName: string, fromPromise?: boolean) => (
   const value = expected;
   let error;
 
-  if (fromPromise) {
+  if (fromPromise && actual instanceof Error) {
     error = actual;
   } else {
     if (typeof actual !== 'function') {
-      throw new Error(
-        matcherHint(matcherName, 'function', getType(value)) +
-          '\n\n' +
-          'Received value must be a function, but instead ' +
-          `"${getType(actual)}" was found`,
-      );
-    }
-    try {
-      actual();
-    } catch (e) {
-      error = e;
+      if (!fromPromise) {
+        throw new Error(
+          matcherHint(matcherName, 'function', getType(value)) +
+            '\n\n' +
+            'Received value must be a function, but instead ' +
+            `"${getType(actual)}" was found`,
+        );
+      }
+    } else {
+      try {
+        actual();
+      } catch (e) {
+        error = e;
+      }
     }
   }
 

--- a/packages/expect/src/to_throw_matchers.js
+++ b/packages/expect/src/to_throw_matchers.js
@@ -28,11 +28,20 @@ export const createMatcher = (matcherName: string, fromPromise?: boolean) => (
   const value = expected;
   let error;
 
-  if (
-    fromPromise &&
-    typeof actual.name === 'string' &&
-    typeof actual.message === 'string'
-  ) {
+  const isError = value => {
+    switch (Object.prototype.toString.call(value)) {
+      case '[object Error]':
+        return true;
+      case '[object Exception]':
+        return true;
+      case '[object DOMException]':
+        return true;
+      default:
+        return value instanceof Error;
+    }
+  };
+
+  if (fromPromise && isError(actual)) {
     error = actual;
   } else {
     if (typeof actual !== 'function') {

--- a/packages/expect/src/to_throw_matchers.js
+++ b/packages/expect/src/to_throw_matchers.js
@@ -20,6 +20,7 @@ import {
   printWithType,
 } from 'jest-matcher-utils';
 import {equals} from './jasmine_utils';
+import {isError} from './utils';
 
 export const createMatcher = (matcherName: string, fromPromise?: boolean) => (
   actual: Function,
@@ -27,19 +28,6 @@ export const createMatcher = (matcherName: string, fromPromise?: boolean) => (
 ) => {
   const value = expected;
   let error;
-
-  const isError = value => {
-    switch (Object.prototype.toString.call(value)) {
-      case '[object Error]':
-        return true;
-      case '[object Exception]':
-        return true;
-      case '[object DOMException]':
-        return true;
-      default:
-        return value instanceof Error;
-    }
-  };
 
   if (fromPromise && isError(actual)) {
     error = actual;

--- a/packages/expect/src/to_throw_matchers.js
+++ b/packages/expect/src/to_throw_matchers.js
@@ -28,7 +28,11 @@ export const createMatcher = (matcherName: string, fromPromise?: boolean) => (
   const value = expected;
   let error;
 
-  if (fromPromise && actual instanceof Error) {
+  if (
+    fromPromise &&
+    typeof actual.name === 'string' &&
+    typeof actual.message === 'string'
+  ) {
     error = actual;
   } else {
     if (typeof actual !== 'function') {

--- a/packages/expect/src/utils.js
+++ b/packages/expect/src/utils.js
@@ -195,3 +195,17 @@ export const partition = <T>(
 
   return result;
 };
+
+// Copied from https://github.com/graingert/angular.js/blob/a43574052e9775cbc1d7dd8a086752c979b0f020/src/Angular.js#L685-L693
+export const isError = (value: any) => {
+  switch (Object.prototype.toString.call(value)) {
+    case '[object Error]':
+      return true;
+    case '[object Exception]':
+      return true;
+    case '[object DOMException]':
+      return true;
+    default:
+      return value instanceof Error;
+  }
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Fix 1)
Fixes `rejects.not` path, where previously regular (non-promise) matcher was used.
![image](https://user-images.githubusercontent.com/26599181/36679673-1651d004-1b14-11e8-8754-4425ed241327.png)


Fix 2)
Current behavior of `toThrow` matcher allows to pass on any resolved/rejected promise. For example:
```
// Will successfully pass the test
test('Resolved promise', async () => {
  await expect(Promise.resolve('anything')).resolves.toThrow();
});
```

![image](https://user-images.githubusercontent.com/26599181/36680987-a3f5babc-1b17-11e8-8fe1-b8ad3e87252d.png)


I propose to pass `toThrow` tests only if promise resolves/rejects to `Error` object. Also see https://github.com/facebook/jest/pull/4884#issue-152281796

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Tests have been added and run successfully.
