### PR TITLE
Watch mode number of CPUs & documentation.

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -214,7 +214,7 @@ Prevents Jest from executing more than the specified amount of tests at the same
 
 ### `--maxWorkers=<num>|<string>`
 
-Alias: `-w`. Specifies the maximum number of workers the worker-pool will spawn for running tests. This defaults to the number of the cores available on your machine. It may be useful to adjust this in resource limited environments like CIs but the default should be adequate for most use-cases.
+Alias: `-w`. Specifies the maximum number of workers the worker-pool will spawn for running tests. In single run mode, this defaults to the number of the cores available on your machine minus one for the main thread. In watch mode, this defaults to half of the available cores on your machine to ensure Jest is unobtrusive and does not grind your machine to a halt. It may be useful to adjust this in resource limited environments like CIs but the defaults should be adequate for most use-cases.
 
 For environments with variable CPUs available, you can use percentage based configuration: `--maxWorkers=50%`
 

--- a/packages/jest-config/src/__tests__/getMaxWorkers.test.ts
+++ b/packages/jest-config/src/__tests__/getMaxWorkers.test.ts
@@ -32,7 +32,7 @@ describe('getMaxWorkers', () => {
 
   it('Returns based on the number of cpus', () => {
     expect(getMaxWorkers({})).toBe(3);
-    expect(getMaxWorkers({watch: true})).toBe(3);
+    expect(getMaxWorkers({watch: true})).toBe(2);
   });
 
   describe('% based', () => {

--- a/packages/jest-config/src/getMaxWorkers.ts
+++ b/packages/jest-config/src/getMaxWorkers.ts
@@ -31,7 +31,7 @@ export default function getMaxWorkers(
 
     return parsed > 0 ? parsed : 1;
   } else {
-    // In watch mode, Jest should be unobtrusive and not take all available CPU.
+    // In watch mode, Jest should be unobtrusive and not use all available CPUs.
     const cpus = os.cpus() ? os.cpus().length : 1;
     return Math.max(argv.watch ? Math.floor(cpus / 2) : cpus - 1, 1);
   }

--- a/packages/jest-config/src/getMaxWorkers.ts
+++ b/packages/jest-config/src/getMaxWorkers.ts
@@ -31,7 +31,8 @@ export default function getMaxWorkers(
 
     return parsed > 0 ? parsed : 1;
   } else {
+    // In watch mode, Jest should be unobtrusive and not take all available CPU.
     const cpus = os.cpus() ? os.cpus().length : 1;
-    return Math.max(cpus - 1, 1);
+    return Math.max(argv.watch ? Math.floor(cpus / 2) : cpus - 1, 1);
   }
 }

--- a/website/versioned_docs/version-22.x/CLI.md
+++ b/website/versioned_docs/version-22.x/CLI.md
@@ -184,7 +184,7 @@ Logs the heap usage after every test. Useful to debug memory leaks. Use together
 
 ### `--maxWorkers=<num>`
 
-Alias: `-w`. Specifies the maximum number of workers the worker-pool will spawn for running tests. This defaults to the number of the cores available on your machine. It may be useful to adjust this in resource limited environments like CIs but the default should be adequate for most use-cases.
+Alias: `-w`. Specifies the maximum number of workers the worker-pool will spawn for running tests. In single run mode, this defaults to the number of the cores available on your machine minus one for the main thread. In watch mode, this defaults to half of the available cores on your machine to ensure Jest is unobtrusive and does not grind your machine to a halt. It may be useful to adjust this in resource limited environments like CIs but the defaults should be adequate for most use-cases.
 
 ### `--noStackTrace`
 

--- a/website/versioned_docs/version-23.x/CLI.md
+++ b/website/versioned_docs/version-23.x/CLI.md
@@ -196,7 +196,7 @@ Logs the heap usage after every test. Useful to debug memory leaks. Use together
 
 ### `--maxWorkers=<num>`
 
-Alias: `-w`. Specifies the maximum number of workers the worker-pool will spawn for running tests. This defaults to the number of the cores available on your machine. It may be useful to adjust this in resource limited environments like CIs but the default should be adequate for most use-cases.
+Alias: `-w`. Specifies the maximum number of workers the worker-pool will spawn for running tests. In single run mode, this defaults to the number of the cores available on your machine minus one for the main thread. In watch mode, this defaults to half of the available cores on your machine to ensure Jest is unobtrusive and does not grind your machine to a halt. It may be useful to adjust this in resource limited environments like CIs but the defaults should be adequate for most use-cases.
 
 ### `--noStackTrace`
 

--- a/website/versioned_docs/version-24.0/CLI.md
+++ b/website/versioned_docs/version-24.0/CLI.md
@@ -211,7 +211,7 @@ Logs the heap usage after every test. Useful to debug memory leaks. Use together
 
 ### `--maxWorkers=<num>|<string>`
 
-Alias: `-w`. Specifies the maximum number of workers the worker-pool will spawn for running tests. This defaults to the number of the cores available on your machine. It may be useful to adjust this in resource limited environments like CIs but the default should be adequate for most use-cases.
+Alias: `-w`. Specifies the maximum number of workers the worker-pool will spawn for running tests. In single run mode, this defaults to the number of the cores available on your machine minus one for the main thread. In watch mode, this defaults to half of the available cores on your machine to ensure Jest is unobtrusive and does not grind your machine to a halt. It may be useful to adjust this in resource limited environments like CIs but the defaults should be adequate for most use-cases.
 
 For environments with variable CPUs available, you can use percentage based configuration: `--maxWorkers=50%`
 

--- a/website/versioned_docs/version-24.1/CLI.md
+++ b/website/versioned_docs/version-24.1/CLI.md
@@ -215,7 +215,7 @@ Prevents Jest from executing more than the specified amount of tests at the same
 
 ### `--maxWorkers=<num>|<string>`
 
-Alias: `-w`. Specifies the maximum number of workers the worker-pool will spawn for running tests. This defaults to the number of the cores available on your machine. It may be useful to adjust this in resource limited environments like CIs but the default should be adequate for most use-cases.
+Alias: `-w`. Specifies the maximum number of workers the worker-pool will spawn for running tests. In single run mode, this defaults to the number of the cores available on your machine minus one for the main thread. In watch mode, this defaults to half of the available cores on your machine to ensure Jest is unobtrusive and does not grind your machine to a halt. It may be useful to adjust this in resource limited environments like CIs but the defaults should be adequate for most use-cases.
 
 For environments with variable CPUs available, you can use percentage based configuration: `--maxWorkers=50%`
 


### PR DESCRIPTION
## Summary

Revert change to number of CPUs and add docs to resolve @cpojer comment:
https://github.com/facebook/jest/pull/8201#issuecomment-476221537

Benchmarked Jest non-e2e test performance for this branch from 14.973s to 16.504s, which is still a massive win over the original 23.234s and probably points to further optimizations being possible since I'd hope that giving it 5 extra CPUs would do more for the performance.

## Test plan

- All tests pass, including the test that specifically touches this number.
