### PR TITLE
Add support for debugging Jest inside the current file

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug Jest with current test file",
+      "program": "${workspaceFolder}/packages/jest-cli/bin/jest.js",
+      "args": ["--runInBand", "${file}"]
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,19 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "args": ["run", "watch"],
+      "command": "yarn",
+      "identifier": "watch",
+      "isBackground": true,
+      "type": "process",
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "label": "Babel Watcher"
+    }
+  ]
+}


### PR DESCRIPTION
Now you can trigger the watcher inside the editor, and use the debugging tool to look through the transpiled code. 

Couldn't get source maps working, gave it ~2 hours. Mainly it's a limitation on vscode's side that a sourcemap url change can only be reflected with one glob, e.g. `app/source/*` -> `app/dist/*`, but for yarn workspace/lerna repos, it needs to to be `app/packages/*/source/*`  -> `app/packages/*/dist/*`.

It still works well if you throw `debugger // eslint-disable-line` anywhere in the codebase though, and that was enough for me to be productive 👍 