### PR TITLE
chore: getMaxWorkers types

### DIFF
--- a/packages/jest-config/src/getMaxWorkers.ts
+++ b/packages/jest-config/src/getMaxWorkers.ts
@@ -15,8 +15,8 @@ export default function getMaxWorkers(
     return 1;
   } else if (argv.maxWorkers) {
     // TODO: How to type this properly? Should probably use `coerce` from `yargs`
-    const maxWorkers = (argv.maxWorkers as unknown) as number | string;
-    const parsed = parseInt(maxWorkers as string, 10);
+    const maxWorkers = argv.maxWorkers;
+    const parsed = parseInt(<string>maxWorkers, 10);
 
     if (
       typeof maxWorkers === 'string' &&

--- a/packages/jest-config/src/getMaxWorkers.ts
+++ b/packages/jest-config/src/getMaxWorkers.ts
@@ -16,7 +16,7 @@ export default function getMaxWorkers(
   } else if (argv.maxWorkers) {
     // TODO: How to type this properly? Should probably use `coerce` from `yargs`
     const maxWorkers = argv.maxWorkers;
-    const parsed = parseInt(<string>maxWorkers, 10);
+    const parsed = parseInt(maxWorkers as string, 10);
 
     if (
       typeof maxWorkers === 'string' &&

--- a/packages/jest-types/src/Config.ts
+++ b/packages/jest-types/src/Config.ts
@@ -452,7 +452,7 @@ export type Argv = Arguments<
     json: boolean;
     lastCommit: boolean;
     logHeapUsage: boolean;
-    maxWorkers: number;
+    maxWorkers: number | string;
     moduleDirectories: Array<string>;
     moduleFileExtensions: Array<string>;
     moduleNameMapper: string;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary
Note: Creating separate isolated PR's for type adjustments that narrow the scope of effected files.
See #8436 

getMaxWorkers - has capability to parse percentage strings , Therefore we should add string to its type, and remove unnecessary casting. `const maxWorkers = (argv.maxWorkers as unknown) as number | string;` to `const maxWorkers = argv.maxWorkers`. Or depreceate
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan
No type errors thrown on build
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
