### PR TITLE
fix 1-indexed JEST_WORKER_ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - `[pretty-format]` Print `BigInt` as a readable number instead of `{}` ([#8138](https://github.com/facebook/jest/pull/8138))
 - `[jest-core]` Fix ability to transform dependencies required from globalSetup script [#8143](https://github.com/facebook/jest/pull/8143)
 - `[@jest/reporters]` Fix Cannot read property converageData of null ([#8168](https://github.com/facebook/jest/pull/8168))
+- `[jest-worker]` `JEST_WORKER_ID` starts at 1 ([#8205](https://github.com/facebook/jest/pull/8205))
 
 ### Chore & Maintenance
 

--- a/packages/jest-worker/src/workers/ChildProcessWorker.ts
+++ b/packages/jest-worker/src/workers/ChildProcessWorker.ts
@@ -67,7 +67,7 @@ export default class ChildProcessWorker implements WorkerInterface {
       cwd: process.cwd(),
       env: {
         ...process.env,
-        JEST_WORKER_ID: String(this._options.workerId),
+        JEST_WORKER_ID: String(this._options.workerId + 1),
         ...forceColor,
       } as NodeJS.ProcessEnv,
       // Suppress --debug / --inspect flags while preserving others (like --harmony).

--- a/packages/jest-worker/src/workers/ChildProcessWorker.ts
+++ b/packages/jest-worker/src/workers/ChildProcessWorker.ts
@@ -67,7 +67,7 @@ export default class ChildProcessWorker implements WorkerInterface {
       cwd: process.cwd(),
       env: {
         ...process.env,
-        JEST_WORKER_ID: String(this._options.workerId + 1),
+        JEST_WORKER_ID: String(this._options.workerId + 1), // 0-indexed workerId, 1-indexed JEST_WORKER_ID
         ...forceColor,
       } as NodeJS.ProcessEnv,
       // Suppress --debug / --inspect flags while preserving others (like --harmony).

--- a/packages/jest-worker/src/workers/NodeThreadsWorker.ts
+++ b/packages/jest-worker/src/workers/NodeThreadsWorker.ts
@@ -54,7 +54,7 @@ export default class ExperimentalWorker implements WorkerInterface {
         cwd: process.cwd(),
         env: {
           ...process.env,
-          JEST_WORKER_ID: String(this._options.workerId),
+          JEST_WORKER_ID: String(this._options.workerId + 1),
         } as NodeJS.ProcessEnv,
         // Suppress --debug / --inspect flags while preserving others (like --harmony).
         execArgv: process.execArgv.filter(v => !/^--(debug|inspect)/.test(v)),

--- a/packages/jest-worker/src/workers/NodeThreadsWorker.ts
+++ b/packages/jest-worker/src/workers/NodeThreadsWorker.ts
@@ -54,7 +54,7 @@ export default class ExperimentalWorker implements WorkerInterface {
         cwd: process.cwd(),
         env: {
           ...process.env,
-          JEST_WORKER_ID: String(this._options.workerId + 1),
+          JEST_WORKER_ID: String(this._options.workerId + 1), // 0-indexed workerId, 1-indexed JEST_WORKER_ID
         } as NodeJS.ProcessEnv,
         // Suppress --debug / --inspect flags while preserving others (like --harmony).
         execArgv: process.execArgv.filter(v => !/^--(debug|inspect)/.test(v)),

--- a/packages/jest-worker/src/workers/__tests__/ChildProcessWorker.test.js
+++ b/packages/jest-worker/src/workers/__tests__/ChildProcessWorker.test.js
@@ -58,7 +58,7 @@ it('passes fork options down to child_process.fork, adding the defaults', () => 
       execPath: 'hello',
     },
     maxRetries: 3,
-    workerId: process.env.JEST_WORKER_ID,
+    workerId: process.env.JEST_WORKER_ID - 1,
     workerPath: '/tmp/foo/bar/baz.js',
   });
 
@@ -72,7 +72,7 @@ it('passes fork options down to child_process.fork, adding the defaults', () => 
   });
 });
 
-it('passes workerId to the child process and assign it to env.JEST_WORKER_ID', () => {
+it('passes workerId to the child process and assign it 1-indexed to env.JEST_WORKER_ID', () => {
   new Worker({
     forkOptions: {},
     maxRetries: 3,
@@ -80,7 +80,7 @@ it('passes workerId to the child process and assign it to env.JEST_WORKER_ID', (
     workerPath: '/tmp/foo',
   });
 
-  expect(childProcess.fork.mock.calls[0][2].env.JEST_WORKER_ID).toEqual('2');
+  expect(childProcess.fork.mock.calls[0][2].env.JEST_WORKER_ID).toEqual('3');
 });
 
 it('initializes the child process with the given workerPath', () => {

--- a/packages/jest-worker/src/workers/__tests__/ChildProcessWorker.test.js
+++ b/packages/jest-worker/src/workers/__tests__/ChildProcessWorker.test.js
@@ -72,7 +72,7 @@ it('passes fork options down to child_process.fork, adding the defaults', () => 
   });
 });
 
-it('passes workerId to the child process and assign it 1-indexed to env.JEST_WORKER_ID', () => {
+it('passes workerId to the child process and assign it to 1-indexed env.JEST_WORKER_ID', () => {
   new Worker({
     forkOptions: {},
     maxRetries: 3,

--- a/packages/jest-worker/src/workers/__tests__/NodeThreadsWorker.test.js
+++ b/packages/jest-worker/src/workers/__tests__/NodeThreadsWorker.test.js
@@ -63,7 +63,7 @@ it('passes fork options down to child_process.fork, adding the defaults', () => 
       execPath: 'hello',
     },
     maxRetries: 3,
-    workerId: process.env.JEST_WORKER_ID,
+    workerId: process.env.JEST_WORKER_ID - 1,
     workerPath: '/tmp/foo/bar/baz.js',
   });
 
@@ -91,7 +91,7 @@ it('passes workerId to the child process and assign it to env.JEST_WORKER_ID', (
   });
 
   expect(childProcess.mock.calls[0][1].workerData.env.JEST_WORKER_ID).toEqual(
-    '2',
+    '3',
   );
 });
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Fixes #8204 
It's weird that it's 1-indexed (I looked at making our `workerId` 1-indexed too for consistency, but that would make our code really weird), but I guess it's documented, used to work like that and still does for `runInBand` 🤷‍♂️ 
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
