### PR TITLE
[jest-each] refactor into multiple files with better types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 
 ### Chore & Maintenance
 
+- `[jest-each]`: Refactor into multiple files with better types ([#8018](https://github.com/facebook/jest/pull/8018))
 - `[jest-each]`: Migrate to Typescript ([#8007](https://github.com/facebook/jest/pull/8007))
 - `[jest-environment-jsdom]`: Migrate to TypeScript ([#7985](https://github.com/facebook/jest/pull/8003))
 - `[jest-environment-node]`: Migrate to TypeScript ([#7985](https://github.com/facebook/jest/pull/7985))

--- a/packages/jest-each/src/bind.ts
+++ b/packages/jest-each/src/bind.ts
@@ -10,12 +10,16 @@ import chalk from 'chalk';
 import pretty from 'pretty-format';
 import {ErrorWithStack} from 'jest-util';
 
-// TODO: renmae this
-import arrayTableToX from './table/array';
-import templateTableToX from './table/template';
+import convertArrayTable from './table/array';
+import convertTemplateTable from './table/template';
 
 const EXPECTED_COLOR = chalk.green;
 const RECEIVED_COLOR = chalk.red;
+
+export type EachTable = Array<{
+  title: string;
+  arguments: Array<unknown>;
+}>;
 
 export default (cb: Function, supportsDone: boolean = true) => (...args: any) =>
   function eachBind(title: string, test: Function, timeout?: number): void {
@@ -65,7 +69,7 @@ export default (cb: Function, supportsDone: boolean = true) => (...args: any) =>
           throw error;
         });
       }
-      return arrayTableToX(title, tableArg).forEach(row =>
+      return convertArrayTable(title, tableArg).forEach(row =>
         cb(
           row.title,
           applyArguments(supportsDone, row.arguments, test),
@@ -101,7 +105,7 @@ export default (cb: Function, supportsDone: boolean = true) => (...args: any) =>
       });
     }
 
-    return templateTableToX(title, keys, data).forEach(row =>
+    return convertTemplateTable(title, keys, data).forEach(row =>
       cb(row.title, applyArguments(supportsDone, row.arguments, test), timeout),
     );
   };

--- a/packages/jest-each/src/bind.ts
+++ b/packages/jest-each/src/bind.ts
@@ -7,15 +7,11 @@
  */
 
 import {DoneFn, ItBase} from '@jest/types/build/Global';
-import chalk from 'chalk';
-import pretty from 'pretty-format';
 import {ErrorWithStack} from 'jest-util';
 
 import convertArrayTable from './table/array';
 import convertTemplateTable from './table/template';
-
-const EXPECTED_COLOR = chalk.green;
-const RECEIVED_COLOR = chalk.red;
+import {validateArrayTable, validateTemplateTableHeadings} from './validation';
 
 type EachTestFn = (...args: any[]) => Promise<any> | void | undefined;
 
@@ -32,87 +28,50 @@ export type EachTests = Array<{
   arguments: Array<unknown>;
 }>;
 
-type Result = EachTests | string;
-
-// TODO: update cb to ItBase | DescribeBase and deprecate supportsDone
 export default (cb: ItBase, supportsDone: boolean = true) => (
   table: EachTable,
   ...taggedTemplateData: TemplateData
 ) =>
   function eachBind(title: string, test: EachTestFn, timeout?: number): void {
-    const result = isArrayTable(taggedTemplateData)
-      ? buildArrayTests(title, table)
-      : buildTemplateTests(title, table, taggedTemplateData);
+    try {
+      const tests = isArrayTable(taggedTemplateData)
+        ? buildArrayTests(title, table)
+        : buildTemplateTests(title, table, taggedTemplateData);
 
-    if (typeof result === 'string') {
-      const error = new ErrorWithStack(result, eachBind);
+      return tests.forEach(row =>
+        cb(
+          row.title,
+          applyArguments(supportsDone, row.arguments, test),
+          timeout,
+        ),
+      );
+    } catch (e) {
+      const error = new ErrorWithStack(e, eachBind);
       return cb(title, () => {
         throw error;
       });
     }
-
-    return result.forEach(row =>
-      cb(row.title, applyArguments(supportsDone, row.arguments, test), timeout),
-    );
   };
 
 const isArrayTable = (data: TemplateData) => data.length === 0;
 
-const buildArrayTests = (title: string, table: EachTable): Result => {
-  if (!Array.isArray(table)) {
-    return (
-      '`.each` must be called with an Array or Tagged Template Literal.\n\n' +
-      `Instead was called with: ${pretty(table, {
-        maxDepth: 1,
-        min: true,
-      })}\n`
-    );
-  }
-
-  if (isTaggedTemplateLiteral(table)) {
-    if (isEmptyString(table[0])) {
-      return 'Error: `.each` called with an empty Tagged Template Literal of table data.\n';
-    }
-
-    return 'Error: `.each` called with a Tagged Template Literal with no data, remember to interpolate with ${expression} syntax.\n';
-  }
-
-  if (isEmptyTable(table)) {
-    return 'Error: `.each` called with an empty Array of table data.\n';
-  }
-  return convertArrayTable(title, table);
+const buildArrayTests = (title: string, table: EachTable): EachTests => {
+  validateArrayTable(table);
+  return convertArrayTable(title, table as ArrayTable);
 };
 
 const buildTemplateTests = (
   title: string,
   table: EachTable,
   taggedTemplateData: TemplateData,
-): Result => {
-  const keys = getHeadingKeys(table[0] as string);
-  const missingData = taggedTemplateData.length % keys.length;
-
-  if (missingData > 0) {
-    return (
-      'Not enough arguments supplied for given headings:\n' +
-      EXPECTED_COLOR(keys.join(' | ')) +
-      '\n\n' +
-      'Received:\n' +
-      RECEIVED_COLOR(pretty(taggedTemplateData)) +
-      '\n\n' +
-      `Missing ${RECEIVED_COLOR(missingData.toString())} ${pluralize(
-        'argument',
-        missingData,
-      )}`
-    );
-  }
-
-  return convertTemplateTable(title, keys, taggedTemplateData);
+): EachTests => {
+  const headings = getHeadingKeys(table[0] as string);
+  validateTemplateTableHeadings(headings, taggedTemplateData);
+  return convertTemplateTable(title, headings, taggedTemplateData);
 };
 
-const isTaggedTemplateLiteral = (array: any) => array.raw !== undefined;
-const isEmptyTable = (table: Array<any>) => table.length === 0;
-const isEmptyString = (str: string | unknown) =>
-  typeof str === 'string' && str.trim() === '';
+const getHeadingKeys = (headings: string): Array<string> =>
+  headings.replace(/\s/g, '').split('|');
 
 const applyArguments = (
   supportsDone: boolean,
@@ -122,9 +81,3 @@ const applyArguments = (
   supportsDone && params.length < test.length
     ? (done: DoneFn) => test(...params, done)
     : () => test(...params);
-
-const getHeadingKeys = (headings: string): Array<string> =>
-  headings.replace(/\s/g, '').split('|');
-
-const pluralize = (word: string, count: number) =>
-  word + (count === 1 ? '' : 's');

--- a/packages/jest-each/src/bind.ts
+++ b/packages/jest-each/src/bind.ts
@@ -19,11 +19,10 @@ const RECEIVED_COLOR = chalk.red;
 
 type EachTestFn = (...args: any[]) => Promise<any> | void | undefined;
 
-// TODO: re-use these everywhere
-type Col = unknown;
-type Row = Array<Col>;
-type Table = Array<Row>;
-type ArrayTable = Table | Row;
+export type Col = unknown;
+export type Row = Array<Col>;
+export type Table = Array<Row>;
+export type ArrayTable = Table | Row;
 type TemplateTable = TemplateStringsArray;
 export type TemplateData = Array<unknown>;
 export type EachTable = ArrayTable | TemplateTable;

--- a/packages/jest-each/src/bind.ts
+++ b/packages/jest-each/src/bind.ts
@@ -6,29 +6,28 @@
  *
  */
 
-import {DoneFn, ItBase} from '@jest/types/build/Global';
+import {
+  DoneFn,
+  EachTable,
+  TemplateData,
+  EachTestFn,
+  ArrayTable,
+} from '@jest/types/build/Global';
 import {ErrorWithStack} from 'jest-util';
 
 import convertArrayTable from './table/array';
 import convertTemplateTable from './table/template';
 import {validateArrayTable, validateTemplateTableHeadings} from './validation';
 
-type EachTestFn = (...args: any[]) => Promise<any> | void | undefined;
-
-export type Col = unknown;
-export type Row = Array<Col>;
-export type Table = Array<Row>;
-export type ArrayTable = Table | Row;
-type TemplateTable = TemplateStringsArray;
-export type TemplateData = Array<unknown>;
-export type EachTable = ArrayTable | TemplateTable;
-
 export type EachTests = Array<{
   title: string;
   arguments: Array<unknown>;
 }>;
 
-export default (cb: ItBase, supportsDone: boolean = true) => (
+type TestFn = (done?: DoneFn) => Promise<any> | void | undefined;
+type GlobalCallback = (testName: string, fn: TestFn, timeout?: number) => void;
+
+export default (cb: GlobalCallback, supportsDone: boolean = true) => (
   table: EachTable,
   ...taggedTemplateData: TemplateData
 ) =>

--- a/packages/jest-each/src/bind.ts
+++ b/packages/jest-each/src/bind.ts
@@ -6,7 +6,7 @@
  *
  */
 
-import {Global} from '@jest/types/';
+import {Global} from '@jest/types';
 import {ErrorWithStack} from 'jest-util';
 
 import convertArrayTable from './table/array';

--- a/packages/jest-each/src/bind.ts
+++ b/packages/jest-each/src/bind.ts
@@ -6,6 +6,7 @@
  *
  */
 
+import {DoneFn, ItBase} from '@jest/types/build/Global';
 import chalk from 'chalk';
 import pretty from 'pretty-format';
 import {ErrorWithStack} from 'jest-util';
@@ -16,13 +17,17 @@ import convertTemplateTable from './table/template';
 const EXPECTED_COLOR = chalk.green;
 const RECEIVED_COLOR = chalk.red;
 
+type EachTestFn = (...args: any[]) => Promise<any> | void | undefined;
+
 export type EachTable = Array<{
   title: string;
   arguments: Array<unknown>;
 }>;
 
-export default (cb: Function, supportsDone: boolean = true) => (...args: any) =>
-  function eachBind(title: string, test: Function, timeout?: number): void {
+// TODO: update cb to ItBase | DescribeBase and deprecate supportsDone
+// TODO: update args from any
+export default (cb: ItBase, supportsDone: boolean = true) => (...args: any) =>
+  function eachBind(title: string, test: EachTestFn, timeout?: number): void {
     if (args.length === 1) {
       const [tableArg] = args;
 
@@ -115,15 +120,13 @@ const isEmptyTable = (table: Array<any>) => table.length === 0;
 const isEmptyString = (str: string) =>
   typeof str === 'string' && str.trim() === '';
 
-type Done = () => {};
-
 const applyArguments = (
   supportsDone: boolean,
-  params: Array<any>,
-  test: Function,
-) =>
+  params: Array<unknown>,
+  test: EachTestFn,
+): EachTestFn =>
   supportsDone && params.length < test.length
-    ? (done: Done) => test(...params, done)
+    ? (done: DoneFn) => test(...params, done)
     : () => test(...params);
 
 const getHeadingKeys = (headings: string): Array<string> =>

--- a/packages/jest-each/src/bind.ts
+++ b/packages/jest-each/src/bind.ts
@@ -45,7 +45,7 @@ export default (cb: GlobalCallback, supportsDone: boolean = true) => (
         ),
       );
     } catch (e) {
-      const error = new ErrorWithStack(e, eachBind);
+      const error = new ErrorWithStack(e.message, eachBind);
       return cb(title, () => {
         throw error;
       });

--- a/packages/jest-each/src/bind.ts
+++ b/packages/jest-each/src/bind.ts
@@ -6,13 +6,7 @@
  *
  */
 
-import {
-  DoneFn,
-  EachTable,
-  TemplateData,
-  EachTestFn,
-  ArrayTable,
-} from '@jest/types/build/Global';
+import {Global} from '@jest/types/';
 import {ErrorWithStack} from 'jest-util';
 
 import convertArrayTable from './table/array';
@@ -24,14 +18,18 @@ export type EachTests = Array<{
   arguments: Array<unknown>;
 }>;
 
-type TestFn = (done?: DoneFn) => Promise<any> | void | undefined;
+type TestFn = (done?: Global.DoneFn) => Promise<any> | void | undefined;
 type GlobalCallback = (testName: string, fn: TestFn, timeout?: number) => void;
 
 export default (cb: GlobalCallback, supportsDone: boolean = true) => (
-  table: EachTable,
-  ...taggedTemplateData: TemplateData
+  table: Global.EachTable,
+  ...taggedTemplateData: Global.TemplateData
 ) =>
-  function eachBind(title: string, test: EachTestFn, timeout?: number): void {
+  function eachBind(
+    title: string,
+    test: Global.EachTestFn,
+    timeout?: number,
+  ): void {
     try {
       const tests = isArrayTable(taggedTemplateData)
         ? buildArrayTests(title, table)
@@ -52,17 +50,17 @@ export default (cb: GlobalCallback, supportsDone: boolean = true) => (
     }
   };
 
-const isArrayTable = (data: TemplateData) => data.length === 0;
+const isArrayTable = (data: Global.TemplateData) => data.length === 0;
 
-const buildArrayTests = (title: string, table: EachTable): EachTests => {
+const buildArrayTests = (title: string, table: Global.EachTable): EachTests => {
   validateArrayTable(table);
-  return convertArrayTable(title, table as ArrayTable);
+  return convertArrayTable(title, table as Global.ArrayTable);
 };
 
 const buildTemplateTests = (
   title: string,
-  table: EachTable,
-  taggedTemplateData: TemplateData,
+  table: Global.EachTable,
+  taggedTemplateData: Global.TemplateData,
 ): EachTests => {
   const headings = getHeadingKeys(table[0] as string);
   validateTemplateTableHeadings(headings, taggedTemplateData);
@@ -75,8 +73,8 @@ const getHeadingKeys = (headings: string): Array<string> =>
 const applyArguments = (
   supportsDone: boolean,
   params: Array<unknown>,
-  test: EachTestFn,
-): EachTestFn =>
+  test: Global.EachTestFn,
+): Global.EachTestFn =>
   supportsDone && params.length < test.length
-    ? (done: DoneFn) => test(...params, done)
+    ? (done: Global.DoneFn) => test(...params, done)
     : () => test(...params);

--- a/packages/jest-each/src/index.ts
+++ b/packages/jest-each/src/index.ts
@@ -6,8 +6,8 @@
  *
  */
 
-import {TestFn} from '@jest/types/build/Global';
-import bind, {EachTable, TemplateData} from './bind';
+import {TestFn, EachTable, TemplateData} from '@jest/types/build/Global';
+import bind from './bind';
 
 type Global = NodeJS.Global;
 

--- a/packages/jest-each/src/index.ts
+++ b/packages/jest-each/src/index.ts
@@ -7,38 +7,40 @@
  */
 
 import {TestFn} from '@jest/types/build/Global';
-import bind from './bind';
+import bind, {EachTable, TemplateData} from './bind';
 
 type Global = NodeJS.Global;
 
-const install = (g: Global, ...args: Array<any>) => {
+const install = (g: Global, table: EachTable, ...data: TemplateData) => {
   const test = (title: string, test: TestFn, timeout?: number) =>
-    bind(g.test)(...args)(title, test, timeout);
-  test.skip = bind(g.test.skip)(...args);
-  test.only = bind(g.test.only)(...args);
+    bind(g.test)(table, ...data)(title, test, timeout);
+  test.skip = bind(g.test.skip)(table, ...data);
+  test.only = bind(g.test.only)(table, ...data);
 
   const it = (title: string, test: TestFn, timeout?: number) =>
-    bind(g.it)(...args)(title, test, timeout);
-  it.skip = bind(g.it.skip)(...args);
-  it.only = bind(g.it.only)(...args);
+    bind(g.it)(table, ...data)(title, test, timeout);
+  it.skip = bind(g.it.skip)(table, ...data);
+  it.only = bind(g.it.only)(table, ...data);
 
-  const xit = bind(g.xit)(...args);
-  const fit = bind(g.fit)(...args);
-  const xtest = bind(g.xtest)(...args);
+  const xit = bind(g.xit)(table, ...data);
+  const fit = bind(g.fit)(table, ...data);
+  const xtest = bind(g.xtest)(table, ...data);
 
   const describe = (title: string, suite: TestFn, timeout?: number) =>
-    bind(g.describe, false)(...args)(title, suite, timeout);
-  describe.skip = bind(g.describe.skip, false)(...args);
-  describe.only = bind(g.describe.only, false)(...args);
-  const fdescribe = bind(g.fdescribe, false)(...args);
-  const xdescribe = bind(g.xdescribe, false)(...args);
+    bind(g.describe, false)(table, ...data)(title, suite, timeout);
+  describe.skip = bind(g.describe.skip, false)(table, ...data);
+  describe.only = bind(g.describe.only, false)(table, ...data);
+  const fdescribe = bind(g.fdescribe, false)(table, ...data);
+  const xdescribe = bind(g.xdescribe, false)(table, ...data);
 
   return {describe, fdescribe, fit, it, test, xdescribe, xit, xtest};
 };
 
-const each = (...args: Array<any>) => install(global, ...args);
+const each = (table: EachTable, ...data: TemplateData) =>
+  install(global, table, ...data);
 
-each.withGlobal = (g: Global) => (...args: Array<any>) => install(g, ...args);
+each.withGlobal = (g: Global) => (table: EachTable, ...data: TemplateData) =>
+  install(g, table, ...data);
 
 export {bind};
 

--- a/packages/jest-each/src/index.ts
+++ b/packages/jest-each/src/index.ts
@@ -6,18 +6,22 @@
  *
  */
 
-import {TestFn, EachTable, TemplateData} from '@jest/types/build/Global';
+import {Global} from '@jest/types';
 import bind from './bind';
 
 type Global = NodeJS.Global;
 
-const install = (g: Global, table: EachTable, ...data: TemplateData) => {
-  const test = (title: string, test: TestFn, timeout?: number) =>
+const install = (
+  g: Global,
+  table: Global.EachTable,
+  ...data: Global.TemplateData
+) => {
+  const test = (title: string, test: Global.TestFn, timeout?: number) =>
     bind(g.test)(table, ...data)(title, test, timeout);
   test.skip = bind(g.test.skip)(table, ...data);
   test.only = bind(g.test.only)(table, ...data);
 
-  const it = (title: string, test: TestFn, timeout?: number) =>
+  const it = (title: string, test: Global.TestFn, timeout?: number) =>
     bind(g.it)(table, ...data)(title, test, timeout);
   it.skip = bind(g.it.skip)(table, ...data);
   it.only = bind(g.it.only)(table, ...data);
@@ -26,7 +30,7 @@ const install = (g: Global, table: EachTable, ...data: TemplateData) => {
   const fit = bind(g.fit)(table, ...data);
   const xtest = bind(g.xtest)(table, ...data);
 
-  const describe = (title: string, suite: TestFn, timeout?: number) =>
+  const describe = (title: string, suite: Global.TestFn, timeout?: number) =>
     bind(g.describe, false)(table, ...data)(title, suite, timeout);
   describe.skip = bind(g.describe.skip, false)(table, ...data);
   describe.only = bind(g.describe.only, false)(table, ...data);
@@ -36,11 +40,13 @@ const install = (g: Global, table: EachTable, ...data: TemplateData) => {
   return {describe, fdescribe, fit, it, test, xdescribe, xit, xtest};
 };
 
-const each = (table: EachTable, ...data: TemplateData) =>
+const each = (table: Global.EachTable, ...data: Global.TemplateData) =>
   install(global, table, ...data);
 
-each.withGlobal = (g: Global) => (table: EachTable, ...data: TemplateData) =>
-  install(g, table, ...data);
+each.withGlobal = (g: Global) => (
+  table: Global.EachTable,
+  ...data: Global.TemplateData
+) => install(g, table, ...data);
 
 export {bind};
 

--- a/packages/jest-each/src/index.ts
+++ b/packages/jest-each/src/index.ts
@@ -6,17 +6,18 @@
  *
  */
 
-type Global = NodeJS.Global;
-
+import {TestFn} from '@jest/types/build/Global';
 import bind from './bind';
 
+type Global = NodeJS.Global;
+
 const install = (g: Global, ...args: Array<any>) => {
-  const test = (title: string, test: Function, timeout?: number) =>
+  const test = (title: string, test: TestFn, timeout?: number) =>
     bind(g.test)(...args)(title, test, timeout);
   test.skip = bind(g.test.skip)(...args);
   test.only = bind(g.test.only)(...args);
 
-  const it = (title: string, test: Function, timeout?: number) =>
+  const it = (title: string, test: TestFn, timeout?: number) =>
     bind(g.it)(...args)(title, test, timeout);
   it.skip = bind(g.it.skip)(...args);
   it.only = bind(g.it.only)(...args);
@@ -25,7 +26,7 @@ const install = (g: Global, ...args: Array<any>) => {
   const fit = bind(g.fit)(...args);
   const xtest = bind(g.xtest)(...args);
 
-  const describe = (title: string, suite: Function, timeout?: number) =>
+  const describe = (title: string, suite: TestFn, timeout?: number) =>
     bind(g.describe, false)(...args)(title, suite, timeout);
   describe.skip = bind(g.describe.skip, false)(...args);
   describe.only = bind(g.describe.only, false)(...args);

--- a/packages/jest-each/src/table/array.ts
+++ b/packages/jest-each/src/table/array.ts
@@ -1,3 +1,11 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
 import util from 'util';
 import pretty from 'pretty-format';
 
@@ -10,8 +18,8 @@ const INDEX_PLACEHOLDER = '%#';
 
 export default (title: string, arrayTable: Global.ArrayTable): EachTests =>
   normaliseTable(arrayTable).map((row, index) => ({
-    title: formatTitle(title, row, index),
     arguments: row,
+    title: formatTitle(title, row, index),
   }));
 
 const normaliseTable = (table: Global.ArrayTable): Global.Table =>

--- a/packages/jest-each/src/table/array.ts
+++ b/packages/jest-each/src/table/array.ts
@@ -1,22 +1,17 @@
 import util from 'util';
 import pretty from 'pretty-format';
+import {EachTable} from '../bind';
 
 type Col = unknown;
 type Row = Array<Col>;
 type Table = Array<Row>;
 type ArrayTable = Table | Row;
 
-// TODO: rename X and maybe arguments
-type X = Array<{
-  title: string;
-  arguments: Array<unknown>;
-}>;
-
 const SUPPORTED_PLACEHOLDERS = /%[sdifjoOp%]/g;
 const PRETTY_PLACEHOLDER = '%p';
 const INDEX_PLACEHOLDER = '%#';
 
-export default (title: string, arrayTable: ArrayTable): X =>
+export default (title: string, arrayTable: ArrayTable): EachTable =>
   normaliseTable(arrayTable).map((row, index) => ({
     title: formatTitle(title, row, index),
     arguments: row,

--- a/packages/jest-each/src/table/array.ts
+++ b/packages/jest-each/src/table/array.ts
@@ -1,0 +1,50 @@
+import util from 'util';
+import pretty from 'pretty-format';
+
+type Col = unknown;
+type Row = Array<Col>;
+type Table = Array<Row>;
+type ArrayTable = Table | Row;
+
+// TODO: rename X and maybe arguments
+type X = Array<{
+  title: string;
+  arguments: Array<unknown>;
+}>;
+
+const SUPPORTED_PLACEHOLDERS = /%[sdifjoOp%]/g;
+const PRETTY_PLACEHOLDER = '%p';
+const INDEX_PLACEHOLDER = '%#';
+
+export default (title: string, arrayTable: ArrayTable): X =>
+  normaliseTable(arrayTable).map((row, index) => ({
+    title: formatTitle(title, row, index),
+    arguments: row,
+  }));
+
+const normaliseTable = (table: ArrayTable): Table =>
+  isTable(table) ? (table as Table) : (table as Row).map(colToRow);
+
+const isTable = (table: ArrayTable): boolean => table.every(Array.isArray);
+
+const colToRow = (col: Col): Row => [col];
+
+const formatTitle = (title: string, row: Row, rowIndex: number): string =>
+  row.reduce<string>((formattedTitle, value) => {
+    const [placeholder] = getMatchingPlaceholders(formattedTitle);
+    if (!placeholder) return formattedTitle;
+
+    if (placeholder === PRETTY_PLACEHOLDER)
+      return interpolatePrettyPlaceholder(formattedTitle, value);
+
+    return util.format(formattedTitle, value);
+  }, interpolateTitleIndex(title, rowIndex));
+
+const getMatchingPlaceholders = (title: string) =>
+  title.match(SUPPORTED_PLACEHOLDERS) || [];
+
+const interpolateTitleIndex = (title: string, index: number) =>
+  title.replace(INDEX_PLACEHOLDER, index.toString());
+
+const interpolatePrettyPlaceholder = (title: string, value: unknown) =>
+  title.replace(PRETTY_PLACEHOLDER, pretty(value, {maxDepth: 1, min: true}));

--- a/packages/jest-each/src/table/array.ts
+++ b/packages/jest-each/src/table/array.ts
@@ -1,27 +1,34 @@
 import util from 'util';
 import pretty from 'pretty-format';
 
-import {ArrayTable, Table, Row, Col} from '@jest/types/build/Global';
+import {Global} from '@jest/types';
 import {EachTests} from '../bind';
 
 const SUPPORTED_PLACEHOLDERS = /%[sdifjoOp%]/g;
 const PRETTY_PLACEHOLDER = '%p';
 const INDEX_PLACEHOLDER = '%#';
 
-export default (title: string, arrayTable: ArrayTable): EachTests =>
+export default (title: string, arrayTable: Global.ArrayTable): EachTests =>
   normaliseTable(arrayTable).map((row, index) => ({
     title: formatTitle(title, row, index),
     arguments: row,
   }));
 
-const normaliseTable = (table: ArrayTable): Table =>
-  isTable(table) ? (table as Table) : (table as Row).map(colToRow);
+const normaliseTable = (table: Global.ArrayTable): Global.Table =>
+  isTable(table)
+    ? (table as Global.Table)
+    : (table as Global.Row).map(colToRow);
 
-const isTable = (table: ArrayTable): boolean => table.every(Array.isArray);
+const isTable = (table: Global.ArrayTable): boolean =>
+  table.every(Array.isArray);
 
-const colToRow = (col: Col): Row => [col];
+const colToRow = (col: Global.Col): Global.Row => [col];
 
-const formatTitle = (title: string, row: Row, rowIndex: number): string =>
+const formatTitle = (
+  title: string,
+  row: Global.Row,
+  rowIndex: number,
+): string =>
   row.reduce<string>((formattedTitle, value) => {
     const [placeholder] = getMatchingPlaceholders(formattedTitle);
     if (!placeholder) return formattedTitle;

--- a/packages/jest-each/src/table/array.ts
+++ b/packages/jest-each/src/table/array.ts
@@ -23,11 +23,9 @@ export default (title: string, arrayTable: Global.ArrayTable): EachTests =>
   }));
 
 const normaliseTable = (table: Global.ArrayTable): Global.Table =>
-  isTable(table)
-    ? (table as Global.Table)
-    : (table as Global.Row).map(colToRow);
+  isTable(table) ? table : table.map(colToRow);
 
-const isTable = (table: Global.ArrayTable): boolean =>
+const isTable = (table: Global.ArrayTable): table is Global.Table =>
   table.every(Array.isArray);
 
 const colToRow = (col: Global.Col): Global.Row => [col];

--- a/packages/jest-each/src/table/array.ts
+++ b/packages/jest-each/src/table/array.ts
@@ -1,11 +1,7 @@
 import util from 'util';
 import pretty from 'pretty-format';
-import {EachTests} from '../bind';
 
-type Col = unknown;
-type Row = Array<Col>;
-type Table = Array<Row>;
-type ArrayTable = Table | Row;
+import {ArrayTable, Col, EachTests, Row, Table} from '../bind';
 
 const SUPPORTED_PLACEHOLDERS = /%[sdifjoOp%]/g;
 const PRETTY_PLACEHOLDER = '%p';

--- a/packages/jest-each/src/table/array.ts
+++ b/packages/jest-each/src/table/array.ts
@@ -1,7 +1,8 @@
 import util from 'util';
 import pretty from 'pretty-format';
 
-import {ArrayTable, Col, EachTests, Row, Table} from '../bind';
+import {ArrayTable, Table, Row, Col} from '@jest/types/build/Global';
+import {EachTests} from '../bind';
 
 const SUPPORTED_PLACEHOLDERS = /%[sdifjoOp%]/g;
 const PRETTY_PLACEHOLDER = '%p';

--- a/packages/jest-each/src/table/array.ts
+++ b/packages/jest-each/src/table/array.ts
@@ -1,6 +1,6 @@
 import util from 'util';
 import pretty from 'pretty-format';
-import {EachTable} from '../bind';
+import {EachTests} from '../bind';
 
 type Col = unknown;
 type Row = Array<Col>;
@@ -11,7 +11,7 @@ const SUPPORTED_PLACEHOLDERS = /%[sdifjoOp%]/g;
 const PRETTY_PLACEHOLDER = '%p';
 const INDEX_PLACEHOLDER = '%#';
 
-export default (title: string, arrayTable: ArrayTable): EachTable =>
+export default (title: string, arrayTable: ArrayTable): EachTests =>
   normaliseTable(arrayTable).map((row, index) => ({
     title: formatTitle(title, row, index),
     arguments: row,

--- a/packages/jest-each/src/table/template.ts
+++ b/packages/jest-each/src/table/template.ts
@@ -1,0 +1,74 @@
+import pretty from 'pretty-format';
+import {isPrimitive} from 'jest-get-type';
+
+type Col = unknown;
+type Row = Array<Col>;
+type Table = Array<Row>;
+type Template = {[key: string]: unknown};
+type Templates = Array<Template>;
+type Headings = Array<string>;
+
+type X = Array<{
+  title: string;
+  arguments: Array<unknown>;
+}>;
+
+export default (title: string, headings: Headings, row: Row): X => {
+  const table = convertRowToTable(row, headings);
+  const templates = convertTableToTemplates(table, headings);
+  return templates.map(template => ({
+    title: interpolate(title, template),
+    arguments: [template],
+  }));
+};
+
+const convertRowToTable = (
+  row: Row,
+  headings: Headings,
+): Table => // TODO: update this type to include values in headings
+  Array.from({length: row.length / headings.length}).map((_, index) =>
+    row.slice(
+      index * headings.length,
+      index * headings.length + headings.length,
+    ),
+  );
+
+const convertTableToTemplates = (table: Table, headings: Headings): Templates =>
+  table.map(row =>
+    row.reduce<Template>(
+      (acc, value, index) => Object.assign(acc, {[headings[index]]: value}),
+      {},
+    ),
+  );
+
+const interpolate = (title: string, template: Template) =>
+  Object.keys(template)
+    .reduce(getMatchingKeyPaths(title), []) // aka flatMap
+    .reduce(replaceKeyPathWithValue(template), title);
+
+const getMatchingKeyPaths = (title: string) => (
+  matches: Headings,
+  key: string,
+) => matches.concat(title.match(new RegExp(`\\$${key}[\\.\\w]*`, 'g')) || []);
+
+const replaceKeyPathWithValue = (template: Template) => (
+  title: string,
+  match: string,
+) => {
+  const keyPath = match.replace('$', '').split('.');
+  const value = getPath(template, keyPath);
+
+  if (isPrimitive(value)) {
+    return title.replace(match, String(value));
+  }
+  return title.replace(match, pretty(value, {maxDepth: 1, min: true}));
+};
+
+const getPath = (
+  template: Template | any,
+  [head, ...tail]: Array<string>,
+): any => {
+  if (!head || !template.hasOwnProperty || !template.hasOwnProperty(head))
+    return template;
+  return getPath(template[head], tail);
+};

--- a/packages/jest-each/src/table/template.ts
+++ b/packages/jest-each/src/table/template.ts
@@ -1,13 +1,17 @@
 import pretty from 'pretty-format';
 import {isPrimitive} from 'jest-get-type';
-import {Row, Table} from '@jest/types/build/Global';
+import {Global} from '@jest/types';
 import {EachTests} from '../bind';
 
 type Template = {[key: string]: unknown};
 type Templates = Array<Template>;
 type Headings = Array<string>;
 
-export default (title: string, headings: Headings, row: Row): EachTests => {
+export default (
+  title: string,
+  headings: Headings,
+  row: Global.Row,
+): EachTests => {
   const table = convertRowToTable(row, headings);
   const templates = convertTableToTemplates(table, headings);
   return templates.map(template => ({
@@ -16,7 +20,7 @@ export default (title: string, headings: Headings, row: Row): EachTests => {
   }));
 };
 
-const convertRowToTable = (row: Row, headings: Headings): Table =>
+const convertRowToTable = (row: Global.Row, headings: Headings): Global.Table =>
   Array.from({length: row.length / headings.length}).map((_, index) =>
     row.slice(
       index * headings.length,
@@ -24,7 +28,10 @@ const convertRowToTable = (row: Row, headings: Headings): Table =>
     ),
   );
 
-const convertTableToTemplates = (table: Table, headings: Headings): Templates =>
+const convertTableToTemplates = (
+  table: Global.Table,
+  headings: Headings,
+): Templates =>
   table.map(row =>
     row.reduce<Template>(
       (acc, value, index) => Object.assign(acc, {[headings[index]]: value}),

--- a/packages/jest-each/src/table/template.ts
+++ b/packages/jest-each/src/table/template.ts
@@ -1,6 +1,7 @@
 import pretty from 'pretty-format';
 import {isPrimitive} from 'jest-get-type';
-import {EachTests, Row, Table} from '../bind';
+import {Row, Table} from '@jest/types/build/Global';
+import {EachTests} from '../bind';
 
 type Template = {[key: string]: unknown};
 type Templates = Array<Template>;

--- a/packages/jest-each/src/table/template.ts
+++ b/packages/jest-each/src/table/template.ts
@@ -1,5 +1,6 @@
 import pretty from 'pretty-format';
 import {isPrimitive} from 'jest-get-type';
+import {EachTable} from '../bind';
 
 type Col = unknown;
 type Row = Array<Col>;
@@ -8,12 +9,7 @@ type Template = {[key: string]: unknown};
 type Templates = Array<Template>;
 type Headings = Array<string>;
 
-type X = Array<{
-  title: string;
-  arguments: Array<unknown>;
-}>;
-
-export default (title: string, headings: Headings, row: Row): X => {
+export default (title: string, headings: Headings, row: Row): EachTable => {
   const table = convertRowToTable(row, headings);
   const templates = convertTableToTemplates(table, headings);
   return templates.map(template => ({
@@ -22,10 +18,7 @@ export default (title: string, headings: Headings, row: Row): X => {
   }));
 };
 
-const convertRowToTable = (
-  row: Row,
-  headings: Headings,
-): Table => // TODO: update this type to include values in headings
+const convertRowToTable = (row: Row, headings: Headings): Table =>
   Array.from({length: row.length / headings.length}).map((_, index) =>
     row.slice(
       index * headings.length,

--- a/packages/jest-each/src/table/template.ts
+++ b/packages/jest-each/src/table/template.ts
@@ -1,3 +1,11 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
 import pretty from 'pretty-format';
 import {isPrimitive} from 'jest-get-type';
 import {Global} from '@jest/types';
@@ -15,8 +23,8 @@ export default (
   const table = convertRowToTable(row, headings);
   const templates = convertTableToTemplates(table, headings);
   return templates.map(template => ({
-    title: interpolate(title, template),
     arguments: [template],
+    title: interpolate(title, template),
   }));
 };
 

--- a/packages/jest-each/src/table/template.ts
+++ b/packages/jest-each/src/table/template.ts
@@ -1,10 +1,7 @@
 import pretty from 'pretty-format';
 import {isPrimitive} from 'jest-get-type';
-import {EachTests} from '../bind';
+import {EachTests, Row, Table} from '../bind';
 
-type Col = unknown;
-type Row = Array<Col>;
-type Table = Array<Row>;
 type Template = {[key: string]: unknown};
 type Templates = Array<Template>;
 type Headings = Array<string>;

--- a/packages/jest-each/src/table/template.ts
+++ b/packages/jest-each/src/table/template.ts
@@ -1,6 +1,6 @@
 import pretty from 'pretty-format';
 import {isPrimitive} from 'jest-get-type';
-import {EachTable} from '../bind';
+import {EachTests} from '../bind';
 
 type Col = unknown;
 type Row = Array<Col>;
@@ -9,7 +9,7 @@ type Template = {[key: string]: unknown};
 type Templates = Array<Template>;
 type Headings = Array<string>;
 
-export default (title: string, headings: Headings, row: Row): EachTable => {
+export default (title: string, headings: Headings, row: Row): EachTests => {
   const table = convertRowToTable(row, headings);
   const templates = convertTableToTemplates(table, headings);
   return templates.map(template => ({

--- a/packages/jest-each/src/validation.ts
+++ b/packages/jest-each/src/validation.ts
@@ -7,23 +7,31 @@ const RECEIVED_COLOR = chalk.red;
 
 export const validateArrayTable = (table: any) => {
   if (!Array.isArray(table)) {
-    throw '`.each` must be called with an Array or Tagged Template Literal.\n\n' +
-      `Instead was called with: ${pretty(table, {
-        maxDepth: 1,
-        min: true,
-      })}\n`;
+    throw new Error(
+      '`.each` must be called with an Array or Tagged Template Literal.\n\n' +
+        `Instead was called with: ${pretty(table, {
+          maxDepth: 1,
+          min: true,
+        })}\n`,
+    );
   }
 
   if (isTaggedTemplateLiteral(table)) {
     if (isEmptyString(table[0])) {
-      throw 'Error: `.each` called with an empty Tagged Template Literal of table data.\n';
+      throw new Error(
+        'Error: `.each` called with an empty Tagged Template Literal of table data.\n',
+      );
     }
 
-    throw 'Error: `.each` called with a Tagged Template Literal with no data, remember to interpolate with ${expression} syntax.\n';
+    throw new Error(
+      'Error: `.each` called with a Tagged Template Literal with no data, remember to interpolate with ${expression} syntax.\n',
+    );
   }
 
   if (isEmptyTable(table)) {
-    throw 'Error: `.each` called with an empty Array of table data.\n';
+    throw new Error(
+      'Error: `.each` called with an empty Array of table data.\n',
+    );
   }
 };
 
@@ -39,16 +47,18 @@ export const validateTemplateTableHeadings = (
   const missingData = data.length % headings.length;
 
   if (missingData > 0) {
-    throw 'Not enough arguments supplied for given headings:\n' +
-      EXPECTED_COLOR(headings.join(' | ')) +
-      '\n\n' +
-      'Received:\n' +
-      RECEIVED_COLOR(pretty(data)) +
-      '\n\n' +
-      `Missing ${RECEIVED_COLOR(missingData.toString())} ${pluralize(
-        'argument',
-        missingData,
-      )}`;
+    throw new Error(
+      'Not enough arguments supplied for given headings:\n' +
+        EXPECTED_COLOR(headings.join(' | ')) +
+        '\n\n' +
+        'Received:\n' +
+        RECEIVED_COLOR(pretty(data)) +
+        '\n\n' +
+        `Missing ${RECEIVED_COLOR(missingData.toString())} ${pluralize(
+          'argument',
+          missingData,
+        )}`,
+    );
   }
 };
 

--- a/packages/jest-each/src/validation.ts
+++ b/packages/jest-each/src/validation.ts
@@ -1,3 +1,11 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
 import chalk from 'chalk';
 import pretty from 'pretty-format';
 import {TemplateData} from '@jest/types/build/Global';

--- a/packages/jest-each/src/validation.ts
+++ b/packages/jest-each/src/validation.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import pretty from 'pretty-format';
-import {TemplateData} from './bind';
+import {TemplateData} from '@jest/types/build/Global';
 
 const EXPECTED_COLOR = chalk.green;
 const RECEIVED_COLOR = chalk.red;

--- a/packages/jest-each/src/validation.ts
+++ b/packages/jest-each/src/validation.ts
@@ -1,0 +1,56 @@
+import chalk from 'chalk';
+import pretty from 'pretty-format';
+import {TemplateData} from './bind';
+
+const EXPECTED_COLOR = chalk.green;
+const RECEIVED_COLOR = chalk.red;
+
+export const validateArrayTable = (table: any) => {
+  if (!Array.isArray(table)) {
+    throw '`.each` must be called with an Array or Tagged Template Literal.\n\n' +
+      `Instead was called with: ${pretty(table, {
+        maxDepth: 1,
+        min: true,
+      })}\n`;
+  }
+
+  if (isTaggedTemplateLiteral(table)) {
+    if (isEmptyString(table[0])) {
+      throw 'Error: `.each` called with an empty Tagged Template Literal of table data.\n';
+    }
+
+    throw 'Error: `.each` called with a Tagged Template Literal with no data, remember to interpolate with ${expression} syntax.\n';
+  }
+
+  if (isEmptyTable(table)) {
+    throw 'Error: `.each` called with an empty Array of table data.\n';
+  }
+};
+
+const isTaggedTemplateLiteral = (array: any) => array.raw !== undefined;
+const isEmptyTable = (table: Array<any>) => table.length === 0;
+const isEmptyString = (str: string | unknown) =>
+  typeof str === 'string' && str.trim() === '';
+
+export const validateTemplateTableHeadings = (
+  headings: Array<string>,
+  data: TemplateData,
+) => {
+  const missingData = data.length % headings.length;
+
+  if (missingData > 0) {
+    throw 'Not enough arguments supplied for given headings:\n' +
+      EXPECTED_COLOR(headings.join(' | ')) +
+      '\n\n' +
+      'Received:\n' +
+      RECEIVED_COLOR(pretty(data)) +
+      '\n\n' +
+      `Missing ${RECEIVED_COLOR(missingData.toString())} ${pluralize(
+        'argument',
+        missingData,
+      )}`;
+  }
+};
+
+const pluralize = (word: string, count: number) =>
+  word + (count === 1 ? '' : 's');

--- a/packages/jest-each/src/validation.ts
+++ b/packages/jest-each/src/validation.ts
@@ -8,7 +8,9 @@
 
 import chalk from 'chalk';
 import pretty from 'pretty-format';
-import {TemplateData} from '@jest/types/build/Global';
+import {Global} from '@jest/types';
+
+type TemplateData = Global.TemplateData;
 
 const EXPECTED_COLOR = chalk.green;
 const RECEIVED_COLOR = chalk.red;

--- a/packages/jest-types/src/Global.ts
+++ b/packages/jest-types/src/Global.ts
@@ -16,8 +16,19 @@ export type BlockName = string;
 // TODO: Get rid of this at some point
 type JasmineType = {_DEFAULT_TIMEOUT_INTERVAL?: number; addMatchers: Function};
 
-// TODO Replace with actual type when `jest-each` is ready
-type Each = () => void;
+export type Col = unknown;
+export type Row = Array<Col>;
+export type Table = Array<Row>;
+export type ArrayTable = Table | Row;
+export type TemplateTable = TemplateStringsArray;
+export type TemplateData = Array<unknown>;
+export type EachTable = ArrayTable | TemplateTable;
+export type EachTestFn = (...args: any[]) => Promise<any> | void | undefined;
+
+type Each = (
+  table: EachTable,
+  ...taggedTemplateData: Array<unknown>
+) => (title: string, test: EachTestFn, timeout?: number) => void;
 
 export interface ItBase {
   (testName: TestName, fn: TestFn, timeout?: number): void;

--- a/packages/jest-types/src/Global.ts
+++ b/packages/jest-types/src/Global.ts
@@ -23,7 +23,9 @@ export type ArrayTable = Table | Row;
 export type TemplateTable = TemplateStringsArray;
 export type TemplateData = Array<unknown>;
 export type EachTable = ArrayTable | TemplateTable;
-export type EachTestFn = (...args: any[]) => Promise<any> | void | undefined;
+export type EachTestFn = (
+  ...args: Array<any>
+) => Promise<any> | void | undefined;
 
 type Each = (
   table: EachTable,


### PR DESCRIPTION
## Summary

This PR refactors `jest-each` to make it more modular and have better type definitions both of which I am hoping will make it easier to maintain.

## Test plan

All existing tests (unit and e2e) should still pass.