### PR TITLE
Add fsChange hook for plugins

### DIFF
--- a/packages/jest-cli/src/__tests__/watch.test.js
+++ b/packages/jest-cli/src/__tests__/watch.test.js
@@ -18,6 +18,31 @@ const watchPluginPath = `${__dirname}/__fixtures__/watch_plugin`;
 const watchPlugin2Path = `${__dirname}/__fixtures__/watch_plugin2`;
 let results;
 
+jest.mock(
+  '../search_source',
+  () =>
+    class {
+      constructor(context) {
+        this._context = context;
+      }
+
+      findMatchingTests(pattern) {
+        const paths = [
+          './path/to/file1-test.js',
+          './path/to/file2-test.js',
+        ].filter(path => path.match(pattern));
+
+        return {
+          tests: paths.map(path => ({
+            context: this._context,
+            duration: null,
+            path,
+          })),
+        };
+      }
+    },
+);
+
 jest.doMock('chalk', () => new chalk.constructor({enabled: false}));
 jest.doMock(
   '../run_jest',
@@ -272,6 +297,41 @@ describe('Watch mode flows', () => {
     await nextTick();
 
     expect(apply).toHaveBeenCalled();
+  });
+
+  it('allows WatchPlugins to hook into file system changes', async () => {
+    const fsChange = jest.fn();
+    const pluginPath = `${__dirname}/__fixtures__/plugin_path_fs_change`;
+    jest.doMock(
+      pluginPath,
+      () =>
+        class WatchPlugin {
+          apply(jestHooks) {
+            jestHooks.fsChange(fsChange);
+          }
+        },
+      {virtual: true},
+    );
+
+    watch(
+      Object.assign({}, globalConfig, {
+        rootDir: __dirname,
+        watchPlugins: [pluginPath],
+      }),
+      contexts,
+      pipe,
+      hasteMapInstances,
+      stdin,
+    );
+
+    expect(fsChange).toHaveBeenCalledWith({
+      projects: [
+        {
+          config: contexts[0].config,
+          testPaths: ['./path/to/file1-test.js', './path/to/file2-test.js'],
+        },
+      ],
+    });
   });
 
   it('triggers enter on a WatchPlugin when its key is pressed', async () => {

--- a/packages/jest-cli/src/__tests__/watch.test.js
+++ b/packages/jest-cli/src/__tests__/watch.test.js
@@ -300,14 +300,14 @@ describe('Watch mode flows', () => {
   });
 
   it('allows WatchPlugins to hook into file system changes', async () => {
-    const fsChange = jest.fn();
+    const fileChange = jest.fn();
     const pluginPath = `${__dirname}/__fixtures__/plugin_path_fs_change`;
     jest.doMock(
       pluginPath,
       () =>
         class WatchPlugin {
           apply(jestHooks) {
-            jestHooks.fsChange(fsChange);
+            jestHooks.fileChange(fileChange);
           }
         },
       {virtual: true},
@@ -324,7 +324,7 @@ describe('Watch mode flows', () => {
       stdin,
     );
 
-    expect(fsChange).toHaveBeenCalledWith({
+    expect(fileChange).toHaveBeenCalledWith({
       projects: [
         {
           config: contexts[0].config,

--- a/packages/jest-cli/src/jest_hooks.js
+++ b/packages/jest-cli/src/jest_hooks.js
@@ -19,27 +19,27 @@ type ShouldRunTestSuite = (testPath: string) => Promise<boolean>;
 type TestRunComplete = (results: AggregatedResult) => void;
 
 export type JestHookSubscriber = {
-  fsChange: (fn: FsChange) => void,
+  fileChange: (fn: FsChange) => void,
   shouldRunTestSuite: (fn: ShouldRunTestSuite) => void,
   testRunComplete: (fn: TestRunComplete) => void,
 };
 
 export type JestHookEmitter = {
-  fsChange: (fs: JestHookExposedFS) => void,
+  fileChange: (fs: JestHookExposedFS) => void,
   shouldRunTestSuite: (testPath: string) => Promise<boolean>,
   testRunComplete: (results: AggregatedResult) => void,
 };
 
 class JestHooks {
   _listeners: {
-    fsChange: Array<FsChange>,
+    fileChange: Array<FsChange>,
     shouldRunTestSuite: Array<ShouldRunTestSuite>,
     testRunComplete: Array<TestRunComplete>,
   };
 
   constructor() {
     this._listeners = {
-      fsChange: [],
+      fileChange: [],
       shouldRunTestSuite: [],
       testRunComplete: [],
     };
@@ -51,8 +51,8 @@ class JestHooks {
 
   getSubscriber(): JestHookSubscriber {
     return {
-      fsChange: fn => {
-        this._listeners.fsChange.push(fn);
+      fileChange: fn => {
+        this._listeners.fileChange.push(fn);
       },
       shouldRunTestSuite: fn => {
         this._listeners.shouldRunTestSuite.push(fn);
@@ -65,8 +65,8 @@ class JestHooks {
 
   getEmitter(): JestHookEmitter {
     return {
-      fsChange: fs =>
-        this._listeners.fsChange.forEach(listener => listener(fs)),
+      fileChange: fs =>
+        this._listeners.fileChange.forEach(listener => listener(fs)),
       shouldRunTestSuite: async testPath =>
         Promise.all(
           this._listeners.shouldRunTestSuite.map(listener =>

--- a/packages/jest-cli/src/jest_hooks.js
+++ b/packages/jest-cli/src/jest_hooks.js
@@ -8,35 +8,52 @@
  */
 
 import type {AggregatedResult} from 'types/TestResult';
+import type {ProjectConfig, Path} from 'types/Config';
 
+type JestHookExposedFS = {
+  projects: Array<{config: ProjectConfig, testPaths: Array<Path>}>,
+};
+
+type FsChange = (fs: JestHookExposedFS) => void;
 type ShouldRunTestSuite = (testPath: string) => Promise<boolean>;
 type TestRunComplete = (results: AggregatedResult) => void;
 
 export type JestHookSubscriber = {
+  fsChange: (fn: FsChange) => void,
   shouldRunTestSuite: (fn: ShouldRunTestSuite) => void,
   testRunComplete: (fn: TestRunComplete) => void,
 };
 
 export type JestHookEmitter = {
+  fsChange: (fs: JestHookExposedFS) => void,
   shouldRunTestSuite: (testPath: string) => Promise<boolean>,
   testRunComplete: (results: AggregatedResult) => void,
 };
 
 class JestHooks {
   _listeners: {
+    fsChange: Array<FsChange>,
     shouldRunTestSuite: Array<ShouldRunTestSuite>,
     testRunComplete: Array<TestRunComplete>,
   };
 
   constructor() {
     this._listeners = {
+      fsChange: [],
       shouldRunTestSuite: [],
       testRunComplete: [],
     };
   }
 
+  isUsed(hook: string) {
+    return this._listeners[hook] && this._listeners[hook].length;
+  }
+
   getSubscriber(): JestHookSubscriber {
     return {
+      fsChange: fn => {
+        this._listeners.fsChange.push(fn);
+      },
       shouldRunTestSuite: fn => {
         this._listeners.shouldRunTestSuite.push(fn);
       },
@@ -48,6 +65,8 @@ class JestHooks {
 
   getEmitter(): JestHookEmitter {
     return {
+      fsChange: fs =>
+        this._listeners.fsChange.forEach(listener => listener(fs)),
       shouldRunTestSuite: async testPath =>
         Promise.all(
           this._listeners.shouldRunTestSuite.map(listener =>

--- a/packages/jest-cli/src/watch.js
+++ b/packages/jest-cli/src/watch.js
@@ -155,12 +155,12 @@ export default function watch(
   let isWatchUsageDisplayed = false;
 
   const emitFsChange = () => {
-    if (hooks.isUsed('fsChange')) {
+    if (hooks.isUsed('fileChange')) {
       const projects = searchSources.map(({context, searchSource}) => ({
         config: context.config,
         testPaths: searchSource.findMatchingTests('').tests.map(t => t.path),
       }));
-      hooks.getEmitter().fsChange({projects});
+      hooks.getEmitter().fileChange({projects});
     }
   };
 

--- a/packages/jest-cli/src/watch.js
+++ b/packages/jest-cli/src/watch.js
@@ -154,6 +154,18 @@ export default function watch(
   let shouldDisplayWatchUsage = true;
   let isWatchUsageDisplayed = false;
 
+  const emitFsChange = () => {
+    if (hooks.isUsed('fsChange')) {
+      const projects = searchSources.map(({context, searchSource}) => ({
+        config: context.config,
+        testPaths: searchSource.findMatchingTests('').tests.map(t => t.path),
+      }));
+      hooks.getEmitter().fsChange({projects});
+    }
+  };
+
+  emitFsChange();
+
   hasteMapInstances.forEach((hasteMapInstance, index) => {
     hasteMapInstance.on('change', ({eventsQueue, hasteFS, moduleMap}) => {
       const validPaths = eventsQueue.filter(({filePath}) => {
@@ -176,6 +188,7 @@ export default function watch(
           context,
           searchSource: new SearchSource(context),
         };
+        emitFsChange();
         startRun(globalConfig);
       }
     });


### PR DESCRIPTION
## Summary

Feedback would be awesome!

If we want to enable stuff like test path typeahead in plugins, it seems that we would need to provide a way to get access to all the test files.


## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
