### PR TITLE
Fixes automocks when using resolvers

### DIFF
--- a/integration-tests/custom-resolver/__mocks__/manual-mock.js
+++ b/integration-tests/custom-resolver/__mocks__/manual-mock.js
@@ -1,0 +1,1 @@
+module.exports = require('bar');

--- a/integration-tests/custom-resolver/__tests__/custom-resolver.test.js
+++ b/integration-tests/custom-resolver/__tests__/custom-resolver.test.js
@@ -13,3 +13,18 @@ test('should use the custom resolver', () => {
 test('should have regenerator injected', () => {
   expect(global.fakeRegeneratorInjected).toEqual(true);
 });
+
+test('should work with automock', () => {
+  jest.mock('foo');
+
+  const foo = require('foo');
+  foo();
+
+  expect(foo).toHaveBeenCalled();
+});
+
+test('should allow manual mocks to make require calls through the resolver', () => {
+  jest.mock('../manual-mock');
+
+  expect(require('../manual-mock')).toEqual('bar');
+});

--- a/integration-tests/custom-resolver/bar.js
+++ b/integration-tests/custom-resolver/bar.js
@@ -1,1 +1,1 @@
-module.exports = () => {};
+module.exports = 'bar';

--- a/integration-tests/custom-resolver/manual-mock.js
+++ b/integration-tests/custom-resolver/manual-mock.js
@@ -1,0 +1,1 @@
+throw new Error('Must be mocked');

--- a/packages/jest-resolve/src/__tests__/resolve.test.js
+++ b/packages/jest-resolve/src/__tests__/resolve.test.js
@@ -172,28 +172,6 @@ describe('getMockModule', () => {
       path.dirname(src),
     );
   });
-
-  it('is possible to use custom resolver to resolve deps inside mock modules without moduleNameMapper', () => {
-    userResolver.mockImplementation(() => 'module');
-
-    const moduleMap = new ModuleMap({
-      duplicates: [],
-      map: [],
-      mocks: [],
-    });
-    const resolver = new Resolver(moduleMap, {
-      resolver: require.resolve('../__mocks__/userResolver'),
-    });
-    const src = require.resolve('../');
-    resolver.getMockModule(src, 'dependentModule');
-
-    expect(userResolver).toHaveBeenCalled();
-    expect(userResolver.mock.calls[0][0]).toBe('dependentModule');
-    expect(userResolver.mock.calls[0][1]).toHaveProperty(
-      'basedir',
-      path.dirname(src),
-    );
-  });
 });
 
 describe('nodeModulesPaths', () => {

--- a/packages/jest-resolve/src/index.js
+++ b/packages/jest-resolve/src/index.js
@@ -374,22 +374,6 @@ Please check:
         }
       }
     }
-    if (resolver) {
-      // if moduleNameMapper didn't match anything, fallback to just the
-      // regular resolver
-      const module =
-        this.getModule(moduleName) ||
-        Resolver.findNodeModule(moduleName, {
-          basedir: dirname,
-          browser: this._options.browser,
-          extensions,
-          moduleDirectory,
-          paths,
-          resolver,
-          rootDir: this._options.rootDir,
-        });
-      return module;
-    }
     return null;
   }
 


### PR DESCRIPTION
## Summary

#4174 introduced a few lines of code that broke automocking when using custom resolvers (reported as #4985). This new diff reverts the part of the code responsible for the breakage.

I'm not entirely sure what was the purpose of the previous code - if I understand correctly it was ensuring that resolvers were correctly called when calling `require()` from within a mock, but I added an integration test and it seems to work fine even with the code removed.

Maybe @midzelis can shed some light on this?

## Test plan

I've added a test to make sure that automocking would continue working, removed a unit test that was testing the behavior of `getMockModule` (since it was testing the behavior causing the bug), and added a new test to make sure that `require()` calls work with manual mocking + custom resolvers.
