### PR TITLE
Support forwardRef and Context in pretty-format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,8 @@
   ([#5720](https://github.com/facebook/jest/pull/5720))
 * `[pretty-format]` Handle React fragments better
   ([#5816](https://github.com/facebook/jest/pull/5816))
+* `[pretty-format]` Handle formatting of `React.forwardRef` and `Context`
+  components ([#6093](https://github.com/facebook/jest/pull/6093))
 * `[jest-cli]` Switch collectCoverageFrom back to a string
   ([#5914](https://github.com/facebook/jest/pull/5914))
 * `[jest-regex-util]` Fix handling regex symbols in tests path on Windows

--- a/packages/pretty-format/src/__tests__/react.test.js
+++ b/packages/pretty-format/src/__tests__/react.test.js
@@ -717,3 +717,37 @@ test('ReactTestComponent plugin highlights syntax with color from theme option',
     }),
   ).toMatchSnapshot();
 });
+
+test('supports forwardRef with a child', () => {
+  function Cat(props) {
+    return React.createElement('div', props, props.children);
+  }
+
+  expect(
+    formatElement(React.createElement(React.forwardRef(Cat), null, 'mouse')),
+  ).toEqual('<ForwardRef(Cat)>\n  mouse\n</ForwardRef(Cat)>');
+});
+
+test('supports context Provider with a child', () => {
+  const {Provider} = React.createContext('test');
+
+  expect(
+    formatElement(
+      React.createElement(Provider, {value: 'test-value'}, 'child'),
+    ),
+  ).toEqual(
+    '<Context.Provider\n  value="test-value"\n>\n  child\n</Context.Provider>',
+  );
+});
+
+test('supports context Consumer with a child', () => {
+  const {Consumer} = React.createContext('test');
+
+  expect(
+    formatElement(
+      React.createElement(Consumer, null, () =>
+        React.createElement('div', null, 'child'),
+      ),
+    ),
+  ).toEqual('<Context.Consumer>\n  [Function anonymous]\n</Context.Consumer>');
+});

--- a/packages/pretty-format/src/__tests__/react.test.js
+++ b/packages/pretty-format/src/__tests__/react.test.js
@@ -724,6 +724,7 @@ test('supports forwardRef with a child', () => {
   }
 
   expect(
+    // $FlowFixMe - https://github.com/facebook/flow/issues/6103
     formatElement(React.createElement(React.forwardRef(Cat), null, 'mouse')),
   ).toEqual('<ForwardRef(Cat)>\n  mouse\n</ForwardRef(Cat)>');
 });

--- a/packages/pretty-format/src/plugins/react_element.js
+++ b/packages/pretty-format/src/plugins/react_element.js
@@ -36,17 +36,16 @@ const getChildren = (arg, children = []) => {
 };
 
 const getType = element => {
-  if (typeof element.type === 'string') {
-    return element.type;
+  const type = element.type;
+  if (typeof type === 'string') {
+    return type;
   }
-  if (typeof element.type === 'function') {
-    return element.type.displayName || element.type.name || 'Unknown';
+  if (typeof type === 'function') {
+    return type.displayName || type.name || 'Unknown';
   }
-  if (element.type === fragmentSymbol) {
+  if (type === fragmentSymbol) {
     return 'React.Fragment';
   }
-
-  const type = element.type;
   if (typeof type === 'object' && type !== null) {
     if (type.$$typeof === providerSymbol) {
       return 'Context.Provider';

--- a/packages/pretty-format/src/plugins/react_element.js
+++ b/packages/pretty-format/src/plugins/react_element.js
@@ -19,6 +19,8 @@ import {
 const elementSymbol = Symbol.for('react.element');
 const fragmentSymbol = Symbol.for('react.fragment');
 const forwardRefSymbol = Symbol.for('react.forward_ref');
+const providerSymbol = Symbol.for('react.provider');
+const contextSymbol = Symbol.for('react.context');
 
 // Given element.props.children, or subtree during recursive traversal,
 // return flattened array of children.
@@ -43,13 +45,24 @@ const getType = element => {
   if (element.type === fragmentSymbol) {
     return 'React.Fragment';
   }
-  if (element.type === forwardRefSymbol) {
-    const functionName =
-      element.type.render.displayName || element.type.render.name || '';
 
-    return functionName !== ''
-      ? 'ForwardRef(' + functionName + ')'
-      : 'ForwardRef';
+  const type = element.type;
+  if (typeof type === 'object' && type !== null) {
+    if (type.$$typeof === providerSymbol) {
+      return 'Context.Provider';
+    }
+
+    if (type.$$typeof === contextSymbol) {
+      return 'Context.Consumer';
+    }
+
+    if (type.$$typeof === forwardRefSymbol) {
+      const functionName = type.render.displayName || type.render.name || '';
+
+      return functionName !== ''
+        ? 'ForwardRef(' + functionName + ')'
+        : 'ForwardRef';
+    }
   }
   return 'UNDEFINED';
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -7567,6 +7567,10 @@ react-dom@^15.5.4:
     object-assign "^4.1.0"
     prop-types "^15.5.10"
 
+react-is@^16.3.2:
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.3.2.tgz#f4d3d0e2f5fbb6ac46450641eb2e25bf05d36b22"
+
 react-native@^0.51.0:
   version "0.51.1"
   resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.51.1.tgz#be47ef396c07151722cf8246c942686d6df1170e"
@@ -7641,7 +7645,16 @@ react-reconciler@^0.7.0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
-react-test-renderer@*, react-test-renderer@^16.0.0-0:
+react-test-renderer@*:
+  version "16.3.2"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.3.2.tgz#3d1ed74fda8db42521fdf03328e933312214749a"
+  dependencies:
+    fbjs "^0.8.16"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
+    react-is "^16.3.2"
+
+react-test-renderer@^16.0.0-0:
   version "16.2.0"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.2.0.tgz#bddf259a6b8fcd8555f012afc8eacc238872a211"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -7567,10 +7567,6 @@ react-dom@^15.5.4:
     object-assign "^4.1.0"
     prop-types "^15.5.10"
 
-react-is@^16.3.2:
-  version "16.3.2"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.3.2.tgz#f4d3d0e2f5fbb6ac46450641eb2e25bf05d36b22"
-
 react-native@^0.51.0:
   version "0.51.1"
   resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.51.1.tgz#be47ef396c07151722cf8246c942686d6df1170e"
@@ -7645,16 +7641,7 @@ react-reconciler@^0.7.0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
-react-test-renderer@*:
-  version "16.3.2"
-  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.3.2.tgz#3d1ed74fda8db42521fdf03328e933312214749a"
-  dependencies:
-    fbjs "^0.8.16"
-    object-assign "^4.1.1"
-    prop-types "^15.6.0"
-    react-is "^16.3.2"
-
-react-test-renderer@^16.0.0-0:
+react-test-renderer@*, react-test-renderer@^16.0.0-0:
   version "16.2.0"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.2.0.tgz#bddf259a6b8fcd8555f012afc8eacc238872a211"
   dependencies:


### PR DESCRIPTION
## Summary

Supersedes https://github.com/facebook/jest/pull/6076 and adds support for formatting the new Context api. Naming for the `Context` components is up for grabs.

The PR also includes an upgrade of React since it's necessary to test. However once https://github.com/facebook/jest/pull/6090 is merged I can rebase this PR.  

## Test plan

Run tests and make sure they pass.
