### PR TITLE
chore: convert jest-cli and jest-validate to esm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - `[docs]` Fix broken link pointing to legacy JS file in "Snapshot Testing".
 - `[jest]` [**BREAKING**] Use ESM exports ([#8874](https://github.com/facebook/jest/pull/8874))
 - `[jest-cli]` [**BREAKING**] Use ESM exports ([#8874](https://github.com/facebook/jest/pull/8874))
+- `[jest-cli]` [**BREAKING**] Remove re-exports from `@jest/core` ([#8874](https://github.com/facebook/jest/pull/8874))
 - `[jest-environment-jsdom]` [**BREAKING**] Upgrade JSDOM from v11 to v15 ([#8851](https://github.com/facebook/jest/pull/8851))
 - `[jest-util]` [**BREAKING**] Remove deprecated exports ([#8863](https://github.com/facebook/jest/pull/8863))
 - `[jest-validate]` [**BREAKING**] Use ESM exports ([#8874](https://github.com/facebook/jest/pull/8874))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,9 @@
 - `[*]` [**BREAKING**] Drop support for Node 6 ([#8455](https://github.com/facebook/jest/pull/8455))
 - `[*]` Add Node 12 to CI ([#8411](https://github.com/facebook/jest/pull/8411))
 - `[*]` [**BREAKING**] Upgrade to Micromatch v4 ([#8852](https://github.com/facebook/jest/pull/8852))
+- `[babel-plugin-jest-hoist]` [**BREAKING**] Use ESM exports ([#8874](https://github.com/facebook/jest/pull/8874))
 - `[docs]` Fix broken link pointing to legacy JS file in "Snapshot Testing".
+- `[jest]` [**BREAKING**] Use ESM exports ([#8874](https://github.com/facebook/jest/pull/8874))
 - `[jest-cli]` [**BREAKING**] Use ESM exports ([#8874](https://github.com/facebook/jest/pull/8874))
 - `[jest-environment-jsdom]` [**BREAKING**] Upgrade JSDOM from v11 to v15 ([#8851](https://github.com/facebook/jest/pull/8851))
 - `[jest-util]` [**BREAKING**] Remove deprecated exports ([#8863](https://github.com/facebook/jest/pull/8863))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,10 @@
 - `[*]` Add Node 12 to CI ([#8411](https://github.com/facebook/jest/pull/8411))
 - `[*]` [**BREAKING**] Upgrade to Micromatch v4 ([#8852](https://github.com/facebook/jest/pull/8852))
 - `[docs]` Fix broken link pointing to legacy JS file in "Snapshot Testing".
+- `[jest-cli]` [**BREAKING**] Use ESM exports
 - `[jest-environment-jsdom]` [**BREAKING**] Upgrade JSDOM from v11 to v15 ([#8851](https://github.com/facebook/jest/pull/8851))
 - `[jest-util]` [**BREAKING**] Remove deprecated exports ([#8863](https://github.com/facebook/jest/pull/8863))
+- `[jest-validate]` [**BREAKING**] Use ESM exports
 
 ### Performance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,10 @@
 - `[*]` Add Node 12 to CI ([#8411](https://github.com/facebook/jest/pull/8411))
 - `[*]` [**BREAKING**] Upgrade to Micromatch v4 ([#8852](https://github.com/facebook/jest/pull/8852))
 - `[docs]` Fix broken link pointing to legacy JS file in "Snapshot Testing".
-- `[jest-cli]` [**BREAKING**] Use ESM exports
+- `[jest-cli]` [**BREAKING**] Use ESM exports ([#8874](https://github.com/facebook/jest/pull/8874))
 - `[jest-environment-jsdom]` [**BREAKING**] Upgrade JSDOM from v11 to v15 ([#8851](https://github.com/facebook/jest/pull/8851))
 - `[jest-util]` [**BREAKING**] Remove deprecated exports ([#8863](https://github.com/facebook/jest/pull/8863))
-- `[jest-validate]` [**BREAKING**] Use ESM exports
+- `[jest-validate]` [**BREAKING**] Use ESM exports ([#8874](https://github.com/facebook/jest/pull/8874))
 
 ### Performance
 

--- a/e2e/run-programmatically/cjs.js
+++ b/e2e/run-programmatically/cjs.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- * @flow
  */
 
 // Running Jest like this is not officially supported,

--- a/e2e/run-programmatically/esm.js
+++ b/e2e/run-programmatically/esm.js
@@ -3,12 +3,10 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- * @flow
  */
 
-import myJestImport from 'jest';
+import {run} from 'jest';
 
 // Running Jest like this is not officially supported,
 // but it is common practice until there is a proper API as a substitute.
-myJestImport.run(process.argv);
+run(process.argv);

--- a/packages/babel-plugin-jest-hoist/src/index.ts
+++ b/packages/babel-plugin-jest-hoist/src/index.ts
@@ -154,7 +154,7 @@ FUNCTIONS.deepUnmock = args => args.length === 1 && args[0].isStringLiteral();
 FUNCTIONS.disableAutomock = FUNCTIONS.enableAutomock = args =>
   args.length === 0;
 
-export = () => {
+export default () => {
   const shouldHoistExpression = (expr: NodePath): boolean => {
     if (!expr.isCallExpression()) {
       return false;

--- a/packages/jest-cli/src/index.ts
+++ b/packages/jest-cli/src/index.ts
@@ -6,20 +6,11 @@
  */
 
 // TODO: remove @jest/core exports for the next major
-import {
+export {
   SearchSource,
   TestScheduler,
   TestWatcher,
   getVersion,
   runCLI,
 } from '@jest/core';
-import {run} from './cli';
-
-export = {
-  SearchSource,
-  TestScheduler,
-  TestWatcher,
-  getVersion,
-  run,
-  runCLI,
-};
+export {run} from './cli';

--- a/packages/jest-cli/src/index.ts
+++ b/packages/jest-cli/src/index.ts
@@ -5,12 +5,4 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// TODO: remove @jest/core exports for the next major
-export {
-  SearchSource,
-  TestScheduler,
-  TestWatcher,
-  getVersion,
-  runCLI,
-} from '@jest/core';
 export {run} from './cli';

--- a/packages/jest-jasmine2/src/index.ts
+++ b/packages/jest-jasmine2/src/index.ts
@@ -38,7 +38,7 @@ async function jasmine2(
   });
 
   const env = jasmine.getEnv();
-  const jasmineInterface = jasmineFactory.interface(jasmine, env);
+  const jasmineInterface = jasmineFactory._interface(jasmine, env);
   Object.assign(environment.global, jasmineInterface);
   env.addReporter(jasmineInterface.jsApiReporter);
 

--- a/packages/jest-jasmine2/src/jasmine/jasmineLight.ts
+++ b/packages/jest-jasmine2/src/jasmine/jasmineLight.ts
@@ -40,7 +40,7 @@ import SpyRegistry from './spyRegistry';
 import Suite from './Suite';
 import Timer from './Timer';
 
-const create = function(createOptions: Record<string, any>): Jasmine {
+export const create = function(createOptions: Record<string, any>): Jasmine {
   const j$ = {...createOptions} as Jasmine;
 
   j$._DEFAULT_TIMEOUT_INTERVAL = createOptions.testTimeout || 5000;
@@ -63,7 +63,8 @@ const create = function(createOptions: Record<string, any>): Jasmine {
   return j$;
 };
 
-const _interface = function(jasmine: Jasmine, env: any) {
+// Interface is a reserved word in strict mode, so can't export it as ESM
+export const _interface = function(jasmine: Jasmine, env: any) {
   const jasmineInterface = {
     describe(description: string, specDefinitions: Function) {
       return env.describe(description, specDefinitions);
@@ -146,6 +147,3 @@ const _interface = function(jasmine: Jasmine, env: any) {
 
   return jasmineInterface;
 };
-
-// Interface is a reserved word in strict mode, so can't export it as ESM
-export = {create, interface: _interface};

--- a/packages/jest-validate/src/index.ts
+++ b/packages/jest-validate/src/index.ts
@@ -5,22 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {
+export {
   ValidationError,
   createDidYouMeanMessage,
   format,
   logValidationWarning,
 } from './utils';
-import validate from './validate';
-import validateCLIOptions from './validateCLIOptions';
-import {multipleValidOptions} from './condition';
-
-export = {
-  ValidationError,
-  createDidYouMeanMessage,
-  format,
-  logValidationWarning,
-  multipleValidOptions,
-  validate,
-  validateCLIOptions,
-};
+export {default as validate} from './validate';
+export {default as validateCLIOptions} from './validateCLIOptions';
+export {multipleValidOptions} from './condition';

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -5,6 +5,7 @@
   "main": "build/jest.js",
   "types": "build/jest.d.ts",
   "dependencies": {
+    "@jest/core": "^24.9.0",
     "import-local": "^3.0.2",
     "jest-cli": "^24.9.0"
   },

--- a/packages/jest/src/jest.ts
+++ b/packages/jest/src/jest.ts
@@ -5,6 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import * as cli from 'jest-cli';
-
-export = cli;
+export {
+  SearchSource,
+  TestScheduler,
+  TestWatcher,
+  getVersion,
+  run,
+  runCLI,
+} from 'jest-cli';

--- a/packages/jest/src/jest.ts
+++ b/packages/jest/src/jest.ts
@@ -10,6 +10,7 @@ export {
   TestScheduler,
   TestWatcher,
   getVersion,
-  run,
   runCLI,
-} from 'jest-cli';
+} from '@jest/core';
+
+export {run} from 'jest-cli';

--- a/packages/jest/tsconfig.json
+++ b/packages/jest/tsconfig.json
@@ -5,6 +5,7 @@
     "outDir": "build"
   },
   "references": [
-    {"path": "../jest-cli"}
+    {"path": "../jest-cli"},
+    {"path": "../jest-core"}
   ]
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

We wanna migrate off of `export =` as it's not valid JS. These ones should be free as they already export objects. Marking them as breaking, but it should just be breaking for people using `TS` - either `import` or `require` should work the same

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Green CI

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
