### PR TITLE
Refractor requireAndTranspileModule to use exts from moduleFileExtenstions

### DIFF
--- a/packages/jest-transform/src/ScriptTransformer.ts
+++ b/packages/jest-transform/src/ScriptTransformer.ts
@@ -475,7 +475,7 @@ export default class ScriptTransformer {
         }
       },
       {
-        exts: [path.extname(moduleName)],
+        exts: this._config.moduleFileExtensions.map(ext => `.${ext}`),
         ignoreNodeModules: false,
         matcher: filename => {
           if (transforming) {


### PR DESCRIPTION
## Summary

In the current implementation of `requireAndTranspileModule` the `extensions` used for pirates is determined by `path.extname`. `path.extname` returns empty string for directories, which resulted in `PnP` test failing in #8854. Restricting the extensions to the ones specified in `moduleFileExtensions`

/cc @SimenB @jeysal 

## Test plan

Existing tests should not break
All PRs related to #8810 should not be affected
