### PR TITLE
scripts: Don’t make empty subfolders for ignored files in build folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - `[docs]` Replace shallow equality with referential identity in `ExpectAPI.md` ([#6991](https://github.com/facebook/jest/pull/6991))
 - `[jest-changed-files]` Refactor to use `execa` over `child_process` ([#6987](https://github.com/facebook/jest/pull/6987))
 - `[*]` Bump dated dependencies ([#6978](https://github.com/facebook/jest/pull/6978))
+- `[scripts]` Don’t make empty subfolders for ignored files in build folder ([#7001](https://github.com/facebook/jest/pull/7001))
 
 ## 23.6.0
 

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -7,9 +7,9 @@
 
 /**
  * script to build (transpile) files.
- * By default it transpiles all files for all packages and writes them
+ * By default it transpiles js files for all packages and writes them
  * into `build/` directory.
- * Non-js or files matching IGNORE_PATTERN will be copied without transpiling.
+ * Non-js files not matching IGNORE_PATTERN will be copied without transpiling.
  *
  * Example:
  *  node ./scripts/build.js
@@ -124,7 +124,6 @@ function buildBrowserPackage(p) {
 function buildFile(file, silent) {
   const destPath = getBuildPath(file, BUILD_DIR);
 
-  mkdirp.sync(path.dirname(destPath));
   if (micromatch.isMatch(file, IGNORE_PATTERN)) {
     silent ||
       process.stdout.write(
@@ -132,7 +131,11 @@ function buildFile(file, silent) {
           path.relative(PACKAGES_DIR, file) +
           ' (ignore)\n'
       );
-  } else if (!micromatch.isMatch(file, JS_FILES_PATTERN)) {
+    return;
+  }
+
+  mkdirp.sync(path.dirname(destPath));
+  if (!micromatch.isMatch(file, JS_FILES_PATTERN)) {
     fs.createReadStream(file).pipe(fs.createWriteStream(destPath));
     silent ||
       process.stdout.write(


### PR DESCRIPTION
## Summary

I noticed empty `build/__tests__` folder in the installed `diff-sequences@23.2.0` package.

Although I didn’t find where that problem was fixed between 23.4.0 and 23.4.1, I did find change in assumption as reason for many empty subfolders in `build` folder.

Comment in `scripts/build.js` file:

> Non-js or files matching IGNORE_PATTERN will be copied without transpiling.

For a long while, files in folders matching `IGNORE_PATTERN` are **not** copied, so `buildFile` function can return early before `mkdirp` call.

The diff after code is moved with a change takes a second look to understand what happened :(

## Test plan

`yarn build-clean` and `yarn build` and `yarn jest`

| after `yarn build` | baseline | improved |
| ---: | ---: | ---: |
| files | 250 | 250 |
| folders | 189 | 56 |
| `__tests__` or `__mocks__` folders or subfolders | 133 | 0 |
| empty folders | 83 | 0 |

The improved number of folder 56 = 189 - 133

The baseline number of empty folders 83 < 133 because some intermediate level subfolder do contain subfolders (even though they don’t contain files)

Here are the commands for rows in preceding table:

* `find packages/*/build -type f -print | wc`
* `find packages/*/build -type d -print | wc`
* `find packages/*/build -type d -print | grep -e __tests__ -e __mocks__ | wc`
* `find packages/*/build -type d -empty -print | wc`