### PR TITLE
Mock "exit" in "process"

### DIFF
--- a/packages/jest-util/src/create_process_object.js
+++ b/packages/jest-util/src/create_process_object.js
@@ -90,6 +90,7 @@ export default function() {
   }
 
   newProcess.env = createProcessEnv();
+  newProcess.exit = () => {};
   newProcess.send = () => {};
 
   return newProcess;


### PR DESCRIPTION
Since functions exposed in `process` are the real ones, `exit` is being exposed as-is. The issue is that calling `process.exit` with a zero exit code might trick the workers, thinking the execution was stopped.

Pretty much like we do with `send`, we will override it with an empty method that does nothin.