### PR TITLE
Revert changes for source map suppport (#5945)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,8 +93,6 @@
   ([#5888](https://github.com/facebook/jest/pull/5888))
 * `[jest-mock]` [**BREAKING**] Replace timestamps with `invocationCallOrder`
   ([#5867](https://github.com/facebook/jest/pull/5867))
-* `[jest-jasmine2]` Install `sourcemap-support` into normal runtime to catch
-  runtime errors ([#5945](https://github.com/facebook/jest/pull/5945))
 * `[jest-jasmine2]` Added assertion error handling inside `afterAll hook`
   ([#5884](https://github.com/facebook/jest/pull/5884))
 * `[jest-cli]` Remove the notifier actions in case of failure when not in watch

--- a/integration-tests/__tests__/__snapshots__/globals.test.js.snap
+++ b/integration-tests/__tests__/__snapshots__/globals.test.js.snap
@@ -29,7 +29,7 @@ exports[`cannot test with no implementation 1`] = `
       1 | 
       2 |     it('it', () => {});
     > 3 |     it('it, no implementation');
-        |     ^
+        | ^
       4 |     test('test, no implementation');
       5 |   
       
@@ -57,7 +57,7 @@ exports[`cannot test with no implementation with expand arg 1`] = `
       1 | 
       2 |     it('it', () => {});
     > 3 |     it('it, no implementation');
-        |     ^
+        | ^
       4 |     test('test, no implementation');
       5 |   
       

--- a/integration-tests/__tests__/stack_trace.test.js
+++ b/integration-tests/__tests__/stack_trace.test.js
@@ -22,7 +22,6 @@ describe('Stack Trace', () => {
     expect(stderr).toMatch(
       /ReferenceError: thisIsARuntimeError is not defined/,
     );
-    expect(stderr).toMatch(/> 10 \| thisIsARuntimeError\(\);/);
     expect(stderr).toMatch(
       /\s+at\s(?:.+?)\s\(__tests__\/runtime_error.test\.js/,
     );


### PR DESCRIPTION
In #5945 we accidentally introduced a memory leak that makes all tests leak. This was detected with the help of @SimenB, by running the `--detectLeaks` flag against the own suite.

It turns out that the fix needs to be done in `source-map-support`, for which [a PR has been put up](https://github.com/evanw/node-source-map-support/pull/215). In the meantime, we will revert the commit.