### PR TITLE
Fix: `expect` no longer tries to equal non-enumerable symbolic properties.…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## master
 
+### Fixes
+
+- `[expect]` `toEqual` no longer tries to compare non-enumerable symbolic properties, to be consistent with non-symbolic properties. ([]())
+
 ## 23.1.0
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Fixes
 
-- `[expect]` `toEqual` no longer tries to compare non-enumerable symbolic properties, to be consistent with non-symbolic properties. ([]())
+- `[expect]` `toEqual` no longer tries to compare non-enumerable symbolic properties, to be consistent with non-symbolic properties. ([#6398](https://github.com/facebook/jest/pull/6398))
 
 ## 23.1.0
 

--- a/packages/expect/src/__tests__/matchers.test.js
+++ b/packages/expect/src/__tests__/matchers.test.js
@@ -442,6 +442,29 @@ describe('.toEqual()', () => {
       );
     }
   });
+
+  test('non-enumerable members should be skipped during equal', () => {
+    const actual = {
+      x: 3
+    };
+    Object.defineProperty(actual, "test", {
+          enumerable: false,
+          value: 5
+    });
+    expect(actual).toEqual({ x: 3 });
+  });
+
+  test('non-enumerable symbolic members should be skipped during equal', () => {
+    const actual = {
+      x: 3
+    };
+    const mySymbol = Symbol("test");
+    Object.defineProperty(actual, mySymbol, {
+          enumerable: false,
+          value: 5
+    });
+    expect(actual).toEqual({ x: 3 });
+  });
 });
 
 describe('.toBeInstanceOf()', () => {

--- a/packages/expect/src/__tests__/matchers.test.js
+++ b/packages/expect/src/__tests__/matchers.test.js
@@ -445,25 +445,25 @@ describe('.toEqual()', () => {
 
   test('non-enumerable members should be skipped during equal', () => {
     const actual = {
-      x: 3
+      x: 3,
     };
-    Object.defineProperty(actual, "test", {
-          enumerable: false,
-          value: 5
+    Object.defineProperty(actual, 'test', {
+      enumerable: false,
+      value: 5,
     });
-    expect(actual).toEqual({ x: 3 });
+    expect(actual).toEqual({x: 3});
   });
 
   test('non-enumerable symbolic members should be skipped during equal', () => {
     const actual = {
-      x: 3
+      x: 3,
     };
-    const mySymbol = Symbol("test");
+    const mySymbol = Symbol('test');
     Object.defineProperty(actual, mySymbol, {
-          enumerable: false,
-          value: 5
+      enumerable: false,
+      value: 5,
     });
-    expect(actual).toEqual({ x: 3 });
+    expect(actual).toEqual({x: 3});
   });
 });
 

--- a/packages/expect/src/jasmine_utils.js
+++ b/packages/expect/src/jasmine_utils.js
@@ -211,6 +211,7 @@ function keys(obj, isArray, hasKey) {
     }
     return keys.concat(
       (Object.getOwnPropertySymbols(o): Array<any>).filter(
+        //$FlowFixMe Jest complains about nullability, but we know for sure that property 'symbol' does exist.
         symbol => Object.getOwnPropertyDescriptor(o, symbol).enumerable,
       ),
     );

--- a/packages/expect/src/jasmine_utils.js
+++ b/packages/expect/src/jasmine_utils.js
@@ -209,7 +209,11 @@ function keys(obj, isArray, hasKey) {
         keys.push(key);
       }
     }
-    return keys.concat((Object.getOwnPropertySymbols(o): Array<any>));
+    return keys.concat(
+      (Object.getOwnPropertySymbols(o): Array<any>).filter(
+        symbol => Object.getOwnPropertyDescriptor(o, symbol).enumerable,
+      ),
+    );
   })(obj);
 
   if (!isArray) {


### PR DESCRIPTION
… Fixes #6392

## Summary

See #6392. Non-enumerable members are not compared when using the `toEquals` matcher. However, if the non-enumerable member is symbolic, it is still used for comparison. Which results in failing equality checks with non visible difference. 

_Note: it could be considered a separate bug that enumerable members declared on the prototype are considered for equality, while symbolic members on the prototype are not considered for equality (only ownSymbols are iterated), but I didn't change that in this MR to not fix two different bugs in one PR_

## Test plan

See unit test in the PR. Before this PR the first test would succeed and the second one fail. After this PR both will succeed.
