### PR TITLE
Revert sync timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,8 +40,6 @@
 - `[jest-jasmine2`] Fix crash when test return Promise rejected with null ([#7049](https://github.com/facebook/jest/pull/7049))
 - `[jest-runtime]` Check `_isMockFunction` is true rather than truthy on potential global mocks ([#7017](https://github.com/facebook/jest/pull/7017))
 - `[jest-jasmine]` Show proper error message from async `assert` errors ([#6821](https://github.com/facebook/jest/pull/6821))
-- `[jest-circus]` Fail synchronous hook timeouts ([#7074](https://github.com/facebook/jest/pull/7074))
-- `[jest-jasmine2]` Fail synchronous test timeouts ([#7074](https://github.com/facebook/jest/pull/7074))
 - `[jest-jasmine2]` Better error message when a describe block is empty ([#6372](https://github.com/facebook/jest/pull/6372))
 - `[jest-jasmine2]` Pending calls inside async tests are reported as pending not failed ([#6782](https://github.com/facebook/jest/pull/6782))
 - `[jest-circus]` Better error message when a describe block is empty ([#6372](https://github.com/facebook/jest/pull/6372))

--- a/e2e/__tests__/__snapshots__/timeouts.test.js.snap
+++ b/e2e/__tests__/__snapshots__/timeouts.test.js.snap
@@ -1,38 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`before hook does not exceed the timeout 1`] = `
-"PASS __tests__/a-banana.js
-  ✓ banana
-
-"
-`;
-
-exports[`before hook does not exceed the timeout 2`] = `
-"Test Suites: 1 passed, 1 total
-Tests:       1 passed, 1 total
-Snapshots:   0 total
-Time:        <<REPLACED>>
-Ran all test suites."
-`;
-
-exports[`before hook exceeds the timeout 1`] = `
-"Test Suites: 1 failed, 1 total
-Tests:       1 failed, 1 total
-Snapshots:   0 total
-Time:        <<REPLACED>>
-Ran all test suites.
-"
-`;
-
-exports[`before hook exceeds the timeout synchronously 1`] = `
-"Test Suites: 1 failed, 1 total
-Tests:       1 failed, 1 total
-Snapshots:   0 total
-Time:        <<REPLACED>>
-Ran all test suites.
-"
-`;
-
 exports[`does not exceed the timeout 1`] = `
 "PASS __tests__/a-banana.js
   ✓ banana
@@ -49,15 +16,6 @@ Ran all test suites."
 `;
 
 exports[`exceeds the timeout 1`] = `
-"Test Suites: 1 failed, 1 total
-Tests:       1 failed, 1 total
-Snapshots:   0 total
-Time:        <<REPLACED>>
-Ran all test suites.
-"
-`;
-
-exports[`exceeds the timeout synchronously 1`] = `
 "Test Suites: 1 failed, 1 total
 Tests:       1 failed, 1 total
 Snapshots:   0 total

--- a/e2e/__tests__/timeouts.test.js
+++ b/e2e/__tests__/timeouts.test.js
@@ -40,29 +40,6 @@ test('exceeds the timeout', () => {
   expect(status).toBe(1);
 });
 
-test('exceeds the timeout synchronously', () => {
-  writeFiles(DIR, {
-    '__tests__/a-banana.js': `
-      jest.setTimeout(20);
-
-      test('banana', () => {
-        const startTime = Date.now();
-        while (Date.now() - startTime < 100) {
-        }
-      });
-    `,
-    'package.json': '{}',
-  });
-
-  const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false']);
-  const {rest, summary} = extractSummary(stderr);
-  expect(rest).toMatch(
-    /(jest\.setTimeout|jasmine\.DEFAULT_TIMEOUT_INTERVAL|Exceeded timeout)/,
-  );
-  expect(summary).toMatchSnapshot();
-  expect(status).toBe(1);
-});
-
 test('does not exceed the timeout', () => {
   writeFiles(DIR, {
     '__tests__/a-banana.js': `
@@ -73,78 +50,6 @@ test('does not exceed the timeout', () => {
           setTimeout(resolve, 20);
         });
       });
-    `,
-    'package.json': '{}',
-  });
-
-  const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false']);
-  const {rest, summary} = extractSummary(stderr);
-  expect(rest).toMatchSnapshot();
-  expect(summary).toMatchSnapshot();
-  expect(status).toBe(0);
-});
-
-test('before hook exceeds the timeout', () => {
-  writeFiles(DIR, {
-    '__tests__/a-banana.js': `
-      jest.setTimeout(20);
-
-      beforeEach(() => {
-        return new Promise(resolve => {
-          setTimeout(resolve, 100);
-        });
-      })
-
-      test('banana', () => {});
-    `,
-    'package.json': '{}',
-  });
-
-  const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false']);
-  const {rest, summary} = extractSummary(stderr);
-  expect(rest).toMatch(
-    /(jest\.setTimeout|jasmine\.DEFAULT_TIMEOUT_INTERVAL|Exceeded timeout)/,
-  );
-  expect(summary).toMatchSnapshot();
-  expect(status).toBe(1);
-});
-
-test('before hook exceeds the timeout synchronously', () => {
-  writeFiles(DIR, {
-    '__tests__/a-banana.js': `
-      jest.setTimeout(20);
-
-      beforeEach(() => {
-        const startTime = Date.now();
-        while (Date.now() - startTime < 100) {}
-      })
-
-      test('banana', () => {});
-    `,
-    'package.json': '{}',
-  });
-
-  const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false']);
-  const {rest, summary} = extractSummary(stderr);
-  expect(rest).toMatch(
-    /(jest\.setTimeout|jasmine\.DEFAULT_TIMEOUT_INTERVAL|Exceeded timeout)/,
-  );
-  expect(summary).toMatchSnapshot();
-  expect(status).toBe(1);
-});
-
-test('before hook does not exceed the timeout', () => {
-  writeFiles(DIR, {
-    '__tests__/a-banana.js': `
-      jest.setTimeout(100);
-
-      beforeEach(() => {
-        return new Promise(resolve => {
-          setTimeout(resolve, 20);
-        });
-      })
-
-      test('banana', () => {});
     `,
     'package.json': '{}',
   });

--- a/packages/jest-circus/src/event_handler.js
+++ b/packages/jest-circus/src/event_handler.js
@@ -16,7 +16,6 @@ import {
   invariant,
   makeTest,
   describeBlockHasTests,
-  getTimestamp,
 } from './utils';
 import {
   injectGlobalErrorHandlers,
@@ -118,7 +117,7 @@ const handler: EventHandler = (event, state): void => {
     }
     case 'test_start': {
       state.currentlyRunningTest = event.test;
-      event.test.startedAt = getTimestamp();
+      event.test.startedAt = Date.now();
       event.test.invocations += 1;
       break;
     }

--- a/packages/jest-circus/src/utils.js
+++ b/packages/jest-circus/src/utils.js
@@ -155,7 +155,7 @@ export const getEachHooksForTest = (
 export const describeBlockHasTests = (describe: DescribeBlock) =>
   describe.tests.length || describe.children.some(describeBlockHasTests);
 
-const _makeTimeoutMessage = (timeout: number, isHook: ?boolean) =>
+const _makeTimeoutMessage = (timeout, isHook) =>
   `Exceeded timeout of ${timeout}ms for a ${
     isHook ? 'hook' : 'test'
   }.\nUse jest.setTimeout(newTimeout) to increase the timeout value, if this is a long-running test.`;
@@ -167,10 +167,9 @@ const {setTimeout, clearTimeout} = global;
 export const callAsyncCircusFn = (
   fn: AsyncFn,
   testContext: ?TestContext,
-  {isHook, timeout}: {isHook: ?boolean, timeout: number},
+  {isHook, timeout}: {isHook?: ?boolean, timeout: number},
 ): Promise<mixed> => {
   let timeoutID;
-  const startedAt = getTimestamp();
 
   return new Promise((resolve, reject) => {
     timeoutID = setTimeout(
@@ -237,9 +236,6 @@ export const callAsyncCircusFn = (
       // it's resolved.
       timeoutID.unref && timeoutID.unref();
       clearTimeout(timeoutID);
-      if (getTimestamp() - startedAt > timeout) {
-        throw new Error(_makeTimeoutMessage(timeout, isHook));
-      }
     })
     .catch(error => {
       timeoutID.unref && timeoutID.unref();
@@ -248,11 +244,9 @@ export const callAsyncCircusFn = (
     });
 };
 
-export const getTimestamp = Date.now.bind(Date);
-
 export const getTestDuration = (test: TestEntry): ?number => {
   const {startedAt} = test;
-  return startedAt ? getTimestamp() - startedAt : null;
+  return startedAt ? Date.now() - startedAt : null;
 };
 
 export const makeRunResult = (

--- a/packages/jest-jasmine2/src/__tests__/p_timeout.test.js
+++ b/packages/jest-jasmine2/src/__tests__/p_timeout.test.js
@@ -16,14 +16,7 @@ describe('pTimeout', () => {
   it('calls `clearTimeout` and resolves when `promise` resolves.', async () => {
     const onTimeout = jest.fn();
     const promise = Promise.resolve();
-    await pTimeout(
-      promise,
-      Date.now(),
-      1000,
-      clearTimeout,
-      setTimeout,
-      onTimeout,
-    );
+    await pTimeout(promise, 1000, clearTimeout, setTimeout, onTimeout);
     expect(setTimeout).toHaveBeenCalled();
     expect(clearTimeout).toHaveBeenCalled();
     expect(onTimeout).not.toHaveBeenCalled();
@@ -33,14 +26,7 @@ describe('pTimeout', () => {
     const onTimeout = jest.fn();
     const promise = Promise.reject();
     try {
-      await pTimeout(
-        promise,
-        Date.now(),
-        1000,
-        clearTimeout,
-        setTimeout,
-        onTimeout,
-      );
+      await pTimeout(promise, 1000, clearTimeout, setTimeout, onTimeout);
     } catch (e) {}
     expect(setTimeout).toHaveBeenCalled();
     expect(clearTimeout).toHaveBeenCalled();
@@ -53,7 +39,6 @@ describe('pTimeout', () => {
     const promise = new Promise(() => {});
     const timeoutPromise = pTimeout(
       promise,
-      Date.now(),
       1000,
       clearTimeout,
       setTimeout,

--- a/packages/jest-jasmine2/src/p_timeout.js
+++ b/packages/jest-jasmine2/src/p_timeout.js
@@ -10,13 +10,11 @@
 // Try getting the real promise object from the context, if available. Someone
 // could have overridden it in a test.
 const Promise = global[Symbol.for('jest-native-promise')] || global.Promise;
-const timestamp = Date.now.bind(Date);
 
 // A specialized version of `p-timeout` that does not touch globals.
 // It does not throw on timeout.
 export default function pTimeout(
   promise: Promise<any>,
-  startTime: number,
   ms: number,
   clearTimeout: (timeoutID: number) => void,
   setTimeout: (func: () => void, delay: number) => number,
@@ -27,13 +25,7 @@ export default function pTimeout(
     promise.then(
       val => {
         clearTimeout(timer);
-
-        // when running single threaded, we need to double check the timeout
-        if (timestamp() - startTime > ms) {
-          resolve(onTimeout());
-        } else {
-          resolve(val);
-        }
+        resolve(val);
       },
       err => {
         clearTimeout(timer);

--- a/packages/jest-jasmine2/src/queue_runner.js
+++ b/packages/jest-jasmine2/src/queue_runner.js
@@ -11,7 +11,6 @@
 // could have overridden it in a test.
 const Promise: Class<Promise> =
   global[Symbol.for('jest-native-promise')] || global.Promise;
-const timestamp = Date.now.bind(Date);
 
 import PCancelable from './p_cancelable';
 import pTimeout from './p_timeout';
@@ -36,8 +35,6 @@ export default function queueRunner(options: Options) {
   });
 
   const mapper = ({fn, timeout, initError = new Error()}) => {
-    // Flow wants us to initialize this even though it's safe
-    let startTime: number = timestamp();
     let promise = new Promise(resolve => {
       const next = function(err) {
         if (err) {
@@ -51,7 +48,6 @@ export default function queueRunner(options: Options) {
         resolve();
       };
       try {
-        startTime = timestamp();
         fn.call(options.userContext, next);
       } catch (e) {
         options.onException(e);
@@ -69,7 +65,6 @@ export default function queueRunner(options: Options) {
 
     return pTimeout(
       promise,
-      startTime,
       timeoutMs,
       options.clearTimeout,
       options.setTimeout,


### PR DESCRIPTION
## Summary

#7074 made sync tests fail if they finished after the defined timeout. That's a breaking change whose benefits don't compensate the upgrade cost and there's a valid workaround to implement it in userland. See the comments in #6947.

## Test plan

Unit and e2e tests.