### PR TITLE
Fix retries and error notification in workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - `[jest-cli]` export functions compatible with `import {default}` ([#8080](https://github.com/facebook/jest/pull/8080))
+- `[jest-worker]`: Fix retries and error notification in workers ([#8079](https://github.com/facebook/jest/pull/8079))
 
 ### Chore & Maintenance
 

--- a/e2e/__tests__/fatalWorkerError.test.ts
+++ b/e2e/__tests__/fatalWorkerError.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import path from 'path';
+import os from 'os';
+import {cleanup, writeFiles} from '../Utils';
+import runJest from '../runJest';
+
+const DIR = path.resolve(os.tmpdir(), 'fatal-worker-error');
+
+beforeEach(() => cleanup(DIR));
+afterAll(() => cleanup(DIR));
+
+const NUMBER_OF_TESTS_TO_FORCE_USING_WORKERS = 25;
+
+test('fails a test that terminates the worker with a fatal error', () => {
+  const testFiles = {
+    '__tests__/fatalWorkerError.test.js': `
+      test('fatal worker error', () => {
+        process.exit(134);
+      });
+    `,
+  };
+
+  for (let i = 0; i <= NUMBER_OF_TESTS_TO_FORCE_USING_WORKERS; i++) {
+    testFiles[`__tests__/test${i}.test.js`] = `
+      test('test ${i}', () => {});
+    `;
+  }
+
+  writeFiles(DIR, {
+    ...testFiles,
+    'package.json': '{}',
+  });
+
+  const {status, stderr} = runJest(DIR);
+  expect(status).toBe(1);
+  expect(stderr).toContain('FAIL __tests__/fatalWorkerError.test.js');
+  expect(stderr).toContain('Call retries were exceeded');
+});

--- a/e2e/__tests__/fatalWorkerError.test.ts
+++ b/e2e/__tests__/fatalWorkerError.test.ts
@@ -37,8 +37,12 @@ test('fails a test that terminates the worker with a fatal error', () => {
     'package.json': '{}',
   });
 
-  const {status, stderr} = runJest(DIR);
-  expect(status).toBe(1);
+  const {status, stderr} = runJest(DIR, ['--maxWorkers=2']);
+
+  const numberOfTestsPassed = (stderr.match(/\bPASS\b/g) || []).length;
+
+  expect(status).not.toBe(0);
+  expect(numberOfTestsPassed).toBe(Object.keys(testFiles).length - 1);
   expect(stderr).toContain('FAIL __tests__/fatalWorkerError.test.js');
   expect(stderr).toContain('Call retries were exceeded');
 });

--- a/packages/jest-worker/src/workers/ChildProcessWorker.ts
+++ b/packages/jest-worker/src/workers/ChildProcessWorker.ts
@@ -159,7 +159,7 @@ export default class ChildProcessWorker implements WorkerInterface {
       // while waiting for a new request (timers, unhandled rejections...)
       this._request = null;
       return onProcessEnd(...args);
-    }
+    };
 
     this._request = request;
     this._retries = 0;

--- a/packages/jest-worker/src/workers/NodeThreadsWorker.ts
+++ b/packages/jest-worker/src/workers/NodeThreadsWorker.ts
@@ -142,7 +142,7 @@ export default class ExperimentalWorker implements WorkerInterface {
       // while waiting for a new request (timers, unhandled rejections...)
       this._request = null;
       return onProcessEnd(...args);
-    }
+    };
 
     this._request = request;
     this._retries = 0;

--- a/packages/jest-worker/src/workers/NodeThreadsWorker.ts
+++ b/packages/jest-worker/src/workers/NodeThreadsWorker.ts
@@ -87,7 +87,6 @@ export default class ExperimentalWorker implements WorkerInterface {
 
     switch (response[0]) {
       case PARENT_MESSAGE_OK:
-        this._request = null;
         this._onProcessEnd(null, response[1]);
         break;
 
@@ -110,7 +109,6 @@ export default class ExperimentalWorker implements WorkerInterface {
           }
         }
 
-        this._request = null;
         this._onProcessEnd(error, null);
         break;
       case PARENT_MESSAGE_SETUP_ERROR:
@@ -120,7 +118,6 @@ export default class ExperimentalWorker implements WorkerInterface {
         error.type = response[1];
         error.stack = response[3];
 
-        this._request = null;
         this._onProcessEnd(error, null);
         break;
       default:
@@ -140,7 +137,12 @@ export default class ExperimentalWorker implements WorkerInterface {
 
   send(request: ChildMessage, onProcessStart: OnStart, onProcessEnd: OnEnd) {
     onProcessStart(this);
-    this._onProcessEnd = onProcessEnd;
+    this._onProcessEnd = (...args) => {
+      // Clean the request to avoid sending past requests to workers that fail
+      // while waiting for a new request (timers, unhandled rejections...)
+      this._request = null;
+      return onProcessEnd(...args);
+    }
 
     this._request = request;
     this._retries = 0;

--- a/packages/jest-worker/src/workers/__tests__/ChildProcessWorker.test.js
+++ b/packages/jest-worker/src/workers/__tests__/ChildProcessWorker.test.js
@@ -151,6 +151,29 @@ it('sends the task to the child process', () => {
   expect(forkInterface.send.mock.calls[1][0]).toEqual(request);
 });
 
+it('resends the task to the child process after a retry', () => {
+  const worker = new Worker({
+    forkOptions: {},
+    maxRetries: 3,
+    workerPath: '/tmp/foo/bar/baz.js',
+  });
+
+  const request = [CHILD_MESSAGE_CALL, false, 'foo', []];
+
+  worker.send(request, () => {}, () => {});
+
+  // Skipping call "0" because it corresponds to the "initialize" one.
+  expect(forkInterface.send.mock.calls[1][0]).toEqual(request);
+
+  const previousForkInterface = forkInterface;
+  forkInterface.emit('exit');
+
+  expect(forkInterface).not.toBe(previousForkInterface);
+
+  // Skipping call "0" because it corresponds to the "initialize" one.
+  expect(forkInterface.send.mock.calls[1][0]).toEqual(request);
+});
+
 it('calls the onProcessStart method synchronously if the queue is empty', () => {
   const worker = new Worker({
     forkOptions: {},

--- a/packages/jest-worker/src/workers/__tests__/NodeThreadsWorker.test.js
+++ b/packages/jest-worker/src/workers/__tests__/NodeThreadsWorker.test.js
@@ -160,6 +160,29 @@ it('sends the task to the child process', () => {
   expect(worker._worker.postMessage.mock.calls[1][0]).toEqual(request);
 });
 
+it('resends the task to the child process after a retry', () => {
+  const worker = new Worker({
+    forkOptions: {},
+    maxRetries: 3,
+    workerPath: '/tmp/foo/bar/baz.js',
+  });
+
+  const request = [CHILD_MESSAGE_CALL, false, 'foo', []];
+
+  worker.send(request, () => {}, () => {});
+
+  // Skipping call "0" because it corresponds to the "initialize" one.
+  expect(worker._worker.postMessage.mock.calls[1][0]).toEqual(request);
+
+  const previousWorker = worker._worker;
+  worker._worker.emit('exit');
+
+  expect(worker._worker).not.toBe(previousWorker);
+
+  // Skipping call "0" because it corresponds to the "initialize" one.
+  expect(worker._worker.postMessage.mock.calls[1][0]).toEqual(request);
+});
+
 it('calls the onProcessStart method synchronously if the queue is empty', () => {
   const worker = new Worker({
     forkOptions: {},


### PR DESCRIPTION
## Summary

Handling of errors in workers in `jest-worker` worker is broken which causes several observable issues:

- Jobs are never retried
- Errors are not notified (as we're waiting for the retries), so Jest hangs when a worker has an error (fixes #8068)

## Test plan

Added unit tests for the workers to make sure messages are re-send to the workers after they're initialized, and an e2e test that makes sure we handle fatal errors in tests properly.