### PR TITLE
add a descriptive error for invalid globalSetup or globalTeardown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@
 
 ### Fixes
 
+* `[jest-cli]` Add descriptive error message when trying to use
+  `globalSetup`/`globalTeardown` file that doesn't export a function.
+  ([#5835](https://github.com/facebook/jest/pull/5835))
 * `[expect]` Do not rely on `instanceof RegExp`, since it will not work for
   RegExps created inside of a different VM
   ([#5729](https://github.com/facebook/jest/pull/5729))

--- a/integration-tests/__tests__/global_setup.test.js
+++ b/integration-tests/__tests__/global_setup.test.js
@@ -35,5 +35,8 @@ test('jest throws an error when globalSetup does not export a function', () => {
   ]);
 
   expect(status).toBe(1);
-  expect(stderr).toMatch('Error: globalSetup file must export a function');
+  expect(stderr).toMatch(
+    'TypeError: globalSetup file must export a function at',
+  );
+  expect(stderr).toMatch(setupPath);
 });

--- a/integration-tests/__tests__/global_setup.test.js
+++ b/integration-tests/__tests__/global_setup.test.js
@@ -27,3 +27,13 @@ test('globalSetup is triggered once before all test suites', () => {
   const setup = fs.readFileSync(path.join(DIR, files[0]), 'utf8');
   expect(setup).toBe('setup');
 });
+
+test('jest throws an error when globalSetup does not export a function', () => {
+  const setupPath = path.resolve(__dirname, '../global-setup/invalid_setup.js');
+  const {status, stderr} = runJest('global-setup', [
+    `--globalSetup=${setupPath}`,
+  ]);
+
+  expect(status).toBe(1);
+  expect(stderr).toMatch('Error: globalSetup file must export a function');
+});

--- a/integration-tests/__tests__/global_setup.test.js
+++ b/integration-tests/__tests__/global_setup.test.js
@@ -36,7 +36,6 @@ test('jest throws an error when globalSetup does not export a function', () => {
 
   expect(status).toBe(1);
   expect(stderr).toMatch(
-    'TypeError: globalSetup file must export a function at',
+    `TypeError: globalSetup file must export a function at ${setupPath}`,
   );
-  expect(stderr).toMatch(setupPath);
 });

--- a/integration-tests/__tests__/global_teardown.test.js
+++ b/integration-tests/__tests__/global_teardown.test.js
@@ -36,14 +36,17 @@ test('globalTeardown is triggered once after all test suites', () => {
 });
 
 test('jest throws an error when globalTeardown does not export a function', () => {
-  const setupPath = path.resolve(
+  const teardownPath = path.resolve(
     __dirname,
     '../global-teardown/invalid_teardown.js',
   );
   const {status, stderr} = runJest('global-teardown', [
-    `--globalTeardown=${setupPath}`,
+    `--globalTeardown=${teardownPath}`,
   ]);
 
   expect(status).toBe(1);
-  expect(stderr).toMatch('Error: globalTeardown file must export a function');
+  expect(stderr).toMatch(
+    'TypeError: globalTeardown file must export a function at',
+  );
+  expect(stderr).toMatch(teardownPath);
 });

--- a/integration-tests/__tests__/global_teardown.test.js
+++ b/integration-tests/__tests__/global_teardown.test.js
@@ -46,7 +46,6 @@ test('jest throws an error when globalTeardown does not export a function', () =
 
   expect(status).toBe(1);
   expect(stderr).toMatch(
-    'TypeError: globalTeardown file must export a function at',
+    `TypeError: globalTeardown file must export a function at ${teardownPath}`,
   );
-  expect(stderr).toMatch(teardownPath);
 });

--- a/integration-tests/__tests__/global_teardown.test.js
+++ b/integration-tests/__tests__/global_teardown.test.js
@@ -34,3 +34,16 @@ test('globalTeardown is triggered once after all test suites', () => {
   const teardown = fs.readFileSync(path.join(DIR, files[0]), 'utf8');
   expect(teardown).toBe('teardown');
 });
+
+test('jest throws an error when globalTeardown does not export a function', () => {
+  const setupPath = path.resolve(
+    __dirname,
+    '../global-teardown/invalid_teardown.js',
+  );
+  const {status, stderr} = runJest('global-teardown', [
+    `--globalTeardown=${setupPath}`,
+  ]);
+
+  expect(status).toBe(1);
+  expect(stderr).toMatch('Error: globalTeardown file must export a function');
+});

--- a/integration-tests/global-setup/invalid_setup.js
+++ b/integration-tests/global-setup/invalid_setup.js
@@ -1,0 +1,1 @@
+console.log('there is no exported function');

--- a/integration-tests/global-teardown/invalid_teardown.js
+++ b/integration-tests/global-teardown/invalid_teardown.js
@@ -1,0 +1,1 @@
+console.log('there is no exported function');

--- a/packages/jest-cli/src/run_jest.js
+++ b/packages/jest-cli/src/run_jest.js
@@ -202,7 +202,12 @@ export default (async function runJest({
   setConfig(contexts, {cwd: process.cwd()});
   if (globalConfig.globalSetup) {
     // $FlowFixMe
-    await require(globalConfig.globalSetup)();
+    const globalSetup = await require(globalConfig.globalSetup);
+    if (typeof globalSetup !== 'function') {
+      throw new Error('globalSetup file must export a function');
+    }
+
+    globalSetup();
   }
   const results = await new TestScheduler(
     globalConfig,
@@ -216,7 +221,12 @@ export default (async function runJest({
 
   if (globalConfig.globalTeardown) {
     // $FlowFixMe
-    await require(globalConfig.globalTeardown)();
+    const globalTeardown = await require(globalConfig.globalTeardown);
+    if (typeof globalTeardown !== 'function') {
+      throw new Error('globalTeardown file must export a function');
+    }
+
+    globalTeardown();
   }
   return processResults(results, {
     isJSON: globalConfig.json,

--- a/packages/jest-cli/src/run_jest.js
+++ b/packages/jest-cli/src/run_jest.js
@@ -202,12 +202,16 @@ export default (async function runJest({
   setConfig(contexts, {cwd: process.cwd()});
   if (globalConfig.globalSetup) {
     // $FlowFixMe
-    const globalSetup = await require(globalConfig.globalSetup);
+    const globalSetup = require(globalConfig.globalSetup);
     if (typeof globalSetup !== 'function') {
-      throw new Error('globalSetup file must export a function');
+      throw new TypeError(
+        `globalSetup file must export a function at ${
+          globalConfig.globalSetup
+        }`,
+      );
     }
 
-    globalSetup();
+    await globalSetup();
   }
   const results = await new TestScheduler(
     globalConfig,
@@ -221,12 +225,16 @@ export default (async function runJest({
 
   if (globalConfig.globalTeardown) {
     // $FlowFixMe
-    const globalTeardown = await require(globalConfig.globalTeardown);
+    const globalTeardown = require(globalConfig.globalTeardown);
     if (typeof globalTeardown !== 'function') {
-      throw new Error('globalTeardown file must export a function');
+      throw new TypeError(
+        `globalTeardown file must export a function at ${
+          globalConfig.globalTeardown
+        }`,
+      );
     }
 
-    globalTeardown();
+    await globalTeardown();
   }
   return processResults(results, {
     isJSON: globalConfig.json,


### PR DESCRIPTION
## Summary
This PR solves #5628 by providing a descriptive error message for cases that `globalSetup` or `globalTeardown` does not export a function.

## Test plan

Verify that we see the wanted error in stdout after using an invalid `globalSetup`/`globalTeardown` file.
