### PR TITLE
Add missing export statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 - `[jest-changed-files]` Refactor to use `execa` over `child_process` ([#6987](https://github.com/facebook/jest/pull/6987))
 - `[*]` Bump dated dependencies ([#6978](https://github.com/facebook/jest/pull/6978))
 - `[scripts]` Don’t make empty subfolders for ignored files in build folder ([#7001](https://github.com/facebook/jest/pull/7001))
+- `[docs]` Add missing export statement in `puppeteer_environment.js` under `docs/Puppeteer.md` ([#7127](https://github.com/facebook/jest/pull/7127))
 
 ## 23.6.0
 

--- a/docs/Puppeteer.md
+++ b/docs/Puppeteer.md
@@ -112,6 +112,8 @@ class PuppeteerEnvironment extends NodeEnvironment {
     return super.runScript(script);
   }
 }
+
+module.exports = PuppeteerEnvironment;
 ```
 
 Finally we can close the puppeteer instance and clean-up the file


### PR DESCRIPTION
Add missing export statement in puppeteer_environment.js

Just found that the puppeteer_environment.js under docs/Puppeteer.md doesn't export the environment