### PR TITLE
Replace YAML extension of adamvoss with redhat

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,7 +3,7 @@
   // for the documentation about the extensions.json format
   "recommendations": [
     "dbaeumer.vscode-eslint",
-    "adamvoss.yaml",
+    "redhat.vscode-yaml",
     "flowtype.flow-for-vscode",
     "esbenp.prettier-vscode",
     "Orta.vscode-jest"


### PR DESCRIPTION
adamvoss.yaml is unpublished from Marketplace
https://marketplace.visualstudio.com/items?itemName=adamvoss.yaml

The one by Redhat is most popular (with 1.6M installs)
https://marketplace.visualstudio.com/search?term=YAML&target=VSCode

VSCode shows the following error with adamvoss.yaml recommendation:
![screenshot from 2018-08-27 19-44-58](https://user-images.githubusercontent.com/16024985/44697726-e6f90900-aa31-11e8-90f1-83338d01f542.png)


<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
