### PR TITLE
Added method to get an iterator for all files in HasteFS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 - `[pretty-format]` Option to not escape strings in diff messages ([#5661](https://github.com/facebook/jest/pull/5661))
+- `[jest-haste-map]` Add `getFileIterator` to `HasteFS` for faster file iteration ([#7010](https://github.com/facebook/jest/pull/7010)).
 
 ### Fixes
 

--- a/packages/jest-haste-map/src/haste_fs.js
+++ b/packages/jest-haste-map/src/haste_fs.js
@@ -44,6 +44,10 @@ export default class HasteFS {
     return Array.from(this._files.keys());
   }
 
+  getFileIterator(): Iterator<string> {
+    return this._files.keys();
+  }
+
   matchFiles(pattern: RegExp | string): Array<Path> {
     if (!(pattern instanceof RegExp)) {
       pattern = new RegExp(pattern);

--- a/packages/jest-resolve-dependencies/src/index.js
+++ b/packages/jest-resolve-dependencies/src/index.js
@@ -100,10 +100,13 @@ class DependencyResolver {
         }
       }
     }
-    const modules = this._hasteFS.getAllFiles().map(file => ({
-      dependencies: this.resolve(file, options),
-      file,
-    }));
+    const modules = [];
+    for (const file of this._hasteFS.getFileIterator()) {
+      modules.push({
+        dependencies: this.resolve(file, options),
+        file,
+      });
+    }
     return Array.from(collectModules(relatedPaths, modules, changed));
   }
 }


### PR DESCRIPTION
## Summary

This method is faster if the consumer only want to traverse the files (no need to create a new array). It is especially relevant if the number of files in the map is large.

## Test plan

Only flow typechecking. This file isn't unit tested, but the code is so simple it doesn't really need it. Manually tested in the terminal.

Edit: tested through jest-resolve-dependencies, where it's used now
