### PR TITLE
Correct docs about `expect.toThrow(String)`

### DIFF
--- a/docs/ExpectAPI.md
+++ b/docs/ExpectAPI.md
@@ -1080,9 +1080,9 @@ test('throws on octopus', () => {
 ```
 
 If you want to test that a specific error gets thrown, you can provide an
-argument to `toThrow`. The argument can be a string for the error message, a
-class for the error, or a regex that should match the error. For example, let's
-say that `drinkFlavor` is coded like this:
+argument to `toThrow`. The argument can be a string that should be contained in
+the error message, a class for the error, or a regex that should match the error
+message. For example, let's say that `drinkFlavor` is coded like this:
 
 ```js
 function drinkFlavor(flavor) {
@@ -1101,11 +1101,12 @@ test('throws on octopus', () => {
     drinkFlavor('octopus');
   }
 
-  // Test the exact error message
-  expect(drinkOctopus).toThrowError('yuck, octopus flavor');
-
-  // Test that the error message says "yuck" somewhere
+  // Test that the error message says "yuck" somewhere: these are equivalent
   expect(drinkOctopus).toThrowError(/yuck/);
+  expect(drinkOctopus).toThrowError('yuck');
+
+  // Test the exact error message
+  expect(drinkOctopus).toThrowError(/^yuck, octopus flavor$/);
 
   // Test that we get a DisgustingFlavorError
   expect(drinkOctopus).toThrowError(DisgustingFlavorError);

--- a/website/versioned_docs/version-22.0/ExpectAPI.md
+++ b/website/versioned_docs/version-22.0/ExpectAPI.md
@@ -986,9 +986,9 @@ test('throws on octopus', () => {
 ```
 
 If you want to test that a specific error gets thrown, you can provide an
-argument to `toThrow`. The argument can be a string for the error message, a
-class for the error, or a regex that should match the error. For example, let's
-say that `drinkFlavor` is coded like this:
+argument to `toThrow`. The argument can be a string that should be contained in
+the error message, a class for the error, or a regex that should match the error
+message. For example, let's say that `drinkFlavor` is coded like this:
 
 ```js
 function drinkFlavor(flavor) {
@@ -1007,11 +1007,12 @@ test('throws on octopus', () => {
     drinkFlavor('octopus');
   }
 
-  // Test the exact error message
-  expect(drinkOctopus).toThrowError('yuck, octopus flavor');
-
-  // Test that the error message says "yuck" somewhere
+  // Test that the error message says "yuck" somewhere: these are equivalent
   expect(drinkOctopus).toThrowError(/yuck/);
+  expect(drinkOctopus).toThrowError('yuck');
+
+  // Test the exact error message
+  expect(drinkOctopus).toThrowError(/^yuck, octopus flavor$/);
 
   // Test that we get a DisgustingFlavorError
   expect(drinkOctopus).toThrowError(DisgustingFlavorError);

--- a/website/versioned_docs/version-22.1/ExpectAPI.md
+++ b/website/versioned_docs/version-22.1/ExpectAPI.md
@@ -980,9 +980,9 @@ test('throws on octopus', () => {
 ```
 
 If you want to test that a specific error gets thrown, you can provide an
-argument to `toThrow`. The argument can be a string for the error message, a
-class for the error, or a regex that should match the error. For example, let's
-say that `drinkFlavor` is coded like this:
+argument to `toThrow`. The argument can be a string that should be contained in
+the error message, a class for the error, or a regex that should match the error
+message. For example, let's say that `drinkFlavor` is coded like this:
 
 ```js
 function drinkFlavor(flavor) {
@@ -1001,11 +1001,12 @@ test('throws on octopus', () => {
     drinkFlavor('octopus');
   }
 
-  // Test the exact error message
-  expect(drinkOctopus).toThrowError('yuck, octopus flavor');
-
-  // Test that the error message says "yuck" somewhere
+  // Test that the error message says "yuck" somewhere: these are equivalent
   expect(drinkOctopus).toThrowError(/yuck/);
+  expect(drinkOctopus).toThrowError('yuck');
+
+  // Test the exact error message
+  expect(drinkOctopus).toThrowError(/^yuck, octopus flavor$/);
 
   // Test that we get a DisgustingFlavorError
   expect(drinkOctopus).toThrowError(DisgustingFlavorError);

--- a/website/versioned_docs/version-22.2/ExpectAPI.md
+++ b/website/versioned_docs/version-22.2/ExpectAPI.md
@@ -980,9 +980,9 @@ test('throws on octopus', () => {
 ```
 
 If you want to test that a specific error gets thrown, you can provide an
-argument to `toThrow`. The argument can be a string for the error message, a
-class for the error, or a regex that should match the error. For example, let's
-say that `drinkFlavor` is coded like this:
+argument to `toThrow`. The argument can be a string that should be contained in
+the error message, a class for the error, or a regex that should match the error
+message. For example, let's say that `drinkFlavor` is coded like this:
 
 ```js
 function drinkFlavor(flavor) {
@@ -1001,11 +1001,12 @@ test('throws on octopus', () => {
     drinkFlavor('octopus');
   }
 
-  // Test the exact error message
-  expect(drinkOctopus).toThrowError('yuck, octopus flavor');
-
-  // Test that the error message says "yuck" somewhere
+  // Test that the error message says "yuck" somewhere: these are equivalent
   expect(drinkOctopus).toThrowError(/yuck/);
+  expect(drinkOctopus).toThrowError('yuck');
+
+  // Test the exact error message
+  expect(drinkOctopus).toThrowError(/^yuck, octopus flavor$/);
 
   // Test that we get a DisgustingFlavorError
   expect(drinkOctopus).toThrowError(DisgustingFlavorError);

--- a/website/versioned_docs/version-22.3/ExpectAPI.md
+++ b/website/versioned_docs/version-22.3/ExpectAPI.md
@@ -980,9 +980,9 @@ test('throws on octopus', () => {
 ```
 
 If you want to test that a specific error gets thrown, you can provide an
-argument to `toThrow`. The argument can be a string for the error message, a
-class for the error, or a regex that should match the error. For example, let's
-say that `drinkFlavor` is coded like this:
+argument to `toThrow`. The argument can be a string that should be contained in
+the error message, a class for the error, or a regex that should match the error
+message. For example, let's say that `drinkFlavor` is coded like this:
 
 ```js
 function drinkFlavor(flavor) {
@@ -1001,11 +1001,12 @@ test('throws on octopus', () => {
     drinkFlavor('octopus');
   }
 
-  // Test the exact error message
-  expect(drinkOctopus).toThrowError('yuck, octopus flavor');
-
-  // Test that the error message says "yuck" somewhere
+  // Test that the error message says "yuck" somewhere: these are equivalent
   expect(drinkOctopus).toThrowError(/yuck/);
+  expect(drinkOctopus).toThrowError('yuck');
+
+  // Test the exact error message
+  expect(drinkOctopus).toThrowError(/^yuck, octopus flavor$/);
 
   // Test that we get a DisgustingFlavorError
   expect(drinkOctopus).toThrowError(DisgustingFlavorError);

--- a/website/versioned_docs/version-22.4/ExpectAPI.md
+++ b/website/versioned_docs/version-22.4/ExpectAPI.md
@@ -1054,9 +1054,9 @@ test('throws on octopus', () => {
 ```
 
 If you want to test that a specific error gets thrown, you can provide an
-argument to `toThrow`. The argument can be a string for the error message, a
-class for the error, or a regex that should match the error. For example, let's
-say that `drinkFlavor` is coded like this:
+argument to `toThrow`. The argument can be a string that should be contained in
+the error message, a class for the error, or a regex that should match the error
+message. For example, let's say that `drinkFlavor` is coded like this:
 
 ```js
 function drinkFlavor(flavor) {
@@ -1075,11 +1075,12 @@ test('throws on octopus', () => {
     drinkFlavor('octopus');
   }
 
-  // Test the exact error message
-  expect(drinkOctopus).toThrowError('yuck, octopus flavor');
-
-  // Test that the error message says "yuck" somewhere
+  // Test that the error message says "yuck" somewhere: these are equivalent
   expect(drinkOctopus).toThrowError(/yuck/);
+  expect(drinkOctopus).toThrowError('yuck');
+
+  // Test the exact error message
+  expect(drinkOctopus).toThrowError(/^yuck, octopus flavor$/);
 
   // Test that we get a DisgustingFlavorError
   expect(drinkOctopus).toThrowError(DisgustingFlavorError);


### PR DESCRIPTION
Summary:
The current docs indicate that a test like the following should fail,
but it actually passes:
```js
function scary() {
  throw new Error("...Boo!");
}

it("should be scary", () => {
  // Should fail, according to current docs: not an exact match.
  // Actually passes.
  expect(() => scary()).toThrow("Boo");
});
```

We can see in the implementation that the actual behavior is that
strings are simply injected into `RegExp`s, without anchors:

https://github.com/facebook/jest/blob/5a21be3e07c223ba9fbb434f26bce96da0dddd31/packages/expect/src/to_throw_matchers.js#L53-L55

This patch corrects the docs accordingly. Inspecting prior versions of
the code indicates that this behavior has been present back to at least
v22.0, so I have updated historical docs, too.

Test Plan:
Create a new project, and `yarn add jest`. Paste the above example code
into `demo.test.js`, and note that `yarn jest` passes (but changing the
string to `"something else"` causes it to fail, so Jest is actually
running).

Note that after `(cd website; yarn && yarn start)`, navigating to

http://localhost:3000/jest/docs/en/expect.html#tothrowerror

shows the new text.

wchargin-branch: docs-expect-tothrow-string