### PR TITLE
Test environment gets current file path as option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - `[jest-worker]` Add node worker-thread support to jest-worker ([#7408](https://github.com/facebook/jest/pull/7408))
 - `[jest-config]` Allow `bail` setting to be configured with a number allowing tests to abort after `n` of failures ([#7335](https://github.com/facebook/jest/pull/7335))
 - `[jest-config]` Allow % based configuration of `--max-workers` ([#7494](https://github.com/facebook/jest/pull/7494))
+- `[jest-runner]` Instantiate the test environment class with the current `testPath` ([#7442](https://github.com/facebook/jest/pull/7442))
 
 ### Fixes
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -771,13 +771,14 @@ Example:
 const NodeEnvironment = require('jest-environment-node');
 
 class CustomEnvironment extends NodeEnvironment {
-  constructor(config) {
-    super(config);
+  constructor(config, context) {
+    super(config, context);
+    this.testPath = context.testPath;
   }
 
   async setup() {
     await super.setup();
-    await someSetupTasks();
+    await someSetupTasks(this.testPath);
     this.global.someGlobalObject = createGlobalObject();
   }
 

--- a/e2e/__tests__/test_environment_async.test.js
+++ b/e2e/__tests__/test_environment_async.test.js
@@ -9,6 +9,7 @@
 'use strict';
 
 import fs from 'fs';
+import path from 'path';
 import os from 'os';
 import runJest from '../runJest';
 import {cleanup} from '../Utils';
@@ -19,8 +20,18 @@ beforeEach(() => cleanup(DIR));
 afterAll(() => cleanup(DIR));
 
 it('triggers setup/teardown hooks', () => {
+  const testDir = path.resolve(
+    __dirname,
+    '..',
+    'test-environment-async',
+    '__tests__',
+  );
+  const testFile = path.join(testDir, 'custom.test.js');
+
   const result = runJest('test-environment-async');
   expect(result.status).toBe(0);
+  expect(result.stdout).toContain(`TestEnvironment.setup: ${testFile}`);
+
   const teardown = fs.readFileSync(DIR + '/teardown', 'utf8');
   expect(teardown).toBe('teardown');
 });

--- a/e2e/test-environment-async/TestEnvironment.js
+++ b/e2e/test-environment-async/TestEnvironment.js
@@ -10,11 +10,13 @@ const JSDOMEnvironment = require('jest-environment-jsdom');
 const DIR = os.tmpdir() + '/jest-test-environment';
 
 class TestEnvironment extends JSDOMEnvironment {
-  constructor(config) {
-    super(config);
+  constructor(config, context) {
+    super(config, context);
+    this.context = context;
   }
 
   setup() {
+    console.info('TestEnvironment.setup:', this.context.testPath);
     return super.setup().then(() => {
       this.global.setup = 'setup';
     });

--- a/packages/jest-environment-jsdom/src/index.js
+++ b/packages/jest-environment-jsdom/src/index.js
@@ -8,7 +8,7 @@
 
 import type {Script} from 'vm';
 import type {ProjectConfig} from 'types/Config';
-import type {EnvironmentOptions} from 'types/Environment';
+import type {EnvironmentContext} from 'types/Environment';
 import type {Global} from 'types/Global';
 import type {ModuleMocker} from 'jest-mock';
 
@@ -23,7 +23,7 @@ class JSDOMEnvironment {
   errorEventListener: ?Function;
   moduleMocker: ?ModuleMocker;
 
-  constructor(config: ProjectConfig, options?: EnvironmentOptions = {}) {
+  constructor(config: ProjectConfig, options?: EnvironmentContext = {}) {
     this.dom = new JSDOM(
       '<!DOCTYPE html>',
       Object.assign(

--- a/packages/jest-runner/src/runTest.js
+++ b/packages/jest-runner/src/runTest.js
@@ -101,7 +101,10 @@ async function runTestInternal(
     testConsole = new BufferedConsole(() => runtime && runtime.getSourceMaps());
   }
 
-  const environment = new TestEnvironment(config, {console: testConsole});
+  const environment = new TestEnvironment(config, {
+    console: testConsole,
+    testPath: path,
+  });
   const leakDetector = config.detectLeaks
     ? new LeakDetector(environment)
     : null;

--- a/types/Environment.js
+++ b/types/Environment.js
@@ -12,12 +12,13 @@ import type {Global} from './Global';
 import type {Script} from 'vm';
 import type {ModuleMocker} from 'jest-mock';
 
-export type EnvironmentOptions = {
+export type EnvironmentContext = {
   console?: Object,
+  testPath?: string,
 };
 
 declare class $JestEnvironment {
-  constructor(config: ProjectConfig, options?: EnvironmentOptions): void;
+  constructor(config: ProjectConfig, context?: EnvironmentContext): void;
   runScript(script: Script): any;
   global: Global;
   fakeTimers: {


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

The [`testEnvironment`](https://jestjs.io/docs/en/configuration#testenvironment-string) feature enables a whole new suite of tests to be written with Jest.

However the following use case can present itself:

1. an application has an async setup with involves a connection task and a resource bootstrapping task (e.g. prepare some external resources).
2. the application's connection task is slow, but is safe to run several times (since it has already initialized connections to the external resources) - so running this in a `setupFiles` is less than optimal, as we would pay the price for this task on each test file
1. the application's bootstrap task needs to be configurable per test file - we currently don't have any option to do this.
1. the application's bootstrap task can not run in the test file context, because the connection task was not run in the same context (due to the time penalty described in 2.)

PS: Related #6889

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

```
$ node ./packages/jest-cli/bin/jest.js test_environment_async
 PASS  e2e/__tests__/test_environment_async.test.js
  ✓ triggers setup/teardown hooks (861ms)

Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        1.288s, estimated 2s
Ran all test suites matching /test_environment_async/i.
```