### PR TITLE
chore: Delete obsolete FlowFixMe comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - `[*]` [**BREAKING**] Drop support for Node 6 ([#8455](https://github.com/facebook/jest/pull/8455))
 - `[*]` Add Node 12 to CI ([#8411](https://github.com/facebook/jest/pull/8411))
 - `[*]` [**BREAKING**] Upgrade to Micromatch v4 ([#8852](https://github.com/facebook/jest/pull/8852))
+- `[*]` Delete obsolete `$FlowFixMe` comments ([#8885](https://github.com/facebook/jest/pull/8885))
 - `[babel-plugin-jest-hoist]` [**BREAKING**] Use ESM exports ([#8874](https://github.com/facebook/jest/pull/8874))
 - `[docs]` Fix broken link pointing to legacy JS file in "Snapshot Testing".
 - `[jest]` [**BREAKING**] Use ESM exports ([#8874](https://github.com/facebook/jest/pull/8874))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@
 - `[*]` [**BREAKING**] Drop support for Node 6 ([#8455](https://github.com/facebook/jest/pull/8455))
 - `[*]` Add Node 12 to CI ([#8411](https://github.com/facebook/jest/pull/8411))
 - `[*]` [**BREAKING**] Upgrade to Micromatch v4 ([#8852](https://github.com/facebook/jest/pull/8852))
-- `[*]` Delete obsolete `$FlowFixMe` comments ([#8885](https://github.com/facebook/jest/pull/8885))
 - `[babel-plugin-jest-hoist]` [**BREAKING**] Use ESM exports ([#8874](https://github.com/facebook/jest/pull/8874))
 - `[docs]` Fix broken link pointing to legacy JS file in "Snapshot Testing".
 - `[jest]` [**BREAKING**] Use ESM exports ([#8874](https://github.com/facebook/jest/pull/8874))

--- a/e2e/__tests__/__snapshots__/failures.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/failures.test.ts.snap
@@ -265,14 +265,14 @@ FAIL __tests__/testMacro.test.js
     Expected: 2
     Received: 1
 
-      10 | 
-      11 | module.exports = (one: any, two: any) => {
-    > 12 |   expect(one).toEqual(two);
+       8 | 
+       9 | module.exports = (one: any, two: any) => {
+    > 10 |   expect(one).toEqual(two);
          |               ^
-      13 | };
-      14 | 
+      11 | };
+      12 | 
 
-      at toEqual (macros.js:12:15)
+      at toEqual (macros.js:10:15)
       at Object.shouldEqual (__tests__/testMacro.test.js:13:3)
 `;
 

--- a/e2e/__tests__/detectOpenHandles.ts
+++ b/e2e/__tests__/detectOpenHandles.ts
@@ -9,7 +9,6 @@ import {wrap} from 'jest-snapshot-serializer-raw';
 import runJest, {until} from '../runJest';
 
 try {
-  // $FlowFixMe: Node core
   require('async_hooks');
 } catch (e) {
   if (e.code === 'MODULE_NOT_FOUND') {

--- a/e2e/__tests__/iterator-to-null-test.ts
+++ b/e2e/__tests__/iterator-to-null-test.ts
@@ -8,9 +8,7 @@
 
 'use strict';
 
-// $FlowFixMe
 Array.prototype[Symbol.iterator] = null;
-// $FlowFixMe
 String.prototype[Symbol.iterator] = null;
 
 test('modifying global object does not affect test runner', () => {});

--- a/e2e/__tests__/snapshot.test.ts
+++ b/e2e/__tests__/snapshot.test.ts
@@ -107,7 +107,6 @@ describe('Snapshot', () => {
     expect(json.numPendingTests).toBe(0);
     expect(result.status).toBe(0);
 
-    // $FlowFixMe dynamic require
     const content = require(snapshotFile);
     expect(
       content['snapshot is not influenced by previous counter 1'],
@@ -238,7 +237,6 @@ describe('Snapshot', () => {
     it('works on subsequent runs without `-u`', () => {
       const firstRun = runWithJson('snapshot', ['-w=1', '--ci=false']);
 
-      // $FlowFixMe dynamic require
       const content = require(snapshotOfCopy);
       expect(content).not.toBe(undefined);
       const secondRun = runWithJson('snapshot', []);
@@ -257,7 +255,6 @@ describe('Snapshot', () => {
       const firstRun = runWithJson('snapshot', ['-w=1', '--ci=false']);
       fs.unlinkSync(copyOfTestPath);
 
-      // $FlowFixMe dynamic require
       const content = require(snapshotOfCopy);
       expect(content).not.toBe(undefined);
       const secondRun = runWithJson('snapshot', ['-w=1', '--ci=false', '-u']);

--- a/e2e/__tests__/snapshotMockFs.test.ts
+++ b/e2e/__tests__/snapshotMockFs.test.ts
@@ -28,7 +28,6 @@ test('store snapshot even if fs is mocked', () => {
   expect(stderr).toMatch('1 snapshot written from 1 test suite.');
   expect(wrap(extractSummary(stderr).summary)).toMatchSnapshot();
 
-  // $FlowFixMe dynamic require
   const content = require(snapshotFile);
   expect(content['snapshot 1']).toBe(`
 Object {

--- a/e2e/__tests__/snapshotResolver.test.ts
+++ b/e2e/__tests__/snapshotResolver.test.ts
@@ -33,7 +33,6 @@ describe('Custom snapshot resolver', () => {
 
     expect(result.stderr).toMatch('1 snapshot written from 1 test suite');
 
-    // $FlowFixMe dynamic require
     const content = require(snapshotFile);
     expect(content).toHaveProperty(
       'snapshots are written to custom location 1',

--- a/e2e/__tests__/snapshotSerializers.test.ts
+++ b/e2e/__tests__/snapshotSerializers.test.ts
@@ -33,7 +33,6 @@ describe('Snapshot serializers', () => {
 
   it('renders snapshot', () => {
     runAndAssert();
-    // $FlowFixMe dynamic require
     const snapshot = require(snapshotPath);
     expect(snapshot).toMatchSnapshot();
   });

--- a/e2e/auto-clear-mocks/with-auto-clear/index.js
+++ b/e2e/auto-clear-mocks/with-auto-clear/index.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- * @flow
  */
 
 module.exports = () => {};

--- a/e2e/bad-source-map/__tests__/badSourceMap.js
+++ b/e2e/bad-source-map/__tests__/badSourceMap.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- * @flow
  */
 'use strict';
 

--- a/e2e/clear-cache/__tests__/clearCache.test.js
+++ b/e2e/clear-cache/__tests__/clearCache.test.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- * @flow
  */
 'use strict';
 

--- a/e2e/failures/macros.js
+++ b/e2e/failures/macros.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- * @flow
  */
 'use strict';
 

--- a/e2e/mock-names/with-empty-mock-name-not-called/index.js
+++ b/e2e/mock-names/with-empty-mock-name-not-called/index.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- * @flow
  */
 
 module.exports = () => {};

--- a/e2e/mock-names/with-empty-mock-name/index.js
+++ b/e2e/mock-names/with-empty-mock-name/index.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- * @flow
  */
 
 module.exports = () => {};

--- a/e2e/mock-names/with-mock-name-call-times-fail/index.js
+++ b/e2e/mock-names/with-mock-name-call-times-fail/index.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- * @flow
  */
 
 module.exports = () => {};

--- a/e2e/mock-names/with-mock-name-call-times-pass/index.js
+++ b/e2e/mock-names/with-mock-name-call-times-pass/index.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- * @flow
  */
 
 module.exports = () => {};

--- a/e2e/mock-names/with-mock-name-not-called-fail/index.js
+++ b/e2e/mock-names/with-mock-name-not-called-fail/index.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- * @flow
  */
 
 module.exports = () => {};

--- a/e2e/mock-names/with-mock-name-not-called-pass/index.js
+++ b/e2e/mock-names/with-mock-name-not-called-pass/index.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- * @flow
  */
 
 module.exports = () => {};

--- a/e2e/mock-names/with-mock-name-not-called/index.js
+++ b/e2e/mock-names/with-mock-name-not-called/index.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- * @flow
  */
 
 module.exports = () => {};

--- a/e2e/mock-names/with-mock-name/index.js
+++ b/e2e/mock-names/with-mock-name/index.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- * @flow
  */
 
 module.exports = () => {};

--- a/e2e/mock-names/without-mock-name-not-called/index.js
+++ b/e2e/mock-names/without-mock-name-not-called/index.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- * @flow
  */
 
 module.exports = () => {};

--- a/e2e/mock-names/without-mock-name/index.js
+++ b/e2e/mock-names/without-mock-name/index.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- * @flow
  */
 
 module.exports = () => {};

--- a/e2e/override-globals/index.js
+++ b/e2e/override-globals/index.js
@@ -3,8 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- * @flow
  */
 
 global.Promise = function() {

--- a/e2e/run-programmatically/index.js
+++ b/e2e/run-programmatically/index.js
@@ -4,8 +4,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- * @flow
  */
 
 require('@babel/register');


### PR DESCRIPTION
## Summary

As far as I can find, this is the last of them:

* 1 in `./e2e/__tests__/detectOpenHandles.ts`
* 2 in `./e2e/__tests__/iterator-to-null-test.ts`
* 3 in `./e2e/__tests__/snapshot.test.ts`
* 1 in `./e2e/__tests__/snapshotMockFs.test.ts`
* 1 in `./e2e/__tests__/snapshotResolver.test.ts`
* 1 in `./e2e/__tests__/snapshotSerializers.test.ts`

EDIT here is the command that I used to find those file in the project:

```sh
fgrep -lr --exclude-dir 'node_modules' --include '*.[j|t]s' '$FlowFixMe' .
```

## Test plan

Local lint and tests, and then CI