### PR TITLE
fix: make babel-jest warn when file to tarnsform is ignored by babel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - `[jest-cli]` Load transformers before installing require hooks ([#7752](https://github.com/facebook/jest/pull/7752)
 - `[jest-cli]` Handle missing `numTodoTests` in test results ([#7779](https://github.com/facebook/jest/pull/7779))
 - `[jest-runtime]` Exclude setup/teardown files from coverage report ([#7790](https://github.com/facebook/jest/pull/7790)
+- `[babel-jest]` Throw an error if `babel-jest` tries to transform a file ignored by Babel 
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 - `[jest-cli]` Load transformers before installing require hooks ([#7752](https://github.com/facebook/jest/pull/7752)
 - `[jest-cli]` Handle missing `numTodoTests` in test results ([#7779](https://github.com/facebook/jest/pull/7779))
 - `[jest-runtime]` Exclude setup/teardown files from coverage report ([#7790](https://github.com/facebook/jest/pull/7790)
-- `[babel-jest]` Throw an error if `babel-jest` tries to transform a file ignored by Babel 
+- `[babel-jest]` Throw an error if `babel-jest` tries to transform a file ignored by Babel ([#7797](https://github.com/facebook/jest/pull/7797))
 
 ### Chore & Maintenance
 

--- a/e2e/__tests__/__snapshots__/transform.test.js.snap
+++ b/e2e/__tests__/__snapshots__/transform.test.js.snap
@@ -4,7 +4,7 @@ exports[`babel-jest ignored tells user to match ignored files 1`] = `
 FAIL __tests__/ignoredFile.test.js
   ● Test suite failed to run
 
-    Babel-Jest: Babel ignores __tests__/ignoredFile.test.js - make sure to include the file in Jest's transformIgnorePatterns as well.
+    babel-jest: Babel ignores __tests__/ignoredFile.test.js - make sure to include the file in Jest's transformIgnorePatterns as well.
 
       at loadBabelConfig (../../../packages/babel-jest/build/index.js:124:13)
 `;

--- a/e2e/__tests__/__snapshots__/transform.test.js.snap
+++ b/e2e/__tests__/__snapshots__/transform.test.js.snap
@@ -1,5 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`babel-jest ignored tells user to match ignored files 1`] = `
+FAIL __tests__/ignoredFile.test.js
+  ● Test suite failed to run
+
+    Babel-Jest: Babel ignores __tests__/ignoredFile.test.js - make sure to include the file in Jest's transformIgnorePatterns as well.
+
+      at loadBabelConfig (../../../packages/babel-jest/build/index.js:124:13)
+`;
+
 exports[`babel-jest instruments only specific files and collects coverage 1`] = `
 ------------|----------|----------|----------|----------|-------------------|
 File        |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |

--- a/e2e/__tests__/__snapshots__/transform.test.js.snap
+++ b/e2e/__tests__/__snapshots__/transform.test.js.snap
@@ -6,7 +6,7 @@ FAIL __tests__/ignoredFile.test.js
 
     babel-jest: Babel ignores __tests__/ignoredFile.test.js - make sure to include the file in Jest's transformIgnorePatterns as well.
 
-      at loadBabelConfig (../../../packages/babel-jest/build/index.js:124:13)
+      at loadBabelConfig (../../../packages/babel-jest/build/index.js:134:13)
 `;
 
 exports[`babel-jest instruments only specific files and collects coverage 1`] = `

--- a/e2e/__tests__/transform.test.js
+++ b/e2e/__tests__/transform.test.js
@@ -11,7 +11,7 @@ import path from 'path';
 import {
   cleanup,
   copyDir,
-  createEmptyPackage,
+  createEmptyPackage, extractSummary,
   linkJestPackage,
   run,
 } from '../Utils';
@@ -42,6 +42,17 @@ describe('babel-jest', () => {
     expect(stdout).not.toMatch('excludedFromCoverage.js');
     // coverage result should not change
     expect(wrap(stdout)).toMatchSnapshot();
+  });
+});
+
+describe('babel-jest ignored', () => {
+  const dir = path.resolve(__dirname, '..', 'transform/babel-jest-ignored');
+
+  it('tells user to match ignored files', () => {
+    // --no-cache because babel can cache stuff and result in false green
+    const {status, stderr} = runJest(dir, ['--no-cache']);
+    expect(status).toBe(1);
+    expect(wrap(extractSummary(stderr).rest)).toMatchSnapshot();
   });
 });
 

--- a/e2e/__tests__/transform.test.js
+++ b/e2e/__tests__/transform.test.js
@@ -11,7 +11,8 @@ import path from 'path';
 import {
   cleanup,
   copyDir,
-  createEmptyPackage, extractSummary,
+  createEmptyPackage,
+  extractSummary,
   linkJestPackage,
   run,
 } from '../Utils';

--- a/e2e/transform/babel-jest-ignored/__tests__/ignoredFile.test.js
+++ b/e2e/transform/babel-jest-ignored/__tests__/ignoredFile.test.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+it('should not run since the file is ignored by babel config', () => {
+  expect(true).toBe(true);
+});

--- a/e2e/transform/babel-jest-ignored/babel.config.js
+++ b/e2e/transform/babel-jest-ignored/babel.config.js
@@ -1,0 +1,3 @@
+// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+
+module.exports = {only: ['blablabla']};

--- a/e2e/transform/babel-jest-ignored/package.json
+++ b/e2e/transform/babel-jest-ignored/package.json
@@ -1,0 +1,5 @@
+{
+  "jest": {
+    "testEnvironment": "node"
+  }
+}

--- a/packages/babel-jest/package.json
+++ b/packages/babel-jest/package.json
@@ -11,7 +11,8 @@
   "main": "build/index.js",
   "dependencies": {
     "babel-plugin-istanbul": "^5.1.0",
-    "babel-preset-jest": "^24.0.0"
+    "babel-preset-jest": "^24.0.0",
+    "chalk": "^2.4.2"
   },
   "devDependencies": {
     "@babel/core": "^7.1.0"

--- a/packages/babel-jest/package.json
+++ b/packages/babel-jest/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "babel-plugin-istanbul": "^5.1.0",
     "babel-preset-jest": "^24.0.0",
-    "chalk": "^2.4.2"
+    "chalk": "^2.4.2",
+    "slash": "^2.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.1.0"

--- a/packages/babel-jest/src/index.js
+++ b/packages/babel-jest/src/index.js
@@ -47,7 +47,7 @@ const createTransformer = (options: any): Transformer => {
 
     if (!babelConfig) {
       throw new Error(
-        `Babel-Jest: Babel ignores ${chalk.bold(
+        `babel-jest: Babel ignores ${chalk.bold(
           path.relative(cwd, filename),
         )} - make sure to include the file in Jest's ${chalk.bold(
           'transformIgnorePatterns',

--- a/packages/babel-jest/src/index.js
+++ b/packages/babel-jest/src/index.js
@@ -19,6 +19,7 @@ import crypto from 'crypto';
 import fs from 'fs';
 import path from 'path';
 import {transformSync as babelTransform, loadPartialConfig} from '@babel/core';
+import chalk from 'chalk';
 
 const THIS_FILE = fs.readFileSync(__filename);
 const jestPresetPath = require.resolve('babel-preset-jest');
@@ -40,9 +41,22 @@ const createTransformer = (options: any): Transformer => {
   delete options.cacheDirectory;
   delete options.filename;
 
-  const loadBabelConfig = (cwd, filename) =>
+  function loadBabelConfig(cwd, filename) {
     // `cwd` first to allow incoming options to override it
-    loadPartialConfig({cwd, ...options, filename});
+    const babelConfig = loadPartialConfig({cwd, ...options, filename});
+
+    if (!babelConfig) {
+      throw new Error(
+        `Babel-Jest: Babel ignores ${chalk.bold(
+          path.relative(cwd, filename),
+        )} - make sure to include the file in Jest's ${chalk.bold(
+          'transformIgnorePatterns',
+        )} as well.`,
+      );
+    }
+
+    return babelConfig;
+  }
 
   return {
     canInstrument: true,

--- a/packages/babel-jest/src/index.js
+++ b/packages/babel-jest/src/index.js
@@ -20,6 +20,7 @@ import fs from 'fs';
 import path from 'path';
 import {transformSync as babelTransform, loadPartialConfig} from '@babel/core';
 import chalk from 'chalk';
+import slash from 'slash';
 
 const THIS_FILE = fs.readFileSync(__filename);
 const jestPresetPath = require.resolve('babel-preset-jest');
@@ -48,7 +49,7 @@ const createTransformer = (options: any): Transformer => {
     if (!babelConfig) {
       throw new Error(
         `babel-jest: Babel ignores ${chalk.bold(
-          path.relative(cwd, filename),
+          slash(path.relative(cwd, filename)),
         )} - make sure to include the file in Jest's ${chalk.bold(
           'transformIgnorePatterns',
         )} as well.`,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

If we don't wanna throw, we should just coerce the return value from `loadPartialConfig` to an empty config I guess.

Not sure what the impact on coverage is.

![image](https://user-images.githubusercontent.com/1404810/52213726-33256080-2890-11e9-89f7-72e927664edb.png)

Fixes #7765.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

E2E test added

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
