### PR TITLE
Added support for babel.config.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## master
 
+### Features
+
+- `[babel-jest]` Add support for `babel.config.js` added in Babel 7.0.0 ([#6911](https://github.com/facebook/jest/pull/6911))
+
 ### Fixes
 
 - `[expect]` Fix variadic custom asymmetric matchers ([#6898](https://github.com/facebook/jest/pull/6898))

--- a/packages/babel-jest/src/index.js
+++ b/packages/babel-jest/src/index.js
@@ -24,6 +24,7 @@ import babelIstanbulPlugin from 'babel-plugin-istanbul';
 
 const BABELRC_FILENAME = '.babelrc';
 const BABELRC_JS_FILENAME = '.babelrc.js';
+const BABEL_CONFIG_JS_FILENAME = 'babel.config.js';
 const BABEL_CONFIG_KEY = 'babel';
 const PACKAGE_JSON = 'package.json';
 const THIS_FILE = fs.readFileSync(__filename);
@@ -45,7 +46,13 @@ const createTransformer = (options: any): Transformer => {
         cache[directory] = fs.readFileSync(configFilePath, 'utf8');
         break;
       }
-      const configJsFilePath = path.join(directory, BABELRC_JS_FILENAME);
+      let configJsFilePath = path.join(directory, BABELRC_JS_FILENAME);
+      if (fs.existsSync(configJsFilePath)) {
+        // $FlowFixMe
+        cache[directory] = JSON.stringify(require(configJsFilePath));
+        break;
+      }
+      configJsFilePath = path.join(directory, BABEL_CONFIG_JS_FILENAME);
       if (fs.existsSync(configJsFilePath)) {
         // $FlowFixMe
         cache[directory] = JSON.stringify(require(configJsFilePath));


### PR DESCRIPTION
## Summary

Fixes #6908 

With the arrival of Babel 7.0.0 comes support for `.js` configuration files from Babel.

[See here for details.](https://babeljs.io/blog/2018/08/27/7.0.0#javascript-config-files)

> We are introducing babel.config.js. It isn't a requirement or even a replacement for .babelrc, but having this may be useful in certain cases.

> *.js configuration files are fairly common in the JavaScript ecosystem. ESLint and Webpack both allow for .eslintrc.js and webpack.config.js configuration files, respectively.

This PR adds support for the new config file added by the Babel team.
