### PR TITLE
feat: print error msg & stack on preset normalization error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - `[expect]`: Improve report when matcher fails, part 7 ([#7866](https://github.com/facebook/jest/pull/7866))
 - `[expect]`: Improve report when matcher fails, part 8 ([#7876](https://github.com/facebook/jest/pull/7876))
 - `[pretty-format]` Support `React.memo` ([#7891](https://github.com/facebook/jest/pull/7891))
+- `[jest-config]` Print error information on preset normalization error ([#7935](https://github.com/facebook/jest/pull/7935))
 
 ### Fixes
 

--- a/packages/jest-config/src/__tests__/normalize.test.js
+++ b/packages/jest-config/src/__tests__/normalize.test.js
@@ -934,6 +934,10 @@ describe('preset', () => {
         return '/node_modules/react-native/jest-preset.json';
       }
 
+      if (name === 'react-native-js-preset/jest-preset') {
+        return '/node_modules/react-native-js-preset/jest-preset.js';
+      }
+
       if (name === 'doesnt-exist') {
         return null;
       }
@@ -948,6 +952,15 @@ describe('preset', () => {
         setupFiles: ['b'],
         setupFilesAfterEnv: ['b'],
         transform: {b: 'b'},
+      }),
+      {virtual: true},
+    );
+    jest.doMock(
+      '/node_modules/react-native-js-preset/jest-preset.js',
+      () => ({
+        moduleNameMapper: {
+          json: true,
+        },
       }),
       {virtual: true},
     );
@@ -1021,7 +1034,29 @@ describe('preset', () => {
         },
         {},
       );
-    }).toThrowError(/Unexpected token }/);
+    }).toThrowError(/Unexpected token } in JSON at position 104[\s\S]* at /);
+  });
+
+  test('throws when preset evaluation throws type error', () => {
+    jest.doMock(
+      '/node_modules/react-native-js-preset/jest-preset.js',
+      () => ({
+        transform: {}.nonExistingProp.call(),
+      }),
+      {virtual: true},
+    );
+
+    expect(() => {
+      normalize(
+        {
+          preset: 'react-native-js-preset',
+          rootDir: '/root/path/foo',
+        },
+        {},
+      );
+    }).toThrowError(
+      /TypeError: Cannot read property 'call' of undefined[\s\S]* at /,
+    );
   });
 
   test('works with "react-native"', () => {

--- a/packages/jest-config/src/normalize.js
+++ b/packages/jest-config/src/normalize.js
@@ -95,9 +95,11 @@ const setupPreset = (
     // $FlowFixMe
     preset = (require(presetModule): InitialOptions);
   } catch (error) {
-    if (error instanceof SyntaxError) {
+    if (error instanceof SyntaxError || error instanceof TypeError) {
       throw createConfigError(
-        `  Preset ${chalk.bold(presetPath)} is invalid:\n  ${error.message}`,
+        `  Preset ${chalk.bold(presetPath)} is invalid:\n\n  ${
+          error.message
+        }\n  ${error.stack}`,
       );
     }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary
When loading a `jest-preset.js`, which does some computation or load other packages, errors can occur.

This PR will help preset-developers to see the error message and stack. Currently only the misleading error message `Module jest-preset-angular should have "jest-preset.js" or "jest-preset.json" file at the root.` is displayed.

Inspired by https://github.com/thymikee/jest-preset-angular/pull/230, kudos to @thymikee 

## Test plan

Unit test added
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
