### PR TITLE
Change "suggest to equal" message to be more advisory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Features
 
+* `[jest-matcher-utils] Change "suggest to equal" message to be more advisory`
+  ([#6103](https://github.com/facebook/jest/issues/6103))
 * `[jest-message-util]` Don't ignore messages with `vendor` anymore
   ([#6117](https://github.com/facebook/jest/pull/6117))
 * `[jest-validate]` Get rid of `jest-config` dependency

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Features
 
-* `[jest-matcher-utils] Change "suggest to equal" message to be more advisory`
+* `[jest-matcher-utils]` Change "suggest to equal" message to be more advisory
   ([#6103](https://github.com/facebook/jest/issues/6103))
 * `[jest-message-util]` Don't ignore messages with `vendor` anymore
   ([#6117](https://github.com/facebook/jest/pull/6117))

--- a/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -290,7 +290,7 @@ Received: <red>[]</>
 
 Difference:
 
-<dim>Compared values have no visual difference.</> <dim>Looks like you wanted to test for object/array equality with the stricter \`toBe\` matcher. You probably need to use \`toEqual\` instead.</>"
+<dim>Compared values have no visual difference.</> <dim>Note that you are testing for equality with the stricter \`toBe\` matcher using \`Object.is\`. For deep equality only, use \`toEqual\` instead.</>"
 `;
 
 exports[`.toBe() fails for: {"a": 1} and {"a": 1} 1`] = `
@@ -301,7 +301,7 @@ Received: <red>{\\"a\\": 1}</>
 
 Difference:
 
-<dim>Compared values have no visual difference.</> <dim>Looks like you wanted to test for object/array equality with the stricter \`toBe\` matcher. You probably need to use \`toEqual\` instead.</>"
+<dim>Compared values have no visual difference.</> <dim>Note that you are testing for equality with the stricter \`toBe\` matcher using \`Object.is\`. For deep equality only, use \`toEqual\` instead.</>"
 `;
 
 exports[`.toBe() fails for: {"a": 1} and {"a": 5} 1`] = `
@@ -329,7 +329,7 @@ Received: <red>{}</>
 
 Difference:
 
-<dim>Compared values have no visual difference.</> <dim>Looks like you wanted to test for object/array equality with the stricter \`toBe\` matcher. You probably need to use \`toEqual\` instead.</>"
+<dim>Compared values have no visual difference.</> <dim>Note that you are testing for equality with the stricter \`toBe\` matcher using \`Object.is\`. For deep equality only, use \`toEqual\` instead.</>"
 `;
 
 exports[`.toBe() fails for: -0 and 0 1`] = `

--- a/packages/jest-matcher-utils/src/index.js
+++ b/packages/jest-matcher-utils/src/index.js
@@ -49,7 +49,7 @@ const NUMBERS = [
 ];
 
 export const SUGGEST_TO_EQUAL = chalk.dim(
-  'Looks like you wanted to test for object/array equality with the stricter `toBe` matcher. You probably need to use `toEqual` instead.',
+  'Note that you are testing for equality with the stricter `toBe` matcher using `Object.is`. For deep equality only, use `toEqual` instead.',
 );
 
 export const SUGGEST_TO_CONTAIN_EQUAL = chalk.dim(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
change with regards to #6103 

## Test plan

```
•100% ➜ node -v && yarn -v
v8.9.3
1.6.0

•100% ➜ yarn test
yarn run v1.6.0
$ yarn typecheck && yarn lint && yarn jest
$ flow check --include-warnings
Found 0 errors
$ eslint . --cache --ext js,md
$ node ./packages/jest-cli/bin/jest.js
 PASS  integration-tests/__tests__/babel_plugin_jest_hoist.test.js (5.885s)
 PASS  integration-tests/__tests__/test_path_pattern_reporter_message.test.js (9.984s)
 PASS  integration-tests/__tests__/jasmine_async.test.js (15.625s)
 PASS  integration-tests/__tests__/snapshot.test.js (23.556s)
 PASS  integration-tests/__tests__/jest_changed_files.test.js (13.844s)
 PASS  integration-tests/__tests__/transform.test.js (26.693s)
 PASS  integration-tests/__tests__/multi_project_runner.test.js (28.2s)
 PASS  integration-tests/__tests__/coverage_transform_instrumented.test.js
 PASS  integration-tests/__tests__/failures.test.js (10.859s)
 PASS  integration-tests/__tests__/jest.config.js.test.js (6.4s)
 PASS  integration-tests/__tests__/console.test.js (6.124s)
 PASS  integration-tests/__tests__/force_exit.test.js
 PASS  integration-tests/__tests__/globals.test.js (11.944s)
 PASS  integration-tests/__tests__/coverage_threshold.test.js
 PASS  integration-tests/__tests__/config.test.js (5.837s)
 PASS  integration-tests/__tests__/run_tests_by_path.test.js
 PASS  integration-tests/__tests__/timeouts.test.js (6.228s)
 PASS  integration-tests/__tests__/coverage_report.test.js (41.455s)
 PASS  integration-tests/__tests__/only_changed.test.js (41.692s)
 PASS  integration-tests/__tests__/native_async_mock.test.js
 PASS  integration-tests/__tests__/test_in_root.test.js
 PASS  integration-tests/__tests__/verbose.test.js
 PASS  integration-tests/__tests__/coverage_remapping.test.js
 PASS  integration-tests/__tests__/filter.test.js (6.629s)
 PASS  integration-tests/__tests__/custom_reporters.test.js (16.99s)
 PASS  integration-tests/__tests__/module_name_mapper.test.js (6.163s)
 PASS  integration-tests/__tests__/jest_require_mock.test.js (6.368s)

 RUNS  packages/jest-runtime/src/__tests__/runtime_cli.test.js
 RUNS  integration-tests/__tests__/stack_trace.test.js
 RUNS  integration-tests/__tests__/find_related_files.test.js
 RUNS  packages/jest-cli/src/__tests__/test_scheduler.test.js
 RUNS  integration-tests/__tests__/to_match_snapshot.test.js
 RUNS  integration-tests/__tests__/mock_names.test.js
 RUNS  packages/jest-runtime/src/__tests__/runtime_require_module_or_mock_transitive_deps.test.js

Test Suites: 27 passed, 27 of 257 total
 PASS  packages/jest-cli/src/__tests__/test_scheduler.test.js
 PASS  packages/jest-runtime/src/__tests__/runtime_require_module_or_mock_transitive_deps.test.js
 PASS  packages/jest-runtime/src/__tests__/runtime_cli.test.js (8.534s)
 PASS  integration-tests/__tests__/stack_trace.test.js (7.384s)
 PASS  integration-tests/__tests__/find_related_files.test.js (5.645s)
 PASS  integration-tests/__tests__/mock_names.test.js (8.426s)
 PASS  integration-tests/__tests__/to_match_snapshot.test.js (14.08s)
 PASS  integration-tests/__tests__/to_throw_error_matching_snapshot.test.js (5.015s)
 PASS  integration-tests/__tests__/env.test.js
 PASS  integration-tests/__tests__/auto_restore_mocks.test.js
 PASS  integration-tests/__tests__/expect-async-matcher.test.js
 PASS  integration-tests/__tests__/setup_test_framework_script_file_cli_config.test.js
 PASS  integration-tests/__tests__/before-each-queue.js
 PASS  integration-tests/__tests__/compare_dom_nodes.test.js
 PASS  integration-tests/__tests__/module_parent_null_in_test.js
 PASS  integration-tests/__tests__/global_teardown.test.js
 PASS  integration-tests/__tests__/stack_trace_source_maps.test.js
 PASS  integration-tests/__tests__/jest_require_actual.test.js
 PASS  integration-tests/__tests__/no_tests_found.test.js
 PASS  integration-tests/__tests__/location_in_results.test.js
 PASS  packages/jest-runtime/src/__tests__/runtime_node_path.test.js
 PASS  integration-tests/__tests__/typescript_coverage.test.js
 PASS  integration-tests/__tests__/require_after_teardown.test.js
 PASS  integration-tests/__tests__/snapshot_serializers.test.js
 PASS  packages/jest-circus/src/__tests__/hooks.test.js
 PASS  integration-tests/__tests__/test_environment_async.test.js
 PASS  integration-tests/__tests__/json_reporter.test.js
 PASS  packages/jest-runtime/src/__tests__/script_transformer.test.js (6.675s)
 PASS  integration-tests/__tests__/timer_reset_mocks.test.js
 PASS  packages/jest-runtime/src/__tests__/runtime_require_mock.test.js
 PASS  integration-tests/__tests__/test_failure_exit_code.test.js
 PASS  integration-tests/__tests__/deprecated_cli_options.test.js
 PASS  integration-tests/__tests__/execute-tests-once-in-mpr.js
 PASS  integration-tests/__tests__/custom-resolver.test.js
 PASS  integration-tests/__tests__/test_environment.test.js
 PASS  integration-tests/__tests__/nested_event_loop.test.js
 PASS  integration-tests/__tests__/use_stderr.test.js
 PASS  integration-tests/__tests__/auto_clear_mocks.test.js
 PASS  packages/jest-runtime/src/__tests__/runtime_require_module.test.js
 PASS  examples/manual-mocks/__tests__/user.test.js
 PASS  packages/jest-repl/src/__tests__/jest_repl.test.js
 PASS  packages/jest-cli/src/__tests__/search_source.test.js
 PASS  integration-tests/__tests__/custom_matcher_stack_trace.test.js
 PASS  integration-tests/__tests__/cli-handles-exact-filenames.test.js
 PASS  integration-tests/__tests__/global_setup.test.js
 PASS  packages/jest-runtime/src/__tests__/runtime_module_directories.test.js
 PASS  packages/jest-environment-jsdom/src/__tests__/jsdom_environment.test.js
 PASS  integration-tests/__tests__/set_immediate.test.js
 PASS  packages/jest-runtime/src/__tests__/resolve_browser.test.js
 PASS  integration-tests/__tests__/resolve.test.js
 PASS  integration-tests/__tests__/resolve-node-module.test.js
 PASS  integration-tests/__tests__/empty_suite_error.test.js
 PASS  integration-tests/__tests__/console_log_output_when_run_in_band.test.js
 PASS  integration-tests/__tests__/test_name_pattern.test.js
 PASS  integration-tests/__tests__/runtime_internal_module_registry.test.js
 PASS  integration-tests/__tests__/regex_(char_in_path.test.js
 PASS  integration-tests/__tests__/log_heap_usage.test.js
 PASS  integration-tests/__tests__/auto_reset_mocks.test.js
 PASS  integration-tests/__tests__/list_tests.test.js
 PASS  integration-tests/__tests__/stack_trace_no_captureStackTrace.test.js
 PASS  integration-tests/__tests__/transform-linked-modules.test.js
 PASS  integration-tests/__tests__/clear_cache.test.js
 PASS  integration-tests/__tests__/test_results_processor.test.js
 PASS  integration-tests/__tests__/timer_use_real_timers.test.js
 PASS  integration-tests/__tests__/bad_source_map.test.js
 PASS  integration-tests/__tests__/generator_mock.test.js
 PASS  integration-tests/__tests__/lifecycles.js
 PASS  integration-tests/__tests__/override-globals.test.js
 PASS  integration-tests/__tests__/node_path.test.js
 PASS  packages/jest-runtime/src/__tests__/runtime_internal_module.test.js
 PASS  integration-tests/__tests__/expect_in_vm.test.js
 PASS  integration-tests/__tests__/debug.test.js
 PASS  integration-tests/__tests__/require_main.test.js
 PASS  packages/jest-haste-map/src/__tests__/index.test.js
 PASS  packages/jest-cli/src/__tests__/run_jest.test.js
 PASS  packages/jest-runtime/src/__tests__/runtime_jest_fn.js
 PASS  packages/jest-cli/src/reporters/__tests__/coverage_reporter.test.js
 PASS  examples/typescript/__tests__/checkbox_with_label.test.tsx
 PASS  examples/typescript/__tests__/sub-test.ts
 PASS  packages/jest-runtime/src/__tests__/runtime_environment.test.js
 PASS  examples/react-native/__tests__/intro.test.js
 PASS  examples/typescript/__tests__/sum-test.ts
 PASS  packages/expect/src/__tests__/matchers.test.js
 PASS  examples/manual-mocks/__tests__/lodashMocking.test.js
 PASS  packages/jest-runtime/src/__tests__/runtime_require_module_or_mock.test.js
 PASS  packages/jest-editor-support/src/__tests__/snapshot.test.js
 PASS  packages/babel-jest/src/__tests__/index.js
 PASS  packages/jest-runtime/src/__tests__/runtime_mock.test.js
 PASS  integration-tests/__tests__/show_config.test.js
 PASS  packages/jest-test-typescript-parser/src/__tests__/type_script_parser.test.js
 PASS  packages/jest-util/src/__tests__/fake_timers.test.js
 PASS  packages/jest-runtime/src/__tests__/instrumentation.test.js
 PASS  packages/jest-leak-detector/src/__tests__/index.test.js
 PASS  packages/jest-runtime/src/__tests__/Runtime-sourceMaps.test.js
 PASS  packages/jest-runtime/src/__tests__/runtime_jest_spy_on.test.js
 PASS  examples/react/__tests__/checkbox_with_label.test.js
 PASS  packages/jest-runtime/src/__tests__/runtime_gen_mock_from_module.test.js
 PASS  packages/jest-config/src/__tests__/normalize.test.js
 PASS  examples/async/__tests__/user.test.js
 PASS  examples/jquery/__tests__/display_user.test.js
 PASS  integration-tests/__tests__/version.test.js
 PASS  packages/jest-matcher-utils/src/__tests__/index.test.js
 PASS  packages/jest-resolve-dependencies/src/__tests__/dependency_resolver.test.js
 PASS  examples/automatic_mocks/__tests__/automock.test.js
 PASS  examples/getting-started/sum.test.js
 PASS  packages/jest-cli/src/__tests__/generate_empty_coverage.test.js
 PASS  packages/jest-cli/src/__tests__/watch.test.js
 PASS  integration-tests/__tests__/no_test_found.test.js
 PASS  packages/jest-mock/src/__tests__/jest_mock.test.js
 PASS  packages/pretty-format/src/__tests__/immutable.test.js
 PASS  examples/automatic_mocks/__tests__/genMockFromModule.test.js
 PASS  examples/timer/__tests__/infinite_timer_game.test.js
  ● Console

    console.log examples/timer/infiniteTimerGame.js:4
      Ready....go!
    console.log examples/timer/infiniteTimerGame.js:7
      Times up! 10 seconds before the next game starts...

 PASS  packages/jest-worker/src/__tests__/child.test.js
 PASS  examples/timer/__tests__/timer_game.test.js
  ● Console

    console.log examples/timer/timerGame.js:4
      Ready....go!
    console.log examples/timer/timerGame.js:4
      Ready....go!
    console.log examples/timer/timerGame.js:6
      Times up -- stop!
    console.log examples/timer/timerGame.js:6
      Times up -- stop!
    console.log examples/timer/timerGame.js:4
      Ready....go!
    console.log examples/timer/timerGame.js:6
      Times up -- stop!

 PASS  examples/module-mock/__tests__/partial_mock.js
 PASS  packages/pretty-format/src/__tests__/pretty_format.test.js
 PASS  packages/jest-diff/src/__tests__/diff.test.js
 PASS  examples/automatic_mocks/__tests__/disableAutomocking.test.js
 PASS  packages/jest-resolve/src/__tests__/resolve.test.js
 PASS  packages/pretty-format/src/__tests__/dom_element.test.js
 PASS  examples/enzyme/__tests__/checkbox_with_label.test.js
 PASS  packages/jest-cli/src/__tests__/notify_reporter.test.js
 PASS  packages/jest-cli/src/reporters/__tests__/coverage_worker.test.js
 PASS  packages/jest-serializer/src/__tests__/index.test.js
 PASS  packages/jest-worker/src/__tests__/index.test.js
 PASS  examples/manual-mocks/__tests__/file_summarizer.test.js
 PASS  examples/module-mock/__tests__/full_mock.js
 PASS  packages/jest-cli/src/__tests__/watch_filename_pattern_mode.test.js
 PASS  packages/jest-worker/src/__tests__/worker.test.js
 PASS  packages/jest-editor-support/src/__tests__/parsers/babylon_parser.test.js
 PASS  packages/jest-cli/src/__tests__/watch_test_name_pattern_mode.test.js
 PASS  packages/expect/src/__tests__/spy_matchers.test.js
 PASS  packages/pretty-format/src/__tests__/react.test.js
 PASS  packages/jest-cli/src/__tests__/snapshot_interactive_mode.test.js
 PASS  packages/jest-circus/src/__tests__/circus_it_test_error.test.js
 PASS  examples/snapshot/__tests__/clock.react.test.js
 PASS  examples/snapshot/__tests__/link.react.test.js
 PASS  packages/pretty-format/src/__tests__/convert_ansi.test.js
 PASS  packages/jest-config/src/__tests__/defaults.test.js
 PASS  packages/expect/src/__tests__/to_throw_matchers.test.js
 PASS  packages/jest-docblock/src/__tests__/index.test.js
 PASS  packages/jest-cli/src/__tests__/run_jest_with_coverage.test.js
 PASS  examples/module-mock/__tests__/mock_per_test.js
 PASS  examples/jquery/__tests__/fetch_current_user.test.js
 PASS  packages/pretty-format/src/__tests__/dom_collection.test.js
 PASS  packages/jest-haste-map/src/__tests__/worker.test.js
 PASS  packages/jest-worker/src/__tests__/index-integration.test.js
 PASS  packages/jest-haste-map/src/crawlers/__tests__/watchman.test.js
 PASS  packages/jest-cli/src/__tests__/test_sequencer.test.js
 PASS  packages/jest-config/src/__tests__/set_from_argv.test.js
 PASS  packages/jest-message-util/src/__tests__/messages.test.js
 PASS  packages/jest-runner/src/__tests__/test_runner.test.js
 PASS  packages/jest-util/src/__tests__/buffered_console.test.js
 PASS  packages/jest-util/src/__tests__/get_callsite.test.js
 PASS  packages/jest-editor-support/src/__tests__/runner.test.js
 PASS  packages/jest-snapshot/src/__tests__/throw_matcher.test.js
 PASS  packages/diff-sequences/src/__tests__/index.test.js
 PASS  packages/jest-haste-map/src/crawlers/__tests__/node.test.js
 PASS  packages/jest-snapshot/src/__tests__/utils.test.js
 PASS  packages/jest-config/src/__tests__/read_config.test.js
 PASS  packages/jest-environment-node/src/__tests__/node_environment.test.js
 PASS  packages/jest-cli/src/lib/__tests__/scroll_list.test.js
 PASS  packages/jest-runtime/src/__tests__/should_instrument.test.js
 PASS  examples/typescript/__tests__/sum.test.js
 PASS  packages/jest-validate/src/__tests__/validate.test.js
 PASS  packages/jest-editor-support/src/__tests__/settings.test.js
 PASS  packages/jest-editor-support/src/__tests__/process.test.js
 PASS  packages/jest-cli/src/reporters/__tests__/default_reporter.test.js
 PASS  packages/jest-cli/src/lib/__tests__/is_valid_path.test.js
 PASS  packages/jest-util/src/__tests__/console.test.js
 PASS  packages/expect/src/__tests__/asymmetric_matchers.test.js
 PASS  packages/jest-cli/src/lib/__tests__/format_test_name_by_pattern.test.js
 PASS  packages/expect/src/__tests__/assertion_counts.test.js
 PASS  packages/expect/src/__tests__/utils.test.js
 PASS  packages/jest-editor-support/src/__tests__/test_reconciler.test.js
 PASS  packages/jest-snapshot/src/__tests__/matcher.test.js
 PASS  packages/jest-jasmine2/src/__tests__/expectation_result_factory.test.js
 PASS  packages/expect/src/__tests__/stacktrace.test.js
 PASS  packages/jest-cli/src/reporters/__tests__/verbose_reporter.test.js
 PASS  packages/jest-util/src/__tests__/create_process_object.test.js
 PASS  packages/jest-config/src/__tests__/resolve_config_path.test.js
 PASS  packages/jest-validate/src/__tests__/validate_cli_options.test.js
 PASS  packages/jest-jasmine2/src/__tests__/integration/lifecycle_hooks_test.js
 PASS  packages/jest-cli/src/__tests__/cli/args.test.js
 PASS  packages/jest-cli/src/reporters/__tests__/utils.test.js
 PASS  packages/jest-jasmine2/src/__tests__/queue_runner.test.js
 PASS  packages/jest-jasmine2/src/__tests__/Suite.test.js
 PASS  packages/jest-haste-map/src/lib/__tests__/extract_requires.test.js
 PASS  packages/expect/src/__tests__/is_error.test.js
 PASS  packages/jest-editor-support/src/__tests__/project_workspace.test.js
 PASS  packages/jest-util/src/__tests__/install_common_globals.test.js
 PASS  packages/jest-jasmine2/src/__tests__/reporter.test.js
 PASS  packages/jest-get-type/src/__tests__/index.test.js
 PASS  packages/jest-config/src/__tests__/validate_pattern.test.js
 PASS  packages/jest-cli/src/reporters/__tests__/get_snapshot_status.test.js
 PASS  packages/jest-regex-util/src/__tests__/index.test.js
 PASS  packages/jest-jasmine2/src/__tests__/it_test_error.test.js
 PASS  integration-tests/test-in-root/test.js
 PASS  packages/jest-jasmine2/src/__tests__/iterators.test.js
 PASS  integration-tests/__tests__/require_v8_module.test.js
 PASS  packages/pretty-format/src/__tests__/asymmetric_matcher.test.js
 PASS  packages/jest-util/src/__tests__/format_test_results.test.js
 PASS  packages/jest-cli/src/reporters/__tests__/summary_reporter.test.js
 PASS  packages/jest-cli/src/reporters/__tests__/get_snapshot_summary.test.js
 PASS  packages/expect/src/__tests__/symbol_in_objects.test.js
 PASS  integration-tests/timer-reset-mocks/with-reset-mocks/timer_with_mock.test.js
 PASS  packages/jest-snapshot/src/__tests__/mock_serializer.test.js
 PASS  packages/jest-util/src/__tests__/is_interactive.test.js
 PASS  packages/jest-util/src/__tests__/deep_cyclic_copy.test.js
 PASS  packages/jest-jasmine2/src/__tests__/p_timeout.test.js
 PASS  packages/jest-cli/src/lib/__tests__/log_debug_messages.test.js
 PASS  packages/jest-haste-map/src/__tests__/get_mock_name.test.js
 PASS  packages/jest-util/src/__tests__/get_failed_snapshot.test.js
 PASS  integration-tests/test-in-root/spec.js
 PASS  packages/jest-haste-map/src/lib/__tests__/normalize_path_sep.test.js
 PASS  packages/jest-config/src/__tests__/get_max_workers.test.js
 PASS  packages/jest-cli/src/lib/__tests__/prompt.test.js
 PASS  packages/jest-resolve/src/__tests__/is_builtin_module.test.js
 PASS  packages/expect/src/__tests__/extend.test.js
 PASS  integration-tests/__tests__/symbol.test.js
 PASS  integration-tests/timer-reset-mocks/after-reset-all-mocks/timer_and_mock.test.js
 PASS  integration-tests/__tests__/global.test.js
 PASS  packages/jest-haste-map/src/lib/__tests__/get_platform_extension.test.js
 PASS  packages/jest-cli/src/__tests__/globals.test.js
 PASS  integration-tests/__tests__/json.test.js
 PASS  packages/jest-jasmine2/src/__tests__/it_to_test_alias.test.js
 PASS  packages/expect/src/__tests__/fake_chalk.test.js
 PASS  packages/jest-cli/src/__tests__/failed_tests_cache.test.js
 PASS  packages/jest-jasmine2/src/__tests__/matchers.test.js
 PASS  examples/manual-mocks/__tests__/userMocked.test.js

Test Suites: 257 passed, 257 total
Tests:       2268 passed, 2268 total
Snapshots:   869 passed, 869 total
Time:        78.885s, estimated 212s
Ran all test suites in 13 projects.
✨  Done in 121.06s.

```
