### PR TITLE
Migrate back to CommonJS export for jest-runtime

### DIFF
--- a/packages/jest-cli/src/__tests__/SearchSource.test.js
+++ b/packages/jest-cli/src/__tests__/SearchSource.test.js
@@ -31,7 +31,7 @@ describe('SearchSource', () => {
   let searchSource;
 
   beforeEach(() => {
-    Runtime = require('jest-runtime').default;
+    Runtime = require('jest-runtime');
     SearchSource = require('../SearchSource').default;
     normalize = require('jest-config').normalize;
   });

--- a/packages/jest-resolve-dependencies/src/__tests__/dependency_resolver.test.js
+++ b/packages/jest-resolve-dependencies/src/__tests__/dependency_resolver.test.js
@@ -23,7 +23,7 @@ const cases = {
 const filter = path => Object.keys(cases).every(key => cases[key](path));
 
 beforeEach(() => {
-  Runtime = require('jest-runtime').default;
+  Runtime = require('jest-runtime');
   config = normalize(
     {
       rootDir: '.',

--- a/packages/jest-runner/src/runTest.js
+++ b/packages/jest-runner/src/runTest.js
@@ -73,7 +73,7 @@ async function runTestInternal(
   const Runtime = ((config.moduleLoader
     ? /* $FlowFixMe */
       require(config.moduleLoader)
-    : require('jest-runtime').default): Class<RuntimeClass>);
+    : require('jest-runtime')): Class<RuntimeClass>);
 
   let runtime = undefined;
 

--- a/packages/jest-runtime/src/__mocks__/createRuntime.js
+++ b/packages/jest-runtime/src/__mocks__/createRuntime.js
@@ -9,7 +9,7 @@ import path from 'path';
 
 module.exports = function createRuntime(filename, config) {
   const NodeEnvironment = require('jest-environment-node');
-  const Runtime = require('../').default;
+  const Runtime = require('../');
 
   const {normalize} = require('jest-config');
 

--- a/packages/jest-runtime/src/cli/index.js
+++ b/packages/jest-runtime/src/cli/index.js
@@ -17,8 +17,6 @@ import yargs from 'yargs';
 import {Console, setGlobal} from 'jest-util';
 import {validateCLIOptions} from 'jest-validate';
 import {readConfig, deprecationEntries} from 'jest-config';
-// eslint-disable-next-line import/default
-import Runtime from '../';
 import * as args from './args';
 
 const VERSION = (require('../../package.json').version: string);
@@ -75,6 +73,10 @@ export function run(cliArgv?: Argv, cliInfo?: Array<string>) {
     automock: false,
     unmockedModulePathPatterns: null,
   });
+
+  // Break circular dependency
+  const Runtime = require('..');
+
   Runtime.createContext(config, {
     maxWorkers: Math.max(os.cpus().length - 1, 1),
     watchman: globalConfig.watchman,

--- a/packages/jest-runtime/src/index.js
+++ b/packages/jest-runtime/src/index.js
@@ -1017,4 +1017,4 @@ class Runtime {
 
 Runtime.ScriptTransformer = ScriptTransformer;
 
-export default Runtime;
+module.exports = Runtime;


### PR DESCRIPTION
## Summary

`jest-runtime` was inadvertently migrated to export ESM in #7016 and it's actually a breaking change. This should have been part of #7602.

## Test plan

Current tests.