### PR TITLE
Website: Styling of backers avatars, preserve avatars proportions.

### DIFF
--- a/website/static/css/jest.css
+++ b/website/static/css/jest.css
@@ -24,6 +24,7 @@
   border-radius: 50%;
   border: 1px solid white;
   overflow: hidden;
+  object-fit: contain;
 }
 
 .support-button {


### PR DESCRIPTION
## Summary

Just a minor styling change. Backers avatars should look better now, images won't be stretched.

## Test plan

Before:
![image](https://user-images.githubusercontent.com/6403957/51474898-0c8c0380-1d81-11e9-91e7-593ddc0ded3b.png)

After:
![image](https://user-images.githubusercontent.com/6403957/51474913-19a8f280-1d81-11e9-81d1-12523995d321.png)

