### PR TITLE
fix: print log entries if logging happens after teardown

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,6 +1,7 @@
 [ignore]
 .*/examples/.*
 .*/node_modules/metro-bundler/.*
+.*/node_modules/metro-config/.*
 .*/node_modules/metro/.*
 .*/node_modules/module-deps/.*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - `[jest-config]` Extract setupFilesAfterEnv from preset ([#7724](https://github.com/facebook/jest/pull/7724))
 - `[jest-cli]` Do not execute any `globalSetup` or `globalTeardown` if there are no tests to execute ([#7745](https://github.com/facebook/jest/pull/7745))
 - `[jest-runtime]` Lock down version of `write-file-atomic` ([#7725](https://github.com/facebook/jest/pull/7725))
+- `[jest-cli]` Fail tests if logging happens after test environment is torn down ([#7731](https://github.com/facebook/jest/pull/7731))
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - `[jest-config]` Extract setupFilesAfterEnv from preset ([#7724](https://github.com/facebook/jest/pull/7724))
 - `[jest-cli]` Do not execute any `globalSetup` or `globalTeardown` if there are no tests to execute ([#7745](https://github.com/facebook/jest/pull/7745))
 - `[jest-runtime]` Lock down version of `write-file-atomic` ([#7725](https://github.com/facebook/jest/pull/7725))
-- `[jest-cli]` Fail tests if logging happens after test environment is torn down ([#7731](https://github.com/facebook/jest/pull/7731))
+- `[jest-cli]` Print log entries when logging happens after test environment is torn down ([#7731](https://github.com/facebook/jest/pull/7731))
 
 ### Chore & Maintenance
 

--- a/e2e/__tests__/__snapshots__/consoleAfterTeardown.test.js.snap
+++ b/e2e/__tests__/__snapshots__/consoleAfterTeardown.test.js.snap
@@ -15,6 +15,6 @@ PASS __tests__/console.test.js
       15 | });
       16 |
 
-      at Function.write (../../packages/jest-util/build/BufferedConsole.js:82:12)
+      at BufferedConsole.log (../../packages/jest-util/build/BufferedConsole.js:169:10)
       at log (__tests__/console.test.js:13:13)
 `;

--- a/e2e/__tests__/__snapshots__/consoleAfterTeardown.test.js.snap
+++ b/e2e/__tests__/__snapshots__/consoleAfterTeardown.test.js.snap
@@ -8,13 +8,13 @@ PASS __tests__/console.test.js
     Attempted to log "hello!".
 
        9 | test('throws error', () => {
-      10 |   setTimeout(() => {
+      10 |   new Promise(resolve => setTimeout(resolve, 500)).then(() => {
     > 11 |     console.log('hello!');
          |             ^
-      12 |   }, 500);
+      12 |   });
       13 | });
       14 |
 
       at Function.write (../../packages/jest-util/build/BufferedConsole.js:82:12)
-      at Timeout.log [as _onTimeout] (__tests__/console.test.js:11:13)
+      at log (__tests__/console.test.js:11:13)
 `;

--- a/e2e/__tests__/__snapshots__/consoleAfterTeardown.test.js.snap
+++ b/e2e/__tests__/__snapshots__/consoleAfterTeardown.test.js.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`console printing 1`] = `
+PASS __tests__/console.test.js
+
+
+  ●  Cannot log after tests are done. Did you forget to wait for something async in your test?
+    Attempted to log "hello!".
+
+       9 | test('throws error', () => {
+      10 |   setTimeout(() => {
+    > 11 |     console.log('hello!');
+         |             ^
+      12 |   }, 500);
+      13 | });
+      14 |
+
+      at Function.write (../../packages/jest-util/build/BufferedConsole.js:82:12)
+      at Timeout.log [as _onTimeout] (__tests__/console.test.js:11:13)
+`;

--- a/e2e/__tests__/__snapshots__/consoleAfterTeardown.test.js.snap
+++ b/e2e/__tests__/__snapshots__/consoleAfterTeardown.test.js.snap
@@ -13,7 +13,7 @@ PASS __tests__/console.test.js
          |             ^
       14 |   });
       15 | });
-      16 |
+      16 | 
 
       at BufferedConsole.log (../../packages/jest-util/build/BufferedConsole.js:169:10)
       at log (__tests__/console.test.js:13:13)

--- a/e2e/__tests__/__snapshots__/consoleAfterTeardown.test.js.snap
+++ b/e2e/__tests__/__snapshots__/consoleAfterTeardown.test.js.snap
@@ -7,14 +7,14 @@ PASS __tests__/console.test.js
   ●  Cannot log after tests are done. Did you forget to wait for something async in your test?
     Attempted to log "hello!".
 
-       9 | test('throws error', () => {
-      10 |   new Promise(resolve => setTimeout(resolve, 500)).then(() => {
-    > 11 |     console.log('hello!');
+      11 |   // eslint-disable-next-line prefer-arrow-callback
+      12 |   new Promise(resolve => setTimeout(resolve, 500)).then(function log() {
+    > 13 |     console.log('hello!');
          |             ^
-      12 |   });
-      13 | });
-      14 |
+      14 |   });
+      15 | });
+      16 |
 
       at Function.write (../../packages/jest-util/build/BufferedConsole.js:82:12)
-      at log (__tests__/console.test.js:11:13)
+      at log (__tests__/console.test.js:13:13)
 `;

--- a/e2e/__tests__/consoleAfterTeardown.test.js
+++ b/e2e/__tests__/consoleAfterTeardown.test.js
@@ -15,6 +15,6 @@ test('console printing', () => {
   const {stderr, status} = runJest('console-after-teardown');
   const {rest} = extractSummary(stderr);
 
-  expect(status).toBe(1);
+  expect(status).toBe(0);
   expect(wrap(rest)).toMatchSnapshot();
 });

--- a/e2e/__tests__/consoleAfterTeardown.test.js
+++ b/e2e/__tests__/consoleAfterTeardown.test.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import {extractSummary} from '../Utils';
+import runJest from '../runJest';
+import {wrap} from 'jest-snapshot-serializer-raw';
+
+test('console printing', () => {
+  const {stderr, status} = runJest('console-after-teardown');
+  const {rest} = extractSummary(stderr);
+
+  expect(status).toBe(1);
+  expect(wrap(rest)).toMatchSnapshot();
+});

--- a/e2e/__tests__/forceExit.test.js
+++ b/e2e/__tests__/forceExit.test.js
@@ -28,17 +28,25 @@ test('exits the process after test are done but before timers complete', () => {
     'package.json': JSON.stringify({jest: {testEnvironment: 'node'}}),
   });
 
+  let output;
+  let stdout;
   let stderr;
-  ({stderr} = runJest(DIR));
-  expect(stderr).toMatch(/PASS.*test\.test\.js/);
-  expect(stderr).toMatch(/TIMER_DONE/);
+  ({stdout, stderr} = runJest(DIR));
+
+  output = `${stdout}\n${stderr}`;
+
+  expect(output).toMatch(/PASS.*test\.test\.js/);
+  expect(output).toMatch(/TIMER_DONE/);
   writeFiles(DIR, {
     'package.json': JSON.stringify({
       jest: {forceExit: true, testEnvironment: 'node'},
     }),
   });
 
-  ({stderr} = runJest(DIR));
-  expect(stderr).toMatch(/PASS.*test\.test\.js/);
-  expect(stderr).not.toMatch(/TIMER_DONE/);
+  ({stdout, stderr} = runJest(DIR));
+
+  output = `${stdout}\n${stderr}`;
+
+  expect(output).toMatch(/PASS.*test\.test\.js/);
+  expect(output).not.toMatch(/TIMER_DONE/);
 });

--- a/e2e/__tests__/forceExit.test.js
+++ b/e2e/__tests__/forceExit.test.js
@@ -28,18 +28,17 @@ test('exits the process after test are done but before timers complete', () => {
     'package.json': JSON.stringify({jest: {testEnvironment: 'node'}}),
   });
 
-  let stdout;
   let stderr;
-  ({stdout, stderr} = runJest(DIR));
+  ({stderr} = runJest(DIR));
   expect(stderr).toMatch(/PASS.*test\.test\.js/);
-  expect(stdout).toMatch(/TIMER_DONE/);
+  expect(stderr).toMatch(/TIMER_DONE/);
   writeFiles(DIR, {
     'package.json': JSON.stringify({
       jest: {forceExit: true, testEnvironment: 'node'},
     }),
   });
 
-  ({stdout, stderr} = runJest(DIR));
+  ({stderr} = runJest(DIR));
   expect(stderr).toMatch(/PASS.*test\.test\.js/);
-  expect(stdout).not.toMatch(/TIMER_DONE/);
+  expect(stderr).not.toMatch(/TIMER_DONE/);
 });

--- a/e2e/console-after-teardown/__tests__/console.test.js
+++ b/e2e/console-after-teardown/__tests__/console.test.js
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+'use strict';
+
+test('throws error', () => {
+  setTimeout(() => {
+    console.log('hello!');
+  }, 500);
+});

--- a/e2e/console-after-teardown/__tests__/console.test.js
+++ b/e2e/console-after-teardown/__tests__/console.test.js
@@ -7,7 +7,7 @@
 'use strict';
 
 test('throws error', () => {
-  setTimeout(() => {
+  new Promise(resolve => setTimeout(resolve, 500)).then(() => {
     console.log('hello!');
-  }, 500);
+  });
 });

--- a/e2e/console-after-teardown/__tests__/console.test.js
+++ b/e2e/console-after-teardown/__tests__/console.test.js
@@ -7,7 +7,9 @@
 'use strict';
 
 test('throws error', () => {
-  new Promise(resolve => setTimeout(resolve, 500)).then(() => {
+  // To have the function be named the same in jasmine and circus
+  // eslint-disable-next-line prefer-arrow-callback
+  new Promise(resolve => setTimeout(resolve, 500)).then(function log() {
     console.log('hello!');
   });
 });

--- a/e2e/console-after-teardown/package.json
+++ b/e2e/console-after-teardown/package.json
@@ -1,0 +1,6 @@
+{
+  "jest": {
+    "testEnvironment": "node",
+    "verbose": false
+  }
+}

--- a/packages/jest-runner/package.json
+++ b/packages/jest-runner/package.json
@@ -9,6 +9,7 @@
   "license": "MIT",
   "main": "build/index.js",
   "dependencies": {
+    "chalk": "^2.4.2",
     "exit": "^0.1.2",
     "graceful-fs": "^4.1.15",
     "jest-config": "^24.0.0",

--- a/packages/jest-runner/src/runTest.js
+++ b/packages/jest-runner/src/runTest.js
@@ -53,7 +53,8 @@ function freezeConsole(buffer: ConsoleBuffer, config: ProjectConfig) {
     );
 
     process.stderr.write(formattedError);
-    process.exitCode = 1;
+    // TODO: set exit code in Jest 25
+    // process.exitCode = 1;
   };
 }
 

--- a/packages/jest-runner/src/runTest.js
+++ b/packages/jest-runner/src/runTest.js
@@ -42,11 +42,11 @@ function freezeConsole(
   // $FlowFixMe: overwrite it for pretty errors
   testConsole._log = function fakeConsolePush(_type, message) {
     const error = new ErrorWithStack(
-      chalk.red(
+      `${chalk.red(
         `${chalk.bold(
           'Cannot log after tests are done.',
         )} Did you forget to wait for something async in your test?`,
-      ) + `\nAttempted to log "${message}".`,
+      )}\nAttempted to log "${message}".`,
       fakeConsolePush,
     );
 

--- a/packages/jest-runner/src/runTest.js
+++ b/packages/jest-runner/src/runTest.js
@@ -30,6 +30,7 @@ import {getTestEnvironment} from 'jest-config';
 import * as docblock from 'jest-docblock';
 import {formatExecError} from 'jest-message-util';
 import sourcemapSupport from 'source-map-support';
+import chalk from 'chalk';
 
 type RunTestInternalResult = {
   leakDetector: ?LeakDetector,
@@ -40,7 +41,11 @@ function freezeConsole(buffer: ConsoleBuffer, config: ProjectConfig) {
   // $FlowFixMe: overwrite it for pretty errors. `Object.freeze` works, but gives ugly errors
   buffer.push = function fakeConsolePush({message}) {
     const error = new ErrorWithStack(
-      `Cannot log after tests are done. Did you forget to wait for something async in your test?\nAttempted to log "${message}".`,
+      chalk.red(
+        `${chalk.bold(
+          'Cannot log after tests are done.',
+        )} Did you forget to wait for something async in your test?`,
+      ) + `\nAttempted to log "${message}".`,
       fakeConsolePush,
     );
 
@@ -52,7 +57,7 @@ function freezeConsole(buffer: ConsoleBuffer, config: ProjectConfig) {
       true,
     );
 
-    process.stderr.write(formattedError);
+    process.stderr.write('\n' + formattedError + '\n');
     // TODO: set exit code in Jest 25
     // process.exitCode = 1;
   };

--- a/packages/jest-runner/src/runTest.js
+++ b/packages/jest-runner/src/runTest.js
@@ -39,8 +39,8 @@ function freezeConsole(
   testConsole: BufferedConsole | Console | NullConsole,
   config: ProjectConfig,
 ) {
-  // $FlowFixMe: overwrite it for pretty errors. `Object.freeze` works, but gives ugly errors
-  testConsole._log = function fakeConsolePush({message}) {
+  // $FlowFixMe: overwrite it for pretty errors
+  testConsole._log = function fakeConsolePush(_type, message) {
     const error = new ErrorWithStack(
       chalk.red(
         `${chalk.bold(

--- a/packages/jest-util/src/CustomConsole.js
+++ b/packages/jest-util/src/CustomConsole.js
@@ -10,10 +10,10 @@
 
 import type {
   ConsoleBuffer,
-  LogType,
-  LogMessage,
   LogCounters,
+  LogMessage,
   LogTimers,
+  LogType,
 } from 'types/Console';
 import type {SourceMapRegistry} from 'types/SourceMaps';
 
@@ -55,7 +55,7 @@ export default class CustomConsole extends Console {
     super.log(message);
   }
 
-  _storeInBuffer(message: string, type: LogType) {
+  _storeInBuffer(type: LogType, message: string) {
     let origin = '';
 
     if (this._getSourceMaps) {
@@ -71,13 +71,10 @@ export default class CustomConsole extends Console {
   _log(type: LogType, message: string) {
     clearLine(this._stdout);
 
-    const formattedMessage = this._formatBuffer(
-      type,
-      '  '.repeat(this._groupDepth) + message,
+    this._storeInBuffer(type, message);
+    this._logToParentConsole(
+      this._formatBuffer(type, '  '.repeat(this._groupDepth)),
     );
-
-    this._storeInBuffer(formattedMessage, type);
-    this._logToParentConsole(formattedMessage);
 
     // I have no idea why this is needed. If not included, it breaks ./__tests__/console.test.js ¯\_(ツ)_/¯
     return undefined;

--- a/packages/jest-util/src/CustomConsole.js
+++ b/packages/jest-util/src/CustomConsole.js
@@ -78,6 +78,9 @@ export default class CustomConsole extends Console {
 
     this._storeInBuffer(formattedMessage, type);
     this._logToParentConsole(formattedMessage);
+
+    // I have no idea why this is needed. If not included, it breaks ./__tests__/console.test.js ¯\_(ツ)_/¯
+    return undefined;
   }
 
   assert(...args: Array<any>) {

--- a/packages/jest-util/src/CustomConsole.js
+++ b/packages/jest-util/src/CustomConsole.js
@@ -75,9 +75,6 @@ export default class CustomConsole extends Console {
     this._logToParentConsole(
       this._formatBuffer(type, '  '.repeat(this._groupDepth) + message),
     );
-
-    // I have no idea why this is needed. If not included, it breaks ./__tests__/console.test.js ¯\_(ツ)_/¯
-    return undefined;
   }
 
   assert(...args: Array<any>) {

--- a/packages/jest-util/src/CustomConsole.js
+++ b/packages/jest-util/src/CustomConsole.js
@@ -73,7 +73,7 @@ export default class CustomConsole extends Console {
 
     this._storeInBuffer(type, message);
     this._logToParentConsole(
-      this._formatBuffer(type, '  '.repeat(this._groupDepth)),
+      this._formatBuffer(type, '  '.repeat(this._groupDepth) + message),
     );
 
     // I have no idea why this is needed. If not included, it breaks ./__tests__/console.test.js ¯\_(ツ)_/¯


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Ref #3853

With this test:

```js
test('throws error', () => {
  setTimeout(() => {
    console.log('hello!');
  }, 500);
});
```

Before this PR:
![image](https://user-images.githubusercontent.com/1404810/51805488-2ee4bc00-226e-11e9-84ed-9e20d132e1e2.png)

After this PR:
![image](https://user-images.githubusercontent.com/1404810/51805495-373cf700-226e-11e9-9c3c-7218804b5693.png)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan
Integration test added

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
