### PR TITLE
Add marker at first place of string mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 - `[expect]` Improve report when matcher fails, part 17 ([#8349](https://github.com/facebook/jest/pull/8349))
 - `[expect]` Improve report when matcher fails, part 18 ([#8356](https://github.com/facebook/jest/pull/8356))
 - `[expect]` Improve report when matcher fails, part 19 ([#8367](https://github.com/facebook/jest/pull/8367))
+- `[expect]` Show marker at first place of string mismatch ([#8400](https://github.com/facebook/jest/pull/8400))
+
 
 ### Fixes
 

--- a/packages/expect/src/print.ts
+++ b/packages/expect/src/print.ts
@@ -126,10 +126,17 @@ export const printDiffOrStringify = (
   const printLabel = getLabelPrinter(expectedLabel, receivedLabel);
   let markerLoc = '';
   if (typeof expected == 'string' || expected instanceof String) {
-    // Padded end is defined from 'Received:  ' length;
-    markerLoc =
-      '\n'.padEnd(expectedLabel.length + 4, ' ') +
-      diffLocation(stringify(expected), stringify(received));
+
+    // Specific first occurrence difference marker
+    // not relevant to char comparisons or snapshots
+    if (expected.length > 2
+      && !(expected.includes('<') && expected.includes('>'))) {
+
+      // Padded end is defined from 'Received:  ' length;
+      markerLoc =
+        '\n'.padEnd(expectedLabel.length + 4, ' ') +
+        diffLocation(stringify(expected), stringify(received));
+    }
   }
   return (
     `${printLabel(expectedLabel)}${printExpected(expected)}\n` +

--- a/packages/expect/src/print.ts
+++ b/packages/expect/src/print.ts
@@ -124,13 +124,20 @@ export const printDiffOrStringify = (
   }
 
   const printLabel = getLabelPrinter(expectedLabel, receivedLabel);
+  let markerLoc = '';
+  if (typeof expected == 'string' || expected instanceof String) {
+    // Padded end is defined from 'Received:  ' length;
+    markerLoc =
+      '\n'.padEnd(expectedLabel.length + 4, ' ') +
+      diffLocation(stringify(expected), stringify(received));
+  }
   return (
     `${printLabel(expectedLabel)}${printExpected(expected)}\n` +
     `${printLabel(receivedLabel)}${
       stringify(expected) === stringify(received)
         ? 'serializes to the same string'
         : printReceived(received)
-    }`
+    }${markerLoc}`
   );
 };
 
@@ -182,3 +189,14 @@ const printConstructorName = (
           ? EXPECTED_COLOR(constructor.name)
           : RECEIVED_COLOR(constructor.name)
       }`;
+
+// When comparing strings returns marker at first instance of difference
+function diffLocation(a: string, b: string) {
+  const longerLength = Math.max(a.length, b.length);
+  for (let i = 0; i < longerLength; i++) {
+    // When found match
+    if (a[i] !== b[i]) return '^'.padStart(i, ' ');
+  }
+
+  return '';
+}

--- a/packages/expect/src/print.ts
+++ b/packages/expect/src/print.ts
@@ -125,7 +125,7 @@ export const printDiffOrStringify = (
 
   const printLabel = getLabelPrinter(expectedLabel, receivedLabel);
   let markerLoc = '';
-  if (typeof expected == 'string' || expected instanceof String) {
+  if (typeof expected == 'string') {
 
     // Specific first occurrence difference marker
     // not relevant to char comparisons or snapshots


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

Addresses #6881

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
This is not final rather just a step I think, want to get your feedback and move accordingly. 

![Screenshot from 2019-04-30 17-38-31](https://user-images.githubusercontent.com/5521110/57004670-9835dd00-6b85-11e9-947d-a93978b67c1b.png)

Regarding the diffLocation() there might be a little extra performance usage here with the ^ location output I couldn't find the other code that generates it below.

Regarding the spaces discussion in #6881 I think if the spaces are shown with marker it should be obvious to 9/10 people that there is a difference there can add another section that shows if first character that is different is a xA0, em-dash, x20, dash, or similar then output symbol hex as well (Expected: 1x20234)