### PR TITLE
Emphasize 'mock' variable name exception in docs

### DIFF
--- a/docs/Es6ClassMocks.md
+++ b/docs/Es6ClassMocks.md
@@ -148,7 +148,6 @@ jest.mock('./sound-player', () => {
 A limitation with the factory parameter is that, since calls to `jest.mock()` are hoisted to the top of the file, it's not possible to first define a variable and then use it in the factory. An exception is made for variables that start with the word 'mock'. It's up to you to guarantee that they will be initialized on time! For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration:
 
 ```javascript
-
 // Note: this will fail
 import SoundPlayer from './sound-player';
 const fakePlaySoundFile = jest.fn();

--- a/docs/Es6ClassMocks.md
+++ b/docs/Es6ClassMocks.md
@@ -148,6 +148,8 @@ jest.mock('./sound-player', () => {
 A limitation with the factory parameter is that, since calls to `jest.mock()` are hoisted to the top of the file, it's not possible to first define a variable and then use it in the factory. An exception is made for variables that start with the word 'mock'. It's up to you to guarantee that they will be initialized on time! For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration:
 
 ```javascript
+
+// Note: this will fail
 import SoundPlayer from './sound-player';
 const fakePlaySoundFile = jest.fn();
 jest.mock('./sound-player', () => {

--- a/docs/Es6ClassMocks.md
+++ b/docs/Es6ClassMocks.md
@@ -145,7 +145,17 @@ jest.mock('./sound-player', () => {
 });
 ```
 
-A limitation with the factory parameter is that, since calls to `jest.mock()` are hoisted to the top of the file, it's not possible to first define a variable and then use it in the factory. An exception is made for variables that start with the word 'mock'. It's up to you to guarantee that they will be initialized on time!
+A limitation with the factory parameter is that, since calls to `jest.mock()` are hoisted to the top of the file, it's not possible to first define a variable and then use it in the factory. An exception is made for variables that start with the word 'mock'. It's up to you to guarantee that they will be initialized on time! For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration:
+
+```javascript
+import SoundPlayer from './sound-player';
+const fakePlaySoundFile = jest.fn();
+jest.mock('./sound-player', () => {
+  return jest.fn().mockImplementation(() => {
+    return {playSoundFile: fakePlaySoundFile};
+  });
+});
+```
 
 ### Replacing the mock using [`mockImplementation()`](MockFunctionAPI.md#mockfnmockimplementationfn) or [`mockImplementationOnce()`](MockFunctionAPI.md#mockfnmockimplementationoncefn)
 

--- a/website/versioned_docs/version-23.x/Es6ClassMocks.md
+++ b/website/versioned_docs/version-23.x/Es6ClassMocks.md
@@ -146,7 +146,18 @@ jest.mock('./sound-player', () => {
 });
 ```
 
-A limitation with the factory parameter is that, since calls to `jest.mock()` are hoisted to the top of the file, it's not possible to first define a variable and then use it in the factory. An exception is made for variables that start with the word 'mock'. It's up to you to guarantee that they will be initialized on time!
+A limitation with the factory parameter is that, since calls to `jest.mock()` are hoisted to the top of the file, it's not possible to first define a variable and then use it in the factory. An exception is made for variables that start with the word 'mock'. It's up to you to guarantee that they will be initialized on time! For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration:
+
+ ```javascript
+// Note: this will fail
+import SoundPlayer from './sound-player';
+const fakePlaySoundFile = jest.fn();
+jest.mock('./sound-player', () => {
+  return jest.fn().mockImplementation(() => {
+    return {playSoundFile: fakePlaySoundFile};
+  });
+});
+```
 
 ### Replacing the mock using [`mockImplementation()`](MockFunctionAPI.md#mockfnmockimplementationfn) or [`mockImplementationOnce()`](MockFunctionAPI.md#mockfnmockimplementationoncefn)
 

--- a/website/versioned_docs/version-23.x/Es6ClassMocks.md
+++ b/website/versioned_docs/version-23.x/Es6ClassMocks.md
@@ -148,7 +148,7 @@ jest.mock('./sound-player', () => {
 
 A limitation with the factory parameter is that, since calls to `jest.mock()` are hoisted to the top of the file, it's not possible to first define a variable and then use it in the factory. An exception is made for variables that start with the word 'mock'. It's up to you to guarantee that they will be initialized on time! For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration:
 
- ```javascript
+```javascript
 // Note: this will fail
 import SoundPlayer from './sound-player';
 const fakePlaySoundFile = jest.fn();

--- a/website/versioned_docs/version-24.0/Es6ClassMocks.md
+++ b/website/versioned_docs/version-24.0/Es6ClassMocks.md
@@ -146,7 +146,18 @@ jest.mock('./sound-player', () => {
 });
 ```
 
-A limitation with the factory parameter is that, since calls to `jest.mock()` are hoisted to the top of the file, it's not possible to first define a variable and then use it in the factory. An exception is made for variables that start with the word 'mock'. It's up to you to guarantee that they will be initialized on time!
+A limitation with the factory parameter is that, since calls to `jest.mock()` are hoisted to the top of the file, it's not possible to first define a variable and then use it in the factory. An exception is made for variables that start with the word 'mock'. It's up to you to guarantee that they will be initialized on time! For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration:
+
+ ```javascript
+// Note: this will fail
+import SoundPlayer from './sound-player';
+const fakePlaySoundFile = jest.fn();
+jest.mock('./sound-player', () => {
+  return jest.fn().mockImplementation(() => {
+    return {playSoundFile: fakePlaySoundFile};
+  });
+});
+```
 
 ### Replacing the mock using [`mockImplementation()`](MockFunctionAPI.md#mockfnmockimplementationfn) or [`mockImplementationOnce()`](MockFunctionAPI.md#mockfnmockimplementationoncefn)
 

--- a/website/versioned_docs/version-24.0/Es6ClassMocks.md
+++ b/website/versioned_docs/version-24.0/Es6ClassMocks.md
@@ -148,7 +148,7 @@ jest.mock('./sound-player', () => {
 
 A limitation with the factory parameter is that, since calls to `jest.mock()` are hoisted to the top of the file, it's not possible to first define a variable and then use it in the factory. An exception is made for variables that start with the word 'mock'. It's up to you to guarantee that they will be initialized on time! For example, the following will throw an out-of-scope error due to the use of 'fake' instead of 'mock' in the variable declaration:
 
- ```javascript
+```javascript
 // Note: this will fail
 import SoundPlayer from './sound-player';
 const fakePlaySoundFile = jest.fn();


### PR DESCRIPTION
The docs don't explicitly say that in the `mockImplementation` example `const mockPlaySoundFile = jest.fn();` is relying on some behind-the-scenes magic. Not sure why but the explanation didn't click for me and it seems like I'm not the only one. This is an attempt to highlight this point

For reference: https://github.com/facebook/jest/issues/2567#issuecomment-462520630