### PR TITLE
jest-haste-map: Fixed Haste whitelist generation for scoped modules on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixes
 
 - `[jest-haste-map]` [**BREAKING**] Replaced internal data structures to improve performance ([#6960](https://github.com/facebook/jest/pull/6960))
+- `[jest-haste-map]` Fixed Haste whitelist generation for scoped modules on Windows ([#6980](https://github.com/facebook/jest/pull/6980))
 
 ### Chore & Maintenance
 

--- a/packages/jest-haste-map/src/index.js
+++ b/packages/jest-haste-map/src/index.js
@@ -114,11 +114,14 @@ const escapePathSeparator = string =>
 
 const getWhiteList = (list: ?Array<string>): ?RegExp => {
   if (list && list.length) {
+    const newList = list.map(item =>
+      escapePathSeparator(item.replace(/(\/)/g, path.sep)),
+    );
     return new RegExp(
       '(' +
         escapePathSeparator(NODE_MODULES) +
         '(?:' +
-        list.join('|') +
+        newList.join('|') +
         ')(?=$|' +
         escapePathSeparator(path.sep) +
         '))',


### PR DESCRIPTION

## Summary

This PR modifies the function `getWhiteList` in `jest-haste-map` to handle flipping the path separator on `@scoped/modules` on Windows. This allows Haste to properly resolve JS files inside of scoped modules on Windows.

Needed to resolve https://github.com/facebook/metro/issues/241 and https://github.com/facebook/metro/pull/249

## Test plan

Using a version of `jest-haste-map` patched with this patch, and the test suite in my Metro pull request, all tests pass