### PR TITLE
install sourcecmap-support into normal runtime as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@
 
 ### Fixes
 
+* `[jest-jasmine2]` Install `sourcemap-support` into normal runtime to catch
+  runtime errors ([#5945](https://github.com/facebook/jest/pull/5945))
 * `[jest-jasmine2]` Added assertion error handling inside `afterAll hook`
   ([#5884](https://github.com/facebook/jest/pull/5884))
 * `[jest-cli]` Remove the notifier actions in case of failure when not in watch

--- a/integration-tests/__tests__/stack_trace.test.js
+++ b/integration-tests/__tests__/stack_trace.test.js
@@ -22,6 +22,7 @@ describe('Stack Trace', () => {
     expect(stderr).toMatch(
       /ReferenceError: thisIsARuntimeError is not defined/,
     );
+    expect(stderr).toMatch(/> 10 \| thisIsARuntimeError\(\);/);
     expect(stderr).toMatch(
       /\s+at\s(?:.+?)\s\(__tests__\/runtime_error.test\.js/,
     );


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary
I'm not really sure why this is needed. The runtime error is thrown from the jest environment (either node or jsdom), shouldn't the sourcemap-support be installed properly there?

/cc @jwbay @felipeochoa 

Fixes #5925.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan
New assertion added to existing test which fails without the code change.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
