### PR TITLE
Add stack-utils types

### DIFF
--- a/flow-typed/stack-utils.js
+++ b/flow-typed/stack-utils.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+type ParsedFrame = {
+  line: number,
+  column: number,
+  file: string,
+};
+declare class StackUtils {
+  constructor(?{cwd?: string}): StackUtils;
+  parseLine(string): ParsedFrame;
+  static nodeInternals: () => Array<RegExp>;
+}
+
+declare module 'stack-utils' {
+  declare export default typeof StackUtils;
+}


### PR DESCRIPTION
Add types for the `stack-utils` library.

I've only added the properties we use. I could read the code and try to add others, but I don't know how I could trust that I got them right.

Is it okay to add more as we use more methods/properties.

## Test method

`yarn flow`.