### PR TITLE
Correct example usage of `expect().rejects`

### DIFF
--- a/website/versioned_docs/version-23.6/ExpectAPI.md
+++ b/website/versioned_docs/version-23.6/ExpectAPI.md
@@ -501,7 +501,7 @@ For example, this code tests that the promise rejects with reason `'octopus'`:
 ```js
 test('rejects to octopus', () => {
   // make sure to add a return statement
-  return expect(Promise.reject(new Error('octopus'))).rejects.toThrow(
+  return expect(Promise.reject(new Error('octopus'))).rejects.toEqual(
     'octopus',
   );
 });
@@ -513,7 +513,7 @@ Alternatively, you can use `async/await` in combination with `.rejects`.
 
 ```js
 test('rejects to octopus', async () => {
-  await expect(Promise.reject(new Error('octopus'))).rejects.toThrow('octopus');
+  await expect(Promise.reject(new Error('octopus'))).rejects.toEqual('octopus');
 });
 ```
 


### PR DESCRIPTION
I tried following the docs to learn how `expect().rejects` works, but I couldn't get my tests to pass. I then found https://jestjs.io/docs/en/tutorial-async#rejects and that got my tests to pass. This PR updates the docs to match.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
