### PR TITLE
chore: migrate jest-worker to TypeScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - `[jest-util]`: Migrate to TypeScript ([#7844](https://github.com/facebook/jest/pull/7844))
 - `[jest-watcher]`: Migrate to TypeScript ([#7843](https://github.com/facebook/jest/pull/7843))
 - `[jest-mock]`: Migrate to TypeScript ([#7847](https://github.com/facebook/jest/pull/7847), [#7850](https://github.com/facebook/jest/pull/7850))
+- `[jest-worker]`: Migrate to TypeScript ([#7853](https://github.com/facebook/jest/pull/7853))
 
 ### Performance
 

--- a/packages/jest-cli/src/reporters/coverage_reporter.js
+++ b/packages/jest-cli/src/reporters/coverage_reporter.js
@@ -159,7 +159,6 @@ export default class CoverageReporter extends BaseReporter {
     if (this._globalConfig.maxWorkers <= 1) {
       worker = require('./coverage_worker');
     } else {
-      // $FlowFixMe: assignment of a worker with custom properties.
       worker = new Worker(require.resolve('./coverage_worker'), {
         exposedMethods: ['worker'],
         maxRetries: 2,

--- a/packages/jest-haste-map/src/index.js
+++ b/packages/jest-haste-map/src/index.js
@@ -670,7 +670,6 @@ class HasteMap extends EventEmitter {
       if ((options && options.forceInBand) || this._options.maxWorkers <= 1) {
         this._worker = {getSha1, worker};
       } else {
-        // $FlowFixMe: assignment of a worker with custom properties.
         this._worker = (new Worker(require.resolve('./worker'), {
           exposedMethods: ['getSha1', 'worker'],
           maxRetries: 3,

--- a/packages/jest-runner/src/index.js
+++ b/packages/jest-runner/src/index.js
@@ -98,7 +98,6 @@ class TestRunner {
     onResult: OnTestSuccess,
     onFailure: OnTestFailure,
   ) {
-    // $FlowFixMe: class object is augmented with worker when instantiating.
     const worker: WorkerInterface = new Worker(TEST_WORKER_PATH, {
       exposedMethods: ['worker'],
       forkOptions: {stdio: 'pipe'},

--- a/packages/jest-worker/package.json
+++ b/packages/jest-worker/package.json
@@ -8,7 +8,9 @@
   },
   "license": "MIT",
   "main": "build/index.js",
+  "types": "build/index.d.ts",
   "dependencies": {
+    "@types/node": "*",
     "merge-stream": "^1.0.1",
     "supports-color": "^6.1.0"
   },

--- a/packages/jest-worker/src/WorkerPool.ts
+++ b/packages/jest-worker/src/WorkerPool.ts
@@ -3,15 +3,11 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- * @flow
  */
-
-'use strict';
 
 import BaseWorkerPool from './base/BaseWorkerPool';
 
-import type {
+import {
   ChildMessage,
   WorkerOptions,
   OnStart,

--- a/packages/jest-worker/src/base/BaseWorkerPool.ts
+++ b/packages/jest-worker/src/base/BaseWorkerPool.ts
@@ -3,26 +3,24 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- * @flow
  */
 
-'use strict';
-
-import mergeStream from 'merge-stream';
 import path from 'path';
+import mergeStream from 'merge-stream';
 
-import {CHILD_MESSAGE_END} from '../types';
-
-import type {Readable} from 'stream';
-import type {WorkerPoolOptions, WorkerOptions, WorkerInterface} from '../types';
+import {
+  CHILD_MESSAGE_END,
+  WorkerPoolOptions,
+  WorkerOptions,
+  WorkerInterface,
+} from '../types';
 
 /* istanbul ignore next */
 const emptyMethod = () => {};
 
 export default class BaseWorkerPool {
-  _stderr: Readable;
-  _stdout: Readable;
+  _stderr: NodeJS.ReadableStream;
+  _stdout: NodeJS.ReadableStream;
   _options: WorkerPoolOptions;
   _workers: Array<WorkerInterface>;
 
@@ -67,11 +65,11 @@ export default class BaseWorkerPool {
     this._stderr = stderr;
   }
 
-  getStderr(): Readable {
+  getStderr(): NodeJS.ReadableStream {
     return this._stderr;
   }
 
-  getStdout(): Readable {
+  getStdout(): NodeJS.ReadableStream {
     return this._stdout;
   }
 
@@ -83,7 +81,7 @@ export default class BaseWorkerPool {
     return this._workers[workerId];
   }
 
-  createWorker(workerOptions: WorkerOptions): WorkerInterface {
+  createWorker(_workerOptions: WorkerOptions): WorkerInterface {
     throw Error('Missing method createWorker in WorkerPool');
   }
 

--- a/packages/jest-worker/src/types.ts
+++ b/packages/jest-worker/src/types.ts
@@ -148,7 +148,7 @@ export type ParentMessage = ParentMessageOk | ParentMessageError;
 
 // Queue types.
 export type OnStart = (worker: WorkerInterface) => void;
-export type OnEnd = (err: Error | null, result: unknown | undefined) => void;
+export type OnEnd = (err: Error | null, result: unknown) => void;
 
 export type QueueChildMessage = {
   request: ChildMessage;

--- a/packages/jest-worker/src/types.ts
+++ b/packages/jest-worker/src/types.ts
@@ -3,15 +3,11 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- * @flow
  */
-
-'use strict';
 
 // Because of the dynamic nature of a worker communication process, all messages
 // coming from any of the other processes cannot be typed. Thus, many types
-// include "any" as a flow type, which is (unfortunately) correct here.
+// include "unknown" as a TS type, which is (unfortunately) correct here.
 
 export const CHILD_MESSAGE_INITIALIZE: 0 = 0;
 export const CHILD_MESSAGE_CALL: 1 = 1;
@@ -27,98 +23,105 @@ export type PARENT_MESSAGE_ERROR =
 
 // Option objects.
 
-import type {Readable} from 'stream';
 const EventEmitter = require('events');
 
 export type ForkOptions = {
-  cwd?: string,
-  env?: Object,
-  execPath?: string,
-  execArgv?: Array<string>,
-  silent?: boolean,
-  stdio?: Array<any>,
-  uid?: number,
-  gid?: number,
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  execPath?: string;
+  execArgv?: Array<string>;
+  silent?: boolean;
+  stdio?: Array<any>;
+  uid?: number;
+  gid?: number;
 };
 
 export interface WorkerPoolInterface {
-  getStderr(): Readable;
-  getStdout(): Readable;
+  getStderr(): NodeJS.ReadableStream;
+  getStdout(): NodeJS.ReadableStream;
   getWorkers(): Array<WorkerInterface>;
-  createWorker(WorkerOptions): WorkerInterface;
-  send(number, ChildMessage, Function, Function): void;
+  createWorker(options: WorkerOptions): WorkerInterface;
+  send(
+    workerId: number,
+    request: ChildMessage,
+    onStart: OnStart,
+    onEnd: OnEnd,
+  ): void;
   end(): void;
 }
 
 export interface WorkerInterface {
-  send(ChildMessage, Function, Function): void;
+  send(
+    request: ChildMessage,
+    onProcessStart: OnStart,
+    onProcessEnd: OnEnd,
+  ): void;
   getWorkerId(): number;
-  getStderr(): Readable;
-  getStdout(): Readable;
-  onExit(number): void;
-  onMessage(any): void;
+  getStderr(): NodeJS.ReadableStream;
+  getStdout(): NodeJS.ReadableStream;
+  onExit(exitCode: number): void;
+  onMessage(message: ParentMessage): void;
 }
 
 export type FarmOptions = {
-  computeWorkerKey?: (string, ...Array<any>) => ?string,
-  exposedMethods?: $ReadOnlyArray<string>,
-  forkOptions?: ForkOptions,
-  setupArgs?: Array<mixed>,
-  maxRetries?: number,
-  numWorkers?: number,
+  computeWorkerKey?: (method: string, ...args: Array<unknown>) => string | null;
+  exposedMethods?: ReadonlyArray<string>;
+  forkOptions?: ForkOptions;
+  setupArgs?: Array<unknown>;
+  maxRetries?: number;
+  numWorkers?: number;
   WorkerPool?: (
     workerPath: string,
     options?: WorkerPoolOptions,
-  ) => WorkerPoolInterface,
-  enableWorkerThreads?: boolean,
+  ) => WorkerPoolInterface;
+  enableWorkerThreads?: boolean;
 };
 
-export type WorkerPoolOptions = {|
-  setupArgs: Array<mixed>,
-  forkOptions: ForkOptions,
-  maxRetries: number,
-  numWorkers: number,
-  enableWorkerThreads: boolean,
-|};
+export type WorkerPoolOptions = {
+  setupArgs: Array<unknown>;
+  forkOptions: ForkOptions;
+  maxRetries: number;
+  numWorkers: number;
+  enableWorkerThreads: boolean;
+};
 
-export type WorkerOptions = {|
-  forkOptions: ForkOptions,
-  setupArgs: Array<mixed>,
-  maxRetries: number,
-  workerId: number,
-  workerPath: string,
-|};
+export type WorkerOptions = {
+  forkOptions: ForkOptions;
+  setupArgs: Array<unknown>;
+  maxRetries: number;
+  workerId: number;
+  workerPath: string;
+};
 
 // Messages passed from the parent to the children.
 
-export type MessagePort = {
-  ...typeof EventEmitter,
-  postMessage(any): void,
+export type MessagePort = typeof EventEmitter & {
+  postMessage(message: unknown): void;
 };
 
 export type MessageChannel = {
-  port1: MessagePort,
-  port2: MessagePort,
+  port1: MessagePort;
+  port2: MessagePort;
 };
 
 export type ChildMessageInitialize = [
   typeof CHILD_MESSAGE_INITIALIZE, // type
   boolean, // processed
   string, // file
-  ?Array<mixed>, // setupArgs
-  ?MessagePort, // MessagePort
+  Array<unknown> | undefined, // setupArgs
+  MessagePort | undefined // MessagePort
 ];
 
 export type ChildMessageCall = [
   typeof CHILD_MESSAGE_CALL, // type
   boolean, // processed
   string, // method
-  $ReadOnlyArray<any>, // args
+  Array<unknown> // args
 ];
 
 export type ChildMessageEnd = [
   typeof CHILD_MESSAGE_END, // type
-  boolean, // processed
+  boolean // processed
 ];
 
 export type ChildMessage =
@@ -130,7 +133,7 @@ export type ChildMessage =
 
 export type ParentMessageOk = [
   typeof PARENT_MESSAGE_OK, // type
-  any, // result
+  unknown // result
 ];
 
 export type ParentMessageError = [
@@ -138,18 +141,18 @@ export type ParentMessageError = [
   string, // constructor
   string, // message
   string, // stack
-  any, // extra
+  unknown // extra
 ];
 
 export type ParentMessage = ParentMessageOk | ParentMessageError;
 
 // Queue types.
-export type OnStart = WorkerInterface => void;
-export type OnEnd = (?Error, ?any) => void;
+export type OnStart = (worker: WorkerInterface) => void;
+export type OnEnd = (err: Error | null, result: unknown | undefined) => void;
 
-export type QueueChildMessage = {|
-  request: ChildMessage,
-  onStart: OnStart,
-  onEnd: OnEnd,
-  next?: QueueChildMessage,
-|};
+export type QueueChildMessage = {
+  request: ChildMessage;
+  onStart: OnStart;
+  onEnd: OnEnd;
+  next?: QueueChildMessage;
+};

--- a/packages/jest-worker/src/workers/ChildProcessWorker.ts
+++ b/packages/jest-worker/src/workers/ChildProcessWorker.ts
@@ -3,38 +3,47 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- * @flow
  */
 
-'use strict';
+import childProcess, {ChildProcess} from 'child_process';
+import supportsColor from 'supports-color';
 
 import {
   CHILD_MESSAGE_INITIALIZE,
-  PARENT_MESSAGE_OK,
   PARENT_MESSAGE_CLIENT_ERROR,
   PARENT_MESSAGE_SETUP_ERROR,
-} from '../types';
-
-import path from 'path';
-
-import type {Readable} from 'stream';
-import type {
+  PARENT_MESSAGE_OK,
+  WorkerInterface,
   ChildMessage,
   OnEnd,
   OnStart,
   WorkerOptions,
-  WorkerInterface,
+  ParentMessage,
 } from '../types';
 
-// $FlowFixMe: Flow doesn't know about experimental features of Node
-const {Worker} = require('worker_threads');
-
-export default class ExperimentalWorker implements WorkerInterface {
-  _worker: Worker;
+/**
+ * This class wraps the child process and provides a nice interface to
+ * communicate with. It takes care of:
+ *
+ *  - Re-spawning the process if it dies.
+ *  - Queues calls while the worker is busy.
+ *  - Re-sends the requests if the worker blew up.
+ *
+ * The reason for queueing them here (since childProcess.send also has an
+ * internal queue) is because the worker could be doing asynchronous work, and
+ * this would lead to the child process to read its receiving buffer and start a
+ * second call. By queueing calls here, we don't send the next call to the
+ * children until we receive the result of the previous one.
+ *
+ * As soon as a request starts to be processed by a worker, its "processed"
+ * field is changed to "true", so that other workers which might encounter the
+ * same call skip it.
+ */
+export default class ChildProcessWorker implements WorkerInterface {
+  _child!: ChildProcess;
   _options: WorkerOptions;
-  _onProcessEnd: OnEnd;
-  _retries: number;
+  _onProcessEnd!: OnEnd;
+  _retries!: number;
 
   constructor(options: WorkerOptions) {
     this._options = options;
@@ -42,30 +51,31 @@ export default class ExperimentalWorker implements WorkerInterface {
   }
 
   initialize() {
-    this._worker = new Worker(path.resolve(__dirname, './threadChild.js'), {
-      eval: false,
-      stderr: true,
-      stdout: true,
-      workerData: {
-        cwd: process.cwd(),
-        env: {...process.env, JEST_WORKER_ID: this._options.workerId},
-        // Suppress --debug / --inspect flags while preserving others (like --harmony).
-        execArgv: process.execArgv.filter(v => !/^--(debug|inspect)/.test(v)),
-        silent: true,
-        ...this._options.forkOptions,
-      },
+    const forceColor = supportsColor.stdout ? {FORCE_COLOR: '1'} : {};
+    const child = childProcess.fork(require.resolve('./processChild'), [], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        JEST_WORKER_ID: String(this._options.workerId),
+        ...forceColor,
+      } as NodeJS.ProcessEnv,
+      // Suppress --debug / --inspect flags while preserving others (like --harmony).
+      execArgv: process.execArgv.filter(v => !/^--(debug|inspect)/.test(v)),
+      silent: true,
+      ...this._options.forkOptions,
     });
 
-    this._worker.on('message', this.onMessage.bind(this));
-    this._worker.on('exit', this.onExit.bind(this));
+    child.on('message', this.onMessage.bind(this));
+    child.on('exit', this.onExit.bind(this));
 
-    this._worker.postMessage([
+    child.send([
       CHILD_MESSAGE_INITIALIZE,
       false,
       this._options.workerPath,
       this._options.setupArgs,
     ]);
 
+    this._child = child;
     this._retries++;
 
     // If we exceeded the amount of retries, we will emulate an error reply
@@ -78,13 +88,13 @@ export default class ExperimentalWorker implements WorkerInterface {
         PARENT_MESSAGE_CLIENT_ERROR,
         error.name,
         error.message,
-        error.stack,
+        error.stack!,
         {type: 'WorkerError'},
       ]);
     }
   }
 
-  onMessage(response: any /* Should be ParentMessage */) {
+  onMessage(response: ParentMessage) {
     let error;
 
     switch (response[0]) {
@@ -97,31 +107,33 @@ export default class ExperimentalWorker implements WorkerInterface {
 
         if (error != null && typeof error === 'object') {
           const extra = error;
+          // @ts-ignore: no index
           const NativeCtor = global[response[1]];
           const Ctor = typeof NativeCtor === 'function' ? NativeCtor : Error;
 
           error = new Ctor(response[2]);
-          // $FlowFixMe: adding custom properties to errors.
           error.type = response[1];
           error.stack = response[3];
 
           for (const key in extra) {
-            // $FlowFixMe: adding custom properties to errors.
+            // @ts-ignore: adding custom properties to errors.
             error[key] = extra[key];
           }
         }
 
         this._onProcessEnd(error, null);
         break;
+
       case PARENT_MESSAGE_SETUP_ERROR:
         error = new Error('Error when calling setup: ' + response[2]);
 
-        // $FlowFixMe: adding custom properties to errors.
+        // @ts-ignore: adding custom properties to errors.
         error.type = response[1];
         error.stack = response[3];
 
         this._onProcessEnd(error, null);
         break;
+
       default:
         throw new TypeError('Unexpected response from worker: ' + response[0]);
     }
@@ -138,19 +150,18 @@ export default class ExperimentalWorker implements WorkerInterface {
     this._onProcessEnd = onProcessEnd;
 
     this._retries = 0;
-
-    this._worker.postMessage(request);
+    this._child.send(request);
   }
 
   getWorkerId(): number {
     return this._options.workerId;
   }
 
-  getStdout(): Readable {
-    return this._worker.stdout;
+  getStdout(): NodeJS.ReadableStream {
+    return this._child.stdout;
   }
 
-  getStderr(): Readable {
-    return this._worker.stderr;
+  getStderr(): NodeJS.ReadableStream {
+    return this._child.stderr;
   }
 }

--- a/packages/jest-worker/src/workers/NodeThreadsWorker.ts
+++ b/packages/jest-worker/src/workers/NodeThreadsWorker.ts
@@ -3,52 +3,31 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- * @flow
  */
 
-'use strict';
-
-import childProcess from 'child_process';
+import path from 'path';
+// ESLint doesn't know about this experimental module
+// eslint-disable-next-line import/no-unresolved
+import {Worker} from 'worker_threads';
 
 import {
   CHILD_MESSAGE_INITIALIZE,
+  PARENT_MESSAGE_OK,
   PARENT_MESSAGE_CLIENT_ERROR,
   PARENT_MESSAGE_SETUP_ERROR,
-  PARENT_MESSAGE_OK,
+  ChildMessage,
+  OnEnd,
+  OnStart,
+  WorkerOptions,
   WorkerInterface,
+  ParentMessage,
 } from '../types';
 
-import type {ChildProcess} from 'child_process';
-import type {Readable} from 'stream';
-
-import type {ChildMessage, OnEnd, OnStart, WorkerOptions} from '../types';
-
-import supportsColor from 'supports-color';
-
-/**
- * This class wraps the child process and provides a nice interface to
- * communicate with. It takes care of:
- *
- *  - Re-spawning the process if it dies.
- *  - Queues calls while the worker is busy.
- *  - Re-sends the requests if the worker blew up.
- *
- * The reason for queueing them here (since childProcess.send also has an
- * internal queue) is because the worker could be doing asynchronous work, and
- * this would lead to the child process to read its receiving buffer and start a
- * second call. By queueing calls here, we don't send the next call to the
- * children until we receive the result of the previous one.
- *
- * As soon as a request starts to be processed by a worker, its "processed"
- * field is changed to "true", so that other workers which might encounter the
- * same call skip it.
- */
-export default class ChildProcessWorker implements WorkerInterface {
-  _child: ChildProcess;
+export default class ExperimentalWorker implements WorkerInterface {
+  _worker!: Worker;
   _options: WorkerOptions;
-  _onProcessEnd: OnEnd;
-  _retries: number;
+  _onProcessEnd!: OnEnd;
+  _retries!: number;
 
   constructor(options: WorkerOptions) {
     this._options = options;
@@ -56,31 +35,33 @@ export default class ChildProcessWorker implements WorkerInterface {
   }
 
   initialize() {
-    const forceColor = supportsColor.stdout ? {FORCE_COLOR: '1'} : {};
-    const child = childProcess.fork(require.resolve('./processChild'), {
-      cwd: process.cwd(),
-      env: {
-        ...process.env,
-        JEST_WORKER_ID: this._options.workerId,
-        ...forceColor,
+    this._worker = new Worker(path.resolve(__dirname, './threadChild.js'), {
+      eval: false,
+      stderr: true,
+      stdout: true,
+      workerData: {
+        cwd: process.cwd(),
+        env: {
+          ...process.env,
+          JEST_WORKER_ID: String(this._options.workerId),
+        } as NodeJS.ProcessEnv,
+        // Suppress --debug / --inspect flags while preserving others (like --harmony).
+        execArgv: process.execArgv.filter(v => !/^--(debug|inspect)/.test(v)),
+        silent: true,
+        ...this._options.forkOptions,
       },
-      // Suppress --debug / --inspect flags while preserving others (like --harmony).
-      execArgv: process.execArgv.filter(v => !/^--(debug|inspect)/.test(v)),
-      silent: true,
-      ...this._options.forkOptions,
     });
 
-    child.on('message', this.onMessage.bind(this));
-    child.on('exit', this.onExit.bind(this));
+    this._worker.on('message', this.onMessage.bind(this));
+    this._worker.on('exit', this.onExit.bind(this));
 
-    child.send([
+    this._worker.postMessage([
       CHILD_MESSAGE_INITIALIZE,
       false,
       this._options.workerPath,
       this._options.setupArgs,
     ]);
 
-    this._child = child;
     this._retries++;
 
     // If we exceeded the amount of retries, we will emulate an error reply
@@ -93,13 +74,13 @@ export default class ChildProcessWorker implements WorkerInterface {
         PARENT_MESSAGE_CLIENT_ERROR,
         error.name,
         error.message,
-        error.stack,
+        error.stack!,
         {type: 'WorkerError'},
       ]);
     }
   }
 
-  onMessage(response: any /* Should be ParentMessage */) {
+  onMessage(response: ParentMessage) {
     let error;
 
     switch (response[0]) {
@@ -112,33 +93,31 @@ export default class ChildProcessWorker implements WorkerInterface {
 
         if (error != null && typeof error === 'object') {
           const extra = error;
+          // @ts-ignore: no index
           const NativeCtor = global[response[1]];
           const Ctor = typeof NativeCtor === 'function' ? NativeCtor : Error;
 
           error = new Ctor(response[2]);
-          // $FlowFixMe: adding custom properties to errors.
           error.type = response[1];
           error.stack = response[3];
 
           for (const key in extra) {
-            // $FlowFixMe: adding custom properties to errors.
+            // @ts-ignore: no index
             error[key] = extra[key];
           }
         }
 
         this._onProcessEnd(error, null);
         break;
-
       case PARENT_MESSAGE_SETUP_ERROR:
         error = new Error('Error when calling setup: ' + response[2]);
 
-        // $FlowFixMe: adding custom properties to errors.
+        // @ts-ignore: adding custom properties to errors.
         error.type = response[1];
         error.stack = response[3];
 
         this._onProcessEnd(error, null);
         break;
-
       default:
         throw new TypeError('Unexpected response from worker: ' + response[0]);
     }
@@ -155,18 +134,19 @@ export default class ChildProcessWorker implements WorkerInterface {
     this._onProcessEnd = onProcessEnd;
 
     this._retries = 0;
-    this._child.send(request);
+
+    this._worker.postMessage(request);
   }
 
   getWorkerId(): number {
     return this._options.workerId;
   }
 
-  getStdout(): Readable {
-    return this._child.stdout;
+  getStdout(): NodeJS.ReadableStream {
+    return this._worker.stdout;
   }
 
-  getStderr(): Readable {
-    return this._child.stderr;
+  getStderr(): NodeJS.ReadableStream {
+    return this._worker.stderr;
   }
 }

--- a/packages/jest-worker/src/workers/__tests__/ChildProcessWorker.test.js
+++ b/packages/jest-worker/src/workers/__tests__/ChildProcessWorker.test.js
@@ -5,8 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-'use strict';
-
 /* eslint-disable no-new */
 
 import EventEmitter from 'events';
@@ -63,7 +61,7 @@ it('passes fork options down to child_process.fork, adding the defaults', () => 
   });
 
   expect(childProcess.fork.mock.calls[0][0]).toBe(child);
-  expect(childProcess.fork.mock.calls[0][1]).toEqual({
+  expect(childProcess.fork.mock.calls[0][2]).toEqual({
     cwd: '/tmp', // Overridden default option.
     env: {...process.env, FORCE_COLOR: supportsColor.stdout ? '1' : undefined}, // Default option.
     execArgv: ['-p'], // Filtered option.
@@ -80,7 +78,7 @@ it('passes workerId to the child process and assign it to env.JEST_WORKER_ID', (
     workerPath: '/tmp/foo',
   });
 
-  expect(childProcess.fork.mock.calls[0][1].env.JEST_WORKER_ID).toEqual(2);
+  expect(childProcess.fork.mock.calls[0][2].env.JEST_WORKER_ID).toEqual('2');
 });
 
 it('initializes the child process with the given workerPath', () => {

--- a/packages/jest-worker/src/workers/__tests__/NodeThreadsWorker.test.js
+++ b/packages/jest-worker/src/workers/__tests__/NodeThreadsWorker.test.js
@@ -63,7 +63,7 @@ it('passes fork options down to child_process.fork, adding the defaults', () => 
     workerPath: '/tmp/foo/bar/baz.js',
   });
 
-  expect(childProcess.mock.calls[0][0]).toBe(child);
+  expect(childProcess.mock.calls[0][0]).toBe(child.replace(/\.ts$/, '.js'));
   expect(childProcess.mock.calls[0][1]).toEqual({
     eval: false,
     stderr: true,
@@ -87,7 +87,7 @@ it('passes workerId to the child process and assign it to env.JEST_WORKER_ID', (
   });
 
   expect(childProcess.mock.calls[0][1].workerData.env.JEST_WORKER_ID).toEqual(
-    2,
+    '2',
   );
 });
 

--- a/packages/jest-worker/tsconfig.json
+++ b/packages/jest-worker/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "build"
+  }
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

I left the tests alone as there were way too many typer errors for the effort I wanted to put into it :P

At some point we can probably make the types smarter (having it infer exports from the file coming in, filtering by `exposedMethods` etc). My hope is that someone will contribute that as a PR at some point 😀 

built diff:

<details>

```diff
diff --git i/packages/jest-worker/build/Farm.js w/packages/jest-worker/build/Farm.js
index ed652e867..f16fe5df8 100644
--- i/packages/jest-worker/build/Farm.js
+++ w/packages/jest-worker/build/Farm.js
@@ -1,11 +1,3 @@
-/**
- * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- *
- *
- */
 'use strict';
 
 Object.defineProperty(exports, '__esModule', {
@@ -15,6 +7,12 @@ exports.default = void 0;
 
 var _types = require('./types');
 
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 class Farm {
   constructor(numOfWorkers, callback, computeWorkerKey) {
     this._callback = callback;
@@ -38,7 +36,7 @@ class Farm {
       let hash = null;
 
       if (computeWorkerKey) {
-        hash = computeWorkerKey.apply(this, [method].concat(args));
+        hash = computeWorkerKey.call(this, method, ...args);
         worker = hash == null ? null : this._cacheKeys[hash];
       }
 
@@ -74,7 +72,7 @@ class Farm {
     let queueHead = this._queue[workerId];
 
     while (queueHead && queueHead.request[1]) {
-      queueHead = queueHead.next;
+      queueHead = queueHead.next || null;
     }
 
     this._queue[workerId] = queueHead;
diff --git i/packages/jest-worker/build/WorkerPool.js w/packages/jest-worker/build/WorkerPool.js
index 5ab4dada6..16ed8908b 100644
--- i/packages/jest-worker/build/WorkerPool.js
+++ w/packages/jest-worker/build/WorkerPool.js
@@ -1,11 +1,3 @@
-/**
- * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- *
- *
- */
 'use strict';
 
 Object.defineProperty(exports, '__esModule', {
@@ -19,6 +11,12 @@ function _interopRequireDefault(obj) {
   return obj && obj.__esModule ? obj : {default: obj};
 }
 
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 const canUseWorkerThreads = () => {
   try {
     // $FlowFixMe: Flow doesn't know about experimental APIs
diff --git i/packages/jest-worker/build/base/BaseWorkerPool.js w/packages/jest-worker/build/base/BaseWorkerPool.js
index 8f83a8808..eefd02c84 100644
--- i/packages/jest-worker/build/base/BaseWorkerPool.js
+++ w/packages/jest-worker/build/base/BaseWorkerPool.js
@@ -1,11 +1,3 @@
-/**
- * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- *
- *
- */
 'use strict';
 
 Object.defineProperty(exports, '__esModule', {
@@ -13,20 +5,20 @@ Object.defineProperty(exports, '__esModule', {
 });
 exports.default = void 0;
 
-function _mergeStream() {
-  const data = _interopRequireDefault(require('merge-stream'));
+function _path() {
+  const data = _interopRequireDefault(require('path'));
 
-  _mergeStream = function _mergeStream() {
+  _path = function _path() {
     return data;
   };
 
   return data;
 }
 
-function _path() {
-  const data = _interopRequireDefault(require('path'));
+function _mergeStream() {
+  const data = _interopRequireDefault(require('merge-stream'));
 
-  _path = function _path() {
+  _mergeStream = function _mergeStream() {
     return data;
   };
 
@@ -39,6 +31,13 @@ function _interopRequireDefault(obj) {
   return obj && obj.__esModule ? obj : {default: obj};
 }
 
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 /* istanbul ignore next */
 const emptyMethod = () => {};
 
@@ -100,7 +99,7 @@ class BaseWorkerPool {
     return this._workers[workerId];
   }
 
-  createWorker(workerOptions) {
+  createWorker(_workerOptions) {
     throw Error('Missing method createWorker in WorkerPool');
   }
 
diff --git i/packages/jest-worker/build/index.js w/packages/jest-worker/build/index.js
index 45fc7702a..73ba44544 100644
--- i/packages/jest-worker/build/index.js
+++ w/packages/jest-worker/build/index.js
@@ -1,11 +1,3 @@
-/**
- * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- *
- *
- */
 'use strict';
 
 Object.defineProperty(exports, '__esModule', {
@@ -67,15 +59,15 @@ function getExposedMethods(workerPath, options) {
   let exposedMethods = options.exposedMethods; // If no methods list is given, try getting it by auto-requiring the module.
 
   if (!exposedMethods) {
-    // $FlowFixMe: This has to be a dynamic require.
     const module = require(workerPath);
 
     exposedMethods = Object.keys(module).filter(
+      // @ts-ignore: no index
       name => typeof module[name] === 'function'
     );
 
     if (typeof module === 'function') {
-      exposedMethods.push('default');
+      exposedMethods = [...exposedMethods, 'default'];
     }
   }
 
@@ -110,6 +102,7 @@ function getExposedMethods(workerPath, options) {
 class JestWorker {
   constructor(workerPath, options) {
     this._options = _objectSpread({}, options);
+    this._ending = false;
     const workerPoolOptions = {
       enableWorkerThreads: this._options.enableWorkerThreads || false,
       forkOptions: this._options.forkOptions || {},
@@ -119,9 +112,17 @@ class JestWorker {
         Math.max(_os().default.cpus().length - 1, 1),
       setupArgs: this._options.setupArgs || []
     };
-    this._workerPool = this._options.WorkerPool
-      ? new this._options.WorkerPool(workerPath, workerPoolOptions)
-      : new _WorkerPool.default(workerPath, workerPoolOptions);
+
+    if (this._options.WorkerPool) {
+      // @ts-ignore: constructor target any?
+      this._workerPool = new this._options.WorkerPool(
+        workerPath,
+        workerPoolOptions
+      );
+    } else {
+      this._workerPool = new _WorkerPool.default(workerPath, workerPoolOptions);
+    }
+
     this._farm = new _Farm.default(
       workerPoolOptions.numWorkers,
       this._workerPool.send.bind(this._workerPool),
@@ -139,7 +140,7 @@ class JestWorker {
 
       if (this.constructor.prototype.hasOwnProperty(name)) {
         throw new TypeError('Cannot define a method called ' + name);
-      } // $FlowFixMe: dynamic extension of the class instance is expected.
+      } // @ts-ignore: dynamic extension of the class instance is expected.
 
       this[name] = this._callFunctionWithArgs.bind(this, name);
     });
diff --git i/packages/jest-worker/build/types.js w/packages/jest-worker/build/types.js
index 9ac9874cf..eb8beb09d 100644
--- i/packages/jest-worker/build/types.js
+++ w/packages/jest-worker/build/types.js
@@ -1,19 +1,18 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', {
+  value: true
+});
+exports.PARENT_MESSAGE_SETUP_ERROR = exports.PARENT_MESSAGE_CLIENT_ERROR = exports.PARENT_MESSAGE_OK = exports.CHILD_MESSAGE_END = exports.CHILD_MESSAGE_CALL = exports.CHILD_MESSAGE_INITIALIZE = void 0;
+
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
-'use strict'; // Because of the dynamic nature of a worker communication process, all messages
+// Because of the dynamic nature of a worker communication process, all messages
 // coming from any of the other processes cannot be typed. Thus, many types
-// include "any" as a flow type, which is (unfortunately) correct here.
-
-Object.defineProperty(exports, '__esModule', {
-  value: true
-});
-exports.PARENT_MESSAGE_SETUP_ERROR = exports.PARENT_MESSAGE_CLIENT_ERROR = exports.PARENT_MESSAGE_OK = exports.CHILD_MESSAGE_END = exports.CHILD_MESSAGE_CALL = exports.CHILD_MESSAGE_INITIALIZE = void 0;
 const CHILD_MESSAGE_INITIALIZE = 0;
 exports.CHILD_MESSAGE_INITIALIZE = CHILD_MESSAGE_INITIALIZE;
 const CHILD_MESSAGE_CALL = 1;
@@ -27,4 +26,5 @@ exports.PARENT_MESSAGE_CLIENT_ERROR = PARENT_MESSAGE_CLIENT_ERROR;
 const PARENT_MESSAGE_SETUP_ERROR = 2;
 exports.PARENT_MESSAGE_SETUP_ERROR = PARENT_MESSAGE_SETUP_ERROR;
 
+// Option objects.
 const EventEmitter = require('events');
diff --git i/packages/jest-worker/build/workers/ChildProcessWorker.js w/packages/jest-worker/build/workers/ChildProcessWorker.js
index 3252e6faa..6abdf5721 100644
--- i/packages/jest-worker/build/workers/ChildProcessWorker.js
+++ w/packages/jest-worker/build/workers/ChildProcessWorker.js
@@ -1,11 +1,3 @@
-/**
- * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- *
- *
- */
 'use strict';
 
 Object.defineProperty(exports, '__esModule', {
@@ -23,8 +15,6 @@ function _child_process() {
   return data;
 }
 
-var _types = require('../types');
-
 function _supportsColor() {
   const data = _interopRequireDefault(require('supports-color'));
 
@@ -35,6 +25,8 @@ function _supportsColor() {
   return data;
 }
 
+var _types = require('../types');
+
 function _interopRequireDefault(obj) {
   return obj && obj.__esModule ? obj : {default: obj};
 }
@@ -104,6 +96,7 @@ class ChildProcessWorker {
 
     const child = _child_process().default.fork(
       require.resolve('./processChild'),
+      [],
       _objectSpread(
         {
           cwd: process.cwd(),
@@ -111,7 +104,7 @@ class ChildProcessWorker {
             {},
             process.env,
             {
-              JEST_WORKER_ID: this._options.workerId
+              JEST_WORKER_ID: String(this._options.workerId)
             },
             forceColor
           ),
@@ -150,10 +143,7 @@ class ChildProcessWorker {
     }
   }
 
-  onMessage(
-    response
-    /* Should be ParentMessage */
-  ) {
+  onMessage(response) {
     let error;
 
     switch (response[0]) {
@@ -166,16 +156,16 @@ class ChildProcessWorker {
         error = response[4];
 
         if (error != null && typeof error === 'object') {
-          const extra = error;
+          const extra = error; // @ts-ignore: no index
+
           const NativeCtor = global[response[1]];
           const Ctor = typeof NativeCtor === 'function' ? NativeCtor : Error;
-          error = new Ctor(response[2]); // $FlowFixMe: adding custom properties to errors.
-
+          error = new Ctor(response[2]);
           error.type = response[1];
           error.stack = response[3];
 
           for (const key in extra) {
-            // $FlowFixMe: adding custom properties to errors.
+            // @ts-ignore: adding custom properties to errors.
             error[key] = extra[key];
           }
         }
@@ -185,7 +175,7 @@ class ChildProcessWorker {
         break;
 
       case _types.PARENT_MESSAGE_SETUP_ERROR:
-        error = new Error('Error when calling setup: ' + response[2]); // $FlowFixMe: adding custom properties to errors.
+        error = new Error('Error when calling setup: ' + response[2]); // @ts-ignore: adding custom properties to errors.
 
         error.type = response[1];
         error.stack = response[3];
diff --git i/packages/jest-worker/build/workers/NodeThreadsWorker.js w/packages/jest-worker/build/workers/NodeThreadsWorker.js
index 5a08a8972..d91ed0aa8 100644
--- i/packages/jest-worker/build/workers/NodeThreadsWorker.js
+++ w/packages/jest-worker/build/workers/NodeThreadsWorker.js
@@ -1,11 +1,3 @@
-/**
- * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- *
- *
- */
 'use strict';
 
 Object.defineProperty(exports, '__esModule', {
@@ -13,8 +5,6 @@ Object.defineProperty(exports, '__esModule', {
 });
 exports.default = void 0;
 
-var _types = require('../types');
-
 function _path() {
   const data = _interopRequireDefault(require('path'));
 
@@ -25,6 +15,18 @@ function _path() {
   return data;
 }
 
+function _worker_threads() {
+  const data = require('worker_threads');
+
+  _worker_threads = function _worker_threads() {
+    return data;
+  };
+
+  return data;
+}
+
+var _types = require('../types');
+
 function _interopRequireDefault(obj) {
   return obj && obj.__esModule ? obj : {default: obj};
 }
@@ -61,10 +63,6 @@ function _defineProperty(obj, key, value) {
   return obj;
 }
 
-// $FlowFixMe: Flow doesn't know about experimental features of Node
-const _require = require('worker_threads'),
-  Worker = _require.Worker;
-
 class ExperimentalWorker {
   constructor(options) {
     this._options = options;
@@ -72,7 +70,7 @@ class ExperimentalWorker {
   }
 
   initialize() {
-    this._worker = new Worker(
+    this._worker = new (_worker_threads()).Worker(
       _path().default.resolve(__dirname, './threadChild.js'),
       {
         eval: false,
@@ -82,7 +80,7 @@ class ExperimentalWorker {
           {
             cwd: process.cwd(),
             env: _objectSpread({}, process.env, {
-              JEST_WORKER_ID: this._options.workerId
+              JEST_WORKER_ID: String(this._options.workerId)
             }),
             // Suppress --debug / --inspect flags while preserving others (like --harmony).
             execArgv: process.execArgv.filter(
@@ -124,10 +122,7 @@ class ExperimentalWorker {
     }
   }
 
-  onMessage(
-    response
-    /* Should be ParentMessage */
-  ) {
+  onMessage(response) {
     let error;
 
     switch (response[0]) {
@@ -140,16 +135,16 @@ class ExperimentalWorker {
         error = response[4];
 
         if (error != null && typeof error === 'object') {
-          const extra = error;
+          const extra = error; // @ts-ignore: no index
+
           const NativeCtor = global[response[1]];
           const Ctor = typeof NativeCtor === 'function' ? NativeCtor : Error;
-          error = new Ctor(response[2]); // $FlowFixMe: adding custom properties to errors.
-
+          error = new Ctor(response[2]);
           error.type = response[1];
           error.stack = response[3];
 
           for (const key in extra) {
-            // $FlowFixMe: adding custom properties to errors.
+            // @ts-ignore: no index
             error[key] = extra[key];
           }
         }
@@ -159,7 +154,7 @@ class ExperimentalWorker {
         break;
 
       case _types.PARENT_MESSAGE_SETUP_ERROR:
-        error = new Error('Error when calling setup: ' + response[2]); // $FlowFixMe: adding custom properties to errors.
+        error = new Error('Error when calling setup: ' + response[2]); // @ts-ignore: adding custom properties to errors.
 
         error.type = response[1];
         error.stack = response[3];
diff --git i/packages/jest-worker/build/workers/processChild.js w/packages/jest-worker/build/workers/processChild.js
index 409e0c673..222242c86 100644
--- i/packages/jest-worker/build/workers/processChild.js
+++ w/packages/jest-worker/build/workers/processChild.js
@@ -1,11 +1,3 @@
-/**
- * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- *
- *
- */
 'use strict';
 
 var _types = require('../types');
@@ -118,7 +110,6 @@ function reportError(error, type) {
 }
 
 function end() {
-  // $FlowFixMe: This has to be a dynamic require.
   const main = require(file);
 
   if (!main.teardown) {
@@ -134,7 +125,6 @@ function exitProcess() {
 }
 
 function execMethod(method, args) {
-  // $FlowFixMe: This has to be a dynamic require.
   const main = require(file);
 
   let fn;
diff --git i/packages/jest-worker/build/workers/threadChild.js w/packages/jest-worker/build/workers/threadChild.js
index 346510ed0..941c69992 100644
--- i/packages/jest-worker/build/workers/threadChild.js
+++ w/packages/jest-worker/build/workers/threadChild.js
@@ -1,15 +1,5 @@
-/**
- * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- *
- *
- */
 'use strict';
 
-var _types = require('../types');
-
 function _worker_threads() {
   const data = require('worker_threads');
 
@@ -20,6 +10,8 @@ function _worker_threads() {
   return data;
 }
 
+var _types = require('../types');
+
 function _objectSpread(target) {
   for (var i = 1; i < arguments.length; i++) {
     var source = arguments[i] != null ? arguments[i] : {};
@@ -55,11 +47,6 @@ function _defineProperty(obj, key, value) {
 let file = null;
 let setupArgs = [];
 let initialized = false;
-/* eslint-disable import/no-unresolved */
-// $FlowFixMe: Flow doesn't support experimental node modules
-
-/* eslint-enable import/no-unresolved */
-
 /**
  * This file is a small bootstrapper for workers. It sets up the communication
  * between the worker and the parent process, interpreting parent messages and
@@ -73,6 +60,7 @@ let initialized = false;
  * If an invalid message is detected, the child will exit (by throwing) with a
  * non-zero exit code.
  */
+
 _worker_threads().parentPort.on('message', request => {
   switch (request[0]) {
     case _types.CHILD_MESSAGE_INITIALIZE:
@@ -126,13 +114,12 @@ function reportError(error, type) {
     type,
     error.constructor && error.constructor.name,
     error.message,
-    error.stack, // $FlowFixMe: this is safe to just inherit from Object.
+    error.stack,
     typeof error === 'object' ? _objectSpread({}, error) : error
   ]);
 }
 
 function end() {
-  // $FlowFixMe: This has to be a dynamic require.
   const main = require(file);
 
   if (!main.teardown) {
@@ -148,7 +135,6 @@ function exitProcess() {
 }
 
 function execMethod(method, args) {
-  // $FlowFixMe: This has to be a dynamic require.
   const main = require(file);
 
   let fn;
```
</details>

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Green CI

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
