### PR TITLE
Fix paths for Windows

### DIFF
--- a/integration-tests/__tests__/before-each-queue.js
+++ b/integration-tests/__tests__/before-each-queue.js
@@ -13,6 +13,6 @@ const runJest = require('../runJest');
 describe('Correct beforeEach order', () => {
   it('ensures the correct order for beforeEach', () => {
     const result = runJest('before-each-queue');
-    expect(result.stdout).toMatchSnapshot();
+    expect(result.stdout.replace(/\\/g, '/')).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
Windows uses backslashes (`\\`) so standardize before snapshotting.