### PR TITLE
Support async sort in custom testSequencer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - `[pretty-format]` Render custom displayName of memoized components
 - `[jest-validate]` Allow `maxWorkers` as part of the `jest.config.js` ([#8565](https://github.com/facebook/jest/pull/8565))
 - `[jest-runtime]` Allow passing configuration objects to transformers ([#7288](https://github.com/facebook/jest/pull/7288))
+- `[@jest/core, @jest/test-sequencer]` Support async sort in custom `testSequencer` ([#7288](https://github.com/facebook/jest/pull/8642))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - `[pretty-format]` Render custom displayName of memoized components
 - `[jest-validate]` Allow `maxWorkers` as part of the `jest.config.js` ([#8565](https://github.com/facebook/jest/pull/8565))
 - `[jest-runtime]` Allow passing configuration objects to transformers ([#7288](https://github.com/facebook/jest/pull/7288))
-- `[@jest/core, @jest/test-sequencer]` Support async sort in custom `testSequencer` ([#7288](https://github.com/facebook/jest/pull/8642))
+- `[@jest/core, @jest/test-sequencer]` Support async sort in custom `testSequencer` ([#8642](https://github.com/facebook/jest/pull/8642))
 
 ### Fixes
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -1039,11 +1039,11 @@ An example of such function can be found in our default [jasmine2 test runner pa
 
 Default: `@jest/test-sequencer`
 
-This option allows you to use a custom sequencer instead of Jest's default.
+This option allows you to use a custom sequencer instead of Jest's default. `sort` may optionally return a Promise.
 
 Example:
 
-Sort test path alphabetically
+Sort test path alphabetically.
 
 ```js
 const Sequencer = require('@jest/test-sequencer').default;

--- a/e2e/__tests__/customTestSequencers.test.ts
+++ b/e2e/__tests__/customTestSequencers.test.ts
@@ -10,8 +10,43 @@ import runJest from '../runJest';
 import {extractSummary} from '../Utils';
 const dir = path.resolve(__dirname, '../custom-test-sequencer');
 
-test('run prioritySequence first', () => {
-  const result = runJest(dir, ['-i']);
+test('run prioritySequence first sync', () => {
+  const result = runJest(
+    dir,
+    [
+      '-i',
+      '--config',
+      JSON.stringify({
+        testSequencer: '<rootDir>/testSequencer.js',
+      }),
+    ],
+    {},
+  );
+  expect(result.status).toBe(0);
+  const sequence = extractSummary(result.stderr)
+    .rest.replace(/PASS /g, '')
+    .split('\n');
+  expect(sequence).toEqual([
+    './a.test.js',
+    './b.test.js',
+    './c.test.js',
+    './d.test.js',
+    './e.test.js',
+  ]);
+});
+
+test('run prioritySequence first async', () => {
+  const result = runJest(
+    dir,
+    [
+      '-i',
+      '--config',
+      JSON.stringify({
+        testSequencer: '<rootDir>/testSequencerAsync.js',
+      }),
+    ],
+    {},
+  );
   expect(result.status).toBe(0);
   const sequence = extractSummary(result.stderr)
     .rest.replace(/PASS /g, '')

--- a/e2e/custom-test-sequencer/package.json
+++ b/e2e/custom-test-sequencer/package.json
@@ -1,6 +1,5 @@
 {
   "jest": {
-    "testEnvironment": "node",
-    "testSequencer": "<rootDir>/testSequencer.js"
+    "testEnvironment": "node"
   }
 }

--- a/e2e/custom-test-sequencer/testSequencerAsync.js
+++ b/e2e/custom-test-sequencer/testSequencerAsync.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const Sequencer = require('@jest/test-sequencer').default;
+
+class CustomSequencer extends Sequencer {
+  sort(tests) {
+    return new Promise(resolve => {
+      setTimeout(() => {
+        const copyTests = Array.from(tests);
+        resolve(
+          copyTests.sort((testA, testB) => (testA.path > testB.path ? 1 : -1))
+        );
+      }, 50);
+    });
+  }
+}
+
+module.exports = CustomSequencer;

--- a/packages/jest-core/src/runJest.ts
+++ b/packages/jest-core/src/runJest.ts
@@ -183,7 +183,7 @@ export default (async function runJest({
     }),
   );
 
-  allTests = sequencer.sort(allTests);
+  allTests = await sequencer.sort(allTests);
 
   if (globalConfig.listTests) {
     const testsPaths = Array.from(new Set(allTests.map(test => test.path)));


### PR DESCRIPTION
## Summary

When overriding `testSequencer` with custom logic, forcing synchronous sorting can be limiting. One use-case is fetching test runtime from an endpoint instead of relying on the local cache; this requires an async roundtrip and is not currently possible.

This extremely simple PR adds the optional ability for `sort` to return a `Promise` without requiring it to.

## Test plan

- All existing tests pass.
- Added e2e test for async use of `sort`.
- Tested manually with real-world implementation.