### PR TITLE
Test results errored

### DIFF
--- a/e2e/__tests__/__snapshots__/globals.test.js.snap
+++ b/e2e/__tests__/__snapshots__/globals.test.js.snap
@@ -37,7 +37,7 @@ exports[`cannot have describe with no implementation 1`] = `
 
 exports[`cannot have describe with no implementation 2`] = `
 "Test Suites: 1 failed, 1 total
-Tests:       0 total
+Tests:       1 total
 Snapshots:   0 total
 Time:        <<REPLACED>>
 Ran all test suites.
@@ -64,7 +64,7 @@ exports[`cannot test with no implementation 1`] = `
 
 exports[`cannot test with no implementation 2`] = `
 "Test Suites: 1 failed, 1 total
-Tests:       0 total
+Tests:       1 total
 Snapshots:   0 total
 Time:        <<REPLACED>>
 Ran all test suites.
@@ -91,7 +91,7 @@ exports[`cannot test with no implementation with expand arg 1`] = `
 
 exports[`cannot test with no implementation with expand arg 2`] = `
 "Test Suites: 1 failed, 1 total
-Tests:       0 total
+Tests:       1 total
 Snapshots:   0 total
 Time:        <<REPLACED>>
 Ran all test suites.

--- a/e2e/__tests__/__snapshots__/multi_project_runner.test.js.snap
+++ b/e2e/__tests__/__snapshots__/multi_project_runner.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`can pass projects or global config 1`] = `
 "Test Suites: 3 failed, 3 total
-Tests:       0 total
+Tests:       3 total
 Snapshots:   0 total
 Time:        <<REPLACED>>
 Ran all test suites.

--- a/e2e/__tests__/__snapshots__/stack_trace.test.js.snap
+++ b/e2e/__tests__/__snapshots__/stack_trace.test.js.snap
@@ -20,7 +20,7 @@ Ran all test suites matching /stack_trace.test.js/i.
 
 exports[`Stack Trace does not print a stack trace for runtime errors when --noStackTrace is given 1`] = `
 "Test Suites: 1 failed, 1 total
-Tests:       0 total
+Tests:       1 total
 Snapshots:   0 total
 Time:        <<REPLACED>>
 Ran all test suites matching /runtime_error.test.js/i.
@@ -56,7 +56,7 @@ Ran all test suites matching /stack_trace.test.js/i.
 
 exports[`Stack Trace prints a stack trace for runtime errors 1`] = `
 "Test Suites: 1 failed, 1 total
-Tests:       0 total
+Tests:       1 total
 Snapshots:   0 total
 Time:        <<REPLACED>>
 Ran all test suites matching /runtime_error.test.js/i.

--- a/e2e/__tests__/__snapshots__/watch_mode_patterns.test.js.snap
+++ b/e2e/__tests__/__snapshots__/watch_mode_patterns.test.js.snap
@@ -1,18 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`can press "p" to filter by file name 1`] = `
-
+"
 Pattern Mode Usage
  › Press Esc to exit pattern mode.
  › Press Enter to filter by a filenames regex pattern.
 
- pattern › 
- pattern › b
- pattern › ba
- pattern › bar
+ pattern ›  pattern › b pattern › ba pattern › bar
 
-
-
+"
 `;
 
 exports[`can press "p" to filter by file name: test results 1`] = `
@@ -44,16 +40,14 @@ Ran all test suites matching /bar/i."
 `;
 
 exports[`can press "t" to filter by test name 1`] = `
-
+"
 Pattern Mode Usage
  › Press Esc to exit pattern mode.
  › Press Enter to filter by a tests regex pattern.
 
- pattern › 
- pattern › 2
+ pattern ›  pattern › 2
 
-
-
+"
 `;
 
 exports[`can press "t" to filter by test name: test results 1`] = `

--- a/packages/expect/jest_assertion_error_object.js
+++ b/packages/expect/jest_assertion_error_object.js
@@ -1,7 +1,0 @@
-class JestAssertionError extends Error {
-  constructor(...params) {
-    super(...params);
-  }
-}
-
-module.exports = JestAssertionError;

--- a/packages/expect/jest_assertion_error_object.js
+++ b/packages/expect/jest_assertion_error_object.js
@@ -1,0 +1,7 @@
+class JestAssertionError extends Error {
+  constructor(...params) {
+    super(...params);
+  }
+}
+
+module.exports = JestAssertionError;

--- a/packages/expect/src/index.js
+++ b/packages/expect/src/index.js
@@ -49,7 +49,9 @@ import {
 } from './jest_matchers_object';
 import extractExpectedAssertionsErrors from './extract_expected_assertions_errors';
 
-const JestAssertionError = require('../jest_assertion_error_object');
+class JestAssertionError extends Error {
+  matcherResult: any;
+}
 
 const isPromise = obj =>
   !!obj &&
@@ -383,5 +385,8 @@ expect.hasAssertions = hasAssertions;
 expect.getState = getState;
 expect.setState = setState;
 expect.extractExpectedAssertionsErrors = extractExpectedAssertionsErrors;
+
+// Exporting for external assertion comparisons in circus
+expect.JestAssertionError = JestAssertionError;
 
 module.exports = (expect: Expect);

--- a/packages/expect/src/index.js
+++ b/packages/expect/src/index.js
@@ -49,9 +49,7 @@ import {
 } from './jest_matchers_object';
 import extractExpectedAssertionsErrors from './extract_expected_assertions_errors';
 
-class JestAssertionError extends Error {
-  matcherResult: any;
-}
+const JestAssertionError = require('../jest_assertion_error_object');
 
 const isPromise = obj =>
   !!obj &&

--- a/packages/jest-circus/src/event_handler.js
+++ b/packages/jest-circus/src/event_handler.js
@@ -4,12 +4,12 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow strict-local
+ * @flow
  */
 
 import type {EventHandler} from 'types/Circus';
 
-const JestAssertionError = require('expect/jest_assertion_error_object');
+import expect from 'expect';
 
 import {
   addErrorToEachTestUnderDescribe,
@@ -133,7 +133,7 @@ const handler: EventHandler = (event, state): void => {
       // Detect if this is an unknown error
       // So we can differentiate known assertion errors
       // From uncaught errors
-      if (!(error instanceof JestAssertionError)) {
+      if (!(error instanceof expect.JestAssertionError)) {
         event.test.status = 'error';
       }
 

--- a/packages/jest-circus/src/legacy_code_todo_rewrite/jest_adapter_init.js
+++ b/packages/jest-circus/src/legacy_code_todo_rewrite/jest_adapter_init.js
@@ -125,6 +125,7 @@ export const runAndTransformResultsToJestFormat = async ({
 }): Promise<TestResult> => {
   const runResult = await run();
 
+  let numErroredTests = 0;
   let numFailingTests = 0;
   let numPassingTests = 0;
   let numPendingTests = 0;
@@ -132,7 +133,10 @@ export const runAndTransformResultsToJestFormat = async ({
 
   const assertionResults = runResult.testResults.map(testResult => {
     let status: Status;
-    if (testResult.status === 'skip') {
+
+    if (testResult.status === 'error') {
+      numErroredTests += 1;
+    } else if (testResult.status === 'skip') {
       status = 'pending';
       numPendingTests += 1;
     } else if (testResult.status === 'todo') {
@@ -191,6 +195,7 @@ export const runAndTransformResultsToJestFormat = async ({
     displayName: config.displayName,
     failureMessage,
     leaks: false, // That's legacy code, just adding it so Flow is happy.
+    numErroredTests,
     numFailingTests,
     numPassingTests,
     numPendingTests,

--- a/packages/jest-cli/src/__tests__/generateEmptyCoverage.test.js
+++ b/packages/jest-cli/src/__tests__/generateEmptyCoverage.test.js
@@ -14,7 +14,6 @@ const os = require('os');
 const {makeGlobalConfig, makeProjectConfig} = require('../../../../TestUtils');
 
 jest.mock('jest-runtime', () => {
-  // $FlowFixMe requireActual
   const realRuntime = jest.requireActual('jest-runtime');
   realRuntime.shouldInstrument = () => true;
   return realRuntime;

--- a/packages/jest-cli/src/reporters/get_result_header.js
+++ b/packages/jest-cli/src/reporters/get_result_header.js
@@ -34,7 +34,11 @@ export default (
 ) => {
   const testPath = result.testFilePath;
   const status =
-    result.numFailingTests > 0 || result.testExecError ? FAIL : PASS;
+    result.numFailingTests > 0 ||
+    result.numErroredTests > 0 ||
+    result.testExecError
+      ? FAIL
+      : PASS;
 
   const runTime = result.perfStats
     ? (result.perfStats.end - result.perfStats.start) / 1000

--- a/packages/jest-cli/src/testResultHelpers.js
+++ b/packages/jest-cli/src/testResultHelpers.js
@@ -14,6 +14,7 @@ import type {
 } from 'types/TestResult';
 
 export const makeEmptyAggregatedTestResult = (): AggregatedResult => ({
+  numErroredTests: 0,
   numFailedTestSuites: 0,
   numFailedTests: 0,
   numPassedTestSuites: 0,
@@ -55,6 +56,7 @@ export const buildFailureTestResult = (
   displayName: '',
   failureMessage: null,
   leaks: false,
+  numErroredTests: 1,
   numFailingTests: 0,
   numPassingTests: 0,
   numPendingTests: 0,
@@ -88,9 +90,11 @@ export const addResult = (
   aggregatedResults.testResults.push(testResult);
   aggregatedResults.numTotalTests +=
     testResult.numPassingTests +
+    testResult.numErroredTests +
     testResult.numFailingTests +
     testResult.numPendingTests +
     testResult.numTodoTests;
+  aggregatedResults.numErroredTests += testResult.numErroredTests;
   aggregatedResults.numFailedTests += testResult.numFailingTests;
   aggregatedResults.numPassedTests += testResult.numPassingTests;
   aggregatedResults.numPendingTests += testResult.numPendingTests;

--- a/packages/jest-jasmine2/src/reporter.js
+++ b/packages/jest-jasmine2/src/reporter.js
@@ -82,13 +82,16 @@ export default class Jasmine2Reporter {
   }
 
   jasmineDone(): void {
+    let numErroredTests = 0;
     let numFailingTests = 0;
     let numPassingTests = 0;
     let numPendingTests = 0;
     let numTodoTests = 0;
     const testResults = this._testResults;
     testResults.forEach(testResult => {
-      if (testResult.status === 'failed') {
+      if (testResult.status === 'error') {
+        numErroredTests++;
+      } else if (testResult.status === 'failed') {
         numFailingTests++;
       } else if (testResult.status === 'pending') {
         numPendingTests++;
@@ -107,6 +110,7 @@ export default class Jasmine2Reporter {
         this._globalConfig,
         this._testPath,
       ),
+      numErroredTests,
       numFailingTests,
       numPassingTests,
       numPendingTests,

--- a/types/Circus.js
+++ b/types/Circus.js
@@ -149,7 +149,7 @@ export type Event =
       name: 'teardown',
     |};
 
-export type TestStatus = 'skip' | 'done' | 'todo';
+export type TestStatus = 'skip' | 'done' | 'todo' | 'error';
 export type TestResult = {|
   duration: ?number,
   errors: Array<FormattedError>,

--- a/types/Matchers.js
+++ b/types/Matchers.js
@@ -66,6 +66,7 @@ export type Expect = {
   stringMatching(expected: string | RegExp): AsymmetricMatcher,
   [id: string]: AsymmetricMatcher,
   not: {[id: string]: AsymmetricMatcher},
+  JestAssertionError: Object,
 };
 
 export type ExpectationObject = {

--- a/types/TestResult.js
+++ b/types/TestResult.js
@@ -113,6 +113,7 @@ export type FormattedAssertionResult = {
 };
 
 export type AggregatedResultWithoutCoverage = {
+  numErroredTests: number,
   numFailedTests: number,
   numFailedTestSuites: number,
   numPassedTests: number,
@@ -148,6 +149,7 @@ export type TestResult = {|
   failureMessage: ?string,
   leaks: boolean,
   memoryUsage?: Bytes,
+  numErroredTests: number,
   numFailingTests: number,
   numPassingTests: number,
   numPendingTests: number,


### PR DESCRIPTION
## Summary

This change updates the reporters API so test status can be 'failure' or 'error'.
A failure classification would be for assertions and known errors. An error classification would be if a test failed to run or for uncaught/unexpected errors.

## Test plan

Existing tests pass. 
Looking for feedback on how to properly test this with automated tests. I think a reporter test will work if we can have a jest-circus only reporter test.