### PR TITLE
[jest-each] Use array.push instead of array.concat

### DIFF
--- a/packages/jest-each/src/bind.js
+++ b/packages/jest-each/src/bind.js
@@ -126,11 +126,12 @@ const isEmptyTable = table => table.length === 0;
 const isEmptyString = str => typeof str === 'string' && str.trim() === '';
 
 const getPrettyIndexes = placeholders =>
-  placeholders.reduce(
-    (indexes, placeholder, index) =>
-      placeholder === PRETTY_PLACEHOLDER ? indexes.concat(index) : indexes,
-    [],
-  );
+  placeholders.reduce((indexes, placeholder, index) => {
+    if (placeholder === PRETTY_PLACEHOLDER) {
+      indexes.push(index);
+    }
+    return indexes;
+  }, []);
 
 const arrayFormat = (title, rowIndex, ...args) => {
   const placeholders = title.match(SUPPORTED_PLACEHOLDERS) || [];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary
Array.push works faster than Array.concat for reduce.
I tested it with array (100 elements). In chrome it works more than 60x faster.
https://jsperf.com/reduce-concat-vs-reduce-push
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
