### PR TITLE
Dispose document when tearing down JSDom environment

### DIFF
--- a/packages/jest-environment-jsdom/src/index.js
+++ b/packages/jest-environment-jsdom/src/index.js
@@ -97,6 +97,8 @@ class JSDOMEnvironment {
       if (this.errorEventListener) {
         this.global.removeEventListener('error', this.errorEventListener);
       }
+      // Dispose "document" to prevent "load" event from triggering.
+      Object.defineProperty(this.global, 'document', {value: null});
       this.global.close();
     }
     this.errorEventListener = null;


### PR DESCRIPTION
The `load` event is triggered asynchronously by JSDom, and, [since it happens into the constructor](https://github.com/jsdom/jsdom/blob/master/lib/jsdom/browser/Window.js#L595), nothing can be done.

However, an early check for `document` existence is done before (as you wouldn't be able to check its status if it's already gone). Based on this, for synchronous tests, we can skip the `load` event, which was anyway triggered later.