### PR TITLE
Fix handling circular references correctly in objects (closes #8663)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - `[jest-core]` Fix incorrect `passWithNoTests` warning ([#8595](https://github.com/facebook/jest/pull/8595))
 - `[jest-snapshots]` Fix test retries that contain snapshots ([#8629](https://github.com/facebook/jest/pull/8629))
 - `[jest-mock]` Fix incorrect assignments when restoring mocks in instances where they originally didn't exist ([#8631](https://github.com/facebook/jest/pull/8631))
+- `[expect]` Fix stack overflow when matching objects with circular references ([#8687](https://github.com/facebook/jest/pull/8687))
 
 ### Chore & Maintenance
 

--- a/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -4092,6 +4092,104 @@ Expected: not <green>Set {2, 1}</>
 Received:     <red>Set {1, 2}</>"
 `;
 
+exports[`toMatchObject() circular references simple circular references {pass: false} expect({"a": "hello", "ref": [Circular]}).toMatchObject({"a": "world", "ref": [Circular]}) 1`] = `"Maximum call stack size exceeded"`;
+
+exports[`toMatchObject() circular references simple circular references {pass: false} expect({"ref": "not a ref"}).toMatchObject({"a": "hello", "ref": [Circular]}) 1`] = `
+"<dim>expect(</><red>received</><dim>).</>toMatchObject<dim>(</><green>expected</><dim>)</>
+
+<green>- Expected</>
+<red>+ Received</>
+
+<dim>  Object {</>
+<green>-   \\"a\\": \\"hello\\",</>
+<green>-   \\"ref\\": [Circular],</>
+<red>+   \\"ref\\": \\"not a ref\\",</>
+<dim>  }</>"
+`;
+
+exports[`toMatchObject() circular references simple circular references {pass: false} expect({}).toMatchObject({"a": "hello", "ref": [Circular]}) 1`] = `
+"<dim>expect(</><red>received</><dim>).</>toMatchObject<dim>(</><green>expected</><dim>)</>
+
+<green>- Expected</>
+<red>+ Received</>
+
+<green>- Object {</>
+<green>-   \\"a\\": \\"hello\\",</>
+<green>-   \\"ref\\": [Circular],</>
+<green>- }</>
+<red>+ Object {}</>"
+`;
+
+exports[`toMatchObject() circular references simple circular references {pass: true} expect({"a": "hello", "ref": [Circular]}).toMatchObject({"a": "hello", "ref": [Circular]}) 1`] = `
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toMatchObject<dim>(</><green>expected</><dim>)</>
+
+Expected: not <green>{\\"a\\": \\"hello\\", \\"ref\\": [Circular]}</>"
+`;
+
+exports[`toMatchObject() circular references simple circular references {pass: true} expect({"a": "hello", "ref": [Circular]}).toMatchObject({}) 1`] = `
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toMatchObject<dim>(</><green>expected</><dim>)</>
+
+Expected: not <green>{}</>
+Received:     <red>{\\"a\\": \\"hello\\", \\"ref\\": [Circular]}</>"
+`;
+
+exports[`toMatchObject() circular references transitive circular references {pass: false} expect({"a": "world", "nestedObj": {"parentObj": [Circular]}}).toMatchObject({"a": "hello", "nestedObj": {"parentObj": [Circular]}}) 1`] = `"Maximum call stack size exceeded"`;
+
+exports[`toMatchObject() circular references transitive circular references {pass: false} expect({"nestedObj": {"parentObj": "not the parent ref"}}).toMatchObject({"a": "hello", "nestedObj": {"parentObj": [Circular]}}) 1`] = `
+"<dim>expect(</><red>received</><dim>).</>toMatchObject<dim>(</><green>expected</><dim>)</>
+
+<green>- Expected</>
+<red>+ Received</>
+
+<dim>  Object {</>
+<green>-   \\"a\\": \\"hello\\",</>
+<dim>    \\"nestedObj\\": Object {</>
+<green>-     \\"parentObj\\": [Circular],</>
+<red>+     \\"parentObj\\": \\"not the parent ref\\",</>
+<dim>    },</>
+<dim>  }</>"
+`;
+
+exports[`toMatchObject() circular references transitive circular references {pass: false} expect({}).toMatchObject({"a": "hello", "nestedObj": {"parentObj": [Circular]}}) 1`] = `
+"<dim>expect(</><red>received</><dim>).</>toMatchObject<dim>(</><green>expected</><dim>)</>
+
+<green>- Expected</>
+<red>+ Received</>
+
+<green>- Object {</>
+<green>-   \\"a\\": \\"hello\\",</>
+<green>-   \\"nestedObj\\": Object {</>
+<green>-     \\"parentObj\\": [Circular],</>
+<green>-   },</>
+<green>- }</>
+<red>+ Object {}</>"
+`;
+
+exports[`toMatchObject() circular references transitive circular references {pass: true} expect({"a": "hello", "nestedObj": {"parentObj": [Circular]}}).toMatchObject({"a": "hello", "nestedObj": {"parentObj": [Circular]}}) 1`] = `
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toMatchObject<dim>(</><green>expected</><dim>)</>
+
+Expected: not <green>{\\"a\\": \\"hello\\", \\"nestedObj\\": {\\"parentObj\\": [Circular]}}</>"
+`;
+
+exports[`toMatchObject() circular references transitive circular references {pass: true} expect({"a": "hello", "nestedObj": {"parentObj": [Circular]}}).toMatchObject({}) 1`] = `
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toMatchObject<dim>(</><green>expected</><dim>)</>
+
+Expected: not <green>{}</>
+Received:     <red>{\\"a\\": \\"hello\\", \\"nestedObj\\": {\\"parentObj\\": [Circular]}}</>"
+`;
+
+exports[`toMatchObject() does not match properties up in the prototype chain 1`] = `
+"<dim>expect(</><red>received</><dim>).</>toMatchObject<dim>(</><green>expected</><dim>)</>
+
+<green>- Expected</>
+<red>+ Received</>
+
+<dim>  Object {</>
+<dim>    \\"other\\": \\"child\\",</>
+<green>-   \\"ref\\": [Circular],</>
+<dim>  }</>"
+`;
+
 exports[`toMatchObject() throws expect("44").toMatchObject({}) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>toMatchObject<dim>(</><green>expected</><dim>)</>
 

--- a/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -4092,7 +4092,18 @@ Expected: not <green>Set {2, 1}</>
 Received:     <red>Set {1, 2}</>"
 `;
 
-exports[`toMatchObject() circular references simple circular references {pass: false} expect({"a": "hello", "ref": [Circular]}).toMatchObject({"a": "world", "ref": [Circular]}) 1`] = `"Maximum call stack size exceeded"`;
+exports[`toMatchObject() circular references simple circular references {pass: false} expect({"a": "hello", "ref": [Circular]}).toMatchObject({"a": "world", "ref": [Circular]}) 1`] = `
+"<dim>expect(</><red>received</><dim>).</>toMatchObject<dim>(</><green>expected</><dim>)</>
+
+<green>- Expected</>
+<red>+ Received</>
+
+<dim>  Object {</>
+<green>-   \\"a\\": \\"world\\",</>
+<red>+   \\"a\\": \\"hello\\",</>
+<dim>    \\"ref\\": [Circular],</>
+<dim>  }</>"
+`;
 
 exports[`toMatchObject() circular references simple circular references {pass: false} expect({"ref": "not a ref"}).toMatchObject({"a": "hello", "ref": [Circular]}) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>toMatchObject<dim>(</><green>expected</><dim>)</>
@@ -4133,7 +4144,20 @@ Expected: not <green>{}</>
 Received:     <red>{\\"a\\": \\"hello\\", \\"ref\\": [Circular]}</>"
 `;
 
-exports[`toMatchObject() circular references transitive circular references {pass: false} expect({"a": "world", "nestedObj": {"parentObj": [Circular]}}).toMatchObject({"a": "hello", "nestedObj": {"parentObj": [Circular]}}) 1`] = `"Maximum call stack size exceeded"`;
+exports[`toMatchObject() circular references transitive circular references {pass: false} expect({"a": "world", "nestedObj": {"parentObj": [Circular]}}).toMatchObject({"a": "hello", "nestedObj": {"parentObj": [Circular]}}) 1`] = `
+"<dim>expect(</><red>received</><dim>).</>toMatchObject<dim>(</><green>expected</><dim>)</>
+
+<green>- Expected</>
+<red>+ Received</>
+
+<dim>  Object {</>
+<green>-   \\"a\\": \\"hello\\",</>
+<red>+   \\"a\\": \\"world\\",</>
+<dim>    \\"nestedObj\\": Object {</>
+<dim>      \\"parentObj\\": [Circular],</>
+<dim>    },</>
+<dim>  }</>"
+`;
 
 exports[`toMatchObject() circular references transitive circular references {pass: false} expect({"nestedObj": {"parentObj": "not the parent ref"}}).toMatchObject({"a": "hello", "nestedObj": {"parentObj": [Circular]}}) 1`] = `
 "<dim>expect(</><red>received</><dim>).</>toMatchObject<dim>(</><green>expected</><dim>)</>

--- a/packages/expect/src/__tests__/matchers.test.js
+++ b/packages/expect/src/__tests__/matchers.test.js
@@ -1537,7 +1537,91 @@ describe('toMatchObject()', () => {
     }
   }
 
-  [
+  const testNotToMatchSnapshots = tuples => {
+    tuples.forEach(([n1, n2]) => {
+      it(`{pass: true} expect(${stringify(n1)}).toMatchObject(${stringify(
+        n2,
+      )})`, () => {
+        jestExpect(n1).toMatchObject(n2);
+        expect(() =>
+          jestExpect(n1).not.toMatchObject(n2),
+        ).toThrowErrorMatchingSnapshot();
+      });
+    });
+  };
+
+  const testToMatchSnapshots = tuples => {
+    tuples.forEach(([n1, n2]) => {
+      it(`{pass: false} expect(${stringify(n1)}).toMatchObject(${stringify(
+        n2,
+      )})`, () => {
+        jestExpect(n1).not.toMatchObject(n2);
+        expect(() =>
+          jestExpect(n1).toMatchObject(n2),
+        ).toThrowErrorMatchingSnapshot();
+      });
+    });
+  };
+
+  describe('circular references', () => {
+    describe('simple circular references', () => {
+      const circularObjA1 = {a: 'hello'};
+      circularObjA1.ref = circularObjA1;
+
+      const circularObjB = {a: 'world'};
+      circularObjB.ref = circularObjB;
+
+      const circularObjA2 = {a: 'hello'};
+      circularObjA2.ref = circularObjA2;
+
+      const primitiveInsteadOfRef = {};
+      primitiveInsteadOfRef.ref = 'not a ref';
+
+      testNotToMatchSnapshots([
+        [circularObjA1, {}],
+        [circularObjA2, circularObjA1],
+      ]);
+
+      testToMatchSnapshots([
+        [{}, circularObjA1],
+        [circularObjA1, circularObjB],
+        [primitiveInsteadOfRef, circularObjA1],
+      ]);
+    });
+
+    describe('transitive circular references', () => {
+      const transitiveCircularObjA1 = {a: 'hello'};
+      transitiveCircularObjA1.nestedObj = {parentObj: transitiveCircularObjA1};
+
+      const transitiveCircularObjA2 = {a: 'hello'};
+      transitiveCircularObjA2.nestedObj = {
+        parentObj: transitiveCircularObjA2,
+      };
+
+      const transitiveCircularObjB = {a: 'world'};
+      transitiveCircularObjB.nestedObj = {
+        parentObj: transitiveCircularObjB,
+      };
+
+      const primitiveInsteadOfRef = {};
+      primitiveInsteadOfRef.nestedObj = {
+        parentObj: 'not the parent ref',
+      };
+
+      testNotToMatchSnapshots([
+        [transitiveCircularObjA1, {}],
+        [transitiveCircularObjA2, transitiveCircularObjA1],
+      ]);
+
+      testToMatchSnapshots([
+        [{}, transitiveCircularObjA1],
+        [transitiveCircularObjB, transitiveCircularObjA1],
+        [primitiveInsteadOfRef, transitiveCircularObjA1],
+      ]);
+    });
+  });
+
+  testNotToMatchSnapshots([
     [{a: 'b', c: 'd'}, {a: 'b'}],
     [{a: 'b', c: 'd'}, {a: 'b', c: 'd'}],
     [{a: 'b', t: {x: {r: 'r'}, z: 'z'}}, {a: 'b', t: {z: 'z'}}],
@@ -1560,18 +1644,9 @@ describe('toMatchObject()', () => {
     [new Error('bar'), {message: 'bar'}],
     [new Foo(), {a: undefined, b: 'b'}],
     [Object.assign(Object.create(null), {a: 'b'}), {a: 'b'}],
-  ].forEach(([n1, n2]) => {
-    it(`{pass: true} expect(${stringify(n1)}).toMatchObject(${stringify(
-      n2,
-    )})`, () => {
-      jestExpect(n1).toMatchObject(n2);
-      expect(() =>
-        jestExpect(n1).not.toMatchObject(n2),
-      ).toThrowErrorMatchingSnapshot();
-    });
-  });
+  ]);
 
-  [
+  testToMatchSnapshots([
     [{a: 'b', c: 'd'}, {e: 'b'}],
     [{a: 'b', c: 'd'}, {a: 'b!', c: 'd'}],
     [{a: 'a', c: 'd'}, {a: jestExpect.any(Number)}],
@@ -1597,16 +1672,7 @@ describe('toMatchObject()', () => {
     [[1, 2, 3], [1, 2, 2]],
     [new Error('foo'), new Error('bar')],
     [Object.assign(Object.create(null), {a: 'b'}), {c: 'd'}],
-  ].forEach(([n1, n2]) => {
-    it(`{pass: false} expect(${stringify(n1)}).toMatchObject(${stringify(
-      n2,
-    )})`, () => {
-      jestExpect(n1).not.toMatchObject(n2);
-      expect(() =>
-        jestExpect(n1).toMatchObject(n2),
-      ).toThrowErrorMatchingSnapshot();
-    });
-  });
+  ]);
 
   [
     [null, {}],
@@ -1627,5 +1693,21 @@ describe('toMatchObject()', () => {
         jestExpect(n1).toMatchObject(n2),
       ).toThrowErrorMatchingSnapshot();
     });
+  });
+
+  it('does not match properties up in the prototype chain', () => {
+    const a = {};
+    a.ref = a;
+
+    const b = Object.create(a);
+    b.other = 'child';
+
+    const matcher = {other: 'child'};
+    matcher.ref = matcher;
+
+    jestExpect(b).not.toMatchObject(matcher);
+    expect(() =>
+      jestExpect(b).toMatchObject(matcher),
+    ).toThrowErrorMatchingSnapshot();
   });
 });

--- a/packages/expect/src/__tests__/utils.test.js
+++ b/packages/expect/src/__tests__/utils.test.js
@@ -202,6 +202,60 @@ describe('subsetEquality()', () => {
   test('undefined does not return errors', () => {
     expect(subsetEquality(undefined, {foo: 'bar'})).not.toBeTruthy();
   });
+
+  describe('matching subsets with circular references', () => {
+    test('simple circular references', () => {
+      const circularObjA1 = {a: 'hello'};
+      circularObjA1.ref = circularObjA1;
+
+      const circularObjA2 = {a: 'hello'};
+      circularObjA2.ref = circularObjA2;
+
+      const circularObjB = {a: 'world'};
+      circularObjB.ref = circularObjB;
+
+      const primitiveInsteadOfRef = {};
+      primitiveInsteadOfRef.ref = 'not a ref';
+
+      expect(subsetEquality(circularObjA1, {})).toBe(true);
+      expect(subsetEquality({}, circularObjA1)).toBe(false);
+      expect(subsetEquality(circularObjA2, circularObjA1)).toBe(true);
+      expect(subsetEquality(circularObjB, circularObjA1)).toBe(false);
+      expect(subsetEquality(primitiveInsteadOfRef, circularObjA1)).toBe(false);
+    });
+
+    test('transitive circular references', () => {
+      const transitiveCircularObjA1 = {a: 'hello'};
+      transitiveCircularObjA1.nestedObj = {parentObj: transitiveCircularObjA1};
+
+      const transitiveCircularObjA2 = {a: 'hello'};
+      transitiveCircularObjA2.nestedObj = {
+        parentObj: transitiveCircularObjA2,
+      };
+
+      const transitiveCircularObjB = {a: 'world'};
+      transitiveCircularObjB.nestedObj = {
+        parentObj: transitiveCircularObjB,
+      };
+
+      const primitiveInsteadOfRef = {};
+      primitiveInsteadOfRef.nestedObj = {
+        parentObj: 'not the parent ref',
+      };
+
+      expect(subsetEquality(transitiveCircularObjA1, {})).toBe(true);
+      expect(subsetEquality({}, transitiveCircularObjA1)).toBe(false);
+      expect(
+        subsetEquality(transitiveCircularObjA2, transitiveCircularObjA1),
+      ).toBe(true);
+      expect(
+        subsetEquality(transitiveCircularObjB, transitiveCircularObjA1),
+      ).toBe(false);
+      expect(
+        subsetEquality(primitiveInsteadOfRef, transitiveCircularObjA1),
+      ).toBe(false);
+    });
+  });
 });
 
 describe('iterableEquality', () => {


### PR DESCRIPTION
## Summary

This PR fixes the StackOverflow caused by passing objects with circular references to `toMatchObject` as per described in #8663.

And many thanks to @leoselig for providing an accurate report 💖 


## Why this problem happens

1. The object matching happens in the `toMatchObject` method of `expect`. [This method uses `equals` and passes two custom testers to it: `iterableEquality` and `subsetEquality`](https://github.com/facebook/jest/blob/b76f01bc1c93e2bc4f4f0ed9834227753d7d65cc/packages/expect/src/matchers.ts#L874).
2. The `equals` method will then [use the passed `customTesters` to check for equality between `a` and `b`](https://github.com/facebook/jest/blob/b76f01bc1c93e2bc4f4f0ed9834227753d7d65cc/packages/expect/src/jasmineUtils.ts#L80-L85). If a `customTester` returns something other than `undefined`, that result is returned.
3. [The `subsetEquality` method would then use `equals` for all the properties in the `object` with itself as one of the `customTesters`](https://github.com/facebook/jest/blob/b76f01bc1c93e2bc4f4f0ed9834227753d7d65cc/packages/expect/src/utils.ts#L275-L280). Due to this, if there were circular references [the `equals` method would call `subsetEquality` with the very same object repeatedly](https://github.com/facebook/jest/blob/b76f01bc1c93e2bc4f4f0ed9834227753d7d65cc/packages/expect/src/jasmineUtils.ts#L81) and the stack would reach its limit.

It's important to highlight that this problem would only occur if the `subset` were the object which contained circular references since it's the one whose keys we iterate through.

Please notice that even though [`equals` had its own mechanism to avoid infinite recursion on circular references](https://github.com/facebook/jest/blob/b76f01bc1c93e2bc4f4f0ed9834227753d7d65cc/packages/expect/src/jasmineUtils.ts#L81) that would never get called [because of the `customTesters` which would cause that function to return early](https://github.com/facebook/jest/blob/b76f01bc1c93e2bc4f4f0ed9834227753d7d65cc/packages/expect/src/jasmineUtils.ts#L80-L85).


## Implementation details

To solve this [I created a nested function called `subsetEqualityWithContext`](https://github.com/facebook/jest/compare/master...lucasfcosta:fix-matching-circular-objects?expand=1#diff-9111985eee7caeef66ff59f389ebe52fR277) which takes not only `a` and `b` but also a [`WeakMap`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap) to keep track of checked objects. I then [use `subsetEqualityWithContext` instead of `subsetEquality` as one of the `customTesters` for `equals`](https://github.com/facebook/jest/compare/master...lucasfcosta:fix-matching-circular-objects?expand=1#diff-9111985eee7caeef66ff59f389ebe52fR297).

This approach works because [we add any found objects to `seenReferences`](https://github.com/facebook/jest/compare/master...lucasfcosta:fix-matching-circular-objects?expand=1#diff-9111985eee7caeef66ff59f389ebe52fR289) so that [the next time they are seen we can use `equals` without the `customTester`](https://github.com/facebook/jest/compare/master...lucasfcosta:fix-matching-circular-objects?expand=1#diff-9111985eee7caeef66ff59f389ebe52fR286) which would cause infinite recursion.


## A little bit of semantics

The choice [to use `equals` again if the object has already been seen](https://github.com/facebook/jest/compare/master...lucasfcosta:fix-matching-circular-objects?expand=1#diff-9111985eee7caeef66ff59f389ebe52fR287) is due to the semantics of circular references when it comes to equality. **This is a very important detail**. I opted for considering a circular reference as always being equal to another circular reference instead of checking the actual target of the reference.

This implementation choice makes the following objects match successfully even though `ref` in `otherCircularObj` does not point to `circularObj`.

```js
const circularObj = {a: 'hello'};
circularObj.ref = circularObj;

const otherCircularObj = {a: 'hello'};
otherCircularObj.ref = otherCircularObj;

expect(otherCircularObj).toMatchObject(circularObj);
```

If we simply returned `true` or `false` we would be avoiding to check `ref` and if we used strict equality (`===`) `ref` would have to point to the exact same object in order for them to match:

```js
const circularObj = {a: 'hello'};
circularObj.ref = circularObj;

const otherCircularObj = {a: 'hello'};
otherCircularObj.ref = circularObj;

// This would pass if we used strict equality (`===`)
expect(otherCircularObj).toMatchObject(circularObj);
```

In a testing context, I believe users will want the former behaviour, and therefore I opted for making all circular references semantically equal.


## Test plan

I have extensively tested this code both with simple circular references and transitive circular references.

In the tests for `toMatchObject`, I have checked both if they are matched correctly and also the snapshots of when the matching fails. To make these tests less verbose and repetitive, I also extracted the method responsible for doing the match and the negated match (the one with `.not`) and reuse them throughout the tests for `toMatchObject`.

I also added tests for the `subsetEquality` function in `utils` to ensure that it's returning the correct boolean results itself and maintain tests granular (covering different layers of `toMatchObject`).

In these I cover the following cases (separately for simple references and transitive references):
* Circular references in both sides of `toMatchObject`
* Circular references in different objects which match
* Circular references in different objects which don't match
* Circular references which would be compared against primitives

Circular references in Arrays were already being handled correctly, but I added tests for it just to avoid any possible regressions.