### PR TITLE
update deprecated process.binding() call

### DIFF
--- a/packages/jest-resolve/src/isBuiltinModule.js
+++ b/packages/jest-resolve/src/isBuiltinModule.js
@@ -17,13 +17,7 @@ declare var process: {
 
 const EXPERIMENTAL_MODULES = ['worker_threads'];
 
-const BUILTIN_MODULES = new Set(
-  builtinModules
-    ? builtinModules.concat(EXPERIMENTAL_MODULES)
-    : Object.keys(process.binding('natives'))
-        .filter((module: string) => !/^internal\//.test(module))
-        .concat(EXPERIMENTAL_MODULES),
-);
+const BUILTIN_MODULES = new Set(builtinModules.concat(EXPERIMENTAL_MODULES));
 
 export default function isBuiltinModule(module: string): boolean {
   return BUILTIN_MODULES.has(module);


### PR DESCRIPTION
process.binding() is deprecated (in documentation only for now). Replace
use of it to get list of modules with supported module.builtinModules.
Although undocumented before Node.js 9.x, it's in all currently-supported
versions including 6.x and 8.x.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

`process.binding()` is currently documentation-deprecated in Node.js. Replace an instance of it with a supported API that provides the same information.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

I ran `yarn test` locally and this did not seem to introduce any new failures. Unfortunately, I could not get `yarn test` to run cleanly on an unmodified master branch checkout. Anyway, since this is a refactor and does not introduce new stuff, that should be sufficient. It would be great if Travis or something else were used to test this across different Node.js releases. I notice that the `engines` field in `package.json` says Node.js 6.x is supported, for example. I tested locally with a few different versions of Node.js. But given my inability to get a clean test run on master, it would be great if someone else or an automated tool could verify on all supported release lines.