### PR TITLE
Fix for Babel7 bridge package name in documentation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - `[jest-haste-map]` [**BREAKING**] Replaced internal data structures to improve performance ([#6960](https://github.com/facebook/jest/pull/6960))
 
+### Chore & Maintenance
+
+- `[docs]` Fix babel-core installation instructions ([#6745](https://github.com/facebook/jest/pull/6745))
+
 ## 23.6.0
 
 ### Features
@@ -76,7 +80,6 @@
 - `[babel-jest]` Make `getCacheKey()` take into account `createTransformer` options ([#6699](https://github.com/facebook/jest/pull/6699))
 - `[jest-jasmine2]` Use prettier through `require` instead of `localRequire`. Fixes `matchInlineSnapshot` where prettier dependencies like `path` and `fs` are mocked with `jest.mock`. ([#6776](https://github.com/facebook/jest/pull/6776))
 - `[docs]` Fix contributors link ([#6711](https://github.com/facebook/jest/pull/6711))
-- `[docs]` Fix babel-core installation instructions ([#6745](https://github.com/facebook/jest/pull/6745))
 - `[website]` Fix website versions page to link to correct language ([#6734](https://github.com/facebook/jest/pull/6734))
 - `[expect]` Update `toContain` suggestion to contain equal message ([#6792](https://github.com/facebook/jest/pull/6810))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@
 - `[babel-jest]` Make `getCacheKey()` take into account `createTransformer` options ([#6699](https://github.com/facebook/jest/pull/6699))
 - `[jest-jasmine2]` Use prettier through `require` instead of `localRequire`. Fixes `matchInlineSnapshot` where prettier dependencies like `path` and `fs` are mocked with `jest.mock`. ([#6776](https://github.com/facebook/jest/pull/6776))
 - `[docs]` Fix contributors link ([#6711](https://github.com/facebook/jest/pull/6711))
+- `[docs]` Fix babel-core installation instructions ([#6745](https://github.com/facebook/jest/pull/6745))
 - `[website]` Fix website versions page to link to correct language ([#6734](https://github.com/facebook/jest/pull/6734))
 - `[expect]` Update `toContain` suggestion to contain equal message ([#6792](https://github.com/facebook/jest/pull/6810))
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ If you'd like to learn more about running `jest` through the command line, take 
 
 [Babel](http://babeljs.io/) is automatically handled by Jest using `babel-jest`. You don't need install anything extra for using Babel.
 
-> Note: If you are using a babel version 7 then you need to install `babel-core@^7.0.0-bridge.0` and `@babel/core` with the following command:
+> Note: If you are using Babel version 7, then you need to install `babel-core@^7.0.0-bridge.0` and `@babel/core` with the following command:
 >
 > ```bash
 > yarn add --dev babel-core@^7.0.0-bridge.0 @babel/core

--- a/README.md
+++ b/README.md
@@ -101,10 +101,10 @@ If you'd like to learn more about running `jest` through the command line, take 
 
 [Babel](http://babeljs.io/) is automatically handled by Jest using `babel-jest`. You don't need install anything extra for using Babel.
 
-> Note: If you are using a babel version 7 then you need to install `babel-core@^7.0.0-0` and `@babel/core` with the following command:
+> Note: If you are using a babel version 7 then you need to install `babel-core@^7.0.0-bridge.0` and `@babel/core` with the following command:
 >
 > ```bash
-> yarn add --dev 'babel-core@^7.0.0-0' @babel/core
+> yarn add --dev 'babel-core@^7.0.0-bridge.0' @babel/core
 > ```
 
 Don't forget to add a [`.babelrc`](https://babeljs.io/docs/usage/babelrc/) file in your project's root folder. For example, if you are using ES6 and [React.js](https://reactjs.org) with the [`babel-preset-env`](https://babeljs.io/docs/plugins/preset-env/) and [`babel-preset-react`](https://babeljs.io/docs/plugins/preset-react/) presets:

--- a/README.md
+++ b/README.md
@@ -101,10 +101,10 @@ If you'd like to learn more about running `jest` through the command line, take 
 
 [Babel](http://babeljs.io/) is automatically handled by Jest using `babel-jest`. You don't need install anything extra for using Babel.
 
-> Note: If you are using Babel version 7, then you need to install `babel-core@^7.0.0-bridge.0` and `@babel/core` with the following command:
+> Note: If you are using Babel version 7 then you need to install `babel-jest`, `babel-core@^7.0.0-bridge.0` and `@babel/core` with the following command:
 >
 > ```bash
-> yarn add --dev babel-core@^7.0.0-bridge.0 @babel/core
+> yarn add --dev babel-jest babel-core@^7.0.0-bridge.0 @babel/core regenerator-runtime
 > ```
 
 Don't forget to add a [`.babelrc`](https://babeljs.io/docs/usage/babelrc/) file in your project's root folder. For example, if you are using ES6 and [React.js](https://reactjs.org) with the [`babel-preset-env`](https://babeljs.io/docs/plugins/preset-env/) and [`babel-preset-react`](https://babeljs.io/docs/plugins/preset-react/) presets:

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ If you'd like to learn more about running `jest` through the command line, take 
 > Note: If you are using a babel version 7 then you need to install `babel-core@^7.0.0-bridge.0` and `@babel/core` with the following command:
 >
 > ```bash
-> yarn add --dev 'babel-core@^7.0.0-bridge.0' @babel/core
+> yarn add --dev babel-core@^7.0.0-bridge.0 @babel/core
 > ```
 
 Don't forget to add a [`.babelrc`](https://babeljs.io/docs/usage/babelrc/) file in your project's root folder. For example, if you are using ES6 and [React.js](https://reactjs.org) with the [`babel-preset-env`](https://babeljs.io/docs/plugins/preset-env/) and [`babel-preset-react`](https://babeljs.io/docs/plugins/preset-react/) presets:

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -85,10 +85,10 @@ To use [Babel](http://babeljs.io/), install the `babel-jest` and `regenerator-ru
 yarn add --dev babel-jest babel-core regenerator-runtime
 ```
 
-> Note: If you are using a babel version 7 then you need to install `babel-jest` with the following command:
+> Note: If you are using Babel version 7 then you need to install `babel-jest` with the following command:
 >
 > ```bash
-> yarn add --dev babel-jest 'babel-core@^7.0.0-0' @babel/core regenerator-runtime
+> yarn add --dev babel-jest babel-core@^7.0.0-bridge.0 @babel/core regenerator-runtime
 > ```
 
 _Note: Explicitly installing `regenerator-runtime` is not needed if you use `npm` 3 or 4 or Yarn_

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -85,7 +85,7 @@ To use [Babel](http://babeljs.io/), install the `babel-jest` and `regenerator-ru
 yarn add --dev babel-jest babel-core regenerator-runtime
 ```
 
-> Note: If you are using Babel version 7 then you need to install `babel-jest` with the following command:
+> Note: If you are using Babel version 7 then you need to install `babel-jest`, `babel-core@^7.0.0-bridge.0` and `@babel/core` with the following command:
 >
 > ```bash
 > yarn add --dev babel-jest babel-core@^7.0.0-bridge.0 @babel/core regenerator-runtime

--- a/website/versioned_docs/version-22.0/GettingStarted.md
+++ b/website/versioned_docs/version-22.0/GettingStarted.md
@@ -78,10 +78,10 @@ To use [Babel](http://babeljs.io/), install the `babel-jest` and `regenerator-ru
 npm install --save-dev babel-jest babel-core regenerator-runtime
 ```
 
-> Note: If you are using a babel version 7 then you need to install `babel-jest` with the following command:
+> Note: If you are using Babel version 7 then you need to install `babel-jest`, `babel-core@^7.0.0-bridge.0` and `@babel/core` with the following command:
 >
-> ```
-> npm install --save-dev babel-jest 'babel-core@^7.0.0-0' @babel/core regenerator-runtime
+> ```bash
+> npm install --save-dev babel-jest babel-core@^7.0.0-bridge.0 @babel/core regenerator-runtime
 > ```
 
 _Note: Explicitly installing `regenerator-runtime` is not needed if you use `npm` 3 or 4 or Yarn_

--- a/website/versioned_docs/version-22.1/GettingStarted.md
+++ b/website/versioned_docs/version-22.1/GettingStarted.md
@@ -78,10 +78,10 @@ To use [Babel](http://babeljs.io/), install the `babel-jest` and `regenerator-ru
 npm install --save-dev babel-jest babel-core regenerator-runtime
 ```
 
-> Note: If you are using a babel version 7 then you need to install `babel-jest` with the following command:
+> Note: If you are using Babel version 7 then you need to install `babel-jest`, `babel-core@^7.0.0-bridge.0` and `@babel/core` with the following command:
 >
-> ```
-> npm install --save-dev babel-jest 'babel-core@^7.0.0-0' @babel/core regenerator-runtime
+> ```bash
+> npm install --save-dev  babel-jest babel-core@^7.0.0-bridge.0 @babel/core regenerator-runtime
 > ```
 
 _Note: Explicitly installing `regenerator-runtime` is not needed if you use `npm` 3 or 4 or Yarn_

--- a/website/versioned_docs/version-22.2/GettingStarted.md
+++ b/website/versioned_docs/version-22.2/GettingStarted.md
@@ -78,10 +78,10 @@ To use [Babel](http://babeljs.io/), install the `babel-jest` and `regenerator-ru
 npm install --save-dev babel-jest babel-core regenerator-runtime
 ```
 
-> Note: If you are using a babel version 7 then you need to install `babel-jest` with the following command:
+> Note: If you are using Babel version 7 then you need to install `babel-jest`, `babel-core@^7.0.0-bridge.0` and `@babel/core` with the following command:
 >
 > ```bash
-> npm install --save-dev babel-jest 'babel-core@^7.0.0-0' @babel/core regenerator-runtime
+> npm install --save-dev babel-jest babel-core@^7.0.0-bridge.0 @babel/core regenerator-runtime
 > ```
 
 _Note: Explicitly installing `regenerator-runtime` is not needed if you use `npm` 3 or 4 or Yarn_

--- a/website/versioned_docs/version-22.3/GettingStarted.md
+++ b/website/versioned_docs/version-22.3/GettingStarted.md
@@ -78,10 +78,10 @@ To use [Babel](http://babeljs.io/), install the `babel-jest` and `regenerator-ru
 npm install --save-dev babel-jest babel-core regenerator-runtime
 ```
 
-> Note: If you are using a babel version 7 then you need to install `babel-jest` with the following command:
+> Note: If you are using Babel version 7 then you need to install `babel-jest`, `babel-core@^7.0.0-bridge.0` and `@babel/core` with the following command:
 >
 > ```bash
-> npm install --save-dev babel-jest 'babel-core@^7.0.0-0' @babel/core regenerator-runtime
+> npm install --save-dev babel-jest babel-core@^7.0.0-bridge.0 @babel/core regenerator-runtime
 > ```
 
 _Note: Explicitly installing `regenerator-runtime` is not needed if you use `npm` 3 or 4 or Yarn_

--- a/website/versioned_docs/version-22.4/GettingStarted.md
+++ b/website/versioned_docs/version-22.4/GettingStarted.md
@@ -78,10 +78,10 @@ To use [Babel](http://babeljs.io/), install the `babel-jest` and `regenerator-ru
 yarn add --dev babel-jest babel-core regenerator-runtime
 ```
 
-> Note: If you are using a babel version 7 then you need to install `babel-jest` with the following command:
+> Note: If you are using Babel version 7 then you need to install `babel-jest`, `babel-core@^7.0.0-bridge.0` and `@babel/core` with the following command:
 >
 > ```bash
-> yarn add --dev babel-jest 'babel-core@^7.0.0-0' @babel/core regenerator-runtime
+> yarn add --dev babel-jest babel-core@^7.0.0-bridge.0 @babel/core regenerator-runtime
 > ```
 
 _Note: Explicitly installing `regenerator-runtime` is not needed if you use `npm` 3 or 4 or Yarn_

--- a/website/versioned_docs/version-23.2/GettingStarted.md
+++ b/website/versioned_docs/version-23.2/GettingStarted.md
@@ -86,10 +86,10 @@ To use [Babel](http://babeljs.io/), install the `babel-jest` and `regenerator-ru
 yarn add --dev babel-jest babel-core regenerator-runtime
 ```
 
-> Note: If you are using a babel version 7 then you need to install `babel-jest` with the following command:
+> Note: If you are using Babel version 7 then you need to install `babel-jest`, `babel-core@^7.0.0-bridge.0` and `@babel/core` with the following command:
 >
 > ```bash
-> yarn add --dev babel-jest 'babel-core@^7.0.0-0' @babel/core regenerator-runtime
+> yarn add --dev babel-jest babel-core@^7.0.0-bridge.0 @babel/core regenerator-runtime
 > ```
 
 _Note: Explicitly installing `regenerator-runtime` is not needed if you use `npm` 3 or 4 or Yarn_


### PR DESCRIPTION
resolves #6720

## Summary

yarn cannot find a package with semvar `^7.0.0-0`. Further, the `7.0.0-beta#` builds do not work. The accurate package version is `^7.0.0-bridge.0`.
![image](https://user-images.githubusercontent.com/343837/42959062-1a4166d0-8b4d-11e8-862e-148f3910b91a.png)
(The quotation marks around the package in the documentation also cause an error.)

## To Reproduce
`yarn add --dev babel-core@^7.0.0-0`

## Expected behavior
The package `babel-core@^7.0.0-bridge.0` should be added.

[Issue in @babel/babel-bridge](https://github.com/babel/babel-bridge/issues/5)

## Test plan

No code changes.