### PR TITLE
expect: Improve report when matcher fails, part 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 - `[expect]`: Improve report when matcher fails, part 7 ([#7866](https://github.com/facebook/jest/pull/7866))
+- `[expect]`: Improve report when matcher fails, part 8 ([#7876](https://github.com/facebook/jest/pull/7876))
 
 ### Fixes
 

--- a/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -395,7 +395,7 @@ Expected: <green>-1.23</>
 Received: <red>-Infinity</>
 
 Expected precision:    <green>2</>
-Expected difference: < <green>5e-3</>
+Expected difference: < <green>0.005</>
 Received difference:   <red>Infinity</>"
 `;
 
@@ -406,7 +406,7 @@ Expected: <green>-Infinity</>
 Received: <red>Infinity</>
 
 Expected precision:    <green>2</>
-Expected difference: < <green>5e-3</>
+Expected difference: < <green>0.005</>
 Received difference:   <red>Infinity</>"
 `;
 
@@ -417,7 +417,7 @@ Expected: <green>1.23</>
 Received: <red>Infinity</>
 
 Expected precision:    <green>2</>
-Expected difference: < <green>5e-3</>
+Expected difference: < <green>0.005</>
 Received difference:   <red>Infinity</>"
 `;
 
@@ -442,8 +442,8 @@ Expected: not <green>0.001</>
 Received:     <red>0</>
 
 Expected precision:        <green>2</>
-Expected difference: not < <green>5e-3</>
-Received difference:       <red>1e-3</>"
+Expected difference: not < <green>0.005</>
+Received difference:       <red>0.001</>"
 `;
 
 exports[`.toBeCloseTo() {pass: true} expect(1.23)toBeCloseTo( 1.225) 1`] = `
@@ -453,8 +453,8 @@ Expected: not <green>1.225</>
 Received:     <red>1.23</>
 
 Expected precision:        <green>2</>
-Expected difference: not < <green>5e-3</>
-Received difference:       <red>4.999999999999893e-3</>"
+Expected difference: not < <green>0.005</>
+Received difference:       <red>0.004999999999999893</>"
 `;
 
 exports[`.toBeCloseTo() {pass: true} expect(1.23)toBeCloseTo( 1.226) 1`] = `
@@ -464,8 +464,8 @@ Expected: not <green>1.226</>
 Received:     <red>1.23</>
 
 Expected precision:        <green>2</>
-Expected difference: not < <green>5e-3</>
-Received difference:       <red>4.0000000000000036e-3</>"
+Expected difference: not < <green>0.005</>
+Received difference:       <red>0.0040000000000000036</>"
 `;
 
 exports[`.toBeCloseTo() {pass: true} expect(1.23)toBeCloseTo( 1.229) 1`] = `
@@ -475,8 +475,8 @@ Expected: not <green>1.229</>
 Received:     <red>1.23</>
 
 Expected precision:        <green>2</>
-Expected difference: not < <green>5e-3</>
-Received difference:       <red>9.999999999998899e-4</>"
+Expected difference: not < <green>0.005</>
+Received difference:       <red>0.0009999999999998899</>"
 `;
 
 exports[`.toBeCloseTo() {pass: true} expect(1.23)toBeCloseTo( 1.234) 1`] = `
@@ -486,8 +486,8 @@ Expected: not <green>1.234</>
 Received:     <red>1.23</>
 
 Expected precision:        <green>2</>
-Expected difference: not < <green>5e-3</>
-Received difference:       <red>4.0000000000000036e-3</>"
+Expected difference: not < <green>0.005</>
+Received difference:       <red>0.0040000000000000036</>"
 `;
 
 exports[`.toBeCloseTo() {pass: true} expect(Infinity)toBeCloseTo( Infinity) 1`] = `
@@ -504,8 +504,8 @@ Expected: not <green>0.000004</>
 Received:     <red>0</>
 
 Expected precision:        <green>5</>
-Expected difference: not < <green>5e-6</>
-Received difference:       <red>4e-6</>"
+Expected difference: not < <green>0.000005</>
+Received difference:       <red>0.000004</>"
 `;
 
 exports[`.toBeCloseTo() accepts an optional precision argument: [0, 0.0001, 3] 1`] = `
@@ -515,8 +515,8 @@ Expected: not <green>0.0001</>
 Received:     <red>0</>
 
 Expected precision:        <green>3</>
-Expected difference: not < <green>5e-4</>
-Received difference:       <red>1e-4</>"
+Expected difference: not < <green>0.0005</>
+Received difference:       <red>0.0001</>"
 `;
 
 exports[`.toBeCloseTo() accepts an optional precision argument: [0, 0.1, 0] 1`] = `
@@ -526,8 +526,8 @@ Expected: not <green>0.1</>
 Received:     <red>0</>
 
 Expected precision:        <green>0</>
-Expected difference: not < <green>5e-1</>
-Received difference:       <red>1e-1</>"
+Expected difference: not < <green>0.5</>
+Received difference:       <red>0.1</>"
 `;
 
 exports[`.toBeCloseTo() throws: [0, 0.01] 1`] = `
@@ -537,8 +537,8 @@ Expected: <green>0.01</>
 Received: <red>0</>
 
 Expected precision:    <green>2</>
-Expected difference: < <green>5e-3</>
-Received difference:   <red>1e-2</>"
+Expected difference: < <green>0.005</>
+Received difference:   <red>0.01</>"
 `;
 
 exports[`.toBeCloseTo() throws: [1, 1.23] 1`] = `
@@ -548,8 +548,8 @@ Expected: <green>1.23</>
 Received: <red>1</>
 
 Expected precision:    <green>2</>
-Expected difference: < <green>5e-3</>
-Received difference:   <red>2.2999999999999998e-1</>"
+Expected difference: < <green>0.005</>
+Received difference:   <red>0.22999999999999998</>"
 `;
 
 exports[`.toBeCloseTo() throws: [1.23, 1.2249999] 1`] = `
@@ -559,8 +559,8 @@ Expected: <green>1.2249999</>
 Received: <red>1.23</>
 
 Expected precision:    <green>2</>
-Expected difference: < <green>5e-3</>
-Received difference:   <red>5.000099999999952e-3</>"
+Expected difference: < <green>0.005</>
+Received difference:   <red>0.005000099999999952</>"
 `;
 
 exports[`.toBeDefined(), .toBeUndefined() '"a"' is defined 1`] = `

--- a/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -389,139 +389,178 @@ Received: <red>true</>"
 `;
 
 exports[`.toBeCloseTo() {pass: false} expect(-Infinity)toBeCloseTo( -1.23) 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeCloseTo(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toBeCloseTo<dim>(</><green>expected</><dim>)</>
 
-Precision: <green>2</>-digit
-Expected:  <green>-1.23</>
-Received:  <red>-Infinity</>"
+Expected: <green>-1.23</>
+Received: <red>-Infinity</>
+
+Expected precision:    <green>2</>
+Expected difference: < <green>5e-3</>
+Received difference:   <red>Infinity</>"
 `;
 
 exports[`.toBeCloseTo() {pass: false} expect(Infinity)toBeCloseTo( -Infinity) 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeCloseTo(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toBeCloseTo<dim>(</><green>expected</><dim>)</>
 
-Precision: <green>2</>-digit
-Expected:  <green>-Infinity</>
-Received:  <red>Infinity</>"
+Expected: <green>-Infinity</>
+Received: <red>Infinity</>
+
+Expected precision:    <green>2</>
+Expected difference: < <green>5e-3</>
+Received difference:   <red>Infinity</>"
 `;
 
 exports[`.toBeCloseTo() {pass: false} expect(Infinity)toBeCloseTo( 1.23) 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeCloseTo(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toBeCloseTo<dim>(</><green>expected</><dim>)</>
 
-Precision: <green>2</>-digit
-Expected:  <green>1.23</>
-Received:  <red>Infinity</>"
+Expected: <green>1.23</>
+Received: <red>Infinity</>
+
+Expected precision:    <green>2</>
+Expected difference: < <green>5e-3</>
+Received difference:   <red>Infinity</>"
 `;
 
 exports[`.toBeCloseTo() {pass: true} expect(-Infinity)toBeCloseTo( -Infinity) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.toBeCloseTo(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeCloseTo<dim>(</><green>expected</><dim>)</>
 
-Precision: <green>2</>-digit
-Expected:  <green>-Infinity</>
-Received:  <red>-Infinity</>"
+Expected: not <green>-Infinity</>
+"
 `;
 
 exports[`.toBeCloseTo() {pass: true} expect(0)toBeCloseTo( 0) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.toBeCloseTo(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeCloseTo<dim>(</><green>expected</><dim>)</>
 
-Precision: <green>2</>-digit
-Expected:  <green>0</>
-Received:  <red>0</>"
+Expected: not <green>0</>
+"
 `;
 
 exports[`.toBeCloseTo() {pass: true} expect(0)toBeCloseTo( 0.001) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.toBeCloseTo(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeCloseTo<dim>(</><green>expected</><dim>)</>
 
-Precision: <green>2</>-digit
-Expected:  <green>0.001</>
-Received:  <red>0</>"
+Expected: not <green>0.001</>
+Received:     <red>0</>
+
+Expected precision:        <green>2</>
+Expected difference: not < <green>5e-3</>
+Received difference:       <red>1e-3</>"
 `;
 
 exports[`.toBeCloseTo() {pass: true} expect(1.23)toBeCloseTo( 1.225) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.toBeCloseTo(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeCloseTo<dim>(</><green>expected</><dim>)</>
 
-Precision: <green>2</>-digit
-Expected:  <green>1.225</>
-Received:  <red>1.23</>"
+Expected: not <green>1.225</>
+Received:     <red>1.23</>
+
+Expected precision:        <green>2</>
+Expected difference: not < <green>5e-3</>
+Received difference:       <red>4.999999999999893e-3</>"
 `;
 
 exports[`.toBeCloseTo() {pass: true} expect(1.23)toBeCloseTo( 1.226) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.toBeCloseTo(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeCloseTo<dim>(</><green>expected</><dim>)</>
 
-Precision: <green>2</>-digit
-Expected:  <green>1.226</>
-Received:  <red>1.23</>"
+Expected: not <green>1.226</>
+Received:     <red>1.23</>
+
+Expected precision:        <green>2</>
+Expected difference: not < <green>5e-3</>
+Received difference:       <red>4.0000000000000036e-3</>"
 `;
 
 exports[`.toBeCloseTo() {pass: true} expect(1.23)toBeCloseTo( 1.229) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.toBeCloseTo(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeCloseTo<dim>(</><green>expected</><dim>)</>
 
-Precision: <green>2</>-digit
-Expected:  <green>1.229</>
-Received:  <red>1.23</>"
+Expected: not <green>1.229</>
+Received:     <red>1.23</>
+
+Expected precision:        <green>2</>
+Expected difference: not < <green>5e-3</>
+Received difference:       <red>9.999999999998899e-4</>"
 `;
 
 exports[`.toBeCloseTo() {pass: true} expect(1.23)toBeCloseTo( 1.234) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.toBeCloseTo(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeCloseTo<dim>(</><green>expected</><dim>)</>
 
-Precision: <green>2</>-digit
-Expected:  <green>1.234</>
-Received:  <red>1.23</>"
+Expected: not <green>1.234</>
+Received:     <red>1.23</>
+
+Expected precision:        <green>2</>
+Expected difference: not < <green>5e-3</>
+Received difference:       <red>4.0000000000000036e-3</>"
 `;
 
 exports[`.toBeCloseTo() {pass: true} expect(Infinity)toBeCloseTo( Infinity) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.toBeCloseTo(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeCloseTo<dim>(</><green>expected</><dim>)</>
 
-Precision: <green>2</>-digit
-Expected:  <green>Infinity</>
-Received:  <red>Infinity</>"
+Expected: not <green>Infinity</>
+"
 `;
 
 exports[`.toBeCloseTo() accepts an optional precision argument: [0, 0.000004, 5] 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.toBeCloseTo(</><green>expected</><dim>, </><green>precision</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeCloseTo<dim>(</><green>expected</><dim>, </><green>precision</><dim>)</>
 
-Precision: <green>5</>-digit
-Expected:  <green>0.000004</>
-Received:  <red>0</>"
+Expected: not <green>0.000004</>
+Received:     <red>0</>
+
+Expected precision:        <green>5</>
+Expected difference: not < <green>5e-6</>
+Received difference:       <red>4e-6</>"
 `;
 
 exports[`.toBeCloseTo() accepts an optional precision argument: [0, 0.0001, 3] 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.toBeCloseTo(</><green>expected</><dim>, </><green>precision</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeCloseTo<dim>(</><green>expected</><dim>, </><green>precision</><dim>)</>
 
-Precision: <green>3</>-digit
-Expected:  <green>0.0001</>
-Received:  <red>0</>"
+Expected: not <green>0.0001</>
+Received:     <red>0</>
+
+Expected precision:        <green>3</>
+Expected difference: not < <green>5e-4</>
+Received difference:       <red>1e-4</>"
 `;
 
 exports[`.toBeCloseTo() accepts an optional precision argument: [0, 0.1, 0] 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.toBeCloseTo(</><green>expected</><dim>, </><green>precision</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeCloseTo<dim>(</><green>expected</><dim>, </><green>precision</><dim>)</>
 
-Precision: <green>0</>-digit
-Expected:  <green>0.1</>
-Received:  <red>0</>"
+Expected: not <green>0.1</>
+Received:     <red>0</>
+
+Expected precision:        <green>0</>
+Expected difference: not < <green>5e-1</>
+Received difference:       <red>1e-1</>"
 `;
 
 exports[`.toBeCloseTo() throws: [0, 0.01] 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeCloseTo(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toBeCloseTo<dim>(</><green>expected</><dim>)</>
 
-Precision: <green>2</>-digit
-Expected:  <green>0.01</>
-Received:  <red>0</>"
+Expected: <green>0.01</>
+Received: <red>0</>
+
+Expected precision:    <green>2</>
+Expected difference: < <green>5e-3</>
+Received difference:   <red>1e-2</>"
 `;
 
 exports[`.toBeCloseTo() throws: [1, 1.23] 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeCloseTo(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toBeCloseTo<dim>(</><green>expected</><dim>)</>
 
-Precision: <green>2</>-digit
-Expected:  <green>1.23</>
-Received:  <red>1</>"
+Expected: <green>1.23</>
+Received: <red>1</>
+
+Expected precision:    <green>2</>
+Expected difference: < <green>5e-3</>
+Received difference:   <red>2.2999999999999998e-1</>"
 `;
 
 exports[`.toBeCloseTo() throws: [1.23, 1.2249999] 1`] = `
-"<dim>expect(</><red>received</><dim>).toBeCloseTo(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toBeCloseTo<dim>(</><green>expected</><dim>)</>
 
-Precision: <green>2</>-digit
-Expected:  <green>1.2249999</>
-Received:  <red>1.23</>"
+Expected: <green>1.2249999</>
+Received: <red>1.23</>
+
+Expected precision:    <green>2</>
+Expected difference: < <green>5e-3</>
+Received difference:   <red>5.000099999999952e-3</>"
 `;
 
 exports[`.toBeDefined(), .toBeUndefined() '"a"' is defined 1`] = `

--- a/packages/expect/src/matchers.js
+++ b/packages/expect/src/matchers.js
@@ -121,12 +121,8 @@ const matchers: MatchersObject = {
             : `Received:     ${printReceived(received)}\n` +
               '\n' +
               `Expected precision:        ${printExpected(precision)}\n` +
-              `Expected difference: not < ${EXPECTED_COLOR(
-                expectedDiff.toExponential(),
-              )}\n` +
-              `Received difference:       ${RECEIVED_COLOR(
-                receivedDiff.toExponential(),
-              )}`)
+              `Expected difference: not < ${printExpected(expectedDiff)}\n` +
+              `Received difference:       ${printReceived(receivedDiff)}`)
       : () =>
           matcherHint('toBeCloseTo', undefined, undefined, options) +
           '\n\n' +
@@ -134,12 +130,8 @@ const matchers: MatchersObject = {
           `Received: ${printReceived(received)}\n` +
           '\n' +
           `Expected precision:    ${printExpected(precision)}\n` +
-          `Expected difference: < ${EXPECTED_COLOR(
-            expectedDiff.toExponential(),
-          )}\n` +
-          `Received difference:   ${RECEIVED_COLOR(
-            receivedDiff.toExponential(),
-          )}`;
+          `Expected difference: < ${printExpected(expectedDiff)}\n` +
+          `Received difference:   ${printReceived(receivedDiff)}`;
 
     return {message, pass};
   },

--- a/packages/expect/src/matchers.js
+++ b/packages/expect/src/matchers.js
@@ -87,25 +87,59 @@ const matchers: MatchersObject = {
     return {actual: received, expected, message, name: 'toBe', pass};
   },
 
-  toBeCloseTo(actual: number, expected: number, precision?: number = 2) {
+  toBeCloseTo(received: number, expected: number, precision?: number = 2) {
     const secondArgument = arguments.length === 3 ? 'precision' : null;
-    ensureNumbers(actual, expected, '.toBeCloseTo');
+    const isNot = this.isNot;
+    const options = {
+      isNot,
+      promise: this.promise,
+      secondArgument,
+    };
+    ensureNumbers(received, expected, '.toBeCloseTo');
 
     let pass = false;
+    let expectedDiff = 0;
+    let receivedDiff = 0;
 
-    if (actual == Infinity && expected == Infinity) pass = true;
-    else if (actual == -Infinity && expected == -Infinity) pass = true;
-    else pass = Math.abs(expected - actual) < Math.pow(10, -precision) / 2;
+    if (received === Infinity && expected === Infinity) {
+      pass = true; // Infinity - Infinity is NaN
+    } else if (received === -Infinity && expected === -Infinity) {
+      pass = true; // -Infinity - -Infinity is NaN
+    } else {
+      expectedDiff = Math.pow(10, -precision) / 2;
+      receivedDiff = Math.abs(expected - received);
+      pass = receivedDiff < expectedDiff;
+    }
 
-    const message = () =>
-      matcherHint('.toBeCloseTo', undefined, undefined, {
-        isNot: this.isNot,
-        secondArgument,
-      }) +
-      '\n\n' +
-      `Precision: ${printExpected(precision)}-digit\n` +
-      `Expected:  ${printExpected(expected)}\n` +
-      `Received:  ${printReceived(actual)}`;
+    const message = pass
+      ? () =>
+          matcherHint('toBeCloseTo', undefined, undefined, options) +
+          '\n\n' +
+          `Expected: not ${printExpected(expected)}\n` +
+          (receivedDiff === 0
+            ? ''
+            : `Received:     ${printReceived(received)}\n` +
+              '\n' +
+              `Expected precision:        ${printExpected(precision)}\n` +
+              `Expected difference: not < ${EXPECTED_COLOR(
+                expectedDiff.toExponential(),
+              )}\n` +
+              `Received difference:       ${RECEIVED_COLOR(
+                receivedDiff.toExponential(),
+              )}`)
+      : () =>
+          matcherHint('toBeCloseTo', undefined, undefined, options) +
+          '\n\n' +
+          `Expected: ${printExpected(expected)}\n` +
+          `Received: ${printReceived(received)}\n` +
+          '\n' +
+          `Expected precision:    ${printExpected(precision)}\n` +
+          `Expected difference: < ${EXPECTED_COLOR(
+            expectedDiff.toExponential(),
+          )}\n` +
+          `Received difference:   ${RECEIVED_COLOR(
+            receivedDiff.toExponential(),
+          )}`;
 
     return {message, pass};
   },


### PR DESCRIPTION
## Summary

For `.toBeCloseTo` matcher:

* Display matcher name in regular **black** instead of dim color
* Display expected and received **difference** to make criterion more transparent
* Repeat **not** following `Expected:` and `Expected difference:` labels
* Experiment to **omit** received value if it is **equal to** the `not` expected value (am happy if y’all can suggest as an alternative a concise explicit way to communicate that is reason why test fails)

For more information, see discussion with @jeysal in #7795

Residue for future pull requests:

1. In call to `ensureNumbers` helper function:
    * delete period in matcher name to display matcher name in regular black instead of dim color
    * provide `options` as argument to display `promise` and `isNot`

2. Decide whether `.toBeCloseTo` throws matcher error:
    * when expected or received is `NaN`
    * when `precision` argument is not integer number

## Test plan

Updated 17 snapshot tests

See also pictures in following comments