### PR TITLE
packages/babel-jest - fix readme

### DIFF
--- a/packages/babel-jest/README.md
+++ b/packages/babel-jest/README.md
@@ -13,7 +13,7 @@ yarn add --dev babel-jest babel-core
 > Note: If you are using babel version 7 you have to install `babel-jest` with
 >
 > ```bash
-> yarn add --dev babel-jest babel-core@^7.0.0-0 @babel/core
+> yarn add --dev babel-jest 'babel-core@^7.0.0-0' @babel/core
 > ```
 
 If you would like to write your own preprocessor, uninstall and delete babel-jest and set the [config.transform](https://jestjs.io/docs/configuration#transform-object-string-string) option to your preprocessor.


### PR DESCRIPTION
## Summary
I got an error when I tried to use following command from readme:  
```yarn add --dev babel-jest babel-core@^7.0.0-0 @babel/core```
 It should be similar with command from getting the start page (https://jestjs.io/docs/en/getting-started), `babel-core@^7.0.0-0` in single quotes
```yarn add --dev babel-jest 'babel-core@^7.0.0-0' @babel/core``` 

