### PR TITLE
Double check that a timeout is not exceeded

### DIFF
--- a/packages/jest-jasmine2/src/p_timeout.js
+++ b/packages/jest-jasmine2/src/p_timeout.js
@@ -21,11 +21,18 @@ export default function pTimeout(
   onTimeout: () => any,
 ): Promise<any> {
   return new Promise((resolve, reject) => {
+    const startTime = Date.now();
     const timer = setTimeout(() => resolve(onTimeout()), ms);
     promise.then(
       val => {
         clearTimeout(timer);
-        resolve(val);
+
+        // when running single threaded, we need to double check the timeout
+        if (Date.now() - startTime > ms) {
+          resolve(onTimeout());
+        } else {
+          resolve(val);
+        }
       },
       err => {
         clearTimeout(timer);


### PR DESCRIPTION
<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

When running in a single-threaded environment, `setTimeout()` waits for the current thread to finish work (see also [mdn](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setTimeout#Late_timeouts
) on the topic). That is if a synchronous test keeps the current thread busy, the timeout specified with `jest.setTimeout()` is never checked. This adds a check if the test duration has exceeded the timeout.

closes https://github.com/facebook/jest/issues/6947

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
