### PR TITLE
Fixes the jest-haste-map mapper option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - `[jest-snapshot]` Inline snapshots: do not indent empty lines ([#8277](https://github.com/facebook/jest/pull/8277))
 - `[jest-core]` Make `detectOpenHandles` imply `runInBand` ([#8283](https://github.com/facebook/jest/pull/8283))
+- `[jest-haste-map]` Fix the `mapper` option which was incorrectly ignored ([#8299](https://github.com/facebook/jest/pull/8299))
 
 ### Chore & Maintenance
 

--- a/packages/jest-haste-map/src/index.ts
+++ b/packages/jest-haste-map/src/index.ts
@@ -256,6 +256,7 @@ class HasteMap extends EventEmitter {
       forceNodeFilesystemAPI: !!options.forceNodeFilesystemAPI,
       hasteImplModulePath: options.hasteImplModulePath,
       ignorePattern: options.ignorePattern,
+      mapper: options.mapper,
       maxWorkers: options.maxWorkers,
       mocksPattern: options.mocksPattern
         ? new RegExp(options.mocksPattern)


### PR DESCRIPTION
## Summary

I forgot in my previous PR to forward the `mapper` option from the `JestHasteMap` options to the crawler option. It went unnoticed because the tests directly instantiate the crawler and because in Metro this logic wasn't necessary because the PnP resolution bypassed the Haste map.

I noticed the problem by removing this bypass, which highlighted that the mapper never got called 😞 

## Test plan

Modified my Jest copy locally, checked that the mapper was called as it should be.
