### PR TITLE
[jest-circus] override-globals

### DIFF
--- a/packages/jest-circus/src/legacy_code_todo_rewrite/jest_adapter_init.js
+++ b/packages/jest-circus/src/legacy_code_todo_rewrite/jest_adapter_init.js
@@ -15,10 +15,12 @@ import {extractExpectedAssertionsErrors, getState, setState} from 'expect';
 import {formatExecError, formatResultsErrors} from 'jest-message-util';
 import {SnapshotState, addSerializer} from 'jest-snapshot';
 import {addEventHandler, dispatch, ROOT_DESCRIBE_BLOCK_NAME} from '../state';
-import {getTestID} from '../utils';
+import {getTestID, getOriginalPromise} from '../utils';
 import run from '../run';
 // eslint-disable-next-line import/default
 import globals from '../index';
+
+const Promise = getOriginalPromise();
 
 export const initialize = ({
   config,

--- a/packages/jest-circus/src/run.js
+++ b/packages/jest-circus/src/run.js
@@ -23,7 +23,10 @@ import {
   getTestID,
   invariant,
   makeRunResult,
+  getOriginalPromise,
 } from './utils';
+
+const Promise = getOriginalPromise();
 
 const run = async (): Promise<RunResult> => {
   const {rootDescribeBlock} = getState();

--- a/packages/jest-circus/src/utils.js
+++ b/packages/jest-circus/src/utils.js
@@ -23,6 +23,12 @@ import type {
   TestResults,
 } from 'types/Circus';
 
+// Try getting the real promise object from the context, if available. Someone
+// could have overridden it in a test. Async functions return it implicitly.
+// eslint-disable-next-line no-unused-vars
+const Promise = global[Symbol.for('jest-native-promise')] || global.Promise;
+export const getOriginalPromise = () => Promise;
+
 export const makeDescribe = (
   name: BlockName,
   parent: ?DescribeBlock,


### PR DESCRIPTION
That's not a scalable solution, but that's what we're doing now.
We should create a lint rule that looks for usage of global, overridable variables (e.g. `Promise`, `setTimeout`) and warns if you're using them from `global` object prompting to capture the original values in the closure