### PR TITLE
exit workers gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@
 - `[babel-plugin-jest-hoist]` Show codeframe on static hoisting issues ([#8865](https://github.com/facebook/jest/pull/8865))
 - `[jest-config]` [**BREAKING**] Set default display name color based on runner ([#8689](https://github.com/facebook/jest/pull/8689))
 - `[jest-diff]` Add options for colors and symbols ([#8841](https://github.com/facebook/jest/pull/8841))
+- `[jest-runner]` Warn if a worker had to be force exited ([#8206](https://github.com/facebook/jest/pull/8206))
 - `[@jest/test-result]` Create method to create empty `TestResult` ([#8867](https://github.com/facebook/jest/pull/8867))
+- `[jest-worker]` [**BREAKING**] Return a promise from `end()`, resolving with the information whether workers exited gracefully ([#8206](https://github.com/facebook/jest/pull/8206))
 
 ### Fixes
 

--- a/e2e/Utils.ts
+++ b/e2e/Utils.ts
@@ -90,6 +90,21 @@ export const writeFiles = (
   });
 };
 
+const NUMBER_OF_TESTS_TO_FORCE_USING_WORKERS = 25;
+/**
+ * Forces Jest to use workers by generating many test files to run.
+ * Slow and modifies the test output. Use sparingly.
+ */
+export const generateTestFilesToForceUsingWorkers = () => {
+  const testFiles = {};
+  for (let i = 0; i <= NUMBER_OF_TESTS_TO_FORCE_USING_WORKERS; i++) {
+    testFiles[`__tests__/test${i}.test.js`] = `
+      test('test ${i}', () => {});
+    `;
+  }
+  return testFiles;
+};
+
 export const copyDir = (src: string, dest: string) => {
   const srcStat = fs.lstatSync(src);
   if (srcStat.isDirectory()) {

--- a/e2e/Utils.ts
+++ b/e2e/Utils.ts
@@ -99,7 +99,7 @@ export const generateTestFilesToForceUsingWorkers = () => {
   const testFiles = {};
   for (let i = 0; i <= NUMBER_OF_TESTS_TO_FORCE_USING_WORKERS; i++) {
     testFiles[`__tests__/test${i}.test.js`] = `
-      test('test ${i}', () => {});
+      test.todo('test ${i}');
     `;
   }
   return testFiles;

--- a/e2e/__tests__/fatalWorkerError.test.ts
+++ b/e2e/__tests__/fatalWorkerError.test.ts
@@ -7,7 +7,11 @@
 
 import * as path from 'path';
 import {tmpdir} from 'os';
-import {cleanup, writeFiles} from '../Utils';
+import {
+  cleanup,
+  generateTestFilesToForceUsingWorkers,
+  writeFiles,
+} from '../Utils';
 import runJest from '../runJest';
 
 const DIR = path.resolve(tmpdir(), 'fatal-worker-error');
@@ -15,22 +19,15 @@ const DIR = path.resolve(tmpdir(), 'fatal-worker-error');
 beforeEach(() => cleanup(DIR));
 afterAll(() => cleanup(DIR));
 
-const NUMBER_OF_TESTS_TO_FORCE_USING_WORKERS = 25;
-
 test('fails a test that terminates the worker with a fatal error', () => {
   const testFiles = {
+    ...generateTestFilesToForceUsingWorkers(),
     '__tests__/fatalWorkerError.test.js': `
       test('fatal worker error', () => {
         process.exit(134);
       });
     `,
   };
-
-  for (let i = 0; i <= NUMBER_OF_TESTS_TO_FORCE_USING_WORKERS; i++) {
-    testFiles[`__tests__/test${i}.test.js`] = `
-      test('test ${i}', () => {});
-    `;
-  }
 
   writeFiles(DIR, {
     ...testFiles,

--- a/e2e/__tests__/workerForceExit.test.ts
+++ b/e2e/__tests__/workerForceExit.test.ts
@@ -1,0 +1,62 @@
+import {tmpdir} from 'os';
+import {resolve} from 'path';
+import findProcess from 'find-process';
+
+import {
+  cleanup,
+  generateTestFilesToForceUsingWorkers,
+  writeFiles,
+} from '../Utils';
+import runJest from '../runJest';
+
+const DIR = resolve(tmpdir(), 'worker-force-exit');
+
+beforeEach(() => cleanup(DIR));
+const testFiles = {
+  ...generateTestFilesToForceUsingWorkers(),
+  'package.json': `{
+      "testEnvironment": "node"
+  }`,
+};
+afterEach(() => cleanup(DIR));
+
+const verifyNumPassed = stderr => {
+  const numberOfTestsPassed = (stderr.match(/\bPASS\b/g) || []).length;
+  // assuming -1 because of package.json, but +1 because of the individual test file
+  expect(numberOfTestsPassed).toBe(Object.keys(testFiles).length);
+};
+
+test('prints a warning if a worker is force exited', () => {
+  writeFiles(DIR, {
+    ...testFiles,
+    '__tests__/simple.test.js': `
+      test('t', () => {
+        require('http').createServer().listen(0);
+      });
+    `,
+  });
+  const {status, stderr, stdout} = runJest(DIR, ['--maxWorkers=2']);
+
+  expect(status).toBe(0);
+  verifyNumPassed(stderr);
+  expect(stdout).toContain('A worker process has failed to exit gracefully');
+});
+
+test('force exits a worker that fails to exit gracefully', async () => {
+  writeFiles(DIR, {
+    ...testFiles,
+    '__tests__/timeoutKilled.test.js': `
+      test('t', () => {
+        require('http').createServer().listen(0);
+        console.error('pid: ' + process.pid);
+      });
+    `,
+  });
+  const {status, stderr} = runJest(DIR, ['--maxWorkers=2']);
+
+  expect(status).toBe(0);
+  verifyNumPassed(stderr);
+
+  const [pid] = /pid: \d+/.exec(stderr);
+  expect(await findProcess('pid', pid)).toHaveLength(0);
+});

--- a/e2e/__tests__/workerForceExit.test.ts
+++ b/e2e/__tests__/workerForceExit.test.ts
@@ -19,13 +19,13 @@ import runJest from '../runJest';
 const DIR = resolve(tmpdir(), 'worker-force-exit');
 
 beforeEach(() => cleanup(DIR));
+afterEach(() => cleanup(DIR));
 const testFiles = {
   ...generateTestFilesToForceUsingWorkers(),
   'package.json': `{
       "testEnvironment": "node"
   }`,
 };
-afterEach(() => cleanup(DIR));
 
 const verifyNumPassed = stderr => {
   const numberOfTestsPassed = (stderr.match(/\bPASS\b/g) || []).length;

--- a/e2e/__tests__/workerForceExit.test.ts
+++ b/e2e/__tests__/workerForceExit.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 import {tmpdir} from 'os';
 import {resolve} from 'path';
 import findProcess from 'find-process';

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "eslint-plugin-react": "^7.1.0",
     "execa": "^2.0.4",
     "fast-check": "^1.13.0",
+    "find-process": "^1.4.1",
     "glob": "^7.1.1",
     "graceful-fs": "^4.1.15",
     "isbinaryfile": "^4.0.0",

--- a/packages/jest-runner/src/__tests__/testRunner.test.ts
+++ b/packages/jest-runner/src/__tests__/testRunner.test.ts
@@ -15,7 +15,7 @@ jest.mock('jest-worker', () =>
   jest.fn(
     worker =>
       (mockWorkerFarm = {
-        end: jest.fn(),
+        end: jest.fn().mockResolvedValue({forceExited: false}),
         getStderr: jest.fn(),
         getStdout: jest.fn(),
         worker: jest.fn((data, callback) => require(worker)(data, callback)),

--- a/packages/jest-runner/src/index.ts
+++ b/packages/jest-runner/src/index.ts
@@ -8,6 +8,7 @@
 import {Config} from '@jest/types';
 import {SerializableError} from '@jest/test-result';
 import exit = require('exit');
+import chalk from 'chalk';
 import throat from 'throat';
 import Worker from 'jest-worker';
 import runTest from './runTest';
@@ -189,7 +190,18 @@ class TestRunner {
       ),
     );
 
-    const cleanup = () => worker.end();
+    const cleanup = async () => {
+      const {forceExited} = await worker.end();
+      if (forceExited) {
+        console.log(
+          chalk.yellow(
+            'A worker process has failed to exit gracefully and has been force exited. ' +
+              'This is likely caused by tests leaking due to improper teardown. ' +
+              'Try running with --runInBand --detectOpenHandles to find leaks.',
+          ),
+        );
+      }
+    };
     return Promise.race([runAllTests, onInterrupt]).then(cleanup, cleanup);
   }
 }

--- a/packages/jest-worker/README.md
+++ b/packages/jest-worker/README.md
@@ -107,6 +107,8 @@ Returns a `ReadableStream` where the standard error of all workers is piped. Not
 
 ### `end()`
 
+TODO explain returned Promise, adapt examples
+
 Finishes the workers by killing all workers. No further calls can be done to the `Worker` instance.
 
 **Note:** Each worker has a unique id (index that starts with `1`) which is available on `process.env.JEST_WORKER_ID`

--- a/packages/jest-worker/README.md
+++ b/packages/jest-worker/README.md
@@ -107,9 +107,9 @@ Returns a `ReadableStream` where the standard error of all workers is piped. Not
 
 ### `end()`
 
-TODO explain returned Promise, adapt examples
-
 Finishes the workers by killing all workers. No further calls can be done to the `Worker` instance.
+
+Returns a Promise that resolves with `{ forceExited: boolean }` once all workers are dead. If `forceExited` is `true`, at least one of the workers did not exit gracefully, which likely happened because it executed a leaky task that left handles open. This should be avoided, force exiting workers is a last resort to prevent creating lots of orphans.
 
 **Note:** Each worker has a unique id (index that starts with `1`) which is available on `process.env.JEST_WORKER_ID`
 
@@ -141,7 +141,10 @@ async function main() {
   console.log(await myWorker.bar('Bob')); // "Hello from bar: Bob"
   console.log(await myWorker.getWorkerId()); // "3" -> this message has sent from the 3rd worker
 
-  myWorker.end();
+  const {forceExited} = await myWorker.end();
+  if (forceExited) {
+    console.error('Workers failed to exit gracefully');
+  }
 }
 
 main();
@@ -188,7 +191,10 @@ async function main() {
   // the same worker that processed the file the first time will process it now.
   console.log(await myWorker.transform('/tmp/foo.js'));
 
-  myWorker.end();
+  const {forceExited} = await myWorker.end();
+  if (forceExited) {
+    console.error('Workers failed to exit gracefully');
+  }
 }
 
 main();

--- a/packages/jest-worker/src/__tests__/index.test.js
+++ b/packages/jest-worker/src/__tests__/index.test.js
@@ -133,7 +133,7 @@ it('does not let make calls after the farm is ended', () => {
   );
 });
 
-it('does not let end the farm after it is ended', () => {
+it('does not let end the farm after it is ended', async () => {
   const farm = new Farm('/tmp/baz.js', {
     exposedMethods: ['foo', 'bar'],
     numWorkers: 4,
@@ -141,10 +141,10 @@ it('does not let end the farm after it is ended', () => {
 
   farm.end();
   expect(farm._workerPool.end).toHaveBeenCalledTimes(1);
-  expect(farm.end()).rejects.toThrow(
+  await expect(farm.end()).rejects.toThrow(
     'Farm is ended, no more calls can be done to it',
   );
-  expect(farm.end()).rejects.toThrow(
+  await expect(farm.end()).rejects.toThrow(
     'Farm is ended, no more calls can be done to it',
   );
   expect(farm._workerPool.end).toHaveBeenCalledTimes(1);

--- a/packages/jest-worker/src/__tests__/index.test.js
+++ b/packages/jest-worker/src/__tests__/index.test.js
@@ -141,10 +141,10 @@ it('does not let end the farm after it is ended', () => {
 
   farm.end();
   expect(farm._workerPool.end).toHaveBeenCalledTimes(1);
-  expect(() => farm.end()).toThrow(
+  expect(farm.end()).rejects.toThrow(
     'Farm is ended, no more calls can be done to it',
   );
-  expect(() => farm.end()).toThrow(
+  expect(farm.end()).rejects.toThrow(
     'Farm is ended, no more calls can be done to it',
   );
   expect(farm._workerPool.end).toHaveBeenCalledTimes(1);

--- a/packages/jest-worker/src/base/__tests__/BaseWorkerPool.test.js
+++ b/packages/jest-worker/src/base/__tests__/BaseWorkerPool.test.js
@@ -7,15 +7,11 @@
 
 'use strict';
 
-import {CHILD_MESSAGE_END} from '../../types';
+import {CHILD_MESSAGE_END, CHILD_MESSAGE_FORCE_EXIT} from '../../types';
 
 import BaseWorkerPool from '../BaseWorkerPool';
 
-const Worker = jest.fn(() => ({
-  getStderr: () => ({once() {}, pipe() {}}),
-  getStdout: () => ({once() {}, pipe() {}}),
-  send: jest.fn(),
-}));
+const Worker = jest.fn();
 
 const mockSend = jest.fn();
 
@@ -31,6 +27,12 @@ class MockWorkerPool extends BaseWorkerPool {
 describe('BaseWorkerPool', () => {
   beforeEach(() => {
     Worker.mockClear();
+    Worker.mockImplementation(() => ({
+      getStderr: () => ({once() {}, pipe() {}}),
+      getStdout: () => ({once() {}, pipe() {}}),
+      send: jest.fn(),
+      waitForExit: () => Promise.resolve(),
+    }));
   });
 
   it('throws error when createWorker is not defined', () => {
@@ -58,24 +60,6 @@ describe('BaseWorkerPool', () => {
     expect(pool.getWorkerById(1)).toBeDefined();
     expect(pool.getWorkerById(2)).toBeDefined();
     expect(pool.getWorkerById(3)).toBeDefined();
-  });
-
-  it('ends all workers', () => {
-    const pool = new MockWorkerPool('/tmp/baz.js', {
-      forkOptions: {execArgv: []},
-      maxRetries: 6,
-      numWorkers: 4,
-      setupArgs: [],
-    });
-
-    const workers = pool.getWorkers();
-    pool.end();
-
-    const endMessage = [CHILD_MESSAGE_END, false];
-    expect(workers[0].send.mock.calls[0][0]).toEqual(endMessage);
-    expect(workers[1].send.mock.calls[0][0]).toEqual(endMessage);
-    expect(workers[2].send.mock.calls[0][0]).toEqual(endMessage);
-    expect(workers[3].send.mock.calls[0][0]).toEqual(endMessage);
   });
 
   it('creates and expoeses n workers', () => {
@@ -220,5 +204,78 @@ describe('BaseWorkerPool', () => {
 
     expect(() => farm.send()).not.toThrow();
     expect(() => farm.send()).not.toThrow();
+  });
+
+  describe('end', () => {
+    it('ends all workers', async () => {
+      const pool = new MockWorkerPool('/tmp/baz.js', {
+        forkOptions: {execArgv: []},
+        maxRetries: 6,
+        numWorkers: 4,
+        setupArgs: [],
+      });
+
+      const workers = pool.getWorkers();
+      await pool.end();
+
+      const endMessage = [CHILD_MESSAGE_END, false];
+      expect(workers[0].send.mock.calls[0][0]).toEqual(endMessage);
+      expect(workers[1].send.mock.calls[0][0]).toEqual(endMessage);
+      expect(workers[2].send.mock.calls[0][0]).toEqual(endMessage);
+      expect(workers[3].send.mock.calls[0][0]).toEqual(endMessage);
+    });
+
+    it('resolves with forceExited=false if workers exited gracefully', async () => {
+      Worker.mockImplementation(() => ({
+        getStderr: () => null,
+        getStdout: () => null,
+        send: jest.fn(),
+        waitForExit: () => Promise.resolve(),
+      }));
+
+      const pool = new MockWorkerPool('/tmp/baz.js', {
+        forkOptions: {execArgv: []},
+        maxRetries: 6,
+        numWorkers: 4,
+        setupArgs: [],
+      });
+
+      expect(await pool.end()).toEqual({forceExited: false});
+    });
+
+    it('force exits workers that do not exit gracefully and resolves with forceExited=true', async () => {
+      // Set it up so that the first worker does not resolve waitForExit immediately,
+      // but only when it receives CHILD_MESSAGE_FORCE_EXIT
+      let worker0Exited;
+      Worker.mockImplementationOnce(() => ({
+        getStderr: () => null,
+        getStdout: () => null,
+        send: request => {
+          if (request[0] === CHILD_MESSAGE_FORCE_EXIT) {
+            worker0Exited();
+          }
+        },
+        waitForExit: () => new Promise(resolve => (worker0Exited = resolve)),
+      })).mockImplementation(() => ({
+        getStderr: () => null,
+        getStdout: () => null,
+        send: jest.fn(),
+        waitForExit: () => Promise.resolve(),
+      }));
+
+      const pool = new MockWorkerPool('/tmp/baz.js', {
+        forkOptions: {execArgv: []},
+        maxRetries: 6,
+        numWorkers: 2,
+        setupArgs: [],
+      });
+
+      const workers = pool.getWorkers();
+      expect(await pool.end()).toEqual({forceExited: true});
+
+      expect(workers[1].send).not.toHaveBeenCalledWith([
+        CHILD_MESSAGE_FORCE_EXIT,
+      ]);
+    });
   });
 });

--- a/packages/jest-worker/src/index.ts
+++ b/packages/jest-worker/src/index.ts
@@ -137,12 +137,12 @@ export default class JestWorker {
     return this._workerPool.getStdout();
   }
 
-  end(): Promise<PoolExitResult> {
+  async end(): Promise<PoolExitResult> {
     if (this._ending) {
       throw new Error('Farm is ended, no more calls can be done to it');
     }
     this._ending = true;
 
-    return this._workerPool.end();
+    return await this._workerPool.end();
   }
 }

--- a/packages/jest-worker/src/index.ts
+++ b/packages/jest-worker/src/index.ts
@@ -8,7 +8,12 @@
 import {cpus} from 'os';
 import WorkerPool from './WorkerPool';
 import Farm from './Farm';
-import {FarmOptions, WorkerPoolInterface, WorkerPoolOptions} from './types';
+import {
+  FarmOptions,
+  PoolExitResult,
+  WorkerPoolInterface,
+  WorkerPoolOptions,
+} from './types';
 
 function getExposedMethods(
   workerPath: string,
@@ -132,13 +137,12 @@ export default class JestWorker {
     return this._workerPool.getStdout();
   }
 
-  end(): void {
+  end(): Promise<PoolExitResult> {
     if (this._ending) {
       throw new Error('Farm is ended, no more calls can be done to it');
     }
-
-    this._workerPool.end();
-
     this._ending = true;
+
+    return this._workerPool.end();
   }
 }

--- a/packages/jest-worker/src/index.ts
+++ b/packages/jest-worker/src/index.ts
@@ -143,6 +143,6 @@ export default class JestWorker {
     }
     this._ending = true;
 
-    return await this._workerPool.end();
+    return this._workerPool.end();
   }
 }

--- a/packages/jest-worker/src/types.ts
+++ b/packages/jest-worker/src/types.ts
@@ -15,7 +15,6 @@ import {ForkOptions} from 'child_process';
 export const CHILD_MESSAGE_INITIALIZE: 0 = 0;
 export const CHILD_MESSAGE_CALL: 1 = 1;
 export const CHILD_MESSAGE_END: 2 = 2;
-export const CHILD_MESSAGE_FORCE_EXIT: 3 = 3;
 
 export const PARENT_MESSAGE_OK: 0 = 0;
 export const PARENT_MESSAGE_CLIENT_ERROR: 1 = 1;
@@ -46,6 +45,7 @@ export interface WorkerInterface {
     onProcessEnd: OnEnd,
   ): void;
   waitForExit(): Promise<void>;
+  forceExit(): void;
 
   getWorkerId(): number;
   getStderr(): NodeJS.ReadableStream | null;
@@ -121,13 +121,10 @@ export type ChildMessageEnd = [
   boolean, // processed
 ];
 
-export type ChildMessageForceExit = [typeof CHILD_MESSAGE_FORCE_EXIT];
-
 export type ChildMessage =
   | ChildMessageInitialize
   | ChildMessageCall
-  | ChildMessageEnd
-  | ChildMessageForceExit;
+  | ChildMessageEnd;
 
 // Messages passed from the children to the parent.
 

--- a/packages/jest-worker/src/workers/ChildProcessWorker.ts
+++ b/packages/jest-worker/src/workers/ChildProcessWorker.ts
@@ -23,6 +23,10 @@ import {
   WorkerOptions,
 } from '../types';
 
+const SIGNAL_BASE_EXIT_CODE = 128;
+const SIGKILL_EXIT_CODE = SIGNAL_BASE_EXIT_CODE + 9;
+const SIGTERM_EXIT_CODE = SIGNAL_BASE_EXIT_CODE + 15;
+
 // How long to wait after SIGTERM before sending SIGKILL
 const SIGKILL_DELAY = 500;
 
@@ -198,8 +202,8 @@ export default class ChildProcessWorker implements WorkerInterface {
   private _onExit(exitCode: number) {
     if (
       exitCode !== 0 &&
-      exitCode !== 137 && // SIGKILL
-      exitCode !== 143 // SIGTERM
+      exitCode !== SIGTERM_EXIT_CODE &&
+      exitCode !== SIGKILL_EXIT_CODE
     ) {
       this.initialize();
 

--- a/packages/jest-worker/src/workers/ChildProcessWorker.ts
+++ b/packages/jest-worker/src/workers/ChildProcessWorker.ts
@@ -198,7 +198,8 @@ export default class ChildProcessWorker implements WorkerInterface {
   private _onExit(exitCode: number) {
     if (
       exitCode !== 0 &&
-      exitCode <= 128 // importantly, do not reinitialize for 137 (SIGKILL) or 143 (SIGTERM)
+      exitCode !== 137 && // SIGKILL
+      exitCode !== 143 // SIGTERM
     ) {
       this.initialize();
 

--- a/packages/jest-worker/src/workers/NodeThreadsWorker.ts
+++ b/packages/jest-worker/src/workers/NodeThreadsWorker.ts
@@ -25,6 +25,8 @@ import {
   WorkerOptions,
 } from '../types';
 
+// TODO
+
 export default class ExperimentalWorker implements WorkerInterface {
   private _worker!: Worker;
   private _options: WorkerOptions;

--- a/packages/jest-worker/src/workers/NodeThreadsWorker.ts
+++ b/packages/jest-worker/src/workers/NodeThreadsWorker.ts
@@ -25,24 +25,35 @@ import {
   WorkerOptions,
 } from '../types';
 
-// TODO
-
 export default class ExperimentalWorker implements WorkerInterface {
   private _worker!: Worker;
   private _options: WorkerOptions;
-  private _onProcessEnd!: OnEnd;
+
   private _request: ChildMessage | null;
   private _retries!: number;
-  private _stderr: ReturnType<typeof mergeStream> | null;
-  private _stdout: ReturnType<typeof mergeStream> | null;
+  private _onProcessEnd!: OnEnd;
+
   private _fakeStream: PassThrough | null;
+  private _stdout: ReturnType<typeof mergeStream> | null;
+  private _stderr: ReturnType<typeof mergeStream> | null;
+
+  private _exitPromise: Promise<void>;
+  private _resolveExitPromise!: () => void;
+  private _forceExited: boolean;
 
   constructor(options: WorkerOptions) {
     this._options = options;
+
     this._request = null;
-    this._stderr = null;
-    this._stdout = null;
+
     this._fakeStream = null;
+    this._stdout = null;
+    this._stderr = null;
+
+    this._exitPromise = new Promise(resolve => {
+      this._resolveExitPromise = resolve;
+    });
+    this._forceExited = false;
 
     this.initialize();
   }
@@ -85,8 +96,8 @@ export default class ExperimentalWorker implements WorkerInterface {
       this._stderr.add(this._worker.stderr);
     }
 
-    this._worker.on('message', this.onMessage.bind(this));
-    this._worker.on('exit', this.onExit.bind(this));
+    this._worker.on('message', this._onMessage.bind(this));
+    this._worker.on('exit', this._onExit.bind(this));
 
     this._worker.postMessage([
       CHILD_MESSAGE_INITIALIZE,
@@ -103,7 +114,7 @@ export default class ExperimentalWorker implements WorkerInterface {
     if (this._retries > this._options.maxRetries) {
       const error = new Error('Call retries were exceeded');
 
-      this.onMessage([
+      this._onMessage([
         PARENT_MESSAGE_CLIENT_ERROR,
         error.name,
         error.message,
@@ -119,9 +130,11 @@ export default class ExperimentalWorker implements WorkerInterface {
       this._fakeStream.end();
       this._fakeStream = null;
     }
+
+    this._resolveExitPromise();
   }
 
-  onMessage(response: ParentMessage) {
+  private _onMessage(response: ParentMessage) {
     let error;
 
     switch (response[0]) {
@@ -164,8 +177,8 @@ export default class ExperimentalWorker implements WorkerInterface {
     }
   }
 
-  onExit(exitCode: number) {
-    if (exitCode !== 0) {
+  private _onExit(exitCode: number) {
+    if (exitCode !== 0 && !this._forceExited) {
       this.initialize();
 
       if (this._request) {
@@ -174,6 +187,15 @@ export default class ExperimentalWorker implements WorkerInterface {
     } else {
       this._shutdown();
     }
+  }
+
+  waitForExit() {
+    return this._exitPromise;
+  }
+
+  forceExit() {
+    this._forceExited = true;
+    this._worker.terminate();
   }
 
   send(request: ChildMessage, onProcessStart: OnStart, onProcessEnd: OnEnd) {

--- a/packages/jest-worker/src/workers/__tests__/ChildProcessWorker.test.js
+++ b/packages/jest-worker/src/workers/__tests__/ChildProcessWorker.test.js
@@ -298,6 +298,18 @@ it('does not restart the child if it cleanly exited', () => {
   expect(childProcess.fork).toHaveBeenCalledTimes(1);
 });
 
+it('resolves waitForExit() after the child process cleanly exited', async () => {
+  const worker = new Worker({
+    forkOptions: {},
+    maxRetries: 3,
+    workerPath: '/tmp/foo',
+  });
+
+  expect(childProcess.fork).toHaveBeenCalledTimes(1);
+  forkInterface.emit('exit', 0);
+  await worker.waitForExit(); // should not timeout
+});
+
 it('restarts the child when the child process dies', () => {
   new Worker({
     workerPath: '/tmp/foo',

--- a/packages/jest-worker/src/workers/__tests__/ChildProcessWorker.test.js
+++ b/packages/jest-worker/src/workers/__tests__/ChildProcessWorker.test.js
@@ -117,10 +117,10 @@ it('stops initializing the worker after the amount of retries is exceeded', () =
   worker.send(request, onProcessStart, onProcessEnd);
 
   // We fail four times (initial + three retries).
-  forkInterface.emit('exit');
-  forkInterface.emit('exit');
-  forkInterface.emit('exit');
-  forkInterface.emit('exit');
+  forkInterface.emit('exit', 1);
+  forkInterface.emit('exit', 1);
+  forkInterface.emit('exit', 1);
+  forkInterface.emit('exit', 1);
 
   expect(childProcess.fork).toHaveBeenCalledTimes(5);
   expect(onProcessStart).toBeCalledWith(worker);
@@ -142,7 +142,7 @@ it('provides stdout and stderr from the child processes', async () => {
 
   forkInterface.stdout.end('Hello ', {encoding: 'utf8'});
   forkInterface.stderr.end('Jest ', {encoding: 'utf8'});
-  forkInterface.emit('exit');
+  forkInterface.emit('exit', 1);
   forkInterface.stdout.end('World!', {encoding: 'utf8'});
   forkInterface.stderr.end('Workers!', {encoding: 'utf8'});
   forkInterface.emit('exit', 0);
@@ -182,7 +182,7 @@ it('resends the task to the child process after a retry', () => {
   expect(forkInterface.send.mock.calls[1][0]).toEqual(request);
 
   const previousForkInterface = forkInterface;
-  forkInterface.emit('exit');
+  forkInterface.emit('exit', 1);
 
   expect(forkInterface).not.toBe(previousForkInterface);
 

--- a/packages/jest-worker/src/workers/__tests__/NodeThreadsWorker.test.js
+++ b/packages/jest-worker/src/workers/__tests__/NodeThreadsWorker.test.js
@@ -20,7 +20,7 @@ import {
 } from '../../types';
 
 let Worker;
-let childProcess;
+let workerThreads;
 let originalExecArgv;
 
 beforeEach(() => {
@@ -31,6 +31,7 @@ beforeEach(() => {
 
       const thread = new EventEmitter();
       thread.postMessage = jest.fn();
+      thread.terminate = jest.fn();
       thread.stdout = new PassThrough();
       thread.stderr = new PassThrough();
       return thread;
@@ -42,8 +43,8 @@ beforeEach(() => {
   });
   originalExecArgv = process.execArgv;
 
-  childProcess = require('worker_threads').Worker;
-  childProcess.postMessage = jest.fn();
+  workerThreads = require('worker_threads').Worker;
+  workerThreads.postMessage = jest.fn();
 
   Worker = require('../NodeThreadsWorker').default;
 });
@@ -54,7 +55,7 @@ afterEach(() => {
 });
 
 it('passes fork options down to child_process.fork, adding the defaults', () => {
-  const child = require.resolve('../threadChild');
+  const thread = require.resolve('../threadChild');
 
   process.execArgv = ['--inspect', '-p'];
 
@@ -68,8 +69,8 @@ it('passes fork options down to child_process.fork, adding the defaults', () => 
     workerPath: '/tmp/foo/bar/baz.js',
   });
 
-  expect(childProcess.mock.calls[0][0]).toBe(child.replace(/\.ts$/, '.js'));
-  expect(childProcess.mock.calls[0][1]).toEqual({
+  expect(workerThreads.mock.calls[0][0]).toBe(thread.replace(/\.ts$/, '.js'));
+  expect(workerThreads.mock.calls[0][1]).toEqual({
     eval: false,
     stderr: true,
     stdout: true,
@@ -83,7 +84,7 @@ it('passes fork options down to child_process.fork, adding the defaults', () => 
   });
 });
 
-it('passes workerId to the child process and assign it to env.JEST_WORKER_ID', () => {
+it('passes workerId to the thread and assign it to env.JEST_WORKER_ID', () => {
   new Worker({
     forkOptions: {},
     maxRetries: 3,
@@ -91,12 +92,12 @@ it('passes workerId to the child process and assign it to env.JEST_WORKER_ID', (
     workerPath: '/tmp/foo',
   });
 
-  expect(childProcess.mock.calls[0][1].workerData.env.JEST_WORKER_ID).toEqual(
+  expect(workerThreads.mock.calls[0][1].workerData.env.JEST_WORKER_ID).toEqual(
     '3',
   );
 });
 
-it('initializes the child process with the given workerPath', () => {
+it('initializes the thread with the given workerPath', () => {
   const worker = new Worker({
     forkOptions: {},
     maxRetries: 3,
@@ -131,7 +132,7 @@ it('stops initializing the worker after the amount of retries is exceeded', () =
   worker._worker.emit('exit');
   worker._worker.emit('exit');
 
-  expect(childProcess).toHaveBeenCalledTimes(5);
+  expect(workerThreads).toHaveBeenCalledTimes(5);
   expect(onProcessStart).toBeCalledWith(worker);
   expect(onProcessEnd).toHaveBeenCalledTimes(1);
   expect(onProcessEnd.mock.calls[0][0]).toBeInstanceOf(Error);
@@ -139,7 +140,7 @@ it('stops initializing the worker after the amount of retries is exceeded', () =
   expect(onProcessEnd.mock.calls[0][1]).toBe(null);
 });
 
-it('provides stdout and stderr from the child processes', async () => {
+it('provides stdout and stderr from the threads', async () => {
   const worker = new Worker({
     forkOptions: {},
     maxRetries: 3,
@@ -160,7 +161,7 @@ it('provides stdout and stderr from the child processes', async () => {
   await expect(getStream(stderr)).resolves.toEqual('Jest Workers!');
 });
 
-it('sends the task to the child process', () => {
+it('sends the task to the thread', () => {
   const worker = new Worker({
     forkOptions: {},
     maxRetries: 3,
@@ -175,7 +176,7 @@ it('sends the task to the child process', () => {
   expect(worker._worker.postMessage.mock.calls[1][0]).toEqual(request);
 });
 
-it('resends the task to the child process after a retry', () => {
+it('resends the task to the thread after a retry', () => {
   const worker = new Worker({
     forkOptions: {},
     maxRetries: 3,
@@ -282,7 +283,7 @@ it('creates error instances for known errors', () => {
   expect(callback3.mock.calls[0][0]).toBe(412);
 });
 
-it('throws when the child process returns a strange message', () => {
+it('throws when the thread returns a strange message', () => {
   const worker = new Worker({
     forkOptions: {},
     maxRetries: 3,
@@ -297,24 +298,47 @@ it('throws when the child process returns a strange message', () => {
   }).toThrow(TypeError);
 });
 
-it('does not restart the child if it cleanly exited', () => {
+it('does not restart the thread if it cleanly exited', () => {
   const worker = new Worker({
     forkOptions: {},
     maxRetries: 3,
     workerPath: '/tmp/foo',
   });
 
-  expect(childProcess).toHaveBeenCalledTimes(1);
+  expect(workerThreads).toHaveBeenCalledTimes(1);
   worker._worker.emit('exit', 0);
-  expect(childProcess).toHaveBeenCalledTimes(1);
+  expect(workerThreads).toHaveBeenCalledTimes(1);
 });
 
-it('restarts the child when the child process dies', () => {
+it('resolves waitForExit() after the thread cleanly exited', async () => {
+  const worker = new Worker({
+    forkOptions: {},
+    maxRetries: 3,
+    workerPath: '/tmp/foo',
+  });
+
+  expect(workerThreads).toHaveBeenCalledTimes(1);
+  worker._worker.emit('exit', 0);
+  await worker.waitForExit(); // should not timeout
+});
+
+it('restarts the thread when the thread dies', () => {
   const worker = new Worker({
     workerPath: '/tmp/foo',
   });
 
-  expect(childProcess).toHaveBeenCalledTimes(1);
+  expect(workerThreads).toHaveBeenCalledTimes(1);
   worker._worker.emit('exit', 1);
-  expect(childProcess).toHaveBeenCalledTimes(2);
+  expect(workerThreads).toHaveBeenCalledTimes(2);
+});
+
+it('terminates the thread when forceExit() is called', () => {
+  const worker = new Worker({
+    forkOptions: {},
+    maxRetries: 3,
+    workerPath: '/tmp/foo',
+  });
+
+  worker.forceExit();
+  expect(worker._worker.terminate).toHaveBeenCalled();
 });

--- a/packages/jest-worker/src/workers/__tests__/processChild.test.js
+++ b/packages/jest-worker/src/workers/__tests__/processChild.test.js
@@ -17,6 +17,7 @@ const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 import {
   CHILD_MESSAGE_CALL,
   CHILD_MESSAGE_END,
+  CHILD_MESSAGE_FORCE_EXIT,
   CHILD_MESSAGE_INITIALIZE,
   PARENT_MESSAGE_CLIENT_ERROR,
   PARENT_MESSAGE_OK,
@@ -314,6 +315,19 @@ it('calls the main export if the method call is "default" and it is a Babel tran
   expect(process.send.mock.calls[0][0]).toEqual([PARENT_MESSAGE_OK, 67890]);
 });
 
+it('removes the message listener on END message', () => {
+  // So that there are no more open handles preventing Node from exiting
+  process.emit('message', [
+    CHILD_MESSAGE_INITIALIZE,
+    true, // Not really used here, but for flow type purity.
+    './my-fancy-worker',
+  ]);
+
+  process.emit('message', [CHILD_MESSAGE_END]);
+
+  expect(process.listenerCount('message')).toBe(0);
+});
+
 it('finishes the process with exit code 0 if requested', () => {
   process.emit('message', [
     CHILD_MESSAGE_INITIALIZE,
@@ -322,7 +336,7 @@ it('finishes the process with exit code 0 if requested', () => {
   ]);
 
   process.emit('message', [
-    CHILD_MESSAGE_END,
+    CHILD_MESSAGE_FORCE_EXIT,
     true, // Not really used here, but for flow type purity.
   ]);
 

--- a/packages/jest-worker/src/workers/__tests__/processChild.test.js
+++ b/packages/jest-worker/src/workers/__tests__/processChild.test.js
@@ -17,7 +17,6 @@ const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 import {
   CHILD_MESSAGE_CALL,
   CHILD_MESSAGE_END,
-  CHILD_MESSAGE_FORCE_EXIT,
   CHILD_MESSAGE_INITIALIZE,
   PARENT_MESSAGE_CLIENT_ERROR,
   PARENT_MESSAGE_OK,
@@ -326,21 +325,6 @@ it('removes the message listener on END message', () => {
   process.emit('message', [CHILD_MESSAGE_END]);
 
   expect(process.listenerCount('message')).toBe(0);
-});
-
-it('finishes the process with exit code 0 if requested', () => {
-  process.emit('message', [
-    CHILD_MESSAGE_INITIALIZE,
-    true, // Not really used here, but for flow type purity.
-    './my-fancy-worker',
-  ]);
-
-  process.emit('message', [
-    CHILD_MESSAGE_FORCE_EXIT,
-    true, // Not really used here, but for flow type purity.
-  ]);
-
-  expect(process.exit.mock.calls[0]).toEqual([0]);
 });
 
 it('calls the teardown method ', () => {

--- a/packages/jest-worker/src/workers/__tests__/threadChild.test.js
+++ b/packages/jest-worker/src/workers/__tests__/threadChild.test.js
@@ -114,14 +114,11 @@ beforeEach(() => {
 
   thread = require('worker_threads').parentPort;
 
-  process.exit = jest.fn();
-
   // Require the child!
   require('../threadChild');
 });
 
 beforeEach(() => {
-  process.exit.mockClear();
   thread.postMessage.mockClear();
 });
 
@@ -341,7 +338,8 @@ it('calls the main export if the method call is "default" and it is a Babel tran
   ]);
 });
 
-it('finishes the process with exit code 0 if requested', () => {
+it('removes the message listener on END message', () => {
+  // So that there are no more open handles preventing Node from exiting
   thread.emit('message', [
     CHILD_MESSAGE_INITIALIZE,
     true, // Not really used here, but for flow type purity.
@@ -353,7 +351,7 @@ it('finishes the process with exit code 0 if requested', () => {
     true, // Not really used here, but for flow type purity.
   ]);
 
-  expect(process.exit).toHaveBeenCalledWith(0);
+  expect(thread.listenerCount('message')).toBe(0);
 });
 
 it('calls the teardown method ', () => {

--- a/packages/jest-worker/src/workers/processChild.ts
+++ b/packages/jest-worker/src/workers/processChild.ts
@@ -8,7 +8,6 @@
 import {
   CHILD_MESSAGE_CALL,
   CHILD_MESSAGE_END,
-  CHILD_MESSAGE_FORCE_EXIT,
   CHILD_MESSAGE_INITIALIZE,
   ChildMessageCall,
   ChildMessageInitialize,
@@ -50,10 +49,6 @@ const messageListener = (request: any) => {
 
     case CHILD_MESSAGE_END:
       end();
-      break;
-
-    case CHILD_MESSAGE_FORCE_EXIT:
-      forceExit();
       break;
 
     default:
@@ -113,10 +108,6 @@ function end(): void {
 function exitProcess(): void {
   // Clean up open handles so the process ideally exits gracefully
   process.removeListener('message', messageListener);
-}
-
-function forceExit(): void {
-  process.exit(0);
 }
 
 function execMethod(method: string, args: Array<any>): void {

--- a/packages/jest-worker/src/workers/threadChild.ts
+++ b/packages/jest-worker/src/workers/threadChild.ts
@@ -38,7 +38,7 @@ let initialized = false;
  * If an invalid message is detected, the child will exit (by throwing) with a
  * non-zero exit code.
  */
-parentPort!.on('message', (request: any) => {
+const messageListener = (request: any) => {
   switch (request[0]) {
     case CHILD_MESSAGE_INITIALIZE:
       const init: ChildMessageInitialize = request;
@@ -60,7 +60,8 @@ parentPort!.on('message', (request: any) => {
         'Unexpected request from parent process: ' + request[0],
       );
   }
-});
+};
+parentPort!.on('message', messageListener);
 
 function reportSuccess(result: any) {
   if (isMainThread) {
@@ -109,7 +110,8 @@ function end(): void {
 }
 
 function exitProcess(): void {
-  process.exit(0);
+  // Clean up open handles so the worker ideally exits gracefully
+  parentPort!.removeListener('message', messageListener);
 }
 
 function execMethod(method: string, args: Array<any>): void {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6227,6 +6227,15 @@ find-up@3.0.0, find-up@^3.0.0:
   dependencies:
     locate-path "^3.0.0"
 
+find-process@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/find-process/-/find-process-1.4.1.tgz#628c576a494d1525a27673fb26c77af90db5db02"
+  integrity sha512-RkYWDeukxEoDKUyocqMGKAYuwhSwq77zL99gCqhX9czWon3otdlzihJ0MSZ6YWNKHyvS/MN2YR4+RGYOuIEANg==
+  dependencies:
+    chalk "^2.0.1"
+    commander "^2.11.0"
+    debug "^2.6.8"
+
 find-up@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-1.1.2.tgz#6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

This PR makes child process workers avoid `process.exit`, instead gracefully exiting them by clearing open handles. If they fail to exit gracefully (usually because the user code leaks) after a delay, they are force exited using `SIGTERM` and if that doesn't help after another delay using `SIGKILL`. For Node worker threads, the force exit method is `terminate()`.
The primary use for this (besides being cleaner) is that we can at least print a warning if tests leak open handles (which this PR also does) instead of effectively just cancelling the whole event loop by terminating the worker. Many users have complained about bugs like `console.log`s being lost and this is likely one of the reasons why stuff like that happens, hopefully exiting gracefully can reduce such hard-to-debug behavior a bit.
This is not a breaking change because right now `jest-worker` doesn't guarantee either that the worker processes have exited when `end()` returns (and why should the user care about some leftover worker processes, as long as they will eventually exit).

See also https://github.com/facebook/jest/pull/7731#issuecomment-475984795

- [x] `jest-runner`: warn if a worker had to be force exited
- [x] e2e test that has to be force exited
- [x] `NodeThreadsWorker` (type errors)
- [x] manually run e2e test with `NodeThreadsWorker` (not done on CI because worker threads cause many other errors)
- [x] `jest-worker/README.md`
- [x] changelog
- [x] PleaseCanItJustWorkOnWindowsThanx - Azure says it does 🎉

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Updated and added some `jest-worker` tests, added an e2e test for the warning and to check that force exit works.
Also run the e2e test and a manual Jest execution with worker threads enabled in `jest-runner` and the Node flag.
On master, the e2e test "force exits a worker" passes (because master always force exits them using `process.exit`), but "prints a warning" fails.