### PR TITLE
Improve the error message when 2 projects resolve to the same config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
   symlinked paths ([#5085](https://github.com/facebook/jest/pull/5085))
 * `[jest-editor-support]` Update `Settings` to use spawn in shell option
   ([#5658](https://github.com/facebook/jest/pull/5658))
+* `[jest-cli]` Improve the error message when 2 projects resolve to the same
+  config ([#5674](https://github.com/facebook/jest/pull/5674))
 
 ## 22.4.2
 

--- a/integration-tests/__tests__/multi_project_runner.test.js
+++ b/integration-tests/__tests__/multi_project_runner.test.js
@@ -12,6 +12,7 @@
 import runJest from '../runJest';
 import os from 'os';
 import path from 'path';
+import stripAnsi from 'strip-ansi';
 
 const {cleanup, extractSummary, writeFiles} = require('../Utils');
 const SkipOnWindows = require('../../scripts/SkipOnWindows');
@@ -303,12 +304,15 @@ test('resolves projects and their <rootDir> properly', () => {
     }),
   });
 
-  ({stderr} = runJest(DIR));
+  ({stderr} = stripAnsi(runJest(DIR)));
   expect(stderr).toMatch(
-    /One or more specified projects share the same config file/,
+    /Whoops! Two projects resolved to the same config path/,
   );
+  expect(stderr).toMatch(`${path.join(DIR, 'package.json')}`);
+  expect(stderr).toMatch(/Project 1|2: dir1/);
+  expect(stderr).toMatch(/Project 1|2: dir2/);
 
-  // praject with a directory/file that does not exist
+  // project with a directory/file that does not exist
   writeFiles(DIR, {
     'package.json': JSON.stringify({
       jest: {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Before:

<img width="554" alt="screen shot 2018-02-26 at 23 01 56" src="https://user-images.githubusercontent.com/5106466/36698036-132910b0-1b49-11e8-8cfd-b50a0aae4c5f.png">

After:

<img width="995" alt="screen shot 2018-02-26 at 22 59 23" src="https://user-images.githubusercontent.com/5106466/36698008-ff77516c-1b48-11e8-98f9-9aa91b5498cb.png">


## Test plan

Updated the existing test.

cc @pedrottimark 