### PR TITLE
[WIP] Initial support for passing back fixits with `--json`

### DIFF
--- a/packages/expect/src/__tests__/fixits.test.js
+++ b/packages/expect/src/__tests__/fixits.test.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import matchers from '../matchers';
+
+it('passes back a fixit when the values are two numbers', () => {
+  const toEqual = matchers['toEqual'];
+  const results = toEqual(1, 2);
+  expect(results.fixit).toBeTruthy();
+});
+
+it('passes a null fixit when the values are not two numbers', () => {
+  const toEqual = matchers['toEqual'];
+  const results = toEqual(1, '');
+  expect(results.fixit).toBeFalsy();
+});

--- a/packages/expect/src/fixits/__tests__/__snapshots__/to_equal.test.js.snap
+++ b/packages/expect/src/fixits/__tests__/__snapshots__/to_equal.test.js.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`returns fixit metadata for two numbers 1`] = `
+Object {
+  "expected": Object {
+    "value": 1,
+  },
+  "message": "Update toEquals expectation from 2 to 1",
+  "received": Object {
+    "value": 2,
+  },
+  "type": "number",
+}
+`;

--- a/packages/expect/src/fixits/__tests__/to_equal.test.js
+++ b/packages/expect/src/fixits/__tests__/to_equal.test.js
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import {fixitForToEqual} from '../to_equal';
+
+it('returns fixit metadata for two numbers', () => {
+  expect(fixitForToEqual(1, 2)).toMatchSnapshot();
+});
+
+it('returns null metadata for other types', () => {
+  expect(fixitForToEqual(1, '')).toBeFalsy();
+  expect(fixitForToEqual('1', '')).toBeFalsy();
+  expect(fixitForToEqual({}, [])).toBeFalsy();
+  expect(fixitForToEqual('', [])).toBeFalsy();
+});

--- a/packages/expect/src/fixits/to_equal.js
+++ b/packages/expect/src/fixits/to_equal.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {ExpectationFixit} from 'types/Matchers';
+
+const areBothNumbers = (l, r) => typeof l === 'number' && typeof r === 'number';
+
+export const fixitForToEqual = (
+  expected: any,
+  received: any,
+): ?ExpectationFixit => {
+  if (areBothNumbers(expected, received)) {
+    return {
+      expected: {
+        value: expected,
+      },
+      message: `Update toEquals expectation from ${received} to ${expected}`,
+      received: {
+        value: received,
+      },
+      type: 'number',
+    };
+  }
+
+  return undefined;
+};

--- a/packages/expect/src/matchers.js
+++ b/packages/expect/src/matchers.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import type {MatchersObject} from 'types/Matchers';
+import type {MatchersObject, ExpectationFixit} from 'types/Matchers';
 
 import diff from 'jest-diff';
 import getType from 'jest-get-type';
@@ -30,6 +30,7 @@ import {
   subsetEquality,
 } from './utils';
 import {equals} from './jasmine_utils';
+import {fixitForToEqual} from './fixits/to_equal';
 
 type ContainIterable =
   | Array<any>
@@ -376,10 +377,15 @@ const matchers: MatchersObject = {
           );
         };
 
+    let fixit: ?ExpectationFixit = null;
+    if (!pass) {
+      fixit = fixitForToEqual(received, expected);
+    }
+
     // Passing the the actual and expected objects so that a custom reporter
     // could access them, for example in order to display a custom visual diff,
     // or create a different error message
-    return {actual: received, expected, message, name: 'toEqual', pass};
+    return {actual: received, expected, fixit, message, name: 'toEqual', pass};
   },
 
   toHaveLength(received: any, length: number) {

--- a/packages/jest-circus/src/legacy_code_todo_rewrite/jest_adapter_init.js
+++ b/packages/jest-circus/src/legacy_code_todo_rewrite/jest_adapter_init.js
@@ -104,12 +104,12 @@ export const runAndTransformResultsToJestFormat = async ({
       name => name !== ROOT_DESCRIBE_BLOCK_NAME,
     );
     const title = ancestorTitles.pop();
-
     // $FlowFixMe Types are slightly incompatible and need to be refactored
     return {
       ancestorTitles,
       duration: testResult.duration,
       failureMessages: testResult.errors,
+      fixits: testResult.fixits,
       fullName: ancestorTitles.concat(title).join(' '),
       numPassingAsserts: 0,
       status,

--- a/packages/jest-circus/src/utils.js
+++ b/packages/jest-circus/src/utils.js
@@ -213,6 +213,7 @@ export const makeTestResults = (describeBlock: DescribeBlock): TestResults => {
     testResults.push({
       duration: test.duration,
       errors: test.errors.map(_formatError),
+      fixits: test.fixits,
       status,
       testPath,
     });

--- a/packages/jest-editor-support/src/types.js
+++ b/packages/jest-editor-support/src/types.js
@@ -7,6 +7,8 @@
  * @flow
  */
 
+import type {ExpectationFixit} from 'types/Matchers';
+
 export type Location = {
   column: number,
   line: number,
@@ -63,6 +65,7 @@ export type TestAssertionStatus = {
   shortMessage: ?string,
   terseMessage: ?string,
   line: ?number,
+  fixit: ?ExpectationFixit,
 };
 
 export type JestTotalResultsMeta = {

--- a/packages/jest-jasmine2/src/expectation_result_factory.js
+++ b/packages/jest-jasmine2/src/expectation_result_factory.js
@@ -57,6 +57,10 @@ export default function expectationResultFactory(options: Options) {
     actual: options.actual,
     error: options.error,
     expected: options.expected,
+    fixit:
+      options.error &&
+      options.error.matcherResult &&
+      options.error.matcherResult.fixit,
     matcherName: options.matcherName,
     message,
     passed: options.passed,

--- a/packages/jest-jasmine2/src/jasmine/Env.js
+++ b/packages/jest-jasmine2/src/jasmine/Env.js
@@ -541,6 +541,7 @@ export default function(j$) {
         actual: '',
         message,
         error: error && error.message ? error : null,
+        fixit: error && error.fixit,
       });
     };
   }

--- a/packages/jest-jasmine2/src/jasmine/Spec.js
+++ b/packages/jest-jasmine2/src/jasmine/Spec.js
@@ -65,6 +65,7 @@ export default function Spec(attrs: Object) {
     fullName: this.getFullName(),
     failedExpectations: [],
     passedExpectations: [],
+    fixits: [],
     pendingReason: '',
     testPath: attrs.getTestPath(),
   };
@@ -76,7 +77,11 @@ Spec.prototype.addExpectationResult = function(passed, data, isError) {
     this.result.passedExpectations.push(expectationResult);
   } else {
     this.result.failedExpectations.push(expectationResult);
-
+    if (expectationResult.fixit) {
+      debugger; // eslint-disable-line
+      this.result.fixits.push(expectationResult.fixit);
+    }
+    debugger; // eslint-disable-line
     if (this.throwOnExpectationFailure && !isError) {
       throw new ExpectationFailed();
     }

--- a/packages/jest-jasmine2/src/reporter.js
+++ b/packages/jest-jasmine2/src/reporter.js
@@ -7,8 +7,10 @@
  * @flow
  */
 
+import type {ExpectationFixit} from 'types/Matchers';
 import type {GlobalConfig, Path, ProjectConfig} from 'types/Config';
 import type {Environment} from 'types/Environment';
+
 import type {
   AssertionResult,
   FailedAssertion,
@@ -32,6 +34,7 @@ type SpecResult = {
   description: string,
   duration?: Milliseconds,
   failedExpectations: Array<FailedAssertion>,
+  fixits: Array<ExpectationFixit>,
   fullName: string,
   id: string,
   status: Status,
@@ -166,6 +169,7 @@ export default class Jasmine2Reporter {
       ancestorTitles,
       duration,
       failureMessages: [],
+      fixits: specResult.fixits,
       fullName: specResult.fullName,
       location,
       numPassingAsserts: 0, // Jasmine2 only returns an array of failed asserts.

--- a/packages/jest-jasmine2/src/setup_jest_globals.js
+++ b/packages/jest-jasmine2/src/setup_jest_globals.js
@@ -20,7 +20,7 @@ export type SetupOptions = {|
   testPath: Path,
 |};
 
-// Get suppressed errors form  jest-matchers that weren't throw during
+// Get suppressed errors from jest-matchers that weren't throw during
 // test execution and add them to the test result, potentially failing
 // a passing test.
 const addSuppressedErrors = result => {
@@ -34,6 +34,7 @@ const addSuppressedErrors = result => {
       // passing error for custom test reporters
       error,
       expected: '',
+      fixit: error.matcherResult && error.matcherResult.fixit,
       message: error.message,
       passed: false,
       stack: error.stack,
@@ -48,6 +49,7 @@ const addAssertionErrors = result => {
       return {
         actual,
         expected,
+        fixit: error.matcherResult && error.matcherResult.fixit,
         message: error.stack,
         passed: false,
       };

--- a/packages/jest-util/src/format_test_results.js
+++ b/packages/jest-util/src/format_test_results.js
@@ -61,6 +61,7 @@ function formatTestAssertion(
   const result: FormattedAssertionResult = {
     ancestorTitles: assertion.ancestorTitles,
     failureMessages: null,
+    fixits: assertion.fixits,
     fullName: assertion.fullName,
     location: assertion.location,
     status: assertion.status,

--- a/types/Circus.js
+++ b/types/Circus.js
@@ -7,6 +7,8 @@
  * @flow
  */
 
+import type {ExpectationFixit} from 'types/Matchers';
+
 export type DoneFn = (reason?: string | Error) => void;
 export type BlockFn = () => void;
 export type BlockName = string | Function;
@@ -94,6 +96,7 @@ export type TestStatus = 'pass' | 'fail' | 'skip';
 export type TestResult = {|
   duration: ?number,
   errors: Array<FormattedError>,
+  fixits: Array<ExpectationFixit>,
   status: TestStatus,
   testPath: Array<TestName>,
 |};
@@ -119,6 +122,7 @@ export type DescribeBlock = {|
 
 export type TestEntry = {|
   errors: Array<Exception>,
+  fixits: Array<ExpectationFixit>,
   fn: ?TestFn,
   mode: TestMode,
   name: TestName,

--- a/types/Matchers.js
+++ b/types/Matchers.js
@@ -10,9 +10,21 @@
 import type {Path} from 'types/Config';
 import type {SnapshotState} from 'jest-snapshot';
 
+export type ExpectationFixit = {
+  message: string,
+  type: 'number', // This will get built out as more types are supported
+  expected: {
+    value: any,
+  },
+  received: {
+    value: any,
+  },
+};
+
 export type ExpectationResult = {
   pass: boolean,
   message: () => string,
+  fixit?: ExpectationFixit,
 };
 
 export type RawMatcherFn = (

--- a/types/TestResult.js
+++ b/types/TestResult.js
@@ -7,6 +7,8 @@
  * @flow
  */
 
+import type {ExpectationFixit} from 'types/Matchers';
+
 import type {ConsoleBuffer} from './Console';
 
 export type RawFileCoverage = {|
@@ -97,6 +99,7 @@ export type AssertionResult = {|
   numPassingAsserts: number,
   status: Status,
   title: string,
+  fixits?: Array<ExpectationFixit>,
 |};
 
 export type FormattedAssertionResult = {
@@ -105,6 +108,7 @@ export type FormattedAssertionResult = {
   location: ?Callsite,
   status: Status,
   title: string,
+  fixits?: Array<ExpectationFixit>,
 };
 
 export type AggregatedResultWithoutCoverage = {
@@ -139,6 +143,7 @@ export type TestResult = {|
   coverage?: RawCoverage,
   displayName: ?string,
   failureMessage: ?string,
+  fixits: Array<ExpectationFixit>,
   leaks: boolean,
   memoryUsage?: Bytes,
   numFailingTests: number,


### PR DESCRIPTION
## Summary

I'd like the Jest runner to provide enough information so that jest-editor-support or a watcher plugin could provide an implementation of a fixit. Re: https://github.com/facebook/jest/issues/4442

So for this test:

```js
it('!!!!!!!!!', () => {
  expect(1).toEqual(2);
});
```

It would result in this JSON:

```json
{
  ...
  "testResults": [
    {
      "assertionResults": [
        {
          "ancestorTitles": [],
          "failureMessages": [
            "Error: ..."
          ],
          "fixits": [
            {
              "expected": {"value": 1},
              "message": "Update value from ${received} to ${expected}",
              "received": {"value": 2},
              "type": "number"
            }
          ],
          "fullName": "!!!!!!!!!",
          "location": null,
          "status": "failed",
          "title": "!!!!!!!!!"
        }
      ],
      "endTime": 1520173114536,
      "message":"...",
      "name":
        "/Users/orta/dev/projects/jest/jest2/packages/expect/src/fixits/__tests__/to_equal.test.js",
      "startTime": 1520173114238,
      "status": "failed",
      "summary": ""
    }
  ],
  "wasInterrupted": false
}
```

## Things that are still a bit ambiguous

The data here is going to need to be enough to have an AST runner dig through the tree to find the right `expect` and subsequent assertion.

So in this case:

 * Look for the `test`/`it` with the same name
 * Loop through all the matchers in that test for the one with the same name
 * Look at the matcher's parameters to see if there's a number primitive e.g. `1` not a variable
 * Use that to offer a way to edit the source code

I feel like the fixit should probably include the matcher name, and maybe I could even include the first line of the error'd stack trace in there to provide a way to verify that the change is on the right one 


```json
{
  "expected": {"value": 1},
  "message": "Update value from ${received} to ${expected}",
  "received": {"value": 2},
  "type": "number",

  "matcher": "toEqual"
  "line": 231
}
```


## Test plan

Would like to add an integration test to verify the whole system