### PR TITLE
Fix asymmetric equal for Number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `[jest-cli]` Refactor `-o` and `--coverage` combined ([#7611](https://github.com/facebook/jest/pull/7611))
 - `[expect]` Fix custom async matcher stack trace ([#7652](https://github.com/facebook/jest/pull/7652))
 - `[expect]` Fix `toStrictEqual` not considering arrays with objects having undefined values correctly ([#7938](https://github.com/facebook/jest/pull/7938))
+- `[expect]` Fix non-symmetric equal for Number ([#7948](https://github.com/facebook/jest/pull/7948))
 - `[jest-changed-files]` Improve default file selection for Mercurial repos ([#7880](https://github.com/facebook/jest/pull/7880))
 - `[jest-validate]` Fix validating async functions ([#7894](https://github.com/facebook/jest/issues/7894))
 - `[jest-circus]` Fix bug with test.only ([#7888](https://github.com/facebook/jest/pull/7888))

--- a/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -1818,6 +1818,13 @@ Expected: <green>\\"abc\\"</>
 Received: <red>\\"abc\\"</>"
 `;
 
+exports[`.toEqual() {pass: false} expect("abc").not.toEqual({"0": "a", "1": "b", "2": "c"}) 1`] = `
+"<dim>expect(</><red>received</><dim>).</>not<dim>.toEqual(</><green>expected</><dim>)</>
+
+Expected: <green>{\\"0\\": \\"a\\", \\"1\\": \\"b\\", \\"2\\": \\"c\\"}</>
+Received: <red>\\"abc\\"</>"
+`;
+
 exports[`.toEqual() {pass: false} expect("abcd").not.toEqual(StringContaining "bc") 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.toEqual(</><green>expected</><dim>)</>
 
@@ -1931,6 +1938,13 @@ Expected: <green>Any<Function></>
 Received: <red>[Function anonymous]</>"
 `;
 
+exports[`.toEqual() {pass: false} expect({"0": "a", "1": "b", "2": "c"}).not.toEqual("abc") 1`] = `
+"<dim>expect(</><red>received</><dim>).</>not<dim>.toEqual(</><green>expected</><dim>)</>
+
+Expected: <green>\\"abc\\"</>
+Received: <red>{\\"0\\": \\"a\\", \\"1\\": \\"b\\", \\"2\\": \\"c\\"}</>"
+`;
+
 exports[`.toEqual() {pass: false} expect({"a": 1, "b": [Function b], "c": true}).not.toEqual({"a": 1, "b": Any<Function>, "c": Anything}) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.toEqual(</><green>expected</><dim>)</>
 
@@ -2004,6 +2018,20 @@ exports[`.toEqual() {pass: false} expect({}).not.toEqual({}) 1`] = `
 
 Expected: <green>{}</>
 Received: <red>{}</>"
+`;
+
+exports[`.toEqual() {pass: false} expect({}).not.toEqual(0) 1`] = `
+"<dim>expect(</><red>received</><dim>).</>not<dim>.toEqual(</><green>expected</><dim>)</>
+
+Expected: <green>0</>
+Received: <red>{}</>"
+`;
+
+exports[`.toEqual() {pass: false} expect(0).not.toEqual({}) 1`] = `
+"<dim>expect(</><red>received</><dim>).</>not<dim>.toEqual(</><green>expected</><dim>)</>
+
+Expected: <green>{}</>
+Received: <red>0</>"
 `;
 
 exports[`.toEqual() {pass: false} expect(0).toEqual(-0) 1`] = `
@@ -2406,6 +2434,13 @@ exports[`.toEqual() {pass: false} expect(Map {1 => ["one"], 2 => ["two"]}).not.t
 
 Expected: <green>Map {2 => [\\"two\\"], 1 => [\\"one\\"]}</>
 Received: <red>Map {1 => [\\"one\\"], 2 => [\\"two\\"]}</>"
+`;
+
+exports[`.toEqual() {pass: false} expect(NaN).not.toEqual(NaN) 1`] = `
+"<dim>expect(</><red>received</><dim>).</>not<dim>.toEqual(</><green>expected</><dim>)</>
+
+Expected: <green>NaN</>
+Received: <red>NaN</>"
 `;
 
 exports[`.toEqual() {pass: false} expect(Set {[1], [2], [3], [3]}).not.toEqual(Set {[3], [3], [2], [1]}) 1`] = `

--- a/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -2013,6 +2013,13 @@ Expected: <green>-0</>
 Received: <red>0</>"
 `;
 
+exports[`.toEqual() {pass: false} expect(0).toEqual(5e-324) 1`] = `
+"<dim>expect(</><red>received</><dim>).toEqual(</><green>expected</><dim>)</>
+
+Expected: <green>5e-324</>
+Received: <red>0</>"
+`;
+
 exports[`.toEqual() {pass: false} expect(1).not.toEqual(1) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.toEqual(</><green>expected</><dim>)</>
 
@@ -2032,6 +2039,13 @@ exports[`.toEqual() {pass: false} expect(1).toEqual(ArrayContaining [1, 2]) 1`] 
 
 Expected: <green>ArrayContaining [1, 2]</>
 Received: <red>1</>"
+`;
+
+exports[`.toEqual() {pass: false} expect(5e-324).toEqual(0) 1`] = `
+"<dim>expect(</><red>received</><dim>).toEqual(</><green>expected</><dim>)</>
+
+Expected: <green>0</>
+Received: <red>5e-324</>"
 `;
 
 exports[`.toEqual() {pass: false} expect(Immutable.List [1, 2]).not.toEqual(Immutable.List [1, 2]) 1`] = `

--- a/packages/expect/src/__tests__/matchers.test.js
+++ b/packages/expect/src/__tests__/matchers.test.js
@@ -428,7 +428,16 @@ describe('.toEqual()', () => {
   [
     [true, true],
     [1, 1],
+    [NaN, NaN],
+    // eslint-disable-next-line no-new-wrappers
+    [0, new Number(0)],
+    // eslint-disable-next-line no-new-wrappers
+    [new Number(0), 0],
     ['abc', 'abc'],
+    // eslint-disable-next-line no-new-wrappers
+    [new String('abc'), 'abc'],
+    // eslint-disable-next-line no-new-wrappers
+    ['abc', new String('abc')],
     [[1], [1]],
     [[1, 2], [1, 2]],
     [Immutable.List([1]), Immutable.List([1])],

--- a/packages/expect/src/__tests__/matchers.test.js
+++ b/packages/expect/src/__tests__/matchers.test.js
@@ -344,6 +344,8 @@ describe('.toEqual()', () => {
     [true, false],
     [1, 2],
     [0, -0],
+    [0, Number.MIN_VALUE], // issues/7941
+    [Number.MIN_VALUE, 0],
     [{a: 5}, {b: 6}],
     ['banana', 'apple'],
     [null, undefined],

--- a/packages/expect/src/jasmineUtils.ts
+++ b/packages/expect/src/jasmineUtils.ts
@@ -106,8 +106,6 @@ function eq(
       // $FlowFixMe – Flow sees `a` as a number
       return a == String(b);
     case '[object Number]':
-      // `NaN`s are equivalent, but non-reflexive. An `egal` comparison is performed for
-      // other numeric values.
       return Object.is(Number(a), Number(b));
     case '[object Date]':
     case '[object Boolean]':

--- a/packages/expect/src/jasmineUtils.ts
+++ b/packages/expect/src/jasmineUtils.ts
@@ -108,7 +108,7 @@ function eq(
     case '[object Number]':
       // `NaN`s are equivalent, but non-reflexive. An `egal` comparison is performed for
       // other numeric values.
-      return a != +a ? b != +b : a === 0 && b === 0 ? 1 / a == 1 / b : a == +b;
+      return a != +a ? b != +b : Number(a) === 0 && Number(b) === 0 ? 1 / a == 1 / b : a == +b;
     case '[object Date]':
     case '[object Boolean]':
       // Coerce dates and booleans to numeric primitive values. Dates are compared by their

--- a/packages/expect/src/jasmineUtils.ts
+++ b/packages/expect/src/jasmineUtils.ts
@@ -108,7 +108,7 @@ function eq(
     case '[object Number]':
       // `NaN`s are equivalent, but non-reflexive. An `egal` comparison is performed for
       // other numeric values.
-      return a != +a ? b != +b : a === 0 ? 1 / a == 1 / b : a == +b;
+      return a != +a ? b != +b : a === 0 && b === 0 ? 1 / a == 1 / b : a == +b;
     case '[object Date]':
     case '[object Boolean]':
       // Coerce dates and booleans to numeric primitive values. Dates are compared by their

--- a/packages/expect/src/jasmineUtils.ts
+++ b/packages/expect/src/jasmineUtils.ts
@@ -108,7 +108,7 @@ function eq(
     case '[object Number]':
       // `NaN`s are equivalent, but non-reflexive. An `egal` comparison is performed for
       // other numeric values.
-      return a != +a ? b != +b : Number(a) === 0 && Number(b) === 0 ? 1 / a == 1 / b : a == +b;
+      return Object.is(Number(a), Number(b));
     case '[object Date]':
     case '[object Boolean]':
       // Coerce dates and booleans to numeric primitive values. Dates are compared by their


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Fixes #7941: `toStrictEqual` fails to distinguish 0 from 5e-324

The real problem is that the `equal` operation defined into `jasmineUtils` is not symmetric.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Before that change, the following assertion was failing:

```js
expect(0).not.toStrictEqual(5e-324);
```

Now it passes as expected.
