### PR TITLE
Migrate jest-regex-util to Typescript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - `[pretty-format]`: Migrate to TypeScript ([#7809](https://github.com/facebook/jest/pull/7809))
 - `[diff-sequences]`: Migrate to Typescript ([#7820](https://github.com/facebook/jest/pull/7820))
 - `[jest-get-type]`: Migrate to TypeScript ([#7818](https://github.com/facebook/jest/pull/7818))
+- `[jest-regex-util]`: Migrate to TypeScript ([#7822](https://github.com/facebook/jest/pull/7822))
 
 ### Performance
 

--- a/packages/jest-regex-util/package.json
+++ b/packages/jest-regex-util/package.json
@@ -11,5 +11,6 @@
   },
   "license": "MIT",
   "main": "build/index.js",
+  "types": "build/index.d.ts",
   "gitHead": "634e5a54f46b2a62d1dc81a170562e6f4e55ad60"
 }

--- a/packages/jest-regex-util/src/__tests__/index.test.ts
+++ b/packages/jest-regex-util/src/__tests__/index.test.ts
@@ -2,8 +2,8 @@
 
 jest.mock('path');
 
-import {replacePathSepForRegex} from '../index';
 import path from 'path';
+import {replacePathSepForRegex} from '../index';
 
 describe('replacePathSepForRegex()', () => {
   describe('posix', () => {
@@ -11,7 +11,7 @@ describe('replacePathSepForRegex()', () => {
 
     it('should return the path', () => {
       const expected = {};
-      expect(replacePathSepForRegex(expected)).toBe(expected);
+      expect(replacePathSepForRegex(expected as any)).toBe(expected);
     });
   });
 

--- a/packages/jest-regex-util/src/__tests__/index.test.ts
+++ b/packages/jest-regex-util/src/__tests__/index.test.ts
@@ -2,12 +2,12 @@
 
 jest.mock('path');
 
-import {replacePathSepForRegex} from '../index';
 import path from 'path';
+import {replacePathSepForRegex} from '../index';
 
 describe('replacePathSepForRegex()', () => {
   describe('posix', () => {
-    beforeEach(() => (path.sep = '/'));
+    beforeEach(() => ((path as any).sep = '/'));
 
     it('should return the path', () => {
       const expected = {};
@@ -16,7 +16,7 @@ describe('replacePathSepForRegex()', () => {
   });
 
   describe('win32', () => {
-    beforeEach(() => (path.sep = '\\'));
+    beforeEach(() => ((path as any).sep = '\\'));
 
     it('should replace POSIX path separators', () => {
       expect(replacePathSepForRegex('a/b/c')).toBe('a\\\\b\\\\c');

--- a/packages/jest-regex-util/src/__tests__/index.test.ts
+++ b/packages/jest-regex-util/src/__tests__/index.test.ts
@@ -2,8 +2,8 @@
 
 jest.mock('path');
 
-import path from 'path';
 import {replacePathSepForRegex} from '../index';
+import path from 'path';
 
 describe('replacePathSepForRegex()', () => {
   describe('posix', () => {

--- a/packages/jest-regex-util/src/index.ts
+++ b/packages/jest-regex-util/src/index.ts
@@ -24,7 +24,7 @@ export const replacePathSepForRegex = (string: string) => {
   if (path.sep === '\\') {
     return string.replace(
       /(\/|(.)?\\(?![[\]{}()*+?.^$|\\]))/g,
-      (_match, p1, p2) => (p2 && p2 !== '\\' ? p2 + '\\\\' : '\\\\'),
+      (_match, _, p2) => (p2 && p2 !== '\\' ? p2 + '\\\\' : '\\\\'),
     );
   }
   return string;

--- a/packages/jest-regex-util/src/index.ts
+++ b/packages/jest-regex-util/src/index.ts
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow
  */
 
 import path from 'path';

--- a/packages/jest-regex-util/tsconfig.json
+++ b/packages/jest-regex-util/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "build"
+  }
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Diff:

<details>

```diff
diff --git a/packages/jest-regex-util/build/index.js b/packages/jest-regex-util/build/index.js
index 310d6876b..f3611a56f 100644
--- a/packages/jest-regex-util/build/index.js
+++ b/packages/jest-regex-util/build/index.js
@@ -17,7 +17,6 @@ function _interopRequireDefault(obj) {
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- *
  */
 const escapePathForRegex = dir => {
   if (_path.default.sep === '\\') {
@@ -40,7 +39,7 @@ const replacePathSepForRegex = string => {
   if (_path.default.sep === '\\') {
     return string.replace(
       /(\/|(.)?\\(?![[\]{}()*+?.^$|\\]))/g,
-      (_match, p1, p2) => (p2 && p2 !== '\\' ? p2 + '\\\\' : '\\\\')
+      (_match, _, p2) => (p2 && p2 !== '\\' ? p2 + '\\\\' : '\\\\')
     );
   }
```

</details>

## Test plan

Green CI
