### PR TITLE
Add changedSince to allowed watchmode configs

### DIFF
--- a/packages/jest-cli/src/__tests__/watch.test.js
+++ b/packages/jest-cli/src/__tests__/watch.test.js
@@ -576,7 +576,7 @@ describe('Watch mode flows', () => {
     ok      | option
     ${'✔︎'} | ${'bail'}
     ${'✖︎'} | ${'changedFilesWithAncestor'}
-    ${'✖︎'} | ${'changedSince'}
+    ${'✔︎'} | ${'changedSince'}
     ${'✔︎'} | ${'collectCoverage'}
     ${'✔︎'} | ${'collectCoverageFrom'}
     ${'✔︎'} | ${'collectCoverageOnlyFrom'}

--- a/packages/jest-cli/src/lib/update_global_config.js
+++ b/packages/jest-cli/src/lib/update_global_config.js
@@ -13,6 +13,7 @@ import type {GlobalConfig} from 'types/Config';
 
 export type Options = {
   bail?: $PropertyType<GlobalConfig, 'bail'>,
+  changedSince?: $PropertyType<GlobalConfig, 'changedSince'>,
   collectCoverage?: $PropertyType<GlobalConfig, 'collectCoverage'>,
   collectCoverageFrom?: $PropertyType<GlobalConfig, 'collectCoverageFrom'>,
   collectCoverageOnlyFrom?: $PropertyType<
@@ -67,6 +68,10 @@ export default (globalConfig: GlobalConfig, options: Options): GlobalConfig => {
 
   if (options.bail !== undefined) {
     newConfig.bail = options.bail || false;
+  }
+
+  if (options.changedSince !== undefined) {
+    newConfig.changedSince = options.changedSince || false;
   }
 
   if (options.collectCoverage !== undefined) {

--- a/packages/jest-cli/src/watch.js
+++ b/packages/jest-cli/src/watch.js
@@ -82,6 +82,7 @@ export default function watch(
 
   const updateConfigAndRun = ({
     bail,
+    changedSince,
     collectCoverage,
     collectCoverageFrom,
     collectCoverageOnlyFrom,
@@ -100,6 +101,7 @@ export default function watch(
     const previousUpdateSnapshot = globalConfig.updateSnapshot;
     globalConfig = updateGlobalConfig(globalConfig, {
       bail,
+      changedSince,
       collectCoverage,
       collectCoverageFrom,
       collectCoverageOnlyFrom,


### PR DESCRIPTION
## Summary

I'd like to publish [`jest-watch-master`](https://github.com/rickhanlonii/jest-watch-master) which would add a watchmode option "m" to check changes since master:

![](http://dp.hanlon.io/71adc439286e/Screen%252520Recording%2525202018-09-08%252520at%25252003.09%252520PM.gif)

This PR exposes the `changedSince`  config to watch mode plugins 👍 



## Test plan

- Updated unit tests