### PR TITLE
jest-snapshot: Distinguish empty string from external snapshot not written

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - `[jest-leak-detector]` [**BREAKING**] Use `weak-napi` instead of `weak` package ([#8686](https://github.com/facebook/jest/pull/8686))
 - `[jest-mock]` Fix for mockReturnValue overriding mockImplementationOnce ([#8398](https://github.com/facebook/jest/pull/8398))
 - `[jest-snapshot]` Remove only the added newlines in multiline snapshots ([#8859](https://github.com/facebook/jest/pull/8859))
+- `[jest-snapshot]` Distinguish empty string from external snapshot not written ([#8880](https://github.com/facebook/jest/pull/8880))
 
 ### Chore & Maintenance
 

--- a/e2e/__tests__/toMatchSnapshotWithStringSerializer.test.ts
+++ b/e2e/__tests__/toMatchSnapshotWithStringSerializer.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import * as path from 'path';
+import {cleanup, makeTemplate, writeFiles} from '../Utils';
+import runJest from '../runJest';
+
+const DIR = path.resolve(
+  __dirname,
+  '../to-match-snapshot-with-string-serializer',
+);
+const TESTS_DIR = path.resolve(DIR, '__tests__');
+
+beforeEach(() => cleanup(TESTS_DIR));
+afterAll(() => cleanup(TESTS_DIR));
+
+test('empty external', () => {
+  // Make sure empty string as expected value of external snapshot
+  // is not confused with new snapshot not written because of --ci option.
+  const filename = 'empty-external.test.js';
+  const template = makeTemplate(
+    `test('string serializer', () => { expect($1).toMatchSnapshot(); })`,
+  );
+
+  {
+    writeFiles(TESTS_DIR, {
+      [filename]: template(['""']), // empty string
+    });
+    const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+    expect(stderr).toMatch('1 snapshot written from 1 test suite.');
+    expect(status).toBe(0);
+  }
+
+  {
+    const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+    expect(stderr).toMatch('Snapshots:   1 passed, 1 total');
+    expect(stderr).not.toMatch('1 snapshot written from 1 test suite.');
+    expect(status).toBe(0);
+  }
+
+  {
+    writeFiles(TESTS_DIR, {
+      [filename]: template(['"non-empty"']),
+    });
+    const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+    expect(stderr).toMatch('Snapshots:   1 failed, 1 total');
+    expect(stderr).not.toMatch('not written'); // not confused with --ci option
+    expect(stderr).toMatch(/- Snapshot|Snapshot:/); // ordinary report
+    expect(status).toBe(1);
+  }
+});

--- a/e2e/to-match-snapshot-with-string-serializer/package.json
+++ b/e2e/to-match-snapshot-with-string-serializer/package.json
@@ -1,0 +1,8 @@
+{
+  "jest": {
+    "testEnvironment": "node",
+    "snapshotSerializers": [
+      "./serializers/string"
+    ]
+  }
+}

--- a/e2e/to-match-snapshot-with-string-serializer/serializers/string.js
+++ b/e2e/to-match-snapshot-with-string-serializer/serializers/string.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+// Serialize string (especially empty) without enclosing punctuation.
+module.exports = {
+  print: val => val,
+  test: val => typeof val === 'string',
+};

--- a/packages/jest-snapshot/src/State.ts
+++ b/packages/jest-snapshot/src/State.ts
@@ -185,7 +185,7 @@ export default class SnapshotState {
     // Do not mark the snapshot as "checked" if the snapshot is inline and
     // there's an external snapshot. This way the external snapshot can be
     // removed with `--updateSnapshot`.
-    if (!(isInline && this._snapshotData[key])) {
+    if (!(isInline && this._snapshotData[key] !== undefined)) {
       this._uncheckedKeys.delete(key);
     }
 
@@ -248,7 +248,7 @@ export default class SnapshotState {
         return {
           actual: unescape(receivedSerialized),
           count,
-          expected: expected ? unescape(expected) : null,
+          expected: expected !== undefined ? unescape(expected) : null,
           key,
           pass: false,
         };

--- a/packages/jest-snapshot/src/State.ts
+++ b/packages/jest-snapshot/src/State.ts
@@ -35,6 +35,14 @@ export type SnapshotMatchOptions = {
   error?: Error;
 };
 
+type SnapshotReturnOptions = {
+  actual: string;
+  count: number;
+  expected?: string;
+  key: string;
+  pass: boolean;
+};
+
 export default class SnapshotState {
   private _counters: Map<string, number>;
   private _dirty: boolean;
@@ -173,7 +181,7 @@ export default class SnapshotState {
     key,
     inlineSnapshot,
     error,
-  }: SnapshotMatchOptions) {
+  }: SnapshotMatchOptions): SnapshotReturnOptions {
     this._counters.set(testName, (this._counters.get(testName) || 0) + 1);
     const count = Number(this._counters.get(testName));
     const isInline = inlineSnapshot !== undefined;

--- a/packages/jest-snapshot/src/State.ts
+++ b/packages/jest-snapshot/src/State.ts
@@ -248,7 +248,7 @@ export default class SnapshotState {
         return {
           actual: unescape(receivedSerialized),
           count,
-          expected: expected !== undefined ? unescape(expected) : null,
+          expected: expected !== undefined ? unescape(expected) : undefined,
           key,
           pass: false,
         };

--- a/packages/jest-snapshot/src/index.ts
+++ b/packages/jest-snapshot/src/index.ts
@@ -340,7 +340,7 @@ const _toMatchSnapshot = ({
   let report: () => string;
   if (pass) {
     return {message: () => '', pass: true};
-  } else if (!expected) {
+  } else if (expected == null) {
     report = () =>
       `New snapshot was ${RECEIVED_COLOR('not written')}. The update flag ` +
       `must be explicitly passed to write a new snapshot.\n\n` +

--- a/packages/jest-snapshot/src/index.ts
+++ b/packages/jest-snapshot/src/index.ts
@@ -340,7 +340,7 @@ const _toMatchSnapshot = ({
   let report: () => string;
   if (pass) {
     return {message: () => '', pass: true};
-  } else if (expected == null) {
+  } else if (expected === undefined) {
     report = () =>
       `New snapshot was ${RECEIVED_COLOR('not written')}. The update flag ` +
       `must be explicitly passed to write a new snapshot.\n\n` +

--- a/packages/jest-snapshot/src/index.ts
+++ b/packages/jest-snapshot/src/index.ts
@@ -349,8 +349,8 @@ const _toMatchSnapshot = ({
       `${RECEIVED_COLOR('Received value')} ` +
       `${actual}`;
   } else {
-    expected = utils.removeExtraLineBreaks(expected || '');
-    actual = utils.removeExtraLineBreaks(actual || '');
+    expected = utils.removeExtraLineBreaks(expected);
+    actual = utils.removeExtraLineBreaks(actual);
 
     // Assign to local variable because of declaration let expected:
     // TypeScript thinks it could change before report function is called.


### PR DESCRIPTION
## Summary

When I tested the report for edge case that snapshot is **empty string** from custom serializer and received value is non-empty string, Jest confused it with new snapshot not written:

<img width="800" alt="snapshot empty string 1" src="https://user-images.githubusercontent.com/11862657/63712037-cc0ad180-c80a-11e9-845a-bc26c5ef23eb.png">

Fixed three places where the code distinguished snapshot from no snapshot:

* baseline: truthy versus falsey
* improved: string versus undefined (or nil, see Question) following example of code snippet:

```js
    const hasSnapshot = isInline
      ? inlineSnapshot !== ''
      : this._snapshotData[key] !== undefined;
```

**Question**: What do you think about the conditional expression where `undefined` becomes `null` in the object that `match` returns? I am trying to keep the changes in complicated code to a minimum, but it fails the `grep` test to be able to find `undefined` :(

**Residue**:

* The test feedback above does not include the snapshot name
* Inline snapshots also have problems with empty string versus undefined

## Test plan

The test `does not save snapshots in CI mode by default` still passes in e2e `snapshot.test.ts`

Also a local test of new snapshot with `--ci` option passed before and after

Here is the report when the local test fails for the correct reason:

<img width="800" alt="snapshot empty string 2" src="https://user-images.githubusercontent.com/11862657/63712045-d200b280-c80a-11e9-87a7-85e30c547e9e.png">

I guess I had better get comfortable writing e2e tests for snapshots ;)