### PR TITLE
Fix forwardRef handling in snapshot tests

### DIFF
--- a/packages/pretty-format/src/plugins/react_element.js
+++ b/packages/pretty-format/src/plugins/react_element.js
@@ -43,7 +43,8 @@ const getType = element => {
   if (element.type === fragmentSymbol) {
     return 'React.Fragment';
   }
-  if (element.type === forwardRefSymbol) {
+  if (typeof element.type === 'object' && element.type !== null
+    && element.type.$$typeof === forwardRefSymbol) {
     const functionName =
       element.type.render.displayName || element.type.render.name || '';
 


### PR DESCRIPTION
## Summary

Previous PR #6069 didn't actually fix the issue, as it wasn't correctly comparing the forwardRefSymbol with `element.type.$$typeof`

## Test plan

Run `jest -u` on a known snapshot test that depends on a component that uses `forwardRef`, ensure that the component name of `ForwardRef(MyComponent)` is used.
