### PR TITLE
Issue 8547: side effect import deps extracted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Fixes
 
+- `[jest-cli]` Detect side-effect only imports when running `--onlyChanged` or `--changedSince` ([#8670](https://github.com/facebook/jest/pull/8670))
 - `[jest-cli]` Allow `--maxWorkers` to work with % input again ([#8565](https://github.com/facebook/jest/pull/8565))
 - `[babel-plugin-jest-hoist]` Expand list of whitelisted globals in global mocks ([#8429](https://github.com/facebook/jest/pull/8429)
 - `[jest-core]` Make watch plugin initialization errors look nice ([#8422](https://github.com/facebook/jest/pull/8422))

--- a/packages/jest-haste-map/src/lib/__tests__/dependencyExtractor.test.js
+++ b/packages/jest-haste-map/src/lib/__tests__/dependencyExtractor.test.js
@@ -14,9 +14,13 @@ describe('dependencyExtractor', () => {
   it('should not extract dependencies inside comments', () => {
     const code = `
       // import a from 'ignore-line-comment';
+      // import 'ignore-line-comment';
+      // import './ignore-line-comment';
       // require('ignore-line-comment');
       /*
        * import a from 'ignore-block-comment';
+       * import './ignore-block-comment';
+       * import 'ignore-block-comment';
        * require('ignore-block-comment');
        */
     `;
@@ -65,6 +69,23 @@ describe('dependencyExtractor', () => {
       ${COMMENT_NO_NEG_LB} foo . export ('inv2');
     `;
     expect(extract(code)).toEqual(new Set(['dep1', 'dep2', 'dep3', 'dep4']));
+  });
+
+  // https://github.com/facebook/jest/issues/8547
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#Import_a_module_for_its_side_effects_only
+  it('should extract dependencies from side-effect only `import` statements', () => {
+    const code = `
+        // Good
+        import './side-effect-dep1';
+        import 'side-effect-dep2';
+
+        // Bad
+        import ./inv1;
+        import inv2
+      `;
+    expect(extract(code)).toEqual(
+      new Set(['./side-effect-dep1', 'side-effect-dep2']),
+    );
   });
 
   it('should not extract dependencies from `import type/typeof` statements', () => {

--- a/packages/jest-haste-map/src/lib/dependencyExtractor.ts
+++ b/packages/jest-haste-map/src/lib/dependencyExtractor.ts
@@ -54,7 +54,7 @@ const REQUIRE_OR_DYNAMIC_IMPORT_RE = createRegExp(
 
 const IMPORT_OR_EXPORT_RE = createRegExp(
   [
-    '\\b(?:import|export)\\s+(?!type(?:of)?\\s+)[^\'"]+\\s+from\\s+',
+    '\\b(?:import|export)\\s+(?!type(?:of)?\\s+)(?:[^\'"]+\\s+from\\s+)?',
     CAPTURE_STRING_LITERAL(1),
   ],
   'g',


### PR DESCRIPTION
## Summary

Jest previously wouldn't find changes to side-effect only imports when watching files.

https://github.com/facebook/jest/issues/8547

## Test plan

1. Added a test to make it fail
1. Made the test pass
1. Tried to ensure other tests failing / passing status were the same running a full `yarn jest`, but there's a fair amount of noise is pre-existing failures. Also tried to use `yarn jest --json --outputFile=[...]` before and after but a lot of noise there in comparing. Settled for similar looking summaries before / after that looks something like the below when run close together:

>Snapshot Summary
 › 4 snapshots failed from 2 test suites. Inspect your code changes or run `yarn run jest -u` to update them.
>
> Test Suites: 7 failed, 328 passed, 335 total
Tests:       12 failed, 9 skipped, 3465 passed, 3486 total
Snapshots:   4 failed, 1465 passed, 1469 total
Time:        154.846s, estimated 158s
Ran all test suites in 14 projects.
