### PR TITLE
fix(expect): do not rely on 'instanceof RegExp'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@
 
 ### Fixes
 
+* `[expect]` Do not rely on `instanceof RegExp`, since it will not work for
+  RegExps created inside of a different VM
+  ([#5729](https://github.com/facebook/jest/pull/5729))
 * `[jest-resolve]` Update node module resolution algorithm to correctly handle
   symlinked paths ([#5085](https://github.com/facebook/jest/pull/5085))
 * `[jest-editor-support]` Update `Settings` to use spawn in shell option

--- a/integration-tests/__tests__/expect_in_vm.test.js
+++ b/integration-tests/__tests__/expect_in_vm.test.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+'use strict';
+
+const runJest = require('../runJest');
+
+test('expect works correctly with RegExps created inside a VM', () => {
+  const result = runJest('expect-in-vm');
+  expect(result.status).toBe(0);
+});

--- a/integration-tests/expect-in-vm/__tests__/expect-in-vm.test.js
+++ b/integration-tests/expect-in-vm/__tests__/expect-in-vm.test.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+const vm = require('vm');
+
+it('correctly expects RegExp inside a new VM context', () => {
+  const fn = vm.runInNewContext(
+    `(function(require, module, exports, __dirname, __filename, expect) {
+  expect('ab12cd').toMatch(/ab12cd/);
+})`,
+    global
+  );
+
+  const module = {
+    exports: {},
+  };
+
+  fn.call(
+    module.exports,
+    require,
+    module,
+    module.exports,
+    __dirname,
+    __filename,
+    expect
+  );
+});

--- a/integration-tests/expect-in-vm/package.json
+++ b/integration-tests/expect-in-vm/package.json
@@ -1,0 +1,5 @@
+{
+  "jest": {
+    "testEnvironment": "node"
+  }
+}

--- a/packages/expect/src/matchers.js
+++ b/packages/expect/src/matchers.js
@@ -518,7 +518,10 @@ const matchers: MatchersObject = {
       );
     }
 
-    if (!(expected instanceof RegExp) && !(typeof expected === 'string')) {
+    if (
+      !(expected && typeof expected.test === 'function') &&
+      !(typeof expected === 'string')
+    ) {
       throw new Error(
         matcherHint('[.not].toMatch', 'string', 'expected') +
           '\n\n' +

--- a/packages/expect/src/to_throw_matchers.js
+++ b/packages/expect/src/to_throw_matchers.js
@@ -57,9 +57,14 @@ export const createMatcher = (matcherName: string, fromPromise?: boolean) => (
   if (typeof expected === 'function') {
     return toThrowMatchingError(matcherName, error, expected);
   } else if (expected && typeof expected.test === 'function') {
-    return toThrowMatchingStringOrRegexp(matcherName, error, expected, value);
+    return toThrowMatchingStringOrRegexp(
+      matcherName,
+      error,
+      (expected: any),
+      value,
+    );
   } else if (expected && typeof expected === 'object') {
-    return toThrowMatchingErrorInstance(matcherName, error, expected);
+    return toThrowMatchingErrorInstance(matcherName, error, (expected: any));
   } else if (expected === undefined) {
     const pass = error !== undefined;
     return {

--- a/packages/expect/src/to_throw_matchers.js
+++ b/packages/expect/src/to_throw_matchers.js
@@ -56,7 +56,7 @@ export const createMatcher = (matcherName: string, fromPromise?: boolean) => (
 
   if (typeof expected === 'function') {
     return toThrowMatchingError(matcherName, error, expected);
-  } else if (expected instanceof RegExp) {
+  } else if (expected && typeof expected.test === 'function') {
     return toThrowMatchingStringOrRegexp(matcherName, error, expected, value);
   } else if (expected && typeof expected === 'object') {
     return toThrowMatchingErrorInstance(matcherName, error, expected);


### PR DESCRIPTION
## Summary

`instanceof RegExp` will not be true for RegExp objects created inside of a different NodeJS VM or Window.

This commit fixes this issue by checking for the existence of `test` function on the object instead.

## Test plan

Added integration test which otherwise failed without this fix.