### PR TITLE
Extends .toHaveBeenCalled message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@
 
 ### Fixes
 
+* `[jest-mock]` Extend .toHaveBeenCalled return message with outcome
+  ([#5951](https://github.com/facebook/jest/pull/5951))
 * `[jest-runner]` Assign `process.env.JEST_WORKER_ID="1"` when in runInBand mode
   ([#5860](https://github.com/facebook/jest/pull/5860))
 * `[jest-cli]` Add descriptive error message when trying to use

--- a/packages/expect/src/__tests__/__snapshots__/spy_matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/spy_matchers.test.js.snap
@@ -256,7 +256,7 @@ Got:
 exports[`toBeCalled .not passes when called 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).toBeCalled(</><dim>)</>
 
-Expected mock function to have been called."
+Expected mock function to have been called, but it was not called."
 `;
 
 exports[`toBeCalled fails with any argument passed 1`] = `
@@ -541,7 +541,7 @@ Got:
 exports[`toHaveBeenCalled .not passes when called 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).toHaveBeenCalled(</><dim>)</>
 
-Expected mock function to have been called."
+Expected mock function to have been called, but it was not called."
 `;
 
 exports[`toHaveBeenCalled fails with any argument passed 1`] = `

--- a/packages/expect/src/spy_matchers.js
+++ b/packages/expect/src/spy_matchers.js
@@ -49,7 +49,7 @@ const createToBeCalledMatcher = matcherName => (received, expected) => {
     : () =>
         matcherHint(matcherName, receivedName, '') +
         '\n\n' +
-        `Expected ${type} to have been called.`;
+        `Expected ${type} to have been called, but it was not called.`;
 
   return {message, pass};
 };


### PR DESCRIPTION
Pull request based on https://twitter.com/lukesobek/status/982508206919442432 to extend the message `.toHaveBeenCalled`  returns on failure
from `Expected mock function to have been called.`  
to `Expected mock function to have been called, but it was not called.`

## Summary

The pull request puts the behavior of .toHaveBeenCalled in line with other .toHaveBeenCalled... explicitly stating what was expected and what the result was.

## Test plan

2 related snapshots were updated, jest returned a fully green run
