### PR TITLE
chore: use `as const` rather than casting individual strings

### DIFF
--- a/packages/jest-cli/src/cli/args.ts
+++ b/packages/jest-cli/src/cli/args.ts
@@ -74,19 +74,19 @@ export const options = {
       'The opposite of `onlyChanged`. If `onlyChanged` is set by ' +
       'default, running jest with `--all` will force Jest to run all tests ' +
       'instead of running only tests related to changed files.',
-    type: 'boolean' as 'boolean',
+    type: 'boolean',
   },
   automock: {
     default: undefined,
     description: 'Automock all files by default.',
-    type: 'boolean' as 'boolean',
+    type: 'boolean',
   },
   bail: {
     alias: 'b',
     default: undefined,
     description:
       'Exit the test suite immediately after `n` number of failing tests.',
-    type: 'boolean' as 'boolean',
+    type: 'boolean',
   },
   browser: {
     default: undefined,
@@ -94,27 +94,27 @@ export const options = {
       'Respect the "browser" field in package.json ' +
       'when resolving modules. Some packages export different versions ' +
       'based on whether they are operating in node.js or a browser.',
-    type: 'boolean' as 'boolean',
+    type: 'boolean',
   },
   cache: {
     default: undefined,
     description:
       'Whether to use the transform cache. Disable the cache ' +
       'using --no-cache.',
-    type: 'boolean' as 'boolean',
+    type: 'boolean',
   },
   cacheDirectory: {
     description:
       'The directory where Jest should store its cached ' +
       ' dependency information.',
-    type: 'string' as 'string',
+    type: 'string',
   },
   changedFilesWithAncestor: {
     default: undefined,
     description:
       'Runs tests related to the current changes and the changes made in the ' +
       'last commit. Behaves similarly to `--onlyChanged`.',
-    type: 'boolean' as 'boolean',
+    type: 'boolean',
   },
   changedSince: {
     description:
@@ -122,7 +122,7 @@ export const options = {
       'current branch has diverged from the given branch, then only changes ' +
       'made locally will be tested. Behaves similarly to `--onlyChanged`.',
     nargs: 1,
-    type: 'string' as 'string',
+    type: 'string',
   },
   ci: {
     default: isCI,
@@ -130,49 +130,49 @@ export const options = {
       'Whether to run Jest in continuous integration (CI) mode. ' +
       'This option is on by default in most popular CI environments. It will ' +
       ' prevent snapshots from being written unless explicitly requested.',
-    type: 'boolean' as 'boolean',
+    type: 'boolean',
   },
   clearCache: {
     default: undefined,
     description:
       'Clears the configured Jest cache directory and then exits. ' +
       'Default directory can be found by calling jest --showConfig',
-    type: 'boolean' as 'boolean',
+    type: 'boolean',
   },
   clearMocks: {
     default: undefined,
     description:
       'Automatically clear mock calls and instances between every ' +
       'test. Equivalent to calling jest.clearAllMocks() between each test.',
-    type: 'boolean' as 'boolean',
+    type: 'boolean',
   },
   collectCoverage: {
     default: undefined,
     description: 'Alias for --coverage.',
-    type: 'boolean' as 'boolean',
+    type: 'boolean',
   },
   collectCoverageFrom: {
     description:
       'A glob pattern relative to <rootDir> matching the files that coverage ' +
       'info needs to be collected from.',
-    type: 'string' as 'string',
+    type: 'string',
   },
   collectCoverageOnlyFrom: {
     description: 'Explicit list of paths coverage will be restricted to.',
     string: true as true,
-    type: 'array' as 'array',
+    type: 'array',
   },
   color: {
     default: undefined,
     description:
       'Forces test results output color highlighting (even if ' +
       'stdout is not a TTY). Set to false if you would like to have no colors.',
-    type: 'boolean' as 'boolean',
+    type: 'boolean',
   },
   colors: {
     default: undefined,
     description: 'Alias for `--color`.',
-    type: 'boolean' as 'boolean',
+    type: 'boolean',
   },
   config: {
     alias: 'c',
@@ -181,18 +181,18 @@ export const options = {
       'and execute tests. If no rootDir is set in the config, the directory ' +
       'containing the config file is assumed to be the rootDir for the project.' +
       'This can also be a JSON encoded value which Jest will use as configuration.',
-    type: 'string' as 'string',
+    type: 'string',
   },
   coverage: {
     default: undefined,
     description:
       'Indicates that test coverage information should be ' +
       'collected and reported in the output.',
-    type: 'boolean' as 'boolean',
+    type: 'boolean',
   },
   coverageDirectory: {
     description: 'The directory where Jest should output its coverage files.',
-    type: 'string' as 'string',
+    type: 'string',
   },
   coveragePathIgnorePatterns: {
     description:
@@ -200,25 +200,25 @@ export const options = {
       'against all file paths before executing the test. If the file path' +
       'matches any of the patterns, coverage information will be skipped.',
     string: true as true,
-    type: 'array' as 'array',
+    type: 'array',
   },
   coverageReporters: {
     description:
       'A list of reporter names that Jest uses when writing ' +
       'coverage reports. Any istanbul reporter can be used.',
     string: true as true,
-    type: 'array' as 'array',
+    type: 'array',
   },
   coverageThreshold: {
     description:
       'A JSON string with which will be used to configure ' +
       'minimum threshold enforcement for coverage results',
-    type: 'string' as 'string',
+    type: 'string',
   },
   debug: {
     default: undefined,
     description: 'Print debugging info about your jest config.',
-    type: 'boolean' as 'boolean',
+    type: 'boolean',
   },
   detectLeaks: {
     default: false,
@@ -226,32 +226,32 @@ export const options = {
       '**EXPERIMENTAL**: Detect memory leaks in tests. After executing a ' +
       'test, it will try to garbage collect the global object used, and fail ' +
       'if it was leaked',
-    type: 'boolean' as 'boolean',
+    type: 'boolean',
   },
   detectOpenHandles: {
     default: false,
     description:
       'Print out remaining open handles preventing Jest from exiting at the ' +
       'end of a test run. Implies `runInBand`.',
-    type: 'boolean' as 'boolean',
+    type: 'boolean',
   },
   env: {
     description:
       'The test environment used for all tests. This can point to ' +
       'any file or node module. Examples: `jsdom`, `node` or ' +
       '`path/to/my-environment.js`',
-    type: 'string' as 'string',
+    type: 'string',
   },
   errorOnDeprecated: {
     default: false,
     description: 'Make calling deprecated APIs throw helpful error messages.',
-    type: 'boolean' as 'boolean',
+    type: 'boolean',
   },
   expand: {
     alias: 'e',
     default: undefined,
     description: 'Use this flag to show full diffs instead of a patch.',
-    type: 'boolean' as 'boolean',
+    type: 'boolean',
   },
   filter: {
     default: undefined,
@@ -260,7 +260,7 @@ export const options = {
       'a list of tests which can be manipulated to exclude tests from ' +
       'running. Especially useful when used in conjunction with a testing ' +
       'infrastructure to filter known broken tests.',
-    type: 'string' as 'string',
+    type: 'string',
   },
   findRelatedTests: {
     default: undefined,
@@ -268,7 +268,7 @@ export const options = {
       'Find related tests for a list of source files that were ' +
       'passed in as arguments. Useful for pre-commit hook integration to run ' +
       'the minimal amount of tests necessary.',
-    type: 'boolean' as 'boolean',
+    type: 'boolean',
   },
   forceExit: {
     default: undefined,
@@ -276,44 +276,44 @@ export const options = {
       'Force Jest to exit after all tests have completed running. ' +
       'This is useful when resources set up by test code cannot be ' +
       'adequately cleaned up.',
-    type: 'boolean' as 'boolean',
+    type: 'boolean',
   },
   globalSetup: {
     description: 'The path to a module that runs before All Tests.',
-    type: 'string' as 'string',
+    type: 'string',
   },
   globalTeardown: {
     description: 'The path to a module that runs after All Tests.',
-    type: 'string' as 'string',
+    type: 'string',
   },
   globals: {
     description:
       'A JSON string with map of global variables that need ' +
       'to be available in all test environments.',
-    type: 'string' as 'string',
+    type: 'string',
   },
   haste: {
     description:
       'A JSON string with map of variables for the haste module system',
-    type: 'string' as 'string',
+    type: 'string',
   },
   init: {
     description: 'Generate a basic configuration file',
-    type: 'boolean' as 'boolean',
+    type: 'boolean',
   },
   json: {
     default: undefined,
     description:
       'Prints the test results in JSON. This mode will send all ' +
       'other test output and user messages to stderr.',
-    type: 'boolean' as 'boolean',
+    type: 'boolean',
   },
   lastCommit: {
     default: undefined,
     description:
       'Run all tests affected by file changes in the last commit made. ' +
       'Behaves similarly to `--onlyChanged`.',
-    type: 'boolean' as 'boolean',
+    type: 'boolean',
   },
   listTests: {
     default: false,
@@ -321,7 +321,7 @@ export const options = {
       'Lists all tests Jest will run given the arguments and ' +
       'exits. Most useful in a CI system together with `--findRelatedTests` ' +
       'to determine the tests Jest will run based on specific files',
-    type: 'boolean' as 'boolean',
+    type: 'boolean',
   },
   logHeapUsage: {
     default: undefined,
@@ -329,21 +329,21 @@ export const options = {
       'Logs the heap usage after every test. Useful to debug ' +
       'memory leaks. Use together with `--runInBand` and `--expose-gc` in ' +
       'node.',
-    type: 'boolean' as 'boolean',
+    type: 'boolean',
   },
   mapCoverage: {
     default: undefined,
     description:
       'Maps code coverage reports against original source code ' +
       'when transformers supply source maps.\n\nDEPRECATED',
-    type: 'boolean' as 'boolean',
+    type: 'boolean',
   },
   maxConcurrency: {
     default: 5,
     description:
       'Specifies the maximum number of tests that are allowed to run' +
       'concurrently. This only affects tests using `test.concurrent`.',
-    type: 'number' as 'number',
+    type: 'number',
   },
   maxWorkers: {
     alias: 'w',
@@ -352,14 +352,14 @@ export const options = {
       'will spawn for running tests. This defaults to the number of the ' +
       'cores available on your machine. (its usually best not to override ' +
       'this default)',
-    type: 'string' as 'string',
+    type: 'string',
   },
   moduleDirectories: {
     description:
       'An array of directory names to be searched recursively ' +
       "up from the requiring module's location.",
     string: true as true,
-    type: 'array' as 'array',
+    type: 'array',
   },
   moduleFileExtensions: {
     description:
@@ -367,14 +367,14 @@ export const options = {
       'require modules without specifying a file extension, these are the ' +
       'extensions Jest will look for. ',
     string: true as true,
-    type: 'array' as 'array',
+    type: 'array',
   },
   moduleNameMapper: {
     description:
       'A JSON string with a map from regular expressions to ' +
       'module names that allow to stub out resources, like images or ' +
       'styles with a single module',
-    type: 'string' as 'string',
+    type: 'string',
   },
   modulePathIgnorePatterns: {
     description:
@@ -382,7 +382,7 @@ export const options = {
       'against all module paths before those paths are to be considered ' +
       '"visible" to the module loader.',
     string: true as true,
-    type: 'array' as 'array',
+    type: 'array',
   },
   modulePaths: {
     description:
@@ -390,22 +390,22 @@ export const options = {
       'modulePaths is an array of absolute paths to additional locations to ' +
       'search when resolving modules.',
     string: true as true,
-    type: 'array' as 'array',
+    type: 'array',
   },
   noStackTrace: {
     default: undefined,
     description: 'Disables stack trace in test results output',
-    type: 'boolean' as 'boolean',
+    type: 'boolean',
   },
   notify: {
     default: undefined,
     description: 'Activates notifications for test results.',
-    type: 'boolean' as 'boolean',
+    type: 'boolean',
   },
   notifyMode: {
     default: 'failure-change',
     description: 'Specifies when notifications will appear for test results.',
-    type: 'string' as 'string',
+    type: 'string',
   },
   onlyChanged: {
     alias: 'o',
@@ -414,84 +414,84 @@ export const options = {
       'Attempts to identify which tests to run based on which ' +
       "files have changed in the current repository. Only works if you're " +
       'running tests in a git or hg repository at the moment.',
-    type: 'boolean' as 'boolean',
+    type: 'boolean',
   },
   onlyFailures: {
     alias: 'f',
     default: undefined,
     description: 'Run tests that failed in the previous execution.',
-    type: 'boolean' as 'boolean',
+    type: 'boolean',
   },
   outputFile: {
     description:
       'Write test results to a file when the --json option is ' +
       'also specified.',
-    type: 'string' as 'string',
+    type: 'string',
   },
   passWithNoTests: {
     default: false,
     description:
       'Will not fail if no tests are found (for example while using `--testPathPattern`.)',
-    type: 'boolean' as 'boolean',
+    type: 'boolean',
   },
   preset: {
     description: "A preset that is used as a base for Jest's configuration.",
-    type: 'string' as 'string',
+    type: 'string',
   },
   prettierPath: {
     default: undefined,
     description: 'The path to the "prettier" module used for inline snapshots.',
-    type: 'string' as 'string',
+    type: 'string',
   },
   projects: {
     description:
       'A list of projects that use Jest to run all tests of all ' +
       'projects in a single instance of Jest.',
     string: true as true,
-    type: 'array' as 'array',
+    type: 'array',
   },
   reporters: {
     description: 'A list of custom reporters for the test suite.',
     string: true as true,
-    type: 'array' as 'array',
+    type: 'array',
   },
   resetMocks: {
     default: undefined,
     description:
       'Automatically reset mock state between every test. ' +
       'Equivalent to calling jest.resetAllMocks() between each test.',
-    type: 'boolean' as 'boolean',
+    type: 'boolean',
   },
   resetModules: {
     default: undefined,
     description:
       'If enabled, the module registry for every test file will ' +
       'be reset before running each individual test.',
-    type: 'boolean' as 'boolean',
+    type: 'boolean',
   },
   resolver: {
     description: 'A JSON string which allows the use of a custom resolver.',
-    type: 'string' as 'string',
+    type: 'string',
   },
   restoreMocks: {
     default: undefined,
     description:
       'Automatically restore mock state and implementation between every test. ' +
       'Equivalent to calling jest.restoreAllMocks() between each test.',
-    type: 'boolean' as 'boolean',
+    type: 'boolean',
   },
   rootDir: {
     description:
       'The root directory that Jest should scan for tests and ' +
       'modules within.',
-    type: 'string' as 'string',
+    type: 'string',
   },
   roots: {
     description:
       'A list of paths to directories that Jest should use to ' +
       'search for files in.',
     string: true as true,
-    type: 'array' as 'array',
+    type: 'array',
   },
   runInBand: {
     alias: 'i',
@@ -501,7 +501,7 @@ export const options = {
       'creating a worker pool of child processes that run tests). This ' +
       'is sometimes useful for debugging, but such use cases are pretty ' +
       'rare.',
-    type: 'boolean' as 'boolean',
+    type: 'boolean',
   },
   runTestsByPath: {
     default: false,
@@ -509,79 +509,79 @@ export const options = {
       'Used when provided patterns are exact file paths. This avoids ' +
       'converting them into a regular expression and matching it against ' +
       'every single file.',
-    type: 'boolean' as 'boolean',
+    type: 'boolean',
   },
   runner: {
     description:
       "Allows to use a custom runner instead of Jest's default test runner.",
-    type: 'string' as 'string',
+    type: 'string',
   },
   setupFiles: {
     description:
       'A list of paths to modules that run some code to configure or ' +
       'set up the testing environment before each test. ',
     string: true as true,
-    type: 'array' as 'array',
+    type: 'array',
   },
   setupFilesAfterEnv: {
     description:
       'A list of paths to modules that run some code to configure or ' +
       'set up the testing framework before each test ',
     string: true as true,
-    type: 'array' as 'array',
+    type: 'array',
   },
   showConfig: {
     default: undefined,
     description: 'Print your jest config and then exits.',
-    type: 'boolean' as 'boolean',
+    type: 'boolean',
   },
   silent: {
     default: undefined,
     description: 'Prevent tests from printing messages through the console.',
-    type: 'boolean' as 'boolean',
+    type: 'boolean',
   },
   skipFilter: {
     default: undefined,
     description:
       'Disables the filter provided by --filter. Useful for CI jobs, or ' +
       'local enforcement when fixing tests.',
-    type: 'boolean' as 'boolean',
+    type: 'boolean',
   },
   snapshotSerializers: {
     description:
       'A list of paths to snapshot serializer modules Jest should ' +
       'use for snapshot testing.',
     string: true as true,
-    type: 'array' as 'array',
+    type: 'array',
   },
   testEnvironment: {
     description: 'Alias for --env',
-    type: 'string' as 'string',
+    type: 'string',
   },
   testEnvironmentOptions: {
     description:
       'Test environment options that will be passed to the testEnvironment. ' +
       'The relevant options depend on the environment.',
-    type: 'string' as 'string', // Object
+    type: 'string', // Object
   },
   testFailureExitCode: {
     description: 'Exit code of `jest` command if the test run failed',
-    type: 'string' as 'string', // number
+    type: 'string', // number
   },
   testLocationInResults: {
     default: false,
     description: 'Add `location` information to the test results',
-    type: 'boolean' as 'boolean',
+    type: 'boolean',
   },
   testMatch: {
     description: 'The glob patterns Jest uses to detect test files.',
     string: true as true,
-    type: 'array' as 'array',
+    type: 'array',
   },
   testNamePattern: {
     alias: 't',
     description: 'Run only tests with a name that matches the regex pattern.',
-    type: 'string' as 'string',
+    type: 'string',
   },
   testPathIgnorePatterns: {
     description:
@@ -589,68 +589,68 @@ export const options = {
       'against all test paths before executing the test. If the test path ' +
       'matches any of the patterns, it will be skipped.',
     string: true as true,
-    type: 'array' as 'array',
+    type: 'array',
   },
   testPathPattern: {
     description:
       'A regexp pattern string that is matched against all tests ' +
       'paths before executing the test.',
     string: true as true,
-    type: 'array' as 'array',
+    type: 'array',
   },
   testRegex: {
     description:
       'A string or array of string regexp patterns that Jest uses to detect test files.',
     string: true as true,
-    type: 'array' as 'array',
+    type: 'array',
   },
   testResultsProcessor: {
     description:
       'Allows the use of a custom results processor. ' +
       'This processor must be a node module that exports ' +
       'a function expecting as the first argument the result object.',
-    type: 'string' as 'string',
+    type: 'string',
   },
   testRunner: {
     description:
       'Allows to specify a custom test runner. The default is ' +
       ' `jasmine2`. A path to a custom test runner can be provided: ' +
       '`<rootDir>/path/to/testRunner.js`.',
-    type: 'string' as 'string',
+    type: 'string',
   },
   testSequencer: {
     description:
       'Allows to specify a custom test sequencer. The default is ' +
       '`@jest/test-sequencer`. A path to a custom test sequencer can be ' +
       'provided: `<rootDir>/path/to/testSequencer.js`',
-    type: 'string' as 'string',
+    type: 'string',
   },
   testTimeout: {
     description: 'This option sets the default timeouts of test cases.',
-    type: 'number' as 'number',
+    type: 'number',
   },
   testURL: {
     description: 'This option sets the URL for the jsdom environment.',
-    type: 'string' as 'string',
+    type: 'string',
   },
   timers: {
     description:
       'Setting this value to fake allows the use of fake timers ' +
       'for functions such as setTimeout.',
-    type: 'string' as 'string',
+    type: 'string',
   },
   transform: {
     description:
       'A JSON string which maps from regular expressions to paths ' +
       'to transformers.',
-    type: 'string' as 'string',
+    type: 'string',
   },
   transformIgnorePatterns: {
     description:
       'An array of regexp pattern strings that are matched ' +
       'against all source file paths before transformation.',
     string: true as true,
-    type: 'array' as 'array',
+    type: 'array',
   },
   unmockedModulePathPatterns: {
     description:
@@ -658,7 +658,7 @@ export const options = {
       'against all modules before the module loader will automatically ' +
       'return a mock for them.',
     string: true as true,
-    type: 'array' as 'array',
+    type: 'array',
   },
   updateSnapshot: {
     alias: 'u',
@@ -668,24 +668,24 @@ export const options = {
       'Can be used together with a test suite pattern or with ' +
       '`--testNamePattern` to re-record snapshot for test matching ' +
       'the pattern',
-    type: 'boolean' as 'boolean',
+    type: 'boolean',
   },
   useStderr: {
     default: undefined,
     description: 'Divert all output to stderr.',
-    type: 'boolean' as 'boolean',
+    type: 'boolean',
   },
   verbose: {
     default: undefined,
     description:
       'Display individual test results with the test suite hierarchy.',
-    type: 'boolean' as 'boolean',
+    type: 'boolean',
   },
   version: {
     alias: 'v',
     default: undefined,
     description: 'Print the version and exit',
-    type: 'boolean' as 'boolean',
+    type: 'boolean',
   },
   watch: {
     default: undefined,
@@ -693,7 +693,7 @@ export const options = {
       'Watch files for changes and rerun tests related to ' +
       'changed files. If you want to re-run all tests when a file has ' +
       'changed, use the `--watchAll` option.',
-    type: 'boolean' as 'boolean',
+    type: 'boolean',
   },
   watchAll: {
     default: undefined,
@@ -701,7 +701,7 @@ export const options = {
       'Watch files for changes and rerun all tests. If you want ' +
       'to re-run only the tests related to the changed files, use the ' +
       '`--watch` option.',
-    type: 'boolean' as 'boolean',
+    type: 'boolean',
   },
   watchPathIgnorePatterns: {
     description:
@@ -709,13 +709,13 @@ export const options = {
       'against all paths before trigger test re-run in watch mode. ' +
       'If the test path matches any of the patterns, it will be skipped.',
     string: true as true,
-    type: 'array' as 'array',
+    type: 'array',
   },
   watchman: {
     default: undefined,
     description:
       'Whether to use watchman for file crawling. Disable using ' +
       '--no-watchman.',
-    type: 'boolean' as 'boolean',
+    type: 'boolean',
   },
-};
+} as const;

--- a/packages/jest-cli/src/cli/args.ts
+++ b/packages/jest-cli/src/cli/args.ts
@@ -159,7 +159,7 @@ export const options = {
   },
   collectCoverageOnlyFrom: {
     description: 'Explicit list of paths coverage will be restricted to.',
-    string: true as true,
+    string: true,
     type: 'array',
   },
   color: {
@@ -199,14 +199,14 @@ export const options = {
       'An array of regexp pattern strings that are matched ' +
       'against all file paths before executing the test. If the file path' +
       'matches any of the patterns, coverage information will be skipped.',
-    string: true as true,
+    string: true,
     type: 'array',
   },
   coverageReporters: {
     description:
       'A list of reporter names that Jest uses when writing ' +
       'coverage reports. Any istanbul reporter can be used.',
-    string: true as true,
+    string: true,
     type: 'array',
   },
   coverageThreshold: {
@@ -358,7 +358,7 @@ export const options = {
     description:
       'An array of directory names to be searched recursively ' +
       "up from the requiring module's location.",
-    string: true as true,
+    string: true,
     type: 'array',
   },
   moduleFileExtensions: {
@@ -366,7 +366,7 @@ export const options = {
       'An array of file extensions your modules use. If you ' +
       'require modules without specifying a file extension, these are the ' +
       'extensions Jest will look for. ',
-    string: true as true,
+    string: true,
     type: 'array',
   },
   moduleNameMapper: {
@@ -381,7 +381,7 @@ export const options = {
       'An array of regexp pattern strings that are matched ' +
       'against all module paths before those paths are to be considered ' +
       '"visible" to the module loader.',
-    string: true as true,
+    string: true,
     type: 'array',
   },
   modulePaths: {
@@ -389,7 +389,7 @@ export const options = {
       'An alternative API to setting the NODE_PATH env variable, ' +
       'modulePaths is an array of absolute paths to additional locations to ' +
       'search when resolving modules.',
-    string: true as true,
+    string: true,
     type: 'array',
   },
   noStackTrace: {
@@ -447,12 +447,12 @@ export const options = {
     description:
       'A list of projects that use Jest to run all tests of all ' +
       'projects in a single instance of Jest.',
-    string: true as true,
+    string: true,
     type: 'array',
   },
   reporters: {
     description: 'A list of custom reporters for the test suite.',
-    string: true as true,
+    string: true,
     type: 'array',
   },
   resetMocks: {
@@ -490,7 +490,7 @@ export const options = {
     description:
       'A list of paths to directories that Jest should use to ' +
       'search for files in.',
-    string: true as true,
+    string: true,
     type: 'array',
   },
   runInBand: {
@@ -520,14 +520,14 @@ export const options = {
     description:
       'A list of paths to modules that run some code to configure or ' +
       'set up the testing environment before each test. ',
-    string: true as true,
+    string: true,
     type: 'array',
   },
   setupFilesAfterEnv: {
     description:
       'A list of paths to modules that run some code to configure or ' +
       'set up the testing framework before each test ',
-    string: true as true,
+    string: true,
     type: 'array',
   },
   showConfig: {
@@ -551,7 +551,7 @@ export const options = {
     description:
       'A list of paths to snapshot serializer modules Jest should ' +
       'use for snapshot testing.',
-    string: true as true,
+    string: true,
     type: 'array',
   },
   testEnvironment: {
@@ -575,7 +575,7 @@ export const options = {
   },
   testMatch: {
     description: 'The glob patterns Jest uses to detect test files.',
-    string: true as true,
+    string: true,
     type: 'array',
   },
   testNamePattern: {
@@ -588,20 +588,20 @@ export const options = {
       'An array of regexp pattern strings that are matched ' +
       'against all test paths before executing the test. If the test path ' +
       'matches any of the patterns, it will be skipped.',
-    string: true as true,
+    string: true,
     type: 'array',
   },
   testPathPattern: {
     description:
       'A regexp pattern string that is matched against all tests ' +
       'paths before executing the test.',
-    string: true as true,
+    string: true,
     type: 'array',
   },
   testRegex: {
     description:
       'A string or array of string regexp patterns that Jest uses to detect test files.',
-    string: true as true,
+    string: true,
     type: 'array',
   },
   testResultsProcessor: {
@@ -649,7 +649,7 @@ export const options = {
     description:
       'An array of regexp pattern strings that are matched ' +
       'against all source file paths before transformation.',
-    string: true as true,
+    string: true,
     type: 'array',
   },
   unmockedModulePathPatterns: {
@@ -657,7 +657,7 @@ export const options = {
       'An array of regexp pattern strings that are matched ' +
       'against all modules before the module loader will automatically ' +
       'return a mock for them.',
-    string: true as true,
+    string: true,
     type: 'array',
   },
   updateSnapshot: {
@@ -708,7 +708,7 @@ export const options = {
       'An array of regexp pattern strings that are matched ' +
       'against all paths before trigger test re-run in watch mode. ' +
       'If the test path matches any of the patterns, it will be skipped.',
-    string: true as true,
+    string: true,
     type: 'array',
   },
   watchman: {

--- a/packages/jest-config/src/ValidConfig.ts
+++ b/packages/jest-config/src/ValidConfig.ts
@@ -39,9 +39,9 @@ const initialOptions: Config.InitialOptions = {
   },
   dependencyExtractor: '<rootDir>/dependencyExtractor.js',
   displayName: multipleValidOptions('test-config', {
-    color: 'blue' as 'blue',
+    color: 'blue',
     name: 'test-config',
-  }),
+  } as const),
   errorOnDeprecated: false,
   expand: false,
   extraGlobals: [],

--- a/packages/jest-transform/src/ScriptTransformer.ts
+++ b/packages/jest-transform/src/ScriptTransformer.ts
@@ -176,7 +176,11 @@ export default class ScriptTransformer {
         return transformer;
       }
 
-      transform = require(transformPath) as Transformer;
+      transform = require(transformPath);
+
+      if (!transform) {
+        throw new TypeError('Jest: a transform must export something.');
+      }
       const transformerConfig = this._transformConfigCache.get(transformPath);
       if (typeof transform.createTransformer === 'function') {
         transform = transform.createTransformer(transformerConfig);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

We've upgraded to a version of Babel that supports this syntax

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Green CI

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
