### PR TITLE
add a note that testNamePattern regex is matched against full name

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -285,6 +285,9 @@ For example, suppose you want to run only tests related to authorization which
 will have names like `"GET /api/posts with auth"`, then you can use
 `jest -t=auth`.
 
+_Note: The regex is matched against the full name, which is a combination of the
+test name and all its surrounding suites._
+
 ### `--testLocationInResults`
 
 Adds a `location` field to test results. Useful if you want to report the

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -280,13 +280,13 @@ Prevent tests from printing messages through the console.
 
 ### `--testNamePattern=<regex>`
 
-Alias: `-t`. Run only tests and test suites with a name that matches the regex.
-For example, suppose you want to run only tests related to authorization which
-will have names like `"GET /api/posts with auth"`, then you can use
+Alias: `-t`. Run only tests and describe blocks with a name that matches the
+regex. For example, suppose you want to run only tests related to authorization
+which will have names like `"GET /api/posts with auth"`, then you can use
 `jest -t=auth`.
 
 _Note: The regex is matched against the full name, which is a combination of the
-test name and all its surrounding suites._
+test name and all its surrounding describe blocks._
 
 ### `--testLocationInResults`
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -280,10 +280,9 @@ Prevent tests from printing messages through the console.
 
 ### `--testNamePattern=<regex>`
 
-Alias: `-t`. Run only tests and describe blocks with a name that matches the
-regex. For example, suppose you want to run only tests related to authorization
-which will have names like `"GET /api/posts with auth"`, then you can use
-`jest -t=auth`.
+Alias: `-t`. Run only tests with a name that matches the regex. For example,
+suppose you want to run only tests related to authorization which will have
+names like `"GET /api/posts with auth"`, then you can use `jest -t=auth`.
 
 _Note: The regex is matched against the full name, which is a combination of the
 test name and all its surrounding describe blocks._


### PR DESCRIPTION
<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

A documentation note, following the discussion on #5882

Should clarify that the regex on testNamePattern is matched against the full name of the test.