### PR TITLE
fix: Allow setting extra options in this.global for Typescript

### DIFF
--- a/packages/jest-types/src/Global.ts
+++ b/packages/jest-types/src/Global.ts
@@ -82,4 +82,5 @@ export interface Global extends NodeJS.Global {
   pending: () => void;
   spyOn: () => void;
   spyOnProperty: () => void;
+  [extras: string]: any;
 }


### PR DESCRIPTION
## Summary

As per the documentation of [testEnvironment](https://jestjs.io/docs/en/configuration#testenvironment-string) 
> You can also pass variables from this module to your test suites by assigning them to this.global object 

However if I'm writing my environment in Typescript, assigning a variable in `this.global` is reported as an error by the compiler, due to the strict typing of `Global`

Based on a discussion from #8751 

<img width="750" alt="cust-env" src="https://user-images.githubusercontent.com/20227996/62003328-41fc1a00-b133-11e9-8761-b937bec43e70.png">

## Test plan

Existing e2e tests should cover it.
