### PR TITLE
Added missing TextEncoder and TextDecoder to jest-envirotment-node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Fixes
 
+- `[jest-environment-node]` Add mising globals: TextEncoder and TextDecoder ([#8022](https://github.com/facebook/jest/pull/8022))
 - `[jest-cli]` Fix prototype pollution vulnerability in dependency ([#7904](https://github.com/facebook/jest/pull/7904))
 - `[jest-cli]` Refactor `-o` and `--coverage` combined ([#7611](https://github.com/facebook/jest/pull/7611))
 - `[expect]` Fix custom async matcher stack trace ([#7652](https://github.com/facebook/jest/pull/7652))

--- a/packages/jest-environment-node/src/index.ts
+++ b/packages/jest-environment-node/src/index.ts
@@ -43,7 +43,10 @@ class NodeEnvironment implements JestEnvironment {
       global.URLSearchParams = URLSearchParams;
     }
     // TextDecoder and TextDecoder are global in Node >= 11
-    if (typeof TextEncoder !== 'undefined' && typeof TextDecoder !== 'undefined') {
+    if (
+      typeof TextEncoder !== 'undefined' &&
+      typeof TextDecoder !== 'undefined'
+    ) {
       /* global TextEncoder, TextDecoder */
       global.TextEncoder = TextEncoder;
       global.TextDecoder = TextDecoder;

--- a/packages/jest-environment-node/src/index.ts
+++ b/packages/jest-environment-node/src/index.ts
@@ -42,6 +42,12 @@ class NodeEnvironment implements JestEnvironment {
       global.URL = URL;
       global.URLSearchParams = URLSearchParams;
     }
+    // TextDecoder and TextDecoder are global in Node >= 11
+    if (typeof TextEncoder !== 'undefined' && typeof TextDecoder !== 'undefined') {
+      /* global TextEncoder, TextDecoder */
+      global.TextEncoder = TextEncoder;
+      global.TextDecoder = TextDecoder;
+    }
     installCommonGlobals(global, config.globals);
     this.moduleMocker = new ModuleMocker(global);
 


### PR DESCRIPTION
## Summary
Added missing globals to jest-environment-node. Use the same approach as the URL. 

These were added in node 11:  https://nodejs.org/api/globals.html#globals_textdecoder

## Test plan
I tested locally with yarn link. I am not sure if pipeline have node11?

