### PR TITLE
fix: show stack traces on async assert errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - `[jest-cli]` Update jest-cli to show git ref in message when using `changedSince` ([#7028](https://github.com/facebook/jest/pull/7028))
 - `[jest-jasmine2`] Fix crash when test return Promise rejected with null ([#7049](https://github.com/facebook/jest/pull/7049))
 - `[jest-runtime]` Check `_isMockFunction` is true rather than truthy on potential global mocks ([#7017](https://github.com/facebook/jest/pull/7017))
+- `[jest-jasmine]` Show proper error message from async `assert` errors ([#6821](https://github.com/facebook/jest/pull/6821))
 
 ### Chore & Maintenance
 

--- a/e2e/__tests__/__snapshots__/failures.test.js.snap
+++ b/e2e/__tests__/__snapshots__/failures.test.js.snap
@@ -456,6 +456,7 @@ exports[`works with node assert 1`] = `
   ✕ assert.ifError
   ✕ assert.doesNotThrow
   ✕ assert.throws
+  ✕ async
 
   ● assert
 
@@ -809,8 +810,42 @@ exports[`works with node assert 1`] = `
          |          ^
       78 | });
       79 | 
+      80 | test('async', async () => {
 
       at __tests__/node_assertion_error.test.js:77:10
+
+  ● async
+
+    assert.equal(received, expected) or assert(received) 
+
+    Expected value to be equal to:
+      \\"hello\\"
+    Received:
+      \\"hello
+    goodbye\\"
+
+    Message:
+      hmmm
+
+    Difference:
+
+    - Expected
+    + Received
+
+      hello
+    + goodbye
+
+      79 | 
+      80 | test('async', async () => {
+    > 81 |   assert.equal('hello\\\\ngoodbye', 'hello', 'hmmm');
+         |          ^
+      82 | });
+      83 | 
+
+      at __tests__/node_assertion_error.test.js:81:10
+      at __tests__/node_assertion_error.test.js:12:191
+      at __tests__/node_assertion_error.test.js:12:437
+      at __tests__/node_assertion_error.test.js:12:99
 
 "
 `;

--- a/e2e/failures/__tests__/node_assertion_error.test.js
+++ b/e2e/failures/__tests__/node_assertion_error.test.js
@@ -76,3 +76,7 @@ test('assert.doesNotThrow', () => {
 test('assert.throws', () => {
   assert.throws(() => {});
 });
+
+test('async', async () => {
+  assert.equal('hello\ngoodbye', 'hello', 'hmmm');
+});

--- a/packages/jest-jasmine2/src/jasmine/Env.js
+++ b/packages/jest-jasmine2/src/jasmine/Env.js
@@ -30,9 +30,11 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 /* eslint-disable sort-keys */
 
+import {AssertionError} from 'assert';
 import queueRunner from '../queue_runner';
 import treeProcessor from '../tree_processor';
 import checkIsError from '../is_error';
+import assertionErrorMessage from '../assert_support';
 
 // Try getting the real promise object from the context, if available. Someone
 // could have overridden it in a test. Async functions return it implicitly.
@@ -547,7 +549,18 @@ export default function(j$) {
     };
 
     this.fail = function(error) {
-      const {isError, message} = checkIsError(error);
+      let isError;
+      let message;
+
+      if (error instanceof AssertionError) {
+        isError = false;
+        message = assertionErrorMessage(error, {expand: j$.Spec.expand});
+      } else {
+        const check = checkIsError(error);
+
+        isError = check.isError;
+        message = check.message;
+      }
 
       currentRunnable().addExpectationResult(false, {
         matcherName: '',


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary
While jest-circus worked just like it should (🎉), jest-jasmine only checked for node assert on thrown errors, not rejected ones (from async errors).

Not sure about the best way to fix the test assertion for Circus. Failure looks like this: 
![image](https://user-images.githubusercontent.com/1404810/43923342-cc241dcc-9c21-11e8-8153-d9fe723b5270.png)

Fixes #6752

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan
Test added

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
