### PR TITLE
Add dot containing keys example to .toHaveProperty docs

### DIFF
--- a/docs/ExpectAPI.md
+++ b/docs/ExpectAPI.md
@@ -1019,7 +1019,7 @@ test('this house has my desired features', () => {
   expect(houseForSale).toHaveProperty(['kitchen', 'amenities', 0], 'oven');
   expect(houseForSale).toHaveProperty(['kitchen', 'nice.oven']);
   expect(houseForSale).not.toHaveProperty(['kitchen', 'open']);
-  
+
   // Referencing keys with dot in the key itself
   expect(houseForSale).toHaveProperty(['ceiling.height'], 'tall');
 });

--- a/docs/ExpectAPI.md
+++ b/docs/ExpectAPI.md
@@ -990,6 +990,7 @@ const houseForSale = {
     wallColor: 'white',
     'nice.oven': true,
   },
+  ceiling.height: 2',
 };
 
 test('this house has my desired features', () => {
@@ -1018,6 +1019,9 @@ test('this house has my desired features', () => {
   expect(houseForSale).toHaveProperty(['kitchen', 'amenities', 0], 'oven');
   expect(houseForSale).toHaveProperty(['kitchen', 'nice.oven']);
   expect(houseForSale).not.toHaveProperty(['kitchen', 'open']);
+  
+  // Referencing keys with dot in the key itself
+    expect(houseForSale).toHaveProperty(['ceiling.height'], 'tall');
 });
 ```
 

--- a/docs/ExpectAPI.md
+++ b/docs/ExpectAPI.md
@@ -990,7 +990,7 @@ const houseForSale = {
     wallColor: 'white',
     'nice.oven': true,
   },
-  ceiling.height: 2',
+  ceiling.height: 2'
 };
 
 test('this house has my desired features', () => {

--- a/docs/ExpectAPI.md
+++ b/docs/ExpectAPI.md
@@ -990,7 +990,7 @@ const houseForSale = {
     wallColor: 'white',
     'nice.oven': true,
   },
-  ceiling.height: 2'
+  'ceiling.height': 2',
 };
 
 test('this house has my desired features', () => {
@@ -1021,7 +1021,7 @@ test('this house has my desired features', () => {
   expect(houseForSale).not.toHaveProperty(['kitchen', 'open']);
   
   // Referencing keys with dot in the key itself
-    expect(houseForSale).toHaveProperty(['ceiling.height'], 'tall');
+  expect(houseForSale).toHaveProperty(['ceiling.height'], 'tall');
 });
 ```
 

--- a/docs/ExpectAPI.md
+++ b/docs/ExpectAPI.md
@@ -990,7 +990,7 @@ const houseForSale = {
     wallColor: 'white',
     'nice.oven': true,
   },
-  'ceiling.height': 2',
+  'ceiling.height': 2,
 };
 
 test('this house has my desired features', () => {


### PR DESCRIPTION
This docs don't cover this because it is assumed dot notation is for nested properties.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
