### PR TITLE
TypeScript custom matchers declaration snippet

### DIFF
--- a/docs/ExpectAPI.md
+++ b/docs/ExpectAPI.md
@@ -65,7 +65,7 @@ test('numeric ranges', () => {
 });
 ```
 
-Tip: In TypeScript, you can declare the new `toBeWithinRange` matcher like this:
+Tip: In TypeScript, when using `@types/jest` for example, you can declare the new `toBeWithinRange` matcher like this:
 
 ```ts
 declare global {

--- a/docs/ExpectAPI.md
+++ b/docs/ExpectAPI.md
@@ -65,6 +65,18 @@ test('numeric ranges', () => {
 });
 ```
 
+Tip: In TypeScript, you can declare the new `toBeWithinRange` matcher like this:
+
+```ts
+declare global {
+  namespace jest {
+    interface Matchers<R> {
+      toBeWithinRange(a: number, b: number): R
+    }
+  }
+}
+```
+
 #### Async Matchers
 
 `expect.extend` also supports async matchers. Async matchers return a Promise so you will need to await the returned value. Let's use an example matcher to illustrate the usage of them. We are going to implement a matcher called `toBeDivisibleByExternalValue`, where the divisible number is going to be pulled from an external source.

--- a/docs/ExpectAPI.md
+++ b/docs/ExpectAPI.md
@@ -65,13 +65,13 @@ test('numeric ranges', () => {
 });
 ```
 
-Tip: In TypeScript, when using `@types/jest` for example, you can declare the new `toBeWithinRange` matcher like this:
+_Note_: In TypeScript, when using `@types/jest` for example, you can declare the new `toBeWithinRange` matcher like this:
 
 ```ts
 declare global {
   namespace jest {
     interface Matchers<R> {
-      toBeWithinRange(a: number, b: number): R
+      toBeWithinRange(a: number, b: number): R;
     }
   }
 }

--- a/website/versioned_docs/version-22.x/ExpectAPI.md
+++ b/website/versioned_docs/version-22.x/ExpectAPI.md
@@ -61,6 +61,18 @@ test('even and odd numbers', () => {
 });
 ```
 
+_Note_: In TypeScript, when using `@types/jest` for example, you can declare the new `toBeWithinRange` matcher like this:
+
+```ts
+declare global {
+  namespace jest {
+    interface Matchers<R> {
+      toBeWithinRange(a: number, b: number): R;
+    }
+  }
+}
+```
+
 Matchers should return an object with two keys. `pass` indicates whether there was a match or not, and `message` provides a function with no arguments that returns an error message in case of failure. Thus, when `pass` is false, `message` should return the error message for when `expect(x).yourMatcher()` fails. And when `pass` is true, `message` should return the error message for when `expect(x).not.yourMatcher()` fails.
 
 These helper functions and properties can be found on `this` inside a custom matcher:

--- a/website/versioned_docs/version-23.x/ExpectAPI.md
+++ b/website/versioned_docs/version-23.x/ExpectAPI.md
@@ -66,6 +66,18 @@ test('numeric ranges', () => {
 });
 ```
 
+_Note_: In TypeScript, when using `@types/jest` for example, you can declare the new `toBeWithinRange` matcher like this:
+
+```ts
+declare global {
+  namespace jest {
+    interface Matchers<R> {
+      toBeWithinRange(a: number, b: number): R;
+    }
+  }
+}
+```
+
 #### Async Matchers
 
 `expect.extend` also supports async matchers. Async matchers return a Promise so you will need to await the returned value. Let's use an example matcher to illustrate the usage of them. We are going to implement a matcher called `toBeDivisibleByExternalValue`, where the divisible number is going to be pulled from an external source.

--- a/website/versioned_docs/version-24.0/ExpectAPI.md
+++ b/website/versioned_docs/version-24.0/ExpectAPI.md
@@ -66,6 +66,18 @@ test('numeric ranges', () => {
 });
 ```
 
+_Note_: In TypeScript, when using `@types/jest` for example, you can declare the new `toBeWithinRange` matcher like this:
+
+```ts
+declare global {
+  namespace jest {
+    interface Matchers<R> {
+      toBeWithinRange(a: number, b: number): R;
+    }
+  }
+}
+```
+
 #### Async Matchers
 
 `expect.extend` also supports async matchers. Async matchers return a Promise so you will need to await the returned value. Let's use an example matcher to illustrate the usage of them. We are going to implement a matcher called `toBeDivisibleByExternalValue`, where the divisible number is going to be pulled from an external source.


### PR DESCRIPTION
A small note in `expect.extend()` documentation for TypeScript users since it's not obvious how to declare  types for custom marchers. 

Thanks, keep it up!
