### PR TITLE
cleanup node 4 legacy code

### DIFF
--- a/e2e/Utils.js
+++ b/e2e/Utils.js
@@ -152,10 +152,10 @@ export const extractSummary = (stdout: string) => {
 
   const summary = replaceTime(match[0]);
 
-  const rest = cleanupStackTrace(
+  const rest = stdout
+    .replace(match[0], '')
     // remove all timestamps
-    stdout.replace(match[0], '').replace(/\s*\(\d*\.?\d+m?s\)$/gm, ''),
-  );
+    .replace(/\s*\(\d*\.?\d+m?s\)$/gm, '');
 
   return {rest, summary};
 };
@@ -209,14 +209,6 @@ export const extractSummaries = (
     })
     .map(({start, end}) => extractSortedSummary(stdout.slice(start, end)));
 };
-
-// different versions of Node print different stack traces. This function
-// unifies their output to make it possible to snapshot them.
-// TODO: Remove when we drop support for node 4
-export const cleanupStackTrace = (output: string) =>
-  output
-    .replace(/.*(?=packages)/g, '      at ')
-    .replace(/^.*at.*[\s][\(]?(\S*\:\d*\:\d*).*$/gm, '      at $1');
 
 export const normalizeIcons = (str: string) => {
   if (!str) {

--- a/e2e/__tests__/__snapshots__/custom_matcher_stack_trace.test.js.snap
+++ b/e2e/__tests__/__snapshots__/custom_matcher_stack_trace.test.js.snap
@@ -19,12 +19,12 @@ exports[`works with custom matchers 1`] = `
       47 | 
       48 |     // This expecation fails due to an error we throw (intentionally)
 
-      at __tests__/custom_matcher.test.js:45:13
-      at __tests__/custom_matcher.test.js:43:23
-      at __tests__/custom_matcher.test.js:42:23
-      at __tests__/custom_matcher.test.js:52:7
-      at __tests__/custom_matcher.test.js:11:18
-      at __tests__/custom_matcher.test.js:53:8
+      at Error (__tests__/custom_matcher.test.js:45:13)
+      at baz (__tests__/custom_matcher.test.js:43:23)
+      at bar (__tests__/custom_matcher.test.js:42:23)
+      at foo (__tests__/custom_matcher.test.js:52:7)
+      at Object.callback (__tests__/custom_matcher.test.js:11:18)
+      at Object.toCustomMatch (__tests__/custom_matcher.test.js:53:8)
 
 "
 `;

--- a/e2e/__tests__/__snapshots__/each.test.js.snap
+++ b/e2e/__tests__/__snapshots__/each.test.js.snap
@@ -72,7 +72,7 @@ exports[`shows error message when not enough arguments are supplied to tests 1`]
       10 |   \${true} | \${true}
       11 |   \${true}
 
-      at __tests__/each-exception.test.js:8:1
+      at Object.<anonymous> (__tests__/each-exception.test.js:8:1)
 
   ● throws exception when not enough arguments are supplied $left == $right
 
@@ -95,7 +95,7 @@ exports[`shows error message when not enough arguments are supplied to tests 1`]
       21 |   \${true} | \${true}
       22 | \`(
 
-      at __tests__/each-exception.test.js:19:1
+      at Object.<anonymous> (__tests__/each-exception.test.js:19:1)
 
 "
 `;
@@ -161,7 +161,7 @@ exports[`shows the correct errors in stderr when failing tests 1`] = `
       13 | );
       14 |
 
-      at __tests__/failure.test.js:11:18
+      at toBe (__tests__/failure.test.js:11:18)
 
   ● array table fails on all rows expected 1 == 2
 
@@ -178,7 +178,7 @@ exports[`shows the correct errors in stderr when failing tests 1`] = `
       20 | );
       21 |
 
-      at __tests__/failure.test.js:18:18
+      at toBe (__tests__/failure.test.js:18:18)
 
   ● array table fails on all rows expected 3 == 4
 
@@ -195,7 +195,7 @@ exports[`shows the correct errors in stderr when failing tests 1`] = `
       20 | );
       21 |
 
-      at __tests__/failure.test.js:18:18
+      at toBe (__tests__/failure.test.js:18:18)
 
   ● template table fails on one row expected: true == false
 
@@ -212,7 +212,7 @@ exports[`shows the correct errors in stderr when failing tests 1`] = `
       31 | );
       32 |
 
-      at __tests__/failure.test.js:29:18
+      at toBe (__tests__/failure.test.js:29:18)
 
   ● template table fails on all rows expected: 1 == 2
 
@@ -229,7 +229,7 @@ exports[`shows the correct errors in stderr when failing tests 1`] = `
       42 | );
       43 |
 
-      at __tests__/failure.test.js:40:18
+      at toBe (__tests__/failure.test.js:40:18)
 
   ● template table fails on all rows expected: 3 == 4
 
@@ -246,7 +246,7 @@ exports[`shows the correct errors in stderr when failing tests 1`] = `
       42 | );
       43 |
 
-      at __tests__/failure.test.js:40:18
+      at toBe (__tests__/failure.test.js:40:18)
 
   ● The word red contains the letter 'z'
 
@@ -263,7 +263,7 @@ exports[`shows the correct errors in stderr when failing tests 1`] = `
       49 | );
       50 |
 
-      at __tests__/failure.test.js:47:28
+      at toBe (__tests__/failure.test.js:47:28)
 
   ● The word green contains the letter 'z'
 
@@ -280,7 +280,7 @@ exports[`shows the correct errors in stderr when failing tests 1`] = `
       49 | );
       50 |
 
-      at __tests__/failure.test.js:47:28
+      at toBe (__tests__/failure.test.js:47:28)
 
   ● The word bean contains the letter 'z'
 
@@ -297,7 +297,7 @@ exports[`shows the correct errors in stderr when failing tests 1`] = `
       49 | );
       50 |
 
-      at __tests__/failure.test.js:47:28
+      at toBe (__tests__/failure.test.js:47:28)
 
   ● template table describe fails on all rows expected \\"a\\" == \\"b\\" › fails
 
@@ -314,7 +314,7 @@ exports[`shows the correct errors in stderr when failing tests 1`] = `
       61 |   }
       62 | );
 
-      at __tests__/failure.test.js:59:20
+      at Object.toBe (__tests__/failure.test.js:59:20)
 
   ● template table describe fails on all rows expected \\"c\\" == \\"d\\" › fails
 
@@ -331,7 +331,7 @@ exports[`shows the correct errors in stderr when failing tests 1`] = `
       61 |   }
       62 | );
 
-      at __tests__/failure.test.js:59:20
+      at Object.toBe (__tests__/failure.test.js:59:20)
 
   ● array table describe fails on all rows expected a == b › fails
 
@@ -348,7 +348,7 @@ exports[`shows the correct errors in stderr when failing tests 1`] = `
       70 |   }
       71 | );
 
-      at __tests__/failure.test.js:68:20
+      at Object.toBe (__tests__/failure.test.js:68:20)
 
   ● array table describe fails on all rows expected c == d › fails
 
@@ -365,7 +365,7 @@ exports[`shows the correct errors in stderr when failing tests 1`] = `
       70 |   }
       71 | );
 
-      at __tests__/failure.test.js:68:20
+      at Object.toBe (__tests__/failure.test.js:68:20)
 
 "
 `;

--- a/e2e/__tests__/__snapshots__/empty-describe-with-hooks.test.js.snap
+++ b/e2e/__tests__/__snapshots__/empty-describe-with-hooks.test.js.snap
@@ -28,8 +28,8 @@ Object {
       11 | 
       12 | describe('another block with tests', () => {
 
-      at __tests__/hook-in-empty-describe.test.js:9:3
-      at __tests__/hook-in-empty-describe.test.js:8:1
+      at beforeEach (__tests__/hook-in-empty-describe.test.js:9:3)
+      at Object.describe (__tests__/hook-in-empty-describe.test.js:8:1)
 
 ",
   "summary": "Test Suites: 1 failed, 1 total
@@ -58,8 +58,8 @@ Object {
       11 | });
       12 | 
 
-      at __tests__/hook-in-empty-nested-describe.test.js:9:3
-      at __tests__/hook-in-empty-nested-describe.test.js:8:1
+      at beforeEach (__tests__/hook-in-empty-nested-describe.test.js:9:3)
+      at Object.describe (__tests__/hook-in-empty-nested-describe.test.js:8:1)
 
 ",
   "summary": "Test Suites: 1 failed, 1 total
@@ -88,8 +88,8 @@ Object {
       11 |   afterAll(() => {});
       12 |   beforeAll(() => {});
 
-      at __tests__/multiple-hooks-in-empty-describe.test.js:9:3
-      at __tests__/multiple-hooks-in-empty-describe.test.js:8:1
+      at beforeEach (__tests__/multiple-hooks-in-empty-describe.test.js:9:3)
+      at Object.describe (__tests__/multiple-hooks-in-empty-describe.test.js:8:1)
 
   ● Test suite failed to run
 
@@ -103,8 +103,8 @@ Object {
       12 |   beforeAll(() => {});
       13 | });
 
-      at __tests__/multiple-hooks-in-empty-describe.test.js:10:3
-      at __tests__/multiple-hooks-in-empty-describe.test.js:8:1
+      at afterEach (__tests__/multiple-hooks-in-empty-describe.test.js:10:3)
+      at Object.describe (__tests__/multiple-hooks-in-empty-describe.test.js:8:1)
 
   ● Test suite failed to run
 
@@ -118,8 +118,8 @@ Object {
       13 | });
       14 | 
 
-      at __tests__/multiple-hooks-in-empty-describe.test.js:11:3
-      at __tests__/multiple-hooks-in-empty-describe.test.js:8:1
+      at afterAll (__tests__/multiple-hooks-in-empty-describe.test.js:11:3)
+      at Object.describe (__tests__/multiple-hooks-in-empty-describe.test.js:8:1)
 
   ● Test suite failed to run
 
@@ -133,8 +133,8 @@ Object {
       14 | 
       15 | describe('another block with tests', () => {
 
-      at __tests__/multiple-hooks-in-empty-describe.test.js:12:3
-      at __tests__/multiple-hooks-in-empty-describe.test.js:8:1
+      at beforeAll (__tests__/multiple-hooks-in-empty-describe.test.js:12:3)
+      at Object.describe (__tests__/multiple-hooks-in-empty-describe.test.js:8:1)
 
 ",
   "summary": "Test Suites: 1 failed, 1 total

--- a/e2e/__tests__/__snapshots__/error-on-deprecated.test.js.snap
+++ b/e2e/__tests__/__snapshots__/error-on-deprecated.test.js.snap
@@ -16,7 +16,7 @@ exports[`DEFAULT_TIMEOUT_INTERVAL.test.js errors in errorOnDeprecated mode 1`] =
       12 | });
       13 | 
 
-      at __tests__/DEFAULT_TIMEOUT_INTERVAL.test.js:10:3
+      at Object.<anonymous>.test (__tests__/DEFAULT_TIMEOUT_INTERVAL.test.js:10:3)
 
 "
 `;
@@ -37,7 +37,7 @@ exports[`fail.test.js errors in errorOnDeprecated mode 1`] = `
       15 | });
       16 | 
 
-      at __tests__/fail.test.js:13:5
+      at Object.fail (__tests__/fail.test.js:13:5)
 
 "
 `;
@@ -56,7 +56,7 @@ exports[`jasmine.addMatchers.test.js errors in errorOnDeprecated mode 1`] = `
       11 |     compare: (actual, expected) => ({
       12 |       message: 'Nobdy expects the Spanish Inquisition!',
 
-      at __tests__/jasmine.addMatchers.test.js:9:9
+      at Object.addMatchers (__tests__/jasmine.addMatchers.test.js:9:9)
 
 "
 `;
@@ -76,7 +76,7 @@ exports[`jasmine.any.test.js errors in errorOnDeprecated mode 1`] = `
       11 | });
       12 | 
 
-      at __tests__/jasmine.any.test.js:10:51
+      at Object.any (__tests__/jasmine.any.test.js:10:51)
 
 "
 `;
@@ -96,7 +96,7 @@ exports[`jasmine.anything.test.js errors in errorOnDeprecated mode 1`] = `
       11 | });
       12 | 
 
-      at __tests__/jasmine.anything.test.js:10:62
+      at Object.anything (__tests__/jasmine.anything.test.js:10:62)
 
 "
 `;
@@ -116,7 +116,7 @@ exports[`jasmine.arrayContaining.test.js errors in errorOnDeprecated mode 1`] = 
       11 | });
       12 | 
 
-      at __tests__/jasmine.arrayContaining.test.js:10:45
+      at Object.arrayContaining (__tests__/jasmine.arrayContaining.test.js:10:45)
 
 "
 `;
@@ -137,7 +137,7 @@ exports[`jasmine.createSpy.test.js errors in errorOnDeprecated mode 1`] = `
       12 |   expect(mySpy).toHaveBeenCalledWith('hello?');
       13 | });
 
-      at __tests__/jasmine.createSpy.test.js:10:25
+      at Object.createSpy (__tests__/jasmine.createSpy.test.js:10:25)
 
 "
 `;
@@ -158,7 +158,7 @@ exports[`jasmine.objectContaining.test.js errors in errorOnDeprecated mode 1`] =
       13 | });
       14 | 
 
-      at __tests__/jasmine.objectContaining.test.js:11:13
+      at Object.objectContaining (__tests__/jasmine.objectContaining.test.js:11:13)
 
 "
 `;
@@ -178,7 +178,7 @@ exports[`jasmine.stringMatching.test.js errors in errorOnDeprecated mode 1`] = `
       11 | });
       12 | 
 
-      at __tests__/jasmine.stringMatching.test.js:10:50
+      at Object.stringMatching (__tests__/jasmine.stringMatching.test.js:10:50)
 
 "
 `;
@@ -199,7 +199,7 @@ exports[`pending.test.js errors in errorOnDeprecated mode 1`] = `
       13 |   expect(false).toBe(true);
       14 | });
 
-      at __tests__/pending.test.js:11:5
+      at Object.pending (__tests__/pending.test.js:11:5)
 
 "
 `;
@@ -220,7 +220,7 @@ exports[`spyOn.test.js errors in errorOnDeprecated mode 1`] = `
       17 | });
       18 | 
 
-      at __tests__/spyOn.test.js:15:3
+      at Object.spyOn (__tests__/spyOn.test.js:15:3)
 
 "
 `;
@@ -241,7 +241,7 @@ exports[`spyOnProperty.test.js errors in errorOnDeprecated mode 1`] = `
       26 |   obj.method();
       27 | 
 
-      at __tests__/spyOnProperty.test.js:24:15
+      at Object.spyOnProperty (__tests__/spyOnProperty.test.js:24:15)
 
 "
 `;

--- a/e2e/__tests__/__snapshots__/expect-async-matcher.test.js.snap
+++ b/e2e/__tests__/__snapshots__/expect-async-matcher.test.js.snap
@@ -44,11 +44,11 @@ exports[`shows the correct errors in stderr when failing tests 1`] = `
       26 |   );
       27 | });
 
-      at __tests__/failure.test.js:24:54
-      at __tests__/failure.test.js:11:103
-      at __tests__/failure.test.js:13:194
+      at Object.toHaveLengthAsync (__tests__/failure.test.js:24:54)
+      at asyncGeneratorStep (__tests__/failure.test.js:11:103)
+      at _next (__tests__/failure.test.js:13:194)
       at __tests__/failure.test.js:13:364
-      at __tests__/failure.test.js:13:97
+      at Object.<anonymous> (__tests__/failure.test.js:13:97)
 
   ● fail with expected promise values and not
 
@@ -67,11 +67,11 @@ exports[`shows the correct errors in stderr when failing tests 1`] = `
       32 |   );
       33 | });
 
-      at __tests__/failure.test.js:30:61
-      at __tests__/failure.test.js:11:103
-      at __tests__/failure.test.js:13:194
+      at Object.toHaveLengthAsync (__tests__/failure.test.js:30:61)
+      at asyncGeneratorStep (__tests__/failure.test.js:11:103)
+      at _next (__tests__/failure.test.js:13:194)
       at __tests__/failure.test.js:13:364
-      at __tests__/failure.test.js:13:97
+      at Object.<anonymous> (__tests__/failure.test.js:13:97)
 
 "
 `;

--- a/e2e/__tests__/__snapshots__/failures.test.js.snap
+++ b/e2e/__tests__/__snapshots__/failures.test.js.snap
@@ -50,7 +50,7 @@ exports[`not throwing Error objects 4`] = `
       15 | const redeclare = () => {
       16 |   expect.assertions(1);
 
-      at __tests__/assertion_count.test.js:13:17
+      at Object.toBeTruthy (__tests__/assertion_count.test.js:13:17)
 
   ● .assertions() › throws
 
@@ -66,7 +66,7 @@ exports[`not throwing Error objects 4`] = `
       14 | };
       15 | const redeclare = () => {
 
-      at __tests__/assertion_count.test.js:12:10
+      at Object.assertions (__tests__/assertion_count.test.js:12:10)
 
   ● .assertions() › throws on redeclare of assertion count
 
@@ -82,7 +82,7 @@ exports[`not throwing Error objects 4`] = `
       19 | };
       20 | 
 
-      at __tests__/assertion_count.test.js:17:17
+      at Object.toBeTruthy (__tests__/assertion_count.test.js:17:17)
 
   ● .assertions() › throws on assertion
 
@@ -98,7 +98,7 @@ exports[`not throwing Error objects 4`] = `
       24 | };
       25 | 
 
-      at __tests__/assertion_count.test.js:22:10
+      at Object.assertions (__tests__/assertion_count.test.js:22:10)
 
   ● .hasAssertions() › throws when there are not assertions
 
@@ -114,7 +114,7 @@ exports[`not throwing Error objects 4`] = `
       29 | 
       30 | describe('.assertions()', () => {
 
-      at __tests__/assertion_count.test.js:27:10
+      at Object.hasAssertions (__tests__/assertion_count.test.js:27:10)
 
 "
 `;
@@ -142,7 +142,7 @@ exports[`not throwing Error objects 5`] = `
       11 | });
       12 | 
 
-      at __tests__/during_tests.test.js:9:1
+      at Object.test (__tests__/during_tests.test.js:9:1)
 
   ● Boolean thrown during test
 
@@ -156,7 +156,7 @@ exports[`not throwing Error objects 5`] = `
       15 |   throw false;
       16 | });
 
-      at __tests__/during_tests.test.js:13:1
+      at Object.test (__tests__/during_tests.test.js:13:1)
 
   ● undefined thrown during test
 
@@ -170,7 +170,7 @@ exports[`not throwing Error objects 5`] = `
       20 |   throw undefined;
       21 | });
 
-      at __tests__/during_tests.test.js:18:1
+      at Object.test (__tests__/during_tests.test.js:18:1)
 
   ● Object thrown during test
 
@@ -191,7 +191,7 @@ exports[`not throwing Error objects 5`] = `
       25 |   throw deepObject;
       26 | });
 
-      at __tests__/during_tests.test.js:23:1
+      at Object.test (__tests__/during_tests.test.js:23:1)
 
   ● Error during test
 
@@ -205,7 +205,7 @@ exports[`not throwing Error objects 5`] = `
       32 | 
       33 | test('done(Error)', done => {
 
-      at __tests__/during_tests.test.js:30:3
+      at Object.doesNotExist (__tests__/during_tests.test.js:30:3)
 
   ● done(Error)
 
@@ -219,7 +219,7 @@ exports[`not throwing Error objects 5`] = `
       36 | 
       37 | test('done(non-error)', done => {
 
-      at __tests__/during_tests.test.js:34:8
+      at Object.<anonymous>.done (__tests__/during_tests.test.js:34:8)
 
   ● done(non-error)
 
@@ -240,7 +240,7 @@ exports[`not throwing Error objects 5`] = `
       40 | 
       41 | test('returned promise rejection', () => Promise.reject(deepObject));
 
-      at __tests__/during_tests.test.js:38:3
+      at Object.done (__tests__/during_tests.test.js:38:3)
 
   ● returned promise rejection
 
@@ -259,7 +259,7 @@ exports[`not throwing Error objects 5`] = `
          | ^
       42 | 
 
-      at __tests__/during_tests.test.js:41:1
+      at Object.test (__tests__/during_tests.test.js:41:1)
 
 "
 `;
@@ -284,8 +284,8 @@ exports[`works with assertions in separate files 1`] = `
       13 | };
       14 | 
 
-      at macros.js:12:15
-      at __tests__/test_macro.test.js:14:3
+      at toEqual (macros.js:12:15)
+      at Object.shouldEqual (__tests__/test_macro.test.js:14:3)
 
 "
 `;
@@ -325,7 +325,7 @@ exports[`works with async failures 1`] = `
       14 | test('reject, but fail', () =>
       15 |   expect(Promise.reject({foo: 'bar'})).rejects.toEqual({baz: 'bar'}));
 
-      at __tests__/async_failures.test.js:12:50
+      at Object.toEqual (__tests__/async_failures.test.js:12:50)
 
   ● reject, but fail
 
@@ -354,7 +354,7 @@ exports[`works with async failures 1`] = `
       17 | test('expect reject', () =>
       18 |   expect(Promise.resolve({foo: 'bar'})).rejects.toEqual({foo: 'bar'}));
 
-      at __tests__/async_failures.test.js:15:48
+      at Object.toEqual (__tests__/async_failures.test.js:15:48)
 
   ● expect reject
 
@@ -371,7 +371,7 @@ exports[`works with async failures 1`] = `
       20 | test('expect resolve', () =>
       21 |   expect(Promise.reject({foo: 'bar'})).resolves.toEqual({foo: 'bar'}));
 
-      at __tests__/async_failures.test.js:18:3
+      at Object.expect (__tests__/async_failures.test.js:18:3)
 
   ● expect resolve
 
@@ -388,7 +388,7 @@ exports[`works with async failures 1`] = `
       23 | test('timeout', done => {
       24 |   setTimeout(done, 50);
 
-      at __tests__/async_failures.test.js:21:3
+      at Object.expect (__tests__/async_failures.test.js:21:3)
 
   ● timeout
 
@@ -402,7 +402,7 @@ exports[`works with async failures 1`] = `
       25 | }, 5);
       26 | 
 
-      at __tests__/async_failures.test.js:23:1
+      at Object.test (__tests__/async_failures.test.js:23:1)
 
 "
 `;
@@ -430,7 +430,7 @@ exports[`works with named snapshot failures 1`] = `
       13 | });
       14 | 
 
-      at __tests__/snapshot_named.test.js:12:17
+      at Object.toMatchSnapshot (__tests__/snapshot_named.test.js:12:17)
 
  › 1 snapshot failed.
 "
@@ -473,7 +473,7 @@ exports[`works with node assert 1`] = `
       17 | 
       18 | test('assert with a message', () => {
 
-      at __tests__/node_assertion_error.test.js:15:3
+      at Object.assert (__tests__/node_assertion_error.test.js:15:3)
 
   ● assert with a message
 
@@ -495,7 +495,7 @@ exports[`works with node assert 1`] = `
       21 | 
       22 | test('assert.ok', () => {
 
-      at __tests__/node_assertion_error.test.js:19:3
+      at Object.assert (__tests__/node_assertion_error.test.js:19:3)
 
   ● assert.ok
 
@@ -514,7 +514,7 @@ exports[`works with node assert 1`] = `
       25 | 
       26 | test('assert.ok with a message', () => {
 
-      at __tests__/node_assertion_error.test.js:23:10
+      at Object.ok (__tests__/node_assertion_error.test.js:23:10)
 
   ● assert.ok with a message
 
@@ -536,7 +536,7 @@ exports[`works with node assert 1`] = `
       29 | 
       30 | test('assert.equal', () => {
 
-      at __tests__/node_assertion_error.test.js:27:10
+      at Object.ok (__tests__/node_assertion_error.test.js:27:10)
 
   ● assert.equal
 
@@ -555,7 +555,7 @@ exports[`works with node assert 1`] = `
       33 | 
       34 | test('assert.notEqual', () => {
 
-      at __tests__/node_assertion_error.test.js:31:10
+      at Object.equal (__tests__/node_assertion_error.test.js:31:10)
 
   ● assert.notEqual
 
@@ -578,7 +578,7 @@ exports[`works with node assert 1`] = `
       37 | 
       38 | test('assert.deepEqual', () => {
 
-      at __tests__/node_assertion_error.test.js:35:10
+      at Object.notEqual (__tests__/node_assertion_error.test.js:35:10)
 
   ● assert.deepEqual
 
@@ -611,7 +611,7 @@ exports[`works with node assert 1`] = `
       41 | 
       42 | test('assert.deepEqual with a message', () => {
 
-      at __tests__/node_assertion_error.test.js:39:10
+      at Object.deepEqual (__tests__/node_assertion_error.test.js:39:10)
 
   ● assert.deepEqual with a message
 
@@ -647,7 +647,7 @@ exports[`works with node assert 1`] = `
       45 | 
       46 | test('assert.notDeepEqual', () => {
 
-      at __tests__/node_assertion_error.test.js:43:10
+      at Object.deepEqual (__tests__/node_assertion_error.test.js:43:10)
 
   ● assert.notDeepEqual
 
@@ -670,7 +670,7 @@ exports[`works with node assert 1`] = `
       49 | 
       50 | test('assert.strictEqual', () => {
 
-      at __tests__/node_assertion_error.test.js:47:10
+      at Object.notDeepEqual (__tests__/node_assertion_error.test.js:47:10)
 
   ● assert.strictEqual
 
@@ -689,7 +689,7 @@ exports[`works with node assert 1`] = `
       53 | 
       54 | test('assert.notStrictEqual', () => {
 
-      at __tests__/node_assertion_error.test.js:51:10
+      at Object.strictEqual (__tests__/node_assertion_error.test.js:51:10)
 
   ● assert.notStrictEqual
 
@@ -715,7 +715,7 @@ exports[`works with node assert 1`] = `
       57 | 
       58 | test('assert.deepStrictEqual', () => {
 
-      at __tests__/node_assertion_error.test.js:55:10
+      at Object.notStrictEqual (__tests__/node_assertion_error.test.js:55:10)
 
   ● assert.deepStrictEqual
 
@@ -744,7 +744,7 @@ exports[`works with node assert 1`] = `
       61 | 
       62 | test('assert.notDeepStrictEqual', () => {
 
-      at __tests__/node_assertion_error.test.js:59:10
+      at Object.deepStrictEqual (__tests__/node_assertion_error.test.js:59:10)
 
   ● assert.notDeepStrictEqual
 
@@ -767,7 +767,7 @@ exports[`works with node assert 1`] = `
       65 | 
       66 | test('assert.ifError', () => {
 
-      at __tests__/node_assertion_error.test.js:63:10
+      at Object.notDeepStrictEqual (__tests__/node_assertion_error.test.js:63:10)
 
   ● assert.ifError
 
@@ -790,7 +790,7 @@ exports[`works with node assert 1`] = `
       73 |   });
       74 | });
 
-      at __tests__/node_assertion_error.test.js:71:10
+      at Object.doesNotThrow (__tests__/node_assertion_error.test.js:71:10)
 
   ● assert.throws
 
@@ -810,7 +810,7 @@ exports[`works with node assert 1`] = `
       79 | 
       80 | test('async', async () => {
 
-      at __tests__/node_assertion_error.test.js:77:10
+      at Object.throws (__tests__/node_assertion_error.test.js:77:10)
 
   ● async
 
@@ -840,11 +840,11 @@ exports[`works with node assert 1`] = `
       82 | });
       83 | 
 
-      at __tests__/node_assertion_error.test.js:81:10
-      at __tests__/node_assertion_error.test.js:11:103
-      at __tests__/node_assertion_error.test.js:13:194
+      at Object.equal (__tests__/node_assertion_error.test.js:81:10)
+      at asyncGeneratorStep (__tests__/node_assertion_error.test.js:11:103)
+      at _next (__tests__/node_assertion_error.test.js:13:194)
       at __tests__/node_assertion_error.test.js:13:364
-      at __tests__/node_assertion_error.test.js:13:97
+      at Object.<anonymous> (__tests__/node_assertion_error.test.js:13:97)
 
 "
 `;
@@ -872,7 +872,7 @@ exports[`works with snapshot failures 1`] = `
       13 | });
       14 | 
 
-      at __tests__/snapshot.test.js:12:17
+      at Object.toMatchSnapshot (__tests__/snapshot.test.js:12:17)
 
  › 1 snapshot failed.
 "

--- a/e2e/__tests__/__snapshots__/globals.test.js.snap
+++ b/e2e/__tests__/__snapshots__/globals.test.js.snap
@@ -30,7 +30,7 @@ exports[`cannot have describe with no implementation 1`] = `
         |              ^
       3 |   
 
-      at __tests__/only-constructs.test.js:2:14
+      at Object.<anonymous> (__tests__/only-constructs.test.js:2:14)
 
 "
 `;
@@ -57,7 +57,7 @@ exports[`cannot test with no implementation 1`] = `
       4 |     test('test, no implementation');
       5 |   
 
-      at __tests__/only-constructs.test.js:3:5
+      at Object.it (__tests__/only-constructs.test.js:3:5)
 
 "
 `;
@@ -84,7 +84,7 @@ exports[`cannot test with no implementation with expand arg 1`] = `
       4 |     test('test, no implementation');
       5 |   
 
-      at __tests__/only-constructs.test.js:3:5
+      at Object.it (__tests__/only-constructs.test.js:3:5)
 
 "
 `;

--- a/e2e/__tests__/__snapshots__/module_name_mapper.test.js.snap
+++ b/e2e/__tests__/__snapshots__/module_name_mapper.test.js.snap
@@ -32,8 +32,8 @@ exports[`moduleNameMapper wrong configuration 1`] = `
       12 | module.exports = () => 'test';
       13 | 
 
-      at packages/jest-resolve/build/index.js:452:17
-      at index.js:10:1
+      at createNoMappedModuleFoundError (../../packages/jest-resolve/build/index.js:452:17)
+      at Object.require (index.js:10:1)
 
 "
 `;

--- a/e2e/__tests__/__snapshots__/resolve_no_file_extensions.test.js.snap
+++ b/e2e/__tests__/__snapshots__/resolve_no_file_extensions.test.js.snap
@@ -33,8 +33,8 @@ exports[`show error message with matching files 1`] = `
         |                  ^
       4 | 
 
-      at packages/jest-resolve/build/index.js:217:17
-      at index.js:3:18
+      at Resolver.resolveModule (../../packages/jest-resolve/build/index.js:217:17)
+      at Object.require (index.js:3:18)
 
 "
 `;

--- a/e2e/__tests__/__snapshots__/test-todo.test.js.snap
+++ b/e2e/__tests__/__snapshots__/test-todo.test.js.snap
@@ -12,7 +12,7 @@ exports[`shows error messages when called with invalid argument 1`] = `
         |    ^
       9 | 
 
-      at __tests__/todo_non_string.test.js:8:4
+      at Object.todo (__tests__/todo_non_string.test.js:8:4)
 
 "
 `;
@@ -29,7 +29,7 @@ exports[`shows error messages when called with multiple arguments 1`] = `
         |    ^
       9 | 
 
-      at __tests__/todo_multiple_args.test.js:8:4
+      at Object.todo (__tests__/todo_multiple_args.test.js:8:4)
 
 "
 `;
@@ -46,7 +46,7 @@ exports[`shows error messages when called with no arguments 1`] = `
         |    ^
       9 | 
 
-      at __tests__/todo_no_args.test.js:8:4
+      at Object.todo (__tests__/todo_no_args.test.js:8:4)
 
 "
 `;
@@ -73,7 +73,7 @@ exports[`works with all statuses 1`] = `
       15 | 
       16 | it.skip('skips', () => {
 
-      at __tests__/statuses.test.js:13:14
+      at Object.toBe (__tests__/statuses.test.js:13:14)
 
 "
 `;

--- a/e2e/__tests__/__snapshots__/watch_mode_only_failed.test.js.snap
+++ b/e2e/__tests__/__snapshots__/watch_mode_only_failed.test.js.snap
@@ -10,7 +10,7 @@ exports[`can press "f" to run only failed tests: test results 1`] = `
     > 2 |       test('bar 1', () => { expect('bar').toBe('foo'); });
         |                                           ^
       3 |
-      at __tests__/bar.spec.js:2:43
+      at Object.toBe (__tests__/bar.spec.js:2:43)
 
 PASS __tests__/foo.spec.js"
 `;
@@ -26,7 +26,7 @@ exports[`can press "f" to run only failed tests: test results 2`] = `
     > 2 |       test('bar 1', () => { expect('bar').toBe('foo'); });
         |                                           ^
       3 |
-      at __tests__/bar.spec.js:2:43
+      at Object.toBe (__tests__/bar.spec.js:2:43)
 "
 `;
 

--- a/e2e/__tests__/__snapshots__/watch_mode_update_snapshot.test.js.snap
+++ b/e2e/__tests__/__snapshots__/watch_mode_update_snapshot.test.js.snap
@@ -14,7 +14,7 @@ exports[`can press "u" to update snapshots: test results 1`] = `
     > 2 |       test('bar', () => { expect('bar').toMatchSnapshot(); });
         |                                         ^
       3 |
-      at __tests__/bar.spec.js:2:41
+      at Object.toMatchSnapshot (__tests__/bar.spec.js:2:41)
  › 1 snapshot failed.
 Snapshot Summary
  › 1 snapshot failed from 1 test suite. Inspect your code changes or press \`u\` to update them.

--- a/e2e/__tests__/failures.test.js
+++ b/e2e/__tests__/failures.test.js
@@ -64,7 +64,7 @@ test('works with node assert', () => {
       73 |   });
       74 | });
 
-      at __tests__/node_assertion_error.test.js:71:10
+      at Object.doesNotThrow (__tests__/node_assertion_error.test.js:71:10)
 `);
 
     const commonErrorMessage = `Message:
@@ -114,7 +114,7 @@ test('works with node assert', () => {
       69 | 
       70 | test('assert.doesNotThrow', () => {
 
-      at __tests__/node_assertion_error.test.js:67:10
+      at Object.ifError (__tests__/node_assertion_error.test.js:67:10)
 `;
 
     expect(summary).toContain(ifErrorMessage);
@@ -131,7 +131,7 @@ test('works with node assert', () => {
       68 | });
       69 | 
 
-      at __tests__/node_assertion_error.test.js:66:1
+      at Object.test (__tests__/node_assertion_error.test.js:66:1)
 `;
 
     expect(summary).toContain(ifErrorMessage);

--- a/packages/jest-message-util/src/__tests__/__snapshots__/messages.test.js.snap
+++ b/packages/jest-message-util/src/__tests__/__snapshots__/messages.test.js.snap
@@ -19,6 +19,7 @@ exports[`formatStackTrace should strip node internals 1`] = `
           \\"string\\"
 <dim></>
 <dim>      <dim>at Object.it (<dim>__tests__/test.js<dim>:8:14)<dim></>
+<dim>      <dim>at <dim>internal/process/next_tick.js<dim>:188:7<dim></>
 "
 `;
 

--- a/packages/jest-message-util/src/index.js
+++ b/packages/jest-message-util/src/index.js
@@ -26,10 +26,7 @@ const stackUtils = new StackUtils({
 let nodeInternals = [];
 
 try {
-  nodeInternals = StackUtils.nodeInternals()
-    // this is to have the tests be the same in node 4 and node 6.
-    // TODO: Remove when we drop support for node 4
-    .concat(new RegExp('internal/process/next_tick.js'));
+  nodeInternals = StackUtils.nodeInternals();
 } catch (e) {
   // `StackUtils.nodeInternals()` fails in browsers. We don't need to remove
   // node internals in the browser though, so no issue.

--- a/packages/pretty-format/src/__tests__/prettyFormat.test.js
+++ b/packages/pretty-format/src/__tests__/prettyFormat.test.js
@@ -15,9 +15,7 @@ function returnArguments(...args) {
   return arguments;
 }
 
-// Node.js 4 does not support the following:
-// class MyArray extends Array {
-// }
+class MyArray<T> extends Array<T> {}
 
 function MyObject(value) {
   this.name = value;
@@ -485,8 +483,7 @@ describe('prettyFormat()', () => {
         'arguments non-empty': returnArguments('arg'),
         'array literal empty': [],
         'array literal non-empty': ['item'],
-        // Node.js 4 does not support the following:
-        // 'extended array empty': new MyArray(),
+        'extended array empty': new MyArray(),
         'map empty': new Map(),
         'map non-empty': new Map([['name', 'value']]),
         'object literal empty': {},
@@ -505,8 +502,7 @@ describe('prettyFormat()', () => {
         '    "arguments non-empty": [Arguments],',
         '    "array literal empty": [Array],',
         '    "array literal non-empty": [Array],',
-        // Node.js 4 does not support the following:
-        // '    "extended array empty": [MyArray],',
+        '    "extended array empty": [MyArray],',
         '    "map empty": [Map],',
         '    "map non-empty": [Map],',
         '    "object literal empty": [Object],',
@@ -786,8 +782,7 @@ describe('prettyFormat()', () => {
         'arguments non-empty': returnArguments('arg'),
         'array literal empty': [],
         'array literal non-empty': ['item'],
-        // Node.js 4 does not support the following:
-        // 'extended array empty': new MyArray(),
+        'extended array empty': new MyArray(),
         'map empty': new Map(),
         'map non-empty': new Map([['name', 'value']]),
         'object literal empty': {},
@@ -808,8 +803,7 @@ describe('prettyFormat()', () => {
             '"arguments non-empty": ["arg"]',
             '"array literal empty": []',
             '"array literal non-empty": ["item"]',
-            // Node.js 4 does not support the following:
-            // '"extended array empty": []',
+            '"extended array empty": []',
             '"map empty": Map {}',
             '"map non-empty": Map {"name" => "value"}',
             '"object literal empty": {}',


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Node 4 is unsupported by Jest since #4769. This PR removes leftover (mostly test) code that performs special handling if running in Node 4.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Updated snapshots now include more stack trace data, because stripping it out to make it consistent across Node 4 and 6+ is no longer necessary.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
