### PR TITLE
Declare global prototype in JSDOMEnvironment to fix issue #8347

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - `[jest-core]` Make `detectOpenHandles` imply `runInBand` ([#8283](https://github.com/facebook/jest/pull/8283))
 - `[jest-haste-map]` Fix the `mapper` option which was incorrectly ignored ([#8299](https://github.com/facebook/jest/pull/8299))
 - `[jest-jasmine2]` Fix describe return value warning being shown if the describe function throws ([#8335](https://github.com/facebook/jest/pull/8335))
+- `[jest-environment-jsdom]` Re-declare global prototype of JSDOMEnvironment ([#8352](https://github.com/facebook/jest/pull/8352))
 
 ### Chore & Maintenance
 

--- a/packages/jest-environment-jsdom/src/index.ts
+++ b/packages/jest-environment-jsdom/src/index.ts
@@ -15,13 +15,14 @@ import {JSDOM, VirtualConsole} from 'jsdom';
 
 // The `Window` interface does not have an `Error.stackTraceLimit` property, but
 // `JSDOMEnvironment` assumes it is there.
-interface Win extends Window {
-  Error: {
-    stackTraceLimit: number;
+type Win = Window &
+  Global.Global & {
+    Error: {
+      stackTraceLimit: number;
+    };
   };
-}
 
-function isWin(globals: Win | Global.Global): globals is Win {
+function isWin(globals: Win): globals is Win {
   return (globals as Win).document !== undefined;
 }
 
@@ -31,8 +32,7 @@ function isWin(globals: Win | Global.Global): globals is Win {
 class JSDOMEnvironment implements JestEnvironment {
   dom: JSDOM | null;
   fakeTimers: FakeTimers<number> | null;
-  // @ts-ignore
-  global: Global.Global | Win | null;
+  global: Win;
   errorEventListener: ((event: Event & {error: Error}) => void) | null;
   moduleMocker: ModuleMocker | null;
 
@@ -119,6 +119,7 @@ class JSDOMEnvironment implements JestEnvironment {
       }
     }
     this.errorEventListener = null;
+    // @ts-ignore
     this.global = null;
     this.dom = null;
     this.fakeTimers = null;

--- a/packages/jest-environment-jsdom/src/index.ts
+++ b/packages/jest-environment-jsdom/src/index.ts
@@ -22,13 +22,6 @@ type Win = Window &
     };
   };
 
-function isWin(globals: Win | Global.Global): globals is Win {
-  return (globals as Win).document !== undefined;
-}
-
-// A lot of the globals expected by other APIs are `NodeJS.Global` and not
-// `Window`, so we need to cast here and there
-
 class JSDOMEnvironment implements JestEnvironment {
   dom: JSDOM | null;
   fakeTimers: FakeTimers<number> | null;
@@ -109,16 +102,16 @@ class JSDOMEnvironment implements JestEnvironment {
       this.fakeTimers.dispose();
     }
     if (this.global) {
-      if (this.errorEventListener && isWin(this.global)) {
+      if (this.errorEventListener) {
         this.global.removeEventListener('error', this.errorEventListener);
       }
       // Dispose "document" to prevent "load" event from triggering.
       Object.defineProperty(this.global, 'document', {value: null});
-      if (isWin(this.global)) {
-        this.global.close();
-      }
+      this.global.close();
     }
     this.errorEventListener = null;
+    // @ts-ignore
+    this.global = null;
     this.dom = null;
     this.fakeTimers = null;
     return Promise.resolve();

--- a/packages/jest-environment-jsdom/src/index.ts
+++ b/packages/jest-environment-jsdom/src/index.ts
@@ -22,7 +22,7 @@ type Win = Window &
     };
   };
 
-function isWin(globals: Win): globals is Win {
+function isWin(globals: Win | Global.Global): globals is Win {
   return (globals as Win).document !== undefined;
 }
 
@@ -119,8 +119,6 @@ class JSDOMEnvironment implements JestEnvironment {
       }
     }
     this.errorEventListener = null;
-    // @ts-ignore
-    this.global = null;
     this.dom = null;
     this.fakeTimers = null;
     return Promise.resolve();


### PR DESCRIPTION
I have described an issue at https://github.com/facebook/jest/issues/8347.
We know ignores were not emitted by Typescript creating declaration files (ref https://github.com/Microsoft/TypeScript/issues/20360) and we can't build in your Typescript project if not skip checking types in libraries using.

I re-declared `global` prototype in JSDOMEnvironment class. I checked in my project and build files.