### PR TITLE
Perf improvements by lazy loading some dependencies

### DIFF
--- a/packages/babel-jest/src/index.js
+++ b/packages/babel-jest/src/index.js
@@ -20,7 +20,8 @@ import fs from 'fs';
 import path from 'path';
 import jestPreset from 'babel-preset-jest';
 import {transform as babelTransform, util as babelUtil} from 'babel-core';
-import babelIstanbulPlugin from 'babel-plugin-istanbul';
+
+const getBabelPluginIstanbul = () => require('babel-plugin-istanbul').default;
 
 const BABELRC_FILENAME = '.babelrc';
 const BABELRC_JS_FILENAME = '.babelrc.js';
@@ -127,6 +128,7 @@ const createTransformer = (options: any): Transformer => {
 
       const theseOptions = Object.assign({filename}, options);
       if (transformOptions && transformOptions.instrument) {
+        const babelIstanbulPlugin = getBabelPluginIstanbul();
         theseOptions.auxiliaryCommentBefore = ' istanbul ignore next ';
         // Copied from jest-runtime transform.js
         theseOptions.plugins = theseOptions.plugins.concat([

--- a/packages/jest-editor-support/src/Snapshot.js
+++ b/packages/jest-editor-support/src/Snapshot.js
@@ -12,7 +12,6 @@
 
 import type {ProjectConfig} from 'types/Config';
 
-import traverse from 'babel-traverse';
 import {getASTfor} from './parsers/babylon_parser';
 import {buildSnapshotResolver, utils} from 'jest-snapshot';
 
@@ -111,6 +110,7 @@ export default class Snapshot {
   }
 
   getMetadata(filePath: string): Array<SnapshotMetadata> {
+    const traverse = require('babel-traverse').default;
     const fileNode = this._parser(filePath);
     const state = {
       found: [],

--- a/packages/jest-haste-map/src/index.js
+++ b/packages/jest-haste-map/src/index.js
@@ -24,7 +24,6 @@ import nodeCrawl from './crawlers/node';
 import normalizePathSep from './lib/normalize_path_sep';
 import os from 'os';
 import path from 'path';
-import sane from 'sane';
 import serializer from 'jest-serializer';
 // eslint-disable-next-line import/default
 import watchmanCrawl from './crawlers/watchman';
@@ -43,6 +42,8 @@ import type {
   MockData,
 } from 'types/HasteMap';
 import type {SerializableModuleMap as HasteSerializableModuleMap} from './module_map';
+
+const getSane = () => require('sane').default;
 
 type HType = typeof H;
 
@@ -711,13 +712,14 @@ class HasteMap extends EventEmitter {
     // all files, even changes to node_modules.
     this._options.throwOnModuleCollision = false;
     this._options.retainAllFiles = true;
-
-    const Watcher =
-      canUseWatchman && this._options.useWatchman
-        ? WatchmanWatcher
-        : os.platform() === 'darwin'
-          ? sane.FSEventsWatcher
-          : sane.NodeWatcher;
+    let Watcher;
+    if (canUseWatchman && this._options.useWatchman) {
+      Watcher = WatchmanWatcher;
+    } else {
+      const sane = getSane();
+      Watcher =
+        os.platform() === 'darwin' ? sane.FSEventsWatcher : sane.NodeWatcher;
+    }
     const extensions = this._options.extensions;
     const ignorePattern = this._options.ignorePattern;
     const rootDir = this._options.rootDir;

--- a/packages/jest-runtime/src/script_transformer.js
+++ b/packages/jest-runtime/src/script_transformer.js
@@ -20,8 +20,6 @@ import path from 'path';
 import vm from 'vm';
 import {createDirectory} from 'jest-util';
 import fs from 'graceful-fs';
-import {transform as babelTransform} from 'babel-core';
-import babelPluginIstanbul from 'babel-plugin-istanbul';
 import convertSourceMap from 'convert-source-map';
 import HasteMap from 'jest-haste-map';
 import stableStringify from 'fast-json-stable-stringify';
@@ -31,6 +29,9 @@ import shouldInstrument from './should_instrument';
 import writeFileAtomic from 'write-file-atomic';
 import {sync as realpath} from 'realpath-native';
 import {enhanceUnexpectedTokenMessage} from './helpers';
+
+const getBabelCore = () => require('babel-core');
+const getBabelPluginIstanbul = () => require('babel-plugin-istanbul').default;
 
 export type Options = {|
   collectCoverage: boolean,
@@ -169,6 +170,8 @@ export default class ScriptTransformer {
   }
 
   _instrumentFile(filename: Path, content: string): string {
+    const {transform: babelTransform} = getBabelCore();
+    const babelPluginIstanbul = getBabelPluginIstanbul();
     return babelTransform(content, {
       auxiliaryCommentBefore: ' istanbul ignore next ',
       babelrc: false,

--- a/packages/jest-snapshot/src/inline_snapshots.js
+++ b/packages/jest-snapshot/src/inline_snapshots.js
@@ -10,7 +10,6 @@
 import fs from 'fs';
 import semver from 'semver';
 import path from 'path';
-import {templateElement, templateLiteral, file} from 'babel-types';
 
 import type {Path} from 'types/Config';
 import {escapeBacktickString} from './utils';
@@ -19,6 +18,8 @@ export type InlineSnapshot = {|
   snapshot: string,
   frame: {line: number, column: number, file: string},
 |};
+
+const getBabelTypes = () => require('babel-types');
 
 export const saveInlineSnapshots = (
   snapshots: InlineSnapshot[],
@@ -112,6 +113,7 @@ const createParser = (
   parsers: {[key: string]: (string) => any},
   options: any,
 ) => {
+  const {templateElement, templateLiteral, file} = getBabelTypes();
   // Workaround for https://github.com/prettier/prettier/issues/3150
   options.parser = inferredParser;
 


### PR DESCRIPTION
## Summary

I know that it is had to benchmark small improvements, also considering all the other things that are happening in a computer while a run the tests and that can interfere with the timings.

With a warm cache I consistently see an improvement of around 2-3 seconds when running  jest packages in the facebook/jest repo. Before: ~23 seconds, After ~20/21 seconds

I see similar results with other projects. For example in webpack/webpack I consistently see around a half a second improvement when running jest unittest Before: ~3.0 seconds, After: ~2.5 seconds

I know that this small improvements are really hard to deterministically measure, which is why I wanted to see if it even shows an improvement in other computers, other projects or different OS(Windows)

## Test plan

I created this small tool to benchmark it `npx jest-benchmarks`(https://github.com/rogeliog/jest-benchmark) to benchmark it.

```
`jest jest-circus`
# Before
Number of runs: 10
Average: 2.896s
Max: 3.092s
Min: 2.574s

# After:
Number of runs: 10
Average: 2.392s
Max: 2.723s
Min: 2.114s
```

```
`jest jest-r`

# Before
Number of runs: 10
Average: 8.025s
Max: 9.128s
Min: 7.209s

# After
Number of runs: 10
Average: 6.701
Max: 7.505
Min: 6.251
```
