### PR TITLE
Fix `jest-test-sequencer` incorrect directory field.

### DIFF
--- a/packages/jest-test-sequencer/package.json
+++ b/packages/jest-test-sequencer/package.json
@@ -4,7 +4,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/facebook/jest.git",
-    "directory": "packages/test-sequencer"
+    "directory": "packages/jest-test-sequencer"
   },
   "license": "MIT",
   "main": "build/index.js",


### PR DESCRIPTION
## Summary

Directory field incorrect in new package.

## Test plan

Not applicable.