### PR TITLE
fix: toStrictEqual considers array sparseness (resolves #7586)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@
 
 ### Fixes
 
-- `[expect]` `toStrictArray` considers sparseness of arrays. ([#7591](https://github.com/facebook/jest/pull/7591))
+- `[expect]` `toStrictEqual` considers sparseness of arrays. ([#7591](https://github.com/facebook/jest/pull/7591))
 - `[jest-cli]` Fix empty coverage data for untested files ([#7388](https://github.com/facebook/jest/pull/7388))
 - `[jest-cli]` [**BREAKING**] Do not use `text-summary` coverage reporter by default if other reporters are configured ([#7058](https://github.com/facebook/jest/pull/7058))
 - `[jest-mock]` [**BREAKING**] Fix bugs with mock/spy result tracking of recursive functions ([#6381](https://github.com/facebook/jest/pull/6381))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 
 ### Fixes
 
+- `[expect]` `toStrictArray` considers sparseness of arrays. ([#7591](https://github.com/facebook/jest/pull/7591))
 - `[jest-cli]` Fix empty coverage data for untested files ([#7388](https://github.com/facebook/jest/pull/7388))
 - `[jest-cli]` [**BREAKING**] Do not use `text-summary` coverage reporter by default if other reporters are configured ([#7058](https://github.com/facebook/jest/pull/7058))
 - `[jest-mock]` [**BREAKING**] Fix bugs with mock/spy result tracking of recursive functions ([#6381](https://github.com/facebook/jest/pull/6381))

--- a/docs/ExpectAPI.md
+++ b/docs/ExpectAPI.md
@@ -1125,6 +1125,7 @@ Use `.toStrictEqual` to test that objects have the same types as well as structu
 Differences from `.toEqual`:
 
 - Keys with `undefined` properties are checked. e.g. `{a: undefined, b: 2}` does not match `{b: 2}` when using `.toStrictEqual`.
+- Array sparseness is checked. e.g. `[, 1]` does not match `[undefined, 1]` when using `.toStrictEqual`.
 - Object types are checked to be equal. e.g. A class instance with fields `a` and `b` will not equal a literal object with fields `a` and `b`.
 
 ```js

--- a/packages/expect/src/__tests__/matchers.test.js
+++ b/packages/expect/src/__tests__/matchers.test.js
@@ -271,6 +271,16 @@ describe('.toStrictEqual()', () => {
     expect(c.constructor.name).toEqual(d.constructor.name);
     expect({test: c}).not.toStrictEqual({test: d});
   });
+
+  it('does not pass when sparseness of arrays do not match', () => {
+    expect([, 1]).not.toStrictEqual([undefined, 1]); // eslint-disable-line no-sparse-arrays
+    expect([undefined, 1]).not.toStrictEqual([, 1]); // eslint-disable-line no-sparse-arrays
+    expect([, , , 1]).not.toStrictEqual([, 1]); // eslint-disable-line no-sparse-arrays
+  });
+
+  it('does not pass when equally sparse arrays have different values', () => {
+    expect([, 1]).not.toStrictEqual([, 2]); // eslint-disable-line no-sparse-arrays
+  });
 });
 
 describe('.toEqual()', () => {

--- a/packages/expect/src/__tests__/matchers.test.js
+++ b/packages/expect/src/__tests__/matchers.test.js
@@ -272,15 +272,21 @@ describe('.toStrictEqual()', () => {
     expect({test: c}).not.toStrictEqual({test: d});
   });
 
+  /* eslint-disable no-sparse-arrays */
+  it('passes for matching sparse arrays', () => {
+    expect([, 1]).toStrictEqual([, 1]);
+  });
+
   it('does not pass when sparseness of arrays do not match', () => {
-    expect([, 1]).not.toStrictEqual([undefined, 1]); // eslint-disable-line no-sparse-arrays
-    expect([undefined, 1]).not.toStrictEqual([, 1]); // eslint-disable-line no-sparse-arrays
-    expect([, , , 1]).not.toStrictEqual([, 1]); // eslint-disable-line no-sparse-arrays
+    expect([, 1]).not.toStrictEqual([undefined, 1]);
+    expect([undefined, 1]).not.toStrictEqual([, 1]);
+    expect([, , , 1]).not.toStrictEqual([, 1]);
   });
 
   it('does not pass when equally sparse arrays have different values', () => {
-    expect([, 1]).not.toStrictEqual([, 2]); // eslint-disable-line no-sparse-arrays
+    expect([, 1]).not.toStrictEqual([, 2]);
   });
+  /* eslint-enable */
 });
 
 describe('.toEqual()', () => {

--- a/packages/expect/src/matchers.js
+++ b/packages/expect/src/matchers.js
@@ -30,6 +30,7 @@ import {
   getObjectSubset,
   getPath,
   iterableEquality,
+  sparseArrayEquality,
   subsetEquality,
   typeEquality,
   isOneline,
@@ -666,7 +667,7 @@ const matchers: MatchersObject = {
     const pass = equals(
       received,
       expected,
-      [iterableEquality, typeEquality],
+      [iterableEquality, typeEquality, sparseArrayEquality],
       true,
     );
 

--- a/packages/expect/src/utils.js
+++ b/packages/expect/src/utils.js
@@ -243,6 +243,17 @@ export const typeEquality = (a: any, b: any) => {
   return false;
 };
 
+export const sparseArrayEquality = (a: any, b: any) => {
+  if (!Array.isArray(a) || !Array.isArray(b)) {
+    return undefined;
+  }
+
+  // A sparse array [, , 1] will have keys ["2"] whereas [undefined, undefined, 1] will have keys ["0", "1", "2"]
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  return equals(a, b) && equals(aKeys, bKeys);
+};
+
 export const partition = <T>(
   items: Array<T>,
   predicate: T => boolean,


### PR DESCRIPTION
## Summary

Fixes the bug raised in https://github.com/facebook/jest/issues/7586.

## Test plan

Unit tests are included to cover the case.