### PR TITLE
chore: make sure to call `realpath` when accessing `cwd`

### DIFF
--- a/packages/jest-cli/src/SearchSource.js
+++ b/packages/jest-cli/src/SearchSource.js
@@ -186,7 +186,7 @@ export default class SearchSource {
       tests: toTests(
         this._context,
         paths
-          .map(p => path.resolve(process.cwd(), p))
+          .map(p => path.resolve(this._context.config.cwd, p))
           .filter(this.isTestFilePath.bind(this)),
       ),
     };
@@ -197,7 +197,9 @@ export default class SearchSource {
     collectCoverage: boolean,
   ): SearchResult {
     if (Array.isArray(paths) && paths.length) {
-      const resolvedPaths = paths.map(p => path.resolve(process.cwd(), p));
+      const resolvedPaths = paths.map(p =>
+        path.resolve(this._context.config.cwd, p),
+      );
       return this.findRelatedTests(new Set(resolvedPaths), collectCoverage);
     }
     return {tests: []};

--- a/packages/jest-cli/src/getNoTestFound.js
+++ b/packages/jest-cli/src/getNoTestFound.js
@@ -1,9 +1,22 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {GlobalConfig} from 'types/Config';
+import type {TestRunData} from 'types/TestRunner';
 
 import chalk from 'chalk';
 import pluralize from './pluralize';
 
-export default function getNoTestFound(testRunData, globalConfig): string {
+export default function getNoTestFound(
+  testRunData: TestRunData,
+  globalConfig: GlobalConfig,
+): string {
   const testFiles = testRunData.reduce(
     (current, testRun) => current + testRun.matches.total || 0,
     0,
@@ -25,7 +38,7 @@ export default function getNoTestFound(testRunData, globalConfig): string {
     '\n' +
     'Run with `--passWithNoTests` to exit with code 0' +
     '\n' +
-    `In ${chalk.bold(process.cwd())}` +
+    `In ${chalk.bold(globalConfig.rootDir)}` +
     '\n' +
     `  ${pluralize('file', testFiles, 's')} checked across ${pluralize(
       'project',

--- a/packages/jest-cli/src/getNoTestsFoundMessage.js
+++ b/packages/jest-cli/src/getNoTestsFoundMessage.js
@@ -1,4 +1,14 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import type {GlobalConfig} from 'types/Config';
+import type {TestRunData} from 'types/TestRunner';
 
 import getNoTestFound from './getNoTestFound';
 import getNoTestFoundRelatedToChangedFiles from './getNoTestFoundRelatedToChangedFiles';
@@ -6,8 +16,8 @@ import getNoTestFoundVerbose from './getNoTestFoundVerbose';
 import getNoTestFoundFailed from './getNoTestFoundFailed';
 
 export default function getNoTestsFoundMessage(
-  testRunData,
-  globalConfig,
+  testRunData: TestRunData,
+  globalConfig: GlobalConfig,
 ): string {
   if (globalConfig.onlyFailures) {
     return getNoTestFoundFailed();

--- a/packages/jest-cli/src/lib/init/index.js
+++ b/packages/jest-cli/src/lib/init/index.js
@@ -11,6 +11,7 @@ import chalk from 'chalk';
 import fs from 'fs';
 import path from 'path';
 import prompts from 'prompts';
+import {sync as realpath} from 'realpath-native';
 import defaultQuestions, {testScriptQuestion} from './questions';
 import {NotFoundPackageJsonError, MalformedPackageJsonError} from './errors';
 import {PACKAGE_JSON, JEST_CONFIG} from '../../constants';
@@ -24,7 +25,7 @@ type PromptsResults = {
   scripts: boolean,
 };
 
-export default async (rootDir: string = process.cwd()) => {
+export default async (rootDir: string = realpath(process.cwd())) => {
   // prerequisite checks
   const projectPackageJsonPath: string = path.join(rootDir, PACKAGE_JSON);
   const jestConfigPath: string = path.join(rootDir, JEST_CONFIG);

--- a/packages/jest-cli/src/runJest.js
+++ b/packages/jest-cli/src/runJest.js
@@ -18,6 +18,7 @@ import type TestWatcher from './TestWatcher';
 import micromatch from 'micromatch';
 import chalk from 'chalk';
 import path from 'path';
+import {sync as realpath} from 'realpath-native';
 import {Console, formatTestResults} from 'jest-util';
 import exit from 'exit';
 import fs from 'graceful-fs';
@@ -73,7 +74,6 @@ const processResults = (runResults, options) => {
     onComplete,
     outputStream,
     testResultsProcessor,
-    rootDir,
     collectHandles,
   } = options;
 
@@ -89,11 +89,12 @@ const processResults = (runResults, options) => {
   }
   if (isJSON) {
     if (outputFile) {
-      const filePath = path.resolve(rootDir, outputFile);
+      const cwd = realpath(process.cwd());
+      const filePath = path.resolve(cwd, outputFile);
 
       fs.writeFileSync(filePath, JSON.stringify(formatTestResults(runResults)));
       outputStream.write(
-        `Test results written to: ${path.relative(rootDir, filePath)}\n`,
+        `Test results written to: ${path.relative(cwd, filePath)}\n`,
       );
     } else {
       process.stdout.write(JSON.stringify(formatTestResults(runResults)));
@@ -274,7 +275,6 @@ export default (async function runJest({
     onComplete,
     outputFile: globalConfig.outputFile,
     outputStream,
-    rootDir: globalConfig.rootDir,
     testResultsProcessor: globalConfig.testResultsProcessor,
   });
 });

--- a/packages/jest-resolve/src/index.js
+++ b/packages/jest-resolve/src/index.js
@@ -12,8 +12,8 @@ import type {ModuleMap} from 'types/HasteMap';
 import type {ResolveModuleConfig} from 'types/Resolve';
 import type {ErrorWithCode} from 'types/Errors';
 
-import fs from 'fs';
 import path from 'path';
+import {sync as realpath} from 'realpath-native';
 import nodeModulesPaths from './nodeModulesPaths';
 import isBuiltinModule from './isBuiltinModule';
 import defaultResolver from './defaultResolver';
@@ -53,7 +53,7 @@ const NATIVE_PLATFORM = 'native';
 
 // We might be inside a symlink.
 const cwd = process.cwd();
-const resolvedCwd = fs.realpathSync(cwd) || cwd;
+const resolvedCwd = realpath(cwd) || cwd;
 const nodePaths = process.env.NODE_PATH
   ? process.env.NODE_PATH.split(path.delimiter)
       .filter(Boolean)

--- a/packages/jest-runtime/src/cli/index.js
+++ b/packages/jest-runtime/src/cli/index.js
@@ -13,6 +13,7 @@ import type {EnvironmentClass} from 'types/Environment';
 import chalk from 'chalk';
 import os from 'os';
 import path from 'path';
+import {sync as realpath} from 'realpath-native';
 import yargs from 'yargs';
 import {Console, setGlobal} from 'jest-util';
 import {validateCLIOptions} from 'jest-validate';
@@ -59,7 +60,7 @@ export function run(cliArgv?: Argv, cliInfo?: Array<string>) {
     return;
   }
 
-  const root = process.cwd();
+  const root = realpath(process.cwd());
   const filePath = path.resolve(root, argv._[0]);
 
   if (argv.debug) {

--- a/types/TestRunner.js
+++ b/types/TestRunner.js
@@ -60,3 +60,8 @@ export type TestFramework = (
 export type TestRunnerOptions = {
   serial: boolean,
 };
+
+export type TestRunData = Array<{
+  context: Context,
+  matches: {allTests: number, tests: Array<Test>, total: number},
+}>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4503,7 +4503,7 @@ diacritics-map@^0.1.0:
   resolved "https://registry.yarnpkg.com/diacritics-map/-/diacritics-map-0.1.0.tgz#6dfc0ff9d01000a2edf2865371cac316e94977af"
   integrity sha1-bfwP+dAQAKLt8oZTccrDFulJd68=
 
-diff@3.5.0, diff@^3.2.0:
+diff@3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
   integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary
More from #7556. There's quite a few places we access `cwd`, even though we have a `cwd` in `ProjectConfig` already. Instead of `realpath`ing them again, we should reuse the one from config.

Also consistently `realpath` `cwd` in the places where we don't have `config`.

/cc @willsmythe

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan
Green CI

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
