### PR TITLE
FIxed the duplicate files warning(#2070)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 ## master
 
 ### Features
-
+* `[jest-haste-map]` Mocks are stored by their full path, not only filename
+  ([#6024](https://github.com/facebook/jest/pull/6024))
+* `[jest-haste-map]` Support extracting dynamic `import`s
+  ([#5883](https://github.com/facebook/jest/pull/5883))
 * `[jest-snapshot]` [**BREAKING**] Concatenate name of test, optional snapshot
   name and count ([#6015](https://github.com/facebook/jest/pull/6015))
 * `[jest-runtime]` Allow for transform plugins to skip the definition process

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,6 @@
 ### Features
 * `[jest-haste-map]` Mocks are stored by their full path, not only filename
   ([#6024](https://github.com/facebook/jest/pull/6024))
-* `[jest-haste-map]` Support extracting dynamic `import`s
-  ([#5883](https://github.com/facebook/jest/pull/5883))
 * `[jest-snapshot]` [**BREAKING**] Concatenate name of test, optional snapshot
   name and count ([#6015](https://github.com/facebook/jest/pull/6015))
 * `[jest-runtime]` Allow for transform plugins to skip the definition process

--- a/packages/jest-haste-map/src/index.js
+++ b/packages/jest-haste-map/src/index.js
@@ -418,7 +418,7 @@ class HasteMap extends EventEmitter {
       this._options.mocksPattern.test(filePath)
     ) {
       const mockPath = getMockName(filePath);
-      if (mocks[mockPath]) {
+      if (mocks[filePath]) {
         this._console.warn(
           `jest-haste-map: duplicate manual mock found:\n` +
             `  Module name: ${mockPath}\n` +
@@ -430,7 +430,7 @@ class HasteMap extends EventEmitter {
             `${mocks[mockPath]}\n${filePath}\n\n`,
         );
       }
-      mocks[mockPath] = filePath;
+      mocks[filePath] = filePath;
     }
 
     const fileMetadata = hasteMap.files[filePath];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Running code using mock files with the same name provided a warning in the console.
I moved the warning from being thrown when files had the same name to only when full paths are the same.

## Test plan

All my tests still function after the change, only difference is the warnings have been removed.

