### PR TITLE
fix beforeAll hooks in jest-circus

### DIFF
--- a/packages/jest-circus/src/__tests__/__snapshots__/after_all.test.js.snap
+++ b/packages/jest-circus/src/__tests__/__snapshots__/after_all.test.js.snap
@@ -13,16 +13,25 @@ finish_describe_definition: describe
 run_start
 run_describe_start: ROOT_DESCRIBE_BLOCK
 run_describe_start: describe
+hook_start: beforeAll
+> beforeAll
+hook_success: beforeAll
 run_describe_start: child describe
 test_start: my test
 hook_start: beforeEach
+> beforeEach
 hook_success: beforeEach
 test_fn_start: my test
-test_fn_failure: my test
+> my test
+test_fn_success: my test
 hook_start: afterEach
+> afterEach
 hook_success: afterEach
 test_done: my test
 run_describe_finish: child describe
+hook_start: afterAll
+> afterAll
+hook_success: afterAll
 run_describe_finish: describe
 run_describe_finish: ROOT_DESCRIBE_BLOCK
 run_finish

--- a/packages/jest-circus/src/__tests__/__snapshots__/hooks.test.js.snap
+++ b/packages/jest-circus/src/__tests__/__snapshots__/hooks.test.js.snap
@@ -1,5 +1,48 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`beforeAll is exectued correctly 1`] = `
+"start_describe_definition: describe 1
+add_hook: beforeAll
+add_test: test 1
+start_describe_definition: 2nd level describe
+add_hook: beforeAll
+add_test: test 2
+add_test: test 3
+finish_describe_definition: 2nd level describe
+finish_describe_definition: describe 1
+run_start
+run_describe_start: ROOT_DESCRIBE_BLOCK
+run_describe_start: describe 1
+hook_start: beforeAll
+> beforeAll 1
+hook_success: beforeAll
+test_start: test 1
+test_fn_start: test 1
+> test 1
+test_fn_success: test 1
+test_done: test 1
+run_describe_start: 2nd level describe
+hook_start: beforeAll
+> beforeAll 2
+hook_success: beforeAll
+test_start: test 2
+test_fn_start: test 2
+> test 2
+test_fn_success: test 2
+test_done: test 2
+test_start: test 3
+test_fn_start: test 3
+> test 3
+test_fn_success: test 3
+test_done: test 3
+run_describe_finish: 2nd level describe
+run_describe_finish: describe 1
+run_describe_finish: ROOT_DESCRIBE_BLOCK
+run_finish
+
+unhandledErrors: 0"
+`;
+
 exports[`beforeEach is executed before each test in current/child describe blocks 1`] = `
 "start_describe_definition: describe
 add_hook: beforeEach

--- a/packages/jest-circus/src/__tests__/after_all.test.js
+++ b/packages/jest-circus/src/__tests__/after_all.test.js
@@ -54,14 +54,12 @@ test('describe block cannot have hooks and no tests', () => {
 test('describe block _can_ have hooks if a child describe block has tests', () => {
   const result = runTest(`
     describe('describe', () => {
-      afterEach(() => {});
-      beforeEach(() => {});
-      afterAll(() => {});
-      beforeAll(() => {});
+      afterEach(() => console.log('> afterEach'));
+      beforeEach(() => console.log('> beforeEach'));
+      afterAll(() => console.log('> afterAll'));
+      beforeAll(() => console.log('> beforeAll'));
       describe('child describe', () => {
-        test('my test', () => {
-          expect(true).toBe(true);
-        })
+        test('my test', () => console.log('> my test'));
       })
     })
   `);

--- a/packages/jest-circus/src/__tests__/hooks.test.js
+++ b/packages/jest-circus/src/__tests__/hooks.test.js
@@ -59,3 +59,20 @@ test('multiple before each hooks in one describe are executed in the right order
 
   expect(stdout).toMatchSnapshot();
 });
+
+test('beforeAll is exectued correctly', () => {
+  const {stdout} = runTest(`
+    describe('describe 1', () => {
+      beforeAll(() => console.log('> beforeAll 1'));
+      test('test 1', () => console.log('> test 1'));
+
+      describe('2nd level describe', () => {
+        beforeAll(() => console.log('> beforeAll 2'));
+        test('test 2', () => console.log('> test 2'));
+        test('test 3', () => console.log('> test 3'));
+      });
+    });
+  `);
+
+  expect(stdout).toMatchSnapshot();
+});

--- a/packages/jest-circus/src/utils.js
+++ b/packages/jest-circus/src/utils.js
@@ -90,9 +90,11 @@ export const makeTest = (
   };
 };
 
+// Traverse the tree of describe blocks and return true if at least one describe
+// block has an enabled test.
 const hasEnabledTest = (describeBlock: DescribeBlock): boolean => {
   const {hasFocusedTests, testNamePattern} = getState();
-  return describeBlock.tests.some(
+  const hasOwnEnabledTests = describeBlock.tests.some(
     test =>
       !(
         test.mode === 'skip' ||
@@ -100,6 +102,8 @@ const hasEnabledTest = (describeBlock: DescribeBlock): boolean => {
         (testNamePattern && !testNamePattern.test(getTestID(test)))
       ),
   );
+
+  return hasOwnEnabledTests || describeBlock.children.some(hasEnabledTest);
 };
 
 export const getAllHooksForDescribe = (


### PR DESCRIPTION
hm... i don't even know how be broke it, but apparently we did :)
`beforeAll` hooks weren't executing at all if there's no other tests in the immediate describe block.