### PR TITLE
Fix typo

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -404,7 +404,7 @@ Specifies notification mode. Requires `notify: true`.
 - `success`: send a notification when tests pass.
 - `change`: send a notification when the status changed.
 - `success-change`: send a notification when tests pass or once when it fails.
-- `failure-change`: send a notification when tests fails or once when it passes.
+- `failure-change`: send a notification when tests fail or once when it passes.
 
 ### `preset` [string]
 

--- a/docs/JestObjectAPI.md
+++ b/docs/JestObjectAPI.md
@@ -315,7 +315,7 @@ Returns the `jest` object for chaining.
 
 ### `jest.retryTimes()`
 
-Runs failed tests n-times until they pass or until the max number of retries are exhausted. This only works with [jest-circus](https://github.com/facebook/jest/tree/master/packages/jest-circus)!
+Runs failed tests n-times until they pass or until the max number of retries is exhausted. This only works with [jest-circus](https://github.com/facebook/jest/tree/master/packages/jest-circus)!
 
 Example in a test:
 

--- a/docs/MockFunctions.md
+++ b/docs/MockFunctions.md
@@ -95,7 +95,7 @@ console.log(myMock(), myMock(), myMock(), myMock());
 // > 10, 'x', true, true
 ```
 
-Mock functions are also very effective in code that uses a functional continuation-passing style. Code written in this style helps avoid the need for complicated stubs that recreate behavior of the real component they're standing in for, in favor of injecting values directly into the test right before they're used.
+Mock functions are also very effective in code that uses a functional continuation-passing style. Code written in this style helps avoid the need for complicated stubs that recreate the behavior of the real component they're standing in for, in favor of injecting values directly into the test right before they're used.
 
 ```javascript
 const filterTestFn = jest.fn();

--- a/docs/SnapshotTesting.md
+++ b/docs/SnapshotTesting.md
@@ -42,7 +42,7 @@ exports[`renders correctly 1`] = `
 The snapshot artifact should be committed alongside code changes, and reviewed as part of your code review process. Jest uses [pretty-format](https://github.com/facebook/jest/tree/master/packages/pretty-format) to make snapshots human-readable during code review. On subsequent test runs Jest will simply compare the rendered output with the previous snapshot. If they match, the test will pass. If they don't match, either the test runner found a bug in your code (in this case, it's `<Link>` component) that should be fixed, or the implementation has changed and the snapshot needs to be updated.
 
 > Note: The snapshot is directly scoped to the data you render – in our example it's `<Link />` component with page prop passed to it. This implies that even if any other file has missing props (Say, `App.js`) in the `<Link />` component, it will still pass the test as the test doesn't know the usage of `<Link />` component and it's scoped only to the `Link.react.js`.  
-> Also, Rendering the same component with different props in other snapshot test will not affect the first one, as the tests don't know about each other.
+> Also, Rendering the same component with different props in other snapshot tests will not affect the first one, as the tests don't know about each other.
 
 More information on how snapshot testing works and why we built it can be found on the [release blog post](https://jestjs.io/blog/2016/07/27/jest-14.html). We recommend reading [this blog post](http://benmccormick.org/2016/09/19/testing-with-jest-snapshots-first-impressions/) to get a good sense of when you should use snapshot testing. We also recommend watching this [egghead video](https://egghead.io/lessons/javascript-use-jest-s-snapshot-testing-feature?pl=testing-javascript-with-jest-a36c4074) on Snapshot Testing with Jest.
 
@@ -308,11 +308,11 @@ Jest has been rewritten with performance in mind, and snapshot testing is not an
 
 ### How do I resolve conflicts within snapshot files?
 
-Snapshot files must always represent the current state of the modules they are covering. Therefore, if you are merging two branches and encounter a conflict in the snapshot files, you can either resolve the conflict manually or to update the snapshot file by running Jest and inspecting the result.
+Snapshot files must always represent the current state of the modules they are covering. Therefore, if you are merging two branches and encounter a conflict in the snapshot files, you can either resolve the conflict manually or update the snapshot file by running Jest and inspecting the result.
 
 ### Is it possible to apply test-driven development principles with snapshot testing?
 
-Although it is possible to write snapshot files manually, that is usually not approachable. Snapshots help figuring out whether the output of the modules covered by tests is changed, rather than giving guidance to design the code in the first place.
+Although it is possible to write snapshot files manually, that is usually not approachable. Snapshots help to figure out whether the output of the modules covered by tests is changed, rather than giving guidance to design the code in the first place.
 
 ### Does code coverage work with snapshot testing?
 


### PR DESCRIPTION
This PR fixes the following typo:
* `tests fails` -> `tests fail`
* `the max number of retries are exhausted` -> `the max number of retries is exhausted`
* `recreate behavior` -> `recreate the behavior`
* `other snapshot test` -> `other snapshot tests`
* `resolve the conflict manually or to update the snapshot file` -> `resolve the conflict manually or update the snapshot file`
* `Snapshots help figuring out` -> `Snapshots help to figure out`