### PR TITLE
Fix typo in Es6ClassMocks.md

### DIFF
--- a/docs/Es6ClassMocks.md
+++ b/docs/Es6ClassMocks.md
@@ -214,7 +214,7 @@ class, but does not provide a way to spy on calls.
 For the contrived example, the mock might look like this:
 
 ```javascript
-// __mocks/sound-player.js
+// __mocks__/sound-player.js
 export default class SoundPlayer {
   constructor() {
     console.log('Mock SoundPlayer: constructor was called');


### PR DESCRIPTION
## Summary

The correct location for mocks is `__mocks__/`, not `__mocks/`.

I didn't add anything in the CHANGELOG as I don't think it's worth it for a typo fix.

## Test plan

N/A