### PR TITLE
chore: add runtimeArgs in VSCode launch.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,8 @@
       "request": "launch",
       "name": "Debug Jest with current test file",
       "program": "${workspaceFolder}/packages/jest-cli/bin/jest.js",
-      "args": ["--runInBand", "${file}"]
+      "args": ["--runInBand", "${file}"],
+      "runtimeArgs": ["-r", "flow-remove-types/register"]
     }
   ]
 }


### PR DESCRIPTION
This is a fix to ensure debugger stops at correct breakpoint in VSCode
Refs: https://github.com/facebook/jest/issues/6918

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

The contributors who use VSCode editor are not able to use debugger, as it doesn't stop at correct points as described in #6918
The issue was discussed in https://github.com/jest-community/vscode-jest/issues/372 where @connectdotz pointed out debugger configuration to be added as Jest uses flow ([documentation](https://github.com/flowtype/flow-for-vscode#debugger-configuration))
This PR adds that debugger configuration `"runtimeArgs": ["-r", "flow-remove-types/register"]` in VSCode launch configuration

## Test plan

* Screen recording of the issue:
[![Debug Jest with current test file not stopping at correct breakpoint](https://img.youtube.com/vi/VZUJyI3GeYY/0.jpg)](https://www.youtube.com/watch?v=VZUJyI3GeYY)
* Screen recording of the fix:
[![Debug Jest with current test file not stopping at correct breakpoint](https://img.youtube.com/vi/IJdzxfvotGM/0.jpg)](https://www.youtube.com/watch?v=IJdzxfvotGM)