### PR TITLE
fix(jest-jasmine2): point to inline snapshot documentation if prettier is unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `[jest-cli]` Break dependency cycle when using Jest programmatically ([#7707](https://github.com/facebook/jest/pull/7707))
 - `[jest-config]` Extract setupFilesAfterEnv from preset ([#7724](https://github.com/facebook/jest/pull/7724))
+- `[jest-jasmine2]` Point to inline snapshot documentation is prettier is unavailable ([#7744](https://github.com/facebook/jest/pull/7744))
 
 ### Chore & Maintenance
 

--- a/packages/jest-jasmine2/src/setup_jest_globals.js
+++ b/packages/jest-jasmine2/src/setup_jest_globals.js
@@ -118,7 +118,7 @@ export default ({
             error.message = `
 ${error.message}
 
-If you are using inline snapshots, you need to install prettier.
+If you are using inline snapshots, you need to install Prettier.
 See more at https://jestjs.io/docs/en/snapshot-testing#inline-snapshots
 `.trim();
           }

--- a/packages/jest-jasmine2/src/setup_jest_globals.js
+++ b/packages/jest-jasmine2/src/setup_jest_globals.js
@@ -108,9 +108,27 @@ export default ({
   const snapshotState = new SnapshotState(snapshotPath, {
     expand,
     getBabelTraverse: () => require('@babel/traverse').default,
-    getPrettier: () =>
-      // $FlowFixMe dynamic require
-      config.prettierPath ? require(config.prettierPath) : null,
+    getPrettier: () => {
+      if (config.prettierPath) {
+        try {
+          // $FlowFixMe dynamic require
+          return require(config.prettierPath);
+        } catch (error) {
+          if (error.code === 'MODULE_NOT_FOUND') {
+            error.message = `
+${error.message}
+
+If you are using inline snapshots, you need to install prettier.
+See more at https://jestjs.io/docs/en/snapshot-testing#inline-snapshots
+`.trim();
+          }
+
+          throw error;
+        }
+      }
+
+      return null;
+    },
     updateSnapshot,
   });
   setState({snapshotState, testPath});


### PR DESCRIPTION
## Summary

Use of inline snapshots requires the project to expose `prettier`. If `prettier` is not available, Jest currently fails with a message that does not indicate any required action on the user's part:

![image](https://user-images.githubusercontent.com/1404650/51901064-1502c080-23b7-11e9-963b-a20bbeea3d12.png)

These changes append a brief message and a link to the inline snapshot docs to that message (I've since changed `prettier` to `Prettier` in the message):

![image](https://user-images.githubusercontent.com/1404650/51900999-ef75b700-23b6-11e9-8c4e-0b4ad8a759a5.png)

## Test plan

To be honest, I have no idea how to write a test for this. To verify the changes manually, I ended up removing the `prettier` dependency from a test project (https://github.com/theneva/post-utils), and:

1. Linked `jest-jasmine2` into the test project
2. Made my changes to `jest`
3. Built `jest`
4. `rm -rf node_modules/prettier` in `jest` to prevent it being accidentally made available through the linked dependency
5. Ran `yarn jest` in the test project

If it makes sense to write an integration test for this, I'd be happy to do so if someone points me in the right direction :smile: