### PR TITLE
Fix testMatch config in docs

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -893,7 +893,7 @@ given to [jsdom](https://github.com/tmpvar/jsdom) such as
 
 ### `testMatch` [array<string>]
 
-(default: `[ '**/__tests__/**/*.js?(x)', '**/?(*.)+(spec|test).js?(x)' ]`)
+(default: `[ "**/__tests__/**/*.js?(x)", "**/?(*.)+(spec|test).js?(x)" ]`)
 
 The glob patterns Jest uses to detect test files. By default it looks for `.js`
 and `.jsx` files inside of `__tests__` folders, as well as any files with a


### PR DESCRIPTION
## Summary

Single quoted strings are not allowed in JSON

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
