### PR TITLE
(docs) Add missing numTodoTests in Result Object.

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -937,11 +937,11 @@ This option allows the use of a custom results processor. This processor must be
   "numPassedTestSuites": number,
   "numFailedTestSuites": number,
   "numRuntimeErrorTestSuites": number,
-  "numTodoTests": number,
   "numTotalTests": number,
   "numPassedTests": number,
   "numFailedTests": number,
   "numPendingTests": number,
+  "numTodoTests": number,
   "openHandles": Array<Error>,
   "testResults": [{
     "numFailingTests": number,

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -937,6 +937,7 @@ This option allows the use of a custom results processor. This processor must be
   "numPassedTestSuites": number,
   "numFailedTestSuites": number,
   "numRuntimeErrorTestSuites": number,
+  "numTodoTests": number,
   "numTotalTests": number,
   "numPassedTests": number,
   "numFailedTests": number,

--- a/website/versioned_docs/version-24.0/Configuration.md
+++ b/website/versioned_docs/version-24.0/Configuration.md
@@ -936,6 +936,7 @@ This option allows the use of a custom results processor. This processor must be
   "numPassedTests": number,
   "numFailedTests": number,
   "numPendingTests": number,
+  "numTodoTests": number,
   "openHandles": Array<Error>,
   "testResults": [{
     "numFailingTests": number,

--- a/website/versioned_docs/version-24.1/Configuration.md
+++ b/website/versioned_docs/version-24.1/Configuration.md
@@ -942,6 +942,7 @@ This option allows the use of a custom results processor. This processor must be
   "numPassedTests": number,
   "numFailedTests": number,
   "numPendingTests": number,
+  "numTodoTests": number,
   "openHandles": Array<Error>,
   "testResults": [{
     "numFailingTests": number,


### PR DESCRIPTION
Reference: https://github.com/facebook/jest/blob/master/types/TestResult.js#L128

## Summary

This PR simply updates the documentation for `testResultsProcessor`. https://jestjs.io/docs/en/configuration#testresultsprocessor-string

## Test plan
Run `jest` with `--json`. The JSON output will contain a numeric `numTodoTests` property.