### PR TITLE
CustomConsole: print console.error and console.assert to stderr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 ### Fixes
 
-- `[@jest/console]` Print to stderr when calling `console.error` or `console.assert` using the `jest-runtime` CLI ([#8261](https://github.com/facebook/jest/pull/8261))
+- `[@jest/console]` Print to stderr when calling `console.error`, `console.warn` or `console.assert` using the `jest-runtime` CLI ([#8261](https://github.com/facebook/jest/pull/8261))
 - `[expect]` Add negative equality tests for iterables ([#8260](https://github.com/facebook/jest/pull/8260))
 - `[jest-haste-map]` Resolve fs watcher EMFILE error ([#8258](https://github.com/facebook/jest/pull/8258))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Fixes
 
+- `[@jest/console]` Print to stderr when calling `console.error` or `console.assert` in verbose mode or using the `jest-runtime` CLI ([#8261](https://github.com/facebook/jest/pull/8261))
 - `[expect]` Add negative equality tests for iterables ([#8260](https://github.com/facebook/jest/pull/8260))
 - `[jest-haste-map]` Resolve fs watcher EMFILE error ([#8258](https://github.com/facebook/jest/pull/8258))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- `[@jest/console]` Print to stderr when calling `console.error`, `console.warn` or `console.assert` using the `jest-runtime` CLI ([#8261](https://github.com/facebook/jest/pull/8261))
+
 ### Chore & Maintenance
 
 ### Performance
@@ -17,7 +19,6 @@
 
 ### Fixes
 
-- `[@jest/console]` Print to stderr when calling `console.error`, `console.warn` or `console.assert` using the `jest-runtime` CLI ([#8261](https://github.com/facebook/jest/pull/8261))
 - `[expect]` Add negative equality tests for iterables ([#8260](https://github.com/facebook/jest/pull/8260))
 - `[jest-haste-map]` Resolve fs watcher EMFILE error ([#8258](https://github.com/facebook/jest/pull/8258))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 ### Fixes
 
-- `[@jest/console]` Print to stderr when calling `console.error` or `console.assert` in verbose mode or using the `jest-runtime` CLI ([#8261](https://github.com/facebook/jest/pull/8261))
+- `[@jest/console]` Print to stderr when calling `console.error` or `console.assert` using the `jest-runtime` CLI ([#8261](https://github.com/facebook/jest/pull/8261))
 - `[expect]` Add negative equality tests for iterables ([#8260](https://github.com/facebook/jest/pull/8260))
 - `[jest-haste-map]` Resolve fs watcher EMFILE error ([#8258](https://github.com/facebook/jest/pull/8258))
 

--- a/packages/jest-console/src/CustomConsole.ts
+++ b/packages/jest-console/src/CustomConsole.ts
@@ -43,26 +43,24 @@ export default class CustomConsole extends Console {
   }
 
   private _log(type: LogType, message: string) {
-    const isErrorType = type === 'error' || type === 'assert';
-    const formattedMessage = this._formatBuffer(
-      type,
-      '  '.repeat(this._groupDepth) + message,
+    clearLine(this._stdout);
+    super.log(
+      this._formatBuffer(type, '  '.repeat(this._groupDepth) + message),
     );
+  }
 
-    if (isErrorType) {
-      clearLine(this._stderr);
-      super.error(formattedMessage);
-    } else {
-      clearLine(this._stdout);
-      super.log(formattedMessage);
-    }
+  private _logError(type: LogType, message: string) {
+    clearLine(this._stderr);
+    super.error(
+      this._formatBuffer(type, '  '.repeat(this._groupDepth) + message),
+    );
   }
 
   assert(value: any, message?: string | Error) {
     try {
       assert(value, message);
     } catch (error) {
-      this._log('assert', error.toString());
+      this._logError('assert', error.toString());
     }
   }
 
@@ -91,7 +89,7 @@ export default class CustomConsole extends Console {
   }
 
   error(firstArg: any, ...args: Array<any>) {
-    this._log('error', format(firstArg, ...args));
+    this._logError('error', format(firstArg, ...args));
   }
 
   group(title?: string, ...args: Array<any>) {

--- a/packages/jest-console/src/CustomConsole.ts
+++ b/packages/jest-console/src/CustomConsole.ts
@@ -142,7 +142,7 @@ export default class CustomConsole extends Console {
   }
 
   warn(firstArg: any, ...args: Array<any>) {
-    this._log('warn', format(firstArg, ...args));
+    this._logError('warn', format(firstArg, ...args));
   }
 
   getBuffer() {

--- a/packages/jest-console/src/__tests__/CustomConsole.test.ts
+++ b/packages/jest-console/src/__tests__/CustomConsole.test.ts
@@ -76,14 +76,17 @@ describe('CustomConsole', () => {
       _console.assert(false);
 
       expect(_stderr).toMatch('AssertionError');
-      expect(_stderr).toMatch('The expression evaluated to a falsy value:');
+      expect(_stderr).toMatch(
+        // The message may differ across Node versions
+        /(false == true)|(The expression evaluated to a falsy value:)/,
+      );
     });
 
     test('log the assertion error when the assertion is falsy with another message argument', () => {
-      _console.assert(false, 'ok');
+      _console.assert(false, 'this should not happen');
 
       expect(_stderr).toMatch('AssertionError');
-      expect(_stderr).toMatch('ok');
+      expect(_stderr).toMatch('this should not happen');
     });
   });
 

--- a/packages/jest-console/src/__tests__/CustomConsole.test.ts
+++ b/packages/jest-console/src/__tests__/CustomConsole.test.ts
@@ -76,7 +76,7 @@ describe('CustomConsole', () => {
       _console.assert(false);
 
       expect(_stderr).toMatch('AssertionError');
-      expect(_stderr).toMatch('false == true');
+      expect(_stderr).toMatch('The expression evaluated to a falsy value:');
     });
 
     test('log the assertion error when the assertion is falsy with another message argument', () => {

--- a/packages/jest-console/src/__tests__/CustomConsole.test.ts
+++ b/packages/jest-console/src/__tests__/CustomConsole.test.ts
@@ -51,6 +51,14 @@ describe('CustomConsole', () => {
     });
   });
 
+  describe('warn', () => {
+    test('should print to stderr', () => {
+      _console.warn('Found some warning!');
+
+      expect(_stderr).toBe('Found some warning!\n');
+    });
+  });
+
   describe('assert', () => {
     test('do not log when the assertion is truthy', () => {
       _console.assert(true);

--- a/packages/jest-runner/src/runTest.ts
+++ b/packages/jest-runner/src/runTest.ts
@@ -135,13 +135,9 @@ async function runTestInternal(
   let testConsole;
 
   if (globalConfig.silent) {
-    testConsole = new NullConsole(consoleOut, process.stderr, consoleFormatter);
+    testConsole = new NullConsole(consoleOut, consoleOut, consoleFormatter);
   } else if (globalConfig.verbose) {
-    testConsole = new CustomConsole(
-      consoleOut,
-      process.stderr,
-      consoleFormatter,
-    );
+    testConsole = new CustomConsole(consoleOut, consoleOut, consoleFormatter);
   } else {
     testConsole = new BufferedConsole(() => runtime && runtime.getSourceMaps());
   }


### PR DESCRIPTION
## Summary

When using the CLI in `jest-runtime`, `console.error`, `console.warn` and `console.assert` print to stdout, which is wrong. `CustomConsole` should print to the given `stderr` when calling those methods.

## Test plan

Added unit tests in `CustomConsole`.