### PR TITLE
Optimize haste map tracking of deleted files with Watchman.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,8 @@
 
 ### Performance
 
+- `[jest-haste-map]` Optimize haste map tracking of deleted files with Watchman. ([#8056](https://github.com/facebook/jest/pull/8056))
+
 ## 24.1.0
 
 ### Features

--- a/packages/jest-haste-map/src/__tests__/index.test.js
+++ b/packages/jest-haste-map/src/__tests__/index.test.js
@@ -62,8 +62,8 @@ jest.mock('../crawlers/watchman', () =>
     }
 
     return Promise.resolve({
-      removedFiles,
       hasteMap: data,
+      removedFiles,
     });
   }),
 );
@@ -425,8 +425,8 @@ describe('HasteMap', () => {
           });
 
           return Promise.resolve({
-            removedFiles: new Map(),
             hasteMap: data,
+            removedFiles: new Map(),
           });
         });
 
@@ -990,7 +990,7 @@ describe('HasteMap', () => {
       mockImpl(options).then(() => {
         const {data} = options;
         data.files.set('fruits/invalid/file.js', ['', 34, 44, 0, []]);
-        return {removedFiles: new Map(), hasteMap: data};
+        return {hasteMap: data, removedFiles: new Map()};
       }),
     );
     return new HasteMap(defaultConfig)
@@ -1089,8 +1089,8 @@ describe('HasteMap', () => {
         'fruits/Banana.js': ['', 32, 42, 0, [], null],
       });
       return Promise.resolve({
-        removedFiles: new Map(),
         hasteMap: data,
+        removedFiles: new Map(),
       });
     });
 
@@ -1123,8 +1123,8 @@ describe('HasteMap', () => {
         'fruits/Banana.js': ['', 32, 42, 0, [], null],
       });
       return Promise.resolve({
-        removedFiles: new Map(),
         hasteMap: data,
+        removedFiles: new Map(),
       });
     });
 

--- a/packages/jest-haste-map/src/__tests__/index.test.js
+++ b/packages/jest-haste-map/src/__tests__/index.test.js
@@ -40,7 +40,7 @@ jest.mock('../crawlers/watchman', () =>
 
     const {data, ignore, rootDir, roots, computeSha1} = options;
     const list = mockChangedFiles || mockFs;
-    const deprecatedFiles = new Map();
+    const removedFiles = new Map();
 
     data.clocks = mockClocks;
 
@@ -54,7 +54,7 @@ jest.mock('../crawlers/watchman', () =>
         } else {
           const fileData = data.files.get(relativeFilePath);
           if (fileData) {
-            deprecatedFiles.set(relativeFilePath, fileData);
+            removedFiles.set(relativeFilePath, fileData);
             data.files.delete(relativeFilePath);
           }
         }
@@ -62,7 +62,7 @@ jest.mock('../crawlers/watchman', () =>
     }
 
     return Promise.resolve({
-      deprecatedFiles,
+      removedFiles,
       hasteMap: data,
     });
   }),
@@ -425,7 +425,7 @@ describe('HasteMap', () => {
           });
 
           return Promise.resolve({
-            deprecatedFiles: new Map(),
+            removedFiles: new Map(),
             hasteMap: data,
           });
         });
@@ -990,7 +990,7 @@ describe('HasteMap', () => {
       mockImpl(options).then(() => {
         const {data} = options;
         data.files.set('fruits/invalid/file.js', ['', 34, 44, 0, []]);
-        return {deprecatedFiles: new Map(), hasteMap: data};
+        return {removedFiles: new Map(), hasteMap: data};
       }),
     );
     return new HasteMap(defaultConfig)
@@ -1089,7 +1089,7 @@ describe('HasteMap', () => {
         'fruits/Banana.js': ['', 32, 42, 0, [], null],
       });
       return Promise.resolve({
-        deprecatedFiles: new Map(),
+        removedFiles: new Map(),
         hasteMap: data,
       });
     });
@@ -1123,7 +1123,7 @@ describe('HasteMap', () => {
         'fruits/Banana.js': ['', 32, 42, 0, [], null],
       });
       return Promise.resolve({
-        deprecatedFiles: new Map(),
+        removedFiles: new Map(),
         hasteMap: data,
       });
     });

--- a/packages/jest-haste-map/src/crawlers/__tests__/node.test.js
+++ b/packages/jest-haste-map/src/crawlers/__tests__/node.test.js
@@ -178,7 +178,7 @@ describe('node crawler', () => {
     });
   });
 
-  it('returns deprecated files', () => {
+  it('returns removed files', () => {
     process.platform = 'linux';
 
     nodeCrawl = require('../node');

--- a/packages/jest-haste-map/src/crawlers/__tests__/node.test.js
+++ b/packages/jest-haste-map/src/crawlers/__tests__/node.test.js
@@ -114,7 +114,7 @@ describe('node crawler', () => {
       ignore: pearMatcher,
       rootDir,
       roots: ['/project/fruits', '/project/vegtables'],
-    }).then(({hasteMap, deprecatedFiles}) => {
+    }).then(({hasteMap, removedFiles}) => {
       expect(childProcess.spawn).lastCalledWith('find', [
         '/project/fruits',
         '/project/vegtables',
@@ -139,7 +139,7 @@ describe('node crawler', () => {
         }),
       );
 
-      expect(deprecatedFiles).toEqual(new Map());
+      expect(removedFiles).toEqual(new Map());
     });
 
     return promise;
@@ -163,7 +163,7 @@ describe('node crawler', () => {
       ignore: pearMatcher,
       rootDir,
       roots: ['/project/fruits'],
-    }).then(({hasteMap, deprecatedFiles}) => {
+    }).then(({hasteMap, removedFiles}) => {
       expect(hasteMap.files).toEqual(
         createMap({
           'fruits/strawberry.js': ['', 32, 42, 0, [], null],
@@ -174,7 +174,7 @@ describe('node crawler', () => {
       // Make sure it is the *same* unchanged object.
       expect(hasteMap.files.get('fruits/tomato.js')).toBe(tomato);
 
-      expect(deprecatedFiles).toEqual(new Map());
+      expect(removedFiles).toEqual(new Map());
     });
   });
 
@@ -197,14 +197,14 @@ describe('node crawler', () => {
       ignore: pearMatcher,
       rootDir,
       roots: ['/project/fruits'],
-    }).then(({hasteMap, deprecatedFiles}) => {
+    }).then(({hasteMap, removedFiles}) => {
       expect(hasteMap.files).toEqual(
         createMap({
           'fruits/strawberry.js': ['', 32, 42, 0, [], null],
           'fruits/tomato.js': ['', 33, 42, 0, [], null],
         }),
       );
-      expect(deprecatedFiles).toEqual(
+      expect(removedFiles).toEqual(
         createMap({
           'fruits/previouslyExisted.js': ['', 30, 40, 1, [], null],
         }),
@@ -225,14 +225,14 @@ describe('node crawler', () => {
       ignore: pearMatcher,
       rootDir,
       roots: ['/project/fruits'],
-    }).then(({hasteMap, deprecatedFiles}) => {
+    }).then(({hasteMap, removedFiles}) => {
       expect(hasteMap.files).toEqual(
         createMap({
           'fruits/directory/strawberry.js': ['', 33, 42, 0, [], null],
           'fruits/tomato.js': ['', 32, 42, 0, [], null],
         }),
       );
-      expect(deprecatedFiles).toEqual(new Map());
+      expect(removedFiles).toEqual(new Map());
     });
   });
 
@@ -249,14 +249,14 @@ describe('node crawler', () => {
       ignore: pearMatcher,
       rootDir,
       roots: ['/project/fruits'],
-    }).then(({hasteMap, deprecatedFiles}) => {
+    }).then(({hasteMap, removedFiles}) => {
       expect(hasteMap.files).toEqual(
         createMap({
           'fruits/directory/strawberry.js': ['', 33, 42, 0, [], null],
           'fruits/tomato.js': ['', 32, 42, 0, [], null],
         }),
       );
-      expect(deprecatedFiles).toEqual(new Map());
+      expect(removedFiles).toEqual(new Map());
     });
   });
 
@@ -273,9 +273,9 @@ describe('node crawler', () => {
       ignore: pearMatcher,
       rootDir,
       roots: [],
-    }).then(({hasteMap, deprecatedFiles}) => {
+    }).then(({hasteMap, removedFiles}) => {
       expect(hasteMap.files).toEqual(new Map());
-      expect(deprecatedFiles).toEqual(new Map());
+      expect(removedFiles).toEqual(new Map());
     });
   });
 
@@ -291,9 +291,9 @@ describe('node crawler', () => {
       ignore: pearMatcher,
       rootDir,
       roots: ['/error'],
-    }).then(({hasteMap, deprecatedFiles}) => {
+    }).then(({hasteMap, removedFiles}) => {
       expect(hasteMap.files).toEqual(new Map());
-      expect(deprecatedFiles).toEqual(new Map());
+      expect(removedFiles).toEqual(new Map());
     });
   });
 });

--- a/packages/jest-haste-map/src/crawlers/__tests__/watchman.test.js
+++ b/packages/jest-haste-map/src/crawlers/__tests__/watchman.test.js
@@ -221,7 +221,7 @@ describe('watchman watch', () => {
     });
   });
 
-  test('updates file map and deprecatedFile when the clock is given', () => {
+  test('updates file map and removedFiles when the clock is given', () => {
     mockResponse = {
       'list-capabilities': {
         [undefined]: {
@@ -291,7 +291,7 @@ describe('watchman watch', () => {
     });
   });
 
-  test('resets the file map and tracks deprecatedFile when watchman is fresh', () => {
+  test('resets the file map and tracks removedFiles when watchman is fresh', () => {
     const mockTomatoSha1 = '321f6b7e8bf7f29aab89c5e41a555b1b0baa41a9';
 
     mockResponse = {

--- a/packages/jest-haste-map/src/crawlers/__tests__/watchman.test.js
+++ b/packages/jest-haste-map/src/crawlers/__tests__/watchman.test.js
@@ -128,7 +128,7 @@ describe('watchman watch', () => {
       ignore: pearMatcher,
       rootDir: ROOT_MOCK,
       roots: ROOTS,
-    }).then(({hasteMap, deprecatedFiles}) => {
+    }).then(({hasteMap, removedFiles}) => {
       const client = watchman.Client.mock.instances[0];
       const calls = client.command.mock.calls;
 
@@ -167,7 +167,7 @@ describe('watchman watch', () => {
 
       expect(hasteMap.files).toEqual(mockFiles);
 
-      expect(deprecatedFiles).toEqual(new Map());
+      expect(removedFiles).toEqual(new Map());
 
       expect(client.end).toBeCalled();
     }));
@@ -210,14 +210,14 @@ describe('watchman watch', () => {
           : null,
       rootDir: ROOT_MOCK,
       roots: ROOTS,
-    }).then(({hasteMap, deprecatedFiles}) => {
+    }).then(({hasteMap, removedFiles}) => {
       expect(hasteMap.files).toEqual(
         createMap({
           [path.join(DURIAN_RELATIVE, 'foo.1.js')]: ['', 33, 43, 0, [], null],
           [path.join(DURIAN_RELATIVE, 'foo.2.js')]: ['', 33, 43, 0, [], null],
         }),
       );
-      expect(deprecatedFiles).toEqual(new Map());
+      expect(removedFiles).toEqual(new Map());
     });
   });
 
@@ -265,7 +265,7 @@ describe('watchman watch', () => {
       ignore: pearMatcher,
       rootDir: ROOT_MOCK,
       roots: ROOTS,
-    }).then(({hasteMap, deprecatedFiles}) => {
+    }).then(({hasteMap, removedFiles}) => {
       // The object was reused.
       expect(hasteMap.files).toBe(mockFiles);
 
@@ -283,7 +283,7 @@ describe('watchman watch', () => {
         }),
       );
 
-      expect(deprecatedFiles).toEqual(
+      expect(removedFiles).toEqual(
         createMap({
           [TOMATO_RELATIVE]: ['', 31, 41, 0, [], null],
         }),
@@ -349,7 +349,7 @@ describe('watchman watch', () => {
       ignore: pearMatcher,
       rootDir: ROOT_MOCK,
       roots: ROOTS,
-    }).then(({hasteMap, deprecatedFiles}) => {
+    }).then(({hasteMap, removedFiles}) => {
       // The file object was *not* reused.
       expect(hasteMap.files).not.toBe(mockFiles);
 
@@ -375,7 +375,7 @@ describe('watchman watch', () => {
       // Old file objects are not reused if they have a different mtime
       expect(hasteMap.files.get(TOMATO_RELATIVE)).not.toBe(mockTomatoMetadata);
 
-      expect(deprecatedFiles).toEqual(
+      expect(removedFiles).toEqual(
         createMap({
           [MELON_RELATIVE]: ['', 33, 43, 0, [], null],
           [STRAWBERRY_RELATIVE]: ['', 30, 40, 0, [], null],
@@ -443,7 +443,7 @@ describe('watchman watch', () => {
       ignore: pearMatcher,
       rootDir: ROOT_MOCK,
       roots: ROOTS,
-    }).then(({hasteMap, deprecatedFiles}) => {
+    }).then(({hasteMap, removedFiles}) => {
       expect(hasteMap.clocks).toEqual(
         createMap({
           [FRUITS_RELATIVE]: 'c:fake-clock:3',
@@ -458,7 +458,7 @@ describe('watchman watch', () => {
         }),
       );
 
-      expect(deprecatedFiles).toEqual(
+      expect(removedFiles).toEqual(
         createMap({
           [STRAWBERRY_RELATIVE]: ['', 30, 40, 0, [], null],
           [TOMATO_RELATIVE]: ['', 31, 41, 0, [], null],
@@ -506,7 +506,7 @@ describe('watchman watch', () => {
       ignore: pearMatcher,
       rootDir: ROOT_MOCK,
       roots: [...ROOTS, ROOT_MOCK],
-    }).then(({hasteMap, deprecatedFiles}) => {
+    }).then(({hasteMap, removedFiles}) => {
       const client = watchman.Client.mock.instances[0];
       const calls = client.command.mock.calls;
 
@@ -540,7 +540,7 @@ describe('watchman watch', () => {
 
       expect(hasteMap.files).toEqual(new Map());
 
-      expect(deprecatedFiles).toEqual(new Map());
+      expect(removedFiles).toEqual(new Map());
 
       expect(client.end).toBeCalled();
     });

--- a/packages/jest-haste-map/src/crawlers/node.ts
+++ b/packages/jest-haste-map/src/crawlers/node.ts
@@ -171,8 +171,8 @@ export = function nodeCrawl(
       data.files = files;
 
       resolve({
-        removedFiles,
         hasteMap: data,
+        removedFiles,
       });
     };
 

--- a/packages/jest-haste-map/src/crawlers/node.ts
+++ b/packages/jest-haste-map/src/crawlers/node.ts
@@ -136,7 +136,7 @@ function findNative(
 export = function nodeCrawl(
   options: CrawlerOptions,
 ): Promise<{
-  deprecatedFiles: FileData;
+  removedFiles: FileData;
   hasteMap: InternalHasteMap;
 }> {
   if (options.mapper) {
@@ -155,7 +155,7 @@ export = function nodeCrawl(
   return new Promise(resolve => {
     const callback = (list: Result) => {
       const files = new Map();
-      const deprecatedFiles = new Map(data.files);
+      const removedFiles = new Map(data.files);
       list.forEach(fileData => {
         const [filePath, mtime, size] = fileData;
         const relativeFilePath = fastPath.relative(rootDir, filePath);
@@ -166,12 +166,12 @@ export = function nodeCrawl(
           // See ../constants.js; SHA-1 will always be null and fulfilled later.
           files.set(relativeFilePath, ['', mtime, size, 0, [], null]);
         }
-        deprecatedFiles.delete(relativeFilePath);
+        removedFiles.delete(relativeFilePath);
       });
       data.files = files;
 
       resolve({
-        deprecatedFiles,
+        removedFiles,
         hasteMap: data,
       });
     };

--- a/packages/jest-haste-map/src/crawlers/node.ts
+++ b/packages/jest-haste-map/src/crawlers/node.ts
@@ -10,7 +10,12 @@ import path from 'path';
 import {spawn} from 'child_process';
 import H from '../constants';
 import * as fastPath from '../lib/fast_path';
-import {IgnoreMatcher, InternalHasteMap, CrawlerOptions} from '../types';
+import {
+  IgnoreMatcher,
+  InternalHasteMap,
+  CrawlerOptions,
+  FileData,
+} from '../types';
 
 type Result = Array<[/* id */ string, /* mtime */ number, /* size */ number]>;
 
@@ -130,7 +135,10 @@ function findNative(
 
 export = function nodeCrawl(
   options: CrawlerOptions,
-): Promise<InternalHasteMap> {
+): Promise<{
+  deprecatedFiles: FileData;
+  hasteMap: InternalHasteMap;
+}> {
   if (options.mapper) {
     throw new Error(`Option 'mapper' isn't supported by the Node crawler`);
   }
@@ -147,6 +155,7 @@ export = function nodeCrawl(
   return new Promise(resolve => {
     const callback = (list: Result) => {
       const files = new Map();
+      const deprecatedFiles = new Map(data.files);
       list.forEach(fileData => {
         const [filePath, mtime, size] = fileData;
         const relativeFilePath = fastPath.relative(rootDir, filePath);
@@ -157,9 +166,14 @@ export = function nodeCrawl(
           // See ../constants.js; SHA-1 will always be null and fulfilled later.
           files.set(relativeFilePath, ['', mtime, size, 0, [], null]);
         }
+        deprecatedFiles.delete(relativeFilePath);
       });
       data.files = files;
-      resolve(data);
+
+      resolve({
+        deprecatedFiles,
+        hasteMap: data,
+      });
     };
 
     if (forceNodeFilesystemAPI || process.platform === 'win32') {

--- a/packages/jest-haste-map/src/crawlers/watchman.ts
+++ b/packages/jest-haste-map/src/crawlers/watchman.ts
@@ -189,11 +189,15 @@ export = async function watchmanCrawl(
       }
 
       if (!fileData.exists) {
-        // If watchman is not fresh, we will know what specific files were
-        // deleted since we last ran and can track only those files.
-        if (!isFresh && existingFileData) {
-          deprecatedFiles.set(relativeFilePath, existingFileData);
+        // No need to act on files that do not exist and were not tracked.
+        if (existingFileData) {
           files.delete(relativeFilePath);
+
+          // If watchman is not fresh, we will know what specific files were
+          // deleted since we last ran and can track only those files.
+          if (!isFresh) {
+            deprecatedFiles.set(relativeFilePath, existingFileData);
+          }
         }
       } else if (!ignore(filePath)) {
         const mtime =

--- a/packages/jest-haste-map/src/crawlers/watchman.ts
+++ b/packages/jest-haste-map/src/crawlers/watchman.ts
@@ -182,7 +182,7 @@ export = async function watchmanCrawl(
       const relativeFilePath = fastPath.relative(rootDir, filePath);
       const existingFileData = data.files.get(relativeFilePath);
 
-      // If watchman is fresh, the deprecated files map starts with all files
+      // If watchman is fresh, the removed files map starts with all files
       // and we remove them as we verify they still exist.
       if (isFresh && existingFileData && fileData.exists) {
         removedFiles.delete(relativeFilePath);

--- a/packages/jest-haste-map/src/crawlers/watchman.ts
+++ b/packages/jest-haste-map/src/crawlers/watchman.ts
@@ -254,7 +254,7 @@ export = async function watchmanCrawl(
 
   data.files = files;
   return {
-    removedFiles,
     hasteMap: data,
+    removedFiles,
   };
 };

--- a/packages/jest-haste-map/src/crawlers/watchman.ts
+++ b/packages/jest-haste-map/src/crawlers/watchman.ts
@@ -33,7 +33,7 @@ function WatchmanError(error: Error): Error {
 export = async function watchmanCrawl(
   options: CrawlerOptions,
 ): Promise<{
-  deprecatedFiles: FileData;
+  removedFiles: FileData;
   hasteMap: InternalHasteMap;
 }> {
   const fields = ['name', 'exists', 'mtime_ms', 'size'];
@@ -147,7 +147,7 @@ export = async function watchmanCrawl(
   }
 
   let files = data.files;
-  let deprecatedFiles = new Map();
+  let removedFiles = new Map();
   let watchmanFiles: Map<string, any>;
   let isFresh = false;
   try {
@@ -158,7 +158,7 @@ export = async function watchmanCrawl(
     // files.
     if (watchmanFileResults.isFresh) {
       files = new Map();
-      deprecatedFiles = new Map(data.files);
+      removedFiles = new Map(data.files);
       isFresh = true;
     }
 
@@ -185,7 +185,7 @@ export = async function watchmanCrawl(
       // If watchman is fresh, the deprecated files map starts with all files
       // and we remove them as we verify they still exist.
       if (isFresh && existingFileData && fileData.exists) {
-        deprecatedFiles.delete(relativeFilePath);
+        removedFiles.delete(relativeFilePath);
       }
 
       if (!fileData.exists) {
@@ -196,7 +196,7 @@ export = async function watchmanCrawl(
           // If watchman is not fresh, we will know what specific files were
           // deleted since we last ran and can track only those files.
           if (!isFresh) {
-            deprecatedFiles.set(relativeFilePath, existingFileData);
+            removedFiles.set(relativeFilePath, existingFileData);
           }
         }
       } else if (!ignore(filePath)) {
@@ -254,7 +254,7 @@ export = async function watchmanCrawl(
 
   data.files = files;
   return {
-    deprecatedFiles,
+    removedFiles,
     hasteMap: data,
   };
 };

--- a/packages/jest-haste-map/src/index.ts
+++ b/packages/jest-haste-map/src/index.ts
@@ -396,7 +396,7 @@ class HasteMap extends EventEmitter {
    * 2. crawl the file system.
    */
   private _buildFileMap(): Promise<{
-    deprecatedFiles: FileData;
+    removedFiles: FileData;
     hasteMap: InternalHasteMap;
   }> {
     const read = this._options.resetCache ? this._createEmptyMap : this.read;
@@ -619,15 +619,15 @@ class HasteMap extends EventEmitter {
   }
 
   private _buildHasteMap(data: {
-    deprecatedFiles: FileData;
+    removedFiles: FileData;
     hasteMap: InternalHasteMap;
   }): Promise<InternalHasteMap> {
-    const {deprecatedFiles, hasteMap} = data;
+    const {removedFiles, hasteMap} = data;
     const map = new Map();
     const mocks = new Map();
     const promises = [];
 
-    for (const [relativeFilePath, fileMetadata] of deprecatedFiles) {
+    for (const [relativeFilePath, fileMetadata] of removedFiles) {
       this._recoverDuplicates(hasteMap, relativeFilePath, fileMetadata[H.ID]);
     }
 


### PR DESCRIPTION
## Summary

This is a minor PR to improve the performance of tracking deleted files by taking advantage of Watchman when available.

Currently, deleted files are tracked within jest-haste-map by:
1. Making a shallow copy of the Haste Map files before building the file map.
2. Filtering the shallow copy against the generated file map to remove all files that still exist.

Benchmarking this operation against a large locally-generated test Haste Map of 300k~ files with one deletion, the operation currently takes about 150ms on my machine and grows linearly with more files tracked. Using Watchman makes it almost free and only grows with the number of files changed.

I've updated the non-Watchman implementation to also track deleted files within the crawler to keep the interface consistent, although that update is neutral on performance.

## Test plan

- Benchmarked the performance to ensure what looked like a performance gain was one in practice.
- Tested manually with and without Watchman to ensure deleted files were being picked up as expected.
- Added tests for tracking deleted files with Watchman crawler when fresh and when not fresh.
- Added tests for tracking deleted file with Node crawler.
- Updated all related tests.
