### PR TITLE
remove assert message from stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## master
 
+## 22.4.3
+
+### Fixes
+
+* `[jest-jasmine2]` Always remove node core message from assert stack traces
+  ([#6061](https://github.com/facebook/jest/pull/6061))
+
 ## 22.4.2
 
 ### Fixes

--- a/integration-tests/__tests__/__snapshots__/failures.test.js.snap
+++ b/integration-tests/__tests__/__snapshots__/failures.test.js.snap
@@ -146,7 +146,7 @@ exports[`works with node assert 1`] = `
 
     assert.equal(received, expected) or assert(received) 
     
-    Expected value to be (operator: ==):
+    Expected value to be equal to:
       true
     Received:
       false
@@ -164,7 +164,7 @@ exports[`works with node assert 1`] = `
 
     assert.equal(received, expected) or assert(received) 
     
-    Expected value to be (operator: ==):
+    Expected value to be equal to:
       true
     Received:
       false
@@ -185,7 +185,7 @@ exports[`works with node assert 1`] = `
 
     assert.equal(received, expected) or assert(received) 
     
-    Expected value to be (operator: ==):
+    Expected value to be equal to:
       true
     Received:
       false
@@ -203,7 +203,7 @@ exports[`works with node assert 1`] = `
 
     assert.equal(received, expected) or assert(received) 
     
-    Expected value to be (operator: ==):
+    Expected value to be equal to:
       true
     Received:
       false
@@ -224,7 +224,7 @@ exports[`works with node assert 1`] = `
 
     assert.equal(received, expected) or assert(received) 
     
-    Expected value to be (operator: ==):
+    Expected value to be equal to:
       2
     Received:
       1
@@ -242,7 +242,7 @@ exports[`works with node assert 1`] = `
 
     assert.notEqual(received, expected)
     
-    Expected value not to be (operator: !=):
+    Expected value to not be equal to:
       1
     Received:
       1
@@ -353,7 +353,7 @@ exports[`works with node assert 1`] = `
 
     assert.strictEqual(received, expected)
     
-    Expected value to be (operator: ===):
+    Expected value to strictly be equal to:
       NaN
     Received:
       1
@@ -371,7 +371,7 @@ exports[`works with node assert 1`] = `
 
     assert.notStrictEqual(received, expected)
     
-    Expected value not to be (operator: !==):
+    Expected value not be strictly equal to:
       1
     Received:
       1
@@ -443,9 +443,6 @@ exports[`works with node assert 1`] = `
       at __tests__/node_assertion_error.test.js:63:10
 
   ● assert.ifError
-
-    Error
-      1 thrown
 
   ● assert.doesNotThrow
 

--- a/integration-tests/__tests__/failures.test.js
+++ b/integration-tests/__tests__/failures.test.js
@@ -55,12 +55,13 @@ test('not throwing Error objects', () => {
 });
 
 test('works with node assert', () => {
+  const nodeMajorVersion = Number(process.versions.node.split('.')[0]);
   const {stderr} = runJest(dir, ['node_assertion_error.test.js']);
   let summary = normalizeDots(extractSummary(stderr).rest);
 
   // Node 9 started to include the error for `doesNotThrow`
   // https://github.com/nodejs/node/pull/12167
-  if (Number(process.versions.node.split('.')[0]) >= 9) {
+  if (nodeMajorVersion >= 9) {
     expect(summary).toContain(`
     assert.doesNotThrow(function)
     
@@ -70,9 +71,9 @@ test('works with node assert', () => {
     
     Message:
       Got unwanted exception.
-    err!
-    err!
+`);
 
+    expect(summary).toContain(`
       69 | 
       70 | test('assert.doesNotThrow', () => {
     > 71 |   assert.doesNotThrow(() => {
@@ -83,16 +84,65 @@ test('works with node assert', () => {
       at __tests__/node_assertion_error.test.js:71:10
 `);
 
-    summary = summary.replace(
-      `Message:
+    const commonErrorMessage = `Message:
+      Got unwanted exception.
+`;
+
+    if (nodeMajorVersion === 9) {
+      const specificErrorMessage = `Message:
       Got unwanted exception.
     err!
-    err!
-`,
-      `Message:
+`;
+
+      expect(summary).toContain(specificErrorMessage);
+      summary = summary.replace(specificErrorMessage, commonErrorMessage);
+    } else {
+      const specificErrorMessage = `Message:
       Got unwanted exception.
-`,
-    );
+    Actual message: "err!"
+`;
+
+      expect(summary).toContain(specificErrorMessage);
+      summary = summary.replace(specificErrorMessage, commonErrorMessage);
+    }
+  }
+
+  if (nodeMajorVersion >= 10) {
+    const ifErrorMessage = `
+    assert.ifError(received, expected)
+    
+    Expected value ifError to:
+      null
+    Received:
+      1
+    
+    Message:
+      ifError got unwanted exception: 1
+    
+    Difference:
+    
+      Comparing two different types of values. Expected null but received number.
+
+      65 | 
+      66 | test('assert.ifError', () => {
+    > 67 |   assert.ifError(1);
+      68 | });
+      69 | 
+      70 | test('assert.doesNotThrow', () => {
+      
+      at __tests__/node_assertion_error.test.js:67:10
+`;
+
+    expect(summary).toContain(ifErrorMessage);
+    summary = summary.replace(ifErrorMessage, '');
+  } else {
+    const ifErrorMessage = `
+    Error
+      1 thrown
+`;
+
+    expect(summary).toContain(ifErrorMessage);
+    summary = summary.replace(ifErrorMessage, '');
   }
 
   expect(summary).toMatchSnapshot();

--- a/packages/jest-jasmine2/src/assert_support.js
+++ b/packages/jest-jasmine2/src/assert_support.js
@@ -33,8 +33,12 @@ const assertOperatorsMap = {
 const humanReadableOperators = {
   deepEqual: 'to deeply equal',
   deepStrictEqual: 'to deeply and strictly equal',
+  equal: 'to be equal',
   notDeepEqual: 'not to deeply equal',
   notDeepStrictEqual: 'not to deeply and strictly equal',
+  notEqual: 'to not be equal',
+  notStrictEqual: 'not be strictly equal',
+  strictEqual: 'to strictly be equal',
 };
 
 const getOperatorName = (operator: ?string, stack: string) => {
@@ -50,12 +54,15 @@ const getOperatorName = (operator: ?string, stack: string) => {
   return '';
 };
 
-const operatorMessage = (operator: ?string, negator: boolean) =>
-  typeof operator === 'string'
-    ? operator.startsWith('!') || operator.startsWith('=')
-      ? `${negator ? 'not ' : ''}to be (operator: ${operator}):\n`
-      : `${humanReadableOperators[operator] || operator} to:\n`
+const operatorMessage = (operator: ?string) => {
+  const niceOperatorName = getOperatorName(operator, '');
+  // $FlowFixMe: we default to the operator itself, so holes in the map doesn't matter
+  const humanReadableOperator = humanReadableOperators[niceOperatorName];
+
+  return typeof operator === 'string'
+    ? `${humanReadableOperator || niceOperatorName} to:\n`
     : '';
+};
 
 const assertThrowingMatcherHint = (operatorName: string) => {
   return (
@@ -88,13 +95,13 @@ const assertMatcherHint = (operator: ?string, operatorName: string) => {
 };
 
 function assertionErrorMessage(error: AssertionError, options: DiffOptions) {
-  const {expected, actual, message, operator, stack} = error;
+  const {expected, actual, generatedMessage, message, operator, stack} = error;
   const diffString = diff(expected, actual, options);
-  const negator =
-    typeof operator === 'string' &&
-    (operator.startsWith('!') || operator.startsWith('not'));
-  const hasCustomMessage = !error.generatedMessage;
+  const hasCustomMessage = !generatedMessage;
   const operatorName = getOperatorName(operator, stack);
+  const trimmedStack = stack
+    .replace(message, '')
+    .replace(/AssertionError(.*)/g, '');
 
   if (operatorName === 'doesNotThrow') {
     return (
@@ -104,7 +111,7 @@ function assertionErrorMessage(error: AssertionError, options: DiffOptions) {
       chalk.reset(`Instead, it threw:\n`) +
       `  ${printReceived(actual)}` +
       chalk.reset(hasCustomMessage ? '\n\nMessage:\n  ' + message : '') +
-      stack.replace(/AssertionError(.*)/g, '')
+      trimmedStack
     );
   }
 
@@ -115,20 +122,20 @@ function assertionErrorMessage(error: AssertionError, options: DiffOptions) {
       chalk.reset(`Expected the function to throw an error.\n`) +
       chalk.reset(`But it didn't throw anything.`) +
       chalk.reset(hasCustomMessage ? '\n\nMessage:\n  ' + message : '') +
-      stack.replace(/AssertionError(.*)/g, '')
+      trimmedStack
     );
   }
 
   return (
     assertMatcherHint(operator, operatorName) +
     '\n\n' +
-    chalk.reset(`Expected value ${operatorMessage(operator, negator)}`) +
+    chalk.reset(`Expected value ${operatorMessage(operator)}`) +
     `  ${printExpected(expected)}\n` +
     chalk.reset(`Received:\n`) +
     `  ${printReceived(actual)}` +
     chalk.reset(hasCustomMessage ? '\n\nMessage:\n  ' + message : '') +
     (diffString ? `\n\nDifference:\n\n${diffString}` : '') +
-    stack.replace(/AssertionError(.*)/g, '')
+    trimmedStack
   );
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary
We've merged node 10 compat into master (#6055), but because we've landed breaking changes leading up to a v23, we cannot release it.

I think the changes to the message from the assert module (a diff view with swapped `+` and `-` from what Jest uses) are large enough that it will confuse users of Jest, so we should make a patch release of Jest 22 with just the removal of that diff.

In this PR, I've basically cherry picked #6055 on top of the 22.4.2 release commit. I've also setup a https://github.com/facebook/jest/tree/22.x branch which this can be merged to.

See this screenshot for example of the output this PR cleans up: ![image](https://user-images.githubusercontent.com/1404810/39114230-7f825e22-46de-11e8-8352-026fd1102634.png)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan
Green CI. `node@10.0.0-rc.2` also passes with this change.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
