### PR TITLE
jest-haste-map: improve JSON parse error

### DIFF
--- a/packages/jest-haste-map/src/worker.js
+++ b/packages/jest-haste-map/src/worker.js
@@ -52,11 +52,15 @@ export async function worker(data: WorkerMessage): Promise<WorkerMetadata> {
   // Process a package.json that is returned as a PACKAGE type with its name.
   if (filePath.endsWith(PACKAGE_JSON)) {
     content = fs.readFileSync(filePath, 'utf8');
-    const fileData = JSON.parse(content);
+    try {
+      const fileData = JSON.parse(content);
 
-    if (fileData.name) {
-      id = fileData.name;
-      module = [filePath, H.PACKAGE];
+      if (fileData.name) {
+        id = fileData.name;
+        module = [filePath, H.PACKAGE];
+      }
+    } catch (err) {
+      throw new Error(`Cannot parse ${filePath} as JSON: ${err.message}`)
     }
 
     // Process a randome file that is returned as a MODULE.

--- a/packages/jest-haste-map/src/worker.js
+++ b/packages/jest-haste-map/src/worker.js
@@ -60,7 +60,7 @@ export async function worker(data: WorkerMessage): Promise<WorkerMetadata> {
         module = [filePath, H.PACKAGE];
       }
     } catch (err) {
-      throw new Error(`Cannot parse ${filePath} as JSON: ${err.message}`)
+      throw new Error(`Cannot parse ${filePath} as JSON: ${err.message}`);
     }
 
     // Process a randome file that is returned as a MODULE.


### PR DESCRIPTION
Ran into this failing because of a git branch named `package.json` and it was hard to debug. This adds the path to the error.

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

It makes #4839 easier to debug

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

I edited the code in-place in node_modules and here present the untested clean version 😬