### PR TITLE
Add projectConfig argument to shouldRunTestSuite hook

### DIFF
--- a/packages/jest-cli/src/run_jest.js
+++ b/packages/jest-cli/src/run_jest.js
@@ -58,7 +58,9 @@ const getTestPaths = async (
   }
 
   const shouldTestArray = await Promise.all(
-    data.tests.map(test => jestHooks.shouldRunTestSuite(test.path)),
+    data.tests.map(test =>
+      jestHooks.shouldRunTestSuite(test.path, test.context.config),
+    ),
   );
 
   const filteredTests = data.tests.filter((test, i) => shouldTestArray[i]);

--- a/packages/jest-watch/src/jest_hooks.js
+++ b/packages/jest-watch/src/jest_hooks.js
@@ -61,11 +61,11 @@ class JestHooks {
         this._listeners.onTestRunComplete.forEach(listener =>
           listener(results),
         ),
-      shouldRunTestSuite: async testPath =>
+      shouldRunTestSuite: async (testPath, config) =>
         Promise.all(
-          this._listeners.shouldRunTestSuite.map(listener =>
-            listener(testPath),
-          ),
+          this._listeners.shouldRunTestSuite.map(listener => {
+            return listener(testPath, config);
+          }),
         ).then(result =>
           result.every(shouldRunTestSuite => shouldRunTestSuite),
         ),

--- a/types/JestHooks.js
+++ b/types/JestHooks.js
@@ -15,7 +15,10 @@ export type JestHookExposedFS = {
 };
 
 export type FileChange = (fs: JestHookExposedFS) => void;
-export type ShouldRunTestSuite = (testPath: string) => Promise<boolean>;
+export type ShouldRunTestSuite = (
+  testPath: string,
+  config: ProjectConfig,
+) => Promise<boolean>;
 export type TestRunComplete = (results: AggregatedResult) => void;
 
 export type JestHookSubscriber = {
@@ -27,5 +30,8 @@ export type JestHookSubscriber = {
 export type JestHookEmitter = {
   onFileChange: (fs: JestHookExposedFS) => void,
   onTestRunComplete: (results: AggregatedResult) => void,
-  shouldRunTestSuite: (testPath: string) => Promise<boolean>,
+  shouldRunTestSuite: (
+    testPath: string,
+    config: ProjectConfig,
+  ) => Promise<boolean>,
 };

--- a/website/versioned_docs/version-23.0/WatchPlugins.md
+++ b/website/versioned_docs/version-23.0/WatchPlugins.md
@@ -37,7 +37,7 @@ class MyWatchPlugin {
 
 Below are the hooks available in Jest.
 
-#### `jestHooks.shouldRunTestSuite(testPath)`
+#### `jestHooks.shouldRunTestSuite(testPath, projectConfig)`
 
 Returns a boolean (or `Promise<boolean>`) for handling asynchronous operations) to specify if a test should be run or not.
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Currently, the `shouldRunTestSuite` hook only takes the `testPath`. I did that intentionally when designing plugins to keep the API surface as small as possible, but it seems that getting the ProjectConfig, along with the `testPath` might be useful. 

Another idea was to pass the whole `test: Test` object, which seems really nice but I'm worried that it will leak out a lot of implementation details, for example `context.moduleMap` and `context.hasteFS`... The only other option inside test that would be interesting to get, is `duration`.

This should allow us to do something like a `project selection plugin`.
![select-projects](https://user-images.githubusercontent.com/574806/40687850-d23ec5ea-6350-11e8-8a8d-a72b7faf2163.gif)
