### PR TITLE
Use namespace for dependency extractor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 - `[babel-preset-jest]` [**BREAKING**] Export a function instead of an object for Babel 7 compatibility ([#7203](https://github.com/facebook/jest/pull/7203))
 - `[expect]` Check constructor equality in .toStrictEqual() ([#7005](https://github.com/facebook/jest/pull/7005))
 - `[jest-util]` Add `jest.getTimerCount()` to get the count of scheduled fake timers ([#7285](https://github.com/facebook/jest/pull/7285))
-- `[jest-config]` Add `dependencyExtractor` option to use a custom module to extract dependencies from files ([#7313](https://github.com/facebook/jest/pull/7313))
+- `[jest-config]` Add `dependencyExtractor` option to use a custom module to extract dependencies from files ([#7313](https://github.com/facebook/jest/pull/7313), [#7349](https://github.com/facebook/jest/pull/7349)).
 - `[jest-haste-map]` [**BREAKING**] Expose relative paths when getting the file iterator ([#7321](https://github.com/facebook/jest/pull/7321))
 - `[jest-config]` Add `haste.computeSha1` option to compute the sha-1 of the files in the haste map ([#7345](https://github.com/facebook/jest/pull/7345))
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -261,7 +261,7 @@ Jest will fail if:
 
 Default: `undefined`
 
-This option allows the use of a custom dependency extractor. It must be a node module that exports a function expecting a string as the first argument for the code to analyze and Jest's dependency extractor as the second argument (in case you only want to extend it).
+This option allows the use of a custom dependency extractor. It must be a node module that exports an object with an `extract` function expecting a string as the first argument for the code to analyze and Jest's dependency extractor as the second argument (in case you only want to extend it).
 
 The function should return an iterable (`Array`, `Set`, etc.) with the dependencies found in the code.
 

--- a/e2e/__tests__/find_related_files.test.js
+++ b/e2e/__tests__/find_related_files.test.js
@@ -53,14 +53,16 @@ describe('--findRelatedTests flag', () => {
       'a.js': 'module.exports = {foo: 5};',
       'dependencyExtractor.js': `
         const DYNAMIC_IMPORT_RE = /(?:^|[^.]\\s*)(\\bdynamicImport\\s*?\\(\\s*?)([\`'"])([^\`'"]+)(\\2\\s*?\\))/g;
-        module.exports = function dependencyExtractor(code) {
-          const dependencies = new Set();
-          const addDependency = (match, pre, quot, dep, post) => {
-            dependencies.add(dep);
-            return match;
-          };
-          code.replace(DYNAMIC_IMPORT_RE, addDependency);
-          return dependencies;
+        module.exports = {
+          extract(code) {
+            const dependencies = new Set();
+            const addDependency = (match, pre, quot, dep, post) => {
+              dependencies.add(dep);
+              return match;
+            };
+            code.replace(DYNAMIC_IMPORT_RE, addDependency);
+            return dependencies;
+          },
         };
       `,
       'package.json': JSON.stringify({

--- a/packages/jest-haste-map/src/__tests__/dependencyExtractor.js
+++ b/packages/jest-haste-map/src/__tests__/dependencyExtractor.js
@@ -11,10 +11,7 @@ const blockCommentRe = /\/\*[^]*?\*\//g;
 const lineCommentRe = /\/\/.*/g;
 const LOAD_MODULE_RE = /(?:^|[^.]\s*)(\bloadModule\s*?\(\s*?)([`'"])([^`'"]+)(\2\s*?\))/g;
 
-module.exports = function dependencyExtractor(
-  code,
-  defaultDependencyExtractor,
-) {
+export function extract(code, defaultDependencyExtractor) {
   const dependencies = defaultDependencyExtractor(code);
 
   const addDependency = (match, pre, quot, dep, post) => {
@@ -28,4 +25,4 @@ module.exports = function dependencyExtractor(
     .replace(LOAD_MODULE_RE, addDependency);
 
   return dependencies;
-};
+}

--- a/packages/jest-haste-map/src/lib/__tests__/dependencyExtractor.js
+++ b/packages/jest-haste-map/src/lib/__tests__/dependencyExtractor.js
@@ -9,7 +9,7 @@
  */
 'use strict';
 
-import extractRequires from '../extractRequires';
+import {extract as extractRequires} from '../dependencyExtractor';
 
 it('extracts both requires and imports from code', () => {
   const code = `

--- a/packages/jest-haste-map/src/lib/dependencyExtractor.js
+++ b/packages/jest-haste-map/src/lib/dependencyExtractor.js
@@ -18,7 +18,7 @@ const replacePatterns = {
   REQUIRE_RE: /(?:^|[^.]\s*)(\brequire\s*?\(\s*?)([`'"])([^`'"]+)(\2\s*?\))/g,
 };
 
-export default function extractRequires(code: string): Set<string> {
+export function extract(code: string): Set<string> {
   const dependencies = new Set();
   const addDependency = (match, pre, quot, dep, post) => {
     dependencies.add(dep);

--- a/packages/jest-haste-map/src/worker.js
+++ b/packages/jest-haste-map/src/worker.js
@@ -14,7 +14,7 @@ import path from 'path';
 import fs from 'graceful-fs';
 import blacklist from './blacklist';
 import H from './constants';
-import extractRequires from './lib/extractRequires';
+import * as dependencyExtractor from './lib/dependencyExtractor';
 
 const PACKAGE_JSON = path.sep + 'package.json';
 
@@ -81,8 +81,11 @@ export async function worker(data: WorkerMessage): Promise<WorkerMetadata> {
       dependencies = Array.from(
         data.dependencyExtractor
           ? // $FlowFixMe
-            require(data.dependencyExtractor)(content, extractRequires)
-          : extractRequires(content),
+            require(data.dependencyExtractor).extract(
+              content,
+              dependencyExtractor.extract,
+            )
+          : dependencyExtractor.extract(content),
       );
     }
 


### PR DESCRIPTION
## Summary

Changed the interface for the new dependency extractors feature to be a namespace/object instead of a function. This is a prerequisite to add `getCacheKey` to invalidate any caches that have been created using this logic when it changes (#7350).

## Test plan

Updated unit tests