### PR TITLE
Added link to Mercurial

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,8 +73,9 @@ _Before_ submitting a pull request, please make sure the following is done…
 5.  If you've changed APIs, update the documentation.
 
 6.  Ensure the test suite passes via `yarn test`. To run the test suite you may
-    need to install Mercurial (`hg`). On macOS, this can be done using
-    [homebrew](http://brew.sh/): `brew install hg`.
+    need to install [Mercurial](https://www.mercurial-scm.org/) (`hg`). On
+    macOS, this can be done using [homebrew](http://brew.sh/):
+    `brew install hg`.
 
     ```sh
     brew install hg # maybe


### PR DESCRIPTION
## Summary

CONTRIBUTING.md has links to Yarn and homebrew, but not Mercurial.
This PR adds link to Mercurial website https://www.mercurial-scm.org/ if contributors want to find more info.

## Test plan

It's just a documentation update in CONTRIBUTING.md, testing not necessary.