### PR TITLE
chore: migrate jest-mock to TypeScript

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,6 +25,7 @@ module.exports = {
           {argsIgnorePattern: '^_'},
         ],
         'import/order': 'error',
+        'no-dupe-class-members': 'off',
         'no-unused-vars': 'off',
       },
     },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - `[@jest/types]`: New package to handle shared types ([#7834](https://github.com/facebook/jest/pull/7834))
 - `[jest-util]`: Migrate to TypeScript ([#7844](https://github.com/facebook/jest/pull/7844))
 - `[jest-watcher]`: Migrate to TypeScript ([#7843](https://github.com/facebook/jest/pull/7843))
+- `[jest-mock]`: Migrate to TypeScript ([#7847](https://github.com/facebook/jest/pull/7847))
 
 ### Performance
 

--- a/packages/jest-mock/package.json
+++ b/packages/jest-mock/package.json
@@ -9,6 +9,9 @@
   "engines": {
     "node": ">= 6"
   },
+  "dependencies": {
+    "@jest/types": "^24.1.0"
+  },
   "license": "MIT",
   "main": "build/index.js",
   "browser": "build-es5/index.js",

--- a/packages/jest-mock/package.json
+++ b/packages/jest-mock/package.json
@@ -14,6 +14,7 @@
   },
   "license": "MIT",
   "main": "build/index.js",
+  "types": "build/index.d.ts",
   "browser": "build-es5/index.js",
   "gitHead": "634e5a54f46b2a62d1dc81a170562e6f4e55ad60"
 }

--- a/packages/jest-mock/src/__tests__/index.test.ts
+++ b/packages/jest-mock/src/__tests__/index.test.ts
@@ -8,7 +8,7 @@
 
 'use strict';
 
-const vm = require('vm');
+import vm from 'vm';
 
 describe('moduleMocker', () => {
   let moduleMocker;
@@ -182,6 +182,7 @@ describe('moduleMocker', () => {
     it('mocks ES2015 non-enumerable static properties and methods', () => {
       class ClassFoo {
         static foo() {}
+        static fooProp: Function;
       }
       ClassFoo.fooProp = () => {};
 

--- a/packages/jest-mock/src/__tests__/index.test.ts
+++ b/packages/jest-mock/src/__tests__/index.test.ts
@@ -6,8 +6,6 @@
  *
  */
 
-'use strict';
-
 import vm from 'vm';
 
 describe('moduleMocker', () => {

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -1092,4 +1092,5 @@ class ModuleMockerClass {
 }
 
 export type ModuleMocker = ModuleMockerClass;
-module.exports = new ModuleMockerClass(global);
+
+export default new ModuleMockerClass(global);

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -17,7 +17,8 @@ type MockFunctionMetadataType =
   | 'null'
   | 'undefined';
 
-export type MockFunctionMetadata<
+// TODO: bring this type export back once done with TS migration
+type MockFunctionMetadata<
   T,
   Y extends unknown[],
   Type = MockFunctionMetadataType
@@ -1091,6 +1092,7 @@ class ModuleMockerClass {
   }
 }
 
-export type ModuleMocker = ModuleMockerClass;
+// TODO: bring this type export back once done with TS migration
+// export type ModuleMocker = ModuleMockerClass;
 
-export default new ModuleMockerClass(global);
+export = new ModuleMockerClass(global);

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -478,8 +478,6 @@ class ModuleMockerClass {
     ) {
       return metadata.value;
     } else if (metadata.type === 'function') {
-      let f: Mock<T, Y>;
-
       const prototype =
         (metadata.members &&
           metadata.members.prototype &&
@@ -593,7 +591,7 @@ class ModuleMockerClass {
         return finalReturnValue;
       }, metadata.length || 0);
 
-      f = (this._createMockFunction(
+      const f = (this._createMockFunction(
         metadata,
         mockConstructor,
       ) as unknown) as Mock<T, Y>;

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -68,21 +68,21 @@ interface MockInstance<T, Y extends unknown[]> {
   getMockName(): string;
   getMockImplementation(): Function | undefined;
   mock: MockFunctionState<T, Y>;
-  mockClear(): void;
-  mockReset(): void;
+  mockClear(): this;
+  mockReset(): this;
   mockRestore(): void;
-  mockImplementation(fn: (...args: Y) => T): Mock<T, Y>;
-  mockImplementation(fn: () => Promise<T>): Mock<T, Y>;
-  mockImplementationOnce(fn: (...args: Y) => T): Mock<T, Y>;
-  mockImplementationOnce(fn: () => Promise<T>): Mock<T, Y>;
-  mockName(name: string): Mock<T, Y>;
-  mockReturnThis(): Mock<T, Y>;
-  mockReturnValue(value: T): Mock<T, Y>;
-  mockReturnValueOnce(value: T): Mock<T, Y>;
-  mockResolvedValue(value: T): Mock<T, Y>;
-  mockResolvedValueOnce(value: T): Mock<T, Y>;
-  mockRejectedValue(value: T): Mock<T, Y>;
-  mockRejectedValueOnce(value: T): Mock<T, Y>;
+  mockImplementation(fn: (...args: Y) => T): this;
+  mockImplementation(fn: () => Promise<T>): this;
+  mockImplementationOnce(fn: (...args: Y) => T): this;
+  mockImplementationOnce(fn: () => Promise<T>): this;
+  mockName(name: string): this;
+  mockReturnThis(): this;
+  mockReturnValue(value: T): this;
+  mockReturnValueOnce(value: T): this;
+  mockResolvedValue(value: T): this;
+  mockResolvedValueOnce(value: T): this;
+  mockRejectedValue(value: T): this;
+  mockRejectedValueOnce(value: T): this;
 }
 
 const MOCK_CONSTRUCTOR_NAME = 'mockConstructor';

--- a/packages/jest-mock/tsconfig.json
+++ b/packages/jest-mock/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "build"
+  }
+}

--- a/packages/jest-mock/tsconfig.json
+++ b/packages/jest-mock/tsconfig.json
@@ -3,5 +3,6 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "build"
-  }
+  },
+  "references": [{"path": "../jest-types"}]
 }

--- a/packages/jest-types/src/Mocks.ts
+++ b/packages/jest-types/src/Mocks.ts
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export type MockFunctionMetadataType =
+  | 'object'
+  | 'array'
+  | 'regexp'
+  | 'function'
+  | 'constant'
+  | 'collection'
+  | 'null'
+  | 'undefined';
+
+export type MockFunctionMetadata<
+  T,
+  Y extends unknown[],
+  Type = MockFunctionMetadataType
+> = {
+  ref?: number;
+  members?: {[key: string]: MockFunctionMetadata<T, Y>};
+  mockImpl?: (...args: Y) => T;
+  name?: string;
+  refID?: number;
+  type?: Type;
+  value?: T;
+  length?: number;
+};

--- a/packages/jest-types/src/index.ts
+++ b/packages/jest-types/src/index.ts
@@ -9,5 +9,6 @@ import * as Config from './Config';
 import * as Console from './Console';
 import * as SourceMaps from './SourceMaps';
 import * as TestResult from './TestResult';
+import * as Mocks from './Mocks';
 
-export {Config, Console, SourceMaps, TestResult};
+export {Config, Console, SourceMaps, TestResult, Mocks};

--- a/packages/jest-util/src/FakeTimers.ts
+++ b/packages/jest-util/src/FakeTimers.ts
@@ -5,10 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// not yet migrated to TS
-// import {ModuleMocker} from 'jest-mock';
-
-type ModuleMocker = any;
+type ModuleMocker = typeof import('jest-mock');
 
 import {formatStackTrace, StackTraceConfig} from 'jest-message-util';
 import setGlobal from './setGlobal';
@@ -356,8 +353,10 @@ export default class FakeTimers<TimerRef> {
 
   _createMocks() {
     const fn = (impl: Function) =>
+      // @ts-ignore TODO: figure out better typings here
       this._moduleMocker.fn().mockImplementation(impl);
 
+    // TODO: add better typings; these are mocks, but typed as regular timers
     this._fakeTimerAPIs = {
       clearImmediate: fn(this._fakeClearImmediate.bind(this)),
       clearInterval: fn(this._fakeClearTimer.bind(this)),

--- a/packages/jest-util/src/FakeTimers.ts
+++ b/packages/jest-util/src/FakeTimers.ts
@@ -5,10 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-type ModuleMocker = typeof import('jest-mock');
-
+import mock from 'jest-mock';
 import {formatStackTrace, StackTraceConfig} from 'jest-message-util';
 import setGlobal from './setGlobal';
+
+type ModuleMocker = typeof mock;
 
 /**
  * We don't know the type of arguments for a callback ahead of time which is why

--- a/packages/jest-util/src/__tests__/fakeTimers.test.ts
+++ b/packages/jest-util/src/__tests__/fakeTimers.test.ts
@@ -6,9 +6,10 @@
  */
 
 import vm from 'vm';
-// @ts-ignore: not yet migrated
-import mock, {ModuleMocker} from 'jest-mock';
+import mock from 'jest-mock';
 import FakeTimers from '../FakeTimers';
+// TODO: import this type directly from jest-mock once TS migration is done
+type ModuleMocker = typeof mock;
 
 const timerConfig = {
   idToRef: (id: number) => id,

--- a/packages/jest-util/tsconfig.json
+++ b/packages/jest-util/tsconfig.json
@@ -4,5 +4,5 @@
     "rootDir": "src",
     "outDir": "build"
   },
-  "references": [{"path":  "../jest-types"}]
+  "references": [{"path": "../jest-types"}, {"path": "../jest-mock"}]
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

build/index.js

<details>

```diff
diff --git a/packages/jest-mock/build/index.js b/packages/jest-mock/build/index.js
index 76dc3630f..91ed19a0c 100644
--- a/packages/jest-mock/build/index.js
+++ b/packages/jest-mock/build/index.js
@@ -5,8 +5,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */

 /**
@@ -83,63 +81,82 @@ function matchArity(fn, length) {

   switch (length) {
     case 1:
-      mockConstructor = function mockConstructor(a) {
+      mockConstructor = function mockConstructor(_a) {
         return fn.apply(this, arguments);
       };

       break;

     case 2:
-      mockConstructor = function mockConstructor(a, b) {
+      mockConstructor = function mockConstructor(_a, _b) {
         return fn.apply(this, arguments);
       };

       break;

     case 3:
-      mockConstructor = function mockConstructor(a, b, c) {
+      mockConstructor = function mockConstructor(_a, _b, _c) {
         return fn.apply(this, arguments);
       };

       break;

     case 4:
-      mockConstructor = function mockConstructor(a, b, c, d) {
+      mockConstructor = function mockConstructor(_a, _b, _c, _d) {
         return fn.apply(this, arguments);
       };

       break;

     case 5:
-      mockConstructor = function mockConstructor(a, b, c, d, e) {
+      mockConstructor = function mockConstructor(_a, _b, _c, _d, _e) {
         return fn.apply(this, arguments);
       };

       break;

     case 6:
-      mockConstructor = function mockConstructor(a, b, c, d, e, f) {
+      mockConstructor = function mockConstructor(_a, _b, _c, _d, _e, _f) {
         return fn.apply(this, arguments);
       };

       break;

     case 7:
-      mockConstructor = function mockConstructor(a, b, c, d, e, f, g) {
+      mockConstructor = function mockConstructor(_a, _b, _c, _d, _e, _f, _g) {
         return fn.apply(this, arguments);
       };

       break;

     case 8:
-      mockConstructor = function mockConstructor(a, b, c, d, e, f, g, h) {
+      mockConstructor = function mockConstructor(
+        _a,
+        _b,
+        _c,
+        _d,
+        _e,
+        _f,
+        _g,
+        _h
+      ) {
         return fn.apply(this, arguments);
       };

       break;

     case 9:
-      mockConstructor = function mockConstructor(a, b, c, d, e, f, g, h, i) {
+      mockConstructor = function mockConstructor(
+        _a,
+        _b,
+        _c,
+        _d,
+        _e,
+        _f,
+        _g,
+        _h,
+        _i
+      ) {
         return fn.apply(this, arguments);
       };

@@ -271,7 +288,7 @@ class ModuleMockerClass {
         const prop = ownNames[i];

         if (!isReadonlyProp(object, prop)) {
-          const propDesc = Object.getOwnPropertyDescriptor(object, prop);
+          const propDesc = Object.getOwnPropertyDescriptor(object, prop); // @ts-ignore Object.__esModule

           if ((propDesc !== undefined && !propDesc.get) || object.__esModule) {
             slots.add(prop);
@@ -344,10 +361,7 @@ class ModuleMockerClass {
     ) {
       return metadata.value;
     } else if (metadata.type === 'function') {
-      /* eslint-disable prefer-const */
       let f;
-      /* eslint-enable prefer-const */
-
       const prototype =
         (metadata.members &&
           metadata.members.prototype &&
@@ -357,13 +371,13 @@ class ModuleMockerClass {
       const prototypeSlots = this._getSlots(prototype);

       const mocker = this;
-      const mockConstructor = matchArity(function() {
+      const mockConstructor = matchArity(function(...args) {
         const mockState = mocker._ensureMockState(f);

         const mockConfig = mocker._ensureMockConfig(f);

         mockState.instances.push(this);
-        mockState.calls.push(Array.prototype.slice.call(arguments)); // Create and record an "incomplete" mock result immediately upon
+        mockState.calls.push(args); // Create and record an "incomplete" mock result immediately upon
         // calling rather than waiting for the mock to return. This avoids
         // issues caused by recursion where results can be recorded in the
         // wrong order.
@@ -396,8 +410,11 @@ class ModuleMockerClass {
                 // it easier to interact with mock instance call and
                 // return values
                 if (prototype[slot].type === 'function') {
-                  const protoImpl = this[slot];
-                  this[slot] = mocker.generateFromMetadata(prototype[slot]);
+                  // @ts-ignore no index signature
+                  const protoImpl = this[slot]; // @ts-ignore no index signature
+
+                  this[slot] = mocker.generateFromMetadata(prototype[slot]); // @ts-ignore no index signature
+
                   this[slot]._protoImpl = protoImpl;
                 }
               }); // Run the mock constructor implementation
@@ -471,7 +488,7 @@ class ModuleMockerClass {

       this._mockState.set(f, this._defaultMockState());

-      this._mockConfigRegistry.set(f, this._defaultMockConfig()); // $FlowFixMe - defineProperty getters not supported
+      this._mockConfigRegistry.set(f, this._defaultMockConfig());

       Object.defineProperty(f, 'mock', {
         configurable: false,
@@ -634,6 +651,9 @@ class ModuleMockerClass {
   }

   _generateMock(metadata, callbacks, refs) {
+    // metadata not compatible but it's the same type, maybe problem with
+    // overloading of _makeComponent and not _generateMock?
+    // @ts-ignore
     const mock = this._makeComponent(metadata);

     if (metadata.refID != null) {
@@ -644,7 +664,11 @@ class ModuleMockerClass {
       const slotMetadata = (metadata.members && metadata.members[slot]) || {};

       if (slotMetadata.ref != null) {
-        callbacks.push(() => (mock[slot] = refs[slotMetadata.ref]));
+        callbacks.push(
+          (function(ref) {
+            return () => (mock[slot] = refs[ref]);
+          })(slotMetadata.ref)
+        );
       } else {
         mock[slot] = this._generateMock(slotMetadata, callbacks, refs);
       }
@@ -709,9 +733,11 @@ class ModuleMockerClass {
       metadata.value = component;
       return metadata;
     } else if (type === 'function') {
-      metadata.name = component.name;
+      // @ts-ignore this is a function so it has a name
+      metadata.name = component.name; // @ts-ignore may be a mock

       if (component._isMockFunction === true) {
+        // @ts-ignore may be a mock
         metadata.mockImpl = component.getMockImplementation();
       }
     }
@@ -721,15 +747,14 @@ class ModuleMockerClass {
     let members = null; // Leave arrays alone

     if (type !== 'array') {
-      if (type !== 'undefined') {
       this._getSlots(component).forEach(slot => {
         if (
-            type === 'function' &&
+          type === 'function' && // @ts-ignore may be a mock
           component._isMockFunction === true &&
           slot.match(/^mock/)
         ) {
           return;
-          }
+        } // @ts-ignore no index signature

         const slotMetadata = this.getMetadata(component[slot], refs);

@@ -742,7 +767,6 @@ class ModuleMockerClass {
         }
       });
     }
-    }

     if (members) {
       metadata.members = members;
@@ -792,7 +816,7 @@ class ModuleMockerClass {
             this._typeOf(original) +
             ' given instead'
         );
-      }
+      } // @ts-ignore overriding original method with a Mock

       object[methodName] = this._makeComponent(
         {
@@ -801,7 +825,8 @@ class ModuleMockerClass {
         () => {
           object[methodName] = original;
         }
-      );
+      ); // @ts-ignore original method is now a Mock
+
       object[methodName].mockImplementation(function() {
         return original.apply(this, arguments);
       });
@@ -867,13 +894,12 @@ class ModuleMockerClass {
           type: 'function'
         },
         () => {
-          // $FlowFixMe
-          descriptor[accessType] = original; // $FlowFixMe
-
+          descriptor[accessType] = original;
           Object.defineProperty(obj, propertyName, descriptor);
         }
       );
       descriptor[accessType].mockImplementation(function() {
+        // @ts-ignore
         return original.apply(this, arguments);
       });
     }
@@ -900,6 +926,7 @@ class ModuleMockerClass {
   _typeOf(value) {
     return value == null ? '' + value : typeof value;
   }
-}
+} // TODO: bring this type export back once done with TS migration
+// export type ModuleMocker = ModuleMockerClass;

 module.exports = new ModuleMockerClass(global);

```

</details>


build-es5/index.js

<details>

```diff
diff --git a/packages/jest-mock/build-es5/index.js b/packages/jest-mock/build-es5/index.js
index eea6b7758..34d7668e1 100644
--- a/packages/jest-mock/build-es5/index.js
+++ b/packages/jest-mock/build-es5/index.js
@@ -91,7 +91,7 @@ return /******/ (function(modules) { // webpackBootstrap
 /******/
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(__webpack_require__.s = "./packages/jest-mock/src/index.js");
+/******/ 	return __webpack_require__(__webpack_require__.s = "./packages/jest-mock/src/index.ts");
 /******/ })
 /************************************************************************/
 /******/ ({
@@ -129,9 +129,9 @@ module.exports = g;

 /***/ }),

-/***/ "./packages/jest-mock/src/index.js":
+/***/ "./packages/jest-mock/src/index.ts":
 /*!*****************************************!*\
-  !*** ./packages/jest-mock/src/index.js ***!
+  !*** ./packages/jest-mock/src/index.ts ***!
   \*****************************************/
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
@@ -152,8 +152,6 @@ function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _d
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */

 /**
@@ -178,63 +176,63 @@ function matchArity(fn, length) {

   switch (length) {
     case 1:
-      mockConstructor = function mockConstructor(a) {
+      mockConstructor = function mockConstructor(_a) {
         return fn.apply(this, arguments);
       };

       break;

     case 2:
-      mockConstructor = function mockConstructor(a, b) {
+      mockConstructor = function mockConstructor(_a, _b) {
         return fn.apply(this, arguments);
       };

       break;

     case 3:
-      mockConstructor = function mockConstructor(a, b, c) {
+      mockConstructor = function mockConstructor(_a, _b, _c) {
         return fn.apply(this, arguments);
       };

       break;

     case 4:
-      mockConstructor = function mockConstructor(a, b, c, d) {
+      mockConstructor = function mockConstructor(_a, _b, _c, _d) {
         return fn.apply(this, arguments);
       };

       break;

     case 5:
-      mockConstructor = function mockConstructor(a, b, c, d, e) {
+      mockConstructor = function mockConstructor(_a, _b, _c, _d, _e) {
         return fn.apply(this, arguments);
       };

       break;

     case 6:
-      mockConstructor = function mockConstructor(a, b, c, d, e, f) {
+      mockConstructor = function mockConstructor(_a, _b, _c, _d, _e, _f) {
         return fn.apply(this, arguments);
       };

       break;

     case 7:
-      mockConstructor = function mockConstructor(a, b, c, d, e, f, g) {
+      mockConstructor = function mockConstructor(_a, _b, _c, _d, _e, _f, _g) {
         return fn.apply(this, arguments);
       };

       break;

     case 8:
-      mockConstructor = function mockConstructor(a, b, c, d, e, f, g, h) {
+      mockConstructor = function mockConstructor(_a, _b, _c, _d, _e, _f, _g, _h) {
         return fn.apply(this, arguments);
       };

       break;

     case 9:
-      mockConstructor = function mockConstructor(a, b, c, d, e, f, g, h, i) {
+      mockConstructor = function mockConstructor(_a, _b, _c, _d, _e, _f, _g, _h, _i) {
         return fn.apply(this, arguments);
       };

@@ -336,7 +334,7 @@ function () {
           var prop = ownNames[i];

           if (!isReadonlyProp(object, prop)) {
-            var propDesc = Object.getOwnPropertyDescriptor(object, prop);
+            var propDesc = Object.getOwnPropertyDescriptor(object, prop); // @ts-ignore Object.__esModule

             if (propDesc !== undefined && !propDesc.get || object.__esModule) {
               slots.add(prop);
@@ -411,10 +409,7 @@ function () {
       } else if (metadata.type === 'constant' || metadata.type === 'collection' || metadata.type === 'null' || metadata.type === 'undefined') {
         return metadata.value;
       } else if (metadata.type === 'function') {
-        /* eslint-disable prefer-const */
         var f;
-        /* eslint-enable prefer-const */
-
         var prototype = metadata.members && metadata.members.prototype && metadata.members.prototype.members || {};

         var prototypeSlots = this._getSlots(prototype);
@@ -424,12 +419,16 @@ function () {
           var _this = this,
               _arguments = arguments;

+          for (var _len = arguments.length, args = new Array(_len), _key = 0; _key < _len; _key++) {
+            args[_key] = arguments[_key];
+          }
+
           var mockState = mocker._ensureMockState(f);

           var mockConfig = mocker._ensureMockConfig(f);

           mockState.instances.push(this);
-          mockState.calls.push(Array.prototype.slice.call(arguments)); // Create and record an "incomplete" mock result immediately upon
+          mockState.calls.push(args); // Create and record an "incomplete" mock result immediately upon
           // calling rather than waiting for the mock to return. This avoids
           // issues caused by recursion where results can be recorded in the
           // wrong order.
@@ -462,14 +461,18 @@ function () {
                   // it easier to interact with mock instance call and
                   // return values
                   if (prototype[slot].type === 'function') {
-                    var protoImpl = _this[slot];
-                    _this[slot] = mocker.generateFromMetadata(prototype[slot]);
+                    // @ts-ignore
+                    var protoImpl = _this[slot]; // @ts-ignore
+
+                    _this[slot] = mocker.generateFromMetadata(prototype[slot]); // @ts-ignore
+
                     _this[slot]._protoImpl = protoImpl;
                   }
                 }); // Run the mock constructor implementation

-                var mockImpl = mockConfig.specificMockImpls.length ? mockConfig.specificMockImpls.shift() : mockConfig.mockImpl;
-                return mockImpl && mockImpl.apply(_this, _arguments);
+                var _mockImpl = mockConfig.specificMockImpls.length ? mockConfig.specificMockImpls.shift() : mockConfig.mockImpl;
+
+                return _mockImpl && _mockImpl.apply(_this, _arguments);
               }

               var returnValue = mockConfig.defaultReturnValue; // If return value is last set, either specific or default, i.e.
@@ -539,8 +542,7 @@ function () {

         this._mockState.set(f, this._defaultMockState());

-        this._mockConfigRegistry.set(f, this._defaultMockConfig()); // $FlowFixMe - defineProperty getters not supported
-
+        this._mockConfigRegistry.set(f, this._defaultMockConfig());

         Object.defineProperty(f, 'mock', {
           configurable: false,
@@ -714,6 +716,7 @@ function () {
     value: function _generateMock(metadata, callbacks, refs) {
       var _this3 = this;

+      // @ts-ignore
       var mock = this._makeComponent(metadata);

       if (metadata.refID != null) {
@@ -724,9 +727,11 @@ function () {
         var slotMetadata = metadata.members && metadata.members[slot] || {};

         if (slotMetadata.ref != null) {
-          callbacks.push(function () {
-            return mock[slot] = refs[slotMetadata.ref];
-          });
+          callbacks.push(function (ref) {
+            return function () {
+              return mock[slot] = refs[ref];
+            };
+          }(slotMetadata.ref));
         } else {
           mock[slot] = _this3._generateMock(slotMetadata, callbacks, refs);
         }
@@ -790,9 +795,11 @@ function () {
         metadata.value = component;
         return metadata;
       } else if (type === 'function') {
-        metadata.name = component.name;
+        // @ts-ignore this is a function so it has a name
+        metadata.name = component.name; // @ts-ignore may be a mock

         if (component._isMockFunction === true) {
+          // @ts-ignore may be a mock
           metadata.mockImpl = component.getMockImplementation();
         }
       }
@@ -802,11 +809,12 @@ function () {
       var members = null; // Leave arrays alone

       if (type !== 'array') {
-        if (type !== 'undefined') {
         this._getSlots(component).forEach(function (slot) {
-            if (type === 'function' && component._isMockFunction === true && slot.match(/^mock/)) {
+          if (type === 'function' && // @ts-ignore may be a mock
+          component._isMockFunction === true && slot.match(/^mock/)) {
             return;
-            }
+          } // @ts-ignore implicit 'any' type because type '{}' has no index signature
+

           var slotMetadata = _this4.getMetadata(component[slot], refs);

@@ -819,7 +827,6 @@ function () {
           }
         });
       }
-      }

       if (members) {
         metadata.members = members;
@@ -864,13 +871,15 @@ function () {
       if (!this.isMockFunction(original)) {
         if (typeof original !== 'function') {
           throw new Error('Cannot spy the ' + methodName + ' property because it is not a function; ' + this._typeOf(original) + ' given instead');
-        }
+        } // @ts-ignore overriding original method with a Mock
+

         object[methodName] = this._makeComponent({
           type: 'function'
         }, function () {
           object[methodName] = original;
-        });
+        }); // @ts-ignore original method is now a Mock
+
         object[methodName].mockImplementation(function () {
           return original.apply(this, arguments);
         });
@@ -925,12 +934,15 @@ function () {
         descriptor[accessType] = this._makeComponent({
           type: 'function'
         }, function () {
-          // $FlowFixMe
-          descriptor[accessType] = original; // $FlowFixMe
+          if (!descriptor) {
+            return;
+          }

+          descriptor[accessType] = original;
           Object.defineProperty(obj, propertyName, descriptor);
         });
         descriptor[accessType].mockImplementation(function () {
+          // @ts-ignore
           return original.apply(this, arguments);
         });
       }
```

</details>

## Test plan

Green CI 