### PR TITLE
Add help for configuration of collectCoverageFrom

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -153,6 +153,24 @@ This will collect coverage information for all the files inside the project's `r
 
 _Note: This option requires `collectCoverage` to be set to true or Jest to be invoked with `--coverage`._
 
+<details>
+  <summary>Help:</summary>
+  If you are seeing coverage output such as...
+
+```
+=============================== Coverage summary ===============================
+Statements   : Unknown% ( 0/0 )
+Branches     : Unknown% ( 0/0 )
+Functions    : Unknown% ( 0/0 )
+Lines        : Unknown% ( 0/0 )
+================================================================================
+Jest: Coverage data for global was not found.
+```
+
+Most likely your glob patterns are not matching any files. Refer to the [micromatch](https://github.com/jonschlinkert/micromatch) documentation to ensure your globs are compatible.
+
+</details>
+
 ### `coverageDirectory` [string]
 
 Default: `undefined`


### PR DESCRIPTION
Due to breaking changes in an upgrade of the dependency micromatch
from ^2.3.11 to ^3.1.10 many users saw their coverage reporting
failing because their glob matching was in an unsupported format.

Adding the help text here gives users a good starting point for
debugging when they run into issues related to this option. This will
help alleviate support issues (such as #6563) concerning this configuration
option.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Give users a hint as to what could be causing an unexpected summary output when running coverage reporting with Jest. 

This lowers the barrier to troubleshooting this configuration issue since it points to what I would consider the most likely cause of the unexpected output when using this configuration option (an unsupported or malformed glob). Jest doesn't raise any errors in this case which I think is the correct thing to do, but can be hard to debug for newcomers.

Since glob expansion varies across implementations I think it makes sense to explicitly point out this possible misconfiguration and point to the internal dependency's (micromatch) documentation (it is already mentioned in the docs, but I overlooked it multiple times when identifying the problem myself) another callout to those docs could be a good idea to push users to understand the globbing implementation used.

## Test plan
 
Verify the new documentation fits in with the current Jest documentation style.

Get confirmation that this is the best place to point out this possible misconfiguration.
