### PR TITLE
chore: Check copyright and license as one joined substring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 - `[jest-core]` Add `getVersion` (moved from `jest-cli`) ([#8706](https://github.com/facebook/jest/pull/8706))
 - `[docs]` Fix MockFunctions example that was using toContain instead of toContainEqual ([#8765](https://github.com/facebook/jest/pull/8765))
 - `[*]` Make sure copyright header comment includes license ([#8783](https://github.com/facebook/jest/pull/8783))
+- `[*]` Check copyright and license as one joined substring ([#8815](https://github.com/facebook/jest/pull/8815))
 - `[docs]` Fix WatchPlugins `jestHooks.shouldRunTestSuite` example that receives an object ([#8784](https://github.com/facebook/jest/pull/8784))
 - `[*]` Enforce LF line endings ([#8809](https://github.com/facebook/jest/pull/8809))
 

--- a/scripts/checkCopyrightHeaders.js
+++ b/scripts/checkCopyrightHeaders.js
@@ -115,11 +115,12 @@ const INCLUDED_PATTERNS = [
   /\.[^/]+$/,
 ];
 
-const COPYRIGHT_HEADER =
-  'Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.';
-const LICENSE1 =
-  'This source code is licensed under the MIT license found in the';
-const LICENSE2 = 'LICENSE file in the root directory of this source tree.';
+const COPYRIGHT_LICENSE = [
+  ' * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.',
+  ' *',
+  ' * This source code is licensed under the MIT license found in the',
+  ' * LICENSE file in the root directory of this source tree.',
+].join('\n');
 
 function needsCopyrightHeader(file) {
   const contents = getFileContents(file);
@@ -127,12 +128,7 @@ function needsCopyrightHeader(file) {
   // Match lines individually to avoid false positive for:
   // comment block versus lines
   // line ending LF versus CRLF
-  return (
-    contents.trim().length > 0 &&
-    (!contents.includes(COPYRIGHT_HEADER) ||
-      !contents.includes(LICENSE1) ||
-      !contents.includes(LICENSE2))
-  );
+  return contents.trim().length > 0 && !contents.includes(COPYRIGHT_LICENSE);
 }
 
 function check() {

--- a/scripts/checkCopyrightHeaders.js
+++ b/scripts/checkCopyrightHeaders.js
@@ -124,10 +124,6 @@ const COPYRIGHT_LICENSE = [
 
 function needsCopyrightHeader(file) {
   const contents = getFileContents(file);
-
-  // Match lines individually to avoid false positive for:
-  // comment block versus lines
-  // line ending LF versus CRLF
   return contents.trim().length > 0 && !contents.includes(COPYRIGHT_LICENSE);
 }
 


### PR DESCRIPTION
## Summary

What do y’all think? In the first draft of #8783 a joined substring found some mistakes:

* 6 files with extra redundant `All rights reserved.` line between copyright and license
* missing period at end of copyright line in `checkCopyrightHeaders.js` itself ;)

that searching for the 3 lines independently (in the merged code) does not find

## Test plan

`yarn check-copyright-headers`

After #8809 the script will pass when run locally on Windows system, correct?

Tim, thanks again for researching such a smart solution ❤️