### PR TITLE
Add publishConfig to all public packages in preparation for the @jest scope

### DIFF
--- a/packages/babel-jest/package.json
+++ b/packages/babel-jest/package.json
@@ -29,5 +29,8 @@
   "engines": {
     "node": ">= 6"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "b16789230fd45056a7f2fa199bae06c7a1780deb"
 }

--- a/packages/babel-plugin-jest-hoist/package.json
+++ b/packages/babel-plugin-jest-hoist/package.json
@@ -18,5 +18,8 @@
   "devDependencies": {
     "@babel/types": "^7.3.3"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "b16789230fd45056a7f2fa199bae06c7a1780deb"
 }

--- a/packages/babel-preset-jest/package.json
+++ b/packages/babel-preset-jest/package.json
@@ -18,5 +18,8 @@
   "engines": {
     "node": ">= 6"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "b16789230fd45056a7f2fa199bae06c7a1780deb"
 }

--- a/packages/diff-sequences/package.json
+++ b/packages/diff-sequences/package.json
@@ -27,5 +27,8 @@
     "benchmark": "^2.1.4",
     "diff": "^4.0.1"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "634e5a54f46b2a62d1dc81a170562e6f4e55ad60"
 }

--- a/packages/eslint-config-fb-strict/package.json
+++ b/packages/eslint-config-fb-strict/package.json
@@ -23,5 +23,8 @@
   "engines": {
     "node": ">= 6"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "634e5a54f46b2a62d1dc81a170562e6f4e55ad60"
 }

--- a/packages/expect/package.json
+++ b/packages/expect/package.json
@@ -24,5 +24,8 @@
   "engines": {
     "node": ">= 6"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "b16789230fd45056a7f2fa199bae06c7a1780deb"
 }

--- a/packages/jest-changed-files/package.json
+++ b/packages/jest-changed-files/package.json
@@ -20,5 +20,8 @@
   "engines": {
     "node": ">= 6"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "634e5a54f46b2a62d1dc81a170562e6f4e55ad60"
 }

--- a/packages/jest-circus/package.json
+++ b/packages/jest-circus/package.json
@@ -39,5 +39,8 @@
   "engines": {
     "node": ">= 6"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "b16789230fd45056a7f2fa199bae06c7a1780deb"
 }

--- a/packages/jest-cli/package.json
+++ b/packages/jest-cli/package.json
@@ -67,5 +67,8 @@
     "typescript",
     "watch"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "b16789230fd45056a7f2fa199bae06c7a1780deb"
 }

--- a/packages/jest-config/package.json
+++ b/packages/jest-config/package.json
@@ -35,5 +35,8 @@
   "engines": {
     "node": ">= 6"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "b16789230fd45056a7f2fa199bae06c7a1780deb"
 }

--- a/packages/jest-console/package.json
+++ b/packages/jest-console/package.json
@@ -21,5 +21,8 @@
   "engines": {
     "node": ">= 6"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "634e5a54f46b2a62d1dc81a170562e6f4e55ad60"
 }

--- a/packages/jest-core/package.json
+++ b/packages/jest-core/package.json
@@ -80,5 +80,8 @@
     "testing",
     "typescript",
     "watch"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/jest-diff/package.json
+++ b/packages/jest-diff/package.json
@@ -22,5 +22,8 @@
   "engines": {
     "node": ">= 6"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "634e5a54f46b2a62d1dc81a170562e6f4e55ad60"
 }

--- a/packages/jest-docblock/package.json
+++ b/packages/jest-docblock/package.json
@@ -17,5 +17,8 @@
   "engines": {
     "node": ">= 6"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "634e5a54f46b2a62d1dc81a170562e6f4e55ad60"
 }

--- a/packages/jest-each/package.json
+++ b/packages/jest-each/package.json
@@ -27,5 +27,8 @@
   "engines": {
     "node": ">= 6"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "634e5a54f46b2a62d1dc81a170562e6f4e55ad60"
 }

--- a/packages/jest-environment-jsdom/package.json
+++ b/packages/jest-environment-jsdom/package.json
@@ -23,5 +23,8 @@
   "engines": {
     "node": ">= 6"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "634e5a54f46b2a62d1dc81a170562e6f4e55ad60"
 }

--- a/packages/jest-environment-node/package.json
+++ b/packages/jest-environment-node/package.json
@@ -19,5 +19,8 @@
   "engines": {
     "node": ">= 6"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "634e5a54f46b2a62d1dc81a170562e6f4e55ad60"
 }

--- a/packages/jest-environment/package.json
+++ b/packages/jest-environment/package.json
@@ -19,5 +19,8 @@
   "engines": {
     "node": ">= 6"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "b16789230fd45056a7f2fa199bae06c7a1780deb"
 }

--- a/packages/jest-fake-timers/package.json
+++ b/packages/jest-fake-timers/package.json
@@ -18,5 +18,8 @@
   "engines": {
     "node": ">= 6"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "b16789230fd45056a7f2fa199bae06c7a1780deb"
 }

--- a/packages/jest-get-type/package.json
+++ b/packages/jest-get-type/package.json
@@ -13,5 +13,8 @@
   "license": "MIT",
   "main": "build/index.js",
   "types": "build/index.d.ts",
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "634e5a54f46b2a62d1dc81a170562e6f4e55ad60"
 }

--- a/packages/jest-haste-map/package.json
+++ b/packages/jest-haste-map/package.json
@@ -31,5 +31,8 @@
   "engines": {
     "node": ">= 6"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "634e5a54f46b2a62d1dc81a170562e6f4e55ad60"
 }

--- a/packages/jest-jasmine2/package.json
+++ b/packages/jest-jasmine2/package.json
@@ -33,5 +33,8 @@
   "engines": {
     "node": ">= 6"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "b16789230fd45056a7f2fa199bae06c7a1780deb"
 }

--- a/packages/jest-leak-detector/package.json
+++ b/packages/jest-leak-detector/package.json
@@ -19,5 +19,8 @@
   "engines": {
     "node": ">= 6"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "634e5a54f46b2a62d1dc81a170562e6f4e55ad60"
 }

--- a/packages/jest-matcher-utils/package.json
+++ b/packages/jest-matcher-utils/package.json
@@ -18,5 +18,8 @@
     "jest-get-type": "^24.0.0",
     "pretty-format": "^24.0.0"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "634e5a54f46b2a62d1dc81a170562e6f4e55ad60"
 }

--- a/packages/jest-message-util/package.json
+++ b/packages/jest-message-util/package.json
@@ -27,5 +27,8 @@
     "@types/micromatch": "^3.1.0",
     "@types/slash": "^2.0.0"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "634e5a54f46b2a62d1dc81a170562e6f4e55ad60"
 }

--- a/packages/jest-mock/package.json
+++ b/packages/jest-mock/package.json
@@ -16,5 +16,8 @@
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "browser": "build-es5/index.js",
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "634e5a54f46b2a62d1dc81a170562e6f4e55ad60"
 }

--- a/packages/jest-phabricator/package.json
+++ b/packages/jest-phabricator/package.json
@@ -15,5 +15,8 @@
   },
   "license": "MIT",
   "main": "build/index.js",
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "634e5a54f46b2a62d1dc81a170562e6f4e55ad60"
 }

--- a/packages/jest-regex-util/package.json
+++ b/packages/jest-regex-util/package.json
@@ -12,5 +12,8 @@
   "license": "MIT",
   "main": "build/index.js",
   "types": "build/index.d.ts",
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "634e5a54f46b2a62d1dc81a170562e6f4e55ad60"
 }

--- a/packages/jest-repl/package.json
+++ b/packages/jest-repl/package.json
@@ -27,5 +27,8 @@
   "engines": {
     "node": ">= 6"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "b16789230fd45056a7f2fa199bae06c7a1780deb"
 }

--- a/packages/jest-reporters/package.json
+++ b/packages/jest-reporters/package.json
@@ -48,5 +48,8 @@
   },
   "homepage": "https://jestjs.io/",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "b16789230fd45056a7f2fa199bae06c7a1780deb"
 }

--- a/packages/jest-resolve-dependencies/package.json
+++ b/packages/jest-resolve-dependencies/package.json
@@ -26,5 +26,8 @@
   "engines": {
     "node": ">= 6"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "b16789230fd45056a7f2fa199bae06c7a1780deb"
 }

--- a/packages/jest-resolve/package.json
+++ b/packages/jest-resolve/package.json
@@ -25,5 +25,8 @@
   "engines": {
     "node": ">= 6"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "b16789230fd45056a7f2fa199bae06c7a1780deb"
 }

--- a/packages/jest-runner/package.json
+++ b/packages/jest-runner/package.json
@@ -38,5 +38,8 @@
   "engines": {
     "node": ">= 6"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "b16789230fd45056a7f2fa199bae06c7a1780deb"
 }

--- a/packages/jest-runtime/package.json
+++ b/packages/jest-runtime/package.json
@@ -48,5 +48,8 @@
   "engines": {
     "node": ">= 6"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "b16789230fd45056a7f2fa199bae06c7a1780deb"
 }

--- a/packages/jest-serializer/package.json
+++ b/packages/jest-serializer/package.json
@@ -12,5 +12,8 @@
   "license": "MIT",
   "main": "build/index.js",
   "types": "build/index.d.ts",
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "634e5a54f46b2a62d1dc81a170562e6f4e55ad60"
 }

--- a/packages/jest-snapshot/package.json
+++ b/packages/jest-snapshot/package.json
@@ -37,5 +37,8 @@
   "engines": {
     "node": ">= 6"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "b16789230fd45056a7f2fa199bae06c7a1780deb"
 }

--- a/packages/jest-source-map/package.json
+++ b/packages/jest-source-map/package.json
@@ -20,5 +20,8 @@
   "engines": {
     "node": ">= 6"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "634e5a54f46b2a62d1dc81a170562e6f4e55ad60"
 }

--- a/packages/jest-test-result/package.json
+++ b/packages/jest-test-result/package.json
@@ -17,5 +17,8 @@
   "engines": {
     "node": ">= 6"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "634e5a54f46b2a62d1dc81a170562e6f4e55ad60"
 }

--- a/packages/jest-transform/package.json
+++ b/packages/jest-transform/package.json
@@ -36,5 +36,8 @@
   "engines": {
     "node": ">= 6"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "b16789230fd45056a7f2fa199bae06c7a1780deb"
 }

--- a/packages/jest-types/package.json
+++ b/packages/jest-types/package.json
@@ -15,5 +15,8 @@
   "dependencies": {
     "@types/istanbul-lib-coverage": "^1.1.0",
     "@types/yargs": "^12.0.9"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/jest-util/package.json
+++ b/packages/jest-util/package.json
@@ -33,5 +33,8 @@
   "engines": {
     "node": ">= 6"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "634e5a54f46b2a62d1dc81a170562e6f4e55ad60"
 }

--- a/packages/jest-validate/package.json
+++ b/packages/jest-validate/package.json
@@ -24,5 +24,8 @@
   "engines": {
     "node": ">= 6"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "634e5a54f46b2a62d1dc81a170562e6f4e55ad60"
 }

--- a/packages/jest-watcher/package.json
+++ b/packages/jest-watcher/package.json
@@ -30,5 +30,8 @@
   },
   "homepage": "https://jestjs.io/",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "634e5a54f46b2a62d1dc81a170562e6f4e55ad60"
 }

--- a/packages/jest-worker/package.json
+++ b/packages/jest-worker/package.json
@@ -22,5 +22,8 @@
   "engines": {
     "node": ">= 6"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "634e5a54f46b2a62d1dc81a170562e6f4e55ad60"
 }

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -46,5 +46,8 @@
     "typescript",
     "watch"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "b16789230fd45056a7f2fa199bae06c7a1780deb"
 }

--- a/packages/pretty-format/package.json
+++ b/packages/pretty-format/package.json
@@ -30,5 +30,8 @@
   "engines": {
     "node": ">= 6"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "gitHead": "634e5a54f46b2a62d1dc81a170562e6f4e55ad60"
 }


### PR DESCRIPTION
## Summary

This adds the `publishConfig` field to the package.json of all public packages to avoid problems when we migrate to the `@jest` scope.

I don't think a changelog entry is necessary for this.