### PR TITLE
Generalise package main resolving issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,8 @@
   ([#5914](https://github.com/facebook/jest/pull/5914))
 * `[jest-regex-util]` Fix handling regex symbols in tests path on Windows
   ([#5941](https://github.com/facebook/jest/pull/5941))
+* `[jest-resolve]` Generalise test for package main entries equivalent to ".".
+  ([#5968)](https://github.com/facebook/jest/pull/5968)
 
 ### Chore & Maintenance
 

--- a/docs/ExpectAPI.md
+++ b/docs/ExpectAPI.md
@@ -335,8 +335,8 @@ describe('not.stringContaining', () => {
 
 ### `expect.not.stringMatching(string | regexp)`
 
-`expect.not.stringMatching(string | regexp)` matches the received string that does not
-match the expected regexp.
+`expect.not.stringMatching(string | regexp)` matches the received string that
+does not match the expected regexp.
 
 It is the inverse of `expect.stringMatching`.
 
@@ -384,8 +384,8 @@ exact expected string.
 
 ### `expect.stringMatching(string | regexp)`
 
-`expect.stringMatching(string | regexp)` matches the received string that matches the
-expected regexp.
+`expect.stringMatching(string | regexp)` matches the received string that
+matches the expected regexp.
 
 You can use it instead of a literal value:
 

--- a/integration-tests/resolve-node-module/__mocks__/mock-module-alt/index.js
+++ b/integration-tests/resolve-node-module/__mocks__/mock-module-alt/index.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+module.exports = 'test';

--- a/integration-tests/resolve-node-module/__mocks__/mock-module-alt/package.json
+++ b/integration-tests/resolve-node-module/__mocks__/mock-module-alt/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "mock-module-alt",
+  "main": "./"
+}

--- a/integration-tests/resolve-node-module/__tests__/resolve-node-module.test.js
+++ b/integration-tests/resolve-node-module/__tests__/resolve-node-module.test.js
@@ -8,6 +8,7 @@
 'use strict';
 
 jest.mock('mock-module');
+jest.mock('mock-module-alt');
 jest.mock('mock-jsx-module');
 
 it('should resolve entry as index.js when package main is "."', () => {
@@ -15,7 +16,12 @@ it('should resolve entry as index.js when package main is "."', () => {
   expect(mockModule).toEqual('test');
 });
 
-it('should resolve entry as index with other configured module file extention when package main is "."', () => {
+it('should resolve entry as index.js when package main is "./"', () => {
+  const mockModule = require('mock-module-alt');
+  expect(mockModule).toEqual('test');
+});
+
+it('should resolve entry as index with other configured module file extension when package main is "."', () => {
   const mockJsxModule = require('mock-jsx-module');
   expect(mockJsxModule).toEqual('test jsx');
 });

--- a/packages/jest-resolve/src/default_resolver.js
+++ b/packages/jest-resolve/src/default_resolver.js
@@ -129,7 +129,7 @@ function resolveSync(target: Path, options: ResolverOptions): Path {
       pkgmain = JSON.parse(body).main;
     } catch (e) {}
 
-    if (pkgmain && pkgmain !== '.') {
+    if (pkgmain && !isCurrentDirectory(pkgmain)) {
       const resolveTarget = path.resolve(name, pkgmain);
       const result = tryResolve(resolveTarget);
       if (result) {
@@ -174,4 +174,8 @@ function isDirectory(dir: Path): boolean {
   }
 
   return result;
+}
+
+function isCurrentDirectory(testPath: Path): boolean {
+  return path.resolve('.') === path.resolve(testPath);
 }


### PR DESCRIPTION
Resolves #5967.

## Summary

#5967 resolved an issue with module resolution when the main entry in package.json is set to ".".  However, there are other ways to refer to the current directory, such as "./" (or even "././").  This PR generalises the fix by checking whether the resolved path for package main differs from the resolved path for ".".

## Test plan

New test added to explicitly test "./" along with ".".
