### PR TITLE
Update toStrictEqual failure message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 - `[babel-jest]` Cache includes babel environment variables ([#7239](https://github.com/facebook/jest/pull/7239))
 - `[jest-config]` Use strings instead of `RegExp` instances in normalized configuration ([#7251](https://github.com/facebook/jest/pull/7251))
 - `[jest-circus]` Make sure to display real duration even if time is mocked ([#7264](https://github.com/facebook/jest/pull/7264))
+- `[expect]` Improves the failing message for `toStrictEqual` matcher. ([#7224](https://github.com/facebook/jest/pull/7224))
 
 ### Chore & Maintenance
 

--- a/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -3479,6 +3479,30 @@ Received:
   <red>\\"bar\\"</>"
 `;
 
+exports[`.toStrictEqual() matches the expected snapshot when it fails 1`] = `
+"<dim>expect(</><red>received</><dim>).toStrictEqual(</><green>expected</><dim>)</>
+
+Difference:
+
+<green>- Expected</>
+<red>+ Received</>
+
+<dim>  Object {</>
+<green>-   \\"test\\": TestClassA {</>
+<green>-     \\"a\\": 1,</>
+<green>-     \\"b\\": 2,</>
+<green>-   },</>
+<red>+   \\"test\\": 2,</>
+<dim>  }</>"
+`;
+
+exports[`.toStrictEqual() matches the expected snapshot when it fails 2`] = `
+"<dim>expect(</><red>received</><dim>).</>not<dim>.toStrictEqual(</><green>expected</><dim>)</>
+
+Expected: <green>{\\"test\\": {\\"a\\": 1, \\"b\\": 2}}</>
+Received: <red>{\\"test\\": {\\"a\\": 1, \\"b\\": 2}}</>"
+`;
+
 exports[`toMatchObject() {pass: false} expect([0]).toMatchObject([-0]) 1`] = `
 "<dim>expect(</><red>received</><dim>).toMatchObject(</><green>expected</><dim>)</>
 

--- a/packages/expect/src/__tests__/matchers.test.js
+++ b/packages/expect/src/__tests__/matchers.test.js
@@ -244,6 +244,20 @@ describe('.toStrictEqual()', () => {
     }).toStrictEqual({test: new TestClassA(1, 2)});
   });
 
+  it('matches the expected snapshot when it fails', () => {
+    expect(() =>
+      jestExpect({
+        test: 2,
+      }).toStrictEqual({test: new TestClassA(1, 2)}),
+    ).toThrowErrorMatchingSnapshot();
+
+    expect(() =>
+      jestExpect({
+        test: new TestClassA(1, 2),
+      }).not.toStrictEqual({test: new TestClassA(1, 2)}),
+    ).toThrowErrorMatchingSnapshot();
+  });
+
   it('does not pass for different types', () => {
     expect({
       test: new TestClassA(1, 2),

--- a/packages/expect/src/matchers.js
+++ b/packages/expect/src/matchers.js
@@ -628,27 +628,20 @@ const matchers: MatchersObject = {
       true,
     );
 
+    const hint = matcherHint('.toStrictEqual', undefined, undefined, {
+      isNot: this.isNot,
+    });
     const message = pass
       ? () =>
-          matcherHint('.not.toStrictEqual') +
+          hint +
           '\n\n' +
-          `Expected value to not equal:\n` +
-          `  ${printExpected(expected)}\n` +
-          `Received:\n` +
-          `  ${printReceived(received)}`
+          `Expected: ${printExpected(expected)}\n` +
+          `Received: ${printReceived(received)}`
       : () => {
           const diffString = diff(expected, received, {
             expand: this.expand,
           });
-          return (
-            matcherHint('.toStrictEqual') +
-            '\n\n' +
-            `Expected value to equal:\n` +
-            `  ${printExpected(expected)}\n` +
-            `Received:\n` +
-            `  ${printReceived(received)}` +
-            (diffString ? `\n\nDifference:\n\n${diffString}` : '')
-          );
+          return hint + (diffString ? `\n\nDifference:\n\n${diffString}` : '');
         };
 
     // Passing the the actual and expected objects so that a custom reporter


### PR DESCRIPTION
## Summary

This pull request updates the failure message returned by toStrictEqual so that it is more inline with what #7105 envisions.
 
## Test plan

The matcher is tested with a snapshot test. 

Here are a few screenshots of the before and after along with the test file.

Before: (I had to minimize the image to fit both tests in one screen)

![image](https://user-images.githubusercontent.com/18214059/47253151-16505300-d482-11e8-9596-a5a37c238d4b.png)


After:

![image](https://user-images.githubusercontent.com/18214059/47253131-e012d380-d481-11e8-9211-be3417ec0cd7.png)

