### PR TITLE
Fix --coverage with --findRelatedTests overwriting collectCoverageFrom options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `[babel-jest]` Make `getCacheKey()` take into account `createTransformer` options ([#6699](https://github.com/facebook/jest/pull/6699))
 - `[docs]` Fix contributors link ([#6711](https://github.com/facebook/jest/pull/6711))
 - `[website]` Fix website versions page to link to correct language ([#6734](https://github.com/facebook/jest/pull/6734))
+- `[jest-config]` Fix `--coverage` with `--findRelatedTests` overwriting `collectCoverageFrom` options ([#6736](https://github.com/facebook/jest/pull/6736))
 
 ## 23.4.1
 

--- a/e2e/__tests__/__snapshots__/find_related_files.test.js.snap
+++ b/e2e/__tests__/__snapshots__/find_related_files.test.js.snap
@@ -5,7 +5,7 @@ exports[`--findRelatedTests flag coverage configuration is applied correctly 1`]
 Tests:       1 passed, 1 total
 Snapshots:   0 total
 Time:        <<REPLACED>>
-Ran all test suites related to files matching /a.js/i."
+Ran all test suites related to files matching /a.js|b.js/i."
 `;
 
 exports[`--findRelatedTests flag coverage configuration is applied correctly 2`] = `

--- a/e2e/__tests__/__snapshots__/find_related_files.test.js.snap
+++ b/e2e/__tests__/__snapshots__/find_related_files.test.js.snap
@@ -1,5 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`--findRelatedTests flag coverage configuration is applied correctly 1`] = `
+"Test Suites: 1 passed, 1 total
+Tests:       1 passed, 1 total
+Snapshots:   0 total
+Time:        <<REPLACED>>
+Ran all test suites related to files matching /a.js/i."
+`;
+
+exports[`--findRelatedTests flag coverage configuration is applied correctly 2`] = `
+"
+
+PASS __tests__/a.test.js
+✓ a"
+`;
+
+exports[`--findRelatedTests flag coverage configuration is applied correctly 3`] = `
+"----------|----------|----------|----------|----------|-------------------|
+File      |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
+----------|----------|----------|----------|----------|-------------------|
+All files |      100 |      100 |      100 |      100 |                   |
+ a.js     |      100 |      100 |      100 |      100 |                   |
+----------|----------|----------|----------|----------|-------------------|"
+`;
+
 exports[`--findRelatedTests flag generates coverage report for filename 1`] = `
 "Test Suites: 2 passed, 2 total
 Tests:       2 passed, 2 total

--- a/e2e/__tests__/find_related_files.test.js
+++ b/e2e/__tests__/find_related_files.test.js
@@ -123,10 +123,9 @@ describe('--findRelatedTests flag', () => {
         .sort()
         .join('\n'),
     ).toMatchSnapshot();
-    expect(stdout).toMatchSnapshot();
 
     // Only a.js should be in the report
-    const summaryMsg = 'Ran all test suites related to files matching /a.js/i.';
-    expect(stderr).toMatch(summaryMsg);
+    expect(stdout).toMatchSnapshot();
+    expect(stdout).not.toMatch('b.js');
   });
 });

--- a/e2e/__tests__/find_related_files.test.js
+++ b/e2e/__tests__/find_related_files.test.js
@@ -90,4 +90,43 @@ describe('--findRelatedTests flag', () => {
     // coverage should be collected only for a.js
     expect(stdout).toMatchSnapshot();
   });
+
+  test('coverage configuration is applied correctly', () => {
+    writeFiles(DIR, {
+      '.watchmanconfig': '',
+      '__tests__/a.test.js': `
+        require('../a');
+        test('a', () => expect(1).toBe(1));
+      `,
+      'a.js': 'module.exports = {}',
+      'b.js': 'module.exports = {}',
+      'package.json': JSON.stringify({
+        jest: {
+          collectCoverage: true,
+          collectCoverageFrom: ['a.js', '!b.js'],
+          testEnvironment: 'node',
+        },
+      }),
+    });
+
+    const {stdout, stderr} = runJest(DIR, [
+      '--findRelatedTests',
+      'a.js',
+      'b.js',
+    ]);
+    const {summary, rest} = extractSummary(stderr);
+    expect(summary).toMatchSnapshot();
+    expect(
+      rest
+        .split('\n')
+        .map(s => s.trim())
+        .sort()
+        .join('\n'),
+    ).toMatchSnapshot();
+    expect(stdout).toMatchSnapshot();
+
+    // Only a.js should be in the report
+    const summaryMsg = 'Ran all test suites related to files matching /a.js/i.';
+    expect(stderr).toMatch(summaryMsg);
+  });
 });

--- a/e2e/__tests__/find_related_files.test.js
+++ b/e2e/__tests__/find_related_files.test.js
@@ -103,17 +103,16 @@ describe('--findRelatedTests flag', () => {
       'package.json': JSON.stringify({
         jest: {
           collectCoverage: true,
-          collectCoverageFrom: ['a.js', '!b.js'],
+          collectCoverageFrom: ['!b.js', 'a.js'],
           testEnvironment: 'node',
         },
       }),
     });
 
-    const {stdout, stderr} = runJest(DIR, [
-      '--findRelatedTests',
-      'a.js',
-      'b.js',
-    ]);
+    let stdout;
+    let stderr;
+    ({stdout, stderr} = runJest(DIR, ['--findRelatedTests', 'a.js', 'b.js']));
+
     const {summary, rest} = extractSummary(stderr);
     expect(summary).toMatchSnapshot();
     expect(
@@ -126,6 +125,12 @@ describe('--findRelatedTests flag', () => {
 
     // Only a.js should be in the report
     expect(stdout).toMatchSnapshot();
+    expect(stdout).toMatch('a.js');
     expect(stdout).not.toMatch('b.js');
+
+    ({stdout, stderr} = runJest(DIR, ['--findRelatedTests', 'b.js']));
+
+    // Neither a.js or b.js should be in the report
+    expect(stdout).toMatch('No tests found');
   });
 });

--- a/e2e/__tests__/find_related_files.test.js
+++ b/e2e/__tests__/find_related_files.test.js
@@ -132,5 +132,6 @@ describe('--findRelatedTests flag', () => {
 
     // Neither a.js or b.js should be in the report
     expect(stdout).toMatch('No tests found');
+    expect(stderr).toBe('');
   });
 });

--- a/packages/jest-config/package.json
+++ b/packages/jest-config/package.json
@@ -18,9 +18,9 @@
     "jest-jasmine2": "^23.4.1",
     "jest-regex-util": "^23.3.0",
     "jest-resolve": "^23.4.1",
-    "jest-runtime": "^23.4.1",
     "jest-util": "^23.4.0",
     "jest-validate": "^23.4.0",
+    "micromatch": "^2.3.11",
     "pretty-format": "^23.2.0"
   }
 }

--- a/packages/jest-config/package.json
+++ b/packages/jest-config/package.json
@@ -18,6 +18,7 @@
     "jest-jasmine2": "^23.4.1",
     "jest-regex-util": "^23.3.0",
     "jest-resolve": "^23.4.1",
+    "jest-runtime": "^23.4.1",
     "jest-util": "^23.4.0",
     "jest-validate": "^23.4.0",
     "pretty-format": "^23.2.0"


### PR DESCRIPTION
## Summary

Fixes #6462 by adding a check to the `collectCoverage` + `findRelatedTests` normalization.
If there's `collectCoverageFrom` patterns defined in the config it'll reduce (map + filter) to ensure that the generated patterns do not override existing patterns.

It is also no longer overwritten, existing patterns are merged with the dynamic ones.

## Test plan

Expand upon the existing `--findRelatedTests` to cover the specific edge cases related to `collectCoverageFrom` patterns.