### PR TITLE
docs: Add notice for known bug with puppeteer

### DIFF
--- a/docs/Puppeteer.md
+++ b/docs/Puppeteer.md
@@ -5,6 +5,8 @@ title: Using with puppeteer
 
 With the [Global Setup/Teardown](Configuration.md#globalsetup-string) and [Async Test Environment](Configuration.md#testenvironment-string) APIs, Jest can work smoothly with [puppeteer](https://github.com/GoogleChrome/puppeteer).
 
+> Generating code coverage for test files using Puppeteer is currently not possible if your test uses `page.$eval`, `page.$$eval` or `page.evaluate` as the passed function is executed outside of Jest's scope. Check out [issue #7962](https://github.com/facebook/jest/issues/7962#issuecomment-495272339) on GitHub for a workaround.
+
 ## Use jest-puppeteer Preset
 
 [Jest Puppeteer](https://github.com/smooth-code/jest-puppeteer) provides all required configuration to run your tests using Puppeteer.

--- a/website/versioned_docs/version-22.x/Puppeteer.md
+++ b/website/versioned_docs/version-22.x/Puppeteer.md
@@ -6,6 +6,8 @@ original_id: puppeteer
 
 With the [Global Setup/Teardown](Configuration.md#globalsetup-string) and [Async Test Environment](Configuration.md#testenvironment-string) APIs, Jest can work smoothly with [puppeteer](https://github.com/GoogleChrome/puppeteer).
 
+> Generating code coverage for test files using Puppeteer is currently not possible if your test uses `page.$eval`, `page.$$eval` or `page.evaluate` as the passed function is executed outside of Jest's scope. Check out [issue #7962](https://github.com/facebook/jest/issues/7962#issuecomment-495272339) on GitHub for a workaround.
+
 ## A jest-puppeteer example
 
 The basic idea is to:

--- a/website/versioned_docs/version-23.x/Puppeteer.md
+++ b/website/versioned_docs/version-23.x/Puppeteer.md
@@ -6,6 +6,8 @@ original_id: puppeteer
 
 With the [Global Setup/Teardown](Configuration.md#globalsetup-string) and [Async Test Environment](Configuration.md#testenvironment-string) APIs, Jest can work smoothly with [puppeteer](https://github.com/GoogleChrome/puppeteer).
 
+> Generating code coverage for test files using Puppeteer is currently not possible if your test uses `page.$eval`, `page.$$eval` or `page.evaluate` as the passed function is executed outside of Jest's scope. Check out [issue #7962](https://github.com/facebook/jest/issues/7962#issuecomment-495272339) on GitHub for a workaround.
+
 ## Use jest-puppeteer Preset
 
 [Jest Puppeteer](https://github.com/smooth-code/jest-puppeteer) provides all required configuration to run your tests using Puppeteer.

--- a/website/versioned_docs/version-24.0/Puppeteer.md
+++ b/website/versioned_docs/version-24.0/Puppeteer.md
@@ -6,6 +6,8 @@ original_id: puppeteer
 
 With the [Global Setup/Teardown](Configuration.md#globalsetup-string) and [Async Test Environment](Configuration.md#testenvironment-string) APIs, Jest can work smoothly with [puppeteer](https://github.com/GoogleChrome/puppeteer).
 
+> Generating code coverage for test files using Puppeteer is currently not possible if your test uses `page.$eval`, `page.$$eval` or `page.evaluate` as the passed function is executed outside of Jest's scope. Check out [issue #7962](https://github.com/facebook/jest/issues/7962#issuecomment-495272339) on GitHub for a workaround.
+
 ## Use jest-puppeteer Preset
 
 [Jest Puppeteer](https://github.com/smooth-code/jest-puppeteer) provides all required configuration to run your tests using Puppeteer.


### PR DESCRIPTION
## Summary
I spent a few hours bashing my head on my desk until I found issue #7962 and the workaround suggested there.

The documentation currently uses `page.evaluate` in an example, but this example breaks with a rather obscure error when code coverage is generated for the test file.

By adding a notice, hopefully I can save someone else from becoming frustrated! :-)

I wasn't sure about the wording (I tried to keep it in the same style as the rest of the document), so if any edits are needed, no problem!

## Test plan

It's a doc change, no test plan.
