### PR TITLE
Stops using realpath in the resolution

### DIFF
--- a/packages/jest-resolve/src/default_resolver.js
+++ b/packages/jest-resolve/src/default_resolver.js
@@ -97,7 +97,7 @@ function resolveSync(target: Path, options: ResolverOptions): Path {
     if (result) {
       // Dereference symlinks to ensure we don't create a separate
       // module instance depending on how it was referenced.
-      result = fs.realpathSync(result);
+      result = path.resolve(process.cwd(), result);
     }
     return result;
   }


### PR DESCRIPTION
## Summary

The default resolver uses `realpath` to ensure that multiple identical paths always share the same underlying module. This is a behavior that should belong to the component instantiating the modules rather than the one resolving the paths.

One example of problem it could cause is when using `yarn link` with peer dependencies. In this case, it's important to preserve the symlinks as they are in order to properly resolve the peer dependencies relative to the location of the symlink rather than the one of the actual package on the filesystem.

## Test plan

Existing tests should still pass.