### PR TITLE
Update babel-core dependency to v7 for jest-config 

### DIFF
--- a/packages/jest-config/package.json
+++ b/packages/jest-config/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "main": "build/index.js",
   "dependencies": {
-    "babel-core": "7.0.0-bridge.0",
+    "@babel/core": "^7.0.0",
     "babel-jest": "^23.4.2",
     "chalk": "^2.0.1",
     "glob": "^7.1.1",

--- a/packages/jest-config/package.json
+++ b/packages/jest-config/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "main": "build/index.js",
   "dependencies": {
-    "babel-core": "^6.0.0",
+    "babel-core": "^7.0.0",
     "babel-jest": "^23.4.2",
     "chalk": "^2.0.1",
     "glob": "^7.1.1",

--- a/packages/jest-config/package.json
+++ b/packages/jest-config/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "main": "build/index.js",
   "dependencies": {
-    "babel-core": "^7.0.0",
+    "babel-core": "7.0.0-bridge.0",
     "babel-jest": "^23.4.2",
     "chalk": "^2.0.1",
     "glob": "^7.1.1",


### PR DESCRIPTION
Resolves https://github.com/facebook/jest/issues/6913

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

I was seeing the same error as reported in #6913. I had `babel-core@7.0.0-bridge.0` installed locally. I noticed that inside my `node_modules/jest-config` directory, it installed `babel-core@6.26.3` inside its `node_modules`. I traced this back to the `package.json` file specifying `"babel-core": "^6.0.0"` which does not allow for usage of `babel-core@7.0.0-bridge.0`, so npm will install the latest 6.* version of `babel-core`. When you run your tests, you get the same error as seen in #6913.

```
npm ls
# truncated output to show problem
├─┬ jest-config@23.5.0
│   │ ├─┬ babel-core@6.26.3
│   │ │ ├── babel-code-frame@6.26.0 deduped
│   │ │ ├── babel-generator@6.26.0 deduped
│   │ │ ├─┬ babel-helpers@6.24.1
│   │ │ │ ├── babel-runtime@6.26.0 deduped
│   │ │ │ └── babel-template@6.26.0 deduped
│   │ │ ├── babel-messages@6.23.0 deduped
│   │ │ ├─┬ babel-register@6.26.0
│   │ │ │ ├─┬ babel-core@6.26.3
```

If you have `babel-core@7.0.0-bridge.0` installed in your `package.json`, this will still be ignored by jest-config as it installs an older version.

## Test plan
Using npm version 6.1.0, download `jest` via `npm install jest --save-dev`. Install `babel-core@7.0.0-bridge.0` as well. Dig through `node_modules/jest-config/node_modules` to see if it installed v6.26.3 of `babel-core`.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
