### PR TITLE
Update docs to use results instead of returnValues for mock functions

### DIFF
--- a/docs/MockFunctions.md
+++ b/docs/MockFunctions.md
@@ -67,7 +67,7 @@ expect(someMockFunction.mock.calls[0][0]).toBe('first arg');
 expect(someMockFunction.mock.calls[0][1]).toBe('second arg');
 
 // The return value of the first call to the function was 'return value'
-expect(someMockFunction.mock.results[0]).toBe('return value');
+expect(someMockFunction.mock.results[0].value).toBe('return value');
 
 // This function was instantiated exactly twice
 expect(someMockFunction.mock.instances.length).toBe(2);

--- a/docs/MockFunctions.md
+++ b/docs/MockFunctions.md
@@ -35,7 +35,7 @@ expect(mockCallback.mock.calls[0][0]).toBe(0);
 expect(mockCallback.mock.calls[1][0]).toBe(1);
 
 // The return value of the first call to the function was 42
-expect(mockCallback.mock.returnValues[0]).toBe(42);
+expect(mockCallback.mock.results[0].value).toBe(42);
 ```
 
 ## `.mock` property
@@ -67,7 +67,7 @@ expect(someMockFunction.mock.calls[0][0]).toBe('first arg');
 expect(someMockFunction.mock.calls[0][1]).toBe('second arg');
 
 // The return value of the first call to the function was 'return value'
-expect(someMockFunction.mock.returnValues[0]).toBe('return value');
+expect(someMockFunction.mock.results[0]).toBe('return value');
 
 // This function was instantiated exactly twice
 expect(someMockFunction.mock.instances.length).toBe(2);

--- a/website/versioned_docs/version-23.0/MockFunctions.md
+++ b/website/versioned_docs/version-23.0/MockFunctions.md
@@ -36,7 +36,7 @@ expect(mockCallback.mock.calls[0][0]).toBe(0);
 expect(mockCallback.mock.calls[1][0]).toBe(1);
 
 // The return value of the first call to the function was 42
-expect(mockCallback.mock.results[0]).toBe(42);
+expect(mockCallback.mock.results[0].value).toBe(42);
 ```
 
 ## `.mock` property

--- a/website/versioned_docs/version-23.0/MockFunctions.md
+++ b/website/versioned_docs/version-23.0/MockFunctions.md
@@ -68,7 +68,7 @@ expect(someMockFunction.mock.calls[0][0]).toBe('first arg');
 expect(someMockFunction.mock.calls[0][1]).toBe('second arg');
 
 // The return value of the first call to the function was 'return value'
-expect(someMockFunction.mock.results[0]).toBe('return value');
+expect(someMockFunction.mock.results[0].value).toBe('return value');
 
 // This function was instantiated exactly twice
 expect(someMockFunction.mock.instances.length).toBe(2);

--- a/website/versioned_docs/version-23.0/MockFunctions.md
+++ b/website/versioned_docs/version-23.0/MockFunctions.md
@@ -36,7 +36,7 @@ expect(mockCallback.mock.calls[0][0]).toBe(0);
 expect(mockCallback.mock.calls[1][0]).toBe(1);
 
 // The return value of the first call to the function was 42
-expect(mockCallback.mock.returnValues[0]).toBe(42);
+expect(mockCallback.mock.results[0]).toBe(42);
 ```
 
 ## `.mock` property
@@ -68,7 +68,7 @@ expect(someMockFunction.mock.calls[0][0]).toBe('first arg');
 expect(someMockFunction.mock.calls[0][1]).toBe('second arg');
 
 // The return value of the first call to the function was 'return value'
-expect(someMockFunction.mock.returnValues[0]).toBe('return value');
+expect(someMockFunction.mock.results[0]).toBe('return value');
 
 // This function was instantiated exactly twice
 expect(someMockFunction.mock.instances.length).toBe(2);


### PR DESCRIPTION
## Summary

```returnValues``` was replaced with ```results```. This updates the docs for the change.

Issue #6324 has more information about this change if needed.

https://github.com/facebook/jest/pull/6172/files#diff-3eb46e5efb818eec731c401704f180feR42 

## Test plan

Verify website docs display correctly.
