### PR TITLE
chore: remove unused @babel/core dep from jest-config

### DIFF
--- a/packages/jest-config/package.json
+++ b/packages/jest-config/package.json
@@ -9,7 +9,6 @@
   "license": "MIT",
   "main": "build/index.js",
   "dependencies": {
-    "@babel/core": "^7.1.0",
     "babel-jest": "^24.0.0",
     "chalk": "^2.0.1",
     "glob": "^7.1.1",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Spotted while reading this comment https://github.com/facebook/jest/pull/7715#discussion_r251193298. It adds unnecessary babel downloads to anyone that depends on `jest-junit`. cc @SimenB @palmerj3 	

## Test plan

Green
