### PR TITLE
Fix tests on Node 11 and run them in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,7 @@ jobs:
   test-browser:
     working_directory: ~/jest
     docker:
-      - image: circleci/node:8-browsers
+      - image: circleci/node:10-browsers
     steps:
       - checkout
       - restore-cache: *restore-cache
@@ -115,7 +115,7 @@ jobs:
   test-or-deploy-website:
     working_directory: ~/jest
     docker:
-      - image: circleci/node:8
+      - image: circleci/node:10
     resource_class: large
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,16 +30,34 @@ jobs:
       - store_test_results:
           path: reports/junit
 
-  test-browser:
+  test-node-6:
     working_directory: ~/jest
     docker:
-      - image: circleci/node:8-browsers
+      - image: circleci/node:6
+    steps:
+      - checkout
+      - restore-cache: *restore-cache
+      - run: yarn --no-progress --ignore-engines
+      - save-cache: *save-cache
+      - run:
+          # react-native does not work with node 6
+          command: rm -rf examples/react-native && yarn test-ci-partial
+      - store_test_results:
+          path: reports/junit
+
+  test-node-8:
+    working_directory: ~/jest
+    docker:
+      - image: circleci/node:8
     steps:
       - checkout
       - restore-cache: *restore-cache
       - run: yarn --no-progress
       - save-cache: *save-cache
-      - run: yarn test-ci-es5-build-in-browser
+      - run:
+          command: yarn test-ci-partial
+      - store_test_results:
+          path: reports/junit
 
   test-node-10:
     working_directory: ~/jest
@@ -69,10 +87,10 @@ jobs:
       - store_test_results:
           path: reports/junit
 
-  test-node-8:
+  test-node-11:
     working_directory: ~/jest
     docker:
-      - image: circleci/node:8
+      - image: circleci/node:11
     steps:
       - checkout
       - restore-cache: *restore-cache
@@ -83,20 +101,16 @@ jobs:
       - store_test_results:
           path: reports/junit
 
-  test-node-6:
+  test-browser:
     working_directory: ~/jest
     docker:
-      - image: circleci/node:6
+      - image: circleci/node:8-browsers
     steps:
       - checkout
       - restore-cache: *restore-cache
-      - run: yarn --no-progress --ignore-engines
+      - run: yarn --no-progress
       - save-cache: *save-cache
-      - run:
-          # react-native does not work with node 6
-          command: rm -rf examples/react-native && yarn test-ci-partial
-      - store_test_results:
-          path: reports/junit
+      - run: yarn test-ci-es5-build-in-browser
 
   test-or-deploy-website:
     working_directory: ~/jest
@@ -118,10 +132,11 @@ workflows:
   build-and-deploy:
     jobs:
       - lint-and-typecheck
-      - test-node-8
       - test-node-6
+      - test-node-8
       - test-node-10
       - test-jest-circus
+      - test-node-11 # current
       - test-browser
       - test-or-deploy-website:
           filters: *filter-ignore-gh-pages

--- a/packages/jest-cli/src/TestSequencer.js
+++ b/packages/jest-cli/src/TestSequencer.js
@@ -83,8 +83,8 @@ export default class TestSequencer {
       if (failedA !== failedB) {
         return failedA ? -1 : 1;
       } else if (hasTimeA != (testB.duration != null)) {
-        // Check if only one of two tests has timing information
-        return hasTimeA != null ? 1 : -1;
+        // If only one of two tests has timing information, run it last
+        return hasTimeA ? 1 : -1;
       } else if (testA.duration != null && testB.duration != null) {
         return testA.duration < testB.duration ? 1 : -1;
       } else {

--- a/packages/jest-cli/src/lib/watch_plugins_helpers.js
+++ b/packages/jest-cli/src/lib/watch_plugins_helpers.js
@@ -33,17 +33,22 @@ export const getSortedUsageRows = (
 ): Array<UsageData> =>
   filterInteractivePlugins(watchPlugins, globalConfig)
     .sort((a: WatchPlugin, b: WatchPlugin) => {
-      if (a.isInternal) {
-        return -1;
+      if (a.isInternal && b.isInternal) {
+        // internal plugins in the order we specify them
+        return 0;
+      }
+      if (a.isInternal !== b.isInternal) {
+        // external plugins afterwards
+        return a.isInternal ? -1 : 1;
       }
 
       const usageInfoA = a.getUsageInfo && a.getUsageInfo(globalConfig);
       const usageInfoB = b.getUsageInfo && b.getUsageInfo(globalConfig);
 
       if (usageInfoA && usageInfoB) {
+        // external plugins in alphabetical order
         return usageInfoA.key.localeCompare(usageInfoB.key);
       }
-
       return 0;
     })
     .map(p => p.getUsageInfo && p.getUsageInfo(globalConfig))


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Jest tests currently fail on Node 11, which is annoying because I (like probably many others) have Node 11 installed as their default environment on dev machines.

The test sequencer and watch mode usage are affected, both because Node 11 (via a v8 update) now has a stable `Array.sort`, revealing that our compareFunctions were inconsistent.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Tests that previously passed on Node 10 but failed on Node 11 now pass on both.
CI now runs the tests on Node 11 as well.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
