### PR TITLE
expect: Improve report when mock-spy matcher fails, part 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `[expect]` Improve report when mock-spy matcher fails, part 1 ([#8640](https://github.com/facebook/jest/pull/8640))
 - `[expect]` Improve report when mock-spy matcher fails, part 2 ([#8649](https://github.com/facebook/jest/pull/8649))
 - `[expect]` Improve report when mock-spy matcher fails, part 3 ([#8697](https://github.com/facebook/jest/pull/8697))
+- `[expect]` Improve report when mock-spy matcher fails, part 4 ([#8710](https://github.com/facebook/jest/pull/8710))
 - `[jest-snapshot]` Highlight substring differences when matcher fails, part 3 ([#8569](https://github.com/facebook/jest/pull/8569))
 - `[jest-cli]` Improve chai support (with detailed output, to match jest exceptions) ([#8454](https://github.com/facebook/jest/pull/8454))
 - `[*]` Manage the global timeout with `--testTimeout` command line argument. ([#8456](https://github.com/facebook/jest/pull/8456))

--- a/packages/expect/src/__tests__/__snapshots__/spyMatchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/spyMatchers.test.js.snap
@@ -127,44 +127,56 @@ Expected mock function to have been last called with:
 `;
 
 exports[`lastReturnedWith a call that throws is not considered to have returned 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).lastReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>lastReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected mock function to have last returned:
-  <green>undefined</>
-But the last call <red>threw an error</>"
+Expected value: <green>undefined</>
+Received value:
+             1: threw an error
+
+Received number of returns: <red>0</>
+Received number of calls:   <red>1</>"
 `;
 
 exports[`lastReturnedWith a call that throws undefined is not considered to have returned 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).lastReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>lastReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected mock function to have last returned:
-  <green>undefined</>
-But the last call <red>threw an error</>"
+Expected value: <green>undefined</>
+Received value:
+             1: threw an error
+
+Received number of returns: <red>0</>
+Received number of calls:   <red>1</>"
 `;
 
 exports[`lastReturnedWith includes the custom mock name in the error message 1`] = `
-"<dim>expect(</><red>named-mock</><dim>).lastReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>named-mock</><dim>).</>lastReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected mock function \\"named-mock\\" to have last returned:
-  <green>\\"foo\\"</>
-But it was <red>not called</>"
+Expected value: <green>\\"foo\\"</>
+
+Received number of returns: <red>0</>"
 `;
 
 exports[`lastReturnedWith lastReturnedWith incomplete recursive calls are handled properly 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).lastReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>lastReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected mock function to have last returned:
-  <green>0</>
-But the last call <red>has not returned yet</>"
+Expected value: <green>0</>
+Received value:
+             3: has not returned yet
+             4: has not returned yet
+
+Received number of returns: <red>0</>
+Received number of calls:   <red>4</>"
 `;
 
 exports[`lastReturnedWith lastReturnedWith works with three calls 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.lastReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>lastReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected mock function to not have last returned:
-  <green>\\"foo3\\"</>
-But it last returned exactly:
-  <red>\\"foo3\\"</>"
+Expected value: not <green>\\"foo3\\"</>
+Received value:
+             2:     <red>\\"foo2\\"</>
+             3:     <red>\\"foo3\\"</>
+
+Received number of returns: <red>3</>"
 `;
 
 exports[`lastReturnedWith works only on spies or jest.fn 1`] = `
@@ -177,92 +189,101 @@ Received has value: <red>[Function fn]</>"
 `;
 
 exports[`lastReturnedWith works when not called 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).lastReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>lastReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected mock function to have last returned:
-  <green>\\"foo\\"</>
-But it was <red>not called</>"
+Expected value: <green>\\"foo\\"</>
+
+Received number of returns: <red>0</>"
 `;
 
 exports[`lastReturnedWith works with Immutable.js objects directly created 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.lastReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>lastReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected mock function to not have last returned:
-  <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
-But it last returned exactly:
-  <red>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>"
+Expected value: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
+Received value:
+             1:     <red>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
+
+Received number of returns: <red>1</>"
 `;
 
 exports[`lastReturnedWith works with Immutable.js objects indirectly created 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.lastReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>lastReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected mock function to not have last returned:
-  <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
-But it last returned exactly:
-  <red>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>"
+Expected value: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
+Received value:
+             1:     <red>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
+
+Received number of returns: <red>1</>"
 `;
 
 exports[`lastReturnedWith works with Map 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.lastReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>lastReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected mock function to not have last returned:
-  <green>Map {1 => 2, 2 => 1}</>
-But it last returned exactly:
-  <red>Map {1 => 2, 2 => 1}</>"
+Expected value: not <green>Map {1 => 2, 2 => 1}</>
+Received value:
+             1:     <red>Map {1 => 2, 2 => 1}</>
+
+Received number of returns: <red>1</>"
 `;
 
 exports[`lastReturnedWith works with Map 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).lastReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>lastReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected mock function to have last returned:
-  <green>Map {\\"a\\" => \\"b\\", \\"b\\" => \\"a\\"}</>
-But the last call returned:
-  <red>Map {1 => 2, 2 => 1}</>"
+Expected value: <green>Map {\\"a\\" => \\"b\\", \\"b\\" => \\"a\\"}</>
+Received value:
+             1: <red>Map {1 => 2, 2 => 1}</>
+
+Received number of returns: <red>1</>"
 `;
 
 exports[`lastReturnedWith works with Set 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.lastReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>lastReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected mock function to not have last returned:
-  <green>Set {1, 2}</>
-But it last returned exactly:
-  <red>Set {1, 2}</>"
+Expected value: not <green>Set {1, 2}</>
+Received value:
+             1:     <red>Set {1, 2}</>
+
+Received number of returns: <red>1</>"
 `;
 
 exports[`lastReturnedWith works with Set 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).lastReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>lastReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected mock function to have last returned:
-  <green>Set {3, 4}</>
-But the last call returned:
-  <red>Set {1, 2}</>"
+Expected value: <green>Set {3, 4}</>
+Received value:
+             1: <red>Set {1, 2}</>
+
+Received number of returns: <red>1</>"
 `;
 
 exports[`lastReturnedWith works with argument that does match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.lastReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>lastReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected mock function to not have last returned:
-  <green>\\"foo\\"</>
-But it last returned exactly:
-  <red>\\"foo\\"</>"
+Expected value: not <green>\\"foo\\"</>
+Received value:
+             1:     <red>\\"foo\\"</>
+
+Received number of returns: <red>1</>"
 `;
 
 exports[`lastReturnedWith works with argument that does not match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).lastReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>lastReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected mock function to have last returned:
-  <green>\\"bar\\"</>
-But the last call returned:
-  <red>\\"foo\\"</>"
+Expected value: <green>\\"bar\\"</>
+Received value:
+             1: <red>\\"foo\\"</>
+
+Received number of returns: <red>1</>"
 `;
 
 exports[`lastReturnedWith works with undefined 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.lastReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>lastReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected mock function to not have last returned:
-  <green>undefined</>
-But it last returned exactly:
-  <red>undefined</>"
+Expected value: not <green>undefined</>
+Received value:
+             1:     <red>undefined</>
+
+Received number of returns: <red>1</>"
 `;
 
 exports[`nthCalledWith includes the custom mock name in the error message 1`] = `
@@ -426,61 +447,90 @@ Expected mock function first call to have been called with:
 `;
 
 exports[`nthReturnedWith a call that throws is not considered to have returned 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).nthReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Expected mock function first call to have returned with:
-  <green>undefined</>
-But the first call <red>threw an error</>"
+Call n:      1
+Expected value: <green>undefined</>
+Received value:
+             1: threw an error
+
+Received number of returns: <red>0</>
+Received number of calls:   <red>1</>"
 `;
 
 exports[`nthReturnedWith a call that throws undefined is not considered to have returned 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).nthReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Expected mock function first call to have returned with:
-  <green>undefined</>
-But the first call <red>threw an error</>"
+Call n:      1
+Expected value: <green>undefined</>
+Received value:
+             1: threw an error
+
+Received number of returns: <red>0</>
+Received number of calls:   <red>1</>"
 `;
 
 exports[`nthReturnedWith includes the custom mock name in the error message 1`] = `
-"<dim>expect(</><red>named-mock</><dim>).nthReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>named-mock</><dim>).</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Expected mock function \\"named-mock\\" first call to have returned with:
-  <green>\\"foo\\"</>
-But it was <red>not called</>"
+Call n:      1
+Expected value: <green>\\"foo\\"</>
+
+Received number of returns: <red>0</>"
 `;
 
 exports[`nthReturnedWith nthReturnedWith incomplete recursive calls are handled properly 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).nthReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Expected mock function first call to have returned with:
-  <green>6</>
-But the first call <red>has not returned yet</>"
+Call n:      1
+Expected value: <green>6</>
+Received value:
+             1: has not returned yet
+             2: has not returned yet
+
+Received number of returns: <red>2</>
+Received number of calls:   <red>4</>"
 `;
 
 exports[`nthReturnedWith nthReturnedWith incomplete recursive calls are handled properly 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).nthReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Expected mock function second call to have returned with:
-  <green>3</>
-But the second call <red>has not returned yet</>"
+Call n:      2
+Expected value: <green>3</>
+Received value:
+             1: has not returned yet
+             2: has not returned yet
+             3: <red>1</>
+
+Received number of returns: <red>2</>
+Received number of calls:   <red>4</>"
 `;
 
 exports[`nthReturnedWith nthReturnedWith incomplete recursive calls are handled properly 3`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.nthReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Expected mock function third call to not have returned with:
-  <green>1</>
-But the third call returned exactly:
-  <red>1</>"
+Call n:      3
+Expected value: not <green>1</>
+Received value:
+             2:     has not returned yet
+             3:     <red>1</>
+             4:     <red>0</>
+
+Received number of returns: <red>2</>
+Received number of calls:   <red>4</>"
 `;
 
 exports[`nthReturnedWith nthReturnedWith incomplete recursive calls are handled properly 4`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.nthReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Expected mock function 4th call to not have returned with:
-  <green>0</>
-But the 4th call returned exactly:
-  <red>0</>"
+Call n:      4
+Expected value: not <green>0</>
+Received value:
+             3:     <red>1</>
+             4:     <red>0</>
+
+Received number of returns: <red>2</>
+Received number of calls:   <red>4</>"
 `;
 
 exports[`nthReturnedWith nthReturnedWith negative throw matcher error for n that is not number 1`] = `
@@ -510,38 +560,50 @@ n has value: <green>0</>"
 `;
 
 exports[`nthReturnedWith nthReturnedWith should reject nth value greater than number of calls 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).nthReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Expected mock function 4th call to have returned with:
-  <green>\\"foo\\"</>
-But it was only called <red>3</> times"
+Call n:      4
+Expected value: <green>\\"foo\\"</>
+Received value:
+             3: <red>\\"foo\\"</>
+
+Received number of returns: <red>3</>"
 `;
 
 exports[`nthReturnedWith nthReturnedWith should replace 1st, 2nd, 3rd with first, second, third 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).nthReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Expected mock function first call to have returned with:
-  <green>\\"bar1\\"</>
-But the first call returned with:
-  <red>\\"foo1\\"</>"
+Call n:      1
+Expected value: <green>\\"bar1\\"</>
+Received value:
+             1: <red>\\"foo1\\"</>
+             2: <red>\\"foo2\\"</>
+
+Received number of returns: <red>3</>"
 `;
 
 exports[`nthReturnedWith nthReturnedWith should replace 1st, 2nd, 3rd with first, second, third 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.nthReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Expected mock function first call to not have returned with:
-  <green>\\"foo1\\"</>
-But the first call returned exactly:
-  <red>\\"foo1\\"</>"
+Call n:      1
+Expected value: not <green>\\"foo1\\"</>
+Received value:
+             1:     <red>\\"foo1\\"</>
+             2:     <red>\\"foo2\\"</>
+
+Received number of returns: <red>3</>"
 `;
 
 exports[`nthReturnedWith nthReturnedWith works with three calls 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.nthReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Expected mock function first call to not have returned with:
-  <green>\\"foo1\\"</>
-But the first call returned exactly:
-  <red>\\"foo1\\"</>"
+Call n:      1
+Expected value: not <green>\\"foo1\\"</>
+Received value:
+             1:     <red>\\"foo1\\"</>
+             2:     <red>\\"foo2\\"</>
+
+Received number of returns: <red>3</>"
 `;
 
 exports[`nthReturnedWith works only on spies or jest.fn 1`] = `
@@ -554,92 +616,111 @@ Received has value: <red>[Function fn]</>"
 `;
 
 exports[`nthReturnedWith works when not called 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).nthReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Expected mock function first call to have returned with:
-  <green>\\"foo\\"</>
-But it was <red>not called</>"
+Call n:      1
+Expected value: <green>\\"foo\\"</>
+
+Received number of returns: <red>0</>"
 `;
 
 exports[`nthReturnedWith works with Immutable.js objects directly created 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.nthReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Expected mock function first call to not have returned with:
-  <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
-But the first call returned exactly:
-  <red>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>"
+Call n:      1
+Expected value: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
+Received value:
+             1:     <red>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
+
+Received number of returns: <red>1</>"
 `;
 
 exports[`nthReturnedWith works with Immutable.js objects indirectly created 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.nthReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Expected mock function first call to not have returned with:
-  <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
-But the first call returned exactly:
-  <red>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>"
+Call n:      1
+Expected value: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
+Received value:
+             1:     <red>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
+
+Received number of returns: <red>1</>"
 `;
 
 exports[`nthReturnedWith works with Map 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.nthReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Expected mock function first call to not have returned with:
-  <green>Map {1 => 2, 2 => 1}</>
-But the first call returned exactly:
-  <red>Map {1 => 2, 2 => 1}</>"
+Call n:      1
+Expected value: not <green>Map {1 => 2, 2 => 1}</>
+Received value:
+             1:     <red>Map {1 => 2, 2 => 1}</>
+
+Received number of returns: <red>1</>"
 `;
 
 exports[`nthReturnedWith works with Map 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).nthReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Expected mock function first call to have returned with:
-  <green>Map {\\"a\\" => \\"b\\", \\"b\\" => \\"a\\"}</>
-But the first call returned with:
-  <red>Map {1 => 2, 2 => 1}</>"
+Call n:      1
+Expected value: <green>Map {\\"a\\" => \\"b\\", \\"b\\" => \\"a\\"}</>
+Received value:
+             1: <red>Map {1 => 2, 2 => 1}</>
+
+Received number of returns: <red>1</>"
 `;
 
 exports[`nthReturnedWith works with Set 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.nthReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Expected mock function first call to not have returned with:
-  <green>Set {1, 2}</>
-But the first call returned exactly:
-  <red>Set {1, 2}</>"
+Call n:      1
+Expected value: not <green>Set {1, 2}</>
+Received value:
+             1:     <red>Set {1, 2}</>
+
+Received number of returns: <red>1</>"
 `;
 
 exports[`nthReturnedWith works with Set 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).nthReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Expected mock function first call to have returned with:
-  <green>Set {3, 4}</>
-But the first call returned with:
-  <red>Set {1, 2}</>"
+Call n:      1
+Expected value: <green>Set {3, 4}</>
+Received value:
+             1: <red>Set {1, 2}</>
+
+Received number of returns: <red>1</>"
 `;
 
 exports[`nthReturnedWith works with argument that does match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.nthReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Expected mock function first call to not have returned with:
-  <green>\\"foo\\"</>
-But the first call returned exactly:
-  <red>\\"foo\\"</>"
+Call n:      1
+Expected value: not <green>\\"foo\\"</>
+Received value:
+             1:     <red>\\"foo\\"</>
+
+Received number of returns: <red>1</>"
 `;
 
 exports[`nthReturnedWith works with argument that does not match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).nthReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Expected mock function first call to have returned with:
-  <green>\\"bar\\"</>
-But the first call returned with:
-  <red>\\"foo\\"</>"
+Call n:      1
+Expected value: <green>\\"bar\\"</>
+Received value:
+             1: <red>\\"foo\\"</>
+
+Received number of returns: <red>1</>"
 `;
 
 exports[`nthReturnedWith works with undefined 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.nthReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Expected mock function first call to not have returned with:
-  <green>undefined</>
-But the first call returned exactly:
-  <red>undefined</>"
+Call n:      1
+Expected value: not <green>undefined</>
+Received value:
+             1:     <red>undefined</>
+
+Received number of returns: <red>1</>"
 `;
 
 exports[`toBeCalled .not fails with any argument passed 1`] = `
@@ -1589,44 +1670,56 @@ Expected mock function first call to have been called with:
 `;
 
 exports[`toHaveLastReturnedWith a call that throws is not considered to have returned 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toHaveLastReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveLastReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected mock function to have last returned:
-  <green>undefined</>
-But the last call <red>threw an error</>"
+Expected value: <green>undefined</>
+Received value:
+             1: threw an error
+
+Received number of returns: <red>0</>
+Received number of calls:   <red>1</>"
 `;
 
 exports[`toHaveLastReturnedWith a call that throws undefined is not considered to have returned 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toHaveLastReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveLastReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected mock function to have last returned:
-  <green>undefined</>
-But the last call <red>threw an error</>"
+Expected value: <green>undefined</>
+Received value:
+             1: threw an error
+
+Received number of returns: <red>0</>
+Received number of calls:   <red>1</>"
 `;
 
 exports[`toHaveLastReturnedWith includes the custom mock name in the error message 1`] = `
-"<dim>expect(</><red>named-mock</><dim>).toHaveLastReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>named-mock</><dim>).</>toHaveLastReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected mock function \\"named-mock\\" to have last returned:
-  <green>\\"foo\\"</>
-But it was <red>not called</>"
+Expected value: <green>\\"foo\\"</>
+
+Received number of returns: <red>0</>"
 `;
 
 exports[`toHaveLastReturnedWith lastReturnedWith incomplete recursive calls are handled properly 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toHaveLastReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveLastReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected mock function to have last returned:
-  <green>0</>
-But the last call <red>has not returned yet</>"
+Expected value: <green>0</>
+Received value:
+             3: has not returned yet
+             4: has not returned yet
+
+Received number of returns: <red>0</>
+Received number of calls:   <red>4</>"
 `;
 
 exports[`toHaveLastReturnedWith lastReturnedWith works with three calls 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toHaveLastReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveLastReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected mock function to not have last returned:
-  <green>\\"foo3\\"</>
-But it last returned exactly:
-  <red>\\"foo3\\"</>"
+Expected value: not <green>\\"foo3\\"</>
+Received value:
+             2:     <red>\\"foo2\\"</>
+             3:     <red>\\"foo3\\"</>
+
+Received number of returns: <red>3</>"
 `;
 
 exports[`toHaveLastReturnedWith works only on spies or jest.fn 1`] = `
@@ -1639,150 +1732,188 @@ Received has value: <red>[Function fn]</>"
 `;
 
 exports[`toHaveLastReturnedWith works when not called 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toHaveLastReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveLastReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected mock function to have last returned:
-  <green>\\"foo\\"</>
-But it was <red>not called</>"
+Expected value: <green>\\"foo\\"</>
+
+Received number of returns: <red>0</>"
 `;
 
 exports[`toHaveLastReturnedWith works with Immutable.js objects directly created 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toHaveLastReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveLastReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected mock function to not have last returned:
-  <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
-But it last returned exactly:
-  <red>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>"
+Expected value: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
+Received value:
+             1:     <red>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
+
+Received number of returns: <red>1</>"
 `;
 
 exports[`toHaveLastReturnedWith works with Immutable.js objects indirectly created 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toHaveLastReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveLastReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected mock function to not have last returned:
-  <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
-But it last returned exactly:
-  <red>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>"
+Expected value: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
+Received value:
+             1:     <red>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
+
+Received number of returns: <red>1</>"
 `;
 
 exports[`toHaveLastReturnedWith works with Map 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toHaveLastReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveLastReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected mock function to not have last returned:
-  <green>Map {1 => 2, 2 => 1}</>
-But it last returned exactly:
-  <red>Map {1 => 2, 2 => 1}</>"
+Expected value: not <green>Map {1 => 2, 2 => 1}</>
+Received value:
+             1:     <red>Map {1 => 2, 2 => 1}</>
+
+Received number of returns: <red>1</>"
 `;
 
 exports[`toHaveLastReturnedWith works with Map 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toHaveLastReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveLastReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected mock function to have last returned:
-  <green>Map {\\"a\\" => \\"b\\", \\"b\\" => \\"a\\"}</>
-But the last call returned:
-  <red>Map {1 => 2, 2 => 1}</>"
+Expected value: <green>Map {\\"a\\" => \\"b\\", \\"b\\" => \\"a\\"}</>
+Received value:
+             1: <red>Map {1 => 2, 2 => 1}</>
+
+Received number of returns: <red>1</>"
 `;
 
 exports[`toHaveLastReturnedWith works with Set 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toHaveLastReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveLastReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected mock function to not have last returned:
-  <green>Set {1, 2}</>
-But it last returned exactly:
-  <red>Set {1, 2}</>"
+Expected value: not <green>Set {1, 2}</>
+Received value:
+             1:     <red>Set {1, 2}</>
+
+Received number of returns: <red>1</>"
 `;
 
 exports[`toHaveLastReturnedWith works with Set 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toHaveLastReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveLastReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected mock function to have last returned:
-  <green>Set {3, 4}</>
-But the last call returned:
-  <red>Set {1, 2}</>"
+Expected value: <green>Set {3, 4}</>
+Received value:
+             1: <red>Set {1, 2}</>
+
+Received number of returns: <red>1</>"
 `;
 
 exports[`toHaveLastReturnedWith works with argument that does match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toHaveLastReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveLastReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected mock function to not have last returned:
-  <green>\\"foo\\"</>
-But it last returned exactly:
-  <red>\\"foo\\"</>"
+Expected value: not <green>\\"foo\\"</>
+Received value:
+             1:     <red>\\"foo\\"</>
+
+Received number of returns: <red>1</>"
 `;
 
 exports[`toHaveLastReturnedWith works with argument that does not match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toHaveLastReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveLastReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected mock function to have last returned:
-  <green>\\"bar\\"</>
-But the last call returned:
-  <red>\\"foo\\"</>"
+Expected value: <green>\\"bar\\"</>
+Received value:
+             1: <red>\\"foo\\"</>
+
+Received number of returns: <red>1</>"
 `;
 
 exports[`toHaveLastReturnedWith works with undefined 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toHaveLastReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveLastReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected mock function to not have last returned:
-  <green>undefined</>
-But it last returned exactly:
-  <red>undefined</>"
+Expected value: not <green>undefined</>
+Received value:
+             1:     <red>undefined</>
+
+Received number of returns: <red>1</>"
 `;
 
 exports[`toHaveNthReturnedWith a call that throws is not considered to have returned 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toHaveNthReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Expected mock function first call to have returned with:
-  <green>undefined</>
-But the first call <red>threw an error</>"
+Call n:      1
+Expected value: <green>undefined</>
+Received value:
+             1: threw an error
+
+Received number of returns: <red>0</>
+Received number of calls:   <red>1</>"
 `;
 
 exports[`toHaveNthReturnedWith a call that throws undefined is not considered to have returned 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toHaveNthReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Expected mock function first call to have returned with:
-  <green>undefined</>
-But the first call <red>threw an error</>"
+Call n:      1
+Expected value: <green>undefined</>
+Received value:
+             1: threw an error
+
+Received number of returns: <red>0</>
+Received number of calls:   <red>1</>"
 `;
 
 exports[`toHaveNthReturnedWith includes the custom mock name in the error message 1`] = `
-"<dim>expect(</><red>named-mock</><dim>).toHaveNthReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>named-mock</><dim>).</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Expected mock function \\"named-mock\\" first call to have returned with:
-  <green>\\"foo\\"</>
-But it was <red>not called</>"
+Call n:      1
+Expected value: <green>\\"foo\\"</>
+
+Received number of returns: <red>0</>"
 `;
 
 exports[`toHaveNthReturnedWith nthReturnedWith incomplete recursive calls are handled properly 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toHaveNthReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Expected mock function first call to have returned with:
-  <green>6</>
-But the first call <red>has not returned yet</>"
+Call n:      1
+Expected value: <green>6</>
+Received value:
+             1: has not returned yet
+             2: has not returned yet
+
+Received number of returns: <red>2</>
+Received number of calls:   <red>4</>"
 `;
 
 exports[`toHaveNthReturnedWith nthReturnedWith incomplete recursive calls are handled properly 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toHaveNthReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Expected mock function second call to have returned with:
-  <green>3</>
-But the second call <red>has not returned yet</>"
+Call n:      2
+Expected value: <green>3</>
+Received value:
+             1: has not returned yet
+             2: has not returned yet
+             3: <red>1</>
+
+Received number of returns: <red>2</>
+Received number of calls:   <red>4</>"
 `;
 
 exports[`toHaveNthReturnedWith nthReturnedWith incomplete recursive calls are handled properly 3`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toHaveNthReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Expected mock function third call to not have returned with:
-  <green>1</>
-But the third call returned exactly:
-  <red>1</>"
+Call n:      3
+Expected value: not <green>1</>
+Received value:
+             2:     has not returned yet
+             3:     <red>1</>
+             4:     <red>0</>
+
+Received number of returns: <red>2</>
+Received number of calls:   <red>4</>"
 `;
 
 exports[`toHaveNthReturnedWith nthReturnedWith incomplete recursive calls are handled properly 4`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toHaveNthReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Expected mock function 4th call to not have returned with:
-  <green>0</>
-But the 4th call returned exactly:
-  <red>0</>"
+Call n:      4
+Expected value: not <green>0</>
+Received value:
+             3:     <red>1</>
+             4:     <red>0</>
+
+Received number of returns: <red>2</>
+Received number of calls:   <red>4</>"
 `;
 
 exports[`toHaveNthReturnedWith nthReturnedWith negative throw matcher error for n that is not number 1`] = `
@@ -1812,38 +1943,50 @@ n has value: <green>0</>"
 `;
 
 exports[`toHaveNthReturnedWith nthReturnedWith should reject nth value greater than number of calls 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toHaveNthReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Expected mock function 4th call to have returned with:
-  <green>\\"foo\\"</>
-But it was only called <red>3</> times"
+Call n:      4
+Expected value: <green>\\"foo\\"</>
+Received value:
+             3: <red>\\"foo\\"</>
+
+Received number of returns: <red>3</>"
 `;
 
 exports[`toHaveNthReturnedWith nthReturnedWith should replace 1st, 2nd, 3rd with first, second, third 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toHaveNthReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Expected mock function first call to have returned with:
-  <green>\\"bar1\\"</>
-But the first call returned with:
-  <red>\\"foo1\\"</>"
+Call n:      1
+Expected value: <green>\\"bar1\\"</>
+Received value:
+             1: <red>\\"foo1\\"</>
+             2: <red>\\"foo2\\"</>
+
+Received number of returns: <red>3</>"
 `;
 
 exports[`toHaveNthReturnedWith nthReturnedWith should replace 1st, 2nd, 3rd with first, second, third 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toHaveNthReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Expected mock function first call to not have returned with:
-  <green>\\"foo1\\"</>
-But the first call returned exactly:
-  <red>\\"foo1\\"</>"
+Call n:      1
+Expected value: not <green>\\"foo1\\"</>
+Received value:
+             1:     <red>\\"foo1\\"</>
+             2:     <red>\\"foo2\\"</>
+
+Received number of returns: <red>3</>"
 `;
 
 exports[`toHaveNthReturnedWith nthReturnedWith works with three calls 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toHaveNthReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Expected mock function first call to not have returned with:
-  <green>\\"foo1\\"</>
-But the first call returned exactly:
-  <red>\\"foo1\\"</>"
+Call n:      1
+Expected value: not <green>\\"foo1\\"</>
+Received value:
+             1:     <red>\\"foo1\\"</>
+             2:     <red>\\"foo2\\"</>
+
+Received number of returns: <red>3</>"
 `;
 
 exports[`toHaveNthReturnedWith works only on spies or jest.fn 1`] = `
@@ -1856,92 +1999,111 @@ Received has value: <red>[Function fn]</>"
 `;
 
 exports[`toHaveNthReturnedWith works when not called 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toHaveNthReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Expected mock function first call to have returned with:
-  <green>\\"foo\\"</>
-But it was <red>not called</>"
+Call n:      1
+Expected value: <green>\\"foo\\"</>
+
+Received number of returns: <red>0</>"
 `;
 
 exports[`toHaveNthReturnedWith works with Immutable.js objects directly created 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toHaveNthReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Expected mock function first call to not have returned with:
-  <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
-But the first call returned exactly:
-  <red>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>"
+Call n:      1
+Expected value: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
+Received value:
+             1:     <red>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
+
+Received number of returns: <red>1</>"
 `;
 
 exports[`toHaveNthReturnedWith works with Immutable.js objects indirectly created 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toHaveNthReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Expected mock function first call to not have returned with:
-  <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
-But the first call returned exactly:
-  <red>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>"
+Call n:      1
+Expected value: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
+Received value:
+             1:     <red>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
+
+Received number of returns: <red>1</>"
 `;
 
 exports[`toHaveNthReturnedWith works with Map 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toHaveNthReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Expected mock function first call to not have returned with:
-  <green>Map {1 => 2, 2 => 1}</>
-But the first call returned exactly:
-  <red>Map {1 => 2, 2 => 1}</>"
+Call n:      1
+Expected value: not <green>Map {1 => 2, 2 => 1}</>
+Received value:
+             1:     <red>Map {1 => 2, 2 => 1}</>
+
+Received number of returns: <red>1</>"
 `;
 
 exports[`toHaveNthReturnedWith works with Map 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toHaveNthReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Expected mock function first call to have returned with:
-  <green>Map {\\"a\\" => \\"b\\", \\"b\\" => \\"a\\"}</>
-But the first call returned with:
-  <red>Map {1 => 2, 2 => 1}</>"
+Call n:      1
+Expected value: <green>Map {\\"a\\" => \\"b\\", \\"b\\" => \\"a\\"}</>
+Received value:
+             1: <red>Map {1 => 2, 2 => 1}</>
+
+Received number of returns: <red>1</>"
 `;
 
 exports[`toHaveNthReturnedWith works with Set 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toHaveNthReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Expected mock function first call to not have returned with:
-  <green>Set {1, 2}</>
-But the first call returned exactly:
-  <red>Set {1, 2}</>"
+Call n:      1
+Expected value: not <green>Set {1, 2}</>
+Received value:
+             1:     <red>Set {1, 2}</>
+
+Received number of returns: <red>1</>"
 `;
 
 exports[`toHaveNthReturnedWith works with Set 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toHaveNthReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Expected mock function first call to have returned with:
-  <green>Set {3, 4}</>
-But the first call returned with:
-  <red>Set {1, 2}</>"
+Call n:      1
+Expected value: <green>Set {3, 4}</>
+Received value:
+             1: <red>Set {1, 2}</>
+
+Received number of returns: <red>1</>"
 `;
 
 exports[`toHaveNthReturnedWith works with argument that does match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toHaveNthReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Expected mock function first call to not have returned with:
-  <green>\\"foo\\"</>
-But the first call returned exactly:
-  <red>\\"foo\\"</>"
+Call n:      1
+Expected value: not <green>\\"foo\\"</>
+Received value:
+             1:     <red>\\"foo\\"</>
+
+Received number of returns: <red>1</>"
 `;
 
 exports[`toHaveNthReturnedWith works with argument that does not match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toHaveNthReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Expected mock function first call to have returned with:
-  <green>\\"bar\\"</>
-But the first call returned with:
-  <red>\\"foo\\"</>"
+Call n:      1
+Expected value: <green>\\"bar\\"</>
+Received value:
+             1: <red>\\"foo\\"</>
+
+Received number of returns: <red>1</>"
 `;
 
 exports[`toHaveNthReturnedWith works with undefined 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toHaveNthReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Expected mock function first call to not have returned with:
-  <green>undefined</>
-But the first call returned exactly:
-  <red>undefined</>"
+Call n:      1
+Expected value: not <green>undefined</>
+Received value:
+             1:     <red>undefined</>
+
+Received number of returns: <red>1</>"
 `;
 
 exports[`toHaveReturned .not fails with any argument passed 1`] = `
@@ -2216,54 +2378,58 @@ Received has value: <red>[Function fn]</>"
 `;
 
 exports[`toHaveReturnedWith a call that throws is not considered to have returned 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toHaveReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected mock function to have returned:
-  <green>undefined</>
-But it did <red>not return</>."
+Expected value: <green>undefined</>
+Received value:
+             1: threw an error
+
+Received number of returns: <red>0</>
+Received number of calls:   <red>1</>"
 `;
 
 exports[`toHaveReturnedWith a call that throws undefined is not considered to have returned 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toHaveReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected mock function to have returned:
-  <green>undefined</>
-But it did <red>not return</>."
+Expected value: <green>undefined</>
+Received value:
+             1: threw an error
+
+Received number of returns: <red>0</>
+Received number of calls:   <red>1</>"
 `;
 
 exports[`toHaveReturnedWith includes the custom mock name in the error message 1`] = `
-"<dim>expect(</><red>named-mock</><dim>).toHaveReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>named-mock</><dim>).</>toHaveReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected mock function \\"named-mock\\" to have returned:
-  <green>\\"foo\\"</>
-But it did <red>not return</>."
+Expected value: <green>\\"foo\\"</>
+
+Received number of returns: <red>0</>"
 `;
 
 exports[`toHaveReturnedWith returnedWith incomplete recursive calls are handled properly 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toHaveReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected mock function to have returned:
-  <green>undefined</>
-But it did <red>not return</>."
+Expected value: <green>undefined</>
+Received value:
+             1: has not returned yet
+             2: has not returned yet
+             3: has not returned yet
+
+Received number of returns: <red>0</>
+Received number of calls:   <red>4</>"
 `;
 
 exports[`toHaveReturnedWith returnedWith works with more calls than the limit 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toHaveReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected mock function to have returned:
-  <green>\\"bar\\"</>
-But it returned:
-  <red>\\"foo1\\"</>
+Expected value: <green>\\"bar\\"</>
+Received value:
+             1: <red>\\"foo1\\"</>
+             2: <red>\\"foo2\\"</>
+             3: <red>\\"foo3\\"</>
 
-  <red>\\"foo2\\"</>
-
-  <red>\\"foo3\\"</>
-
-  <red>\\"foo4\\"</>
-
-  <red>\\"foo5\\"</>
-
-  ...and <red>1</> more"
+Received number of returns: <red>6</>"
 `;
 
 exports[`toHaveReturnedWith works only on spies or jest.fn 1`] = `
@@ -2276,92 +2442,101 @@ Received has value: <red>[Function fn]</>"
 `;
 
 exports[`toHaveReturnedWith works when not called 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toHaveReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected mock function to have returned:
-  <green>\\"foo\\"</>
-But it did <red>not return</>."
+Expected value: <green>\\"foo\\"</>
+
+Received number of returns: <red>0</>"
 `;
 
 exports[`toHaveReturnedWith works with Immutable.js objects directly created 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toHaveReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected mock function not to have returned:
-  <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
-But it returned exactly:
-  <red>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>"
+Expected value: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
+Received value:
+             1:     <red>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
+
+Received number of returns: <red>1</>"
 `;
 
 exports[`toHaveReturnedWith works with Immutable.js objects indirectly created 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toHaveReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected mock function not to have returned:
-  <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
-But it returned exactly:
-  <red>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>"
+Expected value: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
+Received value:
+             1:     <red>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
+
+Received number of returns: <red>1</>"
 `;
 
 exports[`toHaveReturnedWith works with Map 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toHaveReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected mock function not to have returned:
-  <green>Map {1 => 2, 2 => 1}</>
-But it returned exactly:
-  <red>Map {1 => 2, 2 => 1}</>"
+Expected value: not <green>Map {1 => 2, 2 => 1}</>
+Received value:
+             1:     <red>Map {1 => 2, 2 => 1}</>
+
+Received number of returns: <red>1</>"
 `;
 
 exports[`toHaveReturnedWith works with Map 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toHaveReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected mock function to have returned:
-  <green>Map {\\"a\\" => \\"b\\", \\"b\\" => \\"a\\"}</>
-But it returned:
-  <red>Map {1 => 2, 2 => 1}</>"
+Expected value: <green>Map {\\"a\\" => \\"b\\", \\"b\\" => \\"a\\"}</>
+Received value:
+             1: <red>Map {1 => 2, 2 => 1}</>
+
+Received number of returns: <red>1</>"
 `;
 
 exports[`toHaveReturnedWith works with Set 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toHaveReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected mock function not to have returned:
-  <green>Set {1, 2}</>
-But it returned exactly:
-  <red>Set {1, 2}</>"
+Expected value: not <green>Set {1, 2}</>
+Received value:
+             1:     <red>Set {1, 2}</>
+
+Received number of returns: <red>1</>"
 `;
 
 exports[`toHaveReturnedWith works with Set 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toHaveReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected mock function to have returned:
-  <green>Set {3, 4}</>
-But it returned:
-  <red>Set {1, 2}</>"
+Expected value: <green>Set {3, 4}</>
+Received value:
+             1: <red>Set {1, 2}</>
+
+Received number of returns: <red>1</>"
 `;
 
 exports[`toHaveReturnedWith works with argument that does match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toHaveReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected mock function not to have returned:
-  <green>\\"foo\\"</>
-But it returned exactly:
-  <red>\\"foo\\"</>"
+Expected value: not <green>\\"foo\\"</>
+Received value:
+             1:     <red>\\"foo\\"</>
+
+Received number of returns: <red>1</>"
 `;
 
 exports[`toHaveReturnedWith works with argument that does not match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toHaveReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected mock function to have returned:
-  <green>\\"bar\\"</>
-But it returned:
-  <red>\\"foo\\"</>"
+Expected value: <green>\\"bar\\"</>
+Received value:
+             1: <red>\\"foo\\"</>
+
+Received number of returns: <red>1</>"
 `;
 
 exports[`toHaveReturnedWith works with undefined 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toHaveReturnedWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected mock function not to have returned:
-  <green>undefined</>
-But it returned exactly:
-  <red>undefined</>"
+Expected value: not <green>undefined</>
+Received value:
+             1:     <red>undefined</>
+
+Received number of returns: <red>1</>"
 `;
 
 exports[`toReturn .not fails with any argument passed 1`] = `
@@ -2636,54 +2811,58 @@ Received has value: <red>[Function fn]</>"
 `;
 
 exports[`toReturnWith a call that throws is not considered to have returned 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toReturnWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toReturnWith<dim>(</><green>expected</><dim>)</>
 
-Expected mock function to have returned:
-  <green>undefined</>
-But it did <red>not return</>."
+Expected value: <green>undefined</>
+Received value:
+             1: threw an error
+
+Received number of returns: <red>0</>
+Received number of calls:   <red>1</>"
 `;
 
 exports[`toReturnWith a call that throws undefined is not considered to have returned 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toReturnWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toReturnWith<dim>(</><green>expected</><dim>)</>
 
-Expected mock function to have returned:
-  <green>undefined</>
-But it did <red>not return</>."
+Expected value: <green>undefined</>
+Received value:
+             1: threw an error
+
+Received number of returns: <red>0</>
+Received number of calls:   <red>1</>"
 `;
 
 exports[`toReturnWith includes the custom mock name in the error message 1`] = `
-"<dim>expect(</><red>named-mock</><dim>).toReturnWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>named-mock</><dim>).</>toReturnWith<dim>(</><green>expected</><dim>)</>
 
-Expected mock function \\"named-mock\\" to have returned:
-  <green>\\"foo\\"</>
-But it did <red>not return</>."
+Expected value: <green>\\"foo\\"</>
+
+Received number of returns: <red>0</>"
 `;
 
 exports[`toReturnWith returnedWith incomplete recursive calls are handled properly 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toReturnWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toReturnWith<dim>(</><green>expected</><dim>)</>
 
-Expected mock function to have returned:
-  <green>undefined</>
-But it did <red>not return</>."
+Expected value: <green>undefined</>
+Received value:
+             1: has not returned yet
+             2: has not returned yet
+             3: has not returned yet
+
+Received number of returns: <red>0</>
+Received number of calls:   <red>4</>"
 `;
 
 exports[`toReturnWith returnedWith works with more calls than the limit 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toReturnWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toReturnWith<dim>(</><green>expected</><dim>)</>
 
-Expected mock function to have returned:
-  <green>\\"bar\\"</>
-But it returned:
-  <red>\\"foo1\\"</>
+Expected value: <green>\\"bar\\"</>
+Received value:
+             1: <red>\\"foo1\\"</>
+             2: <red>\\"foo2\\"</>
+             3: <red>\\"foo3\\"</>
 
-  <red>\\"foo2\\"</>
-
-  <red>\\"foo3\\"</>
-
-  <red>\\"foo4\\"</>
-
-  <red>\\"foo5\\"</>
-
-  ...and <red>1</> more"
+Received number of returns: <red>6</>"
 `;
 
 exports[`toReturnWith works only on spies or jest.fn 1`] = `
@@ -2696,90 +2875,99 @@ Received has value: <red>[Function fn]</>"
 `;
 
 exports[`toReturnWith works when not called 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toReturnWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toReturnWith<dim>(</><green>expected</><dim>)</>
 
-Expected mock function to have returned:
-  <green>\\"foo\\"</>
-But it did <red>not return</>."
+Expected value: <green>\\"foo\\"</>
+
+Received number of returns: <red>0</>"
 `;
 
 exports[`toReturnWith works with Immutable.js objects directly created 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toReturnWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toReturnWith<dim>(</><green>expected</><dim>)</>
 
-Expected mock function not to have returned:
-  <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
-But it returned exactly:
-  <red>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>"
+Expected value: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
+Received value:
+             1:     <red>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
+
+Received number of returns: <red>1</>"
 `;
 
 exports[`toReturnWith works with Immutable.js objects indirectly created 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toReturnWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toReturnWith<dim>(</><green>expected</><dim>)</>
 
-Expected mock function not to have returned:
-  <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
-But it returned exactly:
-  <red>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>"
+Expected value: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
+Received value:
+             1:     <red>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
+
+Received number of returns: <red>1</>"
 `;
 
 exports[`toReturnWith works with Map 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toReturnWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toReturnWith<dim>(</><green>expected</><dim>)</>
 
-Expected mock function not to have returned:
-  <green>Map {1 => 2, 2 => 1}</>
-But it returned exactly:
-  <red>Map {1 => 2, 2 => 1}</>"
+Expected value: not <green>Map {1 => 2, 2 => 1}</>
+Received value:
+             1:     <red>Map {1 => 2, 2 => 1}</>
+
+Received number of returns: <red>1</>"
 `;
 
 exports[`toReturnWith works with Map 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toReturnWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toReturnWith<dim>(</><green>expected</><dim>)</>
 
-Expected mock function to have returned:
-  <green>Map {\\"a\\" => \\"b\\", \\"b\\" => \\"a\\"}</>
-But it returned:
-  <red>Map {1 => 2, 2 => 1}</>"
+Expected value: <green>Map {\\"a\\" => \\"b\\", \\"b\\" => \\"a\\"}</>
+Received value:
+             1: <red>Map {1 => 2, 2 => 1}</>
+
+Received number of returns: <red>1</>"
 `;
 
 exports[`toReturnWith works with Set 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toReturnWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toReturnWith<dim>(</><green>expected</><dim>)</>
 
-Expected mock function not to have returned:
-  <green>Set {1, 2}</>
-But it returned exactly:
-  <red>Set {1, 2}</>"
+Expected value: not <green>Set {1, 2}</>
+Received value:
+             1:     <red>Set {1, 2}</>
+
+Received number of returns: <red>1</>"
 `;
 
 exports[`toReturnWith works with Set 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toReturnWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toReturnWith<dim>(</><green>expected</><dim>)</>
 
-Expected mock function to have returned:
-  <green>Set {3, 4}</>
-But it returned:
-  <red>Set {1, 2}</>"
+Expected value: <green>Set {3, 4}</>
+Received value:
+             1: <red>Set {1, 2}</>
+
+Received number of returns: <red>1</>"
 `;
 
 exports[`toReturnWith works with argument that does match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toReturnWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toReturnWith<dim>(</><green>expected</><dim>)</>
 
-Expected mock function not to have returned:
-  <green>\\"foo\\"</>
-But it returned exactly:
-  <red>\\"foo\\"</>"
+Expected value: not <green>\\"foo\\"</>
+Received value:
+             1:     <red>\\"foo\\"</>
+
+Received number of returns: <red>1</>"
 `;
 
 exports[`toReturnWith works with argument that does not match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toReturnWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toReturnWith<dim>(</><green>expected</><dim>)</>
 
-Expected mock function to have returned:
-  <green>\\"bar\\"</>
-But it returned:
-  <red>\\"foo\\"</>"
+Expected value: <green>\\"bar\\"</>
+Received value:
+             1: <red>\\"foo\\"</>
+
+Received number of returns: <red>1</>"
 `;
 
 exports[`toReturnWith works with undefined 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toReturnWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toReturnWith<dim>(</><green>expected</><dim>)</>
 
-Expected mock function not to have returned:
-  <green>undefined</>
-But it returned exactly:
-  <red>undefined</>"
+Expected value: not <green>undefined</>
+Received value:
+             1:     <red>undefined</>
+
+Received number of returns: <red>1</>"
 `;

--- a/packages/expect/src/__tests__/__snapshots__/spyMatchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/spyMatchers.test.js.snap
@@ -130,8 +130,7 @@ exports[`lastReturnedWith a call that throws is not considered to have returned 
 "<dim>expect(</><red>jest.fn()</><dim>).</>lastReturnedWith<dim>(</><green>expected</><dim>)</>
 
 Expected value: <green>undefined</>
-Received value:
-             1: threw an error
+Received value: threw an error
 
 Received number of returns: <red>0</>
 Received number of calls:   <red>1</>"
@@ -141,8 +140,7 @@ exports[`lastReturnedWith a call that throws undefined is not considered to have
 "<dim>expect(</><red>jest.fn()</><dim>).</>lastReturnedWith<dim>(</><green>expected</><dim>)</>
 
 Expected value: <green>undefined</>
-Received value:
-             1: threw an error
+Received value: threw an error
 
 Received number of returns: <red>0</>
 Received number of calls:   <red>1</>"
@@ -160,9 +158,9 @@ exports[`lastReturnedWith lastReturnedWith incomplete recursive calls are handle
 "<dim>expect(</><red>jest.fn()</><dim>).</>lastReturnedWith<dim>(</><green>expected</><dim>)</>
 
 Expected value: <green>0</>
-Received value:
+Received value
              3: has not returned yet
-             4: has not returned yet
+->           4: has not returned yet
 
 Received number of returns: <red>0</>
 Received number of calls:   <red>4</>"
@@ -172,9 +170,9 @@ exports[`lastReturnedWith lastReturnedWith works with three calls 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>lastReturnedWith<dim>(</><green>expected</><dim>)</>
 
 Expected value: not <green>\\"foo3\\"</>
-Received value:
+Received value
              2:     <red>\\"foo2\\"</>
-             3:     <red>\\"foo3\\"</>
+->           3:     <red>\\"foo3\\"</>
 
 Received number of returns: <red>3</>"
 `;
@@ -200,8 +198,6 @@ exports[`lastReturnedWith works with Immutable.js objects directly created 1`] =
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>lastReturnedWith<dim>(</><green>expected</><dim>)</>
 
 Expected value: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
-Received value:
-             1:     <red>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
 
 Received number of returns: <red>1</>"
 `;
@@ -210,8 +206,6 @@ exports[`lastReturnedWith works with Immutable.js objects indirectly created 1`]
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>lastReturnedWith<dim>(</><green>expected</><dim>)</>
 
 Expected value: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
-Received value:
-             1:     <red>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
 
 Received number of returns: <red>1</>"
 `;
@@ -220,8 +214,6 @@ exports[`lastReturnedWith works with Map 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>lastReturnedWith<dim>(</><green>expected</><dim>)</>
 
 Expected value: not <green>Map {1 => 2, 2 => 1}</>
-Received value:
-             1:     <red>Map {1 => 2, 2 => 1}</>
 
 Received number of returns: <red>1</>"
 `;
@@ -230,8 +222,7 @@ exports[`lastReturnedWith works with Map 2`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>lastReturnedWith<dim>(</><green>expected</><dim>)</>
 
 Expected value: <green>Map {\\"a\\" => \\"b\\", \\"b\\" => \\"a\\"}</>
-Received value:
-             1: <red>Map {1 => 2, 2 => 1}</>
+Received value: <red>Map {1 => 2, 2 => 1}</>
 
 Received number of returns: <red>1</>"
 `;
@@ -240,8 +231,6 @@ exports[`lastReturnedWith works with Set 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>lastReturnedWith<dim>(</><green>expected</><dim>)</>
 
 Expected value: not <green>Set {1, 2}</>
-Received value:
-             1:     <red>Set {1, 2}</>
 
 Received number of returns: <red>1</>"
 `;
@@ -250,8 +239,7 @@ exports[`lastReturnedWith works with Set 2`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>lastReturnedWith<dim>(</><green>expected</><dim>)</>
 
 Expected value: <green>Set {3, 4}</>
-Received value:
-             1: <red>Set {1, 2}</>
+Received value: <red>Set {1, 2}</>
 
 Received number of returns: <red>1</>"
 `;
@@ -260,8 +248,6 @@ exports[`lastReturnedWith works with argument that does match 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>lastReturnedWith<dim>(</><green>expected</><dim>)</>
 
 Expected value: not <green>\\"foo\\"</>
-Received value:
-             1:     <red>\\"foo\\"</>
 
 Received number of returns: <red>1</>"
 `;
@@ -270,8 +256,7 @@ exports[`lastReturnedWith works with argument that does not match 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>lastReturnedWith<dim>(</><green>expected</><dim>)</>
 
 Expected value: <green>\\"bar\\"</>
-Received value:
-             1: <red>\\"foo\\"</>
+Received value: <red>\\"foo\\"</>
 
 Received number of returns: <red>1</>"
 `;
@@ -280,8 +265,6 @@ exports[`lastReturnedWith works with undefined 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>lastReturnedWith<dim>(</><green>expected</><dim>)</>
 
 Expected value: not <green>undefined</>
-Received value:
-             1:     <red>undefined</>
 
 Received number of returns: <red>1</>"
 `;
@@ -449,10 +432,9 @@ Expected mock function first call to have been called with:
 exports[`nthReturnedWith a call that throws is not considered to have returned 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Call n:      1
+n: 1
 Expected value: <green>undefined</>
-Received value:
-             1: threw an error
+Received value: threw an error
 
 Received number of returns: <red>0</>
 Received number of calls:   <red>1</>"
@@ -461,10 +443,9 @@ Received number of calls:   <red>1</>"
 exports[`nthReturnedWith a call that throws undefined is not considered to have returned 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Call n:      1
+n: 1
 Expected value: <green>undefined</>
-Received value:
-             1: threw an error
+Received value: threw an error
 
 Received number of returns: <red>0</>
 Received number of calls:   <red>1</>"
@@ -473,7 +454,7 @@ Received number of calls:   <red>1</>"
 exports[`nthReturnedWith includes the custom mock name in the error message 1`] = `
 "<dim>expect(</><red>named-mock</><dim>).</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Call n:      1
+n: 1
 Expected value: <green>\\"foo\\"</>
 
 Received number of returns: <red>0</>"
@@ -482,10 +463,10 @@ Received number of returns: <red>0</>"
 exports[`nthReturnedWith nthReturnedWith incomplete recursive calls are handled properly 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Call n:      1
+n: 1
 Expected value: <green>6</>
-Received value:
-             1: has not returned yet
+Received value
+->           1: has not returned yet
              2: has not returned yet
 
 Received number of returns: <red>2</>
@@ -495,11 +476,11 @@ Received number of calls:   <red>4</>"
 exports[`nthReturnedWith nthReturnedWith incomplete recursive calls are handled properly 2`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Call n:      2
+n: 2
 Expected value: <green>3</>
-Received value:
+Received value
              1: has not returned yet
-             2: has not returned yet
+->           2: has not returned yet
              3: <red>1</>
 
 Received number of returns: <red>2</>
@@ -509,11 +490,11 @@ Received number of calls:   <red>4</>"
 exports[`nthReturnedWith nthReturnedWith incomplete recursive calls are handled properly 3`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Call n:      3
+n: 3
 Expected value: not <green>1</>
-Received value:
+Received value
              2:     has not returned yet
-             3:     <red>1</>
+->           3:     <red>1</>
              4:     <red>0</>
 
 Received number of returns: <red>2</>
@@ -523,11 +504,11 @@ Received number of calls:   <red>4</>"
 exports[`nthReturnedWith nthReturnedWith incomplete recursive calls are handled properly 4`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Call n:      4
+n: 4
 Expected value: not <green>0</>
-Received value:
+Received value
              3:     <red>1</>
-             4:     <red>0</>
+->           4:     <red>0</>
 
 Received number of returns: <red>2</>
 Received number of calls:   <red>4</>"
@@ -562,9 +543,9 @@ n has value: <green>0</>"
 exports[`nthReturnedWith nthReturnedWith should reject nth value greater than number of calls 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Call n:      4
+n: 4
 Expected value: <green>\\"foo\\"</>
-Received value:
+Received value
              3: <red>\\"foo\\"</>
 
 Received number of returns: <red>3</>"
@@ -573,10 +554,10 @@ Received number of returns: <red>3</>"
 exports[`nthReturnedWith nthReturnedWith should replace 1st, 2nd, 3rd with first, second, third 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Call n:      1
+n: 1
 Expected value: <green>\\"bar1\\"</>
-Received value:
-             1: <red>\\"foo1\\"</>
+Received value
+->           1: <red>\\"foo1\\"</>
              2: <red>\\"foo2\\"</>
 
 Received number of returns: <red>3</>"
@@ -585,10 +566,10 @@ Received number of returns: <red>3</>"
 exports[`nthReturnedWith nthReturnedWith should replace 1st, 2nd, 3rd with first, second, third 2`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Call n:      1
+n: 1
 Expected value: not <green>\\"foo1\\"</>
-Received value:
-             1:     <red>\\"foo1\\"</>
+Received value
+->           1:     <red>\\"foo1\\"</>
              2:     <red>\\"foo2\\"</>
 
 Received number of returns: <red>3</>"
@@ -597,10 +578,10 @@ Received number of returns: <red>3</>"
 exports[`nthReturnedWith nthReturnedWith works with three calls 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Call n:      1
+n: 1
 Expected value: not <green>\\"foo1\\"</>
-Received value:
-             1:     <red>\\"foo1\\"</>
+Received value
+->           1:     <red>\\"foo1\\"</>
              2:     <red>\\"foo2\\"</>
 
 Received number of returns: <red>3</>"
@@ -618,7 +599,7 @@ Received has value: <red>[Function fn]</>"
 exports[`nthReturnedWith works when not called 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Call n:      1
+n: 1
 Expected value: <green>\\"foo\\"</>
 
 Received number of returns: <red>0</>"
@@ -627,10 +608,8 @@ Received number of returns: <red>0</>"
 exports[`nthReturnedWith works with Immutable.js objects directly created 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Call n:      1
+n: 1
 Expected value: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
-Received value:
-             1:     <red>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
 
 Received number of returns: <red>1</>"
 `;
@@ -638,10 +617,8 @@ Received number of returns: <red>1</>"
 exports[`nthReturnedWith works with Immutable.js objects indirectly created 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Call n:      1
+n: 1
 Expected value: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
-Received value:
-             1:     <red>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
 
 Received number of returns: <red>1</>"
 `;
@@ -649,10 +626,8 @@ Received number of returns: <red>1</>"
 exports[`nthReturnedWith works with Map 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Call n:      1
+n: 1
 Expected value: not <green>Map {1 => 2, 2 => 1}</>
-Received value:
-             1:     <red>Map {1 => 2, 2 => 1}</>
 
 Received number of returns: <red>1</>"
 `;
@@ -660,10 +635,9 @@ Received number of returns: <red>1</>"
 exports[`nthReturnedWith works with Map 2`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Call n:      1
+n: 1
 Expected value: <green>Map {\\"a\\" => \\"b\\", \\"b\\" => \\"a\\"}</>
-Received value:
-             1: <red>Map {1 => 2, 2 => 1}</>
+Received value: <red>Map {1 => 2, 2 => 1}</>
 
 Received number of returns: <red>1</>"
 `;
@@ -671,10 +645,8 @@ Received number of returns: <red>1</>"
 exports[`nthReturnedWith works with Set 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Call n:      1
+n: 1
 Expected value: not <green>Set {1, 2}</>
-Received value:
-             1:     <red>Set {1, 2}</>
 
 Received number of returns: <red>1</>"
 `;
@@ -682,10 +654,9 @@ Received number of returns: <red>1</>"
 exports[`nthReturnedWith works with Set 2`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Call n:      1
+n: 1
 Expected value: <green>Set {3, 4}</>
-Received value:
-             1: <red>Set {1, 2}</>
+Received value: <red>Set {1, 2}</>
 
 Received number of returns: <red>1</>"
 `;
@@ -693,10 +664,8 @@ Received number of returns: <red>1</>"
 exports[`nthReturnedWith works with argument that does match 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Call n:      1
+n: 1
 Expected value: not <green>\\"foo\\"</>
-Received value:
-             1:     <red>\\"foo\\"</>
 
 Received number of returns: <red>1</>"
 `;
@@ -704,10 +673,9 @@ Received number of returns: <red>1</>"
 exports[`nthReturnedWith works with argument that does not match 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Call n:      1
+n: 1
 Expected value: <green>\\"bar\\"</>
-Received value:
-             1: <red>\\"foo\\"</>
+Received value: <red>\\"foo\\"</>
 
 Received number of returns: <red>1</>"
 `;
@@ -715,10 +683,8 @@ Received number of returns: <red>1</>"
 exports[`nthReturnedWith works with undefined 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Call n:      1
+n: 1
 Expected value: not <green>undefined</>
-Received value:
-             1:     <red>undefined</>
 
 Received number of returns: <red>1</>"
 `;
@@ -1673,8 +1639,7 @@ exports[`toHaveLastReturnedWith a call that throws is not considered to have ret
 "<dim>expect(</><red>jest.fn()</><dim>).</>toHaveLastReturnedWith<dim>(</><green>expected</><dim>)</>
 
 Expected value: <green>undefined</>
-Received value:
-             1: threw an error
+Received value: threw an error
 
 Received number of returns: <red>0</>
 Received number of calls:   <red>1</>"
@@ -1684,8 +1649,7 @@ exports[`toHaveLastReturnedWith a call that throws undefined is not considered t
 "<dim>expect(</><red>jest.fn()</><dim>).</>toHaveLastReturnedWith<dim>(</><green>expected</><dim>)</>
 
 Expected value: <green>undefined</>
-Received value:
-             1: threw an error
+Received value: threw an error
 
 Received number of returns: <red>0</>
 Received number of calls:   <red>1</>"
@@ -1703,9 +1667,9 @@ exports[`toHaveLastReturnedWith lastReturnedWith incomplete recursive calls are 
 "<dim>expect(</><red>jest.fn()</><dim>).</>toHaveLastReturnedWith<dim>(</><green>expected</><dim>)</>
 
 Expected value: <green>0</>
-Received value:
+Received value
              3: has not returned yet
-             4: has not returned yet
+->           4: has not returned yet
 
 Received number of returns: <red>0</>
 Received number of calls:   <red>4</>"
@@ -1715,9 +1679,9 @@ exports[`toHaveLastReturnedWith lastReturnedWith works with three calls 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveLastReturnedWith<dim>(</><green>expected</><dim>)</>
 
 Expected value: not <green>\\"foo3\\"</>
-Received value:
+Received value
              2:     <red>\\"foo2\\"</>
-             3:     <red>\\"foo3\\"</>
+->           3:     <red>\\"foo3\\"</>
 
 Received number of returns: <red>3</>"
 `;
@@ -1743,8 +1707,6 @@ exports[`toHaveLastReturnedWith works with Immutable.js objects directly created
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveLastReturnedWith<dim>(</><green>expected</><dim>)</>
 
 Expected value: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
-Received value:
-             1:     <red>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
 
 Received number of returns: <red>1</>"
 `;
@@ -1753,8 +1715,6 @@ exports[`toHaveLastReturnedWith works with Immutable.js objects indirectly creat
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveLastReturnedWith<dim>(</><green>expected</><dim>)</>
 
 Expected value: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
-Received value:
-             1:     <red>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
 
 Received number of returns: <red>1</>"
 `;
@@ -1763,8 +1723,6 @@ exports[`toHaveLastReturnedWith works with Map 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveLastReturnedWith<dim>(</><green>expected</><dim>)</>
 
 Expected value: not <green>Map {1 => 2, 2 => 1}</>
-Received value:
-             1:     <red>Map {1 => 2, 2 => 1}</>
 
 Received number of returns: <red>1</>"
 `;
@@ -1773,8 +1731,7 @@ exports[`toHaveLastReturnedWith works with Map 2`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>toHaveLastReturnedWith<dim>(</><green>expected</><dim>)</>
 
 Expected value: <green>Map {\\"a\\" => \\"b\\", \\"b\\" => \\"a\\"}</>
-Received value:
-             1: <red>Map {1 => 2, 2 => 1}</>
+Received value: <red>Map {1 => 2, 2 => 1}</>
 
 Received number of returns: <red>1</>"
 `;
@@ -1783,8 +1740,6 @@ exports[`toHaveLastReturnedWith works with Set 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveLastReturnedWith<dim>(</><green>expected</><dim>)</>
 
 Expected value: not <green>Set {1, 2}</>
-Received value:
-             1:     <red>Set {1, 2}</>
 
 Received number of returns: <red>1</>"
 `;
@@ -1793,8 +1748,7 @@ exports[`toHaveLastReturnedWith works with Set 2`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>toHaveLastReturnedWith<dim>(</><green>expected</><dim>)</>
 
 Expected value: <green>Set {3, 4}</>
-Received value:
-             1: <red>Set {1, 2}</>
+Received value: <red>Set {1, 2}</>
 
 Received number of returns: <red>1</>"
 `;
@@ -1803,8 +1757,6 @@ exports[`toHaveLastReturnedWith works with argument that does match 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveLastReturnedWith<dim>(</><green>expected</><dim>)</>
 
 Expected value: not <green>\\"foo\\"</>
-Received value:
-             1:     <red>\\"foo\\"</>
 
 Received number of returns: <red>1</>"
 `;
@@ -1813,8 +1765,7 @@ exports[`toHaveLastReturnedWith works with argument that does not match 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>toHaveLastReturnedWith<dim>(</><green>expected</><dim>)</>
 
 Expected value: <green>\\"bar\\"</>
-Received value:
-             1: <red>\\"foo\\"</>
+Received value: <red>\\"foo\\"</>
 
 Received number of returns: <red>1</>"
 `;
@@ -1823,8 +1774,6 @@ exports[`toHaveLastReturnedWith works with undefined 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveLastReturnedWith<dim>(</><green>expected</><dim>)</>
 
 Expected value: not <green>undefined</>
-Received value:
-             1:     <red>undefined</>
 
 Received number of returns: <red>1</>"
 `;
@@ -1832,10 +1781,9 @@ Received number of returns: <red>1</>"
 exports[`toHaveNthReturnedWith a call that throws is not considered to have returned 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Call n:      1
+n: 1
 Expected value: <green>undefined</>
-Received value:
-             1: threw an error
+Received value: threw an error
 
 Received number of returns: <red>0</>
 Received number of calls:   <red>1</>"
@@ -1844,10 +1792,9 @@ Received number of calls:   <red>1</>"
 exports[`toHaveNthReturnedWith a call that throws undefined is not considered to have returned 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Call n:      1
+n: 1
 Expected value: <green>undefined</>
-Received value:
-             1: threw an error
+Received value: threw an error
 
 Received number of returns: <red>0</>
 Received number of calls:   <red>1</>"
@@ -1856,7 +1803,7 @@ Received number of calls:   <red>1</>"
 exports[`toHaveNthReturnedWith includes the custom mock name in the error message 1`] = `
 "<dim>expect(</><red>named-mock</><dim>).</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Call n:      1
+n: 1
 Expected value: <green>\\"foo\\"</>
 
 Received number of returns: <red>0</>"
@@ -1865,10 +1812,10 @@ Received number of returns: <red>0</>"
 exports[`toHaveNthReturnedWith nthReturnedWith incomplete recursive calls are handled properly 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Call n:      1
+n: 1
 Expected value: <green>6</>
-Received value:
-             1: has not returned yet
+Received value
+->           1: has not returned yet
              2: has not returned yet
 
 Received number of returns: <red>2</>
@@ -1878,11 +1825,11 @@ Received number of calls:   <red>4</>"
 exports[`toHaveNthReturnedWith nthReturnedWith incomplete recursive calls are handled properly 2`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Call n:      2
+n: 2
 Expected value: <green>3</>
-Received value:
+Received value
              1: has not returned yet
-             2: has not returned yet
+->           2: has not returned yet
              3: <red>1</>
 
 Received number of returns: <red>2</>
@@ -1892,11 +1839,11 @@ Received number of calls:   <red>4</>"
 exports[`toHaveNthReturnedWith nthReturnedWith incomplete recursive calls are handled properly 3`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Call n:      3
+n: 3
 Expected value: not <green>1</>
-Received value:
+Received value
              2:     has not returned yet
-             3:     <red>1</>
+->           3:     <red>1</>
              4:     <red>0</>
 
 Received number of returns: <red>2</>
@@ -1906,11 +1853,11 @@ Received number of calls:   <red>4</>"
 exports[`toHaveNthReturnedWith nthReturnedWith incomplete recursive calls are handled properly 4`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Call n:      4
+n: 4
 Expected value: not <green>0</>
-Received value:
+Received value
              3:     <red>1</>
-             4:     <red>0</>
+->           4:     <red>0</>
 
 Received number of returns: <red>2</>
 Received number of calls:   <red>4</>"
@@ -1945,9 +1892,9 @@ n has value: <green>0</>"
 exports[`toHaveNthReturnedWith nthReturnedWith should reject nth value greater than number of calls 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Call n:      4
+n: 4
 Expected value: <green>\\"foo\\"</>
-Received value:
+Received value
              3: <red>\\"foo\\"</>
 
 Received number of returns: <red>3</>"
@@ -1956,10 +1903,10 @@ Received number of returns: <red>3</>"
 exports[`toHaveNthReturnedWith nthReturnedWith should replace 1st, 2nd, 3rd with first, second, third 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Call n:      1
+n: 1
 Expected value: <green>\\"bar1\\"</>
-Received value:
-             1: <red>\\"foo1\\"</>
+Received value
+->           1: <red>\\"foo1\\"</>
              2: <red>\\"foo2\\"</>
 
 Received number of returns: <red>3</>"
@@ -1968,10 +1915,10 @@ Received number of returns: <red>3</>"
 exports[`toHaveNthReturnedWith nthReturnedWith should replace 1st, 2nd, 3rd with first, second, third 2`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Call n:      1
+n: 1
 Expected value: not <green>\\"foo1\\"</>
-Received value:
-             1:     <red>\\"foo1\\"</>
+Received value
+->           1:     <red>\\"foo1\\"</>
              2:     <red>\\"foo2\\"</>
 
 Received number of returns: <red>3</>"
@@ -1980,10 +1927,10 @@ Received number of returns: <red>3</>"
 exports[`toHaveNthReturnedWith nthReturnedWith works with three calls 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Call n:      1
+n: 1
 Expected value: not <green>\\"foo1\\"</>
-Received value:
-             1:     <red>\\"foo1\\"</>
+Received value
+->           1:     <red>\\"foo1\\"</>
              2:     <red>\\"foo2\\"</>
 
 Received number of returns: <red>3</>"
@@ -2001,7 +1948,7 @@ Received has value: <red>[Function fn]</>"
 exports[`toHaveNthReturnedWith works when not called 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Call n:      1
+n: 1
 Expected value: <green>\\"foo\\"</>
 
 Received number of returns: <red>0</>"
@@ -2010,10 +1957,8 @@ Received number of returns: <red>0</>"
 exports[`toHaveNthReturnedWith works with Immutable.js objects directly created 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Call n:      1
+n: 1
 Expected value: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
-Received value:
-             1:     <red>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
 
 Received number of returns: <red>1</>"
 `;
@@ -2021,10 +1966,8 @@ Received number of returns: <red>1</>"
 exports[`toHaveNthReturnedWith works with Immutable.js objects indirectly created 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Call n:      1
+n: 1
 Expected value: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
-Received value:
-             1:     <red>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
 
 Received number of returns: <red>1</>"
 `;
@@ -2032,10 +1975,8 @@ Received number of returns: <red>1</>"
 exports[`toHaveNthReturnedWith works with Map 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Call n:      1
+n: 1
 Expected value: not <green>Map {1 => 2, 2 => 1}</>
-Received value:
-             1:     <red>Map {1 => 2, 2 => 1}</>
 
 Received number of returns: <red>1</>"
 `;
@@ -2043,10 +1984,9 @@ Received number of returns: <red>1</>"
 exports[`toHaveNthReturnedWith works with Map 2`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Call n:      1
+n: 1
 Expected value: <green>Map {\\"a\\" => \\"b\\", \\"b\\" => \\"a\\"}</>
-Received value:
-             1: <red>Map {1 => 2, 2 => 1}</>
+Received value: <red>Map {1 => 2, 2 => 1}</>
 
 Received number of returns: <red>1</>"
 `;
@@ -2054,10 +1994,8 @@ Received number of returns: <red>1</>"
 exports[`toHaveNthReturnedWith works with Set 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Call n:      1
+n: 1
 Expected value: not <green>Set {1, 2}</>
-Received value:
-             1:     <red>Set {1, 2}</>
 
 Received number of returns: <red>1</>"
 `;
@@ -2065,10 +2003,9 @@ Received number of returns: <red>1</>"
 exports[`toHaveNthReturnedWith works with Set 2`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Call n:      1
+n: 1
 Expected value: <green>Set {3, 4}</>
-Received value:
-             1: <red>Set {1, 2}</>
+Received value: <red>Set {1, 2}</>
 
 Received number of returns: <red>1</>"
 `;
@@ -2076,10 +2013,8 @@ Received number of returns: <red>1</>"
 exports[`toHaveNthReturnedWith works with argument that does match 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Call n:      1
+n: 1
 Expected value: not <green>\\"foo\\"</>
-Received value:
-             1:     <red>\\"foo\\"</>
 
 Received number of returns: <red>1</>"
 `;
@@ -2087,10 +2022,9 @@ Received number of returns: <red>1</>"
 exports[`toHaveNthReturnedWith works with argument that does not match 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Call n:      1
+n: 1
 Expected value: <green>\\"bar\\"</>
-Received value:
-             1: <red>\\"foo\\"</>
+Received value: <red>\\"foo\\"</>
 
 Received number of returns: <red>1</>"
 `;
@@ -2098,10 +2032,8 @@ Received number of returns: <red>1</>"
 exports[`toHaveNthReturnedWith works with undefined 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
-Call n:      1
+n: 1
 Expected value: not <green>undefined</>
-Received value:
-             1:     <red>undefined</>
 
 Received number of returns: <red>1</>"
 `;
@@ -2381,8 +2313,7 @@ exports[`toHaveReturnedWith a call that throws is not considered to have returne
 "<dim>expect(</><red>jest.fn()</><dim>).</>toHaveReturnedWith<dim>(</><green>expected</><dim>)</>
 
 Expected value: <green>undefined</>
-Received value:
-             1: threw an error
+Received value: threw an error
 
 Received number of returns: <red>0</>
 Received number of calls:   <red>1</>"
@@ -2392,8 +2323,7 @@ exports[`toHaveReturnedWith a call that throws undefined is not considered to ha
 "<dim>expect(</><red>jest.fn()</><dim>).</>toHaveReturnedWith<dim>(</><green>expected</><dim>)</>
 
 Expected value: <green>undefined</>
-Received value:
-             1: threw an error
+Received value: threw an error
 
 Received number of returns: <red>0</>
 Received number of calls:   <red>1</>"
@@ -2411,7 +2341,7 @@ exports[`toHaveReturnedWith returnedWith incomplete recursive calls are handled 
 "<dim>expect(</><red>jest.fn()</><dim>).</>toHaveReturnedWith<dim>(</><green>expected</><dim>)</>
 
 Expected value: <green>undefined</>
-Received value:
+Received value
              1: has not returned yet
              2: has not returned yet
              3: has not returned yet
@@ -2424,7 +2354,7 @@ exports[`toHaveReturnedWith returnedWith works with more calls than the limit 1`
 "<dim>expect(</><red>jest.fn()</><dim>).</>toHaveReturnedWith<dim>(</><green>expected</><dim>)</>
 
 Expected value: <green>\\"bar\\"</>
-Received value:
+Received value
              1: <red>\\"foo1\\"</>
              2: <red>\\"foo2\\"</>
              3: <red>\\"foo3\\"</>
@@ -2453,8 +2383,6 @@ exports[`toHaveReturnedWith works with Immutable.js objects directly created 1`]
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveReturnedWith<dim>(</><green>expected</><dim>)</>
 
 Expected value: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
-Received value:
-             1:     <red>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
 
 Received number of returns: <red>1</>"
 `;
@@ -2463,8 +2391,6 @@ exports[`toHaveReturnedWith works with Immutable.js objects indirectly created 1
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveReturnedWith<dim>(</><green>expected</><dim>)</>
 
 Expected value: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
-Received value:
-             1:     <red>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
 
 Received number of returns: <red>1</>"
 `;
@@ -2473,8 +2399,6 @@ exports[`toHaveReturnedWith works with Map 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveReturnedWith<dim>(</><green>expected</><dim>)</>
 
 Expected value: not <green>Map {1 => 2, 2 => 1}</>
-Received value:
-             1:     <red>Map {1 => 2, 2 => 1}</>
 
 Received number of returns: <red>1</>"
 `;
@@ -2483,8 +2407,7 @@ exports[`toHaveReturnedWith works with Map 2`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>toHaveReturnedWith<dim>(</><green>expected</><dim>)</>
 
 Expected value: <green>Map {\\"a\\" => \\"b\\", \\"b\\" => \\"a\\"}</>
-Received value:
-             1: <red>Map {1 => 2, 2 => 1}</>
+Received value: <red>Map {1 => 2, 2 => 1}</>
 
 Received number of returns: <red>1</>"
 `;
@@ -2493,8 +2416,6 @@ exports[`toHaveReturnedWith works with Set 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveReturnedWith<dim>(</><green>expected</><dim>)</>
 
 Expected value: not <green>Set {1, 2}</>
-Received value:
-             1:     <red>Set {1, 2}</>
 
 Received number of returns: <red>1</>"
 `;
@@ -2503,8 +2424,7 @@ exports[`toHaveReturnedWith works with Set 2`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>toHaveReturnedWith<dim>(</><green>expected</><dim>)</>
 
 Expected value: <green>Set {3, 4}</>
-Received value:
-             1: <red>Set {1, 2}</>
+Received value: <red>Set {1, 2}</>
 
 Received number of returns: <red>1</>"
 `;
@@ -2513,8 +2433,6 @@ exports[`toHaveReturnedWith works with argument that does match 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveReturnedWith<dim>(</><green>expected</><dim>)</>
 
 Expected value: not <green>\\"foo\\"</>
-Received value:
-             1:     <red>\\"foo\\"</>
 
 Received number of returns: <red>1</>"
 `;
@@ -2523,8 +2441,7 @@ exports[`toHaveReturnedWith works with argument that does not match 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>toHaveReturnedWith<dim>(</><green>expected</><dim>)</>
 
 Expected value: <green>\\"bar\\"</>
-Received value:
-             1: <red>\\"foo\\"</>
+Received value: <red>\\"foo\\"</>
 
 Received number of returns: <red>1</>"
 `;
@@ -2533,8 +2450,6 @@ exports[`toHaveReturnedWith works with undefined 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveReturnedWith<dim>(</><green>expected</><dim>)</>
 
 Expected value: not <green>undefined</>
-Received value:
-             1:     <red>undefined</>
 
 Received number of returns: <red>1</>"
 `;
@@ -2814,8 +2729,7 @@ exports[`toReturnWith a call that throws is not considered to have returned 1`] 
 "<dim>expect(</><red>jest.fn()</><dim>).</>toReturnWith<dim>(</><green>expected</><dim>)</>
 
 Expected value: <green>undefined</>
-Received value:
-             1: threw an error
+Received value: threw an error
 
 Received number of returns: <red>0</>
 Received number of calls:   <red>1</>"
@@ -2825,8 +2739,7 @@ exports[`toReturnWith a call that throws undefined is not considered to have ret
 "<dim>expect(</><red>jest.fn()</><dim>).</>toReturnWith<dim>(</><green>expected</><dim>)</>
 
 Expected value: <green>undefined</>
-Received value:
-             1: threw an error
+Received value: threw an error
 
 Received number of returns: <red>0</>
 Received number of calls:   <red>1</>"
@@ -2844,7 +2757,7 @@ exports[`toReturnWith returnedWith incomplete recursive calls are handled proper
 "<dim>expect(</><red>jest.fn()</><dim>).</>toReturnWith<dim>(</><green>expected</><dim>)</>
 
 Expected value: <green>undefined</>
-Received value:
+Received value
              1: has not returned yet
              2: has not returned yet
              3: has not returned yet
@@ -2857,7 +2770,7 @@ exports[`toReturnWith returnedWith works with more calls than the limit 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>toReturnWith<dim>(</><green>expected</><dim>)</>
 
 Expected value: <green>\\"bar\\"</>
-Received value:
+Received value
              1: <red>\\"foo1\\"</>
              2: <red>\\"foo2\\"</>
              3: <red>\\"foo3\\"</>
@@ -2886,8 +2799,6 @@ exports[`toReturnWith works with Immutable.js objects directly created 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toReturnWith<dim>(</><green>expected</><dim>)</>
 
 Expected value: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
-Received value:
-             1:     <red>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
 
 Received number of returns: <red>1</>"
 `;
@@ -2896,8 +2807,6 @@ exports[`toReturnWith works with Immutable.js objects indirectly created 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toReturnWith<dim>(</><green>expected</><dim>)</>
 
 Expected value: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
-Received value:
-             1:     <red>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
 
 Received number of returns: <red>1</>"
 `;
@@ -2906,8 +2815,6 @@ exports[`toReturnWith works with Map 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toReturnWith<dim>(</><green>expected</><dim>)</>
 
 Expected value: not <green>Map {1 => 2, 2 => 1}</>
-Received value:
-             1:     <red>Map {1 => 2, 2 => 1}</>
 
 Received number of returns: <red>1</>"
 `;
@@ -2916,8 +2823,7 @@ exports[`toReturnWith works with Map 2`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>toReturnWith<dim>(</><green>expected</><dim>)</>
 
 Expected value: <green>Map {\\"a\\" => \\"b\\", \\"b\\" => \\"a\\"}</>
-Received value:
-             1: <red>Map {1 => 2, 2 => 1}</>
+Received value: <red>Map {1 => 2, 2 => 1}</>
 
 Received number of returns: <red>1</>"
 `;
@@ -2926,8 +2832,6 @@ exports[`toReturnWith works with Set 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toReturnWith<dim>(</><green>expected</><dim>)</>
 
 Expected value: not <green>Set {1, 2}</>
-Received value:
-             1:     <red>Set {1, 2}</>
 
 Received number of returns: <red>1</>"
 `;
@@ -2936,8 +2840,7 @@ exports[`toReturnWith works with Set 2`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>toReturnWith<dim>(</><green>expected</><dim>)</>
 
 Expected value: <green>Set {3, 4}</>
-Received value:
-             1: <red>Set {1, 2}</>
+Received value: <red>Set {1, 2}</>
 
 Received number of returns: <red>1</>"
 `;
@@ -2946,8 +2849,6 @@ exports[`toReturnWith works with argument that does match 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toReturnWith<dim>(</><green>expected</><dim>)</>
 
 Expected value: not <green>\\"foo\\"</>
-Received value:
-             1:     <red>\\"foo\\"</>
 
 Received number of returns: <red>1</>"
 `;
@@ -2956,8 +2857,7 @@ exports[`toReturnWith works with argument that does not match 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>toReturnWith<dim>(</><green>expected</><dim>)</>
 
 Expected value: <green>\\"bar\\"</>
-Received value:
-             1: <red>\\"foo\\"</>
+Received value: <red>\\"foo\\"</>
 
 Received number of returns: <red>1</>"
 `;
@@ -2966,8 +2866,6 @@ exports[`toReturnWith works with undefined 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toReturnWith<dim>(</><green>expected</><dim>)</>
 
 Expected value: not <green>undefined</>
-Received value:
-             1:     <red>undefined</>
 
 Received number of returns: <red>1</>"
 `;

--- a/packages/expect/src/__tests__/__snapshots__/spyMatchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/spyMatchers.test.js.snap
@@ -129,52 +129,52 @@ Expected mock function to have been last called with:
 exports[`lastReturnedWith a call that throws is not considered to have returned 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>lastReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected value: <green>undefined</>
-Received value: threw an error
+Expected: <green>undefined</>
+Received: function call threw an error
 
-Received number of returns: <red>0</>
-Received number of calls:   <red>1</>"
+Number of returns: <red>0</>
+Number of calls:   <red>1</>"
 `;
 
 exports[`lastReturnedWith a call that throws undefined is not considered to have returned 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>lastReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected value: <green>undefined</>
-Received value: threw an error
+Expected: <green>undefined</>
+Received: function call threw an error
 
-Received number of returns: <red>0</>
-Received number of calls:   <red>1</>"
+Number of returns: <red>0</>
+Number of calls:   <red>1</>"
 `;
 
 exports[`lastReturnedWith includes the custom mock name in the error message 1`] = `
 "<dim>expect(</><red>named-mock</><dim>).</>lastReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected value: <green>\\"foo\\"</>
+Expected: <green>\\"foo\\"</>
 
-Received number of returns: <red>0</>"
+Number of returns: <red>0</>"
 `;
 
 exports[`lastReturnedWith lastReturnedWith incomplete recursive calls are handled properly 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>lastReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected value: <green>0</>
-Received value
-             3: has not returned yet
-->           4: has not returned yet
+Expected: <green>0</>
+Received
+       3: function call has not returned yet
+->     4: function call has not returned yet
 
-Received number of returns: <red>0</>
-Received number of calls:   <red>4</>"
+Number of returns: <red>0</>
+Number of calls:   <red>4</>"
 `;
 
 exports[`lastReturnedWith lastReturnedWith works with three calls 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>lastReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected value: not <green>\\"foo3\\"</>
-Received value
-             2:     <red>\\"foo2\\"</>
-->           3:     <red>\\"foo3\\"</>
+Expected: not <green>\\"foo3\\"</>
+Received
+       2:     <red>\\"foo2\\"</>
+->     3:     <red>\\"foo3\\"</>
 
-Received number of returns: <red>3</>"
+Number of returns: <red>3</>"
 `;
 
 exports[`lastReturnedWith works only on spies or jest.fn 1`] = `
@@ -189,84 +189,84 @@ Received has value: <red>[Function fn]</>"
 exports[`lastReturnedWith works when not called 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>lastReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected value: <green>\\"foo\\"</>
+Expected: <green>\\"foo\\"</>
 
-Received number of returns: <red>0</>"
+Number of returns: <red>0</>"
 `;
 
 exports[`lastReturnedWith works with Immutable.js objects directly created 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>lastReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected value: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
+Expected: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
 
-Received number of returns: <red>1</>"
+Number of returns: <red>1</>"
 `;
 
 exports[`lastReturnedWith works with Immutable.js objects indirectly created 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>lastReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected value: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
+Expected: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
 
-Received number of returns: <red>1</>"
+Number of returns: <red>1</>"
 `;
 
 exports[`lastReturnedWith works with Map 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>lastReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected value: not <green>Map {1 => 2, 2 => 1}</>
+Expected: not <green>Map {1 => 2, 2 => 1}</>
 
-Received number of returns: <red>1</>"
+Number of returns: <red>1</>"
 `;
 
 exports[`lastReturnedWith works with Map 2`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>lastReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected value: <green>Map {\\"a\\" => \\"b\\", \\"b\\" => \\"a\\"}</>
-Received value: <red>Map {1 => 2, 2 => 1}</>
+Expected: <green>Map {\\"a\\" => \\"b\\", \\"b\\" => \\"a\\"}</>
+Received: <red>Map {1 => 2, 2 => 1}</>
 
-Received number of returns: <red>1</>"
+Number of returns: <red>1</>"
 `;
 
 exports[`lastReturnedWith works with Set 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>lastReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected value: not <green>Set {1, 2}</>
+Expected: not <green>Set {1, 2}</>
 
-Received number of returns: <red>1</>"
+Number of returns: <red>1</>"
 `;
 
 exports[`lastReturnedWith works with Set 2`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>lastReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected value: <green>Set {3, 4}</>
-Received value: <red>Set {1, 2}</>
+Expected: <green>Set {3, 4}</>
+Received: <red>Set {1, 2}</>
 
-Received number of returns: <red>1</>"
+Number of returns: <red>1</>"
 `;
 
 exports[`lastReturnedWith works with argument that does match 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>lastReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected value: not <green>\\"foo\\"</>
+Expected: not <green>\\"foo\\"</>
 
-Received number of returns: <red>1</>"
+Number of returns: <red>1</>"
 `;
 
 exports[`lastReturnedWith works with argument that does not match 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>lastReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected value: <green>\\"bar\\"</>
-Received value: <red>\\"foo\\"</>
+Expected: <green>\\"bar\\"</>
+Received: <red>\\"foo\\"</>
 
-Received number of returns: <red>1</>"
+Number of returns: <red>1</>"
 `;
 
 exports[`lastReturnedWith works with undefined 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>lastReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected value: not <green>undefined</>
+Expected: not <green>undefined</>
 
-Received number of returns: <red>1</>"
+Number of returns: <red>1</>"
 `;
 
 exports[`nthCalledWith includes the custom mock name in the error message 1`] = `
@@ -433,85 +433,85 @@ exports[`nthReturnedWith a call that throws is not considered to have returned 1
 "<dim>expect(</><red>jest.fn()</><dim>).</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
 n: 1
-Expected value: <green>undefined</>
-Received value: threw an error
+Expected: <green>undefined</>
+Received: function call threw an error
 
-Received number of returns: <red>0</>
-Received number of calls:   <red>1</>"
+Number of returns: <red>0</>
+Number of calls:   <red>1</>"
 `;
 
 exports[`nthReturnedWith a call that throws undefined is not considered to have returned 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
 n: 1
-Expected value: <green>undefined</>
-Received value: threw an error
+Expected: <green>undefined</>
+Received: function call threw an error
 
-Received number of returns: <red>0</>
-Received number of calls:   <red>1</>"
+Number of returns: <red>0</>
+Number of calls:   <red>1</>"
 `;
 
 exports[`nthReturnedWith includes the custom mock name in the error message 1`] = `
 "<dim>expect(</><red>named-mock</><dim>).</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
 n: 1
-Expected value: <green>\\"foo\\"</>
+Expected: <green>\\"foo\\"</>
 
-Received number of returns: <red>0</>"
+Number of returns: <red>0</>"
 `;
 
 exports[`nthReturnedWith nthReturnedWith incomplete recursive calls are handled properly 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
 n: 1
-Expected value: <green>6</>
-Received value
-->           1: has not returned yet
-             2: has not returned yet
+Expected: <green>6</>
+Received
+->     1: function call has not returned yet
+       2: function call has not returned yet
 
-Received number of returns: <red>2</>
-Received number of calls:   <red>4</>"
+Number of returns: <red>2</>
+Number of calls:   <red>4</>"
 `;
 
 exports[`nthReturnedWith nthReturnedWith incomplete recursive calls are handled properly 2`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
 n: 2
-Expected value: <green>3</>
-Received value
-             1: has not returned yet
-->           2: has not returned yet
-             3: <red>1</>
+Expected: <green>3</>
+Received
+       1: function call has not returned yet
+->     2: function call has not returned yet
+       3: <red>1</>
 
-Received number of returns: <red>2</>
-Received number of calls:   <red>4</>"
+Number of returns: <red>2</>
+Number of calls:   <red>4</>"
 `;
 
 exports[`nthReturnedWith nthReturnedWith incomplete recursive calls are handled properly 3`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
 n: 3
-Expected value: not <green>1</>
-Received value
-             2:     has not returned yet
-->           3:     <red>1</>
-             4:     <red>0</>
+Expected: not <green>1</>
+Received
+       2:     function call has not returned yet
+->     3:     <red>1</>
+       4:     <red>0</>
 
-Received number of returns: <red>2</>
-Received number of calls:   <red>4</>"
+Number of returns: <red>2</>
+Number of calls:   <red>4</>"
 `;
 
 exports[`nthReturnedWith nthReturnedWith incomplete recursive calls are handled properly 4`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
 n: 4
-Expected value: not <green>0</>
-Received value
-             3:     <red>1</>
-->           4:     <red>0</>
+Expected: not <green>0</>
+Received
+       3:     <red>1</>
+->     4:     <red>0</>
 
-Received number of returns: <red>2</>
-Received number of calls:   <red>4</>"
+Number of returns: <red>2</>
+Number of calls:   <red>4</>"
 `;
 
 exports[`nthReturnedWith nthReturnedWith negative throw matcher error for n that is not number 1`] = `
@@ -544,47 +544,47 @@ exports[`nthReturnedWith nthReturnedWith should reject nth value greater than nu
 "<dim>expect(</><red>jest.fn()</><dim>).</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
 n: 4
-Expected value: <green>\\"foo\\"</>
-Received value
-             3: <red>\\"foo\\"</>
+Expected: <green>\\"foo\\"</>
+Received
+       3: <red>\\"foo\\"</>
 
-Received number of returns: <red>3</>"
+Number of returns: <red>3</>"
 `;
 
 exports[`nthReturnedWith nthReturnedWith should replace 1st, 2nd, 3rd with first, second, third 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
 n: 1
-Expected value: <green>\\"bar1\\"</>
-Received value
-->           1: <red>\\"foo1\\"</>
-             2: <red>\\"foo2\\"</>
+Expected: <green>\\"bar1\\"</>
+Received
+->     1: <red>\\"foo1\\"</>
+       2: <red>\\"foo2\\"</>
 
-Received number of returns: <red>3</>"
+Number of returns: <red>3</>"
 `;
 
 exports[`nthReturnedWith nthReturnedWith should replace 1st, 2nd, 3rd with first, second, third 2`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
 n: 1
-Expected value: not <green>\\"foo1\\"</>
-Received value
-->           1:     <red>\\"foo1\\"</>
-             2:     <red>\\"foo2\\"</>
+Expected: not <green>\\"foo1\\"</>
+Received
+->     1:     <red>\\"foo1\\"</>
+       2:     <red>\\"foo2\\"</>
 
-Received number of returns: <red>3</>"
+Number of returns: <red>3</>"
 `;
 
 exports[`nthReturnedWith nthReturnedWith works with three calls 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
 n: 1
-Expected value: not <green>\\"foo1\\"</>
-Received value
-->           1:     <red>\\"foo1\\"</>
-             2:     <red>\\"foo2\\"</>
+Expected: not <green>\\"foo1\\"</>
+Received
+->     1:     <red>\\"foo1\\"</>
+       2:     <red>\\"foo2\\"</>
 
-Received number of returns: <red>3</>"
+Number of returns: <red>3</>"
 `;
 
 exports[`nthReturnedWith works only on spies or jest.fn 1`] = `
@@ -600,93 +600,93 @@ exports[`nthReturnedWith works when not called 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
 n: 1
-Expected value: <green>\\"foo\\"</>
+Expected: <green>\\"foo\\"</>
 
-Received number of returns: <red>0</>"
+Number of returns: <red>0</>"
 `;
 
 exports[`nthReturnedWith works with Immutable.js objects directly created 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
 n: 1
-Expected value: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
+Expected: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
 
-Received number of returns: <red>1</>"
+Number of returns: <red>1</>"
 `;
 
 exports[`nthReturnedWith works with Immutable.js objects indirectly created 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
 n: 1
-Expected value: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
+Expected: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
 
-Received number of returns: <red>1</>"
+Number of returns: <red>1</>"
 `;
 
 exports[`nthReturnedWith works with Map 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
 n: 1
-Expected value: not <green>Map {1 => 2, 2 => 1}</>
+Expected: not <green>Map {1 => 2, 2 => 1}</>
 
-Received number of returns: <red>1</>"
+Number of returns: <red>1</>"
 `;
 
 exports[`nthReturnedWith works with Map 2`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
 n: 1
-Expected value: <green>Map {\\"a\\" => \\"b\\", \\"b\\" => \\"a\\"}</>
-Received value: <red>Map {1 => 2, 2 => 1}</>
+Expected: <green>Map {\\"a\\" => \\"b\\", \\"b\\" => \\"a\\"}</>
+Received: <red>Map {1 => 2, 2 => 1}</>
 
-Received number of returns: <red>1</>"
+Number of returns: <red>1</>"
 `;
 
 exports[`nthReturnedWith works with Set 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
 n: 1
-Expected value: not <green>Set {1, 2}</>
+Expected: not <green>Set {1, 2}</>
 
-Received number of returns: <red>1</>"
+Number of returns: <red>1</>"
 `;
 
 exports[`nthReturnedWith works with Set 2`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
 n: 1
-Expected value: <green>Set {3, 4}</>
-Received value: <red>Set {1, 2}</>
+Expected: <green>Set {3, 4}</>
+Received: <red>Set {1, 2}</>
 
-Received number of returns: <red>1</>"
+Number of returns: <red>1</>"
 `;
 
 exports[`nthReturnedWith works with argument that does match 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
 n: 1
-Expected value: not <green>\\"foo\\"</>
+Expected: not <green>\\"foo\\"</>
 
-Received number of returns: <red>1</>"
+Number of returns: <red>1</>"
 `;
 
 exports[`nthReturnedWith works with argument that does not match 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
 n: 1
-Expected value: <green>\\"bar\\"</>
-Received value: <red>\\"foo\\"</>
+Expected: <green>\\"bar\\"</>
+Received: <red>\\"foo\\"</>
 
-Received number of returns: <red>1</>"
+Number of returns: <red>1</>"
 `;
 
 exports[`nthReturnedWith works with undefined 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
 n: 1
-Expected value: not <green>undefined</>
+Expected: not <green>undefined</>
 
-Received number of returns: <red>1</>"
+Number of returns: <red>1</>"
 `;
 
 exports[`toBeCalled .not fails with any argument passed 1`] = `
@@ -1638,52 +1638,52 @@ Expected mock function first call to have been called with:
 exports[`toHaveLastReturnedWith a call that throws is not considered to have returned 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>toHaveLastReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected value: <green>undefined</>
-Received value: threw an error
+Expected: <green>undefined</>
+Received: function call threw an error
 
-Received number of returns: <red>0</>
-Received number of calls:   <red>1</>"
+Number of returns: <red>0</>
+Number of calls:   <red>1</>"
 `;
 
 exports[`toHaveLastReturnedWith a call that throws undefined is not considered to have returned 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>toHaveLastReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected value: <green>undefined</>
-Received value: threw an error
+Expected: <green>undefined</>
+Received: function call threw an error
 
-Received number of returns: <red>0</>
-Received number of calls:   <red>1</>"
+Number of returns: <red>0</>
+Number of calls:   <red>1</>"
 `;
 
 exports[`toHaveLastReturnedWith includes the custom mock name in the error message 1`] = `
 "<dim>expect(</><red>named-mock</><dim>).</>toHaveLastReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected value: <green>\\"foo\\"</>
+Expected: <green>\\"foo\\"</>
 
-Received number of returns: <red>0</>"
+Number of returns: <red>0</>"
 `;
 
 exports[`toHaveLastReturnedWith lastReturnedWith incomplete recursive calls are handled properly 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>toHaveLastReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected value: <green>0</>
-Received value
-             3: has not returned yet
-->           4: has not returned yet
+Expected: <green>0</>
+Received
+       3: function call has not returned yet
+->     4: function call has not returned yet
 
-Received number of returns: <red>0</>
-Received number of calls:   <red>4</>"
+Number of returns: <red>0</>
+Number of calls:   <red>4</>"
 `;
 
 exports[`toHaveLastReturnedWith lastReturnedWith works with three calls 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveLastReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected value: not <green>\\"foo3\\"</>
-Received value
-             2:     <red>\\"foo2\\"</>
-->           3:     <red>\\"foo3\\"</>
+Expected: not <green>\\"foo3\\"</>
+Received
+       2:     <red>\\"foo2\\"</>
+->     3:     <red>\\"foo3\\"</>
 
-Received number of returns: <red>3</>"
+Number of returns: <red>3</>"
 `;
 
 exports[`toHaveLastReturnedWith works only on spies or jest.fn 1`] = `
@@ -1698,169 +1698,169 @@ Received has value: <red>[Function fn]</>"
 exports[`toHaveLastReturnedWith works when not called 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>toHaveLastReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected value: <green>\\"foo\\"</>
+Expected: <green>\\"foo\\"</>
 
-Received number of returns: <red>0</>"
+Number of returns: <red>0</>"
 `;
 
 exports[`toHaveLastReturnedWith works with Immutable.js objects directly created 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveLastReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected value: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
+Expected: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
 
-Received number of returns: <red>1</>"
+Number of returns: <red>1</>"
 `;
 
 exports[`toHaveLastReturnedWith works with Immutable.js objects indirectly created 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveLastReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected value: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
+Expected: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
 
-Received number of returns: <red>1</>"
+Number of returns: <red>1</>"
 `;
 
 exports[`toHaveLastReturnedWith works with Map 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveLastReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected value: not <green>Map {1 => 2, 2 => 1}</>
+Expected: not <green>Map {1 => 2, 2 => 1}</>
 
-Received number of returns: <red>1</>"
+Number of returns: <red>1</>"
 `;
 
 exports[`toHaveLastReturnedWith works with Map 2`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>toHaveLastReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected value: <green>Map {\\"a\\" => \\"b\\", \\"b\\" => \\"a\\"}</>
-Received value: <red>Map {1 => 2, 2 => 1}</>
+Expected: <green>Map {\\"a\\" => \\"b\\", \\"b\\" => \\"a\\"}</>
+Received: <red>Map {1 => 2, 2 => 1}</>
 
-Received number of returns: <red>1</>"
+Number of returns: <red>1</>"
 `;
 
 exports[`toHaveLastReturnedWith works with Set 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveLastReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected value: not <green>Set {1, 2}</>
+Expected: not <green>Set {1, 2}</>
 
-Received number of returns: <red>1</>"
+Number of returns: <red>1</>"
 `;
 
 exports[`toHaveLastReturnedWith works with Set 2`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>toHaveLastReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected value: <green>Set {3, 4}</>
-Received value: <red>Set {1, 2}</>
+Expected: <green>Set {3, 4}</>
+Received: <red>Set {1, 2}</>
 
-Received number of returns: <red>1</>"
+Number of returns: <red>1</>"
 `;
 
 exports[`toHaveLastReturnedWith works with argument that does match 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveLastReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected value: not <green>\\"foo\\"</>
+Expected: not <green>\\"foo\\"</>
 
-Received number of returns: <red>1</>"
+Number of returns: <red>1</>"
 `;
 
 exports[`toHaveLastReturnedWith works with argument that does not match 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>toHaveLastReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected value: <green>\\"bar\\"</>
-Received value: <red>\\"foo\\"</>
+Expected: <green>\\"bar\\"</>
+Received: <red>\\"foo\\"</>
 
-Received number of returns: <red>1</>"
+Number of returns: <red>1</>"
 `;
 
 exports[`toHaveLastReturnedWith works with undefined 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveLastReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected value: not <green>undefined</>
+Expected: not <green>undefined</>
 
-Received number of returns: <red>1</>"
+Number of returns: <red>1</>"
 `;
 
 exports[`toHaveNthReturnedWith a call that throws is not considered to have returned 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
 n: 1
-Expected value: <green>undefined</>
-Received value: threw an error
+Expected: <green>undefined</>
+Received: function call threw an error
 
-Received number of returns: <red>0</>
-Received number of calls:   <red>1</>"
+Number of returns: <red>0</>
+Number of calls:   <red>1</>"
 `;
 
 exports[`toHaveNthReturnedWith a call that throws undefined is not considered to have returned 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
 n: 1
-Expected value: <green>undefined</>
-Received value: threw an error
+Expected: <green>undefined</>
+Received: function call threw an error
 
-Received number of returns: <red>0</>
-Received number of calls:   <red>1</>"
+Number of returns: <red>0</>
+Number of calls:   <red>1</>"
 `;
 
 exports[`toHaveNthReturnedWith includes the custom mock name in the error message 1`] = `
 "<dim>expect(</><red>named-mock</><dim>).</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
 n: 1
-Expected value: <green>\\"foo\\"</>
+Expected: <green>\\"foo\\"</>
 
-Received number of returns: <red>0</>"
+Number of returns: <red>0</>"
 `;
 
 exports[`toHaveNthReturnedWith nthReturnedWith incomplete recursive calls are handled properly 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
 n: 1
-Expected value: <green>6</>
-Received value
-->           1: has not returned yet
-             2: has not returned yet
+Expected: <green>6</>
+Received
+->     1: function call has not returned yet
+       2: function call has not returned yet
 
-Received number of returns: <red>2</>
-Received number of calls:   <red>4</>"
+Number of returns: <red>2</>
+Number of calls:   <red>4</>"
 `;
 
 exports[`toHaveNthReturnedWith nthReturnedWith incomplete recursive calls are handled properly 2`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
 n: 2
-Expected value: <green>3</>
-Received value
-             1: has not returned yet
-->           2: has not returned yet
-             3: <red>1</>
+Expected: <green>3</>
+Received
+       1: function call has not returned yet
+->     2: function call has not returned yet
+       3: <red>1</>
 
-Received number of returns: <red>2</>
-Received number of calls:   <red>4</>"
+Number of returns: <red>2</>
+Number of calls:   <red>4</>"
 `;
 
 exports[`toHaveNthReturnedWith nthReturnedWith incomplete recursive calls are handled properly 3`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
 n: 3
-Expected value: not <green>1</>
-Received value
-             2:     has not returned yet
-->           3:     <red>1</>
-             4:     <red>0</>
+Expected: not <green>1</>
+Received
+       2:     function call has not returned yet
+->     3:     <red>1</>
+       4:     <red>0</>
 
-Received number of returns: <red>2</>
-Received number of calls:   <red>4</>"
+Number of returns: <red>2</>
+Number of calls:   <red>4</>"
 `;
 
 exports[`toHaveNthReturnedWith nthReturnedWith incomplete recursive calls are handled properly 4`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
 n: 4
-Expected value: not <green>0</>
-Received value
-             3:     <red>1</>
-->           4:     <red>0</>
+Expected: not <green>0</>
+Received
+       3:     <red>1</>
+->     4:     <red>0</>
 
-Received number of returns: <red>2</>
-Received number of calls:   <red>4</>"
+Number of returns: <red>2</>
+Number of calls:   <red>4</>"
 `;
 
 exports[`toHaveNthReturnedWith nthReturnedWith negative throw matcher error for n that is not number 1`] = `
@@ -1893,47 +1893,47 @@ exports[`toHaveNthReturnedWith nthReturnedWith should reject nth value greater t
 "<dim>expect(</><red>jest.fn()</><dim>).</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
 n: 4
-Expected value: <green>\\"foo\\"</>
-Received value
-             3: <red>\\"foo\\"</>
+Expected: <green>\\"foo\\"</>
+Received
+       3: <red>\\"foo\\"</>
 
-Received number of returns: <red>3</>"
+Number of returns: <red>3</>"
 `;
 
 exports[`toHaveNthReturnedWith nthReturnedWith should replace 1st, 2nd, 3rd with first, second, third 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
 n: 1
-Expected value: <green>\\"bar1\\"</>
-Received value
-->           1: <red>\\"foo1\\"</>
-             2: <red>\\"foo2\\"</>
+Expected: <green>\\"bar1\\"</>
+Received
+->     1: <red>\\"foo1\\"</>
+       2: <red>\\"foo2\\"</>
 
-Received number of returns: <red>3</>"
+Number of returns: <red>3</>"
 `;
 
 exports[`toHaveNthReturnedWith nthReturnedWith should replace 1st, 2nd, 3rd with first, second, third 2`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
 n: 1
-Expected value: not <green>\\"foo1\\"</>
-Received value
-->           1:     <red>\\"foo1\\"</>
-             2:     <red>\\"foo2\\"</>
+Expected: not <green>\\"foo1\\"</>
+Received
+->     1:     <red>\\"foo1\\"</>
+       2:     <red>\\"foo2\\"</>
 
-Received number of returns: <red>3</>"
+Number of returns: <red>3</>"
 `;
 
 exports[`toHaveNthReturnedWith nthReturnedWith works with three calls 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
 n: 1
-Expected value: not <green>\\"foo1\\"</>
-Received value
-->           1:     <red>\\"foo1\\"</>
-             2:     <red>\\"foo2\\"</>
+Expected: not <green>\\"foo1\\"</>
+Received
+->     1:     <red>\\"foo1\\"</>
+       2:     <red>\\"foo2\\"</>
 
-Received number of returns: <red>3</>"
+Number of returns: <red>3</>"
 `;
 
 exports[`toHaveNthReturnedWith works only on spies or jest.fn 1`] = `
@@ -1949,93 +1949,93 @@ exports[`toHaveNthReturnedWith works when not called 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
 n: 1
-Expected value: <green>\\"foo\\"</>
+Expected: <green>\\"foo\\"</>
 
-Received number of returns: <red>0</>"
+Number of returns: <red>0</>"
 `;
 
 exports[`toHaveNthReturnedWith works with Immutable.js objects directly created 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
 n: 1
-Expected value: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
+Expected: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
 
-Received number of returns: <red>1</>"
+Number of returns: <red>1</>"
 `;
 
 exports[`toHaveNthReturnedWith works with Immutable.js objects indirectly created 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
 n: 1
-Expected value: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
+Expected: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
 
-Received number of returns: <red>1</>"
+Number of returns: <red>1</>"
 `;
 
 exports[`toHaveNthReturnedWith works with Map 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
 n: 1
-Expected value: not <green>Map {1 => 2, 2 => 1}</>
+Expected: not <green>Map {1 => 2, 2 => 1}</>
 
-Received number of returns: <red>1</>"
+Number of returns: <red>1</>"
 `;
 
 exports[`toHaveNthReturnedWith works with Map 2`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
 n: 1
-Expected value: <green>Map {\\"a\\" => \\"b\\", \\"b\\" => \\"a\\"}</>
-Received value: <red>Map {1 => 2, 2 => 1}</>
+Expected: <green>Map {\\"a\\" => \\"b\\", \\"b\\" => \\"a\\"}</>
+Received: <red>Map {1 => 2, 2 => 1}</>
 
-Received number of returns: <red>1</>"
+Number of returns: <red>1</>"
 `;
 
 exports[`toHaveNthReturnedWith works with Set 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
 n: 1
-Expected value: not <green>Set {1, 2}</>
+Expected: not <green>Set {1, 2}</>
 
-Received number of returns: <red>1</>"
+Number of returns: <red>1</>"
 `;
 
 exports[`toHaveNthReturnedWith works with Set 2`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
 n: 1
-Expected value: <green>Set {3, 4}</>
-Received value: <red>Set {1, 2}</>
+Expected: <green>Set {3, 4}</>
+Received: <red>Set {1, 2}</>
 
-Received number of returns: <red>1</>"
+Number of returns: <red>1</>"
 `;
 
 exports[`toHaveNthReturnedWith works with argument that does match 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
 n: 1
-Expected value: not <green>\\"foo\\"</>
+Expected: not <green>\\"foo\\"</>
 
-Received number of returns: <red>1</>"
+Number of returns: <red>1</>"
 `;
 
 exports[`toHaveNthReturnedWith works with argument that does not match 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
 n: 1
-Expected value: <green>\\"bar\\"</>
-Received value: <red>\\"foo\\"</>
+Expected: <green>\\"bar\\"</>
+Received: <red>\\"foo\\"</>
 
-Received number of returns: <red>1</>"
+Number of returns: <red>1</>"
 `;
 
 exports[`toHaveNthReturnedWith works with undefined 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
 
 n: 1
-Expected value: not <green>undefined</>
+Expected: not <green>undefined</>
 
-Received number of returns: <red>1</>"
+Number of returns: <red>1</>"
 `;
 
 exports[`toHaveReturned .not fails with any argument passed 1`] = `
@@ -2312,54 +2312,54 @@ Received has value: <red>[Function fn]</>"
 exports[`toHaveReturnedWith a call that throws is not considered to have returned 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>toHaveReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected value: <green>undefined</>
-Received value: threw an error
+Expected: <green>undefined</>
+Received: function call threw an error
 
-Received number of returns: <red>0</>
-Received number of calls:   <red>1</>"
+Number of returns: <red>0</>
+Number of calls:   <red>1</>"
 `;
 
 exports[`toHaveReturnedWith a call that throws undefined is not considered to have returned 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>toHaveReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected value: <green>undefined</>
-Received value: threw an error
+Expected: <green>undefined</>
+Received: function call threw an error
 
-Received number of returns: <red>0</>
-Received number of calls:   <red>1</>"
+Number of returns: <red>0</>
+Number of calls:   <red>1</>"
 `;
 
 exports[`toHaveReturnedWith includes the custom mock name in the error message 1`] = `
 "<dim>expect(</><red>named-mock</><dim>).</>toHaveReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected value: <green>\\"foo\\"</>
+Expected: <green>\\"foo\\"</>
 
-Received number of returns: <red>0</>"
+Number of returns: <red>0</>"
 `;
 
 exports[`toHaveReturnedWith returnedWith incomplete recursive calls are handled properly 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>toHaveReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected value: <green>undefined</>
-Received value
-             1: has not returned yet
-             2: has not returned yet
-             3: has not returned yet
+Expected: <green>undefined</>
+Received
+       1: function call has not returned yet
+       2: function call has not returned yet
+       3: function call has not returned yet
 
-Received number of returns: <red>0</>
-Received number of calls:   <red>4</>"
+Number of returns: <red>0</>
+Number of calls:   <red>4</>"
 `;
 
 exports[`toHaveReturnedWith returnedWith works with more calls than the limit 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>toHaveReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected value: <green>\\"bar\\"</>
-Received value
-             1: <red>\\"foo1\\"</>
-             2: <red>\\"foo2\\"</>
-             3: <red>\\"foo3\\"</>
+Expected: <green>\\"bar\\"</>
+Received
+       1: <red>\\"foo1\\"</>
+       2: <red>\\"foo2\\"</>
+       3: <red>\\"foo3\\"</>
 
-Received number of returns: <red>6</>"
+Number of returns: <red>6</>"
 `;
 
 exports[`toHaveReturnedWith works only on spies or jest.fn 1`] = `
@@ -2374,84 +2374,84 @@ Received has value: <red>[Function fn]</>"
 exports[`toHaveReturnedWith works when not called 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>toHaveReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected value: <green>\\"foo\\"</>
+Expected: <green>\\"foo\\"</>
 
-Received number of returns: <red>0</>"
+Number of returns: <red>0</>"
 `;
 
 exports[`toHaveReturnedWith works with Immutable.js objects directly created 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected value: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
+Expected: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
 
-Received number of returns: <red>1</>"
+Number of returns: <red>1</>"
 `;
 
 exports[`toHaveReturnedWith works with Immutable.js objects indirectly created 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected value: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
+Expected: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
 
-Received number of returns: <red>1</>"
+Number of returns: <red>1</>"
 `;
 
 exports[`toHaveReturnedWith works with Map 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected value: not <green>Map {1 => 2, 2 => 1}</>
+Expected: not <green>Map {1 => 2, 2 => 1}</>
 
-Received number of returns: <red>1</>"
+Number of returns: <red>1</>"
 `;
 
 exports[`toHaveReturnedWith works with Map 2`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>toHaveReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected value: <green>Map {\\"a\\" => \\"b\\", \\"b\\" => \\"a\\"}</>
-Received value: <red>Map {1 => 2, 2 => 1}</>
+Expected: <green>Map {\\"a\\" => \\"b\\", \\"b\\" => \\"a\\"}</>
+Received: <red>Map {1 => 2, 2 => 1}</>
 
-Received number of returns: <red>1</>"
+Number of returns: <red>1</>"
 `;
 
 exports[`toHaveReturnedWith works with Set 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected value: not <green>Set {1, 2}</>
+Expected: not <green>Set {1, 2}</>
 
-Received number of returns: <red>1</>"
+Number of returns: <red>1</>"
 `;
 
 exports[`toHaveReturnedWith works with Set 2`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>toHaveReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected value: <green>Set {3, 4}</>
-Received value: <red>Set {1, 2}</>
+Expected: <green>Set {3, 4}</>
+Received: <red>Set {1, 2}</>
 
-Received number of returns: <red>1</>"
+Number of returns: <red>1</>"
 `;
 
 exports[`toHaveReturnedWith works with argument that does match 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected value: not <green>\\"foo\\"</>
+Expected: not <green>\\"foo\\"</>
 
-Received number of returns: <red>1</>"
+Number of returns: <red>1</>"
 `;
 
 exports[`toHaveReturnedWith works with argument that does not match 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>toHaveReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected value: <green>\\"bar\\"</>
-Received value: <red>\\"foo\\"</>
+Expected: <green>\\"bar\\"</>
+Received: <red>\\"foo\\"</>
 
-Received number of returns: <red>1</>"
+Number of returns: <red>1</>"
 `;
 
 exports[`toHaveReturnedWith works with undefined 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveReturnedWith<dim>(</><green>expected</><dim>)</>
 
-Expected value: not <green>undefined</>
+Expected: not <green>undefined</>
 
-Received number of returns: <red>1</>"
+Number of returns: <red>1</>"
 `;
 
 exports[`toReturn .not fails with any argument passed 1`] = `
@@ -2728,54 +2728,54 @@ Received has value: <red>[Function fn]</>"
 exports[`toReturnWith a call that throws is not considered to have returned 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>toReturnWith<dim>(</><green>expected</><dim>)</>
 
-Expected value: <green>undefined</>
-Received value: threw an error
+Expected: <green>undefined</>
+Received: function call threw an error
 
-Received number of returns: <red>0</>
-Received number of calls:   <red>1</>"
+Number of returns: <red>0</>
+Number of calls:   <red>1</>"
 `;
 
 exports[`toReturnWith a call that throws undefined is not considered to have returned 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>toReturnWith<dim>(</><green>expected</><dim>)</>
 
-Expected value: <green>undefined</>
-Received value: threw an error
+Expected: <green>undefined</>
+Received: function call threw an error
 
-Received number of returns: <red>0</>
-Received number of calls:   <red>1</>"
+Number of returns: <red>0</>
+Number of calls:   <red>1</>"
 `;
 
 exports[`toReturnWith includes the custom mock name in the error message 1`] = `
 "<dim>expect(</><red>named-mock</><dim>).</>toReturnWith<dim>(</><green>expected</><dim>)</>
 
-Expected value: <green>\\"foo\\"</>
+Expected: <green>\\"foo\\"</>
 
-Received number of returns: <red>0</>"
+Number of returns: <red>0</>"
 `;
 
 exports[`toReturnWith returnedWith incomplete recursive calls are handled properly 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>toReturnWith<dim>(</><green>expected</><dim>)</>
 
-Expected value: <green>undefined</>
-Received value
-             1: has not returned yet
-             2: has not returned yet
-             3: has not returned yet
+Expected: <green>undefined</>
+Received
+       1: function call has not returned yet
+       2: function call has not returned yet
+       3: function call has not returned yet
 
-Received number of returns: <red>0</>
-Received number of calls:   <red>4</>"
+Number of returns: <red>0</>
+Number of calls:   <red>4</>"
 `;
 
 exports[`toReturnWith returnedWith works with more calls than the limit 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>toReturnWith<dim>(</><green>expected</><dim>)</>
 
-Expected value: <green>\\"bar\\"</>
-Received value
-             1: <red>\\"foo1\\"</>
-             2: <red>\\"foo2\\"</>
-             3: <red>\\"foo3\\"</>
+Expected: <green>\\"bar\\"</>
+Received
+       1: <red>\\"foo1\\"</>
+       2: <red>\\"foo2\\"</>
+       3: <red>\\"foo3\\"</>
 
-Received number of returns: <red>6</>"
+Number of returns: <red>6</>"
 `;
 
 exports[`toReturnWith works only on spies or jest.fn 1`] = `
@@ -2790,82 +2790,82 @@ Received has value: <red>[Function fn]</>"
 exports[`toReturnWith works when not called 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>toReturnWith<dim>(</><green>expected</><dim>)</>
 
-Expected value: <green>\\"foo\\"</>
+Expected: <green>\\"foo\\"</>
 
-Received number of returns: <red>0</>"
+Number of returns: <red>0</>"
 `;
 
 exports[`toReturnWith works with Immutable.js objects directly created 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toReturnWith<dim>(</><green>expected</><dim>)</>
 
-Expected value: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
+Expected: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
 
-Received number of returns: <red>1</>"
+Number of returns: <red>1</>"
 `;
 
 exports[`toReturnWith works with Immutable.js objects indirectly created 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toReturnWith<dim>(</><green>expected</><dim>)</>
 
-Expected value: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
+Expected: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
 
-Received number of returns: <red>1</>"
+Number of returns: <red>1</>"
 `;
 
 exports[`toReturnWith works with Map 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toReturnWith<dim>(</><green>expected</><dim>)</>
 
-Expected value: not <green>Map {1 => 2, 2 => 1}</>
+Expected: not <green>Map {1 => 2, 2 => 1}</>
 
-Received number of returns: <red>1</>"
+Number of returns: <red>1</>"
 `;
 
 exports[`toReturnWith works with Map 2`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>toReturnWith<dim>(</><green>expected</><dim>)</>
 
-Expected value: <green>Map {\\"a\\" => \\"b\\", \\"b\\" => \\"a\\"}</>
-Received value: <red>Map {1 => 2, 2 => 1}</>
+Expected: <green>Map {\\"a\\" => \\"b\\", \\"b\\" => \\"a\\"}</>
+Received: <red>Map {1 => 2, 2 => 1}</>
 
-Received number of returns: <red>1</>"
+Number of returns: <red>1</>"
 `;
 
 exports[`toReturnWith works with Set 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toReturnWith<dim>(</><green>expected</><dim>)</>
 
-Expected value: not <green>Set {1, 2}</>
+Expected: not <green>Set {1, 2}</>
 
-Received number of returns: <red>1</>"
+Number of returns: <red>1</>"
 `;
 
 exports[`toReturnWith works with Set 2`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>toReturnWith<dim>(</><green>expected</><dim>)</>
 
-Expected value: <green>Set {3, 4}</>
-Received value: <red>Set {1, 2}</>
+Expected: <green>Set {3, 4}</>
+Received: <red>Set {1, 2}</>
 
-Received number of returns: <red>1</>"
+Number of returns: <red>1</>"
 `;
 
 exports[`toReturnWith works with argument that does match 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toReturnWith<dim>(</><green>expected</><dim>)</>
 
-Expected value: not <green>\\"foo\\"</>
+Expected: not <green>\\"foo\\"</>
 
-Received number of returns: <red>1</>"
+Number of returns: <red>1</>"
 `;
 
 exports[`toReturnWith works with argument that does not match 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>toReturnWith<dim>(</><green>expected</><dim>)</>
 
-Expected value: <green>\\"bar\\"</>
-Received value: <red>\\"foo\\"</>
+Expected: <green>\\"bar\\"</>
+Received: <red>\\"foo\\"</>
 
-Received number of returns: <red>1</>"
+Number of returns: <red>1</>"
 `;
 
 exports[`toReturnWith works with undefined 1`] = `
 "<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toReturnWith<dim>(</><green>expected</><dim>)</>
 
-Expected value: not <green>undefined</>
+Expected: not <green>undefined</>
 
-Received number of returns: <red>1</>"
+Number of returns: <red>1</>"
 `;

--- a/packages/expect/src/spyMatchers.ts
+++ b/packages/expect/src/spyMatchers.ts
@@ -70,9 +70,9 @@ const getRightAlignedPrinter = (label: string): PrintLabel => {
 
 const printResult = (result: any) =>
   result.type === 'throw'
-    ? 'threw an error'
+    ? 'function call threw an error'
     : result.type === 'incomplete'
-    ? 'has not returned yet'
+    ? 'function call has not returned yet'
     : printReceived(result.value);
 
 type IndexedResult = [number, any];

--- a/packages/expect/src/spyMatchers.ts
+++ b/packages/expect/src/spyMatchers.ts
@@ -376,13 +376,13 @@ const createToReturnWithMatcher = (matcherName: string) =>
           return (
             matcherHint(matcherName, receivedName, expectedArgument, options) +
             '\n\n' +
-            `Expected value: not ${printExpected(expected)}\n` +
+            `Expected: not ${printExpected(expected)}\n` +
             (results.length === 1 &&
             results[0].type === 'return' &&
             stringify(results[0].value) === stringify(expected)
               ? ''
               : printReceivedResults(
-                  'Received value:     ',
+                  'Received:     ',
                   indexedResults,
                   results.length === 1,
                 )) +
@@ -401,9 +401,9 @@ const createToReturnWithMatcher = (matcherName: string) =>
           return (
             matcherHint(matcherName, receivedName, expectedArgument, options) +
             '\n\n' +
-            `Expected value: ${printExpected(expected)}\n` +
+            `Expected: ${printExpected(expected)}\n` +
             printReceivedResults(
-              'Received value: ',
+              'Received: ',
               indexedResults,
               results.length === 1,
             ) +
@@ -486,13 +486,13 @@ const createLastReturnedMatcher = (matcherName: string) =>
           return (
             matcherHint(matcherName, receivedName, expectedArgument, options) +
             '\n\n' +
-            `Expected value: not ${printExpected(expected)}\n` +
+            `Expected: not ${printExpected(expected)}\n` +
             (results.length === 1 &&
             results[0].type === 'return' &&
             stringify(results[0].value) === stringify(expected)
               ? ''
               : printReceivedResults(
-                  'Received value:     ',
+                  'Received:     ',
                   indexedResults,
                   results.length === 1,
                   iLast,
@@ -522,9 +522,9 @@ const createLastReturnedMatcher = (matcherName: string) =>
           return (
             matcherHint(matcherName, receivedName, expectedArgument, options) +
             '\n\n' +
-            `Expected value: ${printExpected(expected)}\n` +
+            `Expected: ${printExpected(expected)}\n` +
             printReceivedResults(
-              'Received value: ',
+              'Received: ',
               indexedResults,
               results.length === 1,
               iLast,
@@ -651,13 +651,13 @@ const createNthReturnedWithMatcher = (matcherName: string) =>
             matcherHint(matcherName, receivedName, expectedArgument, options) +
             '\n\n' +
             `n: ${nth}\n` +
-            `Expected value: not ${printExpected(expected)}\n` +
+            `Expected: not ${printExpected(expected)}\n` +
             (results.length === 1 &&
             results[0].type === 'return' &&
             stringify(results[0].value) === stringify(expected)
               ? ''
               : printReceivedResults(
-                  'Received value:     ',
+                  'Received:     ',
                   indexedResults,
                   results.length === 1,
                   iNth,
@@ -715,9 +715,9 @@ const createNthReturnedWithMatcher = (matcherName: string) =>
             matcherHint(matcherName, receivedName, expectedArgument, options) +
             '\n\n' +
             `n: ${nth}\n` +
-            `Expected value: ${printExpected(expected)}\n` +
+            `Expected: ${printExpected(expected)}\n` +
             printReceivedResults(
-              'Received value: ',
+              'Received: ',
               indexedResults,
               results.length === 1,
               iNth,

--- a/packages/expect/src/spyMatchers.ts
+++ b/packages/expect/src/spyMatchers.ts
@@ -46,9 +46,9 @@ const printNumberOfReturns = (
   countReturns: number,
   countCalls: number,
 ): string =>
-  `\nReceived number of returns: ${printReceived(countReturns)}` +
+  `\nNumber of returns: ${printReceived(countReturns)}` +
   (countCalls !== countReturns
-    ? `\nReceived number of calls:   ${printReceived(countCalls)}`
+    ? `\nNumber of calls:   ${printReceived(countCalls)}`
     : '');
 
 type PrintLabel = (string: string, isExpectedCall: boolean) => string;


### PR DESCRIPTION
## Summary

For `toHave*ReturnedWith` matchers:

* Display matcher name in regular black instead of dim color
* Replace sentences with `Expected` and `Received` labels
* For negative matcher, repeat `not` following `Expected` label
* At end of report, display `Received number of returns`
* If any calls didn’t return, display `Received number of calls`

Display up to 3 call results as context, so testers can diagnose problems: in code, or test, or both

Your **feedback** is especially welcome about questions:

1. For special case of exactly **one call**, is it clearer to display `Received value: whatever` on one line instead of two? (see pictures in following comments)
2. Is the following **context** relevant?

Read the following descriptions with the qualifier **if they exist**:

| matcher | context |
| ---: | :--- |
| `.not.toHaveReturnedWith` | first 3 results that are equal to expected value |
| `.toHaveReturnedWith` | first 3 results, including `threw an error` |
| `.not.toHaveLastReturnedWith` | last and next-to-last results |
| `.toHaveLastReturnedWith` | last result and either nearest preceding value that is equal to expected; otherwise, next-to-last result |
| `.not.toHaveNthReturnedWith` | nth and adjacent results |
| `.toHaveNthReturnedWith` | nth and either nearest preceding/following value that is equal to expected; otherwise, adjacent results |

## Test plan

Updated 102 snapshots

| | long name | short name |
| ---: | :--- | :--- |
| 30 | `toHaveReturnedWith` | `toReturnWith` |
| 30 | `toHaveLastReturnedWith` | `lastReturnedWith` |
| 42 | `toHaveNthReturnedWith` | `nthReturnedWith` |

See also pictures in following comments

Example pictures baseline at left and **improved at right**