### PR TITLE
simplify `module.file` to `file`

### DIFF
--- a/packages/jest-resolve-dependencies/src/index.ts
+++ b/packages/jest-resolve-dependencies/src/index.ts
@@ -101,7 +101,7 @@ class DependencyResolver {
               related.delete(file);
             }
             visitedModules.add(file);
-            acc.push(module.file);
+            acc.push(file);
             return acc;
           }, []),
         );


### PR DESCRIPTION
Hey guys, I just explored your mechanism of retrieving a list of transitive inverse dependencies, and found this redundant `module`.

I assume that `file` and `module.file` are still the same after `filter(file)`, and no monkey patching occurs :)