### PR TITLE
Add docs section to highlight jest.requireActual

### DIFF
--- a/docs/BypassingModuleMocks.md
+++ b/docs/BypassingModuleMocks.md
@@ -1,0 +1,60 @@
+---
+id: bypassing-module-mocks
+title: Bypassing module mocks
+---
+
+Jest allows you to mock out whole modules in your tests, which can be useful for testing your code is calling functions from that module correctly. However, sometimes you may want to use parts of a mocked module in your *test file*, in which case you want to access the original implementation, rather than a mocked version.
+
+Consider writing a test case for this `createUser` function:
+
+```javascript
+// createUser.js
+import fetch from "node-fetch"
+
+export const createUser = async () => {
+    const response = await fetch("http://website.com/users", { method: "POST" })
+    const userId = await response.text()
+    return userId
+}
+```
+
+Your test will want to mock the `fetch` function so that we can be sure that it gets called without actually making the network request. However, you'll also need to mock the return value of `fetch` with a `Response` (wrapped in a `Promise`), as our function uses it to grab the created user's ID. So you might initially try writing a test like this:
+
+```javascript
+jest.mock("node-fetch")
+
+import fetch, { Response } from "node-fetch"
+
+import { createUser } from "./createUser"
+
+test("createUser calls fetch with the right args and returns the user id", async () => {
+    fetch.mockReturnValue(Promise.resolve(new Response("4")))
+
+    const userId = await createUser()
+
+    expect(fetch).toHaveBeenCalledTimes(1)
+    expect(fetch).toHaveBeenCalledWith("http://website.com/users", {
+        method: "POST",
+    })
+    expect(userId).toBe("4")
+})
+```
+
+However, if you ran that test you would find that the `createUser` function would fail, throwing the error: `TypeError: response.text is not a function`. This is because the `Response` class you've imported from `node-fetch` has been mocked (due to the `jest.mock` call at the top of the test file) so it no longer behaves the way it should.
+
+To get around problems like this, Jest provides the `require.requireActual` helper. To make the above test work, make the following change to the imports in the test file:
+
+```javascript
+// BEFORE
+jest.mock("node-fetch")
+import fetch, { Response } from "node-fetch"
+```
+
+```javascript
+// AFTER
+jest.mock("node-fetch")
+import fetch from "node-fetch"
+const { Response } = require.requireActual("node-fetch")
+```
+
+This allows your test file to import the actual `Response` object from `node-fetch`, rather than a mocked version. This means the test will now pass correctly.

--- a/docs/BypassingModuleMocks.md
+++ b/docs/BypassingModuleMocks.md
@@ -3,58 +3,58 @@ id: bypassing-module-mocks
 title: Bypassing module mocks
 ---
 
-Jest allows you to mock out whole modules in your tests, which can be useful for testing your code is calling functions from that module correctly. However, sometimes you may want to use parts of a mocked module in your *test file*, in which case you want to access the original implementation, rather than a mocked version.
+Jest allows you to mock out whole modules in your tests, which can be useful for testing your code is calling functions from that module correctly. However, sometimes you may want to use parts of a mocked module in your _test file_, in which case you want to access the original implementation, rather than a mocked version.
 
 Consider writing a test case for this `createUser` function:
 
 ```javascript
 // createUser.js
-import fetch from "node-fetch"
+import fetch from 'node-fetch';
 
 export const createUser = async () => {
-    const response = await fetch("http://website.com/users", { method: "POST" })
-    const userId = await response.text()
-    return userId
-}
+  const response = await fetch('http://website.com/users', {method: 'POST'});
+  const userId = await response.text();
+  return userId;
+};
 ```
 
 Your test will want to mock the `fetch` function so that we can be sure that it gets called without actually making the network request. However, you'll also need to mock the return value of `fetch` with a `Response` (wrapped in a `Promise`), as our function uses it to grab the created user's ID. So you might initially try writing a test like this:
 
 ```javascript
-jest.mock("node-fetch")
+jest.mock('node-fetch');
 
-import fetch, { Response } from "node-fetch"
+import fetch, {Response} from 'node-fetch';
 
-import { createUser } from "./createUser"
+import {createUser} from './createUser';
 
-test("createUser calls fetch with the right args and returns the user id", async () => {
-    fetch.mockReturnValue(Promise.resolve(new Response("4")))
+test('createUser calls fetch with the right args and returns the user id', async () => {
+  fetch.mockReturnValue(Promise.resolve(new Response('4')));
 
-    const userId = await createUser()
+  const userId = await createUser();
 
-    expect(fetch).toHaveBeenCalledTimes(1)
-    expect(fetch).toHaveBeenCalledWith("http://website.com/users", {
-        method: "POST",
-    })
-    expect(userId).toBe("4")
-})
+  expect(fetch).toHaveBeenCalledTimes(1);
+  expect(fetch).toHaveBeenCalledWith('http://website.com/users', {
+    method: 'POST',
+  });
+  expect(userId).toBe('4');
+});
 ```
 
 However, if you ran that test you would find that the `createUser` function would fail, throwing the error: `TypeError: response.text is not a function`. This is because the `Response` class you've imported from `node-fetch` has been mocked (due to the `jest.mock` call at the top of the test file) so it no longer behaves the way it should.
 
-To get around problems like this, Jest provides the `require.requireActual` helper. To make the above test work, make the following change to the imports in the test file:
+To get around problems like this, Jest provides the `jest.requireActual` helper. To make the above test work, make the following change to the imports in the test file:
 
 ```javascript
 // BEFORE
-jest.mock("node-fetch")
-import fetch, { Response } from "node-fetch"
+jest.mock('node-fetch');
+import fetch, {Response} from 'node-fetch';
 ```
 
 ```javascript
 // AFTER
-jest.mock("node-fetch")
-import fetch from "node-fetch"
-const { Response } = require.requireActual("node-fetch")
+jest.mock('node-fetch');
+import fetch from 'node-fetch';
+const {Response} = jest.requireActual('node-fetch');
 ```
 
 This allows your test file to import the actual `Response` object from `node-fetch`, rather than a mocked version. This means the test will now pass correctly.

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -16,6 +16,7 @@
       "timer-mocks",
       "manual-mocks",
       "es6-class-mocks",
+      "bypassing-module-mocks",
       "webpack",
       "puppeteer",
       "mongodb",


### PR DESCRIPTION
First – thanks so much for this project, I've been using Jest for a couple of years and have benefited from it a lot!

## Summary

I've been in the situation a few times where I've had a problem that could be solved by `require.requireActual` but didn't know about it because it seems to be quite hidden away in the docs (as far as I could tell, it's only really documented in the "Globals" section of the API reference). As a result of not knowing about it, I've wasted quite a lot of hours writing my own manual mocks rather than using Jest's automocking features. This PR adds a section to the docs entitled "Bypassing module mocks" which presents an issue similar to one I encountered recently, and talks the reader through how `require.requireActual` can solve the problem.

Let me know what you think. I've tried to match the tone of the rest of Jest's docs, and tried to pick an example that's simple enough to quickly make sense of but also resonates with the sort of tests people would actually write in real life.

I'm not at all wedded to the particular example I use – I'm mostly just keen that something gets added to the docs that draws attention to `require.requireActual`.

When I built the docs locally (by running `yarn start` in the `website` folder) it didn't seem reflect my changes as I made them, so I haven't been able to verify if the markdown gets rendered into the web page correctly. But I imagine that's a simple task.

Thanks very much.

## Test plan
N/A
