### PR TITLE
Update MongoDB.md

### DIFF
--- a/docs/MongoDB.md
+++ b/docs/MongoDB.md
@@ -26,7 +26,7 @@ const {MongoMemoryServer} = require('mongodb-memory-server');
 
 const globalConfigPath = path.join(__dirname, 'globalConfig.json');
 
-const mongoServer = new MongoMemoryServer({
+const mongod = new MongoMemoryServer({
   autoStart: false,
 });
 
@@ -37,14 +37,14 @@ module.exports = async () => {
 
   const mongoConfig = {
     mongoDBName: 'jest',
-    mongoUri: await mongoServer.getConnectionString(),
+    mongoUri: await mongod.getConnectionString(),
   };
 
   // Write global config to disk because all tests run in different contexts.
   fs.writeFileSync(globalConfigPath, JSON.stringify(mongoConfig));
 
   // Set reference to mongod in order to close the server during teardown.
-  global.__MONGOD__ = mongoServer;
+  global.__MONGOD__ = mongod;
 };
 ```
 

--- a/website/versioned_docs/version-22.3/MongoDB.md
+++ b/website/versioned_docs/version-22.3/MongoDB.md
@@ -27,7 +27,7 @@ const {MongoMemoryServer} = require('mongodb-memory-server');
 
 const globalConfigPath = path.join(__dirname, 'globalConfig.json');
 
-const mongoServer = new MongoMemoryServer({
+const mongod = new MongoMemoryServer({
   autoStart: false,
 });
 
@@ -38,14 +38,14 @@ module.exports = async () => {
 
   const mongoConfig = {
     mongoDBName: 'jest',
-    mongoUri: await mongoServer.getConnectionString(),
+    mongoUri: await mongod.getConnectionString(),
   };
 
   // Write global config to disk because all tests run in different contexts.
   fs.writeFileSync(globalConfigPath, JSON.stringify(mongoConfig));
 
   // Set reference to mongod in order to close the server during teardown.
-  global.__MONGOD__ = mongoServer;
+  global.__MONGOD__ = mongod;
 };
 ```
 

--- a/website/versioned_docs/version-23.0/MongoDB.md
+++ b/website/versioned_docs/version-23.0/MongoDB.md
@@ -27,7 +27,7 @@ const {MongoMemoryServer} = require('mongodb-memory-server');
 
 const globalConfigPath = path.join(__dirname, 'globalConfig.json');
 
-const mongoServer = new MongoMemoryServer({
+const mongod = new MongoMemoryServer({
   autoStart: false,
 });
 
@@ -38,14 +38,14 @@ module.exports = async () => {
 
   const mongoConfig = {
     mongoDBName: 'jest',
-    mongoUri: await mongoServer.getConnectionString(),
+    mongoUri: await mongod.getConnectionString(),
   };
 
   // Write global config to disk because all tests run in different contexts.
   fs.writeFileSync(globalConfigPath, JSON.stringify(mongoConfig));
 
   // Set reference to mongod in order to close the server during teardown.
-  global.__MONGOD__ = mongoServer;
+  global.__MONGOD__ = mongod;
 };
 ```
 

--- a/website/versioned_docs/version-23.2/MongoDB.md
+++ b/website/versioned_docs/version-23.2/MongoDB.md
@@ -27,7 +27,7 @@ const {MongoMemoryServer} = require('mongodb-memory-server');
 
 const globalConfigPath = path.join(__dirname, 'globalConfig.json');
 
-const mongoServer = new MongoMemoryServer({
+const mongod = new MongoMemoryServer({
   autoStart: false,
 });
 
@@ -38,14 +38,14 @@ module.exports = async () => {
 
   const mongoConfig = {
     mongoDBName: 'jest',
-    mongoUri: await mongoServer.getConnectionString(),
+    mongoUri: await mongod.getConnectionString(),
   };
 
   // Write global config to disk because all tests run in different contexts.
   fs.writeFileSync(globalConfigPath, JSON.stringify(mongoConfig));
 
   // Set reference to mongod in order to close the server during teardown.
-  global.__MONGOD__ = mongoServer;
+  global.__MONGOD__ = mongod;
 };
 ```
 


### PR DESCRIPTION
fix incorrect variable name for MongoMemoryServer object(both `mongoServer` and `mongod` were used) in the document.

Should I update CHANGELOG for fixing document? plz tell me if necessary.

## Summary

It seems two different variable names(`mongod` and `mongoServer`) are used for MongoMemoryServer, and since then check below(line33-36) won't work.

```js
if (!mongod.isRunning) {
  await mongod.start();
}
```

I chose to use `mongod` to adjust example(https://github.com/vladgolubev/jest-mongodb/blob/master/setup.js), even though mongoServer seems clearer.

Closes #7320

## Test plan

no test due to fixing document.