### PR TITLE
Force redirecting stdout to stderr if useStderr is passed

### DIFF
--- a/e2e/__tests__/useStderr.test.ts
+++ b/e2e/__tests__/useStderr.test.ts
@@ -13,26 +13,58 @@ import {cleanup, writeFiles} from '../Utils';
 const DIR = path.resolve(os.tmpdir(), 'use-stderr-test');
 
 beforeEach(() => cleanup(DIR));
-afterEach(() => cleanup(DIR));
+afterAll(() => cleanup(DIR));
 
-test('no tests found message is redirected to stderr', () => {
+const NUMBER_OF_TESTS_TO_FORCE_USING_WORKERS = 25;
+
+function runTest(useStderr: boolean, forceWorkers: boolean) {
+  const additionalTests = {};
+
+  if (forceWorkers) {
+    for (let i = 0; i < NUMBER_OF_TESTS_TO_FORCE_USING_WORKERS; i++) {
+      additionalTests[
+        `__tests__/test${i}.test.js`
+      ] = `test('test ${i}', () => {});`;
+    }
+  }
+
   writeFiles(DIR, {
+    ...additionalTests,
+    '__tests__/test.test.js': `
+      require('../file1');
+      test('file1', () => {
+        console.log('Hello from console');
+        process.stdout.write('Hello from stdout\\n');
+        process.stderr.write('Hello from stderr\\n');
+      });
+    `,
     '.watchmanconfig': '',
     'file1.js': 'module.exports = {}',
     'package.json': JSON.stringify({jest: {testEnvironment: 'node'}}),
   });
-  let stderr;
-  let stdout;
 
-  ({stdout, stderr} = runJest(DIR, ['--useStderr']));
-  expect(stdout).toBe('');
-  expect(stderr).toMatch('No tests found');
+  const {stdout, stderr} = runJest(DIR, [
+    '--verbose',
+    useStderr ? '--useStderr' : '',
+    forceWorkers ? '--maxWorkers=2' : '--runInBand',
+  ]);
 
-  writeFiles(DIR, {
-    '__tests__/test.test.js': `require('../file1'); test('file1', () => {});`,
-  });
+  if (useStderr) {
+    expect(stdout).toBe('');
+  }
 
-  ({stdout, stderr} = runJest(DIR, ['--useStderr']));
-  expect(stdout).toBe('');
+  const generalOutput = useStderr ? stderr : stdout;
+  expect(generalOutput).toContain('Hello from stdout');
+  expect(generalOutput).toContain('Hello from console');
   expect(stderr).toMatch(/PASS.*test\.test\.js/);
+  expect(stderr).toContain('Hello from stderr');
+}
+
+test.each([
+  [true, 'in band'],
+  [false, 'in band'],
+  [true, 'with workers'],
+  [false, 'with workers'],
+])('passes when useStderr is %s, running %s', (useStderr, runMode) => {
+  runTest(useStderr, runMode === 'with workers');
 });

--- a/packages/jest-runner/src/index.ts
+++ b/packages/jest-runner/src/index.ts
@@ -110,8 +110,14 @@ class TestRunner {
       numWorkers: this._globalConfig.maxWorkers,
     }) as WorkerInterface;
 
-    if (worker.getStdout()) worker.getStdout().pipe(process.stdout);
-    if (worker.getStderr()) worker.getStderr().pipe(process.stderr);
+    if (worker.getStdout()) {
+      worker
+        .getStdout()
+        .pipe(this._globalConfig.useStderr ? process.stderr : process.stdout);
+    }
+    if (worker.getStderr()) {
+      worker.getStderr().pipe(process.stderr);
+    }
 
     const mutex = throat(this._globalConfig.maxWorkers);
 


### PR DESCRIPTION
## Summary

Right now anything written to `process.stdout` in a test (or in a worker) goes to stdout even if `useStderr` is passed. This breaks JSON output if a test explicitly writes to stdout or if a worker runs out of memory (v8 prints directly to stdout :S), which we handle correctly making the test fail.

| useStderr | method | real output |
| -- | -- | -- |
| false | console.log | stdout |
| false | process.stdout | stdout |
| false | process.stderr | stderr |
| true | console.log | stderr |
| true | process.stdout | stdout => stderr |
| true | process.stderr | stderr |

## Test plan

Updated tests.