### PR TITLE
repro for #7493

### DIFF
--- a/e2e/test-retries/__tests__/__snapshots__/retry.test.js.snap
+++ b/e2e/test-retries/__tests__/__snapshots__/retry.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`retryTimes set 1`] = `1`;
+
+exports[`retryTimes set 2`] = `1`;
+
+exports[`retryTimes set 3`] = `1`;
+
+exports[`retryTimes set 4`] = `1`;

--- a/e2e/test-retries/__tests__/retry.test.js
+++ b/e2e/test-retries/__tests__/retry.test.js
@@ -9,5 +9,6 @@
 jest.retryTimes(3);
 
 it('retryTimes set', () => {
+  expect(1).toMatchSnapshot();
   expect(true).toBeFalsy();
 });


### PR DESCRIPTION
this is a reproduction for #7493. as you can see, there are 4 snapshots generated, and that's not the expected behavior. it's not a failing test per se, but I just wanted to share the issue real quick, I can work on a more robust failing test later