### PR TITLE
chore: make `weak-napi` optional

### DIFF
--- a/packages/jest-leak-detector/package.json
+++ b/packages/jest-leak-detector/package.json
@@ -11,11 +11,11 @@
   "types": "build/index.d.ts",
   "dependencies": {
     "jest-get-type": "^24.9.0",
-    "pretty-format": "^24.9.0",
-    "weak-napi": "^1.0.3"
+    "pretty-format": "^24.9.0"
   },
   "devDependencies": {
-    "@types/weak-napi": "^1.0.0"
+    "@types/weak-napi": "^1.0.0",
+    "weak-napi": "^1.0.3"
   },
   "engines": {
     "node": ">= 8"

--- a/packages/jest-leak-detector/src/index.ts
+++ b/packages/jest-leak-detector/src/index.ts
@@ -7,7 +7,6 @@
 
 import {setFlagsFromString} from 'v8';
 import {runInNewContext} from 'vm';
-import weak = require('weak-napi');
 import prettyFormat = require('pretty-format');
 import {isPrimitive} from 'jest-get-type';
 
@@ -21,6 +20,22 @@ export default class {
           'Primitives cannot leak memory.',
           'You passed a ' + typeof value + ': <' + prettyFormat(value) + '>',
         ].join(' '),
+      );
+    }
+
+    let weak: typeof import('weak-napi');
+
+    try {
+      // eslint-disable-next-line import/no-extraneous-dependencies
+      weak = require('weak-napi');
+    } catch (err) {
+      if (!err || err.code !== 'MODULE_NOT_FOUND') {
+        throw err;
+      }
+
+      throw new Error(
+        'The leaking detection mechanism requires the "weak-napi" package to be installed and work. ' +
+          'Please install it as a dependency on your main project',
       );
     }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Discovered we still need this when upgrading to 25 at work.

```sh-session
$ docker run --interactive --tty --rm node:lts-alpine yarn add weak-napi
$ docker run --interactive --tty --rm node:lts-alpine sh -c "apk add --no-cache python && yarn add weak-napi"
```

You need to install quite a bit of stuff

This is essentially #5252 again

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Dunno...

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
