### PR TITLE
Fix "instanceof Error"

### DIFF
--- a/e2e/__tests__/instanceof.test.ts
+++ b/e2e/__tests__/instanceof.test.ts
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+import runJest from '../runJest';
+
+test('suite with `instanceof` checks', () => {
+  const {status} = runJest('instanceof');
+
+  expect(status).toBe(0);
+});

--- a/e2e/instanceof/__tests__/test.ts
+++ b/e2e/instanceof/__tests__/test.ts
@@ -1,0 +1,35 @@
+const fs = require('fs');
+const http = require('http');
+
+test('fs error', () => {
+  expect.hasAssertions();
+
+  try {
+    fs.readFileSync('does not exist');
+  } catch (err) {
+    expect(err).toBeInstanceOf(Error);
+  }
+});
+
+test('http error', () =>
+  new Promise((resolve, reject) => {
+    const request = http.request('http://does-not-exist/blah', res => {
+      console.log(`STATUS: ${res.statusCode}`);
+      res.on('end', () => {
+        reject(new Error('Ended before failure'));
+      });
+    });
+
+    request.once('error', err => {
+      try {
+        expect(err).toBeInstanceOf(Error);
+        resolve();
+      } catch (e) {
+        reject(e);
+      }
+    });
+  }));
+
+test('Array', () => {
+  expect([]).toBeInstanceOf(Array);
+});

--- a/e2e/instanceof/package.json
+++ b/e2e/instanceof/package.json
@@ -1,0 +1,5 @@
+{
+  "jest": {
+    "testEnvironment": "node"
+  }
+}

--- a/packages/jest-util/src/fixInstanceOf.ts
+++ b/packages/jest-util/src/fixInstanceOf.ts
@@ -1,0 +1,11 @@
+export function fixInstanceOfError(error: typeof Error): void {
+  const toString = Object.prototype.toString;
+  const originalHasInstance = error[Symbol.hasInstance];
+  Object.defineProperty(error, Symbol.hasInstance, {
+    value(potentialInstance: any): boolean {
+      return this === error
+        ? toString.call(potentialInstance) === '[object Error]'
+        : originalHasInstance.call(this, potentialInstance);
+    },
+  });
+}

--- a/packages/jest-util/src/installCommonGlobals.ts
+++ b/packages/jest-util/src/installCommonGlobals.ts
@@ -9,6 +9,7 @@ import fs from 'fs';
 import {Config} from '@jest/types';
 import createProcessObject from './createProcessObject';
 import deepCyclicCopy from './deepCyclicCopy';
+import {fixInstanceOfError} from './fixInstanceOf';
 
 const DTRACE = Object.keys(global).filter(key => key.startsWith('DTRACE'));
 
@@ -66,6 +67,8 @@ export default function(
   globalObject.Buffer = global.Buffer;
   globalObject.setImmediate = global.setImmediate;
   globalObject.clearImmediate = global.clearImmediate;
+
+  fixInstanceOfError(globalObject.Error);
 
   return Object.assign(globalObject, deepCyclicCopy(globals));
 }


### PR DESCRIPTION
Partially fixes https://github.com/facebook/jest/issues/2549.

It fixes only `instanceof Error` and does not affect `instanceof AnySubClassOfError` nor any other `instanceof` usage. Because it is so specific, I don't think it is suitable for merging. https://github.com/facebook/jest/pull/5995 would certainly be a better fix, if it worked.

Comparing my fix and https://github.com/facebook/jest/pull/5995, I think the problem might be that errors are somehow mishandled in `jest` itself, which results in issues with `instanceof SubClassOfError` checks within `jest`. Once those are fixed, https://github.com/facebook/jest/pull/5995 should just work. Does it make sense?

cc @SimenB 