### PR TITLE
[Docs] Clarified the use of literal values as property matchers in toMatchSnapshot()

### DIFF
--- a/docs/ExpectAPI.md
+++ b/docs/ExpectAPI.md
@@ -1025,7 +1025,7 @@ test('this house has my desired features', () => {
 
 This ensures that a value matches the most recent snapshot. Check out [the Snapshot Testing guide](SnapshotTesting.md) for more information.
 
-The optional `propertyMatchers` argument allows you to specify asymmetric matchers which are verified instead of the exact values.
+The optional `propertyMatchers` argument allows you to specify asymmetric matchers which are verified instead of the exact values. Any value will be matched exactly if not provided as a matcher.
 
 The last argument allows you option to specify a snapshot name. Otherwise, the name is inferred from the test.
 

--- a/docs/SnapshotTesting.md
+++ b/docs/SnapshotTesting.md
@@ -187,7 +187,7 @@ Object {
 `;
 ```
 
-Any given value that is not a matcher will be checked exactly and saved to the snaptshot:
+Any given value that is not a matcher will be checked exactly and saved to the snapshot:
 
 ```javascript
 it('will check the values and pass', () => {

--- a/docs/SnapshotTesting.md
+++ b/docs/SnapshotTesting.md
@@ -187,6 +187,30 @@ Object {
 `;
 ```
 
+Any given value that is not a matcher will be checked exactly and saved to the snaptshot:
+
+```javascript
+it('will check the values and pass', () => {
+  const user = {
+    createdAt: new Date(),
+    name: 'Bond... James Bond',
+  };
+
+  expect(user).toMatchSnapshot({
+    createdAt: expect.any(Date),
+    name: 'Bond... James Bond',
+  });
+});
+
+// Snapshot
+exports[`will check the values and pass 1`] = `
+Object {
+  "createdAt": Any<Date>,
+  "name": 'Bond... James Bond',
+}
+`;
+```
+
 ## Best Practices
 
 Snapshots are a fantastic tool for identifying unexpected interface changes within your application – whether that interface is an API response, UI, logs, or error messages. As with any testing strategy, there are some best-practices you should be aware of, and guidelines you should follow, in order to use them effectively.


### PR DESCRIPTION
## Summary

Docs are updated to clarify the use of literal values when used as property matchers, as opposed to just asymmetric matchers. The actual behaviour is to check and pass any value as it is but the docs weren't clear about that.

Closes #6774.