### PR TITLE
Allow --errorOnDeprecated to error on DEFAULT_TIMEOUT_INTERVAL

### DIFF
--- a/e2e/__tests__/__snapshots__/error-on-deprecated.test.js.snap
+++ b/e2e/__tests__/__snapshots__/error-on-deprecated.test.js.snap
@@ -1,5 +1,26 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`DEFAULT_TIMEOUT_INTERVAL.test.js errors in errorOnDeprecated mode 1`] = `
+"FAIL __tests__/DEFAULT_TIMEOUT_INTERVAL.test.js
+  ✕ DEFAULT_TIMEOUT_INTERVAL
+
+  ● DEFAULT_TIMEOUT_INTERVAL
+
+    Illegal usage of \`jasmine.DEFAULT_TIMEOUT_INTERVAL\`, prefer \`jest.setTimeout\`.
+
+       8 | 
+       9 | test('DEFAULT_TIMEOUT_INTERVAL', () => {
+    > 10 |   jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000;
+         |   ^
+      11 |   expect(true).toBe(true);
+      12 | });
+      13 | 
+
+      at __tests__/DEFAULT_TIMEOUT_INTERVAL.test.js:10:3
+
+"
+`;
+
 exports[`fail.test.js errors in errorOnDeprecated mode 1`] = `
 "FAIL __tests__/fail.test.js
   ✕ fail

--- a/e2e/__tests__/__snapshots__/timeouts_legacy.test.js.snap
+++ b/e2e/__tests__/__snapshots__/timeouts_legacy.test.js.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`can read and write jasmine.DEFAULT_TIMEOUT_INTERVAL 1`] = `
+"Test Suites: 1 passed, 1 total
+Tests:       1 passed, 1 total
+Snapshots:   0 total
+Time:        <<REPLACED>>
+Ran all test suites."
+`;
+
+exports[`does not exceed the timeout using jasmine.DEFAULT_TIMEOUT_INTERVAL 1`] = `
+"PASS __tests__/a-banana.js
+  ✓ banana
+
+"
+`;
+
+exports[`does not exceed the timeout using jasmine.DEFAULT_TIMEOUT_INTERVAL 2`] = `
+"Test Suites: 1 passed, 1 total
+Tests:       1 passed, 1 total
+Snapshots:   0 total
+Time:        <<REPLACED>>
+Ran all test suites."
+`;
+
+exports[`exceeds the timeout set using jasmine.DEFAULT_TIMEOUT_INTERVAL 1`] = `
+"Test Suites: 1 failed, 1 total
+Tests:       1 failed, 1 total
+Snapshots:   0 total
+Time:        <<REPLACED>>
+Ran all test suites.
+"
+`;

--- a/e2e/__tests__/error-on-deprecated.test.js
+++ b/e2e/__tests__/error-on-deprecated.test.js
@@ -26,6 +26,7 @@ const testFiles = [
   'pending.test.js',
   'spyOn.test.js',
   'spyOnProperty.test.js',
+  'DEFAULT_TIMEOUT_INTERVAL.test.js',
 ];
 
 const SHOULD_NOT_PASS_IN_JEST = new Set([

--- a/e2e/__tests__/timeouts_legacy.test.js
+++ b/e2e/__tests__/timeouts_legacy.test.js
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ * @flow
+ */
+
+'use strict';
+
+const path = require('path');
+const {extractSummary, cleanup, writeFiles} = require('../Utils');
+const runJest = require('../runJest');
+const ConditionalTest = require('../../scripts/ConditionalTest');
+
+/**
+ * NOTE: This test should be removed once jest-circus is rolled out as a breaking change.
+ */
+
+const DIR = path.resolve(__dirname, '../timeouts-legacy');
+
+ConditionalTest.skipSuiteOnJestCircus();
+
+beforeEach(() => cleanup(DIR));
+afterAll(() => cleanup(DIR));
+
+test('exceeds the timeout set using jasmine.DEFAULT_TIMEOUT_INTERVAL', () => {
+  writeFiles(DIR, {
+    '__tests__/a-banana.js': `
+      jasmine.DEFAULT_TIMEOUT_INTERVAL = 20;
+
+      test('banana', () => {
+        return new Promise(resolve => {
+          setTimeout(resolve, 100);
+        });
+      });
+    `,
+    'package.json': '{}',
+  });
+
+  const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false']);
+  const {rest, summary} = extractSummary(stderr);
+  expect(rest).toMatch(
+    /(jest\.setTimeout|jasmine\.DEFAULT_TIMEOUT_INTERVAL|Exceeded timeout)/,
+  );
+  expect(summary).toMatchSnapshot();
+  expect(status).toBe(1);
+});
+
+test('does not exceed the timeout using jasmine.DEFAULT_TIMEOUT_INTERVAL', () => {
+  writeFiles(DIR, {
+    '__tests__/a-banana.js': `
+      jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000;
+
+      test('banana', () => {
+        return new Promise(resolve => {
+          setTimeout(resolve, 20);
+        });
+      });
+    `,
+    'package.json': '{}',
+  });
+
+  const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false']);
+  const {rest, summary} = extractSummary(stderr);
+  expect(rest).toMatchSnapshot();
+  expect(summary).toMatchSnapshot();
+  expect(status).toBe(0);
+});
+
+test('can read and write jasmine.DEFAULT_TIMEOUT_INTERVAL', () => {
+  writeFiles(DIR, {
+    '__tests__/a-banana.js': `
+      const timeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
+      jasmine.DEFAULT_TIMEOUT_INTERVAL = 154;
+      const newTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
+
+      test('banana', () => {
+        expect(timeout).toBe(5000);
+        expect(newTimeout).toBe(154);
+      });
+    `,
+    'package.json': '{}',
+  });
+
+  const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false']);
+  const {summary} = extractSummary(stderr);
+  expect(summary).toMatchSnapshot();
+  expect(status).toBe(0);
+});

--- a/e2e/error-on-deprecated/__tests__/DEFAULT_TIMEOUT_INTERVAL.test.js
+++ b/e2e/error-on-deprecated/__tests__/DEFAULT_TIMEOUT_INTERVAL.test.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+'use strict';
+
+test('DEFAULT_TIMEOUT_INTERVAL', () => {
+  jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000;
+  expect(true).toBe(true);
+});

--- a/packages/jest-jasmine2/src/error_on_private.js
+++ b/packages/jest-jasmine2/src/error_on_private.js
@@ -41,6 +41,22 @@ export function installErrorOnPrivate(global: Global): void {
       throwAtFunction(disabledJasmineMethods[methodName], jasmine[methodName]);
     };
   });
+
+  function set() {
+    throwAtFunction(
+      'Illegal usage of `jasmine.DEFAULT_TIMEOUT_INTERVAL`, prefer `jest.setTimeout`.',
+      set,
+    );
+  }
+
+  const original = jasmine.DEFAULT_TIMEOUT_INTERVAL;
+  // $FlowFixMe Flow seems to be confused about accessors and tries to enfoce having a `value` property.
+  Object.defineProperty(jasmine, 'DEFAULT_TIMEOUT_INTERVAL', {
+    configurable: true,
+    enumerable: true,
+    get: () => original,
+    set,
+  });
 }
 
 function throwAtFunction(message, fn) {

--- a/packages/jest-jasmine2/src/index.js
+++ b/packages/jest-jasmine2/src/index.js
@@ -103,6 +103,18 @@ async function jasmine2(
 
   if (globalConfig.errorOnDeprecated) {
     installErrorOnPrivate(environment.global);
+  } else {
+    // $FlowFixMe Flow seems to be confused about accessors and tries to enfoce having a `value` property.
+    Object.defineProperty(jasmine, 'DEFAULT_TIMEOUT_INTERVAL', {
+      configurable: true,
+      enumerable: true,
+      get() {
+        return this._DEFAULT_TIMEOUT_INTERVAL;
+      },
+      set(value) {
+        this._DEFAULT_TIMEOUT_INTERVAL = value;
+      },
+    });
   }
 
   const snapshotState: SnapshotState = runtime

--- a/packages/jest-jasmine2/src/jasmine/Env.js
+++ b/packages/jest-jasmine2/src/jasmine/Env.js
@@ -417,7 +417,7 @@ export default function(j$) {
         queueableFn: {
           fn,
           timeout() {
-            return timeout || j$.DEFAULT_TIMEOUT_INTERVAL;
+            return timeout || j$._DEFAULT_TIMEOUT_INTERVAL;
           },
         },
         throwOnExpectationFailure,
@@ -506,7 +506,7 @@ export default function(j$) {
       currentDeclarationSuite.beforeEach({
         fn: beforeEachFunction,
         timeout() {
-          return timeout || j$.DEFAULT_TIMEOUT_INTERVAL;
+          return timeout || j$._DEFAULT_TIMEOUT_INTERVAL;
         },
       });
     };
@@ -515,7 +515,7 @@ export default function(j$) {
       currentDeclarationSuite.beforeAll({
         fn: beforeAllFunction,
         timeout() {
-          return timeout || j$.DEFAULT_TIMEOUT_INTERVAL;
+          return timeout || j$._DEFAULT_TIMEOUT_INTERVAL;
         },
       });
     };
@@ -524,7 +524,7 @@ export default function(j$) {
       currentDeclarationSuite.afterEach({
         fn: afterEachFunction,
         timeout() {
-          return timeout || j$.DEFAULT_TIMEOUT_INTERVAL;
+          return timeout || j$._DEFAULT_TIMEOUT_INTERVAL;
         },
       });
     };
@@ -533,7 +533,7 @@ export default function(j$) {
       currentDeclarationSuite.afterAll({
         fn: afterAllFunction,
         timeout() {
-          return timeout || j$.DEFAULT_TIMEOUT_INTERVAL;
+          return timeout || j$._DEFAULT_TIMEOUT_INTERVAL;
         },
       });
     };

--- a/packages/jest-jasmine2/src/jasmine/jasmine_light.js
+++ b/packages/jest-jasmine2/src/jasmine/jasmine_light.js
@@ -45,7 +45,7 @@ import Timer from './Timer';
 exports.create = function(createOptions: Object) {
   const j$ = Object.assign({}, createOptions);
 
-  j$.DEFAULT_TIMEOUT_INTERVAL = 5000;
+  j$._DEFAULT_TIMEOUT_INTERVAL = 5000;
 
   j$.getEnv = function(options: Object) {
     const env = (j$.currentEnv_ = j$.currentEnv_ || new j$.Env(options));

--- a/packages/jest-runtime/src/index.js
+++ b/packages/jest-runtime/src/index.js
@@ -822,7 +822,7 @@ class Runtime {
 
     const setTimeout = (timeout: number) => {
       this._environment.global.jasmine
-        ? (this._environment.global.jasmine.DEFAULT_TIMEOUT_INTERVAL = timeout)
+        ? (this._environment.global.jasmine._DEFAULT_TIMEOUT_INTERVAL = timeout)
         : (this._environment.global[
             Symbol.for('TEST_TIMEOUT_SYMBOL')
           ] = timeout);


### PR DESCRIPTION
Followup from https://github.com/facebook/jest/pull/6339.

I figured I'd split this out into a separate PR since it seems a little invasive just to give a nice deprecation error.