### PR TITLE
Ignore rootDir to determine the cache key of transformed files in babel-jest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `[expect]`: Improve report when matcher fails, part 9 ([#7940](https://github.com/facebook/jest/pull/7940))
 - `[pretty-format]` Support `React.memo` ([#7891](https://github.com/facebook/jest/pull/7891))
 - `[jest-config]` Print error information on preset normalization error ([#7935](https://github.com/facebook/jest/pull/7935))
+- `[babel-jest]` Ignore `rootDir` to determine the cache key of transformed files ([#7947](https://github.com/facebook/jest/pull/7947))
 
 ### Fixes
 

--- a/e2e/__tests__/__snapshots__/transform.test.js.snap
+++ b/e2e/__tests__/__snapshots__/transform.test.js.snap
@@ -6,7 +6,7 @@ FAIL __tests__/ignoredFile.test.js
 
     babel-jest: Babel ignores __tests__/ignoredFile.test.js - make sure to include the file in Jest's transformIgnorePatterns as well.
 
-      at loadBabelConfig (../../../packages/babel-jest/build/index.js:132:13)
+      at loadBabelConfig (../../../packages/babel-jest/build/index.js:142:13)
 `;
 
 exports[`babel-jest instruments only specific files and collects coverage 1`] = `

--- a/packages/babel-jest/package.json
+++ b/packages/babel-jest/package.json
@@ -17,6 +17,7 @@
     "babel-plugin-istanbul": "^5.1.0",
     "babel-preset-jest": "^24.1.0",
     "chalk": "^2.4.2",
+    "jest-regex-util": "^24.0.0",
     "slash": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/babel-jest/src/index.ts
+++ b/packages/babel-jest/src/index.ts
@@ -76,7 +76,10 @@ const createTransformer = (
     return rootDirRegExpCache[rootDir];
   }
 
-  function getCacheKeyForBabelOptions(babelOptions: any, rootDir: Config.Path) {
+  function getCacheKeyForBabelOptions(
+    babelOptions: PartialConfig,
+    rootDir: Config.Path,
+  ) {
     const rootDirRegExp = getRootDirRegExp(rootDir);
 
     // Not pretty but not coupled to a specific signature of the

--- a/packages/babel-jest/src/index.ts
+++ b/packages/babel-jest/src/index.ts
@@ -69,7 +69,7 @@ const createTransformer = (
   function getRootDirRegExp(rootDir: Config.Path): RegExp {
     if (!rootDirRegExpCache[rootDir]) {
       rootDirRegExpCache[rootDir] = new RegExp(
-        `^${escapeStrForRegex(rootDir)}(${escapeStrForRegex(path.sep)}|$)`,
+        `^${escapeStrForRegex(rootDir)}(?=${escapeStrForRegex(path.sep)}|$)`,
       );
     }
 
@@ -86,7 +86,7 @@ const createTransformer = (
     // babel options to relativize paths
     return JSON.stringify(babelOptions.options, (_key, value) => {
       if (typeof value === 'string') {
-        return value.replace(rootDirRegExp, '<rootDir>$1');
+        return value.replace(rootDirRegExp, '<rootDir>');
       }
       return value;
     });

--- a/packages/babel-jest/tsconfig.json
+++ b/packages/babel-jest/tsconfig.json
@@ -7,6 +7,7 @@
   // TODO: include `babel-preset-jest` if it's ever in TS even though we don't care about its types
   "references": [
     {"path": "../jest-transform"},
-    {"path": "../jest-types"}
+    {"path": "../jest-types"},
+    {"path": "../jest-regex-util"}
   ]
 }


### PR DESCRIPTION
## Summary

Removes the root directory from the determination of the cache key in `babel-jest`.

The cache directory used by Jest depends on the root directory so different projects store their artifacts in different caches. With that guarantee, we don't need to take the root directory into account to compute the cache key of the transformed files, so we can store them remotely and restore them in different hosts/locations.

## Test plan

Added a test to verify this behaviour.

In terms of performance, we crawl the filesystem by default to find Babel configuration files and that's an order of magnitude higher than the additional processing we're doing with this change.
