### PR TITLE
Add toBeNaN matcher to docs

### DIFF
--- a/docs/ExpectAPI.md
+++ b/docs/ExpectAPI.md
@@ -890,6 +890,17 @@ test('the best drink for octopus flavor is undefined', () => {
 
 You could write `expect(bestDrinkForFlavor('octopus')).toBe(undefined)`, but it's better practice to avoid referring to `undefined` directly in your code.
 
+### `.toBeNaN()`
+
+Use `.toBeNaN` when checking a value is `NaN`.
+
+```js
+test('passes when value is NaN', () => {
+  expect(NaN).toBeNaN();
+  expect(1).not.toBeNaN();
+});
+```
+
 ### `.toContain(item)`
 
 Use `.toContain` when you want to check that an item is in an array. For testing the items in the array, this uses `===`, a strict equality check. `.toContain` can also check whether a string is a substring of another string.

--- a/website/versioned_docs/version-22.0/ExpectAPI.md
+++ b/website/versioned_docs/version-22.0/ExpectAPI.md
@@ -632,6 +632,17 @@ test('the best drink for octopus flavor is undefined', () => {
 
 You could write `expect(bestDrinkForFlavor('octopus')).toBe(undefined)`, but it's better practice to avoid referring to `undefined` directly in your code.
 
+### `.toBeNaN()`
+
+Use `.toBeNaN` when checking a value is `NaN`.
+
+```js
+test('passes when value is NaN', () => {
+  expect(NaN).toBeNaN();
+  expect(1).not.toBeNaN();
+});
+```
+
 ### `.toContain(item)`
 
 Use `.toContain` when you want to check that an item is in an array. For testing the items in the array, this uses `===`, a strict equality check. `.toContain` can also check whether a string is a substring of another string.

--- a/website/versioned_docs/version-22.1/ExpectAPI.md
+++ b/website/versioned_docs/version-22.1/ExpectAPI.md
@@ -626,6 +626,17 @@ test('the best drink for octopus flavor is undefined', () => {
 
 You could write `expect(bestDrinkForFlavor('octopus')).toBe(undefined)`, but it's better practice to avoid referring to `undefined` directly in your code.
 
+### `.toBeNaN()`
+
+Use `.toBeNaN` when checking a value is `NaN`.
+
+```js
+test('passes when value is NaN', () => {
+  expect(NaN).toBeNaN();
+  expect(1).not.toBeNaN();
+});
+```
+
 ### `.toContain(item)`
 
 Use `.toContain` when you want to check that an item is in an array. For testing the items in the array, this uses `===`, a strict equality check. `.toContain` can also check whether a string is a substring of another string.

--- a/website/versioned_docs/version-22.2/ExpectAPI.md
+++ b/website/versioned_docs/version-22.2/ExpectAPI.md
@@ -626,6 +626,17 @@ test('the best drink for octopus flavor is undefined', () => {
 
 You could write `expect(bestDrinkForFlavor('octopus')).toBe(undefined)`, but it's better practice to avoid referring to `undefined` directly in your code.
 
+### `.toBeNaN()`
+
+Use `.toBeNaN` when checking a value is `NaN`.
+
+```js
+test('passes when value is NaN', () => {
+  expect(NaN).toBeNaN();
+  expect(1).not.toBeNaN();
+});
+```
+
 ### `.toContain(item)`
 
 Use `.toContain` when you want to check that an item is in an array. For testing the items in the array, this uses `===`, a strict equality check. `.toContain` can also check whether a string is a substring of another string.

--- a/website/versioned_docs/version-22.3/ExpectAPI.md
+++ b/website/versioned_docs/version-22.3/ExpectAPI.md
@@ -626,6 +626,17 @@ test('the best drink for octopus flavor is undefined', () => {
 
 You could write `expect(bestDrinkForFlavor('octopus')).toBe(undefined)`, but it's better practice to avoid referring to `undefined` directly in your code.
 
+### `.toBeNaN()`
+
+Use `.toBeNaN` when checking a value is `NaN`.
+
+```js
+test('passes when value is NaN', () => {
+  expect(NaN).toBeNaN();
+  expect(1).not.toBeNaN();
+});
+```
+
 ### `.toContain(item)`
 
 Use `.toContain` when you want to check that an item is in an array. For testing the items in the array, this uses `===`, a strict equality check. `.toContain` can also check whether a string is a substring of another string.

--- a/website/versioned_docs/version-23.0/ExpectAPI.md
+++ b/website/versioned_docs/version-23.0/ExpectAPI.md
@@ -843,6 +843,17 @@ test('the best drink for octopus flavor is undefined', () => {
 
 You could write `expect(bestDrinkForFlavor('octopus')).toBe(undefined)`, but it's better practice to avoid referring to `undefined` directly in your code.
 
+### `.toBeNaN()`
+
+Use `.toBeNaN` when checking a value is `NaN`.
+
+```js
+test('passes when value is NaN', () => {
+  expect(NaN).toBeNaN();
+  expect(1).not.toBeNaN();
+});
+```
+
 ### `.toContain(item)`
 
 Use `.toContain` when you want to check that an item is in an array. For testing the items in the array, this uses `===`, a strict equality check. `.toContain` can also check whether a string is a substring of another string.

--- a/website/versioned_docs/version-23.1/ExpectAPI.md
+++ b/website/versioned_docs/version-23.1/ExpectAPI.md
@@ -843,6 +843,17 @@ test('the best drink for octopus flavor is undefined', () => {
 
 You could write `expect(bestDrinkForFlavor('octopus')).toBe(undefined)`, but it's better practice to avoid referring to `undefined` directly in your code.
 
+### `.toBeNaN()`
+
+Use `.toBeNaN` when checking a value is `NaN`.
+
+```js
+test('passes when value is NaN', () => {
+  expect(NaN).toBeNaN();
+  expect(1).not.toBeNaN();
+});
+```
+
 ### `.toContain(item)`
 
 Use `.toContain` when you want to check that an item is in an array. For testing the items in the array, this uses `===`, a strict equality check. `.toContain` can also check whether a string is a substring of another string.

--- a/website/versioned_docs/version-23.2/ExpectAPI.md
+++ b/website/versioned_docs/version-23.2/ExpectAPI.md
@@ -843,6 +843,17 @@ test('the best drink for octopus flavor is undefined', () => {
 
 You could write `expect(bestDrinkForFlavor('octopus')).toBe(undefined)`, but it's better practice to avoid referring to `undefined` directly in your code.
 
+### `.toBeNaN()`
+
+Use `.toBeNaN` when checking a value is `NaN`.
+
+```js
+test('passes when value is NaN', () => {
+  expect(NaN).toBeNaN();
+  expect(1).not.toBeNaN();
+});
+```
+
 ### `.toContain(item)`
 
 Use `.toContain` when you want to check that an item is in an array. For testing the items in the array, this uses `===`, a strict equality check. `.toContain` can also check whether a string is a substring of another string.

--- a/website/versioned_docs/version-23.3/ExpectAPI.md
+++ b/website/versioned_docs/version-23.3/ExpectAPI.md
@@ -843,6 +843,17 @@ test('the best drink for octopus flavor is undefined', () => {
 
 You could write `expect(bestDrinkForFlavor('octopus')).toBe(undefined)`, but it's better practice to avoid referring to `undefined` directly in your code.
 
+### `.toBeNaN()`
+
+Use `.toBeNaN` when checking a value is `NaN`.
+
+```js
+test('passes when value is NaN', () => {
+  expect(NaN).toBeNaN();
+  expect(1).not.toBeNaN();
+});
+```
+
 ### `.toContain(item)`
 
 Use `.toContain` when you want to check that an item is in an array. For testing the items in the array, this uses `===`, a strict equality check. `.toContain` can also check whether a string is a substring of another string.

--- a/website/versioned_docs/version-23.4/ExpectAPI.md
+++ b/website/versioned_docs/version-23.4/ExpectAPI.md
@@ -843,6 +843,17 @@ test('the best drink for octopus flavor is undefined', () => {
 
 You could write `expect(bestDrinkForFlavor('octopus')).toBe(undefined)`, but it's better practice to avoid referring to `undefined` directly in your code.
 
+### `.toBeNaN()`
+
+Use `.toBeNaN` when checking a value is `NaN`.
+
+```js
+test('passes when value is NaN', () => {
+  expect(NaN).toBeNaN();
+  expect(1).not.toBeNaN();
+});
+```
+
 ### `.toContain(item)`
 
 Use `.toContain` when you want to check that an item is in an array. For testing the items in the array, this uses `===`, a strict equality check. `.toContain` can also check whether a string is a substring of another string.

--- a/website/versioned_docs/version-23.5/ExpectAPI.md
+++ b/website/versioned_docs/version-23.5/ExpectAPI.md
@@ -843,6 +843,17 @@ test('the best drink for octopus flavor is undefined', () => {
 
 You could write `expect(bestDrinkForFlavor('octopus')).toBe(undefined)`, but it's better practice to avoid referring to `undefined` directly in your code.
 
+### `.toBeNaN()`
+
+Use `.toBeNaN` when checking a value is `NaN`.
+
+```js
+test('passes when value is NaN', () => {
+  expect(NaN).toBeNaN();
+  expect(1).not.toBeNaN();
+});
+```
+
 ### `.toContain(item)`
 
 Use `.toContain` when you want to check that an item is in an array. For testing the items in the array, this uses `===`, a strict equality check. `.toContain` can also check whether a string is a substring of another string.

--- a/website/versioned_docs/version-23.6/ExpectAPI.md
+++ b/website/versioned_docs/version-23.6/ExpectAPI.md
@@ -891,6 +891,17 @@ test('the best drink for octopus flavor is undefined', () => {
 
 You could write `expect(bestDrinkForFlavor('octopus')).toBe(undefined)`, but it's better practice to avoid referring to `undefined` directly in your code.
 
+### `.toBeNaN()`
+
+Use `.toBeNaN` when checking a value is `NaN`.
+
+```js
+test('passes when value is NaN', () => {
+  expect(NaN).toBeNaN();
+  expect(1).not.toBeNaN();
+});
+```
+
 ### `.toContain(item)`
 
 Use `.toContain` when you want to check that an item is in an array. For testing the items in the array, this uses `===`, a strict equality check. `.toContain` can also check whether a string is a substring of another string.


### PR DESCRIPTION
> Closes #7577 

Present Issue
--------------
`toBeNan()` matcher was added in #1265 which was not documented.

Proposed solution
------------------
Added `toBeNaN()` along with other matchers to the docs.