### PR TITLE
Updates babel-jest resolution

### DIFF
--- a/integration-tests/Utils.js
+++ b/integration-tests/Utils.js
@@ -129,7 +129,14 @@ const createEmptyPackage = (
   );
 };
 
-const extractSummary = (stdout: string) => {
+type ExtractSummaryOptions = {|
+  stripLocation: boolean,
+|};
+
+const extractSummary = (
+  stdout: string,
+  {stripLocation = false}: ExtractSummaryOptions = {},
+) => {
   const match = stdout.match(
     /Test Suites:.*\nTests.*\nSnapshots.*\nTime.*(\nRan all test suites)*.*\n*$/gm,
   );
@@ -147,10 +154,14 @@ const extractSummary = (stdout: string) => {
     .replace(/\d*\.?\d+m?s/g, '<<REPLACED>>')
     .replace(/, estimated <<REPLACED>>/g, '');
 
-  const rest = cleanupStackTrace(
+  let rest = cleanupStackTrace(
     // remove all timestamps
     stdout.slice(0, -match[0].length).replace(/\s*\(\d*\.?\d+m?s\)$/gm, ''),
   );
+
+  if (stripLocation) {
+    rest = rest.replace(/(at .*):\d+:\d+/g, '$1:<<LINE>>:<<COLUMN>>');
+  }
 
   return {rest, summary};
 };

--- a/integration-tests/__tests__/__snapshots__/globals.test.js.snap
+++ b/integration-tests/__tests__/__snapshots__/globals.test.js.snap
@@ -32,8 +32,8 @@ exports[`cannot test with no implementation 1`] = `
       4 |     test('test, no implementation');
       5 |   
       
-      at packages/jest-jasmine2/build/jasmine/Env.js:429:15
-      at __tests__/only-constructs.test.js:3:5
+      at packages/jest-jasmine2/build/jasmine/Env.js:<<LINE>>:<<COLUMN>>
+      at __tests__/only-constructs.test.js:<<LINE>>:<<COLUMN>>
 
 "
 `;
@@ -59,8 +59,8 @@ exports[`cannot test with no implementation with expand arg 1`] = `
       4 |     test('test, no implementation');
       5 |   
       
-      at packages/jest-jasmine2/build/jasmine/Env.js:429:15
-      at __tests__/only-constructs.test.js:3:5
+      at packages/jest-jasmine2/build/jasmine/Env.js:<<LINE>>:<<COLUMN>>
+      at __tests__/only-constructs.test.js:<<LINE>>:<<COLUMN>>
 
 "
 `;

--- a/integration-tests/__tests__/__snapshots__/show_config.test.js.snap
+++ b/integration-tests/__tests__/__snapshots__/show_config.test.js.snap
@@ -54,6 +54,12 @@ exports[`--showConfig outputs config info and exits 1`] = `
       \\"testRunner\\": \\"<<REPLACED_JEST_PACKAGES_DIR>>/jest-jasmine2/build/index.js\\",
       \\"testURL\\": \\"about:blank\\",
       \\"timers\\": \\"real\\",
+      \\"transform\\": [
+        [
+          \\"^.+\\\\\\\\.jsx?$\\",
+          \\"<<REPLACED_JEST_PACKAGES_DIR>>/babel-jest/build/index.js\\"
+        ]
+      ],
       \\"transformIgnorePatterns\\": [
         \\"/node_modules/\\"
       ],

--- a/integration-tests/__tests__/globals.test.js
+++ b/integration-tests/__tests__/globals.test.js
@@ -122,8 +122,7 @@ test('cannot test with no implementation', () => {
   const {stderr, status} = runJest(DIR);
   expect(status).toBe(1);
 
-  const {summary, rest} = extractSummary(stderr);
-
+  const {summary, rest} = extractSummary(stderr, {stripLocation: true});
   expect(rest).toMatchSnapshot();
   expect(summary).toMatchSnapshot();
 });
@@ -201,7 +200,7 @@ test('cannot test with no implementation with expand arg', () => {
   const {stderr, status} = runJest(DIR, ['--expand']);
   expect(status).toBe(1);
 
-  const {summary, rest} = extractSummary(stderr);
+  const {summary, rest} = extractSummary(stderr, {stripLocation: true});
   expect(rest).toMatchSnapshot();
   expect(summary).toMatchSnapshot();
 });

--- a/packages/jest-config/src/__tests__/normalize.test.js
+++ b/packages/jest-config/src/__tests__/normalize.test.js
@@ -25,7 +25,7 @@ let expectedPathAbs;
 let expectedPathAbsAnother;
 
 const findNodeModule = jest.fn(name => {
-  if (name.indexOf('jest-jasmine2') !== -1) {
+  if (name.match(/jest-jasmine2|babel-jest/)) {
     return name;
   }
   return null;
@@ -300,7 +300,7 @@ describe('transform', () => {
 
     expect(options.transform).toEqual([
       [DEFAULT_CSS_PATTERN, '/root/node_modules/jest-regex-util'],
-      [DEFAULT_JS_PATTERN, 'babel-jest'],
+      [DEFAULT_JS_PATTERN, require.resolve('babel-jest')],
       ['abs-path', '/qux/quux'],
     ]);
   });
@@ -684,7 +684,9 @@ describe('babel-jest', () => {
   beforeEach(() => {
     Resolver = require('jest-resolve');
     Resolver.findNodeModule = jest.fn(
-      name => path.sep + 'node_modules' + path.sep + name,
+      name => {
+        return name.indexOf('babel-jest') === -1 ? path.sep + 'node_modules' + path.sep + name : name;
+      }
     );
   });
 
@@ -698,7 +700,7 @@ describe('babel-jest', () => {
 
     expect(options.transform[0][0]).toBe(DEFAULT_JS_PATTERN);
     expect(options.transform[0][1]).toEqual(
-      path.sep + 'node_modules' + path.sep + 'babel-jest',
+      require.resolve('babel-jest'),
     );
     expect(options.setupFiles).toEqual([
       path.sep +
@@ -723,7 +725,7 @@ describe('babel-jest', () => {
     );
 
     expect(options.transform[0][0]).toBe(customJSPattern);
-    expect(options.transform[0][1]).toEqual('/node_modules/babel-jest');
+    expect(options.transform[0][1]).toEqual(require.resolve('babel-jest'));
     expect(options.setupFiles).toEqual([
       path.sep +
         'node_modules' +
@@ -732,20 +734,6 @@ describe('babel-jest', () => {
         path.sep +
         'runtime',
     ]);
-  });
-
-  it(`doesn't use babel-jest if its not available`, () => {
-    Resolver.findNodeModule = findNodeModule;
-
-    const {options} = normalize(
-      {
-        rootDir: '/root',
-      },
-      {},
-    );
-
-    expect(options.transform).toEqual(undefined);
-    expect(options.setupFiles).toEqual([]);
   });
 
   it('uses regenerator if babel-jest is explicitly specified', () => {

--- a/packages/jest-config/src/__tests__/normalize.test.js
+++ b/packages/jest-config/src/__tests__/normalize.test.js
@@ -684,9 +684,10 @@ describe('babel-jest', () => {
   beforeEach(() => {
     Resolver = require('jest-resolve');
     Resolver.findNodeModule = jest.fn(
-      name => {
-        return name.indexOf('babel-jest') === -1 ? path.sep + 'node_modules' + path.sep + name : name;
-      }
+      name =>
+        name.indexOf('babel-jest') === -1
+          ? path.sep + 'node_modules' + path.sep + name
+          : name,
     );
   });
 
@@ -699,9 +700,7 @@ describe('babel-jest', () => {
     );
 
     expect(options.transform[0][0]).toBe(DEFAULT_JS_PATTERN);
-    expect(options.transform[0][1]).toEqual(
-      require.resolve('babel-jest'),
-    );
+    expect(options.transform[0][1]).toEqual(require.resolve('babel-jest'));
     expect(options.setupFiles).toEqual([
       path.sep +
         'node_modules' +

--- a/packages/jest-config/src/normalize.js
+++ b/packages/jest-config/src/normalize.js
@@ -29,11 +29,7 @@ import {
   getTestEnvironment,
   resolve,
 } from './utils';
-import {
-  NODE_MODULES,
-  DEFAULT_JS_PATTERN,
-  DEFAULT_REPORTER_LABEL,
-} from './constants';
+import {DEFAULT_JS_PATTERN, DEFAULT_REPORTER_LABEL} from './constants';
 import {validateReporters} from './reporter_validation_errors';
 import DEFAULT_CONFIG from './defaults';
 import DEPRECATED_CONFIG from './deprecated';
@@ -103,7 +99,6 @@ const setupPreset = (
 };
 
 const setupBabelJest = (options: InitialOptions) => {
-  const basedir = options.rootDir;
   const transform = options.transform;
   let babelJest;
   if (transform) {
@@ -113,11 +108,11 @@ const setupBabelJest = (options: InitialOptions) => {
     });
 
     if (customJSPattern) {
-      const customJSTransformer = options.transform[customJSPattern];
+      const customJSTransformer = transform[customJSPattern];
 
       if (customJSTransformer === 'babel-jest') {
         babelJest = require.resolve('babel-jest');
-        options.transform[customJSPattern] = babelJest;
+        transform[customJSPattern] = babelJest;
       } else if (customJSTransformer.includes('babel-jest')) {
         babelJest = customJSTransformer;
       }
@@ -125,7 +120,7 @@ const setupBabelJest = (options: InitialOptions) => {
   } else {
     babelJest = require.resolve('babel-jest');
     options.transform = {
-      [DEFAULT_JS_PATTERN]: babelJest
+      [DEFAULT_JS_PATTERN]: babelJest,
     };
   }
 

--- a/packages/jest-config/src/normalize.js
+++ b/packages/jest-config/src/normalize.js
@@ -113,24 +113,20 @@ const setupBabelJest = (options: InitialOptions) => {
     });
 
     if (customJSPattern) {
-      const jsTransformer = Resolver.findNodeModule(
-        transform[customJSPattern],
-        {basedir},
-      );
-      if (
-        jsTransformer &&
-        jsTransformer.includes(NODE_MODULES + 'babel-jest')
-      ) {
-        babelJest = jsTransformer;
+      const customJSTransformer = options.transform[customJSPattern];
+
+      if (customJSTransformer === 'babel-jest') {
+        babelJest = require.resolve('babel-jest');
+        options.transform[customJSPattern] = babelJest;
+      } else if (customJSTransformer.includes('babel-jest')) {
+        babelJest = customJSTransformer;
       }
     }
   } else {
-    babelJest = Resolver.findNodeModule('babel-jest', {basedir});
-    if (babelJest) {
-      options.transform = {
-        [DEFAULT_JS_PATTERN]: 'babel-jest',
-      };
-    }
+    babelJest = require.resolve('babel-jest');
+    options.transform = {
+      [DEFAULT_JS_PATTERN]: babelJest
+    };
   }
 
   return babelJest;


### PR DESCRIPTION
## Summary

The `babel-jest` default transform is currently located through `Resolver.findNodeModules`. This has the inconvenient that when using a custom resolver, this new custom resolver will be completely  bypassed.

Given that `require.resolve` is the standard and safe way to obtain the requirable path to a package, I think we should use it whenever possible, at least until the custom resolver has been properly setup (ie after the config has been normalized).

Two notes:

- This might be a slight breaking change if users were specifying different version of `babel-jest` than the default. I'm not sure it's often the case, so it doesn't feel too problematic.

- The `regenerator` package is still located using `Resolver.findNodeModules`. It would be nice to fix this as well, but since this package is meant to be added by the user, only the user can use `require.resolve` to obtain its path (we can't use `process.main` because it points to the Jest cli). Since it's quite more complex, it can be done later on.

## Test plan

I've updated the tests to match the behavior (ie mostly checked that the resulting configuration was matching whatever is returned by `require.resolve` rather than an hardcoded `node_modules/babel-jest`).