### PR TITLE
Improve jest-worker (up to 4x)

### DIFF
--- a/packages/jest-worker/src/__performance_tests__/workers/jest_worker.js
+++ b/packages/jest-worker/src/__performance_tests__/workers/jest_worker.js
@@ -5,3 +5,7 @@ const pi = require('./pi');
 module.exports.loadTest = function() {
   return pi();
 };
+
+module.exports.empty = function() {
+  // Do nothing.
+};

--- a/packages/jest-worker/src/__performance_tests__/workers/worker_farm.js
+++ b/packages/jest-worker/src/__performance_tests__/workers/worker_farm.js
@@ -5,3 +5,8 @@ const pi = require('./pi');
 module.exports.loadTest = function(callback) {
   callback(null, pi());
 };
+
+module.exports.empty = function(callback) {
+  // Do nothing.
+  callback();
+};

--- a/packages/jest-worker/src/types.js
+++ b/packages/jest-worker/src/types.js
@@ -99,4 +99,5 @@ export type QueueCallback = (?Error, ?any) => void;
 export type QueueChildMessage = {|
   request: ChildMessage,
   callback: QueueCallback,
+  next: ?QueueChildMessage,
 |};

--- a/packages/jest-worker/src/worker.js
+++ b/packages/jest-worker/src/worker.js
@@ -49,12 +49,13 @@ export default class {
   _busy: boolean;
   _child: ChildProcess;
   _options: WorkerOptions;
-  _queue: Array<QueueChildMessage>;
+  _queue: ?QueueChildMessage;
+  _last: ?QueueChildMessage;
   _retries: number;
 
   constructor(options: WorkerOptions) {
     this._options = options;
-    this._queue = [];
+    this._queue = null;
 
     this._initialize();
   }
@@ -68,7 +69,15 @@ export default class {
   }
 
   send(request: ChildMessage, callback: QueueCallback) {
-    this._queue.push({callback, request});
+    const item = {callback, next: null, request};
+
+    if (this._last) {
+      this._last.next = item;
+    } else {
+      this._queue = item;
+    }
+
+    this._last = item;
     this._process();
   }
 
@@ -82,7 +91,7 @@ export default class {
           env: Object.assign({}, process.env, {
             JEST_WORKER_ID: this._options.workerId,
           }),
-          // suppress --debug / --inspect flags while preserving others (like --harmony)
+          // Suppress --debug / --inspect flags while preserving others (like --harmony).
           execArgv: process.execArgv.filter(v => !/^--(debug|inspect)/.test(v)),
           silent: true,
         },
@@ -121,35 +130,39 @@ export default class {
       return;
     }
 
-    const queue = this._queue;
-    let skip = 0;
+    let item = this._queue;
 
     // Calls in the queue might have already been processed by another worker,
     // so we have to skip them.
-    while (queue.length > skip && queue[skip].request[1]) {
-      skip++;
+    while (item && item.request[1]) {
+      item = item.next;
     }
 
-    // Remove all pieces at once.
-    queue.splice(0, skip);
+    this._queue = item;
 
-    if (queue.length) {
-      const call = queue[0];
-
+    if (item) {
       // Flag the call as processed, so that other workers know that they don't
       // have to process it as well.
-      call.request[1] = true;
+      item.request[1] = true;
 
       this._retries = 0;
       this._busy = true;
 
       // $FlowFixMe: wrong "ChildProcess.send" signature.
-      this._child.send(call.request);
+      this._child.send(item.request);
+    } else {
+      this._last = item;
     }
   }
 
   _receive(response: any /* Should be ParentMessage */) {
-    const callback = this._queue[0].callback;
+    const item = this._queue;
+
+    if (!item) {
+      throw new TypeError('Unexpected response with an empty queue');
+    }
+
+    const callback = item.callback;
 
     this._busy = false;
     this._process();

--- a/packages/jest-worker/src/worker.js
+++ b/packages/jest-worker/src/worker.js
@@ -48,9 +48,9 @@ import type {
 export default class {
   _busy: boolean;
   _child: ChildProcess;
+  _last: ?QueueChildMessage;
   _options: WorkerOptions;
   _queue: ?QueueChildMessage;
-  _last: ?QueueChildMessage;
   _retries: number;
 
   constructor(options: WorkerOptions) {


### PR DESCRIPTION
This PR modifies the way internal worker queues are managed, passing from an array to a linked-list, improving a 10% the current benchmark, and 400% over a new benchmark.

## How come this wasn't noticed before?

When `jest-worker` was initially benchmarked, it was done by using not so many jobs (~10k), but very heavy in time. While this is the usual approach (few jobs, lots of time per job), sometimes you have the opposite (i.e. lots of jobs, but each of them very fast). _This is actually what `jest-haste-map` does._

Since the internal queue was an array, re-indexing the queue is a `O(n)` operation, which becomes especially relevant on the second scenario. Switching to a linked list means that all operations for advancing the queue become `O(1)`, no matter its length. This results in massive speed improvements on really long queues.

## Some benchmarks

Using the extended performance test, the `empty` function, called 100,000 times results in:

```
---------------------------------------------------------------------------
jest-worker: { globalTime: 11102, processingTime: 11058 }
worker-farm: { globalTime: 9713, processingTime: 9685 }
---------------------------------------------------------------------------
jest-worker: { globalTime: 10790, processingTime: 10762 }
worker-farm: { globalTime: 10453, processingTime: 10432 }
---------------------------------------------------------------------------
jest-worker: { globalTime: 11111, processingTime: 11079 }
worker-farm: { globalTime: 10133, processingTime: 10112 }
---------------------------------------------------------------------------
```

Now, **with the change**, it results in:

```
---------------------------------------------------------------------------
jest-worker: { globalTime: 2634, processingTime: 2594 }
worker-farm: { globalTime: 10165, processingTime: 10141 }
---------------------------------------------------------------------------
jest-worker: { globalTime: 2780, processingTime: 2756 }
worker-farm: { globalTime: 10132, processingTime: 10110 }
---------------------------------------------------------------------------
jest-worker: { globalTime: 2608, processingTime: 2581 }
worker-farm: { globalTime: 10295, processingTime: 10272 }
---------------------------------------------------------------------------
```
## What about the existing metrics?

The previous metric (which we initially used for benchmarking, `loadTest` called 10,000 times), has also improved, but only slightly, since that one was already optimized:

```
---------------------------------------------------------------------------
jest-worker: { globalTime: 726, processingTime: 690 }
worker-farm: { globalTime: 769, processingTime: 748 }
---------------------------------------------------------------------------
jest-worker: { globalTime: 719, processingTime: 693 }
worker-farm: { globalTime: 784, processingTime: 765 }
---------------------------------------------------------------------------
jest-worker: { globalTime: 703, processingTime: 673 }
worker-farm: { globalTime: 748, processingTime: 731 }
---------------------------------------------------------------------------
```

## Tests

I ensured all tests pass, but I also added some slight modifications into the `__performance__tests__` so that you can pass an arbitrary worker method as well as an arbitrary number of iterations. This allowed me to test the other scenario.

_On a personal note: this is actually WHY algorithms and data structures knowledge ARE important for a frontend developer!_ 🙂