### PR TITLE
Fix requireActual fail with moduleNameMapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - `[jest-resolve]`: Remove internal peer dependencies ([#8215](https://github.com/facebook/jest/pull/8215))
 - `[jest-snapshot]`: Remove internal peer dependencies ([#8215](https://github.com/facebook/jest/pull/8215))
 - `[jest-resolve]` Fix requireActual with moduleNameMapper ([#7981](https://github.com/facebook/jest/issues/7981))
+- `[jest-resolve]` Fix requireActual with moduleNameMapper ([#7981](https://github.com/facebook/jest/pull/8210))
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - `[jest-snapshot]`: Remove internal peer dependencies ([#8215](https://github.com/facebook/jest/pull/8215))
 - `[jest-resolve]` Fix requireActual with moduleNameMapper ([#7981](https://github.com/facebook/jest/issues/7981))
 - `[jest-resolve]` Fix requireActual with moduleNameMapper ([#7981](https://github.com/facebook/jest/pull/8210))
+- `[jest-resolve]` Fix requireActual with moduleNameMapper ([#8210](https://github.com/facebook/jest/pull/8210))
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - `[jest-resolve-dependencies]`: Remove internal peer dependencies ([#8215](https://github.com/facebook/jest/pull/8215))
 - `[jest-resolve]`: Remove internal peer dependencies ([#8215](https://github.com/facebook/jest/pull/8215))
 - `[jest-snapshot]`: Remove internal peer dependencies ([#8215](https://github.com/facebook/jest/pull/8215))
+- `[jest-resolve]` Fix requireActual with moduleNameMapper ([#7981](https://github.com/facebook/jest/issues/7981))
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,6 @@
 - `[jest-resolve-dependencies]`: Remove internal peer dependencies ([#8215](https://github.com/facebook/jest/pull/8215))
 - `[jest-resolve]`: Remove internal peer dependencies ([#8215](https://github.com/facebook/jest/pull/8215))
 - `[jest-snapshot]`: Remove internal peer dependencies ([#8215](https://github.com/facebook/jest/pull/8215))
-- `[jest-resolve]` Fix requireActual with moduleNameMapper ([#7981](https://github.com/facebook/jest/issues/7981))
-- `[jest-resolve]` Fix requireActual with moduleNameMapper ([#7981](https://github.com/facebook/jest/pull/8210))
 - `[jest-resolve]` Fix requireActual with moduleNameMapper ([#8210](https://github.com/facebook/jest/pull/8210))
 
 ### Chore & Maintenance

--- a/e2e/__tests__/__snapshots__/moduleNameMapper.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/moduleNameMapper.test.ts.snap
@@ -30,6 +30,6 @@ FAIL __tests__/index.js
       12 | module.exports = () => 'test';
       13 | 
 
-      at createNoMappedModuleFoundError (../../packages/jest-resolve/build/index.js:473:17)
+      at createNoMappedModuleFoundError (../../packages/jest-resolve/build/index.js:471:17)
       at Object.require (index.js:10:1)
 `;

--- a/e2e/__tests__/__snapshots__/resolveNoFileExtensions.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/resolveNoFileExtensions.test.ts.snap
@@ -33,6 +33,6 @@ FAIL __tests__/test.js
         |                  ^
       4 | 
 
-      at Resolver.resolveModule (../../packages/jest-resolve/build/index.js:231:17)
+      at Resolver.resolveModule (../../packages/jest-resolve/build/index.js:229:17)
       at Object.require (index.js:3:18)
 `;

--- a/packages/jest-resolve/src/index.ts
+++ b/packages/jest-resolve/src/index.ts
@@ -195,11 +195,9 @@ class Resolver {
     options?: Resolver.ResolveModuleConfig,
   ): Config.Path {
     const dirname = path.dirname(from);
-    const module = this.resolveModuleFromDirIfExists(
-      dirname,
-      moduleName,
-      options,
-    );
+    const module =
+      this.resolveStubModuleName(from, moduleName) ||
+      this.resolveModuleFromDirIfExists(dirname, moduleName, options);
     if (module) return module;
 
     // 5. Throw an error if the module could not be found. `resolve.sync` only

--- a/packages/jest-runtime/src/__tests__/runtime_require_actual.test.js
+++ b/packages/jest-runtime/src/__tests__/runtime_require_actual.test.js
@@ -23,4 +23,17 @@ describe('Runtime requireActual', () => {
       );
       expect(exports.isManualMockModule).toBe(false);
     }));
+
+  test('requireActual with moduleNameMapper', () =>
+    createRuntime(__filename, {
+      moduleNameMapper: {
+        '^testMapped/(.*)': '<rootDir>/mapped_dir/$1',
+      },
+    }).then(runtime => {
+      const exports = runtime.requireActual(
+        runtime.__mockRootPath,
+        'testMapped/moduleInMapped',
+      );
+      expect(exports).toBe('in_mapped');
+    }));
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This PR fixes #7981 , requireActual not work with moduleNameMapper, witch currently throws an error. 

This PR make `jest-resolve` `resolveModule` invoke `resolveStubModuleName`, which resolves module with moduleNameMapper. `resolveStubModuleName` is invoked before `resolveModuleFromDirIfExists`, so that moduleNameMapper config can override default behavior.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Test requireActual with a moduleNameMapper configuration, and it should resolve the module successfully.
