### PR TITLE
fix(jest-haste-map): don't throw on missing mapper in Node crawler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - `[babel-plugin-jest-hoist]` Expand list of whitelisted globals in global mocks ([#8429](https://github.com/facebook/jest/pull/8429)
 - `[jest-core]` Make watch plugin initialization errors look nice ([#8422](https://github.com/facebook/jest/pull/8422))
 - `[jest-snapshot]` Prevent inline snapshots from drifting when inline snapshots are updated ([#8492](https://github.com/facebook/jest/pull/8492))
+- `[jest-haste-map]` Don't pass mapper to Node crawler snapshots are updated ([#8558](https://github.com/facebook/jest/pull/8558))
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - `[babel-plugin-jest-hoist]` Expand list of whitelisted globals in global mocks ([#8429](https://github.com/facebook/jest/pull/8429)
 - `[jest-core]` Make watch plugin initialization errors look nice ([#8422](https://github.com/facebook/jest/pull/8422))
 - `[jest-snapshot]` Prevent inline snapshots from drifting when inline snapshots are updated ([#8492](https://github.com/facebook/jest/pull/8492))
-- `[jest-haste-map]` Don't pass mapper to Node crawler snapshots are updated ([#8558](https://github.com/facebook/jest/pull/8558))
+- `[jest-haste-map]` Don't throw on missing mapper in Node crawler ([#8558](https://github.com/facebook/jest/pull/8558))
 
 ### Chore & Maintenance
 

--- a/packages/jest-haste-map/src/__tests__/index.test.js
+++ b/packages/jest-haste-map/src/__tests__/index.test.js
@@ -408,6 +408,9 @@ describe('HasteMap', () => {
         node.mockImplementation(options => {
           const {data} = options;
 
+          // `mapper` is not supported in Node crawl
+          expect(options.mapper).toBeUndefined();
+
           // The node crawler returns "null" for the SHA-1.
           data.files = createMap({
             'fruits/Banana.js': ['Banana', 32, 42, 0, 'Strawberry', null],
@@ -426,6 +429,7 @@ describe('HasteMap', () => {
         const hasteMap = new HasteMap({
           ...defaultConfig,
           computeSha1: true,
+          mapper: file => [file],
           maxWorkers: 1,
           useWatchman,
         });

--- a/packages/jest-haste-map/src/__tests__/index.test.js
+++ b/packages/jest-haste-map/src/__tests__/index.test.js
@@ -408,9 +408,6 @@ describe('HasteMap', () => {
         node.mockImplementation(options => {
           const {data} = options;
 
-          // `mapper` is not supported in Node crawl
-          expect(options.mapper).toBeUndefined();
-
           // The node crawler returns "null" for the SHA-1.
           data.files = createMap({
             'fruits/Banana.js': ['Banana', 32, 42, 0, 'Strawberry', null],

--- a/packages/jest-haste-map/src/crawlers/node.ts
+++ b/packages/jest-haste-map/src/crawlers/node.ts
@@ -139,10 +139,6 @@ export = function nodeCrawl(
   removedFiles: FileData;
   hasteMap: InternalHasteMap;
 }> {
-  if (options.mapper) {
-    throw new Error(`Option 'mapper' isn't supported by the Node crawler`);
-  }
-
   const {
     data,
     extensions,

--- a/packages/jest-haste-map/src/index.ts
+++ b/packages/jest-haste-map/src/index.ts
@@ -741,15 +741,15 @@ class HasteMap extends EventEmitter {
   private _crawl(hasteMap: InternalHasteMap) {
     const options = this._options;
     const ignore = this._ignore.bind(this);
-    const useWatchman = canUseWatchman && this._options.useWatchman;
-    const crawl = useWatchman ? watchmanCrawl : nodeCrawl;
+    const crawl =
+      canUseWatchman && this._options.useWatchman ? watchmanCrawl : nodeCrawl;
     const crawlerOptions: CrawlerOptions = {
       computeSha1: options.computeSha1,
       data: hasteMap,
       extensions: options.extensions,
       forceNodeFilesystemAPI: options.forceNodeFilesystemAPI,
       ignore,
-      mapper: useWatchman ? options.mapper : undefined,
+      mapper: options.mapper,
       rootDir: options.rootDir,
       roots: options.roots,
     };

--- a/packages/jest-haste-map/src/index.ts
+++ b/packages/jest-haste-map/src/index.ts
@@ -741,15 +741,15 @@ class HasteMap extends EventEmitter {
   private _crawl(hasteMap: InternalHasteMap) {
     const options = this._options;
     const ignore = this._ignore.bind(this);
-    const crawl =
-      canUseWatchman && this._options.useWatchman ? watchmanCrawl : nodeCrawl;
+    const useWatchman = canUseWatchman && this._options.useWatchman;
+    const crawl = useWatchman ? watchmanCrawl : nodeCrawl;
     const crawlerOptions: CrawlerOptions = {
       computeSha1: options.computeSha1,
       data: hasteMap,
       extensions: options.extensions,
       forceNodeFilesystemAPI: options.forceNodeFilesystemAPI,
       ignore,
-      mapper: options.mapper,
+      mapper: useWatchman ? options.mapper : undefined,
       rootDir: options.rootDir,
       roots: options.roots,
     };


### PR DESCRIPTION
## Summary

The `mapper` option passed to HasteMap is not supported in Node crawler, so we shouldn't pass it there. It's likely a cause of a regression in React Native 0.60 RC: https://github.com/facebook/react-native/pull/25241#issuecomment-501442208.

The regression was a part of this refactoring: https://github.com/facebook/jest/pull/8056/files#diff-5c5055968e3661a18f280d5e3f10c969L738

## Test plan

Added extra assertion to validate that mapper is not passed to Node crawler.

cc @scotthovestadt @arcanis 
