### PR TITLE
Handle Watchman `EAGAIN` on connect attempt by retrying

### DIFF
--- a/packages/jest-haste-map/src/lib/WatchmanWatcher.js
+++ b/packages/jest-haste-map/src/lib/WatchmanWatcher.js
@@ -60,7 +60,10 @@ WatchmanWatcher.prototype.init = function() {
             this.eagCounter
           })`,
         );
-        this.init();
+
+        // Try again as instructed by Watchman.
+        // Wait 500-2000ms (depending on how long we've been trying).
+        setTimeout(() => this.init(), Math.min(this.eagCounter * 500, 2000));
         return;
       }
     }


### PR DESCRIPTION
## Summary

This PR adds retry logic to handle the `EAGAIN` error that Watchman may throw on attempted connection. The code is inspired by Yarn's retry logic. I also handled cases where the connection was ended manually when a retry would have happened.

## Test plan

- Tested manually by triggering an error manually during the Jest run and the Metro run.
- Ensured the normal flow continued to work unchanged.

Working on trying to add some tests (no tests currently exist for this file) but feel free to review in the meantime.