### PR TITLE
Add stack traces on async failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 * `[expect]` Add stack trace for async errors (TBD)
+* `[jest-jasmine2]` Add stack trace for timeouts (TBD)
 * `[jest-runtime]` Prevent modules from marking themselves as their own parent
   ([#5235](https://github.com/facebook/jest/issues/5235))
 * `[jest-mock]` Add support for auto-mocking generator functions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 
+* `[expect]` Add stack trace for async errors (TBD)
 * `[jest-runtime]` Prevent modules from marking themselves as their own parent
   ([#5235](https://github.com/facebook/jest/issues/5235))
 * `[jest-mock]` Add support for auto-mocking generator functions

--- a/integration-tests/__tests__/__snapshots__/expect-async-matcher.test.js.snap
+++ b/integration-tests/__tests__/__snapshots__/expect-async-matcher.test.js.snap
@@ -30,23 +30,49 @@ Object {
 
   ● fail with expected promise values
 
-    Error
-      Error: Expected value to have length:
-        2
-      Received:
-        1
-      received.length:
-        1
+    Expected value to have length:
+      2
+    Received:
+      1
+    received.length:
+      1
+
+      22 | 
+      23 | it('fail with expected promise values', async () => {
+    > 24 |   await (expect(Promise.resolve([1])): any).resolves.toHaveLengthAsync(
+         |                                                      ^
+      25 |     Promise.resolve(2)
+      26 |   );
+      27 | });
+      
+      at packages/expect/build/index.js:165:22
+      at __tests__/failure.test.js:24:54
+      at __tests__/failure.test.js:11:191
+      at __tests__/failure.test.js:11:437
+      at __tests__/failure.test.js:11:99
 
   ● fail with expected promise values and not
 
-    Error
-      Error: Expected value to not have length:
-        2
-      Received:
-        1,2
-      received.length:
-        2
+    Expected value to not have length:
+      2
+    Received:
+      1,2
+    received.length:
+      2
+
+      28 | 
+      29 | it('fail with expected promise values and not', async () => {
+    > 30 |   await (expect(Promise.resolve([1, 2])).resolves.not: any).toHaveLengthAsync(
+         |                                                             ^
+      31 |     Promise.resolve(2)
+      32 |   );
+      33 | });
+      
+      at packages/expect/build/index.js:165:22
+      at __tests__/failure.test.js:30:61
+      at __tests__/failure.test.js:11:191
+      at __tests__/failure.test.js:11:437
+      at __tests__/failure.test.js:11:99
 
 ",
   "summary": "Test Suites: 1 failed, 1 total

--- a/integration-tests/__tests__/__snapshots__/failures.test.js.snap
+++ b/integration-tests/__tests__/__snapshots__/failures.test.js.snap
@@ -195,6 +195,7 @@ exports[`works with async failures 1`] = `
   ✕ reject, but fail
   ✕ expect reject
   ✕ expect resolve
+  ✕ timeout
 
   ● resolve, but fail
 
@@ -287,9 +288,25 @@ exports[`works with async failures 1`] = `
          |          ^
       25 | });
       26 | 
+      27 | test('timeout', done => {
       
       at packages/expect/build/index.js:96:15
       at __tests__/async_failures.test.js:24:10
+
+  ● timeout
+
+    Timeout - Async callback was not invoked within the 5ms timeout specified by jest.setTimeout.
+
+      25 | });
+      26 | 
+    > 27 | test('timeout', done => {
+         | ^
+      28 |   jest.setTimeout(5);
+      29 | 
+      30 |   setTimeout(done, 10);
+      
+      at packages/jest-jasmine2/build/jasmine/Env.js:445:20
+      at __tests__/async_failures.test.js:27:1
 
 "
 `;

--- a/integration-tests/__tests__/__snapshots__/failures.test.js.snap
+++ b/integration-tests/__tests__/__snapshots__/failures.test.js.snap
@@ -191,9 +191,12 @@ exports[`works with assertions in separate files 1`] = `
 
 exports[`works with async failures 1`] = `
 "FAIL __tests__/async_failures.test.js
-  ✕ something async
+  ✕ resolve, but fail
+  ✕ reject, but fail
+  ✕ expect reject
+  ✕ expect resolve
 
-  ● something async
+  ● resolve, but fail
 
     expect(received).toEqual(expected)
     
@@ -211,8 +214,82 @@ exports[`works with async failures 1`] = `
     -   \\"baz\\": \\"bar\\",
     +   \\"foo\\": \\"bar\\",
       }
+
+      10 | 
+      11 | test('resolve, but fail', () => {
+    > 12 |   return expect(Promise.resolve({foo: 'bar'})).resolves.toEqual({baz: 'bar'});
+         |                                                         ^
+      13 | });
+      14 | 
+      15 | test('reject, but fail', () => {
       
-      at packages/expect/build/index.js:160:61
+      at packages/expect/build/index.js:165:22
+      at __tests__/async_failures.test.js:12:57
+
+  ● reject, but fail
+
+    expect(received).toEqual(expected)
+    
+    Expected value to equal:
+      {\\"baz\\": \\"bar\\"}
+    Received:
+      {\\"foo\\": \\"bar\\"}
+    
+    Difference:
+    
+    - Expected
+    + Received
+    
+      Object {
+    -   \\"baz\\": \\"bar\\",
+    +   \\"foo\\": \\"bar\\",
+      }
+
+      14 | 
+      15 | test('reject, but fail', () => {
+    > 16 |   return expect(Promise.reject({foo: 'bar'})).rejects.toEqual({baz: 'bar'});
+         |                                                       ^
+      17 | });
+      18 | 
+      19 | test('expect reject', () => {
+      
+      at packages/expect/build/index.js:202:22
+      at __tests__/async_failures.test.js:16:55
+
+  ● expect reject
+
+    expect(received).rejects.toEqual()
+    
+    Expected received Promise to reject, instead it resolved to value
+      {\\"foo\\": \\"bar\\"}
+
+      18 | 
+      19 | test('expect reject', () => {
+    > 20 |   return expect(Promise.resolve({foo: 'bar'})).rejects.toEqual({foo: 'bar'});
+         |          ^
+      21 | });
+      22 | 
+      23 | test('expect resolve', () => {
+      
+      at packages/expect/build/index.js:96:15
+      at __tests__/async_failures.test.js:20:10
+
+  ● expect resolve
+
+    expect(received).resolves.toEqual()
+    
+    Expected received Promise to resolve, instead it rejected to value
+      {\\"foo\\": \\"bar\\"}
+
+      22 | 
+      23 | test('expect resolve', () => {
+    > 24 |   return expect(Promise.reject({foo: 'bar'})).resolves.toEqual({foo: 'bar'});
+         |          ^
+      25 | });
+      26 | 
+      
+      at packages/expect/build/index.js:96:15
+      at __tests__/async_failures.test.js:24:10
 
 "
 `;

--- a/integration-tests/failures/__tests__/async_failures.test.js
+++ b/integration-tests/failures/__tests__/async_failures.test.js
@@ -8,6 +8,18 @@
  */
 'use strict';
 
-test('something async', () => {
+test('resolve, but fail', () => {
   return expect(Promise.resolve({foo: 'bar'})).resolves.toEqual({baz: 'bar'});
+});
+
+test('reject, but fail', () => {
+  return expect(Promise.reject({foo: 'bar'})).rejects.toEqual({baz: 'bar'});
+});
+
+test('expect reject', () => {
+  return expect(Promise.resolve({foo: 'bar'})).rejects.toEqual({foo: 'bar'});
+});
+
+test('expect resolve', () => {
+  return expect(Promise.reject({foo: 'bar'})).resolves.toEqual({foo: 'bar'});
 });

--- a/integration-tests/failures/__tests__/async_failures.test.js
+++ b/integration-tests/failures/__tests__/async_failures.test.js
@@ -23,3 +23,9 @@ test('expect reject', () => {
 test('expect resolve', () => {
   return expect(Promise.reject({foo: 'bar'})).resolves.toEqual({foo: 'bar'});
 });
+
+test('timeout', done => {
+  jest.setTimeout(5);
+
+  setTimeout(done, 10);
+});

--- a/packages/jest-jasmine2/src/jasmine/Env.js
+++ b/packages/jest-jasmine2/src/jasmine/Env.js
@@ -398,6 +398,12 @@ export default function(j$) {
     }
 
     const specFactory = function(description, fn, suite, timeout) {
+      const timeoutError = new Error();
+
+      if (Error.captureStackTrace) {
+        Error.captureStackTrace(timeoutError, specFactory);
+      }
+
       totalSpecsDefined++;
       const spec = new j$.Spec({
         id: getNextSpecId(),
@@ -420,6 +426,7 @@ export default function(j$) {
           timeout() {
             return timeout || j$.DEFAULT_TIMEOUT_INTERVAL;
           },
+          timeoutError,
         },
         throwOnExpectationFailure,
       });

--- a/packages/jest-jasmine2/src/queue_runner.js
+++ b/packages/jest-jasmine2/src/queue_runner.js
@@ -34,7 +34,7 @@ export default function queueRunner(options: Options) {
     onCancel(resolve);
   });
 
-  const mapper = ({fn, timeout}) => {
+  const mapper = ({fn, timeout, timeoutError = new Error()}) => {
     let promise = new Promise(resolve => {
       const next = function(err) {
         if (err) {
@@ -69,12 +69,11 @@ export default function queueRunner(options: Options) {
       options.clearTimeout,
       options.setTimeout,
       () => {
-        const error = new Error(
+        timeoutError.message =
           'Timeout - Async callback was not invoked within the ' +
-            timeoutMs +
-            'ms timeout specified by jest.setTimeout.',
-        );
-        options.onException(error);
+          timeoutMs +
+          'ms timeout specified by jest.setTimeout.';
+        options.onException(timeoutError);
       },
     );
   };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary
This is missing adding a stack trace to random `throw` statements (or `await Promise.reject()`), otherwise I think every case is covered. We can point back to the test itself for that (like on timeout) if we want?

Fixes #5104.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan
Updated snapshots with stacktraces

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
