### PR TITLE
Update info about how rootDir is set (if not explicitly specified)

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -131,7 +131,7 @@ Forces test results output highlighting even if stdout is not a TTY.
 
 ### `--config=<path>`
 
-Alias: `-c`. The path to a Jest config file specifying how to find and execute tests. If no `rootDir` is set in the config, the current directory is assumed to be the rootDir for the project. This can also be a JSON-encoded value which Jest will use as configuration.
+Alias: `-c`. The path to a Jest config file specifying how to find and execute tests. If no `rootDir` is set in the config, the directory containing the config file is assumed to be the rootDir for the project. This can also be a JSON-encoded value which Jest will use as configuration.
 
 ### `--coverage`
 

--- a/packages/jest-cli/src/cli/args.js
+++ b/packages/jest-cli/src/cli/args.js
@@ -177,9 +177,9 @@ export const options = {
     alias: 'c',
     description:
       'The path to a jest config file specifying how to find ' +
-      'and execute tests. If no rootDir is set in the config, the current ' +
-      'directory is assumed to be the rootDir for the project. This can also ' +
-      'be a JSON encoded value which Jest will use as configuration.',
+      'and execute tests. If no rootDir is set in the config, the directory ' +
+      'containing the config file is assumed to be the rootDir for the project.' +
+      'This can also be a JSON encoded value which Jest will use as configuration.',
     type: 'string',
   },
   coverage: {

--- a/website/versioned_docs/version-22.0/CLI.md
+++ b/website/versioned_docs/version-22.0/CLI.md
@@ -112,7 +112,7 @@ Forces test results output highlighting even if stdout is not a TTY.
 
 ### `--config=<path>`
 
-Alias: `-c`. The path to a Jest config file specifying how to find and execute tests. If no `rootDir` is set in the config, the current directory is assumed to be the rootDir for the project. This can also be a JSON-encoded value which Jest will use as configuration.
+Alias: `-c`. The path to a Jest config file specifying how to find and execute tests. If no `rootDir` is set in the config, the directory containing the config file is assumed to be the rootDir for the project. This can also be a JSON-encoded value which Jest will use as configuration.
 
 ### `--coverage`
 

--- a/website/versioned_docs/version-22.2/CLI.md
+++ b/website/versioned_docs/version-22.2/CLI.md
@@ -114,7 +114,7 @@ Forces test results output highlighting even if stdout is not a TTY.
 
 ### `--config=<path>`
 
-Alias: `-c`. The path to a Jest config file specifying how to find and execute tests. If no `rootDir` is set in the config, the current directory is assumed to be the rootDir for the project. This can also be a JSON-encoded value which Jest will use as configuration.
+Alias: `-c`. The path to a Jest config file specifying how to find and execute tests. If no `rootDir` is set in the config, the directory containing the config file is assumed to be the rootDir for the project. This can also be a JSON-encoded value which Jest will use as configuration.
 
 ### `--coverage`
 

--- a/website/versioned_docs/version-22.3/CLI.md
+++ b/website/versioned_docs/version-22.3/CLI.md
@@ -114,7 +114,7 @@ Forces test results output highlighting even if stdout is not a TTY.
 
 ### `--config=<path>`
 
-Alias: `-c`. The path to a Jest config file specifying how to find and execute tests. If no `rootDir` is set in the config, the current directory is assumed to be the rootDir for the project. This can also be a JSON-encoded value which Jest will use as configuration.
+Alias: `-c`. The path to a Jest config file specifying how to find and execute tests. If no `rootDir` is set in the config, the directory containing the config file is assumed to be the rootDir for the project. This can also be a JSON-encoded value which Jest will use as configuration.
 
 ### `--coverage`
 

--- a/website/versioned_docs/version-22.4/CLI.md
+++ b/website/versioned_docs/version-22.4/CLI.md
@@ -132,7 +132,7 @@ Forces test results output highlighting even if stdout is not a TTY.
 
 ### `--config=<path>`
 
-Alias: `-c`. The path to a Jest config file specifying how to find and execute tests. If no `rootDir` is set in the config, the current directory is assumed to be the rootDir for the project. This can also be a JSON-encoded value which Jest will use as configuration.
+Alias: `-c`. The path to a Jest config file specifying how to find and execute tests. If no `rootDir` is set in the config, the directory containing the config file is assumed to be the rootDir for the project. This can also be a JSON-encoded value which Jest will use as configuration.
 
 ### `--coverage`
 

--- a/website/versioned_docs/version-23.0/CLI.md
+++ b/website/versioned_docs/version-23.0/CLI.md
@@ -132,7 +132,7 @@ Forces test results output highlighting even if stdout is not a TTY.
 
 ### `--config=<path>`
 
-Alias: `-c`. The path to a Jest config file specifying how to find and execute tests. If no `rootDir` is set in the config, the current directory is assumed to be the rootDir for the project. This can also be a JSON-encoded value which Jest will use as configuration.
+Alias: `-c`. The path to a Jest config file specifying how to find and execute tests. If no `rootDir` is set in the config, the directory containing the config file is assumed to be the rootDir for the project. This can also be a JSON-encoded value which Jest will use as configuration.
 
 ### `--coverage`
 

--- a/website/versioned_docs/version-23.1/CLI.md
+++ b/website/versioned_docs/version-23.1/CLI.md
@@ -132,7 +132,7 @@ Forces test results output highlighting even if stdout is not a TTY.
 
 ### `--config=<path>`
 
-Alias: `-c`. The path to a Jest config file specifying how to find and execute tests. If no `rootDir` is set in the config, the current directory is assumed to be the rootDir for the project. This can also be a JSON-encoded value which Jest will use as configuration.
+Alias: `-c`. The path to a Jest config file specifying how to find and execute tests. If no `rootDir` is set in the config, the directory containing the config file is assumed to be the rootDir for the project. This can also be a JSON-encoded value which Jest will use as configuration.
 
 ### `--coverage`
 

--- a/website/versioned_docs/version-23.2/CLI.md
+++ b/website/versioned_docs/version-23.2/CLI.md
@@ -132,7 +132,7 @@ Forces test results output highlighting even if stdout is not a TTY.
 
 ### `--config=<path>`
 
-Alias: `-c`. The path to a Jest config file specifying how to find and execute tests. If no `rootDir` is set in the config, the current directory is assumed to be the rootDir for the project. This can also be a JSON-encoded value which Jest will use as configuration.
+Alias: `-c`. The path to a Jest config file specifying how to find and execute tests. If no `rootDir` is set in the config, the directory containing the config file is assumed to be the rootDir for the project. This can also be a JSON-encoded value which Jest will use as configuration.
 
 ### `--coverage`
 

--- a/website/versioned_docs/version-23.3/CLI.md
+++ b/website/versioned_docs/version-23.3/CLI.md
@@ -132,7 +132,7 @@ Forces test results output highlighting even if stdout is not a TTY.
 
 ### `--config=<path>`
 
-Alias: `-c`. The path to a Jest config file specifying how to find and execute tests. If no `rootDir` is set in the config, the current directory is assumed to be the rootDir for the project. This can also be a JSON-encoded value which Jest will use as configuration.
+Alias: `-c`. The path to a Jest config file specifying how to find and execute tests. If no `rootDir` is set in the config, the directory containing the config file is assumed to be the rootDir for the project. This can also be a JSON-encoded value which Jest will use as configuration.
 
 ### `--coverage`
 

--- a/website/versioned_docs/version-23.5/CLI.md
+++ b/website/versioned_docs/version-23.5/CLI.md
@@ -132,7 +132,7 @@ Forces test results output highlighting even if stdout is not a TTY.
 
 ### `--config=<path>`
 
-Alias: `-c`. The path to a Jest config file specifying how to find and execute tests. If no `rootDir` is set in the config, the current directory is assumed to be the rootDir for the project. This can also be a JSON-encoded value which Jest will use as configuration.
+Alias: `-c`. The path to a Jest config file specifying how to find and execute tests. If no `rootDir` is set in the config, the directory containing the config file is assumed to be the rootDir for the project. This can also be a JSON-encoded value which Jest will use as configuration.
 
 ### `--coverage`
 

--- a/website/versioned_docs/version-23.6/CLI.md
+++ b/website/versioned_docs/version-23.6/CLI.md
@@ -132,7 +132,7 @@ Forces test results output highlighting even if stdout is not a TTY.
 
 ### `--config=<path>`
 
-Alias: `-c`. The path to a Jest config file specifying how to find and execute tests. If no `rootDir` is set in the config, the current directory is assumed to be the rootDir for the project. This can also be a JSON-encoded value which Jest will use as configuration.
+Alias: `-c`. The path to a Jest config file specifying how to find and execute tests. If no `rootDir` is set in the config, the directory containing the config file is assumed to be the rootDir for the project. This can also be a JSON-encoded value which Jest will use as configuration.
 
 ### `--coverage`
 


### PR DESCRIPTION
Current directory brings current working directory to mind and therefore is IMHO confusing.

https://github.com/facebook/jest/blob/87a5a67c483b4bd37cc8e351d8a145d7bcbd1690/packages/jest-config/src/readConfigFileAndSetRootDir.js#L54-L55

