### PR TITLE
jest-message-util: don't exclude trace lines with `vendor` anymore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Features
 
+* `[jest-message-util]` Don't ignore messages with `vendor` anymore
+  ([#XXXX](https://github.com/facebook/jest/pull/XXXX))
 * `[jest-validate]` Get rid of `jest-config` dependency
   ([#6067](https://github.com/facebook/jest/pull/6067))
 * `[jest-validate]` Adds option to inject `deprecationEntries`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Features
 
 * `[jest-message-util]` Don't ignore messages with `vendor` anymore
-  ([#XXXX](https://github.com/facebook/jest/pull/XXXX))
+  ([#6117](https://github.com/facebook/jest/pull/6117))
 * `[jest-validate]` Get rid of `jest-config` dependency
   ([#6067](https://github.com/facebook/jest/pull/6067))
 * `[jest-validate]` Adds option to inject `deprecationEntries`

--- a/packages/jest-message-util/src/__tests__/__snapshots__/messages.test.js.snap
+++ b/packages/jest-message-util/src/__tests__/__snapshots__/messages.test.js.snap
@@ -33,3 +33,21 @@ exports[`should exclude jasmine from stack trace for Unix paths. 1`] = `
 <dim>      <dim>at Object.it (<dim>build/__tests__/messages-test.js<dim>:45:41)<dim></>
 "
 `;
+
+exports[`should not exclude vendor from stack trace 1`] = `
+"<bold><red>  <bold>● <bold>Vendor test</></>
+
+      
+        Expected value to be of type:
+          \\"number\\"
+        Received:
+          \\"\\"
+        type:
+          \\"string\\"
+<dim>      </>
+<dim>      </>
+<dim>      <dim>at Object.it (<dim>__tests__/vendor/cool_test.js<dim>:6:666)<dim></>
+<dim>      <dim>at Object.asyncFn (<dim>__tests__/vendor/sulu/node_modules/sulu-content-bundle/best_component.js<dim>:1:5)<dim></>
+<dim>      </>
+"
+`;

--- a/packages/jest-message-util/src/__tests__/messages.test.js
+++ b/packages/jest-message-util/src/__tests__/messages.test.js
@@ -44,6 +44,20 @@ const assertionStack =
       at internal/process/next_tick.js:188:7
 `;
 
+const vendorStack =
+  '  ' +
+  `
+    Expected value to be of type:
+      "number"
+    Received:
+      ""
+    type:
+      "string"
+
+      at Object.it (__tests__/vendor/cool_test.js:6:666)
+      at Object.asyncFn (__tests__/vendor/sulu/node_modules/sulu-content-bundle/best_component.js:1:5)
+`;
+
 it('should exclude jasmine from stack trace for Unix paths.', () => {
   const messages = formatResultsErrors(
     [
@@ -91,6 +105,26 @@ it('formatStackTrace should strip node internals', () => {
         ancestorTitles: [],
         failureMessages: [assertionStack],
         title: 'Unix test',
+      },
+    ],
+    {
+      rootDir: '',
+    },
+    {
+      noStackTrace: false,
+    },
+  );
+
+  expect(messages).toMatchSnapshot();
+});
+
+it('should not exclude vendor from stack trace', () => {
+  const messages = formatResultsErrors(
+    [
+      {
+        ancestorTitles: [],
+        failureMessages: [vendorStack],
+        title: 'Vendor test',
       },
     ],
     {

--- a/packages/jest-message-util/src/index.js
+++ b/packages/jest-message-util/src/index.js
@@ -48,7 +48,7 @@ const PATH_NODE_MODULES = `${path.sep}node_modules${path.sep}`;
 const PATH_JEST_PACKAGES = `${path.sep}jest${path.sep}packages${path.sep}`;
 
 // filter for noisy stack trace lines
-const JASMINE_IGNORE = /^\s+at(?:(?:.*?vendor\/|jasmine\-)|\s+jasmine\.buildExpectationResult)/;
+const JASMINE_IGNORE = /^\s+at(?:(?:.jasmine\-)|\s+jasmine\.buildExpectationResult)/;
 const JEST_INTERNALS_IGNORE = /^\s+at.*?jest(-.*?)?(\/|\\)(build|node_modules|packages)(\/|\\)/;
 const ANONYMOUS_FN_IGNORE = /^\s+at <anonymous>.*$/;
 const ANONYMOUS_PROMISE_IGNORE = /^\s+at (new )?Promise \(<anonymous>\).*$/;


### PR DESCRIPTION
Fix #6114 
