### PR TITLE
Add option to call initialize and end methods in workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - `[pretty-format]` Option to not escape strings in diff messages ([#5661](https://github.com/facebook/jest/pull/5661))
 - `[jest-haste-map]` Add `getFileIterator` to `HasteFS` for faster file iteration ([#7010](https://github.com/facebook/jest/pull/7010)).
+- `[jest-worker]` [**BREAKING**] Add functionality to call a `setup` method in the worker before the first call and a `teardown` method when ending the farm ([#7014](https://github.com/facebook/jest/pull/7014)).
 
 ### Fixes
 

--- a/packages/jest-worker/README.md
+++ b/packages/jest-worker/README.md
@@ -73,6 +73,10 @@ The callback you provide is called with the method name, plus all the rest of th
 
 By default, no process is bound to any worker.
 
+#### `setupArgs: Array<mixed>` (optional)
+
+The arguments that will be passed to the `setup` method during initialization.
+
 ## Worker
 
 The returned `Worker` instance has all the exposed methods, plus some additional ones to interact with the workers itself:
@@ -90,6 +94,13 @@ Returns a `ReadableStream` where the standard error of all workers is piped. Not
 Finishes the workers by killing all workers. No further calls can be done to the `Worker` instance.
 
 **Note:** Each worker has a unique id (index that starts with `1`) which is available on `process.env.JEST_WORKER_ID`
+
+## Setting up and tearing down the child process
+
+The child process can define two special methods (both of them can be asynchronous):
+
+- `setup()`: If defined, it's executed before the first call to any method in the child.
+- `teardown()`: If defined, it's executed when the farm ends.
 
 # More examples
 

--- a/packages/jest-worker/src/__tests__/child.test.js
+++ b/packages/jest-worker/src/__tests__/child.test.js
@@ -11,6 +11,7 @@ const mockError = new TypeError('Booo');
 const mockExtendedError = new ReferenceError('Booo extended');
 const processExit = process.exit;
 const processSend = process.send;
+const uninitializedParam = {};
 const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 import {
@@ -18,13 +19,16 @@ import {
   CHILD_MESSAGE_CALL,
   CHILD_MESSAGE_END,
   PARENT_MESSAGE_OK,
-  PARENT_MESSAGE_ERROR,
+  PARENT_MESSAGE_CLIENT_ERROR,
 } from '../types';
 
+let ended;
 let mockCount;
+let initializeParm = uninitializedParam;
 
 beforeEach(() => {
   mockCount = 0;
+  ended = false;
 
   jest.mock(
     '../my-fancy-worker',
@@ -67,6 +71,14 @@ beforeEach(() => {
 
         fooWorks() {
           return 1989;
+        },
+
+        setup(param) {
+          initializeParm = param;
+        },
+
+        teardown() {
+          ended = true;
         },
       };
     },
@@ -116,6 +128,7 @@ it('lazily requires the file', () => {
   ]);
 
   expect(mockCount).toBe(0);
+  expect(initializeParm).toBe(uninitializedParam); // Not called yet.
 
   process.emit('message', [
     CHILD_MESSAGE_CALL,
@@ -125,6 +138,27 @@ it('lazily requires the file', () => {
   ]);
 
   expect(mockCount).toBe(1);
+  expect(initializeParm).toBe(undefined);
+});
+
+it('calls initialize with the correct arguments', () => {
+  expect(mockCount).toBe(0);
+
+  process.emit('message', [
+    CHILD_MESSAGE_INITIALIZE,
+    true, // Not really used here, but for flow type purity.
+    './my-fancy-worker',
+    ['foo'], // Pass empty initialize params so the initialize method is called.
+  ]);
+
+  process.emit('message', [
+    CHILD_MESSAGE_CALL,
+    true, // Not really used here, but for flow type purity.
+    'fooWorks',
+    [],
+  ]);
+
+  expect(initializeParm).toBe('foo');
 });
 
 it('returns results immediately when function is synchronous', () => {
@@ -153,7 +187,7 @@ it('returns results immediately when function is synchronous', () => {
   ]);
 
   expect(process.send.mock.calls[1][0]).toEqual([
-    PARENT_MESSAGE_ERROR,
+    PARENT_MESSAGE_CLIENT_ERROR,
     'TypeError',
     'Booo',
     mockError.stack,
@@ -168,7 +202,7 @@ it('returns results immediately when function is synchronous', () => {
   ]);
 
   expect(process.send.mock.calls[2][0]).toEqual([
-    PARENT_MESSAGE_ERROR,
+    PARENT_MESSAGE_CLIENT_ERROR,
     'Number',
     void 0,
     void 0,
@@ -183,7 +217,7 @@ it('returns results immediately when function is synchronous', () => {
   ]);
 
   expect(process.send.mock.calls[3][0]).toEqual([
-    PARENT_MESSAGE_ERROR,
+    PARENT_MESSAGE_CLIENT_ERROR,
     'ReferenceError',
     'Booo extended',
     mockExtendedError.stack,
@@ -197,7 +231,7 @@ it('returns results immediately when function is synchronous', () => {
     [],
   ]);
 
-  expect(process.send.mock.calls[4][0][0]).toBe(PARENT_MESSAGE_ERROR);
+  expect(process.send.mock.calls[4][0][0]).toBe(PARENT_MESSAGE_CLIENT_ERROR);
   expect(process.send.mock.calls[4][0][1]).toBe('Error');
   expect(process.send.mock.calls[4][0][2]).toEqual(
     '"null" or "undefined" thrown',
@@ -236,7 +270,7 @@ it('returns results when it gets resolved if function is asynchronous', async ()
   await sleep(10);
 
   expect(process.send.mock.calls[1][0]).toEqual([
-    PARENT_MESSAGE_ERROR,
+    PARENT_MESSAGE_CLIENT_ERROR,
     'TypeError',
     'Booo',
     mockError.stack,
@@ -293,6 +327,21 @@ it('finishes the process with exit code 0 if requested', () => {
   ]);
 
   expect(process.exit.mock.calls[0]).toEqual([0]);
+});
+
+it('calls the teardown method ', () => {
+  process.emit('message', [
+    CHILD_MESSAGE_INITIALIZE,
+    true, // Not really used here, but for flow type purity.
+    './my-fancy-worker',
+  ]);
+
+  process.emit('message', [
+    CHILD_MESSAGE_END,
+    true, // Not really used here, but for flow type purity.
+  ]);
+
+  expect(ended).toBe(true);
 });
 
 it('throws if an invalid message is detected', () => {

--- a/packages/jest-worker/src/__tests__/index.test.js
+++ b/packages/jest-worker/src/__tests__/index.test.js
@@ -121,6 +121,7 @@ it('tries instantiating workers with the right options', () => {
   expect(Worker.mock.calls[0][0]).toEqual({
     forkOptions: {execArgv: []},
     maxRetries: 6,
+    setupArgs: [],
     workerId: 1,
     workerPath: '/tmp/baz.js',
   });

--- a/packages/jest-worker/src/__tests__/worker.test.js
+++ b/packages/jest-worker/src/__tests__/worker.test.js
@@ -14,7 +14,7 @@ import EventEmitter from 'events';
 import {
   CHILD_MESSAGE_CALL,
   CHILD_MESSAGE_INITIALIZE,
-  PARENT_MESSAGE_ERROR,
+  PARENT_MESSAGE_CLIENT_ERROR,
   PARENT_MESSAGE_OK,
 } from '../types';
 
@@ -86,6 +86,7 @@ it('initializes the child process with the given workerPath', () => {
   new Worker({
     forkOptions: {},
     maxRetries: 3,
+    setupArgs: ['foo', 'bar'],
     workerPath: '/tmp/foo/bar/baz.js',
   });
 
@@ -93,6 +94,7 @@ it('initializes the child process with the given workerPath', () => {
     CHILD_MESSAGE_INITIALIZE,
     false,
     '/tmp/foo/bar/baz.js',
+    ['foo', 'bar'],
   ]);
 });
 
@@ -201,7 +203,7 @@ it('relates replies to requests, in order', () => {
 
   // and then the second call replies...
   forkInterface.emit('message', [
-    PARENT_MESSAGE_ERROR,
+    PARENT_MESSAGE_CLIENT_ERROR,
     'TypeError',
     'foo',
     'TypeError: foo',
@@ -287,7 +289,7 @@ it('creates error instances for known errors', () => {
   worker.send([CHILD_MESSAGE_CALL, false, 'method', []], () => {}, callback1);
 
   forkInterface.emit('message', [
-    PARENT_MESSAGE_ERROR,
+    PARENT_MESSAGE_CLIENT_ERROR,
     'TypeError',
     'bar',
     'TypeError: bar',
@@ -303,7 +305,7 @@ it('creates error instances for known errors', () => {
   worker.send([CHILD_MESSAGE_CALL, false, 'method', []], () => {}, callback2);
 
   forkInterface.emit('message', [
-    PARENT_MESSAGE_ERROR,
+    PARENT_MESSAGE_CLIENT_ERROR,
     'RandomCustomError',
     'bar',
     'RandomCustomError: bar',
@@ -320,7 +322,7 @@ it('creates error instances for known errors', () => {
   worker.send([CHILD_MESSAGE_CALL, false, 'method', []], () => {}, callback3);
 
   forkInterface.emit('message', [
-    PARENT_MESSAGE_ERROR,
+    PARENT_MESSAGE_CLIENT_ERROR,
     'Number',
     null,
     null,

--- a/packages/jest-worker/src/index.js
+++ b/packages/jest-worker/src/index.js
@@ -69,6 +69,7 @@ export default class {
     const sharedWorkerOptions = {
       forkOptions: options.forkOptions || {},
       maxRetries: options.maxRetries || 3,
+      setupArgs: options.setupArgs || [],
       workerPath,
     };
 

--- a/packages/jest-worker/src/types.js
+++ b/packages/jest-worker/src/types.js
@@ -20,7 +20,12 @@ export const CHILD_MESSAGE_CALL: 1 = 1;
 export const CHILD_MESSAGE_END: 2 = 2;
 
 export const PARENT_MESSAGE_OK: 0 = 0;
-export const PARENT_MESSAGE_ERROR: 1 = 1;
+export const PARENT_MESSAGE_CLIENT_ERROR: 1 = 1;
+export const PARENT_MESSAGE_SETUP_ERROR: 2 = 2;
+
+export type PARENT_MESSAGE_ERROR =
+  | typeof PARENT_MESSAGE_CLIENT_ERROR
+  | typeof PARENT_MESSAGE_SETUP_ERROR;
 
 // Option objects.
 
@@ -41,12 +46,14 @@ export type FarmOptions = {
   computeWorkerKey?: (string, ...Array<any>) => ?string,
   exposedMethods?: $ReadOnlyArray<string>,
   forkOptions?: ForkOptions,
+  setupArgs?: Array<mixed>,
   maxRetries?: number,
   numWorkers?: number,
 };
 
 export type WorkerOptions = {|
   forkOptions: ForkOptions,
+  setupArgs: Array<mixed>,
   maxRetries: number,
   workerId: number,
   workerPath: string,
@@ -58,6 +65,7 @@ export type ChildMessageInitialize = [
   typeof CHILD_MESSAGE_INITIALIZE, // type
   boolean, // processed
   string, // file
+  ?Array<mixed>, // setupArgs
 ];
 
 export type ChildMessageCall = [
@@ -85,7 +93,7 @@ export type ParentMessageOk = [
 ];
 
 export type ParentMessageError = [
-  typeof PARENT_MESSAGE_ERROR, // type
+  PARENT_MESSAGE_ERROR, // type
   string, // constructor
   string, // message
   string, // stack


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

There is no way to make `jest-worker` call an `initialize` method before calling a method in the worker for the first time. 

This PR adds the possibility to call an `initialize` method if it exists in the worker and an `initializeArgs` option has been passed (I've opted to not call by default this method to not make this PR a breaking change, but I can change this easily).

Also, to make the behaviour consistent, I've added some logic to call an `end` method in the worker if it exists when the Worker farm is being ended.

## Test plan

I've created unit tests to verify the behaviour