### PR TITLE
Revert "Mock inherited static properties and methods"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@
 - `[jest-cli]` Fix incorrect `testEnvironmentOptions` warning ([#6852](https://github.com/facebook/jest/pull/6852))
 - `[jest-each]` Prevent done callback being supplied to describe ([#6843](https://github.com/facebook/jest/pull/6843))
 - `[jest-config]` Better error message for a case when a preset module was found, but no `jest-preset.js` or `jest-preset.json` at the root ([#6863](https://github.com/facebook/jest/pull/6863))
-- `[jest-mock]` Fix inheritance of static properties and methods in mocks ([#6921](https://github.com/facebook/jest/pull/6921))
 
 ### Chore & Maintenance
 

--- a/packages/jest-mock/src/__tests__/jest_mock.test.js
+++ b/packages/jest-mock/src/__tests__/jest_mock.test.js
@@ -185,24 +185,6 @@ describe('moduleMocker', () => {
       expect(instanceFooMock.toString.mock).not.toBeUndefined();
     });
 
-    it('mocks ES2015 non-enumerable static properties and methods', () => {
-      class ClassFoo {
-        static foo() {}
-      }
-      ClassFoo.fooProp = () => {};
-
-      class ClassBar extends ClassFoo {}
-
-      const ClassBarMock = moduleMocker.generateFromMetadata(
-        moduleMocker.getMetadata(ClassBar),
-      );
-
-      expect(typeof ClassBarMock.foo).toBe('function');
-      expect(typeof ClassBarMock.fooProp).toBe('function');
-      expect(ClassBarMock.foo.mock).not.toBeUndefined();
-      expect(ClassBarMock.fooProp.mock).not.toBeUndefined();
-    });
-
     it('mocks methods that are bound multiple times', () => {
       const func = function func() {};
       const multipleBoundFunc = func.bind(null).bind(null);

--- a/packages/jest-mock/src/index.js
+++ b/packages/jest-mock/src/index.js
@@ -690,9 +690,7 @@ class ModuleMockerClass {
           if (
             (!component.hasOwnProperty && component[slot] !== undefined) ||
             (component.hasOwnProperty && component.hasOwnProperty(slot)) ||
-            (type === 'object' && component[slot] != Object.prototype[slot]) ||
-            // $FlowFixMe `Function` definition does not include `prototype`
-            (type === 'function' && component[slot] != Function.prototype[slot])
+            (type === 'object' && component[slot] != Object.prototype[slot])
           ) {
             const slotMetadata = this.getMetadata(component[slot], refs);
             if (slotMetadata) {


### PR DESCRIPTION
Reverts facebook/jest#6921

This causes some errors in Facebook tests, which means it could be breaking something. I'll investigate further and create a new PR.