### PR TITLE
Fix babel-plugin-jest-hoist: getting full list of whitelisted globals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- `[babel-plugin-jest-hoist]` Expand list of whitelisted globals in global mocks ([#8429](https://github.com/facebook/jest/pull/8429)
+
 ### Chore & Maintenance
 
 ### Performance

--- a/packages/babel-plugin-jest-hoist/src/index.ts
+++ b/packages/babel-plugin-jest-hoist/src/index.ts
@@ -74,7 +74,7 @@ const WHITELISTED_IDENTIFIERS: Set<string> = new Set([
   'require',
   'undefined',
 ]);
-Object.keys(global).forEach(name => {
+Object.getOwnPropertyNames(global).forEach(name => {
   WHITELISTED_IDENTIFIERS.add(name);
 });
 


### PR DESCRIPTION
Ref #8427

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

As mentioned in #8427, Node v12 has changed the enumerability of `global.process` and `global.Buffer`, thus the list of allowed globals became much shorter. I believe, that suggested change will improve the testing experience because it provides more complete list of available globals that can be safely used in hoisted mocks.

## Test plan

I ran the e2e test for this plugin and it was all green.
```
npx jest
 PASS  __tests__/typescript.test.ts
 PASS  __tests__/integrationAutomockOff.test.js
 PASS  __tests__/integration.test.js

Test Suites: 3 passed, 3 total
Tests:       12 passed, 12 total
Snapshots:   0 total
Time:        2.25s
```

P.S. I signed the CLA.