### PR TITLE
don't use `master` as hg bookmark name

### DIFF
--- a/integration-tests/__tests__/jest_changed_files.test.js
+++ b/integration-tests/__tests__/jest_changed_files.test.js
@@ -306,7 +306,7 @@ test('gets changed files for hg', async () => {
       .sort(),
   ).toEqual(['file1.txt', 'file4.txt']);
 
-  run(`${HG} bookmark master`, DIR);
+  run(`${HG} bookmark main`, DIR);
   // Back up and develop on a different branch
   run(`${HG} checkout --rev=-2`, DIR);
 
@@ -317,9 +317,9 @@ test('gets changed files for hg', async () => {
   run(`${HG} commit -m "test4"`, DIR);
 
   ({changedFiles: files} = await getChangedFilesForRoots(roots, {
-    changedSince: 'master',
+    changedSince: 'main',
   }));
-  // Returns files from this branch but not ones that only exist on master
+  // Returns files from this branch but not ones that only exist on main
   expect(
     Array.from(files)
       .map(filePath => path.basename(filePath))


### PR DESCRIPTION
some versions of mercurial don't allow to use `master` as a bookmark name and this test failed on some machines. this PR renames the bookmark to `main` instead

<img width="814" alt="screen shot 2018-02-26 at 6 19 53 pm" src="https://user-images.githubusercontent.com/940133/36707217-357c4488-1b22-11e8-8ae7-f8f06c02cee9.png">
