### PR TITLE
Fix module registry memory leak.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Performance
 
+- `[jest-runtime]` Fix module registry memory leak ([#8282](https://github.com/facebook/jest/pull/8282))
+
 ## 24.7.1
 
 ### Fixes

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -517,8 +517,8 @@ class Runtime {
   resetModules() {
     this._isolatedModuleRegistry = null;
     this._isolatedMockRegistry = null;
-    this._mockRegistry = new Map();
-    this._moduleRegistry = new Map();
+    this._mockRegistry.clear();
+    this._moduleRegistry.clear();
 
     if (this._environment) {
       if (this._environment.global) {


### PR DESCRIPTION
## Summary

This leak is caused by this line:
https://github.com/facebook/jest/blob/01044dabf2253287a5a84e6a87b8505b559e9257/packages/jest-runtime/src/index.ts#L693

The `moduleRegistry` is preserved in the closure and never GC'd, along with all modules within the registry, making it a pretty nasty memory leak. I'm fairly certain it's also a bug fix: when you reset the registry, this reference to the registry continued referencing the old version. That doesn't make sense after a reset.

This code is now a map and easy to clear but until very recently it was a normal `Object` which explains why it was 'cleared' in this way.

## Memory Impact

command: `yarn jest --logHeapUsage --w=1 packages/`

`--expose-gc` enabled to trigger gc manually after each test for accurate readings on the leak

without circus:
295 MB -> 262 MB (11% savings)

with circus:
848 MB -> 762 MB (10% savings)

## Test plan

- All tests pass.
- Reason for leak identified.
- Memory impact quantified.
- Hoping CI for Circus doesn't OOM now. :)