### PR TITLE
Switch to jestjs.io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## master
 
+### Chore & Maintenance
+
+- `[website]` Switch domain to https://jestjs.io ([#6549](https://github.com/facebook/jest/pull/6549))
+
 ## 23.2.0
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -149,10 +149,10 @@ Learn more about using [Jest on the official site!](http://facebook.github.io/je
 
 ## Badge
 
-Show the world you're using _Jest_ → [![tested with jest](https://img.shields.io/badge/tested_with-jest-99424f.svg)](https://github.com/facebook/jest) [![jest](https://facebook.github.io/jest/img/jest-badge.svg)](https://github.com/facebook/jest)
+Show the world you're using _Jest_ → [![tested with jest](https://img.shields.io/badge/tested_with-jest-99424f.svg)](https://github.com/facebook/jest) [![jest](https://jestjs.io/img/jest-badge.svg)](https://github.com/facebook/jest)
 
 ```md
-[![tested with jest](https://img.shields.io/badge/tested_with-jest-99424f.svg)](https://github.com/facebook/jest) [![jest](https://facebook.github.io/jest/img/jest-badge.svg)](https://github.com/facebook/jest)
+[![tested with jest](https://img.shields.io/badge/tested_with-jest-99424f.svg)](https://github.com/facebook/jest) [![jest](https://jestjs.io/img/jest-badge.svg)](https://github.com/facebook/jest)
 ```
 
 ## Contributing

--- a/docs/SnapshotTesting.md
+++ b/docs/SnapshotTesting.md
@@ -61,7 +61,7 @@ it('renders correctly', () => {
 
 In that case, Jest will print this output:
 
-![](/jest/img/content/failedSnapshotTest.png)
+![](/img/content/failedSnapshotTest.png)
 
 Since we just updated our component to point to a different address, it's reasonable to expect changes in the snapshot for this component. Our snapshot test case is failing because the snapshot for our updated component no longer matches the snapshot artifact for this test case.
 
@@ -81,17 +81,17 @@ You can try out this functionality by cloning the [snapshot example](https://git
 
 Failed snapshots can also be updated interactively in watch mode:
 
-![](/jest/img/content/interactiveSnapshot.png)
+![](/img/content/interactiveSnapshot.png)
 
 Once you enter Interactive Snapshot Mode, Jest will step you through the failed snapshots one test at a time and give you the opportunity to review the failed output.
 
 From here you can choose to update that snapshot or skip to the next:
 
-![](/jest/img/content/interactiveSnapshotUpdate.gif)
+![](/img/content/interactiveSnapshotUpdate.gif)
 
 Once you're finished, Jest will give you a summary before returning back to watch mode:
 
-![](/jest/img/content/interactiveSnapshotDone.png)
+![](/img/content/interactiveSnapshotDone.png)
 
 ### Property Matchers
 

--- a/packages/jest-cli/package.json
+++ b/packages/jest-cli/package.json
@@ -54,7 +54,7 @@
   "bugs": {
     "url": "https://github.com/facebook/jest/issues"
   },
-  "homepage": "http://facebook.github.io/jest/",
+  "homepage": "http://jestjs.io/",
   "license": "MIT",
   "keywords": [
     "ava",

--- a/packages/jest-runtime/src/index.js
+++ b/packages/jest-runtime/src/index.js
@@ -632,7 +632,7 @@ class Runtime {
       if (mockMetadata == null) {
         throw new Error(
           `Failed to get mock metadata: ${modulePath}\n\n` +
-            `See: http://facebook.github.io/jest/docs/manual-mocks.html#content`,
+            `See: http://jestjs.io/docs/manual-mocks.html#content`,
         );
       }
       this._mockMetaDataCache[modulePath] = mockMetadata;

--- a/packages/jest-util/src/__tests__/__snapshots__/fake_timers.test.js.snap
+++ b/packages/jest-util/src/__tests__/__snapshots__/fake_timers.test.js.snap
@@ -3,5 +3,5 @@
 exports[`FakeTimers runAllTimers warns when trying to advance timers while real timers are used 1`] = `
 "A function to advance timers was called but the timers API is not mocked with fake timers. Call \`jest.useFakeTimers()\` in this test or enable fake timers globally by setting \`\\"timers\\": \\"fake\\"\` in the configuration file. This warning is likely a result of a default configuration change in Jest 15.
 
-Release Blog Post: https://facebook.github.io/jest/blog/2016/09/01/jest-15.html"
+Release Blog Post: https://jestjs.io/blog/2016/09/01/jest-15.html"
 `;

--- a/packages/jest-util/src/fake_timers.js
+++ b/packages/jest-util/src/fake_timers.js
@@ -361,7 +361,7 @@ export default class FakeTimers<TimerRef> {
           `\`"timers": "fake"\` in ` +
           `the configuration file. This warning is likely a result of a ` +
           `default configuration change in Jest 15.\n\n` +
-          `Release Blog Post: https://facebook.github.io/jest/blog/2016/09/01/jest-15.html\n` +
+          `Release Blog Post: https://jestjs.io/blog/2016/09/01/jest-15.html\n` +
           `Stack Trace:\n` +
           formatStackTrace(new Error().stack, this._config, {
             noStackTrace: false,

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -17,7 +17,7 @@
     "type": "git",
     "url": "https://github.com/facebook/jest"
   },
-  "homepage": "http://facebook.github.io/jest/",
+  "homepage": "http://jestjs.io/",
   "license": "MIT",
   "keywords": [
     "ava",

--- a/website/blog/2016-03-11-javascript-unit-testing-performance.md
+++ b/website/blog/2016-03-11-javascript-unit-testing-performance.md
@@ -25,7 +25,7 @@ Most of the time our static analysis determines that more than one test needs to
 
 Recently we noticed Jest often seemed stuck _“Waiting for 3 tests”_ for up to a minute toward the end of a run. It turned out we had a few really slow tests in our codebase that were dominating the test runtime. While we were able to speed these individual tests up significantly, we also made a change in how Jest schedules test runs. Previously we used to schedule test runs based on file system traversal, which was actually quite random. Here is an example of 11 tests in gray blocks over two workers. The size of the block is the runtime of the test:
 
-![perf-basic-scheduling](/jest/img/blog/Scheduling1.png)
+![perf-basic-scheduling](/img/blog/Scheduling1.png)
 
 We were randomly running a mix of fast and slow tests, and one of our slowest tests ended up running as almost all the other tests were completed, during which the second worker sat idle.
 
@@ -33,7 +33,7 @@ We made a change to schedule tests based on their file size which is usually a g
 
 Here is an example of the same test run from before with better scheduling:
 
-![perf-improved-scheduling](/jest/img/blog/Scheduling2.png)
+![perf-improved-scheduling](/img/blog/Scheduling2.png)
 
 Because we are running slow tests first, Jest can sometimes seem to take a long time to start up – we only print results after the first test has completed. For the future we are planning to run previously failed tests first, because getting that info to developers as quickly as possible matters the most.
 

--- a/website/blog/2016-07-27-jest-14.md
+++ b/website/blog/2016-07-27-jest-14.md
@@ -41,7 +41,7 @@ The snapshot artifact should be committed alongside code changes. We use [pretty
 
 If we change the address the Link component in our example is pointing to, Jest will print this output:
 
-![snapshot-testing](/jest/img/blog/snapshot.png)
+![snapshot-testing](/img/blog/snapshot.png)
 
 Now you know that you either need to accept the changes with `jest -u`, or fix the component if the changes were unintentional. To try out this functionality, please clone the [snapshot example](https://github.com/facebook/jest/tree/master/examples/snapshot), modify the Link component and run Jest. We updated the [React Tutorial](/jest/docs/tutorial-react.html) with a new guide for snapshot testing.
 

--- a/website/blog/2016-09-01-jest-15.md
+++ b/website/blog/2016-09-01-jest-15.md
@@ -15,13 +15,13 @@ The most important change to talk about is a set of [new defaults](https://githu
 
 As part of our effort to remove Jasmine incrementally within Jest, replacing all Jasmine matchers was almost completed. A lot of time was spent tweaking every error message for every matcher to give the best signal to users when a test is failing – the time when Jest should provide the most value to you. In addition to printing the expected and received values, a diff is printed for the `toBe` and `toEqual` matchers to help spot mistakes. More colors were added and relevant files from stack traces are highlighted more prominently.
 
-Here is a comparison of the before and after on a light terminal: ![failure1](/jest/img/blog/15-failure1.png) It also works well with darker colors: ![failure2](/jest/img/blog/15-failure2.png)
+Here is a comparison of the before and after on a light terminal: ![failure1](/img/blog/15-failure1.png) It also works well with darker colors: ![failure2](/img/blog/15-failure2.png)
 
 ## New watch command
 
 We completely rewrote `jest --watch` to be more interactive. It can now switch between running all tests or only test files related to changed files by pressing `a` or `o`. By pressing `p` a prompt appears that allows to specify a test pattern to focus on a specific set of files. Snapshot tests can be updated by pressing `u`.
 
-![watch](/jest/img/blog/15-watch.gif)
+![watch](/img/blog/15-watch.gif)
 
 ## jest-react-native improvements
 
@@ -40,7 +40,7 @@ There have also been a number of improvements around mocking images, the fetch m
 
 Jest parallelizes test runs across workers to maximize performance. Previously Jest used to forward console messages from workers to the parent and printed them immediately. When running multiple tests in parallel, it was often hard to find out which test and which module was calling a log function. In Jest 15, all console messages are buffered and printed together with individual test results. In addition the file and line number of the log call is printed so the code can easily be inspected.
 
-Compare the output of the previous version of Jest and Jest 15: ![console](/jest/img/blog/15-console.png)
+Compare the output of the previous version of Jest and Jest 15: ![console](/img/blog/15-console.png)
 
 ## Disabled Automocking
 

--- a/website/blog/2016-10-03-jest-16.md
+++ b/website/blog/2016-10-03-jest-16.md
@@ -9,7 +9,7 @@ It's been one month since the last major release and we've made significant impr
 
 ## Upgraded CLI
 
-![reporter](/jest/img/blog/16-reporter.gif)
+![reporter](/img/blog/16-reporter.gif)
 
 Jest 16 features a new reporter interface that shows running tests as well as a live summary and a progress bar based on the estimated test runtime from previous test runs. We also improved the CLI output to work better with different color schemes. If there were test failures in a previous run, Jest will now always run those tests first to give useful signal to users as quickly as possible.
 
@@ -28,7 +28,7 @@ We also added a lot of new features which you may find useful:
 - We improved module resolution when `moduleNameMapper` is used.
 - Finally, a `--findRelatedTests <fileA> <fileB>` cli option was added to run tests related to the specified files. This is especially helpful as a pre-commit hook if you'd like to run tests only on a specified set of files that have tests associated with them.
 
-This is what Jest looks like when a test run is interrupted in watch mode: ![watch](/jest/img/blog/16-watch.gif)
+This is what Jest looks like when a test run is interrupted in watch mode: ![watch](/img/blog/16-watch.gif)
 
 ## Snapshot Updates
 
@@ -38,7 +38,7 @@ Jest's snapshot implementation was completely rewritten. The new version of the 
 - We removed function names from snapshots. They were causing issues with different versions of Node, with code coverage instrumentation and we generally felt like it wasn't useful signal to show to the user that the name of a function has changed.
 - Snapshots are now sorted using natural sort order within a file.
 
-When upgrading to Jest 16, the diff might look similar to this one: ![snapshots](/jest/img/blog/16-snapshots.png)
+When upgrading to Jest 16, the diff might look similar to this one: ![snapshots](/img/blog/16-snapshots.png)
 
 ## Test Library Updates
 

--- a/website/blog/2017-01-30-a-great-developer-experience.md
+++ b/website/blog/2017-01-30-a-great-developer-experience.md
@@ -29,11 +29,11 @@ We have created a [showcase of users](/jest/users.html) to highlight some of the
 
 <div class="productShowcaseSection">
  <div class="logos">
-   <img src="/jest/img/logos/twitter.png" title="Twitter"/>
-   <img src="/jest/img/logos/pinterest.png" title="Pinterest"/>
-   <img src="/jest/img/logos/paypal.png" title="PayPal"/>
-   <img src="/jest/img/logos/ibm.png" title="IBM"/>
-   <img src="/jest/img/logos/spotify.png" title="Spotify"/>
+   <img src="/img/logos/twitter.png" title="Twitter"/>
+   <img src="/img/logos/pinterest.png" title="Pinterest"/>
+   <img src="/img/logos/paypal.png" title="PayPal"/>
+   <img src="/img/logos/ibm.png" title="IBM"/>
+   <img src="/img/logos/spotify.png" title="Spotify"/>
  </div>
 </div>
 

--- a/website/blog/2017-02-21-jest-19-immersive-watch-mode-test-platform-improvements.md
+++ b/website/blog/2017-02-21-jest-19-immersive-watch-mode-test-platform-improvements.md
@@ -54,7 +54,7 @@ exports[`snap 1`] = `
 
 We decided it's a good time to introduce versioned snapshots to ensure all developers are using a compatible version of Jest. Here's how we warn you about the need to update your snapshot:
 
-![snapshot-version](/jest/img/blog/19-snapshot-version.png)
+![snapshot-version](/img/blog/19-snapshot-version.png)
 
 Please make sure you revert any local changes before updating to make the transition smooth and to ensure you aren't including any unwanted changes from failing tests in your new snapshots.
 
@@ -62,7 +62,7 @@ Please make sure you revert any local changes before updating to make the transi
 
 Skipped tests are now printed as a single line instead of showing every individual one when testing in verbose mode or a single suite. Hopefully it will let you focus on currently important tests. It also occupies far less space!
 
-![skipped-tests](/jest/img/blog/19-skipped-tests.png)
+![skipped-tests](/img/blog/19-skipped-tests.png)
 
 ## New CLI arguments
 
@@ -73,7 +73,7 @@ Jest 19 ships with two new coverage-related arguments which you can run from CLI
 
 We now also error on invalid CLI arguments instead of ignoring them. But we've got your back with helpful error message like the one below, e.g. when you try running `jest --watc`:
 
-![cli-error](/jest/img/blog/19-cli-error.png)
+![cli-error](/img/blog/19-cli-error.png)
 
 ## `expect` Improvements
 
@@ -99,7 +99,7 @@ While we refactored the validation and normalization code for Jest's configurati
 
 `jest-validate` is a generic configuration validation tool that helps you with warnings, errors and deprecation messages in your JavaScript tool. It's also capable of showing users friendly examples of correct configuration and it comes with a simple but powerful API. We hope it'll make a good addition to your projects!
 
-![validate](/jest/img/blog/19-validate.png)
+![validate](/img/blog/19-validate.png)
 
 We're happy to announce that `jest-validate` is validating config options of [prettier](https://github.com/jlongster/prettier) since [v0.12](https://github.com/jlongster/prettier/blob/master/CHANGELOG.md#0120). Feel free to add it to your project, try it, send us feedback and improve it by making pull requests on GitHub.
 
@@ -107,7 +107,7 @@ We're happy to announce that `jest-validate` is validating config options of [pr
 
 We moved the asymmetric matchers implementation from Jasmine into Jest, which enabled us to further improve the user experience around them. As a result, asymmetric matchers are now pretty-printed nicely, we added the new [`expect.stringContaining()`](http://facebook.github.io/jest/docs/expect.html#expectstringcontainingstring) matcher and we also paired them with [`expect.toMatchObject()`](http://facebook.github.io/jest/docs/expect.html#tomatchobjectobject) so you can use the best of both:
 
-![asymmetric-matchers](/jest/img/blog/19-asymmetric-matchers.png)
+![asymmetric-matchers](/img/blog/19-asymmetric-matchers.png)
 
 ## Better manual mocks
 

--- a/website/blog/2017-05-06-jest-20-delightful-testing-multi-project-runner.md
+++ b/website/blog/2017-05-06-jest-20-delightful-testing-multi-project-runner.md
@@ -11,7 +11,7 @@ A few months ago we announced [Jest 19](http://facebook.github.io/jest/blog/2017
 
 Until now, Jest could only operate in one project at a time. This is often cumbersome if you are working on many smaller projects that each have their own setup and configuration. With Jest 20, we rewrote the test runner completely to run many projects at the same time within a single instance of Jest, for example if you are working on a React frontend and a node.js backend. Here is a video of Jest running tests for [React](https://github.com/facebook/react), [Relay](https://github.com/facebook/relay), [Yarn](https://github.com/yarnpkg/yarn) and Jest all at the same time:
 
-![multi-runner](/jest/img/blog/20-multi-runner.gif)
+![multi-runner](/img/blog/20-multi-runner.gif)
 
 <!--truncate-->
 
@@ -62,7 +62,7 @@ test('compares apples and bananas', async () => {
 
 This example will print a test failure similar to this:
 
-![testing-apis](/jest/img/blog/20-testing-apis.png)
+![testing-apis](/img/blog/20-testing-apis.png)
 
 ## Breaking Changes
 

--- a/website/blog/2017-12-18-jest-22.md
+++ b/website/blog/2017-12-18-jest-22.md
@@ -39,11 +39,11 @@ test('some test', () => {
 
 In Jest 21, we would display the following error:
 
-![failure in Jest 21](/jest/img/blog/22-failure-21.png)
+![failure in Jest 21](/img/blog/22-failure-21.png)
 
 In Jest 22, we have added a codeframe, giving more context to the failing assertions. We have also cleaned up the stack trace to remove more clutter than ever.
 
-![failure in Jest 22](/jest/img/blog/22-failure-22.png)
+![failure in Jest 22](/img/blog/22-failure-22.png)
 
 ## Easier testing of errors thrown in async code
 
@@ -122,7 +122,7 @@ The community around Jest is working hard to make the testing experience even gr
 
 We'd also like to announce that recently we launched a new place for high quality Jest additions – [jest-community](https://github.com/jest-community). It's a new GitHub organization already featuring our favorite projects, like [vscode-jest](https://github.com/jest-community/vscode-jest), [jest-extended](https://github.com/jest-community/jest-extended), to name a few, curated by Jest maintainers and collaborators. We've even migrated our [eslint-plugin-jest](https://github.com/jest-community/eslint-plugin-jest) there, and already see some great contributions, which are published independently at a faster pace.
 
-![Jest Community](/jest/img/blog/22-community.png)
+![Jest Community](/img/blog/22-community.png)
 
 Community projects under one organisation are also a great way for us to experiment on things like automated releases, which we'd like to explore for Jest as well. They also enable us to share some common things between them, like the shape of the README for example (thanks to the webpack Community for the idea), making it easier to learn and use for all of us.
 

--- a/website/blog/2018-05-29-jest-23-blazing-fast-delightful-testing.md
+++ b/website/blog/2018-05-29-jest-23-blazing-fast-delightful-testing.md
@@ -17,7 +17,7 @@ For a full list see the [changelog](https://github.com/facebook/jest/blob/master
 
 We've added a new default watch menu option we're calling Interactive Snapshot Mode. This new mode allows you to step through each failing snapshot in each failing suite to review your failed snapshots and choose to update or skip each individually.
 
-![Interactive snapshot mode in action](/jest/img/blog/23-interactive.gif)
+![Interactive snapshot mode in action](/img/blog/23-interactive.gif)
 
 See the Interactive Snapshot Mode docs [here](https://facebook.github.io/jest/docs/en/snapshot-testing.html#interactive-snapshot-mode).
 
@@ -25,7 +25,7 @@ See the Interactive Snapshot Mode docs [here](https://facebook.github.io/jest/do
 
 Often, objects you're snapshotting contain generated values like Dates and IDs. Jest now allows you to pass properties to the snapshot matcher which specify the structure of the data instead of the specific values. These property matchers are then verified before serializing the matcher type (instead of the value), giving you consistent snapshot results across test runs.
 
-![Snapshot Property Matchers](/jest/img/blog/23-snapshot-matchers.png)
+![Snapshot Property Matchers](/img/blog/23-snapshot-matchers.png)
 
 See the updated `toMatchSnapshot` [docs](https://facebook.github.io/jest/docs/en/expect.html#tomatchsnapshotpropertymatchers-snapshotname) or the Property Matcher [guide](https://facebook.github.io/jest/docs/en/snapshot-testing.html#property-matchers) for more information.
 
@@ -33,7 +33,7 @@ See the updated `toMatchSnapshot` [docs](https://facebook.github.io/jest/docs/en
 
 We now support asynchronous matchers with `expect.extends`! Async matchers return a Promise so that you can `await` for the matcher to resolve. As an example:
 
-![Custom asynchronous matchers in action](/jest/img/blog/23-async-matchers.png)
+![Custom asynchronous matchers in action](/img/blog/23-async-matchers.png)
 
 Docs available [here](https://facebook.github.io/jest/docs/en/expect.html#expectextendmatchers).
 
@@ -41,13 +41,13 @@ Docs available [here](https://facebook.github.io/jest/docs/en/expect.html#expect
 
 Asymmetric matchers are a great tool to use when you only care about asymmetric equality. For example, when the left side is expected to be an object with some subset of properties on the right, instead of an exact match. Jest provides a number of asymmetric matchers out of the box, and in this release we're introducing Custom Asymmetric Matchers.
 
-![Custom asymmetric matchers in action](/jest/img/blog/23-asymmetric-matchers.png)
+![Custom asymmetric matchers in action](/img/blog/23-asymmetric-matchers.png)
 
 ## Jest Each
 
 [@mattphillipsio](https://twitter.com/mattphillipsio) has donated the `jest-each` package to Jest Core (thanks Matt!). `jest-each` is a library inspired by [`mocha-each`](https://yarnpkg.com/en/package/mocha-each) and [Spock Data Tables](http://spockframework.org/spock/docs/1.1/data_driven_testing.html#data-tables) which allows you to define a table of test cases, and then run a test for each row with the specified column values. We support both array types and template literals for all flavors of `describe` and `test`. Docs are available [here](https://facebook.github.io/jest/docs/en/api.html#testeachtable-name-fn), and for those not on Jest 23 yet, we're still publishing [`jest-each`](https://yarnpkg.com/en/package/jest-each) separately!
 
-![jest-each in action](/jest/img/blog/23-jest-each.png)
+![jest-each in action](/img/blog/23-jest-each.png)
 
 Huge shout out to Prettier for [fixing](https://github.com/prettier/prettier/pull/4423) the table formatting so quickly ([see Prettier 1.13](https://prettier.io/blog/2018/05/23/1.13.0.html#format-new-describeeach-table-in-jest-23-4423-by-ikatyang))!
 
@@ -63,7 +63,7 @@ We only add matchers to core if we believe they will be useful to a large amount
 - nthReturnedWith
 - toStrictEqual
 
-![New matchers in action](/jest/img/blog/23-new-matchers.png)
+![New matchers in action](/img/blog/23-new-matchers.png)
 
 See the updated expect docs [here](https://facebook.github.io/jest/docs/en/expect.html).
 
@@ -73,11 +73,11 @@ A common issue we see on the issue tracker relates to “Jest” hanging after a
 
 To help debug these issues, we're now detecting when Jest does not exit:
 
-![Detecting hanging tests](/jest/img/blog/23-hanging-before.png)
+![Detecting hanging tests](/img/blog/23-hanging-before.png)
 
 And we offer a new flag `--detectOpenHandles` to help find the open handles:
 
-![Running detectOpenHandles](/jest/img/blog/23-hanging-after.png)
+![Running detectOpenHandles](/img/blog/23-hanging-after.png)
 
 See the updated CLI docs [here](https://facebook.github.io/jest/docs/en/cli.html#detectopenhandles).
 
@@ -87,7 +87,7 @@ We have completely rewritten the watch mode system to allow adding custom plugin
 
 With this change, we're also now able to bring back typeahead support as a Watch Mode Plugin via [jest-watch-typeahead](https://yarnpkg.com/en/package/jest-watch-typeahead)!
 
-![Typeahead plugin in action](/jest/img/blog/23-typeahead.gif)
+![Typeahead plugin in action](/img/blog/23-typeahead.gif)
 
 See [jest-watch-typeahead](https://github.com/jest-community/jest-watch-typeahead) for documentation and install instructions. Huge thank you to [@rogeliog](https://twitter.com/rogeliog) for the new watch mode plugin system and the jest-watch-typeahead plugin!
 

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -128,7 +128,7 @@ class Index extends React.Component {
                       Works out of the box for any React project.
                     </translate>
                   ),
-                  image: '/jest/img/content/female-technologist.png',
+                  image: '/img/content/female-technologist.png',
                   imageAlign: 'top',
                   title: <translate>Developer Ready</translate>,
                 },
@@ -139,7 +139,7 @@ class Index extends React.Component {
                       to changed files and is optimized to give signal quickly.
                     </translate>
                   ),
-                  image: '/jest/img/content/runner.png',
+                  image: '/img/content/runner.png',
                   imageAlign: 'top',
                   title: <translate>Instant Feedback</translate>,
                 },
@@ -151,7 +151,7 @@ class Index extends React.Component {
                       changes over time.
                     </translate>
                   ),
-                  image: '/jest/img/content/camera-with-flash.png',
+                  image: '/img/content/camera-with-flash.png',
                   imageAlign: 'top',
                   title: <translate>Snapshot Testing</translate>,
                 },
@@ -192,7 +192,7 @@ class Index extends React.Component {
                       tests conflict with each other.
                     </translate>
                   ),
-                  image: '/jest/img/content/feature-fast.png',
+                  image: '/img/content/feature-fast.png',
                   imageAlign: 'right',
                   title: <translate>Fast and sandboxed</translate>,
                 },
@@ -212,7 +212,7 @@ class Index extends React.Component {
                       untested files.
                     </translate>
                   ),
-                  image: '/jest/img/content/feature-coverage.png',
+                  image: '/img/content/feature-coverage.png',
                   imageAlign: 'left',
                   title: <translate>Built-in code coverage reports</translate>,
                 },
@@ -235,7 +235,7 @@ class Index extends React.Component {
                       prefer, Jest will find and run your tests.
                     </translate>
                   ),
-                  image: '/jest/img/content/feature-config-react.png',
+                  image: '/img/content/feature-config-react.png',
                   imageAlign: 'right',
                   title: <translate>Zero configuration</translate>,
                 },
@@ -280,7 +280,7 @@ class Index extends React.Component {
                       `jest-react-native`.
                     </translate>
                   ),
-                  image: '/jest/img/content/feature-mocking.png',
+                  image: '/img/content/feature-mocking.png',
                   imageAlign: 'left',
                   title: <translate>Powerful mocking library</translate>,
                 },
@@ -300,7 +300,7 @@ class Index extends React.Component {
                       [ts-jest](https://github.com/kulshekhar/ts-jest).
                     </translate>
                   ),
-                  image: '/jest/img/content/feature-typescript.png',
+                  image: '/img/content/feature-typescript.png',
                   imageAlign: 'right',
                   title: <translate>Works with TypeScript</translate>,
                 },

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -87,6 +87,7 @@ const siteConfig = {
   title: 'Jest',
   tagline: '🃏 Delightful JavaScript Testing',
   url: 'https://facebook.github.io',
+  cname: 'jestjs.io',
   baseUrl: '/',
   projectName: 'jest',
   repo: 'facebook/jest',

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -50,33 +50,33 @@ const videos = [
 const users = [
   {
     caption: 'Facebook',
-    image: '/jest/img/logos/facebook.png',
+    image: '/img/logos/facebook.png',
     infoLink: 'https://code.facebook.com',
   },
 
   {
     caption: 'Twitter',
-    image: '/jest/img/logos/twitter.png',
+    image: '/img/logos/twitter.png',
     infoLink: 'https://www.twitter.com',
   },
   {
     caption: 'The New York Times',
-    image: '/jest/img/logos/nyt.png',
+    image: '/img/logos/nyt.png',
     infoLink: 'http://www.nytimes.com/',
   },
   {
     caption: 'Spotify',
-    image: '/jest/img/logos/spotify.png',
+    image: '/img/logos/spotify.png',
     infoLink: 'https://www.spotify.com',
   },
   {
     caption: 'Airbnb',
-    image: '/jest/img/logos/airbnb.png',
+    image: '/img/logos/airbnb.png',
     infoLink: 'https://www.airbnb.com/',
   },
   {
     caption: 'Instagram',
-    image: '/jest/img/logos/instagram.png',
+    image: '/img/logos/instagram.png',
     infoLink: 'https://www.instagram.com/',
   },
 ];

--- a/website/static/img/favicon/browserconfig.xml
+++ b/website/static/img/favicon/browserconfig.xml
@@ -2,7 +2,7 @@
 <browserconfig>
     <msapplication>
         <tile>
-            <square150x150logo src="/jest/img/favicon/mstile-150x150.png"/>
+            <square150x150logo src="/img/favicon/mstile-150x150.png"/>
             <TileColor>#2b5797</TileColor>
         </tile>
     </msapplication>

--- a/website/static/img/favicon/manifest.json
+++ b/website/static/img/favicon/manifest.json
@@ -2,12 +2,12 @@
     "name": "",
     "icons": [
         {
-            "src": "/jest/img/favicon/android-chrome-192x192.png",
+            "src": "/img/favicon/android-chrome-192x192.png",
             "sizes": "192x192",
             "type": "image/png"
         },
         {
-            "src": "/jest/img/favicon/android-chrome-512x512.png",
+            "src": "/img/favicon/android-chrome-512x512.png",
             "sizes": "512x512",
             "type": "image/png"
         }

--- a/website/versioned_docs/version-22.0/MoreResources.md
+++ b/website/versioned_docs/version-22.0/MoreResources.md
@@ -22,4 +22,4 @@ You will find a number of example test cases in the [`examples`](https://github.
 
 Ask questions and find answers from other Jest users like you. [Reactiflux](http://www.reactiflux.com/) is a Discord chat where a lot of Jest discussion happens. Check out the [#jest](https://discordapp.com/channels/102860784329052160/103622435865104384) channel.
 
-Follow the [Jest Twitter account](https://twitter.com/fbjest) and [blog](/jest/blog/) to find out what's happening in the world of Jest.
+Follow the [Jest Twitter account](https://twitter.com/fbjest) and [blog](/blog/) to find out what's happening in the world of Jest.

--- a/website/versioned_docs/version-22.0/SnapshotTesting.md
+++ b/website/versioned_docs/version-22.0/SnapshotTesting.md
@@ -62,7 +62,7 @@ it('renders correctly', () => {
 
 In that case, Jest will print this output:
 
-![](/jest/img/content/failedSnapshotTest.png)
+![](/img/content/failedSnapshotTest.png)
 
 Since we just updated our component to point to a different address, it's reasonable to expect changes in the snapshot for this component. Our snapshot test case is failing because the snapshot for our updated component no longer matches the snapshot artifact for this test case.
 
@@ -106,7 +106,7 @@ Yes, all snapshot files should be committed alongside the modules they are cover
 
 ### What's the difference between snapshot testing and visual regression testing?
 
-Snapshot testing and visual regression testing are two distinct ways of testing UIs, and they serve different purposes. Visual regression testing tools take screenshots of web pages and compare the resulting images pixel by pixel. With Snapshot testing values are serialized, stored within text files and compared using a diff algorithm. There are different trade-offs to consider and we listed the reasons why snapshot testing was built in the [Jest blog](http://facebook.github.io/jest/blog/2016/07/27/jest-14.html#why-snapshot-testing).
+Snapshot testing and visual regression testing are two distinct ways of testing UIs, and they serve different purposes. Visual regression testing tools take screenshots of web pages and compare the resulting images pixel by pixel. With Snapshot testing values are serialized, stored within text files and compared using a diff algorithm. There are different trade-offs to consider and we listed the reasons why snapshot testing was built in the [Jest blog](http://jestjs.io/blog/2016/07/27/jest-14.html#why-snapshot-testing).
 
 ### Does snapshot testing substitute unit testing?
 

--- a/website/versioned_docs/version-22.1/SnapshotTesting.md
+++ b/website/versioned_docs/version-22.1/SnapshotTesting.md
@@ -62,7 +62,7 @@ it('renders correctly', () => {
 
 In that case, Jest will print this output:
 
-![](/jest/img/content/failedSnapshotTest.png)
+![](/img/content/failedSnapshotTest.png)
 
 Since we just updated our component to point to a different address, it's reasonable to expect changes in the snapshot for this component. Our snapshot test case is failing because the snapshot for our updated component no longer matches the snapshot artifact for this test case.
 

--- a/website/versioned_docs/version-22.2/SnapshotTesting.md
+++ b/website/versioned_docs/version-22.2/SnapshotTesting.md
@@ -62,7 +62,7 @@ it('renders correctly', () => {
 
 In that case, Jest will print this output:
 
-![](/jest/img/content/failedSnapshotTest.png)
+![](/img/content/failedSnapshotTest.png)
 
 Since we just updated our component to point to a different address, it's reasonable to expect changes in the snapshot for this component. Our snapshot test case is failing because the snapshot for our updated component no longer matches the snapshot artifact for this test case.
 

--- a/website/versioned_docs/version-22.3/SnapshotTesting.md
+++ b/website/versioned_docs/version-22.3/SnapshotTesting.md
@@ -62,7 +62,7 @@ it('renders correctly', () => {
 
 In that case, Jest will print this output:
 
-![](/jest/img/content/failedSnapshotTest.png)
+![](/img/content/failedSnapshotTest.png)
 
 Since we just updated our component to point to a different address, it's reasonable to expect changes in the snapshot for this component. Our snapshot test case is failing because the snapshot for our updated component no longer matches the snapshot artifact for this test case.
 
@@ -82,13 +82,13 @@ You can try out this functionality by cloning the [snapshot example](https://git
 
 Failed snapshots can also be updated interactively in watch mode:
 
-![](/jest/img/content/interactiveSnapshot.png)
+![](/img/content/interactiveSnapshot.png)
 
 Once you enter Interactive Snapshot Mode, Jest will step you through the failed snapshots one test suite at a time and give you the opportunity to review the failed output.
 
 From here you can choose to update that snapshot or skip to the next:
 
-![](/jest/img/content/interactiveSnapshotUpdate.gif)
+![](/img/content/interactiveSnapshotUpdate.gif)
 
 ## Best Practices
 

--- a/website/versioned_docs/version-23.0/SnapshotTesting.md
+++ b/website/versioned_docs/version-23.0/SnapshotTesting.md
@@ -62,7 +62,7 @@ it('renders correctly', () => {
 
 In that case, Jest will print this output:
 
-![](/jest/img/content/failedSnapshotTest.png)
+![](/img/content/failedSnapshotTest.png)
 
 Since we just updated our component to point to a different address, it's reasonable to expect changes in the snapshot for this component. Our snapshot test case is failing because the snapshot for our updated component no longer matches the snapshot artifact for this test case.
 
@@ -82,17 +82,17 @@ You can try out this functionality by cloning the [snapshot example](https://git
 
 Failed snapshots can also be updated interactively in watch mode:
 
-![](/jest/img/content/interactiveSnapshot.png)
+![](/img/content/interactiveSnapshot.png)
 
 Once you enter Interactive Snapshot Mode, Jest will step you through the failed snapshots one test at a time and give you the opportunity to review the failed output.
 
 From here you can choose to update that snapshot or skip to the next:
 
-![](/jest/img/content/interactiveSnapshotUpdate.gif)
+![](/img/content/interactiveSnapshotUpdate.gif)
 
 Once you're finished, Jest will give you a summary before returning back to watch mode:
 
-![](/jest/img/content/interactiveSnapshotDone.png)
+![](/img/content/interactiveSnapshotDone.png)
 
 ### Property Matchers
 


### PR DESCRIPTION
## Summary

This PR switches a few remaining items (like images and links) over to the new jestjs.io domain, and fixes the deploy to not break the CNAME file