### PR TITLE
Add rootDir to runtime FileNotFound error message (#5693)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   errors to `it`/ `test` for invalid arguements.
 * `[jest-matcher-utils]` Add `isNot` option to `matcherHint` function
   ([#5512](https://github.com/facebook/jest/pull/5512))
+* `[jest-config]` Add `<rootDir>` to runtime files not found error report
+  ([#5693](https://github.com/facebook/jest/pull/5693))
 
 ### Fixes
 

--- a/packages/jest-config/src/utils.js
+++ b/packages/jest-config/src/utils.js
@@ -40,7 +40,8 @@ export const resolve = (rootDir: string, key: string, filePath: Path) => {
     throw createValidationError(
       `  Module ${chalk.bold(filePath)} in the ${chalk.bold(
         key,
-      )} option was not found.`,
+      )} option was not found.
+         ${chalk.bold('<rootDir>')} is: ${rootDir}`,
     );
   }
 


### PR DESCRIPTION
## Summary

Printing out rootDir when runtime file is not found.

## Test plan
Given the following jest project configuration. Jest should log the `rootDir` to the standard output if the `setupFile` is not found.

```
{
	"setupFiles": [
		"<rootDir>/config/polyfills.js"
	]
}
```
