### PR TITLE
Allows projects to specify individual root dirs

### DIFF
--- a/integration-tests/multi-project-config-root/bar/__tests__/boggus-bar.test.js
+++ b/integration-tests/multi-project-config-root/bar/__tests__/boggus-bar.test.js
@@ -1,0 +1,5 @@
+describe('Bar', () => {
+  it('fail', () => {
+    throw new Error('Expected failure');
+  });
+});

--- a/integration-tests/multi-project-config-root/foo/__tests__/boggus-foo.test.js
+++ b/integration-tests/multi-project-config-root/foo/__tests__/boggus-foo.test.js
@@ -1,0 +1,5 @@
+describe('Foo', () => {
+  it('fail', () => {
+    throw new Error('Expected failure');
+  });
+});

--- a/integration-tests/multi-project-config-root/package.json
+++ b/integration-tests/multi-project-config-root/package.json
@@ -1,0 +1,18 @@
+{
+  "jest": {
+    "projects": [
+        {
+            "rootDir": "<rootDir>/foo",
+            "testPathIgnorePatterns": [
+                "<rootDir>/__tests__/boggus-foo.test.js"
+            ]
+        },
+        {
+            "rootDir": "<rootDir>/bar",
+            "testPathIgnorePatterns": [
+                "<rootDir>/__tests__/boggus-bar.test.js"
+            ]
+        }
+    ]
+  }
+}

--- a/packages/jest-config/src/index.js
+++ b/packages/jest-config/src/index.js
@@ -16,7 +16,7 @@ import type {
 } from 'types/Config';
 
 import path from 'path';
-import {isJSONString} from './utils';
+import {isJSONString, replaceRootDirInPath} from './utils';
 import normalize from './normalize';
 import resolveConfigPath from './resolve_config_path';
 import readConfigFileAndSetRootDir from './read_config_file_and_set_root_dir';
@@ -47,8 +47,11 @@ export function readConfig(
 
   if (typeof packageRootOrConfig !== 'string') {
     if (parentConfigPath) {
+      const parentConfigDirname = path.dirname(parentConfigPath);
       rawOptions = packageRootOrConfig;
-      rawOptions.rootDir = path.dirname(parentConfigPath);
+      rawOptions.rootDir = rawOptions.rootDir
+        ? replaceRootDirInPath(parentConfigDirname, rawOptions.rootDir)
+        : parentConfigDirname;
     } else {
       throw new Error(
         'Jest: Cannot use configuration as an object without a file path.',

--- a/packages/jest-config/src/normalize.js
+++ b/packages/jest-config/src/normalize.js
@@ -469,7 +469,12 @@ export default function normalize(options: InitialOptions, argv: Argv) {
         break;
       case 'projects':
         value = (options[key] || [])
-          .map(project => _replaceRootDirTags(options.rootDir, project))
+          .map(
+            project =>
+              typeof project === 'string'
+                ? _replaceRootDirTags(options.rootDir, project)
+                : project,
+          )
           .reduce((projects, project) => {
             // Project can be specified as globs. If a glob matches any files,
             // We expand it to these paths. If not, we keep the original path


### PR DESCRIPTION
## Summary

This diff fixes #5479 by allowing project configurations to specify a custom rootDir that only applies to them.

## Test plan

I added an integration test.