### PR TITLE
Allow skip process method if createTransformer definded

### DIFF
--- a/packages/jest-runtime/src/script_transformer.js
+++ b/packages/jest-runtime/src/script_transformer.js
@@ -136,9 +136,12 @@ export default class ScriptTransformer {
 
       // $FlowFixMe
       transform = (require(transformPath): Transformer);
-      if (typeof transform.process !== 'function') {
+      if (
+        typeof transform.process !== 'function' &&
+        typeof transform.createTransformer !== 'function'
+      ) {
         throw new TypeError(
-          'Jest: a transform must export a `process` function.',
+          'Jest: a transform must export a `process` or `createTransformer` function.',
         );
       }
       if (typeof transform.createTransformer === 'function') {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary
Allow for transform plugins skip defining `process` method if `createTransformer` method was defined.
If `createTransformer` was definded then `process` method is not required because `createTransformer` returns new Transformer object.
## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
