### PR TITLE
Always use workers when using the watch mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## master
 
+### Fixes
+
+- `[jest-runner]` Force parallel runs for watch mode, to avoid TTY freeze ([#6647](https://github.com/facebook/jest/pull/6647))
+
 ## 23.3.0
 
 ### Features


### PR DESCRIPTION
When using the `watch` mode, we use the TTY as an input mechanism (for keystrokes), so that different options can be selected. When only one test is selected, it will run by default in band, which causes the TTY to be unresponsive.

Blacklisting "in band" mode when using the `watch` mode fixes the issue, since tests are executed in workers, freeing the main process.

Fixes #6599.