### PR TITLE
feat: allow test environment to run with preset/transform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - `[jest-config]` [**BREAKING**] Default to Node testing environment instead of browser (JSDOM) ([#9874](https://github.com/facebook/jest/pull/9874))
 - `[jest-runner]` [**BREAKING**] set exit code to 1 if test logs after teardown ([#10728](https://github.com/facebook/jest/pull/10728))
 - `[jest-snapshot]`: [**BREAKING**] Make prettier optional for inline snapshots - fall back to string replacement ([#7792](https://github.com/facebook/jest/pull/7792))
+- `[jest-repl, jest-runner]` [**BREAKING**] Run transforms over environment ([#8751](https://github.com/facebook/jest/pull/8751))
 
 ### Fixes
 

--- a/e2e/__tests__/transform.test.ts
+++ b/e2e/__tests__/transform.test.ts
@@ -205,3 +205,14 @@ describe('transformer caching', () => {
     expect(loggedFiles).toHaveLength(2);
   });
 });
+
+describe('transform-environment', () => {
+  const dir = path.resolve(__dirname, '../transform/transform-environment');
+
+  it('should transform the environment', () => {
+    const {json, stderr} = runWithJson(dir, ['--no-cache']);
+    expect(stderr).toMatch(/PASS/);
+    expect(json.success).toBe(true);
+    expect(json.numPassedTests).toBe(1);
+  });
+});

--- a/e2e/babel-plugin-jest-hoist/package.json
+++ b/e2e/babel-plugin-jest-hoist/package.json
@@ -7,6 +7,9 @@
   },
   "jest": {
     "automock": true,
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "transformIgnorePatterns": [
+      "/jest-environment-node/"
+    ]
   }
 }

--- a/e2e/coverage-transform-instrumented/package.json
+++ b/e2e/coverage-transform-instrumented/package.json
@@ -6,6 +6,9 @@
     },
     "testRegex": "/__tests__/.*\\.(js)$",
     "testEnvironment": "node",
+    "transformIgnorePatterns": [
+      "/jest-environment-node/"
+    ],
     "moduleFileExtensions": [
       "js"
     ]

--- a/e2e/transform-linked-modules/package.json
+++ b/e2e/transform-linked-modules/package.json
@@ -4,7 +4,8 @@
     "transformIgnorePatterns": [
       "/node_modules/",
       "<rootDir>/__tests__",
-      "<rootDir>/ignored/"
+      "<rootDir>/ignored/",
+      "/jest-environment-node/"
     ],
     "transform": {
       "\\.js$": "<rootDir>/preprocessor.js"

--- a/e2e/transform/multiple-transformers/package.json
+++ b/e2e/transform/multiple-transformers/package.json
@@ -5,7 +5,10 @@
       "\\.js$": "<rootDir>/jsPreprocessor.js",
       "\\.svg$": "<rootDir>/filePreprocessor.js"
     },
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "transformIgnorePatterns": [
+      "/jest-environment-node/"
+    ]
   },
   "dependencies": {
     "@babel/core": "^7.0.0",

--- a/e2e/transform/transform-environment/__tests__/add.test.js
+++ b/e2e/transform/transform-environment/__tests__/add.test.js
@@ -5,4 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-module.exports = {only: ['blablabla', /jest-environment-node/]};
+it('should add two numbers', () => {
+  // eslint-disable-next-line no-undef
+  expect(one + 1).toBe(2);
+});

--- a/e2e/transform/transform-environment/babel.config.js
+++ b/e2e/transform/transform-environment/babel.config.js
@@ -5,4 +5,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-module.exports = {only: ['blablabla', /jest-environment-node/]};
+module.exports = {
+  presets: [
+    ['@babel/preset-typescript'],
+    [
+      '@babel/preset-env',
+      {
+        targets: {node: 8},
+      },
+    ],
+  ],
+};

--- a/e2e/transform/transform-environment/babel.config.js
+++ b/e2e/transform/transform-environment/babel.config.js
@@ -7,12 +7,7 @@
 
 module.exports = {
   presets: [
-    ['@babel/preset-typescript'],
-    [
-      '@babel/preset-env',
-      {
-        targets: {node: 8},
-      },
-    ],
+    ['@babel/preset-env', {targets: {node: 'current'}}],
+    '@babel/preset-typescript',
   ],
 };

--- a/e2e/transform/transform-environment/environment.ts
+++ b/e2e/transform/transform-environment/environment.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {Config} from '@jest/types';
+import type {Config} from '@jest/types';
 import NodeEnvironment from 'jest-environment-node';
 
 export default class CustomEnvironment extends NodeEnvironment {

--- a/e2e/transform/transform-environment/environment.ts
+++ b/e2e/transform/transform-environment/environment.ts
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {Config} from '@jest/types';
+import NodeEnvironment from 'jest-environment-node';
+
+export default class CustomEnvironment extends NodeEnvironment {
+  constructor(config: Config.ProjectConfig) {
+    super(config);
+    this.global.one = 1;
+  }
+}

--- a/e2e/transform/transform-environment/package.json
+++ b/e2e/transform/transform-environment/package.json
@@ -9,6 +9,6 @@
   "dependencies": {
     "@babel/preset-env": "^7.0.0",
     "@babel/preset-typescript": "^7.0.0",
-    "jest-environment-node": "^24.9.0"
+    "jest-environment-node": "^26.6.2"
   }
 }

--- a/e2e/transform/transform-environment/package.json
+++ b/e2e/transform/transform-environment/package.json
@@ -1,0 +1,14 @@
+{
+  "jest": {
+    "testEnvironment": "<rootDir>/environment.ts",
+    "transformIgnorePatterns": [
+      "jest-environment-node"
+    ],
+    "rootDir": "./"
+  },
+  "dependencies": {
+    "@babel/preset-env": "^7.0.0",
+    "@babel/preset-typescript": "^7.0.0",
+    "jest-environment-node": "^24.9.0"
+  }
+}

--- a/e2e/transform/transform-environment/tsconfig.json
+++ b/e2e/transform/transform-environment/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "esModuleInterop": true,
+    "module": "commonjs",
+  }
+}

--- a/e2e/v8-coverage/empty-sourcemap/babel.config.js
+++ b/e2e/v8-coverage/empty-sourcemap/babel.config.js
@@ -7,12 +7,7 @@
 
 module.exports = {
   presets: [
-    ['@babel/preset-typescript'],
-    [
-      '@babel/preset-env',
-      {
-        targets: {node: 8},
-      },
-    ],
+    ['@babel/preset-env', {targets: {node: 'current'}}],
+    '@babel/preset-typescript',
   ],
 };

--- a/e2e/v8-coverage/empty-sourcemap/babel.config.js
+++ b/e2e/v8-coverage/empty-sourcemap/babel.config.js
@@ -6,5 +6,13 @@
  */
 
 module.exports = {
-  presets: ['@babel/preset-env', '@babel/preset-typescript'],
+  presets: [
+    ['@babel/preset-typescript'],
+    [
+      '@babel/preset-env',
+      {
+        targets: {node: 8},
+      },
+    ],
+  ],
 };

--- a/e2e/v8-coverage/no-sourcemap/package.json
+++ b/e2e/v8-coverage/no-sourcemap/package.json
@@ -6,6 +6,9 @@
     "transform": {
       "\\.[jt]sx?$": "babel-jest",
       "\\.css$": "<rootDir>/cssTransform.js"
-    }
+    },
+    "transformIgnorePatterns": [
+      "jest-environment-node"
+    ]
   }
 }

--- a/e2e/v8-coverage/no-sourcemap/package.json
+++ b/e2e/v8-coverage/no-sourcemap/package.json
@@ -6,9 +6,6 @@
     "transform": {
       "\\.[jt]sx?$": "babel-jest",
       "\\.css$": "<rootDir>/cssTransform.js"
-    },
-    "transformIgnorePatterns": [
-      "jest-environment-node"
-    ]
+    }
   }
 }

--- a/packages/jest-repl/src/cli/runtime-cli.ts
+++ b/packages/jest-repl/src/cli/runtime-cli.ts
@@ -11,10 +11,11 @@ import chalk = require('chalk');
 import yargs = require('yargs');
 import {CustomConsole} from '@jest/console';
 import type {JestEnvironment} from '@jest/environment';
+import {ScriptTransformer} from '@jest/transform';
 import type {Config} from '@jest/types';
 import {deprecationEntries, readConfig} from 'jest-config';
 import Runtime from 'jest-runtime';
-import {setGlobal, tryRealpath} from 'jest-util';
+import {interopRequireDefault, setGlobal, tryRealpath} from 'jest-util';
 import {validateCLIOptions} from 'jest-validate';
 import * as args from './args';
 import {VERSION} from './version';
@@ -73,7 +74,10 @@ export async function run(
       watchman: globalConfig.watchman,
     });
 
-    const Environment: typeof JestEnvironment = require(config.testEnvironment);
+    const transformer = new ScriptTransformer(config);
+    const Environment: typeof JestEnvironment = interopRequireDefault(
+      transformer.requireAndTranspileModule(config.testEnvironment),
+    ).default;
     const environment = new Environment(config);
     setGlobal(
       environment.global,

--- a/packages/jest-runner/src/runTest.ts
+++ b/packages/jest-runner/src/runTest.ts
@@ -19,6 +19,7 @@ import {
 } from '@jest/console';
 import type {JestEnvironment} from '@jest/environment';
 import type {TestResult} from '@jest/test-result';
+import {ScriptTransformer} from '@jest/transform';
 import type {Config} from '@jest/types';
 import {getTestEnvironment} from 'jest-config';
 import * as docblock from 'jest-docblock';
@@ -102,8 +103,9 @@ async function runTestInternal(
     });
   }
 
+  const transformer = new ScriptTransformer(config);
   const TestEnvironment: typeof JestEnvironment = interopRequireDefault(
-    require(testEnvironment),
+    transformer.requireAndTranspileModule(testEnvironment),
   ).default;
   const testFramework: TestFramework = interopRequireDefault(
     process.env.JEST_CIRCUS === '1'

--- a/packages/jest-runner/tsconfig.json
+++ b/packages/jest-runner/tsconfig.json
@@ -15,6 +15,7 @@
     {"path": "../jest-resolve"},
     {"path": "../jest-runtime"},
     {"path": "../jest-test-result"},
+    {"path": "../jest-transform"},
     {"path": "../jest-types"},
     {"path": "../jest-worker"},
     {"path": "../jest-util"}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Fixes #8479. The exact same approach as #7562. 
- Using the `Runtime` create an instance of `Transformer`
- Hijack the `require` and perform the transform
- Remove the hook on `require`

As of now the logic for the transformation is repeated across `jest-cli`, `jest-runner`, `jest-runtime` packages. Can you give me some inputs on whether it can be extracted to a single location?

## Test plan

Existing test cases should not be affected by the change, an additional test where the environment needs to be transformed to pass is added.
