### PR TITLE
Set compact to false to avoid Babel warnings on large files (Fixes #5703)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@
   ([#5692](https://github.com/facebook/jest/pull/5692))
 * `[jest-cli]` Fix update snapshot issue when using watchAll
   ([#5696](https://github.com/facebook/jest/pull/5696))
+* `[jest-runtime]` Prevent Babel warnings on large files when running in
+  coverage mode
+  ([#5702](https://github.com/facebook/jest/pull/5702))
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,7 @@
   ([#5692](https://github.com/facebook/jest/pull/5692))
 * `[jest-cli]` Fix update snapshot issue when using watchAll
   ([#5696](https://github.com/facebook/jest/pull/5696))
-* `[jest-runtime]` Prevent Babel warnings on large files when running in
-  coverage mode
+* `[jest-runtime]` Prevent Babel warnings on large files
   ([#5702](https://github.com/facebook/jest/pull/5702))
 
 ### Chore & Maintenance

--- a/packages/babel-jest/src/index.js
+++ b/packages/babel-jest/src/index.js
@@ -72,7 +72,7 @@ const createTransformer = (options: any): Transformer => {
   };
 
   options = Object.assign({}, options, {
-    compact: true,
+    compact: false,
     plugins: (options && options.plugins) || [],
     presets: ((options && options.presets) || []).concat([jestPreset]),
     sourceMaps: 'both',

--- a/packages/babel-jest/src/index.js
+++ b/packages/babel-jest/src/index.js
@@ -72,6 +72,7 @@ const createTransformer = (options: any): Transformer => {
   };
 
   options = Object.assign({}, options, {
+    compact: true,
     plugins: (options && options.plugins) || [],
     presets: ((options && options.presets) || []).concat([jestPreset]),
     sourceMaps: 'both',

--- a/packages/jest-runtime/src/script_transformer.js
+++ b/packages/jest-runtime/src/script_transformer.js
@@ -158,11 +158,11 @@ export default class ScriptTransformer {
         [
           babelPluginIstanbul,
           {
+            compact: false,
             // files outside `cwd` will not be instrumented
             cwd: this._config.rootDir,
             exclude: [],
             useInlineSourceMaps: false,
-            compact: false
           },
         ],
       ],

--- a/packages/jest-runtime/src/script_transformer.js
+++ b/packages/jest-runtime/src/script_transformer.js
@@ -162,6 +162,7 @@ export default class ScriptTransformer {
             cwd: this._config.rootDir,
             exclude: [],
             useInlineSourceMaps: false,
+            compact: false
           },
         ],
       ],


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary
Our build system does not cache the results of building a project when it emits warnings. We noticed that when jest ran on some of our larger files, it was emitting a warning of the form: 
[BABEL] Note: The code generator has deoptimised the styling of "[Path to File]" as it exceeds the max of "500KB".

Digging in deeper shows that script_transformer.js runs babel for coverage mode, but does not respect any existing babel configurations. This particular babel warning is only emitted when [compact](https://babeljs.io/docs/usage/api/) is left with the default value of auto, setting it to either true or false would cause this warning to no longer be emitted. I set it to false since it matches the behavior of auto for most files.

## Test plan
Should be a reasonably safe change.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
