### PR TITLE
Fix console reporter

### DIFF
--- a/packages/jest-core/src/ReporterDispatcher.ts
+++ b/packages/jest-core/src/ReporterDispatcher.ts
@@ -40,7 +40,6 @@ export default class ReporterDispatcher {
     // Release memory if unused later.
     testResult.sourceMaps = undefined;
     testResult.coverage = undefined;
-    testResult.console = undefined;
   }
 
   async onTestStart(test: Test) {

--- a/packages/jest-jasmine2/src/reporter.ts
+++ b/packages/jest-jasmine2/src/reporter.ts
@@ -78,7 +78,7 @@ export default class Jasmine2Reporter implements Reporter {
     });
 
     const testResult = {
-      console: null,
+      console: undefined,
       failureMessage: formatResultsErrors(
         testResults,
         this._config,


### PR DESCRIPTION
## Summary

Fixes a bug that set result.console to undefined for jest reporters. Seen here.

https://github.com/jest-community/jest-junit/issues/45
https://github.com/facebook/jest/issues/8499

## Test plan

See that a jest reporter shows console data for suites with > 1 test.