### PR TITLE
Bumps Yarn to 1.15

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,2 +1,1 @@
-
-workspaces-experimental true
+yarn-path ".yarn/releases/yarn-1.15.0.js"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,5 +23,10 @@
     "esModuleInterop": true,
     "resolveJsonModule": true
   },
-  "exclude": ["**/__tests__/**/*", "**/build/**/*", "**/build-es5/**/*"]
+  "exclude": [
+    ".yarn/releases/*",
+    "**/__tests__/**/*",
+    "**/build/**/*",
+    "**/build-es5/**/*"
+  ]
 }


### PR DESCRIPTION
## Summary

This diff uses the `yarn-path` configuration settings to ensure that Jest always run with the specified Yarn release, regardless of the one used in the global environment.

I've also removed `workspaces-experimental` since it's not required anymore.

## Test plan

Ran `yarn -v` in the repo, got `1.15`. CI should print it as well.