### PR TITLE
Cache checking supports native platform

### DIFF
--- a/e2e/__tests__/__snapshots__/module_name_mapper.test.js.snap
+++ b/e2e/__tests__/__snapshots__/module_name_mapper.test.js.snap
@@ -32,7 +32,7 @@ exports[`moduleNameMapper wrong configuration 1`] = `
       12 | module.exports = () => 'test';
       13 | 
 
-      at packages/jest-resolve/build/index.js:411:17
+      at packages/jest-resolve/build/index.js:410:17
       at index.js:10:1
 
 "

--- a/e2e/__tests__/__snapshots__/resolve_no_file_extensions.test.js.snap
+++ b/e2e/__tests__/__snapshots__/resolve_no_file_extensions.test.js.snap
@@ -33,7 +33,7 @@ exports[`show error message with matching files 1`] = `
         |                  ^
       4 | 
 
-      at packages/jest-resolve/build/index.js:221:17
+      at packages/jest-resolve/build/index.js:224:17
       at index.js:3:18
 
 "

--- a/packages/jest-resolve/src/index.js
+++ b/packages/jest-resolve/src/index.js
@@ -67,6 +67,7 @@ class Resolver {
   _moduleIDCache: {[key: string]: string, __proto__: null};
   _moduleNameCache: {[name: string]: Path, __proto__: null};
   _modulePathCache: {[path: Path]: Array<Path>, __proto__: null};
+  _supportsNativePlatform: boolean;
 
   constructor(moduleMap: ModuleMap, options: ResolverConfig) {
     this._options = {
@@ -82,6 +83,9 @@ class Resolver {
       resolver: options.resolver,
       rootDir: options.rootDir,
     };
+    this._supportsNativePlatform = options.platforms
+      ? options.platforms.includes(NATIVE_PLATFORM)
+      : false;
     this._moduleMap = moduleMap;
     this._moduleIDCache = Object.create(null);
     this._moduleNameCache = Object.create(null);
@@ -118,7 +122,7 @@ class Resolver {
     const key = dirname + path.delimiter + moduleName;
     const defaultPlatform = this._options.defaultPlatform;
     const extensions = this._options.extensions.slice();
-    if (this._supportsNativePlatform()) {
+    if (this._supportsNativePlatform) {
       extensions.unshift(
         ...this._options.extensions.map(ext => '.' + NATIVE_PLATFORM + ext),
       );
@@ -221,7 +225,7 @@ class Resolver {
     return this._moduleMap.getModule(
       name,
       this._options.defaultPlatform,
-      this._supportsNativePlatform(),
+      this._supportsNativePlatform,
     );
   }
 
@@ -236,7 +240,7 @@ class Resolver {
     return this._moduleMap.getPackage(
       name,
       this._options.defaultPlatform,
-      this._supportsNativePlatform(),
+      this._supportsNativePlatform,
     );
   }
 
@@ -380,10 +384,6 @@ class Resolver {
       }
     }
     return null;
-  }
-
-  _supportsNativePlatform() {
-    return (this._options.platforms || []).indexOf(NATIVE_PLATFORM) !== -1;
   }
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Method `this._supportsNativePlatform()` calls very offten. But it is not required, because it just checks: 
```js
_supportsNativePlatform() {
    (this._options.platforms || []).indexOf(NATIVE_PLATFORM) !== -1;
}
```
We can check it once in `constructor` and use simple boolean flag.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
