### PR TITLE
Feature: Enable defining tests/suites asynchronously (inside of tests or lifecycle hooks)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### Features
 
+* `[jest-jasmine2]` Add an extra pass to the tree processor executing children
+  added _during_ the initial run, making it possible to define tests and suites
+  inside of other tests or their lifecycle hooks (except for `afterAll`) thus
+  enabling adding tests and suites asynchronously
 * `[jest-jasmine2]` Adds error throwing and descriptive errors to `it`/ `test`
   for invalid arguements. `[jest-circus]` Adds error throwing and descriptive
   errors to `it`/ `test` for invalid arguements.
@@ -14,6 +18,11 @@
   symlinked paths ([#5085](https://github.com/facebook/jest/pull/5085))
 * `[jest-editor-support]` Update `Settings` to use spawn in shell option
   ([#5658](https://github.com/facebook/jest/pull/5658))
+
+### Chore & Maintenance
+
+* `[jest-jasmine2]` Simplify `Env.execute` to setup and clean resources for the
+  top suite the same way as for all of the children suites.
 
 ## 22.4.2
 

--- a/integration-tests/__tests__/__snapshots__/globals.test.js.snap
+++ b/integration-tests/__tests__/__snapshots__/globals.test.js.snap
@@ -32,7 +32,7 @@ exports[`cannot test with no implementation 1`] = `
       4 |     test('test, no implementation');
       5 |   
       
-      at packages/jest-jasmine2/build/jasmine/Env.js:390:15
+      at packages/jest-jasmine2/build/jasmine/Env.js:412:15
       at __tests__/only-constructs.test.js:3:5
 
 "
@@ -59,7 +59,7 @@ exports[`cannot test with no implementation with expand arg 1`] = `
       4 |     test('test, no implementation');
       5 |   
       
-      at packages/jest-jasmine2/build/jasmine/Env.js:390:15
+      at packages/jest-jasmine2/build/jasmine/Env.js:412:15
       at __tests__/only-constructs.test.js:3:5
 
 "

--- a/integration-tests/__tests__/__snapshots__/nested_tests.test.js.snap
+++ b/integration-tests/__tests__/__snapshots__/nested_tests.test.js.snap
@@ -1,0 +1,368 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`runs tests and suites defined inside other tests 1`] = `
+"  console.log __tests__/nested-tests.test.js:30
+    a:sync > beforeAll > sync:passing
+
+  console.log __tests__/nested-tests.test.js:30
+    a:sync > beforeAll > sync:failing
+
+  console.log __tests__/nested-tests.test.js:30
+    a:sync > test1 > sync:passing
+
+  console.log __tests__/nested-tests.test.js:30
+    a:sync > test2 > sync:failing
+
+  console.log __tests__/nested-tests.test.js:86
+    a:sync > afterAll
+
+  console.log __tests__/nested-tests.test.js:18
+    b:async > beforeAll > async,passing
+
+  console.log __tests__/nested-tests.test.js:18
+    b:async > beforeAll > async,failing
+
+  console.log __tests__/nested-tests.test.js:18
+    b:async > test1 > async,passing
+
+  console.log __tests__/nested-tests.test.js:18
+    b:async > test2 > async,failing
+
+  console.log __tests__/nested-tests.test.js:86
+    b:async > afterAll
+
+  console.log __tests__/nested-tests.test.js:30
+    c:both:sync > beforeAll > sync:passing
+
+  console.log __tests__/nested-tests.test.js:30
+    c:both:sync > beforeAll > sync:failing
+
+  console.log __tests__/nested-tests.test.js:18
+    c:both:async > beforeAll > async,passing
+
+  console.log __tests__/nested-tests.test.js:18
+    c:both:async > beforeAll > async,failing
+
+  console.log __tests__/nested-tests.test.js:30
+    c:both:sync > test1 > sync:passing
+
+  console.log __tests__/nested-tests.test.js:30
+    c:both:sync > test2 > sync:failing
+
+  console.log __tests__/nested-tests.test.js:18
+    c:both:async > test1 > async,passing
+
+  console.log __tests__/nested-tests.test.js:18
+    c:both:async > test2 > async,failing
+
+  console.log __tests__/nested-tests.test.js:86
+    c:both:async > afterAll
+
+  console.log __tests__/nested-tests.test.js:86
+    c:both:sync > afterAll
+
+  console.log __tests__/nested-tests.test.js:30
+    d:withNested:sync > beforeAll > sync:passing
+
+  console.log __tests__/nested-tests.test.js:30
+    d:withNested:sync > beforeAll > sync:failing
+
+  console.log __tests__/nested-tests.test.js:30
+    beforeAll > describeSync > beforeAll > sync:passing
+
+  console.log __tests__/nested-tests.test.js:30
+    beforeAll > describeSync > beforeAll > sync:failing
+
+  console.log __tests__/nested-tests.test.js:30
+    beforeAll > describeSync > test1 > sync:passing
+
+  console.log __tests__/nested-tests.test.js:30
+    beforeAll > describeSync > test2 > sync:failing
+
+  console.log __tests__/nested-tests.test.js:86
+    beforeAll > describeSync > afterAll
+
+  console.log __tests__/nested-tests.test.js:30
+    beforeAll > describeAsync > beforeAll > sync:passing
+
+  console.log __tests__/nested-tests.test.js:30
+    beforeAll > describeAsync > beforeAll > sync:failing
+
+  console.log __tests__/nested-tests.test.js:30
+    beforeAll > describeAsync > test1 > sync:passing
+
+  console.log __tests__/nested-tests.test.js:30
+    beforeAll > describeAsync > test2 > sync:failing
+
+  console.log __tests__/nested-tests.test.js:86
+    beforeAll > describeAsync > afterAll
+
+  console.log __tests__/nested-tests.test.js:30
+    d:withNested:sync > test1 > sync:passing
+
+  console.log __tests__/nested-tests.test.js:30
+    d:withNested:sync > test2 > sync:failing
+
+  console.log __tests__/nested-tests.test.js:30
+    d:withNested:sync > describeSync > beforeAll > sync:passing
+
+  console.log __tests__/nested-tests.test.js:30
+    d:withNested:sync > describeSync > beforeAll > sync:failing
+
+  console.log __tests__/nested-tests.test.js:30
+    d:withNested:sync > describeSync > test1 > sync:passing
+
+  console.log __tests__/nested-tests.test.js:30
+    d:withNested:sync > describeSync > test2 > sync:failing
+
+  console.log __tests__/nested-tests.test.js:86
+    d:withNested:sync > describeSync > afterAll
+
+  console.log __tests__/nested-tests.test.js:30
+    d:withNested:sync > describeAsync > beforeAll > sync:passing
+
+  console.log __tests__/nested-tests.test.js:30
+    d:withNested:sync > describeAsync > beforeAll > sync:failing
+
+  console.log __tests__/nested-tests.test.js:30
+    d:withNested:sync > describeAsync > test1 > sync:passing
+
+  console.log __tests__/nested-tests.test.js:30
+    d:withNested:sync > describeAsync > test2 > sync:failing
+
+  console.log __tests__/nested-tests.test.js:86
+    d:withNested:sync > describeAsync > afterAll
+
+  console.log __tests__/nested-tests.test.js:86
+    d:withNested:sync > afterAll
+
+  console.log __tests__/nested-tests.test.js:18
+    e:withNested:async > beforeAll > async,passing
+
+  console.log __tests__/nested-tests.test.js:18
+    e:withNested:async > beforeAll > async,failing
+
+  console.log __tests__/nested-tests.test.js:18
+    beforeAll > describeSync > beforeAll > async,passing
+
+  console.log __tests__/nested-tests.test.js:18
+    beforeAll > describeSync > beforeAll > async,failing
+
+  console.log __tests__/nested-tests.test.js:18
+    beforeAll > describeSync > test1 > async,passing
+
+  console.log __tests__/nested-tests.test.js:18
+    beforeAll > describeSync > test2 > async,failing
+
+  console.log __tests__/nested-tests.test.js:86
+    beforeAll > describeSync > afterAll
+
+  console.log __tests__/nested-tests.test.js:18
+    beforeAll > describeAsync > beforeAll > async,passing
+
+  console.log __tests__/nested-tests.test.js:18
+    beforeAll > describeAsync > beforeAll > async,failing
+
+  console.log __tests__/nested-tests.test.js:18
+    beforeAll > describeAsync > test1 > async,passing
+
+  console.log __tests__/nested-tests.test.js:18
+    beforeAll > describeAsync > test2 > async,failing
+
+  console.log __tests__/nested-tests.test.js:86
+    beforeAll > describeAsync > afterAll
+
+  console.log __tests__/nested-tests.test.js:18
+    e:withNested:async > test1 > async,passing
+
+  console.log __tests__/nested-tests.test.js:18
+    e:withNested:async > test2 > async,failing
+
+  console.log __tests__/nested-tests.test.js:18
+    e:withNested:async > describeSync > beforeAll > async,passing
+
+  console.log __tests__/nested-tests.test.js:18
+    e:withNested:async > describeSync > beforeAll > async,failing
+
+  console.log __tests__/nested-tests.test.js:18
+    e:withNested:async > describeSync > test1 > async,passing
+
+  console.log __tests__/nested-tests.test.js:18
+    e:withNested:async > describeSync > test2 > async,failing
+
+  console.log __tests__/nested-tests.test.js:86
+    e:withNested:async > describeSync > afterAll
+
+  console.log __tests__/nested-tests.test.js:18
+    e:withNested:async > describeAsync > beforeAll > async,passing
+
+  console.log __tests__/nested-tests.test.js:18
+    e:withNested:async > describeAsync > beforeAll > async,failing
+
+  console.log __tests__/nested-tests.test.js:18
+    e:withNested:async > describeAsync > test1 > async,passing
+
+  console.log __tests__/nested-tests.test.js:18
+    e:withNested:async > describeAsync > test2 > async,failing
+
+  console.log __tests__/nested-tests.test.js:86
+    e:withNested:async > describeAsync > afterAll
+
+  console.log __tests__/nested-tests.test.js:86
+    e:withNested:async > afterAll
+
+  console.log __tests__/nested-tests.test.js:30
+    f:withNested:both:sync > beforeAll > sync:passing
+
+  console.log __tests__/nested-tests.test.js:30
+    f:withNested:both:sync > beforeAll > sync:failing
+
+  console.log __tests__/nested-tests.test.js:30
+    beforeAll > describeSync > beforeAll > sync:passing
+
+  console.log __tests__/nested-tests.test.js:30
+    beforeAll > describeSync > beforeAll > sync:failing
+
+  console.log __tests__/nested-tests.test.js:30
+    beforeAll > describeSync > test1 > sync:passing
+
+  console.log __tests__/nested-tests.test.js:30
+    beforeAll > describeSync > test2 > sync:failing
+
+  console.log __tests__/nested-tests.test.js:86
+    beforeAll > describeSync > afterAll
+
+  console.log __tests__/nested-tests.test.js:30
+    beforeAll > describeAsync > beforeAll > sync:passing
+
+  console.log __tests__/nested-tests.test.js:30
+    beforeAll > describeAsync > beforeAll > sync:failing
+
+  console.log __tests__/nested-tests.test.js:30
+    beforeAll > describeAsync > test1 > sync:passing
+
+  console.log __tests__/nested-tests.test.js:30
+    beforeAll > describeAsync > test2 > sync:failing
+
+  console.log __tests__/nested-tests.test.js:86
+    beforeAll > describeAsync > afterAll
+
+  console.log __tests__/nested-tests.test.js:18
+    f:withNested:both:async > beforeAll > async,passing
+
+  console.log __tests__/nested-tests.test.js:18
+    f:withNested:both:async > beforeAll > async,failing
+
+  console.log __tests__/nested-tests.test.js:18
+    beforeAll > describeSync > beforeAll > async,passing
+
+  console.log __tests__/nested-tests.test.js:18
+    beforeAll > describeSync > beforeAll > async,failing
+
+  console.log __tests__/nested-tests.test.js:18
+    beforeAll > describeSync > test1 > async,passing
+
+  console.log __tests__/nested-tests.test.js:18
+    beforeAll > describeSync > test2 > async,failing
+
+  console.log __tests__/nested-tests.test.js:86
+    beforeAll > describeSync > afterAll
+
+  console.log __tests__/nested-tests.test.js:18
+    beforeAll > describeAsync > beforeAll > async,passing
+
+  console.log __tests__/nested-tests.test.js:18
+    beforeAll > describeAsync > beforeAll > async,failing
+
+  console.log __tests__/nested-tests.test.js:18
+    beforeAll > describeAsync > test1 > async,passing
+
+  console.log __tests__/nested-tests.test.js:18
+    beforeAll > describeAsync > test2 > async,failing
+
+  console.log __tests__/nested-tests.test.js:86
+    beforeAll > describeAsync > afterAll
+
+  console.log __tests__/nested-tests.test.js:30
+    f:withNested:both:sync > test1 > sync:passing
+
+  console.log __tests__/nested-tests.test.js:30
+    f:withNested:both:sync > test2 > sync:failing
+
+  console.log __tests__/nested-tests.test.js:30
+    f:withNested:both:sync > describeSync > beforeAll > sync:passing
+
+  console.log __tests__/nested-tests.test.js:30
+    f:withNested:both:sync > describeSync > beforeAll > sync:failing
+
+  console.log __tests__/nested-tests.test.js:30
+    f:withNested:both:sync > describeSync > test1 > sync:passing
+
+  console.log __tests__/nested-tests.test.js:30
+    f:withNested:both:sync > describeSync > test2 > sync:failing
+
+  console.log __tests__/nested-tests.test.js:86
+    f:withNested:both:sync > describeSync > afterAll
+
+  console.log __tests__/nested-tests.test.js:30
+    f:withNested:both:sync > describeAsync > beforeAll > sync:passing
+
+  console.log __tests__/nested-tests.test.js:30
+    f:withNested:both:sync > describeAsync > beforeAll > sync:failing
+
+  console.log __tests__/nested-tests.test.js:30
+    f:withNested:both:sync > describeAsync > test1 > sync:passing
+
+  console.log __tests__/nested-tests.test.js:30
+    f:withNested:both:sync > describeAsync > test2 > sync:failing
+
+  console.log __tests__/nested-tests.test.js:86
+    f:withNested:both:sync > describeAsync > afterAll
+
+  console.log __tests__/nested-tests.test.js:18
+    f:withNested:both:async > test1 > async,passing
+
+  console.log __tests__/nested-tests.test.js:18
+    f:withNested:both:async > test2 > async,failing
+
+  console.log __tests__/nested-tests.test.js:18
+    f:withNested:both:async > describeSync > beforeAll > async,passing
+
+  console.log __tests__/nested-tests.test.js:18
+    f:withNested:both:async > describeSync > beforeAll > async,failing
+
+  console.log __tests__/nested-tests.test.js:18
+    f:withNested:both:async > describeSync > test1 > async,passing
+
+  console.log __tests__/nested-tests.test.js:18
+    f:withNested:both:async > describeSync > test2 > async,failing
+
+  console.log __tests__/nested-tests.test.js:86
+    f:withNested:both:async > describeSync > afterAll
+
+  console.log __tests__/nested-tests.test.js:18
+    f:withNested:both:async > describeAsync > beforeAll > async,passing
+
+  console.log __tests__/nested-tests.test.js:18
+    f:withNested:both:async > describeAsync > beforeAll > async,failing
+
+  console.log __tests__/nested-tests.test.js:18
+    f:withNested:both:async > describeAsync > test1 > async,passing
+
+  console.log __tests__/nested-tests.test.js:18
+    f:withNested:both:async > describeAsync > test2 > async,failing
+
+  console.log __tests__/nested-tests.test.js:86
+    f:withNested:both:async > describeAsync > afterAll
+
+  console.log __tests__/nested-tests.test.js:86
+    f:withNested:both:async > afterAll
+
+  console.log __tests__/nested-tests.test.js:86
+    f:withNested:both:sync > afterAll
+
+  console.log __tests__/nested-tests.test.js:115
+    { allSuitesCount: 16, allTestsCount: 152 }
+
+"
+`;

--- a/integration-tests/__tests__/nested_tests.test.js
+++ b/integration-tests/__tests__/nested_tests.test.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+'use strict';
+
+const runJest = require('../runJest');
+
+test('runs tests and suites defined inside other tests', () => {
+  const result = runJest('nested-tests');
+  expect(result.stdout).toMatch('allSuitesCount: 16');
+  expect(result.stdout).toMatch('allTestsCount: 152');
+  result.stderr.split('\n').forEach(line => {
+    // only tests with "failing" in the name should be failing
+    if (line.includes('✕ ')) {
+      expect(line).toMatch('failing');
+    } else if (line.includes('✓ ')) {
+      expect(line).not.toMatch('failing');
+    }
+  });
+  const afterAlls = result.stdout
+    .split('\n')
+    .filter(line => line.includes(' > afterAll'));
+  expect(afterAlls).toHaveLength(24);
+  expect(result.stderr).toMatch('48 failed, 104 passed, 152 total');
+  expect(result.stdout).toMatchSnapshot();
+  expect(result.status).toBe(1);
+});

--- a/integration-tests/nested-tests/__tests__/nested-tests.test.js
+++ b/integration-tests/nested-tests/__tests__/nested-tests.test.js
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+let allTestsCount = 0;
+let allSuitesCount = 0;
+const delay = 1;
+
+const createTestAsync = (name, passing) => done => {
+  const fullName = `${name} > async,${passing ? 'passing' : 'failing'}`;
+  setTimeout(() => {
+    test(fullName, () => {
+      console.log(fullName);
+      expect(true).toBe(passing);
+    });
+    done();
+  }, delay);
+
+  allTestsCount++;
+};
+
+const createTestSync = (name, passing) => () => {
+  const fullName = `${name} > sync:${passing ? 'passing' : 'failing'}`;
+  test(fullName, () => {
+    console.log(fullName);
+    expect(true).toBe(passing);
+  });
+
+  allTestsCount++;
+};
+
+const createTestWithDescribeSync = (name, createTest) => () => {
+  describe(`${name} > describeSync (testCreatingSuite)`, () =>
+    createTestSet(`${name} > describeSync`, createTest));
+
+  allSuitesCount++;
+};
+const createTestWithDescribeAsync = (name, createTest) => done => {
+  setTimeout(() => {
+    describe(`${name} > describeAsync (testCreatingSuite)`, () =>
+      createTestSet(`${name} > describeAsync`, createTest));
+    done();
+  }, delay);
+
+  allSuitesCount++;
+};
+
+const createTestSet = (name, createTest, withSuite = []) => {
+  beforeAll(createTest(`${name} > beforeAll`, true));
+  beforeAll(createTest(`${name} > beforeAll`, false));
+  test(
+    `${name} > test1 (testCreatingTest)`,
+    createTest(`${name} > test1`, true)
+  );
+  allTestsCount++;
+  test(
+    `${name} > test2 (testCreatingTest)`,
+    createTest(`${name} > test2`, false)
+  );
+  allTestsCount++;
+
+  if (withSuite.includes('sync')) {
+    beforeAll(createTestWithDescribeSync('beforeAll', createTest));
+    test(
+      `${name} > describeSync (testCreatingTest)`,
+      createTestWithDescribeSync(name, createTest)
+    );
+    allTestsCount++;
+  }
+
+  if (withSuite.includes('async')) {
+    beforeAll(createTestWithDescribeAsync('beforeAll', createTest));
+    test(
+      `${name} > describeAsync (testCreatingTest)`,
+      createTestWithDescribeAsync(name, createTest)
+    );
+    allTestsCount++;
+  }
+
+  afterAll(() => {
+    console.log(`${name} > afterAll`);
+  });
+};
+
+describe('master', () => {
+  describe(`a:sync`, () => {
+    createTestSet('a:sync', createTestSync);
+  });
+  describe(`b:async`, () => {
+    createTestSet('b:async', createTestAsync);
+  });
+  describe(`c:both`, () => {
+    createTestSet('c:both:sync', createTestSync);
+    createTestSet('c:both:async', createTestAsync);
+  });
+  describe(`d:withNested:sync`, () => {
+    createTestSet('d:withNested:sync', createTestSync, ['async', 'sync']);
+  });
+  describe(`e:withNested:async`, () => {
+    createTestSet('e:withNested:async', createTestAsync, ['async', 'sync']);
+  });
+  describe(`f:withNested:both`, () => {
+    createTestSet('f:withNested:both:sync', createTestSync, ['async', 'sync']);
+    createTestSet('f:withNested:both:async', createTestAsync, [
+      'async',
+      'sync',
+    ]);
+  });
+  afterAll(() => {
+    console.log({
+      allSuitesCount,
+      allTestsCount,
+    });
+  });
+});

--- a/integration-tests/nested-tests/package.json
+++ b/integration-tests/nested-tests/package.json
@@ -1,0 +1,5 @@
+{
+  "jest": {
+    "testEnvironment": "node"
+  }
+}

--- a/packages/jest-jasmine2/src/jasmine/Env.js
+++ b/packages/jest-jasmine2/src/jasmine/Env.js
@@ -176,73 +176,38 @@ export default function(j$) {
         return j$.testPath;
       },
     });
-    defaultResourcesForRunnable(topSuite.id);
+
     currentDeclarationSuite = topSuite;
 
     this.topSuite = function() {
       return topSuite;
     };
 
-    this.execute = async function(runnablesToRun) {
-      if (!runnablesToRun) {
-        if (focusedRunnables.length) {
-          runnablesToRun = focusedRunnables;
-        } else {
-          runnablesToRun = [topSuite.id];
-        }
+    const uncaught = err => {
+      if (currentSpec) {
+        currentSpec.onException(err);
+        currentSpec.cancel();
+      } else {
+        console.error('Unhandled error');
+        console.error(err.stack);
       }
+    };
 
-      const uncaught = err => {
-        if (currentSpec) {
-          currentSpec.onException(err);
-          currentSpec.cancel();
-        } else {
-          console.error('Unhandled error');
-          console.error(err.stack);
-        }
-      };
-
+    let oldListenersException;
+    let oldListenersRejection;
+    const executionSetup = function() {
       // Need to ensure we are the only ones handling these exceptions.
-      const oldListenersException = process
-        .listeners('uncaughtException')
-        .slice();
-      const oldListenersRejection = process
-        .listeners('unhandledRejection')
-        .slice();
+      oldListenersException = process.listeners('uncaughtException').slice();
+      oldListenersRejection = process.listeners('unhandledRejection').slice();
 
       j$.process.removeAllListeners('uncaughtException');
       j$.process.removeAllListeners('unhandledRejection');
 
       j$.process.on('uncaughtException', uncaught);
       j$.process.on('unhandledRejection', uncaught);
+    };
 
-      reporter.jasmineStarted({totalSpecsDefined});
-
-      currentlyExecutingSuites.push(topSuite);
-
-      await treeProcessor({
-        nodeComplete(suite) {
-          if (!suite.disabled) {
-            clearResourcesForRunnable(suite.id);
-          }
-          currentlyExecutingSuites.pop();
-          reporter.suiteDone(suite.getResult());
-        },
-        nodeStart(suite) {
-          currentlyExecutingSuites.push(suite);
-          defaultResourcesForRunnable(suite.id, suite.parentSuite.id);
-          reporter.suiteStarted(suite.result);
-        },
-        queueRunnerFactory,
-        runnableIds: runnablesToRun,
-        tree: topSuite,
-      });
-      clearResourcesForRunnable(topSuite.id);
-      currentlyExecutingSuites.pop();
-      reporter.jasmineDone({
-        failedExpectations: topSuite.result.failedExpectations,
-      });
-
+    const executionTeardown = function() {
       j$.process.removeListener('uncaughtException', uncaught);
       j$.process.removeListener('unhandledRejection', uncaught);
 
@@ -254,6 +219,60 @@ export default function(j$) {
       oldListenersRejection.forEach(listener => {
         j$.process.on('unhandledRejection', listener);
       });
+    };
+
+    this.execute = async function(runnablesToRun, suiteTree = topSuite) {
+      if (!runnablesToRun) {
+        if (focusedRunnables.length) {
+          runnablesToRun = focusedRunnables;
+        } else {
+          runnablesToRun = [suiteTree.id];
+        }
+      }
+
+      if (currentlyExecutingSuites.length === 0) {
+        executionSetup();
+      }
+
+      const lastDeclarationSuite = currentDeclarationSuite;
+
+      await treeProcessor({
+        nodeComplete(suite) {
+          if (!suite.disabled) {
+            clearResourcesForRunnable(suite.id);
+          }
+          currentlyExecutingSuites.pop();
+          if (suite === topSuite) {
+            reporter.jasmineDone({
+              failedExpectations: topSuite.result.failedExpectations,
+            });
+          } else {
+            reporter.suiteDone(suite.getResult());
+          }
+        },
+        nodeStart(suite) {
+          currentDeclarationSuite = suite;
+          currentlyExecutingSuites.push(suite);
+          defaultResourcesForRunnable(
+            suite.id,
+            suite.parentSuite && suite.parentSuite.id,
+          );
+          if (suite === topSuite) {
+            reporter.jasmineStarted({totalSpecsDefined});
+          } else {
+            reporter.suiteStarted(suite.result);
+          }
+        },
+        queueRunnerFactory,
+        runnableIds: runnablesToRun,
+        tree: suiteTree,
+      });
+
+      currentDeclarationSuite = lastDeclarationSuite;
+
+      if (currentlyExecutingSuites.length === 0) {
+        executionTeardown();
+      }
     };
 
     this.addReporter = function(reporterToAdd) {
@@ -447,18 +466,6 @@ export default function(j$) {
       );
       if (currentDeclarationSuite.markedPending) {
         spec.pend();
-      }
-
-      // When a test is defined inside another, jasmine will not run it.
-      // This check throws an error to warn the user about the edge-case.
-      if (currentSpec !== null) {
-        throw new Error(
-          'Tests cannot be nested. Test `' +
-            spec.description +
-            '` cannot run because it is nested within `' +
-            currentSpec.description +
-            '`.',
-        );
       }
       currentDeclarationSuite.addChild(spec);
       return spec;


### PR DESCRIPTION
## Context and motivation

It's currently not possible to add tests to a suite once the suite has been started. 

While [migrating Webpack's](https://github.com/webpack/webpack/pull/6565) test suite from Mocha to Jest, me and @ooflorent have encountered this issue, because of the pattern Webpack uses to test its builds:

```js
// pseudo-code to illustrate:
test('compile', (done) => {
  webpack.compile((err, compiledFileContent) => {
    if (err) done(err);

    const fn = vm.runInThisContext(
      `(function(require, module, exports, __dirname, __filename, it, expect) {
        // the compiled file contains test definitions,
        // which we want to add to the suite:
        ${compiledFileContent}
      })`
	);

    fn();
  })
});
```

The above call to webpack compiles a file containing a set of test definitions, then runs that file in the context of the suite. This pattern does work in Mocha (albeit by manually executing the suite), and I believe it's a very good solution to the problem at hand (testing compiled code).

I couldn't find anything in the `jest` ecosystem that would work just as well, without resorting to hacks, or having two-step testing, with separate configurations, test file generated from within tests, etc., which would add unnecessary complexity to the system.

Currently in `jest`, calling `it` or `test` within another `it` throws an error:

https://github.com/facebook/jest/blob/f6f0c9c8b8c418c98b49ca3bf90e248756072e74/packages/jest-jasmine2/src/jasmine/Env.js#L452-L462

Interestingly, the same check isn't applied to `fit` (forced test), but I get that it's probably because they're rarely used and not well documented. Just as the warning in the `it` definition states, these tests would not run. Similarly, it was possible to create suites with `describe` inside of a test, but it wouldn't run).

As a side note, I did find a hacky way to force such a test to run, but it runs the test without the blessing of the `jest`s runner:

```js
it('parent', (done) => {
  // "fit" because "it" throws:
  const spec = fit('child', () => {})
  spec.execute(done);
})
```

This was really hacky so I did a little digging into `jest`'s internals.

It turned out there was a pretty simple way to enable:
- defining tests/suites inside of tests
- defining tests/suites in lifecycle hooks
- defining tests asynchronously

It all boils down to adding an extra pass to the tree processor, which executes children added _during_ the initial run.

In this PR, I've also unified/cleaned-up the way the setup and teardown is done for the top suite - it's now done by the tree processor, just as for other suites, instead of having the code manually duplicated, as it was before.

All the changes in the PR are contained in the `jest-jasmine2` package.

Finally, note that nesting `test`s doesn't add children to the currently running `test` (since tests don't have children), but simply schedules that test to run within the context of the current suite. Similarly, defining a suite inside of a `test` would make it run just before the currently scheduled suite's `afterAll` hook (if one exists).

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

I've added a comprehensive test for all the newly supported scenarios:

- nested async test definition
- nested sync test definition
- doubly nested (both async and sync scenarios)
- adding tests to suite within `beforeAll`
