### PR TITLE
Fix broken website search

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -111,10 +111,10 @@ const siteConfig = {
   onPageNav: 'separate',
   recruitingLink: 'https://crowdin.com/project/jest',
   algolia: {
-    apiKey: process.env.ALGOLIA_JEST_API_KEY,
+    apiKey: '833906d7486e4059359fa58823c4ef56',
     indexName: 'jest',
     algoliaOptions: {
-      facetFilters: ['language:LANGUAGE', 'version:23.0'],
+      facetFilters: ['language:LANGUAGE'],
     },
   },
   gaTrackingId: 'UA-44373548-17',


### PR DESCRIPTION
## Summary

Search is currently broken. Couldn't test it before due to hidden API key. I think it's okay to expose the API key because it's easier to test for contributors.

Look at how Docusaurus do it https://github.com/facebook/Docusaurus/blob/e9f290f7887aaeb7a899ffdce7f8ea3d398758ba/website/siteConfig.js#L37

## Test plan

jestjs.io (before)
![before](https://user-images.githubusercontent.com/17883920/42026956-06cdb05c-7afb-11e8-9e08-d0b096767e7e.gif)

after
![after](https://user-images.githubusercontent.com/17883920/42026958-0eb3f3da-7afb-11e8-8dce-e550fe2a2d75.gif)

