### PR TITLE
add note in configuration docs

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -773,6 +773,8 @@ The following is a visualization of the default regex:
 └── component.js # not test
 ```
 
+_Note: `testRegex` will try to detect test files using the **absolute file path** therefore having a folder with name that match it will run all the files as tests_
+
 ### `testResultsProcessor` [string]
 
 Default: `undefined`


### PR DESCRIPTION
## Summary

As requested in https://github.com/facebook/jest/issues/5974 I added to the docs a note to reflect the fact that the test files regex is tested against the absolute path. 

## Test plan
I actually opened this PR to understand how can I test changes in the docs. I would love to get such help. 
