### PR TITLE
[docs] Fix getMockName example of Mock Function document

### DIFF
--- a/docs/MockFunctions.md
+++ b/docs/MockFunctions.md
@@ -280,7 +280,7 @@ expect(mockFunc.mock.calls[mockFunc.mock.calls.length - 1][0]).toBe(42);
 // A snapshot will check that a mock was invoked the same number of times,
 // in the same order, with the same arguments. It will also assert on the name.
 expect(mockFunc.mock.calls).toEqual([[arg1, arg2]]);
-expect(mockFunc.mock.getMockName()).toBe('a mock name');
+expect(mockFunc.getMockName()).toBe('a mock name');
 ```
 
 For a complete list of matchers, check out the [reference docs](ExpectAPI.md).


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

According to the API documentation of `getMockName` function ( https://jestjs.io/docs/en/mock-function-api#mockfngetmockname ), the getMockName function should be called via `mockFunc.getMockName()`, not `mockFunc.mock.getMockName()`.

Is there anything else I need to do?