### PR TITLE
Memory leak fix: release source map info after processed and minor optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 - `[jest-core]` Improve performance of SearchSource.findMatchingTests by 15% ([#8184](https://github.com/facebook/jest/pull/8184))
 - `[jest-resolve]` Optimize internal cache lookup performance ([#8183](https://github.com/facebook/jest/pull/8183))
 - `[jest-core]` Dramatically improve watch mode performance ([#8201](https://github.com/facebook/jest/pull/8201))
+- `[jest-reporters]` Fix memory leak of source map info and minor performance improvements ([#8234](https://github.com/facebook/jest/pull/8234))
 
 ## 24.5.0
 

--- a/packages/jest-core/src/ReporterDispatcher.ts
+++ b/packages/jest-core/src/ReporterDispatcher.ts
@@ -36,6 +36,10 @@ export default class ReporterDispatcher {
       reporter.onTestResult &&
         (await reporter.onTestResult(test, testResult, results));
     }
+
+    // Release memory if unused later.
+    testResult.sourceMaps = undefined;
+    testResult.coverage = undefined;
   }
 
   async onTestStart(test: Test) {

--- a/packages/jest-reporters/src/coverage_reporter.ts
+++ b/packages/jest-reporters/src/coverage_reporter.ts
@@ -53,12 +53,8 @@ export default class CoverageReporter extends BaseReporter {
     testResult: TestResult,
     _aggregatedResults: AggregatedResult,
   ) {
-    // Coverage and source maps are only appended to the test result for this
-    // handler. Delete when processed to preserve memory.
-
     if (testResult.coverage) {
       this._coverageMap.merge(testResult.coverage);
-      testResult.coverage = undefined;
     }
 
     const sourceMaps = testResult.sourceMaps;
@@ -81,7 +77,6 @@ export default class CoverageReporter extends BaseReporter {
           }
         }
       });
-      testResult.sourceMaps = undefined;
     }
   }
 

--- a/packages/jest-runner/src/runTest.ts
+++ b/packages/jest-runner/src/runTest.ts
@@ -253,6 +253,7 @@ async function runTestInternal(
 
     result.perfStats = {end: Date.now(), start};
     result.testFilePath = path;
+    result.console = testConsole.getBuffer();
     result.skipped = testCount === result.numPendingTests;
     result.displayName = config.displayName;
 

--- a/packages/jest-runner/src/runTest.ts
+++ b/packages/jest-runner/src/runTest.ts
@@ -253,13 +253,17 @@ async function runTestInternal(
 
     result.perfStats = {end: Date.now(), start};
     result.testFilePath = path;
-    result.coverage = runtime.getAllCoverageInfoCopy();
-    result.sourceMaps = runtime.getSourceMapInfo(
-      new Set(Object.keys(result.coverage || {})),
-    );
-    result.console = testConsole.getBuffer();
     result.skipped = testCount === result.numPendingTests;
     result.displayName = config.displayName;
+
+    const coverage = runtime.getAllCoverageInfoCopy();
+    if (coverage) {
+      const coverageKeys = Object.keys(coverage);
+      if (coverageKeys.length) {
+        result.coverage = coverage;
+        result.sourceMaps = runtime.getSourceMapInfo(new Set(coverageKeys));
+      }
+    }
 
     if (globalConfig.logHeapUsage) {
       if (global.gc) {

--- a/packages/jest-test-result/src/formatTestResults.ts
+++ b/packages/jest-test-result/src/formatTestResults.ts
@@ -41,10 +41,10 @@ const formatTestResult = (
     return {
       assertionResults,
       coverage: codeCoverageFormatter
-        ? (testResult.coverage, reporter)
+        ? codeCoverageFormatter(testResult.coverage, reporter)
         : testResult.coverage,
       endTime: testResult.perfStats.end,
-      message: testResult.failureMessage ? testResult.failureMessage : '',
+      message: testResult.failureMessage || '',
       name: testResult.testFilePath,
       startTime: testResult.perfStats.start,
       status: allTestsPassed ? 'passed' : 'failed',

--- a/packages/jest-test-result/src/formatTestResults.ts
+++ b/packages/jest-test-result/src/formatTestResults.ts
@@ -16,41 +16,41 @@ import {
   TestResult,
 } from './types';
 
-const formatResult = (
+const formatTestResult = (
   testResult: TestResult,
-  codeCoverageFormatter: CodeCoverageFormatter,
-  reporter: CodeCoverageReporter,
+  codeCoverageFormatter?: CodeCoverageFormatter,
+  reporter?: CodeCoverageReporter,
 ): FormattedTestResult => {
-  const now = Date.now();
-  const output: FormattedTestResult = {
-    assertionResults: [],
-    coverage: {},
-    endTime: now,
-    message: '',
-    name: testResult.testFilePath,
-    startTime: now,
-    status: 'failed',
-    summary: '',
-  };
-
+  const assertionResults = testResult.testResults.map(formatTestAssertion);
   if (testResult.testExecError) {
-    output.message = testResult.testExecError.message;
-    output.coverage = {};
+    const now = Date.now();
+    return {
+      assertionResults,
+      coverage: {},
+      endTime: now,
+      message: testResult.failureMessage
+        ? testResult.failureMessage
+        : testResult.testExecError.message,
+      name: testResult.testFilePath,
+      startTime: now,
+      status: 'failed',
+      summary: '',
+    };
   } else {
     const allTestsPassed = testResult.numFailingTests === 0;
-    output.status = allTestsPassed ? 'passed' : 'failed';
-    output.startTime = testResult.perfStats.start;
-    output.endTime = testResult.perfStats.end;
-    output.coverage = codeCoverageFormatter(testResult.coverage, reporter);
+    return {
+      assertionResults,
+      coverage: codeCoverageFormatter
+        ? (testResult.coverage, reporter)
+        : testResult.coverage,
+      endTime: testResult.perfStats.end,
+      message: testResult.failureMessage ? testResult.failureMessage : '',
+      name: testResult.testFilePath,
+      startTime: testResult.perfStats.start,
+      status: allTestsPassed ? 'passed' : 'failed',
+      summary: '',
+    };
   }
-
-  output.assertionResults = testResult.testResults.map(formatTestAssertion);
-
-  if (testResult.failureMessage) {
-    output.message = testResult.failureMessage;
-  }
-
-  return output;
 };
 
 function formatTestAssertion(
@@ -72,13 +72,11 @@ function formatTestAssertion(
 
 export default function formatTestResults(
   results: AggregatedResult,
-  codeCoverageFormatter?: CodeCoverageFormatter | null,
+  codeCoverageFormatter?: CodeCoverageFormatter,
   reporter?: CodeCoverageReporter,
 ): FormattedTestResults {
-  const formatter = codeCoverageFormatter || (coverage => coverage);
-
   const testResults = results.testResults.map(testResult =>
-    formatResult(testResult, formatter, reporter),
+    formatTestResult(testResult, codeCoverageFormatter, reporter),
   );
 
   return {...results, testResults};

--- a/packages/jest-test-result/src/types.ts
+++ b/packages/jest-test-result/src/types.ts
@@ -126,7 +126,7 @@ export type TestResult = {
     unmatched: number;
     updated: number;
   };
-  sourceMaps: {
+  sourceMaps?: {
     [sourcePath: string]: string;
   };
   testExecError?: SerializableError;


### PR DESCRIPTION
## Summary

Previously, `sourceMaps`:
- Was always populated with a call to `getSourceMapInfo` and set to an object, even when it was guaranteed to be empty.
- Was never released from memory.

It's companion, `coverage`, was released from memory but unfortunately using the `delete` operator, which is significantly slower than `= undefined` even with modern V8 versions:
https://jsperf.com/delete-vs-undefined-vs-null/87

I've resolved the leak and minor performance issues along with a minor change to `formatTestResults` that is slightly more efficient for the same result.

## Test plan

- All tests pass.
- Memory and performance characteristics verified.
