### PR TITLE
Fix Custom Matchers API example message property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@
 
 ### Chore & Maintenance
 
+- `[docs]` Fix message property in custom matcher example to return a function instead of a constant.
 - `[jest-watcher]` Standardize filenames ([#7314](https://github.com/facebook/jest/pull/7314))
 - `[jest-circus]` Standardize file naming in `jest-circus` ([#7301](https://github.com/facebook/jest/pull/7301))
 - `[docs]` Add synchronous test.each setup ([#7150](https://github.com/facebook/jest/pull/7150))

--- a/docs/ExpectAPI.md
+++ b/docs/ExpectAPI.md
@@ -107,7 +107,7 @@ expect.extend({
   yourMatcher(x, y, z) {
     return {
       pass: true,
-      message: '',
+      message: () => '',
     };
   },
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
The example for a custom matcher 'message' property returns a string, it should be a function.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
`Types of property 'message' are incompatible. Type 'string' is not assignable to type '() => string'` so updated accordingly