### PR TITLE
Fix example used in custom environment docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - `[docs]` Add example to `jest.mock` for mocking ES6 modules with the `factory` parameter ([#8550](https://github.com/facebook/jest/pull/8550))
 - `[docs]` Add information about using `jest.doMock` with ES6 imports ([#8573](https://github.com/facebook/jest/pull/8573))
 - `[docs]` Fix variable name in custom-matcher-api code example ([#8582](https://github.com/facebook/jest/pull/8582))
+- `[docs]` Fix example used in custom environment docs ([#8617](https://github.com/facebook/jest/pull/8617))
 
 ### Performance
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -875,10 +875,10 @@ Example:
 const NodeEnvironment = require('jest-environment-node');
 
 class CustomEnvironment extends NodeEnvironment {
-  constructor(config, {testPath, docblockPragmas}) {
+  constructor(config, context) {
     super(config, context);
-    this.testPath = testPath;
-    this.docblockPragmas = docblockPragmas;
+    this.testPath = context.testPath;
+    this.docblockPragmas = context.docblockPragmas;
   }
 
   async setup() {

--- a/website/versioned_docs/version-24.8/Configuration.md
+++ b/website/versioned_docs/version-24.8/Configuration.md
@@ -876,10 +876,10 @@ Example:
 const NodeEnvironment = require('jest-environment-node');
 
 class CustomEnvironment extends NodeEnvironment {
-  constructor(config, {testPath, docblockPragmas}) {
+  constructor(config, context) {
     super(config, context);
-    this.testPath = testPath;
-    this.docblockPragmas = docblockPragmas;
+    this.testPath = context.testPath;
+    this.docblockPragmas = context.docblockPragmas;
   }
 
   async setup() {


### PR DESCRIPTION
## Summary

Fixes the example used in the Jest configuration docs, because `context` was not defined.

## Test plan

Documentation udpate
