### PR TITLE
haste-map: Support extracting dynamic `import`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 
+* `[jest-haste-map]` Support extracting dynamic `import`s (TBD)
 * `[expect]` Improve output format for mismatchedArgs in mock/spy calls.
   ([#5846](https://github.com/facebook/jest/pull/5846))
 * `[jest-cli]` Add support for using `--coverage` in combination with watch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ### Features
 
-* `[jest-haste-map]` Support extracting dynamic `import`s (TBD)
+* `[jest-haste-map]` Support extracting dynamic `import`s
+  ([#5883](https://github.com/facebook/jest/pull/5883))
 * `[expect]` Improve output format for mismatchedArgs in mock/spy calls.
   ([#5846](https://github.com/facebook/jest/pull/5846))
 * `[jest-cli]` Add support for using `--coverage` in combination with watch

--- a/packages/jest-haste-map/src/index.js
+++ b/packages/jest-haste-map/src/index.js
@@ -14,7 +14,6 @@ import crypto from 'crypto';
 import EventEmitter from 'events';
 import getMockName from './get_mock_name';
 import getPlatformExtension from './lib/get_platform_extension';
-// eslint-disable-next-line import/no-duplicates
 import H from './constants';
 import HasteFS from './haste_fs';
 import HasteModuleMap from './module_map';
@@ -41,8 +40,7 @@ import type {
   MockData,
 } from 'types/HasteMap';
 
-// eslint-disable-next-line import/no-duplicates
-import typeof HType from './constants';
+type HType = typeof H;
 
 type Options = {
   cacheDirectory?: string,

--- a/packages/jest-haste-map/src/lib/__tests__/extract_requires.test.js
+++ b/packages/jest-haste-map/src/lib/__tests__/extract_requires.test.js
@@ -15,9 +15,10 @@ it('extracts both requires and imports from code', () => {
   const code = `
       import module1 from 'module1';
       const module2 = require('module2');
+      import('module3').then(module3 => {})';
     `;
 
-  expect(extractRequires(code)).toEqual(['module1', 'module2']);
+  expect(extractRequires(code)).toEqual(['module1', 'module2', 'module3']);
 });
 
 it('extracts requires in order', () => {

--- a/packages/jest-haste-map/src/lib/extract_requires.js
+++ b/packages/jest-haste-map/src/lib/extract_requires.js
@@ -11,7 +11,7 @@ const blockCommentRe = /\/\*[^]*?\*\//g;
 const lineCommentRe = /\/\/.*/g;
 
 const replacePatterns = {
-  DYNAMIC_IMPORT_RE: /(?:^|[^.]\s*)(\import\s*?\(\s*?)([`'"])([^`'"]+)(\2\s*?\))/g,
+  DYNAMIC_IMPORT_RE: /(?:^|[^.]\s*)(\bimport\s*?\(\s*?)([`'"])([^`'"]+)(\2\s*?\))/g,
   EXPORT_RE: /(\bexport\s+(?!type )(?:[^'"]+\s+from\s+)??)(['"])([^'"]+)(\2)/g,
   IMPORT_RE: /(\bimport\s+(?!type )(?:[^'"]+\s+from\s+)??)(['"])([^'"]+)(\2)/g,
   REQUIRE_EXTENSIONS_PATTERN: /(?:^|[^.]\s*)(\b(?:require\s*?\.\s*?(?:requireActual|requireMock)|jest\s*?\.\s*?(?:requireActual|requireMock|genMockFromModule))\s*?\(\s*?)([`'"])([^`'"]+)(\2\s*?\))/g,

--- a/packages/jest-haste-map/src/lib/extract_requires.js
+++ b/packages/jest-haste-map/src/lib/extract_requires.js
@@ -11,6 +11,7 @@ const blockCommentRe = /\/\*[^]*?\*\//g;
 const lineCommentRe = /\/\/.*/g;
 
 const replacePatterns = {
+  DYNAMIC_IMPORT_RE: /(?:^|[^.]\s*)(\import\s*?\(\s*?)([`'"])([^`'"]+)(\2\s*?\))/g,
   EXPORT_RE: /(\bexport\s+(?!type )(?:[^'"]+\s+from\s+)??)(['"])([^'"]+)(\2)/g,
   IMPORT_RE: /(\bimport\s+(?!type )(?:[^'"]+\s+from\s+)??)(['"])([^'"]+)(\2)/g,
   REQUIRE_EXTENSIONS_PATTERN: /(?:^|[^.]\s*)(\b(?:require\s*?\.\s*?(?:requireActual|requireMock)|jest\s*?\.\s*?(?:requireActual|requireMock|genMockFromModule))\s*?\(\s*?)([`'"])([^`'"]+)(\2\s*?\))/g,
@@ -30,7 +31,8 @@ export default function extractRequires(code: string): Array<string> {
     .replace(replacePatterns.EXPORT_RE, addDependency)
     .replace(replacePatterns.IMPORT_RE, addDependency)
     .replace(replacePatterns.REQUIRE_EXTENSIONS_PATTERN, addDependency)
-    .replace(replacePatterns.REQUIRE_RE, addDependency);
+    .replace(replacePatterns.REQUIRE_RE, addDependency)
+    .replace(replacePatterns.DYNAMIC_IMPORT_RE, addDependency);
 
   return Array.from(dependencies);
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary
Support `import('some-module')` when building up a dependency tree within `jest-haste-map`.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan
Assertion added

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
