### PR TITLE
Fix init when there is one project in `projects` config.

### DIFF
--- a/e2e/__tests__/multiProjectRunner.test.ts
+++ b/e2e/__tests__/multiProjectRunner.test.ts
@@ -170,6 +170,42 @@ test('"No tests found" message for projects', () => {
   );
 });
 
+test.each([{projectPath: 'packages/somepackage'}, {projectPath: 'packages/*'}])(
+  'allows a single non-root project',
+  ({projectPath}: {projectPath: string}) => {
+    writeFiles(DIR, {
+      'package.json': `
+        {
+          "jest": {
+            "testMatch": ["<rootDir>/packages/somepackage/test.js"],
+            "projects": [
+              "${projectPath}"
+            ]
+          }
+        }
+      `,
+      'packages/somepackage/package.json': `
+        {
+          "jest": {
+            "displayName": "somepackage"
+          }
+        }
+      `,
+      'packages/somepackage/test.js': `
+        test('1+1', () => {
+          expect(1).toBe(1);
+        });
+      `,
+    });
+
+    const {stdout, stderr, status} = runJest(DIR, ['--no-watchman']);
+    expect(stderr).toContain('PASS packages/somepackage/test.js');
+    expect(stderr).toContain('Test Suites: 1 passed, 1 total');
+    expect(stdout).toEqual('');
+    expect(status).toEqual(0);
+  },
+);
+
 test('projects can be workspaces with non-JS/JSON files', () => {
   writeFiles(DIR, {
     'package.json': JSON.stringify({

--- a/packages/jest-config/src/index.ts
+++ b/packages/jest-config/src/index.ts
@@ -293,7 +293,10 @@ export function readConfigs(
     }
   }
 
-  if (projects.length) {
+  if (
+    projects.length > 1 ||
+    (projects.length && typeof projects[0] === 'object')
+  ) {
     const parsedConfigs = projects
       .filter(root => {
         // Ignore globbed files that cannot be `require`d.

--- a/packages/jest-config/src/index.ts
+++ b/packages/jest-config/src/index.ts
@@ -218,6 +218,10 @@ const ensureNoDuplicateConfigs = (
   parsedConfigs: Array<ReadConfig>,
   projects: Config.GlobalConfig['projects'],
 ) => {
+  if (projects.length <= 1) {
+    return;
+  }
+
   const configPathMap = new Map();
 
   for (const config of parsedConfigs) {
@@ -289,7 +293,7 @@ export function readConfigs(
     }
   }
 
-  if (projects.length > 1) {
+  if (projects.length) {
     const parsedConfigs = projects
       .filter(root => {
         // Ignore globbed files that cannot be `require`d.


### PR DESCRIPTION
## Summary

There may be cases where users have a single project in the `projects` config (because of conditional projects). Currently, this doesn't go through the same code path as multiple projects and I've noticed it causing Jest fail to initialize.

## Test plan

Added test from issue #7496 (PR #7498).

All existing tests pass.

I manually tested that Jest initializes correctly with single project.
