### PR TITLE
`[expect]` Fix TypeError in `toBeInstanceOf` on `null` or `undefined`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixes
 
+- `[expect]` Fix TypeError in `toBeInstanceOf` on `null` or `undefined` ([#6912](https://github.com/facebook/jest/pull/6912))
 - `[jest-jasmine2]` Throw a descriptive error if the first argument supplied to a hook was not a function ([#6917](https://github.com/facebook/jest/pull/6917))
 - `[jest-circus]` Throw a descriptive error if the first argument supplied to a hook was not a function ([#6917](https://github.com/facebook/jest/pull/6917))
 - `[expect]` Fix variadic custom asymmetric matchers ([#6898](https://github.com/facebook/jest/pull/6898))

--- a/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -1082,7 +1082,7 @@ exports[`.toBeInstanceOf() failing null and [Function String] 1`] = `
 "<dim>expect(</><red>value</><dim>).toBeInstanceOf(</><green>constructor</><dim>)</>
 
 Expected constructor: <green>String</>
-Received constructor:
+Received constructor: 
 Received value: <red>null</>"
 `;
 
@@ -1098,7 +1098,7 @@ exports[`.toBeInstanceOf() failing undefined and [Function String] 1`] = `
 "<dim>expect(</><red>value</><dim>).toBeInstanceOf(</><green>constructor</><dim>)</>
 
 Expected constructor: <green>String</>
-Received constructor:
+Received constructor: 
 Received value: <red>undefined</>"
 `;
 

--- a/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -1078,12 +1078,28 @@ Received constructor: <red>Number</>
 Received value: <red>1</>"
 `;
 
+exports[`.toBeInstanceOf() failing null and [Function String] 1`] = `
+"<dim>expect(</><red>value</><dim>).toBeInstanceOf(</><green>constructor</><dim>)</>
+
+Expected constructor: <green>String</>
+Received constructor:
+Received value: <red>null</>"
+`;
+
 exports[`.toBeInstanceOf() failing true and [Function Boolean] 1`] = `
 "<dim>expect(</><red>value</><dim>).toBeInstanceOf(</><green>constructor</><dim>)</>
 
 Expected constructor: <green>Boolean</>
 Received constructor: <red>Boolean</>
 Received value: <red>true</>"
+`;
+
+exports[`.toBeInstanceOf() failing undefined and [Function String] 1`] = `
+"<dim>expect(</><red>value</><dim>).toBeInstanceOf(</><green>constructor</><dim>)</>
+
+Expected constructor: <green>String</>
+Received constructor:
+Received value: <red>undefined</>"
 `;
 
 exports[`.toBeInstanceOf() passing [] and [Function Array] 1`] = `

--- a/packages/expect/src/__tests__/matchers.test.js
+++ b/packages/expect/src/__tests__/matchers.test.js
@@ -500,6 +500,8 @@ describe('.toBeInstanceOf()', () => {
     [true, Boolean],
     [new A(), B],
     [Object.create(null), A],
+    [undefined, String],
+    [null, String],
   ].forEach(([a, b]) => {
     test(`failing ${stringify(a)} and ${stringify(b)}`, () => {
       expect(() =>

--- a/packages/expect/src/matchers.js
+++ b/packages/expect/src/matchers.js
@@ -183,7 +183,9 @@ const matchers: MatchersObject = {
             constructor.name || String(constructor),
           )}\n` +
           `Received constructor: ${RECEIVED_COLOR(
-            received.constructor && received.constructor.name,
+            received !== undefined && received !== null
+              ? received.constructor && received.constructor.name
+              : '',
           )}\n` +
           `Received value: ${printReceived(received)}`;
 

--- a/packages/expect/src/matchers.js
+++ b/packages/expect/src/matchers.js
@@ -183,7 +183,7 @@ const matchers: MatchersObject = {
             constructor.name || String(constructor),
           )}\n` +
           `Received constructor: ${RECEIVED_COLOR(
-            received !== undefined && received !== null
+            received != null
               ? received.constructor && received.constructor.name
               : '',
           )}\n` +


### PR DESCRIPTION
## Summary

When using `toBeInstanceOf()` on an `undefined` or `null` value Jest attempts to use `undefined.constructor` in its error message, which throws a TypeError along the lines of "TypeError: Cannot read property 'constructor' of undefined"

This makes the matcher more robust and returns a normal matcher error along the lines of "Expected X, received X"

## Test plan

Also added two snapshot tests for `toBeInstanceOf()` for `undefined` and `null` and confirmed reasonable error messages are now returned for these values.