### PR TITLE
Moves babel-jest into jest-config rather than jest-runtime

### DIFF
--- a/packages/jest-config/package.json
+++ b/packages/jest-config/package.json
@@ -8,6 +8,8 @@
   "license": "MIT",
   "main": "build/index.js",
   "dependencies": {
+    "babel-core": "^6.0.0",
+    "babel-jest": "^22.4.1",
     "chalk": "^2.0.1",
     "glob": "^7.1.1",
     "jest-environment-jsdom": "^22.4.1",

--- a/packages/jest-runtime/package.json
+++ b/packages/jest-runtime/package.json
@@ -9,7 +9,6 @@
   "main": "build/index.js",
   "dependencies": {
     "babel-core": "^6.0.0",
-    "babel-jest": "^22.4.1",
     "babel-plugin-istanbul": "^4.1.5",
     "chalk": "^2.0.1",
     "convert-source-map": "^1.4.0",


### PR DESCRIPTION
## Summary

I noticed that jest-runtime doesn't make any require to babel-jest, so it doesn't need to be there. Inversely, jest-config needs babel-jest to be able to work properly (because of [normalize](https://github.com/facebook/jest/blob/master/packages/jest-config/src/normalize.js#L105-L137)), so it needs to be declared as a dependency.

I guess it was put this way so that babel-core would be used for both jest-config and jest-runtime, but that's an optimization that should be left to the package manager.

## Test plan

Existing tests should pass, no new test should be needed.