### PR TITLE
Perf improvements - avoid persisting haste map / processing files when not changed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 ### Performance
 
+- `[jest-haste-map]` Avoid persisting haste map or processing files when not changed ([#8153](https://github.com/facebook/jest/pull/8153))
+
 ## 24.5.0
 
 ### Features

--- a/packages/jest-haste-map/src/crawlers/__tests__/watchman.test.js
+++ b/packages/jest-haste-map/src/crawlers/__tests__/watchman.test.js
@@ -128,7 +128,7 @@ describe('watchman watch', () => {
       ignore: pearMatcher,
       rootDir: ROOT_MOCK,
       roots: ROOTS,
-    }).then(({hasteMap, removedFiles}) => {
+    }).then(({changedFiles, hasteMap, removedFiles}) => {
       const client = watchman.Client.mock.instances[0];
       const calls = client.command.mock.calls;
 
@@ -164,6 +164,8 @@ describe('watchman watch', () => {
           '': 'c:fake-clock:1',
         }),
       );
+
+      expect(changedFiles).toEqual(undefined);
 
       expect(hasteMap.files).toEqual(mockFiles);
 
@@ -210,7 +212,8 @@ describe('watchman watch', () => {
           : null,
       rootDir: ROOT_MOCK,
       roots: ROOTS,
-    }).then(({hasteMap, removedFiles}) => {
+    }).then(({changedFiles, hasteMap, removedFiles}) => {
+      expect(changedFiles).toEqual(undefined);
       expect(hasteMap.files).toEqual(
         createMap({
           [path.join(DURIAN_RELATIVE, 'foo.1.js')]: ['', 33, 43, 0, [], null],
@@ -265,13 +268,19 @@ describe('watchman watch', () => {
       ignore: pearMatcher,
       rootDir: ROOT_MOCK,
       roots: ROOTS,
-    }).then(({hasteMap, removedFiles}) => {
+    }).then(({changedFiles, hasteMap, removedFiles}) => {
       // The object was reused.
       expect(hasteMap.files).toBe(mockFiles);
 
       expect(hasteMap.clocks).toEqual(
         createMap({
           '': 'c:fake-clock:2',
+        }),
+      );
+
+      expect(changedFiles).toEqual(
+        createMap({
+          [KIWI_RELATIVE]: ['', 42, 40, 0, [], null],
         }),
       );
 
@@ -349,7 +358,7 @@ describe('watchman watch', () => {
       ignore: pearMatcher,
       rootDir: ROOT_MOCK,
       roots: ROOTS,
-    }).then(({hasteMap, removedFiles}) => {
+    }).then(({changedFiles, hasteMap, removedFiles}) => {
       // The file object was *not* reused.
       expect(hasteMap.files).not.toBe(mockFiles);
 
@@ -358,6 +367,8 @@ describe('watchman watch', () => {
           '': 'c:fake-clock:3',
         }),
       );
+
+      expect(changedFiles).toEqual(undefined);
 
       // strawberry and melon removed from the file list.
       expect(hasteMap.files).toEqual(
@@ -443,13 +454,15 @@ describe('watchman watch', () => {
       ignore: pearMatcher,
       rootDir: ROOT_MOCK,
       roots: ROOTS,
-    }).then(({hasteMap, removedFiles}) => {
+    }).then(({changedFiles, hasteMap, removedFiles}) => {
       expect(hasteMap.clocks).toEqual(
         createMap({
           [FRUITS_RELATIVE]: 'c:fake-clock:3',
           [VEGETABLES_RELATIVE]: 'c:fake-clock:4',
         }),
       );
+
+      expect(changedFiles).toEqual(undefined);
 
       expect(hasteMap.files).toEqual(
         createMap({
@@ -506,7 +519,7 @@ describe('watchman watch', () => {
       ignore: pearMatcher,
       rootDir: ROOT_MOCK,
       roots: [...ROOTS, ROOT_MOCK],
-    }).then(({hasteMap, removedFiles}) => {
+    }).then(({changedFiles, hasteMap, removedFiles}) => {
       const client = watchman.Client.mock.instances[0];
       const calls = client.command.mock.calls;
 
@@ -537,6 +550,8 @@ describe('watchman watch', () => {
           '': 'c:fake-clock:1',
         }),
       );
+
+      expect(changedFiles).toEqual(new Map());
 
       expect(hasteMap.files).toEqual(new Map());
 

--- a/packages/jest-haste-map/src/crawlers/watchman.ts
+++ b/packages/jest-haste-map/src/crawlers/watchman.ts
@@ -33,8 +33,8 @@ function WatchmanError(error: Error): Error {
 export = async function watchmanCrawl(
   options: CrawlerOptions,
 ): Promise<{
-  removedFiles: FileData;
   changedFiles?: FileData;
+  removedFiles: FileData;
   hasteMap: InternalHasteMap;
 }> {
   const fields = ['name', 'exists', 'mtime_ms', 'size'];
@@ -258,8 +258,8 @@ export = async function watchmanCrawl(
 
   data.files = files;
   return {
+    changedFiles: isFresh ? undefined : changedFiles,
     hasteMap: data,
     removedFiles,
-    changedFiles: isFresh ? undefined : changedFiles,
   };
 };

--- a/packages/jest-haste-map/src/crawlers/watchman.ts
+++ b/packages/jest-haste-map/src/crawlers/watchman.ts
@@ -34,6 +34,7 @@ export = async function watchmanCrawl(
   options: CrawlerOptions,
 ): Promise<{
   removedFiles: FileData;
+  changedFiles?: FileData;
   hasteMap: InternalHasteMap;
 }> {
   const fields = ['name', 'exists', 'mtime_ms', 'size'];
@@ -148,6 +149,7 @@ export = async function watchmanCrawl(
 
   let files = data.files;
   let removedFiles = new Map();
+  const changedFiles = new Map();
   let watchmanFiles: Map<string, any>;
   let isFresh = false;
   try {
@@ -243,10 +245,12 @@ export = async function watchmanCrawl(
                 absoluteVirtualFilePath,
               );
               files.set(relativeVirtualFilePath, nextData);
+              changedFiles.set(relativeVirtualFilePath, nextData);
             }
           }
         } else {
           files.set(relativeFilePath, nextData);
+          changedFiles.set(relativeFilePath, nextData);
         }
       }
     }
@@ -256,5 +260,6 @@ export = async function watchmanCrawl(
   return {
     hasteMap: data,
     removedFiles,
+    changedFiles: isFresh ? undefined : changedFiles,
   };
 };

--- a/packages/jest-haste-map/src/index.ts
+++ b/packages/jest-haste-map/src/index.ts
@@ -339,30 +339,42 @@ class HasteMap extends EventEmitter {
 
   build(): Promise<InternalHasteMapObject> {
     if (!this._buildPromise) {
-      this._buildPromise = this._buildFileMap()
-        .then(data => this._buildHasteMap(data))
-        .then(hasteMap => {
-          this._persist(hasteMap);
+      this._buildPromise = (async () => {
+        const data = await this._buildFileMap();
 
-          const rootDir = this._options.rootDir;
-          const hasteFS = new HasteFS({
-            files: hasteMap.files,
-            rootDir,
-          });
-          const moduleMap = new HasteModuleMap({
-            duplicates: hasteMap.duplicates,
-            map: hasteMap.map,
-            mocks: hasteMap.mocks,
-            rootDir,
-          });
-          const __hasteMapForTest =
-            (process.env.NODE_ENV === 'test' && hasteMap) || null;
-          return this._watch(hasteMap).then(() => ({
-            __hasteMapForTest,
-            hasteFS,
-            moduleMap,
-          }));
+        // Persist when we don't know if files changed (changedFiles undefined)
+        // or when we know a file was changed or deleted.
+        let hasteMap: InternalHasteMap;
+        if (
+          data.changedFiles === undefined ||
+          data.changedFiles.size > 0 ||
+          data.removedFiles.size > 0
+        ) {
+          hasteMap = await this._buildHasteMap(data);
+          this._persist(hasteMap);
+        } else {
+          hasteMap = data.hasteMap;
+        }
+
+        const rootDir = this._options.rootDir;
+        const hasteFS = new HasteFS({
+          files: hasteMap.files,
+          rootDir,
         });
+        const moduleMap = new HasteModuleMap({
+          duplicates: hasteMap.duplicates,
+          map: hasteMap.map,
+          mocks: hasteMap.mocks,
+          rootDir,
+        });
+        const __hasteMapForTest =
+          (process.env.NODE_ENV === 'test' && hasteMap) || null;
+        return this._watch(hasteMap).then(() => ({
+          __hasteMapForTest,
+          hasteFS,
+          moduleMap,
+        }));
+      })();
     }
     return this._buildPromise;
   }
@@ -395,16 +407,19 @@ class HasteMap extends EventEmitter {
   /**
    * 2. crawl the file system.
    */
-  private _buildFileMap(): Promise<{
+  private async _buildFileMap(): Promise<{
     removedFiles: FileData;
+    changedFiles?: FileData;
     hasteMap: InternalHasteMap;
   }> {
-    const read = this._options.resetCache ? this._createEmptyMap : this.read;
-
-    return Promise.resolve()
-      .then(() => read.call(this))
-      .catch(() => this._createEmptyMap())
-      .then(hasteMap => this._crawl(hasteMap));
+    let hasteMap: InternalHasteMap;
+    try {
+      const read = this._options.resetCache ? this._createEmptyMap : this.read;
+      hasteMap = await read.call(this);
+    } catch {
+      hasteMap = this._createEmptyMap();
+    }
+    return this._crawl(hasteMap);
   }
 
   /**
@@ -618,20 +633,34 @@ class HasteMap extends EventEmitter {
       .then(workerReply, workerError);
   }
 
-  private _buildHasteMap(data: {
+  private async _buildHasteMap(data: {
     removedFiles: FileData;
+    changedFiles?: FileData;
     hasteMap: InternalHasteMap;
   }): Promise<InternalHasteMap> {
-    const {removedFiles, hasteMap} = data;
-    const map = new Map();
-    const mocks = new Map();
-    const promises = [];
+    const {removedFiles, changedFiles, hasteMap} = data;
+
+    // If any files were removed or we did not track what files changed, process
+    // every file looking for changes. Otherwise, process only changed files.
+    let map: ModuleMapData;
+    let mocks: MockData;
+    let filesToProcess: FileData;
+    if (changedFiles === undefined || removedFiles.size) {
+      map = new Map();
+      mocks = new Map();
+      filesToProcess = hasteMap.files;
+    } else {
+      map = hasteMap.map;
+      mocks = hasteMap.mocks;
+      filesToProcess = changedFiles;
+    }
 
     for (const [relativeFilePath, fileMetadata] of removedFiles) {
       this._recoverDuplicates(hasteMap, relativeFilePath, fileMetadata[H.ID]);
     }
 
-    for (const relativeFilePath of hasteMap.files.keys()) {
+    const promises = [];
+    for (const relativeFilePath of filesToProcess.keys()) {
       if (
         this._options.skipPackageJson &&
         relativeFilePath.endsWith(PACKAGE_JSON)
@@ -649,17 +678,16 @@ class HasteMap extends EventEmitter {
       }
     }
 
-    return Promise.all(promises)
-      .then(() => {
-        this._cleanup();
-        hasteMap.map = map;
-        hasteMap.mocks = mocks;
-        return hasteMap;
-      })
-      .catch(error => {
-        this._cleanup();
-        return Promise.reject(error);
-      });
+    try {
+      await Promise.all(promises);
+      this._cleanup();
+      hasteMap.map = map;
+      hasteMap.mocks = mocks;
+      return hasteMap;
+    } catch (error) {
+      this._cleanup();
+      throw error;
+    }
   }
 
   private _cleanup() {

--- a/packages/jest-haste-map/src/index.ts
+++ b/packages/jest-haste-map/src/index.ts
@@ -369,11 +369,12 @@ class HasteMap extends EventEmitter {
         });
         const __hasteMapForTest =
           (process.env.NODE_ENV === 'test' && hasteMap) || null;
-        return this._watch(hasteMap).then(() => ({
+        await this._watch(hasteMap);
+        return {
           __hasteMapForTest,
           hasteFS,
           moduleMap,
-        }));
+        };
       })();
     }
     return this._buildPromise;


### PR DESCRIPTION
## Summary

At Facebook, in a common situation where you've changed a couple of files in the largest haste map, this PR cuts off 25%~ of the startup time. In other less common situations where you've working on a smaller haste map, the improvement is 60%~.

The improvement is gained by:
- Not re-serializing and writing the haste map to disk if it was loaded off of disk and then not changed.
- Not re-creating from scratch the `map` and `mocks` part of the haste map on startup when we know what specific files were changed. Instead, just re-process only the specific changed files.

I've benchmarked the startup time by:
1. Setting up a single test
2. Running once to prime the cache
3. Changing a test file
4. Running the test again with `--skipFilter` (measuring at this point via `time`)

I've been a bit conservative and I'm just doing a full re-process when files were deleted (same as current behavior) but I may improve that. It's much less common to delete a file than to edit a file and I wanted to keep the code as simple as possible initially.

In cases where Watchman isn't being used or is freshly started, there is no difference.

I'm always a little suspicious when something relatively simple yields such a large performance improvement, so please help by casting a very critical eye on this PR and all assumptions that I made.

## Test plan

- All tests pass.
- Tested manually in multiple situations.
- No change in behavior without watchman.
- Manually verified the cache file is updated appropriately in a variety of situations.