### PR TITLE
Update with a working example

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -87,6 +87,8 @@ To use [Babel](http://babeljs.io/), install the `babel-jest` and `@babel/core` p
 yarn add --dev babel-jest @babel/core
 ```
 
+Find working example here: https://github.com/kevinsimper/babel-jest-example
+
 Don't forget to add a [`babel.config.js`](https://babeljs.io/docs/en/config-files) file in your project's root folder. For example, if you are using ES6 and [React.js](https://reactjs.org) with the [`@babel/preset-env`](https://babeljs.io/docs/en/babel-preset-env) and [`@babel/preset-react`](https://babeljs.io/docs/en/babel-preset-react) presets:
 
 ```js


### PR DESCRIPTION
I also submitted a PR here: https://github.com/facebook/jest/pull/7558

----

It was difficult to get working without a minimal working example to refer to, basically every tutorial had problems or was not updated to the latest babel 7 upgrades with the new @babel namespace, giving errors like below.

This would have helped me a lot in getting something to work and if somebody come up with a smaller example I will love to replace it and see it 😄 

```
 FAIL  src/index.test.js
  ● Test suite failed to run

    Requires Babel "^7.0.0-0", but was loaded with "6.26.3". If you are sure you have a compatible version of @babel/core, it is likely that something in your build process is loading the wrong version. Inspect the stack trace of this error to look for the first entry that doesn't mention "@babel/core" or "babel-core" to see what is calling Babel. (While processing preset: "/Users/kevinsimper/Projects/meetuplabel/screenshot/node_modules/@babel/preset-env/lib/index.js")
```

```
$ npm test

> babel-jest-example@1.0.0 test /Users/kevinsimper/Projects/babel-jest-example
> jest

 FAIL  src/index.test.js
  ● Test suite failed to run

    /Users/kevinsimper/Projects/babel-jest-example/src/index.test.js:1
    ({"Object.<anonymous>":function(module,exports,require,__dirname,__filename,global,jest){import index from "./index.js";
                                                                                                    ^^^^^

    SyntaxError: Unexpected identifier

      at ScriptTransformer._transformAndBuildScript (node_modules/jest-runtime/build/script_transformer.js:403:17)
```