### PR TITLE
#6003: include snapshot name in error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ### Features
 
-* `[jest-snapshot]` [**BREAKING**] Concatenate name of test, optional snapshot name and count
-  ([#6015](https://github.com/facebook/jest/pull/6015))
+* `[jest-snapshot]` [**BREAKING**] Concatenate name of test, optional snapshot
+  name and count ([#6015](https://github.com/facebook/jest/pull/6015))
 * `[jest-runtime]` Allow for transform plugins to skip the definition process
   method if createTransformer method was defined.
   ([#5999](https://github.com/facebook/jest/pull/5999))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Features
 
+* `[jest-snapshot]` [**BREAKING**] Concatenate name of test, optional snapshot name and count
+  ([#6015](https://github.com/facebook/jest/pull/6015))
 * `[jest-runtime]` Allow for transform plugins to skip the definition process
   method if createTransformer method was defined.
   ([#5999](https://github.com/facebook/jest/pull/5999))

--- a/integration-tests/__tests__/__snapshots__/failures.test.js.snap
+++ b/integration-tests/__tests__/__snapshots__/failures.test.js.snap
@@ -399,6 +399,32 @@ exports[`works with async failures 1`] = `
 "
 `;
 
+exports[`works with named snapshot failures 1`] = `
+"FAIL __tests__/snapshot_named.test.js
+  ✕ failing named snapshot
+
+  ● failing named snapshot
+
+    expect(value).toMatchSnapshot()
+    
+    Received value does not match stored snapshot snapname 1.
+    
+    - \\"bar\\"
+    + \\"foo\\"
+
+      10 | 
+      11 | test('failing named snapshot', () => {
+    > 12 |   expect('foo').toMatchSnapshot('snapname');
+         |                 ^
+      13 | });
+      14 | 
+      
+      at __tests__/snapshot_named.test.js:12:17
+
+ › 1 snapshot test failed.
+"
+`;
+
 exports[`works with node assert 1`] = `
 "FAIL __tests__/node_assertion_error.test.js
   ✕ assert

--- a/integration-tests/__tests__/__snapshots__/failures.test.js.snap
+++ b/integration-tests/__tests__/__snapshots__/failures.test.js.snap
@@ -407,7 +407,7 @@ exports[`works with named snapshot failures 1`] = `
 
     expect(value).toMatchSnapshot()
     
-    Received value does not match stored snapshot snapname 1.
+    Received value does not match stored snapshot \\"snapname 1\\".
     
     - \\"bar\\"
     + \\"foo\\"
@@ -854,7 +854,7 @@ exports[`works with snapshot failures 1`] = `
 
     expect(value).toMatchSnapshot()
     
-    Received value does not match stored snapshot 1.
+    Received value does not match stored snapshot \\"1\\".
     
     - \\"bar\\"
     + \\"foo\\"

--- a/integration-tests/__tests__/__snapshots__/failures.test.js.snap
+++ b/integration-tests/__tests__/__snapshots__/failures.test.js.snap
@@ -407,7 +407,7 @@ exports[`works with named snapshot failures 1`] = `
 
     expect(value).toMatchSnapshot()
     
-    Received value does not match stored snapshot \\"snapname 1\\".
+    Received value does not match stored snapshot \\"failing named snapshot: snapname 1\\".
     
     - \\"bar\\"
     + \\"foo\\"
@@ -854,7 +854,7 @@ exports[`works with snapshot failures 1`] = `
 
     expect(value).toMatchSnapshot()
     
-    Received value does not match stored snapshot \\"1\\".
+    Received value does not match stored snapshot \\"failing snapshot 1\\".
     
     - \\"bar\\"
     + \\"foo\\"

--- a/integration-tests/__tests__/failures.test.js
+++ b/integration-tests/__tests__/failures.test.js
@@ -103,3 +103,13 @@ test('works with snapshot failures', () => {
     result.substring(0, result.indexOf('Snapshot Summary')),
   ).toMatchSnapshot();
 });
+
+test('works with named snapshot failures', () => {
+  const {stderr} = runJest(dir, ['snapshot_named.test.js']);
+
+  const result = normalizeDots(extractSummary(stderr).rest);
+
+  expect(
+    result.substring(0, result.indexOf('Snapshot Summary')),
+  ).toMatchSnapshot();
+});

--- a/integration-tests/failures/__tests__/__snapshots__/snapshot_named.test.js.snap
+++ b/integration-tests/failures/__tests__/__snapshots__/snapshot_named.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`failing named snapshot: snapname 1`] = `"bar"`;

--- a/integration-tests/failures/__tests__/snapshot_named.test.js
+++ b/integration-tests/failures/__tests__/snapshot_named.test.js
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @emails oncall+jsinfra
+ */
+'use strict';
+
+test('failing named snapshot', () => {
+  expect('foo').toMatchSnapshot('snapname');
+});

--- a/packages/jest-snapshot/src/State.js
+++ b/packages/jest-snapshot/src/State.js
@@ -165,6 +165,7 @@ export default class SnapshotState {
         actual: '',
         count,
         expected: '',
+        key,
         pass: true,
       };
     } else {
@@ -174,6 +175,7 @@ export default class SnapshotState {
           actual: unescape(receivedSerialized),
           count,
           expected: expected ? unescape(expected) : null,
+          key,
           pass: false,
         };
       } else {
@@ -182,6 +184,7 @@ export default class SnapshotState {
           actual: '',
           count,
           expected: '',
+          key,
           pass: true,
         };
       }

--- a/packages/jest-snapshot/src/index.js
+++ b/packages/jest-snapshot/src/index.js
@@ -67,7 +67,7 @@ const toMatchSnapshot = function(received: any, testName?: string) {
       : currentTestName || '',
     received,
   );
-  const {count, pass} = result;
+  const {pass} = result;
   let {actual, expected} = result;
 
   let report;
@@ -92,9 +92,7 @@ const toMatchSnapshot = function(received: any, testName?: string) {
 
     report = () =>
       `${RECEIVED_COLOR('Received value')} does not match ` +
-      `${EXPECTED_COLOR(
-        `stored snapshot "${testName ? testName + ' ' : ''}${count}"`,
-      )}.\n\n` +
+      `${EXPECTED_COLOR(`stored snapshot "${result.key}"`)}.\n\n` +
       (diffMessage ||
         EXPECTED_COLOR('- ' + (expected || '')) +
           '\n' +

--- a/packages/jest-snapshot/src/index.js
+++ b/packages/jest-snapshot/src/index.js
@@ -92,7 +92,9 @@ const toMatchSnapshot = function(received: any, testName?: string) {
 
     report = () =>
       `${RECEIVED_COLOR('Received value')} does not match ` +
-      `${EXPECTED_COLOR('stored snapshot ' + count)}.\n\n` +
+      `${EXPECTED_COLOR(
+        `stored snapshot ${testName ? testName + ' ' : ''}${count}`,
+      )}.\n\n` +
       (diffMessage ||
         EXPECTED_COLOR('- ' + (expected || '')) +
           '\n' +

--- a/packages/jest-snapshot/src/index.js
+++ b/packages/jest-snapshot/src/index.js
@@ -93,7 +93,7 @@ const toMatchSnapshot = function(received: any, testName?: string) {
     report = () =>
       `${RECEIVED_COLOR('Received value')} does not match ` +
       `${EXPECTED_COLOR(
-        `stored snapshot ${testName ? testName + ' ' : ''}${count}`,
+        `stored snapshot "${testName ? testName + ' ' : ''}${count}"`,
       )}.\n\n` +
       (diffMessage ||
         EXPECTED_COLOR('- ' + (expected || '')) +


### PR DESCRIPTION
## Summary

Implements #6003.

## Test plan

Added [named snapshot unit test](https://github.com/hroemer/jest/blob/issue-6003/integration-tests/failures/__tests__/snapshot_named.test.js) and additional test in [failures.test.js](https://github.com/hroemer/jest/blob/issue-6003/integration-tests/__tests__/failures.test.js#L107:L115)