### PR TITLE
Fix watch plugins link

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -1040,7 +1040,7 @@ These patterns match against the full path. Use the `<rootDir>` string token to 
 
 Default: `[]`
 
-This option allows you to use a custom watch plugins. Read more about watch plugins [here](watch-plugins).
+This option allows you to use a custom watch plugins. Read more about watch plugins [here](WatchPlugins.md).
 
 Examples of watch plugins include:
 


### PR DESCRIPTION
The current link leads me to [404](https://github.com/facebook/jest/blob/master/docs/watch-plugins)
