### PR TITLE
Fix MockFunctions example that was using toContain instead of toContainEqual

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 - `[docs]` Updated react tutorial to refer to new package of react-testing-library (@testing-library/react) ([#8753](https://github.com/facebook/jest/pull/8753))
 - `[docs]` Updated imports of react-testing-library to @testing-library/react in website ([#8757](https://github.com/facebook/jest/pull/8757))
 - `[jest-core]` Add `getVersion` (moved from `jest-cli`) ([#8706](https://github.com/facebook/jest/pull/8706))
+- `[docs]` Fix MockFunctions example that was using toContain instead of toContainEqual ([#8765](https://github.com/facebook/jest/pull/8765))
 
 ### Performance
 

--- a/docs/MockFunctions.md
+++ b/docs/MockFunctions.md
@@ -263,7 +263,7 @@ These matchers are really just sugar for common forms of inspecting the `.mock` 
 expect(mockFunc.mock.calls.length).toBeGreaterThan(0);
 
 // The mock function was called at least once with the specified args
-expect(mockFunc.mock.calls).toContain([arg1, arg2]);
+expect(mockFunc.mock.calls).toContainEqual([arg1, arg2]);
 
 // The last call to the mock function was called with the specified args
 expect(mockFunc.mock.calls[mockFunc.mock.calls.length - 1]).toEqual([

--- a/website/versioned_docs/version-22.x/MockFunctions.md
+++ b/website/versioned_docs/version-22.x/MockFunctions.md
@@ -221,7 +221,7 @@ These matchers are really just sugar for common forms of inspecting the `.mock` 
 expect(mockFunc.mock.calls.length).toBeGreaterThan(0);
 
 // The mock function was called at least once with the specified args
-expect(mockFunc.mock.calls).toContain([arg1, arg2]);
+expect(mockFunc.mock.calls).toContainEqual([arg1, arg2]);
 
 // The last call to the mock function was called with the specified args
 expect(mockFunc.mock.calls[mockFunc.mock.calls.length - 1]).toEqual([

--- a/website/versioned_docs/version-23.x/MockFunctions.md
+++ b/website/versioned_docs/version-23.x/MockFunctions.md
@@ -267,7 +267,7 @@ These matchers are really just sugar for common forms of inspecting the `.mock` 
 expect(mockFunc.mock.calls.length).toBeGreaterThan(0);
 
 // The mock function was called at least once with the specified args
-expect(mockFunc.mock.calls).toContain([arg1, arg2]);
+expect(mockFunc.mock.calls).toContainEqual([arg1, arg2]);
 
 // The last call to the mock function was called with the specified args
 expect(mockFunc.mock.calls[mockFunc.mock.calls.length - 1]).toEqual([

--- a/website/versioned_docs/version-24.0/MockFunctions.md
+++ b/website/versioned_docs/version-24.0/MockFunctions.md
@@ -264,7 +264,7 @@ These matchers are really just sugar for common forms of inspecting the `.mock` 
 expect(mockFunc.mock.calls.length).toBeGreaterThan(0);
 
 // The mock function was called at least once with the specified args
-expect(mockFunc.mock.calls).toContain([arg1, arg2]);
+expect(mockFunc.mock.calls).toContainEqual([arg1, arg2]);
 
 // The last call to the mock function was called with the specified args
 expect(mockFunc.mock.calls[mockFunc.mock.calls.length - 1]).toEqual([


### PR DESCRIPTION
## Summary

toContain won't work in the case of the example, because it will try to compare arrays with Object.is.

## Test plan

Documentation update.
