### PR TITLE
Hotfix/invalid to throw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## master
 
 ### Features
-
+- `[expect]` Check if the string is empty in the createMatcher function ([#6805](https://github.com/facebook/jest/pull/6805))
 - `[jest-validate]` Add support for comments in `package.json` using a `"//"` key [#7295](https://github.com/facebook/jest/pull/7295))
 - `[jest-config]` Add shorthand for watch plugins and runners ([#7213](https://github.com/facebook/jest/pull/7213))
 - `[jest-config]` [**BREAKING**] Deprecate `setupTestFrameworkScriptFile` in favor of new `setupFilesAfterEnv` ([#7119](https://github.com/facebook/jest/pull/7119))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## master
 
 ### Features
+
 - `[expect]` Check if the string is empty in the createMatcher function ([#6805](https://github.com/facebook/jest/pull/6805))
 - `[jest-validate]` Add support for comments in `package.json` using a `"//"` key [#7295](https://github.com/facebook/jest/pull/7295))
 - `[jest-config]` Add shorthand for watch plugins and runners ([#7213](https://github.com/facebook/jest/pull/7213))

--- a/packages/expect/src/toThrowMatchers.js
+++ b/packages/expect/src/toThrowMatchers.js
@@ -51,7 +51,9 @@ export const createMatcher = (matcherName: string, fromPromise?: boolean) => (
   }
 
   if (typeof expected === 'string') {
-    expected = new RegExp(escapeStrForRegex(expected));
+    if (expected !== '') {
+      expected = new RegExp(escapeStrForRegex(expected));
+    }
   }
 
   if (typeof expected === 'function') {


### PR DESCRIPTION


## Summary

The toThrow function was not working properly with empty strings, to avoid this we check is the string is empty in the toThrowMatchers function.

## Test plan

To test this we can use this sample of code 

`it('must fail when compared against an empty string', () => {
    expect(() => {
        throw 'something';
     }).toThrow(''); 
});`

And this should fail as it should. 
