### PR TITLE
chore: Make sure copyright header comment includes license

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@
 - `[docs]` Updated react tutorial to refer to new package of react-testing-library (@testing-library/react) ([#8753](https://github.com/facebook/jest/pull/8753))
 - `[docs]` Updated imports of react-testing-library to @testing-library/react in website ([#8757](https://github.com/facebook/jest/pull/8757))
 - `[jest-core]` Add `getVersion` (moved from `jest-cli`) ([#8706](https://github.com/facebook/jest/pull/8706))
-- `[docs]` Fix MockFunctions example that was using toContain instead of toContainEqual ([#8765](https://github.com/facebook/jest/pull/8765))
+- `[docs]` Fix MockFunctions example that was using toContain instead of toContainEqual ([#8765](https://github.com/facebook/jest/pull/8765)) `[*]` Make sure copyright header comment includes license ([#8783](https://github.com/facebook/jest/pull/8783))
 
 ### Performance
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 module.exports = {
   babelrcRoots: ['examples/*'],

--- a/e2e/__tests__/__snapshots__/beforeAllFiltered.ts.snap
+++ b/e2e/__tests__/__snapshots__/beforeAllFiltered.ts.snap
@@ -1,19 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Correct BeforeAll run ensures the BeforeAll of ignored suite is not run 1`] = `
-  console.log __tests__/beforeAllFiltered.test.js:5
+  console.log __tests__/beforeAllFiltered.test.js:10
     beforeAll 1
 
-  console.log __tests__/beforeAllFiltered.test.js:8
+  console.log __tests__/beforeAllFiltered.test.js:13
     beforeEach 1
 
-  console.log __tests__/beforeAllFiltered.test.js:17
+  console.log __tests__/beforeAllFiltered.test.js:22
     It Foo
 
-  console.log __tests__/beforeAllFiltered.test.js:11
+  console.log __tests__/beforeAllFiltered.test.js:16
     afterEach 1
 
-  console.log __tests__/beforeAllFiltered.test.js:14
+  console.log __tests__/beforeAllFiltered.test.js:19
     afterAll 1
 
 `;

--- a/e2e/__tests__/__snapshots__/beforeEachQueue.ts.snap
+++ b/e2e/__tests__/__snapshots__/beforeEachQueue.ts.snap
@@ -1,19 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Correct beforeEach order ensures the correct order for beforeEach 1`] = `
-  console.log __tests__/beforeEachQueue.test.js:5
+  console.log __tests__/beforeEachQueue.test.js:10
     BeforeEach
 
-  console.log __tests__/beforeEachQueue.test.js:9
+  console.log __tests__/beforeEachQueue.test.js:14
     It Foo
 
-  console.log __tests__/beforeEachQueue.test.js:12
+  console.log __tests__/beforeEachQueue.test.js:17
     BeforeEach Inline Foo
 
-  console.log __tests__/beforeEachQueue.test.js:5
+  console.log __tests__/beforeEachQueue.test.js:10
     BeforeEach
 
-  console.log __tests__/beforeEachQueue.test.js:17
+  console.log __tests__/beforeEachQueue.test.js:22
     It Bar
 
 `;

--- a/e2e/__tests__/__snapshots__/coverageRemapping.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/coverageRemapping.test.ts.snap
@@ -27,32 +27,32 @@ Object {
         "loc": Object {
           "end": Object {
             "column": 35,
-            "line": 6,
+            "line": 11,
           },
           "start": Object {
             "column": 34,
-            "line": 6,
+            "line": 11,
           },
         },
         "locations": Array [
           Object {
             "end": Object {
               "column": 35,
-              "line": 6,
+              "line": 11,
             },
             "start": Object {
               "column": 34,
-              "line": 6,
+              "line": 11,
             },
           },
           Object {
             "end": Object {
               "column": 39,
-              "line": 6,
+              "line": 11,
             },
             "start": Object {
               "column": 38,
-              "line": 6,
+              "line": 11,
             },
           },
         ],
@@ -62,32 +62,32 @@ Object {
         "loc": Object {
           "end": Object {
             "column": 35,
-            "line": 7,
+            "line": 12,
           },
           "start": Object {
             "column": 34,
-            "line": 7,
+            "line": 12,
           },
         },
         "locations": Array [
           Object {
             "end": Object {
               "column": 35,
-              "line": 7,
+              "line": 12,
             },
             "start": Object {
               "column": 34,
-              "line": 7,
+              "line": 12,
             },
           },
           Object {
             "end": Object {
               "column": 39,
-              "line": 7,
+              "line": 12,
             },
             "start": Object {
               "column": 38,
-              "line": 7,
+              "line": 12,
             },
           },
         ],
@@ -97,42 +97,42 @@ Object {
         "loc": Object {
           "end": Object {
             "column": 31,
-            "line": 8,
+            "line": 13,
           },
           "start": Object {
             "column": 27,
-            "line": 8,
+            "line": 13,
           },
         },
         "locations": Array [
           Object {
             "end": Object {
               "column": 31,
-              "line": 8,
+              "line": 13,
             },
             "start": Object {
               "column": 27,
-              "line": 8,
+              "line": 13,
             },
           },
           Object {
             "end": Object {
               "column": 39,
-              "line": 8,
+              "line": 13,
             },
             "start": Object {
               "column": 35,
-              "line": 8,
+              "line": 13,
             },
           },
           Object {
             "end": Object {
               "column": 48,
-              "line": 8,
+              "line": 13,
             },
             "start": Object {
               "column": 43,
-              "line": 8,
+              "line": 13,
             },
           },
         ],
@@ -142,32 +142,32 @@ Object {
         "loc": Object {
           "end": Object {
             "column": 40,
-            "line": 9,
+            "line": 14,
           },
           "start": Object {
             "column": 30,
-            "line": 9,
+            "line": 14,
           },
         },
         "locations": Array [
           Object {
             "end": Object {
               "column": 40,
-              "line": 9,
+              "line": 14,
             },
             "start": Object {
               "column": 30,
-              "line": 9,
+              "line": 14,
             },
           },
           Object {
             "end": Object {
               "column": 53,
-              "line": 9,
+              "line": 14,
             },
             "start": Object {
               "column": 43,
-              "line": 9,
+              "line": 14,
             },
           },
         ],
@@ -184,21 +184,21 @@ Object {
         "decl": Object {
           "end": Object {
             "column": 29,
-            "line": 5,
+            "line": 10,
           },
           "start": Object {
             "column": 9,
-            "line": 5,
+            "line": 10,
           },
         },
         "loc": Object {
           "end": Object {
             "column": 1,
-            "line": 12,
+            "line": 17,
           },
           "start": Object {
             "column": 49,
-            "line": 5,
+            "line": 10,
           },
         },
         "name": "difference",
@@ -207,21 +207,21 @@ Object {
         "decl": Object {
           "end": Object {
             "column": 36,
-            "line": 9,
+            "line": 14,
           },
           "start": Object {
             "column": 30,
-            "line": 9,
+            "line": 14,
           },
         },
         "loc": Object {
           "end": Object {
             "column": 40,
-            "line": 9,
+            "line": 14,
           },
           "start": Object {
             "column": 30,
-            "line": 9,
+            "line": 14,
           },
         },
         "name": "(anonymous_1)",
@@ -230,21 +230,21 @@ Object {
         "decl": Object {
           "end": Object {
             "column": 49,
-            "line": 9,
+            "line": 14,
           },
           "start": Object {
             "column": 43,
-            "line": 9,
+            "line": 14,
           },
         },
         "loc": Object {
           "end": Object {
             "column": 53,
-            "line": 9,
+            "line": 14,
           },
           "start": Object {
             "column": 43,
-            "line": 9,
+            "line": 14,
           },
         },
         "name": "(anonymous_2)",
@@ -265,81 +265,81 @@ Object {
       "0": Object {
         "end": Object {
           "column": 2,
-          "line": 12,
+          "line": 17,
         },
         "start": Object {
           "column": 0,
-          "line": 5,
+          "line": 10,
         },
       },
       "1": Object {
         "end": Object {
           "column": 39,
-          "line": 6,
+          "line": 11,
         },
         "start": Object {
           "column": 27,
-          "line": 6,
+          "line": 11,
         },
       },
       "2": Object {
         "end": Object {
           "column": 39,
-          "line": 7,
+          "line": 12,
         },
         "start": Object {
           "column": 27,
-          "line": 7,
+          "line": 12,
         },
       },
       "3": Object {
         "end": Object {
           "column": 48,
-          "line": 8,
+          "line": 13,
         },
         "start": Object {
           "column": 27,
-          "line": 8,
+          "line": 13,
         },
       },
       "4": Object {
         "end": Object {
           "column": 53,
-          "line": 9,
+          "line": 14,
         },
         "start": Object {
           "column": 23,
-          "line": 9,
+          "line": 14,
         },
       },
       "5": Object {
         "end": Object {
           "column": 43,
-          "line": 9,
+          "line": 14,
         },
         "start": Object {
           "column": 36,
-          "line": 9,
+          "line": 14,
         },
       },
       "6": Object {
         "end": Object {
           "column": 54,
-          "line": 9,
+          "line": 14,
         },
         "start": Object {
           "column": 49,
-          "line": 9,
+          "line": 14,
         },
       },
       "7": Object {
         "end": Object {
           "column": 15,
-          "line": 11,
+          "line": 16,
         },
         "start": Object {
           "column": 2,
-          "line": 11,
+          "line": 16,
         },
       },
     },

--- a/e2e/__tests__/__snapshots__/detectOpenHandles.ts.snap
+++ b/e2e/__tests__/__snapshots__/detectOpenHandles.ts.snap
@@ -13,14 +13,14 @@ Jest has detected the following 1 open handle potentially keeping Jest from exit
 
   ●  GETADDRINFOREQWRAP
 
-       7 | const app = new Server();
-       8 | 
-    >  9 | app.listen({host: 'localhost', port: 0});
+      12 | const app = new Server();
+      13 | 
+    > 14 | app.listen({host: 'localhost', port: 0});
          |     ^
-      10 | 
+      15 | 
 
-      at Object.listen (server.js:9:5)
-      at Object.require (__tests__/outside.js:3:1)
+      at Object.listen (server.js:14:5)
+      at Object.require (__tests__/outside.js:8:1)
 `;
 
 exports[`prints out info about open handlers from inside tests 1`] = `
@@ -28,13 +28,13 @@ Jest has detected the following 1 open handle potentially keeping Jest from exit
 
   ●  Timeout
 
-      2 | 
-      3 | test('something', () => {
-    > 4 |   setTimeout(() => {}, 30000);
-        |   ^
-      5 |   expect(true).toBe(true);
-      6 | });
-      7 | 
+       7 | 
+       8 | test('something', () => {
+    >  9 |   setTimeout(() => {}, 30000);
+         |   ^
+      10 |   expect(true).toBe(true);
+      11 | });
+      12 | 
 
-      at Object.setTimeout (__tests__/inside.js:4:3)
+      at Object.setTimeout (__tests__/inside.js:9:3)
 `;

--- a/e2e/__tests__/__snapshots__/failures.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/failures.test.ts.snap
@@ -126,43 +126,43 @@ FAIL __tests__/duringTests.test.js
 
     thrown: Promise {}
 
-       7 | };
-       8 | 
-    >  9 | test('Promise thrown during test', () => {
+      12 | };
+      13 | 
+    > 14 | test('Promise thrown during test', () => {
          | ^
-      10 |   throw Promise.resolve(5);
-      11 | });
-      12 | 
+      15 |   throw Promise.resolve(5);
+      16 | });
+      17 | 
 
-      at Object.test (__tests__/duringTests.test.js:9:1)
+      at Object.test (__tests__/duringTests.test.js:14:1)
 
   ● Boolean thrown during test
 
     thrown: false
 
-      11 | });
-      12 | 
-    > 13 | test('Boolean thrown during test', () => {
-         | ^
-      14 |   // eslint-disable-next-line no-throw-literal
-      15 |   throw false;
       16 | });
+      17 | 
+    > 18 | test('Boolean thrown during test', () => {
+         | ^
+      19 |   // eslint-disable-next-line no-throw-literal
+      20 |   throw false;
+      21 | });
 
-      at Object.test (__tests__/duringTests.test.js:13:1)
+      at Object.test (__tests__/duringTests.test.js:18:1)
 
   ● undefined thrown during test
 
     thrown: undefined
 
-      16 | });
-      17 | 
-    > 18 | test('undefined thrown during test', () => {
-         | ^
-      19 |   // eslint-disable-next-line no-throw-literal
-      20 |   throw undefined;
       21 | });
+      22 | 
+    > 23 | test('undefined thrown during test', () => {
+         | ^
+      24 |   // eslint-disable-next-line no-throw-literal
+      25 |   throw undefined;
+      26 | });
 
-      at Object.test (__tests__/duringTests.test.js:18:1)
+      at Object.test (__tests__/duringTests.test.js:23:1)
 
   ● Object thrown during test
 
@@ -175,43 +175,43 @@ FAIL __tests__/duringTests.test.js
       ],
     }
 
-      21 | });
-      22 | 
-    > 23 | test('Object thrown during test', () => {
+      26 | });
+      27 | 
+    > 28 | test('Object thrown during test', () => {
          | ^
-      24 |   throw deepObject;
-      25 | });
-      26 | 
+      29 |   throw deepObject;
+      30 | });
+      31 | 
 
-      at Object.test (__tests__/duringTests.test.js:23:1)
+      at Object.test (__tests__/duringTests.test.js:28:1)
 
   ● Error during test
 
     ReferenceError: doesNotExist is not defined
 
-      27 | test('Error during test', () => {
-      28 |   // eslint-disable-next-line no-undef
-    > 29 |   doesNotExist.alsoThisNot;
+      32 | test('Error during test', () => {
+      33 |   // eslint-disable-next-line no-undef
+    > 34 |   doesNotExist.alsoThisNot;
          |   ^
-      30 | });
-      31 | 
-      32 | test('done(Error)', done => {
+      35 | });
+      36 | 
+      37 | test('done(Error)', done => {
 
-      at Object.doesNotExist (__tests__/duringTests.test.js:29:3)
+      at Object.doesNotExist (__tests__/duringTests.test.js:34:3)
 
   ● done(Error)
 
     this is an error
 
-      31 | 
-      32 | test('done(Error)', done => {
-    > 33 |   done(new Error('this is an error'));
+      36 | 
+      37 | test('done(Error)', done => {
+    > 38 |   done(new Error('this is an error'));
          |        ^
-      34 | });
-      35 | 
-      36 | test('done(non-error)', done => {
+      39 | });
+      40 | 
+      41 | test('done(non-error)', done => {
 
-      at Object.<anonymous>.done (__tests__/duringTests.test.js:33:8)
+      at Object.<anonymous>.done (__tests__/duringTests.test.js:38:8)
 
   ● done(non-error)
 
@@ -224,15 +224,15 @@ FAIL __tests__/duringTests.test.js
       ],
     }
 
-      35 | 
-      36 | test('done(non-error)', done => {
-    > 37 |   done(deepObject);
+      40 | 
+      41 | test('done(non-error)', done => {
+    > 42 |   done(deepObject);
          |   ^
-      38 | });
-      39 | 
-      40 | test('returned promise rejection', () => Promise.reject(deepObject));
+      43 | });
+      44 | 
+      45 | test('returned promise rejection', () => Promise.reject(deepObject));
 
-      at Object.done (__tests__/duringTests.test.js:37:3)
+      at Object.done (__tests__/duringTests.test.js:42:3)
 
   ● returned promise rejection
 
@@ -245,13 +245,13 @@ FAIL __tests__/duringTests.test.js
       ],
     }
 
-      38 | });
-      39 | 
-    > 40 | test('returned promise rejection', () => Promise.reject(deepObject));
+      43 | });
+      44 | 
+    > 45 | test('returned promise rejection', () => Promise.reject(deepObject));
          | ^
-      41 | 
+      46 | 
 
-      at Object.test (__tests__/duringTests.test.js:40:1)
+      at Object.test (__tests__/duringTests.test.js:45:1)
 `;
 
 exports[`works with assertions in separate files 1`] = `

--- a/e2e/__tests__/__snapshots__/processExit.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/processExit.test.ts.snap
@@ -3,14 +3,14 @@
 exports[`prints stack trace pointing to process.exit call 1`] = `
   ●  process.exit called with "1"
 
-      1 | // Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
-      2 | 
-    > 3 | process.exit(1);
-        |         ^
-      4 | 
-      5 | test('something', () => {
-      6 |   expect(true).toBe(true);
+       6 |  */
+       7 | 
+    >  8 | process.exit(1);
+         |         ^
+       9 | 
+      10 | test('something', () => {
+      11 |   expect(true).toBe(true);
 
-      at Object.exit (__tests__/test.js:3:9)
+      at Object.exit (__tests__/test.js:8:9)
 
 `;

--- a/e2e/__tests__/__snapshots__/resolveNoFileExtensions.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/resolveNoFileExtensions.test.ts.snap
@@ -27,12 +27,12 @@ FAIL __tests__/test.js
 
     See https://jestjs.io/docs/en/configuration#modulefileextensions-array-string
 
-      1 | // Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
-      2 | 
-    > 3 | module.exports = require('./some-json-file');
+      6 |  */
+      7 | 
+    > 8 | module.exports = require('./some-json-file');
         |                  ^
-      4 | 
+      9 | 
 
       at Resolver.resolveModule (../../packages/jest-resolve/build/index.js:259:17)
-      at Object.require (index.js:3:18)
+      at Object.require (index.js:8:18)
 `;

--- a/e2e/async-regenerator/__tests__/test.js
+++ b/e2e/async-regenerator/__tests__/test.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 test('dummy test', async () => {
   const value = await Promise.resolve(1);

--- a/e2e/async-regenerator/babel.config.js
+++ b/e2e/async-regenerator/babel.config.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 module.exports = {
   plugins: [

--- a/e2e/babel-plugin-jest-hoist/babel.config.js
+++ b/e2e/babel-plugin-jest-hoist/babel.config.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 module.exports = {
   overrides: [

--- a/e2e/before-all-filtered/__tests__/beforeAllFiltered.test.js
+++ b/e2e/before-all-filtered/__tests__/beforeAllFiltered.test.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 describe('test_1', () => {
   beforeAll(() => {

--- a/e2e/before-each-queue/__tests__/beforeEachQueue.test.js
+++ b/e2e/before-each-queue/__tests__/beforeEachQueue.test.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 describe('test', () => {
   beforeEach(() => {

--- a/e2e/compare-dom-nodes/__tests__/failedAssertion.js
+++ b/e2e/compare-dom-nodes/__tests__/failedAssertion.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 /* global document */
 

--- a/e2e/coverage-remapping/__tests__/coveredTest.ts
+++ b/e2e/coverage-remapping/__tests__/coveredTest.ts
@@ -1,4 +1,10 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 const difference = require('../covered.ts');
 
 it('subtracts correctly', () => {

--- a/e2e/coverage-remapping/covered.ts
+++ b/e2e/coverage-remapping/covered.ts
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 /* eslint-disable @typescript-eslint/no-unused-vars */
 

--- a/e2e/coverage-report/babel.config.js
+++ b/e2e/coverage-report/babel.config.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 module.exports = {
   presets: ['@babel/preset-flow'],

--- a/e2e/custom-resolver/__mocks__/manualMock.js
+++ b/e2e/custom-resolver/__mocks__/manualMock.js
@@ -1,3 +1,8 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 module.exports = require('bar');

--- a/e2e/custom-resolver/bar.js
+++ b/e2e/custom-resolver/bar.js
@@ -1,3 +1,8 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 module.exports = 'bar';

--- a/e2e/custom-resolver/foo.js
+++ b/e2e/custom-resolver/foo.js
@@ -1,3 +1,8 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 module.exports = () => {};

--- a/e2e/custom-resolver/manualMock.js
+++ b/e2e/custom-resolver/manualMock.js
@@ -1,3 +1,8 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 throw new Error('Must be mocked');

--- a/e2e/custom-resolver/resolver.js
+++ b/e2e/custom-resolver/resolver.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 const {
   default: defaultResolver,

--- a/e2e/deprecated-cli-options/__tests__/dummy.js
+++ b/e2e/deprecated-cli-options/__tests__/dummy.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 test('Dummy', () => {
   expect(2).toBe(2);

--- a/e2e/detect-open-handles/__tests__/inside.js
+++ b/e2e/detect-open-handles/__tests__/inside.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 test('something', () => {
   setTimeout(() => {}, 30000);

--- a/e2e/detect-open-handles/__tests__/outside.js
+++ b/e2e/detect-open-handles/__tests__/outside.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 require('../server');
 

--- a/e2e/detect-open-handles/__tests__/promise.js
+++ b/e2e/detect-open-handles/__tests__/promise.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 test('something', () => {
   // eslint-disable-next-line no-new

--- a/e2e/detect-open-handles/babel.config.js
+++ b/e2e/detect-open-handles/babel.config.js
@@ -1,3 +1,8 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 module.exports = require('../../babel.config');

--- a/e2e/detect-open-handles/server.js
+++ b/e2e/detect-open-handles/server.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 'use strict';
 

--- a/e2e/expect-async-matcher/babel.config.js
+++ b/e2e/expect-async-matcher/babel.config.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 const baseConfig = require('../../babel.config');
 

--- a/e2e/failures/__tests__/duringTests.test.js
+++ b/e2e/failures/__tests__/duringTests.test.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 'use strict';
 

--- a/e2e/failures/babel.config.js
+++ b/e2e/failures/babel.config.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 const baseConfig = require('../../babel.config');
 

--- a/e2e/filter/my-broken-filter.js
+++ b/e2e/filter/my-broken-filter.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 'use strict';
 

--- a/e2e/filter/my-broken-setup-filter.js
+++ b/e2e/filter/my-broken-setup-filter.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 'use strict';
 

--- a/e2e/filter/my-clowny-filter.js
+++ b/e2e/filter/my-clowny-filter.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 'use strict';
 

--- a/e2e/filter/my-filter.js
+++ b/e2e/filter/my-filter.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 'use strict';
 

--- a/e2e/filter/my-secondary-filter.js
+++ b/e2e/filter/my-secondary-filter.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 'use strict';
 

--- a/e2e/filter/my-setup-filter.js
+++ b/e2e/filter/my-setup-filter.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 'use strict';
 

--- a/e2e/global-setup-custom-transform/index.js
+++ b/e2e/global-setup-custom-transform/index.js
@@ -1,3 +1,8 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 module.exports = 'hello!';

--- a/e2e/global-setup-custom-transform/transformer.js
+++ b/e2e/global-setup-custom-transform/transformer.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 'use strict';
 

--- a/e2e/global-setup/babel.config.js
+++ b/e2e/global-setup/babel.config.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 module.exports = {
   presets: ['@babel/preset-env', '@babel/preset-flow'],

--- a/e2e/global-setup/custom-tests-dir/pass.test.js
+++ b/e2e/global-setup/custom-tests-dir/pass.test.js
@@ -1,3 +1,8 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 test('should pass', () => {});

--- a/e2e/global-setup/invalidSetup.js
+++ b/e2e/global-setup/invalidSetup.js
@@ -1,3 +1,8 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 console.log('there is no exported function');

--- a/e2e/global-teardown/babel.config.js
+++ b/e2e/global-teardown/babel.config.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 module.exports = {
   presets: ['@babel/preset-env', '@babel/preset-flow'],

--- a/e2e/global-teardown/custom-tests-dir/pass.test.js
+++ b/e2e/global-teardown/custom-tests-dir/pass.test.js
@@ -1,3 +1,8 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 test('should pass', () => {});

--- a/e2e/global-teardown/invalidTeardown.js
+++ b/e2e/global-teardown/invalidTeardown.js
@@ -1,3 +1,8 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 console.log('there is no exported function');

--- a/e2e/jasmine-async/__tests__/pendingInPromise.test.js
+++ b/e2e/jasmine-async/__tests__/pendingInPromise.test.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 'use strict';
 

--- a/e2e/multi-project-config-root/bar/__tests__/boggusBar.test.js
+++ b/e2e/multi-project-config-root/bar/__tests__/boggusBar.test.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 describe('Bar', () => {
   it('fail', () => {

--- a/e2e/multi-project-config-root/foo/__tests__/boggusFoo.test.js
+++ b/e2e/multi-project-config-root/foo/__tests__/boggusFoo.test.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 describe('Foo', () => {
   it('fail', () => {

--- a/e2e/native-async-mock/Native.js
+++ b/e2e/native-async-mock/Native.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 'use strict';
 

--- a/e2e/native-async-mock/__tests__/nativeAsyncMock.test.js
+++ b/e2e/native-async-mock/__tests__/nativeAsyncMock.test.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 'use strict';
 

--- a/e2e/override-globals/babel.config.js
+++ b/e2e/override-globals/babel.config.js
@@ -1,3 +1,8 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 module.exports = require('../../babel.config');

--- a/e2e/presets/js/node_modules/jest-preset-js/jest-preset.js
+++ b/e2e/presets/js/node_modules/jest-preset-js/jest-preset.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 module.exports = {
   moduleNameMapper: {

--- a/e2e/presets/js/node_modules/jest-preset-js/mapper.js
+++ b/e2e/presets/js/node_modules/jest-preset-js/mapper.js
@@ -1,3 +1,8 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 module.exports = 42;

--- a/e2e/presets/json/node_modules/jest-preset-json/mapper.js
+++ b/e2e/presets/json/node_modules/jest-preset-json/mapper.js
@@ -1,3 +1,8 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 module.exports = 42;

--- a/e2e/process-exit/__tests__/test.js
+++ b/e2e/process-exit/__tests__/test.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 process.exit(1);
 

--- a/e2e/process-exit/babel.config.js
+++ b/e2e/process-exit/babel.config.js
@@ -1,3 +1,8 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 module.exports = require('../../babel.config');

--- a/e2e/require-main/babel.config.js
+++ b/e2e/require-main/babel.config.js
@@ -1,3 +1,8 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 module.exports = require('../../babel.config');

--- a/e2e/resolve-get-paths/babel.config.js
+++ b/e2e/resolve-get-paths/babel.config.js
@@ -1,3 +1,8 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 module.exports = require('../../babel.config');

--- a/e2e/resolve-no-extensions/__tests__/test.js
+++ b/e2e/resolve-no-extensions/__tests__/test.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 const m = require('../');
 

--- a/e2e/resolve-no-extensions/babel.config.js
+++ b/e2e/resolve-no-extensions/babel.config.js
@@ -1,3 +1,8 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 module.exports = require('../../babel.config');

--- a/e2e/resolve-no-extensions/index.js
+++ b/e2e/resolve-no-extensions/index.js
@@ -1,3 +1,8 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 module.exports = require('./some-json-file');

--- a/e2e/resolve-with-paths/babel.config.js
+++ b/e2e/resolve-with-paths/babel.config.js
@@ -1,3 +1,8 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 module.exports = require('../../babel.config');

--- a/e2e/run-programmatically/babel.config.js
+++ b/e2e/run-programmatically/babel.config.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 module.exports = {
   presets: ['@babel/preset-env'],

--- a/e2e/snapshot-resolver/__tests__/snapshot.test.js
+++ b/e2e/snapshot-resolver/__tests__/snapshot.test.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 test('snapshots are written to custom location', () => {
   expect('foobar').toMatchSnapshot();

--- a/e2e/snapshot-resolver/customSnapshotResolver.js
+++ b/e2e/snapshot-resolver/customSnapshotResolver.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 module.exports = {
   resolveSnapshotPath: (testPath, snapshotExtension) =>

--- a/e2e/test-environment-async/TestEnvironment.js
+++ b/e2e/test-environment-async/TestEnvironment.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 'use strict';
 

--- a/e2e/test-environment-circus/CircusHandleTestEventEnvironment.js
+++ b/e2e/test-environment-circus/CircusHandleTestEventEnvironment.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 'use strict';
 

--- a/e2e/test-environment-circus/__tests__/circusHandleTestEvent.test.js
+++ b/e2e/test-environment-circus/__tests__/circusHandleTestEvent.test.js
@@ -1,6 +1,9 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
  * @jest-environment ./CircusHandleTestEventEnvironment.js
  */
 

--- a/e2e/test-environment/DocblockPragmasEnvironment.js
+++ b/e2e/test-environment/DocblockPragmasEnvironment.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 'use strict';
 

--- a/e2e/test-environment/__tests__/docblockPragmas.test.js
+++ b/e2e/test-environment/__tests__/docblockPragmas.test.js
@@ -1,6 +1,9 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
  * @jest-environment ./DocblockPragmasEnvironment.js
  * @my-custom-pragma pragma-value
  */

--- a/e2e/timer-reset-mocks/after-reset-all-mocks/timerAndMock.test.js
+++ b/e2e/timer-reset-mocks/after-reset-all-mocks/timerAndMock.test.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 describe('timers', () => {
   it('should work before calling resetAllMocks', () => {

--- a/e2e/timer-reset-mocks/with-reset-mocks/timerWithMock.test.js
+++ b/e2e/timer-reset-mocks/with-reset-mocks/timerWithMock.test.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 describe('timers', () => {
   it('should work before calling resetAllMocks', () => {

--- a/e2e/timer-use-real-timers/__tests__/useRealTimers.test.js
+++ b/e2e/timer-use-real-timers/__tests__/useRealTimers.test.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 jest.useRealTimers();
 

--- a/e2e/to-match-inline-snapshot/babel.config.js
+++ b/e2e/to-match-inline-snapshot/babel.config.js
@@ -1,3 +1,8 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 module.exports = require('../../babel.config');

--- a/e2e/to-throw-error-matching-inline-snapshot/babel.config.js
+++ b/e2e/to-throw-error-matching-inline-snapshot/babel.config.js
@@ -1,3 +1,8 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 module.exports = require('../../babel.config');

--- a/e2e/transform-linked-modules/__tests__/linkedModules.test.js
+++ b/e2e/transform-linked-modules/__tests__/linkedModules.test.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 test('normal file', () => {
   const normal = require('../ignored/normal');

--- a/e2e/transform-linked-modules/ignored/normal.js
+++ b/e2e/transform-linked-modules/ignored/normal.js
@@ -1,3 +1,8 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 module.exports = 'ignored/normal';

--- a/e2e/transform-linked-modules/package/index.js
+++ b/e2e/transform-linked-modules/package/index.js
@@ -1,3 +1,8 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 module.exports = 'package/index';

--- a/e2e/transform-linked-modules/preprocessor.js
+++ b/e2e/transform-linked-modules/preprocessor.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 module.exports = {
   process() {

--- a/e2e/transform/babel-jest-ignored/babel.config.js
+++ b/e2e/transform/babel-jest-ignored/babel.config.js
@@ -1,3 +1,8 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 module.exports = {only: ['blablabla']};

--- a/e2e/transform/babel-jest/babel.config.js
+++ b/e2e/transform/babel-jest/babel.config.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 module.exports = {
   presets: ['@babel/preset-flow'],

--- a/e2e/transform/ecmascript-modules-support/babel.config.js
+++ b/e2e/transform/ecmascript-modules-support/babel.config.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 module.exports = {
   presets: [

--- a/e2e/transform/ecmascript-modules-support/src/index.mjs
+++ b/e2e/transform/ecmascript-modules-support/src/index.mjs
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 import {foo} from './module';
 

--- a/e2e/transform/ecmascript-modules-support/src/module.mjs
+++ b/e2e/transform/ecmascript-modules-support/src/module.mjs
@@ -1,3 +1,8 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 export const foo = () => 'a';

--- a/e2e/transform/multiple-transformers/babel.config.js
+++ b/e2e/transform/multiple-transformers/babel.config.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 module.exports = {
   presets: ['@babel/preset-env', '@babel/preset-react'],

--- a/e2e/typescript-coverage/__tests__/coveredTest.ts
+++ b/e2e/typescript-coverage/__tests__/coveredTest.ts
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 it('adds 1 + 2 to equal 3 in TScript', () => {
   const sum = require('../covered.ts');

--- a/e2e/typescript-coverage/covered.ts
+++ b/e2e/typescript-coverage/covered.ts
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 export = function sum(a: number, b: number): number {
   return a + b;

--- a/e2e/typescript-coverage/typescriptPreprocessor.js
+++ b/e2e/typescript-coverage/typescriptPreprocessor.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 const tsc = require('typescript');
 

--- a/jest.config.ci.js
+++ b/jest.config.ci.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 'use strict';
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 'use strict';
 

--- a/packages/jest-circus/runner.js
+++ b/packages/jest-circus/runner.js
@@ -1,9 +1,8 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 // Allow people to use `jest-circus/runner` as a runner.

--- a/packages/jest-circus/src/__mocks__/testEventHandler.ts
+++ b/packages/jest-circus/src/__mocks__/testEventHandler.ts
@@ -1,9 +1,8 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 import {Circus} from '@jest/types';

--- a/packages/jest-circus/src/__mocks__/testUtils.ts
+++ b/packages/jest-circus/src/__mocks__/testUtils.ts
@@ -1,9 +1,8 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 import fs from 'fs';

--- a/packages/jest-circus/src/__tests__/afterAll.test.ts
+++ b/packages/jest-circus/src/__tests__/afterAll.test.ts
@@ -1,9 +1,8 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 import {runTest} from '../__mocks__/testUtils';

--- a/packages/jest-circus/src/__tests__/baseTest.test.ts
+++ b/packages/jest-circus/src/__tests__/baseTest.test.ts
@@ -1,9 +1,8 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 import {runTest} from '../__mocks__/testUtils';

--- a/packages/jest-circus/src/__tests__/hooks.test.ts
+++ b/packages/jest-circus/src/__tests__/hooks.test.ts
@@ -1,9 +1,8 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 import {runTest} from '../__mocks__/testUtils';

--- a/packages/jest-cli/src/init/__tests__/fixtures/has_jest_config_file/jest.config.js
+++ b/packages/jest-cli/src/init/__tests__/fixtures/has_jest_config_file/jest.config.js
@@ -1,3 +1,8 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 module.exports = {};

--- a/packages/jest-config/src/__tests__/Defaults.test.ts
+++ b/packages/jest-config/src/__tests__/Defaults.test.ts
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 import {defaults} from '../index';
 

--- a/packages/jest-config/src/__tests__/readConfig.test.ts
+++ b/packages/jest-config/src/__tests__/readConfig.test.ts
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 import {readConfig} from '../index';
 

--- a/packages/jest-config/src/__tests__/readConfigs.test.ts
+++ b/packages/jest-config/src/__tests__/readConfigs.test.ts
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 import {readConfigs} from '../index';
 

--- a/packages/jest-core/src/SnapshotInteractiveMode.ts
+++ b/packages/jest-core/src/SnapshotInteractiveMode.ts
@@ -1,9 +1,8 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 import chalk from 'chalk';

--- a/packages/jest-core/src/__tests__/FailedTestsCache.test.js
+++ b/packages/jest-core/src/__tests__/FailedTestsCache.test.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 import FailedTestsCache from '../FailedTestsCache';
 

--- a/packages/jest-core/src/__tests__/__fixtures__/watch_plugin_throws.js
+++ b/packages/jest-core/src/__tests__/__fixtures__/watch_plugin_throws.js
@@ -1,3 +1,8 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 throw new Error('initialization error');

--- a/packages/jest-core/src/__tests__/__snapshots__/watch.test.js.snap
+++ b/packages/jest-core/src/__tests__/__snapshots__/watch.test.js.snap
@@ -57,7 +57,7 @@ exports[`Watch mode flows makes watch plugin initialization errors look nice 1`]
 
     initialization error
 
-      at Object.<anonymous> (__fixtures__/watch_plugin_throws.js:3:7)
+      at Object.<anonymous> (__fixtures__/watch_plugin_throws.js:8:7)
 ]
 `;
 

--- a/packages/jest-core/src/__tests__/getNoTestsFoundMessage.test.js
+++ b/packages/jest-core/src/__tests__/getNoTestsFoundMessage.test.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 import getNoTestsFoundMessage from '../getNoTestsFoundMessage';
 

--- a/packages/jest-core/src/__tests__/run_jest.test.js
+++ b/packages/jest-core/src/__tests__/run_jest.test.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 import runJest from '../runJest';
 

--- a/packages/jest-core/src/__tests__/test_root/__testtests__/test.foobar
+++ b/packages/jest-core/src/__tests__/test_root/__testtests__/test.foobar
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 // test.foobar
 

--- a/packages/jest-core/src/__tests__/test_root/__testtests__/test.js
+++ b/packages/jest-core/src/__tests__/test_root/__testtests__/test.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 // test.js
 

--- a/packages/jest-core/src/__tests__/test_root/__testtests__/test.jsx
+++ b/packages/jest-core/src/__tests__/test_root/__testtests__/test.jsx
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 // test.jsx
 

--- a/packages/jest-core/src/__tests__/test_root/module.foobar
+++ b/packages/jest-core/src/__tests__/test_root/module.foobar
@@ -1,3 +1,8 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 // module.foobar

--- a/packages/jest-core/src/__tests__/test_root/module.jsx
+++ b/packages/jest-core/src/__tests__/test_root/module.jsx
@@ -1,3 +1,8 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 // module.jsx

--- a/packages/jest-core/src/__tests__/test_root/no_tests.js
+++ b/packages/jest-core/src/__tests__/test_root/no_tests.js
@@ -1,3 +1,8 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 // no tests for this one

--- a/packages/jest-core/src/__tests__/test_root_with_(parentheses)/__testtests__/test.js
+++ b/packages/jest-core/src/__tests__/test_root_with_(parentheses)/__testtests__/test.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 // test.js
 

--- a/packages/jest-core/src/__tests__/test_root_with_(parentheses)/module.jsx
+++ b/packages/jest-core/src/__tests__/test_root_with_(parentheses)/module.jsx
@@ -1,3 +1,8 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 // module.jsx

--- a/packages/jest-core/src/getNoTestFoundFailed.ts
+++ b/packages/jest-core/src/getNoTestFoundFailed.ts
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 import chalk from 'chalk';
 

--- a/packages/jest-core/src/getNoTestFoundPassWithNoTests.ts
+++ b/packages/jest-core/src/getNoTestFoundPassWithNoTests.ts
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 import chalk from 'chalk';
 

--- a/packages/jest-core/src/getNoTestFoundRelatedToChangedFiles.ts
+++ b/packages/jest-core/src/getNoTestFoundRelatedToChangedFiles.ts
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 import chalk from 'chalk';
 import {Config} from '@jest/types';

--- a/packages/jest-core/src/getNoTestFoundVerbose.ts
+++ b/packages/jest-core/src/getNoTestFoundVerbose.ts
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 import chalk from 'chalk';
 import {Config} from '@jest/types';

--- a/packages/jest-core/src/pluralize.ts
+++ b/packages/jest-core/src/pluralize.ts
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 export default function pluralize(word: string, count: number, ending: string) {
   return `${count} ${word}${count === 1 ? '' : ending}`;

--- a/packages/jest-docblock/src/__tests__/index.test.ts
+++ b/packages/jest-docblock/src/__tests__/index.test.ts
@@ -1,6 +1,5 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
- * All rights reserved.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/packages/jest-haste-map/src/lib/__tests__/fast_path.test.js
+++ b/packages/jest-haste-map/src/lib/__tests__/fast_path.test.js
@@ -1,10 +1,8 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
- * All rights reserved.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
  */
 
 import path from 'path';

--- a/packages/jest-haste-map/src/lib/__tests__/getPlatformExtension.test.js
+++ b/packages/jest-haste-map/src/lib/__tests__/getPlatformExtension.test.js
@@ -1,10 +1,8 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
- * All rights reserved.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
  */
 
 import getPlatformExtension from '../getPlatformExtension';

--- a/packages/jest-haste-map/src/lib/__tests__/normalizePathSep.test.js
+++ b/packages/jest-haste-map/src/lib/__tests__/normalizePathSep.test.js
@@ -1,10 +1,8 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
- * All rights reserved.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
  */
 
 'use strict';

--- a/packages/jest-leak-detector/src/__tests__/index.test.ts
+++ b/packages/jest-leak-detector/src/__tests__/index.test.ts
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 'use strict';
 

--- a/packages/jest-regex-util/src/__tests__/index.test.ts
+++ b/packages/jest-regex-util/src/__tests__/index.test.ts
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 jest.mock('path');
 

--- a/packages/jest-repl/src/cli/repl.ts
+++ b/packages/jest-repl/src/cli/repl.ts
@@ -1,10 +1,8 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
- * All rights reserved.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
  */
 
 declare const jestGlobalConfig: Config.GlobalConfig;

--- a/packages/jest-resolve/src/__tests__/isBuiltinModule.test.ts
+++ b/packages/jest-resolve/src/__tests__/isBuiltinModule.test.ts
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 import isBuiltinModule from '../isBuiltinModule';
 

--- a/packages/jest-runtime/src/__tests__/defaultResolver.js
+++ b/packages/jest-runtime/src/__tests__/defaultResolver.js
@@ -1,10 +1,9 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
- *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
+
 import resolver from 'jest-resolve/build/defaultResolver.js';
 module.exports = resolver;

--- a/packages/jest-runtime/src/__tests__/test_root/__mocks__/nested1/nested2/nested3.js
+++ b/packages/jest-runtime/src/__tests__/test_root/__mocks__/nested1/nested2/nested3.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 'use strict';
 

--- a/packages/jest-runtime/src/__tests__/test_root/dep_on_mapped_module.js
+++ b/packages/jest-runtime/src/__tests__/test_root/dep_on_mapped_module.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 'use strict';
 

--- a/packages/jest-runtime/src/__tests__/test_root/mapped_dir/moduleInMapped.js
+++ b/packages/jest-runtime/src/__tests__/test_root/mapped_dir/moduleInMapped.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 'use strict';
 

--- a/packages/jest-runtime/src/__tests__/test_root/nested1/nested2/nested3.js
+++ b/packages/jest-runtime/src/__tests__/test_root/nested1/nested2/nested3.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 'use strict';
 

--- a/packages/jest-runtime/src/__tests__/test_root/node_modules/jest-resolve-test/browser.js
+++ b/packages/jest-runtime/src/__tests__/test_root/node_modules/jest-resolve-test/browser.js
@@ -1,3 +1,8 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 module.exports.isBrowser = true;

--- a/packages/jest-runtime/src/__tests__/test_root/node_modules/jest-resolve-test/node.js
+++ b/packages/jest-runtime/src/__tests__/test_root/node_modules/jest-resolve-test/node.js
@@ -1,3 +1,8 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 module.exports.isBrowser = false;

--- a/packages/jest-runtime/src/__tests__/test_root/sourcemaps/out/throwing-mapped-fn.js
+++ b/packages/jest-runtime/src/__tests__/test_root/sourcemaps/out/throwing-mapped-fn.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 'use strict';
 
@@ -9,9 +14,8 @@ exports.sum = sum;
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 function sum() {

--- a/packages/jest-runtime/src/__tests__/test_root/sourcemaps/throwing-mapped-fn.js
+++ b/packages/jest-runtime/src/__tests__/test_root/sourcemaps/throwing-mapped-fn.js
@@ -1,9 +1,8 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree. An additional grant
- * of patent rights can be found in the PATENTS file in the same directory.
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 export function sum() {

--- a/packages/jest-runtime/src/helpers.ts
+++ b/packages/jest-runtime/src/helpers.ts
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 import path from 'path';
 import slash from 'slash';

--- a/packages/jest-snapshot/src/__mocks__/prettier.js
+++ b/packages/jest-snapshot/src/__mocks__/prettier.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 const prettier = jest.requireActual('prettier');
 

--- a/packages/jest-snapshot/src/__tests__/fixtures/customSnapshotResolver-inconsistent-fns.js
+++ b/packages/jest-snapshot/src/__tests__/fixtures/customSnapshotResolver-inconsistent-fns.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 module.exports = {
   resolveSnapshotPath: (testPath, snapshotExtension) =>

--- a/packages/jest-snapshot/src/__tests__/fixtures/customSnapshotResolver-missing-resolveSnapshotPath.js
+++ b/packages/jest-snapshot/src/__tests__/fixtures/customSnapshotResolver-missing-resolveSnapshotPath.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 module.exports = {
   resolveTestPath: () => {},

--- a/packages/jest-snapshot/src/__tests__/fixtures/customSnapshotResolver-missing-resolveTestPath.js
+++ b/packages/jest-snapshot/src/__tests__/fixtures/customSnapshotResolver-missing-resolveTestPath.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 module.exports = {
   resolveSnapshotPath: () => {},

--- a/packages/jest-snapshot/src/__tests__/fixtures/customSnapshotResolver-missing-test-path-for-consistency-check.js
+++ b/packages/jest-snapshot/src/__tests__/fixtures/customSnapshotResolver-missing-test-path-for-consistency-check.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 module.exports = {
   resolveSnapshotPath: (testPath, snapshotExtension) => {},

--- a/packages/jest-snapshot/src/__tests__/fixtures/customSnapshotResolver.js
+++ b/packages/jest-snapshot/src/__tests__/fixtures/customSnapshotResolver.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 module.exports = {
   resolveSnapshotPath: (testPath, snapshotExtension) =>

--- a/packages/jest-snapshot/src/__tests__/snapshot_resolver.test.ts
+++ b/packages/jest-snapshot/src/__tests__/snapshot_resolver.test.ts
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 import path from 'path';
 import {Config} from '@jest/types';

--- a/packages/jest-source-map/src/__tests__/getCallsite.test.ts
+++ b/packages/jest-source-map/src/__tests__/getCallsite.test.ts
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 import fs from 'fs';
 import SourceMap from 'source-map';

--- a/packages/jest-transform/src/enhanceUnexpectedTokenMessage.ts
+++ b/packages/jest-transform/src/enhanceUnexpectedTokenMessage.ts
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 import chalk from 'chalk';
 

--- a/packages/jest-util/src/__tests__/isInteractive.test.ts
+++ b/packages/jest-util/src/__tests__/isInteractive.test.ts
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 let oldIsTTY: typeof process.stdout.isTTY;
 let oldTERM: string | undefined;

--- a/packages/jest-util/src/isInteractive.ts
+++ b/packages/jest-util/src/isInteractive.ts
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 import isCI from 'is-ci';
 

--- a/packages/jest-watcher/src/lib/__tests__/scroll.test.ts
+++ b/packages/jest-watcher/src/lib/__tests__/scroll.test.ts
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 import scroll from '../scroll';
 

--- a/scripts/checkCopyrightHeaders.js
+++ b/scripts/checkCopyrightHeaders.js
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.

--- a/scripts/checkCopyrightHeaders.js
+++ b/scripts/checkCopyrightHeaders.js
@@ -117,10 +117,22 @@ const INCLUDED_PATTERNS = [
 
 const COPYRIGHT_HEADER =
   'Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.';
+const LICENSE1 =
+  'This source code is licensed under the MIT license found in the';
+const LICENSE2 = 'LICENSE file in the root directory of this source tree.';
 
 function needsCopyrightHeader(file) {
   const contents = getFileContents(file);
-  return contents.trim().length > 0 && !contents.includes(COPYRIGHT_HEADER);
+
+  // Match lines individually to avoid false positive for:
+  // comment block versus lines
+  // line ending LF versus CRLF
+  return (
+    contents.trim().length > 0 &&
+    (!contents.includes(COPYRIGHT_HEADER) ||
+      !contents.includes(LICENSE1) ||
+      !contents.includes(LICENSE2))
+  );
 }
 
 function check() {

--- a/scripts/remove-postinstall.js
+++ b/scripts/remove-postinstall.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 'use strict';
 

--- a/website/fetchSupporters.js
+++ b/website/fetchSupporters.js
@@ -1,6 +1,11 @@
 #!/usr/bin/env node
 
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 const fs = require('fs');
 const request = require('request');

--- a/website/languages.js
+++ b/website/languages.js
@@ -1,7 +1,10 @@
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
  *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
  */
+
 const languages = [
   {
     enabled: true,

--- a/website/pages/en/videos.js
+++ b/website/pages/en/videos.js
@@ -1,4 +1,9 @@
-// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 const React = require('react');
 

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -1,11 +1,10 @@
-/*eslint sort-keys: 0*/
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
- * All rights reserved.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+/*eslint sort-keys: 0*/
 
 /* List of talks & videos */
 

--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -1,4 +1,9 @@
-/* Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved. */
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 .mainContainer a {
   text-decoration: underline;

--- a/website/static/css/hljs-jest.css
+++ b/website/static/css/hljs-jest.css
@@ -1,4 +1,9 @@
-/* Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved. */
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 /* 
 Jest's Color Scheme for Highlight JS

--- a/website/static/css/jest.css
+++ b/website/static/css/jest.css
@@ -1,4 +1,9 @@
-/* Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved. */
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 :root {
   --yellow: #c2a813;

--- a/website/static/landing.js
+++ b/website/static/landing.js
@@ -1,4 +1,9 @@
-/* Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved. */
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 /* global document, window, localStorage */
 


### PR DESCRIPTION
## Summary

Fixes #8666

* Make criterion string more complete in `scripts/checkCopyrightHeaders.js`
* Update comment in 152 files, ironically including `scripts/checkCopyrightHeaders.js`

Replace obsolete license:

* `packages/jest-circus/runner.js`
* `packages/jest-circus/src/__mocks__/testEventHandler.ts`
* `packages/jest-circus/src/__mocks__/testUtils.ts`
* `packages/jest-circus/src/__tests__/afterAll.test.ts`
* `packages/jest-circus/src/__tests__/baseTest.test.ts`
* `packages/jest-circus/src/__tests__/hooks.test.ts`
* `packages/jest-core/src/SnapshotInteractiveMode.ts`
* `packages/jest-runtime/src/__tests__/defaultResolver.js`
* `packages/jest-runtime/src/__tests__/test_root/sourcemaps/out/throwing-mapped-fn.js`
* `packages/jest-runtime/src/__tests__/test_root/sourcemaps/throwing-mapped-fn.js`

Draft multi-line criterion failed because of line endings, but I did not update yet:

* `packages/expect/src/__tests__/__arbitraries__/sharedSettings.ts`
* `packages/expect/src/__tests__/matchers-toContain.property.test.ts`
* `packages/expect/src/__tests__/matchers-toContainEqual.property.test.ts`
* `packages/expect/src/__tests__/matchers-toEqual.property.test.ts`
* `packages/expect/src/__tests__/matchers-toStrictEqual.property.test.ts`

Draft multi-line criterion found error extra `All rights reserved.` line:

* `packages/jest-docblock/src/__tests__/index.test.ts`
* `packages/jest-haste-map/src/lib/__tests__/fast_path.test.js`
* `packages/jest-haste-map/src/lib/__tests__/getPlatformExtension.test.js`
* `packages/jest-haste-map/src/lib/__tests__/normalizePathSep.test.js`
* `packages/jest-repl/src/cli/repl.ts`
* `website/siteConfig.js`

**Question**: What do you think?

* Test each line individually to be less specific for comment syntax?
* Test lines together but allow variation in line endings?
* Test lines together and require nl=LF line endings?

## Test plan

Updated 9 snapshots because line numbers increase by 5:

* 1 `e2e/__tests__/beforeAllFiltered.ts`
* 1 `e2e/__tests__/beforeEachQueue.ts`
* 1 `e2e/__tests__/coverageRemapping.test.ts`
* 2 `e2e/__tests__/detectOpenHandles.ts`
* 1 `e2e/__tests__/failures.test.ts`
* 1 `e2e/__tests__/processExit.test.ts`
* 1 `e2e/__tests__/resolveNoFileExtensions.test.ts`
* 1 `packages/jest-core/src/__tests__/watch.test.js`

Residue: tests passes even though `packages/jest-runtime/src/__tests__/test_root/sourcemaps/out/throwing-mapped-fn.js.map` still has obsolete license comment