### PR TITLE
chore: reduce reliance on esModuleInterop

### DIFF
--- a/e2e/Utils.ts
+++ b/e2e/Utils.ts
@@ -6,8 +6,8 @@
  *
  */
 
-import fs from 'fs';
-import path from 'path';
+import * as fs from 'fs';
+import * as path from 'path';
 import {Config} from '@jest/types';
 
 import {sync as spawnSync, ExecaReturns} from 'execa';

--- a/e2e/__tests__/__snapshots__/moduleNameMapper.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/moduleNameMapper.test.ts.snap
@@ -30,6 +30,6 @@ FAIL __tests__/index.js
       12 | module.exports = () => 'test';
       13 | 
 
-      at createNoMappedModuleFoundError (../../packages/jest-resolve/build/index.js:501:17)
+      at createNoMappedModuleFoundError (../../packages/jest-resolve/build/index.js:493:17)
       at Object.require (index.js:10:1)
 `;

--- a/e2e/__tests__/__snapshots__/resolveNoFileExtensions.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/resolveNoFileExtensions.test.ts.snap
@@ -33,6 +33,6 @@ FAIL __tests__/test.js
         |                  ^
       9 | 
 
-      at Resolver.resolveModule (../../packages/jest-resolve/build/index.js:259:17)
+      at Resolver.resolveModule (../../packages/jest-resolve/build/index.js:255:17)
       at Object.require (index.js:8:18)
 `;

--- a/e2e/__tests__/__snapshots__/transform.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/transform.test.ts.snap
@@ -6,7 +6,7 @@ FAIL __tests__/ignoredFile.test.js
 
     babel-jest: Babel ignores __tests__/ignoredFile.test.js - make sure to include the file in Jest's transformIgnorePatterns as well.
 
-      at loadBabelConfig (../../../packages/babel-jest/build/index.js:132:13)
+      at loadBabelConfig (../../../packages/babel-jest/build/index.js:157:13)
 `;
 
 exports[`babel-jest instruments only specific files and collects coverage 1`] = `

--- a/e2e/__tests__/asyncRegenerator.test.ts
+++ b/e2e/__tests__/asyncRegenerator.test.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
+import * as path from 'path';
 import {run} from '../Utils';
 import {json as runWithJson} from '../runJest';
 

--- a/e2e/__tests__/babelPluginJestHoist.test.ts
+++ b/e2e/__tests__/babelPluginJestHoist.test.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
+import * as path from 'path';
 import {json as runWithJson} from '../runJest';
 import {run} from '../Utils';
 

--- a/e2e/__tests__/chaiAssertionLibrary.ts
+++ b/e2e/__tests__/chaiAssertionLibrary.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
+import * as path from 'path';
 import {wrap} from 'jest-snapshot-serializer-raw';
 import runJest from '../runJest';
 import {extractSummary, run} from '../Utils';

--- a/e2e/__tests__/clearCache.test.ts
+++ b/e2e/__tests__/clearCache.test.ts
@@ -5,12 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import fs from 'fs';
-import os from 'os';
-import path from 'path';
+import * as fs from 'fs';
+import {tmpdir} from 'os';
+import * as path from 'path';
 import runJest from '../runJest';
 
-const CACHE = path.resolve(os.tmpdir(), 'clear-cache-directory');
+const CACHE = path.resolve(tmpdir(), 'clear-cache-directory');
 
 describe('jest --clearCache', () => {
   test('normal run results in cache directory being written', () => {

--- a/e2e/__tests__/cliHandlesExactFilenames.test.ts
+++ b/e2e/__tests__/cliHandlesExactFilenames.test.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
+import * as path from 'path';
 import {wrap} from 'jest-snapshot-serializer-raw';
 import {skipSuiteOnWindows} from '@jest/test-utils';
 import {cleanup, extractSummary, writeFiles} from '../Utils';

--- a/e2e/__tests__/console.test.ts
+++ b/e2e/__tests__/console.test.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
+import * as path from 'path';
 import {wrap} from 'jest-snapshot-serializer-raw';
 import {extractSummary, run} from '../Utils';
 import runJest from '../runJest';

--- a/e2e/__tests__/consoleLogOutputWhenRunInBand.test.ts
+++ b/e2e/__tests__/consoleLogOutputWhenRunInBand.test.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
+import * as path from 'path';
 import {wrap} from 'jest-snapshot-serializer-raw';
 import {cleanup, extractSummary, writeFiles} from '../Utils';
 import runJest from '../runJest';

--- a/e2e/__tests__/coverageRemapping.test.ts
+++ b/e2e/__tests__/coverageRemapping.test.ts
@@ -6,7 +6,7 @@
  */
 
 import {readFileSync} from 'fs';
-import path from 'path';
+import * as path from 'path';
 import {cleanup, run} from '../Utils';
 import runJest from '../runJest';
 

--- a/e2e/__tests__/coverageReport.test.ts
+++ b/e2e/__tests__/coverageReport.test.ts
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import fs from 'fs';
-import path from 'path';
+import * as fs from 'fs';
+import * as path from 'path';
 import {wrap} from 'jest-snapshot-serializer-raw';
 import {extractSummary, run} from '../Utils';
 import runJest from '../runJest';

--- a/e2e/__tests__/coverageThreshold.test.ts
+++ b/e2e/__tests__/coverageThreshold.test.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
+import * as path from 'path';
 import {wrap} from 'jest-snapshot-serializer-raw';
 import {cleanup, extractSummary, writeFiles} from '../Utils';
 import runJest from '../runJest';

--- a/e2e/__tests__/coverageTransformInstrumented.test.ts
+++ b/e2e/__tests__/coverageTransformInstrumented.test.ts
@@ -6,7 +6,7 @@
  */
 
 import {readFileSync} from 'fs';
-import path from 'path';
+import * as path from 'path';
 import {cleanup, run} from '../Utils';
 import runJest from '../runJest';
 

--- a/e2e/__tests__/customReporters.test.ts
+++ b/e2e/__tests__/customReporters.test.ts
@@ -5,13 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import os from 'os';
-import path from 'path';
+import {tmpdir} from 'os';
+import * as path from 'path';
 import {wrap} from 'jest-snapshot-serializer-raw';
 import runJest from '../runJest';
 import {cleanup, extractSummary, writeFiles} from '../Utils';
 
-const DIR = path.resolve(os.tmpdir(), 'custom-reporters-test-dir');
+const DIR = path.resolve(tmpdir(), 'custom-reporters-test-dir');
 
 beforeEach(() => cleanup(DIR));
 afterEach(() => cleanup(DIR));

--- a/e2e/__tests__/customTestSequencers.test.ts
+++ b/e2e/__tests__/customTestSequencers.test.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
+import * as path from 'path';
 import runJest from '../runJest';
 import {extractSummary} from '../Utils';
 const dir = path.resolve(__dirname, '../custom-test-sequencer');

--- a/e2e/__tests__/debug.test.ts
+++ b/e2e/__tests__/debug.test.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
+import * as path from 'path';
 import runJest from '../runJest';
 
 describe('jest --debug', () => {

--- a/e2e/__tests__/dependencyClash.test.ts
+++ b/e2e/__tests__/dependencyClash.test.ts
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
-import os from 'os';
+import * as path from 'path';
+import {tmpdir} from 'os';
 import {skipSuiteOnWindows} from '@jest/test-utils';
 import {cleanup, createEmptyPackage, writeFiles} from '../Utils';
 import runJest from '../runJest';
@@ -14,7 +14,7 @@ import runJest from '../runJest';
 skipSuiteOnWindows();
 
 // doing test in a temp directory because we don't want jest node_modules affect it
-const tempDir = path.resolve(os.tmpdir(), 'clashing-dependencies-test');
+const tempDir = path.resolve(tmpdir(), 'clashing-dependencies-test');
 const hasteImplModulePath = path.resolve(
   './packages/jest-haste-map/src/__tests__/haste_impl.js',
 );

--- a/e2e/__tests__/deprecatedCliOptions.test.ts
+++ b/e2e/__tests__/deprecatedCliOptions.test.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
+import * as path from 'path';
 import runJest from '../runJest';
 
 const dir = path.resolve(__dirname, '../deprecated-cli-options');

--- a/e2e/__tests__/each.test.ts
+++ b/e2e/__tests__/each.test.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
+import * as path from 'path';
 import {wrap} from 'jest-snapshot-serializer-raw';
 import runJest from '../runJest';
 import {extractSummary} from '../Utils';

--- a/e2e/__tests__/emptyDescribeWithHooks.test.ts
+++ b/e2e/__tests__/emptyDescribeWithHooks.test.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
+import * as path from 'path';
 import {skipSuiteOnJasmine} from '@jest/test-utils';
 import runJest from '../runJest';
 import {extractSummary} from '../Utils';

--- a/e2e/__tests__/emptySuiteError.test.ts
+++ b/e2e/__tests__/emptySuiteError.test.ts
@@ -7,7 +7,7 @@
 
 'use strict';
 
-import path from 'path';
+import * as path from 'path';
 import runJest from '../runJest';
 
 const DIR = path.resolve(__dirname, '../empty-suite-error');

--- a/e2e/__tests__/executeTestsOnceInMpr.ts
+++ b/e2e/__tests__/executeTestsOnceInMpr.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
+import * as path from 'path';
 import {wrap} from 'jest-snapshot-serializer-raw';
 import {cleanup, extractSummary, writeFiles} from '../Utils';
 import runJest from '../runJest';

--- a/e2e/__tests__/expectAsyncMatcher.test.ts
+++ b/e2e/__tests__/expectAsyncMatcher.test.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
+import * as path from 'path';
 import {wrap} from 'jest-snapshot-serializer-raw';
 import runJest from '../runJest';
 import {extractSummary, run} from '../Utils';

--- a/e2e/__tests__/failures.test.ts
+++ b/e2e/__tests__/failures.test.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
+import * as path from 'path';
 import {wrap} from 'jest-snapshot-serializer-raw';
 import {extractSummary, run} from '../Utils';
 import runJest from '../runJest';

--- a/e2e/__tests__/fatalWorkerError.test.ts
+++ b/e2e/__tests__/fatalWorkerError.test.ts
@@ -5,12 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
-import os from 'os';
+import * as path from 'path';
+import {tmpdir} from 'os';
 import {cleanup, writeFiles} from '../Utils';
 import runJest from '../runJest';
 
-const DIR = path.resolve(os.tmpdir(), 'fatal-worker-error');
+const DIR = path.resolve(tmpdir(), 'fatal-worker-error');
 
 beforeEach(() => cleanup(DIR));
 afterAll(() => cleanup(DIR));

--- a/e2e/__tests__/findRelatedFiles.test.ts
+++ b/e2e/__tests__/findRelatedFiles.test.ts
@@ -5,13 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import os from 'os';
-import path from 'path';
+import {tmpdir} from 'os';
+import * as path from 'path';
 import {wrap} from 'jest-snapshot-serializer-raw';
 import {cleanup, extractSummary, writeFiles} from '../Utils';
 import runJest from '../runJest';
 
-const DIR = path.resolve(os.tmpdir(), 'find-related-tests-test');
+const DIR = path.resolve(tmpdir(), 'find-related-tests-test');
 
 beforeEach(() => cleanup(DIR));
 afterEach(() => cleanup(DIR));

--- a/e2e/__tests__/forceExit.test.ts
+++ b/e2e/__tests__/forceExit.test.ts
@@ -5,12 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import os from 'os';
-import path from 'path';
+import {tmpdir} from 'os';
+import * as path from 'path';
 import runJest from '../runJest';
 import {cleanup, writeFiles} from '../Utils';
 
-const DIR = path.resolve(os.tmpdir(), 'force-exit-test');
+const DIR = path.resolve(tmpdir(), 'force-exit-test');
 
 beforeEach(() => cleanup(DIR));
 afterEach(() => cleanup(DIR));

--- a/e2e/__tests__/globalSetup.test.ts
+++ b/e2e/__tests__/globalSetup.test.ts
@@ -6,20 +6,20 @@
  */
 'use strict';
 
-import fs from 'fs';
-import os from 'os';
-import path from 'path';
+import * as fs from 'fs';
+import {tmpdir} from 'os';
+import * as path from 'path';
 import runJest, {json as runWithJson} from '../runJest';
 import {cleanup, run} from '../Utils';
 
-const DIR = path.join(os.tmpdir(), 'jest-global-setup');
-const project1DIR = path.join(os.tmpdir(), 'jest-global-setup-project-1');
-const project2DIR = path.join(os.tmpdir(), 'jest-global-setup-project-2');
+const DIR = path.join(tmpdir(), 'jest-global-setup');
+const project1DIR = path.join(tmpdir(), 'jest-global-setup-project-1');
+const project2DIR = path.join(tmpdir(), 'jest-global-setup-project-2');
 const customTransformDIR = path.join(
-  os.tmpdir(),
+  tmpdir(),
   'jest-global-setup-custom-transform',
 );
-const nodeModulesDIR = path.join(os.tmpdir(), 'jest-global-setup-node-modules');
+const nodeModulesDIR = path.join(tmpdir(), 'jest-global-setup-node-modules');
 const e2eDir = path.resolve(__dirname, '../global-setup');
 
 beforeAll(() => {

--- a/e2e/__tests__/globalTeardown.test.ts
+++ b/e2e/__tests__/globalTeardown.test.ts
@@ -6,16 +6,16 @@
  */
 'use strict';
 
-import fs from 'fs';
-import os from 'os';
-import path from 'path';
+import * as fs from 'fs';
+import {tmpdir} from 'os';
+import * as path from 'path';
 import {createDirectory} from 'jest-util';
 import runJest, {json as runWithJson} from '../runJest';
 import {cleanup, run} from '../Utils';
 
-const DIR = path.join(os.tmpdir(), 'jest-global-teardown');
-const project1DIR = path.join(os.tmpdir(), 'jest-global-teardown-project-1');
-const project2DIR = path.join(os.tmpdir(), 'jest-global-teardown-project-2');
+const DIR = path.join(tmpdir(), 'jest-global-teardown');
+const project1DIR = path.join(tmpdir(), 'jest-global-teardown-project-1');
+const project2DIR = path.join(tmpdir(), 'jest-global-teardown-project-2');
 const e2eDir = path.resolve(__dirname, '../global-teardown');
 
 beforeAll(() => {

--- a/e2e/__tests__/globals.test.ts
+++ b/e2e/__tests__/globals.test.ts
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
-import os from 'os';
+import * as path from 'path';
+import {tmpdir} from 'os';
 import {wrap} from 'jest-snapshot-serializer-raw';
 import runJest from '../runJest';
 import {
@@ -16,7 +16,7 @@ import {
   writeFiles,
 } from '../Utils';
 
-const DIR = path.resolve(os.tmpdir(), 'globalVariables.test');
+const DIR = path.resolve(tmpdir(), 'globalVariables.test');
 const TEST_DIR = path.resolve(DIR, '__tests__');
 
 function cleanStderr(stderr) {

--- a/e2e/__tests__/hasteMapMockChanged.test.ts
+++ b/e2e/__tests__/hasteMapMockChanged.test.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
+import * as path from 'path';
 import JestHasteMap from 'jest-haste-map';
 import {cleanup, writeFiles} from '../Utils';
 

--- a/e2e/__tests__/hasteMapSha1.test.ts
+++ b/e2e/__tests__/hasteMapSha1.test.ts
@@ -5,12 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import os from 'os';
-import path from 'path';
+import {tmpdir} from 'os';
+import * as path from 'path';
 import JestHasteMap from 'jest-haste-map';
 import {cleanup, writeFiles} from '../Utils';
 
-const DIR = path.resolve(os.tmpdir(), 'haste_map_sha1');
+const DIR = path.resolve(tmpdir(), 'haste_map_sha1');
 
 beforeEach(() => cleanup(DIR));
 afterEach(() => cleanup(DIR));

--- a/e2e/__tests__/hasteMapSize.test.ts
+++ b/e2e/__tests__/hasteMapSize.test.ts
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import os from 'os';
-import path from 'path';
+import {tmpdir} from 'os';
+import * as path from 'path';
 import HasteMap from 'jest-haste-map';
 import {sync as realpath} from 'realpath-native';
 import {cleanup, writeFiles} from '../Utils';

--- a/e2e/__tests__/hasteMapSize.test.ts
+++ b/e2e/__tests__/hasteMapSize.test.ts
@@ -11,7 +11,7 @@ import HasteMap from 'jest-haste-map';
 import {sync as realpath} from 'realpath-native';
 import {cleanup, writeFiles} from '../Utils';
 
-const DIR = path.resolve(realpath(os.tmpdir()), 'haste_map_size');
+const DIR = path.resolve(realpath(tmpdir()), 'haste_map_size');
 
 beforeEach(() => {
   cleanup(DIR);

--- a/e2e/__tests__/jest.config.js.test.ts
+++ b/e2e/__tests__/jest.config.js.test.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
+import * as path from 'path';
 import {wrap} from 'jest-snapshot-serializer-raw';
 import runJest from '../runJest';
 import {cleanup, extractSummary, writeFiles} from '../Utils';

--- a/e2e/__tests__/jestChangedFiles.test.ts
+++ b/e2e/__tests__/jestChangedFiles.test.ts
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import os from 'os';
-import path from 'path';
+import {tmpdir} from 'os';
+import * as path from 'path';
 import {wrap} from 'jest-snapshot-serializer-raw';
 import {findRepos, getChangedFilesForRoots} from 'jest-changed-files';
 import {skipSuiteOnWindows} from '@jest/test-utils';
@@ -15,7 +15,7 @@ import runJest from '../runJest';
 
 skipSuiteOnWindows();
 
-const DIR = path.resolve(os.tmpdir(), 'jest-changed-files-test-dir');
+const DIR = path.resolve(tmpdir(), 'jest-changed-files-test-dir');
 
 const GIT = 'git -c user.name=jest_test -c user.email=jest_test@test.com';
 const HG = 'hg --config ui.username=jest_test';

--- a/e2e/__tests__/jestRequireActual.test.ts
+++ b/e2e/__tests__/jestRequireActual.test.ts
@@ -5,12 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
-import os from 'os';
+import * as path from 'path';
+import {tmpdir} from 'os';
 import {cleanup, writeFiles} from '../Utils';
 import runJest from '../runJest';
 
-const DIR = path.resolve(os.tmpdir(), 'jest-require-actual-test');
+const DIR = path.resolve(tmpdir(), 'jest-require-actual-test');
 
 beforeEach(() => cleanup(DIR));
 afterAll(() => cleanup(DIR));

--- a/e2e/__tests__/jestRequireMock.test.ts
+++ b/e2e/__tests__/jestRequireMock.test.ts
@@ -5,12 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
-import os from 'os';
+import * as path from 'path';
+import {tmpdir} from 'os';
 import {cleanup, writeFiles} from '../Utils';
 import runJest from '../runJest';
 
-const DIR = path.resolve(os.tmpdir(), 'jest-require-mock-test');
+const DIR = path.resolve(tmpdir(), 'jest-require-mock-test');
 
 beforeEach(() => cleanup(DIR));
 afterAll(() => cleanup(DIR));

--- a/e2e/__tests__/jsonReporter.test.ts
+++ b/e2e/__tests__/jsonReporter.test.ts
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import fs from 'fs';
-import path from 'path';
+import * as fs from 'fs';
+import * as path from 'path';
 import runJest from '../runJest';
 
 describe('JSON Reporter', () => {

--- a/e2e/__tests__/listTests.test.ts
+++ b/e2e/__tests__/listTests.test.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
+import * as path from 'path';
 import {wrap} from 'jest-snapshot-serializer-raw';
 import runJest from '../runJest';
 

--- a/e2e/__tests__/logHeapUsage.test.ts
+++ b/e2e/__tests__/logHeapUsage.test.ts
@@ -5,12 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
-import os from 'os';
+import * as path from 'path';
+import {tmpdir} from 'os';
 import {cleanup, writeFiles} from '../Utils';
 import runJest from '../runJest';
 
-const DIR = path.resolve(os.tmpdir(), 'log_heap_usage_test');
+const DIR = path.resolve(tmpdir(), 'log_heap_usage_test');
 
 beforeEach(() => cleanup(DIR));
 afterAll(() => cleanup(DIR));

--- a/e2e/__tests__/multiProjectRunner.test.ts
+++ b/e2e/__tests__/multiProjectRunner.test.ts
@@ -5,13 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import os from 'os';
-import path from 'path';
+import {tmpdir} from 'os';
+import * as path from 'path';
 import {wrap} from 'jest-snapshot-serializer-raw';
 import {cleanup, extractSummary, sortLines, writeFiles} from '../Utils';
 import runJest from '../runJest';
 
-const DIR = path.resolve(os.tmpdir(), 'multi-project-runner-test');
+const DIR = path.resolve(tmpdir(), 'multi-project-runner-test');
 
 const SAMPLE_FILE_CONTENT = 'module.exports = {};';
 

--- a/e2e/__tests__/nativeAsyncMock.test.ts
+++ b/e2e/__tests__/nativeAsyncMock.test.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
+import * as path from 'path';
 import {extractSummary, run} from '../Utils';
 import runJest from '../runJest';
 

--- a/e2e/__tests__/noTestsFound.test.ts
+++ b/e2e/__tests__/noTestsFound.test.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
+import * as path from 'path';
 import runJest from '../runJest';
 
 const DIR = path.resolve(__dirname, '../no-tests-found-test');

--- a/e2e/__tests__/onlyChanged.test.ts
+++ b/e2e/__tests__/onlyChanged.test.ts
@@ -5,12 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import os from 'os';
-import path from 'path';
+import {tmpdir} from 'os';
+import * as path from 'path';
 import runJest from '../runJest';
 import {cleanup, run, writeFiles} from '../Utils';
 
-const DIR = path.resolve(os.tmpdir(), 'jest_only_changed');
+const DIR = path.resolve(tmpdir(), 'jest_only_changed');
 const GIT = 'git -c user.name=jest_test -c user.email=jest_test@test.com';
 const HG = 'hg --config ui.username=jest_test';
 

--- a/e2e/__tests__/pnp.test.ts
+++ b/e2e/__tests__/pnp.test.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
+import * as path from 'path';
 import {skipSuiteOnWindows} from '@jest/test-utils';
 import {json as runWithJson} from '../runJest';
 import {run} from '../Utils';

--- a/e2e/__tests__/promiseReject.test.ts
+++ b/e2e/__tests__/promiseReject.test.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
+import * as path from 'path';
 import runJest from '../runJest';
 import {cleanup, writeFiles} from '../Utils';
 

--- a/e2e/__tests__/resolveNoFileExtensions.test.ts
+++ b/e2e/__tests__/resolveNoFileExtensions.test.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
+import * as path from 'path';
 import {wrap} from 'jest-snapshot-serializer-raw';
 import runJest from '../runJest';
 import {cleanup, extractSummary, writeFiles} from '../Utils';

--- a/e2e/__tests__/runTestsByPath.test.ts
+++ b/e2e/__tests__/runTestsByPath.test.ts
@@ -5,12 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import os from 'os';
-import path from 'path';
+import {tmpdir} from 'os';
+import * as path from 'path';
 import runJest from '../runJest';
 import {cleanup, writeFiles} from '../Utils';
 
-const DIR = path.resolve(os.tmpdir(), 'run-tests-by-path-test');
+const DIR = path.resolve(tmpdir(), 'run-tests-by-path-test');
 
 beforeEach(() => cleanup(DIR));
 afterEach(() => cleanup(DIR));

--- a/e2e/__tests__/setupFilesAfterEnvConfig.test.ts
+++ b/e2e/__tests__/setupFilesAfterEnvConfig.test.ts
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import fs from 'fs';
-import path from 'path';
+import * as fs from 'fs';
+import * as path from 'path';
 import {json as runWithJson} from '../runJest';
 import {writeFiles} from '../Utils';
 

--- a/e2e/__tests__/showConfig.test.ts
+++ b/e2e/__tests__/showConfig.test.ts
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
-import os from 'os';
+import * as path from 'path';
+import {tmpdir} from 'os';
 import {wrap} from 'jest-snapshot-serializer-raw';
 import {skipSuiteOnWindows} from '@jest/test-utils';
 import runJest from '../runJest';
@@ -14,7 +14,7 @@ import {cleanup, writeFiles} from '../Utils';
 
 skipSuiteOnWindows();
 
-const DIR = path.resolve(os.tmpdir(), 'show-config-test');
+const DIR = path.resolve(tmpdir(), 'show-config-test');
 
 beforeEach(() => cleanup(DIR));
 afterEach(() => cleanup(DIR));

--- a/e2e/__tests__/snapshot.test.ts
+++ b/e2e/__tests__/snapshot.test.ts
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import fs from 'fs';
-import path from 'path';
+import * as fs from 'fs';
+import * as path from 'path';
 import {wrap} from 'jest-snapshot-serializer-raw';
 import {extractSummary} from '../Utils';
 import runJest, {json as runWithJson} from '../runJest';

--- a/e2e/__tests__/snapshotMockFs.test.ts
+++ b/e2e/__tests__/snapshotMockFs.test.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
+import * as path from 'path';
 import rimraf from 'rimraf';
 import {wrap} from 'jest-snapshot-serializer-raw';
 import {extractSummary} from '../Utils';

--- a/e2e/__tests__/snapshotResolver.test.ts
+++ b/e2e/__tests__/snapshotResolver.test.ts
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import fs from 'fs';
-import path from 'path';
+import * as fs from 'fs';
+import * as path from 'path';
 import runJest from '../runJest';
 
 const snapshotDir = path.resolve(

--- a/e2e/__tests__/snapshotSerializers.test.ts
+++ b/e2e/__tests__/snapshotSerializers.test.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
+import * as path from 'path';
 import {cleanup} from '../Utils';
 import {json as runWithJson} from '../runJest';
 

--- a/e2e/__tests__/stackTraceSourceMaps.test.ts
+++ b/e2e/__tests__/stackTraceSourceMaps.test.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
+import * as path from 'path';
 import {run} from '../Utils';
 import runJest from '../runJest';
 

--- a/e2e/__tests__/supportsDashedArgs.ts
+++ b/e2e/__tests__/supportsDashedArgs.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
+import * as path from 'path';
 import runJest from '../runJest';
 
 const consoleDir = path.resolve(__dirname, '../console');

--- a/e2e/__tests__/testEnvironmentAsync.test.ts
+++ b/e2e/__tests__/testEnvironmentAsync.test.ts
@@ -5,13 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import fs from 'fs';
-import path from 'path';
-import os from 'os';
+import * as fs from 'fs';
+import * as path from 'path';
+import {tmpdir} from 'os';
 import runJest from '../runJest';
 import {cleanup} from '../Utils';
 
-const DIR = os.tmpdir() + '/jest-test-environment';
+const DIR = tmpdir() + '/jest-test-environment';
 
 beforeEach(() => cleanup(DIR));
 afterAll(() => cleanup(DIR));

--- a/e2e/__tests__/testFailureExitCode.test.ts
+++ b/e2e/__tests__/testFailureExitCode.test.ts
@@ -5,12 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
-import os from 'os';
+import * as path from 'path';
+import {tmpdir} from 'os';
 import {cleanup, writeFiles} from '../Utils';
 import runJest from '../runJest';
 
-const DIR = path.resolve(os.tmpdir(), 'test-failure-exit-code-test');
+const DIR = path.resolve(tmpdir(), 'test-failure-exit-code-test');
 
 beforeEach(() => cleanup(DIR));
 afterAll(() => cleanup(DIR));

--- a/e2e/__tests__/testInRoot.test.ts
+++ b/e2e/__tests__/testInRoot.test.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
+import * as path from 'path';
 import {json as runWithJson} from '../runJest';
 
 it('runs tests in only test.js and spec.js', () => {

--- a/e2e/__tests__/testPathPatternReporterMessage.test.ts
+++ b/e2e/__tests__/testPathPatternReporterMessage.test.ts
@@ -7,12 +7,12 @@
 
 'use strict';
 
-import os from 'os';
-import path from 'path';
+import {tmpdir} from 'os';
+import * as path from 'path';
 import runJest from '../runJest';
 import {cleanup, writeFiles} from '../Utils';
 
-const DIR = path.resolve(os.tmpdir(), 'jest-path-pattern-reporter-message');
+const DIR = path.resolve(tmpdir(), 'jest-path-pattern-reporter-message');
 
 beforeEach(() => cleanup(DIR));
 afterEach(() => cleanup(DIR));

--- a/e2e/__tests__/testResultsProcessor.test.ts
+++ b/e2e/__tests__/testResultsProcessor.test.ts
@@ -6,7 +6,7 @@
  */
 'use strict';
 
-import path from 'path';
+import * as path from 'path';
 import {json as runWithJson} from '../runJest';
 
 test('testNamePattern', () => {

--- a/e2e/__tests__/testRetries.test.ts
+++ b/e2e/__tests__/testRetries.test.ts
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import fs from 'fs';
-import path from 'path';
+import * as fs from 'fs';
+import * as path from 'path';
 import {skipSuiteOnJasmine} from '@jest/test-utils';
 import runJest from '../runJest';
 

--- a/e2e/__tests__/testTodo.test.ts
+++ b/e2e/__tests__/testTodo.test.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
+import * as path from 'path';
 import {wrap} from 'jest-snapshot-serializer-raw';
 import runJest from '../runJest';
 import {extractSummary} from '../Utils';

--- a/e2e/__tests__/timeouts.test.ts
+++ b/e2e/__tests__/timeouts.test.ts
@@ -7,7 +7,7 @@
 
 'use strict';
 
-import path from 'path';
+import * as path from 'path';
 import {wrap} from 'jest-snapshot-serializer-raw';
 import {cleanup, extractSummary, writeFiles} from '../Utils';
 import runJest from '../runJest';

--- a/e2e/__tests__/timeoutsLegacy.test.ts
+++ b/e2e/__tests__/timeoutsLegacy.test.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
+import * as path from 'path';
 import {wrap} from 'jest-snapshot-serializer-raw';
 import {skipSuiteOnJestCircus} from '@jest/test-utils';
 import {cleanup, extractSummary, writeFiles} from '../Utils';

--- a/e2e/__tests__/toMatchInlineSnapshot.test.ts
+++ b/e2e/__tests__/toMatchInlineSnapshot.test.ts
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import fs from 'fs';
-import path from 'path';
+import * as fs from 'fs';
+import * as path from 'path';
 import {wrap} from 'jest-snapshot-serializer-raw';
 import {cleanup, makeTemplate, writeFiles} from '../Utils';
 import runJest from '../runJest';

--- a/e2e/__tests__/toMatchInlineSnapshotWithRetries.test.ts
+++ b/e2e/__tests__/toMatchInlineSnapshotWithRetries.test.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
+import * as path from 'path';
 import {cleanup, makeTemplate, writeFiles} from '../Utils';
 import runJest from '../runJest';
 

--- a/e2e/__tests__/toMatchSnapshot.test.ts
+++ b/e2e/__tests__/toMatchSnapshot.test.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
+import * as path from 'path';
 import {cleanup, makeTemplate, writeFiles} from '../Utils';
 import runJest from '../runJest';
 

--- a/e2e/__tests__/toMatchSnapshotWithRetries.test.ts
+++ b/e2e/__tests__/toMatchSnapshotWithRetries.test.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
+import * as path from 'path';
 import {cleanup, makeTemplate, writeFiles} from '../Utils';
 import runJest from '../runJest';
 

--- a/e2e/__tests__/toThrowErrorMatchingInlineSnapshot.test.ts
+++ b/e2e/__tests__/toThrowErrorMatchingInlineSnapshot.test.ts
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
-import fs from 'fs';
+import * as path from 'path';
+import * as fs from 'fs';
 import {wrap} from 'jest-snapshot-serializer-raw';
 import {cleanup, makeTemplate, writeFiles} from '../Utils';
 import runJest from '../runJest';

--- a/e2e/__tests__/toThrowErrorMatchingSnapshot.test.ts
+++ b/e2e/__tests__/toThrowErrorMatchingSnapshot.test.ts
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
-import fs from 'fs';
+import * as path from 'path';
+import * as fs from 'fs';
 import {wrap} from 'jest-snapshot-serializer-raw';
 import {cleanup, makeTemplate, writeFiles} from '../Utils';
 import runJest from '../runJest';

--- a/e2e/__tests__/transform.test.ts
+++ b/e2e/__tests__/transform.test.ts
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
-import os from 'os';
+import * as path from 'path';
+import {tmpdir} from 'os';
 import {wrap} from 'jest-snapshot-serializer-raw';
 import {
   cleanup,
@@ -75,7 +75,7 @@ describe('babel-jest with manual transformer', () => {
 describe('no babel-jest', () => {
   const dir = path.resolve(__dirname, '..', 'transform/no-babel-jest');
   // doing test in a temp directory because we don't want jest node_modules affect it
-  const tempDir = path.resolve(os.tmpdir(), 'transform-no-babel-jest');
+  const tempDir = path.resolve(tmpdir(), 'transform-no-babel-jest');
 
   beforeEach(() => {
     cleanup(tempDir);

--- a/e2e/__tests__/typescriptCoverage.test.ts
+++ b/e2e/__tests__/typescriptCoverage.test.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
+import * as path from 'path';
 import {wrap} from 'jest-snapshot-serializer-raw';
 import {run} from '../Utils';
 import runJest from '../runJest';

--- a/e2e/__tests__/unexpectedToken.test.ts
+++ b/e2e/__tests__/unexpectedToken.test.ts
@@ -5,12 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import os from 'os';
-import path from 'path';
+import {tmpdir} from 'os';
+import * as path from 'path';
 import runJest from '../runJest';
 import {cleanup, writeFiles} from '../Utils';
 
-const DIR = path.resolve(os.tmpdir(), 'unexpected-token');
+const DIR = path.resolve(tmpdir(), 'unexpected-token');
 
 beforeEach(() => cleanup(DIR));
 afterEach(() => cleanup(DIR));

--- a/e2e/__tests__/useStderr.test.ts
+++ b/e2e/__tests__/useStderr.test.ts
@@ -5,12 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import os from 'os';
-import path from 'path';
+import {tmpdir} from 'os';
+import * as path from 'path';
 import runJest from '../runJest';
 import {cleanup, writeFiles} from '../Utils';
 
-const DIR = path.resolve(os.tmpdir(), 'use-stderr-test');
+const DIR = path.resolve(tmpdir(), 'use-stderr-test');
 
 beforeEach(() => cleanup(DIR));
 afterEach(() => cleanup(DIR));

--- a/e2e/__tests__/version.test.ts
+++ b/e2e/__tests__/version.test.ts
@@ -5,12 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
-import os from 'os';
+import * as path from 'path';
+import {tmpdir} from 'os';
 import {cleanup, writeFiles} from '../Utils';
 import runJest from '../runJest';
 
-const DIR = path.resolve(os.tmpdir(), 'version-test');
+const DIR = path.resolve(tmpdir(), 'version-test');
 
 beforeEach(() => cleanup(DIR));
 afterAll(() => cleanup(DIR));

--- a/e2e/__tests__/watchModeOnlyFailed.test.ts
+++ b/e2e/__tests__/watchModeOnlyFailed.test.ts
@@ -5,13 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
-import os from 'os';
+import * as path from 'path';
+import {tmpdir} from 'os';
 import {wrap} from 'jest-snapshot-serializer-raw';
 import {cleanup, extractSummaries, writeFiles} from '../Utils';
 import runJest from '../runJest';
 
-const DIR = path.resolve(os.tmpdir(), 'watch-mode-only-failed');
+const DIR = path.resolve(tmpdir(), 'watch-mode-only-failed');
 const pluginPath = path.resolve(__dirname, '../MockStdinWatchPlugin');
 
 beforeEach(() => cleanup(DIR));

--- a/e2e/__tests__/watchModePatterns.test.ts
+++ b/e2e/__tests__/watchModePatterns.test.ts
@@ -5,13 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
-import os from 'os';
+import * as path from 'path';
+import {tmpdir} from 'os';
 import {wrap} from 'jest-snapshot-serializer-raw';
 import {cleanup, extractSummaries, writeFiles} from '../Utils';
 import runJest from '../runJest';
 
-const DIR = path.resolve(os.tmpdir(), 'watch-mode-patterns');
+const DIR = path.resolve(tmpdir(), 'watch-mode-patterns');
 const pluginPath = path.resolve(__dirname, '../MockStdinWatchPlugin');
 
 beforeEach(() => cleanup(DIR));

--- a/e2e/__tests__/watchModeUpdateSnapshot.test.ts
+++ b/e2e/__tests__/watchModeUpdateSnapshot.test.ts
@@ -5,13 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
-import os from 'os';
+import * as path from 'path';
+import {tmpdir} from 'os';
 import {wrap} from 'jest-snapshot-serializer-raw';
 import {cleanup, extractSummaries, writeFiles} from '../Utils';
 import runJest from '../runJest';
 
-const DIR = path.resolve(os.tmpdir(), 'watch-mode-update-snapshot');
+const DIR = path.resolve(tmpdir(), 'watch-mode-update-snapshot');
 const pluginPath = path.resolve(__dirname, '../MockStdinWatchPlugin');
 
 beforeEach(() => cleanup(DIR));

--- a/e2e/runJest.ts
+++ b/e2e/runJest.ts
@@ -6,8 +6,8 @@
  *
  */
 
-import path from 'path';
-import fs from 'fs';
+import * as path from 'path';
+import * as fs from 'fs';
 import {Writable} from 'stream';
 import execa, {ExecaChildProcess, ExecaReturns} from 'execa';
 import stripAnsi from 'strip-ansi';

--- a/packages/babel-jest/src/index.ts
+++ b/packages/babel-jest/src/index.ts
@@ -5,9 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import crypto from 'crypto';
-import fs from 'fs';
-import path from 'path';
+import {createHash} from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
 import {Transformer} from '@jest/transform';
 import {Config} from '@jest/types';
 import {
@@ -77,8 +77,7 @@ const createTransformer = (
         babelOptions.babelrc || '',
       ];
 
-      return crypto
-        .createHash('md5')
+      return createHash('md5')
         .update(THIS_FILE)
         .update('\0', 'utf8')
         .update(JSON.stringify(babelOptions.options))

--- a/packages/jest-changed-files/src/git.ts
+++ b/packages/jest-changed-files/src/git.ts
@@ -6,7 +6,7 @@
  *
  */
 
-import path from 'path';
+import * as path from 'path';
 import execa from 'execa';
 import {Config} from '@jest/types';
 

--- a/packages/jest-changed-files/src/hg.ts
+++ b/packages/jest-changed-files/src/hg.ts
@@ -6,7 +6,7 @@
  *
  */
 
-import path from 'path';
+import * as path from 'path';
 import execa from 'execa';
 import {Config} from '@jest/types';
 

--- a/packages/jest-circus/src/__mocks__/testUtils.ts
+++ b/packages/jest-circus/src/__mocks__/testUtils.ts
@@ -5,10 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import fs from 'fs';
-import os from 'os';
-import path from 'path';
-import crypto from 'crypto';
+import * as fs from 'fs';
+import {tmpdir} from 'os';
+import * as path from 'path';
+import {createHash} from 'crypto';
 import {sync as spawnSync, ExecaReturns} from 'execa';
 import {skipSuiteOnWindows} from '@jest/test-utils';
 
@@ -26,11 +26,10 @@ interface Result extends ExecaReturns {
 }
 
 export const runTest = (source: string) => {
-  const filename = crypto
-    .createHash('md5')
+  const filename = createHash('md5')
     .update(source)
     .digest('hex');
-  const tmpFilename = path.join(os.tmpdir(), filename);
+  const tmpFilename = path.join(tmpdir(), filename);
 
   const content = `
     require('${BABEL_REGISTER_PATH}')({extensions: [".js", ".ts"]});

--- a/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapter.ts
+++ b/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapter.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
+import * as path from 'path';
 import {Config} from '@jest/types';
 import {JestEnvironment} from '@jest/environment';
 import {TestResult} from '@jest/test-result';

--- a/packages/jest-cli/src/cli/index.ts
+++ b/packages/jest-cli/src/cli/index.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
+import * as path from 'path';
 import {Config} from '@jest/types';
 import {AggregatedResult} from '@jest/test-result';
 import {clearLine} from 'jest-util';

--- a/packages/jest-cli/src/init/__tests__/init.test.js
+++ b/packages/jest-cli/src/init/__tests__/init.test.js
@@ -6,8 +6,8 @@
  */
 
 /* eslint-disable no-eval */
-import fs from 'fs';
-import path from 'path';
+import * as fs from 'fs';
+import * as path from 'path';
 import prompts from 'prompts';
 import init from '../';
 
@@ -16,23 +16,24 @@ jest.mock('../../../../jest-config/build/getCacheDirectory', () => () =>
   '/tmp/jest',
 );
 jest.mock('path', () => ({...jest.requireActual('path'), sep: '/'}));
+jest.mock('fs', () => ({
+  ...jest.requireActual('fs'),
+  writeFileSync: jest.fn(),
+}));
 
 const resolveFromFixture = relativePath =>
   path.resolve(__dirname, 'fixtures', relativePath);
 
-const writeFileSync = fs.writeFileSync;
 const consoleLog = console.log;
 
 describe('init', () => {
   beforeEach(() => {
     console.log = jest.fn();
-    fs.writeFileSync = jest.fn();
   });
 
   afterEach(() => {
     jest.clearAllMocks();
     console.log = consoleLog;
-    fs.writeFileSync = writeFileSync;
   });
 
   describe('project with package.json and no jest config', () => {

--- a/packages/jest-cli/src/init/index.ts
+++ b/packages/jest-cli/src/init/index.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import * as fs from 'fs';
+import fs from 'fs';
 import * as path from 'path';
 import chalk from 'chalk';
 import prompts from 'prompts';

--- a/packages/jest-cli/src/init/index.ts
+++ b/packages/jest-cli/src/init/index.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import fs from 'fs';
+import * as fs from 'fs';
 import * as path from 'path';
 import chalk from 'chalk';
 import prompts from 'prompts';

--- a/packages/jest-cli/src/init/index.ts
+++ b/packages/jest-cli/src/init/index.ts
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import fs from 'fs';
-import path from 'path';
+import * as fs from 'fs';
+import * as path from 'path';
 import chalk from 'chalk';
 import prompts from 'prompts';
 import {sync as realpath} from 'realpath-native';

--- a/packages/jest-config/src/__tests__/resolveConfigPath.test.ts
+++ b/packages/jest-config/src/__tests__/resolveConfigPath.test.ts
@@ -5,13 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import os from 'os';
-import path from 'path';
+import {tmpdir} from 'os';
+import * as path from 'path';
 import resolveConfigPath from '../resolveConfigPath';
 
 const {cleanup, writeFiles} = require('../../../../e2e/Utils');
 
-const DIR = path.resolve(os.tmpdir(), 'resolve_config_path_test');
+const DIR = path.resolve(tmpdir(), 'resolve_config_path_test');
 const ERROR_PATTERN = /Could not find a config file based on provided values/;
 const NO_ROOT_DIR_ERROR_PATTERN = /Can\'t find a root directory/;
 

--- a/packages/jest-config/src/constants.ts
+++ b/packages/jest-config/src/constants.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
+import * as path from 'path';
 
 export const NODE_MODULES = path.sep + 'node_modules' + path.sep;
 export const DEFAULT_JS_PATTERN = '^.+\\.[jt]sx?$';

--- a/packages/jest-config/src/getCacheDirectory.ts
+++ b/packages/jest-config/src/getCacheDirectory.ts
@@ -5,20 +5,20 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
-import os from 'os';
+import * as path from 'path';
+import {tmpdir} from 'os';
 import {sync as realpath} from 'realpath-native';
 
 const getCacheDirectory = () => {
   const {getuid} = process;
-  const tmpdir = path.join(realpath(os.tmpdir()), 'jest');
+  const tmpdirPath = path.join(realpath(tmpdir()), 'jest');
   if (getuid == null) {
-    return tmpdir;
+    return tmpdirPath;
   } else {
     // On some platforms tmpdir() is `/tmp`, causing conflicts between different
     // users and permission issues. Adding an additional subdivision by UID can
     // help.
-    return `${tmpdir}_${getuid.call(process).toString(36)}`;
+    return `${tmpdirPath}_${getuid.call(process).toString(36)}`;
   }
 };
 

--- a/packages/jest-config/src/getMaxWorkers.ts
+++ b/packages/jest-config/src/getMaxWorkers.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import os from 'os';
+import {cpus} from 'os';
 import {Config} from '@jest/types';
 
 export default function getMaxWorkers(
@@ -20,8 +20,8 @@ export default function getMaxWorkers(
     return parseWorkers(defaultOptions.maxWorkers);
   } else {
     // In watch mode, Jest should be unobtrusive and not use all available CPUs.
-    const cpus = os.cpus() ? os.cpus().length : 1;
-    return Math.max(argv.watch ? Math.floor(cpus / 2) : cpus - 1, 1);
+    const numCpus = cpus() ? cpus().length : 1;
+    return Math.max(argv.watch ? Math.floor(numCpus / 2) : numCpus - 1, 1);
   }
 }
 
@@ -34,8 +34,8 @@ const parseWorkers = (maxWorkers: string | number): number => {
     parsed > 0 &&
     parsed <= 100
   ) {
-    const cpus = os.cpus().length;
-    const workers = Math.floor((parsed / 100) * cpus);
+    const numCpus = cpus().length;
+    const workers = Math.floor((parsed / 100) * numCpus);
     return workers >= 1 ? workers : 1;
   }
 

--- a/packages/jest-config/src/index.ts
+++ b/packages/jest-config/src/index.ts
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import fs from 'fs';
-import path from 'path';
+import * as fs from 'fs';
+import * as path from 'path';
 import {Config} from '@jest/types';
 import chalk from 'chalk';
 import {isJSONString, replaceRootDirInPath} from './utils';

--- a/packages/jest-config/src/normalize.ts
+++ b/packages/jest-config/src/normalize.ts
@@ -5,14 +5,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import crypto from 'crypto';
-import path from 'path';
-import glob from 'glob';
+import {createHash} from 'crypto';
+import * as path from 'path';
+import {sync as glob} from 'glob';
 import {Config} from '@jest/types';
 import {ValidationError, validate} from 'jest-validate';
 import {clearLine, replacePathSepForGlob} from 'jest-util';
 import chalk from 'chalk';
-import micromatch from 'micromatch';
+import {some as micromatchSome} from 'micromatch';
 import {sync as realpath} from 'realpath-native';
 import Resolver from 'jest-resolve';
 import {replacePathSepForRegex} from 'jest-regex-util';
@@ -297,8 +297,7 @@ const normalizeMissingOptions = (
   projectIndex: number,
 ): Config.InitialOptions => {
   if (!options.name) {
-    options.name = crypto
-      .createHash('md5')
+    options.name = createHash('md5')
       .update(options.rootDir)
       // In case we load config from some path that has the same root dir
       .update(configPath || '')
@@ -680,7 +679,7 @@ export default function normalize(
               // We expand it to these paths. If not, we keep the original path
               // for the future resolution.
               const globMatches =
-                typeof project === 'string' ? glob.sync(project) : [];
+                typeof project === 'string' ? glob(project) : [];
               return projects.concat(
                 globMatches.length ? globMatches : project,
               );
@@ -983,7 +982,7 @@ export default function normalize(
     if (newOptions.collectCoverageFrom) {
       collectCoverageFrom = collectCoverageFrom.reduce((patterns, filename) => {
         if (
-          !micromatch.some(
+          !micromatchSome(
             replacePathSepForGlob(path.relative(options.rootDir, filename)),
             newOptions.collectCoverageFrom!,
           )

--- a/packages/jest-config/src/readConfigFileAndSetRootDir.ts
+++ b/packages/jest-config/src/readConfigFileAndSetRootDir.ts
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
-import fs from 'fs';
+import * as path from 'path';
+import * as fs from 'fs';
 import {Config} from '@jest/types';
 // @ts-ignore: vendored
 import jsonlint from './vendor/jsonlint';

--- a/packages/jest-config/src/resolveConfigPath.ts
+++ b/packages/jest-config/src/resolveConfigPath.ts
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
-import fs from 'fs';
+import * as path from 'path';
+import * as fs from 'fs';
 import {Config} from '@jest/types';
 import {JEST_CONFIG, PACKAGE_JSON} from './constants';
 

--- a/packages/jest-config/src/utils.ts
+++ b/packages/jest-config/src/utils.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
+import * as path from 'path';
 import {Config} from '@jest/types';
 import {ValidationError} from 'jest-validate';
 import Resolver from 'jest-resolve';

--- a/packages/jest-console/src/getConsoleOutput.ts
+++ b/packages/jest-console/src/getConsoleOutput.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
+import * as path from 'path';
 import chalk from 'chalk';
 import slash from 'slash';
 import {ConsoleBuffer} from './types';

--- a/packages/jest-core/src/SearchSource.ts
+++ b/packages/jest-core/src/SearchSource.ts
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
-import micromatch from 'micromatch';
+import * as path from 'path';
+import {some as micromatchSome} from 'micromatch';
 import {Context} from 'jest-runtime';
 import {Config} from '@jest/types';
 import {Test} from 'jest-runner';
@@ -37,7 +37,7 @@ export type TestSelectionConfig = {
 };
 
 const globsToMatcher = (globs: Array<Config.Glob>) => (path: Config.Path) =>
-  micromatch.some(replacePathSepForGlob(path), globs, {dot: true});
+  micromatchSome(replacePathSepForGlob(path), globs, {dot: true});
 
 const regexToMatcher = (testRegex: Array<string>) => (path: Config.Path) =>
   testRegex.some(testRegex => new RegExp(testRegex).test(path));

--- a/packages/jest-core/src/__tests__/SearchSource.test.ts
+++ b/packages/jest-core/src/__tests__/SearchSource.test.ts
@@ -6,7 +6,7 @@
  *
  */
 
-import path from 'path';
+import * as path from 'path';
 import Runtime from 'jest-runtime';
 import {normalize} from 'jest-config';
 import {Test} from 'jest-runner';

--- a/packages/jest-core/src/__tests__/watch-file-changes.test.ts
+++ b/packages/jest-core/src/__tests__/watch-file-changes.test.ts
@@ -8,9 +8,9 @@
 
 'use strict';
 
-import path from 'path';
-import fs from 'fs';
-import os from 'os';
+import * as path from 'path';
+import * as fs from 'fs';
+import {tmpdir} from 'os';
 import {JestHook} from 'jest-watcher';
 import Runtime from 'jest-runtime';
 import {normalize} from 'jest-config';
@@ -24,13 +24,13 @@ describe('Watch mode flows with changed files', () => {
   let watch: any;
   let pipe: NodeJS.ReadStream;
   let stdin: MockStdin;
-  const testDirectory = path.resolve(os.tmpdir(), 'jest-tmp');
+  const testDirectory = path.resolve(tmpdir(), 'jest-tmp');
   const fileTargetPath = path.resolve(testDirectory, 'lost-file.js');
   const fileTargetPath2 = path.resolve(
     testDirectory,
     'watch-test-fake.test.js',
   );
-  const cacheDirectory = path.resolve(os.tmpdir(), `tmp${Math.random()}`);
+  const cacheDirectory = path.resolve(tmpdir(), `tmp${Math.random()}`);
   let hasteMapInstance: HasteMap;
 
   beforeEach(() => {

--- a/packages/jest-core/src/lib/__tests__/is_valid_path.test.ts
+++ b/packages/jest-core/src/lib/__tests__/is_valid_path.test.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
+import * as path from 'path';
 import isValidPath from '../is_valid_path';
 import {makeGlobalConfig} from '../../../../../TestUtils';
 

--- a/packages/jest-core/src/runJest.ts
+++ b/packages/jest-core/src/runJest.ts
@@ -5,13 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
+import * as path from 'path';
 import chalk from 'chalk';
 import {sync as realpath} from 'realpath-native';
 import {CustomConsole} from '@jest/console';
 import {formatTestResults, interopRequireDefault} from 'jest-util';
 import exit from 'exit';
-import fs from 'graceful-fs';
+import * as fs from 'graceful-fs';
 import {JestHook, JestHookEmitter} from 'jest-watcher';
 import {Context} from 'jest-runtime';
 import {Test} from 'jest-runner';

--- a/packages/jest-core/src/watch.ts
+++ b/packages/jest-core/src/watch.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
+import * as path from 'path';
 import ansiEscapes from 'ansi-escapes';
 import chalk from 'chalk';
 import exit from 'exit';

--- a/packages/jest-docblock/src/__tests__/index.test.ts
+++ b/packages/jest-docblock/src/__tests__/index.test.ts
@@ -5,86 +5,68 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {tmpdir} from 'os';
+import {EOL} from 'os';
 import * as docblock from '..';
 
 describe('docblock', () => {
   it('extracts valid docblock with line comment', () => {
     const code =
       '/**' +
-      os.EOL +
+      EOL +
       ' * @team foo' +
-      os.EOL +
+      EOL +
       '* // TODO: test' +
-      os.EOL +
+      EOL +
       '*/' +
-      os.EOL +
+      EOL +
       'const x = foo;';
     expect(docblock.extract(code)).toBe(
-      '/**' +
-        os.EOL +
-        ' * @team foo' +
-        os.EOL +
-        '* // TODO: test' +
-        os.EOL +
-        '*/',
+      '/**' + EOL + ' * @team foo' + EOL + '* // TODO: test' + EOL + '*/',
     );
   });
 
   it('extracts valid docblock', () => {
     const code =
-      '/**' +
-      os.EOL +
-      ' * @team foo' +
-      os.EOL +
-      '*/' +
-      os.EOL +
-      'const x = foo;';
+      '/**' + EOL + ' * @team foo' + EOL + '*/' + EOL + 'const x = foo;';
     expect(docblock.extract(code)).toBe(
-      '/**' + os.EOL + ' * @team foo' + os.EOL + '*/',
+      '/**' + EOL + ' * @team foo' + EOL + '*/',
     );
   });
 
   it('extracts valid docblock with more comments', () => {
     const code =
       '/**' +
-      os.EOL +
+      EOL +
       ' * @team foo' +
-      os.EOL +
+      EOL +
       '*/' +
-      os.EOL +
+      EOL +
       'const x = foo;' +
-      os.EOL +
+      EOL +
       '/**foo*/';
     expect(docblock.extract(code)).toBe(
-      '/**' + os.EOL + ' * @team foo' + os.EOL + '*/',
+      '/**' + EOL + ' * @team foo' + EOL + '*/',
     );
   });
 
   it('extracts from invalid docblock', () => {
     const code =
-      '/*' +
-      os.EOL +
-      ' * @team foo' +
-      os.EOL +
-      '*/' +
-      os.EOL +
-      'const x = foo;';
+      '/*' + EOL + ' * @team foo' + EOL + '*/' + EOL + 'const x = foo;';
     expect(docblock.extract(code)).toBe(
-      '/*' + os.EOL + ' * @team foo' + os.EOL + '*/',
+      '/*' + EOL + ' * @team foo' + EOL + '*/',
     );
   });
 
   it('returns extract and parsedocblock', () => {
     const code =
       '/** @provides module-name */' +
-      os.EOL +
+      EOL +
       '' +
       '' +
-      os.EOL +
+      EOL +
       '' +
       '.dummy {}' +
-      os.EOL +
+      EOL +
       '';
 
     expect(docblock.parse(docblock.extract(code))).toEqual({
@@ -95,16 +77,16 @@ describe('docblock', () => {
   it('parses directives out of a docblock', () => {
     const code =
       '/**' +
-      os.EOL +
+      EOL +
       '' +
       ' * @team foo' +
-      os.EOL +
+      EOL +
       '' +
       ' * @css a b' +
-      os.EOL +
+      EOL +
       '' +
       ' * @preserve-whitespace' +
-      os.EOL +
+      EOL +
       '' +
       ' */';
     expect(docblock.parse(code)).toEqual({
@@ -117,16 +99,16 @@ describe('docblock', () => {
   it('parses multiple of the same directives out of a docblock', () => {
     const code =
       '/**' +
-      os.EOL +
+      EOL +
       '' +
       ' * @x foo' +
-      os.EOL +
+      EOL +
       '' +
       ' * @x bar' +
-      os.EOL +
+      EOL +
       '' +
       ' * @y' +
-      os.EOL +
+      EOL +
       '' +
       ' */';
     expect(docblock.parse(code)).toEqual({
@@ -138,16 +120,16 @@ describe('docblock', () => {
   it('parses >=3 of the same directives out of a docblock', () => {
     const code =
       '/**' +
-      os.EOL +
+      EOL +
       '' +
       ' * @x foo' +
-      os.EOL +
+      EOL +
       '' +
       ' * @x bar' +
-      os.EOL +
+      EOL +
       '' +
       ' * @x baz' +
-      os.EOL +
+      EOL +
       '' +
       ' */';
     expect(docblock.parse(code)).toEqual({
@@ -158,25 +140,25 @@ describe('docblock', () => {
   it('parses directives out of a docblock with comments', () => {
     const code =
       '/**' +
-      os.EOL +
+      EOL +
       '' +
       ' * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.' +
-      os.EOL +
+      EOL +
       '' +
       ' * @team foo' +
-      os.EOL +
+      EOL +
       '' +
       ' * @css a b' +
-      os.EOL +
+      EOL +
       '' +
       ' *' +
-      os.EOL +
+      EOL +
       '' +
       ' * And some license here' +
-      os.EOL +
+      EOL +
       '' +
       ' * @preserve-whitespace' +
-      os.EOL +
+      EOL +
       '' +
       ' */';
     expect(docblock.parse(code)).toEqual({
@@ -189,13 +171,13 @@ describe('docblock', () => {
   it('parses directives out of a docblock with line comments', () => {
     const code =
       '/**' +
-      os.EOL +
+      EOL +
       '' +
       ' * @team foo' +
-      os.EOL +
+      EOL +
       '' +
       ' * // TODO: test' +
-      os.EOL +
+      EOL +
       '' +
       ' */';
     expect(docblock.parseWithComments(code)).toEqual({
@@ -207,25 +189,25 @@ describe('docblock', () => {
   it('parses multiline directives', () => {
     const code =
       '/**' +
-      os.EOL +
+      EOL +
       '' +
       ' * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.' +
-      os.EOL +
+      EOL +
       '' +
       ' * @class A long declaration of a class' +
-      os.EOL +
+      EOL +
       '' +
       ' *        goes here, so we can read it and enjoy' +
-      os.EOL +
+      EOL +
       '' +
       ' *' +
-      os.EOL +
+      EOL +
       '' +
       ' * And some license here' +
-      os.EOL +
+      EOL +
       '' +
       ' * @preserve-whitespace' +
-      os.EOL +
+      EOL +
       '' +
       ' */';
     expect(docblock.parse(code)).toEqual({
@@ -239,35 +221,35 @@ describe('docblock', () => {
   it('parses multiline directives even if there are linecomments within the docblock', () => {
     const code =
       '/**' +
-      os.EOL +
+      EOL +
       '' +
       ' * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.' +
-      os.EOL +
+      EOL +
       '' +
       ' * @class A long declaration of a class' +
-      os.EOL +
+      EOL +
       '' +
       ' *        goes here, so we can read it and enjoy' +
-      os.EOL +
+      EOL +
       '' +
       ' *' +
-      os.EOL +
+      EOL +
       '' +
       ' * And some license here' +
-      os.EOL +
+      EOL +
       '' +
       ' * @preserve-whitespace' +
-      os.EOL +
+      EOL +
       '' +
       '// heres a comment' +
       ' */';
     expect(docblock.parseWithComments(code)).toEqual({
       comments:
         'Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.' +
-        os.EOL +
-        os.EOL +
+        EOL +
+        EOL +
         'And some license here' +
-        os.EOL +
+        EOL +
         '// heres a comment',
       pragmas: {
         class:
@@ -279,7 +261,7 @@ describe('docblock', () => {
   });
 
   it('supports slashes in @team directive', () => {
-    const code = '/**' + os.EOL + ' * @team apple/banana' + os.EOL + ' */';
+    const code = '/**' + EOL + ' * @team apple/banana' + EOL + ' */';
     expect(docblock.parse(code)).toEqual({
       team: 'apple/banana',
     });
@@ -287,13 +269,7 @@ describe('docblock', () => {
 
   it('extracts comments from docblock', () => {
     const code =
-      '/**' +
-      os.EOL +
-      ' * hello world' +
-      os.EOL +
-      ' * @flow yes' +
-      os.EOL +
-      ' */';
+      '/**' + EOL + ' * hello world' + EOL + ' * @flow yes' + EOL + ' */';
     expect(docblock.parseWithComments(code)).toEqual({
       comments: 'hello world',
       pragmas: {flow: 'yes'},
@@ -303,39 +279,38 @@ describe('docblock', () => {
   it('extracts multiline comments from docblock', () => {
     const code =
       '/**' +
-      os.EOL +
+      EOL +
       ' * hello' +
-      os.EOL +
+      EOL +
       ' * world' +
-      os.EOL +
+      EOL +
       ' * @flow yes' +
-      os.EOL +
+      EOL +
       ' */';
     expect(docblock.parseWithComments(code)).toEqual({
-      comments: 'hello' + os.EOL + 'world',
+      comments: 'hello' + EOL + 'world',
       pragmas: {flow: 'yes'},
     });
   });
 
   it('preserves leading whitespace in multiline comments from docblock', () => {
-    const code =
-      '/**' + os.EOL + ' *  hello' + os.EOL + ' *   world' + os.EOL + ' */';
+    const code = '/**' + EOL + ' *  hello' + EOL + ' *   world' + EOL + ' */';
 
     expect(docblock.parseWithComments(code).comments).toEqual(
-      ' hello' + os.EOL + '  world',
+      ' hello' + EOL + '  world',
     );
   });
 
   it('removes leading newlines in multiline comments from docblock', () => {
     const code =
       '/**' +
-      os.EOL +
+      EOL +
       ' * @snailcode' +
-      os.EOL +
+      EOL +
       ' *' +
-      os.EOL +
+      EOL +
       ' *  hello world' +
-      os.EOL +
+      EOL +
       ' */';
 
     expect(docblock.parseWithComments(code).comments).toEqual(' hello world');
@@ -344,25 +319,24 @@ describe('docblock', () => {
   it('extracts comments from beginning and end of docblock', () => {
     const code =
       '/**' +
-      os.EOL +
+      EOL +
       ' * hello' +
-      os.EOL +
+      EOL +
       ' * @flow yes' +
-      os.EOL +
+      EOL +
       ' * ' +
-      os.EOL +
+      EOL +
       ' * world' +
-      os.EOL +
+      EOL +
       ' */';
     expect(docblock.parseWithComments(code)).toEqual({
-      comments: 'hello' + os.EOL + os.EOL + 'world',
+      comments: 'hello' + EOL + EOL + 'world',
       pragmas: {flow: 'yes'},
     });
   });
 
   it("preserve urls within a pragma's values", () => {
-    const code =
-      '/**' + os.EOL + ' * @see: https://example.com' + os.EOL + ' */';
+    const code = '/**' + EOL + ' * @see: https://example.com' + EOL + ' */';
     expect(docblock.parseWithComments(code)).toEqual({
       comments: '',
       pragmas: {'see:': 'https://example.com'},
@@ -370,8 +344,7 @@ describe('docblock', () => {
   });
 
   it('strip linecomments from pragmas but preserve for comments', () => {
-    const code =
-      '/**' + os.EOL + ' * @format: everything' + os.EOL + '// keep me */';
+    const code = '/**' + EOL + ' * @format: everything' + EOL + '// keep me */';
     expect(docblock.parseWithComments(code)).toEqual({
       comments: '// keep me',
       pragmas: {'format:': 'everything'},
@@ -420,7 +393,7 @@ describe('docblock', () => {
       format: '',
     };
     expect(docblock.print({pragmas})).toEqual(
-      '/**' + os.EOL + ' * @flow' + os.EOL + ' * @format' + os.EOL + ' */',
+      '/**' + EOL + ' * @flow' + EOL + ' * @format' + EOL + ' */',
     );
   });
 
@@ -430,15 +403,7 @@ describe('docblock', () => {
       y: 'c',
     };
     expect(docblock.print({pragmas})).toEqual(
-      '/**' +
-        os.EOL +
-        ' * @x a' +
-        os.EOL +
-        ' * @x b' +
-        os.EOL +
-        ' * @y c' +
-        os.EOL +
-        ' */',
+      '/**' + EOL + ' * @x a' + EOL + ' * @x b' + EOL + ' * @y c' + EOL + ' */',
     );
   });
   it('prints docblocks with pragmas', () => {
@@ -447,13 +412,7 @@ describe('docblock', () => {
       team: 'x/y/z',
     };
     expect(docblock.print({pragmas})).toEqual(
-      '/**' +
-        os.EOL +
-        ' * @flow foo' +
-        os.EOL +
-        ' * @team x/y/z' +
-        os.EOL +
-        ' */',
+      '/**' + EOL + ' * @flow foo' + EOL + ' * @team x/y/z' + EOL + ' */',
     );
   });
 
@@ -462,13 +421,13 @@ describe('docblock', () => {
     const comments = 'hello';
     expect(docblock.print({comments, pragmas})).toEqual(
       '/**' +
-        os.EOL +
+        EOL +
         ' * hello' +
-        os.EOL +
+        EOL +
         ' *' +
-        os.EOL +
+        EOL +
         ' * @flow foo' +
-        os.EOL +
+        EOL +
         ' */',
     );
   });
@@ -478,15 +437,15 @@ describe('docblock', () => {
     const comments =
       'Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.';
     expect(docblock.print({comments, pragmas})).toEqual(
-      '/**' + os.EOL + ' * ' + comments + os.EOL + ' */',
+      '/**' + EOL + ' * ' + comments + EOL + ' */',
     );
   });
 
   it('prints docblocks with multiline comments', () => {
     const pragmas = {};
-    const comments = 'hello' + os.EOL + 'world';
+    const comments = 'hello' + EOL + 'world';
     expect(docblock.print({comments, pragmas})).toEqual(
-      '/**' + os.EOL + ' * hello' + os.EOL + ' * world' + os.EOL + ' */',
+      '/**' + EOL + ' * hello' + EOL + ' * world' + EOL + ' */',
     );
   });
 
@@ -499,22 +458,21 @@ describe('docblock', () => {
   });
 
   it('can augment existing docblocks with comments', () => {
-    const before =
-      '/**' + os.EOL + ' * Legalese' + os.EOL + ' * @flow' + os.EOL + ' */';
+    const before = '/**' + EOL + ' * Legalese' + EOL + ' * @flow' + EOL + ' */';
     const {comments, pragmas} = docblock.parseWithComments(before);
     pragmas.format = '';
     const after = docblock.print({comments, pragmas});
     expect(after).toEqual(
       '/**' +
-        os.EOL +
+        EOL +
         ' * Legalese' +
-        os.EOL +
+        EOL +
         ' *' +
-        os.EOL +
+        EOL +
         ' * @flow' +
-        os.EOL +
+        EOL +
         ' * @format' +
-        os.EOL +
+        EOL +
         ' */',
     );
   });

--- a/packages/jest-docblock/src/__tests__/index.test.ts
+++ b/packages/jest-docblock/src/__tests__/index.test.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import os from 'os';
+import {tmpdir} from 'os';
 import * as docblock from '..';
 
 describe('docblock', () => {

--- a/packages/jest-each/src/table/array.ts
+++ b/packages/jest-each/src/table/array.ts
@@ -6,7 +6,7 @@
  *
  */
 
-import util from 'util';
+import * as util from 'util';
 import pretty from 'pretty-format';
 
 import {Global} from '@jest/types';

--- a/packages/jest-fake-timers/src/__tests__/jestFakeTimers.test.ts
+++ b/packages/jest-fake-timers/src/__tests__/jestFakeTimers.test.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import vm from 'vm';
+import {runInNewContext} from 'vm';
 import mock from 'jest-mock';
 import FakeTimers from '../jestFakeTimers';
 
@@ -23,7 +23,7 @@ describe('FakeTimers', () => {
   let moduleMocker: mock.ModuleMocker;
 
   beforeEach(() => {
-    const global = vm.runInNewContext('this');
+    const global = runInNewContext('this');
     moduleMocker = new mock.ModuleMocker(global);
   });
 

--- a/packages/jest-haste-map/src/HasteFS.ts
+++ b/packages/jest-haste-map/src/HasteFS.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import micromatch from 'micromatch';
+import {some as micromatchSome} from 'micromatch';
 import {replacePathSepForGlob} from 'jest-util';
 import {Config} from '@jest/types';
 import {FileData} from './types';
@@ -86,7 +86,7 @@ export default class HasteFS {
     const files = new Set<string>();
     for (const file of this.getAbsoluteFileIterator()) {
       const filePath = root ? fastPath.relative(root, file) : file;
-      if (micromatch.some(replacePathSepForGlob(filePath), globs)) {
+      if (micromatchSome(replacePathSepForGlob(filePath), globs)) {
         files.add(file);
       }
     }

--- a/packages/jest-haste-map/src/crawlers/node.ts
+++ b/packages/jest-haste-map/src/crawlers/node.ts
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import fs from 'fs';
-import path from 'path';
+import * as fs from 'fs';
+import * as path from 'path';
 import {spawn} from 'child_process';
 import H from '../constants';
 import * as fastPath from '../lib/fast_path';

--- a/packages/jest-haste-map/src/crawlers/watchman.ts
+++ b/packages/jest-haste-map/src/crawlers/watchman.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
+import * as path from 'path';
 import watchman from 'fb-watchman';
 import {Config} from '@jest/types';
 import * as fastPath from '../lib/fast_path';

--- a/packages/jest-haste-map/src/getMockName.ts
+++ b/packages/jest-haste-map/src/getMockName.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
+import * as path from 'path';
 
 const MOCKS_PATTERN = path.sep + '__mocks__' + path.sep;
 

--- a/packages/jest-haste-map/src/index.ts
+++ b/packages/jest-haste-map/src/index.ts
@@ -6,12 +6,12 @@
  */
 
 import {execSync} from 'child_process';
-import crypto from 'crypto';
-import EventEmitter from 'events';
-import fs from 'fs';
-import os from 'os';
-import path from 'path';
-import sane from 'sane';
+import {createHash} from 'crypto';
+import {EventEmitter} from 'events';
+import * as fs from 'fs';
+import {tmpdir} from 'os';
+import * as path from 'path';
+import {NodeWatcher, Watcher as SaneWatcher} from 'sane';
 import invariant from 'invariant';
 import {Config} from '@jest/types';
 import serializer from 'jest-serializer';
@@ -245,7 +245,7 @@ class HasteMap extends EventEmitter {
   constructor(options: Options) {
     super();
     this._options = {
-      cacheDirectory: options.cacheDirectory || os.tmpdir(),
+      cacheDirectory: options.cacheDirectory || tmpdir(),
       computeDependencies:
         options.computeDependencies === undefined
           ? true
@@ -280,8 +280,7 @@ class HasteMap extends EventEmitter {
       );
     }
 
-    const rootDirHash = crypto
-      .createHash('md5')
+    const rootDirHash = createHash('md5')
       .update(options.rootDir)
       .digest('hex');
     let hasteImplHash = '';
@@ -328,7 +327,7 @@ class HasteMap extends EventEmitter {
     name: string,
     ...extra: Array<string>
   ): string {
-    const hash = crypto.createHash('md5').update(extra.join(''));
+    const hash = createHash('md5').update(extra.join(''));
     return path.join(
       tmpdir,
       name.replace(/\W/g, '-') + '-' + hash.digest('hex'),
@@ -800,12 +799,12 @@ class HasteMap extends EventEmitter {
     this._options.retainAllFiles = true;
 
     // WatchmanWatcher > FSEventsWatcher > sane.NodeWatcher
-    const Watcher: sane.Watcher =
+    const Watcher: SaneWatcher =
       canUseWatchman && this._options.useWatchman
         ? WatchmanWatcher
         : FSEventsWatcher.isSupported()
         ? FSEventsWatcher
-        : sane.NodeWatcher;
+        : NodeWatcher;
 
     const extensions = this._options.extensions;
     const ignorePattern = this._options.ignorePattern;

--- a/packages/jest-haste-map/src/lib/FSEventsWatcher.ts
+++ b/packages/jest-haste-map/src/lib/FSEventsWatcher.ts
@@ -6,11 +6,11 @@
  *
  */
 
-import fs from 'fs';
-import path from 'path';
+import * as fs from 'fs';
+import * as path from 'path';
 import {EventEmitter} from 'events';
 import anymatch from 'anymatch';
-import micromatch from 'micromatch';
+import {some as micromatchSome} from 'micromatch';
 // eslint-disable-next-line
 import {Watcher} from 'fsevents';
 // @ts-ignore no types
@@ -139,8 +139,8 @@ class FSEventsWatcher extends EventEmitter {
       return false;
     }
     return this.glob.length
-      ? micromatch.some(relativePath, this.glob, {dot: this.dot})
-      : this.dot || micromatch.some(relativePath, '**/*');
+      ? micromatchSome(relativePath, this.glob, {dot: this.dot})
+      : this.dot || micromatchSome(relativePath, '**/*');
   }
 
   private handleEvent(filepath: string) {

--- a/packages/jest-haste-map/src/lib/fast_path.ts
+++ b/packages/jest-haste-map/src/lib/fast_path.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
+import * as path from 'path';
 
 // rootDir and filename must be absolute paths (resolved)
 export function relative(rootDir: string, filename: string): string {

--- a/packages/jest-haste-map/src/lib/normalizePathSep.ts
+++ b/packages/jest-haste-map/src/lib/normalizePathSep.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
+import * as path from 'path';
 
 let normalizePathSep: (string: string) => string;
 if (path.sep === '/') {

--- a/packages/jest-haste-map/src/types.ts
+++ b/packages/jest-haste-map/src/types.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import fs from 'fs';
+import * as fs from 'fs';
 import {Config} from '@jest/types';
 import ModuleMap from './ModuleMap';
 import HasteFS from './HasteFS';

--- a/packages/jest-haste-map/src/worker.ts
+++ b/packages/jest-haste-map/src/worker.ts
@@ -5,9 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import crypto from 'crypto';
-import path from 'path';
-import fs from 'graceful-fs';
+import {createHash} from 'crypto';
+import * as path from 'path';
+import * as fs from 'graceful-fs';
 import {HasteImpl, WorkerMessage, WorkerMetadata} from './types';
 import blacklist from './blacklist';
 import H from './constants';
@@ -19,8 +19,7 @@ let hasteImpl: HasteImpl | null = null;
 let hasteImplModulePath: string | null = null;
 
 function sha1hex(content: string | Buffer): string {
-  return crypto
-    .createHash('sha1')
+  return createHash('sha1')
     .update(content)
     .digest('hex');
 }

--- a/packages/jest-jasmine2/src/index.ts
+++ b/packages/jest-jasmine2/src/index.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
+import * as path from 'path';
 import {Config, Global} from '@jest/types';
 import {AssertionResult, TestResult} from '@jest/test-result';
 import {JestEnvironment} from '@jest/environment';

--- a/packages/jest-leak-detector/src/index.ts
+++ b/packages/jest-leak-detector/src/index.ts
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import v8 from 'v8';
-import vm from 'vm';
+import {setFlagsFromString} from 'v8';
+import {runInNewContext} from 'vm';
 import prettyFormat from 'pretty-format';
 import {isPrimitive} from 'jest-get-type';
 
@@ -56,12 +56,12 @@ export default class {
     const isGarbageCollectorHidden = !global.gc;
 
     // GC is usually hidden, so we have to expose it before running.
-    v8.setFlagsFromString('--expose-gc');
-    vm.runInNewContext('gc')();
+    setFlagsFromString('--expose-gc');
+    runInNewContext('gc')();
 
     // The GC was not initially exposed, so let's hide it again.
     if (isGarbageCollectorHidden) {
-      v8.setFlagsFromString('--no-expose-gc');
+      setFlagsFromString('--no-expose-gc');
     }
   }
 }

--- a/packages/jest-message-util/src/index.ts
+++ b/packages/jest-message-util/src/index.ts
@@ -5,12 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import fs from 'fs';
-import path from 'path';
+import * as fs from 'fs';
+import * as path from 'path';
 import {Config} from '@jest/types';
 import {AssertionResult, SerializableError} from '@jest/test-result';
 import chalk from 'chalk';
-import micromatch from 'micromatch';
+import {some as micromatchSome} from 'micromatch';
 import slash from 'slash';
 import {codeFrameColumns} from '@babel/code-frame';
 import StackUtils from 'stack-utils';
@@ -216,7 +216,7 @@ const formatPaths = (
   if (
     (config.testMatch &&
       config.testMatch.length &&
-      micromatch.some(filePath, config.testMatch)) ||
+      micromatchSome(filePath, config.testMatch)) ||
     filePath === relativeTestPath
   ) {
     filePath = chalk.reset.cyan(filePath);

--- a/packages/jest-regex-util/src/__tests__/index.test.ts
+++ b/packages/jest-regex-util/src/__tests__/index.test.ts
@@ -5,14 +5,16 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-jest.mock('path');
-
-import * as path from 'path';
-import {replacePathSepForRegex} from '../index';
-
 describe('replacePathSepForRegex()', () => {
+  let replacePathSepForRegex: (str: string) => string;
+
   describe('posix', () => {
-    beforeEach(() => ((path as any).sep = '/'));
+    beforeAll(() => {
+      jest.mock('path', () => ({...jest.genMockFromModule('path'), sep: '/'}));
+      jest.isolateModules(() => {
+        replacePathSepForRegex = require('../').replacePathSepForRegex;
+      });
+    });
 
     it('should return the path', () => {
       const expected = {};
@@ -21,7 +23,12 @@ describe('replacePathSepForRegex()', () => {
   });
 
   describe('win32', () => {
-    beforeEach(() => ((path as any).sep = '\\'));
+    beforeAll(() => {
+      jest.mock('path', () => ({...jest.genMockFromModule('path'), sep: '\\'}));
+      jest.isolateModules(() => {
+        replacePathSepForRegex = require('../').replacePathSepForRegex;
+      });
+    });
 
     it('should replace POSIX path separators', () => {
       expect(replacePathSepForRegex('a/b/c')).toBe('a\\\\b\\\\c');

--- a/packages/jest-regex-util/src/__tests__/index.test.ts
+++ b/packages/jest-regex-util/src/__tests__/index.test.ts
@@ -7,7 +7,7 @@
 
 jest.mock('path');
 
-import path from 'path';
+import * as path from 'path';
 import {replacePathSepForRegex} from '../index';
 
 describe('replacePathSepForRegex()', () => {

--- a/packages/jest-regex-util/src/index.ts
+++ b/packages/jest-regex-util/src/index.ts
@@ -6,10 +6,10 @@
  *
  */
 
-import * as path from 'path';
+import {sep} from 'path';
 
 export const escapePathForRegex = (dir: string) => {
-  if (path.sep === '\\') {
+  if (sep === '\\') {
     // Replace "\" with "/" so it's not escaped by escapeStrForRegex.
     // replacePathSepForRegex will convert it back.
     dir = dir.replace(/\\/g, '/');
@@ -21,7 +21,7 @@ export const escapeStrForRegex = (string: string) =>
   string.replace(/[[\]{}()*+?.\\^$|]/g, '\\$&');
 
 export const replacePathSepForRegex = (string: string) => {
-  if (path.sep === '\\') {
+  if (sep === '\\') {
     return string.replace(
       /(\/|(.)?\\(?![[\]{}()*+?.^$|\\]))/g,
       (_match, _, p2) => (p2 && p2 !== '\\' ? p2 + '\\\\' : '\\\\'),

--- a/packages/jest-regex-util/src/index.ts
+++ b/packages/jest-regex-util/src/index.ts
@@ -6,7 +6,7 @@
  *
  */
 
-import path from 'path';
+import * as path from 'path';
 
 export const escapePathForRegex = (dir: string) => {
   if (path.sep === '\\') {

--- a/packages/jest-repl/src/cli/repl.ts
+++ b/packages/jest-repl/src/cli/repl.ts
@@ -8,9 +8,9 @@
 declare const jestGlobalConfig: Config.GlobalConfig;
 declare const jestProjectConfig: Config.ProjectConfig;
 
-import path from 'path';
-import repl from 'repl';
-import vm from 'vm';
+import * as path from 'path';
+import * as repl from 'repl';
+import {runInThisContext} from 'vm';
 import {Transformer} from '@jest/transform';
 import {Config} from '@jest/types';
 
@@ -35,7 +35,7 @@ const evalCommand: repl.REPLEval = (
           ? transformResult
           : transformResult.code;
     }
-    result = vm.runInThisContext(cmd);
+    result = runInThisContext(cmd);
   } catch (e) {
     return callback(isRecoverableError(e) ? new repl.Recoverable(e) : e);
   }

--- a/packages/jest-reporters/src/coverage_reporter.ts
+++ b/packages/jest-reporters/src/coverage_reporter.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
+import * as path from 'path';
 import {Config} from '@jest/types';
 import {AggregatedResult, TestResult} from '@jest/test-result';
 import {clearLine, isInteractive} from 'jest-util';

--- a/packages/jest-reporters/src/coverage_worker.ts
+++ b/packages/jest-reporters/src/coverage_worker.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import fs from 'fs';
+import * as fs from 'fs';
 import {Config} from '@jest/types';
 import exit from 'exit';
 import {CoverageReporterSerializedOptions} from './types';

--- a/packages/jest-reporters/src/notify_reporter.ts
+++ b/packages/jest-reporters/src/notify_reporter.ts
@@ -5,12 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
-import util from 'util';
+import * as path from 'path';
+import * as util from 'util';
 import exit from 'exit';
 import {Config} from '@jest/types';
 import {AggregatedResult} from '@jest/test-result';
-import notifier from 'node-notifier';
+import {notify} from 'node-notifier';
 import {TestSchedulerContext, Context} from './types';
 import BaseReporter from './base_reporter';
 
@@ -78,7 +78,7 @@ export default class NotifyReporter extends BaseReporter {
         result.numPassedTests,
       );
 
-      notifier.notify({icon, message, title});
+      notify({icon, message, title});
     } else if (
       testsHaveRun &&
       !success &&
@@ -106,13 +106,9 @@ export default class NotifyReporter extends BaseReporter {
       const quitAnswer = 'Exit tests';
 
       if (!watchMode) {
-        notifier.notify({
-          icon,
-          message,
-          title,
-        });
+        notify({icon, message, title});
       } else {
-        notifier.notify(
+        notify(
           {
             actions: [restartAnswer, quitAnswer],
             closeLabel: 'Close',

--- a/packages/jest-reporters/src/utils.ts
+++ b/packages/jest-reporters/src/utils.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
+import * as path from 'path';
 import {Config} from '@jest/types';
 import {AggregatedResult} from '@jest/test-result';
 import chalk from 'chalk';

--- a/packages/jest-resolve-dependencies/src/__tests__/dependency_resolver.test.ts
+++ b/packages/jest-resolve-dependencies/src/__tests__/dependency_resolver.test.ts
@@ -6,7 +6,7 @@
  */
 
 import {tmpdir} from 'os';
-import path from 'path';
+import * as path from 'path';
 import {Config} from '@jest/types';
 import {buildSnapshotResolver} from 'jest-snapshot';
 import {makeProjectConfig} from '../../../../TestUtils';

--- a/packages/jest-resolve/src/__tests__/resolve.test.ts
+++ b/packages/jest-resolve/src/__tests__/resolve.test.ts
@@ -6,8 +6,8 @@
  *
  */
 
-import fs from 'fs';
-import path from 'path';
+import * as fs from 'fs';
+import * as path from 'path';
 import {ModuleMap} from 'jest-haste-map';
 import Resolver from '../';
 // @ts-ignore: js file

--- a/packages/jest-resolve/src/defaultResolver.ts
+++ b/packages/jest-resolve/src/defaultResolver.ts
@@ -5,9 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import fs from 'fs';
-import path from 'path';
-import browserResolve from 'browser-resolve';
+import * as fs from 'fs';
+import * as path from 'path';
+import {sync as browserResolve} from 'browser-resolve';
 import pnpResolver from 'jest-pnp-resolver';
 import {Config} from '@jest/types';
 import isBuiltinModule from './isBuiltinModule';
@@ -32,7 +32,7 @@ export default function defaultResolver(
     return pnpResolver(path, options);
   }
 
-  const resolve = options.browser ? browserResolve.sync : resolveSync;
+  const resolve = options.browser ? browserResolve : resolveSync;
 
   return resolve(path, {
     basedir: options.basedir,

--- a/packages/jest-resolve/src/index.ts
+++ b/packages/jest-resolve/src/index.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
+import * as path from 'path';
 import {Config} from '@jest/types';
 import {ModuleMap} from 'jest-haste-map'; // eslint-disable-line import/no-extraneous-dependencies
 import {sync as realpath} from 'realpath-native';

--- a/packages/jest-resolve/src/nodeModulesPaths.ts
+++ b/packages/jest-resolve/src/nodeModulesPaths.ts
@@ -7,7 +7,7 @@
  * Adapted from: https://github.com/substack/node-resolve
  */
 
-import path from 'path';
+import * as path from 'path';
 import {Config} from '@jest/types';
 import {sync as realpath} from 'realpath-native';
 

--- a/packages/jest-runner/src/runTest.ts
+++ b/packages/jest-runner/src/runTest.ts
@@ -18,7 +18,7 @@ import {
 } from '@jest/console';
 import {JestEnvironment} from '@jest/environment';
 import RuntimeClass from 'jest-runtime';
-import fs from 'graceful-fs';
+import * as fs from 'graceful-fs';
 import {ErrorWithStack, setGlobal, interopRequireDefault} from 'jest-util';
 import LeakDetector from 'jest-leak-detector';
 import Resolver from 'jest-resolve';

--- a/packages/jest-runtime/src/cli/index.ts
+++ b/packages/jest-runtime/src/cli/index.ts
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import os from 'os';
-import path from 'path';
+import {cpus} from 'os';
+import * as path from 'path';
 import chalk from 'chalk';
 import {sync as realpath} from 'realpath-native';
 import yargs from 'yargs';
@@ -78,7 +78,7 @@ export function run(cliArgv?: Config.Argv, cliInfo?: Array<string>) {
   const Runtime: any = require('..');
 
   (Runtime.createContext(config, {
-    maxWorkers: Math.max(os.cpus().length - 1, 1),
+    maxWorkers: Math.max(cpus().length - 1, 1),
     watchman: globalConfig.watchman,
   }) as Promise<Context>)
     .then(hasteMap => {

--- a/packages/jest-runtime/src/helpers.ts
+++ b/packages/jest-runtime/src/helpers.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
+import * as path from 'path';
 import slash from 'slash';
 import glob from 'glob';
 import {Config} from '@jest/types';

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
+import * as path from 'path';
 import {Config} from '@jest/types';
 import {
   Jest,
@@ -27,7 +27,7 @@ import {
   shouldInstrument,
   TransformationOptions,
 } from '@jest/transform';
-import fs from 'graceful-fs';
+import * as fs from 'graceful-fs';
 import stripBOM from 'strip-bom';
 import {run as cliRun} from './cli';
 import {options as cliOptions} from './cli/args';

--- a/packages/jest-serializer/src/__tests__/index.test.ts
+++ b/packages/jest-serializer/src/__tests__/index.test.ts
@@ -7,9 +7,9 @@
 
 'use strict';
 
-import fs from 'fs';
-import os from 'os';
-import path from 'path';
+import * as fs from 'fs';
+import {tmpdir} from 'os';
+import * as path from 'path';
 import v8 from 'v8';
 import prettyFormat from 'pretty-format';
 
@@ -38,7 +38,7 @@ const objs = [
   {buf: Buffer.from([0, 255, 127])},
 ];
 
-const file = path.join(os.tmpdir(), '__jest-serialize-test__');
+const file = path.join(tmpdir(), '__jest-serialize-test__');
 
 afterEach(() => {
   try {

--- a/packages/jest-serializer/src/index.ts
+++ b/packages/jest-serializer/src/index.ts
@@ -7,7 +7,7 @@
 // TODO: Remove this
 /// <reference path="../v8.d.ts" />
 
-import fs from 'fs';
+import * as fs from 'fs';
 import v8 from 'v8';
 
 type Path = string;

--- a/packages/jest-snapshot/src/State.ts
+++ b/packages/jest-snapshot/src/State.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import fs from 'fs';
+import * as fs from 'fs';
 import {Config} from '@jest/types';
 
 import {getTopFrame, getStackTraceLines} from 'jest-message-util';

--- a/packages/jest-snapshot/src/__tests__/inline_snapshots.test.ts
+++ b/packages/jest-snapshot/src/__tests__/inline_snapshots.test.ts
@@ -5,7 +5,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-jest.mock('fs');
+jest.mock('fs', () => ({
+  ...jest.genMockFromModule('fs'),
+  existsSync: jest.fn().mockReturnValue(true),
+  readdirSync: jest.fn().mockReturnValue([]),
+  statSync: jest.fn(filePath => ({
+    isDirectory: () => !filePath.endsWith('.js'),
+  })),
+}));
 jest.mock('prettier');
 
 import * as fs from 'fs';
@@ -15,29 +22,8 @@ import babelTraverse from '@babel/traverse';
 import {Frame} from 'jest-message-util';
 
 import {saveInlineSnapshots} from '../inline_snapshots';
-
-const writeFileSync = fs.writeFileSync;
-const readFileSync = fs.readFileSync;
-const existsSync = fs.existsSync;
-const statSync = fs.statSync;
-const readdirSync = fs.readdirSync;
 beforeEach(() => {
-  fs.writeFileSync = jest.fn();
-  fs.readFileSync = jest.fn();
-  fs.existsSync = jest.fn(() => true);
-  (fs.statSync as jest.Mock).mockImplementation(filePath => ({
-    isDirectory: () => !filePath.endsWith('.js'),
-  }));
-  fs.readdirSync = jest.fn(() => []);
-
   (prettier.resolveConfig.sync as jest.Mock).mockReset();
-});
-afterEach(() => {
-  fs.writeFileSync = writeFileSync;
-  fs.readFileSync = readFileSync;
-  fs.existsSync = existsSync;
-  fs.statSync = statSync;
-  fs.readdirSync = readdirSync;
 });
 
 test('saveInlineSnapshots() replaces empty function call with a template literal', () => {

--- a/packages/jest-snapshot/src/__tests__/inline_snapshots.test.ts
+++ b/packages/jest-snapshot/src/__tests__/inline_snapshots.test.ts
@@ -8,8 +8,8 @@
 jest.mock('fs');
 jest.mock('prettier');
 
-import fs from 'fs';
-import path from 'path';
+import * as fs from 'fs';
+import * as path from 'path';
 import prettier from 'prettier';
 import babelTraverse from '@babel/traverse';
 import {Frame} from 'jest-message-util';

--- a/packages/jest-snapshot/src/__tests__/printDiffOrStringified.test.ts
+++ b/packages/jest-snapshot/src/__tests__/printDiffOrStringified.test.ts
@@ -6,7 +6,7 @@
  */
 
 import ansiRegex from 'ansi-regex';
-import style from 'ansi-styles';
+import * as style from 'ansi-styles';
 import {printDiffOrStringified} from '../print';
 import {serialize, unescape} from '../utils';
 

--- a/packages/jest-snapshot/src/__tests__/snapshot_resolver.test.ts
+++ b/packages/jest-snapshot/src/__tests__/snapshot_resolver.test.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
+import * as path from 'path';
 import {Config} from '@jest/types';
 
 import {buildSnapshotResolver, SnapshotResolver} from '../snapshot_resolver';

--- a/packages/jest-snapshot/src/__tests__/utils.test.ts
+++ b/packages/jest-snapshot/src/__tests__/utils.test.ts
@@ -5,7 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-jest.mock('fs');
+jest.mock('fs', () => ({
+  ...jest.genMockFromModule('fs'),
+  existsSync: jest.fn().mockReturnValue(true),
+}));
 
 import * as fs from 'fs';
 import * as path from 'path';
@@ -23,20 +26,6 @@ import {
   SNAPSHOT_VERSION,
   SNAPSHOT_VERSION_WARNING,
 } from '../utils';
-
-const writeFileSync = fs.writeFileSync;
-const readFileSync = fs.readFileSync;
-const existsSync = fs.existsSync;
-beforeEach(() => {
-  fs.writeFileSync = jest.fn();
-  fs.readFileSync = jest.fn();
-  fs.existsSync = jest.fn(() => true);
-});
-afterEach(() => {
-  fs.writeFileSync = writeFileSync;
-  fs.readFileSync = readFileSync;
-  fs.existsSync = existsSync;
-});
 
 test('keyToTestName()', () => {
   expect(keyToTestName('abc cde 12')).toBe('abc cde');
@@ -177,8 +166,11 @@ test('getSnapshotData() marks valid snapshot not dirty when updating', () => {
 test('escaping', () => {
   const filename = path.join(__dirname, 'escaping.snap');
   const data = '"\'\\';
+  const writeFileSync = fs.writeFileSync as jest.Mock;
+
+  writeFileSync.mockReset();
   saveSnapshotFile({key: data}, filename);
-  const writtenData = (fs.writeFileSync as jest.Mock).mock.calls[0][1];
+  const writtenData = writeFileSync.mock.calls[0][1];
   expect(writtenData).toBe(
     `// Jest Snapshot v1, ${SNAPSHOT_GUIDE_LINK}\n\n` +
       'exports[`key`] = `"\'\\\\`;\n',

--- a/packages/jest-snapshot/src/__tests__/utils.test.ts
+++ b/packages/jest-snapshot/src/__tests__/utils.test.ts
@@ -7,8 +7,8 @@
 
 jest.mock('fs');
 
-import fs from 'fs';
-import path from 'path';
+import * as fs from 'fs';
+import * as path from 'path';
 import assert from 'assert';
 import chalk from 'chalk';
 

--- a/packages/jest-snapshot/src/index.ts
+++ b/packages/jest-snapshot/src/index.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import fs from 'fs';
+import * as fs from 'fs';
 import {Config} from '@jest/types';
 import {FS as HasteFS} from 'jest-haste-map'; // eslint-disable-line import/no-extraneous-dependencies
 import {MatcherState} from 'expect';

--- a/packages/jest-snapshot/src/inline_snapshots.ts
+++ b/packages/jest-snapshot/src/inline_snapshots.ts
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import fs from 'fs';
-import path from 'path';
+import * as fs from 'fs';
+import * as path from 'path';
 import semver from 'semver';
 import {
   templateElement,

--- a/packages/jest-snapshot/src/snapshot_resolver.ts
+++ b/packages/jest-snapshot/src/snapshot_resolver.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
+import * as path from 'path';
 import {Config} from '@jest/types';
 import chalk from 'chalk';
 

--- a/packages/jest-snapshot/src/utils.ts
+++ b/packages/jest-snapshot/src/utils.ts
@@ -5,9 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import fs from 'fs';
-import path from 'path';
-import mkdirp from 'mkdirp';
+import * as fs from 'fs';
+import * as path from 'path';
+import {sync as mkdirp} from 'mkdirp';
 import naturalCompare from 'natural-compare';
 import chalk from 'chalk';
 import {Config} from '@jest/types';
@@ -150,7 +150,7 @@ const printBacktickString = (str: string): string =>
 
 export const ensureDirectoryExists = (filePath: Config.Path) => {
   try {
-    mkdirp.sync(path.join(path.dirname(filePath)), '777');
+    mkdirp(path.join(path.dirname(filePath)), '777');
   } catch (e) {}
 };
 

--- a/packages/jest-source-map/src/__tests__/getCallsite.test.ts
+++ b/packages/jest-source-map/src/__tests__/getCallsite.test.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import fs from 'fs';
+import * as fs from 'fs';
 import SourceMap from 'source-map';
 import getCallsite from '../getCallsite';
 

--- a/packages/jest-source-map/src/getCallsite.ts
+++ b/packages/jest-source-map/src/getCallsite.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import fs from 'graceful-fs';
+import {readFileSync} from 'graceful-fs';
 import callsites, {CallSite} from 'callsites';
 import {SourceMapConsumer} from 'source-map';
 import {SourceMapRegistry} from './types';
@@ -53,7 +53,7 @@ export default (level: number, sourceMaps?: SourceMapRegistry | null) => {
 
   if (sourceMapFileName) {
     try {
-      const sourceMap = fs.readFileSync(sourceMapFileName, 'utf8');
+      const sourceMap = readFileSync(sourceMapFileName, 'utf8');
       // @ts-ignore: Not allowed to pass string
       addSourceMapConsumer(stack, new SourceMapConsumer(sourceMap));
     } catch (e) {

--- a/packages/jest-test-sequencer/src/__tests__/test_sequencer.test.js
+++ b/packages/jest-test-sequencer/src/__tests__/test_sequencer.test.js
@@ -6,12 +6,15 @@
  */
 'use strict';
 
+import * as fs from 'fs';
+import * as path from 'path';
 import TestSequencer from '../index';
 
-jest.mock('fs');
-
-const fs = require('fs');
-const path = require('path');
+jest.mock('fs', () => ({
+  ...jest.genMockFromModule('fs'),
+  existsSync: jest.fn(() => true),
+  readFileSync: jest.fn(() => '{}'),
+}));
 const FAIL = 0;
 const SUCCESS = 1;
 
@@ -47,11 +50,8 @@ const toTests = paths =>
   }));
 
 beforeEach(() => {
+  jest.clearAllMocks()
   sequencer = new TestSequencer();
-
-  fs.readFileSync = jest.fn(() => '{}');
-  fs.existsSync = () => true;
-  fs.writeFileSync = jest.fn();
 });
 
 test('sorts by file size if there is no timing information', () => {
@@ -62,7 +62,7 @@ test('sorts by file size if there is no timing information', () => {
 });
 
 test('sorts based on timing information', () => {
-  fs.readFileSync = jest.fn(() =>
+  fs.readFileSync.mockImplementationOnce(() =>
     JSON.stringify({
       '/test-a.js': [SUCCESS, 5],
       '/test-ab.js': [SUCCESS, 3],
@@ -75,7 +75,7 @@ test('sorts based on timing information', () => {
 });
 
 test('sorts based on failures and timing information', () => {
-  fs.readFileSync = jest.fn(() =>
+  fs.readFileSync.mockImplementationOnce(() =>
     JSON.stringify({
       '/test-a.js': [SUCCESS, 5],
       '/test-ab.js': [FAIL, 0],
@@ -96,7 +96,7 @@ test('sorts based on failures and timing information', () => {
 });
 
 test('sorts based on failures, timing information and file size', () => {
-  fs.readFileSync = jest.fn(() =>
+  fs.readFileSync.mockImplementationOnce(() =>
     JSON.stringify({
       '/test-a.js': [SUCCESS, 5],
       '/test-ab.js': [FAIL, 1],
@@ -125,7 +125,7 @@ test('sorts based on failures, timing information and file size', () => {
 });
 
 test('writes the cache based on results without existing cache', () => {
-  fs.readFileSync = jest.fn(() => {
+  fs.readFileSync.mockImplementationOnce(() => {
     throw new Error('File does not exist.');
   });
 
@@ -164,7 +164,7 @@ test('writes the cache based on results without existing cache', () => {
 });
 
 test('writes the cache based on the results', () => {
-  fs.readFileSync = jest.fn(() =>
+  fs.readFileSync.mockImplementationOnce(() =>
     JSON.stringify({
       '/test-a.js': [SUCCESS, 5],
       '/test-b.js': [FAIL, 1],
@@ -208,7 +208,7 @@ test('writes the cache based on the results', () => {
 });
 
 test('works with multiple contexts', () => {
-  fs.readFileSync = jest.fn(cacheName =>
+  fs.readFileSync.mockImplementationOnce(cacheName =>
     cacheName.startsWith(path.sep + 'cache' + path.sep)
       ? JSON.stringify({
           '/test-a.js': [SUCCESS, 5],

--- a/packages/jest-test-sequencer/src/__tests__/test_sequencer.test.js
+++ b/packages/jest-test-sequencer/src/__tests__/test_sequencer.test.js
@@ -50,7 +50,7 @@ const toTests = paths =>
   }));
 
 beforeEach(() => {
-  jest.clearAllMocks()
+  jest.clearAllMocks();
   sequencer = new TestSequencer();
 });
 

--- a/packages/jest-test-sequencer/src/index.ts
+++ b/packages/jest-test-sequencer/src/index.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import fs from 'fs';
+import * as fs from 'fs';
 import {AggregatedResult} from '@jest/test-result';
 import {getCacheFilePath} from 'jest-haste-map';
 import {Context} from 'jest-runtime';

--- a/packages/jest-transform/src/shouldInstrument.ts
+++ b/packages/jest-transform/src/shouldInstrument.ts
@@ -5,11 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
+import * as path from 'path';
 import {Config} from '@jest/types';
 import {escapePathForRegex} from 'jest-regex-util';
 import {replacePathSepForGlob} from 'jest-util';
-import micromatch from 'micromatch';
+import {any as micromatchAny, some as micromatchSome} from 'micromatch';
 import {ShouldInstrumentOptions} from './types';
 
 const MOCKS_PATTERN = new RegExp(
@@ -27,7 +27,7 @@ export default function shouldInstrument(
 
   if (
     config.forceCoverageMatch.length &&
-    micromatch.any(filename, config.forceCoverageMatch)
+    micromatchAny(filename, config.forceCoverageMatch)
   ) {
     return true;
   }
@@ -39,7 +39,7 @@ export default function shouldInstrument(
       return false;
     }
 
-    if (micromatch.some(replacePathSepForGlob(filename), config.testMatch)) {
+    if (micromatchSome(replacePathSepForGlob(filename), config.testMatch)) {
       return false;
     }
   }
@@ -57,7 +57,7 @@ export default function shouldInstrument(
     // still cover if `only` is specified
     !options.collectCoverageOnlyFrom &&
     options.collectCoverageFrom &&
-    !micromatch.some(
+    !micromatchSome(
       replacePathSepForGlob(path.relative(config.rootDir, filename)),
       options.collectCoverageFrom,
     )

--- a/packages/jest-util/src/__tests__/createProcessObject.test.ts
+++ b/packages/jest-util/src/__tests__/createProcessObject.test.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import EventEmitter from 'events';
+import {EventEmitter} from 'events';
 
 let createProcessObject;
 

--- a/packages/jest-util/src/__tests__/installCommonGlobals.test.ts
+++ b/packages/jest-util/src/__tests__/installCommonGlobals.test.ts
@@ -5,13 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import vm from 'vm';
+import {createContext, runInContext} from 'vm';
 
 let installCommonGlobals: any;
 let fake: jest.Mock;
 
 function getGlobal(): NodeJS.Global {
-  return vm.runInContext('this', vm.createContext());
+  return runInContext('this', createContext());
 }
 
 beforeEach(() => {

--- a/packages/jest-util/src/createDirectory.ts
+++ b/packages/jest-util/src/createDirectory.ts
@@ -5,12 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import mkdirp from 'mkdirp';
+import {sync as mkdirp} from 'mkdirp';
 import {Config} from '@jest/types';
 
 export default function createDirectory(path: Config.Path) {
   try {
-    mkdirp.sync(path, '777');
+    mkdirp(path, '777');
   } catch (e) {
     if (e.code !== 'EEXIST') {
       throw e;

--- a/packages/jest-util/src/installCommonGlobals.ts
+++ b/packages/jest-util/src/installCommonGlobals.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import fs from 'fs';
+import * as fs from 'fs';
 import {Config} from '@jest/types';
 import createProcessObject from './createProcessObject';
 import deepCyclicCopy from './deepCyclicCopy';

--- a/packages/jest-validate/src/__tests__/fixtures/jestConfig.ts
+++ b/packages/jest-validate/src/__tests__/fixtures/jestConfig.ts
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import os from 'os';
-import path from 'path';
+import {tmpdir} from 'os';
+import * as path from 'path';
 import chalk from 'chalk';
 
 const NODE_MODULES = path.sep + 'node_modules' + path.sep;
@@ -23,7 +23,7 @@ const defaultConfig = {
   automock: false,
   bail: 0,
   browser: false,
-  cacheDirectory: path.join(os.tmpdir(), 'jest'),
+  cacheDirectory: path.join(tmpdir(), 'jest'),
   clearMocks: false,
   coveragePathIgnorePatterns: [NODE_MODULES_REGEXP],
   coverageReporters: ['json', 'text', 'lcov', 'clover'],

--- a/packages/jest-worker/src/base/BaseWorkerPool.ts
+++ b/packages/jest-worker/src/base/BaseWorkerPool.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
+import * as path from 'path';
 import mergeStream from 'merge-stream';
 
 import {

--- a/packages/jest-worker/src/index.ts
+++ b/packages/jest-worker/src/index.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import os from 'os';
+import {cpus} from 'os';
 import WorkerPool from './WorkerPool';
 import Farm from './Farm';
 import {WorkerPoolInterface, WorkerPoolOptions, FarmOptions} from './types';
@@ -72,7 +72,7 @@ export default class JestWorker {
       enableWorkerThreads: this._options.enableWorkerThreads || false,
       forkOptions: this._options.forkOptions || {},
       maxRetries: this._options.maxRetries || 3,
-      numWorkers: this._options.numWorkers || Math.max(os.cpus().length - 1, 1),
+      numWorkers: this._options.numWorkers || Math.max(cpus().length - 1, 1),
       setupArgs: this._options.setupArgs || [],
     };
 

--- a/packages/jest-worker/src/workers/ChildProcessWorker.ts
+++ b/packages/jest-worker/src/workers/ChildProcessWorker.ts
@@ -5,10 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import childProcess, {ChildProcess} from 'child_process';
+import {fork, ChildProcess} from 'child_process';
 import {PassThrough} from 'stream';
 import mergeStream from 'merge-stream';
-import supportsColor from 'supports-color';
+import {stdout as stdoutSupportsColor} from 'supports-color';
 
 import {
   CHILD_MESSAGE_INITIALIZE,
@@ -62,8 +62,8 @@ export default class ChildProcessWorker implements WorkerInterface {
   }
 
   initialize() {
-    const forceColor = supportsColor.stdout ? {FORCE_COLOR: '1'} : {};
-    const child = childProcess.fork(require.resolve('./processChild'), [], {
+    const forceColor = stdoutSupportsColor ? {FORCE_COLOR: '1'} : {};
+    const child = fork(require.resolve('./processChild'), [], {
       cwd: process.cwd(),
       env: {
         ...process.env,

--- a/packages/jest-worker/src/workers/NodeThreadsWorker.ts
+++ b/packages/jest-worker/src/workers/NodeThreadsWorker.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import path from 'path';
+import * as path from 'path';
 import {PassThrough} from 'stream';
 // ESLint doesn't know about this experimental module
 // eslint-disable-next-line import/no-unresolved

--- a/packages/pretty-format/src/index.ts
+++ b/packages/pretty-format/src/index.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import style from 'ansi-styles';
+import * as style from 'ansi-styles';
 import * as PrettyFormat from './types';
 
 import {

--- a/packages/pretty-format/src/plugins/ConvertAnsi.ts
+++ b/packages/pretty-format/src/plugins/ConvertAnsi.ts
@@ -6,7 +6,7 @@
  */
 
 import ansiRegex from 'ansi-regex';
-import style from 'ansi-styles';
+import * as style from 'ansi-styles';
 import {Config, Printer, NewPlugin, Refs} from '../types';
 
 const toHumanReadableAnsi = (text: string) =>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,6 @@
     "declarationMap": true,
     "composite": true,
     "emitDeclarationOnly": true,
-    // "importHelpers": true,
     // "isolatedModules": true,
 
     "strict": true,
@@ -20,6 +19,7 @@
 
     /* Module Resolution Options */
     "moduleResolution": "node",
+    /* This needs to be false so our types are possible to consume without setting this */
     "esModuleInterop": true,
     "resolveJsonModule": true
   },


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary
In order for our own types to be as consumable as possible, we should avoid relying on `esModuleInterop` (as that will force our consumers to also use that flag). This PR removes about 2/3 of our usage of it. Removing all will be a breaking change since it will remove `export =`, which means we must either use default or named exports. Also, we have to update some upstream libraries that only support node 8 so that they work without it. So at least one more PR will come when we drop node 6 and bump some libs. But this is a good start

https://github.com/DefinitelyTyped/DefinitelyTyped/pull/33705#issuecomment-473034112

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Green CI as this just changes how we import modules

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
