### PR TITLE
Updated URL to fix broken link

### DIFF
--- a/docs/Webpack.md
+++ b/docs/Webpack.md
@@ -230,4 +230,4 @@ If you use dynamic imports (`import('some-file.js').then(module => ...)`), you n
 }
 ```
 
-For an example of how to use Jest with Webpack with React, Redux, and Node, you can view one [here](https://github.com/jenniferkaplannyc/jest_react_redux_node_webpack_complex_example).
+For an example of how to use Jest with Webpack with React, Redux, and Node, you can view one [here](https://github.com/jenniferabowd/jest_react_redux_node_webpack_complex_example).


### PR DESCRIPTION
I got married, changed my last name, and therefore changed my GitHub name. This is updating the URL to match my new GitHub URL. Nothing else changed and this fixes a broken link.