### PR TITLE
Correct erroneous rejects test example

### DIFF
--- a/docs/ExpectAPI.md
+++ b/docs/ExpectAPI.md
@@ -446,7 +446,8 @@ For example, this code tests that the promise rejects with reason `'octopus'`:
 ```js
 test('rejects to octopus', () => {
   // make sure to add a return statement
-  return expect(Promise.reject(new Error('octopus'))).rejects.toThrow(
+  return expect(Promise.reject(new Error('octopus'))).rejects.toHaveProperty(
+    'message',
     'octopus',
   );
 });
@@ -458,7 +459,10 @@ Alternatively, you can use `async/await` in combination with `.rejects`.
 
 ```js
 test('rejects to octopus', async () => {
-  await expect(Promise.reject(new Error('octopus'))).rejects.toThrow('octopus');
+  await expect(Promise.reject(new Error('octopus'))).rejects.toHaveProperty(
+    'message',
+    'octopus',
+  );
 });
 ```
 

--- a/website/versioned_docs/version-23.0/WatchPlugins.md
+++ b/website/versioned_docs/version-23.0/WatchPlugins.md
@@ -24,7 +24,7 @@ class MyWatchPlugin {
 ## Hooking into Jest
 
 To connect your watch plugin to Jest, add its path under `watchPlugins` in your Jest configuration:
- 
+
 ```javascript
 // jest.config.js
 module.exports = {


### PR DESCRIPTION
## Summary

as `rejects` will receive the rejected promise payload, not a function,
resulting in the following error message when the test was run:
`Received value must be a function, but instead "object" was found`

## Test plan

Run the examples in Jest:

 ```js
 test('rejects to octopus', () => {
  return expect(Promise.reject(new Error('octopus'))).rejects.toHaveProperty(
    'message',
    'octopus'
   );
 });
 ```
```js
 test('rejects to octopus', async () => {
  await expect(Promise.reject(new Error('octopus'))).rejects.toHaveProperty(
    'message',
    'octopus'
  );
 });
 ```
Expected output:

`Ran all test suites.`
