### PR TITLE
[jest-transform] use includes instead of some

### DIFF
--- a/packages/jest-transform/src/shouldInstrument.ts
+++ b/packages/jest-transform/src/shouldInstrument.ts
@@ -79,11 +79,11 @@ export default function shouldInstrument(
     return false;
   }
 
-  if (config.setupFiles.some(setupFile => setupFile === filename)) {
+  if (config.setupFiles.includes(filename)) {
     return false;
   }
 
-  if (config.setupFilesAfterEnv.some(setupFile => setupFile === filename)) {
+  if (config.setupFilesAfterEnv.includes(filename)) {
     return false;
   }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary
Just used `includes` instead of `some` for performance reasons.
https://jsperf.com/includes-vs-some-12333
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
