### PR TITLE
fix: jest-worker can return `null` for `getStdout()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- `[jest-worker]` `worker.getStdout()` can return `null`
+
 ### Chore & Maintenance
 
 ### Performance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- `[jest-worker]` `worker.getStdout()` can return `null`
+- `[jest-worker]` `worker.getStdout()` can return `null` ([#8083](https://github.com/facebook/jest/pull/8083))
 
 ### Chore & Maintenance
 

--- a/packages/jest-worker/src/types.ts
+++ b/packages/jest-worker/src/types.ts
@@ -49,8 +49,8 @@ export interface WorkerInterface {
     onProcessEnd: OnEnd,
   ): void;
   getWorkerId(): number;
-  getStderr(): NodeJS.ReadableStream;
-  getStdout(): NodeJS.ReadableStream;
+  getStderr(): NodeJS.ReadableStream | null;
+  getStdout(): NodeJS.ReadableStream | null;
   onExit(exitCode: number): void;
   onMessage(message: ParentMessage): void;
 }

--- a/packages/jest-worker/src/workers/ChildProcessWorker.ts
+++ b/packages/jest-worker/src/workers/ChildProcessWorker.ts
@@ -166,25 +166,15 @@ export default class ChildProcessWorker implements WorkerInterface {
     this._child.send(request);
   }
 
-  getWorkerId(): number {
+  getWorkerId() {
     return this._options.workerId;
   }
 
-  getStdout(): NodeJS.ReadableStream {
-    if (this._child.stdout === null) {
-      throw new Error(
-        'stdout is null - this should never happen. Please open up an issue at https://github.com/facebook/jest',
-      );
-    }
+  getStdout() {
     return this._child.stdout;
   }
 
-  getStderr(): NodeJS.ReadableStream {
-    if (this._child.stderr === null) {
-      throw new Error(
-        'stderr is null - this should never happen. Please open up an issue at https://github.com/facebook/jest',
-      );
-    }
+  getStderr() {
     return this._child.stderr;
   }
 }

--- a/packages/jest-worker/src/workers/NodeThreadsWorker.ts
+++ b/packages/jest-worker/src/workers/NodeThreadsWorker.ts
@@ -150,15 +150,15 @@ export default class ExperimentalWorker implements WorkerInterface {
     this._worker.postMessage(request);
   }
 
-  getWorkerId(): number {
+  getWorkerId() {
     return this._options.workerId;
   }
 
-  getStdout(): NodeJS.ReadableStream {
+  getStdout() {
     return this._worker.stdout;
   }
 
-  getStderr(): NodeJS.ReadableStream {
+  getStderr() {
     return this._worker.stderr;
   }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

A `null` check was added in https://github.com/facebook/jest/pull/8045#discussion_r262154917. However, it most certainly _can_ be `null`, and the type definition for `WorkerInterface` was wrong. `jest-runner` even guards against it: https://github.com/facebook/jest/blob/1fd565168dbf5b49780df959a214148eb35d32db/packages/jest-runner/src/index.ts#L113-L114

Fixes #8078

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Not really a testable change since the unit tests mock out `child_process.fork`. However, the type is now corrected.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
