### PR TITLE
Add expect(x).toMatchSnapshotAndLog()

### DIFF
--- a/docs/ExpectAPI.md
+++ b/docs/ExpectAPI.md
@@ -1059,6 +1059,11 @@ from the test.
 _Note: While snapshot testing is most commonly used with React components, any
 serializable value can be used as a snapshot._
 
+### `.toMatchSnapshotAndLog(optionalString)`
+
+This runs `.toMatchSnapshot` and also `console.log`s the value passed in. It can
+be useful in development.
+
 ### `.toThrow(error)`
 
 Also under the alias: `.toThrowError(error)`

--- a/integration-tests/__tests__/to_match_snapshot_and_log.test.js
+++ b/integration-tests/__tests__/to_match_snapshot_and_log.test.js
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+const path = require('path');
+const {makeTemplate, writeFiles, cleanup} = require('../Utils');
+const runJest = require('../runJest');
+
+const DIR = path.resolve(__dirname, '../toMatchSnapshotAndLog');
+const TESTS_DIR = path.resolve(DIR, '__tests__');
+
+beforeEach(() => cleanup(TESTS_DIR));
+afterAll(() => cleanup(TESTS_DIR));
+
+test('basic support', () => {
+  const filename = 'basic-support.test.js';
+  const template = makeTemplate(`test('works fine when function throws error', () => {
+       expect('this is the value').toMatchSnapshotAndLog();
+    });
+    `);
+
+  {
+    writeFiles(TESTS_DIR, {[filename]: template()});
+    const {stdout, stderr, status} = runJest(DIR, [
+      '-w=1',
+      '--ci=false',
+      filename,
+    ]);
+    expect(stdout).toMatch('this is the value');
+    expect(stderr).toMatch('1 snapshot written in 1 test suite.');
+    expect(status).toBe(0);
+  }
+});
+
+test('accepts custom snapshot name', () => {
+  const filename = 'accept-custom-snapshot-name.test.js';
+  const template = makeTemplate(`test('accepts custom snapshot name', () => {
+      expect('this is the value').toMatchSnapshotAndLog('custom-name');
+    });
+    `);
+
+  {
+    writeFiles(TESTS_DIR, {[filename]: template()});
+    const {stdout, stderr, status} = runJest(DIR, [
+      '-w=1',
+      '--ci=false',
+      filename,
+    ]);
+    expect(stdout).toMatch('this is the value');
+    expect(stderr).toMatch('1 snapshot written in 1 test suite.');
+    expect(status).toBe(0);
+  }
+});
+
+test('cannot be used with .not', () => {
+  const filename = 'cannot-be-used-with-not.test.js';
+  const template = makeTemplate(`test('cannot be used with .not', () => {
+       expect('this is the value').not.toMatchSnapshotAndLog();
+    });
+    `);
+
+  {
+    writeFiles(TESTS_DIR, {[filename]: template()});
+    const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+    expect(stderr).toMatch(
+      'Jest: `.not` cannot be used with `.toMatchSnapshotAndLog()`.',
+    );
+    expect(status).toBe(1);
+  }
+});

--- a/integration-tests/toMatchSnapshotAndLog/package.json
+++ b/integration-tests/toMatchSnapshotAndLog/package.json
@@ -1,0 +1,5 @@
+{
+  "jest": {
+    "testEnvironment": "node"
+  }
+}

--- a/packages/jest-circus/src/legacy_code_todo_rewrite/jest_expect.js
+++ b/packages/jest-circus/src/legacy_code_todo_rewrite/jest_expect.js
@@ -14,6 +14,7 @@ import expect from 'expect';
 import {
   addSerializer,
   toMatchSnapshot,
+  toMatchSnapshotAndLog,
   toThrowErrorMatchingSnapshot,
 } from 'jest-snapshot';
 
@@ -30,6 +31,7 @@ export default (config: {expand: boolean}) => {
   });
   expect.extend({
     toMatchSnapshot,
+    toMatchSnapshotAndLog,
     toThrowErrorMatchingSnapshot,
   });
 

--- a/packages/jest-jasmine2/src/jest_expect.js
+++ b/packages/jest-jasmine2/src/jest_expect.js
@@ -13,6 +13,7 @@ import expect from 'expect';
 import {
   addSerializer,
   toMatchSnapshot,
+  toMatchSnapshotAndLog,
   toThrowErrorMatchingSnapshot,
 } from 'jest-snapshot';
 
@@ -28,6 +29,7 @@ export default (config: {expand: boolean}) => {
   expect.setState({expand: config.expand});
   expect.extend({
     toMatchSnapshot,
+    toMatchSnapshotAndLog,
     toThrowErrorMatchingSnapshot,
   });
   (expect: Object).addSnapshotSerializer = addSerializer;

--- a/packages/jest-snapshot/src/index.js
+++ b/packages/jest-snapshot/src/index.js
@@ -112,6 +112,21 @@ const toMatchSnapshot = function(received: any, testName?: string) {
   };
 };
 
+const toMatchSnapshotAndLog = function(received: any, testName?: string) {
+  this.dontThrow && this.dontThrow();
+
+  const {isNot} = this;
+
+  if (isNot) {
+    throw new Error(
+      'Jest: `.not` cannot be used with `.toMatchSnapshotAndLog()`.',
+    );
+  }
+
+  console.log(received);
+  return toMatchSnapshot.call(this, received, testName);
+};
+
 const toThrowErrorMatchingSnapshot = function(
   received: any,
   testName?: string,
@@ -158,6 +173,7 @@ module.exports = {
   cleanup,
   getSerializers,
   toMatchSnapshot,
+  toMatchSnapshotAndLog,
   toThrowErrorMatchingSnapshot,
   utils,
 };


### PR DESCRIPTION
It just console.logs x and then does toMatchSnapshot.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Context: https://twitter.com/suchipi/status/972207795188584448

In development, it can be useful to verify that the snapshots you are writing make sense. This matcher is a drop-in replacement for toMatchSnapshot that will also `console.log` the value you're snapshotting. Once you're satisfied with the output, you can change the matcher from `toMatchSnapshotAndLog` back to `toMatchSnapshot`.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
See integration tests
