### PR TITLE
expect: Improve report when assertion fails, part 3

### DIFF
--- a/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -1469,226 +1469,165 @@ Got: <green>null</>"
 `;
 
 exports[`.toContain(), .toContainEqual() '"11112111"' contains '"2"' 1`] = `
-"<dim>expect(</><red>string</><dim>).not.toContain(</><green>value</><dim>)</>
+"<dim>expect(</><red>string</><dim>).</>not<dim>.toContain(</><green>value</><dim>) // indexOf</>
 
-Expected string:
-  <red>\\"11112111\\"</>
-Not to contain value:
-  <green>\\"2\\"</>
-"
+Expected value: <green>\\"2\\"</>
+Received string: <red>\\"11112111\\"</>"
 `;
 
 exports[`.toContain(), .toContainEqual() '"abcdef"' contains '"abc"' 1`] = `
-"<dim>expect(</><red>string</><dim>).not.toContain(</><green>value</><dim>)</>
+"<dim>expect(</><red>string</><dim>).</>not<dim>.toContain(</><green>value</><dim>) // indexOf</>
 
-Expected string:
-  <red>\\"abcdef\\"</>
-Not to contain value:
-  <green>\\"abc\\"</>
-"
+Expected value: <green>\\"abc\\"</>
+Received string: <red>\\"abcdef\\"</>"
 `;
 
 exports[`.toContain(), .toContainEqual() '["a", "b", "c", "d"]' contains '"a"' 1`] = `
-"<dim>expect(</><red>array</><dim>).not.toContain(</><green>value</><dim>)</>
+"<dim>expect(</><red>array</><dim>).</>not<dim>.toContain(</><green>value</><dim>) // indexOf</>
 
-Expected array:
-  <red>[\\"a\\", \\"b\\", \\"c\\", \\"d\\"]</>
-Not to contain value:
-  <green>\\"a\\"</>
-"
+Expected value: <green>\\"a\\"</>
+Received array: <red>[\\"a\\", \\"b\\", \\"c\\", \\"d\\"]</>"
 `;
 
 exports[`.toContain(), .toContainEqual() '["a", "b", "c", "d"]' contains a value equal to '"a"' 1`] = `
-"<dim>expect(</><red>array</><dim>).not.toContainEqual(</><green>value</><dim>)</>
+"<dim>expect(</><red>array</><dim>).</>not<dim>.toContainEqual(</><green>value</><dim>) // deep equality</>
 
-Expected array:
-  <red>[\\"a\\", \\"b\\", \\"c\\", \\"d\\"]</>
-Not to contain a value equal to:
-  <green>\\"a\\"</>
-"
+Expected value: <green>\\"a\\"</>
+Received array: <red>[\\"a\\", \\"b\\", \\"c\\", \\"d\\"]</>"
 `;
 
 exports[`.toContain(), .toContainEqual() '[{"a": "b"}, {"a": "c"}]' contains a value equal to '{"a": "b"}' 1`] = `
-"<dim>expect(</><red>array</><dim>).not.toContainEqual(</><green>value</><dim>)</>
+"<dim>expect(</><red>array</><dim>).</>not<dim>.toContainEqual(</><green>value</><dim>) // deep equality</>
 
-Expected array:
-  <red>[{\\"a\\": \\"b\\"}, {\\"a\\": \\"c\\"}]</>
-Not to contain a value equal to:
-  <green>{\\"a\\": \\"b\\"}</>
-"
+Expected value: <green>{\\"a\\": \\"b\\"}</>
+Received array: <red>[{\\"a\\": \\"b\\"}, {\\"a\\": \\"c\\"}]</>"
 `;
 
 exports[`.toContain(), .toContainEqual() '[{"a": "b"}, {"a": "c"}]' does not contain a value equal to'{"a": "d"}' 1`] = `
-"<dim>expect(</><red>array</><dim>).toContainEqual(</><green>value</><dim>)</>
+"<dim>expect(</><red>array</><dim>).toContainEqual(</><green>value</><dim>) // deep equality</>
 
-Expected array:
-  <red>[{\\"a\\": \\"b\\"}, {\\"a\\": \\"c\\"}]</>
-To contain a value equal to:
-  <green>{\\"a\\": \\"d\\"}</>"
+Expected value: <green>{\\"a\\": \\"d\\"}</>
+Received array: <red>[{\\"a\\": \\"b\\"}, {\\"a\\": \\"c\\"}]</>"
 `;
 
 exports[`.toContain(), .toContainEqual() '[{}, []]' does not contain '[]' 1`] = `
-"<dim>expect(</><red>array</><dim>).toContain(</><green>value</><dim>)</>
+"<dim>expect(</><red>array</><dim>).toContain(</><green>value</><dim>) // indexOf</>
 
-Expected array:
-  <red>[{}, []]</>
-To contain value:
-  <green>[]</>
+Expected value: <green>[]</>
+Received array: <red>[{}, []]</>
 
 <dim>Looks like you wanted to test for object/array equality with the stricter \`toContain\` matcher. You probably need to use \`toContainEqual\` instead.</>"
 `;
 
 exports[`.toContain(), .toContainEqual() '[{}, []]' does not contain '{}' 1`] = `
-"<dim>expect(</><red>array</><dim>).toContain(</><green>value</><dim>)</>
+"<dim>expect(</><red>array</><dim>).toContain(</><green>value</><dim>) // indexOf</>
 
-Expected array:
-  <red>[{}, []]</>
-To contain value:
-  <green>{}</>
+Expected value: <green>{}</>
+Received array: <red>[{}, []]</>
 
 <dim>Looks like you wanted to test for object/array equality with the stricter \`toContain\` matcher. You probably need to use \`toContainEqual\` instead.</>"
 `;
 
 exports[`.toContain(), .toContainEqual() '[0, 1]' contains '1' 1`] = `
-"<dim>expect(</><red>object</><dim>).not.toContain(</><green>value</><dim>)</>
+"<dim>expect(</><red>object</><dim>).</>not<dim>.toContain(</><green>value</><dim>) // indexOf</>
 
-Expected object:
-  <red>[0, 1]</>
-Not to contain value:
-  <green>1</>
-"
+Expected value: <green>1</>
+Received object: <red>[0, 1]</>"
 `;
 
 exports[`.toContain(), .toContainEqual() '[0, 1]' contains a value equal to '1' 1`] = `
-"<dim>expect(</><red>object</><dim>).not.toContainEqual(</><green>value</><dim>)</>
+"<dim>expect(</><red>object</><dim>).</>not<dim>.toContainEqual(</><green>value</><dim>) // deep equality</>
 
-Expected object:
-  <red>[0, 1]</>
-Not to contain a value equal to:
-  <green>1</>
-"
+Expected value: <green>1</>
+Received object: <red>[0, 1]</>"
 `;
 
 exports[`.toContain(), .toContainEqual() '[1, 2, 3, 4]' contains '1' 1`] = `
-"<dim>expect(</><red>array</><dim>).not.toContain(</><green>value</><dim>)</>
+"<dim>expect(</><red>array</><dim>).</>not<dim>.toContain(</><green>value</><dim>) // indexOf</>
 
-Expected array:
-  <red>[1, 2, 3, 4]</>
-Not to contain value:
-  <green>1</>
-"
+Expected value: <green>1</>
+Received array: <red>[1, 2, 3, 4]</>"
 `;
 
 exports[`.toContain(), .toContainEqual() '[1, 2, 3, 4]' contains a value equal to '1' 1`] = `
-"<dim>expect(</><red>array</><dim>).not.toContainEqual(</><green>value</><dim>)</>
+"<dim>expect(</><red>array</><dim>).</>not<dim>.toContainEqual(</><green>value</><dim>) // deep equality</>
 
-Expected array:
-  <red>[1, 2, 3, 4]</>
-Not to contain a value equal to:
-  <green>1</>
-"
+Expected value: <green>1</>
+Received array: <red>[1, 2, 3, 4]</>"
 `;
 
 exports[`.toContain(), .toContainEqual() '[1, 2, 3]' does not contain '4' 1`] = `
-"<dim>expect(</><red>array</><dim>).toContain(</><green>value</><dim>)</>
+"<dim>expect(</><red>array</><dim>).toContain(</><green>value</><dim>) // indexOf</>
 
-Expected array:
-  <red>[1, 2, 3]</>
-To contain value:
-  <green>4</>"
+Expected value: <green>4</>
+Received array: <red>[1, 2, 3]</>"
 `;
 
 exports[`.toContain(), .toContainEqual() '[Symbol(a)]' contains 'Symbol(a)' 1`] = `
-"<dim>expect(</><red>array</><dim>).not.toContain(</><green>value</><dim>)</>
+"<dim>expect(</><red>array</><dim>).</>not<dim>.toContain(</><green>value</><dim>) // indexOf</>
 
-Expected array:
-  <red>[Symbol(a)]</>
-Not to contain value:
-  <green>Symbol(a)</>
-"
+Expected value: <green>Symbol(a)</>
+Received array: <red>[Symbol(a)]</>"
 `;
 
 exports[`.toContain(), .toContainEqual() '[Symbol(a)]' contains a value equal to 'Symbol(a)' 1`] = `
-"<dim>expect(</><red>array</><dim>).not.toContainEqual(</><green>value</><dim>)</>
+"<dim>expect(</><red>array</><dim>).</>not<dim>.toContainEqual(</><green>value</><dim>) // deep equality</>
 
-Expected array:
-  <red>[Symbol(a)]</>
-Not to contain a value equal to:
-  <green>Symbol(a)</>
-"
+Expected value: <green>Symbol(a)</>
+Received array: <red>[Symbol(a)]</>"
 `;
 
 exports[`.toContain(), .toContainEqual() '[null, undefined]' does not contain '1' 1`] = `
-"<dim>expect(</><red>array</><dim>).toContain(</><green>value</><dim>)</>
+"<dim>expect(</><red>array</><dim>).toContain(</><green>value</><dim>) // indexOf</>
 
-Expected array:
-  <red>[null, undefined]</>
-To contain value:
-  <green>1</>"
+Expected value: <green>1</>
+Received array: <red>[null, undefined]</>"
 `;
 
 exports[`.toContain(), .toContainEqual() '[undefined, null]' contains 'null' 1`] = `
-"<dim>expect(</><red>array</><dim>).not.toContain(</><green>value</><dim>)</>
+"<dim>expect(</><red>array</><dim>).</>not<dim>.toContain(</><green>value</><dim>) // indexOf</>
 
-Expected array:
-  <red>[undefined, null]</>
-Not to contain value:
-  <green>null</>
-"
+Expected value: <green>null</>
+Received array: <red>[undefined, null]</>"
 `;
 
 exports[`.toContain(), .toContainEqual() '[undefined, null]' contains 'undefined' 1`] = `
-"<dim>expect(</><red>array</><dim>).not.toContain(</><green>value</><dim>)</>
+"<dim>expect(</><red>array</><dim>).</>not<dim>.toContain(</><green>value</><dim>) // indexOf</>
 
-Expected array:
-  <red>[undefined, null]</>
-Not to contain value:
-  <green>undefined</>
-"
+Expected value: <green>undefined</>
+Received array: <red>[undefined, null]</>"
 `;
 
 exports[`.toContain(), .toContainEqual() '[undefined, null]' contains a value equal to 'null' 1`] = `
-"<dim>expect(</><red>array</><dim>).not.toContainEqual(</><green>value</><dim>)</>
+"<dim>expect(</><red>array</><dim>).</>not<dim>.toContainEqual(</><green>value</><dim>) // deep equality</>
 
-Expected array:
-  <red>[undefined, null]</>
-Not to contain a value equal to:
-  <green>null</>
-"
+Expected value: <green>null</>
+Received array: <red>[undefined, null]</>"
 `;
 
 exports[`.toContain(), .toContainEqual() '[undefined, null]' contains a value equal to 'undefined' 1`] = `
-"<dim>expect(</><red>array</><dim>).not.toContainEqual(</><green>value</><dim>)</>
+"<dim>expect(</><red>array</><dim>).</>not<dim>.toContainEqual(</><green>value</><dim>) // deep equality</>
 
-Expected array:
-  <red>[undefined, null]</>
-Not to contain a value equal to:
-  <green>undefined</>
-"
+Expected value: <green>undefined</>
+Received array: <red>[undefined, null]</>"
 `;
 
 exports[`.toContain(), .toContainEqual() 'Set {"abc", "def"}' contains '"abc"' 1`] = `
-"<dim>expect(</><red>set</><dim>).not.toContain(</><green>value</><dim>)</>
+"<dim>expect(</><red>set</><dim>).</>not<dim>.toContain(</><green>value</><dim>) // indexOf</>
 
-Expected set:
-  <red>Set {\\"abc\\", \\"def\\"}</>
-Not to contain value:
-  <green>\\"abc\\"</>
-"
+Expected value: <green>\\"abc\\"</>
+Received set: <red>Set {\\"abc\\", \\"def\\"}</>"
 `;
 
 exports[`.toContain(), .toContainEqual() 'Set {1, 2, 3, 4}' contains a value equal to '1' 1`] = `
-"<dim>expect(</><red>set</><dim>).not.toContainEqual(</><green>value</><dim>)</>
+"<dim>expect(</><red>set</><dim>).</>not<dim>.toContainEqual(</><green>value</><dim>) // deep equality</>
 
-Expected set:
-  <red>Set {1, 2, 3, 4}</>
-Not to contain a value equal to:
-  <green>1</>
-"
+Expected value: <green>1</>
+Received set: <red>Set {1, 2, 3, 4}</>"
 `;
 
 exports[`.toContain(), .toContainEqual() error cases 1`] = `
-"<dim>expect(</><red>collection</><dim>)[.not].toContainEqual(</><green>value</><dim>)</>
+"<dim>expect(</><red>collection</><dim>)[.not].toContain(</><green>value</><dim>)</>
 
 Expected <red>collection</> to be an array-like structure.
 Received: <red>null</>"
@@ -2742,111 +2681,81 @@ Received:
 exports[`.toHaveLength {pass: false} expect("").toHaveLength(1) 1`] = `
 "<dim>expect(</><red>received</><dim>).toHaveLength(</><green>length</><dim>)</>
 
-Expected value to have length:
-  <green>1</>
-Received:
-  <red>\\"\\"</>
-received.length:
-  <red>0</>"
+Expected length: <green>1</>
+Received length: <red>0</>
+Received value: <red>\\"\\"</>"
 `;
 
 exports[`.toHaveLength {pass: false} expect("abc").toHaveLength(66) 1`] = `
 "<dim>expect(</><red>received</><dim>).toHaveLength(</><green>length</><dim>)</>
 
-Expected value to have length:
-  <green>66</>
-Received:
-  <red>\\"abc\\"</>
-received.length:
-  <red>3</>"
+Expected length: <green>66</>
+Received length: <red>3</>
+Received value: <red>\\"abc\\"</>"
 `;
 
 exports[`.toHaveLength {pass: false} expect(["a", "b"]).toHaveLength(99) 1`] = `
 "<dim>expect(</><red>received</><dim>).toHaveLength(</><green>length</><dim>)</>
 
-Expected value to have length:
-  <green>99</>
-Received:
-  <red>[\\"a\\", \\"b\\"]</>
-received.length:
-  <red>2</>"
+Expected length: <green>99</>
+Received length: <red>2</>
+Received value: <red>[\\"a\\", \\"b\\"]</>"
 `;
 
 exports[`.toHaveLength {pass: false} expect([]).toHaveLength(1) 1`] = `
 "<dim>expect(</><red>received</><dim>).toHaveLength(</><green>length</><dim>)</>
 
-Expected value to have length:
-  <green>1</>
-Received:
-  <red>[]</>
-received.length:
-  <red>0</>"
+Expected length: <green>1</>
+Received length: <red>0</>
+Received value: <red>[]</>"
 `;
 
 exports[`.toHaveLength {pass: false} expect([1, 2]).toHaveLength(3) 1`] = `
 "<dim>expect(</><red>received</><dim>).toHaveLength(</><green>length</><dim>)</>
 
-Expected value to have length:
-  <green>3</>
-Received:
-  <red>[1, 2]</>
-received.length:
-  <red>2</>"
+Expected length: <green>3</>
+Received length: <red>2</>
+Received value: <red>[1, 2]</>"
 `;
 
 exports[`.toHaveLength {pass: true} expect("").toHaveLength(0) 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toHaveLength(</><green>length</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.toHaveLength(</><green>length</><dim>)</>
 
-Expected value to not have length:
-  <green>0</>
-Received:
-  <red>\\"\\"</>
-received.length:
-  <red>0</>"
+Expected length: <green>0</>
+Received length: <red>0</>
+Received value: <red>\\"\\"</>"
 `;
 
 exports[`.toHaveLength {pass: true} expect("abc").toHaveLength(3) 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toHaveLength(</><green>length</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.toHaveLength(</><green>length</><dim>)</>
 
-Expected value to not have length:
-  <green>3</>
-Received:
-  <red>\\"abc\\"</>
-received.length:
-  <red>3</>"
+Expected length: <green>3</>
+Received length: <red>3</>
+Received value: <red>\\"abc\\"</>"
 `;
 
 exports[`.toHaveLength {pass: true} expect(["a", "b"]).toHaveLength(2) 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toHaveLength(</><green>length</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.toHaveLength(</><green>length</><dim>)</>
 
-Expected value to not have length:
-  <green>2</>
-Received:
-  <red>[\\"a\\", \\"b\\"]</>
-received.length:
-  <red>2</>"
+Expected length: <green>2</>
+Received length: <red>2</>
+Received value: <red>[\\"a\\", \\"b\\"]</>"
 `;
 
 exports[`.toHaveLength {pass: true} expect([]).toHaveLength(0) 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toHaveLength(</><green>length</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.toHaveLength(</><green>length</><dim>)</>
 
-Expected value to not have length:
-  <green>0</>
-Received:
-  <red>[]</>
-received.length:
-  <red>0</>"
+Expected length: <green>0</>
+Received length: <red>0</>
+Received value: <red>[]</>"
 `;
 
 exports[`.toHaveLength {pass: true} expect([1, 2]).toHaveLength(2) 1`] = `
-"<dim>expect(</><red>received</><dim>).not.toHaveLength(</><green>length</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.toHaveLength(</><green>length</><dim>)</>
 
-Expected value to not have length:
-  <green>2</>
-Received:
-  <red>[1, 2]</>
-received.length:
-  <red>2</>"
+Expected length: <green>2</>
+Received length: <red>2</>
+Received value: <red>[1, 2]</>"
 `;
 
 exports[`.toHaveLength error cases 1`] = `

--- a/packages/expect/src/matchers.js
+++ b/packages/expect/src/matchers.js
@@ -280,7 +280,7 @@ const matchers: MatchersObject = {
         converted = Array.from(collection);
       } catch (e) {
         throw new Error(
-          matcherHint('[.not].toContainEqual', 'collection', 'value') +
+          matcherHint('[.not].toContain', 'collection', 'value') +
             '\n\n' +
             `Expected ${RECEIVED_COLOR(
               'collection',
@@ -289,17 +289,19 @@ const matchers: MatchersObject = {
         );
       }
     }
+    const comment = 'indexOf';
     // At this point, we're either a string or an Array,
     // which was converted from an array-like structure.
     const pass = converted.indexOf(value) != -1;
     const message = pass
       ? () =>
-          matcherHint('.not.toContain', collectionType, 'value') +
+          matcherHint('.toContain', collectionType, 'value', {
+            comment,
+            isNot: this.isNot,
+          }) +
           '\n\n' +
-          `Expected ${collectionType}:\n` +
-          `  ${printReceived(collection)}\n` +
-          `Not to contain value:\n` +
-          `  ${printExpected(value)}\n`
+          `Expected value: ${printExpected(value)}\n` +
+          `Received ${collectionType}: ${printReceived(collection)}`
       : () => {
           const suggestToContainEqual =
             converted !== null &&
@@ -309,12 +311,13 @@ const matchers: MatchersObject = {
               equals(item, value, [iterableEquality]),
             ) !== -1;
           return (
-            matcherHint('.toContain', collectionType, 'value') +
+            matcherHint('.toContain', collectionType, 'value', {
+              comment,
+              isNot: this.isNot,
+            }) +
             '\n\n' +
-            `Expected ${collectionType}:\n` +
-            `  ${printReceived(collection)}\n` +
-            `To contain value:\n` +
-            `  ${printExpected(value)}` +
+            `Expected value: ${printExpected(value)}\n` +
+            `Received ${collectionType}: ${printReceived(collection)}` +
             (suggestToContainEqual ? `\n\n${SUGGEST_TO_CONTAIN_EQUAL}` : '')
           );
         };
@@ -342,24 +345,18 @@ const matchers: MatchersObject = {
       }
     }
 
+    const comment = 'deep equality';
     const pass =
       converted.findIndex(item => equals(item, value, [iterableEquality])) !==
       -1;
-    const message = pass
-      ? () =>
-          matcherHint('.not.toContainEqual', collectionType, 'value') +
-          '\n\n' +
-          `Expected ${collectionType}:\n` +
-          `  ${printReceived(collection)}\n` +
-          `Not to contain a value equal to:\n` +
-          `  ${printExpected(value)}\n`
-      : () =>
-          matcherHint('.toContainEqual', collectionType, 'value') +
-          '\n\n' +
-          `Expected ${collectionType}:\n` +
-          `  ${printReceived(collection)}\n` +
-          `To contain a value equal to:\n` +
-          `  ${printExpected(value)}`;
+    const message = () =>
+      matcherHint('.toContainEqual', collectionType, 'value', {
+        comment,
+        isNot: this.isNot,
+      }) +
+      '\n\n' +
+      `Expected value: ${printExpected(value)}\n` +
+      `Received ${collectionType}: ${printReceived(collection)}`;
 
     return {message, pass};
   },
@@ -414,25 +411,14 @@ const matchers: MatchersObject = {
     }
 
     const pass = received.length === length;
-    const message = pass
-      ? () =>
-          matcherHint('.not.toHaveLength', 'received', 'length') +
-          '\n\n' +
-          `Expected value to not have length:\n` +
-          `  ${printExpected(length)}\n` +
-          `Received:\n` +
-          `  ${printReceived(received)}\n` +
-          `received.length:\n` +
-          `  ${printReceived(received.length)}`
-      : () =>
-          matcherHint('.toHaveLength', 'received', 'length') +
-          '\n\n' +
-          `Expected value to have length:\n` +
-          `  ${printExpected(length)}\n` +
-          `Received:\n` +
-          `  ${printReceived(received)}\n` +
-          `received.length:\n` +
-          `  ${printReceived(received.length)}`;
+    const message = () =>
+      matcherHint('.toHaveLength', 'received', 'length', {
+        isNot: this.isNot,
+      }) +
+      '\n\n' +
+      `Expected length: ${printExpected(length)}\n` +
+      `Received length: ${printReceived(received.length)}\n` +
+      `Received value: ${printReceived(received)}`;
 
     return {message, pass};
   },


### PR DESCRIPTION
## Summary

Delete paraphrased info from value labels which the description line can communicate by formatting.

* “Expected …” phrase above **received** value makes me stop and reread every time :(
* Especially because `Expected:` and `Received:` have same length without paraphrased info, display values starting on **same line** instead of indented on following line.

Will continue in small chunks picking up from #5437 and #5512

After small chunks, matcher name from dim to regular font weight will affect hundreds of snapshots.

## Test plan

Updated 33 snapshots.

Examples of baseline and improved reports:

<img width="900" alt="tocontain" src="https://user-images.githubusercontent.com/11862657/46886090-ce00b780-ce27-11e8-87fb-c7ce335d844f.png">

Examples of baseline and improved reports with `.not` notice **regular** font weight:

<img width="900" alt="not-tocontain" src="https://user-images.githubusercontent.com/11862657/46886103-db1da680-ce27-11e8-94e7-3a279a354000.png">
