### PR TITLE
expect, jest-matcher-utils: Improve report when matcher fails, part 9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - `[expect]`: Improve report when matcher fails, part 7 ([#7866](https://github.com/facebook/jest/pull/7866))
 - `[expect]`: Improve report when matcher fails, part 8 ([#7876](https://github.com/facebook/jest/pull/7876))
+- `[expect]`: Improve report when matcher fails, part 9 ([#7940](https://github.com/facebook/jest/pull/7940))
 - `[pretty-format]` Support `React.memo` ([#7891](https://github.com/facebook/jest/pull/7891))
 - `[jest-config]` Print error information on preset normalization error ([#7935](https://github.com/facebook/jest/pull/7935))
 

--- a/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -564,7 +564,7 @@ Received difference:   <red>0.005000099999999952</>"
 `;
 
 exports[`.toBeCloseTo() throws: Matcher error promise empty isNot false received 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeCloseTo<dim>(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toBeCloseTo<dim>(</><green>expected</><dim>, </><green>precision</><dim>)</>
 
 <bold>Matcher error</>: <red>received</> value must be a number
 

--- a/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -563,6 +563,58 @@ Expected difference: < <green>0.005</>
 Received difference:   <red>0.005000099999999952</>"
 `;
 
+exports[`.toBeCloseTo() throws: Matcher error promise empty isNot false received 1`] = `
+"<dim>expect(</><red>received</><dim>).</>toBeCloseTo<dim>(</><green>expected</><dim>)</>
+
+<bold>Matcher error</>: <red>received</> value must be a number
+
+Received has type:  string
+Received has value: <red>\\"\\"</>"
+`;
+
+exports[`.toBeCloseTo() throws: Matcher error promise empty isNot true expected 1`] = `
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeCloseTo<dim>(</><green>expected</><dim>)</>
+
+<bold>Matcher error</>: <green>expected</> value must be a number
+
+Expected has value: <green>undefined</>"
+`;
+
+exports[`.toBeCloseTo() throws: Matcher error promise rejects isNot false expected 1`] = `
+"<dim>expect(</><red>received</><dim>).</>rejects<dim>.</>toBeCloseTo<dim>(</><green>expected</><dim>)</>
+
+<bold>Matcher error</>: <green>expected</> value must be a number
+
+Expected has type:  string
+Expected has value: <green>\\"0\\"</>"
+`;
+
+exports[`.toBeCloseTo() throws: Matcher error promise rejects isNot true received 1`] = `
+"<dim>expect(</><red>received</><dim>).</>rejects<dim>.</>not<dim>.</>toBeCloseTo<dim>(</><green>expected</><dim>)</>
+
+<bold>Matcher error</>: <red>received</> value must be a number
+
+Received has type:  symbol
+Received has value: <red>Symbol(0.1)</>"
+`;
+
+exports[`.toBeCloseTo() throws: Matcher error promise resolves isNot false received 1`] = `
+"<dim>expect(</><red>received</><dim>).</>resolves<dim>.</>toBeCloseTo<dim>(</><green>expected</><dim>, </><green>precision</><dim>)</>
+
+<bold>Matcher error</>: <red>received</> value must be a number
+
+Received has type:  boolean
+Received has value: <red>false</>"
+`;
+
+exports[`.toBeCloseTo() throws: Matcher error promise resolves isNot true expected 1`] = `
+"<dim>expect(</><red>received</><dim>).</>resolves<dim>.</>not<dim>.</>toBeCloseTo<dim>(</><green>expected</><dim>, </><green>precision</><dim>)</>
+
+<bold>Matcher error</>: <green>expected</> value must be a number
+
+Expected has value: <green>null</>"
+`;
+
 exports[`.toBeDefined(), .toBeUndefined() '"a"' is defined 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeDefined<dim>()</>
 

--- a/packages/expect/src/__tests__/matchers.test.js
+++ b/packages/expect/src/__tests__/matchers.test.js
@@ -998,6 +998,56 @@ describe('.toBeCloseTo()', () => {
       ).toThrowErrorMatchingSnapshot();
     });
   });
+
+  describe('throws: Matcher error', () => {
+    test('promise empty isNot false received', () => {
+      const expected = 0;
+      const received = '';
+      expect(() => {
+        jestExpect(received).toBeCloseTo(expected);
+      }).toThrowErrorMatchingSnapshot();
+    });
+
+    test('promise empty isNot true expected', () => {
+      const received = 0.1;
+      // expected is undefined
+      expect(() => {
+        jestExpect(received).not.toBeCloseTo();
+      }).toThrowErrorMatchingSnapshot();
+    });
+
+    test('promise rejects isNot false expected', () => {
+      const expected = '0';
+      const received = Promise.reject(0.01);
+      return expect(
+        jestExpect(received).rejects.toBeCloseTo(expected),
+      ).rejects.toThrowErrorMatchingSnapshot();
+    });
+
+    test('promise rejects isNot true received', () => {
+      const expected = 0;
+      const received = Promise.reject(Symbol('0.1'));
+      return expect(
+        jestExpect(received).rejects.not.toBeCloseTo(expected),
+      ).rejects.toThrowErrorMatchingSnapshot();
+    });
+
+    test('promise resolves isNot false received', () => {
+      const expected = 0;
+      const received = Promise.resolve(false);
+      return expect(
+        jestExpect(received).resolves.toBeCloseTo(expected, 3),
+      ).rejects.toThrowErrorMatchingSnapshot();
+    });
+
+    test('promise resolves isNot true expected', () => {
+      const expected = null;
+      const received = Promise.resolve(0.1);
+      expect(
+        jestExpect(received).resolves.not.toBeCloseTo(expected, 3),
+      ).rejects.toThrowErrorMatchingSnapshot();
+    });
+  });
 });
 
 describe('.toMatch()', () => {

--- a/packages/expect/src/__tests__/matchers.test.js
+++ b/packages/expect/src/__tests__/matchers.test.js
@@ -1034,18 +1034,20 @@ describe('.toBeCloseTo()', () => {
     });
 
     test('promise resolves isNot false received', () => {
+      const precision = 3;
       const expected = 0;
       const received = Promise.resolve(false);
       return expect(
-        jestExpect(received).resolves.toBeCloseTo(expected, 3),
+        jestExpect(received).resolves.toBeCloseTo(expected, precision),
       ).rejects.toThrowErrorMatchingSnapshot();
     });
 
     test('promise resolves isNot true expected', () => {
+      const precision = 3;
       const expected = null;
       const received = Promise.resolve(0.1);
       expect(
-        jestExpect(received).resolves.not.toBeCloseTo(expected, 3),
+        jestExpect(received).resolves.not.toBeCloseTo(expected, precision),
       ).rejects.toThrowErrorMatchingSnapshot();
     });
   });

--- a/packages/expect/src/__tests__/matchers.test.js
+++ b/packages/expect/src/__tests__/matchers.test.js
@@ -1001,10 +1001,11 @@ describe('.toBeCloseTo()', () => {
 
   describe('throws: Matcher error', () => {
     test('promise empty isNot false received', () => {
+      const precision = 3;
       const expected = 0;
       const received = '';
       expect(() => {
-        jestExpect(received).toBeCloseTo(expected);
+        jestExpect(received).toBeCloseTo(expected, precision);
       }).toThrowErrorMatchingSnapshot();
     });
 

--- a/packages/expect/src/matchers.ts
+++ b/packages/expect/src/matchers.ts
@@ -99,7 +99,7 @@ const matchers: MatchersObject = {
       promise: this.promise,
       secondArgument,
     };
-    ensureNumbers(received, expected, '.toBeCloseTo');
+    ensureNumbers(received, expected, 'toBeCloseTo', options);
 
     let pass = false;
     let expectedDiff = 0;
@@ -180,7 +180,7 @@ const matchers: MatchersObject = {
       isNot,
       promise: this.promise,
     };
-    ensureNumbers(received, expected, '.toBeGreaterThan');
+    ensureNumbers(received, expected, 'toBeGreaterThan', options);
 
     const pass = received > expected;
 
@@ -203,7 +203,7 @@ const matchers: MatchersObject = {
       isNot,
       promise: this.promise,
     };
-    ensureNumbers(received, expected, '.toBeGreaterThanOrEqual');
+    ensureNumbers(received, expected, 'toBeGreaterThanOrEqual', options);
 
     const pass = received >= expected;
 
@@ -266,7 +266,7 @@ const matchers: MatchersObject = {
       isNot,
       promise: this.promise,
     };
-    ensureNumbers(received, expected, '.toBeLessThan');
+    ensureNumbers(received, expected, 'toBeLessThan', options);
 
     const pass = received < expected;
 
@@ -285,7 +285,7 @@ const matchers: MatchersObject = {
       isNot,
       promise: this.promise,
     };
-    ensureNumbers(received, expected, '.toBeLessThanOrEqual');
+    ensureNumbers(received, expected, 'toBeLessThanOrEqual', options);
 
     const pass = received <= expected;
 

--- a/packages/expect/src/matchers.ts
+++ b/packages/expect/src/matchers.ts
@@ -93,9 +93,8 @@ const matchers: MatchersObject = {
     precision: number = 2,
   ) {
     const secondArgument = arguments.length === 3 ? 'precision' : undefined;
-    const isNot = this.isNot;
     const options: MatcherHintOptions = {
-      isNot,
+      isNot: this.isNot,
       promise: this.promise,
       secondArgument,
     };

--- a/packages/jest-matcher-utils/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/jest-matcher-utils/src/__tests__/__snapshots__/index.test.ts.snap
@@ -37,7 +37,7 @@ Received has value: <red>\\"not_a_number\\"</>"
 `;
 
 exports[`.ensureNumbers() with options promise empty isNot false received 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeCloseTo<dim>(</><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toBeCloseTo<dim>(</><green>expected</><dim>, </><green>precision</><dim>)</>
 
 <bold>Matcher error</>: <red>received</> value must be a number
 

--- a/packages/jest-matcher-utils/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/jest-matcher-utils/src/__tests__/__snapshots__/index.test.ts.snap
@@ -18,8 +18,8 @@ Expected has type:  object
 Expected has value: <green>{\\"a\\": 1}</>"
 `;
 
-exports[`.ensureNumbers() throws error when expected is not a number 1`] = `
-"<dim>expect(</><red>received</><dim>)[.not]This matcher(</><green>expected</><dim>)</>
+exports[`.ensureNumbers() throws error when expected is not a number (backward compatibility) 1`] = `
+"<dim>expect(</><red>received</><dim>)[.not].toBeCloseTo(</><green>expected</><dim>)</>
 
 <bold>Matcher error</>: <green>expected</> value must be a number
 
@@ -27,13 +27,65 @@ Expected has type:  string
 Expected has value: <green>\\"not_a_number\\"</>"
 `;
 
-exports[`.ensureNumbers() throws error when received is not a number 1`] = `
-"<dim>expect(</><red>received</><dim>)[.not]This matcher(</><green>expected</><dim>)</>
+exports[`.ensureNumbers() throws error when received is not a number (backward compatibility) 1`] = `
+"<dim>expect(</><red>received</><dim>)[.not].toBeCloseTo(</><green>expected</><dim>)</>
 
 <bold>Matcher error</>: <red>received</> value must be a number
 
 Received has type:  string
 Received has value: <red>\\"not_a_number\\"</>"
+`;
+
+exports[`.ensureNumbers() with options promise empty isNot false received 1`] = `
+"<dim>expect(</><red>received</><dim>).</>toBeCloseTo<dim>(</><green>expected</><dim>)</>
+
+<bold>Matcher error</>: <red>received</> value must be a number
+
+Received has type:  string
+Received has value: <red>\\"\\"</>"
+`;
+
+exports[`.ensureNumbers() with options promise empty isNot true expected 1`] = `
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeCloseTo<dim>(</><green>expected</><dim>)</>
+
+<bold>Matcher error</>: <green>expected</> value must be a number
+
+Expected has value: <green>undefined</>"
+`;
+
+exports[`.ensureNumbers() with options promise rejects isNot false expected 1`] = `
+"<dim>expect(</><red>received</><dim>).</>rejects<dim>.</>toBeCloseTo<dim>(</><green>expected</><dim>)</>
+
+<bold>Matcher error</>: <green>expected</> value must be a number
+
+Expected has type:  string
+Expected has value: <green>\\"0\\"</>"
+`;
+
+exports[`.ensureNumbers() with options promise rejects isNot true received 1`] = `
+"<dim>expect(</><red>received</><dim>).</>rejects<dim>.</>not<dim>.</>toBeCloseTo<dim>(</><green>expected</><dim>)</>
+
+<bold>Matcher error</>: <red>received</> value must be a number
+
+Received has type:  symbol
+Received has value: <red>Symbol(0.1)</>"
+`;
+
+exports[`.ensureNumbers() with options promise resolves isNot false received 1`] = `
+"<dim>expect(</><red>received</><dim>).</>resolves<dim>.</>toBeCloseTo<dim>(</><green>expected</><dim>)</>
+
+<bold>Matcher error</>: <red>received</> value must be a number
+
+Received has type:  boolean
+Received has value: <red>false</>"
+`;
+
+exports[`.ensureNumbers() with options promise resolves isNot true expected 1`] = `
+"<dim>expect(</><red>received</><dim>).</>resolves<dim>.</>not<dim>.</>toBeCloseTo<dim>(</><green>expected</><dim>)</>
+
+<bold>Matcher error</>: <green>expected</> value must be a number
+
+Expected has value: <green>null</>"
 `;
 
 exports[`.stringify() reduces maxDepth if stringifying very large objects 1`] = `"{\\"a\\": 1, \\"b\\": [Object]}"`;

--- a/packages/jest-matcher-utils/src/__tests__/index.test.ts
+++ b/packages/jest-matcher-utils/src/__tests__/index.test.ts
@@ -120,6 +120,7 @@ describe('.ensureNumbers()', () => {
       const options: MatcherHintOptions = {
         isNot: false,
         promise: '',
+        secondArgument: 'precision',
       };
       expect(() => {
         // @ts-ignore

--- a/packages/jest-matcher-utils/src/__tests__/index.test.ts
+++ b/packages/jest-matcher-utils/src/__tests__/index.test.ts
@@ -13,6 +13,7 @@ import {
   getLabelPrinter,
   pluralize,
   stringify,
+  MatcherHintOptions,
 } from '../';
 
 describe('.stringify()', () => {
@@ -98,18 +99,88 @@ describe('.ensureNumbers()', () => {
     }).not.toThrow();
   });
 
-  test('throws error when expected is not a number', () => {
+  test('throws error when expected is not a number (backward compatibility)', () => {
     expect(() => {
       // @ts-ignore
-      ensureNumbers(1, 'not_a_number');
+      ensureNumbers(1, 'not_a_number', '.toBeCloseTo');
     }).toThrowErrorMatchingSnapshot();
   });
 
-  test('throws error when received is not a number', () => {
+  test('throws error when received is not a number (backward compatibility)', () => {
     expect(() => {
       // @ts-ignore
-      ensureNumbers('not_a_number', 3);
+      ensureNumbers('not_a_number', 3, '.toBeCloseTo');
     }).toThrowErrorMatchingSnapshot();
+  });
+
+  describe('with options', () => {
+    const matcherName = 'toBeCloseTo';
+
+    test('promise empty isNot false received', () => {
+      const options: MatcherHintOptions = {
+        isNot: false,
+        promise: '',
+      };
+      expect(() => {
+        // @ts-ignore
+        ensureNumbers('', 0, matcherName, options);
+      }).toThrowErrorMatchingSnapshot();
+    });
+
+    test('promise empty isNot true expected', () => {
+      const options: MatcherHintOptions = {
+        isNot: true,
+        // promise undefined is equivalent to empty string
+      };
+      expect(() => {
+        // @ts-ignore
+        ensureNumbers(0.1, undefined, matcherName, options);
+      }).toThrowErrorMatchingSnapshot();
+    });
+
+    test('promise rejects isNot false expected', () => {
+      const options: MatcherHintOptions = {
+        isNot: false,
+        promise: 'rejects',
+      };
+      expect(() => {
+        // @ts-ignore
+        ensureNumbers(0.01, '0', matcherName, options);
+      }).toThrowErrorMatchingSnapshot();
+    });
+
+    test('promise rejects isNot true received', () => {
+      const options: MatcherHintOptions = {
+        isNot: true,
+        promise: 'rejects',
+      };
+      expect(() => {
+        // @ts-ignore
+        ensureNumbers(Symbol('0.1'), 0, matcherName, options);
+      }).toThrowErrorMatchingSnapshot();
+    });
+
+    test('promise resolves isNot false received', () => {
+      const options: MatcherHintOptions = {
+        isNot: false,
+        promise: 'resolves',
+      };
+      expect(() => {
+        // @ts-ignore
+        ensureNumbers(false, 0, matcherName, options);
+      }).toThrowErrorMatchingSnapshot();
+    });
+
+    test('promise resolves isNot true expected', () => {
+      const options: MatcherHintOptions = {
+        isNot: true,
+        promise: 'resolves',
+      };
+      expect(() => {
+        // @ts-ignore
+        ensureNumbers(0.1, null, matcherName, options);
+      }).toThrowErrorMatchingSnapshot();
+    });
   });
 });
 

--- a/packages/jest-matcher-utils/src/index.ts
+++ b/packages/jest-matcher-utils/src/index.ts
@@ -130,12 +130,17 @@ export const ensureNoExpected = (
   }
 };
 
-export const ensureActualIsNumber = (actual: unknown, matcherName: string) => {
-  matcherName || (matcherName = 'This matcher');
+export const ensureActualIsNumber = (
+  actual: unknown,
+  matcherName: string,
+  options?: MatcherHintOptions,
+) => {
   if (typeof actual !== 'number') {
+    // Prepend maybe not only for backward compatibility.
+    const matcherString = (options ? '' : '[.not]') + matcherName;
     throw new Error(
       matcherErrorMessage(
-        matcherHint('[.not]' + matcherName),
+        matcherHint(matcherString, undefined, undefined, options),
         `${RECEIVED_COLOR('received')} value must be a number`,
         printWithType('Received', actual, printReceived),
       ),
@@ -146,12 +151,14 @@ export const ensureActualIsNumber = (actual: unknown, matcherName: string) => {
 export const ensureExpectedIsNumber = (
   expected: unknown,
   matcherName: string,
+  options?: MatcherHintOptions,
 ) => {
-  matcherName || (matcherName = 'This matcher');
   if (typeof expected !== 'number') {
+    // Prepend maybe not only for backward compatibility.
+    const matcherString = (options ? '' : '[.not]') + matcherName;
     throw new Error(
       matcherErrorMessage(
-        matcherHint('[.not]' + matcherName),
+        matcherHint(matcherString, undefined, undefined, options),
         `${EXPECTED_COLOR('expected')} value must be a number`,
         printWithType('Expected', expected, printExpected),
       ),
@@ -163,9 +170,10 @@ export const ensureNumbers = (
   actual: unknown,
   expected: unknown,
   matcherName: string,
+  options?: MatcherHintOptions,
 ) => {
-  ensureActualIsNumber(actual, matcherName);
-  ensureExpectedIsNumber(expected, matcherName);
+  ensureActualIsNumber(actual, matcherName, options);
+  ensureExpectedIsNumber(expected, matcherName, options);
 };
 
 // Sometimes, e.g. when comparing two numbers, the output from jest-diff


### PR DESCRIPTION
## Summary

For matcher error in:

* `.toBeCloseTo`
* `.toBeGreaterThan`
* `.toBeGreaterThanOrEqual`
* `.toBeLessThan`
* `.toBeLessThanOrEqual`

When expected or received must be a number:

* Because matcher name does not include period, display in black instead of dim color
* With options argument, display `.not` or `.rejects` or `.resolves`

In `ensureActualIsNumber` and `ensureExpectedIsNumber` functions:

* Support backward compatible `[.not]` and dim matcher name if it does include period.
* Delete `'This matcher'` default for `matcherName` arg. I doubt it has ever been used.

**Residue** provide options to `ensureExpectedIsNumber` calls when we improve spy matchers:

* `.toHaveBeenCalledTimes` and `.toBeCalledTimes`
* `.toHaveReturnedTimes` and `.toReturn`

## Test plan

* jest-matcher-utils: updated 2 snapshot tests and added 6 new snapshot tests
* expect matchers: added 6 new snapshots tests to `.toBeCloseTo` as integration test
* expect spyMatchers: 48 snapshot tests unchanged backward compatibility (see Residue)