### PR TITLE
fix: default bail to boolean instead of number

### DIFF
--- a/packages/jest-config/src/Defaults.ts
+++ b/packages/jest-config/src/Defaults.ts
@@ -14,7 +14,7 @@ const NODE_MODULES_REGEXP = replacePathSepForRegex(NODE_MODULES);
 
 const defaultOptions: Config.DefaultOptions = {
   automock: false,
-  bail: 0,
+  bail: true,
   browser: false,
   cache: true,
   cacheDirectory: getCacheDirectory(),


### PR DESCRIPTION
As of 24.4.0 I get an error when importing defaults due to a type mismatch

```
● Validation Error:

  Option "bail" must be of type:
    boolean
  but instead received:
    number

  Example:
  {
    "bail": false
  }

  Configuration Documentation:
  https://jestjs.io/docs/configuration.html
```

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
