### PR TITLE
Fix incorrect duplicate mock warning.

### DIFF
--- a/e2e/__tests__/hasteMapMockChanged.test.ts
+++ b/e2e/__tests__/hasteMapMockChanged.test.ts
@@ -28,9 +28,9 @@ test('should not warn when a mock file changes', async () => {
     retainAllFiles: false,
     rootDir: DIR,
     roots: [DIR],
+    throwOnModuleCollision: true,
     useWatchman: true,
     watch: false,
-    throwOnModuleCollision: true,
   };
 
   // Populate the cache.

--- a/e2e/__tests__/hasteMapMockChanged.test.ts
+++ b/e2e/__tests__/hasteMapMockChanged.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import path from 'path';
+import JestHasteMap from 'jest-haste-map';
+import {cleanup, writeFiles} from '../Utils';
+
+// Directory must be here for Watchman to be enabled.
+const DIR = path.resolve(__dirname, 'haste_map_mock_changed');
+
+beforeEach(() => cleanup(DIR));
+afterEach(() => cleanup(DIR));
+
+test('should not warn when a mock file changes', async () => {
+  const hasteConfig = {
+    computeSha1: false,
+    extensions: ['js', 'json', 'png'],
+    forceNodeFilesystemAPI: false,
+    ignorePattern: / ^/,
+    maxWorkers: 2,
+    mocksPattern: '__mocks__',
+    name: 'tmp_' + Date.now(),
+    platforms: [],
+    retainAllFiles: false,
+    rootDir: DIR,
+    roots: [DIR],
+    useWatchman: true,
+    watch: false,
+    throwOnModuleCollision: true,
+  };
+
+  // Populate the cache.
+  writeFiles(DIR, {
+    '__mocks__/fs.js': '"foo fs"',
+  });
+  await new JestHasteMap(hasteConfig).build();
+
+  // This will throw if the mock file being updated triggers a warning.
+  writeFiles(DIR, {
+    '__mocks__/fs.js': '"foo fs!"',
+  });
+  await new JestHasteMap(hasteConfig).build();
+});

--- a/packages/jest-haste-map/src/index.ts
+++ b/packages/jest-haste-map/src/index.ts
@@ -574,20 +574,24 @@ class HasteMap extends EventEmitter {
 
       if (existingMockPath) {
         const secondMockPath = fastPath.relative(rootDir, filePath);
-        const method = this._options.throwOnModuleCollision ? 'error' : 'warn';
+        if (existingMockPath !== secondMockPath) {
+          const method = this._options.throwOnModuleCollision
+            ? 'error'
+            : 'warn';
 
-        this._console[method](
-          [
-            'jest-haste-map: duplicate manual mock found: ' + mockPath,
-            '  The following files share their name; please delete one of them:',
-            '    * <rootDir>' + path.sep + existingMockPath,
-            '    * <rootDir>' + path.sep + secondMockPath,
-            '',
-          ].join('\n'),
-        );
+          this._console[method](
+            [
+              'jest-haste-map: duplicate manual mock found: ' + mockPath,
+              '  The following files share their name; please delete one of them:',
+              '    * <rootDir>' + path.sep + existingMockPath,
+              '    * <rootDir>' + path.sep + secondMockPath,
+              '',
+            ].join('\n'),
+          );
 
-        if (this._options.throwOnModuleCollision) {
-          throw new DuplicateError(existingMockPath, secondMockPath);
+          if (this._options.throwOnModuleCollision) {
+            throw new DuplicateError(existingMockPath, secondMockPath);
+          }
         }
       }
 


### PR DESCRIPTION
## Summary

This fixes a regression introduced by: https://github.com/facebook/jest/pull/8153

I've fixed it by using the same logic already present for modules, which also check to be sure the file path isn't a match before warning.

## Test plan

I added an e2e test that catches the behavior to ensure this regression will not happen again.

To reproduce manually:
1. Run `yarn jest packages/jest-haste-map/src/__tests__/index.test.js` (or any other test)
2. Make any change to a mock file, for example add a comment to `packages/jest-config/src/__mocks__/fs.js`
3. Run Jest again, the warning `jest-haste-map: duplicate manual mock found: fs` incorrectly shows up