### PR TITLE
fix: handle process[toString] being readonly on newer nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### Fixes
 
-- `[jest-environment-node]` Add mising globals: TextEncoder and TextDecoder ([#8022](https://github.com/facebook/jest/pull/8022))
+- `[jest-environment-node]` Add missing globals: TextEncoder and TextDecoder ([#8022](https://github.com/facebook/jest/pull/8022))
 - `[jest-cli]` Fix prototype pollution vulnerability in dependency ([#7904](https://github.com/facebook/jest/pull/7904))
 - `[jest-cli]` Refactor `-o` and `--coverage` combined ([#7611](https://github.com/facebook/jest/pull/7611))
 - `[expect]` Fix custom async matcher stack trace ([#7652](https://github.com/facebook/jest/pull/7652))
@@ -24,7 +24,7 @@
 - `[jest-changed-files]` Improve default file selection for Mercurial repos ([#7880](https://github.com/facebook/jest/pull/7880))
 - `[jest-validate]` Fix validating async functions ([#7894](https://github.com/facebook/jest/issues/7894))
 - `[jest-circus]` Fix bug with test.only ([#7888](https://github.com/facebook/jest/pull/7888))
-- `[jest-transform]` Normalize config and remove unecessary checks, convert `TestUtils.js` to TypeScript ([#7801](https://github.com/facebook/jest/pull/7801))
+- `[jest-transform]` Normalize config and remove unnecessary checks, convert `TestUtils.js` to TypeScript ([#7801](https://github.com/facebook/jest/pull/7801))
 - `[jest-worker]` Fix `jest-worker` when using pre-allocated jobs ([#7934](https://github.com/facebook/jest/pull/7934))
 - `[jest-changed-files]` Fix `getChangedFilesFromRoots` to not return parts of the commit messages as if they were files, when the commit messages contained multiple paragraphs ([#7961](https://github.com/facebook/jest/pull/7961))
 - `[jest-haste-map]` Enforce uniqueness in names (mocks and haste ids) ([#8002](https://github.com/facebook/jest/pull/8002))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - `[jest-circus]`: Throw explicit error when errors happen after test is considered complete ([#8005](https://github.com/facebook/jest/pull/8005))
 - `[expect]` Remove duck typing and obsolete browser support code when comparing DOM nodes and use DOM-Level-3 API instead ([#7995](https://github.com/facebook/jest/pull/7995))
 - `[jest-mock]` Adds a type check to `prototype` to allow mocks of objects with a primitive `prototype` property. ([#8040](https://github.com/facebook/jest/pull/8040))
+- `[jest-util]`Make sure to not fail if unable to assign `toStringTag` to the `process` object, which is read only in Node 12 ([#8050](https://github.com/facebook/jest/pull/8050))
 
 ### Chore & Maintenance
 

--- a/packages/jest-util/src/createProcessObject.ts
+++ b/packages/jest-util/src/createProcessObject.ts
@@ -81,9 +81,11 @@ export default function() {
   } catch (e) {
     // Make sure it's actually set instead of potentially ignoring errors
     if (newProcess[Symbol.toStringTag] !== 'process') {
-      throw new Error(
-        'Unable to set toStringTag on process. Please open up an issue at https://github.com/facebook/jest',
-      );
+      e.message =
+        'Unable to set toStringTag on process. Please open up an issue at https://github.com/facebook/jest\n\n' +
+        e.message;
+
+      throw e;
     }
   }
 

--- a/packages/jest-util/src/createProcessObject.ts
+++ b/packages/jest-util/src/createProcessObject.ts
@@ -75,7 +75,17 @@ export default function() {
     keepPrototype: true,
   });
 
-  newProcess[Symbol.toStringTag] = 'process';
+  try {
+    // This fails on Node 12, but it's already set to 'process'
+    newProcess[Symbol.toStringTag] = 'process';
+  } catch (e) {
+    // Make sure it's actually set instead of potentially ignoring errors
+    if (newProcess[Symbol.toStringTag] !== 'process') {
+      throw new Error(
+        'Unable to set toStringTag on process. Please open up an issue at https://github.com/facebook/jest',
+      );
+    }
+  }
 
   // Sequentially execute all constructors over the object.
   let proto = process;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

If we do not do this, Jest fails horribly on Node 12 (tested with yesterday's nightly release)

![image](https://user-images.githubusercontent.com/1404810/53797876-63b3f500-3f37-11e9-8c33-2142c4e2a810.png)

Beyond this failure, the only things that fails are the leak detector tests since `weak` does not compile on Node 12

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Green CI (although we don't test node 12 yet, at least avoid regressions)

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
