### PR TITLE
Explore use of require.resolve() in jest-resolve.

### DIFF
--- a/packages/jest-resolve/src/defaultResolver.ts
+++ b/packages/jest-resolve/src/defaultResolver.ts
@@ -67,17 +67,11 @@ function resolveSync(
     }
   } else {
     // otherwise search for node_modules
-    const dirs = nodeModulesPaths(basedir, {
+    const paths = nodeModulesPaths(basedir, {
       moduleDirectory: options.moduleDirectory,
       paths,
     });
-    for (let i = 0; i < dirs.length; i++) {
-      const resolveTarget = path.join(dirs[i], target);
-      const result = tryResolve(resolveTarget);
-      if (result) {
-        return result;
-      }
-    }
+    return require.resolve(target, { paths });
   }
 
   if (isBuiltinModule(target)) {
@@ -123,26 +117,11 @@ function resolveSync(
   }
 
   function resolveAsDirectory(name: Config.Path): Config.Path | undefined {
-    if (!isDirectory(name)) {
-      return undefined;
-    }
-
-    const pkgfile = path.join(name, 'package.json');
-    let pkgmain;
     try {
-      const body = fs.readFileSync(pkgfile, 'utf8');
-      pkgmain = JSON.parse(body).main;
-    } catch (e) {}
-
-    if (pkgmain && !isCurrentDirectory(pkgmain)) {
-      const resolveTarget = path.resolve(name, pkgmain);
-      const result = tryResolve(resolveTarget);
-      if (result) {
-        return result;
-      }
+      return require.resolve(name);
+    } catch {
+      return undefined
     }
-
-    return resolveAsFile(path.join(name, 'index'));
   }
 }
 
@@ -190,9 +169,4 @@ function isFile(file: Config.Path): boolean {
 
 function isDirectory(dir: Config.Path): boolean {
   return statSyncCached(dir) === IPathType.DIRECTORY;
-}
-
-const CURRENT_DIRECTORY = path.resolve('.');
-function isCurrentDirectory(testPath: Config.Path): boolean {
-  return CURRENT_DIRECTORY === path.resolve(testPath);
 }


### PR DESCRIPTION
* Simplified node_modules resolution in resolveSync()
* Drastically simplified resolveAsDirectory()
* Removed now obsolete helper function.

## Summary

First: This is meant as a base of discussion, not for actual merging. As I don't know all implications this change has, I did not commit fully to `require.resolve()`.

In the performance regression thread, the question was raised where jest-resolve and nodejs `require` differ in their way of resolving modules.  I stumbled onto [ `require.resolve()`](https://nodejs.org/api/modules.html#modules_require_resolve_request_options) when I looked into that.

That function only returns the path to the file, instead of actually loading it.

I found that, even with a conservative effort, I could replace quite a decent amount of code and thus reduce complexity. 

## Test plan

* Tested the change against an existing suite of tests.
* CI / CD
* Existing unit tests?

(Again, this isn't meant to be merged, just to discuss the approach)
