### PR TITLE
Fix getting function name for rare cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - `[jest-jasmine2]` Fix describe return value warning being shown if the describe function throws ([#8335](https://github.com/facebook/jest/pull/8335))
 - `[jest-environment-jsdom]` Re-declare global prototype of JSDOMEnvironment ([#8352](https://github.com/facebook/jest/pull/8352))
 - `[jest-snapshot]` Handle arrays when merging snapshots ([#7089](https://github.com/facebook/jest/pull/7089))
+- `[expect]` Extract names of async and generator functions ([#8362](https://github.com/facebook/jest/pull/8362))
 
 ### Chore & Maintenance
 

--- a/packages/expect/src/__tests__/asymmetricMatchers.test.js
+++ b/packages/expect/src/__tests__/asymmetricMatchers.test.js
@@ -42,6 +42,47 @@ test('Any.toAsymmetricMatcher()', () => {
   jestExpect(any(Number).toAsymmetricMatcher()).toBe('Any<Number>');
 });
 
+test('Any.toAsymmetricMatcher() with function name', () => {
+  [
+    ['someFunc', function someFunc() {}],
+    ['$someFunc', function $someFunc() {}],
+    [
+      '$someFunc2',
+      (function() {
+        function $someFunc2() {}
+        Object.defineProperty($someFunc2, 'name', {value: ''});
+        return $someFunc2;
+      })(),
+    ],
+    [
+      '$someAsyncFunc',
+      (function() {
+        async function $someAsyncFunc() {}
+        Object.defineProperty($someAsyncFunc, 'name', {value: ''});
+        return $someAsyncFunc;
+      })(),
+    ],
+    [
+      '$someGeneratorFunc',
+      (function() {
+        function* $someGeneratorFunc() {}
+        Object.defineProperty($someGeneratorFunc, 'name', {value: ''});
+        return $someGeneratorFunc;
+      })(),
+    ],
+    [
+      '$someFuncWithFakeToString',
+      (function() {
+        function $someFuncWithFakeToString() {}
+        $someFuncWithFakeToString.toString = () => 'Fake to string';
+        return $someFuncWithFakeToString;
+      })(),
+    ],
+  ].forEach(([name, fn]: [string, any]) => {
+    jestExpect(any(fn).toAsymmetricMatcher()).toBe(`Any<${name}>`);
+  });
+});
+
 test('Any throws when called with empty constructor', () => {
   jestExpect(() => any()).toThrow();
 });

--- a/packages/expect/src/jasmineUtils.ts
+++ b/packages/expect/src/jasmineUtils.ts
@@ -37,6 +37,8 @@ export function equals(
   return eq(a, b, [], [], customTesters, strictCheck ? hasKey : hasDefinedKey);
 }
 
+const functionToString = Function.prototype.toString;
+
 function isAsymmetric(obj: any) {
   return !!obj && isA('Function', obj.asymmetricMatch);
 }
@@ -258,7 +260,9 @@ export function fnNameFor(func: Function) {
     return func.name;
   }
 
-  const matches = func.toString().match(/^\s*function\s*(\w*)\s*\(/);
+  const matches = functionToString
+    .call(func)
+    .match(/^(?:async)?\s*function\s*\*?\s*([\w$]+)\s*\(/);
   return matches ? matches[1] : '<anonymous>';
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary
Helper for getting function name in some cases returns wrong function name.
For example: If we somehow lost the property `name` in function, then we used regExp that failed with async function, function generator and function with `$` in name.
One more rare case if toString method was changed.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan
I added tests for these cases
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
