### PR TITLE
Fix typos in snapshotResolver configuration docs

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -730,7 +730,7 @@ _Note: `setupTestFrameworkScriptFile` is deprecated in favor of `setupFilesAfter
 
 Default: `undefined`
 
-The path to a module that can resolve test<->snapshot path. This config option lets you customize where Jest stores that snapshot files on disk.
+The path to a module that can resolve test<->snapshot path. This config option lets you customize where Jest stores snapshot files on disk.
 
 Example snapshot resolver module:
 
@@ -746,7 +746,7 @@ module.exports = {
       .replace('__snapshots__', '__tests__')
       .slice(0, -snapshotExtension.length),
 
-  // Example test path, used for preflight concistency check of the implementation above
+  // Example test path, used for preflight consistency check of the implementation above
   testPathForConsistencyCheck: 'some/__tests__/example.test.js',
 };
 ```

--- a/website/versioned_docs/version-24.0/Configuration.md
+++ b/website/versioned_docs/version-24.0/Configuration.md
@@ -725,7 +725,7 @@ _Note: `setupTestFrameworkScriptFile` is deprecated in favor of `setupFilesAfter
 
 Default: `undefined`
 
-The path to a module that can resolve test<->snapshot path. This config option lets you customize where Jest stores that snapshot files on disk.
+The path to a module that can resolve test<->snapshot path. This config option lets you customize where Jest stores snapshot files on disk.
 
 Example snapshot resolver module:
 
@@ -741,7 +741,7 @@ module.exports = {
       .replace('__snapshots__', '__tests__')
       .slice(0, -snapshotExtension.length),
 
-  // Example test path, used for preflight concistency check of the implementation above
+  // Example test path, used for preflight consistency check of the implementation above
   testPathForConsistencyCheck: 'some/__tests__/example.test.js',
 };
 ```


### PR DESCRIPTION
This PR fixes a couple of typos in the `snapshotResolver` configuration docs.