### PR TITLE
chore: Delete obsolete emails tag from header comment in test files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - `[expect]` Fix label and add opposite assertion for toEqual tests ([#8288](https://github.com/facebook/jest/pull/8288))
 - `[docs]` Mention Jest MongoDB Preset ([#8318](https://github.com/facebook/jest/pull/8318))
 - `[@jest/reporters]` Migrate away from `istanbul-api` ([#8294](https://github.com/facebook/jest/pull/8294))
+- `[*]` Delete obsolete emails tag from header comment in test files ([#8377](https://github.com/facebook/jest/pull/8377))
 
 ### Performance
 

--- a/e2e/__tests__/__snapshots__/failures.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/failures.test.ts.snap
@@ -36,15 +36,15 @@ FAIL __tests__/assertionCount.test.js
 
     Received: false
 
-      11 | const throws = () => {
-      12 |   expect.assertions(2);
-    > 13 |   expect(false).toBeTruthy();
+      10 | const throws = () => {
+      11 |   expect.assertions(2);
+    > 12 |   expect(false).toBeTruthy();
          |                 ^
-      14 | };
-      15 | const redeclare = () => {
-      16 |   expect.assertions(1);
+      13 | };
+      14 | const redeclare = () => {
+      15 |   expect.assertions(1);
 
-      at Object.toBeTruthy (__tests__/assertionCount.test.js:13:17)
+      at Object.toBeTruthy (__tests__/assertionCount.test.js:12:17)
 
   ● .assertions() › throws
 
@@ -52,15 +52,15 @@ FAIL __tests__/assertionCount.test.js
 
     Expected two assertions to be called but received one assertion call.
 
-      10 | 
-      11 | const throws = () => {
-    > 12 |   expect.assertions(2);
+       9 | 
+      10 | const throws = () => {
+    > 11 |   expect.assertions(2);
          |          ^
-      13 |   expect(false).toBeTruthy();
-      14 | };
-      15 | const redeclare = () => {
+      12 |   expect(false).toBeTruthy();
+      13 | };
+      14 | const redeclare = () => {
 
-      at Object.assertions (__tests__/assertionCount.test.js:12:10)
+      at Object.assertions (__tests__/assertionCount.test.js:11:10)
 
   ● .assertions() › throws on redeclare of assertion count
 
@@ -68,15 +68,15 @@ FAIL __tests__/assertionCount.test.js
 
     Received: false
 
-      15 | const redeclare = () => {
-      16 |   expect.assertions(1);
-    > 17 |   expect(false).toBeTruthy();
+      14 | const redeclare = () => {
+      15 |   expect.assertions(1);
+    > 16 |   expect(false).toBeTruthy();
          |                 ^
-      18 |   expect.assertions(2);
-      19 | };
-      20 | 
+      17 |   expect.assertions(2);
+      18 | };
+      19 | 
 
-      at Object.toBeTruthy (__tests__/assertionCount.test.js:17:17)
+      at Object.toBeTruthy (__tests__/assertionCount.test.js:16:17)
 
   ● .assertions() › throws on assertion
 
@@ -84,15 +84,15 @@ FAIL __tests__/assertionCount.test.js
 
     Expected zero assertions to be called but received one assertion call.
 
-      20 | 
-      21 | const noAssertions = () => {
-    > 22 |   expect.assertions(0);
+      19 | 
+      20 | const noAssertions = () => {
+    > 21 |   expect.assertions(0);
          |          ^
-      23 |   expect(true).toBeTruthy();
-      24 | };
-      25 | 
+      22 |   expect(true).toBeTruthy();
+      23 | };
+      24 | 
 
-      at Object.assertions (__tests__/assertionCount.test.js:22:10)
+      at Object.assertions (__tests__/assertionCount.test.js:21:10)
 
   ● .hasAssertions() › throws when there are not assertions
 
@@ -100,15 +100,15 @@ FAIL __tests__/assertionCount.test.js
 
     Expected at least one assertion to be called but received none.
 
-      25 | 
-      26 | const hasNoAssertions = () => {
-    > 27 |   expect.hasAssertions();
+      24 | 
+      25 | const hasNoAssertions = () => {
+    > 26 |   expect.hasAssertions();
          |          ^
-      28 | };
-      29 | 
-      30 | describe('.assertions()', () => {
+      27 | };
+      28 | 
+      29 | describe('.assertions()', () => {
 
-      at Object.hasAssertions (__tests__/assertionCount.test.js:27:10)
+      at Object.hasAssertions (__tests__/assertionCount.test.js:26:10)
 `;
 
 exports[`not throwing Error objects 5`] = `
@@ -273,7 +273,7 @@ FAIL __tests__/testMacro.test.js
       14 | 
 
       at toEqual (macros.js:12:15)
-      at Object.shouldEqual (__tests__/testMacro.test.js:14:3)
+      at Object.shouldEqual (__tests__/testMacro.test.js:13:3)
 `;
 
 exports[`works with async failures 1`] = `
@@ -296,15 +296,15 @@ FAIL __tests__/asyncFailures.test.js
     +   "foo": "bar",
       }
 
-      10 | 
-      11 | test('resolve, but fail', () =>
-    > 12 |   expect(Promise.resolve({foo: 'bar'})).resolves.toEqual({baz: 'bar'}));
+       9 | 
+      10 | test('resolve, but fail', () =>
+    > 11 |   expect(Promise.resolve({foo: 'bar'})).resolves.toEqual({baz: 'bar'}));
          |                                                  ^
-      13 | 
-      14 | test('reject, but fail', () =>
-      15 |   expect(Promise.reject({foo: 'bar'})).rejects.toEqual({baz: 'bar'}));
+      12 | 
+      13 | test('reject, but fail', () =>
+      14 |   expect(Promise.reject({foo: 'bar'})).rejects.toEqual({baz: 'bar'}));
 
-      at Object.toEqual (__tests__/asyncFailures.test.js:12:50)
+      at Object.toEqual (__tests__/asyncFailures.test.js:11:50)
 
   ● reject, but fail
 
@@ -318,15 +318,15 @@ FAIL __tests__/asyncFailures.test.js
     +   "foo": "bar",
       }
 
-      13 | 
-      14 | test('reject, but fail', () =>
-    > 15 |   expect(Promise.reject({foo: 'bar'})).rejects.toEqual({baz: 'bar'}));
+      12 | 
+      13 | test('reject, but fail', () =>
+    > 14 |   expect(Promise.reject({foo: 'bar'})).rejects.toEqual({baz: 'bar'}));
          |                                                ^
-      16 | 
-      17 | test('expect reject', () =>
-      18 |   expect(Promise.resolve({foo: 'bar'})).rejects.toEqual({foo: 'bar'}));
+      15 | 
+      16 | test('expect reject', () =>
+      17 |   expect(Promise.resolve({foo: 'bar'})).rejects.toEqual({foo: 'bar'}));
 
-      at Object.toEqual (__tests__/asyncFailures.test.js:15:48)
+      at Object.toEqual (__tests__/asyncFailures.test.js:14:48)
 
   ● expect reject
 
@@ -335,15 +335,15 @@ FAIL __tests__/asyncFailures.test.js
     Received promise resolved instead of rejected
     Resolved to value: {"foo": "bar"}
 
-      16 | 
-      17 | test('expect reject', () =>
-    > 18 |   expect(Promise.resolve({foo: 'bar'})).rejects.toEqual({foo: 'bar'}));
+      15 | 
+      16 | test('expect reject', () =>
+    > 17 |   expect(Promise.resolve({foo: 'bar'})).rejects.toEqual({foo: 'bar'}));
          |   ^
-      19 | 
-      20 | test('expect resolve', () =>
-      21 |   expect(Promise.reject({foo: 'bar'})).resolves.toEqual({foo: 'bar'}));
+      18 | 
+      19 | test('expect resolve', () =>
+      20 |   expect(Promise.reject({foo: 'bar'})).resolves.toEqual({foo: 'bar'}));
 
-      at Object.expect (__tests__/asyncFailures.test.js:18:3)
+      at Object.expect (__tests__/asyncFailures.test.js:17:3)
 
   ● expect resolve
 
@@ -352,29 +352,29 @@ FAIL __tests__/asyncFailures.test.js
     Received promise rejected instead of resolved
     Rejected to value: {"foo": "bar"}
 
-      19 | 
-      20 | test('expect resolve', () =>
-    > 21 |   expect(Promise.reject({foo: 'bar'})).resolves.toEqual({foo: 'bar'}));
+      18 | 
+      19 | test('expect resolve', () =>
+    > 20 |   expect(Promise.reject({foo: 'bar'})).resolves.toEqual({foo: 'bar'}));
          |   ^
-      22 | 
-      23 | test('timeout', done => {
-      24 |   setTimeout(done, 50);
+      21 | 
+      22 | test('timeout', done => {
+      23 |   setTimeout(done, 50);
 
-      at Object.expect (__tests__/asyncFailures.test.js:21:3)
+      at Object.expect (__tests__/asyncFailures.test.js:20:3)
 
   ● timeout
 
 <REPLACED>
 
-      21 |   expect(Promise.reject({foo: 'bar'})).resolves.toEqual({foo: 'bar'}));
-      22 | 
-    > 23 | test('timeout', done => {
+      20 |   expect(Promise.reject({foo: 'bar'})).resolves.toEqual({foo: 'bar'}));
+      21 | 
+    > 22 | test('timeout', done => {
          | ^
-      24 |   setTimeout(done, 50);
-      25 | }, 5);
-      26 | 
+      23 |   setTimeout(done, 50);
+      24 | }, 5);
+      25 | 
 
-      at Object.test (__tests__/asyncFailures.test.js:23:1)
+      at Object.test (__tests__/asyncFailures.test.js:22:1)
 `;
 
 exports[`works with node assert 1`] = `
@@ -406,15 +406,15 @@ FAIL __tests__/assertionError.test.js
     Received:
       false
 
-      13 | 
-      14 | test('assert', () => {
-    > 15 |   assert(false);
+      12 | 
+      13 | test('assert', () => {
+    > 14 |   assert(false);
          |   ^
-      16 | });
-      17 | 
-      18 | test('assert with a message', () => {
+      15 | });
+      16 | 
+      17 | test('assert with a message', () => {
 
-      at Object.assert (__tests__/assertionError.test.js:15:3)
+      at Object.assert (__tests__/assertionError.test.js:14:3)
 
   ● assert with a message
 
@@ -428,15 +428,15 @@ FAIL __tests__/assertionError.test.js
     Message:
       this is a message
 
-      17 | 
-      18 | test('assert with a message', () => {
-    > 19 |   assert(false, 'this is a message');
+      16 | 
+      17 | test('assert with a message', () => {
+    > 18 |   assert(false, 'this is a message');
          |   ^
-      20 | });
-      21 | 
-      22 | test('assert.ok', () => {
+      19 | });
+      20 | 
+      21 | test('assert.ok', () => {
 
-      at Object.assert (__tests__/assertionError.test.js:19:3)
+      at Object.assert (__tests__/assertionError.test.js:18:3)
 
   ● assert.ok
 
@@ -447,15 +447,15 @@ FAIL __tests__/assertionError.test.js
     Received:
       false
 
-      21 | 
-      22 | test('assert.ok', () => {
-    > 23 |   assert.ok(false);
+      20 | 
+      21 | test('assert.ok', () => {
+    > 22 |   assert.ok(false);
          |          ^
-      24 | });
-      25 | 
-      26 | test('assert.ok with a message', () => {
+      23 | });
+      24 | 
+      25 | test('assert.ok with a message', () => {
 
-      at Object.ok (__tests__/assertionError.test.js:23:10)
+      at Object.ok (__tests__/assertionError.test.js:22:10)
 
   ● assert.ok with a message
 
@@ -469,15 +469,15 @@ FAIL __tests__/assertionError.test.js
     Message:
       this is a message
 
-      25 | 
-      26 | test('assert.ok with a message', () => {
-    > 27 |   assert.ok(false, 'this is a message');
+      24 | 
+      25 | test('assert.ok with a message', () => {
+    > 26 |   assert.ok(false, 'this is a message');
          |          ^
-      28 | });
-      29 | 
-      30 | test('assert.equal', () => {
+      27 | });
+      28 | 
+      29 | test('assert.equal', () => {
 
-      at Object.ok (__tests__/assertionError.test.js:27:10)
+      at Object.ok (__tests__/assertionError.test.js:26:10)
 
   ● assert.equal
 
@@ -488,15 +488,15 @@ FAIL __tests__/assertionError.test.js
     Received:
       1
 
-      29 | 
-      30 | test('assert.equal', () => {
-    > 31 |   assert.equal(1, 2);
+      28 | 
+      29 | test('assert.equal', () => {
+    > 30 |   assert.equal(1, 2);
          |          ^
-      32 | });
-      33 | 
-      34 | test('assert.notEqual', () => {
+      31 | });
+      32 | 
+      33 | test('assert.notEqual', () => {
 
-      at Object.equal (__tests__/assertionError.test.js:31:10)
+      at Object.equal (__tests__/assertionError.test.js:30:10)
 
   ● assert.notEqual
 
@@ -507,15 +507,15 @@ FAIL __tests__/assertionError.test.js
     Received:
       1
 
-      33 | 
-      34 | test('assert.notEqual', () => {
-    > 35 |   assert.notEqual(1, 1);
+      32 | 
+      33 | test('assert.notEqual', () => {
+    > 34 |   assert.notEqual(1, 1);
          |          ^
-      36 | });
-      37 | 
-      38 | test('assert.deepEqual', () => {
+      35 | });
+      36 | 
+      37 | test('assert.deepEqual', () => {
 
-      at Object.notEqual (__tests__/assertionError.test.js:35:10)
+      at Object.notEqual (__tests__/assertionError.test.js:34:10)
 
   ● assert.deepEqual
 
@@ -540,15 +540,15 @@ FAIL __tests__/assertionError.test.js
         },
       }
 
-      37 | 
-      38 | test('assert.deepEqual', () => {
-    > 39 |   assert.deepEqual({a: {b: {c: 5}}}, {a: {b: {c: 6}}});
+      36 | 
+      37 | test('assert.deepEqual', () => {
+    > 38 |   assert.deepEqual({a: {b: {c: 5}}}, {a: {b: {c: 6}}});
          |          ^
-      40 | });
-      41 | 
-      42 | test('assert.deepEqual with a message', () => {
+      39 | });
+      40 | 
+      41 | test('assert.deepEqual with a message', () => {
 
-      at Object.deepEqual (__tests__/assertionError.test.js:39:10)
+      at Object.deepEqual (__tests__/assertionError.test.js:38:10)
 
   ● assert.deepEqual with a message
 
@@ -576,15 +576,15 @@ FAIL __tests__/assertionError.test.js
         },
       }
 
-      41 | 
-      42 | test('assert.deepEqual with a message', () => {
-    > 43 |   assert.deepEqual({a: {b: {c: 5}}}, {a: {b: {c: 7}}}, 'this is a message');
+      40 | 
+      41 | test('assert.deepEqual with a message', () => {
+    > 42 |   assert.deepEqual({a: {b: {c: 5}}}, {a: {b: {c: 7}}}, 'this is a message');
          |          ^
-      44 | });
-      45 | 
-      46 | test('assert.notDeepEqual', () => {
+      43 | });
+      44 | 
+      45 | test('assert.notDeepEqual', () => {
 
-      at Object.deepEqual (__tests__/assertionError.test.js:43:10)
+      at Object.deepEqual (__tests__/assertionError.test.js:42:10)
 
   ● assert.notDeepEqual
 
@@ -599,15 +599,15 @@ FAIL __tests__/assertionError.test.js
 
     Compared values have no visual difference.
 
-      45 | 
-      46 | test('assert.notDeepEqual', () => {
-    > 47 |   assert.notDeepEqual({a: 1}, {a: 1});
+      44 | 
+      45 | test('assert.notDeepEqual', () => {
+    > 46 |   assert.notDeepEqual({a: 1}, {a: 1});
          |          ^
-      48 | });
-      49 | 
-      50 | test('assert.strictEqual', () => {
+      47 | });
+      48 | 
+      49 | test('assert.strictEqual', () => {
 
-      at Object.notDeepEqual (__tests__/assertionError.test.js:47:10)
+      at Object.notDeepEqual (__tests__/assertionError.test.js:46:10)
 
   ● assert.strictEqual
 
@@ -618,15 +618,15 @@ FAIL __tests__/assertionError.test.js
     Received:
       1
 
-      49 | 
-      50 | test('assert.strictEqual', () => {
-    > 51 |   assert.strictEqual(1, NaN);
+      48 | 
+      49 | test('assert.strictEqual', () => {
+    > 50 |   assert.strictEqual(1, NaN);
          |          ^
-      52 | });
-      53 | 
-      54 | test('assert.notStrictEqual', () => {
+      51 | });
+      52 | 
+      53 | test('assert.notStrictEqual', () => {
 
-      at Object.strictEqual (__tests__/assertionError.test.js:51:10)
+      at Object.strictEqual (__tests__/assertionError.test.js:50:10)
 
   ● assert.notStrictEqual
 
@@ -640,15 +640,15 @@ FAIL __tests__/assertionError.test.js
     Message:
       My custom error message
 
-      53 | 
-      54 | test('assert.notStrictEqual', () => {
-    > 55 |   assert.notStrictEqual(1, 1, 'My custom error message');
+      52 | 
+      53 | test('assert.notStrictEqual', () => {
+    > 54 |   assert.notStrictEqual(1, 1, 'My custom error message');
          |          ^
-      56 | });
-      57 | 
-      58 | test('assert.deepStrictEqual', () => {
+      55 | });
+      56 | 
+      57 | test('assert.deepStrictEqual', () => {
 
-      at Object.notStrictEqual (__tests__/assertionError.test.js:55:10)
+      at Object.notStrictEqual (__tests__/assertionError.test.js:54:10)
 
   ● assert.deepStrictEqual
 
@@ -669,15 +669,15 @@ FAIL __tests__/assertionError.test.js
     +   "a": 1,
       }
 
-      57 | 
-      58 | test('assert.deepStrictEqual', () => {
-    > 59 |   assert.deepStrictEqual({a: 1}, {a: 2});
+      56 | 
+      57 | test('assert.deepStrictEqual', () => {
+    > 58 |   assert.deepStrictEqual({a: 1}, {a: 2});
          |          ^
-      60 | });
-      61 | 
-      62 | test('assert.notDeepStrictEqual', () => {
+      59 | });
+      60 | 
+      61 | test('assert.notDeepStrictEqual', () => {
 
-      at Object.deepStrictEqual (__tests__/assertionError.test.js:59:10)
+      at Object.deepStrictEqual (__tests__/assertionError.test.js:58:10)
 
   ● assert.notDeepStrictEqual
 
@@ -692,15 +692,15 @@ FAIL __tests__/assertionError.test.js
 
     Compared values have no visual difference.
 
-      61 | 
-      62 | test('assert.notDeepStrictEqual', () => {
-    > 63 |   assert.notDeepStrictEqual({a: 1}, {a: 1});
+      60 | 
+      61 | test('assert.notDeepStrictEqual', () => {
+    > 62 |   assert.notDeepStrictEqual({a: 1}, {a: 1});
          |          ^
-      64 | });
-      65 | 
-      66 | test('assert.ifError', () => {
+      63 | });
+      64 | 
+      65 | test('assert.ifError', () => {
 
-      at Object.notDeepStrictEqual (__tests__/assertionError.test.js:63:10)
+      at Object.notDeepStrictEqual (__tests__/assertionError.test.js:62:10)
 
   ● assert.ifError
 
@@ -715,15 +715,15 @@ FAIL __tests__/assertionError.test.js
     Message:
       Got unwanted exception.
 
-      69 | 
-      70 | test('assert.doesNotThrow', () => {
-    > 71 |   assert.doesNotThrow(() => {
+      68 | 
+      69 | test('assert.doesNotThrow', () => {
+    > 70 |   assert.doesNotThrow(() => {
          |          ^
-      72 |     throw Error('err!');
-      73 |   });
-      74 | });
+      71 |     throw Error('err!');
+      72 |   });
+      73 | });
 
-      at Object.doesNotThrow (__tests__/assertionError.test.js:71:10)
+      at Object.doesNotThrow (__tests__/assertionError.test.js:70:10)
 
   ● assert.throws
 
@@ -735,15 +735,15 @@ FAIL __tests__/assertionError.test.js
     Message:
       Missing expected exception.
 
-      75 | 
-      76 | test('assert.throws', () => {
-    > 77 |   assert.throws(() => {});
+      74 | 
+      75 | test('assert.throws', () => {
+    > 76 |   assert.throws(() => {});
          |          ^
-      78 | });
-      79 | 
-      80 | test('async', async () => {
+      77 | });
+      78 | 
+      79 | test('async', async () => {
 
-      at Object.throws (__tests__/assertionError.test.js:77:10)
+      at Object.throws (__tests__/assertionError.test.js:76:10)
 
   ● async
 
@@ -766,18 +766,18 @@ FAIL __tests__/assertionError.test.js
       hello
     + goodbye
 
-      79 | 
-      80 | test('async', async () => {
-    > 81 |   assert.equal('hello\\ngoodbye', 'hello', 'hmmm');
+      78 | 
+      79 | test('async', async () => {
+    > 80 |   assert.equal('hello\\ngoodbye', 'hello', 'hmmm');
          |          ^
-      82 | });
-      83 | 
+      81 | });
+      82 | 
 
-      at Object.equal (__tests__/assertionError.test.js:81:10)
-      at asyncGeneratorStep (__tests__/assertionError.test.js:11:103)
-      at _next (__tests__/assertionError.test.js:13:194)
-      at __tests__/assertionError.test.js:13:364
-      at Object.<anonymous> (__tests__/assertionError.test.js:13:97)
+      at Object.equal (__tests__/assertionError.test.js:80:10)
+      at asyncGeneratorStep (__tests__/assertionError.test.js:10:103)
+      at _next (__tests__/assertionError.test.js:12:194)
+      at __tests__/assertionError.test.js:12:364
+      at Object.<anonymous> (__tests__/assertionError.test.js:12:97)
 `;
 
 exports[`works with snapshot failures 1`] = `
@@ -796,14 +796,14 @@ FAIL __tests__/snapshot.test.js
     - "bar"
     + "foo"
 
-      10 | 
-      11 | test('failing snapshot', () => {
-    > 12 |   expect('foo').toMatchSnapshot();
+       9 | 
+      10 | test('failing snapshot', () => {
+    > 11 |   expect('foo').toMatchSnapshot();
          |                 ^
-      13 | });
-      14 | 
+      12 | });
+      13 | 
 
-      at Object.toMatchSnapshot (__tests__/snapshot.test.js:12:17)
+      at Object.toMatchSnapshot (__tests__/snapshot.test.js:11:17)
 
  › 1 snapshot failed.
 
@@ -825,14 +825,14 @@ FAIL __tests__/snapshotWithHint.test.js
     - "bar"
     + "foo"
 
-      10 | 
-      11 | test('failing snapshot with hint', () => {
-    > 12 |   expect('foo').toMatchSnapshot('descriptive hint');
+       9 | 
+      10 | test('failing snapshot with hint', () => {
+    > 11 |   expect('foo').toMatchSnapshot('descriptive hint');
          |                 ^
-      13 | });
-      14 | 
+      12 | });
+      13 | 
 
-      at Object.toMatchSnapshot (__tests__/snapshotWithHint.test.js:12:17)
+      at Object.toMatchSnapshot (__tests__/snapshotWithHint.test.js:11:17)
 
  › 1 snapshot failed.
 

--- a/e2e/__tests__/failures.test.ts
+++ b/e2e/__tests__/failures.test.ts
@@ -55,15 +55,15 @@ test('works with node assert', () => {
 `);
 
     expect(summary).toContain(`
-      69 | 
-      70 | test('assert.doesNotThrow', () => {
-    > 71 |   assert.doesNotThrow(() => {
+      68 | 
+      69 | test('assert.doesNotThrow', () => {
+    > 70 |   assert.doesNotThrow(() => {
          |          ^
-      72 |     throw Error('err!');
-      73 |   });
-      74 | });
+      71 |     throw Error('err!');
+      72 |   });
+      73 | });
 
-      at Object.doesNotThrow (__tests__/assertionError.test.js:71:10)
+      at Object.doesNotThrow (__tests__/assertionError.test.js:70:10)
 `);
 
     const commonErrorMessage = `Message:
@@ -105,15 +105,15 @@ test('works with node assert', () => {
 
       Comparing two different types of values. Expected null but received number.
 
-      65 | 
-      66 | test('assert.ifError', () => {
-    > 67 |   assert.ifError(1);
+      64 | 
+      65 | test('assert.ifError', () => {
+    > 66 |   assert.ifError(1);
          |          ^
-      68 | });
-      69 | 
-      70 | test('assert.doesNotThrow', () => {
+      67 | });
+      68 | 
+      69 | test('assert.doesNotThrow', () => {
 
-      at Object.ifError (__tests__/assertionError.test.js:67:10)
+      at Object.ifError (__tests__/assertionError.test.js:66:10)
 `;
 
     expect(summary).toContain(ifErrorMessage);
@@ -122,15 +122,15 @@ test('works with node assert', () => {
     const ifErrorMessage = `
     thrown: 1
 
-      64 | });
-      65 | 
-    > 66 | test('assert.ifError', () => {
+      63 | });
+      64 | 
+    > 65 | test('assert.ifError', () => {
          | ^
-      67 |   assert.ifError(1);
-      68 | });
-      69 | 
+      66 |   assert.ifError(1);
+      67 | });
+      68 | 
 
-      at Object.test (__tests__/assertionError.test.js:66:1)
+      at Object.test (__tests__/assertionError.test.js:65:1)
 `;
 
     expect(summary).toContain(ifErrorMessage);

--- a/e2e/babel-plugin-jest-hoist/__tests__/integration.test.js
+++ b/e2e/babel-plugin-jest-hoist/__tests__/integration.test.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @emails oncall+jsinfra
  */
 
 /* eslint-disable no-useless-concat */

--- a/e2e/babel-plugin-jest-hoist/__tests__/integrationAutomockOff.test.js
+++ b/e2e/babel-plugin-jest-hoist/__tests__/integrationAutomockOff.test.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @emails oncall+jsinfra
  */
 
 'use strict';

--- a/e2e/babel-plugin-jest-hoist/__tests__/typescript.test.ts
+++ b/e2e/babel-plugin-jest-hoist/__tests__/typescript.test.ts
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @emails oncall+jsinfra
  */
 
 import {Color} from '../types';

--- a/e2e/failures/__tests__/assertionCount.test.js
+++ b/e2e/failures/__tests__/assertionCount.test.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @emails oncall+jsinfra
  */
 'use strict';
 

--- a/e2e/failures/__tests__/assertionError.test.js
+++ b/e2e/failures/__tests__/assertionError.test.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @emails oncall+jsinfra
  */
 
 'use strict';

--- a/e2e/failures/__tests__/asyncFailures.test.js
+++ b/e2e/failures/__tests__/asyncFailures.test.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @emails oncall+jsinfra
  */
 'use strict';
 

--- a/e2e/failures/__tests__/errorAfterTestComplete.test.js
+++ b/e2e/failures/__tests__/errorAfterTestComplete.test.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @emails oncall+jsinfra
  */
 'use strict';
 

--- a/e2e/failures/__tests__/snapshot.test.js
+++ b/e2e/failures/__tests__/snapshot.test.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @emails oncall+jsinfra
  */
 'use strict';
 

--- a/e2e/failures/__tests__/snapshotWithHint.test.js
+++ b/e2e/failures/__tests__/snapshotWithHint.test.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @emails oncall+jsinfra
  */
 'use strict';
 

--- a/e2e/failures/__tests__/testMacro.test.js
+++ b/e2e/failures/__tests__/testMacro.test.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @emails oncall+jsinfra
  */
 'use strict';
 

--- a/e2e/snapshot-mock-fs/__tests__/snapshot.test.js
+++ b/e2e/snapshot-mock-fs/__tests__/snapshot.test.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @emails oncall+jsinfra
  */
 'use strict';
 

--- a/e2e/snapshot/__tests__/secondSnapshot.test.js
+++ b/e2e/snapshot/__tests__/secondSnapshot.test.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @emails oncall+jsinfra
  */
 'use strict';
 

--- a/e2e/snapshot/__tests__/snapshot.test.js
+++ b/e2e/snapshot/__tests__/snapshot.test.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @emails oncall+jsinfra
  */
 'use strict';
 

--- a/packages/jest-runtime/src/__tests__/Runtime-sourceMaps.test.js
+++ b/packages/jest-runtime/src/__tests__/Runtime-sourceMaps.test.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @emails oncall+jsinfra
  */
 'use strict';
 


### PR DESCRIPTION
## Summary

Delete 14 occurrences of ` * @emails oncall+jsinfra` line in header comment:

* `e2e/babel-plugin-jest-hoist/__tests__/integration.test.js`
* `e2e/babel-plugin-jest-hoist/__tests__/integrationAutomockOff.test.js`
* `e2e/babel-plugin-jest-hoist/__tests__/typescript.test.ts`
* `e2e/failures/__tests__/assertionCount.test.js`
* `e2e/failures/__tests__/assertionError.test.js`
* `e2e/failures/__tests__/asyncFailures.test.js`
* `e2e/failures/__tests__/errorAfterTestComplete.test.js`
* `e2e/failures/__tests__/snapshot.test.js`
* `e2e/failures/__tests__/snapshotWithHint.test.js`
* `e2e/failures/__tests__/testMacro.test.js`
* `e2e/snapshot-mock-fs/__tests__/snapshot.test.js`
* `e2e/snapshot/__tests__/secondSnapshot.test.js`
* `e2e/snapshot/__tests__/snapshot.test.js`
* `packages/jest-runtime/src/__tests__/Runtime-sourceMaps.test.js`

## Test plan

Now I remember why I didn’t delete them when I first noticed:

* 5 snapshots in `e2e/__tests__/__snapshots__/failures.test.ts.snap`
* 3 `toContain` expected strings in `e2e/__tests__/failures.test.ts`

CI will tell us how effective my local testing of Node versions was (made me feel like Simen lite :)