### PR TITLE
Use regexp instead of split-map-join

### DIFF
--- a/packages/jest-message-util/src/index.js
+++ b/packages/jest-message-util/src/index.js
@@ -63,12 +63,10 @@ const STACK_TRACE_COLOR = chalk.dim;
 const STACK_PATH_REGEXP = /\s*at.*\(?(\:\d*\:\d*|native)\)?/;
 const EXEC_ERROR_MESSAGE = 'Test suite failed to run';
 const ERROR_TEXT = 'Error: ';
+const REG_EXP_NOT_EMPTY_LINE = /^(?!$)/gm;
 
 const indentAllLines = (lines: string, indent: string) =>
-  lines
-    .split('\n')
-    .map(line => (line ? indent + line : line))
-    .join('\n');
+  lines.replace(REG_EXP_NOT_EMPTY_LINE, indent);
 
 const trim = string => (string || '').trim();
 

--- a/packages/jest-message-util/src/index.js
+++ b/packages/jest-message-util/src/index.js
@@ -63,10 +63,10 @@ const STACK_TRACE_COLOR = chalk.dim;
 const STACK_PATH_REGEXP = /\s*at.*\(?(\:\d*\:\d*|native)\)?/;
 const EXEC_ERROR_MESSAGE = 'Test suite failed to run';
 const ERROR_TEXT = 'Error: ';
-const REG_EXP_NOT_EMPTY_LINE = /^(?!$)/gm;
+const NOT_EMPTY_LINE_REGEXP = /^(?!$)/gm;
 
 const indentAllLines = (lines: string, indent: string) =>
-  lines.replace(REG_EXP_NOT_EMPTY_LINE, indent);
+  lines.replace(NOT_EMPTY_LINE_REGEXP, indent);
 
 const trim = string => (string || '').trim();
 


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Used regexp instead of split-map-join for adding indent for not empty line in message report.
It works 2x faster.
https://jsperf.com/regexp-vssplit-map-join
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
