### PR TITLE
Add support for bigint to pretty-format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- `[pretty-format]` Print `BigInt` as a readable number instead of `{}` [#8138](https://github.com/facebook/jest/pull/8138)
+
 ### Chore & Maintenance
 
 - `[*]` Remove flow from code base ([#8061](https://github.com/facebook/jest/pull/8061))

--- a/packages/pretty-format/src/__tests__/prettyFormat.test.ts
+++ b/packages/pretty-format/src/__tests__/prettyFormat.test.ts
@@ -209,19 +209,9 @@ describe('prettyFormat()', () => {
     expect(prettyFormat(val)).toEqual('123');
   });
 
-  it('prints a positive bigint', () => {
-    const val = BigInt(123);
-    expect(prettyFormat(val)).toEqual('123n');
-  });
-
   it('prints a negative number', () => {
     const val = -123;
     expect(prettyFormat(val)).toEqual('-123');
-  });
-
-  it('prints a negative bigint', () => {
-    const val = BigInt(-123);
-    expect(prettyFormat(val)).toEqual('-123n');
   });
 
   it('prints zero', () => {
@@ -229,20 +219,33 @@ describe('prettyFormat()', () => {
     expect(prettyFormat(val)).toEqual('0');
   });
 
-  it('prints zero bigint', () => {
-    const val = BigInt(0);
-    expect(prettyFormat(val)).toEqual('0n');
-  });
-
   it('prints negative zero', () => {
     const val = -0;
     expect(prettyFormat(val)).toEqual('-0');
   });
 
-  it('prints negative zero bigint', () => {
-    const val = BigInt(-0);
-    expect(prettyFormat(val)).toEqual('0n');
-  });
+  /* global BigInt */
+  if (typeof BigInt === 'function') {
+    it('prints a positive bigint', () => {
+      const val = BigInt(123);
+      expect(prettyFormat(val)).toEqual('123n');
+    });
+
+    it('prints a negative bigint', () => {
+      const val = BigInt(-123);
+      expect(prettyFormat(val)).toEqual('-123n');
+    });
+
+    it('prints zero bigint', () => {
+      const val = BigInt(0);
+      expect(prettyFormat(val)).toEqual('0n');
+    });
+
+    it('prints negative zero bigint', () => {
+      const val = BigInt(-0);
+      expect(prettyFormat(val)).toEqual('0n');
+    });
+  }
 
   it('prints a date', () => {
     const val = new Date(10e11);

--- a/packages/pretty-format/src/__tests__/prettyFormat.test.ts
+++ b/packages/pretty-format/src/__tests__/prettyFormat.test.ts
@@ -209,9 +209,19 @@ describe('prettyFormat()', () => {
     expect(prettyFormat(val)).toEqual('123');
   });
 
+  it('prints a positive bigint', () => {
+    const val = BigInt(123);
+    expect(prettyFormat(val)).toEqual('123n');
+  });
+
   it('prints a negative number', () => {
     const val = -123;
     expect(prettyFormat(val)).toEqual('-123');
+  });
+
+  it('prints a negative bigint', () => {
+    const val = BigInt(-123);
+    expect(prettyFormat(val)).toEqual('-123n');
   });
 
   it('prints zero', () => {
@@ -219,9 +229,19 @@ describe('prettyFormat()', () => {
     expect(prettyFormat(val)).toEqual('0');
   });
 
+  it('prints zero bigint', () => {
+    const val = BigInt(0);
+    expect(prettyFormat(val)).toEqual('0n');
+  });
+
   it('prints negative zero', () => {
     const val = -0;
     expect(prettyFormat(val)).toEqual('-0');
+  });
+
+  it('prints negative zero bigint', () => {
+    const val = BigInt(-0);
+    expect(prettyFormat(val)).toEqual('0n');
   });
 
   it('prints a date', () => {

--- a/packages/pretty-format/src/index.ts
+++ b/packages/pretty-format/src/index.ts
@@ -72,6 +72,10 @@ function printNumber(val: number): string {
   return Object.is(val, -0) ? '-0' : String(val);
 }
 
+function printBigInt(val: bigint): string {
+  return String(`${val}n`);
+}
+
 function printFunction(val: Function, printFunctionName: boolean): string {
   if (!printFunctionName) {
     return '[Function]';
@@ -111,6 +115,9 @@ function printBasicValue(
 
   if (typeOf === 'number') {
     return printNumber(val);
+  }
+  if (typeOf === 'bigint') {
+    return printBigInt(val);
   }
   if (typeOf === 'string') {
     if (escapeString) {


### PR DESCRIPTION
## Summary

I was experimenting with BigInt numbers and noticed that Jest will not print these correctly in diffs. For example, for

```js
const f = {
  a: BigInt(1),
  b: BigInt(2)
}
```

Jest would print the diff something like

```
Received: f {a: {}, b: {}}
Expected: f {a: {}, b: {}}
```

because `pretty-format` thinks `BigInt` is an object.

I made BigInts print with an `n` appended, like they print in the browser and Node so that the above would print something like this instead

```js
Received: f {a: 1n, b: 2n}
Expected: f {a: 2n, b: 1n}
```

## Test plan

I added unit tests that mimic the unit tests for number types.