### PR TITLE
Allow multilple valid types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `[jest-runtime]` If `require` fails without a file extension, print all files that match with one ([#7160](https://github.com/facebook/jest/pull/7160))
 - `[jest-haste-map]` Make `ignorePattern` optional ([#7166](https://github.com/facebook/jest/pull/7166))
 - `[jest-runtime]` Remove `cacheDirectory` from `ignorePattern` for `HasteMap` if not necessary ([#7166](https://github.com/facebook/jest/pull/7166))
+- `[jest-validate]` Add syntax to validate multiple permitted types ([#7207](https://github.com/facebook/jest/pull/7207))
 
 ### Fixes
 

--- a/packages/jest-validate/README.md
+++ b/packages/jest-validate/README.md
@@ -79,7 +79,7 @@ You will find examples of `condition`, `deprecate`, `error`, `unknown`, and `dep
 
 - it matches the JavaScript type of the example value, e.g. `string`, `number`, `array`, `boolean`, `function`, or `object`
 - it is `null` or `undefined`
-- the example value is an array where the first element is the special value `MultipleValidOptions`, and the value matches the type of _any_ of the other values in the array
+- it matches the Javascript type of any of arguments passed to `MultipleValidOptions(...)`
 
 The last condition is a special syntax that allows validating where more than one type is permissible; see example below. It's acceptable to have multiple values of the same type in the example, so you can also use this syntax to provide more than one example. When a validation failure occurs, the error message will show all other values in the array as examples.
 
@@ -145,7 +145,7 @@ import {MultipleValidOptions} from 'jest-validate';
 
 validate(config, {
   // `bar` will accept either a string or a number
-  bar: [MultipleValidOptions, 'string is ok', 2],
+  bar: MultipleValidOptions('string is ok', 2),
 });
 ```
 

--- a/packages/jest-validate/README.md
+++ b/packages/jest-validate/README.md
@@ -73,6 +73,16 @@ Almost anything can be overwritten to suite your needs.
 
 You will find examples of `condition`, `deprecate`, `error`, `unknown`, and `deprecatedConfig` inside source of this repository, named respectively.
 
+## exampleConfig syntax
+
+`exampleConfig` should be an object with key/value pairs that contain an example of a valid value for each key. A configuration value is considered valid when:
+
+- it matches the JavaScript type of the example value, e.g. `string`, `number`, `array`, `boolean`, `function`, or `object`
+- it is `null` or `undefined`
+- the example value is an array where the first element is the special value `MultipleValidOptions`, and the value matches the type of _any_ of the other values in the array
+
+The last condition is a special syntax that allows validating where more than one type is permissible; see example below. It's acceptable to have multiple values of the same type in the example, so you can also use this syntax to provide more than one example. When a validation failure occurs, the error message will show all other values in the array as examples.
+
 ## Examples
 
 Minimal example:
@@ -123,6 +133,41 @@ This will output:
     "transform": {
       "^.+\\.js$": "<rootDir>/preprocessor.js"
     }
+  }
+
+  Documentation: http://custom-docs.com
+```
+
+## Example validating multiple types
+
+```js
+import {MultipleValidOptions} from 'jest-validate';
+
+validate(config, {
+  // `bar` will accept either a string or a number
+  bar: [MultipleValidOptions, 'string is ok', 2],
+});
+```
+
+#### Error:
+
+```bash
+● Validation Error:
+
+  Option foo must be of type:
+    string or number
+  but instead received:
+    array
+
+  Example:
+  {
+    "bar": "string is ok"
+  }
+
+  or
+
+  {
+    "bar": 2
   }
 
   Documentation: http://custom-docs.com

--- a/packages/jest-validate/src/__tests__/__snapshots__/validate.test.js.snap
+++ b/packages/jest-validate/src/__tests__/__snapshots__/validate.test.js.snap
@@ -1,5 +1,32 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Repeated types within multiple valid examples are coalesced in error report 1`] = `
+"<red><bold><bold>●<bold> Validation Error</>:</>
+<red></>
+<red>  Option <bold>\\"foo\\"</> must be of type:</>
+<red>    <bold><green>string or number<red></></>
+<red>  but instead received:</>
+<red>    <bold><red>boolean<red></></>
+<red></>
+<red>  Example:</>
+<red>  {</>
+<red>    <bold>\\"foo\\"</>: <bold>\\"foo\\"</></>
+<red>  }</>
+<red></>
+<red>  or</>
+<red></>
+<red>  {</>
+<red>    <bold>\\"foo\\"</>: <bold>\\"bar\\"</></>
+<red>  }</>
+<red></>
+<red>  or</>
+<red></>
+<red>  {</>
+<red>    <bold>\\"foo\\"</>: <bold>2</></>
+<red>  }</>
+<red></>"
+`;
+
 exports[`displays warning for deprecated config options 1`] = `
 "<yellow><bold><bold>●<bold> Deprecation Warning</>:</>
 <yellow></>
@@ -103,6 +130,29 @@ exports[`pretty prints valid config for String 1`] = `
 <red>  Example:</>
 <red>  {</>
 <red>    <bold>\\"preset\\"</>: <bold>\\"react-native\\"</></>
+<red>  }</>
+<red></>"
+`;
+
+exports[`reports errors nicely when failing with multiple valid options 1`] = `
+"<red><bold><bold>●<bold> Validation Error</>:</>
+<red></>
+<red>  Option <bold>\\"foo\\"</> must be of type:</>
+<red>    <bold><green>string or array<red></></>
+<red>  but instead received:</>
+<red>    <bold><red>number<red></></>
+<red></>
+<red>  Example:</>
+<red>  {</>
+<red>    <bold>\\"foo\\"</>: <bold>\\"text\\"</></>
+<red>  }</>
+<red></>
+<red>  or</>
+<red></>
+<red>  {</>
+<red>    <bold>\\"foo\\"</>: <bold>[</></>
+<red><bold>      \\"text\\"</></>
+<red><bold>    ]</></>
 <red>  }</>
 <red></>"
 `;

--- a/packages/jest-validate/src/__tests__/__snapshots__/validate.test.js.snap
+++ b/packages/jest-validate/src/__tests__/__snapshots__/validate.test.js.snap
@@ -4,7 +4,7 @@ exports[`Repeated types within multiple valid examples are coalesced in error re
 "<red><bold><bold>●<bold> Validation Error</>:</>
 <red></>
 <red>  Option <bold>\\"foo\\"</> must be of type:</>
-<red>    <bold><green>string or number<red></></>
+<red>    <bold><green>string<red></> or <bold><green>number<red></></>
 <red>  but instead received:</>
 <red>    <bold><red>boolean<red></></>
 <red></>
@@ -138,7 +138,7 @@ exports[`reports errors nicely when failing with multiple valid options 1`] = `
 "<red><bold><bold>●<bold> Validation Error</>:</>
 <red></>
 <red>  Option <bold>\\"foo\\"</> must be of type:</>
-<red>    <bold><green>string or array<red></></>
+<red>    <bold><green>string<red></> or <bold><green>array<red></></>
 <red>  but instead received:</>
 <red>    <bold><red>number<red></></>
 <red></>

--- a/packages/jest-validate/src/__tests__/validate.test.js
+++ b/packages/jest-validate/src/__tests__/validate.test.js
@@ -210,7 +210,7 @@ test('works with custom deprecations', () => {
 
 test('works with multiple valid types', () => {
   const exampleConfig = {
-    foo: [MultipleValidOptions, 'text', ['text']],
+    foo: MultipleValidOptions('text', ['text']),
   };
 
   expect(
@@ -239,7 +239,7 @@ test('works with multiple valid types', () => {
 
 test('reports errors nicely when failing with multiple valid options', () => {
   const exampleConfig = {
-    foo: [MultipleValidOptions, 'text', ['text']],
+    foo: MultipleValidOptions('text', ['text']),
   };
 
   expect(() =>
@@ -254,7 +254,7 @@ test('reports errors nicely when failing with multiple valid options', () => {
 
 test('Repeated types within multiple valid examples are coalesced in error report', () => {
   const exampleConfig = {
-    foo: [MultipleValidOptions, 'foo', 'bar', 2],
+    foo: MultipleValidOptions('foo', 'bar', 2),
   };
 
   expect(() =>

--- a/packages/jest-validate/src/__tests__/validate.test.js
+++ b/packages/jest-validate/src/__tests__/validate.test.js
@@ -9,6 +9,7 @@
 'use strict';
 
 import validate from '../validate';
+import {MultipleValidOptions} from '../condition';
 import jestValidateExampleConfig from '../example_config';
 import jestValidateDefaultConfig from '../default_config';
 
@@ -205,4 +206,63 @@ test('works with custom deprecations', () => {
 
   expect(console.warn.mock.calls[0][0]).toMatchSnapshot();
   console.warn = warn;
+});
+
+test('works with multiple valid types', () => {
+  const exampleConfig = {
+    foo: [MultipleValidOptions, 'text', ['text']],
+  };
+
+  expect(
+    validate(
+      {foo: 'foo'},
+      {
+        exampleConfig,
+      },
+    ),
+  ).toEqual({
+    hasDeprecationWarnings: false,
+    isValid: true,
+  });
+  expect(
+    validate(
+      {foo: ['foo']},
+      {
+        exampleConfig,
+      },
+    ),
+  ).toEqual({
+    hasDeprecationWarnings: false,
+    isValid: true,
+  });
+});
+
+test('reports errors nicely when failing with multiple valid options', () => {
+  const exampleConfig = {
+    foo: [MultipleValidOptions, 'text', ['text']],
+  };
+
+  expect(() =>
+    validate(
+      {foo: 2},
+      {
+        exampleConfig,
+      },
+    ),
+  ).toThrowErrorMatchingSnapshot();
+});
+
+test('Repeated types within multiple valid examples are coalesced in error report', () => {
+  const exampleConfig = {
+    foo: [MultipleValidOptions, 'foo', 'bar', 2],
+  };
+
+  expect(() =>
+    validate(
+      {foo: false},
+      {
+        exampleConfig,
+      },
+    ),
+  ).toThrowErrorMatchingSnapshot();
 });

--- a/packages/jest-validate/src/condition.js
+++ b/packages/jest-validate/src/condition.js
@@ -9,7 +9,7 @@
 
 const toString = Object.prototype.toString;
 
-export const MultipleValidOptions = Symbol('JEST_MULTIPLE_VALID_OPTIONS');
+const MultipleValidOptionsSymbol = Symbol('JEST_MULTIPLE_VALID_OPTIONS');
 
 function validationConditionSingle(option: any, validOption: any): boolean {
   return (
@@ -19,11 +19,11 @@ function validationConditionSingle(option: any, validOption: any): boolean {
   );
 }
 
-export function getConditions(validOption: any) {
+export function getValues(validOption: any) {
   if (
     Array.isArray(validOption) &&
     validOption.length &&
-    validOption[0] === MultipleValidOptions
+    validOption[0] === MultipleValidOptionsSymbol
   ) {
     return validOption.slice(1);
   }
@@ -31,7 +31,9 @@ export function getConditions(validOption: any) {
 }
 
 export function validationCondition(option: any, validOption: any): boolean {
-  return getConditions(validOption).some(e =>
-    validationConditionSingle(option, e),
-  );
+  return getValues(validOption).some(e => validationConditionSingle(option, e));
+}
+
+export function MultipleValidOptions(...args: Array<any>) {
+  return [MultipleValidOptionsSymbol, ...args];
 }

--- a/packages/jest-validate/src/condition.js
+++ b/packages/jest-validate/src/condition.js
@@ -9,13 +9,29 @@
 
 const toString = Object.prototype.toString;
 
-export default function validationCondition(
-  option: any,
-  validOption: any,
-): boolean {
+export const MultipleValidOptions = Symbol('JEST_MULTIPLE_VALID_OPTIONS');
+
+function validationConditionSingle(option: any, validOption: any): boolean {
   return (
     option === null ||
     option === undefined ||
     toString.call(option) === toString.call(validOption)
+  );
+}
+
+export function getConditions(validOption: any) {
+  if (
+    Array.isArray(validOption) &&
+    validOption.length &&
+    validOption[0] === MultipleValidOptions
+  ) {
+    return validOption.slice(1);
+  }
+  return [validOption];
+}
+
+export function validationCondition(option: any, validOption: any): boolean {
+  return getConditions(validOption).some(e =>
+    validationConditionSingle(option, e),
   );
 }

--- a/packages/jest-validate/src/default_config.js
+++ b/packages/jest-validate/src/default_config.js
@@ -12,7 +12,7 @@ import type {ValidationOptions} from './types';
 import {deprecationWarning} from './deprecated';
 import {unknownOptionWarning} from './warnings';
 import {errorMessage} from './errors';
-import validationCondition from './condition';
+import {validationCondition} from './condition';
 import {ERROR, DEPRECATION, WARNING} from './utils';
 
 export default ({

--- a/packages/jest-validate/src/errors.js
+++ b/packages/jest-validate/src/errors.js
@@ -12,7 +12,7 @@ import type {ValidationOptions} from './types';
 import chalk from 'chalk';
 import getType from 'jest-get-type';
 import {formatPrettyObject, ValidationError, ERROR} from './utils';
-import {getConditions} from './condition';
+import {getValues} from './condition';
 
 export const errorMessage = (
   option: string,
@@ -21,16 +21,15 @@ export const errorMessage = (
   options: ValidationOptions,
   path?: Array<string>,
 ): void => {
-  const conditions = getConditions(defaultValue);
-  const validTypes = conditions
-    .map(getType)
-    .filter(uniqueFilter())
-    .join(' or ');
+  const conditions = getValues(defaultValue);
+  const validTypes: Array<string> = Array.from(
+    new Set(conditions.map(getType)),
+  );
 
   const message = `  Option ${chalk.bold(
     `"${path && path.length > 0 ? path.join('.') + '.' : ''}${option}"`,
   )} must be of type:
-    ${chalk.bold.green(validTypes)}
+    ${validTypes.map(e => chalk.bold.green(e)).join(' or ')}
   but instead received:
     ${chalk.bold.red(getType(received))}
 
@@ -53,14 +52,4 @@ function formatExamples(option: string, examples: Array<any>) {
   or
 
 `);
-}
-
-function uniqueFilter() {
-  const seen: {[string]: any} = {};
-  return function(key) {
-    if (seen[key]) {
-      return false;
-    }
-    return (seen[key] = true);
-  };
 }

--- a/packages/jest-validate/src/errors.js
+++ b/packages/jest-validate/src/errors.js
@@ -12,6 +12,7 @@ import type {ValidationOptions} from './types';
 import chalk from 'chalk';
 import getType from 'jest-get-type';
 import {formatPrettyObject, ValidationError, ERROR} from './utils';
+import {getConditions} from './condition';
 
 export const errorMessage = (
   option: string,
@@ -20,22 +21,46 @@ export const errorMessage = (
   options: ValidationOptions,
   path?: Array<string>,
 ): void => {
+  const conditions = getConditions(defaultValue);
+  const validTypes = conditions
+    .map(getType)
+    .filter(uniqueFilter())
+    .join(' or ');
+
   const message = `  Option ${chalk.bold(
     `"${path && path.length > 0 ? path.join('.') + '.' : ''}${option}"`,
   )} must be of type:
-    ${chalk.bold.green(getType(defaultValue))}
+    ${chalk.bold.green(validTypes)}
   but instead received:
     ${chalk.bold.red(getType(received))}
 
   Example:
-  {
-    ${chalk.bold(`"${option}"`)}: ${chalk.bold(
-    formatPrettyObject(defaultValue),
-  )}
-  }`;
+${formatExamples(option, conditions)}`;
 
   const comment = options.comment;
   const name = (options.title && options.title.error) || ERROR;
 
   throw new ValidationError(name, message, comment);
 };
+
+function formatExamples(option: string, examples: Array<any>) {
+  return examples.map(
+    e => `  {
+    ${chalk.bold(`"${option}"`)}: ${chalk.bold(formatPrettyObject(e))}
+  }`,
+  ).join(`
+
+  or
+
+`);
+}
+
+function uniqueFilter() {
+  const seen: {[string]: any} = {};
+  return function(key) {
+    if (seen[key]) {
+      return false;
+    }
+    return (seen[key] = true);
+  };
+}

--- a/packages/jest-validate/src/index.js
+++ b/packages/jest-validate/src/index.js
@@ -15,8 +15,10 @@ import {
 } from './utils';
 import validate from './validate';
 import validateCLIOptions from './validate_cli_options';
+import {MultipleValidOptions} from './condition';
 
 module.exports = {
+  MultipleValidOptions,
   ValidationError,
   createDidYouMeanMessage,
   format,


### PR DESCRIPTION
## Summary

Split from https://github.com/facebook/jest/pull/7194
Prerequisite to resolving https://github.com/facebook/jest/issues/7180

This PR provides a syntax for `jest-validate` to accept more than one example for a single config value, which can be of different types. This allows overloading config options to accept multiple types.

## Test plan

- existing unit tests pass (except as expected where internal config changed types)
- added unit tests to cover new valid and error conditions

