### PR TITLE
Fix typo in question.md issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -8,7 +8,7 @@ about: If you have questions, please check our Discord or StackOverflow
 
 ## 💬 Questions and Help
 
-### Please note that this issue tracker is not a help form and this issue will be closed.
+### Please note that this issue tracker is not a help forum and this issue will be closed.
 
 For questions or help please see:
 


### PR DESCRIPTION
## Summary

Trivial. Replace "form" with "forum" in issue template.

## Test plan

Skipped tests, as this is a minor typo fix in a GitHub issue template.