### PR TITLE
Check _isMockFunction is true rather than truthy on global properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,10 @@
 - `[jest-haste-map]` Fixed Haste whitelist generation for scoped modules on Windows ([#6980](https://github.com/facebook/jest/pull/6980))
 - `[jest-mock]` Fix inheritance of static properties and methods in mocks ([#7003](https://github.com/facebook/jest/pull/7003))
 - `[jest-mock]` Fix mocking objects without `Object.prototype` in their prototype chain ([#7003](https://github.com/facebook/jest/pull/7003))
+- `[jest-mock]` Check `_isMockFunction` is true rather than truthy on potential mocks ([#7017](https://github.com/facebook/jest/pull/7017))
 - `[jest-cli]` Update jest-cli to show git ref in message when using `changedSince` ([#7028](https://github.com/facebook/jest/pull/7028))
 - `[jest-jasmine2`] Fix crash when test return Promise rejected with null ([#7049](https://github.com/facebook/jest/pull/7049))
+- `[jest-runtime]` Check `_isMockFunction` is true rather than truthy on potential global mocks ([#7017](https://github.com/facebook/jest/pull/7017))
 
 ### Chore & Maintenance
 

--- a/e2e/__tests__/reset_modules.test.js
+++ b/e2e/__tests__/reset_modules.test.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+'use strict';
+
+const runJest = require('../runJest');
+
+test('jest.resetModules should not error when _isMockFunction is defined but not boolean', () => {
+  const result = runJest('reset_modules');
+  expect(result.status).toBe(0);
+});

--- a/e2e/reset_modules/__tests__/reset_modules.test.js
+++ b/e2e/reset_modules/__tests__/reset_modules.test.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+'use strict';
+
+global.testObject = new Proxy(
+  {},
+  {
+    get: function getter(target, key) {
+      return key;
+    },
+  }
+);
+test('jest.resetModules should not error when _isMockFunction is defined but not boolean', () => {
+  jest.resetModules();
+});

--- a/e2e/reset_modules/package.json
+++ b/e2e/reset_modules/package.json
@@ -1,0 +1,5 @@
+{
+  "jest": {
+    "testEnvironment": "node"
+  }
+}

--- a/packages/jest-mock/src/index.js
+++ b/packages/jest-mock/src/index.js
@@ -687,7 +687,7 @@ class ModuleMockerClass {
       return metadata;
     } else if (type === 'function') {
       metadata.name = component.name;
-      if (component._isMockFunction) {
+      if (component._isMockFunction === true) {
         metadata.mockImpl = component.getMockImplementation();
       }
     }
@@ -702,7 +702,7 @@ class ModuleMockerClass {
         this._getSlots(component).forEach(slot => {
           if (
             type === 'function' &&
-            component._isMockFunction &&
+            component._isMockFunction === true &&
             slot.match(/^mock/)
           ) {
             return;
@@ -727,7 +727,7 @@ class ModuleMockerClass {
   }
 
   isMockFunction(fn: any): boolean {
-    return !!(fn && fn._isMockFunction);
+    return !!fn && fn._isMockFunction === true;
   }
 
   fn(implementation?: any): any {

--- a/packages/jest-runtime/src/index.js
+++ b/packages/jest-runtime/src/index.js
@@ -430,7 +430,7 @@ class Runtime {
           (typeof globalMock === 'object' && globalMock !== null) ||
           typeof globalMock === 'function'
         ) {
-          globalMock._isMockFunction && globalMock.mockClear();
+          globalMock._isMockFunction === true && globalMock.mockClear();
         }
       });
 


### PR DESCRIPTION
Fixes #7009

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary
`resetModules` checks if `_isMockFunction` is truthy on all properties of the global object, which can lead to TypeErrors when a global property is mocked using `identity-obj-proxy`. Changing the condition to check if `_isMockFunction` is true rather than truthy will fix the issue and keep the original intent of the code, so it shouldn't cause any breaking changes.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan
Tests all ran OK.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
