### PR TITLE
fix(jest-haste-map): Fix slowdown on node versions > 10 (second attempt)

### DIFF
--- a/packages/jest-haste-map/src/index.ts
+++ b/packages/jest-haste-map/src/index.ts
@@ -391,7 +391,7 @@ class HasteMap extends EventEmitter {
     try {
       hasteMap = serializer.readFileSync(this._cachePath);
     } catch (err) {
-      hasteMap = this._createEmptyMap();
+      hasteMap = createEmptyMap();
     }
 
     return hasteMap;
@@ -417,10 +417,10 @@ class HasteMap extends EventEmitter {
   }> {
     let hasteMap: InternalHasteMap;
     try {
-      const read = this._options.resetCache ? this._createEmptyMap : this.read;
+      const read = this._options.resetCache ? createEmptyMap : this.read;
       hasteMap = await read.call(this);
     } catch {
-      hasteMap = this._createEmptyMap();
+      hasteMap = createEmptyMap();
     }
     return this._crawl(hasteMap);
   }
@@ -1102,16 +1102,6 @@ class HasteMap extends EventEmitter {
     return true;
   }
 
-  private _createEmptyMap(): InternalHasteMap {
-    return {
-      clocks: new Map(),
-      duplicates: new Map(),
-      files: new Map(),
-      map: new Map(),
-      mocks: new Map(),
-    };
-  }
-
   static H: HType;
   static DuplicateError: typeof DuplicateError;
   static ModuleMap: typeof HasteModuleMap;
@@ -1127,6 +1117,16 @@ class DuplicateError extends Error {
     this.mockPath1 = mockPath1;
     this.mockPath2 = mockPath2;
   }
+}
+
+function createEmptyMap(): InternalHasteMap {
+  return {
+    clocks: new Map(),
+    duplicates: new Map(),
+    files: new Map(),
+    map: new Map(),
+    mocks: new Map(),
+  };
 }
 
 function copy<T extends Record<string, any>>(object: T): T {

--- a/packages/jest-haste-map/src/index.ts
+++ b/packages/jest-haste-map/src/index.ts
@@ -636,7 +636,7 @@ class HasteMap extends EventEmitter {
       .then(workerReply, workerError);
   }
 
-  private async _buildHasteMap(data: {
+  private _buildHasteMap(data: {
     removedFiles: FileData;
     changedFiles?: FileData;
     hasteMap: InternalHasteMap;
@@ -681,16 +681,17 @@ class HasteMap extends EventEmitter {
       }
     }
 
-    try {
-      await Promise.all(promises);
-      this._cleanup();
-      hasteMap.map = map;
-      hasteMap.mocks = mocks;
-      return hasteMap;
-    } catch (error) {
-      this._cleanup();
-      throw error;
-    }
+    return Promise.all(promises)
+      .then(() => {
+        this._cleanup();
+        hasteMap.map = map;
+        hasteMap.mocks = mocks;
+        return hasteMap;
+      })
+      .catch(error => {
+        this._cleanup();
+        throw error;
+      });
   }
 
   private _cleanup() {

--- a/packages/jest-haste-map/src/index.ts
+++ b/packages/jest-haste-map/src/index.ts
@@ -410,18 +410,12 @@ class HasteMap extends EventEmitter {
   /**
    * 2. crawl the file system.
    */
-  private async _buildFileMap(): Promise<{
+  private _buildFileMap(): Promise<{
     removedFiles: FileData;
     changedFiles?: FileData;
     hasteMap: InternalHasteMap;
   }> {
-    let hasteMap: InternalHasteMap;
-    try {
-      const read = this._options.resetCache ? createEmptyMap : this.read;
-      hasteMap = await read.call(this);
-    } catch {
-      hasteMap = createEmptyMap();
-    }
+    const hasteMap = this._options.resetCache ? createEmptyMap() : this.read();
     return this._crawl(hasteMap);
   }
 


### PR DESCRIPTION
This is second attempt (first was #8803 and was incorrect, I definitely should run tests)
Fixes facebook/metro#429 for example.

Yes here is #8787, but I will try anyway. This time I split commits to small chunks. I prefer to eliminate any async/await syntax from file not only because it triggers some strange bugs in v8, but mostly because this syntax is ugly and leads to hard-to-understand code while promise based api is more clean (from my point of view).
