### PR TITLE
Correcting a link that leads to the documentation of Jest inside the create-react-app's documentation

### DIFF
--- a/docs/TutorialReact.md
+++ b/docs/TutorialReact.md
@@ -9,7 +9,7 @@ At Facebook, we use Jest to test [React](http://facebook.github.io/react/) appli
 
 ### Setup with Create React App
 
-If you are just getting started with React, we recommend using [Create React App](https://github.com/facebookincubator/create-react-app). It is ready to use and [ships with Jest](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#running-tests)! You will only need to add `react-test-renderer` for rendering snapshots.
+If you are just getting started with React, we recommend using [Create React App](https://github.com/facebookincubator/create-react-app). It is ready to use and [ships with Jest](https://facebook.github.io/create-react-app/docs/running-tests#docsNav)! You will only need to add `react-test-renderer` for rendering snapshots.
 
 Run
 

--- a/website/versioned_docs/version-22.x/TutorialReact.md
+++ b/website/versioned_docs/version-22.x/TutorialReact.md
@@ -10,7 +10,7 @@ At Facebook, we use Jest to test [React](http://facebook.github.io/react/) appli
 
 ### Setup with Create React App
 
-If you are just getting started with React, we recommend using [Create React App](https://github.com/facebookincubator/create-react-app). It is ready to use and [ships with Jest](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#running-tests)! You don't need to do any extra steps for setup, and can head straight to the next section.
+If you are just getting started with React, we recommend using [Create React App](https://github.com/facebookincubator/create-react-app). It is ready to use and [ships with Jest](https://github.com/facebookincubator/create-react-app)! You don't need to do any extra steps for setup, and can head straight to the next section.
 
 ### Setup without Create React App
 

--- a/website/versioned_docs/version-23.x/TutorialReact.md
+++ b/website/versioned_docs/version-23.x/TutorialReact.md
@@ -10,7 +10,7 @@ At Facebook, we use Jest to test [React](http://facebook.github.io/react/) appli
 
 ### Setup with Create React App
 
-If you are just getting started with React, we recommend using [Create React App](https://github.com/facebookincubator/create-react-app). It is ready to use and [ships with Jest](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#running-tests)! You will only need to add `react-test-renderer` for rendering snapshots.
+If you are just getting started with React, we recommend using [Create React App](https://github.com/facebookincubator/create-react-app). It is ready to use and [ships with Jest](https://github.com/facebookincubator/create-react-app)! You will only need to add `react-test-renderer` for rendering snapshots.
 
 Run
 

--- a/website/versioned_docs/version-24.0/TutorialReact.md
+++ b/website/versioned_docs/version-24.0/TutorialReact.md
@@ -10,7 +10,7 @@ At Facebook, we use Jest to test [React](http://facebook.github.io/react/) appli
 
 ### Setup with Create React App
 
-If you are just getting started with React, we recommend using [Create React App](https://github.com/facebookincubator/create-react-app). It is ready to use and [ships with Jest](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#running-tests)! You will only need to add `react-test-renderer` for rendering snapshots.
+If you are just getting started with React, we recommend using [Create React App](https://github.com/facebookincubator/create-react-app). It is ready to use and [ships with Jest](https://github.com/facebookincubator/create-react-app)! You will only need to add `react-test-renderer` for rendering snapshots.
 
 Run
 


### PR DESCRIPTION
Correcting a link that leads to the documentation of Jest inside the create-react-app's documentation

https://jestjs.io/docs/en/tutorial-react

