### PR TITLE
Clone to new test environment options while create test environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - `[jest-runtime]` Fix virtual mocks not being unmockable after previously being mocked ([#8396](https://github.com/facebook/jest/pull/8396))
 - `[jest-transform]` Replace special characters in transform cache filenames to support Windows ([#8353](https://github.com/facebook/jest/pull/8353))
 - `[jest-config]` Allow exactly one project ([#7498](https://github.com/facebook/jest/pull/7498))
+- `[jest-environment-jsdom]` `[jest-environment-node]` Fix `testEnvironmentOptions` affected in the test process ([#8420](https://github.com/facebook/jest/pull/8420))
 
 ### Chore & Maintenance
 

--- a/packages/jest-environment-jsdom/src/index.ts
+++ b/packages/jest-environment-jsdom/src/index.ts
@@ -35,7 +35,7 @@ class JSDOMEnvironment implements JestEnvironment {
       runScripts: 'dangerously',
       url: config.testURL,
       virtualConsole: new VirtualConsole().sendTo(options.console || console),
-      ...config.testEnvironmentOptions,
+      ...Object.create(config.testEnvironmentOptions),
     });
     const global = (this.global = this.dom.window.document.defaultView as Win);
 

--- a/packages/jest-environment-jsdom/src/index.ts
+++ b/packages/jest-environment-jsdom/src/index.ts
@@ -30,13 +30,20 @@ class JSDOMEnvironment implements JestEnvironment {
   moduleMocker: ModuleMocker | null;
 
   constructor(config: Config.ProjectConfig, options: EnvironmentContext = {}) {
-    this.dom = new JSDOM('<!DOCTYPE html>', {
-      pretendToBeVisual: true,
-      runScripts: 'dangerously',
-      url: config.testURL,
-      virtualConsole: new VirtualConsole().sendTo(options.console || console),
-      ...Object.create(config.testEnvironmentOptions),
-    });
+    this.dom = new JSDOM(
+      '<!DOCTYPE html>',
+      Object.assign(
+        {
+          pretendToBeVisual: true,
+          runScripts: 'dangerously',
+          url: config.testURL,
+          virtualConsole: new VirtualConsole().sendTo(
+            options.console || console,
+          ),
+        },
+        Object.create(config.testEnvironmentOptions || null),
+      ),
+    );
     const global = (this.global = this.dom.window.document.defaultView as Win);
 
     if (!global) {

--- a/packages/jest-environment-node/src/index.ts
+++ b/packages/jest-environment-node/src/index.ts
@@ -28,7 +28,10 @@ class NodeEnvironment implements JestEnvironment {
     this.context = vm.createContext();
     const global = (this.global = vm.runInContext(
       'this',
-      Object.assign(this.context, Object.create(config.testEnvironmentOptions)),
+      Object.assign(
+        this.context,
+        Object.create(config.testEnvironmentOptions || null),
+      ),
     ));
     global.global = global;
     global.clearInterval = clearInterval;

--- a/packages/jest-environment-node/src/index.ts
+++ b/packages/jest-environment-node/src/index.ts
@@ -28,7 +28,7 @@ class NodeEnvironment implements JestEnvironment {
     this.context = vm.createContext();
     const global = (this.global = vm.runInContext(
       'this',
-      Object.assign(this.context, config.testEnvironmentOptions),
+      Object.assign(this.context, Object.create(config.testEnvironmentOptions)),
     ));
     global.global = global;
     global.clearInterval = clearInterval;


### PR DESCRIPTION
Resolved #8393 #5223

In test runner, when a test environment creates a new instance it using ref object of `testEnvironmentOptions` and if in the process have an action to affect object `testEnvironmentOptions` will affect too.

To fix it, we will clone an object `testEnvironmentOptions` in a test environment.