### PR TITLE
Update Puppeteer.md

### DIFF
--- a/docs/Puppeteer.md
+++ b/docs/Puppeteer.md
@@ -40,9 +40,10 @@ Here's an example of the GlobalSetup script
 module.exports = async function() {
   const browser = await puppeteer.launch();
   // store the browser instance so we can teardown it later
-  global.__BROWSER__ = browser;
+  // this global is only available in the teardown but not in TestEnvironments
+  global.__BROWSER_GLOBAL__ = browser;
 
-  // file the wsEndpoint for TestEnvironments
+  // use the file system to expose the wsEndpoint for TestEnvironments
   mkdirp.sync(DIR);
   fs.writeFileSync(path.join(DIR, 'wsEndpoint'), browser.wsEndpoint());
 };
@@ -87,7 +88,7 @@ Finally we can close the puppeteer instance and clean-up the file
 // teardown.js
 module.exports = async function() {
   // close the browser instance
-  await global.__BROWSER__.close();
+  await global.__BROWSER_GLOBAL__.close();
 
   // clean-up the wsEndpoint file
   rimraf.sync(DIR);


### PR DESCRIPTION
## Summary

Being new to Jest, I was pretty confused about the detour via file system since I was expecting `global.__BROWSER__` to be the same in every env. Renaming it and adding a comment should make it more clear.

## Test plan

I have submitted the same PR in https://github.com/xfumihiro/jest-puppeteer-example/pull/12 where I ran the demo test successfully.