### PR TITLE
Test Jest website build for every PR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,10 +11,10 @@ aliases:
       - website/node_modules
     key: v2-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}
 
-  - &deploy
+  - &website
     command: |
       if [[ $CIRCLE_PROJECT_USERNAME == "facebook" && -z $CI_PULL_REQUEST && -z $CIRCLE_PR_USERNAME ]]; then
-        # Deploy Jest website using Docusaurus bot
+        # configure Docusaurus bot
         git config --global user.email "docusaurus-bot@users.noreply.github.com"
         git config --global user.name "Website Deployment Script"
         echo "machine github.com login docusaurus-bot password $DOCUSAURUS_PUBLISH_TOKEN" > ~/.netrc
@@ -32,7 +32,8 @@ aliases:
         # build and publish website
         GIT_USER=docusaurus-bot USE_SSH=false yarn publish-gh-pages
       else
-        echo "Skipping deploy."
+        echo "Skipping deploy. Test website build"
+        cd website && yarn && yarn build
       fi
   
   - &filter-ignore-gh-pages
@@ -129,7 +130,7 @@ jobs:
       - store_test_results:
                 path: reports/junit
 
-  test-and-deploy-website:
+  test-or-deploy-website:
     working_directory: ~/jest
     docker:
       - image: circleci/node:8
@@ -139,7 +140,7 @@ jobs:
       - restore-cache: *restore-cache
       - run: yarn --no-progress
       - save-cache: *save-cache
-      - deploy: *deploy
+      - run: *website
 
 # Workflows enables us to run multiple jobs in parallel
 workflows:
@@ -152,5 +153,5 @@ workflows:
       - test-node-10
       - test-jest-circus
       - test-browser
-      - test-and-deploy-website:
+      - test-or-deploy-website:
           filters: *filter-ignore-gh-pages

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -17,6 +17,8 @@ const translation = require('../../server/translation.js');
 const backers = require(process.cwd() + '/backers.json');
 
 const siteConfig = require(process.cwd() + '/siteConfig.js');
+const idx = (target, path) =>
+  path.reduce((obj, key) => (obj && obj[key] ? obj[key] : null), target);
 
 class Button extends React.Component {
   render() {
@@ -130,10 +132,11 @@ class HomeSplash extends React.Component {
               <h2 className="projectTitle">
                 {siteConfig.title}
                 <small>
-                  {
-                    translation[this.props.language]['localized-strings']
-                      .tagline
-                  }
+                  {idx(translation, [
+                    this.props.language,
+                    'localized-strings',
+                    'tagline',
+                  ]) || siteConfig.tagline}
                 </small>
               </h2>
               <div className="section promoSection">


### PR DESCRIPTION
## Summary

This is successor of #6590. 

Changes:
1. CircleCI will try to build jest website when it is a *PULL REQUEST* instead of just skipping it. This is to ensure that there is nothing wrong with building the website
2. Use a safe getter function (inspired from Facebook idx function to access deeply nested values of an object)

Notice this
```js
translation[this.props.language]['localized-strings'].tagline
```
This can cause build error which will return an unhandled promise. Currently jest use Docusaurus 1.3.0 which doesn't give non zero exit code when there is a build error. This is fixed in Docusaurus >= 1.3.1

Current local `yarn build` has an unhandled promise (build error)
<img width="701" alt="yarn build before" src="https://user-images.githubusercontent.com/17883920/42268635-99d1e9e2-7fae-11e8-9dc5-1b118b32abf3.PNG">


Current website deploy has an unhandled promise (build error)
https://circleci.com/gh/facebook/jest/27857
![image](https://user-images.githubusercontent.com/17883920/42236166-b5d7f514-7f2c-11e8-8dd5-f479950866e0.png)


## Test plan

1. Ensure that `yarn build` has no more unhandled promise
<img width="706" alt="yarn build after" src="https://user-images.githubusercontent.com/17883920/42268271-abe86e2c-7fad-11e8-80a3-4267ddb2212c.PNG">
2. Check this PR circleci run, should try to build the website for testing

https://circleci.com/gh/facebook/jest/27867

<img width="903" alt="ci build" src="https://user-images.githubusercontent.com/17883920/42268468-2d35c3f8-7fae-11e8-9b5e-32c0a5d35c6b.PNG">
