### PR TITLE
Properly resolve mocked node modules without package.json defined

### DIFF
--- a/integration-tests/resolve-node-module/__mocks__/mock-module-without-pkg/index.js
+++ b/integration-tests/resolve-node-module/__mocks__/mock-module-without-pkg/index.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+module.exports = 'test mock-module-without-pkg';

--- a/integration-tests/resolve-node-module/__tests__/resolve-node-module.test.js
+++ b/integration-tests/resolve-node-module/__tests__/resolve-node-module.test.js
@@ -10,6 +10,7 @@
 jest.mock('mock-module');
 jest.mock('mock-module-alt');
 jest.mock('mock-jsx-module');
+jest.mock('mock-module-without-pkg');
 
 it('should resolve entry as index.js when package main is "."', () => {
   const mockModule = require('mock-module');
@@ -24,4 +25,9 @@ it('should resolve entry as index.js when package main is "./"', () => {
 it('should resolve entry as index with other configured module file extension when package main is "."', () => {
   const mockJsxModule = require('mock-jsx-module');
   expect(mockJsxModule).toEqual('test jsx');
+});
+
+it('should resolve entry as index without package.json', () => {
+  const mockModuleWithoutPkg = require('mock-module-without-pkg');
+  expect(mockModuleWithoutPkg).toEqual('test mock-module-without-pkg');
 });

--- a/packages/jest-haste-map/src/module_map.js
+++ b/packages/jest-haste-map/src/module_map.js
@@ -56,7 +56,7 @@ export default class ModuleMap {
   }
 
   getMockModule(name: string): ?Path {
-    return this._raw.mocks[name];
+    return this._raw.mocks[name] || this._raw.mocks[name + '/index'];
   }
 
   getRawModuleMap(): RawModuleMap {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Fixes #4439 

While constructing ModuleMap, the `getMockName` fn resolves like this:
```
./src/__mocks__/my-module.js 			-> "my-module" (1)
./src/__mocks__/my-module/sth.js		-> "my-module/sth" (2)
./src/__mocks__/my-module/index.js		-> "my-module/index" (3)
```

However, the `ModuleMap#getMockModule` doesn't account for the third scenario, when the manually mocked module is required as `my-module` – it just gets `"my-module"` as a second param. To fix this, I've added a fallback check for `*/index` to mimic node resolution algorithm.

Not sure if this is the right place to put this fix, open to suggestions.
Possible other place to update the resolution logic would be: https://github.com/facebook/jest/blob/2745e3e6cc196f191bfb8f33625e45ec4b4a1ded/packages/jest-resolve/src/index.js#L230

## Test plan

Added an integration test
