### PR TITLE
Cache JestHook emitters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@
 
 ### Performance
 
+- `[jest-watcher]` Minor optimization for JestHook ([#8746](https://github.com/facebook/jest/pull/8746)
+
 ## 24.8.0
 
 ### Features

--- a/packages/jest-watcher/src/JestHooks.ts
+++ b/packages/jest-watcher/src/JestHooks.ts
@@ -25,20 +25,17 @@ class JestHooks {
     shouldRunTestSuite: Array<ShouldRunTestSuite>;
   };
 
+  private _subscriber: JestHookSubscriber;
+  private _emitter: JestHookEmitter;
+
   constructor() {
     this._listeners = {
       onFileChange: [],
       onTestRunComplete: [],
       shouldRunTestSuite: [],
     };
-  }
 
-  isUsed(hook: AvailableHooks) {
-    return this._listeners[hook] && this._listeners[hook].length;
-  }
-
-  getSubscriber(): JestHookSubscriber {
-    return {
+    this._subscriber = {
       onFileChange: fn => {
         this._listeners.onFileChange.push(fn);
       },
@@ -49,10 +46,8 @@ class JestHooks {
         this._listeners.shouldRunTestSuite.push(fn);
       },
     };
-  }
 
-  getEmitter(): JestHookEmitter {
-    return {
+    this._emitter = {
       onFileChange: fs =>
         this._listeners.onFileChange.forEach(listener => listener(fs)),
       onTestRunComplete: results =>
@@ -69,6 +64,18 @@ class JestHooks {
         return result.every(Boolean);
       },
     };
+  }
+
+  isUsed(hook: AvailableHooks) {
+    return this._listeners[hook] && this._listeners[hook].length;
+  }
+
+  getSubscriber(): Readonly<JestHookSubscriber> {
+    return this._subscriber;
+  }
+
+  getEmitter(): Readonly<JestHookEmitter> {
+    return this._emitter;
   }
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary
Just cached `JestHookSubscriber` and `JestHookEmitter` to avoid creating new object on each `getSubscriber()`, `getEmitter()` calls.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
