### PR TITLE
Fix extensions not being respected when using '--browser' (#6005)

### DIFF
--- a/packages/jest-resolve/package.json
+++ b/packages/jest-resolve/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "main": "build/index.js",
   "dependencies": {
-    "browser-resolve": "^1.11.2",
+    "browser-resolve": "^1.11.3",
     "chalk": "^2.0.1",
     "realpath-native": "^1.0.0"
   },


### PR DESCRIPTION
## Summary

In earlier versions of `browser-resolve`, the sync behavior did not properly resolve module extensions due to a divergence between their sync and async implementations.  This was resolved in https://github.com/defunctzombie/node-browser-resolve/pull/90 which should align their sync/async behaviors and allow extensions to be resolved propery when using the `browser` flag.

## Test plan

All tests required were committed in the referenced pull request for `browser-resolve`.  This was a patch release to `browser-resolve`, so the caret range defined would have implicitly picked up this patch in the future on `yarn install`, we're just being explicit about wanting this fix.