### PR TITLE
Add util to create empty testResult

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - `[babel-plugin-jest-hoist]` Show codeframe on static hoisting issues ([#8865](https://github.com/facebook/jest/pull/8865))
 - `[jest-config]` [**BREAKING**] Set default display name color based on runner ([#8689](https://github.com/facebook/jest/pull/8689))
+- `[@jest/test-result]` Create method to create empty `TestResult` ([#8867](https://github.com/facebook/jest/pull/8867))
 
 ### Fixes
 

--- a/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapterInit.ts
+++ b/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapterInit.ts
@@ -7,7 +7,12 @@
 
 import {Circus, Config, Global} from '@jest/types';
 import {JestEnvironment} from '@jest/environment';
-import {AssertionResult, Status, TestResult} from '@jest/test-result';
+import {
+  AssertionResult,
+  Status,
+  TestResult,
+  emptyTestResult,
+} from '@jest/test-result';
 import {extractExpectedAssertionsErrors, getState, setState} from 'expect';
 import {formatExecError, formatResultsErrors} from 'jest-message-util';
 import {
@@ -215,30 +220,14 @@ export const runAndTransformResultsToJestFormat = async ({
 
   dispatch({name: 'teardown'});
   return {
+    ...emptyTestResult(),
     console: undefined,
     displayName: config.displayName,
     failureMessage,
-    leaks: false, // That's legacy code, just adding it so Flow is happy.
     numFailingTests,
     numPassingTests,
     numPendingTests,
     numTodoTests,
-    openHandles: [],
-    perfStats: {
-      // populated outside
-      end: 0,
-      start: 0,
-    },
-    skipped: false,
-    snapshot: {
-      added: 0,
-      fileDeleted: false,
-      matched: 0,
-      unchecked: 0,
-      uncheckedKeys: [],
-      unmatched: 0,
-      updated: 0,
-    },
     sourceMaps: {},
     testExecError,
     testFilePath: testPath,

--- a/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapterInit.ts
+++ b/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapterInit.ts
@@ -11,7 +11,7 @@ import {
   AssertionResult,
   Status,
   TestResult,
-  emptyTestResult,
+  createEmptyTestResult,
 } from '@jest/test-result';
 import {extractExpectedAssertionsErrors, getState, setState} from 'expect';
 import {formatExecError, formatResultsErrors} from 'jest-message-util';
@@ -220,7 +220,7 @@ export const runAndTransformResultsToJestFormat = async ({
 
   dispatch({name: 'teardown'});
   return {
-    ...emptyTestResult(),
+    ...createEmptyTestResult(),
     console: undefined,
     displayName: config.displayName,
     failureMessage,

--- a/packages/jest-jasmine2/src/reporter.ts
+++ b/packages/jest-jasmine2/src/reporter.ts
@@ -6,7 +6,11 @@
  */
 
 import {Config} from '@jest/types';
-import {AssertionResult, TestResult, createEmptyTestResult} from '@jest/test-result';
+import {
+  AssertionResult,
+  TestResult,
+  createEmptyTestResult,
+} from '@jest/test-result';
 import {formatResultsErrors} from 'jest-message-util';
 import {SpecResult} from './jasmine/Spec';
 import {SuiteResult} from './jasmine/Suite';

--- a/packages/jest-jasmine2/src/reporter.ts
+++ b/packages/jest-jasmine2/src/reporter.ts
@@ -6,7 +6,7 @@
  */
 
 import {Config} from '@jest/types';
-import {AssertionResult, TestResult} from '@jest/test-result';
+import {AssertionResult, TestResult, emptyTestResult} from '@jest/test-result';
 import {formatResultsErrors} from 'jest-message-util';
 import {SpecResult} from './jasmine/Spec';
 import {SuiteResult} from './jasmine/Suite';
@@ -78,6 +78,7 @@ export default class Jasmine2Reporter implements Reporter {
     });
 
     const testResult = {
+      ...emptyTestResult(),
       console: null,
       failureMessage: formatResultsErrors(
         testResults,
@@ -89,10 +90,6 @@ export default class Jasmine2Reporter implements Reporter {
       numPassingTests,
       numPendingTests,
       numTodoTests,
-      perfStats: {
-        end: 0,
-        start: 0,
-      },
       snapshot: {
         added: 0,
         fileDeleted: false,

--- a/packages/jest-jasmine2/src/reporter.ts
+++ b/packages/jest-jasmine2/src/reporter.ts
@@ -6,7 +6,7 @@
  */
 
 import {Config} from '@jest/types';
-import {AssertionResult, TestResult, emptyTestResult} from '@jest/test-result';
+import {AssertionResult, TestResult, createEmptyTestResult} from '@jest/test-result';
 import {formatResultsErrors} from 'jest-message-util';
 import {SpecResult} from './jasmine/Spec';
 import {SuiteResult} from './jasmine/Suite';
@@ -78,7 +78,7 @@ export default class Jasmine2Reporter implements Reporter {
     });
 
     const testResult = {
-      ...emptyTestResult(),
+      ...createEmptyTestResult(),
       console: null,
       failureMessage: formatResultsErrors(
         testResults,

--- a/packages/jest-test-result/src/helpers.ts
+++ b/packages/jest-test-result/src/helpers.ts
@@ -147,7 +147,7 @@ export const addResult = (
 };
 
 export const createEmptyTestResult = (): TestResult => ({
-  leaks: false, // That's legacy code, just adding it so Flow is happy.
+  leaks: false,
   numFailingTests: 0,
   numPassingTests: 0,
   numPendingTests: 0,

--- a/packages/jest-test-result/src/helpers.ts
+++ b/packages/jest-test-result/src/helpers.ts
@@ -147,7 +147,7 @@ export const addResult = (
 };
 
 export const createEmptyTestResult = (): TestResult => ({
-  leaks: false,
+  leaks: false, // That's legacy code, just adding it as needed for typing
   numFailingTests: 0,
   numPassingTests: 0,
   numPendingTests: 0,

--- a/packages/jest-test-result/src/helpers.ts
+++ b/packages/jest-test-result/src/helpers.ts
@@ -146,7 +146,7 @@ export const addResult = (
     testResult.snapshot.updated;
 };
 
-export const emptyTestResult = (): TestResult => ({
+export const createEmptyTestResult = (): TestResult => ({
   leaks: false, // That's legacy code, just adding it so Flow is happy.
   numFailingTests: 0,
   numPassingTests: 0,

--- a/packages/jest-test-result/src/helpers.ts
+++ b/packages/jest-test-result/src/helpers.ts
@@ -145,3 +145,28 @@ export const addResult = (
     testResult.snapshot.unmatched +
     testResult.snapshot.updated;
 };
+
+export const emptyTestResult = (): TestResult => ({
+  leaks: false, // That's legacy code, just adding it so Flow is happy.
+  numFailingTests: 0,
+  numPassingTests: 0,
+  numPendingTests: 0,
+  numTodoTests: 0,
+  openHandles: [],
+  perfStats: {
+    end: 0,
+    start: 0,
+  },
+  skipped: false,
+  snapshot: {
+    added: 0,
+    fileDeleted: false,
+    matched: 0,
+    unchecked: 0,
+    uncheckedKeys: [],
+    unmatched: 0,
+    updated: 0,
+  },
+  testFilePath: '',
+  testResults: [],
+});

--- a/packages/jest-test-result/src/index.ts
+++ b/packages/jest-test-result/src/index.ts
@@ -9,6 +9,7 @@ export {default as formatTestResults} from './formatTestResults';
 export {
   addResult,
   buildFailureTestResult,
+  emptyTestResult,
   makeEmptyAggregatedTestResult,
 } from './helpers';
 export {

--- a/packages/jest-test-result/src/index.ts
+++ b/packages/jest-test-result/src/index.ts
@@ -9,7 +9,7 @@ export {default as formatTestResults} from './formatTestResults';
 export {
   addResult,
   buildFailureTestResult,
-  emptyTestResult,
+  createEmptyTestResult,
   makeEmptyAggregatedTestResult,
 } from './helpers';
 export {


### PR DESCRIPTION
## Summary

Based on a suggestion in #8823

Creating an util in `@jest/test-result` which will create an empty `TestResult`

/cc @SimenB 

## Test plan

Existing test cases should work after the change