### PR TITLE
fix dependency name clash bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 - `[jest-cli]` Watch plugins now have access to a broader range of global configuration options in their `updateConfigAndRun` callbacks, so they can provide a wider set of extra features ([#6473](https://github.com/facebook/jest/pull/6473))
+- `[jest-snapshot]` `babel-traverse` is now passed to `jest-snapshot` explicitly to avoid unnecessary requires in every test
 
 ## 23.4.0
 

--- a/e2e/Utils.js
+++ b/e2e/Utils.js
@@ -42,7 +42,7 @@ const run = (cmd: string, cwd?: Path) => {
 const linkJestPackage = (packageName: string, cwd: Path) => {
   const packagesDir = path.resolve(__dirname, '../packages');
   const packagePath = path.resolve(packagesDir, packageName);
-  const destination = path.resolve(cwd, 'node_modules/');
+  const destination = path.resolve(cwd, 'node_modules/', packageName);
   mkdirp.sync(destination);
   rimraf.sync(destination);
   fs.symlinkSync(packagePath, destination, 'dir');

--- a/e2e/__tests__/dependency_clash.test.js
+++ b/e2e/__tests__/dependency_clash.test.js
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+const path = require('path');
+const {
+  cleanup,
+  createEmptyPackage,
+  linkJestPackage,
+  writeFiles,
+} = require('../Utils');
+const runJest = require('../runJest');
+const os = require('os');
+const mkdirp = require('mkdirp');
+const fs = require('fs');
+const ConditionalTest = require('../../scripts/ConditionalTest');
+
+ConditionalTest.skipSuiteOnWindows();
+
+// doing test in a temp directory because we don't want jest node_modules affect it
+const tempDir = path.resolve(os.tmpdir(), 'clashing-dependencies-test');
+const thirdPartyDir = path.resolve(tempDir, 'third-party');
+
+beforeEach(() => {
+  cleanup(tempDir);
+  createEmptyPackage(tempDir);
+  mkdirp(path.join(thirdPartyDir, 'node_modules'));
+  linkJestPackage('babel-jest', thirdPartyDir);
+});
+
+// This test case is checking that when having both
+// `invariant` package from npm and `invariant.js` that provides `invariant`
+// module we can still require the right invariant. This is pretty specific
+// use case and in the future we should probably delete this test.
+// see: https://github.com/facebook/jest/pull/6687
+test('fails with syntax error on flow types', () => {
+  const babelFileThatRequiresInvariant = require.resolve(
+    'babel-traverse/lib/path/index.js',
+  );
+
+  expect(fs.existsSync(babelFileThatRequiresInvariant)).toBe(true);
+  // make sure the babel depenency that depends on `invariant` from npm still
+  // exists, otherwise the test will pass regardless of whether the bug still
+  // exists or no.
+  expect(fs.readFileSync(babelFileThatRequiresInvariant).toString()).toMatch(
+    /invariant/,
+  );
+  writeFiles(tempDir, {
+    '.babelrc': `
+      {
+        "plugins": [
+          "${require.resolve('babel-plugin-transform-flow-strip-types')}"
+        ]
+      }
+    `,
+    '__tests__/test.js': `
+      const invariant = require('invariant');
+      test('haii', () => expect(invariant(false, 'haii')).toBe('haii'));
+    `,
+    'invariant.js': `/**
+      * @providesModule invariant
+      * @flow
+      */
+      const invariant = (condition: boolean, message: string) => message;
+      module.exports = invariant;
+    `,
+    'jest.config.js': `module.exports = {
+      transform: {'.*\\.js': './third-party/node_modules/babel-jest'},
+    };`,
+  });
+  const {stderr, status} = runJest(tempDir, ['--no-cache', '--no-watchman']);
+  // make sure there are no errors that lead to invariant.js (if we were to
+  // require a wrong `invariant.js` we'd have a syntax error, because jest
+  // internals wouldn't be able to parse flow annotations)
+  expect(stderr).not.toMatch('invariant');
+  expect(stderr).toMatch('PASS');
+  expect(status).toBe(0);
+});

--- a/packages/jest-circus/package.json
+++ b/packages/jest-circus/package.json
@@ -8,6 +8,7 @@
   "license": "MIT",
   "main": "build/index.js",
   "dependencies": {
+    "babel-traverse": "^6.0.0",
     "chalk": "^2.0.1",
     "co": "^4.6.0",
     "expect": "^23.4.0",

--- a/packages/jest-circus/src/legacy_code_todo_rewrite/jest_adapter.js
+++ b/packages/jest-circus/src/legacy_code_todo_rewrite/jest_adapter.js
@@ -33,8 +33,14 @@ const jestAdapter = async (
       expand: globalConfig.expand,
     });
 
+  const getPrettier = () =>
+    config.prettierPath ? require(config.prettierPath) : null;
+  const getBabelTraverse = () => require('babel-traverse').default;
+
   const {globals, snapshotState} = initialize({
     config,
+    getBabelTraverse,
+    getPrettier,
     globalConfig,
     localRequire: runtime.requireModule.bind(runtime),
     parentProcess: process,

--- a/packages/jest-circus/src/legacy_code_todo_rewrite/jest_adapter_init.js
+++ b/packages/jest-circus/src/legacy_code_todo_rewrite/jest_adapter_init.js
@@ -23,12 +23,16 @@ import globals from '../index';
 const Promise = getOriginalPromise();
 export const initialize = ({
   config,
+  getPrettier,
+  getBabelTraverse,
   globalConfig,
   localRequire,
   parentProcess,
   testPath,
 }: {
   config: ProjectConfig,
+  getPrettier: () => null | any,
+  getBabelTraverse: () => Function,
   globalConfig: GlobalConfig,
   localRequire: Path => any,
   testPath: Path,
@@ -94,8 +98,8 @@ export const initialize = ({
   const {expand, updateSnapshot} = globalConfig;
   const snapshotState = new SnapshotState(testPath, {
     expand,
-    getPrettier: () =>
-      config.prettierPath ? localRequire(config.prettierPath) : null,
+    getBabelTraverse,
+    getPrettier,
     updateSnapshot,
   });
   setState({snapshotState, testPath});

--- a/packages/jest-jasmine2/package.json
+++ b/packages/jest-jasmine2/package.json
@@ -8,6 +8,7 @@
   "license": "MIT",
   "main": "build/index.js",
   "dependencies": {
+    "babel-traverse": "^6.0.0",
     "chalk": "^2.0.1",
     "co": "^4.6.0",
     "expect": "^23.4.0",

--- a/packages/jest-jasmine2/src/setup_jest_globals.js
+++ b/packages/jest-jasmine2/src/setup_jest_globals.js
@@ -100,6 +100,7 @@ export default ({
   const {expand, updateSnapshot} = globalConfig;
   const snapshotState = new SnapshotState(testPath, {
     expand,
+    getBabelTraverse: () => require('babel-traverse').default,
     getPrettier: () =>
       config.prettierPath ? localRequire(config.prettierPath) : null,
     updateSnapshot,

--- a/packages/jest-snapshot/package.json
+++ b/packages/jest-snapshot/package.json
@@ -8,7 +8,6 @@
   "license": "MIT",
   "main": "build/index.js",
   "dependencies": {
-    "babel-traverse": "^6.0.0",
     "babel-types": "^6.0.0",
     "chalk": "^2.0.1",
     "jest-diff": "^23.2.0",

--- a/packages/jest-snapshot/src/State.js
+++ b/packages/jest-snapshot/src/State.js
@@ -25,6 +25,7 @@ import {saveInlineSnapshots, type InlineSnapshot} from './inline_snapshots';
 export type SnapshotStateOptions = {|
   updateSnapshot: SnapshotUpdateState,
   getPrettier: () => null | any,
+  getBabelTraverse: () => Function,
   snapshotPath?: string,
   expand?: boolean,
 |};
@@ -46,6 +47,7 @@ export default class SnapshotState {
   _snapshotPath: Path;
   _inlineSnapshots: Array<InlineSnapshot>;
   _uncheckedKeys: Set<string>;
+  _getBabelTraverse: () => Function;
   _getPrettier: () => null | any;
   added: number;
   expand: boolean;
@@ -61,6 +63,7 @@ export default class SnapshotState {
     );
     this._snapshotData = data;
     this._dirty = dirty;
+    this._getBabelTraverse = options.getBabelTraverse;
     this._getPrettier = options.getPrettier;
     this._inlineSnapshots = [];
     this._uncheckedKeys = new Set(Object.keys(this._snapshotData));
@@ -122,7 +125,8 @@ export default class SnapshotState {
       }
       if (hasInlineSnapshots) {
         const prettier = this._getPrettier(); // Load lazily
-        saveInlineSnapshots(this._inlineSnapshots, prettier);
+        const babelTraverse = this._getBabelTraverse(); // Load lazily
+        saveInlineSnapshots(this._inlineSnapshots, prettier, babelTraverse);
       }
       status.saved = true;
     } else if (!hasExternalSnapshots && fs.existsSync(this._snapshotPath)) {


### PR DESCRIPTION
to fix the bug i moved `prettier` and `babel-traverse` outside of node VM, so it is only required once per worker (and not in each individual test).

by doing this we'll also avoid taking the source code of our these dependencies through our resolution/transformation pipeline, which solves the issue of conflicting module names (since babel is no longer required from within the test code any more)

old description:

>It seems like a pretty serious bug, i don't have a fix yet, but i'm submitting the repro in case anyone >knows what's the best way to approach it.
>
>TL;DR:
>- we use `@providesModule` system at fb that let's us require files directly by their names (e.g. >`require('myModule111')` that'll resolve to `some/dir/myModule111.js`)
>- npm can import dependencies that have similar names
>- we have a module `invariant.js` in fb codebase
>- `inline-snapshots` introduced a babel dependency that also depends on `invariant` pakcage from >npm (https://github.com/babel/babel/blob/c7980b2b90744098ed5d67a105f8f6e7270e7cbe/packages/babel-traverse/src/path/index.js#L5)
>- when we run the test, `babel-traverse` requires `invariant` that resolves to the local `invarian.js` >and everything breaks because our `invariant.js` uses flow types that aren't parseable.