### PR TITLE
[jest-mock] Include tracked call results in serialized mock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,8 @@
   ([#6221](https://github.com/facebook/jest/pull/6221))
 * `[expect]` Improve return matchers
   ([#6172](https://github.com/facebook/jest/pull/6172))
+* `[jest-mock]` Include tracked call results in serialized mock
+  ([#6244](https://github.com/facebook/jest/pull/6244))
 
 ### Fixes
 

--- a/packages/jest-snapshot/src/__tests__/__snapshots__/mock_serializer.test.js.snap
+++ b/packages/jest-snapshot/src/__tests__/__snapshots__/mock_serializer.test.js.snap
@@ -22,6 +22,12 @@ Object {
         },
       ],
     ],
+    "results": Array [
+      Object {
+        "isThrow": false,
+        "value": undefined,
+      },
+    ],
   },
 }
 `;
@@ -34,6 +40,12 @@ exports[`mock with 1 calls in React element 1`] = `
         Array [
           "Mocking you!",
         ],
+      ],
+      "results": Array [
+        Object {
+          "isThrow": false,
+          "value": undefined,
+        },
       ],
     }
   }
@@ -52,6 +64,39 @@ exports[`mock with 2 calls 1`] = `
       },
       42,
     ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": undefined,
+    },
+    Object {
+      "isThrow": false,
+      "value": undefined,
+    },
+  ],
+}
+`;
+
+exports[`mock with 2 calls, 1 return, 1 throw 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      2,
+    ],
+    Array [
+      3,
+    ],
+  ],
+  "results": Array [
+    Object {
+      "isThrow": false,
+      "value": 4,
+    },
+    Object {
+      "isThrow": true,
+      "value": [Error: Error Message!],
+    },
   ],
 }
 `;

--- a/packages/jest-snapshot/src/__tests__/mock_serializer.test.js
+++ b/packages/jest-snapshot/src/__tests__/mock_serializer.test.js
@@ -16,6 +16,26 @@ test('mock with 0 calls and default name', () => {
   expect(fn).toMatchSnapshot();
 });
 
+test('mock with 2 calls, 1 return, 1 throw', () => {
+  const fn = jest.fn(value => {
+    if (value % 2 === 0) {
+      return value * 2;
+    } else {
+      throw new Error('Error Message!');
+    }
+  });
+
+  fn(2);
+
+  try {
+    fn(3);
+  } catch (error) {
+    // ignore error
+  }
+
+  expect(fn).toMatchSnapshot();
+});
+
 test('mock with 0 calls and default name in React element', () => {
   const fn = jest.fn();
   const val = {
@@ -68,7 +88,7 @@ test('mock with 2 calls', () => {
 });
 
 test('indent option', () => {
-  const fn = jest.fn();
+  const fn = jest.fn(val => val);
   fn({key: 'value'});
   const expected = [
     '[MockFunction] {',
@@ -79,15 +99,24 @@ test('indent option', () => {
     '},',
     '],',
     '],',
+    '"results": Array [',
+    'Object {',
+    '"isThrow": false,',
+    '"value": Object {',
+    '"key": "value",',
+    '},',
+    '},',
+    '],',
     '}',
   ].join('\n');
   expect(prettyFormat(fn, {indent: 0, plugins: [plugin]})).toBe(expected);
 });
 
 test('min option', () => {
-  const fn = jest.fn();
+  const fn = jest.fn(val => val);
   fn({key: 'value'});
-  const expected = '[MockFunction] {"calls": [[{"key": "value"}]]}';
+  const expected =
+    '[MockFunction] {"calls": [[{"key": "value"}]], "results": [{"isThrow": false, "value": {"key": "value"}}]}';
   expect(prettyFormat(fn, {min: true, plugins: [plugin]})).toBe(expected);
 });
 
@@ -119,16 +148,26 @@ test('maxDepth option', () => {
     '        [Object],', // ++depth === 4
     '      ],',
     '    ],',
+    '    "results": Array [', // ++depth === 2
+    '      Object {', // ++depth === 3
+    '        "isThrow": false,',
+    '        "value": undefined,',
+    '      },',
+    '    ],',
     '  },',
     '  "greaterThan1": Object {', // ++depth === 2
     '    "fn2": [MockFunction atDepth2] {',
     '      "calls": Array [', // ++depth === 3
     '        [Array],', // ++depth === 4
     '      ],',
+    '      "results": Array [', // ++depth === 3
+    '        [Object],', // ++depth === 4
+    '      ],',
     '    },',
     '    "greaterThan2": Object {', // ++depth === 3
     '      "fn3": [MockFunction atDepth3] {',
     '        "calls": [Array],', // ++depth === 4
+    '        "results": [Array],', // ++depth === 4
     '      },',
     '    },',
     '  },',

--- a/packages/jest-snapshot/src/mock_serializer.js
+++ b/packages/jest-snapshot/src/mock_serializer.js
@@ -30,6 +30,11 @@ export const serialize = (
       indentationNext +
       '"calls": ' +
       printer(val.mock.calls, config, indentationNext, depth, refs) +
+      (config.min ? ', ' : ',') +
+      config.spacingOuter +
+      indentationNext +
+      '"results": ' +
+      printer(val.mock.results, config, indentationNext, depth, refs) +
       (config.min ? '' : ',') +
       config.spacingOuter +
       indentation +


### PR DESCRIPTION
## Summary

Mock functions have recently been updated to not only track params for each call, but also the result of each call (whether it threw an error, what value was returned/thrown).

This PR adds that new information to the serialized representation of a mock function.

As requested in this comment: https://github.com/facebook/jest/pull/5752#issuecomment-386791326

## Test plan

* Updated existing mock_serializer.test.js unit tests to expect additional results data, and updated the mock functions in some tests to actually return a value.
* Added a new unit test to mock_serializer.test.js that involves a call to a mock that returns a value, and another call to the same mock that throws.
* Ran `yarn run jest mock_serializer` and reviewed all snapshot mismatches (caused by the new expected data).
* Ran `yarn run jest mock_serializer -u` to update snapshots after confirming the new snapshots looked good.