### PR TITLE
Tweak jest-haste-map watchman initial query to make it faster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - `[jest-cli]` Watch plugins now have access to a broader range of global configuration options in their `updateConfigAndRun` callbacks, so they can provide a wider set of extra features ([#6473](https://github.com/facebook/jest/pull/6473))
 
+## Fixes
+
+- `[jest-haste-map]` Optimize watchman crawler by using `glob` on initial query
+
 ## 23.4.0
 
 ### Features

--- a/packages/jest-haste-map/src/crawlers/watchman.js
+++ b/packages/jest-haste-map/src/crawlers/watchman.js
@@ -93,6 +93,8 @@ module.exports = async function watchmanCrawl(
       Array.from(rootProjectDirMappings).map(
         async ([root, directoryFilters]) => {
           const expression = Array.from(defaultWatchExpression);
+          const glob = [];
+
           if (directoryFilters.length > 0) {
             expression.push([
               'anyof',
@@ -100,11 +102,17 @@ module.exports = async function watchmanCrawl(
             ]);
           }
 
+          for (const directory of directoryFilters) {
+            for (const extension of extensions) {
+              glob.push(`${directory}/**/*.${extension}`);
+            }
+          }
+
           const query = clocks[root]
             ? // Use the `since` generator if we have a clock available
               {expression, fields, since: clocks[root]}
-            : // Otherwise use the `suffix` generator
-              {expression, fields, suffix: extensions};
+            : // Otherwise use the `glob` filter
+              {expression, fields, glob};
 
           const response = await cmd('query', root, query);
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

This PR tweaks the initial `watchman` query that's used by `jest-haste-map` crawler to use the `glob` filter instead of the standard expression ([more info](https://facebook.github.io/watchman/docs/file-query.html)).

This makes initial crawls using `watchman` considerably faster in some situations (specially when using `jest` internally at FB).

## Test plan

Tested in our internal codebase (against Metro bundler). Checked that `jest-haste-map` gets initialized correctly both with and without its local cache.
