### PR TITLE
Fix for pretty-format and react elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - `[jest-mock]` [**BREAKING**] Fix bugs with mock/spy result tracking of recursive functions ([#6381](https://github.com/facebook/jest/pull/6381))
 - `[jest-haste-map]` [**BREAKING**] Recover files correctly after haste name collisions are fixed ([#7329](https://github.com/facebook/jest/pull/7329))
 - `[pretty-format]` [**BREAKING**] Omit non-enumerable symbol properties ([#7448](https://github.com/facebook/jest/pull/7448))
+- `[pretty-format]` [**BREAKING**] Better formatting for React components using ForwardRef ([#7460](https://github.com/facebook/jest/pull/7460))
 - `[expect]` Standardize file naming in `expect` ([#7306](https://github.com/facebook/jest/pull/7306))
 - `[jest-each]` Add empty array validation check ([#7249](https://github.com/facebook/jest/pull/7249))
 - `[jest-cli]` Interrupt tests if interactive watch plugin key is pressed ([#7222](https://github.com/facebook/jest/pull/7222))

--- a/packages/pretty-format/src/plugins/ReactElement.js
+++ b/packages/pretty-format/src/plugins/ReactElement.js
@@ -37,6 +37,22 @@ const getChildren = (arg, children = []) => {
 
 const getType = element => {
   const type = element.type;
+  if (type.$$typeof === providerSymbol) {
+    return 'Context.Provider';
+  }
+
+  if (type.$$typeof === contextSymbol) {
+    return 'Context.Consumer';
+  }
+
+  if (type.$$typeof === forwardRefSymbol) {
+    const functionName = type.render.displayName || type.render.name || '';
+
+    return functionName !== ''
+      ? 'ForwardRef(' + functionName + ')'
+      : 'ForwardRef';
+  }
+
   if (typeof type === 'string') {
     return type;
   }
@@ -46,23 +62,7 @@ const getType = element => {
   if (type === fragmentSymbol) {
     return 'React.Fragment';
   }
-  if (typeof type === 'object' && type !== null) {
-    if (type.$$typeof === providerSymbol) {
-      return 'Context.Provider';
-    }
 
-    if (type.$$typeof === contextSymbol) {
-      return 'Context.Consumer';
-    }
-
-    if (type.$$typeof === forwardRefSymbol) {
-      const functionName = type.render.displayName || type.render.name || '';
-
-      return functionName !== ''
-        ? 'ForwardRef(' + functionName + ')'
-        : 'ForwardRef';
-    }
-  }
   return 'UNDEFINED';
 };
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

This PR fixes an issue with the pretty-format react plugin where it was only checking the `$$typeof` symbol for object element types. I found that function element types are possible with the `$$typeof` checks, so I moved those checks to before the `typeof type === function` check

The practical change is that in some scenarios, instead of printing 

```jsx
<Component />
```

We will now print

```jsx
<ForwardRef(Foo) />
```

## Test plan

I actually can't figure out how to write a test for this issue in our repo, but I did apply the change manually in https://github.com/rajivshah3/rn-broken-snapshot/tree/broken-example, where I discovered the issue, to confirm the fix

I suspect it's related to some combination of jest, react, react-native, and react-test-renderer
