### PR TITLE
Fix broken contributors graph link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixes
 
 - `[babel-jest]` Make `getCacheKey()` take into account `createTransformer` options ([#6699](https://github.com/facebook/jest/pull/6699))
+- `[docs]` Fix contributors link ([#6711](https://github.com/facebook/jest/pull/6711))
 
 ## 23.4.1
 

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ To help you get your feet wet and get you familiar with our contribution process
 
 ## Credits
 
-This project exists thanks to all the people who [contribute](CONTRIBUTING.md). <a href="graphs/contributors"><img src="https://opencollective.com/jest/contributors.svg?width=890&button=false" /></a>
+This project exists thanks to all the people who [contribute](CONTRIBUTING.md). <a href="https://github.com/facebook/jest/graphs/contributors"><img src="https://opencollective.com/jest/contributors.svg?width=890&button=false" /></a>
 
 ### [Backers](https://opencollective.com/jest#backer)
 


### PR DESCRIPTION
## Summary

Currently the link in the contributors image points to: https://github.com/facebook/jest/blob/master/graphs/contributors which is a 404.

This PR updates the link to be absolute and points it to https://github.com/facebook/jest/graphs/contributors
