### PR TITLE
feat: set global timeout in command line argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - `[expect]` Highlight substring differences when matcher fails, part 1 ([#8448](https://github.com/facebook/jest/pull/8448))
 - `[jest-cli]` Improve chai support (with detailed output, to match jest exceptions) ([#8454](https://github.com/facebook/jest/pull/8454))
+- `[*]` Manage the global timeout with `--timeout` command line argument. ([#8456](https://github.com/facebook/jest/pull/8456))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - `[expect]` Highlight substring differences when matcher fails, part 1 ([#8448](https://github.com/facebook/jest/pull/8448))
 - `[jest-cli]` Improve chai support (with detailed output, to match jest exceptions) ([#8454](https://github.com/facebook/jest/pull/8454))
-- `[*]` Manage the global timeout with `--timeout` command line argument. ([#8456](https://github.com/facebook/jest/pull/8456))
+- `[*]` Manage the global timeout with `--testTimeout` command line argument. ([#8456](https://github.com/facebook/jest/pull/8456))
 
 ### Fixes
 

--- a/TestUtils.ts
+++ b/TestUtils.ts
@@ -55,6 +55,7 @@ const DEFAULT_GLOBAL_CONFIG: Config.GlobalConfig = {
   testNamePattern: '',
   testPathPattern: '',
   testResultsProcessor: null,
+  timeout: 5000,
   updateSnapshot: 'none',
   useStderr: false,
   verbose: false,

--- a/TestUtils.ts
+++ b/TestUtils.ts
@@ -55,7 +55,7 @@ const DEFAULT_GLOBAL_CONFIG: Config.GlobalConfig = {
   testNamePattern: '',
   testPathPattern: '',
   testResultsProcessor: null,
-  timeout: 5000,
+  testTimeout: 5000,
   updateSnapshot: 'none',
   useStderr: false,
   verbose: false,

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -301,9 +301,9 @@ Lets you specify a custom test runner.
 
 Lets you specify a custom test sequencer. Please refer to the documentation of the corresponding configuration property for details.
 
-### `--timeout=<number>`
+### `--testTimeout=<number>`
 
-Default timeout of the test case. If the value is 0 then the timeout is 1 193 days.
+Default timeout of a test. If the value is 0 then the timeout is ~1 193 days.
 
 ### `--updateSnapshot`
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -301,6 +301,10 @@ Lets you specify a custom test runner.
 
 Lets you specify a custom test sequencer. Please refer to the documentation of the corresponding configuration property for details.
 
+### `--timeout=<number>`
+
+Default timeout of the test case. If the value is 0 then the timeout is 1 193 days.
+
 ### `--updateSnapshot`
 
 Alias: `-u`. Use this flag to re-record every snapshot that fails during this test run. Can be used together with a test suite pattern or with `--testNamePattern` to re-record snapshots.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -303,7 +303,7 @@ Lets you specify a custom test sequencer. Please refer to the documentation of t
 
 ### `--testTimeout=<number>`
 
-Default timeout of a test in milliseconds.
+Default timeout of a test in milliseconds. Default value: 5000.
 
 ### `--updateSnapshot`
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -303,7 +303,7 @@ Lets you specify a custom test sequencer. Please refer to the documentation of t
 
 ### `--testTimeout=<number>`
 
-Default timeout of a test. If the value is 0 then the timeout is ~1 193 days.
+Default timeout of a test in milliseconds.
 
 ### `--updateSnapshot`
 

--- a/e2e/__tests__/__snapshots__/timeouts.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/timeouts.test.ts.snap
@@ -21,7 +21,7 @@ Time:        <<REPLACED>>
 Ran all test suites.
 `;
 
-exports[`exceeds the command line timeout 1`] = `
+exports[`exceeds the command line testTimeout 1`] = `
 Test Suites: 1 failed, 1 total
 Tests:       1 failed, 1 total
 Snapshots:   0 total
@@ -29,12 +29,12 @@ Time:        <<REPLACED>>
 Ran all test suites.
 `;
 
-exports[`does not exceed the command line timeout 1`] = `
+exports[`does not exceed the command line testTimeout 1`] = `
 PASS __tests__/a-banana.js
   ✓ banana
 `;
 
-exports[`does not exceed the command line timeout 2`] = `
+exports[`does not exceed the command line testTimeout 2`] = `
 Test Suites: 1 passed, 1 total
 Tests:       1 passed, 1 total
 Snapshots:   0 total
@@ -42,12 +42,12 @@ Time:        <<REPLACED>>
 Ran all test suites.
 `;
 
-exports[`if command line timeout=0 its mean no timeout 1`] = `
+exports[`if command line timeout=0 its mean no testTimeout 1`] = `
 PASS __tests__/a-banana.js
   ✓ banana
 `;
 
-exports[`if command line timeout=0 its mean no timeout 2`] = `
+exports[`if command line timeout=0 its mean no testTimeout 2`] = `
 Test Suites: 1 passed, 1 total
 Tests:       1 passed, 1 total
 Snapshots:   0 total

--- a/e2e/__tests__/__snapshots__/timeouts.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/timeouts.test.ts.snap
@@ -1,34 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`does not exceed the timeout 1`] = `
-PASS __tests__/a-banana.js
-  ✓ banana
-`;
-
-exports[`does not exceed the timeout 2`] = `
-Test Suites: 1 passed, 1 total
-Tests:       1 passed, 1 total
-Snapshots:   0 total
-Time:        <<REPLACED>>
-Ran all test suites.
-`;
-
-exports[`exceeds the timeout 1`] = `
-Test Suites: 1 failed, 1 total
-Tests:       1 failed, 1 total
-Snapshots:   0 total
-Time:        <<REPLACED>>
-Ran all test suites.
-`;
-
-exports[`exceeds the command line testTimeout 1`] = `
-Test Suites: 1 failed, 1 total
-Tests:       1 failed, 1 total
-Snapshots:   0 total
-Time:        <<REPLACED>>
-Ran all test suites.
-`;
-
 exports[`does not exceed the command line testTimeout 1`] = `
 PASS __tests__/a-banana.js
   ✓ banana
@@ -42,9 +13,33 @@ Time:        <<REPLACED>>
 Ran all test suites.
 `;
 
-exports[`if command line timeout=0 its mean no testTimeout 1`] = `
+exports[`does not exceed the timeout 1`] = `
 PASS __tests__/a-banana.js
   ✓ banana
+`;
+
+exports[`does not exceed the timeout 2`] = `
+Test Suites: 1 passed, 1 total
+Tests:       1 passed, 1 total
+Snapshots:   0 total
+Time:        <<REPLACED>>
+Ran all test suites.
+`;
+
+exports[`exceeds the command line testTimeout 1`] = `
+Test Suites: 1 failed, 1 total
+Tests:       1 failed, 1 total
+Snapshots:   0 total
+Time:        <<REPLACED>>
+Ran all test suites.
+`;
+
+exports[`exceeds the timeout 1`] = `
+Test Suites: 1 failed, 1 total
+Tests:       1 failed, 1 total
+Snapshots:   0 total
+Time:        <<REPLACED>>
+Ran all test suites.
 `;
 
 exports[`if command line timeout=0 its mean no testTimeout 2`] = `

--- a/e2e/__tests__/__snapshots__/timeouts.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/timeouts.test.ts.snap
@@ -20,3 +20,37 @@ Snapshots:   0 total
 Time:        <<REPLACED>>
 Ran all test suites.
 `;
+
+exports[`exceeds the command line timeout 1`] = `
+Test Suites: 1 failed, 1 total
+Tests:       1 failed, 1 total
+Snapshots:   0 total
+Time:        <<REPLACED>>
+Ran all test suites.
+`;
+
+exports[`does not exceed the command line timeout 1`] = `
+PASS __tests__/a-banana.js
+  ✓ banana
+`;
+
+exports[`does not exceed the command line timeout 2`] = `
+Test Suites: 1 passed, 1 total
+Tests:       1 passed, 1 total
+Snapshots:   0 total
+Time:        <<REPLACED>>
+Ran all test suites.
+`;
+
+exports[`if command line timeout=0 its mean no timeout 1`] = `
+PASS __tests__/a-banana.js
+  ✓ banana
+`;
+
+exports[`if command line timeout=0 its mean no timeout 2`] = `
+Test Suites: 1 passed, 1 total
+Tests:       1 passed, 1 total
+Snapshots:   0 total
+Time:        <<REPLACED>>
+Ran all test suites.
+`;

--- a/e2e/__tests__/__snapshots__/timeouts.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/timeouts.test.ts.snap
@@ -41,11 +41,3 @@ Snapshots:   0 total
 Time:        <<REPLACED>>
 Ran all test suites.
 `;
-
-exports[`if command line timeout=0 its mean no testTimeout 2`] = `
-Test Suites: 1 passed, 1 total
-Tests:       1 passed, 1 total
-Snapshots:   0 total
-Time:        <<REPLACED>>
-Ran all test suites.
-`;

--- a/e2e/__tests__/timeouts.test.ts
+++ b/e2e/__tests__/timeouts.test.ts
@@ -61,7 +61,7 @@ test('does not exceed the timeout', () => {
   expect(status).toBe(0);
 });
 
-test('exceeds the command line timeout', () => {
+test('exceeds the command line testTimeout', () => {
   writeFiles(DIR, {
     '__tests__/a-banana.js': `
 
@@ -77,7 +77,7 @@ test('exceeds the command line timeout', () => {
   const {stderr, status} = runJest(DIR, [
     '-w=1',
     '--ci=false',
-    '--timeout=200',
+    '--testTimeout=200',
   ]);
   const {rest, summary} = extractSummary(stderr);
   expect(rest).toMatch(
@@ -87,7 +87,7 @@ test('exceeds the command line timeout', () => {
   expect(status).toBe(1);
 });
 
-test('does not exceed the command line timeout', () => {
+test('does not exceed the command line testTimeout', () => {
   writeFiles(DIR, {
     '__tests__/a-banana.js': `
 
@@ -103,7 +103,7 @@ test('does not exceed the command line timeout', () => {
   const {stderr, status} = runJest(DIR, [
     '-w=1',
     '--ci=false',
-    '--timeout=1000',
+    '--testTimeout=1000',
   ]);
   const {rest, summary} = extractSummary(stderr);
   expect(wrap(rest)).toMatchSnapshot();
@@ -111,7 +111,7 @@ test('does not exceed the command line timeout', () => {
   expect(status).toBe(0);
 });
 
-test('if command line timeout=0 its mean no timeout', () => {
+test('if command line timeout=0 its mean no testTimeout', () => {
   writeFiles(DIR, {
     '__tests__/a-banana.js': `
 
@@ -124,7 +124,11 @@ test('if command line timeout=0 its mean no timeout', () => {
     'package.json': '{}',
   });
 
-  const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', '--timeout=0']);
+  const {stderr, status} = runJest(DIR, [
+    '-w=1',
+    '--ci=false',
+    '--testTimeout=0',
+  ]);
   const {rest, summary} = extractSummary(stderr);
   expect(wrap(rest)).toMatchSnapshot();
   expect(wrap(summary)).toMatchSnapshot();

--- a/e2e/__tests__/timeouts.test.ts
+++ b/e2e/__tests__/timeouts.test.ts
@@ -110,27 +110,3 @@ test('does not exceed the command line testTimeout', () => {
   expect(wrap(summary)).toMatchSnapshot();
   expect(status).toBe(0);
 });
-
-test('if command line timeout=0 its mean no testTimeout', () => {
-  writeFiles(DIR, {
-    '__tests__/a-banana.js': `
-
-      test('banana', () => {
-        return new Promise(resolve => {
-          setTimeout(resolve, 6000);
-        });
-      });
-    `,
-    'package.json': '{}',
-  });
-
-  const {stderr, status} = runJest(DIR, [
-    '-w=1',
-    '--ci=false',
-    '--testTimeout=0',
-  ]);
-  const {rest, summary} = extractSummary(stderr);
-  expect(wrap(rest)).toMatchSnapshot();
-  expect(wrap(summary)).toMatchSnapshot();
-  expect(status).toBe(0);
-});

--- a/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapterInit.ts
+++ b/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapterInit.ts
@@ -47,8 +47,9 @@ export const initialize = ({
   testPath: Config.Path;
   parentProcess: Process;
 }) => {
-  if (globalConfig.testTimeout)
+  if (globalConfig.testTimeout) {
     getRunnerState().testTimeout = globalConfig.testTimeout;
+  }
 
   const mutex = throat(globalConfig.maxConcurrency);
 

--- a/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapterInit.ts
+++ b/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapterInit.ts
@@ -47,7 +47,8 @@ export const initialize = ({
   testPath: Config.Path;
   parentProcess: Process;
 }) => {
-  if (globalConfig.timeout) getRunnerState().testTimeout = globalConfig.timeout;
+  if (globalConfig.testTimeout)
+    getRunnerState().testTimeout = globalConfig.testTimeout;
 
   const mutex = throat(globalConfig.maxConcurrency);
 

--- a/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapterInit.ts
+++ b/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapterInit.ts
@@ -16,7 +16,12 @@ import {
   buildSnapshotResolver,
 } from 'jest-snapshot';
 import throat from 'throat';
-import {addEventHandler, dispatch, ROOT_DESCRIBE_BLOCK_NAME} from '../state';
+import {
+  addEventHandler,
+  dispatch,
+  getState as getRunnerState,
+  ROOT_DESCRIBE_BLOCK_NAME,
+} from '../state';
 import {getTestID} from '../utils';
 import run from '../run';
 import globals from '..';
@@ -42,6 +47,8 @@ export const initialize = ({
   testPath: Config.Path;
   parentProcess: Process;
 }) => {
+  if (globalConfig.timeout) getRunnerState().testTimeout = globalConfig.timeout;
+
   const mutex = throat(globalConfig.maxConcurrency);
 
   Object.assign(global, globals);

--- a/packages/jest-cli/src/cli/args.ts
+++ b/packages/jest-cli/src/cli/args.ts
@@ -626,6 +626,12 @@ export const options = {
     description: 'This option sets the URL for the jsdom environment.',
     type: 'string' as 'string',
   },
+  timeout: {
+    description:
+      'This option sets the default timeouts of test cases.' +
+      "If you don't want timeout set it to 0",
+    type: 'number' as 'number',
+  },
   timers: {
     description:
       'Setting this value to fake allows the use of fake timers ' +

--- a/packages/jest-cli/src/cli/args.ts
+++ b/packages/jest-cli/src/cli/args.ts
@@ -622,15 +622,15 @@ export const options = {
       'provided: `<rootDir>/path/to/testSequencer.js`',
     type: 'string' as 'string',
   },
-  testURL: {
-    description: 'This option sets the URL for the jsdom environment.',
-    type: 'string' as 'string',
-  },
-  timeout: {
+  testTimeout: {
     description:
       'This option sets the default timeouts of test cases.' +
       "If you don't want timeout set it to 0",
     type: 'number' as 'number',
+  },
+  testURL: {
+    description: 'This option sets the URL for the jsdom environment.',
+    type: 'string' as 'string',
   },
   timers: {
     description:

--- a/packages/jest-cli/src/cli/args.ts
+++ b/packages/jest-cli/src/cli/args.ts
@@ -623,9 +623,7 @@ export const options = {
     type: 'string' as 'string',
   },
   testTimeout: {
-    description:
-      'This option sets the default timeouts of test cases.' +
-      "If you don't want timeout set it to 0",
+    description: 'This option sets the default timeouts of test cases.',
     type: 'number' as 'number',
   },
   testURL: {

--- a/packages/jest-config/src/ValidConfig.ts
+++ b/packages/jest-config/src/ValidConfig.ts
@@ -114,6 +114,7 @@ const initialOptions: Config.InitialOptions = {
   testRunner: 'jasmine2',
   testSequencer: '@jest/test-sequencer',
   testURL: 'http://localhost',
+  timeout: 5000,
   timers: 'real',
   transform: {
     '^.+\\.js$': '<rootDir>/preprocessor.js',

--- a/packages/jest-config/src/ValidConfig.ts
+++ b/packages/jest-config/src/ValidConfig.ts
@@ -113,8 +113,8 @@ const initialOptions: Config.InitialOptions = {
   testResultsProcessor: 'processor-node-module',
   testRunner: 'jasmine2',
   testSequencer: '@jest/test-sequencer',
+  testTimeout: 5000,
   testURL: 'http://localhost',
-  timeout: 5000,
   timers: 'real',
   transform: {
     '^.+\\.js$': '<rootDir>/preprocessor.js',

--- a/packages/jest-config/src/__tests__/__snapshots__/normalize.test.js.snap
+++ b/packages/jest-config/src/__tests__/__snapshots__/normalize.test.js.snap
@@ -168,6 +168,16 @@ exports[`testPathPattern <regexForTestFiles> ignores invalid regular expressions
 
 exports[`testPathPattern --testPathPattern ignores invalid regular expressions and logs a warning 1`] = `"<red>  Invalid testPattern a( supplied. Running all tests instead.</>"`;
 
+exports[`testTimeout should throw an error if timeout is a negative number 1`] = `
+"<red><bold><bold>● <bold>Validation Error</>:</>
+<red></>
+<red>  Option \\"<bold>testTimeout</>\\" must be a natural number.</>
+<red></>
+<red>  <bold>Configuration Documentation:</></>
+<red>  https://jestjs.io/docs/configuration.html</>
+<red></>"
+`;
+
 exports[`watchPlugins throw error when a watch plugin is not found 1`] = `
 "<red><bold><bold>● <bold>Validation Error</>:</>
 <red></>

--- a/packages/jest-config/src/__tests__/normalize.test.js
+++ b/packages/jest-config/src/__tests__/normalize.test.js
@@ -1572,9 +1572,9 @@ describe('testTimeout', () => {
     expect(console.warn).not.toHaveBeenCalled();
   });
 
-  it('should return with 2^32 -1 if timeout=0', () => {
-    const {options} = normalize({rootDir: '/root/', testTimeout: 0}, {});
-
-    expect(options.testTimeout).toBe(Math.pow(2, 31) - 1);
+  it('should throw an error if timeout is a negative number', () => {
+    expect(() =>
+      normalize({rootDir: '/root/', testTimeout: -1}, {}),
+    ).toThrowErrorMatchingSnapshot();
   });
 });

--- a/packages/jest-config/src/__tests__/normalize.test.js
+++ b/packages/jest-config/src/__tests__/normalize.test.js
@@ -1563,18 +1563,18 @@ describe('displayName', () => {
   );
 });
 
-describe('timeout', () => {
+describe('testTimeout', () => {
   it('should return timeout value if defined', () => {
     console.warn.mockImplementation(() => {});
-    const {options} = normalize({rootDir: '/root/', timeout: 1000}, {});
+    const {options} = normalize({rootDir: '/root/', testTimeout: 1000}, {});
 
-    expect(options.timeout).toBe(1000);
+    expect(options.testTimeout).toBe(1000);
     expect(console.warn).not.toHaveBeenCalled();
   });
 
   it('should return with 2^32 -1 if timeout=0', () => {
-    const {options} = normalize({rootDir: '/root/', timeout: 0}, {});
+    const {options} = normalize({rootDir: '/root/', testTimeout: 0}, {});
 
-    expect(options.timeout).toBe(Math.pow(2, 31) - 1);
+    expect(options.testTimeout).toBe(Math.pow(2, 31) - 1);
   });
 });

--- a/packages/jest-config/src/__tests__/normalize.test.js
+++ b/packages/jest-config/src/__tests__/normalize.test.js
@@ -1562,3 +1562,19 @@ describe('displayName', () => {
     },
   );
 });
+
+describe('timeout', () => {
+  it('should return timeout value if defined', () => {
+    console.warn.mockImplementation(() => {});
+    const {options} = normalize({rootDir: '/root/', timeout: 1000}, {});
+
+    expect(options.timeout).toBe(1000);
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+
+  it('should return with 2^32 -1 if timeout=0', () => {
+    const {options} = normalize({rootDir: '/root/', timeout: 0}, {});
+
+    expect(options.timeout).toBe(Math.pow(2, 31) - 1);
+  });
+});

--- a/packages/jest-config/src/index.ts
+++ b/packages/jest-config/src/index.ts
@@ -149,6 +149,7 @@ const groupOptions = (
     testPathPattern: options.testPathPattern,
     testResultsProcessor: options.testResultsProcessor,
     testSequencer: options.testSequencer,
+    timeout: options.timeout,
     updateSnapshot: options.updateSnapshot,
     useStderr: options.useStderr,
     verbose: options.verbose,

--- a/packages/jest-config/src/index.ts
+++ b/packages/jest-config/src/index.ts
@@ -149,7 +149,7 @@ const groupOptions = (
     testPathPattern: options.testPathPattern,
     testResultsProcessor: options.testResultsProcessor,
     testSequencer: options.testSequencer,
-    timeout: options.timeout,
+    testTimeout: options.testTimeout,
     updateSnapshot: options.updateSnapshot,
     useStderr: options.useStderr,
     verbose: options.verbose,

--- a/packages/jest-config/src/normalize.ts
+++ b/packages/jest-config/src/normalize.ts
@@ -40,6 +40,7 @@ import VALID_CONFIG from './ValidConfig';
 const ERROR = `${BULLET}Validation Error`;
 const PRESET_EXTENSIONS = ['.json', '.js'];
 const PRESET_NAME = 'jest-preset';
+const MAX_32_BIT_SIGNED_INTEGER = Math.pow(2, 31) - 1;
 
 type AllOptions = Config.ProjectConfig & Config.GlobalConfig;
 
@@ -787,6 +788,11 @@ export default function normalize(
           }
         }
         value = oldOptions[key];
+        break;
+      }
+      case 'timeout': {
+        value =
+          oldOptions[key] === 0 ? MAX_32_BIT_SIGNED_INTEGER : oldOptions[key];
         break;
       }
       case 'automock':

--- a/packages/jest-config/src/normalize.ts
+++ b/packages/jest-config/src/normalize.ts
@@ -40,7 +40,6 @@ import VALID_CONFIG from './ValidConfig';
 const ERROR = `${BULLET}Validation Error`;
 const PRESET_EXTENSIONS = ['.json', '.js'];
 const PRESET_NAME = 'jest-preset';
-const MAX_32_BIT_SIGNED_INTEGER = Math.pow(2, 31) - 1;
 
 type AllOptions = Config.ProjectConfig & Config.GlobalConfig;
 
@@ -791,8 +790,13 @@ export default function normalize(
         break;
       }
       case 'testTimeout': {
-        value =
-          oldOptions[key] === 0 ? MAX_32_BIT_SIGNED_INTEGER : oldOptions[key];
+        if (oldOptions[key] < 0) {
+          throw createConfigError(
+            `  Option "${chalk.bold('testTimeout')}" must be a natural number.`,
+          );
+        }
+
+        value = oldOptions[key];
         break;
       }
       case 'automock':

--- a/packages/jest-config/src/normalize.ts
+++ b/packages/jest-config/src/normalize.ts
@@ -790,7 +790,7 @@ export default function normalize(
         value = oldOptions[key];
         break;
       }
-      case 'timeout': {
+      case 'testTimeout': {
         value =
           oldOptions[key] === 0 ? MAX_32_BIT_SIGNED_INTEGER : oldOptions[key];
         break;

--- a/packages/jest-core/src/lib/__tests__/__snapshots__/log_debug_messages.test.ts.snap
+++ b/packages/jest-core/src/lib/__tests__/__snapshots__/log_debug_messages.test.ts.snap
@@ -112,6 +112,7 @@ exports[`prints the config object 1`] = `
     "testNamePattern": "",
     "testPathPattern": "",
     "testResultsProcessor": null,
+    "timeout": 5000,
     "updateSnapshot": "none",
     "useStderr": false,
     "verbose": false,

--- a/packages/jest-core/src/lib/__tests__/__snapshots__/log_debug_messages.test.ts.snap
+++ b/packages/jest-core/src/lib/__tests__/__snapshots__/log_debug_messages.test.ts.snap
@@ -112,7 +112,7 @@ exports[`prints the config object 1`] = `
     "testNamePattern": "",
     "testPathPattern": "",
     "testResultsProcessor": null,
-    "timeout": 5000,
+    "testTimeout": 5000,
     "updateSnapshot": "none",
     "useStderr": false,
     "verbose": false,

--- a/packages/jest-jasmine2/src/index.ts
+++ b/packages/jest-jasmine2/src/index.ts
@@ -32,6 +32,7 @@ async function jasmine2(
   const reporter = new JasmineReporter(globalConfig, config, testPath);
   const jasmineFactory = runtime.requireInternalModule(JASMINE);
   const jasmine = jasmineFactory.create({
+    globalConfig,
     process,
     testPath,
   });

--- a/packages/jest-jasmine2/src/index.ts
+++ b/packages/jest-jasmine2/src/index.ts
@@ -32,9 +32,9 @@ async function jasmine2(
   const reporter = new JasmineReporter(globalConfig, config, testPath);
   const jasmineFactory = runtime.requireInternalModule(JASMINE);
   const jasmine = jasmineFactory.create({
-    globalConfig,
     process,
     testPath,
+    testTimeout: globalConfig.testTimeout,
   });
 
   const env = jasmine.getEnv();

--- a/packages/jest-jasmine2/src/jasmine/jasmineLight.ts
+++ b/packages/jest-jasmine2/src/jasmine/jasmineLight.ts
@@ -43,7 +43,7 @@ import Timer from './Timer';
 const create = function(createOptions: Record<string, any>): Jasmine {
   const j$ = {...createOptions} as Jasmine;
 
-  j$._DEFAULT_TIMEOUT_INTERVAL = createOptions.globalConfig.timeout || 5000;
+  j$._DEFAULT_TIMEOUT_INTERVAL = createOptions.globalConfig.testTimeout || 5000;
 
   j$.getEnv = function(options?: object) {
     const env = (j$.currentEnv_ = j$.currentEnv_ || new j$.Env(options));

--- a/packages/jest-jasmine2/src/jasmine/jasmineLight.ts
+++ b/packages/jest-jasmine2/src/jasmine/jasmineLight.ts
@@ -43,7 +43,7 @@ import Timer from './Timer';
 const create = function(createOptions: Record<string, any>): Jasmine {
   const j$ = {...createOptions} as Jasmine;
 
-  j$._DEFAULT_TIMEOUT_INTERVAL = 5000;
+  j$._DEFAULT_TIMEOUT_INTERVAL = createOptions.globalConfig.timeout || 5000;
 
   j$.getEnv = function(options?: object) {
     const env = (j$.currentEnv_ = j$.currentEnv_ || new j$.Env(options));

--- a/packages/jest-jasmine2/src/jasmine/jasmineLight.ts
+++ b/packages/jest-jasmine2/src/jasmine/jasmineLight.ts
@@ -43,7 +43,7 @@ import Timer from './Timer';
 const create = function(createOptions: Record<string, any>): Jasmine {
   const j$ = {...createOptions} as Jasmine;
 
-  j$._DEFAULT_TIMEOUT_INTERVAL = createOptions.globalConfig.testTimeout || 5000;
+  j$._DEFAULT_TIMEOUT_INTERVAL = createOptions.testTimeout || 5000;
 
   j$.getEnv = function(options?: object) {
     const env = (j$.currentEnv_ = j$.currentEnv_ || new j$.Env(options));

--- a/packages/jest-types/src/Config.ts
+++ b/packages/jest-types/src/Config.ts
@@ -207,6 +207,7 @@ export type InitialOptions = {
   testRunner?: string;
   testSequencer?: string;
   testURL?: string;
+  timeout?: number;
   timers?: 'real' | 'fake';
   transform?: {
     [key: string]: string;
@@ -344,6 +345,7 @@ export type GlobalConfig = {
   testPathPattern: string;
   testResultsProcessor: string | null | undefined;
   testSequencer: string;
+  timeout: number;
   updateSnapshot: SnapshotUpdateState;
   useStderr: boolean;
   verbose: boolean | null | undefined;
@@ -489,6 +491,7 @@ export type Argv = Arguments<
     testRunner: string;
     testSequencer: string;
     testURL: string;
+    timeout: number | null | undefined;
     timers: string;
     transform: string;
     transformIgnorePatterns: Array<string>;

--- a/packages/jest-types/src/Config.ts
+++ b/packages/jest-types/src/Config.ts
@@ -207,7 +207,7 @@ export type InitialOptions = {
   testRunner?: string;
   testSequencer?: string;
   testURL?: string;
-  timeout?: number;
+  testTimeout?: number;
   timers?: 'real' | 'fake';
   transform?: {
     [key: string]: string;
@@ -345,7 +345,7 @@ export type GlobalConfig = {
   testPathPattern: string;
   testResultsProcessor: string | null | undefined;
   testSequencer: string;
-  timeout: number;
+  testTimeout: number;
   updateSnapshot: SnapshotUpdateState;
   useStderr: boolean;
   verbose: boolean | null | undefined;
@@ -491,7 +491,7 @@ export type Argv = Arguments<
     testRunner: string;
     testSequencer: string;
     testURL: string;
-    timeout: number | null | undefined;
+    testTimeout: number | null | undefined;
     timers: string;
     transform: string;
     transformIgnorePatterns: Array<string>;


### PR DESCRIPTION
## Summary
My motivation is. When I debug the unit tests in IntelliJ and I got a timeout error.
Other's motivation: #6216

I would like to set the timeout to Infinity when jest runner in debug mode if this PR is approved. I like the step by step development

## Test plan

I extended the timeout e2e tests with use cases