### PR TITLE
Limit the number of workers when no `maxWorkers` arg is passed

### DIFF
--- a/packages/jest-config/src/__tests__/getMaxWorkers.test.ts
+++ b/packages/jest-config/src/__tests__/getMaxWorkers.test.ts
@@ -35,6 +35,17 @@ describe('getMaxWorkers', () => {
     expect(getMaxWorkers({watch: true})).toBe(2);
   });
 
+  describe('number of cpus > CPU_UPPER_LIMIT', () => {
+    beforeEach(() => {
+      require('os').__setCpus({length: 36});
+    });
+
+    it('Returns based on default CPU upper limit', () => {
+      expect(getMaxWorkers({})).toBe(7);
+      expect(getMaxWorkers({watch: true})).toBe(4);
+    });
+  });
+
   describe('% based', () => {
     it('50% = 2 workers', () => {
       const argv = {maxWorkers: '50%'};

--- a/packages/jest-config/src/getMaxWorkers.ts
+++ b/packages/jest-config/src/getMaxWorkers.ts
@@ -7,6 +7,7 @@
 
 import os from 'os';
 import {Config} from '@jest/types';
+const CPU_UPPER_LIMIT = 8;
 
 export default function getMaxWorkers(
   argv: Partial<Pick<Config.Argv, 'maxWorkers' | 'runInBand' | 'watch'>>,
@@ -32,7 +33,8 @@ export default function getMaxWorkers(
     return parsed > 0 ? parsed : 1;
   } else {
     // In watch mode, Jest should be unobtrusive and not use all available CPUs.
-    const cpus = os.cpus() ? os.cpus().length : 1;
+    // It should not use more than CPU_UPPER_LIMIT workers when 'maxWorkers' not specified
+    const cpus = os.cpus() ? Math.min(CPU_UPPER_LIMIT, os.cpus().length) : 1;
     return Math.max(argv.watch ? Math.floor(cpus / 2) : cpus - 1, 1);
   }
 }


### PR DESCRIPTION

## Summary

When running Jest in a machine with many CPU cores it forks
too many workers. If the machine is low in resouces while running the tests
the tests will timeout of run out of memory

This change sets the upper limit to 8 to ensure than no more than 7 workers
are forked when `maxWorkers` arg is not specified on CLI

More information is provided on the issue: https://github.com/facebook/jest/issues/8302

## Test plan

`yarn run jest` was used to run unit tests and verify the changes.