### PR TITLE
Optimize haste map data structure for serialization/deserialization.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 ### Performance
 
+- `[jest-haste-map]` Optimize haste map data structure for serialization/deserialization ([#8171](https://github.com/facebook/jest/pull/8171))
 - `[jest-haste-map]` Avoid persisting haste map or processing files when not changed ([#8153](https://github.com/facebook/jest/pull/8153))
 
 ## 24.5.0

--- a/packages/jest-haste-map/src/HasteFS.ts
+++ b/packages/jest-haste-map/src/HasteFS.ts
@@ -33,11 +33,14 @@ export default class HasteFS {
 
   getDependencies(file: Config.Path): Array<string> | null {
     const fileMetadata = this._getFileData(file);
-    return (
-      (fileMetadata &&
-        fileMetadata[H.DEPENDENCIES].split(H.DEPENDENCY_DELIM)) ||
-      null
-    );
+
+    if (fileMetadata) {
+      return fileMetadata[H.DEPENDENCIES]
+        ? fileMetadata[H.DEPENDENCIES].split(H.DEPENDENCY_DELIM)
+        : [];
+    } else {
+      return null;
+    }
   }
 
   getSha1(file: Config.Path): string | null {

--- a/packages/jest-haste-map/src/HasteFS.ts
+++ b/packages/jest-haste-map/src/HasteFS.ts
@@ -33,7 +33,7 @@ export default class HasteFS {
 
   getDependencies(file: Config.Path): Array<string> | null {
     const fileMetadata = this._getFileData(file);
-    return (fileMetadata && fileMetadata[H.DEPENDENCIES]) || null;
+    return (fileMetadata && fileMetadata[H.DEPENDENCIES].split('\t')) || null;
   }
 
   getSha1(file: Config.Path): string | null {

--- a/packages/jest-haste-map/src/HasteFS.ts
+++ b/packages/jest-haste-map/src/HasteFS.ts
@@ -33,7 +33,11 @@ export default class HasteFS {
 
   getDependencies(file: Config.Path): Array<string> | null {
     const fileMetadata = this._getFileData(file);
-    return (fileMetadata && fileMetadata[H.DEPENDENCIES].split('\t')) || null;
+    return (
+      (fileMetadata &&
+        fileMetadata[H.DEPENDENCIES].split(H.DEPENDENCY_DELIM)) ||
+      null
+    );
   }
 
   getSha1(file: Config.Path): string | null {

--- a/packages/jest-haste-map/src/__tests__/index.test.js
+++ b/packages/jest-haste-map/src/__tests__/index.test.js
@@ -340,17 +340,17 @@ describe('HasteMap', () => {
 
       expect(data.files).toEqual(
         createMap({
-          'fruits/Banana.js': ['Banana', 32, 42, 1, ['Strawberry'], null],
-          'fruits/Pear.js': ['Pear', 32, 42, 1, ['Banana', 'Strawberry'], null],
-          'fruits/Strawberry.js': ['Strawberry', 32, 42, 1, [], null],
-          'fruits/__mocks__/Pear.js': ['', 32, 42, 1, ['Melon'], null],
+          'fruits/Banana.js': ['Banana', 32, 42, 1, 'Strawberry', null],
+          'fruits/Pear.js': ['Pear', 32, 42, 1, 'Banana\tStrawberry', null],
+          'fruits/Strawberry.js': ['Strawberry', 32, 42, 1, '', null],
+          'fruits/__mocks__/Pear.js': ['', 32, 42, 1, 'Melon', null],
           // node modules
           'fruits/node_modules/fbjs/lib/flatMap.js': [
             'flatMap',
             32,
             42,
             1,
-            [],
+            '',
             null,
           ],
           'fruits/node_modules/react/React.js': [
@@ -358,10 +358,10 @@ describe('HasteMap', () => {
             32,
             42,
             1,
-            ['Component'],
+            'Component',
             null,
           ],
-          'vegetables/Melon.js': ['Melon', 32, 42, 1, [], null],
+          'vegetables/Melon.js': ['Melon', 32, 42, 1, '', null],
         }),
       );
 
@@ -410,18 +410,11 @@ describe('HasteMap', () => {
 
           // The node crawler returns "null" for the SHA-1.
           data.files = createMap({
-            'fruits/Banana.js': ['Banana', 32, 42, 0, ['Strawberry'], null],
-            'fruits/Pear.js': [
-              'Pear',
-              32,
-              42,
-              0,
-              ['Banana', 'Strawberry'],
-              null,
-            ],
-            'fruits/Strawberry.js': ['Strawberry', 32, 42, 0, [], null],
-            'fruits/__mocks__/Pear.js': ['', 32, 42, 0, ['Melon'], null],
-            'vegetables/Melon.js': ['Melon', 32, 42, 0, [], null],
+            'fruits/Banana.js': ['Banana', 32, 42, 0, 'Strawberry', null],
+            'fruits/Pear.js': ['Pear', 32, 42, 0, 'Banana/Strawberry', null],
+            'fruits/Strawberry.js': ['Strawberry', 32, 42, 0, '', null],
+            'fruits/__mocks__/Pear.js': ['', 32, 42, 0, 'Melon', null],
+            'vegetables/Melon.js': ['Melon', 32, 42, 0, '', null],
           });
 
           return Promise.resolve({
@@ -446,7 +439,7 @@ describe('HasteMap', () => {
               32,
               42,
               1,
-              ['Strawberry'],
+              'Strawberry',
               '7772b628e422e8cf59c526be4bb9f44c0898e3d1',
             ],
             'fruits/Pear.js': [
@@ -454,7 +447,7 @@ describe('HasteMap', () => {
               32,
               42,
               1,
-              ['Banana', 'Strawberry'],
+              'Banana\tStrawberry',
               '89d0c2cc11dcc5e1df50b8af04ab1b597acfba2f',
             ],
             'fruits/Strawberry.js': [
@@ -462,7 +455,7 @@ describe('HasteMap', () => {
               32,
               42,
               1,
-              [],
+              '',
               'e8aa38e232b3795f062f1d777731d9240c0f8c25',
             ],
             'fruits/__mocks__/Pear.js': [
@@ -470,7 +463,7 @@ describe('HasteMap', () => {
               32,
               42,
               1,
-              ['Melon'],
+              'Melon',
               '8d40afbb6e2dc78e1ba383b6d02cafad35cceef2',
             ],
             'vegetables/Melon.js': [
@@ -478,7 +471,7 @@ describe('HasteMap', () => {
               32,
               42,
               1,
-              [],
+              '',
               'f16ccf6f2334ceff2ddb47628a2c5f2d748198ca',
             ],
           }),
@@ -626,7 +619,7 @@ describe('HasteMap', () => {
               32,
               42,
               1,
-              ['Blackberry'],
+              'Blackberry',
               null,
             ],
             'fruits/Strawberry.ios.js': [
@@ -634,10 +627,10 @@ describe('HasteMap', () => {
               32,
               42,
               1,
-              ['Raspberry'],
+              'Raspberry',
               null,
             ],
-            'fruits/Strawberry.js': ['Strawberry', 32, 42, 1, ['Banana'], null],
+            'fruits/Strawberry.js': ['Strawberry', 32, 42, 1, 'Banana', null],
           }),
         );
 
@@ -724,14 +717,7 @@ describe('HasteMap', () => {
             expect(useBuitinsInContext(data.clocks)).toEqual(mockClocks);
 
             const files = new Map(initialData.files);
-            files.set('fruits/Banana.js', [
-              'Banana',
-              32,
-              42,
-              1,
-              ['Kiwi'],
-              null,
-            ]);
+            files.set('fruits/Banana.js', ['Banana', 32, 42, 1, 'Kiwi', null]);
 
             expect(useBuitinsInContext(data.files)).toEqual(files);
 
@@ -1102,7 +1088,7 @@ describe('HasteMap', () => {
 
         expect(data.files).toEqual(
           createMap({
-            'fruits/Banana.js': ['Banana', 32, 42, 1, ['Strawberry'], null],
+            'fruits/Banana.js': ['Banana', 32, 42, 1, 'Strawberry', null],
           }),
         );
 
@@ -1136,7 +1122,7 @@ describe('HasteMap', () => {
 
         expect(data.files).toEqual(
           createMap({
-            'fruits/Banana.js': ['Banana', 32, 42, 1, ['Strawberry'], null],
+            'fruits/Banana.js': ['Banana', 32, 42, 1, 'Strawberry', null],
           }),
         );
       });

--- a/packages/jest-haste-map/src/__tests__/index.test.js
+++ b/packages/jest-haste-map/src/__tests__/index.test.js
@@ -1072,7 +1072,7 @@ describe('HasteMap', () => {
     node.mockImplementation(options => {
       const {data} = options;
       data.files = createMap({
-        'fruits/Banana.js': ['', 32, 42, 0, [], null],
+        'fruits/Banana.js': ['', 32, 42, 0, '', null],
       });
       return Promise.resolve({
         hasteMap: data,
@@ -1106,7 +1106,7 @@ describe('HasteMap', () => {
     node.mockImplementation(options => {
       const {data} = options;
       data.files = createMap({
-        'fruits/Banana.js': ['', 32, 42, 0, [], null],
+        'fruits/Banana.js': ['', 32, 42, 0, '', null],
       });
       return Promise.resolve({
         hasteMap: data,

--- a/packages/jest-haste-map/src/__tests__/index.test.js
+++ b/packages/jest-haste-map/src/__tests__/index.test.js
@@ -341,7 +341,7 @@ describe('HasteMap', () => {
       expect(data.files).toEqual(
         createMap({
           'fruits/Banana.js': ['Banana', 32, 42, 1, 'Strawberry', null],
-          'fruits/Pear.js': ['Pear', 32, 42, 1, 'Banana\tStrawberry', null],
+          'fruits/Pear.js': ['Pear', 32, 42, 1, 'Banana:Strawberry', null],
           'fruits/Strawberry.js': ['Strawberry', 32, 42, 1, '', null],
           'fruits/__mocks__/Pear.js': ['', 32, 42, 1, 'Melon', null],
           // node modules
@@ -411,7 +411,7 @@ describe('HasteMap', () => {
           // The node crawler returns "null" for the SHA-1.
           data.files = createMap({
             'fruits/Banana.js': ['Banana', 32, 42, 0, 'Strawberry', null],
-            'fruits/Pear.js': ['Pear', 32, 42, 0, 'Banana\tStrawberry', null],
+            'fruits/Pear.js': ['Pear', 32, 42, 0, 'Banana:Strawberry', null],
             'fruits/Strawberry.js': ['Strawberry', 32, 42, 0, '', null],
             'fruits/__mocks__/Pear.js': ['', 32, 42, 0, 'Melon', null],
             'vegetables/Melon.js': ['Melon', 32, 42, 0, '', null],
@@ -447,7 +447,7 @@ describe('HasteMap', () => {
               32,
               42,
               1,
-              'Banana\tStrawberry',
+              'Banana:Strawberry',
               '89d0c2cc11dcc5e1df50b8af04ab1b597acfba2f',
             ],
             'fruits/Strawberry.js': [

--- a/packages/jest-haste-map/src/__tests__/index.test.js
+++ b/packages/jest-haste-map/src/__tests__/index.test.js
@@ -411,7 +411,7 @@ describe('HasteMap', () => {
           // The node crawler returns "null" for the SHA-1.
           data.files = createMap({
             'fruits/Banana.js': ['Banana', 32, 42, 0, 'Strawberry', null],
-            'fruits/Pear.js': ['Pear', 32, 42, 0, 'Banana/Strawberry', null],
+            'fruits/Pear.js': ['Pear', 32, 42, 0, 'Banana\tStrawberry', null],
             'fruits/Strawberry.js': ['Strawberry', 32, 42, 0, '', null],
             'fruits/__mocks__/Pear.js': ['', 32, 42, 0, 'Melon', null],
             'vegetables/Melon.js': ['Melon', 32, 42, 0, '', null],

--- a/packages/jest-haste-map/src/__tests__/index.test.js
+++ b/packages/jest-haste-map/src/__tests__/index.test.js
@@ -341,7 +341,7 @@ describe('HasteMap', () => {
       expect(data.files).toEqual(
         createMap({
           'fruits/Banana.js': ['Banana', 32, 42, 1, 'Strawberry', null],
-          'fruits/Pear.js': ['Pear', 32, 42, 1, 'Banana:Strawberry', null],
+          'fruits/Pear.js': ['Pear', 32, 42, 1, 'Banana\0Strawberry', null],
           'fruits/Strawberry.js': ['Strawberry', 32, 42, 1, '', null],
           'fruits/__mocks__/Pear.js': ['', 32, 42, 1, 'Melon', null],
           // node modules
@@ -411,7 +411,7 @@ describe('HasteMap', () => {
           // The node crawler returns "null" for the SHA-1.
           data.files = createMap({
             'fruits/Banana.js': ['Banana', 32, 42, 0, 'Strawberry', null],
-            'fruits/Pear.js': ['Pear', 32, 42, 0, 'Banana:Strawberry', null],
+            'fruits/Pear.js': ['Pear', 32, 42, 0, 'Banana\0Strawberry', null],
             'fruits/Strawberry.js': ['Strawberry', 32, 42, 0, '', null],
             'fruits/__mocks__/Pear.js': ['', 32, 42, 0, 'Melon', null],
             'vegetables/Melon.js': ['Melon', 32, 42, 0, '', null],
@@ -447,7 +447,7 @@ describe('HasteMap', () => {
               32,
               42,
               1,
-              'Banana:Strawberry',
+              'Banana\0Strawberry',
               '89d0c2cc11dcc5e1df50b8af04ab1b597acfba2f',
             ],
             'fruits/Strawberry.js': [

--- a/packages/jest-haste-map/src/constants.ts
+++ b/packages/jest-haste-map/src/constants.ts
@@ -19,7 +19,7 @@ import {HType} from './types';
 
 const constants: HType = {
   /* dependency serialization */
-  DEPENDENCY_DELIM: ':',
+  DEPENDENCY_DELIM: '\0',
 
   /* file map attributes */
   ID: 0,

--- a/packages/jest-haste-map/src/constants.ts
+++ b/packages/jest-haste-map/src/constants.ts
@@ -18,6 +18,9 @@
 import {HType} from './types';
 
 const constants: HType = {
+  /* dependency serialization */
+  DEPENDENCY_DELIM: ':',
+
   /* file map attributes */
   ID: 0,
   MTIME: 1,

--- a/packages/jest-haste-map/src/crawlers/__tests__/node.test.js
+++ b/packages/jest-haste-map/src/crawlers/__tests__/node.test.js
@@ -133,9 +133,9 @@ describe('node crawler', () => {
 
       expect(hasteMap.files).toEqual(
         createMap({
-          'fruits/strawberry.js': ['', 32, 42, 0, [], null],
-          'fruits/tomato.js': ['', 33, 42, 0, [], null],
-          'vegetables/melon.json': ['', 34, 42, 0, [], null],
+          'fruits/strawberry.js': ['', 32, 42, 0, '', null],
+          'fruits/tomato.js': ['', 33, 42, 0, '', null],
+          'vegetables/melon.json': ['', 34, 42, 0, '', null],
         }),
       );
 
@@ -151,9 +151,9 @@ describe('node crawler', () => {
     nodeCrawl = require('../node');
 
     // In this test sample, strawberry is changed and tomato is unchanged
-    const tomato = ['', 33, 42, 1, [], null];
+    const tomato = ['', 33, 42, 1, '', null];
     const files = createMap({
-      'fruits/strawberry.js': ['', 30, 40, 1, [], null],
+      'fruits/strawberry.js': ['', 30, 40, 1, '', null],
       'fruits/tomato.js': tomato,
     });
 
@@ -166,7 +166,7 @@ describe('node crawler', () => {
     }).then(({hasteMap, removedFiles}) => {
       expect(hasteMap.files).toEqual(
         createMap({
-          'fruits/strawberry.js': ['', 32, 42, 0, [], null],
+          'fruits/strawberry.js': ['', 32, 42, 0, '', null],
           'fruits/tomato.js': tomato,
         }),
       );
@@ -186,9 +186,9 @@ describe('node crawler', () => {
     // In this test sample, previouslyExisted was present before and will not be
     // when crawling this directory.
     const files = createMap({
-      'fruits/previouslyExisted.js': ['', 30, 40, 1, [], null],
-      'fruits/strawberry.js': ['', 33, 42, 0, [], null],
-      'fruits/tomato.js': ['', 32, 42, 0, [], null],
+      'fruits/previouslyExisted.js': ['', 30, 40, 1, '', null],
+      'fruits/strawberry.js': ['', 33, 42, 0, '', null],
+      'fruits/tomato.js': ['', 32, 42, 0, '', null],
     });
 
     return nodeCrawl({
@@ -200,13 +200,13 @@ describe('node crawler', () => {
     }).then(({hasteMap, removedFiles}) => {
       expect(hasteMap.files).toEqual(
         createMap({
-          'fruits/strawberry.js': ['', 32, 42, 0, [], null],
-          'fruits/tomato.js': ['', 33, 42, 0, [], null],
+          'fruits/strawberry.js': ['', 32, 42, 0, '', null],
+          'fruits/tomato.js': ['', 33, 42, 0, '', null],
         }),
       );
       expect(removedFiles).toEqual(
         createMap({
-          'fruits/previouslyExisted.js': ['', 30, 40, 1, [], null],
+          'fruits/previouslyExisted.js': ['', 30, 40, 1, '', null],
         }),
       );
     });
@@ -228,8 +228,8 @@ describe('node crawler', () => {
     }).then(({hasteMap, removedFiles}) => {
       expect(hasteMap.files).toEqual(
         createMap({
-          'fruits/directory/strawberry.js': ['', 33, 42, 0, [], null],
-          'fruits/tomato.js': ['', 32, 42, 0, [], null],
+          'fruits/directory/strawberry.js': ['', 33, 42, 0, '', null],
+          'fruits/tomato.js': ['', 32, 42, 0, '', null],
         }),
       );
       expect(removedFiles).toEqual(new Map());
@@ -252,8 +252,8 @@ describe('node crawler', () => {
     }).then(({hasteMap, removedFiles}) => {
       expect(hasteMap.files).toEqual(
         createMap({
-          'fruits/directory/strawberry.js': ['', 33, 42, 0, [], null],
-          'fruits/tomato.js': ['', 32, 42, 0, [], null],
+          'fruits/directory/strawberry.js': ['', 33, 42, 0, '', null],
+          'fruits/tomato.js': ['', 32, 42, 0, '', null],
         }),
       );
       expect(removedFiles).toEqual(new Map());

--- a/packages/jest-haste-map/src/crawlers/__tests__/watchman.test.js
+++ b/packages/jest-haste-map/src/crawlers/__tests__/watchman.test.js
@@ -108,9 +108,9 @@ describe('watchman watch', () => {
     };
 
     mockFiles = createMap({
-      [MELON_RELATIVE]: ['', 33, 43, 0, [], null],
-      [STRAWBERRY_RELATIVE]: ['', 30, 40, 0, [], null],
-      [TOMATO_RELATIVE]: ['', 31, 41, 0, [], null],
+      [MELON_RELATIVE]: ['', 33, 43, 0, '', null],
+      [STRAWBERRY_RELATIVE]: ['', 30, 40, 0, '', null],
+      [TOMATO_RELATIVE]: ['', 31, 41, 0, '', null],
     });
   });
 
@@ -216,8 +216,8 @@ describe('watchman watch', () => {
       expect(changedFiles).toEqual(undefined);
       expect(hasteMap.files).toEqual(
         createMap({
-          [path.join(DURIAN_RELATIVE, 'foo.1.js')]: ['', 33, 43, 0, [], null],
-          [path.join(DURIAN_RELATIVE, 'foo.2.js')]: ['', 33, 43, 0, [], null],
+          [path.join(DURIAN_RELATIVE, 'foo.1.js')]: ['', 33, 43, 0, '', null],
+          [path.join(DURIAN_RELATIVE, 'foo.2.js')]: ['', 33, 43, 0, '', null],
         }),
       );
       expect(removedFiles).toEqual(new Map());
@@ -280,21 +280,21 @@ describe('watchman watch', () => {
 
       expect(changedFiles).toEqual(
         createMap({
-          [KIWI_RELATIVE]: ['', 42, 40, 0, [], null],
+          [KIWI_RELATIVE]: ['', 42, 40, 0, '', null],
         }),
       );
 
       expect(hasteMap.files).toEqual(
         createMap({
-          [KIWI_RELATIVE]: ['', 42, 40, 0, [], null],
-          [MELON_RELATIVE]: ['', 33, 43, 0, [], null],
-          [STRAWBERRY_RELATIVE]: ['', 30, 40, 0, [], null],
+          [KIWI_RELATIVE]: ['', 42, 40, 0, '', null],
+          [MELON_RELATIVE]: ['', 33, 43, 0, '', null],
+          [STRAWBERRY_RELATIVE]: ['', 30, 40, 0, '', null],
         }),
       );
 
       expect(removedFiles).toEqual(
         createMap({
-          [TOMATO_RELATIVE]: ['', 31, 41, 0, [], null],
+          [TOMATO_RELATIVE]: ['', 31, 41, 0, '', null],
         }),
       );
     });
@@ -374,7 +374,7 @@ describe('watchman watch', () => {
       expect(hasteMap.files).toEqual(
         createMap({
           [BANANA_RELATIVE]: mockBananaMetadata,
-          [KIWI_RELATIVE]: ['', 42, 52, 0, [], null],
+          [KIWI_RELATIVE]: ['', 42, 52, 0, '', null],
           [TOMATO_RELATIVE]: ['Tomato', 76, 41, 1, [], mockTomatoSha1],
         }),
       );
@@ -388,8 +388,8 @@ describe('watchman watch', () => {
 
       expect(removedFiles).toEqual(
         createMap({
-          [MELON_RELATIVE]: ['', 33, 43, 0, [], null],
-          [STRAWBERRY_RELATIVE]: ['', 30, 40, 0, [], null],
+          [MELON_RELATIVE]: ['', 33, 43, 0, '', null],
+          [STRAWBERRY_RELATIVE]: ['', 30, 40, 0, '', null],
         }),
       );
     });
@@ -466,15 +466,15 @@ describe('watchman watch', () => {
 
       expect(hasteMap.files).toEqual(
         createMap({
-          [KIWI_RELATIVE]: ['', 42, 52, 0, [], null],
-          [MELON_RELATIVE]: ['', 33, 43, 0, [], null],
+          [KIWI_RELATIVE]: ['', 42, 52, 0, '', null],
+          [MELON_RELATIVE]: ['', 33, 43, 0, '', null],
         }),
       );
 
       expect(removedFiles).toEqual(
         createMap({
-          [STRAWBERRY_RELATIVE]: ['', 30, 40, 0, [], null],
-          [TOMATO_RELATIVE]: ['', 31, 41, 0, [], null],
+          [STRAWBERRY_RELATIVE]: ['', 30, 40, 0, '', null],
+          [TOMATO_RELATIVE]: ['', 31, 41, 0, '', null],
         }),
       );
     });

--- a/packages/jest-haste-map/src/crawlers/node.ts
+++ b/packages/jest-haste-map/src/crawlers/node.ts
@@ -164,7 +164,7 @@ export = function nodeCrawl(
           files.set(relativeFilePath, existingFile);
         } else {
           // See ../constants.js; SHA-1 will always be null and fulfilled later.
-          files.set(relativeFilePath, ['', mtime, size, 0, [], null]);
+          files.set(relativeFilePath, ['', mtime, size, 0, '', null]);
         }
         removedFiles.delete(relativeFilePath);
       });

--- a/packages/jest-haste-map/src/crawlers/watchman.ts
+++ b/packages/jest-haste-map/src/crawlers/watchman.ts
@@ -232,7 +232,7 @@ export = async function watchmanCrawl(
           ];
         } else {
           // See ../constants.ts
-          nextData = ['', mtime, size, 0, [], sha1hex];
+          nextData = ['', mtime, size, 0, '', sha1hex];
         }
 
         const mappings = options.mapper ? options.mapper(filePath) : null;

--- a/packages/jest-haste-map/src/index.ts
+++ b/packages/jest-haste-map/src/index.ts
@@ -326,7 +326,7 @@ class HasteMap extends EventEmitter {
     name: string,
     ...extra: Array<string>
   ): string {
-    const hash = crypto.createHash('md5').update(extra.join('') + 'v2');
+    const hash = crypto.createHash('md5').update(extra.join(''));
     return path.join(
       tmpdir,
       name.replace(/\W/g, '-') + '-' + hash.digest('hex'),

--- a/packages/jest-haste-map/src/index.ts
+++ b/packages/jest-haste-map/src/index.ts
@@ -326,7 +326,7 @@ class HasteMap extends EventEmitter {
     name: string,
     ...extra: Array<string>
   ): string {
-    const hash = crypto.createHash('md5').update(extra.join(''));
+    const hash = crypto.createHash('md5').update(extra.join('') + 'v2');
     return path.join(
       tmpdir,
       name.replace(/\W/g, '-') + '-' + hash.digest('hex'),
@@ -522,7 +522,9 @@ class HasteMap extends EventEmitter {
         setModule(metadataId, metadataModule);
       }
 
-      fileMetadata[H.DEPENDENCIES] = metadata.dependencies || [];
+      fileMetadata[H.DEPENDENCIES] = metadata.dependencies
+        ? metadata.dependencies.join('\t')
+        : '';
 
       if (computeSha1) {
         fileMetadata[H.SHA1] = metadata.sha1;
@@ -940,7 +942,7 @@ class HasteMap extends EventEmitter {
               stat ? stat.mtime.getTime() : -1,
               stat ? stat.size : 0,
               0,
-              [],
+              '',
               null,
             ];
             hasteMap.files.set(relativeFilePath, fileMetadata);

--- a/packages/jest-haste-map/src/index.ts
+++ b/packages/jest-haste-map/src/index.ts
@@ -523,7 +523,7 @@ class HasteMap extends EventEmitter {
       }
 
       fileMetadata[H.DEPENDENCIES] = metadata.dependencies
-        ? metadata.dependencies.join('\t')
+        ? metadata.dependencies.join(H.DEPENDENCY_DELIM)
         : '';
 
       if (computeSha1) {

--- a/packages/jest-haste-map/src/types.ts
+++ b/packages/jest-haste-map/src/types.ts
@@ -51,7 +51,7 @@ export type FileMetaData = [
   /* mtime */ number,
   /* size */ number,
   /* visited */ 0 | 1,
-  /* dependencies */ Array<string>,
+  /* dependencies */ string,
   /* sha1 */ string | null | undefined
 ];
 

--- a/packages/jest-haste-map/src/types.ts
+++ b/packages/jest-haste-map/src/types.ts
@@ -100,7 +100,7 @@ export type HType = {
   PACKAGE: 1;
   GENERIC_PLATFORM: 'g';
   NATIVE_PLATFORM: 'native';
-  DEPENDENCY_DELIM: ':';
+  DEPENDENCY_DELIM: '\0';
 };
 
 export type HTypeValue = HType[keyof HType];

--- a/packages/jest-haste-map/src/types.ts
+++ b/packages/jest-haste-map/src/types.ts
@@ -100,6 +100,7 @@ export type HType = {
   PACKAGE: 1;
   GENERIC_PLATFORM: 'g';
   NATIVE_PLATFORM: 'native';
+  DEPENDENCY_DELIM: ':';
 };
 
 export type HTypeValue = HType[keyof HType];


### PR DESCRIPTION
## Summary

This simple PR is the result of a ridiculous number of attempts to specifically optimize the serialization and deserialization of the haste map followed by a simple realization: creating arrays is expensive. :)

Currently, we store each file's dependencies as an expensive array. However, we don't typically access many file dependencies, so it's not time well-spent.

I've modified the data structure to store the file dependencies as a much cheaper string (tab separated) that is deserialized to an array on-demand. No change to the public interface, but now we're not doing any unnecessary work.

I profiled both the full Jest run time and the read/persist time to ensure I had a clear view into the characteristics of this change. It's somewhere in the neighborhood of a 10%~ startup time improvement at FB, which is significant.

Benchmarking against a generated benchmark hash map of 300,000 files:

before--
read: 2,291ms
persist: 2,413ms
total: 4,704ms

after--
read: 1,852ms
persist: 1,539ms
total: 3,391ms

delta: 1,313ms

## Test plan

- Updated tests
- All tests pass
- Manually benchmarked
