### PR TITLE
Add support for external sourcemap files

### DIFF
--- a/packages/babel-jest/package.json
+++ b/packages/babel-jest/package.json
@@ -10,7 +10,8 @@
   "main": "build/index.js",
   "dependencies": {
     "babel-plugin-istanbul": "^4.1.6",
-    "babel-preset-jest": "^23.2.0"
+    "babel-preset-jest": "^23.2.0",
+    "convert-source-map": "^1.4.0"
   },
   "devDependencies": {
     "babel-core": "^6.0.0"

--- a/packages/babel-jest/src/index.js
+++ b/packages/babel-jest/src/index.js
@@ -15,6 +15,7 @@ import type {
   TransformedSource,
 } from 'types/Transform';
 
+import convertSourceMap from 'convert-source-map';
 import crypto from 'crypto';
 import fs from 'fs';
 import path from 'path';
@@ -140,6 +141,14 @@ const createTransformer = (options: any): Transformer => {
             },
           ],
         ]);
+      }
+
+      const sourceMapFromFile = convertSourceMap.fromMapFileSource(
+        src,
+        path.dirname(filename),
+      );
+      if (sourceMapFromFile) {
+        theseOptions.inputSourceMap = sourceMapFromFile.toObject();
       }
 
       // babel v7 might return null in the case when the file has been ignored.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Resolves https://github.com/facebook/jest/issues/5876, allowing colocated `.js.map` source maps.

**However**, it's worth noting that this has already been resolved in `@babel/core` v7 (https://github.com/babel/babel/pull/7980), so it might be better to close this PR and focusing on a Babel upgrade.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
I copied the `packages/babel-jest/build/index.js` file into `node_modules/babel-jest/build/index.js` of a separate TypeScript project then ran tests with coverage. Before it listed `.js` files in the coverage output, and afterwards it listed `.ts` files.

I would add unit tests, but before I do that, I'd like to know where the project is at in terms of upgrading Babel.

Thanks!