### PR TITLE
fix: cache transforms within a worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - `[jest-mock]` Fix for mockReturnValue overriding mockImplementationOnce ([#8398](https://github.com/facebook/jest/pull/8398))
 - `[jest-snapshot]` Remove only the added newlines in multiline snapshots ([#8859](https://github.com/facebook/jest/pull/8859))
 - `[jest-snapshot]` Distinguish empty string from external snapshot not written ([#8880](https://github.com/facebook/jest/pull/8880))
+- `[jest-transform]` Properly cache transformed files across tests ([#8890](https://github.com/facebook/jest/pull/8890))
 
 ### Chore & Maintenance
 

--- a/e2e/__tests__/transform.test.ts
+++ b/e2e/__tests__/transform.test.ts
@@ -187,23 +187,21 @@ describe('transformer-config', () => {
 });
 
 describe('transformer caching', () => {
-  const dir = path.resolve(__dirname, '..', 'transform/cache');
-  const dirRegexp = new RegExp('^' + dir);
+  const dir = path.resolve(__dirname, '../transform/cache');
+  const transformedFile = path.resolve(dir, './common-file.js');
 
   it('does not rerun transform within worker', () => {
     // --no-cache because babel can cache stuff and result in false green
     const {stdout} = runJest(dir, ['--no-cache', '-w=2']);
 
-    const loggedFiles = stdout.split('\n').map(line => {
-      expect(line).toMatch(dirRegexp);
+    const loggedFiles = stdout.split('\n');
 
-      return line.replace(dirRegexp, '<rootDir>');
+    // Verify any lines logged are _just_ the file we care about
+    loggedFiles.forEach(line => {
+      expect(line).toBe(transformedFile);
     });
 
     // We run with 2 workers, so the file should be transformed twice
-    expect(loggedFiles).toEqual([
-      '<rootDir>/common-file.js',
-      '<rootDir>/common-file.js',
-    ]);
+    expect(loggedFiles).toHaveLength(2);
   });
 });

--- a/e2e/__tests__/transform.test.ts
+++ b/e2e/__tests__/transform.test.ts
@@ -185,3 +185,25 @@ describe('transformer-config', () => {
     expect(stdout).toMatchSnapshot();
   });
 });
+
+describe('transformer caching', () => {
+  const dir = path.resolve(__dirname, '..', 'transform/cache');
+  const dirRegexp = new RegExp('^' + dir);
+
+  it('does not rerun transform within worker', () => {
+    // --no-cache because babel can cache stuff and result in false green
+    const {stdout} = runJest(dir, ['--no-cache', '-w=2']);
+
+    const loggedFiles = stdout.split('\n').map(line => {
+      expect(line).toMatch(dirRegexp);
+
+      return line.replace(dirRegexp, '<rootDir>');
+    });
+
+    // We run with 2 workers, so the file should be transformed twice
+    expect(loggedFiles).toEqual([
+      '<rootDir>/common-file.js',
+      '<rootDir>/common-file.js',
+    ]);
+  });
+});

--- a/e2e/transform/cache/__tests__/aTests.js
+++ b/e2e/transform/cache/__tests__/aTests.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const phrase = require('../common-file');
+
+test('A', () => {
+  expect(phrase).toBe('hello');
+});

--- a/e2e/transform/cache/__tests__/bTests.js
+++ b/e2e/transform/cache/__tests__/bTests.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const phrase = require('../common-file');
+
+test('B', () => {
+  expect(phrase).toBe('hello');
+});

--- a/e2e/transform/cache/__tests__/cTests.js
+++ b/e2e/transform/cache/__tests__/cTests.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const phrase = require('../common-file');
+
+test('C', () => {
+  expect(phrase).toBe('hello');
+});

--- a/e2e/transform/cache/__tests__/dTests.js
+++ b/e2e/transform/cache/__tests__/dTests.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const phrase = require('../common-file');
+
+test('D', () => {
+  expect(phrase).toBe('hello');
+});

--- a/e2e/transform/cache/common-file.js
+++ b/e2e/transform/cache/common-file.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+module.exports = 'hello';

--- a/e2e/transform/cache/package.json
+++ b/e2e/transform/cache/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "cache",
+  "version": "1.0.0",
+  "jest": {
+    "testEnvironment": "node",
+    "transform": {
+      "^.+\\.js$": "<rootDir>/transformer.js"
+    }
+  }
+}

--- a/e2e/transform/cache/transformer.js
+++ b/e2e/transform/cache/transformer.js
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+module.exports = {
+  process(src, path) {
+    if (path.includes('common')) {
+      console.log(path);
+    }
+
+    return src;
+  },
+};

--- a/packages/jest-transform/src/ScriptTransformer.ts
+++ b/packages/jest-transform/src/ScriptTransformer.ts
@@ -43,10 +43,7 @@ const {version: VERSION} = require('../package.json');
 // This data structure is used to avoid recalculating some data every time that
 // we need to transform a file. Since ScriptTransformer is instantiated for each
 // file we need to keep this object in the local scope of this module.
-const projectCaches: WeakMap<
-  Config.ProjectConfig,
-  ProjectCache
-> = new WeakMap();
+const projectCaches = new Map<string, ProjectCache>();
 
 // To reset the cache for specific changesets (rather than package version).
 const CACHE_VERSION = '1';
@@ -74,17 +71,18 @@ export default class ScriptTransformer {
     this._transformCache = new Map();
     this._transformConfigCache = new Map();
 
-    let projectCache = projectCaches.get(config);
+    const configString = stableStringify(this._config);
+    let projectCache = projectCaches.get(configString);
 
     if (!projectCache) {
       projectCache = {
-        configString: stableStringify(this._config),
+        configString,
         ignorePatternsRegExp: calcIgnorePatternRegExp(this._config),
         transformRegExp: calcTransformRegExp(this._config),
         transformedFiles: new Map(),
       };
 
-      projectCaches.set(config, projectCache);
+      projectCaches.set(configString, projectCache);
     }
 
     this._cache = projectCache;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

May or may not fix #7811, but it looks pretty good!

---

Due to the changes in #7186, we no longer cached transformed files between tests within a single worker. Not sure why, but we get a cache miss in the weakmap. Anyone has any good ideas?

@rafeca I realise you don't work at FB aymore, but FYI just in case you remember some context or have any comments 🙂 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Added test. Without the changes in `ScriptTransformer`, this is the result of the new test:

![image](https://user-images.githubusercontent.com/1404810/64001853-032dfb00-cb09-11e9-8f9e-f018857fbfc9.png)

(I've since tweaked this test to work on Windows, but it's still essentially accurate)

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
