### PR TITLE
global setup and global teardown now gets globalConfig as a parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Fixes
 
+- `[jest-cli]` Pass `globalConfig` as a parameter to `globalSetup` and `globalTeardown` functions ([#6486](https://github.com/facebook/jest/pull/6486))
 - `[jest-config]` Add missing options to the `defaults` object ([#6428](https://github.com/facebook/jest/pull/6428))
 - `[expect]` Using symbolic property names in arrays no longer causes the `toEqual` matcher to fail ([#6391](https://github.com/facebook/jest/pull/6391))
 - `[expect]` `toEqual` no longer tries to compare non-enumerable symbolic properties, to be consistent with non-symbolic properties. ([#6398](https://github.com/facebook/jest/pull/6398))

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -303,13 +303,13 @@ Note that, if you specify a global reference value (like an object or array) her
 
 Default: `undefined`
 
-This option allows the use of a custom global setup module which exports an async function that is triggered once before all test suites.
+This option allows the use of a custom global setup module which exports an async function that is triggered once before all test suites. This function gets Jest's `globalConfig` object as a parameter.
 
 ### `globalTeardown` [string]
 
 Default: `undefined`
 
-This option allows the use of a custom global teardown module which exports an async function that is triggered once after all test suites.
+This option allows the use of a custom global teardown module which exports an async function that is triggered once after all test suites. This function gets Jest's `globalConfig` object as a parameter.
 
 ### `moduleDirectories` [array<string>]
 

--- a/e2e/__tests__/global_setup.test.js
+++ b/e2e/__tests__/global_setup.test.js
@@ -46,7 +46,7 @@ test('globalSetup function gets jest config object as a parameter', () => {
     '../global-setup/setup-with-config.js',
   );
 
-  const testPathPattern = 'custom_tests_dir/pass';
+  const testPathPattern = 'pass';
 
   const result = runJest('global-setup', [
     `--globalSetup=${setupPath}`,

--- a/e2e/__tests__/global_setup.test.js
+++ b/e2e/__tests__/global_setup.test.js
@@ -39,3 +39,19 @@ test('jest throws an error when globalSetup does not export a function', () => {
     `TypeError: globalSetup file must export a function at ${setupPath}`,
   );
 });
+
+test('globalSetup function gets jest config object as a parameter', () => {
+  const setupPath = path.resolve(
+    __dirname,
+    '../global-setup/setup-with-config.js',
+  );
+
+  const testPathPattern = 'custom_tests_dir/pass';
+
+  const result = runJest('global-setup', [
+    `--globalSetup=${setupPath}`,
+    `--testPathPattern=${testPathPattern}`,
+  ]);
+
+  expect(result.stdout).toBe(testPathPattern);
+});

--- a/e2e/__tests__/global_teardown.test.js
+++ b/e2e/__tests__/global_teardown.test.js
@@ -49,3 +49,19 @@ test('jest throws an error when globalTeardown does not export a function', () =
     `TypeError: globalTeardown file must export a function at ${teardownPath}`,
   );
 });
+
+test('globalTeardown function gets jest config object as a parameter', () => {
+  const teardownPath = path.resolve(
+    __dirname,
+    '../global-teardown/teardown-with-config.js',
+  );
+
+  const testPathPattern = 'custom_tests_dir/pass';
+
+  const result = runJest('global-teardown', [
+    `--globalTeardown=${teardownPath}`,
+    `--testPathPattern=${testPathPattern}`,
+  ]);
+
+  expect(result.stdout).toBe(testPathPattern);
+});

--- a/e2e/__tests__/global_teardown.test.js
+++ b/e2e/__tests__/global_teardown.test.js
@@ -56,7 +56,7 @@ test('globalTeardown function gets jest config object as a parameter', () => {
     '../global-teardown/teardown-with-config.js',
   );
 
-  const testPathPattern = 'custom_tests_dir/pass';
+  const testPathPattern = 'pass';
 
   const result = runJest('global-teardown', [
     `--globalTeardown=${teardownPath}`,

--- a/e2e/global-setup/custom_tests_dir/pass.test.js
+++ b/e2e/global-setup/custom_tests_dir/pass.test.js
@@ -1,0 +1,1 @@
+test('should pass', () => {});

--- a/e2e/global-setup/setup-with-config.js
+++ b/e2e/global-setup/setup-with-config.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+module.exports = function(jestConfig) {
+  console.log(jestConfig.testPathPattern);
+};

--- a/e2e/global-teardown/custom_tests_dir/pass.test.js
+++ b/e2e/global-teardown/custom_tests_dir/pass.test.js
@@ -1,0 +1,1 @@
+test('should pass', () => {});

--- a/e2e/global-teardown/teardown-with-config.js
+++ b/e2e/global-teardown/teardown-with-config.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+module.exports = function(jestConfig) {
+  console.log(jestConfig.testPathPattern);
+};

--- a/packages/jest-cli/src/run_jest.js
+++ b/packages/jest-cli/src/run_jest.js
@@ -278,7 +278,7 @@ export default (async function runJest({
       );
     }
 
-    await globalSetup();
+    await globalSetup(globalConfig);
   }
   const results = await new TestScheduler(
     globalConfig,
@@ -301,7 +301,7 @@ export default (async function runJest({
       );
     }
 
-    await globalTeardown();
+    await globalTeardown(globalConfig);
   }
   return processResults(results, {
     collectHandles,


### PR DESCRIPTION
## Summary

This PR fixes #5957.

`globalSetup` and `globalTeardown` functions will receive Jest's `globalConfig` object as a parameter.

## Test plan

Pass a specific parameter to the configuration, `console.log` it from the `globalSetup`/`globalTeardown` functions and verify it shows up in the stdout.