### PR TITLE
expect: Improve report when positive CalledWith assertion fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - `[expect]` Improve report when mock-spy matcher fails, part 4 ([#8710](https://github.com/facebook/jest/pull/8710))
 - `[expect]` Throw matcher error when received cannot be jasmine spy ([#8747](https://github.com/facebook/jest/pull/8747))
 - `[expect]` Improve report when negative CalledWith assertion fails ([#8755](https://github.com/facebook/jest/pull/8755))
+- `[expect]` Improve report when positive CalledWith assertion fails ([#8771](https://github.com/facebook/jest/pull/8771))
 - `[jest-snapshot]` Highlight substring differences when matcher fails, part 3 ([#8569](https://github.com/facebook/jest/pull/8569))
 - `[jest-core]` Improve report when snapshots are obsolete ([#8448](https://github.com/facebook/jest/pull/8665))
 - `[jest-cli]` Improve chai support (with detailed output, to match jest exceptions) ([#8454](https://github.com/facebook/jest/pull/8454))

--- a/packages/expect/src/__tests__/__snapshots__/spyMatchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/spyMatchers.test.js.snap
@@ -18,11 +18,11 @@ Received has value: <red>[Function fn]</>"
 `;
 
 exports[`lastCalledWith works when not called 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).lastCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>lastCalledWith<dim>(</><green>...expected</><dim>)</>
 
-Expected mock function to have been last called with:
-  <green>[\\"foo\\", \\"bar\\"]</>
-But it was <red>not called</>."
+Expected: <green>\\"foo\\"</>, <green>\\"bar\\"</>
+
+Number of calls: <red>0</>"
 `;
 
 exports[`lastCalledWith works with Immutable.js objects 1`] = `
@@ -42,14 +42,7 @@ Number of calls: <red>1</>"
 `;
 
 exports[`lastCalledWith works with Map 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).lastCalledWith(</><green>expected</><dim>)</>
-
-Expected mock function to have been last called with:
-  <green>Map {\\"a\\" => \\"b\\", \\"b\\" => \\"a\\"}</>
-as argument 1, but it was called with
-  <red>Map {1 => 2, 2 => 1}</>.
-
-Difference:
+"<dim>expect(</><red>jest.fn()</><dim>).</>lastCalledWith<dim>(</><green>...expected</><dim>)</>
 
 <green>- Expected</>
 <red>+ Received</>
@@ -59,7 +52,9 @@ Difference:
 <green>-   \\"b\\" => \\"a\\",</>
 <red>+   1 => 2,</>
 <red>+   2 => 1,</>
-<dim>  }</>"
+<dim>  }</>,
+
+Number of calls: <red>1</>"
 `;
 
 exports[`lastCalledWith works with Set 1`] = `
@@ -71,14 +66,7 @@ Number of calls: <red>1</>"
 `;
 
 exports[`lastCalledWith works with Set 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).lastCalledWith(</><green>expected</><dim>)</>
-
-Expected mock function to have been last called with:
-  <green>Set {3, 4}</>
-as argument 1, but it was called with
-  <red>Set {1, 2}</>.
-
-Difference:
+"<dim>expect(</><red>jest.fn()</><dim>).</>lastCalledWith<dim>(</><green>...expected</><dim>)</>
 
 <green>- Expected</>
 <red>+ Received</>
@@ -88,16 +76,18 @@ Difference:
 <green>-   4,</>
 <red>+   1,</>
 <red>+   2,</>
-<dim>  }</>"
+<dim>  }</>,
+
+Number of calls: <red>1</>"
 `;
 
 exports[`lastCalledWith works with arguments that don't match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).lastCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>lastCalledWith<dim>(</><green>...expected</><dim>)</>
 
-Expected mock function to have been last called with:
-  <green>\\"bar\\"</>
-as argument 2, but it was called with
-  <red>\\"bar1\\"</>."
+Expected: <green>\\"foo\\"</>, <green>\\"bar\\"</>
+Received: <dim>\\"foo\\"</>, <red>\\"bar1\\"</>
+
+Number of calls: <red>1</>"
 `;
 
 exports[`lastCalledWith works with arguments that match 1`] = `
@@ -120,19 +110,23 @@ Number of calls: <red>3</>"
 `;
 
 exports[`lastCalledWith works with many arguments that don't match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).lastCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>lastCalledWith<dim>(</><green>...expected</><dim>)</>
 
-Expected mock function to have been last called with:
-  <green>\\"bar\\"</>
-as argument 2, but it was called with
-  <red>\\"bar3\\"</>."
+Expected: <green>\\"foo\\"</>, <green>\\"bar\\"</>
+Received
+       2: <dim>\\"foo\\"</>, <red>\\"bar2\\"</>
+->     3: <dim>\\"foo\\"</>, <red>\\"bar3\\"</>
+
+Number of calls: <red>3</>"
 `;
 
 exports[`lastCalledWith works with trailing undefined arguments 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).lastCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>lastCalledWith<dim>(</><green>...expected</><dim>)</>
 
-Expected mock function to have been last called with:
-  Did not expect argument 2 but it was called with <red>undefined</>."
+Expected: <green>\\"foo\\"</>
+Received: <dim>\\"foo\\"</>, <red>undefined</>
+
+Number of calls: <red>1</>"
 `;
 
 exports[`lastReturnedWith a call that throws is not considered to have returned 1`] = `
@@ -324,11 +318,12 @@ Received has value: <red>[Function fn]</>"
 `;
 
 exports[`nthCalledWith works when not called 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).nthCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>nthCalledWith<dim>(</><green>n</><dim>, </><green>...expected</><dim>)</>
 
-Expected mock function first call to have been called with:
-  <green>[\\"foo\\", \\"bar\\"]</>
-But it was <red>not called</>."
+n: 1
+Expected: <green>\\"foo\\"</>, <green>\\"bar\\"</>
+
+Number of calls: <red>0</>"
 `;
 
 exports[`nthCalledWith works with Immutable.js objects 1`] = `
@@ -350,15 +345,9 @@ Number of calls: <red>1</>"
 `;
 
 exports[`nthCalledWith works with Map 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).nthCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>nthCalledWith<dim>(</><green>n</><dim>, </><green>...expected</><dim>)</>
 
-Expected mock function first call to have been called with:
-  <green>Map {\\"a\\" => \\"b\\", \\"b\\" => \\"a\\"}</>
-as argument 1, but it was called with
-  <red>Map {1 => 2, 2 => 1}</>.
-
-Difference:
-
+n: 1
 <green>- Expected</>
 <red>+ Received</>
 
@@ -367,7 +356,9 @@ Difference:
 <green>-   \\"b\\" => \\"a\\",</>
 <red>+   1 => 2,</>
 <red>+   2 => 1,</>
-<dim>  }</>"
+<dim>  }</>,
+
+Number of calls: <red>1</>"
 `;
 
 exports[`nthCalledWith works with Set 1`] = `
@@ -380,15 +371,9 @@ Number of calls: <red>1</>"
 `;
 
 exports[`nthCalledWith works with Set 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).nthCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>nthCalledWith<dim>(</><green>n</><dim>, </><green>...expected</><dim>)</>
 
-Expected mock function first call to have been called with:
-  <green>Set {3, 4}</>
-as argument 1, but it was called with
-  <red>Set {1, 2}</>.
-
-Difference:
-
+n: 1
 <green>- Expected</>
 <red>+ Received</>
 
@@ -397,16 +382,19 @@ Difference:
 <green>-   4,</>
 <red>+   1,</>
 <red>+   2,</>
-<dim>  }</>"
+<dim>  }</>,
+
+Number of calls: <red>1</>"
 `;
 
 exports[`nthCalledWith works with arguments that don't match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).nthCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>nthCalledWith<dim>(</><green>n</><dim>, </><green>...expected</><dim>)</>
 
-Expected mock function first call to have been called with:
-  <green>\\"bar\\"</>
-as argument 2, but it was called with
-  <red>\\"bar1\\"</>."
+n: 1
+Expected: <green>\\"foo\\"</>, <green>\\"bar\\"</>
+Received: <dim>\\"foo\\"</>, <red>\\"bar1\\"</>
+
+Number of calls: <red>1</>"
 `;
 
 exports[`nthCalledWith works with arguments that match 1`] = `
@@ -431,10 +419,13 @@ Number of calls: <red>3</>"
 `;
 
 exports[`nthCalledWith works with trailing undefined arguments 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).nthCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>nthCalledWith<dim>(</><green>n</><dim>, </><green>...expected</><dim>)</>
 
-Expected mock function first call to have been called with:
-  Did not expect argument 2 but it was called with <red>undefined</>."
+n: 1
+Expected: <green>\\"foo\\"</>
+Received: <dim>\\"foo\\"</>, <red>undefined</>
+
+Number of calls: <red>1</>"
 `;
 
 exports[`nthReturnedWith a call that throws is not considered to have returned 1`] = `
@@ -911,11 +902,11 @@ Received has value: <red>[Function fn]</>"
 `;
 
 exports[`toBeCalledWith works when not called 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toBeCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toBeCalledWith<dim>(</><green>...expected</><dim>)</>
 
-Expected mock function to have been called with:
-  <green>[\\"foo\\", \\"bar\\"]</>
-But it was <red>not called</>."
+Expected: <green>\\"foo\\"</>, <green>\\"bar\\"</>
+
+Number of calls: <red>0</>"
 `;
 
 exports[`toBeCalledWith works with Immutable.js objects 1`] = `
@@ -935,14 +926,7 @@ Number of calls: <red>1</>"
 `;
 
 exports[`toBeCalledWith works with Map 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toBeCalledWith(</><green>expected</><dim>)</>
-
-Expected mock function to have been called with:
-  <green>Map {\\"a\\" => \\"b\\", \\"b\\" => \\"a\\"}</>
-as argument 1, but it was called with
-  <red>Map {1 => 2, 2 => 1}</>.
-
-Difference:
+"<dim>expect(</><red>jest.fn()</><dim>).</>toBeCalledWith<dim>(</><green>...expected</><dim>)</>
 
 <green>- Expected</>
 <red>+ Received</>
@@ -952,7 +936,9 @@ Difference:
 <green>-   \\"b\\" => \\"a\\",</>
 <red>+   1 => 2,</>
 <red>+   2 => 1,</>
-<dim>  }</>"
+<dim>  }</>,
+
+Number of calls: <red>1</>"
 `;
 
 exports[`toBeCalledWith works with Set 1`] = `
@@ -964,14 +950,7 @@ Number of calls: <red>1</>"
 `;
 
 exports[`toBeCalledWith works with Set 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toBeCalledWith(</><green>expected</><dim>)</>
-
-Expected mock function to have been called with:
-  <green>Set {3, 4}</>
-as argument 1, but it was called with
-  <red>Set {1, 2}</>.
-
-Difference:
+"<dim>expect(</><red>jest.fn()</><dim>).</>toBeCalledWith<dim>(</><green>...expected</><dim>)</>
 
 <green>- Expected</>
 <red>+ Received</>
@@ -981,16 +960,18 @@ Difference:
 <green>-   4,</>
 <red>+   1,</>
 <red>+   2,</>
-<dim>  }</>"
+<dim>  }</>,
+
+Number of calls: <red>1</>"
 `;
 
 exports[`toBeCalledWith works with arguments that don't match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toBeCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toBeCalledWith<dim>(</><green>...expected</><dim>)</>
 
-Expected mock function to have been called with:
-  <green>\\"bar\\"</>
-as argument 2, but it was called with
-  <red>\\"bar1\\"</>."
+Expected: <green>\\"foo\\"</>, <green>\\"bar\\"</>
+Received: <dim>\\"foo\\"</>, <red>\\"bar1\\"</>
+
+Number of calls: <red>1</>"
 `;
 
 exports[`toBeCalledWith works with arguments that match 1`] = `
@@ -1012,27 +993,24 @@ Number of calls: <red>3</>"
 `;
 
 exports[`toBeCalledWith works with many arguments that don't match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toBeCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toBeCalledWith<dim>(</><green>...expected</><dim>)</>
 
-Expected mock function to have been called with:
-  <green>\\"bar\\"</>
-as argument 2, but it was called with
-  <red>\\"bar3\\"</>.
+Expected: <green>\\"foo\\"</>, <green>\\"bar\\"</>
+Received
+       1: <dim>\\"foo\\"</>, <red>\\"bar1\\"</>
+       2: <dim>\\"foo\\"</>, <red>\\"bar2\\"</>
+       3: <dim>\\"foo\\"</>, <red>\\"bar3\\"</>
 
-  <green>\\"bar\\"</>
-as argument 2, but it was called with
-  <red>\\"bar2\\"</>.
-
-  <green>\\"bar\\"</>
-as argument 2, but it was called with
-  <red>\\"bar1\\"</>."
+Number of calls: <red>3</>"
 `;
 
 exports[`toBeCalledWith works with trailing undefined arguments 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toBeCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toBeCalledWith<dim>(</><green>...expected</><dim>)</>
 
-Expected mock function to have been called with:
-  Did not expect argument 2 but it was called with <red>undefined</>."
+Expected: <green>\\"foo\\"</>
+Received: <dim>\\"foo\\"</>, <red>undefined</>
+
+Number of calls: <red>1</>"
 `;
 
 exports[`toHaveBeenCalled .not fails with any argument passed 1`] = `
@@ -1249,11 +1227,11 @@ Received has value: <red>[Function fn]</>"
 `;
 
 exports[`toHaveBeenCalledWith works when not called 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toHaveBeenCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveBeenCalledWith<dim>(</><green>...expected</><dim>)</>
 
-Expected mock function to have been called with:
-  <green>[\\"foo\\", \\"bar\\"]</>
-But it was <red>not called</>."
+Expected: <green>\\"foo\\"</>, <green>\\"bar\\"</>
+
+Number of calls: <red>0</>"
 `;
 
 exports[`toHaveBeenCalledWith works with Immutable.js objects 1`] = `
@@ -1273,14 +1251,7 @@ Number of calls: <red>1</>"
 `;
 
 exports[`toHaveBeenCalledWith works with Map 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toHaveBeenCalledWith(</><green>expected</><dim>)</>
-
-Expected mock function to have been called with:
-  <green>Map {\\"a\\" => \\"b\\", \\"b\\" => \\"a\\"}</>
-as argument 1, but it was called with
-  <red>Map {1 => 2, 2 => 1}</>.
-
-Difference:
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveBeenCalledWith<dim>(</><green>...expected</><dim>)</>
 
 <green>- Expected</>
 <red>+ Received</>
@@ -1290,7 +1261,9 @@ Difference:
 <green>-   \\"b\\" => \\"a\\",</>
 <red>+   1 => 2,</>
 <red>+   2 => 1,</>
-<dim>  }</>"
+<dim>  }</>,
+
+Number of calls: <red>1</>"
 `;
 
 exports[`toHaveBeenCalledWith works with Set 1`] = `
@@ -1302,14 +1275,7 @@ Number of calls: <red>1</>"
 `;
 
 exports[`toHaveBeenCalledWith works with Set 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toHaveBeenCalledWith(</><green>expected</><dim>)</>
-
-Expected mock function to have been called with:
-  <green>Set {3, 4}</>
-as argument 1, but it was called with
-  <red>Set {1, 2}</>.
-
-Difference:
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveBeenCalledWith<dim>(</><green>...expected</><dim>)</>
 
 <green>- Expected</>
 <red>+ Received</>
@@ -1319,16 +1285,18 @@ Difference:
 <green>-   4,</>
 <red>+   1,</>
 <red>+   2,</>
-<dim>  }</>"
+<dim>  }</>,
+
+Number of calls: <red>1</>"
 `;
 
 exports[`toHaveBeenCalledWith works with arguments that don't match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toHaveBeenCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveBeenCalledWith<dim>(</><green>...expected</><dim>)</>
 
-Expected mock function to have been called with:
-  <green>\\"bar\\"</>
-as argument 2, but it was called with
-  <red>\\"bar1\\"</>."
+Expected: <green>\\"foo\\"</>, <green>\\"bar\\"</>
+Received: <dim>\\"foo\\"</>, <red>\\"bar1\\"</>
+
+Number of calls: <red>1</>"
 `;
 
 exports[`toHaveBeenCalledWith works with arguments that match 1`] = `
@@ -1350,27 +1318,24 @@ Number of calls: <red>3</>"
 `;
 
 exports[`toHaveBeenCalledWith works with many arguments that don't match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toHaveBeenCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveBeenCalledWith<dim>(</><green>...expected</><dim>)</>
 
-Expected mock function to have been called with:
-  <green>\\"bar\\"</>
-as argument 2, but it was called with
-  <red>\\"bar3\\"</>.
+Expected: <green>\\"foo\\"</>, <green>\\"bar\\"</>
+Received
+       1: <dim>\\"foo\\"</>, <red>\\"bar1\\"</>
+       2: <dim>\\"foo\\"</>, <red>\\"bar2\\"</>
+       3: <dim>\\"foo\\"</>, <red>\\"bar3\\"</>
 
-  <green>\\"bar\\"</>
-as argument 2, but it was called with
-  <red>\\"bar2\\"</>.
-
-  <green>\\"bar\\"</>
-as argument 2, but it was called with
-  <red>\\"bar1\\"</>."
+Number of calls: <red>3</>"
 `;
 
 exports[`toHaveBeenCalledWith works with trailing undefined arguments 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toHaveBeenCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveBeenCalledWith<dim>(</><green>...expected</><dim>)</>
 
-Expected mock function to have been called with:
-  Did not expect argument 2 but it was called with <red>undefined</>."
+Expected: <green>\\"foo\\"</>
+Received: <dim>\\"foo\\"</>, <red>undefined</>
+
+Number of calls: <red>1</>"
 `;
 
 exports[`toHaveBeenLastCalledWith includes the custom mock name in the error message 1`] = `
@@ -1391,11 +1356,11 @@ Received has value: <red>[Function fn]</>"
 `;
 
 exports[`toHaveBeenLastCalledWith works when not called 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toHaveBeenLastCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveBeenLastCalledWith<dim>(</><green>...expected</><dim>)</>
 
-Expected mock function to have been last called with:
-  <green>[\\"foo\\", \\"bar\\"]</>
-But it was <red>not called</>."
+Expected: <green>\\"foo\\"</>, <green>\\"bar\\"</>
+
+Number of calls: <red>0</>"
 `;
 
 exports[`toHaveBeenLastCalledWith works with Immutable.js objects 1`] = `
@@ -1415,14 +1380,7 @@ Number of calls: <red>1</>"
 `;
 
 exports[`toHaveBeenLastCalledWith works with Map 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toHaveBeenLastCalledWith(</><green>expected</><dim>)</>
-
-Expected mock function to have been last called with:
-  <green>Map {\\"a\\" => \\"b\\", \\"b\\" => \\"a\\"}</>
-as argument 1, but it was called with
-  <red>Map {1 => 2, 2 => 1}</>.
-
-Difference:
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveBeenLastCalledWith<dim>(</><green>...expected</><dim>)</>
 
 <green>- Expected</>
 <red>+ Received</>
@@ -1432,7 +1390,9 @@ Difference:
 <green>-   \\"b\\" => \\"a\\",</>
 <red>+   1 => 2,</>
 <red>+   2 => 1,</>
-<dim>  }</>"
+<dim>  }</>,
+
+Number of calls: <red>1</>"
 `;
 
 exports[`toHaveBeenLastCalledWith works with Set 1`] = `
@@ -1444,14 +1404,7 @@ Number of calls: <red>1</>"
 `;
 
 exports[`toHaveBeenLastCalledWith works with Set 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toHaveBeenLastCalledWith(</><green>expected</><dim>)</>
-
-Expected mock function to have been last called with:
-  <green>Set {3, 4}</>
-as argument 1, but it was called with
-  <red>Set {1, 2}</>.
-
-Difference:
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveBeenLastCalledWith<dim>(</><green>...expected</><dim>)</>
 
 <green>- Expected</>
 <red>+ Received</>
@@ -1461,16 +1414,18 @@ Difference:
 <green>-   4,</>
 <red>+   1,</>
 <red>+   2,</>
-<dim>  }</>"
+<dim>  }</>,
+
+Number of calls: <red>1</>"
 `;
 
 exports[`toHaveBeenLastCalledWith works with arguments that don't match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toHaveBeenLastCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveBeenLastCalledWith<dim>(</><green>...expected</><dim>)</>
 
-Expected mock function to have been last called with:
-  <green>\\"bar\\"</>
-as argument 2, but it was called with
-  <red>\\"bar1\\"</>."
+Expected: <green>\\"foo\\"</>, <green>\\"bar\\"</>
+Received: <dim>\\"foo\\"</>, <red>\\"bar1\\"</>
+
+Number of calls: <red>1</>"
 `;
 
 exports[`toHaveBeenLastCalledWith works with arguments that match 1`] = `
@@ -1493,19 +1448,23 @@ Number of calls: <red>3</>"
 `;
 
 exports[`toHaveBeenLastCalledWith works with many arguments that don't match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toHaveBeenLastCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveBeenLastCalledWith<dim>(</><green>...expected</><dim>)</>
 
-Expected mock function to have been last called with:
-  <green>\\"bar\\"</>
-as argument 2, but it was called with
-  <red>\\"bar3\\"</>."
+Expected: <green>\\"foo\\"</>, <green>\\"bar\\"</>
+Received
+       2: <dim>\\"foo\\"</>, <red>\\"bar2\\"</>
+->     3: <dim>\\"foo\\"</>, <red>\\"bar3\\"</>
+
+Number of calls: <red>3</>"
 `;
 
 exports[`toHaveBeenLastCalledWith works with trailing undefined arguments 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toHaveBeenLastCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveBeenLastCalledWith<dim>(</><green>...expected</><dim>)</>
 
-Expected mock function to have been last called with:
-  Did not expect argument 2 but it was called with <red>undefined</>."
+Expected: <green>\\"foo\\"</>
+Received: <dim>\\"foo\\"</>, <red>undefined</>
+
+Number of calls: <red>1</>"
 `;
 
 exports[`toHaveBeenNthCalledWith includes the custom mock name in the error message 1`] = `
@@ -1554,11 +1513,12 @@ Received has value: <red>[Function fn]</>"
 `;
 
 exports[`toHaveBeenNthCalledWith works when not called 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toHaveBeenNthCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveBeenNthCalledWith<dim>(</><green>n</><dim>, </><green>...expected</><dim>)</>
 
-Expected mock function first call to have been called with:
-  <green>[\\"foo\\", \\"bar\\"]</>
-But it was <red>not called</>."
+n: 1
+Expected: <green>\\"foo\\"</>, <green>\\"bar\\"</>
+
+Number of calls: <red>0</>"
 `;
 
 exports[`toHaveBeenNthCalledWith works with Immutable.js objects 1`] = `
@@ -1580,15 +1540,9 @@ Number of calls: <red>1</>"
 `;
 
 exports[`toHaveBeenNthCalledWith works with Map 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toHaveBeenNthCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveBeenNthCalledWith<dim>(</><green>n</><dim>, </><green>...expected</><dim>)</>
 
-Expected mock function first call to have been called with:
-  <green>Map {\\"a\\" => \\"b\\", \\"b\\" => \\"a\\"}</>
-as argument 1, but it was called with
-  <red>Map {1 => 2, 2 => 1}</>.
-
-Difference:
-
+n: 1
 <green>- Expected</>
 <red>+ Received</>
 
@@ -1597,7 +1551,9 @@ Difference:
 <green>-   \\"b\\" => \\"a\\",</>
 <red>+   1 => 2,</>
 <red>+   2 => 1,</>
-<dim>  }</>"
+<dim>  }</>,
+
+Number of calls: <red>1</>"
 `;
 
 exports[`toHaveBeenNthCalledWith works with Set 1`] = `
@@ -1610,15 +1566,9 @@ Number of calls: <red>1</>"
 `;
 
 exports[`toHaveBeenNthCalledWith works with Set 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toHaveBeenNthCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveBeenNthCalledWith<dim>(</><green>n</><dim>, </><green>...expected</><dim>)</>
 
-Expected mock function first call to have been called with:
-  <green>Set {3, 4}</>
-as argument 1, but it was called with
-  <red>Set {1, 2}</>.
-
-Difference:
-
+n: 1
 <green>- Expected</>
 <red>+ Received</>
 
@@ -1627,16 +1577,19 @@ Difference:
 <green>-   4,</>
 <red>+   1,</>
 <red>+   2,</>
-<dim>  }</>"
+<dim>  }</>,
+
+Number of calls: <red>1</>"
 `;
 
 exports[`toHaveBeenNthCalledWith works with arguments that don't match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toHaveBeenNthCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveBeenNthCalledWith<dim>(</><green>n</><dim>, </><green>...expected</><dim>)</>
 
-Expected mock function first call to have been called with:
-  <green>\\"bar\\"</>
-as argument 2, but it was called with
-  <red>\\"bar1\\"</>."
+n: 1
+Expected: <green>\\"foo\\"</>, <green>\\"bar\\"</>
+Received: <dim>\\"foo\\"</>, <red>\\"bar1\\"</>
+
+Number of calls: <red>1</>"
 `;
 
 exports[`toHaveBeenNthCalledWith works with arguments that match 1`] = `
@@ -1661,10 +1614,13 @@ Number of calls: <red>3</>"
 `;
 
 exports[`toHaveBeenNthCalledWith works with trailing undefined arguments 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).toHaveBeenNthCalledWith(</><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveBeenNthCalledWith<dim>(</><green>n</><dim>, </><green>...expected</><dim>)</>
 
-Expected mock function first call to have been called with:
-  Did not expect argument 2 but it was called with <red>undefined</>."
+n: 1
+Expected: <green>\\"foo\\"</>
+Received: <dim>\\"foo\\"</>, <red>undefined</>
+
+Number of calls: <red>1</>"
 `;
 
 exports[`toHaveLastReturnedWith a call that throws is not considered to have returned 1`] = `

--- a/packages/expect/src/spyMatchers.ts
+++ b/packages/expect/src/spyMatchers.ts
@@ -205,7 +205,7 @@ const printExpectedReceivedCallsPositive = (
       const aligned = printAligned(String(i + 1), i === iExpectedCall);
       return (
         printed +
-        ((iExpectedCall === undefined || i === iExpectedCall) &&
+        ((i === iExpectedCall || iExpectedCall === undefined) &&
         isLineDiffableCall(expected, received)
           ? aligned.replace(': ', '\n') +
             printDiffCall(expected, received, expand)

--- a/packages/expect/src/spyMatchers.ts
+++ b/packages/expect/src/spyMatchers.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import getType, {isPrimitive} from 'jest-get-type';
 import {
   diff,
   ensureExpectedIsNumber,
@@ -22,11 +23,12 @@ import {
 } from 'jest-matcher-utils';
 import {MatchersObject, MatcherState, SyncExpectationResult} from './types';
 import {equals} from './jasmineUtils';
-import {iterableEquality, partition, isOneline} from './utils';
+import {iterableEquality} from './utils';
+
+// The optional property of matcher context is true if undefined.
+const isExpand = (expand?: boolean): boolean => expand !== false;
 
 const PRINT_LIMIT = 3;
-const CALL_PRINT_LIMIT = 3;
-const LAST_CALL_PRINT_LIMIT = 1;
 
 const NO_ARGUMENTS = 'called with 0 arguments';
 
@@ -99,8 +101,6 @@ const getRightAlignedPrinter = (label: string): PrintLabel => {
 
 type IndexedCall = [number, Array<unknown>];
 
-// Return either empty string or one line per indexed result,
-// so additional empty line can separate from `Number of returns` which follows.
 const printReceivedCallsNegative = (
   expected: Array<unknown>,
   indexedCalls: Array<IndexedCall>,
@@ -131,6 +131,189 @@ const printReceivedCallsNegative = (
   );
 };
 
+const printExpectedReceivedCallsPositive = (
+  expected: Array<unknown>,
+  indexedCalls: Array<IndexedCall>,
+  expand: boolean,
+  isOnlyCall: boolean,
+  iExpectedCall?: number,
+) => {
+  const expectedLine = `Expected: ${printExpectedArgs(expected)}\n`;
+  if (indexedCalls.length === 0) {
+    return expectedLine;
+  }
+
+  const label = 'Received: ';
+  if (isOnlyCall && (iExpectedCall === 0 || iExpectedCall === undefined)) {
+    const received = indexedCalls[0][1];
+    const isOnlyCallLineDiffable = isLineDiffableCall(expected, received);
+
+    if (isOnlyCallLineDiffable) {
+      // Display diff without indentation.
+      const lines = [
+        EXPECTED_COLOR('- Expected'),
+        RECEIVED_COLOR('+ Received'),
+        '',
+      ];
+
+      const length = Math.max(expected.length, received.length);
+      for (let i = 0; i < length; i += 1) {
+        if (i < expected.length && i < received.length) {
+          if (isEqualValue(expected[i], received[i])) {
+            lines.push(`  ${printCommon(received[i])},`);
+            continue;
+          }
+
+          if (isLineDiffableArg(expected[i], received[i])) {
+            const difference = diff(expected[i], received[i], {expand});
+            if (
+              typeof difference === 'string' &&
+              difference.includes('- Expected') &&
+              difference.includes('+ Received')
+            ) {
+              // Omit annotation in case multiple args have diff.
+              lines.push(
+                difference
+                  .split('\n')
+                  .slice(3)
+                  .join('\n') + ',',
+              );
+              continue;
+            }
+          }
+        }
+
+        if (i < expected.length) {
+          lines.push(EXPECTED_COLOR('- ' + stringify(expected[i])) + ',');
+        }
+        if (i < received.length) {
+          lines.push(RECEIVED_COLOR('+ ' + stringify(received[i])) + ',');
+        }
+      }
+
+      return lines.join('\n') + '\n';
+    }
+
+    return expectedLine + label + printReceivedArgs(received, expected) + '\n';
+  }
+
+  const printAligned = getRightAlignedPrinter(label);
+
+  return (
+    expectedLine +
+    'Received\n' +
+    indexedCalls.reduce((printed: string, [i, received]: IndexedCall) => {
+      const aligned = printAligned(String(i + 1), i === iExpectedCall);
+      return (
+        printed +
+        ((iExpectedCall === undefined || i === iExpectedCall) &&
+        isLineDiffableCall(expected, received)
+          ? aligned.replace(': ', '\n') +
+            printDiffCall(expected, received, expand)
+          : aligned + printReceivedArgs(received, expected)) +
+        '\n'
+      );
+    }, '')
+  );
+};
+
+const indentation = 'Received'.replace(/\w/g, ' ');
+
+const printDiffCall = (
+  expected: Array<unknown>,
+  received: Array<unknown>,
+  expand: boolean,
+) =>
+  received
+    .map((arg, i) => {
+      if (i < expected.length) {
+        if (isEqualValue(expected[i], arg)) {
+          return indentation + '  ' + printCommon(arg) + ',';
+        }
+
+        if (isLineDiffableArg(expected[i], arg)) {
+          const difference = diff(expected[i], arg, {expand});
+
+          if (
+            typeof difference === 'string' &&
+            difference.includes('- Expected') &&
+            difference.includes('+ Received')
+          ) {
+            // Display diff with indentation.
+            // Omit annotation in case multiple args have diff.
+            return (
+              difference
+                .split('\n')
+                .slice(3)
+                .map(line => indentation + line)
+                .join('\n') + ','
+            );
+          }
+        }
+      }
+
+      // Display + only if received arg has no corresponding expected arg.
+      return (
+        indentation +
+        (i < expected.length
+          ? '  ' + printReceived(arg)
+          : RECEIVED_COLOR('+ ' + stringify(arg))) +
+        ','
+      );
+    })
+    .join('\n');
+
+const isLineDiffableCall = (
+  expected: Array<unknown>,
+  received: Array<unknown>,
+): boolean =>
+  expected.some(
+    (arg, i) => i < received.length && isLineDiffableArg(arg, received[i]),
+  );
+
+// Almost redundant with function in jest-matcher-utils,
+// except no line diff for any strings.
+const isLineDiffableArg = (expected: unknown, received: unknown): boolean => {
+  const expectedType = getType(expected);
+  const receivedType = getType(received);
+
+  if (expectedType !== receivedType) {
+    return false;
+  }
+
+  if (isPrimitive(expected)) {
+    return false;
+  }
+
+  if (
+    expectedType === 'date' ||
+    expectedType === 'function' ||
+    expectedType === 'regexp'
+  ) {
+    return false;
+  }
+
+  if (expected instanceof Error && received instanceof Error) {
+    return false;
+  }
+
+  if (
+    expectedType === 'object' &&
+    typeof (expected as any).asymmetricMatch === 'function'
+  ) {
+    return false;
+  }
+
+  if (
+    receivedType === 'object' &&
+    typeof (received as any).asymmetricMatch === 'function'
+  ) {
+    return false;
+  }
+
+  return true;
+};
+
 const printResult = (result: any) =>
   result.type === 'throw'
     ? 'function call threw an error'
@@ -152,7 +335,7 @@ const printReceivedResults = (
     return '';
   }
 
-  if (isOnlyCall) {
+  if (isOnlyCall && (iExpectedCall === 0 || iExpectedCall === undefined)) {
     return label + printResult(indexedResults[0][1]) + '\n';
   }
 
@@ -375,21 +558,13 @@ const createToBeCalledWithMatcher = (matcherName: string) =>
     ensureMockOrSpy(received, matcherName, expectedArgument, options);
 
     const receivedIsSpy = isSpy(received);
-    const type = receivedIsSpy ? 'spy' : 'mock function';
     const receivedName = receivedIsSpy ? 'spy' : received.getMockName();
-    const identifier =
-      receivedIsSpy || receivedName === 'jest.fn()'
-        ? type
-        : `${type} "${receivedName}"`;
 
     const calls = receivedIsSpy
       ? received.calls.all().map((x: any) => x.args)
       : received.mock.calls;
 
-    const [match, fail] = partition(calls, call =>
-      isEqualCall(expected, call as Array<unknown>),
-    );
-    const pass = match.length > 0;
+    const pass = calls.some((call: any) => isEqualCall(expected, call));
 
     const message = pass
       ? () => {
@@ -417,11 +592,27 @@ const createToBeCalledWithMatcher = (matcherName: string) =>
             `\nNumber of calls: ${printReceived(calls.length)}`
           );
         }
-      : () =>
-          matcherHint('.' + matcherName, receivedName) +
-          '\n\n' +
-          `Expected ${identifier} to have been called with:\n` +
-          formatMismatchedCalls(fail, expected, CALL_PRINT_LIMIT);
+      : () => {
+          // Some examples of calls that are not equal to expected value.
+          const indexedCalls: Array<IndexedCall> = [];
+          let i = 0;
+          while (i < calls.length && indexedCalls.length < PRINT_LIMIT) {
+            indexedCalls.push([i, calls[i]]);
+            i += 1;
+          }
+
+          return (
+            matcherHint(matcherName, receivedName, expectedArgument, options) +
+            '\n\n' +
+            printExpectedReceivedCallsPositive(
+              expected,
+              indexedCalls,
+              isExpand(this.expand),
+              calls.length === 1,
+            ) +
+            `\nNumber of calls: ${printReceived(calls.length)}`
+          );
+        };
 
     return {message, pass};
   };
@@ -511,12 +702,7 @@ const createLastCalledWithMatcher = (matcherName: string) =>
     ensureMockOrSpy(received, matcherName, expectedArgument, options);
 
     const receivedIsSpy = isSpy(received);
-    const type = receivedIsSpy ? 'spy' : 'mock function';
     const receivedName = receivedIsSpy ? 'spy' : received.getMockName();
-    const identifier =
-      receivedIsSpy || receivedName === 'jest.fn()'
-        ? type
-        : `${type} "${receivedName}"`;
 
     const calls = receivedIsSpy
       ? received.calls.all().map((x: any) => x.args)
@@ -549,11 +735,38 @@ const createLastCalledWithMatcher = (matcherName: string) =>
             `\nNumber of calls: ${printReceived(calls.length)}`
           );
         }
-      : () =>
-          matcherHint('.' + matcherName, receivedName) +
-          '\n\n' +
-          `Expected ${identifier} to have been last called with:\n` +
-          formatMismatchedCalls(calls, expected, LAST_CALL_PRINT_LIMIT);
+      : () => {
+          const indexedCalls: Array<IndexedCall> = [];
+          if (iLast >= 0) {
+            if (iLast > 0) {
+              let i = iLast - 1;
+              // Is there a preceding call that is equal to expected args?
+              while (i >= 0 && !isEqualCall(expected, calls[i])) {
+                i -= 1;
+              }
+              if (i < 0) {
+                i = iLast - 1; // otherwise, preceding call
+              }
+
+              indexedCalls.push([i, calls[i]]);
+            }
+
+            indexedCalls.push([iLast, calls[iLast]]);
+          }
+
+          return (
+            matcherHint(matcherName, receivedName, expectedArgument, options) +
+            '\n\n' +
+            printExpectedReceivedCallsPositive(
+              expected,
+              indexedCalls,
+              isExpand(this.expand),
+              calls.length === 1,
+              iLast,
+            ) +
+            `\nNumber of calls: ${printReceived(calls.length)}`
+          );
+        };
 
     return {message, pass};
   };
@@ -666,13 +879,7 @@ const createNthCalledWithMatcher = (matcherName: string) =>
     }
 
     const receivedIsSpy = isSpy(received);
-    const type = receivedIsSpy ? 'spy' : 'mock function';
-
     const receivedName = receivedIsSpy ? 'spy' : received.getMockName();
-    const identifier =
-      receivedIsSpy || receivedName === 'jest.fn()'
-        ? type
-        : `${type} "${receivedName}"`;
 
     const calls = receivedIsSpy
       ? received.calls.all().map((x: any) => x.args)
@@ -711,17 +918,66 @@ const createNthCalledWithMatcher = (matcherName: string) =>
             `\nNumber of calls: ${printReceived(calls.length)}`
           );
         }
-      : () =>
-          matcherHint('.' + matcherName, receivedName) +
-          '\n\n' +
-          `Expected ${identifier} ${nthToString(
-            nth,
-          )} call to have been called with:\n` +
-          formatMismatchedCalls(
-            calls[nth - 1] ? [calls[nth - 1]] : [],
-            expected,
-            LAST_CALL_PRINT_LIMIT,
+      : () => {
+          // Display preceding and following calls:
+          // * nearest call that is equal to expected args
+          // * otherwise, adjacent call
+          // in case assertions fails because of index, especially off by one.
+          const indexedCalls: Array<IndexedCall> = [];
+          if (iNth < length) {
+            if (iNth - 1 >= 0) {
+              let i = iNth - 1;
+              // Is there a preceding call that is equal to expected args?
+              while (i >= 0 && !isEqualCall(expected, calls[i])) {
+                i -= 1;
+              }
+              if (i < 0) {
+                i = iNth - 1; // otherwise, adjacent call
+              }
+
+              indexedCalls.push([i, calls[i]]);
+            }
+            indexedCalls.push([iNth, calls[iNth]]);
+            if (iNth + 1 < length) {
+              let i = iNth + 1;
+              // Is there a following call that is equal to expected args?
+              while (i < length && !isEqualCall(expected, calls[i])) {
+                i += 1;
+              }
+              if (i >= length) {
+                i = iNth + 1; // otherwise, adjacent call
+              }
+
+              indexedCalls.push([i, calls[i]]);
+            }
+          } else if (length > 0) {
+            // The number of received calls is fewer than the expected number.
+            let i = length - 1;
+            // Is there a call that is equal to expected args?
+            while (i >= 0 && !isEqualCall(expected, calls[i])) {
+              i -= 1;
+            }
+            if (i < 0) {
+              i = length - 1; // otherwise, last call
+            }
+
+            indexedCalls.push([i, calls[i]]);
+          }
+
+          return (
+            matcherHint(matcherName, receivedName, expectedArgument, options) +
+            '\n\n' +
+            `n: ${nth}\n` +
+            printExpectedReceivedCallsPositive(
+              expected,
+              indexedCalls,
+              isExpand(this.expand),
+              calls.length === 1,
+              iNth,
+            ) +
+            `\nNumber of calls: ${printReceived(calls.length)}`
           );
+        };
 
     return {message, pass};
   };
@@ -921,79 +1177,6 @@ const ensureMock = (
       ),
     );
   }
-};
-
-const getPrintedCalls = (
-  calls: Array<any>,
-  limit: number,
-  sep: string,
-  fn: Function,
-): string => {
-  const result = [];
-  let i = calls.length;
-
-  while (--i >= 0 && --limit >= 0) {
-    result.push(fn(calls[i]));
-  }
-
-  return result.join(sep);
-};
-
-const formatMismatchedCalls = (
-  calls: Array<any>,
-  expected: any,
-  limit: number,
-): string => {
-  if (calls.length) {
-    return getPrintedCalls(
-      calls,
-      limit,
-      '\n\n',
-      formatMismatchedArgs.bind(null, expected),
-    );
-  } else {
-    return (
-      `  ${printExpected(expected)}\n` +
-      `But it was ${RECEIVED_COLOR('not called')}.`
-    );
-  }
-};
-
-const formatMismatchedArgs = (expected: any, received: any): string => {
-  const length = Math.max(expected.length, received.length);
-
-  const printedArgs = [];
-  for (let i = 0; i < length; i++) {
-    if (!equals(expected[i], received[i], [iterableEquality])) {
-      const oneline = isOneline(expected[i], received[i]);
-      const diffString = diff(expected[i], received[i]);
-      printedArgs.push(
-        `  ${printExpected(expected[i])}\n` +
-          `as argument ${i + 1}, but it was called with\n` +
-          `  ${printReceived(received[i])}.` +
-          (diffString && !oneline ? `\n\nDifference:\n\n${diffString}` : ''),
-      );
-    } else if (i >= expected.length) {
-      printedArgs.push(
-        `  Did not expect argument ${i + 1} ` +
-          `but it was called with ${printReceived(received[i])}.`,
-      );
-    }
-  }
-
-  return printedArgs.join('\n');
-};
-
-const nthToString = (nth: number): string => {
-  switch (nth) {
-    case 1:
-      return 'first';
-    case 2:
-      return 'second';
-    case 3:
-      return 'third';
-  }
-  return `${nth}th`;
 };
 
 export default spyMatchers;

--- a/packages/expect/src/spyMatchers.ts
+++ b/packages/expect/src/spyMatchers.ts
@@ -146,9 +146,8 @@ const printExpectedReceivedCallsPositive = (
   const label = 'Received: ';
   if (isOnlyCall && (iExpectedCall === 0 || iExpectedCall === undefined)) {
     const received = indexedCalls[0][1];
-    const isOnlyCallLineDiffable = isLineDiffableCall(expected, received);
 
-    if (isOnlyCallLineDiffable) {
+    if (isLineDiffableCall(expected, received)) {
       // Display diff without indentation.
       const lines = [
         EXPECTED_COLOR('- Expected'),


### PR DESCRIPTION
## Summary

Fixes #7884

For positive `toHaveBeen*CalledWith` assertions:

* Display matcher name in regular black instead of dim color
* Replace sentences with `Expected` and `Received` labels
* Display `Number of calls` at end of report
* Display received call arguments on one line separated by commas with dim color if value is equal to expected, except for the following special cases:

Display line diff for received call which corresponds to expected call number:

* not indented if only one received call
* indented if multiple received calls

Residue: replace line diff with data-driven diff formatted on one line, when it becomes available

@bandersongit These improvements build on recent pull requests:

* #8755 for negative `toHaveBeen*CalledWith` matchers
* #8710 for `toHave*ReturnedWith` matchers
* #8649 for simpler mock-spy matchers

Read the following descriptions with the qualifier **if they exist**:

| matcher | report displays calls |
| ---: | :--- |
| `toHaveBeenCalledWith` | first 3 calls, including `called with 0 arguments` |
| `toHaveBeenLastCalledWith` | last call and either nearest preceding arguments that are equal to expected; otherwise, next-to-last call |
| `toHaveBeenNthCalledWith` | nth call and either nearest preceding/following arguments that are equal to expected; otherwise, adjacent calls |

**Questions**

* What do you think about **comma** following argument when report contains line diff?
* Is **dim** color relevant to `toHave*Returned` matchers when received value is equal to expected?

Faithful reviewers, this is last in series of basic improvements to all matchers! Thank you ❤️

## Test plan

Updated 34 snapshots

| | long name | short name |
| ---: | :--- | :--- |
| 6 | `toHaveBeenCalledWith` | `toBeCalledWith` |
| 6 | `toHaveBeenLastCalledWith` | `lastCalledWith` |
| 5 | `toHaveBeenNthCalledWith` | `nthCalledWith` |

See also pictures in following comments

Example pictures baseline at left and **improved at right**