### PR TITLE
Implement SHA-1 support in jest-haste-map

### DIFF
--- a/packages/jest-haste-map/src/__tests__/index.test.js
+++ b/packages/jest-haste-map/src/__tests__/index.test.js
@@ -37,14 +37,15 @@ jest.mock('jest-worker', () => {
 jest.mock('../crawlers/node');
 jest.mock('../crawlers/watchman', () =>
   jest.fn(options => {
-    const {data, ignore, roots, sha1} = options;
+    const {data, ignore, roots, computeSha1} = options;
+    const list = mockChangedFiles || mockFs;
+
     data.clocks = mockClocks;
 
-    const list = mockChangedFiles || mockFs;
     for (const file in list) {
       if (new RegExp(roots.join('|')).test(file) && !ignore(file)) {
         if (list[file]) {
-          const hash = sha1 ? mockHashContents(list[file]) : null;
+          const hash = computeSha1 ? mockHashContents(list[file]) : null;
 
           data.files[file] = ['', 32, 0, [], hash];
         } else {
@@ -352,8 +353,8 @@ describe('HasteMap', () => {
 
         const hasteMap = new HasteMap(
           Object.assign({}, defaultConfig, {
+            computeSha1: true,
             maxWorkers: 1,
-            sha1: true,
             useWatchman,
           }),
         );
@@ -906,37 +907,37 @@ describe('HasteMap', () => {
         expect(mockWorker.mock.calls).toEqual([
           [
             {
+              computeSha1: false,
               filePath: '/fruits/__mocks__/Pear.js',
               hasteImplModulePath: undefined,
-              sha1: false,
             },
           ],
           [
             {
+              computeSha1: false,
               filePath: '/fruits/banana.js',
               hasteImplModulePath: undefined,
-              sha1: false,
             },
           ],
           [
             {
+              computeSha1: false,
               filePath: '/fruits/pear.js',
               hasteImplModulePath: undefined,
-              sha1: false,
             },
           ],
           [
             {
+              computeSha1: false,
               filePath: '/fruits/strawberry.js',
               hasteImplModulePath: undefined,
-              sha1: false,
             },
           ],
           [
             {
+              computeSha1: false,
               filePath: '/vegetables/melon.js',
               hasteImplModulePath: undefined,
-              sha1: false,
             },
           ],
         ]);

--- a/packages/jest-haste-map/src/__tests__/index.test.js
+++ b/packages/jest-haste-map/src/__tests__/index.test.js
@@ -8,6 +8,15 @@
 
 'use strict';
 
+const crypto = require('crypto');
+
+function mockHashContents(contents) {
+  return crypto
+    .createHash('sha1')
+    .update(contents)
+    .digest('hex');
+}
+
 jest.mock('child_process', () => ({
   // If this does not throw, we'll use the (mocked) watchman crawler
   execSync() {},
@@ -28,14 +37,16 @@ jest.mock('jest-worker', () => {
 jest.mock('../crawlers/node');
 jest.mock('../crawlers/watchman', () =>
   jest.fn(options => {
-    const {data, ignore, roots} = options;
+    const {data, ignore, roots, sha1} = options;
     data.clocks = mockClocks;
 
     const list = mockChangedFiles || mockFs;
     for (const file in list) {
       if (new RegExp(roots.join('|')).test(file) && !ignore(file)) {
         if (list[file]) {
-          data.files[file] = ['', 32, 0, []];
+          const hash = sha1 ? mockHashContents(list[file]) : null;
+
+          data.files[file] = ['', 32, 0, [], hash];
         } else {
           delete data.files[file];
         }
@@ -265,15 +276,27 @@ describe('HasteMap', () => {
       expect(data.clocks).toEqual(mockClocks);
 
       expect(data.files).toEqual({
-        '/fruits/__mocks__/Pear.js': ['', 32, 1, ['Melon']],
-        '/fruits/banana.js': ['Banana', 32, 1, ['Strawberry']],
+        '/fruits/__mocks__/Pear.js': ['', 32, 1, ['Melon'], null],
+        '/fruits/banana.js': ['Banana', 32, 1, ['Strawberry'], null],
         // node modules
-        '/fruits/node_modules/fbjs/lib/flatMap.js': ['flatMap', 32, 1, []],
-        '/fruits/node_modules/react/react.js': ['React', 32, 1, ['Component']],
+        '/fruits/node_modules/fbjs/lib/flatMap.js': [
+          'flatMap',
+          32,
+          1,
+          [],
+          null,
+        ],
+        '/fruits/node_modules/react/react.js': [
+          'React',
+          32,
+          1,
+          ['Component'],
+          null,
+        ],
 
-        '/fruits/pear.js': ['Pear', 32, 1, ['Banana', 'Strawberry']],
-        '/fruits/strawberry.js': ['Strawberry', 32, 1, []],
-        '/vegetables/melon.js': ['Melon', 32, 1, []],
+        '/fruits/pear.js': ['Pear', 32, 1, ['Banana', 'Strawberry'], null],
+        '/fruits/strawberry.js': ['Strawberry', 32, 1, [], null],
+        '/vegetables/melon.js': ['Melon', 32, 1, [], null],
       });
 
       expect(data.map).toEqual({
@@ -301,9 +324,82 @@ describe('HasteMap', () => {
         Pear: '/fruits/__mocks__/Pear.js',
       });
 
-      // The cache file must exactly mirror the data structure returned
-      // from a build.
+      // The cache file must exactly mirror the data structure returned from a
+      // build.
       expect(hasteMap.read()).toEqual(data);
+    });
+  });
+
+  describe('builds a haste map on a fresh cache with SHA-1s', () => {
+    [false, true].forEach(useWatchman => {
+      it('uses watchman: ' + useWatchman, async () => {
+        const node = require('../crawlers/node');
+
+        node.mockImplementation(options => {
+          const {data} = options;
+
+          // The node crawler returns "null" for the SHA-1.
+          data.files = object({
+            '/fruits/__mocks__/Pear.js': ['', 32, 0, ['Melon'], null],
+            '/fruits/banana.js': ['Banana', 32, 0, ['Strawberry'], null],
+            '/fruits/pear.js': ['Pear', 32, 0, ['Banana', 'Strawberry'], null],
+            '/fruits/strawberry.js': ['Strawberry', 32, 0, [], null],
+            '/vegetables/melon.js': ['Melon', 32, 0, [], null],
+          });
+
+          return Promise.resolve(data);
+        });
+
+        const hasteMap = new HasteMap(
+          Object.assign({}, defaultConfig, {
+            maxWorkers: 1,
+            sha1: true,
+            useWatchman,
+          }),
+        );
+
+        const data = (await hasteMap.build()).__hasteMapForTest;
+
+        expect(data.files).toEqual({
+          '/fruits/__mocks__/Pear.js': [
+            '',
+            32,
+            1,
+            ['Melon'],
+            'a315b7804be2b124b77c1f107205397f45226964',
+          ],
+          '/fruits/banana.js': [
+            'Banana',
+            32,
+            1,
+            ['Strawberry'],
+            'f24c6984cce6f032f6d55d771d04ab8dbbe63c8c',
+          ],
+          '/fruits/pear.js': [
+            'Pear',
+            32,
+            1,
+            ['Banana', 'Strawberry'],
+            '211a8ff1e67007b204727d26943c15cf9fd00031',
+          ],
+          '/fruits/strawberry.js': [
+            'Strawberry',
+            32,
+            1,
+            [],
+            'd55d545ad7d997cb2aa10fb412e0cc287d4fbfb3',
+          ],
+          '/vegetables/melon.js': [
+            'Melon',
+            32,
+            1,
+            [],
+            '45c5d30e29313187829dfd5a16db81c3143fbcc7',
+          ],
+        });
+
+        expect(hasteMap.read()).toEqual(data);
+      });
     });
   });
 
@@ -351,6 +447,7 @@ describe('HasteMap', () => {
         32,
         0,
         [],
+        null,
       ]);
 
       expect(data.map.fbjs).not.toBeDefined();
@@ -452,9 +549,16 @@ describe('HasteMap', () => {
             32,
             1,
             ['Blackberry'],
+            null,
           ],
-          '/fruits/strawberry.ios.js': ['Strawberry', 32, 1, ['Raspberry']],
-          '/fruits/strawberry.js': ['Strawberry', 32, 1, ['Banana']],
+          '/fruits/strawberry.ios.js': [
+            'Strawberry',
+            32,
+            1,
+            ['Raspberry'],
+            null,
+          ],
+          '/fruits/strawberry.js': ['Strawberry', 32, 1, ['Banana'], null],
         });
 
         expect(data.map).toEqual({
@@ -539,7 +643,7 @@ describe('HasteMap', () => {
             expect(data.clocks).toEqual(mockClocks);
 
             const files = object(initialData.files);
-            files['/fruits/banana.js'] = ['Kiwi', 32, 1, ['Raspberry']];
+            files['/fruits/banana.js'] = ['Kiwi', 32, 1, ['Raspberry'], null];
 
             expect(data.files).toEqual(files);
 
@@ -800,11 +904,41 @@ describe('HasteMap', () => {
         expect(mockWorker.mock.calls.length).toBe(5);
 
         expect(mockWorker.mock.calls).toEqual([
-          [{filePath: '/fruits/__mocks__/Pear.js'}],
-          [{filePath: '/fruits/banana.js'}],
-          [{filePath: '/fruits/pear.js'}],
-          [{filePath: '/fruits/strawberry.js'}],
-          [{filePath: '/vegetables/melon.js'}],
+          [
+            {
+              filePath: '/fruits/__mocks__/Pear.js',
+              hasteImplModulePath: undefined,
+              sha1: false,
+            },
+          ],
+          [
+            {
+              filePath: '/fruits/banana.js',
+              hasteImplModulePath: undefined,
+              sha1: false,
+            },
+          ],
+          [
+            {
+              filePath: '/fruits/pear.js',
+              hasteImplModulePath: undefined,
+              sha1: false,
+            },
+          ],
+          [
+            {
+              filePath: '/fruits/strawberry.js',
+              hasteImplModulePath: undefined,
+              sha1: false,
+            },
+          ],
+          [
+            {
+              filePath: '/vegetables/melon.js',
+              hasteImplModulePath: undefined,
+              sha1: false,
+            },
+          ],
         ]);
 
         expect(mockEnd).toBeCalled();
@@ -821,7 +955,7 @@ describe('HasteMap', () => {
     node.mockImplementation(options => {
       const {data} = options;
       data.files = object({
-        '/fruits/banana.js': ['', 32, 0, []],
+        '/fruits/banana.js': ['', 32, 0, [], null],
       });
       return Promise.resolve(data);
     });
@@ -833,7 +967,7 @@ describe('HasteMap', () => {
         expect(node).toBeCalled();
 
         expect(data.files).toEqual({
-          '/fruits/banana.js': ['Banana', 32, 1, ['Strawberry']],
+          '/fruits/banana.js': ['Banana', 32, 1, ['Strawberry'], null],
         });
 
         expect(console.warn.mock.calls[0][0]).toMatchSnapshot();
@@ -850,7 +984,7 @@ describe('HasteMap', () => {
     node.mockImplementation(options => {
       const {data} = options;
       data.files = object({
-        '/fruits/banana.js': ['', 32, 0, []],
+        '/fruits/banana.js': ['', 32, 0, [], null],
       });
       return Promise.resolve(data);
     });
@@ -862,7 +996,7 @@ describe('HasteMap', () => {
         expect(node).toBeCalled();
 
         expect(data.files).toEqual({
-          '/fruits/banana.js': ['Banana', 32, 1, ['Strawberry']],
+          '/fruits/banana.js': ['Banana', 32, 1, ['Strawberry'], null],
         });
       });
   });
@@ -1022,14 +1156,17 @@ describe('HasteMap', () => {
       },
       {
         mockFs: {
-          '/fruits/Orange.android.js': `/**
- * @providesModule Orange
- */
-`,
-          '/fruits/Orange.ios.js': `/**
-* @providesModule Orange
-*/
-`,
+          '/fruits/Orange.android.js': [
+            '/**',
+            ' * @providesModule Orange',
+            ' */',
+          ].join('\n'),
+
+          '/fruits/Orange.ios.js': [
+            '/**',
+            ' * @providesModule Orange',
+            ' */',
+          ].join('\n'),
         },
       },
     );

--- a/packages/jest-haste-map/src/constants.js
+++ b/packages/jest-haste-map/src/constants.js
@@ -22,6 +22,7 @@ export default {
   MTIME: 1,
   VISITED: 2,
   DEPENDENCIES: 3,
+  SHA1: 4,
 
   /* module map attributes */
   PATH: 0,

--- a/packages/jest-haste-map/src/crawlers/__tests__/node.test.js
+++ b/packages/jest-haste-map/src/crawlers/__tests__/node.test.js
@@ -125,9 +125,9 @@ describe('node crawler', () => {
       expect(data.files).not.toBe(null);
 
       expect(data.files).toEqual({
-        '/fruits/strawberry.js': ['', 32, 0, []],
-        '/fruits/tomato.js': ['', 33, 0, []],
-        '/vegetables/melon.json': ['', 34, 0, []],
+        '/fruits/strawberry.js': ['', 32, 0, [], null],
+        '/fruits/tomato.js': ['', 33, 0, [], null],
+        '/vegetables/melon.json': ['', 34, 0, [], null],
       });
     });
 
@@ -142,8 +142,8 @@ describe('node crawler', () => {
     const files = Object.create(null);
 
     // In this test sample, strawberry is changed and tomato is unchanged
-    const tomato = ['', 33, 1, []];
-    files['/fruits/strawberry.js'] = ['', 30, 1, []];
+    const tomato = ['', 33, 1, [], null];
+    files['/fruits/strawberry.js'] = ['', 30, 1, [], null];
     files['/fruits/tomato.js'] = tomato;
 
     return nodeCrawl({
@@ -153,7 +153,7 @@ describe('node crawler', () => {
       roots: ['/fruits'],
     }).then(data => {
       expect(data.files).toEqual({
-        '/fruits/strawberry.js': ['', 32, 0, []],
+        '/fruits/strawberry.js': ['', 32, 0, [], null],
         '/fruits/tomato.js': tomato,
       });
 
@@ -175,8 +175,8 @@ describe('node crawler', () => {
       roots: ['/fruits'],
     }).then(data => {
       expect(data.files).toEqual({
-        '/fruits/directory/strawberry.js': ['', 33, 0, []],
-        '/fruits/tomato.js': ['', 32, 0, []],
+        '/fruits/directory/strawberry.js': ['', 33, 0, [], null],
+        '/fruits/tomato.js': ['', 32, 0, [], null],
       });
     });
   });
@@ -195,8 +195,8 @@ describe('node crawler', () => {
       roots: ['/fruits'],
     }).then(data => {
       expect(data.files).toEqual({
-        '/fruits/directory/strawberry.js': ['', 33, 0, []],
-        '/fruits/tomato.js': ['', 32, 0, []],
+        '/fruits/directory/strawberry.js': ['', 33, 0, [], null],
+        '/fruits/tomato.js': ['', 32, 0, [], null],
       });
     });
   });

--- a/packages/jest-haste-map/src/crawlers/__tests__/watchman.test.js
+++ b/packages/jest-haste-map/src/crawlers/__tests__/watchman.test.js
@@ -92,9 +92,9 @@ describe('watchman watch', () => {
     };
 
     mockFiles = Object.assign(Object.create(null), {
-      [MELON]: ['', 33, 0, []],
-      [STRAWBERRY]: ['', 30, 0, []],
-      [TOMATO]: ['', 31, 0, []],
+      [MELON]: ['', 33, 0, [], null],
+      [STRAWBERRY]: ['', 30, 0, [], null],
+      [TOMATO]: ['', 31, 0, [], null],
     });
   });
 
@@ -192,9 +192,9 @@ describe('watchman watch', () => {
       });
 
       expect(data.files).toEqual({
-        [KIWI]: ['', 42, 0, []],
-        [MELON]: ['', 33, 0, []],
-        [STRAWBERRY]: ['', 30, 0, []],
+        [KIWI]: ['', 42, 0, [], null],
+        [MELON]: ['', 33, 0, [], null],
+        [STRAWBERRY]: ['', 30, 0, [], null],
       });
     });
   });
@@ -228,7 +228,7 @@ describe('watchman watch', () => {
       'watch-project': WATCH_PROJECT_MOCK,
     };
 
-    const mockMetadata = ['Banana', 41, 1, ['Raspberry']];
+    const mockMetadata = ['Banana', 41, 1, ['Raspberry'], null];
     mockFiles[BANANA] = mockMetadata;
 
     const clocks = Object.assign(Object.create(null), {
@@ -254,7 +254,7 @@ describe('watchman watch', () => {
       // /fruits/strawberry.js was removed from the file list.
       expect(data.files).toEqual({
         [BANANA]: mockMetadata,
-        [KIWI]: ['', 42, 0, []],
+        [KIWI]: ['', 42, 0, [], null],
         [TOMATO]: mockFiles[TOMATO],
       });
 
@@ -324,8 +324,8 @@ describe('watchman watch', () => {
       });
 
       expect(data.files).toEqual({
-        [KIWI]: ['', 42, 0, []],
-        [MELON]: ['', 33, 0, []],
+        [KIWI]: ['', 42, 0, [], null],
+        [MELON]: ['', 33, 0, [], null],
       });
     });
   });

--- a/packages/jest-haste-map/src/crawlers/__tests__/watchman.test.js
+++ b/packages/jest-haste-map/src/crawlers/__tests__/watchman.test.js
@@ -15,7 +15,8 @@ jest.mock('fb-watchman', () => {
   const Client = jest.fn();
   Client.prototype.command = jest.fn((args, callback) =>
     setImmediate(() => {
-      const response = mockResponse[args[0]][normalizePathSep(args[1])];
+      const path = args[1] ? normalizePathSep(args[1]) : undefined;
+      const response = mockResponse[args[0]][path];
       callback(null, response.next ? response.next().value : response);
     }),
   );

--- a/packages/jest-haste-map/src/crawlers/node.js
+++ b/packages/jest-haste-map/src/crawlers/node.js
@@ -136,8 +136,8 @@ module.exports = function nodeCrawl(
         if (existingFile && existingFile[H.MTIME] === mtime) {
           files[name] = existingFile;
         } else {
-          // See ../constants.js
-          files[name] = ['', mtime, 0, []];
+          // See ../constants.js; SHA-1 will always be null and fulfilled later.
+          files[name] = ['', mtime, 0, [], null];
         }
       });
       data.files = files;

--- a/packages/jest-haste-map/src/crawlers/watchman.js
+++ b/packages/jest-haste-map/src/crawlers/watchman.js
@@ -38,10 +38,6 @@ module.exports = async function watchmanCrawl(
   const clocks = data.clocks;
   const client = new watchman.Client();
 
-  if (options.sha1) {
-    fields.push('content.sha1hex');
-  }
-
   let clientError;
   client.on('error', error => (clientError = WatchmanError(error)));
 
@@ -53,6 +49,14 @@ module.exports = async function watchmanCrawl(
           error ? reject(WatchmanError(error)) : resolve(result),
       ),
     );
+
+  if (options.computeSha1) {
+    const {capabilities} = await cmd('list-capabilities');
+
+    if (capabilities.indexOf('field-content.sha1hex') !== -1) {
+      fields.push('content.sha1hex');
+    }
+  }
 
   async function getWatchmanRoots(roots) {
     const watchmanRoots = new Map();

--- a/packages/jest-haste-map/src/types.js
+++ b/packages/jest-haste-map/src/types.js
@@ -12,25 +12,25 @@ import type {InternalHasteMap, ModuleMetaData} from 'types/HasteMap';
 export type IgnoreMatcher = (item: string) => boolean;
 
 export type WorkerMessage = {
+  computeSha1: boolean,
   filePath: string,
   hasteImplModulePath?: string,
-  sha1: boolean,
 };
 
 export type WorkerMetadata = {|
+  dependencies: ?Array<string>,
   id: ?string,
   module: ?ModuleMetaData,
-  dependencies: ?Array<string>,
   sha1: ?string,
 |};
 
 export type CrawlerOptions = {|
+  computeSha1: boolean,
   data: InternalHasteMap,
   extensions: Array<string>,
   forceNodeFilesystemAPI: boolean,
   ignore: IgnoreMatcher,
   roots: Array<string>,
-  sha1: boolean,
 |};
 
 export type HasteImpl = {

--- a/packages/jest-haste-map/src/types.js
+++ b/packages/jest-haste-map/src/types.js
@@ -14,13 +14,15 @@ export type IgnoreMatcher = (item: string) => boolean;
 export type WorkerMessage = {
   filePath: string,
   hasteImplModulePath?: string,
+  sha1: boolean,
 };
 
-export type WorkerMetadata = {
+export type WorkerMetadata = {|
   id: ?string,
   module: ?ModuleMetaData,
   dependencies: ?Array<string>,
-};
+  sha1: ?string,
+|};
 
 export type CrawlerOptions = {|
   data: InternalHasteMap,
@@ -28,6 +30,7 @@ export type CrawlerOptions = {|
   forceNodeFilesystemAPI: boolean,
   ignore: IgnoreMatcher,
   roots: Array<string>,
+  sha1: boolean,
 |};
 
 export type HasteImpl = {

--- a/packages/jest-haste-map/src/worker.js
+++ b/packages/jest-haste-map/src/worker.js
@@ -71,7 +71,7 @@ export async function worker(data: WorkerMessage): Promise<WorkerMetadata> {
   }
 
   // If a SHA-1 is requested on update, compute it.
-  if (data.sha1) {
+  if (data.computeSha1) {
     if (content == null) {
       content = fs.readFileSync(filePath);
     }

--- a/packages/jest-haste-map/src/worker.js
+++ b/packages/jest-haste-map/src/worker.js
@@ -9,6 +9,7 @@
 
 import type {HasteImpl, WorkerMessage, WorkerMetadata} from './types';
 
+import crypto from 'crypto';
 import path from 'path';
 import * as docblock from 'jest-docblock';
 import fs from 'graceful-fs';
@@ -35,23 +36,25 @@ export async function worker(data: WorkerMessage): Promise<WorkerMetadata> {
   }
 
   const filePath = data.filePath;
-  let module;
-  let id: ?string;
+  let content;
   let dependencies;
+  let id;
+  let module;
+  let sha1;
 
+  // Process a package.json that is returned as a PACKAGE type with its name.
   if (filePath.endsWith(PACKAGE_JSON)) {
-    const fileData = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+    content = fs.readFileSync(filePath, 'utf8');
+    const fileData = JSON.parse(content);
 
     if (fileData.name) {
       id = fileData.name;
       module = [filePath, H.PACKAGE];
     }
 
-    return {dependencies, id, module};
-  }
-
-  if (!blacklist.has(filePath.substr(filePath.lastIndexOf('.')))) {
-    const content = fs.readFileSync(filePath, 'utf8');
+    // Process a randome file that is returned as a MODULE.
+  } else if (!blacklist.has(filePath.substr(filePath.lastIndexOf('.')))) {
+    content = fs.readFileSync(filePath, 'utf8');
 
     if (hasteImpl) {
       id = hasteImpl.getHasteName(filePath);
@@ -67,5 +70,17 @@ export async function worker(data: WorkerMessage): Promise<WorkerMetadata> {
     }
   }
 
-  return {dependencies, id, module};
+  // If a SHA-1 is requested on update, compute it.
+  if (data.sha1) {
+    if (content == null) {
+      content = fs.readFileSync(filePath);
+    }
+
+    sha1 = crypto
+      .createHash('sha1')
+      .update(content)
+      .digest('hex');
+  }
+
+  return {dependencies, id, module, sha1};
 }

--- a/types/HasteMap.js
+++ b/types/HasteMap.js
@@ -53,6 +53,7 @@ export type FileMetaData = [
   /* mtime */ number,
   /* visited */ 0 | 1,
   /* dependencies */ Array<string>,
+  /* sha1 */ ?string,
 ];
 
 type ModuleMapItem = {[platform: string]: ModuleMetaData};


### PR DESCRIPTION
Adds support to `jest-haste-map` to provide in their public API the SHA-1 of the file. This SHA-1 is extracted from `watchman` when possible, and when not, it is processed by the worker tied to `jest-haste-map`. This however only happens when requested via the `sha1` option when building the Haste Map.

The benefits of this are mainly related to cache invalidation, which is the same reason on why it first got built in `watchman` itself.

I've added tests to confirm that when the SHA-1 is `null`, and it is requested by the user,  the worker will process it (which is what happens with the `node` crawler).