### PR TITLE
feat: add "skipHastePackages" option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `[expect]`: Improve report when matcher fails, part 10 ([#7960](https://github.com/facebook/jest/pull/7960))
 - `[pretty-format]` Support `React.memo` ([#7891](https://github.com/facebook/jest/pull/7891))
 - `[jest-config]` Print error information on preset normalization error ([#7935](https://github.com/facebook/jest/pull/7935))
+- `[jest-haste-map]` Add "skipPackageJson" option
 
 ### Fixes
 

--- a/packages/jest-haste-map/src/index.ts
+++ b/packages/jest-haste-map/src/index.ts
@@ -64,6 +64,7 @@ type Options = {
   retainAllFiles: boolean;
   rootDir: string;
   roots: Array<string>;
+  skipPackageJson?: boolean;
   throwOnModuleCollision?: boolean;
   useWatchman?: boolean;
   watch?: boolean;
@@ -87,6 +88,7 @@ type InternalOptions = {
   retainAllFiles: boolean;
   rootDir: string;
   roots: Array<string>;
+  skipPackageJson: boolean;
   throwOnModuleCollision: boolean;
   useWatchman: boolean;
   watch: boolean;
@@ -108,6 +110,7 @@ namespace HasteMap {
 const CHANGE_INTERVAL = 30;
 const MAX_WAIT_TIME = 240000;
 const NODE_MODULES = path.sep + 'node_modules' + path.sep;
+const PACKAGE_JSON = path.sep + 'package.json';
 
 // TypeScript doesn't like us importing from outside `rootDir`, but it doesn't
 // understand `require`.
@@ -256,6 +259,7 @@ class HasteMap extends EventEmitter {
       retainAllFiles: options.retainAllFiles,
       rootDir: options.rootDir,
       roots: Array.from(new Set(options.roots)),
+      skipPackageJson: !!options.skipPackageJson,
       throwOnModuleCollision: !!options.throwOnModuleCollision,
       useWatchman: options.useWatchman == null ? true : options.useWatchman,
       watch: !!options.watch,
@@ -623,6 +627,12 @@ class HasteMap extends EventEmitter {
     }
 
     for (const relativeFilePath of hasteMap.files.keys()) {
+      if (
+        this._options.skipPackageJson &&
+        relativeFilePath.endsWith(PACKAGE_JSON)
+      ) {
+        continue;
+      }
       // SHA-1, if requested, should already be present thanks to the crawler.
       const filePath = fastPath.resolve(
         this._options.rootDir,


### PR DESCRIPTION
## Summary

The `skipHastePackages` option prevents reading of `package.json` files and keeps them out of the module map. It's important to fixing package deduplication in Metro (see here: https://github.com/facebook/metro/issues/350), especially after symlink support is merged (see here: https://github.com/facebook/metro/pull/257).

With support for symlinks in `node_modules`, it's very easy for the dependencies of one "locally developed" package to collide with another package's dependencies, which results in frustrating errors that are entirely avoidable.

## Test plan

I tested it manually. Works great! I don't have time to get familiar with your test suite.
