### PR TITLE
Remove redundant stripAnsi

### DIFF
--- a/e2e/__tests__/multiProjectRunner.test.js
+++ b/e2e/__tests__/multiProjectRunner.test.js
@@ -10,7 +10,6 @@
 import runJest from '../runJest';
 import os from 'os';
 import path from 'path';
-import stripAnsi from 'strip-ansi';
 import {cleanup, extractSummary, sortLines, writeFiles} from '../Utils';
 import {wrap} from 'jest-snapshot-serializer-raw';
 
@@ -322,7 +321,7 @@ test('resolves projects and their <rootDir> properly', () => {
     }),
   });
 
-  ({stderr} = stripAnsi(runJest(DIR, ['--no-watchman'])));
+  ({stderr} = runJest(DIR, ['--no-watchman']));
   expect(stderr).toMatch(
     /Whoops! Two projects resolved to the same config path/,
   );


### PR DESCRIPTION
## Summary

It doesn't make sense to wrap a `runJust` call into `stripAnsi` since the latter works only with strings.
`runJest` returns an object so stripAnsi just passes it along.

Materials:

- Commit where the code was added in the first place: https://github.com/facebook/jest/commit/e12cab63f06cabaf4e38c18fac18cf463fc10e1f#diff-4cf7d6c79ff377b63522b3af20e34e8eR307
- stripAnsi source code: https://github.com/chalk/strip-ansi/blob/097894423fedb6b4dca3005ad45608b893fcdcf8/index.js