### PR TITLE
add explanation how to link build version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,6 +109,10 @@ To run tests in another project with the development build of Jest:
 
 ```sh
 cd /path/to/another/project
+
+# link development build to the other project
+yarn link jest-cli
+
 jest [options] # run jest-cli/bin/jest.js in the development build
 ```
 


### PR DESCRIPTION
## Summary

The CONTRIBUTING.md is currently lacking a command in the process of linking build version of jest. 
Yarn's link command should be run both in jest-cli folder and in the project as well. 
(Here is yarn's output while running `yarn link` inside jest-cli
<img width="664" alt="screen shot 2018-06-20 at 8 16 49" src="https://user-images.githubusercontent.com/17698441/41638573-c75cc1ea-7462-11e8-8cdd-d4f78cba476f.png">)

## Test plan

Relevant lines in CONTRIBUTING.md after the change:
<img width="900" alt="screen shot 2018-06-20 at 8 25 02" src="https://user-images.githubusercontent.com/17698441/41638716-7f543364-7463-11e8-801b-8bab940a986c.png">

