### PR TITLE
Using Jest with MongoDB example - wrong variables

### DIFF
--- a/docs/MongoDB.md
+++ b/docs/MongoDB.md
@@ -35,10 +35,10 @@ module.exports = async function() {
   };
 
   // Write global config to disk because all tests run in different contexts.
-  fs.writeFileSync(mongoFileConfigPath, JSON.stringify(mongoConfig));
+  fs.writeFileSync(globalConfigPath, JSON.stringify(mongoConfig));
 
   // Set reference to mongod in order to close the server during teardown.
-  global.__MONGOD__ = mongod;
+  global.__MONGOD__ = mongoServer;
 };
 ```
 


### PR DESCRIPTION


<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

In the example file setup.js the variables `mongod` and `mongoFileConfigPath` are undefined. I think they are `mongoserver` and `globalConfigPath`.

## Test plan

none
