### PR TITLE
TestSequencer heuristic using dependency tree file sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
 
 ### Performance
 
+- `[jest-cli]` Better test order heuristics on first run without cache ([#7553](https://github.com/facebook/jest/pull/7553))
+
 ## 24.1.0
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 - `[jest-resolve-dependencies]` Add `DependencyResolver.resolveRecursive` ([#7553](https://github.com/facebook/jest/pull/7553))
+- `[jest-resolve-dependencies]` Add `DependencyResolver includeCoreModules` option ([#7553](https://github.com/facebook/jest/pull/7553))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Features
 
+- `[jest-resolve-dependencies]` Add `DependencyResolver.resolveRecursive` ([#7553](https://github.com/facebook/jest/pull/7553))
+
 ### Fixes
 
 - `[jest-cli]` Refactor `-o` and `--coverage` combined ([#7611](https://github.com/facebook/jest/pull/7611))

--- a/e2e/__tests__/__snapshots__/listTests.test.js.snap
+++ b/e2e/__tests__/__snapshots__/listTests.test.js.snap
@@ -3,6 +3,7 @@
 exports[`--listTests flag causes tests to be printed in different lines 1`] = `
 /MOCK_ABOLUTE_PATH/e2e/list-tests/__tests__/dummy.test.js
 /MOCK_ABOLUTE_PATH/e2e/list-tests/__tests__/other.test.js
+/MOCK_ABOLUTE_PATH/e2e/list-tests/__tests__/with-dep.test.js
 `;
 
-exports[`--listTests flag causes tests to be printed out as JSON when using the --json flag 1`] = `["/MOCK_ABOLUTE_PATH/e2e/list-tests/__tests__/dummy.test.js","/MOCK_ABOLUTE_PATH/e2e/list-tests/__tests__/other.test.js"]`;
+exports[`--listTests flag causes tests to be printed out as JSON when using the --json flag 1`] = `["/MOCK_ABOLUTE_PATH/e2e/list-tests/__tests__/dummy.test.js","/MOCK_ABOLUTE_PATH/e2e/list-tests/__tests__/other.test.js","/MOCK_ABOLUTE_PATH/e2e/list-tests/__tests__/with-dep.test.js"]`;

--- a/e2e/__tests__/listTests.test.js
+++ b/e2e/__tests__/listTests.test.js
@@ -35,6 +35,16 @@ describe('--listTests flag', () => {
     ).toMatchSnapshot();
   });
 
+  it('prints tests in the execution order determined by their dependency sizes', () => {
+    const {status, stdout} = runJest('list-tests', ['--listTests']);
+    expect(status).toBe(0);
+    expect(normalizePaths(stdout).split('\n')).toEqual([
+      expect.stringContaining('/with-dep.test.js'),
+      expect.stringContaining('/other.test.js'),
+      expect.stringContaining('/dummy.test.js'),
+    ]);
+  });
+
   it('causes tests to be printed out as JSON when using the --json flag', () => {
     const {status, stdout} = runJest('list-tests', ['--listTests', '--json']);
 

--- a/e2e/list-tests/__tests__/with-dep.test.js
+++ b/e2e/list-tests/__tests__/with-dep.test.js
@@ -7,10 +7,9 @@
 
 'use strict';
 
+require('./dummy.test.js');
+
 it("isn't actually run", () => {
   // (because it is only used for --listTests)
   expect(true).toBe(false);
 });
-
-// Because of this comment, other.test.js is slightly larger than dummy.test.js.
-// This matters for the order in which tests are sequenced.

--- a/packages/jest-resolve-dependencies/src/__tests__/__fixtures__/circular/a.js
+++ b/packages/jest-resolve-dependencies/src/__tests__/__fixtures__/circular/a.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+'use strict';
+
+require('./b');

--- a/packages/jest-resolve-dependencies/src/__tests__/__fixtures__/circular/b.js
+++ b/packages/jest-resolve-dependencies/src/__tests__/__fixtures__/circular/b.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+'use strict';
+
+require('./c');

--- a/packages/jest-resolve-dependencies/src/__tests__/__fixtures__/circular/c.js
+++ b/packages/jest-resolve-dependencies/src/__tests__/__fixtures__/circular/c.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+'use strict';
+
+require('./a');

--- a/packages/jest-resolve-dependencies/src/__tests__/__fixtures__/core.test.js
+++ b/packages/jest-resolve-dependencies/src/__tests__/__fixtures__/core.test.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+'use strict';
+
+require('fs');

--- a/packages/jest-resolve-dependencies/src/__tests__/__fixtures__/recursive/a.js
+++ b/packages/jest-resolve-dependencies/src/__tests__/__fixtures__/recursive/a.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+'use strict';
+
+require('./b');

--- a/packages/jest-resolve-dependencies/src/__tests__/__fixtures__/recursive/b.js
+++ b/packages/jest-resolve-dependencies/src/__tests__/__fixtures__/recursive/b.js
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+'use strict';
+
+require('./c1');
+require('./c2');

--- a/packages/jest-resolve-dependencies/src/__tests__/__fixtures__/recursive/c1.js
+++ b/packages/jest-resolve-dependencies/src/__tests__/__fixtures__/recursive/c1.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+'use strict';

--- a/packages/jest-resolve-dependencies/src/__tests__/__fixtures__/recursive/c2.js
+++ b/packages/jest-resolve-dependencies/src/__tests__/__fixtures__/recursive/c2.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+'use strict';

--- a/packages/jest-resolve-dependencies/src/__tests__/dependency_resolver.test.js
+++ b/packages/jest-resolve-dependencies/src/__tests__/dependency_resolver.test.js
@@ -64,6 +64,23 @@ describe('resolve', () => {
       expect.stringContaining(path.join('@myorg', 'pkg')),
     ]);
   });
+
+  describe('includeCoreModules', () => {
+    test('does not include core modules without the option', () => {
+      const resolved = dependencyResolver.resolve(
+        path.resolve(__dirname, '__fixtures__', 'core.test.js'),
+      );
+      expect(Array.from(resolved)).toEqual([]);
+    });
+
+    test('includes core modules with the option', () => {
+      const resolved = dependencyResolver.resolve(
+        path.resolve(__dirname, '__fixtures__', 'core.test.js'),
+        {includeCoreModules: true},
+      );
+      expect(Array.from(resolved)).toEqual(['fs']);
+    });
+  });
 });
 
 describe('resolveRecursive', () => {
@@ -91,6 +108,23 @@ describe('resolveRecursive', () => {
       expect.stringContaining('b.js'),
       expect.stringContaining('c.js'),
     ]);
+  });
+
+  describe('includeCoreModules', () => {
+    test('does not include core modules without the option', () => {
+      const resolved = dependencyResolver.resolveRecursive(
+        path.resolve(__dirname, '__fixtures__', 'core.test.js'),
+      );
+      expect(Array.from(resolved)).toEqual([]);
+    });
+
+    test('includes core modules with the option', () => {
+      const resolved = dependencyResolver.resolveRecursive(
+        path.resolve(__dirname, '__fixtures__', 'core.test.js'),
+        {includeCoreModules: true},
+      );
+      expect(Array.from(resolved)).toEqual(['fs']);
+    });
   });
 });
 

--- a/packages/jest-resolve-dependencies/src/__tests__/dependency_resolver.test.js
+++ b/packages/jest-resolve-dependencies/src/__tests__/dependency_resolver.test.js
@@ -40,66 +40,73 @@ beforeEach(() => {
   });
 });
 
-test('resolves no dependencies for non-existent path', () => {
-  const resolved = dependencyResolver.resolve('/non/existent/path');
-  expect(resolved.length).toEqual(0);
+describe('resolve', () => {
+  test('resolves no dependencies for non-existent path', () => {
+    const resolved = dependencyResolver.resolve('/non/existent/path');
+    expect(resolved.length).toEqual(0);
+  });
+
+  test('resolves dependencies for existing path', () => {
+    const resolved = dependencyResolver.resolve(
+      path.resolve(__dirname, '__fixtures__', 'file.js'),
+    );
+    expect(resolved).toEqual([
+      expect.stringContaining('jest-resolve-dependencies'),
+      expect.stringContaining('jest-regex-util'),
+    ]);
+  });
+
+  test('resolves dependencies for scoped packages', () => {
+    const resolved = dependencyResolver.resolve(
+      path.resolve(__dirname, '__fixtures__', 'scoped.js'),
+    );
+    expect(resolved).toEqual([
+      expect.stringContaining(path.join('@myorg', 'pkg')),
+    ]);
+  });
 });
 
-test('resolves dependencies for existing path', () => {
-  const resolved = dependencyResolver.resolve(
-    path.resolve(__dirname, '__fixtures__', 'file.js'),
-  );
-  expect(resolved).toEqual([
-    expect.stringContaining('jest-resolve-dependencies'),
-    expect.stringContaining('jest-regex-util'),
-  ]);
-});
+describe('resolveInverse', () => {
+  test('resolves no inverse dependencies for empty paths set', () => {
+    const paths = new Set();
+    const resolved = dependencyResolver.resolveInverse(paths, filter);
+    expect(resolved.length).toEqual(0);
+  });
 
-test('resolves dependencies for scoped packages', () => {
-  const resolved = dependencyResolver.resolve(
-    path.resolve(__dirname, '__fixtures__', 'scoped.js'),
-  );
-  expect(resolved).toEqual([
-    expect.stringContaining(path.join('@myorg', 'pkg')),
-  ]);
-});
+  test('resolves no inverse dependencies for set of non-existent paths', () => {
+    const paths = new Set(['/non/existent/path', '/another/one']);
+    const resolved = dependencyResolver.resolveInverse(paths, filter);
+    expect(resolved.length).toEqual(0);
+  });
 
-test('resolves no inverse dependencies for empty paths set', () => {
-  const paths = new Set();
-  const resolved = dependencyResolver.resolveInverse(paths, filter);
-  expect(resolved.length).toEqual(0);
-});
-
-test('resolves no inverse dependencies for set of non-existent paths', () => {
-  const paths = new Set(['/non/existent/path', '/another/one']);
-  const resolved = dependencyResolver.resolveInverse(paths, filter);
-  expect(resolved.length).toEqual(0);
-});
-
-test('resolves inverse dependencies for existing path', () => {
-  const paths = new Set([path.resolve(__dirname, '__fixtures__/file.js')]);
-  const resolved = dependencyResolver.resolveInverse(paths, filter);
-  expect(resolved).toEqual([
-    expect.stringContaining(
-      path.join('__tests__', '__fixtures__', 'file.test.js'),
-    ),
-  ]);
-});
-
-test('resolves inverse dependencies from available snapshot', () => {
-  const paths = new Set([
-    path.resolve(__dirname, '__fixtures__/file.js'),
-    path.resolve(__dirname, '__fixtures__/__snapshots__/related.test.js.snap'),
-  ]);
-  const resolved = dependencyResolver.resolveInverse(paths, filter);
-  expect(resolved).toEqual(
-    expect.arrayContaining([
+  test('resolves inverse dependencies for existing path', () => {
+    const paths = new Set([path.resolve(__dirname, '__fixtures__/file.js')]);
+    const resolved = dependencyResolver.resolveInverse(paths, filter);
+    expect(resolved).toEqual([
       expect.stringContaining(
         path.join('__tests__', '__fixtures__', 'file.test.js'),
       ),
-      expect.stringContaining(
-        path.join('__tests__', '__fixtures__', 'related.test.js'),
+    ]);
+  });
+
+  test('resolves inverse dependencies from available snapshot', () => {
+    const paths = new Set([
+      path.resolve(__dirname, '__fixtures__/file.js'),
+      path.resolve(
+        __dirname,
+        '__fixtures__/__snapshots__/related.test.js.snap',
       ),
-    ]),
-  );
+    ]);
+    const resolved = dependencyResolver.resolveInverse(paths, filter);
+    expect(resolved).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining(
+          path.join('__tests__', '__fixtures__', 'file.test.js'),
+        ),
+        expect.stringContaining(
+          path.join('__tests__', '__fixtures__', 'related.test.js'),
+        ),
+      ]),
+    );
+  });
 });

--- a/packages/jest-resolve-dependencies/src/__tests__/dependency_resolver.test.js
+++ b/packages/jest-resolve-dependencies/src/__tests__/dependency_resolver.test.js
@@ -43,7 +43,7 @@ beforeEach(() => {
 describe('resolve', () => {
   test('resolves no dependencies for non-existent path', () => {
     const resolved = dependencyResolver.resolve('/non/existent/path');
-    expect(resolved.length).toEqual(0);
+    expect(resolved).toHaveLength(0);
   });
 
   test('resolves dependencies for existing path', () => {
@@ -66,17 +66,45 @@ describe('resolve', () => {
   });
 });
 
+describe('resolveRecursive', () => {
+  test('resolves no dependencies for non-existent path', () => {
+    const resolved = dependencyResolver.resolveRecursive('/non/existent/path');
+    expect(Array.from(resolved)).toHaveLength(0);
+  });
+
+  test('resolves dependencies for existing path', () => {
+    const resolved = dependencyResolver.resolveRecursive(
+      path.resolve(__dirname, '__fixtures__', 'recursive', 'a.js'),
+    );
+    expect(Array.from(resolved)).toEqual([
+      expect.stringContaining('b.js'),
+      expect.stringContaining('c1.js'),
+      expect.stringContaining('c2.js'),
+    ]);
+  });
+
+  test('resolves circular dependencies', () => {
+    const resolved = dependencyResolver.resolveRecursive(
+      path.resolve(__dirname, '__fixtures__', 'circular', 'a.js'),
+    );
+    expect(Array.from(resolved)).toEqual([
+      expect.stringContaining('b.js'),
+      expect.stringContaining('c.js'),
+    ]);
+  });
+});
+
 describe('resolveInverse', () => {
   test('resolves no inverse dependencies for empty paths set', () => {
     const paths = new Set();
     const resolved = dependencyResolver.resolveInverse(paths, filter);
-    expect(resolved.length).toEqual(0);
+    expect(resolved).toHaveLength(0);
   });
 
   test('resolves no inverse dependencies for set of non-existent paths', () => {
     const paths = new Set(['/non/existent/path', '/another/one']);
     const resolved = dependencyResolver.resolveInverse(paths, filter);
-    expect(resolved.length).toEqual(0);
+    expect(resolved).toHaveLength(0);
   });
 
   test('resolves inverse dependencies for existing path', () => {

--- a/packages/jest-resolve-dependencies/src/index.js
+++ b/packages/jest-resolve-dependencies/src/index.js
@@ -44,8 +44,10 @@ class DependencyResolver {
       return [];
     }
 
+    const includeCoreModules = options && options.includeCoreModules;
+
     return dependencies.reduce((acc, dependency) => {
-      if (this._resolver.isCoreModule(dependency)) {
+      if (!includeCoreModules && this._resolver.isCoreModule(dependency)) {
         return acc;
       }
       let resolvedDependency;

--- a/packages/jest-resolve-dependencies/src/index.js
+++ b/packages/jest-resolve-dependencies/src/index.js
@@ -18,8 +18,10 @@ import type {SnapshotResolver} from 'types/SnapshotResolver';
 import {isSnapshotPath} from 'jest-snapshot';
 
 /**
- * DependencyResolver is used to resolve the direct dependencies of a module or
- * to retrieve a list of all transitive inverse dependencies.
+ * DependencyResolver is used
+ * to resolve the direct dependencies of a module (resolve) or
+ * to resolve the transitive (direct and indirect) dependencies of a module (resolveRecursive) or
+ * to retrieve a list of all transitive inverse dependencies (resolveInverse{,ModuleMap}).
  */
 class DependencyResolver {
   _hasteFS: HasteFS;
@@ -63,6 +65,21 @@ class DependencyResolver {
 
       return acc;
     }, []);
+  }
+
+  resolveRecursive(rootFile: Path, options?: ResolveModuleConfig): Set<Path> {
+    const known = new Set();
+    const recurse = (file: Path) => {
+      if (known.has(file)) {
+        return;
+      }
+      if (file !== rootFile) {
+        known.add(file);
+      }
+      this.resolve(file, options).forEach(recurse);
+    };
+    recurse(rootFile);
+    return known;
   }
 
   resolveInverseModuleMap(

--- a/types/Resolve.js
+++ b/types/Resolve.js
@@ -13,6 +13,7 @@ import type {Path} from './Config';
 
 export type ResolveModuleConfig = {|
   skipNodeResolution?: boolean,
+  includeCoreModules?: boolean,
   paths?: Path[],
 |};
 


### PR DESCRIPTION
## Summary

In https://www.youtube.com/watch?v=3YDiloj8_d0, @cpojer mentioned that the `TestSequencer` heuristics aside from failures/durations from previous runs could use some improvements.
This PR improves the existing "file size" heuristic that is used as a fallback when there is no information from previous runs available by calculating the size of the whole dependency tree of a test in order to schedule more complex tests first.
Note that this PR does not touch on the idea of "test priority" based on changed files that is also mentioned in the video.

## Test plan
Edit: See comments below for more up-to-date information.

I used [this script](https://gist.github.com/jeysal/cfabec19861c8e5318c2f4734cac1560) on a few small & large open source projects that came to my mind that use Jest.
The script diffs the test order without a cache (which is determined by the file size heuristic) against the test order after one full Jest run (which is determined by the test durations) and counts the number of lines that `diff` prints, which serves as a rough approximation of how close we got to the best test order (lower is better)

project: master (median of 4 runs) / this PR (median of 4 runs)
redux: 14 / 12
downshift: 27 / 25
recompose: 75.5 / 75
gatsby: 225.5 / 225
react: 370 / 363.5
jest: 598 / 585.5
prettier: 1816 / 1812.5

The difference might not seem like a lot (and tbh I initially hoped for more), but in hindsight I actually think this is pretty good. The larger projects showed quite consistently improved numbers. I hacked together the alternative approaches "counting test/it occurrences" and "number of files in dependency graph" and they showed no significant improvements over `master` at all, so I think this is pretty much as good as you can get with a reasonably simple heuristic.