### PR TITLE
WIP fix performance regression

### DIFF
--- a/packages/jest-message-util/package.json
+++ b/packages/jest-message-util/package.json
@@ -17,13 +17,13 @@
     "@jest/types": "^24.1.0",
     "@types/stack-utils": "^1.0.1",
     "chalk": "^2.0.1",
-    "micromatch": "^3.1.10",
+    "micromatch": "^2.3.11",
     "slash": "^2.0.0",
     "stack-utils": "^1.0.1"
   },
   "devDependencies": {
     "@types/babel__code-frame": "^7.0.0",
-    "@types/micromatch": "^3.1.0",
+    "@types/micromatch": "^2.3.11",
     "@types/slash": "^2.0.0"
   },
   "gitHead": "634e5a54f46b2a62d1dc81a170562e6f4e55ad60"

--- a/packages/jest-message-util/src/index.ts
+++ b/packages/jest-message-util/src/index.ts
@@ -217,7 +217,7 @@ const formatPaths = (
   if (
     (config.testMatch &&
       config.testMatch.length &&
-      micromatch.some(filePath, config.testMatch)) ||
+      micromatch.any(filePath, config.testMatch)) ||
     filePath === relativeTestPath
   ) {
     filePath = chalk.reset.cyan(filePath);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

Note: This is more of a PR to discuss how to deal with this problem and not one to merge in the current form, I'd really like to avoid downgrading `micromatch` again.

## Summary

https://github.com/facebook/jest/issues/6783 and https://github.com/facebook/jest/issues/7963 reported severe performance regressions, especially on reruns in watch mode.
I profiled the issue and found that the key difference is the time it takes to `require` the dependency tree of `braces`, which we use via `jest-{runtime,jasmine2} > jest-message-util > micromatch`. @gsteacy noticed this in https://github.com/facebook/jest/issues/6783#issuecomment-410215339 but was testing reruns specifically, which had other factors such as https://github.com/facebook/jest/pull/6647 playing into it, so the effect of micromatch was not further investigated.
micromatch 3 uses braces 2, while micromatch 2 uses braces 1. Here's some data to back up that this is the (primary) culprit for the regression.

Profile subtree for `require('braces')` on the example repo from #7963:
`jest@22.4.4`:
![image](https://user-images.githubusercontent.com/16069751/53699293-dd889900-3de6-11e9-84cb-bb6a99eb8431.png)
`jest@24.1.0`:
![image](https://user-images.githubusercontent.com/16069751/53699299-f1cc9600-3de6-11e9-8780-31dfeb6a6c17.png)
`jest` linked from this branch:
![image](https://user-images.githubusercontent.com/16069751/53699324-6bfd1a80-3de7-11e9-96c4-b0e48b9755db.png)
Exported cpuprofiles https://gist.github.com/jeysal/6ed666edbb554150310d625ae4c7ee3e

Dependency trees:
`micromatch@2`: https://npm.anvaka.com/#/view/2d/micromatch/2.3.11 (38 nodes)
`micromatch@3`: https://npm.anvaka.com/#/view/2d/micromatch/3.1.10 (83 nodes)

More specifically:
`braces@1`: https://npm.anvaka.com/#/view/2d/braces/1.8.5 (15 nodes)
`braces@2`: https://npm.anvaka.com/#/view/2d/braces/2.3.2 (74 nodes)

`time node -e 'require("micromatch")'`
`micromatch@2`: ~240ms
`micromatch@3`: ~500ms

Reruns on #7963 / #6783: *
`jest@24.1.0`: 4.5s / 1.7s
`jest` linked from this branch: <0.1s / <0.1s

* This is an indirect consequence due to Jest deciding not to `runInBand` because the test is never <1s with the `braces` initialization time. It could also be fixed by reusing workers to avoid the reloading of all the runtime modules.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
