### PR TITLE
fix: add console error to catch block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Fixes
 
+- `[jest-resolve]` Add console error for when an error is caught ([#6665](https://github.com/facebook/jest/pull/6665))
 - `[jest-runner]` Force parallel runs for watch mode, to avoid TTY freeze ([#6647](https://github.com/facebook/jest/pull/6647))
 - `[jest-cli]` properly reprint resolver errors in watch mode ([#6407](https://github.com/facebook/jest/pull/6407))
 - `[jest-cli]` Write configuration to stdout when the option was explicitly passed to Jest ([#6447](https://github.com/facebook/jest/pull/6447))

--- a/packages/jest-resolve-dependencies/src/index.js
+++ b/packages/jest-resolve-dependencies/src/index.js
@@ -47,7 +47,9 @@ class DependencyResolver {
         }
         try {
           return this._resolver.resolveModule(file, dependency, options);
-        } catch (e) {}
+        } catch (e) {
+          console.error(e);
+        }
         return this._resolver.getMockModule(file, dependency);
       })
       .filter(Boolean);


### PR DESCRIPTION
## Summary

I had an issue recently where the jest-resolve-dependencies was swallowing errors in the catch statement. The error was actually causing the `jest --watch` command to hang, I thought that it'd be helpful for users to see the errors so that they are able to rectify them.

I found that errors were being swallowed from the following: https://github.com/facebook/jest/issues/6025

## Test plan

No tests added for a `console.error`
