### PR TITLE
Fix incorrect `console` global variable pr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,7 +83,7 @@
 * `[jest-worker]` Stick calls to workers before processing them
   ([#6073](https://github.com/facebook/jest/pull/6073))
 * `[babel-plugin-jest-hoist]` Allow using `console` global variable
-  ([#6074](https://github.com/facebook/jest/pull/6074))
+  ([#6075](https://github.com/facebook/jest/pull/6075))
 * `[jest-jasmine2]` Always remove node core message from assert stack traces
   ([#6055](https://github.com/facebook/jest/pull/6055))
 * `[expect]` Add stack trace when `expect.assertions` and `expect.hasAssertions`


### PR DESCRIPTION
## Summary

It referred to another PR instead of the one actually containing the changes. See [PR#6075](https://github.com/facebook/jest/pull/6075).

## Test plan

_none_