### PR TITLE
Use FORCE_COLOR=0 for all tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -201,6 +201,7 @@
 ### Chore & Maintenance
 
 - `[website]` Switch domain to https://jestjs.io ([#6549](https://github.com/facebook/jest/pull/6549))
+- `[tests]` Free tests from the dependency on value of FORCE_COLOR ([#6585](https://github.com/facebook/jest/pull/6585/files))
 - `[tests]` Improve stability of `yarn test` on Windows ([#6534](https://github.com/facebook/jest/pull/6534))
 - `[*]` Transpile object shorthand into Node 4 compatible syntax ([#6582](https://github.com/facebook/jest/pull/6582))
 - `[*]` Update all legacy links to jestjs.io ([#6622](https://github.com/facebook/jest/pull/6622))

--- a/e2e/__tests__/coverage_report.test.js
+++ b/e2e/__tests__/coverage_report.test.js
@@ -16,7 +16,9 @@ import runJest from '../runJest';
 const DIR = path.resolve(__dirname, '../coverage-report');
 
 test('outputs coverage report', () => {
-  const {stdout, status} = runJest(DIR, ['--no-cache', '--coverage']);
+  const {stdout, status} = runJest(DIR, ['--no-cache', '--coverage'], {
+    stripAnsi: true,
+  });
   const coverageDir = path.resolve(__dirname, '../coverage-report/coverage');
 
   // - the `setup.js` file is ignored and should not be in the coverage report.
@@ -31,53 +33,71 @@ test('outputs coverage report', () => {
 });
 
 test('collects coverage only from specified file', () => {
-  const {stdout} = runJest(DIR, [
-    '--no-cache',
-    '--coverage',
-    '--collectCoverageFrom', // overwrites the one in package.json
-    'setup.js',
-  ]);
+  const {stdout} = runJest(
+    DIR,
+    [
+      '--no-cache',
+      '--coverage',
+      '--collectCoverageFrom', // overwrites the one in package.json
+      'setup.js',
+    ],
+    {stripAnsi: true},
+  );
 
   // Coverage report should only have `setup.js` coverage info
   expect(stdout).toMatchSnapshot();
 });
 
 test('collects coverage only from multiple specified files', () => {
-  const {stdout} = runJest(DIR, [
-    '--no-cache',
-    '--coverage',
-    '--collectCoverageFrom',
-    'setup.js',
-    '--collectCoverageFrom',
-    'OtherFile.js',
-  ]);
+  const {stdout} = runJest(
+    DIR,
+    [
+      '--no-cache',
+      '--coverage',
+      '--collectCoverageFrom',
+      'setup.js',
+      '--collectCoverageFrom',
+      'OtherFile.js',
+    ],
+    {stripAnsi: true},
+  );
 
   expect(stdout).toMatchSnapshot();
 });
 
 test('collects coverage only from specified files avoiding dependencies', () => {
-  const {stdout} = runJest(DIR, [
-    '--no-cache',
-    '--coverage',
-    '--collectCoverageOnlyFrom',
-    'Sum.js',
-    '--',
-    'Sum.test.js',
-  ]);
+  const {stdout} = runJest(
+    DIR,
+    [
+      '--no-cache',
+      '--coverage',
+      '--collectCoverageOnlyFrom',
+      'Sum.js',
+      '--',
+      'Sum.test.js',
+    ],
+    {stripAnsi: true},
+  );
 
   // Coverage report should only have `sum.js` coverage info
   expect(stdout).toMatchSnapshot();
 });
 
 test('json reporter printing with --coverage', () => {
-  const {stderr, status} = runJest('json-reporter', ['--coverage']);
+  const {stderr, status} = runJest('json-reporter', ['--coverage'], {
+    stripAnsi: true,
+  });
   const {summary} = extractSummary(stderr);
   expect(status).toBe(1);
   expect(summary).toMatchSnapshot();
 });
 
 test('outputs coverage report as json', () => {
-  const {stdout, status} = runJest(DIR, ['--no-cache', '--coverage', '--json']);
+  const {stdout, status} = runJest(
+    DIR,
+    ['--no-cache', '--coverage', '--json'],
+    {stripAnsi: true},
+  );
   expect(status).toBe(0);
 
   try {
@@ -90,35 +110,43 @@ test('outputs coverage report as json', () => {
 });
 
 test('outputs coverage report when text is requested', () => {
-  const {stdout, status} = runJest(DIR, [
-    '--no-cache',
-    '--coverage',
-    '--coverageReporters=text',
-    '--coverageReporters=html',
-  ]);
+  const {stdout, status} = runJest(
+    DIR,
+    [
+      '--no-cache',
+      '--coverage',
+      '--coverageReporters=text',
+      '--coverageReporters=html',
+    ],
+    {stripAnsi: true},
+  );
   expect(status).toBe(0);
   expect(stdout).toMatch(/Stmts | . Branch/);
   expect(stdout).toMatchSnapshot();
 });
 
 test('outputs coverage report when text-summary is requested', () => {
-  const {stdout, status} = runJest(DIR, [
-    '--no-cache',
-    '--coverage',
-    '--coverageReporters=text-summary',
-  ]);
+  const {stdout, status} = runJest(
+    DIR,
+    ['--no-cache', '--coverage', '--coverageReporters=text-summary'],
+    {stripAnsi: true},
+  );
   expect(status).toBe(0);
   expect(stdout).toMatch(/Coverage summary/);
   expect(stdout).toMatchSnapshot();
 });
 
 test('outputs coverage report when text and text-summary is requested', () => {
-  const {stdout, status} = runJest(DIR, [
-    '--no-cache',
-    '--coverage',
-    '--coverageReporters=text-summary',
-    '--coverageReporters=text',
-  ]);
+  const {stdout, status} = runJest(
+    DIR,
+    [
+      '--no-cache',
+      '--coverage',
+      '--coverageReporters=text-summary',
+      '--coverageReporters=text',
+    ],
+    {stripAnsi: true},
+  );
   expect(status).toBe(0);
   expect(stdout).toMatch(/Stmts | . Branch/);
   expect(stdout).toMatch(/Coverage summary/);
@@ -126,11 +154,11 @@ test('outputs coverage report when text and text-summary is requested', () => {
 });
 
 test('does not output coverage report when html is requested', () => {
-  const {stdout, status} = runJest(DIR, [
-    '--no-cache',
-    '--coverage',
-    '--coverageReporters=html',
-  ]);
+  const {stdout, status} = runJest(
+    DIR,
+    ['--no-cache', '--coverage', '--coverageReporters=html'],
+    {stripAnsi: true},
+  );
   expect(status).toBe(0);
   expect(stdout).toMatch(/^$/);
   expect(stdout).toMatchSnapshot();
@@ -150,10 +178,10 @@ test('collects coverage from duplicate files avoiding shared cache', () => {
     'Identical.test.js',
   ];
   // Run once to prime the cache
-  runJest(DIR, args);
+  runJest(DIR, args, {stripAnsi: true});
 
   // Run for the second time
-  const {stdout, status} = runJest(DIR, args);
+  const {stdout, status} = runJest(DIR, args, {stripAnsi: true});
   expect(stdout).toMatchSnapshot();
   expect(status).toBe(0);
 });

--- a/e2e/__tests__/coverage_threshold.test.js
+++ b/e2e/__tests__/coverage_threshold.test.js
@@ -44,7 +44,9 @@ test('exits with 1 if coverage threshold is not met', () => {
     'package.json': JSON.stringify(pkgJson, null, 2),
   });
 
-  const {stdout, stderr, status} = runJest(DIR, ['--coverage', '--ci=false']);
+  const {stdout, stderr, status} = runJest(DIR, ['--coverage', '--ci=false'], {
+    stripAnsi: true,
+  });
   const {rest, summary} = extractSummary(stderr);
 
   expect(status).toBe(1);
@@ -79,7 +81,9 @@ test('exits with 1 if path threshold group is not found in coverage data', () =>
     'package.json': JSON.stringify(pkgJson, null, 2),
   });
 
-  const {stdout, stderr, status} = runJest(DIR, ['--coverage', '--ci=false']);
+  const {stdout, stderr, status} = runJest(DIR, ['--coverage', '--ci=false'], {
+    stripAnsi: true,
+  });
   const {rest, summary} = extractSummary(stderr);
 
   expect(status).toBe(1);
@@ -117,7 +121,9 @@ test('exits with 0 if global threshold group is not found in coverage data', () 
     'package.json': JSON.stringify(pkgJson, null, 2),
   });
 
-  const {stdout, status} = runJest(DIR, ['--coverage', '--ci=false']);
+  const {stdout, status} = runJest(DIR, ['--coverage', '--ci=false'], {
+    stripAnsi: true,
+  });
 
   expect(status).toBe(0);
   expect(stdout).toMatchSnapshot('stdout');
@@ -157,7 +163,9 @@ test('excludes tests matched by path threshold groups from global group', () => 
     'package.json': JSON.stringify(pkgJson, null, 2),
   });
 
-  const {stdout, stderr, status} = runJest(DIR, ['--coverage', '--ci=false']);
+  const {stdout, stderr, status} = runJest(DIR, ['--coverage', '--ci=false'], {
+    stripAnsi: true,
+  });
   const {rest, summary} = extractSummary(stderr);
 
   expect(status).toBe(1);
@@ -198,7 +206,9 @@ test('file is matched by all path and glob threshold groups', () => {
     'package.json': JSON.stringify(pkgJson, null, 2),
   });
 
-  const {stdout, stderr, status} = runJest(DIR, ['--coverage', '--ci=false']);
+  const {stdout, stderr, status} = runJest(DIR, ['--coverage', '--ci=false'], {
+    stripAnsi: true,
+  });
   const {rest, summary} = extractSummary(
     /* This test also runs on windows and when the glob fails it outputs
     the system specific absolute path to the test file. */

--- a/e2e/__tests__/find_related_files.test.js
+++ b/e2e/__tests__/find_related_files.test.js
@@ -63,7 +63,7 @@ describe('--findRelatedTests flag', () => {
     let stdout;
     let stderr;
 
-    ({stdout, stderr} = runJest(DIR));
+    ({stdout, stderr} = runJest(DIR, [], {stripAnsi: true}));
     let summary;
     let rest;
     ({summary, rest} = extractSummary(stderr));
@@ -79,7 +79,9 @@ describe('--findRelatedTests flag', () => {
     // both a.js and b.js should be in the coverage
     expect(stdout).toMatchSnapshot();
 
-    ({stdout, stderr} = runJest(DIR, ['--findRelatedTests', 'a.js']));
+    ({stdout, stderr} = runJest(DIR, ['--findRelatedTests', 'a.js'], {
+      stripAnsi: true,
+    }));
 
     ({summary, rest} = extractSummary(stderr));
 
@@ -110,7 +112,9 @@ describe('--findRelatedTests flag', () => {
 
     let stdout;
     let stderr;
-    ({stdout, stderr} = runJest(DIR, ['--findRelatedTests', 'a.js', 'b.js']));
+    ({stdout, stderr} = runJest(DIR, ['--findRelatedTests', 'a.js', 'b.js'], {
+      stripAnsi: true,
+    }));
 
     const {summary, rest} = extractSummary(stderr);
     expect(summary).toMatchSnapshot();

--- a/e2e/__tests__/module_name_mapper.test.js
+++ b/e2e/__tests__/module_name_mapper.test.js
@@ -20,7 +20,9 @@ test('moduleNameMapper wrong configuration', () => {
 });
 
 test('moduleNameMapper correct configuration', () => {
-  const {stderr, status} = runJest('module-name-mapper-correct-config');
+  const {stderr, status} = runJest('module-name-mapper-correct-config', [], {
+    stripAnsi: true,
+  });
   const {rest} = extractSummary(stderr);
 
   expect(status).toBe(0);

--- a/e2e/__tests__/transform.test.js
+++ b/e2e/__tests__/transform.test.js
@@ -33,7 +33,9 @@ describe('babel-jest', () => {
   });
 
   it('instruments only specific files and collects coverage', () => {
-    const {stdout} = runJest(dir, ['--coverage', '--no-cache']);
+    const {stdout} = runJest(dir, ['--coverage', '--no-cache'], {
+      stripAnsi: true,
+    });
     expect(stdout).toMatch('Covered.js');
     expect(stdout).not.toMatch('NotCovered.js');
     expect(stdout).not.toMatch('ExcludedFromCoverage.js');
@@ -63,11 +65,11 @@ describe('no babel-jest', () => {
   });
 
   test('instrumentation with no babel-jest', () => {
-    const {stdout} = runJest(tempDir, [
-      '--no-cache',
-      '--coverage',
-      '--no-watchman',
-    ]);
+    const {stdout} = runJest(
+      tempDir,
+      ['--no-cache', '--coverage', '--no-watchman'],
+      {stripAnsi: true},
+    );
     expect(stdout).toMatch('Covered.js');
     expect(stdout).not.toMatch('ExcludedFromCoverage.js');
     // coverage result should not change
@@ -92,7 +94,9 @@ describe('custom transformer', () => {
   });
 
   it('instruments files', () => {
-    const {stdout, status} = runJest(dir, ['--no-cache', '--coverage']);
+    const {stdout, status} = runJest(dir, ['--no-cache', '--coverage'], {
+      stripAnsi: true,
+    });
     // coverage should be empty because there's no real instrumentation
     expect(stdout).toMatchSnapshot();
     expect(status).toBe(0);

--- a/e2e/__tests__/typescript_coverage.test.js
+++ b/e2e/__tests__/typescript_coverage.test.js
@@ -14,6 +14,8 @@ import runJest from '../runJest';
 it('instruments and collects coverage for typescript files', () => {
   const dir = path.resolve(__dirname, '../typescript-coverage');
   run('yarn', dir);
-  const {stdout} = runJest(dir, ['--coverage', '--no-cache']);
+  const {stdout} = runJest(dir, ['--coverage', '--no-cache'], {
+    stripAnsi: true,
+  });
   expect(stdout).toMatchSnapshot();
 });


### PR DESCRIPTION
## Summary

This change ensures that the tests work regardless of the value of
`FORCE_COLOR` environment variable. There are environments where this
variable is set to 1 and the tests fail. For example the tests fail when
they are run from Jetbrains IDEs (Rubymine, Webstorm and etc).

istanbul-* packages were updated because 1.* version uses old `support-colors` package that doesn't allow to disable colors with `FORCE_COLOR=0`. Instead it interpreters zero value in the same way as 1 or anything else by forcing colors. The latest version of istanbul uses the updated package that disables colors if `FORCE_COLOR=0`

I suppose this patch is the logical final for #5646 and #5652.

## Test plan

If you run tests on master with defined FORCE_COLOR=1 you will receive this:

```powershell
PS E:\src\jest> $Env:FORCE_COLOR=1; yarn jest
...skip...
Test Suites: 45 failed, 234 passed, 279 total
Tests:       131 failed, 91 skipped, 2599 passed, 2821 total
Snapshots:   15 failed, 10 obsolete, 982 passed, 997 total
Time:        537.5s, estimated 563s
```

With this patch applied the situation is resolved and all tests pass regardless of the value of FORCE_COLOR.