### PR TITLE
babel-jest: Suggest the correct bridge version

### DIFF
--- a/packages/babel-jest/README.md
+++ b/packages/babel-jest/README.md
@@ -13,7 +13,7 @@ yarn add --dev babel-jest babel-core
 > Note: If you are using babel version 7 you have to install `babel-jest` with
 >
 > ```bash
-> yarn add --dev babel-jest 'babel-core@^7.0.0-0' @babel/core
+> yarn add --dev babel-jest 'babel-core@^7.0.0-bridge' @babel/core
 > ```
 
 If you would like to write your own preprocessor, uninstall and delete babel-jest and set the [config.transform](https://jestjs.io/docs/configuration#transform-object-string-string) option to your preprocessor.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This makes babel-jest's docs congruent with what `babel-core` suggests. From [babel-core@7.0.0-bridge.0 docs](https://www.npmjs.com/package/babel-core/v/7.0.0-bridge.0):

> to install Babel 6, they could now do
>
> `npm i some-package babel-core@^7.0.0-bridge @babel/core

## Test plan`

Nothing to test, this is just a documentation change.