### PR TITLE
Extended toEqual to allow custom equality matcher.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 
+- `[expect]` Extend .toEqual API to allow custom equality matchers [#7352](https://github.com/facebook/jest/pull/7352)
 - `[jest-validate]` Add support for comments in `package.json` using a `"//"` key [#7295](https://github.com/facebook/jest/pull/7295))
 - `[jest-config]` Add shorthand for watch plugins and runners ([#7213](https://github.com/facebook/jest/pull/7213))
 - `[jest-config]` [**BREAKING**] Deprecate `setupTestFrameworkScriptFile` in favor of new `setupFilesAfterEnv` ([#7119](https://github.com/facebook/jest/pull/7119))

--- a/docs/ExpectAPI.md
+++ b/docs/ExpectAPI.md
@@ -915,7 +915,7 @@ describe('my beverage', () => {
 });
 ```
 
-### `.toEqual(value)`
+### `.toEqual(value, customEqualityMatchers)`
 
 Use `.toEqual` to compare recursively all properties of object instances (also known as "deep" equality). It calls `Object.is` to compare primitive values, which is even better for testing than `===` strict equality operator.
 
@@ -947,6 +947,19 @@ If differences between properties do not help you to understand why a test fails
 
 - rewrite `expect(received).toEqual(expected)` as `expect(received.equals(expected)).toBe(true)`
 - rewrite `expect(received).not.toEqual(expected)` as `expect(received.equals(expected)).toBe(false)`
+
+Optionally, you may provide custom equality matchers.  Custom equality matchers allow you to substitute your own logic for property comparison, or simply return `undefined` to use built-in equality comparison.  For example, to prevent false floating-point comparison errors, you could provide a custom equality matcher for numeric fields:
+
+```js
+const customNumericMatcher = (a, b) => {
+  if (typeof a !== 'number' || typeof b !== 'number') return undefined;
+  expect(a).toBeCloseTo(b, 4);
+  return true;
+};
+const expected = {s: 'foo', x: 3};
+const actual = {s: 'foo', x: 2.9999999};
+jestExpect(expected).toEqual(actual, [customNumericMatcher]);  // passes
+```
 
 ### `.toHaveLength(number)`
 

--- a/packages/expect/src/__tests__/matchers.test.js
+++ b/packages/expect/src/__tests__/matchers.test.js
@@ -467,6 +467,17 @@ describe('.toEqual()', () => {
     });
   });
 
+  test('toEqual accepts custom equality matchers', () => {
+    const a = {s: 'foo', x: 3};
+    const b = {s: 'foo', x: 2.9999999};
+    const customEqualityMatcher = (a, b) => {
+      if (typeof a !== 'number' || typeof b !== 'number') return undefined;
+      expect(a).toBeCloseTo(b, 4);
+      return true;
+    };
+    jestExpect(a).toEqual(b, [customEqualityMatcher]);
+  });
+
   test('assertion error matcherResult property contains matcher name, expected and actual values', () => {
     const actual = {a: 1};
     const expected = {a: 2};

--- a/packages/expect/src/matchers.js
+++ b/packages/expect/src/matchers.js
@@ -366,8 +366,12 @@ const matchers: MatchersObject = {
     return {message, pass};
   },
 
-  toEqual(received: any, expected: any) {
-    const pass = equals(received, expected, [iterableEquality]);
+  toEqual(received: any, expected: any, customEqualityMatchers = []) {
+    const pass = equals(
+      received,
+      expected,
+      customEqualityMatchers.concat(iterableEquality),
+    );
 
     const message = pass
       ? () =>


### PR DESCRIPTION
## Summary

The internal implementation of `toEqual` allows for custom equality matchers.  Jest takes advantage of this currently for iterable equality, but it would be very useful for end users to have access to this same extensibility.  In particular, my case is that I want to be able to combine the functionality of `toBeCloseTo` with `toEqual`.  That is, I have test cases with large, deep objects with floating-point values I wish to compare approximately.  Exposing the existing custom equality matcher functionality allows this and other useful extensions.

## Test plan

All existing tests pass, and I added a unit test to demonstrate the effective use of custom equality matchers to do approximate numeric comparison.  Specifically:

Example of undesirable failing test:

```js
const expected = {s: 'foo', x: 3};
const actual = {s: 'foo', x: 2.9999999};
jestExpect(expected).toEqual(actual) // fails undesirably
```

Using custom numeric matchers to create passing test with approximate numeric comparison:
```js
const customNumericMatcher = (a, b) => {
  if (typeof a !== 'number' || typeof b !== 'number') return undefined;
  expect(a).toBeCloseTo(b, 4);
  return true;
};
const expected = {s: 'foo', x: 3};
const actual = {s: 'foo', x: 2.9999999};
jestExpect(expected).toEqual(actual, [customNumericMatcher]);  // passes desirably
```