### PR TITLE
handle objects with no constructor in hasOwnProperty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
 - `[jest-message-util]` Improve parsing of error messages for unusually formatted stack traces ([#7319](https://github.com/facebook/jest/pull/7319))
 - `[jest-runtime]` Ensure error message text is not lost on errors with code frames ([#7319](https://github.com/facebook/jest/pull/7319))
 - `[jest-haste-map]` Fix to resolve path that is start with words same as rootDir ([#7324](https://github.com/facebook/jest/pull/7324))
+- `[expect]` Fix toMatchObject matcher when used with `Object.create(null)` ([#7334](https://github.com/facebook/jest/pull/7334))
 
 ### Chore & Maintenance
 

--- a/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -3688,6 +3688,23 @@ Difference:
 <dim>  }</>"
 `;
 
+exports[`toMatchObject() {pass: false} expect({"a": "b"}).toMatchObject({"c": "d"}) 1`] = `
+"<dim>expect(</><red>received</><dim>).toMatchObject(</><green>expected</><dim>)</>
+
+Expected value to match object:
+  <green>{\\"c\\": \\"d\\"}</>
+Received:
+  <red>{\\"a\\": \\"b\\"}</>
+Difference:
+<green>- Expected</>
+<red>+ Received</>
+
+<dim>  Object {</>
+<green>-   \\"c\\": \\"d\\",</>
+<red>+   \\"a\\": \\"b\\",</>
+<dim>  }</>"
+`;
+
 exports[`toMatchObject() {pass: false} expect({"a": [{"a": "a", "b": "b"}]}).toMatchObject({"a": [{"a": "c"}]}) 1`] = `
 "<dim>expect(</><red>received</><dim>).toMatchObject(</><green>expected</><dim>)</>
 
@@ -4024,6 +4041,15 @@ Expected value not to match object:
   <green>{\\"t\\": {\\"x\\": {\\"r\\": \\"r\\"}}}</>
 Received:
   <red>{\\"a\\": \\"b\\", \\"t\\": {\\"x\\": {\\"r\\": \\"r\\"}, \\"z\\": \\"z\\"}}</>"
+`;
+
+exports[`toMatchObject() {pass: true} expect({"a": "b"}).toMatchObject({"a": "b"}) 1`] = `
+"<dim>expect(</><red>received</><dim>).not.toMatchObject(</><green>expected</><dim>)</>
+
+Expected value not to match object:
+  <green>{\\"a\\": \\"b\\"}</>
+Received:
+  <red>{\\"a\\": \\"b\\"}</>"
 `;
 
 exports[`toMatchObject() {pass: true} expect({"a": [{"a": "a", "b": "b"}]}).toMatchObject({"a": [{"a": "a"}]}) 1`] = `

--- a/packages/expect/src/__tests__/matchers.test.js
+++ b/packages/expect/src/__tests__/matchers.test.js
@@ -1142,6 +1142,7 @@ describe('toMatchObject()', () => {
     [new Error('foo'), new Error('foo')],
     [new Error('bar'), {message: 'bar'}],
     [new Foo(), {a: undefined, b: 'b'}],
+    [Object.assign(Object.create(null), {a: 'b'}), {a: 'b'}],
   ].forEach(([n1, n2]) => {
     it(`{pass: true} expect(${stringify(n1)}).toMatchObject(${stringify(
       n2,
@@ -1178,6 +1179,7 @@ describe('toMatchObject()', () => {
     [[1, 2, 3], [2, 3, 1]],
     [[1, 2, 3], [1, 2, 2]],
     [new Error('foo'), new Error('bar')],
+    [Object.assign(Object.create(null), {a: 'b'}), {c: 'd'}],
   ].forEach(([n1, n2]) => {
     it(`{pass: false} expect(${stringify(n1)}).toMatchObject(${stringify(
       n2,

--- a/packages/expect/src/utils.js
+++ b/packages/expect/src/utils.js
@@ -21,9 +21,17 @@ type GetPath = {
   value?: any,
 };
 
-export const hasOwnProperty = (object: Object, value: string) =>
-  Object.prototype.hasOwnProperty.call(object, value) ||
-  Object.prototype.hasOwnProperty.call(object.constructor.prototype, value);
+export const hasOwnProperty = (object: Object, value: string) => {
+  // Account for objects created using unconventional means such as
+  // `Object.create(null)`, in which case the `object.constructor` is undefined
+  // See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/create#Custom_and_Null_objects
+  const objectConstructor = object.constructor || Object;
+
+  return (
+    Object.prototype.hasOwnProperty.call(object, value) ||
+    Object.prototype.hasOwnProperty.call(objectConstructor.prototype, value)
+  );
+};
 
 export const getPath = (
   object: Object,


### PR DESCRIPTION


<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

I'm not super excited about the fix, so any feedback is welcome! It got hairy really quick, and looking at the docs for `Object.create`, I can see how this is a weird edge case that some have run into (including myself)

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This problem is discussed in #6730 .

In short, objects created using unconventional means such as `Object.create(null)` will not have a `constructor` property, causing an exception to be throw in "packages/expect/src/utils.js" `hasOwnProperty` function.

This odd behavior of JS objects is discussed in depth in the [MDN docs here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/create#Custom_and_Null_objects).

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Added a test case to the unit tests for `toMatchObject` matcher. The included test case will throw an error `TypeError: Cannot read property 'prototype' of undefined` without the included fix. 


Closes #6730
