### PR TITLE
Normalize config and remove unecessary checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - `[jest-changed-files]` Improve default file selection for Mercurial repos ([#7880](https://github.com/facebook/jest/pull/7880))
 - `[jest-validate]` Fix validating async functions ([#7894](https://github.com/facebook/jest/issues/7894))
 - `[jest-circus]` Fix bug with test.only ([#7888](https://github.com/facebook/jest/pull/7888))
-- `[jest-transform]` Normalize config and remove unecessary checks ([#7801](https://github.com/facebook/jest/pull/7801)
+- `[jest-transform]` Normalize config and remove unecessary checks, convert `TestUtils.js` to TypeScript ([#7801](https://github.com/facebook/jest/pull/7801)
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - `[jest-changed-files]` Improve default file selection for Mercurial repos ([#7880](https://github.com/facebook/jest/pull/7880))
 - `[jest-validate]` Fix validating async functions ([#7894](https://github.com/facebook/jest/issues/7894))
 - `[jest-circus]` Fix bug with test.only ([#7888](https://github.com/facebook/jest/pull/7888))
+- `[jest-transform]` Normalize config and remove unecessary checks ([#7801](https://github.com/facebook/jest/pull/7801)
 
 ### Chore & Maintenance
 

--- a/TestUtils.js
+++ b/TestUtils.js
@@ -149,5 +149,5 @@ export const makeProjectConfig = (overrides: Object = {}): ProjectConfig => {
     `);
   }
 
-  return {...DEFAULT_GLOBAL_CONFIG, ...overrides};
+  return {...DEFAULT_PROJECT_CONFIG, ...overrides};
 };

--- a/TestUtils.ts
+++ b/TestUtils.ts
@@ -3,15 +3,12 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- * @flow
  */
 
-'use strict';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import {Config} from '@jest/types';
 
-import type {GlobalConfig, ProjectConfig} from 'types/Config';
-
-const DEFAULT_GLOBAL_CONFIG: GlobalConfig = {
+const DEFAULT_GLOBAL_CONFIG: Config.GlobalConfig = {
   bail: 0,
   changedFilesWithAncestor: false,
   changedSince: '',
@@ -67,7 +64,7 @@ const DEFAULT_GLOBAL_CONFIG: GlobalConfig = {
   watchman: false,
 };
 
-const DEFAULT_PROJECT_CONFIG: ProjectConfig = {
+const DEFAULT_PROJECT_CONFIG: Config.ProjectConfig = {
   automock: false,
   browser: false,
   cache: false,
@@ -124,7 +121,9 @@ const DEFAULT_PROJECT_CONFIG: ProjectConfig = {
   watchPathIgnorePatterns: [],
 };
 
-export const makeGlobalConfig = (overrides: Object = {}): GlobalConfig => {
+export const makeGlobalConfig = (
+  overrides: Partial<Config.GlobalConfig> = {},
+): Config.GlobalConfig => {
   const overridesKeys = new Set(Object.keys(overrides));
   Object.keys(DEFAULT_GLOBAL_CONFIG).forEach(key => overridesKeys.delete(key));
 
@@ -138,7 +137,9 @@ export const makeGlobalConfig = (overrides: Object = {}): GlobalConfig => {
   return {...DEFAULT_GLOBAL_CONFIG, ...overrides};
 };
 
-export const makeProjectConfig = (overrides: Object = {}): ProjectConfig => {
+export const makeProjectConfig = (
+  overrides: Partial<Config.ProjectConfig> = {},
+): Config.ProjectConfig => {
   const overridesKeys = new Set(Object.keys(overrides));
   Object.keys(DEFAULT_PROJECT_CONFIG).forEach(key => overridesKeys.delete(key));
 

--- a/packages/jest-core/src/lib/__tests__/is_valid_path.test.js
+++ b/packages/jest-core/src/lib/__tests__/is_valid_path.test.js
@@ -9,6 +9,7 @@
 
 import isValidPath from '../is_valid_path';
 import path from 'path';
+//$FlowFixMe: Converted to TS
 import {makeGlobalConfig} from '../../../../../TestUtils';
 
 const rootDir = path.resolve(path.sep, 'root');

--- a/packages/jest-reporters/src/__tests__/generateEmptyCoverage.test.js
+++ b/packages/jest-reporters/src/__tests__/generateEmptyCoverage.test.js
@@ -13,6 +13,7 @@ import generateEmptyCoverage from '../generateEmptyCoverage';
 
 import path from 'path';
 import os from 'os';
+//$FlowFixMe: Converted to TS
 import {makeGlobalConfig, makeProjectConfig} from '../../../../TestUtils';
 
 jest.mock('@jest/transform', () => ({

--- a/packages/jest-runtime/src/__tests__/instrumentation.test.js
+++ b/packages/jest-runtime/src/__tests__/instrumentation.test.js
@@ -12,6 +12,7 @@ import vm from 'vm';
 import path from 'path';
 import os from 'os';
 import {ScriptTransformer} from '@jest/transform';
+import {makeProjectConfig} from '../../../../TestUtils';
 
 jest.mock('vm');
 
@@ -21,11 +22,11 @@ const FILE_PATH_TO_INSTRUMENT = path.resolve(
 );
 
 it('instruments files', () => {
-  const config = {
+  const config = makeProjectConfig({
     cache: false,
     cacheDirectory: os.tmpdir(),
     rootDir: '/',
-  };
+  });
   const instrumented = new ScriptTransformer(config).transform(
     FILE_PATH_TO_INSTRUMENT,
     {collectCoverage: true},

--- a/packages/jest-transform/src/__tests__/__snapshots__/script_transformer.test.js.snap
+++ b/packages/jest-transform/src/__tests__/__snapshots__/script_transformer.test.js.snap
@@ -3,10 +3,60 @@
 exports[`ScriptTransformer passes expected transform options to getCacheKey 1`] = `
 Object {
   "config": Object {
+    "automock": false,
+    "browser": false,
     "cache": true,
     "cacheDirectory": "/cache/",
+    "clearMocks": false,
+    "coveragePathIgnorePatterns": Array [],
+    "cwd": "/test_root_dir/",
+    "detectLeaks": false,
+    "detectOpenHandles": false,
+    "displayName": undefined,
+    "errorOnDeprecated": false,
+    "extraGlobals": Array [],
+    "filter": null,
+    "forceCoverageMatch": Array [],
+    "globalSetup": null,
+    "globalTeardown": null,
+    "globals": Object {},
+    "haste": Object {
+      "providesModuleNodeModules": Array [],
+    },
+    "moduleDirectories": Array [],
+    "moduleFileExtensions": Array [
+      "js",
+    ],
+    "moduleLoader": "/test_module_loader_path",
+    "moduleNameMapper": Array [],
+    "modulePathIgnorePatterns": Array [],
+    "modulePaths": Array [],
     "name": "test",
+    "prettierPath": "prettier",
+    "resetMocks": false,
+    "resetModules": false,
+    "resolver": null,
+    "restoreMocks": false,
     "rootDir": "/",
+    "roots": Array [],
+    "runner": "jest-runner",
+    "setupFiles": Array [],
+    "setupFilesAfterEnv": Array [],
+    "skipFilter": false,
+    "skipNodeResolution": false,
+    "snapshotResolver": null,
+    "snapshotSerializers": Array [],
+    "testEnvironment": "node",
+    "testEnvironmentOptions": Object {},
+    "testLocationInResults": false,
+    "testMatch": Array [],
+    "testPathIgnorePatterns": Array [],
+    "testRegex": Array [
+      "\\\\.test\\\\.js$",
+    ],
+    "testRunner": "jest-jasmine2",
+    "testURL": "",
+    "timers": "real",
     "transform": Array [
       Array [
         "^.+\\\\.js$",
@@ -16,6 +66,8 @@ Object {
     "transformIgnorePatterns": Array [
       "/node_modules/",
     ],
+    "unmockedModulePathPatterns": null,
+    "watchPathIgnorePatterns": Array [],
   },
   "instrument": true,
   "rootDir": "/",
@@ -172,7 +224,7 @@ exports[`ScriptTransformer uses multiple preprocessors 1`] = `
           const TRANSFORMED = {
             filename: '/fruits/banana.js',
             script: 'module.exports = \\"banana\\";',
-            config: '{\\"cache\\":true,\\"cacheDirectory\\":\\"/cache/\\",\\"name\\":\\"test\\",\\"rootDir\\":\\"/\\",\\"transformIgnorePatterns\\":[\\"/node_modules/\\"],\\"transform\\":[[\\"^.+\\\\\\\\.js$\\",\\"test_preprocessor\\"],[\\"^.+\\\\\\\\.css$\\",\\"css-preprocessor\\"]]}',
+            config: '{\\"automock\\":false,\\"browser\\":false,\\"cache\\":true,\\"cacheDirectory\\":\\"/cache/\\",\\"clearMocks\\":false,\\"coveragePathIgnorePatterns\\":[],\\"cwd\\":\\"/test_root_dir/\\",\\"detectLeaks\\":false,\\"detectOpenHandles\\":false,\\"errorOnDeprecated\\":false,\\"extraGlobals\\":[],\\"filter\\":null,\\"forceCoverageMatch\\":[],\\"globalSetup\\":null,\\"globalTeardown\\":null,\\"globals\\":{},\\"haste\\":{\\"providesModuleNodeModules\\":[]},\\"moduleDirectories\\":[],\\"moduleFileExtensions\\":[\\"js\\"],\\"moduleLoader\\":\\"/test_module_loader_path\\",\\"moduleNameMapper\\":[],\\"modulePathIgnorePatterns\\":[],\\"modulePaths\\":[],\\"name\\":\\"test\\",\\"prettierPath\\":\\"prettier\\",\\"resetMocks\\":false,\\"resetModules\\":false,\\"resolver\\":null,\\"restoreMocks\\":false,\\"rootDir\\":\\"/\\",\\"roots\\":[],\\"runner\\":\\"jest-runner\\",\\"setupFiles\\":[],\\"setupFilesAfterEnv\\":[],\\"skipFilter\\":false,\\"skipNodeResolution\\":false,\\"snapshotResolver\\":null,\\"snapshotSerializers\\":[],\\"testEnvironment\\":\\"node\\",\\"testEnvironmentOptions\\":{},\\"testLocationInResults\\":false,\\"testMatch\\":[],\\"testPathIgnorePatterns\\":[],\\"testRegex\\":[\\"\\\\\\\\.test\\\\\\\\.js$\\"],\\"testRunner\\":\\"jest-jasmine2\\",\\"testURL\\":\\"\\",\\"timers\\":\\"real\\",\\"transform\\":[[\\"^.+\\\\\\\\.js$\\",\\"test_preprocessor\\"],[\\"^.+\\\\\\\\.css$\\",\\"css-preprocessor\\"]],\\"transformIgnorePatterns\\":[\\"/node_modules/\\"],\\"unmockedModulePathPatterns\\":null,\\"watchPathIgnorePatterns\\":[]}',
           };
         
 }});"
@@ -198,7 +250,7 @@ exports[`ScriptTransformer uses the supplied preprocessor 1`] = `
           const TRANSFORMED = {
             filename: '/fruits/banana.js',
             script: 'module.exports = \\"banana\\";',
-            config: '{\\"cache\\":true,\\"cacheDirectory\\":\\"/cache/\\",\\"name\\":\\"test\\",\\"rootDir\\":\\"/\\",\\"transformIgnorePatterns\\":[\\"/node_modules/\\"],\\"transform\\":[[\\"^.+\\\\\\\\.js$\\",\\"test_preprocessor\\"]]}',
+            config: '{\\"automock\\":false,\\"browser\\":false,\\"cache\\":true,\\"cacheDirectory\\":\\"/cache/\\",\\"clearMocks\\":false,\\"coveragePathIgnorePatterns\\":[],\\"cwd\\":\\"/test_root_dir/\\",\\"detectLeaks\\":false,\\"detectOpenHandles\\":false,\\"errorOnDeprecated\\":false,\\"extraGlobals\\":[],\\"filter\\":null,\\"forceCoverageMatch\\":[],\\"globalSetup\\":null,\\"globalTeardown\\":null,\\"globals\\":{},\\"haste\\":{\\"providesModuleNodeModules\\":[]},\\"moduleDirectories\\":[],\\"moduleFileExtensions\\":[\\"js\\"],\\"moduleLoader\\":\\"/test_module_loader_path\\",\\"moduleNameMapper\\":[],\\"modulePathIgnorePatterns\\":[],\\"modulePaths\\":[],\\"name\\":\\"test\\",\\"prettierPath\\":\\"prettier\\",\\"resetMocks\\":false,\\"resetModules\\":false,\\"resolver\\":null,\\"restoreMocks\\":false,\\"rootDir\\":\\"/\\",\\"roots\\":[],\\"runner\\":\\"jest-runner\\",\\"setupFiles\\":[],\\"setupFilesAfterEnv\\":[],\\"skipFilter\\":false,\\"skipNodeResolution\\":false,\\"snapshotResolver\\":null,\\"snapshotSerializers\\":[],\\"testEnvironment\\":\\"node\\",\\"testEnvironmentOptions\\":{},\\"testLocationInResults\\":false,\\"testMatch\\":[],\\"testPathIgnorePatterns\\":[],\\"testRegex\\":[\\"\\\\\\\\.test\\\\\\\\.js$\\"],\\"testRunner\\":\\"jest-jasmine2\\",\\"testURL\\":\\"\\",\\"timers\\":\\"real\\",\\"transform\\":[[\\"^.+\\\\\\\\.js$\\",\\"test_preprocessor\\"]],\\"transformIgnorePatterns\\":[\\"/node_modules/\\"],\\"unmockedModulePathPatterns\\":null,\\"watchPathIgnorePatterns\\":[]}',
           };
         
 }});"

--- a/packages/jest-transform/src/__tests__/script_transformer.test.js
+++ b/packages/jest-transform/src/__tests__/script_transformer.test.js
@@ -8,6 +8,8 @@
 
 'use strict';
 
+import {makeProjectConfig} from '../../../../TestUtils';
+
 jest
   .mock('fs', () =>
     // Node 10.5.x compatibility
@@ -185,13 +187,13 @@ describe('ScriptTransformer', () => {
 
     writeFileAtomic = require('write-file-atomic');
 
-    config = {
+    config = makeProjectConfig({
       cache: true,
       cacheDirectory: '/cache/',
       name: 'test',
       rootDir: '/',
       transformIgnorePatterns: ['/node_modules/'],
-    };
+    });
 
     ScriptTransformer = require('../ScriptTransformer').default;
   };

--- a/packages/jest-transform/src/__tests__/should_instrument.test.js
+++ b/packages/jest-transform/src/__tests__/should_instrument.test.js
@@ -7,22 +7,25 @@
  */
 
 import shouldInstrument from '../shouldInstrument';
-import {makeGlobalConfig} from '../../../../TestUtils';
+import {makeProjectConfig} from '../../../../TestUtils';
 
 describe('shouldInstrument', () => {
   const defaultFilename = 'source_file.test.js';
   const defaultOptions = {
     collectCoverage: true,
   };
-  const defaultConfig = makeGlobalConfig({rootDir: '/'});
-
+  const defaultConfig = makeProjectConfig({rootDir: '/'});
   describe('should return true', () => {
     const testShouldInstrument = (
       filename = defaultFilename,
-      options = defaultOptions,
-      config = defaultConfig,
+      options,
+      config,
     ) => {
-      const result = shouldInstrument(filename, options, config);
+      const result = shouldInstrument(
+        filename,
+        {...defaultOptions, ...options},
+        {...defaultConfig, ...config},
+      );
       expect(result).toBe(true);
     };
 
@@ -74,7 +77,6 @@ describe('shouldInstrument', () => {
       testShouldInstrument(
         'collect/only/from/here.js',
         {
-          collectCoverage: true,
           collectCoverageOnlyFrom: {'collect/only/from/here.js': true},
         },
         defaultConfig,
@@ -85,7 +87,6 @@ describe('shouldInstrument', () => {
       testShouldInstrument(
         'do/collect/coverage.js',
         {
-          collectCoverage: true,
           collectCoverageFrom: ['!**/dont/**/*.js', '**/do/**/*.js'],
         },
         defaultConfig,
@@ -95,14 +96,12 @@ describe('shouldInstrument', () => {
     it('should return true if the file is not in coveragePathIgnorePatterns', () => {
       testShouldInstrument('do/collect/coverage.js', defaultOptions, {
         coveragePathIgnorePatterns: ['dont'],
-        rootDir: '/',
       });
     });
 
     it('should return true if file is a testfile but forceCoverageMatch is set', () => {
       testShouldInstrument('do/collect/sum.coverage.test.js', defaultOptions, {
         forceCoverageMatch: ['**/*.(coverage).(test).js'],
-        rootDir: '/',
         testRegex: ['.*\\.(test)\\.(js)$'],
       });
     });
@@ -111,10 +110,14 @@ describe('shouldInstrument', () => {
   describe('should return false', () => {
     const testShouldInstrument = (
       filename = defaultFilename,
-      options = defaultOptions,
-      config = defaultConfig,
+      options,
+      config,
     ) => {
-      const result = shouldInstrument(filename, options, config);
+      const result = shouldInstrument(
+        filename,
+        {...defaultOptions, ...options},
+        {...defaultConfig, ...config},
+      );
       expect(result).toBe(false);
     };
 
@@ -164,7 +167,6 @@ describe('shouldInstrument', () => {
       testShouldInstrument(
         'source_file.js',
         {
-          collectCoverage: true,
           collectCoverageOnlyFrom: {'collect/only/from/here.js': true},
         },
         defaultConfig,
@@ -175,7 +177,6 @@ describe('shouldInstrument', () => {
       testShouldInstrument(
         'dont/collect/coverage.js',
         {
-          collectCoverage: true,
           collectCoverageFrom: ['!**/dont/**/*.js', '**/do/**/*.js'],
         },
         defaultConfig,
@@ -185,7 +186,6 @@ describe('shouldInstrument', () => {
     it('if the file is in coveragePathIgnorePatterns', () => {
       testShouldInstrument('dont/collect/coverage.js', defaultOptions, {
         coveragePathIgnorePatterns: ['dont'],
-        rootDir: '/',
       });
     });
 
@@ -201,27 +201,23 @@ describe('shouldInstrument', () => {
     it('if file is a globalSetup file', () => {
       testShouldInstrument('globalSetup.js', defaultOptions, {
         globalSetup: 'globalSetup.js',
-        rootDir: '/',
       });
     });
 
     it('if file is globalTeardown file', () => {
       testShouldInstrument('globalTeardown.js', defaultOptions, {
         globalTeardown: 'globalTeardown.js',
-        rootDir: '/',
       });
     });
 
     it('if file is in setupFiles', () => {
       testShouldInstrument('setupTest.js', defaultOptions, {
-        rootDir: '/',
         setupFiles: ['setupTest.js'],
       });
     });
 
     it('if file is in setupFilesAfterEnv', () => {
       testShouldInstrument('setupTest.js', defaultOptions, {
-        rootDir: '/',
         setupFilesAfterEnv: ['setupTest.js'],
       });
     });

--- a/packages/jest-transform/src/shouldInstrument.ts
+++ b/packages/jest-transform/src/shouldInstrument.ts
@@ -26,7 +26,6 @@ export default function shouldInstrument(
   }
 
   if (
-    config.forceCoverageMatch &&
     config.forceCoverageMatch.length &&
     micromatch.any(filename, config.forceCoverageMatch)
   ) {
@@ -34,21 +33,13 @@ export default function shouldInstrument(
   }
 
   if (
-    !config.testPathIgnorePatterns ||
     !config.testPathIgnorePatterns.some(pattern => !!filename.match(pattern))
   ) {
-    if (
-      config.testRegex &&
-      config.testRegex.some(regex => new RegExp(regex).test(filename))
-    ) {
+    if (config.testRegex.some(regex => new RegExp(regex).test(filename))) {
       return false;
     }
 
-    if (
-      config.testMatch &&
-      config.testMatch.length &&
-      micromatch.some(replacePathSepForGlob(filename), config.testMatch)
-    ) {
+    if (micromatch.some(replacePathSepForGlob(filename), config.testMatch)) {
       return false;
     }
   }
@@ -75,7 +66,6 @@ export default function shouldInstrument(
   }
 
   if (
-    config.coveragePathIgnorePatterns &&
     config.coveragePathIgnorePatterns.some(pattern => !!filename.match(pattern))
   ) {
     return false;
@@ -89,19 +79,11 @@ export default function shouldInstrument(
     return false;
   }
 
-  if (
-    //TODO: Remove additional check when normalized config provided in unit test
-    config.setupFiles &&
-    config.setupFiles.some(setupFile => setupFile === filename)
-  ) {
+  if (config.setupFiles.some(setupFile => setupFile === filename)) {
     return false;
   }
 
-  if (
-    //TODO: Remove additional check when normalized config provided in unit test
-    config.setupFilesAfterEnv &&
-    config.setupFilesAfterEnv.some(setupFile => setupFile === filename)
-  ) {
+  if (config.setupFilesAfterEnv.some(setupFile => setupFile === filename)) {
     return false;
   }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

`shouldInstrument` function expects the config object to be normalized, but some of the unit tests don't respect that so I've tried to change this. When we will be sure that the received config is normalized we can remove the additional checks from the conditions in `shouldInstrument.js` file.

This is work in progress, but I've wanted to hear your opinion regarding my modified version of `testShouldInstrument` function in the `should_instrument.test.js` file. Can you think of any cases that can break this? Is it better to just simply provide a normalized config as an argument every time?

I'm taking care of the failed unit tests right now, any clues how to approach this?
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan
Adjusted unit tests. If we are certain that `shouldInstrument` receives normalized config, I think it should be enough.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
