### PR TITLE
Make getFileIterator() return relative paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - `[expect]` Check constructor equality in .toStrictEqual() ([#7005](https://github.com/facebook/jest/pull/7005))
 - `[jest-util]` Add `jest.getTimerCount()` to get the count of scheduled fake timers ([#7285](https://github.com/facebook/jest/pull/7285))
 - `[jest-config]` Add `dependencyExtractor` option to use a custom module to extract dependencies from files ([#7313](https://github.com/facebook/jest/pull/7313))
+- `[jest-haste-map]` [**BREAKING**] Expose relative paths when getting the file iterator ([#7321](https://github.com/facebook/jest/pull/7321))
 
 ### Fixes
 

--- a/packages/jest-haste-map/src/HasteFS.js
+++ b/packages/jest-haste-map/src/HasteFS.js
@@ -43,10 +43,14 @@ export default class HasteFS {
   }
 
   getAllFiles(): Array<string> {
-    return Array.from(this.getFileIterator());
+    return Array.from(this.getAbsoluteFileIterator());
   }
 
-  *getFileIterator(): Iterator<string> {
+  getFileIterator(): Iterator<string> {
+    return this._files.keys();
+  }
+
+  *getAbsoluteFileIterator(): Iterator<string> {
     for (const file of this._files.keys()) {
       yield fastPath.resolve(this._rootDir, file);
     }
@@ -57,7 +61,7 @@ export default class HasteFS {
       pattern = new RegExp(pattern);
     }
     const files = [];
-    for (const file of this.getFileIterator()) {
+    for (const file of this.getAbsoluteFileIterator()) {
       if (pattern.test(file)) {
         files.push(file);
       }
@@ -67,7 +71,7 @@ export default class HasteFS {
 
   matchFilesWithGlob(globs: Array<Glob>, root: ?Path): Set<Path> {
     const files = new Set();
-    for (const file of this.getFileIterator()) {
+    for (const file of this.getAbsoluteFileIterator()) {
       const filePath = root ? fastPath.relative(root, file) : file;
       if (micromatch([filePath], globs).length) {
         files.add(file);

--- a/packages/jest-resolve-dependencies/src/index.js
+++ b/packages/jest-resolve-dependencies/src/index.js
@@ -97,7 +97,7 @@ class DependencyResolver {
       }
     }
     const modules = [];
-    for (const file of this._hasteFS.getFileIterator()) {
+    for (const file of this._hasteFS.getAbsoluteFileIterator()) {
       modules.push({
         dependencies: this.resolve(file, options),
         file,


### PR DESCRIPTION
## Summary

Currently, `hasteFS.getFileIterator()` converts all file paths to absolute, which can be expensive when `jest-haste-map` tracks a lot of files.

This PR changes the behaviour and makes `getFileIterator()` return relative paths (the same way that `hasteFS` now accepts relative paths, and creates a new method (`getAbsoluteFileIterator()`) which returns the absolute paths.

## Test plan

Unit tests