### PR TITLE
Run code transforms over `global{Setup,Teardown}`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - `[jest-haste-map]` [**BREAKING**] Remove name from hash in `HasteMap.getCacheFilePath` ([#7218](https://github.com/facebook/jest/pull/7218))
 - `[babel-preset-jest]` [**BREAKING**] Export a function instead of an object for Babel 7 compatibility ([#7203](https://github.com/facebook/jest/pull/7203))
 - `[jest-haste-map]` [**BREAKING**] Expose relative paths when getting the file iterator ([#7321](https://github.com/facebook/jest/pull/7321))
+- `[jest-cli]` [**BREAKING**] Run code transforms over `global{Setup,Teardown}` ([#7562](https://github.com/facebook/jest/pull/7562))
 - `[jest-haste-map]` Add `hasteFS.getSize(path)` ([#7580](https://github.com/facebook/jest/pull/7580))
 - `[jest-cli]` Print version ending in `-dev` when running a local Jest clone ([#7582](https://github.com/facebook/jest/pull/7582))
 - `[jest-cli]` Add Support for `globalSetup` and `globalTeardown` in projects ([#6865](https://github.com/facebook/jest/pull/6865))
@@ -49,7 +50,6 @@
 - `[jest-config]` Allow % based configuration of `--max-workers` ([#7494](https://github.com/facebook/jest/pull/7494))
 - `[jest-runner]` Instantiate the test environment class with the current `testPath` ([#7442](https://github.com/facebook/jest/pull/7442))
 - `[jest-config]` Always resolve jest-environment-jsdom from jest-config ([#7476](https://github.com/facebook/jest/pull/7476))
-- `[jest-cli]` Run code transforms over `global{Setup,Teardown}` ([#7562](https://github.com/facebook/jest/pull/7562))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 - `[jest-config]` Allow % based configuration of `--max-workers` ([#7494](https://github.com/facebook/jest/pull/7494))
 - `[jest-runner]` Instantiate the test environment class with the current `testPath` ([#7442](https://github.com/facebook/jest/pull/7442))
 - `[jest-config]` Always resolve jest-environment-jsdom from jest-config ([#7476](https://github.com/facebook/jest/pull/7476))
+- `[jest-cli]` Run code transforms over `global{Setup,Teardown}` ([#7562](https://github.com/facebook/jest/pull/7562))
 
 ### Fixes
 

--- a/e2e/custom-resolver/package.json
+++ b/e2e/custom-resolver/package.json
@@ -2,6 +2,10 @@
   "name": "custom-resolver",
   "jest": {
     "globalSetup": "foo",
-    "resolver": "./resolver.js"
+    "resolver": "./resolver.js",
+    "transformIgnorePatterns": [
+      "/node_modules/",
+      "/packages/"
+    ]
   }
 }

--- a/e2e/global-setup/babel.config.js
+++ b/e2e/global-setup/babel.config.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
 
 module.exports = {
   presets: ['@babel/preset-flow'],

--- a/e2e/global-setup/babel.config.js
+++ b/e2e/global-setup/babel.config.js
@@ -1,0 +1,5 @@
+// Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
+
+module.exports = {
+  presets: ['@babel/preset-flow'],
+};

--- a/e2e/global-setup/package.json
+++ b/e2e/global-setup/package.json
@@ -1,5 +1,9 @@
 {
   "jest": {
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "transformIgnorePatterns": [
+      "/node_modules/",
+      "/packages/"
+    ]
   }
 }

--- a/e2e/global-setup/projects.jest.config.js
+++ b/e2e/global-setup/projects.jest.config.js
@@ -15,12 +15,14 @@ module.exports = {
       globalSetup: '<rootDir>/setup.js',
       rootDir: path.resolve(__dirname, './project-1'),
       testMatch: ['<rootDir>/**/*.test.js'],
+      transformIgnorePatterns: ['/node_modules/', '/packages/'],
     },
     {
       displayName: 'project-2',
       globalSetup: '<rootDir>/setup.js',
       rootDir: path.resolve(__dirname, './project-2'),
       testMatch: ['<rootDir>/**/*.test.js'],
+      transformIgnorePatterns: ['/node_modules/', '/packages/'],
     },
   ],
 };

--- a/e2e/global-setup/setup.js
+++ b/e2e/global-setup/setup.js
@@ -13,7 +13,8 @@ const path = require('path');
 const DIR = path.join(os.tmpdir(), 'jest-global-setup');
 
 module.exports = function() {
-  return new Promise((resolve, reject) => {
+  // This uses a flow annotation to show it can be transpiled
+  return new Promise((resolve, reject: any) => {
     createDirectory(DIR);
     const fileId = crypto.randomBytes(20).toString('hex');
     fs.writeFileSync(path.join(DIR, fileId), 'setup');

--- a/e2e/global-teardown/package.json
+++ b/e2e/global-teardown/package.json
@@ -1,5 +1,9 @@
 {
   "jest": {
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "transformIgnorePatterns": [
+      "/node_modules/",
+      "/packages/"
+    ]
   }
 }

--- a/e2e/global-teardown/projects.jest.config.js
+++ b/e2e/global-teardown/projects.jest.config.js
@@ -15,12 +15,14 @@ module.exports = {
       globalTeardown: '<rootDir>/teardown.js',
       rootDir: path.resolve(__dirname, './project-1'),
       testMatch: ['<rootDir>/**/*.test.js'],
+      transformIgnorePatterns: ['/node_modules/', '/packages/'],
     },
     {
       displayName: 'project-2',
       globalTeardown: '<rootDir>/teardown.js',
       rootDir: path.resolve(__dirname, './project-2'),
       testMatch: ['<rootDir>/**/*.test.js'],
+      transformIgnorePatterns: ['/node_modules/', '/packages/'],
     },
   ],
 };

--- a/packages/jest-cli/package.json
+++ b/packages/jest-cli/package.json
@@ -32,6 +32,8 @@
     "jest-worker": "^23.2.0",
     "micromatch": "^2.3.11",
     "node-notifier": "^5.2.1",
+    "p-each-series": "^1.0.0",
+    "pirates": "^4.0.0",
     "prompts": "^2.0.1",
     "realpath-native": "^1.0.0",
     "rimraf": "^2.5.4",

--- a/packages/jest-cli/src/runGlobalHook.js
+++ b/packages/jest-cli/src/runGlobalHook.js
@@ -13,7 +13,7 @@ import type {Test} from 'types/TestRunner';
 import {extname} from 'path';
 import pEachSeries from 'p-each-series';
 import {addHook} from 'pirates';
-import {ScriptTransformer} from 'jest-runtime';
+import Runtime from 'jest-runtime';
 
 export default ({
   allTests,
@@ -47,7 +47,7 @@ export default ({
         : // Fallback to first config
           allTests[0].context.config;
 
-      const transformer = new ScriptTransformer(projectConfig);
+      const transformer = new Runtime.ScriptTransformer(projectConfig);
 
       const revertHook = addHook(
         (code, filename) =>

--- a/packages/jest-cli/src/runGlobalHook.js
+++ b/packages/jest-cli/src/runGlobalHook.js
@@ -38,12 +38,14 @@ export default ({
         return;
       }
 
-      const projectConfig =
-        allTests
-          .map(t => t.context.config)
-          .find(c => c[moduleName] === modulePath) ||
-        // Fallback to first one
-        allTests[0].context.config;
+      const correctConfig = allTests.find(
+        t => t.context.config[moduleName] === modulePath,
+      );
+
+      const projectConfig = correctConfig
+        ? correctConfig.context.config
+        : // Fallback to first config
+          allTests[0].context.config;
 
       const transformer = new ScriptTransformer(projectConfig);
 

--- a/packages/jest-cli/src/runGlobalHook.js
+++ b/packages/jest-cli/src/runGlobalHook.js
@@ -10,17 +10,10 @@
 import type {GlobalConfig} from 'types/Config';
 import type {Test} from 'types/TestRunner';
 
-import {extname, resolve, sep} from 'path';
+import {extname} from 'path';
 import pEachSeries from 'p-each-series';
 import {addHook} from 'pirates';
 import {ScriptTransformer} from 'jest-runtime';
-
-const inJestsSource = __dirname.includes(`packages${sep}jest-cli`);
-let packagesRoot;
-
-if (inJestsSource) {
-  packagesRoot = resolve(__dirname, '../../');
-}
 
 export default ({
   allTests,
@@ -59,13 +52,7 @@ export default ({
           transformer.transformSource(filename, code, false).code || code,
         {
           exts: [extname(modulePath)],
-          matcher(filename) {
-            // `babel-jest` etc would normally be caught by `node_modules`, but not in Jest's own repo
-            if (inJestsSource && filename.includes(packagesRoot)) {
-              return false;
-            }
-            return transformer._shouldTransform(filename);
-          },
+          matcher: transformer._shouldTransform.bind(transformer),
         },
       );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9557,6 +9557,13 @@ p-defer@^1.0.0:
   resolved "https://registry.yarnpkg.com/p-defer/-/p-defer-1.0.0.tgz#9f6eb182f6c9aa8cd743004a7d4f96b196b0fb0c"
   integrity sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=
 
+p-each-series@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-each-series/-/p-each-series-1.0.0.tgz#930f3d12dd1f50e7434457a22cd6f04ac6ad7f71"
+  integrity sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=
+  dependencies:
+    p-reduce "^1.0.0"
+
 p-finally@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary
Fixes #5164. A caveat is that this can not transpile stuff in `node_modules`. This is because in order to transpile using e.g. `babel-jest`, we would need to load `babel-jest`, which means we cannot transpile it.

We _could_ try to do static analysis on the transformer modules defined in the config and create a dependency tree of the only files we won't transform, but I'm not sure if it's worth it (or possible). Stuff in `node_modules` should be runnable in node either way.

EDIT: If people want, we can disable `node-modules` ignoring, and try to catch errors during transform. By default, Jest has `transformIgnorePattern` on `node_modules`, so shouldn't make a huge difference

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan
I added a flow annotation to an existing test to show the transform happens.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
