### PR TITLE
expect: Improve report when matcher fails, part 19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - `[docs]` Add DynamoDB guide ([#8319](https://github.com/facebook/jest/pull/8319))
 - `[expect]` Improve report when matcher fails, part 17 ([#8349](https://github.com/facebook/jest/pull/8349))
 - `[expect]` Improve report when matcher fails, part 18 ([#8356](https://github.com/facebook/jest/pull/8356))
+- `[expect]` Improve report when matcher fails, part 19 ([#8367](https://github.com/facebook/jest/pull/8367))
 
 ### Fixes
 

--- a/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -1357,7 +1357,15 @@ exports[`.toBeInstanceOf() passing {} and [Function B] 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeInstanceOf<dim>(</><green>expected</><dim>)</>
 
 Expected constructor: not <green>B</>
-Received constructor:     <red>C</>
+Received constructor:     <red>C</> extends <green>B</>
+"
+`;
+
+exports[`.toBeInstanceOf() passing {} and [Function B] 2`] = `
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeInstanceOf<dim>(</><green>expected</><dim>)</>
+
+Expected constructor: not <green>B</>
+Received constructor:     <red>E</> extends … extends <green>B</>
 "
 `;
 

--- a/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -1265,6 +1265,7 @@ exports[`.toBeInstanceOf() failing "a" and [Function String] 1`] = `
 "<dim>expect(</><red>received</><dim>).</>toBeInstanceOf<dim>(</><green>expected</><dim>)</>
 
 Expected constructor: <green>String</>
+
 Received value has no prototype
 Received value: <red>\\"a\\"</>"
 `;
@@ -1274,13 +1275,14 @@ exports[`.toBeInstanceOf() failing /\\w+/ and [Function anonymous] 1`] = `
 
 Expected constructor name is an empty string
 Received constructor: <red>RegExp</>
-Received value: <red>/\\\\w+/</>"
+"
 `;
 
 exports[`.toBeInstanceOf() failing {} and [Function A] 1`] = `
 "<dim>expect(</><red>received</><dim>).</>toBeInstanceOf<dim>(</><green>expected</><dim>)</>
 
 Expected constructor: <green>A</>
+
 Received value has no prototype
 Received value: <red>{}</>"
 `;
@@ -1290,7 +1292,7 @@ exports[`.toBeInstanceOf() failing {} and [Function B] 1`] = `
 
 Expected constructor: <green>B</>
 Received constructor: <red>A</>
-Received value: <red>{}</>"
+"
 `;
 
 exports[`.toBeInstanceOf() failing {} and [Function RegExp] 1`] = `
@@ -1298,13 +1300,14 @@ exports[`.toBeInstanceOf() failing {} and [Function RegExp] 1`] = `
 
 Expected constructor: <green>RegExp</>
 Received constructor name is an empty string
-Received value: <red>{}</>"
+"
 `;
 
 exports[`.toBeInstanceOf() failing 1 and [Function Number] 1`] = `
 "<dim>expect(</><red>received</><dim>).</>toBeInstanceOf<dim>(</><green>expected</><dim>)</>
 
 Expected constructor: <green>Number</>
+
 Received value has no prototype
 Received value: <red>1</>"
 `;
@@ -1313,6 +1316,7 @@ exports[`.toBeInstanceOf() failing null and [Function String] 1`] = `
 "<dim>expect(</><red>received</><dim>).</>toBeInstanceOf<dim>(</><green>expected</><dim>)</>
 
 Expected constructor: <green>String</>
+
 Received value has no prototype
 Received value: <red>null</>"
 `;
@@ -1321,6 +1325,7 @@ exports[`.toBeInstanceOf() failing true and [Function Boolean] 1`] = `
 "<dim>expect(</><red>received</><dim>).</>toBeInstanceOf<dim>(</><green>expected</><dim>)</>
 
 Expected constructor: <green>Boolean</>
+
 Received value has no prototype
 Received value: <red>true</>"
 `;
@@ -1329,6 +1334,7 @@ exports[`.toBeInstanceOf() failing undefined and [Function String] 1`] = `
 "<dim>expect(</><red>received</><dim>).</>toBeInstanceOf<dim>(</><green>expected</><dim>)</>
 
 Expected constructor: <green>String</>
+
 Received value has no prototype
 Received value: <red>undefined</>"
 `;
@@ -1337,35 +1343,36 @@ exports[`.toBeInstanceOf() passing [] and [Function Array] 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeInstanceOf<dim>(</><green>expected</><dim>)</>
 
 Expected constructor: not <green>Array</>
-Received value: <red>[]</>"
+"
 `;
 
 exports[`.toBeInstanceOf() passing {} and [Function A] 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeInstanceOf<dim>(</><green>expected</><dim>)</>
 
 Expected constructor: not <green>A</>
-Received value: <red>{}</>"
+"
 `;
 
 exports[`.toBeInstanceOf() passing {} and [Function B] 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeInstanceOf<dim>(</><green>expected</><dim>)</>
 
 Expected constructor: not <green>B</>
-Received value: <red>{}</>"
+Received constructor:     <red>C</>
+"
 `;
 
 exports[`.toBeInstanceOf() passing {} and [Function name() {}] 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeInstanceOf<dim>(</><green>expected</><dim>)</>
 
 Expected constructor name is not a string
-Received value: <red>{}</>"
+"
 `;
 
 exports[`.toBeInstanceOf() passing Map {} and [Function Map] 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeInstanceOf<dim>(</><green>expected</><dim>)</>
 
 Expected constructor: not <green>Map</>
-Received value: <red>Map {}</>"
+"
 `;
 
 exports[`.toBeInstanceOf() throws if constructor is not a function 1`] = `

--- a/packages/expect/src/__tests__/__snapshots__/toThrowMatchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/toThrowMatchers.test.js.snap
@@ -118,7 +118,18 @@ exports[`toThrow error class threw, but class should not match (error subclass) 
 "<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrow<dim>(</><green>expected</><dim>)</>
 
 Expected constructor: not <green>Err</>
-Received constructor:     <red>SubErr</>
+Received constructor:     <red>SubErr</> extends <green>Err</>
+
+Received message: <red>\\"apple\\"</>
+
+      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+`;
+
+exports[`toThrow error class threw, but class should not match (error subsubclass) 1`] = `
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrow<dim>(</><green>expected</><dim>)</>
+
+Expected constructor: not <green>Err</>
+Received constructor:     <red>SubSubErr</> extends … extends <green>Err</>
 
 Received message: <red>\\"apple\\"</>
 
@@ -403,7 +414,18 @@ exports[`toThrowError error class threw, but class should not match (error subcl
 "<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrowError<dim>(</><green>expected</><dim>)</>
 
 Expected constructor: not <green>Err</>
-Received constructor:     <red>SubErr</>
+Received constructor:     <red>SubErr</> extends <green>Err</>
+
+Received message: <red>\\"apple\\"</>
+
+      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+`;
+
+exports[`toThrowError error class threw, but class should not match (error subsubclass) 1`] = `
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrowError<dim>(</><green>expected</><dim>)</>
+
+Expected constructor: not <green>Err</>
+Received constructor:     <red>SubSubErr</> extends … extends <green>Err</>
 
 Received message: <red>\\"apple\\"</>
 

--- a/packages/expect/src/__tests__/__snapshots__/toThrowMatchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/toThrowMatchers.test.js.snap
@@ -89,7 +89,7 @@ Received message: <red>\\"apple\\"</>
 exports[`toThrow error class did not throw at all 1`] = `
 "<dim>expect(</><red>received</><dim>).</>toThrow<dim>(</><green>expected</><dim>)</>
 
-Expected name: <green>\\"Err\\"</>
+Expected constructor: <green>Err</>
 
 Received function did not throw"
 `;
@@ -97,8 +97,8 @@ Received function did not throw"
 exports[`toThrow error class threw, but class did not match (error) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>toThrow<dim>(</><green>expected</><dim>)</>
 
-Expected name: <green>\\"Err2\\"</>
-Received name: <red>\\"Error\\"</>
+Expected constructor: <green>Err2</>
+Received constructor: <red>Err</>
 
 Received message: <red>\\"apple\\"</>
 
@@ -108,17 +108,27 @@ Received message: <red>\\"apple\\"</>
 exports[`toThrow error class threw, but class did not match (non-error falsey) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>toThrow<dim>(</><green>expected</><dim>)</>
 
-Expected name: <green>\\"Err2\\"</>
+Expected constructor: <green>Err2</>
 
 Received value: <red>undefined</>
 "
 `;
 
+exports[`toThrow error class threw, but class should not match (error subclass) 1`] = `
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrow<dim>(</><green>expected</><dim>)</>
+
+Expected constructor: not <green>Err</>
+Received constructor:     <red>SubErr</>
+
+Received message: <red>\\"apple\\"</>
+
+      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+`;
+
 exports[`toThrow error class threw, but class should not match (error) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrow<dim>(</><green>expected</><dim>)</>
 
-Expected name: <green>\\"Err\\"</>
-Received name: <red>\\"Error\\"</>
+Expected constructor: not <green>Err</>
 
 Received message: <red>\\"apple\\"</>
 
@@ -174,8 +184,8 @@ Received function did not throw"
 exports[`toThrow promise/async throws if Error-like object is returned threw, but class did not match 1`] = `
 "<dim>expect(</><red>received</><dim>).</>rejects<dim>.</>toThrow<dim>(</><green>expected</><dim>)</>
 
-Expected name: <green>\\"Err2\\"</>
-Received name: <red>\\"Error\\"</>
+Expected constructor: <green>Err2</>
+Received constructor: <red>Err</>
 
 Received message: <red>\\"async apple\\"</>
 
@@ -364,7 +374,7 @@ Received message: <red>\\"apple\\"</>
 exports[`toThrowError error class did not throw at all 1`] = `
 "<dim>expect(</><red>received</><dim>).</>toThrowError<dim>(</><green>expected</><dim>)</>
 
-Expected name: <green>\\"Err\\"</>
+Expected constructor: <green>Err</>
 
 Received function did not throw"
 `;
@@ -372,8 +382,8 @@ Received function did not throw"
 exports[`toThrowError error class threw, but class did not match (error) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>toThrowError<dim>(</><green>expected</><dim>)</>
 
-Expected name: <green>\\"Err2\\"</>
-Received name: <red>\\"Error\\"</>
+Expected constructor: <green>Err2</>
+Received constructor: <red>Err</>
 
 Received message: <red>\\"apple\\"</>
 
@@ -383,17 +393,27 @@ Received message: <red>\\"apple\\"</>
 exports[`toThrowError error class threw, but class did not match (non-error falsey) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>toThrowError<dim>(</><green>expected</><dim>)</>
 
-Expected name: <green>\\"Err2\\"</>
+Expected constructor: <green>Err2</>
 
 Received value: <red>undefined</>
 "
 `;
 
+exports[`toThrowError error class threw, but class should not match (error subclass) 1`] = `
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrowError<dim>(</><green>expected</><dim>)</>
+
+Expected constructor: not <green>Err</>
+Received constructor:     <red>SubErr</>
+
+Received message: <red>\\"apple\\"</>
+
+      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+`;
+
 exports[`toThrowError error class threw, but class should not match (error) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrowError<dim>(</><green>expected</><dim>)</>
 
-Expected name: <green>\\"Err\\"</>
-Received name: <red>\\"Error\\"</>
+Expected constructor: not <green>Err</>
 
 Received message: <red>\\"apple\\"</>
 
@@ -449,8 +469,8 @@ Received function did not throw"
 exports[`toThrowError promise/async throws if Error-like object is returned threw, but class did not match 1`] = `
 "<dim>expect(</><red>received</><dim>).</>rejects<dim>.</>toThrowError<dim>(</><green>expected</><dim>)</>
 
-Expected name: <green>\\"Err2\\"</>
-Received name: <red>\\"Error\\"</>
+Expected constructor: <green>Err2</>
+Received constructor: <red>Err</>
 
 Received message: <red>\\"async apple\\"</>
 

--- a/packages/expect/src/__tests__/matchers.test.js
+++ b/packages/expect/src/__tests__/matchers.test.js
@@ -687,6 +687,8 @@ describe('.toBeInstanceOf()', () => {
   class A {}
   class B {}
   class C extends B {}
+  class D extends C {}
+  class E extends D {}
 
   class HasStaticNameMethod {
     constructor() {}
@@ -705,7 +707,8 @@ describe('.toBeInstanceOf()', () => {
     [new Map(), Map],
     [[], Array],
     [new A(), A],
-    [new C(), B], // subclass
+    [new C(), B], // C extends B
+    [new E(), B], // E extends … extends B
     [new HasStaticNameMethod(), HasStaticNameMethod],
   ].forEach(([a, b]) => {
     test(`passing ${stringify(a)} and ${stringify(b)}`, () => {

--- a/packages/expect/src/__tests__/toThrowMatchers.test.js
+++ b/packages/expect/src/__tests__/toThrowMatchers.test.js
@@ -146,6 +146,15 @@ class customError extends Error {
     });
 
     describe('error class', () => {
+      class SubErr extends Err {
+        constructor(...args) {
+          super(...args);
+          // In a carefully written error subclass,
+          // name property is equal to constructor name.
+          this.name = this.constructor.name;
+        }
+      }
+
       it('passes', () => {
         jestExpect(() => {
           throw new Err();
@@ -186,6 +195,14 @@ class customError extends Error {
         expect(() => {
           jestExpect(() => {
             throw new Err('apple');
+          }).not[toThrow](Err);
+        }).toThrowErrorMatchingSnapshot();
+      });
+
+      test('threw, but class should not match (error subclass)', () => {
+        expect(() => {
+          jestExpect(() => {
+            throw new SubErr('apple');
           }).not[toThrow](Err);
         }).toThrowErrorMatchingSnapshot();
       });

--- a/packages/expect/src/__tests__/toThrowMatchers.test.js
+++ b/packages/expect/src/__tests__/toThrowMatchers.test.js
@@ -155,6 +155,15 @@ class customError extends Error {
         }
       }
 
+      class SubSubErr extends SubErr {
+        constructor(...args) {
+          super(...args);
+          // In a carefully written error subclass,
+          // name property is equal to constructor name.
+          this.name = this.constructor.name;
+        }
+      }
+
       it('passes', () => {
         jestExpect(() => {
           throw new Err();
@@ -203,6 +212,14 @@ class customError extends Error {
         expect(() => {
           jestExpect(() => {
             throw new SubErr('apple');
+          }).not[toThrow](Err);
+        }).toThrowErrorMatchingSnapshot();
+      });
+
+      test('threw, but class should not match (error subsubclass)', () => {
+        expect(() => {
+          jestExpect(() => {
+            throw new SubSubErr('apple');
           }).not[toThrow](Err);
         }).toThrowErrorMatchingSnapshot();
       });

--- a/packages/expect/src/matchers.ts
+++ b/packages/expect/src/matchers.ts
@@ -274,11 +274,11 @@ const matchers: MatchersObject = {
           matcherHint(matcherName, undefined, undefined, options) +
           '\n\n' +
           printExpectedConstructorName('Expected constructor', expected, true) +
-          (received.constructor != null &&
-          received.constructor.name !== expected.name
+          (typeof received.constructor === 'function' &&
+          received.constructor !== expected
             ? printReceivedConstructorName(
                 'Received constructor',
-                received,
+                received.constructor,
                 true,
               )
             : '')
@@ -298,7 +298,7 @@ const matchers: MatchersObject = {
             ? `\nReceived value: ${printReceived(received)}`
             : printReceivedConstructorName(
                 'Received constructor',
-                received,
+                received.constructor,
                 false,
               ));
 

--- a/packages/expect/src/matchers.ts
+++ b/packages/expect/src/matchers.ts
@@ -27,7 +27,9 @@ import {
 import {MatchersObject, MatcherState} from './types';
 import {
   printDiffOrStringify,
+  printExpectedConstructorName,
   printReceivedArrayContainExpectedItem,
+  printReceivedConstructorName,
   printReceivedStringContainExpectedResult,
   printReceivedStringContainExpectedSubstring,
 } from './print';
@@ -267,45 +269,38 @@ const matchers: MatchersObject = {
 
     const pass = received instanceof expected;
 
-    const NAME_IS_NOT_STRING = ' name is not a string\n';
-    const NAME_IS_EMPTY_STRING = ' name is an empty string\n';
-
     const message = pass
       ? () =>
           matcherHint(matcherName, undefined, undefined, options) +
           '\n\n' +
-          // A truthy test for `expected.name` property has false positive for:
-          // function with a defined name property
-          // class with a static name method
-          (typeof expected.name !== 'string'
-            ? 'Expected constructor' + NAME_IS_NOT_STRING
-            : expected.name.length === 0
-            ? 'Expected constructor' + NAME_IS_EMPTY_STRING
-            : `Expected constructor: not ${EXPECTED_COLOR(expected.name)}\n`) +
-          `Received value: ${printReceived(received)}`
+          printExpectedConstructorName('Expected constructor', expected, true) +
+          (received.constructor != null &&
+          received.constructor.name !== expected.name
+            ? printReceivedConstructorName(
+                'Received constructor',
+                received,
+                true,
+              )
+            : '')
       : () =>
           matcherHint(matcherName, undefined, undefined, options) +
           '\n\n' +
-          // A truthy test for `expected.name` property has false positive for:
-          // function with a defined name property
-          // class with a static name method
-          (typeof expected.name !== 'string'
-            ? 'Expected constructor' + NAME_IS_NOT_STRING
-            : expected.name.length === 0
-            ? 'Expected constructor' + NAME_IS_EMPTY_STRING
-            : `Expected constructor: ${EXPECTED_COLOR(expected.name)}\n`) +
+          printExpectedConstructorName(
+            'Expected constructor',
+            expected,
+            false,
+          ) +
           (isPrimitive(received) || Object.getPrototypeOf(received) === null
-            ? 'Received value has no prototype\n'
+            ? `\nReceived value has no prototype\nReceived value: ${printReceived(
+                received,
+              )}`
             : typeof received.constructor !== 'function'
-            ? ''
-            : typeof received.constructor.name !== 'string'
-            ? 'Received constructor' + NAME_IS_NOT_STRING
-            : received.constructor.name.length === 0
-            ? 'Received constructor' + NAME_IS_EMPTY_STRING
-            : `Received constructor: ${RECEIVED_COLOR(
-                received.constructor.name,
-              )}\n`) +
-          `Received value: ${printReceived(received)}`;
+            ? `\nReceived value: ${printReceived(received)}`
+            : printReceivedConstructorName(
+                'Received constructor',
+                received,
+                false,
+              ));
 
     return {message, pass};
   },

--- a/packages/expect/src/matchers.ts
+++ b/packages/expect/src/matchers.ts
@@ -28,8 +28,10 @@ import {MatchersObject, MatcherState} from './types';
 import {
   printDiffOrStringify,
   printExpectedConstructorName,
+  printExpectedConstructorNameNot,
   printReceivedArrayContainExpectedItem,
   printReceivedConstructorName,
+  printReceivedConstructorNameNot,
   printReceivedStringContainExpectedResult,
   printReceivedStringContainExpectedSubstring,
 } from './print';
@@ -273,23 +275,19 @@ const matchers: MatchersObject = {
       ? () =>
           matcherHint(matcherName, undefined, undefined, options) +
           '\n\n' +
-          printExpectedConstructorName('Expected constructor', expected, true) +
+          printExpectedConstructorNameNot('Expected constructor', expected) +
           (typeof received.constructor === 'function' &&
           received.constructor !== expected
-            ? printReceivedConstructorName(
+            ? printReceivedConstructorNameNot(
                 'Received constructor',
                 received.constructor,
-                true,
+                expected,
               )
             : '')
       : () =>
           matcherHint(matcherName, undefined, undefined, options) +
           '\n\n' +
-          printExpectedConstructorName(
-            'Expected constructor',
-            expected,
-            false,
-          ) +
+          printExpectedConstructorName('Expected constructor', expected) +
           (isPrimitive(received) || Object.getPrototypeOf(received) === null
             ? `\nReceived value has no prototype\nReceived value: ${printReceived(
                 received,
@@ -299,7 +297,6 @@ const matchers: MatchersObject = {
             : printReceivedConstructorName(
                 'Received constructor',
                 received.constructor,
-                false,
               ));
 
     return {message, pass};

--- a/packages/expect/src/print.ts
+++ b/packages/expect/src/print.ts
@@ -8,6 +8,7 @@
 
 import getType, {isPrimitive} from 'jest-get-type';
 import {
+  EXPECTED_COLOR,
   INVERTED_COLOR,
   RECEIVED_COLOR,
   diff,
@@ -131,4 +132,47 @@ export const printDiffOrStringify = (
         : printReceived(received)
     }`
   );
+};
+
+export const printExpectedConstructorName = (
+  label: string,
+  expected: Function,
+  isNot: boolean,
+) => printConstructorName(label, expected, isNot, true);
+
+export const printReceivedConstructorName = (
+  label: string,
+  received: any, // unknown has TypeScript errors :(
+  isNot: boolean,
+) => {
+  if (received == null) {
+    return '';
+  }
+
+  if (typeof received.constructor === 'function') {
+    return printConstructorName(label, received.constructor, isNot, false);
+  }
+
+  return '';
+};
+
+const printConstructorName = (
+  label: string,
+  constructor: Function,
+  isNot: boolean,
+  isExpected: boolean,
+): string => {
+  if (constructor == null) {
+    return '';
+  }
+
+  return typeof constructor.name !== 'string'
+    ? `${label} name is not a string\n`
+    : constructor.name.length === 0
+    ? `${label} name is an empty string\n`
+    : `${label}: ${!isNot ? '' : isExpected ? 'not ' : '    '}${
+        isExpected
+          ? EXPECTED_COLOR(constructor.name)
+          : RECEIVED_COLOR(constructor.name)
+      }\n`;
 };

--- a/packages/expect/src/print.ts
+++ b/packages/expect/src/print.ts
@@ -137,14 +137,35 @@ export const printDiffOrStringify = (
 export const printExpectedConstructorName = (
   label: string,
   expected: Function,
-  isNot: boolean,
-) => printConstructorName(label, expected, isNot, true);
+) => printConstructorName(label, expected, false, true) + '\n';
+
+export const printExpectedConstructorNameNot = (
+  label: string,
+  expected: Function,
+) => printConstructorName(label, expected, true, true) + '\n';
 
 export const printReceivedConstructorName = (
   label: string,
   received: Function,
-  isNot: boolean,
-) => printConstructorName(label, received, isNot, false);
+) => printConstructorName(label, received, false, false) + '\n';
+
+export function printReceivedConstructorNameNot(
+  label: string,
+  received: Function,
+  expected: Function,
+) {
+  let printed = printConstructorName(label, received, true, false);
+
+  if (typeof received.name === 'string' && received.name.length !== 0) {
+    printed += ` ${
+      Object.getPrototypeOf(received) === expected
+        ? 'extends'
+        : 'extends … extends'
+    } ${EXPECTED_COLOR(expected.name)}`;
+  }
+
+  return printed + '\n';
+}
 
 const printConstructorName = (
   label: string,
@@ -153,11 +174,11 @@ const printConstructorName = (
   isExpected: boolean,
 ): string =>
   typeof constructor.name !== 'string'
-    ? `${label} name is not a string\n`
+    ? `${label} name is not a string`
     : constructor.name.length === 0
-    ? `${label} name is an empty string\n`
+    ? `${label} name is an empty string`
     : `${label}: ${!isNot ? '' : isExpected ? 'not ' : '    '}${
         isExpected
           ? EXPECTED_COLOR(constructor.name)
           : RECEIVED_COLOR(constructor.name)
-      }\n`;
+      }`;

--- a/packages/expect/src/print.ts
+++ b/packages/expect/src/print.ts
@@ -142,19 +142,9 @@ export const printExpectedConstructorName = (
 
 export const printReceivedConstructorName = (
   label: string,
-  received: any, // unknown has TypeScript errors :(
+  received: Function,
   isNot: boolean,
-) => {
-  if (received == null) {
-    return '';
-  }
-
-  if (typeof received.constructor === 'function') {
-    return printConstructorName(label, received.constructor, isNot, false);
-  }
-
-  return '';
-};
+) => printConstructorName(label, received, isNot, false);
 
 const printConstructorName = (
   label: string,

--- a/packages/expect/src/print.ts
+++ b/packages/expect/src/print.ts
@@ -161,12 +161,8 @@ const printConstructorName = (
   constructor: Function,
   isNot: boolean,
   isExpected: boolean,
-): string => {
-  if (constructor == null) {
-    return '';
-  }
-
-  return typeof constructor.name !== 'string'
+): string =>
+  typeof constructor.name !== 'string'
     ? `${label} name is not a string\n`
     : constructor.name.length === 0
     ? `${label} name is an empty string\n`
@@ -175,4 +171,3 @@ const printConstructorName = (
           ? EXPECTED_COLOR(constructor.name)
           : RECEIVED_COLOR(constructor.name)
       }\n`;
-};

--- a/packages/expect/src/toThrowMatchers.ts
+++ b/packages/expect/src/toThrowMatchers.ts
@@ -18,6 +18,8 @@ import {
   MatcherHintOptions,
 } from 'jest-matcher-utils';
 import {
+  printExpectedConstructorName,
+  printReceivedConstructorName,
   printReceivedStringContainExpectedResult,
   printReceivedStringContainExpectedSubstring,
 } from './print';
@@ -250,8 +252,17 @@ const toThrowExpectedClass = (
     ? () =>
         matcherHint(matcherName, undefined, undefined, options) +
         '\n\n' +
-        formatExpected('Expected name: ', expected.name) +
-        formatReceived('Received name: ', thrown, 'name') +
+        printExpectedConstructorName('Expected constructor', expected, true) +
+        (thrown !== null &&
+        thrown.value != null &&
+        thrown.value.constructor != null &&
+        thrown.value.constructor.name !== expected.name
+          ? printReceivedConstructorName(
+              'Received constructor',
+              thrown.value,
+              true,
+            )
+          : '') +
         '\n' +
         (thrown !== null && thrown.hasMessage
           ? formatReceived('Received message: ', thrown, 'message') +
@@ -260,15 +271,21 @@ const toThrowExpectedClass = (
     : () =>
         matcherHint(matcherName, undefined, undefined, options) +
         '\n\n' +
-        formatExpected('Expected name: ', expected.name) +
+        printExpectedConstructorName('Expected constructor', expected, false) +
         (thrown === null
           ? '\n' + DID_NOT_THROW
-          : thrown.hasMessage
-          ? formatReceived('Received name: ', thrown, 'name') +
+          : (thrown.value != null
+              ? printReceivedConstructorName(
+                  'Received constructor',
+                  thrown.value,
+                  false,
+                )
+              : '') +
             '\n' +
-            formatReceived('Received message: ', thrown, 'message') +
-            formatStack(thrown)
-          : '\n' + formatReceived('Received value: ', thrown, 'value'));
+            (thrown.hasMessage
+              ? formatReceived('Received message: ', thrown, 'message') +
+                formatStack(thrown)
+              : formatReceived('Received value: ', thrown, 'value')));
 
   return {message, pass};
 };

--- a/packages/expect/src/toThrowMatchers.ts
+++ b/packages/expect/src/toThrowMatchers.ts
@@ -255,11 +255,11 @@ const toThrowExpectedClass = (
         printExpectedConstructorName('Expected constructor', expected, true) +
         (thrown !== null &&
         thrown.value != null &&
-        thrown.value.constructor != null &&
-        thrown.value.constructor.name !== expected.name
+        typeof thrown.value.constructor === 'function' &&
+        thrown.value.constructor !== expected
           ? printReceivedConstructorName(
               'Received constructor',
-              thrown.value,
+              thrown.value.constructor,
               true,
             )
           : '') +
@@ -274,10 +274,11 @@ const toThrowExpectedClass = (
         printExpectedConstructorName('Expected constructor', expected, false) +
         (thrown === null
           ? '\n' + DID_NOT_THROW
-          : (thrown.value != null
+          : (thrown.value != null &&
+            typeof thrown.value.constructor === 'function'
               ? printReceivedConstructorName(
                   'Received constructor',
-                  thrown.value,
+                  thrown.value.constructor,
                   false,
                 )
               : '') +

--- a/packages/expect/src/toThrowMatchers.ts
+++ b/packages/expect/src/toThrowMatchers.ts
@@ -19,7 +19,9 @@ import {
 } from 'jest-matcher-utils';
 import {
   printExpectedConstructorName,
+  printExpectedConstructorNameNot,
   printReceivedConstructorName,
+  printReceivedConstructorNameNot,
   printReceivedStringContainExpectedResult,
   printReceivedStringContainExpectedSubstring,
 } from './print';
@@ -252,15 +254,15 @@ const toThrowExpectedClass = (
     ? () =>
         matcherHint(matcherName, undefined, undefined, options) +
         '\n\n' +
-        printExpectedConstructorName('Expected constructor', expected, true) +
+        printExpectedConstructorNameNot('Expected constructor', expected) +
         (thrown !== null &&
         thrown.value != null &&
         typeof thrown.value.constructor === 'function' &&
         thrown.value.constructor !== expected
-          ? printReceivedConstructorName(
+          ? printReceivedConstructorNameNot(
               'Received constructor',
               thrown.value.constructor,
-              true,
+              expected,
             )
           : '') +
         '\n' +
@@ -271,7 +273,7 @@ const toThrowExpectedClass = (
     : () =>
         matcherHint(matcherName, undefined, undefined, options) +
         '\n\n' +
-        printExpectedConstructorName('Expected constructor', expected, false) +
+        printExpectedConstructorName('Expected constructor', expected) +
         (thrown === null
           ? '\n' + DID_NOT_THROW
           : (thrown.value != null &&
@@ -279,7 +281,6 @@ const toThrowExpectedClass = (
               ? printReceivedConstructorName(
                   'Received constructor',
                   thrown.value.constructor,
-                  false,
                 )
               : '') +
             '\n' +


### PR DESCRIPTION
## Summary

Follow up on residue from #7621 and #8077 according to recent improvements

For `toBeInstanceOf` matcher:

Factor out `printConstructorName` similar to `printWithType` function in `jest-matcher-utils`

* Positive assertion: show received value **only if** it is not function with prototype **otherwise** display received constructor name
* Negative assertion: instead of received value, show received constructor name **only if** it is not equal to expected assertion name

For `toThrow(Constructor)` matcher:

* Display constructor name consistent with `toBeInstanceOf`
* Omit expected and received `name` property, because it is usually redundant with constructor name

**Residue**: why TypeScript errors for `received: unknown` in `printReceivedConstructorName`

## Test plan

| matcher | pass | snapshots |
| :--- | :--- | :--- |
| `toBeInstanceOf` | `false` | updated 9 |
| `toBeInstanceOf` | `true` | updated 5 |
| `toThrow(Constructor)` | `false` | updated 8 |
| `toThrow(Constructor)` | `true` | updated 2 and added 2 |

See also pictures in following comments.

Example pictures baseline at left and **improved at right**