### PR TITLE
First setup presets before options validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Fixes
 
-- `[jest-cli]` Break dependency cycle when using Jest programmatically ([#7707](https://github.com/facebook/jest/pull/7707)
+- `[jest-cli]` Break dependency cycle when using Jest programmatically ([#7707](https://github.com/facebook/jest/pull/7707))
+- `[jest-config]` Extract setupFilesAfterEnv from preset ([#7724](https://github.com/facebook/jest/pull/7724))
 
 ### Chore & Maintenance
 

--- a/packages/jest-config/src/__tests__/normalize.test.js
+++ b/packages/jest-config/src/__tests__/normalize.test.js
@@ -926,6 +926,7 @@ describe('preset', () => {
         moduleNameMapper: {b: 'b'},
         modulePathIgnorePatterns: ['b'],
         setupFiles: ['b'],
+        setupFilesAfterEnv: ['b'],
         transform: {b: 'b'},
       }),
       {virtual: true},
@@ -1105,6 +1106,18 @@ describe('preset', () => {
       ['c', '/node_modules/cc'],
       ['a', '/node_modules/aa'],
     ]);
+  });
+
+  test('extracts setupFilesAfterEnv from preset', () => {
+    const {options} = normalize(
+      {
+        preset: 'react-native',
+        rootDir: '/root/path/foo',
+      },
+      {},
+    );
+
+    expect(options.setupFilesAfterEnv).toEqual(['/node_modules/b']);
   });
 });
 

--- a/packages/jest-config/src/normalize.js
+++ b/packages/jest-config/src/normalize.js
@@ -398,6 +398,10 @@ export default function normalize(options: InitialOptions, argv: Argv) {
     ),
   );
 
+  if (options.preset) {
+    options = setupPreset(options, options.preset);
+  }
+
   if (!options.setupFilesAfterEnv) {
     options.setupFilesAfterEnv = [];
   }
@@ -418,10 +422,6 @@ export default function normalize(options: InitialOptions, argv: Argv) {
 
   if (options.setupTestFrameworkScriptFile) {
     options.setupFilesAfterEnv.push(options.setupTestFrameworkScriptFile);
-  }
-
-  if (options.preset) {
-    options = setupPreset(options, options.preset);
   }
 
   options.testEnvironment = getTestEnvironment({


### PR DESCRIPTION
## Summary

`setupFilesAfterEnv` config from preset is ignored according to #7719

## Test plan

Linked `jest` to https://github.com/sbekrin/jest-24-setup-files-after-env-bug and run tests.
