### PR TITLE
Jest diff numbers and booleans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 
 ### Fixes
 
+- `[jest-diff]` Do not claim that `-0` and `0` have no visual difference ([#7605](https://github.com/facebook/jest/pull/7605))
 - `[jest-mock]` Fix automock for numeric function names ([#7653](https://github.com/facebook/jest/pull/7653))
 - `[jest-config]` Ensure `existsSync` is only called with a string parameter ([#7607](https://github.com/facebook/jest/pull/7607))
 - `[expect]` `toStrictEqual` considers sparseness of arrays. ([#7591](https://github.com/facebook/jest/pull/7591))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 - `[jest-runtime]` Add `jest.isolateModules` for scoped module initialization ([#6701](https://github.com/facebook/jest/pull/6701))
+- `[jest-diff]` [**BREAKING**] Support diffing numbers and booleans instead of returning null for different ones ([#7605](https://github.com/facebook/jest/pull/7605))
 - `[jest-diff]` [**BREAKING**] Replace `diff` with `diff-sequences` package ([#6961](https://github.com/facebook/jest/pull/6961))
 - `[jest-cli]` [**BREAKING**] Only set error process error codes when they are non-zero ([#7363](https://github.com/facebook/jest/pull/7363))
 - `[jest-config]` [**BREAKING**] Deprecate `setupTestFrameworkScriptFile` in favor of new `setupFilesAfterEnv` ([#7119](https://github.com/facebook/jest/pull/7119))

--- a/e2e/__tests__/__snapshots__/failures.test.js.snap
+++ b/e2e/__tests__/__snapshots__/failures.test.js.snap
@@ -540,10 +540,6 @@ FAIL __tests__/assertionError.test.js
     Received:
       1
 
-    Difference:
-
-    Compared values have no visual difference.
-
       33 | 
       34 | test('assert.notEqual', () => {
     > 35 |   assert.notEqual(1, 1);
@@ -676,10 +672,6 @@ FAIL __tests__/assertionError.test.js
 
     Message:
       My custom error message
-
-    Difference:
-
-    Compared values have no visual difference.
 
       53 | 
       54 | test('assert.notStrictEqual', () => {

--- a/packages/expect/package.json
+++ b/packages/expect/package.json
@@ -11,7 +11,6 @@
   "browser": "build-es5/index.js",
   "dependencies": {
     "ansi-styles": "^3.2.0",
-    "jest-diff": "^23.6.0",
     "jest-get-type": "^22.1.0",
     "jest-matcher-utils": "^23.6.0",
     "jest-message-util": "^23.4.0",

--- a/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -360,11 +360,7 @@ exports[`.toBe() fails for: -0 and 0 1`] = `
 "<dim>expect(</><red>received</><dim>).toBe(</><green>expected</><dim>) // Object.is equality</>
 
 Expected: <green>0</>
-Received: <red>-0</>
-
-Difference:
-
-<dim>Compared values have no visual difference.</>"
+Received: <red>-0</>"
 `;
 
 exports[`.toBe() fails for: 1 and 2 1`] = `

--- a/packages/expect/src/matchers.js
+++ b/packages/expect/src/matchers.js
@@ -9,7 +9,6 @@
 
 import type {MatchersObject} from 'types/Matchers';
 
-import jestDiff from 'jest-diff';
 import getType from 'jest-get-type';
 import {escapeStrForRegex} from 'jest-regex-util';
 import {
@@ -17,6 +16,7 @@ import {
   RECEIVED_COLOR,
   SUGGEST_TO_EQUAL,
   SUGGEST_TO_CONTAIN_EQUAL,
+  diff,
   ensureNoExpected,
   ensureNumbers,
   getLabelPrinter,
@@ -25,7 +25,6 @@ import {
   printReceived,
   printExpected,
   printWithType,
-  shouldPrintDiff,
 } from 'jest-matcher-utils';
 import {
   getObjectSubset,
@@ -44,9 +43,6 @@ type ContainIterable =
   | NodeList<any>
   | DOMTokenList
   | HTMLCollection<any>;
-
-const diff: typeof jestDiff = (a, b, options) =>
-  shouldPrintDiff(a, b) ? jestDiff(a, b, options) : null;
 
 const matchers: MatchersObject = {
   toBe(received: any, expected: any) {

--- a/packages/expect/src/matchers.js
+++ b/packages/expect/src/matchers.js
@@ -9,7 +9,7 @@
 
 import type {MatchersObject} from 'types/Matchers';
 
-import diff from 'jest-diff';
+import jestDiff from 'jest-diff';
 import getType from 'jest-get-type';
 import {escapeStrForRegex} from 'jest-regex-util';
 import {
@@ -25,6 +25,7 @@ import {
   printReceived,
   printExpected,
   printWithType,
+  shouldPrintDiff,
 } from 'jest-matcher-utils';
 import {
   getObjectSubset,
@@ -43,6 +44,9 @@ type ContainIterable =
   | NodeList<any>
   | DOMTokenList
   | HTMLCollection<any>;
+
+const diff: typeof jestDiff = (a, b, options) =>
+  shouldPrintDiff(a, b) ? jestDiff(a, b, options) : null;
 
 const matchers: MatchersObject = {
   toBe(received: any, expected: any) {

--- a/packages/expect/src/spyMatchers.js
+++ b/packages/expect/src/spyMatchers.js
@@ -13,6 +13,7 @@ const CALL_PRINT_LIMIT = 3;
 const RETURN_PRINT_LIMIT = 5;
 const LAST_CALL_PRINT_LIMIT = 1;
 import {
+  diff,
   ensureExpectedIsNumber,
   ensureNoExpected,
   EXPECTED_COLOR,
@@ -26,7 +27,6 @@ import {
 } from 'jest-matcher-utils';
 import {equals} from './jasmineUtils';
 import {iterableEquality, partition, isOneline} from './utils';
-import diff from 'jest-diff';
 
 const createToBeCalledMatcher = matcherName => (received, expected) => {
   ensureNoExpected(expected, matcherName);

--- a/packages/jest-circus/package.json
+++ b/packages/jest-circus/package.json
@@ -14,7 +14,6 @@
     "co": "^4.6.0",
     "expect": "^23.6.0",
     "is-generator-fn": "^2.0.0",
-    "jest-diff": "^23.6.0",
     "jest-each": "^23.6.0",
     "jest-matcher-utils": "^23.6.0",
     "jest-message-util": "^23.4.0",
@@ -25,6 +24,7 @@
   },
   "devDependencies": {
     "execa": "^1.0.0",
+    "jest-diff": "^23.6.0",
     "jest-runtime": "^23.6.0"
   },
   "engines": {

--- a/packages/jest-circus/src/formatNodeAssertErrors.js
+++ b/packages/jest-circus/src/formatNodeAssertErrors.js
@@ -10,9 +10,8 @@
 import type {DiffOptions} from 'jest-diff/src/diffStrings';
 import type {Event, State} from 'types/Circus';
 
-import {printExpected, printReceived} from 'jest-matcher-utils';
+import {diff, printExpected, printReceived} from 'jest-matcher-utils';
 import chalk from 'chalk';
-import diff from 'jest-diff';
 import prettyFormat from 'pretty-format';
 
 type AssertionError = {|

--- a/packages/jest-diff/src/__tests__/diff.test.js
+++ b/packages/jest-diff/src/__tests__/diff.test.js
@@ -48,9 +48,12 @@ describe('no visual difference', () => {
     [[], []],
     [[1, 2], [1, 2]],
     [11, 11],
+    [NaN, NaN],
+    [Number.NaN, NaN],
     [() => {}, () => {}],
     [null, null],
     [undefined, undefined],
+    [false, false],
     [{a: 1}, {a: 1}],
     [{a: {b: 5}}, {a: {b: 5}}],
   ].forEach(values => {
@@ -178,13 +181,17 @@ describe('objects', () => {
 });
 
 test('numbers', () => {
-  const result = diff(123, 234);
-  expect(result).toBe(null);
+  expect(stripped(1, 2)).toEqual(expect.stringContaining('- 1\n+ 2'));
+});
+
+test('-0 and 0', () => {
+  expect(stripped(-0, 0)).toEqual(expect.stringContaining('- -0\n+ 0'));
 });
 
 test('booleans', () => {
-  const result = diff(true, false);
-  expect(result).toBe(null);
+  expect(stripped(false, true)).toEqual(
+    expect.stringContaining('- false\n+ true'),
+  );
 });
 
 describe('multiline string non-snapshot', () => {

--- a/packages/jest-diff/src/index.js
+++ b/packages/jest-diff/src/index.js
@@ -46,7 +46,7 @@ const FALLBACK_FORMAT_OPTIONS_0 = {...FALLBACK_FORMAT_OPTIONS, indent: 0};
 // Generate a string that will highlight the difference between two values
 // with green and red. (similar to how github does code diffing)
 function diff(a: any, b: any, options: ?DiffOptions): ?string {
-  if (a === b) {
+  if (Object.is(a, b)) {
     return NO_DIFF_MESSAGE;
   }
 

--- a/packages/jest-diff/src/index.js
+++ b/packages/jest-diff/src/index.js
@@ -83,9 +83,9 @@ function diff(a: any, b: any, options: ?DiffOptions): ?string {
   switch (aType) {
     case 'string':
       return diffStrings(a, b, options);
-    case 'number':
     case 'boolean':
-      return null;
+    case 'number':
+      return comparePrimitive(a, b, options);
     case 'map':
       return compareObjects(sortMap(a), sortMap(b), options);
     case 'set':
@@ -93,6 +93,18 @@ function diff(a: any, b: any, options: ?DiffOptions): ?string {
     default:
       return compareObjects(a, b, options);
   }
+}
+
+function comparePrimitive(
+  a: number | boolean,
+  b: number | boolean,
+  options: ?DiffOptions,
+) {
+  return diffStrings(
+    prettyFormat(a, FORMAT_OPTIONS),
+    prettyFormat(b, FORMAT_OPTIONS),
+    options,
+  );
 }
 
 function sortMap(map) {

--- a/packages/jest-jasmine2/package.json
+++ b/packages/jest-jasmine2/package.json
@@ -14,7 +14,6 @@
     "co": "^4.6.0",
     "expect": "^23.6.0",
     "is-generator-fn": "^2.0.0",
-    "jest-diff": "^23.6.0",
     "jest-each": "^23.6.0",
     "jest-matcher-utils": "^23.6.0",
     "jest-message-util": "^23.4.0",
@@ -23,6 +22,7 @@
     "pretty-format": "^23.6.0"
   },
   "devDependencies": {
+    "jest-diff": "^23.6.0",
     "jest-runtime": "^23.6.0"
   },
   "engines": {

--- a/packages/jest-jasmine2/src/assertionErrorMessage.js
+++ b/packages/jest-jasmine2/src/assertionErrorMessage.js
@@ -9,9 +9,8 @@
 
 import type {DiffOptions} from 'jest-diff/src/diffStrings';
 
-import {printReceived, printExpected} from 'jest-matcher-utils';
+import {diff, printReceived, printExpected} from 'jest-matcher-utils';
 import chalk from 'chalk';
-import diff from 'jest-diff';
 
 type AssertionError = {|
   actual: ?string,

--- a/packages/jest-matcher-utils/package.json
+++ b/packages/jest-matcher-utils/package.json
@@ -14,6 +14,7 @@
   "main": "build/index.js",
   "dependencies": {
     "chalk": "^2.0.1",
+    "jest-diff": "^23.6.0",
     "jest-get-type": "^22.1.0",
     "pretty-format": "^23.6.0"
   }

--- a/packages/jest-matcher-utils/src/__tests__/index.test.js
+++ b/packages/jest-matcher-utils/src/__tests__/index.test.js
@@ -7,11 +7,11 @@
  */
 
 import {
+  diff,
   ensureNumbers,
   ensureNoExpected,
   getLabelPrinter,
   pluralize,
-  shouldPrintDiff,
   stringify,
 } from '../';
 
@@ -130,8 +130,9 @@ describe('.ensureNoExpected()', () => {
   });
 });
 
-describe('shouldPrintDiff', () => {
-  test('true', () => {
+jest.mock('jest-diff', () => () => 'diff output');
+describe('diff', () => {
+  test('forwards to jest-diff', () => {
     [
       ['a', 'b'],
       ['a', {}],
@@ -141,16 +142,16 @@ describe('shouldPrintDiff', () => {
       ['a', true],
       [1, true],
     ].forEach(([actual, expected]) =>
-      expect(shouldPrintDiff(actual, expected)).toBe(true),
+      expect(diff(actual, expected)).toBe('diff output'),
     );
   });
 
   test('two booleans', () => {
-    expect(shouldPrintDiff(false, true)).toBe(false);
+    expect(diff(false, true)).toBe(null);
   });
 
   test('two numbers', () => {
-    expect(shouldPrintDiff(1, 2)).toBe(false);
+    expect(diff(1, 2)).toBe(null);
   });
 });
 

--- a/packages/jest-matcher-utils/src/__tests__/index.test.js
+++ b/packages/jest-matcher-utils/src/__tests__/index.test.js
@@ -11,6 +11,7 @@ import {
   ensureNoExpected,
   getLabelPrinter,
   pluralize,
+  shouldPrintDiff,
   stringify,
 } from '../';
 
@@ -126,6 +127,30 @@ describe('.ensureNoExpected()', () => {
     expect(() => {
       ensureNoExpected({a: 1}, 'toBeDefined', {isNot: true});
     }).toThrowErrorMatchingSnapshot();
+  });
+});
+
+describe('shouldPrintDiff', () => {
+  test('true', () => {
+    [
+      ['a', 'b'],
+      ['a', {}],
+      ['a', null],
+      ['a', undefined],
+      ['a', 1],
+      ['a', true],
+      [1, true],
+    ].forEach(([actual, expected]) =>
+      expect(shouldPrintDiff(actual, expected)).toBe(true),
+    );
+  });
+
+  test('two booleans', () => {
+    expect(shouldPrintDiff(false, true)).toBe(false);
+  });
+
+  test('two numbers', () => {
+    expect(shouldPrintDiff(1, 2)).toBe(false);
   });
 });
 

--- a/packages/jest-matcher-utils/src/index.js
+++ b/packages/jest-matcher-utils/src/index.js
@@ -10,6 +10,7 @@
 import type {MatcherHintOptions} from 'types/Matchers';
 
 import chalk from 'chalk';
+import jestDiff from 'jest-diff';
 import getType from 'jest-get-type';
 import prettyFormat from 'pretty-format';
 const {
@@ -163,7 +164,7 @@ export const ensureNumbers = (
 // Sometimes, e.g. when comparing two numbers, the output from jest-diff
 // does not contain more information than the `Expected:` / `Received:` already gives.
 // In those cases, we do not print a diff to make the output shorter and not redundant.
-export const shouldPrintDiff = (actual: any, expected: any) => {
+const shouldPrintDiff = (actual: any, expected: any) => {
   if (typeof actual === 'number' && typeof expected === 'number') {
     return false;
   }
@@ -172,6 +173,8 @@ export const shouldPrintDiff = (actual: any, expected: any) => {
   }
   return true;
 };
+export const diff: typeof jestDiff = (a, b, options) =>
+  shouldPrintDiff(a, b) ? jestDiff(a, b, options) : null;
 
 export const pluralize = (word: string, count: number) =>
   (NUMBERS[count] || count) + ' ' + word + (count === 1 ? '' : 's');

--- a/packages/jest-matcher-utils/src/index.js
+++ b/packages/jest-matcher-utils/src/index.js
@@ -160,6 +160,19 @@ export const ensureNumbers = (
   ensureExpectedIsNumber(expected, matcherName);
 };
 
+// Sometimes, e.g. when comparing two numbers, the output from jest-diff
+// does not contain more information than the `Expected:` / `Received:` already gives.
+// In those cases, we do not print a diff to make the output shorter and not redundant.
+export const shouldPrintDiff = (actual: any, expected: any) => {
+  if (typeof actual === 'number' && typeof expected === 'number') {
+    return false;
+  }
+  if (typeof actual === 'boolean' && typeof expected === 'boolean') {
+    return false;
+  }
+  return true;
+};
+
 export const pluralize = (word: string, count: number) =>
   (NUMBERS[count] || count) + ' ' + word + (count === 1 ? '' : 's');
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Currently, `jest-diff` returns `null` when diffing numbers or booleans (or `NO_DIFF_MESSAGE` if they are equal).
This is because the matchers that use jest-diff already print something like
```
Expected: 2
Received: 1
```
if they differ, so the jest-diff output would be redundant.

This behavior is unintuitive if you are using `jest-diff` for something other than Jest's test failure output.
I stumbled upon this trying to build a `diff`-like CLI for `jest-diff`.
It was also quite inexplicable to me when I first read the jest-diff code ("why does it just not do anything if a and b are numbers?"), so I think this piece of code needed clarification in general.

This PR changes jest-diff to behave like normal diffing by default, with an `omitTrivial` option that the matchers use to tell jest-diff not to generate a diff between numbers or booleans.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Added tests for numbers and booleans to `diff.test`.
e2e tests unchanged, confirming that this does not change the overall behavior of Jest.
One exception: Along the way, I also fixed the following contradictory output :D
```
Expected: 0
Received: -0

Difference:

Compared values have no visual difference.
```
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->