### PR TITLE
fix(jest-changed-files): only return files from `getChangedFilesFromRoots`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - `[jest-circus]` Fix bug with test.only ([#7888](https://github.com/facebook/jest/pull/7888))
 - `[jest-transform]` Normalize config and remove unecessary checks, convert `TestUtils.js` to TypeScript ([#7801](https://github.com/facebook/jest/pull/7801))
 - `[jest-worker]` Fix `jest-worker` when using pre-allocated jobs ([#7934](https://github.com/facebook/jest/pull/7934))
+- `[jest-changed-files]` Fix `getChangedFilesFromRoots` to not return parts of the commit messages as if they were files, when the commit messages contained multiple paragraphs ([#7961](https://github.com/facebook/jest/pull/7961))
 
 ### Chore & Maintenance
 

--- a/e2e/__tests__/jestChangedFiles.test.js
+++ b/e2e/__tests__/jestChangedFiles.test.js
@@ -148,7 +148,11 @@ test('gets changed files for git', async () => {
   ).toEqual(['file1.txt', 'file2.txt', 'file3.txt']);
 
   run(`${GIT} add .`, DIR);
-  run(`${GIT} commit --no-gpg-sign -m "test"`, DIR);
+
+  // Uses multiple `-m` to make the commit message have multiple
+  // paragraphs. This is done to ensure that `changedFiles` only
+  // returns files and not parts of commit messages.
+  run(`${GIT} commit --no-gpg-sign -m "test" -m "extra-line"`, DIR);
 
   ({changedFiles: files} = await getChangedFilesForRoots(roots, {}));
   expect(Array.from(files)).toEqual([]);
@@ -266,8 +270,13 @@ test('gets changed files for hg', async () => {
     // skip this test and run it only locally.
     return;
   }
+
+  // file1.txt is used to make a multi-line commit message
+  // with `hg commit -l file1.txt`.
+  // This is done to ensure that `changedFiles` only returns files
+  // and not parts of commit messages.
   writeFiles(DIR, {
-    'file1.txt': 'file1',
+    'file1.txt': 'file1\n\nextra-line',
     'nested-dir/file2.txt': 'file2',
     'nested-dir/second-nested-dir/file3.txt': 'file3',
   });
@@ -286,7 +295,7 @@ test('gets changed files for hg', async () => {
   ).toEqual(['file1.txt', 'file2.txt', 'file3.txt']);
 
   run(`${HG} add .`, DIR);
-  run(`${HG} commit -m "test"`, DIR);
+  run(`${HG} commit -l file1.txt`, DIR);
 
   ({changedFiles: files} = await getChangedFilesForRoots(roots, {}));
   expect(Array.from(files)).toEqual([]);

--- a/packages/jest-changed-files/src/git.ts
+++ b/packages/jest-changed-files/src/git.ts
@@ -35,7 +35,9 @@ const adapter: SCMAdapter = {
 
     if (options && options.lastCommit) {
       return findChangedFilesUsingCommand(
-        ['show', '--name-only', '--pretty=%b', 'HEAD'].concat(includePaths),
+        ['show', '--name-only', '--pretty=format:', 'HEAD'].concat(
+          includePaths,
+        ),
         cwd,
       );
     } else if (changedSince) {
@@ -43,7 +45,7 @@ const adapter: SCMAdapter = {
         [
           'log',
           '--name-only',
-          '--pretty=%b',
+          '--pretty=format:',
           'HEAD',
           `^${changedSince}`,
         ].concat(includePaths),


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Fixes #7956.

Previously, `getChangedFilesFromRoots` would return parts of commit messages as if they were files, if the commit message contained multiple paragraphs of text.

## Test plan

I've updated the e2e tests in `jestChangedFiles.test.js` to include a commit message that includes multiple paragraphs (for both `hg` and `git`).

I decided on augmenting existing tests instead of making new ones to prevent an increase in running time.

In the case of `hg`, one of the files in the repository has had its contents changed to be on multiple lines, and one of the commits to be made with `hg commit -l filename`

It could have been done with `sh -c echo "line1\\nline2" | hg commit -l -"`, but that would have required a change of functionality in `Utils.js#run`, which I didn't feel like. 😄 

For `git`, the multiline commit message is made with multiple `-m` parameters, which puts the different messages in separate paragraphs.
