### PR TITLE
chore: bump ansi-escapes

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "jest-junit": "^6.2.1",
     "jest-silent-reporter": "^0.1.2",
     "jest-snapshot-serializer-raw": "^1.1.0",
-    "jest-watch-typeahead": "^0.3.1",
+    "jest-watch-typeahead": "^0.4.0",
     "jquery": "^3.2.1",
     "karma": "^4.0.1",
     "karma-chrome-launcher": "^3.0.0",

--- a/packages/jest-core/package.json
+++ b/packages/jest-core/package.json
@@ -10,7 +10,7 @@
     "@jest/test-result": "^24.9.0",
     "@jest/transform": "^24.9.0",
     "@jest/types": "^24.9.0",
-    "ansi-escapes": "^3.0.0",
+    "ansi-escapes": "^4.2.1",
     "chalk": "^2.0.1",
     "exit": "^0.1.2",
     "graceful-fs": "^4.1.15",
@@ -36,7 +36,6 @@
   },
   "devDependencies": {
     "@jest/test-sequencer": "^24.9.0",
-    "@types/ansi-escapes": "^3.0.1",
     "@types/exit": "^0.1.30",
     "@types/graceful-fs": "^4.1.2",
     "@types/micromatch": "^3.1.0",

--- a/packages/jest-watcher/package.json
+++ b/packages/jest-watcher/package.json
@@ -7,13 +7,12 @@
     "@jest/test-result": "^24.9.0",
     "@jest/types": "^24.9.0",
     "@types/yargs": "^13.0.0",
-    "ansi-escapes": "^3.0.0",
+    "ansi-escapes": "^4.2.1",
     "chalk": "^2.0.1",
     "jest-util": "^24.9.0",
     "string-length": "^2.0.0"
   },
   "devDependencies": {
-    "@types/ansi-escapes": "^3.0.0",
     "@types/string-length": "^2.0.0"
   },
   "repository": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8487,16 +8487,16 @@ jest-snapshot-serializer-raw@^1.1.0:
   resolved "https://registry.yarnpkg.com/jest-snapshot-serializer-raw/-/jest-snapshot-serializer-raw-1.1.0.tgz#1d7f09c02f3dbbc3ae70b5b7598fb2f45e37d6c8"
   integrity sha512-OL3bXRCnSn7Kur3YTGYj+A3Hwh2eyb5QL5VLQ9OSsPBOva7r3sCB0Jf1rOT/KN3ypzH42hrkDz96lpbiMo+AlQ==
 
-jest-watch-typeahead@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/jest-watch-typeahead/-/jest-watch-typeahead-0.3.1.tgz#47701024b64b444aa325d801b4b3a6d61ed70701"
-  integrity sha512-cDIko96c4Yqg/7mfye1eEYZ6Pvugo9mnOOhGQod3Es7/KptNv1b+9gFVaotzdqNqTlwbkA80BnWHtzV4dc+trA==
+jest-watch-typeahead@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/jest-watch-typeahead/-/jest-watch-typeahead-0.4.0.tgz#4d5356839a85421588ce452d2440bf0d25308397"
+  integrity sha512-bJR/HPNgOQnkmttg1OkBIrYFAYuxFxExtgQh67N2qPvaWGVC8TCkedRNPKBfmZfVXFD3u2sCH+9OuS5ApBfCgA==
   dependencies:
-    ansi-escapes "^3.0.0"
+    ansi-escapes "^4.2.1"
     chalk "^2.4.1"
     jest-watcher "^24.3.0"
-    slash "^2.0.0"
-    string-length "^2.0.0"
+    slash "^3.0.0"
+    string-length "^3.1.0"
     strip-ansi "^5.0.0"
 
 jest-worker@24.0.0-alpha.6:
@@ -12741,6 +12741,11 @@ slash@^2.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
   integrity sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==
 
+slash@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
+  integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
+
 slice-ansi@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-2.1.0.tgz#cacd7693461a637a5788d92a7dd4fba068e81636"
@@ -13107,6 +13112,14 @@ string-length@^2.0.0:
   dependencies:
     astral-regex "^1.0.0"
     strip-ansi "^4.0.0"
+
+string-length@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/string-length/-/string-length-3.1.0.tgz#107ef8c23456e187a8abd4a61162ff4ac6e25837"
+  integrity sha512-Ttp5YvkGm5v9Ijagtaz1BnN+k9ObpvS0eIBblPMp2YWL8FBmi9qblQ9fexc2k/CXFgrTIteU3jAw3payCnwSTA==
+  dependencies:
+    astral-regex "^1.0.0"
+    strip-ansi "^5.2.0"
 
 string-template@~0.2.1:
   version "0.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2143,13 +2143,6 @@
     "@babel/runtime" "^7.5.4"
     "@testing-library/dom" "^5.5.4"
 
-"@types/ansi-escapes@^3.0.0", "@types/ansi-escapes@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@types/ansi-escapes/-/ansi-escapes-3.0.1.tgz#328e46c6ac3177ca4cf2efdeed326cf77da01ef7"
-  integrity sha512-GD/QLUGxSvy3yGQb+m12qsRtP4p/dewNePDb5F8qV19CXuO+gtbsmMjjsClpG/Nu84y8SF1zPKrTnQZHDiPUgg==
-  dependencies:
-    "@types/node" "*"
-
 "@types/ansi-regex@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/ansi-regex/-/ansi-regex-4.0.0.tgz#cb20bb66da7700ea9b26f16971f03f0e092eddad"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

This needs https://github.com/jest-community/jest-watch-typeahead/pull/30 to be released due to how it's hoisted (v3 is hoisted, so wrong thing is mocked in the tests)

EDIT: I forgot I had publish access to that module, so this is fixed. I'll combine it with the other PR to keep history a bit cleaner

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

At some point, green CI

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
