### PR TITLE
await for async jest config

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -23,10 +23,10 @@ module.exports = {
   verbose: true,
 };
 //Or async function
-module.exports = async ()=>{
+module.exports = async () => {
   return {
     verbose: true,
-  }
+  };
 };
 ```
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -18,8 +18,15 @@ Or through JavaScript:
 
 ```js
 // jest.config.js
+//Sync object
 module.exports = {
   verbose: true,
+};
+//Or async function
+module.exports = async ()=>{
+  return {
+    verbose: true,
+  }
 };
 ```
 

--- a/packages/jest-config/package.json
+++ b/packages/jest-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-config",
-  "version": "24.9.0",
+  "version": "25.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/facebook/jest.git",

--- a/packages/jest-config/src/__tests__/readConfig.test.ts
+++ b/packages/jest-config/src/__tests__/readConfig.test.ts
@@ -7,16 +7,15 @@
 
 import {readConfig} from '../index';
 
-test('readConfig() throws when an object is passed without a file path', () => {
-  expect(() => {
-    readConfig(
-      // @ts-ignore
-      null /* argv */,
-      {} /* packageRootOrConfig */,
-      false /* skipArgvConfigOption */,
-      null /* parentConfigPath */,
-    );
-  }).toThrowError(
+test('readConfig() throws when an object is passed without a file path', async () => {
+  // @ts-ignore
+  const asyncConfig = readConfig(
+    null /* argv */,
+    {} /* packageRootOrConfig */,
+    false /* skipArgvConfigOption */,
+    null /* parentConfigPath */,
+  );
+  await expect(asyncConfig).rejects.toThrowError(
     'Jest: Cannot use configuration as an object without a file path',
   );
 });

--- a/packages/jest-config/src/__tests__/readConfigs.test.ts
+++ b/packages/jest-config/src/__tests__/readConfigs.test.ts
@@ -7,9 +7,10 @@
 
 import {readConfigs} from '../index';
 
-test('readConfigs() throws when called without project paths', () => {
-  expect(() => {
-    // @ts-ignore
-    readConfigs(null /* argv */, [] /* projectPaths */);
-  }).toThrowError('jest: No configuration found for any project.');
+test('readConfigs() throws when called without project paths', async () => {
+  // @ts-ignore
+  const asyncConfig = readConfigs(null /* argv */, [] /* projectPaths */);
+  await expect(asyncConfig).rejects.toThrowError(
+    'jest: No configuration found for any project.',
+  );
 });

--- a/packages/jest-config/src/index.ts
+++ b/packages/jest-config/src/index.ts
@@ -312,11 +312,11 @@ export async function readConfigs(
             return false;
           }
 
-        return true;
-      })
-      .map(async (root, projectIndex) =>
-        readConfig(argv, root, true, configPath, projectIndex),
-      ),
+          return true;
+        })
+        .map(async (root, projectIndex) =>
+          readConfig(argv, root, true, configPath, projectIndex),
+        ),
     );
 
     ensureNoDuplicateConfigs(parsedConfigs, projects);

--- a/packages/jest-config/src/readConfigFileAndSetRootDir.ts
+++ b/packages/jest-config/src/readConfigFileAndSetRootDir.ts
@@ -15,7 +15,9 @@ import {PACKAGE_JSON} from './constants';
 // Read the configuration and set its `rootDir`
 // 1. If it's a `package.json` file, we look into its "jest" property
 // 2. For any other file, we just require it.
-export default (configPath: Config.Path): Config.InitialOptions => {
+export default async (
+  configPath: Config.Path,
+): Promise<Config.InitialOptions> => {
   const isJSON = configPath.endsWith('.json');
   let configObject;
 

--- a/packages/jest-core/src/cli/index.ts
+++ b/packages/jest-core/src/cli/index.ts
@@ -49,7 +49,7 @@ export const runCLI = async (
   const outputStream =
     argv.json || argv.useStderr ? process.stderr : process.stdout;
 
-  const {globalConfig, configs, hasDeprecationWarnings} = readConfigs(
+  const {globalConfig, configs, hasDeprecationWarnings} = await readConfigs(
     argv,
     projects,
   );

--- a/packages/jest-runtime/src/cli/index.ts
+++ b/packages/jest-runtime/src/cli/index.ts
@@ -20,7 +20,7 @@ import {VERSION} from '../version';
 import {Context} from '../types';
 import * as args from './args';
 
-export function run(cliArgv?: Config.Argv, cliInfo?: Array<string>) {
+export async function run(cliArgv?: Config.Argv, cliInfo?: Array<string>) {
   const realFs = require('fs');
   const fs = require('graceful-fs');
   fs.gracefulify(realFs);
@@ -65,7 +65,7 @@ export function run(cliArgv?: Config.Argv, cliInfo?: Array<string>) {
   }
   // TODO: Figure this out
   // @ts-ignore: this might not have the correct arguments
-  const options = readConfig(argv, root);
+  const options = await readConfig(argv, root);
   const globalConfig = options.globalConfig;
   // Always disable automocking in scripts.
   const config: Config.ProjectConfig = {

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -749,7 +749,7 @@ class Runtime {
         filename,
         localModule.require as LocalModuleRequire,
       ), // jest object
-      ...this._config.extraGlobals.map(globalVariable => {
+      ...(this._config.extraGlobals || []).map(globalVariable => {
         if (this._environment.global[globalVariable]) {
           return this._environment.global[globalVariable];
         }


### PR DESCRIPTION

## Summary
Currently jest cli `require` the dynamic config module synchronously, this PR enables loading jest config module async. 

## Test plan
Tested project using `yarn test` - got some issues not related to my change:
```bash
/jest/packages/jest-haste-map/src/lib/FSEventsWatcher.ts
14:1  error  Unused eslint-disable directive (no problems were reported)
/jest/packages/jest-transform/src/ScriptTransformer.ts
578:3  warning  Arrow function expected no return value  consistent-return
594:3  warning  Arrow function expected no return value  consistent-return
```
In addition created a tiny project and tested the async config module using `yarn link` - no issues were observed.