### PR TITLE
Adds @babel/core to the peer dependencies

### DIFF
--- a/packages/babel-preset-jest/package.json
+++ b/packages/babel-preset-jest/package.json
@@ -12,6 +12,9 @@
     "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
     "babel-plugin-jest-hoist": "^24.1.0"
   },
+  "peerDependencies": {
+    "@babel/core": "^7.0.0"
+  },
   "engines": {
     "node": ">= 6"
   },


### PR DESCRIPTION
## Summary

The `@babel/plugin-syntax-object-rest-spread` package has peer dependencies on `@babel/core`, which means that `babel-preset-jest` also depends on it.

## Test plan

n/a
