### PR TITLE
Allow config.transform[regex] to be a function for jest.runCLI(config)

### DIFF
--- a/packages/jest-cli/src/__tests__/__fixtures__/run/aFile.js
+++ b/packages/jest-cli/src/__tests__/__fixtures__/run/aFile.js
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+module.exports = {
+  toReplace: 1,
+};

--- a/packages/jest-cli/src/__tests__/__fixtures__/run/aFile_spec.js
+++ b/packages/jest-cli/src/__tests__/__fixtures__/run/aFile_spec.js
@@ -13,6 +13,6 @@ const aFile = require('./aFile');
 
 describe('aFile test', () => {
   it('should have transformed aFile', () => {
-    expect(JSON.stringify(aFile)).toEqual(JSON.stringify({transformModuleReplaced: 1}));
+    expect(JSON.stringify(aFile)).toEqual(JSON.stringify({runReplaced: 1}));
   });
 });

--- a/packages/jest-cli/src/__tests__/__fixtures__/run/aFile_spec.js
+++ b/packages/jest-cli/src/__tests__/__fixtures__/run/aFile_spec.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+const expect = require('expect');
+const aFile = require('./aFile');
+
+describe('aFile test', () => {
+  it('should have transformed aFile', () => {
+    expect(JSON.stringify(aFile)).toEqual(JSON.stringify({transformModuleReplaced: 1}));
+  });
+});

--- a/packages/jest-cli/src/__tests__/__fixtures__/run/transform-module.js
+++ b/packages/jest-cli/src/__tests__/__fixtures__/run/transform-module.js
@@ -1,0 +1,3 @@
+module.exports = {
+  process: (src, filename) => src.replace('toReplace', 'transformModuleReplaced')
+};

--- a/packages/jest-cli/src/__tests__/__fixtures__/run/transform-module.js
+++ b/packages/jest-cli/src/__tests__/__fixtures__/run/transform-module.js
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
 module.exports = {
-  process: (src, filename) => src.replace('toReplace', 'runReplaced')
+  process: (src, filename) => src.replace('toReplace', 'runReplaced'),
 };

--- a/packages/jest-cli/src/__tests__/__fixtures__/run/transform-module.js
+++ b/packages/jest-cli/src/__tests__/__fixtures__/run/transform-module.js
@@ -1,3 +1,3 @@
 module.exports = {
-  process: (src, filename) => src.replace('toReplace', 'transformModuleReplaced')
+  process: (src, filename) => src.replace('toReplace', 'runReplaced')
 };

--- a/packages/jest-cli/src/__tests__/__fixtures__/runCLI/aFile.js
+++ b/packages/jest-cli/src/__tests__/__fixtures__/runCLI/aFile.js
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
 module.exports = {
   toReplace: 1,
 };

--- a/packages/jest-cli/src/__tests__/__fixtures__/runCLI/aFile.js
+++ b/packages/jest-cli/src/__tests__/__fixtures__/runCLI/aFile.js
@@ -1,3 +1,3 @@
 module.exports = {
-  toReplace: 1
+  toReplace: 1,
 };

--- a/packages/jest-cli/src/__tests__/__fixtures__/runCLI/aFile.js
+++ b/packages/jest-cli/src/__tests__/__fixtures__/runCLI/aFile.js
@@ -1,0 +1,3 @@
+module.exports = {
+  toReplace: 1
+};

--- a/packages/jest-cli/src/__tests__/__fixtures__/runCLI/aFile_spec.js
+++ b/packages/jest-cli/src/__tests__/__fixtures__/runCLI/aFile_spec.js
@@ -3,6 +3,6 @@ const aFile = require('./aFile');
 
 describe('aFile test', () => {
   it('should have transformed aFile', () => {
-    expect(JSON.stringify(aFile)).toEqual(JSON.stringify({ 'replaced': 1 }));
-  })
+    expect(JSON.stringify(aFile)).toEqual(JSON.stringify({replaced: 1}));
+  });
 });

--- a/packages/jest-cli/src/__tests__/__fixtures__/runCLI/aFile_spec.js
+++ b/packages/jest-cli/src/__tests__/__fixtures__/runCLI/aFile_spec.js
@@ -1,0 +1,8 @@
+const expect = require('expect');
+const aFile = require('./aFile');
+
+describe('aFile test', () => {
+  it('should have transformed aFile', () => {
+    expect(JSON.stringify(aFile)).toEqual(JSON.stringify({ 'replaced2': 1 }));
+  })
+});

--- a/packages/jest-cli/src/__tests__/__fixtures__/runCLI/aFile_spec.js
+++ b/packages/jest-cli/src/__tests__/__fixtures__/runCLI/aFile_spec.js
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
 const expect = require('expect');
 const aFile = require('./aFile');
 

--- a/packages/jest-cli/src/__tests__/__fixtures__/runCLI/aFile_spec.js
+++ b/packages/jest-cli/src/__tests__/__fixtures__/runCLI/aFile_spec.js
@@ -13,6 +13,6 @@ const aFile = require('./aFile');
 
 describe('aFile test', () => {
   it('should have transformed aFile', () => {
-    expect(JSON.stringify(aFile)).toEqual(JSON.stringify({replaced: 1}));
+    expect(JSON.stringify(aFile)).toEqual(JSON.stringify({ runCLIReplaced: 1}));
   });
 });

--- a/packages/jest-cli/src/__tests__/__fixtures__/runCLI/aFile_spec.js
+++ b/packages/jest-cli/src/__tests__/__fixtures__/runCLI/aFile_spec.js
@@ -13,6 +13,6 @@ const aFile = require('./aFile');
 
 describe('aFile test', () => {
   it('should have transformed aFile', () => {
-    expect(JSON.stringify(aFile)).toEqual(JSON.stringify({ runCLIReplaced: 1}));
+    expect(JSON.stringify(aFile)).toEqual(JSON.stringify({runCLIReplaced: 1}));
   });
 });

--- a/packages/jest-cli/src/__tests__/__fixtures__/runCLI/aFile_spec.js
+++ b/packages/jest-cli/src/__tests__/__fixtures__/runCLI/aFile_spec.js
@@ -3,6 +3,6 @@ const aFile = require('./aFile');
 
 describe('aFile test', () => {
   it('should have transformed aFile', () => {
-    expect(JSON.stringify(aFile)).toEqual(JSON.stringify({ 'replaced2': 1 }));
+    expect(JSON.stringify(aFile)).toEqual(JSON.stringify({ 'replaced': 1 }));
   })
 });

--- a/packages/jest-cli/src/__tests__/__fixtures__/runCLI/transform-module.js
+++ b/packages/jest-cli/src/__tests__/__fixtures__/runCLI/transform-module.js
@@ -1,3 +1,13 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
 module.exports = {
-  process: (src, filename) => src.replace('toReplace', 'runCLIReplaced')
+  process: (src, filename) => src.replace('toReplace', 'runCLIReplaced'),
 };

--- a/packages/jest-cli/src/__tests__/__fixtures__/runCLI/transform-module.js
+++ b/packages/jest-cli/src/__tests__/__fixtures__/runCLI/transform-module.js
@@ -1,0 +1,3 @@
+module.exports = {
+  process: (src, filename) => src.replace('toReplace', 'runCLIReplaced')
+};

--- a/packages/jest-cli/src/__tests__/cli/run.test.js
+++ b/packages/jest-cli/src/__tests__/cli/run.test.js
@@ -18,26 +18,24 @@ jest.mock('exit');
 const runArgvString = [
   '--config',
   JSON.stringify({
-    "rootDir": runProject,
-    "testMatch": ["<rootDir>/*_spec.js"],
-    "transform": {
-      "^.+\\.jsx?$": "./transform-module"
-    }
-  })
+    rootDir: runProject,
+    testMatch: ['<rootDir>/*_spec.js'],
+    transform: {
+      '^.+\\.jsx?$': './transform-module',
+    },
+  }),
 ];
 
 const runArgvObject = [
   '--config',
   {
-    "rootDir": runProject,
-    "testMatch": ["<rootDir>/*_spec.js"],
-    "transform": {
-      "^.+\\.jsx?$": "./transform-module"
-    }
-  }
+    rootDir: runProject,
+    testMatch: ['<rootDir>/*_spec.js'],
+    transform: {
+      '^.+\\.jsx?$': './transform-module',
+    },
+  },
 ];
-
-const mockArgv = ['arg1', 'arg2'];
 
 const processOnFn = process.on;
 const processExitFn = process.exit;
@@ -47,24 +45,16 @@ const consoleErrorFn = console.error;
 const noSubTestLogs = true;
 
 describe('run', () => {
-  let processOnSpy;
-  let processExitSpy;
-  let stderrSpy;
-  let consoleErrorSpy;
   beforeEach(() => {
     if (noSubTestLogs) {
       process.on = jest.fn();
       process.on.mockReset();
-      processOnSpy = jest.spyOn(process, 'on');
       process.exit = jest.fn();
       process.exit.mockReset();
-      processExitSpy = jest.spyOn(process, 'exit');
       process.stderr.write = jest.fn();
       process.stderr.write.mockReset();
-      stderrSpy = jest.spyOn(process.stderr, 'write');
       console.error = jest.fn();
       console.error.mockReset();
-      consoleErrorSpy = jest.spyOn(console, 'error');
     }
   });
 

--- a/packages/jest-cli/src/__tests__/cli/run.test.js
+++ b/packages/jest-cli/src/__tests__/cli/run.test.js
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+import path from 'path';
+import {run} from '../../cli';
+
+const runProject = path.join(__dirname, '../__fixtures__/run');
+
+jest.mock('exit');
+
+const runArgvString = [
+  '--config',
+  JSON.stringify({
+    "rootDir": runProject,
+    "testMatch": ["<rootDir>/*_spec.js"],
+    "transform": {
+      "^.+\\.jsx?$": "./transform-module"
+    }
+  })
+];
+
+const runArgvObject = [
+  '--config',
+  {
+    "rootDir": runProject,
+    "testMatch": ["<rootDir>/*_spec.js"],
+    "transform": {
+      "^.+\\.jsx?$": "./transform-module"
+    }
+  }
+];
+
+const mockArgv = ['arg1', 'arg2'];
+
+const processOnFn = process.on;
+const processExitFn = process.exit;
+const processErrWriteFn = process.stderr.write;
+const consoleErrorFn = console.error;
+
+const noSubTestLogs = true;
+
+describe('run', () => {
+  let processOnSpy;
+  let processExitSpy;
+  let stderrSpy;
+  let consoleErrorSpy;
+  beforeEach(() => {
+    if (noSubTestLogs) {
+      process.on = jest.fn();
+      process.on.mockReset();
+      processOnSpy = jest.spyOn(process, 'on');
+      process.exit = jest.fn();
+      process.exit.mockReset();
+      processExitSpy = jest.spyOn(process, 'exit');
+      process.stderr.write = jest.fn();
+      process.stderr.write.mockReset();
+      stderrSpy = jest.spyOn(process.stderr, 'write');
+      console.error = jest.fn();
+      console.error.mockReset();
+      consoleErrorSpy = jest.spyOn(console, 'error');
+    }
+  });
+
+  afterEach(() => {
+    if (noSubTestLogs) {
+      process.on = processOnFn;
+      process.exit = processExitFn;
+      process.stderr.write = processErrWriteFn;
+      console.error = consoleErrorFn;
+    }
+  });
+
+  describe('config as string', () => {
+    it('passes the test when the config has a transform module path', async () => {
+      let runResult = null;
+      let error = null;
+      try {
+        runResult = await run(runArgvString, runProject);
+      } catch (ex) {
+        error = ex;
+      }
+      const numPassedTests = runResult ? runResult.numPassedTests : -1;
+      expect(error).toBe(null);
+      expect(numPassedTests).toBe(1);
+    });
+  });
+
+  describe('config as object', () => {
+    it('throws running the test when the config is an object', async () => {
+      let runResult = null;
+      let error = null;
+      try {
+        runResult = await run(runArgvObject, runProject);
+      } catch (ex) {
+        error = ex;
+      }
+      const numPassedTests = runResult ? runResult.numPassedTests : -1;
+      expect(error).not.toBe(null);
+      expect(numPassedTests).toBe(-1);
+    });
+  });
+});

--- a/packages/jest-cli/src/__tests__/cli/run.test.js
+++ b/packages/jest-cli/src/__tests__/cli/run.test.js
@@ -46,11 +46,11 @@ const noSubTestLogs = true;
 
 describe('run', () => {
   beforeEach(() => {
+    process.on = jest.fn();
+    process.on.mockReset();
+    process.exit = jest.fn();
+    process.exit.mockReset();
     if (noSubTestLogs) {
-      process.on = jest.fn();
-      process.on.mockReset();
-      process.exit = jest.fn();
-      process.exit.mockReset();
       process.stderr.write = jest.fn();
       process.stderr.write.mockReset();
       console.error = jest.fn();
@@ -59,9 +59,9 @@ describe('run', () => {
   });
 
   afterEach(() => {
+    process.on = processOnFn;
+    process.exit = processExitFn;
     if (noSubTestLogs) {
-      process.on = processOnFn;
-      process.exit = processExitFn;
       process.stderr.write = processErrWriteFn;
       console.error = consoleErrorFn;
     }

--- a/packages/jest-cli/src/__tests__/cli/runCLI.test.js
+++ b/packages/jest-cli/src/__tests__/cli/runCLI.test.js
@@ -9,37 +9,92 @@
 'use strict';
 
 import path from 'path';
-import {runCLI} from '../../cli';
+import {run, runCLI} from '../../cli';
 
-const project = path.join(__dirname, '../__fixtures__/runCLI');
-const projects = [project];
+const runProject = path.join(__dirname, '../__fixtures__/run');
+const runCLIProject = path.join(__dirname, '../__fixtures__/runCLI');
+const runCLIProjects = [runCLIProject];
 
-const argv = {
+const processor = {
+  process: (src, filename) => src.replace('toReplace', 'replaced')
+};
+
+const runCLIArgv = {
   config: {
     testMatch: ['<rootDir>/*_spec.js'],
     transform: {
-      '^.+\\.jsx?$': () => ({
-        process(src, filename) {
-          return src.replace('toReplace', 'replaced');
-        },
-      }),
+      '^.+\\.jsx?$': () => processor
     },
   },
 };
 
+const runArgvString = [
+  '--config',
+  JSON.stringify({
+    "rootDir": runProject,
+    "testMatch": ["<rootDir>/*_spec.js"],
+    "transform": {
+      "^.+\\.jsx?$": "./transform-module"
+    }
+  })
+];
+
+const runArgvObject = [
+  '--config',
+  {
+    "rootDir": runProject,
+    "testMatch": ["<rootDir>/*_spec.js"],
+    "transform": {
+      "^.+\\.jsx?$": "./transform-module"
+    }
+  }
+];
+
 describe('runCLI', () => {
   describe('config as object', () => {
-    it('runs jest with a standalone config object', async () => {
+    it('passes the test when the config has a transform function', async () => {
       let runResult = null;
       let error = null;
       try {
-        runResult = await runCLI(argv, projects);
+        runResult = await runCLI(runCLIArgv, runCLIProjects);
       } catch (ex) {
         error = ex;
       }
       const numPassedTests = runResult ? runResult.results.numPassedTests : -1;
       expect(error).toBe(null);
       expect(numPassedTests).toBe(1);
+    });
+  });
+});
+
+describe('run', () => {
+  describe('config as string', () => {
+    it('passes the test when the config has a transform module path', async () => {
+      let runResult = null;
+      let error = null;
+      try {
+        runResult = await run(runArgvString, runProject);
+      } catch (ex) {
+        error = ex;
+      }
+      const numPassedTests = runResult ? runResult.numPassedTests : -1;
+      expect(error).toBe(null);
+      expect(numPassedTests).toBe(1);
+    });
+  });
+
+  describe('config as object', () => {
+    it('throws running the test when the config is an object', async () => {
+      let runResult = null;
+      let error = null;
+      try {
+        runResult = await run(runArgvObject, runProject, false);
+      } catch (ex) {
+        error = ex;
+      }
+      const numPassedTests = runResult ? runResult.numPassedTests : -1;
+      expect(error).not.toBe(null);
+      expect(numPassedTests).toBe(-1);
     });
   });
 });

--- a/packages/jest-cli/src/__tests__/cli/runCLI.test.js
+++ b/packages/jest-cli/src/__tests__/cli/runCLI.test.js
@@ -36,18 +36,18 @@ const argvString = {
 
 const processErrWriteFn = process.stderr.write;
 
-const noLogs = true;
+const noSubTestLogs = true;
 
 describe('runCLI', () => {
   beforeEach(() => {
-    if (noLogs) {
+    if (noSubTestLogs) {
       process.stderr.write = jest.fn();
       process.stderr.write.mockReset();
     }
   });
 
   afterEach(() => {
-    if (noLogs) {
+    if (noSubTestLogs) {
       process.stderr.write = processErrWriteFn;
     }
   });

--- a/packages/jest-cli/src/__tests__/cli/runCLI.test.js
+++ b/packages/jest-cli/src/__tests__/cli/runCLI.test.js
@@ -9,25 +9,21 @@
 'use strict';
 
 import path from 'path';
-import { runCLI } from '../../cli';
+import {runCLI} from '../../cli';
 
 const project = path.join(__dirname, '../__fixtures__/runCLI');
 const projects = [project];
 
 const argv = {
   config: {
-    testMatch: [
-      "<rootDir>/*_spec.js"
-    ],
+    testMatch: ['<rootDir>/*_spec.js'],
     transform: {
-      "^.+\\.jsx?$": () => {
-        return {
-          process(src, filename) {
-            return src.replace('toReplace', 'replaced');
-          },
-        };
-      }
-    }
+      '^.+\\.jsx?$': () => ({
+        process(src, filename) {
+          return src.replace('toReplace', 'replaced');
+        },
+      }),
+    },
   },
 };
 
@@ -38,14 +34,12 @@ describe('runCLI', () => {
       let error = null;
       try {
         runResult = await runCLI(argv, projects);
-      }
-      catch (ex) {
+      } catch (ex) {
         error = ex;
       }
-      let numPassedTests = runResult ? runResult.results.numPassedTests : -1;
+      const numPassedTests = runResult ? runResult.results.numPassedTests : -1;
       expect(error).toBe(null);
       expect(numPassedTests).toBe(1);
-    })
-  })
+    });
+  });
 });
-

--- a/packages/jest-cli/src/__tests__/cli/runCLI.test.js
+++ b/packages/jest-cli/src/__tests__/cli/runCLI.test.js
@@ -15,40 +15,34 @@ import transformModule from '../__fixtures__/runCLI/transform-module';
 const project = path.join(__dirname, '../__fixtures__/runCLI');
 const projects = [project];
 
-const processor = {
-  process: (src, filename) => transformModule.process(src, filename)
-};
-
 const argvObject = {
   config: {
     testMatch: ['<rootDir>/*_spec.js'],
     transform: {
-      '^.+\\.jsx?$': () => transformModule
+      '^.+\\.jsx?$': () => transformModule,
     },
   },
 };
 
 const argvString = {
   config: JSON.stringify({
-    "rootDir": project,
-    "testMatch": ["<rootDir>/*_spec.js"],
-    "transform": {
-      "^.+\\.jsx?$": "./transform-module"
-    }
+    rootDir: project,
+    testMatch: ['<rootDir>/*_spec.js'],
+    transform: {
+      '^.+\\.jsx?$': './transform-module',
+    },
   }),
-}
+};
 
 const processErrWriteFn = process.stderr.write;
 
 const noLogs = true;
 
 describe('runCLI', () => {
-  let stderrSpy;
   beforeEach(() => {
     if (noLogs) {
       process.stderr.write = jest.fn();
       process.stderr.write.mockReset();
-      stderrSpy = jest.spyOn(process.stderr, 'write');
     }
   });
 
@@ -88,4 +82,3 @@ describe('runCLI', () => {
     });
   });
 });
-

--- a/packages/jest-cli/src/__tests__/cli/runCLI.test.js
+++ b/packages/jest-cli/src/__tests__/cli/runCLI.test.js
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+import path from 'path';
+import { runCLI } from '../../cli';
+
+const project = path.join(__dirname, '../__fixtures__/runCLI');
+const projects = [project];
+
+const argv = {
+  config: {
+    testMatch: [
+      "<rootDir>/*_spec.js"
+    ],
+    transform: {
+      "^.+\\.jsx?$": () => {
+        return {
+          process(src, filename) {
+            return src.replace('toReplace', 'replaced');
+          },
+        };
+      }
+    }
+  },
+};
+
+describe('runCLI', () => {
+  describe('config as object', () => {
+    it('runs jest with a standalone config object', async () => {
+      let runResult = null;
+      let error = null;
+      try {
+        runResult = await runCLI(argv, projects);
+      }
+      catch (ex) {
+        error = ex;
+      }
+      let numPassedTests = runResult ? runResult.results.numPassedTests : -1;
+      expect(error).toBe(null);
+      expect(numPassedTests).toBe(1);
+    })
+  })
+});
+

--- a/packages/jest-cli/src/cli/index.js
+++ b/packages/jest-cli/src/cli/index.js
@@ -33,7 +33,7 @@ import {sync as realpath} from 'realpath-native';
 import init from '../lib/init';
 import logDebugMessages from '../lib/log_debug_messages';
 
-export async function run(maybeArgv?: Argv, project?: Path) {
+export async function run(maybeArgv?: Argv, project?: Path, logAndExitOnError?: Boolean = true) {
   try {
     const argv: Argv = buildArgv(maybeArgv, project);
 
@@ -46,11 +46,14 @@ export async function run(maybeArgv?: Argv, project?: Path) {
 
     const {results, globalConfig} = await runCLI(argv, projects);
     readResultsAndExit(results, globalConfig);
+    return results;
   } catch (error) {
-    clearLine(process.stderr);
-    clearLine(process.stdout);
-    console.error(chalk.red(error.stack));
-    exit(1);
+    if (logAndExitOnError) {
+      clearLine(process.stderr);
+      clearLine(process.stdout);
+      console.error(chalk.red(error.stack));
+      exit(1);
+    }
     throw error;
   }
 }

--- a/packages/jest-cli/src/cli/index.js
+++ b/packages/jest-cli/src/cli/index.js
@@ -43,7 +43,7 @@ export const run = async (
 
     if (argv.init) {
       await init();
-      return Promise.resolve(results);
+      return results;
     }
 
     const projects = getProjectListFromCLIArgs(argv, project);

--- a/packages/jest-cli/src/cli/index.js
+++ b/packages/jest-cli/src/cli/index.js
@@ -36,7 +36,7 @@ import logDebugMessages from '../lib/log_debug_messages';
 export const run = async (
   maybeArgv?: Argv,
   project?: Path,
-): Promise<AggregatedResult> => {
+): Promise<?AggregatedResult> => {
   let results, globalConfig;
   try {
     const argv: Argv = buildArgv(maybeArgv, project);

--- a/packages/jest-cli/src/cli/index.js
+++ b/packages/jest-cli/src/cli/index.js
@@ -33,20 +33,23 @@ import {sync as realpath} from 'realpath-native';
 import init from '../lib/init';
 import logDebugMessages from '../lib/log_debug_messages';
 
-export async function run(maybeArgv?: Argv, project?: Path) {
+export const run = async (
+  maybeArgv?: Argv,
+  project?: Path,
+): Promise<AggregatedResult> => {
+  let results, globalConfig;
   try {
     const argv: Argv = buildArgv(maybeArgv, project);
 
     if (argv.init) {
       await init();
-      return;
+      return Promise.resolve(results);
     }
 
     const projects = getProjectListFromCLIArgs(argv, project);
 
-    const {results, globalConfig} = await runCLI(argv, projects);
+    ({results, globalConfig} = await runCLI(argv, projects));
     readResultsAndExit(results, globalConfig);
-    return results;
   } catch (error) {
     clearLine(process.stderr);
     clearLine(process.stdout);
@@ -54,7 +57,8 @@ export async function run(maybeArgv?: Argv, project?: Path) {
     exit(1);
     throw error;
   }
-}
+  return Promise.resolve(results);
+};
 
 export const runCLI = async (
   argv: Argv,

--- a/packages/jest-config/src/__tests__/normalize.test.js
+++ b/packages/jest-config/src/__tests__/normalize.test.js
@@ -1119,7 +1119,8 @@ describe('preset', () => {
       '/node_modules/a',
       '/node_modules/b',
     ]);
-    expect(options.transform).toEqual([
+    const sorter = (a, b) => a[0].localeCompare(b[0]);
+    expect(options.transform.sort(sorter)).toEqual([
       ['a', '/node_modules/a'],
       ['b', '/node_modules/b'],
       ['c', aFunction],

--- a/packages/jest-config/src/__tests__/normalize.test.js
+++ b/packages/jest-config/src/__tests__/normalize.test.js
@@ -285,7 +285,7 @@ describe('transform', () => {
     Resolver.findNodeModule = jest.fn(name => name);
   });
 
-  it('normalizes the path', () => {
+  it('normalizes the path if it is a string', () => {
     const {options} = normalize(
       {
         rootDir: '/root/',
@@ -301,6 +301,28 @@ describe('transform', () => {
     expect(options.transform).toEqual([
       [DEFAULT_CSS_PATTERN, '/root/node_modules/jest-regex-util'],
       [DEFAULT_JS_PATTERN, require.resolve('babel-jest')],
+      ['abs-path', '/qux/quux'],
+    ]);
+  });
+
+  it('does not normalize the path if it is a function', () => {
+    const theFunction = () => {}
+
+    const { options } = normalize(
+      {
+        rootDir: '/root/',
+        transform: {
+          [DEFAULT_CSS_PATTERN]: '<rootDir>/node_modules/jest-regex-util',
+          [DEFAULT_JS_PATTERN]: theFunction,
+          'abs-path': '/qux/quux',
+        },
+      },
+      {},
+    );
+
+    expect(options.transform).toEqual([
+      [DEFAULT_CSS_PATTERN, '/root/node_modules/jest-regex-util'],
+      [DEFAULT_JS_PATTERN, theFunction],
       ['abs-path', '/qux/quux'],
     ]);
   });
@@ -1077,6 +1099,8 @@ describe('preset', () => {
   });
 
   test('merges with options', () => {
+    const aFunction = () => {};
+
     const {options} = normalize(
       {
         moduleNameMapper: {a: 'a'},
@@ -1084,7 +1108,7 @@ describe('preset', () => {
         preset: 'react-native',
         rootDir: '/root/path/foo',
         setupFiles: ['a'],
-        transform: {a: 'a'},
+        transform: {a: 'a', c: aFunction},
       },
       {},
     );
@@ -1098,6 +1122,7 @@ describe('preset', () => {
     expect(options.transform).toEqual([
       ['a', '/node_modules/a'],
       ['b', '/node_modules/b'],
+      ['c', aFunction]
     ]);
   });
 

--- a/packages/jest-config/src/__tests__/normalize.test.js
+++ b/packages/jest-config/src/__tests__/normalize.test.js
@@ -306,9 +306,9 @@ describe('transform', () => {
   });
 
   it('does not normalize the path if it is a function', () => {
-    const theFunction = () => {}
+    const theFunction = () => {};
 
-    const { options } = normalize(
+    const {options} = normalize(
       {
         rootDir: '/root/',
         transform: {
@@ -1122,7 +1122,7 @@ describe('preset', () => {
     expect(options.transform).toEqual([
       ['a', '/node_modules/a'],
       ['b', '/node_modules/b'],
-      ['c', aFunction]
+      ['c', aFunction],
     ]);
   });
 

--- a/packages/jest-config/src/index.js
+++ b/packages/jest-config/src/index.js
@@ -60,7 +60,10 @@ export function readConfig(
         'Jest: Cannot use configuration as an object without a file path.',
       );
     }
-  } else if (argv.config && (typeof argv.config === 'object' || isJSONString(argv.config))) {
+  } else if (
+    argv.config &&
+    (typeof argv.config === 'object' || isJSONString(argv.config))
+  ) {
     // A JSON string was passed to `--config` argument and we can parse it
     // and use as is.
     let config;

--- a/packages/jest-config/src/index.js
+++ b/packages/jest-config/src/index.js
@@ -60,16 +60,20 @@ export function readConfig(
         'Jest: Cannot use configuration as an object without a file path.',
       );
     }
-  } else if (isJSONString(argv.config)) {
+  } else if (argv.config && (typeof argv.config === 'object' || isJSONString(argv.config))) {
     // A JSON string was passed to `--config` argument and we can parse it
     // and use as is.
     let config;
-    try {
-      config = JSON.parse(argv.config);
-    } catch (e) {
-      throw new Error(
-        'There was an error while parsing the `--config` argument as a JSON string.',
-      );
+    if (typeof argv.config === 'object') {
+      config = argv.config;
+    } else {
+      try {
+        config = JSON.parse(argv.config);
+      } catch (e) {
+        throw new Error(
+          'There was an error while parsing the `--config` argument as a JSON string.',
+        );
+      }
     }
 
     // NOTE: we might need to resolve this dir to an absolute path in the future

--- a/packages/jest-config/src/normalize.js
+++ b/packages/jest-config/src/normalize.js
@@ -535,11 +535,15 @@ export default function normalize(options: InitialOptions, argv: Argv) {
           transform &&
           Object.keys(transform).map(regex => [
             regex,
-            resolve(newOptions.resolver, {
-              filePath: transform[regex],
-              key,
-              rootDir: options.rootDir,
-            }),
+            typeof transform[regex] === 'string'
+            ?
+              resolve(newOptions.resolver, {
+                filePath: transform[regex],
+                key,
+                rootDir: options.rootDir,
+              })
+            :
+              transform[regex]
           ]);
         break;
       case 'coveragePathIgnorePatterns':

--- a/packages/jest-config/src/normalize.js
+++ b/packages/jest-config/src/normalize.js
@@ -144,7 +144,11 @@ const setupBabelJest = (options: InitialOptions) => {
       if (customJSTransformer === 'babel-jest') {
         babelJest = require.resolve('babel-jest');
         transform[customJSPattern] = babelJest;
-      } else if (customJSTransformer && customJSTransformer.includes && customJSTransformer.includes('babel-jest')) {
+      } else if (
+        customJSTransformer &&
+        customJSTransformer.includes &&
+        customJSTransformer.includes('babel-jest')
+      ) {
         babelJest = customJSTransformer;
       }
     }

--- a/packages/jest-config/src/normalize.js
+++ b/packages/jest-config/src/normalize.js
@@ -144,7 +144,7 @@ const setupBabelJest = (options: InitialOptions) => {
       if (customJSTransformer === 'babel-jest') {
         babelJest = require.resolve('babel-jest');
         transform[customJSPattern] = babelJest;
-      } else if (customJSTransformer.includes('babel-jest')) {
+      } else if (customJSTransformer && customJSTransformer.includes && customJSTransformer.includes('babel-jest')) {
         babelJest = customJSTransformer;
       }
     }

--- a/packages/jest-config/src/normalize.js
+++ b/packages/jest-config/src/normalize.js
@@ -536,14 +536,12 @@ export default function normalize(options: InitialOptions, argv: Argv) {
           Object.keys(transform).map(regex => [
             regex,
             typeof transform[regex] === 'string'
-            ?
-              resolve(newOptions.resolver, {
-                filePath: transform[regex],
-                key,
-                rootDir: options.rootDir,
-              })
-            :
-              transform[regex]
+              ? resolve(newOptions.resolver, {
+                  filePath: transform[regex],
+                  key,
+                  rootDir: options.rootDir,
+                })
+              : transform[regex],
           ]);
         break;
       case 'coveragePathIgnorePatterns':

--- a/packages/jest-runtime/src/__tests__/__snapshots__/script_transformer.test.js.snap
+++ b/packages/jest-runtime/src/__tests__/__snapshots__/script_transformer.test.js.snap
@@ -195,3 +195,37 @@ exports[`ScriptTransformer uses the supplied preprocessor 2`] = `
 "({\\"Object.<anonymous>\\":function(module,exports,require,__dirname,__filename,global,jest){module.exports = \\"react\\";
 }});"
 `;
+
+exports[`ScriptTransformer uses the supplied preprocessor if it is a file path 1`] = `
+"({\\"Object.<anonymous>\\":function(module,exports,require,__dirname,__filename,global,jest){
+          const TRANSFORMED = {
+            filename: '/fruits/banana.js',
+            script: 'module.exports = \\"banana\\";',
+            config: '{\\"cache\\":true,\\"cacheDirectory\\":\\"/cache/\\",\\"name\\":\\"test\\",\\"rootDir\\":\\"/\\",\\"transformIgnorePatterns\\":[\\"/node_modules/\\"],\\"transform\\":[[\\"^.+\\\\\\\\.js$\\",\\"test_preprocessor\\"]]}',
+          };
+        
+}});"
+`;
+
+exports[`ScriptTransformer uses the supplied preprocessor if it is a file path 2`] = `
+"({\\"Object.<anonymous>\\":function(module,exports,require,__dirname,__filename,global,jest){module.exports = \\"react\\";
+}});"
+`;
+
+exports[`ScriptTransformer uses the supplied preprocessor if it is a function 1`] = `
+"({\\"Object.<anonymous>\\":function(module,exports,require,__dirname,__filename,global,jest){
+          const TRANSFORMED = {
+            filename: '/fruits/banana.js',
+            script: 'module.exports = \\"banana\\";',
+            config: '{\\"cache\\":true,\\"cacheDirectory\\":\\"/cache/\\",\\"name\\":\\"test\\",\\"rootDir\\":\\"/\\",\\"transformIgnorePatterns\\":[\\"/node_modules/\\"],\\"transform\\":[[\\"^.+\\\\\\\\.js$\\",null]]}',
+          };
+        
+}});"
+`;
+
+exports[`ScriptTransformer uses the supplied preprocessor if it is a function 2`] = `"module.exports = \\"banana\\";"`;
+
+exports[`ScriptTransformer uses the supplied preprocessor if it is a function 3`] = `
+"({\\"Object.<anonymous>\\":function(module,exports,require,__dirname,__filename,global,jest){module.exports = \\"react\\";
+}});"
+`;

--- a/packages/jest-runtime/src/__tests__/__snapshots__/script_transformer.test.js.snap
+++ b/packages/jest-runtime/src/__tests__/__snapshots__/script_transformer.test.js.snap
@@ -180,22 +180,6 @@ exports[`ScriptTransformer uses multiple preprocessors 3`] = `
 }});"
 `;
 
-exports[`ScriptTransformer uses the supplied preprocessor 1`] = `
-"({\\"Object.<anonymous>\\":function(module,exports,require,__dirname,__filename,global,jest){
-          const TRANSFORMED = {
-            filename: '/fruits/banana.js',
-            script: 'module.exports = \\"banana\\";',
-            config: '{\\"cache\\":true,\\"cacheDirectory\\":\\"/cache/\\",\\"name\\":\\"test\\",\\"rootDir\\":\\"/\\",\\"transformIgnorePatterns\\":[\\"/node_modules/\\"],\\"transform\\":[[\\"^.+\\\\\\\\.js$\\",\\"test_preprocessor\\"]]}',
-          };
-        
-}});"
-`;
-
-exports[`ScriptTransformer uses the supplied preprocessor 2`] = `
-"({\\"Object.<anonymous>\\":function(module,exports,require,__dirname,__filename,global,jest){module.exports = \\"react\\";
-}});"
-`;
-
 exports[`ScriptTransformer uses the supplied preprocessor if it is a file path 1`] = `
 "({\\"Object.<anonymous>\\":function(module,exports,require,__dirname,__filename,global,jest){
           const TRANSFORMED = {

--- a/packages/jest-runtime/src/script_transformer.js
+++ b/packages/jest-runtime/src/script_transformer.js
@@ -148,11 +148,9 @@ export default class ScriptTransformer {
 
     const transformFunctionOrPath = this._getTransformFunctionOrPath(filename);
     if (transformFunctionOrPath) {
-      let isTransformFunction = typeof transformFunctionOrPath === 'function';
-      if (isTransformFunction) {
-        transform = transformFunctionOrPath();
-      }
-      else {
+      if (typeof transformFunctionOrPath === 'function') {
+        transform = (transformFunctionOrPath(): Transformer);
+      } else {
         const transformer = this._transformCache.get(transformFunctionOrPath);
         if (transformer != null) {
           return transformer;
@@ -169,7 +167,7 @@ export default class ScriptTransformer {
           'Jest: a transform must export a `process` function.',
         );
       }
-      if (!isTransformFunction) {
+      if (typeof transformFunctionOrPath !== 'function') {
         this._transformCache.set(transformFunctionOrPath, transform);
       }
     }


### PR DESCRIPTION
Currently with `jest.runCLI` you can only pass JSON parseable strings like this:

```
const jest = require('jest);

jest.runCLI(
  {
    config: '{ "testMatch": "<rootDir>/test/*_spec.js", "transform": { "^.+\\.jsx?$": "require-path-to-transform" } }'
  }
);
```


If we want to create a utility function to run jest with a custom configuration like:

```
const jest = require('jest);

function runJest(someOptions) {
  jest.runCLI({ config: createConfigFromOptions(someOptions) });
}
```


We run into the problem that `createConfigFromOptions` can only configure the preprocessor transforms by specifying path to files, leading to the need to split the configuration across multiple source files.

With this PR that workflow is much nicer in that you can just do:

```
const jest = require('jest');

jest.runCLI(
  {
    config: {
      testMatch: [
        "<rootDir>/**/*_spec.js"
      ],
      transform: {
        "^.+\\.jsx?$": () => ({
          process: (src, filename) => src + 'you can transform the file src right here'
        })
      }
    }
  }
);
```
No extra source files required for the transform to work! :-)

Several tests were added to show that it works properly, including a new test that actually calls `jest.runCLI` from within a test!
