### PR TITLE
Add computeSha1 option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - `[jest-util]` Add `jest.getTimerCount()` to get the count of scheduled fake timers ([#7285](https://github.com/facebook/jest/pull/7285))
 - `[jest-config]` Add `dependencyExtractor` option to use a custom module to extract dependencies from files ([#7313](https://github.com/facebook/jest/pull/7313))
 - `[jest-haste-map]` [**BREAKING**] Expose relative paths when getting the file iterator ([#7321](https://github.com/facebook/jest/pull/7321))
+- `[jest-config]` Add `haste.computeSha1` option to compute the sha-1 of the files in the haste map ([#7345](https://github.com/facebook/jest/pull/7345))
 
 ### Fixes
 

--- a/e2e/__tests__/__snapshots__/show_config.test.js.snap
+++ b/e2e/__tests__/__snapshots__/show_config.test.js.snap
@@ -21,6 +21,7 @@ exports[`--showConfig outputs config info and exits 1`] = `
       \\"forceCoverageMatch\\": [],
       \\"globals\\": {},
       \\"haste\\": {
+        \\"computeSha1\\": false,
         \\"providesModuleNodeModules\\": []
       },
       \\"moduleDirectories\\": [

--- a/packages/jest-config/src/Defaults.js
+++ b/packages/jest-config/src/Defaults.js
@@ -41,6 +41,7 @@ export default ({
   globalTeardown: null,
   globals: {},
   haste: {
+    computeSha1: false,
     providesModuleNodeModules: [],
   },
   moduleDirectories: ['node_modules'],

--- a/packages/jest-config/src/ValidConfig.js
+++ b/packages/jest-config/src/ValidConfig.js
@@ -51,6 +51,7 @@ export default ({
   globalTeardown: 'teardown.js',
   globals: {__DEV__: true},
   haste: {
+    computeSha1: true,
     defaultPlatform: 'ios',
     hasteImplModulePath: '<rootDir>/haste_impl.js',
     platforms: ['ios', 'android'],

--- a/packages/jest-runtime/src/index.js
+++ b/packages/jest-runtime/src/index.js
@@ -236,6 +236,7 @@ class Runtime {
 
     return new HasteMap({
       cacheDirectory: config.cacheDirectory,
+      computeSha1: config.haste.computeSha1,
       console: options && options.console,
       dependencyExtractor: config.dependencyExtractor,
       extensions: [Snapshot.EXTENSION].concat(config.moduleFileExtensions),

--- a/types/Config.js
+++ b/types/Config.js
@@ -11,6 +11,7 @@ export type Path = string;
 export type Glob = string;
 
 export type HasteConfig = {|
+  computeSha1?: boolean,
   defaultPlatform?: ?string,
   hasteImplModulePath?: string,
   platforms?: Array<string>,


### PR DESCRIPTION
## Summary

The HasteMap class has an option to compute the sha-1 of files and use it to determine if a file has changed if the modification times differ. This is used by external packages (e.g. Metro) but the option wasn't exposed in Jest. It's exposed as an option instead of enabling it by default because it has a performance impact that only pays off for some use cases (like remote caching, where mtimes differ).

## Test plan

This is difficult to test e2e (as it'll mostly be used with watchman and remote caching where mtime is lost) and we don't test that options are forwarded in the different packages in unit tests, so I trust Flow typing and manual testing here.