### PR TITLE
pretty-format: Omit non-enumerable symbol properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,7 +77,7 @@
 - `[jest-haste-map]` Remove legacy condition for duplicate module detection ([#7333](https://github.com/facebook/jest/pull/7333))
 - `[jest-haste-map]` Fix `require` detection with trailing commas and ignore `import typeof` modules ([#7385](https://github.com/facebook/jest/pull/7385))
 - `[jest-cli]` Fix to set prettierPath via config file ([#7412](https://github.com/facebook/jest/pull/7412))
-- `[pretty-format]` [**BREAKING**] Omit non-enumerable symbol properties ([#7363](https://github.com/facebook/jest/pull/7448))
+- `[pretty-format]` [**BREAKING**] Omit non-enumerable symbol properties ([#7448](https://github.com/facebook/jest/pull/7448))
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@
 - `[jest-haste-map]` Remove legacy condition for duplicate module detection ([#7333](https://github.com/facebook/jest/pull/7333))
 - `[jest-haste-map]` Fix `require` detection with trailing commas and ignore `import typeof` modules ([#7385](https://github.com/facebook/jest/pull/7385))
 - `[jest-cli]` Fix to set prettierPath via config file ([#7412](https://github.com/facebook/jest/pull/7412))
+- `[pretty-format]` [**BREAKING**] Omit non-enumerable symbol properties ([#7363](https://github.com/facebook/jest/pull/7448))
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - `[jest-cli]` [**BREAKING**] Do not use `text-summary` coverage reporter by default if other reporters are configured ([#7058](https://github.com/facebook/jest/pull/7058))
 - `[jest-mock]` [**BREAKING**] Fix bugs with mock/spy result tracking of recursive functions ([#6381](https://github.com/facebook/jest/pull/6381))
 - `[jest-haste-map]` [**BREAKING**] Recover files correctly after haste name collisions are fixed ([#7329](https://github.com/facebook/jest/pull/7329))
+- `[pretty-format]` [**BREAKING**] Omit non-enumerable symbol properties ([#7448](https://github.com/facebook/jest/pull/7448))
 - `[expect]` Standardize file naming in `expect` ([#7306](https://github.com/facebook/jest/pull/7306))
 - `[jest-each]` Add empty array validation check ([#7249](https://github.com/facebook/jest/pull/7249))
 - `[jest-cli]` Interrupt tests if interactive watch plugin key is pressed ([#7222](https://github.com/facebook/jest/pull/7222))
@@ -77,7 +78,6 @@
 - `[jest-haste-map]` Remove legacy condition for duplicate module detection ([#7333](https://github.com/facebook/jest/pull/7333))
 - `[jest-haste-map]` Fix `require` detection with trailing commas and ignore `import typeof` modules ([#7385](https://github.com/facebook/jest/pull/7385))
 - `[jest-cli]` Fix to set prettierPath via config file ([#7412](https://github.com/facebook/jest/pull/7412))
-- `[pretty-format]` [**BREAKING**] Omit non-enumerable symbol properties ([#7448](https://github.com/facebook/jest/pull/7448))
 
 ### Chore & Maintenance
 

--- a/packages/pretty-format/src/__tests__/prettyFormat.test.js
+++ b/packages/pretty-format/src/__tests__/prettyFormat.test.js
@@ -261,6 +261,30 @@ describe('prettyFormat()', () => {
     );
   });
 
+  it('prints an object without non-enumerable properties which have string key', () => {
+    const val: any = {
+      enumerable: true,
+    };
+    const key = 'non-enumerable';
+    Object.defineProperty(val, key, {
+      enumerable: false,
+      value: false,
+    });
+    expect(prettyFormat(val)).toEqual('Object {\n  "enumerable": true,\n}');
+  });
+
+  it('prints an object without non-enumerable properties which have symbol key', () => {
+    const val: any = {
+      enumerable: true,
+    };
+    const key = Symbol('non-enumerable');
+    Object.defineProperty(val, key, {
+      enumerable: false,
+      value: false,
+    });
+    expect(prettyFormat(val)).toEqual('Object {\n  "enumerable": true,\n}');
+  });
+
   it('prints an object with sorted properties', () => {
     /* eslint-disable sort-keys */
     const val = {b: 1, a: 2};

--- a/packages/pretty-format/src/collections.js
+++ b/packages/pretty-format/src/collections.js
@@ -162,7 +162,10 @@ export function printObjectProperties(
 ): string {
   let result = '';
   let keys = Object.keys(val).sort();
-  const symbols = getSymbols(val);
+  const symbols = getSymbols(val).filter(
+    //$FlowFixMe because property enumerable is missing in undefined
+    symbol => Object.getOwnPropertyDescriptor(val, symbol).enumerable,
+  );
 
   if (symbols.length) {
     keys = keys.filter(key => !isSymbol(key)).concat(symbols);


### PR DESCRIPTION
## Summary

Fixes #7443

Breaking change for upcoming major upgrade to Jest 24

cc @austinalameda @mweststrate

Goals:

* Make snapshot tests consistent with `toEqual` matcher.
* Omit implementation details from formatted object instances (for example, jsdom element or MobX observable).

## Test plan

Added 2 test cases:

| before | after | description |
| :--- | :--- | :--- |
| passed | passed | prints an object without non-enumerable properties which have string key |
| failed | passed | prints an object without non-enumerable properties which have symbol key |