### PR TITLE
Overhaul watch plugin hooks names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,8 @@
   ([#6221](https://github.com/facebook/jest/pull/6221))
 * `[expect]` Improve return matchers
   ([#6172](https://github.com/facebook/jest/pull/6172))
+* `[jest-cli]` Overhaul watch plugin hooks names
+  ([#6249](https://github.com/facebook/jest/pull/6249))
 
 ### Fixes
 

--- a/docs/WatchPlugins.md
+++ b/docs/WatchPlugins.md
@@ -65,7 +65,7 @@ class MyWatchPlugin {
 }
 ```
 
-#### `jestHooks.testRunComplete(results)`
+#### `jestHooks.onTestRunComplete(results)`
 
 Gets called at the end of every test run. It has the test results as an
 argument.
@@ -75,14 +75,14 @@ For example:
 ```javascript
 class MyWatchPlugin {
   apply(jestHooks) {
-    jestHooks.testRunComplete(results => {
+    jestHooks.onTestRunComplete(results => {
       this._hasSnapshotFailure = results.snapshot.failure;
     });
   }
 }
 ```
 
-#### `jestHooks.fileChange({projects})`
+#### `jestHooks.onFileChange({projects})`
 
 Gets called whenever there is a change in the file system
 
@@ -94,7 +94,7 @@ For example:
 ```javascript
 class MyWatchPlugin {
   apply(jestHooks) {
-    jestHooks.fileChange(({projects}) => {
+    jestHooks.onFileChange(({projects}) => {
       this._projects = projects;
     });
   }

--- a/packages/jest-cli/src/__tests__/watch.test.js
+++ b/packages/jest-cli/src/__tests__/watch.test.js
@@ -359,14 +359,14 @@ describe('Watch mode flows', () => {
   });
 
   it('allows WatchPlugins to hook into file system changes', async () => {
-    const fileChange = jest.fn();
+    const onFileChange = jest.fn();
     const pluginPath = `${__dirname}/__fixtures__/plugin_path_fs_change`;
     jest.doMock(
       pluginPath,
       () =>
         class WatchPlugin {
           apply(jestHooks) {
-            jestHooks.fileChange(fileChange);
+            jestHooks.onFileChange(onFileChange);
           }
         },
       {virtual: true},
@@ -383,7 +383,7 @@ describe('Watch mode flows', () => {
       stdin,
     );
 
-    expect(fileChange).toHaveBeenCalledWith({
+    expect(onFileChange).toHaveBeenCalledWith({
       projects: [
         {
           config: contexts[0].config,
@@ -600,7 +600,7 @@ describe('Watch mode flows', () => {
     watch(globalConfig, contexts, pipe, hasteMapInstances, stdin, hooks);
     runJestMock.mockReset();
 
-    hooks.getEmitter().testRunComplete({snapshot: {failure: true}});
+    hooks.getEmitter().onTestRunComplete({snapshot: {failure: true}});
 
     stdin.emit(KEYS.U);
     await nextTick();

--- a/packages/jest-cli/src/jest_hooks.js
+++ b/packages/jest-cli/src/jest_hooks.js
@@ -17,56 +17,64 @@ type JestHookExposedFS = {
 type FileChange = (fs: JestHookExposedFS) => void;
 type ShouldRunTestSuite = (testPath: string) => Promise<boolean>;
 type TestRunComplete = (results: AggregatedResult) => void;
+type AvailableHooks =
+  | 'onFileChange'
+  | 'onTestRunComplete'
+  | 'shouldRunTestSuite';
 
 export type JestHookSubscriber = {
-  fileChange: (fn: FileChange) => void,
+  onFileChange: (fn: FileChange) => void,
+  onTestRunComplete: (fn: TestRunComplete) => void,
   shouldRunTestSuite: (fn: ShouldRunTestSuite) => void,
-  testRunComplete: (fn: TestRunComplete) => void,
 };
 
 export type JestHookEmitter = {
-  fileChange: (fs: JestHookExposedFS) => void,
+  onFileChange: (fs: JestHookExposedFS) => void,
+  onTestRunComplete: (results: AggregatedResult) => void,
   shouldRunTestSuite: (testPath: string) => Promise<boolean>,
-  testRunComplete: (results: AggregatedResult) => void,
 };
 
 class JestHooks {
   _listeners: {
-    fileChange: Array<FileChange>,
+    onFileChange: Array<FileChange>,
+    onTestRunComplete: Array<TestRunComplete>,
     shouldRunTestSuite: Array<ShouldRunTestSuite>,
-    testRunComplete: Array<TestRunComplete>,
   };
 
   constructor() {
     this._listeners = {
-      fileChange: [],
+      onFileChange: [],
+      onTestRunComplete: [],
       shouldRunTestSuite: [],
-      testRunComplete: [],
     };
   }
 
-  isUsed(hook: string) {
+  isUsed(hook: AvailableHooks) {
     return this._listeners[hook] && this._listeners[hook].length;
   }
 
   getSubscriber(): JestHookSubscriber {
     return {
-      fileChange: fn => {
-        this._listeners.fileChange.push(fn);
+      onFileChange: fn => {
+        this._listeners.onFileChange.push(fn);
+      },
+      onTestRunComplete: fn => {
+        this._listeners.onTestRunComplete.push(fn);
       },
       shouldRunTestSuite: fn => {
         this._listeners.shouldRunTestSuite.push(fn);
-      },
-      testRunComplete: fn => {
-        this._listeners.testRunComplete.push(fn);
       },
     };
   }
 
   getEmitter(): JestHookEmitter {
     return {
-      fileChange: fs =>
-        this._listeners.fileChange.forEach(listener => listener(fs)),
+      onFileChange: fs =>
+        this._listeners.onFileChange.forEach(listener => listener(fs)),
+      onTestRunComplete: results =>
+        this._listeners.onTestRunComplete.forEach(listener =>
+          listener(results),
+        ),
       shouldRunTestSuite: async testPath =>
         Promise.all(
           this._listeners.shouldRunTestSuite.map(listener =>
@@ -75,8 +83,6 @@ class JestHooks {
         ).then(result =>
           result.every(shouldRunTestSuite => shouldRunTestSuite),
         ),
-      testRunComplete: results =>
-        this._listeners.testRunComplete.forEach(listener => listener(results)),
     };
   }
 }

--- a/packages/jest-cli/src/plugins/update_snapshots.js
+++ b/packages/jest-cli/src/plugins/update_snapshots.js
@@ -31,7 +31,7 @@ class UpdateSnapshotsPlugin extends BaseWatchPlugin {
   }
 
   apply(hooks: JestHookSubscriber) {
-    hooks.testRunComplete(results => {
+    hooks.onTestRunComplete(results => {
       this._hasSnapshotFailure = results.snapshot.failure;
     });
   }

--- a/packages/jest-cli/src/plugins/update_snapshots_interactive.js
+++ b/packages/jest-cli/src/plugins/update_snapshots_interactive.js
@@ -53,7 +53,7 @@ class UpdateSnapshotInteractivePlugin extends BaseWatchPlugin {
   }
 
   apply(hooks: JestHookSubscriber) {
-    hooks.testRunComplete(results => {
+    hooks.onTestRunComplete(results => {
       this._failedSnapshotTestAssertions = this.getFailedSnapshotTestAssertions(
         results,
       );

--- a/packages/jest-cli/src/types.js
+++ b/packages/jest-cli/src/types.js
@@ -14,10 +14,6 @@ export type UsageData = {
   prompt: string,
 };
 
-export type JestHooks = {
-  testRunComplete: any,
-};
-
 export interface WatchPlugin {
   +isInternal?: boolean;
   +apply?: (hooks: JestHookSubscriber) => void;

--- a/packages/jest-cli/src/watch.js
+++ b/packages/jest-cli/src/watch.js
@@ -141,12 +141,12 @@ export default function watch(
   let isWatchUsageDisplayed = false;
 
   const emitFileChange = () => {
-    if (hooks.isUsed('fileChange')) {
+    if (hooks.isUsed('onFileChange')) {
       const projects = searchSources.map(({context, searchSource}) => ({
         config: context.config,
         testPaths: searchSource.findMatchingTests('').tests.map(t => t.path),
       }));
-      hooks.getEmitter().fileChange({projects});
+      hooks.getEmitter().onFileChange({projects});
     }
   };
 
@@ -209,7 +209,7 @@ export default function watch(
       jestHooks: hooks.getEmitter(),
       onComplete: results => {
         isRunning = false;
-        hooks.getEmitter().testRunComplete(results);
+        hooks.getEmitter().onTestRunComplete(results);
 
         // Create a new testWatcher instance so that re-runs won't be blocked.
         // The old instance that was passed to Jest will still be interrupted


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Changed the watch plugin hooks names to be a bit more expressive.
Basically:
* `fileChange` -> `onFileChange`
* `testRunComplete` -> `onTestRunComplete`

Waiting for https://github.com/facebook/jest/pull/5895 to merge so the API is updated in the docs as well.

## Test plan

Adjusted tests