### PR TITLE
scripts: Don’t remove node_modules from subdirectories of presets in e2e tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - `[docs]` Improve the documentation regarding preset configuration ([#6864](https://github.com/facebook/jest/issues/6864))
 - `[docs]` Clarify usage of `--projects` CLI option ([#6872](https://github.com/facebook/jest/pull/6872))
 - `[docs]` Correct `failure-change` notification mode ([#6878](https://github.com/facebook/jest/pull/6878))
+- `[scripts]` Don’t remove node_modules from subdirectories of presets in e2e tests ([#6948](https://github.com/facebook/jest/pull/6948))
 
 ## 23.5.0
 

--- a/package.json
+++ b/package.json
@@ -80,7 +80,8 @@
   "scripts": {
     "build-clean": "rm -rf ./packages/*/build ./packages/*/build-es5",
     "build": "node ./scripts/build.js",
-    "clean-all": "rm -rf ./node_modules && rm -rf ./packages/*/node_modules && rm -rf ./e2e/*/*/node_modules && yarn build-clean",
+    "clean-all": "rm -rf ./node_modules && rm -rf ./packages/*/node_modules && yarn clean-e2e && yarn build-clean",
+    "clean-e2e": "find ./e2e -not \\( -path ./e2e/presets/js -prune \\) -not \\( -path ./e2e/presets/json -prune \\) -mindepth 2 -type d \\( -name node_modules -prune \\) -exec rm -r '{}' +",
     "jest": "node ./packages/jest-cli/bin/jest.js",
     "jest-coverage": "yarn jest --coverage",
     "lint": "eslint . --cache --ext js,md",


### PR DESCRIPTION
## Summary

After `yarn` and `yarn jest` the result of `yarn clean-all` is that `git status` displays:

```
deleted:    e2e/presets/js/node_modules/jest-preset-js/jest-preset.js
deleted:    e2e/presets/js/node_modules/jest-preset-js/mapper.js
deleted:    e2e/presets/json/node_modules/jest-preset-json/jest-preset.json
deleted:    e2e/presets/json/node_modules/jest-preset-json/mapper.js
```

#6185 added these files and made an exception in `.gitignore` but not in `package.json` file.

Y’all are welcome to improve the `find` command in new `clean-e2e` script. I wrote it as clear and cross platform as I know how.

## Test plan

I used `find . -type d \( -name node_modules -prune \) -print` to explore `node_modules` directories:

1. After `git clone` there are 2 under `./e2e` and 4 under `./packages`

    ```
    ./e2e/presets/js/node_modules
    ./e2e/presets/json/node_modules
    ./packages/jest-resolve/src/__mocks__/bar/node_modules
    ./packages/jest-resolve/src/__mocks__/foo/node_modules
    ./packages/jest-resolve-dependencies/src/__tests__/__fixtures__/node_modules
    ./packages/jest-runtime/src/__tests__/test_root/node_modules
    ```

2. After `yarn` there are more, of course

    * `./node_modules`
    * `./website/node_modules`
    * 12 under `./examples`
    * 21 under `.packages` including the following 4 related to the preceding 4

        ```
        ./packages/jest-resolve/build/__mocks__/bar/node_modules
        ./packages/jest-resolve/build/__mocks__/foo/node_modules
        ./packages/jest-resolve-dependencies/build/__tests__/__fixtures__/node_modules
        ./packages/jest-runtime/build/__tests__/test_root/node_modules
        ```

3. After `yarn jest` there are 8 more under `./e2e`

    ```
    ./e2e/babel-plugin-jest-hoist/node_modules
    ./e2e/coverage-remapping/node_modules
    ./e2e/coverage-transform-instrumented/node_modules
    ./e2e/native-async-mock/node_modules
    ./e2e/stack-trace-source-maps/node_modules
    ./e2e/transform/babel-jest/node_modules
    ./e2e/transform/multiple-transformers/node_modules
    ./e2e/typescript-coverage/node_modules
    ```

4. After original version of `yarn clean-all`

    * removed `./node_modules`
    * removed 17 under `./packages` and kept the 4 from `git clone`
    * removed 4 under `./e2e` including the 2 from `git clone` that it should have kept but kept the following 6 the it should have removed (but were not because of `./e2e/*/*/node_modules` pattern)

        ```
        ./e2e/babel-plugin-jest-hoist/node_modules
        ./e2e/coverage-remapping/node_modules
        ./e2e/coverage-transform-instrumented/node_modules
        ./e2e/native-async-mock/node_modules
        ./e2e/stack-trace-source-maps/node_modules
        ./e2e/typescript-coverage/node_modules
        ```

5. Repeat steps 1, 2, 3, and then after improved version of `yarn clean-all`

    * removed `./node_modules`
    * removed 17 under `./packages` and kept the 4 from `git clone`
    * removed 8 under `./e2e` and kept the 2 from `git clone` therefore `git status` displays `nothing to commit, working tree clean`
