### PR TITLE
jest-snapshot: Highlight substring differences when matcher fails, part 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - `[expect]` Highlight substring differences when matcher fails, part 1 ([#8448](https://github.com/facebook/jest/pull/8448))
 - `[expect]` Highlight substring differences when matcher fails, part 2 ([#8528](https://github.com/facebook/jest/pull/8528))
+- `[expect]` Highlight substring differences when matcher fails, part 3 ([#8569](https://github.com/facebook/jest/pull/8569))
 - `[jest-cli]` Improve chai support (with detailed output, to match jest exceptions) ([#8454](https://github.com/facebook/jest/pull/8454))
 - `[*]` Manage the global timeout with `--testTimeout` command line argument. ([#8456](https://github.com/facebook/jest/pull/8456))
 - `[pretty-format]` Render custom displayName of memoized components

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - `[expect]` Highlight substring differences when matcher fails, part 1 ([#8448](https://github.com/facebook/jest/pull/8448))
 - `[expect]` Highlight substring differences when matcher fails, part 2 ([#8528](https://github.com/facebook/jest/pull/8528))
-- `[expect]` Highlight substring differences when matcher fails, part 3 ([#8569](https://github.com/facebook/jest/pull/8569))
+- `[jest-snapshot]` Highlight substring differences when matcher fails, part 3 ([#8569](https://github.com/facebook/jest/pull/8569))
 - `[jest-cli]` Improve chai support (with detailed output, to match jest exceptions) ([#8454](https://github.com/facebook/jest/pull/8454))
 - `[*]` Manage the global timeout with `--testTimeout` command line argument. ([#8456](https://github.com/facebook/jest/pull/8456))
 - `[pretty-format]` Render custom displayName of memoized components

--- a/e2e/__tests__/__snapshots__/failures.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/failures.test.ts.snap
@@ -790,11 +790,8 @@ FAIL __tests__/snapshot.test.js
 
     Snapshot name: \`failing snapshot 1\`
 
-    - Snapshot
-    + Received
-
-    - "bar"
-    + "foo"
+    Snapshot: "bar"
+    Received: "foo"
 
        9 | 
       10 | test('failing snapshot', () => {
@@ -819,11 +816,8 @@ FAIL __tests__/snapshotWithHint.test.js
 
     Snapshot name: \`failing snapshot with hint: descriptive hint 1\`
 
-    - Snapshot
-    + Received
-
-    - "bar"
-    + "foo"
+    Snapshot: "bar"
+    Received: "foo"
 
        9 | 
       10 | test('failing snapshot with hint', () => {

--- a/e2e/__tests__/__snapshots__/watchModeUpdateSnapshot.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/watchModeUpdateSnapshot.test.ts.snap
@@ -6,10 +6,8 @@ FAIL __tests__/bar.spec.js
   ● bar
     expect(received).toMatchSnapshot()
     Snapshot name: \`bar 1\`
-    - Snapshot
-    + Received
-    - "foo"
-    + "bar"
+    Snapshot: "foo"
+    Received: "bar"
       1 |
     > 2 |       test('bar', () => { expect('bar').toMatchSnapshot(); });
         |                                         ^

--- a/e2e/__tests__/toMatchSnapshot.test.ts
+++ b/e2e/__tests__/toMatchSnapshot.test.ts
@@ -108,7 +108,7 @@ test('first snapshot fails, second passes', () => {
     writeFiles(TESTS_DIR, {[filename]: template([`'kiwi'`, `'banana'`])});
     const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     expect(stderr).toMatch('Snapshot name: `snapshots 1`');
-    expect(stderr).toMatch('- "apple"\n    + "kiwi"');
+    expect(stderr).toMatch('Snapshot: "apple"\n    Received: "kiwi"');
     expect(stderr).not.toMatch('1 obsolete snapshot found');
     expect(status).toBe(1);
   }

--- a/packages/jest-snapshot/package.json
+++ b/packages/jest-snapshot/package.json
@@ -15,6 +15,7 @@
     "chalk": "^2.0.1",
     "expect": "^24.8.0",
     "jest-diff": "^24.8.0",
+    "jest-get-type": "^24.8.0",
     "jest-matcher-utils": "^24.8.0",
     "jest-message-util": "^24.8.0",
     "jest-resolve": "^24.8.0",

--- a/packages/jest-snapshot/src/__tests__/__snapshots__/printDiffOrStringified.test.ts.snap
+++ b/packages/jest-snapshot/src/__tests__/__snapshots__/printDiffOrStringified.test.ts.snap
@@ -1,0 +1,180 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`empty string expected and received single line 1`] = `
+Snapshot: <g>""</>
+Received: <r>"single line string"</>
+`;
+
+exports[`empty string received and expected multi line 1`] = `
+Snapshot: <g>"multi</>
+<g>line</>
+<g>string"</>
+Received: <r>""</>
+`;
+
+exports[`escape backslash in multi line string 1`] = `
+<g>- Snapshot</>
+<r>+ Received</>
+
+<g>- Forward / slash<i> and b</i>ack \\ slash</>
+<r>+ Forward / slash</>
+<r>+ <i>B</i>ack \\ slash</>
+`;
+
+exports[`escape backslash in single line string 1`] = `
+Snapshot: <g>"<i>f</i>orward / slash and back \\\\ slash"</>
+Received: <r>"<i>F</i>orward / slash and back \\\\ slash"</>
+`;
+
+exports[`escape double quote marks in string 1`] = `
+Snapshot: <g>"What does \\"<i>oo</i>bleck\\" mean?"</>
+Received: <r>"What does \\"<i>ew</i>bleck\\" mean?"</>
+`;
+
+exports[`escape regexp 1`] = `
+Snapshot: <g>/\\\\\\\\\\("\\)/g</>
+Received: <r>/\\\\\\\\\\("\\)/</>
+`;
+
+exports[`expand false 1`] = `
+<g>- Snapshot</>
+<r>+ Received</>
+
+<y>@@ -12,7 +12,9 @@</>
+<d>  ? "number"</>
+<d>  : T extends boolean</>
+<d>  ? "boolean"</>
+<d>  : T extends undefined</>
+<d>  ? "undefined"</>
+<g>- : T extends Function<i> </i>? "function"<i> </i>: "object";</>
+<r>+ : T extends Function</>
+<r>+ ? "function"</>
+<r>+ : "object";</>
+<d>  ↵</>
+`;
+
+exports[`expand true 1`] = `
+<g>- Snapshot</>
+<r>+ Received</>
+
+<d>  type TypeName<T> =</>
+<d>  T extends string ? "string" :</>
+<d>  T extends number ? "number" :</>
+<d>  T extends boolean ? "boolean" :</>
+<d>  T extends undefined ? "undefined" :</>
+<d>  T extends Function ? "function" :</>
+<d>  "object";</>
+<d>  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~</>
+<d>  type TypeName<T> = T extends string</>
+<d>  ? "string"</>
+<d>  : T extends number</>
+<d>  ? "number"</>
+<d>  : T extends boolean</>
+<d>  ? "boolean"</>
+<d>  : T extends undefined</>
+<d>  ? "undefined"</>
+<g>- : T extends Function<i> </i>? "function"<i> </i>: "object";</>
+<r>+ : T extends Function</>
+<r>+ ? "function"</>
+<r>+ : "object";</>
+<d>  ↵</>
+`;
+
+exports[`fallback to line diff 1`] = `
+<g>- Snapshot</>
+<r>+ Received</>
+
+<r>+ ====================================options=====================================</>
+<r>+ parsers: ["flow", "typescript"]</>
+<r>+ printWidth: 80</>
+<r>+                                                                                 | printWidth</>
+<r>+ =====================================input======================================</>
+<d>  [...a, ...b,];</>
+<d>  [...a, ...b];</>
+<g>- ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~</>
+<r>+ </>
+<r>+ =====================================output=====================================</>
+<d>  [...a, ...b];</>
+<d>  [...a, ...b];</>
+<d>  </>
+<r>+ ================================================================================</>
+`;
+
+exports[`isLineDiffable false boolean 1`] = `
+Snapshot: <g>true</>
+Received: <r>false</>
+`;
+
+exports[`isLineDiffable false number 1`] = `
+Snapshot: <g>-0</>
+Received: <r>NaN</>
+`;
+
+exports[`isLineDiffable true array 1`] = `
+<g>- Snapshot</>
+<r>+ Received</>
+
+<d>  Array [</>
+<d>    Object {</>
+<r>+     "_id": "b14680dec683e744ada1f2fe08614086",</>
+<d>      "code": 4011,</>
+<d>      "weight": 2.13,</>
+<d>    },</>
+<d>    Object {</>
+<r>+     "_id": "7fc63ff01769c4fa7d9279e97e307829",</>
+<d>      "code": 4019,</>
+<d>      "count": 4,</>
+<d>    },</>
+<d>  ]</>
+`;
+
+exports[`isLineDiffable true object 1`] = `
+<g>- Snapshot</>
+<r>+ Received</>
+
+<d>  Object {</>
+<d>    "props": Object {</>
+<g>-     "className": "logo",</>
+<g>-     "src": "/img/jest.png",</>
+<r>+     "alt": "Jest logo",</>
+<r>+     "class": "logo",</>
+<r>+     "src": "/img/jest.svg",</>
+<d>    },</>
+<d>    "type": "img",</>
+<d>  }</>
+`;
+
+exports[`multi line small change in one line and other is unchanged 1`] = `
+<g>- Snapshot</>
+<r>+ Received</>
+
+<g>- There is no route defined for key <i>'</i>Settings<i>'</i>.</>
+<r>+ There is no route defined for key Settings.</>
+<d>  Must be one of: 'Home'</>
+`;
+
+exports[`multi line small changes 1`] = `
+<g>- Snapshot</>
+<r>+ Received</>
+
+<g>-     6<i>9</i> |·</>
+<r>+     6<i>8</i> |·</>
+<g>-     <i>70</i> | test('assert.doesNotThrow', () => {</>
+<r>+     <i>69</i> | test('assert.doesNotThrow', () => {</>
+<g>-   > 7<i>1</i> |   assert.doesNotThrow(() => {</>
+<r>+   > 7<i>0</i> |   assert.doesNotThrow(() => {</>
+<d>         |          ^</>
+<g>-     7<i>2</i> |     throw Error('err!');</>
+<r>+     7<i>1</i> |     throw Error('err!');</>
+<g>-     7<i>3</i> |   });</>
+<r>+     7<i>2</i> |   });</>
+<g>-     7<i>4</i> | });</>
+<r>+     7<i>3</i> | });</>
+<g>-     at Object.doesNotThrow (__tests__/assertionError.test.js:7<i>1</i>:10)</>
+<r>+     at Object.doesNotThrow (__tests__/assertionError.test.js:7<i>0</i>:10)</>
+`;
+
+exports[`single line large changes 1`] = `
+Snapshot: <g>"<i>A</i>rray length<i> must be a finite positive integer</i>"</>
+Received: <r>"<i>Invalid a</i>rray length"</>
+`;

--- a/packages/jest-snapshot/src/__tests__/__snapshots__/printDiffOrStringified.test.ts.snap
+++ b/packages/jest-snapshot/src/__tests__/__snapshots__/printDiffOrStringified.test.ts.snap
@@ -144,6 +144,11 @@ exports[`isLineDiffable true object 1`] = `
 <d>  }</>
 `;
 
+exports[`isLineDiffable true single line expected and received 1`] = `
+Snapshot: <g>Array []</>
+Received: <r>Object {}</>
+`;
+
 exports[`multi line small change in one line and other is unchanged 1`] = `
 <g>- Snapshot</>
 <r>+ Received</>

--- a/packages/jest-snapshot/src/__tests__/__snapshots__/printDiffOrStringified.test.ts.snap
+++ b/packages/jest-snapshot/src/__tests__/__snapshots__/printDiffOrStringified.test.ts.snap
@@ -183,3 +183,19 @@ exports[`single line large changes 1`] = `
 Snapshot: <g>"<i>A</i>rray length<i> must be a finite positive integer</i>"</>
 Received: <r>"<i>Invalid a</i>rray length"</>
 `;
+
+exports[`without serialize prettier/pull/5590 1`] = `
+<g>- Snapshot</>
+<r>+ Received</>
+
+<y>@@ -4,8 +4,8 @@</>
+<d>                                                                                  | printWidth</>
+<d>  =====================================input======================================</>
+<d>  <img src="test.png" alt='John "ShotGun" Nelson'></>
+
+<d>  =====================================output=====================================</>
+<g>- <img src="test.png" alt=<i>"</i>John <i>&quot;</i>ShotGun<i>&quot;</i> Nelson<i>"</i> /></>
+<r>+ <img src="test.png" alt=<i>'</i>John <i>"</i>ShotGun<i>"</i> Nelson<i>'</i> /></>
+
+<d>  ================================================================================</>
+`;

--- a/packages/jest-snapshot/src/__tests__/__snapshots__/printDiffOrStringified.test.ts.snap
+++ b/packages/jest-snapshot/src/__tests__/__snapshots__/printDiffOrStringified.test.ts.snap
@@ -1,5 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`backtick single line expected and received 1`] = `
+Snapshot: <g>"var foo = \`backtick\`;"</>
+Received: <r>"var foo = <i>tag</i>\`backtick\`;"</>
+`;
+
 exports[`empty string expected and received single line 1`] = `
 Snapshot: <g>""</>
 Received: <r>"single line string"</>
@@ -144,6 +149,16 @@ exports[`isLineDiffable true object 1`] = `
 <d>  }</>
 `;
 
+exports[`isLineDiffable true single line expected and multi line received 1`] = `
+<g>- Snapshot</>
+<r>+ Received</>
+
+<g>- Array []</>
+<r>+ Array [</>
+<r>+   0,</>
+<r>+ ]</>
+`;
+
 exports[`isLineDiffable true single line expected and received 1`] = `
 Snapshot: <g>Array []</>
 Received: <r>Object {}</>
@@ -182,6 +197,20 @@ exports[`multi line small changes 1`] = `
 exports[`single line large changes 1`] = `
 Snapshot: <g>"<i>A</i>rray length<i> must be a finite positive integer</i>"</>
 Received: <r>"<i>Invalid a</i>rray length"</>
+`;
+
+exports[`without serialize backtick single line expected and multi line received 1`] = `
+<g>- Snapshot</>
+<r>+ Received</>
+
+<g>- var foo = \`backtick\`;</>
+<r>+ var foo = \`back</>
+<r>+ tick\`;</>
+`;
+
+exports[`without serialize backtick single line expected and received 1`] = `
+Snapshot: <g>var foo = \`backtick\`;</>
+Received: <r>var foo = \`back<i>\${x}</i>tick\`;</>
 `;
 
 exports[`without serialize prettier/pull/5590 1`] = `

--- a/packages/jest-snapshot/src/__tests__/printDiffOrStringified.test.ts
+++ b/packages/jest-snapshot/src/__tests__/printDiffOrStringified.test.ts
@@ -264,6 +264,15 @@ describe('isLineDiffable', () => {
         testDiffOrStringified(expected, received, false),
       ).toMatchSnapshot();
     });
+
+    test('single line expected and received', () => {
+      const expected = [];
+      const received = {};
+
+      expect(
+        testDiffOrStringified(expected, received, false),
+      ).toMatchSnapshot();
+    });
   });
 });
 

--- a/packages/jest-snapshot/src/__tests__/printDiffOrStringified.test.ts
+++ b/packages/jest-snapshot/src/__tests__/printDiffOrStringified.test.ts
@@ -94,6 +94,15 @@ const testWithoutSerialize = (
     ),
   );
 
+describe('backtick', () => {
+  test('single line expected and received', () => {
+    const expected = 'var foo = `backtick`;';
+    const received = 'var foo = tag`backtick`;';
+
+    expect(testWithSerialize(expected, received, false)).toMatchSnapshot();
+  });
+});
+
 describe('empty string', () => {
   test('expected and received single line', () => {
     const expected = '';
@@ -286,6 +295,13 @@ describe('isLineDiffable', () => {
 
       expect(testWithSerialize(expected, received, false)).toMatchSnapshot();
     });
+
+    test('single line expected and multi line received', () => {
+      const expected = [];
+      const received = [0];
+
+      expect(testWithSerialize(expected, received, false)).toMatchSnapshot();
+    });
   });
 });
 
@@ -331,6 +347,20 @@ test('single line large changes', () => {
 });
 
 describe('without serialize', () => {
+  test('backtick single line expected and received', () => {
+    const expected = 'var foo = `backtick`;';
+    const received = 'var foo = `back${x}tick`;';
+
+    expect(testWithoutSerialize(expected, received, false)).toMatchSnapshot();
+  });
+
+  test('backtick single line expected and multi line received', () => {
+    const expected = 'var foo = `backtick`;';
+    const received = 'var foo = `back\ntick`;';
+
+    expect(testWithoutSerialize(expected, received, false)).toMatchSnapshot();
+  });
+
   test('prettier/pull/5590', () => {
     const expected = [
       '====================================options=====================================',

--- a/packages/jest-snapshot/src/__tests__/printDiffOrStringified.test.ts
+++ b/packages/jest-snapshot/src/__tests__/printDiffOrStringified.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 import ansiRegex from 'ansi-regex';
 import style from 'ansi-styles';
 import {printDiffOrStringified} from '../print';

--- a/packages/jest-snapshot/src/__tests__/printDiffOrStringified.test.ts
+++ b/packages/jest-snapshot/src/__tests__/printDiffOrStringified.test.ts
@@ -1,0 +1,302 @@
+import ansiRegex from 'ansi-regex';
+import style from 'ansi-styles';
+import {printDiffOrStringified} from '../print';
+import {serialize, unescape} from '../utils';
+
+// This is an experiment to read snapshots more easily:
+// * to avoid first line misaligned because of opening double quote mark,
+//   return string without calling print function to serialize it,
+//   which also reduces extra escape sequences which is a subject of the tests!
+// * to align lines, return <d> <g> <r> <y> tags which have same width
+// * to see inline markup, return matching <i> and </i> tags
+// * to see unexpected escape codes, do not return empty string as default
+expect.addSnapshotSerializer({
+  serialize(val: string) {
+    return val.replace(ansiRegex(), match => {
+      switch (match) {
+        case style.inverse.open:
+          return '<i>';
+        case style.inverse.close:
+          return '</i>';
+
+        case style.dim.open:
+          return '<d>';
+        case style.green.open:
+          return '<g>';
+        case style.red.open:
+          return '<r>';
+        case style.yellow.open:
+          return '<y>';
+
+        case style.dim.close:
+        case style.green.close:
+        case style.red.close:
+        case style.yellow.close:
+          return '</>';
+
+        default:
+          return match;
+      }
+    });
+  },
+  test(val: any) {
+    return typeof val === 'string' && !!val.match(ansiRegex());
+  },
+});
+
+const testDiffOrStringified = (
+  expected: any,
+  received: any,
+  expand: boolean,
+): string => {
+  // Simulate serializing the expected value as a snapshot,
+  // and then returning actual and expected when match function fails.
+  // Assume that the caller of printDiffOrStringified trims the strings.
+  const expectedSerializedTrimmed = unescape(serialize(expected)).trim();
+  const receivedSerializedTrimmed = unescape(serialize(received)).trim();
+
+  return printDiffOrStringified(
+    expectedSerializedTrimmed,
+    receivedSerializedTrimmed,
+    received,
+    'Snapshot',
+    'Received',
+    expand,
+  );
+};
+
+describe('empty string', () => {
+  test('expected and received single line', () => {
+    const expected = '';
+    const received = 'single line string';
+
+    expect(testDiffOrStringified(expected, received, false)).toMatchSnapshot();
+  });
+
+  test('received and expected multi line', () => {
+    const expected = 'multi\nline\nstring';
+    const received = '';
+
+    expect(testDiffOrStringified(expected, received, false)).toMatchSnapshot();
+  });
+});
+
+describe('escape', () => {
+  test('double quote marks in string', () => {
+    const expected = 'What does "oobleck" mean?';
+    const received = 'What does "ewbleck" mean?';
+
+    expect(testDiffOrStringified(expected, received, false)).toMatchSnapshot();
+  });
+
+  test('backslash in multi line string', () => {
+    const expected = 'Forward / slash and back \\ slash';
+    const received = 'Forward / slash\nBack \\ slash';
+
+    expect(testDiffOrStringified(expected, received, false)).toMatchSnapshot();
+  });
+
+  test('backslash in single line string', () => {
+    const expected = 'forward / slash and back \\ slash';
+    const received = 'Forward / slash and back \\ slash';
+
+    expect(testDiffOrStringified(expected, received, false)).toMatchSnapshot();
+  });
+
+  test('regexp', () => {
+    const expected = /\\(")/g;
+    const received = /\\(")/;
+
+    expect(testDiffOrStringified(expected, received, false)).toMatchSnapshot();
+  });
+});
+
+describe('expand', () => {
+  const expected = [
+    'type TypeName<T> =',
+    'T extends string ? "string" :',
+    'T extends number ? "number" :',
+    'T extends boolean ? "boolean" :',
+    'T extends undefined ? "undefined" :',
+    'T extends Function ? "function" :',
+    '"object";',
+    '~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~',
+    'type TypeName<T> = T extends string',
+    '? "string"',
+    ': T extends number',
+    '? "number"',
+    ': T extends boolean',
+    '? "boolean"',
+    ': T extends undefined',
+    '? "undefined"',
+    ': T extends Function ? "function" : "object";',
+    '',
+  ].join('\n');
+  const received = [
+    'type TypeName<T> =',
+    'T extends string ? "string" :',
+    'T extends number ? "number" :',
+    'T extends boolean ? "boolean" :',
+    'T extends undefined ? "undefined" :',
+    'T extends Function ? "function" :',
+    '"object";',
+    '~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~',
+    'type TypeName<T> = T extends string',
+    '? "string"',
+    ': T extends number',
+    '? "number"',
+    ': T extends boolean',
+    '? "boolean"',
+    ': T extends undefined',
+    '? "undefined"',
+    ': T extends Function',
+    '? "function"',
+    ': "object";',
+    '',
+  ].join('\n');
+
+  test('false', () => {
+    expect(testDiffOrStringified(expected, received, false)).toMatchSnapshot();
+  });
+
+  test('true', () => {
+    expect(testDiffOrStringified(expected, received, true)).toMatchSnapshot();
+  });
+});
+
+test('fallback to line diff', () => {
+  const expected = [
+    '[...a, ...b,];',
+    '[...a, ...b];',
+    '~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~',
+    '[...a, ...b];',
+    '[...a, ...b];',
+    '',
+  ].join('\n');
+  const received = [
+    '====================================options=====================================',
+    'parsers: ["flow", "typescript"]',
+    'printWidth: 80',
+    '                                                                                | printWidth',
+    '=====================================input======================================',
+    '[...a, ...b,];',
+    '[...a, ...b];',
+    '',
+    '=====================================output=====================================',
+    '[...a, ...b];',
+    '[...a, ...b];',
+    '',
+    '================================================================================',
+  ].join('\n');
+
+  expect(testDiffOrStringified(expected, received, false)).toMatchSnapshot();
+});
+
+describe('isLineDiffable', () => {
+  describe('false', () => {
+    test('boolean', () => {
+      const expected = true;
+      const received = false;
+
+      expect(
+        testDiffOrStringified(expected, received, false),
+      ).toMatchSnapshot();
+    });
+
+    test('number', () => {
+      const expected = -0;
+      const received = NaN;
+
+      expect(
+        testDiffOrStringified(expected, received, false),
+      ).toMatchSnapshot();
+    });
+  });
+
+  describe('true', () => {
+    test('array', () => {
+      const expected0 = {
+        code: 4011,
+        weight: 2.13,
+      };
+      const expected1 = {
+        code: 4019,
+        count: 4,
+      };
+
+      const expected = [expected0, expected1];
+      const received = [
+        {_id: 'b14680dec683e744ada1f2fe08614086', ...expected0},
+        {_id: '7fc63ff01769c4fa7d9279e97e307829', ...expected1},
+      ];
+
+      expect(
+        testDiffOrStringified(expected, received, false),
+      ).toMatchSnapshot();
+    });
+
+    test('object', () => {
+      const type = 'img';
+      const expected = {
+        props: {
+          className: 'logo',
+          src: '/img/jest.png',
+        },
+        type,
+      };
+      const received = {
+        props: {
+          alt: 'Jest logo',
+          class: 'logo',
+          src: '/img/jest.svg',
+        },
+        type,
+      };
+
+      expect(
+        testDiffOrStringified(expected, received, false),
+      ).toMatchSnapshot();
+    });
+  });
+});
+
+test('multi line small change in one line and other is unchanged', () => {
+  const expected =
+    "There is no route defined for key 'Settings'.\nMust be one of: 'Home'";
+  const received =
+    "There is no route defined for key Settings.\nMust be one of: 'Home'";
+
+  expect(testDiffOrStringified(expected, received, false)).toMatchSnapshot();
+});
+
+test('multi line small changes', () => {
+  const expected = [
+    '    69 | ',
+    "    70 | test('assert.doesNotThrow', () => {",
+    '  > 71 |   assert.doesNotThrow(() => {',
+    '       |          ^',
+    "    72 |     throw Error('err!');",
+    '    73 |   });',
+    '    74 | });',
+    '    at Object.doesNotThrow (__tests__/assertionError.test.js:71:10)',
+  ].join('\n');
+  const received = [
+    '    68 | ',
+    "    69 | test('assert.doesNotThrow', () => {",
+    '  > 70 |   assert.doesNotThrow(() => {',
+    '       |          ^',
+    "    71 |     throw Error('err!');",
+    '    72 |   });',
+    '    73 | });',
+    '    at Object.doesNotThrow (__tests__/assertionError.test.js:70:10)',
+  ].join('\n');
+
+  expect(testDiffOrStringified(expected, received, false)).toMatchSnapshot();
+});
+
+test('single line large changes', () => {
+  const expected = 'Array length must be a finite positive integer';
+  const received = 'Invalid array length';
+
+  expect(testDiffOrStringified(expected, received, false)).toMatchSnapshot();
+});

--- a/packages/jest-snapshot/src/index.ts
+++ b/packages/jest-snapshot/src/index.ts
@@ -344,7 +344,14 @@ const _toMatchSnapshot = ({
     const reported =
       `Snapshot name: ${printName(currentTestName, hint, count)}\n\n` +
       printDiffOrStringify(
-        expected.trim().slice(1, -1),
+        // 1. Remove leading and trailing newline if multiple line string.
+        // 2. Remove enclosing double quote marks.
+        // 3. Remove backslash escape preceding backslash here,
+        //    because unescape replaced it only preceding double quote mark.
+        expected
+          .trim()
+          .slice(1, -1)
+          .replace(/\\\\/g, '\\'),
         received,
         SNAPSHOT_LABEL,
         RECEIVED_LABEL,

--- a/packages/jest-snapshot/src/index.ts
+++ b/packages/jest-snapshot/src/index.ts
@@ -52,9 +52,6 @@ const NOT_SNAPSHOT_MATCHERS = `.${BOLD_WEIGHT(
 const SNAPSHOT_LABEL = 'Snapshot';
 const RECEIVED_LABEL = 'Received';
 
-// The optional property of matcher context is true if undefined.
-const isExpand = (expand?: boolean): boolean => expand !== false;
-
 const HINT_ARG = BOLD_WEIGHT('hint');
 const INLINE_SNAPSHOT_ARG = 'snapshot';
 const PROPERTY_MATCHERS_ARG = 'properties';
@@ -355,7 +352,7 @@ const _toMatchSnapshot = ({
         received,
         SNAPSHOT_LABEL,
         RECEIVED_LABEL,
-        isExpand(snapshotState.expand),
+        snapshotState.expand,
       );
 
     report = () => reported;

--- a/packages/jest-snapshot/src/index.ts
+++ b/packages/jest-snapshot/src/index.ts
@@ -337,7 +337,7 @@ const _toMatchSnapshot = ({
     // Does expected snapshot look like a stringified string:
     expected.length >= 2 &&
     ((expected.startsWith('"') && expected.endsWith('"')) || // single line
-      (expected.startsWith('\n"') && expected.endsWith('"\n'))) // // multi line
+      (expected.startsWith('\n"') && expected.endsWith('"\n'))) // multi line
   ) {
     // Assign to local variable because of declaration let expected:
     // TypeScript thinks it could change before report function is called.

--- a/packages/jest-snapshot/src/print.ts
+++ b/packages/jest-snapshot/src/print.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 import diff from 'jest-diff';
 import getType, {isPrimitive} from 'jest-get-type';
 import {

--- a/packages/jest-snapshot/src/print.ts
+++ b/packages/jest-snapshot/src/print.ts
@@ -61,7 +61,7 @@ export const printDiffOrStringified = (
       receivedSerializedTrimmed === unescape(prettyFormat(received))
     ) {
       // The expected snapshot looks like a stringified string.
-      // The received string has default serialization.
+      // The received serialization is default stringified string.
 
       // Undo default serialization of expected snapshot:
       // Remove enclosing double quote marks.

--- a/packages/jest-snapshot/src/print.ts
+++ b/packages/jest-snapshot/src/print.ts
@@ -94,6 +94,8 @@ export const printDiffOrStringified = (
 
       // Because not default stringify, call EXPECTED_COLOR and RECEIVED_COLOR
       // This is reason to call getStringDiff instead of printDiffOrStringify
+      // Because there is no closing double quote mark at end of single lines,
+      // future improvement is to call replaceSpacesAtEnd if it becomes public.
       const printLabel = getLabelPrinter(expectedLabel, receivedLabel);
       return (
         printLabel(expectedLabel) +

--- a/packages/jest-snapshot/src/print.ts
+++ b/packages/jest-snapshot/src/print.ts
@@ -18,7 +18,7 @@ const isLineDiffable = (received: any): boolean => {
   const receivedType = getType(received);
 
   if (isPrimitive(received)) {
-    return false;
+    return typeof received === 'string' && received.includes('\n');
   }
 
   if (
@@ -71,7 +71,11 @@ export const printDiffOrStringified = (
     );
   }
 
-  if (isLineDiffable(received)) {
+  if (
+    expectedSerializedTrimmed.includes('\n') &&
+    receivedSerializedTrimmed.includes('\n') &&
+    isLineDiffable(received)
+  ) {
     return diff(expectedSerializedTrimmed, receivedSerializedTrimmed, {
       aAnnotation: expectedLabel,
       bAnnotation: receivedLabel,

--- a/packages/jest-snapshot/src/print.ts
+++ b/packages/jest-snapshot/src/print.ts
@@ -72,8 +72,8 @@ export const printDiffOrStringified = (
   }
 
   if (
-    expectedSerializedTrimmed.includes('\n') &&
-    receivedSerializedTrimmed.includes('\n') &&
+    (expectedSerializedTrimmed.includes('\n') ||
+      receivedSerializedTrimmed.includes('\n')) &&
     isLineDiffable(received)
   ) {
     return diff(expectedSerializedTrimmed, receivedSerializedTrimmed, {

--- a/packages/jest-snapshot/src/print.ts
+++ b/packages/jest-snapshot/src/print.ts
@@ -1,0 +1,83 @@
+import diff from 'jest-diff';
+import getType, {isPrimitive} from 'jest-get-type';
+import {
+  EXPECTED_COLOR,
+  RECEIVED_COLOR,
+  getLabelPrinter,
+  printDiffOrStringify,
+} from 'jest-matcher-utils';
+
+const isLineDiffable = (received: any): boolean => {
+  const receivedType = getType(received);
+
+  if (isPrimitive(received)) {
+    return false;
+  }
+
+  if (
+    receivedType === 'date' ||
+    receivedType === 'function' ||
+    receivedType === 'regexp'
+  ) {
+    return false;
+  }
+
+  if (received instanceof Error) {
+    return false;
+  }
+
+  if (
+    receivedType === 'object' &&
+    typeof (received as any).asymmetricMatch === 'function'
+  ) {
+    return false;
+  }
+
+  return true;
+};
+
+export const printDiffOrStringified = (
+  expectedSerializedTrimmed: string,
+  receivedSerializedTrimmed: string,
+  received: unknown,
+  expectedLabel: string,
+  receivedLabel: string,
+  expand: boolean, // CLI options: true if `--expand` or false if `--no-expand`
+): string => {
+  if (
+    typeof received === 'string' &&
+    // Does expected snapshot look like a stringified string:
+    expectedSerializedTrimmed.length >= 2 &&
+    expectedSerializedTrimmed.startsWith('"') &&
+    expectedSerializedTrimmed.endsWith('"')
+  ) {
+    // 0. Assume leading and trailing newline has been trimmed.
+    // 1. Remove enclosing double quote marks.
+    // 2. Remove backslash escape preceding backslash here,
+    //    because unescape replaced it only preceding double quote mark.
+    return printDiffOrStringify(
+      expectedSerializedTrimmed.slice(1, -1).replace(/\\\\/g, '\\'),
+      received,
+      expectedLabel,
+      receivedLabel,
+      expand,
+    );
+  }
+
+  if (isLineDiffable(received)) {
+    return diff(expectedSerializedTrimmed, receivedSerializedTrimmed, {
+      aAnnotation: expectedLabel,
+      bAnnotation: receivedLabel,
+      expand,
+    }) as string;
+  }
+
+  const printLabel = getLabelPrinter(expectedLabel, receivedLabel);
+  return (
+    printLabel(expectedLabel) +
+    EXPECTED_COLOR(expectedSerializedTrimmed) +
+    '\n' +
+    printLabel(receivedLabel) +
+    RECEIVED_COLOR(receivedSerializedTrimmed)
+  );
+};

--- a/packages/jest-snapshot/tsconfig.json
+++ b/packages/jest-snapshot/tsconfig.json
@@ -7,6 +7,7 @@
   "references": [
     {"path": "../expect"},
     {"path": "../jest-diff"},
+    {"path": "../jest-get-type"},
     {"path": "../jest-haste-map"},
     {"path": "../jest-matcher-utils"},
     {"path": "../jest-message-util"},


### PR DESCRIPTION
## Summary

When expected and received are both **string**, snapshot matchers call `printDiffOrStringify`

If neither received nor expected (snapshot) is multiline, or either is empty:

* display following `Snapshot:` and `Received:` labels

If either received or expected (snapshot) is multiline, and neither is empty:

* if semantic cleanup leaves a common substring, highlight substring differences
* otherwise display line diff, however without enclosing double quote marks

## Test plan

The change in report for single-line strings affects a few tests:

* updated 1 `toMatch` assertion in `e2e/__tests__/toMatchSnapshot.test.ts`
* updated 2 snapshots in `e2e/__tests__/failures.test.ts`
* updated 1 snapshot in `watchModeUpdateSnapshot.test.ts`

Added `printDiffOrStringified.test.ts` in `jest-snapshot` package

See pictures of reports from local tests in following comments

Example pictures baseline at left and **improved at right**