### PR TITLE
Example should use always the latest React version

### DIFF
--- a/examples/snapshot/package.json
+++ b/examples/snapshot/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "react": "15.4.2"
+    "react": "*"
   },
   "devDependencies": {
     "babel-jest": "*",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

The original `package.json` uses the latest version of all the packages except for React which is fixed to `15.4.2`. This now breaks the unit tests unless you upgrade to React 16+.

## Test plan

To test the changes:

```bash
cd examples/snapshot
yarn install
yarn jest
```
