### PR TITLE
chore: migrate jest-resolve to TypeScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - `[jest-haste-map]`: Migrate to TypeScript ([#7854](https://github.com/facebook/jest/pull/7854))
 - `[docs]`: Fix image paths in SnapshotTesting.md for current and version 24 ([#7872](https://github.com/facebook/jest/pull/7872))
 - `[babel-jest]`: Migrate to TypeScript ([#7862](https://github.com/facebook/jest/pull/7862))
+- `[jest-resolve]`: Migrate to TypeScript ([#7871](https://github.com/facebook/jest/pull/7871))
 
 ### Performance
 

--- a/e2e/__tests__/__snapshots__/moduleNameMapper.test.js.snap
+++ b/e2e/__tests__/__snapshots__/moduleNameMapper.test.js.snap
@@ -30,6 +30,6 @@ FAIL __tests__/index.js
       12 | module.exports = () => 'test';
       13 | 
 
-      at createNoMappedModuleFoundError (../../packages/jest-resolve/build/index.js:436:17)
+      at createNoMappedModuleFoundError (../../packages/jest-resolve/build/index.js:434:17)
       at Object.require (index.js:10:1)
 `;

--- a/e2e/__tests__/__snapshots__/resolveNoFileExtensions.test.js.snap
+++ b/e2e/__tests__/__snapshots__/resolveNoFileExtensions.test.js.snap
@@ -33,6 +33,6 @@ FAIL __tests__/test.js
         |                  ^
       4 | 
 
-      at Resolver.resolveModule (../../packages/jest-resolve/build/index.js:203:17)
+      at Resolver.resolveModule (../../packages/jest-resolve/build/index.js:201:17)
       at Object.require (index.js:3:18)
 `;

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "progress": "^2.0.0",
     "promise": "^8.0.2",
     "readable-stream": "^3.0.3",
-    "realpath-native": "^1.0.0",
+    "realpath-native": "^1.1.0",
     "resolve": "^1.4.0",
     "rimraf": "^2.6.2",
     "slash": "^2.0.0",

--- a/packages/jest-cli/package.json
+++ b/packages/jest-cli/package.json
@@ -35,7 +35,7 @@
     "p-each-series": "^1.0.0",
     "pirates": "^4.0.0",
     "prompts": "^2.0.1",
-    "realpath-native": "^1.0.0",
+    "realpath-native": "^1.1.0",
     "rimraf": "^2.5.4",
     "slash": "^2.0.0",
     "string-length": "^2.0.0",

--- a/packages/jest-config/package.json
+++ b/packages/jest-config/package.json
@@ -23,7 +23,7 @@
     "jest-validate": "^24.0.0",
     "micromatch": "^3.1.10",
     "pretty-format": "^24.0.0",
-    "realpath-native": "^1.0.2"
+    "realpath-native": "^1.1.0"
   },
   "devDependencies":  {
     "@types/babel__core": "^7.0.4",

--- a/packages/jest-haste-map/src/ModuleMap.ts
+++ b/packages/jest-haste-map/src/ModuleMap.ts
@@ -41,9 +41,9 @@ export default class ModuleMap {
 
   getModule(
     name: string,
-    platform: string | null,
-    supportsNativePlatform: boolean | null,
-    type: HTypeValue | null,
+    platform?: string | null,
+    supportsNativePlatform?: boolean | null,
+    type?: HTypeValue | null,
   ): Config.Path | null {
     if (type == null) {
       type = H.MODULE;
@@ -62,7 +62,7 @@ export default class ModuleMap {
 
   getPackage(
     name: string,
-    platform: string | null,
+    platform: string | null | undefined,
     _supportsNativePlatform: boolean | null,
   ): Config.Path | null {
     return this.getModule(name, platform, null, H.PACKAGE);
@@ -111,7 +111,7 @@ export default class ModuleMap {
    */
   private _getModuleMetadata(
     name: string,
-    platform: string | null,
+    platform: string | null | undefined,
     supportsNativePlatform: boolean,
   ): ModuleMetaData | null {
     const map = this._raw.map.get(name) || EMPTY_OBJ;

--- a/packages/jest-resolve/package.json
+++ b/packages/jest-resolve/package.json
@@ -8,13 +8,18 @@
   },
   "license": "MIT",
   "main": "build/index.js",
+  "types": "build/index.d.ts",
   "dependencies": {
+    "@jest/types": "^24.1.0",
     "browser-resolve": "^1.11.3",
     "chalk": "^2.0.1",
-    "realpath-native": "^1.0.0"
+    "realpath-native": "^1.1.0"
   },
   "devDependencies": {
     "@types/browser-resolve": "^0.0.5",
+    "jest-haste-map": "^24.0.0"
+  },
+  "peerDependencies": {
     "jest-haste-map": "^24.0.0"
   },
   "engines": {

--- a/packages/jest-resolve/src/__tests__/isBuiltinModule.test.ts
+++ b/packages/jest-resolve/src/__tests__/isBuiltinModule.test.ts
@@ -1,5 +1,4 @@
 // Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
-// @flow
 
 import isBuiltinModule from '../isBuiltinModule';
 

--- a/packages/jest-resolve/src/__tests__/resolve.test.ts
+++ b/packages/jest-resolve/src/__tests__/resolve.test.ts
@@ -6,16 +6,18 @@
  *
  */
 
-'use strict';
-
 import fs from 'fs';
 import path from 'path';
-import {ModuleMap} from 'jest-haste-map';
-// eslint-disable-next-line import/default
+import HasteMap from 'jest-haste-map';
 import Resolver from '../';
+// @ts-ignore: js file
 import userResolver from '../__mocks__/userResolver';
 import nodeModulesPaths from '../nodeModulesPaths';
 import defaultResolver from '../defaultResolver';
+import {ResolverConfig} from '../types';
+
+// @ts-ignore: types are wrong. not sure how...
+const {ModuleMap} = HasteMap;
 
 jest.mock('../__mocks__/userResolver');
 
@@ -28,21 +30,21 @@ describe('isCoreModule', () => {
     const moduleMap = ModuleMap.create('/');
     const resolver = new Resolver(moduleMap, {
       hasCoreModules: false,
-    });
+    } as ResolverConfig);
     const isCore = resolver.isCoreModule('assert');
     expect(isCore).toEqual(false);
   });
 
   it('returns true if `hasCoreModules` is true and `moduleName` is a core module.', () => {
     const moduleMap = ModuleMap.create('/');
-    const resolver = new Resolver(moduleMap, {});
+    const resolver = new Resolver(moduleMap, {} as ResolverConfig);
     const isCore = resolver.isCoreModule('assert');
     expect(isCore).toEqual(true);
   });
 
   it('returns false if `hasCoreModules` is true and `moduleName` is not a core module.', () => {
     const moduleMap = ModuleMap.create('/');
-    const resolver = new Resolver(moduleMap, {});
+    const resolver = new Resolver(moduleMap, {} as ResolverConfig);
     const isCore = resolver.isCoreModule('not-a-core-module');
     expect(isCore).toEqual(false);
   });
@@ -84,7 +86,7 @@ describe('findNodeModule', () => {
 });
 
 describe('resolveModule', () => {
-  let moduleMap;
+  let moduleMap: typeof ModuleMap;
   beforeEach(() => {
     moduleMap = ModuleMap.create('/');
   });
@@ -92,7 +94,7 @@ describe('resolveModule', () => {
   it('is possible to resolve node modules', () => {
     const resolver = new Resolver(moduleMap, {
       extensions: ['.js'],
-    });
+    } as ResolverConfig);
     const src = require.resolve('../');
     const resolved = resolver.resolveModule(
       src,
@@ -104,7 +106,7 @@ describe('resolveModule', () => {
   it('is possible to resolve node modules with custom extensions', () => {
     const resolver = new Resolver(moduleMap, {
       extensions: ['.js', '.jsx'],
-    });
+    } as ResolverConfig);
     const src = require.resolve('../');
     const resolvedJsx = resolver.resolveModule(
       src,
@@ -119,7 +121,7 @@ describe('resolveModule', () => {
     const resolver = new Resolver(moduleMap, {
       extensions: ['.js', '.jsx'],
       platforms: ['native'],
-    });
+    } as ResolverConfig);
     const src = require.resolve('../');
     const resolvedJsx = resolver.resolveModule(
       src,
@@ -133,7 +135,7 @@ describe('resolveModule', () => {
   it('is possible to resolve node modules by resolving their realpath', () => {
     const resolver = new Resolver(moduleMap, {
       extensions: ['.js'],
-    });
+    } as ResolverConfig);
     const src = path.join(
       path.resolve(__dirname, '../../src/__mocks__/bar/node_modules/'),
       'foo/index.js',
@@ -147,7 +149,7 @@ describe('resolveModule', () => {
   it('is possible to specify custom resolve paths', () => {
     const resolver = new Resolver(moduleMap, {
       extensions: ['.js'],
-    });
+    } as ResolverConfig);
     const src = require.resolve('../');
     const resolved = resolver.resolveModule(src, 'mockJsDependency', {
       paths: [
@@ -173,7 +175,7 @@ describe('getMockModule', () => {
         },
       ],
       resolver: require.resolve('../__mocks__/userResolver'),
-    });
+    } as ResolverConfig);
     const src = require.resolve('../');
     resolver.getMockModule(src, 'dependentModule');
 
@@ -196,7 +198,7 @@ describe('nodeModulesPaths', () => {
 
 describe('Resolver.getModulePaths() -> nodeModulesPaths()', () => {
   const _path = path;
-  let moduleMap;
+  let moduleMap: typeof ModuleMap;
 
   beforeEach(() => {
     jest.resetModules();
@@ -208,7 +210,7 @@ describe('Resolver.getModulePaths() -> nodeModulesPaths()', () => {
     // This test suite won't work otherwise, since we cannot make assumptions
     // about the test environment when it comes to absolute paths.
     jest.doMock('realpath-native', () => ({
-      sync: dirInput => dirInput,
+      sync: (dirInput: string) => dirInput,
     }));
   });
 

--- a/packages/jest-resolve/src/defaultResolver.ts
+++ b/packages/jest-resolve/src/defaultResolver.ts
@@ -3,33 +3,29 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- * @flow
  */
 
-import type {Path} from 'types/Config';
-import type {ErrorWithCode} from 'types/Errors';
-
-import browserResolve from 'browser-resolve';
 import fs from 'fs';
 import path from 'path';
+import browserResolve from 'browser-resolve';
+import {Config} from '@jest/types';
 import isBuiltinModule from './isBuiltinModule';
 import nodeModulesPaths from './nodeModulesPaths';
 
-type ResolverOptions = {|
-  basedir: Path,
-  browser?: boolean,
-  defaultResolver: typeof defaultResolver,
-  extensions?: Array<string>,
-  moduleDirectory?: Array<string>,
-  paths?: ?Array<Path>,
-  rootDir: ?Path,
-|};
+type ResolverOptions = {
+  basedir: Config.Path;
+  browser?: boolean;
+  defaultResolver: typeof defaultResolver;
+  extensions?: Array<string>;
+  moduleDirectory?: Array<string>;
+  paths?: Array<Config.Path>;
+  rootDir?: Config.Path;
+};
 
 export default function defaultResolver(
-  path: Path,
+  path: Config.Path,
   options: ResolverOptions,
-): Path {
+): Config.Path {
   const resolve = options.browser ? browserResolve.sync : resolveSync;
 
   return resolve(path, {
@@ -44,7 +40,10 @@ export default function defaultResolver(
 
 const REGEX_RELATIVE_IMPORT = /^(?:\.\.?(?:\/|$)|\/|([A-Za-z]:)?[\\\/])/;
 
-function resolveSync(target: Path, options: ResolverOptions): Path {
+function resolveSync(
+  target: Config.Path,
+  options: ResolverOptions,
+): Config.Path {
   const basedir = options.basedir;
   const extensions = options.extensions || ['.js'];
   const paths = options.paths || [];
@@ -75,7 +74,7 @@ function resolveSync(target: Path, options: ResolverOptions): Path {
     return target;
   }
 
-  const err: ErrorWithCode = new Error(
+  const err: Error & {code?: string} = new Error(
     "Cannot find module '" + target + "' from '" + basedir + "'",
   );
   err.code = 'MODULE_NOT_FOUND';
@@ -84,7 +83,7 @@ function resolveSync(target: Path, options: ResolverOptions): Path {
   /*
    * contextual helper functions
    */
-  function tryResolve(name: Path): ?Path {
+  function tryResolve(name: Config.Path): Config.Path | undefined {
     const dir = path.dirname(name);
     let result;
     if (isDirectory(dir)) {
@@ -98,7 +97,7 @@ function resolveSync(target: Path, options: ResolverOptions): Path {
     return result;
   }
 
-  function resolveAsFile(name: Path): ?Path {
+  function resolveAsFile(name: Config.Path): Config.Path | undefined {
     if (isFile(name)) {
       return name;
     }
@@ -113,7 +112,7 @@ function resolveSync(target: Path, options: ResolverOptions): Path {
     return undefined;
   }
 
-  function resolveAsDirectory(name: Path): ?Path {
+  function resolveAsDirectory(name: Config.Path): Config.Path | undefined {
     if (!isDirectory(name)) {
       return undefined;
     }
@@ -140,7 +139,7 @@ function resolveSync(target: Path, options: ResolverOptions): Path {
 /*
  * helper functions
  */
-function isFile(file: Path): boolean {
+function isFile(file: Config.Path): boolean {
   let result;
 
   try {
@@ -156,7 +155,7 @@ function isFile(file: Path): boolean {
   return result;
 }
 
-function isDirectory(dir: Path): boolean {
+function isDirectory(dir: Config.Path): boolean {
   let result;
 
   try {
@@ -172,6 +171,6 @@ function isDirectory(dir: Path): boolean {
   return result;
 }
 
-function isCurrentDirectory(testPath: Path): boolean {
+function isCurrentDirectory(testPath: Config.Path): boolean {
   return path.resolve('.') === path.resolve(testPath);
 }

--- a/packages/jest-resolve/src/isBuiltinModule.ts
+++ b/packages/jest-resolve/src/isBuiltinModule.ts
@@ -3,23 +3,20 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- * @flow
  */
 
-// $FlowFixMe: Flow doesn't know about the `module` module
-import {builtinModules} from 'module';
+import module from 'module';
 
-// https://github.com/facebook/flow/pull/5160
-declare var process: {
-  binding(type: string): {},
+// @ts-ignore: "private" api
+declare const process: {
+  binding(type: string): {};
 };
 
 const EXPERIMENTAL_MODULES = ['worker_threads'];
 
 const BUILTIN_MODULES = new Set(
-  builtinModules
-    ? builtinModules.concat(EXPERIMENTAL_MODULES)
+  module.builtinModules
+    ? module.builtinModules.concat(EXPERIMENTAL_MODULES)
     : Object.keys(process.binding('natives'))
         .filter((module: string) => !/^internal\//.test(module))
         .concat(EXPERIMENTAL_MODULES),

--- a/packages/jest-resolve/src/nodeModulesPaths.ts
+++ b/packages/jest-resolve/src/nodeModulesPaths.ts
@@ -5,26 +5,24 @@
  * LICENSE file in the root directory of this source tree.
  *
  * Adapted from: https://github.com/substack/node-resolve
- *
- * @flow
  */
 
-import type {Path} from 'types/Config';
 import path from 'path';
+import {Config} from '@jest/types';
 import {sync as realpath} from 'realpath-native';
 
-type NodeModulesPathsOptions = {|
-  moduleDirectory?: Array<string>,
-  paths?: ?Array<Path>,
-|};
+type NodeModulesPathsOptions = {
+  moduleDirectory?: Array<string>;
+  paths?: Array<Config.Path>;
+};
 
 export default function nodeModulesPaths(
-  basedir: Path,
+  basedir: Config.Path,
   options: NodeModulesPathsOptions,
-): Path[] {
+): Config.Path[] {
   const modules =
     options && options.moduleDirectory
-      ? [].concat(options.moduleDirectory)
+      ? Array.from(options.moduleDirectory)
       : ['node_modules'];
 
   // ensure that `basedir` is an absolute path at this point,
@@ -48,7 +46,7 @@ export default function nodeModulesPaths(
     physicalBasedir = basedirAbs;
   }
 
-  const paths = [physicalBasedir];
+  const paths: Array<Config.Path> = [physicalBasedir];
   let parsed = path.parse(physicalBasedir);
   while (parsed.dir !== paths[paths.length - 1]) {
     paths.push(parsed.dir);
@@ -67,7 +65,7 @@ export default function nodeModulesPaths(
               : path.join(prefix, aPath, moduleDir),
           ),
         ),
-      [],
+      [] as Array<Config.Path>,
     )
     .filter(dir => dir !== '');
 

--- a/packages/jest-resolve/src/types.ts
+++ b/packages/jest-resolve/src/types.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {Config} from '@jest/types';
+
+export type ResolverConfig = {
+  browser?: boolean;
+  defaultPlatform?: string;
+  extensions: Array<string>;
+  hasCoreModules: boolean;
+  moduleDirectories: Array<string>;
+  moduleNameMapper?: Array<ModuleNameMapperConfig>;
+  modulePaths: Array<Config.Path>;
+  platforms?: Array<string>;
+  resolver: Config.Path;
+  rootDir: Config.Path;
+};
+
+type ModuleNameMapperConfig = {
+  regex: RegExp;
+  moduleName: string;
+};

--- a/packages/jest-resolve/tsconfig.json
+++ b/packages/jest-resolve/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "build"
+  },
+  "references": [{"path":  "../jest-types"}, {"path":  "../jest-haste-map"}]
+}

--- a/packages/jest-runtime/package.json
+++ b/packages/jest-runtime/package.json
@@ -26,7 +26,7 @@
     "jest-util": "^24.0.0",
     "jest-validate": "^24.0.0",
     "micromatch": "^3.1.10",
-    "realpath-native": "^1.0.0",
+    "realpath-native": "^1.1.0",
     "slash": "^2.0.0",
     "strip-bom": "^3.0.0",
     "write-file-atomic": "2.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11063,10 +11063,10 @@ readdirp@^2.0.0:
     micromatch "^3.1.10"
     readable-stream "^2.0.2"
 
-realpath-native@^1.0.0, realpath-native@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/realpath-native/-/realpath-native-1.0.2.tgz#cd51ce089b513b45cf9b1516c82989b51ccc6560"
-  integrity sha512-+S3zTvVt9yTntFrBpm7TQmQ3tzpCrnA1a/y+3cUHAc9ZR6aIjG0WNLR+Rj79QpJktY+VeW/TQtFlQ1bzsehI8g==
+realpath-native@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/realpath-native/-/realpath-native-1.1.0.tgz#2003294fea23fb0672f2476ebe22fcf498a2d65c"
+  integrity sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==
   dependencies:
     util.promisify "^1.0.0"
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

As expected, had to tweak `jest-haste-map`'s types a bit to match `undefined | null` stuff. Can revisit later and be more consistent across the board

Built diff:

<details>

```diff
diff --git c/packages/jest-resolve/build/defaultResolver.js w/packages/jest-resolve/build/defaultResolver.js
index fab1abcb1..60db7374c 100644
--- c/packages/jest-resolve/build/defaultResolver.js
+++ w/packages/jest-resolve/build/defaultResolver.js
@@ -5,30 +5,30 @@ Object.defineProperty(exports, '__esModule', {
 });
 exports.default = defaultResolver;
 
-function _browserResolve() {
-  const data = _interopRequireDefault(require('browser-resolve'));
+function _fs() {
+  const data = _interopRequireDefault(require('fs'));
 
-  _browserResolve = function _browserResolve() {
+  _fs = function _fs() {
     return data;
   };
 
   return data;
 }
 
-function _fs() {
-  const data = _interopRequireDefault(require('fs'));
+function _path() {
+  const data = _interopRequireDefault(require('path'));
 
-  _fs = function _fs() {
+  _path = function _path() {
     return data;
   };
 
   return data;
 }
 
-function _path() {
-  const data = _interopRequireDefault(require('path'));
+function _browserResolve() {
+  const data = _interopRequireDefault(require('browser-resolve'));
 
-  _path = function _path() {
+  _browserResolve = function _browserResolve() {
     return data;
   };
 
@@ -48,8 +48,6 @@ function _interopRequireDefault(obj) {
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 function defaultResolver(path, options) {
   const resolve = options.browser
diff --git c/packages/jest-resolve/build/index.js w/packages/jest-resolve/build/index.js
index a397e5f2b..af3a8dfdb 100644
--- c/packages/jest-resolve/build/index.js
+++ w/packages/jest-resolve/build/index.js
@@ -20,12 +20,6 @@ function _realpathNative() {
   return data;
 }
 
-var _nodeModulesPaths = _interopRequireDefault(require('./nodeModulesPaths'));
-
-var _isBuiltinModule = _interopRequireDefault(require('./isBuiltinModule'));
-
-var _defaultResolver = _interopRequireDefault(require('./defaultResolver'));
-
 function _chalk() {
   const data = _interopRequireDefault(require('chalk'));
 
@@ -36,6 +30,12 @@ function _chalk() {
   return data;
 }
 
+var _nodeModulesPaths = _interopRequireDefault(require('./nodeModulesPaths'));
+
+var _isBuiltinModule = _interopRequireDefault(require('./isBuiltinModule'));
+
+var _defaultResolver = _interopRequireDefault(require('./defaultResolver'));
+
 function _interopRequireDefault(obj) {
   return obj && obj.__esModule ? obj : {default: obj};
 }
@@ -45,8 +45,6 @@ function _interopRequireDefault(obj) {
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
 const NATIVE_PLATFORM = 'native'; // We might be inside a symlink.
 
diff --git c/packages/jest-resolve/build/isBuiltinModule.js w/packages/jest-resolve/build/isBuiltinModule.js
index 9ae6e31ef..a4c9f5035 100644
--- c/packages/jest-resolve/build/isBuiltinModule.js
+++ w/packages/jest-resolve/build/isBuiltinModule.js
@@ -5,29 +5,30 @@ Object.defineProperty(exports, '__esModule', {
 });
 exports.default = isBuiltinModule;
 
-function _module() {
-  const data = require('module');
+function _module2() {
+  const data = _interopRequireDefault(require('module'));
 
-  _module = function _module() {
+  _module2 = function _module2() {
     return data;
   };
 
   return data;
 }
 
+function _interopRequireDefault(obj) {
+  return obj && obj.__esModule ? obj : {default: obj};
+}
+
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- *
  */
-// $FlowFixMe: Flow doesn't know about the `module` module
 const EXPERIMENTAL_MODULES = ['worker_threads'];
 const BUILTIN_MODULES = new Set(
-  _module().builtinModules
-    ? _module().builtinModules.concat(EXPERIMENTAL_MODULES)
+  _module2().default.builtinModules
+    ? _module2().default.builtinModules.concat(EXPERIMENTAL_MODULES)
     : Object.keys(process.binding('natives'))
         .filter(module => !/^internal\//.test(module))
         .concat(EXPERIMENTAL_MODULES)
diff --git c/packages/jest-resolve/build/nodeModulesPaths.js w/packages/jest-resolve/build/nodeModulesPaths.js
index c3bef18cd..8d9d10f0c 100644
--- c/packages/jest-resolve/build/nodeModulesPaths.js
+++ w/packages/jest-resolve/build/nodeModulesPaths.js
@@ -36,13 +36,11 @@ function _interopRequireDefault(obj) {
  * LICENSE file in the root directory of this source tree.
  *
  * Adapted from: https://github.com/substack/node-resolve
- *
- *
  */
 function nodeModulesPaths(basedir, options) {
   const modules =
     options && options.moduleDirectory
-      ? [].concat(options.moduleDirectory)
+      ? Array.from(options.moduleDirectory)
       : ['node_modules']; // ensure that `basedir` is an absolute path at this point,
   // resolving against the process' current working directory
 
diff --git c/packages/jest-resolve/build/types.js w/packages/jest-resolve/build/types.js
new file mode 100644
index 000000000..ad9a93a7c
--- /dev/null
+++ w/packages/jest-resolve/build/types.js
@@ -0,0 +1 @@
+'use strict';

```
</details>

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Green CI

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
