### PR TITLE
normalize icons and slashes across OSes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## master
 
+### Fixes
+
+* `[jest-cli]` Normalize slashes in paths in CLI output on Windows ((#6310)[https://github.com/facebook/jest/pull/6310])
+
 ## 23.0.1
 
 ### Chore & Maintenance

--- a/integration-tests/Utils.js
+++ b/integration-tests/Utils.js
@@ -48,15 +48,6 @@ const linkJestPackage = (packageName: string, cwd: Path) => {
   fs.symlinkSync(packagePath, destination, 'dir');
 };
 
-const fileExists = (filePath: Path) => {
-  try {
-    fs.accessSync(filePath, fs.F_OK);
-    return true;
-  } catch (e) {
-    return false;
-  }
-};
-
 const makeTemplate = (str: string): ((values?: Array<any>) => string) => {
   return (values: ?Array<any>) => {
     return str.replace(/\$(\d+)/g, (match, number) => {
@@ -175,14 +166,25 @@ const cleanupStackTrace = (output: string) => {
     .replace(/^.*at.*[\s][\(]?(\S*\:\d*\:\d*).*$/gm, '      at $1');
 };
 
+const normalizeIcons = (str: string) => {
+  if (!str) {
+    return str;
+  }
+
+  // Make sure to keep in sync with `jest-cli/src/constants`
+  return str
+    .replace(new RegExp('\u00D7', 'g'), '\u2715')
+    .replace(new RegExp('\u221A', 'g'), '\u2713');
+};
+
 module.exports = {
   cleanup,
   copyDir,
   createEmptyPackage,
   extractSummary,
-  fileExists,
   linkJestPackage,
   makeTemplate,
+  normalizeIcons,
   run,
   writeFiles,
 };

--- a/integration-tests/__tests__/__snapshots__/jest.config.js.test.js.snap
+++ b/integration-tests/__tests__/__snapshots__/jest.config.js.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`traverses directory tree up until it finds jest.config 1`] = `
-"  console.log ../../../__tests__/a-banana.js:3
+"  console.log ../../../__tests__/a-banana.js:4
 <<REPLACED>>/jest.config.js/some/nested/directory
 "
 `;

--- a/integration-tests/__tests__/compare_dom_nodes.test.js
+++ b/integration-tests/__tests__/compare_dom_nodes.test.js
@@ -8,10 +8,7 @@
  */
 'use strict';
 
-const SkipOnWindows = require('../../scripts/SkipOnWindows');
 const runJest = require('../runJest');
-
-SkipOnWindows.suite();
 
 test('does not crash when expect involving a DOM node fails', () => {
   const result = runJest('compare-dom-nodes');

--- a/integration-tests/__tests__/console.test.js
+++ b/integration-tests/__tests__/console.test.js
@@ -9,11 +9,8 @@
 
 'use strict';
 
-const SkipOnWindows = require('../../scripts/SkipOnWindows');
 const {extractSummary} = require('../Utils');
 const runJest = require('../runJest');
-
-SkipOnWindows.suite();
 
 test('console printing', () => {
   const {stderr, status} = runJest('console');

--- a/integration-tests/__tests__/console_log_output_when_run_in_band.test.js
+++ b/integration-tests/__tests__/console_log_output_when_run_in_band.test.js
@@ -10,13 +10,10 @@
 'use strict';
 
 const path = require('path');
-const SkipOnWindows = require('../../scripts/SkipOnWindows');
 const {extractSummary, cleanup, writeFiles} = require('../Utils');
 const runJest = require('../runJest');
 
 const DIR = path.resolve(__dirname, '../console_log_output_when_run_in_band');
-
-SkipOnWindows.suite();
 
 beforeEach(() => cleanup(DIR));
 afterAll(() => cleanup(DIR));

--- a/integration-tests/__tests__/coverage_report.test.js
+++ b/integration-tests/__tests__/coverage_report.test.js
@@ -10,13 +10,10 @@
 
 const fs = require('fs');
 const path = require('path');
-const SkipOnWindows = require('../../scripts/SkipOnWindows');
 const {extractSummary} = require('../Utils');
 const runJest = require('../runJest');
 
 const DIR = path.resolve(__dirname, '../coverage-report');
-
-SkipOnWindows.suite();
 
 test('outputs coverage report', () => {
   const {stdout, status} = runJest(DIR, ['--no-cache', '--coverage']);

--- a/integration-tests/__tests__/coverage_threshold.test.js
+++ b/integration-tests/__tests__/coverage_threshold.test.js
@@ -10,13 +10,10 @@
 'use strict';
 
 const path = require('path');
-const SkipOnWindows = require('../../scripts/SkipOnWindows');
 const {cleanup, writeFiles} = require('../Utils');
 const runJest = require('../runJest');
 
 const DIR = path.resolve(__dirname, '../coverage-threshold');
-
-SkipOnWindows.suite();
 
 beforeEach(() => cleanup(DIR));
 afterAll(() => cleanup(DIR));

--- a/integration-tests/__tests__/custom_matcher_stack_trace.test.js
+++ b/integration-tests/__tests__/custom_matcher_stack_trace.test.js
@@ -10,9 +10,6 @@
 
 const runJest = require('../runJest');
 const {extractSummary} = require('../Utils');
-const SkipOnWindows = require('../../scripts/SkipOnWindows');
-
-SkipOnWindows.suite();
 
 test('works with custom matchers', () => {
   const {stderr} = runJest('custom-matcher-stack-trace');

--- a/integration-tests/__tests__/custom_reporters.test.js
+++ b/integration-tests/__tests__/custom_reporters.test.js
@@ -8,7 +8,6 @@
  */
 'use strict';
 
-const SkipOnWindows = require('../../scripts/SkipOnWindows');
 const {cleanup, extractSummary, writeFiles} = require('../Utils');
 const runJest = require('../runJest');
 const os = require('os');
@@ -20,8 +19,6 @@ beforeEach(() => cleanup(DIR));
 afterEach(() => cleanup(DIR));
 
 describe('Custom Reporters Integration', () => {
-  SkipOnWindows.suite();
-
   test('valid string format for adding reporters', () => {
     const reporterConfig = {
       reporters: ['<rootDir>/reporters/TestReporter.js'],

--- a/integration-tests/__tests__/debug.test.js
+++ b/integration-tests/__tests__/debug.test.js
@@ -7,12 +7,9 @@
  */
 
 const path = require('path');
-const SkipOnWindows = require('../../scripts/SkipOnWindows');
 const runJest = require('../runJest');
 
 describe('jest --debug', () => {
-  SkipOnWindows.suite();
-
   const dir = path.resolve(__dirname, '..', 'verbose-reporter');
 
   it('outputs debugging info before running the test', () => {

--- a/integration-tests/__tests__/each.test.js
+++ b/integration-tests/__tests__/each.test.js
@@ -13,10 +13,8 @@ const path = require('path');
 const runJest = require('../runJest');
 const {extractSummary} = require('../Utils');
 const dir = path.resolve(__dirname, '../each');
-const SkipOnWindows = require('../../scripts/SkipOnWindows');
 const SkipOnJestCircus = require('../../scripts/SkipOnJestCircus');
 
-SkipOnWindows.suite();
 SkipOnJestCircus.suite();
 
 test('works with passing tests', () => {

--- a/integration-tests/__tests__/execute-tests-once-in-mpr.js
+++ b/integration-tests/__tests__/execute-tests-once-in-mpr.js
@@ -10,13 +10,10 @@
 'use strict';
 
 const path = require('path');
-const SkipOnWindows = require('../../scripts/SkipOnWindows');
 const {extractSummary, cleanup, writeFiles} = require('../Utils');
 const runJest = require('../runJest');
 
 const DIR = path.resolve(__dirname, '../execute-tests-once-in-mpr');
-
-SkipOnWindows.suite();
 
 beforeEach(() => cleanup(DIR));
 afterAll(() => cleanup(DIR));

--- a/integration-tests/__tests__/expect-async-matcher.test.js
+++ b/integration-tests/__tests__/expect-async-matcher.test.js
@@ -10,12 +10,9 @@
 'use strict';
 
 const path = require('path');
-const SkipOnWindows = require('../../scripts/SkipOnWindows');
 const runJest = require('../runJest');
 const {extractSummary} = require('../Utils');
 const dir = path.resolve(__dirname, '../expect-async-matcher');
-
-SkipOnWindows.suite();
 
 test('works with passing tests', () => {
   const result = runJest(dir, ['success.test.js']);

--- a/integration-tests/__tests__/failures.test.js
+++ b/integration-tests/__tests__/failures.test.js
@@ -8,15 +8,12 @@
  */
 
 const path = require('path');
-const SkipOnWindows = require('../../scripts/SkipOnWindows');
 const {extractSummary} = require('../Utils');
 const runJest = require('../runJest');
 
 const dir = path.resolve(__dirname, '../failures');
 
 const normalizeDots = text => text.replace(/\.{1,}$/gm, '.');
-
-SkipOnWindows.suite();
 
 function cleanStderr(stderr) {
   const {rest} = extractSummary(stderr);

--- a/integration-tests/__tests__/find_related_files.test.js
+++ b/integration-tests/__tests__/find_related_files.test.js
@@ -15,10 +15,7 @@ import path from 'path';
 
 const {cleanup, writeFiles, extractSummary} = require('../Utils');
 
-const SkipOnWindows = require('../../scripts/SkipOnWindows');
 const DIR = path.resolve(os.tmpdir(), 'find_related_tests_test');
-
-SkipOnWindows.suite();
 
 beforeEach(() => cleanup(DIR));
 afterEach(() => cleanup(DIR));

--- a/integration-tests/__tests__/force_exit.test.js
+++ b/integration-tests/__tests__/force_exit.test.js
@@ -14,10 +14,7 @@ import os from 'os';
 import path from 'path';
 const {cleanup, writeFiles} = require('../Utils');
 
-const SkipOnWindows = require('../../scripts/SkipOnWindows');
 const DIR = path.resolve(os.tmpdir(), 'force_exit_test');
-
-SkipOnWindows.suite();
 
 beforeEach(() => cleanup(DIR));
 afterEach(() => cleanup(DIR));

--- a/integration-tests/__tests__/globals.test.js
+++ b/integration-tests/__tests__/globals.test.js
@@ -11,15 +11,12 @@
 
 const path = require('path');
 const os = require('os');
-const SkipOnWindows = require('../../scripts/SkipOnWindows');
 const runJest = require('../runJest');
 const {extractSummary} = require('../Utils');
 const {createEmptyPackage, writeFiles, cleanup} = require('../Utils');
 
 const DIR = path.resolve(os.tmpdir(), 'global-variables.test');
 const TEST_DIR = path.resolve(DIR, '__tests__');
-
-SkipOnWindows.suite();
 
 function cleanStderr(stderr) {
   const {rest} = extractSummary(stderr);

--- a/integration-tests/__tests__/jest.config.js.test.js
+++ b/integration-tests/__tests__/jest.config.js.test.js
@@ -10,13 +10,10 @@
 'use strict';
 
 const path = require('path');
-const SkipOnWindows = require('../../scripts/SkipOnWindows');
 const {extractSummary, cleanup, writeFiles} = require('../Utils');
 const runJest = require('../runJest');
 
 const DIR = path.resolve(__dirname, '../jest.config.js');
-
-SkipOnWindows.suite();
 
 beforeEach(() => cleanup(DIR));
 afterAll(() => cleanup(DIR));

--- a/integration-tests/__tests__/jest.config.js.test.js
+++ b/integration-tests/__tests__/jest.config.js.test.js
@@ -35,8 +35,9 @@ test('works with jest.config.js', () => {
 test('traverses directory tree up until it finds jest.config', () => {
   writeFiles(DIR, {
     '__tests__/a-banana.js': `
+    const slash = require('slash');
     test('banana', () => expect(1).toBe(1));
-    test('abc', () => console.log(process.cwd()));
+    test('abc', () => console.log(slash(process.cwd())));
     `,
     'jest.config.js': `module.exports = {testRegex: '.*-banana.js'};`,
     'package.json': '{}',

--- a/integration-tests/__tests__/jest_require_actual.test.js
+++ b/integration-tests/__tests__/jest_require_actual.test.js
@@ -11,13 +11,10 @@
 
 const path = require('path');
 const os = require('os');
-const SkipOnWindows = require('../../scripts/SkipOnWindows');
 const {cleanup, writeFiles} = require('../Utils');
 const runJest = require('../runJest');
 
 const DIR = path.resolve(os.tmpdir(), 'jest_require_actual_test');
-
-SkipOnWindows.suite();
 
 beforeEach(() => cleanup(DIR));
 afterAll(() => cleanup(DIR));

--- a/integration-tests/__tests__/jest_require_mock.test.js
+++ b/integration-tests/__tests__/jest_require_mock.test.js
@@ -11,13 +11,10 @@
 
 const path = require('path');
 const os = require('os');
-const SkipOnWindows = require('../../scripts/SkipOnWindows');
 const {cleanup, writeFiles} = require('../Utils');
 const runJest = require('../runJest');
 
 const DIR = path.resolve(os.tmpdir(), 'jest_require_mock_test');
-
-SkipOnWindows.suite();
 
 beforeEach(() => cleanup(DIR));
 afterAll(() => cleanup(DIR));

--- a/integration-tests/__tests__/log_heap_usage.test.js
+++ b/integration-tests/__tests__/log_heap_usage.test.js
@@ -11,13 +11,10 @@
 
 const path = require('path');
 const os = require('os');
-const SkipOnWindows = require('../../scripts/SkipOnWindows');
 const {cleanup, writeFiles} = require('../Utils');
 const runJest = require('../runJest');
 
 const DIR = path.resolve(os.tmpdir(), 'log_heap_usage_test');
-
-SkipOnWindows.suite();
 
 beforeEach(() => cleanup(DIR));
 afterAll(() => cleanup(DIR));

--- a/integration-tests/__tests__/module_name_mapper.test.js
+++ b/integration-tests/__tests__/module_name_mapper.test.js
@@ -9,11 +9,7 @@
 'use strict';
 
 const runJest = require('../runJest');
-const SkipOnWindows = require('../../scripts/SkipOnWindows');
 const {extractSummary} = require('../Utils');
-
-// Works on windows, we just need to adjust snapshot test output
-SkipOnWindows.suite();
 
 test('moduleNameMapper wrong configuration', () => {
   const {stderr, status} = runJest('module-name-mapper-wrong-config');

--- a/integration-tests/__tests__/multi_project_runner.test.js
+++ b/integration-tests/__tests__/multi_project_runner.test.js
@@ -15,10 +15,7 @@ import path from 'path';
 import stripAnsi from 'strip-ansi';
 
 const {cleanup, extractSummary, writeFiles} = require('../Utils');
-const SkipOnWindows = require('../../scripts/SkipOnWindows');
 const DIR = path.resolve(os.tmpdir(), 'multi_project_runner_test');
-
-SkipOnWindows.suite();
 
 const fileContentWithProvidesModule = name => `/*
  * @providesModule ${name}

--- a/integration-tests/__tests__/run_tests_by_path.test.js
+++ b/integration-tests/__tests__/run_tests_by_path.test.js
@@ -14,10 +14,7 @@ import os from 'os';
 import path from 'path';
 const {cleanup, writeFiles} = require('../Utils');
 
-const SkipOnWindows = require('../../scripts/SkipOnWindows');
 const DIR = path.resolve(os.tmpdir(), 'run_tests_by_path_test');
-
-SkipOnWindows.suite();
 
 beforeEach(() => cleanup(DIR));
 afterEach(() => cleanup(DIR));

--- a/integration-tests/__tests__/snapshot.test.js
+++ b/integration-tests/__tests__/snapshot.test.js
@@ -13,9 +13,6 @@ const path = require('path');
 const {extractSummary} = require('../Utils');
 const runJest = require('../runJest');
 
-const SkipOnWindows = require('../../scripts/SkipOnWindows');
-SkipOnWindows.suite();
-
 const emptyTest = 'describe("", () => {it("", () => {})})';
 const snapshotDir = path.resolve(
   __dirname,

--- a/integration-tests/__tests__/test_failure_exit_code.test.js
+++ b/integration-tests/__tests__/test_failure_exit_code.test.js
@@ -11,13 +11,10 @@
 
 const path = require('path');
 const os = require('os');
-const SkipOnWindows = require('../../scripts/SkipOnWindows');
 const {cleanup, writeFiles} = require('../Utils');
 const runJest = require('../runJest');
 
 const DIR = path.resolve(os.tmpdir(), 'test_failure_exit_code_test');
-
-SkipOnWindows.suite();
 
 beforeEach(() => cleanup(DIR));
 afterAll(() => cleanup(DIR));

--- a/integration-tests/__tests__/test_path_pattern_reporter_message.test.js
+++ b/integration-tests/__tests__/test_path_pattern_reporter_message.test.js
@@ -13,10 +13,7 @@ import os from 'os';
 import path from 'path';
 const {cleanup, writeFiles} = require('../Utils');
 
-const SkipOnWindows = require('../../scripts/SkipOnWindows');
 const DIR = path.resolve(os.tmpdir(), 'jest_path_pattern_reporter_message');
-
-SkipOnWindows.suite();
 
 beforeEach(() => cleanup(DIR));
 afterEach(() => cleanup(DIR));

--- a/integration-tests/__tests__/timeouts.test.js
+++ b/integration-tests/__tests__/timeouts.test.js
@@ -9,13 +9,10 @@
 'use strict';
 
 const path = require('path');
-const SkipOnWindows = require('../../scripts/SkipOnWindows');
 const {extractSummary, cleanup, writeFiles} = require('../Utils');
 const runJest = require('../runJest');
 
 const DIR = path.resolve(__dirname, '../timeouts');
-
-SkipOnWindows.suite();
 
 beforeEach(() => cleanup(DIR));
 afterAll(() => cleanup(DIR));

--- a/integration-tests/__tests__/transform-linked-modules.test.js
+++ b/integration-tests/__tests__/transform-linked-modules.test.js
@@ -2,10 +2,7 @@
 
 'use strict';
 
-const SkipOnWindows = require('../../scripts/SkipOnWindows');
 const runJest = require('../runJest');
-
-SkipOnWindows.suite();
 
 it('should transform linked modules', () => {
   const result = runJest.json('transform-linked-modules', ['--no-cache']).json;

--- a/integration-tests/__tests__/use_stderr.test.js
+++ b/integration-tests/__tests__/use_stderr.test.js
@@ -14,10 +14,7 @@ import os from 'os';
 import path from 'path';
 const {cleanup, writeFiles} = require('../Utils');
 
-const SkipOnWindows = require('../../scripts/SkipOnWindows');
 const DIR = path.resolve(os.tmpdir(), 'use_stderr_test');
-
-SkipOnWindows.suite();
 
 beforeEach(() => cleanup(DIR));
 afterEach(() => cleanup(DIR));

--- a/integration-tests/__tests__/version.test.js
+++ b/integration-tests/__tests__/version.test.js
@@ -11,13 +11,10 @@
 
 const path = require('path');
 const os = require('os');
-const SkipOnWindows = require('../../scripts/SkipOnWindows');
 const {cleanup, writeFiles} = require('../Utils');
 const runJest = require('../runJest');
 
 const DIR = path.resolve(os.tmpdir(), 'version_test');
-
-SkipOnWindows.suite();
 
 beforeEach(() => cleanup(DIR));
 afterAll(() => cleanup(DIR));

--- a/integration-tests/runJest.js
+++ b/integration-tests/runJest.js
@@ -9,9 +9,10 @@
 'use strict';
 
 const path = require('path');
+const fs = require('fs');
 const execa = require('execa');
 const {Writable} = require('readable-stream');
-const {fileExists} = require('./Utils');
+const {normalizeIcons} = require('./Utils');
 
 const {sync: spawnSync} = execa;
 
@@ -37,7 +38,7 @@ function runJest(
   }
 
   const localPackageJson = path.resolve(dir, 'package.json');
-  if (!options.skipPkgJsonCheck && !fileExists(localPackageJson)) {
+  if (!options.skipPkgJsonCheck && !fs.existsSync(localPackageJson)) {
     throw new Error(
       `
       Make sure you have a local package.json file at
@@ -62,6 +63,9 @@ function runJest(
 
   // For compat with cross-spawn
   result.status = result.code;
+
+  result.stdout = normalizeIcons(result.stdout);
+  result.stderr = normalizeIcons(result.stderr);
 
   return result;
 }
@@ -102,7 +106,7 @@ runJest.until = async function(
   }
 
   const localPackageJson = path.resolve(dir, 'package.json');
-  if (!options.skipPkgJsonCheck && !fileExists(localPackageJson)) {
+  if (!options.skipPkgJsonCheck && !fs.existsSync(localPackageJson)) {
     throw new Error(
       `
       Make sure you have a local package.json file at
@@ -144,6 +148,9 @@ runJest.until = async function(
 
   // For compat with cross-spawn
   result.status = result.code;
+
+  result.stdout = normalizeIcons(result.stdout);
+  result.stderr = normalizeIcons(result.stderr);
 
   return result;
 };

--- a/packages/expect/src/__tests__/assertion_counts.test.js
+++ b/packages/expect/src/__tests__/assertion_counts.test.js
@@ -10,8 +10,6 @@
 
 const jestExpect = require('../');
 
-const SkipOnWindows = require('../../../../scripts/SkipOnWindows');
-
 describe('.assertions()', () => {
   it('does not throw', () => {
     jestExpect.assertions(2);
@@ -31,7 +29,6 @@ describe('.assertions()', () => {
 });
 
 describe('.hasAssertions()', () => {
-  SkipOnWindows.suite();
   it('does not throw if there is an assertion', () => {
     jestExpect.hasAssertions();
     jestExpect('a').toBe('a');

--- a/packages/jest-cli/src/reporters/utils.js
+++ b/packages/jest-cli/src/reporters/utils.js
@@ -76,7 +76,7 @@ export const formatTestPath = (
   testPath: Path,
 ) => {
   const {dirname, basename} = relativePath(config, testPath);
-  return chalk.dim(dirname + path.sep) + chalk.bold(basename);
+  return slash(chalk.dim(dirname + path.sep) + chalk.bold(basename));
 };
 
 export const relativePath = (

--- a/packages/jest-util/package.json
+++ b/packages/jest-util/package.json
@@ -14,6 +14,7 @@
     "is-ci": "^1.0.10",
     "jest-message-util": "^23.0.0",
     "mkdirp": "^0.5.1",
+    "slash": "^1.0.0",
     "source-map": "^0.6.0"
   },
   "devDependencies": {

--- a/packages/jest-util/src/get_console_output.js
+++ b/packages/jest-util/src/get_console_output.js
@@ -11,13 +11,14 @@ import type {ConsoleBuffer} from 'types/Console';
 
 import path from 'path';
 import chalk from 'chalk';
+import slash from 'slash';
 
 export default (root: string, verbose: boolean, buffer: ConsoleBuffer) => {
   const TITLE_INDENT = verbose ? '  ' : '    ';
   const CONSOLE_INDENT = TITLE_INDENT + '  ';
 
   return buffer.reduce((output, {type, message, origin}) => {
-    origin = path.relative(root, origin);
+    origin = slash(path.relative(root, origin));
     message = message
       .split(/\n/)
       .map(line => CONSOLE_INDENT + line)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary
This PR uses `slash` in order for filepaths in test headings and `console` traces in output to be consistent across OSes.
It also normalizes the icons in the integration tests.

Related to https://github.com/facebook/jest/issues/3121

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan
Green CI even though we're activating 30 new integration tests on windows

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
