### PR TITLE
Make ignorePattern optional in HasteMap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - `[pretty-format]` Support HTMLCollection and NodeList in DOMCollection plugin ([#7125](https://github.com/facebook/jest/pull/7125))
 - `[jest-runtime]` Pass the normalized configuration to script transformers ([#7148](https://github.com/facebook/jest/pull/7148))
 - `[jest-runtime]` If `require` fails without a file extension, print all files that match with one ([#7160](https://github.com/facebook/jest/pull/7160))
+- `[jest-haste-map]` Make `ignorePattern` optional ([#7166](https://github.com/facebook/jest/pull/7166))
+- `[jest-runtime]` Remove `cacheDirectory` from `ignorePattern` for `HasteMap` if not necessary ([#7166](https://github.com/facebook/jest/pull/7166))
 
 ### Fixes
 

--- a/packages/jest-haste-map/src/__tests__/index.test.js
+++ b/packages/jest-haste-map/src/__tests__/index.test.js
@@ -144,9 +144,6 @@ describe('HasteMap', () => {
       '/project/fruits/Banana.js': `
         const Strawberry = require("Strawberry");
       `,
-      '/project/fruits/Kiwi.js': `
-        // Kiwi!
-      `,
       '/project/fruits/Pear.js': `
         const Banana = require("Banana");
         const Strawberry = require("Strawberry");
@@ -189,7 +186,6 @@ describe('HasteMap', () => {
     defaultConfig = {
       extensions: ['js', 'json'],
       hasteImplModulePath: require.resolve('./haste_impl.js'),
-      ignorePattern: /Kiwi/,
       maxWorkers: 1,
       name: 'haste-map-test',
       platforms: ['ios', 'android'],
@@ -236,6 +232,16 @@ describe('HasteMap', () => {
         '/project/fruits/__mocks__/Pear.js',
       ]);
     }));
+
+  it('ignores files given a pattern', () => {
+    const config = Object.assign({}, defaultConfig, {ignorePattern: /Kiwi/});
+    mockFs['/project/fruits/Kiwi.js'] = `
+      // Kiwi!
+    `;
+    return new HasteMap(config).build().then(({hasteFS}) => {
+      expect(hasteFS.matchFiles(/Kiwi/)).toEqual([]);
+    });
+  });
 
   it('builds a haste map on a fresh cache', () => {
     // Include these files in the map

--- a/packages/jest-haste-map/src/index.js
+++ b/packages/jest-haste-map/src/index.js
@@ -54,7 +54,7 @@ type Options = {
   extensions: Array<string>,
   forceNodeFilesystemAPI?: boolean,
   hasteImplModulePath?: string,
-  ignorePattern: HasteRegExp,
+  ignorePattern?: ?HasteRegExp,
   maxWorkers: number,
   mocksPattern?: string,
   name: string,
@@ -76,7 +76,7 @@ type InternalOptions = {
   extensions: Array<string>,
   forceNodeFilesystemAPI: boolean,
   hasteImplModulePath?: string,
-  ignorePattern: HasteRegExp,
+  ignorePattern: ?HasteRegExp,
   maxWorkers: number,
   mocksPattern: ?RegExp,
   name: string,
@@ -249,7 +249,7 @@ class HasteMap extends EventEmitter {
       watch: !!options.watch,
     };
     this._console = options.console || global.console;
-    if (!(options.ignorePattern instanceof RegExp)) {
+    if (options.ignorePattern && !(options.ignorePattern instanceof RegExp)) {
       this._console.warn(
         'jest-haste-map: the `ignorePattern` options as a function is being ' +
           'deprecated. Provide a RegExp instead. See https://github.com/facebook/jest/pull/4063.',
@@ -270,7 +270,7 @@ class HasteMap extends EventEmitter {
       this._options.platforms.join(':'),
       this._options.computeSha1.toString(),
       options.mocksPattern || '',
-      options.ignorePattern.toString(),
+      (options.ignorePattern || '').toString(),
     );
     this._whitelist = getWhiteList(options.providesModuleNodeModules);
     this._buildPromise = null;
@@ -966,7 +966,7 @@ class HasteMap extends EventEmitter {
     const ignoreMatched =
       ignorePattern instanceof RegExp
         ? ignorePattern.test(filePath)
-        : ignorePattern(filePath);
+        : ignorePattern && ignorePattern(filePath);
 
     return (
       ignoreMatched ||

--- a/packages/jest-runtime/src/index.js
+++ b/packages/jest-runtime/src/index.js
@@ -224,9 +224,15 @@ class Runtime {
     config: ProjectConfig,
     options?: HasteMapOptions,
   ): HasteMap {
-    const ignorePattern = new RegExp(
-      [config.cacheDirectory].concat(config.modulePathIgnorePatterns).join('|'),
-    );
+    const ignorePatternParts = [
+      ...config.modulePathIgnorePatterns,
+      config.cacheDirectory.startsWith(config.rootDir + path.sep) &&
+        config.cacheDirectory,
+    ].filter(Boolean);
+    const ignorePattern =
+      ignorePatternParts.length > 0
+        ? new RegExp(ignorePatternParts.join('|'))
+        : null;
 
     return new HasteMap({
       cacheDirectory: config.cacheDirectory,


### PR DESCRIPTION
## Summary

This removes the need to pass an ignore pattern to new instances of `HasteMap` and updates `jest-runtime` so it doesn't pass one unless it's necessary.

## Test plan

Updated the current tests and tested in FB infra.
