### PR TITLE
Fix config filename

### DIFF
--- a/integration-tests/__tests__/__snapshots__/jest.config.js.test.js.snap
+++ b/integration-tests/__tests__/__snapshots__/jest.config.js.test.js.snap
@@ -24,14 +24,14 @@ Ran all test suites.
 "
 `;
 
-exports[`works with jest.conf.js 1`] = `
+exports[`works with jest.config.js 1`] = `
 "PASS __tests__/a-banana.js
   ✓ banana
 
 "
 `;
 
-exports[`works with jest.conf.js 2`] = `
+exports[`works with jest.config.js 2`] = `
 "Test Suites: 1 passed, 1 total
 Tests:       1 passed, 1 total
 Snapshots:   0 total

--- a/integration-tests/__tests__/jest.config.js.test.js
+++ b/integration-tests/__tests__/jest.config.js.test.js
@@ -21,7 +21,7 @@ SkipOnWindows.suite();
 beforeEach(() => cleanup(DIR));
 afterAll(() => cleanup(DIR));
 
-test('works with jest.conf.js', () => {
+test('works with jest.config.js', () => {
   writeFiles(DIR, {
     '__tests__/a-banana.js': `test('banana', () => expect(1).toBe(1));`,
     'jest.config.js': `module.exports = {testRegex: '.*-banana.js'};`,

--- a/integration-tests/__tests__/version.test.js
+++ b/integration-tests/__tests__/version.test.js
@@ -22,7 +22,7 @@ SkipOnWindows.suite();
 beforeEach(() => cleanup(DIR));
 afterAll(() => cleanup(DIR));
 
-test('works with jest.conf.js', () => {
+test('works with jest.config.js', () => {
   writeFiles(DIR, {
     '.watchmanconfig': '',
     'package.json': '{}',

--- a/packages/jest-config/src/index.js
+++ b/packages/jest-config/src/index.js
@@ -68,7 +68,7 @@ export function readConfig(
     config.rootDir = config.rootDir || packageRootOrConfig;
     rawOptions = config;
     // A string passed to `--config`, which is either a direct path to the config
-    // or a path to directory containing `package.json` or `jest.conf.js`
+    // or a path to directory containing `package.json` or `jest.config.js`
   } else if (!skipArgvConfigOption && typeof argv.config == 'string') {
     configPath = resolveConfigPath(argv.config, process.cwd());
     rawOptions = readConfigFileAndSetRootDir(configPath);


### PR DESCRIPTION
## Summary

It appears that the file name is called `jest.config.js` in [the configuration documentation](https://facebook.github.io/jest/docs/en/configuration.html).

## Test plan

No tests necessary - only comments and test labels have been changed.