### PR TITLE
Expose SHA-1s via HasteFS

### DIFF
--- a/packages/jest-haste-map/src/haste_fs.js
+++ b/packages/jest-haste-map/src/haste_fs.js
@@ -29,6 +29,10 @@ export default class HasteFS {
     return (this._files[file] && this._files[file][H.DEPENDENCIES]) || null;
   }
 
+  getSha1(file: Path): ?string {
+    return (this._files[file] && this._files[file][H.SHA1]) || null;
+  }
+
   exists(file: Path): boolean {
     return !!this._files[file];
   }


### PR DESCRIPTION
In order to access the SHA-1, if requested, we need to expose a public getter.