### PR TITLE
Update docs re: `moduleFileExtensions` to add ordering note (left-to-right)

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -392,6 +392,8 @@ Default: `["js", "json", "jsx", "ts", "tsx", "node"]`
 
 An array of file extensions your modules use. If you require modules without specifying a file extension, these are the extensions Jest will look for, in left-to-right order.
 
+We recommend placing the extensions most commonly used in your project on the left, so if you are using TypeScript, you may want to consider moving "ts" and/or "tsx" to the beginning of the array.
+
 ### `moduleNameMapper` [object<string, string>]
 
 Default: `null`

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -390,7 +390,7 @@ An array of directory names to be searched recursively up from the requiring mod
 
 Default: `["js", "json", "jsx", "ts", "tsx", "node"]`
 
-An array of file extensions your modules use. If you require modules without specifying a file extension, these are the extensions Jest will look for.
+An array of file extensions your modules use. If you require modules without specifying a file extension, these are the extensions Jest will look for, in left-to-right order.
 
 ### `moduleNameMapper` [object<string, string>]
 

--- a/website/versioned_docs/version-22.0/Configuration.md
+++ b/website/versioned_docs/version-22.0/Configuration.md
@@ -276,9 +276,9 @@ return {
 
 Default: `["js", "json", "jsx", "node"]`
 
-An array of file extensions your modules use. If you require modules without specifying a file extension, these are the extensions Jest will look for.
+An array of file extensions your modules use. If you require modules without specifying a file extension, these are the extensions Jest will look for, in left-to-right order.
 
-If you are using TypeScript this should be `["js", "jsx", "json", "ts", "tsx"]`, check [ts-jest's documentation](https://github.com/kulshekhar/ts-jest).
+If you are using TypeScript, you will want to add `"ts"` and/or `"tsx"` to above default. Where you place these is up to you - we recommend placing the extensions most commonly used in your project on the left.
 
 ### `moduleDirectories` [array<string>]
 

--- a/website/versioned_docs/version-22.0/Configuration.md
+++ b/website/versioned_docs/version-22.0/Configuration.md
@@ -278,7 +278,7 @@ Default: `["js", "json", "jsx", "node"]`
 
 An array of file extensions your modules use. If you require modules without specifying a file extension, these are the extensions Jest will look for, in left-to-right order.
 
-If you are using TypeScript, you will want to add `"ts"` and/or `"tsx"` to above default. Where you place these is up to you - we recommend placing the extensions most commonly used in your project on the left.
+If you are using TypeScript, you will want to add `"ts"` and/or `"tsx"` to the above default. Where you place these is up to you - we recommend placing the extensions most commonly used in your project on the left.
 
 ### `moduleDirectories` [array<string>]
 

--- a/website/versioned_docs/version-22.1/Configuration.md
+++ b/website/versioned_docs/version-22.1/Configuration.md
@@ -276,7 +276,7 @@ Default: `["js", "json", "jsx", "node"]`
 
 An array of file extensions your modules use. If you require modules without specifying a file extension, these are the extensions Jest will look for, in left-to-right order.
 
-If you are using TypeScript, you will want to add `"ts"` and/or `"tsx"` to above default. Where you place these is up to you - we recommend placing the extensions most commonly used in your project on the left.
+If you are using TypeScript, you will want to add `"ts"` and/or `"tsx"` to the above default. Where you place these is up to you - we recommend placing the extensions most commonly used in your project on the left.
 
 ### `moduleDirectories` [array<string>]
 

--- a/website/versioned_docs/version-22.1/Configuration.md
+++ b/website/versioned_docs/version-22.1/Configuration.md
@@ -274,9 +274,9 @@ return {
 
 Default: `["js", "json", "jsx", "node"]`
 
-An array of file extensions your modules use. If you require modules without specifying a file extension, these are the extensions Jest will look for.
+An array of file extensions your modules use. If you require modules without specifying a file extension, these are the extensions Jest will look for, in left-to-right order.
 
-If you are using TypeScript this should be `["js", "jsx", "json", "ts", "tsx"]`, check [ts-jest's documentation](https://github.com/kulshekhar/ts-jest).
+If you are using TypeScript, you will want to add `"ts"` and/or `"tsx"` to above default. Where you place these is up to you - we recommend placing the extensions most commonly used in your project on the left.
 
 ### `moduleDirectories` [array<string>]
 

--- a/website/versioned_docs/version-22.2/Configuration.md
+++ b/website/versioned_docs/version-22.2/Configuration.md
@@ -276,7 +276,7 @@ Default: `["js", "json", "jsx", "node"]`
 
 An array of file extensions your modules use. If you require modules without specifying a file extension, these are the extensions Jest will look for, in left-to-right order.
 
-If you are using TypeScript, you will want to add `"ts"` and/or `"tsx"` to above default. Where you place these is up to you - we recommend placing the extensions most commonly used in your project on the left.
+If you are using TypeScript, you will want to add `"ts"` and/or `"tsx"` to the above default. Where you place these is up to you - we recommend placing the extensions most commonly used in your project on the left.
 
 ### `moduleDirectories` [array<string>]
 

--- a/website/versioned_docs/version-22.2/Configuration.md
+++ b/website/versioned_docs/version-22.2/Configuration.md
@@ -274,9 +274,9 @@ return {
 
 Default: `["js", "json", "jsx", "node"]`
 
-An array of file extensions your modules use. If you require modules without specifying a file extension, these are the extensions Jest will look for.
+An array of file extensions your modules use. If you require modules without specifying a file extension, these are the extensions Jest will look for, in left-to-right order.
 
-If you are using TypeScript this should be `["js", "jsx", "json", "ts", "tsx"]`, check [ts-jest's documentation](https://github.com/kulshekhar/ts-jest).
+If you are using TypeScript, you will want to add `"ts"` and/or `"tsx"` to above default. Where you place these is up to you - we recommend placing the extensions most commonly used in your project on the left.
 
 ### `moduleDirectories` [array<string>]
 

--- a/website/versioned_docs/version-22.3/Configuration.md
+++ b/website/versioned_docs/version-22.3/Configuration.md
@@ -259,9 +259,9 @@ This option allows the use of a custom global teardown module which exports an a
 
 Default: `["js", "json", "jsx", "node"]`
 
-An array of file extensions your modules use. If you require modules without specifying a file extension, these are the extensions Jest will look for.
+An array of file extensions your modules use. If you require modules without specifying a file extension, these are the extensions Jest will look for, in left-to-right order.
 
-If you are using TypeScript this should be `["js", "jsx", "json", "ts", "tsx"]`, check [ts-jest's documentation](https://github.com/kulshekhar/ts-jest).
+If you are using TypeScript, you will want to add `"ts"` and/or `"tsx"` to above default. Where you place these is up to you - we recommend placing the extensions most commonly used in your project on the left.
 
 ### `moduleDirectories` [array<string>]
 

--- a/website/versioned_docs/version-22.3/Configuration.md
+++ b/website/versioned_docs/version-22.3/Configuration.md
@@ -261,7 +261,7 @@ Default: `["js", "json", "jsx", "node"]`
 
 An array of file extensions your modules use. If you require modules without specifying a file extension, these are the extensions Jest will look for, in left-to-right order.
 
-If you are using TypeScript, you will want to add `"ts"` and/or `"tsx"` to above default. Where you place these is up to you - we recommend placing the extensions most commonly used in your project on the left.
+If you are using TypeScript, you will want to add `"ts"` and/or `"tsx"` to the above default. Where you place these is up to you - we recommend placing the extensions most commonly used in your project on the left.
 
 ### `moduleDirectories` [array<string>]
 

--- a/website/versioned_docs/version-22.4/Configuration.md
+++ b/website/versioned_docs/version-22.4/Configuration.md
@@ -290,9 +290,9 @@ This option allows the use of a custom global teardown module which exports an a
 
 Default: `["js", "json", "jsx", "node"]`
 
-An array of file extensions your modules use. If you require modules without specifying a file extension, these are the extensions Jest will look for.
+An array of file extensions your modules use. If you require modules without specifying a file extension, these are the extensions Jest will look for, in left-to-right order.
 
-If you are using TypeScript this should be `["js", "jsx", "json", "ts", "tsx"]`, check [ts-jest's documentation](https://github.com/kulshekhar/ts-jest).
+If you are using TypeScript, you will want to add `"ts"` and/or `"tsx"` to above default. Where you place these is up to you - we recommend placing the extensions most commonly used in your project on the left.
 
 ### `moduleDirectories` [array<string>]
 

--- a/website/versioned_docs/version-22.4/Configuration.md
+++ b/website/versioned_docs/version-22.4/Configuration.md
@@ -292,7 +292,7 @@ Default: `["js", "json", "jsx", "node"]`
 
 An array of file extensions your modules use. If you require modules without specifying a file extension, these are the extensions Jest will look for, in left-to-right order.
 
-If you are using TypeScript, you will want to add `"ts"` and/or `"tsx"` to above default. Where you place these is up to you - we recommend placing the extensions most commonly used in your project on the left.
+If you are using TypeScript, you will want to add `"ts"` and/or `"tsx"` to the above default. Where you place these is up to you - we recommend placing the extensions most commonly used in your project on the left.
 
 ### `moduleDirectories` [array<string>]
 

--- a/website/versioned_docs/version-23.0/Configuration.md
+++ b/website/versioned_docs/version-23.0/Configuration.md
@@ -310,9 +310,9 @@ This option allows the use of a custom global teardown module which exports an a
 
 Default: `["js", "json", "jsx", "node"]`
 
-An array of file extensions your modules use. If you require modules without specifying a file extension, these are the extensions Jest will look for.
+An array of file extensions your modules use. If you require modules without specifying a file extension, these are the extensions Jest will look for, in left-to-right order.
 
-If you are using TypeScript this should be `["js", "jsx", "json", "ts", "tsx"]`, check [ts-jest's documentation](https://github.com/kulshekhar/ts-jest).
+If you are using TypeScript, you will want to add `"ts"` and/or `"tsx"` to above default. Where you place these is up to you - we recommend placing the extensions most commonly used in your project on the left.
 
 ### `moduleDirectories` [array<string>]
 

--- a/website/versioned_docs/version-23.0/Configuration.md
+++ b/website/versioned_docs/version-23.0/Configuration.md
@@ -312,7 +312,7 @@ Default: `["js", "json", "jsx", "node"]`
 
 An array of file extensions your modules use. If you require modules without specifying a file extension, these are the extensions Jest will look for, in left-to-right order.
 
-If you are using TypeScript, you will want to add `"ts"` and/or `"tsx"` to above default. Where you place these is up to you - we recommend placing the extensions most commonly used in your project on the left.
+If you are using TypeScript, you will want to add `"ts"` and/or `"tsx"` to the above default. Where you place these is up to you - we recommend placing the extensions most commonly used in your project on the left.
 
 ### `moduleDirectories` [array<string>]
 

--- a/website/versioned_docs/version-23.1/Configuration.md
+++ b/website/versioned_docs/version-23.1/Configuration.md
@@ -310,9 +310,9 @@ This option allows the use of a custom global teardown module which exports an a
 
 Default: `["js", "json", "jsx", "node"]`
 
-An array of file extensions your modules use. If you require modules without specifying a file extension, these are the extensions Jest will look for.
+An array of file extensions your modules use. If you require modules without specifying a file extension, these are the extensions Jest will look for, in left-to-right order.
 
-If you are using TypeScript this should be `["js", "jsx", "json", "ts", "tsx"]`, check [ts-jest's documentation](https://github.com/kulshekhar/ts-jest).
+If you are using TypeScript, you will want to add `"ts"` and/or `"tsx"` to above default. Where you place these is up to you - we recommend placing the extensions most commonly used in your project on the left.
 
 ### `moduleDirectories` [array<string>]
 

--- a/website/versioned_docs/version-23.1/Configuration.md
+++ b/website/versioned_docs/version-23.1/Configuration.md
@@ -312,7 +312,7 @@ Default: `["js", "json", "jsx", "node"]`
 
 An array of file extensions your modules use. If you require modules without specifying a file extension, these are the extensions Jest will look for, in left-to-right order.
 
-If you are using TypeScript, you will want to add `"ts"` and/or `"tsx"` to above default. Where you place these is up to you - we recommend placing the extensions most commonly used in your project on the left.
+If you are using TypeScript, you will want to add `"ts"` and/or `"tsx"` to the above default. Where you place these is up to you - we recommend placing the extensions most commonly used in your project on the left.
 
 ### `moduleDirectories` [array<string>]
 

--- a/website/versioned_docs/version-23.2/Configuration.md
+++ b/website/versioned_docs/version-23.2/Configuration.md
@@ -322,9 +322,9 @@ An array of directory names to be searched recursively up from the requiring mod
 
 Default: `["js", "json", "jsx", "node"]`
 
-An array of file extensions your modules use. If you require modules without specifying a file extension, these are the extensions Jest will look for.
+An array of file extensions your modules use. If you require modules without specifying a file extension, these are the extensions Jest will look for, in left-to-right order.
 
-If you are using TypeScript this should be `["js", "jsx", "json", "ts", "tsx"]`, check [ts-jest's documentation](https://github.com/kulshekhar/ts-jest).
+If you are using TypeScript, you will want to add `"ts"` and/or `"tsx"` to above default. Where you place these is up to you - we recommend placing the extensions most commonly used in your project on the left.
 
 ### `moduleNameMapper` [object<string, string>]
 

--- a/website/versioned_docs/version-23.2/Configuration.md
+++ b/website/versioned_docs/version-23.2/Configuration.md
@@ -324,7 +324,7 @@ Default: `["js", "json", "jsx", "node"]`
 
 An array of file extensions your modules use. If you require modules without specifying a file extension, these are the extensions Jest will look for, in left-to-right order.
 
-If you are using TypeScript, you will want to add `"ts"` and/or `"tsx"` to above default. Where you place these is up to you - we recommend placing the extensions most commonly used in your project on the left.
+If you are using TypeScript, you will want to add `"ts"` and/or `"tsx"` to the above default. Where you place these is up to you - we recommend placing the extensions most commonly used in your project on the left.
 
 ### `moduleNameMapper` [object<string, string>]
 

--- a/website/versioned_docs/version-23.3/Configuration.md
+++ b/website/versioned_docs/version-23.3/Configuration.md
@@ -322,9 +322,9 @@ An array of directory names to be searched recursively up from the requiring mod
 
 Default: `["js", "json", "jsx", "node"]`
 
-An array of file extensions your modules use. If you require modules without specifying a file extension, these are the extensions Jest will look for.
+An array of file extensions your modules use. If you require modules without specifying a file extension, these are the extensions Jest will look for, in left-to-right order.
 
-If you are using TypeScript this should be `["js", "jsx", "json", "ts", "tsx"]`, check [ts-jest's documentation](https://github.com/kulshekhar/ts-jest).
+If you are using TypeScript, you will want to add `"ts"` and/or `"tsx"` to above default. Where you place these is up to you - we recommend placing the extensions most commonly used in your project on the left.
 
 ### `moduleNameMapper` [object<string, string>]
 

--- a/website/versioned_docs/version-23.3/Configuration.md
+++ b/website/versioned_docs/version-23.3/Configuration.md
@@ -324,7 +324,7 @@ Default: `["js", "json", "jsx", "node"]`
 
 An array of file extensions your modules use. If you require modules without specifying a file extension, these are the extensions Jest will look for, in left-to-right order.
 
-If you are using TypeScript, you will want to add `"ts"` and/or `"tsx"` to above default. Where you place these is up to you - we recommend placing the extensions most commonly used in your project on the left.
+If you are using TypeScript, you will want to add `"ts"` and/or `"tsx"` to the above default. Where you place these is up to you - we recommend placing the extensions most commonly used in your project on the left.
 
 ### `moduleNameMapper` [object<string, string>]
 

--- a/website/versioned_docs/version-23.4/Configuration.md
+++ b/website/versioned_docs/version-23.4/Configuration.md
@@ -322,9 +322,9 @@ An array of directory names to be searched recursively up from the requiring mod
 
 Default: `["js", "json", "jsx", "node"]`
 
-An array of file extensions your modules use. If you require modules without specifying a file extension, these are the extensions Jest will look for.
+An array of file extensions your modules use. If you require modules without specifying a file extension, these are the extensions Jest will look for, in left-to-right order.
 
-If you are using TypeScript this should be `["js", "jsx", "json", "ts", "tsx"]`, check [ts-jest's documentation](https://github.com/kulshekhar/ts-jest).
+If you are using TypeScript, you will want to add `"ts"` and/or `"tsx"` to above default. Where you place these is up to you - we recommend placing the extensions most commonly used in your project on the left.
 
 ### `moduleNameMapper` [object<string, string>]
 

--- a/website/versioned_docs/version-23.4/Configuration.md
+++ b/website/versioned_docs/version-23.4/Configuration.md
@@ -324,7 +324,7 @@ Default: `["js", "json", "jsx", "node"]`
 
 An array of file extensions your modules use. If you require modules without specifying a file extension, these are the extensions Jest will look for, in left-to-right order.
 
-If you are using TypeScript, you will want to add `"ts"` and/or `"tsx"` to above default. Where you place these is up to you - we recommend placing the extensions most commonly used in your project on the left.
+If you are using TypeScript, you will want to add `"ts"` and/or `"tsx"` to the above default. Where you place these is up to you - we recommend placing the extensions most commonly used in your project on the left.
 
 ### `moduleNameMapper` [object<string, string>]
 

--- a/website/versioned_docs/version-23.5/Configuration.md
+++ b/website/versioned_docs/version-23.5/Configuration.md
@@ -342,7 +342,7 @@ Default: `["js", "json", "jsx", "node"]`
 
 An array of file extensions your modules use. If you require modules without specifying a file extension, these are the extensions Jest will look for, in left-to-right order.
 
-If you are using TypeScript, you will want to add `"ts"` and/or `"tsx"` to above default. Where you place these is up to you - we recommend placing the extensions most commonly used in your project on the left.
+If you are using TypeScript, you will want to add `"ts"` and/or `"tsx"` to the above default. Where you place these is up to you - we recommend placing the extensions most commonly used in your project on the left.
 
 ### `moduleNameMapper` [object<string, string>]
 

--- a/website/versioned_docs/version-23.5/Configuration.md
+++ b/website/versioned_docs/version-23.5/Configuration.md
@@ -340,9 +340,9 @@ An array of directory names to be searched recursively up from the requiring mod
 
 Default: `["js", "json", "jsx", "node"]`
 
-An array of file extensions your modules use. If you require modules without specifying a file extension, these are the extensions Jest will look for.
+An array of file extensions your modules use. If you require modules without specifying a file extension, these are the extensions Jest will look for, in left-to-right order.
 
-If you are using TypeScript this should be `["js", "jsx", "json", "ts", "tsx"]`, check [ts-jest's documentation](https://github.com/kulshekhar/ts-jest).
+If you are using TypeScript, you will want to add `"ts"` and/or `"tsx"` to above default. Where you place these is up to you - we recommend placing the extensions most commonly used in your project on the left.
 
 ### `moduleNameMapper` [object<string, string>]
 

--- a/website/versioned_docs/version-23.6/Configuration.md
+++ b/website/versioned_docs/version-23.6/Configuration.md
@@ -342,7 +342,7 @@ Default: `["js", "json", "jsx", "node"]`
 
 An array of file extensions your modules use. If you require modules without specifying a file extension, these are the extensions Jest will look for, in left-to-right order.
 
-If you are using TypeScript, you will want to add `"ts"` and/or `"tsx"` to above default. Where you place these is up to you - we recommend placing the extensions most commonly used in your project on the left.
+If you are using TypeScript, you will want to add `"ts"` and/or `"tsx"` to the above default. Where you place these is up to you - we recommend placing the extensions most commonly used in your project on the left.
 
 ### `moduleNameMapper` [object<string, string>]
 

--- a/website/versioned_docs/version-23.6/Configuration.md
+++ b/website/versioned_docs/version-23.6/Configuration.md
@@ -340,9 +340,9 @@ An array of directory names to be searched recursively up from the requiring mod
 
 Default: `["js", "json", "jsx", "node"]`
 
-An array of file extensions your modules use. If you require modules without specifying a file extension, these are the extensions Jest will look for.
+An array of file extensions your modules use. If you require modules without specifying a file extension, these are the extensions Jest will look for, in left-to-right order.
 
-If you are using TypeScript this should be `["js", "jsx", "json", "ts", "tsx"]`, check [ts-jest's documentation](https://github.com/kulshekhar/ts-jest).
+If you are using TypeScript, you will want to add `"ts"` and/or `"tsx"` to above default. Where you place these is up to you - we recommend placing the extensions most commonly used in your project on the left.
 
 ### `moduleNameMapper` [object<string, string>]
 


### PR DESCRIPTION
Adds note that the `moduleFileExtensions` configuration evaluates the array of file extensions from left-to-right. This may seem self-evident, but personally after dealing with Webpack loaders which work in the opposite direction, I think it doesn't hurt to point out.

See issue #7563 for the original discussion on this matter. If someone is more knowledgable about performance, perhaps we could also add a note that in a TypeScript project, moving the `.ts` and `.tsx` extensions to the beginning could be advantageous (per @thymikee).