### PR TITLE
Update webpack.md dynamic import doc for ts-jest

### DIFF
--- a/docs/Webpack.md
+++ b/docs/Webpack.md
@@ -232,5 +232,25 @@ If you use dynamic imports (`import('some-file.js').then(module => ...)`), you n
   }
 }
 ```
+Note that if you're using Jest with Typescript through ts-jest then this configuration may have to be added to your Jest config globals.
+
+```json
+// jest
+{
+  "globals": {
+    "ts-jest": {
+      "tsConfigFile": "../root/tsconfig.test.json",
+      "babelConfig": {
+        "env": {
+          "test": {
+            "plugins": ["dynamic-import-node"]
+          }
+        }
+      }
+    }
+  }
+}
+```
+
 
 For an example of how to use Jest with Webpack with React, Redux, and Node, you can view one [here](https://github.com/jenniferkaplannyc/jest_react_redux_node_webpack_complex_example).


### PR DESCRIPTION
Adding dynamic import plugin to .babelrc when using Jest with Typescript via ts-jest doesn't fully solve the problem of transpiling `import()` calls to `require` when testing. This leaves many TS users wondering why `dynamic-import-node` isn't working for them.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
I'm using a Typescript variation of Create React App that uses ts-jest. After several hours of trying to figure out why adding the dynamic import plugin to my .babelrc wasn't working for me (`import()` kept throwing an `Unexpected Token` error` I finally found this solution in a single comment on Stack Overflow (which I initially overlooked several times) which was not mentioned anywhere else. The goal here is that now the docs will help other devs avoid my pain and struggle. 

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
This PR does not change the UI.
