### PR TITLE
fix: only set error codes when they are non zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Features
 
-- `[jest-cli]` Only set error process error codes when they are non-zero ([#7363](https://github.com/facebook/jest/pull/7363))
+- `[jest-cli]` [**BREAKING**] Only set error process error codes when they are non-zero ([#7363](https://github.com/facebook/jest/pull/7363))
 - `[jest-validate]` Add support for comments in `package.json` using a `"//"` key [#7295](https://github.com/facebook/jest/pull/7295))
 - `[jest-config]` Add shorthand for watch plugins and runners ([#7213](https://github.com/facebook/jest/pull/7213))
 - `[jest-config]` [**BREAKING**] Deprecate `setupTestFrameworkScriptFile` in favor of new `setupFilesAfterEnv` ([#7119](https://github.com/facebook/jest/pull/7119))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 
+- `[jest-cli]` Only set error process error codes when they are non-zero [#7363]
 - `[jest-validate]` Add support for comments in `package.json` using a `"//"` key [#7295](https://github.com/facebook/jest/pull/7295))
 - `[jest-config]` Add shorthand for watch plugins and runners ([#7213](https://github.com/facebook/jest/pull/7213))
 - `[jest-config]` [**BREAKING**] Deprecate `setupTestFrameworkScriptFile` in favor of new `setupFilesAfterEnv` ([#7119](https://github.com/facebook/jest/pull/7119))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Features
 
-- `[jest-cli]` Only set error process error codes when they are non-zero [#7363]
+- `[jest-cli]` Only set error process error codes when they are non-zero ([#7363](https://github.com/facebook/jest/pull/7363))
 - `[jest-validate]` Add support for comments in `package.json` using a `"//"` key [#7295](https://github.com/facebook/jest/pull/7295))
 - `[jest-config]` Add shorthand for watch plugins and runners ([#7213](https://github.com/facebook/jest/pull/7213))
 - `[jest-config]` [**BREAKING**] Deprecate `setupTestFrameworkScriptFile` in favor of new `setupFilesAfterEnv` ([#7119](https://github.com/facebook/jest/pull/7119))

--- a/packages/jest-cli/src/cli/index.js
+++ b/packages/jest-cli/src/cli/index.js
@@ -137,8 +137,11 @@ const readResultsAndExit = (
   globalConfig: GlobalConfig,
 ) => {
   const code = !result || result.success ? 0 : globalConfig.testFailureExitCode;
-
-  process.on('exit', () => (process.exitCode = code));
+  
+  // Only exit if needed
+  if (code) {
+    process.on('exit', () => (process.exitCode = code));
+  }
 
   if (globalConfig.forceExit) {
     if (!globalConfig.detectOpenHandles) {

--- a/packages/jest-cli/src/cli/index.js
+++ b/packages/jest-cli/src/cli/index.js
@@ -137,7 +137,7 @@ const readResultsAndExit = (
   globalConfig: GlobalConfig,
 ) => {
   const code = !result || result.success ? 0 : globalConfig.testFailureExitCode;
-  
+
   // Only exit if needed
   if (typeof code === 'number' && code !== 0) {
     process.on('exit', () => (process.exitCode = code));

--- a/packages/jest-cli/src/cli/index.js
+++ b/packages/jest-cli/src/cli/index.js
@@ -139,9 +139,11 @@ const readResultsAndExit = (
   const code = !result || result.success ? 0 : globalConfig.testFailureExitCode;
 
   // Only exit if needed
-  if (typeof code === 'number' && code !== 0) {
-    process.on('exit', () => (process.exitCode = code));
-  }
+  process.on('exit', () => {
+    if (typeof code === 'number' && code !== 0) {
+      process.exitCode = code;
+    }
+  });
 
   if (globalConfig.forceExit) {
     if (!globalConfig.detectOpenHandles) {

--- a/packages/jest-cli/src/cli/index.js
+++ b/packages/jest-cli/src/cli/index.js
@@ -139,7 +139,7 @@ const readResultsAndExit = (
   const code = !result || result.success ? 0 : globalConfig.testFailureExitCode;
   
   // Only exit if needed
-  if (code) {
+  if (typeof code === 'number' && code !== 0) {
     process.on('exit', () => (process.exitCode = code));
   }
 


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

I'm working on an internal CLI that runs jest, eslint, and sasslint all in one single process for our frontend team to run from their `package.json`'s

Aka something like, `"test": "cli test"`.

The code `process.on('exit', () => (process.exitCode = code));` adds a listener that is overriding the exit codes we're setting so that when jest is successful, and eslint or sasslint fail, I can't exit with a failing code.

Therefore our CI's are reporting as passed even though the linting fails.

It seems as though there's no reason to actually set the error code at all unless it's non-zero?

Let me know what the thoughts here are. I can come back in and add more, add some additional tests, etc if this looks like an ok change.

Thanks!


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Pretty much just make sure that jest still reports a non-zero exit code with a failing test.
