### PR TITLE
jest-circus: feature parity

### DIFF
--- a/e2e/__tests__/location_in_results.test.js
+++ b/e2e/__tests__/location_in_results.test.js
@@ -11,8 +11,6 @@
 const runJest = require('../runJest');
 const ConditionalTest = require('../../scripts/ConditionalTest');
 
-ConditionalTest.skipSuiteOnJestCircus();
-
 it('defaults to null for location', () => {
   const result = runJest.json('location-in-results').json;
 

--- a/scripts/ConditionalTest.js
+++ b/scripts/ConditionalTest.js
@@ -14,22 +14,6 @@ const ConditionalTest = {
     return process.env.JEST_CIRCUS === '1';
   },
 
-  skipSuiteOnJasmine() {
-    if (!this.isJestCircusRun()) {
-      fit('does not work on Jasmine', () => {
-        console.warn('[SKIP] Does not work on Jasmine');
-      });
-    }
-  },
-
-  skipSuiteOnJestCircus() {
-    if (this.isJestCircusRun()) {
-      fit('does not work on jest-circus', () => {
-        console.warn('[SKIP] Does not work on jest-circus');
-      });
-    }
-  },
-
   skipSuiteOnWindows() {
     if (process.platform === 'win32') {
       fit('does not work on Windows', () => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

`jest-circus` is now fully compatible with Jasmine.

Fixes #4362 


## Test plan

Ideas how to make 
https://github.com/facebook/jest/blob/a43fd6c75d2f38616407a70c69ccaee666cb4f61/scripts/ConditionalTest.js#L13-L15
more env independent? 

This is the only place we use it: 
https://github.com/facebook/jest/blob/9310e9ce497cd2e186c00e70dbc5165706ba5a0d/e2e/__tests__/location_in_results.test.js#L39

Or should we create 2 tests, one for circus, second fo jasmine?
