### PR TITLE
fix: absolute path moduleNameMapper + jest.mock issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `[jest-config, jest-resolve]` [**BREAKING**] Remove support for `browser` field ([#9943](https://github.com/facebook/jest/pull/9943))
 - `[jest-haste-map]` Stop reporting files as changed when they are only accessed ([#7347](https://github.com/facebook/jest/pull/7347))
 - `[jest-resolve]` Show relative path from root dir for `module not found` errors ([#9963](https://github.com/facebook/jest/pull/9963))
+- `[jest-runtime]` Fix absolute path moduleNameMapper + jest.mock bug ([#8727](https://github.com/facebook/jest/pull/8727))
 
 ### Chore & Maintenance
 

--- a/e2e/__tests__/__snapshots__/moduleNameMapper.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/moduleNameMapper.test.ts.snap
@@ -5,6 +5,11 @@ PASS __tests__/index.js
   ✓ moduleNameMapping correct configuration
 `;
 
+exports[`moduleNameMapper correct configuration mocking module of absolute path 1`] = `
+PASS __tests__/index.js
+  ✓ moduleNameMapping correct configuration
+`;
+
 exports[`moduleNameMapper wrong array configuration 1`] = `
 FAIL __tests__/index.js
   ● Test suite failed to run

--- a/e2e/__tests__/moduleNameMapper.test.ts
+++ b/e2e/__tests__/moduleNameMapper.test.ts
@@ -35,6 +35,20 @@ test('moduleNameMapper correct configuration', () => {
   expect(wrap(rest)).toMatchSnapshot();
 });
 
+test('moduleNameMapper correct configuration mocking module of absolute path', () => {
+  const {stderr, exitCode} = runJest(
+    'module-name-mapper-correct-mock-absolute-path',
+    [],
+    {
+      stripAnsi: true,
+    },
+  );
+  const {rest} = extractSummary(stderr);
+
+  expect(exitCode).toBe(0);
+  expect(wrap(rest)).toMatchSnapshot();
+});
+
 test('moduleNameMapper with mocking', () => {
   const {json} = runWithJson('module-name-mapper-mock');
   expect(json.numTotalTests).toBe(2);

--- a/e2e/module-name-mapper-correct-mock-absolute-path/__tests__/index.js
+++ b/e2e/module-name-mapper-correct-mock-absolute-path/__tests__/index.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+const importedFn = require('../');
+
+jest.mock('/components/Button');
+
+test('moduleNameMapping correct configuration', () => {
+  expect(importedFn).toBeDefined();
+});

--- a/e2e/module-name-mapper-correct-mock-absolute-path/index.js
+++ b/e2e/module-name-mapper-correct-mock-absolute-path/index.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+require('/components/Button');
+
+module.exports = () => 'test';

--- a/e2e/module-name-mapper-correct-mock-absolute-path/package.json
+++ b/e2e/module-name-mapper-correct-mock-absolute-path/package.json
@@ -1,0 +1,7 @@
+{
+  "jest": {
+    "moduleNameMapper": {
+      "^/(.*)$": "<rootDir>/src/$1"
+    }
+  }
+}

--- a/e2e/module-name-mapper-correct-mock-absolute-path/src/components/Button.js
+++ b/e2e/module-name-mapper-correct-mock-absolute-path/src/components/Button.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+module.exports = () => 'Button';

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -584,12 +584,10 @@ class Runtime {
     }
 
     const manualMockOrStub = this._resolver.getMockModule(from, moduleName);
-    let modulePath;
-    if (manualMockOrStub) {
-      modulePath = this._resolveModule(from, manualMockOrStub);
-    } else {
-      modulePath = this._resolveModule(from, moduleName);
-    }
+
+    let modulePath =
+      this._resolver.getMockModule(from, moduleName) ||
+      this._resolveModule(from, moduleName);
 
     let isManualMock =
       manualMockOrStub &&


### PR DESCRIPTION
<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

In this special case, the moduleNameMapper got applied to the import path twice, resulting in an invalid module path.

still validating the changes, WIP

Fixes #8633

## Test plan

Added the absolute path moduleNameMapper test case.
