### PR TITLE
[jest-each]: Add flag to prevent done callback being supplied to describe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - `[docs]` Add custom toMatchSnapshot matcher docs ([#6837](https://github.com/facebook/jest/pull/6837))
 
+### Fixes
+
+- `[jest-each`] Prevent done callback being supplied to describe ([#6843](https://github.com/facebook/jest/pull/6843))
+
 ## 23.5.0
 
 ### Features

--- a/packages/jest-circus/src/index.js
+++ b/packages/jest-circus/src/index.js
@@ -121,9 +121,9 @@ test.each = bindEach(test);
 test.only.each = bindEach(test.only);
 test.skip.each = bindEach(test.skip);
 
-describe.each = bindEach(describe);
-describe.only.each = bindEach(describe.only);
-describe.skip.each = bindEach(describe.skip);
+describe.each = bindEach(describe, false);
+describe.only.each = bindEach(describe.only, false);
+describe.skip.each = bindEach(describe.skip, false);
 
 module.exports = {
   afterAll,

--- a/packages/jest-each/src/__tests__/array.test.js
+++ b/packages/jest-each/src/__tests__/array.test.js
@@ -15,6 +15,26 @@ const expectFunction = expect.any(Function);
 const get = (object, lensPath) =>
   lensPath.reduce((acc, key) => acc[key], object);
 
+const getGlobalTestMocks = () => {
+  const globals = {
+    describe: jest.fn(),
+    fdescribe: jest.fn(),
+    fit: jest.fn(),
+    it: jest.fn(),
+    test: jest.fn(),
+    xdescribe: jest.fn(),
+    xit: jest.fn(),
+    xtest: jest.fn(),
+  };
+  globals.test.only = jest.fn();
+  globals.test.skip = jest.fn();
+  globals.it.only = jest.fn();
+  globals.it.skip = jest.fn();
+  globals.describe.only = jest.fn();
+  globals.describe.skip = jest.fn();
+  return globals;
+};
+
 describe('jest-each', () => {
   [
     ['test'],
@@ -27,20 +47,6 @@ describe('jest-each', () => {
     ['describe', 'only'],
   ].forEach(keyPath => {
     describe(`.${keyPath.join('.')}`, () => {
-      const getGlobalTestMocks = () => {
-        const globals = {
-          describe: jest.fn(),
-          fdescribe: jest.fn(),
-          fit: jest.fn(),
-          it: jest.fn(),
-          test: jest.fn(),
-        };
-        globals.test.only = jest.fn();
-        globals.it.only = jest.fn();
-        globals.describe.only = jest.fn();
-        return globals;
-      };
-
       test('calls global with given title', () => {
         const globalTestMocks = getGlobalTestMocks();
         const eachObject = each.withGlobal(globalTestMocks)([[]]);
@@ -237,18 +243,6 @@ describe('jest-each', () => {
         expect(testCallBack).toHaveBeenCalledWith('joe', 'bloggs');
       });
 
-      test('calls global with async done when cb function has more args than params of given test row', () => {
-        const globalTestMocks = getGlobalTestMocks();
-        const eachObject = each.withGlobal(globalTestMocks)([['hello']]);
-
-        const testFunction = get(eachObject, keyPath);
-        testFunction('expected string', (hello, done) => {
-          expect(hello).toBe('hello');
-          expect(done).toBe('DONE');
-        });
-        get(globalTestMocks, keyPath).mock.calls[0][1]('DONE');
-      });
-
       test('calls global with given timeout', () => {
         const globalTestMocks = getGlobalTestMocks();
         const eachObject = each.withGlobal(globalTestMocks)([['hello']]);
@@ -265,6 +259,45 @@ describe('jest-each', () => {
     });
   });
 
+  describe('done callback', () => {
+    test.each([
+      [['test']],
+      [['test', 'only']],
+      [['it']],
+      [['fit']],
+      [['it', 'only']],
+    ])(
+      'calls %O with done when cb function has more args than params of given test row',
+      keyPath => {
+        const globalTestMocks = getGlobalTestMocks();
+        const eachObject = each.withGlobal(globalTestMocks)([['hello']]);
+
+        const testFunction = get(eachObject, keyPath);
+        testFunction('expected string', (hello, done) => {
+          expect(hello).toBe('hello');
+          expect(done).toBe('DONE');
+        });
+        get(globalTestMocks, keyPath).mock.calls[0][1]('DONE');
+      },
+    );
+
+    test.each([[['describe']], [['fdescribe']], [['describe', 'only']]])(
+      'does not call %O with done when test function has more args than params of given test row',
+      keyPath => {
+        const globalTestMocks = getGlobalTestMocks();
+        const eachObject = each.withGlobal(globalTestMocks)([['hello']]);
+
+        const testFunction = get(eachObject, keyPath);
+        testFunction('expected string', function(hello, done) {
+          expect(hello).toBe('hello');
+          expect(arguments.length).toBe(1);
+          expect(done).toBe(undefined);
+        });
+        get(globalTestMocks, keyPath).mock.calls[0][1]('DONE');
+      },
+    );
+  });
+
   [
     ['xtest'],
     ['test', 'skip'],
@@ -274,24 +307,6 @@ describe('jest-each', () => {
     ['describe', 'skip'],
   ].forEach(keyPath => {
     describe(`.${keyPath.join('.')}`, () => {
-      const getGlobalTestMocks = () => {
-        const globals = {
-          describe: {
-            skip: jest.fn(),
-          },
-          it: {
-            skip: jest.fn(),
-          },
-          test: {
-            skip: jest.fn(),
-          },
-          xdescribe: jest.fn(),
-          xit: jest.fn(),
-          xtest: jest.fn(),
-        };
-        return globals;
-      };
-
       test('calls global with given title', () => {
         const globalTestMocks = getGlobalTestMocks();
         const eachObject = each.withGlobal(globalTestMocks)([[]]);

--- a/packages/jest-each/src/__tests__/template.test.js
+++ b/packages/jest-each/src/__tests__/template.test.js
@@ -14,6 +14,26 @@ const expectFunction = expect.any(Function);
 const get = (object, lensPath) =>
   lensPath.reduce((acc, key) => acc[key], object);
 
+const getGlobalTestMocks = () => {
+  const globals = {
+    describe: jest.fn(),
+    fdescribe: jest.fn(),
+    fit: jest.fn(),
+    it: jest.fn(),
+    test: jest.fn(),
+    xdescribe: jest.fn(),
+    xit: jest.fn(),
+    xtest: jest.fn(),
+  };
+  globals.test.only = jest.fn();
+  globals.test.skip = jest.fn();
+  globals.it.only = jest.fn();
+  globals.it.skip = jest.fn();
+  globals.describe.only = jest.fn();
+  globals.describe.skip = jest.fn();
+  return globals;
+};
+
 describe('jest-each', () => {
   [
     ['test'],
@@ -26,20 +46,6 @@ describe('jest-each', () => {
     ['describe', 'only'],
   ].forEach(keyPath => {
     describe(`.${keyPath.join('.')}`, () => {
-      const getGlobalTestMocks = () => {
-        const globals = {
-          describe: jest.fn(),
-          fdescribe: jest.fn(),
-          fit: jest.fn(),
-          it: jest.fn(),
-          test: jest.fn(),
-        };
-        globals.test.only = jest.fn();
-        globals.it.only = jest.fn();
-        globals.describe.only = jest.fn();
-        return globals;
-      };
-
       test('throws error when there are fewer arguments than headings when given one row', () => {
         const globalTestMocks = getGlobalTestMocks();
         const eachObject = each.withGlobal(globalTestMocks)`
@@ -228,22 +234,6 @@ describe('jest-each', () => {
         expect(testCallBack).toHaveBeenCalledWith({a: 1, b: 1, expected: 2});
       });
 
-      test('calls global with async done when cb function has more than one argument', () => {
-        const globalTestMocks = getGlobalTestMocks();
-        const eachObject = each.withGlobal(globalTestMocks)`
-          a    | b    | expected
-          ${0} | ${1} | ${1}
-        `;
-        const testFunction = get(eachObject, keyPath);
-        testFunction('expected string', ({a, b, expected}, done) => {
-          expect(a).toBe(0);
-          expect(b).toBe(1);
-          expect(expected).toBe(1);
-          expect(done).toBe('DONE');
-        });
-        get(globalTestMocks, keyPath).mock.calls[0][1]('DONE');
-      });
-
       test('calls global with given timeout', () => {
         const globalTestMocks = getGlobalTestMocks();
         const eachObject = each.withGlobal(globalTestMocks)`
@@ -263,6 +253,53 @@ describe('jest-each', () => {
     });
   });
 
+  describe('done callback', () => {
+    test.each([
+      [['test']],
+      [['test', 'only']],
+      [['it']],
+      [['fit']],
+      [['it', 'only']],
+    ])(
+      'calls %O with done when cb function has more args than params of given test row',
+      keyPath => {
+        const globalTestMocks = getGlobalTestMocks();
+        const eachObject = each.withGlobal(globalTestMocks)`
+        a    | b    | expected
+        ${0} | ${1} | ${1}
+      `;
+        const testFunction = get(eachObject, keyPath);
+        testFunction('expected string', ({a, b, expected}, done) => {
+          expect(a).toBe(0);
+          expect(b).toBe(1);
+          expect(expected).toBe(1);
+          expect(done).toBe('DONE');
+        });
+        get(globalTestMocks, keyPath).mock.calls[0][1]('DONE');
+      },
+    );
+
+    test.each([[['describe']], [['fdescribe']], [['describe', 'only']]])(
+      'does not call %O with done when test function has more args than params of given test row',
+      keyPath => {
+        const globalTestMocks = getGlobalTestMocks();
+        const eachObject = each.withGlobal(globalTestMocks)`
+        a    | b    | expected
+        ${0} | ${1} | ${1}
+      `;
+        const testFunction = get(eachObject, keyPath);
+        testFunction('expected string', function({a, b, expected}, done) {
+          expect(a).toBe(0);
+          expect(b).toBe(1);
+          expect(expected).toBe(1);
+          expect(done).toBe(undefined);
+          expect(arguments.length).toBe(1);
+        });
+        get(globalTestMocks, keyPath).mock.calls[0][1]('DONE');
+      },
+    );
+  });
+
   [
     ['xtest'],
     ['test', 'skip'],
@@ -272,24 +309,6 @@ describe('jest-each', () => {
     ['describe', 'skip'],
   ].forEach(keyPath => {
     describe(`.${keyPath.join('.')}`, () => {
-      const getGlobalTestMocks = () => {
-        const globals = {
-          describe: {
-            skip: jest.fn(),
-          },
-          it: {
-            skip: jest.fn(),
-          },
-          test: {
-            skip: jest.fn(),
-          },
-          xdescribe: jest.fn(),
-          xit: jest.fn(),
-          xtest: jest.fn(),
-        };
-        return globals;
-      };
-
       test('calls global with given title', () => {
         const globalTestMocks = getGlobalTestMocks();
         const eachObject = each.withGlobal(globalTestMocks)`

--- a/packages/jest-each/src/bind.js
+++ b/packages/jest-each/src/bind.js
@@ -119,12 +119,10 @@ const applyRestParams = (
   supportsDone: boolean,
   params: Array<any>,
   test: Function,
-) => {
-  if (supportsDone && params.length < test.length)
-    return done => test(...params, done);
-
-  return () => test(...params);
-};
+) =>
+  supportsDone && params.length < test.length
+    ? done => test(...params, done)
+    : () => test(...params);
 
 const getHeadingKeys = (headings: string): Array<string> =>
   headings.replace(/\s/g, '').split('|');
@@ -157,11 +155,8 @@ const interpolate = (title: string, data: any) =>
     .reduce(getMatchingKeyPaths(title), []) // aka flatMap
     .reduce(replaceKeyPathWithValue(data), title);
 
-const applyObjectParams = (supportsDone: boolean, obj: any, test: Function) => {
-  if (supportsDone && test.length > 1) return done => test(obj, done);
-
-  return () => test(obj);
-};
+const applyObjectParams = (supportsDone: boolean, obj: any, test: Function) =>
+  supportsDone && test.length > 1 ? done => test(obj, done) : () => test(obj);
 
 const pluralize = (word: string, count: number) =>
   word + (count === 1 ? '' : 's');

--- a/packages/jest-each/src/index.js
+++ b/packages/jest-each/src/index.js
@@ -36,11 +36,11 @@ const install = (g: GlobalCallbacks, ...args: Array<mixed>) => {
   const xtest = bind(g.xtest)(...args);
 
   const describe = (title: string, suite: Function, timeout: number) =>
-    bind(g.describe)(...args)(title, suite, timeout);
-  describe.skip = bind(g.describe.skip)(...args);
-  describe.only = bind(g.describe.only)(...args);
-  const fdescribe = bind(g.fdescribe)(...args);
-  const xdescribe = bind(g.xdescribe)(...args);
+    bind(g.describe, false)(...args)(title, suite, timeout);
+  describe.skip = bind(g.describe.skip, false)(...args);
+  describe.only = bind(g.describe.only, false)(...args);
+  const fdescribe = bind(g.fdescribe, false)(...args);
+  const xdescribe = bind(g.xdescribe, false)(...args);
 
   return {describe, fdescribe, fit, it, test, xdescribe, xit, xtest};
 };

--- a/packages/jest-jasmine2/src/each.js
+++ b/packages/jest-jasmine2/src/each.js
@@ -15,7 +15,16 @@ export default (environment: Environment): void => {
   environment.global.it.each = bindEach(environment.global.it);
   environment.global.fit.each = bindEach(environment.global.fit);
   environment.global.xit.each = bindEach(environment.global.xit);
-  environment.global.describe.each = bindEach(environment.global.describe);
-  environment.global.xdescribe.each = bindEach(environment.global.xdescribe);
-  environment.global.fdescribe.each = bindEach(environment.global.fdescribe);
+  environment.global.describe.each = bindEach(
+    environment.global.describe,
+    false,
+  );
+  environment.global.xdescribe.each = bindEach(
+    environment.global.xdescribe,
+    false,
+  );
+  environment.global.fdescribe.each = bindEach(
+    environment.global.fdescribe,
+    false,
+  );
 };


### PR DESCRIPTION
## Summary

Currently `jest-each` assumes if a test callback has more arguments than supplied in the data (array/template) then the extra argument is a `done` callback. This logic should not apply for `describe` blocks as they do not support `done` callbacks (or any args for that matter).

Fixes: #6838 

## Test plan

Updated unit tests to check `describe` blocks aren't invoked with `done`