### PR TITLE
Workaround a node >=12.5.0 bug that causes the process not to exit after tests have completed and cancerous memory growth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - `[jest-snapshots]` Fix test retries that contain snapshots ([#8629](https://github.com/facebook/jest/pull/8629))
 - `[jest-mock]` Fix incorrect assignments when restoring mocks in instances where they originally didn't exist ([#8631](https://github.com/facebook/jest/pull/8631))
 - `[expect]` Fix stack overflow when matching objects with circular references ([#8687](https://github.com/facebook/jest/pull/8687))
+- `[jest-haste-map]` Workaround a node >=12.5.0 bug that causes the process not to exit after tests have completed and cancerous memory growth  ([#8787](https://github.com/facebook/jest/pull/8787))
 
 ### Chore & Maintenance
 

--- a/packages/jest-haste-map/src/index.ts
+++ b/packages/jest-haste-map/src/index.ts
@@ -687,16 +687,18 @@ class HasteMap extends EventEmitter {
       }
     }
 
-    try {
-      await Promise.all(promises);
-      this._cleanup();
-      hasteMap.map = map;
-      hasteMap.mocks = mocks;
-      return hasteMap;
-    } catch (error) {
-      this._cleanup();
-      throw error;
-    }
+    return Promise.all(promises).then(
+      () => {
+        this._cleanup();
+        hasteMap.map = map;
+        hasteMap.mocks = mocks;
+        return hasteMap;
+      },
+      error => {
+        this._cleanup();
+        throw error;
+      },
+    );
   }
 
   private _cleanup() {

--- a/packages/jest-haste-map/src/index.ts
+++ b/packages/jest-haste-map/src/index.ts
@@ -642,7 +642,7 @@ class HasteMap extends EventEmitter {
       .then(workerReply, workerError);
   }
 
-  private async _buildHasteMap(data: {
+  private _buildHasteMap(data: {
     removedFiles: FileData;
     changedFiles?: FileData;
     hasteMap: InternalHasteMap;


### PR DESCRIPTION
This is a workaround for an issue that occurs in node 12.5.0 and newer, described in detail here:  https://github.com/nodejs/node/issues/29001

The behavior of the code in question is the same, however the change is enough to prevent locking the process into a "cancerous" state of memory growth.

This is one of the weirdest bugs I've ever debugged.

Under certain circumstances, Node process (starting from version 12.5.0, previous versions not affected), would not exit (even if we call `process.exit()` at the end of the file), and instead start to consume memory until it fills the whole available memory, using 100% CPU while at it.

Here's a reproduction based on the `HasteMap`:

https://gist.github.com/niieani/a527e9b2e6caf28e3021a50b938e4a91

Standard memory or CPU profiling doesn't show anything (literally, there are no function calls shown in the profiler). Dumping the heap snapshot results in a 36MB file, even when the memory consumption of the process is 10 GB.

## Summary

The backstory is that in our case [`jest`](https://github.com/facebook/jest) would not end AFTER all the tests have completed, and instead would start consuming huge amounts of memory (on CI, multiple processes from separate PRs would deplete the 128GB of RAM on the machine) so I started going down the rabbit hole to try and pinpoint what is the cause of the issue, which lead me to this minimal reproduction scenario, but also to discover all the quirks that helped to avoid triggering the scenario.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Testing on node 12 is not enabled in CI due to https://github.com/facebook/jest/issues/8397, so it's not possible to make a test for this case at this time.

Locally, it's possible to test it using the data I've provided in the gist above, after replacing the `devDependency` `'weak'` with: 

```json
    "weak": "github:lxe/node-weak#node-12"
```

## Feedback

Looking for feedback before adding the CHANGELOG for this. Perhaps we should fix running `jest` in node 12 first, so this issue could be tested for?

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
