### PR TITLE
jest: add the ability to specify config via env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Features
 
+* `[jest-cli]` Add support for specifying configuration via environment variables
+  ([#6217](https://github.com/facebook/jest/pull/6217))
 * `[jest-cli]` Add `--detectOpenHandles` flag which enables Jest to potentially
   track down handles keeping it open after tests are complete.
   ([#6130](https://github.com/facebook/jest/pull/6130))

--- a/packages/jest-cli/src/cli/index.js
+++ b/packages/jest-cli/src/cli/index.js
@@ -163,6 +163,7 @@ const buildArgv = (maybeArgv: ?Argv, project: ?Path) => {
     .options(args.options)
     .epilogue(args.docs)
     .check(args.check)
+    .env('JEST')
     .version(false).argv;
 
   validateCLIOptions(

--- a/website/versioned_docs/version-22.4/Configuration.md
+++ b/website/versioned_docs/version-22.4/Configuration.md
@@ -39,6 +39,11 @@ When using the `--config` option, the JSON file must not contain a "jest" key:
 }
 ```
 
+Additionally, jest configuration can be overridden via environment variables.
+To do that, you can use the all caps, underscore separated version of the option
+name, prefixed with `JEST_`. For example, the option `cacheDirectory` would
+be specified using the environment variable `JEST_CACHE_DIRECTORY`
+
 ## Options
 
 These options let you control Jest's behavior in your `package.json` file. The


### PR DESCRIPTION
## Summary

Adds the ability to override configuration via environment variables taking advantage of [yargs built in .env() feature](http://yargs.js.org/docs/#api-envprefix)

Its a fix for #6214 - this shold make it a lot easier to have separate caching configuration in CI via JEST_CACHE_DIRECTORY

## Test plan

Not sure if an integration test is necessary for this, as its provided by `yargs`. I did try the following command:

```
$ JEST_CACHE_DIRECTORY=/tmp/hello_world jest --showConfig | grep cacheDirectory
      "cacheDirectory": "/tmp/hello_world",
```

Would need help to set up an integration test, as I couldn't tell if there is currently infrastructure in place to run the cli directly from a test.

Note: CLA is WIP since I may have changed employer since last signing.