### PR TITLE
Override "process.send" with a mock

### DIFF
--- a/packages/jest-util/src/create_process_object.js
+++ b/packages/jest-util/src/create_process_object.js
@@ -90,6 +90,7 @@ export default function() {
   }
 
   newProcess.env = createProcessEnv();
+  newProcess.send = () => {};
 
   return newProcess;
 }


### PR DESCRIPTION
When creating a mock object for `process`, `process.send` is just referenced from the parent context, which means that a test has access to the real IPC channel established by `jest-worker`, thus breaking the sandbox.

As per the Node definition, `process.send` is not defined if the Node process hasn't started off a `fork` call; but this shouldn't be an issue, because `send` has always been exposed and no one complained so far 🙃

This should also fix #5891.