### PR TITLE
docs: mention Jest Puppeteer Preset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@
   ([#5648](https://github.com/facebook/jest/pull/5708))
 * `[docs]` Add docs on using `jest.mock(...)`
   ([#5648](https://github.com/facebook/jest/pull/5648))
+* `[docs]` Mention Jest Puppeteer Preset
+  ([#5722](https://github.com/facebook/jest/pull/5722))
 
 ## 22.4.2
 

--- a/docs/Puppeteer.md
+++ b/docs/Puppeteer.md
@@ -7,7 +7,28 @@ With the [Global Setup/Teardown](Configuration.md#globalsetup-string) and
 [Async Test Environment](Configuration.md#testenvironment-string) APIs, Jest can
 work smoothly with [puppeteer](https://github.com/GoogleChrome/puppeteer).
 
-## A jest-puppeteer example
+## Use Puppeteer Preset
+
+[Jest Puppeteer Preset](https://github.com/smooth-code/jest-puppeteer) provides
+all required configuration to run your tests using Puppeteer.
+
+1.  First install `jest-puppeteer-preset`
+
+```
+yarn add --dev jest-puppeteer-preset
+```
+
+2.  Specify preset in your Jest configuration:
+
+```json
+{
+  "preset": "jest-puppeteer-preset"
+}
+```
+
+See [documentation](https://github.com/smooth-code/jest-puppeteer).
+
+## Custom example
 
 The basic idea is to:
 


### PR DESCRIPTION
## Summary

At Smooth Code, we use Jest + Puppeteer testing in a lot of projects. I decided to open source our configuration under [Jest Puppeteer](https://github.com/smooth-code/jest-puppeteer).

I think it could be valuable to mention it in Puppeteer section since it makes Puppeteer testing easy.
