### PR TITLE
Fix typo in docs and CLI description

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -126,7 +126,7 @@ Runs tests related to the current changes and the changes made in the last commi
 
 ### `--changedSince`
 
-Runs tests related the changes since the provided branch. If the current branch has diverged from the given branch, then only changes made locally will be tested. Behaves similarly to `--onlyChanged`.
+Runs tests related to the changes since the provided branch. If the current branch has diverged from the given branch, then only changes made locally will be tested. Behaves similarly to `--onlyChanged`.
 
 ### `--ci`
 

--- a/packages/jest-cli/src/cli/args.js
+++ b/packages/jest-cli/src/cli/args.js
@@ -118,7 +118,7 @@ export const options = {
   },
   changedSince: {
     description:
-      'Runs tests related the changes since the provided branch. If the ' +
+      'Runs tests related to the changes since the provided branch. If the ' +
       'current branch has diverged from the given branch, then only changes ' +
       'made locally will be tested. Behaves similarly to `--onlyChanged`.',
     nargs: 1,

--- a/website/versioned_docs/version-23.x/CLI.md
+++ b/website/versioned_docs/version-23.x/CLI.md
@@ -112,7 +112,7 @@ Runs tests related to the current changes and the changes made in the last commi
 
 ### `--changedSince`
 
-Runs tests related the changes since the provided branch. If the current branch has diverged from the given branch, then only changes made locally will be tested. Behaves similarly to `--onlyChanged`.
+Runs tests related to the changes since the provided branch. If the current branch has diverged from the given branch, then only changes made locally will be tested. Behaves similarly to `--onlyChanged`.
 
 ### `--ci`
 

--- a/website/versioned_docs/version-24.0/CLI.md
+++ b/website/versioned_docs/version-24.0/CLI.md
@@ -127,7 +127,7 @@ Runs tests related to the current changes and the changes made in the last commi
 
 ### `--changedSince`
 
-Runs tests related the changes since the provided branch. If the current branch has diverged from the given branch, then only changes made locally will be tested. Behaves similarly to `--onlyChanged`.
+Runs tests related to the changes since the provided branch. If the current branch has diverged from the given branch, then only changes made locally will be tested. Behaves similarly to `--onlyChanged`.
 
 ### `--ci`
 


### PR DESCRIPTION
Fix typo in docs and CLI description.