### PR TITLE
Adding missing attribute to GlobalConfig type

### DIFF
--- a/packages/jest-cli/src/run_jest.js
+++ b/packages/jest-cli/src/run_jest.js
@@ -200,9 +200,11 @@ export default (async function runJest({
   );
 
   if (collectCoverageFrom.length) {
-    globalConfig = Object.freeze(
-      Object.assign({}, globalConfig, {collectCoverageFrom}),
-    );
+    // $FlowFixMe Object.assign
+    const newConfig: GlobalConfig = Object.assign({}, globalConfig, {
+      collectCoverageFrom,
+    });
+    globalConfig = Object.freeze(newConfig);
   }
 
   allTests = sequencer.sort(allTests);
@@ -247,9 +249,11 @@ export default (async function runJest({
     globalConfig.silent !== true &&
     globalConfig.verbose !== false
   ) {
-    globalConfig = Object.freeze(
-      Object.assign({}, globalConfig, {verbose: true}),
-    );
+    // $FlowFixMe Object.assign
+    const newConfig: GlobalConfig = Object.assign({}, globalConfig, {
+      verbose: true,
+    });
+    globalConfig = Object.freeze(newConfig);
   }
 
   // When using more than one context, make all printed paths relative to the

--- a/types/Config.js
+++ b/types/Config.js
@@ -189,6 +189,7 @@ export type GlobalConfig = {|
   collectCoverageFrom: Array<Glob>,
   collectCoverageOnlyFrom: ?{[key: string]: boolean},
   coverageDirectory: string,
+  coveragePathIgnorePatterns?: Array<string>,
   coverageReporters: Array<string>,
   coverageThreshold: {global: {[key: string]: number}},
   detectLeaks: boolean,


### PR DESCRIPTION
When we assign a variable to the result of `Object.assign({}, ...)` the
typing for that variable is lost. Therefore we were able to access
`globalConfig.coveragePathIgnorePatterns` even though it didn't exist in
the type.

Commenting these `Object.assign` cases revealed the missing type
property.
