### PR TITLE
[Docs] Fixed bug in example code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,10 +28,8 @@
 ### Chore & Maintenance
 
 - `[docs]` Document another option to avoid warnings with React 16 ([#5258](https://github.com/facebook/jest/issues/5258))
-
-### Chore & Maintenance
-
 - `[docs]` Add note explaining when `jest.setTimeout` should be called ([#6817](https://github.com/facebook/jest/pull/6817/files))
+- `[docs]` Fixed bug in example code ([#6828](https://github.com/facebook/jest/pull/6828))
 
 ## 23.4.2
 

--- a/website/versioned_docs/version-22.0/TutorialReact.md
+++ b/website/versioned_docs/version-22.0/TutorialReact.md
@@ -191,7 +191,7 @@ export default class CheckboxWithLabel extends React.Component {
   }
 
   onChange() {
-    this.setState({isChecked: !this.state.isChecked});
+    this.setState(prevState => ({isChecked: !prevState.isChecked}));
   }
 
   render() {

--- a/website/versioned_docs/version-22.1/TutorialReact.md
+++ b/website/versioned_docs/version-22.1/TutorialReact.md
@@ -220,7 +220,7 @@ export default class CheckboxWithLabel extends React.Component {
   }
 
   onChange() {
-    this.setState({isChecked: !this.state.isChecked});
+    this.setState(prevState => ({isChecked: !prevState.isChecked}));
   }
 
   render() {

--- a/website/versioned_docs/version-22.2/TutorialReact.md
+++ b/website/versioned_docs/version-22.2/TutorialReact.md
@@ -220,7 +220,7 @@ export default class CheckboxWithLabel extends React.Component {
   }
 
   onChange() {
-    this.setState({isChecked: !this.state.isChecked});
+    this.setState(prevState => ({isChecked: !prevState.isChecked}));
   }
 
   render() {

--- a/website/versioned_docs/version-22.3/TutorialReact.md
+++ b/website/versioned_docs/version-22.3/TutorialReact.md
@@ -220,7 +220,7 @@ export default class CheckboxWithLabel extends React.Component {
   }
 
   onChange() {
-    this.setState({isChecked: !this.state.isChecked});
+    this.setState(prevState => ({isChecked: !prevState.isChecked}));
   }
 
   render() {

--- a/website/versioned_docs/version-22.4/TutorialReact.md
+++ b/website/versioned_docs/version-22.4/TutorialReact.md
@@ -220,7 +220,7 @@ export default class CheckboxWithLabel extends React.Component {
   }
 
   onChange() {
-    this.setState({isChecked: !this.state.isChecked});
+    this.setState(prevState => ({isChecked: !prevState.isChecked}));
   }
 
   render() {

--- a/website/versioned_docs/version-23.0/TutorialReact.md
+++ b/website/versioned_docs/version-23.0/TutorialReact.md
@@ -226,7 +226,7 @@ export default class CheckboxWithLabel extends React.Component {
   }
 
   onChange() {
-    this.setState({isChecked: !this.state.isChecked});
+    this.setState(prevState => ({isChecked: !prevState.isChecked}));
   }
 
   render() {


### PR DESCRIPTION
# Summary

Fixed bug in example code: mutated the previous state without the use of a callback in _setState_
