### PR TITLE
[Circus] Add test_fn_timeout, and bugfix for double error printing

### DIFF
--- a/e2e/__tests__/__snapshots__/timeouts.assertions.test.js.snap
+++ b/e2e/__tests__/__snapshots__/timeouts.assertions.test.js.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`exceeds the timeout synchronously 1`] = `
+"Test Suites: 1 failed, 1 total
+Tests:       1 failed, 1 total
+Snapshots:   0 total
+Time:        <<REPLACED>>
+Ran all test suites.
+"
+`;
+
+exports[`exceeds the timeout, without reporting expect.assertions 1`] = `
+"Test Suites: 1 failed, 1 total
+Tests:       1 failed, 1 total
+Snapshots:   0 total
+Time:        <<REPLACED>>
+Ran all test suites.
+"
+`;

--- a/e2e/__tests__/timeouts.assertions.test.js
+++ b/e2e/__tests__/timeouts.assertions.test.js
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ * @flow
+ */
+
+'use strict';
+
+import path from 'path';
+import {cleanup, extractSummary, writeFiles} from '../Utils';
+import {skipSuiteOnJasmine} from '../../scripts/ConditionalTest';
+
+import runJest from '../runJest';
+
+const DIR = path.resolve(__dirname, '../timeouts');
+
+skipSuiteOnJasmine();
+beforeEach(() => cleanup(DIR));
+afterAll(() => cleanup(DIR));
+
+test('exceeds the timeout, without reporting expect.assertions', () => {
+  writeFiles(DIR, {
+    '__tests__/a-banana.js': `
+      jest.setTimeout(20);
+
+      test('banana', () => {
+        expect.assertions(2);
+        return new Promise(resolve => {
+          setTimeout(resolve, 100);
+        });
+      });
+    `,
+    'package.json': '{}',
+  });
+
+  const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false']);
+  const {rest, summary} = extractSummary(stderr);
+  expect(rest).toMatch(
+    /(jest\.setTimeout|jasmine\.DEFAULT_TIMEOUT_INTERVAL|Exceeded timeout)/,
+  );
+  expect(rest).not.toMatch(/Expected two assertions/);
+  expect(summary).toMatchSnapshot();
+  expect(status).toBe(1);
+});
+
+test('exceeds the timeout synchronously', () => {
+  writeFiles(DIR, {
+    '__tests__/a-banana.js': `
+      jest.setTimeout(20);
+
+      test('banana', () => {
+        expect.assertions(2);
+        const startTime = Date.now();
+        while (Date.now() - startTime < 100) {
+        }
+      });
+    `,
+    'package.json': '{}',
+  });
+
+  const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false']);
+  const {rest, summary} = extractSummary(stderr);
+  expect(rest).toMatch(
+    /(jest\.setTimeout|jasmine\.DEFAULT_TIMEOUT_INTERVAL|Exceeded timeout)/,
+  );
+  expect(rest).not.toMatch(/Expected two assertions/);
+  expect(summary).toMatchSnapshot();
+  expect(status).toBe(1);
+});

--- a/packages/jest-circus/src/event_handler.js
+++ b/packages/jest-circus/src/event_handler.js
@@ -130,6 +130,10 @@ const handler: EventHandler = (event, state): void => {
       event.test.errors.push([error, asyncError]);
       break;
     }
+    case 'test_fn_timeout': {
+      event.test.expired = true;
+      break;
+    }
     case 'test_retry': {
       event.test.errors = [];
       break;

--- a/packages/jest-circus/src/legacy_code_todo_rewrite/jest_adapter_init.js
+++ b/packages/jest-circus/src/legacy_code_todo_rewrite/jest_adapter_init.js
@@ -233,6 +233,8 @@ const eventHandler = (event: Event) => {
 };
 
 const _addExpectedAssertionErrors = (test: TestEntry) => {
+  if (test.expired) return;
+
   const failures = extractExpectedAssertionsErrors();
   const errors = failures.map(failure => failure.error);
   test.errors = test.errors.concat(errors);

--- a/packages/jest-circus/src/run.js
+++ b/packages/jest-circus/src/run.js
@@ -121,7 +121,7 @@ const _runTest = async (test: TestEntry): Promise<void> => {
 
   // `afterAll` hooks should not affect test status (pass or fail), because if
   // we had a global `afterAll` hook it would block all existing tests until
-  // this hook is executed. So we dispatche `test_done` right away.
+  // this hook is executed. So we dispatch `test_done` right away.
   dispatch({name: 'test_done', test});
 };
 
@@ -160,7 +160,12 @@ const _callCircusTest = (
 
   return callAsyncCircusFn(test.fn, testContext, {isHook: false, timeout})
     .then(() => dispatch({name: 'test_fn_success', test}))
-    .catch(error => dispatch({error, name: 'test_fn_failure', test}));
+    .catch(message => {
+      if (/^(Error: )?Exceeded timeout/.test(message)) {
+        dispatch({name: 'test_fn_timeout', test});
+      }
+      dispatch({error: message, name: 'test_fn_failure', test});
+    });
 };
 
 export default run;

--- a/packages/jest-circus/src/utils.js
+++ b/packages/jest-circus/src/utils.js
@@ -79,6 +79,7 @@ export const makeTest = (
     asyncError,
     duration: null,
     errors: [],
+    expired: false,
     fn,
     invocations: 0,
     mode: _mode,

--- a/types/Circus.js
+++ b/types/Circus.js
@@ -92,6 +92,10 @@ export type Event =
       test: TestEntry,
     |}
   | {|
+      name: 'test_fn_timeout',
+      test: TestEntry,
+    |}
+  | {|
       name: 'test_retry',
       test: TestEntry,
     |}
@@ -113,7 +117,7 @@ export type Event =
       // test failure is defined by presence of errors in `test.errors`,
       // `test_done` indicates that the test and all its hooks were run,
       // and nothing else will change it's state in the future. (except third
-      // party extentions/plugins)
+      // party extensions/plugins)
       name: 'test_done',
       test: TestEntry,
     |}
@@ -201,6 +205,7 @@ type TestError = Exception | Array<[?Exception, Exception]>; // the error from t
 export type TestEntry = {|
   asyncError: Exception, // Used if the test failure contains no usable stack trace
   errors: TestError,
+  expired: ?boolean,
   fn: ?TestFn,
   invocations: number,
   mode: TestMode,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

This PR adds a new event for jest-circus called `test_fn_timeout` dispatched when a test times out.

This event will be fired in _addition_ to `test_fn_failure` (that choice is up for discussion)

## Motivation
The motivation for this change is to fix https://github.com/facebook/jest/issues/3742

We do this by adding `test.expired` to TestEntry, set that in the `test_fn_timeout` hook, and check that flag before printing expect.assertion errors.

## Test plan

Added e2e tests