### PR TITLE
Fix inconsistency in `rejects.toThrow()`

### DIFF
--- a/packages/expect/src/__tests__/matchers.test.js
+++ b/packages/expect/src/__tests__/matchers.test.js
@@ -51,6 +51,16 @@ describe('.rejects', () => {
     await jestExpect(fn()).rejects.toThrow('some error');
   });
 
+  it('should reject and match non-error class', async () => {
+    class Exception {
+      constructor(message: string) {}
+    }
+    const p = new Promise(() => {
+      throw new Exception('some-info');
+    });
+    await expect(p).rejects.toThrow(Exception);
+  });
+
   [4, [1], {a: 1}, 'a', true, null, undefined, () => {}].forEach(value => {
     it(`fails non-promise value ${stringify(value)} synchronously`, () => {
       let error;

--- a/packages/expect/src/to_throw_matchers.js
+++ b/packages/expect/src/to_throw_matchers.js
@@ -20,7 +20,6 @@ import {
   printWithType,
 } from 'jest-matcher-utils';
 import {equals} from './jasmine_utils';
-import {isError} from './utils';
 
 export const createMatcher = (matcherName: string, fromPromise?: boolean) => (
   actual: Function,
@@ -28,8 +27,7 @@ export const createMatcher = (matcherName: string, fromPromise?: boolean) => (
 ) => {
   const value = expected;
   let error;
-
-  if (fromPromise && isError(actual)) {
+  if (fromPromise) {
     error = actual;
   } else {
     if (typeof actual !== 'function') {


### PR DESCRIPTION
fixes #6675

With this fix sync and async versions of `toThrow` are consistent.

However, throwing non-errors is not a good practice because we don't have the stack trace.