### PR TITLE
Update docs to detail resetModules: false behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - `[*]` Update all legacy links to jestjs.io ([#6622](https://github.com/facebook/jest/pull/6622))
 - `[docs]` Add docs for 23.1, 23.2, and 23.3 ([#6623](https://github.com/facebook/jest/pull/6623))
 - `[website]` Only test/deploy website if relevant files are changed ([#6626](https://github.com/facebook/jest/pull/6626))
+- `[docs]` Describe behavior of `resetModules` option when set to `false` ([#6641](https://github.com/facebook/jest/pull/6641))
 
 ## 23.2.0
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -523,7 +523,7 @@ Automatically reset mock state between every test. Equivalent to calling `jest.r
 
 Default: `false`
 
-If enabled, the module registry for every test file will be reset before running each individual test. This is useful to isolate modules for every test so that local module state doesn't conflict between tests. This can be done programmatically using [`jest.resetModules()`](#jest-resetmodules).
+By default, each test file gets its own independent module registry. Enabling `resetModules` goes a step further and resets the module registry before running each individual test. This is useful to isolate modules for every test so that local module state doesn't conflict between tests. This can be done programmatically using [`jest.resetModules()`](#jest-resetmodules).
 
 ### `resolver` [string]
 


### PR DESCRIPTION
## Summary

The documentation at the moment describes the behavior of Jest when `resetModules` is set to `true`, but leaves the default/false case unclarified. I had a misconception that the module registry would not be reset at all in the false case, where it's still reset between different test files. This misconception was clarified by SimienB in issue #6007.

The reporter of issue #4413 also had this question.

This commit updates the documentation of `resetModules` to explain the default case more explicitly.