### PR TITLE
Fix `getMaxWorkers` on termux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - `[jest-circus]` Better error message when a describe block is empty ([#6372](https://github.com/facebook/jest/pull/6372))
 - `[jest-cli]` Fix unhandled error when a bad revision is provided to `changedSince` ([#7115](https://github.com/facebook/jest/pull/7115))
 - `[jest-config]` Moved dynamically assigned `cwd` from `jest-cli` to default configuration in `jest-config` ([#7146](https://github.com/facebook/jest/pull/7146))
+- `[jest-config]` Fix `getMaxWorkers` on termux ([#7154](https://github.com/facebook/jest/pull/7154))
 
 ### Chore & Maintenance
 

--- a/packages/jest-config/src/__mocks__/os.js
+++ b/packages/jest-config/src/__mocks__/os.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+const os = jest.genMockFromModule('os');
+
+let cpus;
+function __setCpus(newCpus) {
+  cpus = newCpus;
+}
+
+os.__setCpus = __setCpus;
+os.cpus = jest.fn(() => cpus);
+
+module.exports = os;

--- a/packages/jest-config/src/__tests__/getMaxWorkers.test.js
+++ b/packages/jest-config/src/__tests__/getMaxWorkers.test.js
@@ -8,14 +8,21 @@
 
 import getMaxWorkers from '../getMaxWorkers';
 
-jest.mock('os', () => ({
-  cpus: () => ({length: 4}),
-}));
+jest.mock('os');
 
 describe('getMaxWorkers', () => {
+  beforeEach(() => {
+    require('os').__setCpus({length: 4});
+  });
+
   it('Returns 1 when runInBand', () => {
     const argv = {runInBand: true};
     expect(getMaxWorkers(argv)).toBe(1);
+  });
+
+  it('Returns 1 when the OS CPUs are not available', () => {
+    require('os').__setCpus(undefined);
+    expect(getMaxWorkers({})).toBe(1);
   });
 
   it('Returns the `maxWorkers` when specified', () => {

--- a/packages/jest-config/src/getMaxWorkers.js
+++ b/packages/jest-config/src/getMaxWorkers.js
@@ -17,7 +17,7 @@ export default function getMaxWorkers(argv: Argv): number {
   } else if (argv.maxWorkers) {
     return parseInt(argv.maxWorkers, 10);
   } else {
-    const cpus = os.cpus().length;
+    const cpus = os.cpus() ? os.cpus().length : 1;
     return Math.max(argv.watch ? Math.floor(cpus / 2) : cpus - 1, 1);
   }
 }


### PR DESCRIPTION
## Summary

Jest is using `getMaxWorkers` to figure out how many CPUs to use in parallel to run the test suite. However, it's using node's `os.cpus()`, which unfortunately might not return an answer if the corresponding system information is not available.

That's what happens under [termux](https://termux.com), a popular terminal emulator for Android. Using termux, we get:

```
> os = require('os')
...
> os.cpus()
undefined
```

This small detail is crashing jest, since it's trying to read `length` from an undefined object:

```js
const cpus = os.cpus().length;
```

The proposed solution is to default the result of `getMaxWorkers` to 1 when `os.cpus()` is undefined. This is enough to fix the crash.

## Test plan

Coverage for `getMaxWorkers` was updated to reflect the new changes.

In addition, to verify the goal of the PR was achieved, one can run jest on termux in any version of Android, termux and node. The code without this fix should crash, and with this fix it should run successfully.