### PR TITLE
Refactor: unify handling of topSuite and children suites + increase readability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,12 @@
   ([#5648](https://github.com/facebook/jest/pull/5648))
 * `[docs]` Mention Jest Puppeteer Preset
   ([#5722](https://github.com/facebook/jest/pull/5722))
+
+### Chore & Maintenance
+
+* `[jest-jasmine2]` Simplify `Env.execute` and TreeProcessor to setup and clean
+  resources for the top suite the same way as for all of the children suites
+  ([#5673](https://github.com/facebook/jest/pull/5673))
 * `[docs]` Add jest-community section to website
   ([#5675](https://github.com/facebook/jest/pull/5675))
 * `[docs]` Add versioned docs for v22.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,20 +70,17 @@
 
 ### Chore & Maintenance
 
-* `[#5858]` Run Prettier on compiled output
+* `[jest-jasmine2]` Simplify `Env.execute` and TreeProcessor to setup and clean
+  resources for the top suite the same way as for all of the children suites
+  ([#5885](https://github.com/facebook/jest/pull/5885))
+* `*` Run Prettier on compiled output
   ([#5858](https://github.com/facebook/jest/pull/3497))
-* `[#5708]` Add fileChange hook for plugins
+* `[jest-cli]` Add fileChange hook for plugins
   ([#5708](https://github.com/facebook/jest/pull/5708))
 * `[docs]` Add docs on using `jest.mock(...)`
   ([#5648](https://github.com/facebook/jest/pull/5648))
 * `[docs]` Mention Jest Puppeteer Preset
   ([#5722](https://github.com/facebook/jest/pull/5722))
-
-### Chore & Maintenance
-
-* `[jest-jasmine2]` Simplify `Env.execute` and TreeProcessor to setup and clean
-  resources for the top suite the same way as for all of the children suites
-  ([#5673](https://github.com/facebook/jest/pull/5673))
 * `[docs]` Add jest-community section to website
   ([#5675](https://github.com/facebook/jest/pull/5675))
 * `[docs]` Add versioned docs for v22.4

--- a/integration-tests/__tests__/__snapshots__/globals.test.js.snap
+++ b/integration-tests/__tests__/__snapshots__/globals.test.js.snap
@@ -32,7 +32,7 @@ exports[`cannot test with no implementation 1`] = `
       4 |     test('test, no implementation');
       5 |   
       
-      at packages/jest-jasmine2/build/jasmine/Env.js:405:15
+      at packages/jest-jasmine2/build/jasmine/Env.js:429:15
       at __tests__/only-constructs.test.js:3:5
 
 "
@@ -59,7 +59,7 @@ exports[`cannot test with no implementation with expand arg 1`] = `
       4 |     test('test, no implementation');
       5 |   
       
-      at packages/jest-jasmine2/build/jasmine/Env.js:405:15
+      at packages/jest-jasmine2/build/jasmine/Env.js:429:15
       at __tests__/only-constructs.test.js:3:5
 
 "

--- a/packages/jest-jasmine2/src/jasmine/Env.js
+++ b/packages/jest-jasmine2/src/jasmine/Env.js
@@ -176,73 +176,38 @@ export default function(j$) {
         return j$.testPath;
       },
     });
-    defaultResourcesForRunnable(topSuite.id);
+
     currentDeclarationSuite = topSuite;
 
     this.topSuite = function() {
       return topSuite;
     };
 
-    this.execute = async function(runnablesToRun) {
-      if (!runnablesToRun) {
-        if (focusedRunnables.length) {
-          runnablesToRun = focusedRunnables;
-        } else {
-          runnablesToRun = [topSuite.id];
-        }
+    const uncaught = err => {
+      if (currentSpec) {
+        currentSpec.onException(err);
+        currentSpec.cancel();
+      } else {
+        console.error('Unhandled error');
+        console.error(err.stack);
       }
+    };
 
-      const uncaught = err => {
-        if (currentSpec) {
-          currentSpec.onException(err);
-          currentSpec.cancel();
-        } else {
-          console.error('Unhandled error');
-          console.error(err.stack);
-        }
-      };
-
+    let oldListenersException;
+    let oldListenersRejection;
+    const executionSetup = function() {
       // Need to ensure we are the only ones handling these exceptions.
-      const oldListenersException = process
-        .listeners('uncaughtException')
-        .slice();
-      const oldListenersRejection = process
-        .listeners('unhandledRejection')
-        .slice();
+      oldListenersException = process.listeners('uncaughtException').slice();
+      oldListenersRejection = process.listeners('unhandledRejection').slice();
 
       j$.process.removeAllListeners('uncaughtException');
       j$.process.removeAllListeners('unhandledRejection');
 
       j$.process.on('uncaughtException', uncaught);
       j$.process.on('unhandledRejection', uncaught);
+    };
 
-      reporter.jasmineStarted({totalSpecsDefined});
-
-      currentlyExecutingSuites.push(topSuite);
-
-      await treeProcessor({
-        nodeComplete(suite) {
-          if (!suite.disabled) {
-            clearResourcesForRunnable(suite.id);
-          }
-          currentlyExecutingSuites.pop();
-          reporter.suiteDone(suite.getResult());
-        },
-        nodeStart(suite) {
-          currentlyExecutingSuites.push(suite);
-          defaultResourcesForRunnable(suite.id, suite.parentSuite.id);
-          reporter.suiteStarted(suite.result);
-        },
-        queueRunnerFactory,
-        runnableIds: runnablesToRun,
-        tree: topSuite,
-      });
-      clearResourcesForRunnable(topSuite.id);
-      currentlyExecutingSuites.pop();
-      reporter.jasmineDone({
-        failedExpectations: topSuite.result.failedExpectations,
-      });
-
+    const executionTeardown = function() {
       j$.process.removeListener('uncaughtException', uncaught);
       j$.process.removeListener('unhandledRejection', uncaught);
 
@@ -254,6 +219,60 @@ export default function(j$) {
       oldListenersRejection.forEach(listener => {
         j$.process.on('unhandledRejection', listener);
       });
+    };
+
+    this.execute = async function(runnablesToRun, suiteTree = topSuite) {
+      if (!runnablesToRun) {
+        if (focusedRunnables.length) {
+          runnablesToRun = focusedRunnables;
+        } else {
+          runnablesToRun = [suiteTree.id];
+        }
+      }
+
+      if (currentlyExecutingSuites.length === 0) {
+        executionSetup();
+      }
+
+      const lastDeclarationSuite = currentDeclarationSuite;
+
+      await treeProcessor({
+        nodeComplete(suite) {
+          if (!suite.disabled) {
+            clearResourcesForRunnable(suite.id);
+          }
+          currentlyExecutingSuites.pop();
+          if (suite === topSuite) {
+            reporter.jasmineDone({
+              failedExpectations: topSuite.result.failedExpectations,
+            });
+          } else {
+            reporter.suiteDone(suite.getResult());
+          }
+        },
+        nodeStart(suite) {
+          currentDeclarationSuite = suite;
+          currentlyExecutingSuites.push(suite);
+          defaultResourcesForRunnable(
+            suite.id,
+            suite.parentSuite && suite.parentSuite.id,
+          );
+          if (suite === topSuite) {
+            reporter.jasmineStarted({totalSpecsDefined});
+          } else {
+            reporter.suiteStarted(suite.result);
+          }
+        },
+        queueRunnerFactory,
+        runnableIds: runnablesToRun,
+        tree: suiteTree,
+      });
+
+      currentDeclarationSuite = lastDeclarationSuite;
+
+      if (currentlyExecutingSuites.length === 0) {
+        executionTeardown();
+      }
     };
 
     this.addReporter = function(reporterToAdd) {

--- a/packages/jest-jasmine2/src/tree_processor.js
+++ b/packages/jest-jasmine2/src/tree_processor.js
@@ -43,32 +43,29 @@ export default function treeProcessor(options: Options) {
     return parentEnabled || runnableIds.indexOf(node.id) !== -1;
   }
 
-  return queueRunnerFactory({
-    onException: error => tree.onException(error),
-    queueableFns: wrapChildren(tree, isEnabled(tree, false)),
-    userContext: tree.sharedUserContext(),
-  });
-
-  function executeNode(node, parentEnabled) {
+  function getNodeHandler(node: TreeNode, parentEnabled: boolean) {
     const enabled = isEnabled(node, parentEnabled);
-    if (!node.children) {
-      return {
-        fn(done) {
-          node.execute(done, enabled);
-        },
-      };
-    }
-    return {
-      async fn(done) {
-        nodeStart(node);
-        await queueRunnerFactory({
-          onException: error => node.onException(error),
-          queueableFns: wrapChildren(node, enabled),
-          userContext: node.sharedUserContext(),
-        });
-        nodeComplete(node);
-        done();
-      },
+    return node.children
+      ? getNodeWithChildrenHandler(node, enabled)
+      : getNodeWithoutChildrenHandler(node, enabled);
+  }
+
+  function getNodeWithoutChildrenHandler(node: TreeNode, enabled: boolean) {
+    return function fn(done: (error?: any) => void = () => {}) {
+      node.execute(done, enabled);
+    };
+  }
+
+  function getNodeWithChildrenHandler(node: TreeNode, enabled: boolean) {
+    return async function fn(done: (error?: any) => void = () => {}) {
+      nodeStart(node);
+      await queueRunnerFactory({
+        onException: error => node.onException(error),
+        queueableFns: wrapChildren(node, enabled),
+        userContext: node.sharedUserContext(),
+      });
+      nodeComplete(node);
+      done();
     };
   }
 
@@ -76,7 +73,12 @@ export default function treeProcessor(options: Options) {
     if (!node.children) {
       throw new Error('`node.children` is not defined.');
     }
-    const children = node.children.map(child => executeNode(child, enabled));
+    const children = node.children.map(child => ({
+      fn: getNodeHandler(child, enabled),
+    }));
     return node.beforeAllFns.concat(children).concat(node.afterAllFns);
   }
+
+  const treeHandler = getNodeHandler(tree, false);
+  return treeHandler();
 }


### PR DESCRIPTION
## Summary

As agreed with @rickhanlonii, I've extracted the refactorings I've done for #5673:

1. Previously the `topSuite` was being setup separately to other suites, but in fact all suites require the same setup steps (mainly `defaultResourcesForRunnable`). This PR removes the duplicated logic from `Env.execute` and instead uses the same, unified suite logic that only differs in the way it's reported (e.g. `reporter.suiteDone` vs `reporter.jasmineDone` for the `topSuite`).
2. Moved out `executionSetup` and `executionTeardown` into separate functions to simplify the body of `Env.execute`. By reusing `currentlyExecutingSuites`'s `length` property for setup and teardown checks, it makes the method more robust.
3. Made it easier to understand what is going on in the `treeProcessor` function, by clearing out the meaning of how nodes _with_ and _without_ children are handled. I've also unified the handling of the top tree vs the children trees here.

If you need any help tracking what code has moved where, I'm happy to add more comments or discuss it in `jest`'s Discord.

After this is merged, we can discuss enabling defining tests/suites asynchronously (#5673), as it'll really only be a few LOC change (I can show that in another PR, when it's also easier to see what the change does).

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

All the current tests pass. No new logic added, so coverage shouldn't change.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
