### PR TITLE
expect: clarify errors with .not and equal Expected and Received

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `[jest-jasmine2]` Will now only execute at most 5 concurrent tests _within the same testsuite_ when using `test.concurrent` ([#7770](https://github.com/facebook/jest/pull/7770))
 - `[jest-circus]` Same as `[jest-jasmine2]`, only 5 tests will run concurrently by default ([#7770](https://github.com/facebook/jest/pull/7770))
 - `[jest-config]` A new `maxConcurrency` option allows to change the number of tests allowed to run concurrently ([#7770](https://github.com/facebook/jest/pull/7770))
+- `[expect]` Clarify errors with `.not` and equal Expected and Received (TODO)
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - `[jest-jasmine2]` Will now only execute at most 5 concurrent tests _within the same testsuite_ when using `test.concurrent` ([#7770](https://github.com/facebook/jest/pull/7770))
 - `[jest-circus]` Same as `[jest-jasmine2]`, only 5 tests will run concurrently by default ([#7770](https://github.com/facebook/jest/pull/7770))
 - `[jest-config]` A new `maxConcurrency` option allows to change the number of tests allowed to run concurrently ([#7770](https://github.com/facebook/jest/pull/7770))
-- `[expect]` Clarify errors with `.not` and equal Expected and Received (TODO)
+- `[expect]` Clarify errors with `.not` and equal Expected and Received ([#7795](https://github.com/facebook/jest/pull/7795))
 
 ### Fixes
 

--- a/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -244,50 +244,50 @@ Difference:
 exports[`.toBe() fails for '"a"' with '.not' 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.toBe(</><green>expected</><dim>) // Object.is equality</>
 
-Expected: <green>\\"a\\"</>
-Received: <red>\\"a\\"</>"
+Received: <red>\\"a\\"</>
+Expected: <green>any other value</>"
 `;
 
 exports[`.toBe() fails for '[]' with '.not' 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.toBe(</><green>expected</><dim>) // Object.is equality</>
 
-Expected: <green>[]</>
-Received: <red>[]</>"
+Received: <red>[]</>
+Expected: <green>any other value</>"
 `;
 
 exports[`.toBe() fails for '{}' with '.not' 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.toBe(</><green>expected</><dim>) // Object.is equality</>
 
-Expected: <green>{}</>
-Received: <red>{}</>"
+Received: <red>{}</>
+Expected: <green>any other value</>"
 `;
 
 exports[`.toBe() fails for '1' with '.not' 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.toBe(</><green>expected</><dim>) // Object.is equality</>
 
-Expected: <green>1</>
-Received: <red>1</>"
+Received: <red>1</>
+Expected: <green>any other value</>"
 `;
 
 exports[`.toBe() fails for 'false' with '.not' 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.toBe(</><green>expected</><dim>) // Object.is equality</>
 
-Expected: <green>false</>
-Received: <red>false</>"
+Received: <red>false</>
+Expected: <green>any other value</>"
 `;
 
 exports[`.toBe() fails for 'null' with '.not' 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.toBe(</><green>expected</><dim>) // Object.is equality</>
 
-Expected: <green>null</>
-Received: <red>null</>"
+Received: <red>null</>
+Expected: <green>any other value</>"
 `;
 
 exports[`.toBe() fails for 'undefined' with '.not' 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.toBe(</><green>expected</><dim>) // Object.is equality</>
 
-Expected: <green>undefined</>
-Received: <red>undefined</>"
+Received: <red>undefined</>
+Expected: <green>any other value</>"
 `;
 
 exports[`.toBe() fails for: "abc" and "cde" 1`] = `
@@ -1165,22 +1165,25 @@ Received value: <red>undefined</>"
 exports[`.toBeInstanceOf() passing [] and [Function Array] 1`] = `
 "<dim>expect(</><red>value</><dim>).</>not<dim>.toBeInstanceOf(</><green>constructor</><dim>)</>
 
-Expected constructor: <green>Array</>
-Received value: <red>[]</>"
+Received value: <red>[]</>
+Received constructor: <red>Array</>
+Expected: <green>any other constructor</>"
 `;
 
 exports[`.toBeInstanceOf() passing {} and [Function A] 1`] = `
 "<dim>expect(</><red>value</><dim>).</>not<dim>.toBeInstanceOf(</><green>constructor</><dim>)</>
 
-Expected constructor: <green>A</>
-Received value: <red>{}</>"
+Received value: <red>{}</>
+Received constructor: <red>A</>
+Expected: <green>any other constructor</>"
 `;
 
 exports[`.toBeInstanceOf() passing Map {} and [Function Map] 1`] = `
 "<dim>expect(</><red>value</><dim>).</>not<dim>.toBeInstanceOf(</><green>constructor</><dim>)</>
 
-Expected constructor: <green>Map</>
-Received value: <red>Map {}</>"
+Received value: <red>Map {}</>
+Received constructor: <red>Map</>
+Expected: <green>any other constructor</>"
 `;
 
 exports[`.toBeInstanceOf() throws if constructor is not a function 1`] = `
@@ -1709,8 +1712,8 @@ Received has value: <red>null</>"
 exports[`.toEqual() {pass: false} expect("Alice").not.toEqual({"asymmetricMatch": [Function asymmetricMatch]}) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.toEqual(</><green>expected</><dim>)</>
 
-Expected: <green>{\\"asymmetricMatch\\": [Function asymmetricMatch]}</>
-Received: <red>\\"Alice\\"</>"
+Received: <red>\\"Alice\\"</>
+Expected: <green>any different value</>"
 `;
 
 exports[`.toEqual() {pass: false} expect("Eve").toEqual({"asymmetricMatch": [Function asymmetricMatch]}) 1`] = `
@@ -1723,22 +1726,22 @@ Received: <red>\\"Eve\\"</>"
 exports[`.toEqual() {pass: false} expect("abc").not.toEqual("abc") 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.toEqual(</><green>expected</><dim>)</>
 
-Expected: <green>\\"abc\\"</>
-Received: <red>\\"abc\\"</>"
+Received: <red>\\"abc\\"</>
+Expected: <green>any different value</>"
 `;
 
 exports[`.toEqual() {pass: false} expect("abcd").not.toEqual(StringContaining "bc") 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.toEqual(</><green>expected</><dim>)</>
 
-Expected: <green>StringContaining \\"bc\\"</>
-Received: <red>\\"abcd\\"</>"
+Received: <red>\\"abcd\\"</>
+Expected: <green>any different value</>"
 `;
 
 exports[`.toEqual() {pass: false} expect("abcd").not.toEqual(StringMatching /bc/) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.toEqual(</><green>expected</><dim>)</>
 
-Expected: <green>StringMatching /bc/</>
-Received: <red>\\"abcd\\"</>"
+Received: <red>\\"abcd\\"</>
+Expected: <green>any different value</>"
 `;
 
 exports[`.toEqual() {pass: false} expect("abd").toEqual(StringContaining "bc") 1`] = `
@@ -1770,15 +1773,15 @@ Difference:
 exports[`.toEqual() {pass: false} expect([1, 2, 3]).not.toEqual(ArrayContaining [2, 3]) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.toEqual(</><green>expected</><dim>)</>
 
-Expected: <green>ArrayContaining [2, 3]</>
-Received: <red>[1, 2, 3]</>"
+Received: <red>[1, 2, 3]</>
+Expected: <green>any different value</>"
 `;
 
 exports[`.toEqual() {pass: false} expect([1, 2]).not.toEqual([1, 2]) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.toEqual(</><green>expected</><dim>)</>
 
-Expected: <green>[1, 2]</>
-Received: <red>[1, 2]</>"
+Received: <red>[1, 2]</>
+Expected: <green>any different value</>"
 `;
 
 exports[`.toEqual() {pass: false} expect([1, 2]).toEqual([2, 1]) 1`] = `
@@ -1815,8 +1818,8 @@ Difference:
 exports[`.toEqual() {pass: false} expect([1]).not.toEqual([1]) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.toEqual(</><green>expected</><dim>)</>
 
-Expected: <green>[1]</>
-Received: <red>[1]</>"
+Received: <red>[1]</>
+Expected: <green>any different value</>"
 `;
 
 exports[`.toEqual() {pass: false} expect([1]).toEqual([2]) 1`] = `
@@ -1836,22 +1839,22 @@ Difference:
 exports[`.toEqual() {pass: false} expect([Function anonymous]).not.toEqual(Any<Function>) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.toEqual(</><green>expected</><dim>)</>
 
-Expected: <green>Any<Function></>
-Received: <red>[Function anonymous]</>"
+Received: <red>[Function anonymous]</>
+Expected: <green>any different value</>"
 `;
 
 exports[`.toEqual() {pass: false} expect({"a": 1, "b": [Function b], "c": true}).not.toEqual({"a": 1, "b": Any<Function>, "c": Anything}) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.toEqual(</><green>expected</><dim>)</>
 
-Expected: <green>{\\"a\\": 1, \\"b\\": Any<Function>, \\"c\\": Anything}</>
-Received: <red>{\\"a\\": 1, \\"b\\": [Function b], \\"c\\": true}</>"
+Received: <red>{\\"a\\": 1, \\"b\\": [Function b], \\"c\\": true}</>
+Expected: <green>any different value</>"
 `;
 
 exports[`.toEqual() {pass: false} expect({"a": 1, "b": 2}).not.toEqual(ObjectContaining {"a": 1}) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.toEqual(</><green>expected</><dim>)</>
 
-Expected: <green>ObjectContaining {\\"a\\": 1}</>
-Received: <red>{\\"a\\": 1, \\"b\\": 2}</>"
+Received: <red>{\\"a\\": 1, \\"b\\": 2}</>
+Expected: <green>any different value</>"
 `;
 
 exports[`.toEqual() {pass: false} expect({"a": 1, "b": 2}).toEqual(ObjectContaining {"a": 2}) 1`] = `
@@ -1887,8 +1890,8 @@ Difference:
 exports[`.toEqual() {pass: false} expect({"a": 99}).not.toEqual({"a": 99}) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.toEqual(</><green>expected</><dim>)</>
 
-Expected: <green>{\\"a\\": 99}</>
-Received: <red>{\\"a\\": 99}</>"
+Received: <red>{\\"a\\": 99}</>
+Expected: <green>any different value</>"
 `;
 
 exports[`.toEqual() {pass: false} expect({"target": {"nodeType": 1, "value": "a"}}).toEqual({"target": {"nodeType": 1, "value": "b"}}) 1`] = `
@@ -1911,8 +1914,8 @@ Difference:
 exports[`.toEqual() {pass: false} expect({}).not.toEqual({}) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.toEqual(</><green>expected</><dim>)</>
 
-Expected: <green>{}</>
-Received: <red>{}</>"
+Received: <red>{}</>
+Expected: <green>any different value</>"
 `;
 
 exports[`.toEqual() {pass: false} expect(0).toEqual(-0) 1`] = `
@@ -1925,8 +1928,8 @@ Received: <red>0</>"
 exports[`.toEqual() {pass: false} expect(1).not.toEqual(1) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.toEqual(</><green>expected</><dim>)</>
 
-Expected: <green>1</>
-Received: <red>1</>"
+Received: <red>1</>
+Expected: <green>any different value</>"
 `;
 
 exports[`.toEqual() {pass: false} expect(1).toEqual(2) 1`] = `
@@ -1946,8 +1949,8 @@ Received: <red>1</>"
 exports[`.toEqual() {pass: false} expect(Immutable.List [1, 2]).not.toEqual(Immutable.List [1, 2]) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.toEqual(</><green>expected</><dim>)</>
 
-Expected: <green>Immutable.List [1, 2]</>
-Received: <red>Immutable.List [1, 2]</>"
+Received: <red>Immutable.List [1, 2]</>
+Expected: <green>any different value</>"
 `;
 
 exports[`.toEqual() {pass: false} expect(Immutable.List [1, 2]).toEqual(Immutable.List [2, 1]) 1`] = `
@@ -1968,8 +1971,8 @@ Difference:
 exports[`.toEqual() {pass: false} expect(Immutable.List [1]).not.toEqual(Immutable.List [1]) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.toEqual(</><green>expected</><dim>)</>
 
-Expected: <green>Immutable.List [1]</>
-Received: <red>Immutable.List [1]</>"
+Received: <red>Immutable.List [1]</>
+Expected: <green>any different value</>"
 `;
 
 exports[`.toEqual() {pass: false} expect(Immutable.List [1]).toEqual(Immutable.List [2]) 1`] = `
@@ -1989,8 +1992,8 @@ Difference:
 exports[`.toEqual() {pass: false} expect(Immutable.Map {"1": Immutable.Map {"2": {"a": 99}}}).not.toEqual(Immutable.Map {"1": Immutable.Map {"2": {"a": 99}}}) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.toEqual(</><green>expected</><dim>)</>
 
-Expected: <green>Immutable.Map {\\"1\\": Immutable.Map {\\"2\\": {\\"a\\": 99}}}</>
-Received: <red>Immutable.Map {\\"1\\": Immutable.Map {\\"2\\": {\\"a\\": 99}}}</>"
+Received: <red>Immutable.Map {\\"1\\": Immutable.Map {\\"2\\": {\\"a\\": 99}}}</>
+Expected: <green>any different value</>"
 `;
 
 exports[`.toEqual() {pass: false} expect(Immutable.Map {"1": Immutable.Map {"2": {"a": 99}}}).toEqual(Immutable.Map {"1": Immutable.Map {"2": {"a": 11}}}) 1`] = `
@@ -2042,29 +2045,29 @@ Difference:
 exports[`.toEqual() {pass: false} expect(Immutable.Map {}).not.toEqual(Immutable.Map {}) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.toEqual(</><green>expected</><dim>)</>
 
-Expected: <green>Immutable.Map {}</>
-Received: <red>Immutable.Map {}</>"
+Received: <red>Immutable.Map {}</>
+Expected: <green>any different value</>"
 `;
 
 exports[`.toEqual() {pass: false} expect(Immutable.Map {1: "one", 2: "two"}).not.toEqual(Immutable.Map {1: "one", 2: "two"}) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.toEqual(</><green>expected</><dim>)</>
 
-Expected: <green>Immutable.Map {1: \\"one\\", 2: \\"two\\"}</>
-Received: <red>Immutable.Map {1: \\"one\\", 2: \\"two\\"}</>"
+Received: <red>Immutable.Map {1: \\"one\\", 2: \\"two\\"}</>
+Expected: <green>any different value</>"
 `;
 
 exports[`.toEqual() {pass: false} expect(Immutable.Map {1: "one", 2: "two"}).not.toEqual(Immutable.Map {2: "two", 1: "one"}) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.toEqual(</><green>expected</><dim>)</>
 
-Expected: <green>Immutable.Map {2: \\"two\\", 1: \\"one\\"}</>
-Received: <red>Immutable.Map {1: \\"one\\", 2: \\"two\\"}</>"
+Received: <red>Immutable.Map {1: \\"one\\", 2: \\"two\\"}</>
+Expected: <green>any different value</>"
 `;
 
 exports[`.toEqual() {pass: false} expect(Immutable.OrderedMap {1: "one", 2: "two"}).not.toEqual(Immutable.OrderedMap {1: "one", 2: "two"}) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.toEqual(</><green>expected</><dim>)</>
 
-Expected: <green>Immutable.OrderedMap {1: \\"one\\", 2: \\"two\\"}</>
-Received: <red>Immutable.OrderedMap {1: \\"one\\", 2: \\"two\\"}</>"
+Received: <red>Immutable.OrderedMap {1: \\"one\\", 2: \\"two\\"}</>
+Expected: <green>any different value</>"
 `;
 
 exports[`.toEqual() {pass: false} expect(Immutable.OrderedMap {1: "one", 2: "two"}).toEqual(Immutable.OrderedMap {2: "two", 1: "one"}) 1`] = `
@@ -2085,15 +2088,15 @@ Difference:
 exports[`.toEqual() {pass: false} expect(Immutable.OrderedSet []).not.toEqual(Immutable.OrderedSet []) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.toEqual(</><green>expected</><dim>)</>
 
-Expected: <green>Immutable.OrderedSet []</>
-Received: <red>Immutable.OrderedSet []</>"
+Received: <red>Immutable.OrderedSet []</>
+Expected: <green>any different value</>"
 `;
 
 exports[`.toEqual() {pass: false} expect(Immutable.OrderedSet [1, 2]).not.toEqual(Immutable.OrderedSet [1, 2]) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.toEqual(</><green>expected</><dim>)</>
 
-Expected: <green>Immutable.OrderedSet [1, 2]</>
-Received: <red>Immutable.OrderedSet [1, 2]</>"
+Received: <red>Immutable.OrderedSet [1, 2]</>
+Expected: <green>any different value</>"
 `;
 
 exports[`.toEqual() {pass: false} expect(Immutable.OrderedSet [1, 2]).toEqual(Immutable.OrderedSet [2, 1]) 1`] = `
@@ -2114,22 +2117,22 @@ Difference:
 exports[`.toEqual() {pass: false} expect(Immutable.Set []).not.toEqual(Immutable.Set []) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.toEqual(</><green>expected</><dim>)</>
 
-Expected: <green>Immutable.Set []</>
-Received: <red>Immutable.Set []</>"
+Received: <red>Immutable.Set []</>
+Expected: <green>any different value</>"
 `;
 
 exports[`.toEqual() {pass: false} expect(Immutable.Set [1, 2]).not.toEqual(Immutable.Set [1, 2]) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.toEqual(</><green>expected</><dim>)</>
 
-Expected: <green>Immutable.Set [1, 2]</>
-Received: <red>Immutable.Set [1, 2]</>"
+Received: <red>Immutable.Set [1, 2]</>
+Expected: <green>any different value</>"
 `;
 
 exports[`.toEqual() {pass: false} expect(Immutable.Set [1, 2]).not.toEqual(Immutable.Set [2, 1]) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.toEqual(</><green>expected</><dim>)</>
 
-Expected: <green>Immutable.Set [2, 1]</>
-Received: <red>Immutable.Set [1, 2]</>"
+Received: <red>Immutable.Set [1, 2]</>
+Expected: <green>any different value</>"
 `;
 
 exports[`.toEqual() {pass: false} expect(Immutable.Set [1, 2]).toEqual(Immutable.Set []) 1`] = `
@@ -2209,22 +2212,22 @@ Difference:
 exports[`.toEqual() {pass: false} expect(Map {[1] => "one", [2] => "two", [3] => "three", [3] => "four"}).not.toEqual(Map {[3] => "three", [3] => "four", [2] => "two", [1] => "one"}) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.toEqual(</><green>expected</><dim>)</>
 
-Expected: <green>Map {[3] => \\"three\\", [3] => \\"four\\", [2] => \\"two\\", [1] => \\"one\\"}</>
-Received: <red>Map {[1] => \\"one\\", [2] => \\"two\\", [3] => \\"three\\", [3] => \\"four\\"}</>"
+Received: <red>Map {[1] => \\"one\\", [2] => \\"two\\", [3] => \\"three\\", [3] => \\"four\\"}</>
+Expected: <green>any different value</>"
 `;
 
 exports[`.toEqual() {pass: false} expect(Map {[1] => "one", [2] => "two"}).not.toEqual(Map {[2] => "two", [1] => "one"}) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.toEqual(</><green>expected</><dim>)</>
 
-Expected: <green>Map {[2] => \\"two\\", [1] => \\"one\\"}</>
-Received: <red>Map {[1] => \\"one\\", [2] => \\"two\\"}</>"
+Received: <red>Map {[1] => \\"one\\", [2] => \\"two\\"}</>
+Expected: <green>any different value</>"
 `;
 
 exports[`.toEqual() {pass: false} expect(Map {[1] => Map {[1] => "one"}, [2] => Map {[2] => "two"}}).not.toEqual(Map {[2] => Map {[2] => "two"}, [1] => Map {[1] => "one"}}) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.toEqual(</><green>expected</><dim>)</>
 
-Expected: <green>Map {[2] => Map {[2] => \\"two\\"}, [1] => Map {[1] => \\"one\\"}}</>
-Received: <red>Map {[1] => Map {[1] => \\"one\\"}, [2] => Map {[2] => \\"two\\"}}</>"
+Received: <red>Map {[1] => Map {[1] => \\"one\\"}, [2] => Map {[2] => \\"two\\"}}</>
+Expected: <green>any different value</>"
 `;
 
 exports[`.toEqual() {pass: false} expect(Map {[1] => Map {[1] => "one"}}).toEqual(Map {[1] => Map {[1] => "two"}}) 1`] = `
@@ -2250,15 +2253,15 @@ Difference:
 exports[`.toEqual() {pass: false} expect(Map {{"a": 1} => "one", {"b": 2} => "two"}).not.toEqual(Map {{"b": 2} => "two", {"a": 1} => "one"}) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.toEqual(</><green>expected</><dim>)</>
 
-Expected: <green>Map {{\\"b\\": 2} => \\"two\\", {\\"a\\": 1} => \\"one\\"}</>
-Received: <red>Map {{\\"a\\": 1} => \\"one\\", {\\"b\\": 2} => \\"two\\"}</>"
+Received: <red>Map {{\\"a\\": 1} => \\"one\\", {\\"b\\": 2} => \\"two\\"}</>
+Expected: <green>any different value</>"
 `;
 
 exports[`.toEqual() {pass: false} expect(Map {}).not.toEqual(Map {}) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.toEqual(</><green>expected</><dim>)</>
 
-Expected: <green>Map {}</>
-Received: <red>Map {}</>"
+Received: <red>Map {}</>
+Expected: <green>any different value</>"
 `;
 
 exports[`.toEqual() {pass: false} expect(Map {}).toEqual(Set {}) 1`] = `
@@ -2271,15 +2274,15 @@ Received: <red>Map {}</>"
 exports[`.toEqual() {pass: false} expect(Map {1 => "one", 2 => "two"}).not.toEqual(Map {1 => "one", 2 => "two"}) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.toEqual(</><green>expected</><dim>)</>
 
-Expected: <green>Map {1 => \\"one\\", 2 => \\"two\\"}</>
-Received: <red>Map {1 => \\"one\\", 2 => \\"two\\"}</>"
+Received: <red>Map {1 => \\"one\\", 2 => \\"two\\"}</>
+Expected: <green>any different value</>"
 `;
 
 exports[`.toEqual() {pass: false} expect(Map {1 => "one", 2 => "two"}).not.toEqual(Map {2 => "two", 1 => "one"}) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.toEqual(</><green>expected</><dim>)</>
 
-Expected: <green>Map {2 => \\"two\\", 1 => \\"one\\"}</>
-Received: <red>Map {1 => \\"one\\", 2 => \\"two\\"}</>"
+Received: <red>Map {1 => \\"one\\", 2 => \\"two\\"}</>
+Expected: <green>any different value</>"
 `;
 
 exports[`.toEqual() {pass: false} expect(Map {1 => "one", 2 => "two"}).toEqual(Map {1 => "one"}) 1`] = `
@@ -2299,22 +2302,22 @@ Difference:
 exports[`.toEqual() {pass: false} expect(Map {1 => ["one"], 2 => ["two"]}).not.toEqual(Map {2 => ["two"], 1 => ["one"]}) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.toEqual(</><green>expected</><dim>)</>
 
-Expected: <green>Map {2 => [\\"two\\"], 1 => [\\"one\\"]}</>
-Received: <red>Map {1 => [\\"one\\"], 2 => [\\"two\\"]}</>"
+Received: <red>Map {1 => [\\"one\\"], 2 => [\\"two\\"]}</>
+Expected: <green>any different value</>"
 `;
 
 exports[`.toEqual() {pass: false} expect(Set {[1], [2], [3], [3]}).not.toEqual(Set {[3], [3], [2], [1]}) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.toEqual(</><green>expected</><dim>)</>
 
-Expected: <green>Set {[3], [3], [2], [1]}</>
-Received: <red>Set {[1], [2], [3], [3]}</>"
+Received: <red>Set {[1], [2], [3], [3]}</>
+Expected: <green>any different value</>"
 `;
 
 exports[`.toEqual() {pass: false} expect(Set {[1], [2]}).not.toEqual(Set {[2], [1]}) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.toEqual(</><green>expected</><dim>)</>
 
-Expected: <green>Set {[2], [1]}</>
-Received: <red>Set {[1], [2]}</>"
+Received: <red>Set {[1], [2]}</>
+Expected: <green>any different value</>"
 `;
 
 exports[`.toEqual() {pass: false} expect(Set {[1], [2]}).toEqual(Set {[1], [2], [2]}) 1`] = `
@@ -2360,29 +2363,29 @@ Difference:
 exports[`.toEqual() {pass: false} expect(Set {{"a": 1}, {"b": 2}}).not.toEqual(Set {{"b": 2}, {"a": 1}}) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.toEqual(</><green>expected</><dim>)</>
 
-Expected: <green>Set {{\\"b\\": 2}, {\\"a\\": 1}}</>
-Received: <red>Set {{\\"a\\": 1}, {\\"b\\": 2}}</>"
+Received: <red>Set {{\\"a\\": 1}, {\\"b\\": 2}}</>
+Expected: <green>any different value</>"
 `;
 
 exports[`.toEqual() {pass: false} expect(Set {}).not.toEqual(Set {}) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.toEqual(</><green>expected</><dim>)</>
 
-Expected: <green>Set {}</>
-Received: <red>Set {}</>"
+Received: <red>Set {}</>
+Expected: <green>any different value</>"
 `;
 
 exports[`.toEqual() {pass: false} expect(Set {1, 2}).not.toEqual(Set {1, 2}) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.toEqual(</><green>expected</><dim>)</>
 
-Expected: <green>Set {1, 2}</>
-Received: <red>Set {1, 2}</>"
+Received: <red>Set {1, 2}</>
+Expected: <green>any different value</>"
 `;
 
 exports[`.toEqual() {pass: false} expect(Set {1, 2}).not.toEqual(Set {2, 1}) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.toEqual(</><green>expected</><dim>)</>
 
-Expected: <green>Set {2, 1}</>
-Received: <red>Set {1, 2}</>"
+Received: <red>Set {1, 2}</>
+Expected: <green>any different value</>"
 `;
 
 exports[`.toEqual() {pass: false} expect(Set {1, 2}).toEqual(Set {}) 1`] = `
@@ -2418,8 +2421,8 @@ Difference:
 exports[`.toEqual() {pass: false} expect(Set {Set {[1]}, Set {[2]}}).not.toEqual(Set {Set {[2]}, Set {[1]}}) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.toEqual(</><green>expected</><dim>)</>
 
-Expected: <green>Set {Set {[2]}, Set {[1]}}</>
-Received: <red>Set {Set {[1]}, Set {[2]}}</>"
+Received: <red>Set {Set {[1]}, Set {[2]}}</>
+Expected: <green>any different value</>"
 `;
 
 exports[`.toEqual() {pass: false} expect(Set {Set {1}, Set {2}}).toEqual(Set {Set {1}, Set {3}}) 1`] = `
@@ -2458,15 +2461,15 @@ Received: <red>null</>"
 exports[`.toEqual() {pass: false} expect(true).not.toEqual(Anything) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.toEqual(</><green>expected</><dim>)</>
 
-Expected: <green>Anything</>
-Received: <red>true</>"
+Received: <red>true</>
+Expected: <green>any different value</>"
 `;
 
 exports[`.toEqual() {pass: false} expect(true).not.toEqual(true) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.toEqual(</><green>expected</><dim>)</>
 
-Expected: <green>true</>
-Received: <red>true</>"
+Received: <red>true</>
+Expected: <green>any different value</>"
 `;
 
 exports[`.toEqual() {pass: false} expect(true).toEqual(false) 1`] = `
@@ -2507,8 +2510,8 @@ Difference:
 exports[`.toEqual() failure message matches the expected snapshot 2`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.toEqual(</><green>expected</><dim>)</>
 
-Expected: <green>{\\"a\\": 1}</>
-Received: <red>{\\"a\\": 1}</>"
+Received: <red>{\\"a\\": 1}</>
+Expected: <green>any different value</>"
 `;
 
 exports[`.toHaveLength {pass: false} expect("").toHaveLength(1) 1`] = `
@@ -2554,41 +2557,41 @@ Received array:  <red>[1, 2]</>"
 exports[`.toHaveLength {pass: true} expect("").toHaveLength(0) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.toHaveLength(</><green>length</><dim>)</>
 
-Expected length: <green>0</>
+Received string: <red>\\"\\"</>
 Received length: <red>0</>
-Received string: <red>\\"\\"</>"
+Expected:        <green>length !== 0</>"
 `;
 
 exports[`.toHaveLength {pass: true} expect("abc").toHaveLength(3) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.toHaveLength(</><green>length</><dim>)</>
 
-Expected length: <green>3</>
+Received string: <red>\\"abc\\"</>
 Received length: <red>3</>
-Received string: <red>\\"abc\\"</>"
+Expected:        <green>length !== 3</>"
 `;
 
 exports[`.toHaveLength {pass: true} expect(["a", "b"]).toHaveLength(2) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.toHaveLength(</><green>length</><dim>)</>
 
-Expected length: <green>2</>
+Received array:  <red>[\\"a\\", \\"b\\"]</>
 Received length: <red>2</>
-Received array:  <red>[\\"a\\", \\"b\\"]</>"
+Expected:        <green>length !== 2</>"
 `;
 
 exports[`.toHaveLength {pass: true} expect([]).toHaveLength(0) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.toHaveLength(</><green>length</><dim>)</>
 
-Expected length: <green>0</>
+Received array:  <red>[]</>
 Received length: <red>0</>
-Received array:  <red>[]</>"
+Expected:        <green>length !== 0</>"
 `;
 
 exports[`.toHaveLength {pass: true} expect([1, 2]).toHaveLength(2) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.toHaveLength(</><green>length</><dim>)</>
 
-Expected length: <green>2</>
+Received array:  <red>[1, 2]</>
 Received length: <red>2</>
-Received array:  <red>[1, 2]</>"
+Expected:        <green>length !== 2</>"
 `;
 
 exports[`.toHaveLength error cases 1`] = `
@@ -3270,8 +3273,8 @@ Difference:
 exports[`.toStrictEqual() matches the expected snapshot when it fails 2`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.toStrictEqual(</><green>expected</><dim>)</>
 
-Expected: <green>{\\"test\\": {\\"a\\": 1, \\"b\\": 2}}</>
-Received: <red>{\\"test\\": {\\"a\\": 1, \\"b\\": 2}}</>"
+Received: <red>{\\"test\\": {\\"a\\": 1, \\"b\\": 2}}</>
+Expected: <green>any different value</>"
 `;
 
 exports[`toMatchObject() {pass: false} expect([0]).toMatchObject([-0]) 1`] = `

--- a/packages/expect/src/__tests__/__snapshots__/toThrowMatchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/toThrowMatchers.test.js.snap
@@ -117,8 +117,8 @@ Received value: <red>undefined</>
 exports[`.toThrow() error class threw, but class should not match (error) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrow<dim>(</><green>expected</><dim>)</>
 
-Expected name: <green>\\"Err\\"</>
 Received name: <red>\\"Error\\"</>
+Expected: <green>any other name</>
 
 Received message: <red>\\"apple\\"</>
 
@@ -136,8 +136,8 @@ Received message: <red>\\"banana\\"</>
 exports[`.toThrow() error-message fail isNot true 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrow<dim>(</><green>expected</><dim>)</>
 
-Expected message: <green>\\"apple\\"</>
 Received message: <red>\\"apple\\"</>
+Expected: <green>any other message</>
 "
 `;
 
@@ -262,8 +262,8 @@ Received value:     <red>\\"\\"</>
 exports[`.toThrow() strings threw, but message should not match (error) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrow<dim>(</><green>expected</><dim>)</>
 
-Expected substring: <green>\\"apple\\"</>
-Received message:   <red>\\"apple\\"</>
+Expected no substring: <green>\\"apple\\"</>
+Received message:      <red>\\"apple\\"</>
 
       <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
 `;
@@ -271,8 +271,8 @@ Received message:   <red>\\"apple\\"</>
 exports[`.toThrow() strings threw, but message should not match (non-error truthy) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrow<dim>(</><green>expected</><dim>)</>
 
-Expected substring: <green>\\"Server Error\\"</>
-Received value:     <red>\\"Internal Server Error\\"</>
+Expected no substring: <green>\\"Server Error\\"</>
+Received value:        <red>\\"Internal Server Error\\"</>
 "
 `;
 
@@ -393,8 +393,8 @@ Received value: <red>undefined</>
 exports[`.toThrowError() error class threw, but class should not match (error) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrowError<dim>(</><green>expected</><dim>)</>
 
-Expected name: <green>\\"Err\\"</>
 Received name: <red>\\"Error\\"</>
+Expected: <green>any other name</>
 
 Received message: <red>\\"apple\\"</>
 
@@ -412,8 +412,8 @@ Received message: <red>\\"banana\\"</>
 exports[`.toThrowError() error-message fail isNot true 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrowError<dim>(</><green>expected</><dim>)</>
 
-Expected message: <green>\\"apple\\"</>
 Received message: <red>\\"apple\\"</>
+Expected: <green>any other message</>
 "
 `;
 
@@ -538,8 +538,8 @@ Received value:     <red>\\"\\"</>
 exports[`.toThrowError() strings threw, but message should not match (error) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrowError<dim>(</><green>expected</><dim>)</>
 
-Expected substring: <green>\\"apple\\"</>
-Received message:   <red>\\"apple\\"</>
+Expected no substring: <green>\\"apple\\"</>
+Received message:      <red>\\"apple\\"</>
 
       <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
 `;
@@ -547,7 +547,7 @@ Received message:   <red>\\"apple\\"</>
 exports[`.toThrowError() strings threw, but message should not match (non-error truthy) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrowError<dim>(</><green>expected</><dim>)</>
 
-Expected substring: <green>\\"Server Error\\"</>
-Received value:     <red>\\"Internal Server Error\\"</>
+Expected no substring: <green>\\"Server Error\\"</>
+Received value:        <red>\\"Internal Server Error\\"</>
 "
 `;

--- a/packages/expect/src/matchers.js
+++ b/packages/expect/src/matchers.js
@@ -56,8 +56,8 @@ const matchers: MatchersObject = {
             isNot: true,
           }) +
           '\n\n' +
-          `Expected: ${printExpected(expected)}\n` +
-          `Received: ${printReceived(received)}`
+          `Received: ${printReceived(received)}\n` +
+          `Expected: ${EXPECTED_COLOR('any other value')}`
       : () => {
           const receivedType = getType(received);
           const expectedType = getType(expected);
@@ -189,16 +189,19 @@ const matchers: MatchersObject = {
     const message = pass
       ? () =>
           matcherHint('.toBeInstanceOf', 'value', 'constructor', {
-            isNot: this.isNot,
+            isNot: true,
           }) +
           '\n\n' +
-          `Expected constructor: ${EXPECTED_COLOR(
-            constructor.name || String(constructor),
+          `Received value: ${printReceived(received)}\n` +
+          `Received constructor: ${RECEIVED_COLOR(
+            received != null
+              ? received.constructor && received.constructor.name
+              : '',
           )}\n` +
-          `Received value: ${printReceived(received)}`
+          `Expected: ${EXPECTED_COLOR('any other constructor')}`
       : () =>
           matcherHint('.toBeInstanceOf', 'value', 'constructor', {
-            isNot: this.isNot,
+            isNot: false,
           }) +
           '\n\n' +
           `Expected constructor: ${EXPECTED_COLOR(
@@ -414,17 +417,17 @@ const matchers: MatchersObject = {
     const message = pass
       ? () =>
           matcherHint('.toEqual', undefined, undefined, {
-            isNot: this.isNot,
+            isNot: true,
           }) +
           '\n\n' +
-          `Expected: ${printExpected(expected)}\n` +
-          `Received: ${printReceived(received)}`
+          `Received: ${printReceived(received)}\n` +
+          `Expected: ${EXPECTED_COLOR('any different value')}`
       : () => {
           const diffString = diff(expected, received, {expand: this.expand});
 
           return (
             matcherHint('.toEqual', undefined, undefined, {
-              isNot: this.isNot,
+              isNot: false,
             }) +
             '\n\n' +
             (diffString && diffString.includes('- Expect')
@@ -470,28 +473,41 @@ const matchers: MatchersObject = {
       );
     }
 
-    const pass = received.length === length;
+    const receivedLength = received.length;
+    const pass = receivedLength === length;
     const message = () => {
-      const stringExpected = 'Expected length';
+      const stringExpected = 'Expected';
+      const stringExpectedLength = 'Expected length';
       const stringReceivedLength = 'Received length';
       const stringReceivedValue = `Received ${getType(received)}`;
       const printLabel = getLabelPrinter(
         stringExpected,
+        stringExpectedLength,
         stringReceivedLength,
         stringReceivedValue,
       );
 
-      return (
-        matcherHint('.toHaveLength', 'received', 'length', {
-          isNot: this.isNot,
-        }) +
-        '\n\n' +
-        `${printLabel(stringExpected)}${printExpected(length)}\n` +
-        `${printLabel(stringReceivedLength)}${printReceived(
-          received.length,
-        )}\n` +
-        `${printLabel(stringReceivedValue)}${printReceived(received)}`
-      );
+      return pass
+        ? matcherHint('.toHaveLength', 'received', 'length', {
+            isNot: true,
+          }) +
+            '\n\n' +
+            `${printLabel(stringReceivedValue)}${printReceived(received)}\n` +
+            `${printLabel(stringReceivedLength)}${printReceived(
+              receivedLength,
+            )}\n` +
+            `${printLabel(stringExpected)}${EXPECTED_COLOR(
+              'length !== ' + receivedLength,
+            )}`
+        : matcherHint('.toHaveLength', 'received', 'length', {
+            isNot: false,
+          }) +
+            '\n\n' +
+            `${printLabel(stringExpectedLength)}${printExpected(length)}\n` +
+            `${printLabel(stringReceivedLength)}${printReceived(
+              receivedLength,
+            )}\n` +
+            `${printLabel(stringReceivedValue)}${printReceived(received)}`;
     };
 
     return {message, pass};
@@ -707,8 +723,8 @@ const matchers: MatchersObject = {
       ? () =>
           hint +
           '\n\n' +
-          `Expected: ${printExpected(expected)}\n` +
-          `Received: ${printReceived(received)}`
+          `Received: ${printReceived(received)}\n` +
+          `Expected: ${EXPECTED_COLOR('any different value')}`
       : () => {
           const diffString = diff(expected, received, {
             expand: this.expand,

--- a/packages/expect/src/toThrowMatchers.js
+++ b/packages/expect/src/toThrowMatchers.js
@@ -205,11 +205,12 @@ const toThrowExpectedObject = (
     ? () =>
         matcherHint(matcherName, undefined, undefined, options) +
         '\n\n' +
-        formatExpected('Expected message: ', expected.message) +
         (thrown !== null && thrown.hasMessage
           ? formatReceived('Received message: ', thrown, 'message') +
+            `Expected: ${EXPECTED_COLOR('any other message')}\n` +
             formatStack(thrown)
-          : formatReceived('Received value:   ', thrown, 'value'))
+          : formatExpected('Expected message: ', expected.message) +
+            formatReceived('Received value:   ', thrown, 'value'))
     : () =>
         matcherHint(matcherName, undefined, undefined, options) +
         '\n\n' +
@@ -236,8 +237,8 @@ const toThrowExpectedClass = (
     ? () =>
         matcherHint(matcherName, undefined, undefined, options) +
         '\n\n' +
-        formatExpected('Expected name: ', expected.name) +
         formatReceived('Received name: ', thrown, 'name') +
+        `Expected: ${EXPECTED_COLOR('any other name')}\n` +
         '\n' +
         (thrown !== null && thrown.hasMessage
           ? formatReceived('Received message: ', thrown, 'message') +
@@ -271,11 +272,11 @@ const toThrowExpectedString = (
     ? () =>
         matcherHint(matcherName, undefined, undefined, options) +
         '\n\n' +
-        formatExpected('Expected substring: ', expected) +
+        formatExpected('Expected no substring: ', expected) +
         (thrown !== null && thrown.hasMessage
-          ? formatReceived('Received message:   ', thrown, 'message') +
+          ? formatReceived('Received message:      ', thrown, 'message') +
             formatStack(thrown)
-          : formatReceived('Received value:     ', thrown, 'value'))
+          : formatReceived('Received value:        ', thrown, 'value'))
     : () =>
         matcherHint(matcherName, undefined, undefined, options) +
         '\n\n' +


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Currently, errors generated using matchers with `.not` mostly only show the fact that `not` is being used in the `expect(received).not.toEqual(expected)` pseudocode. This leads to (IMO) confusing errors like:
```
Expected: 42
Received: 42
```
My idea is to replace the `Expected: 42` with what the matcher really expects in this case: Anything other than 42.
Expected and Received are swapped so that "anything else" comes after "42"

![screenshot_2019-02-03_23-19-13](https://user-images.githubusercontent.com/16069751/52183864-8f46a100-280c-11e9-9dee-8051e105af03.png)
![screenshot_2019-02-03_23-19-35](https://user-images.githubusercontent.com/16069751/52183867-95d51880-280c-11e9-80e4-16bb2482598d.png)
![screenshot_2019-02-03_23-19-56](https://user-images.githubusercontent.com/16069751/52183868-979edc00-280c-11e9-8311-fb6211ec81df.png)
![screenshot_2019-02-03_23-20-10](https://user-images.githubusercontent.com/16069751/52183871-99689f80-280c-11e9-9b2b-a8487570c7fc.png)
![screenshot_2019-02-03_23-21-15](https://user-images.githubusercontent.com/16069751/52183875-9a99cc80-280c-11e9-879c-a226791dee6f.png)
![screenshot_2019-02-03_23-21-27](https://user-images.githubusercontent.com/16069751/52183877-9bcaf980-280c-11e9-923b-40308af8c492.png)
![screenshot_2019-02-03_23-22-02](https://user-images.githubusercontent.com/16069751/52183878-9c639000-280c-11e9-8b90-21f3be15d561.png)
![screenshot_2019-02-03_23-22-29](https://user-images.githubusercontent.com/16069751/52183879-9d94bd00-280c-11e9-8219-fceba5c7792e.png)

The concrete phrasing may be subject to debate ofc, not sure about the "length" and "thrown substring" ones.
Would love to hear what @pedrottimark in particular thinks about this way of handling `.not` matchers.

Note: There are matchers that can cause Expected and Received to be the same without using `.not`, e.g. `toBeGreaterThan`. I also find errors from those somewhat weird, but did not touch them for this PR.

## Test plan

Updated snapshots
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
