### PR TITLE
Stop running TS builds on CI beyond dedicated lint job

### DIFF
--- a/.azure-pipelines-steps.yml
+++ b/.azure-pipelines-steps.yml
@@ -26,7 +26,10 @@ steps:
     displayName: 'Move source into jest folder'
 
   # Run yarn to install dependencies and build
-  - script: yarn --frozen-lockfile
+  - script: |
+      node scripts/remove-postinstall
+      yarn --no-progress --frozen-lockfile
+      node scripts/build
     workingDirectory: $(JEST_DIR)
     displayName: 'Install dependencies and build'
 

--- a/.azure-pipelines-steps.yml
+++ b/.azure-pipelines-steps.yml
@@ -26,12 +26,15 @@ steps:
     displayName: 'Move source into jest folder'
 
   # Run yarn to install dependencies and build
-  - script: |
-      node scripts/remove-postinstall
-      yarn --no-progress --frozen-lockfile
-      node scripts/build
+  - script: node scripts/remove-postinstall
     workingDirectory: $(JEST_DIR)
-    displayName: 'Install dependencies and build'
+    displayName: 'Remove postinstall script'
+  - script: yarn --no-progress --frozen-lockfile
+    workingDirectory: $(JEST_DIR)
+    displayName: 'Install dependencies'
+  - script: node scripts/build
+    workingDirectory: $(JEST_DIR)
+    displayName: 'Build'
 
   # Run test-ci-partial
   - script: yarn run test-ci-partial

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,9 +36,17 @@ jobs:
       - image: circleci/node:6
     steps:
       - checkout
-      - restore-cache: *restore-cache
+      - restore-cache:
+      keys:
+        - v2-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}-node6
+        # Fallback in case checksum fails
+        - v2-dependencies-{{ .Branch }}-node6
       - run: yarn --no-progress --frozen-lockfile --ignore-engines --ignore-scripts && node scripts/build.js
-      - save-cache: *save-cache
+      - save-cache:
+          paths:
+            - node_modules
+            - website/node_modules
+          key: v2-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}-node6
       - run:
           # react-native does not work with node 6
           command: rm -rf examples/react-native && yarn test-ci-partial

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - checkout
       - restore-cache: *restore-cache
-      - run: node scripts/remove-postinstall && node scripts/build && yarn --no-progress --frozen-lockfile --ignore-engines
+      - run: node scripts/remove-postinstall && yarn --no-progress --frozen-lockfile --ignore-engines && node scripts/build
       - save-cache: *save-cache
       - run:
           # react-native does not work with node 6

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,21 +30,6 @@ jobs:
       - store_test_results:
           path: reports/junit
 
-  test-node-6:
-    working_directory: ~/jest
-    docker:
-      - image: circleci/node:6
-    steps:
-      - checkout
-      - restore-cache: *restore-cache
-      - run: yarn --no-progress --frozen-lockfile --ignore-engines
-      - save-cache: *save-cache
-      - run:
-          # react-native does not work with node 6
-          command: rm -rf examples/react-native && yarn test-ci-partial
-      - store_test_results:
-          path: reports/junit
-
   test-node-8:
     working_directory: ~/jest
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - checkout
       - restore-cache: *restore-cache
-      - run: node scripts/remove-postinstall && yarn --no-progress --frozen-lockfile --ignore-engines
+      - run: node scripts/remove-postinstall && node scripts/build && yarn --no-progress --frozen-lockfile --ignore-engines
       - save-cache: *save-cache
       - run:
           # react-native does not work with node 6

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,8 +14,7 @@ aliases:
   - &filter-ignore-gh-pages
     branches:
       ignore: gh-pages
-  - &install
-    node scripts/remove-postinstall && yarn --no-progress --frozen-lockfile --ignore-engines && node scripts/build
+  - &install node scripts/remove-postinstall && yarn --no-progress --frozen-lockfile --ignore-engines && node scripts/build
 
 version: 2
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,10 +37,10 @@ jobs:
     steps:
       - checkout
       - restore-cache:
-      keys:
-        - v2-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}-node6
-        # Fallback in case checksum fails
-        - v2-dependencies-{{ .Branch }}-node6
+        keys:
+          - v2-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}-node6
+          # Fallback in case checksum fails
+          - v2-dependencies-{{ .Branch }}-node6
       - run: yarn --no-progress --frozen-lockfile --ignore-engines --ignore-scripts && node scripts/build.js
       - save-cache:
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - checkout
       - restore-cache: *restore-cache
-      - run: yarn --no-progress --frozen-lockfile --ignore-engines
+      - run: yarn --no-progress --frozen-lockfile --ignore-engines --ignore-scripts && node scripts/build.js
       - save-cache: *save-cache
       - run:
           # react-native does not work with node 6

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,17 +36,9 @@ jobs:
       - image: circleci/node:6
     steps:
       - checkout
-      - restore-cache:
-          keys:
-            - v2-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}-node6
-            # Fallback in case checksum fails
-            - v2-dependencies-{{ .Branch }}-node6
-      - run: yarn --no-progress --frozen-lockfile --ignore-engines --ignore-scripts && node scripts/build.js
-      - save-cache:
-          paths:
-            - node_modules
-            - website/node_modules
-          key: v2-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}-node6
+      - restore-cache: *restore-cache
+      - run: node scripts/remove-postinstall && yarn --no-progress --frozen-lockfile --ignore-engines
+      - save-cache: *save-cache
       - run:
           # react-native does not work with node 6
           command: rm -rf examples/react-native && yarn test-ci-partial

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,10 +37,10 @@ jobs:
     steps:
       - checkout
       - restore-cache:
-        keys:
-          - v2-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}-node6
-          # Fallback in case checksum fails
-          - v2-dependencies-{{ .Branch }}-node6
+          keys:
+            - v2-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}-node6
+            # Fallback in case checksum fails
+            - v2-dependencies-{{ .Branch }}-node6
       - run: yarn --no-progress --frozen-lockfile --ignore-engines --ignore-scripts && node scripts/build.js
       - save-cache:
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,21 @@ jobs:
       - store_test_results:
           path: reports/junit
 
+  test-node-6:
+    working_directory: ~/jest
+    docker:
+      - image: circleci/node:6
+    steps:
+      - checkout
+      - restore-cache: *restore-cache
+      - run: yarn --no-progress --frozen-lockfile --ignore-engines
+      - save-cache: *save-cache
+      - run:
+          # react-native does not work with node 6
+          command: rm -rf examples/react-native && yarn test-ci-partial
+      - store_test_results:
+          path: reports/junit
+
   test-node-8:
     working_directory: ~/jest
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,8 @@ aliases:
   - &filter-ignore-gh-pages
     branches:
       ignore: gh-pages
+  - &install
+    node scripts/remove-postinstall && yarn --no-progress --frozen-lockfile --ignore-engines && node scripts/build
 
 version: 2
 jobs:
@@ -37,7 +39,7 @@ jobs:
     steps:
       - checkout
       - restore-cache: *restore-cache
-      - run: node scripts/remove-postinstall && yarn --no-progress --frozen-lockfile --ignore-engines && node scripts/build
+      - run: *install
       - save-cache: *save-cache
       - run:
           # react-native does not work with node 6
@@ -52,7 +54,7 @@ jobs:
     steps:
       - checkout
       - restore-cache: *restore-cache
-      - run: yarn --no-progress --frozen-lockfile
+      - run: *install
       - save-cache: *save-cache
       - run:
           command: yarn test-ci-partial
@@ -66,7 +68,7 @@ jobs:
     steps:
       - checkout
       - restore-cache: *restore-cache
-      - run: yarn --no-progress --frozen-lockfile
+      - run: *install
       - save-cache: *save-cache
       - run:
           command: yarn test-ci
@@ -80,7 +82,7 @@ jobs:
     steps:
       - checkout
       - restore-cache: *restore-cache
-      - run: yarn --no-progress --frozen-lockfile
+      - run: *install
       - save-cache: *save-cache
       - run:
           command: JEST_CIRCUS=1 yarn test-ci-partial
@@ -94,7 +96,7 @@ jobs:
     steps:
       - checkout
       - restore-cache: *restore-cache
-      - run: yarn --no-progress --frozen-lockfile
+      - run: *install
       - save-cache: *save-cache
       - run:
           command: yarn test-ci-partial
@@ -108,7 +110,7 @@ jobs:
     steps:
       - checkout
       - restore-cache: *restore-cache
-      - run: yarn --no-progress --frozen-lockfile
+      - run: *install
       - save-cache: *save-cache
       - run: yarn test-ci-es5-build-in-browser
 
@@ -120,7 +122,7 @@ jobs:
     steps:
       - checkout
       - restore-cache: *restore-cache
-      - run: yarn --no-progress --frozen-lockfile
+      - run: *install
       - save-cache: *save-cache
       - run:
           name: Test or Deploy Jest Website

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash
   - export PATH="$HOME/.yarn/bin:$PATH"
 
-install: yarn --frozen-lockfile
+install: node scripts/remove-postinstall && yarn --no-progress --frozen-lockfile --ignore-engines && node scripts/build
 
 cache:
   yarn: true

--- a/scripts/remove-postinstall.js
+++ b/scripts/remove-postinstall.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const {writeFileSync} = require('fs');
+
+const pkgPath = require.resolve('../package.json');
+
+const pkg = require('../package.json');
+
+delete pkg.scripts.postinstall;
+
+writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);

--- a/scripts/remove-postinstall.js
+++ b/scripts/remove-postinstall.js
@@ -1,3 +1,5 @@
+// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+
 'use strict';
 
 const {writeFileSync} = require('fs');


### PR DESCRIPTION
## Summary

We're dropping Node 6 support shortly and it's already failing on CI because it can't compile the TypeScript without dying. Stop running it now since it's failing regardless.

## Test plan

- CI should stop running Node 6.