### PR TITLE
Update readme with a minimal working example

### DIFF
--- a/packages/babel-jest/README.md
+++ b/packages/babel-jest/README.md
@@ -2,6 +2,8 @@
 
 [Babel](https://github.com/babel/babel) [jest](https://github.com/facebook/jest) plugin
 
+Working example can be found here: https://github.com/kevinsimper/babel-jest-example/
+
 ## Usage
 
 If you are already using `jest-cli`, just add `babel-jest` and it will automatically compile JavaScript code using Babel.


### PR DESCRIPTION
It was difficult to get working without a minimal working example to refer to, basically every tutorial had problems or was not updated to the latest babel 7 upgrades with the new @babel namespace, giving errors like below.

This would have helped me a lot in getting something to work and if somebody come up with a smaller example I will love to replace it and see it 😄 

```
 FAIL  src/index.test.js
  ● Test suite failed to run

    Requires Babel "^7.0.0-0", but was loaded with "6.26.3". If you are sure you have a compatible version of @babel/core, it is likely that something in your build process is loading the wrong version. Inspect the stack trace of this error to look for the first entry that doesn't mention "@babel/core" or "babel-core" to see what is calling Babel. (While processing preset: "/Users/kevinsimper/Projects/meetuplabel/screenshot/node_modules/@babel/preset-env/lib/index.js")
```

```
$ npm test

> babel-jest-example@1.0.0 test /Users/kevinsimper/Projects/babel-jest-example
> jest

 FAIL  src/index.test.js
  ● Test suite failed to run

    /Users/kevinsimper/Projects/babel-jest-example/src/index.test.js:1
    ({"Object.<anonymous>":function(module,exports,require,__dirname,__filename,global,jest){import index from "./index.js";
                                                                                                    ^^^^^

    SyntaxError: Unexpected identifier

      at ScriptTransformer._transformAndBuildScript (node_modules/jest-runtime/build/script_transformer.js:403:17)
```