### PR TITLE
perf(changed-files): limit git and hg commands to specified roots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 ## master
 
-
 ### Performance
 
 - `[jest-changed-files]` limit git and hg commands to specified roots ([#6732](https://github.com/facebook/jest/pull/6732))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## master
 
+
+### Performance
+
+- `[jest-changed-files]` limit git and hg commands to specified roots ([#6732](https://github.com/facebook/jest/pull/6732))
+
 ### Fixes
 
 - `[babel-jest]` Make `getCacheKey()` take into account `createTransformer` options ([#6699](https://github.com/facebook/jest/pull/6699))

--- a/e2e/__tests__/jest_changed_files.test.js
+++ b/e2e/__tests__/jest_changed_files.test.js
@@ -224,7 +224,7 @@ test('gets changed files for git', async () => {
   ).toEqual(['file5.txt']);
 });
 
-test('monitors root paths for git', async () => {
+test('monitors only root paths for git', async () => {
   writeFiles(DIR, {
     'file1.txt': 'file1',
     'nested_dir/file2.txt': 'file2',
@@ -346,7 +346,7 @@ test('gets changed files for hg', async () => {
   ).toEqual(['file5.txt']);
 });
 
-test('monitors root paths for hg', async () => {
+test('monitors only root paths for hg', async () => {
   if (process.env.CI) {
     // Circle and Travis have very old version of hg (v2, and current
     // version is v4.2) and its API changed since then and not compatible

--- a/e2e/__tests__/jest_changed_files.test.js
+++ b/e2e/__tests__/jest_changed_files.test.js
@@ -224,6 +224,27 @@ test('gets changed files for git', async () => {
   ).toEqual(['file5.txt']);
 });
 
+test('should only monitor root paths for git', async () => {
+  writeFiles(DIR, {
+    'file1.txt': 'file1',
+    'nested_dir/file2.txt': 'file2',
+    'nested_dir/second_nested_dir/file3.txt': 'file3',
+  });
+
+  run(`${GIT} init`, DIR);
+
+  const roots = ['nested_dir', 'nested_dir/second_nested_dir'].map(filename =>
+    path.resolve(DIR, filename),
+  );
+
+  const {changedFiles: files} = await getChangedFilesForRoots(roots, {});
+  expect(
+    Array.from(files)
+      .map(filePath => path.basename(filePath))
+      .sort(),
+  ).toEqual(['file2.txt', 'file3.txt']);
+});
+
 test('gets changed files for hg', async () => {
   if (process.env.CI) {
     // Circle and Travis have very old version of hg (v2, and current
@@ -325,4 +346,32 @@ test('gets changed files for hg', async () => {
       .map(filePath => path.basename(filePath))
       .sort(),
   ).toEqual(['file5.txt']);
+});
+
+test('should only monitor root paths for hg', async () => {
+  if (process.env.CI) {
+    // Circle and Travis have very old version of hg (v2, and current
+    // version is v4.2) and its API changed since then and not compatible
+    // any more. Changing the SCM version on CIs is not trivial, so we'll just
+    // skip this test and run it only locally.
+    return;
+  }
+  writeFiles(DIR, {
+    'file1.txt': 'file1',
+    'nested_dir/file2.txt': 'file2',
+    'nested_dir/second_nested_dir/file3.txt': 'file3',
+  });
+
+  run(`${HG} init`, DIR);
+
+  const roots = ['nested_dir', 'nested_dir/second_nested_dir'].map(filename =>
+    path.resolve(DIR, filename),
+  );
+
+  const {changedFiles: files} = await getChangedFilesForRoots(roots, {});
+  expect(
+    Array.from(files)
+      .map(filePath => path.basename(filePath))
+      .sort(),
+  ).toEqual(['file2.txt', 'file3.txt']);
 });

--- a/e2e/__tests__/jest_changed_files.test.js
+++ b/e2e/__tests__/jest_changed_files.test.js
@@ -233,9 +233,7 @@ test('should only monitor root paths for git', async () => {
 
   run(`${GIT} init`, DIR);
 
-  const roots = ['nested_dir', 'nested_dir/second_nested_dir'].map(filename =>
-    path.resolve(DIR, filename),
-  );
+  const roots = [path.resolve(DIR, 'nested_dir')];
 
   const {changedFiles: files} = await getChangedFilesForRoots(roots, {});
   expect(
@@ -364,9 +362,7 @@ test('should only monitor root paths for hg', async () => {
 
   run(`${HG} init`, DIR);
 
-  const roots = ['nested_dir', 'nested_dir/second_nested_dir'].map(filename =>
-    path.resolve(DIR, filename),
-  );
+  const roots = [path.resolve(DIR, 'nested_dir')];
 
   const {changedFiles: files} = await getChangedFilesForRoots(roots, {});
   expect(

--- a/e2e/__tests__/jest_changed_files.test.js
+++ b/e2e/__tests__/jest_changed_files.test.js
@@ -224,7 +224,7 @@ test('gets changed files for git', async () => {
   ).toEqual(['file5.txt']);
 });
 
-test('should only monitor root paths for git', async () => {
+test('monitors root paths for git', async () => {
   writeFiles(DIR, {
     'file1.txt': 'file1',
     'nested_dir/file2.txt': 'file2',
@@ -346,7 +346,7 @@ test('gets changed files for hg', async () => {
   ).toEqual(['file5.txt']);
 });
 
-test('should only monitor root paths for hg', async () => {
+test('monitors root paths for hg', async () => {
   if (process.env.CI) {
     // Circle and Travis have very old version of hg (v2, and current
     // version is v4.2) and its API changed since then and not compatible

--- a/packages/jest-changed-files/src/git.js
+++ b/packages/jest-changed-files/src/git.js
@@ -46,15 +46,16 @@ const findChangedFilesUsingCommand = async (
 const adapter: SCMAdapter = {
   findChangedFiles: async (
     cwd: string,
-    roots: Array<Path>,
     options?: Options,
   ): Promise<Array<Path>> => {
     const changedSince: ?string =
       options && (options.withAncestor ? 'HEAD^' : options.changedSince);
 
+    const includePaths: Array<Path> = (options && options.includePaths) || [];
+
     if (options && options.lastCommit) {
       return await findChangedFilesUsingCommand(
-        ['show', '--name-only', '--pretty=%b', 'HEAD'].concat(roots),
+        ['show', '--name-only', '--pretty=%b', 'HEAD'].concat(includePaths),
         cwd,
       );
     } else if (changedSince) {
@@ -65,16 +66,16 @@ const adapter: SCMAdapter = {
           '--pretty=%b',
           'HEAD',
           `^${changedSince}`,
-        ].concat(roots),
+        ].concat(includePaths),
         cwd,
       );
       const staged = await findChangedFilesUsingCommand(
-        ['diff', '--cached', '--name-only'].concat(roots),
+        ['diff', '--cached', '--name-only'].concat(includePaths),
         cwd,
       );
       const unstaged = await findChangedFilesUsingCommand(
         ['ls-files', '--other', '--modified', '--exclude-standard'].concat(
-          roots,
+          includePaths,
         ),
         cwd,
       );
@@ -82,7 +83,7 @@ const adapter: SCMAdapter = {
     } else {
       return await findChangedFilesUsingCommand(
         ['ls-files', '--other', '--modified', '--exclude-standard'].concat(
-          roots,
+          includePaths,
         ),
         cwd,
       );

--- a/packages/jest-changed-files/src/git.js
+++ b/packages/jest-changed-files/src/git.js
@@ -46,6 +46,7 @@ const findChangedFilesUsingCommand = async (
 const adapter: SCMAdapter = {
   findChangedFiles: async (
     cwd: string,
+    roots: Array<Path>,
     options?: Options,
   ): Promise<Array<Path>> => {
     const changedSince: ?string =
@@ -53,26 +54,36 @@ const adapter: SCMAdapter = {
 
     if (options && options.lastCommit) {
       return await findChangedFilesUsingCommand(
-        ['show', '--name-only', '--pretty=%b', 'HEAD'],
+        ['show', '--name-only', '--pretty=%b', 'HEAD'].concat(roots),
         cwd,
       );
     } else if (changedSince) {
       const committed = await findChangedFilesUsingCommand(
-        ['log', '--name-only', '--pretty=%b', 'HEAD', `^${changedSince}`],
+        [
+          'log',
+          '--name-only',
+          '--pretty=%b',
+          'HEAD',
+          `^${changedSince}`,
+        ].concat(roots),
         cwd,
       );
       const staged = await findChangedFilesUsingCommand(
-        ['diff', '--cached', '--name-only'],
+        ['diff', '--cached', '--name-only'].concat(roots),
         cwd,
       );
       const unstaged = await findChangedFilesUsingCommand(
-        ['ls-files', '--other', '--modified', '--exclude-standard'],
+        ['ls-files', '--other', '--modified', '--exclude-standard'].concat(
+          roots,
+        ),
         cwd,
       );
       return [...committed, ...staged, ...unstaged];
     } else {
       return await findChangedFilesUsingCommand(
-        ['ls-files', '--other', '--modified', '--exclude-standard'],
+        ['ls-files', '--other', '--modified', '--exclude-standard'].concat(
+          roots,
+        ),
         cwd,
       );
     }

--- a/packages/jest-changed-files/src/hg.js
+++ b/packages/jest-changed-files/src/hg.js
@@ -31,17 +31,19 @@ const ANCESTORS = [
 const adapter: SCMAdapter = {
   findChangedFiles: async (
     cwd: string,
+    roots: Array<Path>,
     options: Options,
   ): Promise<Array<Path>> =>
     new Promise((resolve, reject) => {
-      let args = ['status', '-amnu'];
+      const args = ['status', '-amnu'];
       if (options && options.withAncestor) {
         args.push('--rev', `ancestor(${ANCESTORS.join(', ')})`);
       } else if (options && options.changedSince) {
         args.push('--rev', `ancestor(., ${options.changedSince})`);
       } else if (options && options.lastCommit === true) {
-        args = ['tip', '--template', '{files%"{file}\n"}'];
+        args.push('-A');
       }
+      args.push(...roots);
       const child = childProcess.spawn('hg', args, {cwd, env});
       let stdout = '';
       let stderr = '';

--- a/packages/jest-changed-files/src/hg.js
+++ b/packages/jest-changed-files/src/hg.js
@@ -31,10 +31,11 @@ const ANCESTORS = [
 const adapter: SCMAdapter = {
   findChangedFiles: async (
     cwd: string,
-    roots: Array<Path>,
     options: Options,
   ): Promise<Array<Path>> =>
     new Promise((resolve, reject) => {
+      const includePaths: Array<Path> = (options && options.includePaths) || [];
+
       const args = ['status', '-amnu'];
       if (options && options.withAncestor) {
         args.push('--rev', `ancestor(${ANCESTORS.join(', ')})`);
@@ -43,7 +44,7 @@ const adapter: SCMAdapter = {
       } else if (options && options.lastCommit === true) {
         args.push('-A');
       }
-      args.push(...roots);
+      args.push(...includePaths);
       const child = childProcess.spawn('hg', args, {cwd, env});
       let stdout = '';
       let stderr = '';

--- a/packages/jest-changed-files/src/index.js
+++ b/packages/jest-changed-files/src/index.js
@@ -28,11 +28,11 @@ export const getChangedFilesForRoots = async (
   const repos = await findRepos(roots);
 
   const gitPromises = Array.from(repos.git).map(repo =>
-    git.findChangedFiles(repo, options),
+    git.findChangedFiles(repo, roots, options),
   );
 
   const hgPromises = Array.from(repos.hg).map(repo =>
-    hg.findChangedFiles(repo, options),
+    hg.findChangedFiles(repo, roots, options),
   );
 
   const changedFiles = (await Promise.all(

--- a/packages/jest-changed-files/src/index.js
+++ b/packages/jest-changed-files/src/index.js
@@ -27,12 +27,14 @@ export const getChangedFilesForRoots = async (
 ): ChangedFilesPromise => {
   const repos = await findRepos(roots);
 
+  const changedFilesOptions = Object.assign({}, {includePaths: roots}, options);
+
   const gitPromises = Array.from(repos.git).map(repo =>
-    git.findChangedFiles(repo, roots, options),
+    git.findChangedFiles(repo, changedFilesOptions),
   );
 
   const hgPromises = Array.from(repos.hg).map(repo =>
-    hg.findChangedFiles(repo, roots, options),
+    hg.findChangedFiles(repo, changedFilesOptions),
   );
 
   const changedFiles = (await Promise.all(

--- a/types/ChangedFiles.js
+++ b/types/ChangedFiles.js
@@ -23,6 +23,10 @@ export type ChangedFilesPromise = Promise<{|
 |}>;
 
 export type SCMAdapter = {|
-  findChangedFiles: (cwd: Path, options: Options) => Promise<Array<Path>>,
+  findChangedFiles: (
+    cwd: Path,
+    roots: Array<Path>,
+    options: Options,
+  ) => Promise<Array<Path>>,
   getRoot: (cwd: Path) => Promise<?Path>,
 |};

--- a/types/ChangedFiles.js
+++ b/types/ChangedFiles.js
@@ -13,6 +13,7 @@ export type Options = {|
   lastCommit?: boolean,
   withAncestor?: boolean,
   changedSince?: string,
+  includePaths?: Array<Path>,
 |};
 
 export type ChangedFiles = Set<Path>;
@@ -23,10 +24,6 @@ export type ChangedFilesPromise = Promise<{|
 |}>;
 
 export type SCMAdapter = {|
-  findChangedFiles: (
-    cwd: Path,
-    roots: Array<Path>,
-    options: Options,
-  ) => Promise<Array<Path>>,
+  findChangedFiles: (cwd: Path, options: Options) => Promise<Array<Path>>,
   getRoot: (cwd: Path) => Promise<?Path>,
 |};


### PR DESCRIPTION
## Summary

Given a monorepo setup under git version control, we saw `jest --watch` commands take significantly longer in a Docker container host mount (`rw:cached`) than when on the host directly. Tracked the issue down to the fact that `git` and `hg` command used to determine `lastCommit` changes were traversing the entire repository, and not just paths specified in the Jest config `roots` values. Given the mounted container latency, things like basic `lstat` gathering be intensive in a large repository. The `roots` we had specified are rather shallow themselves and only contain things we want to test with Jest. When limiting the scope of the `git` command to just the `roots` paths, we saw change determination drop from 2.5m to 3s in our container.

This implementation seem to align more closely with the [`roots` documentation](https://jestjs.io/docs/en/configuration#roots-array-string) which indicates:

> A list of paths to directories that Jest should use to search for files in.

It did seem a little unexpected that Jest would be traversing our entire repo.


## Test plan

Specs have been added for new functionality a build from this fork is currently being used in multiple environments.

For reference, here is our Jest configuration:

```
"jest": {
    "rootDir": "spec/puppeteer",
    "testPathIgnorePatterns": [
        "__image_snapshots__"
    ],
    "testMatch": [
        "<rootDir>/*_screenshot_spec.js"
    ],
    "reporters": [
        "default",
        [
            "jest-junit",
            {
                "output": "test-results/puppeteer.xml"
            }
        ]
    ],
    "verbose": true
}
```

The `spec/puppeteer` subdirectory contains only a handful of files whereas the project containing the `package.json` itself is quite expansive. A similar environment staging is probably easily recreated.
