### PR TITLE
chore(build): add directory details to the package.json of all packages

### DIFF
--- a/packages/babel-jest/package.json
+++ b/packages/babel-jest/package.json
@@ -4,7 +4,8 @@
   "version": "23.6.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/jest.git"
+    "url": "https://github.com/facebook/jest.git",
+    "directory": "packages/babel-jest"
   },
   "license": "MIT",
   "main": "build/index.js",

--- a/packages/babel-plugin-jest-hoist/package.json
+++ b/packages/babel-plugin-jest-hoist/package.json
@@ -3,7 +3,8 @@
   "version": "23.2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/jest.git"
+    "url": "https://github.com/facebook/jest.git",
+    "directory": "packages/babel-plugin-jest-hoist"
   },
   "engines": {
     "node": ">= 6"

--- a/packages/babel-preset-jest/package.json
+++ b/packages/babel-preset-jest/package.json
@@ -3,7 +3,8 @@
   "version": "23.2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/jest.git"
+    "url": "https://github.com/facebook/jest.git",
+    "directory": "packages/babel-preset-jest"
   },
   "license": "MIT",
   "main": "index.js",

--- a/packages/diff-sequences/package.json
+++ b/packages/diff-sequences/package.json
@@ -3,7 +3,8 @@
   "version": "23.6.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/jest.git"
+    "url": "https://github.com/facebook/jest.git",
+    "directory": "packages/diff-sequences"
   },
   "license": "MIT",
   "description": "Compare items in two sequences to find a longest common subsequence",

--- a/packages/eslint-config-fb-strict/package.json
+++ b/packages/eslint-config-fb-strict/package.json
@@ -3,7 +3,8 @@
   "version": "23.2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/jest.git"
+    "url": "https://github.com/facebook/jest.git",
+    "directory": "packages/eslint-config-fb-strict"
   },
   "license": "MIT",
   "dependencies": {

--- a/packages/expect/package.json
+++ b/packages/expect/package.json
@@ -3,7 +3,8 @@
   "version": "23.6.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/jest.git"
+    "url": "https://github.com/facebook/jest.git",
+    "directory": "packages/expect"
   },
   "license": "MIT",
   "main": "build/index.js",

--- a/packages/jest-changed-files/package.json
+++ b/packages/jest-changed-files/package.json
@@ -3,7 +3,8 @@
   "version": "23.4.2",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/jest.git"
+    "url": "https://github.com/facebook/jest.git",
+    "directory": "packages/jest-changed-files"
   },
   "license": "MIT",
   "main": "build/index.js",

--- a/packages/jest-circus/package.json
+++ b/packages/jest-circus/package.json
@@ -3,7 +3,8 @@
   "version": "23.6.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/jest.git"
+    "url": "https://github.com/facebook/jest.git",
+    "directory": "packages/jest-circus"
   },
   "license": "MIT",
   "main": "build/index.js",

--- a/packages/jest-cli/package.json
+++ b/packages/jest-cli/package.json
@@ -49,7 +49,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/jest"
+    "url": "https://github.com/facebook/jest",
+    "directory": "packages/jest-cli"
   },
   "bugs": {
     "url": "https://github.com/facebook/jest/issues"

--- a/packages/jest-config/package.json
+++ b/packages/jest-config/package.json
@@ -3,7 +3,8 @@
   "version": "23.6.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/jest.git"
+    "url": "https://github.com/facebook/jest.git",
+    "directory": "packages/jest-config"
   },
   "license": "MIT",
   "main": "build/index.js",

--- a/packages/jest-diff/package.json
+++ b/packages/jest-diff/package.json
@@ -3,7 +3,8 @@
   "version": "23.6.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/jest.git"
+    "url": "https://github.com/facebook/jest.git",
+    "directory": "packages/jest-diff"
   },
   "license": "MIT",
   "main": "build/index.js",

--- a/packages/jest-docblock/package.json
+++ b/packages/jest-docblock/package.json
@@ -3,7 +3,8 @@
   "version": "23.2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/jest.git"
+    "url": "https://github.com/facebook/jest.git",
+    "directory": "packages/jest-docblock"
   },
   "license": "MIT",
   "main": "build/index.js",

--- a/packages/jest-each/package.json
+++ b/packages/jest-each/package.json
@@ -5,7 +5,8 @@
   "main": "build/index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/jest.git"
+    "url": "https://github.com/facebook/jest.git",
+    "directory": "packages/jest-each"
   },
   "keywords": [
     "jest",

--- a/packages/jest-environment-jsdom/package.json
+++ b/packages/jest-environment-jsdom/package.json
@@ -3,7 +3,8 @@
   "version": "23.4.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/jest.git"
+    "url": "https://github.com/facebook/jest.git",
+    "directory": "packages/jest-environment-jsdom"
   },
   "license": "MIT",
   "main": "build/index.js",

--- a/packages/jest-environment-node/package.json
+++ b/packages/jest-environment-node/package.json
@@ -3,7 +3,8 @@
   "version": "23.4.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/jest.git"
+    "url": "https://github.com/facebook/jest.git",
+    "directory": "packages/jest-environment-node"
   },
   "license": "MIT",
   "main": "build/index.js",

--- a/packages/jest-get-type/package.json
+++ b/packages/jest-get-type/package.json
@@ -4,7 +4,8 @@
   "version": "22.1.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/jest.git"
+    "url": "https://github.com/facebook/jest.git",
+    "directory": "packages/jest-get-type"
   },
   "engines": {
     "node": ">= 6"

--- a/packages/jest-haste-map/package.json
+++ b/packages/jest-haste-map/package.json
@@ -3,7 +3,8 @@
   "version": "23.6.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/jest.git"
+    "url": "https://github.com/facebook/jest.git",
+    "directory": "packages/jest-haste-map"
   },
   "license": "MIT",
   "main": "build/index.js",

--- a/packages/jest-jasmine2/package.json
+++ b/packages/jest-jasmine2/package.json
@@ -3,7 +3,8 @@
   "version": "23.6.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/jest.git"
+    "url": "https://github.com/facebook/jest.git",
+    "directory": "packages/jest-jasmine2"
   },
   "license": "MIT",
   "main": "build/index.js",

--- a/packages/jest-leak-detector/package.json
+++ b/packages/jest-leak-detector/package.json
@@ -3,7 +3,8 @@
   "version": "23.6.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/jest.git"
+    "url": "https://github.com/facebook/jest.git",
+    "directory": "packages/jest-leak-detector"
   },
   "license": "MIT",
   "main": "build/index.js",

--- a/packages/jest-matcher-utils/package.json
+++ b/packages/jest-matcher-utils/package.json
@@ -4,7 +4,8 @@
   "version": "23.6.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/jest.git"
+    "url": "https://github.com/facebook/jest.git",
+    "directory": "packages/jest-matcher-utils"
   },
   "engines": {
     "node": ">= 6"

--- a/packages/jest-message-util/package.json
+++ b/packages/jest-message-util/package.json
@@ -3,7 +3,8 @@
   "version": "23.4.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/jest.git"
+    "url": "https://github.com/facebook/jest.git",
+    "directory": "packages/jest-message-util"
   },
   "engines": {
     "node": ">= 6"

--- a/packages/jest-mock/package.json
+++ b/packages/jest-mock/package.json
@@ -3,7 +3,8 @@
   "version": "23.2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/jest.git"
+    "url": "https://github.com/facebook/jest.git",
+    "directory": "packages/jest-mock"
   },
   "engines": {
     "node": ">= 6"

--- a/packages/jest-phabricator/package.json
+++ b/packages/jest-phabricator/package.json
@@ -3,7 +3,8 @@
   "version": "23.2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/jest.git"
+    "url": "https://github.com/facebook/jest.git",
+    "directory": "packages/jest-phabricator"
   },
   "engines": {
     "node": ">= 6"

--- a/packages/jest-regex-util/package.json
+++ b/packages/jest-regex-util/package.json
@@ -3,7 +3,8 @@
   "version": "23.3.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/jest.git"
+    "url": "https://github.com/facebook/jest.git",
+    "directory": "packages/jest-regex-util"
   },
   "engines": {
     "node": ">= 6"

--- a/packages/jest-repl/package.json
+++ b/packages/jest-repl/package.json
@@ -3,7 +3,8 @@
   "version": "23.6.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/jest.git"
+    "url": "https://github.com/facebook/jest.git",
+    "directory": "packages/jest-repl"
   },
   "license": "MIT",
   "main": "build/index.js",

--- a/packages/jest-resolve-dependencies/package.json
+++ b/packages/jest-resolve-dependencies/package.json
@@ -3,7 +3,8 @@
   "version": "23.6.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/jest.git"
+    "url": "https://github.com/facebook/jest.git",
+    "directory": "packages/jest-resolve-dependencies"
   },
   "license": "MIT",
   "main": "build/index.js",

--- a/packages/jest-resolve/package.json
+++ b/packages/jest-resolve/package.json
@@ -3,7 +3,8 @@
   "version": "23.6.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/jest.git"
+    "url": "https://github.com/facebook/jest.git",
+    "directory": "packages/jest-resolve"
   },
   "license": "MIT",
   "main": "build/index.js",

--- a/packages/jest-runner/package.json
+++ b/packages/jest-runner/package.json
@@ -3,7 +3,8 @@
   "version": "23.6.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/jest.git"
+    "url": "https://github.com/facebook/jest.git",
+    "directory": "packages/jest-runner"
   },
   "license": "MIT",
   "main": "build/index.js",

--- a/packages/jest-runtime/package.json
+++ b/packages/jest-runtime/package.json
@@ -3,7 +3,8 @@
   "version": "23.6.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/jest.git"
+    "url": "https://github.com/facebook/jest.git",
+    "directory": "packages/jest-runtime"
   },
   "license": "MIT",
   "main": "build/index.js",

--- a/packages/jest-serializer/package.json
+++ b/packages/jest-serializer/package.json
@@ -3,7 +3,8 @@
   "version": "23.0.1",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/jest.git"
+    "url": "https://github.com/facebook/jest.git",
+    "directory": "packages/jest-serializer"
   },
   "engines": {
     "node": ">= 6"

--- a/packages/jest-snapshot/package.json
+++ b/packages/jest-snapshot/package.json
@@ -3,7 +3,8 @@
   "version": "23.6.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/jest.git"
+    "url": "https://github.com/facebook/jest.git",
+    "directory": "packages/jest-snapshot"
   },
   "license": "MIT",
   "main": "build/index.js",

--- a/packages/jest-util/package.json
+++ b/packages/jest-util/package.json
@@ -3,7 +3,8 @@
   "version": "23.4.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/jest.git"
+    "url": "https://github.com/facebook/jest.git",
+    "directory": "packages/jest-util"
   },
   "license": "MIT",
   "main": "build/index.js",

--- a/packages/jest-validate/package.json
+++ b/packages/jest-validate/package.json
@@ -3,7 +3,8 @@
   "version": "23.6.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/jest.git"
+    "url": "https://github.com/facebook/jest.git",
+    "directory": "packages/jest-validate"
   },
   "license": "MIT",
   "main": "build/index.js",

--- a/packages/jest-watcher/package.json
+++ b/packages/jest-watcher/package.json
@@ -11,7 +11,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/jest"
+    "url": "https://github.com/facebook/jest",
+    "directory": "packages/jest-watcher"
   },
   "bugs": {
     "url": "https://github.com/facebook/jest/issues"

--- a/packages/jest-worker/package.json
+++ b/packages/jest-worker/package.json
@@ -3,7 +3,8 @@
   "version": "23.2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/jest.git"
+    "url": "https://github.com/facebook/jest.git",
+    "directory": "packages/jest-worker"
   },
   "license": "MIT",
   "main": "build/index.js",

--- a/packages/pretty-format/package.json
+++ b/packages/pretty-format/package.json
@@ -3,7 +3,8 @@
   "version": "23.6.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/facebook/jest.git"
+    "url": "https://github.com/facebook/jest.git",
+    "directory": "packages/pretty-format"
   },
   "license": "MIT",
   "description": "Stringify any JavaScript value.",


### PR DESCRIPTION
Specifying the directory as part of the `repository` field in a `package.json` allows npm and third party tools to provide better support when working with monorepos. For example, it allows them to correctly construct a commit diff for a specific package.

This format was accepted by npm in https://github.com/npm/rfcs/pull/19.