### PR TITLE
more precise circus asyncError types

### DIFF
--- a/packages/jest-circus/src/types.ts
+++ b/packages/jest-circus/src/types.ts
@@ -27,7 +27,7 @@ export type TestContext = Record<string, any>;
 export type Exception = any; // Since in JS anything can be thrown as an error.
 export type FormattedError = string; // String representation of error.
 export type Hook = {
-  asyncError: Exception;
+  asyncError: Error;
   fn: HookFn;
   type: HookType;
   parent: DescribeBlock;
@@ -41,7 +41,7 @@ export type Event =
       name: 'include_test_location_in_result';
     }
   | {
-      asyncError: Exception;
+      asyncError: Error;
       mode: BlockMode;
       name: 'start_describe_definition';
       blockName: BlockName;
@@ -52,14 +52,14 @@ export type Event =
       blockName: BlockName;
     }
   | {
-      asyncError: Exception;
+      asyncError: Error;
       name: 'add_hook';
       hookType: HookType;
       fn: HookFn;
       timeout: number | undefined;
     }
   | {
-      asyncError: Exception;
+      asyncError: Error;
       name: 'add_test';
       testName: TestName;
       fn?: TestFn;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

For some circus events that we attach `asyncError`s to ourselves in `index.ts`, we actually know that we're not going to attach something that's not an `Error`, so we can be more precise than `Exception` (which is an alias of `any`). Events that get `asyncError`s thrown by user code keep `asyncError: Exception` (`any`).
This e.g. types the `.message = ` in https://github.com/facebook/jest/blob/b97ac394ae4b1b5b8b8b69eb1d7b373642746c02/packages/jest-circus/src/eventHandler.ts#L46
correctly instead of just allowing it because of `any`

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
