### PR TITLE
Makes regenerator go through custom resolvers as well

### DIFF
--- a/integration-tests/custom-resolver/__tests__/custom-resolver.test.js
+++ b/integration-tests/custom-resolver/__tests__/custom-resolver.test.js
@@ -9,3 +9,7 @@
 test('should use the custom resolver', () => {
   require('foo');
 });
+
+test('should have regenerator injected', () => {
+  expect(global.fakeRegeneratorInjected).toEqual(true);
+});

--- a/integration-tests/custom-resolver/fake-regenerator.js
+++ b/integration-tests/custom-resolver/fake-regenerator.js
@@ -1,0 +1,1 @@
+global.fakeRegeneratorInjected = true;

--- a/integration-tests/custom-resolver/resolver.js
+++ b/integration-tests/custom-resolver/resolver.js
@@ -1,8 +1,16 @@
 const defaultResolver = require('jest-resolve/build/default_resolver').default;
 
+const exportedModules = new Map([
+  ['foo', 'foo'],
+  ['bar', 'bar'],
+  ['regenerator-runtime/runtime', 'fake-regenerator'],
+]);
+
 module.exports = (name, options) => {
-  if (name === 'foo' || name === 'bar') {
-    return `${__dirname}/${name}.js`;
+  const resolution = exportedModules.get(name);
+
+  if (resolution) {
+    return `${__dirname}/${resolution}.js`;
   } else {
     return defaultResolver(name, options);
   }

--- a/packages/jest-config/src/normalize.js
+++ b/packages/jest-config/src/normalize.js
@@ -587,7 +587,7 @@ export default function normalize(options: InitialOptions, argv: Argv) {
   if (babelJest) {
     const regeneratorRuntimePath = Resolver.findNodeModule(
       'regenerator-runtime/runtime',
-      {basedir: options.rootDir},
+      {basedir: options.rootDir, resolver: newOptions.resolver},
     );
 
     if (regeneratorRuntimePath) {


### PR DESCRIPTION
## Summary

This diff is just a followup to #5976 - I missed this call because it uses `findNodeModule` instead of `resolve` like the others (because it doesn't want to throw if the result cannot be found).

## Test plan

Tests should continue to pass.