### PR TITLE
Enhance function mocks to expose a list of returned values.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
   ([#5670](https://github.com/facebook/jest/pull/5670))
 * `[expect]` Add inverse matchers (`expect.not.arrayContaining`, etc.,
   [#5517](https://github.com/facebook/jest/pull/5517))
+* `[jest-mock]` Add tracking of return values in the `mock` property
+  ([#5738](https://github.com/facebook/jest/issues/5738))
 
 ### Fixes
 

--- a/docs/MockFunctionAPI.md
+++ b/docs/MockFunctionAPI.md
@@ -29,11 +29,24 @@ Each call is represented by an array of arguments that were passed during the
 call.
 
 For example: A mock function `f` that has been called twice, with the arguments
-`f('arg1', 'arg2')`, and then with the arguments `f('arg3', 'arg4')` would have
+`f('arg1', 'arg2')`, and then with the arguments `f('arg3', 'arg4')`, would have
 a `mock.calls` array that looks like this:
 
 ```js
 [['arg1', 'arg2'], ['arg3', 'arg4']];
+```
+
+### `mockFn.mock.returnValues`
+
+An array containing values that have been returned by all calls to this mock
+function.
+
+For example: A mock function `f` that has been called twice, returning
+`result1`, and then returning `result2`, would have a `mock.returnValues` array
+that looks like this:
+
+```js
+['result1', 'result2'];
 ```
 
 ### `mockFn.mock.instances`

--- a/docs/MockFunctions.md
+++ b/docs/MockFunctions.md
@@ -41,13 +41,17 @@ expect(mockCallback.mock.calls[0][0]).toBe(0);
 
 // The first argument of the second call to the function was 1
 expect(mockCallback.mock.calls[1][0]).toBe(1);
+
+// The return value of the first call to the function was 42
+expect(mockCallback.mock.returnValues[0]).toBe(42);
 ```
 
 ## `.mock` property
 
 All mock functions have this special `.mock` property, which is where data about
-how the function has been called is kept. The `.mock` property also tracks the
-value of `this` for each call, so it is possible to inspect this as well:
+how the function has been called and what the function returned is kept. The
+`.mock` property also tracks the value of `this` for each call, so it is
+possible to inspect this as well:
 
 ```javascript
 const myMock = jest.fn();
@@ -62,7 +66,7 @@ console.log(myMock.mock.instances);
 ```
 
 These mock members are very useful in tests to assert how these functions get
-called, or instantiated:
+called, instantiated, or what they returned:
 
 ```javascript
 // The function was called exactly once
@@ -73,6 +77,9 @@ expect(someMockFunction.mock.calls[0][0]).toBe('first arg');
 
 // The second arg of the first call to the function was 'second arg'
 expect(someMockFunction.mock.calls[0][1]).toBe('second arg');
+
+// The return value of the first call to the function was 'return value'
+expect(someMockFunction.mock.returnValues[0]).toBe('return value');
 
 // This function was instantiated exactly twice
 expect(someMockFunction.mock.instances.length).toBe(2);

--- a/packages/jest-mock/src/__tests__/jest_mock.test.js
+++ b/packages/jest-mock/src/__tests__/jest_mock.test.js
@@ -438,6 +438,44 @@ describe('moduleMocker', () => {
       ]);
     });
 
+    describe('return values', () => {
+      it('tracks return values', () => {
+        const fn = moduleMocker.fn(x => x * 2);
+
+        expect(fn.mock.returnValues).toEqual([]);
+
+        fn(1);
+        fn(2);
+
+        expect(fn.mock.returnValues).toEqual([2, 4]);
+      });
+
+      it('tracks mocked return values', () => {
+        const fn = moduleMocker.fn(x => x * 2);
+        fn.mockReturnValueOnce('MOCKED!');
+
+        fn(1);
+        fn(2);
+
+        expect(fn.mock.returnValues).toEqual(['MOCKED!', 4]);
+      });
+
+      it('supports resetting return values', () => {
+        const fn = moduleMocker.fn(x => x * 2);
+
+        expect(fn.mock.returnValues).toEqual([]);
+
+        fn(1);
+        fn(2);
+
+        expect(fn.mock.returnValues).toEqual([2, 4]);
+
+        fn.mockReset();
+
+        expect(fn.mock.returnValues).toEqual([]);
+      });
+    });
+
     describe('timestamps', () => {
       const RealDate = Date;
 


### PR DESCRIPTION
## Summary
Enhances function mocks to a expose a list of return values on the `mock` property. 

Fixes #5738.

## Test plan
Added a few new unit tests to `jest_mock.test.js` to specifically test the new feature. Ran `yarn jest -- jest_mock` to confirm that both the new unit tests and all pre-existing unit tests for `jest-mock` are passing.

Please let me know if there are any additional scenarios I should unit test.