### PR TITLE
Skip deploy website if it is a pull request

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ aliases:
       git config --global user.name "Website Deployment Script"
       echo "machine github.com login docusaurus-bot password $DOCUSAURUS_PUBLISH_TOKEN" > ~/.netrc
       # install Docusaurus and generate file of English strings
-      yarn && cd website && yarn write-translations
+      cd website && yarn && yarn write-translations
       # crowdin install
       sudo apt-get update
       sudo apt-get install default-jre rsync
@@ -28,8 +28,12 @@ aliases:
       # translations upload/download
       yarn crowdin-upload
       yarn crowdin-download
-      # build and publish website
-      GIT_USER=docusaurus-bot USE_SSH=false yarn publish-gh-pages
+      if [[ $CIRCLE_PROJECT_USERNAME == "facebook" && -z $CI_PULL_REQUEST && -z $CIRCLE_PR_USERNAME ]]; then
+        # build and publish website
+        GIT_USER=docusaurus-bot USE_SSH=false yarn publish-gh-pages
+      else
+        yarn build
+      fi
 
 version: 2
 jobs:
@@ -125,6 +129,7 @@ jobs:
     working_directory: ~/jest
     docker:
       - image: circleci/node:8
+    resource_class: large
     steps:
       - checkout
       - restore-cache: *restore-cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,26 +13,26 @@ aliases:
 
   - &deploy
     command: |
-      # Deploy Jest website using Docusaurus bot
-      git config --global user.email "docusaurus-bot@users.noreply.github.com"
-      git config --global user.name "Website Deployment Script"
-      echo "machine github.com login docusaurus-bot password $DOCUSAURUS_PUBLISH_TOKEN" > ~/.netrc
-      # install Docusaurus and generate file of English strings
-      yarn && cd website && yarn write-translations
-      # crowdin install
-      sudo apt-get update
-      sudo apt-get install default-jre rsync
-      wget https://artifacts.crowdin.com/repo/deb/crowdin.deb -O crowdin.deb
-      sudo dpkg -i crowdin.deb
-      sleep 5
-      # translations upload/download
-      yarn crowdin-upload
-      yarn crowdin-download
       if [[ $CIRCLE_PROJECT_USERNAME == "facebook" && -z $CI_PULL_REQUEST && -z $CIRCLE_PR_USERNAME ]]; then
+        # Deploy Jest website using Docusaurus bot
+        git config --global user.email "docusaurus-bot@users.noreply.github.com"
+        git config --global user.name "Website Deployment Script"
+        echo "machine github.com login docusaurus-bot password $DOCUSAURUS_PUBLISH_TOKEN" > ~/.netrc
+        # install Docusaurus and generate file of English strings
+        yarn && cd website && yarn write-translations
+        # crowdin install
+        sudo apt-get update
+        sudo apt-get install default-jre rsync
+        wget https://artifacts.crowdin.com/repo/deb/crowdin.deb -O crowdin.deb
+        sudo dpkg -i crowdin.deb
+        sleep 5
+        # translations upload/download
+        yarn crowdin-upload
+        yarn crowdin-download
         # build and publish website
         GIT_USER=docusaurus-bot USE_SSH=false yarn publish-gh-pages
       else
-        yarn build
+        echo "Skipping deploy."
       fi
 
 version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,10 @@ aliases:
       else
         echo "Skipping deploy."
       fi
+  
+  - &filter-ignore-gh-pages
+    branches:
+      ignore: gh-pages
 
 version: 2
 jobs:
@@ -148,4 +152,5 @@ workflows:
       - test-node-10
       - test-jest-circus
       - test-browser
-      - test-and-deploy-website
+      - test-and-deploy-website:
+          filters: *filter-ignore-gh-pages

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ aliases:
       git config --global user.name "Website Deployment Script"
       echo "machine github.com login docusaurus-bot password $DOCUSAURUS_PUBLISH_TOKEN" > ~/.netrc
       # install Docusaurus and generate file of English strings
-      cd website && yarn && yarn write-translations
+      yarn && cd website && yarn write-translations
       # crowdin install
       sudo apt-get update
       sudo apt-get install default-jre rsync


### PR DESCRIPTION
## Summary

Current CircleCI integration is such that it will install docusaurus, generate english file for strings & then install jre -> install crowdin -> upload crowdin docs -> download crowdin docs -> try to deploy website regardless whether it is a pull request or not.

I think it is much better to skip deploying the website if it is just a pull request & only deploy when it has been pushed to master.

Another change is addition of large resource class for website deploy based on https://github.com/facebook/jest/issues/6567#issuecomment-401694249

## Test plan

Look at circleci jobs of test-deploy-website for this PR.