### PR TITLE
expect: Improve report when matcher fails, part 12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `[expect]`: Improve report when matcher fails, part 9 ([#7940](https://github.com/facebook/jest/pull/7940))
 - `[expect]`: Improve report when matcher fails, part 10 ([#7960](https://github.com/facebook/jest/pull/7960))
 - `[expect]`: Improve report when matcher fails, part 11 ([#8008](https://github.com/facebook/jest/pull/8008))
+- `[expect]`: Improve report when matcher fails, part 12 ([#8033](https://github.com/facebook/jest/pull/8033))
 - `[pretty-format]` Support `React.memo` ([#7891](https://github.com/facebook/jest/pull/7891))
 - `[jest-config]` Print error information on preset normalization error ([#7935](https://github.com/facebook/jest/pull/7935))
 - `[jest-haste-map]` Add `skipPackageJson` option ([#7778](https://github.com/facebook/jest/pull/7778))

--- a/packages/expect/src/__tests__/__snapshots__/toThrowMatchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/toThrowMatchers.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`.toThrow() asymmetric any-Class fail isNot false 1`] = `
+exports[`toThrow asymmetric any-Class fail isNot false 1`] = `
 "<dim>expect(</><red>received</><dim>).</>toThrow<dim>(</><green>expected</><dim>)</>
 
 Expected asymmetric matcher: <green>Any<Err2></>
@@ -11,10 +11,10 @@ Received message: <red>\\"apple\\"</>
       <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
 `;
 
-exports[`.toThrow() asymmetric any-Class fail isNot true 1`] = `
+exports[`toThrow asymmetric any-Class fail isNot true 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrow<dim>(</><green>expected</><dim>)</>
 
-Expected asymmetric matcher: <green>Any<Err></>
+Expected asymmetric matcher: not <green>Any<Err></>
 
 Received name:    <red>\\"Error\\"</>
 Received message: <red>\\"apple\\"</>
@@ -22,7 +22,7 @@ Received message: <red>\\"apple\\"</>
       <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
 `;
 
-exports[`.toThrow() asymmetric anything fail isNot false 1`] = `
+exports[`toThrow asymmetric anything fail isNot false 1`] = `
 "<dim>expect(</><red>received</><dim>).</>toThrow<dim>(</><green>expected</><dim>)</>
 
 Expected asymmetric matcher: <green>Anything</>
@@ -31,10 +31,10 @@ Thrown value: <red>null</>
 "
 `;
 
-exports[`.toThrow() asymmetric anything fail isNot true 1`] = `
+exports[`toThrow asymmetric anything fail isNot true 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrow<dim>(</><green>expected</><dim>)</>
 
-Expected asymmetric matcher: <green>Anything</>
+Expected asymmetric matcher: not <green>Anything</>
 
 Received name:    <red>\\"Error\\"</>
 Received message: <red>\\"apple\\"</>
@@ -42,7 +42,7 @@ Received message: <red>\\"apple\\"</>
       <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
 `;
 
-exports[`.toThrow() asymmetric no-symbol fail isNot false 1`] = `
+exports[`toThrow asymmetric no-symbol fail isNot false 1`] = `
 "<dim>expect(</><red>received</><dim>).</>toThrow<dim>(</><green>expected</><dim>)</>
 
 Expected asymmetric matcher: <green>{\\"asymmetricMatch\\": [Function asymmetricMatch]}</>
@@ -53,10 +53,10 @@ Received message: <red>\\"apple\\"</>
       <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
 `;
 
-exports[`.toThrow() asymmetric no-symbol fail isNot true 1`] = `
+exports[`toThrow asymmetric no-symbol fail isNot true 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrow<dim>(</><green>expected</><dim>)</>
 
-Expected asymmetric matcher: <green>{\\"asymmetricMatch\\": [Function asymmetricMatch]}</>
+Expected asymmetric matcher: not <green>{\\"asymmetricMatch\\": [Function asymmetricMatch]}</>
 
 Received name:    <red>\\"Error\\"</>
 Received message: <red>\\"apple\\"</>
@@ -64,7 +64,7 @@ Received message: <red>\\"apple\\"</>
       <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
 `;
 
-exports[`.toThrow() asymmetric objectContaining fail isNot false 1`] = `
+exports[`toThrow asymmetric objectContaining fail isNot false 1`] = `
 "<dim>expect(</><red>received</><dim>).</>toThrow<dim>(</><green>expected</><dim>)</>
 
 Expected asymmetric matcher: <green>ObjectContaining {\\"name\\": \\"NotError\\"}</>
@@ -75,10 +75,10 @@ Received message: <red>\\"apple\\"</>
       <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
 `;
 
-exports[`.toThrow() asymmetric objectContaining fail isNot true 1`] = `
+exports[`toThrow asymmetric objectContaining fail isNot true 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrow<dim>(</><green>expected</><dim>)</>
 
-Expected asymmetric matcher: <green>ObjectContaining {\\"name\\": \\"Error\\"}</>
+Expected asymmetric matcher: not <green>ObjectContaining {\\"name\\": \\"Error\\"}</>
 
 Received name:    <red>\\"Error\\"</>
 Received message: <red>\\"apple\\"</>
@@ -86,7 +86,7 @@ Received message: <red>\\"apple\\"</>
       <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
 `;
 
-exports[`.toThrow() error class did not throw at all 1`] = `
+exports[`toThrow error class did not throw at all 1`] = `
 "<dim>expect(</><red>received</><dim>).</>toThrow<dim>(</><green>expected</><dim>)</>
 
 Expected name: <green>\\"Err\\"</>
@@ -94,7 +94,7 @@ Expected name: <green>\\"Err\\"</>
 Received function did not throw"
 `;
 
-exports[`.toThrow() error class threw, but class did not match (error) 1`] = `
+exports[`toThrow error class threw, but class did not match (error) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>toThrow<dim>(</><green>expected</><dim>)</>
 
 Expected name: <green>\\"Err2\\"</>
@@ -105,7 +105,7 @@ Received message: <red>\\"apple\\"</>
       <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
 `;
 
-exports[`.toThrow() error class threw, but class did not match (non-error falsey) 1`] = `
+exports[`toThrow error class threw, but class did not match (non-error falsey) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>toThrow<dim>(</><green>expected</><dim>)</>
 
 Expected name: <green>\\"Err2\\"</>
@@ -114,7 +114,7 @@ Received value: <red>undefined</>
 "
 `;
 
-exports[`.toThrow() error class threw, but class should not match (error) 1`] = `
+exports[`toThrow error class threw, but class should not match (error) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrow<dim>(</><green>expected</><dim>)</>
 
 Expected name: <green>\\"Err\\"</>
@@ -125,7 +125,7 @@ Received message: <red>\\"apple\\"</>
       <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
 `;
 
-exports[`.toThrow() error-message fail isNot false 1`] = `
+exports[`toThrow error-message fail isNot false 1`] = `
 "<dim>expect(</><red>received</><dim>).</>toThrow<dim>(</><green>expected</><dim>)</>
 
 Expected message: <green>\\"apple\\"</>
@@ -133,22 +133,21 @@ Received message: <red>\\"banana\\"</>
 "
 `;
 
-exports[`.toThrow() error-message fail isNot true 1`] = `
+exports[`toThrow error-message fail isNot true 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrow<dim>(</><green>expected</><dim>)</>
 
-Expected message: <green>\\"apple\\"</>
-Received message: <red>\\"apple\\"</>
+Expected message: not <green>\\"Invalid array length\\"</>
 "
 `;
 
-exports[`.toThrow() expected is undefined threw, but should not have (non-error falsey) 1`] = `
+exports[`toThrow expected is undefined threw, but should not have (non-error falsey) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrow<dim>()</>
 
 Thrown value: <red>null</>
 "
 `;
 
-exports[`.toThrow() invalid actual 1`] = `
+exports[`toThrow invalid actual 1`] = `
 "<dim>expect(</><red>received</><dim>).</>toThrow<dim>()</>
 
 <bold>Matcher error</>: <red>received</> value must be a function
@@ -157,7 +156,7 @@ Received has type:  string
 Received has value: <red>\\"a string\\"</>"
 `;
 
-exports[`.toThrow() invalid arguments 1`] = `
+exports[`toThrow invalid arguments 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrow<dim>(</><green>expected</><dim>)</>
 
 <bold>Matcher error</>: <green>expected</> value must be a string or regular expression or class or error
@@ -166,13 +165,13 @@ Expected has type:  number
 Expected has value: <green>111</>"
 `;
 
-exports[`.toThrow() promise/async throws if Error-like object is returned did not throw at all 1`] = `
+exports[`toThrow promise/async throws if Error-like object is returned did not throw at all 1`] = `
 "<dim>expect(</><red>received</><dim>).</>rejects<dim>.</>toThrow<dim>()</>
 
 Received function did not throw"
 `;
 
-exports[`.toThrow() promise/async throws if Error-like object is returned threw, but class did not match 1`] = `
+exports[`toThrow promise/async throws if Error-like object is returned threw, but class did not match 1`] = `
 "<dim>expect(</><red>received</><dim>).</>rejects<dim>.</>toThrow<dim>(</><green>expected</><dim>)</>
 
 Expected name: <green>\\"Err2\\"</>
@@ -183,7 +182,7 @@ Received message: <red>\\"async apple\\"</>
       <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
 `;
 
-exports[`.toThrow() promise/async throws if Error-like object is returned threw, but should not have 1`] = `
+exports[`toThrow promise/async throws if Error-like object is returned threw, but should not have 1`] = `
 "<dim>expect(</><red>received</><dim>).</>rejects<dim>.</>not<dim>.</>toThrow<dim>()</>
 
 Error name:    <red>\\"Error\\"</>
@@ -192,7 +191,7 @@ Error message: <red>\\"async apple\\"</>
       <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
 `;
 
-exports[`.toThrow() regexp did not throw at all 1`] = `
+exports[`toThrow regexp did not throw at all 1`] = `
 "<dim>expect(</><red>received</><dim>).</>toThrow<dim>(</><green>expected</><dim>)</>
 
 Expected pattern: <green>/apple/</>
@@ -200,7 +199,7 @@ Expected pattern: <green>/apple/</>
 Received function did not throw"
 `;
 
-exports[`.toThrow() regexp threw, but message did not match (error) 1`] = `
+exports[`toThrow regexp threw, but message did not match (error) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>toThrow<dim>(</><green>expected</><dim>)</>
 
 Expected pattern: <green>/banana/</>
@@ -209,7 +208,7 @@ Received message: <red>\\"apple\\"</>
       <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
 `;
 
-exports[`.toThrow() regexp threw, but message did not match (non-error falsey) 1`] = `
+exports[`toThrow regexp threw, but message did not match (non-error falsey) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>toThrow<dim>(</><green>expected</><dim>)</>
 
 Expected pattern: <green>/^[123456789]\\\\d*/</>
@@ -217,24 +216,24 @@ Received value:   <red>0</>
 "
 `;
 
-exports[`.toThrow() regexp threw, but message should not match (error) 1`] = `
+exports[`toThrow regexp threw, but message should not match (error) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrow<dim>(</><green>expected</><dim>)</>
 
-Expected pattern: <green>/apple/</>
-Received message: <red>\\"apple\\"</>
+Expected pattern: not <green>/ array /</>
+Received message:     <red>\\"Invalid<inverse> array </>length\\"</>
 
       <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
 `;
 
-exports[`.toThrow() regexp threw, but message should not match (non-error truthy) 1`] = `
+exports[`toThrow regexp threw, but message should not match (non-error truthy) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrow<dim>(</><green>expected</><dim>)</>
 
-Expected pattern: <green>/^[123456789]\\\\d*/</>
-Received value:   <red>404</>
+Expected pattern: not <green>/^[123456789]\\\\d*/</>
+Received value:       <red>404</>
 "
 `;
 
-exports[`.toThrow() strings did not throw at all 1`] = `
+exports[`toThrow substring did not throw at all 1`] = `
 "<dim>expect(</><red>received</><dim>).</>toThrow<dim>(</><green>expected</><dim>)</>
 
 Expected substring: <green>\\"apple\\"</>
@@ -242,7 +241,7 @@ Expected substring: <green>\\"apple\\"</>
 Received function did not throw"
 `;
 
-exports[`.toThrow() strings threw, but message did not match (error) 1`] = `
+exports[`toThrow substring threw, but message did not match (error) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>toThrow<dim>(</><green>expected</><dim>)</>
 
 Expected substring: <green>\\"banana\\"</>
@@ -251,7 +250,7 @@ Received message:   <red>\\"apple\\"</>
       <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
 `;
 
-exports[`.toThrow() strings threw, but message did not match (non-error falsey) 1`] = `
+exports[`toThrow substring threw, but message did not match (non-error falsey) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>toThrow<dim>(</><green>expected</><dim>)</>
 
 Expected substring: <green>\\"Server Error\\"</>
@@ -259,24 +258,24 @@ Received value:     <red>\\"\\"</>
 "
 `;
 
-exports[`.toThrow() strings threw, but message should not match (error) 1`] = `
+exports[`toThrow substring threw, but message should not match (error) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrow<dim>(</><green>expected</><dim>)</>
 
-Expected substring: <green>\\"apple\\"</>
-Received message:   <red>\\"apple\\"</>
+Expected substring: not <green>\\"array\\"</>
+Received message:       <red>\\"Invalid <inverse>array</> length\\"</>
 
       <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
 `;
 
-exports[`.toThrow() strings threw, but message should not match (non-error truthy) 1`] = `
+exports[`toThrow substring threw, but message should not match (non-error truthy) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrow<dim>(</><green>expected</><dim>)</>
 
-Expected substring: <green>\\"Server Error\\"</>
-Received value:     <red>\\"Internal Server Error\\"</>
+Expected substring: not <green>\\"Server Error\\"</>
+Received value:         <red>\\"Internal Server Error\\"</>
 "
 `;
 
-exports[`.toThrowError() asymmetric any-Class fail isNot false 1`] = `
+exports[`toThrowError asymmetric any-Class fail isNot false 1`] = `
 "<dim>expect(</><red>received</><dim>).</>toThrowError<dim>(</><green>expected</><dim>)</>
 
 Expected asymmetric matcher: <green>Any<Err2></>
@@ -287,10 +286,10 @@ Received message: <red>\\"apple\\"</>
       <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
 `;
 
-exports[`.toThrowError() asymmetric any-Class fail isNot true 1`] = `
+exports[`toThrowError asymmetric any-Class fail isNot true 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrowError<dim>(</><green>expected</><dim>)</>
 
-Expected asymmetric matcher: <green>Any<Err></>
+Expected asymmetric matcher: not <green>Any<Err></>
 
 Received name:    <red>\\"Error\\"</>
 Received message: <red>\\"apple\\"</>
@@ -298,7 +297,7 @@ Received message: <red>\\"apple\\"</>
       <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
 `;
 
-exports[`.toThrowError() asymmetric anything fail isNot false 1`] = `
+exports[`toThrowError asymmetric anything fail isNot false 1`] = `
 "<dim>expect(</><red>received</><dim>).</>toThrowError<dim>(</><green>expected</><dim>)</>
 
 Expected asymmetric matcher: <green>Anything</>
@@ -307,10 +306,10 @@ Thrown value: <red>null</>
 "
 `;
 
-exports[`.toThrowError() asymmetric anything fail isNot true 1`] = `
+exports[`toThrowError asymmetric anything fail isNot true 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrowError<dim>(</><green>expected</><dim>)</>
 
-Expected asymmetric matcher: <green>Anything</>
+Expected asymmetric matcher: not <green>Anything</>
 
 Received name:    <red>\\"Error\\"</>
 Received message: <red>\\"apple\\"</>
@@ -318,7 +317,7 @@ Received message: <red>\\"apple\\"</>
       <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
 `;
 
-exports[`.toThrowError() asymmetric no-symbol fail isNot false 1`] = `
+exports[`toThrowError asymmetric no-symbol fail isNot false 1`] = `
 "<dim>expect(</><red>received</><dim>).</>toThrowError<dim>(</><green>expected</><dim>)</>
 
 Expected asymmetric matcher: <green>{\\"asymmetricMatch\\": [Function asymmetricMatch]}</>
@@ -329,10 +328,10 @@ Received message: <red>\\"apple\\"</>
       <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
 `;
 
-exports[`.toThrowError() asymmetric no-symbol fail isNot true 1`] = `
+exports[`toThrowError asymmetric no-symbol fail isNot true 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrowError<dim>(</><green>expected</><dim>)</>
 
-Expected asymmetric matcher: <green>{\\"asymmetricMatch\\": [Function asymmetricMatch]}</>
+Expected asymmetric matcher: not <green>{\\"asymmetricMatch\\": [Function asymmetricMatch]}</>
 
 Received name:    <red>\\"Error\\"</>
 Received message: <red>\\"apple\\"</>
@@ -340,7 +339,7 @@ Received message: <red>\\"apple\\"</>
       <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
 `;
 
-exports[`.toThrowError() asymmetric objectContaining fail isNot false 1`] = `
+exports[`toThrowError asymmetric objectContaining fail isNot false 1`] = `
 "<dim>expect(</><red>received</><dim>).</>toThrowError<dim>(</><green>expected</><dim>)</>
 
 Expected asymmetric matcher: <green>ObjectContaining {\\"name\\": \\"NotError\\"}</>
@@ -351,10 +350,10 @@ Received message: <red>\\"apple\\"</>
       <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
 `;
 
-exports[`.toThrowError() asymmetric objectContaining fail isNot true 1`] = `
+exports[`toThrowError asymmetric objectContaining fail isNot true 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrowError<dim>(</><green>expected</><dim>)</>
 
-Expected asymmetric matcher: <green>ObjectContaining {\\"name\\": \\"Error\\"}</>
+Expected asymmetric matcher: not <green>ObjectContaining {\\"name\\": \\"Error\\"}</>
 
 Received name:    <red>\\"Error\\"</>
 Received message: <red>\\"apple\\"</>
@@ -362,7 +361,7 @@ Received message: <red>\\"apple\\"</>
       <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
 `;
 
-exports[`.toThrowError() error class did not throw at all 1`] = `
+exports[`toThrowError error class did not throw at all 1`] = `
 "<dim>expect(</><red>received</><dim>).</>toThrowError<dim>(</><green>expected</><dim>)</>
 
 Expected name: <green>\\"Err\\"</>
@@ -370,7 +369,7 @@ Expected name: <green>\\"Err\\"</>
 Received function did not throw"
 `;
 
-exports[`.toThrowError() error class threw, but class did not match (error) 1`] = `
+exports[`toThrowError error class threw, but class did not match (error) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>toThrowError<dim>(</><green>expected</><dim>)</>
 
 Expected name: <green>\\"Err2\\"</>
@@ -381,7 +380,7 @@ Received message: <red>\\"apple\\"</>
       <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
 `;
 
-exports[`.toThrowError() error class threw, but class did not match (non-error falsey) 1`] = `
+exports[`toThrowError error class threw, but class did not match (non-error falsey) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>toThrowError<dim>(</><green>expected</><dim>)</>
 
 Expected name: <green>\\"Err2\\"</>
@@ -390,7 +389,7 @@ Received value: <red>undefined</>
 "
 `;
 
-exports[`.toThrowError() error class threw, but class should not match (error) 1`] = `
+exports[`toThrowError error class threw, but class should not match (error) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrowError<dim>(</><green>expected</><dim>)</>
 
 Expected name: <green>\\"Err\\"</>
@@ -401,7 +400,7 @@ Received message: <red>\\"apple\\"</>
       <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
 `;
 
-exports[`.toThrowError() error-message fail isNot false 1`] = `
+exports[`toThrowError error-message fail isNot false 1`] = `
 "<dim>expect(</><red>received</><dim>).</>toThrowError<dim>(</><green>expected</><dim>)</>
 
 Expected message: <green>\\"apple\\"</>
@@ -409,22 +408,21 @@ Received message: <red>\\"banana\\"</>
 "
 `;
 
-exports[`.toThrowError() error-message fail isNot true 1`] = `
+exports[`toThrowError error-message fail isNot true 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrowError<dim>(</><green>expected</><dim>)</>
 
-Expected message: <green>\\"apple\\"</>
-Received message: <red>\\"apple\\"</>
+Expected message: not <green>\\"Invalid array length\\"</>
 "
 `;
 
-exports[`.toThrowError() expected is undefined threw, but should not have (non-error falsey) 1`] = `
+exports[`toThrowError expected is undefined threw, but should not have (non-error falsey) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrowError<dim>()</>
 
 Thrown value: <red>null</>
 "
 `;
 
-exports[`.toThrowError() invalid actual 1`] = `
+exports[`toThrowError invalid actual 1`] = `
 "<dim>expect(</><red>received</><dim>).</>toThrowError<dim>()</>
 
 <bold>Matcher error</>: <red>received</> value must be a function
@@ -433,7 +431,7 @@ Received has type:  string
 Received has value: <red>\\"a string\\"</>"
 `;
 
-exports[`.toThrowError() invalid arguments 1`] = `
+exports[`toThrowError invalid arguments 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrowError<dim>(</><green>expected</><dim>)</>
 
 <bold>Matcher error</>: <green>expected</> value must be a string or regular expression or class or error
@@ -442,13 +440,13 @@ Expected has type:  number
 Expected has value: <green>111</>"
 `;
 
-exports[`.toThrowError() promise/async throws if Error-like object is returned did not throw at all 1`] = `
+exports[`toThrowError promise/async throws if Error-like object is returned did not throw at all 1`] = `
 "<dim>expect(</><red>received</><dim>).</>rejects<dim>.</>toThrowError<dim>()</>
 
 Received function did not throw"
 `;
 
-exports[`.toThrowError() promise/async throws if Error-like object is returned threw, but class did not match 1`] = `
+exports[`toThrowError promise/async throws if Error-like object is returned threw, but class did not match 1`] = `
 "<dim>expect(</><red>received</><dim>).</>rejects<dim>.</>toThrowError<dim>(</><green>expected</><dim>)</>
 
 Expected name: <green>\\"Err2\\"</>
@@ -459,7 +457,7 @@ Received message: <red>\\"async apple\\"</>
       <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
 `;
 
-exports[`.toThrowError() promise/async throws if Error-like object is returned threw, but should not have 1`] = `
+exports[`toThrowError promise/async throws if Error-like object is returned threw, but should not have 1`] = `
 "<dim>expect(</><red>received</><dim>).</>rejects<dim>.</>not<dim>.</>toThrowError<dim>()</>
 
 Error name:    <red>\\"Error\\"</>
@@ -468,7 +466,7 @@ Error message: <red>\\"async apple\\"</>
       <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
 `;
 
-exports[`.toThrowError() regexp did not throw at all 1`] = `
+exports[`toThrowError regexp did not throw at all 1`] = `
 "<dim>expect(</><red>received</><dim>).</>toThrowError<dim>(</><green>expected</><dim>)</>
 
 Expected pattern: <green>/apple/</>
@@ -476,7 +474,7 @@ Expected pattern: <green>/apple/</>
 Received function did not throw"
 `;
 
-exports[`.toThrowError() regexp threw, but message did not match (error) 1`] = `
+exports[`toThrowError regexp threw, but message did not match (error) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>toThrowError<dim>(</><green>expected</><dim>)</>
 
 Expected pattern: <green>/banana/</>
@@ -485,7 +483,7 @@ Received message: <red>\\"apple\\"</>
       <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
 `;
 
-exports[`.toThrowError() regexp threw, but message did not match (non-error falsey) 1`] = `
+exports[`toThrowError regexp threw, but message did not match (non-error falsey) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>toThrowError<dim>(</><green>expected</><dim>)</>
 
 Expected pattern: <green>/^[123456789]\\\\d*/</>
@@ -493,24 +491,24 @@ Received value:   <red>0</>
 "
 `;
 
-exports[`.toThrowError() regexp threw, but message should not match (error) 1`] = `
+exports[`toThrowError regexp threw, but message should not match (error) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrowError<dim>(</><green>expected</><dim>)</>
 
-Expected pattern: <green>/apple/</>
-Received message: <red>\\"apple\\"</>
+Expected pattern: not <green>/ array /</>
+Received message:     <red>\\"Invalid<inverse> array </>length\\"</>
 
       <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
 `;
 
-exports[`.toThrowError() regexp threw, but message should not match (non-error truthy) 1`] = `
+exports[`toThrowError regexp threw, but message should not match (non-error truthy) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrowError<dim>(</><green>expected</><dim>)</>
 
-Expected pattern: <green>/^[123456789]\\\\d*/</>
-Received value:   <red>404</>
+Expected pattern: not <green>/^[123456789]\\\\d*/</>
+Received value:       <red>404</>
 "
 `;
 
-exports[`.toThrowError() strings did not throw at all 1`] = `
+exports[`toThrowError substring did not throw at all 1`] = `
 "<dim>expect(</><red>received</><dim>).</>toThrowError<dim>(</><green>expected</><dim>)</>
 
 Expected substring: <green>\\"apple\\"</>
@@ -518,7 +516,7 @@ Expected substring: <green>\\"apple\\"</>
 Received function did not throw"
 `;
 
-exports[`.toThrowError() strings threw, but message did not match (error) 1`] = `
+exports[`toThrowError substring threw, but message did not match (error) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>toThrowError<dim>(</><green>expected</><dim>)</>
 
 Expected substring: <green>\\"banana\\"</>
@@ -527,7 +525,7 @@ Received message:   <red>\\"apple\\"</>
       <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
 `;
 
-exports[`.toThrowError() strings threw, but message did not match (non-error falsey) 1`] = `
+exports[`toThrowError substring threw, but message did not match (non-error falsey) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>toThrowError<dim>(</><green>expected</><dim>)</>
 
 Expected substring: <green>\\"Server Error\\"</>
@@ -535,19 +533,19 @@ Received value:     <red>\\"\\"</>
 "
 `;
 
-exports[`.toThrowError() strings threw, but message should not match (error) 1`] = `
+exports[`toThrowError substring threw, but message should not match (error) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrowError<dim>(</><green>expected</><dim>)</>
 
-Expected substring: <green>\\"apple\\"</>
-Received message:   <red>\\"apple\\"</>
+Expected substring: not <green>\\"array\\"</>
+Received message:       <red>\\"Invalid <inverse>array</> length\\"</>
 
       <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
 `;
 
-exports[`.toThrowError() strings threw, but message should not match (non-error truthy) 1`] = `
+exports[`toThrowError substring threw, but message should not match (non-error truthy) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrowError<dim>(</><green>expected</><dim>)</>
 
-Expected substring: <green>\\"Server Error\\"</>
-Received value:     <red>\\"Internal Server Error\\"</>
+Expected substring: not <green>\\"Server Error\\"</>
+Received value:         <red>\\"Internal Server Error\\"</>
 "
 `;

--- a/packages/expect/src/__tests__/toThrowMatchers.test.js
+++ b/packages/expect/src/__tests__/toThrowMatchers.test.js
@@ -24,7 +24,7 @@ class customError extends Error {
 }
 
 ['toThrowError', 'toThrow'].forEach(toThrow => {
-  describe('.' + toThrow + '()', () => {
+  describe(toThrow, () => {
     class Err extends customError {}
     class Err2 extends customError {}
 
@@ -35,7 +35,7 @@ class customError extends Error {
       jestExpect(() => {}).not[toThrow]();
     });
 
-    describe('strings', () => {
+    describe('substring', () => {
       it('passes', () => {
         jestExpect(() => {
           throw new customError('apple');
@@ -78,8 +78,8 @@ class customError extends Error {
       test('threw, but message should not match (error)', () => {
         expect(() => {
           jestExpect(() => {
-            throw new customError('apple');
-          }).not[toThrow]('apple');
+            throw new customError('Invalid array length');
+          }).not[toThrow]('array');
         }).toThrowErrorMatchingSnapshot();
       });
 
@@ -130,8 +130,8 @@ class customError extends Error {
       test('threw, but message should not match (error)', () => {
         expect(() => {
           jestExpect(() => {
-            throw new customError('apple');
-          }).not[toThrow](/apple/);
+            throw new customError('Invalid array length');
+          }).not[toThrow](/ array /);
         }).toThrowErrorMatchingSnapshot();
       });
 
@@ -225,10 +225,11 @@ class customError extends Error {
         });
 
         test('isNot true', () => {
+          const message = 'Invalid array length';
           expect(() =>
             jestExpect(() => {
-              throw new ErrorMessage('apple');
-            }).not[toThrow](expected),
+              throw new ErrorMessage(message);
+            }).not[toThrow]({message}),
           ).toThrowErrorMatchingSnapshot();
         });
       });

--- a/packages/expect/src/toThrowMatchers.ts
+++ b/packages/expect/src/toThrowMatchers.ts
@@ -361,7 +361,7 @@ const formatReceived = (
           '\n'
         );
       }
-    } else if (expected !== undefined) {
+    } else if (expected instanceof RegExp) {
       return (
         label +
         printReceivedStringContainExpectedResult(

--- a/packages/expect/src/toThrowMatchers.ts
+++ b/packages/expect/src/toThrowMatchers.ts
@@ -18,6 +18,10 @@ import {
   MatcherHintOptions,
 } from 'jest-matcher-utils';
 import {
+  printReceivedStringContainExpectedResult,
+  printReceivedStringContainExpectedSubstring,
+} from './print';
+import {
   MatchersObject,
   MatcherState,
   RawMatcherFn,
@@ -142,11 +146,15 @@ const toThrowExpectedRegExp = (
     ? () =>
         matcherHint(matcherName, undefined, undefined, options) +
         '\n\n' +
-        formatExpected('Expected pattern: ', expected) +
+        formatExpected('Expected pattern: not ', expected) +
         (thrown !== null && thrown.hasMessage
-          ? formatReceived('Received message: ', thrown, 'message') +
-            formatStack(thrown)
-          : formatReceived('Received value:   ', thrown, 'value'))
+          ? formatReceived(
+              'Received message:     ',
+              thrown,
+              'message',
+              expected,
+            ) + formatStack(thrown)
+          : formatReceived('Received value:       ', thrown, 'value'))
     : () =>
         matcherHint(matcherName, undefined, undefined, options) +
         '\n\n' +
@@ -177,7 +185,7 @@ const toThrowExpectedAsymmetric = (
     ? () =>
         matcherHint(matcherName, undefined, undefined, options) +
         '\n\n' +
-        formatExpected('Expected asymmetric matcher: ', expected) +
+        formatExpected('Expected asymmetric matcher: not ', expected) +
         '\n' +
         (thrown !== null && thrown.hasMessage
           ? formatReceived('Received name:    ', thrown, 'name') +
@@ -212,11 +220,10 @@ const toThrowExpectedObject = (
     ? () =>
         matcherHint(matcherName, undefined, undefined, options) +
         '\n\n' +
-        formatExpected('Expected message: ', expected.message) +
+        formatExpected('Expected message: not ', expected.message) +
         (thrown !== null && thrown.hasMessage
-          ? formatReceived('Received message: ', thrown, 'message') +
-            formatStack(thrown)
-          : formatReceived('Received value:   ', thrown, 'value'))
+          ? formatStack(thrown)
+          : formatReceived('Received value:       ', thrown, 'value'))
     : () =>
         matcherHint(matcherName, undefined, undefined, options) +
         '\n\n' +
@@ -278,11 +285,15 @@ const toThrowExpectedString = (
     ? () =>
         matcherHint(matcherName, undefined, undefined, options) +
         '\n\n' +
-        formatExpected('Expected substring: ', expected) +
+        formatExpected('Expected substring: not ', expected) +
         (thrown !== null && thrown.hasMessage
-          ? formatReceived('Received message:   ', thrown, 'message') +
-            formatStack(thrown)
-          : formatReceived('Received value:     ', thrown, 'value'))
+          ? formatReceived(
+              'Received message:       ',
+              thrown,
+              'message',
+              expected,
+            ) + formatStack(thrown)
+          : formatReceived('Received value:         ', thrown, 'value'))
     : () =>
         matcherHint(matcherName, undefined, undefined, options) +
         '\n\n' +
@@ -324,13 +335,44 @@ const toThrow = (
 const formatExpected = (label: string, expected: unknown) =>
   label + printExpected(expected) + '\n';
 
-const formatReceived = (label: string, thrown: Thrown | null, key: string) => {
+const formatReceived = (
+  label: string,
+  thrown: Thrown | null,
+  key: string,
+  expected?: string | RegExp,
+) => {
   if (thrown === null) {
     return '';
   }
 
   if (key === 'message') {
-    return label + printReceived(thrown.message) + '\n';
+    const message = thrown.message;
+
+    if (typeof expected === 'string') {
+      const index = message.indexOf(expected);
+      if (index !== -1) {
+        return (
+          label +
+          printReceivedStringContainExpectedSubstring(
+            message,
+            index,
+            expected.length,
+          ) +
+          '\n'
+        );
+      }
+    } else if (expected !== undefined) {
+      return (
+        label +
+        printReceivedStringContainExpectedResult(
+          message,
+          typeof expected.exec === 'function' ? expected.exec(message) : null,
+        ) +
+        '\n'
+      );
+    }
+
+    return label + printReceived(message) + '\n';
   }
 
   if (key === 'name') {


### PR DESCRIPTION
## Summary

For `.toThrow` and `.toThrowError` matchers:

* Display `not` following expected label
* Inverse highlight not-expected substring or pattern in received error message
* Omit received error message for object instance because criterion is `===` strict equality

**Residue**

* Improve report for **error class** if received `error.name` is not the same as `error.constructor.name` probably together with `.toBeInstanceOf` matcher
* Breaking change to require `.exec` method in addition to `.test` method for RegExp

For more information, see discussion with @jeysal in #7795

## Test plan

Change error message to more realistic `"Invalid array length"` in 6 `.not` snapshots

Chore in snapshot names:
* replace `.toThrow()` and `.toThrowError()` with `toThrow` and `toThrowError`
* replace `strings` with `substring`

Updated existing tests: all 60 **names** because of chore and **snapshots**:

| expected |  |
| :--- | ---: |
| asymmetric | 8 |
| error-message | 2 |
| regexp | 4 |
| substring | 4 |

See also pictures in following comment.