### PR TITLE
Update CLI documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@
 - `[jest-haste-map]` Refactor `dependencyExtractor` and tests ([#7385](https://github.com/facebook/jest/pull/7385))
 - `[docs]` Clarify conditional setting of `NODE_ENV` ([#7369](https://github.com/facebook/jest/pull/7369))
 - `[*]` Standardize file names ([#7316](https://github.com/facebook/jest/pull/7316), [#7266](https://github.com/facebook/jest/pull/7266), [#7238](https://github.com/facebook/jest/pull/7238), [#7314](https://github.com/facebook/jest/pull/7314))
+- `[docs]` Add `testPathIgnorePatterns` in CLI documentation ([#7440](https://github.com/facebook/jest/pull/7440))
 
 ### Performance
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -268,6 +268,10 @@ Note that `column` is 0-indexed while `line` is not.
 
 A regexp pattern string that is matched against all tests paths before executing the test. On Windows, you will need to use `/` as a path separator or escape `\` as `\\`.
 
+### `--testPathIgnorePatterns=[array]`
+
+An array of regexp pattern strings that is tested against all tests paths before executing the test. Contrary to `--testPathPattern`, it will only run those test with a path that does not match with the provided regexp expressions.
+
 ### `--testRunner=<path>`
 
 Lets you specify a custom test runner.


### PR DESCRIPTION
## Summary

testPathIgnorePatterns exist as part of the [SearchSource](https://github.com/facebook/jest/blob/d5c74a2a6b62f50f3c54e322f8f4fa703d5c3393/packages/jest-cli/src/SearchSource.js#L72) but it is not documented. I provide a simple definition so people can use it. 