### PR TITLE
jest-editor-support: Add support for Windows Subsystem for Linux in Runner

### DIFF
--- a/packages/jest-editor-support/index.d.ts
+++ b/packages/jest-editor-support/index.d.ts
@@ -22,6 +22,7 @@ export interface Options {
   testNamePattern?: string;
   testFileNamePattern?: string;
   shell?: boolean;
+  useWsl?: boolean;
 }
 
 export class Runner extends EventEmitter {
@@ -38,8 +39,8 @@ export class Settings extends EventEmitter {
   getConfig(completed: Function): void;
   jestVersionMajor: number | null;
   settings: {
-    testRegex: string,
-    testMatch: string[],
+    testRegex: string;
+    testMatch: string[];
   };
 }
 
@@ -51,6 +52,7 @@ export class ProjectWorkspace {
     localJestMajorVersin: number,
     collectCoverage?: boolean,
     debug?: boolean,
+    useWsl?: boolean,
   );
   pathToJest: string;
   pathToConfig: string;
@@ -58,6 +60,7 @@ export class ProjectWorkspace {
   localJestMajorVersion: number;
   collectCoverage?: boolean;
   debug?: boolean;
+  useWsl?: boolean;
 }
 
 export interface IParseResults {
@@ -188,9 +191,9 @@ export class Snapshot {
 }
 
 type FormattedTestResults = {
-  testResults: TestResult[]
-}
+  testResults: TestResult[];
+};
 
 type TestResult = {
-  name: string
-}
+  name: string;
+};

--- a/packages/jest-editor-support/index.d.ts
+++ b/packages/jest-editor-support/index.d.ts
@@ -52,7 +52,7 @@ export class ProjectWorkspace {
     localJestMajorVersin: number,
     collectCoverage?: boolean,
     debug?: boolean,
-    useWsl?: boolean,
+    useWsl?: boolean | string,
   );
   pathToJest: string;
   pathToConfig: string;
@@ -60,7 +60,7 @@ export class ProjectWorkspace {
   localJestMajorVersion: number;
   collectCoverage?: boolean;
   debug?: boolean;
-  useWsl?: boolean;
+  useWsl?: boolean | string;
 }
 
 export interface IParseResults {

--- a/packages/jest-editor-support/package.json
+++ b/packages/jest-editor-support/package.json
@@ -10,8 +10,8 @@
   "dependencies": {
     "babel-traverse": "^6.14.1",
     "babylon": "^6.14.1",
-    "jest-snapshot": "^23.6.0"
-    "wsl-path": "^1.0.3"
+    "jest-snapshot": "^23.6.0",
+    "wsl-path": "^1.1.0"
   },
   "typings": "index.d.ts"
 }

--- a/packages/jest-editor-support/package.json
+++ b/packages/jest-editor-support/package.json
@@ -11,6 +11,7 @@
     "babel-traverse": "^6.14.1",
     "babylon": "^6.14.1",
     "jest-snapshot": "^23.6.0"
+    "wsl-path": "^1.0.3"
   },
   "typings": "index.d.ts"
 }

--- a/packages/jest-editor-support/src/Runner.js
+++ b/packages/jest-editor-support/src/Runner.js
@@ -12,7 +12,9 @@ import {messageTypes} from './types';
 
 import {ChildProcess, spawn} from 'child_process';
 import {readFile} from 'fs';
+import {readTestResults} from './readTestResults';
 import {tmpdir} from 'os';
+import {sep} from 'path';
 import EventEmitter from 'events';
 import ProjectWorkspace from './project_workspace';
 import {createProcess} from './Process';
@@ -40,7 +42,7 @@ export default class Runner extends EventEmitter {
     this._createProcess = (options && options.createProcess) || createProcess;
     this.options = options || {};
     this.workspace = workspace;
-    this.outputPath = tmpdir() + '/jest_runner.json';
+    this.outputPath = tmpdir() + sep + 'jest_runner.json';
     this.prevMessageTypes = [];
   }
 
@@ -116,7 +118,7 @@ export default class Runner extends EventEmitter {
             this.emit('terminalError', message);
           } else {
             const noTestsFound = this.doResultsFollowNoTestsFoundMessage();
-            this.emit('executableJSON', JSON.parse(data), {
+            this.emit('executableJSON', readTestResults(data, this.workspace), {
               noTestsFound,
             });
           }

--- a/packages/jest-editor-support/src/Runner.js
+++ b/packages/jest-editor-support/src/Runner.js
@@ -14,7 +14,7 @@ import {ChildProcess, spawn} from 'child_process';
 import {readFile} from 'fs';
 import {readTestResults} from './readTestResults';
 import {tmpdir} from 'os';
-import {sep} from 'path';
+import {join} from 'path';
 import EventEmitter from 'events';
 import ProjectWorkspace from './project_workspace';
 import {createProcess} from './Process';
@@ -42,7 +42,7 @@ export default class Runner extends EventEmitter {
     this._createProcess = (options && options.createProcess) || createProcess;
     this.options = options || {};
     this.workspace = workspace;
-    this.outputPath = tmpdir() + sep + 'jest_runner.json';
+    this.outputPath = join(tmpdir(), 'jest_runner.json');
     this.prevMessageTypes = [];
   }
 

--- a/packages/jest-editor-support/src/__tests__/process.test.js
+++ b/packages/jest-editor-support/src/__tests__/process.test.js
@@ -11,6 +11,8 @@
 
 jest.mock('child_process');
 jest.mock('wsl-path');
+jest.mock('../readTestResults', () => ({readTestResults: x => x}));
+
 import {createProcess} from '../Process';
 import {spawn} from 'child_process';
 import * as wslPath from 'wsl-path';

--- a/packages/jest-editor-support/src/__tests__/readTestResults.test.js
+++ b/packages/jest-editor-support/src/__tests__/readTestResults.test.js
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+'use strict';
+
+jest.mock('wsl-path', () => ({
+  wslToWindowsSync: path => 'resolved:' + path,
+}));
+
+import {readTestResults} from '../readTestResults';
+
+const posixPath1 = '/mnt/c/Users/Path/PageTitle.test.tsx';
+const posixPath2 = '/mnt/c/Users/Path2/PageFooter.test.tsx';
+
+const resultFixture = JSON.stringify({
+  coverageMap: {
+    [posixPath1]: {path: posixPath1},
+    [posixPath2]: {path: posixPath2},
+  },
+  testResults: [
+    {
+      assertionResults: [],
+      name: posixPath1,
+    },
+    {
+      assertionResults: [],
+      name: posixPath2,
+    },
+  ],
+});
+
+describe('ResultReader', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should just parse the json result for non wsl environments', () => {
+    const result = readTestResults(resultFixture, {useWsl: false});
+
+    expect(result.testResults[0].name).toBe(posixPath1);
+    expect(Object.keys(result.coverageMap)).toEqual([posixPath1, posixPath2]);
+  });
+
+  it('should replace the testResult paths with the resolved paths when wsl is defined', () => {
+    const result = readTestResults(resultFixture, {useWsl: true});
+
+    expect(result.testResults[0].name).toBe('resolved:' + posixPath1);
+    expect(result.testResults[1].name).toBe('resolved:' + posixPath2);
+  });
+
+  it('should replace the coverageMap paths with the resolved paths when wsl is defined', () => {
+    const result = readTestResults(resultFixture, {useWsl: true});
+
+    const mapKey1 = Object.keys(result.coverageMap)[0];
+    const mapKey2 = Object.keys(result.coverageMap)[1];
+
+    expect(mapKey1).toBe('resolved:' + posixPath1);
+    expect(mapKey2).toBe('resolved:' + posixPath2);
+    expect(result.coverageMap[mapKey1].path).toBe('resolved:' + posixPath1);
+    expect(result.coverageMap[mapKey2].path).toBe('resolved:' + posixPath2);
+  });
+});

--- a/packages/jest-editor-support/src/__tests__/runner.test.js
+++ b/packages/jest-editor-support/src/__tests__/runner.test.js
@@ -13,7 +13,7 @@ jest.mock('../Process');
 jest.mock('child_process', () => ({spawn: jest.fn()}));
 jest.mock('../readTestResults', () => ({readTestResults: x => JSON.parse(x)}));
 
-jest.mock('os', () => ({tmpdir: jest.fn()}));
+jest.mock('os', () => ({tmpdir: jest.fn(() => 'tmpdir')}));
 jest.mock('fs', () => {
   // $FlowFixMe requireActual
   const readFileSync = require.requireActual('fs').readFileSync;
@@ -63,7 +63,7 @@ describe('Runner', () => {
       const workspace: any = {};
       const sut = new Runner(workspace);
 
-      expect(sut.outputPath).toBe('tmpdir' + path.sep + 'jest_runner.json');
+      expect(sut.outputPath).toBe(path.join('tmpdir', 'jest_runner.json'));
     });
 
     it('sets the default options', () => {

--- a/packages/jest-editor-support/src/__tests__/runner.test.js
+++ b/packages/jest-editor-support/src/__tests__/runner.test.js
@@ -11,6 +11,8 @@
 
 jest.mock('../Process');
 jest.mock('child_process', () => ({spawn: jest.fn()}));
+jest.mock('../readTestResults', () => ({readTestResults: x => JSON.parse(x)}));
+
 jest.mock('os', () => ({tmpdir: jest.fn()}));
 jest.mock('fs', () => {
   // $FlowFixMe requireActual
@@ -61,7 +63,7 @@ describe('Runner', () => {
       const workspace: any = {};
       const sut = new Runner(workspace);
 
-      expect(sut.outputPath).toBe('tmpdir/jest_runner.json');
+      expect(sut.outputPath).toBe('tmpdir' + path.sep + 'jest_runner.json');
     });
 
     it('sets the default options', () => {

--- a/packages/jest-editor-support/src/project_workspace.js
+++ b/packages/jest-editor-support/src/project_workspace.js
@@ -60,6 +60,8 @@ export default class ProjectWorkspace {
    */
   debug: ?boolean;
 
+  useWsl: ?boolean;
+
   constructor(
     rootPath: string,
     pathToJest: string,
@@ -67,6 +69,7 @@ export default class ProjectWorkspace {
     localJestMajorVersion: number,
     collectCoverage: ?boolean,
     debug: ?boolean,
+    useWsl: ?boolean,
   ) {
     this.rootPath = rootPath;
     this.pathToJest = pathToJest;
@@ -74,5 +77,6 @@ export default class ProjectWorkspace {
     this.localJestMajorVersion = localJestMajorVersion;
     this.collectCoverage = collectCoverage;
     this.debug = debug;
+    this.useWsl = useWsl;
   }
 }

--- a/packages/jest-editor-support/src/readTestResults.js
+++ b/packages/jest-editor-support/src/readTestResults.js
@@ -1,0 +1,69 @@
+import {wslToWindowsSync} from 'wsl-path';
+
+export const readTestResults = (data: Buffer, workspace: ProjectWorkspace) => {
+  const results = JSON.parse(data);
+  if (!workspace.useWsl) {
+    return results;
+  }
+
+  return Object.assign({}, results, {
+    coverageMap: translateWslPathCoverateToWindowsPaths(
+      results.coverageMap,
+      workspace,
+    ),
+    testResults: translateWslTestResultsToWindowsPaths(
+      results.testResults,
+      workspace,
+    ),
+  });
+};
+
+/**
+ * Return a rewritten copy a coverage map created by a jest run in wsl. All POSIX paths
+ * are rewritten to Windows paths, so vscode-jest running in windows can map the coverage.
+ *
+ * @param coverageMap The coverage map to rewrite
+ */
+const translateWslPathCoverateToWindowsPaths = (
+  coverageMap,
+  workspace: ProjectWorkspace,
+) => {
+  if (!coverageMap) {
+    return coverageMap;
+  }
+  const result = {};
+  Object.keys(coverageMap).forEach(key => {
+    const translatedPath = wslToWindowsSync(key, {
+      wslCommand: getWslCommand(workspace),
+    });
+    const entry = Object.assign({}, coverageMap[key], {path: translatedPath});
+    result[translatedPath] = entry;
+  });
+  return result;
+};
+
+/**
+ * Return a rewritten copy a {@see JestFileResults} array created by a jest run in wsl. All POSIX paths
+ * are rewritten to Windows paths, so vscode-jest running in windows can map the test
+ * status.
+ *
+ * @param testResults the TestResults to rewrite
+ */
+const translateWslTestResultsToWindowsPaths = (
+  testResults,
+  workspace: ProjectWorkspace,
+) => {
+  if (!testResults) {
+    return testResults;
+  }
+  return testResults.map(result =>
+    Object.assign({}, result, {
+      name: wslToWindowsSync(result.name, {
+        wslCommand: getWslCommand(workspace),
+      }),
+    }),
+  );
+};
+
+const getWslCommand = (workspace: ProjectWorkspace): string =>
+  workspace.wslCommand === true ? 'wsl' : workspace.wslCommand;


### PR DESCRIPTION


* Add useWsl configuration flag to project worksapce
* Translate windows paths in call args to POSIX paths valid in WSL

see https://github.com/jest-community/vscode-jest/issues/331

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

See https://github.com/jest-community/vscode-jest/issues/331 for motivation.
When running vscode in Windows but executing jest in WSL (WIndows Subsystem for Linux), additional steps have to be performed:

* project_workspace now has a useWsl flag (like the built-in flag for vscode launch options) which can be set to true
* The wsl command has to be prepended to the shell command if useWsl is true
* The jest output path is a windows path, but wsl is running in a different filesystem with POSIX paths (usually C:/ is /mnt/c), this has to be translated.
* The last step is done in a own package wsl-path, as this is also required in vscode-jest and I don't really see it in the scope of either jest or vscode jest (see https://github.com/mojadev/wsl-path)

## Test plan

See the following command being executed on a Windows 10 Host - normally the path would be C:\..
![grafik](https://user-images.githubusercontent.com/412767/45000906-de23ac80-afc8-11e8-8c78-317c583856a3.png)

