### PR TITLE
Remove unused jest-docblock package from jest-haste-map

### DIFF
--- a/packages/jest-haste-map/package.json
+++ b/packages/jest-haste-map/package.json
@@ -11,7 +11,6 @@
     "fb-watchman": "^2.0.0",
     "graceful-fs": "^4.1.11",
     "invariant": "^2.2.4",
-    "jest-docblock": "^23.2.0",
     "jest-serializer": "^23.0.1",
     "jest-worker": "^23.2.0",
     "micromatch": "^2.3.11",


### PR DESCRIPTION
## Summary

It was used to extract the `@providesModule` tag and removed when we removed the support for it (see [#6104](https://github.com/facebook/jest/pull/6104/files#diff-3ad317b721aba9e2f1a06b591939637cL14)).

## Test plan

`grep 'jest-docblock' -r packages/jest-haste-map/src` and current tests.