### PR TITLE
fix: make reporters respect useStderr option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - `[jest-core]` Fix incorrect `passWithNoTests` warning ([#8595](https://github.com/facebook/jest/pull/8595))
 - `[jest-snapshots]` Fix test retries that contain snapshots ([#8629](https://github.com/facebook/jest/pull/8629))
 - `[jest-mock]` Fix incorrect assignments when restoring mocks in instances where they originally didn't exist ([#8631](https://github.com/facebook/jest/pull/8631))
+- `[jest-reporters]` Make reporters respect `useStderr` option and write to `stdout` by default ([#6583](https://github.com/facebook/jest/pull/6583))
 
 ### Chore & Maintenance
 

--- a/packages/jest-reporters/src/base_reporter.ts
+++ b/packages/jest-reporters/src/base_reporter.ts
@@ -7,19 +7,29 @@
 
 import {AggregatedResult, TestResult} from '@jest/test-result';
 import {preRunMessage} from 'jest-util';
+import {Config} from '@jest/types';
 import {ReporterOnStartOptions, Context, Test, Reporter} from './types';
 
 const {remove: preRunMessageRemove} = preRunMessage;
 
 export default class BaseReporter implements Reporter {
   private _error?: Error;
+  private _stream: NodeJS.WriteStream;
+
+  constructor(globalConfig?: Config.GlobalConfig) {
+    if (globalConfig && globalConfig.useStderr) {
+      this._stream = process.stderr;
+    } else {
+      this._stream = process.stdout;
+    }
+  }
 
   log(message: string) {
-    process.stderr.write(message + '\n');
+    this._stream.write(message + '\n');
   }
 
   onRunStart(_results: AggregatedResult, _options: ReporterOnStartOptions) {
-    preRunMessageRemove(process.stderr);
+    preRunMessageRemove(this._stream);
   }
 
   onTestResult(

--- a/packages/jest-reporters/src/coverage_reporter.ts
+++ b/packages/jest-reporters/src/coverage_reporter.ts
@@ -143,9 +143,14 @@ export default class CoverageReporter extends BaseReporter {
     }
 
     if (isInteractive) {
-      process.stderr.write(
-        RUNNING_TEST_COLOR('Running coverage on untested files...'),
+      const message = RUNNING_TEST_COLOR(
+        'Running coverage on untested files...',
       );
+      if (this._globalConfig.useStderr) {
+        process.stderr.write(message);
+      } else {
+        process.stdout.write(message);
+      }
     }
 
     let worker: CoverageWorker | Worker;

--- a/packages/jest-reporters/src/coverage_reporter.ts
+++ b/packages/jest-reporters/src/coverage_reporter.ts
@@ -38,7 +38,7 @@ export default class CoverageReporter extends BaseReporter {
     globalConfig: Config.GlobalConfig,
     options?: CoverageReporterOptions,
   ) {
-    super();
+    super(globalConfig);
     this._coverageMap = istanbulCoverage.createCoverageMap({});
     this._globalConfig = globalConfig;
     this._sourceMapStore = libSourceMaps.createSourceMapStore();

--- a/packages/jest-reporters/src/default_reporter.ts
+++ b/packages/jest-reporters/src/default_reporter.ts
@@ -29,7 +29,7 @@ export default class DefaultReporter extends BaseReporter {
   private _bufferedOutput: Set<FlushBufferedOutput>;
 
   constructor(globalConfig: Config.GlobalConfig) {
-    super();
+    super(globalConfig);
     this._globalConfig = globalConfig;
     this._clear = '';
     this._out = process.stdout.write.bind(process.stdout);

--- a/packages/jest-reporters/src/notify_reporter.ts
+++ b/packages/jest-reporters/src/notify_reporter.ts
@@ -28,7 +28,7 @@ export default class NotifyReporter extends BaseReporter {
     startRun: (globalConfig: Config.GlobalConfig) => any,
     context: TestSchedulerContext,
   ) {
-    super();
+    super(globalConfig);
     this._globalConfig = globalConfig;
     this._startRun = startRun;
     this._context = context;

--- a/packages/jest-reporters/src/summary_reporter.ts
+++ b/packages/jest-reporters/src/summary_reporter.ts
@@ -67,7 +67,12 @@ export default class SummaryReporter extends BaseReporter {
   // when hundreds of tests are failing.
   private _write(string: string) {
     for (let i = 0; i < string.length; i++) {
-      process.stderr.write(string.charAt(i));
+      const char = string.charAt(i);
+      if (this._globalConfig.useStderr) {
+        process.stderr.write(char);
+      } else {
+        process.stdout.write(char);
+      }
     }
   }
 

--- a/packages/jest-reporters/src/summary_reporter.ts
+++ b/packages/jest-reporters/src/summary_reporter.ts
@@ -55,7 +55,7 @@ export default class SummaryReporter extends BaseReporter {
   private _globalConfig: Config.GlobalConfig;
 
   constructor(globalConfig: Config.GlobalConfig) {
-    super();
+    super(globalConfig);
     this._globalConfig = globalConfig;
     this._estimatedTime = 0;
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary
`useStderr` is currently respected for `console` output, but not our reporter. That's perhaps on purpose, but it was en easy enough fix to make, so I thought why not 🙂 

If this is not accepted, the issue should be closed.

Fixes #5064 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan
Ran script in #5064 and it now printed `stdout` instead.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
