### PR TITLE
Fix toBe incorrect expected type (#6551)

### DIFF
--- a/packages/expect/src/matchers.js
+++ b/packages/expect/src/matchers.js
@@ -42,7 +42,7 @@ type ContainIterable =
   | HTMLCollection<any>;
 
 const matchers: MatchersObject = {
-  toBe(received: any, expected: number) {
+  toBe(received: any, expected: any) {
     const comment = 'Object.is equality';
     const pass = Object.is(received, expected);
 


### PR DESCRIPTION
## Summary

`toBe` expected argument should be `any`.