### PR TITLE
LICENSE: Follow copyright header guidelines and delete For Jest software

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 - `[*]` Delete obsolete emails tag from header comment in test files ([#8377](https://github.com/facebook/jest/pull/8377))
 - `[expect]` optimize compare nodes ([#8368](https://github.com/facebook/jest/pull/8368))
 - `[docs]` Fix typo in MockFunctionAPI.md ([#8406](https://github.com/facebook/jest/pull/8406))
+- `[LICENSE]` Follow copyright header guidelines and delete For Jest software ([#8428](https://github.com/facebook/jest/pull/8428))
 
 ### Performance
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,8 +1,6 @@
 MIT License
 
-For Jest software
-
-Copyright (c) 2014-present, Facebook, Inc.
+Copyright (c) Facebook, Inc. and its affiliates.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary

I noticed `View license` as text of link on `jest` project page compared to `MIT` on `react` project page

This commit removes differences in the `LICENSE` file for Jest compared to React

* My theory is `For Jest software` line is causing GitHub not to match the license text as MIT
* For the copyright line, see https://github.com/facebook/react/pull/13593

## Test plan

See if GitHub matches the `LICENSE` file :)