### PR TITLE
chore: get rid of custom abstraction on top of execa in e2e tests

### DIFF
--- a/e2e/Utils.ts
+++ b/e2e/Utils.ts
@@ -96,7 +96,7 @@ const NUMBER_OF_TESTS_TO_FORCE_USING_WORKERS = 25;
  * Slow and modifies the test output. Use sparingly.
  */
 export const generateTestFilesToForceUsingWorkers = () => {
-  const testFiles = {};
+  const testFiles: Record<string, string> = {};
   for (let i = 0; i <= NUMBER_OF_TESTS_TO_FORCE_USING_WORKERS; i++) {
     testFiles[`__tests__/test${i}.test.js`] = `
       test.todo('test ${i}');

--- a/e2e/__tests__/autoClearMocks.test.ts
+++ b/e2e/__tests__/autoClearMocks.test.ts
@@ -9,10 +9,10 @@ import runJest from '../runJest';
 
 test('suite with auto-clear', () => {
   const result = runJest('auto-clear-mocks/with-auto-clear');
-  expect(result.status).toBe(0);
+  expect(result.exitCode).toBe(0);
 });
 
 test('suite without auto-clear', () => {
   const result = runJest('auto-clear-mocks/without-auto-clear');
-  expect(result.status).toBe(0);
+  expect(result.exitCode).toBe(0);
 });

--- a/e2e/__tests__/autoResetMocks.test.ts
+++ b/e2e/__tests__/autoResetMocks.test.ts
@@ -9,10 +9,10 @@ import runJest from '../runJest';
 
 test('suite with auto-reset', () => {
   const result = runJest('auto-reset-mocks/with-auto-reset');
-  expect(result.status).toBe(0);
+  expect(result.exitCode).toBe(0);
 });
 
 test('suite without auto-reset', () => {
   const result = runJest('auto-reset-mocks/without-auto-reset');
-  expect(result.status).toBe(0);
+  expect(result.exitCode).toBe(0);
 });

--- a/e2e/__tests__/autoRestoreMocks.test.ts
+++ b/e2e/__tests__/autoRestoreMocks.test.ts
@@ -9,10 +9,10 @@ import runJest from '../runJest';
 
 test('suite with auto-restore', () => {
   const result = runJest('auto-restore-mocks/with-auto-restore');
-  expect(result.status).toBe(0);
+  expect(result.exitCode).toBe(0);
 });
 
 test('suite without auto-restore', () => {
   const result = runJest('auto-restore-mocks/without-auto-restore');
-  expect(result.status).toBe(0);
+  expect(result.exitCode).toBe(0);
 });

--- a/e2e/__tests__/clearCache.test.ts
+++ b/e2e/__tests__/clearCache.test.ts
@@ -14,15 +14,15 @@ const CACHE = path.resolve(tmpdir(), 'clear-cache-directory');
 
 describe('jest --clearCache', () => {
   test('normal run results in cache directory being written', () => {
-    const {status} = runJest('clear-cache', [`--cacheDirectory=${CACHE}`]);
+    const {exitCode} = runJest('clear-cache', [`--cacheDirectory=${CACHE}`]);
 
     expect(fs.existsSync(CACHE)).toBe(true);
-    expect(status).toBe(0);
+    expect(exitCode).toBe(0);
   });
-  test('clearCache results in deleted directory and exit status 0', () => {
+  test('clearCache results in deleted directory and exit exitCode 0', () => {
     expect(fs.existsSync(CACHE)).toBe(true);
 
-    const {status, stdout, stderr} = runJest('clear-cache', [
+    const {exitCode, stdout, stderr} = runJest('clear-cache', [
       '--clearCache',
       `--cacheDirectory=${CACHE}`,
     ]);
@@ -30,6 +30,6 @@ describe('jest --clearCache', () => {
     expect(fs.existsSync(CACHE)).toBe(false);
     expect(stdout).toBe(`Cleared ${CACHE}`);
     expect(stderr).toBe('');
-    expect(status).toBe(0);
+    expect(exitCode).toBe(0);
   });
 });

--- a/e2e/__tests__/clearCache.test.ts
+++ b/e2e/__tests__/clearCache.test.ts
@@ -19,7 +19,7 @@ describe('jest --clearCache', () => {
     expect(fs.existsSync(CACHE)).toBe(true);
     expect(exitCode).toBe(0);
   });
-  test('clearCache results in deleted directory and exit exitCode 0', () => {
+  test('clearCache results in deleted directory and exitCode 0', () => {
     expect(fs.existsSync(CACHE)).toBe(true);
 
     const {exitCode, stdout, stderr} = runJest('clear-cache', [

--- a/e2e/__tests__/cliHandlesExactFilenames.test.ts
+++ b/e2e/__tests__/cliHandlesExactFilenames.test.ts
@@ -28,7 +28,7 @@ test('CLI accepts exact file names if matchers matched', () => {
 
   const result = runJest(DIR, ['-i', '--forceExit', './foo/bar.spec.js']);
 
-  expect(result.status).toBe(0);
+  expect(result.exitCode).toBe(0);
 
   const {rest, summary} = extractSummary(result.stderr);
 
@@ -47,7 +47,7 @@ test('CLI skips exact file names if no matchers matched', () => {
 
   const result = runJest(DIR, ['-i', '--forceExit', './foo/bar.js']);
 
-  expect(result.status).toBe(1);
+  expect(result.exitCode).toBe(1);
   expect(result.stdout).toMatch(/No tests found([\S\s]*)2 files checked./);
   expect(result.stderr).toEqual('');
 });

--- a/e2e/__tests__/config.test.ts
+++ b/e2e/__tests__/config.test.ts
@@ -16,7 +16,7 @@ test('config as JSON', () => {
       }),
   ]);
 
-  expect(result.status).toBe(1);
+  expect(result.exitCode).toBe(1);
   expect(result.stdout).toMatch('No tests found');
 });
 
@@ -28,7 +28,7 @@ test('works with sane config JSON', () => {
       }),
   ]);
 
-  expect(result.status).toBe(1);
+  expect(result.exitCode).toBe(1);
   expect(result.stderr).toMatch('works just fine');
 });
 
@@ -65,6 +65,6 @@ test('works with jsdom testEnvironmentOptions config JSON', () => {
       }),
   ]);
 
-  expect(result.status).toBe(0);
+  expect(result.exitCode).toBe(0);
   expect(result.stderr).toContain('found url jestjs.io');
 });

--- a/e2e/__tests__/console.test.ts
+++ b/e2e/__tests__/console.test.ts
@@ -11,29 +11,29 @@ import {extractSummary, run} from '../Utils';
 import runJest from '../runJest';
 
 test('console printing', () => {
-  const {stderr, status} = runJest('console');
+  const {stderr, exitCode} = runJest('console');
   const {summary, rest} = extractSummary(stderr);
 
-  expect(status).toBe(0);
+  expect(exitCode).toBe(0);
   expect(wrap(rest)).toMatchSnapshot();
   expect(wrap(summary)).toMatchSnapshot();
 });
 
 test('console printing with --verbose', () => {
-  const {stderr, stdout, status} = runJest('console', [
+  const {stderr, stdout, exitCode} = runJest('console', [
     '--verbose',
     '--no-cache',
   ]);
   const {summary, rest} = extractSummary(stderr);
 
-  expect(status).toBe(0);
+  expect(exitCode).toBe(0);
   expect(wrap(stdout)).toMatchSnapshot();
   expect(wrap(rest)).toMatchSnapshot();
   expect(wrap(summary)).toMatchSnapshot();
 });
 
 test('does not print to console with --silent', () => {
-  const {stderr, stdout, status} = runJest('console', [
+  const {stderr, stdout, exitCode} = runJest('console', [
     // Need to pass --config because console test specifies `verbose: false`
     '--config=' +
       JSON.stringify({
@@ -44,7 +44,7 @@ test('does not print to console with --silent', () => {
   ]);
   const {summary, rest} = extractSummary(stderr);
 
-  expect(status).toBe(0);
+  expect(exitCode).toBe(0);
   expect(wrap(stdout)).toMatchSnapshot();
   expect(wrap(rest)).toMatchSnapshot();
   expect(wrap(summary)).toMatchSnapshot();
@@ -52,10 +52,10 @@ test('does not print to console with --silent', () => {
 
 // issue: https://github.com/facebook/jest/issues/5223
 test('the jsdom console is the same as the test console', () => {
-  const {stderr, stdout, status} = runJest('console-jsdom');
+  const {stderr, stdout, exitCode} = runJest('console-jsdom');
   const {summary, rest} = extractSummary(stderr);
 
-  expect(status).toBe(0);
+  expect(exitCode).toBe(0);
   expect(wrap(stdout)).toMatchSnapshot();
   expect(wrap(rest)).toMatchSnapshot();
   expect(wrap(summary)).toMatchSnapshot();
@@ -64,10 +64,10 @@ test('the jsdom console is the same as the test console', () => {
 test('does not error out when using winston', () => {
   const dir = path.resolve(__dirname, '../console-winston');
   run('yarn', dir);
-  const {stderr, stdout, status} = runJest(dir);
+  const {stderr, stdout, exitCode} = runJest(dir);
   const {summary, rest} = extractSummary(stderr);
 
-  expect(status).toBe(0);
+  expect(exitCode).toBe(0);
   expect(wrap(stdout)).toMatchSnapshot();
   expect(wrap(rest)).toMatchSnapshot();
   expect(wrap(summary)).toMatchSnapshot();

--- a/e2e/__tests__/consoleAfterTeardown.test.ts
+++ b/e2e/__tests__/consoleAfterTeardown.test.ts
@@ -10,9 +10,9 @@ import {extractSummary} from '../Utils';
 import runJest from '../runJest';
 
 test('console printing', () => {
-  const {stderr, status} = runJest('console-after-teardown');
+  const {stderr, exitCode} = runJest('console-after-teardown');
   const {rest} = extractSummary(stderr);
 
-  expect(status).toBe(0);
+  expect(exitCode).toBe(0);
   expect(wrap(rest)).toMatchSnapshot();
 });

--- a/e2e/__tests__/consoleLogOutputWhenRunInBand.test.ts
+++ b/e2e/__tests__/consoleLogOutputWhenRunInBand.test.ts
@@ -23,13 +23,13 @@ test('prints console.logs when run with forceExit', () => {
     'package.json': '{}',
   });
 
-  const {stderr, stdout, status} = runJest(DIR, [
+  const {stderr, stdout, exitCode} = runJest(DIR, [
     '-i',
     '--ci=false',
     '--forceExit',
   ]);
   const {rest, summary} = extractSummary(stderr);
-  expect(status).toBe(0);
+  expect(exitCode).toBe(0);
   expect(wrap(rest)).toMatchSnapshot();
   expect(wrap(summary)).toMatchSnapshot();
   expect(wrap(stdout)).toMatchSnapshot();

--- a/e2e/__tests__/coverageRemapping.test.ts
+++ b/e2e/__tests__/coverageRemapping.test.ts
@@ -21,7 +21,7 @@ it('maps code coverage against original source', () => {
   run('yarn', dir);
   const result = runJest(dir, ['--coverage', '--no-cache']);
 
-  expect(result.status).toBe(0);
+  expect(result.exitCode).toBe(0);
 
   const coverageMapFile = path.join(coverageDir, 'coverage-final.json');
   const coverageMap = JSON.parse(readFileSync(coverageMapFile, 'utf-8'));

--- a/e2e/__tests__/coverageReport.test.ts
+++ b/e2e/__tests__/coverageReport.test.ts
@@ -18,7 +18,7 @@ beforeAll(() => {
 });
 
 test('outputs coverage report', () => {
-  const {stdout, status} = runJest(DIR, ['--no-cache', '--coverage'], {
+  const {stdout, exitCode} = runJest(DIR, ['--no-cache', '--coverage'], {
     stripAnsi: true,
   });
   const coverageDir = path.join(DIR, 'coverage');
@@ -31,7 +31,7 @@ test('outputs coverage report', () => {
   expect(wrap(stdout)).toMatchSnapshot();
 
   expect(() => fs.accessSync(coverageDir, fs.F_OK)).not.toThrow();
-  expect(status).toBe(0);
+  expect(exitCode).toBe(0);
 });
 
 test('collects coverage only from specified file', () => {
@@ -86,26 +86,26 @@ test('collects coverage only from specified files avoiding dependencies', () => 
 });
 
 test('json reporter printing with --coverage', () => {
-  const {stderr, status} = runJest('json-reporter', ['--coverage'], {
+  const {stderr, exitCode} = runJest('json-reporter', ['--coverage'], {
     stripAnsi: true,
   });
   const {summary} = extractSummary(stderr);
-  expect(status).toBe(1);
+  expect(exitCode).toBe(1);
   expect(wrap(summary)).toMatchSnapshot();
 });
 
 test('outputs coverage report as json', () => {
-  const {stdout, status} = runJest(
+  const {stdout, exitCode} = runJest(
     DIR,
     ['--no-cache', '--coverage', '--json'],
     {stripAnsi: true},
   );
-  expect(status).toBe(0);
+  expect(exitCode).toBe(0);
   expect(() => JSON.parse(stdout)).not.toThrow();
 });
 
 test('outputs coverage report when text is requested', () => {
-  const {stdout, status} = runJest(
+  const {stdout, exitCode} = runJest(
     DIR,
     [
       '--no-cache',
@@ -115,24 +115,24 @@ test('outputs coverage report when text is requested', () => {
     ],
     {stripAnsi: true},
   );
-  expect(status).toBe(0);
+  expect(exitCode).toBe(0);
   expect(stdout).toMatch(/Stmts | . Branch/);
   expect(wrap(stdout)).toMatchSnapshot();
 });
 
 test('outputs coverage report when text-summary is requested', () => {
-  const {stdout, status} = runJest(
+  const {stdout, exitCode} = runJest(
     DIR,
     ['--no-cache', '--coverage', '--coverageReporters=text-summary'],
     {stripAnsi: true},
   );
-  expect(status).toBe(0);
+  expect(exitCode).toBe(0);
   expect(stdout).toMatch(/Coverage summary/);
   expect(wrap(stdout)).toMatchSnapshot();
 });
 
 test('outputs coverage report when text and text-summary is requested', () => {
-  const {stdout, status} = runJest(
+  const {stdout, exitCode} = runJest(
     DIR,
     [
       '--no-cache',
@@ -142,19 +142,19 @@ test('outputs coverage report when text and text-summary is requested', () => {
     ],
     {stripAnsi: true},
   );
-  expect(status).toBe(0);
+  expect(exitCode).toBe(0);
   expect(stdout).toMatch(/Stmts | . Branch/);
   expect(stdout).toMatch(/Coverage summary/);
   expect(wrap(stdout)).toMatchSnapshot();
 });
 
 test('does not output coverage report when html is requested', () => {
-  const {stdout, status} = runJest(
+  const {stdout, exitCode} = runJest(
     DIR,
     ['--no-cache', '--coverage', '--coverageReporters=html'],
     {stripAnsi: true},
   );
-  expect(status).toBe(0);
+  expect(exitCode).toBe(0);
   expect(stdout).toMatch(/^$/);
   expect(wrap(stdout)).toMatchSnapshot();
 });
@@ -162,7 +162,7 @@ test('does not output coverage report when html is requested', () => {
 test('collects coverage from duplicate files avoiding shared cache', () => {
   const args = [
     '--coverage',
-    // Ensure the status code is non-zero if super edge case with coverage triggers
+    // Ensure the exitCode code is non-zero if super edge case with coverage triggers
     '--coverageThreshold',
     '{"global": {"lines": 100}}',
     '--collectCoverageOnlyFrom',
@@ -176,17 +176,17 @@ test('collects coverage from duplicate files avoiding shared cache', () => {
   runJest(DIR, args, {stripAnsi: true});
 
   // Run for the second time
-  const {stdout, status} = runJest(DIR, args, {stripAnsi: true});
+  const {stdout, exitCode} = runJest(DIR, args, {stripAnsi: true});
   expect(wrap(stdout)).toMatchSnapshot();
-  expect(status).toBe(0);
+  expect(exitCode).toBe(0);
 });
 
 test('generates coverage when using the testRegex config param ', () => {
-  const {stdout, status} = runJest(DIR, [
+  const {stdout, exitCode} = runJest(DIR, [
     '--no-cache',
     '--testRegex=__tests__',
     '--coverage',
   ]);
   expect(wrap(stdout)).toMatchSnapshot();
-  expect(status).toBe(0);
+  expect(exitCode).toBe(0);
 });

--- a/e2e/__tests__/coverageReport.test.ts
+++ b/e2e/__tests__/coverageReport.test.ts
@@ -162,7 +162,7 @@ test('does not output coverage report when html is requested', () => {
 test('collects coverage from duplicate files avoiding shared cache', () => {
   const args = [
     '--coverage',
-    // Ensure the exitCode code is non-zero if super edge case with coverage triggers
+    // Ensure the exitCode is non-zero if super edge case with coverage triggers
     '--coverageThreshold',
     '{"global": {"lines": 100}}',
     '--collectCoverageOnlyFrom',

--- a/e2e/__tests__/coverageThreshold.test.ts
+++ b/e2e/__tests__/coverageThreshold.test.ts
@@ -41,12 +41,12 @@ test('exits with 1 if coverage threshold is not met', () => {
     'package.json': JSON.stringify(pkgJson, null, 2),
   });
 
-  const {stdout, stderr, status} = runJest(DIR, ['--coverage', '--ci=false'], {
+  const {stdout, stderr, exitCode} = runJest(DIR, ['--coverage', '--ci=false'], {
     stripAnsi: true,
   });
   const {rest, summary} = extractSummary(stderr);
 
-  expect(status).toBe(1);
+  expect(exitCode).toBe(1);
   expect(wrap(rest)).toMatchSnapshot();
   expect(wrap(summary)).toMatchSnapshot();
   expect(wrap(stdout)).toMatchSnapshot('stdout');
@@ -78,12 +78,12 @@ test('exits with 1 if path threshold group is not found in coverage data', () =>
     'package.json': JSON.stringify(pkgJson, null, 2),
   });
 
-  const {stdout, stderr, status} = runJest(DIR, ['--coverage', '--ci=false'], {
+  const {stdout, stderr, exitCode} = runJest(DIR, ['--coverage', '--ci=false'], {
     stripAnsi: true,
   });
   const {rest, summary} = extractSummary(stderr);
 
-  expect(status).toBe(1);
+  expect(exitCode).toBe(1);
   expect(wrap(rest)).toMatchSnapshot();
   expect(wrap(summary)).toMatchSnapshot();
   expect(wrap(stdout)).toMatchSnapshot('stdout');
@@ -118,11 +118,11 @@ test('exits with 0 if global threshold group is not found in coverage data', () 
     'package.json': JSON.stringify(pkgJson, null, 2),
   });
 
-  const {stdout, status} = runJest(DIR, ['--coverage', '--ci=false'], {
+  const {stdout, exitCode} = runJest(DIR, ['--coverage', '--ci=false'], {
     stripAnsi: true,
   });
 
-  expect(status).toBe(0);
+  expect(exitCode).toBe(0);
   expect(wrap(stdout)).toMatchSnapshot('stdout');
 });
 
@@ -160,12 +160,12 @@ test('excludes tests matched by path threshold groups from global group', () => 
     'package.json': JSON.stringify(pkgJson, null, 2),
   });
 
-  const {stdout, stderr, status} = runJest(DIR, ['--coverage', '--ci=false'], {
+  const {stdout, stderr, exitCode} = runJest(DIR, ['--coverage', '--ci=false'], {
     stripAnsi: true,
   });
   const {rest, summary} = extractSummary(stderr);
 
-  expect(status).toBe(1);
+  expect(exitCode).toBe(1);
   expect(wrap(rest)).toMatchSnapshot();
   expect(wrap(summary)).toMatchSnapshot();
   expect(wrap(stdout)).toMatchSnapshot('stdout');
@@ -203,7 +203,7 @@ test('file is matched by all path and glob threshold groups', () => {
     'package.json': JSON.stringify(pkgJson, null, 2),
   });
 
-  const {stdout, stderr, status} = runJest(DIR, ['--coverage', '--ci=false'], {
+  const {stdout, stderr, exitCode} = runJest(DIR, ['--coverage', '--ci=false'], {
     stripAnsi: true,
   });
   const {rest, summary} = extractSummary(
@@ -215,7 +215,7 @@ test('file is matched by all path and glob threshold groups', () => {
     ),
   );
 
-  expect(status).toBe(1);
+  expect(exitCode).toBe(1);
   expect(wrap(rest)).toMatchSnapshot();
   expect(wrap(summary)).toMatchSnapshot();
   expect(wrap(stdout)).toMatchSnapshot('stdout');

--- a/e2e/__tests__/coverageThreshold.test.ts
+++ b/e2e/__tests__/coverageThreshold.test.ts
@@ -41,9 +41,11 @@ test('exits with 1 if coverage threshold is not met', () => {
     'package.json': JSON.stringify(pkgJson, null, 2),
   });
 
-  const {stdout, stderr, exitCode} = runJest(DIR, ['--coverage', '--ci=false'], {
-    stripAnsi: true,
-  });
+  const {stdout, stderr, exitCode} = runJest(
+    DIR,
+    ['--coverage', '--ci=false'],
+    {stripAnsi: true},
+  );
   const {rest, summary} = extractSummary(stderr);
 
   expect(exitCode).toBe(1);
@@ -78,9 +80,11 @@ test('exits with 1 if path threshold group is not found in coverage data', () =>
     'package.json': JSON.stringify(pkgJson, null, 2),
   });
 
-  const {stdout, stderr, exitCode} = runJest(DIR, ['--coverage', '--ci=false'], {
-    stripAnsi: true,
-  });
+  const {stdout, stderr, exitCode} = runJest(
+    DIR,
+    ['--coverage', '--ci=false'],
+    {stripAnsi: true},
+  );
   const {rest, summary} = extractSummary(stderr);
 
   expect(exitCode).toBe(1);
@@ -160,9 +164,11 @@ test('excludes tests matched by path threshold groups from global group', () => 
     'package.json': JSON.stringify(pkgJson, null, 2),
   });
 
-  const {stdout, stderr, exitCode} = runJest(DIR, ['--coverage', '--ci=false'], {
-    stripAnsi: true,
-  });
+  const {stdout, stderr, exitCode} = runJest(
+    DIR,
+    ['--coverage', '--ci=false'],
+    {stripAnsi: true},
+  );
   const {rest, summary} = extractSummary(stderr);
 
   expect(exitCode).toBe(1);
@@ -203,9 +209,11 @@ test('file is matched by all path and glob threshold groups', () => {
     'package.json': JSON.stringify(pkgJson, null, 2),
   });
 
-  const {stdout, stderr, exitCode} = runJest(DIR, ['--coverage', '--ci=false'], {
-    stripAnsi: true,
-  });
+  const {stdout, stderr, exitCode} = runJest(
+    DIR,
+    ['--coverage', '--ci=false'],
+    {stripAnsi: true},
+  );
   const {rest, summary} = extractSummary(
     /* This test also runs on windows and when the glob fails it outputs
     the system specific absolute path to the test file. */

--- a/e2e/__tests__/coverageTransformInstrumented.test.ts
+++ b/e2e/__tests__/coverageTransformInstrumented.test.ts
@@ -21,7 +21,7 @@ it('code coverage for transform instrumented code', () => {
   run('yarn', dir);
   const result = runJest(dir, ['--coverage', '--no-cache']);
 
-  expect(result.status).toBe(0);
+  expect(result.exitCode).toBe(0);
 
   const coverageMapFile = path.join(coverageDir, 'coverage-final.json');
   const coverageMap = JSON.parse(readFileSync(coverageMapFile, 'utf-8'));

--- a/e2e/__tests__/customReporters.test.ts
+++ b/e2e/__tests__/customReporters.test.ts
@@ -22,13 +22,13 @@ describe('Custom Reporters Integration', () => {
       reporters: ['<rootDir>/reporters/TestReporter.js'],
     };
 
-    const {status} = runJest('custom-reporters', [
+    const {exitCode} = runJest('custom-reporters', [
       '--config',
       JSON.stringify(reporterConfig),
       'add.test.js',
     ]);
 
-    expect(status).toBe(0);
+    expect(exitCode).toBe(0);
   });
 
   test('valid array format for adding reporters', () => {
@@ -38,14 +38,14 @@ describe('Custom Reporters Integration', () => {
       ],
     };
 
-    const {status, stdout} = runJest('custom-reporters', [
+    const {exitCode, stdout} = runJest('custom-reporters', [
       '--config',
       JSON.stringify(reporterConfig),
       'add.test.js',
     ]);
 
     expect(wrap(stdout)).toMatchSnapshot();
-    expect(status).toBe(0);
+    expect(exitCode).toBe(0);
   });
 
   test('invalid format for adding reporters', () => {
@@ -53,18 +53,18 @@ describe('Custom Reporters Integration', () => {
       reporters: [[3243242]],
     };
 
-    const {status, stderr} = runJest('custom-reporters', [
+    const {exitCode, stderr} = runJest('custom-reporters', [
       '--config',
       JSON.stringify(reporterConfig),
       'add.test.js',
     ]);
 
-    expect(status).toBe(1);
+    expect(exitCode).toBe(1);
     expect(wrap(stderr)).toMatchSnapshot();
   });
 
   test('default reporters enabled', () => {
-    const {stderr, stdout, status} = runJest('custom-reporters', [
+    const {stderr, stdout, exitCode} = runJest('custom-reporters', [
       '--config',
       JSON.stringify({
         reporters: ['default', '<rootDir>/reporters/TestReporter.js'],
@@ -75,38 +75,38 @@ describe('Custom Reporters Integration', () => {
     const {summary, rest} = extractSummary(stderr);
     const parsedJSON = JSON.parse(stdout);
 
-    expect(status).toBe(0);
+    expect(exitCode).toBe(0);
     expect(wrap(rest)).toMatchSnapshot();
     expect(wrap(summary)).toMatchSnapshot();
     expect(parsedJSON).toMatchSnapshot();
   });
 
   test('TestReporter with all tests passing', () => {
-    const {stdout, status, stderr} = runJest('custom-reporters', [
+    const {stdout, exitCode, stderr} = runJest('custom-reporters', [
       'add.test.js',
     ]);
 
     const parsedJSON = JSON.parse(stdout);
 
-    expect(status).toBe(0);
+    expect(exitCode).toBe(0);
     expect(stderr).toBe('');
     expect(parsedJSON).toMatchSnapshot();
   });
 
   test('TestReporter with all tests failing', () => {
-    const {stdout, status, stderr} = runJest('custom-reporters', [
+    const {stdout, exitCode, stderr} = runJest('custom-reporters', [
       'addFail.test.js',
     ]);
 
     const parsedJSON = JSON.parse(stdout);
 
-    expect(status).toBe(1);
+    expect(exitCode).toBe(1);
     expect(stderr).toBe('');
     expect(parsedJSON).toMatchSnapshot();
   });
 
   test('IncompleteReporter for flexibility', () => {
-    const {stderr, stdout, status} = runJest('custom-reporters', [
+    const {stderr, stdout, exitCode} = runJest('custom-reporters', [
       '--no-cache',
       '--config',
       JSON.stringify({
@@ -115,7 +115,7 @@ describe('Custom Reporters Integration', () => {
       'add.test.js',
     ]);
 
-    expect(status).toBe(0);
+    expect(exitCode).toBe(0);
     expect(stderr).toBe('');
 
     expect(wrap(stdout)).toMatchSnapshot();
@@ -140,8 +140,8 @@ describe('Custom Reporters Integration', () => {
       `,
     });
 
-    const {stderr, status} = runJest(DIR);
+    const {stderr, exitCode} = runJest(DIR);
     expect(stderr).toMatch(/ON_RUN_START_ERROR/);
-    expect(status).toBe(1);
+    expect(exitCode).toBe(1);
   });
 });

--- a/e2e/__tests__/customResolver.test.ts
+++ b/e2e/__tests__/customResolver.test.ts
@@ -9,5 +9,5 @@ import runJest from '../runJest';
 
 test('use the custom resolver', () => {
   const result = runJest('custom-resolver');
-  expect(result.status).toBe(0);
+  expect(result.exitCode).toBe(0);
 });

--- a/e2e/__tests__/customTestSequencers.test.ts
+++ b/e2e/__tests__/customTestSequencers.test.ts
@@ -22,7 +22,7 @@ test('run prioritySequence first sync', () => {
     ],
     {},
   );
-  expect(result.status).toBe(0);
+  expect(result.exitCode).toBe(0);
   const sequence = extractSummary(result.stderr)
     .rest.replace(/PASS /g, '')
     .split('\n');
@@ -47,7 +47,7 @@ test('run prioritySequence first async', () => {
     ],
     {},
   );
-  expect(result.status).toBe(0);
+  expect(result.exitCode).toBe(0);
   const sequence = extractSummary(result.stderr)
     .rest.replace(/PASS /g, '')
     .split('\n');

--- a/e2e/__tests__/declarationErrors.test.ts
+++ b/e2e/__tests__/declarationErrors.test.ts
@@ -17,7 +17,7 @@ it('warns if describe returns a Promise', () => {
     'describeReturnPromise.test.js',
   ]);
 
-  expect(result.status).toBe(0);
+  expect(result.exitCode).toBe(0);
   expect(normalizeCircusJasmine(result.stdout)).toMatchSnapshot();
 });
 
@@ -26,14 +26,14 @@ it('warns if describe returns something', () => {
     'describeReturnSomething.test.js',
   ]);
 
-  expect(result.status).toBe(0);
+  expect(result.exitCode).toBe(0);
   expect(normalizeCircusJasmine(result.stdout)).toMatchSnapshot();
 });
 
 it('errors if describe throws', () => {
   const result = runJest('declaration-errors', ['describeThrow.test.js']);
 
-  expect(result.status).toBe(1);
+  expect(result.exitCode).toBe(1);
   expect(result.stdout).toBe('');
   expect(result.stderr).toContain('whoops');
 });

--- a/e2e/__tests__/dependencyClash.test.ts
+++ b/e2e/__tests__/dependencyClash.test.ts
@@ -75,11 +75,11 @@ test('does not require project modules from inside node_modules', () => {
       };
     `,
   });
-  const {stderr, status} = runJest(tempDir, ['--no-cache', '--no-watchman']);
+  const {stderr, exitCode} = runJest(tempDir, ['--no-cache', '--no-watchman']);
   // make sure there are no errors that lead to invariant.js (if we were to
   // require a wrong `invariant.js` we'd have a syntax error, because jest
   // internals wouldn't be able to parse flow annotations)
   expect(stderr).not.toMatch('invariant');
   expect(stderr).toMatch('PASS');
-  expect(status).toBe(0);
+  expect(exitCode).toBe(0);
 });

--- a/e2e/__tests__/deprecatedCliOptions.test.ts
+++ b/e2e/__tests__/deprecatedCliOptions.test.ts
@@ -11,8 +11,8 @@ import runJest from '../runJest';
 const dir = path.resolve(__dirname, '../deprecated-cli-options');
 
 it('Prints deprecation warnings for CLI flags', () => {
-  const {stderr, status} = runJest(dir, ['--mapCoverage']);
-  expect(status).toBe(0);
+  const {stderr, exitCode} = runJest(dir, ['--mapCoverage']);
+  expect(exitCode).toBe(0);
   expect(stderr).toMatch(/Test Suites: 1 passed, 1 total/);
   expect(stderr).toMatch(`● Deprecation Warning:
 

--- a/e2e/__tests__/each.test.ts
+++ b/e2e/__tests__/each.test.ts
@@ -14,19 +14,19 @@ const dir = path.resolve(__dirname, '../each');
 
 test('works with passing tests', () => {
   const result = runJest(dir, ['success.test.js']);
-  expect(result.status).toBe(0);
+  expect(result.exitCode).toBe(0);
 });
 
 test('shows error message when not enough arguments are supplied to tests', () => {
   const result = runJest(dir, ['eachException.test.js']);
-  expect(result.status).toBe(1);
+  expect(result.exitCode).toBe(1);
   const {rest} = extractSummary(result.stderr);
   expect(wrap(rest)).toMatchSnapshot();
 });
 
 test('shows the correct errors in stderr when failing tests', () => {
   const result = runJest(dir, ['failure.test.js']);
-  expect(result.status).toBe(1);
+  expect(result.exitCode).toBe(1);
   const output = extractSummary(result.stderr)
     .rest.split('\n')
     .map(line => line.trimRight())
@@ -36,7 +36,7 @@ test('shows the correct errors in stderr when failing tests', () => {
 
 test('shows only the tests with .only as being ran', () => {
   const result = runJest(dir, ['eachOnly.test.js']);
-  expect(result.status).toBe(0);
+  expect(result.exitCode).toBe(0);
   const {rest} = extractSummary(result.stderr);
   expect(wrap(rest)).toMatchSnapshot();
 });
@@ -45,19 +45,19 @@ test('shows only the tests without .skip as being ran', () => {
   const result = runJest(dir, ['eachSkip.test.js']);
   const {rest} = extractSummary(result.stderr);
   expect(wrap(rest)).toMatchSnapshot();
-  expect(result.status).toBe(0);
+  expect(result.exitCode).toBe(0);
 });
 
 test('runs only the describe.only.each tests', () => {
   const result = runJest(dir, ['describeOnly.test.js']);
   const {rest} = extractSummary(result.stderr);
   expect(wrap(rest)).toMatchSnapshot();
-  expect(result.status).toBe(0);
+  expect(result.exitCode).toBe(0);
 });
 
 test('formats args with pretty format when given %p', () => {
   const result = runJest(dir, ['pretty.test.js']);
   const {rest} = extractSummary(result.stderr);
   expect(wrap(rest)).toMatchSnapshot();
-  expect(result.status).toBe(0);
+  expect(result.exitCode).toBe(0);
 });

--- a/e2e/__tests__/emptyDescribeWithHooks.test.ts
+++ b/e2e/__tests__/emptyDescribeWithHooks.test.ts
@@ -16,24 +16,24 @@ skipSuiteOnJasmine();
 
 test('hook in empty describe', () => {
   const result = runJest(dir, ['hookInEmptyDescribe.test.js']);
-  expect(result.status).toBe(1);
+  expect(result.exitCode).toBe(1);
   expect(extractSummary(result.stderr)).toMatchSnapshot();
 });
 
 test('hook in describe with skipped test', () => {
   const result = runJest(dir, ['hookInDescribeWithSkippedTest.test.js']);
-  expect(result.status).toBe(0);
+  expect(result.exitCode).toBe(0);
   expect(extractSummary(result.stderr)).toMatchSnapshot();
 });
 
 test('hook in empty nested describe', () => {
   const result = runJest(dir, ['hookInEmptyNestedDescribe.test.js']);
-  expect(result.status).toBe(1);
+  expect(result.exitCode).toBe(1);
   expect(extractSummary(result.stderr)).toMatchSnapshot();
 });
 
 test('multiple hooks in empty describe', () => {
   const result = runJest(dir, ['multipleHooksInEmptyDescribe.test.js']);
-  expect(result.status).toBe(1);
+  expect(result.exitCode).toBe(1);
   expect(extractSummary(result.stderr)).toMatchSnapshot();
 });

--- a/e2e/__tests__/emptySuiteError.test.ts
+++ b/e2e/__tests__/emptySuiteError.test.ts
@@ -5,8 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-'use strict';
-
 import * as path from 'path';
 import runJest from '../runJest';
 

--- a/e2e/__tests__/env.test.ts
+++ b/e2e/__tests__/env.test.ts
@@ -12,36 +12,36 @@ const getLog = result => result.stdout.split('\n')[1].trim();
 describe('Environment override', () => {
   it('uses jsdom when specified', () => {
     const result = runJest('env-test', ['--env=jsdom', 'env.test.js']);
-    expect(result.status).toBe(0);
+    expect(result.exitCode).toBe(0);
     expect(getLog(result)).toBe('WINDOW');
   });
 
   it('uses node as default from package.json', () => {
     const result = runJest('env-test', ['env.test.js']);
-    expect(result.status).toBe(0);
+    expect(result.exitCode).toBe(0);
     expect(getLog(result)).toBe('NO WINDOW');
   });
 
   it('uses node when specified', () => {
     const result = runJest('env-test', ['--env=node', 'env.test.js']);
-    expect(result.status).toBe(0);
+    expect(result.exitCode).toBe(0);
     expect(getLog(result)).toBe('NO WINDOW');
   });
 
   it('fails when the env is not available', () => {
     const result = runJest('env-test', ['--env=banana', 'env.test.js']);
-    expect(result.status).toBe(1);
+    expect(result.exitCode).toBe(1);
   });
 });
 
 describe('Environment equivalent', () => {
   it('uses jsdom', () => {
     const result = runJest('env-test', ['--env=jsdom', 'equivalent.test.js']);
-    expect(result.status).toBe(0);
+    expect(result.exitCode).toBe(0);
   });
 
   it('uses node', () => {
     const result = runJest('env-test', ['--env=node', 'equivalent.test.js']);
-    expect(result.status).toBe(0);
+    expect(result.exitCode).toBe(0);
   });
 });

--- a/e2e/__tests__/errorOnDeprecated.test.ts
+++ b/e2e/__tests__/errorOnDeprecated.test.ts
@@ -40,7 +40,7 @@ testFiles.forEach(testFile => {
       testFile,
       '--errorOnDeprecated',
     ]);
-    expect(result.status).toBe(1);
+    expect(result.exitCode).toBe(1);
     let {rest} = extractSummary(result.stderr);
 
     if (
@@ -69,6 +69,6 @@ testFiles.forEach(testFile => {
 
   test(testName, () => {
     const result = runJest('error-on-deprecated', [testFile]);
-    expect(result.status).toBe(shouldPass ? 1 : 0);
+    expect(result.exitCode).toBe(shouldPass ? 1 : 0);
   });
 });

--- a/e2e/__tests__/executeTestsOnceInMpr.ts
+++ b/e2e/__tests__/executeTestsOnceInMpr.ts
@@ -47,9 +47,9 @@ test('Tests are executed only once even in an MPR', () => {
   });
   /* eslint-enable sort-keys */
 
-  const {stderr, status} = runJest(DIR, ['foo/folder/my-test-bar.js']);
+  const {stderr, exitCode} = runJest(DIR, ['foo/folder/my-test-bar.js']);
 
-  expect(status).toBe(0);
+  expect(exitCode).toBe(0);
 
   const {rest, summary} = extractSummary(stderr);
 

--- a/e2e/__tests__/expectAsyncMatcher.test.ts
+++ b/e2e/__tests__/expectAsyncMatcher.test.ts
@@ -18,13 +18,13 @@ beforeAll(() => {
 
 test('works with passing tests', () => {
   const result = runJest(dir, ['success.test.js']);
-  expect(result.status).toBe(0);
+  expect(result.exitCode).toBe(0);
 });
 
 test('shows the correct errors in stderr when failing tests', () => {
   const result = runJest(dir, ['failure.test.js']);
 
-  expect(result.status).toBe(1);
+  expect(result.exitCode).toBe(1);
 
   const rest = extractSummary(result.stderr)
     .rest.split('\n')

--- a/e2e/__tests__/expectInVm.test.ts
+++ b/e2e/__tests__/expectInVm.test.ts
@@ -9,5 +9,5 @@ import runJest from '../runJest';
 
 test('expect works correctly with RegExps created inside a VM', () => {
   const result = runJest('expect-in-vm');
-  expect(result.status).toBe(0);
+  expect(result.exitCode).toBe(0);
 });

--- a/e2e/__tests__/fakePromises.test.ts
+++ b/e2e/__tests__/fakePromises.test.ts
@@ -10,11 +10,11 @@ import runJest from '../runJest';
 describe('Fake promises', () => {
   it('should be possible to resolve with fake timers using immediates', () => {
     const result = runJest('fake-promises/immediate');
-    expect(result.status).toBe(0);
+    expect(result.exitCode).toBe(0);
   });
 
   it('should be possible to resolve with fake timers using asap', () => {
     const result = runJest('fake-promises/asap');
-    expect(result.status).toBe(0);
+    expect(result.exitCode).toBe(0);
   });
 });

--- a/e2e/__tests__/fatalWorkerError.test.ts
+++ b/e2e/__tests__/fatalWorkerError.test.ts
@@ -34,11 +34,11 @@ test('fails a test that terminates the worker with a fatal error', () => {
     'package.json': '{}',
   });
 
-  const {status, stderr} = runJest(DIR, ['--maxWorkers=2']);
+  const {exitCode, stderr} = runJest(DIR, ['--maxWorkers=2']);
 
   const numberOfTestsPassed = (stderr.match(/\bPASS\b/g) || []).length;
 
-  expect(status).not.toBe(0);
+  expect(exitCode).not.toBe(0);
   expect(numberOfTestsPassed).toBe(Object.keys(testFiles).length - 1);
   expect(stderr).toContain('FAIL __tests__/fatalWorkerError.test.js');
   expect(stderr).toContain('Call retries were exceeded');

--- a/e2e/__tests__/filter.test.ts
+++ b/e2e/__tests__/filter.test.ts
@@ -11,7 +11,7 @@ describe('Dynamic test filtering', () => {
   it('uses the default JSON option', () => {
     const result = runJest('filter', []);
 
-    expect(result.status).toBe(0);
+    expect(result.exitCode).toBe(0);
     expect(result.stderr).toContain('1 total');
   });
 
@@ -20,7 +20,7 @@ describe('Dynamic test filtering', () => {
       '--filter=<rootDir>/my-secondary-filter.js',
     ]);
 
-    expect(result.status).toBe(0);
+    expect(result.exitCode).toBe(0);
     expect(result.stderr).toContain('1 total');
   });
 
@@ -30,7 +30,7 @@ describe('Dynamic test filtering', () => {
       '--skipFilter',
     ]);
 
-    expect(result.status).toBe(0);
+    expect(result.exitCode).toBe(0);
     expect(result.stderr).toContain('2 total');
   });
 
@@ -39,7 +39,7 @@ describe('Dynamic test filtering', () => {
       '--filter=<rootDir>/my-clowny-filter.js',
     ]);
 
-    expect(result.status).toBe(1);
+    expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain('did not return a valid test list');
     expect(result.stderr).toContain('my-clowny-filter');
   });
@@ -47,7 +47,7 @@ describe('Dynamic test filtering', () => {
   it('will call setup on filter before filtering', () => {
     const result = runJest('filter', ['--filter=<rootDir>/my-setup-filter.js']);
 
-    expect(result.status).toBe(0);
+    expect(result.exitCode).toBe(0);
     expect(result.stderr).toContain('1 total');
   });
 
@@ -56,7 +56,7 @@ describe('Dynamic test filtering', () => {
       '--filter=<rootDir>/my-broken-filter.js',
     ]);
 
-    expect(result.status).toBe(1);
+    expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain('Error: My broken filter error.');
   });
 
@@ -65,7 +65,7 @@ describe('Dynamic test filtering', () => {
       '--filter=<rootDir>/my-broken-setup-filter.js',
     ]);
 
-    expect(result.status).toBe(1);
+    expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain('Error: My broken setup filter error.');
   });
 });

--- a/e2e/__tests__/generatorMock.test.ts
+++ b/e2e/__tests__/generatorMock.test.ts
@@ -8,7 +8,7 @@
 import runJest from '../runJest';
 
 test('mock works with generator', () => {
-  const {status} = runJest('generator-mock');
+  const {exitCode} = runJest('generator-mock');
 
-  expect(status).toBe(0);
+  expect(exitCode).toBe(0);
 });

--- a/e2e/__tests__/globalSetup.test.ts
+++ b/e2e/__tests__/globalSetup.test.ts
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-'use strict';
 
 import * as fs from 'fs';
 import {tmpdir} from 'os';
@@ -48,7 +47,7 @@ test('globalSetup is triggered once before all test suites', () => {
     `--testPathPattern=__tests__`,
   ]);
 
-  expect(result.status).toBe(0);
+  expect(result.exitCode).toBe(0);
   const files = fs.readdirSync(DIR);
   expect(files).toHaveLength(1);
   const setup = fs.readFileSync(path.join(DIR, files[0]), 'utf8');
@@ -57,12 +56,12 @@ test('globalSetup is triggered once before all test suites', () => {
 
 test('jest throws an error when globalSetup does not export a function', () => {
   const setupPath = path.resolve(__dirname, '../global-setup/invalidSetup.js');
-  const {status, stderr} = runJest(e2eDir, [
+  const {exitCode, stderr} = runJest(e2eDir, [
     `--globalSetup=${setupPath}`,
     `--testPathPattern=__tests__`,
   ]);
 
-  expect(status).toBe(1);
+  expect(exitCode).toBe(1);
   expect(stderr).toMatch(
     `TypeError: globalSetup file must export a function at ${setupPath}`,
   );
@@ -86,7 +85,7 @@ test('should call globalSetup function of multiple projects', () => {
 
   const result = runWithJson(e2eDir, [`--config=${configPath}`]);
 
-  expect(result.status).toBe(0);
+  expect(result.exitCode).toBe(0);
 
   expect(fs.existsSync(DIR)).toBe(true);
   expect(fs.existsSync(project1DIR)).toBe(true);
@@ -101,7 +100,7 @@ test('should not call a globalSetup of a project if there are no tests to run fr
     '--testPathPattern=project-1',
   ]);
 
-  expect(result.status).toBe(0);
+  expect(result.exitCode).toBe(0);
 
   expect(fs.existsSync(DIR)).toBe(true);
   expect(fs.existsSync(project1DIR)).toBe(true);
@@ -117,7 +116,7 @@ test('should not call any globalSetup if there are no tests to run', () => {
     '--onlyChanged',
   ]);
 
-  expect(result.status).toBe(0);
+  expect(result.exitCode).toBe(0);
 
   expect(fs.existsSync(DIR)).toBe(false);
   expect(fs.existsSync(project1DIR)).toBe(false);
@@ -140,25 +139,25 @@ test('globalSetup works with default export', () => {
 test('globalSetup throws with named export', () => {
   const setupPath = path.resolve(e2eDir, 'invalidSetupWithNamedExport.js');
 
-  const {status, stderr} = runJest(e2eDir, [
+  const {exitCode, stderr} = runJest(e2eDir, [
     `--globalSetup=${setupPath}`,
     `--testPathPattern=__tests__`,
   ]);
 
-  expect(status).toBe(1);
+  expect(exitCode).toBe(1);
   expect(stderr).toMatch(
     `TypeError: globalSetup file must export a function at ${setupPath}`,
   );
 });
 
 test('should not transpile the transformer', () => {
-  const {status} = runJest('global-setup-custom-transform', [`--no-cache`]);
+  const {exitCode} = runJest('global-setup-custom-transform', [`--no-cache`]);
 
-  expect(status).toBe(0);
+  expect(exitCode).toBe(0);
 });
 
 test('should transform node_modules if configured by transformIgnorePatterns', () => {
-  const {status} = runJest('global-setup-node-modules', [`--no-cache`]);
+  const {exitCode} = runJest('global-setup-node-modules', [`--no-cache`]);
 
-  expect(status).toBe(0);
+  expect(exitCode).toBe(0);
 });

--- a/e2e/__tests__/globalTeardown.test.ts
+++ b/e2e/__tests__/globalTeardown.test.ts
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-'use strict';
 
 import * as fs from 'fs';
 import {tmpdir} from 'os';
@@ -41,7 +40,7 @@ test('globalTeardown is triggered once after all test suites', () => {
     `--testPathPattern=__tests__`,
   ]);
 
-  expect(result.status).toBe(0);
+  expect(result.exitCode).toBe(0);
   const files = fs.readdirSync(DIR);
   expect(files).toHaveLength(1);
   const teardown = fs.readFileSync(path.join(DIR, files[0]), 'utf8');
@@ -50,12 +49,12 @@ test('globalTeardown is triggered once after all test suites', () => {
 
 test('jest throws an error when globalTeardown does not export a function', () => {
   const teardownPath = path.resolve(e2eDir, 'invalidTeardown.js');
-  const {status, stderr} = runJest(e2eDir, [
+  const {exitCode, stderr} = runJest(e2eDir, [
     `--globalTeardown=${teardownPath}`,
     `--testPathPattern=__tests__`,
   ]);
 
-  expect(status).toBe(1);
+  expect(exitCode).toBe(1);
   expect(stderr).toMatch(
     `TypeError: globalTeardown file must export a function at ${teardownPath}`,
   );
@@ -79,7 +78,7 @@ test('should call globalTeardown function of multiple projects', () => {
 
   const result = runWithJson('global-teardown', [`--config=${configPath}`]);
 
-  expect(result.status).toBe(0);
+  expect(result.exitCode).toBe(0);
 
   expect(fs.existsSync(DIR)).toBe(true);
   expect(fs.existsSync(project1DIR)).toBe(true);
@@ -94,7 +93,7 @@ test('should not call a globalTeardown of a project if there are no tests to run
     '--testPathPattern=project-1',
   ]);
 
-  expect(result.status).toBe(0);
+  expect(result.exitCode).toBe(0);
 
   expect(fs.existsSync(DIR)).toBe(true);
   expect(fs.existsSync(project1DIR)).toBe(true);
@@ -120,12 +119,12 @@ test('globalTeardown throws with named export', () => {
     'invalidTeardownWithNamedExport.js',
   );
 
-  const {status, stderr} = runJest(e2eDir, [
+  const {exitCode, stderr} = runJest(e2eDir, [
     `--globalTeardown=${teardownPath}`,
     `--testPathPattern=__tests__`,
   ]);
 
-  expect(status).toBe(1);
+  expect(exitCode).toBe(1);
   expect(stderr).toMatch(
     `TypeError: globalTeardown file must export a function at ${teardownPath}`,
   );

--- a/e2e/__tests__/globals.test.ts
+++ b/e2e/__tests__/globals.test.ts
@@ -44,8 +44,8 @@ test('basic test constructs', () => {
   `;
 
   writeFiles(TEST_DIR, {[filename]: content});
-  const {stderr, status} = runJest(DIR);
-  expect(status).toBe(0);
+  const {stderr, exitCode} = runJest(DIR);
+  expect(exitCode).toBe(0);
 
   const {summary, rest} = extractSummary(stderr);
   expect(wrap(rest)).toMatchSnapshot();
@@ -75,12 +75,12 @@ test('skips', () => {
   `;
 
   writeFiles(TEST_DIR, {[filename]: content});
-  const {stderr, status} = runJest(DIR);
+  const {stderr, exitCode} = runJest(DIR);
 
   const {summary, rest} = extractSummary(stderr);
   expect(wrap(rest)).toMatchSnapshot();
   expect(wrap(summary)).toMatchSnapshot();
-  expect(status).toBe(0);
+  expect(exitCode).toBe(0);
 });
 
 test('only', () => {
@@ -105,8 +105,8 @@ test('only', () => {
   `;
 
   writeFiles(TEST_DIR, {[filename]: content});
-  const {stderr, status} = runJest(DIR);
-  expect(status).toBe(0);
+  const {stderr, exitCode} = runJest(DIR);
+  expect(exitCode).toBe(0);
 
   const {summary, rest} = extractSummary(stderr);
   expect(wrap(rest)).toMatchSnapshot();
@@ -120,8 +120,8 @@ test('cannot have describe with no implementation', () => {
   `;
 
   writeFiles(TEST_DIR, {[filename]: content});
-  const {stderr, status} = runJest(DIR);
-  expect(status).toBe(1);
+  const {stderr, exitCode} = runJest(DIR);
+  expect(exitCode).toBe(1);
 
   const rest = cleanStderr(stderr);
   const {summary} = extractSummary(stderr);
@@ -138,8 +138,8 @@ test('cannot test with no implementation', () => {
   `;
 
   writeFiles(TEST_DIR, {[filename]: content});
-  const {stderr, status} = runJest(DIR);
-  expect(status).toBe(1);
+  const {stderr, exitCode} = runJest(DIR);
+  expect(exitCode).toBe(1);
 
   const {summary} = extractSummary(stderr);
   expect(wrap(cleanStderr(stderr))).toMatchSnapshot();
@@ -169,8 +169,8 @@ test('skips with expand arg', () => {
   `;
 
   writeFiles(TEST_DIR, {[filename]: content});
-  const {stderr, status} = runJest(DIR, ['--expand']);
-  expect(status).toBe(0);
+  const {stderr, exitCode} = runJest(DIR, ['--expand']);
+  expect(exitCode).toBe(0);
 
   const {summary, rest} = extractSummary(stderr);
   expect(wrap(rest)).toMatchSnapshot();
@@ -199,8 +199,8 @@ test('only with expand arg', () => {
   `;
 
   writeFiles(TEST_DIR, {[filename]: content});
-  const {stderr, status} = runJest(DIR, ['--expand']);
-  expect(status).toBe(0);
+  const {stderr, exitCode} = runJest(DIR, ['--expand']);
+  expect(exitCode).toBe(0);
 
   const {summary, rest} = extractSummary(stderr);
   expect(wrap(rest)).toMatchSnapshot();
@@ -216,8 +216,8 @@ test('cannot test with no implementation with expand arg', () => {
   `;
 
   writeFiles(TEST_DIR, {[filename]: content});
-  const {stderr, status} = runJest(DIR, ['--expand']);
-  expect(status).toBe(1);
+  const {stderr, exitCode} = runJest(DIR, ['--expand']);
+  expect(exitCode).toBe(1);
 
   const {summary} = extractSummary(stderr);
   expect(wrap(cleanStderr(stderr))).toMatchSnapshot();
@@ -234,8 +234,8 @@ test('function as descriptor', () => {
   `;
 
   writeFiles(TEST_DIR, {[filename]: content});
-  const {stderr, status} = runJest(DIR);
-  expect(status).toBe(0);
+  const {stderr, exitCode} = runJest(DIR);
+  expect(exitCode).toBe(0);
 
   const {summary, rest} = extractSummary(stderr);
   expect(wrap(rest)).toMatchSnapshot();

--- a/e2e/__tests__/jasmineAsync.test.ts
+++ b/e2e/__tests__/jasmineAsync.test.ts
@@ -9,8 +9,7 @@ import runJest, {json as runWithJson} from '../runJest';
 
 describe('async jasmine', () => {
   it('works with beforeAll', () => {
-    const result = runWithJson('jasmine-async', ['promiseBeforeAll.test.js']);
-    const json = result.json;
+    const {json} = runWithJson('jasmine-async', ['promiseBeforeAll.test.js']);
 
     expect(json.numTotalTests).toBe(4);
     expect(json.numPassedTests).toBe(1);
@@ -25,8 +24,7 @@ describe('async jasmine', () => {
   });
 
   it('works with beforeEach', () => {
-    const result = runWithJson('jasmine-async', ['promiseBeforeEach.test.js']);
-    const json = result.json;
+    const {json} = runWithJson('jasmine-async', ['promiseBeforeEach.test.js']);
 
     expect(json.numTotalTests).toBe(3);
     expect(json.numPassedTests).toBe(1);
@@ -40,7 +38,7 @@ describe('async jasmine', () => {
 
   it('works with afterAll', () => {
     const result = runWithJson('jasmine-async', ['promiseAfterAll.test.js']);
-    const json = result.json;
+    const {json} = result;
 
     expect(json.numTotalTests).toBe(2);
     expect(json.numPassedTests).toBe(2);
@@ -52,8 +50,7 @@ describe('async jasmine', () => {
   });
 
   it('works with afterEach', () => {
-    const result = runWithJson('jasmine-async', ['promiseAfterEach.test.js']);
-    const json = result.json;
+    const {json} = runWithJson('jasmine-async', ['promiseAfterEach.test.js']);
 
     expect(json.numTotalTests).toBe(2);
     expect(json.numPassedTests).toBe(2);
@@ -63,8 +60,7 @@ describe('async jasmine', () => {
   });
 
   it('works with fit', () => {
-    const result = runWithJson('jasmine-async', ['promiseFit.test.js']);
-    const json = result.json;
+    const {json} = runWithJson('jasmine-async', ['promiseFit.test.js']);
 
     expect(json.numTotalTests).toBe(3);
     expect(json.numPassedTests).toBe(1);
@@ -74,8 +70,7 @@ describe('async jasmine', () => {
   });
 
   it('works with xit', () => {
-    const result = runWithJson('jasmine-async', ['promiseXit.test.js']);
-    const json = result.json;
+    const {json} = runWithJson('jasmine-async', ['promiseXit.test.js']);
 
     expect(json.numTotalTests).toBe(2);
     expect(json.numPassedTests).toBe(1);
@@ -84,8 +79,7 @@ describe('async jasmine', () => {
   });
 
   it('throws when not a promise is returned', () => {
-    const result = runWithJson('jasmine-async', ['returningValues.test.js']);
-    const json = result.json;
+    const {json} = runWithJson('jasmine-async', ['returningValues.test.js']);
 
     expect(json.numTotalTests).toBe(11);
     expect(json.numPassedTests).toBe(0);
@@ -94,8 +88,7 @@ describe('async jasmine', () => {
   });
 
   it('tests async promise code', () => {
-    const result = runWithJson('jasmine-async', ['promiseIt.test.js']);
-    const json = result.json;
+    const {json} = runWithJson('jasmine-async', ['promiseIt.test.js']);
     const message = json.testResults[0].message;
 
     expect(json.numTotalTests).toBe(16);
@@ -114,8 +107,7 @@ describe('async jasmine', () => {
   });
 
   it('works with concurrent', () => {
-    const result = runWithJson('jasmine-async', ['concurrent.test.js']);
-    const json = result.json;
+    const {json} = runWithJson('jasmine-async', ['concurrent.test.js']);
     expect(json.numTotalTests).toBe(4);
     expect(json.numPassedTests).toBe(2);
     expect(json.numFailedTests).toBe(1);
@@ -124,8 +116,7 @@ describe('async jasmine', () => {
   });
 
   it("doesn't execute more than 5 tests simultaneously", () => {
-    const result = runWithJson('jasmine-async', ['concurrent-many.test.js']);
-    const json = result.json;
+    const {json} = runWithJson('jasmine-async', ['concurrent-many.test.js']);
     expect(json.numTotalTests).toBe(10);
     expect(json.numPassedTests).toBe(10);
     expect(json.numFailedTests).toBe(0);
@@ -135,7 +126,7 @@ describe('async jasmine', () => {
   it('async test fails', () => {
     const result = runWithJson('jasmine-async', ['asyncTestFails.test.js']);
 
-    expect(result.status).toBe(1);
+    expect(result.exitCode).toBe(1);
     expect(result.json.testResults[0].message).toEqual(
       expect.stringContaining('Received:'),
     );
@@ -144,6 +135,6 @@ describe('async jasmine', () => {
   it('generator test', () => {
     const result = runJest('jasmine-async', ['generator.test.js']);
 
-    expect(result.status).toBe(0);
+    expect(result.exitCode).toBe(0);
   });
 });

--- a/e2e/__tests__/jasmineAsyncWithPendingDuringTest.ts
+++ b/e2e/__tests__/jasmineAsyncWithPendingDuringTest.ts
@@ -12,8 +12,7 @@ describe('async jasmine with pending during test', () => {
   skipSuiteOnJestCircus();
 
   it('should be reported as a pending test', () => {
-    const result = runWithJson('jasmine-async', ['pendingInPromise.test.js']);
-    const json = result.json;
+    const {json} = runWithJson('jasmine-async', ['pendingInPromise.test.js']);
 
     expect(json.numTotalTests).toBe(1);
     expect(json.numPassedTests).toBe(0);

--- a/e2e/__tests__/jest.config.js.test.ts
+++ b/e2e/__tests__/jest.config.js.test.ts
@@ -22,9 +22,9 @@ test('works with jest.config.js', () => {
     'package.json': '{}',
   });
 
-  const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false']);
+  const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false']);
   const {rest, summary} = extractSummary(stderr);
-  expect(status).toBe(0);
+  expect(exitCode).toBe(0);
   expect(wrap(rest)).toMatchSnapshot();
   expect(wrap(summary)).toMatchSnapshot();
 });
@@ -41,7 +41,7 @@ test('traverses directory tree up until it finds jest.config', () => {
     'some/nested/directory/file.js': '// nothing special',
   });
 
-  const {stderr, status, stdout} = runJest(
+  const {stderr, exitCode, stdout} = runJest(
     path.join(DIR, 'some', 'nested', 'directory'),
     ['-w=1', '--ci=false'],
     {skipPkgJsonCheck: true},
@@ -53,7 +53,7 @@ test('traverses directory tree up until it finds jest.config', () => {
   ).toMatchSnapshot();
 
   const {rest, summary} = extractSummary(stderr);
-  expect(status).toBe(0);
+  expect(exitCode).toBe(0);
   expect(wrap(rest)).toMatchSnapshot();
   expect(wrap(summary)).toMatchSnapshot();
 });
@@ -65,7 +65,7 @@ test('invalid JS in jest.config.js', () => {
     'package.json': '{}',
   });
 
-  const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false']);
+  const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false']);
   expect(stderr).toMatch('SyntaxError: ');
-  expect(status).toBe(1);
+  expect(exitCode).toBe(1);
 });

--- a/e2e/__tests__/jestChangedFiles.test.ts
+++ b/e2e/__tests__/jestChangedFiles.test.ts
@@ -254,9 +254,9 @@ test('handles a bad revision for "changedSince", for git', async () => {
   run(`${GIT} add .`, DIR);
   run(`${GIT} commit --no-gpg-sign -m "first"`, DIR);
 
-  const {status, stderr} = runJest(DIR, ['--changedSince=blablabla']);
+  const {exitCode, stderr} = runJest(DIR, ['--changedSince=blablabla']);
 
-  expect(status).toBe(1);
+  expect(exitCode).toBe(1);
   expect(wrap(stderr)).toMatchSnapshot();
 });
 
@@ -406,8 +406,8 @@ test('handles a bad revision for "changedSince", for hg', async () => {
   run(`${HG} add .`, DIR);
   run(`${HG} commit -m "first"`, DIR);
 
-  const {status, stderr} = runJest(DIR, ['--changedSince=blablabla']);
+  const {exitCode, stderr} = runJest(DIR, ['--changedSince=blablabla']);
 
-  expect(status).toBe(1);
+  expect(exitCode).toBe(1);
   expect(wrap(stderr)).toMatchSnapshot();
 });

--- a/e2e/__tests__/jsonReporter.test.ts
+++ b/e2e/__tests__/jsonReporter.test.ts
@@ -66,7 +66,7 @@ describe('JSON Reporter', () => {
     let jsonResult;
 
     expect(result.stderr).toMatch(/1 failed, 2 passed/);
-    expect(result.status).toBe(1);
+    expect(result.exitCode).toBe(1);
 
     try {
       jsonResult = JSON.parse(result.stdout);

--- a/e2e/__tests__/lifecycles.ts
+++ b/e2e/__tests__/lifecycles.ts
@@ -8,7 +8,7 @@
 import runJest from '../runJest';
 
 test('suite with invalid assertions in afterAll', () => {
-  const {stderr, status} = runJest('lifecycles');
+  const {stderr, exitCode} = runJest('lifecycles');
   expect(stderr).toMatch(/afterAll just failed!/);
-  expect(status).toBe(1);
+  expect(exitCode).toBe(1);
 });

--- a/e2e/__tests__/listTests.test.ts
+++ b/e2e/__tests__/listTests.test.ts
@@ -20,9 +20,9 @@ const normalizePaths = rawPaths =>
 
 describe('--listTests flag', () => {
   it('causes tests to be printed in different lines', () => {
-    const {status, stdout} = runJest('list-tests', ['--listTests']);
+    const {exitCode, stdout} = runJest('list-tests', ['--listTests']);
 
-    expect(status).toBe(0);
+    expect(exitCode).toBe(0);
     expect(
       wrap(
         normalizePaths(stdout)
@@ -34,9 +34,9 @@ describe('--listTests flag', () => {
   });
 
   it('causes tests to be printed out as JSON when using the --json flag', () => {
-    const {status, stdout} = runJest('list-tests', ['--listTests', '--json']);
+    const {exitCode, stdout} = runJest('list-tests', ['--listTests', '--json']);
 
-    expect(status).toBe(0);
+    expect(exitCode).toBe(0);
     expect(() => JSON.parse(stdout)).not.toThrow();
     expect(
       wrap(

--- a/e2e/__tests__/mockNames.test.ts
+++ b/e2e/__tests__/mockNames.test.ts
@@ -22,28 +22,36 @@ test('suite without mock name, mock not called', () => {
 });
 
 test('suite with mock name, expect mock not called', () => {
-  const {stderr, exitCode} = runJest('mock-names/with-mock-name-not-called-pass');
+  const {stderr, exitCode} = runJest(
+    'mock-names/with-mock-name-not-called-pass',
+  );
 
   expect(exitCode).toBe(0);
   expect(stderr).toMatch(/PASS/);
 });
 
 test('suite with mock name, mock called, expect fail', () => {
-  const {stderr, exitCode} = runJest('mock-names/with-mock-name-not-called-fail');
+  const {stderr, exitCode} = runJest(
+    'mock-names/with-mock-name-not-called-fail',
+  );
 
   expect(exitCode).toBe(1);
   expect(stderr).toMatch(/expect\(myMockedFunction\)\.not\.toHaveBeenCalled/);
 });
 
 test('suite with mock name, mock called 5 times', () => {
-  const {stderr, exitCode} = runJest('mock-names/with-mock-name-call-times-pass');
+  const {stderr, exitCode} = runJest(
+    'mock-names/with-mock-name-call-times-pass',
+  );
 
   expect(exitCode).toBe(0);
   expect(stderr).toMatch(/PASS/);
 });
 
 test('suite with mock name, mock not called 5 times, expect fail', () => {
-  const {stderr, exitCode} = runJest('mock-names/with-mock-name-call-times-fail');
+  const {stderr, exitCode} = runJest(
+    'mock-names/with-mock-name-call-times-fail',
+  );
 
   expect(exitCode).toBe(1);
   expect(stderr).toMatch(/expect\(myMockedFunction\)\.toHaveBeenCalledTimes/);

--- a/e2e/__tests__/mockNames.test.ts
+++ b/e2e/__tests__/mockNames.test.ts
@@ -8,57 +8,57 @@
 import runJest from '../runJest';
 
 test('suite without mock name, mock called', () => {
-  const {stderr, status} = runJest('mock-names/without-mock-name');
+  const {stderr, exitCode} = runJest('mock-names/without-mock-name');
 
-  expect(status).toBe(0);
+  expect(exitCode).toBe(0);
   expect(stderr).toMatch(/PASS/);
 });
 
 test('suite without mock name, mock not called', () => {
-  const {stderr, status} = runJest('mock-names/without-mock-name-not-called');
+  const {stderr, exitCode} = runJest('mock-names/without-mock-name-not-called');
 
-  expect(status).toBe(1);
+  expect(exitCode).toBe(1);
   expect(stderr).toMatch(/expect\(jest\.fn\(\)\)\.toHaveBeenCalled/);
 });
 
 test('suite with mock name, expect mock not called', () => {
-  const {stderr, status} = runJest('mock-names/with-mock-name-not-called-pass');
+  const {stderr, exitCode} = runJest('mock-names/with-mock-name-not-called-pass');
 
-  expect(status).toBe(0);
+  expect(exitCode).toBe(0);
   expect(stderr).toMatch(/PASS/);
 });
 
 test('suite with mock name, mock called, expect fail', () => {
-  const {stderr, status} = runJest('mock-names/with-mock-name-not-called-fail');
+  const {stderr, exitCode} = runJest('mock-names/with-mock-name-not-called-fail');
 
-  expect(status).toBe(1);
+  expect(exitCode).toBe(1);
   expect(stderr).toMatch(/expect\(myMockedFunction\)\.not\.toHaveBeenCalled/);
 });
 
 test('suite with mock name, mock called 5 times', () => {
-  const {stderr, status} = runJest('mock-names/with-mock-name-call-times-pass');
+  const {stderr, exitCode} = runJest('mock-names/with-mock-name-call-times-pass');
 
-  expect(status).toBe(0);
+  expect(exitCode).toBe(0);
   expect(stderr).toMatch(/PASS/);
 });
 
 test('suite with mock name, mock not called 5 times, expect fail', () => {
-  const {stderr, status} = runJest('mock-names/with-mock-name-call-times-fail');
+  const {stderr, exitCode} = runJest('mock-names/with-mock-name-call-times-fail');
 
-  expect(status).toBe(1);
+  expect(exitCode).toBe(1);
   expect(stderr).toMatch(/expect\(myMockedFunction\)\.toHaveBeenCalledTimes/);
 });
 
 test('suite with mock name, mock called', () => {
-  const {stderr, status} = runJest('mock-names/with-mock-name');
+  const {stderr, exitCode} = runJest('mock-names/with-mock-name');
 
-  expect(status).toBe(0);
+  expect(exitCode).toBe(0);
   expect(stderr).toMatch(/PASS/);
 });
 
 test('suite with mock name, mock not called', () => {
-  const {stderr, status} = runJest('mock-names/with-mock-name-not-called');
+  const {stderr, exitCode} = runJest('mock-names/with-mock-name-not-called');
 
-  expect(status).toBe(1);
+  expect(exitCode).toBe(1);
   expect(stderr).toMatch(/expect\(myMockedFunction\)\.toHaveBeenCalled/);
 });

--- a/e2e/__tests__/moduleNameMapper.test.ts
+++ b/e2e/__tests__/moduleNameMapper.test.ts
@@ -10,20 +10,20 @@ import runJest, {json as runWithJson} from '../runJest';
 import {extractSummary} from '../Utils';
 
 test('moduleNameMapper wrong configuration', () => {
-  const {stderr, status} = runJest('module-name-mapper-wrong-config');
+  const {stderr, exitCode} = runJest('module-name-mapper-wrong-config');
   const {rest} = extractSummary(stderr);
 
-  expect(status).toBe(1);
+  expect(exitCode).toBe(1);
   expect(wrap(rest)).toMatchSnapshot();
 });
 
 test('moduleNameMapper correct configuration', () => {
-  const {stderr, status} = runJest('module-name-mapper-correct-config', [], {
+  const {stderr, exitCode} = runJest('module-name-mapper-correct-config', [], {
     stripAnsi: true,
   });
   const {rest} = extractSummary(stderr);
 
-  expect(status).toBe(0);
+  expect(exitCode).toBe(0);
   expect(wrap(rest)).toMatchSnapshot();
 });
 

--- a/e2e/__tests__/moduleParentNullInTest.ts
+++ b/e2e/__tests__/moduleParentNullInTest.ts
@@ -8,7 +8,7 @@
 import runJest from '../runJest';
 
 test('module.parent should be null in test files', () => {
-  const {status} = runJest('module-parent-null-in-test');
+  const {exitCode} = runJest('module-parent-null-in-test');
 
-  expect(status).toBe(0);
+  expect(exitCode).toBe(0);
 });

--- a/e2e/__tests__/multiProjectRunner.test.ts
+++ b/e2e/__tests__/multiProjectRunner.test.ts
@@ -198,11 +198,11 @@ test.each([{projectPath: 'packages/somepackage'}, {projectPath: 'packages/*'}])(
       `,
     });
 
-    const {stdout, stderr, status} = runJest(DIR, ['--no-watchman']);
+    const {stdout, stderr, exitCode} = runJest(DIR, ['--no-watchman']);
     expect(stderr).toContain('PASS packages/somepackage/test.js');
     expect(stderr).toContain('Test Suites: 1 passed, 1 total');
     expect(stdout).toEqual('');
-    expect(status).toEqual(0);
+    expect(exitCode).toEqual(0);
   },
 );
 
@@ -229,14 +229,14 @@ test('projects can be workspaces with non-JS/JSON files', () => {
     'packages/project2/package.json': '{}',
   });
 
-  const {status, stdout, stderr} = runJest(DIR, ['--no-watchman']);
+  const {exitCode, stdout, stderr} = runJest(DIR, ['--no-watchman']);
 
   expect(stderr).toContain('Test Suites: 2 passed, 2 total');
   expect(stderr).toContain('PASS packages/project1/__tests__/file1.test.js');
   expect(stderr).toContain('PASS packages/project2/__tests__/file2.test.js');
   expect(stderr).toContain('Ran all test suites in 2 projects.');
   expect(stdout).toEqual('');
-  expect(status).toEqual(0);
+  expect(exitCode).toEqual(0);
 });
 
 test('objects in project configuration', () => {
@@ -256,13 +256,13 @@ test('objects in project configuration', () => {
     'package.json': '{}',
   });
 
-  const {stdout, stderr, status} = runJest(DIR, ['--no-watchman']);
+  const {stdout, stderr, exitCode} = runJest(DIR, ['--no-watchman']);
   expect(stderr).toContain('Test Suites: 2 passed, 2 total');
   expect(stderr).toContain('PASS __tests__/file1.test.js');
   expect(stderr).toContain('PASS __tests__/file2.test.js');
   expect(stderr).toContain('Ran all test suites in 2 projects.');
   expect(stdout).toEqual('');
-  expect(status).toEqual(0);
+  expect(exitCode).toEqual(0);
 });
 
 test('allows a single project', () => {
@@ -278,11 +278,11 @@ test('allows a single project', () => {
     'package.json': '{}',
   });
 
-  const {stdout, stderr, status} = runJest(DIR, ['--no-watchman']);
+  const {stdout, stderr, exitCode} = runJest(DIR, ['--no-watchman']);
   expect(stderr).toContain('PASS __tests__/file1.test.js');
   expect(stderr).toContain('Test Suites: 1 passed, 1 total');
   expect(stdout).toEqual('');
-  expect(status).toEqual(0);
+  expect(exitCode).toEqual(0);
 });
 
 test('resolves projects and their <rootDir> properly', () => {

--- a/e2e/__tests__/nestedEventLoop.test.ts
+++ b/e2e/__tests__/nestedEventLoop.test.ts
@@ -9,5 +9,5 @@ import runJest from '../runJest';
 
 test('works with nested event loops', () => {
   const result = runJest('nested-event-loop');
-  expect(result.status).toBe(0);
+  expect(result.exitCode).toBe(0);
 });

--- a/e2e/__tests__/noTestsFound.test.ts
+++ b/e2e/__tests__/noTestsFound.test.ts
@@ -12,50 +12,50 @@ const DIR = path.resolve(__dirname, '../no-tests-found-test');
 
 describe('No tests are found', () => {
   test('fails the test suite in standard situation', () => {
-    const {status, stdout} = runJest(DIR, [
+    const {exitCode, stdout} = runJest(DIR, [
       '--testPathPattern',
       '/non/existing/path/',
     ]);
 
     expect(stdout).toMatch('No tests found');
-    expect(status).toBe(1);
+    expect(exitCode).toBe(1);
   });
 
   test("doesn't fail the test suite if --passWithNoTests passed", () => {
-    const {status, stdout} = runJest(DIR, [
+    const {exitCode, stdout} = runJest(DIR, [
       '--testPathPattern',
       '/non/existing/path/',
       '--passWithNoTests',
     ]);
 
     expect(stdout).toMatch('No tests found');
-    expect(status).toBe(0);
+    expect(exitCode).toBe(0);
   });
 
   test("doesn't fail the test suite if using --lastCommit", () => {
     // Since there are no files in DIR no tests will be found
-    const {status, stdout} = runJest(DIR, ['--lastCommit']);
+    const {exitCode, stdout} = runJest(DIR, ['--lastCommit']);
 
     expect(stdout).toMatch('No tests found');
-    expect(status).toBe(0);
+    expect(exitCode).toBe(0);
   });
 
   test("doesn't fail the test suite if using --onlyChanged", () => {
     // Since there are no files in DIR no tests will be found
-    const {status, stdout} = runJest(DIR, ['--onlyChanged']);
+    const {exitCode, stdout} = runJest(DIR, ['--onlyChanged']);
 
     expect(stdout).toMatch('No tests found');
-    expect(status).toBe(0);
+    expect(exitCode).toBe(0);
   });
 
   test("doesn't fail the test suite if using --findRelatedTests", () => {
     // Since there are no files in DIR no tests will be found
-    const {status, stdout} = runJest(DIR, [
+    const {exitCode, stdout} = runJest(DIR, [
       '--findRelatedTests',
       '/non/existing/path',
     ]);
 
     expect(stdout).toMatch('No tests found');
-    expect(status).toBe(0);
+    expect(exitCode).toBe(0);
   });
 });

--- a/e2e/__tests__/nodePath.test.ts
+++ b/e2e/__tests__/nodePath.test.ts
@@ -11,5 +11,5 @@ test('supports NODE_PATH', () => {
   const result = runJest('node-path', [], {
     nodePath: ['../node-path/src'],
   });
-  expect(result.status).toBe(0);
+  expect(result.exitCode).toBe(0);
 });

--- a/e2e/__tests__/onlyChanged.test.ts
+++ b/e2e/__tests__/onlyChanged.test.ts
@@ -153,12 +153,12 @@ test('do not pickup non-tested files when reporting coverage on only changed fil
     'package.json': JSON.stringify({name: 'new name'}),
   });
 
-  const {stderr, stdout, status} = runJest(DIR, ['-o', '--coverage']);
+  const {stderr, stdout, exitCode} = runJest(DIR, ['-o', '--coverage']);
   expect(stderr).toEqual(
     expect.not.stringContaining('Failed to collect coverage from'),
   );
   expect(stdout).toEqual(expect.not.stringContaining('package.json'));
-  expect(status).toBe(0);
+  expect(exitCode).toBe(0);
 });
 
 test('collect test coverage when using onlyChanged', () => {
@@ -180,11 +180,11 @@ test('collect test coverage when using onlyChanged', () => {
     'b.test.js': 'it("passes", () => {expect(1).toBe(1)})',
   });
 
-  const {stderr, status} = runJest(DIR, ['-o', '--coverage']);
+  const {stderr, exitCode} = runJest(DIR, ['-o', '--coverage']);
   expect(stderr).toEqual(
     expect.not.stringContaining('Failed to collect coverage from'),
   );
-  expect(status).toBe(0);
+  expect(exitCode).toBe(0);
 });
 
 test('onlyChanged in config is overwritten by --all or testPathPattern', () => {

--- a/e2e/__tests__/presets.test.ts
+++ b/e2e/__tests__/presets.test.ts
@@ -9,10 +9,10 @@ import runJest from '../runJest';
 
 test('supports json preset', () => {
   const result = runJest('presets/json');
-  expect(result.status).toBe(0);
+  expect(result.exitCode).toBe(0);
 });
 
 test('supports js preset', () => {
   const result = runJest('presets/js');
-  expect(result.status).toBe(0);
+  expect(result.exitCode).toBe(0);
 });

--- a/e2e/__tests__/promiseReject.test.ts
+++ b/e2e/__tests__/promiseReject.test.ts
@@ -23,8 +23,8 @@ test('', () => {
      });
    `,
   });
-  const {stdout, stderr, status} = runJest(DIR);
+  const {stdout, stderr, exitCode} = runJest(DIR);
   expect(stdout).toBe('');
   expect(stderr).toMatch(/(Failed|thrown): null/);
-  expect(status).toBe(1);
+  expect(exitCode).toBe(1);
 });

--- a/e2e/__tests__/resetModules.test.ts
+++ b/e2e/__tests__/resetModules.test.ts
@@ -9,5 +9,5 @@ import runJest from '../runJest';
 
 test('jest.resetModules should not error when _isMockFunction is defined but not boolean', () => {
   const result = runJest('reset-modules');
-  expect(result.status).toBe(0);
+  expect(result.exitCode).toBe(0);
 });

--- a/e2e/__tests__/resolve.test.ts
+++ b/e2e/__tests__/resolve.test.ts
@@ -9,5 +9,5 @@ import runJest from '../runJest';
 
 test('resolve platform modules', () => {
   const result = runJest('resolve');
-  expect(result.status).toBe(0);
+  expect(result.exitCode).toBe(0);
 });

--- a/e2e/__tests__/resolveGetPaths.test.ts
+++ b/e2e/__tests__/resolveGetPaths.test.ts
@@ -8,6 +8,6 @@
 import runJest from '../runJest';
 
 test('require.resolve.paths', () => {
-  const {status} = runJest('resolve-get-paths');
-  expect(status).toBe(0);
+  const {exitCode} = runJest('resolve-get-paths');
+  expect(exitCode).toBe(0);
 });

--- a/e2e/__tests__/resolveNoFileExtensions.test.ts
+++ b/e2e/__tests__/resolveNoFileExtensions.test.ts
@@ -16,10 +16,10 @@ beforeEach(() => cleanup(DIR));
 afterAll(() => cleanup(DIR));
 
 test('show error message with matching files', () => {
-  const {status, stderr} = runJest('resolve-no-extensions');
+  const {exitCode, stderr} = runJest('resolve-no-extensions');
   const {rest} = extractSummary(stderr);
 
-  expect(status).toBe(1);
+  expect(exitCode).toBe(1);
   expect(wrap(rest)).toMatchSnapshot();
 });
 
@@ -44,8 +44,8 @@ test('show error message when no js moduleFileExtensions', () => {
     `,
   });
 
-  const {status, stderr} = runJest('resolve-no-extensions-no-js');
+  const {exitCode, stderr} = runJest('resolve-no-extensions-no-js');
 
-  expect(status).toBe(1);
+  expect(exitCode).toBe(1);
   expect(wrap(stderr)).toMatchSnapshot();
 });

--- a/e2e/__tests__/resolveNodeModule.test.ts
+++ b/e2e/__tests__/resolveNodeModule.test.ts
@@ -9,5 +9,5 @@ import runJest from '../runJest';
 
 test('resolve node module', () => {
   const result = runJest('resolve-node-module');
-  expect(result.status).toBe(0);
+  expect(result.exitCode).toBe(0);
 });

--- a/e2e/__tests__/resolveWithPaths.test.ts
+++ b/e2e/__tests__/resolveWithPaths.test.ts
@@ -27,6 +27,6 @@ afterAll(() => {
 });
 
 test('require.resolve with paths', () => {
-  const {status} = runJest('resolve-with-paths');
-  expect(status).toBe(0);
+  const {exitCode} = runJest('resolve-with-paths');
+  expect(exitCode).toBe(0);
 });

--- a/e2e/__tests__/setImmediate.test.ts
+++ b/e2e/__tests__/setImmediate.test.ts
@@ -11,5 +11,5 @@ test('setImmediate', () => {
   const result = runJest('set-immediate', ['--verbose']);
 
   expect(result.stderr).toMatch('setImmediate test');
-  expect(result.status).toBe(0);
+  expect(result.exitCode).toBe(0);
 });

--- a/e2e/__tests__/setupFilesAfterEnvConfig.test.ts
+++ b/e2e/__tests__/setupFilesAfterEnvConfig.test.ts
@@ -41,7 +41,7 @@ describe('setupFilesAfterEnv', () => {
     expect(result.json.numTotalTests).toBe(2);
     expect(result.json.numPassedTests).toBe(2);
     expect(result.json.testResults.length).toBe(2);
-    expect(result.status).toBe(0);
+    expect(result.exitCode).toBe(0);
   });
 
   it('requires setup files *after* the test runners are required', () => {
@@ -62,6 +62,6 @@ describe('setupFilesAfterEnv', () => {
     expect(result.json.numTotalTests).toBe(1);
     expect(result.json.numPassedTests).toBe(1);
     expect(result.json.testResults.length).toBe(1);
-    expect(result.status).toBe(0);
+    expect(result.exitCode).toBe(0);
   });
 });

--- a/e2e/__tests__/snapshot-unknown.test.ts
+++ b/e2e/__tests__/snapshot-unknown.test.ts
@@ -15,6 +15,6 @@ describe('Snapshot serializers', () => {
     expect(stderr).toMatch('2 snapshot files obsolete');
     expect(stderr).toMatch('__tests__/__snapshots__/fails.test.js.snap');
     expect(stderr).toMatch('__tests__/__snapshots__/fails2.test.js.snap');
-    expect(result.status).toBe(1);
+    expect(result.exitCode).toBe(1);
   });
 });

--- a/e2e/__tests__/snapshot.test.ts
+++ b/e2e/__tests__/snapshot.test.ts
@@ -56,7 +56,7 @@ const snapshotEscapeSubstitutionFile = path.resolve(
 
 const initialTestData = fs.readFileSync(snapshotEscapeTestFile, 'utf8');
 
-const fileExists = filePath => {
+const fileExists = (filePath: string) => {
   try {
     return fs.statSync(filePath).isFile();
   } catch (e) {}
@@ -98,22 +98,24 @@ describe('Snapshot', () => {
   afterAll(cleanup);
 
   it('stores new snapshots on the first run', () => {
-    const result = runWithJson('snapshot', ['-w=1', '--ci=false']);
-    const json = result.json;
+    const {exitCode, json, stderr} = runWithJson('snapshot', [
+      '-w=1',
+      '--ci=false',
+    ]);
 
     expect(json.numTotalTests).toBe(5);
     expect(json.numPassedTests).toBe(5);
     expect(json.numFailedTests).toBe(0);
     expect(json.numPendingTests).toBe(0);
-    expect(result.status).toBe(0);
+    expect(exitCode).toBe(0);
 
     const content = require(snapshotFile);
     expect(
       content['snapshot is not influenced by previous counter 1'],
     ).not.toBeUndefined();
 
-    expect(result.stderr).toMatch('5 snapshots written from 2 test suites');
-    expect(wrap(extractSummary(result.stderr).summary)).toMatchSnapshot();
+    expect(stderr).toMatch('5 snapshots written from 2 test suites');
+    expect(wrap(extractSummary(stderr).summary)).toMatchSnapshot();
   });
 
   it('works with escaped characters', () => {
@@ -126,7 +128,7 @@ describe('Snapshot', () => {
     let stderr = result.stderr;
 
     expect(stderr).toMatch('1 snapshot written');
-    expect(result.status).toBe(0);
+    expect(result.exitCode).toBe(0);
     expect(wrap(extractSummary(stderr).summary)).toMatchSnapshot();
 
     // Write the second snapshot
@@ -146,7 +148,7 @@ describe('Snapshot', () => {
 
     expect(stderr).toMatch('1 snapshot written');
     expect(wrap(extractSummary(stderr).summary)).toMatchSnapshot();
-    expect(result.status).toBe(0);
+    expect(result.exitCode).toBe(0);
 
     // Now let's check again if everything still passes.
     // If this test doesn't pass, some snapshot data was not properly escaped.
@@ -159,7 +161,7 @@ describe('Snapshot', () => {
 
     expect(stderr).not.toMatch('Snapshot Summary');
     expect(wrap(extractSummary(stderr).summary)).toMatchSnapshot();
-    expect(result.status).toBe(0);
+    expect(result.exitCode).toBe(0);
   });
 
   it('works with escaped regex', () => {
@@ -172,7 +174,7 @@ describe('Snapshot', () => {
     let stderr = result.stderr;
 
     expect(stderr).toMatch('2 snapshots written from 1 test suite.');
-    expect(result.status).toBe(0);
+    expect(result.exitCode).toBe(0);
     expect(wrap(extractSummary(stderr).summary)).toMatchSnapshot();
 
     result = runJest('snapshot-escape', [
@@ -186,7 +188,7 @@ describe('Snapshot', () => {
     // indicate that the snapshot couldn't be loaded properly.
     expect(stderr).not.toMatch('Snapshot Summary');
     expect(wrap(extractSummary(stderr).summary)).toMatchSnapshot();
-    expect(result.status).toBe(0);
+    expect(result.exitCode).toBe(0);
   });
 
   it('works with template literal substitutions', () => {
@@ -199,7 +201,7 @@ describe('Snapshot', () => {
     let stderr = result.stderr;
 
     expect(stderr).toMatch('1 snapshot written');
-    expect(result.status).toBe(0);
+    expect(result.exitCode).toBe(0);
     expect(wrap(extractSummary(stderr).summary)).toMatchSnapshot();
 
     result = runJest('snapshot-escape', [
@@ -213,7 +215,7 @@ describe('Snapshot', () => {
     // indicate that the snapshot couldn't be loaded properly.
     expect(stderr).not.toMatch('1 snapshot written');
     expect(wrap(extractSummary(stderr).summary)).toMatchSnapshot();
-    expect(result.status).toBe(0);
+    expect(result.exitCode).toBe(0);
   });
 
   describe('Validation', () => {

--- a/e2e/__tests__/snapshotMockFs.test.ts
+++ b/e2e/__tests__/snapshotMockFs.test.ts
@@ -19,9 +19,9 @@ beforeEach(() => rimraf.sync(snapshotDir));
 afterAll(() => rimraf.sync(snapshotDir));
 
 test('store snapshot even if fs is mocked', () => {
-  const {json, status, stderr} = runJestJson(DIR, ['--ci=false']);
+  const {json, exitCode, stderr} = runJestJson(DIR, ['--ci=false']);
 
-  expect(status).toBe(0);
+  expect(exitCode).toBe(0);
   expect(json.numTotalTests).toBe(1);
   expect(json.numPassedTests).toBe(1);
 

--- a/e2e/__tests__/snapshotSerializers.test.ts
+++ b/e2e/__tests__/snapshotSerializers.test.ts
@@ -14,17 +14,16 @@ const snapshotsDir = path.resolve(testDir, '__tests__/__snapshots__');
 const snapshotPath = path.resolve(snapshotsDir, 'snapshot.test.js.snap');
 
 const runAndAssert = () => {
-  const result = runWithJson('snapshot-serializers', [
+  const {exitCode, json} = runWithJson('snapshot-serializers', [
     '-w=1',
     '--ci=false',
     '--no-cache',
   ]);
-  const json = result.json;
   expect(json.numTotalTests).toBe(9);
   expect(json.numPassedTests).toBe(9);
   expect(json.numFailedTests).toBe(0);
   expect(json.numPendingTests).toBe(0);
-  expect(result.status).toBe(0);
+  expect(exitCode).toBe(0);
 };
 
 describe('Snapshot serializers', () => {

--- a/e2e/__tests__/stackTrace.test.ts
+++ b/e2e/__tests__/stackTrace.test.ts
@@ -11,11 +11,11 @@ import {extractSummary} from '../Utils';
 
 describe('Stack Trace', () => {
   it('prints a stack trace for runtime errors', () => {
-    const {status, stderr} = runJest('stack-trace', ['runtimeError.test.js']);
+    const {exitCode, stderr} = runJest('stack-trace', ['runtimeError.test.js']);
 
     expect(wrap(extractSummary(stderr).summary)).toMatchSnapshot();
 
-    expect(status).toBe(1);
+    expect(exitCode).toBe(1);
     expect(stderr).toMatch(
       /ReferenceError: thisIsARuntimeError is not defined/,
     );
@@ -26,13 +26,13 @@ describe('Stack Trace', () => {
   });
 
   it('does not print a stack trace for runtime errors when --noStackTrace is given', () => {
-    const {status, stderr} = runJest('stack-trace', [
+    const {exitCode, stderr} = runJest('stack-trace', [
       'runtimeError.test.js',
       '--noStackTrace',
     ]);
 
     expect(wrap(extractSummary(stderr).summary)).toMatchSnapshot();
-    expect(status).toBe(1);
+    expect(exitCode).toBe(1);
 
     expect(stderr).toMatch(
       /ReferenceError: thisIsARuntimeError is not defined/,
@@ -43,22 +43,22 @@ describe('Stack Trace', () => {
   });
 
   it('prints a stack trace for matching errors', () => {
-    const {status, stderr} = runJest('stack-trace', ['stackTrace.test.js']);
+    const {exitCode, stderr} = runJest('stack-trace', ['stackTrace.test.js']);
 
     expect(wrap(extractSummary(stderr).summary)).toMatchSnapshot();
-    expect(status).toBe(1);
+    expect(exitCode).toBe(1);
 
     expect(stderr).toMatch(/\s+at\s(?:.+?)\s\(__tests__\/stackTrace.test\.js/);
   });
 
   it('does not print a stack trace for matching errors when --noStackTrace is given', () => {
-    const {status, stderr} = runJest('stack-trace', [
+    const {exitCode, stderr} = runJest('stack-trace', [
       'stackTrace.test.js',
       '--noStackTrace',
     ]);
 
     expect(wrap(extractSummary(stderr).summary)).toMatchSnapshot();
-    expect(status).toBe(1);
+    expect(exitCode).toBe(1);
 
     expect(stderr).not.toMatch(
       /\s+at\s(?:.+?)\s\(__tests__\/stackTrace.test\.js/,
@@ -66,10 +66,10 @@ describe('Stack Trace', () => {
   });
 
   it('prints a stack trace for errors', () => {
-    const {status, stderr} = runJest('stack-trace', ['testError.test.js']);
+    const {exitCode, stderr} = runJest('stack-trace', ['testError.test.js']);
 
     expect(wrap(extractSummary(stderr).summary)).toMatchSnapshot();
-    expect(status).toBe(1);
+    expect(exitCode).toBe(1);
 
     expect(stderr).toMatch(/this is unexpected\./);
     expect(stderr).toMatch(/this is a string\./);
@@ -87,12 +87,12 @@ describe('Stack Trace', () => {
   });
 
   it('prints a stack trace for errors without message in stack trace', () => {
-    const {status, stderr} = runJest('stack-trace', [
+    const {exitCode, stderr} = runJest('stack-trace', [
       'stackTraceWithoutMessage.test.js',
     ]);
 
     expect(wrap(extractSummary(stderr).summary)).toMatchSnapshot();
-    expect(status).toBe(1);
+    expect(exitCode).toBe(1);
 
     expect(stderr).toMatch(/important message/);
     expect(stderr).toMatch(
@@ -101,13 +101,13 @@ describe('Stack Trace', () => {
   });
 
   it('does not print a stack trace for errors when --noStackTrace is given', () => {
-    const {status, stderr} = runJest('stack-trace', [
+    const {exitCode, stderr} = runJest('stack-trace', [
       'testError.test.js',
       '--noStackTrace',
     ]);
 
     expect(wrap(extractSummary(stderr).summary)).toMatchSnapshot();
-    expect(status).toBe(1);
+    expect(exitCode).toBe(1);
 
     expect(stderr).not.toMatch(
       /\s+at\s(?:.+?)\s\(__tests__\/testError.test\.js/,

--- a/e2e/__tests__/stackTraceNoCaptureStackTrace.test.ts
+++ b/e2e/__tests__/stackTraceNoCaptureStackTrace.test.ts
@@ -8,7 +8,7 @@
 import runJest from '../runJest';
 
 it('prints a usable stack trace even if no Error.captureStackTrace', () => {
-  const {stderr, status} = runJest('stack-trace-no-capture-stack-trace');
+  const {stderr, exitCode} = runJest('stack-trace-no-capture-stack-trace');
   expect(stderr).not.toMatch('Error.captureStackTrace is not a function');
-  expect(status).toBe(1);
+  expect(exitCode).toBe(1);
 });

--- a/e2e/__tests__/supportsDashedArgs.ts
+++ b/e2e/__tests__/supportsDashedArgs.ts
@@ -26,10 +26,10 @@ test('works with passing tests', () => {
     '--clear-mocks',
     '--useStderr',
   ]);
-  if (result.status !== 0) {
+  if (result.exitCode !== 0) {
     console.error(result.stderr);
   }
-  expect(result.status).toBe(0);
+  expect(result.exitCode).toBe(0);
 });
 
 test('throws error for unknown dashed & camelcase args', () => {
@@ -54,5 +54,5 @@ test('throws error for unknown dashed & camelcase args', () => {
       https://jestjs.io/docs/en/cli.html
 
   `);
-  expect(result.status).toBe(1);
+  expect(result.exitCode).toBe(1);
 });

--- a/e2e/__tests__/supportsDashedArgs.ts
+++ b/e2e/__tests__/supportsDashedArgs.ts
@@ -17,7 +17,7 @@ expect.addSnapshotSerializer({
 });
 
 test('works with passing tests', () => {
-  const result = runJest(eachDir, [
+  const {exitCode} = runJest(eachDir, [
     'success.test.js',
     '--runInBand',
     '--collect-coverage',
@@ -26,14 +26,11 @@ test('works with passing tests', () => {
     '--clear-mocks',
     '--useStderr',
   ]);
-  if (result.exitCode !== 0) {
-    console.error(result.stderr);
-  }
-  expect(result.exitCode).toBe(0);
+  expect(exitCode).toBe(0);
 });
 
 test('throws error for unknown dashed & camelcase args', () => {
-  const result = runJest(consoleDir, [
+  const {exitCode, stderr} = runJest(consoleDir, [
     'success.test.js',
     '--runInBand',
     '--collect-coverage',
@@ -44,7 +41,7 @@ test('throws error for unknown dashed & camelcase args', () => {
     '--also-does-not-exist',
     '--useStderr',
   ]);
-  expect(result.stderr).toMatchInlineSnapshot(`
+  expect(stderr).toMatchInlineSnapshot(`
     ● Unrecognized CLI Parameters:
 
       Following options were not recognized:
@@ -54,5 +51,5 @@ test('throws error for unknown dashed & camelcase args', () => {
       https://jestjs.io/docs/en/cli.html
 
   `);
-  expect(result.exitCode).toBe(1);
+  expect(exitCode).toBe(1);
 });

--- a/e2e/__tests__/testEnvironmentAsync.test.ts
+++ b/e2e/__tests__/testEnvironmentAsync.test.ts
@@ -26,7 +26,7 @@ it('triggers setup/teardown hooks', () => {
   const testFile = path.join(testDir, 'custom.test.js');
 
   const result = runJest('test-environment-async');
-  expect(result.status).toBe(0);
+  expect(result.exitCode).toBe(0);
   expect(result.stdout).toContain(`TestEnvironment.setup: ${testFile}`);
 
   const teardown = fs.readFileSync(DIR + '/teardown', 'utf8');

--- a/e2e/__tests__/testFailureExitCode.test.ts
+++ b/e2e/__tests__/testFailureExitCode.test.ts
@@ -23,11 +23,11 @@ test('exits with a specified code when test fail', () => {
     }),
   });
 
-  let {status} = runJest(DIR);
-  expect(status).toBe(99);
+  let {exitCode} = runJest(DIR);
+  expect(exitCode).toBe(99);
 
-  ({status} = runJest(DIR, ['--testFailureExitCode', '77']));
-  expect(status).toBe(77);
+  ({exitCode} = runJest(DIR, ['--testFailureExitCode', '77']));
+  expect(exitCode).toBe(77);
 
   writeFiles(DIR, {
     '__tests__/test.test.js': `test('test', () => { expect(1).toBe(2); });`,
@@ -35,6 +35,6 @@ test('exits with a specified code when test fail', () => {
       jest: {testEnvironment: 'node'},
     }),
   });
-  ({status} = runJest(DIR));
-  expect(status).toBe(1);
+  ({exitCode} = runJest(DIR));
+  expect(exitCode).toBe(1);
 });

--- a/e2e/__tests__/testNamePattern.test.ts
+++ b/e2e/__tests__/testNamePattern.test.ts
@@ -10,12 +10,12 @@ import {extractSummary} from '../Utils';
 import {json as runWithJson} from '../runJest';
 
 test('testNamePattern', () => {
-  const {stderr, status} = runWithJson('test-name-pattern', [
+  const {stderr, exitCode} = runWithJson('test-name-pattern', [
     '--testNamePattern',
     'should match',
   ]);
   const {summary} = extractSummary(stderr);
 
-  expect(status).toBe(0);
+  expect(exitCode).toBe(0);
   expect(wrap(summary)).toMatchSnapshot();
 });

--- a/e2e/__tests__/testNamePatternSkipped.test.ts
+++ b/e2e/__tests__/testNamePatternSkipped.test.ts
@@ -10,12 +10,12 @@ import {extractSummary} from '../Utils';
 import {json as runWithJson} from '../runJest';
 
 test('testNamePattern skipped', () => {
-  const {stderr, status} = runWithJson('test-name-pattern-skipped', [
+  const {stderr, exitCode} = runWithJson('test-name-pattern-skipped', [
     '--testNamePattern',
     'false',
   ]);
   const {summary} = extractSummary(stderr);
 
-  expect(status).toBe(0);
+  expect(exitCode).toBe(0);
   expect(wrap(summary)).toMatchSnapshot();
 });

--- a/e2e/__tests__/testPathPatternReporterMessage.test.ts
+++ b/e2e/__tests__/testPathPatternReporterMessage.test.ts
@@ -5,8 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-'use strict';
-
 import {tmpdir} from 'os';
 import * as path from 'path';
 import runJest from '../runJest';

--- a/e2e/__tests__/testResultsProcessor.test.ts
+++ b/e2e/__tests__/testResultsProcessor.test.ts
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-'use strict';
 
 import * as path from 'path';
 import {json as runWithJson} from '../runJest';
@@ -14,10 +13,9 @@ test('testNamePattern', () => {
     __dirname,
     '../test-results-processor/processor.js',
   );
-  const result = runWithJson('test-results-processor', [
+  const {json} = runWithJson('test-results-processor', [
     '--json',
     `--testResultsProcessor=${processorPath}`,
   ]);
-  const json = result.json;
   expect(json.processed).toBe(true);
 });

--- a/e2e/__tests__/testRetries.test.ts
+++ b/e2e/__tests__/testRetries.test.ts
@@ -27,7 +27,7 @@ describe('Test Retries', () => {
   it('retries failed tests', () => {
     const result = runJest('test-retries', ['e2e.test.js']);
 
-    expect(result.status).toEqual(0);
+    expect(result.exitCode).toEqual(0);
     expect(result.failed).toBe(false);
   });
 

--- a/e2e/__tests__/testTodo.test.ts
+++ b/e2e/__tests__/testTodo.test.ts
@@ -13,35 +13,35 @@ const dir = path.resolve(__dirname, '../test-todo');
 
 test('works with all statuses', () => {
   const result = runJest(dir, ['statuses.test.js']);
-  expect(result.status).toBe(1);
+  expect(result.exitCode).toBe(1);
   const {rest} = extractSummary(result.stderr);
   expect(wrap(rest)).toMatchSnapshot();
 });
 
 test('shows error messages when called with no arguments', () => {
   const result = runJest(dir, ['todoNoArgs.test.js']);
-  expect(result.status).toBe(1);
+  expect(result.exitCode).toBe(1);
   const {rest} = extractSummary(result.stderr);
   expect(wrap(rest)).toMatchSnapshot();
 });
 
 test('shows error messages when called with multiple arguments', () => {
   const result = runJest(dir, ['todoMultipleArgs.test.js']);
-  expect(result.status).toBe(1);
+  expect(result.exitCode).toBe(1);
   const {rest} = extractSummary(result.stderr);
   expect(wrap(rest)).toMatchSnapshot();
 });
 
 test('shows error messages when called with invalid argument', () => {
   const result = runJest(dir, ['todoNonString.test.js']);
-  expect(result.status).toBe(1);
+  expect(result.exitCode).toBe(1);
   const {rest} = extractSummary(result.stderr);
   expect(wrap(rest)).toMatchSnapshot();
 });
 
 test('shows todo messages when in verbose mode', () => {
   const result = runJest(dir, ['verbose.test.js', '--verbose']);
-  expect(result.status).toBe(0);
+  expect(result.exitCode).toBe(0);
   const {rest} = extractSummary(result.stderr);
   expect(wrap(rest)).toMatchSnapshot();
 });

--- a/e2e/__tests__/timeouts.test.ts
+++ b/e2e/__tests__/timeouts.test.ts
@@ -5,8 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-'use strict';
-
 import * as path from 'path';
 import {wrap} from 'jest-snapshot-serializer-raw';
 import {cleanup, extractSummary, writeFiles} from '../Utils';
@@ -31,13 +29,13 @@ test('exceeds the timeout', () => {
     'package.json': '{}',
   });
 
-  const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false']);
+  const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false']);
   const {rest, summary} = extractSummary(stderr);
   expect(rest).toMatch(
     /(jest\.setTimeout|jasmine\.DEFAULT_TIMEOUT_INTERVAL|Exceeded timeout)/,
   );
   expect(wrap(summary)).toMatchSnapshot();
-  expect(status).toBe(1);
+  expect(exitCode).toBe(1);
 });
 
 test('does not exceed the timeout', () => {
@@ -54,11 +52,11 @@ test('does not exceed the timeout', () => {
     'package.json': '{}',
   });
 
-  const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false']);
+  const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false']);
   const {rest, summary} = extractSummary(stderr);
   expect(wrap(rest)).toMatchSnapshot();
   expect(wrap(summary)).toMatchSnapshot();
-  expect(status).toBe(0);
+  expect(exitCode).toBe(0);
 });
 
 test('exceeds the command line testTimeout', () => {
@@ -74,7 +72,7 @@ test('exceeds the command line testTimeout', () => {
     'package.json': '{}',
   });
 
-  const {stderr, status} = runJest(DIR, [
+  const {stderr, exitCode} = runJest(DIR, [
     '-w=1',
     '--ci=false',
     '--testTimeout=200',
@@ -84,7 +82,7 @@ test('exceeds the command line testTimeout', () => {
     /(jest\.setTimeout|jasmine\.DEFAULT_TIMEOUT_INTERVAL|Exceeded timeout)/,
   );
   expect(wrap(summary)).toMatchSnapshot();
-  expect(status).toBe(1);
+  expect(exitCode).toBe(1);
 });
 
 test('does not exceed the command line testTimeout', () => {
@@ -100,7 +98,7 @@ test('does not exceed the command line testTimeout', () => {
     'package.json': '{}',
   });
 
-  const {stderr, status} = runJest(DIR, [
+  const {stderr, exitCode} = runJest(DIR, [
     '-w=1',
     '--ci=false',
     '--testTimeout=1000',
@@ -108,5 +106,5 @@ test('does not exceed the command line testTimeout', () => {
   const {rest, summary} = extractSummary(stderr);
   expect(wrap(rest)).toMatchSnapshot();
   expect(wrap(summary)).toMatchSnapshot();
-  expect(status).toBe(0);
+  expect(exitCode).toBe(0);
 });

--- a/e2e/__tests__/timeoutsLegacy.test.ts
+++ b/e2e/__tests__/timeoutsLegacy.test.ts
@@ -36,13 +36,13 @@ test('exceeds the timeout set using jasmine.DEFAULT_TIMEOUT_INTERVAL', () => {
     'package.json': '{}',
   });
 
-  const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false']);
+  const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false']);
   const {rest, summary} = extractSummary(stderr);
   expect(rest).toMatch(
     /(jest\.setTimeout|jasmine\.DEFAULT_TIMEOUT_INTERVAL|Exceeded timeout)/,
   );
   expect(wrap(summary)).toMatchSnapshot();
-  expect(status).toBe(1);
+  expect(exitCode).toBe(1);
 });
 
 test('does not exceed the timeout using jasmine.DEFAULT_TIMEOUT_INTERVAL', () => {
@@ -59,11 +59,11 @@ test('does not exceed the timeout using jasmine.DEFAULT_TIMEOUT_INTERVAL', () =>
     'package.json': '{}',
   });
 
-  const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false']);
+  const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false']);
   const {rest, summary} = extractSummary(stderr);
   expect(wrap(rest)).toMatchSnapshot();
   expect(wrap(summary)).toMatchSnapshot();
-  expect(status).toBe(0);
+  expect(exitCode).toBe(0);
 });
 
 test('can read and write jasmine.DEFAULT_TIMEOUT_INTERVAL', () => {
@@ -81,8 +81,8 @@ test('can read and write jasmine.DEFAULT_TIMEOUT_INTERVAL', () => {
     'package.json': '{}',
   });
 
-  const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false']);
+  const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false']);
   const {summary} = extractSummary(stderr);
   expect(wrap(summary)).toMatchSnapshot();
-  expect(status).toBe(0);
+  expect(exitCode).toBe(0);
 });

--- a/e2e/__tests__/timerResetMocks.test.ts
+++ b/e2e/__tests__/timerResetMocks.test.ts
@@ -9,10 +9,10 @@ import runJest from '../runJest';
 
 test('run timers after resetAllMocks test', () => {
   const result = runJest('timer-reset-mocks/after-reset-all-mocks');
-  expect(result.status).toBe(0);
+  expect(result.exitCode).toBe(0);
 });
 
 test('run timers with resetMocks in config test', () => {
   const result = runJest('timer-reset-mocks/with-reset-mocks');
-  expect(result.status).toBe(0);
+  expect(result.exitCode).toBe(0);
 });

--- a/e2e/__tests__/timerUseRealTimers.test.ts
+++ b/e2e/__tests__/timerUseRealTimers.test.ts
@@ -10,5 +10,5 @@ import runJest from '../runJest';
 test('useRealTimers cancels "timers": "fake" for whole test file', () => {
   const result = runJest('timer-use-real-timers');
   expect(result.stdout).toMatch('API is not mocked with fake timers.');
-  expect(result.status).toBe(0);
+  expect(result.exitCode).toBe(0);
 });

--- a/e2e/__tests__/toMatchInlineSnapshot.test.ts
+++ b/e2e/__tests__/toMatchInlineSnapshot.test.ts
@@ -30,19 +30,19 @@ test('basic support', () => {
     writeFiles(TESTS_DIR, {
       [filename]: template(['{apple: "original value"}']),
     });
-    const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     const fileAfter = readFile(filename);
     expect(stderr).toMatch('1 snapshot written from 1 test suite.');
-    expect(status).toBe(0);
+    expect(exitCode).toBe(0);
     expect(wrap(fileAfter)).toMatchSnapshot('initial write');
   }
 
   {
-    const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     const fileAfter = readFile(filename);
     expect(stderr).toMatch('Snapshots:   1 passed, 1 total');
     expect(stderr).not.toMatch('1 snapshot written from 1 test suite.');
-    expect(status).toBe(0);
+    expect(exitCode).toBe(0);
     expect(wrap(fileAfter)).toMatchSnapshot('snapshot passed');
   }
 
@@ -50,15 +50,15 @@ test('basic support', () => {
     writeFiles(TESTS_DIR, {
       [filename]: readFile(filename).replace('original value', 'updated value'),
     });
-    const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     const fileAfter = readFile(filename);
     expect(stderr).toMatch('Snapshot name: `inline snapshots 1`');
-    expect(status).toBe(1);
+    expect(exitCode).toBe(1);
     expect(wrap(fileAfter)).toMatchSnapshot('snapshot mismatch');
   }
 
   {
-    const {stderr, status} = runJest(DIR, [
+    const {stderr, exitCode} = runJest(DIR, [
       '-w=1',
       '--ci=false',
       filename,
@@ -66,7 +66,7 @@ test('basic support', () => {
     ]);
     const fileAfter = readFile(filename);
     expect(stderr).toMatch('1 snapshot updated from 1 test suite.');
-    expect(status).toBe(0);
+    expect(exitCode).toBe(0);
     expect(wrap(fileAfter)).toMatchSnapshot('snapshot updated');
   }
 });
@@ -81,19 +81,19 @@ test('do not indent empty lines', () => {
     writeFiles(TESTS_DIR, {
       [filename]: template(['`hello\n\nworld`']),
     });
-    const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     const fileAfter = readFile(filename);
     expect(stderr).toMatch('1 snapshot written from 1 test suite.');
-    expect(status).toBe(0);
+    expect(exitCode).toBe(0);
     expect(wrap(fileAfter)).toMatchSnapshot('initial write');
   }
 
   {
-    const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     const fileAfter = readFile(filename);
     expect(stderr).toMatch('Snapshots:   1 passed, 1 total');
     expect(stderr).not.toMatch('1 snapshot written from 1 test suite.');
-    expect(status).toBe(0);
+    expect(exitCode).toBe(0);
     expect(wrap(fileAfter)).toMatchSnapshot('snapshot passed');
   }
 });
@@ -107,18 +107,18 @@ test('handles property matchers', () => {
 
   {
     writeFiles(TESTS_DIR, {[filename]: template(['new Date()'])});
-    const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     const fileAfter = readFile(filename);
     expect(stderr).toMatch('1 snapshot written from 1 test suite.');
-    expect(status).toBe(0);
+    expect(exitCode).toBe(0);
     expect(wrap(fileAfter)).toMatchSnapshot('initial write');
   }
 
   {
-    const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     const fileAfter = readFile(filename);
     expect(stderr).toMatch('Snapshots:   1 passed, 1 total');
-    expect(status).toBe(0);
+    expect(exitCode).toBe(0);
     expect(wrap(fileAfter)).toMatchSnapshot('snapshot passed');
   }
 
@@ -126,11 +126,11 @@ test('handles property matchers', () => {
     writeFiles(TESTS_DIR, {
       [filename]: readFile(filename).replace('new Date()', '"string"'),
     });
-    const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     const fileAfter = readFile(filename);
     expect(stderr).toMatch('Snapshot name: `handles property matchers 1`');
     expect(stderr).toMatch('Snapshots:   1 failed, 1 total');
-    expect(status).toBe(1);
+    expect(exitCode).toBe(1);
     expect(wrap(fileAfter)).toMatchSnapshot('snapshot failed');
   }
 
@@ -138,7 +138,7 @@ test('handles property matchers', () => {
     writeFiles(TESTS_DIR, {
       [filename]: readFile(filename).replace('any(Date)', 'any(String)'),
     });
-    const {stderr, status} = runJest(DIR, [
+    const {stderr, exitCode} = runJest(DIR, [
       '-w=1',
       '--ci=false',
       filename,
@@ -146,7 +146,7 @@ test('handles property matchers', () => {
     ]);
     const fileAfter = readFile(filename);
     expect(stderr).toMatch('1 snapshot updated from 1 test suite.');
-    expect(status).toBe(0);
+    expect(exitCode).toBe(0);
     expect(wrap(fileAfter)).toMatchSnapshot('snapshot updated');
   }
 });
@@ -166,26 +166,26 @@ test('removes obsolete external snapshots', () => {
 
   {
     writeFiles(TESTS_DIR, {[filename]: template(['toMatchSnapshot'])});
-    const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     const fileAfter = readFile(filename);
     expect(stderr).toMatch('1 snapshot written from 1 test suite.');
-    expect(status).toBe(0);
+    expect(exitCode).toBe(0);
     expect(wrap(fileAfter)).toMatchSnapshot('initial write');
     expect(fs.existsSync(snapshotPath)).toEqual(true);
   }
 
   {
     writeFiles(TESTS_DIR, {[filename]: template(['toMatchInlineSnapshot'])});
-    const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     const fileAfter = readFile(filename);
     expect(stderr).toMatch('Snapshots:   1 obsolete, 1 written, 1 total');
-    expect(status).toBe(1);
+    expect(exitCode).toBe(1);
     expect(wrap(fileAfter)).toMatchSnapshot('inline snapshot written');
     expect(fs.existsSync(snapshotPath)).toEqual(true);
   }
 
   {
-    const {stderr, status} = runJest(DIR, [
+    const {stderr, exitCode} = runJest(DIR, [
       '-w=1',
       '--ci=false',
       filename,
@@ -193,7 +193,7 @@ test('removes obsolete external snapshots', () => {
     ]);
     const fileAfter = readFile(filename);
     expect(stderr).toMatch('Snapshots:   1 file removed, 1 passed, 1 total');
-    expect(status).toBe(0);
+    expect(exitCode).toBe(0);
     expect(wrap(fileAfter)).toMatchSnapshot('external snapshot cleaned');
     expect(fs.existsSync(snapshotPath)).toEqual(false);
   }
@@ -209,10 +209,10 @@ test('supports async matchers', () => {
   `;
 
   writeFiles(TESTS_DIR, {[filename]: test});
-  const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+  const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
   const fileAfter = readFile(filename);
   expect(stderr).toMatch('2 snapshots written from 1 test suite.');
-  expect(status).toBe(0);
+  expect(exitCode).toBe(0);
   expect(wrap(fileAfter)).toMatchSnapshot();
 });
 
@@ -226,10 +226,10 @@ test('supports async tests', () => {
   `;
 
   writeFiles(TESTS_DIR, {[filename]: test});
-  const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+  const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
   const fileAfter = readFile(filename);
   expect(stderr).toMatch('1 snapshot written from 1 test suite.');
-  expect(status).toBe(0);
+  expect(exitCode).toBe(0);
   expect(wrap(fileAfter)).toMatchSnapshot();
 });
 
@@ -242,11 +242,11 @@ test('writes snapshots with non-literals in expect(...)', () => {
   `;
 
   writeFiles(TESTS_DIR, {[filename]: test});
-  const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+  const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
 
   const fileAfter = readFile(filename);
   expect(stderr).toMatch('1 snapshot written from 1 test suite.');
-  expect(status).toBe(0);
+  expect(exitCode).toBe(0);
   expect(wrap(fileAfter)).toMatchSnapshot();
 });
 
@@ -262,7 +262,7 @@ test('handles mocking native modules prettier relies on', () => {
   `;
 
   writeFiles(TESTS_DIR, {[filename]: test});
-  const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+  const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
   expect(stderr).toMatch('1 snapshot written from 1 test suite.');
-  expect(status).toBe(0);
+  expect(exitCode).toBe(0);
 });

--- a/e2e/__tests__/toMatchInlineSnapshotWithRetries.test.ts
+++ b/e2e/__tests__/toMatchInlineSnapshotWithRetries.test.ts
@@ -30,16 +30,16 @@ test('works with a single snapshot', () => {
     writeFiles(TESTS_DIR, {
       [filename]: template(['3', '1' /* retries */]),
     });
-    const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     expect(stderr).toMatch('Snapshots:   1 passed, 1 total');
-    expect(status).toBe(0);
+    expect(exitCode).toBe(0);
   }
 
   {
     writeFiles(TESTS_DIR, {
       [filename]: template(['index', '2' /* retries */]),
     });
-    const {stderr, status} = runJest(DIR, [
+    const {stderr, exitCode} = runJest(DIR, [
       '-w=1',
       '--ci=false',
       '--testRunner=jest-circus/runner',
@@ -47,21 +47,21 @@ test('works with a single snapshot', () => {
     ]);
     expect(stderr).toMatch('Received: 2');
     expect(stderr).toMatch('1 snapshot failed from 1 test suite.');
-    expect(status).toBe(1);
+    expect(exitCode).toBe(1);
   }
 
   {
     writeFiles(TESTS_DIR, {
       [filename]: template(['index', '4' /* retries */]),
     });
-    const {stderr, status} = runJest(DIR, [
+    const {stderr, exitCode} = runJest(DIR, [
       '-w=1',
       '--ci=false',
       '--testRunner=jest-circus/runner',
       filename,
     ]);
     expect(stderr).toMatch('Snapshots:   1 passed, 1 total');
-    expect(status).toBe(0);
+    expect(exitCode).toBe(0);
   }
 });
 
@@ -79,10 +79,10 @@ test('works when a different assertion is failing', () => {
     writeFiles(TESTS_DIR, {
       [filename]: template(['4']),
     });
-    const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     expect(stderr).toMatch('Test Suites: 1 failed, 1 total');
     expect(stderr).toMatch('Snapshots:   1 passed, 1 total');
-    expect(status).toBe(1);
+    expect(exitCode).toBe(1);
   }
 });
 
@@ -104,16 +104,16 @@ test('works when multiple tests have snapshots but only one of them failed multi
     writeFiles(TESTS_DIR, {
       [filename]: template(['3', '2' /* retries */]),
     });
-    const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     expect(stderr).toMatch('Snapshots:   2 passed, 2 total');
-    expect(status).toBe(0);
+    expect(exitCode).toBe(0);
   }
 
   {
     writeFiles(TESTS_DIR, {
       [filename]: template(['index', '2' /* retries */]),
     });
-    const {stderr, status} = runJest(DIR, [
+    const {stderr, exitCode} = runJest(DIR, [
       '-w=1',
       '--ci=false',
       '--testRunner=jest-circus/runner',
@@ -122,20 +122,20 @@ test('works when multiple tests have snapshots but only one of them failed multi
     expect(stderr).toMatch('Snapshot name: `with retries snapshots 1`');
     expect(stderr).toMatch('Received: 2');
     expect(stderr).toMatch('1 snapshot failed from 1 test suite.');
-    expect(status).toBe(1);
+    expect(exitCode).toBe(1);
   }
 
   {
     writeFiles(TESTS_DIR, {
       [filename]: template(['index', '4' /* retries */]),
     });
-    const {stderr, status} = runJest(DIR, [
+    const {stderr, exitCode} = runJest(DIR, [
       '-w=1',
       '--ci=false',
       '--testRunner=jest-circus/runner',
       filename,
     ]);
     expect(stderr).toMatch('Snapshots:   1 passed, 1 total');
-    expect(status).toBe(0);
+    expect(exitCode).toBe(0);
   }
 });

--- a/e2e/__tests__/toMatchSnapshot.test.ts
+++ b/e2e/__tests__/toMatchSnapshot.test.ts
@@ -25,36 +25,36 @@ test('basic support', () => {
     writeFiles(TESTS_DIR, {
       [filename]: template(['{apple: "original value"}']),
     });
-    const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     expect(stderr).toMatch('1 snapshot written from 1 test suite.');
-    expect(status).toBe(0);
+    expect(exitCode).toBe(0);
   }
 
   {
-    const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     expect(stderr).toMatch('Snapshots:   1 passed, 1 total');
     expect(stderr).not.toMatch('1 snapshot written from 1 test suite.');
-    expect(status).toBe(0);
+    expect(exitCode).toBe(0);
   }
 
   {
     writeFiles(TESTS_DIR, {
       [filename]: template(['{apple: "updated value"}']),
     });
-    const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     expect(stderr).toMatch('Snapshot name: `snapshots 1`');
-    expect(status).toBe(1);
+    expect(exitCode).toBe(1);
   }
 
   {
-    const {stderr, status} = runJest(DIR, [
+    const {stderr, exitCode} = runJest(DIR, [
       '-w=1',
       '--ci=false',
       filename,
       '-u',
     ]);
     expect(stderr).toMatch('1 snapshot updated from 1 test suite.');
-    expect(status).toBe(0);
+    expect(exitCode).toBe(0);
   }
 });
 
@@ -69,24 +69,24 @@ test('error thrown before snapshot', () => {
     writeFiles(TESTS_DIR, {
       [filename]: template(['true', '{a: "original"}']),
     });
-    const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     expect(stderr).toMatch('1 snapshot written from 1 test suite.');
-    expect(status).toBe(0);
+    expect(exitCode).toBe(0);
   }
 
   {
-    const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     expect(stderr).toMatch('Snapshots:   1 passed, 1 total');
-    expect(status).toBe(0);
+    expect(exitCode).toBe(0);
   }
 
   {
     writeFiles(TESTS_DIR, {
       [filename]: template(['false', '{a: "original"}']),
     });
-    const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     expect(stderr).not.toMatch('1 obsolete snapshot found');
-    expect(status).toBe(1);
+    expect(exitCode).toBe(1);
   }
 });
 
@@ -99,18 +99,18 @@ test('first snapshot fails, second passes', () => {
 
   {
     writeFiles(TESTS_DIR, {[filename]: template([`'apple'`, `'banana'`])});
-    const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     expect(stderr).toMatch('2 snapshots written from 1 test suite.');
-    expect(status).toBe(0);
+    expect(exitCode).toBe(0);
   }
 
   {
     writeFiles(TESTS_DIR, {[filename]: template([`'kiwi'`, `'banana'`])});
-    const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     expect(stderr).toMatch('Snapshot name: `snapshots 1`');
     expect(stderr).toMatch('Snapshot: "apple"\n    Received: "kiwi"');
     expect(stderr).not.toMatch('1 obsolete snapshot found');
-    expect(status).toBe(1);
+    expect(exitCode).toBe(1);
   }
 });
 
@@ -127,16 +127,16 @@ test('does not mark snapshots as obsolete in skipped tests', () => {
 
   {
     writeFiles(TESTS_DIR, {[filename]: template(['test'])});
-    const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     expect(stderr).toMatch('1 snapshot written from 1 test suite.');
-    expect(status).toBe(0);
+    expect(exitCode).toBe(0);
   }
 
   {
     writeFiles(TESTS_DIR, {[filename]: template(['test.skip'])});
-    const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     expect(stderr).not.toMatch('1 obsolete snapshot found');
-    expect(status).toBe(0);
+    expect(exitCode).toBe(0);
   }
 });
 
@@ -149,9 +149,9 @@ test('accepts custom snapshot name', () => {
 
   {
     writeFiles(TESTS_DIR, {[filename]: template()});
-    const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     expect(stderr).toMatch('1 snapshot written from 1 test suite.');
-    expect(status).toBe(0);
+    expect(exitCode).toBe(0);
   }
 });
 
@@ -164,23 +164,23 @@ test('handles property matchers', () => {
 
   {
     writeFiles(TESTS_DIR, {[filename]: template(['new Date()'])});
-    const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     expect(stderr).toMatch('1 snapshot written from 1 test suite.');
-    expect(status).toBe(0);
+    expect(exitCode).toBe(0);
   }
 
   {
-    const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     expect(stderr).toMatch('Snapshots:   1 passed, 1 total');
-    expect(status).toBe(0);
+    expect(exitCode).toBe(0);
   }
 
   {
     writeFiles(TESTS_DIR, {[filename]: template(['"string"'])});
-    const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     expect(stderr).toMatch('Snapshot name: `handles property matchers 1`');
     expect(stderr).toMatch('Snapshots:   1 failed, 1 total');
-    expect(status).toBe(1);
+    expect(exitCode).toBe(1);
   }
 });
 
@@ -193,9 +193,9 @@ test('handles invalid property matchers', () => {
       });
     `,
     });
-    const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     expect(stderr).toMatch('Property matchers must be an object.');
-    expect(status).toBe(1);
+    expect(exitCode).toBe(1);
   }
   {
     writeFiles(TESTS_DIR, {
@@ -204,12 +204,12 @@ test('handles invalid property matchers', () => {
       });
     `,
     });
-    const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     expect(stderr).toMatch('Property matchers must be an object.');
     expect(stderr).toMatch(
       'To provide a snapshot test name without property matchers, use: toMatchSnapshot("name")',
     );
-    expect(status).toBe(1);
+    expect(exitCode).toBe(1);
   }
   {
     writeFiles(TESTS_DIR, {
@@ -218,12 +218,12 @@ test('handles invalid property matchers', () => {
       });
     `,
     });
-    const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     expect(stderr).toMatch('Property matchers must be an object.');
     expect(stderr).toMatch(
       'To provide a snapshot test name without property matchers, use: toMatchSnapshot("name")',
     );
-    expect(status).toBe(1);
+    expect(exitCode).toBe(1);
   }
 });
 
@@ -236,26 +236,26 @@ test('handles property matchers with hint', () => {
 
   {
     writeFiles(TESTS_DIR, {[filename]: template(['new Date()'])});
-    const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     expect(stderr).toMatch('1 snapshot written from 1 test suite.');
-    expect(status).toBe(0);
+    expect(exitCode).toBe(0);
   }
 
   {
-    const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     expect(stderr).toMatch('Snapshots:   1 passed, 1 total');
-    expect(status).toBe(0);
+    expect(exitCode).toBe(0);
   }
 
   {
     writeFiles(TESTS_DIR, {[filename]: template(['"string"'])});
-    const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     expect(stderr).toMatch(
       'Snapshot name: `handles property matchers with hint: descriptive hint 1`',
     );
     expect(stderr).toMatch('Expected properties:');
     expect(stderr).toMatch('Snapshots:   1 failed, 1 total');
-    expect(status).toBe(1);
+    expect(exitCode).toBe(1);
   }
 });
 
@@ -268,35 +268,35 @@ test('handles property matchers with deep properties', () => {
 
   {
     writeFiles(TESTS_DIR, {[filename]: template(['new Date()', '"Jest"'])});
-    const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     expect(stderr).toMatch('1 snapshot written from 1 test suite.');
-    expect(status).toBe(0);
+    expect(exitCode).toBe(0);
   }
 
   {
-    const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     expect(stderr).toMatch('Snapshots:   1 passed, 1 total');
-    expect(status).toBe(0);
+    expect(exitCode).toBe(0);
   }
 
   {
     writeFiles(TESTS_DIR, {[filename]: template(['"string"', '"Jest"'])});
-    const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     expect(stderr).toMatch(
       'Snapshot name: `handles property matchers with deep properties 1`',
     );
     expect(stderr).toMatch('Expected properties:');
     expect(stderr).toMatch('Snapshots:   1 failed, 1 total');
-    expect(status).toBe(1);
+    expect(exitCode).toBe(1);
   }
 
   {
     writeFiles(TESTS_DIR, {[filename]: template(['new Date()', '"CHANGED"'])});
-    const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     expect(stderr).toMatch(
       'Snapshot name: `handles property matchers with deep properties 1`',
     );
     expect(stderr).toMatch('Snapshots:   1 failed, 1 total');
-    expect(status).toBe(1);
+    expect(exitCode).toBe(1);
   }
 });

--- a/e2e/__tests__/toMatchSnapshotWithRetries.test.ts
+++ b/e2e/__tests__/toMatchSnapshotWithRetries.test.ts
@@ -30,16 +30,16 @@ test('works with a single snapshot', () => {
     writeFiles(TESTS_DIR, {
       [filename]: template(['3', '1' /* retries */]),
     });
-    const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     expect(stderr).toMatch('1 snapshot written from 1 test suite.');
-    expect(status).toBe(0);
+    expect(exitCode).toBe(0);
   }
 
   {
     writeFiles(TESTS_DIR, {
       [filename]: template(['index', '2' /* retries */]),
     });
-    const {stderr, status} = runJest(DIR, [
+    const {stderr, exitCode} = runJest(DIR, [
       '-w=1',
       '--ci=false',
       '--testRunner=jest-circus/runner',
@@ -47,21 +47,21 @@ test('works with a single snapshot', () => {
     ]);
     expect(stderr).toMatch('Received: 2');
     expect(stderr).toMatch('1 snapshot failed from 1 test suite.');
-    expect(status).toBe(1);
+    expect(exitCode).toBe(1);
   }
 
   {
     writeFiles(TESTS_DIR, {
       [filename]: template(['index', '4' /* retries */]),
     });
-    const {stderr, status} = runJest(DIR, [
+    const {stderr, exitCode} = runJest(DIR, [
       '-w=1',
       '--ci=false',
       '--testRunner=jest-circus/runner',
       filename,
     ]);
     expect(stderr).toMatch('Snapshots:   1 passed, 1 total');
-    expect(status).toBe(0);
+    expect(exitCode).toBe(0);
   }
 });
 
@@ -83,16 +83,16 @@ test('works when multiple tests have snapshots but only one of them failed multi
     writeFiles(TESTS_DIR, {
       [filename]: template(['3', '2' /* retries */]),
     });
-    const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     expect(stderr).toMatch('2 snapshots written from 1 test suite.');
-    expect(status).toBe(0);
+    expect(exitCode).toBe(0);
   }
 
   {
     writeFiles(TESTS_DIR, {
       [filename]: template(['index', '2' /* retries */]),
     });
-    const {stderr, status} = runJest(DIR, [
+    const {stderr, exitCode} = runJest(DIR, [
       '-w=1',
       '--ci=false',
       '--testRunner=jest-circus/runner',
@@ -100,20 +100,20 @@ test('works when multiple tests have snapshots but only one of them failed multi
     ]);
     expect(stderr).toMatch('Received: 2');
     expect(stderr).toMatch('1 snapshot failed from 1 test suite.');
-    expect(status).toBe(1);
+    expect(exitCode).toBe(1);
   }
 
   {
     writeFiles(TESTS_DIR, {
       [filename]: template(['index', '4' /* retries */]),
     });
-    const {stderr, status} = runJest(DIR, [
+    const {stderr, exitCode} = runJest(DIR, [
       '-w=1',
       '--ci=false',
       '--testRunner=jest-circus/runner',
       filename,
     ]);
     expect(stderr).toMatch('Snapshots:   1 passed, 1 total');
-    expect(status).toBe(0);
+    expect(exitCode).toBe(0);
   }
 });

--- a/e2e/__tests__/toMatchSnapshotWithStringSerializer.test.ts
+++ b/e2e/__tests__/toMatchSnapshotWithStringSerializer.test.ts
@@ -40,27 +40,27 @@ test('empty external', () => {
     writeFiles(TESTS_DIR, {
       [filename]: template([`''`]),
     });
-    const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     expect(stderr).toMatch('1 snapshot written from 1 test suite.');
-    expect(status).toBe(0);
+    expect(exitCode).toBe(0);
   }
 
   {
-    const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     expect(stderr).toMatch('Snapshots:   1 passed, 1 total');
     expect(stderr).not.toMatch('1 snapshot written from 1 test suite.');
-    expect(status).toBe(0);
+    expect(exitCode).toBe(0);
   }
 
   {
     writeFiles(TESTS_DIR, {
       [filename]: template([`'non-empty'`]),
     });
-    const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     expect(stderr).toMatch('Snapshots:   1 failed, 1 total');
     expect(stderr).not.toMatch('not written'); // not confused with --ci option
     expect(stderr).toMatch(ORDINARY_FAILURE);
-    expect(status).toBe(1);
+    expect(exitCode).toBe(1);
   }
 });
 
@@ -79,20 +79,20 @@ test('empty internal ci false', () => {
     writeFiles(TESTS_DIR, {
       [filename]: template([received1]),
     });
-    const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     expect(stderr).toMatch('1 snapshot written from 1 test suite.');
-    expect(status).toBe(0);
+    expect(exitCode).toBe(0);
   }
 
   {
     writeFiles(TESTS_DIR, {
       [filename]: readFile(filename).replace(received1, received2),
     });
-    const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     expect(stderr).toMatch('Snapshots:   1 failed, 1 total');
     expect(stderr).not.toMatch('1 snapshot written from 1 test suite.');
     expect(stderr).toMatch(ORDINARY_FAILURE);
-    expect(status).toBe(1);
+    expect(exitCode).toBe(1);
   }
 });
 
@@ -108,10 +108,10 @@ test('undefined internal ci true', () => {
     writeFiles(TESTS_DIR, {
       [filename]: template([`'non-empty'`]),
     });
-    const {stderr, status} = runJest(DIR, ['-w=1', '--ci=true', filename]);
+    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=true', filename]);
     expect(stderr).toMatch('Snapshots:   1 failed, 1 total');
     expect(stderr).not.toMatch(ORDINARY_FAILURE);
     expect(stderr).toMatch(NOT_WRITTEN);
-    expect(status).toBe(1);
+    expect(exitCode).toBe(1);
   }
 });

--- a/e2e/__tests__/toThrowErrorMatchingInlineSnapshot.test.ts
+++ b/e2e/__tests__/toThrowErrorMatchingInlineSnapshot.test.ts
@@ -36,11 +36,11 @@ test('works fine when function throws error', () => {
 
   {
     writeFiles(TESTS_DIR, {[filename]: template()});
-    const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     const fileAfter = readFile(filename);
     expect(stderr).toMatch('1 snapshot written from 1 test suite.');
     expect(wrap(fileAfter)).toMatchSnapshot('initial write');
-    expect(status).toBe(0);
+    expect(exitCode).toBe(0);
   }
 });
 
@@ -57,7 +57,7 @@ test('updates existing snapshot', () => {
 
   {
     writeFiles(TESTS_DIR, {[filename]: template()});
-    const {stderr, status} = runJest(DIR, [
+    const {stderr, exitCode} = runJest(DIR, [
       '-w=1',
       '--ci=false',
       filename,
@@ -66,7 +66,7 @@ test('updates existing snapshot', () => {
     const fileAfter = readFile(filename);
     expect(stderr).toMatch('1 snapshot updated from 1 test suite.');
     expect(wrap(fileAfter)).toMatchSnapshot('updated snapshot');
-    expect(status).toBe(0);
+    expect(exitCode).toBe(0);
   }
 });
 
@@ -80,9 +80,9 @@ test('cannot be used with .not', () => {
 
   {
     writeFiles(TESTS_DIR, {[filename]: template()});
-    const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     expect(stderr).toMatch('.not cannot be used with snapshot matchers');
-    expect(status).toBe(1);
+    expect(exitCode).toBe(1);
   }
 });
 
@@ -96,9 +96,9 @@ test('should support rejecting promises', () => {
   `);
 
   writeFiles(TESTS_DIR, {[filename]: template()});
-  const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+  const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
   const fileAfter = readFile(filename);
   expect(stderr).toMatch('1 snapshot written from 1 test suite.');
   expect(wrap(fileAfter)).toMatchSnapshot();
-  expect(status).toBe(0);
+  expect(exitCode).toBe(0);
 });

--- a/e2e/__tests__/toThrowErrorMatchingSnapshot.test.ts
+++ b/e2e/__tests__/toThrowErrorMatchingSnapshot.test.ts
@@ -27,9 +27,9 @@ test('works fine when function throws error', () => {
 
   {
     writeFiles(TESTS_DIR, {[filename]: template()});
-    const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     expect(stderr).toMatch('1 snapshot written from 1 test suite.');
-    expect(status).toBe(0);
+    expect(exitCode).toBe(0);
   }
 });
 
@@ -42,9 +42,9 @@ test(`throws the error if tested function didn't throw error`, () => {
 
   {
     writeFiles(TESTS_DIR, {[filename]: template()});
-    const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     expect(stderr).toMatch('Received function did not throw');
-    expect(status).toBe(1);
+    expect(exitCode).toBe(1);
   }
 });
 
@@ -58,9 +58,9 @@ test('accepts custom snapshot name', () => {
 
   {
     writeFiles(TESTS_DIR, {[filename]: template()});
-    const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     expect(stderr).toMatch('1 snapshot written from 1 test suite.');
-    expect(status).toBe(0);
+    expect(exitCode).toBe(0);
   }
 });
 
@@ -73,9 +73,9 @@ test('cannot be used with .not', () => {
 
   {
     writeFiles(TESTS_DIR, {[filename]: template()});
-    const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     expect(stderr).toMatch('.not cannot be used with snapshot matchers');
-    expect(status).toBe(1);
+    expect(exitCode).toBe(1);
   }
 });
 
@@ -88,7 +88,7 @@ test('should support rejecting promises', () => {
 
   {
     writeFiles(TESTS_DIR, {[filename]: template()});
-    const {stderr, status} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
 
     const snapshot = fs.readFileSync(
       `${TESTS_DIR}/__snapshots__/${filename}.snap`,
@@ -97,6 +97,6 @@ test('should support rejecting promises', () => {
 
     expect(stderr).toMatch('1 snapshot written from 1 test suite.');
     expect(wrap(snapshot)).toMatchSnapshot();
-    expect(status).toBe(0);
+    expect(exitCode).toBe(0);
   }
 });

--- a/e2e/__tests__/transform.test.ts
+++ b/e2e/__tests__/transform.test.ts
@@ -49,8 +49,8 @@ describe('babel-jest ignored', () => {
 
   it('tells user to match ignored files', () => {
     // --no-cache because babel can cache stuff and result in false green
-    const {status, stderr} = runJest(dir, ['--no-cache']);
-    expect(status).toBe(1);
+    const {exitCode, stderr} = runJest(dir, ['--no-cache']);
+    expect(exitCode).toBe(1);
     expect(wrap(extractSummary(stderr).rest)).toMatchSnapshot();
   });
 });
@@ -120,12 +120,12 @@ describe('custom transformer', () => {
   });
 
   it('instruments files', () => {
-    const {stdout, status} = runJest(dir, ['--no-cache', '--coverage'], {
+    const {stdout, exitCode} = runJest(dir, ['--no-cache', '--coverage'], {
       stripAnsi: true,
     });
     // coverage should be empty because there's no real instrumentation
     expect(wrap(stdout)).toMatchSnapshot();
-    expect(status).toBe(0);
+    expect(exitCode).toBe(0);
   });
 });
 

--- a/e2e/__tests__/verbose.test.ts
+++ b/e2e/__tests__/verbose.test.ts
@@ -8,9 +8,9 @@
 import runJest from '../runJest';
 
 test('Verbose Reporter', () => {
-  const {status, stderr} = runJest('verbose-reporter');
+  const {exitCode, stderr} = runJest('verbose-reporter');
 
-  expect(status).toBe(1);
+  expect(exitCode).toBe(1);
   expect(stderr).toMatch('works just fine');
   expect(stderr).toMatch('does not work');
   expect(stderr).toMatch(/Verbose\n.*?works/);

--- a/e2e/__tests__/version.test.ts
+++ b/e2e/__tests__/version.test.ts
@@ -21,10 +21,10 @@ test('works with jest.config.js', () => {
     'package.json': '{}',
   });
 
-  const {status, stdout, stderr} = runJest(DIR, ['--version']);
+  const {exitCode, stdout, stderr} = runJest(DIR, ['--version']);
   expect(stdout).toMatch(/\d{2}\.\d{1,2}\.\d{1,2}[\-\S]*-dev$/);
   // Only version gets printed and nothing else
   expect(stdout.split(/\n/)).toHaveLength(1);
   expect(stderr).toBe('');
-  expect(status).toBe(0);
+  expect(exitCode).toBe(0);
 });

--- a/e2e/__tests__/watchModeOnlyFailed.test.ts
+++ b/e2e/__tests__/watchModeOnlyFailed.test.ts
@@ -43,7 +43,7 @@ test('can press "f" to run only failed tests', () => {
   const input = [{keys: ['f']}, {keys: ['q']}];
   setupFiles(input);
 
-  const {status, stderr} = runJest(DIR, ['--no-watchman', '--watchAll']);
+  const {exitCode, stderr} = runJest(DIR, ['--no-watchman', '--watchAll']);
   const results = extractSummaries(stderr);
 
   expect(results).toHaveLength(2);
@@ -51,5 +51,5 @@ test('can press "f" to run only failed tests', () => {
     expect(wrap(rest)).toMatchSnapshot('test results');
     expect(wrap(summary)).toMatchSnapshot('test summary');
   });
-  expect(status).toBe(0);
+  expect(exitCode).toBe(0);
 });

--- a/e2e/__tests__/watchModePatterns.test.ts
+++ b/e2e/__tests__/watchModePatterns.test.ts
@@ -45,7 +45,7 @@ test('can press "p" to filter by file name', () => {
   const input = [{keys: ['p', 'b', 'a', 'r', '\r']}, {keys: ['q']}];
   setupFiles(input);
 
-  const {status, stdout, stderr} = runJest(DIR, [
+  const {exitCode, stdout, stderr} = runJest(DIR, [
     '--no-watchman',
     '--watchAll',
   ]);
@@ -58,14 +58,14 @@ test('can press "p" to filter by file name', () => {
     expect(wrap(rest)).toMatchSnapshot('test results');
     expect(wrap(summary)).toMatchSnapshot('test summary');
   });
-  expect(status).toBe(0);
+  expect(exitCode).toBe(0);
 });
 
 test('can press "t" to filter by test name', () => {
   const input = [{keys: ['t', '2', '\r']}, {keys: ['q']}];
   setupFiles(input);
 
-  const {status, stdout, stderr} = runJest(DIR, [
+  const {exitCode, stdout, stderr} = runJest(DIR, [
     '--no-watchman',
     '--watchAll',
   ]);
@@ -78,5 +78,5 @@ test('can press "t" to filter by test name', () => {
     expect(wrap(rest)).toMatchSnapshot('test results');
     expect(wrap(summary)).toMatchSnapshot('test summary');
   });
-  expect(status).toBe(0);
+  expect(exitCode).toBe(0);
 });

--- a/e2e/__tests__/watchModeUpdateSnapshot.test.ts
+++ b/e2e/__tests__/watchModeUpdateSnapshot.test.ts
@@ -44,12 +44,12 @@ test('can press "u" to update snapshots', () => {
   const input = [{keys: ['u']}, {keys: ['q']}];
   setupFiles(input);
 
-  const {status, stderr} = runJest(DIR, ['--no-watchman', '--watchAll']);
+  const {exitCode, stderr} = runJest(DIR, ['--no-watchman', '--watchAll']);
   const results = extractSummaries(stderr);
   expect(results).toHaveLength(2);
   results.forEach(({rest, summary}) => {
     expect(wrap(rest)).toMatchSnapshot('test results');
     expect(wrap(summary)).toMatchSnapshot('test summary');
   });
-  expect(status).toBe(0);
+  expect(exitCode).toBe(0);
 });

--- a/e2e/__tests__/workerForceExit.test.ts
+++ b/e2e/__tests__/workerForceExit.test.ts
@@ -42,9 +42,9 @@ test('prints a warning if a worker is force exited', () => {
       });
     `,
   });
-  const {status, stderr, stdout} = runJest(DIR, ['--maxWorkers=2']);
+  const {exitCode, stderr, stdout} = runJest(DIR, ['--maxWorkers=2']);
 
-  expect(status).toBe(0);
+  expect(exitCode).toBe(0);
   verifyNumPassed(stderr);
   expect(stdout).toContain('A worker process has failed to exit gracefully');
 });
@@ -59,9 +59,9 @@ test('force exits a worker that fails to exit gracefully', async () => {
       });
     `,
   });
-  const {status, stderr} = runJest(DIR, ['--maxWorkers=2']);
+  const {exitCode, stderr} = runJest(DIR, ['--maxWorkers=2']);
 
-  expect(status).toBe(0);
+  expect(exitCode).toBe(0);
   verifyNumPassed(stderr);
 
   const [pid] = /pid: \d+/.exec(stderr);

--- a/examples/typescript/CheckboxWithLabel.tsx
+++ b/examples/typescript/CheckboxWithLabel.tsx
@@ -1,7 +1,5 @@
 // Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
 
-/// <reference path="./typings/react/react.d.ts" />
-
 import * as React from 'react';
 
 interface CheckboxWithLabelProps {

--- a/packages/jest-test-result/src/index.ts
+++ b/packages/jest-test-result/src/index.ts
@@ -17,6 +17,7 @@ export {
   AssertionLocation,
   AssertionResult,
   FailedAssertion,
+  FormattedTestResults,
   Milliseconds,
   SerializableError,
   SnapshotSummary,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Removes the mapping of `exitCode -> status`. Also types the `json` field properly

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Green CI

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
