### PR TITLE
Fix unhandled error when a bad revision is provided to `changedSince`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - `[jest-jasmine2`] Fix crash when test return Promise rejected with null ([#7049](https://github.com/facebook/jest/pull/7049))
 - `[jest-runtime]` Check `_isMockFunction` is true rather than truthy on potential global mocks ([#7017](https://github.com/facebook/jest/pull/7017))
 - `[jest-jasmine]` Show proper error message from async `assert` errors ([#6821](https://github.com/facebook/jest/pull/6821))
+- `[jest-cli]` Fix unhandled error when a bad revision is provided to `changedSince` ([#7112](https://github.com/facebook/jest/pull/7112))
 
 ### Chore & Maintenance
 

--- a/packages/jest-changed-files/src/git.js
+++ b/packages/jest-changed-files/src/git.js
@@ -17,12 +17,22 @@ const findChangedFilesUsingCommand = async (
   args: Array<string>,
   cwd: Path,
 ): Promise<Array<Path>> => {
-  const result = await execa('git', args, {cwd});
+  try {
+    const result = await execa('git', args, {cwd});
 
-  return result.stdout
-    .split('\n')
-    .filter(s => s !== '')
-    .map(changedPath => path.resolve(cwd, changedPath));
+    return result.stdout
+      .split('\n')
+      .filter(s => s !== '')
+      .map(changedPath => path.resolve(cwd, changedPath));
+  } catch (e) {
+    const errorMsg = e.message.split('\n')[1];
+
+    console.error(`\n\n${errorMsg}\n`);
+
+    process.exit(0);
+
+    return [];
+  }
 };
 
 const adapter: SCMAdapter = {

--- a/packages/jest-changed-files/src/hg.js
+++ b/packages/jest-changed-files/src/hg.js
@@ -45,12 +45,22 @@ const adapter: SCMAdapter = {
     }
     args.push(...includePaths);
 
-    const result = await execa('hg', args, {cwd, env});
+    try {
+      const result = await execa('hg', args, {cwd, env});
 
-    return result.stdout
-      .split('\n')
-      .filter(s => s !== '')
-      .map(changedPath => path.resolve(cwd, changedPath));
+      return result.stdout
+        .split('\n')
+        .filter(s => s !== '')
+        .map(changedPath => path.resolve(cwd, changedPath));
+    } catch (e) {
+      const errorMsg = e.message.split('\n')[1];
+
+      console.error(`\n\n${errorMsg}\n`);
+
+      process.exit(0);
+
+      return [];
+    }
   },
 
   getRoot: async (cwd: Path): Promise<?Path> => {


### PR DESCRIPTION
## Summary

 This PR fixes #7025 – when a bad revision is passed to the `--changedSince` argument, causing an unhandled rejection error message. It will now output the error message from git/hg instead.

**Before:**
![image](https://user-images.githubusercontent.com/6972226/46574962-19672180-c961-11e8-9f66-e84ab0000be2.png)

**After**
![image](https://user-images.githubusercontent.com/6972226/46574981-592e0900-c961-11e8-89d1-73423fd2a0fc.png)

## Test plan

Updated integration tests.