### PR TITLE
Max workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 - `[jest-runtime]` Fix virtual mocks not being unmockable after previously being mocked ([#8396](https://github.com/facebook/jest/pull/8396))
 - `[jest-transform]` Replace special characters in transform cache filenames to support Windows ([#8353](https://github.com/facebook/jest/pull/8353))
 - `[jest-config]` Allow exactly one project ([#7498](https://github.com/facebook/jest/pull/7498))
-- `[jest-config]` Adjust `--maxWorkers` behavior to use the lesser of provided number and number of cores. ([#TODO}(https://github.com/facebook/jest/pull/todo)])
+- `[jest-config]` Adjust `--maxWorkers` behavior to use the lesser of provided number and number of cores. ([#8410](https://github.com/facebook/jest/pull/8410))
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - `[jest-runtime]` Fix virtual mocks not being unmockable after previously being mocked ([#8396](https://github.com/facebook/jest/pull/8396))
 - `[jest-transform]` Replace special characters in transform cache filenames to support Windows ([#8353](https://github.com/facebook/jest/pull/8353))
 - `[jest-config]` Allow exactly one project ([#7498](https://github.com/facebook/jest/pull/7498))
+- `[jest-config]` Adjust `--maxWorkers` behavior to use the lesser of provided number and number of cores. ([#TODO}(https://github.com/facebook/jest/pull/todo)])
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,6 @@
 - `[jest-runtime]` Fix virtual mocks not being unmockable after previously being mocked ([#8396](https://github.com/facebook/jest/pull/8396))
 - `[jest-transform]` Replace special characters in transform cache filenames to support Windows ([#8353](https://github.com/facebook/jest/pull/8353))
 - `[jest-config]` Allow exactly one project ([#7498](https://github.com/facebook/jest/pull/7498))
-- `[jest-config]` Adjust `--maxWorkers` behavior to use the lesser of provided number and number of cores. ([#8410](https://github.com/facebook/jest/pull/8410))
 
 ### Chore & Maintenance
 
@@ -40,6 +39,7 @@
 
 - `[jest-runtime]` Fix module registry memory leak ([#8282](https://github.com/facebook/jest/pull/8282))
 - `[jest-resolve]` optimize resolve module path ([#8388](https://github.com/facebook/jest/pull/8388))
+- `[jest-config]` Adjust `--maxWorkers` behavior to use the lesser of provided number and number of cores. ([#8410](https://github.com/facebook/jest/pull/8410))
 
 ## 24.7.1
 

--- a/packages/jest-config/src/__tests__/getMaxWorkers.test.ts
+++ b/packages/jest-config/src/__tests__/getMaxWorkers.test.ts
@@ -25,9 +25,9 @@ describe('getMaxWorkers', () => {
     expect(getMaxWorkers({})).toBe(1);
   });
 
-  it('Returns the `maxWorkers` when specified', () => {
-    const argv = {maxWorkers: 8};
-    expect(getMaxWorkers(argv)).toBe(8);
+  it('Returns the lesser of `maxWorkers` and the number of cpus', () => {
+    expect(getMaxWorkers({maxWorkers: 2})).toBe(2);
+    expect(getMaxWorkers({maxWorkers: 50})).toBe(4);
   });
 
   it('Returns based on the number of cpus', () => {

--- a/packages/jest-config/src/__tests__/getMaxWorkers.test.ts
+++ b/packages/jest-config/src/__tests__/getMaxWorkers.test.ts
@@ -25,9 +25,9 @@ describe('getMaxWorkers', () => {
     expect(getMaxWorkers({})).toBe(1);
   });
 
-  it('Returns the lesser of `maxWorkers` and the number of cpus', () => {
+  it('Returns the lesser of `maxWorkers` and (the number of cpus - 1)', () => {
     expect(getMaxWorkers({maxWorkers: 2})).toBe(2);
-    expect(getMaxWorkers({maxWorkers: 50})).toBe(4);
+    expect(getMaxWorkers({maxWorkers: 50})).toBe(3);
   });
 
   it('Returns based on the number of cpus', () => {

--- a/packages/jest-config/src/getMaxWorkers.ts
+++ b/packages/jest-config/src/getMaxWorkers.ts
@@ -11,6 +11,7 @@ import {Config} from '@jest/types';
 export default function getMaxWorkers(
   argv: Partial<Pick<Config.Argv, 'maxWorkers' | 'runInBand' | 'watch'>>,
 ): number {
+  const cpus = os.cpus() ? os.cpus().length : 1;
   if (argv.runInBand) {
     return 1;
   } else if (argv.maxWorkers) {
@@ -18,7 +19,6 @@ export default function getMaxWorkers(
     const maxWorkers = (argv.maxWorkers as unknown) as number | string;
     const parsed = parseInt(maxWorkers as string, 10);
 
-    const cpus = os.cpus().length;
     if (
       typeof maxWorkers === 'string' &&
       maxWorkers.trim().endsWith('%') &&
@@ -29,10 +29,9 @@ export default function getMaxWorkers(
       return workers >= 1 ? workers : 1;
     }
 
-    return Math.max(Math.min(cpus, parsed), 1);
+    return Math.max(Math.min(cpus - 1, parsed), 1);
   } else {
     // In watch mode, Jest should be unobtrusive and not use all available CPUs.
-    const cpus = os.cpus() ? os.cpus().length : 1;
     return Math.max(argv.watch ? Math.floor(cpus / 2) : cpus - 1, 1);
   }
 }

--- a/packages/jest-config/src/getMaxWorkers.ts
+++ b/packages/jest-config/src/getMaxWorkers.ts
@@ -18,18 +18,18 @@ export default function getMaxWorkers(
     const maxWorkers = (argv.maxWorkers as unknown) as number | string;
     const parsed = parseInt(maxWorkers as string, 10);
 
+    const cpus = os.cpus().length;
     if (
       typeof maxWorkers === 'string' &&
       maxWorkers.trim().endsWith('%') &&
       parsed > 0 &&
       parsed <= 100
     ) {
-      const cpus = os.cpus().length;
       const workers = Math.floor((parsed / 100) * cpus);
       return workers >= 1 ? workers : 1;
     }
 
-    return parsed > 0 ? parsed : 1;
+    return Math.max(Math.min(cpus, parsed), 1);
   } else {
     // In watch mode, Jest should be unobtrusive and not use all available CPUs.
     const cpus = os.cpus() ? os.cpus().length : 1;

--- a/packages/jest-haste-map/src/lib/FSEventsWatcher.ts
+++ b/packages/jest-haste-map/src/lib/FSEventsWatcher.ts
@@ -11,7 +11,6 @@ import path from 'path';
 import {EventEmitter} from 'events';
 import anymatch from 'anymatch';
 import micromatch from 'micromatch';
-// eslint-disable-next-line
 import {Watcher} from 'fsevents';
 // @ts-ignore no types
 import walker from 'walker';

--- a/packages/jest-haste-map/src/lib/FSEventsWatcher.ts
+++ b/packages/jest-haste-map/src/lib/FSEventsWatcher.ts
@@ -11,6 +11,7 @@ import path from 'path';
 import {EventEmitter} from 'events';
 import anymatch from 'anymatch';
 import micromatch from 'micromatch';
+// eslint-disable-next-line
 import {Watcher} from 'fsevents';
 // @ts-ignore no types
 import walker from 'walker';

--- a/packages/jest-transform/src/ScriptTransformer.ts
+++ b/packages/jest-transform/src/ScriptTransformer.ts
@@ -573,7 +573,7 @@ const calcIgnorePatternRegExp = (config: Config.ProjectConfig) => {
     !config.transformIgnorePatterns ||
     config.transformIgnorePatterns.length === 0
   ) {
-    return;
+    return undefined;
   }
 
   return new RegExp(config.transformIgnorePatterns.join('|'));
@@ -581,7 +581,7 @@ const calcIgnorePatternRegExp = (config: Config.ProjectConfig) => {
 
 const calcTransformRegExp = (config: Config.ProjectConfig) => {
   if (!config.transform.length) {
-    return;
+    return undefined;
   }
 
   const transformRegexp: Array<[RegExp, string]> = [];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

This PR fixes https://github.com/facebook/jest/issues/8407, adjusting `--maxWorkers` behavior to act as an upper bound. With this change, Jest will use the lesser of the provided number and the number of CPU cores.

This better matches the behavior implied by the option's usage information.

## Test plan

Unit tests have been updated to cover the changed behavior.