### PR TITLE
Fix for 'Good First Issue' url in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Facebook has adopted a Code of Conduct that we expect project participants to ad
 
 Read our [contributing guide](CONTRIBUTING.md) to learn about our development process, how to propose bugfixes and improvements, and how to build and test your changes to Jest.
 
-### [Good First Issues](https://github.com/facebook/jest/labels/Good%20First%20Issue%20%3Awave%3A)
+### [Good First Issues](https://github.com/facebook/jest/labels/wave%3AGood%20First%20Issue%20%3A)
 
 To help you get your feet wet and get you familiar with our contribution process, we have a list of [good first issues](https://github.com/facebook/jest/labels/Good%20First%20Issue%20%3Awave%3A) that contain bugs which have a relatively limited scope. This is a great place to get started.
 

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Facebook has adopted a Code of Conduct that we expect project participants to ad
 
 Read our [contributing guide](CONTRIBUTING.md) to learn about our development process, how to propose bugfixes and improvements, and how to build and test your changes to Jest.
 
-### [Good First Issues](https://github.com/facebook/jest/labels/wave%3AGood%20First%20Issue%20%3A)
+### [Good First Issues](https://github.com/facebook/jest/labels/wave%3A%20Good%20First%20Issue%20%3A)
 
 To help you get your feet wet and get you familiar with our contribution process, we have a list of [good first issues](https://github.com/facebook/jest/labels/Good%20First%20Issue%20%3Awave%3A) that contain bugs which have a relatively limited scope. This is a great place to get started.
 

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Facebook has adopted a Code of Conduct that we expect project participants to ad
 
 Read our [contributing guide](CONTRIBUTING.md) to learn about our development process, how to propose bugfixes and improvements, and how to build and test your changes to Jest.
 
-### [Good First Issues](https://github.com/facebook/jest/labels/wave%3A%20Good%20First%20Issue%20%3A)
+### [Good First Issues](https://github.com/facebook/jest/labels/3Awave%3A%20Good%20First%20Issue)
 
 To help you get your feet wet and get you familiar with our contribution process, we have a list of [good first issues](https://github.com/facebook/jest/labels/Good%20First%20Issue%20%3Awave%3A) that contain bugs which have a relatively limited scope. This is a great place to get started.
 

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Facebook has adopted a Code of Conduct that we expect project participants to ad
 
 Read our [contributing guide](CONTRIBUTING.md) to learn about our development process, how to propose bugfixes and improvements, and how to build and test your changes to Jest.
 
-### [Good First Issues](https://github.com/facebook/jest/labels/3Awave%3A%20Good%20First%20Issue)
+### [Good First Issues](https://github.com/facebook/jest/labels/%3Awave%3A%20Good%20First%20Issue)
 
 To help you get your feet wet and get you familiar with our contribution process, we have a list of [good first issues](https://github.com/facebook/jest/labels/Good%20First%20Issue%20%3Awave%3A) that contain bugs which have a relatively limited scope. This is a great place to get started.
 


### PR DESCRIPTION
This fixes the 'Good First Issue' url in the readme under the 'Contributing' section.
Currently when the link is clicked it will redirect users to the 'Issues' page for this project, but no issues will be displayed because the label has an error in its formatting.