### PR TITLE
fix(pretty-format): Render custom displayName of memoized components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - `[expect]` Highlight substring differences when matcher fails, part 1 ([#8448](https://github.com/facebook/jest/pull/8448))
 - `[jest-cli]` Improve chai support (with detailed output, to match jest exceptions) ([#8454](https://github.com/facebook/jest/pull/8454))
 - `[*]` Manage the global timeout with `--testTimeout` command line argument. ([#8456](https://github.com/facebook/jest/pull/8456))
+- `[pretty-format]` Render custom displayName of memoized components
 
 ### Fixes
 

--- a/packages/pretty-format/src/__tests__/react.test.tsx
+++ b/packages/pretty-format/src/__tests__/react.test.tsx
@@ -722,24 +722,41 @@ test('supports forwardRef with a child', () => {
   ).toEqual('<ForwardRef(Cat)>\n  mouse\n</ForwardRef(Cat)>');
 });
 
-test('supports memo with a child', () => {
-  function Dog(props: any) {
-    return React.createElement('div', props, props.children);
-  }
+describe('React.memo', () => {
+  describe('without displayName', () => {
+    test('renders the component name', () => {
+      function Dog(props: any) {
+        return React.createElement('div', props, props.children);
+      }
 
-  expect(
-    formatElement(React.createElement(React.memo(Dog), null, 'cat')),
-  ).toEqual('<Memo(Dog)>\n  cat\n</Memo(Dog)>');
-});
+      expect(
+        formatElement(React.createElement(React.memo(Dog), null, 'cat')),
+      ).toEqual('<Memo(Dog)>\n  cat\n</Memo(Dog)>');
+    });
+  });
 
-test('supports memo with displayName', () => {
-  const Foo = () => React.createElement('div');
-  const MemoFoo = React.memo(Foo);
-  MemoFoo.displayName = 'MyDisplayName(Foo)';
+  describe('with displayName', () => {
+    test('renders the displayName of component before memoizing', () => {
+      const Foo = () => React.createElement('div');
+      Foo.displayName = 'DisplayNameBeforeMemoizing(Foo)';
+      const MemoFoo = React.memo(Foo);
 
-  expect(formatElement(React.createElement(MemoFoo, null, 'cat'))).toEqual(
-    '<Memo(MyDisplayName(Foo))>\n  cat\n</Memo(MyDisplayName(Foo))>',
-  );
+      expect(formatElement(React.createElement(MemoFoo, null, 'cat'))).toEqual(
+        '<Memo(DisplayNameBeforeMemoizing(Foo))>\n  cat\n</Memo(DisplayNameBeforeMemoizing(Foo))>',
+      );
+    });
+
+    test('renders the displayName of memoized component', () => {
+      const Foo = () => React.createElement('div');
+      Foo.displayName = 'DisplayNameThatWillBeIgnored(Foo)';
+      const MemoFoo = React.memo(Foo);
+      MemoFoo.displayName = 'DisplayNameForMemoized(Foo)';
+
+      expect(formatElement(React.createElement(MemoFoo, null, 'cat'))).toEqual(
+        '<Memo(DisplayNameForMemoized(Foo))>\n  cat\n</Memo(DisplayNameForMemoized(Foo))>',
+      );
+    });
+  });
 });
 
 test('supports context Provider with a child', () => {

--- a/packages/pretty-format/src/__tests__/react.test.tsx
+++ b/packages/pretty-format/src/__tests__/react.test.tsx
@@ -732,6 +732,16 @@ test('supports memo with a child', () => {
   ).toEqual('<Memo(Dog)>\n  cat\n</Memo(Dog)>');
 });
 
+test('supports memo with displayName', () => {
+  const Foo = () => React.createElement('div');
+  const MemoFoo = React.memo(Foo);
+  MemoFoo.displayName = 'MyDisplayName(Foo)';
+
+  expect(formatElement(React.createElement(MemoFoo, null, 'cat'))).toEqual(
+    '<Memo(MyDisplayName(Foo))>\n  cat\n</Memo(MyDisplayName(Foo))>',
+  );
+});
+
 test('supports context Provider with a child', () => {
   const {Provider} = React.createContext('test');
 

--- a/packages/pretty-format/src/plugins/ReactElement.ts
+++ b/packages/pretty-format/src/plugins/ReactElement.ts
@@ -61,7 +61,8 @@ const getType = (element: any) => {
     }
 
     if (ReactIs.isMemo(type)) {
-      const functionName = type.type.displayName || type.type.name || '';
+      const functionName =
+        type.displayName || type.type.displayName || type.type.name || '';
 
       return functionName !== '' ? 'Memo(' + functionName + ')' : 'Memo';
     }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Currently, the way `jest` and `enzyme` handle memoized components is out of sync. This leads to some snapshot tests rendering the incorrect memoized component's displayName. e.g.: while using the latest `react-redux` version, some connected components are memoized and they respect the custom `displayName`, it can be checked here: https://github.com/reduxjs/react-redux/blob/master/src/components/connectAdvanced.js#L416.

`enzyme` has fixed it here: https://github.com/airbnb/enzyme/pull/2137/files, notice that it checks for the type's displayName, before going to the type's type displayName.

## Test plan

Prior to this, when a memoized/connected `React.Node` is passed as another component's props, the snapshot tests of that component would return `<Memo(ConnectFunction)>`, now they return the correct component displayName instead: `<Memo(Connect(MyComponent))>`

You can check the wrong case here: https://github.com/gustavovnicius/enzyme-display-name-bug/blob/master/src/__snapshots__/App.test.js.snap#L6

In the snapshot, it should be `body={<Memo(Connect(Body)) />}` instead of `body={<Memo(ConnectFunction) />}`
