### PR TITLE
[jest-circus] lifecycle (after All errors)

### DIFF
--- a/integration-tests/__tests__/lifecycles.js
+++ b/integration-tests/__tests__/lifecycles.js
@@ -12,7 +12,6 @@ const runJest = require('../runJest');
 
 test('suite with invalid assertions in afterAll', () => {
   const {stderr, status} = runJest('lifecycles');
-
-  expect(status).toBe(1);
   expect(stderr).toMatch(/afterAll just failed!/);
+  expect(status).toBe(1);
 });

--- a/packages/jest-circus/src/run.js
+++ b/packages/jest-circus/src/run.js
@@ -8,8 +8,8 @@
  */
 
 import type {
+  RunResult,
   TestEntry,
-  TestResults,
   TestContext,
   Hook,
   DescribeBlock,
@@ -22,15 +22,18 @@ import {
   getEachHooksForTest,
   getTestID,
   invariant,
-  makeTestResults,
+  makeRunResult,
 } from './utils';
 
-const run = async (): Promise<TestResults> => {
+const run = async (): Promise<RunResult> => {
   const {rootDescribeBlock} = getState();
   dispatch({name: 'run_start'});
   await _runTestsForDescribeBlock(rootDescribeBlock);
   dispatch({name: 'run_finish'});
-  return makeTestResults(getState().rootDescribeBlock);
+  return makeRunResult(
+    getState().rootDescribeBlock,
+    getState().unhandledErrors,
+  );
 };
 
 const _runTestsForDescribeBlock = async (describeBlock: DescribeBlock) => {

--- a/packages/jest-circus/src/utils.js
+++ b/packages/jest-circus/src/utils.js
@@ -14,6 +14,7 @@ import type {
   DescribeBlock,
   Exception,
   Hook,
+  RunResult,
   TestEntry,
   TestContext,
   TestFn,
@@ -200,7 +201,17 @@ export const getTestDuration = (test: TestEntry): ?number => {
   return startedAt ? Date.now() - startedAt : null;
 };
 
-export const makeTestResults = (describeBlock: DescribeBlock): TestResults => {
+export const makeRunResult = (
+  describeBlock: DescribeBlock,
+  unhandledErrors: Array<Error>,
+): RunResult => {
+  return {
+    testResults: makeTestResults(describeBlock),
+    unhandledErrors: unhandledErrors.map(_formatError),
+  };
+};
+
+const makeTestResults = (describeBlock: DescribeBlock): TestResults => {
   let testResults = [];
   for (const test of describeBlock.tests) {
     const testPath = [];

--- a/types/Circus.js
+++ b/types/Circus.js
@@ -132,8 +132,13 @@ export type TestResult = {|
   duration: ?number,
   errors: Array<FormattedError>,
   status: TestStatus,
-  testPath: Array<TestName>,
+  testPath: Array<TestName | BlockName>,
 |};
+
+export type RunResult = {
+  unhandledErrors: Array<FormattedError>,
+  testResults: TestResults,
+};
 
 export type TestResults = Array<TestResult>;
 


### PR DESCRIPTION
this adds a concept of `unhandledErrors`
any unhandled error is treated as `testExecError` and fails the test (even though all test could be passing)

afterEach hook's logic is pretty bizarre in Jasmine (it reports 0 test passed even if all tests succeeded) 

with this implementation it'll report tests normally, but fail the whole suite at the end.

Error formatting logic is a bit weird because of Jasmin error format, but it all lives under `legacy` code dir and we'll rewrite it after `jest-circus` ships