### PR TITLE
Ignore imports of types with typescript

### DIFF
--- a/packages/jest-haste-map/package.json
+++ b/packages/jest-haste-map/package.json
@@ -8,6 +8,7 @@
   "license": "MIT",
   "main": "build/index.js",
   "dependencies": {
+    "@babel/plugin-transform-typescript": "^7.2.0",
     "fb-watchman": "^2.0.0",
     "graceful-fs": "^4.1.15",
     "invariant": "^2.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -400,6 +400,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
+"@babel/plugin-syntax-typescript@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.2.0.tgz#55d240536bd314dcbbec70fd949c5cabaed1de29"
+  integrity sha512-WhKr6yu6yGpGcNMVgIBuI9MkredpVc7Y3YR4UzEZmDztHoL6wV56YBHLhWnjO1EvId1B32HrD3DRFc+zSoKI1g==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
 "@babel/plugin-transform-arrow-functions@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.0.0.tgz#a6c14875848c68a3b4b3163a486535ef25c7e749"
@@ -691,6 +698,14 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-typescript" "^7.0.0"
+
+"@babel/plugin-transform-typescript@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.2.0.tgz#bce7c06300434de6a860ae8acf6a442ef74a99d1"
+  integrity sha512-EnI7i2/gJ7ZNr2MuyvN2Hu+BHJENlxWte5XygPvfj/MbvtOkWor9zcnHpMMQL2YYaaCcqtIvJUyJ7QVfoGs7ew==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-syntax-typescript" "^7.2.0"
 
 "@babel/plugin-transform-unicode-regex@^7.0.0":
   version "7.0.0"
@@ -4503,7 +4518,7 @@ diacritics-map@^0.1.0:
   resolved "https://registry.yarnpkg.com/diacritics-map/-/diacritics-map-0.1.0.tgz#6dfc0ff9d01000a2edf2865371cac316e94977af"
   integrity sha1-bfwP+dAQAKLt8oZTccrDFulJd68=
 
-diff@3.5.0, diff@^3.2.0:
+diff@3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
   integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==


### PR DESCRIPTION
Currently importing the types from a separate file creates a dependency, that will cause jest to run substantially more tests than it should be.

To show a specific case I created a semi-generated graphql [server](https://github.com/TheBrainFamily/test-driven-and-typed-graphql-server) : where I did outside-in TDD development (and then replicated in two other types that are basically the same). This way I have ~250 tests that are completely decoupled. Besides the first-layer tests that hit the graphql directly, all the remaining tests are concerned with one class/file, and should preferably only run in a watch mode when that particular corresponding file changes. Similarly, all files (besides the graphql layer), should cause only a single test to run.

With this change applied and jest linked, when changing src/articles/articlesRepository.ts:

<img width="1075" alt="screen shot 2019-01-12 at 7 10 31 pm" src="https://user-images.githubusercontent.com/4002543/51075044-bd1e4700-169f-11e9-9956-9262d5e6b2e5.png">

Without it (same file changed):

<img width="1090" alt="screen shot 2019-01-12 at 7 13 15 pm" src="https://user-images.githubusercontent.com/4002543/51075048-c1e2fb00-169f-11e9-8bc2-8b044a1b5468.png">


My solution/proposition is to use babel to strip the imports of the types, which will decouple files that are depending on types ("interfaces"), but not implementations. 

This was an idea that came to me after an enlightening (for me) [discussion](https://github.com/testdouble/testdouble.js/pull/401) with @searls @marcpeabody and @samhatoum  around the topic of  Dependency Inversion/using interfaces that will be implemented by single classes, while writing documentation about using TestDouble with TypeScript.

I acknowledge that there is a performance hit on the start, but it happens only the first time jest is ran in the given project, after that the hastemap cache is doing an amazing job of keeping everything very snappy. 

I also acknowledge, that this might be a rare usecase, but maybe with a change like this more people would be willing to look at it? I think the advantages for a Test Driven workflow are significant. 

If there is no chance of merging it like this, maybe some way to opt-in for this behavior? I wish I was able to just use the dependencyExtractor for something like this, but it only takes text, so it doesn't know if a given import is for a type, or for something concrete. 

Another suggestion would be to allow dependencyExtractor to take a file path instead of code as a text.

Thank you guys!

## Test plan

I added the tests, although I'm pretty sure there is a better place to add them, please advise. I treat this as a WIP/proposal open for discussion.