### PR TITLE
Better snapshot summaries 

### DIFF
--- a/integration-tests/__tests__/__snapshots__/failures.test.js.snap
+++ b/integration-tests/__tests__/__snapshots__/failures.test.js.snap
@@ -419,7 +419,8 @@ exports[`works with named snapshot failures 1`] = `
       
       at __tests__/snapshot_named.test.js:12:17
 
- › 1 snapshot test failed.
+ › 1 snapshot failed.
+
 "
 `;
 
@@ -852,6 +853,7 @@ exports[`works with snapshot failures 1`] = `
       
       at __tests__/snapshot.test.js:12:17
 
- › 1 snapshot test failed.
+ › 1 snapshot failed.
+
 "
 `;

--- a/integration-tests/__tests__/__snapshots__/failures.test.js.snap
+++ b/integration-tests/__tests__/__snapshots__/failures.test.js.snap
@@ -420,7 +420,6 @@ exports[`works with named snapshot failures 1`] = `
       at __tests__/snapshot_named.test.js:12:17
 
  › 1 snapshot failed.
-
 "
 `;
 
@@ -854,6 +853,5 @@ exports[`works with snapshot failures 1`] = `
       at __tests__/snapshot.test.js:12:17
 
  › 1 snapshot failed.
-
 "
 `;

--- a/integration-tests/__tests__/__snapshots__/snapshot.test.js.snap
+++ b/integration-tests/__tests__/__snapshots__/snapshot.test.js.snap
@@ -3,7 +3,7 @@
 exports[`Snapshot Validation deletes a snapshot when a test does removes all the snapshots 1`] = `
 "Test Suites: 3 passed, 3 total
 Tests:       9 passed, 9 total
-Snapshots:   9 added, 9 total
+Snapshots:   9 written, 9 total
 Time:        <<REPLACED>>
 Ran all test suites."
 `;
@@ -11,7 +11,7 @@ Ran all test suites."
 exports[`Snapshot Validation deletes a snapshot when a test does removes all the snapshots 2`] = `
 "Test Suites: 3 passed, 3 total
 Tests:       6 passed, 6 total
-Snapshots:   5 passed, 5 total
+Snapshots:   1 file removed, 5 passed, 5 total
 Time:        <<REPLACED>>
 Ran all test suites."
 `;
@@ -19,7 +19,7 @@ Ran all test suites."
 exports[`Snapshot Validation deletes the snapshot if the test suite has been removed 1`] = `
 "Test Suites: 3 passed, 3 total
 Tests:       9 passed, 9 total
-Snapshots:   9 added, 9 total
+Snapshots:   9 written, 9 total
 Time:        <<REPLACED>>
 Ran all test suites."
 `;
@@ -27,7 +27,7 @@ Ran all test suites."
 exports[`Snapshot Validation deletes the snapshot if the test suite has been removed 2`] = `
 "Test Suites: 2 passed, 2 total
 Tests:       5 passed, 5 total
-Snapshots:   5 passed, 5 total
+Snapshots:   1 file removed, 5 passed, 5 total
 Time:        <<REPLACED>>
 Ran all test suites."
 `;
@@ -44,7 +44,7 @@ Ran all test suites.
 exports[`Snapshot Validation updates the snapshot when a test removes some snapshots 1`] = `
 "Test Suites: 3 passed, 3 total
 Tests:       9 passed, 9 total
-Snapshots:   9 added, 9 total
+Snapshots:   9 written, 9 total
 Time:        <<REPLACED>>
 Ran all test suites."
 `;
@@ -52,7 +52,7 @@ Ran all test suites."
 exports[`Snapshot Validation updates the snapshot when a test removes some snapshots 2`] = `
 "Test Suites: 3 passed, 3 total
 Tests:       9 passed, 9 total
-Snapshots:   1 updated, 7 passed, 8 total
+Snapshots:   1 removed, 1 updated, 7 passed, 8 total
 Time:        <<REPLACED>>
 Ran all test suites."
 `;
@@ -60,7 +60,7 @@ Ran all test suites."
 exports[`Snapshot Validation works on subsequent runs without \`-u\` 1`] = `
 "Test Suites: 3 passed, 3 total
 Tests:       9 passed, 9 total
-Snapshots:   9 added, 9 total
+Snapshots:   9 written, 9 total
 Time:        <<REPLACED>>
 Ran all test suites."
 `;
@@ -76,7 +76,7 @@ Ran all test suites."
 exports[`Snapshot stores new snapshots on the first run 1`] = `
 "Test Suites: 2 passed, 2 total
 Tests:       5 passed, 5 total
-Snapshots:   5 added, 5 total
+Snapshots:   5 written, 5 total
 Time:        <<REPLACED>>
 Ran all test suites."
 `;
@@ -84,7 +84,7 @@ Ran all test suites."
 exports[`Snapshot works with escaped characters 1`] = `
 "Test Suites: 1 passed, 1 total
 Tests:       1 passed, 1 total
-Snapshots:   1 added, 1 total
+Snapshots:   1 written, 1 total
 Time:        <<REPLACED>>
 Ran all test suites matching /snapshot.test.js/i."
 `;
@@ -92,7 +92,7 @@ Ran all test suites matching /snapshot.test.js/i."
 exports[`Snapshot works with escaped characters 2`] = `
 "Test Suites: 1 passed, 1 total
 Tests:       2 passed, 2 total
-Snapshots:   1 added, 1 passed, 2 total
+Snapshots:   1 written, 1 passed, 2 total
 Time:        <<REPLACED>>
 Ran all test suites matching /snapshot.test.js/i."
 `;
@@ -108,7 +108,7 @@ Ran all test suites matching /snapshot.test.js/i."
 exports[`Snapshot works with escaped regex 1`] = `
 "Test Suites: 1 passed, 1 total
 Tests:       2 passed, 2 total
-Snapshots:   2 added, 2 total
+Snapshots:   2 written, 2 total
 Time:        <<REPLACED>>
 Ran all test suites matching /snapshot_escape_regex.js/i."
 `;
@@ -121,15 +121,15 @@ Time:        <<REPLACED>>
 Ran all test suites matching /snapshot_escape_regex.js/i."
 `;
 
-exports[`Snapshot works with template literal subsitutions 1`] = `
+exports[`Snapshot works with template literal substitutions 1`] = `
 "Test Suites: 1 passed, 1 total
 Tests:       1 passed, 1 total
-Snapshots:   1 added, 1 total
+Snapshots:   1 written, 1 total
 Time:        <<REPLACED>>
 Ran all test suites matching /snapshot_escape_substitution.test.js/i."
 `;
 
-exports[`Snapshot works with template literal subsitutions 2`] = `
+exports[`Snapshot works with template literal substitutions 2`] = `
 "Test Suites: 1 passed, 1 total
 Tests:       1 passed, 1 total
 Snapshots:   1 passed, 1 total

--- a/integration-tests/__tests__/snapshot.test.js
+++ b/integration-tests/__tests__/snapshot.test.js
@@ -118,7 +118,7 @@ describe('Snapshot', () => {
       content['snapshot is not influenced by previous counter 1'],
     ).not.toBeUndefined();
 
-    expect(result.stderr).toMatch('5 snapshots written in 2 test suites');
+    expect(result.stderr).toMatch('5 snapshots written from 2 test suites');
     expect(extractSummary(result.stderr).summary).toMatchSnapshot();
   });
 
@@ -177,7 +177,7 @@ describe('Snapshot', () => {
     ]);
     let stderr = result.stderr;
 
-    expect(stderr).toMatch('2 snapshots written in 1 test suite.');
+    expect(stderr).toMatch('2 snapshots written from 1 test suite.');
     expect(result.status).toBe(0);
     expect(extractSummary(stderr).summary).toMatchSnapshot();
 
@@ -195,7 +195,7 @@ describe('Snapshot', () => {
     expect(result.status).toBe(0);
   });
 
-  it('works with template literal subsitutions', () => {
+  it('works with template literal substitutions', () => {
     // Write the first snapshot
     let result = runJest('snapshot-escape', [
       '-w=1',
@@ -252,7 +252,7 @@ describe('Snapshot', () => {
       expect(secondRun.json.numTotalTests).toBe(9);
       expect(secondRun.json.success).toBe(true);
 
-      expect(firstRun.stderr).toMatch('9 snapshots written in 3 test suites');
+      expect(firstRun.stderr).toMatch('9 snapshots written from 3 test suites');
       expect(secondRun.stderr).toMatch('9 passed, 9 total');
       expect(extractSummary(firstRun.stderr).summary).toMatchSnapshot();
       expect(extractSummary(secondRun.stderr).summary).toMatchSnapshot();
@@ -271,8 +271,10 @@ describe('Snapshot', () => {
       expect(secondRun.json.numTotalTests).toBe(5);
       expect(fileExists(snapshotOfCopy)).toBe(false);
 
-      expect(firstRun.stderr).toMatch('9 snapshots written in 3 test suites');
-      expect(secondRun.stderr).toMatch('1 obsolete snapshot file removed');
+      expect(firstRun.stderr).toMatch('9 snapshots written from 3 test suites');
+      expect(secondRun.stderr).toMatch(
+        '1 snapshot file removed from 1 test suite',
+      );
       expect(extractSummary(firstRun.stderr).summary).toMatchSnapshot();
       expect(extractSummary(secondRun.stderr).summary).toMatchSnapshot();
     });
@@ -288,8 +290,10 @@ describe('Snapshot', () => {
       expect(secondRun.json.numTotalTests).toBe(6);
 
       expect(fileExists(snapshotOfCopy)).toBe(false);
-      expect(firstRun.stderr).toMatch('9 snapshots written in 3 test suites');
-      expect(secondRun.stderr).toMatch('1 obsolete snapshot file removed');
+      expect(firstRun.stderr).toMatch('9 snapshots written from 3 test suites');
+      expect(secondRun.stderr).toMatch(
+        '1 snapshot file removed from 1 test suite',
+      );
       expect(extractSummary(firstRun.stderr).summary).toMatchSnapshot();
       expect(extractSummary(secondRun.stderr).summary).toMatchSnapshot();
     });
@@ -323,10 +327,10 @@ describe('Snapshot', () => {
       expect(beforeRemovingSnapshot[keyToCheck]).not.toBe(undefined);
       expect(afterRemovingSnapshot[keyToCheck]).toBe(undefined);
 
-      expect(firstRun.stderr).toMatch('9 snapshots written in 3 test suites');
+      expect(firstRun.stderr).toMatch('9 snapshots written from 3 test suites');
       expect(extractSummary(firstRun.stderr).summary).toMatchSnapshot();
-      expect(secondRun.stderr).toMatch('1 snapshot updated in 1 test suite');
-      expect(secondRun.stderr).toMatch('1 obsolete snapshot removed');
+      expect(secondRun.stderr).toMatch('1 snapshot updated from 1 test suite');
+      expect(secondRun.stderr).toMatch('1 snapshot removed from 1 test suite');
       expect(extractSummary(secondRun.stderr).summary).toMatchSnapshot();
     });
   });

--- a/integration-tests/__tests__/to_match_snapshot.test.js
+++ b/integration-tests/__tests__/to_match_snapshot.test.js
@@ -28,14 +28,14 @@ test('basic support', () => {
       [filename]: template(['{apple: "original value"}']),
     });
     const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
-    expect(stderr).toMatch('1 snapshot written in 1 test suite.');
+    expect(stderr).toMatch('1 snapshot written from 1 test suite.');
     expect(status).toBe(0);
   }
 
   {
     const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     expect(stderr).toMatch('Snapshots:   1 passed, 1 total');
-    expect(stderr).not.toMatch('1 snapshot written in 1 test suite.');
+    expect(stderr).not.toMatch('1 snapshot written from 1 test suite.');
     expect(status).toBe(0);
   }
 
@@ -58,7 +58,7 @@ test('basic support', () => {
       filename,
       '-u',
     ]);
-    expect(stderr).toMatch('1 snapshot updated in 1 test suite.');
+    expect(stderr).toMatch('1 snapshot updated from 1 test suite.');
     expect(status).toBe(0);
   }
 });
@@ -75,7 +75,7 @@ test('error thrown before snapshot', () => {
       [filename]: template(['true', '{a: "original"}']),
     });
     const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
-    expect(stderr).toMatch('1 snapshot written in 1 test suite.');
+    expect(stderr).toMatch('1 snapshot written from 1 test suite.');
     expect(status).toBe(0);
   }
 
@@ -105,7 +105,7 @@ test('first snapshot fails, second passes', () => {
   {
     writeFiles(TESTS_DIR, {[filename]: template([`'apple'`, `'banana'`])});
     const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
-    expect(stderr).toMatch('2 snapshots written in 1 test suite.');
+    expect(stderr).toMatch('2 snapshots written from 1 test suite.');
     expect(status).toBe(0);
   }
 
@@ -133,7 +133,7 @@ test('does not mark snapshots as obsolete in skipped tests', () => {
   {
     writeFiles(TESTS_DIR, {[filename]: template(['test'])});
     const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
-    expect(stderr).toMatch('1 snapshot written in 1 test suite.');
+    expect(stderr).toMatch('1 snapshot written from 1 test suite.');
     expect(status).toBe(0);
   }
 
@@ -155,7 +155,7 @@ test('accepts custom snapshot name', () => {
   {
     writeFiles(TESTS_DIR, {[filename]: template()});
     const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
-    expect(stderr).toMatch('1 snapshot written in 1 test suite.');
+    expect(stderr).toMatch('1 snapshot written from 1 test suite.');
     expect(status).toBe(0);
   }
 });

--- a/integration-tests/__tests__/to_throw_error_matching_snapshot.test.js
+++ b/integration-tests/__tests__/to_throw_error_matching_snapshot.test.js
@@ -29,7 +29,7 @@ test('works fine when function throws error', () => {
   {
     writeFiles(TESTS_DIR, {[filename]: template()});
     const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
-    expect(stderr).toMatch('1 snapshot written in 1 test suite.');
+    expect(stderr).toMatch('1 snapshot written from 1 test suite.');
     expect(status).toBe(0);
   }
 });
@@ -60,7 +60,7 @@ test('accepts custom snapshot name', () => {
   {
     writeFiles(TESTS_DIR, {[filename]: template()});
     const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
-    expect(stderr).toMatch('1 snapshot written in 1 test suite.');
+    expect(stderr).toMatch('1 snapshot written from 1 test suite.');
     expect(status).toBe(0);
   }
 });
@@ -98,7 +98,7 @@ test('should support rejecting promises', () => {
       'utf8',
     );
 
-    expect(stderr).toMatch('1 snapshot written in 1 test suite.');
+    expect(stderr).toMatch('1 snapshot written from 1 test suite.');
     expect(snapshot).toMatchSnapshot();
     expect(status).toBe(0);
   }

--- a/packages/jest-cli/src/reporters/__tests__/__snapshots__/get_snapshot_status.test.js.snap
+++ b/packages/jest-cli/src/reporters/__tests__/__snapshots__/get_snapshot_status.test.js.snap
@@ -2,23 +2,23 @@
 
 exports[`Retrieves the snapshot status 1`] = `
 Array [
-  "<bold><green> › 1 snapshot</></> written.",
-  "<bold><green> › 1 snapshot</></> updated.",
-  "<bold><red> › 1 obsolete snapshot</></> found.",
-  "<bold><red>  - test suite with unchecked snapshot</></>",
-  "<bold><red> › 1 snapshot test</></> failed.",
+  "<bold><green> › 1 snapshot written.</></>",
+  "<bold><green> › 1 snapshot updated.</></>",
+  "<bold><red> › 1 snapshot failed.</></>",
+  "<bold><yellow> › 1 snapshot obsolete</></>.",
+  "   • test suite with unchecked snapshot",
 ]
 `;
 
 exports[`Retrieves the snapshot status after a snapshot update 1`] = `
 Array [
-  "<bold><green> › 2 snapshots</></> written.",
-  "<bold><green> › 2 snapshots</></> updated.",
-  "<bold><red> › 2 obsolete snapshots</></> removed.",
-  "<bold><red>  - first test suite with unchecked snapshot</></>",
-  "<bold><red>  - second test suite with unchecked snapshot</></>",
-  "<bold><red> › Obsolete snapshot file</></> removed.",
-  "<bold><red> › 2 snapshot tests</></> failed.",
+  "<bold><green> › 2 snapshots written.</></>",
+  "<bold><green> › 2 snapshots updated.</></>",
+  "<bold><red> › 2 snapshots failed.</></>",
+  "<bold><green> › 2 snapshots removed.</></>",
+  "   • first test suite with unchecked snapshot",
+  "   • second test suite with unchecked snapshot",
+  "<bold><green> › snapshot file removed.</></>",
 ]
 `;
 

--- a/packages/jest-cli/src/reporters/__tests__/__snapshots__/get_snapshot_summary.test.js.snap
+++ b/packages/jest-cli/src/reporters/__tests__/__snapshots__/get_snapshot_summary.test.js.snap
@@ -2,8 +2,7 @@
 
 exports[`creates a snapshot summary 1`] = `
 Array [
-  "<bold></>
-<bold>Snapshot Summary</>",
+  "<bold>Snapshot Summary</>",
   "<bold><green> › 1 snapshot written </></>from 1 test suite.",
   "<bold><red> › 1 snapshot failed</></> from 1 test suite. <dim>Inspect your code changes or press --u to update them.</>",
   "<bold><green> › 1 snapshot updated </></>from 1 test suite.",
@@ -16,8 +15,7 @@ Array [
 
 exports[`creates a snapshot summary after an update 1`] = `
 Array [
-  "<bold></>
-<bold>Snapshot Summary</>",
+  "<bold>Snapshot Summary</>",
   "<bold><green> › 1 snapshot written </></>from 1 test suite.",
   "<bold><red> › 1 snapshot failed</></> from 1 test suite. <dim>Inspect your code changes or press --u to update them.</>",
   "<bold><green> › 1 snapshot updated </></>from 1 test suite.",
@@ -30,8 +28,7 @@ Array [
 
 exports[`creates a snapshot summary with multiple snapshot being written/updated 1`] = `
 Array [
-  "<bold></>
-<bold>Snapshot Summary</>",
+  "<bold>Snapshot Summary</>",
   "<bold><green> › 2 snapshots written </></>from 2 test suites.",
   "<bold><red> › 2 snapshots failed</></> from 2 test suites. <dim>Inspect your code changes or press --u to update them.</>",
   "<bold><green> › 2 snapshots updated </></>from 2 test suites.",
@@ -46,7 +43,6 @@ Array [
 
 exports[`returns nothing if there are no updates 1`] = `
 Array [
-  "<bold></>
-<bold>Snapshot Summary</>",
+  "<bold>Snapshot Summary</>",
 ]
 `;

--- a/packages/jest-cli/src/reporters/__tests__/__snapshots__/get_snapshot_summary.test.js.snap
+++ b/packages/jest-cli/src/reporters/__tests__/__snapshots__/get_snapshot_summary.test.js.snap
@@ -2,39 +2,51 @@
 
 exports[`creates a snapshot summary 1`] = `
 Array [
-  "<bold>Snapshot Summary</>",
-  "<bold><green> › 1 snapshot</></> written in 1 test suite.",
-  "<bold><red> › 1 snapshot test</></> failed in 1 test suite. <dim>Inspect your code changes or press --u to update them.</>",
-  "<bold><green> › 1 snapshot</></> updated in 1 test suite.",
-  "<bold><red> › 1 obsolete snapshot file</></> found, press --u to remove it.",
-  "<bold><red> › 1 obsolete snapshot</></> found, press --u to remove it.",
+  "<bold></>
+<bold>Snapshot Summary</>",
+  "<bold><green> › 1 snapshot written </></>from 1 test suite.",
+  "<bold><red> › 1 snapshot failed</></> from 1 test suite. <dim>Inspect your code changes or press --u to update them.</>",
+  "<bold><green> › 1 snapshot updated </></>from 1 test suite.",
+  "<bold><yellow> › 1 snapshot file obsolete </></>from 1 test suite. <dim>To remove it, press --u.</>",
+  "<bold><yellow> › 1 snapshot obsolete </></>from 1 test suite. <dim>To remove it, press --u.</>",
+  "   ↳ <dim>../path/to/</><bold>suite_one</>",
+  "       • unchecked snapshot 1",
 ]
 `;
 
 exports[`creates a snapshot summary after an update 1`] = `
 Array [
-  "<bold>Snapshot Summary</>",
-  "<bold><green> › 1 snapshot</></> written in 1 test suite.",
-  "<bold><red> › 1 snapshot test</></> failed in 1 test suite. <dim>Inspect your code changes or press --u to update them.</>",
-  "<bold><green> › 1 snapshot</></> updated in 1 test suite.",
-  "<bold><red> › 1 obsolete snapshot file</></> removed.",
-  "<bold><red> › 1 obsolete snapshot</></> removed.",
+  "<bold></>
+<bold>Snapshot Summary</>",
+  "<bold><green> › 1 snapshot written </></>from 1 test suite.",
+  "<bold><red> › 1 snapshot failed</></> from 1 test suite. <dim>Inspect your code changes or press --u to update them.</>",
+  "<bold><green> › 1 snapshot updated </></>from 1 test suite.",
+  "<bold><green> › 1 snapshot file removed </></>from 1 test suite.",
+  "<bold><green> › 1 snapshot removed </></>from 1 test suite.",
+  "   ↳ <dim>../path/to/</><bold>suite_one</>",
+  "       • unchecked snapshot 1",
 ]
 `;
 
 exports[`creates a snapshot summary with multiple snapshot being written/updated 1`] = `
 Array [
-  "<bold>Snapshot Summary</>",
-  "<bold><green> › 2 snapshots</></> written in 2 test suites.",
-  "<bold><red> › 2 snapshot tests</></> failed in 2 test suites. <dim>Inspect your code changes or press --u to update them.</>",
-  "<bold><green> › 2 snapshots</></> updated in 2 test suites.",
-  "<bold><red> › 2 obsolete snapshot files</></> found, press --u to remove them..",
-  "<bold><red> › 2 obsolete snapshots</></> found, press --u to remove them.",
+  "<bold></>
+<bold>Snapshot Summary</>",
+  "<bold><green> › 2 snapshots written </></>from 2 test suites.",
+  "<bold><red> › 2 snapshots failed</></> from 2 test suites. <dim>Inspect your code changes or press --u to update them.</>",
+  "<bold><green> › 2 snapshots updated </></>from 2 test suites.",
+  "<bold><yellow> › 2 snapshot files obsolete </></>from 2 test suites. <dim>To remove them all, press --u.</>",
+  "<bold><yellow> › 2 snapshots obsolete </></>from 2 test suites. <dim>To remove them all, press --u.</>",
+  "   ↳ <dim>../path/to/</><bold>suite_one</>",
+  "       • unchecked snapshot 1",
+  "   ↳ <dim>../path/to/</><bold>suite_two</>",
+  "       • unchecked snapshot 2",
 ]
 `;
 
 exports[`returns nothing if there are no updates 1`] = `
 Array [
-  "<bold>Snapshot Summary</>",
+  "<bold></>
+<bold>Snapshot Summary</>",
 ]
 `;

--- a/packages/jest-cli/src/reporters/__tests__/__snapshots__/get_snapshot_summary.test.js.snap
+++ b/packages/jest-cli/src/reporters/__tests__/__snapshots__/get_snapshot_summary.test.js.snap
@@ -1,44 +1,38 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`creates a snapshot summary 1`] = `
-Array [
-  "<bold>Snapshot Summary</>",
-  "<bold><green> › 1 snapshot written </></>from 1 test suite.",
-  "<bold><red> › 1 snapshot failed</></> from 1 test suite. <dim>Inspect your code changes or press --u to update them.</>",
-  "<bold><green> › 1 snapshot updated </></>from 1 test suite.",
-  "<bold><yellow> › 1 snapshot file obsolete </></>from 1 test suite. <dim>To remove it, press --u.</>",
-  "<bold><yellow> › 1 snapshot obsolete </></>from 1 test suite. <dim>To remove it, press --u.</>",
-  "   ↳ <dim>../path/to/</><bold>suite_one</>",
-  "       • unchecked snapshot 1",
-]
+"<bold>Snapshot Summary</>
+<bold><green> › 1 snapshot written </></>from 1 test suite.
+<bold><red> › 1 snapshot failed</></> from 1 test suite. <dim>Inspect your code changes or press --u to update them.</>
+<bold><green> › 1 snapshot updated </></>from 1 test suite.
+<bold><yellow> › 1 snapshot file obsolete </></>from 1 test suite. <dim>To remove it, press --u.</>
+<bold><yellow> › 1 snapshot obsolete </></>from 1 test suite. <dim>To remove it, press --u.</>
+   ↳ <dim>../path/to/</><bold>suite_one</>
+       • unchecked snapshot 1"
 `;
 
 exports[`creates a snapshot summary after an update 1`] = `
-Array [
-  "<bold>Snapshot Summary</>",
-  "<bold><green> › 1 snapshot written </></>from 1 test suite.",
-  "<bold><red> › 1 snapshot failed</></> from 1 test suite. <dim>Inspect your code changes or press --u to update them.</>",
-  "<bold><green> › 1 snapshot updated </></>from 1 test suite.",
-  "<bold><green> › 1 snapshot file removed </></>from 1 test suite.",
-  "<bold><green> › 1 snapshot removed </></>from 1 test suite.",
-  "   ↳ <dim>../path/to/</><bold>suite_one</>",
-  "       • unchecked snapshot 1",
-]
+"<bold>Snapshot Summary</>
+<bold><green> › 1 snapshot written </></>from 1 test suite.
+<bold><red> › 1 snapshot failed</></> from 1 test suite. <dim>Inspect your code changes or press --u to update them.</>
+<bold><green> › 1 snapshot updated </></>from 1 test suite.
+<bold><green> › 1 snapshot file removed </></>from 1 test suite.
+<bold><green> › 1 snapshot removed </></>from 1 test suite.
+   ↳ <dim>../path/to/</><bold>suite_one</>
+       • unchecked snapshot 1"
 `;
 
 exports[`creates a snapshot summary with multiple snapshot being written/updated 1`] = `
-Array [
-  "<bold>Snapshot Summary</>",
-  "<bold><green> › 2 snapshots written </></>from 2 test suites.",
-  "<bold><red> › 2 snapshots failed</></> from 2 test suites. <dim>Inspect your code changes or press --u to update them.</>",
-  "<bold><green> › 2 snapshots updated </></>from 2 test suites.",
-  "<bold><yellow> › 2 snapshot files obsolete </></>from 2 test suites. <dim>To remove them all, press --u.</>",
-  "<bold><yellow> › 2 snapshots obsolete </></>from 2 test suites. <dim>To remove them all, press --u.</>",
-  "   ↳ <dim>../path/to/</><bold>suite_one</>",
-  "       • unchecked snapshot 1",
-  "   ↳ <dim>../path/to/</><bold>suite_two</>",
-  "       • unchecked snapshot 2",
-]
+"<bold>Snapshot Summary</>
+<bold><green> › 2 snapshots written </></>from 2 test suites.
+<bold><red> › 2 snapshots failed</></> from 2 test suites. <dim>Inspect your code changes or press --u to update them.</>
+<bold><green> › 2 snapshots updated </></>from 2 test suites.
+<bold><yellow> › 2 snapshot files obsolete </></>from 2 test suites. <dim>To remove them all, press --u.</>
+<bold><yellow> › 2 snapshots obsolete </></>from 2 test suites. <dim>To remove them all, press --u.</>
+   ↳ <dim>../path/to/</><bold>suite_one</>
+       • unchecked snapshot 1
+   ↳ <dim>../path/to/</><bold>suite_two</>
+       • unchecked snapshot 2"
 `;
 
 exports[`returns nothing if there are no updates 1`] = `

--- a/packages/jest-cli/src/reporters/__tests__/__snapshots__/get_snapshot_summary.test.js.snap
+++ b/packages/jest-cli/src/reporters/__tests__/__snapshots__/get_snapshot_summary.test.js.snap
@@ -35,8 +35,4 @@ exports[`creates a snapshot summary with multiple snapshot being written/updated
        • unchecked snapshot 2"
 `;
 
-exports[`returns nothing if there are no updates 1`] = `
-Array [
-  "<bold>Snapshot Summary</>",
-]
-`;
+exports[`returns nothing if there are no updates 1`] = `"<bold>Snapshot Summary</>"`;

--- a/packages/jest-cli/src/reporters/__tests__/__snapshots__/summary_reporter.test.js.snap
+++ b/packages/jest-cli/src/reporters/__tests__/__snapshots__/summary_reporter.test.js.snap
@@ -1,8 +1,47 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`snapshots all have results (after update) 1`] = `
+"<bold></>
+<bold>Snapshot Summary</>
+<bold><green> › 1 snapshot written </></>from 1 test suite.
+<bold><red> › 1 snapshot failed</></> from 1 test suite. <dim>Inspect your code changes or run \`yarn test -u\` to update them.</>
+<bold><green> › 1 snapshot updated </></>from 1 test suite.
+<bold><green> › 1 snapshot file removed </></>from 1 test suite.
+<bold><green> › 1 snapshot removed </></>from 1 test suite.
+   ↳ <dim>../path/to/</><bold>suite_one</>
+       • unchecked snapshot 1
+
+<bold>Test Suites: </><bold><red>1 failed</></>, 1 total
+<bold>Tests:       </><bold><red>1 failed</></>, 1 total
+<bold>Snapshots:   </><bold><red>1 failed</></>, <bold><green>1 removed</></>, <bold><green>1 file removed</></>, <bold><green>1 updated</></>, <bold><green>1 written</></>, <bold><green>2 passed</></>, 2 total
+<bold>Time:</>        0.01s
+<dim>Ran all test suites</><dim>.</>
+"
+`;
+
+exports[`snapshots all have results (no update) 1`] = `
+"<bold></>
+<bold>Snapshot Summary</>
+<bold><green> › 1 snapshot written </></>from 1 test suite.
+<bold><red> › 1 snapshot failed</></> from 1 test suite. <dim>Inspect your code changes or run \`yarn test -u\` to update them.</>
+<bold><green> › 1 snapshot updated </></>from 1 test suite.
+<bold><yellow> › 1 snapshot file obsolete </></>from 1 test suite. <dim>To remove it, run \`yarn test -u\`.</>
+<bold><yellow> › 1 snapshot obsolete </></>from 1 test suite. <dim>To remove it, run \`yarn test -u\`.</>
+   ↳ <dim>../path/to/</><bold>suite_one</>
+       • unchecked snapshot 1
+
+<bold>Test Suites: </><bold><red>1 failed</></>, 1 total
+<bold>Tests:       </><bold><red>1 failed</></>, 1 total
+<bold>Snapshots:   </><bold><red>1 failed</></>, <bold><yellow>1 obsolete</></>, <bold><yellow>1 file obsolete</></>, <bold><green>1 updated</></>, <bold><green>1 written</></>, <bold><green>2 passed</></>, 2 total
+<bold>Time:</>        0.01s
+<dim>Ran all test suites</><dim>.</>
+"
+`;
+
 exports[`snapshots needs update with npm test 1`] = `
-"<bold>Snapshot Summary</>
-<bold><red> › 2 snapshot tests</></> failed in 1 test suite. <dim>Inspect your code changes or run \`npm test -- -u\` to update them.</>
+"<bold></>
+<bold>Snapshot Summary</>
+<bold><red> › 2 snapshots failed</></> from 1 test suite. <dim>Inspect your code changes or run \`npm test -- -u\` to update them.</>
 
 <bold>Test Suites: </><bold><red>1 failed</></>, 1 total
 <bold>Tests:       </><bold><red>1 failed</></>, 1 total
@@ -13,8 +52,9 @@ exports[`snapshots needs update with npm test 1`] = `
 `;
 
 exports[`snapshots needs update with yarn test 1`] = `
-"<bold>Snapshot Summary</>
-<bold><red> › 2 snapshot tests</></> failed in 1 test suite. <dim>Inspect your code changes or run \`yarn test -u\` to update them.</>
+"<bold></>
+<bold>Snapshot Summary</>
+<bold><red> › 2 snapshots failed</></> from 1 test suite. <dim>Inspect your code changes or run \`yarn test -u\` to update them.</>
 
 <bold>Test Suites: </><bold><red>1 failed</></>, 1 total
 <bold>Tests:       </><bold><red>1 failed</></>, 1 total

--- a/packages/jest-cli/src/reporters/__tests__/__snapshots__/summary_reporter.test.js.snap
+++ b/packages/jest-cli/src/reporters/__tests__/__snapshots__/summary_reporter.test.js.snap
@@ -1,8 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`snapshots all have results (after update) 1`] = `
-"<bold></>
-<bold>Snapshot Summary</>
+"<bold>Snapshot Summary</>
 <bold><green> › 1 snapshot written </></>from 1 test suite.
 <bold><red> › 1 snapshot failed</></> from 1 test suite. <dim>Inspect your code changes or run \`yarn test -u\` to update them.</>
 <bold><green> › 1 snapshot updated </></>from 1 test suite.
@@ -20,8 +19,7 @@ exports[`snapshots all have results (after update) 1`] = `
 `;
 
 exports[`snapshots all have results (no update) 1`] = `
-"<bold></>
-<bold>Snapshot Summary</>
+"<bold>Snapshot Summary</>
 <bold><green> › 1 snapshot written </></>from 1 test suite.
 <bold><red> › 1 snapshot failed</></> from 1 test suite. <dim>Inspect your code changes or run \`yarn test -u\` to update them.</>
 <bold><green> › 1 snapshot updated </></>from 1 test suite.
@@ -39,8 +37,7 @@ exports[`snapshots all have results (no update) 1`] = `
 `;
 
 exports[`snapshots needs update with npm test 1`] = `
-"<bold></>
-<bold>Snapshot Summary</>
+"<bold>Snapshot Summary</>
 <bold><red> › 2 snapshots failed</></> from 1 test suite. <dim>Inspect your code changes or run \`npm test -- -u\` to update them.</>
 
 <bold>Test Suites: </><bold><red>1 failed</></>, 1 total
@@ -52,8 +49,7 @@ exports[`snapshots needs update with npm test 1`] = `
 `;
 
 exports[`snapshots needs update with yarn test 1`] = `
-"<bold></>
-<bold>Snapshot Summary</>
+"<bold>Snapshot Summary</>
 <bold><red> › 2 snapshots failed</></> from 1 test suite. <dim>Inspect your code changes or run \`yarn test -u\` to update them.</>
 
 <bold>Test Suites: </><bold><red>1 failed</></>, 1 total

--- a/packages/jest-cli/src/reporters/__tests__/get_snapshot_summary.test.js
+++ b/packages/jest-cli/src/reporters/__tests__/get_snapshot_summary.test.js
@@ -11,6 +11,10 @@ import getSnapshotSummary from '../get_snapshot_summary';
 
 const UPDATE_COMMAND = 'press --u';
 
+const globalConfig = {
+  rootDir: 'root',
+};
+
 test('creates a snapshot summary', () => {
   const snapshots = {
     added: 1,
@@ -22,11 +26,19 @@ test('creates a snapshot summary', () => {
     matched: 2,
     total: 2,
     unchecked: 1,
+    uncheckedKeysByFile: [
+      {
+        filePath: 'path/to/suite_one',
+        keys: ['unchecked snapshot 1'],
+      },
+    ],
     unmatched: 1,
     updated: 1,
   };
 
-  expect(getSnapshotSummary(snapshots, UPDATE_COMMAND)).toMatchSnapshot();
+  expect(
+    getSnapshotSummary(snapshots, globalConfig, UPDATE_COMMAND),
+  ).toMatchSnapshot();
 });
 
 test('creates a snapshot summary after an update', () => {
@@ -38,11 +50,19 @@ test('creates a snapshot summary after an update', () => {
     filesUnmatched: 1,
     filesUpdated: 1,
     unchecked: 1,
+    uncheckedKeysByFile: [
+      {
+        filePath: 'path/to/suite_one',
+        keys: ['unchecked snapshot 1'],
+      },
+    ],
     unmatched: 1,
     updated: 1,
   };
 
-  expect(getSnapshotSummary(snapshots, UPDATE_COMMAND)).toMatchSnapshot();
+  expect(
+    getSnapshotSummary(snapshots, globalConfig, UPDATE_COMMAND),
+  ).toMatchSnapshot();
 });
 
 it('creates a snapshot summary with multiple snapshot being written/updated', () => {
@@ -54,11 +74,23 @@ it('creates a snapshot summary with multiple snapshot being written/updated', ()
     filesUnmatched: 2,
     filesUpdated: 2,
     unchecked: 2,
+    uncheckedKeysByFile: [
+      {
+        filePath: 'path/to/suite_one',
+        keys: ['unchecked snapshot 1'],
+      },
+      {
+        filePath: 'path/to/suite_two',
+        keys: ['unchecked snapshot 2'],
+      },
+    ],
     unmatched: 2,
     updated: 2,
   };
 
-  expect(getSnapshotSummary(snapshots, UPDATE_COMMAND)).toMatchSnapshot();
+  expect(
+    getSnapshotSummary(snapshots, globalConfig, UPDATE_COMMAND),
+  ).toMatchSnapshot();
 });
 
 it('returns nothing if there are no updates', () => {
@@ -70,8 +102,11 @@ it('returns nothing if there are no updates', () => {
     filesUnmatched: 0,
     filesUpdated: 0,
     unchecked: 0,
+    uncheckedKeysByFile: [],
     unmatched: 0,
     updated: 0,
   };
-  expect(getSnapshotSummary(snapshots, UPDATE_COMMAND)).toMatchSnapshot();
+  expect(
+    getSnapshotSummary(snapshots, globalConfig, UPDATE_COMMAND),
+  ).toMatchSnapshot();
 });

--- a/packages/jest-cli/src/reporters/__tests__/get_snapshot_summary.test.js
+++ b/packages/jest-cli/src/reporters/__tests__/get_snapshot_summary.test.js
@@ -37,7 +37,9 @@ test('creates a snapshot summary', () => {
   };
 
   expect(
-    getSnapshotSummary(snapshots, globalConfig, UPDATE_COMMAND),
+    getSnapshotSummary(snapshots, globalConfig, UPDATE_COMMAND)
+      .join('\n')
+      .replace(/\\/g, '/'),
   ).toMatchSnapshot();
 });
 
@@ -61,7 +63,9 @@ test('creates a snapshot summary after an update', () => {
   };
 
   expect(
-    getSnapshotSummary(snapshots, globalConfig, UPDATE_COMMAND),
+    getSnapshotSummary(snapshots, globalConfig, UPDATE_COMMAND)
+      .join('\n')
+      .replace(/\\/g, '/'),
   ).toMatchSnapshot();
 });
 
@@ -89,7 +93,9 @@ it('creates a snapshot summary with multiple snapshot being written/updated', ()
   };
 
   expect(
-    getSnapshotSummary(snapshots, globalConfig, UPDATE_COMMAND),
+    getSnapshotSummary(snapshots, globalConfig, UPDATE_COMMAND)
+      .join('\n')
+      .replace(/\\/g, '/'),
   ).toMatchSnapshot();
 });
 
@@ -107,6 +113,6 @@ it('returns nothing if there are no updates', () => {
     updated: 0,
   };
   expect(
-    getSnapshotSummary(snapshots, globalConfig, UPDATE_COMMAND),
+    getSnapshotSummary(snapshots, globalConfig, UPDATE_COMMAND).join('\n'),
   ).toMatchSnapshot();
 });

--- a/packages/jest-cli/src/reporters/__tests__/summary_reporter.test.js
+++ b/packages/jest-cli/src/reporters/__tests__/summary_reporter.test.js
@@ -110,7 +110,7 @@ test('snapshots all have results (no update)', () => {
 
   const testReporter = new SummaryReporter(globalConfig);
   testReporter.onRunComplete(new Set(), aggregatedResults);
-  expect(results.join('')).toMatchSnapshot();
+  expect(results.join('').replace(/\\/g, '/')).toMatchSnapshot();
 });
 
 test('snapshots all have results (after update)', () => {
@@ -145,7 +145,7 @@ test('snapshots all have results (after update)', () => {
 
   const testReporter = new SummaryReporter(globalConfig);
   testReporter.onRunComplete(new Set(), aggregatedResults);
-  expect(results.join('')).toMatchSnapshot();
+  expect(results.join('').replace(/\\/g, '/')).toMatchSnapshot();
 });
 
 // TODO: add obsolete snapshots and files

--- a/packages/jest-cli/src/reporters/__tests__/summary_reporter.test.js
+++ b/packages/jest-cli/src/reporters/__tests__/summary_reporter.test.js
@@ -12,21 +12,8 @@ const env = Object.assign({}, process.env);
 const now = Date.now;
 const write = process.stderr.write;
 const globalConfig = {
+  rootDir: 'root',
   watch: false,
-};
-const aggregatedResults = {
-  numFailedTestSuites: 1,
-  numFailedTests: 1,
-  numPassedTestSuites: 0,
-  numTotalTestSuites: 1,
-  numTotalTests: 1,
-  snapshot: {
-    filesUnmatched: 1,
-    total: 2,
-    unmatched: 2,
-  },
-  startTime: 0,
-  testResults: {},
 };
 
 let results = [];
@@ -46,6 +33,22 @@ afterEach(() => {
 });
 
 test('snapshots needs update with npm test', () => {
+  const aggregatedResults = {
+    numFailedTestSuites: 1,
+    numFailedTests: 1,
+    numPassedTestSuites: 0,
+    numTotalTestSuites: 1,
+    numTotalTests: 1,
+    snapshot: {
+      filesUnmatched: 1,
+      total: 2,
+      uncheckedKeysByFile: [],
+      unmatched: 2,
+    },
+    startTime: 0,
+    testResults: {},
+  };
+
   process.env.npm_config_user_agent = 'npm';
   const testReporter = new SummaryReporter(globalConfig);
   testReporter.onRunComplete(new Set(), aggregatedResults);
@@ -53,8 +56,97 @@ test('snapshots needs update with npm test', () => {
 });
 
 test('snapshots needs update with yarn test', () => {
+  const aggregatedResults = {
+    numFailedTestSuites: 1,
+    numFailedTests: 1,
+    numPassedTestSuites: 0,
+    numTotalTestSuites: 1,
+    numTotalTests: 1,
+    snapshot: {
+      filesUnmatched: 1,
+      total: 2,
+      uncheckedKeysByFile: [],
+      unmatched: 2,
+    },
+    startTime: 0,
+    testResults: {},
+  };
+
   process.env.npm_config_user_agent = 'yarn';
   const testReporter = new SummaryReporter(globalConfig);
   testReporter.onRunComplete(new Set(), aggregatedResults);
   expect(results.join('')).toMatchSnapshot();
 });
+
+test('snapshots all have results (no update)', () => {
+  const aggregatedResults = {
+    numFailedTestSuites: 1,
+    numFailedTests: 1,
+    numPassedTestSuites: 0,
+    numTotalTestSuites: 1,
+    numTotalTests: 1,
+    snapshot: {
+      added: 1,
+      didUpdate: false,
+      filesAdded: 1,
+      filesRemoved: 1,
+      filesUnmatched: 1,
+      filesUpdated: 1,
+      matched: 2,
+      total: 2,
+      unchecked: 1,
+      uncheckedKeysByFile: [
+        {
+          filePath: 'path/to/suite_one',
+          keys: ['unchecked snapshot 1'],
+        },
+      ],
+      unmatched: 1,
+      updated: 1,
+    },
+    startTime: 0,
+    testResults: {},
+  };
+
+  const testReporter = new SummaryReporter(globalConfig);
+  testReporter.onRunComplete(new Set(), aggregatedResults);
+  expect(results.join('')).toMatchSnapshot();
+});
+
+test('snapshots all have results (after update)', () => {
+  const aggregatedResults = {
+    numFailedTestSuites: 1,
+    numFailedTests: 1,
+    numPassedTestSuites: 0,
+    numTotalTestSuites: 1,
+    numTotalTests: 1,
+    snapshot: {
+      added: 1,
+      didUpdate: true,
+      filesAdded: 1,
+      filesRemoved: 1,
+      filesUnmatched: 1,
+      filesUpdated: 1,
+      matched: 2,
+      total: 2,
+      unchecked: 1,
+      uncheckedKeysByFile: [
+        {
+          filePath: 'path/to/suite_one',
+          keys: ['unchecked snapshot 1'],
+        },
+      ],
+      unmatched: 1,
+      updated: 1,
+    },
+    startTime: 0,
+    testResults: {},
+  };
+
+  const testReporter = new SummaryReporter(globalConfig);
+  testReporter.onRunComplete(new Set(), aggregatedResults);
+  expect(results.join('')).toMatchSnapshot();
+});
+
+// TODO: add obsolete snapshots and files
+// TODO: add more tests to get_snapshot_summary

--- a/packages/jest-cli/src/reporters/get_snapshot_status.js
+++ b/packages/jest-cli/src/reporters/get_snapshot_status.js
@@ -14,10 +14,11 @@ const chalk = require('chalk');
 const {pluralize} = require('./utils');
 
 const ARROW = ' \u203A ';
+const DOT = ' \u2022 ';
 const FAIL_COLOR = chalk.bold.red;
 const SNAPSHOT_ADDED = chalk.bold.green;
-const SNAPSHOT_REMOVED = chalk.bold.red;
 const SNAPSHOT_UPDATED = chalk.bold.green;
+const SNAPSHOT_OUTDATED = chalk.bold.yellow;
 
 export default (
   snapshot: $PropertyType<TestResult, 'snapshot'>,
@@ -27,41 +28,51 @@ export default (
 
   if (snapshot.added) {
     statuses.push(
-      SNAPSHOT_ADDED(ARROW + pluralize('snapshot', snapshot.added)) +
-        ' written.',
+      SNAPSHOT_ADDED(
+        ARROW + pluralize('snapshot', snapshot.added) + ' written.',
+      ),
     );
   }
 
   if (snapshot.updated) {
     statuses.push(
-      SNAPSHOT_UPDATED(ARROW + pluralize('snapshot', snapshot.updated)) +
-        ` updated.`,
-    );
-  }
-
-  if (snapshot.unchecked) {
-    statuses.push(
-      FAIL_COLOR(ARROW + pluralize('obsolete snapshot', snapshot.unchecked)) +
-        (afterUpdate ? ' removed' : ' found') +
-        '.',
-    );
-
-    snapshot.uncheckedKeys.forEach(key => {
-      statuses.push(FAIL_COLOR(`  - ${key}`));
-    });
-  }
-
-  if (snapshot.fileDeleted) {
-    statuses.push(
-      SNAPSHOT_REMOVED(ARROW + 'Obsolete snapshot file') + ` removed.`,
+      SNAPSHOT_UPDATED(
+        ARROW + pluralize('snapshot', snapshot.updated) + ' updated.',
+      ),
     );
   }
 
   if (snapshot.unmatched) {
     statuses.push(
-      FAIL_COLOR(ARROW + pluralize('snapshot test', snapshot.unmatched)) +
-        ' failed.',
+      FAIL_COLOR(
+        ARROW + pluralize('snapshot', snapshot.unmatched) + ' failed.',
+      ),
     );
   }
+
+  if (snapshot.unchecked) {
+    if (afterUpdate) {
+      statuses.push(
+        SNAPSHOT_UPDATED(
+          ARROW + pluralize('snapshot', snapshot.unchecked) + ' removed.',
+        ),
+      );
+    } else {
+      statuses.push(
+        SNAPSHOT_OUTDATED(
+          ARROW + pluralize('snapshot', snapshot.unchecked) + ' obsolete',
+        ) + '.',
+      );
+    }
+
+    snapshot.uncheckedKeys.forEach(key => {
+      statuses.push(`  ${DOT}${key}`);
+    });
+  }
+
+  if (snapshot.fileDeleted) {
+    statuses.push(SNAPSHOT_UPDATED(ARROW + 'snapshot file removed.'));
+  }
+
   return statuses;
 };

--- a/packages/jest-cli/src/reporters/get_snapshot_summary.js
+++ b/packages/jest-cli/src/reporters/get_snapshot_summary.js
@@ -8,36 +8,43 @@
  */
 
 import type {SnapshotSummary} from 'types/TestResult';
+import type {GlobalConfig} from 'types/Config';
 
 import chalk from 'chalk';
-import {pluralize} from './utils';
+import {formatTestPath, pluralize} from './utils';
 
 const ARROW = ' \u203A ';
+const DOWN_ARROW = ' \u21B3 ';
+const DOT = ' \u2022 ';
 const FAIL_COLOR = chalk.bold.red;
+const OBSOLETE_COLOR = chalk.bold.yellow;
 const SNAPSHOT_ADDED = chalk.bold.green;
 const SNAPSHOT_NOTE = chalk.dim;
-const SNAPSHOT_REMOVED = chalk.bold.red;
+const SNAPSHOT_REMOVED = chalk.bold.green;
 const SNAPSHOT_SUMMARY = chalk.bold;
 const SNAPSHOT_UPDATED = chalk.bold.green;
 
 export default (
   snapshots: SnapshotSummary,
+  globalConfig: GlobalConfig,
   updateCommand: string,
 ): Array<string> => {
   const summary = [];
   summary.push(SNAPSHOT_SUMMARY('Snapshot Summary'));
   if (snapshots.added) {
     summary.push(
-      SNAPSHOT_ADDED(ARROW + pluralize('snapshot', snapshots.added)) +
-        ` written in ${pluralize('test suite', snapshots.filesAdded)}.`,
+      SNAPSHOT_ADDED(
+        ARROW + pluralize('snapshot', snapshots.added) + ' written ',
+      ) + `from ${pluralize('test suite', snapshots.filesAdded)}.`,
     );
   }
 
   if (snapshots.unmatched) {
     summary.push(
-      FAIL_COLOR(ARROW + pluralize('snapshot test', snapshots.unmatched)) +
-        ` failed in ` +
-        `${pluralize('test suite', snapshots.filesUnmatched)}. ` +
+      FAIL_COLOR(
+        `${ARROW}${pluralize('snapshot', snapshots.unmatched)} failed`,
+      ) +
+        ` from ${pluralize('test suite', snapshots.filesUnmatched)}. ` +
         SNAPSHOT_NOTE(
           'Inspect your code changes or ' + updateCommand + ' to update them.',
         ),
@@ -46,37 +53,80 @@ export default (
 
   if (snapshots.updated) {
     summary.push(
-      SNAPSHOT_UPDATED(ARROW + pluralize('snapshot', snapshots.updated)) +
-        ` updated in ${pluralize('test suite', snapshots.filesUpdated)}.`,
+      SNAPSHOT_UPDATED(
+        ARROW + pluralize('snapshot', snapshots.updated) + ' updated ',
+      ) + `from ${pluralize('test suite', snapshots.filesUpdated)}.`,
     );
   }
 
   if (snapshots.filesRemoved) {
-    summary.push(
-      SNAPSHOT_REMOVED(
-        ARROW + pluralize('obsolete snapshot file', snapshots.filesRemoved),
-      ) +
-        (snapshots.didUpdate
-          ? ' removed.'
-          : ' found, ' +
-            updateCommand +
-            ' to remove ' +
-            (snapshots.filesRemoved === 1 ? 'it' : 'them.') +
-            '.'),
-    );
+    if (snapshots.didUpdate) {
+      summary.push(
+        SNAPSHOT_REMOVED(
+          `${ARROW}${pluralize(
+            'snapshot file',
+            snapshots.filesRemoved,
+          )} removed `,
+        ) + `from ${pluralize('test suite', snapshots.filesRemoved)}.`,
+      );
+    } else {
+      summary.push(
+        OBSOLETE_COLOR(
+          `${ARROW}${pluralize(
+            'snapshot file',
+            snapshots.filesRemoved,
+          )} obsolete `,
+        ) +
+          `from ${pluralize('test suite', snapshots.filesRemoved)}. ` +
+          SNAPSHOT_NOTE(
+            `To remove ${
+              snapshots.filesRemoved === 1 ? 'it' : 'them all'
+            }, ${updateCommand}.`,
+          ),
+      );
+    }
   }
 
   if (snapshots.unchecked) {
-    summary.push(
-      FAIL_COLOR(ARROW + pluralize('obsolete snapshot', snapshots.unchecked)) +
-        (snapshots.didUpdate
-          ? ' removed.'
-          : ' found, ' +
-            updateCommand +
-            ' to remove ' +
-            (snapshots.filesRemoved === 1 ? 'it' : 'them') +
-            '.'),
-    );
+    if (snapshots.didUpdate) {
+      summary.push(
+        SNAPSHOT_REMOVED(
+          `${ARROW}${pluralize('snapshot', snapshots.unchecked)} removed `,
+        ) +
+          `from ${pluralize(
+            'test suite',
+            snapshots.uncheckedKeysByFile.length,
+          )}.`,
+      );
+    } else {
+      summary.push(
+        OBSOLETE_COLOR(
+          `${ARROW}${pluralize('snapshot', snapshots.unchecked)} obsolete `,
+        ) +
+          `from ${pluralize(
+            'test suite',
+            snapshots.uncheckedKeysByFile.length,
+          )}. ` +
+          SNAPSHOT_NOTE(
+            `To remove ${
+              snapshots.unchecked === 1 ? 'it' : 'them all'
+            }, ${updateCommand}.`,
+          ),
+      );
+    }
+
+    snapshots.uncheckedKeysByFile.forEach(uncheckedFile => {
+      summary.push(
+        `  ${DOWN_ARROW}${formatTestPath(
+          globalConfig,
+          uncheckedFile.filePath,
+        )}`,
+      );
+
+      uncheckedFile.keys.forEach(key => {
+        summary.push(`      ${DOT}${key}`);
+      });
+    });
   }
 
   return summary;

--- a/packages/jest-cli/src/reporters/summary_reporter.js
+++ b/packages/jest-cli/src/reporters/summary_reporter.js
@@ -149,7 +149,11 @@ export default class SummaryReporter extends BaseReporter {
         updateCommand = 're-run jest with `-u`';
       }
 
-      const snapshotSummary = getSnapshotSummary(snapshots, updateCommand);
+      const snapshotSummary = getSnapshotSummary(
+        snapshots,
+        globalConfig,
+        updateCommand,
+      );
       snapshotSummary.forEach(this.log);
 
       this.log(''); // print empty line

--- a/packages/jest-cli/src/reporters/utils.js
+++ b/packages/jest-cli/src/reporters/utils.js
@@ -108,6 +108,9 @@ export const getSummary = (
   const snapshotResults = aggregatedResults.snapshot;
   const snapshotsAdded = snapshotResults.added;
   const snapshotsFailed = snapshotResults.unmatched;
+  const snapshotsOutdated = snapshotResults.unchecked;
+  const snapshotsFilesRemoved = snapshotResults.filesRemoved;
+  const snapshotsDidUpdate = snapshotResults.didUpdate;
   const snapshotsPassed = snapshotResults.matched;
   const snapshotsTotal = snapshotResults.total;
   const snapshotsUpdated = snapshotResults.updated;
@@ -146,10 +149,28 @@ export const getSummary = (
     (snapshotsFailed
       ? chalk.bold.red(`${snapshotsFailed} failed`) + ', '
       : '') +
+    (snapshotsOutdated && !snapshotsDidUpdate
+      ? chalk.bold.yellow(`${snapshotsOutdated} obsolete`) + ', '
+      : '') +
+    (snapshotsOutdated && snapshotsDidUpdate
+      ? chalk.bold.green(`${snapshotsOutdated} removed`) + ', '
+      : '') +
+    (snapshotsFilesRemoved && !snapshotsDidUpdate
+      ? chalk.bold.yellow(
+          pluralize('file', snapshotsFilesRemoved) + ' obsolete',
+        ) + ', '
+      : '') +
+    (snapshotsFilesRemoved && snapshotsDidUpdate
+      ? chalk.bold.green(
+          pluralize('file', snapshotsFilesRemoved) + ' removed',
+        ) + ', '
+      : '') +
     (snapshotsUpdated
       ? chalk.bold.green(`${snapshotsUpdated} updated`) + ', '
       : '') +
-    (snapshotsAdded ? chalk.bold.green(`${snapshotsAdded} added`) + ', ' : '') +
+    (snapshotsAdded
+      ? chalk.bold.green(`${snapshotsAdded} written`) + ', '
+      : '') +
     (snapshotsPassed
       ? chalk.bold.green(`${snapshotsPassed} passed`) + ', '
       : '') +

--- a/packages/jest-cli/src/test_result_helpers.js
+++ b/packages/jest-cli/src/test_result_helpers.js
@@ -37,7 +37,7 @@ export const makeEmptyAggregatedTestResult = (): AggregatedResult => {
       matched: 0,
       total: 0,
       unchecked: 0,
-      uncheckedKeys: [],
+      uncheckedKeysByFile: [],
       unmatched: 0,
       updated: 0,
     },
@@ -71,7 +71,7 @@ export const buildFailureTestResult = (
       fileDeleted: false,
       matched: 0,
       unchecked: 0,
-      uncheckedKeys: [],
+      uncheckedKeysByFile: [],
       unmatched: 0,
       updated: 0,
     },
@@ -125,7 +125,16 @@ export const addResult = (
   aggregatedResults.snapshot.added += testResult.snapshot.added;
   aggregatedResults.snapshot.matched += testResult.snapshot.matched;
   aggregatedResults.snapshot.unchecked += testResult.snapshot.unchecked;
-  aggregatedResults.snapshot.uncheckedKeys = testResult.snapshot.uncheckedKeys;
+  if (
+    testResult.snapshot.uncheckedKeys &&
+    testResult.snapshot.uncheckedKeys.length > 0
+  ) {
+    aggregatedResults.snapshot.uncheckedKeysByFile.push({
+      filePath: testResult.testFilePath,
+      keys: testResult.snapshot.uncheckedKeys,
+    });
+  }
+
   aggregatedResults.snapshot.unmatched += testResult.snapshot.unmatched;
   aggregatedResults.snapshot.updated += testResult.snapshot.updated;
   aggregatedResults.snapshot.total +=

--- a/packages/jest-cli/src/test_result_helpers.js
+++ b/packages/jest-cli/src/test_result_helpers.js
@@ -71,7 +71,7 @@ export const buildFailureTestResult = (
       fileDeleted: false,
       matched: 0,
       unchecked: 0,
-      uncheckedKeysByFile: [],
+      uncheckedKeys: [],
       unmatched: 0,
       updated: 0,
     },

--- a/types/TestResult.js
+++ b/types/TestResult.js
@@ -207,6 +207,11 @@ export type CodeCoverageFormatter = (
   reporter?: CodeCoverageReporter,
 ) => ?Object;
 
+export type UncheckedSnapshot = {|
+  filePath: string,
+  keys: Array<string>,
+|};
+
 export type SnapshotSummary = {|
   added: number,
   didUpdate: boolean,
@@ -218,7 +223,7 @@ export type SnapshotSummary = {|
   matched: number,
   total: number,
   unchecked: number,
-  uncheckedKeys: Array<string>,
+  uncheckedKeysByFile: Array<UncheckedSnapshot>,
   unmatched: number,
   updated: number,
 |};


### PR DESCRIPTION
## Summary

This PR makes a number of improvements to the snapshot and test summary outputs, including:

- Printing obsolete test files and names (closes https://github.com/facebook/jest/issues/6074)
- Makes the language for "added" vs "written" more consistent 
- Makes the syntax consistent for "x snapshots (failed|written|obsolete)"
- Makes ordering consistent for in-test summaries and end of test summaries
- Fixes the update notes so they have consistent language and dimming
- Adds obsolete snapshot and file information to the Test Summary
- Switches "obsolete" information to yellow
- Switches "removed" information to green to match "updated"

## Test plan

Updated and added unit and integration tests

## Screenshots
For all of these, the left is 22.4 and the right is this PR

#### Adding a snapshot
![](https://d3vv6lp55qjaqc.cloudfront.net/items/0r0i0D1X2T1e0y1a3B45/Image%202018-05-13%20at%205.15.31%20PM.png)

#### 2 obsolete snapshots in 2 suites
![](https://d3vv6lp55qjaqc.cloudfront.net/items/1J3v13231Q3b3e0C1n0s/Image%202018-05-13%20at%205.16.37%20PM.png)

#### Removing obsolete snapshots
![](https://d3vv6lp55qjaqc.cloudfront.net/items/2X1Z0l1P1G3s2c291x2Q/Image%202018-05-13%20at%205.17.13%20PM.png)

#### Renaming a test file
![](https://d3vv6lp55qjaqc.cloudfront.net/items/2h3K271S0K1t1k190j2v/Image%202018-05-13%20at%205.18.48%20PM.png)

#### Removing obsolete file
![](https://d3vv6lp55qjaqc.cloudfront.net/items/2231060H3r0803210V2f/Image%202018-05-13%20at%205.18.57%20PM.png)

#### Mix of all three: failure, written, and obsolete
![](https://d3vv6lp55qjaqc.cloudfront.net/items/3Z2L1w3m0m0W0p1H372D/Screen%20Recording%202018-05-13%20at%2005.24%20PM.gif)
