### PR TITLE
chore: remove leading newline in front of "RUNS"

### DIFF
--- a/packages/jest-cli/src/reporters/Status.js
+++ b/packages/jest-cli/src/reporters/Status.js
@@ -137,7 +137,7 @@ export default class Status {
 
     // $FlowFixMe
     const width: number = process.stdout.columns;
-    let content = '\n';
+    let content = '';
     this._currentTests.get().forEach(record => {
       if (record) {
         const {config, testPath} = record;


### PR DESCRIPTION
Fixes #1781

Before:

![before](https://img1.picload.org/image/dolwrrrl/bildschirmfoto2018-05-27um21.1.png)

After:

![after](https://img1.picload.org/image/dolwrrrr/bildschirmfoto2018-05-27um21.1.png)

Run some tests - output looks good for my personal projects
