### PR TITLE
Correcting link on index.js for Mocking Functions section.

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -361,10 +361,9 @@ class Index extends React.Component {
                 {
                   content: (
                     <translate>
-                      Powerful [mocking
-                      library](/docs/en/mock-functions.html) for functions
-                      and modules. Mock React Native components using
-                      `jest-react-native`.
+                      Powerful [mocking library](/docs/en/mock-functions.html)
+                      for functions and modules. Mock React Native components
+                      using `jest-react-native`.
                     </translate>
                   ),
                   image: '/img/content/feature-mocking.png',

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -362,7 +362,7 @@ class Index extends React.Component {
                   content: (
                     <translate>
                       Powerful [mocking
-                      library](/jest/docs/en/mock-functions.html) for functions
+                      library](/docs/en/mock-functions.html) for functions
                       and modules. Mock React Native components using
                       `jest-react-native`.
                     </translate>


### PR DESCRIPTION
## Summary

Updated link in `index.js` for "Mocking Library" to ensure that it points to an existing page and not a 404.

Resolves #6620