### PR TITLE
update flow && add flow strict

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -10,5 +10,12 @@ module.name_mapper='\(jest-[^/]*\)' -> '<PROJECT_ROOT>/packages/\1/src/index.js'
 include_warnings=true
 emoji=true
 
+[strict]
+nonstrict-import
+unclear-type
+unsafe-getters-setters
+untyped-import
+untyped-type-import
+
 [version]
-^0.71.0
+^0.73.0

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "eslint-plugin-react": "^7.1.0",
     "eslint-plugin-relay": "~0.0.19",
     "execa": "^0.10.0",
-    "flow-bin": "^0.71.0",
+    "flow-bin": "^0.73.0",
     "glob": "^7.1.1",
     "graceful-fs": "^4.1.11",
     "istanbul-api": "^1.3.1",

--- a/packages/jest-circus/src/__mocks__/test_event_handler.js
+++ b/packages/jest-circus/src/__mocks__/test_event_handler.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @flow
+ * @flow scrict-local
  */
 
 'use strict';

--- a/packages/jest-circus/src/__mocks__/test_utils.js
+++ b/packages/jest-circus/src/__mocks__/test_utils.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @flow
+ * @flow strict-local
  */
 
 'use strict';

--- a/packages/jest-circus/src/__tests__/after_all-test.js
+++ b/packages/jest-circus/src/__tests__/after_all-test.js
@@ -4,6 +4,8 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow strict-local
  */
 
 'use strict';

--- a/packages/jest-circus/src/__tests__/base_test-test.js
+++ b/packages/jest-circus/src/__tests__/base_test-test.js
@@ -4,6 +4,8 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow strict-local
  */
 
 'use strict';

--- a/packages/jest-circus/src/__tests__/circus_it_test_error.test.js
+++ b/packages/jest-circus/src/__tests__/circus_it_test_error.test.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow
+ * @flow strict-local
  */
 
 'use strict';

--- a/packages/jest-circus/src/__tests__/hooks.test.js
+++ b/packages/jest-circus/src/__tests__/hooks.test.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * @flow
+ * @flow strict-local
  */
 
 'use strict';

--- a/packages/jest-circus/src/event_handler.js
+++ b/packages/jest-circus/src/event_handler.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow
+ * @flow strict-local
  */
 
 import type {EventHandler} from 'types/Circus';

--- a/packages/jest-circus/src/format_node_assert_errors.js
+++ b/packages/jest-circus/src/format_node_assert_errors.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow
+ * @flow strict-local
  */
 
 import type {DiffOptions} from 'jest-diff/src/diff_strings.js';

--- a/packages/jest-circus/src/index.js
+++ b/packages/jest-circus/src/index.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow
+ * @flow strict-local
  */
 
 import type {

--- a/packages/jest-circus/src/legacy_code_todo_rewrite/jest_adapter.js
+++ b/packages/jest-circus/src/legacy_code_todo_rewrite/jest_adapter.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow
+ * @flow strict-local
  */
 
 import type {Environment} from 'types/Environment';

--- a/packages/jest-circus/src/run.js
+++ b/packages/jest-circus/src/run.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow
+ * @flow strict-local
  */
 
 import type {
@@ -99,7 +99,7 @@ const _callHook = ({
   describeBlock?: DescribeBlock,
   test?: TestEntry,
   testContext?: TestContext,
-}): Promise<any> => {
+}): Promise<mixed> => {
   dispatch({hook, name: 'hook_start'});
   const timeout = hook.timeout || getState().testTimeout;
   return callAsyncFn(hook.fn, testContext, {isHook: true, timeout})

--- a/packages/jest-circus/src/state.js
+++ b/packages/jest-circus/src/state.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow
+ * @flow strict-local
  */
 
 import type {Event, State, EventHandler} from 'types/Circus';

--- a/packages/jest-circus/src/utils.js
+++ b/packages/jest-circus/src/utils.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow
+ * @flow strict-local
  */
 
 import type {
@@ -27,15 +27,16 @@ export const makeDescribe = (
   parent: ?DescribeBlock,
   mode?: BlockMode,
 ): DescribeBlock => {
+  let _mode;
   if (parent && !mode) {
     // If not set explicitly, inherit from the parent describe.
-    mode = parent.mode;
+    _mode = parent.mode;
   }
 
   return {
     children: [],
     hooks: [],
-    mode,
+    mode: _mode,
     name,
     parent,
     tests: [],
@@ -49,18 +50,19 @@ export const makeTest = (
   parent: DescribeBlock,
   timeout: ?number,
 ): TestEntry => {
+  let _mode;
   if (!fn) {
-    mode = 'skip'; // skip test if no fn passed
+    _mode = 'skip'; // skip test if no fn passed
   } else if (!mode) {
     // if not set explicitly, inherit from its parent describe
-    mode = parent.mode;
+    _mode = parent.mode;
   }
 
   return {
     duration: null,
     errors: [],
     fn,
-    mode,
+    mode: _mode,
     name,
     parent,
     startedAt: null,
@@ -130,7 +132,7 @@ export const callAsyncFn = (
     test,
     timeout,
   }: {isHook?: ?boolean, test?: TestEntry, timeout: number},
-): Promise<any> => {
+): Promise<mixed> => {
   let timeoutID;
 
   return new Promise((resolve, reject) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3813,9 +3813,9 @@ flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
 
-flow-bin@^0.71.0:
-  version "0.71.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.71.0.tgz#fd1b27a6458c3ebaa5cb811853182ed631918b70"
+flow-bin@^0.73.0:
+  version "0.73.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.73.0.tgz#da1b90a02b0ef9c439f068c2fc14968db83be425"
 
 flow-remove-types@^1.1.0:
   version "1.2.3"


### PR DESCRIPTION
update flow, add `strict` mode and make `jest-circus` use `@flow strict-local`

flow strict caught a problem with importing `expect`, turns out it wasn't typed and was imported as `any`.
how do other modules get types? e.g. `import {...} from `jest-snapshot` in the same file had proper types