### PR TITLE
jest-diff CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - `[jest-jasmine2]` Will now only execute at most 5 concurrent tests _within the same testsuite_ when using `test.concurrent` ([#7770](https://github.com/facebook/jest/pull/7770))
 - `[jest-circus]` Same as `[jest-jasmine2]`, only 5 tests will run concurrently by default ([#7770](https://github.com/facebook/jest/pull/7770))
 - `[jest-config]` A new `maxConcurrency` option allows to change the number of tests allowed to run concurrently ([#7770](https://github.com/facebook/jest/pull/7770))
-- `[jest-diff]` Provide a CLI for diffing JSON (TODO)
+- `[jest-diff]` Provide a CLI for diffing JSON ([#7781](https://github.com/facebook/jest/pull/7781))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `[jest-jasmine2]` Will now only execute at most 5 concurrent tests _within the same testsuite_ when using `test.concurrent` ([#7770](https://github.com/facebook/jest/pull/7770))
 - `[jest-circus]` Same as `[jest-jasmine2]`, only 5 tests will run concurrently by default ([#7770](https://github.com/facebook/jest/pull/7770))
 - `[jest-config]` A new `maxConcurrency` option allows to change the number of tests allowed to run concurrently ([#7770](https://github.com/facebook/jest/pull/7770))
+- `[jest-diff]` Provide a CLI for diffing JSON (TODO)
 
 ### Fixes
 

--- a/docs/JestPlatform.md
+++ b/docs/JestPlatform.md
@@ -43,6 +43,14 @@ const result = diff(a, b);
 console.log(result);
 ```
 
+### CLI
+
+It also comes with a CLI, so if you install `jest-diff` globally, you can use it to compare JSON files similarly to the UNIX program `diff`:
+
+```sh-session
+$ jest-diff a.json b.json
+```
+
 ## jest-docblock
 
 Tool for extracting and parsing the comments at the top of a JavaScript file. Exports various functions to manipulate the data inside the comment block.

--- a/e2e/__tests__/__snapshots__/jestDiffCli.test.js.snap
+++ b/e2e/__tests__/__snapshots__/jestDiffCli.test.js.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`different 1`] = `
+- Expected
++ Received
+
+  Array [
+-   42,
++   1337,
+    Object {
+-     "a": true,
++     "b": false,
+    },
+  ]
+`;
+
+exports[`help 1`] = `
+jest-diff.js a.json b.json
+
+Options:
+  -v, --version  Show version number                                   [boolean]
+  -h, --help     Show help                                             [boolean]
+`;

--- a/e2e/__tests__/__snapshots__/jestDiffCli.test.js.snap
+++ b/e2e/__tests__/__snapshots__/jestDiffCli.test.js.snap
@@ -12,6 +12,7 @@ exports[`different 1`] = `
 +     "b": false,
     },
   ]
+
 `;
 
 exports[`help 1`] = `

--- a/e2e/__tests__/jestDiffCli.test.js
+++ b/e2e/__tests__/jestDiffCli.test.js
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import execa from 'execa';
+import {tmpdir} from 'os';
+import {resolve} from 'path';
+import {wrap} from 'jest-snapshot-serializer-raw';
+import stripAnsi from 'strip-ansi';
+
+import {cleanup, writeFiles} from '../Utils';
+
+const DIR = resolve(tmpdir(), 'jest-diff-cli');
+const JEST_DIFF = resolve(
+  __dirname,
+  '../../packages/jest-diff/bin/jest-diff.js',
+);
+
+beforeAll(() =>
+  writeFiles(DIR, {
+    'a.json': '[42, {"a": true}]',
+    'b.json': '[1337, {"b": false}]',
+    'not.json': 'not JSON',
+  }),
+);
+afterAll(() => cleanup(DIR));
+
+test('equal', async () => {
+  const {code, stdout} = await execa(JEST_DIFF, ['a.json', 'a.json'], {
+    cwd: DIR,
+  });
+  expect(code).toBe(0);
+  expect(stdout).toBe('');
+});
+
+test('different', async () => {
+  const {code, stdout} = await execa(JEST_DIFF, ['a.json', 'b.json'], {
+    cwd: DIR,
+    reject: false,
+  });
+  expect(code).toBe(1);
+  expect(wrap(stripAnsi(stdout))).toMatchSnapshot();
+});
+
+// --- IO-related ---
+
+test('file does not exist', async () => {
+  const {code, stderr} = await execa(JEST_DIFF, ['a.json', 'nope.jpg'], {
+    cwd: DIR,
+    reject: false,
+  });
+  expect(code).toBe(20);
+  expect(stderr).toMatch(/no such file.*nope\.jpg/);
+});
+
+test('not JSON', async () => {
+  const {code, stderr} = await execa(JEST_DIFF, ['a.json', 'not.json'], {
+    cwd: DIR,
+    reject: false,
+  });
+  expect(code).toBe(30);
+  expect(stderr).toMatch(/Failed to parse.*JSON/);
+});
+
+// --- CLI-related ---
+
+describe('invalid usage', () => {
+  test('too few arguments', async () => {
+    const {code, stderr} = await execa(JEST_DIFF, ['a'], {reject: false});
+    expect(code).toBe(2);
+    expect(stderr).toEqual(
+      expect.stringContaining('Not enough non-option arguments'),
+    );
+  });
+
+  test('too many arguments', async () => {
+    const {code, stderr} = await execa(JEST_DIFF, ['a', 'b', 'c'], {
+      reject: false,
+    });
+    expect(code).toBe(2);
+    expect(stderr).toEqual(
+      expect.stringContaining('Too many non-option arguments'),
+    );
+  });
+});
+
+test('version', async () => {
+  const {code, stdout} = await execa(JEST_DIFF, ['-v']);
+  expect(code).toBe(0);
+  expect(stdout).toMatch(/\d{2}\.\d{1,2}\.\d{1,2}[\-\S]*/);
+});
+
+test('help', async () => {
+  const {code, stdout} = await execa(JEST_DIFF, ['-h']);
+  expect(code).toBe(0);
+  expect(wrap(stdout)).toMatchSnapshot();
+});

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "clean-e2e": "find ./e2e -not \\( -path ./e2e/presets/js -prune \\) -not \\( -path ./e2e/presets/json -prune \\) -mindepth 2 -type d \\( -name node_modules -prune \\) -exec rm -r '{}' +",
     "jest": "node ./packages/jest-cli/bin/jest.js",
     "jest-coverage": "yarn jest --coverage",
+    "jest-diff": "node ./packages/jest-diff/bin/jest-diff.js",
     "lint": "eslint . --cache --report-unused-disable-directives --ext js,md",
     "lint-es5-build": "eslint --no-eslintrc --no-ignore --env=browser packages/*/build-es5",
     "lint:md": "yarn --silent lint:md:ci --fix",

--- a/packages/jest-diff/bin/jest-diff.js
+++ b/packages/jest-diff/bin/jest-diff.js
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+'use strict';
+
+require('../build/cli').default();

--- a/packages/jest-diff/package.json
+++ b/packages/jest-diff/package.json
@@ -12,7 +12,11 @@
     "chalk": "^2.0.1",
     "diff-sequences": "^24.0.0",
     "jest-get-type": "^24.0.0",
-    "pretty-format": "^24.0.0"
+    "pretty-format": "^24.0.0",
+    "yargs": "^12.0.5"
+  },
+  "bin": {
+    "jest-diff": "./bin/jest-diff.js"
   },
   "engines": {
     "node": ">= 6"

--- a/packages/jest-diff/src/cli/index.js
+++ b/packages/jest-diff/src/cli/index.js
@@ -73,7 +73,7 @@ export default async () => {
   } else if (diffMsg === NO_DIFF_MESSAGE) {
     process.exit(EXIT_CODES.EQUAL);
   } else {
-    process.stdout.write(diffMsg);
+    console.log(diffMsg);
     process.exit(EXIT_CODES.DIFFERENT);
   }
 };

--- a/packages/jest-diff/src/cli/index.js
+++ b/packages/jest-diff/src/cli/index.js
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
+import yargs from 'yargs';
+import {readFile} from 'fs';
+
+// eslint-disable-next-line import/default
+import jestDiff from '../';
+import {NO_DIFF_MESSAGE} from '../constants';
+
+/* eslint-disable sort-keys */
+const EXIT_CODES = {
+  // like GNU diff
+  EQUAL: 0,
+  DIFFERENT: 1,
+  INVALID_USAGE: 2,
+
+  // more specific than GNU diff, which exits with 2 in all error cases
+  INTERNAL_ERROR: 10,
+  IO_ERROR: 20,
+  INVALID_JSON: 30,
+};
+/* eslint-enable sort-keys */
+
+const read = (path: string) =>
+  new Promise(resolve =>
+    readFile(path, (readErr, data) => {
+      if (readErr) {
+        console.error(`Failed to read file ${path}`, readErr);
+        process.exit(EXIT_CODES.IO_ERROR);
+      }
+      try {
+        const json = JSON.parse(String(data));
+        resolve(json);
+      } catch (parseErr) {
+        console.error(`Failed to parse file ${path} as JSON`, parseErr);
+        process.exit(EXIT_CODES.INVALID_JSON);
+      }
+    }),
+  );
+
+export default async () => {
+  const parser = yargs(process.argv.slice(2))
+    // positional
+    .demandCommand(2, 2)
+    // version
+    .version()
+    .alias('v', 'version')
+    // help
+    .usage('$0 a.json b.json')
+    .help()
+    .alias('h', 'help')
+    // error handling
+    .fail((msg, err, yargs) => {
+      if (err) throw err;
+      console.error(yargs.help());
+      console.error(msg);
+      process.exit(EXIT_CODES.INVALID_USAGE);
+    });
+
+  const [aPath, bPath] = parser.argv._;
+  const [a, b] = await Promise.all([read(aPath), read(bPath)]);
+
+  const diffMsg = jestDiff(a, b);
+  if (diffMsg == null) {
+    console.error('diff unexpectedly returned null');
+    process.exit(EXIT_CODES.INTERNAL_ERROR);
+  } else if (diffMsg === NO_DIFF_MESSAGE) {
+    process.exit(EXIT_CODES.EQUAL);
+  } else {
+    process.stdout.write(diffMsg);
+    process.exit(EXIT_CODES.DIFFERENT);
+  }
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -13089,6 +13089,14 @@ yargs-parser@^11.1.1:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
+yargs-parser@^11.1.1:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-11.1.1.tgz#879a0865973bca9f6bab5cbdf3b1c67ec7d3bcf4"
+  integrity sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
 yargs-parser@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-7.0.0.tgz#8d0ac42f16ea55debd332caf4c4038b3e3f5dfd9"
@@ -13122,6 +13130,24 @@ yargs@^10.0.3:
     yargs-parser "^8.1.0"
 
 yargs@^12.0.1, yargs@^12.0.2:
+  version "12.0.5"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-12.0.5.tgz#05f5997b609647b64f66b81e3b4b10a368e7ad13"
+  integrity sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==
+  dependencies:
+    cliui "^4.0.0"
+    decamelize "^1.2.0"
+    find-up "^3.0.0"
+    get-caller-file "^1.0.1"
+    os-locale "^3.0.0"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^2.0.0"
+    which-module "^2.0.0"
+    y18n "^3.2.1 || ^4.0.0"
+    yargs-parser "^11.1.1"
+
+yargs@^12.0.5:
   version "12.0.5"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-12.0.5.tgz#05f5997b609647b64f66b81e3b4b10a368e7ad13"
   integrity sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

`jest-diff` is a nice utility for comparing large JSON structures. I've written node scripts like
```js
const {readFileSync} = require('fs')
const diff = require('jest-diff')
const a = JSON.parse(readFileSync('/tmp/a'))
const b = JSON.parse(readFileSync('/tmp/b'))
console.log(diff(a, b))
```
quite a few times to compare e.g. HTTP response bodies.
This PR adds a CLI to `jest-diff` that can be used after installing `jest-diff` globally (or, if installed locally, e.g. in a project's shell scripts).

It is sort of a minimum viable implementation, it would be conceivable to add e.g. support for command-line flags that control `DiffOptions` in the future.
It would also be conceivable to give other packages this treatment if they could be useful as a CLI tool, e.g. `pretty-format`.

cc @pedrottimark had this lying around semi-finished for some time now - this is the thing that lead me to https://github.com/facebook/jest/pull/7605 :smile: 	

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

CLI e2e tests included.
`jest-diff` script added for convenient manual testing.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
