### PR TITLE
chore: don't strip trailing whitespace in snapshot files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,5 +7,5 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[*.md]
+[{*.md,*.snap}]
 trim_trailing_whitespace = false


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary
Trailing whitespace is significant in snapshot files, so they should not be trimmed when edited manually.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan
N/A

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
