### PR TITLE
`toStrictEqual` does not consider arrays with objects having undefined values correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - `[jest-cli]` Fix prototype pollution vulnerability in dependency ([#7904](https://github.com/facebook/jest/pull/7904))
 - `[jest-cli]` Refactor `-o` and `--coverage` combined ([#7611](https://github.com/facebook/jest/pull/7611))
 - `[expect]` Fix custom async matcher stack trace ([#7652](https://github.com/facebook/jest/pull/7652))
+- `[expect]` `toStrictEqual` does not consider arrays with objects having undefined values correctly ([#7938](https://github.com/facebook/jest/pull/7938))
 - `[jest-changed-files]` Improve default file selection for Mercurial repos ([#7880](https://github.com/facebook/jest/pull/7880))
 - `[jest-validate]` Fix validating async functions ([#7894](https://github.com/facebook/jest/issues/7894))
 - `[jest-circus]` Fix bug with test.only ([#7888](https://github.com/facebook/jest/pull/7888))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - `[jest-cli]` Fix prototype pollution vulnerability in dependency ([#7904](https://github.com/facebook/jest/pull/7904))
 - `[jest-cli]` Refactor `-o` and `--coverage` combined ([#7611](https://github.com/facebook/jest/pull/7611))
 - `[expect]` Fix custom async matcher stack trace ([#7652](https://github.com/facebook/jest/pull/7652))
-- `[expect]` `toStrictEqual` does not consider arrays with objects having undefined values correctly ([#7938](https://github.com/facebook/jest/pull/7938))
+- `[expect]` Fix `toStrictEqual` not considering arrays with objects having undefined values correctly ([#7938](https://github.com/facebook/jest/pull/7938))
 - `[jest-changed-files]` Improve default file selection for Mercurial repos ([#7880](https://github.com/facebook/jest/pull/7880))
 - `[jest-validate]` Fix validating async functions ([#7894](https://github.com/facebook/jest/issues/7894))
 - `[jest-circus]` Fix bug with test.only ([#7888](https://github.com/facebook/jest/pull/7888))

--- a/packages/expect/src/__tests__/matchers.test.js
+++ b/packages/expect/src/__tests__/matchers.test.js
@@ -281,6 +281,10 @@ describe('.toStrictEqual()', () => {
     }).not.toStrictEqual({b: 2});
   });
 
+  it('does not ignore keys with undefined values inside an array', () => {
+    expect([{a: undefined}]).not.toStrictEqual([{}]);
+  });
+
   it('passes when comparing same type', () => {
     expect({
       test: new TestClassA(1, 2),

--- a/packages/expect/src/__tests__/matchers.test.js
+++ b/packages/expect/src/__tests__/matchers.test.js
@@ -285,6 +285,10 @@ describe('.toStrictEqual()', () => {
     expect([{a: undefined}]).not.toStrictEqual([{}]);
   });
 
+  it('does not ignore keys with undefined values deep inside an object', () => {
+    expect([{a: [{a: undefined}]}]).not.toStrictEqual([{a: [{}]}]);
+  });
+
   it('passes when comparing same type', () => {
     expect({
       test: new TestClassA(1, 2),

--- a/packages/expect/src/utils.ts
+++ b/packages/expect/src/utils.ts
@@ -257,8 +257,7 @@ export const sparseArrayEquality = (a: unknown, b: unknown) => {
   const aKeys = Object.keys(a);
   const bKeys = Object.keys(b);
   return (
-    equals(a, b, [iterableEquality, typeEquality], true) &&
-    equals(aKeys, bKeys)
+    equals(a, b, [iterableEquality, typeEquality], true) && equals(aKeys, bKeys)
   );
 };
 

--- a/packages/expect/src/utils.ts
+++ b/packages/expect/src/utils.ts
@@ -256,7 +256,10 @@ export const sparseArrayEquality = (a: unknown, b: unknown) => {
   // A sparse array [, , 1] will have keys ["2"] whereas [undefined, undefined, 1] will have keys ["0", "1", "2"]
   const aKeys = Object.keys(a);
   const bKeys = Object.keys(b);
-  return equals(a, b) && equals(aKeys, bKeys);
+  return (
+    equals(a, b, [iterableEquality, typeEquality], true) &&
+    equals(aKeys, bKeys)
+  );
 };
 
 export const partition = <T>(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Fixes #7937: `toStrictEqual` does not consider arrays with objects having undefined values correctly

## Test plan

Before that change, the following assertion was failing:

```js
expect([{a: undefined}]).not.toStrictEqual([{}]);
```

Now it passes as expected.
