### PR TITLE
fix: Allow babel 7 as dependecy of config and runtime

### DIFF
--- a/packages/jest-config/package.json
+++ b/packages/jest-config/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "main": "build/index.js",
   "dependencies": {
-    "babel-core": "^6.0.0",
+    "babel-core": "^6.0.0 || ^7.0.0-0",
     "babel-jest": "^23.6.0",
     "chalk": "^2.0.1",
     "glob": "^7.1.1",

--- a/packages/jest-runtime/package.json
+++ b/packages/jest-runtime/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "main": "build/index.js",
   "dependencies": {
-    "babel-core": "^6.0.0",
+    "babel-core": "^6.0.0 || ^7.0.0-0",
     "babel-plugin-istanbul": "^4.1.6",
     "chalk": "^2.0.1",
     "convert-source-map": "^1.4.0",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
See issue #7433

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Not yet tested. I don't really know how to test with the packages actually being published as the problem is what version yarn places in the root node_module folder. This changes should allow yarn to not install babel-core v6 at all.

Fixes #7433