### PR TITLE
chore: move getVersion to jest-core from cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - `[docs]` Add information about using `jest.doMock` with ES6 imports ([#8573](https://github.com/facebook/jest/pull/8573))
 - `[docs]` Fix variable name in custom-matcher-api code example ([#8582](https://github.com/facebook/jest/pull/8582))
 - `[docs]` Fix example used in custom environment docs ([#8617](https://github.com/facebook/jest/pull/8617))
+- `[jest-core]` Add `getVersion` (moved from `jest-cli`)
 
 ### Performance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@
 - `[docs]` Add information about using `jest.doMock` with ES6 imports ([#8573](https://github.com/facebook/jest/pull/8573))
 - `[docs]` Fix variable name in custom-matcher-api code example ([#8582](https://github.com/facebook/jest/pull/8582))
 - `[docs]` Fix example used in custom environment docs ([#8617](https://github.com/facebook/jest/pull/8617))
-- `[jest-core]` Add `getVersion` (moved from `jest-cli`)
+- `[jest-core]` Add `getVersion` (moved from `jest-cli`) ([#8706](https://github.com/facebook/jest/pull/8706))
 
 ### Performance
 

--- a/packages/jest-cli/src/cli/index.ts
+++ b/packages/jest-cli/src/cli/index.ts
@@ -11,13 +11,12 @@ import {AggregatedResult} from '@jest/test-result';
 import {clearLine} from 'jest-util';
 import {validateCLIOptions} from 'jest-validate';
 import {deprecationEntries} from 'jest-config';
-import {runCLI} from '@jest/core';
+import {getVersion, runCLI} from '@jest/core';
 import chalk from 'chalk';
 import exit from 'exit';
 import yargs from 'yargs';
 import {sync as realpath} from 'realpath-native';
 import init from '../init';
-import getVersion from '../version';
 import * as args from './args';
 
 export async function run(maybeArgv?: Array<string>, project?: Config.Path) {

--- a/packages/jest-cli/src/index.ts
+++ b/packages/jest-cli/src/index.ts
@@ -6,9 +6,14 @@
  */
 
 // TODO: remove @jest/core exports for the next major
-import {runCLI, SearchSource, TestScheduler, TestWatcher} from '@jest/core';
+import {
+  getVersion,
+  runCLI,
+  SearchSource,
+  TestScheduler,
+  TestWatcher,
+} from '@jest/core';
 import {run} from './cli';
-import {default as getVersion} from './version';
 
 export = {
   SearchSource,

--- a/packages/jest-core/src/jest.ts
+++ b/packages/jest-core/src/jest.ts
@@ -9,3 +9,4 @@ export {default as SearchSource} from './SearchSource';
 export {default as TestScheduler} from './TestScheduler';
 export {default as TestWatcher} from './TestWatcher';
 export {runCLI} from './cli';
+export {default as getVersion} from './version';

--- a/packages/jest-core/src/version.ts
+++ b/packages/jest-core/src/version.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+// Cannot be `import` as it's not under TS root dir
 const {version: VERSION} = require('../package.json');
 
 export default function getVersion(): string {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary
Makes sure `jest-cli` just exports the actual CLI running interface, nothing else

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan
Green CI

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
