### PR TITLE
Fix invalid re-run of tests in watch mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - `[jest-circus]` [**BREAKING**] Fail tests if a test takes a done callback and have return values ([#9129](https://github.com/facebook/jest/pull/9129))
 - `[jest-circus]` [**BREAKING**] Throw a proper error if a test / hook is defined asynchronously ([#8096](https://github.com/facebook/jest/pull/8096))
 - `[jest-config, jest-resolve]` [**BREAKING**] Remove support for `browser` field ([#9943](https://github.com/facebook/jest/pull/9943))
+- `[jest-haste-map]` Stop reporting files as changed when they are only accessed ([#7347](https://github.com/facebook/jest/pull/7347))
 - `[jest-resolve]` Show relative path from root dir for `module not found` errors ([#9963](https://github.com/facebook/jest/pull/9963))
 
 ### Chore & Maintenance

--- a/e2e/__tests__/watchModeNoAccess.test.ts
+++ b/e2e/__tests__/watchModeNoAccess.test.ts
@@ -1,13 +1,10 @@
 /**
- * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow
  */
-
-'use strict';
 
 import * as os from 'os';
 import * as path from 'path';

--- a/e2e/__tests__/watch_mode_no_access.test.js
+++ b/e2e/__tests__/watch_mode_no_access.test.js
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+'use strict';
+
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {cleanup, writeFiles} from '../Utils';
+import {runContinuous} from '../runJest';
+
+const DIR = path.resolve(os.tmpdir(), 'watch_mode_no_access');
+
+const sleep = time => new Promise(resolve => setTimeout(resolve, time));
+
+beforeEach(() => cleanup(DIR));
+afterAll(() => cleanup(DIR));
+
+const setupFiles = () => {
+  writeFiles(DIR, {
+    '__tests__/foo.spec.js': `
+      const foo = require('../foo');
+      test('foo', () => { expect(typeof foo).toBe('number'); });
+    `,
+    'foo.js': `
+      module.exports = 0;
+    `,
+    'package.json': JSON.stringify({
+      jest: {},
+    }),
+  });
+};
+
+let testRun;
+
+afterEach(async () => {
+  if (testRun) {
+    await testRun.end();
+  }
+});
+
+test('does not re-run tests when only access time is modified', async () => {
+  setupFiles();
+
+  testRun = runContinuous(DIR, ['--watchAll', '--no-watchman']);
+
+  const testCompletedRE = /Ran all test suites./g;
+  const numberOfTestRuns = (stderr: string): number => {
+    const matches = stderr.match(testCompletedRE);
+    return matches ? matches.length : 0;
+  };
+
+  // First run
+  await testRun.waitUntil(({stderr}) => numberOfTestRuns(stderr) === 1);
+
+  // Should re-run the test
+  const modulePath = path.join(DIR, 'foo.js');
+  const stat = fs.lstatSync(modulePath);
+  fs.utimesSync(modulePath, stat.atime, stat.mtime);
+  await testRun.waitUntil(({stderr}) => numberOfTestRuns(stderr) === 2);
+
+  // Should NOT re-run the test
+  const fakeATime = 1541723621;
+  fs.utimesSync(modulePath, fakeATime, stat.mtime);
+  await sleep(3000);
+  expect(numberOfTestRuns(testRun.getCurrentOutput().stderr)).toBe(2);
+
+  // Should re-run the test
+  fs.writeFileSync(modulePath, 'module.exports = 1;', {encoding: 'utf-8'});
+  await testRun.waitUntil(({stderr}) => numberOfTestRuns(stderr) === 3);
+});

--- a/packages/jest-haste-map/src/index.ts
+++ b/packages/jest-haste-map/src/index.ts
@@ -892,6 +892,8 @@ class HasteMap extends EventEmitter {
             return null;
           };
 
+          const fileMetadata = hasteMap.files.get(relativeFilePath);
+
           // If it's not an addition, delete the file and all its metadata
           if (fileMetadata != null) {
             const moduleName = fileMetadata[H.ID];

--- a/packages/jest-haste-map/src/index.ts
+++ b/packages/jest-haste-map/src/index.ts
@@ -852,7 +852,9 @@ class HasteMap extends EventEmitter {
       // The file has been accessed, not modified
       if (
         type === 'change' &&
-        fileMetadata?.[H.MTIME] === stat?.mtime.getTime()
+        fileMetadata &&
+        stat &&
+        fileMetadata[H.MTIME] === stat.mtime.getTime()
       ) {
         return;
       }

--- a/packages/jest-haste-map/src/index.ts
+++ b/packages/jest-haste-map/src/index.ts
@@ -851,10 +851,8 @@ class HasteMap extends EventEmitter {
 
       // The file has been accessed, not modified
       if (
-        fileMetadata &&
         type === 'change' &&
-        stat &&
-        fileMetadata[H.MTIME] === stat.mtime.getTime()
+        fileMetadata?.[H.MTIME] === stat?.mtime.getTime()
       ) {
         return;
       }

--- a/packages/jest-haste-map/src/index.ts
+++ b/packages/jest-haste-map/src/index.ts
@@ -846,6 +846,19 @@ class HasteMap extends EventEmitter {
         return;
       }
 
+      const relativeFilePath = fastPath.relative(rootDir, filePath);
+      const fileMetadata = hasteMap.files.get(relativeFilePath);
+
+      // The file has been accessed, not modified
+      if (
+        fileMetadata &&
+        type === 'change' &&
+        stat &&
+        fileMetadata[H.MTIME] === stat.mtime.getTime()
+      ) {
+        return;
+      }
+
       changeQueue = changeQueue
         .then(() => {
           // If we get duplicate events for the same file, ignore them.
@@ -878,9 +891,6 @@ class HasteMap extends EventEmitter {
             eventsQueue.push({filePath, stat, type});
             return null;
           };
-
-          const relativeFilePath = fastPath.relative(rootDir, filePath);
-          const fileMetadata = hasteMap.files.get(relativeFilePath);
 
           // If it's not an addition, delete the file and all its metadata
           if (fileMetadata != null) {


### PR DESCRIPTION
## Summary

Fixes #7124. Watch mode shouldn't trigger a new test run when only the access time of the file has been modified.

## Test plan

Added e2e tests.