### PR TITLE
Fix dependency clash test modified in #6104

### DIFF
--- a/e2e/__tests__/dependency_clash.test.js
+++ b/e2e/__tests__/dependency_clash.test.js
@@ -8,29 +8,22 @@
  */
 
 import path from 'path';
-import {
-  cleanup,
-  createEmptyPackage,
-  linkJestPackage,
-  writeFiles,
-} from '../Utils';
+import {cleanup, createEmptyPackage, writeFiles} from '../Utils';
 import runJest from '../runJest';
 import os from 'os';
-import mkdirp from 'mkdirp';
-import fs from 'fs';
 import {skipSuiteOnWindows} from '../../scripts/ConditionalTest';
 
 skipSuiteOnWindows();
 
 // doing test in a temp directory because we don't want jest node_modules affect it
 const tempDir = path.resolve(os.tmpdir(), 'clashing-dependencies-test');
-const thirdPartyDir = path.resolve(tempDir, 'third-party');
+const hasteImplModulePath = path.resolve(
+  './packages/jest-haste-map/src/__tests__/haste_impl.js',
+);
 
 beforeEach(() => {
   cleanup(tempDir);
   createEmptyPackage(tempDir);
-  mkdirp(path.join(thirdPartyDir, 'node_modules'));
-  linkJestPackage('babel-jest', thirdPartyDir);
 });
 
 // This test case is checking that when having both
@@ -38,39 +31,51 @@ beforeEach(() => {
 // module we can still require the right invariant. This is pretty specific
 // use case and in the future we should probably delete this test.
 // see: https://github.com/facebook/jest/pull/6687
-test('fails with syntax error on flow types', () => {
-  const babelFileThatRequiresInvariant = require.resolve(
-    'babel-traverse/lib/path/index.js',
-  );
-
-  expect(fs.existsSync(babelFileThatRequiresInvariant)).toBe(true);
-  // make sure the babel depenency that depends on `invariant` from npm still
-  // exists, otherwise the test will pass regardless of whether the bug still
-  // exists or no.
-  expect(fs.readFileSync(babelFileThatRequiresInvariant).toString()).toMatch(
-    /invariant/,
-  );
+test('does not require project modules from inside node_modules', () => {
   writeFiles(tempDir, {
-    '.babelrc': `
-      {
-        "plugins": [
-          "${require.resolve('babel-plugin-transform-flow-strip-types')}"
-        ]
-      }
-    `,
     '__tests__/test.js': `
-      const invariant = require('../invariant');
+      const invariant = require('invariant');
       test('haii', () => expect(invariant(false, 'haii')).toBe('haii'));
     `,
-    'invariant.js': `/**
-      * @flow
-      */
-      const invariant = (condition: boolean, message: string) => message;
+    'invariant.js': `
+      INVALID CODE FRAGMENT THAT WILL BE REMOVED BY THE TRANSFORMER
+      const invariant = (condition, message) => message;
       module.exports = invariant;
     `,
     'jest.config.js': `module.exports = {
-      transform: {'.*\\.js': './third-party/node_modules/babel-jest'},
+      haste: {
+        hasteImplModulePath: '${hasteImplModulePath}',
+      },
+      transform: {'.*\\.js': './third-party/node_modules/transform'},
     };`,
+    'third-party/node_modules/invariant/index.js': `
+      const invariant = (condition, message) => {
+        if (!condition) {
+          throw new Error(message);
+        }
+      };
+      module.exports = invariant;
+    `,
+    'third-party/node_modules/transform/index.js': `
+      const invariant = require('invariant');
+      module.exports = {
+        process: script => {
+          let threw = false;
+          try {
+            invariant(false, 'this should throw');
+          } catch (e) {
+            threw = true;
+          }
+          if (!threw) {
+            throw new Error('It used the wrong invariant module!');
+          }
+          return script.replace(
+            'INVALID CODE FRAGMENT THAT WILL BE REMOVED BY THE TRANSFORMER',
+            ''
+          );
+        },
+      };
+    `,
   });
   const {stderr, status} = runJest(tempDir, ['--no-cache', '--no-watchman']);
   // make sure there are no errors that lead to invariant.js (if we were to


### PR DESCRIPTION
## Summary

That test was supposed to test the interaction between Haste modules and installed node_modules, so changing it to use relative paths made it useless. This fixes it by using `hasteImplModulePath` to convert it into a Haste module.

## Test plan

Just ran the test.