### PR TITLE
fix: unable to resolve path to mapped file with custom platform

### DIFF
--- a/e2e/resolve/__tests__/resolve.test.js
+++ b/e2e/resolve/__tests__/resolve.test.js
@@ -47,6 +47,11 @@ test('should resolve filename.native.js', () => {
   expect(platform.extension).toBe('native.js');
 });
 
+test('should resolve filename.native.js with moduleNameMapper', () => {
+  expect(testRequire('test2')).not.toThrow();
+  expect(platform.extension).toBe('native.js');
+});
+
 test('should resolve filename.js', () => {
   expect(testRequire('../test3')).not.toThrow();
   expect(platform.extension).toBe('js');

--- a/e2e/resolve/package.json
+++ b/e2e/resolve/package.json
@@ -2,9 +2,14 @@
   "name": "custom-resolve",
   "jest": {
     "haste": {
-      "platforms": ["native"],
+      "platforms": [
+        "native"
+      ],
       "defaultPlatform": "android"
     },
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "moduleNameMapper": {
+      "test2": "<rootDir>/test2mapper"
+    }
   }
 }

--- a/e2e/resolve/test2mapper.native.js
+++ b/e2e/resolve/test2mapper.native.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+module.exports = {extension: 'native.js'};

--- a/packages/jest-resolve/src/__tests__/resolve.test.js
+++ b/packages/jest-resolve/src/__tests__/resolve.test.js
@@ -161,6 +161,7 @@ describe('getMockModule', () => {
 
     const moduleMap = ModuleMap.create('/');
     const resolver = new Resolver(moduleMap, {
+      extensions: ['.js'],
       moduleNameMapper: [
         {
           moduleName: '$1',

--- a/packages/jest-resolve/src/index.js
+++ b/packages/jest-resolve/src/index.js
@@ -341,10 +341,23 @@ class Resolver {
   _resolveStubModuleName(from: Path, moduleName: string): ?Path {
     const dirname = path.dirname(from);
     const paths = this._options.modulePaths;
-    const extensions = this._options.extensions;
+    const extensions = this._options.extensions.slice();
     const moduleDirectory = this._options.moduleDirectories;
     const moduleNameMapper = this._options.moduleNameMapper;
     const resolver = this._options.resolver;
+    const defaultPlatform = this._options.defaultPlatform;
+
+    if (this._supportsNativePlatform) {
+      extensions.unshift(
+        ...this._options.extensions.map(ext => '.' + NATIVE_PLATFORM + ext),
+      );
+    }
+
+    if (defaultPlatform) {
+      extensions.unshift(
+        ...this._options.extensions.map(ext => '.' + defaultPlatform + ext),
+      );
+    }
 
     if (moduleNameMapper) {
       for (const {moduleName: mappedModuleName, regex} of moduleNameMapper) {


### PR DESCRIPTION
## Summary

Fixes a bug where Jest was unable to resolve a path to a file mapped with `moduleNameMapper` _and_ having custom platforms set.

This is done by applying logic from `resolveModuleFromDirIfExists` to `_resolveStubModuleName`:

https://github.com/facebook/jest/blob/bb9efac6c0e5fa3e487d80a639658c29044e081c/packages/jest-resolve/src/index.js#L115-L134

## Test plan

Added a test that fails before applying to this fix.
