### PR TITLE
Docs: Fixing link to reporter interface

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -619,7 +619,7 @@ class MyCustomReporter {
 }
 ```
 
-For the full list of methods and argument types see `Reporter` type in [types/TestRunner.js](https://github.com/facebook/jest/blob/master/types/TestRunner.js)
+For the full list of methods and argument types see `Reporter` interface in [packages/jest-reporters/src/types.ts](https://github.com/facebook/jest/blob/master/packages/jest-reporters/src/types.ts)
 
 ### `resetMocks` [boolean]
 

--- a/website/versioned_docs/version-24.1/Configuration.md
+++ b/website/versioned_docs/version-24.1/Configuration.md
@@ -620,7 +620,7 @@ class MyCustomReporter {
 }
 ```
 
-For the full list of methods and argument types see `Reporter` type in [types/TestRunner.js](https://github.com/facebook/jest/blob/master/types/TestRunner.js)
+For the full list of methods and argument types see `Reporter` interface in [packages/jest-reporters/src/types.ts](https://github.com/facebook/jest/blob/master/packages/jest-reporters/src/types.ts)
 
 ### `resetMocks` [boolean]
 


### PR DESCRIPTION
A link in the documentation around reporters seems to be broken since the big move to Typescript. This PR updates the link to the appropriate location. 🎉 