### PR TITLE
chore: avoid adding trailing whitespace to blank lines in stack traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,6 +191,8 @@
   ([#5812](https://github.com/facebook/jest/issues/5812))
 * `[jest-runtime]` [**BREAKING**] Remove `jest.genMockFn` and
   `jest.genMockFunction` ([#6173](https://github.com/facebook/jest/pull/6173))
+* `[jest-message-util]` Avoid adding unnecessary indent to blank lines in stack
+  traces (TBD)
 
 ## 22.4.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,7 +192,7 @@
 * `[jest-runtime]` [**BREAKING**] Remove `jest.genMockFn` and
   `jest.genMockFunction` ([#6173](https://github.com/facebook/jest/pull/6173))
 * `[jest-message-util]` Avoid adding unnecessary indent to blank lines in stack
-  traces (TBD)
+  traces ([#6211](https://github.com/facebook/jest/pull/6211))
 
 ## 22.4.2
 

--- a/integration-tests/__tests__/__snapshots__/custom_matcher_stack_trace.test.js.snap
+++ b/integration-tests/__tests__/__snapshots__/custom_matcher_stack_trace.test.js.snap
@@ -18,7 +18,7 @@ exports[`works with custom matchers 1`] = `
       46 |     };
       47 | 
       48 |     // This expecation fails due to an error we throw (intentionally)
-      
+
       at __tests__/custom_matcher.test.js:45:13
       at __tests__/custom_matcher.test.js:43:23
       at __tests__/custom_matcher.test.js:42:23

--- a/integration-tests/__tests__/__snapshots__/detect_open_handles.js.snap
+++ b/integration-tests/__tests__/__snapshots__/detect_open_handles.js.snap
@@ -22,7 +22,7 @@ exports[`prints out info about open handlers 1`] = `
     > 7 | app.listen({host: 'localhost', port: 0});
         |     ^
       8 | 
-      
+
       at Object.<anonymous> (server.js:7:5)
       at Object.<anonymous> (__tests__/test.js:3:1)"
 `;

--- a/integration-tests/__tests__/__snapshots__/each.test.js.snap
+++ b/integration-tests/__tests__/__snapshots__/each.test.js.snap
@@ -8,14 +8,14 @@ exports[`shows error message when not enough arguments are supplied to tests 1`]
 
     Not enough arguments supplied for given headings:
     left | right
-    
+
     Received:
     Array [
       true,
       true,
       true,
     ]
-    
+
     Missing 1 arguments
       
       at packages/jest-jasmine2/build/each.js:84:17

--- a/integration-tests/__tests__/__snapshots__/each.test.js.snap
+++ b/integration-tests/__tests__/__snapshots__/each.test.js.snap
@@ -17,7 +17,7 @@ exports[`shows error message when not enough arguments are supplied to tests 1`]
     ]
 
     Missing 1 arguments
-      
+
       at packages/jest-jasmine2/build/each.js:84:17
 
 "

--- a/integration-tests/__tests__/__snapshots__/expect-async-matcher.test.js.snap
+++ b/integration-tests/__tests__/__snapshots__/expect-async-matcher.test.js.snap
@@ -10,6 +10,7 @@ exports[`shows the correct errors in stderr when failing tests 1`] = `
   ● fail with expected non promise values
 
     Error
+
       Error: Expected value to have length:
         2
       Received:
@@ -20,6 +21,7 @@ exports[`shows the correct errors in stderr when failing tests 1`] = `
   ● fail with expected non promise values and not
 
     Error
+
       Error: Expected value to not have length:
         2
       Received:
@@ -43,7 +45,7 @@ exports[`shows the correct errors in stderr when failing tests 1`] = `
       25 |     Promise.resolve(2)
       26 |   );
       27 | });
-      
+
       at __tests__/failure.test.js:24:54
       at __tests__/failure.test.js:11:191
       at __tests__/failure.test.js:11:437
@@ -65,7 +67,7 @@ exports[`shows the correct errors in stderr when failing tests 1`] = `
       31 |     Promise.resolve(2)
       32 |   );
       33 | });
-      
+
       at __tests__/failure.test.js:30:61
       at __tests__/failure.test.js:11:191
       at __tests__/failure.test.js:11:437

--- a/integration-tests/__tests__/__snapshots__/failures.test.js.snap
+++ b/integration-tests/__tests__/__snapshots__/failures.test.js.snap
@@ -14,6 +14,7 @@ exports[`not throwing Error objects 2`] = `
   ● Test suite failed to run
 
     Error
+
       banana
 
 "
@@ -142,7 +143,6 @@ exports[`not throwing Error objects 5`] = `
        9 | });
       10 | 
 
-
       at packages/jest-jasmine2/build/jasmine/Spec.js:85:20
       at __tests__/during_tests.test.js:7:1
 
@@ -158,7 +158,6 @@ exports[`not throwing Error objects 5`] = `
       13 |   throw false;
       14 | });
 
-
       at packages/jest-jasmine2/build/jasmine/Spec.js:85:20
       at __tests__/during_tests.test.js:11:1
 
@@ -173,7 +172,6 @@ exports[`not throwing Error objects 5`] = `
       17 |   // eslint-disable-next-line no-throw-literal
       18 |   throw undefined;
       19 | });
-
 
       at packages/jest-jasmine2/build/jasmine/Spec.js:85:20
       at __tests__/during_tests.test.js:16:1
@@ -196,7 +194,6 @@ exports[`not throwing Error objects 5`] = `
       22 |   // eslint-disable-next-line no-throw-literal
       23 |   throw deepObject;
       24 | });
-
 
       at packages/jest-jasmine2/build/jasmine/Spec.js:85:20
       at __tests__/during_tests.test.js:21:1

--- a/integration-tests/__tests__/__snapshots__/failures.test.js.snap
+++ b/integration-tests/__tests__/__snapshots__/failures.test.js.snap
@@ -40,7 +40,7 @@ exports[`not throwing Error objects 4`] = `
   ● .assertions() › throws
 
     expect(received).toBeTruthy()
-    
+
     Received: false
 
       11 | const throws = () => {
@@ -56,7 +56,7 @@ exports[`not throwing Error objects 4`] = `
   ● .assertions() › throws
 
     expect.assertions(2)
-    
+
     Expected two assertions to be called but received one assertion call.
 
       10 | 
@@ -72,7 +72,7 @@ exports[`not throwing Error objects 4`] = `
   ● .assertions() › throws on redeclare of assertion count
 
     expect(received).toBeTruthy()
-    
+
     Received: false
 
       15 | const redeclare = () => {
@@ -88,7 +88,7 @@ exports[`not throwing Error objects 4`] = `
   ● .assertions() › throws on assertion
 
     expect.assertions(0)
-    
+
     Expected zero assertions to be called but received one assertion call.
 
       20 | 
@@ -104,7 +104,7 @@ exports[`not throwing Error objects 4`] = `
   ● .hasAssertions() › throws when there are not assertions
 
     expect.hasAssertions()
-    
+
     Expected at least one assertion to be called but received none.
 
       25 | 
@@ -260,7 +260,7 @@ exports[`works with assertions in separate files 1`] = `
   ● use some imported macro to make assertion
 
     expect(received).toEqual(expected)
-    
+
     Expected value to equal:
       2
     Received:
@@ -290,17 +290,17 @@ exports[`works with async failures 1`] = `
   ● resolve, but fail
 
     expect(received).toEqual(expected)
-    
+
     Expected value to equal:
       {\\"baz\\": \\"bar\\"}
     Received:
       {\\"foo\\": \\"bar\\"}
-    
+
     Difference:
-    
+
     - Expected
     + Received
-    
+
       Object {
     -   \\"baz\\": \\"bar\\",
     +   \\"foo\\": \\"bar\\",
@@ -319,17 +319,17 @@ exports[`works with async failures 1`] = `
   ● reject, but fail
 
     expect(received).toEqual(expected)
-    
+
     Expected value to equal:
       {\\"baz\\": \\"bar\\"}
     Received:
       {\\"foo\\": \\"bar\\"}
-    
+
     Difference:
-    
+
     - Expected
     + Received
-    
+
       Object {
     -   \\"baz\\": \\"bar\\",
     +   \\"foo\\": \\"bar\\",
@@ -348,7 +348,7 @@ exports[`works with async failures 1`] = `
   ● expect reject
 
     expect(received).rejects.toEqual()
-    
+
     Expected received Promise to reject, instead it resolved to value
       {\\"foo\\": \\"bar\\"}
 
@@ -365,7 +365,7 @@ exports[`works with async failures 1`] = `
   ● expect resolve
 
     expect(received).resolves.toEqual()
-    
+
     Expected received Promise to resolve, instead it rejected to value
       {\\"foo\\": \\"bar\\"}
 
@@ -404,12 +404,12 @@ exports[`works with named snapshot failures 1`] = `
   ● failing named snapshot
 
     expect(value).toMatchSnapshot()
-    
+
     Received value does not match stored snapshot \\"failing named snapshot: snapname 1\\".
-    
+
     - Snapshot
     + Received
-    
+
     - \\"bar\\"
     + \\"foo\\"
 
@@ -448,7 +448,7 @@ exports[`works with node assert 1`] = `
   ● assert
 
     assert.equal(received, expected) or assert(received) 
-    
+
     Expected value to be equal to:
       true
     Received:
@@ -469,12 +469,12 @@ exports[`works with node assert 1`] = `
   ● assert with a message
 
     assert.equal(received, expected) or assert(received) 
-    
+
     Expected value to be equal to:
       true
     Received:
       false
-    
+
     Message:
       this is a message
 
@@ -493,7 +493,7 @@ exports[`works with node assert 1`] = `
   ● assert.ok
 
     assert.equal(received, expected) or assert(received) 
-    
+
     Expected value to be equal to:
       true
     Received:
@@ -514,12 +514,12 @@ exports[`works with node assert 1`] = `
   ● assert.ok with a message
 
     assert.equal(received, expected) or assert(received) 
-    
+
     Expected value to be equal to:
       true
     Received:
       false
-    
+
     Message:
       this is a message
 
@@ -538,7 +538,7 @@ exports[`works with node assert 1`] = `
   ● assert.equal
 
     assert.equal(received, expected) or assert(received) 
-    
+
     Expected value to be equal to:
       2
     Received:
@@ -559,14 +559,14 @@ exports[`works with node assert 1`] = `
   ● assert.notEqual
 
     assert.notEqual(received, expected)
-    
+
     Expected value to not be equal to:
       1
     Received:
       1
-    
+
     Difference:
-    
+
     Compared values have no visual difference.
 
       33 | 
@@ -584,17 +584,17 @@ exports[`works with node assert 1`] = `
   ● assert.deepEqual
 
     assert.deepEqual(received, expected)
-    
+
     Expected value to deeply equal to:
       {\\"a\\": {\\"b\\": {\\"c\\": 6}}}
     Received:
       {\\"a\\": {\\"b\\": {\\"c\\": 5}}}
-    
+
     Difference:
-    
+
     - Expected
     + Received
-    
+
       Object {
         \\"a\\": Object {
           \\"b\\": Object {
@@ -619,20 +619,20 @@ exports[`works with node assert 1`] = `
   ● assert.deepEqual with a message
 
     assert.deepEqual(received, expected)
-    
+
     Expected value to deeply equal to:
       {\\"a\\": {\\"b\\": {\\"c\\": 7}}}
     Received:
       {\\"a\\": {\\"b\\": {\\"c\\": 5}}}
-    
+
     Message:
       this is a message
-    
+
     Difference:
-    
+
     - Expected
     + Received
-    
+
       Object {
         \\"a\\": Object {
           \\"b\\": Object {
@@ -657,14 +657,14 @@ exports[`works with node assert 1`] = `
   ● assert.notDeepEqual
 
     assert.notDeepEqual(received, expected)
-    
+
     Expected value not to deeply equal to:
       {\\"a\\": 1}
     Received:
       {\\"a\\": 1}
-    
+
     Difference:
-    
+
     Compared values have no visual difference.
 
       45 | 
@@ -682,7 +682,7 @@ exports[`works with node assert 1`] = `
   ● assert.strictEqual
 
     assert.strictEqual(received, expected)
-    
+
     Expected value to strictly be equal to:
       NaN
     Received:
@@ -703,17 +703,17 @@ exports[`works with node assert 1`] = `
   ● assert.notStrictEqual
 
     assert.notStrictEqual(received, expected)
-    
+
     Expected value not be strictly equal to:
       1
     Received:
       1
-    
+
     Message:
       My custom error message
-    
+
     Difference:
-    
+
     Compared values have no visual difference.
 
       53 | 
@@ -731,17 +731,17 @@ exports[`works with node assert 1`] = `
   ● assert.deepStrictEqual
 
     assert.deepStrictEqual(received, expected)
-    
+
     Expected value to deeply and strictly equal to:
       {\\"a\\": 2}
     Received:
       {\\"a\\": 1}
-    
+
     Difference:
-    
+
     - Expected
     + Received
-    
+
       Object {
     -   \\"a\\": 2,
     +   \\"a\\": 1,
@@ -762,14 +762,14 @@ exports[`works with node assert 1`] = `
   ● assert.notDeepStrictEqual
 
     assert.notDeepStrictEqual(received, expected)
-    
+
     Expected value not to deeply and strictly equal to:
       {\\"a\\": 1}
     Received:
       {\\"a\\": 1}
-    
+
     Difference:
-    
+
     Compared values have no visual difference.
 
       61 | 
@@ -789,11 +789,11 @@ exports[`works with node assert 1`] = `
   ● assert.doesNotThrow
 
     assert.doesNotThrow(function)
-    
+
     Expected the function not to throw an error.
     Instead, it threw:
       [Error: err!]
-    
+
     Message:
       Got unwanted exception.
 
@@ -812,10 +812,10 @@ exports[`works with node assert 1`] = `
   ● assert.throws
 
     assert.throws(function)
-    
+
     Expected the function to throw an error.
     But it didn't throw anything.
-    
+
     Message:
       Missing expected exception.
 
@@ -840,12 +840,12 @@ exports[`works with snapshot failures 1`] = `
   ● failing snapshot
 
     expect(value).toMatchSnapshot()
-    
+
     Received value does not match stored snapshot \\"failing snapshot 1\\".
-    
+
     - Snapshot
     + Received
-    
+
     - \\"bar\\"
     + \\"foo\\"
 

--- a/integration-tests/__tests__/__snapshots__/failures.test.js.snap
+++ b/integration-tests/__tests__/__snapshots__/failures.test.js.snap
@@ -50,7 +50,7 @@ exports[`not throwing Error objects 4`] = `
       14 | };
       15 | const redeclare = () => {
       16 |   expect.assertions(1);
-      
+
       at __tests__/assertion_count.test.js:13:17
 
   ● .assertions() › throws
@@ -66,7 +66,7 @@ exports[`not throwing Error objects 4`] = `
       13 |   expect(false).toBeTruthy();
       14 | };
       15 | const redeclare = () => {
-      
+
       at __tests__/assertion_count.test.js:12:10
 
   ● .assertions() › throws on redeclare of assertion count
@@ -82,7 +82,7 @@ exports[`not throwing Error objects 4`] = `
       18 |   expect.assertions(2);
       19 | };
       20 | 
-      
+
       at __tests__/assertion_count.test.js:17:17
 
   ● .assertions() › throws on assertion
@@ -98,7 +98,7 @@ exports[`not throwing Error objects 4`] = `
       23 |   expect(true).toBeTruthy();
       24 | };
       25 | 
-      
+
       at __tests__/assertion_count.test.js:22:10
 
   ● .hasAssertions() › throws when there are not assertions
@@ -114,7 +114,7 @@ exports[`not throwing Error objects 4`] = `
       28 | };
       29 | 
       30 | describe('.assertions()', () => {
-      
+
       at __tests__/assertion_count.test.js:27:10
 
 "
@@ -141,8 +141,8 @@ exports[`not throwing Error objects 5`] = `
        8 |   throw Promise.resolve(5);
        9 | });
       10 | 
-      
-      
+
+
       at packages/jest-jasmine2/build/jasmine/Spec.js:85:20
       at __tests__/during_tests.test.js:7:1
 
@@ -157,8 +157,8 @@ exports[`not throwing Error objects 5`] = `
       12 |   // eslint-disable-next-line no-throw-literal
       13 |   throw false;
       14 | });
-      
-      
+
+
       at packages/jest-jasmine2/build/jasmine/Spec.js:85:20
       at __tests__/during_tests.test.js:11:1
 
@@ -173,8 +173,8 @@ exports[`not throwing Error objects 5`] = `
       17 |   // eslint-disable-next-line no-throw-literal
       18 |   throw undefined;
       19 | });
-      
-      
+
+
       at packages/jest-jasmine2/build/jasmine/Spec.js:85:20
       at __tests__/during_tests.test.js:16:1
 
@@ -196,8 +196,8 @@ exports[`not throwing Error objects 5`] = `
       22 |   // eslint-disable-next-line no-throw-literal
       23 |   throw deepObject;
       24 | });
-      
-      
+
+
       at packages/jest-jasmine2/build/jasmine/Spec.js:85:20
       at __tests__/during_tests.test.js:21:1
 
@@ -212,7 +212,7 @@ exports[`not throwing Error objects 5`] = `
       29 | });
       30 | 
       31 | test('done(Error)', done => {
-      
+
       at __tests__/during_tests.test.js:28:3
 
   ● done(Error)
@@ -226,7 +226,7 @@ exports[`not throwing Error objects 5`] = `
       33 | });
       34 | 
       35 | test('done(non-error)', done => {
-      
+
       at __tests__/during_tests.test.js:32:8
 
   ● done(non-error)
@@ -246,7 +246,7 @@ exports[`not throwing Error objects 5`] = `
          |   ^
       37 | });
       38 | 
-      
+
       at packages/jest-jasmine2/build/jasmine/Env.js:541:34
       at __tests__/during_tests.test.js:36:3
 
@@ -272,7 +272,7 @@ exports[`works with assertions in separate files 1`] = `
          |               ^
       13 | };
       14 | 
-      
+
       at macros.js:12:15
       at __tests__/test_macro.test.js:14:3
 
@@ -313,7 +313,7 @@ exports[`works with async failures 1`] = `
       13 | });
       14 | 
       15 | test('reject, but fail', () => {
-      
+
       at __tests__/async_failures.test.js:12:57
 
   ● reject, but fail
@@ -342,7 +342,7 @@ exports[`works with async failures 1`] = `
       17 | });
       18 | 
       19 | test('expect reject', () => {
-      
+
       at __tests__/async_failures.test.js:16:55
 
   ● expect reject
@@ -359,7 +359,7 @@ exports[`works with async failures 1`] = `
       21 | });
       22 | 
       23 | test('expect resolve', () => {
-      
+
       at __tests__/async_failures.test.js:20:10
 
   ● expect resolve
@@ -376,7 +376,7 @@ exports[`works with async failures 1`] = `
       25 | });
       26 | 
       27 | test('timeout', done => {
-      
+
       at __tests__/async_failures.test.js:24:10
 
   ● timeout
@@ -390,7 +390,7 @@ exports[`works with async failures 1`] = `
       28 |   jest.setTimeout(5);
       29 | 
       30 |   setTimeout(done, 10);
-      
+
       at packages/jest-jasmine2/build/jasmine/Spec.js:85:20
       at __tests__/async_failures.test.js:27:1
 
@@ -419,7 +419,7 @@ exports[`works with named snapshot failures 1`] = `
          |                 ^
       13 | });
       14 | 
-      
+
       at __tests__/snapshot_named.test.js:12:17
 
  › 1 snapshot failed.
@@ -461,7 +461,7 @@ exports[`works with node assert 1`] = `
       16 | });
       17 | 
       18 | test('assert with a message', () => {
-      
+
       at __tests__/node_assertion_error.test.js:15:3
 
   ● assert with a message
@@ -483,7 +483,7 @@ exports[`works with node assert 1`] = `
       20 | });
       21 | 
       22 | test('assert.ok', () => {
-      
+
       at __tests__/node_assertion_error.test.js:19:3
 
   ● assert.ok
@@ -502,7 +502,7 @@ exports[`works with node assert 1`] = `
       24 | });
       25 | 
       26 | test('assert.ok with a message', () => {
-      
+
       at __tests__/node_assertion_error.test.js:23:10
 
   ● assert.ok with a message
@@ -524,7 +524,7 @@ exports[`works with node assert 1`] = `
       28 | });
       29 | 
       30 | test('assert.equal', () => {
-      
+
       at __tests__/node_assertion_error.test.js:27:10
 
   ● assert.equal
@@ -543,7 +543,7 @@ exports[`works with node assert 1`] = `
       32 | });
       33 | 
       34 | test('assert.notEqual', () => {
-      
+
       at __tests__/node_assertion_error.test.js:31:10
 
   ● assert.notEqual
@@ -566,7 +566,7 @@ exports[`works with node assert 1`] = `
       36 | });
       37 | 
       38 | test('assert.deepEqual', () => {
-      
+
       at __tests__/node_assertion_error.test.js:35:10
 
   ● assert.deepEqual
@@ -599,7 +599,7 @@ exports[`works with node assert 1`] = `
       40 | });
       41 | 
       42 | test('assert.deepEqual with a message', () => {
-      
+
       at __tests__/node_assertion_error.test.js:39:10
 
   ● assert.deepEqual with a message
@@ -635,7 +635,7 @@ exports[`works with node assert 1`] = `
       44 | });
       45 | 
       46 | test('assert.notDeepEqual', () => {
-      
+
       at __tests__/node_assertion_error.test.js:43:10
 
   ● assert.notDeepEqual
@@ -658,7 +658,7 @@ exports[`works with node assert 1`] = `
       48 | });
       49 | 
       50 | test('assert.strictEqual', () => {
-      
+
       at __tests__/node_assertion_error.test.js:47:10
 
   ● assert.strictEqual
@@ -677,7 +677,7 @@ exports[`works with node assert 1`] = `
       52 | });
       53 | 
       54 | test('assert.notStrictEqual', () => {
-      
+
       at __tests__/node_assertion_error.test.js:51:10
 
   ● assert.notStrictEqual
@@ -703,7 +703,7 @@ exports[`works with node assert 1`] = `
       56 | });
       57 | 
       58 | test('assert.deepStrictEqual', () => {
-      
+
       at __tests__/node_assertion_error.test.js:55:10
 
   ● assert.deepStrictEqual
@@ -732,7 +732,7 @@ exports[`works with node assert 1`] = `
       60 | });
       61 | 
       62 | test('assert.notDeepStrictEqual', () => {
-      
+
       at __tests__/node_assertion_error.test.js:59:10
 
   ● assert.notDeepStrictEqual
@@ -755,7 +755,7 @@ exports[`works with node assert 1`] = `
       64 | });
       65 | 
       66 | test('assert.ifError', () => {
-      
+
       at __tests__/node_assertion_error.test.js:63:10
 
   ● assert.ifError
@@ -778,7 +778,7 @@ exports[`works with node assert 1`] = `
       72 |     throw Error('err!');
       73 |   });
       74 | });
-      
+
       at __tests__/node_assertion_error.test.js:71:10
 
   ● assert.throws
@@ -797,7 +797,7 @@ exports[`works with node assert 1`] = `
          |          ^
       78 | });
       79 | 
-      
+
       at __tests__/node_assertion_error.test.js:77:10
 
 "
@@ -825,7 +825,7 @@ exports[`works with snapshot failures 1`] = `
          |                 ^
       13 | });
       14 | 
-      
+
       at __tests__/snapshot.test.js:12:17
 
  › 1 snapshot failed.

--- a/integration-tests/__tests__/__snapshots__/failures.test.js.snap
+++ b/integration-tests/__tests__/__snapshots__/failures.test.js.snap
@@ -463,8 +463,6 @@ exports[`works with node assert 1`] = `
       18 | test('assert with a message', () => {
       
       at __tests__/node_assertion_error.test.js:15:3
-      
-      at __tests__/node_assertion_error.test.js:14:1
 
   ● assert with a message
 
@@ -487,8 +485,6 @@ exports[`works with node assert 1`] = `
       22 | test('assert.ok', () => {
       
       at __tests__/node_assertion_error.test.js:19:3
-      
-      at __tests__/node_assertion_error.test.js:18:1
 
   ● assert.ok
 
@@ -508,8 +504,6 @@ exports[`works with node assert 1`] = `
       26 | test('assert.ok with a message', () => {
       
       at __tests__/node_assertion_error.test.js:23:10
-      
-      at __tests__/node_assertion_error.test.js:22:1
 
   ● assert.ok with a message
 
@@ -532,8 +526,6 @@ exports[`works with node assert 1`] = `
       30 | test('assert.equal', () => {
       
       at __tests__/node_assertion_error.test.js:27:10
-      
-      at __tests__/node_assertion_error.test.js:26:1
 
   ● assert.equal
 
@@ -553,8 +545,6 @@ exports[`works with node assert 1`] = `
       34 | test('assert.notEqual', () => {
       
       at __tests__/node_assertion_error.test.js:31:10
-      
-      at __tests__/node_assertion_error.test.js:30:1
 
   ● assert.notEqual
 
@@ -578,8 +568,6 @@ exports[`works with node assert 1`] = `
       38 | test('assert.deepEqual', () => {
       
       at __tests__/node_assertion_error.test.js:35:10
-      
-      at __tests__/node_assertion_error.test.js:34:1
 
   ● assert.deepEqual
 
@@ -613,8 +601,6 @@ exports[`works with node assert 1`] = `
       42 | test('assert.deepEqual with a message', () => {
       
       at __tests__/node_assertion_error.test.js:39:10
-      
-      at __tests__/node_assertion_error.test.js:38:1
 
   ● assert.deepEqual with a message
 
@@ -651,8 +637,6 @@ exports[`works with node assert 1`] = `
       46 | test('assert.notDeepEqual', () => {
       
       at __tests__/node_assertion_error.test.js:43:10
-      
-      at __tests__/node_assertion_error.test.js:42:1
 
   ● assert.notDeepEqual
 
@@ -676,8 +660,6 @@ exports[`works with node assert 1`] = `
       50 | test('assert.strictEqual', () => {
       
       at __tests__/node_assertion_error.test.js:47:10
-      
-      at __tests__/node_assertion_error.test.js:46:1
 
   ● assert.strictEqual
 
@@ -697,8 +679,6 @@ exports[`works with node assert 1`] = `
       54 | test('assert.notStrictEqual', () => {
       
       at __tests__/node_assertion_error.test.js:51:10
-      
-      at __tests__/node_assertion_error.test.js:50:1
 
   ● assert.notStrictEqual
 
@@ -725,8 +705,6 @@ exports[`works with node assert 1`] = `
       58 | test('assert.deepStrictEqual', () => {
       
       at __tests__/node_assertion_error.test.js:55:10
-      
-      at __tests__/node_assertion_error.test.js:54:1
 
   ● assert.deepStrictEqual
 
@@ -756,8 +734,6 @@ exports[`works with node assert 1`] = `
       62 | test('assert.notDeepStrictEqual', () => {
       
       at __tests__/node_assertion_error.test.js:59:10
-      
-      at __tests__/node_assertion_error.test.js:58:1
 
   ● assert.notDeepStrictEqual
 
@@ -781,8 +757,6 @@ exports[`works with node assert 1`] = `
       66 | test('assert.ifError', () => {
       
       at __tests__/node_assertion_error.test.js:63:10
-      
-      at __tests__/node_assertion_error.test.js:62:1
 
   ● assert.ifError
 
@@ -806,8 +780,6 @@ exports[`works with node assert 1`] = `
       74 | });
       
       at __tests__/node_assertion_error.test.js:71:10
-      
-      at __tests__/node_assertion_error.test.js:70:1
 
   ● assert.throws
 
@@ -827,8 +799,6 @@ exports[`works with node assert 1`] = `
       79 | 
       
       at __tests__/node_assertion_error.test.js:77:10
-      
-      at __tests__/node_assertion_error.test.js:76:1
 
 "
 `;

--- a/integration-tests/__tests__/__snapshots__/module_name_mapper.test.js.snap
+++ b/integration-tests/__tests__/__snapshots__/module_name_mapper.test.js.snap
@@ -12,11 +12,11 @@ exports[`moduleNameMapper wrong configuration 1`] = `
   ● Test suite failed to run
 
     Configuration error:
-    
+
     Could not locate module ./style.css (mapped as no-such-module)
-    
+
     Please check:
-    
+
     \\"moduleNameMapper\\": {
       \\"/\\\\.(css|less)$/\\": \\"no-such-module\\"
     },

--- a/integration-tests/__tests__/failures.test.js
+++ b/integration-tests/__tests__/failures.test.js
@@ -111,8 +111,6 @@ test('works with node assert', () => {
       70 | test('assert.doesNotThrow', () => {
       
       at __tests__/node_assertion_error.test.js:67:10
-      
-      at __tests__/node_assertion_error.test.js:66:1
 `;
 
     expect(summary).toContain(ifErrorMessage);

--- a/integration-tests/__tests__/failures.test.js
+++ b/integration-tests/__tests__/failures.test.js
@@ -42,11 +42,11 @@ test('works with node assert', () => {
   if (nodeMajorVersion >= 9) {
     expect(summary).toContain(`
     assert.doesNotThrow(function)
-    
+
     Expected the function not to throw an error.
     Instead, it threw:
       [Error: err!]
-    
+
     Message:
       Got unwanted exception.
 `);
@@ -89,17 +89,17 @@ test('works with node assert', () => {
   if (nodeMajorVersion >= 10) {
     const ifErrorMessage = `
     assert.ifError(received, expected)
-    
+
     Expected value ifError to:
       null
     Received:
       1
-    
+
     Message:
       ifError got unwanted exception: 1
-    
+
     Difference:
-    
+
       Comparing two different types of values. Expected null but received number.
 
       65 | 

--- a/integration-tests/__tests__/failures.test.js
+++ b/integration-tests/__tests__/failures.test.js
@@ -59,7 +59,7 @@ test('works with node assert', () => {
       72 |     throw Error('err!');
       73 |   });
       74 | });
-      
+
       at __tests__/node_assertion_error.test.js:71:10
 `);
 
@@ -109,7 +109,7 @@ test('works with node assert', () => {
       68 | });
       69 | 
       70 | test('assert.doesNotThrow', () => {
-      
+
       at __tests__/node_assertion_error.test.js:67:10
 `;
 
@@ -126,8 +126,7 @@ test('works with node assert', () => {
       67 |   assert.ifError(1);
       68 | });
       69 | 
-      
-      
+
       at packages/jest-jasmine2/build/jasmine/Spec.js:85:20
       at __tests__/node_assertion_error.test.js:66:1
 `;

--- a/packages/expect/src/__tests__/__snapshots__/to_throw_matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/to_throw_matchers.test.js.snap
@@ -14,7 +14,7 @@ exports[`.toThrow() error class threw, but class did not match 1`] = `
 Expected the function to throw an error of type:
   <green>\\"Err2\\"</>
 Instead, it threw:
-<red>  Error      </>
+<red>  Error</>
 <red>      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</></>"
 `;
 
@@ -24,7 +24,7 @@ exports[`.toThrow() error class threw, but should not have 1`] = `
 Expected the function not to throw an error of type:
   <green>\\"Err\\"</>
 Instead, it threw:
-<red>  Error      </>
+<red>  Error</>
 <red>      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</></>"
 `;
 
@@ -56,7 +56,7 @@ exports[`.toThrow() promise/async throws if Error-like object is returned threw,
 Expected the function to throw an error of type:
   [32m"Err2"[39m
 Instead, it threw:
-[31m  Error      [39m
+[31m  Error[39m
 [31m      [2mat jestExpect ([22mpackages/expect/src/__tests__/toThrowMatchers-test.js[2m:24:74)[22m[39m]
 `;
 
@@ -65,7 +65,7 @@ exports[`.toThrow() promise/async throws if Error-like object is returned threw,
 
 Expected the function not to throw an error.
 Instead, it threw:
-[31m  Error      [39m
+[31m  Error[39m
 [31m      [2mat jestExpect ([22mpackages/expect/src/__tests__/toThrowMatchers-test.js[2m:24:74)[22m[39m]
 `;
 
@@ -83,7 +83,7 @@ exports[`.toThrow() regexp threw, but message did not match 1`] = `
 Expected the function to throw an error matching:
   <green>/banana/</>
 Instead, it threw:
-<red>  Error      </>
+<red>  Error</>
 <red>      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</></>"
 `;
 
@@ -93,7 +93,7 @@ exports[`.toThrow() regexp threw, but should not have 1`] = `
 Expected the function not to throw an error matching:
   <green>/apple/</>
 Instead, it threw:
-<red>  Error      </>
+<red>  Error</>
 <red>      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</></>"
 `;
 
@@ -111,7 +111,7 @@ exports[`.toThrow() strings threw, but message did not match 1`] = `
 Expected the function to throw an error matching:
   <green>\\"banana\\"</>
 Instead, it threw:
-<red>  Error      </>
+<red>  Error</>
 <red>      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</></>"
 `;
 
@@ -121,7 +121,7 @@ exports[`.toThrow() strings threw, but should not have 1`] = `
 Expected the function not to throw an error matching:
   <green>\\"apple\\"</>
 Instead, it threw:
-<red>  Error      </>
+<red>  Error</>
 <red>      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</></>"
 `;
 
@@ -139,7 +139,7 @@ exports[`.toThrowError() error class threw, but class did not match 1`] = `
 Expected the function to throw an error of type:
   <green>\\"Err2\\"</>
 Instead, it threw:
-<red>  Error      </>
+<red>  Error</>
 <red>      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</></>"
 `;
 
@@ -149,7 +149,7 @@ exports[`.toThrowError() error class threw, but should not have 1`] = `
 Expected the function not to throw an error of type:
   <green>\\"Err\\"</>
 Instead, it threw:
-<red>  Error      </>
+<red>  Error</>
 <red>      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</></>"
 `;
 
@@ -181,7 +181,7 @@ exports[`.toThrowError() promise/async throws if Error-like object is returned t
 Expected the function to throw an error of type:
   [32m"Err2"[39m
 Instead, it threw:
-[31m  Error      [39m
+[31m  Error[39m
 [31m      [2mat jestExpect ([22mpackages/expect/src/__tests__/toThrowMatchers-test.js[2m:24:74)[22m[39m]
 `;
 
@@ -190,7 +190,7 @@ exports[`.toThrowError() promise/async throws if Error-like object is returned t
 
 Expected the function not to throw an error.
 Instead, it threw:
-[31m  Error      [39m
+[31m  Error[39m
 [31m      [2mat jestExpect ([22mpackages/expect/src/__tests__/toThrowMatchers-test.js[2m:24:74)[22m[39m]
 `;
 
@@ -208,7 +208,7 @@ exports[`.toThrowError() regexp threw, but message did not match 1`] = `
 Expected the function to throw an error matching:
   <green>/banana/</>
 Instead, it threw:
-<red>  Error      </>
+<red>  Error</>
 <red>      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</></>"
 `;
 
@@ -218,7 +218,7 @@ exports[`.toThrowError() regexp threw, but should not have 1`] = `
 Expected the function not to throw an error matching:
   <green>/apple/</>
 Instead, it threw:
-<red>  Error      </>
+<red>  Error</>
 <red>      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</></>"
 `;
 
@@ -236,7 +236,7 @@ exports[`.toThrowError() strings threw, but message did not match 1`] = `
 Expected the function to throw an error matching:
   <green>\\"banana\\"</>
 Instead, it threw:
-<red>  Error      </>
+<red>  Error</>
 <red>      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</></>"
 `;
 
@@ -246,6 +246,6 @@ exports[`.toThrowError() strings threw, but should not have 1`] = `
 Expected the function not to throw an error matching:
   <green>\\"apple\\"</>
 Instead, it threw:
-<red>  Error      </>
+<red>  Error</>
 <red>      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</></>"
 `;

--- a/packages/jest-jasmine2/src/expectation_result_factory.js
+++ b/packages/jest-jasmine2/src/expectation_result_factory.js
@@ -47,7 +47,7 @@ function stackFormatter(options, initError, errorMessage) {
   }
 
   if (initError) {
-    return errorMessage + '\n' + initError.stack;
+    return errorMessage.trimRight() + '\n\n' + initError.stack;
   }
 
   return new Error(errorMessage).stack;

--- a/packages/jest-jasmine2/src/expectation_result_factory.js
+++ b/packages/jest-jasmine2/src/expectation_result_factory.js
@@ -36,8 +36,14 @@ function stackFormatter(options, initError, errorMessage) {
     return '';
   }
 
-  if (options.error && options.error.stack) {
-    return options.error.stack;
+  if (options.error) {
+    if (options.error.stack) {
+      return options.error.stack;
+    }
+
+    if (options.error === errorMessage) {
+      return errorMessage;
+    }
   }
 
   if (initError) {

--- a/packages/jest-message-util/src/__tests__/__snapshots__/messages.test.js.snap
+++ b/packages/jest-message-util/src/__tests__/__snapshots__/messages.test.js.snap
@@ -17,10 +17,8 @@ exports[`formatStackTrace should strip node internals 1`] = `
           \\"\\"
         type:
           \\"string\\"
-<dim>      </>
-<dim>      </>
+<dim></>
 <dim>      <dim>at Object.it (<dim>__tests__/test.js<dim>:8:14)<dim></>
-<dim>      </>
 "
 `;
 
@@ -28,7 +26,7 @@ exports[`should exclude jasmine from stack trace for Unix paths. 1`] = `
 "<bold><red>  <bold>● <bold>Unix test</></>
 
       at stack (../jest-jasmine2/build/jasmine-2.4.1.js:1580:17)
-<dim>      </>
+<dim></>
 <dim>      <dim>at Object.addResult (<dim>../jest-jasmine2/build/jasmine-2.4.1.js<dim>:1550:14)<dim></>
 <dim>      <dim>at Object.it (<dim>build/__tests__/messages-test.js<dim>:45:41)<dim></>
 "
@@ -44,10 +42,8 @@ exports[`should not exclude vendor from stack trace 1`] = `
           \\"\\"
         type:
           \\"string\\"
-<dim>      </>
-<dim>      </>
+<dim></>
 <dim>      <dim>at Object.it (<dim>__tests__/vendor/cool_test.js<dim>:6:666)<dim></>
 <dim>      <dim>at Object.asyncFn (<dim>__tests__/vendor/sulu/node_modules/sulu-content-bundle/best_component.js<dim>:1:5)<dim></>
-<dim>      </>
 "
 `;

--- a/packages/jest-message-util/src/index.js
+++ b/packages/jest-message-util/src/index.js
@@ -64,6 +64,12 @@ const STACK_PATH_REGEXP = /\s*at.*\(?(\:\d*\:\d*|native)\)?/;
 const EXEC_ERROR_MESSAGE = 'Test suite failed to run';
 const ERROR_TEXT = 'Error: ';
 
+const indentAllLines = (lines: string, indent: string) =>
+  lines
+    .split('\n')
+    .map(line => (line ? indent + line : line))
+    .join('\n');
+
 const trim = string => (string || '').trim();
 
 // Some errors contain not only line numbers in stack traces
@@ -84,10 +90,7 @@ const getRenderedCallsite = (
     {highlightCode: true},
   );
 
-  renderedCallsite = renderedCallsite
-    .split('\n')
-    .map(line => MESSAGE_INDENT + line)
-    .join('\n');
+  renderedCallsite = indentAllLines(renderedCallsite, MESSAGE_INDENT);
 
   renderedCallsite = `\n${renderedCallsite}\n`;
   return renderedCallsite;
@@ -127,10 +130,8 @@ export const formatExecError = (
     message = separated.message;
   }
 
-  message = message
-    .split(/\n/)
-    .map(line => MESSAGE_INDENT + line)
-    .join('\n');
+  message = indentAllLines(message, MESSAGE_INDENT);
+
   stack =
     stack && !options.noStackTrace
       ? '\n' + formatStackTrace(stack, config, options, testPath)
@@ -311,10 +312,7 @@ export const formatResultsErrors = (
             formatStackTrace(stack, config, options, testPath),
           ) + '\n';
 
-      message = message
-        .split(/\n/)
-        .map(line => MESSAGE_INDENT + line)
-        .join('\n');
+      message = indentAllLines(message, MESSAGE_INDENT);
 
       const title =
         chalk.bold.red(

--- a/packages/jest-message-util/src/index.js
+++ b/packages/jest-message-util/src/index.js
@@ -278,6 +278,7 @@ export const formatStackTrace = (
   }
 
   const stacktrace = lines
+    .filter(Boolean)
     .map(
       line =>
         STACK_INDENT +
@@ -285,7 +286,7 @@ export const formatStackTrace = (
     )
     .join('\n');
 
-  return renderedCallsite + stacktrace;
+  return `${renderedCallsite}\n${stacktrace}`;
 };
 
 export const formatResultsErrors = (


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary
We currently indent all lines in error messages the same, regardless of whether or not that line has any content.

This diff just checks if a line is truthy before indenting it.

EDIT: It also has some other minor cleanup of stack traces

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan
Updated snapshots

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
