### PR TITLE
fix jest-haste-map-types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 
 ### Chore & Maintenance
 
-- `[*]`: Setup building, linting and testing of TypeScript ([#7808](https://github.com/facebook/jest/pull/7808), [#7855](https://github.com/facebook/jest/pull/7855))
+- `[*]`: Setup building, linting and testing of TypeScript ([#7808](https://github.com/facebook/jest/pull/7808), [#7855](https://github.com/facebook/jest/pull/7855), [#7951](https://github.com/facebook/jest/pull/7951))
 - `[pretty-format]`: Migrate to TypeScript ([#7809](https://github.com/facebook/jest/pull/7809))
 - `[diff-sequences]`: Migrate to Typescript ([#7820](https://github.com/facebook/jest/pull/7820))
 - `[jest-get-type]`: Migrate to TypeScript ([#7818](https://github.com/facebook/jest/pull/7818))
@@ -38,7 +38,7 @@
 - `[jest-watcher]`: Migrate to TypeScript ([#7843](https://github.com/facebook/jest/pull/7843))
 - `[jest-mock]`: Migrate to TypeScript ([#7847](https://github.com/facebook/jest/pull/7847), [#7850](https://github.com/facebook/jest/pull/7850))
 - `[jest-worker]`: Migrate to TypeScript ([#7853](https://github.com/facebook/jest/pull/7853))
-- `[jest-haste-map]`: Migrate to TypeScript ([#7854](https://github.com/facebook/jest/pull/7854))
+- `[jest-haste-map]`: Migrate to TypeScript ([#7854](https://github.com/facebook/jest/pull/7854), [#7951](https://github.com/facebook/jest/pull/7951))
 - `[docs]`: Fix image paths in SnapshotTesting.md for current and version 24 ([#7872](https://github.com/facebook/jest/pull/7872))
 - `[babel-jest]`: Migrate to TypeScript ([#7862](https://github.com/facebook/jest/pull/7862))
 - `[jest-resolve]`: Migrate to TypeScript ([#7871](https://github.com/facebook/jest/pull/7871))

--- a/babel.config.js
+++ b/babel.config.js
@@ -9,6 +9,7 @@ module.exports = {
     },
     {
       plugins: [
+        'babel-plugin-typescript-strip-namespaces',
         require.resolve(
           './scripts/babel-plugin-jest-replace-ts-export-assignment.js'
         ),

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "ansi-styles": "^3.2.0",
     "babel-eslint": "^9.0.0",
     "babel-loader": "^8.0.5",
+    "babel-plugin-typescript-strip-namespaces": "^1.1.0",
     "camelcase": "^5.0.0",
     "chalk": "^2.0.1",
     "codecov": "^3.0.0",

--- a/packages/jest-haste-map/src/index.ts
+++ b/packages/jest-haste-map/src/index.ts
@@ -98,9 +98,11 @@ type Watcher = {
 
 type WorkerInterface = {worker: typeof worker; getSha1: typeof getSha1};
 
-export type ModuleMap = HasteModuleMap;
-export type SerializableModuleMap = HasteSerializableModuleMap;
-export type FS = HasteFS;
+namespace HasteMap {
+  export type ModuleMap = HasteModuleMap;
+  export type SerializableModuleMap = HasteSerializableModuleMap;
+  export type FS = HasteFS;
+}
 
 const CHANGE_INTERVAL = 30;
 const MAX_WAIT_TIME = 240000;
@@ -368,7 +370,7 @@ class HasteMap extends EventEmitter {
     return hasteMap;
   }
 
-  readModuleMap(): ModuleMap {
+  readModuleMap(): HasteModuleMap {
     const data = this.read();
     return new HasteModuleMap({
       duplicates: data.duplicates,
@@ -1079,4 +1081,4 @@ function copyMap<K, V>(input: Map<K, V>): Map<K, V> {
 HasteMap.H = H;
 HasteMap.ModuleMap = HasteModuleMap;
 
-module.exports = HasteMap;
+export = HasteMap;

--- a/packages/jest-haste-map/src/index.ts
+++ b/packages/jest-haste-map/src/index.ts
@@ -98,6 +98,7 @@ type Watcher = {
 
 type WorkerInterface = {worker: typeof worker; getSha1: typeof getSha1};
 
+// TODO: Ditch namespace when this module exports ESM
 namespace HasteMap {
   export type ModuleMap = HasteModuleMap;
   export type SerializableModuleMap = HasteSerializableModuleMap;

--- a/packages/jest-resolve-dependencies/src/__tests__/dependency_resolver.test.ts
+++ b/packages/jest-resolve-dependencies/src/__tests__/dependency_resolver.test.ts
@@ -33,10 +33,10 @@ beforeEach(() => {
     roots: ['./packages/jest-resolve-dependencies'],
   });
   return Runtime.createContext(config, {maxWorkers, watchman: false}).then(
-    (hasteMap: any) => {
+    (runtimeContext: any) => {
       dependencyResolver = new DependencyResolver(
-        hasteMap.resolver,
-        hasteMap.hasteFS,
+        runtimeContext.resolver,
+        runtimeContext.hasteFS,
         buildSnapshotResolver(config),
       );
     },

--- a/packages/jest-resolve/src/__tests__/resolve.test.ts
+++ b/packages/jest-resolve/src/__tests__/resolve.test.ts
@@ -8,16 +8,13 @@
 
 import fs from 'fs';
 import path from 'path';
-import HasteMap from 'jest-haste-map';
+import {ModuleMap} from 'jest-haste-map';
 import Resolver from '../';
 // @ts-ignore: js file
 import userResolver from '../__mocks__/userResolver';
 import nodeModulesPaths from '../nodeModulesPaths';
 import defaultResolver from '../defaultResolver';
 import {ResolverConfig} from '../types';
-
-// @ts-ignore: types are wrong. not sure how...
-const {ModuleMap} = HasteMap;
 
 jest.mock('../__mocks__/userResolver');
 

--- a/packages/jest-transform/src/ScriptTransformer.ts
+++ b/packages/jest-transform/src/ScriptTransformer.ts
@@ -110,7 +110,6 @@ export default class ScriptTransformer {
     content: string,
     instrument: boolean,
   ): Config.Path {
-    // @ts-ignore: not properly exported (needs ESM)
     const baseCacheDir = HasteMap.getCacheFilePath(
       this._config.cacheDirectory,
       'jest-transform-cache-' + this._config.name,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2610,6 +2610,11 @@ babel-plugin-syntax-trailing-function-commas@^7.0.0-beta.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-7.0.0-beta.0.tgz#aa213c1435e2bffeb6fca842287ef534ad05d5cf"
   integrity sha512-Xj9XuRuz3nTSbaTXWv3itLOcxyF4oPD8douBBmj7U9BBC6nEBYfyOJYQMf/8PJAFotC62UY5dFfIGEPr7WswzQ==
 
+babel-plugin-typescript-strip-namespaces@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-typescript-strip-namespaces/-/babel-plugin-typescript-strip-namespaces-1.1.0.tgz#7f8b022505bc742905801f9c41dd93f08f34ffc4"
+  integrity sha512-69kdF5HJoSIdgTVtHDor6XGJzVcxF5Hh92Rnh+rcitBZpj0pVU3Go0CrNJdPog6uoTcB90Ifk9O55FPZg0XN4w==
+
 babel-polyfill@6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.23.0.tgz#8364ca62df8eafb830499f699177466c3b03499d"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

`jest-haste-map` wants to do both `export = HasteMap` and multiple `export type SomeType`. Until we migrate it over to use a proper ESM default export, the way to do this in TypeScript is namespaces - see [this StackOverflow answer](https://stackoverflow.com/a/51238234). This fixes our `jest-haste-map/build/index.d.ts`:

<details>
<summary>Diff</summary>

```diff
diff --git a/tmp/old/index.d.ts b/tmp/new/index.d.ts
index ff4589f52..d2fe5bd75 100644
--- a/tmp/old/index.d.ts
+++ b/tmp/new/index.d.ts
@@ -4,9 +4,180 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+/// <reference types="node" />
+import EventEmitter from 'events';
+import { Config } from '@jest/types';
+import H from './constants';
 import HasteFS from './HasteFS';
 import HasteModuleMap, { SerializableModuleMap as HasteSerializableModuleMap } from './ModuleMap';
-export declare type ModuleMap = HasteModuleMap;
-export declare type SerializableModuleMap = HasteSerializableModuleMap;
-export declare type FS = HasteFS;
+import { HasteMap as HasteMapObject, HasteRegExp, InternalHasteMap, Mapper } from './types';
+declare type HType = typeof H;
+declare type Options = {
+    cacheDirectory?: string;
+    computeDependencies?: boolean;
+    computeSha1?: boolean;
+    console?: Console;
+    dependencyExtractor?: string;
+    extensions: Array<string>;
+    forceNodeFilesystemAPI?: boolean;
+    hasteImplModulePath?: string;
+    ignorePattern?: HasteRegExp;
+    mapper?: Mapper;
+    maxWorkers: number;
+    mocksPattern?: string;
+    name: string;
+    platforms: Array<string>;
+    providesModuleNodeModules?: Array<string>;
+    resetCache?: boolean;
+    retainAllFiles: boolean;
+    rootDir: string;
+    roots: Array<string>;
+    throwOnModuleCollision?: boolean;
+    useWatchman?: boolean;
+    watch?: boolean;
+};
+declare namespace HasteMap {
+    type ModuleMap = HasteModuleMap;
+    type SerializableModuleMap = HasteSerializableModuleMap;
+    type FS = HasteFS;
+}
+/**
+ * HasteMap is a JavaScript implementation of Facebook's haste module system.
+ *
+ * This implementation is inspired by https://github.com/facebook/node-haste
+ * and was built with for high-performance in large code repositories with
+ * hundreds of thousands of files. This implementation is scalable and provides
+ * predictable performance.
+ *
+ * Because the haste map creation and synchronization is critical to startup
+ * performance and most tasks are blocked by I/O this class makes heavy use of
+ * synchronous operations. It uses worker processes for parallelizing file
+ * access and metadata extraction.
+ *
+ * The data structures created by `jest-haste-map` can be used directly from the
+ * cache without further processing. The metadata objects in the `files` and
+ * `map` objects contain cross-references: a metadata object from one can look
+ * up the corresponding metadata object in the other map. Note that in most
+ * projects, the number of files will be greater than the number of haste
+ * modules one module can refer to many files based on platform extensions.
+ *
+ * type HasteMap = {
+ *   clocks: WatchmanClocks,
+ *   files: {[filepath: string]: FileMetaData},
+ *   map: {[id: string]: ModuleMapItem},
+ *   mocks: {[id: string]: string},
+ * }
+ *
+ * // Watchman clocks are used for query synchronization and file system deltas.
+ * type WatchmanClocks = {[filepath: string]: string};
+ *
+ * type FileMetaData = {
+ *   id: ?string, // used to look up module metadata objects in `map`.
+ *   mtime: number, // check for outdated files.
+ *   size: number, // size of the file in bytes.
+ *   visited: boolean, // whether the file has been parsed or not.
+ *   dependencies: Array<string>, // all relative dependencies of this file.
+ *   sha1: ?string, // SHA-1 of the file, if requested via options.
+ * };
+ *
+ * // Modules can be targeted to a specific platform based on the file name.
+ * // Example: platform.ios.js and Platform.android.js will both map to the same
+ * // `Platform` module. The platform should be specified during resolution.
+ * type ModuleMapItem = {[platform: string]: ModuleMetaData};
+ *
+ * //
+ * type ModuleMetaData = {
+ *   path: string, // the path to look up the file object in `files`.
+ *   type: string, // the module type (either `package` or `module`).
+ * };
+ *
+ * Note that the data structures described above are conceptual only. The actual
+ * implementation uses arrays and constant keys for metadata storage. Instead of
+ * `{id: 'flatMap', mtime: 3421, size: 42, visited: true, dependencies: []}` the real
+ * representation is similar to `['flatMap', 3421, 42, 1, []]` to save storage space
+ * and reduce parse and write time of a big JSON blob.
+ *
+ * The HasteMap is created as follows:
+ *  1. read data from the cache or create an empty structure.
+ *
+ *  2. crawl the file system.
+ *     * empty cache: crawl the entire file system.
+ *     * cache available:
+ *       * if watchman is available: get file system delta changes.
+ *       * if watchman is unavailable: crawl the entire file system.
+ *     * build metadata objects for every file. This builds the `files` part of
+ *       the `HasteMap`.
+ *
+ *  3. parse and extract metadata from changed files.
+ *     * this is done in parallel over worker processes to improve performance.
+ *     * the worst case is to parse all files.
+ *     * the best case is no file system access and retrieving all data from
+ *       the cache.
+ *     * the average case is a small number of changed files.
+ *
+ *  4. serialize the new `HasteMap` in a cache file.
+ *     Worker processes can directly access the cache through `HasteMap.read()`.
+ *
+ */
+declare class HasteMap extends EventEmitter {
+    private _buildPromise;
+    private _cachePath;
+    private _changeInterval?;
+    private _console;
+    private _options;
+    private _watchers;
+    private _whitelist;
+    private _worker;
+    constructor(options: Options);
+    static getCacheFilePath(tmpdir: Config.Path, name: string, ...extra: Array<string>): string;
+    getCacheFilePath(): string;
+    build(): Promise<HasteMapObject>;
+    /**
+     * 1. read data from the cache or create an empty structure.
+     */
+    read(): InternalHasteMap;
+    readModuleMap(): HasteModuleMap;
+    /**
+     * 2. crawl the file system.
+     */
+    private _buildFileMap;
+    /**
+     * 3. parse and extract metadata from changed files.
+     */
+    private _processFile;
+    private _buildHasteMap;
+    private _cleanup;
+    /**
+     * 4. serialize the new `HasteMap` in a cache file.
+     */
+    private _persist;
+    /**
+     * Creates workers or parses files and extracts metadata in-process.
+     */
+    private _getWorker;
+    private _crawl;
+    /**
+     * Watch mode
+     */
+    private _watch;
+    /**
+     * This function should be called when the file under `filePath` is removed
+     * or changed. When that happens, we want to figure out if that file was
+     * part of a group of files that had the same ID. If it was, we want to
+     * remove it from the group. Furthermore, if there is only one file
+     * remaining in the group, then we want to restore that single file as the
+     * correct resolution for its ID, and cleanup the duplicates index.
+     */
+    private _recoverDuplicates;
+    end(): Promise<void>;
+    /**
+     * Helpers
+     */
+    private _ignore;
+    private _isNodeModulesDir;
+    private _createEmptyMap;
+    static H: HType;
+    static ModuleMap: typeof HasteModuleMap;
+}
+export = HasteMap;
 //# sourceMappingURL=index.d.ts.map
\ No newline at end of file
```
</details>

---

`@babel/plugin-transform-typescript` does not support namespaces (because it's not possible to really support them), but we only want to put a few types in them, so I wrote a [Babel plugin](https://github.com/jeysal/babel-plugin-typescript-strip-namespaces) that strips them away in those simple cases. This way, `yarn build` works and `jest-haste-map/build/index.js` is unchanged.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Manual inspection of `jest-haste-map/build/index.{js,d.ts}`