### PR TITLE
fix: make sure generated `name` in config is stable across runs of Jest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - `[jest-cli]` Do not execute any `globalSetup` or `globalTeardown` if there are no tests to execute ([#7745](https://github.com/facebook/jest/pull/7745))
 - `[jest-runtime]` Lock down version of `write-file-atomic` ([#7725](https://github.com/facebook/jest/pull/7725))
 - `[jest-cli]` Print log entries when logging happens after test environment is torn down ([#7731](https://github.com/facebook/jest/pull/7731))
+- `[jest-config]` Do not use a uuid as `name` since that breaks caching ([#7746](https://github.com/facebook/jest/pull/7746))
 
 ### Chore & Maintenance
 

--- a/e2e/__tests__/multiProjectRunner.test.js
+++ b/e2e/__tests__/multiProjectRunner.test.js
@@ -439,8 +439,8 @@ describe("doesn't bleed module file extensions resolution with multiple workers"
 
     const [{name: name1}, {name: name2}] = configs;
 
-    expect(name1).toBeTruthy();
-    expect(name2).toBeTruthy();
+    expect(name1).toEqual(expect.any(String));
+    expect(name2).toEqual(expect.any(String));
     expect(name1).toHaveLength(32);
     expect(name2).toHaveLength(32);
     expect(name1).not.toEqual(name2);
@@ -484,8 +484,8 @@ describe("doesn't bleed module file extensions resolution with multiple workers"
 
     const [{name: name1}, {name: name2}] = configs;
 
-    expect(name1).toBeTruthy();
-    expect(name2).toBeTruthy();
+    expect(name1).toEqual(expect.any(String));
+    expect(name2).toEqual(expect.any(String));
     expect(name1).toHaveLength(32);
     expect(name2).toHaveLength(32);
     expect(name1).not.toEqual(name2);

--- a/e2e/__tests__/multiProjectRunner.test.js
+++ b/e2e/__tests__/multiProjectRunner.test.js
@@ -425,6 +425,25 @@ test("doesn't bleed module file extensions resolution with multiple workers", ()
       };`,
   });
 
+  const {stdout: configOutput} = runJest(DIR, [
+    '--show-config',
+    '--projects',
+    'project1',
+    'project2',
+  ]);
+
+  const {configs} = JSON.parse(configOutput);
+
+  expect(configs).toHaveLength(2);
+
+  const [{name: name1}, {name: name2}] = configs;
+
+  expect(name1).toBeTruthy();
+  expect(name2).toBeTruthy();
+  expect(name1).toHaveLength(32);
+  expect(name2).toHaveLength(32);
+  expect(name1).not.toEqual(name2);
+
   const {stderr} = runJest(DIR, [
     '--no-watchman',
     '-w=2',

--- a/packages/jest-config/package.json
+++ b/packages/jest-config/package.json
@@ -23,8 +23,7 @@
     "jest-validate": "^24.0.0",
     "micromatch": "^3.1.10",
     "pretty-format": "^24.0.0",
-    "realpath-native": "^1.0.2",
-    "uuid": "^3.3.2"
+    "realpath-native": "^1.0.2"
   },
   "engines": {
     "node": ">= 6"

--- a/packages/jest-config/src/__tests__/normalize.test.js
+++ b/packages/jest-config/src/__tests__/normalize.test.js
@@ -6,15 +6,16 @@
  *
  */
 
+import crypto from 'crypto';
+import path from 'path';
 import {escapeStrForRegex} from 'jest-regex-util';
 import normalize from '../normalize';
 
-jest.mock('jest-resolve');
-jest.mock('path', () => jest.requireActual('path').posix);
+import {DEFAULT_JS_PATTERN} from '../constants';
 
-const path = require('path');
-const DEFAULT_JS_PATTERN = require('../constants').DEFAULT_JS_PATTERN;
 const DEFAULT_CSS_PATTERN = '^.+\\.(css)$';
+
+jest.mock('jest-resolve').mock('path', () => jest.requireActual('path').posix);
 
 let root;
 let expectedPathFooBar;
@@ -46,16 +47,95 @@ beforeEach(() => {
   require('jest-resolve').findNodeModule = findNodeModule;
 });
 
-it('assigns a random 32-byte hash as a name to avoid clashes', () => {
+it('picks a name based on the rootDir', () => {
   const rootDir = '/root/path/foo';
-  const {name: name1} = normalize({rootDir}, {}).options;
-  const {name: name2} = normalize({rootDir}, {}).options;
+  const expected = crypto
+    .createHash('md5')
+    .update('/root/path/foo')
+    .digest('hex');
+  expect(
+    normalize(
+      {
+        rootDir,
+      },
+      {},
+    ).options.name,
+  ).toBe(expected);
+});
 
-  expect(name1).toEqual(expect.any(String));
-  expect(name1).toHaveLength(32);
-  expect(name2).toEqual(expect.any(String));
-  expect(name2).toHaveLength(32);
-  expect(name1).not.toBe(name2);
+it('picks a name for projects based on the main rootDir', () => {
+  const rootDir = '/root/path/foo';
+  const firstExpected = crypto
+    .createHash('md5')
+    .update('/root/path/foo')
+    .digest('hex');
+  const secondExpected = crypto
+    .createHash('md5')
+    .update('/root/path/foo:1')
+    .digest('hex');
+
+  const options = normalize(
+    {
+      projects: [{}, {}],
+      rootDir,
+    },
+    {},
+  );
+
+  expect(options.options.projects[0].name).toBe(firstExpected);
+  expect(options.options.projects[1].name).toBe(secondExpected);
+});
+
+it('picks a name for projects based on the projects rootDir', () => {
+  const firstRootDir = '/root/path/foo';
+  const secondRootDir = '/root/path/bar';
+  const firstExpected = crypto
+    .createHash('md5')
+    .update('/root/path/foo')
+    .digest('hex');
+  const secondExpected = crypto
+    .createHash('md5')
+    .update('/root/path/foo:1')
+    .digest('hex');
+  const thirdExpected = crypto
+    .createHash('md5')
+    .update('/root/path/bar')
+    .digest('hex');
+  const fourthExpected = crypto
+    .createHash('md5')
+    .update('/root/path/baz')
+    .digest('hex');
+
+  const options = normalize(
+    {
+      projects: [
+        {rootDir: firstRootDir},
+        {rootDir: firstRootDir},
+        {rootDir: secondRootDir},
+        {},
+      ],
+      rootDir: '/root/path/baz',
+    },
+    {},
+  );
+
+  expect(options.options.projects[0].name).toBe(firstExpected);
+  expect(options.options.projects[1].name).toBe(secondExpected);
+  expect(options.options.projects[2].name).toBe(thirdExpected);
+  expect(options.options.projects[3].name).toBe(fourthExpected);
+});
+
+it('keeps custom project name based on the projects rootDir', () => {
+  const name = 'test';
+  const options = normalize(
+    {
+      projects: [{name, rootDir: '/path/to/foo'}],
+      rootDir: '/root/path/baz',
+    },
+    {},
+  );
+
+  expect(options.options.projects[0].name).toBe(name);
 });
 
 it('keeps custom names based on the rootDir', () => {
@@ -68,6 +148,16 @@ it('keeps custom names based on the rootDir', () => {
       {},
     ).options.name,
   ).toBe('custom-name');
+});
+
+it('minimal config is stable across runs', () => {
+  const firstNormalization = normalize({rootDir: '/root/path/foo'}, {});
+  const secondNormalization = normalize({rootDir: '/root/path/foo'}, {});
+
+  expect(firstNormalization).toEqual(secondNormalization);
+  expect(JSON.stringify(firstNormalization)).toBe(
+    JSON.stringify(secondNormalization),
+  );
 });
 
 it('sets coverageReporters correctly when argv.json is set', () => {

--- a/packages/jest-config/src/__tests__/normalize.test.js
+++ b/packages/jest-config/src/__tests__/normalize.test.js
@@ -63,68 +63,6 @@ it('picks a name based on the rootDir', () => {
   ).toBe(expected);
 });
 
-it('picks a name for projects based on the main rootDir', () => {
-  const rootDir = '/root/path/foo';
-  const firstExpected = crypto
-    .createHash('md5')
-    .update('/root/path/foo')
-    .digest('hex');
-  const secondExpected = crypto
-    .createHash('md5')
-    .update('/root/path/foo:1')
-    .digest('hex');
-
-  const options = normalize(
-    {
-      projects: [{}, {}],
-      rootDir,
-    },
-    {},
-  );
-
-  expect(options.options.projects[0].name).toBe(firstExpected);
-  expect(options.options.projects[1].name).toBe(secondExpected);
-});
-
-it('picks a name for projects based on the projects rootDir', () => {
-  const firstRootDir = '/root/path/foo';
-  const secondRootDir = '/root/path/bar';
-  const firstExpected = crypto
-    .createHash('md5')
-    .update('/root/path/foo')
-    .digest('hex');
-  const secondExpected = crypto
-    .createHash('md5')
-    .update('/root/path/foo:1')
-    .digest('hex');
-  const thirdExpected = crypto
-    .createHash('md5')
-    .update('/root/path/bar')
-    .digest('hex');
-  const fourthExpected = crypto
-    .createHash('md5')
-    .update('/root/path/baz')
-    .digest('hex');
-
-  const options = normalize(
-    {
-      projects: [
-        {rootDir: firstRootDir},
-        {rootDir: firstRootDir},
-        {rootDir: secondRootDir},
-        {},
-      ],
-      rootDir: '/root/path/baz',
-    },
-    {},
-  );
-
-  expect(options.options.projects[0].name).toBe(firstExpected);
-  expect(options.options.projects[1].name).toBe(secondExpected);
-  expect(options.options.projects[2].name).toBe(thirdExpected);
-  expect(options.options.projects[3].name).toBe(fourthExpected);
-});
-
 it('keeps custom project name based on the projects rootDir', () => {
   const name = 'test';
   const options = normalize(

--- a/packages/jest-config/src/__tests__/normalize.test.js
+++ b/packages/jest-config/src/__tests__/normalize.test.js
@@ -52,6 +52,7 @@ it('picks a name based on the rootDir', () => {
   const expected = crypto
     .createHash('md5')
     .update('/root/path/foo')
+    .update(String(Infinity))
     .digest('hex');
   expect(
     normalize(

--- a/packages/jest-config/src/index.js
+++ b/packages/jest-config/src/index.js
@@ -39,6 +39,7 @@ export function readConfig(
   // read individual configs for every project.
   skipArgvConfigOption?: boolean,
   parentConfigPath: ?Path,
+  projectIndex?: number = Infinity,
 ): {
   configPath: ?Path,
   globalConfig: GlobalConfig,
@@ -90,6 +91,7 @@ export function readConfig(
     rawOptions,
     argv,
     configPath,
+    projectIndex,
   );
 
   const {globalConfig, projectConfig} = groupOptions(options);
@@ -302,7 +304,9 @@ export function readConfigs(
 
         return true;
       })
-      .map(root => readConfig(argv, root, true, configPath));
+      .map((root, projectIndex) =>
+        readConfig(argv, root, true, configPath, projectIndex),
+      );
 
     ensureNoDuplicateConfigs(parsedConfigs, projects);
     configs = parsedConfigs.map(({projectConfig}) => projectConfig);

--- a/packages/jest-config/src/index.js
+++ b/packages/jest-config/src/index.js
@@ -86,7 +86,12 @@ export function readConfig(
     rawOptions = readConfigFileAndSetRootDir(configPath);
   }
 
-  const {options, hasDeprecationWarnings} = normalize(rawOptions, argv);
+  const {options, hasDeprecationWarnings} = normalize(
+    rawOptions,
+    argv,
+    configPath,
+  );
+
   const {globalConfig, projectConfig} = groupOptions(options);
   return {
     configPath,
@@ -210,7 +215,7 @@ const groupOptions = (
   }),
 });
 
-const ensureNoDuplicateConfigs = (parsedConfigs, projects, rootConfigPath) => {
+const ensureNoDuplicateConfigs = (parsedConfigs, projects) => {
   const configPathMap = new Map();
 
   for (const config of parsedConfigs) {
@@ -299,7 +304,7 @@ export function readConfigs(
       })
       .map(root => readConfig(argv, root, true, configPath));
 
-    ensureNoDuplicateConfigs(parsedConfigs, projects, configPath);
+    ensureNoDuplicateConfigs(parsedConfigs, projects);
     configs = parsedConfigs.map(({projectConfig}) => projectConfig);
     if (!hasDeprecationWarnings) {
       hasDeprecationWarnings = parsedConfigs.some(

--- a/packages/jest-config/src/normalize.js
+++ b/packages/jest-config/src/normalize.js
@@ -385,7 +385,7 @@ export default function normalize(
   options: InitialOptions,
   argv: Argv,
   configPath: ?Path,
-  projectIndex: number,
+  projectIndex?: number = Infinity,
 ) {
   const {hasDeprecationWarnings} = validate(options, {
     comment: DOCUMENTATION_NOTE,

--- a/packages/jest-config/src/normalize.js
+++ b/packages/jest-config/src/normalize.js
@@ -267,6 +267,7 @@ const normalizePreprocessor = (options: InitialOptions): InitialOptions => {
 const normalizeMissingOptions = (
   options: InitialOptions,
   configPath: ?Path,
+  projectIndex: number,
 ): InitialOptions => {
   if (!options.name) {
     options.name = crypto
@@ -274,6 +275,7 @@ const normalizeMissingOptions = (
       .update(options.rootDir)
       // In case we load config from some path that has the same root dir
       .update(configPath || '')
+      .update(String(projectIndex))
       .digest('hex');
   }
 
@@ -383,6 +385,7 @@ export default function normalize(
   options: InitialOptions,
   argv: Argv,
   configPath: ?Path,
+  projectIndex: number,
 ) {
   const {hasDeprecationWarnings} = validate(options, {
     comment: DOCUMENTATION_NOTE,
@@ -405,6 +408,7 @@ export default function normalize(
       normalizeMissingOptions(
         normalizeRootDir(setFromArgv(options, argv)),
         configPath,
+        projectIndex,
       ),
     ),
   );

--- a/packages/jest-config/src/normalize.js
+++ b/packages/jest-config/src/normalize.js
@@ -17,7 +17,6 @@ import type {
 } from 'types/Config';
 
 import crypto from 'crypto';
-import uuid from 'uuid/v4';
 import glob from 'glob';
 import path from 'path';
 import {ValidationError, validate} from 'jest-validate';
@@ -265,12 +264,31 @@ const normalizePreprocessor = (options: InitialOptions): InitialOptions => {
 };
 
 const normalizeMissingOptions = (options: InitialOptions): InitialOptions => {
+  const knownRootDirs: Set<string> = new Set();
   if (!options.name) {
     options.name = crypto
       .createHash('md5')
       .update(options.rootDir)
-      .update(uuid())
       .digest('hex');
+  }
+
+  if (Array.isArray(options.projects)) {
+    options.projects = options.projects.map((project, index) => {
+      if (typeof project !== 'string' && !project.name) {
+        let rootDir = project.rootDir || options.rootDir;
+        if (knownRootDirs.has(rootDir)) {
+          rootDir = `${rootDir}:${index}`;
+        }
+
+        knownRootDirs.add(rootDir);
+        project.name = crypto
+          .createHash('md5')
+          .update(rootDir)
+          .digest('hex');
+      }
+
+      return project;
+    });
   }
 
   if (!options.setupFiles) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Fixes #7732 ~~by basically reverting a change within #5862 (https://github.com/facebook/jest/commit/a370c21539aad54f79d577b3b95203351b1fc169).~~

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

~~Restored the tests from the linked commit, and added a new one (`minimal config is stable across runs'`)~~

Added a new test to check two runs of `normalize` are stable, plus an e2e test checking name specifically, both for linked config and inline config

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
