### PR TITLE
add `toBeEmpty` matcher to expect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## master
 
+### Features
+
+- `[expect]` Add `toBeEmpty` matcher ([#????]https://github.com/facebook/jest/pull/????)
+
 ## 23.5.0
 
 ### Features

--- a/docs/ExpectAPI.md
+++ b/docs/ExpectAPI.md
@@ -886,12 +886,27 @@ describe('the La Croix cans on my desk', () => {
 
 Use `.toHaveLength` to check that an object has a `.length` property and it is set to a certain numeric value.
 
-This is especially useful for checking arrays or strings size.
+This is especially useful for checking arrays or strings size. 
+
+Before using `.toHaveLength(0)`, consider `.toBeEmpty()` instead.
 
 ```js
 expect([1, 2, 3]).toHaveLength(3);
 expect('abc').toHaveLength(3);
 expect('').not.toHaveLength(5);
+```
+
+### `.toBeEmpty()`
+
+Use `.toBeEmpty` to check that an object's `.length` property is equal to `0`.
+
+This is especially useful for checking for empty arrays or strings.
+
+```js
+expect("").toBeEmpty();
+expect([]).toBeEmpty();
+expect([1, 2, 3]).not.toBeEmpty();
+expect(" ").not.toBeEmpty();
 ```
 
 ### `.toMatch(regexpOrString)`

--- a/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -584,6 +584,44 @@ exports[`.toBeDefined(), .toBeUndefined() undefined is undefined 2`] = `
 Received: <red>undefined</>"
 `;
 
+exports[`.toBeEmpty does not accept arguments 1`] = `
+"<dim>expect(</><red>received</><dim>)[.not].toBeEmpty(</><dim>)</>
+
+Matcher does not accept any arguments.
+Got:
+  boolean: <green>false</>"
+`;
+
+exports[`.toBeEmpty error cases 1`] = `
+"<dim>expect(</><red>received</><dim>).toBeEmpty(</><dim>)</>
+
+Received: <red>\\"a\\"</>"
+`;
+
+exports[`.toBeEmpty error cases 2`] = `
+"<dim>expect(</><red>received</><dim>).</>not<dim>.toBeEmpty(</><dim>)</>
+
+Received: <red>\\"\\"</>"
+`;
+
+exports[`.toBeEmpty refuses to considers an object with a non-numeric length property 1`] = `
+"<dim>expect(</><red>received</><dim>)[.not].toHaveLength(</><green>length</><dim>)</>
+
+Expected value to have a 'length' property that is a number. Received:
+  <red>{\\"length\\": \\"not a number\\"}</>
+received.length:
+  <red>\\"not a number\\"</>"
+`;
+
+exports[`.toBeEmpty refuses to considers an object without a length property 1`] = `
+"<dim>expect(</><red>received</><dim>)[.not].toHaveLength(</><green>length</><dim>)</>
+
+Expected value to have a 'length' property that is a number. Received:
+  <red>123</>
+received.length:
+  <red>undefined</>"
+`;
+
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() equal numbers: [-Infinity, -Infinity] 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.toBeGreaterThanOrEqual(</><green>expected</><dim>)</>
 

--- a/packages/expect/src/__tests__/matchers.test.js
+++ b/packages/expect/src/__tests__/matchers.test.js
@@ -617,6 +617,63 @@ describe('.toBeDefined(), .toBeUndefined()', () => {
   });
 });
 
+
+describe('.toBeEmpty', () => {
+  it('does not accept arguments', () => {
+    expect(() => jestExpect([]).toBeEmpty(false)).toThrowErrorMatchingSnapshot();
+  });
+  
+  it('considers [] to be empty', () => {
+    jestExpect([]).toBeEmpty();
+  });
+
+  it('considers "" to be empty', () => {
+    jestExpect('').toBeEmpty();
+  });
+
+  it('considers [1] to not be empty', () => {
+    jestExpect([1]).not.toBeEmpty();
+  });
+
+  it('considers "a" to not be empty', () => {
+    jestExpect('a').not.toBeEmpty();
+  });
+
+  it('considers " " to not be empty', () => {
+    jestExpect(' ').not.toBeEmpty();
+  });
+
+  it('considers a custom object with a length property of 0 to be empty', () => {
+    jestExpect({length: 0}).toBeEmpty();
+  });
+
+  it('considers a custom object with a length property of 1 to not be empty', () => {
+    jestExpect({length: 1}).not.toBeEmpty();
+  });
+
+  it('refuses to considers an object without a length property', () => {
+    expect(() =>
+      jestExpect(123).toBeEmpty()
+    ).toThrowErrorMatchingSnapshot();
+  });
+
+  it('refuses to considers an object with a non-numeric length property', () => {
+    expect(() =>
+      jestExpect({length: 'not a number'}).toBeEmpty()
+    ).toThrowErrorMatchingSnapshot();
+  });
+
+  test('error cases', () => {
+    expect(() =>
+      jestExpect("a").toBeEmpty()
+    ).toThrowErrorMatchingSnapshot();
+
+    expect(() =>
+      jestExpect("").not.toBeEmpty()
+    ).toThrowErrorMatchingSnapshot();
+  });
+});
+
 describe(
   '.toBeGreaterThan(), .toBeLessThan(), ' +
     '.toBeGreaterThanOrEqual(), .toBeLessThanOrEqual()',

--- a/packages/expect/src/matchers.js
+++ b/packages/expect/src/matchers.js
@@ -111,6 +111,35 @@ const matchers: MatchersObject = {
     return {message, pass};
   },
 
+  toBeEmpty(actual: any, expected: void) {
+    ensureNoExpected(expected, '.toBeEmpty');
+
+    if (
+      typeof actual !== 'string' &&
+      (!actual || typeof actual.length !== 'number')
+    ) {
+      throw new Error(
+        matcherHint('[.not].toHaveLength', 'received', 'length') +
+          '\n\n' +
+          `Expected value to have a 'length' property that is a number. ` +
+          `Received:\n` +
+          `  ${printReceived(actual)}\n` +
+          (actual
+            ? `received.length:\n  ${printReceived(actual.length)}`
+            : ''),
+      );
+    }
+
+    const pass = actual.length === 0;
+    const message = () =>
+      matcherHint('.toBeEmpty', 'received', '', {
+        isNot: this.isNot,
+      }) +
+      '\n\n' +
+      `Received: ${printReceived(actual)}`;
+    return {message, pass};
+  },
+
   toBeFalsy(actual: any, expected: void) {
     ensureNoExpected(expected, '.toBeFalsy');
     const pass = !actual;


### PR DESCRIPTION
## Summary

Tests expectations like `expect(errors).toBeEmpty()` are slightly clearer and more expressive than `expect(errors).toHaveLength(0)`. 

Having a matcher that specifically captures the semantics of emptiness (as opposed to length) also opens the door for future enhancements like support for checking emptiness of things like `Set`, `Map`, as well as testing emptiness for iterators which might represent infinite sequences.

(If this new matcher is of interest then I'd be game to pick up the follow-on work of support for `Set`, etc.)

## Test plan
Includes tests for both positive and negative cases, plus snapshot tests for different error cases.