### PR TITLE
Migrate jest-phabricator to TypeScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 - `[jest-resolve-dependencies]`: Migrate to TypeScript ([#7922](https://github.com/facebook/jest/pull/7922))
 - `[expect]`: Migrate to TypeScript ([#7919](https://github.com/facebook/jest/pull/7919))
 - `[jest-circus]`: Migrate to TypeScript ([#7916](https://github.com/facebook/jest/pull/7916))
+- `[jest-phabricator]`: Migrate to TypeScript ([#7965](https://github.com/facebook/jest/pull/7965))
 
 ### Performance
 

--- a/packages/jest-phabricator/package.json
+++ b/packages/jest-phabricator/package.json
@@ -6,6 +6,10 @@
     "url": "https://github.com/facebook/jest.git",
     "directory": "packages/jest-phabricator"
   },
+  "types": "build/index.d.ts",
+  "dependencies": {
+    "@jest/types": "^24.1.0"
+  },
   "engines": {
     "node": ">= 6"
   },

--- a/packages/jest-phabricator/src/index.ts
+++ b/packages/jest-phabricator/src/index.ts
@@ -10,7 +10,7 @@ import {TestResult} from '@jest/types';
 function summarize(coverageMap: TestResult.CoverageMap) {
   const summaries = Object.create(null);
 
-  coverageMap.files().forEach((file: string) => {
+  coverageMap.files().forEach(file => {
     const covered = [];
     const lineCoverage = coverageMap.fileCoverageFor(file).getLineCoverage();
 

--- a/packages/jest-phabricator/src/index.ts
+++ b/packages/jest-phabricator/src/index.ts
@@ -3,23 +3,22 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- * @flow
  */
 
-import type {
+import {
   AggregatedResult,
   AggregatedResultWithoutCoverage,
   CoverageMap,
-} from 'types/TestResult';
+} from '@jest/types';
 
 type PhabricatorReport = AggregatedResultWithoutCoverage & {
-  coverageMap?: ?CoverageMap,
+  coverageMap?: CoverageMap | null;
 };
 
 function summarize(coverageMap: CoverageMap) {
   const summaries = Object.create(null);
 
-  coverageMap.files().forEach(file => {
+  coverageMap.files().forEach((file: string) => {
     const covered = [];
     const lineCoverage = coverageMap.fileCoverageFor(file).getLineCoverage();
 
@@ -42,7 +41,6 @@ function summarize(coverageMap: CoverageMap) {
 }
 
 module.exports = function(results: AggregatedResult): PhabricatorReport {
-  // $FlowFixMe: This should work, but it does not.
   return {
     ...results,
     coverageMap: results.coverageMap && summarize(results.coverageMap),

--- a/packages/jest-phabricator/src/index.ts
+++ b/packages/jest-phabricator/src/index.ts
@@ -7,18 +7,12 @@
 
 import {TestResult} from '@jest/types';
 
-type PhabricatorReport = TestResult.AggregatedResultWithoutCoverage & {
-  coverageMap?: TestResult.CoverageMap | null;
-};
-
 function summarize(coverageMap: TestResult.CoverageMap) {
   const summaries = Object.create(null);
 
   coverageMap.files().forEach((file: string) => {
     const covered = [];
-    const lineCoverage: any = coverageMap
-      .fileCoverageFor(file)
-      .getLineCoverage();
+    const lineCoverage = coverageMap.fileCoverageFor(file).getLineCoverage();
 
     Object.keys(lineCoverage).forEach(lineNumber => {
       // Line numbers start at one
@@ -40,7 +34,7 @@ function summarize(coverageMap: TestResult.CoverageMap) {
 
 module.exports = function(
   results: TestResult.AggregatedResult,
-): PhabricatorReport {
+): TestResult.AggregatedResult {
   return {
     ...results,
     coverageMap: results.coverageMap && summarize(results.coverageMap),

--- a/packages/jest-phabricator/src/index.ts
+++ b/packages/jest-phabricator/src/index.ts
@@ -5,22 +5,20 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {
-  AggregatedResult,
-  AggregatedResultWithoutCoverage,
-  CoverageMap,
-} from '@jest/types';
+import {TestResult} from '@jest/types';
 
-type PhabricatorReport = AggregatedResultWithoutCoverage & {
-  coverageMap?: CoverageMap | null;
+type PhabricatorReport = TestResult.AggregatedResultWithoutCoverage & {
+  coverageMap?: TestResult.CoverageMap | null;
 };
 
-function summarize(coverageMap: CoverageMap) {
+function summarize(coverageMap: TestResult.CoverageMap) {
   const summaries = Object.create(null);
 
   coverageMap.files().forEach((file: string) => {
     const covered = [];
-    const lineCoverage = coverageMap.fileCoverageFor(file).getLineCoverage();
+    const lineCoverage: any = coverageMap
+      .fileCoverageFor(file)
+      .getLineCoverage();
 
     Object.keys(lineCoverage).forEach(lineNumber => {
       // Line numbers start at one
@@ -40,7 +38,9 @@ function summarize(coverageMap: CoverageMap) {
   return summaries;
 }
 
-module.exports = function(results: AggregatedResult): PhabricatorReport {
+module.exports = function(
+  results: TestResult.AggregatedResult,
+): PhabricatorReport {
   return {
     ...results,
     coverageMap: results.coverageMap && summarize(results.coverageMap),

--- a/packages/jest-phabricator/tsconfig.json
+++ b/packages/jest-phabricator/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "build"
+  },
+  "references": [
+    {
+      "path": "../jest-types"
+    }
+  ]
+}

--- a/packages/jest-types/src/TestResult.ts
+++ b/packages/jest-types/src/TestResult.ts
@@ -52,10 +52,10 @@ export type CoverageSummary = {
 };
 
 export type FileCoverage = {
-  getLineCoverage: () => Object;
+  getLineCoverage: () => {[line: string]: string};
   getUncoveredLines: () => Array<number>;
-  getBranchCoverageByLine: () => Object;
-  toJSON: () => Object;
+  getBranchCoverageByLine: () => {[line: string]: string};
+  toJSON: () => {[line: string]: string};
   merge: (other: Object) => undefined;
   computeSimpleTotals: (property: string) => FileCoverageTotal;
   computeBranchTotals: () => FileCoverageTotal;


### PR DESCRIPTION

## Summary


<details>
  <summary>Diff</summary>

```diff
diff --git a/packages/jest-phabricator/build/index.js b/packages/jest-phabricator/build/index.js
index a55e39432..5874e38b8 100644
--- a/packages/jest-phabricator/build/index.js
+++ b/packages/jest-phabricator/build/index.js
@@ -37,7 +37,6 @@ function _defineProperty(obj, key, value) {
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
  */
 function summarize(coverageMap) {
   const summaries = Object.create(null);
@@ -62,7 +61,6 @@ function summarize(coverageMap) {
 }
 
 module.exports = function(results) {
-  // $FlowFixMe: This should work, but it does not.
   return _objectSpread({}, results, {
     coverageMap: results.coverageMap && summarize(results.coverageMap)
   });

```

</details>

## Test plan

💚 build;
