### PR TITLE
Cache checked files in fs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,11 +33,11 @@
 - `[@jest/reporters]` Migrate away from `istanbul-api` ([#8294](https://github.com/facebook/jest/pull/8294))
 - `[*]` Delete obsolete emails tag from header comment in test files ([#8377](https://github.com/facebook/jest/pull/8377))
 - `[expect]` optimize compare nodes ([#8368](https://github.com/facebook/jest/pull/8368))
-- `[jest-resolve]` optimize resolve module path ([#8388](https://github.com/facebook/jest/pull/8388))
 
 ### Performance
 
 - `[jest-runtime]` Fix module registry memory leak ([#8282](https://github.com/facebook/jest/pull/8282))
+- `[jest-resolve]` optimize resolve module path ([#8388](https://github.com/facebook/jest/pull/8388))
 
 ## 24.7.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - `[@jest/reporters]` Migrate away from `istanbul-api` ([#8294](https://github.com/facebook/jest/pull/8294))
 - `[*]` Delete obsolete emails tag from header comment in test files ([#8377](https://github.com/facebook/jest/pull/8377))
 - `[expect]` optimize compare nodes ([#8368](https://github.com/facebook/jest/pull/8368))
+- `[jest-resolve]` optimize resolve module path ([#8388](https://github.com/facebook/jest/pull/8388))
 
 ### Performance
 

--- a/packages/jest-resolve/src/defaultResolver.ts
+++ b/packages/jest-resolve/src/defaultResolver.ts
@@ -142,11 +142,15 @@ function resolveSync(
   }
 }
 
+const checkedFiles = new Map<string, boolean>();
 /*
  * helper functions
  */
 function isFile(file: Config.Path): boolean {
-  let result;
+  let result = checkedFiles.get(file);
+  if (result !== undefined) {
+    return result;
+  }
 
   try {
     const stat = fs.statSync(file);
@@ -158,6 +162,7 @@ function isFile(file: Config.Path): boolean {
     result = false;
   }
 
+  checkedFiles.set(file, result);
   return result;
 }
 

--- a/packages/jest-resolve/src/defaultResolver.ts
+++ b/packages/jest-resolve/src/defaultResolver.ts
@@ -142,10 +142,12 @@ function resolveSync(
   }
 }
 
-const IS_PATH_FILE = 1;
-const IS_PATH_DIRECTORY = 2;
-const IS_PATH_OTHER = 3;
-const checkedPaths = new Map<string, number>();
+enum IPathType {
+  FILE = 1,
+  DIRECTORY = 2,
+  OTHER = 3,
+}
+const checkedPaths = new Map<string, IPathType>();
 function statSyncCached(path: string): number {
   const result = checkedPaths.get(path);
   if (result !== undefined) {
@@ -163,27 +165,27 @@ function statSyncCached(path: string): number {
 
   if (stat) {
     if (stat.isFile() || stat.isFIFO()) {
-      checkedPaths.set(path, IS_PATH_FILE);
-      return IS_PATH_FILE;
+      checkedPaths.set(path, IPathType.FILE);
+      return IPathType.FILE;
     } else if (stat.isDirectory()) {
-      checkedPaths.set(path, IS_PATH_DIRECTORY);
-      return IS_PATH_DIRECTORY;
+      checkedPaths.set(path, IPathType.DIRECTORY);
+      return IPathType.DIRECTORY;
     }
   }
 
-  checkedPaths.set(path, IS_PATH_OTHER);
-  return IS_PATH_OTHER;
+  checkedPaths.set(path, IPathType.OTHER);
+  return IPathType.OTHER;
 }
 
 /*
  * helper functions
  */
 function isFile(file: Config.Path): boolean {
-  return statSyncCached(file) === IS_PATH_FILE;
+  return statSyncCached(file) === IPathType.FILE;
 }
 
 function isDirectory(dir: Config.Path): boolean {
-  return statSyncCached(dir) === IS_PATH_DIRECTORY;
+  return statSyncCached(dir) === IPathType.DIRECTORY;
 }
 
 function isCurrentDirectory(testPath: Config.Path): boolean {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary
For the same path, the function `fs.statSync` can call many times. The more test files, the more often it will be called for the same file or directory.
I just added hash table to avoid repeated call for `fs.statSync`.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
