### PR TITLE
docs: Expand changelog entry for #5367

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,8 +211,8 @@
   malformed source-map. ([#5405](https://github.com/facebook/jest/pull/5405)).
 * `[jest]` Add `import-local` to `jest` package.
   ([#5353](https://github.com/facebook/jest/pull/5353))
-* `[expect]` Support class instances in `.toHaveProperty()` matcher.
-  ([#5367](https://github.com/facebook/jest/pull/5367))
+* `[expect]` Support class instances in `.toHaveProperty()` and `.toMatchObject`
+  matcher. ([#5367](https://github.com/facebook/jest/pull/5367))
 * `[jest-cli]` Fix npm update command for snapshot summary.
   ([#5376](https://github.com/facebook/jest/pull/5376),
   [5389](https://github.com/facebook/jest/pull/5389/))

--- a/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -3840,6 +3840,15 @@ Received:
   <red>{\\"a\\": undefined}</>"
 `;
 
+exports[`toMatchObject() {pass: true} expect({}).toMatchObject({"a": undefined, "b": "b"}) 1`] = `
+"<dim>expect(</><red>received</><dim>).not.toMatchObject(</><green>expected</><dim>)</>
+
+Expected value not to match object:
+  <green>{\\"a\\": undefined, \\"b\\": \\"b\\"}</>
+Received:
+  <red>{}</>"
+`;
+
 exports[`toMatchObject() {pass: true} expect(2015-11-30T00:00:00.000Z).toMatchObject(2015-11-30T00:00:00.000Z) 1`] = `
 "<dim>expect(</><red>received</><dim>).not.toMatchObject(</><green>expected</><dim>)</>
 

--- a/packages/expect/src/__tests__/matchers.test.js
+++ b/packages/expect/src/__tests__/matchers.test.js
@@ -953,6 +953,15 @@ describe('.toHaveProperty()', () => {
 });
 
 describe('toMatchObject()', () => {
+  class Foo {
+    get a() {
+      return undefined;
+    }
+    get b() {
+      return 'b';
+    }
+  }
+
   [
     [{a: 'b', c: 'd'}, {a: 'b'}],
     [{a: 'b', c: 'd'}, {a: 'b', c: 'd'}],
@@ -974,6 +983,7 @@ describe('toMatchObject()', () => {
     [[], []],
     [new Error('foo'), new Error('foo')],
     [new Error('bar'), {message: 'bar'}],
+    [new Foo(), {a: undefined, b: 'b'}],
   ].forEach(([n1, n2]) => {
     it(`{pass: true} expect(${stringify(n1)}).toMatchObject(${stringify(
       n2,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary
Changes from #5367  also affected `toMatchObject`. I added some test cases to proof that behavior and expanded the changelog entry.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

## Future work
It is probably a good idea to show class instance properties when the objects did not match. Currently the diff only shows properties for which `.hasOwnProperty` is true.

https://github.com/facebook/jest/blob/74bf072e43789bf5bcfe85f2aa9492905c4d2e9a/packages/expect/src/utils.js#L93-L97