### PR TITLE
Support React.Suspense in snapshots.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `[jest-snapshot]` Improve report when matcher fails, part 14 ([#8132](https://github.com/facebook/jest/pull/8132))
 - `[@jest/reporter]` Display todo and skip test descriptions when verbose is true ([#8038](https://github.com/facebook/jest/pull/8038))
 - `[jest-runner]` Support default exports for test environments ([#8163](https://github.com/facebook/jest/pull/8163))
+- `[pretty-format]` Support React.Suspense ([#8180](https://github.com/facebook/jest/pull/8180))
 
 ### Fixes
 

--- a/packages/pretty-format/src/__tests__/react.test.tsx
+++ b/packages/pretty-format/src/__tests__/react.test.tsx
@@ -13,6 +13,7 @@ import {OptionsReceived} from '../types';
 
 const elementSymbol = Symbol.for('react.element');
 const fragmentSymbol = Symbol.for('react.fragment');
+const suspenseSymbol = Symbol.for('react.suspense');
 const testSymbol = Symbol.for('react.test.json');
 const {ReactElement, ReactTestComponent} = prettyFormat.plugins;
 
@@ -306,6 +307,18 @@ test('supports a fragment with element child', () => {
       type: fragmentSymbol,
     }),
   ).toEqual('<React.Fragment>\n  <div>\n    test\n  </div>\n</React.Fragment>');
+});
+
+test('supports suspense', () => {
+  expect(
+    formatElement({
+      $$typeof: elementSymbol,
+      props: {
+        children: React.createElement('div', null, 'test'),
+      },
+      type: suspenseSymbol,
+    }),
+  ).toEqual('<React.Suspense>\n  <div>\n    test\n  </div>\n</React.Suspense>');
 });
 
 test('supports a single element with React elements with a child', () => {

--- a/packages/pretty-format/src/plugins/ReactElement.ts
+++ b/packages/pretty-format/src/plugins/ReactElement.ts
@@ -40,6 +40,9 @@ const getType = (element: any) => {
   if (ReactIs.isFragment(element)) {
     return 'React.Fragment';
   }
+  if (ReactIs.isSuspense(element)) {
+    return 'React.Suspense';
+  }
   if (typeof type === 'object' && type !== null) {
     if (ReactIs.isContextProvider(element)) {
       return 'Context.Provider';


### PR DESCRIPTION
## Summary

Resolves #8178

> The ReactElement is not aware of the React.Suspense component type, and as a result it causes snapshots to display "UNDEFINED". Fortunately it looks like this serializer is built on top of react-is which already exports a isSuspense so it should hopefully be easy to add this. 😄

## Test plan

- Added unit test. Verified that it failed previously with `UNDEFINED` as described in the bug report. It now passes.