### PR TITLE
expect: Improve report when mock-spy matcher fails, part 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - `[expect]` Highlight substring differences when matcher fails, part 2 ([#8528](https://github.com/facebook/jest/pull/8528))
 - `[expect]` Improve report when mock-spy matcher fails, part 1 ([#8640](https://github.com/facebook/jest/pull/8640))
 - `[expect]` Improve report when mock-spy matcher fails, part 2 ([#8649](https://github.com/facebook/jest/pull/8649))
+- `[expect]` Improve report when mock-spy matcher fails, part 3 ([#8697](https://github.com/facebook/jest/pull/8697))
 - `[jest-snapshot]` Highlight substring differences when matcher fails, part 3 ([#8569](https://github.com/facebook/jest/pull/8569))
 - `[jest-cli]` Improve chai support (with detailed output, to match jest exceptions) ([#8454](https://github.com/facebook/jest/pull/8454))
 - `[*]` Manage the global timeout with `--testTimeout` command line argument. ([#8456](https://github.com/facebook/jest/pull/8456))

--- a/packages/expect/src/__tests__/__snapshots__/spyMatchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/spyMatchers.test.js.snap
@@ -272,9 +272,32 @@ Expected mock function \\"named-mock\\" first call to not have been called with:
   <green>[\\"foo\\", \\"bar\\"]</>"
 `;
 
-exports[`nthCalledWith should reject non integer nth value 1`] = `"nth value <red>0.1</> must be a positive integer greater than <green>0</>"`;
+exports[`nthCalledWith negative throw matcher error for n that is not integer 1`] = `
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>nthCalledWith<dim>(</><green>n</><dim>, </><green>...expected</><dim>)</>
 
-exports[`nthCalledWith should reject nth value smaller than 1 1`] = `"nth value <red>0</> must be a positive integer greater than <green>0</>"`;
+<bold>Matcher error</>: <green>n</> must be a positive integer
+
+n has type:  number
+n has value: <green>Infinity</>"
+`;
+
+exports[`nthCalledWith positive throw matcher error for n that is not integer 1`] = `
+"<dim>expect(</><red>received</><dim>).</>nthCalledWith<dim>(</><green>n</><dim>, </><green>...expected</><dim>)</>
+
+<bold>Matcher error</>: <green>n</> must be a positive integer
+
+n has type:  number
+n has value: <green>0.1</>"
+`;
+
+exports[`nthCalledWith positive throw matcher error for n that is not positive integer 1`] = `
+"<dim>expect(</><red>received</><dim>).</>nthCalledWith<dim>(</><green>n</><dim>, </><green>...expected</><dim>)</>
+
+<bold>Matcher error</>: <green>n</> must be a positive integer
+
+n has type:  number
+n has value: <green>0</>"
+`;
 
 exports[`nthCalledWith should replace 1st, 2nd, 3rd with first, second, third 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).nthCalledWith(</><green>expected</><dim>)</>
@@ -460,7 +483,31 @@ But the 4th call returned exactly:
   <red>0</>"
 `;
 
-exports[`nthReturnedWith nthReturnedWith should reject non integer nth value 1`] = `"nth value <red>0.1</> must be a positive integer greater than <green>0</>"`;
+exports[`nthReturnedWith nthReturnedWith negative throw matcher error for n that is not number 1`] = `
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
+
+<bold>Matcher error</>: <green>n</> must be a positive integer
+
+n has value: <green>undefined</>"
+`;
+
+exports[`nthReturnedWith nthReturnedWith positive throw matcher error for n that is not integer 1`] = `
+"<dim>expect(</><red>received</><dim>).</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
+
+<bold>Matcher error</>: <green>n</> must be a positive integer
+
+n has type:  number
+n has value: <green>0.1</>"
+`;
+
+exports[`nthReturnedWith nthReturnedWith positive throw matcher error for n that is not positive integer 1`] = `
+"<dim>expect(</><red>received</><dim>).</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
+
+<bold>Matcher error</>: <green>n</> must be a positive integer
+
+n has type:  number
+n has value: <green>0</>"
+`;
 
 exports[`nthReturnedWith nthReturnedWith should reject nth value greater than number of calls 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).nthReturnedWith(</><green>expected</><dim>)</>
@@ -469,8 +516,6 @@ Expected mock function 4th call to have returned with:
   <green>\\"foo\\"</>
 But it was only called <red>3</> times"
 `;
-
-exports[`nthReturnedWith nthReturnedWith should reject nth value smaller than 1 1`] = `"nth value <red>0</> must be a positive integer greater than <green>0</>"`;
 
 exports[`nthReturnedWith nthReturnedWith should replace 1st, 2nd, 3rd with first, second, third 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).nthReturnedWith(</><green>expected</><dim>)</>
@@ -1390,9 +1435,32 @@ Expected mock function \\"named-mock\\" first call to not have been called with:
   <green>[\\"foo\\", \\"bar\\"]</>"
 `;
 
-exports[`toHaveBeenNthCalledWith should reject non integer nth value 1`] = `"nth value <red>0.1</> must be a positive integer greater than <green>0</>"`;
+exports[`toHaveBeenNthCalledWith negative throw matcher error for n that is not integer 1`] = `
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveBeenNthCalledWith<dim>(</><green>n</><dim>, </><green>...expected</><dim>)</>
 
-exports[`toHaveBeenNthCalledWith should reject nth value smaller than 1 1`] = `"nth value <red>0</> must be a positive integer greater than <green>0</>"`;
+<bold>Matcher error</>: <green>n</> must be a positive integer
+
+n has type:  number
+n has value: <green>Infinity</>"
+`;
+
+exports[`toHaveBeenNthCalledWith positive throw matcher error for n that is not integer 1`] = `
+"<dim>expect(</><red>received</><dim>).</>toHaveBeenNthCalledWith<dim>(</><green>n</><dim>, </><green>...expected</><dim>)</>
+
+<bold>Matcher error</>: <green>n</> must be a positive integer
+
+n has type:  number
+n has value: <green>0.1</>"
+`;
+
+exports[`toHaveBeenNthCalledWith positive throw matcher error for n that is not positive integer 1`] = `
+"<dim>expect(</><red>received</><dim>).</>toHaveBeenNthCalledWith<dim>(</><green>n</><dim>, </><green>...expected</><dim>)</>
+
+<bold>Matcher error</>: <green>n</> must be a positive integer
+
+n has type:  number
+n has value: <green>0</>"
+`;
 
 exports[`toHaveBeenNthCalledWith should replace 1st, 2nd, 3rd with first, second, third 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).toHaveBeenNthCalledWith(</><green>expected</><dim>)</>
@@ -1717,7 +1785,31 @@ But the 4th call returned exactly:
   <red>0</>"
 `;
 
-exports[`toHaveNthReturnedWith nthReturnedWith should reject non integer nth value 1`] = `"nth value <red>0.1</> must be a positive integer greater than <green>0</>"`;
+exports[`toHaveNthReturnedWith nthReturnedWith negative throw matcher error for n that is not number 1`] = `
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
+
+<bold>Matcher error</>: <green>n</> must be a positive integer
+
+n has value: <green>undefined</>"
+`;
+
+exports[`toHaveNthReturnedWith nthReturnedWith positive throw matcher error for n that is not integer 1`] = `
+"<dim>expect(</><red>received</><dim>).</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
+
+<bold>Matcher error</>: <green>n</> must be a positive integer
+
+n has type:  number
+n has value: <green>0.1</>"
+`;
+
+exports[`toHaveNthReturnedWith nthReturnedWith positive throw matcher error for n that is not positive integer 1`] = `
+"<dim>expect(</><red>received</><dim>).</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
+
+<bold>Matcher error</>: <green>n</> must be a positive integer
+
+n has type:  number
+n has value: <green>0</>"
+`;
 
 exports[`toHaveNthReturnedWith nthReturnedWith should reject nth value greater than number of calls 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).toHaveNthReturnedWith(</><green>expected</><dim>)</>
@@ -1726,8 +1818,6 @@ Expected mock function 4th call to have returned with:
   <green>\\"foo\\"</>
 But it was only called <red>3</> times"
 `;
-
-exports[`toHaveNthReturnedWith nthReturnedWith should reject nth value smaller than 1 1`] = `"nth value <red>0</> must be a positive integer greater than <green>0</>"`;
 
 exports[`toHaveNthReturnedWith nthReturnedWith should replace 1st, 2nd, 3rd with first, second, third 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).toHaveNthReturnedWith(</><green>expected</><dim>)</>

--- a/packages/expect/src/__tests__/spyMatchers.test.js
+++ b/packages/expect/src/__tests__/spyMatchers.test.js
@@ -338,7 +338,7 @@ const jestExpect = require('../');
         }).toThrowErrorMatchingSnapshot();
       });
 
-      test('should reject nth value smaller than 1', async () => {
+      test('positive throw matcher error for n that is not positive integer', async () => {
         const fn = jest.fn();
         fn('foo1', 'bar');
 
@@ -347,12 +347,21 @@ const jestExpect = require('../');
         }).toThrowErrorMatchingSnapshot();
       });
 
-      test('should reject non integer nth value', async () => {
+      test('positive throw matcher error for n that is not integer', async () => {
         const fn = jest.fn();
         fn('foo1', 'bar');
 
         expect(() => {
           jestExpect(fn)[calledWith](0.1, 'foo1', 'bar');
+        }).toThrowErrorMatchingSnapshot();
+      });
+
+      test('negative throw matcher error for n that is not integer', async () => {
+        const fn = jest.fn();
+        fn('foo1', 'bar');
+
+        expect(() => {
+          jestExpect(fn).not[calledWith](Infinity, 'foo1', 'bar');
         }).toThrowErrorMatchingSnapshot();
       });
     }
@@ -963,7 +972,7 @@ const jestExpect = require('../');
           }).toThrowErrorMatchingSnapshot();
         });
 
-        test('should reject nth value smaller than 1', async () => {
+        test('positive throw matcher error for n that is not positive integer', async () => {
           const fn = jest.fn(() => 'foo');
           fn();
 
@@ -983,12 +992,21 @@ const jestExpect = require('../');
           }).toThrowErrorMatchingSnapshot();
         });
 
-        test('should reject non integer nth value', async () => {
+        test('positive throw matcher error for n that is not integer', async () => {
           const fn = jest.fn(() => 'foo');
           fn('foo');
 
           expect(() => {
             jestExpect(fn)[returnedWith](0.1, 'foo');
+          }).toThrowErrorMatchingSnapshot();
+        });
+
+        test('negative throw matcher error for n that is not number', async () => {
+          const fn = jest.fn(() => 'foo');
+          fn('foo');
+
+          expect(() => {
+            jestExpect(fn).not[returnedWith]();
           }).toThrowErrorMatchingSnapshot();
         });
 

--- a/packages/expect/src/spyMatchers.ts
+++ b/packages/expect/src/spyMatchers.ts
@@ -9,6 +9,7 @@ import {
   diff,
   ensureExpectedIsNumber,
   ensureNoExpected,
+  EXPECTED_COLOR,
   matcherErrorMessage,
   matcherHint,
   MatcherHintOptions,
@@ -422,18 +423,23 @@ const createNthCalledWithMatcher = (matcherName: string) =>
     };
     ensureMock(received, matcherName.slice(1), expectedArgument, options);
 
+    if (!Number.isSafeInteger(nth) || nth < 1) {
+      throw new Error(
+        matcherErrorMessage(
+          matcherHint(
+            matcherName.slice(1),
+            undefined,
+            expectedArgument,
+            options,
+          ),
+          `${EXPECTED_COLOR(expectedArgument)} must be a positive integer`,
+          printWithType(expectedArgument, nth, printExpected),
+        ),
+      );
+    }
+
     const receivedIsSpy = isSpy(received);
     const type = receivedIsSpy ? 'spy' : 'mock function';
-
-    // @ts-ignore
-    if (typeof nth !== 'number' || parseInt(nth, 10) !== nth || nth < 1) {
-      const message = () =>
-        `nth value ${printReceived(
-          nth,
-        )} must be a positive integer greater than ${printExpected(0)}`;
-      const pass = false;
-      return {message, pass};
-    }
 
     const receivedName = receivedIsSpy ? 'spy' : received.getMockName();
     const identifier =
@@ -483,14 +489,19 @@ const createNthReturnedWithMatcher = (matcherName: string) =>
     };
     ensureMock(received, matcherName.slice(1), expectedArgument, options);
 
-    //@ts-ignore
-    if (typeof nth !== 'number' || parseInt(nth, 10) !== nth || nth < 1) {
-      const message = () =>
-        `nth value ${printReceived(
-          nth,
-        )} must be a positive integer greater than ${printExpected(0)}`;
-      const pass = false;
-      return {message, pass};
+    if (!Number.isSafeInteger(nth) || nth < 1) {
+      throw new Error(
+        matcherErrorMessage(
+          matcherHint(
+            matcherName.slice(1),
+            undefined,
+            expectedArgument,
+            options,
+          ),
+          `${EXPECTED_COLOR(expectedArgument)} must be a positive integer`,
+          printWithType(expectedArgument, nth, printExpected),
+        ),
+      );
     }
 
     const receivedName = received.getMockName();


### PR DESCRIPTION
## Summary

Throw matcher error if `n` is not a positive safe integer:

* `toHaveBeenNthCalledWith` and `nthCalledWith`
* `toHaveNthReturnedWith` and `nthReturnedWith`

Because baseline code returns `pass: false` a negative assertion with invalid `n` cannot fail :(

Do y’all think to throw error instead of false negative (pardon pun) as:

* breaking change?
* fixed error?

For consistency with other matcher errors, display `received` instead of `jest.fn()` or mock name

`matcherName.slice(1)` is temporary until future pull requests which will delete period from names in calls to create matcher functions.

## Test plan

* Updated and renamed 8 snapshots for positive assertions
* Added 4 snapshots for negative assertions

Example pictures baseline at left and **improved at right**

Examples of positive assertions:

<img width="1000" alt="positive CalledWith" src="https://user-images.githubusercontent.com/11862657/61304523-4a5d6800-a7b7-11e9-9b84-e6a9ded423c5.png">

<img width="1000" alt="positive ReturnedWith" src="https://user-images.githubusercontent.com/11862657/61304500-403b6980-a7b7-11e9-85fd-4a524fc179a0.png">

Examples of negative assertions:

<img width="1000" alt="negative CalledWIth" src="https://user-images.githubusercontent.com/11862657/61304467-36b20180-a7b7-11e9-82dd-336c28ff1b0d.png">

<img width="1000" alt="negative ReturnedWith" src="https://user-images.githubusercontent.com/11862657/61304453-30bc2080-a7b7-11e9-9ed4-62b3542a4720.png">