### PR TITLE
expect: Improve report when matcher fails, part 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Features
 
+- `[expect]`: Improve report when matcher fails, part 7 ([#7866](https://github.com/facebook/jest/pull/7866))
+
 ### Fixes
 
 - `[jest-cli]` Refactor `-o` and `--coverage` combined ([#7611](https://github.com/facebook/jest/pull/7611))

--- a/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -645,465 +645,465 @@ Received: <red>undefined</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() equal numbers: [-Infinity, -Infinity] 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.toBeGreaterThanOrEqual(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeGreaterThanOrEqual<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>-Infinity</>
-Received: <red>-Infinity</>"
+Expected: not >= <green>-Infinity</>
+Received:        <red>-Infinity</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() equal numbers: [-Infinity, -Infinity] 2`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.toBeLessThanOrEqual(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeLessThanOrEqual<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>-Infinity</>
-Received: <red>-Infinity</>"
+Expected: not <= <green>-Infinity</>
+Received:        <red>-Infinity</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() equal numbers: [1, 1] 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.toBeGreaterThanOrEqual(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeGreaterThanOrEqual<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>1</>
-Received: <red>1</>"
+Expected: not >= <green>1</>
+Received:        <red>1</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() equal numbers: [1, 1] 2`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.toBeLessThanOrEqual(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeLessThanOrEqual<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>1</>
-Received: <red>1</>"
+Expected: not <= <green>1</>
+Received:        <red>1</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() equal numbers: [1.7976931348623157e+308, 1.7976931348623157e+308] 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.toBeGreaterThanOrEqual(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeGreaterThanOrEqual<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>1.7976931348623157e+308</>
-Received: <red>1.7976931348623157e+308</>"
+Expected: not >= <green>1.7976931348623157e+308</>
+Received:        <red>1.7976931348623157e+308</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() equal numbers: [1.7976931348623157e+308, 1.7976931348623157e+308] 2`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.toBeLessThanOrEqual(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeLessThanOrEqual<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>1.7976931348623157e+308</>
-Received: <red>1.7976931348623157e+308</>"
+Expected: not <= <green>1.7976931348623157e+308</>
+Received:        <red>1.7976931348623157e+308</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() equal numbers: [5e-324, 5e-324] 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.toBeGreaterThanOrEqual(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeGreaterThanOrEqual<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>5e-324</>
-Received: <red>5e-324</>"
+Expected: not >= <green>5e-324</>
+Received:        <red>5e-324</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() equal numbers: [5e-324, 5e-324] 2`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.toBeLessThanOrEqual(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeLessThanOrEqual<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>5e-324</>
-Received: <red>5e-324</>"
+Expected: not <= <green>5e-324</>
+Received:        <red>5e-324</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() equal numbers: [Infinity, Infinity] 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.toBeGreaterThanOrEqual(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeGreaterThanOrEqual<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>Infinity</>
-Received: <red>Infinity</>"
+Expected: not >= <green>Infinity</>
+Received:        <red>Infinity</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() equal numbers: [Infinity, Infinity] 2`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.toBeLessThanOrEqual(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeLessThanOrEqual<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>Infinity</>
-Received: <red>Infinity</>"
+Expected: not <= <green>Infinity</>
+Received:        <red>Infinity</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [-Infinity, Infinity] 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeGreaterThan(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toBeGreaterThan<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>Infinity</>
-Received: <red>-Infinity</>"
+Expected: > <green>Infinity</>
+Received:   <red>-Infinity</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [-Infinity, Infinity] 2`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.toBeLessThan(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeLessThan<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>Infinity</>
-Received: <red>-Infinity</>"
+Expected: not < <green>Infinity</>
+Received:       <red>-Infinity</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [-Infinity, Infinity] 3`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.toBeGreaterThan(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeGreaterThan<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>-Infinity</>
-Received: <red>Infinity</>"
+Expected: not > <green>-Infinity</>
+Received:       <red>Infinity</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [-Infinity, Infinity] 4`] = `
-"<dim>expect(</><red>received</><dim>).toBeLessThan(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toBeLessThan<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>-Infinity</>
-Received: <red>Infinity</>"
+Expected: < <green>-Infinity</>
+Received:   <red>Infinity</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [-Infinity, Infinity] 5`] = `
-"<dim>expect(</><red>received</><dim>).toBeGreaterThanOrEqual(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toBeGreaterThanOrEqual<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>Infinity</>
-Received: <red>-Infinity</>"
+Expected: >= <green>Infinity</>
+Received:    <red>-Infinity</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [-Infinity, Infinity] 6`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.toBeLessThanOrEqual(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeLessThanOrEqual<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>Infinity</>
-Received: <red>-Infinity</>"
+Expected: not <= <green>Infinity</>
+Received:        <red>-Infinity</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [-Infinity, Infinity] 7`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.toBeGreaterThanOrEqual(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeGreaterThanOrEqual<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>-Infinity</>
-Received: <red>Infinity</>"
+Expected: not >= <green>-Infinity</>
+Received:        <red>Infinity</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [-Infinity, Infinity] 8`] = `
-"<dim>expect(</><red>received</><dim>).toBeLessThanOrEqual(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toBeLessThanOrEqual<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>-Infinity</>
-Received: <red>Infinity</>"
+Expected: <= <green>-Infinity</>
+Received:    <red>Infinity</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [0.1, 0.2] 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeGreaterThan(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toBeGreaterThan<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>0.2</>
-Received: <red>0.1</>"
+Expected: > <green>0.2</>
+Received:   <red>0.1</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [0.1, 0.2] 2`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.toBeLessThan(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeLessThan<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>0.2</>
-Received: <red>0.1</>"
+Expected: not < <green>0.2</>
+Received:       <red>0.1</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [0.1, 0.2] 3`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.toBeGreaterThan(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeGreaterThan<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>0.1</>
-Received: <red>0.2</>"
+Expected: not > <green>0.1</>
+Received:       <red>0.2</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [0.1, 0.2] 4`] = `
-"<dim>expect(</><red>received</><dim>).toBeLessThan(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toBeLessThan<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>0.1</>
-Received: <red>0.2</>"
+Expected: < <green>0.1</>
+Received:   <red>0.2</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [0.1, 0.2] 5`] = `
-"<dim>expect(</><red>received</><dim>).toBeGreaterThanOrEqual(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toBeGreaterThanOrEqual<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>0.2</>
-Received: <red>0.1</>"
+Expected: >= <green>0.2</>
+Received:    <red>0.1</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [0.1, 0.2] 6`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.toBeLessThanOrEqual(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeLessThanOrEqual<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>0.2</>
-Received: <red>0.1</>"
+Expected: not <= <green>0.2</>
+Received:        <red>0.1</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [0.1, 0.2] 7`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.toBeGreaterThanOrEqual(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeGreaterThanOrEqual<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>0.1</>
-Received: <red>0.2</>"
+Expected: not >= <green>0.1</>
+Received:        <red>0.2</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [0.1, 0.2] 8`] = `
-"<dim>expect(</><red>received</><dim>).toBeLessThanOrEqual(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toBeLessThanOrEqual<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>0.1</>
-Received: <red>0.2</>"
+Expected: <= <green>0.1</>
+Received:    <red>0.2</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [1, 2] 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeGreaterThan(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toBeGreaterThan<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>2</>
-Received: <red>1</>"
+Expected: > <green>2</>
+Received:   <red>1</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [1, 2] 2`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.toBeLessThan(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeLessThan<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>2</>
-Received: <red>1</>"
+Expected: not < <green>2</>
+Received:       <red>1</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [1, 2] 3`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.toBeGreaterThan(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeGreaterThan<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>1</>
-Received: <red>2</>"
+Expected: not > <green>1</>
+Received:       <red>2</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [1, 2] 4`] = `
-"<dim>expect(</><red>received</><dim>).toBeLessThan(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toBeLessThan<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>1</>
-Received: <red>2</>"
+Expected: < <green>1</>
+Received:   <red>2</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [1, 2] 5`] = `
-"<dim>expect(</><red>received</><dim>).toBeGreaterThanOrEqual(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toBeGreaterThanOrEqual<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>2</>
-Received: <red>1</>"
+Expected: >= <green>2</>
+Received:    <red>1</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [1, 2] 6`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.toBeLessThanOrEqual(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeLessThanOrEqual<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>2</>
-Received: <red>1</>"
+Expected: not <= <green>2</>
+Received:        <red>1</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [1, 2] 7`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.toBeGreaterThanOrEqual(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeGreaterThanOrEqual<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>1</>
-Received: <red>2</>"
+Expected: not >= <green>1</>
+Received:        <red>2</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [1, 2] 8`] = `
-"<dim>expect(</><red>received</><dim>).toBeLessThanOrEqual(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toBeLessThanOrEqual<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>1</>
-Received: <red>2</>"
+Expected: <= <green>1</>
+Received:    <red>2</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [3, 7] 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeGreaterThan(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toBeGreaterThan<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>7</>
-Received: <red>3</>"
+Expected: > <green>7</>
+Received:   <red>3</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [3, 7] 2`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.toBeLessThan(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeLessThan<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>7</>
-Received: <red>3</>"
+Expected: not < <green>7</>
+Received:       <red>3</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [3, 7] 3`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.toBeGreaterThan(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeGreaterThan<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>3</>
-Received: <red>7</>"
+Expected: not > <green>3</>
+Received:       <red>7</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [3, 7] 4`] = `
-"<dim>expect(</><red>received</><dim>).toBeLessThan(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toBeLessThan<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>3</>
-Received: <red>7</>"
+Expected: < <green>3</>
+Received:   <red>7</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [3, 7] 5`] = `
-"<dim>expect(</><red>received</><dim>).toBeGreaterThanOrEqual(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toBeGreaterThanOrEqual<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>7</>
-Received: <red>3</>"
+Expected: >= <green>7</>
+Received:    <red>3</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [3, 7] 6`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.toBeLessThanOrEqual(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeLessThanOrEqual<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>7</>
-Received: <red>3</>"
+Expected: not <= <green>7</>
+Received:        <red>3</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [3, 7] 7`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.toBeGreaterThanOrEqual(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeGreaterThanOrEqual<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>3</>
-Received: <red>7</>"
+Expected: not >= <green>3</>
+Received:        <red>7</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [3, 7] 8`] = `
-"<dim>expect(</><red>received</><dim>).toBeLessThanOrEqual(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toBeLessThanOrEqual<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>3</>
-Received: <red>7</>"
+Expected: <= <green>3</>
+Received:    <red>7</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [5e-324, 1.7976931348623157e+308] 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeGreaterThan(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toBeGreaterThan<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>1.7976931348623157e+308</>
-Received: <red>5e-324</>"
+Expected: > <green>1.7976931348623157e+308</>
+Received:   <red>5e-324</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [5e-324, 1.7976931348623157e+308] 2`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.toBeLessThan(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeLessThan<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>1.7976931348623157e+308</>
-Received: <red>5e-324</>"
+Expected: not < <green>1.7976931348623157e+308</>
+Received:       <red>5e-324</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [5e-324, 1.7976931348623157e+308] 3`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.toBeGreaterThan(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeGreaterThan<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>5e-324</>
-Received: <red>1.7976931348623157e+308</>"
+Expected: not > <green>5e-324</>
+Received:       <red>1.7976931348623157e+308</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [5e-324, 1.7976931348623157e+308] 4`] = `
-"<dim>expect(</><red>received</><dim>).toBeLessThan(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toBeLessThan<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>5e-324</>
-Received: <red>1.7976931348623157e+308</>"
+Expected: < <green>5e-324</>
+Received:   <red>1.7976931348623157e+308</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [5e-324, 1.7976931348623157e+308] 5`] = `
-"<dim>expect(</><red>received</><dim>).toBeGreaterThanOrEqual(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toBeGreaterThanOrEqual<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>1.7976931348623157e+308</>
-Received: <red>5e-324</>"
+Expected: >= <green>1.7976931348623157e+308</>
+Received:    <red>5e-324</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [5e-324, 1.7976931348623157e+308] 6`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.toBeLessThanOrEqual(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeLessThanOrEqual<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>1.7976931348623157e+308</>
-Received: <red>5e-324</>"
+Expected: not <= <green>1.7976931348623157e+308</>
+Received:        <red>5e-324</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [5e-324, 1.7976931348623157e+308] 7`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.toBeGreaterThanOrEqual(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeGreaterThanOrEqual<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>5e-324</>
-Received: <red>1.7976931348623157e+308</>"
+Expected: not >= <green>5e-324</>
+Received:        <red>1.7976931348623157e+308</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [5e-324, 1.7976931348623157e+308] 8`] = `
-"<dim>expect(</><red>received</><dim>).toBeLessThanOrEqual(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toBeLessThanOrEqual<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>5e-324</>
-Received: <red>1.7976931348623157e+308</>"
+Expected: <= <green>5e-324</>
+Received:    <red>1.7976931348623157e+308</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [9, 18] 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeGreaterThan(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toBeGreaterThan<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>18</>
-Received: <red>9</>"
+Expected: > <green>18</>
+Received:   <red>9</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [9, 18] 2`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.toBeLessThan(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeLessThan<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>18</>
-Received: <red>9</>"
+Expected: not < <green>18</>
+Received:       <red>9</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [9, 18] 3`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.toBeGreaterThan(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeGreaterThan<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>9</>
-Received: <red>18</>"
+Expected: not > <green>9</>
+Received:       <red>18</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [9, 18] 4`] = `
-"<dim>expect(</><red>received</><dim>).toBeLessThan(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toBeLessThan<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>9</>
-Received: <red>18</>"
+Expected: < <green>9</>
+Received:   <red>18</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [9, 18] 5`] = `
-"<dim>expect(</><red>received</><dim>).toBeGreaterThanOrEqual(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toBeGreaterThanOrEqual<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>18</>
-Received: <red>9</>"
+Expected: >= <green>18</>
+Received:    <red>9</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [9, 18] 6`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.toBeLessThanOrEqual(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeLessThanOrEqual<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>18</>
-Received: <red>9</>"
+Expected: not <= <green>18</>
+Received:        <red>9</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [9, 18] 7`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.toBeGreaterThanOrEqual(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeGreaterThanOrEqual<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>9</>
-Received: <red>18</>"
+Expected: not >= <green>9</>
+Received:        <red>18</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [9, 18] 8`] = `
-"<dim>expect(</><red>received</><dim>).toBeLessThanOrEqual(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toBeLessThanOrEqual<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>9</>
-Received: <red>18</>"
+Expected: <= <green>9</>
+Received:    <red>18</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [17, 34] 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeGreaterThan(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toBeGreaterThan<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>34</>
-Received: <red>17</>"
+Expected: > <green>34</>
+Received:   <red>17</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [17, 34] 2`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.toBeLessThan(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeLessThan<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>34</>
-Received: <red>17</>"
+Expected: not < <green>34</>
+Received:       <red>17</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [17, 34] 3`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.toBeGreaterThan(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeGreaterThan<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>17</>
-Received: <red>34</>"
+Expected: not > <green>17</>
+Received:       <red>34</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [17, 34] 4`] = `
-"<dim>expect(</><red>received</><dim>).toBeLessThan(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toBeLessThan<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>17</>
-Received: <red>34</>"
+Expected: < <green>17</>
+Received:   <red>34</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [17, 34] 5`] = `
-"<dim>expect(</><red>received</><dim>).toBeGreaterThanOrEqual(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toBeGreaterThanOrEqual<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>34</>
-Received: <red>17</>"
+Expected: >= <green>34</>
+Received:    <red>17</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [17, 34] 6`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.toBeLessThanOrEqual(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeLessThanOrEqual<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>34</>
-Received: <red>17</>"
+Expected: not <= <green>34</>
+Received:        <red>17</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [17, 34] 7`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.toBeGreaterThanOrEqual(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeGreaterThanOrEqual<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>17</>
-Received: <red>34</>"
+Expected: not >= <green>17</>
+Received:        <red>34</>"
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [17, 34] 8`] = `
-"<dim>expect(</><red>received</><dim>).toBeLessThanOrEqual(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toBeLessThanOrEqual<dim>(</><green>expected</><dim>)</>
 
-Expected: <green>17</>
-Received: <red>34</>"
+Expected: <= <green>17</>
+Received:    <red>34</>"
 `;
 
 exports[`.toBeInstanceOf() failing "a" and [Function String] 1`] = `

--- a/packages/expect/src/matchers.js
+++ b/packages/expect/src/matchers.js
@@ -144,29 +144,41 @@ const matchers: MatchersObject = {
     return {message, pass};
   },
 
-  toBeGreaterThan(actual: number, expected: number) {
-    ensureNumbers(actual, expected, '.toBeGreaterThan');
-    const pass = actual > expected;
+  toBeGreaterThan(received: number, expected: number) {
+    const isNot = this.isNot;
+    const options = {
+      isNot,
+      promise: this.promise,
+    };
+    ensureNumbers(received, expected, '.toBeGreaterThan');
+
+    const pass = received > expected;
+
     const message = () =>
-      matcherHint('.toBeGreaterThan', undefined, undefined, {
-        isNot: this.isNot,
-      }) +
+      matcherHint('toBeGreaterThan', undefined, undefined, options) +
       '\n\n' +
-      `Expected: ${printExpected(expected)}\n` +
-      `Received: ${printReceived(actual)}`;
+      `Expected:${isNot ? ' not' : ''} > ${printExpected(expected)}\n` +
+      `Received:${isNot ? '    ' : ''}   ${printReceived(received)}`;
+
     return {message, pass};
   },
 
-  toBeGreaterThanOrEqual(actual: number, expected: number) {
-    ensureNumbers(actual, expected, '.toBeGreaterThanOrEqual');
-    const pass = actual >= expected;
+  toBeGreaterThanOrEqual(received: number, expected: number) {
+    const isNot = this.isNot;
+    const options = {
+      isNot,
+      promise: this.promise,
+    };
+    ensureNumbers(received, expected, '.toBeGreaterThanOrEqual');
+
+    const pass = received >= expected;
+
     const message = () =>
-      matcherHint('.toBeGreaterThanOrEqual', undefined, undefined, {
-        isNot: this.isNot,
-      }) +
+      matcherHint('toBeGreaterThanOrEqual', undefined, undefined, options) +
       '\n\n' +
-      `Expected: ${printExpected(expected)}\n` +
-      `Received: ${printReceived(actual)}`;
+      `Expected:${isNot ? ' not' : ''} >= ${printExpected(expected)}\n` +
+      `Received:${isNot ? '    ' : ''}    ${printReceived(received)}`;
+
     return {message, pass};
   },
 
@@ -214,29 +226,41 @@ const matchers: MatchersObject = {
     return {message, pass};
   },
 
-  toBeLessThan(actual: number, expected: number) {
-    ensureNumbers(actual, expected, '.toBeLessThan');
-    const pass = actual < expected;
+  toBeLessThan(received: number, expected: number) {
+    const isNot = this.isNot;
+    const options = {
+      isNot,
+      promise: this.promise,
+    };
+    ensureNumbers(received, expected, '.toBeLessThan');
+
+    const pass = received < expected;
+
     const message = () =>
-      matcherHint('.toBeLessThan', undefined, undefined, {
-        isNot: this.isNot,
-      }) +
+      matcherHint('toBeLessThan', undefined, undefined, options) +
       '\n\n' +
-      `Expected: ${printExpected(expected)}\n` +
-      `Received: ${printReceived(actual)}`;
+      `Expected:${isNot ? ' not' : ''} < ${printExpected(expected)}\n` +
+      `Received:${isNot ? '    ' : ''}   ${printReceived(received)}`;
+
     return {message, pass};
   },
 
-  toBeLessThanOrEqual(actual: number, expected: number) {
-    ensureNumbers(actual, expected, '.toBeLessThanOrEqual');
-    const pass = actual <= expected;
+  toBeLessThanOrEqual(received: number, expected: number) {
+    const isNot = this.isNot;
+    const options = {
+      isNot,
+      promise: this.promise,
+    };
+    ensureNumbers(received, expected, '.toBeLessThanOrEqual');
+
+    const pass = received <= expected;
+
     const message = () =>
-      matcherHint('.toBeLessThanOrEqual', undefined, undefined, {
-        isNot: this.isNot,
-      }) +
+      matcherHint('toBeLessThanOrEqual', undefined, undefined, options) +
       '\n\n' +
-      `Expected: ${printExpected(expected)}\n` +
-      `Received: ${printReceived(actual)}`;
+      `Expected:${isNot ? ' not' : ''} <= ${printExpected(expected)}\n` +
+      `Received:${isNot ? '    ' : ''}    ${printReceived(received)}`;
+
     return {message, pass};
   },
 


### PR DESCRIPTION
## Summary

For 4 matchers which correspond to `>`, `>=`, `<`, `<=` number comparison operators:

* Display matcher name in regular black instead of dim color
* Repeat `not` and operator following `Expected:` label

For more information, see discussion with @jeysal in #7795

For these matchers which define expected intervals, I have not thought of any additional way to reduce apparent weirdness when received value is equal to expected boundary.

Residue for future pull request, in call to `ensureNumbers` helper function:

* Delete period in matcher name to display matcher name in regular black instead of dim color
* Provide `options` as argument to display `promise` and `isNot`

## Test plan

Updated 66 snapshots. To save mental effort, review as 33 adjacent pairs of snapshots.

|  | matcher |
| ---: | :--- |
| 14 | `toBeGreaterThan` |
| 19 | `toBeGreaterThanOrEqual` |
| 14 | `toBeLessThan` |
| 19 | `toBeLessThanOrEqual` |

Here are pictures for 2 out of 4 matchers:

* beyond baseline at left (matcher name already black instead of dim)
* improved at right

<img width="800" alt="tobegreaterthanorequal 3" src="https://user-images.githubusercontent.com/11862657/52582222-ac760380-2dfa-11e9-9db7-867d6e9997e2.png">

<img width="800" alt="tobelessthan 3" src="https://user-images.githubusercontent.com/11862657/52582615-9157c380-2dfb-11e9-8ce7-1baeeb49ba0f.png">
