### PR TITLE
expect: fix regression in toThrow for message prop and asymmetric matchers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,7 +125,6 @@
 - `[jest-config]` Add name to project if one does not exist to pick correct resolver ([#5862](https://github.com/facebook/jest/pull/5862))
 - `[jest-runtime]` Pass `watchPathIgnorePatterns` to Haste instance ([#7585](https://github.com/facebook/jest/pull/7585))
 - `[jest-runtime]` Resolve mock files via Haste when using `require.resolve` ([#7687](https://github.com/facebook/jest/pull/7687))
-- `[expect]` fix regression in toThrow for message prop and asymmetric matchers ([#7697](https://github.com/facebook/jest/pull/7697))
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,7 @@
 - `[babel-plugin-jest-hoist]` Ignore TS type annotations when looking for out-of-scope references ([#7641](https://github.com/facebook/jest/pull/7641))
 - `[jest-config]` Add name to project if one does not exist to pick correct resolver ([#5862](https://github.com/facebook/jest/pull/5862))
 - `[jest-runtime]` Pass `watchPathIgnorePatterns` to Haste instance ([#7585](https://github.com/facebook/jest/pull/7585))
+- `[expect]` fix regression in toThrow for message prop and asymmetric matchers ([#7697](https://github.com/facebook/jest/pull/7697))
 
 ### Chore & Maintenance
 

--- a/packages/expect/src/__tests__/__snapshots__/toThrowMatchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/toThrowMatchers.test.js.snap
@@ -1,5 +1,91 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`.toThrow() asymmetric any-Class fail isNot false 1`] = `
+"<dim>expect(</><red>received</><dim>).</>toThrow<dim>(</><green>expected</><dim>)</>
+
+Expected asymmetric matcher: <green>Any<Err2></>
+
+Error name:    <red>\\"Error\\"</>
+Error message: <red>\\"apple\\"</>
+
+      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+`;
+
+exports[`.toThrow() asymmetric any-Class fail isNot true 1`] = `
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrow<dim>(</><green>expected</><dim>)</>
+
+Expected asymmetric matcher: <green>Any<Err></>
+
+Error name:    <red>\\"Error\\"</>
+Error message: <red>\\"apple\\"</>
+
+      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+`;
+
+exports[`.toThrow() asymmetric anything fail isNot false 1`] = `
+"<dim>expect(</><red>received</><dim>).</>toThrow<dim>(</><green>expected</><dim>)</>
+
+Expected asymmetric matcher: <green>Anything</>
+
+Thrown value: <red>null</>
+"
+`;
+
+exports[`.toThrow() asymmetric anything fail isNot true 1`] = `
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrow<dim>(</><green>expected</><dim>)</>
+
+Expected asymmetric matcher: <green>Anything</>
+
+Error name:    <red>\\"Error\\"</>
+Error message: <red>\\"apple\\"</>
+
+      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+`;
+
+exports[`.toThrow() asymmetric no-symbol fail isNot false 1`] = `
+"<dim>expect(</><red>received</><dim>).</>toThrow<dim>(</><green>expected</><dim>)</>
+
+Expected asymmetric matcher: <green>{\\"asymmetricMatch\\": [Function asymmetricMatch]}</>
+
+Error name:    <red>\\"Error\\"</>
+Error message: <red>\\"apple\\"</>
+
+      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+`;
+
+exports[`.toThrow() asymmetric no-symbol fail isNot true 1`] = `
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrow<dim>(</><green>expected</><dim>)</>
+
+Expected asymmetric matcher: <green>{\\"asymmetricMatch\\": [Function asymmetricMatch]}</>
+
+Error name:    <red>\\"Error\\"</>
+Error message: <red>\\"apple\\"</>
+
+      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+`;
+
+exports[`.toThrow() asymmetric objectContaining fail isNot false 1`] = `
+"<dim>expect(</><red>received</><dim>).</>toThrow<dim>(</><green>expected</><dim>)</>
+
+Expected asymmetric matcher: <green>ObjectContaining {\\"name\\": \\"NotError\\"}</>
+
+Error name:    <red>\\"Error\\"</>
+Error message: <red>\\"apple\\"</>
+
+      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+`;
+
+exports[`.toThrow() asymmetric objectContaining fail isNot true 1`] = `
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrow<dim>(</><green>expected</><dim>)</>
+
+Expected asymmetric matcher: <green>ObjectContaining {\\"name\\": \\"Error\\"}</>
+
+Error name:    <red>\\"Error\\"</>
+Error message: <red>\\"apple\\"</>
+
+      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+`;
+
 exports[`.toThrow() error class did not throw at all 1`] = `
 "<dim>expect(</><red>received</><dim>).</>toThrow<dim>(</><green>expected</><dim>)</>
 
@@ -37,6 +123,22 @@ Received name: <red>\\"Error\\"</>
 Received message: <red>\\"apple\\"</>
 
       <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+`;
+
+exports[`.toThrow() error-message fail isNot false 1`] = `
+"<dim>expect(</><red>received</><dim>).</>toThrow<dim>(</><green>expected</><dim>)</>
+
+Expected message: <green>\\"apple\\"</>
+Received message: <red>\\"banana\\"</>
+"
+`;
+
+exports[`.toThrow() error-message fail isNot true 1`] = `
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrow<dim>(</><green>expected</><dim>)</>
+
+Expected message: <green>\\"apple\\"</>
+Received message: <red>\\"apple\\"</>
+"
 `;
 
 exports[`.toThrow() expected is undefined threw, but should not have (non-error falsey) 1`] = `
@@ -174,6 +276,92 @@ Received value:     <red>\\"Internal Server Error\\"</>
 "
 `;
 
+exports[`.toThrowError() asymmetric any-Class fail isNot false 1`] = `
+"<dim>expect(</><red>received</><dim>).</>toThrowError<dim>(</><green>expected</><dim>)</>
+
+Expected asymmetric matcher: <green>Any<Err2></>
+
+Error name:    <red>\\"Error\\"</>
+Error message: <red>\\"apple\\"</>
+
+      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+`;
+
+exports[`.toThrowError() asymmetric any-Class fail isNot true 1`] = `
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrowError<dim>(</><green>expected</><dim>)</>
+
+Expected asymmetric matcher: <green>Any<Err></>
+
+Error name:    <red>\\"Error\\"</>
+Error message: <red>\\"apple\\"</>
+
+      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+`;
+
+exports[`.toThrowError() asymmetric anything fail isNot false 1`] = `
+"<dim>expect(</><red>received</><dim>).</>toThrowError<dim>(</><green>expected</><dim>)</>
+
+Expected asymmetric matcher: <green>Anything</>
+
+Thrown value: <red>null</>
+"
+`;
+
+exports[`.toThrowError() asymmetric anything fail isNot true 1`] = `
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrowError<dim>(</><green>expected</><dim>)</>
+
+Expected asymmetric matcher: <green>Anything</>
+
+Error name:    <red>\\"Error\\"</>
+Error message: <red>\\"apple\\"</>
+
+      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+`;
+
+exports[`.toThrowError() asymmetric no-symbol fail isNot false 1`] = `
+"<dim>expect(</><red>received</><dim>).</>toThrowError<dim>(</><green>expected</><dim>)</>
+
+Expected asymmetric matcher: <green>{\\"asymmetricMatch\\": [Function asymmetricMatch]}</>
+
+Error name:    <red>\\"Error\\"</>
+Error message: <red>\\"apple\\"</>
+
+      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+`;
+
+exports[`.toThrowError() asymmetric no-symbol fail isNot true 1`] = `
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrowError<dim>(</><green>expected</><dim>)</>
+
+Expected asymmetric matcher: <green>{\\"asymmetricMatch\\": [Function asymmetricMatch]}</>
+
+Error name:    <red>\\"Error\\"</>
+Error message: <red>\\"apple\\"</>
+
+      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+`;
+
+exports[`.toThrowError() asymmetric objectContaining fail isNot false 1`] = `
+"<dim>expect(</><red>received</><dim>).</>toThrowError<dim>(</><green>expected</><dim>)</>
+
+Expected asymmetric matcher: <green>ObjectContaining {\\"name\\": \\"NotError\\"}</>
+
+Error name:    <red>\\"Error\\"</>
+Error message: <red>\\"apple\\"</>
+
+      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+`;
+
+exports[`.toThrowError() asymmetric objectContaining fail isNot true 1`] = `
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrowError<dim>(</><green>expected</><dim>)</>
+
+Expected asymmetric matcher: <green>ObjectContaining {\\"name\\": \\"Error\\"}</>
+
+Error name:    <red>\\"Error\\"</>
+Error message: <red>\\"apple\\"</>
+
+      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+`;
+
 exports[`.toThrowError() error class did not throw at all 1`] = `
 "<dim>expect(</><red>received</><dim>).</>toThrowError<dim>(</><green>expected</><dim>)</>
 
@@ -211,6 +399,22 @@ Received name: <red>\\"Error\\"</>
 Received message: <red>\\"apple\\"</>
 
       <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+`;
+
+exports[`.toThrowError() error-message fail isNot false 1`] = `
+"<dim>expect(</><red>received</><dim>).</>toThrowError<dim>(</><green>expected</><dim>)</>
+
+Expected message: <green>\\"apple\\"</>
+Received message: <red>\\"banana\\"</>
+"
+`;
+
+exports[`.toThrowError() error-message fail isNot true 1`] = `
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrowError<dim>(</><green>expected</><dim>)</>
+
+Expected message: <green>\\"apple\\"</>
+Received message: <red>\\"apple\\"</>
+"
 `;
 
 exports[`.toThrowError() expected is undefined threw, but should not have (non-error falsey) 1`] = `

--- a/packages/expect/src/__tests__/__snapshots__/toThrowMatchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/toThrowMatchers.test.js.snap
@@ -5,8 +5,8 @@ exports[`.toThrow() asymmetric any-Class fail isNot false 1`] = `
 
 Expected asymmetric matcher: <green>Any<Err2></>
 
-Error name:    <red>\\"Error\\"</>
-Error message: <red>\\"apple\\"</>
+Received name:    <red>\\"Error\\"</>
+Received message: <red>\\"apple\\"</>
 
       <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
 `;
@@ -16,8 +16,8 @@ exports[`.toThrow() asymmetric any-Class fail isNot true 1`] = `
 
 Expected asymmetric matcher: <green>Any<Err></>
 
-Error name:    <red>\\"Error\\"</>
-Error message: <red>\\"apple\\"</>
+Received name:    <red>\\"Error\\"</>
+Received message: <red>\\"apple\\"</>
 
       <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
 `;
@@ -36,8 +36,8 @@ exports[`.toThrow() asymmetric anything fail isNot true 1`] = `
 
 Expected asymmetric matcher: <green>Anything</>
 
-Error name:    <red>\\"Error\\"</>
-Error message: <red>\\"apple\\"</>
+Received name:    <red>\\"Error\\"</>
+Received message: <red>\\"apple\\"</>
 
       <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
 `;
@@ -47,8 +47,8 @@ exports[`.toThrow() asymmetric no-symbol fail isNot false 1`] = `
 
 Expected asymmetric matcher: <green>{\\"asymmetricMatch\\": [Function asymmetricMatch]}</>
 
-Error name:    <red>\\"Error\\"</>
-Error message: <red>\\"apple\\"</>
+Received name:    <red>\\"Error\\"</>
+Received message: <red>\\"apple\\"</>
 
       <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
 `;
@@ -58,8 +58,8 @@ exports[`.toThrow() asymmetric no-symbol fail isNot true 1`] = `
 
 Expected asymmetric matcher: <green>{\\"asymmetricMatch\\": [Function asymmetricMatch]}</>
 
-Error name:    <red>\\"Error\\"</>
-Error message: <red>\\"apple\\"</>
+Received name:    <red>\\"Error\\"</>
+Received message: <red>\\"apple\\"</>
 
       <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
 `;
@@ -69,8 +69,8 @@ exports[`.toThrow() asymmetric objectContaining fail isNot false 1`] = `
 
 Expected asymmetric matcher: <green>ObjectContaining {\\"name\\": \\"NotError\\"}</>
 
-Error name:    <red>\\"Error\\"</>
-Error message: <red>\\"apple\\"</>
+Received name:    <red>\\"Error\\"</>
+Received message: <red>\\"apple\\"</>
 
       <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
 `;
@@ -80,8 +80,8 @@ exports[`.toThrow() asymmetric objectContaining fail isNot true 1`] = `
 
 Expected asymmetric matcher: <green>ObjectContaining {\\"name\\": \\"Error\\"}</>
 
-Error name:    <red>\\"Error\\"</>
-Error message: <red>\\"apple\\"</>
+Received name:    <red>\\"Error\\"</>
+Received message: <red>\\"apple\\"</>
 
       <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
 `;
@@ -281,8 +281,8 @@ exports[`.toThrowError() asymmetric any-Class fail isNot false 1`] = `
 
 Expected asymmetric matcher: <green>Any<Err2></>
 
-Error name:    <red>\\"Error\\"</>
-Error message: <red>\\"apple\\"</>
+Received name:    <red>\\"Error\\"</>
+Received message: <red>\\"apple\\"</>
 
       <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
 `;
@@ -292,8 +292,8 @@ exports[`.toThrowError() asymmetric any-Class fail isNot true 1`] = `
 
 Expected asymmetric matcher: <green>Any<Err></>
 
-Error name:    <red>\\"Error\\"</>
-Error message: <red>\\"apple\\"</>
+Received name:    <red>\\"Error\\"</>
+Received message: <red>\\"apple\\"</>
 
       <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
 `;
@@ -312,8 +312,8 @@ exports[`.toThrowError() asymmetric anything fail isNot true 1`] = `
 
 Expected asymmetric matcher: <green>Anything</>
 
-Error name:    <red>\\"Error\\"</>
-Error message: <red>\\"apple\\"</>
+Received name:    <red>\\"Error\\"</>
+Received message: <red>\\"apple\\"</>
 
       <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
 `;
@@ -323,8 +323,8 @@ exports[`.toThrowError() asymmetric no-symbol fail isNot false 1`] = `
 
 Expected asymmetric matcher: <green>{\\"asymmetricMatch\\": [Function asymmetricMatch]}</>
 
-Error name:    <red>\\"Error\\"</>
-Error message: <red>\\"apple\\"</>
+Received name:    <red>\\"Error\\"</>
+Received message: <red>\\"apple\\"</>
 
       <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
 `;
@@ -334,8 +334,8 @@ exports[`.toThrowError() asymmetric no-symbol fail isNot true 1`] = `
 
 Expected asymmetric matcher: <green>{\\"asymmetricMatch\\": [Function asymmetricMatch]}</>
 
-Error name:    <red>\\"Error\\"</>
-Error message: <red>\\"apple\\"</>
+Received name:    <red>\\"Error\\"</>
+Received message: <red>\\"apple\\"</>
 
       <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
 `;
@@ -345,8 +345,8 @@ exports[`.toThrowError() asymmetric objectContaining fail isNot false 1`] = `
 
 Expected asymmetric matcher: <green>ObjectContaining {\\"name\\": \\"NotError\\"}</>
 
-Error name:    <red>\\"Error\\"</>
-Error message: <red>\\"apple\\"</>
+Received name:    <red>\\"Error\\"</>
+Received message: <red>\\"apple\\"</>
 
       <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
 `;
@@ -356,8 +356,8 @@ exports[`.toThrowError() asymmetric objectContaining fail isNot true 1`] = `
 
 Expected asymmetric matcher: <green>ObjectContaining {\\"name\\": \\"Error\\"}</>
 
-Error name:    <red>\\"Error\\"</>
-Error message: <red>\\"apple\\"</>
+Received name:    <red>\\"Error\\"</>
+Received message: <red>\\"apple\\"</>
 
       <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
 `;

--- a/packages/expect/src/toThrowMatchers.js
+++ b/packages/expect/src/toThrowMatchers.js
@@ -179,8 +179,8 @@ const toThrowExpectedAsymmetric = (
         formatExpected('Expected asymmetric matcher: ', expected) +
         '\n' +
         (thrown !== null && thrown.hasMessage
-          ? formatReceived('Error name:    ', thrown, 'name') +
-            formatReceived('Error message: ', thrown, 'message') +
+          ? formatReceived('Received name:    ', thrown, 'name') +
+            formatReceived('Received message: ', thrown, 'message') +
             formatStack(thrown)
           : formatReceived('Thrown value: ', thrown, 'value'))
     : () =>
@@ -191,8 +191,8 @@ const toThrowExpectedAsymmetric = (
         (thrown === null
           ? DID_NOT_THROW
           : thrown.hasMessage
-          ? formatReceived('Error name:    ', thrown, 'name') +
-            formatReceived('Error message: ', thrown, 'message') +
+          ? formatReceived('Received name:    ', thrown, 'name') +
+            formatReceived('Received message: ', thrown, 'message') +
             formatStack(thrown)
           : formatReceived('Thrown value: ', thrown, 'value'));
 

--- a/packages/expect/src/toThrowMatchers.js
+++ b/packages/expect/src/toThrowMatchers.js
@@ -25,32 +25,44 @@ const DID_NOT_THROW = 'Received function did not throw';
 
 type Thrown =
   | {
+      hasMessage: true,
       isError: true,
       message: string,
       value: Error,
     }
   | {
+      hasMessage: boolean,
       isError: false,
       message: string,
       value: any,
     };
 
-const getThrown = (e: any): Thrown =>
-  e !== null &&
-  e !== undefined &&
-  typeof e.message === 'string' &&
-  typeof e.name === 'string' &&
-  typeof e.stack === 'string'
-    ? {
-        isError: true,
-        message: e.message,
-        value: e,
-      }
-    : {
-        isError: false,
-        message: typeof e === 'string' ? e : String(e),
-        value: e,
-      };
+const getThrown = (e: any): Thrown => {
+  if (
+    e !== null &&
+    e !== undefined &&
+    typeof e.message === 'string' &&
+    typeof e.name === 'string' &&
+    typeof e.stack === 'string'
+  ) {
+    return {
+      hasMessage: true,
+      isError: true,
+      message: e.message,
+      value: e,
+    };
+  }
+
+  const hasMessage =
+    e !== null && e !== undefined && typeof e.message === 'string';
+
+  return {
+    hasMessage,
+    isError: false,
+    message: hasMessage ? e.message : typeof e === 'string' ? e : String(e),
+    value: e,
+  };
+};
 
 export const createMatcher = (matcherName: string, fromPromise?: boolean) =>
   function(received: Function, expected: any) {
@@ -92,6 +104,11 @@ export const createMatcher = (matcherName: string, fromPromise?: boolean) =>
       return toThrowExpectedString(matcherName, options, thrown, expected);
     } else if (expected !== null && typeof expected.test === 'function') {
       return toThrowExpectedRegExp(matcherName, options, thrown, expected);
+    } else if (
+      expected !== null &&
+      typeof expected.asymmetricMatch === 'function'
+    ) {
+      return toThrowExpectedAsymmetric(matcherName, options, thrown, expected);
     } else if (expected !== null && typeof expected === 'object') {
       return toThrowExpectedObject(matcherName, options, thrown, expected);
     } else {
@@ -119,27 +136,65 @@ const toThrowExpectedRegExp = (
   expected: RegExp,
 ) => {
   const pass = thrown !== null && expected.test(thrown.message);
-  const isNotError = thrown !== null && !thrown.isError;
 
   const message = pass
     ? () =>
         matcherHint(matcherName, undefined, undefined, options) +
         '\n\n' +
         formatExpected('Expected pattern: ', expected) +
-        (isNotError
-          ? formatReceived('Received value:   ', thrown, 'value')
-          : formatReceived('Received message: ', thrown, 'message') +
-            formatStack(thrown))
+        (thrown !== null && thrown.hasMessage
+          ? formatReceived('Received message: ', thrown, 'message') +
+            formatStack(thrown)
+          : formatReceived('Received value:   ', thrown, 'value'))
     : () =>
         matcherHint(matcherName, undefined, undefined, options) +
         '\n\n' +
         formatExpected('Expected pattern: ', expected) +
         (thrown === null
           ? '\n' + DID_NOT_THROW
-          : isNotError
-          ? formatReceived('Received value:   ', thrown, 'value')
-          : formatReceived('Received message: ', thrown, 'message') +
-            formatStack(thrown));
+          : thrown.hasMessage
+          ? formatReceived('Received message: ', thrown, 'message') +
+            formatStack(thrown)
+          : formatReceived('Received value:   ', thrown, 'value'));
+
+  return {message, pass};
+};
+
+type AsymmetricMatcher = {
+  asymmetricMatch: (received: any) => boolean,
+};
+
+const toThrowExpectedAsymmetric = (
+  matcherName: string,
+  options: MatcherHintOptions,
+  thrown: Thrown | null,
+  expected: AsymmetricMatcher,
+) => {
+  const pass = thrown !== null && expected.asymmetricMatch(thrown.value);
+
+  const message = pass
+    ? () =>
+        matcherHint(matcherName, undefined, undefined, options) +
+        '\n\n' +
+        formatExpected('Expected asymmetric matcher: ', expected) +
+        '\n' +
+        (thrown !== null && thrown.hasMessage
+          ? formatReceived('Error name:    ', thrown, 'name') +
+            formatReceived('Error message: ', thrown, 'message') +
+            formatStack(thrown)
+          : formatReceived('Thrown value: ', thrown, 'value'))
+    : () =>
+        matcherHint(matcherName, undefined, undefined, options) +
+        '\n\n' +
+        formatExpected('Expected asymmetric matcher: ', expected) +
+        '\n' +
+        (thrown === null
+          ? DID_NOT_THROW
+          : thrown.hasMessage
+          ? formatReceived('Error name:    ', thrown, 'name') +
+            formatReceived('Error message: ', thrown, 'message') +
+            formatStack(thrown)
+          : formatReceived('Thrown value: ', thrown, 'value'));
 
   return {message, pass};
 };
@@ -151,27 +206,26 @@ const toThrowExpectedObject = (
   expected: Object,
 ) => {
   const pass = thrown !== null && thrown.message === expected.message;
-  const isNotError = thrown !== null && !thrown.isError;
 
   const message = pass
     ? () =>
         matcherHint(matcherName, undefined, undefined, options) +
         '\n\n' +
         formatExpected('Expected message: ', expected.message) +
-        (isNotError
-          ? formatReceived('Received value:   ', thrown, 'value')
-          : formatReceived('Received message: ', thrown, 'message') +
-            formatStack(thrown))
+        (thrown !== null && thrown.hasMessage
+          ? formatReceived('Received message: ', thrown, 'message') +
+            formatStack(thrown)
+          : formatReceived('Received value:   ', thrown, 'value'))
     : () =>
         matcherHint(matcherName, undefined, undefined, options) +
         '\n\n' +
         formatExpected('Expected message: ', expected.message) +
         (thrown === null
           ? '\n' + DID_NOT_THROW
-          : isNotError
-          ? formatReceived('Received value:   ', thrown, 'value')
-          : formatReceived('Received message: ', thrown, 'message') +
-            formatStack(thrown));
+          : thrown.hasMessage
+          ? formatReceived('Received message: ', thrown, 'message') +
+            formatStack(thrown)
+          : formatReceived('Received value:   ', thrown, 'value'));
 
   return {message, pass};
 };
@@ -183,7 +237,6 @@ const toThrowExpectedClass = (
   expected: Function,
 ) => {
   const pass = thrown !== null && thrown.value instanceof expected;
-  const isNotError = thrown !== null && !thrown.isError;
 
   const message = pass
     ? () =>
@@ -192,22 +245,22 @@ const toThrowExpectedClass = (
         formatExpected('Expected name: ', expected.name) +
         formatReceived('Received name: ', thrown, 'name') +
         '\n' +
-        (isNotError
-          ? formatReceived('Received value: ', thrown, 'value')
-          : formatReceived('Received message: ', thrown, 'message') +
-            formatStack(thrown))
+        (thrown !== null && thrown.hasMessage
+          ? formatReceived('Received message: ', thrown, 'message') +
+            formatStack(thrown)
+          : formatReceived('Received value: ', thrown, 'value'))
     : () =>
         matcherHint(matcherName, undefined, undefined, options) +
         '\n\n' +
         formatExpected('Expected name: ', expected.name) +
         (thrown === null
           ? '\n' + DID_NOT_THROW
-          : isNotError
-          ? '\n' + formatReceived('Received value: ', thrown, 'value')
-          : formatReceived('Received name: ', thrown, 'name') +
+          : thrown.hasMessage
+          ? formatReceived('Received name: ', thrown, 'name') +
             '\n' +
             formatReceived('Received message: ', thrown, 'message') +
-            formatStack(thrown));
+            formatStack(thrown)
+          : '\n' + formatReceived('Received value: ', thrown, 'value'));
 
   return {message, pass};
 };
@@ -219,27 +272,26 @@ const toThrowExpectedString = (
   expected: string,
 ) => {
   const pass = thrown !== null && thrown.message.includes(expected);
-  const isNotError = thrown !== null && !thrown.isError;
 
   const message = pass
     ? () =>
         matcherHint(matcherName, undefined, undefined, options) +
         '\n\n' +
         formatExpected('Expected substring: ', expected) +
-        (isNotError
-          ? formatReceived('Received value:     ', thrown, 'value')
-          : formatReceived('Received message:   ', thrown, 'message') +
-            formatStack(thrown))
+        (thrown !== null && thrown.hasMessage
+          ? formatReceived('Received message:   ', thrown, 'message') +
+            formatStack(thrown)
+          : formatReceived('Received value:     ', thrown, 'value'))
     : () =>
         matcherHint(matcherName, undefined, undefined, options) +
         '\n\n' +
         formatExpected('Expected substring: ', expected) +
         (thrown === null
           ? '\n' + DID_NOT_THROW
-          : isNotError
-          ? formatReceived('Received value:     ', thrown, 'value')
-          : formatReceived('Received message:   ', thrown, 'message') +
-            formatStack(thrown));
+          : thrown.hasMessage
+          ? formatReceived('Received message:   ', thrown, 'message') +
+            formatStack(thrown)
+          : formatReceived('Received value:     ', thrown, 'value'));
 
   return {message, pass};
 };
@@ -250,17 +302,16 @@ const toThrow = (
   thrown: Thrown | null,
 ) => {
   const pass = thrown !== null;
-  const isNotError = thrown !== null && !thrown.isError;
 
   const message = pass
     ? () =>
         matcherHint(matcherName, undefined, '', options) +
         '\n\n' +
-        (isNotError
-          ? formatReceived('Thrown value: ', thrown, 'value')
-          : formatReceived('Error name:    ', thrown, 'name') +
+        (thrown !== null && thrown.hasMessage
+          ? formatReceived('Error name:    ', thrown, 'name') +
             formatReceived('Error message: ', thrown, 'message') +
-            formatStack(thrown))
+            formatStack(thrown)
+          : formatReceived('Thrown value: ', thrown, 'value'))
     : () =>
         matcherHint(matcherName, undefined, '', options) +
         '\n\n' +


### PR DESCRIPTION
## Summary

Fixes #7692

* `Received message:` in report when assertion fails for any object which has a `message` prop
* Support **asymmetric matchers** as expected values that were broken in #7621

## Test plan

All existing tests pass

Added 8 tests and 4 snapshots for each of the following scenarios:

* asymmetric any-Class: `.toThrow(expect.any(Class))`
* asymmetric anything: `.toThrow(expect.anything())`
* asymmetric no-symbol: `.toThrow(customMatcher)`
* asymmetric objectContaining: `.toThrow(expect.objectContaing(props))`
* error-message: `expect(() => { throw { message: 'whatever'}; })`

This quote from original pull request still applies to **any-Class** scenario:

> Depending on how classes that extend Error set name property of instances, that report can still seem confusing, but I think that will have to wait for a future pull request to sort out :(

See also pictures compared to baseline Jest 23.6 in following comments