### PR TITLE
Fix: jest-worker exposing `.default` babel interop

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,7 @@
 {
   "plugins": [
     "syntax-trailing-function-commas",
+    "add-module-exports",
     "transform-flow-strip-types",
     "transform-es2015-destructuring",
     "transform-es2015-parameters",

--- a/docs/JestObjectAPI.md
+++ b/docs/JestObjectAPI.md
@@ -181,7 +181,7 @@ export default {
 
 ```js
 // __tests__/genMockFromModule.test.js
-const utils = jest.genMockFromModule('../utils').default;
+const utils = jest.genMockFromModule('../utils');
 utils.isAuthorized = jest.fn(secret => secret === 'not wizard');
 
 test('implementation created by jest.genMockFromModule', () => {

--- a/examples/automatic_mocks/__tests__/genMockFromModule.test.js
+++ b/examples/automatic_mocks/__tests__/genMockFromModule.test.js
@@ -8,7 +8,7 @@ test('implementation created by automock', () => {
 });
 
 test('implementation created by jest.genMockFromModule', () => {
-  const utils = jest.genMockFromModule('../utils').default;
+  const utils = jest.genMockFromModule('../utils');
   utils.isAuthorized = jest.fn(secret => secret === 'not wizard');
 
   expect(utils.authorize.mock).toBeTruthy();

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "ansi-styles": "^3.2.0",
     "babel-core": "^6.23.1",
     "babel-eslint": "^7.2.3",
+    "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-external-helpers": "^6.22.0",
     "babel-plugin-syntax-trailing-function-commas": "^6.13.0",
     "babel-plugin-transform-async-to-generator": "^6.16.0",

--- a/packages/jest-circus/src/__mocks__/test_utils.js
+++ b/packages/jest-circus/src/__mocks__/test_utils.js
@@ -34,13 +34,13 @@ export const runTest = (source: string) => {
     global.beforeAll = circus.beforeAll;
     global.afterAll = circus.afterAll;
 
-    const testEventHandler = require('${TEST_EVENT_HANDLER_PATH}').default;
+    const testEventHandler = require('${TEST_EVENT_HANDLER_PATH}');
     const addEventHandler = require('${CIRCUS_STATE_PATH}').addEventHandler;
     addEventHandler(testEventHandler);
 
     ${source};
 
-    const run = require('${CIRCUS_RUN_PATH}').default;
+    const run = require('${CIRCUS_RUN_PATH}');
 
     run();
   `;

--- a/packages/jest-cli/src/__tests__/search_source.test.js
+++ b/packages/jest-cli/src/__tests__/search_source.test.js
@@ -34,7 +34,7 @@ describe('SearchSource', () => {
 
   beforeEach(() => {
     Runtime = require('jest-runtime');
-    SearchSource = require('../search_source').default;
+    SearchSource = require('../search_source');
     normalize = require('jest-config').normalize;
   });
 

--- a/packages/jest-cli/src/__tests__/watch.test.js
+++ b/packages/jest-cli/src/__tests__/watch.test.js
@@ -87,7 +87,7 @@ jest.doMock(
   {virtual: true},
 );
 
-const watch = require('../watch').default;
+const watch = require('../watch');
 
 const nextTick = () => new Promise(res => process.nextTick(res));
 const toHex = char => Number(char.charCodeAt(0)).toString(16);
@@ -144,7 +144,7 @@ describe('Watch mode flows', () => {
     const util = require('jest-util');
     util.isInteractive = true;
 
-    const ci_watch = require('../watch').default;
+    const ci_watch = require('../watch');
     ci_watch(globalConfig, contexts, pipe, hasteMapInstances, stdin);
     expect(runJestMock.mock.calls[0][0]).toMatchObject({
       contexts,
@@ -161,7 +161,7 @@ describe('Watch mode flows', () => {
     const util = require('jest-util');
     util.isInteractive = false;
 
-    const ci_watch = require('../watch').default;
+    const ci_watch = require('../watch');
     ci_watch(globalConfig, contexts, pipe, hasteMapInstances, stdin);
     expect(runJestMock.mock.calls[0][0]).toMatchObject({
       contexts,
@@ -193,7 +193,7 @@ describe('Watch mode flows', () => {
     const util = require('jest-util');
     util.isInteractive = true;
 
-    const ci_watch = require('../watch').default;
+    const ci_watch = require('../watch');
     ci_watch(
       Object.assign({}, globalConfig, {
         rootDir: __dirname,
@@ -220,7 +220,7 @@ describe('Watch mode flows', () => {
     util.isInteractive = true;
     results = {snapshot: {failure: true}};
 
-    const ci_watch = require('../watch').default;
+    const ci_watch = require('../watch');
     ci_watch(
       Object.assign({}, globalConfig, {
         rootDir: __dirname,
@@ -248,7 +248,7 @@ describe('Watch mode flows', () => {
     util.getFailedSnapshotTests = jest.fn(() => ['test.js']);
     results = {snapshot: {failure: true}};
 
-    const ci_watch = require('../watch').default;
+    const ci_watch = require('../watch');
     ci_watch(
       Object.assign({}, globalConfig, {
         rootDir: __dirname,

--- a/packages/jest-cli/src/__tests__/watch_filename_pattern_mode.test.js
+++ b/packages/jest-cli/src/__tests__/watch_filename_pattern_mode.test.js
@@ -83,7 +83,7 @@ jest.doMock('../lib/terminal_utils', () => ({
   getTerminalWidth: () => terminalWidth,
 }));
 
-const watch = require('../watch').default;
+const watch = require('../watch');
 
 const nextTick = () => new Promise(res => process.nextTick(res));
 

--- a/packages/jest-cli/src/__tests__/watch_test_name_pattern_mode.test.js
+++ b/packages/jest-cli/src/__tests__/watch_test_name_pattern_mode.test.js
@@ -97,7 +97,7 @@ jest.doMock('../lib/terminal_utils', () => ({
   getTerminalWidth: () => terminalWidth,
 }));
 
-const watch = require('../watch').default;
+const watch = require('../watch');
 
 const toHex = char => Number(char.charCodeAt(0)).toString(16);
 

--- a/packages/jest-cli/src/reporters/__tests__/coverage_reporter.test.js
+++ b/packages/jest-cli/src/reporters/__tests__/coverage_reporter.test.js
@@ -26,7 +26,7 @@ beforeEach(() => {
     write: jest.fn(),
   }));
 
-  CoverageReporter = require('../coverage_reporter').default;
+  CoverageReporter = require('../coverage_reporter');
   libCoverage = require('istanbul-lib-coverage');
   libSourceMaps = require('istanbul-lib-source-maps');
 

--- a/packages/jest-cli/src/reporters/__tests__/coverage_worker.test.js
+++ b/packages/jest-cli/src/reporters/__tests__/coverage_worker.test.js
@@ -21,7 +21,7 @@ beforeEach(() => {
   jest.resetModules();
 
   fs = require('fs');
-  generateEmptyCoverage = require('../../generate_empty_coverage').default;
+  generateEmptyCoverage = require('../../generate_empty_coverage');
   worker = require('../coverage_worker').worker;
 });
 

--- a/packages/jest-cli/src/reporters/__tests__/default_reporter.test.js
+++ b/packages/jest-cli/src/reporters/__tests__/default_reporter.test.js
@@ -53,7 +53,7 @@ beforeEach(() => {
   process.stderr.write = jest.fn();
   stdout = process.stdout.write = jest.fn();
 
-  DefaultReporter = require('../default_reporter').default;
+  DefaultReporter = require('../default_reporter');
 });
 
 afterEach(() => {

--- a/packages/jest-cli/src/reporters/__tests__/verbose_reporter.test.js
+++ b/packages/jest-cli/src/reporters/__tests__/verbose_reporter.test.js
@@ -13,7 +13,7 @@ const wrap = obj => ({suites: obj, tests: [], title: ''});
 let groupTestsBySuites;
 
 beforeEach(() => {
-  const VerboseReporter = require('../verbose_reporter').default;
+  const VerboseReporter = require('../verbose_reporter');
   groupTestsBySuites = VerboseReporter.groupTestsBySuites;
 });
 

--- a/packages/jest-config/src/__tests__/normalize.test.js
+++ b/packages/jest-config/src/__tests__/normalize.test.js
@@ -1156,7 +1156,7 @@ describe('testPathPattern', () => {
 
         it('preserves any use of "\\"', () => {
           const argv = {[opt.property]: ['a\\b', 'c\\\\d']};
-          const {options} = require('../normalize').default(
+          const {options} = require('../normalize')(
             initialOptions,
             argv,
           );
@@ -1166,7 +1166,7 @@ describe('testPathPattern', () => {
 
         it('replaces POSIX path separators', () => {
           const argv = {[opt.property]: ['a/b']};
-          const {options} = require('../normalize').default(
+          const {options} = require('../normalize')(
             initialOptions,
             argv,
           );
@@ -1176,7 +1176,7 @@ describe('testPathPattern', () => {
 
         it('replaces POSIX paths in multiple args', () => {
           const argv = {[opt.property]: ['a/b', 'c/d']};
-          const {options} = require('../normalize').default(
+          const {options} = require('../normalize')(
             initialOptions,
             argv,
           );

--- a/packages/jest-haste-map/src/__tests__/index.test.js
+++ b/packages/jest-haste-map/src/__tests__/index.test.js
@@ -179,7 +179,7 @@ describe('HasteMap', () => {
   });
 
   it('exports constants', () => {
-    expect(HasteMap.H).toBe(require('../constants').default);
+    expect(HasteMap.H).toBe(require('../constants'));
   });
 
   it('creates valid cache file paths', () => {
@@ -1057,7 +1057,7 @@ describe('HasteMap', () => {
         } catch (error) {
           const {
             DuplicateHasteCandidatesError,
-          } = require('../module_map').default;
+          } = require('../module_map');
           expect(error).toBeInstanceOf(DuplicateHasteCandidatesError);
           expect(error.hasteName).toBe('Pear');
           expect(error.platform).toBe('g');

--- a/packages/jest-haste-map/src/crawlers/__tests__/watchman.test.js
+++ b/packages/jest-haste-map/src/crawlers/__tests__/watchman.test.js
@@ -11,7 +11,7 @@
 const path = require('path');
 
 jest.mock('fb-watchman', () => {
-  const normalizePathSep = require('../../lib/normalize_path_sep').default;
+  const normalizePathSep = require('../../lib/normalize_path_sep');
   const Client = jest.fn();
   Client.prototype.command = jest.fn((args, callback) =>
     setImmediate(() => {

--- a/packages/jest-haste-map/src/lib/__tests__/normalize_path_sep.test.js
+++ b/packages/jest-haste-map/src/lib/__tests__/normalize_path_sep.test.js
@@ -13,14 +13,14 @@ describe('normalizePathSep', () => {
   it('does nothing on posix', () => {
     jest.resetModules();
     jest.mock('path', () => require.requireActual('path').posix);
-    const normalizePathSep = require('../normalize_path_sep').default;
+    const normalizePathSep = require('../normalize_path_sep');
     expect(normalizePathSep('foo/bar/baz.js')).toEqual('foo/bar/baz.js');
   });
 
   it('replace slashes on windows', () => {
     jest.resetModules();
     jest.mock('path', () => require.requireActual('path').win32);
-    const normalizePathSep = require('../normalize_path_sep').default;
+    const normalizePathSep = require('../normalize_path_sep');
     expect(normalizePathSep('foo/bar/baz.js')).toEqual('foo\\bar\\baz.js');
   });
 });

--- a/packages/jest-jasmine2/src/jasmine/Spec.js
+++ b/packages/jest-jasmine2/src/jasmine/Spec.js
@@ -133,7 +133,7 @@ Spec.prototype.onException = function onException(error) {
   }
 
   if (error instanceof require('assert').AssertionError) {
-    const assertionErrorMessage = require('../assert_support').default;
+    const assertionErrorMessage = require('../assert_support');
     error = assertionErrorMessage(error, {expand: this.expand});
   }
 

--- a/packages/jest-resolve/src/__tests__/resolve.test.js
+++ b/packages/jest-resolve/src/__tests__/resolve.test.js
@@ -15,7 +15,7 @@ const path = require('path');
 const ModuleMap = require('jest-haste-map').ModuleMap;
 const Resolver = require('../');
 const userResolver = require('../__mocks__/userResolver');
-const nodeModulesPaths = require('../node_modules_paths').default;
+const nodeModulesPaths = require('../node_modules_paths');
 
 beforeEach(() => {
   userResolver.mockClear();

--- a/packages/jest-runtime/src/__tests__/script_transformer.test.js
+++ b/packages/jest-runtime/src/__tests__/script_transformer.test.js
@@ -163,7 +163,7 @@ describe('ScriptTransformer', () => {
       transformIgnorePatterns: ['/node_modules/'],
     };
 
-    ScriptTransformer = require('../script_transformer').default;
+    ScriptTransformer = require('../script_transformer');
   };
 
   beforeEach(reset);
@@ -207,7 +207,7 @@ describe('ScriptTransformer', () => {
   it('does not transform Node core modules', () => {
     jest.mock('../should_instrument');
 
-    const shouldInstrument = require('../should_instrument').default;
+    const shouldInstrument = require('../should_instrument');
     const scriptTransformer = new ScriptTransformer(config);
     const fsSourceCode = process.binding('natives').fs;
 

--- a/packages/jest-util/src/__tests__/fake_timers.test.js
+++ b/packages/jest-util/src/__tests__/fake_timers.test.js
@@ -14,7 +14,7 @@ describe('FakeTimers', () => {
   let FakeTimers, moduleMocker, timerConfig;
 
   beforeEach(() => {
-    FakeTimers = require('../fake_timers').default;
+    FakeTimers = require('../fake_timers');
     const mock = require('jest-mock');
     const global = vm.runInNewContext('this');
     moduleMocker = new mock.ModuleMocker(global);

--- a/packages/jest-util/src/__tests__/install_common_globals.test.js
+++ b/packages/jest-util/src/__tests__/install_common_globals.test.js
@@ -18,7 +18,7 @@ beforeEach(() => {
   fake = jest.fn();
   global.DTRACE_NET_SERVER_CONNECTION = fake;
 
-  installCommonGlobals = require('../install_common_globals').default;
+  installCommonGlobals = require('../install_common_globals');
 });
 
 it('returns the passed object', () => {

--- a/packages/jest-util/src/__tests__/is_interactive.test.js
+++ b/packages/jest-util/src/__tests__/is_interactive.test.js
@@ -17,7 +17,7 @@ it('Returns true when running on interactive environment', () => {
   process.stdout.isTTY = true;
   process.env.TERM = 'xterm-256color';
 
-  const isInteractive = require('../is_interative').default;
+  const isInteractive = require('../is_interative');
   expect(isInteractive).toBe(true);
 });
 
@@ -29,7 +29,7 @@ it('Returns false when running on a non-interactive environment', () => {
   jest.doMock('is-ci', () => true);
   process.stdout.isTTY = false;
   process.env.TERM = 'xterm-256color';
-  isInteractive = require('../is_interative').default;
+  isInteractive = require('../is_interative');
   expect(isInteractive).toBe(expectedResult);
 
   // Test with is-ci being false and isTTY false
@@ -37,7 +37,7 @@ it('Returns false when running on a non-interactive environment', () => {
   jest.doMock('is-ci', () => false);
   process.stdout.isTTY = false;
   process.env.TERM = 'xterm-256color';
-  isInteractive = require('../is_interative').default;
+  isInteractive = require('../is_interative');
   expect(isInteractive).toBe(expectedResult);
 
   // Test with is-ci being true and isTTY true
@@ -45,7 +45,7 @@ it('Returns false when running on a non-interactive environment', () => {
   jest.doMock('is-ci', () => true);
   process.stdout.isTTY = true;
   process.env.TERM = 'xterm-256color';
-  isInteractive = require('../is_interative').default;
+  isInteractive = require('../is_interative');
   expect(isInteractive).toBe(expectedResult);
 
   // Test with dumb terminal
@@ -53,6 +53,6 @@ it('Returns false when running on a non-interactive environment', () => {
   jest.doMock('is-ci', () => false);
   process.stdout.isTTY = false;
   process.env.TERM = 'dumb';
-  isInteractive = require('../is_interative').default;
+  isInteractive = require('../is_interative');
   expect(isInteractive).toBe(expectedResult);
 });

--- a/packages/jest-worker/src/__performance_tests__/test.js
+++ b/packages/jest-worker/src/__performance_tests__/test.js
@@ -3,7 +3,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const workerFarm = require('worker-farm');
 const assert = require('assert');
-const JestWorker = require('../../build').default;
+const JestWorker = require('../../build');
 
 // Typical tests: node --expose-gc test.js empty 100000
 //                node --expose-gc test.js loadTest 10000

--- a/packages/jest-worker/src/__tests__/index.test.js
+++ b/packages/jest-worker/src/__tests__/index.test.js
@@ -64,8 +64,8 @@ beforeEach(() => {
     {virtual: true},
   );
 
-  Worker = require('../worker').default;
-  Farm = require('../index').default;
+  Worker = require('../worker');
+  Farm = require('../index');
 });
 
 afterEach(() => {

--- a/packages/jest-worker/src/__tests__/worker.test.js
+++ b/packages/jest-worker/src/__tests__/worker.test.js
@@ -38,7 +38,7 @@ beforeEach(() => {
     return forkInterface;
   });
 
-  Worker = require('../worker').default;
+  Worker = require('../worker');
 });
 
 afterEach(() => {

--- a/website/versioned_docs/version-22.4/JestObjectAPI.md
+++ b/website/versioned_docs/version-22.4/JestObjectAPI.md
@@ -182,7 +182,7 @@ export default {
 
 ```js
 // __tests__/genMockFromModule.test.js
-const utils = jest.genMockFromModule('../utils').default;
+const utils = jest.genMockFromModule('../utils');
 utils.isAuthorized = jest.fn(secret => secret === 'not wizard');
 
 test('implementation created by jest.genMockFromModule', () => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary
The issue #5803 raised up by @ljharb:

`import a from 'jest-worker'` works fine because it's using babel on both ends.

However, `const b = require('jest-worker')` results in `a !== b`, and to get at the proper value, you need to do b.default.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan
I will appreciate some help to evaluate if this is a valid change and if it solves the problem.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
