### PR TITLE
Throw a more useful error when trying to require modules after the test environment is torn down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,9 @@
 
 ### Fixes
 
+* `[jest-runtime]` Throw a more useful error when trying to require modules
+  after the test environment is torn down
+  ([#5888](https://github.com/facebook/jest/pull/5888))
 * `[jest-jasmine2]` Install `sourcemap-support` into normal runtime to catch
   runtime errors ([#5945](https://github.com/facebook/jest/pull/5945))
 * `[jest-jasmine2]` Added assertion error handling inside `afterAll hook`

--- a/integration-tests/__tests__/__snapshots__/require_after_teardown.test.js.snap
+++ b/integration-tests/__tests__/__snapshots__/require_after_teardown.test.js.snap
@@ -10,6 +10,5 @@ exports[`prints useful error for requires after test is done 1`] = `
       13 |     expect(double(5)).toBe(10);
       14 |   }, 0);
       
-      at Runtime._execModule (../../packages/jest-runtime/build/index.js:585:9)
       at Timeout.setTimeout [as _onTimeout] (__tests__/late-require.test.js:11:20)"
 `;

--- a/integration-tests/__tests__/__snapshots__/require_after_teardown.test.js.snap
+++ b/integration-tests/__tests__/__snapshots__/require_after_teardown.test.js.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`prints useful error for requires after test is done 1`] = `
+"ReferenceError: You are trying to \`import\` a file after the Jest environment has been torn down.
+
+       9 | test('require after done', () => {
+      10 |   setTimeout(() => {
+    > 11 |     const double = require('../');
+      12 | 
+      13 |     expect(double(5)).toBe(10);
+      14 |   }, 0);
+      
+      at Runtime._execModule (../../packages/jest-runtime/build/index.js:585:9)
+      at Timeout.setTimeout [as _onTimeout] (__tests__/late-require.test.js:11:20)"
+`;

--- a/integration-tests/__tests__/__snapshots__/require_after_teardown.test.js.snap
+++ b/integration-tests/__tests__/__snapshots__/require_after_teardown.test.js.snap
@@ -8,7 +8,5 @@ exports[`prints useful error for requires after test is done 1`] = `
     > 11 |     const double = require('../');
       12 | 
       13 |     expect(double(5)).toBe(10);
-      14 |   }, 0);
-      
-      at Timeout.setTimeout [as _onTimeout] (__tests__/late-require.test.js:11:20)"
+      14 |   }, 0);"
 `;

--- a/integration-tests/__tests__/require_after_teardown.test.js
+++ b/integration-tests/__tests__/require_after_teardown.test.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+'use strict';
+
+const runJest = require('../runJest');
+
+test('prints useful error for requires after test is done', () => {
+  const {stderr} = runJest('require-after-teardown');
+
+  const interestingLines = stderr
+    .split('\n')
+    .slice(9, 20)
+    .join('\n');
+
+  expect(interestingLines).toMatchSnapshot();
+});

--- a/integration-tests/__tests__/require_after_teardown.test.js
+++ b/integration-tests/__tests__/require_after_teardown.test.js
@@ -16,7 +16,7 @@ test('prints useful error for requires after test is done', () => {
 
   const interestingLines = stderr
     .split('\n')
-    .slice(9, 20)
+    .slice(9, 19)
     .join('\n');
 
   expect(interestingLines).toMatchSnapshot();

--- a/integration-tests/__tests__/require_after_teardown.test.js
+++ b/integration-tests/__tests__/require_after_teardown.test.js
@@ -16,8 +16,11 @@ test('prints useful error for requires after test is done', () => {
 
   const interestingLines = stderr
     .split('\n')
-    .slice(9, 19)
+    .slice(9, 17)
     .join('\n');
 
   expect(interestingLines).toMatchSnapshot();
+  expect(stderr.split('\n')[18]).toMatch(
+    new RegExp('(__tests__/late-require.test.js:11:20)'),
+  );
 });

--- a/integration-tests/require-after-teardown/__tests__/late-require.test.js
+++ b/integration-tests/require-after-teardown/__tests__/late-require.test.js
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+'use strict';
+
+test('require after done', () => {
+  setTimeout(() => {
+    const double = require('../');
+
+    expect(double(5)).toBe(10);
+  }, 0);
+});

--- a/integration-tests/require-after-teardown/index.js
+++ b/integration-tests/require-after-teardown/index.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+module.exports = function double(input) {
+  return input * 2;
+};

--- a/integration-tests/require-after-teardown/package.json
+++ b/integration-tests/require-after-teardown/package.json
@@ -1,0 +1,5 @@
+{
+  "jest": {
+    "testEnvironment": "node"
+  }
+}

--- a/packages/jest-runtime/package.json
+++ b/packages/jest-runtime/package.json
@@ -16,6 +16,7 @@
     "graceful-fs": "^4.1.11",
     "jest-config": "^22.4.2",
     "jest-haste-map": "^22.4.2",
+    "jest-message-util": "^22.4.0",
     "jest-regex-util": "^22.1.0",
     "jest-resolve": "^22.4.2",
     "jest-snapshot": "^22.4.0",

--- a/packages/jest-runtime/src/index.js
+++ b/packages/jest-runtime/src/index.js
@@ -555,11 +555,15 @@ class Runtime {
     const runScript = this._environment.runScript(transformedFile.script);
 
     if (runScript === null) {
-      const {message, stack} = separateMessageFromStack(
-        new ReferenceError(
-          'You are trying to `import` a file after the Jest environment has been torn down.',
-        ).stack,
-      );
+      const originalStack = new ReferenceError(
+        'You are trying to `import` a file after the Jest environment has been torn down.',
+      ).stack
+        .split('\n')
+        // Remove this file from the stack (jest-message-utils will keep one line)
+        .filter(line => line.indexOf(__filename) === -1)
+        .join('\n');
+
+      const {message, stack} = separateMessageFromStack(originalStack);
 
       console.error(
         `\n${message}\n` +


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary
Instead of this:
![image](https://user-images.githubusercontent.com/1404810/38023805-82832666-3283-11e8-9134-c7dcecfb4cf8.png)

Do this: 
![image](https://user-images.githubusercontent.com/1404810/38023836-8e519888-3283-11e8-9ccf-929aa8daa8ce.png)

While still not super pretty, it's _better_.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan
Integration test included

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
