### PR TITLE
deep merge property matchers in snapshot objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - `[expect]` `toEqual` no longer tries to compare non-enumerable symbolic properties, to be consistent with non-symbolic properties. ([#6398](https://github.com/facebook/jest/pull/6398))
 - `[jest-util]` `console.timeEnd` now properly log elapsed time in milliseconds. ([#6456](https://github.com/facebook/jest/pull/6456))
 - `[jest-mock]` Fix `MockNativeMethods` access in react-native `jest.mock()` ([#6505](https://github.com/facebook/jest/pull/6505))
+- `[jest-snapshot]` Correctly merge property matchers with the rest of the snapshot in `toMatchSnapshot`. ([#6455](https://github.com/facebook/jest/issues/6455))
 
 ### Chore & Maintenance
 

--- a/packages/jest-snapshot/src/index.js
+++ b/packages/jest-snapshot/src/index.js
@@ -48,6 +48,27 @@ const cleanup = (hasteFS: HasteFS, update: SnapshotUpdateState) => {
   };
 };
 
+function isObject(item) {
+  return (item && typeof item === 'object' && !Array.isArray(item));
+}
+
+function deepMerge(target, source) {
+  let mergedOutput = Object.assign({}, target);
+  if (isObject(target) && isObject(source)) {
+    Object.keys(source).forEach(key => {
+      if (isObject(source[key]) && !source[key].$$typeof) {
+        if (!(key in target))
+          Object.assign(output, {[key]: source[key]});
+        else
+          output[key] = deepMerge(target[key], source[key]);
+      } else {
+        Object.assign(output, {[key]: source[key]});
+      }
+    });
+  }
+  return mergedOutput;
+}
+
 const toMatchSnapshot = function(
   received: any,
   propertyMatchers?: any,
@@ -98,7 +119,7 @@ const toMatchSnapshot = function(
         report,
       };
     } else {
-      Object.assign(received, propertyMatchers);
+      received = deepMerge(received, propertyMatchers);
     }
   }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Correct an issue where snapshots that were tested against property matchers would not be merged with the rest of the object being tested.

## Test plan

All tests pass.
