### PR TITLE
expect: Improve report when matcher fails, part 17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `[expect]` Improve report when matcher fails, part 16 ([#8306](https://github.com/facebook/jest/pull/8306))
 - `[jest-runner]` Pass docblock pragmas to TestEnvironment constructor ([#8320](https://github.com/facebook/jest/pull/8320))
 - `[docs]` Add DynamoDB guide ([#8319](https://github.com/facebook/jest/pull/8319))
+- `[expect]` Improve report when matcher fails, part 17 ([#8349](https://github.com/facebook/jest/pull/8349))
 
 ### Fixes
 

--- a/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -3224,7 +3224,7 @@ Received path: <red>\\"a\\"</>
 Expected value: not <green>undefined</>
 Received value:     <red>{}</>
 
-<dim>Because a positive assertion passes for expected value undefined if the property does not exist, therefore this negative assertion fails unless the property does exist and has a defined value</>"
+<dim>Because a positive assertion passes for expected value undefined if the property does not exist, this negative assertion fails unless the property does exist and has a defined value</>"
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({"a": 0}).toHaveProperty('a') 1`] = `

--- a/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -2841,7 +2841,7 @@ Expected has value: <green>-3</>"
 `;
 
 exports[`.toHaveProperty() {error} expect({"a": {"b": {}}}).toHaveProperty('1') 1`] = `
-"<dim>expect(</><red>received</><dim>).toHaveProperty(</><green>path</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toHaveProperty<dim>(</><green>path</><dim>)</>
 
 <bold>Matcher error</>: <green>expected</> path must be a string or array
 
@@ -2850,7 +2850,7 @@ Expected has value: <green>1</>"
 `;
 
 exports[`.toHaveProperty() {error} expect({"a": {"b": {}}}).toHaveProperty('null') 1`] = `
-"<dim>expect(</><red>received</><dim>).toHaveProperty(</><green>path</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toHaveProperty<dim>(</><green>path</><dim>)</>
 
 <bold>Matcher error</>: <green>expected</> path must be a string or array
 
@@ -2858,17 +2858,24 @@ Expected has value: <green>null</>"
 `;
 
 exports[`.toHaveProperty() {error} expect({"a": {"b": {}}}).toHaveProperty('undefined') 1`] = `
-"<dim>expect(</><red>received</><dim>).toHaveProperty(</><green>path</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toHaveProperty<dim>(</><green>path</><dim>)</>
 
 <bold>Matcher error</>: <green>expected</> path must be a string or array
 
 Expected has value: <green>undefined</>"
 `;
 
-exports[`.toHaveProperty() {error} expect({}).toHaveProperty('') 1`] = `"pass must be initialized"`;
+exports[`.toHaveProperty() {error} expect({}).toHaveProperty('') 1`] = `
+"<dim>expect(</><red>received</><dim>).</>toHaveProperty<dim>(</><green>path</><dim>)</>
+
+<bold>Matcher error</>: <green>expected</> path must not be an empty array
+
+Expected has type:  array
+Expected has value: <green>[]</>"
+`;
 
 exports[`.toHaveProperty() {error} expect(null).toHaveProperty('a.b') 1`] = `
-"<dim>expect(</><red>received</><dim>).toHaveProperty(</><green>path</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toHaveProperty<dim>(</><green>path</><dim>)</>
 
 <bold>Matcher error</>: <red>received</> value must not be null nor undefined
 
@@ -2876,7 +2883,7 @@ Received has value: <red>null</>"
 `;
 
 exports[`.toHaveProperty() {error} expect(undefined).toHaveProperty('a') 1`] = `
-"<dim>expect(</><red>received</><dim>).toHaveProperty(</><green>path</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toHaveProperty<dim>(</><green>path</><dim>)</>
 
 <bold>Matcher error</>: <red>received</> value must not be null nor undefined
 
@@ -2884,116 +2891,87 @@ Received has value: <red>undefined</>"
 `;
 
 exports[`.toHaveProperty() {pass: false} expect("").toHaveProperty('key') 1`] = `
-"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toHaveProperty<dim>(</><green>path</><dim>)</>
 
-Expected the object:
-  <red>\\"\\"</>
-To have a nested property:
-  <green>\\"key\\"</>
-"
+Expected path: <green>\\"key\\"</>
+Received path: <red>[]</>
+
+Received value: <red>\\"\\"</>"
 `;
 
 exports[`.toHaveProperty() {pass: false} expect("abc").toHaveProperty('a.b.c') 1`] = `
-"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toHaveProperty<dim>(</><green>path</><dim>)</>
 
-Expected the object:
-  <red>\\"abc\\"</>
-To have a nested property:
-  <green>\\"a.b.c\\"</>
-"
+Expected path: <green>\\"a.b.c\\"</>
+Received path: <red>[]</>
+
+Received value: <red>\\"abc\\"</>"
 `;
 
 exports[`.toHaveProperty() {pass: false} expect("abc").toHaveProperty('a.b.c', {"a": 5}) 1`] = `
-"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</><dim>, </><green>value</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
 
-Expected the object:
-  <red>\\"abc\\"</>
-To have a nested property:
-  <green>\\"a.b.c\\"</>
-With a value of:
-  <green>{\\"a\\": 5}</>
-"
+Expected path: <green>\\"a.b.c\\"</>
+Received path: <red>[]</>
+
+Expected value: <green>{\\"a\\": 5}</>
+Received value: <red>\\"abc\\"</>"
 `;
 
 exports[`.toHaveProperty() {pass: false} expect({"a": {"b": {"c": {"d": 1}}}}).toHaveProperty('a,b,c,d', 2) 1`] = `
-"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</><dim>, </><green>value</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
 
-Expected the object:
-  <red>{\\"a\\": {\\"b\\": {\\"c\\": {\\"d\\": 1}}}}</>
-To have a nested property:
-  <green>[\\"a\\", \\"b\\", \\"c\\", \\"d\\"]</>
-With a value of:
-  <green>2</>
-Received:
-  <red>1</>"
+Expected path: <green>[\\"a\\", \\"b\\", \\"c\\", \\"d\\"]</>
+
+Expected value: <green>2</>
+Received value: <red>1</>"
 `;
 
 exports[`.toHaveProperty() {pass: false} expect({"a": {"b": {"c": {"d": 1}}}}).toHaveProperty('a.b.c.d', 2) 1`] = `
-"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</><dim>, </><green>value</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
 
-Expected the object:
-  <red>{\\"a\\": {\\"b\\": {\\"c\\": {\\"d\\": 1}}}}</>
-To have a nested property:
-  <green>\\"a.b.c.d\\"</>
-With a value of:
-  <green>2</>
-Received:
-  <red>1</>"
+Expected path: <green>\\"a.b.c.d\\"</>
+
+Expected value: <green>2</>
+Received value: <red>1</>"
 `;
 
 exports[`.toHaveProperty() {pass: false} expect({"a": {"b": {"c": {"d": 1}}}}).toHaveProperty('a.b.ttt.d', 1) 1`] = `
-"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</><dim>, </><green>value</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
 
-Expected the object:
-  <red>{\\"a\\": {\\"b\\": {\\"c\\": {\\"d\\": 1}}}}</>
-To have a nested property:
-  <green>\\"a.b.ttt.d\\"</>
-With a value of:
-  <green>1</>
-Received:
-  <red>object</>.a.b: <red>{\\"c\\": {\\"d\\": 1}}</>"
+Expected path: <green>\\"a.b.ttt.d\\"</>
+Received path: <red>\\"a.b\\"</>
+
+Expected value: <green>1</>
+Received value: <red>{\\"c\\": {\\"d\\": 1}}</>"
 `;
 
 exports[`.toHaveProperty() {pass: false} expect({"a": {"b": {"c": {}}}}).toHaveProperty('a.b.c.d') 1`] = `
-"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toHaveProperty<dim>(</><green>path</><dim>)</>
 
-Expected the object:
-  <red>{\\"a\\": {\\"b\\": {\\"c\\": {}}}}</>
-To have a nested property:
-  <green>\\"a.b.c.d\\"</>
-Received:
-  <red>object</>.a.b.c: <red>{}</>"
+Expected path: <green>\\"a.b.c.d\\"</>
+Received path: <red>\\"a.b.c\\"</>
+
+Received value: <red>{}</>"
 `;
 
 exports[`.toHaveProperty() {pass: false} expect({"a": {"b": {"c": {}}}}).toHaveProperty('a.b.c.d', 1) 1`] = `
-"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</><dim>, </><green>value</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
 
-Expected the object:
-  <red>{\\"a\\": {\\"b\\": {\\"c\\": {}}}}</>
-To have a nested property:
-  <green>\\"a.b.c.d\\"</>
-With a value of:
-  <green>1</>
-Received:
-  <red>object</>.a.b.c: <red>{}</>"
+Expected path: <green>\\"a.b.c.d\\"</>
+Received path: <red>\\"a.b.c\\"</>
+
+Expected value: <green>1</>
+Received value: <red>{}</>"
 `;
 
 exports[`.toHaveProperty() {pass: false} expect({"a": {"b": {"c": 5}}}).toHaveProperty('a.b', {"c": 4}) 1`] = `
-"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</><dim>, </><green>value</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
 
-Expected the object:
-  <red>{\\"a\\": {\\"b\\": {\\"c\\": 5}}}</>
-To have a nested property:
-  <green>\\"a.b\\"</>
-With a value of:
-  <green>{\\"c\\": 4}</>
-Received:
-  <red>{\\"c\\": 5}</>
+Expected path: <green>\\"a.b\\"</>
 
-Difference:
-
-<green>- Expected</>
-<red>+ Received</>
+<green>- Expected value</>
+<red>+ Received value</>
 
 <dim>  Object {</>
 <green>-   \\"c\\": 4,</>
@@ -3002,451 +2980,347 @@ Difference:
 `;
 
 exports[`.toHaveProperty() {pass: false} expect({"a": {"b": 3}}).toHaveProperty('a.b', undefined) 1`] = `
-"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</><dim>, </><green>value</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
 
-Expected the object:
-  <red>{\\"a\\": {\\"b\\": 3}}</>
-To have a nested property:
-  <green>\\"a.b\\"</>
-With a value of:
-  <green>undefined</>
-Received:
-  <red>3</>
+Expected path: <green>\\"a.b\\"</>
 
-Difference:
-
-  Comparing two different types of values. Expected <green>undefined</> but received <red>number</>."
+Expected value: <green>undefined</>
+Received value: <red>3</>"
 `;
 
 exports[`.toHaveProperty() {pass: false} expect({"a": 1}).toHaveProperty('a.b.c.d') 1`] = `
-"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toHaveProperty<dim>(</><green>path</><dim>)</>
 
-Expected the object:
-  <red>{\\"a\\": 1}</>
-To have a nested property:
-  <green>\\"a.b.c.d\\"</>
-Received:
-  <red>object</>.a: <red>1</>"
+Expected path: <green>\\"a.b.c.d\\"</>
+Received path: <red>\\"a\\"</>
+
+Received value: <red>1</>"
 `;
 
 exports[`.toHaveProperty() {pass: false} expect({"a": 1}).toHaveProperty('a.b.c.d', 5) 1`] = `
-"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</><dim>, </><green>value</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
 
-Expected the object:
-  <red>{\\"a\\": 1}</>
-To have a nested property:
-  <green>\\"a.b.c.d\\"</>
-With a value of:
-  <green>5</>
-Received:
-  <red>object</>.a: <red>1</>"
+Expected path: <green>\\"a.b.c.d\\"</>
+Received path: <red>\\"a\\"</>
+
+Expected value: <green>5</>
+Received value: <red>1</>"
 `;
 
 exports[`.toHaveProperty() {pass: false} expect({"a.b.c.d": 1}).toHaveProperty('a.b.c.d', 2) 1`] = `
-"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</><dim>, </><green>value</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
 
-Expected the object:
-  <red>{\\"a.b.c.d\\": 1}</>
-To have a nested property:
-  <green>\\"a.b.c.d\\"</>
-With a value of:
-  <green>2</>
-"
+Expected path: <green>\\"a.b.c.d\\"</>
+Received path: <red>[]</>
+
+Expected value: <green>2</>
+Received value: <red>{\\"a.b.c.d\\": 1}</>"
 `;
 
 exports[`.toHaveProperty() {pass: false} expect({"a.b.c.d": 1}).toHaveProperty('a.b.c.d', 2) 2`] = `
-"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</><dim>, </><green>value</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
 
-Expected the object:
-  <red>{\\"a.b.c.d\\": 1}</>
-To have a nested property:
-  <green>[\\"a.b.c.d\\"]</>
-With a value of:
-  <green>2</>
-Received:
-  <red>1</>"
+Expected path: <green>[\\"a.b.c.d\\"]</>
+
+Expected value: <green>2</>
+Received value: <red>1</>"
 `;
 
 exports[`.toHaveProperty() {pass: false} expect({"key": 1}).toHaveProperty('not') 1`] = `
-"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toHaveProperty<dim>(</><green>path</><dim>)</>
 
-Expected the object:
-  <red>{\\"key\\": 1}</>
-To have a nested property:
-  <green>\\"not\\"</>
-"
+Expected path: <green>\\"not\\"</>
+Received path: <red>[]</>
+
+Received value: <red>{\\"key\\": 1}</>"
 `;
 
 exports[`.toHaveProperty() {pass: false} expect({}).toHaveProperty('a') 1`] = `
-"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toHaveProperty<dim>(</><green>path</><dim>)</>
 
-Expected the object:
-  <red>{}</>
-To have a nested property:
-  <green>\\"a\\"</>
-"
+Expected path: <green>\\"a\\"</>
+Received path: <red>[]</>
+
+Received value: <red>{}</>"
 `;
 
 exports[`.toHaveProperty() {pass: false} expect({}).toHaveProperty('a', "a") 1`] = `
-"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</><dim>, </><green>value</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
 
-Expected the object:
-  <red>{}</>
-To have a nested property:
-  <green>\\"a\\"</>
-With a value of:
-  <green>\\"a\\"</>
-Received:
-  <red>undefined</>
+Expected path: <green>\\"a\\"</>
 
-Difference:
-
-  Comparing two different types of values. Expected <green>string</> but received <red>undefined</>."
+Expected value: <green>\\"a\\"</>
+Received value: <red>undefined</>"
 `;
 
 exports[`.toHaveProperty() {pass: false} expect({}).toHaveProperty('a', "test") 1`] = `
-"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</><dim>, </><green>value</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
 
-Expected the object:
-  <red>{}</>
-To have a nested property:
-  <green>\\"a\\"</>
-With a value of:
-  <green>\\"test\\"</>
-"
+Expected path: <green>\\"a\\"</>
+Received path: <red>[]</>
+
+Expected value: <green>\\"test\\"</>
+Received value: <red>{}</>"
 `;
 
 exports[`.toHaveProperty() {pass: false} expect({}).toHaveProperty('b', undefined) 1`] = `
-"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</><dim>, </><green>value</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
 
-Expected the object:
-  <red>{}</>
-To have a nested property:
-  <green>\\"b\\"</>
-With a value of:
-  <green>undefined</>
-Received:
-  <red>\\"b\\"</>
+Expected path: <green>\\"b\\"</>
 
-Difference:
-
-  Comparing two different types of values. Expected <green>undefined</> but received <red>string</>."
+Expected value: <green>undefined</>
+Received value: <red>\\"b\\"</>"
 `;
 
 exports[`.toHaveProperty() {pass: false} expect(0).toHaveProperty('key') 1`] = `
-"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toHaveProperty<dim>(</><green>path</><dim>)</>
 
-Expected the object:
-  <red>0</>
-To have a nested property:
-  <green>\\"key\\"</>
-"
+Expected path: <green>\\"key\\"</>
+Received path: <red>[]</>
+
+Received value: <red>0</>"
 `;
 
 exports[`.toHaveProperty() {pass: false} expect(1).toHaveProperty('a.b.c') 1`] = `
-"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toHaveProperty<dim>(</><green>path</><dim>)</>
 
-Expected the object:
-  <red>1</>
-To have a nested property:
-  <green>\\"a.b.c\\"</>
-"
+Expected path: <green>\\"a.b.c\\"</>
+Received path: <red>[]</>
+
+Received value: <red>1</>"
 `;
 
 exports[`.toHaveProperty() {pass: false} expect(1).toHaveProperty('a.b.c', "test") 1`] = `
-"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</><dim>, </><green>value</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
 
-Expected the object:
-  <red>1</>
-To have a nested property:
-  <green>\\"a.b.c\\"</>
-With a value of:
-  <green>\\"test\\"</>
-"
+Expected path: <green>\\"a.b.c\\"</>
+Received path: <red>[]</>
+
+Expected value: <green>\\"test\\"</>
+Received value: <red>1</>"
 `;
 
 exports[`.toHaveProperty() {pass: false} expect(Symbol()).toHaveProperty('key') 1`] = `
-"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toHaveProperty<dim>(</><green>path</><dim>)</>
 
-Expected the object:
-  <red>Symbol()</>
-To have a nested property:
-  <green>\\"key\\"</>
-"
+Expected path: <green>\\"key\\"</>
+Received path: <red>[]</>
+
+Received value: <red>Symbol()</>"
 `;
 
 exports[`.toHaveProperty() {pass: false} expect(false).toHaveProperty('key') 1`] = `
-"<dim>expect(</><red>object</><dim>).toHaveProperty(</><green>path</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toHaveProperty<dim>(</><green>path</><dim>)</>
 
-Expected the object:
-  <red>false</>
-To have a nested property:
-  <green>\\"key\\"</>
-"
+Expected path: <green>\\"key\\"</>
+Received path: <red>[]</>
+
+Received value: <red>false</>"
 `;
 
 exports[`.toHaveProperty() {pass: true} expect("").toHaveProperty('length', 0) 1`] = `
-"<dim>expect(</><red>object</><dim>).</>not<dim>.toHaveProperty(</><green>path</><dim>, </><green>value</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
 
-Expected the object:
-  <red>\\"\\"</>
-Not to have a nested property:
-  <green>\\"length\\"</>
-With a value of:
-  <green>0</>
-"
+Expected path: <green>\\"length\\"</>
+
+Expected value: not <green>0</>"
 `;
 
 exports[`.toHaveProperty() {pass: true} expect([Function memoized]).toHaveProperty('memo', []) 1`] = `
-"<dim>expect(</><red>object</><dim>).</>not<dim>.toHaveProperty(</><green>path</><dim>, </><green>value</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
 
-Expected the object:
-  <red>[Function memoized]</>
-Not to have a nested property:
-  <green>\\"memo\\"</>
-With a value of:
-  <green>[]</>
-"
+Expected path: <green>\\"memo\\"</>
+
+Expected value: not <green>[]</>"
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({"a": {"b": [1, 2, 3]}}).toHaveProperty('a,b,1') 1`] = `
-"<dim>expect(</><red>object</><dim>).</>not<dim>.toHaveProperty(</><green>path</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveProperty<dim>(</><green>path</><dim>)</>
 
-Expected the object:
-  <red>{\\"a\\": {\\"b\\": [1, 2, 3]}}</>
-Not to have a nested property:
-  <green>[\\"a\\", \\"b\\", 1]</>
-"
+Expected path: not <green>[\\"a\\", \\"b\\", 1]</>
+
+Received value: <red>2</>"
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({"a": {"b": [1, 2, 3]}}).toHaveProperty('a,b,1', 2) 1`] = `
-"<dim>expect(</><red>object</><dim>).</>not<dim>.toHaveProperty(</><green>path</><dim>, </><green>value</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
 
-Expected the object:
-  <red>{\\"a\\": {\\"b\\": [1, 2, 3]}}</>
-Not to have a nested property:
-  <green>[\\"a\\", \\"b\\", 1]</>
-With a value of:
-  <green>2</>
-"
+Expected path: <green>[\\"a\\", \\"b\\", 1]</>
+
+Expected value: not <green>2</>"
+`;
+
+exports[`.toHaveProperty() {pass: true} expect({"a": {"b": [1, 2, 3]}}).toHaveProperty('a,b,1', Any<Number>) 1`] = `
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
+
+Expected path: <green>[\\"a\\", \\"b\\", 1]</>
+
+Expected value: not <green>Any<Number></>
+Received value:     <red>2</>"
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({"a": {"b": {"c": {"d": 1}}}}).toHaveProperty('a,b,c,d') 1`] = `
-"<dim>expect(</><red>object</><dim>).</>not<dim>.toHaveProperty(</><green>path</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveProperty<dim>(</><green>path</><dim>)</>
 
-Expected the object:
-  <red>{\\"a\\": {\\"b\\": {\\"c\\": {\\"d\\": 1}}}}</>
-Not to have a nested property:
-  <green>[\\"a\\", \\"b\\", \\"c\\", \\"d\\"]</>
-"
+Expected path: not <green>[\\"a\\", \\"b\\", \\"c\\", \\"d\\"]</>
+
+Received value: <red>1</>"
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({"a": {"b": {"c": {"d": 1}}}}).toHaveProperty('a,b,c,d', 1) 1`] = `
-"<dim>expect(</><red>object</><dim>).</>not<dim>.toHaveProperty(</><green>path</><dim>, </><green>value</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
 
-Expected the object:
-  <red>{\\"a\\": {\\"b\\": {\\"c\\": {\\"d\\": 1}}}}</>
-Not to have a nested property:
-  <green>[\\"a\\", \\"b\\", \\"c\\", \\"d\\"]</>
-With a value of:
-  <green>1</>
-"
+Expected path: <green>[\\"a\\", \\"b\\", \\"c\\", \\"d\\"]</>
+
+Expected value: not <green>1</>"
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({"a": {"b": {"c": {"d": 1}}}}).toHaveProperty('a.b.c.d') 1`] = `
-"<dim>expect(</><red>object</><dim>).</>not<dim>.toHaveProperty(</><green>path</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveProperty<dim>(</><green>path</><dim>)</>
 
-Expected the object:
-  <red>{\\"a\\": {\\"b\\": {\\"c\\": {\\"d\\": 1}}}}</>
-Not to have a nested property:
-  <green>\\"a.b.c.d\\"</>
-"
+Expected path: not <green>\\"a.b.c.d\\"</>
+
+Received value: <red>1</>"
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({"a": {"b": {"c": {"d": 1}}}}).toHaveProperty('a.b.c.d', 1) 1`] = `
-"<dim>expect(</><red>object</><dim>).</>not<dim>.toHaveProperty(</><green>path</><dim>, </><green>value</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
 
-Expected the object:
-  <red>{\\"a\\": {\\"b\\": {\\"c\\": {\\"d\\": 1}}}}</>
-Not to have a nested property:
-  <green>\\"a.b.c.d\\"</>
-With a value of:
-  <green>1</>
-"
+Expected path: <green>\\"a.b.c.d\\"</>
+
+Expected value: not <green>1</>"
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({"a": {"b": {"c": 5}}}).toHaveProperty('a.b', {"c": 5}) 1`] = `
-"<dim>expect(</><red>object</><dim>).</>not<dim>.toHaveProperty(</><green>path</><dim>, </><green>value</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
 
-Expected the object:
-  <red>{\\"a\\": {\\"b\\": {\\"c\\": 5}}}</>
-Not to have a nested property:
-  <green>\\"a.b\\"</>
-With a value of:
-  <green>{\\"c\\": 5}</>
-"
+Expected path: <green>\\"a.b\\"</>
+
+Expected value: not <green>{\\"c\\": 5}</>"
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({"a": {"b": undefined}}).toHaveProperty('a.b') 1`] = `
-"<dim>expect(</><red>object</><dim>).</>not<dim>.toHaveProperty(</><green>path</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveProperty<dim>(</><green>path</><dim>)</>
 
-Expected the object:
-  <red>{\\"a\\": {\\"b\\": undefined}}</>
-Not to have a nested property:
-  <green>\\"a.b\\"</>
-"
+Expected path: not <green>\\"a.b\\"</>
+
+Received value: <red>undefined</>"
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({"a": {"b": undefined}}).toHaveProperty('a.b', undefined) 1`] = `
-"<dim>expect(</><red>object</><dim>).</>not<dim>.toHaveProperty(</><green>path</><dim>, </><green>value</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
 
-Expected the object:
-  <red>{\\"a\\": {\\"b\\": undefined}}</>
-Not to have a nested property:
-  <green>\\"a.b\\"</>
-With a value of:
-  <green>undefined</>
-"
+Expected path: <green>\\"a.b\\"</>
+
+Expected value: not <green>undefined</>"
+`;
+
+exports[`.toHaveProperty() {pass: true} expect({"a": {}}).toHaveProperty('a.b', undefined) 1`] = `
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
+
+Expected path: <green>\\"a.b\\"</>
+Received path: <red>\\"a\\"</>
+
+Expected value: not <green>undefined</>
+Received value:     <red>{}</>
+
+<dim>Because a positive assertion passes for expected value undefined if the property does not exist, therefore this negative assertion fails unless the property does exist and has a defined value</>"
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({"a": 0}).toHaveProperty('a') 1`] = `
-"<dim>expect(</><red>object</><dim>).</>not<dim>.toHaveProperty(</><green>path</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveProperty<dim>(</><green>path</><dim>)</>
 
-Expected the object:
-  <red>{\\"a\\": 0}</>
-Not to have a nested property:
-  <green>\\"a\\"</>
-"
+Expected path: not <green>\\"a\\"</>
+
+Received value: <red>0</>"
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({"a": 0}).toHaveProperty('a', 0) 1`] = `
-"<dim>expect(</><red>object</><dim>).</>not<dim>.toHaveProperty(</><green>path</><dim>, </><green>value</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
 
-Expected the object:
-  <red>{\\"a\\": 0}</>
-Not to have a nested property:
-  <green>\\"a\\"</>
-With a value of:
-  <green>0</>
-"
+Expected path: <green>\\"a\\"</>
+
+Expected value: not <green>0</>"
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({"a.b.c.d": 1}).toHaveProperty('a.b.c.d') 1`] = `
-"<dim>expect(</><red>object</><dim>).</>not<dim>.toHaveProperty(</><green>path</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveProperty<dim>(</><green>path</><dim>)</>
 
-Expected the object:
-  <red>{\\"a.b.c.d\\": 1}</>
-Not to have a nested property:
-  <green>[\\"a.b.c.d\\"]</>
-"
+Expected path: not <green>[\\"a.b.c.d\\"]</>
+
+Received value: <red>1</>"
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({"a.b.c.d": 1}).toHaveProperty('a.b.c.d', 1) 1`] = `
-"<dim>expect(</><red>object</><dim>).</>not<dim>.toHaveProperty(</><green>path</><dim>, </><green>value</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
 
-Expected the object:
-  <red>{\\"a.b.c.d\\": 1}</>
-Not to have a nested property:
-  <green>[\\"a.b.c.d\\"]</>
-With a value of:
-  <green>1</>
-"
+Expected path: <green>[\\"a.b.c.d\\"]</>
+
+Expected value: not <green>1</>"
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({"nodeName": "DIV"}).toHaveProperty('nodeType', 1) 1`] = `
-"<dim>expect(</><red>object</><dim>).</>not<dim>.toHaveProperty(</><green>path</><dim>, </><green>value</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
 
-Expected the object:
-  <red>{\\"nodeName\\": \\"DIV\\"}</>
-Not to have a nested property:
-  <green>\\"nodeType\\"</>
-With a value of:
-  <green>1</>
-"
+Expected path: <green>\\"nodeType\\"</>
+
+Expected value: not <green>1</>"
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({"property": 1}).toHaveProperty('property', 1) 1`] = `
-"<dim>expect(</><red>object</><dim>).</>not<dim>.toHaveProperty(</><green>path</><dim>, </><green>value</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
 
-Expected the object:
-  <red>{\\"property\\": 1}</>
-Not to have a nested property:
-  <green>\\"property\\"</>
-With a value of:
-  <green>1</>
-"
+Expected path: <green>\\"property\\"</>
+
+Expected value: not <green>1</>"
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({"val": true}).toHaveProperty('a', undefined) 1`] = `
-"<dim>expect(</><red>object</><dim>).</>not<dim>.toHaveProperty(</><green>path</><dim>, </><green>value</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
 
-Expected the object:
-  <red>{\\"val\\": true}</>
-Not to have a nested property:
-  <green>\\"a\\"</>
-With a value of:
-  <green>undefined</>
-"
+Expected path: <green>\\"a\\"</>
+
+Expected value: not <green>undefined</>"
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({"val": true}).toHaveProperty('c', "c") 1`] = `
-"<dim>expect(</><red>object</><dim>).</>not<dim>.toHaveProperty(</><green>path</><dim>, </><green>value</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
 
-Expected the object:
-  <red>{\\"val\\": true}</>
-Not to have a nested property:
-  <green>\\"c\\"</>
-With a value of:
-  <green>\\"c\\"</>
-"
+Expected path: <green>\\"c\\"</>
+
+Expected value: not <green>\\"c\\"</>"
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({"val": true}).toHaveProperty('val', true) 1`] = `
-"<dim>expect(</><red>object</><dim>).</>not<dim>.toHaveProperty(</><green>path</><dim>, </><green>value</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
 
-Expected the object:
-  <red>{\\"val\\": true}</>
-Not to have a nested property:
-  <green>\\"val\\"</>
-With a value of:
-  <green>true</>
-"
+Expected path: <green>\\"val\\"</>
+
+Expected value: not <green>true</>"
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({}).toHaveProperty('a', undefined) 1`] = `
-"<dim>expect(</><red>object</><dim>).</>not<dim>.toHaveProperty(</><green>path</><dim>, </><green>value</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
 
-Expected the object:
-  <red>{}</>
-Not to have a nested property:
-  <green>\\"a\\"</>
-With a value of:
-  <green>undefined</>
-"
+Expected path: <green>\\"a\\"</>
+
+Expected value: not <green>undefined</>"
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({}).toHaveProperty('b', "b") 1`] = `
-"<dim>expect(</><red>object</><dim>).</>not<dim>.toHaveProperty(</><green>path</><dim>, </><green>value</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
 
-Expected the object:
-  <red>{}</>
-Not to have a nested property:
-  <green>\\"b\\"</>
-With a value of:
-  <green>\\"b\\"</>
-"
+Expected path: <green>\\"b\\"</>
+
+Expected value: not <green>\\"b\\"</>"
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({}).toHaveProperty('setter', undefined) 1`] = `
-"<dim>expect(</><red>object</><dim>).</>not<dim>.toHaveProperty(</><green>path</><dim>, </><green>value</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
 
-Expected the object:
-  <red>{}</>
-Not to have a nested property:
-  <green>\\"setter\\"</>
-With a value of:
-  <green>undefined</>
-"
+Expected path: <green>\\"setter\\"</>
+
+Expected value: not <green>undefined</>"
 `;
 
 exports[`.toMatch() {pass: true} expect(Foo bar).toMatch(/^foo/i) 1`] = `

--- a/packages/expect/src/__tests__/matchers.test.js
+++ b/packages/expect/src/__tests__/matchers.test.js
@@ -1340,8 +1340,10 @@ describe('.toHaveProperty()', () => {
     [{a: {b: {c: {d: 1}}}}, ['a', 'b', 'c', 'd'], 1],
     [{'a.b.c.d': 1}, ['a.b.c.d'], 1],
     [{a: {b: [1, 2, 3]}}, ['a', 'b', 1], 2],
+    [{a: {b: [1, 2, 3]}}, ['a', 'b', 1], expect.any(Number)],
     [{a: 0}, 'a', 0],
     [{a: {b: undefined}}, 'a.b', undefined],
+    [{a: {}}, 'a.b', undefined], // delete for breaking change in future major
     [{a: {b: {c: 5}}}, 'a.b', {c: 5}],
     [Object.assign(Object.create(null), {property: 1}), 'property', 1],
     [new Foo(), 'a', undefined],
@@ -1379,7 +1381,7 @@ describe('.toHaveProperty()', () => {
     [{a: {b: {c: 5}}}, 'a.b', {c: 4}],
     [new Foo(), 'a', 'a'],
     [new Foo(), 'b', undefined],
-    // [{a: {}}, 'a.b', undefined], // wait until Jest 25
+    // [{a: {}}, 'a.b', undefined], // add for breaking change in future major
   ].forEach(([obj, keyPath, value]) => {
     test(`{pass: false} expect(${stringify(
       obj,

--- a/packages/expect/src/matchers.ts
+++ b/packages/expect/src/matchers.ts
@@ -661,7 +661,7 @@ const matchers: MatchersObject = {
     const matcherName = 'toHaveProperty';
     const expectedArgument = 'path';
     const hasValue = arguments.length === 3;
-    const options = {
+    const options: MatcherHintOptions = {
       isNot: this.isNot,
       promise: this.promise,
       secondArgument: hasValue ? 'value' : '',
@@ -753,14 +753,14 @@ const matchers: MatchersObject = {
           matcherHint(matcherName, undefined, expectedArgument, options) +
           '\n\n' +
           `Expected path: ${printExpected(expectedPath)}\n` +
-          (hasCompletePath // TODO undefined?
+          (hasCompletePath
             ? '\n' +
               printDiffOrStringify(
                 expectedValue,
                 receivedValue,
                 EXPECTED_VALUE_LABEL,
                 RECEIVED_VALUE_LABEL,
-                this.expand, // TODO
+                this.expand,
               )
             : `Received path: ${printReceived(
                 expectedPathType === 'array' || receivedPath.length === 0

--- a/packages/expect/src/matchers.ts
+++ b/packages/expect/src/matchers.ts
@@ -713,7 +713,7 @@ const matchers: MatchersObject = {
     const pass = hasValue
       ? equals(result.value, expectedValue, [iterableEquality])
       : Boolean(hasEndProp); // theoretically undefined if empty path
-      // Remove type cast if we rewrite getPath as iterative algorithm.
+    // Remove type cast if we rewrite getPath as iterative algorithm.
 
     // Delete this unique report if future breaking change
     // removes the edge case that expected value undefined

--- a/packages/expect/src/matchers.ts
+++ b/packages/expect/src/matchers.ts
@@ -42,9 +42,11 @@ import {
 } from './utils';
 import {equals} from './jasmineUtils';
 
-// Include colon and one or more spaces, same as returned by getLabelPrinter.
-const EXPECTED_LABEL = 'Expected: ';
-const RECEIVED_LABEL = 'Received: ';
+// Omit colon and one or more spaces, so can call getLabelPrinter.
+const EXPECTED_LABEL = 'Expected';
+const RECEIVED_LABEL = 'Received';
+const EXPECTED_VALUE_LABEL = 'Expected value';
+const RECEIVED_VALUE_LABEL = 'Received value';
 
 const toStrictEqualTesters = [
   iterableEquality,
@@ -652,87 +654,123 @@ const matchers: MatchersObject = {
 
   toHaveProperty(
     this: MatcherState,
-    object: object,
-    keyPath: string | Array<string>,
-    value?: unknown,
+    received: object,
+    expectedPath: string | Array<string>,
+    expectedValue?: unknown,
   ) {
-    const matcherName = '.toHaveProperty';
-    const valuePassed = arguments.length === 3;
-    const secondArgument = valuePassed ? 'value' : '';
-    const options: MatcherHintOptions = {
+    const matcherName = 'toHaveProperty';
+    const expectedArgument = 'path';
+    const hasValue = arguments.length === 3;
+    const options = {
       isNot: this.isNot,
-      secondArgument,
+      promise: this.promise,
+      secondArgument: hasValue ? 'value' : '',
     };
 
-    if (object === null || object === undefined) {
+    if (received === null || received === undefined) {
       throw new Error(
         matcherErrorMessage(
-          matcherHint(matcherName, undefined, 'path', options),
+          matcherHint(matcherName, undefined, expectedArgument, options),
           `${RECEIVED_COLOR('received')} value must not be null nor undefined`,
-          printWithType('Received', object, printReceived),
+          printWithType('Received', received, printReceived),
         ),
       );
     }
 
-    const keyPathType = getType(keyPath);
+    const expectedPathType = getType(expectedPath);
 
-    if (keyPathType !== 'string' && keyPathType !== 'array') {
+    if (expectedPathType !== 'string' && expectedPathType !== 'array') {
       throw new Error(
         matcherErrorMessage(
-          matcherHint(matcherName, undefined, 'path', options),
+          matcherHint(matcherName, undefined, expectedArgument, options),
           `${EXPECTED_COLOR('expected')} path must be a string or array`,
-          printWithType('Expected', keyPath, printExpected),
+          printWithType('Expected', expectedPath, printExpected),
         ),
       );
     }
 
-    const result = getPath(object, keyPath);
+    const expectedPathLength =
+      typeof expectedPath === 'string'
+        ? expectedPath.split('.').length
+        : expectedPath.length;
+
+    if (expectedPathType === 'array' && expectedPathLength === 0) {
+      throw new Error(
+        matcherErrorMessage(
+          matcherHint(matcherName, undefined, expectedArgument, options),
+          `${EXPECTED_COLOR('expected')} path must not be an empty array`,
+          printWithType('Expected', expectedPath, printExpected),
+        ),
+      );
+    }
+
+    const result = getPath(received, expectedPath);
     const {lastTraversedObject, hasEndProp} = result;
+    const receivedPath = result.traversedPath;
+    const hasCompletePath = receivedPath.length === expectedPathLength;
+    const receivedValue = hasCompletePath ? result.value : lastTraversedObject;
 
-    const pass = valuePassed
-      ? equals(result.value, value, [iterableEquality])
-      : hasEndProp;
+    const pass = hasValue
+      ? equals(result.value, expectedValue, [iterableEquality])
+      : Boolean(hasEndProp); // theoretically undefined if empty path
+      // Remove type cast if we rewrite getPath as iterative algorithm.
 
-    const traversedPath = result.traversedPath.join('.');
+    // Delete this unique report if future breaking change
+    // removes the edge case that expected value undefined
+    // also matches absence of a property with the key path.
+    if (pass && !hasCompletePath) {
+      const message = () =>
+        matcherHint(matcherName, undefined, expectedArgument, options) +
+        '\n\n' +
+        `Expected path: ${printExpected(expectedPath)}\n` +
+        `Received path: ${printReceived(
+          expectedPathType === 'array' || receivedPath.length === 0
+            ? receivedPath
+            : receivedPath.join('.'),
+        )}\n\n` +
+        `Expected value: not ${printExpected(expectedValue)}\n` +
+        `Received value:     ${printReceived(receivedValue)}\n\n` +
+        DIM_COLOR(
+          'Because a positive assertion passes for expected value undefined if the property does not exist, therefore this negative assertion fails unless the property does exist and has a defined value',
+        );
+
+      return {message, pass};
+    }
 
     const message = pass
       ? () =>
-          matcherHint(matcherName, 'object', 'path', options) +
+          matcherHint(matcherName, undefined, expectedArgument, options) +
           '\n\n' +
-          `Expected the object:\n` +
-          `  ${printReceived(object)}\n` +
-          `Not to have a nested property:\n` +
-          `  ${printExpected(keyPath)}\n` +
-          (valuePassed ? `With a value of:\n  ${printExpected(value)}\n` : '')
-      : () => {
-          const difference =
-            valuePassed && hasEndProp
-              ? diff(value, result.value, {expand: this.expand})
-              : '';
-          return (
-            matcherHint(matcherName, 'object', 'path', options) +
-            '\n\n' +
-            `Expected the object:\n` +
-            `  ${printReceived(object)}\n` +
-            `To have a nested property:\n` +
-            `  ${printExpected(keyPath)}\n` +
-            (valuePassed
-              ? `With a value of:\n  ${printExpected(value)}\n`
-              : '') +
-            (hasEndProp
-              ? `Received:\n` +
-                `  ${printReceived(result.value)}` +
-                (difference ? `\n\nDifference:\n\n${difference}` : '')
-              : traversedPath
-              ? `Received:\n  ${RECEIVED_COLOR(
-                  'object',
-                )}.${traversedPath}: ${printReceived(lastTraversedObject)}`
-              : '')
-          );
-        };
-    if (pass === undefined) {
-      throw new Error('pass must be initialized');
-    }
+          (hasValue
+            ? `Expected path: ${printExpected(expectedPath)}\n\n` +
+              `Expected value: not ${printExpected(expectedValue)}` +
+              (stringify(expectedValue) !== stringify(receivedValue)
+                ? `\nReceived value:     ${printReceived(receivedValue)}`
+                : '')
+            : `Expected path: not ${printExpected(expectedPath)}\n\n` +
+              `Received value: ${printReceived(receivedValue)}`)
+      : () =>
+          matcherHint(matcherName, undefined, expectedArgument, options) +
+          '\n\n' +
+          `Expected path: ${printExpected(expectedPath)}\n` +
+          (hasCompletePath // TODO undefined?
+            ? '\n' +
+              printDiffOrStringify(
+                expectedValue,
+                receivedValue,
+                EXPECTED_VALUE_LABEL,
+                RECEIVED_VALUE_LABEL,
+                this.expand, // TODO
+              )
+            : `Received path: ${printReceived(
+                expectedPathType === 'array' || receivedPath.length === 0
+                  ? receivedPath
+                  : receivedPath.join('.'),
+              )}\n\n` +
+              (hasValue
+                ? `Expected value: ${printExpected(expectedValue)}\n`
+                : '') +
+              `Received value: ${printReceived(receivedValue)}`);
 
     return {message, pass};
   },

--- a/packages/expect/src/matchers.ts
+++ b/packages/expect/src/matchers.ts
@@ -731,7 +731,7 @@ const matchers: MatchersObject = {
         `Expected value: not ${printExpected(expectedValue)}\n` +
         `Received value:     ${printReceived(receivedValue)}\n\n` +
         DIM_COLOR(
-          'Because a positive assertion passes for expected value undefined if the property does not exist, therefore this negative assertion fails unless the property does exist and has a defined value',
+          'Because a positive assertion passes for expected value undefined if the property does not exist, this negative assertion fails unless the property does exist and has a defined value',
         );
 
       return {message, pass};


### PR DESCRIPTION
## Summary

For `toHaveProperty` matcher:

* Display matcher name in regular black instead of dim color
* Display promise `rejects` or `resolves` in matcher hint
* Replace obscure `pass must be initialized` error with `expected path must not be an empty array`
* Omit redundant or distracting information, as described below

When **negative** assertion fails:

* Display `not` between expected label and value
* Display received value **only** if it has different serialization
* Display unique report for edge case

When **positive** assertion fails:

* If received path is not complete: Display value of last received property
* If received path is complete: Display either diff (without `Difference` label) or stringify values, **not both**

**Residue**:
* chore to rewrite `getPath` as iterative algorithm and always return `hasEndProp`
* possible future breaking change (in Jest 26) to remove the edge case that expected value undefined also matches absence of a property with the key path

## Test plan

Snapshots for `toHaveProperty`

* updated 6 for `error`
* updated 24 for `fail`
* updated 23 and added 2 for `pass`

See also pictures in following comment.

Example pictures baseline at left and **improved at right**