### PR TITLE
Allow % based configuration of max workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 
+- `[jest-cli]` Allow % based configuration of `--max-workers`
 - `[jest-cli]` [**BREAKING**] Only set error process error codes when they are non-zero ([#7363](https://github.com/facebook/jest/pull/7363))
 - `[jest-config]` [**BREAKING**] Deprecate `setupTestFrameworkScriptFile` in favor of new `setupFilesAfterEnv` ([#7119](https://github.com/facebook/jest/pull/7119))
 - `[jest-worker]` [**BREAKING**] Add functionality to call a `setup` method in the worker before the first call and a `teardown` method when ending the farm ([#7014](https://github.com/facebook/jest/pull/7014))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Features
 
-- `[jest-cli]` Allow % based configuration of `--max-workers` ([#7494](https://github.com/facebook/jest/pull/7494))
+- `[jest-config]` Allow % based configuration of `--max-workers` ([#7494](https://github.com/facebook/jest/pull/7494))
 - `[jest-cli]` [**BREAKING**] Only set error process error codes when they are non-zero ([#7363](https://github.com/facebook/jest/pull/7363))
 - `[jest-config]` [**BREAKING**] Deprecate `setupTestFrameworkScriptFile` in favor of new `setupFilesAfterEnv` ([#7119](https://github.com/facebook/jest/pull/7119))
 - `[jest-worker]` [**BREAKING**] Add functionality to call a `setup` method in the worker before the first call and a `teardown` method when ending the farm ([#7014](https://github.com/facebook/jest/pull/7014))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ### Features
 
-- `[jest-config]` Allow % based configuration of `--max-workers` ([#7494](https://github.com/facebook/jest/pull/7494))
 - `[jest-cli]` [**BREAKING**] Only set error process error codes when they are non-zero ([#7363](https://github.com/facebook/jest/pull/7363))
 - `[jest-config]` [**BREAKING**] Deprecate `setupTestFrameworkScriptFile` in favor of new `setupFilesAfterEnv` ([#7119](https://github.com/facebook/jest/pull/7119))
 - `[jest-worker]` [**BREAKING**] Add functionality to call a `setup` method in the worker before the first call and a `teardown` method when ending the farm ([#7014](https://github.com/facebook/jest/pull/7014))
@@ -36,6 +35,7 @@
 - `[expect]` `expect(Infinity).toBeCloseTo(Infinity)` Treats `Infinity` as equal in toBeCloseTo matcher ([#7405](https://github.com/facebook/jest/pull/7405))
 - `[jest-worker]` Add node worker-thread support to jest-worker ([#7408](https://github.com/facebook/jest/pull/7408))
 - `[jest-config]` Allow `bail` setting to be configured with a number allowing tests to abort after `n` of failures ([#7335](https://github.com/facebook/jest/pull/7335))
+- `[jest-config]` Allow % based configuration of `--max-workers` ([#7494](https://github.com/facebook/jest/pull/7494))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Features
 
-- `[jest-cli]` Allow % based configuration of `--max-workers`
+- `[jest-cli]` Allow % based configuration of `--max-workers` ([#7494](https://github.com/facebook/jest/pull/7494))
 - `[jest-cli]` [**BREAKING**] Only set error process error codes when they are non-zero ([#7363](https://github.com/facebook/jest/pull/7363))
 - `[jest-config]` [**BREAKING**] Deprecate `setupTestFrameworkScriptFile` in favor of new `setupFilesAfterEnv` ([#7119](https://github.com/facebook/jest/pull/7119))
 - `[jest-worker]` [**BREAKING**] Add functionality to call a `setup` method in the worker before the first call and a `teardown` method when ending the farm ([#7014](https://github.com/facebook/jest/pull/7014))

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -193,9 +193,11 @@ Lists all tests as JSON that Jest will run given the arguments, and exits. This 
 
 Logs the heap usage after every test. Useful to debug memory leaks. Use together with `--runInBand` and `--expose-gc` in node.
 
-### `--maxWorkers=<num>`
+### `--maxWorkers=<num>|<string>`
 
 Alias: `-w`. Specifies the maximum number of workers the worker-pool will spawn for running tests. This defaults to the number of the cores available on your machine. It may be useful to adjust this in resource limited environments like CIs but the default should be adequate for most use-cases.
+
+For environments which could be unknown or changable you can use percentage based configuration, `--maxWorkers=50%`
 
 ### `--noStackTrace`
 

--- a/packages/jest-config/src/__tests__/getMaxWorkers.test.js
+++ b/packages/jest-config/src/__tests__/getMaxWorkers.test.js
@@ -34,4 +34,21 @@ describe('getMaxWorkers', () => {
     expect(getMaxWorkers({})).toBe(3);
     expect(getMaxWorkers({watch: true})).toBe(2);
   });
+
+  describe('% based', () => {
+    it('50% = 2 workers', () => {
+      const argv = {maxWorkers: '50%'};
+      expect(getMaxWorkers(argv)).toBe(2);
+    });
+
+    it('< 0 workers should become 1', () => {
+      const argv = {maxWorkers: '1%'};
+      expect(getMaxWorkers(argv)).toBe(1);
+    });
+
+    it("0% shouldn't break", () => {
+      const argv = {maxWorkers: '0%'};
+      expect(getMaxWorkers(argv)).toBe(1);
+    });
+  });
 });

--- a/packages/jest-config/src/getMaxWorkers.js
+++ b/packages/jest-config/src/getMaxWorkers.js
@@ -15,7 +15,20 @@ export default function getMaxWorkers(argv: Argv): number {
   if (argv.runInBand) {
     return 1;
   } else if (argv.maxWorkers) {
-    return parseInt(argv.maxWorkers, 10);
+    const parsed = parseInt(argv.maxWorkers, 10);
+
+    if (
+      typeof argv.maxWorkers === 'string' &&
+      argv.maxWorkers.trim().endsWith('%') &&
+      parsed > 0 &&
+      parsed <= 100
+    ) {
+      const cpus = os.cpus().length;
+      const workers = Math.floor((parsed / 100) * cpus);
+      return workers >= 1 ? workers : 1;
+    }
+
+    return parsed > 0 ? parsed : 1;
   } else {
     const cpus = os.cpus() ? os.cpus().length : 1;
     return Math.max(argv.watch ? Math.floor(cpus / 2) : cpus - 1, 1);


### PR DESCRIPTION
## Summary

We have various machines in use between 4-16 threads but we always need to have spare threads available for other things like puppeteer/chrome. Doing this will allow simple `--maxWorkers=50%` to always have spare CPU available;

## Test plan
```
$ node ./packages/jest-cli/bin/jest.js getMaxWorkers.test.js
 PASS  packages/jest-config/src/__tests__/getMaxWorkers.test.js
  getMaxWorkers
    √ Returns 1 when runInBand (3ms)
    √ Returns 1 when the OS CPUs are not available (1ms)
    √ Returns the `maxWorkers` when specified
    √ Returns based on the number of cpus (1ms)
    % based
      √ 50% = 2 workers
      √ < 0 workers should become 1 (1ms)
      √ 0% shouldn't break

Test Suites: 1 passed, 1 total
Tests:       7 passed, 7 total
Snapshots:   0 total
Time:        1.315s, estimated 2s
Ran all test suites matching /getMaxWorkers.test.js/i.
Done in 2.96s.
```
