### PR TITLE
Fix toHaveProperty matcher for inherited properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 
 ### Fixes
 
+- `[expect]` Accept inherited properties in `toHaveProperty` matcher ([#7686](https://github.com/facebook/jest/pull/7686))
 - `[jest-diff]` Do not claim that `-0` and `0` have no visual difference ([#7605](https://github.com/facebook/jest/pull/7605))
 - `[jest-mock]` Fix automock for numeric function names ([#7653](https://github.com/facebook/jest/pull/7653))
 - `[jest-config]` Ensure `existsSync` is only called with a string parameter ([#7607](https://github.com/facebook/jest/pull/7607))

--- a/packages/expect/src/__tests__/utils.test.js
+++ b/packages/expect/src/__tests__/utils.test.js
@@ -76,6 +76,18 @@ describe('getPath()', () => {
     });
   });
 
+  test('property is inherited', () => {
+    class A {}
+    A.prototype.a = 'a';
+
+    expect(getPath(new A(), 'a')).toEqual({
+      hasEndProp: true,
+      lastTraversedObject: new A(),
+      traversedPath: ['a'],
+      value: 'a',
+    });
+  });
+
   test('path breaks', () => {
     expect(getPath({a: {}}, 'a.b.c')).toEqual({
       hasEndProp: false,

--- a/packages/expect/src/utils.js
+++ b/packages/expect/src/utils.js
@@ -81,7 +81,7 @@ export const getPath = (
     result.traversedPath.unshift(prop);
 
     if (lastProp) {
-      result.hasEndProp = hasOwnProperty(object, prop);
+      result.hasEndProp = prop in object;
       if (!result.hasEndProp) {
         result.traversedPath.shift();
       }


### PR DESCRIPTION
## Summary

`expect(object).toHaveProperty('foo')` throws if `'foo'` is an inherited property of `object` (not an own property or a getter in its prototype). According to the documentation, inherited properties should work as well.

## Test plan

Added unit test.
