### PR TITLE
[expect] Add `toBeNullish` as a matcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `[jest-worker]` [**BREAKING**] Add functionality to call a `setup` method in the worker before the first call and a `teardown` method when ending the farm ([#7014](https://github.com/facebook/jest/pull/7014)).
 - `[jest-config]` [**BREAKING**] Set default `notifyMode` to `failure-change` ([#7024](https://github.com/facebook/jest/pull/7024))
 - `[jest-snapshot]` Enable configurable snapshot paths ([#6143](https://github.com/facebook/jest/pull/6143))
+- `[expect]` Add `toBeNullish` as a matcher for `value == null` ([#7073](https://github.com/facebook/jest/pull/7073))
 
 ### Fixes
 

--- a/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -464,6 +464,18 @@ Expected: <green>1.2249999</>
 Received: <red>1.23</>"
 `;
 
+exports[`.toBeDefined(), .toBeUndefined() '""' is defined 1`] = `
+"<dim>expect(</><red>received</><dim>).</>not<dim>.toBeDefined(</><dim>)</>
+
+Received: <red>\\"\\"</>"
+`;
+
+exports[`.toBeDefined(), .toBeUndefined() '""' is defined 2`] = `
+"<dim>expect(</><red>received</><dim>).toBeUndefined(</><dim>)</>
+
+Received: <red>\\"\\"</>"
+`;
+
 exports[`.toBeDefined(), .toBeUndefined() '"a"' is defined 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.toBeDefined(</><dim>)</>
 
@@ -512,6 +524,18 @@ exports[`.toBeDefined(), .toBeUndefined() '{}' is defined 2`] = `
 Received: <red>{}</>"
 `;
 
+exports[`.toBeDefined(), .toBeUndefined() '0' is defined 1`] = `
+"<dim>expect(</><red>received</><dim>).</>not<dim>.toBeDefined(</><dim>)</>
+
+Received: <red>0</>"
+`;
+
+exports[`.toBeDefined(), .toBeUndefined() '0' is defined 2`] = `
+"<dim>expect(</><red>received</><dim>).toBeUndefined(</><dim>)</>
+
+Received: <red>0</>"
+`;
+
 exports[`.toBeDefined(), .toBeUndefined() '0.5' is defined 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.toBeDefined(</><dim>)</>
 
@@ -558,6 +582,18 @@ exports[`.toBeDefined(), .toBeUndefined() 'Map {}' is defined 2`] = `
 "<dim>expect(</><red>received</><dim>).toBeUndefined(</><dim>)</>
 
 Received: <red>Map {}</>"
+`;
+
+exports[`.toBeDefined(), .toBeUndefined() 'null' is defined 1`] = `
+"<dim>expect(</><red>received</><dim>).</>not<dim>.toBeDefined(</><dim>)</>
+
+Received: <red>null</>"
+`;
+
+exports[`.toBeDefined(), .toBeUndefined() 'null' is defined 2`] = `
+"<dim>expect(</><red>received</><dim>).toBeUndefined(</><dim>)</>
+
+Received: <red>null</>"
 `;
 
 exports[`.toBeDefined(), .toBeUndefined() 'true' is defined 1`] = `
@@ -1214,6 +1250,12 @@ exports[`.toBeNaN() throws 10`] = `
 Received: <red>-Infinity</>"
 `;
 
+exports[`.toBeNull() fails for '""' with .not 1`] = `
+"<dim>expect(</><red>received</><dim>).toBeNull(</><dim>)</>
+
+Received: <red>\\"\\"</>"
+`;
+
 exports[`.toBeNull() fails for '"a"' with .not 1`] = `
 "<dim>expect(</><red>received</><dim>).toBeNull(</><dim>)</>
 
@@ -1236,6 +1278,12 @@ exports[`.toBeNull() fails for '{}' with .not 1`] = `
 "<dim>expect(</><red>received</><dim>).toBeNull(</><dim>)</>
 
 Received: <red>{}</>"
+`;
+
+exports[`.toBeNull() fails for '0' with .not 1`] = `
+"<dim>expect(</><red>received</><dim>).toBeNull(</><dim>)</>
+
+Received: <red>0</>"
 `;
 
 exports[`.toBeNull() fails for '0.5' with .not 1`] = `
@@ -1268,8 +1316,92 @@ exports[`.toBeNull() fails for 'true' with .not 1`] = `
 Received: <red>true</>"
 `;
 
+exports[`.toBeNull() fails for 'undefined' with .not 1`] = `
+"<dim>expect(</><red>received</><dim>).toBeNull(</><dim>)</>
+
+Received: <red>undefined</>"
+`;
+
 exports[`.toBeNull() pass for null 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.toBeNull(</><dim>)</>
+
+Received: <red>null</>"
+`;
+
+exports[`.toBeNullish() fails for '""' with .not 1`] = `
+"<dim>expect(</><red>received</><dim>).toBeNullish(</><dim>)</>
+
+Received: <red>\\"\\"</>"
+`;
+
+exports[`.toBeNullish() fails for '"a"' with .not 1`] = `
+"<dim>expect(</><red>received</><dim>).toBeNullish(</><dim>)</>
+
+Received: <red>\\"a\\"</>"
+`;
+
+exports[`.toBeNullish() fails for '[]' with .not 1`] = `
+"<dim>expect(</><red>received</><dim>).toBeNullish(</><dim>)</>
+
+Received: <red>[]</>"
+`;
+
+exports[`.toBeNullish() fails for '[Function anonymous]' with .not 1`] = `
+"<dim>expect(</><red>received</><dim>).toBeNullish(</><dim>)</>
+
+Received: <red>[Function anonymous]</>"
+`;
+
+exports[`.toBeNullish() fails for '{}' with .not 1`] = `
+"<dim>expect(</><red>received</><dim>).toBeNullish(</><dim>)</>
+
+Received: <red>{}</>"
+`;
+
+exports[`.toBeNullish() fails for '0' with .not 1`] = `
+"<dim>expect(</><red>received</><dim>).toBeNullish(</><dim>)</>
+
+Received: <red>0</>"
+`;
+
+exports[`.toBeNullish() fails for '0.5' with .not 1`] = `
+"<dim>expect(</><red>received</><dim>).toBeNullish(</><dim>)</>
+
+Received: <red>0.5</>"
+`;
+
+exports[`.toBeNullish() fails for '1' with .not 1`] = `
+"<dim>expect(</><red>received</><dim>).toBeNullish(</><dim>)</>
+
+Received: <red>1</>"
+`;
+
+exports[`.toBeNullish() fails for 'Infinity' with .not 1`] = `
+"<dim>expect(</><red>received</><dim>).toBeNullish(</><dim>)</>
+
+Received: <red>Infinity</>"
+`;
+
+exports[`.toBeNullish() fails for 'Map {}' with .not 1`] = `
+"<dim>expect(</><red>received</><dim>).toBeNullish(</><dim>)</>
+
+Received: <red>Map {}</>"
+`;
+
+exports[`.toBeNullish() fails for 'true' with .not 1`] = `
+"<dim>expect(</><red>received</><dim>).toBeNullish(</><dim>)</>
+
+Received: <red>true</>"
+`;
+
+exports[`.toBeNullish() passes for null 1`] = `
+"<dim>expect(</><red>received</><dim>).</>not<dim>.toBeNullish(</><dim>)</>
+
+Received: <red>null</>"
+`;
+
+exports[`.toBeNullish() passes for undefined 1`] = `
+"<dim>expect(</><red>received</><dim>).</>not<dim>.toBeNullish(</><dim>)</>
 
 Received: <red>null</>"
 `;

--- a/packages/expect/src/__tests__/matchers.test.js
+++ b/packages/expect/src/__tests__/matchers.test.js
@@ -572,7 +572,20 @@ describe('.toBeNaN()', () => {
 });
 
 describe('.toBeNull()', () => {
-  [{}, [], true, 1, 'a', 0.5, new Map(), () => {}, Infinity].forEach(v => {
+  [
+    {},
+    [],
+    true,
+    1,
+    'a',
+    0.5,
+    new Map(),
+    () => {},
+    Infinity,
+    0,
+    '',
+    undefined,
+  ].forEach(v => {
     test(`fails for '${stringify(v)}' with .not`, () => {
       jestExpect(v).not.toBeNull();
 
@@ -589,8 +602,45 @@ describe('.toBeNull()', () => {
   });
 });
 
+describe('.toBeNullish()', () => {
+  [{}, [], true, 1, 'a', 0.5, new Map(), () => {}, Infinity, 0, ''].forEach(
+    v => {
+      test(`fails for '${stringify(v)}' with .not`, () => {
+        jestExpect(v).not.toBeNullish();
+
+        expect(() =>
+          jestExpect(v).toBeNullish(),
+        ).toThrowErrorMatchingSnapshot();
+      });
+    },
+  );
+
+  [null, undefined].forEach(v => {
+    test(`passes for ${stringify(v)}`, () => {
+      jestExpect(v).toBeNullish();
+
+      expect(() =>
+        jestExpect(null).not.toBeNullish(),
+      ).toThrowErrorMatchingSnapshot();
+    });
+  });
+});
+
 describe('.toBeDefined(), .toBeUndefined()', () => {
-  [{}, [], true, 1, 'a', 0.5, new Map(), () => {}, Infinity].forEach(v => {
+  [
+    {},
+    [],
+    true,
+    1,
+    'a',
+    0.5,
+    new Map(),
+    () => {},
+    Infinity,
+    0,
+    '',
+    null,
+  ].forEach(v => {
     test(`'${stringify(v)}' is defined`, () => {
       jestExpect(v).toBeDefined();
       jestExpect(v).not.toBeUndefined();

--- a/packages/expect/src/matchers.js
+++ b/packages/expect/src/matchers.js
@@ -242,6 +242,18 @@ const matchers: MatchersObject = {
     return {message, pass};
   },
 
+  toBeNullish(actual: any, expected: void) {
+    ensureNoExpected(expected, '.toBeNullish');
+    const pass = actual == null;
+    const message = () =>
+      matcherHint('.toBeNullish', 'received', '', {
+        isNot: this.isNot,
+      }) +
+      '\n\n' +
+      `Received: ${printReceived(actual)}`;
+    return {message, pass};
+  },
+
   toBeTruthy(actual: any, expected: void) {
     ensureNoExpected(expected, '.toBeTruthy');
     const pass = !!actual;


### PR DESCRIPTION
Right now there are matchers for checking strict equality of values to `null` and `undefined` separately, as `toBeNull` and `toBeUndefined` respectively. However, it's a common pattern to check for a value's "absense" (either being `null` **or** `undefined`) using abstract equality to null (`value == null`) -- probably the only sensible use of `==`.

This implements a matcher called `toBeNullish` which compares the value against null with `==`. The name "nullish" is borrowed from the proposal for the [nullish coalescing operator](https://github.com/tc39/proposal-nullish-coalescing), which also defines "nullish" as being either `null` or `undefined`.

I'm definitely open to feedback. Possible alternates that came to mind include:
Alternate name: `toBeNullOrUndefined`
Alternate implementation: `value === null || value === undefined`

cc @matthewwithanm @aaronabramov


<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->


<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->