### PR TITLE
Fix regular expression for matching message for findMessageType

### DIFF
--- a/packages/jest-editor-support/src/Runner.js
+++ b/packages/jest-editor-support/src/Runner.js
@@ -177,7 +177,7 @@ export default class Runner extends EventEmitter {
 
   findMessageType(buf: Buffer): MessageType {
     const str = buf.toString('utf8', 0, 58);
-    const lastCommitRegex = /No tests found related to files changed since ((last commit)|([a-z0-9]+))./;
+    const lastCommitRegex = /No tests found related to files changed since ((last commit)|("[a-z0-9]+"))./;
     if (lastCommitRegex.test(str)) {
       return messageTypes.noTests;
     }

--- a/packages/jest-editor-support/src/__tests__/runner.test.js
+++ b/packages/jest-editor-support/src/__tests__/runner.test.js
@@ -464,7 +464,7 @@ describe('events', () => {
 
     it('should track when "No tests found related to files changed since master" is received', () => {
       const data = Buffer.from(
-        'No tests found related to files changed since master.\n' +
+        'No tests found related to files changed since "master".\n' +
           'Press `a` to run all tests, or run Jest with `--watchAll`.',
       );
       fakeProcess.stderr.emit('data', data);
@@ -496,7 +496,7 @@ describe('events', () => {
 
     it('should identify "No tests found related to files changed since git ref."', () => {
       const buf = Buffer.from(
-        'No tests found related to files changed since master.\n' +
+        'No tests found related to files changed since "master".\n' +
           'Press `a` to run all tests, or run Jest with `--watchAll`.',
       );
       expect(runner.findMessageType(buf)).toBe(messageTypes.noTests);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

This pull request updates the regular expression that was wrongly written in #7028 where the tests were passing because the tests were written wrongly. The quotation marks were missing in the regular expression.

## Test plan
The tests in `jest-editor-support/src/__tests__/runner.tests.js` have been updated with the the quotation marks in place.