### PR TITLE
Fix handling regex symbols in tests path on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,8 @@
   ([#5720](https://github.com/facebook/jest/pull/5720))
 * `[pretty-format]` Handle React fragments better
   ([#5816](https://github.com/facebook/jest/pull/5816))
+* `[jest-regex-util]` Fix handling regex symbols in tests path on Windows
+  ([#5941](https://github.com/facebook/jest/pull/5941))
 
 ### Chore & Maintenance
 

--- a/integration-tests/__tests__/regex_(char_in_path.test.js
+++ b/integration-tests/__tests__/regex_(char_in_path.test.js
@@ -8,12 +8,9 @@
  */
 'use strict';
 
-const SkipOnWindows = require('../../scripts/SkipOnWindows');
 const runJest = require('../runJest');
 
 describe('Regex Char In Path', () => {
-  SkipOnWindows.suite();
-
   it('parses paths containing regex chars correctly', () => {
     const {json} = runJest.json('regex-(char-in-path', []);
 

--- a/packages/jest-regex-util/src/__tests__/index.test.js
+++ b/packages/jest-regex-util/src/__tests__/index.test.js
@@ -39,5 +39,9 @@ describe('replacePathSepForRegex()', () => {
         'a\\\\\\\\\\.dotfile',
       );
     });
+
+    it('should not escape an escaped regexp symbol', () => {
+      expect(replacePathSepForRegex('b\\(86')).toBe('b\\(86');
+    });
   });
 });

--- a/packages/jest-regex-util/src/index.js
+++ b/packages/jest-regex-util/src/index.js
@@ -23,7 +23,7 @@ export const escapeStrForRegex = (string: string) =>
 
 export const replacePathSepForRegex = (string: string) => {
   if (path.sep === '\\') {
-    return string.replace(/(\/|\\(?!\.))/g, '\\\\');
+    return string.replace(/(\/|\\(?![[\]{}()*+?.^$|]))/g, '\\\\');
   }
   return string;
 };


### PR DESCRIPTION
## Summary

Fixes #2381

## Test plan

![image](https://user-images.githubusercontent.com/39293/38458659-4c67c9be-3aa9-11e8-869f-958193aee49d.png)
