### PR TITLE
Prevent drifting inline snapshots #8424

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - `[babel-plugin-jest-hoist]` Expand list of whitelisted globals in global mocks ([#8429](https://github.com/facebook/jest/pull/8429)
 - `[jest-core]` Make watch plugin initialization errors look nice ([#8422](https://github.com/facebook/jest/pull/8422))
+- `[jest-snapshot]` Prevent inline snapshots from drifting when inline snapshots are updated ([#8492](https://github.com/facebook/jest/pull/8492))
 
 ### Chore & Maintenance
 

--- a/packages/jest-snapshot/src/inline_snapshots.ts
+++ b/packages/jest-snapshot/src/inline_snapshots.ts
@@ -120,6 +120,13 @@ const groupSnapshotsByFile = groupSnapshotsBy(({frame: {file}}) => file);
 
 const indent = (snapshot: string, numIndents: number, indentation: string) => {
   const lines = snapshot.split('\n');
+  if (
+    lines.length > 2 &&
+    lines[1].startsWith(indentation.repeat(numIndents + 1))
+  ) {
+    return snapshot;
+  }
+
   return lines
     .map((line, index) => {
       if (index === 0) {

--- a/packages/jest-snapshot/src/inline_snapshots.ts
+++ b/packages/jest-snapshot/src/inline_snapshots.ts
@@ -120,8 +120,9 @@ const groupSnapshotsByFile = groupSnapshotsBy(({frame: {file}}) => file);
 
 const indent = (snapshot: string, numIndents: number, indentation: string) => {
   const lines = snapshot.split('\n');
+  // Prevent re-identation of inline snapshots.
   if (
-    lines.length > 2 &&
+    lines.length >= 2 &&
     lines[1].startsWith(indentation.repeat(numIndents + 1))
   ) {
     return snapshot;


### PR DESCRIPTION
Fixes #8424 by avoiding indenting inline snapshot if second line of inline snapshot already has been indented.

## Summary
As described in #8424, existing and unmodified inline snapshot drifts every time inline snapshots are updated.

This pull request fixes this behavior.

## Test plan
1. Added unit test to trigger faulty behavior
2. Fixed code and verified that the faulty behavior was fixed by re-running the unit tests.