### PR TITLE
Use at least one worker by default (fixes #7181)

### DIFF
--- a/packages/jest-worker/src/index.js
+++ b/packages/jest-worker/src/index.js
@@ -57,7 +57,7 @@ export default class {
   _offset: number;
 
   constructor(workerPath: string, options?: FarmOptions = {}) {
-    const numWorkers = options.numWorkers || os.cpus().length - 1;
+    const numWorkers = options.numWorkers || Math.max(os.cpus().length - 1, 1);
     const workers = new Array(numWorkers);
     const stdout = mergeStream();
     const stderr = mergeStream();


### PR DESCRIPTION
Fixes #7181 use at least 1 CPU worker instead of 0 by default when number of CPUs is 1.