### PR TITLE
Avoid NaN in 'no test found' message

### DIFF
--- a/e2e/__tests__/no_test_found.test.js
+++ b/e2e/__tests__/no_test_found.test.js
@@ -19,3 +19,15 @@ describe('Coverage Report', () => {
     expect(stdout).not.toMatch('0 tests passed');
   });
 });
+
+describe('File path not found in mulit-project scenario', () => {
+  it('outputs coverage report', () => {
+    const {stdout} = runJest('multi-project-config-root', [
+      '--runTestsByPath',
+      'not-a-valid-test',
+    ]);
+
+    expect(stdout).toMatch('No tests found');
+    expect(stdout).toMatch(/0 files checked across 2 projects\./);
+  });
+});

--- a/packages/jest-cli/src/get_no_test_found.js
+++ b/packages/jest-cli/src/get_no_test_found.js
@@ -3,7 +3,7 @@ import pluralize from './pluralize';
 
 export default function getNoTestFound(testRunData, globalConfig): string {
   const testFiles = testRunData.reduce(
-    (current, testRun) => (current += testRun.matches.total || 0),
+    (current, testRun) => current + testRun.matches.total || 0,
     0,
   );
   let dataMessage;

--- a/packages/jest-cli/src/get_no_test_found.js
+++ b/packages/jest-cli/src/get_no_test_found.js
@@ -3,7 +3,7 @@ import pluralize from './pluralize';
 
 export default function getNoTestFound(testRunData, globalConfig): string {
   const testFiles = testRunData.reduce(
-    (current, testRun) => (current += testRun.matches.total),
+    (current, testRun) => (current += testRun.matches.total || 0),
     0,
   );
   let dataMessage;


### PR DESCRIPTION
This file is untyped, but the `testRun.matches.length` value here comes from https://github.com/facebook/jest/blob/master/packages/jest-cli/src/search_source.js#L27 where it is optional, so we need to handle the case where the property is not present at all.

`testRun.matches` is actually a Frankenstein's Monster version of the `SearchResult` type, since it's had other properties grafted onto it along the way via `Object.assign` https://github.com/facebook/jest/blob/master/packages/jest-cli/src/run_jest.js#L72-L75

This makes actually typing this file rather difficult.

Looks like our use of `Object.assign` is making the types in this portion of the code base worthless in a number of different places. Are there any patterns which can help us avoid this?

