### PR TITLE
Export necessary types from jest-runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - `[@jest-transform]` Extract transforming require logic within `jest-core` into `@jest-transform` ([#8756](https://github.com/facebook/jest/pull/8756))
 - `[jest-matcher-utils]` Add color options to `matcherHint` ([#8795](https://github.com/facebook/jest/pull/8795))
 - `[jest-circus/jest-jasmine2]` Give clearer output for Node assert errors ([#8792](https://github.com/facebook/jest/pull/8792))
+- `[jest-runner]` Export all types in the type signature of `jest-runner` ([#8825](https://github.com/facebook/jest/pull/8825))`
 
 ### Fixes
 

--- a/packages/jest-runner/src/index.ts
+++ b/packages/jest-runner/src/index.ts
@@ -13,13 +13,13 @@ import Worker from 'jest-worker';
 import runTest from './runTest';
 import {worker, SerializableResolver} from './testWorker';
 import {
-  OnTestFailure,
-  OnTestStart,
-  OnTestSuccess,
+  OnTestFailure as JestOnTestFailure,
+  OnTestStart as JestOnTestStart,
+  OnTestSuccess as JestOnTestSuccess,
   Test as JestTest,
-  TestRunnerContext,
-  TestRunnerOptions,
-  TestWatcher,
+  TestRunnerContext as JestTestRunnerContext,
+  TestRunnerOptions as JestTestRunnerOptions,
+  TestWatcher as JestTestWatcher,
   WatcherState,
 } from './types';
 
@@ -31,25 +31,34 @@ interface WorkerInterface extends Worker {
 
 namespace TestRunner {
   export type Test = JestTest;
+  export type OnTestFailure = JestOnTestFailure;
+  export type OnTestStart = JestOnTestStart;
+  export type OnTestSuccess = JestOnTestSuccess;
+  export type TestWatcher = JestTestWatcher;
+  export type TestRunnerContext = JestTestRunnerContext;
+  export type TestRunnerOptions = JestTestRunnerOptions;
 }
 
 /* eslint-disable-next-line no-redeclare */
 class TestRunner {
   private _globalConfig: Config.GlobalConfig;
-  private _context: TestRunnerContext;
+  private _context: JestTestRunnerContext;
 
-  constructor(globalConfig: Config.GlobalConfig, context?: TestRunnerContext) {
+  constructor(
+    globalConfig: Config.GlobalConfig,
+    context?: JestTestRunnerContext,
+  ) {
     this._globalConfig = globalConfig;
     this._context = context || {};
   }
 
   async runTests(
     tests: Array<JestTest>,
-    watcher: TestWatcher,
-    onStart: OnTestStart,
-    onResult: OnTestSuccess,
-    onFailure: OnTestFailure,
-    options: TestRunnerOptions,
+    watcher: JestTestWatcher,
+    onStart: JestOnTestStart,
+    onResult: JestOnTestSuccess,
+    onFailure: JestOnTestFailure,
+    options: JestTestRunnerOptions,
   ): Promise<void> {
     return await (options.serial
       ? this._createInBandTestRun(tests, watcher, onStart, onResult, onFailure)
@@ -64,10 +73,10 @@ class TestRunner {
 
   private async _createInBandTestRun(
     tests: Array<JestTest>,
-    watcher: TestWatcher,
-    onStart: OnTestStart,
-    onResult: OnTestSuccess,
-    onFailure: OnTestFailure,
+    watcher: JestTestWatcher,
+    onStart: JestOnTestStart,
+    onResult: JestOnTestSuccess,
+    onFailure: JestOnTestFailure,
   ) {
     process.env.JEST_WORKER_ID = '1';
     const mutex = throat(1);
@@ -98,10 +107,10 @@ class TestRunner {
 
   private async _createParallelTestRun(
     tests: Array<JestTest>,
-    watcher: TestWatcher,
-    onStart: OnTestStart,
-    onResult: OnTestSuccess,
-    onFailure: OnTestFailure,
+    watcher: JestTestWatcher,
+    onStart: JestOnTestStart,
+    onResult: JestOnTestSuccess,
+    onFailure: JestOnTestFailure,
   ) {
     const resolvers: Map<string, SerializableResolver> = new Map();
     for (const test of tests) {


### PR DESCRIPTION
## Summary

The following type are required to be exported from `jest-runner`, so that they can be imported when writing a runner in Typescript

Type signature of `runTests`
```js
async runTests(
  tests: Array<Test>,
  watcher: TestWatcher,
  onStart: OnTestStart,
  onResult: OnTestSuccess,
  onFailure: OnTestFailure,
  options: TestRunnerOptions,
): Promise<void>
```

Types needed to be exported
```
OnTestFailure
OnTestStart
OnTestSuccess
TestWatcher 
TestRunnerContext 
TestRunnerOptions
```

Needed for #8810 

/cc @SimenB 

## Test plan

The existing test cases should cover it, will be adding a test using the types when raising a PR for 
#8810 