### PR TITLE
Run with Jest Circus when passing the JEST_CIRCUS env variable as 1

### DIFF
--- a/integration-tests/__tests__/each.test.js
+++ b/integration-tests/__tests__/each.test.js
@@ -14,8 +14,10 @@ const runJest = require('../runJest');
 const {extractSummary} = require('../Utils');
 const dir = path.resolve(__dirname, '../each');
 const SkipOnWindows = require('../../scripts/SkipOnWindows');
+const SkipOnJestCircus = require('../../scripts/SkipOnJestCircus');
 
 SkipOnWindows.suite();
+SkipOnJestCircus.suite();
 
 test('works with passing tests', () => {
   const result = runJest(dir, ['success.test.js']);

--- a/packages/jest-runner/src/run_test.js
+++ b/packages/jest-runner/src/run_test.js
@@ -66,12 +66,14 @@ async function runTestInternal(
     );
   }
 
+  /* $FlowFixMe */
   const TestEnvironment = (require(testEnvironment): EnvironmentClass);
   const testFramework = ((process.env.JEST_CIRCUS === '1'
     ? /* $FlowFixMe */
       require('jest-circus/build/legacy_code_todo_rewrite/jest_adapter.js') // eslint-disable-line import/no-extraneous-dependencies
         .default
-    : require(config.testRunner)): TestFramework);
+    : /* $FlowFixMe */
+      require(config.testRunner)): TestFramework);
   /* $FlowFixMe */
   const Runtime = (require(config.moduleLoader || 'jest-runtime'): Class<
     RuntimeClass,

--- a/packages/jest-runner/src/run_test.js
+++ b/packages/jest-runner/src/run_test.js
@@ -66,12 +66,10 @@ async function runTestInternal(
     );
   }
 
-  /* $FlowFixMe */
   const TestEnvironment = (require(testEnvironment): EnvironmentClass);
-  /* $FlowFixMe */
   const testFramework = ((process.env.JEST_CIRCUS === '1'
-    ? // eslint-disable-next-line import/no-extraneous-dependencies
-      require('jest-circus/build/legacy_code_todo_rewrite/jest_adapter.js')
+    ? /* $FlowFixMe */
+      require('jest-circus/build/legacy_code_todo_rewrite/jest_adapter.js') // eslint-disable-line import/no-extraneous-dependencies
         .default
     : require(config.testRunner)): TestFramework);
   /* $FlowFixMe */

--- a/packages/jest-runner/src/run_test.js
+++ b/packages/jest-runner/src/run_test.js
@@ -69,7 +69,11 @@ async function runTestInternal(
   /* $FlowFixMe */
   const TestEnvironment = (require(testEnvironment): EnvironmentClass);
   /* $FlowFixMe */
-  const testFramework = (require(config.testRunner): TestFramework);
+  const testFramework = ((process.env.JEST_CIRCUS === '1'
+    ? // eslint-disable-next-line import/no-extraneous-dependencies
+      require('jest-circus/build/legacy_code_todo_rewrite/jest_adapter.js')
+        .default
+    : require(config.testRunner)): TestFramework);
   /* $FlowFixMe */
   const Runtime = (require(config.moduleLoader || 'jest-runtime'): Class<
     RuntimeClass,

--- a/scripts/SkipOnJestCircus.js
+++ b/scripts/SkipOnJestCircus.js
@@ -9,7 +9,7 @@
 
 /* eslint-disable jest/no-focused-tests */
 
-const SkipOnWindows = {
+const SkipOnJestCircus = {
   suite() {
     if (process.env.JEST_CIRCUS === '1') {
       fit('does not work on jest-circus', () => {
@@ -27,4 +27,4 @@ const SkipOnWindows = {
   },
 };
 
-module.exports = SkipOnWindows;
+module.exports = SkipOnJestCircus;

--- a/scripts/SkipOnJestCircus.js
+++ b/scripts/SkipOnJestCircus.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+/* eslint-disable jest/no-focused-tests */
+
+const SkipOnWindows = {
+  suite() {
+    if (process.env.JEST_CIRCUS === '1') {
+      fit('does not work on jest-circus', () => {
+        console.warn('[SKIP] Does not work on jest-circus');
+      });
+    }
+  },
+
+  test() {
+    if (process.env.JEST_CIRCUS === '1') {
+      console.warn('[SKIP] Does not work on jest-circus');
+      return true;
+    }
+    return false;
+  },
+};
+
+module.exports = SkipOnWindows;


### PR DESCRIPTION
## Summary

Relates to #4362

You can now run our test with: `JEST_CIRCUS=1 ./jest` and it will use Jest circus.

This will:

1. Make it easy to run a test locally with Jest Circus
2. Enable us to flag individual tests as known to be failing on Jest
   Circus.
3. Make it easy to run Jest Circus on other code bases.
4. Once 2 is complete, we can setup a second CI run that uses Jest
   Circus to ensure we don't regress.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Test plan

<img width="558" alt="screen shot 2018-05-26 at 4 22 33 pm" src="https://user-images.githubusercontent.com/162735/40577648-0f62f290-6101-11e8-8be1-0297509703a2.png">

@aaronabramov 