### PR TITLE
Update README.md

### DIFF
--- a/packages/babel-jest/README.md
+++ b/packages/babel-jest/README.md
@@ -13,7 +13,7 @@ yarn add --dev babel-jest babel-core
 > Note: If you are using babel version 7 you have to install `babel-jest` with
 >
 > ```bash
-> yarn add --dev babel-jest 'babel-core@^7.0.0-bridge' @babel/core
+> yarn add --dev babel-jest 'babel-core@^7.0.0-bridge.0' @babel/core
 > ```
 
 If you would like to write your own preprocessor, uninstall and delete babel-jest and set the [config.transform](https://jestjs.io/docs/configuration#transform-object-string-string) option to your preprocessor.


### PR DESCRIPTION
Updated:
> ```bash
> yarn add --dev babel-jest 'babel-core@^7.0.0-bridge' @babel/core
> ```

To

> ```bash
> yarn add --dev babel-jest 'babel-core@^7.0.0-bridge.0' @babel/core
> ```

## Summary

The documentation is incorrect as the "bridge" tag has been updated to "bridge.0"

## Test plan

 Confirmed working and also is representative to the documentation on the front-page of this repo.
