### PR TITLE
Change --passWithNoTests message to match exit code

### DIFF
--- a/packages/jest-core/src/getNoTestFound.ts
+++ b/packages/jest-core/src/getNoTestFound.ts
@@ -30,11 +30,7 @@ export default function getNoTestFound(
     )} - 0 matches`;
   }
 
-  return (
-    chalk.bold('No tests found, exiting with code 1') +
-    '\n' +
-    'Run with `--passWithNoTests` to exit with code 0' +
-    '\n' +
+  const fixedMessage =
     `In ${chalk.bold(globalConfig.rootDir)}` +
     '\n' +
     `  ${pluralize('file', testFiles, 's')} checked across ${pluralize(
@@ -43,6 +39,19 @@ export default function getNoTestFound(
       's',
     )}. Run with \`--verbose\` for more details.` +
     '\n' +
-    dataMessage
+    dataMessage;
+
+  if (globalConfig.passWithNoTests) {
+    return (
+      chalk.bold('No tests found, exiting with code 0') + '\n' + fixedMessage
+    );
+  }
+
+  return (
+    chalk.bold('No tests found, exiting with code 1') +
+    '\n' +
+    'Run with `--passWithNoTests` to exit with code 0' +
+    '\n' +
+    fixedMessage
   );
 }

--- a/packages/jest-core/src/getNoTestFoundVerbose.ts
+++ b/packages/jest-core/src/getNoTestFoundVerbose.ts
@@ -52,6 +52,16 @@ export default function getNoTestFoundVerbose(
     )} - 0 matches`;
   }
 
+  if (globalConfig.passWithNoTests) {
+    return (
+      chalk.bold('No tests found, exiting with code 0') +
+      '\n' +
+      individualResults.join('\n') +
+      '\n' +
+      dataMessage
+    );
+  }
+
   return (
     chalk.bold('No tests found, exiting with code 1') +
     '\n' +


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Fixes #8187 


## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

```sh
$ y jest blahblah --passWithNoTests
yarn run v1.15.0
$ node ./packages/jest-cli/bin/jest.js blahblah --passWithNoTests
No tests found, exiting with code 0
In /Users/jeanabayo/Side/oss/jest
  2156 files checked across 14 projects. Run with `--verbose` for more details.
Pattern: blahblah - 0 matches
✨  Done in 1.36s.
```
