### PR TITLE
feat: add new 'modern' implementation of Fake Timers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 - `[jest-environment-jsdom]` [**BREAKING**] Upgrade `jsdom` to v16 ([#9606](https://github.com/facebook/jest/pull/9606))
+- `[@jest/fake-timers]` Add possibility to use a modern implementation of fake timers, backed by `@sinonjs/fake-timers` ([#7776](https://github.com/facebook/jest/pull/7776))
 
 ### Fixes
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -1124,7 +1124,9 @@ This option sets the URL for the jsdom environment. It is reflected in propertie
 
 Default: `real`
 
-Setting this value to `fake` allows the use of fake timers for functions such as `setTimeout`. Fake timers are useful when a piece of code sets a long timeout that we don't want to wait for in a test.
+Setting this value to `legacy` or `fake` allows the use of fake timers for functions such as `setTimeout`. Fake timers are useful when a piece of code sets a long timeout that we don't want to wait for in a test.
+
+If the value is `modern`, [`@sinonjs/fake-timers`](https://github.com/sinonjs/fake-timers) will be used as implementation instead of Jest's own legacy implementation. This will be the default fake implementation in Jest 27.
 
 ### `transform` [object\<string, pathToTransformer | [pathToTransformer, object]>]
 

--- a/docs/JestObjectAPI.md
+++ b/docs/JestObjectAPI.md
@@ -577,9 +577,11 @@ Restores all mocks back to their original value. Equivalent to calling [`.mockRe
 
 ## Mock timers
 
-### `jest.useFakeTimers()`
+### `jest.useFakeTimers(implementation?: 'modern' | 'legacy')`
 
 Instructs Jest to use fake versions of the standard timer functions (`setTimeout`, `setInterval`, `clearTimeout`, `clearInterval`, `nextTick`, `setImmediate` and `clearImmediate`).
+
+If you pass `'modern'` as argument, [`@sinonjs/fake-timers`](https://github.com/sinonjs/fake-timers) will be used as implementation instead of Jest's own fake timers. This also mocks additional timers like `Date`. `'modern'` will be the default behavior in Jest 27.
 
 Returns the `jest` object for chaining.
 
@@ -606,6 +608,8 @@ This is often useful for synchronously executing setTimeouts during a test in or
 ### `jest.runAllImmediates()`
 
 Exhausts all tasks queued by `setImmediate()`.
+
+> Note: This function is not available when using modern fake timers implementation
 
 ### `jest.advanceTimersByTime(msToRun)`
 
@@ -638,6 +642,18 @@ This means, if any timers have been scheduled (but have not yet executed), they 
 ### `jest.getTimerCount()`
 
 Returns the number of fake timers still left to run.
+
+### `.jest.setSystemTime()`
+
+Set the current system time used by fake timers. Simulates a user changing the system clock while your program is running. It affects the current time but it does not in itself cause e.g. timers to fire; they will fire exactly as they would have done without the call to `jest.setSystemTime()`.
+
+> Note: This function is only available when using modern fake timers implementation
+
+### `.jest.getRealSystemTime()`
+
+When mocking time, `Date.now()` will also be mocked. If you for some reason need access to the real current time, you can invoke this function.
+
+> Note: This function is only available when using modern fake timers implementation
 
 ## Misc
 

--- a/e2e/__tests__/modernFakeTimers.test.ts
+++ b/e2e/__tests__/modernFakeTimers.test.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import runJest from '../runJest';
+
+describe('modern implementation of fake timers', () => {
+  it('should be possible to use modern implementation from config', () => {
+    const result = runJest('modern-fake-timers/from-config');
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('should be possible to use modern implementation from jest-object', () => {
+    const result = runJest('modern-fake-timers/from-jest-object');
+    expect(result.exitCode).toBe(0);
+  });
+});

--- a/e2e/modern-fake-timers/from-config/__tests__/test.js
+++ b/e2e/modern-fake-timers/from-config/__tests__/test.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+test('fake timers', () => {
+  jest.setSystemTime(0);
+
+  expect(Date.now()).toBe(0);
+
+  jest.setSystemTime(1000);
+
+  expect(Date.now()).toBe(1000);
+});

--- a/e2e/modern-fake-timers/from-config/package.json
+++ b/e2e/modern-fake-timers/from-config/package.json
@@ -1,0 +1,6 @@
+{
+  "jest": {
+    "timers": "modern",
+    "testEnvironment": "node"
+  }
+}

--- a/e2e/modern-fake-timers/from-jest-object/__tests__/test.js
+++ b/e2e/modern-fake-timers/from-jest-object/__tests__/test.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+test('fake timers', () => {
+  jest.useFakeTimers('modern');
+
+  jest.setSystemTime(0);
+
+  expect(Date.now()).toBe(0);
+
+  jest.setSystemTime(1000);
+
+  expect(Date.now()).toBe(1000);
+});

--- a/e2e/modern-fake-timers/from-jest-object/package.json
+++ b/e2e/modern-fake-timers/from-jest-object/package.json
@@ -1,0 +1,5 @@
+{
+  "jest": {
+    "testEnvironment": "node"
+  }
+}

--- a/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapter.ts
+++ b/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapter.ts
@@ -52,9 +52,7 @@ const jestAdapter = async (
   if (config.timers === 'fake' || config.timers === 'legacy') {
     // during setup, this cannot be null (and it's fine to explode if it is)
     environment.fakeTimers!.useFakeTimers();
-  }
-
-  if (config.timers === 'modern') {
+  } else if (config.timers === 'modern') {
     environment.fakeTimersModern!.useFakeTimers();
   }
 

--- a/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapter.ts
+++ b/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapter.ts
@@ -49,9 +49,13 @@ const jestAdapter = async (
     testPath,
   });
 
-  if (config.timers === 'fake') {
+  if (config.timers === 'fake' || config.timers === 'legacy') {
     // during setup, this cannot be null (and it's fine to explode if it is)
     environment.fakeTimers!.useFakeTimers();
+  }
+
+  if (config.timers === 'modern') {
+    environment.fakeTimersModern!.useFakeTimers();
   }
 
   globals.beforeEach(() => {

--- a/packages/jest-environment/src/index.ts
+++ b/packages/jest-environment/src/index.ts
@@ -199,6 +199,8 @@ export interface Jest {
   retryTimes(numRetries: number): Jest;
   /**
    * Exhausts tasks queued by setImmediate().
+   *
+   * > Note: This function is not available when using Lolex as fake timers implementation
    */
   runAllImmediates(): void;
   /**
@@ -269,7 +271,7 @@ export interface Jest {
   /**
    * Instructs Jest to use fake versions of the standard timer functions.
    */
-  useFakeTimers(): Jest;
+  useFakeTimers(implementation?: 'modern' | 'legacy'): Jest;
   /**
    * Instructs Jest to use the real versions of the standard timer functions.
    */
@@ -281,4 +283,18 @@ export interface Jest {
    * every test so that local module state doesn't conflict between tests.
    */
   isolateModules(fn: () => void): Jest;
+
+  /**
+   * When mocking time, `Date.now()` will also be mocked. If you for some reason need access to the real current time, you can invoke this function.
+   *
+   * > Note: This function is only available when using Lolex as fake timers implementation
+   */
+  getRealSystemTime(): number;
+
+  /**
+   *  Set the current system time used by fake timers. Simulates a user changing the system clock while your program is running. It affects the current time but it does not in itself cause e.g. timers to fire; they will fire exactly as they would have done without the call to `jest.setSystemTime()`.
+   *
+   *  > Note: This function is only available when using Lolex as fake timers implementation
+   */
+  setSystemTime(now?: number): void;
 }

--- a/packages/jest-jasmine2/src/index.ts
+++ b/packages/jest-jasmine2/src/index.ts
@@ -93,8 +93,10 @@ async function jasmine2(
   environment.global.describe.skip = environment.global.xdescribe;
   environment.global.describe.only = environment.global.fdescribe;
 
-  if (config.timers === 'fake') {
+  if (config.timers === 'fake' || config.timers === 'legacy') {
     environment.fakeTimers!.useFakeTimers();
+  } else if (config.timers === 'modern') {
+    environment.fakeTimersModern!.useFakeTimers();
   }
 
   env.beforeEach(() => {
@@ -109,7 +111,7 @@ async function jasmine2(
     if (config.resetMocks) {
       runtime.resetAllMocks();
 
-      if (config.timers === 'fake') {
+      if (config.timers === 'fake' || config.timers === 'legacy') {
         environment.fakeTimers!.useFakeTimers();
       }
     }

--- a/packages/jest-runtime/package.json
+++ b/packages/jest-runtime/package.json
@@ -13,6 +13,7 @@
     "@jest/console": "^26.0.0-alpha.0",
     "@jest/environment": "^26.0.0-alpha.0",
     "@jest/globals": "^26.0.0-alpha.0",
+    "@jest/fake-timers": "^26.0.0-alpha.0",
     "@jest/source-map": "^26.0.0-alpha.0",
     "@jest/test-result": "^26.0.0-alpha.0",
     "@jest/transform": "^26.0.0-alpha.0",

--- a/packages/jest-runtime/tsconfig.json
+++ b/packages/jest-runtime/tsconfig.json
@@ -9,6 +9,7 @@
     {"path": "../jest-console"},
     {"path": "../jest-environment"},
     {"path": "../jest-environment-node"},
+    {"path": "../jest-fake-timers"},
     {"path": "../jest-globals"},
     {"path": "../jest-haste-map"},
     {"path": "../jest-message-util"},

--- a/packages/jest-types/src/Config.ts
+++ b/packages/jest-types/src/Config.ts
@@ -344,7 +344,7 @@ export type ProjectConfig = {
   testRegex: Array<string | RegExp>;
   testRunner: string;
   testURL: string;
-  timers: 'real' | 'fake';
+  timers: 'real' | 'fake' | 'modern' | 'legacy';
   transform: Array<[string, Path, Record<string, unknown>]>;
   transformIgnorePatterns: Array<Glob>;
   watchPathIgnorePatterns: Array<string>;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

This is an alternative to #5171 and #7300. Difference from them is that in this PR Lolex is added as an opt-in alternative to the current implementation of fake timers, instead of replacing it.

I've added `jest.useFakeTimers('modern');` which will allow people to migrate test file by test file if they want the new system. People can also use `useFakeTimers('legacy')` if they want to keep using the old implementation.

The default if nothing is passed to `jest.useFakeTimers` (or just `fake` is passed in config) will be the legacy implementation in Jest 26, and we will swap the default in Jest 27. We have no plans to ever remove the legacy implementation.

Hopefully this means FB can migrate over over timer and we can remove Jest's implementation.

Fixes #3465
Fixes #5165
Closes #5171
Closes #7300

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Copied over the refactored unit test from #5171, and added an integration test.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
