### PR TITLE
Mark snapshots as obsolete when moved to an inline snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Fixes
 
+- `[jest-snapshot` Mark snapshots as obsolete when moved to an inline snapshot ([#6773](https://github.com/facebook/jest/pull/6773))
 - `[jest-config]` Fix `--coverage` with `--findRelatedTests` overwriting `collectCoverageFrom` options ([#6736](https://github.com/facebook/jest/pull/6736))
 - `[jest-config]` Update default config for testURL from 'about:blank' to 'http://localhost' to address latest JSDOM security warning. ([#6792](https://github.com/facebook/jest/pull/6792))
 

--- a/e2e/__tests__/__snapshots__/to_match_inline_snapshot.test.js.snap
+++ b/e2e/__tests__/__snapshots__/to_match_inline_snapshot.test.js.snap
@@ -96,6 +96,28 @@ Object {
 "
 `;
 
+exports[`removes obsolete external snapshots: external snapshot cleaned 1`] = `
+"test('removes obsolete external snapshots', () => {
+  expect('1').toMatchInlineSnapshot(\`\\"1\\"\`);
+});
+"
+`;
+
+exports[`removes obsolete external snapshots: initial write 1`] = `
+"
+    test('removes obsolete external snapshots', () => {
+      expect('1').toMatchSnapshot();
+    });
+  "
+`;
+
+exports[`removes obsolete external snapshots: inline snapshot written 1`] = `
+"test('removes obsolete external snapshots', () => {
+  expect('1').toMatchInlineSnapshot(\`\\"1\\"\`);
+});
+"
+`;
+
 exports[`supports async matchers 1`] = `
 "test('inline snapshots', async () => {
   expect(Promise.resolve('success')).resolves.toMatchInlineSnapshot(

--- a/e2e/__tests__/to_match_inline_snapshot.test.js
+++ b/e2e/__tests__/to_match_inline_snapshot.test.js
@@ -130,6 +130,54 @@ test('handles property matchers', () => {
   }
 });
 
+test('removes obsolete external snapshots', () => {
+  const filename = 'removes-obsolete-external-snapshots.test.js';
+  const snapshotPath = path.join(
+    TESTS_DIR,
+    '__snapshots__',
+    filename + '.snap',
+  );
+  const template = makeTemplate(`
+    test('removes obsolete external snapshots', () => {
+      expect('1').$1();
+    });
+  `);
+
+  {
+    writeFiles(TESTS_DIR, {[filename]: template(['toMatchSnapshot'])});
+    const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+    const fileAfter = readFile(filename);
+    expect(stderr).toMatch('1 snapshot written from 1 test suite.');
+    expect(status).toBe(0);
+    expect(fileAfter).toMatchSnapshot('initial write');
+    expect(fs.existsSync(snapshotPath)).toEqual(true);
+  }
+
+  {
+    writeFiles(TESTS_DIR, {[filename]: template(['toMatchInlineSnapshot'])});
+    const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+    const fileAfter = readFile(filename);
+    expect(stderr).toMatch('Snapshots:   1 obsolete, 1 written, 1 total');
+    expect(status).toBe(1);
+    expect(fileAfter).toMatchSnapshot('inline snapshot written');
+    expect(fs.existsSync(snapshotPath)).toEqual(true);
+  }
+
+  {
+    const {stderr, status} = runJest(DIR, [
+      '-w=1',
+      '--ci=false',
+      filename,
+      '-u',
+    ]);
+    const fileAfter = readFile(filename);
+    expect(stderr).toMatch('Snapshots:   1 file removed, 1 passed, 1 total');
+    expect(status).toBe(0);
+    expect(fileAfter).toMatchSnapshot('external snapshot cleaned');
+    expect(fs.existsSync(snapshotPath)).toEqual(false);
+  }
+});
+
 test('supports async matchers', () => {
   const filename = 'async-matchers.test.js';
   const test = `

--- a/packages/jest-snapshot/src/State.js
+++ b/packages/jest-snapshot/src/State.js
@@ -170,7 +170,12 @@ export default class SnapshotState {
       key = testNameToKey(testName, count);
     }
 
-    this._uncheckedKeys.delete(key);
+    // Do not mark the snapshot as "checked" if the snapshot is inline and
+    // there's an external snapshot. This way the external snapshot can be
+    // removed with `--updateSnapshot`.
+    if (!(isInline && this._snapshotData[key])) {
+      this._uncheckedKeys.delete(key);
+    }
 
     const receivedSerialized = serialize(received);
     const expected = isInline ? inlineSnapshot : this._snapshotData[key];


### PR DESCRIPTION
## Summary

Currently when a snapshot is migrated from `toMatchSnapshot` to `toMatchInlineSnapshot`, the external snapshot becomes orphaned and there is no way to remove it (other than manually editing/deleting the file).

This change marks the migrated snapshot as obsolete, thus it can be deleted with `--updateSnapshot`.

```
Snapshots:   1 obsolete, 1 written, 1 total
```

## Test plan

Added an E2E test that writes an external snapshot, changes the code to `toMatchInlineSnapshot`, then runs Jest without `-u` to verify the snapshot is marked as obsolete, then with `-u` to verify the snapshot is removed.

Fixes #6655
