### PR TITLE
Update Puppeteer.md

### DIFF
--- a/docs/Puppeteer.md
+++ b/docs/Puppeteer.md
@@ -23,17 +23,18 @@ yarn add --dev jest-puppeteer
 }
 ```
 
-3. Write your test
+3.  Write your test
+
 ```js
 describe('Google', () => {
   beforeAll(async () => {
-    await page.goto('https://google.com')
-  })
+    await page.goto('https://google.com');
+  });
 
   it('should display "google" text on page', async () => {
-    await expect(page).toMatch('google')
-  })
-})
+    await expect(page).toMatch('google');
+  });
+});
 ```
 
 There's no need to load any dependencies. Puppeteer's `page` and `browser` classes will automatically be exposed
@@ -52,13 +53,13 @@ Here's an example of the GlobalSetup script
 
 ```js
 // setup.js
-const puppeteer = require('puppeteer')
-const mkdirp = require('mkdirp')
-const path = require('path')
-const fs = require('fs')
-const os = require('os')
+const puppeteer = require('puppeteer');
+const mkdirp = require('mkdirp');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
 
-const DIR = path.join(os.tmpdir(), 'jest_puppeteer_global_setup')
+const DIR = path.join(os.tmpdir(), 'jest_puppeteer_global_setup');
 
 module.exports = async function() {
   const browser = await puppeteer.launch();
@@ -76,13 +77,13 @@ Then we need a custom Test Environment for puppeteer
 
 ```js
 // puppeteer_environment.js
-const NodeEnvironment = require('jest-environment-node')
-const fs = require('fs')
-const path = require('path')
-const puppeteer = require('puppeteer')
-const os = require('os')
+const NodeEnvironment = require('jest-environment-node');
+const fs = require('fs');
+const path = require('path');
+const puppeteer = require('puppeteer');
+const os = require('os');
 
-const DIR = path.join(os.tmpdir(), 'jest_puppeteer_global_setup')
+const DIR = path.join(os.tmpdir(), 'jest_puppeteer_global_setup');
 
 class PuppeteerEnvironment extends NodeEnvironment {
   constructor(config) {
@@ -117,11 +118,11 @@ Finally we can close the puppeteer instance and clean-up the file
 
 ```js
 // teardown.js
-const os = require('os')
-const rimraf = require('rimraf')
-const path = require('path')
+const os = require('os');
+const rimraf = require('rimraf');
+const path = require('path');
 
-const DIR = path.join(os.tmpdir(), 'jest_puppeteer_global_setup')
+const DIR = path.join(os.tmpdir(), 'jest_puppeteer_global_setup');
 module.exports = async function() {
   // close the browser instance
   await global.__BROWSER_GLOBAL__.close();
@@ -135,7 +136,7 @@ With all the things set up, we can now write our tests like this:
 
 ```js
 // test.js
-const timeout = 5000
+const timeout = 5000;
 
 describe(
   '/ (Home Page)',
@@ -156,12 +157,13 @@ describe(
 ```
 
 Finally, set `jest.config.js` to read from these files. (The `jest-puppeteer` preset does something like this under the hood.)
+
 ```js
 module.exports = {
   globalSetup: './setup.js',
   globalTeardown: './teardown.js',
   testEnvironment: './puppeteer_environment.js',
-}
+};
 ```
 
 Here's the code of [full working example](https://github.com/xfumihiro/jest-puppeteer-example).

--- a/docs/Puppeteer.md
+++ b/docs/Puppeteer.md
@@ -5,7 +5,7 @@ title: Using with puppeteer
 
 With the [Global Setup/Teardown](Configuration.md#globalsetup-string) and [Async Test Environment](Configuration.md#testenvironment-string) APIs, Jest can work smoothly with [puppeteer](https://github.com/GoogleChrome/puppeteer).
 
-## Use Puppeteer Preset
+## Use jest-puppeteer Preset
 
 [Jest Puppeteer](https://github.com/smooth-code/jest-puppeteer) provides all required configuration to run your tests using Puppeteer.
 
@@ -23,11 +23,26 @@ yarn add --dev jest-puppeteer
 }
 ```
 
+3. Write your test
+```js
+describe('Google', () => {
+  beforeAll(async () => {
+    await page.goto('https://google.com')
+  })
+
+  it('should display "google" text on page', async () => {
+    await expect(page).toMatch('google')
+  })
+})
+```
+
+There's no need to load any dependencies. Puppeteer's `page` and `browser` classes will automatically be exposed
+
 See [documentation](https://github.com/smooth-code/jest-puppeteer).
 
-## Custom example
+## Custom example without jest-puppeteer preset
 
-The basic idea is to:
+You can also hook up puppeteer from scratch. The basic idea is to:
 
 1.  launch & file the websocket endpoint of puppeteer with Global Setup
 2.  connect to puppeteer from each Test Environment
@@ -37,6 +52,14 @@ Here's an example of the GlobalSetup script
 
 ```js
 // setup.js
+const puppeteer = require('puppeteer')
+const mkdirp = require('mkdirp')
+const path = require('path')
+const fs = require('fs')
+const os = require('os')
+
+const DIR = path.join(os.tmpdir(), 'jest_puppeteer_global_setup')
+
 module.exports = async function() {
   const browser = await puppeteer.launch();
   // store the browser instance so we can teardown it later
@@ -53,6 +76,14 @@ Then we need a custom Test Environment for puppeteer
 
 ```js
 // puppeteer_environment.js
+const NodeEnvironment = require('jest-environment-node')
+const fs = require('fs')
+const path = require('path')
+const puppeteer = require('puppeteer')
+const os = require('os')
+
+const DIR = path.join(os.tmpdir(), 'jest_puppeteer_global_setup')
+
 class PuppeteerEnvironment extends NodeEnvironment {
   constructor(config) {
     super(config);
@@ -86,6 +117,11 @@ Finally we can close the puppeteer instance and clean-up the file
 
 ```js
 // teardown.js
+const os = require('os')
+const rimraf = require('rimraf')
+const path = require('path')
+
+const DIR = path.join(os.tmpdir(), 'jest_puppeteer_global_setup')
 module.exports = async function() {
   // close the browser instance
   await global.__BROWSER_GLOBAL__.close();
@@ -99,6 +135,8 @@ With all the things set up, we can now write our tests like this:
 
 ```js
 // test.js
+const timeout = 5000
+
 describe(
   '/ (Home Page)',
   () => {
@@ -115,6 +153,15 @@ describe(
   },
   timeout,
 );
+```
+
+Finally, set `jest.config.js` to read from these files. (The `jest-puppeteer` preset does something like this under the hood.)
+```js
+module.exports = {
+  globalSetup: './setup.js',
+  globalTeardown: './teardown.js',
+  testEnvironment: './puppeteer_environment.js',
+}
 ```
 
 Here's the code of [full working example](https://github.com/xfumihiro/jest-puppeteer-example).


### PR DESCRIPTION
## Summary

I bumped into three frustrating obstacles while reading the Jest Puppeteer docs today.

1. It wasn't clear that the *Use Puppeteer preset* and *Custom Example* were two separate options. Two sources of confusion exist. First, there's no testing file in the *Use Puppeteer preset* section so I thought I had to keep reading to complete the example. Two, *Custom Example* is a vague title. I've updated the titles and added a sentence to the *Custom Example* section to clarify.
2. It wasn't clear where I was supposed to do the setup, teardown or test environment. At first, I thought I had to import the setup modules into each individual test file. I added a `jest.config.js` section at the bottom of the *Custom Example* section.
3. I wasn't sure which variables were global within the `setup.js`, `teardown.js` and `puppeteer.js` files. Particularly, I was confused where `global` was being defined since I'm not a Node developer. I added `require` statements to each of those files

Lemme know what you guys think!

## Test plan

N/a

I'm not sure if this change requires an update to the CHANGELOG since these are doc updates
