### PR TITLE
Update --forceExit and "did not exit for one second" message colors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 - `[expect]` Improve report when matcher fails, part 15 ([#8281](https://github.com/facebook/jest/pull/8281))
+- `[jest-cli]` Update `--forceExit` and "did not exit for one second" message colors ([#8329](https://github.com/facebook/jest/pull/8329))
 
 ### Fixes
 

--- a/e2e/__tests__/__snapshots__/cliHandlesExactFilenames.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/cliHandlesExactFilenames.test.ts.snap
@@ -5,9 +5,7 @@ PASS foo/bar.spec.js
   ✓ foo
 
 
-Force exiting Jest
-
-Have you considered using \`--detectOpenHandles\` to detect async operations that kept running after all tests finished?
+Force exiting Jest: Have you considered using \`--detectOpenHandles\` to detect async operations that kept running after all tests finished?
 `;
 
 exports[`CLI accepts exact file names if matchers matched 2`] = `

--- a/e2e/__tests__/__snapshots__/consoleLogOutputWhenRunInBand.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/consoleLogOutputWhenRunInBand.test.ts.snap
@@ -5,9 +5,7 @@ PASS __tests__/a-banana.js
   ✓ banana
 
 
-Force exiting Jest
-
-Have you considered using \`--detectOpenHandles\` to detect async operations that kept running after all tests finished?
+Force exiting Jest: Have you considered using \`--detectOpenHandles\` to detect async operations that kept running after all tests finished?
 `;
 
 exports[`prints console.logs when run with forceExit 2`] = `

--- a/e2e/__tests__/__snapshots__/detectOpenHandles.ts.snap
+++ b/e2e/__tests__/__snapshots__/detectOpenHandles.ts.snap
@@ -1,10 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`prints message about flag on forceExit 1`] = `
-Force exiting Jest
-
-Have you considered using \`--detectOpenHandles\` to detect async operations that kept running after all tests finished?
-`;
+exports[`prints message about flag on forceExit 1`] = `Force exiting Jest: Have you considered using \`--detectOpenHandles\` to detect async operations that kept running after all tests finished?`;
 
 exports[`prints message about flag on slow tests 1`] = `
 Jest did not exit one second after the test run has completed.

--- a/packages/jest-cli/src/cli/index.ts
+++ b/packages/jest-cli/src/cli/index.ts
@@ -120,11 +120,9 @@ const readResultsAndExit = (
   if (globalConfig.forceExit) {
     if (!globalConfig.detectOpenHandles) {
       console.error(
-        chalk.red.bold('Force exiting Jest\n\n') +
-          chalk.red(
-            'Have you considered using `--detectOpenHandles` to detect ' +
-              'async operations that kept running after all tests finished?',
-          ),
+        chalk.bold('Force exiting Jest: ') +
+          'Have you considered using `--detectOpenHandles` to detect ' +
+          'async operations that kept running after all tests finished?',
       );
     }
 

--- a/packages/jest-cli/src/cli/index.ts
+++ b/packages/jest-cli/src/cli/index.ts
@@ -130,10 +130,10 @@ const readResultsAndExit = (
   } else if (!globalConfig.detectOpenHandles) {
     setTimeout(() => {
       console.error(
-        chalk.red.bold(
+        chalk.yellow.bold(
           'Jest did not exit one second after the test run has completed.\n\n',
         ) +
-          chalk.red(
+          chalk.yellow(
             'This usually means that there are asynchronous operations that ' +
               "weren't stopped in your tests. Consider running Jest with " +
               '`--detectOpenHandles` to troubleshoot this issue.',

--- a/packages/jest-cli/src/cli/index.ts
+++ b/packages/jest-cli/src/cli/index.ts
@@ -119,7 +119,7 @@ const readResultsAndExit = (
 
   if (globalConfig.forceExit) {
     if (!globalConfig.detectOpenHandles) {
-      console.error(
+      console.warn(
         chalk.bold('Force exiting Jest: ') +
           'Have you considered using `--detectOpenHandles` to detect ' +
           'async operations that kept running after all tests finished?',
@@ -129,7 +129,7 @@ const readResultsAndExit = (
     exit(code);
   } else if (!globalConfig.detectOpenHandles) {
     setTimeout(() => {
-      console.error(
+      console.warn(
         chalk.yellow.bold(
           'Jest did not exit one second after the test run has completed.\n\n',
         ) +


### PR DESCRIPTION
## Summary

Currently, the `--forceExit` warning is misleading because it's a bold, red message for something that you've specifically opted in to. When I run tests, my eye is looking for red to show me that something failed. If my project needs to use `--forceExit`, I shouldn't see red every single time. Red should be reserved for errors.

I've updated the message. It's now on one line and white. It's something you will see every single run, it shouldn't draw your eye too much.

<img width="971" alt="Screen Shot 2019-04-13 at 11 57 04 AM" src="https://user-images.githubusercontent.com/1831484/56084118-4d754080-5de3-11e9-8a54-dc03086c52ef.png">

Similarly, the "Jest did not exit for one second" message is currently shown in red. This message shouldn't show every time and should catch the user's eye. However, it's not an error by itself, it's a warning. It's possible that the test run completes successfully after this message is printed. I've updated the color to match.

<img width="1198" alt="Screen Shot 2019-04-13 at 11 58 09 AM" src="https://user-images.githubusercontent.com/1831484/56084125-74337700-5de3-11e9-9a8c-3ca76d33ea66.png">

## Test plan

- All tests pass.
- Updated snapshots.
- Tested manually.