### PR TITLE
Mock inherited static properties and methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - `[jest-cli]` Fix incorrect `testEnvironmentOptions` warning ([#6852](https://github.com/facebook/jest/pull/6852))
 - `[jest-each]` Prevent done callback being supplied to describe ([#6843](https://github.com/facebook/jest/pull/6843))
 - `[jest-config]` Better error message for a case when a preset module was found, but no `jest-preset.js` or `jest-preset.json` at the root ([#6863](https://github.com/facebook/jest/pull/6863))
-- `[jest-mock]` Fix inheritance of static properties and methods in mocks ([#6863](https://github.com/facebook/jest/pull/6921))
+- `[jest-mock]` Fix inheritance of static properties and methods in mocks ([#6921](https://github.com/facebook/jest/pull/6921))
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - `[jest-cli]` Fix incorrect `testEnvironmentOptions` warning ([#6852](https://github.com/facebook/jest/pull/6852))
 - `[jest-each]` Prevent done callback being supplied to describe ([#6843](https://github.com/facebook/jest/pull/6843))
 - `[jest-config]` Better error message for a case when a preset module was found, but no `jest-preset.js` or `jest-preset.json` at the root ([#6863](https://github.com/facebook/jest/pull/6863))
+- `[jest-mock]` Fix inheritance of static properties and methods in mocks ([#6863](https://github.com/facebook/jest/pull/6921))
 
 ### Chore & Maintenance
 

--- a/packages/jest-mock/src/__tests__/jest_mock.test.js
+++ b/packages/jest-mock/src/__tests__/jest_mock.test.js
@@ -185,6 +185,24 @@ describe('moduleMocker', () => {
       expect(instanceFooMock.toString.mock).not.toBeUndefined();
     });
 
+    it('mocks ES2015 non-enumerable static properties and methods', () => {
+      class ClassFoo {
+        static foo() {}
+      }
+      ClassFoo.fooProp = () => {};
+
+      class ClassBar extends ClassFoo {}
+
+      const ClassBarMock = moduleMocker.generateFromMetadata(
+        moduleMocker.getMetadata(ClassBar),
+      );
+
+      expect(typeof ClassBarMock.foo).toBe('function');
+      expect(typeof ClassBarMock.fooProp).toBe('function');
+      expect(ClassBarMock.foo.mock).not.toBeUndefined();
+      expect(ClassBarMock.fooProp.mock).not.toBeUndefined();
+    });
+
     it('mocks methods that are bound multiple times', () => {
       const func = function func() {};
       const multipleBoundFunc = func.bind(null).bind(null);

--- a/packages/jest-mock/src/index.js
+++ b/packages/jest-mock/src/index.js
@@ -690,7 +690,9 @@ class ModuleMockerClass {
           if (
             (!component.hasOwnProperty && component[slot] !== undefined) ||
             (component.hasOwnProperty && component.hasOwnProperty(slot)) ||
-            (type === 'object' && component[slot] != Object.prototype[slot])
+            (type === 'object' && component[slot] != Object.prototype[slot]) ||
+            // $FlowFixMe `Function` definition does not include `prototype`
+            (type === 'function' && component[slot] != Function.prototype[slot])
           ) {
             const slotMetadata = this.getMetadata(component[slot], refs);
             if (slotMetadata) {


### PR DESCRIPTION
## Summary

Mocks don't implement inherited static properties. E.g.:

Bar.js:
```javascript
class Foo {
  static foo() {}
}

class Bar extends Foo {}
```

Bar-test.js:
```javascript
jest.mock('./Bar');
const Bar = require('./Bar');
Bar.foo; // undefined
```

## Test plan

See updated tests.