### PR TITLE
prevent error on empty describe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - `[jest-snapshot]` Introduce `toMatchInlineSnapshot` and `toThrowErrorMatchingInlineSnapshot` matchers ([#6380](https://github.com/facebook/jest/pull/6380))
 
+### Fixes
+
+- `[describe]` no longer throws an error in case of no tests are passed
+
 ### Chore & Maintenance
 
 - `[website]` Switch domain to https://jestjs.io ([#6549](https://github.com/facebook/jest/pull/6549))

--- a/packages/jest-jasmine2/src/jasmine/Env.js
+++ b/packages/jest-jasmine2/src/jasmine/Env.js
@@ -322,6 +322,9 @@ export default function(j$) {
 
     this.describe = function(description, specDefinitions) {
       const suite = suiteFactory(description);
+      if (!specDefinitions) {
+        return;
+      }
       if (specDefinitions.length > 0) {
         throw new Error('describe does not expect any arguments');
       }


### PR DESCRIPTION
## Summary

its a fix for this issue https://github.com/facebook/jest/issues/6224 where an error thrown when no tests are passed to the 'describe' function

## Test plan

this statement : 'describe('this should not throw an error');'
 used to throw this error:
● Test suite failed to run

    TypeError: Cannot read property 'length' of undefined

      at Env.describe (node_modules/jest-jasmine2/build/jasmine/Env.js:297:27)
      at Object.<anonymous> (client/test/components/AccountChooser/AccountChooser-test.js:10:1)
          at Generator.next (<anonymous>)
          at new Promise (<anonymous>)
          at Generator.next (<anonymous>)
          at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)
