### PR TITLE
feature(expect): Return the error from `toThrow` and `toThrowError`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - `[jest-validate]` Allow `maxWorkers` as part of the `jest.config.js` ([#8565](https://github.com/facebook/jest/pull/8565))
 - `[jest-runtime]` Allow passing configuration objects to transformers ([#7288](https://github.com/facebook/jest/pull/7288))
 - `[@jest/core, @jest/test-sequencer]` Support async sort in custom `testSequencer` ([#8642](https://github.com/facebook/jest/pull/8642))
+- `[expect]` Return the error from `toThrow` and `toThrowError` ([#8718](https://github.com/facebook/jest/pull/8718))
 
 ### Fixes
 

--- a/packages/expect/src/__tests__/toThrowMatchers.test.js
+++ b/packages/expect/src/__tests__/toThrowMatchers.test.js
@@ -90,6 +90,43 @@ class customError extends Error {
           }).not[toThrow]('Server Error');
         }).toThrowErrorMatchingSnapshot();
       });
+
+      test('returns error', async () => {
+        const expectedError = new Error('apple');
+
+        expect(
+          jestExpect(() => {
+            throw expectedError;
+          })[toThrow]('apple'),
+        ).toEqual(expectedError);
+
+        await expect(
+          jestExpect(
+            (async () => {
+              throw expectedError;
+            })(),
+          ).rejects[toThrow]('apple'),
+        ).resolves.toEqual(expectedError);
+
+        expect(
+          jestExpect(() => {
+            throw expectedError;
+          }).not[toThrow]('banana'),
+        ).toEqual(expectedError);
+
+        await expect(
+          jestExpect(
+            (async () => {
+              throw expectedError;
+            })(),
+          ).rejects.not[toThrow]('banana'),
+        ).resolves.toEqual(expectedError);
+
+        expect(jestExpect(() => {}).not[toThrow]('apple')).toBeUndefined();
+        await expect(
+          jestExpect((async () => {})()).resolves.not[toThrow]('apple'),
+        ).resolves.toBeUndefined();
+      });
     });
 
     describe('regexp', () => {
@@ -141,6 +178,43 @@ class customError extends Error {
             throw 404;
           }).not[toThrow](/^[123456789]\d*/);
         }).toThrowErrorMatchingSnapshot();
+      });
+
+      test('returns error', async () => {
+        const expectedError = new Error('apple');
+
+        expect(
+          jestExpect(() => {
+            throw expectedError;
+          })[toThrow](/apple/),
+        ).toEqual(expectedError);
+
+        await expect(
+          jestExpect(
+            (async () => {
+              throw expectedError;
+            })(),
+          ).rejects[toThrow](/apple/),
+        ).resolves.toEqual(expectedError);
+
+        expect(
+          jestExpect(() => {
+            throw expectedError;
+          }).not[toThrow](/banana/),
+        ).toEqual(expectedError);
+
+        await expect(
+          jestExpect(
+            (async () => {
+              throw expectedError;
+            })(),
+          ).rejects.not[toThrow](/banana/),
+        ).resolves.toEqual(expectedError);
+
+        expect(jestExpect(() => {}).not[toThrow](/apple/)).toBeUndefined();
+        await expect(
+          jestExpect((async () => {})()).resolves.not[toThrow](/apple/),
+        ).resolves.toBeUndefined();
       });
     });
 
@@ -221,6 +295,29 @@ class customError extends Error {
             throw new SubSubErr('apple');
           }).not[toThrow](Err);
         }).toThrowErrorMatchingSnapshot();
+      });
+
+      test('returns error', async () => {
+        const error = new Err();
+
+        expect(
+          jestExpect(() => {
+            throw error;
+          })[toThrow](Err),
+        ).toEqual(error);
+
+        await expect(
+          jestExpect(
+            (async () => {
+              throw error;
+            })(),
+          ).rejects[toThrow](Err),
+        ).resolves.toEqual(error);
+
+        expect(jestExpect(() => {}).not[toThrow](Err)).toBeUndefined();
+        await expect(
+          jestExpect((async () => {})()).resolves.not[toThrow](Err),
+        ).resolves.toBeUndefined();
       });
     });
 

--- a/packages/expect/src/index.ts
+++ b/packages/expect/src/index.ts
@@ -295,6 +295,8 @@ const makeThrowingMatcher = (
           getState().suppressedErrors.push(error);
         }
       }
+
+      return result.value;
     };
 
     const handlError = (error: Error) => {

--- a/packages/expect/src/toThrowMatchers.ts
+++ b/packages/expect/src/toThrowMatchers.ts
@@ -171,7 +171,9 @@ const toThrowExpectedRegExp = (
             formatStack(thrown)
           : formatReceived('Received value:   ', thrown, 'value'));
 
-  return {message, pass};
+  const value = thrown !== null ? thrown.value : undefined;
+
+  return {message, pass, value};
 };
 
 type AsymmetricMatcher = {
@@ -210,7 +212,9 @@ const toThrowExpectedAsymmetric = (
             formatStack(thrown)
           : formatReceived('Thrown value: ', thrown, 'value'));
 
-  return {message, pass};
+  const value = thrown !== null ? thrown.value : undefined;
+
+  return {message, pass, value};
 };
 
 const toThrowExpectedObject = (
@@ -249,7 +253,9 @@ const toThrowExpectedObject = (
           : formatExpected('Expected message: ', expected.message) +
             formatReceived('Received value:   ', thrown, 'value'));
 
-  return {message, pass};
+  const value = thrown !== null ? thrown.value : undefined;
+
+  return {message, pass, value};
 };
 
 const toThrowExpectedClass = (
@@ -299,7 +305,9 @@ const toThrowExpectedClass = (
                 formatStack(thrown)
               : formatReceived('Received value: ', thrown, 'value')));
 
-  return {message, pass};
+  const value = thrown !== null ? thrown.value : undefined;
+
+  return {message, pass, value};
 };
 
 const toThrowExpectedString = (
@@ -334,7 +342,9 @@ const toThrowExpectedString = (
             formatStack(thrown)
           : formatReceived('Received value:     ', thrown, 'value'));
 
-  return {message, pass};
+  const value = thrown !== null ? thrown.value : undefined;
+
+  return {message, pass, value};
 };
 
 const toThrow = (
@@ -358,7 +368,9 @@ const toThrow = (
         '\n\n' +
         DID_NOT_THROW;
 
-  return {message, pass};
+  const value = thrown !== null ? thrown.value : undefined;
+
+  return {message, pass, value};
 };
 
 const formatExpected = (label: string, expected: unknown) =>

--- a/packages/expect/src/types.ts
+++ b/packages/expect/src/types.ts
@@ -12,6 +12,7 @@ import {INTERNAL_MATCHER_FLAG} from './jestMatchersObject';
 export type SyncExpectationResult = {
   pass: boolean;
   message: () => string;
+  value: any;
 };
 
 export type AsyncExpectationResult = Promise<SyncExpectationResult>;
@@ -23,8 +24,8 @@ export type RawMatcherFn = {
   [INTERNAL_MATCHER_FLAG]?: boolean;
 };
 
-export type ThrowingMatcherFn = (actual: any) => void;
-export type PromiseMatcherFn = (actual: any) => Promise<void>;
+export type ThrowingMatcherFn = (actual: any) => any;
+export type PromiseMatcherFn = (actual: any) => Promise<any>;
 
 export type Tester = (a: any, b: any) => boolean | undefined;
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

When working with a project that uses ava I noticed their [`.throws`](https://github.com/avajs/ava/blob/master/docs/03-assertions.md#throwsfn-expected-message) and [`.throwsAsync`](https://github.com/avajs/ava/blob/master/docs/03-assertions.md#throwsasyncthrower-expected-message) return the original error. It is very convenient.

This would make it possible to never need the [`expect.hasAssertions()` + `try / catch`](https://github.com/jest-community/eslint-plugin-jest/issues/295#issuecomment-509974545) syntax.

Closes #8698.

## Test plan

Added several tests.
