### PR TITLE
Fix a memory leak in Error objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixes
 
 - `[jest-haste-map]` [**BREAKING**] Replaced internal data structures to improve performance ([#6960](https://github.com/facebook/jest/pull/6960))
+- `[jest-jasmine2]` Fix memory leak in Error objects hold by the framework ([#6965](https://github.com/facebook/jest/pull/6965))
 
 ### Chore & Maintenance
 

--- a/packages/jest-jasmine2/src/jasmine/Spec.js
+++ b/packages/jest-jasmine2/src/jasmine/Spec.js
@@ -66,6 +66,12 @@ export default function Spec(attrs: Object) {
   this.initError = new Error();
   this.initError.name = '';
 
+  // Without this line v8 stores references to all closures
+  // in the stack in the Error object. This line stringifies the stack
+  // property to allow garbage-collecting objects on the stack
+  // https://crbug.com/v8/7142
+  this.initError.stack = this.initError.stack;
+
   this.queueableFn.initError = this.initError;
 
   this.result = {

--- a/packages/jest-jasmine2/src/jasmine_async.js
+++ b/packages/jest-jasmine2/src/jasmine_async.js
@@ -37,6 +37,12 @@ function promisifyLifeCycleFunction(originalFn, env) {
 
     const extraError = new Error();
 
+    // Without this line v8 stores references to all closures
+    // in the stack in the Error object. This line stringifies the stack
+    // property to allow garbage-collecting objects on the stack
+    // https://crbug.com/v8/7142
+    extraError.stack = extraError.stack;
+
     // We make *all* functions async and run `done` right away if they
     // didn't return a promise.
     const asyncJestLifecycle = function(done) {
@@ -78,6 +84,12 @@ function promisifyIt(originalFn, env) {
     }
 
     const extraError = new Error();
+
+    // Without this line v8 stores references to all closures
+    // in the stack in the Error object. This line stringifies the stack
+    // property to allow garbage-collecting objects on the stack
+    // https://crbug.com/v8/7142
+    extraError.stack = extraError.stack;
 
     const asyncJestTest = function(done) {
       const wrappedFn = isGeneratorFn(fn) ? co.wrap(fn) : fn;

--- a/packages/jest-jasmine2/src/queue_runner.js
+++ b/packages/jest-jasmine2/src/queue_runner.js
@@ -73,6 +73,7 @@ export default function queueRunner(options: Options) {
           'Timeout - Async callback was not invoked within the ' +
           timeoutMs +
           'ms timeout specified by jest.setTimeout.';
+        initError.stack = initError.message + initError.stack;
         options.onException(initError);
       },
     );


### PR DESCRIPTION
see also https://crbug.com/v8/7142

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary
Error object keep references to all "context"s in the stack. This will lead to memory leaks if the Error objects are stored somewhere persistent. This is an "optimization" of v8, since constructing the `stack` property as string can be expensive.
Accessing the `stack` property will force stringifying of these internal objects and discards references, which allows scopes to be garbage-collected.

A similar fix was made here: https://github.com/mochajs/mocha/issues/3119

These memory leaks are usually very small since very few people store large objects outside of `it()`. In the webpack test suite the `it()` is called from the bundle after compiling. Here the bundle and the Compilation is in the stack. This causes memory leaks.

I believe but can't prove yet, that the inability of running too many test suites at once (in webpack) is also caused by this problem. It hangs without error. Let's see...

## Test plan
Unsure how to test this.
I tested it manually via memory snapshots in the devtools.

I could construct a test suite that allocates much memory and will lead to memory errors without this fix, but this would probably slow down the CI... Tell me if you want this.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
