### PR TITLE
[docs] Fix MockFunctions: implementation is not provided

### DIFF
--- a/docs/MockFunctions.md
+++ b/docs/MockFunctions.md
@@ -22,7 +22,7 @@ function forEach(items, callback) {
 To test this function, we can use a mock function, and inspect the mock's state to ensure the callback is invoked as expected.
 
 ```javascript
-const mockCallback = jest.fn();
+const mockCallback = jest.fn(x => 42 + x);
 forEach([0, 1], mockCallback);
 
 // The mock function is called twice


### PR DESCRIPTION
This PR fixes an issue with the current documentation: https://jestjs.io/docs/en/mock-functions#using-a-mock-function

I think the reader may be confused by the example in the section "Using a mock function".
Consider these few lines taken from the example:
```js
const mockCallback = jest.fn();
forEach([0, 1], mockCallback);
// ... snip ...
// The return value of the first call to the function was 42
expect(mockCallback.mock.results[0].value).toBe(42);
```
The last assertion is actually going to fail: we didn't provide an implementation for our mock. The return value is `undefined`.

With this PR, I configured the mock with a custom implementation `x => 42 + x` so that the assertion will pass.

Another solution would be to remove the last assertion entirely from the example. This is especially true if we don't want to overload the reader with too much information about `mock implementations` (which is anyway covered later in the page).