### PR TITLE
jest-resolve - only resolve realpath once in try-catch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixes
 
+- `[jest-resolve]` Only resolve realpath once in try-catch ([#6925](https://github.com/facebook/jest/pull/6925))
 - `[expect]` Fix TypeError in `toBeInstanceOf` on `null` or `undefined` ([#6912](https://github.com/facebook/jest/pull/6912))
 - `[jest-jasmine2]` Throw a descriptive error if the first argument supplied to a hook was not a function ([#6917](https://github.com/facebook/jest/pull/6917))
 - `[jest-circus]` Throw a descriptive error if the first argument supplied to a hook was not a function ([#6917](https://github.com/facebook/jest/pull/6917))

--- a/packages/jest-resolve/src/__tests__/resolve.test.js
+++ b/packages/jest-resolve/src/__tests__/resolve.test.js
@@ -134,8 +134,9 @@ describe('resolveModule', () => {
     const resolver = new Resolver(moduleMap, {
       extensions: ['.js'],
     });
-    const src = require.resolve(
-      '../../src/__mocks__/bar/node_modules/foo/index.js',
+    const src = path.join(
+      path.resolve(__dirname, '../../src/__mocks__/bar/node_modules/'),
+      'foo/index.js',
     );
     const resolved = resolver.resolveModule(src, 'dep');
     expect(resolved).toBe(

--- a/packages/jest-resolve/src/node_modules_paths.js
+++ b/packages/jest-resolve/src/node_modules_paths.js
@@ -38,17 +38,21 @@ export default function nodeModulesPaths(
     prefix = '\\\\';
   }
 
-  // The node resolution algorithm (as implemented by NodeJS
-  // and TypeScript) traverses parents of the physical path,
-  // not the symlinked path
-  const physicalBasedir = realpath(basedirAbs);
+  // The node resolution algorithm (as implemented by NodeJS and TypeScript)
+  // traverses parents of the physical path, not the symlinked path
+  let physicalBasedir;
+  try {
+    physicalBasedir = realpath(basedirAbs);
+  } catch (err) {
+    // realpath can throw, e.g. on mapped drives
+    physicalBasedir = basedirAbs;
+  }
 
   const paths = [physicalBasedir];
   let parsed = path.parse(physicalBasedir);
   while (parsed.dir !== paths[paths.length - 1]) {
-    const realParsedDir = realpath(parsed.dir);
-    paths.push(realParsedDir);
-    parsed = path.parse(realParsedDir);
+    paths.push(parsed.dir);
+    parsed = path.parse(parsed.dir);
   }
 
   const dirs = paths


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary
Fixes #6880. As discussed in #6906, wrap `realpath` call in try-catch and invoke only once, since it should be enough to resolve the canonical path.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan
Updated the existing tests to make sure nothing breaks.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->


@arcanis, @SimenB, @thymikee, @palmerj3