### PR TITLE
Remove redundant information from the config hash part of the haste map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `[jest-runtime]` If `require` fails without a file extension, print all files that match with one ([#7160](https://github.com/facebook/jest/pull/7160))
 - `[jest-haste-map]` Make `ignorePattern` optional ([#7166](https://github.com/facebook/jest/pull/7166))
 - `[jest-haste-map]` Add `getCacheFilePath` to get the path to the cache file for a `HasteMap` instance ([#7217](https://github.com/facebook/jest/pull/7217))
+- `[jest-haste-map]` [**BREAKING**] Remove name from hash in `HasteMap.getCacheFilePath` ([#7218](https://github.com/facebook/jest/pull/7218))
 - `[jest-runtime]` Remove `cacheDirectory` from `ignorePattern` for `HasteMap` if not necessary ([#7166](https://github.com/facebook/jest/pull/7166))
 - `[jest-validate]` Add syntax to validate multiple permitted types ([#7207](https://github.com/facebook/jest/pull/7207))
 

--- a/packages/jest-haste-map/src/__tests__/index.test.js
+++ b/packages/jest-haste-map/src/__tests__/index.test.js
@@ -211,12 +211,30 @@ describe('HasteMap', () => {
     expect(
       HasteMap.getCacheFilePath('/', '@scoped/package', 'random-value'),
     ).toMatch(/^\/-scoped-package-(.*)$/);
+  });
 
-    expect(
-      HasteMap.getCacheFilePath('/', '@scoped/package', 'random-value'),
-    ).not.toEqual(
-      HasteMap.getCacheFilePath('/', '-scoped-package', 'random-value'),
+  it('creates different cache file paths for different roots', () => {
+    jest.resetModuleRegistry();
+    const HasteMap = require('../');
+    const hasteMap1 = new HasteMap(
+      Object.assign({}, defaultConfig, {rootDir: '/root1'}),
     );
+    const hasteMap2 = new HasteMap(
+      Object.assign({}, defaultConfig, {rootDir: '/root2'}),
+    );
+    expect(hasteMap1.getCacheFilePath()).not.toBe(hasteMap2.getCacheFilePath());
+  });
+
+  it('creates different cache file paths for different projects', () => {
+    jest.resetModuleRegistry();
+    const HasteMap = require('../');
+    const hasteMap1 = new HasteMap(
+      Object.assign({}, defaultConfig, {name: '@scoped/package'}),
+    );
+    const hasteMap2 = new HasteMap(
+      Object.assign({}, defaultConfig, {name: '-scoped-package'}),
+    );
+    expect(hasteMap1.getCacheFilePath()).not.toBe(hasteMap2.getCacheFilePath());
   });
 
   it('matches files against a pattern', () =>

--- a/packages/jest-haste-map/src/index.js
+++ b/packages/jest-haste-map/src/index.js
@@ -263,6 +263,7 @@ class HasteMap extends EventEmitter {
       this._options.cacheDirectory,
       `haste-map-${this._options.name}-${rootDirHash}`,
       VERSION,
+      this._options.name,
       this._options.roots
         .map(root => fastPath.relative(options.rootDir, root))
         .join(':'),
@@ -283,7 +284,7 @@ class HasteMap extends EventEmitter {
     name: string,
     ...extra: Array<string>
   ): string {
-    const hash = crypto.createHash('md5').update(name + extra.join(''));
+    const hash = crypto.createHash('md5').update(extra.join(''));
     return path.join(
       tmpdir,
       name.replace(/\W/g, '-') + '-' + hash.digest('hex'),


### PR DESCRIPTION
## Summary

This simplifies the remote caching of haste map files. Right now the haste map name is structured as `haste-map-${name}-${rootDirHash}-${configHash}`. This modifies the `configHash` so it's not affected by the `rootDirHash` (and passes the project name so it's still taken into account).

## Test plan

Updated unit tests.