### PR TITLE
Revert changes on the TreeProcessor (#6006 and #5885)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,9 +144,6 @@
 
 * `[babel-jest]` [**BREAKING**] Always return object from transformer
   ([#5991](https://github.com/facebook/jest/pull/5991))
-* `[jest-jasmine2]` Simplify `Env.execute` and TreeProcessor to setup and clean
-  resources for the top suite the same way as for all of the children suites
-  ([#5885](https://github.com/facebook/jest/pull/5885))
 * `[*]` Run Prettier on compiled output
   ([#5858](https://github.com/facebook/jest/pull/3497))
 * `[jest-cli]` Add fileChange hook for plugins

--- a/integration-tests/__tests__/__snapshots__/failures.test.js.snap
+++ b/integration-tests/__tests__/__snapshots__/failures.test.js.snap
@@ -247,7 +247,7 @@ exports[`not throwing Error objects 5`] = `
       37 | });
       38 | 
       
-      at packages/jest-jasmine2/build/jasmine/Env.js:542:34
+      at packages/jest-jasmine2/build/jasmine/Env.js:518:34
       at __tests__/during_tests.test.js:36:3
 
 "


### PR DESCRIPTION
The TreeProcessor refactor introduced a change on the behavior of `beforeEach` inside `it`. While this is an edge case, Facebook (and potentially anyone using inline requires) is relying in it.

Some fixes have been suggested, but for the moment we'll just revert the change. cc / @niieani 