### PR TITLE
Add package.json compatiblity with new beta versions of babel core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Fixes
 
+- `[babel-jest]` Fix warning with `babel-core` during `npm install` or `yarn install`
 - `[jest-config]` Fix `--coverage` with `--findRelatedTests` overwriting `collectCoverageFrom` options ([#6736](https://github.com/facebook/jest/pull/6736))
 - `[jest-config]` Update default config for testURL from 'about:blank' to 'http://localhost' to address latest JSDOM security warning. ([#6792](https://github.com/facebook/jest/pull/6792))
 

--- a/packages/babel-jest/package.json
+++ b/packages/babel-jest/package.json
@@ -16,6 +16,6 @@
     "babel-core": "^6.0.0"
   },
   "peerDependencies": {
-    "babel-core": "^6.0.0 || ^7.0.0-0"
+    "babel-core": "^6.0.0 || ^7.0.0-0 || ^7.0.0-beta.56"
   }
 }


### PR DESCRIPTION
## Summary
While `npm install` or `yarn install`, to remove the warning that is caused by no compatibility to compare the beta version of `@babel/core`.
```
warning " > babel-jest@23.4.2" has unmet peer dependency "babel-core@^6.0.0 || ^7.0.0-0".
```

## Test plan
1 - On `npm install` or `yarn install`, the warning seems to have gone on my Ubuntu 18.04 LTS.