### PR TITLE
Add package name to NotifyReporter notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ### Features
 
+- `[jest-cli]` Add package name to `NotifyReporter` notification ([#5898](https://github.com/facebook/jest/pull/5898))
 - `[jest-runner]` print stack trace when `process.exit` is called from user code ([#6714](https://github.com/facebook/jest/pull/6714))
 - `[jest-each]` introduces `%#` option to add index of the test to its title ([#6414](https://github.com/facebook/jest/pull/6414))
-- `[pretty-format]` Support serializing `DocumentFragment` ([#6705](https://github.com/facebook/jest/pull/6705))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - `[jest-cli]` Add package name to `NotifyReporter` notification ([#5898](https://github.com/facebook/jest/pull/5898))
 - `[jest-runner]` print stack trace when `process.exit` is called from user code ([#6714](https://github.com/facebook/jest/pull/6714))
 - `[jest-each]` introduces `%#` option to add index of the test to its title ([#6414](https://github.com/facebook/jest/pull/6414))
+- `[pretty-format]` Support serializing `DocumentFragment` ([#6705](https://github.com/facebook/jest/pull/6705))
 
 ### Fixes
 

--- a/packages/jest-cli/src/__tests__/__snapshots__/notify_reporter.test.js.snap
+++ b/packages/jest-cli/src/__tests__/__snapshots__/notify_reporter.test.js.snap
@@ -29,6 +29,64 @@ Array [
 ]
 `;
 
+exports[`test always with moduleName 1`] = `
+Array [
+  Object {
+    "message": "3 tests passed",
+    "title": "some-module - 100% Passed",
+  },
+  Object {
+    "message": "3 of 3 tests failed",
+    "title": "some-module - 100% Failed",
+  },
+  Object {
+    "message": "3 tests passed",
+    "title": "some-module - 100% Passed",
+  },
+  Object {
+    "message": "3 tests passed",
+    "title": "some-module - 100% Passed",
+  },
+  Object {
+    "message": "3 of 3 tests failed",
+    "title": "some-module - 100% Failed",
+  },
+  Object {
+    "message": "3 of 3 tests failed",
+    "title": "some-module - 100% Failed",
+  },
+]
+`;
+
+exports[`test always with rootDir 1`] = `
+Array [
+  Object {
+    "message": "3 tests passed",
+    "title": "some-test - 100% Passed",
+  },
+  Object {
+    "message": "3 of 3 tests failed",
+    "title": "some-test - 100% Failed",
+  },
+  Object {
+    "message": "3 tests passed",
+    "title": "some-test - 100% Passed",
+  },
+  Object {
+    "message": "3 tests passed",
+    "title": "some-test - 100% Passed",
+  },
+  Object {
+    "message": "3 of 3 tests failed",
+    "title": "some-test - 100% Failed",
+  },
+  Object {
+    "message": "3 of 3 tests failed",
+    "title": "some-test - 100% Failed",
+  },
+]
+`;
+
 exports[`test change 1`] = `
 Array [
   Object {
@@ -42,6 +100,40 @@ Array [
   Object {
     "message": "3 of 3 tests failed",
     "title": "100% Failed",
+  },
+]
+`;
+
+exports[`test change with moduleName 1`] = `
+Array [
+  Object {
+    "message": "3 of 3 tests failed",
+    "title": "some-module - 100% Failed",
+  },
+  Object {
+    "message": "3 tests passed",
+    "title": "some-module - 100% Passed",
+  },
+  Object {
+    "message": "3 of 3 tests failed",
+    "title": "some-module - 100% Failed",
+  },
+]
+`;
+
+exports[`test change with rootDir 1`] = `
+Array [
+  Object {
+    "message": "3 of 3 tests failed",
+    "title": "some-test - 100% Failed",
+  },
+  Object {
+    "message": "3 tests passed",
+    "title": "some-test - 100% Passed",
+  },
+  Object {
+    "message": "3 of 3 tests failed",
+    "title": "some-test - 100% Failed",
   },
 ]
 `;
@@ -67,6 +159,48 @@ Array [
 ]
 `;
 
+exports[`test failure-change with moduleName 1`] = `
+Array [
+  Object {
+    "message": "3 of 3 tests failed",
+    "title": "some-module - 100% Failed",
+  },
+  Object {
+    "message": "3 tests passed",
+    "title": "some-module - 100% Passed",
+  },
+  Object {
+    "message": "3 of 3 tests failed",
+    "title": "some-module - 100% Failed",
+  },
+  Object {
+    "message": "3 of 3 tests failed",
+    "title": "some-module - 100% Failed",
+  },
+]
+`;
+
+exports[`test failure-change with rootDir 1`] = `
+Array [
+  Object {
+    "message": "3 of 3 tests failed",
+    "title": "some-test - 100% Failed",
+  },
+  Object {
+    "message": "3 tests passed",
+    "title": "some-test - 100% Passed",
+  },
+  Object {
+    "message": "3 of 3 tests failed",
+    "title": "some-test - 100% Failed",
+  },
+  Object {
+    "message": "3 of 3 tests failed",
+    "title": "some-test - 100% Failed",
+  },
+]
+`;
+
 exports[`test success 1`] = `
 Array [
   Object {
@@ -80,6 +214,40 @@ Array [
   Object {
     "message": "3 tests passed",
     "title": "100% Passed",
+  },
+]
+`;
+
+exports[`test success with moduleName 1`] = `
+Array [
+  Object {
+    "message": "3 tests passed",
+    "title": "some-module - 100% Passed",
+  },
+  Object {
+    "message": "3 tests passed",
+    "title": "some-module - 100% Passed",
+  },
+  Object {
+    "message": "3 tests passed",
+    "title": "some-module - 100% Passed",
+  },
+]
+`;
+
+exports[`test success with rootDir 1`] = `
+Array [
+  Object {
+    "message": "3 tests passed",
+    "title": "some-test - 100% Passed",
+  },
+  Object {
+    "message": "3 tests passed",
+    "title": "some-test - 100% Passed",
+  },
+  Object {
+    "message": "3 tests passed",
+    "title": "some-test - 100% Passed",
   },
 ]
 `;
@@ -105,6 +273,56 @@ Array [
   Object {
     "message": "3 of 3 tests failed",
     "title": "100% Failed",
+  },
+]
+`;
+
+exports[`test success-change with moduleName 1`] = `
+Array [
+  Object {
+    "message": "3 tests passed",
+    "title": "some-module - 100% Passed",
+  },
+  Object {
+    "message": "3 of 3 tests failed",
+    "title": "some-module - 100% Failed",
+  },
+  Object {
+    "message": "3 tests passed",
+    "title": "some-module - 100% Passed",
+  },
+  Object {
+    "message": "3 tests passed",
+    "title": "some-module - 100% Passed",
+  },
+  Object {
+    "message": "3 of 3 tests failed",
+    "title": "some-module - 100% Failed",
+  },
+]
+`;
+
+exports[`test success-change with rootDir 1`] = `
+Array [
+  Object {
+    "message": "3 tests passed",
+    "title": "some-test - 100% Passed",
+  },
+  Object {
+    "message": "3 of 3 tests failed",
+    "title": "some-test - 100% Failed",
+  },
+  Object {
+    "message": "3 tests passed",
+    "title": "some-test - 100% Passed",
+  },
+  Object {
+    "message": "3 tests passed",
+    "title": "some-test - 100% Passed",
+  },
+  Object {
+    "message": "3 of 3 tests failed",
+    "title": "some-test - 100% Failed",
   },
 ]
 `;

--- a/packages/jest-cli/src/__tests__/notify_reporter.test.js
+++ b/packages/jest-cli/src/__tests__/notify_reporter.test.js
@@ -81,7 +81,7 @@ test('.addReporter() .removeReporter()', () => {
   expect(scheduler._dispatcher._reporters).not.toContain(reporter);
 });
 
-const testModes = (notifyMode: string, arl: Array<AggregatedResult>) => {
+const testModes = ({notifyMode, arl, rootDir, moduleName}) => {
   const notify = require('node-notifier');
 
   let previousContext = initialContext;
@@ -91,12 +91,28 @@ const testModes = (notifyMode: string, arl: Array<AggregatedResult>) => {
       previousSuccess: previousContext.previousSuccess,
     });
     const reporter = new NotifyReporter(
-      {notify: true, notifyMode},
+      {notify: true, notifyMode, rootDir},
       {},
       newContext,
     );
     previousContext = newContext;
-    reporter.onRunComplete(new Set(), ar);
+    const contexts = new Set();
+
+    if (moduleName != null) {
+      contexts.add({
+        hasteFS: {
+          getModuleName() {
+            return moduleName;
+          },
+
+          matchFiles() {
+            return ['package.json'];
+          },
+        },
+      });
+    }
+
+    reporter.onRunComplete(contexts, ar);
 
     if (ar.numTotalTests === 0) {
       expect(notify.notify).not.toHaveBeenCalled();
@@ -112,23 +128,91 @@ const testModes = (notifyMode: string, arl: Array<AggregatedResult>) => {
 };
 
 test('test always', () => {
-  testModes('always', notifyEvents);
+  testModes({arl: notifyEvents, notifyMode: 'always'});
 });
 
 test('test success', () => {
-  testModes('success', notifyEvents);
+  testModes({arl: notifyEvents, notifyMode: 'success'});
 });
 
 test('test change', () => {
-  testModes('change', notifyEvents);
+  testModes({arl: notifyEvents, notifyMode: 'change'});
 });
 
 test('test success-change', () => {
-  testModes('success-change', notifyEvents);
+  testModes({arl: notifyEvents, notifyMode: 'success-change'});
 });
 
 test('test failure-change', () => {
-  testModes('failure-change', notifyEvents);
+  testModes({arl: notifyEvents, notifyMode: 'failure-change'});
+});
+
+test('test always with rootDir', () => {
+  testModes({arl: notifyEvents, notifyMode: 'always', rootDir: 'some-test'});
+});
+
+test('test success with rootDir', () => {
+  testModes({arl: notifyEvents, notifyMode: 'success', rootDir: 'some-test'});
+});
+
+test('test change with rootDir', () => {
+  testModes({arl: notifyEvents, notifyMode: 'change', rootDir: 'some-test'});
+});
+
+test('test success-change with rootDir', () => {
+  testModes({
+    arl: notifyEvents,
+    notifyMode: 'success-change',
+    rootDir: 'some-test',
+  });
+});
+
+test('test failure-change with rootDir', () => {
+  testModes({
+    arl: notifyEvents,
+    notifyMode: 'failure-change',
+    rootDir: 'some-test',
+  });
+});
+
+test('test always with moduleName', () => {
+  testModes({
+    arl: notifyEvents,
+    moduleName: 'some-module',
+    notifyMode: 'always',
+  });
+});
+
+test('test success with moduleName', () => {
+  testModes({
+    arl: notifyEvents,
+    moduleName: 'some-module',
+    notifyMode: 'success',
+  });
+});
+
+test('test change with moduleName', () => {
+  testModes({
+    arl: notifyEvents,
+    moduleName: 'some-module',
+    notifyMode: 'change',
+  });
+});
+
+test('test success-change with moduleName', () => {
+  testModes({
+    arl: notifyEvents,
+    moduleName: 'some-module',
+    notifyMode: 'success-change',
+  });
+});
+
+test('test failure-change with moduleName', () => {
+  testModes({
+    arl: notifyEvents,
+    moduleName: 'some-module',
+    notifyMode: 'failure-change',
+  });
 });
 
 afterEach(() => {

--- a/packages/jest-cli/src/reporters/notify_reporter.js
+++ b/packages/jest-cli/src/reporters/notify_reporter.js
@@ -41,6 +41,26 @@ export default class NotifyReporter extends BaseReporter {
     const success =
       result.numFailedTests === 0 && result.numRuntimeErrorTestSuites === 0;
 
+    const firstContext = contexts.values().next();
+
+    const hasteFS =
+      firstContext && firstContext.value && firstContext.value.hasteFS;
+
+    let packageName;
+    if (hasteFS != null) {
+      // assuming root package.json is the first one
+      const [filePath] = hasteFS.matchFiles('package.json');
+
+      packageName =
+        filePath != null
+          ? hasteFS.getModuleName(filePath)
+          : this._globalConfig.rootDir;
+    } else {
+      packageName = this._globalConfig.rootDir;
+    }
+
+    packageName = packageName != null ? `${packageName} - ` : '';
+
     const notifyMode = this._globalConfig.notifyMode;
     const statusChanged =
       this._context.previousSuccess !== success || this._context.firstRun;
@@ -55,7 +75,7 @@ export default class NotifyReporter extends BaseReporter {
         (notifyMode === 'change' && statusChanged) ||
         (notifyMode === 'failure-change' && statusChanged))
     ) {
-      const title = util.format('%d%% Passed', 100);
+      const title = util.format('%s%d%% Passed', packageName, 100);
       const message = util.format(
         (isDarwin ? '\u2705 ' : '') + '%d tests passed',
         result.numPassedTests,
@@ -74,7 +94,8 @@ export default class NotifyReporter extends BaseReporter {
       const failed = result.numFailedTests / result.numTotalTests;
 
       const title = util.format(
-        '%d%% Failed',
+        '%s%d%% Failed',
+        packageName,
         Math.ceil(Number.isNaN(failed) ? 0 : failed * 100),
       );
       const message = util.format(


### PR DESCRIPTION
## Summary

This change adds package name to notification in NotifyReporter when using `--notify` flag or `notify` configuration option. This clarifies which package is being tested which is especially useful when watching tests in mono-repos and with multiple IDEs opened.

First I'm trying to get hasteFS from the first context to get the module name (must be a better way). Then I'm falling back to `rootDir` and otherwise to original behavior without an additional title. 

Before:

![Before](https://user-images.githubusercontent.com/5013206/38090619-71194b18-3363-11e8-861e-4ca5566ea6a3.png)

After:

![After](https://user-images.githubusercontent.com/5013206/38090620-71388e10-3363-11e8-88fa-65e8ca605ef0.png)