### PR TITLE
Fix 'Good First Issue' url in README (#7157) [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Read our [contributing guide](CONTRIBUTING.md) to learn about our development pr
 
 ### [Good First Issues](https://github.com/facebook/jest/labels/%3Awave%3A%20Good%20First%20Issue)
 
-To help you get your feet wet and get you familiar with our contribution process, we have a list of [good first issues](https://github.com/facebook/jest/labels/Good%20First%20Issue%20%3Awave%3A) that contain bugs which have a relatively limited scope. This is a great place to get started.
+To help you get your feet wet and get you familiar with our contribution process, we have a list of [good first issues](https://github.com/facebook/jest/labels/%3Awave%3A%20Good%20First%20Issue) that contain bugs which have a relatively limited scope. This is a great place to get started.
 
 ## Credits
 


### PR DESCRIPTION
## Summary

A link correction was missing in readme. https://github.com/facebook/jest/pull/7157