### PR TITLE
Fix/test path pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - `[jest-snapshot]`: Remove internal peer dependencies ([#8215](https://github.com/facebook/jest/pull/8215))
 - `[jest-resolve]` Fix requireActual with moduleNameMapper ([#8210](https://github.com/facebook/jest/pull/8210))
 - `[jest-haste-map]` Fix haste map duplicate detection in watch mode ([#8237](https://github.com/facebook/jest/pull/8237))
+- `[@jest/core]` Fix all tests being run when testPathPattern matches any part of the absolute path to the test file ([#8243](https://github.com/facebook/jest/pull/8243))
 
 ### Chore & Maintenance
 

--- a/e2e/__tests__/multiProjectRunner.test.ts
+++ b/e2e/__tests__/multiProjectRunner.test.ts
@@ -34,6 +34,26 @@ test("--listTests doesn't duplicate the test files", () => {
   expect(stdout).toMatch('inBothProjectsTest.js');
 });
 
+test("--listTests doesn't find any tests when test path is part of absolute path", () => {
+  writeFiles(DIR, {
+    './backend/__tests__/backend.test.js': `test('test', () => {});`,
+    './frontend/__tests__/frontend.test.js': `test('test', () => {});`,
+    '.watchmanconfig': '',
+    '/project1.js': `module.exports = {rootDir: './backend', displayName: 'BACKEND'}`,
+    '/project2.js': `module.exports = {rootDir: './frontend', displayName: 'BACKEND'}`,
+    'package.json': JSON.stringify({
+      jest: {projects: ['<rootDir>/project1.js', '<rootDir>/project2.js']},
+    }),
+  });
+
+  // ignore first seperator
+  const [, testPath] = DIR.split(path.sep);
+
+  const {stdout} = runJest(DIR, ['--listTests', testPath]);
+  expect(stdout.split('\n')).toHaveLength(1);
+  expect(stdout).toMatch('');
+});
+
 test('can pass projects or global config', () => {
   writeFiles(DIR, {
     '.watchmanconfig': '',

--- a/e2e/__tests__/multiProjectRunner.test.ts
+++ b/e2e/__tests__/multiProjectRunner.test.ts
@@ -47,7 +47,7 @@ test("--listTests doesn't find any tests when test path is part of absolute path
   });
 
   // ignore first seperator
-  const [,, testPath] = DIR.split(path.sep);
+  const [, , testPath] = DIR.split(path.sep);
 
   const {stdout} = runJest(DIR, ['--listTests', testPath]);
   expect(stdout.split('\n')).toHaveLength(1);

--- a/e2e/__tests__/multiProjectRunner.test.ts
+++ b/e2e/__tests__/multiProjectRunner.test.ts
@@ -40,14 +40,14 @@ test("--listTests doesn't find any tests when test path is part of absolute path
     './frontend/__tests__/frontend.test.js': `test('test', () => {});`,
     '.watchmanconfig': '',
     '/project1.js': `module.exports = {rootDir: './backend', displayName: 'BACKEND'}`,
-    '/project2.js': `module.exports = {rootDir: './frontend', displayName: 'BACKEND'}`,
+    '/project2.js': `module.exports = {rootDir: './frontend', displayName: 'FRONTEND'}`,
     'package.json': JSON.stringify({
       jest: {projects: ['<rootDir>/project1.js', '<rootDir>/project2.js']},
     }),
   });
 
-  // ignore first seperator
-  const [, , testPath] = DIR.split(path.sep);
+  // This is part of the absolute path
+  const testPath = 'multi-project-runner-test';
 
   const {stdout} = runJest(DIR, ['--listTests', testPath]);
   expect(stdout.split('\n')).toHaveLength(1);

--- a/e2e/__tests__/multiProjectRunner.test.ts
+++ b/e2e/__tests__/multiProjectRunner.test.ts
@@ -47,7 +47,7 @@ test("--listTests doesn't find any tests when test path is part of absolute path
   });
 
   // ignore first seperator
-  const [, testPath] = DIR.split(path.sep);
+  const [,, testPath] = DIR.split(path.sep);
 
   const {stdout} = runJest(DIR, ['--listTests', testPath]);
   expect(stdout.split('\n')).toHaveLength(1);

--- a/packages/jest-core/src/SearchSource.ts
+++ b/packages/jest-core/src/SearchSource.ts
@@ -113,7 +113,8 @@ export default class SearchSource {
     if (testPathPattern) {
       let amendedTestPathPattern = testPathPattern;
 
-      const relativePathRegex = new RegExp(`[\.]+${path.sep}`);
+      const pathSeperator = process.platform === 'win32' ? '\\\\' : path.sep;
+      const relativePathRegex = new RegExp(`[\.]+${pathSeperator}`);
       if (relativePathRegex.test(amendedTestPathPattern)) {
         /**
          * This handles the scenario where the test path pattern passed is relative

--- a/packages/jest-core/src/SearchSource.ts
+++ b/packages/jest-core/src/SearchSource.ts
@@ -114,7 +114,8 @@ export default class SearchSource {
       let amendedTestPathPattern = testPathPattern;
 
       const pathSeperator = process.platform === 'win32' ? '\\\\' : path.sep;
-      const relativePathRegex = new RegExp(`[\.]+${pathSeperator}`);
+      const relativePathRegex = new RegExp(`[\.]+${pathSeperator}`, 'g');
+      console.log(amendedTestPathPattern);
       if (relativePathRegex.test(amendedTestPathPattern)) {
         /**
          * This handles the scenario where the test path pattern passed is relative

--- a/packages/jest-core/src/SearchSource.ts
+++ b/packages/jest-core/src/SearchSource.ts
@@ -116,13 +116,10 @@ export default class SearchSource {
       const pathSeperator = process.platform === 'win32' ? '\\\\' : path.sep;
       const relativePathRegex = new RegExp(`[\.]+${pathSeperator}`, 'g');
       if (relativePathRegex.test(amendedTestPathPattern)) {
-        /**
-         * This handles the scenario where the test path pattern passed is relative
-         * We amend the regular expression to make it optional so that the
-         * test pattern regex will match
-         *
-         * E.g `jest ./hello`
-         */
+        // This handles the scenario where the test path pattern passed is relative
+        // We amend the regular expression to make it optional so that the
+        // test pattern regex will match
+        // E.g `jest ./hello`
         amendedTestPathPattern = amendedTestPathPattern.replace(
           relativePathRegex,
           relativePathMatch => `(${relativePathMatch})?`,
@@ -131,14 +128,11 @@ export default class SearchSource {
       const regex = testPathPatternToRegExp(amendedTestPathPattern);
       testCases.push({
         isMatch: (path: Config.Path) => {
-          /**
-           * This prevents tests from being run when the test pattern passed
-           * matches any part of the the absolute path
-           *
-           * E.g. running `jest Users` will match all tests in the project
-           * directory on macos since /Users is part of the absolute path
-           * of all test files
-           */
+          // This prevents tests from being run when the test pattern passed
+          // matches any part of the the absolute path
+          // E.g. running `jest Users` will match all tests in the project
+          // directory on macos since /Users is part of the absolute path
+          // of all test files
           const replacedPath = path.replace(process.cwd(), '');
           return regex.test(replacedPath);
         },

--- a/packages/jest-core/src/SearchSource.ts
+++ b/packages/jest-core/src/SearchSource.ts
@@ -115,7 +115,6 @@ export default class SearchSource {
 
       const pathSeperator = process.platform === 'win32' ? '\\\\' : path.sep;
       const relativePathRegex = new RegExp(`[\.]+${pathSeperator}`, 'g');
-      console.log(amendedTestPathPattern);
       if (relativePathRegex.test(amendedTestPathPattern)) {
         /**
          * This handles the scenario where the test path pattern passed is relative


### PR DESCRIPTION
## Summary

This PR fixes #8226. 

Jest currently does a regex match on the testPathPattern based on the absolute path of the file under test. On macos, for any project running jest, if you run `jest Users`, the whole test suite will be ran since `/Users/some/absolute/path/` is being run against `/Users/i`. In essence, any string which is part of the absolute path to the the test file will cause this issue. 



## Test plan

An integration with this scenario has been added. 