### PR TITLE
Add `testLocationInResults` support to jest-circus

### DIFF
--- a/integration-tests/__tests__/location_in_results.test.js
+++ b/integration-tests/__tests__/location_in_results.test.js
@@ -10,6 +10,7 @@
 
 import skipOnJestCicrus from '../../scripts/SkipOnJestCircus';
 const runJest = require('../runJest');
+const SkipOnJestCircus = require('../../scripts/SkipOnJestCircus');
 
 skipOnJestCicrus.suite();
 
@@ -32,5 +33,11 @@ it('adds correct location info when provided with flag', () => {
   expect(result.success).toBe(true);
   expect(result.numTotalTests).toBe(2);
   expect(assertions[0].location).toEqual({column: 1, line: 10});
-  expect(assertions[1].location).toEqual({column: 2, line: 15});
+
+  // Technically the column should be 3, but callsites is not correct.
+  // jest-circus uses stack-utils + asyncErrors which resolves this.
+  expect(assertions[1].location).toEqual({
+    column: SkipOnJestCircus.isJestCircusRun() ? 3 : 2,
+    line: 15,
+  });
 });

--- a/packages/jest-circus/package.json
+++ b/packages/jest-circus/package.json
@@ -15,7 +15,8 @@
     "jest-message-util": "^23.0.0",
     "jest-snapshot": "^23.0.0",
     "jest-util": "^23.0.0",
-    "pretty-format": "^23.0.0"
+    "pretty-format": "^23.0.0",
+    "stack-utils": "^1.0.1"
   },
   "devDependencies": {
     "jest-runtime": "^23.0.0"

--- a/packages/jest-circus/src/event_handler.js
+++ b/packages/jest-circus/src/event_handler.js
@@ -22,6 +22,10 @@ const TEST_TIMEOUT_SYMBOL = Symbol.for('TEST_TIMEOUT_SYMBOL');
 
 const handler: EventHandler = (event, state): void => {
   switch (event.name) {
+    case 'include_test_location_in_result': {
+      state.includeTestLocationInResult = true;
+      break;
+    }
     case 'hook_start': {
       break;
     }

--- a/packages/jest-circus/src/legacy_code_todo_rewrite/jest_adapter_init.js
+++ b/packages/jest-circus/src/legacy_code_todo_rewrite/jest_adapter_init.js
@@ -102,7 +102,7 @@ export const runAndTransformResultsToJestFormat = async ({
   globalConfig: GlobalConfig,
   testPath: string,
 }): Promise<TestResult> => {
-  const runResult = await run();
+  const runResult = await run(config);
 
   let numFailingTests = 0;
   let numPassingTests = 0;
@@ -131,6 +131,7 @@ export const runAndTransformResultsToJestFormat = async ({
       duration: testResult.duration,
       failureMessages: testResult.errors,
       fullName: ancestorTitles.concat(title).join(' '),
+      location: testResult.location,
       numPassingAsserts: 0,
       status,
       title: testResult.testPath[testResult.testPath.length - 1],
@@ -138,7 +139,6 @@ export const runAndTransformResultsToJestFormat = async ({
   });
 
   let failureMessage = formatResultsErrors(
-    // $FlowFixMe Types are slightly incompatible and need to be refactored
     assertionResults,
     config,
     globalConfig,

--- a/packages/jest-circus/src/legacy_code_todo_rewrite/jest_adapter_init.js
+++ b/packages/jest-circus/src/legacy_code_todo_rewrite/jest_adapter_init.js
@@ -76,6 +76,12 @@ export const initialize = ({
     });
   }
 
+  if (config.testLocationInResults) {
+    dispatch({
+      name: 'include_test_location_in_result',
+    });
+  }
+
   // Jest tests snapshotSerializers in order preceding built-in serializers.
   // Therefore, add in reverse because the last added is the first tested.
   config.snapshotSerializers
@@ -102,7 +108,7 @@ export const runAndTransformResultsToJestFormat = async ({
   globalConfig: GlobalConfig,
   testPath: string,
 }): Promise<TestResult> => {
-  const runResult = await run(config);
+  const runResult = await run();
 
   let numFailingTests = 0;
   let numPassingTests = 0;

--- a/packages/jest-circus/src/run.js
+++ b/packages/jest-circus/src/run.js
@@ -7,6 +7,8 @@
  * @flow strict-local
  */
 
+import type {ProjectConfig} from 'types/Config';
+
 import type {
   RunResult,
   TestEntry,
@@ -28,7 +30,7 @@ import {
 
 const Promise = getOriginalPromise();
 
-const run = async (): Promise<RunResult> => {
+const run = async (config: ProjectConfig): Promise<RunResult> => {
   const {rootDescribeBlock} = getState();
   dispatch({name: 'run_start'});
   await _runTestsForDescribeBlock(rootDescribeBlock);
@@ -36,6 +38,7 @@ const run = async (): Promise<RunResult> => {
   return makeRunResult(
     getState().rootDescribeBlock,
     getState().unhandledErrors,
+    config,
   );
 };
 

--- a/packages/jest-circus/src/run.js
+++ b/packages/jest-circus/src/run.js
@@ -7,8 +7,6 @@
  * @flow strict-local
  */
 
-import type {ProjectConfig} from 'types/Config';
-
 import type {
   RunResult,
   TestEntry,
@@ -30,7 +28,7 @@ import {
 
 const Promise = getOriginalPromise();
 
-const run = async (config: ProjectConfig): Promise<RunResult> => {
+const run = async (): Promise<RunResult> => {
   const {rootDescribeBlock} = getState();
   dispatch({name: 'run_start'});
   await _runTestsForDescribeBlock(rootDescribeBlock);
@@ -38,7 +36,6 @@ const run = async (config: ProjectConfig): Promise<RunResult> => {
   return makeRunResult(
     getState().rootDescribeBlock,
     getState().unhandledErrors,
-    config,
   );
 };
 

--- a/packages/jest-circus/src/state.js
+++ b/packages/jest-circus/src/state.js
@@ -26,6 +26,7 @@ const INITIAL_STATE: State = {
   currentDescribeBlock: ROOT_DESCRIBE_BLOCK,
   expand: undefined,
   hasFocusedTests: false, // whether .only has been used on any test/describe
+  includeTestLocationInResult: false,
   rootDescribeBlock: ROOT_DESCRIBE_BLOCK,
   testNamePattern: null,
   testTimeout: 5000,

--- a/packages/jest-circus/src/utils.js
+++ b/packages/jest-circus/src/utils.js
@@ -7,7 +7,6 @@
  * @flow strict-local
  */
 
-import type {ProjectConfig} from 'types/Config';
 import type {
   AsyncFn,
   BlockMode,
@@ -28,6 +27,8 @@ import {convertDescriptorToString} from 'jest-util';
 import StackUtils from 'stack-utils';
 
 import prettyFormat from 'pretty-format';
+
+import {getState} from './state';
 
 // Try getting the real promise object from the context, if available. Someone
 // could have overridden it in a test. Async functions return it implicitly.
@@ -227,15 +228,15 @@ export const getTestDuration = (test: TestEntry): ?number => {
 export const makeRunResult = (
   describeBlock: DescribeBlock,
   unhandledErrors: Array<Error>,
-  config: ProjectConfig,
 ): RunResult => {
   return {
-    testResults: makeTestResults(describeBlock, config),
+    testResults: makeTestResults(describeBlock),
     unhandledErrors: unhandledErrors.map(_formatError),
   };
 };
 
 const makeTestResults = (describeBlock: DescribeBlock, config): TestResults => {
+  const {includeTestLocationInResult} = getState();
   let testResults = [];
   for (const test of describeBlock.tests) {
     const testPath = [];
@@ -251,7 +252,7 @@ const makeTestResults = (describeBlock: DescribeBlock, config): TestResults => {
     }
 
     let location = null;
-    if (config.testLocationInResults) {
+    if (includeTestLocationInResult) {
       const stackLine = test.asyncError.stack.split('\n')[1];
       const {line, column} = stackUtils.parseLine(stackLine);
       location = {column, line};

--- a/packages/jest-circus/src/utils.js
+++ b/packages/jest-circus/src/utils.js
@@ -35,6 +35,8 @@ import prettyFormat from 'pretty-format';
 const Promise = global[Symbol.for('jest-native-promise')] || global.Promise;
 export const getOriginalPromise = () => Promise;
 
+const stackUtils = new StackUtils({cwd: 'A path that does not exist'});
+
 export const makeDescribe = (
   name: BlockName,
   parent: ?DescribeBlock,
@@ -234,7 +236,6 @@ export const makeRunResult = (
 };
 
 const makeTestResults = (describeBlock: DescribeBlock, config): TestResults => {
-  const stackUtils = new StackUtils();
   let testResults = [];
   for (const test of describeBlock.tests) {
     const testPath = [];

--- a/scripts/SkipOnJestCircus.js
+++ b/scripts/SkipOnJestCircus.js
@@ -10,6 +10,10 @@
 /* eslint-disable jest/no-focused-tests */
 
 const SkipOnJestCircus = {
+  isJestCircusRun() {
+    return process.env.JEST_CIRCUS === '1';
+  },
+
   suite() {
     if (process.env.JEST_CIRCUS === '1') {
       fit('does not work on jest-circus', () => {

--- a/types/Circus.js
+++ b/types/Circus.js
@@ -33,6 +33,9 @@ export type EventHandler = (event: Event, state: State) => void;
 
 export type Event =
   | {|
+      name: 'include_test_location_in_result',
+    |}
+  | {|
       asyncError: Exception,
       mode: BlockMode,
       name: 'start_describe_definition',
@@ -156,6 +159,7 @@ export type State = {|
   testNamePattern: ?RegExp,
   expand?: boolean, // expand error messages
   unhandledErrors: Array<Exception>,
+  includeTestLocationInResult: boolean,
 |};
 
 export type DescribeBlock = {|

--- a/types/Circus.js
+++ b/types/Circus.js
@@ -137,6 +137,7 @@ export type TestResult = {|
   duration: ?number,
   errors: Array<FormattedError>,
   status: TestStatus,
+  location: ?{|column: number, line: number|},
   testPath: Array<TestName | BlockName>,
 |};
 


### PR DESCRIPTION
Part of #4362 

@SimenB 

@aaronabramov importing `stack-utils` in `packages/jest-circus/src/utils.js` breaks flow-strict. Thoughts?