### PR TITLE
expect: Improve report when mock-spy matcher fails, part 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - `[expect]` Highlight substring differences when matcher fails, part 1 ([#8448](https://github.com/facebook/jest/pull/8448))
 - `[expect]` Highlight substring differences when matcher fails, part 2 ([#8528](https://github.com/facebook/jest/pull/8528))
 - `[expect]` Improve report when mock-spy matcher fails, part 1 ([#8640](https://github.com/facebook/jest/pull/8640))
+- `[expect]` Improve report when mock-spy matcher fails, part 2 ([#8649](https://github.com/facebook/jest/pull/8649))
 - `[jest-snapshot]` Highlight substring differences when matcher fails, part 3 ([#8569](https://github.com/facebook/jest/pull/8569))
 - `[jest-cli]` Improve chai support (with detailed output, to match jest exceptions) ([#8454](https://github.com/facebook/jest/pull/8454))
 - `[*]` Manage the global timeout with `--testTimeout` command line argument. ([#8456](https://github.com/facebook/jest/pull/8456))

--- a/packages/expect/src/__tests__/__snapshots__/spyMatchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/spyMatchers.test.js.snap
@@ -1867,14 +1867,16 @@ exports[`toHaveReturned .not passes when a call throws undefined 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>toHaveReturned<dim>()</>
 
 Expected number of returns: >= <green>1</>
-Received number of returns:    <red>0</>"
+Received number of returns:    <red>0</>
+Received number of calls:      <red>1</>"
 `;
 
 exports[`toHaveReturned .not passes when all calls throw 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>toHaveReturned<dim>()</>
 
 Expected number of returns: >= <green>1</>
-Received number of returns:    <red>0</>"
+Received number of returns:    <red>0</>
+Received number of calls:      <red>2</>"
 `;
 
 exports[`toHaveReturned .not passes when not returned 1`] = `
@@ -1915,7 +1917,8 @@ exports[`toHaveReturned incomplete recursive calls are handled properly 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>toHaveReturned<dim>()</>
 
 Expected number of returns: >= <green>1</>
-Received number of returns:    <red>0</>"
+Received number of returns:    <red>0</>
+Received number of calls:      <red>4</>"
 `;
 
 exports[`toHaveReturned passes when at least one call does not throw 1`] = `
@@ -1925,7 +1928,9 @@ Expected number of returns: <green>0</>
 Received number of returns: <red>2</>
 
 1: <red>42</>
-3: <red>42</>"
+3: <red>42</>
+
+Received number of calls:   <red>3</>"
 `;
 
 exports[`toHaveReturned passes when returned 1`] = `
@@ -2021,15 +2026,19 @@ Expected number of returns: not <green>2</>"
 `;
 
 exports[`toHaveReturnedTimes calls that throw are not counted 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveReturnedTimes<dim>(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveReturnedTimes<dim>(</><green>expected</><dim>)</>
 
-Expected number of returns: not <green>2</>"
+Expected number of returns: <green>3</>
+Received number of returns: <red>2</>
+Received number of calls:   <red>3</>"
 `;
 
 exports[`toHaveReturnedTimes calls that throw undefined are not counted 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveReturnedTimes<dim>(</><green>expected</><dim>)</>
 
-Expected number of returns: not <green>2</>"
+Expected number of returns: not <green>2</>
+
+Received number of calls:       <red>3</>"
 `;
 
 exports[`toHaveReturnedTimes includes the custom mock name in the error message 1`] = `
@@ -2042,7 +2051,9 @@ Received number of returns: <red>2</>"
 exports[`toHaveReturnedTimes incomplete recursive calls are handled properly 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveReturnedTimes<dim>(</><green>expected</><dim>)</>
 
-Expected number of returns: not <green>2</>"
+Expected number of returns: not <green>2</>
+
+Received number of calls:       <red>4</>"
 `;
 
 exports[`toHaveReturnedTimes only accepts a number argument 1`] = `
@@ -2276,14 +2287,16 @@ exports[`toReturn .not passes when a call throws undefined 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>toReturn<dim>()</>
 
 Expected number of returns: >= <green>1</>
-Received number of returns:    <red>0</>"
+Received number of returns:    <red>0</>
+Received number of calls:      <red>1</>"
 `;
 
 exports[`toReturn .not passes when all calls throw 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>toReturn<dim>()</>
 
 Expected number of returns: >= <green>1</>
-Received number of returns:    <red>0</>"
+Received number of returns:    <red>0</>
+Received number of calls:      <red>2</>"
 `;
 
 exports[`toReturn .not passes when not returned 1`] = `
@@ -2324,7 +2337,8 @@ exports[`toReturn incomplete recursive calls are handled properly 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>toReturn<dim>()</>
 
 Expected number of returns: >= <green>1</>
-Received number of returns:    <red>0</>"
+Received number of returns:    <red>0</>
+Received number of calls:      <red>4</>"
 `;
 
 exports[`toReturn passes when at least one call does not throw 1`] = `
@@ -2334,7 +2348,9 @@ Expected number of returns: <green>0</>
 Received number of returns: <red>2</>
 
 1: <red>42</>
-3: <red>42</>"
+3: <red>42</>
+
+Received number of calls:   <red>3</>"
 `;
 
 exports[`toReturn passes when returned 1`] = `
@@ -2430,15 +2446,19 @@ Expected number of returns: not <green>2</>"
 `;
 
 exports[`toReturnTimes calls that throw are not counted 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toReturnTimes<dim>(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toReturnTimes<dim>(</><green>expected</><dim>)</>
 
-Expected number of returns: not <green>2</>"
+Expected number of returns: <green>3</>
+Received number of returns: <red>2</>
+Received number of calls:   <red>3</>"
 `;
 
 exports[`toReturnTimes calls that throw undefined are not counted 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toReturnTimes<dim>(</><green>expected</><dim>)</>
 
-Expected number of returns: not <green>2</>"
+Expected number of returns: not <green>2</>
+
+Received number of calls:       <red>3</>"
 `;
 
 exports[`toReturnTimes includes the custom mock name in the error message 1`] = `
@@ -2451,7 +2471,9 @@ Received number of returns: <red>2</>"
 exports[`toReturnTimes incomplete recursive calls are handled properly 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toReturnTimes<dim>(</><green>expected</><dim>)</>
 
-Expected number of returns: not <green>2</>"
+Expected number of returns: not <green>2</>
+
+Received number of calls:       <red>4</>"
 `;
 
 exports[`toReturnTimes only accepts a number argument 1`] = `

--- a/packages/expect/src/__tests__/__snapshots__/spyMatchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/spyMatchers.test.js.snap
@@ -628,7 +628,7 @@ exports[`toBeCalled includes the custom mock name in the error message 1`] = `
 Expected number of calls: <green>0</>
 Received number of calls: <red>1</>
 
-1: <dim>()</>"
+1: no args"
 `;
 
 exports[`toBeCalled passes when called 1`] = `
@@ -637,7 +637,7 @@ exports[`toBeCalled passes when called 1`] = `
 Expected number of calls: <green>0</>
 Received number of calls: <red>1</>
 
-1: <dim>(</><red>\\"arg0\\"</><dim>, </><red>\\"arg1\\"</><dim>, </><red>\\"arg2\\"</><dim>)</>"
+1: <red>\\"arg0\\"</>, <red>\\"arg1\\"</>, <red>\\"arg2\\"</>"
 `;
 
 exports[`toBeCalled works only on spies or jest.fn 1`] = `
@@ -958,7 +958,7 @@ exports[`toHaveBeenCalled includes the custom mock name in the error message 1`]
 Expected number of calls: <green>0</>
 Received number of calls: <red>1</>
 
-1: <dim>()</>"
+1: no args"
 `;
 
 exports[`toHaveBeenCalled passes when called 1`] = `
@@ -967,7 +967,7 @@ exports[`toHaveBeenCalled passes when called 1`] = `
 Expected number of calls: <green>0</>
 Received number of calls: <red>1</>
 
-1: <dim>(</><red>\\"arg0\\"</><dim>, </><red>\\"arg1\\"</><dim>, </><red>\\"arg2\\"</><dim>)</>"
+1: <red>\\"arg0\\"</>, <red>\\"arg1\\"</>, <red>\\"arg2\\"</>"
 `;
 
 exports[`toHaveBeenCalled works only on spies or jest.fn 1`] = `

--- a/packages/expect/src/__tests__/__snapshots__/spyMatchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/spyMatchers.test.js.snap
@@ -607,9 +607,10 @@ Expected has value: <green>555</>"
 `;
 
 exports[`toBeCalled .not passes when called 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toBeCalled()</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toBeCalled<dim>()</>
 
-Expected mock function to have been called, but it was not called."
+Expected number of calls: >= <green>1</>
+Received number of calls:    <red>0</>"
 `;
 
 exports[`toBeCalled fails with any argument passed 1`] = `
@@ -622,17 +623,21 @@ Expected has value: <green>555</>"
 `;
 
 exports[`toBeCalled includes the custom mock name in the error message 1`] = `
-"<dim>expect(</><red>named-mock</><dim>).not.toBeCalled()</>
+"<dim>expect(</><red>named-mock</><dim>).</>not<dim>.</>toBeCalled<dim>()</>
 
-Expected mock function \\"named-mock\\" not to be called but it was called with:
-  <red>[]</>"
+Expected number of calls: <green>0</>
+Received number of calls: <red>1</>
+
+1: <red>[]</>"
 `;
 
 exports[`toBeCalled passes when called 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toBeCalled()</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toBeCalled<dim>()</>
 
-Expected mock function not to be called but it was called with:
-  <red>[]</>"
+Expected number of calls: <green>0</>
+Received number of calls: <red>1</>
+
+1: <red>[]</>"
 `;
 
 exports[`toBeCalled works only on spies or jest.fn 1`] = `
@@ -699,15 +704,17 @@ Expected has value: <green>[Function anonymous]</>"
 `;
 
 exports[`toBeCalledTimes .not passes if function called less than expected times 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toBeCalledTimes(</><green>2</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toBeCalledTimes<dim>(</><green>expected</><dim>)</>
 
-Expected mock function to have been called <green>two times</>, but it was called <red>one time</>."
+Expected number of calls: <green>2</>
+Received number of calls: <red>1</>"
 `;
 
 exports[`toBeCalledTimes .not passes if function called more than expected times 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toBeCalledTimes(</><green>2</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toBeCalledTimes<dim>(</><green>expected</><dim>)</>
 
-Expected mock function to have been called <green>two times</>, but it was called <red>three times</>."
+Expected number of calls: <green>2</>
+Received number of calls: <red>3</>"
 `;
 
 exports[`toBeCalledTimes .not works only on spies or jest.fn 1`] = `
@@ -720,9 +727,10 @@ Received has value: <red>[Function fn]</>"
 `;
 
 exports[`toBeCalledTimes includes the custom mock name in the error message 1`] = `
-"<dim>expect(</><red>named-mock</><dim>).toBeCalledTimes(</><green>2</><dim>)</>
+"<dim>expect(</><red>named-mock</><dim>).</>toBeCalledTimes<dim>(</><green>expected</><dim>)</>
 
-Expected mock function \\"named-mock\\" to have been called <green>two times</>, but it was called <red>one time</>."
+Expected number of calls: <green>2</>
+Received number of calls: <red>1</>"
 `;
 
 exports[`toBeCalledTimes only accepts a number argument 1`] = `
@@ -780,9 +788,9 @@ Expected has value: <green>[Function anonymous]</>"
 `;
 
 exports[`toBeCalledTimes passes if function called equal to expected times 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toBeCalledTimes(</><green>2</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toBeCalledTimes<dim>(</><green>expected</><dim>)</>
 
-Expected mock function not to be called <green>two times</>, but it was called exactly <red>two times</>."
+Expected number of calls: not <green>2</>"
 `;
 
 exports[`toBeCalledWith includes the custom mock name in the error message 1`] = `
@@ -929,9 +937,10 @@ Expected has value: <green>555</>"
 `;
 
 exports[`toHaveBeenCalled .not passes when called 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toHaveBeenCalled()</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveBeenCalled<dim>()</>
 
-Expected mock function to have been called, but it was not called."
+Expected number of calls: >= <green>1</>
+Received number of calls:    <red>0</>"
 `;
 
 exports[`toHaveBeenCalled fails with any argument passed 1`] = `
@@ -944,17 +953,21 @@ Expected has value: <green>555</>"
 `;
 
 exports[`toHaveBeenCalled includes the custom mock name in the error message 1`] = `
-"<dim>expect(</><red>named-mock</><dim>).not.toHaveBeenCalled()</>
+"<dim>expect(</><red>named-mock</><dim>).</>not<dim>.</>toHaveBeenCalled<dim>()</>
 
-Expected mock function \\"named-mock\\" not to be called but it was called with:
-  <red>[]</>"
+Expected number of calls: <green>0</>
+Received number of calls: <red>1</>
+
+1: <red>[]</>"
 `;
 
 exports[`toHaveBeenCalled passes when called 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toHaveBeenCalled()</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveBeenCalled<dim>()</>
 
-Expected mock function not to be called but it was called with:
-  <red>[]</>"
+Expected number of calls: <green>0</>
+Received number of calls: <red>1</>
+
+1: <red>[]</>"
 `;
 
 exports[`toHaveBeenCalled works only on spies or jest.fn 1`] = `
@@ -1021,15 +1034,17 @@ Expected has value: <green>[Function anonymous]</>"
 `;
 
 exports[`toHaveBeenCalledTimes .not passes if function called less than expected times 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toHaveBeenCalledTimes(</><green>2</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveBeenCalledTimes<dim>(</><green>expected</><dim>)</>
 
-Expected mock function to have been called <green>two times</>, but it was called <red>one time</>."
+Expected number of calls: <green>2</>
+Received number of calls: <red>1</>"
 `;
 
 exports[`toHaveBeenCalledTimes .not passes if function called more than expected times 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toHaveBeenCalledTimes(</><green>2</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveBeenCalledTimes<dim>(</><green>expected</><dim>)</>
 
-Expected mock function to have been called <green>two times</>, but it was called <red>three times</>."
+Expected number of calls: <green>2</>
+Received number of calls: <red>3</>"
 `;
 
 exports[`toHaveBeenCalledTimes .not works only on spies or jest.fn 1`] = `
@@ -1042,9 +1057,10 @@ Received has value: <red>[Function fn]</>"
 `;
 
 exports[`toHaveBeenCalledTimes includes the custom mock name in the error message 1`] = `
-"<dim>expect(</><red>named-mock</><dim>).toHaveBeenCalledTimes(</><green>2</><dim>)</>
+"<dim>expect(</><red>named-mock</><dim>).</>toHaveBeenCalledTimes<dim>(</><green>expected</><dim>)</>
 
-Expected mock function \\"named-mock\\" to have been called <green>two times</>, but it was called <red>one time</>."
+Expected number of calls: <green>2</>
+Received number of calls: <red>1</>"
 `;
 
 exports[`toHaveBeenCalledTimes only accepts a number argument 1`] = `
@@ -1102,9 +1118,9 @@ Expected has value: <green>[Function anonymous]</>"
 `;
 
 exports[`toHaveBeenCalledTimes passes if function called equal to expected times 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toHaveBeenCalledTimes(</><green>2</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveBeenCalledTimes<dim>(</><green>expected</><dim>)</>
 
-Expected mock function not to be called <green>two times</>, but it was called exactly <red>two times</>."
+Expected number of calls: not <green>2</>"
 `;
 
 exports[`toHaveBeenCalledWith includes the custom mock name in the error message 1`] = `
@@ -1848,21 +1864,24 @@ Expected has value: <green>555</>"
 `;
 
 exports[`toHaveReturned .not passes when a call throws undefined 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toHaveReturned()</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveReturned<dim>()</>
 
-Expected mock function to have returned."
+Expected number of returns: >= <green>1</>
+Received number of returns:    <red>0</>"
 `;
 
 exports[`toHaveReturned .not passes when all calls throw 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toHaveReturned()</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveReturned<dim>()</>
 
-Expected mock function to have returned."
+Expected number of returns: >= <green>1</>
+Received number of returns:    <red>0</>"
 `;
 
 exports[`toHaveReturned .not passes when not returned 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toHaveReturned()</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveReturned<dim>()</>
 
-Expected mock function to have returned."
+Expected number of returns: >= <green>1</>
+Received number of returns:    <red>0</>"
 `;
 
 exports[`toHaveReturned .not works only on jest.fn 1`] = `
@@ -1884,39 +1903,47 @@ Expected has value: <green>555</>"
 `;
 
 exports[`toHaveReturned includes the custom mock name in the error message 1`] = `
-"<dim>expect(</><red>named-mock</><dim>).not.toHaveReturned()</>
+"<dim>expect(</><red>named-mock</><dim>).</>not<dim>.</>toHaveReturned<dim>()</>
 
-Expected mock function \\"named-mock\\" not to have returned, but it returned:
-  <red>42</>"
+Expected number of returns: <green>0</>
+Received number of returns: <red>1</>
+
+1: <red>42</>"
 `;
 
 exports[`toHaveReturned incomplete recursive calls are handled properly 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toHaveReturned()</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveReturned<dim>()</>
 
-Expected mock function to have returned."
+Expected number of returns: >= <green>1</>
+Received number of returns:    <red>0</>"
 `;
 
 exports[`toHaveReturned passes when at least one call does not throw 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toHaveReturned()</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveReturned<dim>()</>
 
-Expected mock function not to have returned, but it returned:
-  <red>42</>
+Expected number of returns: <green>0</>
+Received number of returns: <red>2</>
 
-  <red>42</>"
+1: <red>42</>
+3: <red>42</>"
 `;
 
 exports[`toHaveReturned passes when returned 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toHaveReturned()</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveReturned<dim>()</>
 
-Expected mock function not to have returned, but it returned:
-  <red>42</>"
+Expected number of returns: <green>0</>
+Received number of returns: <red>1</>
+
+1: <red>42</>"
 `;
 
 exports[`toHaveReturned passes when undefined is returned 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toHaveReturned()</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveReturned<dim>()</>
 
-Expected mock function not to have returned, but it returned:
-  <red>undefined</>"
+Expected number of returns: <green>0</>
+Received number of returns: <red>1</>
+
+1: <red>undefined</>"
 `;
 
 exports[`toHaveReturnedTimes .not only accepts a number argument 1`] = `
@@ -1974,45 +2001,48 @@ Expected has value: <green>[Function anonymous]</>"
 `;
 
 exports[`toHaveReturnedTimes .not passes if function called less than expected times 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toHaveReturnedTimes(</><green>2</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveReturnedTimes<dim>(</><green>expected</><dim>)</>
 
-Expected mock function to have returned <green>two times</>, but it returned <red>one time</>."
+Expected number of returns: <green>2</>
+Received number of returns: <red>1</>"
 `;
 
 exports[`toHaveReturnedTimes .not passes if function returned more than expected times 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toHaveReturnedTimes(</><green>2</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveReturnedTimes<dim>(</><green>expected</><dim>)</>
 
-Expected mock function to have returned <green>two times</>, but it returned <red>three times</>."
+Expected number of returns: <green>2</>
+Received number of returns: <red>3</>"
 `;
 
 exports[`toHaveReturnedTimes calls that return undefined are counted as returns 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toHaveReturnedTimes(</><green>2</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveReturnedTimes<dim>(</><green>expected</><dim>)</>
 
-Expected mock function not to have returned <green>two times</>, but it returned exactly <red>two times</>."
+Expected number of returns: not <green>2</>"
 `;
 
 exports[`toHaveReturnedTimes calls that throw are not counted 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toHaveReturnedTimes(</><green>2</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveReturnedTimes<dim>(</><green>expected</><dim>)</>
 
-Expected mock function not to have returned <green>two times</>, but it returned exactly <red>two times</>."
+Expected number of returns: not <green>2</>"
 `;
 
 exports[`toHaveReturnedTimes calls that throw undefined are not counted 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toHaveReturnedTimes(</><green>2</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveReturnedTimes<dim>(</><green>expected</><dim>)</>
 
-Expected mock function not to have returned <green>two times</>, but it returned exactly <red>two times</>."
+Expected number of returns: not <green>2</>"
 `;
 
 exports[`toHaveReturnedTimes includes the custom mock name in the error message 1`] = `
-"<dim>expect(</><red>named-mock</><dim>).toHaveReturnedTimes(</><green>1</><dim>)</>
+"<dim>expect(</><red>named-mock</><dim>).</>toHaveReturnedTimes<dim>(</><green>expected</><dim>)</>
 
-Expected mock function \\"named-mock\\" to have returned <green>one time</>, but it returned <red>two times</>."
+Expected number of returns: <green>1</>
+Received number of returns: <red>2</>"
 `;
 
 exports[`toHaveReturnedTimes incomplete recursive calls are handled properly 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toHaveReturnedTimes(</><green>2</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveReturnedTimes<dim>(</><green>expected</><dim>)</>
 
-Expected mock function not to have returned <green>two times</>, but it returned exactly <red>two times</>."
+Expected number of returns: not <green>2</>"
 `;
 
 exports[`toHaveReturnedTimes only accepts a number argument 1`] = `
@@ -2070,9 +2100,9 @@ Expected has value: <green>[Function anonymous]</>"
 `;
 
 exports[`toHaveReturnedTimes passes if function returned equal to expected times 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toHaveReturnedTimes(</><green>2</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveReturnedTimes<dim>(</><green>expected</><dim>)</>
 
-Expected mock function not to have returned <green>two times</>, but it returned exactly <red>two times</>."
+Expected number of returns: not <green>2</>"
 `;
 
 exports[`toHaveReturnedTimes works only on spies or jest.fn 1`] = `
@@ -2243,21 +2273,24 @@ Expected has value: <green>555</>"
 `;
 
 exports[`toReturn .not passes when a call throws undefined 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toReturn()</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toReturn<dim>()</>
 
-Expected mock function to have returned."
+Expected number of returns: >= <green>1</>
+Received number of returns:    <red>0</>"
 `;
 
 exports[`toReturn .not passes when all calls throw 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toReturn()</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toReturn<dim>()</>
 
-Expected mock function to have returned."
+Expected number of returns: >= <green>1</>
+Received number of returns:    <red>0</>"
 `;
 
 exports[`toReturn .not passes when not returned 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toReturn()</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toReturn<dim>()</>
 
-Expected mock function to have returned."
+Expected number of returns: >= <green>1</>
+Received number of returns:    <red>0</>"
 `;
 
 exports[`toReturn .not works only on jest.fn 1`] = `
@@ -2279,39 +2312,47 @@ Expected has value: <green>555</>"
 `;
 
 exports[`toReturn includes the custom mock name in the error message 1`] = `
-"<dim>expect(</><red>named-mock</><dim>).not.toReturn()</>
+"<dim>expect(</><red>named-mock</><dim>).</>not<dim>.</>toReturn<dim>()</>
 
-Expected mock function \\"named-mock\\" not to have returned, but it returned:
-  <red>42</>"
+Expected number of returns: <green>0</>
+Received number of returns: <red>1</>
+
+1: <red>42</>"
 `;
 
 exports[`toReturn incomplete recursive calls are handled properly 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toReturn()</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toReturn<dim>()</>
 
-Expected mock function to have returned."
+Expected number of returns: >= <green>1</>
+Received number of returns:    <red>0</>"
 `;
 
 exports[`toReturn passes when at least one call does not throw 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toReturn()</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toReturn<dim>()</>
 
-Expected mock function not to have returned, but it returned:
-  <red>42</>
+Expected number of returns: <green>0</>
+Received number of returns: <red>2</>
 
-  <red>42</>"
+1: <red>42</>
+3: <red>42</>"
 `;
 
 exports[`toReturn passes when returned 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toReturn()</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toReturn<dim>()</>
 
-Expected mock function not to have returned, but it returned:
-  <red>42</>"
+Expected number of returns: <green>0</>
+Received number of returns: <red>1</>
+
+1: <red>42</>"
 `;
 
 exports[`toReturn passes when undefined is returned 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toReturn()</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toReturn<dim>()</>
 
-Expected mock function not to have returned, but it returned:
-  <red>undefined</>"
+Expected number of returns: <green>0</>
+Received number of returns: <red>1</>
+
+1: <red>undefined</>"
 `;
 
 exports[`toReturnTimes .not only accepts a number argument 1`] = `
@@ -2369,45 +2410,48 @@ Expected has value: <green>[Function anonymous]</>"
 `;
 
 exports[`toReturnTimes .not passes if function called less than expected times 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toReturnTimes(</><green>2</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toReturnTimes<dim>(</><green>expected</><dim>)</>
 
-Expected mock function to have returned <green>two times</>, but it returned <red>one time</>."
+Expected number of returns: <green>2</>
+Received number of returns: <red>1</>"
 `;
 
 exports[`toReturnTimes .not passes if function returned more than expected times 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toReturnTimes(</><green>2</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toReturnTimes<dim>(</><green>expected</><dim>)</>
 
-Expected mock function to have returned <green>two times</>, but it returned <red>three times</>."
+Expected number of returns: <green>2</>
+Received number of returns: <red>3</>"
 `;
 
 exports[`toReturnTimes calls that return undefined are counted as returns 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toReturnTimes(</><green>2</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toReturnTimes<dim>(</><green>expected</><dim>)</>
 
-Expected mock function not to have returned <green>two times</>, but it returned exactly <red>two times</>."
+Expected number of returns: not <green>2</>"
 `;
 
 exports[`toReturnTimes calls that throw are not counted 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toReturnTimes(</><green>2</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toReturnTimes<dim>(</><green>expected</><dim>)</>
 
-Expected mock function not to have returned <green>two times</>, but it returned exactly <red>two times</>."
+Expected number of returns: not <green>2</>"
 `;
 
 exports[`toReturnTimes calls that throw undefined are not counted 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toReturnTimes(</><green>2</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toReturnTimes<dim>(</><green>expected</><dim>)</>
 
-Expected mock function not to have returned <green>two times</>, but it returned exactly <red>two times</>."
+Expected number of returns: not <green>2</>"
 `;
 
 exports[`toReturnTimes includes the custom mock name in the error message 1`] = `
-"<dim>expect(</><red>named-mock</><dim>).toReturnTimes(</><green>1</><dim>)</>
+"<dim>expect(</><red>named-mock</><dim>).</>toReturnTimes<dim>(</><green>expected</><dim>)</>
 
-Expected mock function \\"named-mock\\" to have returned <green>one time</>, but it returned <red>two times</>."
+Expected number of returns: <green>1</>
+Received number of returns: <red>2</>"
 `;
 
 exports[`toReturnTimes incomplete recursive calls are handled properly 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toReturnTimes(</><green>2</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toReturnTimes<dim>(</><green>expected</><dim>)</>
 
-Expected mock function not to have returned <green>two times</>, but it returned exactly <red>two times</>."
+Expected number of returns: not <green>2</>"
 `;
 
 exports[`toReturnTimes only accepts a number argument 1`] = `
@@ -2465,9 +2509,9 @@ Expected has value: <green>[Function anonymous]</>"
 `;
 
 exports[`toReturnTimes passes if function returned equal to expected times 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toReturnTimes(</><green>2</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toReturnTimes<dim>(</><green>expected</><dim>)</>
 
-Expected mock function not to have returned <green>two times</>, but it returned exactly <red>two times</>."
+Expected number of returns: not <green>2</>"
 `;
 
 exports[`toReturnTimes works only on spies or jest.fn 1`] = `

--- a/packages/expect/src/__tests__/__snapshots__/spyMatchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/spyMatchers.test.js.snap
@@ -628,7 +628,7 @@ exports[`toBeCalled includes the custom mock name in the error message 1`] = `
 Expected number of calls: <green>0</>
 Received number of calls: <red>1</>
 
-1: no args"
+1: called with no arguments"
 `;
 
 exports[`toBeCalled passes when called 1`] = `
@@ -958,7 +958,7 @@ exports[`toHaveBeenCalled includes the custom mock name in the error message 1`]
 Expected number of calls: <green>0</>
 Received number of calls: <red>1</>
 
-1: no args"
+1: called with no arguments"
 `;
 
 exports[`toHaveBeenCalled passes when called 1`] = `

--- a/packages/expect/src/__tests__/__snapshots__/spyMatchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/spyMatchers.test.js.snap
@@ -628,7 +628,7 @@ exports[`toBeCalled includes the custom mock name in the error message 1`] = `
 Expected number of calls: <green>0</>
 Received number of calls: <red>1</>
 
-1: <red>[]</>"
+1: <dim>()</>"
 `;
 
 exports[`toBeCalled passes when called 1`] = `
@@ -637,7 +637,7 @@ exports[`toBeCalled passes when called 1`] = `
 Expected number of calls: <green>0</>
 Received number of calls: <red>1</>
 
-1: <red>[]</>"
+1: <dim>(</><red>\\"arg0\\"</><dim>, </><red>\\"arg1\\"</><dim>, </><red>\\"arg2\\"</><dim>)</>"
 `;
 
 exports[`toBeCalled works only on spies or jest.fn 1`] = `
@@ -958,7 +958,7 @@ exports[`toHaveBeenCalled includes the custom mock name in the error message 1`]
 Expected number of calls: <green>0</>
 Received number of calls: <red>1</>
 
-1: <red>[]</>"
+1: <dim>()</>"
 `;
 
 exports[`toHaveBeenCalled passes when called 1`] = `
@@ -967,7 +967,7 @@ exports[`toHaveBeenCalled passes when called 1`] = `
 Expected number of calls: <green>0</>
 Received number of calls: <red>1</>
 
-1: <red>[]</>"
+1: <dim>(</><red>\\"arg0\\"</><dim>, </><red>\\"arg1\\"</><dim>, </><red>\\"arg2\\"</><dim>)</>"
 `;
 
 exports[`toHaveBeenCalled works only on spies or jest.fn 1`] = `

--- a/packages/expect/src/__tests__/spyMatchers.test.js
+++ b/packages/expect/src/__tests__/spyMatchers.test.js
@@ -617,10 +617,10 @@ const jestExpect = require('../');
 
       fn(false);
 
-      jestExpect(fn)[returnedTimes](2);
+      jestExpect(fn).not[returnedTimes](3);
 
       expect(() =>
-        jestExpect(fn).not[returnedTimes](2),
+        jestExpect(fn)[returnedTimes](3),
       ).toThrowErrorMatchingSnapshot();
     });
 

--- a/packages/expect/src/__tests__/spyMatchers.test.js
+++ b/packages/expect/src/__tests__/spyMatchers.test.js
@@ -3,7 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
  */
 
 const Immutable = require('immutable');
@@ -19,7 +18,7 @@ const jestExpect = require('../');
 
     test(`passes when called`, () => {
       const fn = jest.fn();
-      fn();
+      fn('arg0', 'arg1', 'arg2');
       jestExpect(fn)[called]();
       expect(() => jestExpect(fn).not[called]()).toThrowErrorMatchingSnapshot();
     });

--- a/packages/expect/src/spyMatchers.ts
+++ b/packages/expect/src/spyMatchers.ts
@@ -28,7 +28,7 @@ const LAST_CALL_PRINT_LIMIT = 1;
 
 const printReceivedArgs = (args: Array<unknown>): string =>
   args.length === 0
-    ? 'no args'
+    ? 'called with no arguments'
     : args.map(arg => printReceived(arg)).join(', ');
 
 const createToBeCalledMatcher = (matcherName: string) =>

--- a/packages/expect/src/spyMatchers.ts
+++ b/packages/expect/src/spyMatchers.ts
@@ -3,11 +3,11 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
  */
 
 import {
   diff,
+  DIM_COLOR,
   ensureExpectedIsNumber,
   ensureNoExpected,
   matcherErrorMessage,
@@ -26,6 +26,13 @@ const PRINT_LIMIT = 3;
 const CALL_PRINT_LIMIT = 3;
 const RETURN_PRINT_LIMIT = 5;
 const LAST_CALL_PRINT_LIMIT = 1;
+
+const printReceivedArgs = (args: Array<unknown>): string =>
+  args.length === 0
+    ? DIM_COLOR('()')
+    : DIM_COLOR('(') +
+      args.map(arg => printReceived(arg)).join(DIM_COLOR(', ')) +
+      DIM_COLOR(')');
 
 const createToBeCalledMatcher = (matcherName: string) =>
   function(
@@ -59,7 +66,7 @@ const createToBeCalledMatcher = (matcherName: string) =>
           calls
             .reduce((lines: Array<string>, args: any, i: number) => {
               if (lines.length < PRINT_LIMIT) {
-                lines.push(`${i + 1}: ${printReceived(args)}`);
+                lines.push(`${i + 1}: ${printReceivedArgs(args)}`);
               }
 
               return lines;

--- a/packages/expect/src/spyMatchers.ts
+++ b/packages/expect/src/spyMatchers.ts
@@ -112,12 +112,22 @@ const createToReturnMatcher = (matcherName: string) =>
 
               return lines;
             }, [])
-            .join('\n')
+            .join('\n') +
+          (received.mock.calls.length !== count
+            ? `\n\nReceived number of calls:   ${printReceived(
+                received.mock.calls.length,
+              )}`
+            : '')
       : () =>
           matcherHint(matcherName, receivedName, expectedArgument, options) +
           '\n\n' +
           `Expected number of returns: >= ${printExpected(1)}\n` +
-          `Received number of returns:    ${printReceived(count)}`;
+          `Received number of returns:    ${printReceived(count)}` +
+          (received.mock.calls.length !== count
+            ? `\nReceived number of calls:      ${printReceived(
+                received.mock.calls.length,
+              )}`
+            : '');
 
     return {message, pass};
   };
@@ -186,12 +196,22 @@ const createToReturnTimesMatcher = (matcherName: string) =>
       ? () =>
           matcherHint(matcherName, receivedName, expectedArgument, options) +
           `\n\n` +
-          `Expected number of returns: not ${printExpected(expected)}`
+          `Expected number of returns: not ${printExpected(expected)}` +
+          (received.mock.calls.length !== count
+            ? `\n\nReceived number of calls:       ${printReceived(
+                received.mock.calls.length,
+              )}`
+            : '')
       : () =>
           matcherHint(matcherName, receivedName, expectedArgument, options) +
           '\n\n' +
           `Expected number of returns: ${printExpected(expected)}\n` +
-          `Received number of returns: ${printReceived(count)}`;
+          `Received number of returns: ${printReceived(count)}` +
+          (received.mock.calls.length !== count
+            ? `\nReceived number of calls:   ${printReceived(
+                received.mock.calls.length,
+              )}`
+            : '');
 
     return {message, pass};
   };

--- a/packages/expect/src/spyMatchers.ts
+++ b/packages/expect/src/spyMatchers.ts
@@ -7,7 +7,6 @@
 
 import {
   diff,
-  DIM_COLOR,
   ensureExpectedIsNumber,
   ensureNoExpected,
   matcherErrorMessage,
@@ -29,10 +28,8 @@ const LAST_CALL_PRINT_LIMIT = 1;
 
 const printReceivedArgs = (args: Array<unknown>): string =>
   args.length === 0
-    ? DIM_COLOR('()')
-    : DIM_COLOR('(') +
-      args.map(arg => printReceived(arg)).join(DIM_COLOR(', ')) +
-      DIM_COLOR(')');
+    ? 'no args'
+    : args.map(arg => printReceived(arg)).join(', ');
 
 const createToBeCalledMatcher = (matcherName: string) =>
   function(


### PR DESCRIPTION
## Summary

For mock-spy matchers whose criterion is number of calls or returns:

* Display matcher name in regular black instead of dim color
* Replace sentences with `Expected` and `Received` labels and number values

For negative matcher:

* with expected times, repeat `not` following `Expected` label
* without expected times, display `>= 1` following `Expected` label
* without expected times, display args or value as lines with one-based call number as label

**Questions** to reviewers

1. What do you think about change to consistent `PRINT_LIMIT = 3` instead of:

    ```js
    const CALL_PRINT_LIMIT = 3;
    const RETURN_PRINT_LIMIT = 5;
    ```

2. For **return** matchers, is the number of **calls** relevant information [EDIT: if it is different from the number of returns] to include on an additional line in report to trouble shoot situations when a test fails because of incorrect assumption about calls versus returns? (see picture in comment below)

**Residue**

* Factor out repeated code, especially to avoid `map` for spy calls unless negative matcher fails
* Edit test names to replace `in the error message` with `as received in matcher hint`
* Replace some `any` types, if possible
* Add tests to increase coverage

## Test plan

Updated 46 snapshots

| | long name | short name |
| ---: | :--- | :--- |
| 3 | `toHaveBeenCalled` | `toBeCalled` |
| 4 | `toHaveBeenCalledTimes` | `toBeCalledTimes` |
| 8 | `toHaveReturned` | `toReturn` |
| 8 | `toHaveReturnedTimes` | `toReturnTimes` |

See also pictures in following comments

Example pictures baseline at left and **improved at right**