### PR TITLE
assign process.env.JEST_WORKER_ID=1 when in runInBand mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@
 
 ### Fixes
 
+* `[jest-runner]` Assign `process.env.JEST_WORKER_ID="0"` when in runInBand mode
+  ([#5860](https://github.com/facebook/jest/pull/5860))
 * `[jest-cli]` Add descriptive error message when trying to use
   `globalSetup`/`globalTeardown` file that doesn't export a function.
   ([#5835](https://github.com/facebook/jest/pull/5835))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@
 
 ### Fixes
 
-* `[jest-runner]` Assign `process.env.JEST_WORKER_ID="0"` when in runInBand mode
+* `[jest-runner]` Assign `process.env.JEST_WORKER_ID="1"` when in runInBand mode
   ([#5860](https://github.com/facebook/jest/pull/5860))
 * `[jest-cli]` Add descriptive error message when trying to use
   `globalSetup`/`globalTeardown` file that doesn't export a function.

--- a/packages/jest-runner/src/__tests__/test_runner.test.js
+++ b/packages/jest-runner/src/__tests__/test_runner.test.js
@@ -86,3 +86,22 @@ test('does not inject the rawModuleMap in serial mode', () => {
       ]);
     });
 });
+
+test('assign process.env.JEST_WORKER_ID = 0 when in runInBand mode', () => {
+  const globalConfig = {maxWorkers: 1, watch: false};
+  const config = {rootDir: '/path/'};
+  const context = {config};
+
+  return new TestRunner(globalConfig)
+    .runTests(
+      [{context, path: './file.test.js'}],
+      new TestWatcher({isWatchMode: globalConfig.watch}),
+      () => {},
+      () => {},
+      () => {},
+      {serial: true},
+    )
+    .then(() => {
+      expect(process.env.JEST_WORKER_ID).toBe('0');
+    });
+});

--- a/packages/jest-runner/src/__tests__/test_runner.test.js
+++ b/packages/jest-runner/src/__tests__/test_runner.test.js
@@ -87,7 +87,7 @@ test('does not inject the rawModuleMap in serial mode', () => {
     });
 });
 
-test('assign process.env.JEST_WORKER_ID = 0 when in runInBand mode', () => {
+test('assign process.env.JEST_WORKER_ID = 1 when in runInBand mode', () => {
   const globalConfig = {maxWorkers: 1, watch: false};
   const config = {rootDir: '/path/'};
   const context = {config};
@@ -102,6 +102,6 @@ test('assign process.env.JEST_WORKER_ID = 0 when in runInBand mode', () => {
       {serial: true},
     )
     .then(() => {
-      expect(process.env.JEST_WORKER_ID).toBe('0');
+      expect(process.env.JEST_WORKER_ID).toBe('1');
     });
 });

--- a/packages/jest-runner/src/index.js
+++ b/packages/jest-runner/src/index.js
@@ -61,7 +61,7 @@ class TestRunner {
     onResult: OnTestSuccess,
     onFailure: OnTestFailure,
   ) {
-    process.env.JEST_WORKER_ID = '0';
+    process.env.JEST_WORKER_ID = '1';
     const mutex = throat(1);
     return tests.reduce(
       (promise, test) =>

--- a/packages/jest-runner/src/index.js
+++ b/packages/jest-runner/src/index.js
@@ -61,6 +61,7 @@ class TestRunner {
     onResult: OnTestSuccess,
     onFailure: OnTestFailure,
   ) {
+    process.env.JEST_WORKER_ID = '0';
     const mutex = throat(1);
     return tests.reduce(
       (promise, test) =>


### PR DESCRIPTION
## Summary
Following #5494, provide `process.env.JEST_WORKER_ID="1"` for cases when Jest runs the tests on the main process.

https://github.com/facebook/jest/blob/6a77ee37ec2d46ece7e9cfd0f891d11c113cc4c4/packages/jest-cli/src/test_scheduler.js#L88-L96

So our tests code could stay the same, without the need to check whether `process.env.JEST_WORKER_ID` is `undefined`.

## Test plan

Test that after we run jest with `{serial: true}` `process.env.JEST_WORKER_ID` will be `"1"`