### PR TITLE
Update setup instructions for typescript files

### DIFF
--- a/packages/babel-jest/README.md
+++ b/packages/babel-jest/README.md
@@ -20,6 +20,6 @@ To explicitly define `babel-jest` as a transformer for your JavaScript code, map
 
 ```json
 "transform": {
-  "^.+\\.jsx?$": "babel-jest"
+  "^.+\\.(t|j)sx?$": "babel-jest"
 },
 ```

--- a/packages/babel-jest/README.md
+++ b/packages/babel-jest/README.md
@@ -16,10 +16,10 @@ If you would like to write your own preprocessor, uninstall and delete babel-jes
 
 _Note: this step is only required if you are using `babel-jest` with additional code preprocessors._
 
-To explicitly define `babel-jest` as a transformer for your JavaScript code, map _.js_ files to the `babel-jest` module.
+To explicitly define `babel-jest` as a transformer for your JavaScript code, map _.js_ files to the `babel-jest` module. Typescript files are also supported.
 
 ```json
 "transform": {
-  "^.+\\.(t|j)sx?$": "babel-jest"
+  "^.+\\.[t|j]sx?$": "babel-jest"
 },
 ```


### PR DESCRIPTION
## Summary

Typescript files require `.ts` or `.tsx` file extension. Now that babel can parse typescript with @babel/preset-typescript, we should use it.

## Test plan

I tried this out locally and it worked for both typescript and js files.
