### PR TITLE
Include createTransformer options in babel-jest's getCacheKey()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,16 @@
 ## master
 
+### Fixes
+
+- `[babel-jest]` Make `getCacheKey()` take into account `createTransformer` options ([#6699](https://github.com/facebook/jest/pull/6699))
+
 ## 23.4.1
 
 ### Features
 
 - `[jest-cli]` Watch plugins now have access to a broader range of global configuration options in their `updateConfigAndRun` callbacks, so they can provide a wider set of extra features ([#6473](https://github.com/facebook/jest/pull/6473))
 
-## Fixes
+### Fixes
 
 - `[jest-haste-map]` Optimize watchman crawler by using `glob` on initial query ([#6689](https://github.com/facebook/jest/pull/6689))
 

--- a/packages/babel-jest/src/index.js
+++ b/packages/babel-jest/src/index.js
@@ -92,6 +92,8 @@ const createTransformer = (options: any): Transformer => {
         .createHash('md5')
         .update(THIS_FILE)
         .update('\0', 'utf8')
+        .update(JSON.stringify(options))
+        .update('\0', 'utf8')
         .update(fileData)
         .update('\0', 'utf8')
         .update(path.relative(rootDir, filename))


### PR DESCRIPTION
## Summary

Previously the options passed to `createTransformer()` were not taken into account when generating the cache key, causing incorrect cache hits when the options had changed.

Fixes #6698.

## Test plan

I've repeated the STR from #6698 in a locally linked copy of Jest, and it no longer reproduces. I did not add a test, since there are no existing tests for `getCacheKey()`.
