### PR TITLE
make watch plugin initialization errors look nice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - `[babel-plugin-jest-hoist]` Expand list of whitelisted globals in global mocks ([#8429](https://github.com/facebook/jest/pull/8429)
+- `[jest-core]` Make watch plugin initialization errors look nice ([#8422](https://github.com/facebook/jest/pull/8422))
 
 ### Chore & Maintenance
 

--- a/packages/jest-cli/src/cli/index.ts
+++ b/packages/jest-cli/src/cli/index.ts
@@ -36,7 +36,7 @@ export async function run(maybeArgv?: Array<string>, project?: Config.Path) {
   } catch (error) {
     clearLine(process.stderr);
     clearLine(process.stdout);
-    console.error(chalk.red(error.stack));
+    console.error(chalk.red(error));
     exit(1);
     throw error;
   }

--- a/packages/jest-cli/src/cli/index.ts
+++ b/packages/jest-cli/src/cli/index.ts
@@ -36,7 +36,12 @@ export async function run(maybeArgv?: Array<string>, project?: Config.Path) {
   } catch (error) {
     clearLine(process.stderr);
     clearLine(process.stdout);
-    console.error(chalk.red(error));
+    if (error.stack) {
+      console.error(chalk.red(error.stack));
+    } else {
+      console.error(chalk.red(error));
+    }
+
     exit(1);
     throw error;
   }

--- a/packages/jest-core/package.json
+++ b/packages/jest-core/package.json
@@ -31,6 +31,7 @@
     "pirates": "^4.0.1",
     "realpath-native": "^1.1.0",
     "rimraf": "^2.5.4",
+    "slash": "^2.0.0",
     "strip-ansi": "^5.0.0"
   },
   "devDependencies": {
@@ -41,6 +42,7 @@
     "@types/micromatch": "^3.1.0",
     "@types/p-each-series": "^1.0.0",
     "@types/rimraf": "^2.0.2",
+    "@types/slash": "^2.0.0",
     "@types/strip-ansi": "^3.0.0"
   },
   "engines": {

--- a/packages/jest-core/src/__tests__/__fixtures__/watch_plugin_throws.js
+++ b/packages/jest-core/src/__tests__/__fixtures__/watch_plugin_throws.js
@@ -1,0 +1,1 @@
+throw new Error('initialization error');

--- a/packages/jest-core/src/__tests__/__fixtures__/watch_plugin_throws.js
+++ b/packages/jest-core/src/__tests__/__fixtures__/watch_plugin_throws.js
@@ -1,1 +1,3 @@
+// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+
 throw new Error('initialization error');

--- a/packages/jest-core/src/__tests__/__snapshots__/watch.test.js.snap
+++ b/packages/jest-core/src/__tests__/__snapshots__/watch.test.js.snap
@@ -51,14 +51,14 @@ Watch Usage
 `;
 
 exports[`Watch mode flows makes watch plugin initialization errors look nice 1`] = `
-"Failed to initialize watch plugin 'PATH_REPLACED':
+[Error: Failed to initialize watch plugin 'packages/jest-core/src/__tests__/__fixtures__/watch_plugin_throws':
 
   ● Test suite failed to run
 
-    initialization failure
+    initialization error
 
-      at Object.jest.doMock [as user:PATH_REPLACED:] (watch.test.js:585:15)
-"
+      at Object.<anonymous> (__fixtures__/watch_plugin_throws.js:1:7)
+]
 `;
 
 exports[`Watch mode flows shows prompts for WatchPlugins in alphabetical order 1`] = `

--- a/packages/jest-core/src/__tests__/__snapshots__/watch.test.js.snap
+++ b/packages/jest-core/src/__tests__/__snapshots__/watch.test.js.snap
@@ -51,13 +51,13 @@ Watch Usage
 `;
 
 exports[`Watch mode flows makes watch plugin initialization errors look nice 1`] = `
-[Error: Failed to initialize watch plugin 'packages/jest-core/src/__tests__/__fixtures__/watch_plugin_throws':
+[Error: Failed to initialize watch plugin "packages/jest-core/src/__tests__/__fixtures__/watch_plugin_throws":
 
   ● Test suite failed to run
 
     initialization error
 
-      at Object.<anonymous> (__fixtures__/watch_plugin_throws.js:1:7)
+      at Object.<anonymous> (__fixtures__/watch_plugin_throws.js:3:7)
 ]
 `;
 

--- a/packages/jest-core/src/__tests__/__snapshots__/watch.test.js.snap
+++ b/packages/jest-core/src/__tests__/__snapshots__/watch.test.js.snap
@@ -51,14 +51,14 @@ Watch Usage
 `;
 
 exports[`Watch mode flows makes watch plugin initialization errors look nice 1`] = `
-[Error: Failed to initialize watch plugin "packages/jest-core/src/__tests__/__fixtures__/watch_plugin_throws":
+"Error: Failed to initialize watch plugin \\"packages/jest-core/src/__tests__/__fixtures__/watch_plugin_throws\\":
 
   ● Test suite failed to run
 
     initialization error
 
       at Object.<anonymous> (__fixtures__/watch_plugin_throws.js:3:7)
-]
+"
 `;
 
 exports[`Watch mode flows shows prompts for WatchPlugins in alphabetical order 1`] = `

--- a/packages/jest-core/src/__tests__/__snapshots__/watch.test.js.snap
+++ b/packages/jest-core/src/__tests__/__snapshots__/watch.test.js.snap
@@ -51,14 +51,14 @@ Watch Usage
 `;
 
 exports[`Watch mode flows makes watch plugin initialization errors look nice 1`] = `
-[Error: Failed to initialize watch plugin '/Users/timseckinger/proj/jest/packages/jest-core/src/__tests__/__fixtures__/plugin_path_throws':
+"Failed to initialize watch plugin 'PATH_REPLACED':
 
   ● Test suite failed to run
 
     initialization failure
 
-      at Object.jest.doMock [as user:/Users/timseckinger/proj/jest/packages/jest-core/src/__tests__/__fixtures__/plugin_path_throws:] (watch.test.js:584:15)
-]
+      at Object.jest.doMock [as user:PATH_REPLACED:] (watch.test.js:585:15)
+"
 `;
 
 exports[`Watch mode flows shows prompts for WatchPlugins in alphabetical order 1`] = `

--- a/packages/jest-core/src/__tests__/__snapshots__/watch.test.js.snap
+++ b/packages/jest-core/src/__tests__/__snapshots__/watch.test.js.snap
@@ -51,14 +51,14 @@ Watch Usage
 `;
 
 exports[`Watch mode flows makes watch plugin initialization errors look nice 1`] = `
-"Error: Failed to initialize watch plugin \\"packages/jest-core/src/__tests__/__fixtures__/watch_plugin_throws\\":
+[Error: Failed to initialize watch plugin "packages/jest-core/src/__tests__/__fixtures__/watch_plugin_throws":
 
   ● Test suite failed to run
 
     initialization error
 
       at Object.<anonymous> (__fixtures__/watch_plugin_throws.js:3:7)
-"
+]
 `;
 
 exports[`Watch mode flows shows prompts for WatchPlugins in alphabetical order 1`] = `

--- a/packages/jest-core/src/__tests__/__snapshots__/watch.test.js.snap
+++ b/packages/jest-core/src/__tests__/__snapshots__/watch.test.js.snap
@@ -50,6 +50,17 @@ Watch Usage
 ]
 `;
 
+exports[`Watch mode flows makes watch plugin initialization errors look nice 1`] = `
+[Error: Failed to initialize watch plugin '/Users/timseckinger/proj/jest/packages/jest-core/src/__tests__/__fixtures__/plugin_path_throws':
+
+  ● Test suite failed to run
+
+    initialization failure
+
+      at Object.jest.doMock [as user:/Users/timseckinger/proj/jest/packages/jest-core/src/__tests__/__fixtures__/plugin_path_throws:] (watch.test.js:584:15)
+]
+`;
+
 exports[`Watch mode flows shows prompts for WatchPlugins in alphabetical order 1`] = `
 Array [
   Array [

--- a/packages/jest-core/src/__tests__/watch.test.js
+++ b/packages/jest-core/src/__tests__/watch.test.js
@@ -8,7 +8,6 @@
 
 'use strict';
 
-import path from 'path';
 import chalk from 'chalk';
 import TestWatcher from '../TestWatcher';
 import {JestHook, KEYS} from 'jest-watcher';
@@ -578,18 +577,10 @@ describe('Watch mode flows', () => {
   });
 
   it('makes watch plugin initialization errors look nice', async () => {
-    const pluginPath = `${__dirname}/__fixtures__/plugin_path_throws`;
-    jest.doMock(
-      pluginPath,
-      () => {
-        throw new Error('initialization failure');
-      },
-      {virtual: true},
-    );
+    const pluginPath = `${__dirname}/__fixtures__/watch_plugin_throws`;
 
-    expect.assertions(1);
-    try {
-      await watch(
+    await expect(
+      watch(
         {
           ...globalConfig,
           rootDir: __dirname,
@@ -599,12 +590,8 @@ describe('Watch mode flows', () => {
         pipe,
         hasteMapInstances,
         stdin,
-      );
-    } catch (err) {
-      expect(
-        err.message.split(path.resolve(pluginPath)).join('PATH_REPLACED'),
-      ).toMatchSnapshot();
-    }
+      ),
+    ).rejects.toMatchSnapshot();
   });
 
   it.each`

--- a/packages/jest-core/src/__tests__/watch.test.js
+++ b/packages/jest-core/src/__tests__/watch.test.js
@@ -579,8 +579,9 @@ describe('Watch mode flows', () => {
   it('makes watch plugin initialization errors look nice', async () => {
     const pluginPath = `${__dirname}/__fixtures__/watch_plugin_throws`;
 
-    await expect(
-      watch(
+    expect.assertions(1);
+    try {
+      await watch(
         {
           ...globalConfig,
           rootDir: __dirname,
@@ -590,8 +591,10 @@ describe('Watch mode flows', () => {
         pipe,
         hasteMapInstances,
         stdin,
-      ),
-    ).rejects.toMatchSnapshot();
+      );
+    } catch (error) {
+      expect(error.toString().replace(/\\/, '/')).toMatchSnapshot();
+    }
   });
 
   it.each`

--- a/packages/jest-core/src/__tests__/watch.test.js
+++ b/packages/jest-core/src/__tests__/watch.test.js
@@ -108,7 +108,12 @@ describe('Watch mode flows', () => {
     isInteractive = true;
     jest.doMock('jest-util/build/isInteractive', () => isInteractive);
     watch = require('../watch').default;
-    const config = {roots: [], testPathIgnorePatterns: [], testRegex: []};
+    const config = {
+      rootDir: __dirname,
+      roots: [],
+      testPathIgnorePatterns: [],
+      testRegex: [],
+    };
     pipe = {write: jest.fn()};
     globalConfig = {watch: true};
     hasteMapInstances = [{on: () => {}}];
@@ -569,6 +574,31 @@ describe('Watch mode flows', () => {
         },
       ],
     });
+  });
+
+  it('makes watch plugin initialization errors look nice', async () => {
+    const pluginPath = `${__dirname}/__fixtures__/plugin_path_throws`;
+    jest.doMock(
+      pluginPath,
+      () => {
+        throw new Error('initialization failure');
+      },
+      {virtual: true},
+    );
+
+    await expect(
+      watch(
+        {
+          ...globalConfig,
+          rootDir: __dirname,
+          watchPlugins: [{config: {}, path: pluginPath}],
+        },
+        contexts,
+        pipe,
+        hasteMapInstances,
+        stdin,
+      ),
+    ).rejects.toMatchSnapshot();
   });
 
   it.each`

--- a/packages/jest-core/src/__tests__/watch.test.js
+++ b/packages/jest-core/src/__tests__/watch.test.js
@@ -579,9 +579,8 @@ describe('Watch mode flows', () => {
   it('makes watch plugin initialization errors look nice', async () => {
     const pluginPath = `${__dirname}/__fixtures__/watch_plugin_throws`;
 
-    expect.assertions(1);
-    try {
-      await watch(
+    await expect(
+      watch(
         {
           ...globalConfig,
           rootDir: __dirname,
@@ -591,10 +590,8 @@ describe('Watch mode flows', () => {
         pipe,
         hasteMapInstances,
         stdin,
-      );
-    } catch (error) {
-      expect(error.toString().replace(/\\/, '/')).toMatchSnapshot();
-    }
+      ),
+    ).rejects.toMatchSnapshot();
   });
 
   it.each`

--- a/packages/jest-core/src/__tests__/watch.test.js
+++ b/packages/jest-core/src/__tests__/watch.test.js
@@ -8,6 +8,7 @@
 
 'use strict';
 
+import path from 'path';
 import chalk from 'chalk';
 import TestWatcher from '../TestWatcher';
 import {JestHook, KEYS} from 'jest-watcher';
@@ -586,8 +587,9 @@ describe('Watch mode flows', () => {
       {virtual: true},
     );
 
-    await expect(
-      watch(
+    expect.assertions(1);
+    try {
+      await watch(
         {
           ...globalConfig,
           rootDir: __dirname,
@@ -597,8 +599,12 @@ describe('Watch mode flows', () => {
         pipe,
         hasteMapInstances,
         stdin,
-      ),
-    ).rejects.toMatchSnapshot();
+      );
+    } catch (err) {
+      expect(
+        err.message.split(path.resolve(pluginPath)).join('PATH_REPLACED'),
+      ).toMatchSnapshot();
+    }
   });
 
   it.each`

--- a/packages/jest-core/src/watch.ts
+++ b/packages/jest-core/src/watch.ts
@@ -171,12 +171,25 @@ export default function watch(
     }
 
     for (const pluginWithConfig of globalConfig.watchPlugins) {
-      const ThirdPartyPlugin = require(pluginWithConfig.path);
-      const plugin: WatchPlugin = new ThirdPartyPlugin({
-        config: pluginWithConfig.config,
-        stdin,
-        stdout: outputStream,
-      });
+      let plugin: WatchPlugin;
+      try {
+        const ThirdPartyPlugin = require(pluginWithConfig.path);
+        plugin = new ThirdPartyPlugin({
+          config: pluginWithConfig.config,
+          stdin,
+          stdout: outputStream,
+        });
+      } catch (err) {
+        return Promise.reject(
+          new Error(
+            `Failed to initialize watch plugin '${
+              pluginWithConfig.path
+            }':\n\n${formatExecError(err, contexts[0].config, {
+              noStackTrace: false,
+            })}`,
+          ),
+        );
+      }
       checkForConflicts(watchPluginKeys, plugin, globalConfig);
 
       const hookSubscriber = hooks.getSubscriber();

--- a/packages/jest-core/src/watch.ts
+++ b/packages/jest-core/src/watch.ts
@@ -182,10 +182,9 @@ export default function watch(
         });
       } catch (error) {
         const errorWithContext = new Error(
-          `Failed to initialize watch plugin '${path.relative(
-            process.cwd(),
-            pluginWithConfig.path,
-          )}':\n\n${formatExecError(error, contexts[0].config, {
+          `Failed to initialize watch plugin "${chalk.bold(
+            path.posix.relative(process.cwd(), pluginWithConfig.path),
+          )}":\n\n${formatExecError(error, contexts[0].config, {
             noStackTrace: false,
           })}`,
         );

--- a/packages/jest-core/src/watch.ts
+++ b/packages/jest-core/src/watch.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import path from 'path';
 import ansiEscapes from 'ansi-escapes';
 import chalk from 'chalk';
 import exit from 'exit';
@@ -179,16 +180,17 @@ export default function watch(
           stdin,
           stdout: outputStream,
         });
-      } catch (err) {
-        return Promise.reject(
-          new Error(
-            `Failed to initialize watch plugin '${
-              pluginWithConfig.path
-            }':\n\n${formatExecError(err, contexts[0].config, {
-              noStackTrace: false,
-            })}`,
-          ),
+      } catch (error) {
+        const errorWithContext = new Error(
+          `Failed to initialize watch plugin '${path.relative(
+            process.cwd(),
+            pluginWithConfig.path,
+          )}':\n\n${formatExecError(error, contexts[0].config, {
+            noStackTrace: false,
+          })}`,
         );
+        delete errorWithContext.stack;
+        return Promise.reject(errorWithContext);
       }
       checkForConflicts(watchPluginKeys, plugin, globalConfig);
 

--- a/packages/jest-core/src/watch.ts
+++ b/packages/jest-core/src/watch.ts
@@ -9,6 +9,7 @@ import path from 'path';
 import ansiEscapes from 'ansi-escapes';
 import chalk from 'chalk';
 import exit from 'exit';
+import slash from 'slash';
 import HasteMap, {HasteChangeEvent} from 'jest-haste-map';
 import {formatExecError} from 'jest-message-util';
 import {isInteractive, preRunMessage, specialChars} from 'jest-util';
@@ -183,7 +184,7 @@ export default function watch(
       } catch (error) {
         const errorWithContext = new Error(
           `Failed to initialize watch plugin "${chalk.bold(
-            path.relative(process.cwd(), pluginWithConfig.path),
+            slash(path.relative(process.cwd(), pluginWithConfig.path)),
           )}":\n\n${formatExecError(error, contexts[0].config, {
             noStackTrace: false,
           })}`,

--- a/packages/jest-core/src/watch.ts
+++ b/packages/jest-core/src/watch.ts
@@ -183,7 +183,7 @@ export default function watch(
       } catch (error) {
         const errorWithContext = new Error(
           `Failed to initialize watch plugin "${chalk.bold(
-            path.posix.relative(process.cwd(), pluginWithConfig.path),
+            path.relative(process.cwd(), pluginWithConfig.path),
           )}":\n\n${formatExecError(error, contexts[0].config, {
             noStackTrace: false,
           })}`,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Follow up to https://github.com/jest-community/jest-watch-typeahead/pull/29

![image](https://user-images.githubusercontent.com/16069751/57201553-995a7600-6f9a-11e9-8f89-d8258c59661b.png)

Any idea how we could get rid of the outer stack trace and / or "Test suite failed to run"? In the current state it IMO looks worse than just the plain error. @SimenB
Edit: fixed outer stack trace, updated screenshot 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Added snapshot test.
Manual test -> see screenshot
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
