### PR TITLE
feat: update spyOnProperty method, fixes #…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,8 @@
   ([#5670](https://github.com/facebook/jest/pull/5670))
 * `[expect]` Add inverse matchers (`expect.not.arrayContaining`, etc.,
   [#5517](https://github.com/facebook/jest/pull/5517))
-* `[jest-mock]` Add tracking of return values in the `mock` property
-  ([#5738](https://github.com/facebook/jest/issues/5738))
-* `[expect]`Add nthCalledWith spy matcher
-  ([#5605](https://github.com/facebook/jest/pull/5605))
-* `[jest-cli]` Add `isSerial` property that runners can expose to specify that
-  they can not run in parallel
-  [#5706](https://github.com/facebook/jest/pull/5706)
+* `[jest-mock]` Update `spyOnProperty` to support spying on the prototype chain
+  ([#5753](https://github.com/facebook/jest/pull/5753))
 
 ### Fixes
 

--- a/packages/jest-mock/src/index.js
+++ b/packages/jest-mock/src/index.js
@@ -724,7 +724,13 @@ class ModuleMockerClass {
       throw new Error('No property name supplied');
     }
 
-    const descriptor = Object.getOwnPropertyDescriptor(obj, propertyName);
+    let descriptor = Object.getOwnPropertyDescriptor(obj, propertyName);
+    let proto = Object.getPrototypeOf(obj);
+
+    while (!descriptor && proto !== null) {
+      descriptor = Object.getOwnPropertyDescriptor(proto, propertyName);
+      proto = Object.getPrototypeOf(proto);
+    }
 
     if (!descriptor) {
       throw new Error(propertyName + ' property does not exist');


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->
## Intro
Hello, this will be my first PR for Jest, so if anything is missing or if I'm doing something wrong, please let me know.

## Summary
The current `spyOnProperty` is limited to only support objects with getters/setters defined on itself. This isn't very helpful in cases where the getters/setters are defined on the object's prototype chain (very common now with es6 classes). It is also inconsistent with the current `spyOn` functionality which supports spying on prototype methods. This pr will update the `spyOnProperty` to find the descriptor on the object's prototype chain if it already is not defined on the object.

1. ~~update `spyOnProperty`~~
2. update `_spyOnProperty` in [spy_registry](packages/jest-jasmine2/src/jasmine/spy_registry.js)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan
Tests are implemented.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

## Question
* Is it necessary for this pr to also update the `_spyOnProperty` in the [spy_registry](packages/jest-jasmine2/src/jasmine/spy_registry.js)?
* I feel like there's some duplication amongst the `spyOn` specs. Should I consider refactoring it or keep it as is?
