### PR TITLE
Use valid glob pattern instead of micromatch-specific

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+package.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,7 @@
     "**/node_modules": true,
     "**/build": true
   },
-  "eslint.autoFixOnSave": true,
+  "editor.formatOnSave": true,
   "flow.useNPMPackagedFlow": true,
   "javascript.validate.enable": false,
   "jest.pathToJest": "yarn jest --",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,7 @@
     "**/node_modules": true,
     "**/build": true
   },
-  "editor.formatOnSave": true,
+  "eslint.autoFixOnSave": true,
   "flow.useNPMPackagedFlow": true,
   "javascript.validate.enable": false,
   "jest.pathToJest": "yarn jest --",

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -889,7 +889,7 @@ given to [jsdom](https://github.com/tmpvar/jsdom) such as
 
 ##### available in Jest **19.0.0+**
 
-(default: `[ '**/__tests__/**/*.js?(x)', '**/?(*.)(spec|test).js?(x)' ]`)
+(default: `[ '**/__tests__/**/*.js?(x)', '**/?(*.)+(spec|test).js?(x)' ]`)
 
 The glob patterns Jest uses to detect test files. By default it looks for `.js`
 and `.jsx` files inside of `__tests__` folders, as well as any files with a

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -17,6 +17,6 @@
     "transform": {
       "^.+\\.(ts|tsx)$": "<rootDir>/preprocessor.js"
     },
-    "testMatch": ["**/__tests__/*.(ts|tsx|js)"]
+    "testMatch": ["**/__tests__/*.+(ts|tsx|js)"]
   }
 }

--- a/integration-tests/__tests__/__snapshots__/show_config.test.js.snap
+++ b/integration-tests/__tests__/__snapshots__/show_config.test.js.snap
@@ -45,7 +45,7 @@ exports[`--showConfig outputs config info and exits 1`] = `
       \\"testLocationInResults\\": false,
       \\"testMatch\\": [
         \\"**/__tests__/**/*.js?(x)\\",
-        \\"**/?(*.)(spec|test).js?(x)\\"
+        \\"**/?(*.)+(spec|test).js?(x)\\"
       ],
       \\"testPathIgnorePatterns\\": [
         \\"/node_modules/\\"

--- a/integration-tests/typescript-coverage/__tests__/covered-test.ts
+++ b/integration-tests/typescript-coverage/__tests__/covered-test.ts
@@ -1,6 +1,6 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
 
-it('adds 1 + 2 to equal 3 in TScript', ()=> {
+it('adds 1 + 2 to equal 3 in TScript', () => {
   const sum = require('../covered.ts');
   expect(sum(1, 2)).toBe(3);
 });

--- a/integration-tests/typescript-coverage/covered.ts
+++ b/integration-tests/typescript-coverage/covered.ts
@@ -2,4 +2,4 @@
 
 export = function sum(a: number, b: number): number {
   return a + b;
-}
+};

--- a/integration-tests/typescript-coverage/package.json
+++ b/integration-tests/typescript-coverage/package.json
@@ -4,7 +4,7 @@
     "transform": {
       "^.+\\.(ts|js)$": "<rootDir>/TypescriptPreprocessor.js"
     },
-    "testMatch": ["**/__tests__/*.(ts|tsx|js)"],
+    "testMatch": ["**/__tests__/*.+(ts|tsx|js)"],
     "testEnvironment": "node",
     "moduleFileExtensions": [
       "ts",

--- a/packages/jest-config/src/defaults.js
+++ b/packages/jest-config/src/defaults.js
@@ -64,7 +64,7 @@ export default ({
   testEnvironmentOptions: {},
   testFailureExitCode: 1,
   testLocationInResults: false,
-  testMatch: ['**/__tests__/**/*.js?(x)', '**/?(*.)(spec|test).js?(x)'],
+  testMatch: ['**/__tests__/**/*.js?(x)', '**/?(*.)+(spec|test).js?(x)'],
   testPathIgnorePatterns: [NODE_MODULES_REGEXP],
   testRegex: '',
   testResultsProcessor: null,

--- a/packages/jest-config/src/valid_config.js
+++ b/packages/jest-config/src/valid_config.js
@@ -86,7 +86,7 @@ export default ({
   testEnvironmentOptions: {},
   testFailureExitCode: 1,
   testLocationInResults: false,
-  testMatch: ['**/__tests__/**/*.js?(x)', '**/?(*.)(spec|test).js?(x)'],
+  testMatch: ['**/__tests__/**/*.js?(x)', '**/?(*.)+(spec|test).js?(x)'],
   testNamePattern: 'test signature',
   testPathIgnorePatterns: [NODE_MODULES_REGEXP],
   testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.jsx?$',

--- a/packages/jest-editor-support/src/Settings.js
+++ b/packages/jest-editor-support/src/Settings.js
@@ -55,7 +55,7 @@ export default class Settings extends EventEmitter {
 
     // Defaults for a Jest project
     this.settings = {
-      testMatch: ['**/__tests__/**/*.js?(x)', '**/?(*.)(spec|test).js?(x)'],
+      testMatch: ['**/__tests__/**/*.js?(x)', '**/?(*.)+(spec|test).js?(x)'],
       testRegex: '(/__tests__/.*|\\.(test|spec))\\.jsx?$',
     };
 


### PR DESCRIPTION


## Summary

I just noticed we use non-idiomatic glob pattern as a default `testMatch`. It works only because of `micromatch` (glob lib we use) special feature called [_regex logical "or"_](https://github.com/micromatch/micromatch#matching-features). 
I think we shouldn't spread invalid glob patterns, so instead of `something.(foo|bar)` we should go with `something.+(foo|bar)` for example.

## Test plan

Tests should pass