### PR TITLE
Support async cacheResults in custom testSequencer

### DIFF
--- a/packages/jest-core/src/runJest.ts
+++ b/packages/jest-core/src/runJest.ts
@@ -251,7 +251,7 @@ export default (async function runJest({
     testSchedulerContext,
   ).scheduleTests(allTests, testWatcher);
 
-  sequencer.cacheResults(allTests, results);
+  await sequencer.cacheResults(allTests, results);
 
   if (hasTests) {
     await runGlobalHook({allTests, globalConfig, moduleName: 'globalTeardown'});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

PR #8642 makes it so that the `sort` method of a `testSequencer` can be async in order to support use cases where you fetch test data from an async endpoint. This PR aims to complement it by adding the possibility to store the cache in an async fashion as well.

The entire PR comes down to adding the `await` keyword to the `cacheResults` method call.


## Test plan

I am opening this PR as a draft PR because I want to consult with the community on how I should test this feature.
At first I added more tests to the [customTestSequencers.test.ts](https://github.com/facebook/jest/blob/master/e2e/__tests__/customTestSequencers.test.ts) suite. Those tests are e2e tests that spawn a process which will wait for the async operation to end before exiting, making the async process work eventually, thus making the test useless.

Instead, I thought about adding unit tests but currently there are no tests for customSequencers other than the aforementioned e2e. The unit tests for the [test_sequencer.test.js](https://github.com/facebook/jest/blob/master/packages/jest-test-sequencer/src/__tests__/test_sequencer.test.js) test the default implementation and I think adding tests for a custom one will make a mess of it all.

Where and how should I test this?
Thanks