### PR TITLE
Uncomment afterAll in watch mode e2e test

### DIFF
--- a/e2e/__tests__/watch_mode_update_snapshot.test.js
+++ b/e2e/__tests__/watch_mode_update_snapshot.test.js
@@ -17,7 +17,7 @@ const DIR = path.resolve(os.tmpdir(), 'watch_mode_update_snapshot');
 const pluginPath = path.resolve(__dirname, '../MockStdinWatchPlugin');
 
 beforeEach(() => cleanup(DIR));
-// afterAll(() => cleanup(DIR));
+afterAll(() => cleanup(DIR));
 
 expect.addSnapshotSerializer({
   print: val => val.replace(/\[s\[u/g, '\n'),


### PR DESCRIPTION
## Summary

I left a commented `afterAll` block after merging #7141. It doesn't impact in the test results since it simply leaves a directory in a `tmp` location, which then gets cleaned up in the next test run.

## Test plan

N/A
