### PR TITLE
exclude __mocks__ from the build step

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -37,7 +37,7 @@ const SRC_DIR = 'src';
 const BUILD_DIR = 'build';
 const BUILD_ES5_DIR = 'build-es5';
 const JS_FILES_PATTERN = '**/*.js';
-const IGNORE_PATTERN = '**/__tests__/**';
+const IGNORE_PATTERN = '**/__{tests,mocks}__/**';
 const PACKAGES_DIR = path.resolve(__dirname, '../packages');
 
 const INLINE_REQUIRE_BLACKLIST = /packages\/expect|(jest-(circus|diff|get-type|jasmine2|matcher-utils|message-util|regex-util|snapshot))|pretty-format\//;


### PR DESCRIPTION
currently we ignore files in `__tests__` when we run our build, but we still transform all the `__mocks__` files.
These files introduce a lot of noise during our CI builds
<img width="754" alt="screen shot 2018-02-26 at 6 35 05 pm" src="https://user-images.githubusercontent.com/940133/36707612-e5b7319a-1b23-11e8-906f-fc588b82dba5.png">

this PR adds `__mocks__` to the ignore list