### PR TITLE
Update contributing to add information about jest_circus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@
 - `[@jest/fake-timers]`: Extract FakeTimers class from `jest-util` into a new separate package ([#7987](https://github.com/facebook/jest/pull/7987))
 - `[jest-repl]`: Migrate to TypeScript ([#8000](https://github.com/facebook/jest/pull/8000))
 - `[jest-validate]`: Migrate to TypeScript ([#7991](https://github.com/facebook/jest/pull/7991))
+- `[docs]`: Update CONTRIBUTING.md to add information about running jest with `jest-circus` locally ([#8013](https://github.com/facebook/jest/pull/8013)).
 
 ### Performance
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,6 +107,14 @@ Time:        0.232s, estimated 1s
 Ran all test suites.
 ```
 
+##### Using jest-circus
+
+There may be cases where you want to run jest using `jest-circus` instead of `jest-jasmine2` (which is the default runner) for integration testing. In situtations like this just set the environment variable `JEST_CIRCUS` to 1. That will configure jest to use `jest-circus`. So something like this.
+
+```bash
+JEST_CIRCUS=1 yarn jest
+```
+
 #### Additional Workflow for any changes made to website or docs
 
 If you are making changes to the website or documentation, test the website folder and run the server to check if your changes are being displayed accurately.


### PR DESCRIPTION
## Summary

New contributors to jest may not know about how to use `jest_circus` when running the jest test suite. 
This PR updates the `CONTRIBUTING.md` to add information about that.