### PR TITLE
Interrupt tests if interactive watch plugin key is pressed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### Fixes
 
+- `[jest-cli]` Interrupt tests if interactive watch plugin key is pressed ([#7222](https://github.com/facebook/jest/pull/7222))
 - `[jest-cli]` Fix coverage summary reporting ([#7058](https://github.com/facebook/jest/pull/7058))
 - `[jest-each]` Add each array validation check ([#7033](https://github.com/facebook/jest/pull/7033))
 - `[jest-haste-map]` [**BREAKING**] Replace internal data structures to improve performance ([#6960](https://github.com/facebook/jest/pull/6960))

--- a/packages/jest-cli/src/watch.js
+++ b/packages/jest-cli/src/watch.js
@@ -321,6 +321,10 @@ export default function watch(
     ).find(plugin => getPluginKey(plugin, globalConfig) === key);
 
     if (matchingWatchPlugin != null) {
+      if (isRunning) {
+        testWatcher.setState({interrupted: true});
+        return;
+      }
       // "activate" the plugin, which has jest ignore keystrokes so the plugin
       // can handle them
       activePlugin = matchingWatchPlugin;


### PR DESCRIPTION
## Summary

This PR fixes a regression that was introduced here. https://github.com/facebook/jest/pull/5399/files#diff-d8a3d0a3a8b42ab87b18835ad8f7cb46L208

Pressing a key of an interactive watch plugin should interrupt the running tests, otherwise, the output gets messed up.


## Test plan

### Before
Pressing "p" while tests were running, does not interrupt test run and the output breaks.
![watch-before](https://user-images.githubusercontent.com/574806/47244674-37924000-d3ab-11e8-96b0-94c6e62e501d.gif)

### After
Pressing "p" while tests were running, interrupts the tests run
![watch-after](https://user-images.githubusercontent.com/574806/47244675-37924000-d3ab-11e8-80ab-421164eee1e0.gif)

