### PR TITLE
Fix test retries that contain snapshots

### DIFF
--- a/packages/expect/src/types.ts
+++ b/packages/expect/src/types.ts
@@ -44,6 +44,7 @@ export type MatcherState = {
   isExpectingAssertions?: boolean;
   isNot: boolean;
   promise: string;
+  snapshotState: any;
   suppressedErrors: Array<Error>;
   testPath?: Config.Path;
   utils: typeof jestMatcherUtils & {


### PR DESCRIPTION
## Summary

WIP DO NOT MERGE

This is an exploratory PR to solve the problem of snapshot data being written multiple times when tests are retried.

Fixes #7493 
Closes https://github.com/facebook/jest/pull/8015

## Test plan

Nothing at the moment aside from the existing test suite. Collecting feedback with this PR on the approach.