### PR TITLE
Improve output format for mismatchedArgs in mock/spy calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Features
 
+* `[expect]` Improve output format for mismatchedArgs in mock/spy calls.
+  ([#5846](https://github.com/facebook/jest/pull/5846))
 * `[jest-cli]` Add support for using `--coverage` in combination with watch
   mode, `--onlyChanged`, `--findRelatedTests` and more
   ([#5601](https://github.com/facebook/jest/pull/5601))

--- a/packages/expect/src/__tests__/__snapshots__/spy_matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/spy_matchers.test.js.snap
@@ -34,7 +34,21 @@ exports[`lastCalledWith works with Map 2`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).lastCalledWith(</><green>expected</><dim>)</>
 
 Expected mock function to have been last called with:
-  <green>Map {\\"a\\" => \\"b\\", \\"b\\" => \\"a\\"}</> as argument 1, but it was called with <red>Map {1 => 2, 2 => 1}</>."
+  <green>Map {\\"a\\" => \\"b\\", \\"b\\" => \\"a\\"}</>
+as argument 1, but it was called with
+  <red>Map {1 => 2, 2 => 1}</>.
+
+Difference:
+
+<green>- Expected</>
+<red>+ Received</>
+
+<dim>  Map {</>
+<green>-   \\"a\\" => \\"b\\",</>
+<green>-   \\"b\\" => \\"a\\",</>
+<red>+   1 => 2,</>
+<red>+   2 => 1,</>
+<dim>  }</>"
 `;
 
 exports[`lastCalledWith works with Set 1`] = `
@@ -48,14 +62,30 @@ exports[`lastCalledWith works with Set 2`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).lastCalledWith(</><green>expected</><dim>)</>
 
 Expected mock function to have been last called with:
-  <green>Set {3, 4}</> as argument 1, but it was called with <red>Set {1, 2}</>."
+  <green>Set {3, 4}</>
+as argument 1, but it was called with
+  <red>Set {1, 2}</>.
+
+Difference:
+
+<green>- Expected</>
+<red>+ Received</>
+
+<dim>  Set {</>
+<green>-   3,</>
+<green>-   4,</>
+<red>+   1,</>
+<red>+   2,</>
+<dim>  }</>"
 `;
 
 exports[`lastCalledWith works with arguments that don't match 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).lastCalledWith(</><green>expected</><dim>)</>
 
 Expected mock function to have been last called with:
-  <green>\\"bar\\"</> as argument 2, but it was called with <red>\\"bar1\\"</>."
+  <green>\\"bar\\"</>
+as argument 2, but it was called with
+  <red>\\"bar1\\"</>."
 `;
 
 exports[`lastCalledWith works with arguments that match 1`] = `
@@ -97,28 +127,36 @@ exports[`lastCalledWith works with many arguments that don't match 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).lastCalledWith(</><green>expected</><dim>)</>
 
 Expected mock function to have been last called with:
-  <green>\\"bar\\"</> as argument 2, but it was called with <red>\\"bar3\\"</>."
+  <green>\\"bar\\"</>
+as argument 2, but it was called with
+  <red>\\"bar3\\"</>."
 `;
 
 exports[`lastCalledWith works with many arguments that don't match 2`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).lastCalledWith(</><green>expected</><dim>)</>
 
 Expected mock function to have been last called with:
-  <green>\\"bar\\"</> as argument 2, but it was called with <red>\\"bar3\\"</>."
+  <green>\\"bar\\"</>
+as argument 2, but it was called with
+  <red>\\"bar3\\"</>."
 `;
 
 exports[`lastCalledWith works with many arguments that don't match 3`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).lastCalledWith(</><green>expected</><dim>)</>
 
 Expected mock function to have been last called with:
-  <green>\\"bar\\"</> as argument 2, but it was called with <red>\\"bar3\\"</>."
+  <green>\\"bar\\"</>
+as argument 2, but it was called with
+  <red>\\"bar3\\"</>."
 `;
 
 exports[`lastCalledWith works with many arguments that don't match 4`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).lastCalledWith(</><green>expected</><dim>)</>
 
 Expected mock function to have been last called with:
-  <green>\\"bar\\"</> as argument 2, but it was called with <red>\\"bar3\\"</>."
+  <green>\\"bar\\"</>
+as argument 2, but it was called with
+  <red>\\"bar3\\"</>."
 `;
 
 exports[`lastCalledWith works with trailing undefined arguments 1`] = `
@@ -254,7 +292,21 @@ exports[`nthCalledWith works with Map 2`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).nthCalledWith(</><green>expected</><dim>)</>
 
 Expected mock function first call to have been called with:
-  <green>Map {\\"a\\" => \\"b\\", \\"b\\" => \\"a\\"}</> as argument 1, but it was called with <red>Map {1 => 2, 2 => 1}</>."
+  <green>Map {\\"a\\" => \\"b\\", \\"b\\" => \\"a\\"}</>
+as argument 1, but it was called with
+  <red>Map {1 => 2, 2 => 1}</>.
+
+Difference:
+
+<green>- Expected</>
+<red>+ Received</>
+
+<dim>  Map {</>
+<green>-   \\"a\\" => \\"b\\",</>
+<green>-   \\"b\\" => \\"a\\",</>
+<red>+   1 => 2,</>
+<red>+   2 => 1,</>
+<dim>  }</>"
 `;
 
 exports[`nthCalledWith works with Set 1`] = `
@@ -268,14 +320,30 @@ exports[`nthCalledWith works with Set 2`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).nthCalledWith(</><green>expected</><dim>)</>
 
 Expected mock function first call to have been called with:
-  <green>Set {3, 4}</> as argument 1, but it was called with <red>Set {1, 2}</>."
+  <green>Set {3, 4}</>
+as argument 1, but it was called with
+  <red>Set {1, 2}</>.
+
+Difference:
+
+<green>- Expected</>
+<red>+ Received</>
+
+<dim>  Set {</>
+<green>-   3,</>
+<green>-   4,</>
+<red>+   1,</>
+<red>+   2,</>
+<dim>  }</>"
 `;
 
 exports[`nthCalledWith works with arguments that don't match 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).nthCalledWith(</><green>expected</><dim>)</>
 
 Expected mock function first call to have been called with:
-  <green>\\"bar\\"</> as argument 2, but it was called with <red>\\"bar1\\"</>."
+  <green>\\"bar\\"</>
+as argument 2, but it was called with
+  <red>\\"bar1\\"</>."
 `;
 
 exports[`nthCalledWith works with arguments that match 1`] = `
@@ -466,7 +534,21 @@ exports[`toHaveBeenCalledWith works with Map 2`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).toHaveBeenCalledWith(</><green>expected</><dim>)</>
 
 Expected mock function to have been called with:
-  <green>Map {\\"a\\" => \\"b\\", \\"b\\" => \\"a\\"}</> as argument 1, but it was called with <red>Map {1 => 2, 2 => 1}</>."
+  <green>Map {\\"a\\" => \\"b\\", \\"b\\" => \\"a\\"}</>
+as argument 1, but it was called with
+  <red>Map {1 => 2, 2 => 1}</>.
+
+Difference:
+
+<green>- Expected</>
+<red>+ Received</>
+
+<dim>  Map {</>
+<green>-   \\"a\\" => \\"b\\",</>
+<green>-   \\"b\\" => \\"a\\",</>
+<red>+   1 => 2,</>
+<red>+   2 => 1,</>
+<dim>  }</>"
 `;
 
 exports[`toHaveBeenCalledWith works with Set 1`] = `
@@ -480,14 +562,30 @@ exports[`toHaveBeenCalledWith works with Set 2`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).toHaveBeenCalledWith(</><green>expected</><dim>)</>
 
 Expected mock function to have been called with:
-  <green>Set {3, 4}</> as argument 1, but it was called with <red>Set {1, 2}</>."
+  <green>Set {3, 4}</>
+as argument 1, but it was called with
+  <red>Set {1, 2}</>.
+
+Difference:
+
+<green>- Expected</>
+<red>+ Received</>
+
+<dim>  Set {</>
+<green>-   3,</>
+<green>-   4,</>
+<red>+   1,</>
+<red>+   2,</>
+<dim>  }</>"
 `;
 
 exports[`toHaveBeenCalledWith works with arguments that don't match 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).toHaveBeenCalledWith(</><green>expected</><dim>)</>
 
 Expected mock function to have been called with:
-  <green>\\"bar\\"</> as argument 2, but it was called with <red>\\"bar1\\"</>."
+  <green>\\"bar\\"</>
+as argument 2, but it was called with
+  <red>\\"bar1\\"</>."
 `;
 
 exports[`toHaveBeenCalledWith works with arguments that match 1`] = `
@@ -529,44 +627,68 @@ exports[`toHaveBeenCalledWith works with many arguments that don't match 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).toHaveBeenCalledWith(</><green>expected</><dim>)</>
 
 Expected mock function to have been called with:
-  <green>\\"bar\\"</> as argument 2, but it was called with <red>\\"bar3\\"</>.
+  <green>\\"bar\\"</>
+as argument 2, but it was called with
+  <red>\\"bar3\\"</>.
 
-  <green>\\"bar\\"</> as argument 2, but it was called with <red>\\"bar2\\"</>.
+  <green>\\"bar\\"</>
+as argument 2, but it was called with
+  <red>\\"bar2\\"</>.
 
-  <green>\\"bar\\"</> as argument 2, but it was called with <red>\\"bar1\\"</>."
+  <green>\\"bar\\"</>
+as argument 2, but it was called with
+  <red>\\"bar1\\"</>."
 `;
 
 exports[`toHaveBeenCalledWith works with many arguments that don't match 2`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).toHaveBeenCalledWith(</><green>expected</><dim>)</>
 
 Expected mock function to have been called with:
-  <green>\\"bar\\"</> as argument 2, but it was called with <red>\\"bar3\\"</>.
+  <green>\\"bar\\"</>
+as argument 2, but it was called with
+  <red>\\"bar3\\"</>.
 
-  <green>\\"bar\\"</> as argument 2, but it was called with <red>\\"bar2\\"</>.
+  <green>\\"bar\\"</>
+as argument 2, but it was called with
+  <red>\\"bar2\\"</>.
 
-  <green>\\"bar\\"</> as argument 2, but it was called with <red>\\"bar1\\"</>."
+  <green>\\"bar\\"</>
+as argument 2, but it was called with
+  <red>\\"bar1\\"</>."
 `;
 
 exports[`toHaveBeenCalledWith works with many arguments that don't match 3`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).toHaveBeenCalledWith(</><green>expected</><dim>)</>
 
 Expected mock function to have been called with:
-  <green>\\"bar\\"</> as argument 2, but it was called with <red>\\"bar3\\"</>.
+  <green>\\"bar\\"</>
+as argument 2, but it was called with
+  <red>\\"bar3\\"</>.
 
-  <green>\\"bar\\"</> as argument 2, but it was called with <red>\\"bar2\\"</>.
+  <green>\\"bar\\"</>
+as argument 2, but it was called with
+  <red>\\"bar2\\"</>.
 
-  <green>\\"bar\\"</> as argument 2, but it was called with <red>\\"bar1\\"</>."
+  <green>\\"bar\\"</>
+as argument 2, but it was called with
+  <red>\\"bar1\\"</>."
 `;
 
 exports[`toHaveBeenCalledWith works with many arguments that don't match 4`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).toHaveBeenCalledWith(</><green>expected</><dim>)</>
 
 Expected mock function to have been called with:
-  <green>\\"bar\\"</> as argument 2, but it was called with <red>\\"bar3\\"</>.
+  <green>\\"bar\\"</>
+as argument 2, but it was called with
+  <red>\\"bar3\\"</>.
 
-  <green>\\"bar\\"</> as argument 2, but it was called with <red>\\"bar2\\"</>.
+  <green>\\"bar\\"</>
+as argument 2, but it was called with
+  <red>\\"bar2\\"</>.
 
-  <green>\\"bar\\"</> as argument 2, but it was called with <red>\\"bar1\\"</>."
+  <green>\\"bar\\"</>
+as argument 2, but it was called with
+  <red>\\"bar1\\"</>."
 `;
 
 exports[`toHaveBeenCalledWith works with trailing undefined arguments 1`] = `
@@ -610,7 +732,21 @@ exports[`toHaveBeenLastCalledWith works with Map 2`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).toHaveBeenLastCalledWith(</><green>expected</><dim>)</>
 
 Expected mock function to have been last called with:
-  <green>Map {\\"a\\" => \\"b\\", \\"b\\" => \\"a\\"}</> as argument 1, but it was called with <red>Map {1 => 2, 2 => 1}</>."
+  <green>Map {\\"a\\" => \\"b\\", \\"b\\" => \\"a\\"}</>
+as argument 1, but it was called with
+  <red>Map {1 => 2, 2 => 1}</>.
+
+Difference:
+
+<green>- Expected</>
+<red>+ Received</>
+
+<dim>  Map {</>
+<green>-   \\"a\\" => \\"b\\",</>
+<green>-   \\"b\\" => \\"a\\",</>
+<red>+   1 => 2,</>
+<red>+   2 => 1,</>
+<dim>  }</>"
 `;
 
 exports[`toHaveBeenLastCalledWith works with Set 1`] = `
@@ -624,14 +760,30 @@ exports[`toHaveBeenLastCalledWith works with Set 2`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).toHaveBeenLastCalledWith(</><green>expected</><dim>)</>
 
 Expected mock function to have been last called with:
-  <green>Set {3, 4}</> as argument 1, but it was called with <red>Set {1, 2}</>."
+  <green>Set {3, 4}</>
+as argument 1, but it was called with
+  <red>Set {1, 2}</>.
+
+Difference:
+
+<green>- Expected</>
+<red>+ Received</>
+
+<dim>  Set {</>
+<green>-   3,</>
+<green>-   4,</>
+<red>+   1,</>
+<red>+   2,</>
+<dim>  }</>"
 `;
 
 exports[`toHaveBeenLastCalledWith works with arguments that don't match 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).toHaveBeenLastCalledWith(</><green>expected</><dim>)</>
 
 Expected mock function to have been last called with:
-  <green>\\"bar\\"</> as argument 2, but it was called with <red>\\"bar1\\"</>."
+  <green>\\"bar\\"</>
+as argument 2, but it was called with
+  <red>\\"bar1\\"</>."
 `;
 
 exports[`toHaveBeenLastCalledWith works with arguments that match 1`] = `
@@ -673,28 +825,36 @@ exports[`toHaveBeenLastCalledWith works with many arguments that don't match 1`]
 "<dim>expect(</><red>jest.fn()</><dim>).toHaveBeenLastCalledWith(</><green>expected</><dim>)</>
 
 Expected mock function to have been last called with:
-  <green>\\"bar\\"</> as argument 2, but it was called with <red>\\"bar3\\"</>."
+  <green>\\"bar\\"</>
+as argument 2, but it was called with
+  <red>\\"bar3\\"</>."
 `;
 
 exports[`toHaveBeenLastCalledWith works with many arguments that don't match 2`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).toHaveBeenLastCalledWith(</><green>expected</><dim>)</>
 
 Expected mock function to have been last called with:
-  <green>\\"bar\\"</> as argument 2, but it was called with <red>\\"bar3\\"</>."
+  <green>\\"bar\\"</>
+as argument 2, but it was called with
+  <red>\\"bar3\\"</>."
 `;
 
 exports[`toHaveBeenLastCalledWith works with many arguments that don't match 3`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).toHaveBeenLastCalledWith(</><green>expected</><dim>)</>
 
 Expected mock function to have been last called with:
-  <green>\\"bar\\"</> as argument 2, but it was called with <red>\\"bar3\\"</>."
+  <green>\\"bar\\"</>
+as argument 2, but it was called with
+  <red>\\"bar3\\"</>."
 `;
 
 exports[`toHaveBeenLastCalledWith works with many arguments that don't match 4`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).toHaveBeenLastCalledWith(</><green>expected</><dim>)</>
 
 Expected mock function to have been last called with:
-  <green>\\"bar\\"</> as argument 2, but it was called with <red>\\"bar3\\"</>."
+  <green>\\"bar\\"</>
+as argument 2, but it was called with
+  <red>\\"bar3\\"</>."
 `;
 
 exports[`toHaveBeenLastCalledWith works with trailing undefined arguments 1`] = `

--- a/packages/expect/src/spy_matchers.js
+++ b/packages/expect/src/spy_matchers.js
@@ -24,6 +24,7 @@ import {
 } from 'jest-matcher-utils';
 import {equals} from './jasmine_utils';
 import {iterableEquality, partition} from './utils';
+import diff from 'jest-diff';
 
 const createToBeCalledMatcher = matcherName => (received, expected) => {
   ensureNoExpected(expected, matcherName);
@@ -268,9 +269,12 @@ const formatMismatchedArgs = (expected, received) => {
   const printedArgs = [];
   for (let i = 0; i < length; i++) {
     if (!equals(expected[i], received[i], [iterableEquality])) {
+      const diffString = diff(expected[i], received[i]);
       printedArgs.push(
-        `  ${printExpected(expected[i])} as argument ${i + 1}, ` +
-          `but it was called with ${printReceived(received[i])}.`,
+        `  ${printExpected(expected[i])}\n` +
+          `as argument ${i + 1}, but it was called with\n` +
+          `  ${printReceived(received[i])}.` +
+          (diffString ? `\n\nDifference:\n\n${diffString}` : ''),
       );
     } else if (i >= expected.length) {
       printedArgs.push(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Solves #5843 

## Test plan

Old output:
![image](https://user-images.githubusercontent.com/2379486/37714160-1fbfc90e-2d19-11e8-9fd7-c529e7c54962.png)

New output:
![image](https://user-images.githubusercontent.com/2379486/37714164-26193a74-2d19-11e8-8b9d-0d43942d4955.png)

