### PR TITLE
Fix virtual mocks not being unmockable after previously being mocked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - `[jest-environment-jsdom]` Re-declare global prototype of JSDOMEnvironment ([#8352](https://github.com/facebook/jest/pull/8352))
 - `[jest-snapshot]` Handle arrays when merging snapshots ([#7089](https://github.com/facebook/jest/pull/7089))
 - `[expect]` Extract names of async and generator functions ([#8362](https://github.com/facebook/jest/pull/8362))
+- `[jest-runtime]` Fix virtual mocks not being unmockable after previously being mocked ([#8396](https://github.com/facebook/jest/pull/8396))
 
 ### Chore & Maintenance
 

--- a/packages/jest-runtime/src/__tests__/runtime_require_module_or_mock.test.js
+++ b/packages/jest-runtime/src/__tests__/runtime_require_module_or_mock.test.js
@@ -176,6 +176,26 @@ it('unmocks modules in config.unmockedModulePathPatterns for tests with automock
     expect(moduleData.isUnmocked()).toBe(true);
   }));
 
+it('unmocks virtual mocks after they have been mocked previously', () =>
+  createRuntime(__filename).then(runtime => {
+    const root = runtime.requireModule(runtime.__mockRootPath);
+
+    const mockImpl = {foo: 'bar'};
+    root.jest.mock('my-virtual-module', () => mockImpl, {virtual: true});
+
+    expect(
+      runtime.requireModuleOrMock(runtime.__mockRootPath, 'my-virtual-module'),
+    ).toEqual(mockImpl);
+
+    root.jest.unmock('my-virtual-module');
+
+    expect(() => {
+      runtime.requireModuleOrMock(runtime.__mockRootPath, 'my-virtual-module');
+    }).toThrowError(
+      new Error("Cannot find module 'my-virtual-module' from 'root.js'"),
+    );
+  }));
+
 describe('resetModules', () => {
   it('resets all the modules', () =>
     createRuntime(__filename, {

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -820,11 +820,6 @@ class Runtime {
   }
 
   private _shouldMock(from: Config.Path, moduleName: string) {
-    const mockPath = this._resolver.getModulePath(from, moduleName);
-    if (mockPath in this._virtualMocks) {
-      return true;
-    }
-
     const explicitShouldMock = this._explicitShouldMock;
     const moduleID = this._resolver.getModuleID(
       this._virtualMocks,


### PR DESCRIPTION
## Summary

Fixes #8395 where virtual mocks could not be unmocked after previously being mocked.

## Test plan

Repro steps are in a test case and now pass.
