### PR TITLE
Improve instructions for enabling typescript support

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -164,14 +164,7 @@ Then add `@babel/preset-typescript` to the list of presets in your `babel.config
 // babel.config.js
 module.exports = {
   presets: [
-    [
-      '@babel/preset-env',
-      {
-        targets: {
-          node: 'current',
-        },
-      },
-    ],
+    ['@babel/preset-env', {targets: {node: 'current'}}],
     '@babel/preset-typescript',
   ],
 };

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -151,8 +151,7 @@ Jest can be used in projects that use [webpack](https://webpack.github.io/) to m
 
 ### Using TypeScript
 
-Jest supports TypeScript, via Babel. First make sure you followed the instructions on [using Babel](#using-babel) above.
-Next install the `@babel/preset-typescript` via `yarn`:
+Jest supports TypeScript, via Babel. First make sure you followed the instructions on [using Babel](#using-babel) above. Next install the `@babel/preset-typescript` via `yarn`:
 
 ```bash
 yarn add --dev @babel/preset-typescript

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -151,6 +151,30 @@ Jest can be used in projects that use [webpack](https://webpack.github.io/) to m
 
 ### Using TypeScript
 
-Jest supports TypeScript out of the box, via Babel.
+Jest supports TypeScript, via Babel. First make sure you followed the instructions on [using Babel](#using-babel) above.
+Next install the `@babel/preset-typescript` via `yarn`:
 
-However, there are some caveats to using Typescript with Babel, see http://artsy.github.io/blog/2017/11/27/Babel-7-and-TypeScript/. Another caveat is that Jest will not typecheck your tests. If you want that, you can use [ts-jest](https://github.com/kulshekhar/ts-jest).
+```bash
+yarn add --dev @babel/preset-typescript
+```
+
+Then add `@babel/preset-typescript` to the list of presets in your `babel.config.js`.
+
+```javascript
+// babel.config.js
+module.exports = {
+  presets: [
+    [
+      '@babel/preset-env',
+      {
+        targets: {
+          node: 'current',
+        },
+      },
+    ],
+    '@babel/preset-typescript',
+  ],
+};
+```
+
+Note that there are some caveats to using Typescript with Babel, see http://artsy.github.io/blog/2017/11/27/Babel-7-and-TypeScript/. Another caveat is that Jest will not typecheck your tests. If you want that, you can use [ts-jest](https://github.com/kulshekhar/ts-jest).

--- a/website/versioned_docs/version-24.0/GettingStarted.md
+++ b/website/versioned_docs/version-24.0/GettingStarted.md
@@ -152,8 +152,7 @@ Jest can be used in projects that use [webpack](https://webpack.github.io/) to m
 
 ### Using TypeScript
 
-Jest supports TypeScript, via Babel. First make sure you followed the instructions on [using Babel](#using-babel) above.
-Next install the `@babel/preset-typescript` via `yarn`:
+Jest supports TypeScript, via Babel. First make sure you followed the instructions on [using Babel](#using-babel) above. Next install the `@babel/preset-typescript` via `yarn`:
 
 ```bash
 yarn add --dev @babel/preset-typescript

--- a/website/versioned_docs/version-24.0/GettingStarted.md
+++ b/website/versioned_docs/version-24.0/GettingStarted.md
@@ -152,6 +152,23 @@ Jest can be used in projects that use [webpack](https://webpack.github.io/) to m
 
 ### Using TypeScript
 
-Jest supports TypeScript out of the box, via Babel.
+Jest supports TypeScript, via Babel. First make sure you followed the instructions on [using Babel](#using-babel) above.
+Next install the `@babel/preset-typescript` via `yarn`:
 
-However, there are some caveats to using Typescript with Babel, see http://artsy.github.io/blog/2017/11/27/Babel-7-and-TypeScript/. Another caveat is that Jest will not typecheck your tests. If you want that, you can use [ts-jest](https://github.com/kulshekhar/ts-jest).
+```bash
+yarn add --dev @babel/preset-typescript
+```
+
+Then add `@babel/preset-typescript` to the list of presets in your `babel.config.js`.
+
+```javascript
+// babel.config.js
+module.exports = {
+  presets: [
+    ['@babel/preset-env', {targets: {node: 'current'}}],
+    '@babel/preset-typescript',
+  ],
+};
+```
+
+Note that there are some caveats to using Typescript with Babel, see http://artsy.github.io/blog/2017/11/27/Babel-7-and-TypeScript/. Another caveat is that Jest will not typecheck your tests. If you want that, you can use [ts-jest](https://github.com/kulshekhar/ts-jest).


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

The instructions said that support for typescript was included "out of the box" but failed to mention that it is necessary to install and configure `@babel/preset-typescript`.

## Test plan

N/A