### PR TITLE
Stops calling existsSync on object configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 
 ### Fixes
 
+- `[jest-config]` Ensure `existsSync` is only called with a string parameter ([#7607](https://github.com/facebook/jest/pull/7607))
 - `[expect]` `toStrictEqual` considers sparseness of arrays. ([#7591](https://github.com/facebook/jest/pull/7591))
 - `[jest-cli]` Fix empty coverage data for untested files ([#7388](https://github.com/facebook/jest/pull/7388))
 - `[jest-cli]` [**BREAKING**] Do not use `text-summary` coverage reporter by default if other reporters are configured ([#7058](https://github.com/facebook/jest/pull/7058))

--- a/packages/jest-config/src/index.js
+++ b/packages/jest-config/src/index.js
@@ -286,6 +286,7 @@ export function readConfigs(
       .filter(root => {
         // Ignore globbed files that cannot be `require`d.
         if (
+          typeof root === 'string' &&
           fs.existsSync(root) &&
           !fs.lstatSync(root).isDirectory() &&
           !root.endsWith('.js') &&


### PR DESCRIPTION
## Summary

The previous code was calling `existsSync` by passing a `root` to it, which could either be a string or a Jest configuration object. The `existsSync` implementation currently accepts both, but this behavior is frowned upon and [might be deprecated](https://github.com/nodejs/node/blob/master/lib/fs.js#L221-L226) in later Node releases. This diff simply checks whether the root is a path before calling `existsSync` on it.

cc @rubennorte 

## Test plan

Not easy to test since it currently works even without the PR 😄 