### PR TITLE
Fix: Symbol based properties in arrays causes `toEqual` to throw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## master
 
+### Fixes
+
 ## 23.1.0
+
+- `[expect]` Using symbolic property names in arrays no longer causes the `toEqual` matcher to fail ([#6391](https://github.com/facebook/jest/pull/6391))
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ### Fixes
 
-## 23.1.0
-
 - `[expect]` Using symbolic property names in arrays no longer causes the `toEqual` matcher to fail ([#6391](https://github.com/facebook/jest/pull/6391))
+
+## 23.1.0
 
 ### Features
 

--- a/packages/expect/src/__tests__/matchers.test.js
+++ b/packages/expect/src/__tests__/matchers.test.js
@@ -442,6 +442,19 @@ describe('.toEqual()', () => {
       );
     }
   });
+
+  test('symbol based keys in arrays are processed correctly', () => {
+    const mySymbol = Symbol("test");
+    const actual1 = [];
+    actual1[mySymbol] = 3;
+    const actual2 = [];
+    actual2[mySymbol] = 4;
+    const expected = [];
+    expected[mySymbol] = 3;
+
+    expect(actual1).toEqual(expected);
+    expect(actual2).not.toEqual(expected);
+  })
 });
 
 describe('.toBeInstanceOf()', () => {

--- a/packages/expect/src/__tests__/matchers.test.js
+++ b/packages/expect/src/__tests__/matchers.test.js
@@ -444,7 +444,7 @@ describe('.toEqual()', () => {
   });
 
   test('symbol based keys in arrays are processed correctly', () => {
-    const mySymbol = Symbol("test");
+    const mySymbol = Symbol('test');
     const actual1 = [];
     actual1[mySymbol] = 3;
     const actual2 = [];
@@ -454,7 +454,7 @@ describe('.toEqual()', () => {
 
     expect(actual1).toEqual(expected);
     expect(actual2).not.toEqual(expected);
-  })
+  });
 });
 
 describe('.toBeInstanceOf()', () => {

--- a/packages/expect/src/jasmine_utils.js
+++ b/packages/expect/src/jasmine_utils.js
@@ -222,6 +222,7 @@ function keys(obj, isArray, hasKey) {
   }
 
   for (var x = 0; x < allKeys.length; x++) {
+    //$FlowFixMe
     if (typeof allKeys[x] === 'symbol' || !allKeys[x].match(/^[0-9]+$/)) {
       extraKeys.push(allKeys[x]);
     }

--- a/packages/expect/src/jasmine_utils.js
+++ b/packages/expect/src/jasmine_utils.js
@@ -222,7 +222,7 @@ function keys(obj, isArray, hasKey) {
   }
 
   for (var x = 0; x < allKeys.length; x++) {
-    if (!allKeys[x].match(/^[0-9]+$/)) {
+    if (typeof allKeys[x] === 'symbol' || !allKeys[x].match(/^[0-9]+$/)) {
       extraKeys.push(allKeys[x]);
     }
   }


### PR DESCRIPTION
## Summary

`toEqual` matcher could not handle _symbol_ based properties in _array_'s, causing jest to throw:

Minimal example:

```javascript
    const mySymbol = Symbol("test");
    const actual1 = [];
    actual1[mySymbol] = 3;
    const expected = [];
    expected[mySymbol] = 3;

    expect(actual1).toEqual(expected);
```

Throws:

```
 TypeError: allKeys[x].match is not a function

      at Object.test (packages/expect/src/__tests__/matchers.test.js:456:21)
```

The cause of this issue is this [line](https://github.com/facebook/jest/blob/241588a08edadbcaef7cc93bb11aad3b9cbad73b/packages/expect/src/jasmine_utils.js#L225) which assumes that all property names of arrays are strings and hence `.match` can be called on them. 

This assumption does not held for symbol based properties. If the property name is a symbol, it is never an index, so it should always be added to the `extraKeys` collection. 

## Test plan

I added a unit test demonstrating that deep equality on arrays behaves correctly now, even in the presence of symbolic properties.