### PR TITLE
print version ending in -dev when running a local Jest clone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - `[jest-haste-map]` [**BREAKING**] Remove name from hash in `HasteMap.getCacheFilePath` ([#7218](https://github.com/facebook/jest/pull/7218))
 - `[babel-preset-jest]` [**BREAKING**] Export a function instead of an object for Babel 7 compatibility ([#7203](https://github.com/facebook/jest/pull/7203))
 - `[jest-haste-map]` [**BREAKING**] Expose relative paths when getting the file iterator ([#7321](https://github.com/facebook/jest/pull/7321))
+- `[jest-cli]` Print version ending in `-dev` when running a local Jest clone
 - `[jest-cli]` Add Support for `globalSetup` and `globalTeardown` in projects ([#6865](https://github.com/facebook/jest/pull/6865))
 - `[jest-runtime]` Add `extraGlobals` to config to load extra global variables into the execution vm ([#7454](https://github.com/facebook/jest/pull/7454))
 - `[jest-util]` Export `specialChars` containing Unicode characters and ANSI escapes for console output ([#7532](https://github.com/facebook/jest/pull/7532))

--- a/e2e/__tests__/version.test.js
+++ b/e2e/__tests__/version.test.js
@@ -26,7 +26,7 @@ test('works with jest.config.js', () => {
   });
 
   const {status, stdout, stderr} = runJest(DIR, ['--version']);
-  expect(stdout).toMatch(/\d{2}\.\d{1,2}\.\d{1,2}[\-\S]*$/);
+  expect(stdout).toMatch(/\d{2}\.\d{1,2}\.\d{1,2}[\-\S]*-dev$/);
   // Only version gets printed and nothing else
   expect(stdout.split(/\n/)).toHaveLength(1);
   expect(stderr).toBe('');

--- a/packages/jest-cli/src/cli/index.js
+++ b/packages/jest-cli/src/cli/index.js
@@ -11,6 +11,7 @@ import type {AggregatedResult} from 'types/TestResult';
 import type {Argv} from 'types/Argv';
 import type {GlobalConfig, Path} from 'types/Config';
 
+import path from 'path';
 import {Console, clearLine, createDirectory} from 'jest-util';
 import {validateCLIOptions} from 'jest-validate';
 import {readConfigs, deprecationEntries} from 'jest-config';
@@ -22,6 +23,7 @@ import getChangedFilesPromise from '../getChangedFilesPromise';
 import {formatHandleErrors} from '../collectHandles';
 import handleDeprecationWarnings from '../lib/handle_deprecation_warnings';
 import {print as preRunMessagePrint} from '../preRunMessage';
+import {getVersion} from '../jest';
 import runJest from '../runJest';
 import Runtime from 'jest-runtime';
 import TestWatcher from '../TestWatcher';
@@ -176,9 +178,14 @@ const readResultsAndExit = (
 };
 
 export const buildArgv = (maybeArgv: ?Argv, project: ?Path) => {
+  const version =
+    getVersion() +
+    (__dirname.includes(`packages${path.sep}jest-cli`) ? '-dev' : '');
+
   const rawArgv: Argv | string[] = maybeArgv || process.argv.slice(2);
   const argv: Argv = yargs(rawArgv)
     .usage(args.usage)
+    .version(version)
     .alias('help', 'h')
     .options(args.options)
     .epilogue(args.docs)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

#7562 (cc @SimenB) used `__dirname.includes('packages/jest-cli')` to determine whether Jest is running from a local clone of the Jest project (as opposed to a regular node_modules installation). We found a cleaner solution than the `includes` there, but this gave me an idea for something else that could use this information: Indicating that Jest is running from a local clone when called with `--version`.
I often `yarn link` Jest into 10+ projects and probably do not always remember to unlink it afterwards. So if Jest behaves strangely, `yarn jest --version` telling me that it might be because I'm unintentionally running the local Jest clone would be nice (and more cross-platform than `realpath node_modules/jest-cli/`)
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
TODO how can we e2e test that it does NOT print `-dev` in a production version of Jest?