### PR TITLE
expect: Make change requested in toThrowMatchers

### DIFF
--- a/packages/expect/src/toThrowMatchers.js
+++ b/packages/expect/src/toThrowMatchers.js
@@ -38,28 +38,22 @@ type Thrown =
     };
 
 const getThrown = (e: any): Thrown => {
-  if (
-    e !== null &&
-    e !== undefined &&
-    typeof e.message === 'string' &&
-    typeof e.name === 'string' &&
-    typeof e.stack === 'string'
-  ) {
+  const hasMessage =
+    e !== null && e !== undefined && typeof e.message === 'string';
+
+  if (hasMessage && typeof e.name === 'string' && typeof e.stack === 'string') {
     return {
-      hasMessage: true,
+      hasMessage,
       isError: true,
       message: e.message,
       value: e,
     };
   }
 
-  const hasMessage =
-    e !== null && e !== undefined && typeof e.message === 'string';
-
   return {
     hasMessage,
     isError: false,
-    message: hasMessage ? e.message : typeof e === 'string' ? e : String(e),
+    message: hasMessage ? e.message : String(e),
     value: e,
   };
 };


### PR DESCRIPTION
## Summary

* Simplify ternary expression, see https://github.com/facebook/jest/pull/7697#discussion_r250949126
* Factor out `hasMessage` but leave explicit strict equality conditions, see https://github.com/facebook/jest/pull/7697#pullrequestreview-196485232
* Attempted to import `AsymmetricMatcher` with added `asymmetricMatch` property from `types/Matchers.js` but Flow reported type errors, see https://github.com/facebook/jest/pull/7697#discussion_r250951098

Not necessary to update change log, true?

## Test plan

All existing tests pass
