### PR TITLE
docs(watchPlugins): fix argument passed to shouldRunTestSuite

### DIFF
--- a/docs/WatchPlugins.md
+++ b/docs/WatchPlugins.md
@@ -46,7 +46,7 @@ class MyWatchPlugin {
 
 Below are the hooks available in Jest.
 
-#### `jestHooks.shouldRunTestSuite(testPath)`
+#### `jestHooks.shouldRunTestSuite(testSuite)`
 
 Returns a boolean (or `Promise<boolean>` for handling asynchronous operations) to specify if a test should be run or not.
 
@@ -55,13 +55,13 @@ For example:
 ```javascript
 class MyWatchPlugin {
   apply(jestHooks) {
-    jestHooks.shouldRunTestSuite(testPath => {
-      return testPath.includes('my-keyword');
+    jestHooks.shouldRunTestSuite(testSuite => {
+      return testSuite.testPath.includes('my-keyword');
     });
 
     // or a promise
-    jestHooks.shouldRunTestSuite(testPath => {
-      return Promise.resolve(testPath.includes('my-keyword'));
+    jestHooks.shouldRunTestSuite(testSuite => {
+      return Promise.resolve(testSuite.testPath.includes('my-keyword'));
     });
   }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

I found the `testPath` was a property of an object and not the direct argument so I updated the doc to use `testSuite` as that's what it looked to me but there is probably a better wording

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

N/A
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
