### PR TITLE
Preserve info from files with matching SHA-1s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 ### Fixes
 
-- `[jest-haste-map]` [**BREAKING**] Replaced internal data structures to improve performance ([#6960](https://github.com/facebook/jest/pull/6960))
+- `[jest-haste-map]` [**BREAKING**] Replace internal data structures to improve performance ([#6960](https://github.com/facebook/jest/pull/6960))
+- `[jest-haste-map]` Do not visit again files with the same sha-1 ([#6990](https://github.com/facebook/jest/pull/6990))
 - `[jest-jasmine2]` Fix memory leak in Error objects hold by the framework ([#6965](https://github.com/facebook/jest/pull/6965))
 
 ### Chore & Maintenance

--- a/packages/jest-haste-map/src/crawlers/watchman.js
+++ b/packages/jest-haste-map/src/crawlers/watchman.js
@@ -169,16 +169,27 @@ module.exports = async function watchmanCrawl(
           typeof fileData.mtime_ms === 'number'
             ? fileData.mtime_ms
             : fileData.mtime_ms.toNumber();
+        let sha1hex = fileData['content.sha1hex'];
+        if (typeof sha1hex !== 'string' || sha1hex.length !== 40) {
+          sha1hex = null;
+        }
+
         const existingFileData = data.files.get(name);
         if (existingFileData && existingFileData[H.MTIME] === mtime) {
           files.set(name, existingFileData);
+        } else if (
+          existingFileData &&
+          sha1hex &&
+          existingFileData[H.SHA1] === sha1hex
+        ) {
+          files.set(name, [
+            existingFileData[0],
+            mtime,
+            existingFileData[2],
+            existingFileData[3],
+            existingFileData[4],
+          ]);
         } else {
-          let sha1hex = fileData['content.sha1hex'];
-
-          if (typeof sha1hex !== 'string' || sha1hex.length !== 40) {
-            sha1hex = null;
-          }
-
           // See ../constants.js
           files.set(name, ['', mtime, 0, [], sha1hex]);
         }


### PR DESCRIPTION
## Summary

The current implementation of the watchman crawler ignores any previous information for files with different modification time. This modifies that part to also preserve the information for files with the same sha-1.

## Test plan

Updated the test suite.
