### PR TITLE
Avoid reading files from Haste map if not needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## master
 
+### Features
+
+- `[jest-haste-map]` Add `computeDependencies` flag to avoid opening files if not needed ([#6667](https://github.com/facebook/jest/pull/6667))
+
 ### Fixes
 
 - `[jest-runner]` Force parallel runs for watch mode, to avoid TTY freeze ([#6647](https://github.com/facebook/jest/pull/6647))

--- a/packages/jest-haste-map/src/__tests__/index.test.js
+++ b/packages/jest-haste-map/src/__tests__/index.test.js
@@ -899,6 +899,7 @@ describe('HasteMap', () => {
         expect(mockWorker.mock.calls).toEqual([
           [
             {
+              computeDependencies: true,
               computeSha1: false,
               filePath: '/fruits/__mocks__/Pear.js',
               hasteImplModulePath: undefined,
@@ -906,6 +907,7 @@ describe('HasteMap', () => {
           ],
           [
             {
+              computeDependencies: true,
               computeSha1: false,
               filePath: '/fruits/banana.js',
               hasteImplModulePath: undefined,
@@ -913,6 +915,7 @@ describe('HasteMap', () => {
           ],
           [
             {
+              computeDependencies: true,
               computeSha1: false,
               filePath: '/fruits/pear.js',
               hasteImplModulePath: undefined,
@@ -920,6 +923,7 @@ describe('HasteMap', () => {
           ],
           [
             {
+              computeDependencies: true,
               computeSha1: false,
               filePath: '/fruits/strawberry.js',
               hasteImplModulePath: undefined,
@@ -927,6 +931,7 @@ describe('HasteMap', () => {
           ],
           [
             {
+              computeDependencies: true,
               computeSha1: false,
               filePath: '/vegetables/melon.js',
               hasteImplModulePath: undefined,

--- a/packages/jest-haste-map/src/index.js
+++ b/packages/jest-haste-map/src/index.js
@@ -44,6 +44,7 @@ type HType = typeof H;
 
 type Options = {
   cacheDirectory?: string,
+  computeDependencies?: boolean,
   computeSha1?: boolean,
   console?: Console,
   extensions: Array<string>,
@@ -65,6 +66,7 @@ type Options = {
 
 type InternalOptions = {
   cacheDirectory: string,
+  computeDependencies: boolean,
   computeSha1: boolean,
   extensions: Array<string>,
   forceNodeFilesystemAPI: boolean,
@@ -213,6 +215,10 @@ class HasteMap extends EventEmitter {
     super();
     this._options = {
       cacheDirectory: options.cacheDirectory || os.tmpdir(),
+      computeDependencies:
+        options.computeDependencies === undefined
+          ? true
+          : options.computeDependencies,
       computeSha1: options.computeSha1 || false,
       extensions: options.extensions,
       forceNodeFilesystemAPI: !!options.forceNodeFilesystemAPI,
@@ -454,6 +460,7 @@ class HasteMap extends EventEmitter {
       if (computeSha1) {
         return this._getWorker(workerOptions)
           .getSha1({
+            computeDependencies: this._options.computeDependencies,
             computeSha1,
             filePath,
             hasteImplModulePath: this._options.hasteImplModulePath,
@@ -510,6 +517,7 @@ class HasteMap extends EventEmitter {
 
     return this._getWorker(workerOptions)
       .worker({
+        computeDependencies: this._options.computeDependencies,
         computeSha1,
         filePath,
         hasteImplModulePath: this._options.hasteImplModulePath,

--- a/packages/jest-haste-map/src/types.js
+++ b/packages/jest-haste-map/src/types.js
@@ -12,6 +12,7 @@ import type {InternalHasteMap, ModuleMetaData} from 'types/HasteMap';
 export type IgnoreMatcher = (item: string) => boolean;
 
 export type WorkerMessage = {
+  computeDependencies: boolean,
   computeSha1: boolean,
   filePath: string,
   hasteImplModulePath?: string,

--- a/packages/jest-haste-map/src/worker.js
+++ b/packages/jest-haste-map/src/worker.js
@@ -22,7 +22,7 @@ const PACKAGE_JSON = path.sep + 'package.json';
 let hasteImpl: ?HasteImpl = null;
 let hasteImplModulePath: ?string = null;
 
-function computeSha1(content) {
+function sha1hex(content: string | Buffer): string {
   return crypto
     .createHash('sha1')
     .update(content)
@@ -42,18 +42,25 @@ export async function worker(data: WorkerMessage): Promise<WorkerMetadata> {
     hasteImpl = (require(hasteImplModulePath): HasteImpl);
   }
 
-  const filePath = data.filePath;
   let content;
   let dependencies;
   let id;
   let module;
   let sha1;
 
-  // Process a package.json that is returned as a PACKAGE type with its name.
+  const {computeDependencies, computeSha1, filePath} = data;
+  const getContent = (): string => {
+    if (content === undefined) {
+      content = fs.readFileSync(filePath, 'utf8');
+    }
+
+    return content;
+  };
+
   if (filePath.endsWith(PACKAGE_JSON)) {
-    content = fs.readFileSync(filePath, 'utf8');
+    // Process a package.json that is returned as a PACKAGE type with its name.
     try {
-      const fileData = JSON.parse(content);
+      const fileData = JSON.parse(getContent());
 
       if (fileData.name) {
         id = fileData.name;
@@ -62,19 +69,18 @@ export async function worker(data: WorkerMessage): Promise<WorkerMetadata> {
     } catch (err) {
       throw new Error(`Cannot parse ${filePath} as JSON: ${err.message}`);
     }
-
-    // Process a randome file that is returned as a MODULE.
   } else if (!blacklist.has(filePath.substr(filePath.lastIndexOf('.')))) {
-    content = fs.readFileSync(filePath, 'utf8');
-
+    // Process a random file that is returned as a MODULE.
     if (hasteImpl) {
       id = hasteImpl.getHasteName(filePath);
     } else {
-      const doc = docblock.parse(docblock.extract(content));
+      const doc = docblock.parse(docblock.extract(getContent()));
       id = [].concat(doc.providesModule || doc.provides)[0];
     }
 
-    dependencies = extractRequires(content);
+    if (computeDependencies) {
+      dependencies = extractRequires(getContent());
+    }
 
     if (id) {
       module = [filePath, H.MODULE];
@@ -82,12 +88,8 @@ export async function worker(data: WorkerMessage): Promise<WorkerMetadata> {
   }
 
   // If a SHA-1 is requested on update, compute it.
-  if (data.computeSha1) {
-    if (content == null) {
-      content = fs.readFileSync(filePath);
-    }
-
-    sha1 = computeSha1(content);
+  if (computeSha1) {
+    sha1 = sha1hex(getContent() || fs.readFileSync(filePath));
   }
 
   return {dependencies, id, module, sha1};
@@ -95,7 +97,7 @@ export async function worker(data: WorkerMessage): Promise<WorkerMetadata> {
 
 export async function getSha1(data: WorkerMessage): Promise<WorkerMetadata> {
   const sha1 = data.computeSha1
-    ? computeSha1(fs.readFileSync(data.filePath))
+    ? sha1hex(fs.readFileSync(data.filePath))
     : null;
 
   return {


### PR DESCRIPTION
Metro also uses `jest-haste-map`, but there is no need to extract dependencies from it, since Metro has its own algorithms. This PR implements a boolean flag that avoids reading from the filesystem when we do not want to extract dependencies. The default is kept to `true` so it's backwards compatible.

I also added specific tests for non-UTF-8 files, and for non-computed dependencies too. The argument is made mandatory at the worker level.