### PR TITLE
[docs] Add this.extend to the Custom Matchers API reference

### DIFF
--- a/docs/ExpectAPI.md
+++ b/docs/ExpectAPI.md
@@ -113,7 +113,7 @@ expect.extend({
 });
 ```
 
-These helper functions can be found on `this` inside a custom matcher:
+These helper functions and properties can be found on `this` inside a custom matcher:
 
 #### `this.isNot`
 
@@ -122,6 +122,10 @@ A boolean to let you know this matcher was called with the negated `.not` modifi
 #### `this.equals(a, b)`
 
 This is a deep-equality function that will return `true` if two objects have the same values (recursively).
+
+#### `this.expand`
+
+A boolean to let you know this matcher was called with an `expand` option. When Jest is called with the `--expand` flag, `this.expand` is used to determine if Jest is expected to show full diffs and errors.
 
 #### `this.utils`
 

--- a/website/versioned_docs/version-22.0/ExpectAPI.md
+++ b/website/versioned_docs/version-22.0/ExpectAPI.md
@@ -63,7 +63,7 @@ test('even and odd numbers', () => {
 
 Matchers should return an object with two keys. `pass` indicates whether there was a match or not, and `message` provides a function with no arguments that returns an error message in case of failure. Thus, when `pass` is false, `message` should return the error message for when `expect(x).yourMatcher()` fails. And when `pass` is true, `message` should return the error message for when `expect(x).not.yourMatcher()` fails.
 
-These helper functions can be found on `this` inside a custom matcher:
+These helper functions and properties can be found on `this` inside a custom matcher:
 
 #### `this.isNot`
 
@@ -72,6 +72,10 @@ A boolean to let you know this matcher was called with the negated `.not` modifi
 #### `this.equals(a, b)`
 
 This is a deep-equality function that will return `true` if two objects have the same values (recursively).
+
+#### `this.expand`
+
+A boolean to let you know this matcher was called with an `expand` option. When Jest is called with the `--expand` flag, `this.expand` is used to determine if Jest is expected to show full diffs and errors.
 
 #### `this.utils`
 

--- a/website/versioned_docs/version-22.1/ExpectAPI.md
+++ b/website/versioned_docs/version-22.1/ExpectAPI.md
@@ -63,7 +63,7 @@ test('even and odd numbers', () => {
 
 Matchers should return an object with two keys. `pass` indicates whether there was a match or not, and `message` provides a function with no arguments that returns an error message in case of failure. Thus, when `pass` is false, `message` should return the error message for when `expect(x).yourMatcher()` fails. And when `pass` is true, `message` should return the error message for when `expect(x).not.yourMatcher()` fails.
 
-These helper functions can be found on `this` inside a custom matcher:
+These helper functions and properties can be found on `this` inside a custom matcher:
 
 #### `this.isNot`
 
@@ -72,6 +72,10 @@ A boolean to let you know this matcher was called with the negated `.not` modifi
 #### `this.equals(a, b)`
 
 This is a deep-equality function that will return `true` if two objects have the same values (recursively).
+
+#### `this.expand`
+
+A boolean to let you know this matcher was called with an `expand` option. When Jest is called with the `--expand` flag, `this.expand` is used to determine if Jest is expected to show full diffs and errors.
 
 #### `this.utils`
 

--- a/website/versioned_docs/version-22.2/ExpectAPI.md
+++ b/website/versioned_docs/version-22.2/ExpectAPI.md
@@ -63,7 +63,7 @@ test('even and odd numbers', () => {
 
 Matchers should return an object with two keys. `pass` indicates whether there was a match or not, and `message` provides a function with no arguments that returns an error message in case of failure. Thus, when `pass` is false, `message` should return the error message for when `expect(x).yourMatcher()` fails. And when `pass` is true, `message` should return the error message for when `expect(x).not.yourMatcher()` fails.
 
-These helper functions can be found on `this` inside a custom matcher:
+These helper functions and properties can be found on `this` inside a custom matcher:
 
 #### `this.isNot`
 
@@ -72,6 +72,10 @@ A boolean to let you know this matcher was called with the negated `.not` modifi
 #### `this.equals(a, b)`
 
 This is a deep-equality function that will return `true` if two objects have the same values (recursively).
+
+#### `this.expand`
+
+A boolean to let you know this matcher was called with an `expand` option. When Jest is called with the `--expand` flag, `this.expand` is used to determine if Jest is expected to show full diffs and errors.
 
 #### `this.utils`
 

--- a/website/versioned_docs/version-22.3/ExpectAPI.md
+++ b/website/versioned_docs/version-22.3/ExpectAPI.md
@@ -63,7 +63,7 @@ test('even and odd numbers', () => {
 
 Matchers should return an object with two keys. `pass` indicates whether there was a match or not, and `message` provides a function with no arguments that returns an error message in case of failure. Thus, when `pass` is false, `message` should return the error message for when `expect(x).yourMatcher()` fails. And when `pass` is true, `message` should return the error message for when `expect(x).not.yourMatcher()` fails.
 
-These helper functions can be found on `this` inside a custom matcher:
+These helper functions and properties can be found on `this` inside a custom matcher:
 
 #### `this.isNot`
 
@@ -72,6 +72,10 @@ A boolean to let you know this matcher was called with the negated `.not` modifi
 #### `this.equals(a, b)`
 
 This is a deep-equality function that will return `true` if two objects have the same values (recursively).
+
+#### `this.expand`
+
+A boolean to let you know this matcher was called with an `expand` option. When Jest is called with the `--expand` flag, `this.expand` is used to determine if Jest is expected to show full diffs and errors.
 
 #### `this.utils`
 

--- a/website/versioned_docs/version-23.0/ExpectAPI.md
+++ b/website/versioned_docs/version-23.0/ExpectAPI.md
@@ -96,7 +96,7 @@ test('is divisible by external value', async () => {
 
 Matchers should return an object (or a Promise of an object) with two keys. `pass` indicates whether there was a match or not, and `message` provides a function with no arguments that returns an error message in case of failure. Thus, when `pass` is false, `message` should return the error message for when `expect(x).yourMatcher()` fails. And when `pass` is true, `message` should return the error message for when `expect(x).not.yourMatcher()` fails.
 
-These helper functions can be found on `this` inside a custom matcher:
+These helper functions and properties can be found on `this` inside a custom matcher:
 
 #### `this.isNot`
 
@@ -105,6 +105,10 @@ A boolean to let you know this matcher was called with the negated `.not` modifi
 #### `this.equals(a, b)`
 
 This is a deep-equality function that will return `true` if two objects have the same values (recursively).
+
+#### `this.expand`
+
+A boolean to let you know this matcher was called with an `expand` option. When Jest is called with the `--expand` flag, `this.expand` is used to determine if Jest is expected to show full diffs and errors.
 
 #### `this.utils`
 

--- a/website/versioned_docs/version-23.1/ExpectAPI.md
+++ b/website/versioned_docs/version-23.1/ExpectAPI.md
@@ -96,7 +96,7 @@ test('is divisible by external value', async () => {
 
 Matchers should return an object (or a Promise of an object) with two keys. `pass` indicates whether there was a match or not, and `message` provides a function with no arguments that returns an error message in case of failure. Thus, when `pass` is false, `message` should return the error message for when `expect(x).yourMatcher()` fails. And when `pass` is true, `message` should return the error message for when `expect(x).not.yourMatcher()` fails.
 
-These helper functions can be found on `this` inside a custom matcher:
+These helper functions and properties can be found on `this` inside a custom matcher:
 
 #### `this.isNot`
 
@@ -105,6 +105,10 @@ A boolean to let you know this matcher was called with the negated `.not` modifi
 #### `this.equals(a, b)`
 
 This is a deep-equality function that will return `true` if two objects have the same values (recursively).
+
+#### `this.expand`
+
+A boolean to let you know this matcher was called with an `expand` option. When Jest is called with the `--expand` flag, `this.expand` is used to determine if Jest is expected to show full diffs and errors.
 
 #### `this.utils`
 

--- a/website/versioned_docs/version-23.2/ExpectAPI.md
+++ b/website/versioned_docs/version-23.2/ExpectAPI.md
@@ -96,7 +96,7 @@ test('is divisible by external value', async () => {
 
 Matchers should return an object (or a Promise of an object) with two keys. `pass` indicates whether there was a match or not, and `message` provides a function with no arguments that returns an error message in case of failure. Thus, when `pass` is false, `message` should return the error message for when `expect(x).yourMatcher()` fails. And when `pass` is true, `message` should return the error message for when `expect(x).not.yourMatcher()` fails.
 
-These helper functions can be found on `this` inside a custom matcher:
+These helper functions and properties can be found on `this` inside a custom matcher:
 
 #### `this.isNot`
 
@@ -105,6 +105,10 @@ A boolean to let you know this matcher was called with the negated `.not` modifi
 #### `this.equals(a, b)`
 
 This is a deep-equality function that will return `true` if two objects have the same values (recursively).
+
+#### `this.expand`
+
+A boolean to let you know this matcher was called with an `expand` option. When Jest is called with the `--expand` flag, `this.expand` is used to determine if Jest is expected to show full diffs and errors.
 
 #### `this.utils`
 

--- a/website/versioned_docs/version-23.3/ExpectAPI.md
+++ b/website/versioned_docs/version-23.3/ExpectAPI.md
@@ -96,7 +96,7 @@ test('is divisible by external value', async () => {
 
 Matchers should return an object (or a Promise of an object) with two keys. `pass` indicates whether there was a match or not, and `message` provides a function with no arguments that returns an error message in case of failure. Thus, when `pass` is false, `message` should return the error message for when `expect(x).yourMatcher()` fails. And when `pass` is true, `message` should return the error message for when `expect(x).not.yourMatcher()` fails.
 
-These helper functions can be found on `this` inside a custom matcher:
+These helper functions and properties can be found on `this` inside a custom matcher:
 
 #### `this.isNot`
 
@@ -105,6 +105,10 @@ A boolean to let you know this matcher was called with the negated `.not` modifi
 #### `this.equals(a, b)`
 
 This is a deep-equality function that will return `true` if two objects have the same values (recursively).
+
+#### `this.expand`
+
+A boolean to let you know this matcher was called with an `expand` option. When Jest is called with the `--expand` flag, `this.expand` is used to determine if Jest is expected to show full diffs and errors.
 
 #### `this.utils`
 

--- a/website/versioned_docs/version-23.4/ExpectAPI.md
+++ b/website/versioned_docs/version-23.4/ExpectAPI.md
@@ -96,7 +96,7 @@ test('is divisible by external value', async () => {
 
 Matchers should return an object (or a Promise of an object) with two keys. `pass` indicates whether there was a match or not, and `message` provides a function with no arguments that returns an error message in case of failure. Thus, when `pass` is false, `message` should return the error message for when `expect(x).yourMatcher()` fails. And when `pass` is true, `message` should return the error message for when `expect(x).not.yourMatcher()` fails.
 
-These helper functions can be found on `this` inside a custom matcher:
+These helper functions and properties can be found on `this` inside a custom matcher:
 
 #### `this.isNot`
 
@@ -105,6 +105,10 @@ A boolean to let you know this matcher was called with the negated `.not` modifi
 #### `this.equals(a, b)`
 
 This is a deep-equality function that will return `true` if two objects have the same values (recursively).
+
+#### `this.expand`
+
+A boolean to let you know this matcher was called with an `expand` option. When Jest is called with the `--expand` flag, `this.expand` is used to determine if Jest is expected to show full diffs and errors.
 
 #### `this.utils`
 

--- a/website/versioned_docs/version-23.5/ExpectAPI.md
+++ b/website/versioned_docs/version-23.5/ExpectAPI.md
@@ -96,7 +96,7 @@ test('is divisible by external value', async () => {
 
 Matchers should return an object (or a Promise of an object) with two keys. `pass` indicates whether there was a match or not, and `message` provides a function with no arguments that returns an error message in case of failure. Thus, when `pass` is false, `message` should return the error message for when `expect(x).yourMatcher()` fails. And when `pass` is true, `message` should return the error message for when `expect(x).not.yourMatcher()` fails.
 
-These helper functions can be found on `this` inside a custom matcher:
+These helper functions and properties can be found on `this` inside a custom matcher:
 
 #### `this.isNot`
 
@@ -105,6 +105,10 @@ A boolean to let you know this matcher was called with the negated `.not` modifi
 #### `this.equals(a, b)`
 
 This is a deep-equality function that will return `true` if two objects have the same values (recursively).
+
+#### `this.expand`
+
+A boolean to let you know this matcher was called with an `expand` option. When Jest is called with the `--expand` flag, `this.expand` is used to determine if Jest is expected to show full diffs and errors.
 
 #### `this.utils`
 

--- a/website/versioned_docs/version-23.6/ExpectAPI.md
+++ b/website/versioned_docs/version-23.6/ExpectAPI.md
@@ -114,7 +114,7 @@ expect.extend({
 });
 ```
 
-These helper functions can be found on `this` inside a custom matcher:
+These helper functions and properties can be found on `this` inside a custom matcher:
 
 #### `this.isNot`
 
@@ -123,6 +123,10 @@ A boolean to let you know this matcher was called with the negated `.not` modifi
 #### `this.equals(a, b)`
 
 This is a deep-equality function that will return `true` if two objects have the same values (recursively).
+
+#### `this.expand`
+
+A boolean to let you know this matcher was called with an `expand` option. When Jest is called with the `--expand` flag, `this.expand` is used to determine if Jest is expected to show full diffs and errors.
 
 #### `this.utils`
 


### PR DESCRIPTION
This is a follow up PR for #7091 

Per conversation on #7091, it appears that `this.expand` is in fact available inside a matcher, but there is no mention of it in the documentation, expect for the example code snippet.

## Summary

This PR adds documentation for the `this.expand` property under the _Custom Matchers API_ section of the `expect` API reference.
