### PR TITLE
Fix jest crashing when potentialError is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - `[jest-mock]` Fix inheritance of static properties and methods in mocks ([#7003](https://github.com/facebook/jest/pull/7003))
 - `[jest-mock]` Fix mocking objects without `Object.prototype` in their prototype chain ([#7003](https://github.com/facebook/jest/pull/7003))
 - `[jest-cli]` Update jest-cli to show git ref in message when using `changedSince` ([#7028](https://github.com/facebook/jest/pull/7028))
+- `[jest-jasmine2`] Fix crash when test return Promise rejected with null ([#7049](https://github.com/facebook/jest/pull/7049))
 
 ### Chore & Maintenance
 

--- a/e2e/__tests__/promise_reject.test.js
+++ b/e2e/__tests__/promise_reject.test.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+'use strict';
+import runJest from '../runJest';
+import path from 'path';
+
+const {cleanup, writeFiles} = require('../Utils');
+const DIR = path.resolve('../promise-reject');
+
+beforeEach(() => cleanup(DIR));
+afterEach(() => cleanup(DIR));
+
+test('', () => {
+  writeFiles(DIR, {
+    'package.json': '{}',
+    'promise_reject.test.js': `
+     test('test', () => {
+       return Promise.reject(null)
+     });
+   `,
+  });
+  const {stdout, stderr, status} = runJest(DIR);
+  expect(stdout).toBe('');
+  expect(stderr).toMatch(/(Failed|thrown): null/);
+  expect(status).toBe(1);
+});

--- a/e2e/promise-reject/package.json
+++ b/e2e/promise-reject/package.json
@@ -1,0 +1,5 @@
+{
+  "jest": {
+    "testEnvironment": "node"
+  }
+}

--- a/packages/jest-jasmine2/src/is_error.js
+++ b/packages/jest-jasmine2/src/is_error.js
@@ -12,9 +12,11 @@ import prettyFormat from 'pretty-format';
 export default function isError(potentialError: any) {
   // duck-type Error, see #2549
   const isError =
+    potentialError !== null &&
     typeof potentialError === 'object' &&
     typeof potentialError.message === 'string' &&
     typeof potentialError.name === 'string';
+
   const message = isError
     ? null
     : `Failed: ${prettyFormat(potentialError, {maxDepth: 3})}`;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

This PR fixes the scenario where a test returns a promise which rejects to null. 

Fixes #6896
Closes #6897
## Test plan

An end to end test has been added to test for this scenario. 
Note that the test assertion has two cases due to jest-jasmine and jest-circus returning different outputs for this case. 

Edit: 
Acknowledging @Pajn here for the work he has done in #6897. 
Just noting that #6897 should also be closed when this PR is accepted. 