### PR TITLE
Fix `environment.teardown` call when not a function

### DIFF
--- a/packages/jest-runner/src/run_test.js
+++ b/packages/jest-runner/src/run_test.js
@@ -190,7 +190,9 @@ async function runTestInternal(
       setImmediate(() => resolve({leakDetector, result}));
     });
   } finally {
-    await environment.teardown();
+    if (typeof environment.teardown === 'function') {
+      await environment.teardown();
+    }
 
     sourcemapSupport.resetRetrieveHandlers();
   }

--- a/packages/jest-runner/src/run_test.js
+++ b/packages/jest-runner/src/run_test.js
@@ -146,7 +146,9 @@ async function runTestInternal(
   sourcemapSupport.install(sourcemapOptions);
 
   try {
-    await environment.setup();
+    if (typeof environment.setup === 'function') {
+      await environment.setup();
+    }
 
     let result: TestResult;
 


### PR DESCRIPTION
To prevent `TypeError: environment.teardown is not a function`
