### PR TITLE
[jest-circus] add types for generator packages

### DIFF
--- a/flow-typed/co.js
+++ b/flow-typed/co.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+declare module 'co' {
+  declare export default {wrap: Function => () => Promise<any>};
+}

--- a/flow-typed/is-generator-fn.js
+++ b/flow-typed/is-generator-fn.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+declare module 'is-generator-fn' {
+  declare export default (Function) => boolean;
+}


### PR DESCRIPTION
they are used in jasmine (currently type of `any`)and i'm going to use them in `jest-circus` as well