### PR TITLE
fix: get relative path in haste map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@
 - `[expect]` Improves the failing message for `toStrictEqual` matcher. ([#7224](https://github.com/facebook/jest/pull/7224))
 - `[jest-mock]` [**BREAKING**] Fix bugs with mock/spy result tracking of recursive functions ([#6381](https://github.com/facebook/jest/pull/6381))
 - `[jest-resolve]` Fix not being able to resolve path to mapped file with custom platform ([#7312](https://github.com/facebook/jest/pull/7312))
+- `[jest-haste-map]` Fix to resolve path that is start with words same as rootDir ([#7324](https://github.com/facebook/jest/pull/7324))
 
 ### Chore & Maintenance
 

--- a/packages/jest-haste-map/src/lib/__tests__/fast_path.test.js
+++ b/packages/jest-haste-map/src/lib/__tests__/fast_path.test.js
@@ -26,6 +26,13 @@ describe('fastPath.relative', () => {
     const relativeFilename = path.join('..', 'baz', 'foobar');
     expect(relative(root, filename)).toBe(relativeFilename);
   });
+
+  it('should get relative paths outside the root when start with same word', () => {
+    const root = path.join(__dirname, 'foo', 'bar');
+    const filename = path.join(__dirname, 'foo', 'barbaz', 'foobar');
+    const relativeFilename = path.join('..', 'barbaz', 'foobar');
+    expect(relative(root, filename)).toBe(relativeFilename);
+  });
 });
 
 describe('fastPath.resolve', () => {

--- a/packages/jest-haste-map/src/lib/fast_path.js
+++ b/packages/jest-haste-map/src/lib/fast_path.js
@@ -11,7 +11,7 @@ import path from 'path';
 
 // rootDir and filename must be absolute paths (resolved)
 export function relative(rootDir: string, filename: string): string {
-  return filename.indexOf(rootDir) === 0
+  return filename.indexOf(rootDir + path.sep) === 0
     ? filename.substr(rootDir.length + 1)
     : path.relative(rootDir, filename);
 }


### PR DESCRIPTION
## Summary
close #7323

ex)
`dirname: foo/bar`
`filename: foo/barbaz/index.js`

And relative() return `az/index.js`.

Expected return `../barbaz/index.js`

## Test plan
Added a test with fix commit.

