### PR TITLE
Ensure that watchman returned a SHA-1

### DIFF
--- a/packages/jest-haste-map/src/crawlers/watchman.js
+++ b/packages/jest-haste-map/src/crawlers/watchman.js
@@ -162,8 +162,14 @@ module.exports = async function watchmanCrawl(
         if (isOld) {
           files[name] = existingFileData;
         } else {
+          let sha1hex = fileData['content.sha1hex'];
+
+          if (typeof sha1hex !== 'string' || sha1hex.length !== 40) {
+            sha1hex = null;
+          }
+
           // See ../constants.js
-          files[name] = ['', mtime, 0, [], fileData['content.sha1hex'] || null];
+          files[name] = ['', mtime, 0, [], sha1hex];
         }
       }
     }


### PR DESCRIPTION
Just found that `content.sha1hex` can be an error object (the docum... _oh, wait_), which is not very good since we do not check the validity of the property getting returned.

This PR adds a defensive line verifying it is a string, and also asserts that the length is `40`, because a SHA-1 is formed by 20 bytes, and the encoding transmission is `hex`. The validity check is not perfect, but it's good enough IMO.

When returning `null`, it falls back to computing it on the worker, as the Node crawler does right now.