### PR TITLE
Docs - Snapshot Testing - Remove references to `images` and `screenshots`

### DIFF
--- a/docs/SnapshotTesting.md
+++ b/docs/SnapshotTesting.md
@@ -5,7 +5,7 @@ title: Snapshot Testing
 
 Snapshot tests are a very useful tool whenever you want to make sure your UI does not change unexpectedly.
 
-A typical snapshot test case for a mobile app renders a UI component, takes a screenshot, then compares it to a reference image stored alongside the test. The test will fail if the two images do not match: either the change is unexpected, or the screenshot needs to be updated to the new version of the UI component.
+A typical snapshot test case for a mobile app renders a UI component, takes a snapshot, then compares it to a reference snapshot file stored alongside the test. The test will fail if the two snapshots do not match: either the change is unexpected, or the reference snapshot needs to be updated to the new version of the UI component.
 
 ## Snapshot Testing with Jest
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Replaces references to "images" and "screenshots" in the intro to snapshot testing.

I am new to snapshot testing and felt that this introductory paragraph was misleading by implying that the comparison is made between two images rather than two `snapshots` - text-based representations of the UI.

Snapshot testing does not use images or screenshots, as described in the docs [below](https://jestjs.io/docs/en/snapshot-testing#what-s-the-difference-between-snapshot-testing-and-visual-regression-testing). The use of these words can cause confusion between visual regression and snapshot testing for those unfamiliar with the difference.

Hope this can help avoid confusion for others coming to jest for the first time. Thanks!

## Test plan

n/a
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
