### PR TITLE
Re-allowed single string arguments for pending tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features
 
+- `[jest-jasmine2]` Updated error throwing with `it`/ `test` to re-allow the valid single string argument for pending tests.
+- `[jest-circus]` Updated error throwing with `it`/ `test` to re-allow the valid single string argument for pending tests
 - `[jest-haste-map]` Add `computeDependencies` flag to avoid opening files if not needed ([#6667](https://github.com/facebook/jest/pull/6667))
 - `[jest-runtime]` Support `require.resolve.paths` ([#6471](https://github.com/facebook/jest/pull/6471))
 - `[jest-runtime]` Support `paths` option for `require.resolve` ([#6471](https://github.com/facebook/jest/pull/6471))

--- a/e2e/__tests__/__snapshots__/globals.test.js.snap
+++ b/e2e/__tests__/__snapshots__/globals.test.js.snap
@@ -19,60 +19,6 @@ Time:        <<REPLACED>>
 Ran all test suites."
 `;
 
-exports[`cannot test with no implementation 1`] = `
-"FAIL __tests__/only-constructs.test.js
-  ● Test suite failed to run
-
-    Missing second argument. It must be a callback function.
-
-      1 | 
-      2 |     it('it', () => {});
-    > 3 |     it('it, no implementation');
-        |     ^
-      4 |     test('test, no implementation');
-      5 |   
-
-      at __tests__/only-constructs.test.js:3:5
-
-"
-`;
-
-exports[`cannot test with no implementation 2`] = `
-"Test Suites: 1 failed, 1 total
-Tests:       0 total
-Snapshots:   0 total
-Time:        <<REPLACED>>
-Ran all test suites.
-"
-`;
-
-exports[`cannot test with no implementation with expand arg 1`] = `
-"FAIL __tests__/only-constructs.test.js
-  ● Test suite failed to run
-
-    Missing second argument. It must be a callback function.
-
-      1 | 
-      2 |     it('it', () => {});
-    > 3 |     it('it, no implementation');
-        |     ^
-      4 |     test('test, no implementation');
-      5 |   
-
-      at __tests__/only-constructs.test.js:3:5
-
-"
-`;
-
-exports[`cannot test with no implementation with expand arg 2`] = `
-"Test Suites: 1 failed, 1 total
-Tests:       0 total
-Snapshots:   0 total
-Time:        <<REPLACED>>
-Ran all test suites.
-"
-`;
-
 exports[`function as descriptor 1`] = `
 "PASS __tests__/function-as-descriptor.test.js
   Foo
@@ -182,6 +128,39 @@ exports[`skips with expand arg 1`] = `
 exports[`skips with expand arg 2`] = `
 "Test Suites: 1 passed, 1 total
 Tests:       8 skipped, 1 passed, 9 total
+Snapshots:   0 total
+Time:        <<REPLACED>>
+Ran all test suites."
+`;
+
+exports[`tests with no implementation 1`] = `
+"PASS __tests__/only-constructs.test.js
+  ✓ it
+  ○ skipped 2 tests
+
+"
+`;
+
+exports[`tests with no implementation 2`] = `
+"Test Suites: 1 passed, 1 total
+Tests:       2 skipped, 1 passed, 3 total
+Snapshots:   0 total
+Time:        <<REPLACED>>
+Ran all test suites."
+`;
+
+exports[`tests with no implementation with expand arg 1`] = `
+"PASS __tests__/only-constructs.test.js
+  ✓ it
+  ○ it, no implementation
+  ○ test, no implementation
+
+"
+`;
+
+exports[`tests with no implementation with expand arg 2`] = `
+"Test Suites: 1 passed, 1 total
+Tests:       2 skipped, 1 passed, 3 total
 Snapshots:   0 total
 Time:        <<REPLACED>>
 Ran all test suites."

--- a/e2e/__tests__/globals.test.js
+++ b/e2e/__tests__/globals.test.js
@@ -112,7 +112,7 @@ test('only', () => {
   expect(summary).toMatchSnapshot();
 });
 
-test('cannot test with no implementation', () => {
+test('tests with no implementation', () => {
   const filename = 'only-constructs.test.js';
   const content = `
     it('it', () => {});
@@ -122,7 +122,7 @@ test('cannot test with no implementation', () => {
 
   writeFiles(TEST_DIR, {[filename]: content});
   const {stderr, status} = runJest(DIR);
-  expect(status).toBe(1);
+  expect(status).toBe(0);
 
   const {summary} = extractSummary(stderr);
   expect(cleanStderr(stderr)).toMatchSnapshot();
@@ -190,7 +190,7 @@ test('only with expand arg', () => {
   expect(summary).toMatchSnapshot();
 });
 
-test('cannot test with no implementation with expand arg', () => {
+test('tests with no implementation with expand arg', () => {
   const filename = 'only-constructs.test.js';
   const content = `
     it('it', () => {});
@@ -200,7 +200,7 @@ test('cannot test with no implementation with expand arg', () => {
 
   writeFiles(TEST_DIR, {[filename]: content});
   const {stderr, status} = runJest(DIR, ['--expand']);
-  expect(status).toBe(1);
+  expect(status).toBe(0);
 
   const {summary} = extractSummary(stderr);
   expect(cleanStderr(stderr)).toMatchSnapshot();

--- a/packages/jest-circus/src/__tests__/circus_it_test_error.test.js
+++ b/packages/jest-circus/src/__tests__/circus_it_test_error.test.js
@@ -33,21 +33,21 @@ describe('test/it error throwing', () => {
       circusIt('test1', () => {});
     }).not.toThrowError();
   });
-  it(`it throws error with missing callback function`, () => {
+  it(`it doesn't throw error with missing callback function`, () => {
     expect(() => {
-      // $FlowFixMe: Easy, we're testing runitme errors here
+      // $FlowFixMe: Easy, we're testing runtime errors here
       circusIt('test2');
-    }).toThrowError('Missing second argument. It must be a callback function.');
+    }).not.toThrowError();
   });
   it(`it throws an error when first argument isn't a string`, () => {
     expect(() => {
-      // $FlowFixMe: Easy, we're testing runitme errors here
+      // $FlowFixMe: Easy, we're testing runtime errors here
       circusIt(() => {});
     }).toThrowError(`Invalid first argument, () => {}. It must be a string.`);
   });
   it('it throws an error when callback function is not a function', () => {
     expect(() => {
-      // $FlowFixMe: Easy, we're testing runitme errors here
+      // $FlowFixMe: Easy, we're testing runtime errors here
       circusIt('test4', 'test4b');
     }).toThrowError(
       `Invalid second argument, test4b. It must be a callback function.`,
@@ -58,21 +58,21 @@ describe('test/it error throwing', () => {
       circusTest('test5', () => {});
     }).not.toThrowError();
   });
-  it(`test throws error with missing callback function`, () => {
+  it(`test doesn't throw error with missing callback function`, () => {
     expect(() => {
-      // $FlowFixMe: Easy, we're testing runitme errors here
+      // $FlowFixMe: Easy, we're testing runtime errors here
       circusTest('test6');
-    }).toThrowError('Missing second argument. It must be a callback function.');
+    }).not.toThrowError();
   });
   it(`test throws an error when first argument isn't a string`, () => {
     expect(() => {
-      // $FlowFixMe: Easy, we're testing runitme errors here
+      // $FlowFixMe: Easy, we're testing runtime errors here
       circusTest(() => {});
     }).toThrowError(`Invalid first argument, () => {}. It must be a string.`);
   });
   it('test throws an error when callback function is not a function', () => {
     expect(() => {
-      // $FlowFixMe: Easy, we're testing runitme errors here
+      // $FlowFixMe: Easy, we're testing runtime errors here
       circusTest('test8', 'test8b');
     }).toThrowError(
       `Invalid second argument, test8b. It must be a callback function.`,

--- a/packages/jest-circus/src/index.js
+++ b/packages/jest-circus/src/index.js
@@ -63,10 +63,7 @@ const test = (testName: TestName, fn: TestFn, timeout?: number) => {
       `Invalid first argument, ${testName}. It must be a string.`,
     );
   }
-  if (fn === undefined) {
-    throw new Error('Missing second argument. It must be a callback function.');
-  }
-  if (typeof fn !== 'function') {
+  if (fn !== undefined && typeof fn !== 'function') {
     throw new Error(
       `Invalid second argument, ${fn}. It must be a callback function.`,
     );

--- a/packages/jest-circus/src/index.js
+++ b/packages/jest-circus/src/index.js
@@ -77,6 +77,7 @@ const test = (testName: TestName, fn: TestFn, timeout?: number) => {
   return dispatch({
     asyncError,
     fn,
+    mode: fn ? undefined : 'skip',
     name: 'add_test',
     testName,
     timeout,

--- a/packages/jest-jasmine2/src/__tests__/it_test_error.test.js
+++ b/packages/jest-jasmine2/src/__tests__/it_test_error.test.js
@@ -9,10 +9,10 @@
 'use strict';
 
 describe('test/it error throwing', () => {
-  it(`it throws error with missing callback function`, () => {
+  it(`it doesn't throw error with missing callback function`, () => {
     expect(() => {
       it('test1');
-    }).toThrowError('Missing second argument. It must be a callback function.');
+    }).not.toThrowError(/argument/i);
   });
   it(`it throws an error when first argument isn't a string`, () => {
     expect(() => {
@@ -26,10 +26,10 @@ describe('test/it error throwing', () => {
       `Invalid second argument, test3b. It must be a callback function.`,
     );
   });
-  test(`test throws error with missing callback function`, () => {
+  test(`test doesn't throw error with missing callback function`, () => {
     expect(() => {
       test('test4');
-    }).toThrowError('Missing second argument. It must be a callback function.');
+    }).not.toThrowError(/argument/i);
   });
   test(`test throws an error when first argument isn't a string`, () => {
     expect(() => {

--- a/packages/jest-jasmine2/src/jasmine/Env.js
+++ b/packages/jest-jasmine2/src/jasmine/Env.js
@@ -448,12 +448,7 @@ export default function(j$) {
           `Invalid first argument, ${description}. It must be a string.`,
         );
       }
-      if (fn === undefined) {
-        throw new Error(
-          'Missing second argument. It must be a callback function.',
-        );
-      }
-      if (typeof fn !== 'function') {
+      if (fn !== undefined && typeof fn !== 'function') {
         throw new Error(
           `Invalid second argument, ${fn}. It must be a callback function.`,
         );


### PR DESCRIPTION
## Summary

This PR updates the logic in the jasmine and circus reporters to allow valid single string arguments. It still keeps the nice feature work from #5558 that noisily fails on accidental pending tests or other incorrect arguments. 

This solves #6430 and #6256, allowing teams (mine included) and individuals that are used to starting off with writing pending tests to continue to use this workflow. I appreciate the flexibility from the contributors on this and think moving to a linter rule would be great for those who want to avoid committing or merging pending tests.

EDIT: It looks like there is already a linter rule for avoiding single-argument (pending) tests here https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/no-disabled-tests.md so I think we should have everything to merge this.

Let me know if I can address any concerns! Thanks.

## Test plan

Snapshots were updates with the pending style again. For the package tests, I opted to leave the tests in as a `not.toThrowError` to ensure this doesn't regress unintentionally. I used the regex form for the `jasmine` tests as they throw a different error with nesting `it` blocks.

I'm not sure why the circus suite is not running on Circle as it was working locally with `JEST_CIRCUS=1`. Any assistance would be helpful!