### PR TITLE
fix: properly reprint resolver errors in watch mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixes
 
 - `[jest-runner]` Force parallel runs for watch mode, to avoid TTY freeze ([#6647](https://github.com/facebook/jest/pull/6647))
+- `[jest-cli]` properly reprint resolver errors in watch mode ([#6407](https://github.com/facebook/jest/pull/6407))
 
 ## 23.3.0
 

--- a/e2e/__tests__/__snapshots__/module_name_mapper.test.js.snap
+++ b/e2e/__tests__/__snapshots__/module_name_mapper.test.js.snap
@@ -32,7 +32,7 @@ exports[`moduleNameMapper wrong configuration 1`] = `
       12 | module.exports = () => 'test';
       13 | 
 
-      at packages/jest-resolve/build/index.js:401:17
+      at packages/jest-resolve/build/index.js:400:17
       at index.js:10:1
 
 "

--- a/e2e/__tests__/__snapshots__/module_name_mapper.test.js.snap
+++ b/e2e/__tests__/__snapshots__/module_name_mapper.test.js.snap
@@ -13,14 +13,27 @@ exports[`moduleNameMapper wrong configuration 1`] = `
 
     Configuration error:
 
-    Could not locate module ./style.css (mapped as no-such-module)
+    Could not locate module ./style.css mapped as:
+    no-such-module.
 
-    Please check:
+    Please check your configuration for these entries:
+    {
+      \\"moduleNameMapper\\": {
+        \\"/\\\\.(css|less)$/\\": \\"no-such-module\\"
+      },
+      \\"resolver\\": null
+    }
 
-    \\"moduleNameMapper\\": {
-      \\"/\\\\.(css|less)$/\\": \\"no-such-module\\"
-    },
-    \\"resolver\\": null
+       8 | 'use strict';
+       9 | 
+    > 10 | require('./style.css');
+         | ^
+      11 | 
+      12 | module.exports = () => 'test';
+      13 | 
+
+      at packages/jest-resolve/build/index.js:401:17
+      at index.js:10:1
 
 "
 `;

--- a/packages/jest-cli/src/watch.js
+++ b/packages/jest-cli/src/watch.js
@@ -236,7 +236,13 @@ export default function watch(
       outputStream,
       startRun,
       testWatcher,
-    }).catch(error => console.error(chalk.red(error.stack)));
+    }).catch(error =>
+      // Errors thrown inside `runJest`, e.g. by resolvers, are caught here for
+      // continuous watch mode execution. We need to reprint them to the
+      // terminal and give just a little bit of extra space so they fit below
+      // `preRunMessagePrint` message nicely.
+      console.error('\n\n' + chalk.red(error)),
+    );
   };
 
   const onKeypress = (key: string) => {

--- a/packages/jest-resolve-dependencies/src/index.js
+++ b/packages/jest-resolve-dependencies/src/index.js
@@ -100,7 +100,6 @@ class DependencyResolver {
         }
       }
     }
-
     const modules = this._hasteFS.getAllFiles().map(file => ({
       dependencies: this.resolve(file, options),
       file,

--- a/packages/jest-resolve/src/index.js
+++ b/packages/jest-resolve/src/index.js
@@ -383,7 +383,7 @@ const createNoMappedModuleFoundError = (
     chalk.red(`${chalk.bold('Configuration error')}:
 
 Could not locate module ${chalk.bold(moduleName)} mapped as:
-${chalk.bold(updatedName)}).
+${chalk.bold(updatedName)}.
 
 Please check your configuration for these entries:
 {

--- a/packages/jest-resolve/src/index.js
+++ b/packages/jest-resolve/src/index.js
@@ -379,10 +379,11 @@ const createNoMappedModuleFoundError = (
   regex,
   resolver,
 ) => {
-  const error = new Error(`
+  const error = new Error(
+    chalk.red(`${chalk.bold('Configuration error')}:
 
 Could not locate module ${chalk.bold(moduleName)} mapped as:
-${chalk.bold(updatedName)}.
+${chalk.bold(updatedName)}).
 
 Please check your configuration for these entries:
 {
@@ -390,9 +391,10 @@ Please check your configuration for these entries:
     "${regex.toString()}": "${chalk.bold(mappedModuleName)}"
   },
   "resolver": ${chalk.bold(String(resolver))}
-}`);
+}`),
+  );
 
-  error.name = chalk.red(`${chalk.bold('Configuration error')}`);
+  error.name = '';
 
   return error;
 };

--- a/packages/jest-resolve/src/index.js
+++ b/packages/jest-resolve/src/index.js
@@ -379,7 +379,7 @@ const createNoMappedModuleFoundError = (
   regex,
   resolver,
 ) => {
-  return new Error(
+  const error = new Error(
     chalk.red(`${chalk.bold('Configuration error')}:
 
 Could not locate module ${chalk.bold(moduleName)} mapped as:
@@ -393,6 +393,10 @@ Please check your configuration for these entries:
   "resolver": ${chalk.bold(String(resolver))}
 }`),
   );
+
+  error.name = '';
+
+  return error;
 };
 
 module.exports = Resolver;

--- a/packages/jest-resolve/src/index.js
+++ b/packages/jest-resolve/src/index.js
@@ -352,22 +352,13 @@ class Resolver {
               rootDir: this._options.rootDir,
             });
           if (!module) {
-            const error = new Error(
-              chalk.red(`${chalk.bold('Configuration error')}:
-
-Could not locate module ${chalk.bold(moduleName)} (mapped as ${chalk.bold(
-                updatedName,
-              )})
-
-Please check:
-
-"moduleNameMapper": {
-  "${regex.toString()}": "${chalk.bold(mappedModuleName)}"
-},
-"resolver": ${chalk.bold(String(resolver))}`),
+            throw createNoMappedModuleFoundError(
+              moduleName,
+              updatedName,
+              mappedModuleName,
+              regex,
+              resolver,
             );
-            error.stack = '';
-            throw error;
           }
           return module;
         }
@@ -380,5 +371,28 @@ Please check:
     return (this._options.platforms || []).indexOf(NATIVE_PLATFORM) !== -1;
   }
 }
+
+const createNoMappedModuleFoundError = (
+  moduleName,
+  updatedName,
+  mappedModuleName,
+  regex,
+  resolver,
+) => {
+  return new Error(
+    chalk.red(`${chalk.bold('Configuration error')}:
+
+Could not locate module ${chalk.bold(moduleName)} mapped as:
+${chalk.bold(updatedName)}).
+
+Please check your configuration for these entries:
+{
+  "moduleNameMapper": {
+    "${regex.toString()}": "${chalk.bold(mappedModuleName)}"
+  },
+  "resolver": ${chalk.bold(String(resolver))}
+}`),
+  );
+};
 
 module.exports = Resolver;

--- a/packages/jest-resolve/src/index.js
+++ b/packages/jest-resolve/src/index.js
@@ -379,11 +379,10 @@ const createNoMappedModuleFoundError = (
   regex,
   resolver,
 ) => {
-  const error = new Error(
-    chalk.red(`${chalk.bold('Configuration error')}:
+  const error = new Error(`
 
 Could not locate module ${chalk.bold(moduleName)} mapped as:
-${chalk.bold(updatedName)}).
+${chalk.bold(updatedName)}.
 
 Please check your configuration for these entries:
 {
@@ -391,10 +390,9 @@ Please check your configuration for these entries:
     "${regex.toString()}": "${chalk.bold(mappedModuleName)}"
   },
   "resolver": ${chalk.bold(String(resolver))}
-}`),
-  );
+}`);
 
-  error.name = '';
+  error.name = chalk.red(`${chalk.bold('Configuration error')}`);
 
   return error;
 };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

We've reprinted only `error.stack` while being in watch mode, which caused "Could not locate module" errors to vanish, because they had their stack cleared (for reasons known to me at the time of writing, which are not relevant now).

Also improved the resolver error message just a bit.

Fixes #4524

## Test plan

No time for tests because I'm heading off on vacation 😎🌴, but hey, I have screenshots!

Before:
<img width="359" alt="screen shot 2018-06-06 at 18 14 43" src="https://user-images.githubusercontent.com/5106466/41051135-8bc8f372-69b5-11e8-9bdd-a33c041257be.png">

After (watch mode resolver errors now shine as never before):
<img width="601" alt="screen shot 2018-06-06 at 18 08 39" src="https://user-images.githubusercontent.com/5106466/41051016-426ce256-69b5-11e8-81e0-853375264717.png">]

To get rid of this extra "Error: " I'd need to only print `error.message` which I think is safer not to do, as proven by `error.stack` version, but maybe I worry to much (just no time for thorough testing).

The regular run is unaffected:
<img width="646" alt="screen shot 2018-06-06 at 18 13 14" src="https://user-images.githubusercontent.com/5106466/41051071-618995d0-69b5-11e8-95fc-276a78908079.png">


