### PR TITLE
Add a 'best practices' section to the Snapshot Testing Guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,7 @@
   ([#5675](https://github.com/facebook/jest/pull/5675))
 * `[docs]` Add versioned docs for v22.4
   ([##5733](https://github.com/facebook/jest/pull/#5733))
+* `[docs]` Improve Snapshot Testing Guide ([#5812](https://github.com/facebook/jest/issues/5812))
 
 ## 22.4.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,7 +159,8 @@
   ([#5675](https://github.com/facebook/jest/pull/5675))
 * `[docs]` Add versioned docs for v22.4
   ([##5733](https://github.com/facebook/jest/pull/#5733))
-* `[docs]` Improve Snapshot Testing Guide ([#5812](https://github.com/facebook/jest/issues/5812))
+* `[docs]` Improve Snapshot Testing Guide
+  ([#5812](https://github.com/facebook/jest/issues/5812))
 
 ## 22.4.2
 

--- a/website/versioned_docs/version-22.3/SnapshotTesting.md
+++ b/website/versioned_docs/version-22.3/SnapshotTesting.md
@@ -138,18 +138,34 @@ From here you can choose to update that snapshot or skip to the next:
 
 ## Best Practices
 
-Snapshots are a fantastic tool for identifying unexpected interface changes within your application – whether that interface is a UI, logs, or error messages; however, they're not a cure-all, and, as with any testing strategy, there are some best-practices you should be aware of, and guidelines you should follow, in order to use them effectively.
+Snapshots are a fantastic tool for identifying unexpected interface changes
+within your application – whether that interface is a UI, logs, or error
+messages; however, they're not a cure-all, and, as with any testing strategy,
+there are some best-practices you should be aware of, and guidelines you should
+follow, in order to use them effectively.
 
 ### 1. Treat Snapshots As First-Class Citizens
 
-Commit snapshots and review them as part of your regular code review process. This implies treating snapshots as you would any other type of test, or code for that matter, in your project. 
+Commit snapshots and review them as part of your regular code review process.
+This implies treating snapshots as you would any other type of test, or code for
+that matter, in your project.
 
-Ensure that your snapshots are _very_ readable by keeping them focused, short, and using tools that enforce these stylistic conventions. 
+Ensure that your snapshots are _very_ readable by keeping them focused, short,
+and using tools that enforce these stylistic conventions.
 
 As mentioned previously, Jest uses
-[pretty-format](https://github.com/facebook/jest/tree/master/packages/pretty-format) to make snapshots human-readable, but you may find it useful to introduce additional tools, like [`eslint-plugin-jest`](https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/no-large-snapshots.md) with its `'no-large-snapshots'` option, and [`snapshot-diff`](https://github.com/jest-community/snapshot-diff) with its component snapshot comparison feature, to promote committing short, focused assertions.
+[pretty-format](https://github.com/facebook/jest/tree/master/packages/pretty-format)
+to make snapshots human-readable, but you may find it useful to introduce
+additional tools, like
+[`eslint-plugin-jest`](https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/no-large-snapshots.md)
+with its `'no-large-snapshots'` option, and
+[`snapshot-diff`](https://github.com/jest-community/snapshot-diff) with its
+component snapshot comparison feature, to promote committing short, focused
+assertions.
 
-The aim here is to avoid the dangerous habits of glossing over snapshots in pull requests, and simply regenerating snapshots when test suites fail instead of examining the root causes of their failure.
+The aim here is to avoid the dangerous habits of glossing over snapshots in pull
+requests, and simply regenerating snapshots when test suites fail instead of
+examining the root causes of their failure.
 
 ### 2. Tests Should Be Deterministic
 
@@ -177,7 +193,12 @@ generated for this component regardless of when the test is run.
 
 ### Are snapshots written automatically on Continuous Integration (CI) systems?
 
-No, as of Jest 20, snapshots in Jest are not automatically written when Jest is run in a CI system without explicitly passing `--updateSnapshot`. It is expected that all snapshots are part of the code that is run on CI and since new snapshots automatically pass, they should not pass a test run on a CI system. It is recommended to always commit all snapshots and to keep them in version control.
+No, as of Jest 20, snapshots in Jest are not automatically written when Jest is
+run in a CI system without explicitly passing `--updateSnapshot`. It is expected
+that all snapshots are part of the code that is run on CI and since new
+snapshots automatically pass, they should not pass a test run on a CI system. It
+is recommended to always commit all snapshots and to keep them in version
+control.
 
 ### Should snapshot files be committed?
 

--- a/website/versioned_docs/version-22.3/SnapshotTesting.md
+++ b/website/versioned_docs/version-22.3/SnapshotTesting.md
@@ -136,7 +136,22 @@ From here you can choose to update that snapshot or skip to the next:
 
 ![](/jest/img/content/interactiveSnapshotUpdate.gif)
 
-### Tests Should Be Deterministic
+## Best Practices
+
+Snapshots are a fantastic tool for identifying unexpected interface changes within your application – whether that interface is a UI, logs, or error messages; however, they're not a cure-all, and, as with any testing strategy, there are some best-practices you should be aware of, and guidelines you should follow, in order to use them effectively.
+
+### 1. Treat Snapshots As First-Class Citizens
+
+Commit snapshots and review them as part of your regular code review process. This implies treating snapshots as you would any other type of test, or code for that matter, in your project. 
+
+Ensure that your snapshots are _very_ readable by keeping them focused, short, and using tools that enforce these stylistic conventions. 
+
+As mentioned previously, Jest uses
+[pretty-format](https://github.com/facebook/jest/tree/master/packages/pretty-format) to make snapshots human-readable, but you may find it useful to introduce additional tools, like [`eslint-plugin-jest`](https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/no-large-snapshots.md) with its `'no-large-snapshots'` option, and [`snapshot-diff`](https://github.com/jest-community/snapshot-diff) with its component snapshot comparison feature, to promote committing short, focused assertions.
+
+The aim here is to avoid the dangerous habits of glossing over snapshots in pull requests, and simply regenerating snapshots when test suites fail instead of examining the root causes of their failure.
+
+### 2. Tests Should Be Deterministic
 
 Your tests should be deterministic. That is, running the same tests multiple
 times on a component that has not changed should produce the same results every
@@ -158,16 +173,11 @@ Now, every time the snapshot test case runs, `Date.now()` will return
 `1482363367071` consistently. This will result in the same snapshot being
 generated for this component regardless of when the test is run.
 
-### Snapshots are not written automatically on Continuous Integration systems (CI)
-
-As of Jest 20, snapshots in Jest are not automatically written when Jest is run
-in a CI system without explicitly passing `--updateSnapshot`. It is expected
-that all snapshots are part of the code that is run on CI and since new
-snapshots automatically pass, they should not pass a test run on a CI system. It
-is recommended to always commit all snapshots and to keep them in version
-control.
-
 ## Frequently Asked Questions
+
+### Are snapshots written automatically on Continuous Integration (CI) systems?
+
+No, as of Jest 20, snapshots in Jest are not automatically written when Jest is run in a CI system without explicitly passing `--updateSnapshot`. It is expected that all snapshots are part of the code that is run on CI and since new snapshots automatically pass, they should not pass a test run on a CI system. It is recommended to always commit all snapshots and to keep them in version control.
 
 ### Should snapshot files be committed?
 

--- a/website/versioned_docs/version-22.3/SnapshotTesting.md
+++ b/website/versioned_docs/version-22.3/SnapshotTesting.md
@@ -139,12 +139,12 @@ From here you can choose to update that snapshot or skip to the next:
 ## Best Practices
 
 Snapshots are a fantastic tool for identifying unexpected interface changes
-within your application – whether that interface is a UI, logs, or error
-messages; however, they're not a cure-all, and, as with any testing strategy,
-there are some best-practices you should be aware of, and guidelines you should
-follow, in order to use them effectively.
+within your application – whether that interface is an API response, UI, logs,
+or error messages. As with any testing strategy, there are some best-practices
+you should be aware of, and guidelines you should follow, in order to use them
+effectively.
 
-### 1. Treat Snapshots As First-Class Citizens
+### 1. Treat snapshots as first-Class citizens
 
 Commit snapshots and review them as part of your regular code review process.
 This implies treating snapshots as you would any other type of test, or code for
@@ -154,20 +154,21 @@ Ensure that your snapshots are _very_ readable by keeping them focused, short,
 and using tools that enforce these stylistic conventions.
 
 As mentioned previously, Jest uses
-[pretty-format](https://github.com/facebook/jest/tree/master/packages/pretty-format)
-to make snapshots human-readable, but you may find it useful to introduce
-additional tools, like
-[`eslint-plugin-jest`](https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/no-large-snapshots.md)
-with its `'no-large-snapshots'` option, and
-[`snapshot-diff`](https://github.com/jest-community/snapshot-diff) with its
-component snapshot comparison feature, to promote committing short, focused
+[`pretty-format`](https://yarnpkg.com/en/package/pretty-format) to make
+snapshots human-readable, but you may find it useful to introduce additional
+tools, like
+[`eslint-plugin-jest`](https://yarnpkg.com/en/package/eslint-plugin-jest) with
+its
+[`no-large-snapshots`](https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/no-large-snapshots.md)
+option, or [`snapshot-diff`](https://yarnpkg.com/en/package/snapshot-diff) with
+its component snapshot comparison feature, to promote committing short, focused
 assertions.
 
 The aim here is to avoid the dangerous habits of glossing over snapshots in pull
 requests, and simply regenerating snapshots when test suites fail instead of
 examining the root causes of their failure.
 
-### 2. Tests Should Be Deterministic
+### 2. Tests should be deterministic
 
 Your tests should be deterministic. That is, running the same tests multiple
 times on a component that has not changed should produce the same results every
@@ -188,6 +189,50 @@ Date.now = jest.fn(() => 1482363367071);
 Now, every time the snapshot test case runs, `Date.now()` will return
 `1482363367071` consistently. This will result in the same snapshot being
 generated for this component regardless of when the test is run.
+
+### 3. Use descriptive snapshot names
+
+Always strive to use descriptive test and/or snapshot names for snapshots. The
+best names describe the expected snapshot content. This makes it easier for
+reviewers to verify the snapshots during review, and for anyone to know whether
+or not an outdated snapshot is the correct behavior before updating.
+
+For example, compare:
+
+```js
+exports[`<UserName /> should handle some test case`] = `null`;
+
+exports[`<UserName /> should handle some other test case`] = `
+<div>
+  Alan Turing
+</div>
+`;
+```
+
+To:
+
+```js
+exports[`<UserName /> should render null`] = `null`;
+
+exports[`<UserName /> should render Alan Turing`] = `
+<div>
+  Alan Turing
+</div>
+`;
+```
+
+Since the later describes exactly what's expected in the output, it's easy to
+see when it's wrong:
+
+```js
+exports[`<UserName /> should render null`] = `
+<div>
+  Alan Turing
+</div>
+`;
+
+exports[`<UserName /> should render Alan Turing`] = `null`;
+```
 
 ## Frequently Asked Questions
 

--- a/website/versioned_docs/version-22.3/SnapshotTesting.md
+++ b/website/versioned_docs/version-22.3/SnapshotTesting.md
@@ -144,14 +144,14 @@ or error messages. As with any testing strategy, there are some best-practices
 you should be aware of, and guidelines you should follow, in order to use them
 effectively.
 
-### 1. Treat snapshots as first-Class citizens
+### 1. Treat snapshots as code
 
 Commit snapshots and review them as part of your regular code review process.
-This implies treating snapshots as you would any other type of test, or code for
-that matter, in your project.
+This means treating snapshots as you would any other type of test or code in
+your project.
 
-Ensure that your snapshots are _very_ readable by keeping them focused, short,
-and using tools that enforce these stylistic conventions.
+Ensure that your snapshots are readable by keeping them focused, short, and by
+using tools that enforce these stylistic conventions.
 
 As mentioned previously, Jest uses
 [`pretty-format`](https://yarnpkg.com/en/package/pretty-format) to make
@@ -164,15 +164,15 @@ option, or [`snapshot-diff`](https://yarnpkg.com/en/package/snapshot-diff) with
 its component snapshot comparison feature, to promote committing short, focused
 assertions.
 
-The aim here is to avoid the dangerous habits of glossing over snapshots in pull
-requests, and simply regenerating snapshots when test suites fail instead of
-examining the root causes of their failure.
+The goal is to make it easy to review snapshots in pull requests, and fight
+against the habit of simply regenerating snapshots when test suites fail instead
+of examining the root causes of their failure.
 
 ### 2. Tests should be deterministic
 
-Your tests should be deterministic. That is, running the same tests multiple
-times on a component that has not changed should produce the same results every
-time. You're responsible for making sure your generated snapshots do not include
+Your tests should be deterministic. Running the same tests multiple times on a
+component that has not changed should produce the same results every time.
+You're responsible for making sure your generated snapshots do not include
 platform specific or other non-deterministic data.
 
 For example, if you have a


### PR DESCRIPTION
Fixes #5812

cc: @thymikee @SimenB 

## Summary
As explained in the issue referenced above (opened by @thymikee), Jest's [Snapshot Testing Guide](https://facebook.github.io/jest/docs/en/snapshot-testing.html) could benefit from some clearer usage guidelines. 

The issue's wording specifically called out adding content that would help devs avoid common mistakes and misuses of snapshot testing. After giving the page a good read it seemed like the guide already had the nucleus of this content with the "Tests Should Be Deterministic" section.

Added some content that closely follows the recommendations outlined in the @kentcdodds's article [Effective Snapshot Testing](https://blog.kentcdodds.com/effective-snapshot-testing-e0d1a2c28eca) referenced in the issue, then grouped this and the existing "Tests Should Be Deterministic" section under a "Best Practices" heading.

Moved the note about snapshots not being automatically written on CI into the FAQ section, since it seemed more like an FYI than part of the guide's core content.

This is just a first-pass, so feedback is warmly welcomed! 😄 

## Test plan
N/A (this is an isolated docs change)
