### PR TITLE
Fix pattern for HG changed files

### DIFF
--- a/packages/jest-changed-files/src/hg.ts
+++ b/packages/jest-changed-files/src/hg.ts
@@ -21,7 +21,7 @@ const adapter: SCMAdapter = {
 
     const args = ['status', '-amnu'];
     if (options && options.withAncestor) {
-      args.push('--rev', `min(!public() & ::.)^`);
+      args.push('--rev', `min((!public() & ::.)+.)^`);
     } else if (options && options.changedSince) {
       args.push('--rev', `ancestor(., ${options.changedSince})`);
     } else if (options && options.lastCommit === true) {


### PR DESCRIPTION
When running in `master` with Mercurial, it throws due to an empty revision set. This PR fixes it, see reply in https://github.com/facebook/jest/pull/7880#issuecomment-468968754.

Tested locally with the use of `hg log --rev`, under bookmarks, branches and public commits.