### PR TITLE
[DOCS] Clarify --projects CLI option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - `[docs]` Add custom toMatchSnapshot matcher docs ([#6837](https://github.com/facebook/jest/pull/6837))
 - `[docs]` Improve the documentation regarding preset configuration ([#6864](https://github.com/facebook/jest/issues/6864))
+- `[docs]` Clarify usage of `--projects` CLI option ([#6872](https://github.com/facebook/jest/pull/6872))
 
 ## 23.5.0
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -215,7 +215,7 @@ Allows the test suite to pass when no files are found.
 
 ### `--projects <path1> ... <pathN>`
 
-Run tests from one or more projects, found in the specified paths; also takes path globs. This option is the CLI equivalent of the [`projects`](configuration#projects-arraystring--projectconfig) configuration option. Note that if configuration files are found in the specified paths, _all_ projects specified within those configuration files will be run. 
+Run tests from one or more projects, found in the specified paths; also takes path globs. This option is the CLI equivalent of the [`projects`](configuration#projects-arraystring--projectconfig) configuration option. Note that if configuration files are found in the specified paths, _all_ projects specified within those configuration files will be run.
 
 ### `--reporters`
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -213,9 +213,9 @@ Alias: `-o`. Attempts to identify which tests to run based on which files have c
 
 Allows the test suite to pass when no files are found.
 
-### `--projects <project1> ... <projectN>`
+### `--projects <path1> ... <pathN>`
 
-Run tests from one or more projects.
+Run tests from one or more projects, found in the specified paths; also takes path globs. This option is the CLI equivalent of the [`projects`](configuration#projects-arraystring--projectconfig) configuration option. Note that if configuration files are found in the specified paths, _all_ projects specified within those configuration files will be run. 
 
 ### `--reporters`
 


### PR DESCRIPTION
## Summary

Several of us have been bitten by `--projects` doing something different than expected, so this PR adds clarification to the docs.

As requested by @SimenB in #5595 with a smiley, which made all the difference.
