### PR TITLE
Clarify position mock function call in docs

### DIFF
--- a/docs/ManualMocks.md
+++ b/docs/ManualMocks.md
@@ -60,8 +60,8 @@ called. To opt out of this behavior you will need to explicitly call
 `jest.unmock('moduleName')` in tests that should use the actual module
 implementation.
 
-> Warning: To make mock works properly we have to put the call
-> `jest.mock('moduleName')` in the same scope as `required/import` statement.
+> Note: In order to mock properly, Jest needs `jest.mock('moduleName')` to be in
+> the same scope as the `require/import` statement.
 
 Here's a contrived example where we have a module that provides a summary of all
 the files in a given directory. In this case we use the core (built in) `fs`

--- a/docs/ManualMocks.md
+++ b/docs/ManualMocks.md
@@ -60,6 +60,9 @@ called. To opt out of this behavior you will need to explicitly call
 `jest.unmock('moduleName')` in tests that should use the actual module
 implementation.
 
+> Warning: To make mock works properly we have to put the call
+> `jest.mock('moduleName')` in the same scope as `required/import` statement.
+
 Here's a contrived example where we have a module that provides a summary of all
 the files in a given directory. In this case we use the core (built in) `fs`
 module.

--- a/website/versioned_docs/version-22.4/ManualMocks.md
+++ b/website/versioned_docs/version-22.4/ManualMocks.md
@@ -60,7 +60,7 @@ called. To opt out of this behavior you will need to explicitly call
 `jest.unmock('moduleName')` in tests that should use the actual module
 implementation.
 
-> Warning: To make mock works properly we have to put call `jest.mock('moduleName')`
+> Warning: To make mock works properly we have to put the call `jest.mock('moduleName')`
 > in the same scope as `required/import` statement.
 
 Here's a contrived example where we have a module that provides a summary of all

--- a/website/versioned_docs/version-22.4/ManualMocks.md
+++ b/website/versioned_docs/version-22.4/ManualMocks.md
@@ -60,9 +60,6 @@ called. To opt out of this behavior you will need to explicitly call
 `jest.unmock('moduleName')` in tests that should use the actual module
 implementation.
 
-> Warning: To make mock works properly we have to put the call `jest.mock('moduleName')`
-> in the same scope as `required/import` statement.
-
 Here's a contrived example where we have a module that provides a summary of all
 the files in a given directory. In this case we use the core (built in) `fs`
 module.

--- a/website/versioned_docs/version-22.4/ManualMocks.md
+++ b/website/versioned_docs/version-22.4/ManualMocks.md
@@ -60,6 +60,9 @@ called. To opt out of this behavior you will need to explicitly call
 `jest.unmock('moduleName')` in tests that should use the actual module
 implementation.
 
+> Warning: To make mock works properly we have to put call `jest.mock('moduleName')`
+> in the same scope as `required/import` statement.
+
 Here's a contrived example where we have a module that provides a summary of all
 the files in a given directory. In this case we use the core (built in) `fs`
 module.


### PR DESCRIPTION
## Summary
For me, it was really not clear from docs where exactly in terms of proper scope I have to call `jest.mock('moduleName')` function, so I spent a couple of hours thinking that the mock function itself was broken and I even created this issue [issues#5993](https://github.com/facebook/jest/issues/5993)

## Test plan
Pull request changes documentation of ManualMock.md (the version of docs is 22.4)
To test it navigate to the root directory of the project and run next commands:
```
cd website 
yarn
yarn start
```
Then open Jest website and navigate to API -> "Manual Mocks" and see changes

Tests can be run from the root project directory via:
```
yarn test
```
