### PR TITLE
Fix `testNamePattern` value with interactive snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - `[jest-snapshot]` Introduce `toMatchInlineSnapshot` and `toThrowErrorMatchingInlineSnapshot` matchers ([#6380](https://github.com/facebook/jest/pull/6380))
 
+### Fixes
+
+- `[jest-cli]` Fix `testNamePattern` value with interactive snapshots ([#6579](https://github.com/facebook/jest/pull/6579))
+
 ### Chore & Maintenance
 
 - `[website]` Switch domain to https://jestjs.io ([#6549](https://github.com/facebook/jest/pull/6549))

--- a/packages/jest-cli/src/__tests__/snapshot_interactive_mode.test.js
+++ b/packages/jest-cli/src/__tests__/snapshot_interactive_mode.test.js
@@ -43,8 +43,8 @@ describe('SnapshotInteractiveMode', () => {
 
   test('call to run process the first file', () => {
     const assertions = [
-      {path: 'first.js', title: 'test one'},
-      {path: 'second.js', title: 'test two'},
+      {fullName: 'test one', path: 'first.js'},
+      {fullName: 'test two', path: 'second.js'},
     ];
     instance.run(assertions, mockCallback);
     expect(instance.isActive()).toBeTruthy();
@@ -53,8 +53,8 @@ describe('SnapshotInteractiveMode', () => {
 
   test('call to abort', () => {
     const assertions = [
-      {path: 'first.js', title: 'test one'},
-      {path: 'second.js', title: 'test two'},
+      {fullName: 'test one', path: 'first.js'},
+      {fullName: 'test two', path: 'second.js'},
     ];
     instance.run(assertions, mockCallback);
     expect(instance.isActive()).toBeTruthy();
@@ -66,8 +66,8 @@ describe('SnapshotInteractiveMode', () => {
 
   test('call to reset', () => {
     const assertions = [
-      {path: 'first.js', title: 'test one'},
-      {path: 'second.js', title: 'test two'},
+      {fullName: 'test one', path: 'first.js'},
+      {fullName: 'test two', path: 'second.js'},
     ];
     instance.run(assertions, mockCallback);
     expect(instance.isActive()).toBeTruthy();
@@ -85,7 +85,7 @@ describe('SnapshotInteractiveMode', () => {
   });
 
   test('press ENTER trigger a run', () => {
-    const assertions = [{path: 'first.js', title: 'test one'}];
+    const assertions = [{fullName: 'test one', path: 'first.js'}];
     instance.run(assertions, mockCallback);
     instance.put(KEYS.ENTER);
     expect(mockCallback).toHaveBeenCalledTimes(2);
@@ -93,7 +93,7 @@ describe('SnapshotInteractiveMode', () => {
   });
 
   test('skip 1 test, then restart', () => {
-    const assertions = [{path: 'first.js', title: 'test one'}];
+    const assertions = [{fullName: 'test one', path: 'first.js'}];
 
     instance.run(assertions, mockCallback);
     expect(mockCallback).nthCalledWith(1, assertions[0], false);
@@ -113,7 +113,7 @@ describe('SnapshotInteractiveMode', () => {
   });
 
   test('skip 1 test, then quit', () => {
-    const assertions = [{path: 'first.js', title: 'test one'}];
+    const assertions = [{fullName: 'test one', path: 'first.js'}];
 
     instance.run(assertions, mockCallback);
     expect(mockCallback).nthCalledWith(1, assertions[0], false);
@@ -143,7 +143,7 @@ describe('SnapshotInteractiveMode', () => {
       instance.updateWithResults({snapshot: {failure: true}});
     });
 
-    const assertions = [{path: 'first.js', title: 'test one'}];
+    const assertions = [{fullName: 'test one', path: 'first.js'}];
 
     instance.run(assertions, mockCallback);
     expect(mockCallback).nthCalledWith(1, assertions[0], false);
@@ -162,8 +162,8 @@ describe('SnapshotInteractiveMode', () => {
 
   test('skip 2 tests, then finish and restart', () => {
     const assertions = [
-      {path: 'first.js', title: 'test one'},
-      {path: 'first.js', title: 'test two'},
+      {fullName: 'test one', path: 'first.js'},
+      {fullName: 'test two', path: 'first.js'},
     ];
     instance.run(assertions, mockCallback);
     expect(mockCallback).nthCalledWith(1, assertions[0], false);
@@ -207,8 +207,8 @@ describe('SnapshotInteractiveMode', () => {
     });
 
     const assertions = [
-      {path: 'first.js', title: 'test one'},
-      {path: 'first.js', title: 'test two'},
+      {fullName: 'test one', path: 'first.js'},
+      {fullName: 'test two', path: 'first.js'},
     ];
 
     instance.run(assertions, mockCallback);
@@ -255,8 +255,8 @@ describe('SnapshotInteractiveMode', () => {
     });
 
     const assertions = [
-      {path: 'first.js', title: 'test one'},
-      {path: 'first.js', title: 'test two'},
+      {fullName: 'test one', path: 'first.js'},
+      {fullName: 'test two', path: 'first.js'},
     ];
 
     instance.run(assertions, mockCallback);
@@ -303,8 +303,8 @@ describe('SnapshotInteractiveMode', () => {
     });
 
     const assertions = [
-      {path: 'first.js', title: 'test one'},
-      {path: 'first.js', title: 'test two'},
+      {fullName: 'test one', path: 'first.js'},
+      {fullName: 'test two', path: 'first.js'},
     ];
 
     instance.run(assertions, mockCallback);

--- a/packages/jest-cli/src/plugins/update_snapshots_interactive.js
+++ b/packages/jest-cli/src/plugins/update_snapshots_interactive.js
@@ -41,8 +41,8 @@ class UpdateSnapshotInteractivePlugin extends BaseWatchPlugin {
         testResult.testResults.forEach(result => {
           if (result.status === 'failed') {
             failedTestPaths.push({
+              fullName: result.fullName,
               path: testResult.testFilePath,
-              title: result.title,
             });
           }
         });
@@ -77,7 +77,7 @@ class UpdateSnapshotInteractivePlugin extends BaseWatchPlugin {
           (assertion: ?AssertionLocation, shouldUpdateSnapshot: boolean) => {
             updateConfigAndRun({
               mode: 'watch',
-              testNamePattern: assertion ? `^${assertion.title}$` : '',
+              testNamePattern: assertion ? `^${assertion.fullName}$` : '',
               testPathPattern: assertion ? assertion.path : '',
 
               updateSnapshot: shouldUpdateSnapshot ? 'all' : 'none',

--- a/types/TestResult.js
+++ b/types/TestResult.js
@@ -79,8 +79,8 @@ export type FailedAssertion = {|
 |};
 
 export type AssertionLocation = {|
+  fullName: string,
   path: string,
-  title: string,
 |};
 
 export type Status = 'passed' | 'failed' | 'skipped' | 'pending';


### PR DESCRIPTION
## Summary

This fixes a regression with interactive snapshot mode where it would fail to find any tests to run in the file. Problem here is it was using the test title with regex pattern to say match the title exactly. But `testNamePattern` also includes any `describe` blocks in the title, so we need to include that as well.

I switched from using the test `title` to `fullName` and it appears to be working as expected now. Since @rickhanlonii, you did the improvements recently, I'd love some feedback from you on this and if it is the correct way to solve it. Also if there is some end to end test that could be done to ensure this is working as intended.

This fix should resolve #6485 and #6431.

## Test plan

All tests pass.