### PR TITLE
Add DynamoDB usage example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 - `[expect]` Improve report when matcher fails, part 15 ([#8281](https://github.com/facebook/jest/pull/8281))
+- `[docs]` Add DynamoDB guide ([#8319](https://github.com/facebook/jest/pull/8319))
 
 ### Fixes
 

--- a/docs/DynamoDB.md
+++ b/docs/DynamoDB.md
@@ -1,0 +1,75 @@
+---
+id: dynamodb
+title: Using with DynamoDB
+---
+
+With the [Global Setup/Teardown](Configuration.md#globalsetup-string) and [Async Test Environment](Configuration.md#testenvironment-string) APIs, Jest can work smoothly with [DynamoDB](https://aws.amazon.com/dynamodb/).
+
+## Use jest-dynamodb Preset
+
+[Jest DynamoDB](https://github.com/shelfio/jest-dynamodb) provides all required configuration to run your tests using DynamoDB.
+
+1.  First install `@shelf/jest-dynamodb`
+
+```
+yarn add @shelf/jest-dynamodb --dev
+```
+
+2.  Specify preset in your Jest configuration:
+
+```json
+{
+  "preset": "@shelf/jest-dynamodb"
+}
+```
+
+3.  Create `jest-dynamodb-config.js` and define DynamoDB tables
+
+See [Create Table API](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB.html#createTable-property)
+
+```js
+module.exports = {
+  tables: [
+    {
+      TableName: `files`,
+      KeySchema: [{AttributeName: 'id', KeyType: 'HASH'}],
+      AttributeDefinitions: [{AttributeName: 'id', AttributeType: 'S'}],
+      ProvisionedThroughput: {ReadCapacityUnits: 1, WriteCapacityUnits: 1}
+    }
+    // etc
+  ]
+};
+```
+
+4.  Configure DynamoDB client
+
+```js
+const {DocumentClient} = require('aws-sdk/clients/dynamodb');
+
+const isTest = process.env.JEST_WORKER_ID;
+const config = {
+  convertEmptyValues: true,
+  ...(isTest && {endpoint: 'localhost:8000', sslEnabled: false, region: 'local-env'})
+};
+
+const ddb = new DocumentClient(config);
+```
+
+5.  Write tests
+
+```js
+it('should insert item into table', async () => {
+  await ddb.put({TableName: 'files', Item: {id: '1', hello: 'world'}}).promise();
+
+  const {Item} = await ddb.get({TableName: 'files', Key: {id: '1'}}).promise();
+
+  expect(Item).toEqual({
+    id: '1',
+    hello: 'world'
+  });
+});
+```
+
+There's no need to load any dependencies.
+
+See [documentation](https://github.com/shelfio/jest-dynamodb) for details.

--- a/docs/DynamoDB.md
+++ b/docs/DynamoDB.md
@@ -34,10 +34,10 @@ module.exports = {
       TableName: `files`,
       KeySchema: [{AttributeName: 'id', KeyType: 'HASH'}],
       AttributeDefinitions: [{AttributeName: 'id', AttributeType: 'S'}],
-      ProvisionedThroughput: {ReadCapacityUnits: 1, WriteCapacityUnits: 1}
-    }
+      ProvisionedThroughput: {ReadCapacityUnits: 1, WriteCapacityUnits: 1},
+    },
     // etc
-  ]
+  ],
 };
 ```
 
@@ -49,7 +49,11 @@ const {DocumentClient} = require('aws-sdk/clients/dynamodb');
 const isTest = process.env.JEST_WORKER_ID;
 const config = {
   convertEmptyValues: true,
-  ...(isTest && {endpoint: 'localhost:8000', sslEnabled: false, region: 'local-env'})
+  ...(isTest && {
+    endpoint: 'localhost:8000',
+    sslEnabled: false,
+    region: 'local-env',
+  }),
 };
 
 const ddb = new DocumentClient(config);
@@ -59,13 +63,15 @@ const ddb = new DocumentClient(config);
 
 ```js
 it('should insert item into table', async () => {
-  await ddb.put({TableName: 'files', Item: {id: '1', hello: 'world'}}).promise();
+  await ddb
+    .put({TableName: 'files', Item: {id: '1', hello: 'world'}})
+    .promise();
 
   const {Item} = await ddb.get({TableName: 'files', Key: {id: '1'}}).promise();
 
   expect(Item).toEqual({
     id: '1',
-    hello: 'world'
+    hello: 'world',
   });
 });
 ```

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -20,6 +20,7 @@
       "webpack",
       "puppeteer",
       "mongodb",
+      "dynamodb",
       "tutorial-jquery",
       "watch-plugins",
       "migration-guide",


### PR DESCRIPTION
## Summary

Inspired by MongoDB usage example, I created a Jest DynamoDB preset based on [dynamodb-local](https://github.com/rynop/dynamodb-local) package

## Test plan

Tests are passing for a library which uses this preset: https://circleci.com/gh/shelfio/dynamodb-parallel-scan/tree/master
