### PR TITLE
chore: checkout last 5 commits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ node_js:
 
 sudo: false
 
+git:
+  depth: 5
+
 branches:
    only:
    - master


### PR DESCRIPTION
By default Travis clones the last 50 commits. 5 should be still enough and a "bit" faster.