### PR TITLE
Excluding second argument should not throw, but instead mark the test as skipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@
 
 ### Fixes
 
+- `[jest-circus]` Omitting test function now causes test to skip ([#6965](https://github.com/facebook/jest/pull/7013))
 - `[jest-haste-map]` [**BREAKING**] Replace internal data structures to improve performance ([#6960](https://github.com/facebook/jest/pull/6960))
 - `[jest-haste-map]` Do not visit again files with the same sha-1 ([#6990](https://github.com/facebook/jest/pull/6990))
 - `[jest-jasmine2]` Fix memory leak in Error objects hold by the framework ([#6965](https://github.com/facebook/jest/pull/6965))
+- `[jest-jasmine2]` Omitting test function now causes test to skip ([#6965](https://github.com/facebook/jest/pull/7013))
 - `[jest-haste-map]` Fixed Haste whitelist generation for scoped modules on Windows ([#6980](https://github.com/facebook/jest/pull/6980))
 - `[jest-mock]` Fix inheritance of static properties and methods in mocks ([#7003](https://github.com/facebook/jest/pull/7003))
 - `[jest-mock]` Fix mocking objects without `Object.prototype` in their prototype chain ([#7003](https://github.com/facebook/jest/pull/7003))

--- a/packages/jest-circus/src/__tests__/circus_it_test_error.test.js
+++ b/packages/jest-circus/src/__tests__/circus_it_test_error.test.js
@@ -33,11 +33,10 @@ describe('test/it error throwing', () => {
       circusIt('test1', () => {});
     }).not.toThrowError();
   });
-  it(`it throws error with missing callback function`, () => {
+  it(`it doesn't throw an error with missing callback function`, () => {
     expect(() => {
-      // $FlowFixMe: Easy, we're testing runitme errors here
       circusIt('test2');
-    }).toThrowError('Missing second argument. It must be a callback function.');
+    }).not.toThrowError();
   });
   it(`it throws an error when first argument isn't a string`, () => {
     expect(() => {
@@ -58,11 +57,10 @@ describe('test/it error throwing', () => {
       circusTest('test5', () => {});
     }).not.toThrowError();
   });
-  it(`test throws error with missing callback function`, () => {
+  it(`test doesn't throw an error with missing callback function`, () => {
     expect(() => {
-      // $FlowFixMe: Easy, we're testing runitme errors here
       circusTest('test6');
-    }).toThrowError('Missing second argument. It must be a callback function.');
+    }).not.toThrowError();
   });
   it(`test throws an error when first argument isn't a string`, () => {
     expect(() => {

--- a/packages/jest-circus/src/index.js
+++ b/packages/jest-circus/src/index.js
@@ -61,14 +61,14 @@ const afterEach: THook = (fn, timeout) =>
 const afterAll: THook = (fn, timeout) =>
   _addHook(fn, 'afterAll', afterAll, timeout);
 
-const test = (testName: TestName, fn: TestFn, timeout?: number) => {
+const test = (testName: TestName, fn?: TestFn, timeout?: number) => {
   if (typeof testName !== 'string') {
     throw new Error(
       `Invalid first argument, ${testName}. It must be a string.`,
     );
   }
   if (fn === undefined) {
-    throw new Error('Missing second argument. It must be a callback function.');
+    return test.skip(testName);
   }
   if (typeof fn !== 'function') {
     throw new Error(

--- a/packages/jest-circus/src/index.js
+++ b/packages/jest-circus/src/index.js
@@ -68,7 +68,7 @@ const test = (testName: TestName, fn?: TestFn, timeout?: number) => {
     );
   }
   if (fn === undefined) {
-    return test.skip(testName);
+    return test.skip(testName, () => {});
   }
   if (typeof fn !== 'function') {
     throw new Error(

--- a/packages/jest-jasmine2/src/__tests__/it_test_error.test.js
+++ b/packages/jest-jasmine2/src/__tests__/it_test_error.test.js
@@ -9,10 +9,10 @@
 'use strict';
 
 describe('test/it error throwing', () => {
-  it(`it throws error with missing callback function`, () => {
+  it(`it doesn\'t throw an error with missing callback function`, () => {
     expect(() => {
       it('test1');
-    }).toThrowError('Missing second argument. It must be a callback function.');
+    }).not.toThrowError();
   });
   it(`it throws an error when first argument isn't a string`, () => {
     expect(() => {
@@ -26,10 +26,10 @@ describe('test/it error throwing', () => {
       `Invalid second argument, test3b. It must be a callback function.`,
     );
   });
-  test(`test throws error with missing callback function`, () => {
+  test(`test doesn\'t throw an error with missing callback function`, () => {
     expect(() => {
       test('test4');
-    }).toThrowError('Missing second argument. It must be a callback function.');
+    }).not.toThrowError();
   });
   test(`test throws an error when first argument isn't a string`, () => {
     expect(() => {

--- a/packages/jest-jasmine2/src/__tests__/it_test_error.test.js
+++ b/packages/jest-jasmine2/src/__tests__/it_test_error.test.js
@@ -9,11 +9,6 @@
 'use strict';
 
 describe('test/it error throwing', () => {
-  it(`it doesn\'t throw an error with missing callback function`, () => {
-    expect(() => {
-      it('test1');
-    }).not.toThrowError();
-  });
   it(`it throws an error when first argument isn't a string`, () => {
     expect(() => {
       it(() => {});
@@ -25,11 +20,6 @@ describe('test/it error throwing', () => {
     }).toThrowError(
       `Invalid second argument, test3b. It must be a callback function.`,
     );
-  });
-  test(`test doesn\'t throw an error with missing callback function`, () => {
-    expect(() => {
-      test('test4');
-    }).not.toThrowError();
   });
   test(`test throws an error when first argument isn't a string`, () => {
     expect(() => {

--- a/packages/jest-jasmine2/src/jasmine/Env.js
+++ b/packages/jest-jasmine2/src/jasmine/Env.js
@@ -449,9 +449,7 @@ export default function(j$) {
         );
       }
       if (fn === undefined) {
-        throw new Error(
-          'Missing second argument. It must be a callback function.',
-        );
+        return this.xit(description);
       }
       if (typeof fn !== 'function') {
         throw new Error(

--- a/packages/jest-jasmine2/src/jasmine/Env.js
+++ b/packages/jest-jasmine2/src/jasmine/Env.js
@@ -449,7 +449,7 @@ export default function(j$) {
         );
       }
       if (fn === undefined) {
-        return this.xit(description);
+        return this.xit(description, () => {});
       }
       if (typeof fn !== 'function') {
         throw new Error(


### PR DESCRIPTION
## Summary

resolves #6430

Omitting a test function `it('should')` should default to `it.skip('should')`, not throw an error.

## Test Plan

Here it is running locally, and correctly skipping tests with no second parameter.

![image](https://user-images.githubusercontent.com/343837/45837470-07d11900-bcd5-11e8-9f6d-ccfa08051a36.png)
