### PR TITLE
Docs: Fixed img links in SnapshotTesting.md

### DIFF
--- a/docs/SnapshotTesting.md
+++ b/docs/SnapshotTesting.md
@@ -64,7 +64,7 @@ it('renders correctly', () => {
 
 In that case, Jest will print this output:
 
-![](/img/content/failedSnapshotTest.png)
+![](/website/static/img/content/failedSnapshotTest.png)
 
 Since we just updated our component to point to a different address, it's reasonable to expect changes in the snapshot for this component. Our snapshot test case is failing because the snapshot for our updated component no longer matches the snapshot artifact for this test case.
 
@@ -84,17 +84,17 @@ You can try out this functionality by cloning the [snapshot example](https://git
 
 Failed snapshots can also be updated interactively in watch mode:
 
-![](/img/content/interactiveSnapshot.png)
+![](/website/static/img/content/interactiveSnapshot.png)
 
 Once you enter Interactive Snapshot Mode, Jest will step you through the failed snapshots one test at a time and give you the opportunity to review the failed output.
 
 From here you can choose to update that snapshot or skip to the next:
 
-![](/img/content/interactiveSnapshotUpdate.gif)
+![](/website/static/img/content/interactiveSnapshotUpdate.gif)
 
 Once you're finished, Jest will give you a summary before returning back to watch mode:
 
-![](/img/content/interactiveSnapshotDone.png)
+![](/website/static/img/content/interactiveSnapshotDone.png)
 
 ### Inline Snapshots
 


### PR DESCRIPTION
## Summary

Images were broken in the repo docs since the directory were they are located has changed and links weren't updated

## Test plan

Website running in local doesnt break with this change:
<img width="1552" alt="captura de pantalla 2018-10-06 a la s 14 56 52" src="https://user-images.githubusercontent.com/8615216/46574352-22afb880-c978-11e8-8356-973b44fbc4cb.png">

