### PR TITLE
fix: Jest multi project runner still cannot handle exactly one project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - `[expect]` Consider all RegExp flags for equality ([#9167](https://github.com/facebook/jest/pull/9167))
 - `[expect]` [**BREAKING**] Consider primitives different from wrappers instantiated with `new` ([#9167](https://github.com/facebook/jest/pull/9167))
 - `[jest-config]` Use half of the available cores when `watchAll` mode is enabled ([#9117](https://github.com/facebook/jest/pull/9117))
+- `[jest-config]` Fix Jest multi project runner still cannot handle exactly one project ([#8894](https://github.com/facebook/jest/pull/8894))
 - `[jest-console]` Add missing `console.group` calls to `NullConsole` ([#9024](https://github.com/facebook/jest/pull/9024))
 - `[jest-core]` Don't include unref'd timers in --detectOpenHandles results ([#8941](https://github.com/facebook/jest/pull/8941))
 - `[jest-diff]` Do not inverse format if line consists of one change ([#8903](https://github.com/facebook/jest/pull/8903))

--- a/e2e/__tests__/multiProjectRunner.test.ts
+++ b/e2e/__tests__/multiProjectRunner.test.ts
@@ -199,7 +199,57 @@ test.each([{projectPath: 'packages/somepackage'}, {projectPath: 'packages/*'}])(
     });
 
     const {stdout, stderr, exitCode} = runJest(DIR, ['--no-watchman']);
-    expect(stderr).toContain('PASS packages/somepackage/test.js');
+    expect(stderr).toContain('PASS somepackage packages/somepackage/test.js');
+    expect(stderr).toContain('Test Suites: 1 passed, 1 total');
+    expect(stdout).toEqual('');
+    expect(exitCode).toEqual(0);
+  },
+);
+
+test.each([
+  {displayName: 'p1', projectPath: 'packages/p1'},
+  {displayName: 'p2', projectPath: 'packages/p2'},
+])(
+  'correctly runs a single non-root project',
+  ({projectPath, displayName}: {projectPath: string; displayName: string}) => {
+    writeFiles(DIR, {
+      'package.json': `
+        {
+          "jest": {
+            "projects": [
+              "${projectPath}"
+            ]
+          }
+        }
+      `,
+      'packages/p1/package.json': `
+        {
+          "jest": {
+            "displayName": "p1"
+          }
+        }
+      `,
+      'packages/p1/test.js': `
+        test('1+1', () => {
+          expect(1).toBe(1);
+        });
+      `,
+      'packages/p2/package.json': `
+        {
+          "jest": {
+            "displayName": "p2"
+          }
+        }
+      `,
+      'packages/p2/test.js': `
+        test('1+1', () => {
+          expect(1).toBe(1);
+        });
+      `,
+    });
+
+    const {stdout, stderr, exitCode} = runJest(DIR, ['--no-watchman']);
+    expect(stderr).toContain(`PASS ${displayName} ${projectPath}/test.js`);
     expect(stderr).toContain('Test Suites: 1 passed, 1 total');
     expect(stdout).toEqual('');
     expect(exitCode).toEqual(0);

--- a/packages/jest-config/src/index.ts
+++ b/packages/jest-config/src/index.ts
@@ -9,6 +9,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import {Config} from '@jest/types';
 import chalk = require('chalk');
+import {sync as realpath} from 'realpath-native';
 import {isJSONString, replaceRootDirInPath} from './utils';
 import normalize from './normalize';
 import resolveConfigPath from './resolveConfigPath';
@@ -278,26 +279,24 @@ export function readConfigs(
     const parsedConfig = readConfig(argv, projects[0]);
     configPath = parsedConfig.configPath;
 
-    if (parsedConfig.globalConfig.projects) {
-      // If this was a single project, and its config has `projects`
-      // settings, use that value instead.
-      projects = parsedConfig.globalConfig.projects;
-    }
-
     hasDeprecationWarnings = parsedConfig.hasDeprecationWarnings;
     globalConfig = parsedConfig.globalConfig;
     configs = [parsedConfig.projectConfig];
     if (globalConfig.projects && globalConfig.projects.length) {
       // Even though we had one project in CLI args, there might be more
       // projects defined in the config.
+      // In other words, if this was a single project,
+      // and its config has `projects` settings, use that value instead.
       projects = globalConfig.projects;
     }
   }
 
-  if (
-    projects.length > 1 ||
-    (projects.length && typeof projects[0] === 'object')
-  ) {
+  if (projects.length > 0) {
+    const projectIsCwd =
+      process.platform === 'win32'
+        ? projects[0] === realpath(process.cwd())
+        : projects[0] === process.cwd();
+
     const parsedConfigs = projects
       .filter(root => {
         // Ignore globbed files that cannot be `require`d.
@@ -313,9 +312,19 @@ export function readConfigs(
 
         return true;
       })
-      .map((root, projectIndex) =>
-        readConfig(argv, root, true, configPath, projectIndex),
-      );
+      .map((root, projectIndex) => {
+        const projectIsTheOnlyProject =
+          projectIndex === 0 && projects.length === 1;
+        const skipArgvConfigOption = !(projectIsTheOnlyProject && projectIsCwd);
+
+        return readConfig(
+          argv,
+          root,
+          skipArgvConfigOption,
+          configPath,
+          projectIndex,
+        );
+      });
 
     ensureNoDuplicateConfigs(parsedConfigs, projects);
     configs = parsedConfigs.map(({projectConfig}) => projectConfig);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->


This PR adds a failing test case for #8860 ~~but I haven't had any clue on how to fix it~~ and I found a way to solve it, but I actually wonder if this is the best way to fix this. I guess I need input from the maintainers.

There are failing tests when I do the following change

```diff
-  if (
-    projects.length > 1 ||
-    (projects.length && typeof projects[0] === 'object')
-  ) {
+  if (projects.length > 0) {
```

The main issue was that at `readConfigs`, when calling `readConfig`, `skipArgvConfigOption` should only be `true` if the project is not "global". By global, I mean, it is not added from `getProjectListFromCLIArgs` using `process.cwd`. That's why I changed `getProjectListFromCLIArgs` to also return `isGlobalProject`.

Update: the implementation have changed based on suggestion during code review: https://github.com/facebook/jest/pull/8894#discussion_r344912982


## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Added unit test case :)