### PR TITLE
Use process.env.ALGOLIA_JEST_API_KEY within siteConfig instead

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -111,7 +111,7 @@ const siteConfig = {
   onPageNav: 'separate',
   recruitingLink: 'https://crowdin.com/project/jest',
   algolia: {
-    apiKey: '833906d7486e4059359fa58823c4ef56',
+    apiKey: process.env.ALGOLIA_JEST_API_KEY,
     indexName: 'jest',
     algoliaOptions: {
       facetFilters: ['language:LANGUAGE', 'version:VERSION'],


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Reduce duplication of Algolia API Key by referencing env variable within siteConfig. Follow up of https://github.com/facebook/jest/pull/6644#issuecomment-403763538.

## Test plan

Netlify test at https://deploy-preview-6666--jest-preview.netlify.com/. Seems to be working as I can search in the preview.

cc @endiliey 