### PR TITLE
chore: update jsdom to latest 13.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - `[jest]` Update jest-junit to ^6.2.1 ([#7739](https://github.com/facebook/jest/pull/7739))
 - `[website]` Fix broken help link on homepage ([#7706](https://github.com/facebook/jest/pull/7706))
 - `[docs]` Changed Babel setup documentation to correctly compile `async/await` ([#7701](https://github.com/facebook/jest/pull/7701))
+- `[jest-environment-jsdom]` Update jsdom to ^13.2.0 ([#7763](https://github.com/facebook/jest/pull/7763))
 
 ### Performance
 

--- a/packages/jest-environment-jsdom/package.json
+++ b/packages/jest-environment-jsdom/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "jest-mock": "^24.0.0",
     "jest-util": "^24.0.0",
-    "jsdom": "^11.5.1"
+    "jsdom": "^13.2.0"
   },
   "engines": {
     "node": ">= 6"


### PR DESCRIPTION
## Summary

jsdom finally got MutationObserver.

## Test plan

Tested with plain jest setup. MutationObserver is available as global variable.