### PR TITLE
Enable single thread mode for runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
   ([#5670](https://github.com/facebook/jest/pull/5670))
 * `[expect]` Add inverse matchers (`expect.not.arrayContaining`, etc.,
   [#5517](https://github.com/facebook/jest/pull/5517))
+* `[jest-cli]` Add `isSerial` property that runners can expose to specify that
+  they can not run in parallel
+  [#5706](https://github.com/facebook/jest/pull/5706)
 
 ### Fixes
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -703,6 +703,10 @@ async runTests(
 ): Promise<void>
 ```
 
+If you need to restrict your test-runner to only run in serial rather then being
+executed in parallel your class should have the property `isSerial` to be set as
+`true`.
+
 ### `setupFiles` [array]
 
 Default: `[]`

--- a/packages/jest-cli/src/__tests__/test_scheduler.test.js
+++ b/packages/jest-cli/src/__tests__/test_scheduler.test.js
@@ -12,6 +12,20 @@ import TestScheduler from '../test_scheduler';
 import SummaryReporter from '../reporters/summary_reporter';
 
 jest.mock('../reporters/default_reporter');
+const mockSerialRunner = {
+  isSerial: true,
+  runTests: jest.fn(),
+};
+jest.mock('jest-runner-serial', () => jest.fn(() => mockSerialRunner), {
+  virtual: true,
+});
+
+const mockParallelRunner = {
+  runTests: jest.fn(),
+};
+jest.mock('jest-runner-parallel', () => jest.fn(() => mockParallelRunner), {
+  virtual: true,
+});
 
 test('.addReporter() .removeReporter()', () => {
   const scheduler = new TestScheduler({}, {});
@@ -20,4 +34,46 @@ test('.addReporter() .removeReporter()', () => {
   expect(scheduler._dispatcher._reporters).toContain(reporter);
   scheduler.removeReporter(SummaryReporter);
   expect(scheduler._dispatcher._reporters).not.toContain(reporter);
+});
+
+test('schedule tests run in parallel per default', async () => {
+  const scheduler = new TestScheduler({}, {});
+  const test = {
+    context: {
+      config: {
+        runner: 'jest-runner-parallel',
+      },
+      hasteFS: {
+        matchFiles: jest.fn(() => []),
+      },
+    },
+    path: './test/path.js',
+  };
+  const tests = [test, test];
+
+  await scheduler.scheduleTests(tests, {isInterrupted: jest.fn()});
+
+  expect(mockParallelRunner.runTests).toHaveBeenCalled();
+  expect(mockParallelRunner.runTests.mock.calls[0][5].serial).toBeFalsy();
+});
+
+test('schedule tests run in serial if the runner flags them', async () => {
+  const scheduler = new TestScheduler({}, {});
+  const test = {
+    context: {
+      config: {
+        runner: 'jest-runner-serial',
+      },
+      hasteFS: {
+        matchFiles: jest.fn(() => []),
+      },
+    },
+    path: './test/path.js',
+  };
+
+  const tests = [test, test];
+  await scheduler.scheduleTests(tests, {isInterrupted: jest.fn()});
+
+  expect(mockSerialRunner.runTests).toHaveBeenCalled();
+  expect(mockSerialRunner.runTests.mock.calls[0][5].serial).toBeTruthy();
 });

--- a/packages/jest-cli/src/test_scheduler.js
+++ b/packages/jest-cli/src/test_scheduler.js
@@ -192,7 +192,7 @@ export default class TestScheduler {
             onResult,
             onFailure,
             {
-              serial: runInBand,
+              serial: runInBand || Boolean(testRunners[runner].isSerial),
             },
           );
         }


### PR DESCRIPTION
## Summary

Some runners for tools that can not be run in parallel need a way
to specify that they should not be executed in parallel. This commits
adds this functionality. This closes #5706


## Test plan

Unit tests are included