### PR TITLE
[Inline Snapshots] Add test cases for #6744

### DIFF
--- a/e2e/__tests__/__snapshots__/to_match_inline_snapshot.test.js.snap
+++ b/e2e/__tests__/__snapshots__/to_match_inline_snapshot.test.js.snap
@@ -113,3 +113,14 @@ exports[`supports async tests 1`] = `
 });
 "
 `;
+
+exports[`writes snapshots with non-literals in expect(...) 1`] = `
+"it('works with inline snapshots', () => {
+  expect({a: 1}).toMatchInlineSnapshot(\`
+Object {
+  \\"a\\": 1,
+}
+\`);
+});
+"
+`;

--- a/e2e/__tests__/to_match_inline_snapshot.test.js
+++ b/e2e/__tests__/to_match_inline_snapshot.test.js
@@ -163,3 +163,19 @@ test('supports async tests', () => {
   expect(status).toBe(0);
   expect(fileAfter).toMatchSnapshot();
 });
+
+test('writes snapshots with non-literals in expect(...)', () => {
+  const filename = 'async.test.js';
+  const test = `
+    it('works with inline snapshots', () => {
+      expect({a: 1}).toMatchInlineSnapshot();
+    });
+  `;
+
+  writeFiles(TESTS_DIR, {[filename]: test});
+  const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+  const fileAfter = readFile(filename);
+  expect(stderr).toMatch('1 snapshot written from 1 test suite.');
+  expect(status).toBe(0);
+  expect(fileAfter).toMatchSnapshot();
+});

--- a/packages/jest-snapshot/src/__tests__/inline_snapshots.test.js
+++ b/packages/jest-snapshot/src/__tests__/inline_snapshots.test.js
@@ -173,3 +173,30 @@ test('saveInlineSnapshots() uses escaped backticks', () => {
     'expect("`").toMatchInlineSnapshot(`\\``);\n',
   );
 });
+
+test('saveInlineSnapshots() works with non-literals in expect call', () => {
+  const filename = path.join(__dirname, 'my.test.js');
+  fs.readFileSync = (jest.fn(
+    () => `expect({a: 'a'}).toMatchInlineSnapshot();\n`,
+  ): any);
+  prettier.resolveConfig.sync.mockReturnValue({
+    bracketSpacing: false,
+    singleQuote: true,
+  });
+
+  saveInlineSnapshots(
+    [
+      {
+        frame: {column: 18, file: filename, line: 1},
+        snapshot: `{a: 'a'}`,
+      },
+    ],
+    prettier,
+    babelTraverse,
+  );
+
+  expect(fs.writeFileSync).toHaveBeenCalledWith(
+    filename,
+    "expect({a: 'a'}).toMatchInlineSnapshot(`{a: 'a'}`);\n",
+  );
+});


### PR DESCRIPTION
An issue with inline snapshots was raised in #6744, while I could not reproduce it, I did write test cases which could prevent regressions. Feel free to merge or decline 😄 