### PR TITLE
Test name pattern

### DIFF
--- a/integration-tests/__tests__/__snapshots__/test_name_pattern.test.js.snap
+++ b/integration-tests/__tests__/__snapshots__/test_name_pattern.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`testNamePattern 1`] = `
 "Test Suites: 1 passed, 1 total
-Tests:       2 skipped, 2 passed, 4 total
+Tests:       3 skipped, 2 passed, 5 total
 Snapshots:   0 total
 Time:        <<REPLACED>>
 Ran all test suites with tests matching \\"should match\\"."

--- a/integration-tests/testNamePattern/__tests__/test_name_pattern.test.js
+++ b/integration-tests/testNamePattern/__tests__/test_name_pattern.test.js
@@ -9,4 +9,5 @@
 test('should match 1', () => expect(1).toBe(1));
 test('should match 2', () => expect(1).toBe(1));
 test('should not match 1', () => expect(1).toBe(1));
+test('wisconsin', () => expect(1).toBe(1));
 test.concurrent('should not match 2', () => expect(1).toBe(1));

--- a/packages/jest-circus/src/event_handler.js
+++ b/packages/jest-circus/src/event_handler.js
@@ -99,6 +99,11 @@ const handler: EventHandler = (event, state): void => {
       state.unhandledErrors.push(event.error);
       break;
     }
+    case 'set_test_name_pattern': {
+      const regexp = new RegExp(event.pattern, 'i');
+      state.testNamePattern = regexp;
+      break;
+    }
   }
 };
 

--- a/packages/jest-circus/src/legacy_code_todo_rewrite/jest_adapter_init.js
+++ b/packages/jest-circus/src/legacy_code_todo_rewrite/jest_adapter_init.js
@@ -14,7 +14,7 @@ import type {Event, TestEntry} from 'types/Circus';
 import {extractExpectedAssertionsErrors, getState, setState} from 'expect';
 import {formatResultsErrors} from 'jest-message-util';
 import {SnapshotState, addSerializer} from 'jest-snapshot';
-import {addEventHandler, ROOT_DESCRIBE_BLOCK_NAME} from '../state';
+import {addEventHandler, dispatch, ROOT_DESCRIBE_BLOCK_NAME} from '../state';
 import {getTestID} from '../utils';
 import run from '../run';
 // eslint-disable-next-line import/default
@@ -66,6 +66,13 @@ export const initialize = ({
   global.test.concurrent.skip = global.test.skip;
 
   addEventHandler(eventHandler);
+
+  if (globalConfig.testNamePattern) {
+    dispatch({
+      name: 'set_test_name_pattern',
+      pattern: globalConfig.testNamePattern,
+    });
+  }
 
   // Jest tests snapshotSerializers in order preceding built-in serializers.
   // Therefore, add in reverse because the last added is the first tested.

--- a/packages/jest-circus/src/run.js
+++ b/packages/jest-circus/src/run.js
@@ -20,6 +20,7 @@ import {
   callAsyncFn,
   getAllHooksForDescribe,
   getEachHooksForTest,
+  getTestID,
   invariant,
   makeTestResults,
 } from './utils';
@@ -56,10 +57,12 @@ const _runTestsForDescribeBlock = async (describeBlock: DescribeBlock) => {
 const _runTest = async (test: TestEntry): Promise<void> => {
   dispatch({name: 'test_start', test});
   const testContext = Object.create(null);
+  const {hasFocusedTests, testNamePattern} = getState();
 
   const isSkipped =
     test.mode === 'skip' ||
-    (getState().hasFocusedTests && test.mode !== 'only');
+    (hasFocusedTests && test.mode !== 'only') ||
+    (testNamePattern && !testNamePattern.test(getTestID(test)));
 
   if (isSkipped) {
     dispatch({name: 'test_skip', test});

--- a/packages/jest-circus/src/state.js
+++ b/packages/jest-circus/src/state.js
@@ -25,8 +25,9 @@ const ROOT_DESCRIBE_BLOCK = makeDescribe(ROOT_DESCRIBE_BLOCK_NAME);
 const INITIAL_STATE: State = {
   currentDescribeBlock: ROOT_DESCRIBE_BLOCK,
   expand: undefined,
-  hasFocusedTests: false,
+  hasFocusedTests: false, // whether .only has been used on any test/describe
   rootDescribeBlock: ROOT_DESCRIBE_BLOCK,
+  testNamePattern: null,
   testTimeout: 5000,
   unhandledErrors: [],
 };

--- a/types/Circus.js
+++ b/types/Circus.js
@@ -121,6 +121,10 @@ export type Event =
       // an `afterAll` hook)
       name: 'error',
       error: Exception,
+    |}
+  | {|
+      name: 'set_test_name_pattern',
+      pattern: string,
     |};
 
 export type TestStatus = 'skip' | 'done';
@@ -138,6 +142,7 @@ export type State = {|
   hasFocusedTests: boolean, // that are defined using test.only
   rootDescribeBlock: DescribeBlock,
   testTimeout: number,
+  testNamePattern: ?RegExp,
   expand?: boolean, // expand error messages
   unhandledErrors: Array<Exception>,
 |};


### PR DESCRIPTION
stacked on top of `flow-strict` commit

fixes the support for `--testNamePattern` in `jest-circus`