### PR TITLE
Docs - Expect API - toThrow - Added a note about the type of value thrown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - `[jest-runtime]` [**BREAKING**] Remove long-deprecated `require.requireActual` and `require.requireMock` methods ([#9854](https://github.com/facebook/jest/pull/9854))
 - `[expect, jest-mock, pretty-format]` [**BREAKING**] Remove `build-es5` from package ([#9945](https://github.com/facebook/jest/pull/9945))
 - `[jest-haste-map]` [**BREAKING**] removed `providesModuleNodeModules` ([#8535](https://github.com/facebook/jest/pull/8535))
+- `[docs]` Add note to `toThrow` Expect API ([#8772](https://github.com/facebook/jest/pull/8772))
 
 ### Performance
 

--- a/docs/ExpectAPI.md
+++ b/docs/ExpectAPI.md
@@ -1208,7 +1208,7 @@ test('throws on octopus', () => {
 });
 ```
 
-> Note: You must wrap the code in a function, otherwise the error will not be caught and the assertion will fail.
+> Note: You must wrap the code in a function, otherwise the error will not be caught and the assertion will fail. Furthermore, `.toThrow` will check that the value thrown is the instance of the Error class, and if not it will not be detected.
 
 You can provide an optional argument to test that a specific error is thrown:
 


### PR DESCRIPTION
## Summary
I and some others have ran into issues where one is testing some code they expect to throw, but the code doesn't specifically throw an instance of `Error`, the test will simply fail without explanation. This can be due to throwing anything other than `new Error(...)`, where Jest will not recognize what the function has thrown. This addition to the docs merely clarifies that `toThrow` is specifically looking for an instance of `Error`.

## Test plan
None, simple addition to the docs for clarification.
