### PR TITLE
Add the "DOM Manipulation" page to the section "guides" on the website

### DIFF
--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -20,6 +20,7 @@
       "webpack",
       "puppeteer",
       "mongodb",
+      "tutorial-jquery",
       "watch-plugins",
       "migration-guide",
       "troubleshooting"

--- a/website/versioned_sidebars/version-22.0-sidebars.json
+++ b/website/versioned_sidebars/version-22.0-sidebars.json
@@ -16,6 +16,7 @@
       "version-22.0-manual-mocks",
       "version-22.0-webpack",
       "version-22.0-puppeteer",
+      "version-22.0-tutorial-jquery",
       "version-22.0-migration-guide",
       "version-22.0-troubleshooting"
     ],

--- a/website/versioned_sidebars/version-22.1-sidebars.json
+++ b/website/versioned_sidebars/version-22.1-sidebars.json
@@ -16,6 +16,7 @@
       "version-22.1-manual-mocks",
       "version-22.1-webpack",
       "version-22.1-puppeteer",
+      "version-22.1-tutorial-jquery",
       "version-22.1-migration-guide",
       "version-22.1-troubleshooting"
     ],

--- a/website/versioned_sidebars/version-22.2-sidebars.json
+++ b/website/versioned_sidebars/version-22.2-sidebars.json
@@ -17,6 +17,7 @@
       "version-22.2-es6-class-mocks",
       "version-22.2-webpack",
       "version-22.2-puppeteer",
+      "version-22.2-tutorial-jquery",
       "version-22.2-migration-guide",
       "version-22.2-troubleshooting"
     ],

--- a/website/versioned_sidebars/version-22.3-sidebars.json
+++ b/website/versioned_sidebars/version-22.3-sidebars.json
@@ -18,6 +18,7 @@
       "version-22.3-webpack",
       "version-22.3-puppeteer",
       "version-22.3-mongodb",
+      "version-22.3-tutorial-jquery",
       "version-22.3-migration-guide",
       "version-22.3-troubleshooting"
     ],

--- a/website/versioned_sidebars/version-23.0-sidebars.json
+++ b/website/versioned_sidebars/version-23.0-sidebars.json
@@ -19,6 +19,7 @@
       "version-23.0-webpack",
       "version-23.0-puppeteer",
       "version-23.0-mongodb",
+      "version-23.0-tutorial-jquery",
       "version-23.0-watch-plugins",
       "version-23.0-migration-guide",
       "version-23.0-troubleshooting"

--- a/website/versioned_sidebars/version-23.4-sidebars.json
+++ b/website/versioned_sidebars/version-23.4-sidebars.json
@@ -20,6 +20,7 @@
       "version-23.4-webpack",
       "version-23.4-puppeteer",
       "version-23.4-mongodb",
+      "version-23.4-tutorial-jquery",
       "version-23.4-watch-plugins",
       "version-23.4-migration-guide",
       "version-23.4-troubleshooting"


### PR DESCRIPTION

FIXES: #7133

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

The document "DOM Manipulation" is archived with all other guides but was inaccessible through the website sidebar, this commit make this page accessible through the sidebar

## Test plan

I ran `yarn build` and `yarn start` on the website folder, and the page "DOM Manipulation" was visible on the sidebar under the "Guides" section as desired
