### PR TITLE
Update Troubleshooting.md

### DIFF
--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -92,7 +92,8 @@ or the following for Windows:
         "--runInBand"
       ],
       "console": "integratedTerminal",
-      "internalConsoleOptions": "neverOpen"
+      "internalConsoleOptions": "neverOpen",
+      "port": 9229
     }
   ]
 }

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -69,7 +69,8 @@ To automatically launch and attach to a process running your tests, use the foll
         "--runInBand"
       ],
       "console": "integratedTerminal",
-      "internalConsoleOptions": "neverOpen"
+      "internalConsoleOptions": "neverOpen",
+      "port": 9229
     }
   ]
 }


### PR DESCRIPTION
## Summary

With the existing launch configuration, VS Code automatically appends `--inspect-brk=<random_port>` resulting in a command like `node --inspect-brk ${workspaceRoot}/node_modules/.bin/jest --runInBand --inspect-brk=35370`. This does not work because the debugger starts listening on port 9229, but Code attempts to attach to it on port 35370 (or whatever random port number it has selected).

Adding the port parameter prevents Code from automatically appending the `--inspect-brk` flag and instructs Code attach to the debugger on port 9229.

I don't think I'll need to update CHANGELOG.md for this, will I?

## Test plan

This change does not include code per se, but I have run the launch configuration in my project and observed that it works properly.
