### PR TITLE
Mention about using commit hash with --changedSince flag

### DIFF
--- a/website/versioned_docs/version-22.2/CLI.md
+++ b/website/versioned_docs/version-22.2/CLI.md
@@ -94,7 +94,7 @@ Runs tests related to the current changes and the changes made in the last commi
 
 ### `--changedSince`
 
-Runs tests related the changes since the provided branch. If the current branch has diverged from the given branch, then only changes made locally will be tested. Behaves similarly to `--onlyChanged`.
+Runs tests related to the changes since the provided branch or commit hash. If the current branch has diverged from the given branch, then only changes made locally will be tested. Behaves similarly to `--onlyChanged`.
 
 ### `--ci`
 

--- a/website/versioned_docs/version-22.3/CLI.md
+++ b/website/versioned_docs/version-22.3/CLI.md
@@ -94,7 +94,7 @@ Runs tests related to the current changes and the changes made in the last commi
 
 ### `--changedSince`
 
-Runs tests related the changes since the provided branch. If the current branch has diverged from the given branch, then only changes made locally will be tested. Behaves similarly to `--onlyChanged`.
+Runs tests related to the changes since the provided branch or commit hash. If the current branch has diverged from the given branch, then only changes made locally will be tested. Behaves similarly to `--onlyChanged`.
 
 ### `--ci`
 

--- a/website/versioned_docs/version-22.4/CLI.md
+++ b/website/versioned_docs/version-22.4/CLI.md
@@ -112,7 +112,7 @@ Runs tests related to the current changes and the changes made in the last commi
 
 ### `--changedSince`
 
-Runs tests related the changes since the provided branch. If the current branch has diverged from the given branch, then only changes made locally will be tested. Behaves similarly to `--onlyChanged`.
+Runs tests related to the changes since the provided branch or commit hash. If the current branch has diverged from the given branch, then only changes made locally will be tested. Behaves similarly to `--onlyChanged`.
 
 ### `--ci`
 

--- a/website/versioned_docs/version-23.0/CLI.md
+++ b/website/versioned_docs/version-23.0/CLI.md
@@ -112,7 +112,7 @@ Runs tests related to the current changes and the changes made in the last commi
 
 ### `--changedSince`
 
-Runs tests related the changes since the provided branch. If the current branch has diverged from the given branch, then only changes made locally will be tested. Behaves similarly to `--onlyChanged`.
+Runs tests related to the changes since the provided branch or commit hash. If the current branch has diverged from the given branch, then only changes made locally will be tested. Behaves similarly to `--onlyChanged`.
 
 ### `--ci`
 


### PR DESCRIPTION
## Summary

Documents the use of commit hash with `--changedSince` flag. #6326 

## Test plan

NA
