### PR TITLE
Fix warning message when there are no tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `[jest-core]` Make watch plugin initialization errors look nice ([#8422](https://github.com/facebook/jest/pull/8422))
 - `[jest-snapshot]` Prevent inline snapshots from drifting when inline snapshots are updated ([#8492](https://github.com/facebook/jest/pull/8492))
 - `[jest-haste-map]` Don't throw on missing mapper in Node crawler ([#8558](https://github.com/facebook/jest/pull/8558))
+- `[jest-core]` Fix incorrect `passWithNoTests` warning ([#8595](https://github.com/facebook/jest/pull/8595))
 
 ### Chore & Maintenance
 

--- a/packages/jest-core/src/__tests__/__snapshots__/getNoTestsFoundMessage.test.js.snap
+++ b/packages/jest-core/src/__tests__/__snapshots__/getNoTestsFoundMessage.test.js.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getNoTestsFoundMessage returns correct message when monitoring only changed 1`] = `"<bold>No tests found related to files changed since last commit.</>"`;
+
+exports[`getNoTestsFoundMessage returns correct message when monitoring only failures 1`] = `
+"<bold>No failed test found.</>
+<bold></><dim>Press \`f\` to quit \\"only failed tests\\" mode.</>"
+`;
+
+exports[`getNoTestsFoundMessage returns correct message with verbose option 1`] = `
+"<bold>No tests found, exiting with code 1</>
+Run with \`--passWithNoTests\` to exit with code 0
+
+Pattern: <yellow>/path/pattern</> - 0 matches"
+`;
+
+exports[`getNoTestsFoundMessage returns correct message without options 1`] = `
+"<bold>No tests found, exiting with code 1</>
+Run with \`--passWithNoTests\` to exit with code 0
+In <bold>/root/dir</>
+  0 files checked across 0 projects. Run with \`--verbose\` for more details.
+Pattern: <yellow>/path/pattern</> - 0 matches"
+`;

--- a/packages/jest-core/src/__tests__/__snapshots__/getNoTestsFoundMessage.test.js.snap
+++ b/packages/jest-core/src/__tests__/__snapshots__/getNoTestsFoundMessage.test.js.snap
@@ -7,6 +7,8 @@ exports[`getNoTestsFoundMessage returns correct message when monitoring only fai
 <bold></><dim>Press \`f\` to quit \\"only failed tests\\" mode.</>"
 `;
 
+exports[`getNoTestsFoundMessage returns correct message with passWithNoTests 1`] = `"<bold>No tests found, exiting with code 0</>"`;
+
 exports[`getNoTestsFoundMessage returns correct message with verbose option 1`] = `
 "<bold>No tests found, exiting with code 1</>
 Run with \`--passWithNoTests\` to exit with code 0

--- a/packages/jest-core/src/__tests__/getNoTestsFoundMessage.test.js
+++ b/packages/jest-core/src/__tests__/getNoTestsFoundMessage.test.js
@@ -28,4 +28,9 @@ describe('getNoTestsFoundMessage', () => {
     const config = createGlobalConfig();
     expect(getNoTestsFoundMessage([], config)).toMatchSnapshot();
   });
+
+  test('returns correct message with passWithNoTests', () => {
+    const config = createGlobalConfig({passWithNoTests: true});
+    expect(getNoTestsFoundMessage([], config)).toMatchSnapshot();
+  });
 });

--- a/packages/jest-core/src/__tests__/getNoTestsFoundMessage.test.js
+++ b/packages/jest-core/src/__tests__/getNoTestsFoundMessage.test.js
@@ -1,3 +1,5 @@
+// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+
 import getNoTestsFoundMessage from '../getNoTestsFoundMessage';
 
 describe('getNoTestsFoundMessage', () => {

--- a/packages/jest-core/src/__tests__/getNoTestsFoundMessage.test.js
+++ b/packages/jest-core/src/__tests__/getNoTestsFoundMessage.test.js
@@ -1,0 +1,31 @@
+import getNoTestsFoundMessage from '../getNoTestsFoundMessage';
+
+describe('getNoTestsFoundMessage', () => {
+  function createGlobalConfig(options) {
+    return {
+      rootDir: '/root/dir',
+      testPathPattern: '/path/pattern',
+      ...options,
+    };
+  }
+
+  test('returns correct message when monitoring only failures', () => {
+    const config = createGlobalConfig({onlyFailures: true});
+    expect(getNoTestsFoundMessage([], config)).toMatchSnapshot();
+  });
+
+  test('returns correct message when monitoring only changed', () => {
+    const config = createGlobalConfig({onlyChanged: true});
+    expect(getNoTestsFoundMessage([], config)).toMatchSnapshot();
+  });
+
+  test('returns correct message with verbose option', () => {
+    const config = createGlobalConfig({verbose: true});
+    expect(getNoTestsFoundMessage([], config)).toMatchSnapshot();
+  });
+
+  test('returns correct message without options', () => {
+    const config = createGlobalConfig();
+    expect(getNoTestsFoundMessage([], config)).toMatchSnapshot();
+  });
+});

--- a/packages/jest-core/src/getNoTestFoundPassWithNoTests.ts
+++ b/packages/jest-core/src/getNoTestFoundPassWithNoTests.ts
@@ -1,0 +1,7 @@
+// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+
+import chalk from 'chalk';
+
+export default function getNoTestFoundPassWithNoTests() {
+  return chalk.bold('No tests found, exiting with code 0');
+}

--- a/packages/jest-core/src/getNoTestsFoundMessage.ts
+++ b/packages/jest-core/src/getNoTestsFoundMessage.ts
@@ -11,6 +11,7 @@ import getNoTestFound from './getNoTestFound';
 import getNoTestFoundRelatedToChangedFiles from './getNoTestFoundRelatedToChangedFiles';
 import getNoTestFoundVerbose from './getNoTestFoundVerbose';
 import getNoTestFoundFailed from './getNoTestFoundFailed';
+import getNoTestFoundPassWithNoTests from './getNoTestFoundPassWithNoTests';
 
 export default function getNoTestsFoundMessage(
   testRunData: TestRunData,
@@ -21,6 +22,9 @@ export default function getNoTestsFoundMessage(
   }
   if (globalConfig.onlyChanged) {
     return getNoTestFoundRelatedToChangedFiles(globalConfig);
+  }
+  if (globalConfig.passWithNoTests) {
+    return getNoTestFoundPassWithNoTests();
   }
   return testRunData.length === 1 || globalConfig.verbose
     ? getNoTestFoundVerbose(testRunData, globalConfig)


### PR DESCRIPTION
## Summary

When running jest with '--passWithNoTests' but there are no tests to execute, it prints a superfluous warning. This PR removes this warning.

## Description

In both screenshots below there are no test files and jest is executed with `--passWithNoOptions`.
It used to log that it exited with code 1 and a message to use `--passWithNoOptions`, while it exits with code 0 and the option is already provided.
 
Closes #8594

Before: 
![image](https://user-images.githubusercontent.com/19822240/59968277-c4475c00-953f-11e9-917d-6eb134bdd454.png)

After:
![image](https://user-images.githubusercontent.com/19822240/59968302-5485a100-9540-11e9-909d-7b7c4d097b23.png)

