### PR TITLE
[docs] Updated react-testing-library imports in website

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - `[docs]` Fix variable name in custom-matcher-api code example ([#8582](https://github.com/facebook/jest/pull/8582))
 - `[docs]` Fix example used in custom environment docs ([#8617](https://github.com/facebook/jest/pull/8617))
 - `[docs]` Updated react tutorial to refer to new package of react-testing-library (@testing-library/react) ([#8753](https://github.com/facebook/jest/pull/8753))
+- `[docs]` Updated imports of react-testing-library to @testing-library/react in website ([#8757](https://github.com/facebook/jest/pull/8757))
 - `[jest-core]` Add `getVersion` (moved from `jest-cli`) ([#8706](https://github.com/facebook/jest/pull/8706))
 
 ### Performance

--- a/docs/TutorialReact.md
+++ b/docs/TutorialReact.md
@@ -253,7 +253,7 @@ export default class CheckboxWithLabel extends React.Component {
 ```javascript
 // __tests__/CheckboxWithLabel-test.js
 import React from 'react';
-import {render, fireEvent, cleanup} from 'react-testing-library';
+import {render, fireEvent, cleanup} from '@testing-library/react';
 import CheckboxWithLabel from '../CheckboxWithLabel';
 
 // automatically unmount and cleanup DOM after the test is finished.

--- a/website/versioned_docs/version-24.0/TutorialReact.md
+++ b/website/versioned_docs/version-24.0/TutorialReact.md
@@ -254,7 +254,7 @@ export default class CheckboxWithLabel extends React.Component {
 ```javascript
 // __tests__/CheckboxWithLabel-test.js
 import React from 'react';
-import {render, fireEvent, cleanup} from 'react-testing-library';
+import {render, fireEvent, cleanup} from '@testing-library/react';
 import CheckboxWithLabel from '../CheckboxWithLabel';
 
 // automatically unmount and cleanup DOM after the test is finished.

--- a/website/versioned_docs/version-24.8/TutorialReact.md
+++ b/website/versioned_docs/version-24.8/TutorialReact.md
@@ -254,7 +254,7 @@ export default class CheckboxWithLabel extends React.Component {
 ```javascript
 // __tests__/CheckboxWithLabel-test.js
 import React from 'react';
-import {render, fireEvent, cleanup} from 'react-testing-library';
+import {render, fireEvent, cleanup} from '@testing-library/react';
 import CheckboxWithLabel from '../CheckboxWithLabel';
 
 // automatically unmount and cleanup DOM after the test is finished.


### PR DESCRIPTION
Updated react-testing-library imports to @testing-library/react in website examples.

## Summary

I've recently sent a PR for updating references of react-testing-library to @testing-library/react in the docs (https://github.com/facebook/jest/pull/8753), but I might have missed the imports part in the examples in the documentation (website). So here is the missing update. Sorry!

## Test plan

Opened the website to make sure changes are displaying correctly.
