### PR TITLE
Simpify getting object type name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,10 @@
 - `[docs]` Removed useless expect.assertions in `TestingAsyncCode.md` ([#7131](https://github.com/facebook/jest/pull/7131))
 - `[docs]` Remove references to `@providesModule` which isn't supported anymore ([#7147](https://github.com/facebook/jest/pull/7147))
 
+### Performance
+
+- `[jest-mock]` Improve `getType` function performance. ([#7159](https://github.com/facebook/jest/pull/7159))
+
 ## 23.6.0
 
 ### Features

--- a/packages/jest-mock/src/index.js
+++ b/packages/jest-mock/src/index.js
@@ -173,31 +173,36 @@ function matchArity(fn: any, length: number): any {
   return mockConstructor;
 }
 
-function isA(typeName: string, value: any): boolean {
-  return Object.prototype.toString.apply(value) === '[object ' + typeName + ']';
+function getObjectType(value: any): string {
+  return Object.prototype.toString.apply(value).slice(8, -1);
 }
 
 function getType(ref?: any): string | null {
+  const typeName = getObjectType(ref);
   if (
-    isA('Function', ref) ||
-    isA('AsyncFunction', ref) ||
-    isA('GeneratorFunction', ref)
+    typeName === 'Function' ||
+    typeName === 'AsyncFunction' ||
+    typeName === 'GeneratorFunction'
   ) {
     return 'function';
   } else if (Array.isArray(ref)) {
     return 'array';
-  } else if (isA('Object', ref)) {
+  } else if (typeName === 'Object') {
     return 'object';
   } else if (
-    isA('Number', ref) ||
-    isA('String', ref) ||
-    isA('Boolean', ref) ||
-    isA('Symbol', ref)
+    typeName === 'Number' ||
+    typeName === 'String' ||
+    typeName === 'Boolean' ||
+    typeName === 'Symbol'
   ) {
     return 'constant';
-  } else if (isA('Map', ref) || isA('WeakMap', ref) || isA('Set', ref)) {
+  } else if (
+    typeName === 'Map' ||
+    typeName === 'WeakMap' ||
+    typeName === 'Set'
+  ) {
     return 'collection';
-  } else if (isA('RegExp', ref)) {
+  } else if (typeName === 'RegExp') {
     return 'regexp';
   } else if (ref === undefined) {
     return 'undefined';
@@ -209,21 +214,31 @@ function getType(ref?: any): string | null {
 }
 
 function isReadonlyProp(object: any, prop: string): boolean {
-  return (
-    ((prop === 'arguments' ||
-      prop === 'caller' ||
-      prop === 'callee' ||
-      prop === 'name' ||
-      prop === 'length') &&
-      (isA('Function', object) ||
-        isA('AsyncFunction', object) ||
-        isA('GeneratorFunction', object))) ||
-    ((prop === 'source' ||
-      prop === 'global' ||
-      prop === 'ignoreCase' ||
-      prop === 'multiline') &&
-      isA('RegExp', object))
-  );
+  if (
+    prop === 'arguments' ||
+    prop === 'caller' ||
+    prop === 'callee' ||
+    prop === 'name' ||
+    prop === 'length'
+  ) {
+    const typeName = getObjectType(object);
+    return (
+      typeName === 'Function' ||
+      typeName === 'AsyncFunction' ||
+      typeName === 'GeneratorFunction'
+    );
+  }
+
+  if (
+    prop === 'source' ||
+    prop === 'global' ||
+    prop === 'ignoreCase' ||
+    prop === 'multiline'
+  ) {
+    return getObjectType(object) === 'RegExp';
+  }
+
+  return false;
 }
 
 class ModuleMockerClass {


### PR DESCRIPTION
## Summary
There is function for checking object type
```js
function isA(typeName: string, value: any): boolean {
  return Object.prototype.toString.apply(value) === '[object ' + typeName + ']';
}
```
But this function called many times for same object. (12 times for same ref)
```js
isA('Number', ref) ||
isA('String', ref) ||
isA('Boolean', ref) ||
isA('Symbol', ref)
... 
```

My fix added caching object name to avoid needless `Object.prototype.toString.apply(value) === '[object ' + typeName + ']'`.

We just can get object name only once.
```js
function getObjectType(value: any): string {
  return Object.prototype.toString.apply(value).slice(8, -1);
}


typeName === 'Number' ||
typeName === 'String' ||
typeName === 'Boolean' ||
typeName === 'Symbol'
...
```

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
