### PR TITLE
expect, jest-snapshot: Change color from green for some args in matcher hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - `[expect]` Improve report when negative CalledWith assertion fails ([#8755](https://github.com/facebook/jest/pull/8755))
 - `[expect]` Improve report when positive CalledWith assertion fails ([#8771](https://github.com/facebook/jest/pull/8771))
 - `[expect]` Display equal values for ReturnedWith similar to CalledWith ([#8791](https://github.com/facebook/jest/pull/8791))
+- `[expect, jest-snapshot]` Change color from green for some args in matcher hints ([#8812](https://github.com/facebook/jest/pull/8812))
 - `[jest-snapshot]` Highlight substring differences when matcher fails, part 3 ([#8569](https://github.com/facebook/jest/pull/8569))
 - `[jest-core]` Improve report when snapshots are obsolete ([#8448](https://github.com/facebook/jest/pull/8665))
 - `[jest-cli]` Improve chai support (with detailed output, to match jest exceptions) ([#8454](https://github.com/facebook/jest/pull/8454))

--- a/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -475,7 +475,7 @@ exports[`.toBeCloseTo() {pass: false} expect(-Infinity)toBeCloseTo( -1.23) 1`] =
 Expected: <green>-1.23</>
 Received: <red>-Infinity</>
 
-Expected precision:    <green>2</>
+Expected precision:    2
 Expected difference: < <green>0.005</>
 Received difference:   <red>Infinity</>"
 `;
@@ -486,7 +486,7 @@ exports[`.toBeCloseTo() {pass: false} expect(Infinity)toBeCloseTo( -Infinity) 1`
 Expected: <green>-Infinity</>
 Received: <red>Infinity</>
 
-Expected precision:    <green>2</>
+Expected precision:    2
 Expected difference: < <green>0.005</>
 Received difference:   <red>Infinity</>"
 `;
@@ -497,7 +497,7 @@ exports[`.toBeCloseTo() {pass: false} expect(Infinity)toBeCloseTo( 1.23) 1`] = `
 Expected: <green>1.23</>
 Received: <red>Infinity</>
 
-Expected precision:    <green>2</>
+Expected precision:    2
 Expected difference: < <green>0.005</>
 Received difference:   <red>Infinity</>"
 `;
@@ -522,7 +522,7 @@ exports[`.toBeCloseTo() {pass: true} expect(0)toBeCloseTo( 0.001) 1`] = `
 Expected: not <green>0.001</>
 Received:     <red>0</>
 
-Expected precision:        <green>2</>
+Expected precision:        2
 Expected difference: not < <green>0.005</>
 Received difference:       <red>0.001</>"
 `;
@@ -533,7 +533,7 @@ exports[`.toBeCloseTo() {pass: true} expect(1.23)toBeCloseTo( 1.225) 1`] = `
 Expected: not <green>1.225</>
 Received:     <red>1.23</>
 
-Expected precision:        <green>2</>
+Expected precision:        2
 Expected difference: not < <green>0.005</>
 Received difference:       <red>0.004999999999999893</>"
 `;
@@ -544,7 +544,7 @@ exports[`.toBeCloseTo() {pass: true} expect(1.23)toBeCloseTo( 1.226) 1`] = `
 Expected: not <green>1.226</>
 Received:     <red>1.23</>
 
-Expected precision:        <green>2</>
+Expected precision:        2
 Expected difference: not < <green>0.005</>
 Received difference:       <red>0.0040000000000000036</>"
 `;
@@ -555,7 +555,7 @@ exports[`.toBeCloseTo() {pass: true} expect(1.23)toBeCloseTo( 1.229) 1`] = `
 Expected: not <green>1.229</>
 Received:     <red>1.23</>
 
-Expected precision:        <green>2</>
+Expected precision:        2
 Expected difference: not < <green>0.005</>
 Received difference:       <red>0.0009999999999998899</>"
 `;
@@ -566,7 +566,7 @@ exports[`.toBeCloseTo() {pass: true} expect(1.23)toBeCloseTo( 1.234) 1`] = `
 Expected: not <green>1.234</>
 Received:     <red>1.23</>
 
-Expected precision:        <green>2</>
+Expected precision:        2
 Expected difference: not < <green>0.005</>
 Received difference:       <red>0.0040000000000000036</>"
 `;
@@ -579,34 +579,34 @@ Expected: not <green>Infinity</>
 `;
 
 exports[`.toBeCloseTo() accepts an optional precision argument: [0, 0.000004, 5] 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeCloseTo<dim>(</><green>expected</><dim>, </><green>precision</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeCloseTo<dim>(</><green>expected</><dim>, </>precision<dim>)</>
 
 Expected: not <green>0.000004</>
 Received:     <red>0</>
 
-Expected precision:        <green>5</>
+Expected precision:        5
 Expected difference: not < <green>0.000005</>
 Received difference:       <red>0.000004</>"
 `;
 
 exports[`.toBeCloseTo() accepts an optional precision argument: [0, 0.0001, 3] 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeCloseTo<dim>(</><green>expected</><dim>, </><green>precision</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeCloseTo<dim>(</><green>expected</><dim>, </>precision<dim>)</>
 
 Expected: not <green>0.0001</>
 Received:     <red>0</>
 
-Expected precision:        <green>3</>
+Expected precision:        3
 Expected difference: not < <green>0.0005</>
 Received difference:       <red>0.0001</>"
 `;
 
 exports[`.toBeCloseTo() accepts an optional precision argument: [0, 0.1, 0] 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeCloseTo<dim>(</><green>expected</><dim>, </><green>precision</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeCloseTo<dim>(</><green>expected</><dim>, </>precision<dim>)</>
 
 Expected: not <green>0.1</>
 Received:     <red>0</>
 
-Expected precision:        <green>0</>
+Expected precision:        0
 Expected difference: not < <green>0.5</>
 Received difference:       <red>0.1</>"
 `;
@@ -617,7 +617,7 @@ exports[`.toBeCloseTo() throws: [0, 0.01] 1`] = `
 Expected: <green>0.01</>
 Received: <red>0</>
 
-Expected precision:    <green>2</>
+Expected precision:    2
 Expected difference: < <green>0.005</>
 Received difference:   <red>0.01</>"
 `;
@@ -628,7 +628,7 @@ exports[`.toBeCloseTo() throws: [1, 1.23] 1`] = `
 Expected: <green>1.23</>
 Received: <red>1</>
 
-Expected precision:    <green>2</>
+Expected precision:    2
 Expected difference: < <green>0.005</>
 Received difference:   <red>0.22999999999999998</>"
 `;
@@ -639,13 +639,13 @@ exports[`.toBeCloseTo() throws: [1.23, 1.2249999] 1`] = `
 Expected: <green>1.2249999</>
 Received: <red>1.23</>
 
-Expected precision:    <green>2</>
+Expected precision:    2
 Expected difference: < <green>0.005</>
 Received difference:   <red>0.005000099999999952</>"
 `;
 
 exports[`.toBeCloseTo() throws: Matcher error promise empty isNot false received 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeCloseTo<dim>(</><green>expected</><dim>, </><green>precision</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toBeCloseTo<dim>(</><green>expected</><dim>, </>precision<dim>)</>
 
 <bold>Matcher error</>: <red>received</> value must be a number
 
@@ -680,7 +680,7 @@ Received has value: <red>Symbol(0.1)</>"
 `;
 
 exports[`.toBeCloseTo() throws: Matcher error promise resolves isNot false received 1`] = `
-"<dim>expect(</><red>received</><dim>).</>resolves<dim>.</>toBeCloseTo<dim>(</><green>expected</><dim>, </><green>precision</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>resolves<dim>.</>toBeCloseTo<dim>(</><green>expected</><dim>, </>precision<dim>)</>
 
 <bold>Matcher error</>: <red>received</> value must be a number
 
@@ -689,7 +689,7 @@ Received has value: <red>false</>"
 `;
 
 exports[`.toBeCloseTo() throws: Matcher error promise resolves isNot true expected 1`] = `
-"<dim>expect(</><red>received</><dim>).</>resolves<dim>.</>not<dim>.</>toBeCloseTo<dim>(</><green>expected</><dim>, </><green>precision</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>resolves<dim>.</>not<dim>.</>toBeCloseTo<dim>(</><green>expected</><dim>, </>precision<dim>)</>
 
 <bold>Matcher error</>: <green>expected</> value must be a number
 

--- a/packages/expect/src/__tests__/__snapshots__/spyMatchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/spyMatchers.test.js.snap
@@ -273,7 +273,7 @@ Number of returns: <red>1</>"
 `;
 
 exports[`nthCalledWith includes the custom mock name in the error message 1`] = `
-"<dim>expect(</><red>named-mock</><dim>).</>not<dim>.</>nthCalledWith<dim>(</><green>n</><dim>, </><green>...expected</><dim>)</>
+"<dim>expect(</><red>named-mock</><dim>).</>not<dim>.</>nthCalledWith<dim>(</>n<dim>, </><green>...expected</><dim>)</>
 
 n: 1
 Expected: not <green>\\"foo\\"</>, <green>\\"bar\\"</>
@@ -282,34 +282,34 @@ Number of calls: <red>1</>"
 `;
 
 exports[`nthCalledWith negative throw matcher error for n that is not integer 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>nthCalledWith<dim>(</><green>n</><dim>, </><green>...expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>nthCalledWith<dim>(</>n<dim>, </><green>...expected</><dim>)</>
 
-<bold>Matcher error</>: <green>n</> must be a positive integer
+<bold>Matcher error</>: n must be a positive integer
 
 n has type:  number
-n has value: <green>Infinity</>"
+n has value: Infinity"
 `;
 
 exports[`nthCalledWith positive throw matcher error for n that is not integer 1`] = `
-"<dim>expect(</><red>received</><dim>).</>nthCalledWith<dim>(</><green>n</><dim>, </><green>...expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>nthCalledWith<dim>(</>n<dim>, </><green>...expected</><dim>)</>
 
-<bold>Matcher error</>: <green>n</> must be a positive integer
+<bold>Matcher error</>: n must be a positive integer
 
 n has type:  number
-n has value: <green>0.1</>"
+n has value: 0.1"
 `;
 
 exports[`nthCalledWith positive throw matcher error for n that is not positive integer 1`] = `
-"<dim>expect(</><red>received</><dim>).</>nthCalledWith<dim>(</><green>n</><dim>, </><green>...expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>nthCalledWith<dim>(</>n<dim>, </><green>...expected</><dim>)</>
 
-<bold>Matcher error</>: <green>n</> must be a positive integer
+<bold>Matcher error</>: n must be a positive integer
 
 n has type:  number
-n has value: <green>0</>"
+n has value: 0"
 `;
 
 exports[`nthCalledWith works only on spies or jest.fn 1`] = `
-"<dim>expect(</><red>received</><dim>).</>nthCalledWith<dim>(</><green>n</><dim>, </><green>...expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>nthCalledWith<dim>(</>n<dim>, </><green>...expected</><dim>)</>
 
 <bold>Matcher error</>: <red>received</> value must be a mock or spy function
 
@@ -318,7 +318,7 @@ Received has value: <red>[Function fn]</>"
 `;
 
 exports[`nthCalledWith works when not called 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>nthCalledWith<dim>(</><green>n</><dim>, </><green>...expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>nthCalledWith<dim>(</>n<dim>, </><green>...expected</><dim>)</>
 
 n: 1
 Expected: <green>\\"foo\\"</>, <green>\\"bar\\"</>
@@ -327,7 +327,7 @@ Number of calls: <red>0</>"
 `;
 
 exports[`nthCalledWith works with Immutable.js objects 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthCalledWith<dim>(</><green>n</><dim>, </><green>...expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthCalledWith<dim>(</>n<dim>, </><green>...expected</><dim>)</>
 
 n: 1
 Expected: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>, <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
@@ -336,7 +336,7 @@ Number of calls: <red>1</>"
 `;
 
 exports[`nthCalledWith works with Map 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthCalledWith<dim>(</><green>n</><dim>, </><green>...expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthCalledWith<dim>(</>n<dim>, </><green>...expected</><dim>)</>
 
 n: 1
 Expected: not <green>Map {1 => 2, 2 => 1}</>
@@ -345,7 +345,7 @@ Number of calls: <red>1</>"
 `;
 
 exports[`nthCalledWith works with Map 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>nthCalledWith<dim>(</><green>n</><dim>, </><green>...expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>nthCalledWith<dim>(</>n<dim>, </><green>...expected</><dim>)</>
 
 n: 1
 <green>- Expected</>
@@ -362,7 +362,7 @@ Number of calls: <red>1</>"
 `;
 
 exports[`nthCalledWith works with Set 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthCalledWith<dim>(</><green>n</><dim>, </><green>...expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthCalledWith<dim>(</>n<dim>, </><green>...expected</><dim>)</>
 
 n: 1
 Expected: not <green>Set {1, 2}</>
@@ -371,7 +371,7 @@ Number of calls: <red>1</>"
 `;
 
 exports[`nthCalledWith works with Set 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>nthCalledWith<dim>(</><green>n</><dim>, </><green>...expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>nthCalledWith<dim>(</>n<dim>, </><green>...expected</><dim>)</>
 
 n: 1
 <green>- Expected</>
@@ -388,7 +388,7 @@ Number of calls: <red>1</>"
 `;
 
 exports[`nthCalledWith works with arguments that don't match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>nthCalledWith<dim>(</><green>n</><dim>, </><green>...expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>nthCalledWith<dim>(</>n<dim>, </><green>...expected</><dim>)</>
 
 n: 1
 Expected: <green>\\"foo\\"</>, <green>\\"bar\\"</>
@@ -398,7 +398,7 @@ Number of calls: <red>1</>"
 `;
 
 exports[`nthCalledWith works with arguments that match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthCalledWith<dim>(</><green>n</><dim>, </><green>...expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthCalledWith<dim>(</>n<dim>, </><green>...expected</><dim>)</>
 
 n: 1
 Expected: not <green>\\"foo\\"</>, <green>\\"bar\\"</>
@@ -407,7 +407,7 @@ Number of calls: <red>1</>"
 `;
 
 exports[`nthCalledWith works with three calls 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthCalledWith<dim>(</><green>n</><dim>, </><green>...expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthCalledWith<dim>(</>n<dim>, </><green>...expected</><dim>)</>
 
 n: 1
 Expected: not <green>\\"foo1\\"</>, <green>\\"bar\\"</>
@@ -419,7 +419,7 @@ Number of calls: <red>3</>"
 `;
 
 exports[`nthCalledWith works with trailing undefined arguments 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>nthCalledWith<dim>(</><green>n</><dim>, </><green>...expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>nthCalledWith<dim>(</>n<dim>, </><green>...expected</><dim>)</>
 
 n: 1
 Expected: <green>\\"foo\\"</>
@@ -429,7 +429,7 @@ Number of calls: <red>1</>"
 `;
 
 exports[`nthReturnedWith a call that throws is not considered to have returned 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>nthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
 
 n: 1
 Expected: <green>undefined</>
@@ -440,7 +440,7 @@ Number of calls:   <red>1</>"
 `;
 
 exports[`nthReturnedWith a call that throws undefined is not considered to have returned 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>nthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
 
 n: 1
 Expected: <green>undefined</>
@@ -451,7 +451,7 @@ Number of calls:   <red>1</>"
 `;
 
 exports[`nthReturnedWith includes the custom mock name in the error message 1`] = `
-"<dim>expect(</><red>named-mock</><dim>).</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
+"<dim>expect(</><red>named-mock</><dim>).</>nthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
 
 n: 1
 Expected: <green>\\"foo\\"</>
@@ -460,7 +460,7 @@ Number of returns: <red>0</>"
 `;
 
 exports[`nthReturnedWith nthReturnedWith incomplete recursive calls are handled properly 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>nthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
 
 n: 1
 Expected: <green>6</>
@@ -473,7 +473,7 @@ Number of calls:   <red>4</>"
 `;
 
 exports[`nthReturnedWith nthReturnedWith incomplete recursive calls are handled properly 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>nthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
 
 n: 2
 Expected: <green>3</>
@@ -487,7 +487,7 @@ Number of calls:   <red>4</>"
 `;
 
 exports[`nthReturnedWith nthReturnedWith incomplete recursive calls are handled properly 3`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
 
 n: 3
 Expected: not <green>1</>
@@ -501,7 +501,7 @@ Number of calls:   <red>4</>"
 `;
 
 exports[`nthReturnedWith nthReturnedWith incomplete recursive calls are handled properly 4`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
 
 n: 4
 Expected: not <green>0</>
@@ -514,33 +514,33 @@ Number of calls:   <red>4</>"
 `;
 
 exports[`nthReturnedWith nthReturnedWith negative throw matcher error for n that is not number 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
 
-<bold>Matcher error</>: <green>n</> must be a positive integer
+<bold>Matcher error</>: n must be a positive integer
 
-n has value: <green>undefined</>"
+n has value: undefined"
 `;
 
 exports[`nthReturnedWith nthReturnedWith positive throw matcher error for n that is not integer 1`] = `
-"<dim>expect(</><red>received</><dim>).</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>nthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
 
-<bold>Matcher error</>: <green>n</> must be a positive integer
+<bold>Matcher error</>: n must be a positive integer
 
 n has type:  number
-n has value: <green>0.1</>"
+n has value: 0.1"
 `;
 
 exports[`nthReturnedWith nthReturnedWith positive throw matcher error for n that is not positive integer 1`] = `
-"<dim>expect(</><red>received</><dim>).</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>nthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
 
-<bold>Matcher error</>: <green>n</> must be a positive integer
+<bold>Matcher error</>: n must be a positive integer
 
 n has type:  number
-n has value: <green>0</>"
+n has value: 0"
 `;
 
 exports[`nthReturnedWith nthReturnedWith should reject nth value greater than number of calls 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>nthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
 
 n: 4
 Expected: <green>\\"foo\\"</>
@@ -551,7 +551,7 @@ Number of returns: <red>3</>"
 `;
 
 exports[`nthReturnedWith nthReturnedWith should replace 1st, 2nd, 3rd with first, second, third 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>nthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
 
 n: 1
 Expected: <green>\\"bar1\\"</>
@@ -563,7 +563,7 @@ Number of returns: <red>3</>"
 `;
 
 exports[`nthReturnedWith nthReturnedWith should replace 1st, 2nd, 3rd with first, second, third 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
 
 n: 1
 Expected: not <green>\\"foo1\\"</>
@@ -575,7 +575,7 @@ Number of returns: <red>3</>"
 `;
 
 exports[`nthReturnedWith nthReturnedWith works with three calls 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
 
 n: 1
 Expected: not <green>\\"foo1\\"</>
@@ -587,7 +587,7 @@ Number of returns: <red>3</>"
 `;
 
 exports[`nthReturnedWith works only on spies or jest.fn 1`] = `
-"<dim>expect(</><red>received</><dim>).</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>nthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
 
 <bold>Matcher error</>: <red>received</> value must be a mock function
 
@@ -596,7 +596,7 @@ Received has value: <red>[Function fn]</>"
 `;
 
 exports[`nthReturnedWith works when not called 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>nthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
 
 n: 1
 Expected: <green>\\"foo\\"</>
@@ -605,7 +605,7 @@ Number of returns: <red>0</>"
 `;
 
 exports[`nthReturnedWith works with Immutable.js objects directly created 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
 
 n: 1
 Expected: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
@@ -614,7 +614,7 @@ Number of returns: <red>1</>"
 `;
 
 exports[`nthReturnedWith works with Immutable.js objects indirectly created 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
 
 n: 1
 Expected: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
@@ -623,7 +623,7 @@ Number of returns: <red>1</>"
 `;
 
 exports[`nthReturnedWith works with Map 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
 
 n: 1
 Expected: not <green>Map {1 => 2, 2 => 1}</>
@@ -632,7 +632,7 @@ Number of returns: <red>1</>"
 `;
 
 exports[`nthReturnedWith works with Map 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>nthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
 
 n: 1
 Expected: <green>Map {\\"a\\" => \\"b\\", \\"b\\" => \\"a\\"}</>
@@ -642,7 +642,7 @@ Number of returns: <red>1</>"
 `;
 
 exports[`nthReturnedWith works with Set 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
 
 n: 1
 Expected: not <green>Set {1, 2}</>
@@ -651,7 +651,7 @@ Number of returns: <red>1</>"
 `;
 
 exports[`nthReturnedWith works with Set 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>nthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
 
 n: 1
 Expected: <green>Set {3, 4}</>
@@ -661,7 +661,7 @@ Number of returns: <red>1</>"
 `;
 
 exports[`nthReturnedWith works with argument that does match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
 
 n: 1
 Expected: not <green>\\"foo\\"</>
@@ -670,7 +670,7 @@ Number of returns: <red>1</>"
 `;
 
 exports[`nthReturnedWith works with argument that does not match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>nthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
 
 n: 1
 Expected: <green>\\"bar\\"</>
@@ -680,7 +680,7 @@ Number of returns: <red>1</>"
 `;
 
 exports[`nthReturnedWith works with undefined 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
 
 n: 1
 Expected: not <green>undefined</>
@@ -1468,7 +1468,7 @@ Number of calls: <red>1</>"
 `;
 
 exports[`toHaveBeenNthCalledWith includes the custom mock name in the error message 1`] = `
-"<dim>expect(</><red>named-mock</><dim>).</>not<dim>.</>toHaveBeenNthCalledWith<dim>(</><green>n</><dim>, </><green>...expected</><dim>)</>
+"<dim>expect(</><red>named-mock</><dim>).</>not<dim>.</>toHaveBeenNthCalledWith<dim>(</>n<dim>, </><green>...expected</><dim>)</>
 
 n: 1
 Expected: not <green>\\"foo\\"</>, <green>\\"bar\\"</>
@@ -1477,34 +1477,34 @@ Number of calls: <red>1</>"
 `;
 
 exports[`toHaveBeenNthCalledWith negative throw matcher error for n that is not integer 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveBeenNthCalledWith<dim>(</><green>n</><dim>, </><green>...expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveBeenNthCalledWith<dim>(</>n<dim>, </><green>...expected</><dim>)</>
 
-<bold>Matcher error</>: <green>n</> must be a positive integer
+<bold>Matcher error</>: n must be a positive integer
 
 n has type:  number
-n has value: <green>Infinity</>"
+n has value: Infinity"
 `;
 
 exports[`toHaveBeenNthCalledWith positive throw matcher error for n that is not integer 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveBeenNthCalledWith<dim>(</><green>n</><dim>, </><green>...expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toHaveBeenNthCalledWith<dim>(</>n<dim>, </><green>...expected</><dim>)</>
 
-<bold>Matcher error</>: <green>n</> must be a positive integer
+<bold>Matcher error</>: n must be a positive integer
 
 n has type:  number
-n has value: <green>0.1</>"
+n has value: 0.1"
 `;
 
 exports[`toHaveBeenNthCalledWith positive throw matcher error for n that is not positive integer 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveBeenNthCalledWith<dim>(</><green>n</><dim>, </><green>...expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toHaveBeenNthCalledWith<dim>(</>n<dim>, </><green>...expected</><dim>)</>
 
-<bold>Matcher error</>: <green>n</> must be a positive integer
+<bold>Matcher error</>: n must be a positive integer
 
 n has type:  number
-n has value: <green>0</>"
+n has value: 0"
 `;
 
 exports[`toHaveBeenNthCalledWith works only on spies or jest.fn 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveBeenNthCalledWith<dim>(</><green>n</><dim>, </><green>...expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toHaveBeenNthCalledWith<dim>(</>n<dim>, </><green>...expected</><dim>)</>
 
 <bold>Matcher error</>: <red>received</> value must be a mock or spy function
 
@@ -1513,7 +1513,7 @@ Received has value: <red>[Function fn]</>"
 `;
 
 exports[`toHaveBeenNthCalledWith works when not called 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveBeenNthCalledWith<dim>(</><green>n</><dim>, </><green>...expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveBeenNthCalledWith<dim>(</>n<dim>, </><green>...expected</><dim>)</>
 
 n: 1
 Expected: <green>\\"foo\\"</>, <green>\\"bar\\"</>
@@ -1522,7 +1522,7 @@ Number of calls: <red>0</>"
 `;
 
 exports[`toHaveBeenNthCalledWith works with Immutable.js objects 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveBeenNthCalledWith<dim>(</><green>n</><dim>, </><green>...expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveBeenNthCalledWith<dim>(</>n<dim>, </><green>...expected</><dim>)</>
 
 n: 1
 Expected: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>, <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
@@ -1531,7 +1531,7 @@ Number of calls: <red>1</>"
 `;
 
 exports[`toHaveBeenNthCalledWith works with Map 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveBeenNthCalledWith<dim>(</><green>n</><dim>, </><green>...expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveBeenNthCalledWith<dim>(</>n<dim>, </><green>...expected</><dim>)</>
 
 n: 1
 Expected: not <green>Map {1 => 2, 2 => 1}</>
@@ -1540,7 +1540,7 @@ Number of calls: <red>1</>"
 `;
 
 exports[`toHaveBeenNthCalledWith works with Map 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveBeenNthCalledWith<dim>(</><green>n</><dim>, </><green>...expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveBeenNthCalledWith<dim>(</>n<dim>, </><green>...expected</><dim>)</>
 
 n: 1
 <green>- Expected</>
@@ -1557,7 +1557,7 @@ Number of calls: <red>1</>"
 `;
 
 exports[`toHaveBeenNthCalledWith works with Set 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveBeenNthCalledWith<dim>(</><green>n</><dim>, </><green>...expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveBeenNthCalledWith<dim>(</>n<dim>, </><green>...expected</><dim>)</>
 
 n: 1
 Expected: not <green>Set {1, 2}</>
@@ -1566,7 +1566,7 @@ Number of calls: <red>1</>"
 `;
 
 exports[`toHaveBeenNthCalledWith works with Set 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveBeenNthCalledWith<dim>(</><green>n</><dim>, </><green>...expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveBeenNthCalledWith<dim>(</>n<dim>, </><green>...expected</><dim>)</>
 
 n: 1
 <green>- Expected</>
@@ -1583,7 +1583,7 @@ Number of calls: <red>1</>"
 `;
 
 exports[`toHaveBeenNthCalledWith works with arguments that don't match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveBeenNthCalledWith<dim>(</><green>n</><dim>, </><green>...expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveBeenNthCalledWith<dim>(</>n<dim>, </><green>...expected</><dim>)</>
 
 n: 1
 Expected: <green>\\"foo\\"</>, <green>\\"bar\\"</>
@@ -1593,7 +1593,7 @@ Number of calls: <red>1</>"
 `;
 
 exports[`toHaveBeenNthCalledWith works with arguments that match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveBeenNthCalledWith<dim>(</><green>n</><dim>, </><green>...expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveBeenNthCalledWith<dim>(</>n<dim>, </><green>...expected</><dim>)</>
 
 n: 1
 Expected: not <green>\\"foo\\"</>, <green>\\"bar\\"</>
@@ -1602,7 +1602,7 @@ Number of calls: <red>1</>"
 `;
 
 exports[`toHaveBeenNthCalledWith works with three calls 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveBeenNthCalledWith<dim>(</><green>n</><dim>, </><green>...expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveBeenNthCalledWith<dim>(</>n<dim>, </><green>...expected</><dim>)</>
 
 n: 1
 Expected: not <green>\\"foo1\\"</>, <green>\\"bar\\"</>
@@ -1614,7 +1614,7 @@ Number of calls: <red>3</>"
 `;
 
 exports[`toHaveBeenNthCalledWith works with trailing undefined arguments 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveBeenNthCalledWith<dim>(</><green>n</><dim>, </><green>...expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveBeenNthCalledWith<dim>(</>n<dim>, </><green>...expected</><dim>)</>
 
 n: 1
 Expected: <green>\\"foo\\"</>
@@ -1767,7 +1767,7 @@ Number of returns: <red>1</>"
 `;
 
 exports[`toHaveNthReturnedWith a call that throws is not considered to have returned 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveNthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
 
 n: 1
 Expected: <green>undefined</>
@@ -1778,7 +1778,7 @@ Number of calls:   <red>1</>"
 `;
 
 exports[`toHaveNthReturnedWith a call that throws undefined is not considered to have returned 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveNthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
 
 n: 1
 Expected: <green>undefined</>
@@ -1789,7 +1789,7 @@ Number of calls:   <red>1</>"
 `;
 
 exports[`toHaveNthReturnedWith includes the custom mock name in the error message 1`] = `
-"<dim>expect(</><red>named-mock</><dim>).</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
+"<dim>expect(</><red>named-mock</><dim>).</>toHaveNthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
 
 n: 1
 Expected: <green>\\"foo\\"</>
@@ -1798,7 +1798,7 @@ Number of returns: <red>0</>"
 `;
 
 exports[`toHaveNthReturnedWith nthReturnedWith incomplete recursive calls are handled properly 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveNthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
 
 n: 1
 Expected: <green>6</>
@@ -1811,7 +1811,7 @@ Number of calls:   <red>4</>"
 `;
 
 exports[`toHaveNthReturnedWith nthReturnedWith incomplete recursive calls are handled properly 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveNthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
 
 n: 2
 Expected: <green>3</>
@@ -1825,7 +1825,7 @@ Number of calls:   <red>4</>"
 `;
 
 exports[`toHaveNthReturnedWith nthReturnedWith incomplete recursive calls are handled properly 3`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
 
 n: 3
 Expected: not <green>1</>
@@ -1839,7 +1839,7 @@ Number of calls:   <red>4</>"
 `;
 
 exports[`toHaveNthReturnedWith nthReturnedWith incomplete recursive calls are handled properly 4`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
 
 n: 4
 Expected: not <green>0</>
@@ -1852,33 +1852,33 @@ Number of calls:   <red>4</>"
 `;
 
 exports[`toHaveNthReturnedWith nthReturnedWith negative throw matcher error for n that is not number 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
 
-<bold>Matcher error</>: <green>n</> must be a positive integer
+<bold>Matcher error</>: n must be a positive integer
 
-n has value: <green>undefined</>"
+n has value: undefined"
 `;
 
 exports[`toHaveNthReturnedWith nthReturnedWith positive throw matcher error for n that is not integer 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toHaveNthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
 
-<bold>Matcher error</>: <green>n</> must be a positive integer
+<bold>Matcher error</>: n must be a positive integer
 
 n has type:  number
-n has value: <green>0.1</>"
+n has value: 0.1"
 `;
 
 exports[`toHaveNthReturnedWith nthReturnedWith positive throw matcher error for n that is not positive integer 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toHaveNthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
 
-<bold>Matcher error</>: <green>n</> must be a positive integer
+<bold>Matcher error</>: n must be a positive integer
 
 n has type:  number
-n has value: <green>0</>"
+n has value: 0"
 `;
 
 exports[`toHaveNthReturnedWith nthReturnedWith should reject nth value greater than number of calls 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveNthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
 
 n: 4
 Expected: <green>\\"foo\\"</>
@@ -1889,7 +1889,7 @@ Number of returns: <red>3</>"
 `;
 
 exports[`toHaveNthReturnedWith nthReturnedWith should replace 1st, 2nd, 3rd with first, second, third 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveNthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
 
 n: 1
 Expected: <green>\\"bar1\\"</>
@@ -1901,7 +1901,7 @@ Number of returns: <red>3</>"
 `;
 
 exports[`toHaveNthReturnedWith nthReturnedWith should replace 1st, 2nd, 3rd with first, second, third 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
 
 n: 1
 Expected: not <green>\\"foo1\\"</>
@@ -1913,7 +1913,7 @@ Number of returns: <red>3</>"
 `;
 
 exports[`toHaveNthReturnedWith nthReturnedWith works with three calls 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
 
 n: 1
 Expected: not <green>\\"foo1\\"</>
@@ -1925,7 +1925,7 @@ Number of returns: <red>3</>"
 `;
 
 exports[`toHaveNthReturnedWith works only on spies or jest.fn 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
+"<dim>expect(</><red>received</><dim>).</>toHaveNthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
 
 <bold>Matcher error</>: <red>received</> value must be a mock function
 
@@ -1934,7 +1934,7 @@ Received has value: <red>[Function fn]</>"
 `;
 
 exports[`toHaveNthReturnedWith works when not called 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveNthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
 
 n: 1
 Expected: <green>\\"foo\\"</>
@@ -1943,7 +1943,7 @@ Number of returns: <red>0</>"
 `;
 
 exports[`toHaveNthReturnedWith works with Immutable.js objects directly created 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
 
 n: 1
 Expected: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
@@ -1952,7 +1952,7 @@ Number of returns: <red>1</>"
 `;
 
 exports[`toHaveNthReturnedWith works with Immutable.js objects indirectly created 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
 
 n: 1
 Expected: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
@@ -1961,7 +1961,7 @@ Number of returns: <red>1</>"
 `;
 
 exports[`toHaveNthReturnedWith works with Map 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
 
 n: 1
 Expected: not <green>Map {1 => 2, 2 => 1}</>
@@ -1970,7 +1970,7 @@ Number of returns: <red>1</>"
 `;
 
 exports[`toHaveNthReturnedWith works with Map 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveNthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
 
 n: 1
 Expected: <green>Map {\\"a\\" => \\"b\\", \\"b\\" => \\"a\\"}</>
@@ -1980,7 +1980,7 @@ Number of returns: <red>1</>"
 `;
 
 exports[`toHaveNthReturnedWith works with Set 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
 
 n: 1
 Expected: not <green>Set {1, 2}</>
@@ -1989,7 +1989,7 @@ Number of returns: <red>1</>"
 `;
 
 exports[`toHaveNthReturnedWith works with Set 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveNthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
 
 n: 1
 Expected: <green>Set {3, 4}</>
@@ -1999,7 +1999,7 @@ Number of returns: <red>1</>"
 `;
 
 exports[`toHaveNthReturnedWith works with argument that does match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
 
 n: 1
 Expected: not <green>\\"foo\\"</>
@@ -2008,7 +2008,7 @@ Number of returns: <red>1</>"
 `;
 
 exports[`toHaveNthReturnedWith works with argument that does not match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveNthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
 
 n: 1
 Expected: <green>\\"bar\\"</>
@@ -2018,7 +2018,7 @@ Number of returns: <red>1</>"
 `;
 
 exports[`toHaveNthReturnedWith works with undefined 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</><green>n</><dim>, </><green>expected</><dim>)</>
+"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
 
 n: 1
 Expected: not <green>undefined</>

--- a/packages/expect/src/matchers.ts
+++ b/packages/expect/src/matchers.ts
@@ -133,6 +133,7 @@ const matchers: MatchersObject = {
       isNot: this.isNot,
       promise: this.promise,
       secondArgument,
+      secondArgumentColor: (arg: string) => arg,
     };
     ensureNumbers(received, expected, matcherName, options);
 
@@ -159,7 +160,7 @@ const matchers: MatchersObject = {
             ? ''
             : `Received:     ${printReceived(received)}\n` +
               '\n' +
-              `Expected precision:        ${printExpected(precision)}\n` +
+              `Expected precision:        ${stringify(precision)}\n` +
               `Expected difference: not < ${printExpected(expectedDiff)}\n` +
               `Received difference:       ${printReceived(receivedDiff)}`)
       : () =>
@@ -168,7 +169,7 @@ const matchers: MatchersObject = {
           `Expected: ${printExpected(expected)}\n` +
           `Received: ${printReceived(received)}\n` +
           '\n' +
-          `Expected precision:    ${printExpected(precision)}\n` +
+          `Expected precision:    ${stringify(precision)}\n` +
           `Expected difference: < ${printExpected(expectedDiff)}\n` +
           `Received difference:   ${printReceived(receivedDiff)}`;
 

--- a/packages/expect/src/spyMatchers.ts
+++ b/packages/expect/src/spyMatchers.ts
@@ -867,6 +867,7 @@ const createNthCalledWithMatcher = (matcherName: string) =>
   ): SyncExpectationResult {
     const expectedArgument = 'n';
     const options: MatcherHintOptions = {
+      expectedColor: (arg: string) => arg,
       isNot: this.isNot,
       promise: this.promise,
       secondArgument: '...expected',
@@ -877,8 +878,8 @@ const createNthCalledWithMatcher = (matcherName: string) =>
       throw new Error(
         matcherErrorMessage(
           matcherHint(matcherName, undefined, expectedArgument, options),
-          `${EXPECTED_COLOR(expectedArgument)} must be a positive integer`,
-          printWithType(expectedArgument, nth, printExpected),
+          `${expectedArgument} must be a positive integer`,
+          printWithType(expectedArgument, nth, stringify),
         ),
       );
     }
@@ -996,6 +997,7 @@ const createNthReturnedWithMatcher = (matcherName: string) =>
   ): SyncExpectationResult {
     const expectedArgument = 'n';
     const options: MatcherHintOptions = {
+      expectedColor: (arg: string) => arg,
       isNot: this.isNot,
       promise: this.promise,
       secondArgument: 'expected',
@@ -1006,8 +1008,8 @@ const createNthReturnedWithMatcher = (matcherName: string) =>
       throw new Error(
         matcherErrorMessage(
           matcherHint(matcherName, undefined, expectedArgument, options),
-          `${EXPECTED_COLOR(expectedArgument)} must be a positive integer`,
-          printWithType(expectedArgument, nth, printExpected),
+          `${expectedArgument} must be a positive integer`,
+          printWithType(expectedArgument, nth, stringify),
         ),
       );
     }

--- a/packages/jest-snapshot/src/index.ts
+++ b/packages/jest-snapshot/src/index.ts
@@ -47,7 +47,8 @@ const NOT_SNAPSHOT_MATCHERS = `.${BOLD_WEIGHT(
   'not',
 )} cannot be used with snapshot matchers`;
 
-const HINT_ARG = BOLD_WEIGHT('hint');
+const HINT_ARG = 'hint';
+const HINT_COLOR = BOLD_WEIGHT;
 const INLINE_SNAPSHOT_ARG = 'snapshot';
 const PROPERTY_MATCHERS_ARG = 'properties';
 const INDENTATION_REGEX = /^([^\S\n]*)\S/m;
@@ -185,6 +186,13 @@ const toMatchSnapshot = function(
     promise: this.promise,
     secondArgument,
   };
+
+  if (expectedArgument === HINT_ARG) {
+    options.expectedColor = HINT_COLOR;
+  }
+  if (secondArgument === HINT_ARG) {
+    options.secondArgumentColor = HINT_COLOR;
+  }
 
   if (arguments.length === 3 && !propertyMatchers) {
     throw new Error(
@@ -385,6 +393,7 @@ const toThrowErrorMatchingSnapshot = function(
   const expectedArgument =
     typeof hint === 'string' && hint.length !== 0 ? HINT_ARG : '';
   const options = {
+    expectedColor: HINT_COLOR,
     isNot: this.isNot,
     promise: this.promise,
     secondArgument: '',


### PR DESCRIPTION
## Summary

For matcher args which do **not** have a received counterpart in red color:

* `precision` in `toBeCloseTo`
* `n` in `toHaveBeenNthCalledWith` and `toHaveNthReturnedWith`
* `hint` in `toMatchSnapshot` and `toThrowErrorMatchingSnapshot`

Especially for matchers whose 2 arguments have different effect on criterion

However, either `path` or `value` in `toHaveProperty` can have received counterpart:

<img width="960" alt="toHaveProperty 1" src="https://user-images.githubusercontent.com/11862657/62839393-638ef280-bc57-11e9-9bb9-0c621c0e8660.png">

<img width="960" alt="toHaveProperty 2" src="https://user-images.githubusercontent.com/11862657/62839399-6689e300-bc57-11e9-9035-6bc6576bf339.png">

## Test plan

Updated 97 snapshots

| | matcher |
| ---: | :--- |
| 17 | `toBeCloseTo` |
| 15 | `nthCalledWith` |
| 25 | `nthReturnedWith` |
| 15 | `toHaveBeenNthCalledWith` |
| 25 | `toHaveNthReturnedWith` |

See also pictures in following comments

Baseline at left and **improved at right**