### PR TITLE
Disable eslint no-bitwise for mock timer delay check

### DIFF
--- a/packages/jest-util/src/fake_timers.js
+++ b/packages/jest-util/src/fake_timers.js
@@ -486,6 +486,7 @@ export default class FakeTimers<TimerRef> {
       return null;
     }
 
+    // eslint-disable-next-line no-bitwise
     delay = Number(delay) | 0;
 
     const args = [];


### PR DESCRIPTION
## Summary

This pull request contains follow up ESLint fix for https://github.com/facebook/jest/pull/5966

_code grep did show that eslint has been also disabled also in other places in jest code for sepcial cases - i guess this one will counter one?_


> as reported in https://github.com/facebook/jest/pull/5966#issuecomment-381396303

/cc @SimenB @AhnpGit 

## Test plan

run linter> `yarn lint`
