### PR TITLE
Simple sugar text correction in Mock Function docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - `[@jest/reporters]` Migrate away from `istanbul-api` ([#8294](https://github.com/facebook/jest/pull/8294))
 - `[*]` Delete obsolete emails tag from header comment in test files ([#8377](https://github.com/facebook/jest/pull/8377))
 - `[expect]` optimize compare nodes ([#8368](https://github.com/facebook/jest/pull/8368))
+- `[docs]` Fix typo in MockFunctionAPI.md ([#8406](https://github.com/facebook/jest/pull/8406))
 
 ### Performance
 

--- a/docs/MockFunctionAPI.md
+++ b/docs/MockFunctionAPI.md
@@ -196,7 +196,7 @@ Will result in this error:
 
 ### `mockFn.mockReturnThis()`
 
-Just a simple sugar function for:
+Just a syntactic sugar function for:
 
 ```js
 jest.fn(function() {
@@ -233,7 +233,7 @@ console.log(myMockFn(), myMockFn(), myMockFn(), myMockFn());
 
 ### `mockFn.mockResolvedValue(value)`
 
-Simple sugar function for:
+Syntactic sugar function for:
 
 ```js
 jest.fn().mockImplementation(() => Promise.resolve(value));
@@ -251,7 +251,7 @@ test('async test', async () => {
 
 ### `mockFn.mockResolvedValueOnce(value)`
 
-Simple sugar function for:
+Syntactic sugar function for:
 
 ```js
 jest.fn().mockImplementationOnce(() => Promise.resolve(value));
@@ -276,7 +276,7 @@ test('async test', async () => {
 
 ### `mockFn.mockRejectedValue(value)`
 
-Simple sugar function for:
+Syntactic sugar function for:
 
 ```js
 jest.fn().mockImplementation(() => Promise.reject(value));
@@ -294,7 +294,7 @@ test('async test', async () => {
 
 ### `mockFn.mockRejectedValueOnce(value)`
 
-Simple sugar function for:
+Syntactic sugar function for:
 
 ```js
 jest.fn().mockImplementationOnce(() => Promise.reject(value));

--- a/docs/MockFunctionAPI.md
+++ b/docs/MockFunctionAPI.md
@@ -196,7 +196,7 @@ Will result in this error:
 
 ### `mockFn.mockReturnThis()`
 
-Just a syntactic sugar function for:
+Syntactic sugar function for:
 
 ```js
 jest.fn(function() {

--- a/website/versioned_docs/version-22.x/MockFunctionAPI.md
+++ b/website/versioned_docs/version-22.x/MockFunctionAPI.md
@@ -164,7 +164,7 @@ Will result in this error:
 
 ### `mockFn.mockReturnThis()`
 
-Just a syntactic sugar function for:
+Syntactic sugar function for:
 
 ```js
 jest.fn(function() {

--- a/website/versioned_docs/version-22.x/MockFunctionAPI.md
+++ b/website/versioned_docs/version-22.x/MockFunctionAPI.md
@@ -164,7 +164,7 @@ Will result in this error:
 
 ### `mockFn.mockReturnThis()`
 
-Just a simple sugar function for:
+Just a syntactic sugar function for:
 
 ```js
 jest.fn(function() {

--- a/website/versioned_docs/version-23.x/MockFunctionAPI.md
+++ b/website/versioned_docs/version-23.x/MockFunctionAPI.md
@@ -191,7 +191,7 @@ Will result in this error:
 
 ### `mockFn.mockReturnThis()`
 
-Just a syntactic sugar function for:
+Syntactic sugar function for:
 
 ```js
 jest.fn(function() {

--- a/website/versioned_docs/version-23.x/MockFunctionAPI.md
+++ b/website/versioned_docs/version-23.x/MockFunctionAPI.md
@@ -191,7 +191,7 @@ Will result in this error:
 
 ### `mockFn.mockReturnThis()`
 
-Just a simple sugar function for:
+Just a syntactic sugar function for:
 
 ```js
 jest.fn(function() {
@@ -228,7 +228,7 @@ console.log(myMockFn(), myMockFn(), myMockFn(), myMockFn());
 
 ### `mockFn.mockResolvedValue(value)`
 
-Simple sugar function for:
+Syntactic sugar function for:
 
 ```js
 jest.fn().mockImplementation(() => Promise.resolve(value));
@@ -246,7 +246,7 @@ test('async test', async () => {
 
 ### `mockFn.mockResolvedValueOnce(value)`
 
-Simple sugar function for:
+Syntactic sugar function for:
 
 ```js
 jest.fn().mockImplementationOnce(() => Promise.resolve(value));
@@ -271,7 +271,7 @@ test('async test', async () => {
 
 ### `mockFn.mockRejectedValue(value)`
 
-Simple sugar function for:
+Syntactic sugar function for:
 
 ```js
 jest.fn().mockImplementation(() => Promise.reject(value));
@@ -289,7 +289,7 @@ test('async test', async () => {
 
 ### `mockFn.mockRejectedValueOnce(value)`
 
-Simple sugar function for:
+Syntactic sugar function for:
 
 ```js
 jest.fn().mockImplementationOnce(() => Promise.reject(value));

--- a/website/versioned_docs/version-24.0/MockFunctionAPI.md
+++ b/website/versioned_docs/version-24.0/MockFunctionAPI.md
@@ -197,7 +197,7 @@ Will result in this error:
 
 ### `mockFn.mockReturnThis()`
 
-Just a simple sugar function for:
+Just a syntactic sugar function for:
 
 ```js
 jest.fn(function() {
@@ -234,7 +234,7 @@ console.log(myMockFn(), myMockFn(), myMockFn(), myMockFn());
 
 ### `mockFn.mockResolvedValue(value)`
 
-Simple sugar function for:
+Syntactic sugar function for:
 
 ```js
 jest.fn().mockImplementation(() => Promise.resolve(value));
@@ -252,7 +252,7 @@ test('async test', async () => {
 
 ### `mockFn.mockResolvedValueOnce(value)`
 
-Simple sugar function for:
+Syntactic sugar function for:
 
 ```js
 jest.fn().mockImplementationOnce(() => Promise.resolve(value));
@@ -277,7 +277,7 @@ test('async test', async () => {
 
 ### `mockFn.mockRejectedValue(value)`
 
-Simple sugar function for:
+Syntactic sugar function for:
 
 ```js
 jest.fn().mockImplementation(() => Promise.reject(value));
@@ -295,7 +295,7 @@ test('async test', async () => {
 
 ### `mockFn.mockRejectedValueOnce(value)`
 
-Simple sugar function for:
+Syntactic sugar function for:
 
 ```js
 jest.fn().mockImplementationOnce(() => Promise.reject(value));

--- a/website/versioned_docs/version-24.0/MockFunctionAPI.md
+++ b/website/versioned_docs/version-24.0/MockFunctionAPI.md
@@ -197,7 +197,7 @@ Will result in this error:
 
 ### `mockFn.mockReturnThis()`
 
-Just a syntactic sugar function for:
+Syntactic sugar function for:
 
 ```js
 jest.fn(function() {


### PR DESCRIPTION
## Summary

A few places in the Mock Function docs refer to "simple sugar" functions. I've updated these to [syntactic sugar](https://en.wikipedia.org/wiki/Syntactic_sugar) to match the correct terminology.
