### PR TITLE
fix: `matchInlineSnapshot` when prettier dependencies are mocked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixes
 
 - `[babel-jest]` Make `getCacheKey()` take into account `createTransformer` options ([#6699](https://github.com/facebook/jest/pull/6699))
+- `[jest-jasmine2]` Use prettier through `require` instead of `localRequire`. Fixes `matchInlineSnapshot` where prettier dependencies like `path` and `fs` are mocked with `jest.mock`. ([#6776](https://github.com/facebook/jest/pull/6776))
 - `[docs]` Fix contributors link ([#6711](https://github.com/facebook/jest/pull/6711))
 - `[website]` Fix website versions page to link to correct language ([#6734](https://github.com/facebook/jest/pull/6734))
 

--- a/e2e/__tests__/to_match_inline_snapshot.test.js
+++ b/e2e/__tests__/to_match_inline_snapshot.test.js
@@ -163,3 +163,20 @@ test('supports async tests', () => {
   expect(status).toBe(0);
   expect(fileAfter).toMatchSnapshot();
 });
+
+// issue: https://github.com/facebook/jest/issues/6702
+test('handles mocking native modules prettier relies on', () => {
+  const filename = 'mockFail.test.js';
+  const test = `
+    jest.mock('path', () => ({}));
+    jest.mock('fs', () => ({}));
+    test('inline snapshots', () => {
+      expect({}).toMatchInlineSnapshot();
+    });
+  `;
+
+  writeFiles(TESTS_DIR, {[filename]: test});
+  const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+  expect(stderr).toMatch('1 snapshot written from 1 test suite.');
+  expect(status).toBe(0);
+});

--- a/packages/jest-jasmine2/src/setup_jest_globals.js
+++ b/packages/jest-jasmine2/src/setup_jest_globals.js
@@ -102,7 +102,8 @@ export default ({
     expand,
     getBabelTraverse: () => require('babel-traverse').default,
     getPrettier: () =>
-      config.prettierPath ? localRequire(config.prettierPath) : null,
+      // $FlowFixMe dynamic require
+      config.prettierPath ? require(config.prettierPath) : null,
     updateSnapshot,
   });
   setState({snapshotState, testPath});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary
This PR fixes https://github.com/facebook/jest/issues/6702 by seizing to local require prettier in jest-jasmine2. Instead `require(config.prettierPath)` is used. This prevents the issue where mocking native modules like `path` and `fs` that prettier depends on would cause `toMatchInlineSnapshot` to fail.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan
Run the new unit test introduced in this PR.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
