### PR TITLE
Add cache for HasteMap instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 - `[docs]` Add jest-each docs for 1 dimensional arrays ([#6444](https://github.com/facebook/jest/pull/6444/files))
 
+### Features
+
+- `[jest-runtime]` Avoid generating multiple instances of haste maps when the configuration is identical ([#6507](https://github.com/facebook/jest/pull/6507/files))
+
 ## 23.1.0
 
 ### Features

--- a/packages/jest-runtime/src/__tests__/runtime_create_haste_map.test.js
+++ b/packages/jest-runtime/src/__tests__/runtime_create_haste_map.test.js
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+const Runtime = require('..');
+
+it('returns the same Haste instance if parameters are the same', () => {
+  jest.mock('jest-haste-map');
+
+  const hasteConfig = {
+    cacheDirectory: '/foo/bar/baz',
+    haste: {
+      hasteImplModulePath: '/haste/impl/module/path.js',
+      providesModuleNodeModules: ['react', 'react-native'],
+    },
+    moduleFileExtensions: ['js', 'json', 're'],
+    roots: ['/foo', '/bar'],
+  };
+
+  const hasteOptions = {
+    maxWorkers: 314,
+    resetCache: true,
+    watch: false,
+    watchman: true,
+  };
+
+  const hasteOptionsChanged = {
+    maxWorkers: 314,
+    resetCache: false,
+    watch: false,
+    watchman: true,
+  };
+
+  const hasteMap1 = Runtime.createHasteMap(hasteConfig, hasteOptions);
+  const hasteMap2 = Runtime.createHasteMap(hasteConfig, hasteOptions);
+  const hasteMap3 = Runtime.createHasteMap(hasteConfig, hasteOptionsChanged);
+
+  // We use "toBe" instead of "toEqual" to check that the instance is the same.
+  expect(hasteMap1).toBe(hasteMap2);
+
+  expect(hasteMap1).not.toBe(hasteMap3);
+  expect(hasteMap2).not.toBe(hasteMap3);
+});

--- a/packages/jest-runtime/src/index.js
+++ b/packages/jest-runtime/src/index.js
@@ -17,6 +17,7 @@ import type {ModuleMap} from 'jest-haste-map';
 import type {MockFunctionMetadata, ModuleMocker} from 'types/Mock';
 import type {SourceMapRegistry} from 'types/SourceMaps';
 
+import crypto from 'crypto';
 import path from 'path';
 import HasteMap from 'jest-haste-map';
 import {formatStackTrace, separateMessageFromStack} from 'jest-message-util';
@@ -61,7 +62,6 @@ type CoverageOptions = {
 };
 
 type ModuleRegistry = {[key: string]: Module, __proto__: null};
-
 type BooleanObject = {[key: string]: boolean, __proto__: null};
 type CacheFS = {[path: Path]: string, __proto__: null};
 
@@ -80,6 +80,7 @@ const getModuleNameMapper = (config: ProjectConfig) => {
 };
 
 const unmockRegExpCache = new WeakMap();
+const hasteMaps = new Map();
 
 class Runtime {
   static ScriptTransformer: Class<ScriptTransformer>;
@@ -226,7 +227,7 @@ class Runtime {
       [config.cacheDirectory].concat(config.modulePathIgnorePatterns).join('|'),
     );
 
-    return new HasteMap({
+    const hasteOptions = {
       cacheDirectory: config.cacheDirectory,
       console: options && options.console,
       extensions: [Snapshot.EXTENSION].concat(config.moduleFileExtensions),
@@ -242,7 +243,22 @@ class Runtime {
       roots: config.roots,
       useWatchman: options && options.watchman,
       watch: options && options.watch,
-    });
+    };
+
+    const hash = crypto.createHash('md5');
+
+    Object.keys(hasteOptions)
+      .sort()
+      .forEach(key =>
+        hash.update(key + '\0' + JSON.stringify(hasteOptions[key]) + '\0\0'),
+      );
+
+    const hasteKey = hash.digest('hex');
+    const hasteMap = hasteMaps.get(hasteKey) || new HasteMap(hasteOptions);
+
+    hasteMaps.set(hasteKey, hasteMap);
+
+    return hasteMap;
   }
 
   static createResolver(config: ProjectConfig, moduleMap: ModuleMap): Resolver {


### PR DESCRIPTION
When two `HasteMap` are required with the same configuration, make sure to return the earlier one built. This is useful to avoid over-using resources where an existing one can do the trick already.

Added a specific test to ensure that two same calls return the same map, but a parameter variation returns a new one.