### PR TITLE
Introduce toStrictEqual

### DIFF
--- a/packages/expect/src/__tests__/matchers.test.js
+++ b/packages/expect/src/__tests__/matchers.test.js
@@ -204,6 +204,32 @@ describe('.toBe()', () => {
   });
 });
 
+describe('.toStrictEqual()', () => {
+  class TestClass {
+    constructor(a, b) {
+      this.a = a;
+      this.b = b;
+    }
+  }
+
+  expect({
+    test: new TestClass(1, 2),
+  }).toStrictEqual({test: new TestClass(1, 2)});
+});
+
+describe('.not.toStrictEqual()', () => {
+  class TestClass {
+    constructor(a, b) {
+      this.a = a;
+      this.b = b;
+    }
+  }
+
+  expect({
+    test: new TestClass(1, 2),
+  }).not.toStrictEqual({test: {a: 1, b: 2}});
+});
+
 describe('.toEqual()', () => {
   [
     [true, false],

--- a/packages/expect/src/matchers.js
+++ b/packages/expect/src/matchers.js
@@ -29,6 +29,7 @@ import {
   getPath,
   iterableEquality,
   subsetEquality,
+  typeEquality,
 } from './utils';
 import {equals} from './jasmine_utils';
 
@@ -614,6 +615,38 @@ const matchers: MatchersObject = {
         };
 
     return {message, pass};
+  },
+
+  toStrictEqual(received: any, expected: any) {
+    const pass = equals(received, expected, [iterableEquality, typeEquality]);
+
+    const message = pass
+      ? () =>
+          matcherHint('.not.toStrictEqual') +
+          '\n\n' +
+          `Expected value to not equal:\n` +
+          `  ${printExpected(expected)}\n` +
+          `Received:\n` +
+          `  ${printReceived(received)}`
+      : () => {
+          const diffString = diff(expected, received, {
+            expand: this.expand,
+          });
+          return (
+            matcherHint('.toStrictEqual') +
+            '\n\n' +
+            `Expected value to equal:\n` +
+            `  ${printExpected(expected)}\n` +
+            `Received:\n` +
+            `  ${printReceived(received)}` +
+            (diffString ? `\n\nDifference:\n\n${diffString}` : '')
+          );
+        };
+
+    // Passing the the actual and expected objects so that a custom reporter
+    // could access them, for example in order to display a custom visual diff,
+    // or create a different error message
+    return {actual: received, expected, message, name: 'toStrictEqual', pass};
   },
 };
 

--- a/packages/expect/src/utils.js
+++ b/packages/expect/src/utils.js
@@ -185,6 +185,14 @@ export const subsetEquality = (object: Object, subset: Object) => {
   );
 };
 
+export const typeEquality = (a: any, b: any) => {
+  if (a == null || b == null || a.constructor.name === b.constructor.name) {
+    return undefined;
+  }
+
+  return false;
+};
+
 export const partition = <T>(
   items: Array<T>,
   predicate: T => boolean,


### PR DESCRIPTION
## Summary

My application is dependent on having the correct class types for objects and not just the correct object structure. So I needed a way to in my tests ensure that that an object is actually equal to another, not just that they include the same data as this does not mean they are semantically equal.

## Test plan

Added test cases for passing and failing.
