### PR TITLE
Support testEnvironment=jest-environment-jsdom with pnpm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -221,6 +221,8 @@
   ([#5560](https://github.com/facebook/jest/pull/5560))
 * `[jest-config]` Make it possible to merge `transform` option with preset
   ([#5505](https://github.com/facebook/jest/pull/5505))
+* `[jest-util]` Fix `console.assert` behavior in custom & buffered consoles
+  ([#5576](https://github.com/facebook/jest/pull/5576))
 * `[jest-runner]` Add test environment dependencies to package.json
   ([#6145](https://github.com/facebook/jest/pull/6145))
 * `[jest-config]` Remove test environment dependencies from package.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -221,8 +221,10 @@
   ([#5560](https://github.com/facebook/jest/pull/5560))
 * `[jest-config]` Make it possible to merge `transform` option with preset
   ([#5505](https://github.com/facebook/jest/pull/5505))
-* `[jest-util]` Fix `console.assert` behavior in custom & buffered consoles
-  ([#5576](https://github.com/facebook/jest/pull/5576))
+* `[jest-runner]` Add test environment dependencies to package.json
+  ([#6145](https://github.com/facebook/jest/pull/6145))
+* `[jest-config]` Remove test environment dependencies from package.json
+  ([#6145](https://github.com/facebook/jest/pull/6145))
 
 ### Features
 

--- a/packages/jest-config/package.json
+++ b/packages/jest-config/package.json
@@ -12,8 +12,6 @@
     "babel-jest": "^22.4.1",
     "chalk": "^2.0.1",
     "glob": "^7.1.1",
-    "jest-environment-jsdom": "^22.4.1",
-    "jest-environment-node": "^22.4.1",
     "jest-get-type": "^22.1.0",
     "jest-jasmine2": "^22.4.2",
     "jest-regex-util": "^22.1.0",

--- a/packages/jest-runner/package.json
+++ b/packages/jest-runner/package.json
@@ -12,6 +12,7 @@
     "jest-config": "^22.4.2",
     "jest-docblock": "^22.4.0",
     "jest-environment-jsdom": "^22.4.1",
+    "jest-environment-node": "^22.4.1",
     "jest-haste-map": "^22.4.2",
     "jest-jasmine2": "^22.4.2",
     "jest-leak-detector": "^22.4.0",

--- a/packages/jest-runner/package.json
+++ b/packages/jest-runner/package.json
@@ -11,6 +11,7 @@
     "exit": "^0.1.2",
     "jest-config": "^22.4.2",
     "jest-docblock": "^22.4.0",
+    "jest-environment-jsdom": "^22.4.1",
     "jest-haste-map": "^22.4.2",
     "jest-jasmine2": "^22.4.2",
     "jest-leak-detector": "^22.4.0",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

The [dynamic require](https://github.com/facebook/jest/blob/v22.4.2/packages/jest-runner/src/run_test.js#L69) of testEnvironment (transpiled to `const testFramework = require(config.testRunner)` in published source) is incompatible with [pnpm](https://github.com/pnpm/pnpm).

I agree with https://github.com/pnpm/pnpm/issues/1130#issuecomment-386718095.

For environment to be truly pluggable, with stricter npm install, I guess this PR needs to consider how to support environments other than jsdom. It could be argued that a class should be injected, rather than `require`d using a runtime value. In practice though I think the suggested addition to package.json solves the problem.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Fixes #5369