### PR TITLE
[WIP] Migrate jest-repl to typescript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
 - `[jest-runner]`: Migrate to TypeScript ([#7968](https://github.com/facebook/jest/pull/7968))
 - `[jest-runtime]`: Migrate to TypeScript ([#7964](https://github.com/facebook/jest/pull/7964), [#7988](https://github.com/facebook/jest/pull/7988))
 - `[@jest/fake-timers]`: Extract FakeTimers class from `jest-util` into a new separate package ([#7987](https://github.com/facebook/jest/pull/7987))
+- `[jest-repl]`: Migrate to TypeScript ([#8000](https://github.com/facebook/jest/pull/8000))
 
 ### Performance
 

--- a/packages/jest-repl/package.json
+++ b/packages/jest-repl/package.json
@@ -11,7 +11,7 @@
   "types": "build/index.d.ts",
   "dependencies": {
     "@jest/transform": "^24.1.0",
-    "@types/jest": "^24.0.9",
+    "@jest/types": "^24.1.0",
     "jest-config": "^24.1.0",
     "jest-runtime": "^24.1.0",
     "jest-validate": "^24.0.0",

--- a/packages/jest-repl/package.json
+++ b/packages/jest-repl/package.json
@@ -8,7 +8,10 @@
   },
   "license": "MIT",
   "main": "build/index.js",
+  "types": "build/index.d.ts",
   "dependencies": {
+    "@jest/transform": "^24.1.0",
+    "@types/jest": "^24.0.9",
     "jest-config": "^24.1.0",
     "jest-runtime": "^24.1.0",
     "jest-validate": "^24.0.0",

--- a/packages/jest-repl/src/cli/args.ts
+++ b/packages/jest-repl/src/cli/args.ts
@@ -4,15 +4,13 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow
  */
 
 import Runtime from 'jest-runtime';
 
 export const usage = 'Usage: $0 [--config=<pathToConfigFile>]';
 
-export const options = {
-  ...Runtime.getCLIOptions(),
+export const options = Object.assign({}, Runtime.getCLIOptions(), {
   replname: {
     alias: 'r',
     description:
@@ -20,4 +18,4 @@ export const options = {
       'transformed. For example, "repl.ts" if using a TypeScript transformer.',
     type: 'string',
   },
-};
+});

--- a/packages/jest-repl/src/cli/index.ts
+++ b/packages/jest-repl/src/cli/index.ts
@@ -7,8 +7,6 @@
  *
  */
 
-import path from 'path';
-
 import Runtime from 'jest-runtime';
 import yargs from 'yargs';
 // @ts-ignore: Wait for jest-validate to get migrated
@@ -16,9 +14,9 @@ import {validateCLIOptions} from 'jest-validate';
 import {deprecationEntries} from 'jest-config';
 import * as args from './args';
 
-const {version: VERSION} = require("../../package.json");
+const {version: VERSION} = require('../../package.json');
 
-const REPL_SCRIPT = path.resolve(__dirname, './repl.js');
+const REPL_SCRIPT = require.resolve('./repl.js');
 
 export = function() {
   const argv = yargs.usage(args.usage).options(args.options).argv;
@@ -27,6 +25,6 @@ export = function() {
 
   argv._ = [REPL_SCRIPT];
 
-  //@ts-ignore Get feedback first in PR
+  // @ts-ignore: not the same arguments
   Runtime.runCLI(argv, [`Jest REPL v${VERSION}`]);
 };

--- a/packages/jest-repl/src/cli/index.ts
+++ b/packages/jest-repl/src/cli/index.ts
@@ -5,13 +5,13 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow
  */
 
 import path from 'path';
 
 import Runtime from 'jest-runtime';
 import yargs from 'yargs';
+// @ts-ignore: Wait for jest-validate to get migrated
 import {validateCLIOptions} from 'jest-validate';
 import {deprecationEntries} from 'jest-config';
 import {version as VERSION} from '../../package.json';
@@ -19,12 +19,13 @@ import * as args from './args';
 
 const REPL_SCRIPT = path.resolve(__dirname, './repl.js');
 
-module.exports = function() {
+exports = function() {
   const argv = yargs.usage(args.usage).options(args.options).argv;
 
   validateCLIOptions(argv, {...args.options, deprecationEntries});
 
   argv._ = [REPL_SCRIPT];
 
+  //@ts-ignore Get feedback first in PR
   Runtime.runCLI(argv, [`Jest REPL v${VERSION}`]);
 };

--- a/packages/jest-repl/src/cli/index.ts
+++ b/packages/jest-repl/src/cli/index.ts
@@ -20,7 +20,7 @@ const {version: VERSION} = require("../../package.json");
 
 const REPL_SCRIPT = path.resolve(__dirname, './repl.js');
 
-exports = function() {
+export = function() {
   const argv = yargs.usage(args.usage).options(args.options).argv;
 
   validateCLIOptions(argv, {...args.options, deprecationEntries});

--- a/packages/jest-repl/src/cli/index.ts
+++ b/packages/jest-repl/src/cli/index.ts
@@ -14,8 +14,9 @@ import yargs from 'yargs';
 // @ts-ignore: Wait for jest-validate to get migrated
 import {validateCLIOptions} from 'jest-validate';
 import {deprecationEntries} from 'jest-config';
-import {version as VERSION} from '../../package.json';
 import * as args from './args';
+
+const {version: VERSION} = require("../../package.json");
 
 const REPL_SCRIPT = path.resolve(__dirname, './repl.js');
 

--- a/packages/jest-repl/src/cli/repl.ts
+++ b/packages/jest-repl/src/cli/repl.ts
@@ -13,8 +13,8 @@ declare var jestProjectConfig: Config.ProjectConfig;
 import path from 'path';
 import repl from 'repl';
 import vm from 'vm';
-import { Transformer } from '@jest/transform';
-import { Config } from '@jest/types';
+import {Transformer} from '@jest/transform';
+import {Config} from '@jest/types';
 
 let transformer: Transformer;
 
@@ -23,16 +23,20 @@ const evalCommand: repl.REPLEval = (
   _context: any,
   _filename: string,
   callback: (e: Error | null, result?: any) => void,
-  _config?: any
+  _config?: any,
 ) => {
   let result;
   try {
     if (transformer) {
-      cmd = transformer.process(
+      const transformResult = transformer.process(
         cmd,
         jestGlobalConfig.replname || 'jest.js',
         jestProjectConfig,
-      ) as string;
+      );
+      cmd =
+        typeof transformResult === 'string'
+          ? transformResult
+          : transformResult.code;
     }
     result = vm.runInThisContext(cmd);
   } catch (e) {

--- a/packages/jest-repl/src/cli/repl.ts
+++ b/packages/jest-repl/src/cli/repl.ts
@@ -13,17 +13,17 @@ declare var jestProjectConfig: Config.ProjectConfig;
 import path from 'path';
 import repl from 'repl';
 import vm from 'vm';
-import {Transformer} from '@jest/transform';
-import {Config} from '@jest/types';
+import { Transformer } from '@jest/transform';
+import { Config } from '@jest/types';
 
 let transformer: Transformer;
 
-const evalCommand = (
+const evalCommand: repl.REPLEval = (
   cmd: string,
   _context: any,
   _filename: string,
   callback: (e: Error | null, result?: any) => void,
-  _config: Config.GlobalConfig,
+  _config?: any
 ) => {
   let result;
   try {
@@ -76,7 +76,7 @@ const replInstance: repl.REPLServer = repl.start({
   eval: evalCommand,
   prompt: '\u203A ',
   useGlobal: true,
-} as repl.ReplOptions);
+});
 
 replInstance.context.require = (moduleName: string) => {
   if (/(\/|\\|\.)/.test(moduleName)) {

--- a/packages/jest-repl/src/cli/repl.ts
+++ b/packages/jest-repl/src/cli/repl.ts
@@ -7,8 +7,8 @@
  *
  */
 
-declare var jestGlobalConfig: Config.GlobalConfig;
-declare var jestProjectConfig: Config.ProjectConfig;
+declare const jestGlobalConfig: Config.GlobalConfig;
+declare const jestProjectConfig: Config.ProjectConfig;
 
 import path from 'path';
 import repl from 'repl';
@@ -23,7 +23,6 @@ const evalCommand: repl.REPLEval = (
   _context: any,
   _filename: string,
   callback: (e: Error | null, result?: any) => void,
-  _config?: any,
 ) => {
   let result;
   try {

--- a/packages/jest-repl/tsconfig.json
+++ b/packages/jest-repl/tsconfig.json
@@ -2,26 +2,14 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "build",
+    "outDir": "build"
   },
   "references": [
-    {
-      "path": "../jest-config"
-    },
-    {
-      "path": "../jest-runtime"
-    },
-    {
-      "path": "../jest-transform"
-    },
-    {
-      "path": "../jest-types"
-    }
+    {"path": "../jest-config"},
+    {"path": "../jest-runtime"},
+    {"path": "../jest-transform"},
+    {"path": "../jest-types"}
     // TODO: Wait for this to get migrated
-    /*
-    {
-      "path": "../jest-validate"
-    }
-    */
+    // {"path": "../jest-validate"}
   ]
 }

--- a/packages/jest-repl/tsconfig.json
+++ b/packages/jest-repl/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "build",
+  },
+  "references": [
+    {
+      "path": "../jest-config"
+    },
+    {
+      "path": "../jest-runtime"
+    },
+    {
+      "path": "../jest-transform"
+    },
+    {
+      "path": "../jest-types"
+    }
+    // TODO: Wait for this to get migrated
+    /*
+    {
+      "path": "../jest-validate"
+    }
+    */
+  ]
+}


### PR DESCRIPTION
This PR migrates jest-repl to typescript. 

Notes:
1. I have one ts-ignore in index.ts
2. Importing package.json outside of the rootDir causes the compiler to fail