### PR TITLE
Remove eagerly evaluated jasmine from jest-runner

### DIFF
--- a/packages/jest-runner/src/run_test.js
+++ b/packages/jest-runner/src/run_test.js
@@ -22,7 +22,6 @@ import {
   getConsoleOutput,
   setGlobal,
 } from 'jest-util';
-import jasmine2 from 'jest-jasmine2';
 import LeakDetector from 'jest-leak-detector';
 import {getTestEnvironment} from 'jest-config';
 import * as docblock from 'jest-docblock';
@@ -32,10 +31,6 @@ type RunTestInternalResult = {
   leakDetector: ?LeakDetector,
   result: TestResult,
 };
-
-// The default jest-runner is required because it is the default test runner
-// and required implicitly through the `testRunner` ProjectConfig option.
-jasmine2;
 
 // Keeping the core of "runTest" as a separate function (as "runTestInternal")
 // is key to be able to detect memory leaks. Since all variables are local to


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Looks like we don't need this code anymore? cc @cpojer 
Stacked on https://github.com/facebook/jest/pull/6359 for greenness.
This change makes jest-circus consistently faster than jasmine by ~5% in my completely unscientific test runs.

## Test plan

🍏
