### PR TITLE
Fix a typo in config description

### DIFF
--- a/packages/jest-cli/src/lib/__tests__/__snapshots__/init.test.js.snap
+++ b/packages/jest-cli/src/lib/__tests__/__snapshots__/init.test.js.snap
@@ -66,7 +66,7 @@ module.exports = {
   // Make calling deprecated APIs throw helpful error messages
   // errorOnDeprecated: false,
 
-  // Force coverage collection from ignored files usin a array of glob patterns
+  // Force coverage collection from ignored files using an array of glob patterns
   // forceCoverageMatch: [],
 
   // A path to a module which exports an async function that is triggered once before all test suites

--- a/packages/jest-config/src/descriptions.js
+++ b/packages/jest-config/src/descriptions.js
@@ -29,7 +29,7 @@ export default ({
   errorOnDeprecated:
     'Make calling deprecated APIs throw helpful error messages',
   forceCoverageMatch:
-    'Force coverage collection from ignored files usin a array of glob patterns',
+    'Force coverage collection from ignored files using an array of glob patterns',
   globalSetup:
     'A path to a module which exports an async function that is triggered once before all test suites',
   globalTeardown:


### PR DESCRIPTION
## Summary

There was a typo in the description of `forceCoverageMatch` config parameter.