### PR TITLE
Resolves the test sequencer even when not explicitly set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- `[@jest/config]` Normalize `testSequencer` to its absolute path ([#8267](https://github.com/facebook/jest/pull/8267))
+
 ### Chore & Maintenance
 
 ### Performance

--- a/e2e/__tests__/__snapshots__/showConfig.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/showConfig.test.ts.snap
@@ -117,7 +117,7 @@ exports[`--showConfig outputs config info and exits 1`] = `
     "testFailureExitCode": 1,
     "testPathPattern": "",
     "testResultsProcessor": null,
-    "testSequencer": "@jest/test-sequencer",
+    "testSequencer": "<<REPLACED_JEST_PACKAGES_DIR>>/jest-test-sequencer/build/index.js",
     "updateSnapshot": "all",
     "useStderr": false,
     "verbose": null,

--- a/packages/jest-config/src/normalize.ts
+++ b/packages/jest-config/src/normalize.ts
@@ -496,11 +496,6 @@ export default function normalize(
     });
   }
 
-  newOptions.testSequencer = getSequencer(newOptions.resolver, {
-    filePath: options.testSequencer || DEFAULT_CONFIG.testSequencer,
-    rootDir: options.rootDir,
-  });
-
   const optionKeys = Object.keys(options) as Array<keyof Config.InitialOptions>;
 
   optionKeys.reduce((newOptions, key: keyof Config.InitialOptions) => {
@@ -876,6 +871,11 @@ export default function normalize(
   } catch (e) {
     // ignored
   }
+
+  newOptions.testSequencer = getSequencer(newOptions.resolver, {
+    filePath: options.testSequencer || DEFAULT_CONFIG.testSequencer,
+    rootDir: options.rootDir,
+  });
 
   newOptions.nonFlagArgs = argv._;
   newOptions.testPathPattern = buildTestPathPattern(argv);

--- a/packages/jest-config/src/normalize.ts
+++ b/packages/jest-config/src/normalize.ts
@@ -478,10 +478,6 @@ export default function normalize(
     options.testRunner = require.resolve('jest-jasmine2');
   }
 
-  if (!options.testSequencer) {
-    options.testSequencer = require.resolve('@jest/test-sequencer');
-  }
-
   if (!options.coverageDirectory) {
     options.coverageDirectory = path.resolve(options.rootDir, 'coverage');
   }
@@ -499,6 +495,11 @@ export default function normalize(
       rootDir: options.rootDir,
     });
   }
+
+  newOptions.testSequencer = getSequencer(newOptions.resolver, {
+    rootDir: options.rootDir,
+    filePath: options.testSequencer || DEFAULT_CONFIG.testSequencer,
+  });
 
   const optionKeys = Object.keys(options) as Array<keyof Config.InitialOptions>;
 
@@ -588,17 +589,6 @@ export default function normalize(
           value =
             option &&
             getRunner(newOptions.resolver, {
-              filePath: option,
-              rootDir: options.rootDir,
-            });
-        }
-        break;
-      case 'testSequencer':
-        {
-          const option = oldOptions[key];
-          value =
-            option &&
-            getSequencer(newOptions.resolver, {
               filePath: option,
               rootDir: options.rootDir,
             });

--- a/packages/jest-config/src/normalize.ts
+++ b/packages/jest-config/src/normalize.ts
@@ -497,8 +497,8 @@ export default function normalize(
   }
 
   newOptions.testSequencer = getSequencer(newOptions.resolver, {
-    rootDir: options.rootDir,
     filePath: options.testSequencer || DEFAULT_CONFIG.testSequencer,
+    rootDir: options.rootDir,
   });
 
   const optionKeys = Object.keys(options) as Array<keyof Config.InitialOptions>;

--- a/packages/jest-config/src/normalize.ts
+++ b/packages/jest-config/src/normalize.ts
@@ -478,6 +478,10 @@ export default function normalize(
     options.testRunner = require.resolve('jest-jasmine2');
   }
 
+  if (!options.testSequencer) {
+    options.testSequencer = require.resolve('@jest/test-sequencer');
+  }
+
   if (!options.coverageDirectory) {
     options.coverageDirectory = path.resolve(options.rootDir, 'coverage');
   }


### PR DESCRIPTION
## Summary

The default value of the test sequencer isn't resolved unless explicitly set (we only iterate on `options`, which contains the user-defined options but not the default ones). This diff ensures that we call `require.resolve` to obtain the real default path of the sequencer (since `@jest/core` is making the require call, it would fail otherwise under PnP).

## Test plan

I modified the code in my cache and checked that my tests were running. We probably should try to add an integration test for PnP at some point.