### PR TITLE
toMatchObject throws TypeError when a source property is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## master
 
+### Fixes
+
+* `[expect]` toMatchObject throws TypeError when a source property is null ([#6313](https://github.com/facebook/jest/pull/6313))
+
 ## 23.0.1
 
 ### Chore & Maintenance

--- a/packages/expect/src/__tests__/utils.test.js
+++ b/packages/expect/src/__tests__/utils.test.js
@@ -9,7 +9,7 @@
 'use strict';
 
 const {stringify} = require('jest-matcher-utils');
-const {emptyObject, getObjectSubset, getPath} = require('../utils');
+const {emptyObject, getObjectSubset, getPath, subsetEquality} = require('../utils');
 
 describe('getPath()', () => {
   test('property exists', () => {
@@ -120,5 +120,28 @@ describe('emptyObject()', () => {
   test('does not match a non-object', () => {
     expect(emptyObject(null)).toBe(false);
     expect(emptyObject(34)).toBe(false);
+  });
+});
+
+describe('subsetEquality()', () => {
+  test('matching object returns true', () => {
+    expect(subsetEquality({foo : 'bar'}, {foo: 'bar'})).toBe(true);
+  });
+
+  test('object without keys is undefined', () => {
+    expect(subsetEquality('foo', 'bar')).toBe(undefined);
+  });
+
+  test('objects to not match', () => {
+    expect(subsetEquality({foo : 'bar'}, {foo : 'baz'})).toBe(false);
+    expect(subsetEquality('foo', {foo : 'baz'})).toBe(false);
+  });
+
+  test('null does not return errors', () => {
+    expect(subsetEquality(null, {foo : 'bar'})).not.toBeTruthy();
+  });
+
+  test('undefined does not return errors', () => {
+    expect(subsetEquality(undefined, {foo : 'bar'})).not.toBeTruthy();
   });
 });

--- a/packages/expect/src/__tests__/utils.test.js
+++ b/packages/expect/src/__tests__/utils.test.js
@@ -9,7 +9,12 @@
 'use strict';
 
 const {stringify} = require('jest-matcher-utils');
-const {emptyObject, getObjectSubset, getPath, subsetEquality} = require('../utils');
+const {
+  emptyObject,
+  getObjectSubset,
+  getPath,
+  subsetEquality,
+} = require('../utils');
 
 describe('getPath()', () => {
   test('property exists', () => {
@@ -125,7 +130,7 @@ describe('emptyObject()', () => {
 
 describe('subsetEquality()', () => {
   test('matching object returns true', () => {
-    expect(subsetEquality({foo : 'bar'}, {foo: 'bar'})).toBe(true);
+    expect(subsetEquality({foo: 'bar'}, {foo: 'bar'})).toBe(true);
   });
 
   test('object without keys is undefined', () => {
@@ -133,15 +138,15 @@ describe('subsetEquality()', () => {
   });
 
   test('objects to not match', () => {
-    expect(subsetEquality({foo : 'bar'}, {foo : 'baz'})).toBe(false);
-    expect(subsetEquality('foo', {foo : 'baz'})).toBe(false);
+    expect(subsetEquality({foo: 'bar'}, {foo: 'baz'})).toBe(false);
+    expect(subsetEquality('foo', {foo: 'baz'})).toBe(false);
   });
 
   test('null does not return errors', () => {
-    expect(subsetEquality(null, {foo : 'bar'})).not.toBeTruthy();
+    expect(subsetEquality(null, {foo: 'bar'})).not.toBeTruthy();
   });
 
   test('undefined does not return errors', () => {
-    expect(subsetEquality(undefined, {foo : 'bar'})).not.toBeTruthy();
+    expect(subsetEquality(undefined, {foo: 'bar'})).not.toBeTruthy();
   });
 });

--- a/packages/expect/src/utils.js
+++ b/packages/expect/src/utils.js
@@ -206,8 +206,7 @@ export const subsetEquality = (object: Object, subset: Object) => {
 
   return Object.keys(subset).every(
     key =>
-      object !== null &&
-      object !== undefined &&
+      object != null &&
       hasOwnProperty(object, key) &&
       equals(object[key], subset[key], [iterableEquality, subsetEquality]),
   );

--- a/packages/expect/src/utils.js
+++ b/packages/expect/src/utils.js
@@ -206,6 +206,8 @@ export const subsetEquality = (object: Object, subset: Object) => {
 
   return Object.keys(subset).every(
     key =>
+      object !== null &&
+      object !== undefined &&
       hasOwnProperty(object, key) &&
       equals(object[key], subset[key], [iterableEquality, subsetEquality]),
   );


### PR DESCRIPTION
## Summary

This fixes the issue brought up in #6235 

```
test.only("foo", () => {
  expect({ foo: null }).toMatchObject({ foo: { bar: "baz" } });
});
```

This code above gives a TypeError as opposed to a nice assertion error.

## Test plan

Added a few tests for the subsetEqulity function.

I've signed the CLA.