### PR TITLE
Re-attach stdout and stderr from new processes after retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `[expect]` Compare DOM nodes even if there are multiple Node classes ([#8064](https://github.com/facebook/jest/pull/8064))
 - `[jest-worker]` `worker.getStdout()` can return `null` ([#8083](https://github.com/facebook/jest/pull/8083))
+- `[jest-worker]` Re-attach stdout and stderr from new processes/threads created after retries ([#8087](https://github.com/facebook/jest/pull/8087))
 
 ### Chore & Maintenance
 

--- a/packages/jest-worker/package.json
+++ b/packages/jest-worker/package.json
@@ -17,6 +17,7 @@
   "devDependencies": {
     "@types/merge-stream": "^1.1.2",
     "@types/supports-color": "^5.3.0",
+    "get-stream": "^4.1.0",
     "worker-farm": "^1.6.0"
   },
   "engines": {

--- a/packages/jest-worker/src/workers/ChildProcessWorker.ts
+++ b/packages/jest-worker/src/workers/ChildProcessWorker.ts
@@ -52,8 +52,8 @@ export default class ChildProcessWorker implements WorkerInterface {
   constructor(options: WorkerOptions) {
     this._options = options;
     this._request = null;
-    this._stdout = null;
     this._stderr = null;
+    this._stdout = null;
 
     this.initialize();
   }
@@ -77,6 +77,7 @@ export default class ChildProcessWorker implements WorkerInterface {
       if (!this._stdout) {
         this._stdout = mergeStream();
       }
+
       this._stdout.add(child.stdout);
     }
 
@@ -84,6 +85,7 @@ export default class ChildProcessWorker implements WorkerInterface {
       if (!this._stderr) {
         this._stderr = mergeStream();
       }
+
       this._stderr.add(child.stderr);
     }
 

--- a/packages/jest-worker/src/workers/NodeThreadsWorker.ts
+++ b/packages/jest-worker/src/workers/NodeThreadsWorker.ts
@@ -36,8 +36,8 @@ export default class ExperimentalWorker implements WorkerInterface {
   constructor(options: WorkerOptions) {
     this._options = options;
     this._request = null;
-    this._stdout = null;
     this._stderr = null;
+    this._stdout = null;
 
     this.initialize();
   }
@@ -64,6 +64,7 @@ export default class ExperimentalWorker implements WorkerInterface {
       if (!this._stdout) {
         this._stdout = mergeStream();
       }
+
       this._stdout.add(this._worker.stdout);
     }
 
@@ -71,6 +72,7 @@ export default class ExperimentalWorker implements WorkerInterface {
       if (!this._stderr) {
         this._stderr = mergeStream();
       }
+
       this._stderr.add(this._worker.stderr);
     }
 

--- a/packages/jest-worker/src/workers/__tests__/ChildProcessWorker.test.js
+++ b/packages/jest-worker/src/workers/__tests__/ChildProcessWorker.test.js
@@ -141,6 +141,7 @@ it('provides stdout and stderr from the child processes', async () => {
   forkInterface.emit('exit');
   forkInterface.stdout.end('World!', {encoding: 'utf8'});
   forkInterface.stderr.end('Workers!', {encoding: 'utf8'});
+  forkInterface.emit('exit', 0);
 
   await expect(getStream(stdout)).resolves.toEqual('Hello World!');
   await expect(getStream(stderr)).resolves.toEqual('Jest Workers!');

--- a/packages/jest-worker/src/workers/__tests__/ChildProcessWorker.test.js
+++ b/packages/jest-worker/src/workers/__tests__/ChildProcessWorker.test.js
@@ -9,6 +9,8 @@
 
 import EventEmitter from 'events';
 import supportsColor from 'supports-color';
+import getStream from 'get-stream';
+import {PassThrough} from 'stream';
 
 import {
   CHILD_MESSAGE_CALL,
@@ -30,8 +32,8 @@ beforeEach(() => {
   childProcess.fork.mockImplementation(() => {
     forkInterface = Object.assign(new EventEmitter(), {
       send: jest.fn(),
-      stderr: {},
-      stdout: {},
+      stderr: new PassThrough(),
+      stdout: new PassThrough(),
     });
 
     return forkInterface;
@@ -124,15 +126,24 @@ it('stops initializing the worker after the amount of retries is exceeded', () =
   expect(onProcessEnd.mock.calls[0][1]).toBe(null);
 });
 
-it('provides stdout and stderr fields from the child process', () => {
+it('provides stdout and stderr from the child processes', async () => {
   const worker = new Worker({
     forkOptions: {},
     maxRetries: 3,
     workerPath: '/tmp/foo',
   });
 
-  expect(worker.getStdout()).toBe(forkInterface.stdout);
-  expect(worker.getStderr()).toBe(forkInterface.stderr);
+  const stdout = worker.getStdout();
+  const stderr = worker.getStderr();
+
+  forkInterface.stdout.end('Hello ', {encoding: 'utf8'});
+  forkInterface.stderr.end('Jest ', {encoding: 'utf8'});
+  forkInterface.emit('exit');
+  forkInterface.stdout.end('World!', {encoding: 'utf8'});
+  forkInterface.stderr.end('Workers!', {encoding: 'utf8'});
+
+  await expect(getStream(stdout)).resolves.toEqual('Hello World!');
+  await expect(getStream(stderr)).resolves.toEqual('Jest Workers!');
 });
 
 it('sends the task to the child process', () => {

--- a/packages/jest-worker/src/workers/__tests__/NodeThreadsWorker.test.js
+++ b/packages/jest-worker/src/workers/__tests__/NodeThreadsWorker.test.js
@@ -9,6 +9,8 @@
 
 /* eslint-disable no-new */
 
+import getStream from 'get-stream';
+
 import {
   CHILD_MESSAGE_CALL,
   CHILD_MESSAGE_INITIALIZE,
@@ -24,10 +26,12 @@ beforeEach(() => {
   jest.mock('worker_threads', () => {
     const fakeClass = jest.fn(() => {
       const EventEmitter = require('events');
+      const {PassThrough} = require('stream');
+
       const thread = new EventEmitter();
       thread.postMessage = jest.fn();
-      thread.stdout = 'stdout';
-      thread.stderr = 'stderr';
+      thread.stdout = new PassThrough();
+      thread.stderr = new PassThrough();
       return thread;
     });
 
@@ -134,15 +138,24 @@ it('stops initializing the worker after the amount of retries is exceeded', () =
   expect(onProcessEnd.mock.calls[0][1]).toBe(null);
 });
 
-it('provides stdout and stderr fields from the child process', () => {
+it('provides stdout and stderr from the child processes', async () => {
   const worker = new Worker({
     forkOptions: {},
     maxRetries: 3,
     workerPath: '/tmp/foo',
   });
 
-  expect(worker.getStdout()).toBe('stdout');
-  expect(worker.getStderr()).toBe('stderr');
+  const stdout = worker.getStdout();
+  const stderr = worker.getStderr();
+
+  worker._worker.stdout.end('Hello ', {encoding: 'utf8'});
+  worker._worker.stderr.end('Jest ', {encoding: 'utf8'});
+  worker._worker.emit('exit');
+  worker._worker.stdout.end('World!', {encoding: 'utf8'});
+  worker._worker.stderr.end('Workers!', {encoding: 'utf8'});
+
+  await expect(getStream(stdout)).resolves.toEqual('Hello World!');
+  await expect(getStream(stderr)).resolves.toEqual('Jest Workers!');
 });
 
 it('sends the task to the child process', () => {

--- a/packages/jest-worker/src/workers/__tests__/NodeThreadsWorker.test.js
+++ b/packages/jest-worker/src/workers/__tests__/NodeThreadsWorker.test.js
@@ -153,6 +153,7 @@ it('provides stdout and stderr from the child processes', async () => {
   worker._worker.emit('exit');
   worker._worker.stdout.end('World!', {encoding: 'utf8'});
   worker._worker.stderr.end('Workers!', {encoding: 'utf8'});
+  worker._worker.emit('exit', 0);
 
   await expect(getStream(stdout)).resolves.toEqual('Hello World!');
   await expect(getStream(stderr)).resolves.toEqual('Jest Workers!');


### PR DESCRIPTION
## Summary

A worker pool exposes a unified stdout and stderr resulting from the combination of all the outputs from the workers it contains. The problem is that the workers only expose stdout/stderr from the first child they spawn and never re-attach the output of any subsequent child they might spawn after an initial one dies (for retries).

This changes both worker implementations (child process and node threads) to return a merged stream, resulting of the combination of all their possible children, so that output isn't lost.

## Test plan

Added unit tests for both
