### PR TITLE
Update MockFunctionAPI doc to be consistent like other API docs

### DIFF
--- a/docs/MockFunctionAPI.md
+++ b/docs/MockFunctionAPI.md
@@ -245,6 +245,8 @@ console.log(myMockFn(), myMockFn(), myMockFn(), myMockFn());
 
 ### `mockFn.mockResolvedValue(value)`
 
+##### available in Jest **22.2.0+**
+
 Simple sugar function for:
 
 ```js
@@ -262,6 +264,8 @@ test('async test', async () => {
 ```
 
 ### `mockFn.mockResolvedValueOnce(value)`
+
+##### available in Jest **22.2.0+**
 
 Simple sugar function for:
 
@@ -288,6 +292,8 @@ test('async test', async () => {
 
 ### `mockFn.mockRejectedValue(value)`
 
+##### available in Jest **22.2.0+**
+
 Simple sugar function for:
 
 ```js
@@ -305,6 +311,8 @@ test('async test', async () => {
 ```
 
 ### `mockFn.mockRejectedValueOnce(value)`
+
+##### available in Jest **22.2.0+**
 
 Simple sugar function for:
 


### PR DESCRIPTION
## Summary

To make the MockFunctionAPI doc to be consistent about which Jest version the new APIs are available like other API docs

## Test plan

- Run `yarn start` in the website directory.
- Browse to http://localhost:3000/jest/docs/en/mock-function-api.html using any browsers
- Check if the 4 methods **mockFn.mockResolvedValue(value)**, **mockFn.mockResolvedValueOnce(value)**, **mockFn.mockRejectedValue(value)**, **mockFn.mockRejectedValueOnce(value)** have the text `Available in Jest 22.2.0+`
