### PR TITLE
fix(matchers): a more robust isDomNode

### DIFF
--- a/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -1916,6 +1916,28 @@ Received:
   <red>{\\"a\\": 99}</>"
 `;
 
+exports[`.toEqual() {pass: false} expect({"target": {"nodeType": 1, "value": "a"}}).toEqual({"target": {"nodeType": 1, "value": "b"}}) 1`] = `
+"<dim>expect(</><red>received</><dim>).toEqual(</><green>expected</><dim>)</>
+
+Expected value to equal:
+  <green>{\\"target\\": {\\"nodeType\\": 1, \\"value\\": \\"b\\"}}</>
+Received:
+  <red>{\\"target\\": {\\"nodeType\\": 1, \\"value\\": \\"a\\"}}</>
+
+Difference:
+
+<green>- Expected</>
+<red>+ Received</>
+
+<dim>  Object {</>
+<dim>    \\"target\\": Object {</>
+<dim>      \\"nodeType\\": 1,</>
+<green>-     \\"value\\": \\"b\\",</>
+<red>+     \\"value\\": \\"a\\",</>
+<dim>    },</>
+<dim>  }</>"
+`;
+
 exports[`.toEqual() {pass: false} expect({}).not.toEqual({}) 1`] = `
 "<dim>expect(</><red>received</><dim>).not.toEqual(</><green>expected</><dim>)</>
 

--- a/packages/expect/src/__tests__/matchers.test.js
+++ b/packages/expect/src/__tests__/matchers.test.js
@@ -294,6 +294,20 @@ describe('.toEqual()', () => {
         },
       },
     ],
+    [
+      {
+        target: {
+          nodeType: 1,
+          value: 'a',
+        },
+      },
+      {
+        target: {
+          nodeType: 1,
+          value: 'b',
+        },
+      },
+    ],
   ].forEach(([a, b]) => {
     test(`{pass: false} expect(${stringify(a)}).toEqual(${stringify(
       b,

--- a/packages/expect/src/jasmine_utils.js
+++ b/packages/expect/src/jasmine_utils.js
@@ -28,7 +28,12 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 type Tester = (a: any, b: any) => boolean | typeof undefined;
 
 // Extracted out of jasmine 2.5.2
-export function equals(a: any, b: any, customTesters?: Array<Tester>, strictCheck?: boolean): boolean {
+export function equals(
+  a: any,
+  b: any,
+  customTesters?: Array<Tester>,
+  strictCheck?: boolean,
+): boolean {
   customTesters = customTesters || [];
   return eq(a, b, [], [], customTesters, strictCheck ? hasKey : hasDefinedKey);
 }
@@ -181,7 +186,9 @@ function eq(a, b, aStack, bStack, customTesters, hasKey): boolean {
     key = aKeys[size];
 
     // Deep compare each member
-    result = hasKey(b, key) && eq(a[key], b[key], aStack, bStack, customTesters, hasKey);
+    result =
+      hasKey(b, key) &&
+      eq(a[key], b[key], aStack, bStack, customTesters, hasKey);
 
     if (!result) {
       return false;
@@ -224,15 +231,11 @@ function keys(obj, isArray, hasKey) {
 }
 
 function hasDefinedKey(obj, key) {
-  return (
-    hasKey(obj, key) && obj[key] !== undefined
-  );
+  return hasKey(obj, key) && obj[key] !== undefined;
 }
 
 function hasKey(obj, key) {
-  return (
-    Object.prototype.hasOwnProperty.call(obj, key)
-  );
+  return Object.prototype.hasOwnProperty.call(obj, key);
 }
 
 export function isA(typeName: string, value: any) {
@@ -240,7 +243,12 @@ export function isA(typeName: string, value: any) {
 }
 
 function isDomNode(obj) {
-  return obj.nodeType > 0;
+  return (
+    obj !== null &&
+    typeof obj === 'object' &&
+    typeof obj.nodeType === 'number' &&
+    typeof obj.nodeName === 'string'
+  );
 }
 
 export function fnNameFor(func: Function) {


### PR DESCRIPTION
<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

This PR fixes #6204

Replace the naive implementation of `isDomNode` just like jasmine following this fix - https://github.com/jasmine/jasmine/commit/ced2b114e47d3e0e108781dab3627aabc8515813

## Test plan

Added a test for a fake dom Node that throws the correct error only with the code modifications in this PR.