### PR TITLE
print stack trace on calls to process.exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Features
 
-- `[jest-runner]` print stack trace when `process.exit` is called from user code
+- `[jest-runner]` print stack trace when `process.exit` is called from user code ([#6714](https://github.com/facebook/jest/pull/6714))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## master
 
+### Features
+
+- `[jest-runner]` print stack trace when `process.exit` is called from user code
+
 ### Fixes
 
 - `[babel-jest]` Make `getCacheKey()` take into account `createTransformer` options ([#6699](https://github.com/facebook/jest/pull/6699))

--- a/e2e/__tests__/__snapshots__/process_exit.test.js.snap
+++ b/e2e/__tests__/__snapshots__/process_exit.test.js.snap
@@ -10,6 +10,5 @@ exports[`prints stack trace pointing to process.exit call 1`] = `
       4 |   expect(true).toBe(true);
 
       at Object.<anonymous> (__tests__/test.js:1:9)
-
 "
 `;

--- a/e2e/__tests__/__snapshots__/process_exit.test.js.snap
+++ b/e2e/__tests__/__snapshots__/process_exit.test.js.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`prints stack trace pointing to process.exit call 1`] = `
+"  ●  process.exit called with \\"1\\"
+
+    > 1 | process.exit(1);
+        |         ^
+      2 | 
+      3 | test('something', () => {
+      4 |   expect(true).toBe(true);
+
+      at Object.<anonymous> (__tests__/test.js:1:9)
+
+"
+`;

--- a/e2e/__tests__/process_exit.test.js
+++ b/e2e/__tests__/process_exit.test.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+'use strict';
+
+const runJest = require('../runJest');
+
+it('prints stack trace pointing to process.exit call', async () => {
+  const {stderr} = await runJest('process-exit');
+
+  expect(stderr).toMatchSnapshot();
+});

--- a/e2e/process-exit/__tests__/test.js
+++ b/e2e/process-exit/__tests__/test.js
@@ -1,0 +1,5 @@
+process.exit(1);
+
+test('something', () => {
+  expect(true).toBe(true);
+});

--- a/e2e/process-exit/package.json
+++ b/e2e/process-exit/package.json
@@ -1,0 +1,5 @@
+{
+  "jest": {
+    "testEnvironment": "node"
+  }
+}

--- a/packages/jest-runner/src/run_test.js
+++ b/packages/jest-runner/src/run_test.js
@@ -146,7 +146,11 @@ async function runTestInternal(
   // For runtime errors
   sourcemapSupport.install(sourcemapOptions);
 
-  if (environment.global.process && environment.global.process.exit) {
+  if (
+    environment.global &&
+    environment.global.process &&
+    environment.global.process.exit
+  ) {
     const realExit = environment.global.process.exit;
 
     environment.global.process.exit = function exit(...args) {

--- a/packages/jest-runner/src/run_test.js
+++ b/packages/jest-runner/src/run_test.js
@@ -25,6 +25,7 @@ import {
 import LeakDetector from 'jest-leak-detector';
 import {getTestEnvironment} from 'jest-config';
 import * as docblock from 'jest-docblock';
+import {formatExecError} from 'jest-message-util';
 import sourcemapSupport from 'source-map-support';
 
 type RunTestInternalResult = {
@@ -144,6 +145,28 @@ async function runTestInternal(
 
   // For runtime errors
   sourcemapSupport.install(sourcemapOptions);
+
+  const realExit = environment.global.process.exit;
+
+  environment.global.process.exit = function exit(...args) {
+    const error = new Error(`process.exit called with "${args.join(', ')}"`);
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(error, exit);
+    }
+
+    const formattedError = formatExecError(
+      error,
+      config,
+      {noStackTrace: false},
+      undefined,
+      true,
+    );
+
+    global.process.stderr.write(formattedError + '\n');
+
+    return realExit(...args);
+  };
 
   try {
     await environment.setup();

--- a/packages/jest-runner/src/run_test.js
+++ b/packages/jest-runner/src/run_test.js
@@ -168,7 +168,7 @@ async function runTestInternal(
         true,
       );
 
-      global.process.stderr.write(formattedError + '\n');
+      process.stderr.write(formattedError);
 
       return realExit(...args);
     };

--- a/packages/jest-runner/src/run_test.js
+++ b/packages/jest-runner/src/run_test.js
@@ -146,27 +146,29 @@ async function runTestInternal(
   // For runtime errors
   sourcemapSupport.install(sourcemapOptions);
 
-  const realExit = environment.global.process.exit;
+  if (environment.global.process && environment.global.process.exit) {
+    const realExit = environment.global.process.exit;
 
-  environment.global.process.exit = function exit(...args) {
-    const error = new Error(`process.exit called with "${args.join(', ')}"`);
+    environment.global.process.exit = function exit(...args) {
+      const error = new Error(`process.exit called with "${args.join(', ')}"`);
 
-    if (Error.captureStackTrace) {
-      Error.captureStackTrace(error, exit);
-    }
+      if (Error.captureStackTrace) {
+        Error.captureStackTrace(error, exit);
+      }
 
-    const formattedError = formatExecError(
-      error,
-      config,
-      {noStackTrace: false},
-      undefined,
-      true,
-    );
+      const formattedError = formatExecError(
+        error,
+        config,
+        {noStackTrace: false},
+        undefined,
+        true,
+      );
 
-    global.process.stderr.write(formattedError + '\n');
+      global.process.stderr.write(formattedError + '\n');
 
-    return realExit(...args);
-  };
+      return realExit(...args);
+    };
+  }
 
   try {
     await environment.setup();


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary
Currently jest just exits without any helpful info if `process.exit` is invoked from user-code.

See the following test file:

```js
process.exit(1);

test('some test', async () => {
  await new Promise(resolve => setTimeout(resolve, 500));
})
```

It currently looks like this:
![image](https://user-images.githubusercontent.com/1404810/42932846-a78fda12-8b43-11e8-885e-95d6cba72a27.png)

With the changes in this PR it looks like this:
![image](https://user-images.githubusercontent.com/1404810/42932983-fd3d82ac-8b43-11e8-81d3-6cd0ef040740.png)

I wanted to stick it along with the fake `process.send` from #5904, but to format the error I need `config`, and passing that through felt like meh. Can move it there, though?

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan
Integration test added

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
