### PR TITLE
include custom mock names in error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,8 @@
   ([#5879](https://github.com/facebook/jest/pull/5879))
 * `[jest-cli]` Improve snapshot summaries
   ([#6181](https://github.com/facebook/jest/pull/6181))
+* `[expect]` Include custom mock names in error messages
+  ([#6199](https://github.com/facebook/jest/pull/6199))
 
 ### Fixes
 

--- a/packages/expect/src/__tests__/__snapshots__/spy_matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/spy_matchers.test.js.snap
@@ -128,7 +128,7 @@ Expected mock function to have been last called with:
 exports[`lastReturnedWith includes the custom mock name in the error message 1`] = `
 "<dim>expect(</><red>named-mock</><dim>).lastReturnedWith(</><green>expected</><dim>)</>
 
-Expected mock function to have last returned:
+Expected mock function \\"named-mock\\" to have last returned:
   <green>\\"foo\\"</>
 But it did <red>not return</>"
 `;
@@ -1354,7 +1354,7 @@ Expected mock function first call to have been called with:
 exports[`toHaveLastReturnedWith includes the custom mock name in the error message 1`] = `
 "<dim>expect(</><red>named-mock</><dim>).toHaveLastReturnedWith(</><green>expected</><dim>)</>
 
-Expected mock function to have last returned:
+Expected mock function \\"named-mock\\" to have last returned:
   <green>\\"foo\\"</>
 But it did <red>not return</>"
 `;

--- a/packages/expect/src/__tests__/__snapshots__/spy_matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/spy_matchers.test.js.snap
@@ -224,7 +224,7 @@ But it last returned:
 exports[`nthCalledWith includes the custom mock name in the error message 1`] = `
 "<dim>expect(</><red>named-mock</><dim>).not.nthCalledWith(</><green>expected</><dim>)</>
 
-Expected mock function first call to not have been called with:
+Expected mock function \\"named-mock\\" first call to not have been called with:
   <green>[\\"foo\\", \\"bar\\"]</>"
 `;
 
@@ -1220,7 +1220,7 @@ Expected mock function to have been last called with:
 exports[`toHaveBeenNthCalledWith includes the custom mock name in the error message 1`] = `
 "<dim>expect(</><red>named-mock</><dim>).not.toHaveBeenNthCalledWith(</><green>expected</><dim>)</>
 
-Expected mock function first call to not have been called with:
+Expected mock function \\"named-mock\\" first call to not have been called with:
   <green>[\\"foo\\", \\"bar\\"]</>"
 `;
 

--- a/packages/expect/src/__tests__/__snapshots__/spy_matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/spy_matchers.test.js.snap
@@ -493,7 +493,7 @@ Got:
 exports[`toBeCalled includes the custom mock name in the error message 1`] = `
 "<dim>expect(</><red>named-mock</><dim>).not.toBeCalled(</><dim>)</>
 
-Expected mock function not to be called but it was called with:
+Expected mock function \\"named-mock\\" not to be called but it was called with:
   <red>[]</>"
 `;
 
@@ -791,7 +791,7 @@ Got:
 exports[`toHaveBeenCalled includes the custom mock name in the error message 1`] = `
 "<dim>expect(</><red>named-mock</><dim>).not.toHaveBeenCalled(</><dim>)</>
 
-Expected mock function not to be called but it was called with:
+Expected mock function \\"named-mock\\" not to be called but it was called with:
   <red>[]</>"
 `;
 

--- a/packages/expect/src/__tests__/__snapshots__/spy_matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/spy_matchers.test.js.snap
@@ -1555,11 +1555,10 @@ Got:
 `;
 
 exports[`toHaveReturned includes the custom mock name in the error message 1`] = `
-"<dim>expect(</><red>received</><dim>)[.not].toHaveReturned(</><dim>)</>
+"<dim>expect(</><red>named-mock</><dim>).not.toHaveReturned(</><dim>)</>
 
-Matcher does not accept any arguments.
-Got:
-  number: <green>555</>"
+Expected mock function not to have returned, but it returned:
+  <red>42</>"
 `;
 
 exports[`toHaveReturned passes when returned 1`] = `
@@ -1843,11 +1842,10 @@ Got:
 `;
 
 exports[`toReturn includes the custom mock name in the error message 1`] = `
-"<dim>expect(</><red>received</><dim>)[.not].toReturn(</><dim>)</>
+"<dim>expect(</><red>named-mock</><dim>).not.toReturn(</><dim>)</>
 
-Matcher does not accept any arguments.
-Got:
-  number: <green>555</>"
+Expected mock function not to have returned, but it returned:
+  <red>42</>"
 `;
 
 exports[`toReturn passes when returned 1`] = `

--- a/packages/expect/src/__tests__/__snapshots__/spy_matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/spy_matchers.test.js.snap
@@ -3,7 +3,7 @@
 exports[`lastCalledWith includes the custom mock name in the error message 1`] = `
 "<dim>expect(</><red>named-mock</><dim>).not.lastCalledWith(</><green>expected</><dim>)</>
 
-Expected mock function to not have been last called with:
+Expected mock function \\"named-mock\\" to not have been last called with:
   <green>[\\"foo\\", \\"bar\\"]</>"
 `;
 
@@ -1095,7 +1095,7 @@ Expected mock function to have been called with:
 exports[`toHaveBeenLastCalledWith includes the custom mock name in the error message 1`] = `
 "<dim>expect(</><red>named-mock</><dim>).not.toHaveBeenLastCalledWith(</><green>expected</><dim>)</>
 
-Expected mock function to not have been last called with:
+Expected mock function \\"named-mock\\" to not have been last called with:
   <green>[\\"foo\\", \\"bar\\"]</>"
 `;
 

--- a/packages/expect/src/__tests__/__snapshots__/spy_matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/spy_matchers.test.js.snap
@@ -358,7 +358,7 @@ Expected mock function first call to have been called with:
 exports[`nthReturnedWith includes the custom mock name in the error message 1`] = `
 "<dim>expect(</><red>named-mock</><dim>).nthReturnedWith(</><green>expected</><dim>)</>
 
-Expected mock function first call to have returned with:
+Expected mock function \\"named-mock\\" first call to have returned with:
   <green>\\"foo\\"</>
 But it did <red>not return</>"
 `;
@@ -1450,7 +1450,7 @@ But it last returned:
 exports[`toHaveNthReturnedWith includes the custom mock name in the error message 1`] = `
 "<dim>expect(</><red>named-mock</><dim>).toHaveNthReturnedWith(</><green>expected</><dim>)</>
 
-Expected mock function first call to have returned with:
+Expected mock function \\"named-mock\\" first call to have returned with:
   <green>\\"foo\\"</>
 But it did <red>not return</>"
 `;

--- a/packages/expect/src/__tests__/__snapshots__/spy_matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/spy_matchers.test.js.snap
@@ -575,7 +575,7 @@ Expected mock function to have been called <green>two times</>, but it was calle
 exports[`toBeCalledTimes includes the custom mock name in the error message 1`] = `
 "<dim>expect(</><red>named-mock</><dim>).toBeCalledTimes(</><green>2</><dim>)</>
 
-Expected mock function to have been called <green>two times</>, but it was called <red>one time</>."
+Expected mock function \\"named-mock\\" to have been called <green>two times</>, but it was called <red>one time</>."
 `;
 
 exports[`toBeCalledTimes only accepts a number argument 1`] = `
@@ -873,7 +873,7 @@ Expected mock function to have been called <green>two times</>, but it was calle
 exports[`toHaveBeenCalledTimes includes the custom mock name in the error message 1`] = `
 "<dim>expect(</><red>named-mock</><dim>).toHaveBeenCalledTimes(</><green>2</><dim>)</>
 
-Expected mock function to have been called <green>two times</>, but it was called <red>one time</>."
+Expected mock function \\"named-mock\\" to have been called <green>two times</>, but it was called <red>one time</>."
 `;
 
 exports[`toHaveBeenCalledTimes only accepts a number argument 1`] = `
@@ -1557,7 +1557,7 @@ Got:
 exports[`toHaveReturned includes the custom mock name in the error message 1`] = `
 "<dim>expect(</><red>named-mock</><dim>).not.toHaveReturned(</><dim>)</>
 
-Expected mock function not to have returned, but it returned:
+Expected mock function \\"named-mock\\" not to have returned, but it returned:
   <red>42</>"
 `;
 
@@ -1844,7 +1844,7 @@ Got:
 exports[`toReturn includes the custom mock name in the error message 1`] = `
 "<dim>expect(</><red>named-mock</><dim>).not.toReturn(</><dim>)</>
 
-Expected mock function not to have returned, but it returned:
+Expected mock function \\"named-mock\\" not to have returned, but it returned:
   <red>42</>"
 `;
 

--- a/packages/expect/src/__tests__/__snapshots__/spy_matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/spy_matchers.test.js.snap
@@ -1,5 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`lastCalledWith includes the custom mock name in the error message 1`] = `
+"<dim>expect(</><red>named-mock</><dim>).not.lastCalledWith(</><green>expected</><dim>)</>
+
+Expected mock function to not have been last called with:
+  <green>[\\"foo\\", \\"bar\\"]</>"
+`;
+
 exports[`lastCalledWith works only on spies or jest.fn 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>)[.not].lastCalledWith(</><dim>)</>
 
@@ -212,6 +219,13 @@ Expected mock function to have last returned:
   <green>\\"bar\\"</>
 But it last returned:
   <red>\\"foo\\"</>"
+`;
+
+exports[`nthCalledWith includes the custom mock name in the error message 1`] = `
+"<dim>expect(</><red>named-mock</><dim>).not.nthCalledWith(</><green>expected</><dim>)</>
+
+Expected mock function first call to not have been called with:
+  <green>[\\"foo\\", \\"bar\\"]</>"
 `;
 
 exports[`nthCalledWith should reject non integer nth value 1`] = `"nth value <red>0.1</> must be a positive integer greater than <green>0</>"`;
@@ -640,6 +654,13 @@ Received:
   function: <red>[Function fn]</>"
 `;
 
+exports[`toBeCalledWith includes the custom mock name in the error message 1`] = `
+"<dim>expect(</><red>named-mock</><dim>).not.toBeCalledWith(</><green>expected</><dim>)</>
+
+Expected mock function \\"named-mock\\" not to have been called with:
+  <green>[\\"foo\\", \\"bar\\"]</>"
+`;
+
 exports[`toBeCalledWith works only on spies or jest.fn 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>)[.not].toBeCalledWith(</><dim>)</>
 
@@ -938,6 +959,13 @@ Received:
   function: <red>[Function fn]</>"
 `;
 
+exports[`toHaveBeenCalledWith includes the custom mock name in the error message 1`] = `
+"<dim>expect(</><red>named-mock</><dim>).not.toHaveBeenCalledWith(</><green>expected</><dim>)</>
+
+Expected mock function \\"named-mock\\" not to have been called with:
+  <green>[\\"foo\\", \\"bar\\"]</>"
+`;
+
 exports[`toHaveBeenCalledWith works only on spies or jest.fn 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>)[.not].toHaveBeenCalledWith(</><dim>)</>
 
@@ -1064,6 +1092,13 @@ Expected mock function to have been called with:
   Did not expect argument 2 but it was called with <red>undefined</>."
 `;
 
+exports[`toHaveBeenLastCalledWith includes the custom mock name in the error message 1`] = `
+"<dim>expect(</><red>named-mock</><dim>).not.toHaveBeenLastCalledWith(</><green>expected</><dim>)</>
+
+Expected mock function to not have been last called with:
+  <green>[\\"foo\\", \\"bar\\"]</>"
+`;
+
 exports[`toHaveBeenLastCalledWith works only on spies or jest.fn 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>)[.not].toHaveBeenLastCalledWith(</><dim>)</>
 
@@ -1180,6 +1215,13 @@ exports[`toHaveBeenLastCalledWith works with trailing undefined arguments 1`] = 
 
 Expected mock function to have been last called with:
   Did not expect argument 2 but it was called with <red>undefined</>."
+`;
+
+exports[`toHaveBeenNthCalledWith includes the custom mock name in the error message 1`] = `
+"<dim>expect(</><red>named-mock</><dim>).not.toHaveBeenNthCalledWith(</><green>expected</><dim>)</>
+
+Expected mock function first call to not have been called with:
+  <green>[\\"foo\\", \\"bar\\"]</>"
 `;
 
 exports[`toHaveBeenNthCalledWith should reject non integer nth value 1`] = `"nth value <red>0.1</> must be a positive integer greater than <green>0</>"`;

--- a/packages/expect/src/__tests__/__snapshots__/spy_matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/spy_matchers.test.js.snap
@@ -118,6 +118,14 @@ Expected mock function to have been last called with:
   Did not expect argument 2 but it was called with <red>undefined</>."
 `;
 
+exports[`lastReturnedWith includes the custom mock name in the error message 1`] = `
+"<dim>expect(</><red>named-mock</><dim>).lastReturnedWith(</><green>expected</><dim>)</>
+
+Expected mock function to have last returned:
+  <green>\\"foo\\"</>
+But it did <red>not return</>"
+`;
+
 exports[`lastReturnedWith works only on spies or jest.fn 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>)[.not].lastReturnedWith(</><dim>)</>
 
@@ -333,6 +341,14 @@ Expected mock function first call to have been called with:
   Did not expect argument 2 but it was called with <red>undefined</>."
 `;
 
+exports[`nthReturnedWith includes the custom mock name in the error message 1`] = `
+"<dim>expect(</><red>named-mock</><dim>).nthReturnedWith(</><green>expected</><dim>)</>
+
+Expected mock function first call to have returned with:
+  <green>\\"foo\\"</>
+But it did <red>not return</>"
+`;
+
 exports[`nthReturnedWith should reject non integer nth value 1`] = `"nth value <red>0.1</> must be a positive integer greater than <green>0</>"`;
 
 exports[`nthReturnedWith should reject nth value smaller than 1 1`] = `"nth value <red>0</> must be a positive integer greater than <green>0</>"`;
@@ -474,6 +490,13 @@ Got:
   number: <green>555</>"
 `;
 
+exports[`toBeCalled includes the custom mock name in the error message 1`] = `
+"<dim>expect(</><red>named-mock</><dim>).not.toBeCalled(</><dim>)</>
+
+Expected mock function not to be called but it was called with:
+  <red>[]</>"
+`;
+
 exports[`toBeCalled passes when called 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).not.toBeCalled(</><dim>)</>
 
@@ -547,6 +570,12 @@ exports[`toBeCalledTimes .not passes if function called more than expected times
 "<dim>expect(</><red>jest.fn()</><dim>).toBeCalledTimes(</><green>2</><dim>)</>
 
 Expected mock function to have been called <green>two times</>, but it was called <red>three times</>."
+`;
+
+exports[`toBeCalledTimes includes the custom mock name in the error message 1`] = `
+"<dim>expect(</><red>named-mock</><dim>).toBeCalledTimes(</><green>2</><dim>)</>
+
+Expected mock function to have been called <green>two times</>, but it was called <red>one time</>."
 `;
 
 exports[`toBeCalledTimes only accepts a number argument 1`] = `
@@ -759,6 +788,13 @@ Got:
   number: <green>555</>"
 `;
 
+exports[`toHaveBeenCalled includes the custom mock name in the error message 1`] = `
+"<dim>expect(</><red>named-mock</><dim>).not.toHaveBeenCalled(</><dim>)</>
+
+Expected mock function not to be called but it was called with:
+  <red>[]</>"
+`;
+
 exports[`toHaveBeenCalled passes when called 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).not.toHaveBeenCalled(</><dim>)</>
 
@@ -832,6 +868,12 @@ exports[`toHaveBeenCalledTimes .not passes if function called more than expected
 "<dim>expect(</><red>jest.fn()</><dim>).toHaveBeenCalledTimes(</><green>2</><dim>)</>
 
 Expected mock function to have been called <green>two times</>, but it was called <red>three times</>."
+`;
+
+exports[`toHaveBeenCalledTimes includes the custom mock name in the error message 1`] = `
+"<dim>expect(</><red>named-mock</><dim>).toHaveBeenCalledTimes(</><green>2</><dim>)</>
+
+Expected mock function to have been called <green>two times</>, but it was called <red>one time</>."
 `;
 
 exports[`toHaveBeenCalledTimes only accepts a number argument 1`] = `
@@ -1267,6 +1309,14 @@ Expected mock function first call to have been called with:
   Did not expect argument 2 but it was called with <red>undefined</>."
 `;
 
+exports[`toHaveLastReturnedWith includes the custom mock name in the error message 1`] = `
+"<dim>expect(</><red>named-mock</><dim>).toHaveLastReturnedWith(</><green>expected</><dim>)</>
+
+Expected mock function to have last returned:
+  <green>\\"foo\\"</>
+But it did <red>not return</>"
+`;
+
 exports[`toHaveLastReturnedWith works only on spies or jest.fn 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>)[.not].toHaveLastReturnedWith(</><dim>)</>
 
@@ -1353,6 +1403,14 @@ Expected mock function to have last returned:
   <green>\\"bar\\"</>
 But it last returned:
   <red>\\"foo\\"</>"
+`;
+
+exports[`toHaveNthReturnedWith includes the custom mock name in the error message 1`] = `
+"<dim>expect(</><red>named-mock</><dim>).toHaveNthReturnedWith(</><green>expected</><dim>)</>
+
+Expected mock function first call to have returned with:
+  <green>\\"foo\\"</>
+But it did <red>not return</>"
 `;
 
 exports[`toHaveNthReturnedWith should reject non integer nth value 1`] = `"nth value <red>0.1</> must be a positive integer greater than <green>0</>"`;
@@ -1496,6 +1554,14 @@ Got:
   number: <green>555</>"
 `;
 
+exports[`toHaveReturned includes the custom mock name in the error message 1`] = `
+"<dim>expect(</><red>received</><dim>)[.not].toHaveReturned(</><dim>)</>
+
+Matcher does not accept any arguments.
+Got:
+  number: <green>555</>"
+`;
+
 exports[`toHaveReturned passes when returned 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).not.toHaveReturned(</><dim>)</>
 
@@ -1571,6 +1637,12 @@ exports[`toHaveReturnedTimes .not passes if function returned more than expected
 Expected mock function to have returned <green>two times</>, but it returned <red>three times</>."
 `;
 
+exports[`toHaveReturnedTimes includes the custom mock name in the error message 1`] = `
+"<dim>expect(</><red>named-mock</><dim>).toHaveReturnedTimes(</><green>1</><dim>)</>
+
+Expected mock function to have returned <green>one time</>, but it returned <red>two times</>."
+`;
+
 exports[`toHaveReturnedTimes only accepts a number argument 1`] = `
 "<dim>expect(</><red>received</><dim>)[.not].toHaveReturnedTimes(</><green>expected</><dim>)</>
 
@@ -1631,6 +1703,14 @@ exports[`toHaveReturnedTimes works only on spies or jest.fn 1`] = `
 <red>jest.fn()</> value must be a mock function or spy.
 Received:
   function: <red>[Function fn]</>"
+`;
+
+exports[`toHaveReturnedWith includes the custom mock name in the error message 1`] = `
+"<dim>expect(</><red>named-mock</><dim>).toHaveReturnedWith(</><green>expected</><dim>)</>
+
+Expected mock function to have returned:
+  <green>\\"foo\\"</>
+But it did <red>not return</>."
 `;
 
 exports[`toHaveReturnedWith works only on spies or jest.fn 1`] = `
@@ -1762,6 +1842,14 @@ Got:
   number: <green>555</>"
 `;
 
+exports[`toReturn includes the custom mock name in the error message 1`] = `
+"<dim>expect(</><red>received</><dim>)[.not].toReturn(</><dim>)</>
+
+Matcher does not accept any arguments.
+Got:
+  number: <green>555</>"
+`;
+
 exports[`toReturn passes when returned 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).not.toReturn(</><dim>)</>
 
@@ -1837,6 +1925,12 @@ exports[`toReturnTimes .not passes if function returned more than expected times
 Expected mock function to have returned <green>two times</>, but it returned <red>three times</>."
 `;
 
+exports[`toReturnTimes includes the custom mock name in the error message 1`] = `
+"<dim>expect(</><red>named-mock</><dim>).toReturnTimes(</><green>1</><dim>)</>
+
+Expected mock function to have returned <green>one time</>, but it returned <red>two times</>."
+`;
+
 exports[`toReturnTimes only accepts a number argument 1`] = `
 "<dim>expect(</><red>received</><dim>)[.not].toReturnTimes(</><green>expected</><dim>)</>
 
@@ -1897,6 +1991,14 @@ exports[`toReturnTimes works only on spies or jest.fn 1`] = `
 <red>jest.fn()</> value must be a mock function or spy.
 Received:
   function: <red>[Function fn]</>"
+`;
+
+exports[`toReturnWith includes the custom mock name in the error message 1`] = `
+"<dim>expect(</><red>named-mock</><dim>).toReturnWith(</><green>expected</><dim>)</>
+
+Expected mock function to have returned:
+  <green>\\"foo\\"</>
+But it did <red>not return</>."
 `;
 
 exports[`toReturnWith works only on spies or jest.fn 1`] = `

--- a/packages/expect/src/__tests__/__snapshots__/spy_matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/spy_matchers.test.js.snap
@@ -1749,7 +1749,7 @@ Received:
 exports[`toHaveReturnedWith includes the custom mock name in the error message 1`] = `
 "<dim>expect(</><red>named-mock</><dim>).toHaveReturnedWith(</><green>expected</><dim>)</>
 
-Expected mock function to have returned:
+Expected mock function \\"named-mock\\" to have returned:
   <green>\\"foo\\"</>
 But it did <red>not return</>."
 `;
@@ -2036,7 +2036,7 @@ Received:
 exports[`toReturnWith includes the custom mock name in the error message 1`] = `
 "<dim>expect(</><red>named-mock</><dim>).toReturnWith(</><green>expected</><dim>)</>
 
-Expected mock function to have returned:
+Expected mock function \\"named-mock\\" to have returned:
   <green>\\"foo\\"</>
 But it did <red>not return</>."
 `;

--- a/packages/expect/src/__tests__/__snapshots__/spy_matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/spy_matchers.test.js.snap
@@ -1639,7 +1639,7 @@ Expected mock function to have returned <green>two times</>, but it returned <re
 exports[`toHaveReturnedTimes includes the custom mock name in the error message 1`] = `
 "<dim>expect(</><red>named-mock</><dim>).toHaveReturnedTimes(</><green>1</><dim>)</>
 
-Expected mock function to have returned <green>one time</>, but it returned <red>two times</>."
+Expected mock function \\"named-mock\\" to have returned <green>one time</>, but it returned <red>two times</>."
 `;
 
 exports[`toHaveReturnedTimes only accepts a number argument 1`] = `
@@ -1926,7 +1926,7 @@ Expected mock function to have returned <green>two times</>, but it returned <re
 exports[`toReturnTimes includes the custom mock name in the error message 1`] = `
 "<dim>expect(</><red>named-mock</><dim>).toReturnTimes(</><green>1</><dim>)</>
 
-Expected mock function to have returned <green>one time</>, but it returned <red>two times</>."
+Expected mock function \\"named-mock\\" to have returned <green>one time</>, but it returned <red>two times</>."
 `;
 
 exports[`toReturnTimes only accepts a number argument 1`] = `

--- a/packages/expect/src/__tests__/spy_matchers.test.js
+++ b/packages/expect/src/__tests__/spy_matchers.test.js
@@ -360,8 +360,13 @@ const jestExpect = require('../');
 
     test(`includes the custom mock name in the error message`, () => {
       const fn = jest.fn().mockName('named-mock');
-      fn();
-      caller(jestExpect(fn)[calledWith]);
+      fn('foo', 'bar');
+
+      caller(jestExpect(fn)[calledWith], 'foo', 'bar');
+
+      expect(() =>
+        caller(jestExpect(fn).not[calledWith], 'foo', 'bar'),
+      ).toThrowErrorMatchingSnapshot();
     });
   });
 });

--- a/packages/expect/src/__tests__/spy_matchers.test.js
+++ b/packages/expect/src/__tests__/spy_matchers.test.js
@@ -408,12 +408,11 @@ const jestExpect = require('../');
     });
 
     test(`includes the custom mock name in the error message`, () => {
-      const fn = jest.fn().mockName('named-mock');
-
+      const fn = jest.fn(() => 42).mockName('named-mock');
       fn();
       jestExpect(fn)[returned]();
       expect(() =>
-        jestExpect(fn)[returned](555),
+        jestExpect(fn).not[returned](),
       ).toThrowErrorMatchingSnapshot();
     });
   });

--- a/packages/expect/src/__tests__/spy_matchers.test.js
+++ b/packages/expect/src/__tests__/spy_matchers.test.js
@@ -45,6 +45,14 @@ const jestExpect = require('../');
         jestExpect(fn).not[called](555),
       ).toThrowErrorMatchingSnapshot();
     });
+
+    test(`includes the custom mock name in the error message`, () => {
+      const fn = jest.fn().mockName('named-mock');
+
+      fn();
+      jestExpect(fn)[called]();
+      expect(() => jestExpect(fn).not[called]()).toThrowErrorMatchingSnapshot();
+    });
   });
 });
 
@@ -113,6 +121,15 @@ const jestExpect = require('../');
 
       jestExpect(fn)[calledTimes](1);
       jestExpect(fn).not[calledTimes](2);
+
+      expect(() =>
+        jestExpect(fn)[calledTimes](2),
+      ).toThrowErrorMatchingSnapshot();
+    });
+
+    test('includes the custom mock name in the error message', () => {
+      const fn = jest.fn().mockName('named-mock');
+      fn();
 
       expect(() =>
         jestExpect(fn)[calledTimes](2),
@@ -340,6 +357,12 @@ const jestExpect = require('../');
         }).toThrowErrorMatchingSnapshot();
       });
     }
+
+    test(`includes the custom mock name in the error message`, () => {
+      const fn = jest.fn().mockName('named-mock');
+      fn();
+      caller(jestExpect(fn)[calledWith]);
+    });
   });
 });
 
@@ -381,6 +404,16 @@ const jestExpect = require('../');
 
       expect(() =>
         jestExpect(fn).not[returned](555),
+      ).toThrowErrorMatchingSnapshot();
+    });
+
+    test(`includes the custom mock name in the error message`, () => {
+      const fn = jest.fn().mockName('named-mock');
+
+      fn();
+      jestExpect(fn)[returned]();
+      expect(() =>
+        jestExpect(fn)[returned](555),
       ).toThrowErrorMatchingSnapshot();
     });
   });
@@ -454,6 +487,18 @@ const jestExpect = require('../');
 
       expect(() =>
         jestExpect(fn)[returnedTimes](2),
+      ).toThrowErrorMatchingSnapshot();
+    });
+
+    test('includes the custom mock name in the error message', () => {
+      const fn = jest.fn(() => 42).mockName('named-mock');
+      fn();
+      fn();
+
+      jestExpect(fn)[returnedTimes](2);
+
+      expect(() =>
+        jestExpect(fn)[returnedTimes](1),
       ).toThrowErrorMatchingSnapshot();
     });
   });
@@ -674,5 +719,14 @@ const jestExpect = require('../');
         }).toThrowErrorMatchingSnapshot();
       });
     }
+
+    test(`includes the custom mock name in the error message`, () => {
+      const fn = jest.fn().mockName('named-mock');
+      caller(jestExpect(fn).not[returnedWith], 'foo');
+
+      expect(() =>
+        caller(jestExpect(fn)[returnedWith], 'foo'),
+      ).toThrowErrorMatchingSnapshot();
+    });
   });
 });

--- a/packages/expect/src/spy_matchers.js
+++ b/packages/expect/src/spy_matchers.js
@@ -122,6 +122,11 @@ const createToReturnTimesMatcher = (matcherName: string) => (
   ensureExpectedIsNumber(expected, matcherName);
   ensureMock(received, matcherName);
 
+  const receivedName = received.getMockName();
+  const identifier = receivedName === 'jest.fn()'
+    ? 'mock function'
+    : `mock function "${receivedName}"`;
+
   const count = received.mock.returnValues.length;
   const pass = count === expected;
 
@@ -133,13 +138,13 @@ const createToReturnTimesMatcher = (matcherName: string) => (
           String(expected),
         ) +
         `\n\n` +
-        `Expected mock function not to have returned ` +
+        `Expected ${identifier} not to have returned ` +
         `${EXPECTED_COLOR(pluralize('time', expected))}, but it` +
         ` returned exactly ${RECEIVED_COLOR(pluralize('time', count))}.`
     : () =>
         matcherHint(matcherName, received.getMockName(), String(expected)) +
         '\n\n' +
-        `Expected mock function to have returned ` +
+        `Expected ${identifier} to have returned ` +
         `${EXPECTED_COLOR(pluralize('time', expected))},` +
         ` but it returned ${RECEIVED_COLOR(pluralize('time', count))}.`;
 

--- a/packages/expect/src/spy_matchers.js
+++ b/packages/expect/src/spy_matchers.js
@@ -60,6 +60,11 @@ const createToReturnMatcher = matcherName => (received, expected) => {
   ensureNoExpected(expected, matcherName);
   ensureMock(received, matcherName);
 
+  const receivedName = received.getMockName();
+  const identifier = receivedName === 'jest.fn()'
+    ? 'mock function'
+    : `mock function "${receivedName}"`;
+
   const returnValues = received.mock.returnValues;
   const count = returnValues.length;
   const pass = count > 0;
@@ -68,12 +73,12 @@ const createToReturnMatcher = matcherName => (received, expected) => {
     ? () =>
         matcherHint('.not' + matcherName, received.getMockName(), '') +
         '\n\n' +
-        `Expected mock function not to have returned, but it returned:\n` +
+        `Expected ${identifier} not to have returned, but it returned:\n` +
         `  ${getPrintedReturnValues(returnValues, RETURN_PRINT_LIMIT)}`
     : () =>
         matcherHint(matcherName, received.getMockName(), '') +
         '\n\n' +
-        `Expected mock function to have returned.`;
+        `Expected ${identifier} to have returned.`;
 
   return {message, pass};
 };

--- a/packages/expect/src/spy_matchers.js
+++ b/packages/expect/src/spy_matchers.js
@@ -34,7 +34,10 @@ const createToBeCalledMatcher = matcherName => (received, expected) => {
   const receivedIsSpy = isSpy(received);
   const type = receivedIsSpy ? 'spy' : 'mock function';
   const receivedName = receivedIsSpy ? 'spy' : received.getMockName();
-  const identifier = receivedIsSpy || receivedName === 'jest.fn()' ? type : `${type} "${receivedName}"`;
+  const identifier =
+    receivedIsSpy || receivedName === 'jest.fn()'
+      ? type
+      : `${type} "${receivedName}"`;
   const count = receivedIsSpy
     ? received.calls.count()
     : received.mock.calls.length;
@@ -61,9 +64,10 @@ const createToReturnMatcher = matcherName => (received, expected) => {
   ensureMock(received, matcherName);
 
   const receivedName = received.getMockName();
-  const identifier = receivedName === 'jest.fn()'
-    ? 'mock function'
-    : `mock function "${receivedName}"`;
+  const identifier =
+    receivedName === 'jest.fn()'
+      ? 'mock function'
+      : `mock function "${receivedName}"`;
 
   const returnValues = received.mock.returnValues;
   const count = returnValues.length;
@@ -93,7 +97,10 @@ const createToBeCalledTimesMatcher = (matcherName: string) => (
   const receivedIsSpy = isSpy(received);
   const type = receivedIsSpy ? 'spy' : 'mock function';
   const receivedName = receivedIsSpy ? 'spy' : received.getMockName();
-  const identifier = receivedIsSpy || receivedName === 'jest.fn()' ? type : `${type} "${receivedName}"`;
+  const identifier =
+    receivedIsSpy || receivedName === 'jest.fn()'
+      ? type
+      : `${type} "${receivedName}"`;
   const count = receivedIsSpy
     ? received.calls.count()
     : received.mock.calls.length;
@@ -123,9 +130,10 @@ const createToReturnTimesMatcher = (matcherName: string) => (
   ensureMock(received, matcherName);
 
   const receivedName = received.getMockName();
-  const identifier = receivedName === 'jest.fn()'
-    ? 'mock function'
-    : `mock function "${receivedName}"`;
+  const identifier =
+    receivedName === 'jest.fn()'
+      ? 'mock function'
+      : `mock function "${receivedName}"`;
 
   const count = received.mock.returnValues.length;
   const pass = count === expected;
@@ -160,7 +168,10 @@ const createToBeCalledWithMatcher = matcherName => (
   const receivedIsSpy = isSpy(received);
   const type = receivedIsSpy ? 'spy' : 'mock function';
   const receivedName = receivedIsSpy ? 'spy' : received.getMockName();
-  const identifier = receivedIsSpy || receivedName === 'jest.fn()' ? type : `${type} "${receivedName}"`;
+  const identifier =
+    receivedIsSpy || receivedName === 'jest.fn()'
+      ? type
+      : `${type} "${receivedName}"`;
 
   const calls = receivedIsSpy
     ? received.calls.all().map(x => x.args)
@@ -193,9 +204,10 @@ const createToReturnWithMatcher = matcherName => (
   ensureMock(received, matcherName);
 
   const receivedName = received.getMockName();
-  const identifier = receivedName === 'jest.fn()'
-    ? 'mock function'
-    : `mock function "${receivedName}"`;
+  const identifier =
+    receivedName === 'jest.fn()'
+      ? 'mock function'
+      : `mock function "${receivedName}"`;
 
   const returnValues = received.mock.returnValues;
   const [match] = partition(returnValues, value =>
@@ -233,7 +245,10 @@ const createLastCalledWithMatcher = matcherName => (
   const receivedIsSpy = isSpy(received);
   const type = receivedIsSpy ? 'spy' : 'mock function';
   const receivedName = receivedIsSpy ? 'spy' : received.getMockName();
-  const identifier = receivedIsSpy || receivedName === 'jest.fn()' ? type : `${type} "${receivedName}"`;
+  const identifier =
+    receivedIsSpy || receivedName === 'jest.fn()'
+      ? type
+      : `${type} "${receivedName}"`;
   const calls = receivedIsSpy
     ? received.calls.all().map(x => x.args)
     : received.mock.calls;
@@ -261,9 +276,10 @@ const createLastReturnedMatcher = matcherName => (
   ensureMock(received, matcherName);
 
   const receivedName = received.getMockName();
-  const identifier = receivedName === 'jest.fn()'
-    ? 'mock function'
-    : `mock function "${receivedName}"`;
+  const identifier =
+    receivedName === 'jest.fn()'
+      ? 'mock function'
+      : `mock function "${receivedName}"`;
 
   const returnValues = received.mock.returnValues;
   const lastReturnValue = returnValues[returnValues.length - 1];
@@ -309,7 +325,10 @@ const createNthCalledWithMatcher = (matcherName: string) => (
   }
 
   const receivedName = receivedIsSpy ? 'spy' : received.getMockName();
-  const identifier = receivedIsSpy || receivedName === 'jest.fn()' ? type : `${type} "${receivedName}"`;
+  const identifier =
+    receivedIsSpy || receivedName === 'jest.fn()'
+      ? type
+      : `${type} "${receivedName}"`;
   const calls = receivedIsSpy
     ? received.calls.all().map(x => x.args)
     : received.mock.calls;
@@ -351,9 +370,10 @@ const createNthReturnedWithMatcher = (matcherName: string) => (
   }
 
   const receivedName = received.getMockName();
-  const identifier = receivedName === 'jest.fn()'
-    ? 'mock function'
-    : `mock function "${receivedName}"`;
+  const identifier =
+    receivedName === 'jest.fn()'
+      ? 'mock function'
+      : `mock function "${receivedName}"`;
 
   const returnValues = received.mock.returnValues;
   const nthValue = returnValues[nth - 1];

--- a/packages/expect/src/spy_matchers.js
+++ b/packages/expect/src/spy_matchers.js
@@ -309,6 +309,7 @@ const createNthCalledWithMatcher = (matcherName: string) => (
   }
 
   const receivedName = receivedIsSpy ? 'spy' : received.getMockName();
+  const identifier = receivedIsSpy || receivedName === 'jest.fn()' ? type : `${type} "${receivedName}"`;
   const calls = receivedIsSpy
     ? received.calls.all().map(x => x.args)
     : received.mock.calls;
@@ -318,14 +319,14 @@ const createNthCalledWithMatcher = (matcherName: string) => (
     ? () =>
         matcherHint('.not' + matcherName, receivedName) +
         '\n\n' +
-        `Expected ${type} ${nthToString(
+        `Expected ${identifier} ${nthToString(
           nth,
         )} call to not have been called with:\n` +
         `  ${printExpected(expected)}`
     : () =>
         matcherHint(matcherName, receivedName) +
         '\n\n' +
-        `Expected ${type} ${nthToString(
+        `Expected ${identifier} ${nthToString(
           nth,
         )} call to have been called with:\n` +
         formatMismatchedCalls(calls, expected, LAST_CALL_PRINT_LIMIT);

--- a/packages/expect/src/spy_matchers.js
+++ b/packages/expect/src/spy_matchers.js
@@ -350,6 +350,11 @@ const createNthReturnedWithMatcher = (matcherName: string) => (
     return {message, pass};
   }
 
+  const receivedName = received.getMockName();
+  const identifier = receivedName === 'jest.fn()'
+    ? 'mock function'
+    : `mock function "${receivedName}"`;
+
   const returnValues = received.mock.returnValues;
   const nthValue = returnValues[nth - 1];
   const pass = equals(nthValue, expected, [iterableEquality]);
@@ -358,14 +363,14 @@ const createNthReturnedWithMatcher = (matcherName: string) => (
     ? () =>
         matcherHint('.not' + matcherName, received.getMockName()) +
         '\n\n' +
-        `Expected mock function ${nthString} call to not have returned with:\n` +
+        `Expected ${identifier} ${nthString} call to not have returned with:\n` +
         `  ${printExpected(expected)}\n` +
         `But the ${nthString} call returned exactly:\n` +
         `  ${printReceived(nthValue)}`
     : () =>
         matcherHint(matcherName, received.getMockName()) +
         '\n\n' +
-        `Expected mock function ${nthString} call to have returned with:\n` +
+        `Expected ${identifier} ${nthString} call to have returned with:\n` +
         `  ${printExpected(expected)}\n` +
         (returnValues.length > 0
           ? `But the ${nthString} call returned with:\n  ${printReceived(

--- a/packages/expect/src/spy_matchers.js
+++ b/packages/expect/src/spy_matchers.js
@@ -260,6 +260,11 @@ const createLastReturnedMatcher = matcherName => (
 ) => {
   ensureMock(received, matcherName);
 
+  const receivedName = received.getMockName();
+  const identifier = receivedName === 'jest.fn()'
+    ? 'mock function'
+    : `mock function "${receivedName}"`;
+
   const returnValues = received.mock.returnValues;
   const lastReturnValue = returnValues[returnValues.length - 1];
   const pass = equals(lastReturnValue, expected, [iterableEquality]);
@@ -268,14 +273,14 @@ const createLastReturnedMatcher = matcherName => (
     ? () =>
         matcherHint('.not' + matcherName, received.getMockName()) +
         '\n\n' +
-        'Expected mock function to not have last returned:\n' +
+        `Expected ${identifier} to not have last returned:\n` +
         `  ${printExpected(expected)}\n` +
         `But it last returned exactly:\n` +
         `  ${printReceived(lastReturnValue)}`
     : () =>
         matcherHint(matcherName, received.getMockName()) +
         '\n\n' +
-        'Expected mock function to have last returned:\n' +
+        `Expected ${identifier} to have last returned:\n` +
         `  ${printExpected(expected)}\n` +
         (returnValues.length > 0
           ? `But it last returned:\n  ${printReceived(lastReturnValue)}`

--- a/packages/expect/src/spy_matchers.js
+++ b/packages/expect/src/spy_matchers.js
@@ -160,6 +160,8 @@ const createToBeCalledWithMatcher = matcherName => (
   const receivedIsSpy = isSpy(received);
   const type = receivedIsSpy ? 'spy' : 'mock function';
   const receivedName = receivedIsSpy ? 'spy' : received.getMockName();
+  const identifier = receivedIsSpy || receivedName === 'jest.fn()' ? type : `${type} "${receivedName}"`;
+
   const calls = receivedIsSpy
     ? received.calls.all().map(x => x.args)
     : received.mock.calls;
@@ -173,12 +175,12 @@ const createToBeCalledWithMatcher = matcherName => (
     ? () =>
         matcherHint('.not' + matcherName, receivedName) +
         '\n\n' +
-        `Expected ${type} not to have been called with:\n` +
+        `Expected ${identifier} not to have been called with:\n` +
         `  ${printExpected(expected)}`
     : () =>
         matcherHint(matcherName, receivedName) +
         '\n\n' +
-        `Expected ${type} to have been called with:\n` +
+        `Expected ${identifier} to have been called with:\n` +
         formatMismatchedCalls(fail, expected, CALL_PRINT_LIMIT);
 
   return {message, pass};

--- a/packages/expect/src/spy_matchers.js
+++ b/packages/expect/src/spy_matchers.js
@@ -233,6 +233,7 @@ const createLastCalledWithMatcher = matcherName => (
   const receivedIsSpy = isSpy(received);
   const type = receivedIsSpy ? 'spy' : 'mock function';
   const receivedName = receivedIsSpy ? 'spy' : received.getMockName();
+  const identifier = receivedIsSpy || receivedName === 'jest.fn()' ? type : `${type} "${receivedName}"`;
   const calls = receivedIsSpy
     ? received.calls.all().map(x => x.args)
     : received.mock.calls;
@@ -242,12 +243,12 @@ const createLastCalledWithMatcher = matcherName => (
     ? () =>
         matcherHint('.not' + matcherName, receivedName) +
         '\n\n' +
-        `Expected ${type} to not have been last called with:\n` +
+        `Expected ${identifier} to not have been last called with:\n` +
         `  ${printExpected(expected)}`
     : () =>
         matcherHint(matcherName, receivedName) +
         '\n\n' +
-        `Expected ${type} to have been last called with:\n` +
+        `Expected ${identifier} to have been last called with:\n` +
         formatMismatchedCalls(calls, expected, LAST_CALL_PRINT_LIMIT);
 
   return {message, pass};

--- a/packages/expect/src/spy_matchers.js
+++ b/packages/expect/src/spy_matchers.js
@@ -34,6 +34,7 @@ const createToBeCalledMatcher = matcherName => (received, expected) => {
   const receivedIsSpy = isSpy(received);
   const type = receivedIsSpy ? 'spy' : 'mock function';
   const receivedName = receivedIsSpy ? 'spy' : received.getMockName();
+  const identifier = receivedIsSpy || receivedName === 'jest.fn()' ? type : `${type} "${receivedName}"`;
   const count = receivedIsSpy
     ? received.calls.count()
     : received.mock.calls.length;
@@ -45,12 +46,12 @@ const createToBeCalledMatcher = matcherName => (received, expected) => {
     ? () =>
         matcherHint('.not' + matcherName, receivedName, '') +
         '\n\n' +
-        `Expected ${type} not to be called ` +
+        `Expected ${identifier} not to be called ` +
         formatReceivedCalls(calls, CALL_PRINT_LIMIT, {sameSentence: true})
     : () =>
         matcherHint(matcherName, receivedName, '') +
         '\n\n' +
-        `Expected ${type} to have been called, but it was not called.`;
+        `Expected ${identifier} to have been called, but it was not called.`;
 
   return {message, pass};
 };

--- a/packages/expect/src/spy_matchers.js
+++ b/packages/expect/src/spy_matchers.js
@@ -192,6 +192,11 @@ const createToReturnWithMatcher = matcherName => (
 ) => {
   ensureMock(received, matcherName);
 
+  const receivedName = received.getMockName();
+  const identifier = receivedName === 'jest.fn()'
+    ? 'mock function'
+    : `mock function "${receivedName}"`;
+
   const returnValues = received.mock.returnValues;
   const [match] = partition(returnValues, value =>
     equals(expected, value, [iterableEquality]),
@@ -202,14 +207,14 @@ const createToReturnWithMatcher = matcherName => (
     ? () =>
         matcherHint('.not' + matcherName, received.getMockName()) +
         '\n\n' +
-        `Expected mock function not to have returned:\n` +
+        `Expected ${identifier} not to have returned:\n` +
         `  ${printExpected(expected)}\n` +
         `But it returned exactly:\n` +
         `  ${printReceived(expected)}`
     : () =>
         matcherHint(matcherName, received.getMockName()) +
         '\n\n' +
-        `Expected mock function to have returned:\n` +
+        `Expected ${identifier} to have returned:\n` +
         formatMismatchedReturnValues(
           returnValues,
           expected,

--- a/packages/expect/src/spy_matchers.js
+++ b/packages/expect/src/spy_matchers.js
@@ -93,6 +93,7 @@ const createToBeCalledTimesMatcher = (matcherName: string) => (
   const receivedIsSpy = isSpy(received);
   const type = receivedIsSpy ? 'spy' : 'mock function';
   const receivedName = receivedIsSpy ? 'spy' : received.getMockName();
+  const identifier = receivedIsSpy || receivedName === 'jest.fn()' ? type : `${type} "${receivedName}"`;
   const count = receivedIsSpy
     ? received.calls.count()
     : received.mock.calls.length;
@@ -101,13 +102,13 @@ const createToBeCalledTimesMatcher = (matcherName: string) => (
     ? () =>
         matcherHint('.not' + matcherName, receivedName, String(expected)) +
         `\n\n` +
-        `Expected ${type} not to be called ` +
+        `Expected ${identifier} not to be called ` +
         `${EXPECTED_COLOR(pluralize('time', expected))}, but it was` +
         ` called exactly ${RECEIVED_COLOR(pluralize('time', count))}.`
     : () =>
         matcherHint(matcherName, receivedName, String(expected)) +
         '\n\n' +
-        `Expected ${type} to have been called ` +
+        `Expected ${identifier} to have been called ` +
         `${EXPECTED_COLOR(pluralize('time', expected))},` +
         ` but it was called ${RECEIVED_COLOR(pluralize('time', count))}.`;
 


### PR DESCRIPTION
Fixes #6192 

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

As detailed in the issue, this features a mock’s custom name more prominently in an error message

## Test plan
<img width="650" alt="screenshot 2018-05-16 14 59 57" src="https://user-images.githubusercontent.com/11544418/40121597-d3a04ce2-5919-11e8-95df-1b25c82348ce.png">

I have added the necessary tests to the test suite and ensured they failed expectedly when making changes before updating the snapshots


<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
