### PR TITLE
Update testURL default value from about:blank to localhost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixes
 
+- `[jest-config]` Update default config for testURL from 'about:blank' to 'http://localhost' to address latest JSDOM security warning. ([#6792](https://github.com/facebook/jest/pull/6792))
 - `[jest-circus]` Fix retryTimes so errors are reset before re-running ([#6762](https://github.com/facebook/jest/pull/6762))
 - `[docs]` Update `expect.objectContaining()` description ([#6754](https://github.com/facebook/jest/pull/6754))
 - `[babel-jest]` Make `getCacheKey()` take into account `createTransformer` options ([#6699](https://github.com/facebook/jest/pull/6699))

--- a/e2e/__tests__/__snapshots__/show_config.test.js.snap
+++ b/e2e/__tests__/__snapshots__/show_config.test.js.snap
@@ -59,7 +59,7 @@ exports[`--showConfig outputs config info and exits 1`] = `
       ],
       \\"testRegex\\": \\"\\",
       \\"testRunner\\": \\"<<REPLACED_JEST_PACKAGES_DIR>>/jest-jasmine2/build/index.js\\",
-      \\"testURL\\": \\"about:blank\\",
+      \\"testURL\\": \\"http://localhost\\",
       \\"timers\\": \\"real\\",
       \\"transform\\": [
         [

--- a/packages/jest-cli/src/lib/__tests__/__snapshots__/init.test.js.snap
+++ b/packages/jest-cli/src/lib/__tests__/__snapshots__/init.test.js.snap
@@ -174,7 +174,7 @@ module.exports = {
   // testRunner: \\"jasmine2\\",
 
   // This option sets the URL for the jsdom environment. It is reflected in properties such as location.href
-  // testURL: \\"about:blank\\",
+  // testURL: \\"http://localhost\\",
 
   // Setting this value to \\"fake\\" allows the use of fake timers for functions such as \\"setTimeout\\"
   // timers: \\"real\\",

--- a/packages/jest-config/src/defaults.js
+++ b/packages/jest-config/src/defaults.js
@@ -72,7 +72,7 @@ export default ({
   testRegex: '',
   testResultsProcessor: null,
   testRunner: 'jasmine2',
-  testURL: 'about:blank',
+  testURL: 'http://localhost',
   timers: 'real',
   transform: null,
   transformIgnorePatterns: [NODE_MODULES_REGEXP],

--- a/packages/jest-config/src/valid_config.js
+++ b/packages/jest-config/src/valid_config.js
@@ -96,7 +96,7 @@ export default ({
   testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.jsx?$',
   testResultsProcessor: 'processor-node-module',
   testRunner: 'jasmine2',
-  testURL: 'about:blank',
+  testURL: 'http://localhost',
   timers: 'real',
   transform: {
     '^.+\\.js$': '<rootDir>/preprocessor.js',

--- a/packages/jest-validate/src/__tests__/fixtures/jest_config.js
+++ b/packages/jest-validate/src/__tests__/fixtures/jest_config.js
@@ -51,7 +51,7 @@ const defaultConfig = {
   testPathIgnorePatterns: [NODE_MODULES_REGEXP],
   testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.jsx?$',
   testResultsProcessor: null,
-  testURL: 'about:blank',
+  testURL: 'http://localhost',
   timers: 'real',
   transformIgnorePatterns: [NODE_MODULES_REGEXP],
   useStderr: false,
@@ -116,7 +116,7 @@ const validConfig = {
   testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.jsx?$',
   testResultsProcessor: 'processor-node-module',
   testRunner: 'jasmine2',
-  testURL: 'about:blank',
+  testURL: 'http://localhost',
   timers: 'real',
   transform: {
     '^.+\\.js$': '<rootDir>/preprocessor.js',


### PR DESCRIPTION
## Summary

Updates jests default value for testURL from 'about:blank' to 'http://localhost'.
This ensures that JSDOM doesn't throw a security error for tests using the jsdom environment.

Should fix https://github.com/facebook/jest/issues/6766

## Test plan

All tests pass

cc @thymikee @SimenB 