### PR TITLE
don't use watchman in MPR test

### DIFF
--- a/integration-tests/__tests__/multi_project_runner.test.js
+++ b/integration-tests/__tests__/multi_project_runner.test.js
@@ -80,7 +80,7 @@ test('can pass projects or global config', () => {
   });
   let stderr;
 
-  ({stderr} = runJest(DIR));
+  ({stderr} = runJest(DIR, ['--no-watchman']));
   expect(stderr).toMatch(
     'The name `file1` was looked up in the Haste module map. It cannot be resolved, because there exists several different files',
   );
@@ -96,6 +96,7 @@ test('can pass projects or global config', () => {
   });
 
   ({stderr} = runJest(DIR, [
+    '--no-watchman',
     '-i',
     '--projects',
     'project1',
@@ -107,7 +108,12 @@ test('can pass projects or global config', () => {
   expect(result1.summary).toMatchSnapshot();
   expect(sortLines(result1.rest)).toMatchSnapshot();
 
-  ({stderr} = runJest(DIR, ['-i', '--config', 'global_config.js']));
+  ({stderr} = runJest(DIR, [
+    '--no-watchman',
+    '-i',
+    '--config',
+    'global_config.js',
+  ]));
   const result2 = extractSummary(stderr);
 
   expect(result2.summary).toMatchSnapshot();
@@ -136,6 +142,7 @@ test('"No tests found" message for projects', () => {
     'project2/jest.config.js': `module.exports = {rootDir: './'}`,
   });
   const {stdout: verboseOutput} = runJest(DIR, [
+    '--no-watchman',
     'xyz321',
     '--verbose',
     '--projects',
@@ -144,6 +151,7 @@ test('"No tests found" message for projects', () => {
   ]);
   expect(verboseOutput).toContain('Pattern: xyz321 - 0 matches');
   const {stdout} = runJest(DIR, [
+    '--no-watchman',
     'xyz321',
     '--projects',
     'project1',
@@ -178,7 +186,7 @@ test('projects can be workspaces with non-JS/JSON files', () => {
     'packages/project2/package.json': '{}',
   });
 
-  const {status, stdout, stderr} = runJest(DIR);
+  const {status, stdout, stderr} = runJest(DIR, ['--no-watchman']);
 
   expect(stderr).toContain('Test Suites: 2 passed, 2 total');
   expect(stderr).toContain('PASS packages/project1/__tests__/file1.test.js');
@@ -205,7 +213,7 @@ test('objects in project configuration', () => {
     'package.json': '{}',
   });
 
-  const {stdout, stderr, status} = runJest(DIR);
+  const {stdout, stderr, status} = runJest(DIR, ['--no-watchman']);
   expect(stderr).toContain('Test Suites: 2 passed, 2 total');
   expect(stderr).toContain('PASS __tests__/file1.test.js');
   expect(stderr).toContain('PASS __tests__/file2.test.js');
@@ -227,7 +235,7 @@ test('allows a single project', () => {
     'package.json': '{}',
   });
 
-  const {stdout, stderr, status} = runJest(DIR);
+  const {stdout, stderr, status} = runJest(DIR, ['--no-watchman']);
   expect(stderr).toContain('PASS __tests__/file1.test.js');
   expect(stderr).toContain('Test Suites: 1 passed, 1 total');
   expect(stdout).toEqual('');
@@ -266,7 +274,7 @@ test('resolves projects and their <rootDir> properly', () => {
   });
 
   let stderr;
-  ({stderr} = runJest(DIR));
+  ({stderr} = runJest(DIR, ['--no-watchman']));
 
   expect(stderr).toMatch('Ran all test suites in 2 projects.');
   expect(stderr).toMatch('PASS project1/__tests__/test.test.js');
@@ -283,7 +291,7 @@ test('resolves projects and their <rootDir> properly', () => {
     }),
   });
 
-  ({stderr} = runJest(DIR));
+  ({stderr} = runJest(DIR, ['--no-watchman']));
   expect(stderr).toMatch('Ran all test suites in 2 projects.');
   expect(stderr).toMatch('PASS project1/__tests__/test.test.js');
   expect(stderr).toMatch('PASS project2/__tests__/test.test.js');
@@ -304,7 +312,7 @@ test('resolves projects and their <rootDir> properly', () => {
     }),
   });
 
-  ({stderr} = stripAnsi(runJest(DIR)));
+  ({stderr} = stripAnsi(runJest(DIR, ['--no-watchman'])));
   expect(stderr).toMatch(
     /Whoops! Two projects resolved to the same config path/,
   );
@@ -325,7 +333,7 @@ test('resolves projects and their <rootDir> properly', () => {
     }),
   });
 
-  ({stderr} = runJest(DIR));
+  ({stderr} = runJest(DIR, ['--no-watchman']));
   expect(stderr).toMatch(
     `Can't find a root directory while resolving a config file path.`,
   );


### PR DESCRIPTION
this test always fails if watchman is installed on the machine (true for facebook laptops)
<img width="795" alt="screen shot 2018-02-26 at 6 11 39 pm" src="https://user-images.githubusercontent.com/940133/36706860-af334878-1b20-11e8-8987-f4f8992e3320.png">

this is obviously a monkeypatch.
would jest be open to adding an env variable check?
like
```js
const watchmanEnabled = !!process.env.JEST_USE_WATCHMAN;
```

this will remove the rest of the noise (we have a few dozen warnings during the full test run).
we can't easily remove them by passing `--no-watchman` because most of the tests run in the subprocess