### PR TITLE
mock console.log to reduce noise from the tests

### DIFF
--- a/packages/jest-cli/src/lib/__tests__/init.test.js
+++ b/packages/jest-cli/src/lib/__tests__/init.test.js
@@ -4,6 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
+ * @flow
  */
 
 /* eslint-disable no-eval */
@@ -28,7 +29,7 @@ const sep = path.sep;
 
 describe('init', () => {
   beforeEach(() => {
-    // mock console.log to reduce noise from the tests
+    // $FlowFixMe mock console.log to reduce noise from the tests
     console.log = jest.fn();
     fs.writeFileSync = jest.fn();
     path.sep = '/';
@@ -36,6 +37,7 @@ describe('init', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
+    // $FlowFixMe
     console.log = consoleLog;
     fs.writeFileSync = writeFileSync;
     path.sep = sep;

--- a/packages/jest-cli/src/lib/__tests__/init.test.js
+++ b/packages/jest-cli/src/lib/__tests__/init.test.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow
  */
 
 /* eslint-disable no-eval */
@@ -24,16 +23,20 @@ const resolveFromFixture = relativePath =>
   path.resolve(__dirname, 'fixtures', relativePath);
 
 const writeFileSync = fs.writeFileSync;
+const consoleLog = console.log;
 const sep = path.sep;
 
 describe('init', () => {
   beforeEach(() => {
+    // mock console.log to reduce noise from the tests
+    console.log = jest.fn();
     fs.writeFileSync = jest.fn();
     path.sep = '/';
   });
 
   afterEach(() => {
     jest.clearAllMocks();
+    console.log = consoleLog;
     fs.writeFileSync = writeFileSync;
     path.sep = sep;
   });


### PR DESCRIPTION
## Summary
Following to @SimenB's [advice](https://github.com/facebook/jest/pull/6442#issuecomment-399333786), mock `console.log` in `init` tests to reduce noise. 

## Test plan

All tests pass (without nonessential logs)