### PR TITLE
Require an example path for custom snapshot resolver consistency check

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -665,7 +665,6 @@ The path to a module that can resolve test<->snapshot path. This config option l
 Example snapshot resolver module:
 
 ```js
-// my-snapshot-resolver-module
 module.exports = {
   // resolves from test to snapshot path
   resolveSnapshotPath: (testPath, snapshotExtension) =>
@@ -676,6 +675,9 @@ module.exports = {
     snapshotFilePath
       .replace('__snapshots__', '__tests__')
       .slice(0, -snapshotExtension.length),
+
+  // Example test path, used for preflight concistency check of the implementation above
+  testPathForConsistencyCheck: 'some/__tests__/example.test.js',
 };
 ```
 

--- a/e2e/snapshot-resolver/customSnapshotResolver.js
+++ b/e2e/snapshot-resolver/customSnapshotResolver.js
@@ -8,4 +8,6 @@ module.exports = {
     snapshotFilePath
       .replace('__snapshots__', '__tests__')
       .slice(0, -snapshotExtension.length),
+
+  testPathForConsistencyCheck: 'foo/__tests__/bar.test.js',
 };

--- a/packages/jest-snapshot/src/__tests__/__snapshots__/snapshot_resolver.test.js.snap
+++ b/packages/jest-snapshot/src/__tests__/__snapshots__/snapshot_resolver.test.js.snap
@@ -1,13 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`malformed custom resolver in project config inconsistent functions throws  1`] = `"<bold>Custom snapshot resolver functions must transform paths consistently, i.e. expects resolveTestPath(resolveSnapshotPath('some-path/__tests__/snapshot_resolver.test.js')) === some-path/__SPECS__/snapshot_resolver.test.js</>"`;
+exports[`malformed custom resolver in project config inconsistent functions throws  1`] = `"<bold>Custom snapshot resolver functions must transform paths consistently, i.e. expects resolveTestPath(resolveSnapshotPath('foo/__tests__/bar.test.js')) === foo/__SPECS__/bar.test.js</>"`;
 
 exports[`malformed custom resolver in project config missing resolveSnapshotPath throws  1`] = `
-"<bold>Custom snapshot resolver must implement a \`resolveSnapshotPath\` function.</>
+"<bold>Custom snapshot resolver must implement a \`resolveSnapshotPath\` as a function.</>
 Documentation: https://facebook.github.io/jest/docs/en/configuration.html#snapshotResolver"
 `;
 
 exports[`malformed custom resolver in project config missing resolveTestPath throws  1`] = `
-"<bold>Custom snapshot resolver must implement a \`resolveTestPath\` function.</>
+"<bold>Custom snapshot resolver must implement a \`resolveTestPath\` as a function.</>
+Documentation: https://facebook.github.io/jest/docs/en/configuration.html#snapshotResolver"
+`;
+
+exports[`malformed custom resolver in project config missing testPathForConsistencyCheck throws  1`] = `
+"<bold>Custom snapshot resolver must implement a \`testPathForConsistencyCheck\` as a string.</>
 Documentation: https://facebook.github.io/jest/docs/en/configuration.html#snapshotResolver"
 `;

--- a/packages/jest-snapshot/src/__tests__/fixtures/customSnapshotResolver-inconsistent-fns.js
+++ b/packages/jest-snapshot/src/__tests__/fixtures/customSnapshotResolver-inconsistent-fns.js
@@ -8,4 +8,6 @@ module.exports = {
     snapshotFilePath
       .replace('__snapshots__', '__SPECS__')
       .slice(0, -snapshotExtension.length),
+
+  testPathForConsistencyCheck: 'foo/__tests__/bar.test.js',
 };

--- a/packages/jest-snapshot/src/__tests__/fixtures/customSnapshotResolver-missing-resolveSnapshotPath.js
+++ b/packages/jest-snapshot/src/__tests__/fixtures/customSnapshotResolver-missing-resolveSnapshotPath.js
@@ -2,4 +2,5 @@
 
 module.exports = {
   resolveTestPath: () => {},
+  testPathForConsistencyCheck: 'foo/__tests__/bar.test.js',
 };

--- a/packages/jest-snapshot/src/__tests__/fixtures/customSnapshotResolver-missing-resolveTestPath.js
+++ b/packages/jest-snapshot/src/__tests__/fixtures/customSnapshotResolver-missing-resolveTestPath.js
@@ -2,4 +2,5 @@
 
 module.exports = {
   resolveSnapshotPath: () => {},
+  testPathForConsistencyCheck: 'foo/__tests__/bar.test.js',
 };

--- a/packages/jest-snapshot/src/__tests__/fixtures/customSnapshotResolver-missing-test-path-for-consistency-check.js
+++ b/packages/jest-snapshot/src/__tests__/fixtures/customSnapshotResolver-missing-test-path-for-consistency-check.js
@@ -1,0 +1,6 @@
+// Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+
+module.exports = {
+  resolveSnapshotPath: (testPath, snapshotExtension) => {},
+  resolveTestPath: (snapshotFilePath, snapshotExtension) => {},
+};

--- a/packages/jest-snapshot/src/__tests__/fixtures/customSnapshotResolver.js
+++ b/packages/jest-snapshot/src/__tests__/fixtures/customSnapshotResolver.js
@@ -8,4 +8,6 @@ module.exports = {
     snapshotFilePath
       .replace('__snapshots__', '__tests__')
       .slice(0, -snapshotExtension.length),
+
+  testPathForConsistencyCheck: 'foo/__tests__/bar.test.js',
 };

--- a/packages/jest-snapshot/src/__tests__/snapshot_resolver.test.js
+++ b/packages/jest-snapshot/src/__tests__/snapshot_resolver.test.js
@@ -99,6 +99,15 @@ describe('malformed custom resolver in project config', () => {
     }).toThrowErrorMatchingSnapshot();
   });
 
+  it('missing testPathForConsistencyCheck throws ', () => {
+    const projectConfig = newProjectConfig(
+      'customSnapshotResolver-missing-test-path-for-consistency-check.js',
+    );
+    expect(() => {
+      buildSnapshotResolver(projectConfig);
+    }).toThrowErrorMatchingSnapshot();
+  });
+
   it('inconsistent functions throws ', () => {
     const projectConfig = newProjectConfig(
       'customSnapshotResolver-inconsistent-fns.js',

--- a/packages/jest-snapshot/src/snapshot_resolver.js
+++ b/packages/jest-snapshot/src/snapshot_resolver.js
@@ -25,20 +25,30 @@ export const buildSnapshotResolver = (
 function createSnapshotResolver(snapshotResolverPath: ?Path): SnapshotResolver {
   return typeof snapshotResolverPath === 'string'
     ? createCustomSnapshotResolver(snapshotResolverPath)
-    : {
-        resolveSnapshotPath: (testPath: Path) =>
-          path.join(
-            path.join(path.dirname(testPath), '__snapshots__'),
-            path.basename(testPath) + DOT_EXTENSION,
-          ),
+    : createDefaultSnapshotResolver();
+}
 
-        resolveTestPath: (snapshotPath: Path) =>
-          path.resolve(
-            path.dirname(snapshotPath),
-            '..',
-            path.basename(snapshotPath, DOT_EXTENSION),
-          ),
-      };
+function createDefaultSnapshotResolver() {
+  return {
+    resolveSnapshotPath: (testPath: Path) =>
+      path.join(
+        path.join(path.dirname(testPath), '__snapshots__'),
+        path.basename(testPath) + DOT_EXTENSION,
+      ),
+
+    resolveTestPath: (snapshotPath: Path) =>
+      path.resolve(
+        path.dirname(snapshotPath),
+        '..',
+        path.basename(snapshotPath, DOT_EXTENSION),
+      ),
+
+    testPathForConsistencyCheck: path.posix.join(
+      'consistency_check',
+      '__tests__',
+      'example.test.js',
+    ),
+  };
 }
 
 function createCustomSnapshotResolver(
@@ -46,18 +56,22 @@ function createCustomSnapshotResolver(
 ): SnapshotResolver {
   const custom = (require(snapshotResolverPath): SnapshotResolver);
 
-  if (typeof custom.resolveSnapshotPath !== 'function') {
-    throw new TypeError(mustImplement('resolveSnapshotPath'));
-  }
-  if (typeof custom.resolveTestPath !== 'function') {
-    throw new TypeError(mustImplement('resolveTestPath'));
-  }
+  [
+    ['resolveSnapshotPath', 'function'],
+    ['resolveTestPath', 'function'],
+    ['testPathForConsistencyCheck', 'string'],
+  ].forEach(([propName, requiredType]) => {
+    if (typeof custom[propName] !== requiredType) {
+      throw new TypeError(mustImplement(propName, requiredType));
+    }
+  });
 
   const customResolver = {
     resolveSnapshotPath: testPath =>
       custom.resolveSnapshotPath(testPath, DOT_EXTENSION),
     resolveTestPath: snapshotPath =>
       custom.resolveTestPath(snapshotPath, DOT_EXTENSION),
+    testPathForConsistencyCheck: custom.testPathForConsistencyCheck,
   };
 
   verifyConsistentTransformations(customResolver);
@@ -65,28 +79,26 @@ function createCustomSnapshotResolver(
   return customResolver;
 }
 
-function mustImplement(functionName: string) {
+function mustImplement(propName: string, requiredType: string) {
   return (
     chalk.bold(
-      `Custom snapshot resolver must implement a \`${functionName}\` function.`,
+      `Custom snapshot resolver must implement a \`${propName}\` as a ${requiredType}.`,
     ) +
     '\nDocumentation: https://facebook.github.io/jest/docs/en/configuration.html#snapshotResolver'
   );
 }
 
 function verifyConsistentTransformations(custom: SnapshotResolver) {
-  const fakeTestPath = path.posix.join(
-    'some-path',
-    '__tests__',
-    'snapshot_resolver.test.js',
+  const resolvedSnapshotPath = custom.resolveSnapshotPath(
+    custom.testPathForConsistencyCheck,
   );
-  const transformedPath = custom.resolveTestPath(
-    custom.resolveSnapshotPath(fakeTestPath),
-  );
-  if (transformedPath !== fakeTestPath) {
+  const resolvedTestPath = custom.resolveTestPath(resolvedSnapshotPath);
+  if (resolvedTestPath !== custom.testPathForConsistencyCheck) {
     throw new Error(
       chalk.bold(
-        `Custom snapshot resolver functions must transform paths consistently, i.e. expects resolveTestPath(resolveSnapshotPath('${fakeTestPath}')) === ${transformedPath}`,
+        `Custom snapshot resolver functions must transform paths consistently, i.e. expects resolveTestPath(resolveSnapshotPath('${
+          custom.testPathForConsistencyCheck
+        }')) === ${resolvedTestPath}`,
       ),
     );
   }

--- a/types/SnapshotResolver.js
+++ b/types/SnapshotResolver.js
@@ -3,6 +3,7 @@
 import type {Path} from './Config';
 
 export type SnapshotResolver = {|
+  testPathForConsistencyCheck: string,
   resolveSnapshotPath(testPath: Path): Path,
   resoveTestPath(snapshotPath: Path): Path,
 |};


### PR DESCRIPTION
## Summary

Make the consistency check of custom snapshot resolver a little more strict, to prevent more reports like #7257

Didn't update the changelog since the original code for custom snapshot resolver isn't released just yet #6143 

## Test plan

Updated & new test cases