### PR TITLE
Expose throwOnModuleCollision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Features
 
+- `[jest-haste-map]` Expose `throwOnModuleCollision` via `config.haste` ([#8113](https://github.com/facebook/jest/pull/8113))
+
 ### Fixes
 
 ### Chore & Maintenance

--- a/e2e/__tests__/__snapshots__/showConfig.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/showConfig.test.ts.snap
@@ -24,7 +24,8 @@ exports[`--showConfig outputs config info and exits 1`] = `
       "globals": {},
       "haste": {
         "computeSha1": false,
-        "providesModuleNodeModules": []
+        "providesModuleNodeModules": [],
+        "throwOnModuleCollision": false
       },
       "moduleDirectories": [
         "node_modules"

--- a/packages/jest-config/src/Defaults.ts
+++ b/packages/jest-config/src/Defaults.ts
@@ -38,6 +38,7 @@ const defaultOptions: Config.DefaultOptions = {
   haste: {
     computeSha1: false,
     providesModuleNodeModules: [],
+    throwOnModuleCollision: false,
   },
   maxConcurrency: 5,
   moduleDirectories: ['node_modules'],

--- a/packages/jest-config/src/ValidConfig.ts
+++ b/packages/jest-config/src/ValidConfig.ts
@@ -57,6 +57,7 @@ const initialOptions: Config.InitialOptions = {
     hasteImplModulePath: '<rootDir>/haste_impl.js',
     platforms: ['ios', 'android'],
     providesModuleNodeModules: ['react', 'react-native'],
+    throwOnModuleCollision: false,
   },
   json: false,
   lastCommit: false,

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -248,6 +248,7 @@ class Runtime {
       retainAllFiles: false,
       rootDir: config.rootDir,
       roots: config.roots,
+      throwOnModuleCollision: config.haste.throwOnModuleCollision,
       useWatchman: options && options.watchman,
       watch: options && options.watch,
     });

--- a/packages/jest-types/src/Config.ts
+++ b/packages/jest-types/src/Config.ts
@@ -17,6 +17,7 @@ export type HasteConfig = {
   hasteImplModulePath?: string;
   platforms?: Array<string>;
   providesModuleNodeModules: Array<string>;
+  throwOnModuleCollision?: boolean;
 };
 
 export type ReporterConfig = [string, {[key: string]: unknown}];

--- a/types/Config.js
+++ b/types/Config.js
@@ -16,6 +16,7 @@ export type HasteConfig = {|
   hasteImplModulePath?: string,
   platforms?: Array<string>,
   providesModuleNodeModules: Array<string>,
+  throwOnModuleCollision?: boolean,
 |};
 
 export type ReporterConfig = [string, Object];


### PR DESCRIPTION
This will let people configure whether two mocks with the same name should crash or not. However, as other `haste` options, it will not be documented.