### PR TITLE
Place "Note" directly after function title

### DIFF
--- a/docs/ExpectAPI.md
+++ b/docs/ExpectAPI.md
@@ -1182,6 +1182,8 @@ test('throws on octopus', () => {
 });
 ```
 
+> Note: You must wrap the code in a function, otherwise the error will not be caught and the assertion will fail.
+
 You can provide an optional argument to test that a specific error is thrown:
 
 - regular expression: error message **matches** the pattern
@@ -1220,8 +1222,6 @@ test('throws on octopus', () => {
   expect(drinkOctopus).toThrowError(DisgustingFlavorError);
 });
 ```
-
-> Note: You must wrap the code in a function, otherwise the error will not be caught and the assertion will fail.
 
 ### `.toThrowErrorMatchingSnapshot(hint?)`
 

--- a/website/versioned_docs/version-22.x/ExpectAPI.md
+++ b/website/versioned_docs/version-22.x/ExpectAPI.md
@@ -877,6 +877,8 @@ test('throws on octopus', () => {
 });
 ```
 
+> Note: You must wrap the code in a function, otherwise the error will not be caught and the assertion will fail.
+
 If you want to test that a specific error gets thrown, you can provide an argument to `toThrow`. The argument can be a string that should be contained in the error message, a class for the error, or a regex that should match the error message. For example, let's say that `drinkFlavor` is coded like this:
 
 ```js
@@ -907,8 +909,6 @@ test('throws on octopus', () => {
   expect(drinkOctopus).toThrowError(DisgustingFlavorError);
 });
 ```
-
-> Note: You must wrap the code in a function, otherwise the error will not be caught and the assertion will fail.
 
 ### `.toThrowErrorMatchingSnapshot()`
 

--- a/website/versioned_docs/version-23.x/ExpectAPI.md
+++ b/website/versioned_docs/version-23.x/ExpectAPI.md
@@ -1163,8 +1163,6 @@ describe('the La Croix cans on my desk', () => {
 
 Also under the alias: `.toThrowError(error)`
 
-> Note: You must wrap the code in a function, otherwise the error will not be caught and the assertion will fail.
-
 Use `.toThrow` to test that a function throws when it is called. For example, if we want to test that `drinkFlavor('octopus')` throws, because octopus flavor is too disgusting to drink, we could write:
 
 ```js
@@ -1174,6 +1172,8 @@ test('throws on octopus', () => {
   }).toThrow();
 });
 ```
+
+> Note: You must wrap the code in a function, otherwise the error will not be caught and the assertion will fail.
 
 If you want to test that a specific error gets thrown, you can provide an argument to `toThrow`. The argument can be a string that should be contained in the error message, a class for the error, or a regex that should match the error message. For example, let's say that `drinkFlavor` is coded like this:
 

--- a/website/versioned_docs/version-23.x/ExpectAPI.md
+++ b/website/versioned_docs/version-23.x/ExpectAPI.md
@@ -1163,6 +1163,8 @@ describe('the La Croix cans on my desk', () => {
 
 Also under the alias: `.toThrowError(error)`
 
+> Note: You must wrap the code in a function, otherwise the error will not be caught and the assertion will fail.
+
 Use `.toThrow` to test that a function throws when it is called. For example, if we want to test that `drinkFlavor('octopus')` throws, because octopus flavor is too disgusting to drink, we could write:
 
 ```js
@@ -1203,8 +1205,6 @@ test('throws on octopus', () => {
   expect(drinkOctopus).toThrowError(DisgustingFlavorError);
 });
 ```
-
-> Note: You must wrap the code in a function, otherwise the error will not be caught and the assertion will fail.
 
 ### `.toThrowErrorMatchingSnapshot()`
 

--- a/website/versioned_docs/version-24.0/ExpectAPI.md
+++ b/website/versioned_docs/version-24.0/ExpectAPI.md
@@ -1189,6 +1189,8 @@ test('throws on octopus', () => {
 });
 ```
 
+> Note: You must wrap the code in a function, otherwise the error will not be caught and the assertion will fail.
+
 You can provide an optional argument to test that a specific error is thrown:
 
 - regular expression: error message **matches** the pattern
@@ -1227,8 +1229,6 @@ test('throws on octopus', () => {
   expect(drinkOctopus).toThrowError(DisgustingFlavorError);
 });
 ```
-
-> Note: You must wrap the code in a function, otherwise the error will not be caught and the assertion will fail.
 
 ### `.toThrowErrorMatchingSnapshot(hint?)`
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

When user looks for function documentation he tries to write code as in examples, but notification about additional function wrap shows at the end. I think it will be better to place it on the top, so user will at first see that note. Closes https://github.com/facebook/jest/issues/8392
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan
No test plan, only manual view checking.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
