### PR TITLE
Add an option to use --no-color chalk CLI argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@
   ([#5826](https://github.com/facebook/jest/pull/5826))
 * `[jest-cli]` Interactive Snapshot Mode improvements
   ([#5864](https://github.com/facebook/jest/pull/5864))
+  * `[jest-editor-support]` Add `no-color` option to runner
+  ([#5909](https://github.com/facebook/jest/pull/5909))
+
 
 ### Fixes
 

--- a/packages/jest-editor-support/index.d.ts
+++ b/packages/jest-editor-support/index.d.ts
@@ -19,6 +19,7 @@ export interface Options {
     args: string[],
     options?: SpawnOptions,
   ): ChildProcess;
+  noColor?: boolean;
   testNamePattern?: string;
   testFileNamePattern?: string;
   shell?: boolean;
@@ -171,7 +172,7 @@ export interface SnapshotMetadata {
   exists: boolean;
   name: string;
   node: {
-    loc: Node
+    loc: Node;
   };
   content?: string;
 }

--- a/packages/jest-editor-support/src/Runner.js
+++ b/packages/jest-editor-support/src/Runner.js
@@ -72,6 +72,9 @@ export default class Runner extends EventEmitter {
     if (this.options.coverage === false) {
       args.push('--no-coverage');
     }
+    if (this.options.noColor === true) {
+      args.push('--no-color');
+    }
 
     const options = {
       shell: this.options.shell,

--- a/packages/jest-editor-support/src/__tests__/runner.test.js
+++ b/packages/jest-editor-support/src/__tests__/runner.test.js
@@ -251,6 +251,17 @@ describe('Runner', () => {
 
       expect((createProcess: any).mock.calls[0][2]).toEqual({shell: true});
     });
+
+    it('calls createProcess with the no color option when provided', () => {
+      const expected = '--no-color';
+
+      const workspace: any = {};
+      const options = {noColor: true};
+      const sut = new Runner(workspace, options);
+      sut.start(false);
+
+      expect((createProcess: any).mock.calls[0][1]).toContain(expected);
+    });
   });
 
   describe('closeProcess', () => {

--- a/packages/jest-editor-support/src/types.js
+++ b/packages/jest-editor-support/src/types.js
@@ -26,6 +26,7 @@ export type Options = {
     args: Array<string>,
     options?: SpawnOptions,
   ) => ChildProcess,
+  noColor?: boolean,
   testNamePattern?: string,
   testFileNamePattern?: string,
   shell?: boolean,


### PR DESCRIPTION
## Summary

Folks who are using the vscode-jest extension have reported that there are ANSI color codes appearing in the inline error messages. This PR adds an option to the test runner that will start Jest using the `--no-color` CLI arg.

This PR will close jest-community/vscode-jest#279.

Is it possible to have this PR deployed in v21 or v22?


## Test plan

I've added a test that should provide enough code coverage for this quick change.
