### PR TITLE
Unify worker module map transmission w/ small perf benefit.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - `[jest-resolve]`: Remove internal peer dependencies ([#8215](https://github.com/facebook/jest/pull/8215))
 - `[jest-snapshot]`: Remove internal peer dependencies ([#8215](https://github.com/facebook/jest/pull/8215))
 - `[jest-resolve]` Fix requireActual with moduleNameMapper ([#8210](https://github.com/facebook/jest/pull/8210))
+- `[jest-haste-map]` Fix haste map duplicate detection in watch mode ([#8237](https://github.com/facebook/jest/pull/8237))
 
 ### Chore & Maintenance
 

--- a/packages/jest-runner/src/__tests__/testRunner.test.js
+++ b/packages/jest-runner/src/__tests__/testRunner.test.js
@@ -65,43 +65,6 @@ test('injects the serializable module map into each worker in watch mode', () =>
     });
 });
 
-test('does not inject the serializable module map in serial mode', () => {
-  const globalConfig = {maxWorkers: 1, watch: false};
-  const config = {rootDir: '/path/'};
-  const context = {config};
-  const runContext = {};
-
-  return new TestRunner(globalConfig, runContext)
-    .runTests(
-      [{context, path: './file.test.js'}, {context, path: './file2.test.js'}],
-      new TestWatcher({isWatchMode: globalConfig.watch}),
-      () => {},
-      () => {},
-      () => {},
-      {serial: false},
-    )
-    .then(() => {
-      expect(mockWorkerFarm.worker.mock.calls).toEqual([
-        [
-          {
-            config,
-            context: runContext,
-            globalConfig,
-            path: './file.test.js',
-          },
-        ],
-        [
-          {
-            config,
-            context: runContext,
-            globalConfig,
-            path: './file2.test.js',
-          },
-        ],
-      ]);
-    });
-});
-
 test('assign process.env.JEST_WORKER_ID = 1 when in runInBand mode', () => {
   const globalConfig = {maxWorkers: 1, watch: false};
   const config = {rootDir: '/path/'};

--- a/packages/jest-runner/src/index.ts
+++ b/packages/jest-runner/src/index.ts
@@ -103,16 +103,13 @@ class TestRunner {
     onResult: OnTestSuccess,
     onFailure: OnTestFailure,
   ) {
-    let resolvers: Map<string, SerializableResolver> | undefined = undefined;
-    if (watcher.isWatchMode()) {
-      resolvers = new Map();
-      for (const test of tests) {
-        if (!resolvers.has(test.context.config.name)) {
-          resolvers.set(test.context.config.name, {
-            config: test.context.config,
-            serializableModuleMap: test.context.moduleMap.toJSON(),
-          });
-        }
+    const resolvers: Map<string, SerializableResolver> = new Map();
+    for (const test of tests) {
+      if (!resolvers.has(test.context.config.name)) {
+        resolvers.set(test.context.config.name, {
+          config: test.context.config,
+          serializableModuleMap: test.context.moduleMap.toJSON(),
+        });
       }
     }
 
@@ -121,13 +118,11 @@ class TestRunner {
       forkOptions: {stdio: 'pipe'},
       maxRetries: 3,
       numWorkers: this._globalConfig.maxWorkers,
-      setupArgs: resolvers
-        ? [
-            {
-              serializableResolvers: Array.from(resolvers.values()),
-            },
-          ]
-        : undefined,
+      setupArgs: [
+        {
+          serializableResolvers: Array.from(resolvers.values()),
+        },
+      ],
     }) as WorkerInterface;
 
     if (worker.getStdout()) worker.getStdout().pipe(process.stdout);

--- a/packages/jest-runner/src/testWorker.ts
+++ b/packages/jest-runner/src/testWorker.ts
@@ -64,8 +64,7 @@ const getResolver = (config: Config.ProjectConfig) => {
 export function setup(setupData: {
   serializableResolvers: Array<SerializableResolver>;
 }) {
-  // Setup data is used in watch mode to pass all module maps that will be used
-  // during the test runs.
+  // Module maps that will be needed for the test runs are passed.
   for (const {
     config,
     serializableModuleMap,

--- a/packages/jest-runner/src/testWorker.ts
+++ b/packages/jest-runner/src/testWorker.ts
@@ -8,7 +8,7 @@
 
 import {Config} from '@jest/types';
 import {SerializableError, TestResult} from '@jest/test-result';
-import HasteMap, {ModuleMap, SerializableModuleMap} from 'jest-haste-map';
+import HasteMap, {SerializableModuleMap} from 'jest-haste-map';
 import exit from 'exit';
 import {separateMessageFromStack} from 'jest-message-util';
 import Runtime from 'jest-runtime';

--- a/packages/jest-runner/src/testWorker.ts
+++ b/packages/jest-runner/src/testWorker.ts
@@ -53,34 +53,25 @@ const formatError = (error: string | ErrorWithCode): SerializableError => {
 };
 
 const resolvers = new Map<string, Resolver>();
-const getResolver = (config: Config.ProjectConfig, moduleMap?: ModuleMap) => {
-  const name = config.name;
-  if (moduleMap || !resolvers.has(name)) {
-    resolvers.set(
-      name,
-      Runtime.createResolver(
-        config,
-        moduleMap || Runtime.createHasteMap(config).readModuleMap(),
-      ),
-    );
+const getResolver = (config: Config.ProjectConfig) => {
+  const resolver = resolvers.get(config.name);
+  if (!resolver) {
+    throw new Error('Cannot find resolver for: ' + config.name);
   }
-  return resolvers.get(name)!;
+  return resolver;
 };
 
-export function setup(setupData?: {
+export function setup(setupData: {
   serializableResolvers: Array<SerializableResolver>;
 }) {
-  // Setup data is only used in watch mode to pass the latest version of all
-  // module maps that will be used during the test runs. Otherwise, module maps
-  // are loaded from disk as needed.
-  if (setupData) {
-    for (const {
-      config,
-      serializableModuleMap,
-    } of setupData.serializableResolvers) {
-      const moduleMap = HasteMap.ModuleMap.fromJSON(serializableModuleMap);
-      getResolver(config, moduleMap);
-    }
+  // Setup data is used in watch mode to pass all module maps that will be used
+  // during the test runs.
+  for (const {
+    config,
+    serializableModuleMap,
+  } of setupData.serializableResolvers) {
+    const moduleMap = HasteMap.ModuleMap.fromJSON(serializableModuleMap);
+    resolvers.set(config.name, Runtime.createResolver(config, moduleMap));
   }
 }
 


### PR DESCRIPTION
## Summary

This PR unifies the way module maps are passed to the worker. Previously, we did it one way for watch mode and a different way for non-watch mode because our watch mode way was a lot slower.

I fixed that slowness for watch mode and realized while doing some performance and memory profiling that the watch mode way is now actually faster on a few levels:
1) It's straight-up faster to transmit it to the process because the module map is significantly smaller than the whole haste map you have to deserialize if you get at it via the file.
2) If you load the whole haste map and want to discard half of it, suddenly there is a bunch of stuff that will need to be GC'd in the future. This happens in the worker because it only wants the module map but has to deserialize the whole file.
3) Not requiring the haste map be written to disk at this point opens up further optimizations in the future.

Here's a benchmark of running `yarn jest packages/expect`, meant to profile starting up some workers and running a couple tests. Each profile was run 10 times after 3 warm ups.

### master
Time (mean ± σ):      3.902 s ±  0.120 s    [User: 21.570 s, System: 5.105 s]
Range (min … max):    3.682 s …  4.084 s    10 run

### this branch
Time (mean ± σ):      3.522 s ±  0.175 s    [User: 19.722 s, System: 4.777 s]
Range (min … max):    3.356 s …  3.897 s    10 runs

It's faster. It's less code with a unified code path. It opens up more optimizations in the future.

## Test plan

1. All tests pass.
2. Benchmarks show better performance in all situations.