### PR TITLE
Add double minus to pipe yarn arguments to jest

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -71,6 +71,12 @@ you can use:
 yarn test -u -t="ColorPicker"
 ```
 
+OR
+
+```bash
+yarn test -- --color
+```
+
 ## Using with npm scripts
 
 If you run Jest via `npm test`, you can still use the command line arguments by


### PR DESCRIPTION
The double minus `--` are included with npm commands. The same applies to yarn.

## Summary
I had trouble running code coverage for jest using yarn. After a couple of hours, I tried using npm format for piping the arguments and it worked. It did not help that `yarn test help` shows similar options to `yarn test -- --help`. 

## Test plan
1. Run code coverage using `yarn test --coverage`
Expectation : Code coverage report is generated.
Reality : Only tests run and there is no code coverage report.
2. Run code coverage using `yarn test -- --coverage`
Expectation : Code coverage report is generated.
Reality : Code coverage report is generated in _coverage/lcov-report/index.html_