### PR TITLE
chore: migrate jest-serializer to TypeScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - `[jest-changed-files]`: Migrate to TypeScript ([#7827](https://github.com/facebook/jest/pull/7827))
 - `[jest-matcher-utils]`: Migrate to TypeScript ([#7835](https://github.com/facebook/jest/pull/7835))
 - `[jest-docblock]`: Migrate to TypeScript ([#7836](https://github.com/facebook/jest/pull/7836))
+- `[jest-serializer]`: Migrate to TypeScript ([#7841](https://github.com/facebook/jest/pull/7841))
 
 ### Performance
 

--- a/packages/jest-serializer/package.json
+++ b/packages/jest-serializer/package.json
@@ -11,5 +11,6 @@
   },
   "license": "MIT",
   "main": "build/index.js",
+  "types": "build/index.d.ts",
   "gitHead": "634e5a54f46b2a62d1dc81a170562e6f4e55ad60"
 }

--- a/packages/jest-serializer/src/__tests__/index.test.ts
+++ b/packages/jest-serializer/src/__tests__/index.test.ts
@@ -18,9 +18,7 @@ import serializer from '..';
 
 const v8s = [
   {
-    // @ts-ignore - Node 8+ only
     deserialize: v8.deserialize,
-    // @ts-ignore - Node 8+ only
     serialize: v8.serialize,
   },
   {
@@ -57,9 +55,7 @@ afterEach(() => {
 v8s.forEach((mockV8, i) => {
   describe('Using V8 implementation ' + i, () => {
     beforeEach(() => {
-      // @ts-ignore - Node 8+ only
       v8.serialize = mockV8.serialize;
-      // @ts-ignore - Node 8+ only
       v8.deserialize = mockV8.deserialize;
     });
 

--- a/packages/jest-serializer/src/__tests__/index.test.ts
+++ b/packages/jest-serializer/src/__tests__/index.test.ts
@@ -18,7 +18,9 @@ import serializer from '..';
 
 const v8s = [
   {
+    // @ts-ignore - Node 8+ only
     deserialize: v8.deserialize,
+    // @ts-ignore - Node 8+ only
     serialize: v8.serialize,
   },
   {
@@ -34,6 +36,7 @@ const objs = [
   {key1: 'foo', key2: 'bar', key3: {array: [null, {}]}},
   {minusInf: -Infinity, nan: NaN, plusInf: +Infinity},
   {date: new Date(1234567890), re: /foo/gi},
+  // @ts-ignore - testing NaN
   {map: new Map([[NaN, 4], [undefined, 'm']]), set: new Set([undefined, NaN])},
   {buf: Buffer.from([0, 255, 127])},
 ];
@@ -54,7 +57,9 @@ afterEach(() => {
 v8s.forEach((mockV8, i) => {
   describe('Using V8 implementation ' + i, () => {
     beforeEach(() => {
+      // @ts-ignore - Node 8+ only
       v8.serialize = mockV8.serialize;
+      // @ts-ignore - Node 8+ only
       v8.deserialize = mockV8.deserialize;
     });
 

--- a/packages/jest-serializer/src/global.d.ts
+++ b/packages/jest-serializer/src/global.d.ts
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+declare module 'v8' {
+  function serialize(value: unknown): Buffer;
+  function deserialize(value: Buffer): unknown;
+}

--- a/packages/jest-serializer/src/index.ts
+++ b/packages/jest-serializer/src/index.ts
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- * @flow
  */
 
 'use strict';
@@ -12,7 +10,7 @@
 import fs from 'fs';
 import v8 from 'v8';
 
-import type {Path} from 'types/Config';
+type Path = string;
 
 // JSON and V8 serializers are both stable when it comes to compatibility. The
 // current JSON specification is well defined in RFC 8259, and V8 ensures that
@@ -23,7 +21,7 @@ const JS_TYPE = '__$t__';
 const JS_VALUE = '__$v__';
 const JS_VF = '__$f__';
 
-function replacer(key: string, value: any): any {
+function replacer(_key: string, value: any): any {
   // NaN cannot be in a switch statement, because NaN !== NaN.
   if (Number.isNaN(value)) {
     return {[JS_TYPE]: 'n'};
@@ -32,10 +30,8 @@ function replacer(key: string, value: any): any {
   switch (value) {
     case undefined:
       return {[JS_TYPE]: 'u'};
-
     case +Infinity:
       return {[JS_TYPE]: '+'};
-
     case -Infinity:
       return {[JS_TYPE]: '-'};
   }
@@ -43,16 +39,12 @@ function replacer(key: string, value: any): any {
   switch (value && value.constructor) {
     case Date:
       return {[JS_TYPE]: 'd', [JS_VALUE]: value.getTime()};
-
     case RegExp:
       return {[JS_TYPE]: 'r', [JS_VALUE]: value.source, [JS_VF]: value.flags};
-
     case Set:
       return {[JS_TYPE]: 's', [JS_VALUE]: Array.from(value)};
-
     case Map:
       return {[JS_TYPE]: 'm', [JS_VALUE]: Array.from(value)};
-
     case Buffer:
       return {[JS_TYPE]: 'b', [JS_VALUE]: value.toString('latin1')};
   }
@@ -60,7 +52,7 @@ function replacer(key: string, value: any): any {
   return value;
 }
 
-function reviver(key: string, value: any): any {
+function reviver(_key: string, value: any): any {
   if (!value || (typeof value !== 'object' && !value.hasOwnProperty(JS_TYPE))) {
     return value;
   }
@@ -68,28 +60,20 @@ function reviver(key: string, value: any): any {
   switch (value[JS_TYPE]) {
     case 'u':
       return undefined;
-
     case 'n':
       return NaN;
-
     case '+':
       return +Infinity;
-
     case '-':
       return -Infinity;
-
     case 'd':
       return new Date(value[JS_VALUE]);
-
     case 'r':
       return new RegExp(value[JS_VALUE], value[JS_VF]);
-
     case 's':
       return new Set(value[JS_VALUE]);
-
     case 'm':
       return new Map(value[JS_VALUE]);
-
     case 'b':
       return Buffer.from(value[JS_VALUE], 'latin1');
   }
@@ -97,7 +81,7 @@ function reviver(key: string, value: any): any {
   return value;
 }
 
-function jsonStringify(content) {
+function jsonStringify(content: unknown) {
   // Not pretty, but the ES JSON spec says that "toJSON" will be called before
   // getting into your replacer, so we have to remove them beforehand. See
   // https://www.ecma-international.org/ecma-262/#sec-serializejsonproperty
@@ -109,55 +93,61 @@ function jsonStringify(content) {
   /* eslint-disable no-extend-native */
 
   try {
-    // $FlowFixMe: intentional removal of "toJSON" property.
+    // @ts-ignore intentional removal of "toJSON" property.
     Date.prototype.toJSON = undefined;
-    // $FlowFixMe: intentional removal of "toJSON" property.
+    // @ts-ignore intentional removal of "toJSON" property.
     Buffer.prototype.toJSON = undefined;
 
     return JSON.stringify(content, replacer);
   } finally {
-    // $FlowFixMe: intentional assignment of "toJSON" property.
     Date.prototype.toJSON = dateToJSON;
-    // $FlowFixMe: intentional assignment of "toJSON" property.
     Buffer.prototype.toJSON = bufferToJSON;
   }
 
   /* eslint-enable no-extend-native */
 }
 
-function jsonParse(content) {
+function jsonParse(content: string) {
   return JSON.parse(content, reviver);
 }
 
 // In memory functions.
 
 export function deserialize(buffer: Buffer): any {
-  // $FlowFixMe - Node 8+ only
+  // @ts-ignore - Node 8+ only
   return v8.deserialize
-    ? v8.deserialize(buffer)
+    ? //
+      // @ts-ignore - Node 8+ only
+      v8.deserialize(buffer)
     : jsonParse(buffer.toString('utf8'));
 }
 
-export function serialize(content: any): Buffer {
-  // $FlowFixMe - Node 8+ only
+export function serialize(content: unknown): Buffer {
+  // @ts-ignore - Node 8+ only
   return v8.serialize
-    ? v8.serialize(content)
+    ? //
+      // @ts-ignore - Node 8+ only
+      v8.serialize(content)
     : Buffer.from(jsonStringify(content));
 }
 
 // Synchronous filesystem functions.
 
 export function readFileSync(filePath: Path): any {
-  // $FlowFixMe - Node 8+ only
+  // @ts-ignore - Node 8+ only
   return v8.deserialize
-    ? v8.deserialize(fs.readFileSync(filePath))
+    ? //
+      // @ts-ignore - Node 8+ only
+      v8.deserialize(fs.readFileSync(filePath))
     : jsonParse(fs.readFileSync(filePath, 'utf8'));
 }
 
 export function writeFileSync(filePath: Path, content: any) {
-  // $FlowFixMe - Node 8+ only
+  // @ts-ignore - Node 8+ only
   return v8.serialize
-    ? fs.writeFileSync(filePath, v8.serialize(content))
+    ? //
+      // @ts-ignore - Node 8+ only
+      fs.writeFileSync(filePath, v8.serialize(content))
     : fs.writeFileSync(filePath, jsonStringify(content), 'utf8');
 }
 

--- a/packages/jest-serializer/src/index.ts
+++ b/packages/jest-serializer/src/index.ts
@@ -114,40 +114,28 @@ function jsonParse(content: string) {
 // In memory functions.
 
 export function deserialize(buffer: Buffer): any {
-  // @ts-ignore - Node 8+ only
   return v8.deserialize
-    ? //
-      // @ts-ignore - Node 8+ only
-      v8.deserialize(buffer)
+    ? v8.deserialize(buffer)
     : jsonParse(buffer.toString('utf8'));
 }
 
 export function serialize(content: unknown): Buffer {
-  // @ts-ignore - Node 8+ only
   return v8.serialize
-    ? //
-      // @ts-ignore - Node 8+ only
-      v8.serialize(content)
+    ? v8.serialize(content)
     : Buffer.from(jsonStringify(content));
 }
 
 // Synchronous filesystem functions.
 
 export function readFileSync(filePath: Path): any {
-  // @ts-ignore - Node 8+ only
   return v8.deserialize
-    ? //
-      // @ts-ignore - Node 8+ only
-      v8.deserialize(fs.readFileSync(filePath))
+    ? v8.deserialize(fs.readFileSync(filePath))
     : jsonParse(fs.readFileSync(filePath, 'utf8'));
 }
 
 export function writeFileSync(filePath: Path, content: any) {
-  // @ts-ignore - Node 8+ only
   return v8.serialize
-    ? //
-      // @ts-ignore - Node 8+ only
-      fs.writeFileSync(filePath, v8.serialize(content))
+    ? fs.writeFileSync(filePath, v8.serialize(content))
     : fs.writeFileSync(filePath, jsonStringify(content), 'utf8');
 }
 

--- a/packages/jest-serializer/src/index.ts
+++ b/packages/jest-serializer/src/index.ts
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-
 import fs from 'fs';
 import v8 from 'v8';
 

--- a/packages/jest-serializer/src/index.ts
+++ b/packages/jest-serializer/src/index.ts
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-'use strict';
 
 import fs from 'fs';
 import v8 from 'v8';

--- a/packages/jest-serializer/tsconfig.json
+++ b/packages/jest-serializer/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "build"
+  }
+}


### PR DESCRIPTION
## Summary

Jumping on a TS train 🚂

<details>

```diff
diff --git a/packages/jest-serializer/build/index.js b/packages/jest-serializer/build/index.js
index b6a60150d..1c0d8cdb7 100644
--- a/packages/jest-serializer/build/index.js
+++ b/packages/jest-serializer/build/index.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 'use strict';

@@ -49,7 +47,7 @@ const JS_TYPE = '__$t__';
 const JS_VALUE = '__$v__';
 const JS_VF = '__$f__';

-function replacer(key, value) {
+function replacer(_key, value) {
   // NaN cannot be in a switch statement, because NaN !== NaN.
   if (Number.isNaN(value)) {
     return {
@@ -110,7 +108,7 @@ function replacer(key, value) {
   return value;
 }

-function reviver(key, value) {
+function reviver(_key, value) {
   if (!value || (typeof value !== 'object' && !value.hasOwnProperty(JS_TYPE))) {
     return value;
   }
@@ -157,15 +155,13 @@ function jsonStringify(content) {
   /* eslint-disable no-extend-native */

   try {
-    // $FlowFixMe: intentional removal of "toJSON" property.
-    Date.prototype.toJSON = undefined; // $FlowFixMe: intentional removal of "toJSON" property.
+    // @ts-ignore intentional removal of "toJSON" property.
+    Date.prototype.toJSON = undefined; // @ts-ignore intentional removal of "toJSON" property.

     Buffer.prototype.toJSON = undefined;
     return JSON.stringify(content, replacer);
   } finally {
-    // $FlowFixMe: intentional assignment of "toJSON" property.
-    Date.prototype.toJSON = dateToJSON; // $FlowFixMe: intentional assignment of "toJSON" property.
-
+    Date.prototype.toJSON = dateToJSON;
     Buffer.prototype.toJSON = bufferToJSON;
   }
   /* eslint-enable no-extend-native */
@@ -176,28 +172,24 @@ function jsonParse(content) {
 } // In memory functions.

 function deserialize(buffer) {
-  // $FlowFixMe - Node 8+ only
   return _v().default.deserialize
     ? _v().default.deserialize(buffer)
     : jsonParse(buffer.toString('utf8'));
 }

 function serialize(content) {
-  // $FlowFixMe - Node 8+ only
   return _v().default.serialize
     ? _v().default.serialize(content)
     : Buffer.from(jsonStringify(content));
 } // Synchronous filesystem functions.

 function readFileSync(filePath) {
-  // $FlowFixMe - Node 8+ only
   return _v().default.deserialize
     ? _v().default.deserialize(_fs().default.readFileSync(filePath))
     : jsonParse(_fs().default.readFileSync(filePath, 'utf8'));
 }

 function writeFileSync(filePath, content) {
-  // $FlowFixMe - Node 8+ only
   return _v().default.serialize
     ? _fs().default.writeFileSync(filePath, _v().default.serialize(content))
     : _fs().default.writeFileSync(filePath, jsonStringify(content), 'utf8');

```
</details>

## Test plan

Green CI
