### PR TITLE
Fix recovery of haste collisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@
 - `[jest-runtime]` Ensure error message text is not lost on errors with code frames ([#7319](https://github.com/facebook/jest/pull/7319))
 - `[jest-haste-map]` Fix to resolve path that is start with words same as rootDir ([#7324](https://github.com/facebook/jest/pull/7324))
 - `[expect]` Fix toMatchObject matcher when used with `Object.create(null)` ([#7334](https://github.com/facebook/jest/pull/7334))
+- `[jest-haste-map]` [**BREAKING**] Recover files correctly after haste name collisions are fixed ([#7329](https://github.com/facebook/jest/pull/7329))
 
 ### Chore & Maintenance
 

--- a/packages/jest-haste-map/src/ModuleMap.js
+++ b/packages/jest-haste-map/src/ModuleMap.js
@@ -21,7 +21,8 @@ import type {
 import * as fastPath from './lib/fast_path';
 import H from './constants';
 
-const EMPTY_MAP = {};
+const EMPTY_OBJ = {};
+const EMPTY_MAP = new Map();
 
 export opaque type SerializableModuleMap = {
   // There is no easier way to extract the type of the entries of a Map
@@ -117,14 +118,14 @@ export default class ModuleMap {
     platform: ?string,
     supportsNativePlatform: boolean,
   ): ?ModuleMetaData {
-    const map = this._raw.map.get(name) || EMPTY_MAP;
+    const map = this._raw.map.get(name) || EMPTY_OBJ;
     const dupMap = this._raw.duplicates.get(name) || EMPTY_MAP;
     if (platform != null) {
       this._assertNoDuplicates(
         name,
         platform,
         supportsNativePlatform,
-        dupMap[platform],
+        dupMap.get(platform),
       );
       if (map[platform] != null) {
         return map[platform];
@@ -135,7 +136,7 @@ export default class ModuleMap {
         name,
         H.NATIVE_PLATFORM,
         supportsNativePlatform,
-        dupMap[H.NATIVE_PLATFORM],
+        dupMap.get(H.NATIVE_PLATFORM),
       );
       if (map[H.NATIVE_PLATFORM]) {
         return map[H.NATIVE_PLATFORM];
@@ -145,7 +146,7 @@ export default class ModuleMap {
       name,
       H.GENERIC_PLATFORM,
       supportsNativePlatform,
-      dupMap[H.GENERIC_PLATFORM],
+      dupMap.get(H.GENERIC_PLATFORM),
     );
     if (map[H.GENERIC_PLATFORM]) {
       return map[H.GENERIC_PLATFORM];
@@ -163,17 +164,19 @@ export default class ModuleMap {
       return;
     }
     // Force flow refinement
-    const previousSet: DuplicatesSet = relativePathSet;
-    const set = Object.keys(previousSet).reduce((set, relativePath) => {
+    const previousSet = relativePathSet;
+    const duplicates = new Map();
+
+    for (const [relativePath, type] of previousSet) {
       const duplicatePath = fastPath.resolve(this._raw.rootDir, relativePath);
-      set[duplicatePath] = previousSet[relativePath];
-      return set;
-    }, Object.create(null));
+      duplicates.set(duplicatePath, type);
+    }
+
     throw new DuplicateHasteCandidatesError(
       name,
       platform,
       supportsNativePlatform,
-      set,
+      duplicates,
     );
   }
 
@@ -206,12 +209,12 @@ class DuplicateHasteCandidatesError extends Error {
         `files, or packages, that provide a module for ` +
         `that particular name and platform. ${platformMessage} You must ` +
         `delete or blacklist files until there remains only one of these:\n\n` +
-        Object.keys(duplicatesSet)
+        Array.from(duplicatesSet)
+          .map(
+            ([dupFilePath, dupFileType]) =>
+              `  * \`${dupFilePath}\` (${getTypeMessage(dupFileType)})\n`,
+          )
           .sort()
-          .map(dupFilePath => {
-            const typeMessage = getTypeMessage(duplicatesSet[dupFilePath]);
-            return `  * \`${dupFilePath}\` (${typeMessage})\n`;
-          })
           .join(''),
     );
     this.hasteName = name;

--- a/packages/jest-haste-map/src/__tests__/index.test.js
+++ b/packages/jest-haste-map/src/__tests__/index.test.js
@@ -783,12 +783,12 @@ describe('HasteMap', () => {
       ).build();
       expect(normalizeMap(data.duplicates)).toEqual(
         createMap({
-          Strawberry: {
-            g: {
+          Strawberry: createMap({
+            g: createMap({
               'fruits/Strawberry.js': H.MODULE,
               'fruits/another/Strawberry.js': H.MODULE,
-            },
-          },
+            }),
+          }),
         }),
       );
       expect(data.map.get('Strawberry')).toEqual({});
@@ -828,13 +828,13 @@ describe('HasteMap', () => {
 
       expect(normalizeMap(data.duplicates)).toEqual(
         createMap({
-          Strawberry: {
-            g: {
+          Strawberry: createMap({
+            g: createMap({
               'fruits/Strawberry.js': H.MODULE,
               'fruits/another/Strawberry.js': H.MODULE,
               'fruits/strawberryPackage/package.json': H.PACKAGE,
-            },
-          },
+            }),
+          }),
         }),
       );
 
@@ -1292,10 +1292,12 @@ describe('HasteMap', () => {
           expect(error.hasteName).toBe('Pear');
           expect(error.platform).toBe('g');
           expect(error.supportsNativePlatform).toBe(false);
-          expect(error.duplicatesSet).toEqual({
-            '/project/fruits/Pear.js': H.MODULE,
-            '/project/fruits/another/Pear.js': H.MODULE,
-          });
+          expect(error.duplicatesSet).toEqual(
+            createMap({
+              '/project/fruits/Pear.js': H.MODULE,
+              '/project/fruits/another/Pear.js': H.MODULE,
+            }),
+          );
           expect(error.message).toMatchSnapshot();
         }
       }

--- a/packages/jest-haste-map/src/__tests__/index.test.js
+++ b/packages/jest-haste-map/src/__tests__/index.test.js
@@ -784,7 +784,10 @@ describe('HasteMap', () => {
       expect(normalizeMap(data.duplicates)).toEqual(
         createMap({
           Strawberry: {
-            g: {'fruits/Strawberry.js': 0, 'fruits/another/Strawberry.js': 0},
+            g: {
+              'fruits/Strawberry.js': H.MODULE,
+              'fruits/another/Strawberry.js': H.MODULE,
+            },
           },
         }),
       );
@@ -806,10 +809,54 @@ describe('HasteMap', () => {
       ).build();
       expect(normalizeMap(data.duplicates)).toEqual(new Map());
       expect(data.map.get('Strawberry')).toEqual({
-        g: ['fruits/Strawberry.js', 0],
+        g: ['fruits/Strawberry.js', H.MODULE],
       });
       // Make sure the other files are not affected.
-      expect(data.map.get('Banana')).toEqual({g: ['fruits/Banana.js', 0]});
+      expect(data.map.get('Banana')).toEqual({
+        g: ['fruits/Banana.js', H.MODULE],
+      });
+    });
+
+    it('recovers with the correct type when a duplicate file is deleted', async () => {
+      mockFs['/project/fruits/strawberryPackage/package.json'] = `
+        {"name": "Strawberry"}
+      `;
+
+      const {__hasteMapForTest: data} = await new HasteMap(
+        defaultConfig,
+      ).build();
+
+      expect(normalizeMap(data.duplicates)).toEqual(
+        createMap({
+          Strawberry: {
+            g: {
+              'fruits/Strawberry.js': H.MODULE,
+              'fruits/another/Strawberry.js': H.MODULE,
+              'fruits/strawberryPackage/package.json': H.PACKAGE,
+            },
+          },
+        }),
+      );
+
+      delete mockFs['/project/fruits/another/Strawberry.js'];
+      delete mockFs['/project/fruits/strawberryPackage/package.json'];
+
+      mockChangedFiles = object({
+        '/project/fruits/another/Strawberry.js': null,
+        '/project/fruits/strawberryPackage/package.json': null,
+      });
+      mockClocks = createMap({
+        fruits: 'c:fake-clock:4',
+      });
+
+      const {__hasteMapForTest: correctData} = await new HasteMap(
+        defaultConfig,
+      ).build();
+
+      expect(normalizeMap(correctData.duplicates)).toEqual(new Map());
+      expect(correctData.map.get('Strawberry')).toEqual({
+        g: ['fruits/Strawberry.js', H.MODULE],
+      });
     });
 
     it('recovers when a duplicate module is renamed', async () => {
@@ -829,13 +876,15 @@ describe('HasteMap', () => {
       ).build();
       expect(normalizeMap(data.duplicates)).toEqual(new Map());
       expect(data.map.get('Strawberry')).toEqual({
-        g: ['fruits/Strawberry.js', 0],
+        g: ['fruits/Strawberry.js', H.MODULE],
       });
       expect(data.map.get('Pineapple')).toEqual({
-        g: ['fruits/another/Pineapple.js', 0],
+        g: ['fruits/another/Pineapple.js', H.MODULE],
       });
       // Make sure the other files are not affected.
-      expect(data.map.get('Banana')).toEqual({g: ['fruits/Banana.js', 0]});
+      expect(data.map.get('Banana')).toEqual({
+        g: ['fruits/Banana.js', H.MODULE],
+      });
     });
   });
 
@@ -1244,8 +1293,8 @@ describe('HasteMap', () => {
           expect(error.platform).toBe('g');
           expect(error.supportsNativePlatform).toBe(false);
           expect(error.duplicatesSet).toEqual({
-            '/project/fruits/Pear.js': 0,
-            '/project/fruits/another/Pear.js': 0,
+            '/project/fruits/Pear.js': H.MODULE,
+            '/project/fruits/another/Pear.js': H.MODULE,
           });
           expect(error.message).toMatchSnapshot();
         }

--- a/types/HasteMap.js
+++ b/types/HasteMap.js
@@ -24,14 +24,8 @@ export type ModuleMapData = Map<string, ModuleMapItem>;
 export type WatchmanClocks = Map<Path, string>;
 export type HasteRegExp = RegExp | ((str: string) => boolean);
 
-export type DuplicatesSet = {
-  [filePath: string]: /* type */ number,
-  __proto__: null,
-};
-export type DuplicatesIndex = Map<
-  string,
-  {[platform: string]: DuplicatesSet, __proto__: null},
->;
+export type DuplicatesSet = Map<string, /* type */ number>;
+export type DuplicatesIndex = Map<string, Map<string, DuplicatesSet>>;
 
 export type InternalHasteMap = {|
   clocks: WatchmanClocks,


### PR DESCRIPTION
## Summary

`jest-haste-map` had a bug when recovering from a haste name collision: it was using the `type` from the deleted file instead of the type from the remaining file in the haste map.

This PR fixes this issue, while it also changes the internal data structure that holds the duplicated modules. 

I've split the PR into two commits: the first one only fixes the issue and the second one converts the `duplicates` structure into a `Map`. We can discard the second commit if needed.

I've marked the change as a breaking change since the duplicated modules are part of the public API of `jest-haste-map` (although it should be very rare for a user to rely on this).

## Test plan

I've created a new unit test that ensures the correct behaviour (that test would fail currently in master).
