### PR TITLE
Performance: Cache regular expression instead of creating anew for every file in ScriptTransformer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 - `[jest-core]` Improve performance of SearchSource.findMatchingTests by 15% ([#8184](https://github.com/facebook/jest/pull/8184))
 - `[jest-resolve]` Optimize internal cache lookup performance ([#8183](https://github.com/facebook/jest/pull/8183))
 - `[jest-core]` Dramatically improve watch mode performance ([#8201](https://github.com/facebook/jest/pull/8201))
+- `[jest-transform]` Cache regular expression instead of creating anew for every file in ScriptTransformer ([#8235](https://github.com/facebook/jest/pull/8235))
 
 ## 24.5.0
 

--- a/packages/jest-transform/src/ScriptTransformer.ts
+++ b/packages/jest-transform/src/ScriptTransformer.ts
@@ -138,9 +138,9 @@ export default class ScriptTransformer {
       return undefined;
     }
 
-    for (const [regExp, transform] of transformRegExp) {
-      if (regExp.test(filename)) {
-        return transform;
+    for (let i = 0; i < transformRegExp.length; i++) {
+      if (transformRegExp[i][0].test(filename)) {
+        return transformRegExp[i][1];
       }
     }
 


### PR DESCRIPTION
## Summary

This PR improves performance by caching the regular expression string -> `RegExp` conversion.

Benchmarks on cached regular expression vs. creating new each time:
```
  new regex x   596 ops/sec ±0.95% (97 runs sampled)
  cached regex  x 1,668 ops/sec ±0.61% (97 runs sampled)
```

For large projects, Jest may process a LOT of files. The more workers in use, the higher chance that the same file is processed multiple times. Additionally, each time it's hit multiple regular expressions may be tested against.

The benchmark I used:
```js
suite.add('new regex', function() {
  for (var i = 0; i < 10000; i++) {
    new RegExp('^.+\\.[jt]sx?$').test(
      'jest/packages/jest-haste-map/src/__tests__/haste_impl.js'
    );
  }
});

suite.add('cached regex', function() {
  const regex = new RegExp('^.+\\.[jt]sx?$');
  for (var i = 0; i < 10000; i++) {
    regex.test(
      'jest/packages/jest-haste-map/src/__tests__/haste_impl.js'
    );
  }
});
```

## Test plan

- All tests pass.
- Performance benefit verified.