### PR TITLE
Get rid of Node 6 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,21 +31,6 @@ jobs:
       - store_test_results:
           path: reports/junit
 
-  test-node-6:
-    working_directory: ~/jest
-    docker:
-      - image: circleci/node:6
-    steps:
-      - checkout
-      - restore-cache: *restore-cache
-      - run: *install
-      - save-cache: *save-cache
-      - run:
-          # react-native and react-testing-library do not work with node 6
-          command: rm -rf examples/react-native examples/react-testing-library && yarn test-ci-partial
-      - store_test_results:
-          path: reports/junit
-
   test-node-8:
     working_directory: ~/jest
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,7 +118,6 @@ workflows:
   build-and-deploy:
     jobs:
       - lint-and-typecheck
-      - test-node-6
       - test-node-8
       - test-node-10
       - test-jest-circus

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Chore & Maintenance
 
-- `[*]` Drop support for Node 6 ([#8455](https://github.com/facebook/jest/pull/8455))
+- `[*]` [**BREAKING**] Drop support for Node 6 ([#8455](https://github.com/facebook/jest/pull/8455))
 - `[docs]` Fix broken link pointing to legacy JS file in "Snapshot Testing".
 
 ### Performance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Chore & Maintenance
 
+- `[*]` Drop support for Node 6 ([#8455](https://github.com/facebook/jest/pull/8455))
 - `[docs]` Fix broken link pointing to legacy JS file in "Snapshot Testing".
 
 ### Performance

--- a/babel.config.js
+++ b/babel.config.js
@@ -27,7 +27,7 @@ module.exports = {
       '@babel/preset-env',
       {
         shippedProposals: true,
-        targets: {node: 6},
+        targets: {node: 8},
       },
     ],
   ],

--- a/e2e/__tests__/__snapshots__/failures.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/failures.test.ts.snap
@@ -774,10 +774,6 @@ FAIL __tests__/assertionError.test.js
       82 | 
 
       at Object.equal (__tests__/assertionError.test.js:80:10)
-      at asyncGeneratorStep (__tests__/assertionError.test.js:10:103)
-      at _next (__tests__/assertionError.test.js:12:194)
-      at __tests__/assertionError.test.js:12:364
-      at Object.<anonymous> (__tests__/assertionError.test.js:12:97)
 `;
 
 exports[`works with snapshot failures 1`] = `

--- a/e2e/__tests__/__snapshots__/moduleNameMapper.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/moduleNameMapper.test.ts.snap
@@ -30,6 +30,6 @@ FAIL __tests__/index.js
       12 | module.exports = () => 'test';
       13 | 
 
-      at createNoMappedModuleFoundError (../../packages/jest-resolve/build/index.js:493:17)
+      at createNoMappedModuleFoundError (../../packages/jest-resolve/build/index.js:468:17)
       at Object.require (index.js:10:1)
 `;

--- a/package.json
+++ b/package.json
@@ -139,6 +139,6 @@
     "logo": "https://opencollective.com/jest/logo.txt"
   },
   "engines": {
-    "node": ">= 6"
+    "node": ">= 8"
   }
 }

--- a/packages/babel-jest/package.json
+++ b/packages/babel-jest/package.json
@@ -27,7 +27,7 @@
     "@babel/core": "^7.0.0"
   },
   "engines": {
-    "node": ">= 6"
+    "node": ">= 8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-jest-hoist/package.json
+++ b/packages/babel-plugin-jest-hoist/package.json
@@ -7,7 +7,7 @@
     "directory": "packages/babel-plugin-jest-hoist"
   },
   "engines": {
-    "node": ">= 6"
+    "node": ">= 8"
   },
   "license": "MIT",
   "main": "build/index.js",

--- a/packages/babel-preset-jest/package.json
+++ b/packages/babel-preset-jest/package.json
@@ -16,7 +16,7 @@
     "@babel/core": "^7.0.0"
   },
   "engines": {
-    "node": ">= 6"
+    "node": ">= 8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/diff-sequences/package.json
+++ b/packages/diff-sequences/package.json
@@ -16,7 +16,7 @@
     "diff"
   ],
   "engines": {
-    "node": ">= 6"
+    "node": ">= 8"
   },
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/packages/eslint-config-fb-strict/package.json
+++ b/packages/eslint-config-fb-strict/package.json
@@ -20,7 +20,7 @@
     "eslint-plugin-react": "^7.1.0"
   },
   "engines": {
-    "node": ">= 6"
+    "node": ">= 8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/expect/package.json
+++ b/packages/expect/package.json
@@ -23,7 +23,7 @@
     "immutable": "^4.0.0-rc.12"
   },
   "engines": {
-    "node": ">= 6"
+    "node": ">= 8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest-changed-files/package.json
+++ b/packages/jest-changed-files/package.json
@@ -18,7 +18,7 @@
     "@types/execa": "^0.9.0"
   },
   "engines": {
-    "node": ">= 6"
+    "node": ">= 8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest-circus/package.json
+++ b/packages/jest-circus/package.json
@@ -36,7 +36,7 @@
     "jest-runtime": "^24.9.0"
   },
   "engines": {
-    "node": ">= 6"
+    "node": ">= 8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest-cli/package.json
+++ b/packages/jest-cli/package.json
@@ -29,7 +29,7 @@
     "jest": "./bin/jest.js"
   },
   "engines": {
-    "node": ">= 6"
+    "node": ">= 8"
   },
   "repository": {
     "type": "git",

--- a/packages/jest-config/package.json
+++ b/packages/jest-config/package.json
@@ -34,7 +34,7 @@
     "@types/micromatch": "^3.1.0"
   },
   "engines": {
-    "node": ">= 6"
+    "node": ">= 8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest-console/package.json
+++ b/packages/jest-console/package.json
@@ -18,7 +18,7 @@
     "@types/slash": "^2.0.0"
   },
   "engines": {
-    "node": ">= 6"
+    "node": ">= 8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest-core/package.json
+++ b/packages/jest-core/package.json
@@ -46,7 +46,7 @@
     "@types/strip-ansi": "^3.0.0"
   },
   "engines": {
-    "node": ">= 6"
+    "node": ">= 8"
   },
   "repository": {
     "type": "git",

--- a/packages/jest-diff/package.json
+++ b/packages/jest-diff/package.json
@@ -20,7 +20,7 @@
     "strip-ansi": "^5.0.0"
   },
   "engines": {
-    "node": ">= 6"
+    "node": ">= 8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest-docblock/package.json
+++ b/packages/jest-docblock/package.json
@@ -15,7 +15,7 @@
     "@types/detect-newline": "^2.1.0"
   },
   "engines": {
-    "node": ">= 6"
+    "node": ">= 8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest-each/package.json
+++ b/packages/jest-each/package.json
@@ -25,7 +25,7 @@
     "pretty-format": "^24.9.0"
   },
   "engines": {
-    "node": ">= 6"
+    "node": ">= 8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest-environment-jsdom/package.json
+++ b/packages/jest-environment-jsdom/package.json
@@ -21,7 +21,7 @@
     "@types/jsdom": "^11.12.0"
   },
   "engines": {
-    "node": ">= 6"
+    "node": ">= 8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest-environment-node/package.json
+++ b/packages/jest-environment-node/package.json
@@ -17,7 +17,7 @@
     "jest-util": "^24.9.0"
   },
   "engines": {
-    "node": ">= 6"
+    "node": ">= 8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest-environment/package.json
+++ b/packages/jest-environment/package.json
@@ -16,7 +16,7 @@
     "jest-mock": "^24.9.0"
   },
   "engines": {
-    "node": ">= 6"
+    "node": ">= 8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest-fake-timers/package.json
+++ b/packages/jest-fake-timers/package.json
@@ -15,7 +15,7 @@
     "jest-mock": "^24.9.0"
   },
   "engines": {
-    "node": ">= 6"
+    "node": ">= 8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest-get-type/package.json
+++ b/packages/jest-get-type/package.json
@@ -8,7 +8,7 @@
     "directory": "packages/jest-get-type"
   },
   "engines": {
-    "node": ">= 6"
+    "node": ">= 8"
   },
   "license": "MIT",
   "main": "build/index.js",

--- a/packages/jest-haste-map/package.json
+++ b/packages/jest-haste-map/package.json
@@ -35,7 +35,7 @@
     "fsevents": "^1.2.7"
   },
   "engines": {
-    "node": ">= 6"
+    "node": ">= 8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest-jasmine2/package.json
+++ b/packages/jest-jasmine2/package.json
@@ -31,7 +31,7 @@
     "@types/babel__traverse": "^7.0.4"
   },
   "engines": {
-    "node": ">= 6"
+    "node": ">= 8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest-leak-detector/package.json
+++ b/packages/jest-leak-detector/package.json
@@ -18,7 +18,7 @@
     "weak": "^1.0.1"
   },
   "engines": {
-    "node": ">= 6"
+    "node": ">= 8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest-matcher-utils/package.json
+++ b/packages/jest-matcher-utils/package.json
@@ -8,7 +8,7 @@
     "directory": "packages/jest-matcher-utils"
   },
   "engines": {
-    "node": ">= 6"
+    "node": ">= 8"
   },
   "license": "MIT",
   "main": "build/index.js",

--- a/packages/jest-message-util/package.json
+++ b/packages/jest-message-util/package.json
@@ -7,7 +7,7 @@
     "directory": "packages/jest-message-util"
   },
   "engines": {
-    "node": ">= 6"
+    "node": ">= 8"
   },
   "license": "MIT",
   "main": "build/index.js",

--- a/packages/jest-mock/package.json
+++ b/packages/jest-mock/package.json
@@ -7,7 +7,7 @@
     "directory": "packages/jest-mock"
   },
   "engines": {
-    "node": ">= 6"
+    "node": ">= 8"
   },
   "dependencies": {
     "@jest/types": "^24.9.0"

--- a/packages/jest-phabricator/package.json
+++ b/packages/jest-phabricator/package.json
@@ -11,7 +11,7 @@
     "@jest/test-result": "^24.9.0"
   },
   "engines": {
-    "node": ">= 6"
+    "node": ">= 8"
   },
   "license": "MIT",
   "main": "build/index.js",

--- a/packages/jest-regex-util/package.json
+++ b/packages/jest-regex-util/package.json
@@ -7,7 +7,7 @@
     "directory": "packages/jest-regex-util"
   },
   "engines": {
-    "node": ">= 6"
+    "node": ">= 8"
   },
   "license": "MIT",
   "main": "build/index.js",

--- a/packages/jest-repl/package.json
+++ b/packages/jest-repl/package.json
@@ -25,7 +25,7 @@
     "jest-repl": "./bin/jest-repl.js"
   },
   "engines": {
-    "node": ">= 6"
+    "node": ">= 8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest-reporters/package.json
+++ b/packages/jest-reporters/package.json
@@ -41,7 +41,7 @@
     "strip-ansi": "^5.0.0"
   },
   "engines": {
-    "node": ">= 6"
+    "node": ">= 8"
   },
   "repository": {
     "type": "git",

--- a/packages/jest-resolve-dependencies/package.json
+++ b/packages/jest-resolve-dependencies/package.json
@@ -20,7 +20,7 @@
     "jest-runtime": "^24.9.0"
   },
   "engines": {
-    "node": ">= 6"
+    "node": ">= 8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest-resolve/package.json
+++ b/packages/jest-resolve/package.json
@@ -21,7 +21,7 @@
     "jest-haste-map": "^24.9.0"
   },
   "engines": {
-    "node": ">= 6"
+    "node": ">= 8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest-runner/package.json
+++ b/packages/jest-runner/package.json
@@ -36,7 +36,7 @@
     "@types/source-map-support": "^0.5.0"
   },
   "engines": {
-    "node": ">= 6"
+    "node": ">= 8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest-runtime/package.json
+++ b/packages/jest-runtime/package.json
@@ -46,7 +46,7 @@
     "jest-runtime": "./bin/jest-runtime.js"
   },
   "engines": {
-    "node": ">= 6"
+    "node": ">= 8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest-serializer/package.json
+++ b/packages/jest-serializer/package.json
@@ -7,7 +7,7 @@
     "directory": "packages/jest-serializer"
   },
   "engines": {
-    "node": ">= 6"
+    "node": ">= 8"
   },
   "license": "MIT",
   "main": "build/index.js",

--- a/packages/jest-serializer/src/__tests__/index.test.ts
+++ b/packages/jest-serializer/src/__tests__/index.test.ts
@@ -10,7 +10,6 @@
 import * as fs from 'fs';
 import {tmpdir} from 'os';
 import * as path from 'path';
-import v8 from 'v8';
 import prettyFormat from 'pretty-format';
 
 import serializer from '..';

--- a/packages/jest-serializer/src/__tests__/index.test.ts
+++ b/packages/jest-serializer/src/__tests__/index.test.ts
@@ -15,17 +15,6 @@ import prettyFormat from 'pretty-format';
 
 import serializer from '..';
 
-const v8s = [
-  {
-    deserialize: v8.deserialize,
-    serialize: v8.serialize,
-  },
-  {
-    deserialize: undefined,
-    serialize: undefined,
-  },
-];
-
 const objs = [
   3,
   null,
@@ -48,45 +37,35 @@ afterEach(() => {
   }
 });
 
-// We execute the same suite of tests over multiple objects ("objs") and over
-// multiple mocks of the V8 object ("v8s") so that we verify that all possible
-// encodings and cases work.
-v8s.forEach((mockV8, i) => {
-  describe('Using V8 implementation ' + i, () => {
-    beforeEach(() => {
-      v8.serialize = mockV8.serialize;
-      v8.deserialize = mockV8.deserialize;
-    });
+describe('Using V8 implementation', () => {
+  it('throws the error with an invalid serialization', () => {
+    // No chance this is a valid serialization, neither in JSON nor V8.
+    const invalidBuffer = Buffer.from([0, 85, 170, 255]);
 
-    it('throws the error with an invalid serialization', () => {
-      // No chance this is a valid serialization, neither in JSON nor V8.
-      const invalidBuffer = Buffer.from([0, 85, 170, 255]);
+    fs.writeFileSync(file, invalidBuffer);
 
-      fs.writeFileSync(file, invalidBuffer);
+    expect(() => serializer.deserialize(invalidBuffer)).toThrow();
+    expect(() => serializer.readFileSync(file)).toThrow();
+  });
 
-      expect(() => serializer.deserialize(invalidBuffer)).toThrow();
-      expect(() => serializer.readFileSync(file)).toThrow();
-    });
+  objs.forEach((obj, i) => {
+    describe('Object ' + i, () => {
+      it('serializes/deserializes in memory', () => {
+        const buf = serializer.serialize(obj);
 
-    objs.forEach((obj, i) => {
-      describe('Object ' + i, () => {
-        it('serializes/deserializes in memory', () => {
-          const buf = serializer.serialize(obj);
+        expect(buf).toBeInstanceOf(Buffer);
 
-          expect(buf).toBeInstanceOf(Buffer);
+        expect(prettyFormat(serializer.deserialize(buf))).toEqual(
+          prettyFormat(obj),
+        );
+      });
 
-          expect(prettyFormat(serializer.deserialize(buf))).toEqual(
-            prettyFormat(obj),
-          );
-        });
+      it('serializes/deserializes in disk', () => {
+        serializer.writeFileSync(file, obj);
 
-        it('serializes/deserializes in disk', () => {
-          serializer.writeFileSync(file, obj);
-
-          expect(prettyFormat(serializer.readFileSync(file))).toEqual(
-            prettyFormat(obj),
-          );
-        });
+        expect(prettyFormat(serializer.readFileSync(file))).toEqual(
+          prettyFormat(obj),
+        );
       });
     });
   });

--- a/packages/jest-serializer/src/index.ts
+++ b/packages/jest-serializer/src/index.ts
@@ -17,126 +17,24 @@ type Path = string;
 // the versions are compatible by encoding the serialization version in the own
 // generated buffer.
 
-const JS_TYPE = '__$t__';
-const JS_VALUE = '__$v__';
-const JS_VF = '__$f__';
-
-function replacer(_key: string, value: any): any {
-  // NaN cannot be in a switch statement, because NaN !== NaN.
-  if (Number.isNaN(value)) {
-    return {[JS_TYPE]: 'n'};
-  }
-
-  switch (value) {
-    case undefined:
-      return {[JS_TYPE]: 'u'};
-    case +Infinity:
-      return {[JS_TYPE]: '+'};
-    case -Infinity:
-      return {[JS_TYPE]: '-'};
-  }
-
-  switch (value && value.constructor) {
-    case Date:
-      return {[JS_TYPE]: 'd', [JS_VALUE]: value.getTime()};
-    case RegExp:
-      return {[JS_TYPE]: 'r', [JS_VALUE]: value.source, [JS_VF]: value.flags};
-    case Set:
-      return {[JS_TYPE]: 's', [JS_VALUE]: Array.from(value)};
-    case Map:
-      return {[JS_TYPE]: 'm', [JS_VALUE]: Array.from(value)};
-    case Buffer:
-      return {[JS_TYPE]: 'b', [JS_VALUE]: value.toString('latin1')};
-  }
-
-  return value;
-}
-
-function reviver(_key: string, value: any): any {
-  if (!value || (typeof value !== 'object' && !value.hasOwnProperty(JS_TYPE))) {
-    return value;
-  }
-
-  switch (value[JS_TYPE]) {
-    case 'u':
-      return undefined;
-    case 'n':
-      return NaN;
-    case '+':
-      return +Infinity;
-    case '-':
-      return -Infinity;
-    case 'd':
-      return new Date(value[JS_VALUE]);
-    case 'r':
-      return new RegExp(value[JS_VALUE], value[JS_VF]);
-    case 's':
-      return new Set(value[JS_VALUE]);
-    case 'm':
-      return new Map(value[JS_VALUE]);
-    case 'b':
-      return Buffer.from(value[JS_VALUE], 'latin1');
-  }
-
-  return value;
-}
-
-function jsonStringify(content: unknown) {
-  // Not pretty, but the ES JSON spec says that "toJSON" will be called before
-  // getting into your replacer, so we have to remove them beforehand. See
-  // https://www.ecma-international.org/ecma-262/#sec-serializejsonproperty
-  // section 2.b for more information.
-
-  const dateToJSON = Date.prototype.toJSON;
-  const bufferToJSON = Buffer.prototype.toJSON;
-
-  /* eslint-disable no-extend-native */
-
-  try {
-    // @ts-ignore intentional removal of "toJSON" property.
-    Date.prototype.toJSON = undefined;
-    // @ts-ignore intentional removal of "toJSON" property.
-    Buffer.prototype.toJSON = undefined;
-
-    return JSON.stringify(content, replacer);
-  } finally {
-    Date.prototype.toJSON = dateToJSON;
-    Buffer.prototype.toJSON = bufferToJSON;
-  }
-
-  /* eslint-enable no-extend-native */
-}
-
-function jsonParse(content: string) {
-  return JSON.parse(content, reviver);
-}
-
 // In memory functions.
 
 export function deserialize(buffer: Buffer): any {
-  return v8.deserialize
-    ? v8.deserialize(buffer)
-    : jsonParse(buffer.toString('utf8'));
+  return v8.deserialize(buffer);
 }
 
 export function serialize(content: unknown): Buffer {
-  return v8.serialize
-    ? v8.serialize(content)
-    : Buffer.from(jsonStringify(content));
+  return v8.serialize(content);
 }
 
 // Synchronous filesystem functions.
 
 export function readFileSync(filePath: Path): any {
-  return v8.deserialize
-    ? v8.deserialize(fs.readFileSync(filePath))
-    : jsonParse(fs.readFileSync(filePath, 'utf8'));
+  return v8.deserialize(fs.readFileSync(filePath));
 }
 
 export function writeFileSync(filePath: Path, content: any) {
-  return v8.serialize
-    ? fs.writeFileSync(filePath, v8.serialize(content))
-    : fs.writeFileSync(filePath, jsonStringify(content), 'utf8');
+  return fs.writeFileSync(filePath, v8.serialize(content));
 }
 
 export default {

--- a/packages/jest-snapshot/package.json
+++ b/packages/jest-snapshot/package.json
@@ -34,7 +34,7 @@
     "prettier": "^1.13.4"
   },
   "engines": {
-    "node": ">= 6"
+    "node": ">= 8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest-source-map/package.json
+++ b/packages/jest-source-map/package.json
@@ -18,7 +18,7 @@
     "@types/graceful-fs": "^4.1.2"
   },
   "engines": {
-    "node": ">= 6"
+    "node": ">= 8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest-test-result/package.json
+++ b/packages/jest-test-result/package.json
@@ -15,7 +15,7 @@
     "@types/istanbul-lib-coverage": "^2.0.0"
   },
   "engines": {
-    "node": ">= 6"
+    "node": ">= 8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest-test-sequencer/package.json
+++ b/packages/jest-test-sequencer/package.json
@@ -16,7 +16,7 @@
     "jest-runtime": "^24.9.0"
   },
   "engines": {
-    "node": ">= 6"
+    "node": ">= 8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest-transform/package.json
+++ b/packages/jest-transform/package.json
@@ -35,7 +35,7 @@
     "@types/write-file-atomic": "^2.1.1"
   },
   "engines": {
-    "node": ">= 6"
+    "node": ">= 8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest-types/package.json
+++ b/packages/jest-types/package.json
@@ -7,7 +7,7 @@
     "directory": "packages/jest-types"
   },
   "engines": {
-    "node": ">= 6"
+    "node": ">= 8"
   },
   "license": "MIT",
   "main": "build/index.js",

--- a/packages/jest-util/package.json
+++ b/packages/jest-util/package.json
@@ -30,7 +30,7 @@
     "@types/slash": "^2.0.0"
   },
   "engines": {
-    "node": ">= 6"
+    "node": ">= 8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest-util/src/deepCyclicCopy.ts
+++ b/packages/jest-util/src/deepCyclicCopy.ts
@@ -12,23 +12,6 @@ export type DeepCyclicCopyOptions = {
   keepPrototype?: boolean;
 };
 
-// Node 6 does not have gOPDs, so we define a simple polyfill for it.
-if (!Object.getOwnPropertyDescriptors) {
-  // @ts-ignore: polyfill
-  Object.getOwnPropertyDescriptors = obj => {
-    const list: Record<string, PropertyDescriptor | undefined> = {};
-
-    (Object.getOwnPropertyNames(obj) as Array<string | symbol>)
-      .concat(Object.getOwnPropertySymbols(obj))
-      .forEach(key => {
-        // @ts-ignore: assignment with a Symbol is OK.
-        list[key] = Object.getOwnPropertyDescriptor(obj, key);
-      });
-
-    return list;
-  };
-}
-
 export default function deepCyclicCopy<T>(
   value: T,
   options: DeepCyclicCopyOptions = {blacklist: EMPTY, keepPrototype: false},

--- a/packages/jest-validate/package.json
+++ b/packages/jest-validate/package.json
@@ -18,7 +18,7 @@
     "pretty-format": "^24.9.0"
   },
   "engines": {
-    "node": ">= 6"
+    "node": ">= 8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest-watcher/package.json
+++ b/packages/jest-watcher/package.json
@@ -25,7 +25,7 @@
     "url": "https://github.com/facebook/jest/issues"
   },
   "engines": {
-    "node": ">= 6"
+    "node": ">= 8"
   },
   "homepage": "https://jestjs.io/",
   "license": "MIT",

--- a/packages/jest-worker/package.json
+++ b/packages/jest-worker/package.json
@@ -20,7 +20,7 @@
     "worker-farm": "^1.6.0"
   },
   "engines": {
-    "node": ">= 6"
+    "node": ">= 8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -12,7 +12,7 @@
     "jest": "./bin/jest.js"
   },
   "engines": {
-    "node": ">= 6"
+    "node": ">= 8"
   },
   "repository": {
     "type": "git",

--- a/packages/pretty-format/package.json
+++ b/packages/pretty-format/package.json
@@ -30,7 +30,7 @@
     "react-test-renderer": "*"
   },
   "engines": {
-    "node": ">= 6"
+    "node": ">= 8"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary
Nodejs team stop support of `node 6` since 30 april.
I propose to remove support for `node 6`.
Many projects have already removed support of this version. For example `Angular`, `Webpack 5 alpha`, `ts-loader`.

Also i removed polyfill for `v8.serialize` because it supports since `node 8`
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
