### PR TITLE
jest-jasmine2: fix describe return value warning being shown if describe throws

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - `[@jest/runtime, @jest/transform]` Allow custom transforms for JSON dependencies ([#2578](https://github.com/facebook/jest/pull/2578))
 - `[jest-core]` Make `detectOpenHandles` imply `runInBand` ([#8283](https://github.com/facebook/jest/pull/8283))
 - `[jest-haste-map]` Fix the `mapper` option which was incorrectly ignored ([#8299](https://github.com/facebook/jest/pull/8299))
+- `[jest-jasmine2]` Fix describe return value warning being shown if the describe function throws ([#8335](https://github.com/facebook/jest/pull/8335))
 
 ### Chore & Maintenance
 

--- a/e2e/__tests__/declarationErrors.test.ts
+++ b/e2e/__tests__/declarationErrors.test.ts
@@ -29,3 +29,11 @@ it('warns if describe returns something', () => {
   expect(result.status).toBe(0);
   expect(normalizeCircusJasmine(result.stdout)).toMatchSnapshot();
 });
+
+it('errors if describe throws', () => {
+  const result = runJest('declaration-errors', ['describeThrow.test.js']);
+
+  expect(result.status).toBe(1);
+  expect(result.stdout).toBe('');
+  expect(result.stderr).toContain('whoops');
+});

--- a/e2e/declaration-errors/__tests__/describeThrow.test.js
+++ b/e2e/declaration-errors/__tests__/describeThrow.test.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+'use strict';
+
+describe('describe throw does not warn', () => {
+  it('t', () => {});
+  throw new Error('whoops');
+});

--- a/packages/jest-jasmine2/src/jasmine/Env.ts
+++ b/packages/jest-jasmine2/src/jasmine/Env.ts
@@ -416,8 +416,8 @@ export default function(j$: Jasmine) {
         parentSuite.addChild(suite);
         currentDeclarationSuite = suite;
 
-        let declarationError: null | Error = null;
-        let describeReturnValue: null | Error = null;
+        let declarationError: undefined | Error = undefined;
+        let describeReturnValue: undefined | Error = undefined;
         try {
           describeReturnValue = specDefinitions.call(suite);
         } catch (e) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Fixes the describe warning part of #8334 (intentionally not marking this as closing the whole issue)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Added e2e test case that fails with master build (the stdout `toBe('')` check).
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
