### PR TITLE
[jest-each] Fix bug with placeholder values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixes
 
+- `[jest-each]` Fix bug with placeholder values ([#8289](https://github.com/facebook/jest/pull/8289))
 - `[jest-snapshot]` Inline snapshots: do not indent empty lines ([#8277](https://github.com/facebook/jest/pull/8277))
 - `[jest-core]` Make `detectOpenHandles` imply `runInBand` ([#8283](https://github.com/facebook/jest/pull/8283))
 

--- a/packages/jest-each/src/__tests__/array.test.ts
+++ b/packages/jest-each/src/__tests__/array.test.ts
@@ -385,6 +385,29 @@ describe('jest-each', () => {
           undefined,
         );
       });
+
+      test('calls global with title with placeholder values correctly interpolated', () => {
+        const globalTestMocks = getGlobalTestMocks();
+        const eachObject = each.withGlobal(globalTestMocks)([
+          ['hello', '%d', 10, '%s', {foo: 'bar'}],
+          ['world', '%i', 1991, '%p', {foo: 'bar'}],
+        ]);
+        const testFunction = get(eachObject, keyPath);
+        testFunction('expected string: %s %s %d %s %p', () => {});
+
+        const globalMock = get(globalTestMocks, keyPath);
+        expect(globalMock).toHaveBeenCalledTimes(2);
+        expect(globalMock).toHaveBeenCalledWith(
+          'expected string: hello %d 10 %s {"foo": "bar"}',
+          expectFunction,
+          undefined,
+        );
+        expect(globalMock).toHaveBeenCalledWith(
+          'expected string: world %i 1991 %p {"foo": "bar"}',
+          expectFunction,
+          undefined,
+        );
+      });
     });
   });
 });

--- a/packages/jest-each/src/table/array.ts
+++ b/packages/jest-each/src/table/array.ts
@@ -15,6 +15,8 @@ import {EachTests} from '../bind';
 const SUPPORTED_PLACEHOLDERS = /%[sdifjoOp%]/g;
 const PRETTY_PLACEHOLDER = '%p';
 const INDEX_PLACEHOLDER = '%#';
+const PLACEHOLDER_PREFIX = '%';
+const JEST_EACH_PLACEHOLDER_ESCAPE = '@@__JEST_EACH_PLACEHOLDER_ESCAPE__@@';
 
 export default (title: string, arrayTable: Global.ArrayTable): EachTests =>
   normaliseTable(arrayTable).map((row, index) => ({
@@ -35,15 +37,23 @@ const formatTitle = (
   row: Global.Row,
   rowIndex: number,
 ): string =>
-  row.reduce<string>((formattedTitle, value) => {
-    const [placeholder] = getMatchingPlaceholders(formattedTitle);
-    if (!placeholder) return formattedTitle;
+  row
+    .reduce<string>((formattedTitle, value) => {
+      const [placeholder] = getMatchingPlaceholders(formattedTitle);
+      const normalisedValued = normalisePlaceholderValue(value);
+      if (!placeholder) return formattedTitle;
 
-    if (placeholder === PRETTY_PLACEHOLDER)
-      return interpolatePrettyPlaceholder(formattedTitle, value);
+      if (placeholder === PRETTY_PLACEHOLDER)
+        return interpolatePrettyPlaceholder(formattedTitle, normalisedValued);
 
-    return util.format(formattedTitle, value);
-  }, interpolateTitleIndex(title, rowIndex));
+      return util.format(formattedTitle, normalisedValued);
+    }, interpolateTitleIndex(title, rowIndex))
+    .replace(new RegExp(JEST_EACH_PLACEHOLDER_ESCAPE, 'g'), PLACEHOLDER_PREFIX);
+
+const normalisePlaceholderValue = (value: unknown) =>
+  typeof value === 'string' && SUPPORTED_PLACEHOLDERS.test(value)
+    ? value.replace(PLACEHOLDER_PREFIX, JEST_EACH_PLACEHOLDER_ESCAPE)
+    : value;
 
 const getMatchingPlaceholders = (title: string) =>
   title.match(SUPPORTED_PLACEHOLDERS) || [];

--- a/packages/jest-each/src/table/array.ts
+++ b/packages/jest-each/src/table/array.ts
@@ -40,13 +40,13 @@ const formatTitle = (
   row
     .reduce<string>((formattedTitle, value) => {
       const [placeholder] = getMatchingPlaceholders(formattedTitle);
-      const normalisedValued = normalisePlaceholderValue(value);
+      const normalisedValue = normalisePlaceholderValue(value);
       if (!placeholder) return formattedTitle;
 
       if (placeholder === PRETTY_PLACEHOLDER)
-        return interpolatePrettyPlaceholder(formattedTitle, normalisedValued);
+        return interpolatePrettyPlaceholder(formattedTitle, normalisedValue);
 
-      return util.format(formattedTitle, normalisedValued);
+      return util.format(formattedTitle, normalisedValue);
     }, interpolateTitleIndex(title, rowIndex))
     .replace(new RegExp(JEST_EACH_PLACEHOLDER_ESCAPE, 'g'), PLACEHOLDER_PREFIX);
 


### PR DESCRIPTION
## Summary

Fixes #8286

Basically what is happening is the valid placeholder values are interpolated and then have a knock on effect to the next value to be interpolated into the test title.

This PR stops this from happening by adding an escape to any placeholder values (`%d`) and then removes the all occurrences of the escape at the end of the formatting

## Test plan

See unit tests.