### PR TITLE
improve "preset not found" error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - `[jest-cli]` Fix incorrect `testEnvironmentOptions` warning ([#6852](https://github.com/facebook/jest/pull/6852))
 - `[jest-each`] Prevent done callback being supplied to describe ([#6843](https://github.com/facebook/jest/pull/6843))
+- `[jest-config`] Better error message for a case when a preset module was found, but no `jest-preset.js` or `jest-preset.json` at the root ([#6863](https://github.com/facebook/jest/pull/6863))
 
 ### Chore & Maintenance
 

--- a/packages/jest-config/src/__tests__/__snapshots__/normalize.test.js.snap
+++ b/packages/jest-config/src/__tests__/__snapshots__/normalize.test.js.snap
@@ -17,6 +17,16 @@ exports[`Upgrade help logs a warning when \`scriptPreprocessor\` and/or \`prepro
 <yellow></>"
 `;
 
+exports[`preset throws when module was found but no "jest-preset.js" or "jest-preset.json" files 1`] = `
+"<red><bold><bold>● <bold>Validation Error</>:</>
+<red></>
+<red>  Module <bold>exist-but-no-jest-preset</> should have \\"jest-preset.js\\" or \\"jest-preset.json\\" file at the root.</>
+<red></>
+<red>  <bold>Configuration Documentation:</></>
+<red>  https://jestjs.io/docs/configuration.html</>
+<red></>"
+`;
+
 exports[`preset throws when preset not found 1`] = `
 "<red><bold><bold>● <bold>Validation Error</>:</>
 <red></>

--- a/packages/jest-config/src/__tests__/normalize.test.js
+++ b/packages/jest-config/src/__tests__/normalize.test.js
@@ -885,6 +885,11 @@ describe('preset', () => {
       if (name === 'react-native/jest-preset') {
         return '/node_modules/react-native/jest-preset.json';
       }
+
+      if (name === 'doesnt-exist') {
+        return null;
+      }
+
       return '/node_modules/' + name;
     });
     jest.doMock(
@@ -915,6 +920,15 @@ describe('preset', () => {
       }),
       {virtual: true},
     );
+    jest.mock(
+      '/node_modules/exist-but-no-jest-preset/index.js',
+      () => ({
+        moduleNameMapper: {
+          js: true,
+        },
+      }),
+      {virtual: true},
+    );
   });
 
   afterEach(() => {
@@ -926,6 +940,18 @@ describe('preset', () => {
       normalize(
         {
           preset: 'doesnt-exist',
+          rootDir: '/root/path/foo',
+        },
+        {},
+      );
+    }).toThrowErrorMatchingSnapshot();
+  });
+
+  test('throws when module was found but no "jest-preset.js" or "jest-preset.json" files', () => {
+    expect(() => {
+      normalize(
+        {
+          preset: 'exist-but-no-jest-preset',
           rootDir: '/root/path/foo',
         },
         {},

--- a/packages/jest-config/src/normalize.js
+++ b/packages/jest-config/src/normalize.js
@@ -90,6 +90,19 @@ const setupPreset = (
         `  Preset ${chalk.bold(presetPath)} is invalid:\n  ${error.message}`,
       );
     }
+
+    const preset = Resolver.findNodeModule(presetPath, {
+      basedir: options.rootDir,
+    });
+
+    if (preset) {
+      throw createConfigError(
+        `  Module ${chalk.bold(
+          presetPath,
+        )} should have "jest-preset.js" or "jest-preset.json" file at the root.`,
+      );
+    }
+
     throw createConfigError(`  Preset ${chalk.bold(presetPath)} not found.`);
   }
 


### PR DESCRIPTION
## Summary
After the discussion on #6538

This PR adds a descriptive error message for a case when preset module exists but doesn't have `jest-preset.js` or `jest-preset.json` files at the root

## Test plan

Add a test case for it in `normalize.test.js`