### PR TITLE
fix: coverage summary reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Fixes
 
+- `[jest-cli]` Fix coverage summary reporting ([#7058](https://github.com/facebook/jest/pull/7058))
 - `[jest-each]` Add each array validation check ([#7033](https://github.com/facebook/jest/pull/7033))
 - `[jest-haste-map]` [**BREAKING**] Replace internal data structures to improve performance ([#6960](https://github.com/facebook/jest/pull/6960))
 - `[jest-haste-map]` Use relative paths to allow remote caching ([#7020](https://github.com/facebook/jest/pull/7020))

--- a/e2e/__tests__/__snapshots__/coverage_report.test.js.snap
+++ b/e2e/__tests__/__snapshots__/coverage_report.test.js.snap
@@ -40,6 +40,8 @@ All files |    85.71 |      100 |       50 |      100 |                   |
 ----------|----------|----------|----------|----------|-------------------|"
 `;
 
+exports[`does not output coverage report when html is requested 1`] = `""`;
+
 exports[`json reporter printing with --coverage 1`] = `
 "Test Suites: 1 failed, 1 total
 Tests:       1 failed, 2 passed, 3 total
@@ -64,4 +66,55 @@ All files                            |    56.52 |        0 |       50 |    55.56
  coverage-report/cached-duplicates/b |      100 |      100 |      100 |      100 |                   |
   Identical.js                       |      100 |      100 |      100 |      100 |                   |
 -------------------------------------|----------|----------|----------|----------|-------------------|"
+`;
+
+exports[`outputs coverage report when text and text-summary is requested 1`] = `
+"
+=============================== Coverage summary ===============================
+Statements   : 56.52% ( 13/23 )
+Branches     : 0% ( 0/4 )
+Functions    : 50% ( 3/6 )
+Lines        : 55.56% ( 10/18 )
+================================================================================
+-------------------------------------|----------|----------|----------|----------|-------------------|
+File                                 |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
+-------------------------------------|----------|----------|----------|----------|-------------------|
+All files                            |    56.52 |        0 |       50 |    55.56 |                   |
+ coverage-report                     |    41.18 |        0 |       25 |    42.86 |                   |
+  OtherFile.js                       |      100 |      100 |      100 |      100 |                   |
+  Sum.js                             |    85.71 |      100 |       50 |      100 |                   |
+  SumDependency.js                   |        0 |        0 |        0 |        0 |           8,10,12 |
+  notRequiredInTestSuite.js          |        0 |        0 |        0 |        0 |     8,15,16,17,19 |
+ coverage-report/cached-duplicates/a |      100 |      100 |      100 |      100 |                   |
+  Identical.js                       |      100 |      100 |      100 |      100 |                   |
+ coverage-report/cached-duplicates/b |      100 |      100 |      100 |      100 |                   |
+  Identical.js                       |      100 |      100 |      100 |      100 |                   |
+-------------------------------------|----------|----------|----------|----------|-------------------|"
+`;
+
+exports[`outputs coverage report when text is requested 1`] = `
+"-------------------------------------|----------|----------|----------|----------|-------------------|
+File                                 |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
+-------------------------------------|----------|----------|----------|----------|-------------------|
+All files                            |    56.52 |        0 |       50 |    55.56 |                   |
+ coverage-report                     |    41.18 |        0 |       25 |    42.86 |                   |
+  OtherFile.js                       |      100 |      100 |      100 |      100 |                   |
+  Sum.js                             |    85.71 |      100 |       50 |      100 |                   |
+  SumDependency.js                   |        0 |        0 |        0 |        0 |           8,10,12 |
+  notRequiredInTestSuite.js          |        0 |        0 |        0 |        0 |     8,15,16,17,19 |
+ coverage-report/cached-duplicates/a |      100 |      100 |      100 |      100 |                   |
+  Identical.js                       |      100 |      100 |      100 |      100 |                   |
+ coverage-report/cached-duplicates/b |      100 |      100 |      100 |      100 |                   |
+  Identical.js                       |      100 |      100 |      100 |      100 |                   |
+-------------------------------------|----------|----------|----------|----------|-------------------|"
+`;
+
+exports[`outputs coverage report when text-summary is requested 1`] = `
+"
+=============================== Coverage summary ===============================
+Statements   : 56.52% ( 13/23 )
+Branches     : 0% ( 0/4 )
+Functions    : 50% ( 3/6 )
+Lines        : 55.56% ( 10/18 )
+================================================================================"
 `;

--- a/e2e/__tests__/coverage_report.test.js
+++ b/e2e/__tests__/coverage_report.test.js
@@ -89,6 +89,53 @@ test('outputs coverage report as json', () => {
   }
 });
 
+test('outputs coverage report when text is requested', () => {
+  const {stdout, status} = runJest(DIR, [
+    '--no-cache',
+    '--coverage',
+    '--coverageReporters=text',
+    '--coverageReporters=html',
+  ]);
+  expect(status).toBe(0);
+  expect(stdout).toMatch(/Stmts | . Branch/);
+  expect(stdout).toMatchSnapshot();
+});
+
+test('outputs coverage report when text-summary is requested', () => {
+  const {stdout, status} = runJest(DIR, [
+    '--no-cache',
+    '--coverage',
+    '--coverageReporters=text-summary',
+  ]);
+  expect(status).toBe(0);
+  expect(stdout).toMatch(/Coverage summary/);
+  expect(stdout).toMatchSnapshot();
+});
+
+test('outputs coverage report when text and text-summary is requested', () => {
+  const {stdout, status} = runJest(DIR, [
+    '--no-cache',
+    '--coverage',
+    '--coverageReporters=text-summary',
+    '--coverageReporters=text',
+  ]);
+  expect(status).toBe(0);
+  expect(stdout).toMatch(/Stmts | . Branch/);
+  expect(stdout).toMatch(/Coverage summary/);
+  expect(stdout).toMatchSnapshot();
+});
+
+test('does not output coverage report when html is requested', () => {
+  const {stdout, status} = runJest(DIR, [
+    '--no-cache',
+    '--coverage',
+    '--coverageReporters=html',
+  ]);
+  expect(status).toBe(0);
+  expect(stdout).toMatch(/^$/);
+  expect(stdout).toMatchSnapshot();
+});
+
 test('collects coverage from duplicate files avoiding shared cache', () => {
   const args = [
     '--coverage',

--- a/packages/jest-cli/src/reporters/coverage_reporter.js
+++ b/packages/jest-cli/src/reporters/coverage_reporter.js
@@ -93,13 +93,10 @@ export default class CoverageReporter extends BaseReporter {
         reporter.dir = this._globalConfig.coverageDirectory;
       }
 
-      let coverageReporters = this._globalConfig.coverageReporters || [];
-      if (
-        !this._globalConfig.useStderr &&
-        coverageReporters.length &&
-        coverageReporters.indexOf('text') === -1
-      ) {
-        coverageReporters = coverageReporters.concat(['text-summary']);
+      const coverageReporters = this._globalConfig.coverageReporters || [];
+
+      if (!this._globalConfig.useStderr && coverageReporters.length < 1) {
+        coverageReporters.push('text-summary');
       }
 
       reporter.addAll(coverageReporters);


### PR DESCRIPTION
## Summary

Prevent text-summary from always being displayed when covereage is
configured. The reporters the configuration specifies should be used.
If no reporters are specified, then add the default text-summary.

Fixes #7048


## Test plan

Not really sure how to write tests for this.