### PR TITLE
expect: Display equal values for ReturnedWith similar to CalledWith

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - `[expect]` Throw matcher error when received cannot be jasmine spy ([#8747](https://github.com/facebook/jest/pull/8747))
 - `[expect]` Improve report when negative CalledWith assertion fails ([#8755](https://github.com/facebook/jest/pull/8755))
 - `[expect]` Improve report when positive CalledWith assertion fails ([#8771](https://github.com/facebook/jest/pull/8771))
+- `[expect]` Display equal values for ReturnedWith similar to CalledWith ([#8791](https://github.com/facebook/jest/pull/8791))
 - `[jest-snapshot]` Highlight substring differences when matcher fails, part 3 ([#8569](https://github.com/facebook/jest/pull/8569))
 - `[jest-core]` Improve report when snapshots are obsolete ([#8448](https://github.com/facebook/jest/pull/8665))
 - `[jest-cli]` Improve chai support (with detailed output, to match jest exceptions) ([#8454](https://github.com/facebook/jest/pull/8454))

--- a/packages/expect/src/__tests__/__snapshots__/spyMatchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/spyMatchers.test.js.snap
@@ -175,7 +175,7 @@ exports[`lastReturnedWith lastReturnedWith works with three calls 1`] = `
 Expected: not <green>\\"foo3\\"</>
 Received
        2:     <red>\\"foo2\\"</>
-->     3:     <red>\\"foo3\\"</>
+->     3:     <dim>\\"foo3\\"</>
 
 Number of returns: <red>3</>"
 `;
@@ -493,7 +493,7 @@ n: 3
 Expected: not <green>1</>
 Received
        2:     function call has not returned yet
-->     3:     <red>1</>
+->     3:     <dim>1</>
        4:     <red>0</>
 
 Number of returns: <red>2</>
@@ -507,7 +507,7 @@ n: 4
 Expected: not <green>0</>
 Received
        3:     <red>1</>
-->     4:     <red>0</>
+->     4:     <dim>0</>
 
 Number of returns: <red>2</>
 Number of calls:   <red>4</>"
@@ -545,7 +545,7 @@ exports[`nthReturnedWith nthReturnedWith should reject nth value greater than nu
 n: 4
 Expected: <green>\\"foo\\"</>
 Received
-       3: <red>\\"foo\\"</>
+       3: <dim>\\"foo\\"</>
 
 Number of returns: <red>3</>"
 `;
@@ -568,7 +568,7 @@ exports[`nthReturnedWith nthReturnedWith should replace 1st, 2nd, 3rd with first
 n: 1
 Expected: not <green>\\"foo1\\"</>
 Received
-->     1:     <red>\\"foo1\\"</>
+->     1:     <dim>\\"foo1\\"</>
        2:     <red>\\"foo2\\"</>
 
 Number of returns: <red>3</>"
@@ -580,7 +580,7 @@ exports[`nthReturnedWith nthReturnedWith works with three calls 1`] = `
 n: 1
 Expected: not <green>\\"foo1\\"</>
 Received
-->     1:     <red>\\"foo1\\"</>
+->     1:     <dim>\\"foo1\\"</>
        2:     <red>\\"foo2\\"</>
 
 Number of returns: <red>3</>"
@@ -1669,7 +1669,7 @@ exports[`toHaveLastReturnedWith lastReturnedWith works with three calls 1`] = `
 Expected: not <green>\\"foo3\\"</>
 Received
        2:     <red>\\"foo2\\"</>
-->     3:     <red>\\"foo3\\"</>
+->     3:     <dim>\\"foo3\\"</>
 
 Number of returns: <red>3</>"
 `;
@@ -1831,7 +1831,7 @@ n: 3
 Expected: not <green>1</>
 Received
        2:     function call has not returned yet
-->     3:     <red>1</>
+->     3:     <dim>1</>
        4:     <red>0</>
 
 Number of returns: <red>2</>
@@ -1845,7 +1845,7 @@ n: 4
 Expected: not <green>0</>
 Received
        3:     <red>1</>
-->     4:     <red>0</>
+->     4:     <dim>0</>
 
 Number of returns: <red>2</>
 Number of calls:   <red>4</>"
@@ -1883,7 +1883,7 @@ exports[`toHaveNthReturnedWith nthReturnedWith should reject nth value greater t
 n: 4
 Expected: <green>\\"foo\\"</>
 Received
-       3: <red>\\"foo\\"</>
+       3: <dim>\\"foo\\"</>
 
 Number of returns: <red>3</>"
 `;
@@ -1906,7 +1906,7 @@ exports[`toHaveNthReturnedWith nthReturnedWith should replace 1st, 2nd, 3rd with
 n: 1
 Expected: not <green>\\"foo1\\"</>
 Received
-->     1:     <red>\\"foo1\\"</>
+->     1:     <dim>\\"foo1\\"</>
        2:     <red>\\"foo2\\"</>
 
 Number of returns: <red>3</>"
@@ -1918,7 +1918,7 @@ exports[`toHaveNthReturnedWith nthReturnedWith works with three calls 1`] = `
 n: 1
 Expected: not <green>\\"foo1\\"</>
 Received
-->     1:     <red>\\"foo1\\"</>
+->     1:     <dim>\\"foo1\\"</>
        2:     <red>\\"foo2\\"</>
 
 Number of returns: <red>3</>"


### PR DESCRIPTION
## Summary

Display received value in **dim** color when it is **equal** to expected

## Test plan

Updated 12 snapshots

| | long name | short name |
| ---: | :--- | :--- |
| 0 | `toHaveReturnedWith` | `toReturnWith` |
| 1 | `toHaveLastReturnedWith` | `lastReturnedWith` |
| 5 | `toHaveNthReturnedWith` | `nthReturnedWith` |

See also pictures in following comments

Example pictures baseline at left and **improved at right** if it changed