### PR TITLE
Update Docusaurus to 1.3.2

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -16,7 +16,7 @@
     "rename-version": "docusaurus-rename-version"
   },
   "dependencies": {
-    "docusaurus": "^1.3.0"
+    "docusaurus": "^1.3.2"
   },
   "devDependencies": {
     "crowdin-cli": "^0.3.0"

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -111,10 +111,10 @@ const siteConfig = {
   onPageNav: 'separate',
   recruitingLink: 'https://crowdin.com/project/jest',
   algolia: {
-    apiKey: process.env.ALGOLIA_JEST_API_KEY,
+    apiKey: '833906d7486e4059359fa58823c4ef56',
     indexName: 'jest',
     algoliaOptions: {
-      facetFilters: ['language:LANGUAGE', 'version:23.3'],
+      facetFilters: ['language:LANGUAGE', 'version:VERSION'],
     },
   },
   gaTrackingId: 'UA-44373548-17',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2361,6 +2361,10 @@ commander@2.15.1, commander@^2.11.0, commander@^2.15.1, commander@^2.9.0:
   version "2.15.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
 
+commander@^2.16.0:
+  version "2.16.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.16.0.tgz#f16390593996ceb4f3eeb020b31d78528f7f8a50"
+
 commander@~2.13.0:
   version "2.13.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.13.0.tgz#6964bca67685df7c1f1430c584f07d7597885b9c"
@@ -3319,9 +3323,9 @@ doctrine@^2.1.0:
   dependencies:
     esutils "^2.0.2"
 
-docusaurus@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/docusaurus/-/docusaurus-1.3.0.tgz#a2a8a8f581390d53bffefc4b5e699699576970c9"
+docusaurus@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/docusaurus/-/docusaurus-1.3.2.tgz#1e5001d1831b028178e496f6b8511e436ac7fda9"
   dependencies:
     babel-plugin-transform-class-properties "^6.24.1"
     babel-plugin-transform-object-rest-spread "^6.26.0"
@@ -3334,7 +3338,7 @@ docusaurus@^1.3.0:
     chalk "^2.1.0"
     classnames "^2.2.6"
     color "^2.0.1"
-    commander "^2.11.0"
+    commander "^2.16.0"
     crowdin-cli "^0.3.0"
     cssnano "^3.10.0"
     escape-string-regexp "^1.0.5"
@@ -3361,7 +3365,7 @@ docusaurus@^1.3.0:
     sitemap "^1.13.0"
     tcp-port-used "^0.1.2"
     tiny-lr "^1.1.1"
-    tree-node-cli "^1.2.2"
+    tree-node-cli "^1.2.5"
 
 dom-serialize@^2.2.0:
   version "2.2.1"
@@ -10707,9 +10711,9 @@ tr46@^1.0.1:
   dependencies:
     punycode "^2.1.0"
 
-tree-node-cli@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/tree-node-cli/-/tree-node-cli-1.2.2.tgz#d8aa63f7ed4eeea02d047e0b30b662194d9ec4fc"
+tree-node-cli@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/tree-node-cli/-/tree-node-cli-1.2.5.tgz#afd75437976bbf2cc0c52b9949798e7530e8fd8c"
   dependencies:
     commander "^2.15.1"
 


### PR DESCRIPTION
## Summary

1. Update Docusaurus to 1.3.2 based on https://github.com/facebook/jest/issues/6640#issuecomment-402938248. This version has few bug fixes which is important imho. In additions:

- Being able to easily debug commit that cause 404 / broken build in gh-pages branch

Consider this commit https://github.com/endiliey/endiliey.github.io/commit/4c6abe0786e2be11cda2ae7c8d847e957d6ba89d
<img width="590" alt="Triggering commit" src="https://user-images.githubusercontent.com/17883920/42290155-212bee00-7ff6-11e8-9440-ebbd78629dec.PNG">

Now the deploy commit on `gh-pages` shows the correct triggering commit
https://github.com/endiliey/endiliey.github.io/commit/936bbc3e2fa8d647aa824e138d52f7b8fbf17b2e
<img width="589" alt="Deploy shows triggering commit" src="https://user-images.githubusercontent.com/17883920/42290187-3f7f5a40-7ff6-11e8-8edb-15b29190deed.PNG">

Make debugging life easier 👍 

- Search docs depending on current version of docs
(refer to test plan below)

2. Expose algolia api key for easy debugging

cc @yangshun @JoelMarcey 

## Test plan

1. Static website build works without non-zero exit code
```
cd website
yarn build
```

2. Test locally
```
cd website
yarn start
```

Search according to current version. 
**Example I'm at 22.2, my search will be scoped to 22.2 docs.**
![search according to version](https://user-images.githubusercontent.com/17883920/42369272-0bfe5dfa-813c-11e8-90a3-60804aac71b3.gif)

**Example I'm at docs/en/next, my search will be scoped to docs/en/next docs.**
![search according to version2](https://user-images.githubusercontent.com/17883920/42370160-991fabec-813e-11e8-85fe-63de8d741621.gif)
