### PR TITLE
Fix message when changedSince is being used 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - `[pretty-format]` Option to not escape strings in diff messages ([#5661](https://github.com/facebook/jest/pull/5661))
 - `[jest-haste-map]` Add `getFileIterator` to `HasteFS` for faster file iteration ([#7010](https://github.com/facebook/jest/pull/7010)).
 - `[jest-worker]` [**BREAKING**] Add functionality to call a `setup` method in the worker before the first call and a `teardown` method when ending the farm ([#7014](https://github.com/facebook/jest/pull/7014)).
-- `[jest-config]` [**BREAKING**] Set default `notifyMode` to `faluire-change` ([#7024](https://github.com/facebook/jest/pull/7024))
+- `[jest-config]` [**BREAKING**] Set default `notifyMode` to `failure-change` ([#7024](https://github.com/facebook/jest/pull/7024))
 
 ### Fixes
 
@@ -15,6 +15,7 @@
 - `[jest-haste-map]` Fixed Haste whitelist generation for scoped modules on Windows ([#6980](https://github.com/facebook/jest/pull/6980))
 - `[jest-mock]` Fix inheritance of static properties and methods in mocks ([#7003](https://github.com/facebook/jest/pull/7003))
 - `[jest-mock]` Fix mocking objects without `Object.prototype` in their prototype chain ([#7003](https://github.com/facebook/jest/pull/7003))
+- `[jest-cli]` Update jest-cli to show git ref in message when using `changedSince` ([#7028](https://github.com/facebook/jest/pull/7028))
 
 ### Chore & Maintenance
 

--- a/e2e/__tests__/only_changed.test.js
+++ b/e2e/__tests__/only_changed.test.js
@@ -21,6 +21,29 @@ const HG = 'hg --config ui.username=jest_test';
 beforeEach(() => cleanup(DIR));
 afterEach(() => cleanup(DIR));
 
+test('run for "onlyChanged" and "changedSince"', () => {
+  writeFiles(DIR, {
+    '.watchmanconfig': '',
+    '__tests__/file1.test.js': `require('../file1'); test('file1', () => {});`,
+    'file1.js': 'module.exports = {}',
+    'package.json': '{}',
+  });
+
+  run(`${GIT} init`, DIR);
+  run(`${GIT} add .`, DIR);
+  run(`${GIT} commit -m "first"`, DIR);
+
+  let stdout = runJest(DIR, ['-o']).stdout;
+  expect(stdout).toMatch(
+    /No tests found related to files changed since last commit./,
+  );
+
+  stdout = runJest(DIR, ['--changedSince=master']).stdout;
+  expect(stdout).toMatch(
+    /No tests found related to files changed since "master"./,
+  );
+});
+
 test('run only changed files', () => {
   writeFiles(DIR, {
     '.watchmanconfig': '',

--- a/packages/jest-cli/src/getNoTestFoundRelatedToChangedFiles.js
+++ b/packages/jest-cli/src/getNoTestFoundRelatedToChangedFiles.js
@@ -2,9 +2,10 @@ import chalk from 'chalk';
 import {isInteractive} from 'jest-util';
 
 export default function getNoTestFoundRelatedToChangedFiles(globalConfig) {
-  let msg = chalk.bold(
-    'No tests found related to files changed since last commit.',
-  );
+  const ref = globalConfig.changedSince
+    ? `"${globalConfig.changedSince}"`
+    : 'last commit';
+  let msg = chalk.bold(`No tests found related to files changed since ${ref}.`);
 
   if (isInteractive) {
     msg += chalk.dim(

--- a/packages/jest-editor-support/src/Runner.js
+++ b/packages/jest-editor-support/src/Runner.js
@@ -177,10 +177,10 @@ export default class Runner extends EventEmitter {
 
   findMessageType(buf: Buffer): MessageType {
     const str = buf.toString('utf8', 0, 58);
-    if (str === 'No tests found related to files changed since last commit.') {
+    const lastCommitRegex = /No tests found related to files changed since ((last commit)|([a-z0-9]+))./;
+    if (lastCommitRegex.test(str)) {
       return messageTypes.noTests;
     }
-
     if (/^\s*Watch Usage\b/.test(str)) {
       return messageTypes.watchUsage;
     }

--- a/packages/jest-editor-support/src/__tests__/runner.test.js
+++ b/packages/jest-editor-support/src/__tests__/runner.test.js
@@ -462,6 +462,16 @@ describe('events', () => {
       expect(runner.prevMessageTypes).toEqual([messageTypes.noTests]);
     });
 
+    it('should track when "No tests found related to files changed since master" is received', () => {
+      const data = Buffer.from(
+        'No tests found related to files changed since master.\n' +
+          'Press `a` to run all tests, or run Jest with `--watchAll`.',
+      );
+      fakeProcess.stderr.emit('data', data);
+
+      expect(runner.prevMessageTypes).toEqual([messageTypes.noTests]);
+    });
+
     it('should clear the message type history when any other other data is received', () => {
       const data = Buffer.from('');
       fakeProcess.stderr.emit('data', data);
@@ -479,6 +489,14 @@ describe('events', () => {
     it('should identify "No tests found related to files changed since last commit."', () => {
       const buf = Buffer.from(
         'No tests found related to files changed since last commit.\n' +
+          'Press `a` to run all tests, or run Jest with `--watchAll`.',
+      );
+      expect(runner.findMessageType(buf)).toBe(messageTypes.noTests);
+    });
+
+    it('should identify "No tests found related to files changed since git ref."', () => {
+      const buf = Buffer.from(
+        'No tests found related to files changed since master.\n' +
           'Press `a` to run all tests, or run Jest with `--watchAll`.',
       );
       expect(runner.findMessageType(buf)).toBe(messageTypes.noTests);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

This pull request makes a quality of life improvement as referred here (#7026). If a `changedSince` flag is being used, the test runner should update the message being shown to reflect the ref that `changedSince` is being pointed to. This PR also updates the runner to be aware of this new message format. 

## Test plan

I've added tests cases in https://github.com/facebook/jest/blob/master/e2e/__tests__/only_changed.test.js and https://github.com/facebook/jest/blob/master/packages/jest-editor-support/src/__tests__/runner.test.js to reflect the changes. 
