### PR TITLE
use react-is instead of manually checking &&typeof in pretty-format

### DIFF
--- a/packages/pretty-format/package.json
+++ b/packages/pretty-format/package.json
@@ -12,7 +12,8 @@
   "author": "James Kyle <me@thejameskyle.com>",
   "dependencies": {
     "ansi-regex": "^4.0.0",
-    "ansi-styles": "^3.2.0"
+    "ansi-styles": "^3.2.0",
+    "react-is": "16.8.3"
   },
   "devDependencies": {
     "immutable": "4.0.0-rc.9",

--- a/packages/pretty-format/src/plugins/ReactElement.js
+++ b/packages/pretty-format/src/plugins/ReactElement.js
@@ -16,11 +16,9 @@ import {
   printProps,
 } from './lib/markup';
 
+import * as ReactIs from 'react-is';
+
 const elementSymbol = Symbol.for('react.element');
-const fragmentSymbol = Symbol.for('react.fragment');
-const forwardRefSymbol = Symbol.for('react.forward_ref');
-const providerSymbol = Symbol.for('react.provider');
-const contextSymbol = Symbol.for('react.context');
 
 // Given element.props.children, or subtree during recursive traversal,
 // return flattened array of children.
@@ -43,19 +41,19 @@ const getType = element => {
   if (typeof type === 'function') {
     return type.displayName || type.name || 'Unknown';
   }
-  if (type === fragmentSymbol) {
+  if (ReactIs.isFragment(element)) {
     return 'React.Fragment';
   }
   if (typeof type === 'object' && type !== null) {
-    if (type.$$typeof === providerSymbol) {
+    if (ReactIs.isContextProvider(element)) {
       return 'Context.Provider';
     }
 
-    if (type.$$typeof === contextSymbol) {
+    if (ReactIs.isContextConsumer(element)) {
       return 'Context.Consumer';
     }
 
-    if (type.$$typeof === forwardRefSymbol) {
+    if (ReactIs.isForwardRef(element)) {
       const functionName = type.render.displayName || type.render.name || '';
 
       return functionName !== ''

--- a/yarn.lock
+++ b/yarn.lock
@@ -10941,6 +10941,11 @@ react-error-overlay@^4.0.1:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-4.0.1.tgz#417addb0814a90f3a7082eacba7cee588d00da89"
   integrity sha512-xXUbDAZkU08aAkjtUvldqbvI04ogv+a1XdHxvYuHPYKIVk/42BIOD0zSKTHAWV4+gDy3yGm283z2072rA2gdtw==
 
+react-is@16.8.3:
+  version "16.8.3"
+  resolved "https://repository.corp.eharmony.com/nexus/repository/npm-all/react-is/-/react-is-16.8.3.tgz#4ad8b029c2a718fc0cfc746c8d4e1b7221e5387d"
+  integrity sha512-Y4rC1ZJmsxxkkPuMLwvKvlL1Zfpbcu+Bf4ZigkHup3v9EfdYhAlWAaVyA19olXq2o2mGn0w+dFKvk3pVVlYcIA==
+
 react-is@^16.5.2:
   version "16.5.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.5.2.tgz#e2a7b7c3f5d48062eb769fcb123505eb928722e3"


### PR DESCRIPTION
## Summary
Instead of manually checking the element's `$$typeof` symbol in the pretty-format package use can use the react-is package which accomplishes the same checks in a nicer way.

## Test plan

Since there is no functionality change existing tests should suffice.
