### PR TITLE
Memory leak fix: release console output reference after printed to stdout.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 - `[jest-core]` Improve performance of SearchSource.findMatchingTests by 15% ([#8184](https://github.com/facebook/jest/pull/8184))
 - `[jest-resolve]` Optimize internal cache lookup performance ([#8183](https://github.com/facebook/jest/pull/8183))
 - `[jest-core]` Dramatically improve watch mode performance ([#8201](https://github.com/facebook/jest/pull/8201))
+- `[jest-console]` Fix memory leak by releasing console output reference when printed to stdout ([#8233](https://github.com/facebook/jest/pull/8233))
 
 ## 24.5.0
 

--- a/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapterInit.ts
+++ b/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapterInit.ts
@@ -196,7 +196,7 @@ export const runAndTransformResultsToJestFormat = async ({
 
   dispatch({name: 'teardown'});
   return {
-    console: null,
+    console: undefined,
     displayName: config.displayName,
     failureMessage,
     leaks: false, // That's legacy code, just adding it so Flow is happy.

--- a/packages/jest-console/src/BufferedConsole.ts
+++ b/packages/jest-console/src/BufferedConsole.ts
@@ -159,7 +159,7 @@ export default class BufferedConsole extends Console {
     this._log('warn', format(firstArg, ...rest));
   }
 
-  getBuffer(): ConsoleBuffer {
-    return this._buffer;
+  getBuffer() {
+    return this._buffer.length ? this._buffer : undefined;
   }
 }

--- a/packages/jest-console/src/CustomConsole.ts
+++ b/packages/jest-console/src/CustomConsole.ts
@@ -141,6 +141,6 @@ export default class CustomConsole extends Console {
   }
 
   getBuffer() {
-    return null;
+    return undefined;
   }
 }

--- a/packages/jest-console/src/__tests__/bufferedConsole.test.ts
+++ b/packages/jest-console/src/__tests__/bufferedConsole.test.ts
@@ -10,11 +10,14 @@ import BufferedConsole from '../BufferedConsole';
 
 describe('CustomConsole', () => {
   let _console: BufferedConsole;
-  const stdout = () =>
-    _console
-      .getBuffer()
-      .map(log => log.message)
-      .join('\n');
+  const stdout = () => {
+    const buffer = _console.getBuffer();
+    if (!buffer) {
+      return '';
+    }
+
+    return buffer.map(log => log.message).join('\n');
+  };
 
   beforeEach(() => {
     _console = new BufferedConsole(() => null);

--- a/packages/jest-core/src/ReporterDispatcher.ts
+++ b/packages/jest-core/src/ReporterDispatcher.ts
@@ -36,6 +36,9 @@ export default class ReporterDispatcher {
       reporter.onTestResult &&
         (await reporter.onTestResult(test, testResult, results));
     }
+
+    // Release memory if unused later.
+    testResult.console = undefined;
   }
 
   async onTestStart(test: Test) {

--- a/packages/jest-reporters/src/default_reporter.ts
+++ b/packages/jest-reporters/src/default_reporter.ts
@@ -172,8 +172,7 @@ export default class DefaultReporter extends BaseReporter {
     result: TestResult,
   ) {
     this.log(getResultHeader(result, this._globalConfig, config));
-    const consoleBuffer = result.console;
-    if (consoleBuffer && consoleBuffer.length) {
+    if (result.console) {
       this.log(
         '  ' +
           TITLE_BULLET +
@@ -181,9 +180,10 @@ export default class DefaultReporter extends BaseReporter {
           getConsoleOutput(
             config.cwd,
             !!this._globalConfig.verbose,
-            consoleBuffer,
+            result.console,
           ),
       );
+      result.console = undefined;
     }
   }
 

--- a/packages/jest-reporters/src/default_reporter.ts
+++ b/packages/jest-reporters/src/default_reporter.ts
@@ -183,7 +183,6 @@ export default class DefaultReporter extends BaseReporter {
             result.console,
           ),
       );
-      result.console = undefined;
     }
   }
 

--- a/packages/jest-test-result/src/helpers.ts
+++ b/packages/jest-test-result/src/helpers.ts
@@ -46,7 +46,7 @@ export const buildFailureTestResult = (
   testPath: Config.Path,
   err: SerializableError,
 ): TestResult => ({
-  console: null,
+  console: undefined,
   displayName: '',
   failureMessage: null,
   leaks: false,

--- a/packages/jest-test-result/src/types.ts
+++ b/packages/jest-test-result/src/types.ts
@@ -101,7 +101,7 @@ export type Suite = {
 };
 
 export type TestResult = {
-  console?: ConsoleBuffer | null;
+  console?: ConsoleBuffer;
   coverage?: CoverageMapData;
   displayName?: Config.DisplayName;
   failureMessage?: string | null;


### PR DESCRIPTION
## Summary

The reference to the console output is printed to `stdout` when the test completes and not used afterwards. Unfortunately, it's currently preserved, never being released. It's not used after that point and can be garbage collected.

I also standardized the "no buffer" output to `undefined`, when it previously could have been an empty array or `null`.


## Test plan

- All tests pass.
- Console output still works as expected.
- Memory does not leak.
- JSON output is unchanged.
