### PR TITLE
Fix typo when adding inline snapshot

### DIFF
--- a/packages/jest-snapshot/src/State.js
+++ b/packages/jest-snapshot/src/State.js
@@ -93,7 +93,9 @@ export default class SnapshotState {
       const lines = getStackTraceLines(error.stack);
       const frame = getTopFrame(lines);
       if (!frame) {
-        throw new Error("Jest: Couln't infer stack frame for inline snapshot.");
+        throw new Error(
+          "Jest: Couldn't infer stack frame for inline snapshot.",
+        );
       }
       this._inlineSnapshots.push({
         frame,


### PR DESCRIPTION
## Summary

This PR fixes a typo when adding an inline snapshot `Couln't` -> `Couldn't`

## Test plan

Just a typo fix
