### PR TITLE
chore: use more `private`

### DIFF
--- a/packages/jest-haste-map/src/index.ts
+++ b/packages/jest-haste-map/src/index.ts
@@ -219,14 +219,14 @@ const getWhiteList = (list: Array<string> | undefined): RegExp | null => {
  *
  */
 class HasteMap extends EventEmitter {
-  _buildPromise: Promise<HasteMapObject> | null;
-  _cachePath: Config.Path;
-  _changeInterval?: NodeJS.Timeout;
-  _console: Console;
-  _options: InternalOptions;
-  _watchers: Array<Watcher>;
-  _whitelist: RegExp | null;
-  _worker: WorkerInterface | null;
+  private _buildPromise: Promise<HasteMapObject> | null;
+  private _cachePath: Config.Path;
+  private _changeInterval?: NodeJS.Timeout;
+  private _console: Console;
+  private _options: InternalOptions;
+  private _watchers: Array<Watcher>;
+  private _whitelist: RegExp | null;
+  private _worker: WorkerInterface | null;
 
   constructor(options: Options) {
     super();
@@ -381,7 +381,7 @@ class HasteMap extends EventEmitter {
   /**
    * 2. crawl the file system.
    */
-  _buildFileMap(): Promise<{
+  private _buildFileMap(): Promise<{
     deprecatedFiles: Array<{moduleName: string; path: string}>;
     hasteMap: InternalHasteMap;
   }> {
@@ -408,7 +408,7 @@ class HasteMap extends EventEmitter {
   /**
    * 3. parse and extract metadata from changed files.
    */
-  _processFile(
+  private _processFile(
     hasteMap: InternalHasteMap,
     map: ModuleMapData,
     mocks: MockData,
@@ -604,7 +604,7 @@ class HasteMap extends EventEmitter {
       .then(workerReply, workerError);
   }
 
-  _buildHasteMap(data: {
+  private _buildHasteMap(data: {
     deprecatedFiles: Array<{moduleName: string; path: string}>;
     hasteMap: InternalHasteMap;
   }): Promise<InternalHasteMap> {
@@ -643,7 +643,7 @@ class HasteMap extends EventEmitter {
       });
   }
 
-  _cleanup() {
+  private _cleanup() {
     const worker = this._worker;
 
     // @ts-ignore

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -73,7 +73,7 @@ interface Mock<T, Y extends unknown[] = unknown[]>
 interface SpyInstance<T, Y extends unknown[]> extends MockInstance<T, Y> {}
 
 interface MockInstance<T, Y extends unknown[]> {
-  _isMockFunction: boolean;
+  _isMockFunction: true;
   _protoImpl: Function;
   getMockName(): string;
   getMockImplementation(): Function | undefined;

--- a/packages/jest-util/src/FakeTimers.ts
+++ b/packages/jest-util/src/FakeTimers.ts
@@ -51,21 +51,21 @@ type TimerConfig<Ref> = {
 const MS_IN_A_YEAR = 31536000000;
 
 export default class FakeTimers<TimerRef> {
-  _cancelledImmediates!: {[key: string]: boolean};
-  _cancelledTicks!: {[key: string]: boolean};
-  _config: StackTraceConfig;
-  _disposed?: boolean;
-  _fakeTimerAPIs!: TimerAPI;
-  _global: NodeJS.Global;
-  _immediates!: Array<Tick>;
-  _maxLoops: number;
-  _moduleMocker: ModuleMocker;
-  _now!: number;
-  _ticks!: Array<Tick>;
-  _timerAPIs: TimerAPI;
-  _timers!: {[key: string]: Timer};
-  _uuidCounter: number;
-  _timerConfig: TimerConfig<TimerRef>;
+  private _cancelledImmediates!: {[key: string]: boolean};
+  private _cancelledTicks!: {[key: string]: boolean};
+  private _config: StackTraceConfig;
+  private _disposed?: boolean;
+  private _fakeTimerAPIs!: TimerAPI;
+  private _global: NodeJS.Global;
+  private _immediates!: Array<Tick>;
+  private _maxLoops: number;
+  private _moduleMocker: ModuleMocker;
+  private _now!: number;
+  private _ticks!: Array<Tick>;
+  private _timerAPIs: TimerAPI;
+  private _timers!: {[key: string]: Timer};
+  private _uuidCounter: number;
+  private _timerConfig: TimerConfig<TimerRef>;
 
   constructor({
     global,
@@ -176,7 +176,7 @@ export default class FakeTimers<TimerRef> {
     }
   }
 
-  _runImmediate(immediate: Tick) {
+  private _runImmediate(immediate: Tick) {
     if (!this._cancelledImmediates.hasOwnProperty(immediate.uuid)) {
       // Callback may throw, so update the map prior calling.
       this._cancelledImmediates[immediate.uuid] = true;
@@ -334,7 +334,7 @@ export default class FakeTimers<TimerRef> {
     return Object.keys(this._timers).length;
   }
 
-  _checkFakeTimers() {
+  private _checkFakeTimers() {
     if (this._global.setTimeout !== this._fakeTimerAPIs.setTimeout) {
       this._global.console.warn(
         `A function to advance timers was called but the timers API is not ` +
@@ -352,7 +352,7 @@ export default class FakeTimers<TimerRef> {
     }
   }
 
-  _createMocks() {
+  private _createMocks() {
     const fn = (impl: Function) =>
       // @ts-ignore TODO: figure out better typings here
       this._moduleMocker.fn().mockImplementation(impl);
@@ -369,7 +369,7 @@ export default class FakeTimers<TimerRef> {
     };
   }
 
-  _fakeClearTimer(timerRef: TimerRef) {
+  private _fakeClearTimer(timerRef: TimerRef) {
     const uuid = this._timerConfig.refToId(timerRef);
 
     if (uuid && this._timers.hasOwnProperty(uuid)) {
@@ -377,11 +377,11 @@ export default class FakeTimers<TimerRef> {
     }
   }
 
-  _fakeClearImmediate(uuid: TimerID) {
+  private _fakeClearImmediate(uuid: TimerID) {
     this._cancelledImmediates[uuid] = true;
   }
 
-  _fakeNextTick(callback: Callback, ...args: Array<any>) {
+  private _fakeNextTick(callback: Callback, ...args: Array<any>) {
     if (this._disposed) {
       return;
     }
@@ -403,7 +403,7 @@ export default class FakeTimers<TimerRef> {
     });
   }
 
-  _fakeSetImmediate(callback: Callback, ...args: Array<any>) {
+  private _fakeSetImmediate(callback: Callback, ...args: Array<any>) {
     if (this._disposed) {
       return null;
     }
@@ -427,7 +427,7 @@ export default class FakeTimers<TimerRef> {
     return uuid;
   }
 
-  _fakeSetInterval(
+  private _fakeSetInterval(
     callback: Callback,
     intervalDelay?: number,
     ...args: Array<any>
@@ -452,7 +452,7 @@ export default class FakeTimers<TimerRef> {
     return this._timerConfig.idToRef(uuid);
   }
 
-  _fakeSetTimeout(callback: Callback, delay?: number, ...args: Array<any>) {
+  private _fakeSetTimeout(callback: Callback, delay?: number, ...args: Array<any>) {
     if (this._disposed) {
       return null;
     }
@@ -472,7 +472,7 @@ export default class FakeTimers<TimerRef> {
     return this._timerConfig.idToRef(uuid);
   }
 
-  _getNextTimerHandle() {
+  private _getNextTimerHandle() {
     let nextTimerHandle = null;
     let uuid;
     let soonestTime = MS_IN_A_YEAR;
@@ -488,7 +488,7 @@ export default class FakeTimers<TimerRef> {
     return nextTimerHandle;
   }
 
-  _runTimerHandle(timerHandle: TimerID) {
+  private _runTimerHandle(timerHandle: TimerID) {
     const timer = this._timers[timerHandle];
 
     if (!timer) {

--- a/packages/jest-util/src/FakeTimers.ts
+++ b/packages/jest-util/src/FakeTimers.ts
@@ -452,7 +452,11 @@ export default class FakeTimers<TimerRef> {
     return this._timerConfig.idToRef(uuid);
   }
 
-  private _fakeSetTimeout(callback: Callback, delay?: number, ...args: Array<any>) {
+  private _fakeSetTimeout(
+    callback: Callback,
+    delay?: number,
+    ...args: Array<any>
+  ) {
     if (this._disposed) {
       return null;
     }

--- a/packages/jest-watcher/src/BaseWatchPlugin.ts
+++ b/packages/jest-watcher/src/BaseWatchPlugin.ts
@@ -8,8 +8,8 @@
 import {WatchPlugin} from './types';
 
 class BaseWatchPlugin implements WatchPlugin {
-  _stdin: NodeJS.ReadableStream;
-  _stdout: NodeJS.WritableStream;
+  protected _stdin: NodeJS.ReadableStream;
+  protected _stdout: NodeJS.WritableStream;
 
   constructor({
     stdin,

--- a/packages/jest-watcher/src/JestHooks.ts
+++ b/packages/jest-watcher/src/JestHooks.ts
@@ -19,7 +19,7 @@ type AvailableHooks =
   | 'shouldRunTestSuite';
 
 class JestHooks {
-  _listeners: {
+  private _listeners: {
     onFileChange: Array<FileChange>;
     onTestRunComplete: Array<TestRunComplete>;
     shouldRunTestSuite: Array<ShouldRunTestSuite>;

--- a/packages/jest-watcher/src/PatternPrompt.ts
+++ b/packages/jest-watcher/src/PatternPrompt.ts
@@ -22,10 +22,10 @@ const usage = (entity: string) =>
 const usageRows = usage('').split('\n').length;
 
 export default class PatternPrompt {
-  _pipe: NodeJS.WritableStream;
-  _prompt: Prompt;
-  _entityName: string;
-  _currentUsageRows: number;
+  protected _pipe: NodeJS.WritableStream;
+  protected _prompt: Prompt;
+  protected _entityName: string;
+  protected _currentUsageRows: number;
 
   constructor(pipe: NodeJS.WritableStream, prompt: Prompt) {
     // TODO: Should come in the constructor

--- a/packages/jest-watcher/src/lib/Prompt.ts
+++ b/packages/jest-watcher/src/lib/Prompt.ts
@@ -9,14 +9,14 @@ import {ScrollOptions} from '../types';
 import {KEYS} from '../constants';
 
 export default class Prompt {
-  _entering: boolean;
-  _value: string;
-  _onChange: () => void;
-  _onSuccess: (value?: string) => void;
-  _onCancel: (value?: string) => void;
-  _offset: number;
-  _promptLength: number;
-  _selection: string | null;
+  private _entering: boolean;
+  private _value: string;
+  private _onChange: () => void;
+  private _onSuccess: (value?: string) => void;
+  private _onCancel: (value?: string) => void;
+  private _offset: number;
+  private _promptLength: number;
+  private _selection: string | null;
 
   constructor() {
     // Copied from `enter` to satisfy TS

--- a/packages/jest-worker/src/Farm.ts
+++ b/packages/jest-worker/src/Farm.ts
@@ -16,14 +16,14 @@ import {
 } from './types';
 
 export default class Farm {
-  _computeWorkerKey: FarmOptions['computeWorkerKey'];
-  _cacheKeys: {[key: string]: WorkerInterface};
-  _callback: Function;
-  _last: Array<QueueChildMessage>;
-  _locks: Array<boolean>;
-  _numOfWorkers: number;
-  _offset: number;
-  _queue: Array<QueueChildMessage | null>;
+  private _computeWorkerKey: FarmOptions['computeWorkerKey'];
+  private _cacheKeys: {[key: string]: WorkerInterface};
+  private _callback: Function;
+  private _last: Array<QueueChildMessage>;
+  private _locks: Array<boolean>;
+  private _numOfWorkers: number;
+  private _offset: number;
+  private _queue: Array<QueueChildMessage | null>;
 
   constructor(
     numOfWorkers: number,
@@ -78,7 +78,7 @@ export default class Farm {
     });
   }
 
-  _getNextJob(workerId: number): QueueChildMessage | null {
+  private _getNextJob(workerId: number): QueueChildMessage | null {
     let queueHead = this._queue[workerId];
 
     while (queueHead && queueHead.request[1]) {
@@ -90,7 +90,7 @@ export default class Farm {
     return queueHead;
   }
 
-  _process(workerId: number): Farm {
+  private _process(workerId: number): Farm {
     if (this.isLocked(workerId)) {
       return this;
     }
@@ -116,7 +116,7 @@ export default class Farm {
     return this;
   }
 
-  _enqueue(task: QueueChildMessage, workerId: number): Farm {
+  private _enqueue(task: QueueChildMessage, workerId: number): Farm {
     if (task.request[1]) {
       return this;
     }
@@ -133,7 +133,7 @@ export default class Farm {
     return this;
   }
 
-  _push(task: QueueChildMessage): Farm {
+  private _push(task: QueueChildMessage): Farm {
     for (let i = 0; i < this._numOfWorkers; i++) {
       const workerIdx = (this._offset + i) % this._numOfWorkers;
       this._enqueue(task, workerIdx);

--- a/packages/jest-worker/src/base/BaseWorkerPool.ts
+++ b/packages/jest-worker/src/base/BaseWorkerPool.ts
@@ -19,10 +19,10 @@ import {
 const emptyMethod = () => {};
 
 export default class BaseWorkerPool {
-  _stderr: NodeJS.ReadableStream;
-  _stdout: NodeJS.ReadableStream;
-  _options: WorkerPoolOptions;
-  _workers: Array<WorkerInterface>;
+  private readonly _stderr: NodeJS.ReadableStream;
+  private readonly _stdout: NodeJS.ReadableStream;
+  protected readonly _options: WorkerPoolOptions;
+  private readonly _workers: Array<WorkerInterface>;
 
   constructor(workerPath: string, options: WorkerPoolOptions) {
     this._options = options;

--- a/packages/jest-worker/src/index.ts
+++ b/packages/jest-worker/src/index.ts
@@ -59,10 +59,10 @@ function getExposedMethods(
  *   caching results.
  */
 export default class JestWorker {
-  _ending: boolean;
-  _farm: Farm;
-  _options: FarmOptions;
-  _workerPool: WorkerPoolInterface;
+  private _ending: boolean;
+  private _farm: Farm;
+  private _options: FarmOptions;
+  private _workerPool: WorkerPoolInterface;
 
   constructor(workerPath: string, options?: FarmOptions) {
     this._options = {...options};
@@ -95,7 +95,10 @@ export default class JestWorker {
     this._bindExposedWorkerMethods(workerPath, this._options);
   }
 
-  _bindExposedWorkerMethods(workerPath: string, options: FarmOptions): void {
+  private _bindExposedWorkerMethods(
+    workerPath: string,
+    options: FarmOptions,
+  ): void {
     getExposedMethods(workerPath, options).forEach(name => {
       if (name.startsWith('_')) {
         return;
@@ -110,7 +113,10 @@ export default class JestWorker {
     });
   }
 
-  _callFunctionWithArgs(method: string, ...args: Array<any>): Promise<any> {
+  private _callFunctionWithArgs(
+    method: string,
+    ...args: Array<any>
+  ): Promise<any> {
     if (this._ending) {
       throw new Error('Farm is ended, no more calls can be done to it');
     }

--- a/packages/jest-worker/src/workers/ChildProcessWorker.ts
+++ b/packages/jest-worker/src/workers/ChildProcessWorker.ts
@@ -40,10 +40,10 @@ import {
  * same call skip it.
  */
 export default class ChildProcessWorker implements WorkerInterface {
-  _child!: ChildProcess;
-  _options: WorkerOptions;
-  _onProcessEnd!: OnEnd;
-  _retries!: number;
+  private _child!: ChildProcess;
+  private _options: WorkerOptions;
+  private _onProcessEnd!: OnEnd;
+  private _retries!: number;
 
   constructor(options: WorkerOptions) {
     this._options = options;

--- a/packages/jest-worker/src/workers/NodeThreadsWorker.ts
+++ b/packages/jest-worker/src/workers/NodeThreadsWorker.ts
@@ -24,10 +24,10 @@ import {
 } from '../types';
 
 export default class ExperimentalWorker implements WorkerInterface {
-  _worker!: Worker;
-  _options: WorkerOptions;
-  _onProcessEnd!: OnEnd;
-  _retries!: number;
+  private _worker!: Worker;
+  private _options: WorkerOptions;
+  private _onProcessEnd!: OnEnd;
+  private _retries!: number;
 
   constructor(options: WorkerOptions) {
     this._options = options;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Guides consumers away from private APIs. Also makes the type definitions smaller in some cases since we don't expose as much

Built diff:

<details>

```diff
diff --git i/packages/jest-mock/build/index.d.ts w/packages/jest-mock/build/index.d.ts
index 5dfae37ba..42348609a 100644
--- i/packages/jest-mock/build/index.d.ts
+++ w/packages/jest-mock/build/index.d.ts
@@ -51,7 +51,7 @@ interface Mock<T, Y extends unknown[] = unknown[]> extends Function, MockInstanc
 interface SpyInstance<T, Y extends unknown[]> extends MockInstance<T, Y> {
 }
 interface MockInstance<T, Y extends unknown[]> {
-    _isMockFunction: boolean;
+    _isMockFunction: true;
     _protoImpl: Function;
     getMockName(): string;
     getMockImplementation(): Function | undefined;
diff --git i/packages/jest-util/build/FakeTimers.d.ts w/packages/jest-util/build/FakeTimers.d.ts
index 75850864c..324976b7d 100644
--- i/packages/jest-util/build/FakeTimers.d.ts
+++ w/packages/jest-util/build/FakeTimers.d.ts
@@ -12,52 +12,26 @@ declare type ModuleMocker = typeof mock;
  * we are disabling the flowtype/no-weak-types rule here.
  */
 declare type Callback = (...args: any) => void;
-declare type TimerID = string;
-declare type Tick = {
-    uuid: string;
-    callback: Callback;
-};
-declare type Timer = {
-    type: string;
-    callback: Callback;
-    expiry: number;
-    interval?: number;
-};
-declare type TimerAPI = {
-    clearImmediate: typeof global.clearImmediate;
-    clearInterval: typeof global.clearInterval;
-    clearTimeout: typeof global.clearTimeout;
-    nextTick: typeof process.nextTick;
-    setImmediate: typeof global.setImmediate;
-    setInterval: typeof global.setInterval;
-    setTimeout: typeof global.setTimeout;
-};
 declare type TimerConfig<Ref> = {
     idToRef: (id: number) => Ref;
     refToId: (ref: Ref) => number | void;
 };
 export default class FakeTimers<TimerRef> {
-    _cancelledImmediates: {
-        [key: string]: boolean;
-    };
-    _cancelledTicks: {
-        [key: string]: boolean;
-    };
-    _config: StackTraceConfig;
-    _disposed?: boolean;
-    _fakeTimerAPIs: TimerAPI;
-    _global: NodeJS.Global;
-    _immediates: Array<Tick>;
-    _maxLoops: number;
-    _moduleMocker: ModuleMocker;
-    _now: number;
-    _ticks: Array<Tick>;
-    _timerAPIs: TimerAPI;
-    _timers: {
-        [key: string]: Timer;
-    };
-    _uuidCounter: number;
-    _timerConfig: TimerConfig<TimerRef>;
+    private _cancelledImmediates;
+    private _cancelledTicks;
+    private _config;
+    private _disposed?;
+    private _fakeTimerAPIs;
+    private _global;
+    private _immediates;
+    private _maxLoops;
+    private _moduleMocker;
+    private _now;
+    private _ticks;
+    private _timerAPIs;
+    private _timers;
+    private _uuidCounter;
+    private _timerConfig;
     constructor({ global, moduleMocker, timerConfig, config, maxLoops, }: {
         global: NodeJS.Global;
         moduleMocker: ModuleMocker;
@@ -70,7 +44,7 @@ export default class FakeTimers<TimerRef> {
     reset(): void;
     runAllTicks(): void;
     runAllImmediates(): void;
-    _runImmediate(immediate: Tick): void;
+    private _runImmediate;
     runAllTimers(): void;
     runOnlyPendingTimers(): void;
     advanceTimersByTime(msToRun: number): void;
@@ -78,16 +52,16 @@ export default class FakeTimers<TimerRef> {
     useRealTimers(): void;
     useFakeTimers(): void;
     getTimerCount(): number;
-    _checkFakeTimers(): void;
-    _createMocks(): void;
-    _fakeClearTimer(timerRef: TimerRef): void;
-    _fakeClearImmediate(uuid: TimerID): void;
-    _fakeNextTick(callback: Callback, ...args: Array<any>): void;
-    _fakeSetImmediate(callback: Callback, ...args: Array<any>): number | null;
-    _fakeSetInterval(callback: Callback, intervalDelay?: number, ...args: Array<any>): TimerRef | null;
-    _fakeSetTimeout(callback: Callback, delay?: number, ...args: Array<any>): TimerRef | null;
-    _getNextTimerHandle(): string | null;
-    _runTimerHandle(timerHandle: TimerID): void;
+    private _checkFakeTimers;
+    private _createMocks;
+    private _fakeClearTimer;
+    private _fakeClearImmediate;
+    private _fakeNextTick;
+    private _fakeSetImmediate;
+    private _fakeSetInterval;
+    private _fakeSetTimeout;
+    private _getNextTimerHandle;
+    private _runTimerHandle;
 }
 export {};
 //# sourceMappingURL=FakeTimers.d.ts.map
\ No newline at end of file
diff --git i/packages/jest-watcher/build/BaseWatchPlugin.d.ts w/packages/jest-watcher/build/BaseWatchPlugin.d.ts
index 5a2c698cb..f15b66222 100644
--- i/packages/jest-watcher/build/BaseWatchPlugin.d.ts
+++ w/packages/jest-watcher/build/BaseWatchPlugin.d.ts
@@ -6,8 +6,8 @@
  */
 import { WatchPlugin } from './types';
 declare class BaseWatchPlugin implements WatchPlugin {
-    _stdin: NodeJS.ReadableStream;
-    _stdout: NodeJS.WritableStream;
+    protected _stdin: NodeJS.ReadableStream;
+    protected _stdout: NodeJS.WritableStream;
     constructor({ stdin, stdout, }: {
         stdin: NodeJS.ReadableStream;
         stdout: NodeJS.WritableStream;
diff --git i/packages/jest-watcher/build/JestHooks.d.ts w/packages/jest-watcher/build/JestHooks.d.ts
index e9fd7d2fd..31e82d7d1 100644
--- i/packages/jest-watcher/build/JestHooks.d.ts
+++ w/packages/jest-watcher/build/JestHooks.d.ts
@@ -4,14 +4,10 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import { JestHookSubscriber, JestHookEmitter, FileChange, ShouldRunTestSuite, TestRunComplete } from './types';
+import { JestHookSubscriber, JestHookEmitter } from './types';
 declare type AvailableHooks = 'onFileChange' | 'onTestRunComplete' | 'shouldRunTestSuite';
 declare class JestHooks {
-    _listeners: {
-        onFileChange: Array<FileChange>;
-        onTestRunComplete: Array<TestRunComplete>;
-        shouldRunTestSuite: Array<ShouldRunTestSuite>;
-    };
+    private _listeners;
     constructor();
     isUsed(hook: AvailableHooks): number;
     getSubscriber(): JestHookSubscriber;
diff --git i/packages/jest-watcher/build/PatternPrompt.d.ts w/packages/jest-watcher/build/PatternPrompt.d.ts
index 6486482d3..3ac674e71 100644
--- i/packages/jest-watcher/build/PatternPrompt.d.ts
+++ w/packages/jest-watcher/build/PatternPrompt.d.ts
@@ -6,10 +6,10 @@
  */
 import Prompt from './lib/Prompt';
 export default class PatternPrompt {
-    _pipe: NodeJS.WritableStream;
-    _prompt: Prompt;
-    _entityName: string;
-    _currentUsageRows: number;
+    protected _pipe: NodeJS.WritableStream;
+    protected _prompt: Prompt;
+    protected _entityName: string;
+    protected _currentUsageRows: number;
     constructor(pipe: NodeJS.WritableStream, prompt: Prompt);
     run(onSuccess: () => void, onCancel: () => void, options?: {
         header: string;
diff --git i/packages/jest-watcher/build/lib/Prompt.d.ts w/packages/jest-watcher/build/lib/Prompt.d.ts
index 5f94140e6..259353aa6 100644
--- i/packages/jest-watcher/build/lib/Prompt.d.ts
+++ w/packages/jest-watcher/build/lib/Prompt.d.ts
@@ -6,14 +6,14 @@
  */
 import { ScrollOptions } from '../types';
 export default class Prompt {
-    _entering: boolean;
-    _value: string;
-    _onChange: () => void;
-    _onSuccess: (value?: string) => void;
-    _onCancel: (value?: string) => void;
-    _offset: number;
-    _promptLength: number;
-    _selection: string | null;
+    private _entering;
+    private _value;
+    private _onChange;
+    private _onSuccess;
+    private _onCancel;
+    private _offset;
+    private _promptLength;
+    private _selection;
     constructor();
     private _onResize;
     enter(onChange: (pattern: string, options: ScrollOptions) => void, onSuccess: () => void, onCancel: () => void): void;
diff --git i/packages/jest-worker/build/Farm.d.ts w/packages/jest-worker/build/Farm.d.ts
index 327738cb8..69da4106d 100644
--- i/packages/jest-worker/build/Farm.d.ts
+++ w/packages/jest-worker/build/Farm.d.ts
@@ -4,24 +4,22 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import { FarmOptions, QueueChildMessage, WorkerInterface } from './types';
+import { FarmOptions } from './types';
 export default class Farm {
-    _computeWorkerKey: FarmOptions['computeWorkerKey'];
-    _cacheKeys: {
-        [key: string]: WorkerInterface;
-    };
-    _callback: Function;
-    _last: Array<QueueChildMessage>;
-    _locks: Array<boolean>;
-    _numOfWorkers: number;
-    _offset: number;
-    _queue: Array<QueueChildMessage | null>;
+    private _computeWorkerKey;
+    private _cacheKeys;
+    private _callback;
+    private _last;
+    private _locks;
+    private _numOfWorkers;
+    private _offset;
+    private _queue;
     constructor(numOfWorkers: number, callback: Function, computeWorkerKey?: FarmOptions['computeWorkerKey']);
     doWork(method: string, ...args: Array<any>): Promise<unknown>;
-    _getNextJob(workerId: number): QueueChildMessage | null;
-    _process(workerId: number): Farm;
-    _enqueue(task: QueueChildMessage, workerId: number): Farm;
-    _push(task: QueueChildMessage): Farm;
+    private _getNextJob;
+    private _process;
+    private _enqueue;
+    private _push;
     lock(workerId: number): void;
     unlock(workerId: number): void;
     isLocked(workerId: number): boolean;
diff --git i/packages/jest-worker/build/base/BaseWorkerPool.d.ts w/packages/jest-worker/build/base/BaseWorkerPool.d.ts
index 21856415b..2ec7b7c8a 100644
--- i/packages/jest-worker/build/base/BaseWorkerPool.d.ts
+++ w/packages/jest-worker/build/base/BaseWorkerPool.d.ts
@@ -6,10 +6,10 @@
  */
 import { WorkerPoolOptions, WorkerOptions, WorkerInterface } from '../types';
 export default class BaseWorkerPool {
-    _stderr: NodeJS.ReadableStream;
-    _stdout: NodeJS.ReadableStream;
-    _options: WorkerPoolOptions;
-    _workers: Array<WorkerInterface>;
+    private readonly _stderr;
+    private readonly _stdout;
+    protected readonly _options: WorkerPoolOptions;
+    private readonly _workers;
     constructor(workerPath: string, options: WorkerPoolOptions);
     getStderr(): NodeJS.ReadableStream;
     getStdout(): NodeJS.ReadableStream;
diff --git i/packages/jest-worker/build/index.d.ts w/packages/jest-worker/build/index.d.ts
index 65c27f3a5..f0537c7e6 100644
--- i/packages/jest-worker/build/index.d.ts
+++ w/packages/jest-worker/build/index.d.ts
@@ -4,8 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import Farm from './Farm';
-import { WorkerPoolInterface, FarmOptions } from './types';
+import { FarmOptions } from './types';
 /**
  * The Jest farm (publicly called "Worker") is a class that allows you to queue
  * methods across multiple child processes, in order to parallelize work. This
@@ -32,13 +31,13 @@ import { WorkerPoolInterface, FarmOptions } from './types';
  *   caching results.
  */
 export default class JestWorker {
-    _ending: boolean;
-    _farm: Farm;
-    _options: FarmOptions;
-    _workerPool: WorkerPoolInterface;
+    private _ending;
+    private _farm;
+    private _options;
+    private _workerPool;
     constructor(workerPath: string, options?: FarmOptions);
-    _bindExposedWorkerMethods(workerPath: string, options: FarmOptions): void;
-    _callFunctionWithArgs(method: string, ...args: Array<any>): Promise<any>;
+    private _bindExposedWorkerMethods;
+    private _callFunctionWithArgs;
     getStderr(): NodeJS.ReadableStream;
     getStdout(): NodeJS.ReadableStream;
     end(): void;
diff --git i/packages/jest-worker/build/workers/ChildProcessWorker.d.ts w/packages/jest-worker/build/workers/ChildProcessWorker.d.ts
index 07d42cff6..fbc01f0f9 100644
--- i/packages/jest-worker/build/workers/ChildProcessWorker.d.ts
+++ w/packages/jest-worker/build/workers/ChildProcessWorker.d.ts
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import { ChildProcess } from 'child_process';
 import { WorkerInterface, ChildMessage, OnEnd, OnStart, WorkerOptions, ParentMessage } from '../types';
 /**
  * This class wraps the child process and provides a nice interface to
@@ -25,10 +24,10 @@ import { WorkerInterface, ChildMessage, OnEnd, OnStart, WorkerOptions, ParentMes
  * same call skip it.
  */
 export default class ChildProcessWorker implements WorkerInterface {
-    _child: ChildProcess;
-    _options: WorkerOptions;
-    _onProcessEnd: OnEnd;
-    _retries: number;
+    private _child;
+    private _options;
+    private _onProcessEnd;
+    private _retries;
     constructor(options: WorkerOptions);
     initialize(): void;
     onMessage(response: ParentMessage): void;
diff --git i/packages/jest-worker/build/workers/NodeThreadsWorker.d.ts w/packages/jest-worker/build/workers/NodeThreadsWorker.d.ts
index d6a7631c8..71c6f158b 100644
--- i/packages/jest-worker/build/workers/NodeThreadsWorker.d.ts
+++ w/packages/jest-worker/build/workers/NodeThreadsWorker.d.ts
@@ -4,13 +4,12 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import { Worker } from 'worker_threads';
 import { ChildMessage, OnEnd, OnStart, WorkerOptions, WorkerInterface, ParentMessage } from '../types';
 export default class ExperimentalWorker implements WorkerInterface {
-    _worker: Worker;
-    _options: WorkerOptions;
-    _onProcessEnd: OnEnd;
-    _retries: number;
+    private _worker;
+    private _options;
+    private _onProcessEnd;
+    private _retries;
     constructor(options: WorkerOptions);
     initialize(): void;
     onMessage(response: ParentMessage): void;

```
</details>

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Nothing really, except looking at the diff above. Build should still be green since we don't use anything now hidden

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
