### PR TITLE
fix(linter): Fix linting failure introduced in #8847 😓

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `[jest-fake-timers]` `getTimerCount` will not include cancelled immediates ([#8764](https://github.com/facebook/jest/pull/8764))
 
 ### Chore & Maintenance
+
 - `[docs]` Fix broken link pointing to legacy JS file in "Snapshot Testing".
 
 ### Performance


### PR DESCRIPTION
## Summary

Hey hey team Jest — I recently updated the CHANGELOG in #8847... and accidentally introduced a [linting failure in CI](https://circleci.com/gh/facebook/jest/69316?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link). A little ironic because I only disabled my prettier autoformat config in vim so that it wouldn't create huge diffs in the other files I was touching. Whoops. 🙃 Sorry all! ❤️ This should set things straight, apart from the unrelated failure in the `jest-circus` job.