### PR TITLE
Allow custom environments to have core (builtin) modules

### DIFF
--- a/packages/jest-runtime/src/index.js
+++ b/packages/jest-runtime/src/index.js
@@ -268,6 +268,16 @@ class Runtime {
     return cliOptions;
   }
 
+  // Core modules are the either native or builtin modules that should not
+  // be transformed/cached.
+  isCoreModule(moduleName: string) {
+    return (
+      (this._environment.isCoreModule &&
+        this._environment.isCoreModule(moduleName)) ||
+      this._resolver.isCoreModule(moduleName)
+    );
+  }
+
   requireModule(
     from: Path,
     moduleName?: string,
@@ -300,7 +310,7 @@ class Runtime {
       modulePath = manualMock;
     }
 
-    if (moduleName && this._resolver.isCoreModule(moduleName)) {
+    if (moduleName && this.isCoreModule(moduleName)) {
       return this._requireCoreModule(moduleName);
     }
 
@@ -661,7 +671,7 @@ class Runtime {
 
     if (
       !this._shouldAutoMock ||
-      this._resolver.isCoreModule(moduleName) ||
+      this.isCoreModule(moduleName) ||
       this._shouldUnmockTransitiveDependenciesCache[key]
     ) {
       return false;

--- a/types/Environment.js
+++ b/types/Environment.js
@@ -31,6 +31,7 @@ declare class $JestEnvironment {
     useFakeTimers(): void,
     useRealTimers(): void,
   };
+  isCoreModule(moduleName: string): boolean;
   testFilePath: string;
   moduleMocker: ModuleMocker;
   setup(): Promise<void>;


### PR DESCRIPTION
We already have a concept of builtin modules (that come from `require('Module').builtinModules`) that bypass all jest transforming/caching mechanism.

This PR introduces the same concept to our `Environment` object.

The use case i have is  testing `electron` apps, where you have an additional list of modules (like `require('electron')`) that are available, but they're resolved differently (usually using [asar](https://github.com/electron/asar) packages). Which means you can require them in a raw process, but requiring them from within a Jest tests will break things.

I didn't use `ProjectConfig` for this, because i wanted to avoid having to configure too many things. And since this is probably only relevant when you already have a custom environment, it's easier to have everything in the environment definition