### PR TITLE
Document mockReturnValue not working with new

### DIFF
--- a/website/versioned_docs/version-22.2/MockFunctionAPI.md
+++ b/website/versioned_docs/version-22.2/MockFunctionAPI.md
@@ -176,7 +176,7 @@ jest.fn(function() {
 
 ### `mockFn.mockReturnValue(value)`
 
-Accepts a value that will be returned whenever the mock function is called.
+Accepts a value that will be returned whenever the mock function is called (unless called using the `new` keyword).
 
 ```js
 const mock = jest.fn();


### PR DESCRIPTION
Unless I'm much mistaken, `mockReturnValue` is incompatible with `new`. This change documents that.

## Summary

Incorrect documentation

## Test plan

Documentation change - no tests
