### PR TITLE
Fix buffer property is not ArrayBuffer issue.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@
 - `[babel-jest]` Set `cwd` to be resilient to it changing during the runtime of the tests ([#7574](https://github.com/facebook/jest/pull/7574))
 - `[jest-snapshot]` Write and read snapshots from disk even if `fs` is mocked ([#7080](https://github.com/facebook/jest/pull/7080))
 - `[jest-config]` Normalize `config.cwd` and `config.rootDir` using `realpath ([#7598](https://github.com/facebook/jest/pull/7598))
+- `[jest-environment-node]` Fix buffer property is not ArrayBuffer issue. ([#7626](https://github.com/facebook/jest/pull/7626))
 
 ### Chore & Maintenance
 

--- a/e2e/__tests__/env.test.js
+++ b/e2e/__tests__/env.test.js
@@ -14,25 +14,37 @@ const getLog = result => result.stdout.split('\n')[1].trim();
 
 describe('Environment override', () => {
   it('uses jsdom when specified', () => {
-    const result = runJest('env-test', ['--env=jsdom']);
+    const result = runJest('env-test', ['--env=jsdom', 'env.test.js']);
     expect(result.status).toBe(0);
     expect(getLog(result)).toBe('WINDOW');
   });
 
   it('uses node as default from package.json', () => {
-    const result = runJest('env-test');
+    const result = runJest('env-test', ['env.test.js']);
     expect(result.status).toBe(0);
     expect(getLog(result)).toBe('NO WINDOW');
   });
 
   it('uses node when specified', () => {
-    const result = runJest('env-test', ['--env=node']);
+    const result = runJest('env-test', ['--env=node', 'env.test.js']);
     expect(result.status).toBe(0);
     expect(getLog(result)).toBe('NO WINDOW');
   });
 
   it('fails when the env is not available', () => {
-    const result = runJest('env-test', ['--env=banana']);
+    const result = runJest('env-test', ['--env=banana', 'env.test.js']);
     expect(result.status).toBe(1);
+  });
+});
+
+describe('Environment equivalent', () => {
+  it('uses jsdom', () => {
+    const result = runJest('env-test', ['--env=jsdom', 'equivalent.test.js']);
+    expect(result.status).toBe(0);
+  });
+
+  it('uses node', () => {
+    const result = runJest('env-test', ['--env=node', 'equivalent.test.js']);
+    expect(result.status).toBe(0);
   });
 });

--- a/e2e/env-test/__tests__/equivalent.test.js
+++ b/e2e/env-test/__tests__/equivalent.test.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+'use strict';
+
+test('Buffer', () => {
+  const bufFromArray = Buffer.from([0x62, 0x75, 0x66, 0x66, 0x65, 0x72]);
+  expect(bufFromArray.buffer instanceof ArrayBuffer).toBeTruthy();
+  const bufFromArrayBuffer = Buffer.from(new ArrayBuffer(6));
+  expect(bufFromArrayBuffer.buffer instanceof ArrayBuffer).toBeTruthy();
+});

--- a/packages/jest-environment-node/src/index.js
+++ b/packages/jest-environment-node/src/index.js
@@ -39,6 +39,7 @@ class NodeEnvironment {
     global.clearTimeout = clearTimeout;
     global.setInterval = setInterval;
     global.setTimeout = setTimeout;
+    global.ArrayBuffer = ArrayBuffer;
     // URL and URLSearchParams are global in Node >= 10
     if (typeof URL !== 'undefined' && typeof URLSearchParams !== 'undefined') {
       /* global URL, URLSearchParams */


### PR DESCRIPTION
In node environment Buffer class buffer property become ArrayBuffer.

* Set ArrayBuffer to global.ArrayBuffer.
* Add tests.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

In the following code.
```js
const bufFromArray = Buffer.from([0x62, 0x75, 0x66, 0x66, 0x65, 0x72]);
bufFromArray.buffer instanceof ArrayBuffer; // (A)
const bufFromArrayBuffer = Buffer.from(new ArrayBuffer(6));
bufFromArrayBuffer.buffer instanceof ArrayBuffer; // (B)
```
Execute in each environment.(`--env=node`, `--env=jsdom`, and `node`)

**Expect:**

- (A) and (B) are always true.

**Actual:**

- In `--env=node`, (A) is not true.

ref.
https://nodejs.org/api/buffer.html#buffer_buf_buffer

## Test plan

- The same results in all environments.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
