### PR TITLE
manual mocks do not automatically take precedence over modules unless automock is true

### DIFF
--- a/docs/ManualMocks.md
+++ b/docs/ManualMocks.md
@@ -53,8 +53,9 @@ accordingly.
 ```
 
 When a manual mock exists for a given module, Jest's module system will use that
-module when explicitly calling `jest.mock('moduleName')`. However, manual mocks
-will take precedence over node modules even if `jest.mock('moduleName')` is not
+module when explicitly calling `jest.mock('moduleName')`. However, when
+`automock` is set to `true`, the manual mock implementation will be used instead
+of the automatically created mock, even if `jest.mock('moduleName')` is not
 called. To opt out of this behavior you will need to explicitly call
 `jest.unmock('moduleName')` in tests that should use the actual module
 implementation.


### PR DESCRIPTION
demonstration code is here: https://github.com/antialias/jest-test/tree/automock-false-does-not-use-manual-mocks

```js
// jest.config.js
module.exports = {
  automock: false
}
```
```js
// src/a.js
module.exports = 'not mocked'
```
```js
// src/__mocks__/a.js
module.exports = 'mocked'
```
```js
// src/__tests__/a.js
const a = require('../a')
describe('a module', function () {
  it('is not mocked', function () {
    expect(a).toEqual('not mocked')
  })
})
```
