### PR TITLE
fix image 404 in the jestjs.io docs

### DIFF
--- a/docs/SnapshotTesting.md
+++ b/docs/SnapshotTesting.md
@@ -64,7 +64,7 @@ it('renders correctly', () => {
 
 In that case, Jest will print this output:
 
-![](/website/static/img/content/failedSnapshotTest.png)
+![](https://raw.githubusercontent.com/facebook/jest/master/website/static/img/content/failedSnapshotTest.png)
 
 Since we just updated our component to point to a different address, it's reasonable to expect changes in the snapshot for this component. Our snapshot test case is failing because the snapshot for our updated component no longer matches the snapshot artifact for this test case.
 
@@ -84,17 +84,17 @@ You can try out this functionality by cloning the [snapshot example](https://git
 
 Failed snapshots can also be updated interactively in watch mode:
 
-![](/website/static/img/content/interactiveSnapshot.png)
+![](https://raw.githubusercontent.com/facebook/jest/master/website/static/img/content/interactiveSnapshot.png)
 
 Once you enter Interactive Snapshot Mode, Jest will step you through the failed snapshots one test at a time and give you the opportunity to review the failed output.
 
 From here you can choose to update that snapshot or skip to the next:
 
-![](/website/static/img/content/interactiveSnapshotUpdate.gif)
+![](https://raw.githubusercontent.com/facebook/jest/master/website/static/img/content/interactiveSnapshotUpdate.gif)
 
 Once you're finished, Jest will give you a summary before returning back to watch mode:
 
-![](/website/static/img/content/interactiveSnapshotDone.png)
+![](https://raw.githubusercontent.com/facebook/jest/master/website/static/img/content/interactiveSnapshotDone.png)
 
 ### Inline Snapshots
 


### PR DESCRIPTION
When opening in https://jestjs.io/docs/en/snapshot-testing the images do not load because the relative path is wrong.
Load the absolute RAW image path instead.

