### PR TITLE
update jest-haste-map sane dep to sane@4

### DIFF
--- a/packages/jest-haste-map/package.json
+++ b/packages/jest-haste-map/package.json
@@ -16,7 +16,7 @@
     "jest-util": "^24.0.0",
     "jest-worker": "^24.0.0",
     "micromatch": "^3.1.10",
-    "sane": "^3.0.0"
+    "sane": "^4.0.0"
   },
   "engines": {
     "node": ">= 6"

--- a/packages/jest-haste-map/src/index.js
+++ b/packages/jest-haste-map/src/index.js
@@ -755,8 +755,6 @@ class HasteMap extends EventEmitter {
     const Watcher =
       canUseWatchman && this._options.useWatchman
         ? WatchmanWatcher
-        : os.platform() === 'darwin'
-        ? sane.FSEventsWatcher
         : sane.NodeWatcher;
     const extensions = this._options.extensions;
     const ignorePattern = this._options.ignorePattern;


### PR DESCRIPTION
## Summary

sane <= 3 depends on fsevents, which doesn't compile with node 12. sane 4 removes this dependency.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

not sure yet 😅 