### PR TITLE
Added compact print option for default reporter

### DIFF
--- a/packages/jest-cli/src/reporters/base_reporter.js
+++ b/packages/jest-cli/src/reporters/base_reporter.js
@@ -13,9 +13,11 @@ import type {Test} from 'types/TestRunner';
 import type {ReporterOnStartOptions} from 'types/Reporters';
 
 import {remove as preRunMessageRemove} from '../preRunMessage';
+import type {GlobalConfig} from '../../../../types/Config';
 
-export default class BaseReporter {
+export default class BaseReporter<Options> {
   _error: ?Error;
+  _globalConfig: GlobalConfig;
 
   log(message: string) {
     process.stderr.write(message + '\n');
@@ -42,5 +44,15 @@ export default class BaseReporter {
   // define whether the test run was successful or failed.
   getLastError(): ?Error {
     return this._error;
+  }
+
+  getOptions(): $Shape<Options> {
+    const reporterName = this.constructor.name
+      .replace('Reporter', '')
+      .toLowerCase();
+    const config = this._globalConfig.reporters.find(
+      item => item[0] === reporterName,
+    );
+    return (config && config[1]) || {};
   }
 }

--- a/packages/jest-cli/src/reporters/utils.js
+++ b/packages/jest-cli/src/reporters/utils.js
@@ -8,7 +8,7 @@
  */
 
 import type {Path, ProjectConfig, GlobalConfig} from 'types/Config';
-import type {AggregatedResult} from 'types/TestResult';
+import type {AggregatedResult, AssertionResult} from 'types/TestResult';
 
 import path from 'path';
 import chalk from 'chalk';
@@ -272,4 +272,15 @@ export const wrapAnsiString = (string: string, terminalWidth: number) => {
       [''],
     )
     .join('\n');
+};
+
+export const getLocation = (assertionResult: AssertionResult) => {
+  if (assertionResult.location) {
+    return assertionResult.location;
+  }
+  const matches = assertionResult.failureMessages[0].match(/(\d+):(\d+)/);
+  return {
+    column: matches[2],
+    line: matches[1],
+  };
 };

--- a/packages/jest-message-util/src/index.js
+++ b/packages/jest-message-util/src/index.js
@@ -310,13 +310,8 @@ export const formatResultsErrors = (
       message = indentAllLines(message, MESSAGE_INDENT);
 
       const title =
-        chalk.bold.red(
-          TITLE_INDENT +
-            TITLE_BULLET +
-            result.ancestorTitles.join(ANCESTRY_SEPARATOR) +
-            (result.ancestorTitles.length ? ANCESTRY_SEPARATOR : '') +
-            result.title,
-        ) + '\n';
+        chalk.bold.red(TITLE_INDENT + TITLE_BULLET + formatFullTitle(result)) +
+        '\n';
 
       return title + '\n' + message + '\n' + stack;
     })
@@ -346,3 +341,10 @@ export const separateMessageFromStack = (content: string) => {
   const stack = messageMatch[2];
   return {message, stack};
 };
+
+export const formatFullTitle = (result: AssertionResult) =>
+  result.ancestorTitles.join(ANCESTRY_SEPARATOR) +
+  (result.ancestorTitles.length ? ANCESTRY_SEPARATOR : '') +
+  result.title;
+
+export {TITLE_INDENT, TITLE_BULLET};


### PR DESCRIPTION
## Summary

Added `compact` option to DefaultReporter so that it will prints only paths and titles.
Resolves #3322

## Test plan

![screen shot 2019-02-10 at 1 33 06 pm](https://user-images.githubusercontent.com/14192979/52531528-943db000-2d38-11e9-88b3-eb3f55cc27af.png)

