### PR TITLE
Updated matchMedia methods

### DIFF
--- a/docs/ManualMocks.md
+++ b/docs/ManualMocks.md
@@ -146,8 +146,10 @@ window.matchMedia = jest.fn().mockImplementation(query => {
     matches: false,
     media: query,
     onchange: null,
-    addListener: jest.fn(),
-    removeListener: jest.fn(),
+    addListener: jest.fn(), // deprecated
+    removeListener: jest.fn(), // deprecated
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
   };
 });
 ```

--- a/docs/ManualMocks.md
+++ b/docs/ManualMocks.md
@@ -150,6 +150,7 @@ window.matchMedia = jest.fn().mockImplementation(query => {
     removeListener: jest.fn(), // deprecated
     addEventListener: jest.fn(),
     removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
   };
 });
 ```

--- a/website/versioned_docs/version-23.x/ManualMocks.md
+++ b/website/versioned_docs/version-23.x/ManualMocks.md
@@ -151,6 +151,7 @@ window.matchMedia = jest.fn().mockImplementation(query => {
     removeListener: jest.fn(), // deprecated
     addEventListener: jest.fn(),
     removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
   };
 });
 ```

--- a/website/versioned_docs/version-23.x/ManualMocks.md
+++ b/website/versioned_docs/version-23.x/ManualMocks.md
@@ -147,8 +147,10 @@ window.matchMedia = jest.fn().mockImplementation(query => {
     matches: false,
     media: query,
     onchange: null,
-    addListener: jest.fn(),
-    removeListener: jest.fn(),
+    addListener: jest.fn(), // deprecated
+    removeListener: jest.fn(), // deprecated
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
   };
 });
 ```


### PR DESCRIPTION
`addListener` and `removeListener` are [deprecated](https://github.com/microsoft/TypeScript/blob/602966ba4ecd0ef7923be61806b98755e2919501/lib/lib.dom.d.ts#L10380) in a favor of `addEventListener` and `removeEventListener`.

From [MediaQueryList/addListener](https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList/addListener)
> This (addListener) is basically an alias for EventTarget.addEventListener(), for backwards compatibility purposes.

They are supported by all major browsers: [EventTarget/addEventListener](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener)

BTW, `TSLint` is producing the following error when trying to use `addListener`:
```
ERROR: /app/Component.tsx:xx:xx - addListener is deprecated.
```