### PR TITLE
Update TutorialReact.md

### DIFF
--- a/docs/TutorialReact.md
+++ b/docs/TutorialReact.md
@@ -13,7 +13,10 @@ applications.
 If you are just getting started with React, we recommend using
 [Create React App](https://github.com/facebookincubator/create-react-app). It is
 ready to use and
-[ships with Jest](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#running-tests)! You will only need to add `react-test-renderer` for rendering snapshots.
+[ships with Jest](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#running-tests)!
+You will only need to add `react-test-renderer` for rendering snapshots.
+
+Run
 
 ```bash
 yarn add --dev react-test-renderer

--- a/docs/TutorialReact.md
+++ b/docs/TutorialReact.md
@@ -13,9 +13,11 @@ applications.
 If you are just getting started with React, we recommend using
 [Create React App](https://github.com/facebookincubator/create-react-app). It is
 ready to use and
-[ships with Jest](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#running-tests)!
-You don't need to do any extra steps for setup, and can head straight to the
-next section.
+[ships with Jest](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#running-tests)! You will only need to add `react-test-renderer` for rendering snapshots.
+
+```bash
+yarn add --dev react-test-renderer
+```
 
 ### Setup without Create React App
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8445,7 +8445,7 @@ supports-color@^3.1.2:
   dependencies:
     has-flag "^1.0.0"
 
-supports-color@^5.2.0, supports-color@^5.3.0:
+supports-color@^5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.3.0.tgz#5b24ac15db80fa927cf5227a4a33fd3c4c7676c0"
   dependencies:


### PR DESCRIPTION
The current docs imply you can use Jest snapshots with create-react-app 'out-the-box', however the Snapshot Testing example doesn't work with a fresh install. You need to additionally install `react-test-renderer` as a dependency.

I thought it was more helpful to change the docs, but if it's better to raise the issue elsewhere let me know!

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary
The docs are a little confusing. It literally says Create React App works without any additional configuration, however one of the examples provided doesn't work without additional configuaration.

## Test plan
I did a fresh install of the latest create-react-app, created the Link.react.app and Link.react.test.js from the docs example and tried to run the tests. It fails unless you add 'react-test-renderer'.
