### PR TITLE
fix: require Node.js 6+ for all packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@
 - `[jest-diff]` Standardize filenames ([#7238](https://github.com/facebook/jest/pull/7238))
 - `[*]` Add babel plugin to make sure Jest is unaffected by fake Promise implementations ([#7225](https://github.com/facebook/jest/pull/7225))
 - `[jest-haste-map]` Standardize filenames ([#7266](https://github.com/facebook/jest/pull/7266))
+- `[*]` Require Node.js 6+ for all packages ([#7258](https://github.com/facebook/jest/pull/7258))
 
 ### Performance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,7 +83,7 @@
 - `[jest-diff]` Standardize filenames ([#7238](https://github.com/facebook/jest/pull/7238))
 - `[*]` Add babel plugin to make sure Jest is unaffected by fake Promise implementations ([#7225](https://github.com/facebook/jest/pull/7225))
 - `[jest-haste-map]` Standardize filenames ([#7266](https://github.com/facebook/jest/pull/7266))
-- `[*]` Require Node.js 6+ for all packages ([#7258](https://github.com/facebook/jest/pull/7258))
+- `[*]` [**BREAKING**] Require Node.js 6+ for all packages ([#7258](https://github.com/facebook/jest/pull/7258))
 
 ### Performance
 

--- a/package.json
+++ b/package.json
@@ -118,5 +118,8 @@
     "type": "opencollective",
     "url": "https://opencollective.com/jest",
     "logo": "https://opencollective.com/jest/logo.txt"
+  },
+  "engines": {
+    "node": ">= 6"
   }
 }

--- a/packages/babel-jest/package.json
+++ b/packages/babel-jest/package.json
@@ -17,5 +17,8 @@
   },
   "peerDependencies": {
     "babel-core": "^6.0.0 || ^7.0.0-0"
+  },
+  "engines": {
+    "node": ">= 6"
   }
 }

--- a/packages/babel-plugin-jest-hoist/package.json
+++ b/packages/babel-plugin-jest-hoist/package.json
@@ -5,6 +5,9 @@
     "type": "git",
     "url": "https://github.com/facebook/jest.git"
   },
+  "engines": {
+    "node": ">= 6"
+  },
   "license": "MIT",
   "main": "build/index.js"
 }

--- a/packages/babel-preset-jest/package.json
+++ b/packages/babel-preset-jest/package.json
@@ -10,5 +10,8 @@
   "dependencies": {
     "babel-plugin-jest-hoist": "^23.2.0",
     "babel-plugin-syntax-object-rest-spread": "^6.13.0"
+  },
+  "engines": {
+    "node": ">= 6"
   }
 }

--- a/packages/diff-sequences/package.json
+++ b/packages/diff-sequences/package.json
@@ -14,5 +14,8 @@
     "callback",
     "diff"
   ],
+  "engines": {
+    "node": ">= 6"
+  },
   "main": "build/index.js"
 }

--- a/packages/eslint-config-fb-strict/package.json
+++ b/packages/eslint-config-fb-strict/package.json
@@ -18,5 +18,8 @@
     "eslint-plugin-jsx-a11y": "^6.0.2",
     "eslint-plugin-react": "^7.1.0",
     "eslint-plugin-relay": "~0.0.8"
+  },
+  "engines": {
+    "node": ">= 6"
   }
 }

--- a/packages/expect/package.json
+++ b/packages/expect/package.json
@@ -15,5 +15,8 @@
     "jest-matcher-utils": "^23.6.0",
     "jest-message-util": "^23.4.0",
     "jest-regex-util": "^23.3.0"
+  },
+  "engines": {
+    "node": ">= 6"
   }
 }

--- a/packages/jest-changed-files/package.json
+++ b/packages/jest-changed-files/package.json
@@ -10,5 +10,8 @@
   "dependencies": {
     "execa": "^1.0.0",
     "throat": "^4.0.0"
+  },
+  "engines": {
+    "node": ">= 6"
   }
 }

--- a/packages/jest-circus/package.json
+++ b/packages/jest-circus/package.json
@@ -25,5 +25,8 @@
   "devDependencies": {
     "execa": "^1.0.0",
     "jest-runtime": "^23.6.0"
+  },
+  "engines": {
+    "node": ">= 6"
   }
 }

--- a/packages/jest-config/package.json
+++ b/packages/jest-config/package.json
@@ -22,5 +22,8 @@
     "jest-validate": "^23.6.0",
     "micromatch": "^2.3.11",
     "pretty-format": "^23.6.0"
+  },
+  "engines": {
+    "node": ">= 6"
   }
 }

--- a/packages/jest-diff/package.json
+++ b/packages/jest-diff/package.json
@@ -12,5 +12,8 @@
     "diff": "^3.2.0",
     "jest-get-type": "^22.1.0",
     "pretty-format": "^23.6.0"
+  },
+  "engines": {
+    "node": ">= 6"
   }
 }

--- a/packages/jest-docblock/package.json
+++ b/packages/jest-docblock/package.json
@@ -9,5 +9,8 @@
   "main": "build/index.js",
   "dependencies": {
     "detect-newline": "^2.1.0"
+  },
+  "engines": {
+    "node": ">= 6"
   }
 }

--- a/packages/jest-each/package.json
+++ b/packages/jest-each/package.json
@@ -19,5 +19,8 @@
     "chalk": "^2.0.1",
     "jest-util": "^23.4.0",
     "pretty-format": "^23.6.0"
+  },
+  "engines": {
+    "node": ">= 6"
   }
 }

--- a/packages/jest-environment-jsdom/package.json
+++ b/packages/jest-environment-jsdom/package.json
@@ -11,5 +11,8 @@
     "jest-mock": "^23.2.0",
     "jest-util": "^23.4.0",
     "jsdom": "^11.5.1"
+  },
+  "engines": {
+    "node": ">= 6"
   }
 }

--- a/packages/jest-environment-node/package.json
+++ b/packages/jest-environment-node/package.json
@@ -10,5 +10,8 @@
   "dependencies": {
     "jest-mock": "^23.2.0",
     "jest-util": "^23.4.0"
+  },
+  "engines": {
+    "node": ">= 6"
   }
 }

--- a/packages/jest-get-type/package.json
+++ b/packages/jest-get-type/package.json
@@ -6,6 +6,9 @@
     "type": "git",
     "url": "https://github.com/facebook/jest.git"
   },
+  "engines": {
+    "node": ">= 6"
+  },
   "license": "MIT",
   "main": "build/index.js"
 }

--- a/packages/jest-haste-map/package.json
+++ b/packages/jest-haste-map/package.json
@@ -16,5 +16,8 @@
     "jest-worker": "^23.2.0",
     "micromatch": "^2.3.11",
     "sane": "^3.0.0"
+  },
+  "engines": {
+    "node": ">= 6"
   }
 }

--- a/packages/jest-jasmine2/package.json
+++ b/packages/jest-jasmine2/package.json
@@ -23,5 +23,8 @@
   },
   "devDependencies": {
     "jest-runtime": "^23.6.0"
+  },
+  "engines": {
+    "node": ">= 6"
   }
 }

--- a/packages/jest-leak-detector/package.json
+++ b/packages/jest-leak-detector/package.json
@@ -12,5 +12,8 @@
   },
   "devDependencies": {
     "weak": "^1.0.1"
+  },
+  "engines": {
+    "node": ">= 6"
   }
 }

--- a/packages/jest-matcher-utils/package.json
+++ b/packages/jest-matcher-utils/package.json
@@ -6,6 +6,9 @@
     "type": "git",
     "url": "https://github.com/facebook/jest.git"
   },
+  "engines": {
+    "node": ">= 6"
+  },
   "license": "MIT",
   "main": "build/index.js",
   "dependencies": {

--- a/packages/jest-message-util/package.json
+++ b/packages/jest-message-util/package.json
@@ -5,6 +5,9 @@
     "type": "git",
     "url": "https://github.com/facebook/jest.git"
   },
+  "engines": {
+    "node": ">= 6"
+  },
   "license": "MIT",
   "main": "build/index.js",
   "dependencies": {

--- a/packages/jest-mock/package.json
+++ b/packages/jest-mock/package.json
@@ -5,6 +5,9 @@
     "type": "git",
     "url": "https://github.com/facebook/jest.git"
   },
+  "engines": {
+    "node": ">= 6"
+  },
   "license": "MIT",
   "main": "build/index.js",
   "browser": "build-es5/index.js"

--- a/packages/jest-phabricator/package.json
+++ b/packages/jest-phabricator/package.json
@@ -5,6 +5,9 @@
     "type": "git",
     "url": "https://github.com/facebook/jest.git"
   },
+  "engines": {
+    "node": ">= 6"
+  },
   "license": "MIT",
   "main": "build/index.js"
 }

--- a/packages/jest-regex-util/package.json
+++ b/packages/jest-regex-util/package.json
@@ -5,6 +5,9 @@
     "type": "git",
     "url": "https://github.com/facebook/jest.git"
   },
+  "engines": {
+    "node": ">= 6"
+  },
   "license": "MIT",
   "main": "build/index.js"
 }

--- a/packages/jest-repl/package.json
+++ b/packages/jest-repl/package.json
@@ -16,5 +16,8 @@
   },
   "bin": {
     "jest-repl": "./bin/jest-repl.js"
+  },
+  "engines": {
+    "node": ">= 6"
   }
 }

--- a/packages/jest-resolve-dependencies/package.json
+++ b/packages/jest-resolve-dependencies/package.json
@@ -10,5 +10,8 @@
   "dependencies": {
     "jest-regex-util": "^23.3.0",
     "jest-snapshot": "^23.6.0"
+  },
+  "engines": {
+    "node": ">= 6"
   }
 }

--- a/packages/jest-resolve/package.json
+++ b/packages/jest-resolve/package.json
@@ -14,5 +14,8 @@
   },
   "devDependencies": {
     "jest-haste-map": "^23.6.0"
+  },
+  "engines": {
+    "node": ">= 6"
   }
 }

--- a/packages/jest-runner/package.json
+++ b/packages/jest-runner/package.json
@@ -21,5 +21,8 @@
     "jest-worker": "^23.2.0",
     "source-map-support": "^0.5.6",
     "throat": "^4.0.0"
+  },
+  "engines": {
+    "node": ">= 6"
   }
 }

--- a/packages/jest-runtime/package.json
+++ b/packages/jest-runtime/package.json
@@ -37,5 +37,8 @@
   },
   "bin": {
     "jest-runtime": "./bin/jest-runtime.js"
+  },
+  "engines": {
+    "node": ">= 6"
   }
 }

--- a/packages/jest-serializer/package.json
+++ b/packages/jest-serializer/package.json
@@ -5,6 +5,9 @@
     "type": "git",
     "url": "https://github.com/facebook/jest.git"
   },
+  "engines": {
+    "node": ">= 6"
+  },
   "license": "MIT",
   "main": "build/index.js"
 }

--- a/packages/jest-snapshot/package.json
+++ b/packages/jest-snapshot/package.json
@@ -21,5 +21,8 @@
   },
   "devDependencies": {
     "prettier": "^1.13.4"
+  },
+  "engines": {
+    "node": ">= 6"
   }
 }

--- a/packages/jest-util/package.json
+++ b/packages/jest-util/package.json
@@ -19,5 +19,8 @@
   },
   "devDependencies": {
     "jest-mock": "^23.2.0"
+  },
+  "engines": {
+    "node": ">= 6"
   }
 }

--- a/packages/jest-validate/package.json
+++ b/packages/jest-validate/package.json
@@ -12,5 +12,8 @@
     "jest-get-type": "^22.1.0",
     "leven": "^2.1.0",
     "pretty-format": "^23.6.0"
+  },
+  "engines": {
+    "node": ">= 6"
   }
 }

--- a/packages/jest-watcher/package.json
+++ b/packages/jest-watcher/package.json
@@ -15,6 +15,9 @@
   "bugs": {
     "url": "https://github.com/facebook/jest/issues"
   },
+  "engines": {
+    "node": ">= 6"
+  },
   "homepage": "https://jestjs.io/",
   "license": "MIT"
 }

--- a/packages/jest-worker/package.json
+++ b/packages/jest-worker/package.json
@@ -9,5 +9,8 @@
   "main": "build/index.js",
   "dependencies": {
     "merge-stream": "^1.0.1"
+  },
+  "engines": {
+    "node": ">= 6"
   }
 }

--- a/packages/pretty-format/package.json
+++ b/packages/pretty-format/package.json
@@ -19,5 +19,8 @@
     "react": "*",
     "react-dom": "*",
     "react-test-renderer": "*"
+  },
+  "engines": {
+    "node": ">= 6"
   }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Changes in Jest packages require at least Node.js 6.5+ so there is also no compatibility with older releases of Node.js 6.

Motivation: Node.js 4 support was officially dropped in Jest 22 and we test only 6, 8 and 10 so it makes sense to enforce `node >= 6` on all packages to prevent breaking builds due to incompatible Node.js versions as this is a hard breaking change.

See https://jestjs.io/blog/2017/12/18/jest-22

See https://github.com/facebook/jest/issues/7253

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
