### PR TITLE
chore: migrate babel-jest to TypeScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - `[jest-worker]`: Migrate to TypeScript ([#7853](https://github.com/facebook/jest/pull/7853))
 - `[jest-haste-map]`: Migrate to TypeScript ([#7854](https://github.com/facebook/jest/pull/7854))
 - `[docs]`: Fix image paths in SnapshotTesting.md for current and version 24 ([#7872](https://github.com/facebook/jest/pull/7872))
+- `[babel-jest]`: Migrate to TypeScript ([#7862](https://github.com/facebook/jest/pull/7862))
 
 ### Performance
 

--- a/e2e/__tests__/__snapshots__/transform.test.js.snap
+++ b/e2e/__tests__/__snapshots__/transform.test.js.snap
@@ -6,7 +6,7 @@ FAIL __tests__/ignoredFile.test.js
 
     babel-jest: Babel ignores __tests__/ignoredFile.test.js - make sure to include the file in Jest's transformIgnorePatterns as well.
 
-      at loadBabelConfig (../../../packages/babel-jest/build/index.js:134:13)
+      at loadBabelConfig (../../../packages/babel-jest/build/index.js:135:13)
 `;
 
 exports[`babel-jest instruments only specific files and collects coverage 1`] = `

--- a/e2e/__tests__/__snapshots__/transform.test.js.snap
+++ b/e2e/__tests__/__snapshots__/transform.test.js.snap
@@ -6,7 +6,7 @@ FAIL __tests__/ignoredFile.test.js
 
     babel-jest: Babel ignores __tests__/ignoredFile.test.js - make sure to include the file in Jest's transformIgnorePatterns as well.
 
-      at loadBabelConfig (../../../packages/babel-jest/build/index.js:135:13)
+      at loadBabelConfig (../../../packages/babel-jest/build/index.js:133:13)
 `;
 
 exports[`babel-jest instruments only specific files and collects coverage 1`] = `

--- a/packages/babel-jest/package.json
+++ b/packages/babel-jest/package.json
@@ -9,7 +9,9 @@
   },
   "license": "MIT",
   "main": "build/index.js",
+  "types": "build/index.d.ts",
   "dependencies": {
+    "@jest/types": "^24.1.0",
     "babel-plugin-istanbul": "^5.1.0",
     "babel-preset-jest": "^24.1.0",
     "chalk": "^2.4.2",

--- a/packages/babel-jest/src/__tests__/index.ts
+++ b/packages/babel-jest/src/__tests__/index.ts
@@ -4,7 +4,9 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-const babelJest = require('../index');
+
+import {Config, Transform} from '@jest/types';
+import babelJest from '../index';
 
 //Mock data for all the tests
 const sourceString = `
@@ -24,12 +26,16 @@ const mockConfig = {
 };
 
 test(`Returns source string with inline maps when no transformOptions is passed`, () => {
-  const result = babelJest.process(sourceString, 'dummy_path.js', mockConfig);
+  const result = babelJest.process(
+    sourceString,
+    'dummy_path.js',
+    (mockConfig as unknown) as Config.ProjectConfig,
+  ) as Transform.TransformedSource;
   expect(typeof result).toBe('object');
   expect(result.code).toBeDefined();
   expect(result.map).toBeDefined();
   expect(result.code).toMatch('//# sourceMappingURL');
   expect(result.code).toMatch('customMultiply');
-  expect(result.map.sources).toEqual(['dummy_path.js']);
-  expect(JSON.stringify(result.map.sourcesContent)).toMatch('customMultiply');
+  expect(result.map!.sources).toEqual(['dummy_path.js']);
+  expect(JSON.stringify(result.map!.sourcesContent)).toMatch('customMultiply');
 });

--- a/packages/babel-jest/src/__tests__/index.ts
+++ b/packages/babel-jest/src/__tests__/index.ts
@@ -36,6 +36,8 @@ test(`Returns source string with inline maps when no transformOptions is passed`
   expect(result.map).toBeDefined();
   expect(result.code).toMatch('//# sourceMappingURL');
   expect(result.code).toMatch('customMultiply');
-  expect(result.map!.sources).toEqual(['dummy_path.js']);
-  expect(JSON.stringify(result.map!.sourcesContent)).toMatch('customMultiply');
+  // @ts-ignore: it's fine if we get wrong types, the tests will fail then
+  expect(result.map.sources).toEqual(['dummy_path.js']);
+  // @ts-ignore: it's fine if we get wrong types, the tests will fail then
+  expect(JSON.stringify(result.map.sourcesContent)).toMatch('customMultiply');
 });

--- a/packages/babel-jest/src/index.ts
+++ b/packages/babel-jest/src/index.ts
@@ -126,8 +126,10 @@ const createTransformer = (
       const transformResult = babelTransform(src, babelOptions);
 
       if (transformResult && typeof transformResult.code === 'string') {
-        // @ts-ignore: why doesn't TS understand this?
-        return transformResult;
+        const {code, map} = transformResult;
+        if (typeof code === 'string') {
+          return {code, map};
+        }
       }
 
       return src;

--- a/packages/babel-jest/src/index.ts
+++ b/packages/babel-jest/src/index.ts
@@ -38,9 +38,6 @@ const createTransformer = (
     sourceMaps: 'both',
   };
 
-  // @ts-ignore: seems like this is removed. Is that true?
-  delete options.cacheDirectory;
-
   function loadBabelConfig(
     cwd: Config.Path,
     filename: Config.Path,

--- a/packages/babel-jest/src/index.ts
+++ b/packages/babel-jest/src/index.ts
@@ -3,22 +3,18 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- * @flow
  */
-
-import type {Path, ProjectConfig} from 'types/Config';
-import type {
-  CacheKeyOptions,
-  Transformer,
-  TransformOptions,
-  TransformedSource,
-} from 'types/Transform';
 
 import crypto from 'crypto';
 import fs from 'fs';
 import path from 'path';
-import {transformSync as babelTransform, loadPartialConfig} from '@babel/core';
+import {Config, Transform} from '@jest/types';
+import {
+  transformSync as babelTransform,
+  loadPartialConfig,
+  TransformOptions,
+  PartialConfig,
+} from '@babel/core';
 import chalk from 'chalk';
 import slash from 'slash';
 
@@ -26,9 +22,12 @@ const THIS_FILE = fs.readFileSync(__filename);
 const jestPresetPath = require.resolve('babel-preset-jest');
 const babelIstanbulPlugin = require.resolve('babel-plugin-istanbul');
 
-const createTransformer = (options: any): Transformer => {
+const createTransformer = (
+  options: TransformOptions = {},
+): Transform.Transformer => {
   options = {
     ...options,
+    // @ts-ignore: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/32955
     caller: {
       name: 'babel-jest',
       supportsStaticESM: false,
@@ -39,10 +38,13 @@ const createTransformer = (options: any): Transformer => {
     sourceMaps: 'both',
   };
 
+  // @ts-ignore: seems like this is removed. Is that true?
   delete options.cacheDirectory;
-  delete options.filename;
 
-  function loadBabelConfig(cwd, filename) {
+  function loadBabelConfig(
+    cwd: Config.Path,
+    filename: Config.Path,
+  ): PartialConfig {
     // `cwd` first to allow incoming options to override it
     const babelConfig = loadPartialConfig({cwd, ...options, filename});
 
@@ -63,9 +65,13 @@ const createTransformer = (options: any): Transformer => {
     canInstrument: true,
     getCacheKey(
       fileData: string,
-      filename: Path,
+      filename: Config.Path,
       configString: string,
-      {config, instrument, rootDir}: {config: ProjectConfig} & CacheKeyOptions,
+      {
+        config,
+        instrument,
+        rootDir,
+      }: {config: Config.ProjectConfig} & Transform.CacheKeyOptions,
     ): string {
       const babelOptions = loadBabelConfig(config.cwd, filename);
       const configPath = [
@@ -96,16 +102,16 @@ const createTransformer = (options: any): Transformer => {
     },
     process(
       src: string,
-      filename: Path,
-      config: ProjectConfig,
-      transformOptions?: TransformOptions,
-    ): string | TransformedSource {
+      filename: Config.Path,
+      config: Config.ProjectConfig,
+      transformOptions?: Transform.TransformOptions,
+    ): string | Transform.TransformedSource {
       const babelOptions = {...loadBabelConfig(config.cwd, filename).options};
 
       if (transformOptions && transformOptions.instrument) {
         babelOptions.auxiliaryCommentBefore = ' istanbul ignore next ';
         // Copied from jest-runtime transform.js
-        babelOptions.plugins = babelOptions.plugins.concat([
+        babelOptions.plugins = (babelOptions.plugins || []).concat([
           [
             babelIstanbulPlugin,
             {
@@ -119,10 +125,21 @@ const createTransformer = (options: any): Transformer => {
 
       const transformResult = babelTransform(src, babelOptions);
 
-      return transformResult || src;
+      if (transformResult && typeof transformResult.code === 'string') {
+        // @ts-ignore: why doesn't TS understand this?
+        return transformResult;
+      }
+
+      return src;
     },
   };
 };
 
-module.exports = createTransformer();
-(module.exports: any).createTransformer = createTransformer;
+const transformer = createTransformer();
+
+// FIXME: This is not part of the exported TS types. When fixed, remember to
+// move @types/babel__core to `dependencies` instead of `devDependencies`
+// (one fix is to use ESM, maybe for Jest 25?)
+transformer.createTransformer = createTransformer;
+
+export = transformer;

--- a/packages/babel-jest/src/index.ts
+++ b/packages/babel-jest/src/index.ts
@@ -125,7 +125,7 @@ const createTransformer = (
 
       const transformResult = babelTransform(src, babelOptions);
 
-      if (transformResult && typeof transformResult.code === 'string') {
+      if (transformResult) {
         const {code, map} = transformResult;
         if (typeof code === 'string') {
           return {code, map};

--- a/packages/babel-jest/tsconfig.json
+++ b/packages/babel-jest/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "build"
+  },
+  "references": [{"path": "../jest-types"}]
+}

--- a/packages/babel-jest/tsconfig.json
+++ b/packages/babel-jest/tsconfig.json
@@ -4,5 +4,6 @@
     "rootDir": "src",
     "outDir": "build"
   },
+  // TODO: include `babel-preset-jest` even though we don't care about its types
   "references": [{"path": "../jest-types"}]
 }

--- a/packages/jest-types/package.json
+++ b/packages/jest-types/package.json
@@ -11,5 +11,8 @@
   },
   "license": "MIT",
   "main": "build/index.js",
-  "types": "build/index.d.ts"
+  "types": "build/index.d.ts",
+  "dependencies": {
+    "source-map": "^0.6.1"
+  }
 }

--- a/packages/jest-types/src/Transform.ts
+++ b/packages/jest-types/src/Transform.ts
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {Script} from 'vm';
+import {Path, ProjectConfig} from './Config';
+
+export type TransformedSource = {
+  code: string;
+  map?: // copied from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/363cdf403a74e0372e87bbcd15eb1668f4c5230b/types/babel__core/index.d.ts#L371-L379
+  {
+    version: number;
+    sources: string[];
+    names: string[];
+    sourceRoot?: string;
+    sourcesContent?: string[];
+    mappings: string;
+    file: string;
+  } | null;
+};
+
+export type TransformResult = {
+  script: Script;
+  mapCoverage: boolean;
+  sourceMapPath?: string;
+};
+
+export type TransformOptions = {
+  instrument: boolean;
+};
+
+export type CacheKeyOptions = {
+  config: ProjectConfig;
+  instrument: boolean;
+  rootDir: string;
+};
+
+export type Transformer = {
+  canInstrument?: boolean;
+  createTransformer?: (options: any) => Transformer;
+
+  getCacheKey: (
+    fileData: string,
+    filePath: Path,
+    configStr: string,
+    options: CacheKeyOptions,
+  ) => string;
+
+  process: (
+    sourceText: string,
+    sourcePath: Path,
+    config: ProjectConfig,
+    options?: TransformOptions,
+  ) => string | TransformedSource;
+};

--- a/packages/jest-types/src/Transform.ts
+++ b/packages/jest-types/src/Transform.ts
@@ -6,22 +6,21 @@
  */
 
 import {Script} from 'vm';
+import {RawSourceMap} from 'source-map';
 import {Path, ProjectConfig} from './Config';
+
+// https://stackoverflow.com/a/48216010/1850276
+type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+
+// This is fixed in a newer version, but that depends on Node 8 which is a
+// breaking change (engine warning when installing)
+interface FixedRawSourceMap extends Omit<RawSourceMap, 'version'> {
+  version: number;
+}
 
 export type TransformedSource = {
   code: string;
-  map?:  // copied from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/363cdf403a74e0372e87bbcd15eb1668f4c5230b/types/babel__core/index.d.ts#L371-L379
-    | {
-        version: number;
-        sources: string[];
-        names: string[];
-        sourceRoot?: string;
-        sourcesContent?: string[];
-        mappings: string;
-        file: string;
-      }
-    | string
-    | null;
+  map?: FixedRawSourceMap | string | null;
 };
 
 export type TransformResult = {

--- a/packages/jest-types/src/Transform.ts
+++ b/packages/jest-types/src/Transform.ts
@@ -10,16 +10,18 @@ import {Path, ProjectConfig} from './Config';
 
 export type TransformedSource = {
   code: string;
-  map?: // copied from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/363cdf403a74e0372e87bbcd15eb1668f4c5230b/types/babel__core/index.d.ts#L371-L379
-  {
-    version: number;
-    sources: string[];
-    names: string[];
-    sourceRoot?: string;
-    sourcesContent?: string[];
-    mappings: string;
-    file: string;
-  } | null;
+  map?:  // copied from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/363cdf403a74e0372e87bbcd15eb1668f4c5230b/types/babel__core/index.d.ts#L371-L379
+    | {
+        version: number;
+        sources: string[];
+        names: string[];
+        sourceRoot?: string;
+        sourcesContent?: string[];
+        mappings: string;
+        file: string;
+      }
+    | string
+    | null;
 };
 
 export type TransformResult = {

--- a/packages/jest-types/src/index.ts
+++ b/packages/jest-types/src/index.ts
@@ -10,5 +10,6 @@ import * as Console from './Console';
 import * as SourceMaps from './SourceMaps';
 import * as TestResult from './TestResult';
 import * as Mocks from './Mocks';
+import * as Transform from './Transform';
 
-export {Config, Console, SourceMaps, TestResult, Mocks};
+export {Config, Console, SourceMaps, TestResult, Mocks, Transform};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Built diff:

<details>

```diff
diff --git c/packages/babel-jest/build/index.js w/packages/babel-jest/build/index.js
index 09b426d20..fc3dd7f8d 100644
--- c/packages/babel-jest/build/index.js
+++ w/packages/babel-jest/build/index.js
@@ -102,8 +102,9 @@ const jestPresetPath = require.resolve('babel-preset-jest');
 
 const babelIstanbulPlugin = require.resolve('babel-plugin-istanbul');
 
-const createTransformer = options => {
+const createTransformer = (options = {}) => {
   options = _objectSpread({}, options, {
+    // @ts-ignore: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/32955
     caller: {
       name: 'babel-jest',
       supportsStaticESM: false
@@ -112,9 +113,9 @@ const createTransformer = options => {
     plugins: (options && options.plugins) || [],
     presets: ((options && options.presets) || []).concat(jestPresetPath),
     sourceMaps: 'both'
-  });
+  }); // @ts-ignore: seems like this is removed. Is that true?
+
   delete options.cacheDirectory;
-  delete options.filename;
 
   function loadBabelConfig(cwd, filename) {
     // `cwd` first to allow incoming options to override it
@@ -188,7 +189,7 @@ const createTransformer = options => {
       if (transformOptions && transformOptions.instrument) {
         babelOptions.auxiliaryCommentBefore = ' istanbul ignore next '; // Copied from jest-runtime transform.js
 
-        babelOptions.plugins = babelOptions.plugins.concat([
+        babelOptions.plugins = (babelOptions.plugins || []).concat([
           [
             babelIstanbulPlugin,
             {
@@ -201,10 +202,20 @@ const createTransformer = options => {
       }
 
       const transformResult = (0, _core().transformSync)(src, babelOptions);
-      return transformResult || src;
+
+      if (transformResult && typeof transformResult.code === 'string') {
+        // @ts-ignore: why doesn't TS understand this?
+        return transformResult;
+      }
+
+      return src;
     }
   };
 };
 
-module.exports = createTransformer();
-module.exports.createTransformer = createTransformer;
+const transformer = createTransformer(); // FIXME: This is not part of the exported TS types. When fixed, remember to
+// move @types/babel__core to `dependencies` instead of `devDependencies`
+// (one fix is to use ESM, maybe for Jest 25?)
+
+transformer.createTransformer = createTransformer;
+module.exports = transformer;
```
</details>

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Green CI

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
