### PR TITLE
Release to GitHub with CI

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -1,7 +1,13 @@
 #
 # Azure Pipelines configuration for building and testing Jest on Linux, Windows, and macOS.
 #
-
+    
+trigger:
+  branches:
+    include:
+    - '*'  
+    - refs/tags/*
+    
 jobs:
   - job: Linux
     pool:
@@ -28,9 +34,27 @@ jobs:
         displayName: 'Install Mercurial'
       - template: .azure-pipelines-steps.yml
 
+  - job: GitHub_Release
+    displayName: Release on GitHub
+    dependsOn: 
+    - Windows
+    - macOs
+    - Linux
+    condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/v24.'))  
+    steps:
+    - task: GitHubRelease@0
+      displayName: 'GitHub release (create)'
+      inputs:
+        gitHubConnection: 'github-zenithworks'
+        title: Jest - Javascript Testing Framework Release 
+        releaseNotesSource: input
+        releaseNotes: | 
+          \## Jest Release- $(Build.SourceBranchName) 
+          [Release notes](https://github.com/facebook/jest/blob/master/CHANGELOG.md)   |   [Documentation](https://jestjs.io/docs/en/getting-started.html)  |   [Jest Website](https://jestjs.io/en/)     
+                    
 variables:
   # Used by chalk. Ensures output from Jest includes ANSI escape characters that are needed to match test snapshots.
   FORCE_COLOR: 1
 
   # Ensures the handful of tests that should be skipped during CI are
-  CI: true
+CI: true

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -46,10 +46,10 @@ jobs:
       displayName: 'GitHub release (create)'
       inputs:
         gitHubConnection: 'github-zenithworks'
-        title: Jest - Javascript Testing Framework Release 
+        title: Jest Release- $(Build.SourceBranchName)
         releaseNotesSource: input
-        releaseNotes: | 
-          \## Jest Release- $(Build.SourceBranchName) 
+        releaseNotes: |            
+          Jest - Javascript Testing Framework 
           [Release notes](https://github.com/facebook/jest/blob/master/CHANGELOG.md)   |   [Documentation](https://jestjs.io/docs/en/getting-started.html)  |   [Jest Website](https://jestjs.io/en/)     
                     
 variables:
@@ -57,4 +57,4 @@ variables:
   FORCE_COLOR: 1
 
   # Ensures the handful of tests that should be skipped during CI are
-CI: true
+  CI: true


### PR DESCRIPTION
Raising a PR as requested in #8502 :
I have added the github release task at the end of CI. It publishes a release whenever a build is run for tag matching pattern 'v24.*' and all linux, windows and mac jobs are successful. The contents of the release notes can be further improved.
Also in the trigger section,  i have explicitly allowed builds to run when a tag is pushed.
Note that  githubConnection parameter value needs to be replaced with the one being used in azure pipelines CI account.
