### PR TITLE
jest-diff: Do not inverse format if line consists of one change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Fixes
 
 - `[expect]` Display expectedDiff more carefully in toBeCloseTo ([#8389](https://github.com/facebook/jest/pull/8389))
+- `[jest-diff]` Do not inverse format if line consists of one change ([#8903](https://github.com/facebook/jest/pull/8903))
 - `[jest-fake-timers]` `getTimerCount` will not include cancelled immediates ([#8764](https://github.com/facebook/jest/pull/8764))
 - `[jest-leak-detector]` [**BREAKING**] Use `weak-napi` instead of `weak` package ([#8686](https://github.com/facebook/jest/pull/8686))
 - `[jest-mock]` Fix for mockReturnValue overriding mockImplementationOnce ([#8398](https://github.com/facebook/jest/pull/8398))

--- a/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -303,9 +303,9 @@ string" 1`] = `
 <green>- Expected</>
 <red>+ Received</>
 
-<green>- <inverse>3</></>
-<red>+ <inverse>four</></>
-<red>+ <inverse>4</></>
+<green>- 3</>
+<red>+ four</>
+<red>+ 4</>
 <dim>  line</>
 <dim>  string</>"
 `;

--- a/packages/jest-diff/src/__tests__/__snapshots__/getAlignedDiffs.test.ts.snap
+++ b/packages/jest-diff/src/__tests__/__snapshots__/getAlignedDiffs.test.ts.snap
@@ -1,34 +1,34 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`getAlignedDiffs lines change preceding and following common 1`] = `
-"<green>- <inverse>delete</></>
-<red>+ <inverse>insert</></>
+"<green>- delete</>
+<red>+ insert</>
 <dim>  common between changes</>
-<green>- <inverse>prev</></>
-<red>+ <inverse>next</></>"
+<green>- prev</>
+<red>+ next</>"
 `;
 
 exports[`getAlignedDiffs lines common at end when both current change lines are empty 1`] = `
-"<green>- <inverse>delete</></>
+"<green>- delete</>
 <dim>  common at end</>"
 `;
 
 exports[`getAlignedDiffs lines common between delete and insert 1`] = `
-"<green>- <inverse>delete</></>
+"<green>- delete</>
 <dim>  common between changes</>
-<red>+ <inverse>insert</></>"
+<red>+ insert</>"
 `;
 
 exports[`getAlignedDiffs lines common between insert and delete 1`] = `
-"<red>+ <inverse>insert</></>
+"<red>+ insert</>
 <dim>  common between changes</>
-<green>- <inverse>delete</></>"
+<green>- delete</>"
 `;
 
 exports[`getAlignedDiffs lines common preceding and following change 1`] = `
 "<dim>  common preceding</>
-<green>- <inverse>delete</></>
-<red>+ <inverse>insert</></>
+<green>- delete</>
+<red>+ insert</>
 <dim>  common following</>"
 `;
 
@@ -85,7 +85,7 @@ exports[`getAlignedDiffs strings delete or insert at start and change at end 1`]
 `;
 
 exports[`getAlignedDiffs substrings first common when both current change lines are empty 1`] = `
-"<red>+ <inverse>insert</></>
+"<red>+ insert</>
 <dim>  first</>
 <dim>  middle</>
 <green>- last <inverse>prev</></>
@@ -101,7 +101,7 @@ exports[`getAlignedDiffs substrings first common when either current change line
 
 exports[`getAlignedDiffs substrings first delete completes the current line 1`] = `
 "<green>- common preceding <inverse>first</></>
-<green>- <inverse>middle</></>
+<green>- middle</>
 <green>- <inverse>last </>and following</>
 <red>+ common preceding and following</>"
 `;
@@ -109,7 +109,7 @@ exports[`getAlignedDiffs substrings first delete completes the current line 1`] 
 exports[`getAlignedDiffs substrings first insert completes the current line 1`] = `
 "<green>- common preceding</>
 <red>+ common preceding<inverse> first</></>
-<red>+ <inverse>middle</></>
+<red>+ middle</>
 <red>+</>"
 `;
 
@@ -140,21 +140,21 @@ exports[`getAlignedDiffs substrings middle is empty in delete between common 1`]
 
 exports[`getAlignedDiffs substrings middle is empty in insert at start 1`] = `
 "<green>- <inverse>expect</>ed common at end</>
-<red>+ <inverse>insert line</></>
+<red>+ insert line</>
 <red>+</>
 <red>+ <inverse>receiv</>ed common at end</>"
 `;
 
 exports[`getAlignedDiffs substrings middle is non-empty in delete at end 1`] = `
 "<green>- common at start precedes <inverse>delete</></>
-<green>- <inverse>non-empty line</></>
-<green>- <inverse>next</></>
+<green>- non-empty line</>
+<green>- next</>
 <red>+ common at start precedes <inverse>prev</></>"
 `;
 
 exports[`getAlignedDiffs substrings middle is non-empty in insert between common 1`] = `
 "<green>- common at start precedes <inverse>delete expect</>ed</>
 <red>+ common at start precedes <inverse>insert</></>
-<red>+ <inverse>non-empty</></>
+<red>+ non-empty</>
 <red>+ <inverse>receiv</>ed</>"
 `;

--- a/packages/jest-diff/src/getAlignedDiffs.ts
+++ b/packages/jest-diff/src/getAlignedDiffs.ts
@@ -27,8 +27,16 @@ class ChangeBuffer {
   private pushLine(): void {
     // Assume call only if line has at least one diff,
     // therefore an empty line must have a diff which has an empty string.
+
+    // If line has multiple diffs, then assume it has a common diff,
+    // therefore change diffs have change color;
+    // otherwise then it has line color only.
     this.lines.push(
-      new Diff(this.op, invertChangedSubstrings(this.op, this.line)),
+      this.line.length !== 1
+        ? new Diff(this.op, invertChangedSubstrings(this.op, this.line))
+        : this.line[0][0] === this.op
+        ? this.line[0] // can use instance
+        : new Diff(this.op, this.line[0][1]), // was common diff
     );
     this.line.length = 0;
   }


### PR DESCRIPTION
## Summary

It distracts attention of reviewer if entire change line has inverse format

## Test plan

Updated snapshots:

| | package | test |
| ---: | ---: | :--- |
| 11 | jest-diff | getAlignedDiffs |
| 1 | expect | matchers |

Realistic regression tests for the win: the code change was more subtle than I thought

Example pictures baseline at left and **improved at right**

The inverse lines fight for attention with the substrings within lines:

<img width="600" alt="inverse 2" src="https://user-images.githubusercontent.com/11862657/64131197-0b9a6600-cd95-11e9-96d4-dd2c7ba1dce8.png">

The inverse lines add insult to injury ~~when cleanup merges `from` and `to` into changes because common `o` is chaff~~:

<img width="600" alt="inverse 1" src="https://user-images.githubusercontent.com/11862657/64131201-12c17400-cd95-11e9-8088-166aaa39647b.png">

To set the record straight, merging `o` chaff into `from` and `to` changes is good cleanup. The problem is the length criterion where common substring `'change '.length` does not have greater  length than adjacent change substring `'delete\n'.length` so is merged into changes.

Notice the effect of one character increase in length to `'changed '`

<img width="600" alt="inverse 3" src="https://user-images.githubusercontent.com/11862657/64178363-5668bc00-ce2f-11e9-8002-ff75b12b7085.png">