### PR TITLE
Do not return all files when checking changed files from last commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 - `[jest-runtime]` Fix missing coverage when using negative glob pattern in `testMatch` ([#7170](https://github.com/facebook/jest/pull/7170))
 - `[*]` Ensure `maxWorkers` is at least 1 (was 0 in some cases where there was only 1 CPU) ([#7182](https://github.com/facebook/jest/pull/7182))
 - `[jest-runtime]` Fix transform cache invalidation when requiring a test file from multiple projects ([#7186](https://github.com/facebook/jest/pull/7186))
+- `[jest-changed-files]` Return correctly the changed files when using `lastCommit=true` on Mercurial repositories ([#7228](https://github.com/facebook/jest/pull/7228))
 
 ### Chore & Maintenance
 

--- a/packages/jest-changed-files/src/hg.js
+++ b/packages/jest-changed-files/src/hg.js
@@ -41,7 +41,7 @@ const adapter: SCMAdapter = {
     } else if (options && options.changedSince) {
       args.push('--rev', `ancestor(., ${options.changedSince})`);
     } else if (options && options.lastCommit === true) {
-      args.push('-A');
+      args.push('--change', '.');
     }
     args.push(...includePaths);
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

#6732 improved the commands used to check the files that have checked for both Mercurial and Git repositories, but caused a bug on Mercurial repositories.

Turns out that executing `hg status -A` returns every single file on the repository, which is wrong (and extreeeemely slow for huge repos like FB's one 😅).

This PR changes the arguments passed to the `hg` command when `lastCommit` is `true` to fix the problem.

## Test plan

`jest-changed-files` does not have any tests (which is understandable since testing its functionality is not straightforward), so I've done some manual testing:

1. Execute manually `hg status -amnu --change . <some_folders>` on a Mercurial repository and check that it always returns the changed files from the current commit.
2. Patch this PR into our internal codebase with a WIP version of Jest v24.0.0-alpha.0 and check that our continuous integration tests pass correctly.
