### PR TITLE
Create basic readme for expect package

### DIFF
--- a/packages/expect/README.md
+++ b/packages/expect/README.md
@@ -1,0 +1,3 @@
+# expect
+
+This package exports the `expect` function used in [Jest](https://facebook.github.io/jest/). You can find its documentation [on Jest's website](https://facebook.github.io/jest/docs/en/expect.html).

--- a/packages/expect/README.md
+++ b/packages/expect/README.md
@@ -1,3 +1,5 @@
 # expect
 
-This package exports the `expect` function used in [Jest](https://facebook.github.io/jest/). You can find its documentation [on Jest's website](https://facebook.github.io/jest/docs/en/expect.html).
+This package exports the `expect` function used in
+[Jest](https://facebook.github.io/jest/). You can find its documentation
+[on Jest's website](https://facebook.github.io/jest/docs/en/expect.html).


### PR DESCRIPTION
## Summary

It's kind of weird that [the expect package on npm](https://www.npmjs.com/package/expect) doesn't have a readme. This adds a simple one which directs users to Jest's docs for `expect`.

## Test plan

N/A