### PR TITLE
Simplify workaround that overrides Jest clone folder on Azure Pipelines

### DIFF
--- a/.azure-pipelines-steps.yml
+++ b/.azure-pipelines-steps.yml
@@ -2,9 +2,9 @@
 # Steps for building and testing Jest. See jobs defined in .azure-pipelines.yml
 #
 
-# Clones the repo
 steps:
   - checkout: self
+    path: jest
 
   # Ensure Node.js 10 is active
   - task: NodeTool@0
@@ -18,34 +18,24 @@ steps:
       versionSpec: '2.7'
     displayName: 'Use Python 2.7'
 
-  # Workaround to move source files under a "jest" folder (see .azure-pipelines.yml for details)
-  - script: |
-      cd /
-      mv $(Build.Repository.LocalPath) $(JEST_DIR)
-      mkdir $(Build.Repository.LocalPath)
-    displayName: 'Move source into jest folder'
-
   # Run yarn to install dependencies and build
   - script: node scripts/remove-postinstall
-    workingDirectory: $(JEST_DIR)
     displayName: 'Remove postinstall script'
+
   - script: yarn --no-progress --frozen-lockfile
-    workingDirectory: $(JEST_DIR)
     displayName: 'Install dependencies'
+
   - script: node scripts/build
-    workingDirectory: $(JEST_DIR)
     displayName: 'Build'
 
   # Run test-ci-partial
   - script: yarn run test-ci-partial
-    workingDirectory: $(JEST_DIR)
     displayName: 'Run tests'
 
   # Publish CI test results
   - task: PublishTestResults@2
     inputs:
       testResultsFiles: '**/reports/junit/*.xml'
-      searchFolder: $(JEST_DIR)
       testRunTitle: 'CI Tests $(Agent.OS)'
     displayName: 'Publish test results'
     condition: succeededOrFailed()

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -32,9 +32,5 @@ variables:
   # Used by chalk. Ensures output from Jest includes ANSI escape characters that are needed to match test snapshots.
   FORCE_COLOR: 1
 
-  # By default, Azure Pipelines clones to an "s" directory, which causes tests to fail due to assumption of Jest being run from a "jest" directory.
-  # See packages/jest-message-util/src/index.js PATH_JEST_PACKAGES for more details.
-  JEST_DIR: $(Agent.BuildDirectory)/jest
-
   # Ensures the handful of tests that should be skipped during CI are
   CI: true


### PR DESCRIPTION
## Summary

This simplifies the Azure Pipelines-specific workaround that overrides the folder Jest gets cloned into during a CI build. See [azure-pipelines-steps.yml (line 22)](https://github.com/facebook/jest/blob/master/.azure-pipelines-steps.yml#L22). 

Why this change? There is now a property on the "checkout" step that makes it easy to set the target directory of "git clone". This avoids the need for a separate step that copies the source to a different folder. This also simplifies the YAML.

Here's why this workaround was (and still is) necessary:

> By default, Azure Pipelines clones to an "s" directory, which causes some Jest tests to fail due to the assumption by Jest that it is being run from a "jest" directory (see packages/jest-message-util/src/index.js PATH_JEST_PACKAGES for more details).

## Test plan

Since this is an Azure Pipelines specific change, there is no impact to the functionality of Jest or existing tests. Just need to ensure the "Git checkout" step shows cloning into a "jest" folder and all tests pass correctly on Windows, Linux, and macOS.
