### PR TITLE
Switch collectCoverageFrom back to a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,6 @@
 * `[jest-editor-support]` Add `no-color` option to runner
   ([#5909](https://github.com/facebook/jest/pull/5909))
 
-
 ### Fixes
 
 * `[jest-runner]` Assign `process.env.JEST_WORKER_ID="1"` when in runInBand mode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,13 +73,15 @@
   ([#5720](https://github.com/facebook/jest/pull/5720))
 * `[pretty-format]` Handle React fragments better
   ([#5816](https://github.com/facebook/jest/pull/5816))
+* `[jest-cli]` Switch collectCoverageFrom back to a string
+  ([#5914](https://github.com/facebook/jest/pull/5914))
 
 ### Chore & Maintenance
 
 * `[jest-jasmine2]` Simplify `Env.execute` and TreeProcessor to setup and clean
   resources for the top suite the same way as for all of the children suites
   ([#5885](https://github.com/facebook/jest/pull/5885))
-* `*` Run Prettier on compiled output
+* `[*]` Run Prettier on compiled output
   ([#5858](https://github.com/facebook/jest/pull/3497))
 * `[jest-cli]` Add fileChange hook for plugins
   ([#5708](https://github.com/facebook/jest/pull/5708))

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -149,8 +149,8 @@ directory. The default cache directory can be found by calling
 
 ### `--collectCoverageFrom=<glob>`
 
-An array of glob patterns relative to <rootDir> matching the files that coverage
-info needs to be collected from.
+A glob pattern relative to <rootDir> matching the files that coverage info needs
+to be collected from.
 
 ### `--colors`
 

--- a/integration-tests/__tests__/coverage_report.test.js
+++ b/integration-tests/__tests__/coverage_report.test.js
@@ -49,8 +49,9 @@ test('collects coverage only from multiple specified files', () => {
   const {stdout} = runJest(DIR, [
     '--no-cache',
     '--coverage',
-    '--collectCoverageFrom', // overwrites the one in package.json
+    '--collectCoverageFrom',
     'setup.js',
+    '--collectCoverageFrom',
     'OtherFile.js',
   ]);
 

--- a/packages/jest-cli/src/cli/args.js
+++ b/packages/jest-cli/src/cli/args.js
@@ -153,9 +153,9 @@ export const options = {
   },
   collectCoverageFrom: {
     description:
-      'An array of glob patterns relative to <rootDir> matching the files ' +
-      'that coverage info needs to be collected from.',
-    type: 'array',
+      'A glob pattern relative to <rootDir> matching the files that coverage ' +
+      'info needs to be collected from.',
+    type: 'string',
   },
   collectCoverageOnlyFrom: {
     description: 'Explicit list of paths coverage will be restricted to.',


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary
The change in https://github.com/facebook/jest/pull/5537 was breaking, and not one we're looking to keep. Instead, the option should be repeated for multiple values.

Closes https://github.com/facebook/jest/issues/5905

## Test plan

- Updated the existing test to use multiple args, snapshot does not need updated