### PR TITLE
chore: initial Azure Pipelines support

### DIFF
--- a/.azure-pipelines-steps.yml
+++ b/.azure-pipelines-steps.yml
@@ -1,0 +1,44 @@
+#
+# CI build and test steps. See azure-pipelines.yml for job details.
+# 
+
+steps:
+- checkout: self
+
+# Ensure Node.js 10 is active
+- task: NodeTool@0
+  inputs:
+    versionSpec: '10.x'
+  displayName: 'Use Node.js 10'
+
+# Ensure Python 2.7 is active
+- task: UsePythonVersion@0
+  inputs:
+    versionSpec: '2.7'
+  displayName: 'Use Python 2.7'
+
+# Workaround to move repo source files into a "jest" folder (see azure-pipelines.yml for details)
+- script: |
+    cd /
+    mv $(Build.Repository.LocalPath) $(JEST_DIR)
+    mkdir $(Build.Repository.LocalPath)
+  displayName: 'Move source into jest folder'
+
+# Run yarn to install dependencies and build
+- script: yarn
+  workingDirectory: $(JEST_DIR)
+  displayName: 'Install dependencies and build'
+
+# Run test-ci-partial
+- script: yarn run test-ci-partial
+  workingDirectory: $(JEST_DIR)
+  displayName: 'Run tests'
+
+# Publish CI test results
+- task: PublishTestResults@2
+  inputs:
+    testResultsFiles: '**/reports/junit/*.xml'
+    searchFolder: $(JEST_DIR)
+    testRunTitle: 'CI Tests $(Agent.OS)'
+  displayName: 'Publish test results'
+  condition: succeededOrFailed()

--- a/.azure-pipelines-steps.yml
+++ b/.azure-pipelines-steps.yml
@@ -1,7 +1,8 @@
 #
-# CI build and test steps. See azure-pipelines.yml for job details.
+# Steps for building and testing Jest. See jobs defined in .azure-pipelines.yml
 # 
 
+# Clones the repo
 steps:
 - checkout: self
 
@@ -17,7 +18,7 @@ steps:
     versionSpec: '2.7'
   displayName: 'Use Python 2.7'
 
-# Workaround to move repo source files into a "jest" folder (see azure-pipelines.yml for details)
+# Workaround to move source files under a "jest" folder (see .azure-pipelines.yml for details)
 - script: |
     cd /
     mv $(Build.Repository.LocalPath) $(JEST_DIR)

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -12,8 +12,6 @@ jobs:
 - job: Windows
   pool:
     vmImage: vs2017-win2016
-  variables:
-    VSTS_OVERWRITE_TEMP: true
   steps:
   - script: |
       git config --global core.autocrlf false
@@ -25,7 +23,7 @@ jobs:
   pool:
     vmImage: macos-10.13
   steps:
-  - script: brew install mercurial
+  - script: HOMEBREW_NO_AUTO_UPDATE=1 brew install mercurial
     displayName: 'Install Mercurial'
   - template: .azure-pipelines-steps.yml
 

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -1,5 +1,5 @@
 #
-# Azure Pipelines CI configuration for Linux, Windows, and macOS.
+# Azure Pipelines configuration for building and testing Jest on Linux, Windows, and macOS.
 #
 
 jobs:
@@ -23,14 +23,18 @@ jobs:
   pool:
     vmImage: macos-10.13
   steps:
+  # This step can be removed once Mercurial gets installed on the macOS image. See https://github.com/Microsoft/azure-pipelines-image-generation/issues/604
   - script: HOMEBREW_NO_AUTO_UPDATE=1 brew install mercurial
     displayName: 'Install Mercurial'
   - template: .azure-pipelines-steps.yml
 
 variables:
-  # Ensures output produced by Jest for certain tests includes ANSI escape characters (needed to match snapshots)
+  # Used by chalk. Ensures output from Jest includes ANSI escape characters that are needed to match test snapshots.
   FORCE_COLOR: 1
-  # Default checkout directory is "s", but inline snapshot tests will fail due to assumption that Jest is running under a "jest" folder
-  # (see packages/jest-message-util/src/index.js PATH_JEST_PACKAGES)
+
+  # By default, Azure Pipelines clones to an "s" directory, which causes tests to fail due to assumption of Jest being run from a "jest" directory.
+  # See packages/jest-message-util/src/index.js PATH_JEST_PACKAGES for more details.
   JEST_DIR: $(Agent.BuildDirectory)/jest
+  
+  # Ensures the handful of tests that should be skipped during CI are
   CI: true

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -5,20 +5,20 @@
 jobs:
 - job: Linux
   pool:
-    vmImage: ubuntu-16.04  
+    vmImage: ubuntu-16.04
   steps:
   - template: .azure-pipelines-steps.yml
 
-- job: Windows  
+- job: Windows
   pool:
-    vmImage: vs2017-win2016  
+    vmImage: vs2017-win2016
+  variables:
+    VSTS_OVERWRITE_TEMP: true
   steps:
-  - script: git config --global core.autocrlf false
-    displayName: 'Clone with LF preserved'
-  
-  - script: choco install hg
-    displayName: 'Install Mercurial'
-  
+  - script: |
+      git config --global core.autocrlf false
+      git config --global core.symlinks true
+    displayName: 'Preserve LF endings and symbolic links on check out'
   - template: .azure-pipelines-steps.yml
 
 - job: macOS
@@ -26,8 +26,7 @@ jobs:
     vmImage: macos-10.13
   steps:
   - script: brew install mercurial
-    displayName: 'Install Mercurial'    
-
+    displayName: 'Install Mercurial'
   - template: .azure-pipelines-steps.yml
 
 variables:
@@ -36,3 +35,4 @@ variables:
   # Default checkout directory is "s", but inline snapshot tests will fail due to assumption that Jest is running under a "jest" folder
   # (see packages/jest-message-util/src/index.js PATH_JEST_PACKAGES)
   JEST_DIR: $(Agent.BuildDirectory)/jest
+  CI: true

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -1,0 +1,38 @@
+#
+# Azure Pipelines CI configuration for Linux, Windows, and macOS.
+#
+
+jobs:
+- job: Linux
+  pool:
+    vmImage: ubuntu-16.04  
+  steps:
+  - template: .azure-pipelines-steps.yml
+
+- job: Windows  
+  pool:
+    vmImage: vs2017-win2016  
+  steps:
+  - script: git config --global core.autocrlf false
+    displayName: 'Clone with LF preserved'
+  
+  - script: choco install hg
+    displayName: 'Install Mercurial'
+  
+  - template: .azure-pipelines-steps.yml
+
+- job: macOS
+  pool:
+    vmImage: macos-10.13
+  steps:
+  - script: brew install mercurial
+    displayName: 'Install Mercurial'    
+
+  - template: .azure-pipelines-steps.yml
+
+variables:
+  # Ensures output produced by Jest for certain tests includes ANSI escape characters (needed to match snapshots)
+  FORCE_COLOR: 1
+  # Default checkout directory is "s", but inline snapshot tests will fail due to assumption that Jest is running under a "jest" folder
+  # (see packages/jest-message-util/src/index.js PATH_JEST_PACKAGES)
+  JEST_DIR: $(Agent.BuildDirectory)/jest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,7 @@
 - `[docs]` Add `testPathIgnorePatterns` in CLI documentation ([#7440](https://github.com/facebook/jest/pull/7440))
 - `[docs]` Removed misleading text about `describe()` grouping together tests into a test suite ([#7434](https://github.com/facebook/jest/pull/7434))
 - `[*]` Replace as many `Object.assign` with object spread as possible
+- `[ci]` Initial support for Azure Pipelines ([#7556](https://github.com/facebook/jest/pull/7556))
 
 ### Performance
 

--- a/e2e/Utils.js
+++ b/e2e/Utils.js
@@ -137,9 +137,11 @@ export const createEmptyPackage = (
 };
 
 export const extractSummary = (stdout: string) => {
-  const match = stdout.replace(/(?:\\[rn])+/g, '\n').match(
-    /Test Suites:.*\nTests.*\nSnapshots.*\nTime.*(\nRan all test suites)*.*\n*$/gm,
-  );
+  const match = stdout
+    .replace(/(?:\\[rn])+/g, '\n')
+    .match(
+      /Test Suites:.*\nTests.*\nSnapshots.*\nTime.*(\nRan all test suites)*.*\n*$/gm,
+    );
   if (!match) {
     throw new Error(
       `

--- a/e2e/Utils.js
+++ b/e2e/Utils.js
@@ -137,7 +137,7 @@ export const createEmptyPackage = (
 };
 
 export const extractSummary = (stdout: string) => {
-  const match = stdout.match(
+  const match = stdout.replace(/(?:\\[rn])+/g, '\n').match(
     /Test Suites:.*\nTests.*\nSnapshots.*\nTime.*(\nRan all test suites)*.*\n*$/gm,
   );
   if (!match) {

--- a/e2e/__tests__/hasteMapSize.test.js
+++ b/e2e/__tests__/hasteMapSize.test.js
@@ -13,8 +13,9 @@ import os from 'os';
 import path from 'path';
 import HasteMap from 'jest-haste-map';
 import {cleanup, writeFiles} from '../Utils';
+import {sync as realpath} from 'realpath-native';
 
-const DIR = path.resolve(os.tmpdir(), 'haste_map_size');
+const DIR = path.resolve(realpath(os.tmpdir()), 'haste_map_size');
 
 beforeEach(() => {
   cleanup(DIR);

--- a/e2e/runJest.js
+++ b/e2e/runJest.js
@@ -31,7 +31,7 @@ export default function runJest(
   args?: Array<string>,
   options: RunJestOptions = {},
 ) {
-  const isRelative = dir[0] !== '/';
+  const isRelative = !path.isAbsolute(dir);
 
   if (isRelative) {
     dir = path.resolve(__dirname, dir);
@@ -101,7 +101,7 @@ export const until = async function(
   text: string,
   options: RunJestOptions = {},
 ) {
-  const isRelative = dir[0] !== '/';
+  const isRelative = !path.isAbsolute(dir);
 
   if (isRelative) {
     dir = path.resolve(__dirname, dir);

--- a/packages/jest-cli/src/SearchSource.js
+++ b/packages/jest-cli/src/SearchSource.js
@@ -19,6 +19,7 @@ import testPathPatternToRegExp from './testPathPatternToRegexp';
 import {escapePathForRegex} from 'jest-regex-util';
 import {replaceRootDirInPath} from 'jest-config';
 import {buildSnapshotResolver} from 'jest-snapshot';
+import {sync as realpath} from 'realpath-native';
 
 type SearchResult = {|
   noSCM?: boolean,

--- a/packages/jest-cli/src/SearchSource.js
+++ b/packages/jest-cli/src/SearchSource.js
@@ -19,7 +19,6 @@ import testPathPatternToRegExp from './testPathPatternToRegexp';
 import {escapePathForRegex} from 'jest-regex-util';
 import {replaceRootDirInPath} from 'jest-config';
 import {buildSnapshotResolver} from 'jest-snapshot';
-import {sync as realpath} from 'realpath-native';
 
 type SearchResult = {|
   noSCM?: boolean,

--- a/packages/jest-config/src/getCacheDirectory.js
+++ b/packages/jest-config/src/getCacheDirectory.js
@@ -14,16 +14,15 @@ import {sync as realpath} from 'realpath-native';
 
 const getCacheDirectory = () => {
   const {getuid} = process;
+  const tmpdir = path.join(realpath(os.tmpdir()), 'jest');
   if (getuid == null) {
-    return path.join(realpath(os.tmpdir()), 'jest');
+    return tmpdir;
+  } else {
+    // On some platforms tmpdir() is `/tmp`, causing conflicts between different
+    // users and permission issues. Adding an additional subdivision by UID can
+    // help.
+    return `${tmpdir}_${getuid.call(process).toString(36)}`;
   }
-  // On some platforms tmpdir() is `/tmp`, causing conflicts between different
-  // users and permission issues. Adding an additional subdivision by UID can
-  // help.
-  return path.join(
-    realpath(os.tmpdir()),
-    'jest_' + getuid.call(process).toString(36),
-  );
 };
 
 export default getCacheDirectory;

--- a/packages/jest-config/src/getCacheDirectory.js
+++ b/packages/jest-config/src/getCacheDirectory.js
@@ -10,15 +10,20 @@
 const path = require('path');
 const os = require('os');
 
+import {sync as realpath} from 'realpath-native';
+
 const getCacheDirectory = () => {
   const {getuid} = process;
   if (getuid == null) {
-    return path.join(os.tmpdir(), 'jest');
+    return path.join(realpath(os.tmpdir()), 'jest');
   }
   // On some platforms tmpdir() is `/tmp`, causing conflicts between different
   // users and permission issues. Adding an additional subdivision by UID can
   // help.
-  return path.join(os.tmpdir(), 'jest_' + getuid.call(process).toString(36));
+  return path.join(
+    realpath(os.tmpdir()),
+    'jest_' + getuid.call(process).toString(36),
+  );
 };
 
 export default getCacheDirectory;


### PR DESCRIPTION
## Summary
As discussed in #7211, this PR is to add initial support for CI on Azure Pipelines across Mac, Windows, and Linux. Currently, Travis doesn't run master on Windows so there's a test gap.

This PR adds the azure-pipelines.yaml file to run test-ci-partial on the 3 OS's with Node 10. This PR can also be updated to run multiple versions of Node if that's desired. Some of the tests were updated as well.

The tests on Windows are currently failing. One appears to be path separator related and another fs.watch related (which can be finicky on Windows).

You can see the [output](https://willsmythe.visualstudio.com/jest/_build/results?buildId=323) of the fork @willsmythe set up. He also set up [test reporting](https://willsmythe.visualstudio.com/jest/_build/results?buildId=323&view=ms.vss-test-web.test-result-details):

![image](https://user-images.githubusercontent.com/20052233/50485103-d649a700-09c1-11e9-8fd9-3a6dd8b7e0bb.png)

If this change looks good, here's how to proceed to set up Azure Pipelines:

1. Merge this PR.
2. Set up the [Azure Pipelines app](https://github.com/apps/azure-pipelines) with this repo. You'll need to have the appropriate repo permissions for this. You can find more info in our [docs](https://docs.microsoft.com/en-us/azure/devops/pipelines/repos/github?view=vsts). If granting write access to Azure Pipelines is a non-starter, you can instead create an Azure Pipelines org and set up the connection using OAuth.
3. Follow the set up flow that immediately follows the app set up to create a Pipeline.

I'll update the CHANGELOG.md once the PR is created.

## Test plan
@willsmythe did most of the leg work here and can comment more on the testing he did.
