### PR TITLE
General Type Maintenance 

### DIFF
--- a/packages/babel-plugin-jest-hoist/src/index.ts
+++ b/packages/babel-plugin-jest-hoist/src/index.ts
@@ -88,9 +88,10 @@ const IDVisitor = {
   blacklist: ['TypeAnnotation', 'TSTypeAnnotation', 'TSTypeReference'],
 };
 
-const FUNCTIONS: {
-  [key: string]: (args: Array<NodePath>) => boolean;
-} = Object.create(null);
+const FUNCTIONS: Record<
+  string,
+  (args: Array<NodePath>) => boolean
+> = Object.create(null);
 
 FUNCTIONS.mock = (args: Array<NodePath>) => {
   if (args.length === 1) {

--- a/packages/expect/src/asymmetricMatchers.ts
+++ b/packages/expect/src/asymmetricMatchers.ts
@@ -158,8 +158,8 @@ class ObjectContaining extends AsymmetricMatcher<Record<string, any>> {
       for (const property in this.sample) {
         if (
           hasProperty(other, property) &&
-          equals((this.sample as any)[property], other[property]) &&
-          !emptyObject((this.sample as any)[property]) &&
+          equals(this.sample[property], other[property]) &&
+          !emptyObject(this.sample[property]) &&
           !emptyObject(other[property])
         ) {
           return false;
@@ -171,7 +171,7 @@ class ObjectContaining extends AsymmetricMatcher<Record<string, any>> {
       for (const property in this.sample) {
         if (
           !hasProperty(other, property) ||
-          !equals((this.sample as any)[property], other[property])
+          !equals(this.sample[property], other[property])
         ) {
           return false;
         }

--- a/packages/expect/src/index.ts
+++ b/packages/expect/src/index.ts
@@ -299,7 +299,7 @@ const makeThrowingMatcher = (
 
     const handlError = (error: Error) => {
       if (
-        (matcher as any)[INTERNAL_MATCHER_FLAG] === true &&
+        matcher[INTERNAL_MATCHER_FLAG] === true &&
         !(error instanceof JestAssertionError) &&
         error.name !== 'PrettyFormatPluginError' &&
         // Guard for some environments (browsers) that do not support this feature.
@@ -314,10 +314,7 @@ const makeThrowingMatcher = (
     let potentialResult: ExpectationResult;
 
     try {
-      potentialResult = matcher.apply(
-        matcherContext,
-        ([actual] as any).concat(args),
-      );
+      potentialResult = matcher.call(matcherContext, actual, ...args);
 
       if (isPromise(potentialResult)) {
         const asyncResult = potentialResult as AsyncExpectationResult;
@@ -340,7 +337,7 @@ const makeThrowingMatcher = (
   };
 
 expect.extend = (matchers: MatchersObject): void =>
-  setMatchers(matchers, false, expect as any);
+  setMatchers(matchers, false, expect);
 
 expect.anything = anything;
 expect.any = any;

--- a/packages/expect/src/jasmineUtils.ts
+++ b/packages/expect/src/jasmineUtils.ts
@@ -208,7 +208,8 @@ function keys(
     return keys.concat(
       (Object.getOwnPropertySymbols(o) as Array<any>).filter(
         symbol =>
-          (Object.getOwnPropertyDescriptor(o, symbol) as any).enumerable,
+          (Object.getOwnPropertyDescriptor(o, symbol) as PropertyDescriptor)
+            .enumerable,
       ),
     );
   })(obj);

--- a/packages/expect/src/jestMatchersObject.ts
+++ b/packages/expect/src/jestMatchersObject.ts
@@ -17,7 +17,7 @@ const JEST_MATCHERS_OBJECT = Symbol.for('$$jest-matchers-object');
 // Jest may override the stack trace of Errors thrown by internal matchers.
 export const INTERNAL_MATCHER_FLAG = Symbol.for('$$jest-internal-matcher');
 
-if (!(global as any)[JEST_MATCHERS_OBJECT]) {
+if (!global.hasOwnProperty(JEST_MATCHERS_OBJECT)) {
   Object.defineProperty(global, JEST_MATCHERS_OBJECT, {
     value: {
       matchers: Object.create(null),

--- a/packages/expect/src/types.ts
+++ b/packages/expect/src/types.ts
@@ -7,6 +7,7 @@
  */
 import {Config} from '@jest/types';
 import * as jestMatcherUtils from 'jest-matcher-utils';
+import {INTERNAL_MATCHER_FLAG} from './jestMatchersObject';
 
 export type SyncExpectationResult = {
   pass: boolean;
@@ -17,11 +18,10 @@ export type AsyncExpectationResult = Promise<SyncExpectationResult>;
 
 export type ExpectationResult = SyncExpectationResult | AsyncExpectationResult;
 
-export type RawMatcherFn = (
-  received: any,
-  expected: any,
-  options?: any,
-) => ExpectationResult;
+export type RawMatcherFn = {
+  (received: any, expected: any, options?: any): ExpectationResult;
+  [INTERNAL_MATCHER_FLAG]?: boolean;
+};
 
 export type ThrowingMatcherFn = (actual: any) => void;
 export type PromiseMatcherFn = (actual: any) => Promise<void>;

--- a/packages/expect/src/utils.ts
+++ b/packages/expect/src/utils.ts
@@ -49,7 +49,7 @@ export const hasOwnProperty = (object: object, key: string) =>
   hasGetterFromConstructor(object, key);
 
 export const getPath = (
-  object: object,
+  object: Record<string, any>,
   propertyPath: string | Array<string>,
 ): GetPath => {
   if (!Array.isArray(propertyPath)) {
@@ -59,7 +59,7 @@ export const getPath = (
   if (propertyPath.length) {
     const lastProp = propertyPath.length === 1;
     const prop = propertyPath[0];
-    const newObject = (object as any)[prop];
+    const newObject = object[prop];
 
     if (!lastProp && (newObject === null || newObject === undefined)) {
       // This is not the last prop in the chain. If we keep recursing it will

--- a/packages/jest-circus/src/formatNodeAssertErrors.ts
+++ b/packages/jest-circus/src/formatNodeAssertErrors.ts
@@ -20,14 +20,14 @@ interface AssertionErrorWithStack extends AssertionError {
   stack: string;
 }
 
-const assertOperatorsMap: {[key: string]: string} = {
+const assertOperatorsMap: Record<string, string> = {
   '!=': 'notEqual',
   '!==': 'notStrictEqual',
   '==': 'equal',
   '===': 'strictEqual',
 };
 
-const humanReadableOperators: {[key: string]: string} = {
+const humanReadableOperators: Record<string, string> = {
   deepEqual: 'to deeply equal',
   deepStrictEqual: 'to deeply and strictly equal',
   equal: 'to be equal',

--- a/packages/jest-cli/src/init/generate_config_file.ts
+++ b/packages/jest-cli/src/init/generate_config_file.ts
@@ -31,7 +31,7 @@ const stringifyOption = (
   );
 };
 
-const generateConfigFile = (results: {[key: string]: unknown}): string => {
+const generateConfigFile = (results: Record<string, unknown>): string => {
   const {coverage, clearMocks, environment} = results;
 
   const overrides: Record<string, any> = {};

--- a/packages/jest-cli/src/init/types.ts
+++ b/packages/jest-cli/src/init/types.ts
@@ -9,5 +9,5 @@ import {Config} from '@jest/types';
 
 export type ProjectPackageJson = {
   jest?: Partial<Config.InitialOptions>;
-  scripts?: {[key: string]: string};
+  scripts?: Record<string, string>;
 };

--- a/packages/jest-config/src/setFromArgv.ts
+++ b/packages/jest-config/src/setFromArgv.ts
@@ -16,7 +16,7 @@ export default function setFromArgv(
 ): Config.InitialOptions {
   const argvToOptions = Object.keys(argv)
     .filter(key => argv[key] !== undefined && specialArgs.indexOf(key) === -1)
-    .reduce((options: {[key: string]: unknown}, key) => {
+    .reduce((options: Record<string, unknown>, key) => {
       switch (key) {
         case 'coverage':
           options.collectCoverage = argv[key];

--- a/packages/jest-config/src/utils.ts
+++ b/packages/jest-config/src/utils.ts
@@ -84,7 +84,7 @@ const _replaceRootDirInObject = <T extends ReplaceRootDirConfigObj>(
 };
 
 type OrArray<T> = T | Array<T>;
-type ReplaceRootDirConfigObj = {[key: string]: Config.Path};
+type ReplaceRootDirConfigObj = Record<string, Config.Path>;
 type ReplaceRootDirConfigValues =
   | OrArray<ReplaceRootDirConfigObj>
   | OrArray<RegExp>

--- a/packages/jest-core/src/FailedTestsCache.ts
+++ b/packages/jest-core/src/FailedTestsCache.ts
@@ -9,7 +9,7 @@ import {Test} from 'jest-runner';
 import {Config} from '@jest/types';
 import {TestResult} from '@jest/test-result';
 
-type TestMap = {[key: string]: {[key: string]: boolean}};
+type TestMap = Record<string, Record<string, boolean>>;
 
 export default class FailedTestsCache {
   private _enabledTestsMap?: TestMap;

--- a/packages/jest-core/src/TestScheduler.ts
+++ b/packages/jest-core/src/TestScheduler.ts
@@ -217,7 +217,7 @@ export default class TestScheduler {
   }
 
   private _partitionTests(
-    testRunners: {[key: string]: TestRunner},
+    testRunners: Record<string, TestRunner>,
     tests: Array<Test>,
   ) {
     if (Object.keys(testRunners).length > 1) {
@@ -327,7 +327,7 @@ export default class TestScheduler {
    */
   private _getReporterProps(
     reporter: string | Config.ReporterConfig,
-  ): {path: string; options: {[key: string]: unknown}} {
+  ): {path: string; options: Record<string, unknown>} {
     if (typeof reporter === 'string') {
       return {options: this._options, path: reporter};
     } else if (Array.isArray(reporter)) {

--- a/packages/jest-core/src/getNoTestFoundVerbose.ts
+++ b/packages/jest-core/src/getNoTestFoundVerbose.ts
@@ -17,7 +17,7 @@ export default function getNoTestFoundVerbose(
         if (key === 'roots' && config.roots.length === 1) {
           return null;
         }
-        const value = (config as {[key: string]: unknown})[key];
+        const value = (config as Record<string, unknown>)[key];
         if (value) {
           const valueAsString = Array.isArray(value)
             ? value.join(', ')

--- a/packages/jest-docblock/src/index.ts
+++ b/packages/jest-docblock/src/index.ts
@@ -8,7 +8,7 @@
 import {EOL} from 'os';
 import detectNewline from 'detect-newline';
 
-type Pragmas = {[key: string]: string | Array<string>};
+type Pragmas = Record<string, string | Array<string>>;
 
 const commentEndRe = /\*\/$/;
 const commentStartRe = /^\/\*\*/;

--- a/packages/jest-each/src/table/template.ts
+++ b/packages/jest-each/src/table/template.ts
@@ -70,8 +70,46 @@ const replaceKeyPathWithValue = (template: Template) => (
   return title.replace(match, pretty(value, {maxDepth: 1, min: true}));
 };
 
-const getPath = (template: Template, [head, ...tail]: Array<string>): any => {
+/* eslint import/export: 0*/
+export function getPath<
+  Obj extends Template,
+  A extends keyof Obj,
+  B extends keyof Obj[A],
+  C extends keyof Obj[A][B],
+  D extends keyof Obj[A][B][C],
+  E extends keyof Obj[A][B][C][D]
+>(obj: Obj, path: [A, B, C, D, E]): Obj[A][B][C][D][E];
+export function getPath<
+  Obj extends Template,
+  A extends keyof Obj,
+  B extends keyof Obj[A],
+  C extends keyof Obj[A][B],
+  D extends keyof Obj[A][B][C]
+>(obj: Obj, path: [A, B, C, D]): Obj[A][B][C][D];
+export function getPath<
+  Obj extends Template,
+  A extends keyof Obj,
+  B extends keyof Obj[A],
+  C extends keyof Obj[A][B]
+>(obj: Obj, path: [A, B, C]): Obj[A][B][C];
+export function getPath<
+  Obj extends Template,
+  A extends keyof Obj,
+  B extends keyof Obj[A]
+>(obj: Obj, path: [A, B]): Obj[A][B];
+export function getPath<Obj extends Template, A extends keyof Obj>(
+  obj: Obj,
+  path: [A],
+): Obj[A];
+export function getPath<Obj extends Template>(
+  obj: Obj,
+  path: Array<string>,
+): unknown;
+export function getPath(
+  template: Template,
+  [head, ...tail]: Array<string>,
+): unknown {
   if (!head || !template.hasOwnProperty || !template.hasOwnProperty(head))
     return template;
   return getPath(template[head] as Template, tail);
-};
+}

--- a/packages/jest-each/src/table/template.ts
+++ b/packages/jest-each/src/table/template.ts
@@ -11,7 +11,7 @@ import {isPrimitive} from 'jest-get-type';
 import {Global} from '@jest/types';
 import {EachTests} from '../bind';
 
-type Template = {[key: string]: unknown};
+type Template = Record<string, unknown>;
 type Templates = Array<Template>;
 type Headings = Array<string>;
 
@@ -70,11 +70,8 @@ const replaceKeyPathWithValue = (template: Template) => (
   return title.replace(match, pretty(value, {maxDepth: 1, min: true}));
 };
 
-const getPath = (
-  template: Template | any,
-  [head, ...tail]: Array<string>,
-): any => {
+const getPath = (template: Template, [head, ...tail]: Array<string>): any => {
   if (!head || !template.hasOwnProperty || !template.hasOwnProperty(head))
     return template;
-  return getPath(template[head], tail);
+  return getPath(template[head] as Template, tail);
 };

--- a/packages/jest-environment/src/index.ts
+++ b/packages/jest-environment/src/index.ts
@@ -18,7 +18,7 @@ type JestMockSpyOn = typeof jestMock.spyOn;
 // passed, or not. The context itself is optional, not properties within it.
 export type EnvironmentContext = Partial<{
   console: Console;
-  docblockPragmas: {[key: string]: string | Array<string>};
+  docblockPragmas: Record<string, string | Array<string>>;
   testPath: Config.Path;
 }>;
 

--- a/packages/jest-fake-timers/src/jestFakeTimers.ts
+++ b/packages/jest-fake-timers/src/jestFakeTimers.ts
@@ -53,8 +53,8 @@ const setGlobal = (
 };
 
 export default class FakeTimers<TimerRef> {
-  private _cancelledImmediates!: {[key: string]: boolean};
-  private _cancelledTicks!: {[key: string]: boolean};
+  private _cancelledImmediates!: Record<string, boolean>;
+  private _cancelledTicks!: Record<string, boolean>;
   private _config: StackTraceConfig;
   private _disposed?: boolean;
   private _fakeTimerAPIs!: TimerAPI;

--- a/packages/jest-haste-map/src/ModuleMap.ts
+++ b/packages/jest-haste-map/src/ModuleMap.ts
@@ -18,7 +18,7 @@ import {
 import * as fastPath from './lib/fast_path';
 import H from './constants';
 
-const EMPTY_OBJ = {} as {[key: string]: any};
+const EMPTY_OBJ = {} as Record<string, any>;
 const EMPTY_MAP = new Map();
 
 type ValueType<T> = T extends Map<string, infer V> ? V : never;

--- a/packages/jest-jasmine2/src/assertionErrorMessage.ts
+++ b/packages/jest-jasmine2/src/assertionErrorMessage.ts
@@ -14,14 +14,14 @@ import {
 import chalk from 'chalk';
 import {AssertionErrorWithStack} from './types';
 
-const assertOperatorsMap: {[key: string]: string} = {
+const assertOperatorsMap: Record<string, string> = {
   '!=': 'notEqual',
   '!==': 'notStrictEqual',
   '==': 'equal',
   '===': 'strictEqual',
 };
 
-const humanReadableOperators: {[key: string]: string} = {
+const humanReadableOperators: Record<string, string> = {
   deepEqual: 'to deeply equal',
   deepStrictEqual: 'to deeply and strictly equal',
   equal: 'to be equal',

--- a/packages/jest-jasmine2/src/jasmine/Env.ts
+++ b/packages/jest-jasmine2/src/jasmine/Env.ts
@@ -66,7 +66,7 @@ export default function(j$: Jasmine) {
     ) => Promise<void>;
     fdescribe: (description: string, specDefinitions: Function) => Suite;
     spyOn: (
-      obj: {[key: string]: any},
+      obj: Record<string, any>,
       methodName: string,
       accessType?: keyof PropertyDescriptor,
     ) => Spy;
@@ -94,7 +94,7 @@ export default function(j$: Jasmine) {
       const realSetTimeout = global.setTimeout;
       const realClearTimeout = global.clearTimeout;
 
-      const runnableResources: {[key: string]: {spies: Array<Spy>}} = {};
+      const runnableResources: Record<string, {spies: Array<Spy>}> = {};
       const currentlyExecutingSuites: Array<Suite> = [];
       let currentSpec: Spec | null = null;
       let throwOnExpectationFailure = false;

--- a/packages/jest-jasmine2/src/jasmine/JsApiReporter.ts
+++ b/packages/jest-jasmine2/src/jasmine/JsApiReporter.ts
@@ -53,7 +53,7 @@ export default class JsApiReporter implements Reporter {
   suiteStarted: (result: SuiteResult) => void;
   suiteDone: (result: SuiteResult) => void;
   suiteResults: (index: number, length: number) => Array<SuiteResult>;
-  suites: () => {[key: string]: SuiteResult};
+  suites: () => Record<string, SuiteResult>;
 
   specResults: (index: number, length: number) => Array<SpecResult>;
   specDone: (result: SpecResult) => void;
@@ -95,7 +95,7 @@ export default class JsApiReporter implements Reporter {
     };
 
     const suites: Array<SuiteResult> = [];
-    const suites_hash: {[key: string]: SuiteResult} = {};
+    const suites_hash: Record<string, SuiteResult> = {};
 
     this.specStarted = function() {};
 

--- a/packages/jest-jasmine2/src/jasmine/createSpy.ts
+++ b/packages/jest-jasmine2/src/jasmine/createSpy.ts
@@ -34,9 +34,8 @@ import {Spy} from '../types';
 import CallTracker, {Context} from './CallTracker';
 import SpyStrategy from './SpyStrategy';
 
-interface Fn {
+interface Fn extends Record<string, any> {
   (): any;
-  [key: string]: any;
 }
 
 function createSpy(name: string, originalFn: Fn): Spy {

--- a/packages/jest-jasmine2/src/jasmine/spyRegistry.ts
+++ b/packages/jest-jasmine2/src/jasmine/spyRegistry.ts
@@ -54,7 +54,7 @@ const getErrorMsg = formatErrorMsg('<spyOn>', 'spyOn(<object>, <methodName>)');
 export default class SpyRegistry {
   allowRespy: (allow: unknown) => void;
   spyOn: (
-    obj: {[key: string]: any},
+    obj: Record<string, any>,
     methodName: string,
     accessType?: keyof PropertyDescriptor,
   ) => Spy;
@@ -62,7 +62,7 @@ export default class SpyRegistry {
   respy: unknown;
 
   private _spyOnProperty: (
-    obj: {[key: string]: any},
+    obj: Record<string, any>,
     propertyName: string,
     accessType: keyof PropertyDescriptor,
   ) => Spy;

--- a/packages/jest-jasmine2/src/types.ts
+++ b/packages/jest-jasmine2/src/types.ts
@@ -58,11 +58,10 @@ export type Reporter = {
 };
 
 export interface Spy extends Record<string, any> {
-  (this: {[key: string]: any}, ...args: Array<any>): unknown;
+  (this: Record<string, unknown>, ...args: Array<any>): unknown;
   and: SpyStrategy;
   calls: CallTracker;
   restoreObjectToOriginalState?: () => void;
-  [key: string]: any;
 }
 
 export type Jasmine = {

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -25,7 +25,7 @@ namespace JestMock {
     Type = MockFunctionMetadataType
   > = {
     ref?: number;
-    members?: {[key: string]: MockFunctionMetadata<T, Y>};
+    members?: Record<string, MockFunctionMetadata<T, Y>>;
     mockImpl?: (...args: Y) => T;
     name?: string;
     refID?: number;
@@ -541,8 +541,8 @@ class ModuleMockerClass {
         // calling rather than waiting for the mock to return. This avoids
         // issues caused by recursion where results can be recorded in the
         // wrong order.
-        const mockResult = {
-          type: ('incomplete' as unknown) as MockFunctionResultType,
+        const mockResult: MockFunctionResult = {
+          type: 'incomplete',
           value: undefined,
         };
         mockState.results.push(mockResult);

--- a/packages/jest-resolve-dependencies/src/__tests__/dependency_resolver.test.ts
+++ b/packages/jest-resolve-dependencies/src/__tests__/dependency_resolver.test.ts
@@ -17,7 +17,7 @@ const maxWorkers = 1;
 let dependencyResolver: DependencyResolver;
 let Runtime;
 let config: Config.ProjectConfig;
-const cases: {[key: string]: jest.Mock} = {
+const cases: Record<string, jest.Mock> = {
   fancyCondition: jest.fn(path => path.length > 10),
   testRegex: jest.fn(path => /.test.js$/.test(path)),
 };

--- a/packages/jest-resolve/src/index.ts
+++ b/packages/jest-resolve/src/index.ts
@@ -25,7 +25,7 @@ type FindNodeModuleConfig = {
   rootDir?: Config.Path;
 };
 
-type BooleanObject = {[key: string]: boolean};
+type BooleanObject = Record<string, boolean>;
 
 namespace Resolver {
   export type ResolveModuleConfig = {

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -51,7 +51,7 @@ type InitialModule = Partial<Module> &
 type ModuleRegistry = Map<string, InitialModule | Module>;
 type ResolveOptions = Parameters<typeof require.resolve>[1];
 
-type BooleanObject = {[key: string]: boolean};
+type BooleanObject = Record<string, boolean>;
 type CacheFS = {[path: string]: string};
 
 namespace Runtime {
@@ -90,7 +90,7 @@ class Runtime {
   private _explicitShouldMock: BooleanObject;
   private _internalModuleRegistry: ModuleRegistry;
   private _isCurrentlyExecutingManualMock: string | null;
-  private _mockFactories: {[key: string]: () => unknown};
+  private _mockFactories:Record<string, () => unknown> ;
   private _mockMetaDataCache: {
     [key: string]: MockFunctionMetadata<unknown, Array<unknown>>;
   };
@@ -786,9 +786,9 @@ class Runtime {
     if (!(modulePath in this._mockMetaDataCache)) {
       // This allows us to handle circular dependencies while generating an
       // automock
-      this._mockMetaDataCache[modulePath] = this._moduleMocker.getMetadata(
-        {},
-      ) as any;
+
+      this._mockMetaDataCache[modulePath] =
+        this._moduleMocker.getMetadata({}) || {};
 
       // In order to avoid it being possible for automocking to potentially
       // cause side-effects within the module environment, we need to execute

--- a/packages/jest-snapshot/src/inline_snapshots.ts
+++ b/packages/jest-snapshot/src/inline_snapshots.ts
@@ -103,7 +103,7 @@ const saveSnapshotsForFile = (
 const groupSnapshotsBy = (
   createKey: (inlineSnapshot: InlineSnapshot) => string,
 ) => (snapshots: Array<InlineSnapshot>) =>
-  snapshots.reduce<{[key: string]: Array<InlineSnapshot>}>(
+  snapshots.reduce<Record<string, Array<InlineSnapshot>>>(
     (object, inlineSnapshot) => {
       const key = createKey(inlineSnapshot);
       return {...object, [key]: (object[key] || []).concat(inlineSnapshot)};
@@ -142,7 +142,7 @@ const indent = (snapshot: string, numIndents: number, indentation: string) => {
 };
 
 const getAst = (
-  parsers: {[key: string]: (text: string) => any},
+  parsers: Record<string, (text: string) => any>,
   inferredParser: string,
   text: string,
 ) => {
@@ -162,7 +162,7 @@ const createInsertionParser = (
   babelTraverse: Function,
 ) => (
   text: string,
-  parsers: {[key: string]: (text: string) => any},
+  parsers: Record<string, (text: string) => any>,
   options: any,
 ) => {
   // Workaround for https://github.com/prettier/prettier/issues/3150
@@ -224,7 +224,7 @@ const createFormattingParser = (
   babelTraverse: Function,
 ) => (
   text: string,
-  parsers: {[key: string]: (text: string) => any},
+  parsers: Record<string, (text: string) => any>,
   options: any,
 ) => {
   // Workaround for https://github.com/prettier/prettier/issues/3150

--- a/packages/jest-snapshot/src/types.ts
+++ b/packages/jest-snapshot/src/types.ts
@@ -5,4 +5,4 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-export type SnapshotData = {[key: string]: string};
+export type SnapshotData = Record<string, string>;

--- a/packages/jest-snapshot/src/utils.ts
+++ b/packages/jest-snapshot/src/utils.ts
@@ -157,7 +157,7 @@ export const ensureDirectoryExists = (filePath: Config.Path) => {
 const normalizeNewlines = (string: string) => string.replace(/\r\n|\r/g, '\n');
 
 export const saveSnapshotFile = (
-  snapshotData: {[key: string]: string},
+  snapshotData: SnapshotData,
   snapshotPath: Config.Path,
 ) => {
   const snapshots = Object.keys(snapshotData)

--- a/packages/jest-source-map/src/types.ts
+++ b/packages/jest-source-map/src/types.ts
@@ -5,4 +5,4 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-export type SourceMapRegistry = {[key: string]: string};
+export type SourceMapRegistry = Record<string, string>;

--- a/packages/jest-types/src/Config.ts
+++ b/packages/jest-types/src/Config.ts
@@ -21,7 +21,7 @@ export type HasteConfig = {
   throwOnModuleCollision?: boolean;
 };
 
-export type ReporterConfig = [string, {[key: string]: unknown}];
+export type ReporterConfig = [string, Record<string, unknown>];
 
 export type ConfigGlobals = Record<string, any>;
 

--- a/packages/jest-util/src/deepCyclicCopy.ts
+++ b/packages/jest-util/src/deepCyclicCopy.ts
@@ -16,7 +16,7 @@ export type DeepCyclicCopyOptions = {
 if (!Object.getOwnPropertyDescriptors) {
   // @ts-ignore: polyfill
   Object.getOwnPropertyDescriptors = obj => {
-    const list: {[key: string]: PropertyDescriptor | undefined} = {};
+    const list: Record<string, PropertyDescriptor | undefined> = {};
 
     (Object.getOwnPropertyNames(obj) as Array<string | symbol>)
       .concat(Object.getOwnPropertySymbols(obj))

--- a/packages/jest-validate/src/deprecated.ts
+++ b/packages/jest-validate/src/deprecated.ts
@@ -17,7 +17,7 @@ const deprecationMessage = (message: string, options: ValidationOptions) => {
 };
 
 export const deprecationWarning = (
-  config: {[key: string]: any},
+  config: Record<string, any>,
   option: string,
   deprecatedOptions: DeprecatedOptions,
   options: ValidationOptions,

--- a/packages/jest-validate/src/types.ts
+++ b/packages/jest-validate/src/types.ts
@@ -17,7 +17,7 @@ export type ValidationOptions = {
   comment?: string;
   condition?: (option: any, validOption: any) => boolean;
   deprecate?: (
-    config: {[key: string]: any},
+    config: Record<string, any>,
     option: string,
     deprecatedOptions: DeprecatedOptions,
     options: ValidationOptions,
@@ -30,13 +30,13 @@ export type ValidationOptions = {
     options: ValidationOptions,
     path?: Array<string>,
   ) => void;
-  exampleConfig: {[key: string]: any};
+  exampleConfig: Record<string, any>;
   recursive?: boolean;
   recursiveBlacklist?: Array<string>;
   title?: Title;
   unknown?: (
-    config: {[key: string]: any},
-    exampleConfig: {[key: string]: any},
+    config: Record<string, any>,
+    exampleConfig: Record<string, any>,
     option: string,
     options: ValidationOptions,
     path?: Array<string>,

--- a/packages/jest-validate/src/validate.ts
+++ b/packages/jest-validate/src/validate.ts
@@ -18,8 +18,8 @@ const shouldSkipValidationForPath = (
 ) => (blacklist ? blacklist.includes([...path, key].join('.')) : false);
 
 const _validate = (
-  config: {[key: string]: any},
-  exampleConfig: {[key: string]: any},
+  config: Record<string, any>,
+  exampleConfig: Record<string, any>,
   options: ValidationOptions,
   path: Array<string> = [],
 ): {hasDeprecationWarnings: boolean} => {
@@ -76,7 +76,7 @@ const _validate = (
   return {hasDeprecationWarnings};
 };
 
-const validate = (config: {[key: string]: any}, options: ValidationOptions) => {
+const validate = (config: Record<string, any>, options: ValidationOptions) => {
   hasDeprecationWarnings = false;
 
   // Preserve default blacklist entries even with user-supplied blacklist

--- a/packages/jest-validate/src/warnings.ts
+++ b/packages/jest-validate/src/warnings.ts
@@ -15,8 +15,8 @@ import {
 } from './utils';
 
 export const unknownOptionWarning = (
-  config: {[s: string]: any},
-  exampleConfig: {[key: string]: any},
+  config: Record<string, any>,
+  exampleConfig: Record<string, any>,
   option: string,
   options: ValidationOptions,
   path?: Array<string>,

--- a/packages/jest-worker/src/Farm.ts
+++ b/packages/jest-worker/src/Farm.ts
@@ -18,7 +18,7 @@ import {
 
 export default class Farm {
   private _computeWorkerKey: FarmOptions['computeWorkerKey'];
-  private _cacheKeys: {[key: string]: WorkerInterface};
+  private _cacheKeys: Record<string, WorkerInterface>;
   private _callback: Function;
   private _last: Array<QueueItem>;
   private _locks: Array<boolean>;

--- a/packages/pretty-format/src/collections.ts
+++ b/packages/pretty-format/src/collections.ts
@@ -176,7 +176,7 @@ export function printObjectProperties(
   printer: Printer,
 ): string {
   let result = '';
-  const keys = getKeysOfEnumerableProperties(val) as Array<string>;
+  const keys = getKeysOfEnumerableProperties(val);
 
   if (keys.length) {
     result += config.spacingOuter;

--- a/packages/pretty-format/src/collections.ts
+++ b/packages/pretty-format/src/collections.ts
@@ -19,7 +19,7 @@ const getKeysOfEnumerableProperties = (object: Record<string, any>) => {
     });
   }
 
-  return keys;
+  return keys as Array<string>;
 };
 
 /**
@@ -176,7 +176,7 @@ export function printObjectProperties(
   printer: Printer,
 ): string {
   let result = '';
-  const keys = getKeysOfEnumerableProperties(val);
+  const keys = getKeysOfEnumerableProperties(val) as Array<string>;
 
   if (keys.length) {
     result += config.spacingOuter;
@@ -186,13 +186,7 @@ export function printObjectProperties(
     for (let i = 0; i < keys.length; i++) {
       const key = keys[i];
       const name = printer(key, config, indentationNext, depth, refs);
-      const value = printer(
-        (val as any)[key],
-        config,
-        indentationNext,
-        depth,
-        refs,
-      );
+      const value = printer(val[key], config, indentationNext, depth, refs);
 
       result += indentationNext + name + ': ' + value;
 

--- a/packages/pretty-format/src/index.ts
+++ b/packages/pretty-format/src/index.ts
@@ -360,7 +360,9 @@ const DEFAULT_THEME: PrettyFormat.Theme = {
   value: 'green',
 };
 
-const DEFAULT_THEME_KEYS = Object.keys(DEFAULT_THEME);
+const DEFAULT_THEME_KEYS = Object.keys(DEFAULT_THEME) as Array<
+  keyof typeof DEFAULT_THEME
+>;
 
 const DEFAULT_OPTIONS: PrettyFormat.Options = {
   callToJSON: true,
@@ -406,10 +408,10 @@ const getColorsHighlight = (
 ): PrettyFormat.Colors =>
   DEFAULT_THEME_KEYS.reduce((colors, key) => {
     const value =
-      options.theme && (options.theme as any)[key] !== undefined
-        ? (options.theme as any)[key]
-        : (DEFAULT_THEME as any)[key];
-    const color = (style as any)[value];
+      options.theme && options.theme[key] !== undefined
+        ? options.theme[key]
+        : DEFAULT_THEME[key];
+    const color = value && (style as any)[value];
     if (
       color &&
       typeof color.close === 'string' &&

--- a/packages/pretty-format/src/plugins/ReactTestComponent.ts
+++ b/packages/pretty-format/src/plugins/ReactTestComponent.ts
@@ -31,7 +31,7 @@ const getPropKeys = (object: ReactTestObject) => {
 
   return props
     ? Object.keys(props)
-        .filter(key => (props as any)[key] !== undefined)
+        .filter(key => props[key] !== undefined)
         .sort()
     : [];
 };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary
 As part of #8436 , this PR has a much larger scope, targeting obvious unnecessary castings and consistent Object Literal Types throughout the codebase.

For consistency I decided to use `Record<string,string>` if the type didnt have a meaningful index key  ie:

``` diff
type PathLookup= {[path:string]:string}
--- type LookupObj= {[key:string]:string}
+++ type LookupObj= Record<string,string>

```
 
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
