### PR TITLE
fix: validating async functions (#7894)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - `[jest-cli]` Refactor `-o` and `--coverage` combined ([#7611](https://github.com/facebook/jest/pull/7611))
 - `[expect]` Fix custom async matcher stack trace ([#7652](https://github.com/facebook/jest/pull/7652))
 - `[jest-changed-files]` Improve default file selection for Mercurial repos ([#7880](https://github.com/facebook/jest/pull/7880))
+- `[jest-validate]` Fix validating async functions ([#7894](https://github.com/facebook/jest/issues/7894))
 
 ### Chore & Maintenance
 

--- a/packages/jest-validate/src/__tests__/validate.test.js
+++ b/packages/jest-validate/src/__tests__/validate.test.js
@@ -89,6 +89,20 @@ test('recursively omits null and undefined config values', () => {
   });
 });
 
+test.each([
+  [function() {}, function() {}],
+  [async function() {}, function() {}],
+  [function() {}, async function() {}],
+  [async function() {}, async function() {}],
+])(
+  'treat async and non-async functions as equivalent',
+  (value, exampleValue) => {
+    expect(
+      validate({name: value}, {exampleConfig: {name: exampleValue}}),
+    ).toEqual({hasDeprecationWarnings: false, isValid: true});
+  },
+);
+
 test('respects blacklist', () => {
   const warn = console.warn;
   console.warn = jest.fn();

--- a/packages/jest-validate/src/condition.js
+++ b/packages/jest-validate/src/condition.js
@@ -15,6 +15,7 @@ function validationConditionSingle(option: any, validOption: any): boolean {
   return (
     option === null ||
     option === undefined ||
+    (typeof option === 'function' && typeof validOption === 'function') ||
     toString.call(option) === toString.call(validOption)
   );
 }


### PR DESCRIPTION
## Summary

`jest-validate` distinguishes between sync and async functions, but it should not. Fixes #7894.

## Test plan

```js
const { validate } = require('jest-validate')
assert(validate({ name: async () => {} }, { exampleConfig: { name: () => {} } }).isValid)
assert(validate({ name: () => {} }, { exampleConfig: { name: async () => {} } }).isValid)
assert(validate({ name: async () => {} }, { exampleConfig: { name: async () => {} } }).isValid)
assert(validate({ name: () => {} }, { exampleConfig: { name: () => {} } }).isValid)
```