### PR TITLE
[jest-circus] fix stack frame for test timeout

### DIFF
--- a/integration-tests/__tests__/__snapshots__/failures.test.js.snap
+++ b/integration-tests/__tests__/__snapshots__/failures.test.js.snap
@@ -390,23 +390,23 @@ exports[`works with async failures 1`] = `
          |          ^
       25 | });
       26 | 
-      27 | test('timeout', done => {
+      27 | test(
 
       at __tests__/async_failures.test.js:24:10
 
   ● timeout
 
-    Timeout - Async callback was not invoked within the 5ms timeout specified by jest.setTimeout.
+    thrown: \\"Exceeded timeout of 5ms for a test.
+    Use jest.setTimeout(newTimeout) to increase the timeout value, if this is a long-running test.\\"
 
       25 | });
       26 | 
-    > 27 | test('timeout', done => {
+    > 27 | test(
          | ^
-      28 |   jest.setTimeout(5);
-      29 | 
-      30 |   setTimeout(done, 10);
+      28 |   'timeout',
+      29 |   done => {
+      30 |     setTimeout(done, 10);
 
-      at packages/jest-jasmine2/build/jasmine/Spec.js:85:20
       at __tests__/async_failures.test.js:27:1
 
 "

--- a/integration-tests/__tests__/__snapshots__/failures.test.js.snap
+++ b/integration-tests/__tests__/__snapshots__/failures.test.js.snap
@@ -405,7 +405,7 @@ exports[`works with async failures 1`] = `
          | ^
       28 |   'timeout',
       29 |   done => {
-      30 |     setTimeout(done, 10);
+      30 |     setTimeout(done, 50);
 
       at __tests__/async_failures.test.js:27:1
 

--- a/integration-tests/__tests__/__snapshots__/failures.test.js.snap
+++ b/integration-tests/__tests__/__snapshots__/failures.test.js.snap
@@ -396,8 +396,7 @@ exports[`works with async failures 1`] = `
 
   ● timeout
 
-    thrown: \\"Exceeded timeout of 5ms for a test.
-    Use jest.setTimeout(newTimeout) to increase the timeout value, if this is a long-running test.\\"
+<REPLACED>
 
       25 | });
       26 | 

--- a/integration-tests/__tests__/failures.test.js
+++ b/integration-tests/__tests__/failures.test.js
@@ -7,9 +7,6 @@
  * @flow
  */
 
-import skipOnJestCircus from '../../scripts/SkipOnJestCircus';
-skipOnJestCircus.suite();
-
 const path = require('path');
 const SkipOnWindows = require('../../scripts/SkipOnWindows');
 const {extractSummary} = require('../Utils');

--- a/integration-tests/__tests__/failures.test.js
+++ b/integration-tests/__tests__/failures.test.js
@@ -153,12 +153,18 @@ test('works with assertions in separate files', () => {
 test('works with async failures', () => {
   const {stderr} = runJest(dir, ['async_failures.test.js']);
 
-  const rest = extractSummary(stderr)
-    .rest.split('\n')
+  const rest = cleanStderr(stderr)
+    .split('\n')
     .filter(line => line.indexOf('packages/expect/build/index.js') === -1)
     .join('\n');
 
-  expect(normalizeDots(rest)).toMatchSnapshot();
+  // Remove replacements when jasmine is gone
+  const result = normalizeDots(rest)
+    .replace(/.*thrown:.*\n/, '')
+    .replace(/.*Use jest\.setTimeout\(newTimeout\).*/, '<REPLACED>')
+    .replace(/.*Timeout - Async callback was not.*/, '<REPLACED>');
+
+  expect(result).toMatchSnapshot();
 });
 
 test('works with snapshot failures', () => {

--- a/integration-tests/failures/__tests__/async_failures.test.js
+++ b/integration-tests/failures/__tests__/async_failures.test.js
@@ -24,8 +24,10 @@ test('expect resolve', () => {
   return expect(Promise.reject({foo: 'bar'})).resolves.toEqual({foo: 'bar'});
 });
 
-test('timeout', done => {
-  jest.setTimeout(5);
-
-  setTimeout(done, 10);
-});
+test(
+  'timeout',
+  done => {
+    setTimeout(done, 10);
+  },
+  5
+);

--- a/integration-tests/failures/__tests__/async_failures.test.js
+++ b/integration-tests/failures/__tests__/async_failures.test.js
@@ -27,7 +27,7 @@ test('expect resolve', () => {
 test(
   'timeout',
   done => {
-    setTimeout(done, 10);
+    setTimeout(done, 50);
   },
   5
 );

--- a/packages/jest-circus/src/utils.js
+++ b/packages/jest-circus/src/utils.js
@@ -124,11 +124,9 @@ export const getEachHooksForTest = (
 };
 
 const _makeTimeoutMessage = (timeout, isHook) =>
-  new Error(
-    `Exceeded timeout of ${timeout}ms for a ${
-      isHook ? 'hook' : 'test'
-    }.\nUse jest.setTimeout(newTimeout) to increase the timeout value, if this is a long-running test.`,
-  );
+  `Exceeded timeout of ${timeout}ms for a ${
+    isHook ? 'hook' : 'test'
+  }.\nUse jest.setTimeout(newTimeout) to increase the timeout value, if this is a long-running test.`;
 
 // Global values can be overwritten by mocks or tests. We'll capture
 // the original values in the variables before we require any files.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary
By not providing a new error, some later code will make sure to append the stack from `asyncError`.

We should probably still fix #6277, fwiw, but this allows us to enable the failures test.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan
Green CI.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
