### PR TITLE
Make the jest-circus export compatible with regular runners

### DIFF
--- a/packages/jest-circus/runner.js
+++ b/packages/jest-circus/runner.js
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+
+// Allow people to use `jest-circus/runner` as a runner.
+const runner = require('./build/legacy_code_todo_rewrite/jest_adapter');
+module.exports = runner;

--- a/packages/jest-circus/src/legacy_code_todo_rewrite/jest_adapter.js
+++ b/packages/jest-circus/src/legacy_code_todo_rewrite/jest_adapter.js
@@ -108,4 +108,4 @@ const _addSnapshotData = (results: TestResult, snapshotState) => {
   return results;
 };
 
-export default jestAdapter;
+module.exports = jestAdapter;

--- a/packages/jest-runner/src/run_test.js
+++ b/packages/jest-runner/src/run_test.js
@@ -69,9 +69,7 @@ async function runTestInternal(
   /* $FlowFixMe */
   const TestEnvironment = (require(testEnvironment): EnvironmentClass);
   const testFramework = ((process.env.JEST_CIRCUS === '1'
-    ? /* $FlowFixMe */
-      require('jest-circus/build/legacy_code_todo_rewrite/jest_adapter.js') // eslint-disable-line import/no-extraneous-dependencies
-        .default
+    ? require('jest-circus/runner') // eslint-disable-line import/no-extraneous-dependencies
     : /* $FlowFixMe */
       require(config.testRunner)): TestFramework);
   /* $FlowFixMe */


### PR DESCRIPTION
This will make it easier to use jest-circus using the regular runner config.

@aaronabramov 