### PR TITLE
use typescript-eslint array-type rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,6 +20,7 @@ module.exports = {
       parser: '@typescript-eslint/parser',
       plugins: ['@typescript-eslint/eslint-plugin'],
       rules: {
+        '@typescript-eslint/array-type': ['error', 'generic'],
         '@typescript-eslint/no-unused-vars': [
           'error',
           {argsIgnorePattern: '^_'},

--- a/packages/expect/src/spyMatchers.ts
+++ b/packages/expect/src/spyMatchers.ts
@@ -488,7 +488,7 @@ const ensureMock = (mockOrSpy: any, matcherName: any) => {
 };
 
 const getPrintedCalls = (
-  calls: any[],
+  calls: Array<any>,
   limit: number,
   sep: string,
   fn: Function,
@@ -503,7 +503,7 @@ const getPrintedCalls = (
   return result.join(sep);
 };
 
-const getPrintedReturnValues = (calls: any[], limit: number): string => {
+const getPrintedReturnValues = (calls: Array<any>, limit: number): string => {
   const result = [];
 
   for (let i = 0; i < calls.length && i < limit; i += 1) {

--- a/packages/jest-changed-files/src/index.ts
+++ b/packages/jest-changed-files/src/index.ts
@@ -27,7 +27,7 @@ const findGitRoot = (dir: string) => mutex(() => git.getRoot(dir));
 const findHgRoot = (dir: string) => mutex(() => hg.getRoot(dir));
 
 export const getChangedFilesForRoots = async (
-  roots: Config.Path[],
+  roots: Array<Config.Path>,
   options: Options,
 ): ChangedFilesPromise => {
   const repos = await findRepos(roots);
@@ -55,15 +55,15 @@ export const getChangedFilesForRoots = async (
   return {changedFiles, repos};
 };
 
-export const findRepos = async (roots: Config.Path[]): Promise<Repos> => {
+export const findRepos = async (roots: Array<Config.Path>): Promise<Repos> => {
   const gitRepos = await Promise.all(
-    roots.reduce<RootPromise[]>(
+    roots.reduce<Array<RootPromise>>(
       (promises, root) => promises.concat(findGitRoot(root)),
       [],
     ),
   );
   const hgRepos = await Promise.all(
-    roots.reduce<RootPromise[]>(
+    roots.reduce<Array<RootPromise>>(
       (promises, root) => promises.concat(findHgRoot(root)),
       [],
     ),

--- a/packages/jest-config/src/normalize.ts
+++ b/packages/jest-config/src/normalize.ts
@@ -173,7 +173,7 @@ const normalizeCollectCoverageOnlyFrom = (
   key: keyof Pick<Config.InitialOptions, 'collectCoverageOnlyFrom'>,
 ) => {
   const initialCollectCoverageFrom = options[key];
-  const collectCoverageOnlyFrom: Config.Glob[] = Array.isArray(
+  const collectCoverageOnlyFrom: Array<Config.Glob> = Array.isArray(
     initialCollectCoverageFrom,
   )
     ? initialCollectCoverageFrom // passed from argv
@@ -194,7 +194,7 @@ const normalizeCollectCoverageFrom = (
   key: keyof Pick<Config.InitialOptions, 'collectCoverageFrom'>,
 ) => {
   const initialCollectCoverageFrom = options[key];
-  let value: Config.Glob[] | undefined;
+  let value: Array<Config.Glob> | undefined;
   if (!initialCollectCoverageFrom) {
     value = [];
   }

--- a/packages/jest-diff/src/diffStrings.ts
+++ b/packages/jest-diff/src/diffStrings.ts
@@ -128,7 +128,7 @@ const diffExpand = (
   const isCommon: Callbacks['isCommon'] = (aIndex, bIndex) =>
     aLinesUn[aIndex] === bLinesUn[bIndex];
 
-  const array: string[] = [];
+  const array: Array<string> = [];
   const put = (line: string) => {
     array.push(line);
   };

--- a/packages/jest-docblock/src/index.ts
+++ b/packages/jest-docblock/src/index.ts
@@ -8,7 +8,7 @@
 import {EOL} from 'os';
 import detectNewline from 'detect-newline';
 
-type Pragmas = {[key: string]: string | string[]};
+type Pragmas = {[key: string]: string | Array<string>};
 
 const commentEndRe = /\*\/$/;
 const commentStartRe = /^\/\*\*/;
@@ -65,7 +65,10 @@ export function parseWithComments(
       typeof result[match[1]] === 'string' ||
       Array.isArray(result[match[1]])
     ) {
-      result[match[1]] = ([] as string[]).concat(result[match[1]], nextPragma);
+      result[match[1]] = ([] as Array<string>).concat(
+        result[match[1]],
+        nextPragma,
+      );
     } else {
       result[match[1]] = nextPragma;
     }
@@ -119,8 +122,8 @@ export function print({
   );
 }
 
-function printKeyValues(key: string, valueOrArray: string | string[]) {
-  return ([] as string[])
+function printKeyValues(key: string, valueOrArray: string | Array<string>) {
+  return ([] as Array<string>)
     .concat(valueOrArray)
     .map(value => `@${key} ${value}`.trim());
 }

--- a/packages/jest-message-util/src/index.ts
+++ b/packages/jest-message-util/src/index.ts
@@ -26,7 +26,7 @@ const stackUtils = new StackUtils({
   cwd: 'something which does not exist',
 });
 
-let nodeInternals: RegExp[] = [];
+let nodeInternals: Array<RegExp> = [];
 
 try {
   nodeInternals = StackUtils.nodeInternals();
@@ -151,9 +151,9 @@ export const formatExecError = (
 };
 
 const removeInternalStackEntries = (
-  lines: string[],
+  lines: Array<string>,
   options: StackTraceOptions,
-): string[] => {
+): Array<string> => {
   let pathCounter = 0;
 
   return lines.filter(line => {
@@ -230,7 +230,7 @@ export const getStackTraceLines = (
   options: StackTraceOptions = {noStackTrace: false},
 ) => removeInternalStackEntries(stack.split(/\n/), options);
 
-export const getTopFrame = (lines: string[]): Frame | null => {
+export const getTopFrame = (lines: Array<string>): Frame | null => {
   for (const line of lines) {
     if (line.includes(PATH_NODE_MODULES) || line.includes(PATH_JEST_PACKAGES)) {
       continue;

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -21,7 +21,7 @@ namespace JestMock {
 
   export type MockFunctionMetadata<
     T,
-    Y extends unknown[],
+    Y extends Array<unknown>,
     Type = MockFunctionMetadataType
   > = {
     ref?: number;
@@ -60,7 +60,7 @@ type MockFunctionResult = {
   value: unknown;
 };
 
-type MockFunctionState<T, Y extends unknown[]> = {
+type MockFunctionState<T, Y extends Array<unknown>> = {
   calls: Array<Y>;
   instances: Array<T>;
   invocationCallOrder: Array<number>;
@@ -81,24 +81,24 @@ type MockFunctionConfig = {
 
 // see https://github.com/Microsoft/TypeScript/issues/25215
 type NonFunctionPropertyNames<T> = {
-  [K in keyof T]: T[K] extends (...args: any[]) => any ? never : K
+  [K in keyof T]: T[K] extends (...args: Array<any>) => any ? never : K
 }[keyof T] &
   string;
 type FunctionPropertyNames<T> = {
-  [K in keyof T]: T[K] extends (...args: any[]) => any ? K : never
+  [K in keyof T]: T[K] extends (...args: Array<any>) => any ? K : never
 }[keyof T] &
   string;
 
-interface Mock<T, Y extends unknown[] = unknown[]>
+interface Mock<T, Y extends Array<unknown> = Array<unknown>>
   extends Function,
     MockInstance<T, Y> {
   new (...args: Y): T;
   (...args: Y): T;
 }
 
-interface SpyInstance<T, Y extends unknown[]> extends MockInstance<T, Y> {}
+interface SpyInstance<T, Y extends Array<unknown>> extends MockInstance<T, Y> {}
 
-interface MockInstance<T, Y extends unknown[]> {
+interface MockInstance<T, Y extends Array<unknown>> {
   _isMockFunction: true;
   _protoImpl: Function;
   getMockName(): string;
@@ -432,7 +432,7 @@ class ModuleMockerClass {
     return Array.from(slots);
   }
 
-  private _ensureMockConfig<T, Y extends unknown[]>(
+  private _ensureMockConfig<T, Y extends Array<unknown>>(
     f: Mock<T, Y>,
   ): MockFunctionConfig {
     let config = this._mockConfigRegistry.get(f);
@@ -443,7 +443,7 @@ class ModuleMockerClass {
     return config;
   }
 
-  private _ensureMockState<T, Y extends unknown[]>(
+  private _ensureMockState<T, Y extends Array<unknown>>(
     f: Mock<T, Y>,
   ): MockFunctionState<T, Y> {
     let state = this._mockState.get(f);
@@ -465,7 +465,10 @@ class ModuleMockerClass {
     };
   }
 
-  private _defaultMockState<T, Y extends unknown[]>(): MockFunctionState<T, Y> {
+  private _defaultMockState<T, Y extends Array<unknown>>(): MockFunctionState<
+    T,
+    Y
+  > {
     return {
       calls: [],
       instances: [],
@@ -474,19 +477,19 @@ class ModuleMockerClass {
     };
   }
 
-  private _makeComponent<T, Y extends unknown[]>(
+  private _makeComponent<T, Y extends Array<unknown>>(
     metadata: JestMock.MockFunctionMetadata<T, Y, 'object'>,
     restore?: () => void,
   ): Object;
-  private _makeComponent<T, Y extends unknown[]>(
+  private _makeComponent<T, Y extends Array<unknown>>(
     metadata: JestMock.MockFunctionMetadata<T, Y, 'array'>,
     restore?: () => void,
   ): Array<unknown>;
-  private _makeComponent<T, Y extends unknown[]>(
+  private _makeComponent<T, Y extends Array<unknown>>(
     metadata: JestMock.MockFunctionMetadata<T, Y, 'regexp'>,
     restore?: () => void,
   ): RegExp;
-  private _makeComponent<T, Y extends unknown[]>(
+  private _makeComponent<T, Y extends Array<unknown>>(
     metadata: JestMock.MockFunctionMetadata<
       T,
       Y,
@@ -494,11 +497,11 @@ class ModuleMockerClass {
     >,
     restore?: () => void,
   ): T;
-  private _makeComponent<T, Y extends unknown[]>(
+  private _makeComponent<T, Y extends Array<unknown>>(
     metadata: JestMock.MockFunctionMetadata<T, Y, 'function'>,
     restore?: () => void,
   ): Mock<T, Y>;
-  private _makeComponent<T, Y extends unknown[]>(
+  private _makeComponent<T, Y extends Array<unknown>>(
     metadata: JestMock.MockFunctionMetadata<T, Y>,
     restore?: () => void,
   ): Object | Array<unknown> | RegExp | T | undefined | Mock<T, Y> {
@@ -744,7 +747,7 @@ class ModuleMockerClass {
     }
   }
 
-  private _createMockFunction<T, Y extends unknown[]>(
+  private _createMockFunction<T, Y extends Array<unknown>>(
     metadata: JestMock.MockFunctionMetadata<T, Y>,
     mockConstructor: Function,
   ): Function {
@@ -804,7 +807,7 @@ class ModuleMockerClass {
     return createConstructor(mockConstructor);
   }
 
-  private _generateMock<T, Y extends unknown[]>(
+  private _generateMock<T, Y extends Array<unknown>>(
     metadata: JestMock.MockFunctionMetadata<T, Y>,
     callbacks: Array<Function>,
     refs: {
@@ -854,10 +857,10 @@ class ModuleMockerClass {
    * @param _metadata Metadata for the mock in the schema returned by the
    * getMetadata method of this module.
    */
-  generateFromMetadata<T, Y extends unknown[]>(
+  generateFromMetadata<T, Y extends Array<unknown>>(
     _metadata: JestMock.MockFunctionMetadata<T, Y>,
   ): Mock<T, Y> {
-    const callbacks: Function[] = [];
+    const callbacks: Array<Function> = [];
     const refs = {};
     const mock = this._generateMock(_metadata, callbacks, refs);
     callbacks.forEach(setter => setter());
@@ -868,7 +871,7 @@ class ModuleMockerClass {
    * @see README.md
    * @param component The component for which to retrieve metadata.
    */
-  getMetadata<T, Y extends unknown[]>(
+  getMetadata<T, Y extends Array<unknown>>(
     component: T,
     _refs?: Map<T, number>,
   ): JestMock.MockFunctionMetadata<T, Y> | null {
@@ -941,7 +944,9 @@ class ModuleMockerClass {
     return !!fn && fn._isMockFunction === true;
   }
 
-  fn<T, Y extends unknown[]>(implementation?: (...args: Y) => T): Mock<T, Y> {
+  fn<T, Y extends Array<unknown>>(
+    implementation?: (...args: Y) => T,
+  ): Mock<T, Y> {
     const length = implementation ? implementation.length : 0;
     const fn = this._makeComponent<T, Y>({length, type: 'function'});
     if (implementation) {
@@ -965,7 +970,7 @@ class ModuleMockerClass {
   spyOn<T extends {}, M extends FunctionPropertyNames<T>>(
     object: T,
     methodName: M,
-  ): T[M] extends (...args: any[]) => any
+  ): T[M] extends (...args: Array<any>) => any
     ? SpyInstance<ReturnType<T[M]>, Parameters<T[M]>>
     : never;
 

--- a/packages/jest-resolve-dependencies/src/index.ts
+++ b/packages/jest-resolve-dependencies/src/index.ts
@@ -13,7 +13,7 @@ import {isSnapshotPath, SnapshotResolver} from 'jest-snapshot';
 namespace DependencyResolver {
   export type ResolvedModule = {
     file: Config.Path;
-    dependencies: Config.Path[];
+    dependencies: Array<Config.Path>;
   };
 }
 

--- a/packages/jest-resolve/src/index.ts
+++ b/packages/jest-resolve/src/index.ts
@@ -30,7 +30,7 @@ type BooleanObject = {[key: string]: boolean};
 namespace Resolver {
   export type ResolveModuleConfig = {
     skipNodeResolution?: boolean;
-    paths?: Config.Path[];
+    paths?: Array<Config.Path>;
   };
 }
 

--- a/packages/jest-resolve/src/nodeModulesPaths.ts
+++ b/packages/jest-resolve/src/nodeModulesPaths.ts
@@ -19,7 +19,7 @@ type NodeModulesPathsOptions = {
 export default function nodeModulesPaths(
   basedir: Config.Path,
   options: NodeModulesPathsOptions,
-): Config.Path[] {
+): Array<Config.Path> {
   const modules =
     options && options.moduleDirectory
       ? Array.from(options.moduleDirectory)

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -85,7 +85,7 @@ class Runtime {
   private _isCurrentlyExecutingManualMock: string | null;
   private _mockFactories: {[key: string]: () => unknown};
   private _mockMetaDataCache: {
-    [key: string]: MockFunctionMetadata<unknown, unknown[]>;
+    [key: string]: MockFunctionMetadata<unknown, Array<unknown>>;
   };
   private _mockRegistry: {[key: string]: any};
   private _isolatedMockRegistry: {[key: string]: any} | null;

--- a/packages/jest-snapshot/src/__tests__/plugins.test.ts
+++ b/packages/jest-snapshot/src/__tests__/plugins.test.ts
@@ -7,7 +7,7 @@
 
 beforeEach(() => jest.resetModules());
 
-const testPath = (names: string[]) => {
+const testPath = (names: Array<string>) => {
   const {addSerializer, getSerializers} = require('../plugins');
   const prev = getSerializers();
   const added = names.map(name =>

--- a/packages/jest-snapshot/src/inline_snapshots.ts
+++ b/packages/jest-snapshot/src/inline_snapshots.ts
@@ -25,7 +25,7 @@ export type InlineSnapshot = {
 };
 
 export const saveInlineSnapshots = (
-  snapshots: InlineSnapshot[],
+  snapshots: Array<InlineSnapshot>,
   prettier: any,
   babelTraverse: Function,
 ) => {
@@ -93,7 +93,7 @@ const saveSnapshotsForFile = (
 const groupSnapshotsBy = (
   createKey: (inlineSnapshot: InlineSnapshot) => string,
 ) => (snapshots: Array<InlineSnapshot>) =>
-  snapshots.reduce<{[key: string]: InlineSnapshot[]}>(
+  snapshots.reduce<{[key: string]: Array<InlineSnapshot>}>(
     (object, inlineSnapshot) => {
       const key = createKey(inlineSnapshot);
       return {...object, [key]: (object[key] || []).concat(inlineSnapshot)};
@@ -109,7 +109,7 @@ const groupSnapshotsByFrame = groupSnapshotsBy(({frame: {line, column}}) =>
 const groupSnapshotsByFile = groupSnapshotsBy(({frame: {file}}) => file);
 
 const createParser = (
-  snapshots: InlineSnapshot[],
+  snapshots: Array<InlineSnapshot>,
   inferredParser: string,
   babelTraverse: Function,
 ) => (

--- a/packages/jest-snapshot/src/snapshot_resolver.ts
+++ b/packages/jest-snapshot/src/snapshot_resolver.ts
@@ -68,7 +68,7 @@ function createCustomSnapshotResolver(
 ): SnapshotResolver {
   const custom: SnapshotResolver = require(snapshotResolverPath);
 
-  const keys: [keyof SnapshotResolver, string][] = [
+  const keys: Array<[keyof SnapshotResolver, string]> = [
     ['resolveSnapshotPath', 'function'],
     ['resolveTestPath', 'function'],
     ['testPathForConsistencyCheck', 'string'],

--- a/packages/jest-validate/src/validateCLIOptions.ts
+++ b/packages/jest-validate/src/validateCLIOptions.ts
@@ -66,7 +66,7 @@ export default function validateCLIOptions(
     [s: string]: {alias?: string};
     deprecationEntries: DeprecatedOptions;
   },
-  rawArgv: string[] = [],
+  rawArgv: Array<string> = [],
 ) {
   const yargsSpecialOptions = ['$0', '_', 'help', 'h'];
   const deprecationEntries = options.deprecationEntries || {};

--- a/packages/pretty-format/src/__tests__/AsymmetricMatcher.test.ts
+++ b/packages/pretty-format/src/__tests__/AsymmetricMatcher.test.ts
@@ -12,7 +12,7 @@ import prettyFormat from '../';
 const {AsymmetricMatcher} = prettyFormat.plugins;
 let options: OptionsReceived;
 
-function fnNameFor(func: (...any: any[]) => any) {
+function fnNameFor(func: (...any: Array<any>) => any) {
   if (func.name) {
     return func.name;
   }

--- a/packages/pretty-format/src/__tests__/prettyFormat.test.ts
+++ b/packages/pretty-format/src/__tests__/prettyFormat.test.ts
@@ -30,7 +30,7 @@ describe('prettyFormat()', () => {
   });
 
   it('prints an empty array', () => {
-    const val: never[] = [];
+    const val: Array<never> = [];
     expect(prettyFormat(val)).toEqual('Array []');
   });
 

--- a/packages/pretty-format/src/index.ts
+++ b/packages/pretty-format/src/index.ts
@@ -33,7 +33,7 @@ const symbolToString = Symbol.prototype.toString;
  * Explicitly comparing typeof constructor to function avoids undefined as name
  * when mock identity-obj-proxy returns the key as the value for any key.
  */
-const getConstructorName = (val: new (...args: any[]) => any) =>
+const getConstructorName = (val: new (...args: Array<any>) => any) =>
   (typeof val.constructor === 'function' && val.constructor.name) || 'Object';
 
 /* global window */

--- a/packages/pretty-format/src/plugins/ReactElement.ts
+++ b/packages/pretty-format/src/plugins/ReactElement.ts
@@ -23,7 +23,7 @@ const memoSymbol = Symbol.for('react.memo');
 
 // Given element.props.children, or subtree during recursive traversal,
 // return flattened array of children.
-const getChildren = (arg: any[], children = []) => {
+const getChildren = (arg: Array<any>, children = []) => {
   if (Array.isArray(arg)) {
     arg.forEach(item => {
       getChildren(item, children);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

The TypeScript sources currently use `Array<T>` and `T[]` inconsistently.
This makes it harder to grep for e.g. `Array<Test>` or `Test[]` because you might miss some of them that use the other syntax.
It might also confuse TS beginners who wonder what the difference between the two might be.
`eslint-typescript` has the `array-type` rule to enforce one syntax or the other (or alternatively `[]` for simple types and `Array` for complex ones).
I've set it to `'array'` (`[]`) and run the auto fixer, but I'd be open to discussion / links to convince me why another option would be better ;)
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
