### PR TITLE
Move assignment of cwd to default config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - `[jest-jasmine2]` Pending calls inside async tests are reported as pending not failed ([#6782](https://github.com/facebook/jest/pull/6782))
 - `[jest-circus]` Better error message when a describe block is empty ([#6372](https://github.com/facebook/jest/pull/6372))
 - `[jest-cli]` Fix unhandled error when a bad revision is provided to `changedSince` ([#7115](https://github.com/facebook/jest/pull/7115))
+- `[jest-config]` Moved dynamically assigned `cwd` from `jest-cli` to default configuration in `jest-config` ([#7146](https://github.com/facebook/jest/pull/7146))
 
 ### Chore & Maintenance
 

--- a/e2e/__tests__/__snapshots__/show_config.test.js.snap
+++ b/e2e/__tests__/__snapshots__/show_config.test.js.snap
@@ -12,6 +12,7 @@ exports[`--showConfig outputs config info and exits 1`] = `
       \\"coveragePathIgnorePatterns\\": [
         \\"/node_modules/\\"
       ],
+      \\"cwd\\": \\"<<REPLACED_ROOT_DIR>>\\",
       \\"detectLeaks\\": false,
       \\"detectOpenHandles\\": false,
       \\"errorOnDeprecated\\": false,

--- a/packages/jest-cli/src/runJest.js
+++ b/packages/jest-cli/src/runJest.js
@@ -29,14 +29,6 @@ import FailedTestsCache from './FailedTestsCache';
 import {JestHook} from 'jest-watcher';
 import collectNodeHandles from './collectHandles';
 
-const setConfig = (contexts, newConfig) =>
-  contexts.forEach(
-    context =>
-      (context.config = Object.freeze(
-        Object.assign({}, context.config, newConfig),
-      )),
-  );
-
 const getTestPaths = async (
   globalConfig,
   context,
@@ -255,15 +247,6 @@ export default (async function runJest({
     });
     globalConfig = Object.freeze(newConfig);
   }
-
-  // When using more than one context, make all printed paths relative to the
-  // current cwd. Do not modify rootDir, since will be used by custom resolvers.
-  // If --runInBand is true, the resolver saved a copy during initialization,
-  // however, if it is running on spawned processes, the initiation of the
-  // custom resolvers is done within each spawned process and it needs the
-  // original value of rootDir. Instead, use the {cwd: Path} property to resolve
-  // paths when printing.
-  setConfig(contexts, {cwd: process.cwd()});
 
   let collectHandles;
 

--- a/packages/jest-config/src/Defaults.js
+++ b/packages/jest-config/src/Defaults.js
@@ -29,6 +29,7 @@ export default ({
   coveragePathIgnorePatterns: [NODE_MODULES_REGEXP],
   coverageReporters: ['json', 'text', 'lcov', 'clover'],
   coverageThreshold: null,
+  cwd: process.cwd(),
   detectLeaks: false,
   detectOpenHandles: false,
   errorOnDeprecated: false,

--- a/types/Config.js
+++ b/types/Config.js
@@ -35,6 +35,7 @@ export type DefaultOptions = {|
   coveragePathIgnorePatterns: Array<string>,
   coverageReporters: Array<string>,
   coverageThreshold: ?{global: {[key: string]: number}},
+  cwd: Path,
   errorOnDeprecated: boolean,
   expand: boolean,
   filter: ?Path,


### PR DESCRIPTION
## Summary

`cwd` is assigned to the project configuration in `jest-cli`, which makes it harder to get a normalized project configuration just using `jest-config`. This adds that configuration to the defaults so anyone using it directly can have exactly the same configuration `jest-cli` would have with the same parameters.

## Test plan

I ran all current tests and manually tested that the configuration contained the default `cwd`.