### PR TITLE
Migrate jest-changed-files to Typescript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `[jest-regex-util]`: Migrate to TypeScript ([#7822](https://github.com/facebook/jest/pull/7822))
 - `[jest-diff]`: Migrate to TypeScript ([#7824](https://github.com/facebook/jest/pull/7824))
 - `[jest-leak-detector]`: Migrate to TypeScript ([#7825](https://github.com/facebook/jest/pull/7825))
+- `[jest-changed-files]`: Migrate to TypeScript ([#7827](https://github.com/facebook/jest/pull/7827))
 
 ### Performance
 

--- a/e2e/__tests__/jestChangedFiles.test.js
+++ b/e2e/__tests__/jestChangedFiles.test.js
@@ -9,14 +9,14 @@
 
 import os from 'os';
 import path from 'path';
+import {wrap} from 'jest-snapshot-serializer-raw';
 import {
   findRepos,
   getChangedFilesForRoots,
-} from '../../packages/jest-changed-files/src';
+} from '../../packages/jest-changed-files';
 import {skipSuiteOnWindows} from '../../scripts/ConditionalTest';
 import {cleanup, run, writeFiles} from '../Utils';
 import runJest from '../runJest';
-import {wrap} from 'jest-snapshot-serializer-raw';
 
 skipSuiteOnWindows();
 

--- a/e2e/__tests__/jestChangedFiles.test.js
+++ b/e2e/__tests__/jestChangedFiles.test.js
@@ -10,10 +10,7 @@
 import os from 'os';
 import path from 'path';
 import {wrap} from 'jest-snapshot-serializer-raw';
-import {
-  findRepos,
-  getChangedFilesForRoots,
-} from 'jest-changed-files';
+import {findRepos, getChangedFilesForRoots} from 'jest-changed-files';
 import {skipSuiteOnWindows} from '../../scripts/ConditionalTest';
 import {cleanup, run, writeFiles} from '../Utils';
 import runJest from '../runJest';

--- a/e2e/__tests__/jestChangedFiles.test.js
+++ b/e2e/__tests__/jestChangedFiles.test.js
@@ -13,7 +13,7 @@ import {wrap} from 'jest-snapshot-serializer-raw';
 import {
   findRepos,
   getChangedFilesForRoots,
-} from '../../packages/jest-changed-files';
+} from 'jest-changed-files';
 import {skipSuiteOnWindows} from '../../scripts/ConditionalTest';
 import {cleanup, run, writeFiles} from '../Utils';
 import runJest from '../runJest';

--- a/packages/jest-changed-files/package.json
+++ b/packages/jest-changed-files/package.json
@@ -8,6 +8,7 @@
   },
   "license": "MIT",
   "main": "build/index.js",
+  "types": "build/index.d.ts",
   "dependencies": {
     "execa": "^1.0.0",
     "throat": "^4.0.0"

--- a/packages/jest-changed-files/src/git.ts
+++ b/packages/jest-changed-files/src/git.ts
@@ -4,14 +4,12 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow
  */
-
-import type {Path} from 'types/Config';
-import type {Options, SCMAdapter} from 'types/ChangedFiles';
 
 import path from 'path';
 import execa from 'execa';
+
+import {Path, Options, SCMAdapter} from './types';
 
 const findChangedFilesUsingCommand = async (
   args: Array<string>,
@@ -30,7 +28,7 @@ const adapter: SCMAdapter = {
     cwd: string,
     options?: Options,
   ): Promise<Array<Path>> => {
-    const changedSince: ?string =
+    const changedSince: string | null | undefined =
       options && (options.withAncestor ? 'HEAD^' : options.changedSince);
 
     const includePaths: Array<Path> = (options && options.includePaths) || [];
@@ -72,7 +70,7 @@ const adapter: SCMAdapter = {
     }
   },
 
-  getRoot: async (cwd: string): Promise<?string> => {
+  getRoot: async (cwd: string): Promise<string | null | undefined> => {
     const options = ['rev-parse', '--show-toplevel'];
 
     try {

--- a/packages/jest-changed-files/src/git.ts
+++ b/packages/jest-changed-files/src/git.ts
@@ -28,7 +28,7 @@ const adapter: SCMAdapter = {
     cwd: string,
     options?: Options,
   ): Promise<Array<Path>> => {
-    const changedSince: string | null | undefined =
+    const changedSince: string | undefined =
       options && (options.withAncestor ? 'HEAD^' : options.changedSince);
 
     const includePaths: Array<Path> = (options && options.includePaths) || [];
@@ -70,7 +70,7 @@ const adapter: SCMAdapter = {
     }
   },
 
-  getRoot: async (cwd: string): Promise<string | null | undefined> => {
+  getRoot: async (cwd: string): Promise<string | null> => {
     const options = ['rev-parse', '--show-toplevel'];
 
     try {

--- a/packages/jest-changed-files/src/hg.ts
+++ b/packages/jest-changed-files/src/hg.ts
@@ -4,16 +4,14 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow
  */
-
-import type {Path} from 'types/Config';
-import type {Options, SCMAdapter} from 'types/ChangedFiles';
 
 import path from 'path';
 import execa from 'execa';
 
-const env = {...process.env, HGPLAIN: 1};
+import {Path, Options, SCMAdapter} from './types';
+
+const env = {...process.env, HGPLAIN: '1'};
 
 const ANCESTORS = [
   // Parent commit to this one.
@@ -51,7 +49,7 @@ const adapter: SCMAdapter = {
       .map(changedPath => path.resolve(cwd, changedPath));
   },
 
-  getRoot: async (cwd: Path): Promise<?Path> => {
+  getRoot: async (cwd: Path): Promise<Path | null | undefined> => {
     try {
       const result = await execa('hg', ['root'], {cwd, env});
 

--- a/packages/jest-changed-files/src/types.ts
+++ b/packages/jest-changed-files/src/types.ts
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+export type Path = string;
+
+export type Options = {
+  lastCommit?: boolean;
+  withAncestor?: boolean;
+  changedSince?: string;
+  includePaths?: Array<Path>;
+};
+
+export type ChangedFiles = Set<Path>;
+export type Repos = {git: Set<Path>; hg: Set<Path>};
+export type ChangedFilesPromise = Promise<{
+  repos: Repos;
+  changedFiles: ChangedFiles;
+}>;
+
+export type SCMAdapter = {
+  findChangedFiles: (cwd: Path, options: Options) => Promise<Array<Path>>;
+  getRoot: (cwd: Path) => Promise<Path | null | undefined>;
+};

--- a/packages/jest-changed-files/tsconfig.json
+++ b/packages/jest-changed-files/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "build"
+  }
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Diff:

<details>

```diff
diff --git a/packages/jest-changed-files/build/hg.js b/packages/jest-changed-files/build/hg.js
index 97a84e96f..27a021d87 100644
--- a/packages/jest-changed-files/build/hg.js
+++ b/packages/jest-changed-files/build/hg.js
@@ -94,7 +94,7 @@ function _defineProperty(obj, key, value) {
 }
 
 const env = _objectSpread({}, process.env, {
-  HGPLAIN: 1
+  HGPLAIN: '1'
 });
 
 const ANCESTORS = [
diff --git a/packages/jest-changed-files/build/index.js b/packages/jest-changed-files/build/index.js
index dbd84f818..5e7db85f2 100644
--- a/packages/jest-changed-files/build/index.js
+++ b/packages/jest-changed-files/build/index.js
@@ -5,10 +5,6 @@ Object.defineProperty(exports, '__esModule', {
 });
 exports.findRepos = exports.getChangedFilesForRoots = void 0;
 
-var _git = _interopRequireDefault(require('./git'));
-
-var _hg = _interopRequireDefault(require('./hg'));
-
 function _throat() {
   const data = _interopRequireDefault(require('throat'));
 
@@ -19,6 +15,10 @@ function _throat() {
   return data;
 }
 
+var _git = _interopRequireDefault(require('./git'));
+
+var _hg = _interopRequireDefault(require('./hg'));
+
 function _interopRequireDefault(obj) {
   return obj && obj.__esModule ? obj : {default: obj};
 }
```

</details>

## Test plan

Green CI
