### PR TITLE
Node 10.5.x compatibility on CI for tests

### DIFF
--- a/packages/jest-runtime/src/__tests__/script_transformer.test.js
+++ b/packages/jest-runtime/src/__tests__/script_transformer.test.js
@@ -11,7 +11,13 @@
 const slash = require('slash');
 
 jest
-  .mock('fs')
+  .mock('fs', () =>
+    // Node 10.5.x compatibility
+    Object.assign({}, jest.genMockFromModule('fs'), {
+      ReadStream: require.requireActual('fs').ReadStream,
+      WriteStream: require.requireActual('fs').WriteStream,
+    }),
+  )
   .mock('graceful-fs')
   .mock('jest-haste-map', () => ({
     getCacheFilePath: (cacheDir, baseDir, version) => cacheDir + baseDir,

--- a/packages/jest-util/src/__tests__/get_callsite.test.js
+++ b/packages/jest-util/src/__tests__/get_callsite.test.js
@@ -2,7 +2,13 @@ import fs from 'fs';
 import SourceMap from 'source-map';
 import getCallsite from '../get_callsite';
 
-jest.mock('fs');
+// Node 10.5.x compatibility
+jest.mock('fs', () =>
+  Object.assign({}, jest.genMockFromModule('fs'), {
+    ReadStream: require.requireActual('fs').ReadStream,
+    WriteStream: require.requireActual('fs').WriteStream,
+  }),
+);
 
 describe('getCallsite', () => {
   test('without source map', () => {


### PR DESCRIPTION
## Summary

Fixes https://github.com/facebook/jest/issues/6529

jest.mock('fn') does not seem to include fs.ReadStream or fs.WriteStream in the resulting mocked module. This updates the tests to specify them in the mock.

I'm assuming larger work is required in jest-mock to address this directly.

## Test plan

All tests pass locally on 10.5.x