### PR TITLE
 Adds a custom resolver option

### DIFF
--- a/TestUtils.js
+++ b/TestUtils.js
@@ -68,6 +68,7 @@ const DEFAULT_PROJECT_CONFIG: ProjectConfig = {
   cacheDirectory: '/test_cache_dir/',
   clearMocks: false,
   coveragePathIgnorePatterns: [],
+  customResolver: null,
   cwd: '/test_root_dir/',
   detectLeaks: false,
   displayName: undefined,

--- a/packages/jest-config/src/defaults.js
+++ b/packages/jest-config/src/defaults.js
@@ -37,6 +37,7 @@ export default ({
   clearMocks: false,
   coveragePathIgnorePatterns: [NODE_MODULES_REGEXP],
   coverageReporters: ['json', 'text', 'lcov', 'clover'],
+  customResolver: null,
   detectLeaks: false,
   expand: false,
   forceCoverageMatch: [],

--- a/packages/jest-config/src/index.js
+++ b/packages/jest-config/src/index.js
@@ -148,6 +148,7 @@ const getConfigs = (
       cacheDirectory: options.cacheDirectory,
       clearMocks: options.clearMocks,
       coveragePathIgnorePatterns: options.coveragePathIgnorePatterns,
+      customResolver: options.customResolver,
       cwd: options.cwd,
       detectLeaks: options.detectLeaks,
       displayName: options.displayName,

--- a/packages/jest-config/src/normalize.js
+++ b/packages/jest-config/src/normalize.js
@@ -485,6 +485,7 @@ export default function normalize(options: InitialOptions, argv: Argv) {
       case 'collectCoverage':
       case 'coverageReporters':
       case 'coverageThreshold':
+      case 'customResolver':
       case 'detectLeaks':
       case 'displayName':
       case 'expand':

--- a/packages/jest-config/src/valid_config.js
+++ b/packages/jest-config/src/valid_config.js
@@ -36,6 +36,7 @@ export default ({
       branches: 50,
     },
   },
+  customResolver: (request, issuer) => require.resolve(request),
   displayName: 'project-name',
   expand: false,
   forceCoverageMatch: ['**/*.t.js'],

--- a/packages/jest-resolve/src/__tests__/resolve.test.js
+++ b/packages/jest-resolve/src/__tests__/resolve.test.js
@@ -204,6 +204,23 @@ describe('nodeModulesPaths', () => {
   });
 });
 
+describe('customResolver', () => {
+  it('allows to specify a custom resolution strategy', () => {
+    const moduleMap = new ModuleMap({
+      duplicates: [],
+      map: [],
+      mocks: [],
+    });
+
+    const resolver = new Resolver(moduleMap, {
+      customResolver: (request, issuer) => `/foo`,
+      extensions: ['.js'],
+    });
+
+    expect(resolver.resolveModule('foo', './foo')).toBe('/foo');
+  });
+});
+
 describe('Resolver.getModulePaths() -> nodeModulesPaths()', () => {
   const _path = path;
   let moduleMap;

--- a/packages/jest-runtime/src/index.js
+++ b/packages/jest-runtime/src/index.js
@@ -247,6 +247,7 @@ class Runtime {
   static createResolver(config: ProjectConfig, moduleMap: ModuleMap): Resolver {
     return new Resolver(moduleMap, {
       browser: config.browser,
+      customResolver: config.customResolver,
       defaultPlatform: config.haste.defaultPlatform,
       extensions: config.moduleFileExtensions.map(extension => '.' + extension),
       hasCoreModules: true,

--- a/types/Config.js
+++ b/types/Config.js
@@ -7,6 +7,8 @@
  * @flow
  */
 
+import type {CustomResolver} from 'types/Resolve';
+
 export type Path = string;
 export type Glob = string;
 
@@ -31,6 +33,7 @@ export type DefaultOptions = {|
   clearMocks: boolean,
   coveragePathIgnorePatterns: Array<string>,
   coverageReporters: Array<string>,
+  customResolver: ?CustomResolver,
   expand: boolean,
   forceCoverageMatch: Array<Glob>,
   globals: ConfigGlobals,
@@ -86,6 +89,7 @@ export type InitialOptions = {
   coveragePathIgnorePatterns?: Array<string>,
   coverageReporters?: Array<string>,
   coverageThreshold?: {global: {[key: string]: number}},
+  customResolver?: ?CustomResolver,
   detectLeaks?: boolean,
   displayName?: string,
   expand?: boolean,
@@ -218,6 +222,7 @@ export type ProjectConfig = {|
   cacheDirectory: Path,
   clearMocks: boolean,
   coveragePathIgnorePatterns: Array<string>,
+  customResolver: ?CustomResolver,
   cwd: Path,
   detectLeaks: boolean,
   displayName: ?string,

--- a/types/Resolve.js
+++ b/types/Resolve.js
@@ -14,3 +14,5 @@ export type ResolveModuleConfig = {|
 |};
 
 export type Resolver = _Resolver;
+
+export type CustomResolver = (string, string) => string;


### PR DESCRIPTION
## Summary

This diff adds a new configuration (`customResolver`) that allows one to hook into `jest-resolve` to bypass the Node resolution while still using the Haste resolution.

## Test plan

Added a tests, previous ones should still pass.