### PR TITLE
expect: Improve report when negative CalledWith assertion fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `[expect]` Improve report when mock-spy matcher fails, part 3 ([#8697](https://github.com/facebook/jest/pull/8697))
 - `[expect]` Improve report when mock-spy matcher fails, part 4 ([#8710](https://github.com/facebook/jest/pull/8710))
 - `[expect]` Throw matcher error when received cannot be jasmine spy ([#8747](https://github.com/facebook/jest/pull/8747))
+- `[expect]` Improve report when negative CalledWith assertion fails ([#8755](https://github.com/facebook/jest/pull/8755))
 - `[jest-snapshot]` Highlight substring differences when matcher fails, part 3 ([#8569](https://github.com/facebook/jest/pull/8569))
 - `[jest-cli]` Improve chai support (with detailed output, to match jest exceptions) ([#8454](https://github.com/facebook/jest/pull/8454))
 - `[*]` Manage the global timeout with `--testTimeout` command line argument. ([#8456](https://github.com/facebook/jest/pull/8456))

--- a/packages/expect/src/__tests__/__snapshots__/spyMatchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/spyMatchers.test.js.snap
@@ -114,7 +114,7 @@ exports[`lastCalledWith works with many arguments 1`] = `
 Expected: not <green>\\"foo\\"</>, <green>\\"bar\\"</>
 Received
        2:     <red>\\"foo\\"</>, <red>\\"bar1\\"</>
-       3:     <red>\\"foo\\"</>, <red>\\"bar\\"</>
+->     3:     <red>\\"foo\\"</>, <red>\\"bar\\"</>
 
 Number of calls: <red>3</>"
 `;
@@ -1508,7 +1508,7 @@ exports[`toHaveBeenLastCalledWith works with many arguments 1`] = `
 Expected: not <green>\\"foo\\"</>, <green>\\"bar\\"</>
 Received
        2:     <red>\\"foo\\"</>, <red>\\"bar1\\"</>
-       3:     <red>\\"foo\\"</>, <red>\\"bar\\"</>
+->     3:     <red>\\"foo\\"</>, <red>\\"bar\\"</>
 
 Number of calls: <red>3</>"
 `;

--- a/packages/expect/src/__tests__/__snapshots__/spyMatchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/spyMatchers.test.js.snap
@@ -113,8 +113,8 @@ exports[`lastCalledWith works with many arguments 1`] = `
 
 Expected: not <green>\\"foo\\"</>, <green>\\"bar\\"</>
 Received
-       2:     <red>\\"foo\\"</>, <red>\\"bar1\\"</>
-->     3:     <red>\\"foo\\"</>, <red>\\"bar\\"</>
+       2:     <dim>\\"foo\\"</>, <red>\\"bar1\\"</>
+->     3:     <dim>\\"foo\\"</>, <dim>\\"bar\\"</>
 
 Number of calls: <red>3</>"
 `;
@@ -314,27 +314,6 @@ n has type:  number
 n has value: <green>0</>"
 `;
 
-exports[`nthCalledWith should replace 1st, 2nd, 3rd with first, second, third 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).nthCalledWith(</><green>expected</><dim>)</>
-
-Expected mock function first call to have been called with:
-  <green>\\"foo\\"</>
-as argument 1, but it was called with
-  <red>\\"foo1\\"</>."
-`;
-
-exports[`nthCalledWith should replace 1st, 2nd, 3rd with first, second, third 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthCalledWith<dim>(</><green>n</><dim>, </><green>...expected</><dim>)</>
-
-n: 1
-Expected: not <green>\\"foo1\\"</>, <green>\\"bar\\"</>
-Received
-->     1:     <red>\\"foo1\\"</>, <red>\\"bar\\"</>
-       2:     <red>\\"foo\\"</>, <red>\\"bar1\\"</>
-
-Number of calls: <red>3</>"
-`;
-
 exports[`nthCalledWith works only on spies or jest.fn 1`] = `
 "<dim>expect(</><red>received</><dim>).</>nthCalledWith<dim>(</><green>n</><dim>, </><green>...expected</><dim>)</>
 
@@ -445,7 +424,7 @@ exports[`nthCalledWith works with three calls 1`] = `
 n: 1
 Expected: not <green>\\"foo1\\"</>, <green>\\"bar\\"</>
 Received
-->     1:     <red>\\"foo1\\"</>, <red>\\"bar\\"</>
+->     1:     <dim>\\"foo1\\"</>, <dim>\\"bar\\"</>
        2:     <red>\\"foo\\"</>, <red>\\"bar1\\"</>
 
 Number of calls: <red>3</>"
@@ -1027,7 +1006,7 @@ exports[`toBeCalledWith works with many arguments 1`] = `
 
 Expected: not <green>\\"foo\\"</>, <green>\\"bar\\"</>
 Received
-       3:     <red>\\"foo\\"</>, <red>\\"bar\\"</>
+       3:     <dim>\\"foo\\"</>, <dim>\\"bar\\"</>
 
 Number of calls: <red>3</>"
 `;
@@ -1365,7 +1344,7 @@ exports[`toHaveBeenCalledWith works with many arguments 1`] = `
 
 Expected: not <green>\\"foo\\"</>, <green>\\"bar\\"</>
 Received
-       3:     <red>\\"foo\\"</>, <red>\\"bar\\"</>
+       3:     <dim>\\"foo\\"</>, <dim>\\"bar\\"</>
 
 Number of calls: <red>3</>"
 `;
@@ -1507,8 +1486,8 @@ exports[`toHaveBeenLastCalledWith works with many arguments 1`] = `
 
 Expected: not <green>\\"foo\\"</>, <green>\\"bar\\"</>
 Received
-       2:     <red>\\"foo\\"</>, <red>\\"bar1\\"</>
-->     3:     <red>\\"foo\\"</>, <red>\\"bar\\"</>
+       2:     <dim>\\"foo\\"</>, <red>\\"bar1\\"</>
+->     3:     <dim>\\"foo\\"</>, <dim>\\"bar\\"</>
 
 Number of calls: <red>3</>"
 `;
@@ -1563,27 +1542,6 @@ exports[`toHaveBeenNthCalledWith positive throw matcher error for n that is not 
 
 n has type:  number
 n has value: <green>0</>"
-`;
-
-exports[`toHaveBeenNthCalledWith should replace 1st, 2nd, 3rd with first, second, third 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toHaveBeenNthCalledWith(</><green>expected</><dim>)</>
-
-Expected mock function first call to have been called with:
-  <green>\\"foo\\"</>
-as argument 1, but it was called with
-  <red>\\"foo1\\"</>."
-`;
-
-exports[`toHaveBeenNthCalledWith should replace 1st, 2nd, 3rd with first, second, third 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveBeenNthCalledWith<dim>(</><green>n</><dim>, </><green>...expected</><dim>)</>
-
-n: 1
-Expected: not <green>\\"foo1\\"</>, <green>\\"bar\\"</>
-Received
-->     1:     <red>\\"foo1\\"</>, <red>\\"bar\\"</>
-       2:     <red>\\"foo\\"</>, <red>\\"bar1\\"</>
-
-Number of calls: <red>3</>"
 `;
 
 exports[`toHaveBeenNthCalledWith works only on spies or jest.fn 1`] = `
@@ -1696,7 +1654,7 @@ exports[`toHaveBeenNthCalledWith works with three calls 1`] = `
 n: 1
 Expected: not <green>\\"foo1\\"</>, <green>\\"bar\\"</>
 Received
-->     1:     <red>\\"foo1\\"</>, <red>\\"bar\\"</>
+->     1:     <dim>\\"foo1\\"</>, <dim>\\"bar\\"</>
        2:     <red>\\"foo\\"</>, <red>\\"bar1\\"</>
 
 Number of calls: <red>3</>"

--- a/packages/expect/src/__tests__/__snapshots__/spyMatchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/spyMatchers.test.js.snap
@@ -1,10 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`lastCalledWith includes the custom mock name in the error message 1`] = `
-"<dim>expect(</><red>named-mock</><dim>).not.lastCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>named-mock</><dim>).</>not<dim>.</>lastCalledWith<dim>(</><green>...expected</><dim>)</>
 
-Expected mock function \\"named-mock\\" to not have been last called with:
-  <green>[\\"foo\\", \\"bar\\"]</>"
+Expected: not <green>\\"foo\\"</>, <green>\\"bar\\"</>
+
+Number of calls: <red>1</>"
 `;
 
 exports[`lastCalledWith works only on spies or jest.fn 1`] = `
@@ -25,17 +26,19 @@ But it was <red>not called</>."
 `;
 
 exports[`lastCalledWith works with Immutable.js objects 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.lastCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>lastCalledWith<dim>(</><green>...expected</><dim>)</>
 
-Expected mock function to not have been last called with:
-  <green>[Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}, Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}]</>"
+Expected: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>, <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
+
+Number of calls: <red>1</>"
 `;
 
 exports[`lastCalledWith works with Map 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.lastCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>lastCalledWith<dim>(</><green>...expected</><dim>)</>
 
-Expected mock function to not have been last called with:
-  <green>[Map {1 => 2, 2 => 1}]</>"
+Expected: not <green>Map {1 => 2, 2 => 1}</>
+
+Number of calls: <red>1</>"
 `;
 
 exports[`lastCalledWith works with Map 2`] = `
@@ -60,10 +63,11 @@ Difference:
 `;
 
 exports[`lastCalledWith works with Set 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.lastCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>lastCalledWith<dim>(</><green>...expected</><dim>)</>
 
-Expected mock function to not have been last called with:
-  <green>[Set {1, 2}]</>"
+Expected: not <green>Set {1, 2}</>
+
+Number of calls: <red>1</>"
 `;
 
 exports[`lastCalledWith works with Set 2`] = `
@@ -97,17 +101,22 @@ as argument 2, but it was called with
 `;
 
 exports[`lastCalledWith works with arguments that match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.lastCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>lastCalledWith<dim>(</><green>...expected</><dim>)</>
 
-Expected mock function to not have been last called with:
-  <green>[\\"foo\\", \\"bar\\"]</>"
+Expected: not <green>\\"foo\\"</>, <green>\\"bar\\"</>
+
+Number of calls: <red>1</>"
 `;
 
 exports[`lastCalledWith works with many arguments 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.lastCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>lastCalledWith<dim>(</><green>...expected</><dim>)</>
 
-Expected mock function to not have been last called with:
-  <green>[\\"foo\\", \\"bar\\"]</>"
+Expected: not <green>\\"foo\\"</>, <green>\\"bar\\"</>
+Received
+       2:     <red>\\"foo\\"</>, <red>\\"bar1\\"</>
+       3:     <red>\\"foo\\"</>, <red>\\"bar\\"</>
+
+Number of calls: <red>3</>"
 `;
 
 exports[`lastCalledWith works with many arguments that don't match 1`] = `
@@ -270,10 +279,12 @@ Number of returns: <red>1</>"
 `;
 
 exports[`nthCalledWith includes the custom mock name in the error message 1`] = `
-"<dim>expect(</><red>named-mock</><dim>).not.nthCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>named-mock</><dim>).</>not<dim>.</>nthCalledWith<dim>(</><green>n</><dim>, </><green>...expected</><dim>)</>
 
-Expected mock function \\"named-mock\\" first call to not have been called with:
-  <green>[\\"foo\\", \\"bar\\"]</>"
+n: 1
+Expected: not <green>\\"foo\\"</>, <green>\\"bar\\"</>
+
+Number of calls: <red>1</>"
 `;
 
 exports[`nthCalledWith negative throw matcher error for n that is not integer 1`] = `
@@ -313,10 +324,15 @@ as argument 1, but it was called with
 `;
 
 exports[`nthCalledWith should replace 1st, 2nd, 3rd with first, second, third 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.nthCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthCalledWith<dim>(</><green>n</><dim>, </><green>...expected</><dim>)</>
 
-Expected mock function first call to not have been called with:
-  <green>[\\"foo1\\", \\"bar\\"]</>"
+n: 1
+Expected: not <green>\\"foo1\\"</>, <green>\\"bar\\"</>
+Received
+->     1:     <red>\\"foo1\\"</>, <red>\\"bar\\"</>
+       2:     <red>\\"foo\\"</>, <red>\\"bar1\\"</>
+
+Number of calls: <red>3</>"
 `;
 
 exports[`nthCalledWith works only on spies or jest.fn 1`] = `
@@ -337,17 +353,21 @@ But it was <red>not called</>."
 `;
 
 exports[`nthCalledWith works with Immutable.js objects 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.nthCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthCalledWith<dim>(</><green>n</><dim>, </><green>...expected</><dim>)</>
 
-Expected mock function first call to not have been called with:
-  <green>[Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}, Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}]</>"
+n: 1
+Expected: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>, <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
+
+Number of calls: <red>1</>"
 `;
 
 exports[`nthCalledWith works with Map 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.nthCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthCalledWith<dim>(</><green>n</><dim>, </><green>...expected</><dim>)</>
 
-Expected mock function first call to not have been called with:
-  <green>[Map {1 => 2, 2 => 1}]</>"
+n: 1
+Expected: not <green>Map {1 => 2, 2 => 1}</>
+
+Number of calls: <red>1</>"
 `;
 
 exports[`nthCalledWith works with Map 2`] = `
@@ -372,10 +392,12 @@ Difference:
 `;
 
 exports[`nthCalledWith works with Set 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.nthCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthCalledWith<dim>(</><green>n</><dim>, </><green>...expected</><dim>)</>
 
-Expected mock function first call to not have been called with:
-  <green>[Set {1, 2}]</>"
+n: 1
+Expected: not <green>Set {1, 2}</>
+
+Number of calls: <red>1</>"
 `;
 
 exports[`nthCalledWith works with Set 2`] = `
@@ -409,17 +431,24 @@ as argument 2, but it was called with
 `;
 
 exports[`nthCalledWith works with arguments that match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.nthCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthCalledWith<dim>(</><green>n</><dim>, </><green>...expected</><dim>)</>
 
-Expected mock function first call to not have been called with:
-  <green>[\\"foo\\", \\"bar\\"]</>"
+n: 1
+Expected: not <green>\\"foo\\"</>, <green>\\"bar\\"</>
+
+Number of calls: <red>1</>"
 `;
 
 exports[`nthCalledWith works with three calls 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.nthCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthCalledWith<dim>(</><green>n</><dim>, </><green>...expected</><dim>)</>
 
-Expected mock function first call to not have been called with:
-  <green>[\\"foo1\\", \\"bar\\"]</>"
+n: 1
+Expected: not <green>\\"foo1\\"</>, <green>\\"bar\\"</>
+Received
+->     1:     <red>\\"foo1\\"</>, <red>\\"bar\\"</>
+       2:     <red>\\"foo\\"</>, <red>\\"bar1\\"</>
+
+Number of calls: <red>3</>"
 `;
 
 exports[`nthCalledWith works with trailing undefined arguments 1`] = `
@@ -720,7 +749,7 @@ exports[`toBeCalled includes the custom mock name in the error message 1`] = `
 Expected number of calls: <green>0</>
 Received number of calls: <red>1</>
 
-1: called with no arguments"
+1: called with 0 arguments"
 `;
 
 exports[`toBeCalled passes when called 1`] = `
@@ -886,10 +915,11 @@ Expected number of calls: not <green>2</>"
 `;
 
 exports[`toBeCalledWith includes the custom mock name in the error message 1`] = `
-"<dim>expect(</><red>named-mock</><dim>).not.toBeCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>named-mock</><dim>).</>not<dim>.</>toBeCalledWith<dim>(</><green>...expected</><dim>)</>
 
-Expected mock function \\"named-mock\\" not to have been called with:
-  <green>[\\"foo\\", \\"bar\\"]</>"
+Expected: not <green>\\"foo\\"</>, <green>\\"bar\\"</>
+
+Number of calls: <red>1</>"
 `;
 
 exports[`toBeCalledWith works only on spies or jest.fn 1`] = `
@@ -910,17 +940,19 @@ But it was <red>not called</>."
 `;
 
 exports[`toBeCalledWith works with Immutable.js objects 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toBeCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toBeCalledWith<dim>(</><green>...expected</><dim>)</>
 
-Expected mock function not to have been called with:
-  <green>[Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}, Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}]</>"
+Expected: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>, <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
+
+Number of calls: <red>1</>"
 `;
 
 exports[`toBeCalledWith works with Map 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toBeCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toBeCalledWith<dim>(</><green>...expected</><dim>)</>
 
-Expected mock function not to have been called with:
-  <green>[Map {1 => 2, 2 => 1}]</>"
+Expected: not <green>Map {1 => 2, 2 => 1}</>
+
+Number of calls: <red>1</>"
 `;
 
 exports[`toBeCalledWith works with Map 2`] = `
@@ -945,10 +977,11 @@ Difference:
 `;
 
 exports[`toBeCalledWith works with Set 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toBeCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toBeCalledWith<dim>(</><green>...expected</><dim>)</>
 
-Expected mock function not to have been called with:
-  <green>[Set {1, 2}]</>"
+Expected: not <green>Set {1, 2}</>
+
+Number of calls: <red>1</>"
 `;
 
 exports[`toBeCalledWith works with Set 2`] = `
@@ -982,17 +1015,21 @@ as argument 2, but it was called with
 `;
 
 exports[`toBeCalledWith works with arguments that match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toBeCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toBeCalledWith<dim>(</><green>...expected</><dim>)</>
 
-Expected mock function not to have been called with:
-  <green>[\\"foo\\", \\"bar\\"]</>"
+Expected: not <green>\\"foo\\"</>, <green>\\"bar\\"</>
+
+Number of calls: <red>1</>"
 `;
 
 exports[`toBeCalledWith works with many arguments 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toBeCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toBeCalledWith<dim>(</><green>...expected</><dim>)</>
 
-Expected mock function not to have been called with:
-  <green>[\\"foo\\", \\"bar\\"]</>"
+Expected: not <green>\\"foo\\"</>, <green>\\"bar\\"</>
+Received
+       3:     <red>\\"foo\\"</>, <red>\\"bar\\"</>
+
+Number of calls: <red>3</>"
 `;
 
 exports[`toBeCalledWith works with many arguments that don't match 1`] = `
@@ -1050,7 +1087,7 @@ exports[`toHaveBeenCalled includes the custom mock name in the error message 1`]
 Expected number of calls: <green>0</>
 Received number of calls: <red>1</>
 
-1: called with no arguments"
+1: called with 0 arguments"
 `;
 
 exports[`toHaveBeenCalled passes when called 1`] = `
@@ -1216,10 +1253,11 @@ Expected number of calls: not <green>2</>"
 `;
 
 exports[`toHaveBeenCalledWith includes the custom mock name in the error message 1`] = `
-"<dim>expect(</><red>named-mock</><dim>).not.toHaveBeenCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>named-mock</><dim>).</>not<dim>.</>toHaveBeenCalledWith<dim>(</><green>...expected</><dim>)</>
 
-Expected mock function \\"named-mock\\" not to have been called with:
-  <green>[\\"foo\\", \\"bar\\"]</>"
+Expected: not <green>\\"foo\\"</>, <green>\\"bar\\"</>
+
+Number of calls: <red>1</>"
 `;
 
 exports[`toHaveBeenCalledWith works only on spies or jest.fn 1`] = `
@@ -1240,17 +1278,19 @@ But it was <red>not called</>."
 `;
 
 exports[`toHaveBeenCalledWith works with Immutable.js objects 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toHaveBeenCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveBeenCalledWith<dim>(</><green>...expected</><dim>)</>
 
-Expected mock function not to have been called with:
-  <green>[Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}, Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}]</>"
+Expected: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>, <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
+
+Number of calls: <red>1</>"
 `;
 
 exports[`toHaveBeenCalledWith works with Map 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toHaveBeenCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveBeenCalledWith<dim>(</><green>...expected</><dim>)</>
 
-Expected mock function not to have been called with:
-  <green>[Map {1 => 2, 2 => 1}]</>"
+Expected: not <green>Map {1 => 2, 2 => 1}</>
+
+Number of calls: <red>1</>"
 `;
 
 exports[`toHaveBeenCalledWith works with Map 2`] = `
@@ -1275,10 +1315,11 @@ Difference:
 `;
 
 exports[`toHaveBeenCalledWith works with Set 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toHaveBeenCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveBeenCalledWith<dim>(</><green>...expected</><dim>)</>
 
-Expected mock function not to have been called with:
-  <green>[Set {1, 2}]</>"
+Expected: not <green>Set {1, 2}</>
+
+Number of calls: <red>1</>"
 `;
 
 exports[`toHaveBeenCalledWith works with Set 2`] = `
@@ -1312,17 +1353,21 @@ as argument 2, but it was called with
 `;
 
 exports[`toHaveBeenCalledWith works with arguments that match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toHaveBeenCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveBeenCalledWith<dim>(</><green>...expected</><dim>)</>
 
-Expected mock function not to have been called with:
-  <green>[\\"foo\\", \\"bar\\"]</>"
+Expected: not <green>\\"foo\\"</>, <green>\\"bar\\"</>
+
+Number of calls: <red>1</>"
 `;
 
 exports[`toHaveBeenCalledWith works with many arguments 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toHaveBeenCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveBeenCalledWith<dim>(</><green>...expected</><dim>)</>
 
-Expected mock function not to have been called with:
-  <green>[\\"foo\\", \\"bar\\"]</>"
+Expected: not <green>\\"foo\\"</>, <green>\\"bar\\"</>
+Received
+       3:     <red>\\"foo\\"</>, <red>\\"bar\\"</>
+
+Number of calls: <red>3</>"
 `;
 
 exports[`toHaveBeenCalledWith works with many arguments that don't match 1`] = `
@@ -1350,10 +1395,11 @@ Expected mock function to have been called with:
 `;
 
 exports[`toHaveBeenLastCalledWith includes the custom mock name in the error message 1`] = `
-"<dim>expect(</><red>named-mock</><dim>).not.toHaveBeenLastCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>named-mock</><dim>).</>not<dim>.</>toHaveBeenLastCalledWith<dim>(</><green>...expected</><dim>)</>
 
-Expected mock function \\"named-mock\\" to not have been last called with:
-  <green>[\\"foo\\", \\"bar\\"]</>"
+Expected: not <green>\\"foo\\"</>, <green>\\"bar\\"</>
+
+Number of calls: <red>1</>"
 `;
 
 exports[`toHaveBeenLastCalledWith works only on spies or jest.fn 1`] = `
@@ -1374,17 +1420,19 @@ But it was <red>not called</>."
 `;
 
 exports[`toHaveBeenLastCalledWith works with Immutable.js objects 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toHaveBeenLastCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveBeenLastCalledWith<dim>(</><green>...expected</><dim>)</>
 
-Expected mock function to not have been last called with:
-  <green>[Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}, Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}]</>"
+Expected: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>, <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
+
+Number of calls: <red>1</>"
 `;
 
 exports[`toHaveBeenLastCalledWith works with Map 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toHaveBeenLastCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveBeenLastCalledWith<dim>(</><green>...expected</><dim>)</>
 
-Expected mock function to not have been last called with:
-  <green>[Map {1 => 2, 2 => 1}]</>"
+Expected: not <green>Map {1 => 2, 2 => 1}</>
+
+Number of calls: <red>1</>"
 `;
 
 exports[`toHaveBeenLastCalledWith works with Map 2`] = `
@@ -1409,10 +1457,11 @@ Difference:
 `;
 
 exports[`toHaveBeenLastCalledWith works with Set 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toHaveBeenLastCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveBeenLastCalledWith<dim>(</><green>...expected</><dim>)</>
 
-Expected mock function to not have been last called with:
-  <green>[Set {1, 2}]</>"
+Expected: not <green>Set {1, 2}</>
+
+Number of calls: <red>1</>"
 `;
 
 exports[`toHaveBeenLastCalledWith works with Set 2`] = `
@@ -1446,17 +1495,22 @@ as argument 2, but it was called with
 `;
 
 exports[`toHaveBeenLastCalledWith works with arguments that match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toHaveBeenLastCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveBeenLastCalledWith<dim>(</><green>...expected</><dim>)</>
 
-Expected mock function to not have been last called with:
-  <green>[\\"foo\\", \\"bar\\"]</>"
+Expected: not <green>\\"foo\\"</>, <green>\\"bar\\"</>
+
+Number of calls: <red>1</>"
 `;
 
 exports[`toHaveBeenLastCalledWith works with many arguments 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toHaveBeenLastCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveBeenLastCalledWith<dim>(</><green>...expected</><dim>)</>
 
-Expected mock function to not have been last called with:
-  <green>[\\"foo\\", \\"bar\\"]</>"
+Expected: not <green>\\"foo\\"</>, <green>\\"bar\\"</>
+Received
+       2:     <red>\\"foo\\"</>, <red>\\"bar1\\"</>
+       3:     <red>\\"foo\\"</>, <red>\\"bar\\"</>
+
+Number of calls: <red>3</>"
 `;
 
 exports[`toHaveBeenLastCalledWith works with many arguments that don't match 1`] = `
@@ -1476,10 +1530,12 @@ Expected mock function to have been last called with:
 `;
 
 exports[`toHaveBeenNthCalledWith includes the custom mock name in the error message 1`] = `
-"<dim>expect(</><red>named-mock</><dim>).not.toHaveBeenNthCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>named-mock</><dim>).</>not<dim>.</>toHaveBeenNthCalledWith<dim>(</><green>n</><dim>, </><green>...expected</><dim>)</>
 
-Expected mock function \\"named-mock\\" first call to not have been called with:
-  <green>[\\"foo\\", \\"bar\\"]</>"
+n: 1
+Expected: not <green>\\"foo\\"</>, <green>\\"bar\\"</>
+
+Number of calls: <red>1</>"
 `;
 
 exports[`toHaveBeenNthCalledWith negative throw matcher error for n that is not integer 1`] = `
@@ -1519,10 +1575,15 @@ as argument 1, but it was called with
 `;
 
 exports[`toHaveBeenNthCalledWith should replace 1st, 2nd, 3rd with first, second, third 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toHaveBeenNthCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveBeenNthCalledWith<dim>(</><green>n</><dim>, </><green>...expected</><dim>)</>
 
-Expected mock function first call to not have been called with:
-  <green>[\\"foo1\\", \\"bar\\"]</>"
+n: 1
+Expected: not <green>\\"foo1\\"</>, <green>\\"bar\\"</>
+Received
+->     1:     <red>\\"foo1\\"</>, <red>\\"bar\\"</>
+       2:     <red>\\"foo\\"</>, <red>\\"bar1\\"</>
+
+Number of calls: <red>3</>"
 `;
 
 exports[`toHaveBeenNthCalledWith works only on spies or jest.fn 1`] = `
@@ -1543,17 +1604,21 @@ But it was <red>not called</>."
 `;
 
 exports[`toHaveBeenNthCalledWith works with Immutable.js objects 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toHaveBeenNthCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveBeenNthCalledWith<dim>(</><green>n</><dim>, </><green>...expected</><dim>)</>
 
-Expected mock function first call to not have been called with:
-  <green>[Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}, Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}]</>"
+n: 1
+Expected: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>, <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
+
+Number of calls: <red>1</>"
 `;
 
 exports[`toHaveBeenNthCalledWith works with Map 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toHaveBeenNthCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveBeenNthCalledWith<dim>(</><green>n</><dim>, </><green>...expected</><dim>)</>
 
-Expected mock function first call to not have been called with:
-  <green>[Map {1 => 2, 2 => 1}]</>"
+n: 1
+Expected: not <green>Map {1 => 2, 2 => 1}</>
+
+Number of calls: <red>1</>"
 `;
 
 exports[`toHaveBeenNthCalledWith works with Map 2`] = `
@@ -1578,10 +1643,12 @@ Difference:
 `;
 
 exports[`toHaveBeenNthCalledWith works with Set 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toHaveBeenNthCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveBeenNthCalledWith<dim>(</><green>n</><dim>, </><green>...expected</><dim>)</>
 
-Expected mock function first call to not have been called with:
-  <green>[Set {1, 2}]</>"
+n: 1
+Expected: not <green>Set {1, 2}</>
+
+Number of calls: <red>1</>"
 `;
 
 exports[`toHaveBeenNthCalledWith works with Set 2`] = `
@@ -1615,17 +1682,24 @@ as argument 2, but it was called with
 `;
 
 exports[`toHaveBeenNthCalledWith works with arguments that match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toHaveBeenNthCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveBeenNthCalledWith<dim>(</><green>n</><dim>, </><green>...expected</><dim>)</>
 
-Expected mock function first call to not have been called with:
-  <green>[\\"foo\\", \\"bar\\"]</>"
+n: 1
+Expected: not <green>\\"foo\\"</>, <green>\\"bar\\"</>
+
+Number of calls: <red>1</>"
 `;
 
 exports[`toHaveBeenNthCalledWith works with three calls 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).not.toHaveBeenNthCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveBeenNthCalledWith<dim>(</><green>n</><dim>, </><green>...expected</><dim>)</>
 
-Expected mock function first call to not have been called with:
-  <green>[\\"foo1\\", \\"bar\\"]</>"
+n: 1
+Expected: not <green>\\"foo1\\"</>, <green>\\"bar\\"</>
+Received
+->     1:     <red>\\"foo1\\"</>, <red>\\"bar\\"</>
+       2:     <red>\\"foo\\"</>, <red>\\"bar1\\"</>
+
+Number of calls: <red>3</>"
 `;
 
 exports[`toHaveBeenNthCalledWith works with trailing undefined arguments 1`] = `

--- a/packages/expect/src/__tests__/spyMatchers.test.js
+++ b/packages/expect/src/__tests__/spyMatchers.test.js
@@ -347,27 +347,6 @@ const createSpy = fn => {
 
         expect(() => {
           jestExpect(fn).not[calledWith](1, 'foo1', 'bar');
-          jestExpect(fn).not[calledWith](2, 'foo', 'bar1');
-          jestExpect(fn).not[calledWith](3, 'foo', 'bar');
-        }).toThrowErrorMatchingSnapshot();
-      });
-
-      test('should replace 1st, 2nd, 3rd with first, second, third', async () => {
-        const fn = jest.fn();
-        fn('foo1', 'bar');
-        fn('foo', 'bar1');
-        fn('foo', 'bar');
-
-        expect(() => {
-          jestExpect(fn)[calledWith](1, 'foo', 'bar');
-          jestExpect(fn)[calledWith](2, 'foo', 'bar');
-          jestExpect(fn)[calledWith](3, 'foo1', 'bar');
-        }).toThrowErrorMatchingSnapshot();
-
-        expect(() => {
-          jestExpect(fn).not[calledWith](1, 'foo1', 'bar');
-          jestExpect(fn).not[calledWith](2, 'foo', 'bar1');
-          jestExpect(fn).not[calledWith](3, 'foo', 'bar');
         }).toThrowErrorMatchingSnapshot();
       });
 

--- a/packages/expect/src/spyMatchers.ts
+++ b/packages/expect/src/spyMatchers.ts
@@ -82,8 +82,7 @@ type IndexedCall = [number, Array<unknown>];
 
 // Return either empty string or one line per indexed result,
 // so additional empty line can separate from `Number of returns` which follows.
-const printReceivedCalls = (
-  label: string,
+const printReceivedCallsNegative = (
   indexedCalls: Array<IndexedCall>,
   isOnlyCall: boolean,
   iExpectedCall?: number,
@@ -92,6 +91,7 @@ const printReceivedCalls = (
     return '';
   }
 
+  const label = 'Received:     ';
   if (isOnlyCall) {
     return label + printReceivedArgs(indexedCalls[0]) + '\n';
   }
@@ -99,8 +99,7 @@ const printReceivedCalls = (
   const printAligned = getRightAlignedPrinter(label);
 
   return (
-    label.replace(':', '').trim() +
-    '\n' +
+    'Received\n' +
     indexedCalls.reduce(
       (printed: string, [i, args]: IndexedCall) =>
         printed +
@@ -388,11 +387,7 @@ const createToBeCalledWithMatcher = (matcherName: string) =>
             `Expected: not ${printExpectedArgs(expected)}\n` +
             (calls.length === 1 && stringify(calls[0]) === stringify(expected)
               ? ''
-              : printReceivedCalls(
-                  'Received:     ',
-                  indexedCalls,
-                  calls.length === 1,
-                )) +
+              : printReceivedCallsNegative(indexedCalls, calls.length === 1)) +
             `\nNumber of calls: ${printReceived(calls.length)}`
           );
         }
@@ -519,8 +514,7 @@ const createLastCalledWithMatcher = (matcherName: string) =>
             `Expected: not ${printExpectedArgs(expected)}\n` +
             (calls.length === 1 && stringify(calls[0]) === stringify(expected)
               ? ''
-              : printReceivedCalls(
-                  'Received:     ',
+              : printReceivedCallsNegative(
                   indexedCalls,
                   calls.length === 1,
                   iLast,
@@ -681,8 +675,7 @@ const createNthCalledWithMatcher = (matcherName: string) =>
             `Expected: not ${printExpectedArgs(expected)}\n` +
             (calls.length === 1 && stringify(calls[0]) === stringify(expected)
               ? ''
-              : printReceivedCalls(
-                  'Received:     ',
+              : printReceivedCallsNegative(
                   indexedCalls,
                   calls.length === 1,
                   iNth,

--- a/packages/expect/src/spyMatchers.ts
+++ b/packages/expect/src/spyMatchers.ts
@@ -523,6 +523,7 @@ const createLastCalledWithMatcher = (matcherName: string) =>
                   'Received:     ',
                   indexedCalls,
                   calls.length === 1,
+                  iLast,
                 )) +
             `\nNumber of calls: ${printReceived(calls.length)}`
           );


### PR DESCRIPTION
## Summary

For `.not.toHaveBeen*CalledWith` assertions:

* repeat `not` following `Expected` label
* replaced `called with no arguments` with `called with 0 arguments` to avoid double negative
* for special case of **one call**, display `Received: whatever` on one line
* but omit the line if received has **same serialization** as expected

Reason to separate pull requests:

* negative assertions adapt context logic from ReturnWith matchers in #8710
* positive assertions will need design discussion about diff for object args

## Test plan

Updated 40 snapshots

| | long name | short name |
| ---: | :--- | :--- |
| 2 | `toHaveBeenCalled` | `toBeCalled` |
| 12 | `toHaveBeenCalledWith` | `toBeCalledWith` |
| 12 | `toHaveBeenLastCalledWith` | `lastCalledWith` |
| 14 | `toHaveBeenNthCalledWith` | `nthCalledWith` |

See also pictures in following comment

Example pictures baseline at left and **improved at right**