### PR TITLE
feat: symlinks in node_modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - `[jest-jasmine2/jest-circus/jest-cli]` Add test.todo ([#6996](https://github.com/facebook/jest/pull/6996))
 - `[pretty-format]` Option to not escape strings in diff messages ([#5661](https://github.com/facebook/jest/pull/5661))
+- `[jest-haste-map]` Support for symlinks in `node_modules` ([#6993](https://github.com/facebook/jest/pull/6993))
 - `[jest-haste-map]` Add `getFileIterator` to `HasteFS` for faster file iteration ([#7010](https://github.com/facebook/jest/pull/7010)).
 - `[jest-worker]` [**BREAKING**] Add functionality to call a `setup` method in the worker before the first call and a `teardown` method when ending the farm ([#7014](https://github.com/facebook/jest/pull/7014)).
 - `[jest-config]` [**BREAKING**] Set default `notifyMode` to `failure-change` ([#7024](https://github.com/facebook/jest/pull/7024))

--- a/packages/jest-haste-map/package.json
+++ b/packages/jest-haste-map/package.json
@@ -15,6 +15,7 @@
     "jest-serializer": "^23.0.1",
     "jest-worker": "^23.2.0",
     "micromatch": "^2.3.11",
+    "realpath-native": "^1.0.0",
     "sane": "^3.0.0"
   }
 }

--- a/packages/jest-haste-map/src/crawlers/node.js
+++ b/packages/jest-haste-map/src/crawlers/node.js
@@ -153,6 +153,7 @@ module.exports = function nodeCrawl(
         }
       });
       data.files = files;
+      data.links = new Map();
       resolve(data);
     };
 

--- a/packages/jest-haste-map/src/crawlers/watchman.js
+++ b/packages/jest-haste-map/src/crawlers/watchman.js
@@ -210,6 +210,7 @@ module.exports = async function watchmanCrawl(
         if (existingFileData && existingFileData[H.MTIME] === mtime) {
           cache.set(fileName, existingFileData);
         } else if (fileData.type !== 'f') {
+          // See ../constants.js
           cache.set(fileName, [undefined, mtime]);
         } else if (
           sha1hex &&
@@ -224,6 +225,7 @@ module.exports = async function watchmanCrawl(
             existingFileData[4],
           ]);
         } else {
+          // See ../constants.js
           cache.set(fileName, ['', mtime, 0, [], sha1hex]);
         }
       }

--- a/packages/jest-haste-map/src/haste_fs.js
+++ b/packages/jest-haste-map/src/haste_fs.js
@@ -8,19 +8,30 @@
  */
 
 import type {Glob, Path} from 'types/Config';
-import type {FileData} from 'types/HasteMap';
+import type {FileData, LinkData} from 'types/HasteMap';
 
 import * as fastPath from './lib/fast_path';
+import fs from 'fs';
 import micromatch from 'micromatch';
 import H from './constants';
 
 export default class HasteFS {
   _rootDir: Path;
   _files: FileData;
+  _links: LinkData;
 
-  constructor({rootDir, files}: {rootDir: Path, files: FileData}) {
+  constructor({
+    rootDir,
+    files,
+    links,
+  }: {
+    rootDir: Path,
+    files: FileData,
+    links: LinkData,
+  }) {
     this._rootDir = rootDir;
     this._files = files;
+    this._links = links;
   }
 
   getModuleName(file: Path): ?string {
@@ -40,6 +51,11 @@ export default class HasteFS {
 
   exists(file: Path): boolean {
     return this._getFileData(file) != null;
+  }
+
+  follow(file: Path): Path {
+    const link = this._links[file];
+    return link ? link[0] || (link[0] = fs.realpathSync(file)) : file;
   }
 
   getAllFiles(): Array<string> {

--- a/packages/jest-haste-map/src/haste_fs.js
+++ b/packages/jest-haste-map/src/haste_fs.js
@@ -11,8 +11,8 @@ import type {Glob, Path} from 'types/Config';
 import type {FileData, LinkData} from 'types/HasteMap';
 
 import * as fastPath from './lib/fast_path';
-import fs from 'fs';
 import micromatch from 'micromatch';
+import {sync as realpath} from 'realpath-native';
 import H from './constants';
 
 export default class HasteFS {
@@ -55,7 +55,13 @@ export default class HasteFS {
 
   follow(file: Path): Path {
     const link = this._links[file];
-    return link ? link[0] || (link[0] = fs.realpathSync(file)) : file;
+    if (link === undefined) {
+      return file;
+    }
+    if (link[0] === undefined) {
+      link[0] = realpath(file);
+    }
+    return link[0];
   }
 
   getAllFiles(): Array<string> {

--- a/packages/jest-haste-map/src/index.js
+++ b/packages/jest-haste-map/src/index.js
@@ -305,6 +305,7 @@ class HasteMap extends EventEmitter {
           const rootDir = this._options.rootDir;
           const hasteFS = new HasteFS({
             files: hasteMap.files,
+            links: hasteMap.links,
             rootDir,
           });
           const moduleMap = new HasteModuleMap({
@@ -760,6 +761,7 @@ class HasteMap extends EventEmitter {
           eventsQueue,
           hasteFS: new HasteFS({
             files: hasteMap.files,
+            links: hasteMap.links,
             rootDir,
           }),
           moduleMap: new HasteModuleMap({
@@ -811,6 +813,7 @@ class HasteMap extends EventEmitter {
               clocks: new Map(hasteMap.clocks),
               duplicates: new Map(hasteMap.duplicates),
               files: new Map(hasteMap.files),
+              links: new Map(hasteMap.links),
               map: new Map(hasteMap.map),
               mocks: new Map(hasteMap.mocks),
             };
@@ -1006,6 +1009,7 @@ class HasteMap extends EventEmitter {
       clocks: new Map(),
       duplicates: new Map(),
       files: new Map(),
+      links: new Map(),
       map: new Map(),
       mocks: new Map(),
     };

--- a/types/HasteMap.js
+++ b/types/HasteMap.js
@@ -19,6 +19,7 @@ export type ModuleMap = _ModuleMap;
 export type SerializableModuleMap = _SerializableModuleMap;
 
 export type FileData = Map<Path, FileMetaData>;
+export type LinkData = Map<Path, LinkMetaData>;
 export type MockData = Map<string, Path>;
 export type ModuleMapData = Map<string, ModuleMapItem>;
 export type WatchmanClocks = Map<Path, string>;
@@ -37,6 +38,7 @@ export type InternalHasteMap = {|
   clocks: WatchmanClocks,
   duplicates: DuplicatesIndex,
   files: FileData,
+  links: LinkData,
   map: ModuleMapData,
   mocks: MockData,
 |};
@@ -61,6 +63,8 @@ export type FileMetaData = [
   /* dependencies */ Array<string>,
   /* sha1 */ ?string,
 ];
+
+export type LinkMetaData = [/* target */ ?string, /* mtime */ number];
 
 type ModuleMapItem = {[platform: string]: ModuleMetaData, __proto__: null};
 export type ModuleMetaData = [Path, /* type */ number];


### PR DESCRIPTION
- add `follow` method to `HasteFS` class
- add `links` property to `InternalHasteMap` type
- add `LinkData` map type
- add `LinkMetaData` array type

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

This PR is required by https://github.com/facebook/metro/pull/257, which also adds support for symlinks in `node_modules` directories.

Only symlinks matching `node_modules/*` or `node_modules/@*/*` are stored in the `links` property. For each symlink found, a `[target, mtime]` tuple is created. The `target` value is undefined until `hasteFS.follow` uses `fs.realpathSync` to resolve the symlink. In this way, symlinks are lazily resolved and then cached.

The user will need Watchman installed for this commit to take effect. Support for the Node crawler should be added in a future commit.

## Test plan

None yet. Not familiar with Jest's test suite, and I assume you'll want some changes, or deny this altogether in favor of a more informed direction.

I've tested this manually with arbitrary symlinks and PNPM installations.