### PR TITLE
[jest-each]: Add empty string/array validation check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 ### Fixes
 
+- `[jest-each]` Add empty array validation check ([#7249](https://github.com/facebook/jest/pull/7249))
 - `[jest-cli]` Interrupt tests if interactive watch plugin key is pressed ([#7222](https://github.com/facebook/jest/pull/7222))
 - `[jest-cli]` Fix coverage summary reporting ([#7058](https://github.com/facebook/jest/pull/7058))
 - `[jest-each]` Add each array validation check ([#7033](https://github.com/facebook/jest/pull/7033))

--- a/packages/jest-each/src/__tests__/__snapshots__/array.test.js.snap
+++ b/packages/jest-each/src/__tests__/__snapshots__/array.test.js.snap
@@ -1,96 +1,96 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`jest-each .describe throws an error when called with an empty array 1`] = `
-"Error: \`.each\` called with an empty array of table data.
+"Error: \`.each\` called with an empty Array of table data.
 "
 `;
 
 exports[`jest-each .describe throws an error when not called with an array 1`] = `
-"\`.each\` must be called with an Array or Tagged Template String.
+"\`.each\` must be called with an Array or Tagged Template Literal.
 
 Instead was called with: undefined
 "
 `;
 
 exports[`jest-each .describe.only throws an error when called with an empty array 1`] = `
-"Error: \`.each\` called with an empty array of table data.
+"Error: \`.each\` called with an empty Array of table data.
 "
 `;
 
 exports[`jest-each .describe.only throws an error when not called with an array 1`] = `
-"\`.each\` must be called with an Array or Tagged Template String.
+"\`.each\` must be called with an Array or Tagged Template Literal.
 
 Instead was called with: undefined
 "
 `;
 
 exports[`jest-each .fdescribe throws an error when called with an empty array 1`] = `
-"Error: \`.each\` called with an empty array of table data.
+"Error: \`.each\` called with an empty Array of table data.
 "
 `;
 
 exports[`jest-each .fdescribe throws an error when not called with an array 1`] = `
-"\`.each\` must be called with an Array or Tagged Template String.
+"\`.each\` must be called with an Array or Tagged Template Literal.
 
 Instead was called with: undefined
 "
 `;
 
 exports[`jest-each .fit throws an error when called with an empty array 1`] = `
-"Error: \`.each\` called with an empty array of table data.
+"Error: \`.each\` called with an empty Array of table data.
 "
 `;
 
 exports[`jest-each .fit throws an error when not called with an array 1`] = `
-"\`.each\` must be called with an Array or Tagged Template String.
+"\`.each\` must be called with an Array or Tagged Template Literal.
 
 Instead was called with: undefined
 "
 `;
 
 exports[`jest-each .it throws an error when called with an empty array 1`] = `
-"Error: \`.each\` called with an empty array of table data.
+"Error: \`.each\` called with an empty Array of table data.
 "
 `;
 
 exports[`jest-each .it throws an error when not called with an array 1`] = `
-"\`.each\` must be called with an Array or Tagged Template String.
+"\`.each\` must be called with an Array or Tagged Template Literal.
 
 Instead was called with: undefined
 "
 `;
 
 exports[`jest-each .it.only throws an error when called with an empty array 1`] = `
-"Error: \`.each\` called with an empty array of table data.
+"Error: \`.each\` called with an empty Array of table data.
 "
 `;
 
 exports[`jest-each .it.only throws an error when not called with an array 1`] = `
-"\`.each\` must be called with an Array or Tagged Template String.
+"\`.each\` must be called with an Array or Tagged Template Literal.
 
 Instead was called with: undefined
 "
 `;
 
 exports[`jest-each .test throws an error when called with an empty array 1`] = `
-"Error: \`.each\` called with an empty array of table data.
+"Error: \`.each\` called with an empty Array of table data.
 "
 `;
 
 exports[`jest-each .test throws an error when not called with an array 1`] = `
-"\`.each\` must be called with an Array or Tagged Template String.
+"\`.each\` must be called with an Array or Tagged Template Literal.
 
 Instead was called with: undefined
 "
 `;
 
 exports[`jest-each .test.only throws an error when called with an empty array 1`] = `
-"Error: \`.each\` called with an empty array of table data.
+"Error: \`.each\` called with an empty Array of table data.
 "
 `;
 
 exports[`jest-each .test.only throws an error when not called with an array 1`] = `
-"\`.each\` must be called with an Array or Tagged Template String.
+"\`.each\` must be called with an Array or Tagged Template Literal.
 
 Instead was called with: undefined
 "

--- a/packages/jest-each/src/__tests__/__snapshots__/array.test.js.snap
+++ b/packages/jest-each/src/__tests__/__snapshots__/array.test.js.snap
@@ -1,9 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`jest-each .describe throws an error when called with an empty array 1`] = `
+"Error: \`.each\` called with an empty array of table data.
+"
+`;
+
 exports[`jest-each .describe throws an error when not called with an array 1`] = `
 "\`.each\` must be called with an Array or Tagged Template String.
 
 Instead was called with: undefined
+"
+`;
+
+exports[`jest-each .describe.only throws an error when called with an empty array 1`] = `
+"Error: \`.each\` called with an empty array of table data.
 "
 `;
 
@@ -14,10 +24,20 @@ Instead was called with: undefined
 "
 `;
 
+exports[`jest-each .fdescribe throws an error when called with an empty array 1`] = `
+"Error: \`.each\` called with an empty array of table data.
+"
+`;
+
 exports[`jest-each .fdescribe throws an error when not called with an array 1`] = `
 "\`.each\` must be called with an Array or Tagged Template String.
 
 Instead was called with: undefined
+"
+`;
+
+exports[`jest-each .fit throws an error when called with an empty array 1`] = `
+"Error: \`.each\` called with an empty array of table data.
 "
 `;
 
@@ -28,10 +48,20 @@ Instead was called with: undefined
 "
 `;
 
+exports[`jest-each .it throws an error when called with an empty array 1`] = `
+"Error: \`.each\` called with an empty array of table data.
+"
+`;
+
 exports[`jest-each .it throws an error when not called with an array 1`] = `
 "\`.each\` must be called with an Array or Tagged Template String.
 
 Instead was called with: undefined
+"
+`;
+
+exports[`jest-each .it.only throws an error when called with an empty array 1`] = `
+"Error: \`.each\` called with an empty array of table data.
 "
 `;
 
@@ -42,10 +72,20 @@ Instead was called with: undefined
 "
 `;
 
+exports[`jest-each .test throws an error when called with an empty array 1`] = `
+"Error: \`.each\` called with an empty array of table data.
+"
+`;
+
 exports[`jest-each .test throws an error when not called with an array 1`] = `
 "\`.each\` must be called with an Array or Tagged Template String.
 
 Instead was called with: undefined
+"
+`;
+
+exports[`jest-each .test.only throws an error when called with an empty array 1`] = `
+"Error: \`.each\` called with an empty array of table data.
 "
 `;
 

--- a/packages/jest-each/src/__tests__/__snapshots__/template.test.js.snap
+++ b/packages/jest-each/src/__tests__/__snapshots__/template.test.js.snap
@@ -34,6 +34,11 @@ Received:
 Missing <red>2</> arguments"
 `;
 
+exports[`jest-each .describe throws error when there are no arguments for given headings 1`] = `
+"Error: \`.each\` called with a Tagged Template Literal with no data, remember to interpolate with \${expression} syntax.
+"
+`;
+
 exports[`jest-each .describe.only throws an error when called with an empty string 1`] = `
 "Error: \`.each\` called with an empty Tagged Template Literal of table data.
 "
@@ -66,6 +71,11 @@ Received:
 <red>]</>
 
 Missing <red>2</> arguments"
+`;
+
+exports[`jest-each .describe.only throws error when there are no arguments for given headings 1`] = `
+"Error: \`.each\` called with a Tagged Template Literal with no data, remember to interpolate with \${expression} syntax.
+"
 `;
 
 exports[`jest-each .fdescribe throws an error when called with an empty string 1`] = `
@@ -102,6 +112,11 @@ Received:
 Missing <red>2</> arguments"
 `;
 
+exports[`jest-each .fdescribe throws error when there are no arguments for given headings 1`] = `
+"Error: \`.each\` called with a Tagged Template Literal with no data, remember to interpolate with \${expression} syntax.
+"
+`;
+
 exports[`jest-each .fit throws an error when called with an empty string 1`] = `
 "Error: \`.each\` called with an empty Tagged Template Literal of table data.
 "
@@ -134,6 +149,11 @@ Received:
 <red>]</>
 
 Missing <red>2</> arguments"
+`;
+
+exports[`jest-each .fit throws error when there are no arguments for given headings 1`] = `
+"Error: \`.each\` called with a Tagged Template Literal with no data, remember to interpolate with \${expression} syntax.
+"
 `;
 
 exports[`jest-each .it throws an error when called with an empty string 1`] = `
@@ -170,6 +190,11 @@ Received:
 Missing <red>2</> arguments"
 `;
 
+exports[`jest-each .it throws error when there are no arguments for given headings 1`] = `
+"Error: \`.each\` called with a Tagged Template Literal with no data, remember to interpolate with \${expression} syntax.
+"
+`;
+
 exports[`jest-each .it.only throws an error when called with an empty string 1`] = `
 "Error: \`.each\` called with an empty Tagged Template Literal of table data.
 "
@@ -202,6 +227,11 @@ Received:
 <red>]</>
 
 Missing <red>2</> arguments"
+`;
+
+exports[`jest-each .it.only throws error when there are no arguments for given headings 1`] = `
+"Error: \`.each\` called with a Tagged Template Literal with no data, remember to interpolate with \${expression} syntax.
+"
 `;
 
 exports[`jest-each .test throws an error when called with an empty string 1`] = `
@@ -238,6 +268,11 @@ Received:
 Missing <red>2</> arguments"
 `;
 
+exports[`jest-each .test throws error when there are no arguments for given headings 1`] = `
+"Error: \`.each\` called with a Tagged Template Literal with no data, remember to interpolate with \${expression} syntax.
+"
+`;
+
 exports[`jest-each .test.only throws an error when called with an empty string 1`] = `
 "Error: \`.each\` called with an empty Tagged Template Literal of table data.
 "
@@ -270,4 +305,9 @@ Received:
 <red>]</>
 
 Missing <red>2</> arguments"
+`;
+
+exports[`jest-each .test.only throws error when there are no arguments for given headings 1`] = `
+"Error: \`.each\` called with a Tagged Template Literal with no data, remember to interpolate with \${expression} syntax.
+"
 `;

--- a/packages/jest-each/src/__tests__/__snapshots__/template.test.js.snap
+++ b/packages/jest-each/src/__tests__/__snapshots__/template.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`jest-each .describe throws an error when called with an empty string 1`] = `
-"Error: \`.each\` called with an empty tagged template string of table data.
+"Error: \`.each\` called with an empty Tagged Template Literal of table data.
 "
 `;
 
@@ -35,7 +35,7 @@ Missing <red>2</> arguments"
 `;
 
 exports[`jest-each .describe.only throws an error when called with an empty string 1`] = `
-"Error: \`.each\` called with an empty tagged template string of table data.
+"Error: \`.each\` called with an empty Tagged Template Literal of table data.
 "
 `;
 
@@ -69,7 +69,7 @@ Missing <red>2</> arguments"
 `;
 
 exports[`jest-each .fdescribe throws an error when called with an empty string 1`] = `
-"Error: \`.each\` called with an empty tagged template string of table data.
+"Error: \`.each\` called with an empty Tagged Template Literal of table data.
 "
 `;
 
@@ -103,7 +103,7 @@ Missing <red>2</> arguments"
 `;
 
 exports[`jest-each .fit throws an error when called with an empty string 1`] = `
-"Error: \`.each\` called with an empty tagged template string of table data.
+"Error: \`.each\` called with an empty Tagged Template Literal of table data.
 "
 `;
 
@@ -137,7 +137,7 @@ Missing <red>2</> arguments"
 `;
 
 exports[`jest-each .it throws an error when called with an empty string 1`] = `
-"Error: \`.each\` called with an empty tagged template string of table data.
+"Error: \`.each\` called with an empty Tagged Template Literal of table data.
 "
 `;
 
@@ -171,7 +171,7 @@ Missing <red>2</> arguments"
 `;
 
 exports[`jest-each .it.only throws an error when called with an empty string 1`] = `
-"Error: \`.each\` called with an empty tagged template string of table data.
+"Error: \`.each\` called with an empty Tagged Template Literal of table data.
 "
 `;
 
@@ -205,7 +205,7 @@ Missing <red>2</> arguments"
 `;
 
 exports[`jest-each .test throws an error when called with an empty string 1`] = `
-"Error: \`.each\` called with an empty tagged template string of table data.
+"Error: \`.each\` called with an empty Tagged Template Literal of table data.
 "
 `;
 
@@ -239,7 +239,7 @@ Missing <red>2</> arguments"
 `;
 
 exports[`jest-each .test.only throws an error when called with an empty string 1`] = `
-"Error: \`.each\` called with an empty tagged template string of table data.
+"Error: \`.each\` called with an empty Tagged Template Literal of table data.
 "
 `;
 

--- a/packages/jest-each/src/__tests__/__snapshots__/template.test.js.snap
+++ b/packages/jest-each/src/__tests__/__snapshots__/template.test.js.snap
@@ -1,5 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`jest-each .describe throws an error when called with an empty string 1`] = `
+"Error: \`.each\` called with an empty tagged template string of table data.
+"
+`;
+
 exports[`jest-each .describe throws error when there are fewer arguments than headings over multiple rows 1`] = `
 "Not enough arguments supplied for given headings:
 <green>a | b | expected</>
@@ -27,6 +32,11 @@ Received:
 <red>]</>
 
 Missing <red>2</> arguments"
+`;
+
+exports[`jest-each .describe.only throws an error when called with an empty string 1`] = `
+"Error: \`.each\` called with an empty tagged template string of table data.
+"
 `;
 
 exports[`jest-each .describe.only throws error when there are fewer arguments than headings over multiple rows 1`] = `
@@ -58,6 +68,11 @@ Received:
 Missing <red>2</> arguments"
 `;
 
+exports[`jest-each .fdescribe throws an error when called with an empty string 1`] = `
+"Error: \`.each\` called with an empty tagged template string of table data.
+"
+`;
+
 exports[`jest-each .fdescribe throws error when there are fewer arguments than headings over multiple rows 1`] = `
 "Not enough arguments supplied for given headings:
 <green>a | b | expected</>
@@ -85,6 +100,11 @@ Received:
 <red>]</>
 
 Missing <red>2</> arguments"
+`;
+
+exports[`jest-each .fit throws an error when called with an empty string 1`] = `
+"Error: \`.each\` called with an empty tagged template string of table data.
+"
 `;
 
 exports[`jest-each .fit throws error when there are fewer arguments than headings over multiple rows 1`] = `
@@ -116,6 +136,11 @@ Received:
 Missing <red>2</> arguments"
 `;
 
+exports[`jest-each .it throws an error when called with an empty string 1`] = `
+"Error: \`.each\` called with an empty tagged template string of table data.
+"
+`;
+
 exports[`jest-each .it throws error when there are fewer arguments than headings over multiple rows 1`] = `
 "Not enough arguments supplied for given headings:
 <green>a | b | expected</>
@@ -143,6 +168,11 @@ Received:
 <red>]</>
 
 Missing <red>2</> arguments"
+`;
+
+exports[`jest-each .it.only throws an error when called with an empty string 1`] = `
+"Error: \`.each\` called with an empty tagged template string of table data.
+"
 `;
 
 exports[`jest-each .it.only throws error when there are fewer arguments than headings over multiple rows 1`] = `
@@ -174,6 +204,11 @@ Received:
 Missing <red>2</> arguments"
 `;
 
+exports[`jest-each .test throws an error when called with an empty string 1`] = `
+"Error: \`.each\` called with an empty tagged template string of table data.
+"
+`;
+
 exports[`jest-each .test throws error when there are fewer arguments than headings over multiple rows 1`] = `
 "Not enough arguments supplied for given headings:
 <green>a | b | expected</>
@@ -201,6 +236,11 @@ Received:
 <red>]</>
 
 Missing <red>2</> arguments"
+`;
+
+exports[`jest-each .test.only throws an error when called with an empty string 1`] = `
+"Error: \`.each\` called with an empty tagged template string of table data.
+"
 `;
 
 exports[`jest-each .test.only throws error when there are fewer arguments than headings over multiple rows 1`] = `

--- a/packages/jest-each/src/__tests__/array.test.js
+++ b/packages/jest-each/src/__tests__/array.test.js
@@ -60,6 +60,19 @@ describe('jest-each', () => {
         ).toThrowErrorMatchingSnapshot();
       });
 
+      test('throws an error when called with an empty array', () => {
+        const globalTestMocks = getGlobalTestMocks();
+        const eachObject = each.withGlobal(globalTestMocks)([]);
+        const testFunction = get(eachObject, keyPath);
+
+        testFunction('expected string', noop);
+        const globalMock = get(globalTestMocks, keyPath);
+
+        expect(() =>
+          globalMock.mock.calls[0][1](),
+        ).toThrowErrorMatchingSnapshot();
+      });
+
       test('calls global with given title', () => {
         const globalTestMocks = getGlobalTestMocks();
         const eachObject = each.withGlobal(globalTestMocks)([[]]);

--- a/packages/jest-each/src/__tests__/template.test.js
+++ b/packages/jest-each/src/__tests__/template.test.js
@@ -46,6 +46,23 @@ describe('jest-each', () => {
     ['describe', 'only'],
   ].forEach(keyPath => {
     describe(`.${keyPath.join('.')}`, () => {
+      test('throws error when there are no arguments for given headings', () => {
+        const globalTestMocks = getGlobalTestMocks();
+        const eachObject = each.withGlobal(globalTestMocks)`
+          a    | b    | expected
+        `;
+        const testFunction = get(eachObject, keyPath);
+        const testCallBack = jest.fn();
+        testFunction('this will blow up :(', testCallBack);
+
+        const globalMock = get(globalTestMocks, keyPath);
+
+        expect(() =>
+          globalMock.mock.calls[0][1](),
+        ).toThrowErrorMatchingSnapshot();
+        expect(testCallBack).not.toHaveBeenCalled();
+      });
+
       test('throws error when there are fewer arguments than headings when given one row', () => {
         const globalTestMocks = getGlobalTestMocks();
         const eachObject = each.withGlobal(globalTestMocks)`

--- a/packages/jest-each/src/__tests__/template.test.js
+++ b/packages/jest-each/src/__tests__/template.test.js
@@ -83,6 +83,21 @@ describe('jest-each', () => {
         expect(testCallBack).not.toHaveBeenCalled();
       });
 
+      test('throws an error when called with an empty string', () => {
+        const globalTestMocks = getGlobalTestMocks();
+        const eachObject = each.withGlobal(globalTestMocks)`   `;
+        const testFunction = get(eachObject, keyPath);
+        const testCallBack = jest.fn();
+        testFunction('this will blow up :(', testCallBack);
+
+        const globalMock = get(globalTestMocks, keyPath);
+
+        expect(() =>
+          globalMock.mock.calls[0][1](),
+        ).toThrowErrorMatchingSnapshot();
+        expect(testCallBack).not.toHaveBeenCalled();
+      });
+
       test('calls global with given title', () => {
         const globalTestMocks = getGlobalTestMocks();
         const eachObject = each.withGlobal(globalTestMocks)`

--- a/packages/jest-each/src/bind.js
+++ b/packages/jest-each/src/bind.js
@@ -31,7 +31,7 @@ export default (cb: Function, supportsDone: boolean = true) => (...args: any) =>
 
       if (!Array.isArray(tableArg)) {
         const error = new ErrorWithStack(
-          '`.each` must be called with an Array or Tagged Template String.\n\n' +
+          '`.each` must be called with an Array or Tagged Template Literal.\n\n' +
             `Instead was called with: ${pretty(tableArg, {
               maxDepth: 1,
               min: true,
@@ -49,7 +49,7 @@ export default (cb: Function, supportsDone: boolean = true) => (...args: any) =>
         tableArg[0].trim() === ''
       ) {
         const error = new ErrorWithStack(
-          'Error: `.each` called with an empty tagged template string of table data.\n',
+          'Error: `.each` called with an empty Tagged Template Literal of table data.\n',
           eachBind,
         );
         return cb(title, () => {
@@ -59,7 +59,7 @@ export default (cb: Function, supportsDone: boolean = true) => (...args: any) =>
 
       if (tableArg.length === 0) {
         const error = new ErrorWithStack(
-          'Error: `.each` called with an empty array of table data.\n',
+          'Error: `.each` called with an empty Array of table data.\n',
           eachBind,
         );
         return cb(title, () => {

--- a/packages/jest-each/src/bind.js
+++ b/packages/jest-each/src/bind.js
@@ -43,6 +43,20 @@ export default (cb: Function, supportsDone: boolean = true) => (...args: any) =>
         });
       }
 
+      if (
+        tableArg.length === 1 &&
+        typeof tableArg[0] === 'string' &&
+        tableArg[0].trim() === ''
+      ) {
+        const error = new ErrorWithStack(
+          'Error: `.each` called with an empty tagged template string of table data.\n',
+          eachBind,
+        );
+        return cb(title, () => {
+          throw error;
+        });
+      }
+
       if (tableArg.length === 0) {
         const error = new ErrorWithStack(
           'Error: `.each` called with an empty array of table data.\n',

--- a/packages/jest-each/src/bind.js
+++ b/packages/jest-each/src/bind.js
@@ -43,13 +43,19 @@ export default (cb: Function, supportsDone: boolean = true) => (...args: any) =>
         });
       }
 
-      if (
-        tableArg.length === 1 &&
-        typeof tableArg[0] === 'string' &&
-        tableArg[0].trim() === ''
-      ) {
+      if (isTaggedTemplateLiteral(tableArg)) {
+        if (isEmptyString(tableArg[0])) {
+          const error = new ErrorWithStack(
+            'Error: `.each` called with an empty Tagged Template Literal of table data.\n',
+            eachBind,
+          );
+          return cb(title, () => {
+            throw error;
+          });
+        }
+
         const error = new ErrorWithStack(
-          'Error: `.each` called with an empty Tagged Template Literal of table data.\n',
+          'Error: `.each` called with a Tagged Template Literal with no data, remember to interpolate with ${expression} syntax.\n',
           eachBind,
         );
         return cb(title, () => {
@@ -57,7 +63,7 @@ export default (cb: Function, supportsDone: boolean = true) => (...args: any) =>
         });
       }
 
-      if (tableArg.length === 0) {
+      if (isEmptyTable(tableArg)) {
         const error = new ErrorWithStack(
           'Error: `.each` called with an empty Array of table data.\n',
           eachBind,
@@ -114,6 +120,10 @@ export default (cb: Function, supportsDone: boolean = true) => (...args: any) =>
       ),
     );
   };
+
+const isTaggedTemplateLiteral = array => array.raw !== undefined;
+const isEmptyTable = table => table.length === 0;
+const isEmptyString = str => typeof str === 'string' && str.trim() === '';
 
 const getPrettyIndexes = placeholders =>
   placeholders.reduce(

--- a/packages/jest-each/src/bind.js
+++ b/packages/jest-each/src/bind.js
@@ -42,6 +42,16 @@ export default (cb: Function, supportsDone: boolean = true) => (...args: any) =>
           throw error;
         });
       }
+
+      if (tableArg.length === 0) {
+        const error = new ErrorWithStack(
+          'Error: `.each` called with an empty array of table data.\n',
+          eachBind,
+        );
+        return cb(title, () => {
+          throw error;
+        });
+      }
       const table: Table = tableArg.every(Array.isArray)
         ? tableArg
         : tableArg.map(entry => [entry]);


### PR DESCRIPTION
## Summary
Motivation: @SimenB's https://github.com/facebook/jest/issues/7100#issuecomment-429042239

> We should probably throw on empty arrays as well, not just non-arrays

## Test plan

- Unit tests