### PR TITLE
Add Jest Architecture overview to docs.

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -1,0 +1,8 @@
+---
+id: architecture
+title: Architecture
+---
+
+If you are interested in learning more about how Jest works, what the architecture behind the framework is, and how Jest is split up into individual reusable packages, check out this video:
+
+<iframe width="560" height="315" src="https://www.youtube.com/embed/3YDiloj8_d0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -23,7 +23,8 @@
       "tutorial-jquery",
       "watch-plugins",
       "migration-guide",
-      "troubleshooting"
+      "troubleshooting",
+      "architecture"
     ],
     "Framework Guides": [
       "tutorial-react",


### PR DESCRIPTION
## Summary
This adds the video discussing Jest's architecture to the "Guides" section of the docs. It's me, staring at your empty eyes as you try to grasp the silly architecture we came up with. Yay!

## Test plan

Looks like this:
<img width="707" alt="screen shot 2018-12-03 at 11 07 59" src="https://user-images.githubusercontent.com/13352/49349013-ea182b00-f6eb-11e8-9080-6b56a290cfca.png">
