### PR TITLE
fix the #6167 - F key misleading message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,7 +90,8 @@
   ([#5879](https://github.com/facebook/jest/pull/5879))
 
 ### Fixes
-* `[jest-cli]` Fix misleading action description for F key when in "only failed 
+
+* `[jest-cli]` Fix misleading action description for F key when in "only failed
   tests" mode. ([#6167](https://github.com/facebook/jest/issues/6167))
 * `[jest-worker]` Stick calls to workers before processing them
   ([#6073](https://github.com/facebook/jest/pull/6073))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,7 +90,7 @@
   ([#5879](https://github.com/facebook/jest/pull/5879))
 
 ### Fixes
-
+* `[jest-cli]` Fix misleading action description for F key when in "only failed tests" mode. ([#6167](https://github.com/facebook/jest/issues/6167))
 * `[jest-worker]` Stick calls to workers before processing them
   ([#6073](https://github.com/facebook/jest/pull/6073))
 * `[babel-plugin-jest-hoist]` Allow using `console` global variable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,7 +90,8 @@
   ([#5879](https://github.com/facebook/jest/pull/5879))
 
 ### Fixes
-* `[jest-cli]` Fix misleading action description for F key when in "only failed tests" mode. ([#6167](https://github.com/facebook/jest/issues/6167))
+* `[jest-cli]` Fix misleading action description for F key when in "only failed 
+  tests" mode. ([#6167](https://github.com/facebook/jest/issues/6167))
 * `[jest-worker]` Stick calls to workers before processing them
   ([#6073](https://github.com/facebook/jest/pull/6073))
 * `[babel-plugin-jest-hoist]` Allow using `console` global variable

--- a/packages/jest-cli/src/__tests__/watch.test.js
+++ b/packages/jest-cli/src/__tests__/watch.test.js
@@ -645,6 +645,23 @@ describe('Watch mode flows', () => {
       globalConfig,
     });
   });
+
+  it('shows the correct usage for the f key in "only failed tests" mode', () => {
+    jest.unmock('jest-util');
+    const util = require('jest-util');
+    util.isInteractive = true;
+
+    const ci_watch = require('../watch').default;
+    ci_watch(globalConfig, contexts, pipe, hasteMapInstances, stdin);
+
+    stdin.emit(KEYS.F);
+    stdin.emit(KEYS.W);
+    const lastWatchDisplay = pipe.write.mock.calls.reverse()[0][0];
+    expect(lastWatchDisplay).toMatch('Press a to run all tests.');
+    expect(lastWatchDisplay).toMatch(
+      'Press f to quit "only failed tests" mode',
+    );
+  });
 });
 
 class MockStdin {

--- a/packages/jest-cli/src/__tests__/watch.test.js
+++ b/packages/jest-cli/src/__tests__/watch.test.js
@@ -650,12 +650,12 @@ describe('Watch mode flows', () => {
     jest.unmock('jest-util');
     const util = require('jest-util');
     util.isInteractive = true;
-
     const ci_watch = require('../watch').default;
     ci_watch(globalConfig, contexts, pipe, hasteMapInstances, stdin);
 
     stdin.emit(KEYS.F);
     stdin.emit(KEYS.W);
+
     const lastWatchDisplay = pipe.write.mock.calls.reverse()[0][0];
     expect(lastWatchDisplay).toMatch('Press a to run all tests.');
     expect(lastWatchDisplay).toMatch(

--- a/packages/jest-cli/src/get_no_test_found_failed.js
+++ b/packages/jest-cli/src/get_no_test_found_failed.js
@@ -3,6 +3,6 @@ import chalk from 'chalk';
 export default function getNoTestFoundFailed() {
   return (
     chalk.bold('No failed test found.\n') +
-    chalk.dim('Press `f` to run all tests.')
+    chalk.dim('Press `f` to quit "only failed tests" mode.')
   );
 }

--- a/packages/jest-cli/src/watch.js
+++ b/packages/jest-cli/src/watch.js
@@ -385,7 +385,9 @@ const usage = (
       : null,
 
     globalConfig.onlyFailures
-      ? chalk.dim(' \u203A Press ') + 'f' + chalk.dim(' to run all tests.')
+      ? chalk.dim(' \u203A Press ') +
+        'f' +
+        chalk.dim(' to quit "only failed tests" mode.')
       : chalk.dim(' \u203A Press ') +
         'f' +
         chalk.dim(' to run only failed tests.'),


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary
Fixes #6167 

Changed the 
"Press `f` to run all tests. " to "Press f to quit "only failed tests" mode" when inside only failed tests mode.

## Test plan

Scenario is covered by the "shows the correct usage for the f key in "only failed tests" mode". 
Also:

![screen shot 2018-05-14 at 12 25 43](https://user-images.githubusercontent.com/4002543/39986172-f92d612e-5771-11e8-9b6e-db384a648597.png)

And
![screen shot 2018-05-14 at 12 26 16](https://user-images.githubusercontent.com/4002543/39986193-03bc4ca4-5772-11e8-890a-a50b2575d28b.png)

