### PR TITLE
[docs] Add synchronous test.each setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 
 ### Chore & Maintenance
 
+- `[docs]` Add synchronous test.each setup ([#7150](https://github.com/facebook/jest/pull/7150))
 - `[docs]` Add `this.extend` to the Custom Matchers API reference ([#7130](https://github.com/facebook/jest/pull/7130))
 - `[docs]` Fix default value for `coverageReporters` value in configuration docs ([#7126](https://github.com/facebook/jest/pull/7126))
 - `[docs]` Add link for jest-extended in expect docs ([#7078](https://github.com/facebook/jest/pull/7078))

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -192,6 +192,23 @@ Jest takes advantage of new features added to Node 6. We recommend that you upgr
 
 Make sure you are not using the `babel-plugin-istanbul` plugin. Jest wraps Istanbul, and therefore also tells Istanbul what files to instrument with coverage collection. When using `babel-plugin-istanbul`, every file that is processed by Babel will have coverage collection code, hence it is not being ignored by `coveragePathIgnorePatterns`.
 
+## Defining Tests
+
+Tests much be defined synchronously for Jest to be able to collect your tests.
+
+This means when you are using `test.each` you cannot set the table asynchronously within a `beforeEach` / `beforeAll`.
+
+As an example to show why this is the case, imagine we wrote a test like so:
+
+```js
+// Don't do this it will not work
+setTimeout(() => {
+  it('passes', () => expect(1).toBe(1));
+}, 0);
+```
+
+When Jest runs your test to collect the `test`s it will not find any because we have set the definition to happen asynchronously on the next tick of the event loop.
+
 ## Still unresolved?
 
 See [Help](/help.html).

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -194,9 +194,7 @@ Make sure you are not using the `babel-plugin-istanbul` plugin. Jest wraps Istan
 
 ## Defining Tests
 
-Tests much be defined synchronously for Jest to be able to collect your tests.
-
-This means when you are using `test.each` you cannot set the table asynchronously within a `beforeEach` / `beforeAll`.
+Tests must be defined synchronously for Jest to be able to collect your tests.
 
 As an example to show why this is the case, imagine we wrote a test like so:
 
@@ -208,6 +206,8 @@ setTimeout(() => {
 ```
 
 When Jest runs your test to collect the `test`s it will not find any because we have set the definition to happen asynchronously on the next tick of the event loop.
+
+_Note:_ This means when you are using `test.each` you cannot set the table asynchronously within a `beforeEach` / `beforeAll`.
 
 ## Still unresolved?
 

--- a/website/versioned_docs/version-23.6/Troubleshooting.md
+++ b/website/versioned_docs/version-23.6/Troubleshooting.md
@@ -195,9 +195,7 @@ Make sure you are not using the `babel-plugin-istanbul` plugin. Jest wraps Istan
 
 ## Defining Tests
 
-Tests much be defined synchronously for Jest to be able to collect your tests.
-
-This means when you are using `test.each` you cannot set the table asynchronously within a `beforeEach` / `beforeAll`.
+Tests must be defined synchronously for Jest to be able to collect your tests.
 
 As an example to show why this is the case, imagine we wrote a test like so:
 
@@ -207,6 +205,10 @@ setTimeout(() => {
   it('passes', () => expect(1).toBe(1));
 }, 0);
 ```
+
+When Jest runs your test to collect the `test`s it will not find any because we have set the definition to happen asynchronously on the next tick of the event loop.
+
+_Note:_ This means when you are using `test.each` you cannot set the table asynchronously within a `beforeEach` / `beforeAll`.
 
 When Jest runs your test to collect the `test`s it will not find any because we have set the definition to happen asynchronously on the next tick of the event loop.
 

--- a/website/versioned_docs/version-23.6/Troubleshooting.md
+++ b/website/versioned_docs/version-23.6/Troubleshooting.md
@@ -193,6 +193,23 @@ Jest takes advantage of new features added to Node 6. We recommend that you upgr
 
 Make sure you are not using the `babel-plugin-istanbul` plugin. Jest wraps Istanbul, and therefore also tells Istanbul what files to instrument with coverage collection. When using `babel-plugin-istanbul`, every file that is processed by Babel will have coverage collection code, hence it is not being ignored by `coveragePathIgnorePatterns`.
 
+## Defining Tests
+
+Tests much be defined synchronously for Jest to be able to collect your tests.
+
+This means when you are using `test.each` you cannot set the table asynchronously within a `beforeEach` / `beforeAll`.
+
+As an example to show why this is the case, imagine we wrote a test like so:
+
+```js
+// Don't do this it will not work
+setTimeout(() => {
+  it('passes', () => expect(1).toBe(1));
+}, 0);
+```
+
+When Jest runs your test to collect the `test`s it will not find any because we have set the definition to happen asynchronously on the next tick of the event loop.
+
 ## Still unresolved?
 
 See [Help](/help.html).


### PR DESCRIPTION
## Summary

Add a note on `test.each` synchronous setup.

Motivation: https://github.com/facebook/jest/issues/7100#issuecomment-429042239

## Test plan

<img width="815" alt="screen shot 2018-10-12 at 17 59 26" src="https://user-images.githubusercontent.com/5610087/46883049-98b89180-ce48-11e8-9343-e38f690fde13.png">
