### PR TITLE
jest-diff: Add changeColor and patchColor options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `[jest-diff]` Add options for colors and symbols ([#8841](https://github.com/facebook/jest/pull/8841))
 - `[jest-diff]` [**BREAKING**] Export as ECMAScript module ([#8873](https://github.com/facebook/jest/pull/8873))
 - `[jest-diff]` Add `includeChangeCounts` and rename `Indicator` options ([#8881](https://github.com/facebook/jest/pull/8881))
+- `[jest-diff]` Add `changeColor` and `patchColor` options ([#8911](https://github.com/facebook/jest/pull/8911))
 - `[jest-runner]` Warn if a worker had to be force exited ([#8206](https://github.com/facebook/jest/pull/8206))
 - `[@jest/test-result]` Create method to create empty `TestResult` ([#8867](https://github.com/facebook/jest/pull/8867))
 - `[jest-worker]` [**BREAKING**] Return a promise from `end()`, resolving with the information whether workers exited gracefully ([#8206](https://github.com/facebook/jest/pull/8206))

--- a/packages/jest-diff/README.md
+++ b/packages/jest-diff/README.md
@@ -91,7 +91,7 @@ const difference = diffStringsUnified(a, b);
 The returned **string** consists of:
 
 - annotation lines: describe the two change indicators with labels, and a blank line
-- comparison lines: similar to “unified” view on GitHub, and **changed substrings** have **inverted** foreground and background colors (which the following example does not show)
+- comparison lines: similar to “unified” view on GitHub, and **changed substrings** have **inverse** foreground and background colors (which the following example does not show)
 
 ```diff
 - Expected
@@ -212,20 +212,22 @@ For other applications, you can provide an options object as a third argument:
 
 ### Properties of options object
 
-| name                  | default       |
-| :-------------------- | :------------ |
-| `aAnnotation`         | `'Expected'`  |
-| `aColor`              | `chalk.green` |
-| `aIndicator`          | `'-'`         |
-| `bAnnotation`         | `'Received'`  |
-| `bColor`              | `chalk.red`   |
-| `bIndicator`          | `'+'`         |
-| `commonColor`         | `chalk.dim`   |
-| `commonIndicator`     | `' '`         |
-| `contextLines`        | `5`           |
-| `expand`              | `true`        |
-| `includeChangeCounts` | `false`       |
-| `omitAnnotationLines` | `false`       |
+| name                  | default         |
+| :-------------------- | :-------------- |
+| `aAnnotation`         | `'Expected'`    |
+| `aColor`              | `chalk.green`   |
+| `aIndicator`          | `'-'`           |
+| `bAnnotation`         | `'Received'`    |
+| `bColor`              | `chalk.red`     |
+| `bIndicator`          | `'+'`           |
+| `changeColor`         | `chalk.inverse` |
+| `commonColor`         | `chalk.dim`     |
+| `commonIndicator`     | `' '`           |
+| `contextLines`        | `5`             |
+| `expand`              | `true`          |
+| `includeChangeCounts` | `false`         |
+| `omitAnnotationLines` | `false`         |
+| `patchColor`          | `chalk.yellow`  |
 
 ### Example of options for labels
 
@@ -240,7 +242,7 @@ const options = {
 
 The `jest-diff` package does not assume that the 2 labels have equal length.
 
-### Example of options for colors
+### Example of options for colors of change lines
 
 For consistency with most diff tools, you might exchange the colors:
 
@@ -252,16 +254,31 @@ const options = {
   bColor: chalk.green,
 };
 ```
+### Example of option for color of change substrings
 
-### Example of option to keep the default color
-
-The value of a color option is a function, which given a string, returns a string.
-
-For common lines to keep the default (usually black) color, you might provide an identity function:
+Although the default inverse of foreground and background colors is hard to beat for change substrings **within lines**, especially because it highlights spaces, if you want bold font weight on yellow background:
 
 ```js
 const options = {
-  commonColor: line => line,
+  changeColor: chalk.bold.bgAnsi256(226), // #ffff00
+};
+```
+
+### Example of options for no colors
+
+The value of a color option is a function, which given a string, returns a string.
+
+To store the difference in a file without escape codes for colors, provide an identity function:
+
+```js
+const identity = string => string;
+
+const options = {
+  aColor: identity,
+  bColor: identity,
+  changeColor: identity,
+  commonColor: identity,
+  patchColor: identity,
 };
 ```
 
@@ -292,6 +309,17 @@ const options = {
 ```
 
 A patch mark like `@@ -12,7 +12,9 @@` accounts for omitted common lines.
+
+### Example of option for color of patch marks
+
+If you want patch marks to have the same dim color as common lines:
+
+```js
+const options = {
+  expand: false,
+  patchColor: chalk.dim,
+};
+```
 
 ### Example of option to include change counts
 

--- a/packages/jest-diff/README.md
+++ b/packages/jest-diff/README.md
@@ -254,6 +254,7 @@ const options = {
   bColor: chalk.green,
 };
 ```
+
 ### Example of option for color of change substrings
 
 Although the default inverse of foreground and background colors is hard to beat for change substrings **within lines**, especially because it highlights spaces, if you want bold font weight on yellow background:

--- a/packages/jest-diff/README.md
+++ b/packages/jest-diff/README.md
@@ -242,7 +242,7 @@ const options = {
 
 The `jest-diff` package does not assume that the 2 labels have equal length.
 
-### Example of options for colors of changes lines
+### Example of options for colors of changed lines
 
 For consistency with most diff tools, you might exchange the colors:
 
@@ -255,9 +255,9 @@ const options = {
 };
 ```
 
-### Example of option for color of changes substringss
+### Example of option for color of changed substrings
 
-Although the default inverse of foreground and background colors is hard to beat for changes substringss **within lines**, especially because it highlights spaces, if you want bold font weight on yellow background:
+Although the default inverse of foreground and background colors is hard to beat for changed substrings **within lines**, especially because it highlights spaces, if you want bold font weight on yellow background:
 
 ```js
 const options = {
@@ -324,7 +324,7 @@ const options = {
 
 ### Example of option to include change counts
 
-To display the number of changes lines at the right of annotation lines:
+To display the number of changed lines at the right of annotation lines:
 
 ```js
 const a = ['change from', 'common'];

--- a/packages/jest-diff/README.md
+++ b/packages/jest-diff/README.md
@@ -242,7 +242,7 @@ const options = {
 
 The `jest-diff` package does not assume that the 2 labels have equal length.
 
-### Example of options for colors of change lines
+### Example of options for colors of changes lines
 
 For consistency with most diff tools, you might exchange the colors:
 
@@ -255,9 +255,9 @@ const options = {
 };
 ```
 
-### Example of option for color of change substrings
+### Example of option for color of changes substringss
 
-Although the default inverse of foreground and background colors is hard to beat for change substrings **within lines**, especially because it highlights spaces, if you want bold font weight on yellow background:
+Although the default inverse of foreground and background colors is hard to beat for changes substringss **within lines**, especially because it highlights spaces, if you want bold font weight on yellow background:
 
 ```js
 const options = {
@@ -324,7 +324,7 @@ const options = {
 
 ### Example of option to include change counts
 
-To display the number of change lines at the right of annotation lines:
+To display the number of changes lines at the right of annotation lines:
 
 ```js
 const a = ['change from', 'common'];

--- a/packages/jest-diff/src/__tests__/__snapshots__/diff.test.ts.snap
+++ b/packages/jest-diff/src/__tests__/__snapshots__/diff.test.ts.snap
@@ -103,7 +103,7 @@ exports[`context number of lines: -1 (5 default) 1`] = `
 "<green>- Expected  1 -</>
 <red>+ Received  1 +</>
 
-<yellow>@@ -6,9 +6,9 @@</>
+<dim>@@ -6,9 +6,9 @@</>
 <dim>      4,</>
 <dim>      5,</>
 <dim>      6,</>
@@ -156,7 +156,7 @@ exports[`context number of lines: 3.1 (5 default) 1`] = `
 "<green>- Expected  1 -</>
 <red>+ Received  1 +</>
 
-<yellow>@@ -6,9 +6,9 @@</>
+<dim>@@ -6,9 +6,9 @@</>
 <dim>      4,</>
 <dim>      5,</>
 <dim>      6,</>
@@ -173,7 +173,7 @@ exports[`context number of lines: undefined (5 default) 1`] = `
 "<green>- Expected  1 -</>
 <red>+ Received  1 +</>
 
-<yellow>@@ -6,9 +6,9 @@</>
+<dim>@@ -6,9 +6,9 @@</>
 <dim>      4,</>
 <dim>      5,</>
 <dim>      6,</>
@@ -320,6 +320,17 @@ exports[`options 7980 diffStringsUnified 1`] = `
 
 <red>- \`\${Ti.App.<inverse>n</>ame} \${Ti.App.<inverse>v</>ersion} \${Ti.Platform.<inverse>n</>ame} \${Ti.Platform.<inverse>v</>ersion}\`</>
 <green>+ \`\${Ti.App.<inverse>getN</>ame<inverse>()</>} \${Ti.App.<inverse>getV</>ersion<inverse>()</>} \${Ti.Platform.<inverse>getN</>ame<inverse>()</>} \${Ti.Platform.<inverse>getV</>ersion<inverse>()</>}\`</>"
+`;
+
+exports[`options change color diffStringsUnified 1`] = `
+"<green>- Expected</>
+<red>+ Received</>
+
+<green>- delete</>
+<green>- changed <bold>from</></>
+<red>+ changed <bold>to</></>
+<red>+ insert</>
+<dim>  common</>"
 `;
 
 exports[`options change indicators diff 1`] = `

--- a/packages/jest-diff/src/__tests__/__snapshots__/getAlignedDiffs.test.ts.snap
+++ b/packages/jest-diff/src/__tests__/__snapshots__/getAlignedDiffs.test.ts.snap
@@ -1,160 +1,160 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`getAlignedDiffs lines change preceding and following common 1`] = `
-"<green>- delete</>
-<red>+ insert</>
-<dim>  common between changes</>
-<green>- prev</>
-<red>+ next</>"
+- delete
++ insert
+  common between changes
+- prev
++ next
 `;
 
 exports[`getAlignedDiffs lines common at end when both current change lines are empty 1`] = `
-"<green>- delete</>
-<dim>  common at end</>"
+- delete
+  common at end
 `;
 
 exports[`getAlignedDiffs lines common between delete and insert 1`] = `
-"<green>- delete</>
-<dim>  common between changes</>
-<red>+ insert</>"
+- delete
+  common between changes
++ insert
 `;
 
 exports[`getAlignedDiffs lines common between insert and delete 1`] = `
-"<red>+ insert</>
-<dim>  common between changes</>
-<green>- delete</>"
++ insert
+  common between changes
+- delete
 `;
 
 exports[`getAlignedDiffs lines common preceding and following change 1`] = `
-"<dim>  common preceding</>
-<green>- delete</>
-<red>+ insert</>
-<dim>  common following</>"
+  common preceding
+- delete
++ insert
+  common following
 `;
 
 exports[`getAlignedDiffs newline change from space 1`] = `
-"<green>- preceding<inverse> </>following</>
-<red>+ preceding</>
-<red>+ following</>"
+- preceding<i> </i>following
++ preceding
++ following
 `;
 
 exports[`getAlignedDiffs newline change to space 1`] = `
-"<green>- preceding</>
-<green>- following</>
-<red>+ preceding<inverse> </>following</>"
+- preceding
+- following
++ preceding<i> </i>following
 `;
 
 exports[`getAlignedDiffs newline delete only 1`] = `
-"<green>- preceding</>
-<green>- following</>
-<red>+ precedingfollowing</>"
+- preceding
+- following
++ precedingfollowing
 `;
 
 exports[`getAlignedDiffs newline delete with adjacent change 1`] = `
-"<green>- preced<inverse>ing</></>
-<green>- following</>
-<red>+ preced<inverse>ed</>following</>"
+- preced<i>ing</i>
+- following
++ preced<i>ed</i>following
 `;
 
 exports[`getAlignedDiffs newline insert only 1`] = `
-"<green>- precedingfollowing</>
-<red>+ preceding</>
-<red>+ following</>"
+- precedingfollowing
++ preceding
++ following
 `;
 
 exports[`getAlignedDiffs newline insert with adjacent changes 1`] = `
-"<green>- preced<inverse>edf</>ollowing</>
-<red>+ preced<inverse>ing</></>
-<red>+ <inverse>F</>ollowing</>"
+- preced<i>edf</i>ollowing
++ preced<i>ing</i>
++ <i>F</i>ollowing
 `;
 
 exports[`getAlignedDiffs strings change at start and delete or insert at end 1`] = `
-"<green>- <inverse>prev</> change common<inverse> delete</></>
-<red>+ <inverse>next</> change common</>
-<dim>  unchanged</>
-<green>- <inverse>expect</>ed change common</>
-<red>+ <inverse>receiv</>ed change common<inverse> insert</></>"
+- <i>prev</i> change common<i> delete</i>
++ <i>next</i> change common
+  unchanged
+- <i>expect</i>ed change common
++ <i>receiv</i>ed change common<i> insert</i>
 `;
 
 exports[`getAlignedDiffs strings delete or insert at start and change at end 1`] = `
-"<green>- common change <inverse>prev</></>
-<red>+ <inverse>insert </>common change <inverse>next</></>
-<dim>  unchanged</>
-<green>- <inverse>delete </>common change th<inverse>is</></>
-<red>+ common change th<inverse>at</></>"
+- common change <i>prev</i>
++ <i>insert </i>common change <i>next</i>
+  unchanged
+- <i>delete </i>common change th<i>is</i>
++ common change th<i>at</i>
 `;
 
 exports[`getAlignedDiffs substrings first common when both current change lines are empty 1`] = `
-"<red>+ insert</>
-<dim>  first</>
-<dim>  middle</>
-<green>- last <inverse>prev</></>
-<red>+ last <inverse>next</></>"
++ insert
+  first
+  middle
+- last <i>prev</i>
++ last <i>next</i>
 `;
 
 exports[`getAlignedDiffs substrings first common when either current change line is non-empty 1`] = `
-"<green>- <inverse>expected </>first</>
-<red>+ first</>
+- <i>expected </i>first
++ first
 
-<dim>  last</>"
+  last
 `;
 
 exports[`getAlignedDiffs substrings first delete completes the current line 1`] = `
-"<green>- common preceding <inverse>first</></>
-<green>- middle</>
-<green>- <inverse>last </>and following</>
-<red>+ common preceding and following</>"
+- common preceding <i>first</i>
+- middle
+- <i>last </i>and following
++ common preceding and following
 `;
 
 exports[`getAlignedDiffs substrings first insert completes the current line 1`] = `
-"<green>- common preceding</>
-<red>+ common preceding<inverse> first</></>
-<red>+ middle</>
-<red>+</>"
+- common preceding
++ common preceding<i> first</i>
++ middle
++
 `;
 
 exports[`getAlignedDiffs substrings last is empty in delete at end 1`] = `
-"<green>- common string preceding <inverse>prev</></>
-<green>-</>
-<red>+ common string preceding <inverse>next</></>"
+- common string preceding <i>prev</i>
+-
++ common string preceding <i>next</i>
 `;
 
 exports[`getAlignedDiffs substrings last is empty in insert at end 1`] = `
-"<green>- common string preceding <inverse>prev</></>
-<red>+ common string preceding <inverse>next</></>
-<red>+</>"
+- common string preceding <i>prev</i>
++ common string preceding <i>next</i>
++
 `;
 
 exports[`getAlignedDiffs substrings last is non-empty in common not at end 1`] = `
-"<dim>  common first</>
-<green>- last <inverse>expect</>ed</>
-<red>+ last <inverse>receiv</>ed</>"
+  common first
+- last <i>expect</i>ed
++ last <i>receiv</i>ed
 `;
 
 exports[`getAlignedDiffs substrings middle is empty in delete between common 1`] = `
-"<green>- common at start precedes <inverse>delete</></>
-<green>-</>
-<green>- <inverse>expect</>ed common at end</>
-<red>+ common at start precedes <inverse>receiv</>ed common at end</>"
+- common at start precedes <i>delete</i>
+-
+- <i>expect</i>ed common at end
++ common at start precedes <i>receiv</i>ed common at end
 `;
 
 exports[`getAlignedDiffs substrings middle is empty in insert at start 1`] = `
-"<green>- <inverse>expect</>ed common at end</>
-<red>+ insert line</>
-<red>+</>
-<red>+ <inverse>receiv</>ed common at end</>"
+- <i>expect</i>ed common at end
++ insert line
++
++ <i>receiv</i>ed common at end
 `;
 
 exports[`getAlignedDiffs substrings middle is non-empty in delete at end 1`] = `
-"<green>- common at start precedes <inverse>delete</></>
-<green>- non-empty line</>
-<green>- next</>
-<red>+ common at start precedes <inverse>prev</></>"
+- common at start precedes <i>delete</i>
+- non-empty line
+- next
++ common at start precedes <i>prev</i>
 `;
 
 exports[`getAlignedDiffs substrings middle is non-empty in insert between common 1`] = `
-"<green>- common at start precedes <inverse>delete expect</>ed</>
-<red>+ common at start precedes <inverse>insert</></>
-<red>+ non-empty</>
-<red>+ <inverse>receiv</>ed</>"
+- common at start precedes <i>delete expect</i>ed
++ common at start precedes <i>insert</i>
++ non-empty
++ <i>receiv</i>ed
 `;

--- a/packages/jest-diff/src/__tests__/__snapshots__/joinAlignedDiffs.test.ts.snap
+++ b/packages/jest-diff/src/__tests__/__snapshots__/joinAlignedDiffs.test.ts.snap
@@ -1,160 +1,160 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`joinAlignedDiffsExpand first line is empty common 1`] = `
-"<dim>  ↵</>
-<dim>  common 2 preceding A</>
-<dim>  common 1 preceding A</>
-<green>- delete line</>
-<green>- change <inverse>expect</>ed A</>
-<red>+ change <inverse>receiv</>ed A</>
-<dim>  common 1 following A</>
-<dim>  common 2 following A</>
-<dim>  common 3 following A</>
-<dim>  common 4 following A</>
-<dim>  common 4 preceding B</>
-<dim>  common 3 preceding B</>
-<dim>  common 2 preceding B</>
-<dim>  common 1 preceding B</>
-<green>- change <inverse>expect</>ed B</>
-<red>+ change <inverse>receiv</>ed B</>
-<red>+ insert line</>
-<dim>  common 1 following B</>
-<dim>  common 2 following B</>
-<dim>  common 3 between B and C</>
-<dim>  common 2 preceding C</>
-<dim>  common 1 preceding C</>
-<green>- change <inverse>expect</>ed C</>
-<red>+ change <inverse>receiv</>ed C</>
-<dim>  common 1 following C</>
-<dim>  common 2 following C</>
-<dim>  common 3 following C</>
+  ↵
+  common 2 preceding A
+  common 1 preceding A
+- delete line
+- change <i>expect</i>ed A
++ change <i>receiv</i>ed A
+  common 1 following A
+  common 2 following A
+  common 3 following A
+  common 4 following A
+  common 4 preceding B
+  common 3 preceding B
+  common 2 preceding B
+  common 1 preceding B
+- change <i>expect</i>ed B
++ change <i>receiv</i>ed B
++ insert line
+  common 1 following B
+  common 2 following B
+  common 3 between B and C
+  common 2 preceding C
+  common 1 preceding C
+- change <i>expect</i>ed C
++ change <i>receiv</i>ed C
+  common 1 following C
+  common 2 following C
+  common 3 following C
 
-<dim>  common 5 following C</>"
+  common 5 following C
 `;
 
 exports[`joinAlignedDiffsNoExpand patch 0 with context 1 and change at start and end 1`] = `
-"<green>- delete</>
-<dim>  common following delete</>
-<dim>  common preceding insert</>
-<red>+ insert</>"
+- delete
+  common following delete
+  common preceding insert
++ insert
 `;
 
 exports[`joinAlignedDiffsNoExpand patch 0 with context 5 and first line is empty common 1`] = `
-"<dim>  ↵</>
-<dim>  common 2 preceding A</>
-<dim>  common 1 preceding A</>
-<green>- delete line</>
-<green>- change <inverse>expect</>ed A</>
-<red>+ change <inverse>receiv</>ed A</>
-<dim>  common 1 following A</>
-<dim>  common 2 following A</>
-<dim>  common 3 following A</>
-<dim>  common 4 following A</>
-<dim>  common 4 preceding B</>
-<dim>  common 3 preceding B</>
-<dim>  common 2 preceding B</>
-<dim>  common 1 preceding B</>
-<green>- change <inverse>expect</>ed B</>
-<red>+ change <inverse>receiv</>ed B</>
-<red>+ insert line</>
-<dim>  common 1 following B</>
-<dim>  common 2 following B</>
-<dim>  common 3 between B and C</>
-<dim>  common 2 preceding C</>
-<dim>  common 1 preceding C</>
-<green>- change <inverse>expect</>ed C</>
-<red>+ change <inverse>receiv</>ed C</>
-<dim>  common 1 following C</>
-<dim>  common 2 following C</>
-<dim>  common 3 following C</>
+  ↵
+  common 2 preceding A
+  common 1 preceding A
+- delete line
+- change <i>expect</i>ed A
++ change <i>receiv</i>ed A
+  common 1 following A
+  common 2 following A
+  common 3 following A
+  common 4 following A
+  common 4 preceding B
+  common 3 preceding B
+  common 2 preceding B
+  common 1 preceding B
+- change <i>expect</i>ed B
++ change <i>receiv</i>ed B
++ insert line
+  common 1 following B
+  common 2 following B
+  common 3 between B and C
+  common 2 preceding C
+  common 1 preceding C
+- change <i>expect</i>ed C
++ change <i>receiv</i>ed C
+  common 1 following C
+  common 2 following C
+  common 3 following C
 
-<dim>  common 5 following C</>"
+  common 5 following C
 `;
 
 exports[`joinAlignedDiffsNoExpand patch 1 with context 4 and last line is empty common 1`] = `
-"<yellow>@@ -1,24 +1,24 @@</>
+@@ -1,24 +1,24 @@
 
-<dim>  common 2 preceding A</>
-<dim>  common 1 preceding A</>
-<green>- delete line</>
-<green>- change <inverse>expect</>ed A</>
-<red>+ change <inverse>receiv</>ed A</>
-<dim>  common 1 following A</>
-<dim>  common 2 following A</>
-<dim>  common 3 following A</>
-<dim>  common 4 following A</>
-<dim>  common 4 preceding B</>
-<dim>  common 3 preceding B</>
-<dim>  common 2 preceding B</>
-<dim>  common 1 preceding B</>
-<green>- change <inverse>expect</>ed B</>
-<red>+ change <inverse>receiv</>ed B</>
-<red>+ insert line</>
-<dim>  common 1 following B</>
-<dim>  common 2 following B</>
-<dim>  common 3 between B and C</>
-<dim>  common 2 preceding C</>
-<dim>  common 1 preceding C</>
-<green>- change <inverse>expect</>ed C</>
-<red>+ change <inverse>receiv</>ed C</>
-<dim>  common 1 following C</>
-<dim>  common 2 following C</>
-<dim>  common 3 following C</>
-<dim>  ↵</>"
+  common 2 preceding A
+  common 1 preceding A
+- delete line
+- change <i>expect</i>ed A
++ change <i>receiv</i>ed A
+  common 1 following A
+  common 2 following A
+  common 3 following A
+  common 4 following A
+  common 4 preceding B
+  common 3 preceding B
+  common 2 preceding B
+  common 1 preceding B
+- change <i>expect</i>ed B
++ change <i>receiv</i>ed B
++ insert line
+  common 1 following B
+  common 2 following B
+  common 3 between B and C
+  common 2 preceding C
+  common 1 preceding C
+- change <i>expect</i>ed C
++ change <i>receiv</i>ed C
+  common 1 following C
+  common 2 following C
+  common 3 following C
+  ↵
 `;
 
 exports[`joinAlignedDiffsNoExpand patch 2 with context 3 1`] = `
-"<yellow>@@ -1,8 +1,7 @@</>
+@@ -1,8 +1,7 @@
 
-<dim>  common 2 preceding A</>
-<dim>  common 1 preceding A</>
-<green>- delete line</>
-<green>- change <inverse>expect</>ed A</>
-<red>+ change <inverse>receiv</>ed A</>
-<dim>  common 1 following A</>
-<dim>  common 2 following A</>
-<dim>  common 3 following A</>
-<yellow>@@ -11,13 +10,14 @@</>
-<dim>  common 3 preceding B</>
-<dim>  common 2 preceding B</>
-<dim>  common 1 preceding B</>
-<green>- change <inverse>expect</>ed B</>
-<red>+ change <inverse>receiv</>ed B</>
-<red>+ insert line</>
-<dim>  common 1 following B</>
-<dim>  common 2 following B</>
-<dim>  common 3 between B and C</>
-<dim>  common 2 preceding C</>
-<dim>  common 1 preceding C</>
-<green>- change <inverse>expect</>ed C</>
-<red>+ change <inverse>receiv</>ed C</>
-<dim>  common 1 following C</>
-<dim>  common 2 following C</>
-<dim>  common 3 following C</>"
+  common 2 preceding A
+  common 1 preceding A
+- delete line
+- change <i>expect</i>ed A
++ change <i>receiv</i>ed A
+  common 1 following A
+  common 2 following A
+  common 3 following A
+@@ -11,13 +10,14 @@
+  common 3 preceding B
+  common 2 preceding B
+  common 1 preceding B
+- change <i>expect</i>ed B
++ change <i>receiv</i>ed B
++ insert line
+  common 1 following B
+  common 2 following B
+  common 3 between B and C
+  common 2 preceding C
+  common 1 preceding C
+- change <i>expect</i>ed C
++ change <i>receiv</i>ed C
+  common 1 following C
+  common 2 following C
+  common 3 following C
 `;
 
 exports[`joinAlignedDiffsNoExpand patch 3 with context 2 and omit excess common at start 1`] = `
-"<yellow>@@ -2,6 +2,5 @@</>
-<dim>  common 2 preceding A</>
-<dim>  common 1 preceding A</>
-<green>- delete line</>
-<green>- change <inverse>expect</>ed A</>
-<red>+ change <inverse>receiv</>ed A</>
-<dim>  common 1 following A</>
-<dim>  common 2 following A</>
-<yellow>@@ -12,5 +11,6 @@</>
-<dim>  common 2 preceding B</>
-<dim>  common 1 preceding B</>
-<green>- change <inverse>expect</>ed B</>
-<red>+ change <inverse>receiv</>ed B</>
-<red>+ insert line</>
-<dim>  common 1 following B</>
-<dim>  common 2 following B</>
-<yellow>@@ -18,5 +18,5 @@</>
-<dim>  common 2 preceding C</>
-<dim>  common 1 preceding C</>
-<green>- change <inverse>expect</>ed C</>
-<red>+ change <inverse>receiv</>ed C</>
-<dim>  common 1 following C</>
-<dim>  common 2 following C</>"
+@@ -2,6 +2,5 @@
+  common 2 preceding A
+  common 1 preceding A
+- delete line
+- change <i>expect</i>ed A
++ change <i>receiv</i>ed A
+  common 1 following A
+  common 2 following A
+@@ -12,5 +11,6 @@
+  common 2 preceding B
+  common 1 preceding B
+- change <i>expect</i>ed B
++ change <i>receiv</i>ed B
++ insert line
+  common 1 following B
+  common 2 following B
+@@ -18,5 +18,5 @@
+  common 2 preceding C
+  common 1 preceding C
+- change <i>expect</i>ed C
++ change <i>receiv</i>ed C
+  common 1 following C
+  common 2 following C
 `;

--- a/packages/jest-diff/src/__tests__/diff.test.ts
+++ b/packages/jest-diff/src/__tests__/diff.test.ts
@@ -838,23 +838,27 @@ test('collapses big diffs to patch format', () => {
 
 describe('context', () => {
   const testDiffContextLines = (contextLines?: number) => {
-    test(`number of lines: ${
-      typeof contextLines === 'number' ? contextLines : 'undefined'
-    } ${
+    const validContextLines =
       typeof contextLines === 'number' &&
       Number.isSafeInteger(contextLines) &&
-      contextLines >= 0
-        ? ''
-        : '(5 default)'
-    }`, () => {
+      contextLines >= 0;
+
+    test(`number of lines: ${
+      typeof contextLines === 'number' ? contextLines : 'undefined'
+    } ${validContextLines ? '' : '(5 default)'}`, () => {
+      const options = {
+        ...optionsCounts,
+        contextLines,
+        expand: false,
+      };
+      if (!validContextLines) {
+        options.patchColor = chalk.dim;
+      }
+
       const result = diff(
         {test: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]},
         {test: [1, 2, 3, 4, 5, 6, 7, 8, 10, 9]},
-        {
-          contextLines,
-          expand: false,
-          ...optionsCounts,
-        },
+        options,
       );
       expect(result).toMatchSnapshot();
     });
@@ -949,6 +953,18 @@ describe('options', () => {
 
     test('diff', () => {
       expect(diff(a, b, options)).toMatchSnapshot();
+    });
+  });
+
+  describe('change color', () => {
+    const options = {
+      changeColor: chalk.bold,
+    };
+
+    test('diffStringsUnified', () => {
+      const aChanged = a.join('\n').replace('change', 'changed');
+      const bChanged = b.join('\n').replace('change', 'changed');
+      expect(diffStringsUnified(aChanged, bChanged, options)).toMatchSnapshot();
     });
   });
 

--- a/packages/jest-diff/src/__tests__/getAlignedDiffs.test.ts
+++ b/packages/jest-diff/src/__tests__/getAlignedDiffs.test.ts
@@ -7,8 +7,28 @@
 
 import {diffStringsUnified} from '../printDiffs';
 
+// To align columns so people can review snapshots confidently:
+
+// 1. Use options to omit line colors.
+const identity = (string: string) => string;
+const changeColor = (string: string) => '<i>' + string + '</i>';
+const options = {
+  aColor: identity,
+  bColor: identity,
+  changeColor,
+  commonColor: identity,
+  omitAnnotationLines: true,
+  patchColor: identity,
+};
+
 const testAlignedDiffs = (a: string, b: string): string =>
-  diffStringsUnified(a, b, {omitAnnotationLines: true});
+  diffStringsUnified(a, b, options);
+
+// 2. Add string serializer to omit double quote marks.
+expect.addSnapshotSerializer({
+  serialize: (val: string) => val,
+  test: (val: unknown) => typeof val === 'string',
+});
 
 describe('getAlignedDiffs', () => {
   describe('lines', () => {

--- a/packages/jest-diff/src/__tests__/joinAlignedDiffs.test.ts
+++ b/packages/jest-diff/src/__tests__/joinAlignedDiffs.test.ts
@@ -6,20 +6,38 @@
  */
 
 import {DIFF_DELETE, DIFF_EQUAL, DIFF_INSERT, Diff} from '../cleanupSemantic';
-import {INVERTED_COLOR} from '../printDiffs';
 import {
   joinAlignedDiffsExpand,
   joinAlignedDiffsNoExpand,
 } from '../joinAlignedDiffs';
 import {normalizeDiffOptions} from '../normalizeDiffOptions';
 
+// To align columns so people can review snapshots confidently:
+
+// 1. Use options to omit line colors.
+const identity = (string: string) => string;
+const changeColor = (string: string) => '<i>' + string + '</i>';
+const optionsNoColor = {
+  aColor: identity,
+  bColor: identity,
+  changeColor,
+  commonColor: identity,
+  patchColor: identity,
+};
+
+// 2. Add string serializer to omit double quote marks.
+expect.addSnapshotSerializer({
+  serialize: (val: string) => val,
+  test: (val: unknown) => typeof val === 'string',
+});
+
 const diffsCommonStartEnd = [
   new Diff(DIFF_EQUAL, ''),
   new Diff(DIFF_EQUAL, 'common 2 preceding A'),
   new Diff(DIFF_EQUAL, 'common 1 preceding A'),
   new Diff(DIFF_DELETE, 'delete line'),
-  new Diff(DIFF_DELETE, ['change ', INVERTED_COLOR('expect'), 'ed A'].join('')),
-  new Diff(DIFF_INSERT, ['change ', INVERTED_COLOR('receiv'), 'ed A'].join('')),
+  new Diff(DIFF_DELETE, ['change ', changeColor('expect'), 'ed A'].join('')),
+  new Diff(DIFF_INSERT, ['change ', changeColor('receiv'), 'ed A'].join('')),
   new Diff(DIFF_EQUAL, 'common 1 following A'),
   new Diff(DIFF_EQUAL, 'common 2 following A'),
   new Diff(DIFF_EQUAL, 'common 3 following A'),
@@ -28,16 +46,16 @@ const diffsCommonStartEnd = [
   new Diff(DIFF_EQUAL, 'common 3 preceding B'),
   new Diff(DIFF_EQUAL, 'common 2 preceding B'),
   new Diff(DIFF_EQUAL, 'common 1 preceding B'),
-  new Diff(DIFF_DELETE, ['change ', INVERTED_COLOR('expect'), 'ed B'].join('')),
-  new Diff(DIFF_INSERT, ['change ', INVERTED_COLOR('receiv'), 'ed B'].join('')),
+  new Diff(DIFF_DELETE, ['change ', changeColor('expect'), 'ed B'].join('')),
+  new Diff(DIFF_INSERT, ['change ', changeColor('receiv'), 'ed B'].join('')),
   new Diff(DIFF_INSERT, 'insert line'),
   new Diff(DIFF_EQUAL, 'common 1 following B'),
   new Diff(DIFF_EQUAL, 'common 2 following B'),
   new Diff(DIFF_EQUAL, 'common 3 between B and C'),
   new Diff(DIFF_EQUAL, 'common 2 preceding C'),
   new Diff(DIFF_EQUAL, 'common 1 preceding C'),
-  new Diff(DIFF_DELETE, ['change ', INVERTED_COLOR('expect'), 'ed C'].join('')),
-  new Diff(DIFF_INSERT, ['change ', INVERTED_COLOR('receiv'), 'ed C'].join('')),
+  new Diff(DIFF_DELETE, ['change ', changeColor('expect'), 'ed C'].join('')),
+  new Diff(DIFF_INSERT, ['change ', changeColor('receiv'), 'ed C'].join('')),
   new Diff(DIFF_EQUAL, 'common 1 following C'),
   new Diff(DIFF_EQUAL, 'common 2 following C'),
   new Diff(DIFF_EQUAL, 'common 3 following C'),
@@ -54,7 +72,8 @@ const diffsChangeStartEnd = [
 
 describe('joinAlignedDiffsExpand', () => {
   test('first line is empty common', () => {
-    const options = normalizeDiffOptions();
+    const options = normalizeDiffOptions(optionsNoColor);
+
     expect(
       joinAlignedDiffsExpand(diffsCommonStartEnd, options),
     ).toMatchSnapshot();
@@ -63,35 +82,56 @@ describe('joinAlignedDiffsExpand', () => {
 
 describe('joinAlignedDiffsNoExpand', () => {
   test('patch 0 with context 1 and change at start and end', () => {
-    const options = normalizeDiffOptions({contextLines: 1, expand: false});
+    const options = normalizeDiffOptions({
+      ...optionsNoColor,
+      contextLines: 1,
+      expand: false,
+    });
+
     expect(
       joinAlignedDiffsNoExpand(diffsChangeStartEnd, options),
     ).toMatchSnapshot();
   });
 
   test('patch 0 with context 5 and first line is empty common', () => {
-    const options = normalizeDiffOptions({expand: false});
+    const options = normalizeDiffOptions({...optionsNoColor, expand: false});
+
     expect(
       joinAlignedDiffsNoExpand(diffsCommonStartEnd, options),
     ).toMatchSnapshot();
   });
 
   test('patch 1 with context 4 and last line is empty common', () => {
-    const options = normalizeDiffOptions({contextLines: 4, expand: false});
+    const options = normalizeDiffOptions({
+      ...optionsNoColor,
+      contextLines: 4,
+      expand: false,
+    });
+
     expect(
       joinAlignedDiffsNoExpand(diffsCommonStartEnd, options),
     ).toMatchSnapshot();
   });
 
   test('patch 2 with context 3', () => {
-    const options = normalizeDiffOptions({contextLines: 3, expand: false});
+    const options = normalizeDiffOptions({
+      ...optionsNoColor,
+      contextLines: 3,
+      expand: false,
+    });
+
     expect(
       joinAlignedDiffsNoExpand(diffsCommonStartEnd, options),
     ).toMatchSnapshot();
   });
 
   test('patch 3 with context 2 and omit excess common at start', () => {
-    const options = normalizeDiffOptions({contextLines: 2, expand: false});
+    const options = normalizeDiffOptions({
+      ...optionsNoColor,
+      contextLines: 2,
+      expand: false,
+    });
+
     expect(
       joinAlignedDiffsNoExpand(diffsCommonStartEnd, options),
     ).toMatchSnapshot();

--- a/packages/jest-diff/src/diffLines.ts
+++ b/packages/jest-diff/src/diffLines.ts
@@ -291,7 +291,7 @@ const diffNoExpand = (
     aEnd += nContextLines;
     bEnd += nContextLines;
 
-    array[iPatchMark] = createPatchMark(aStart, aEnd, bStart, bEnd);
+    array[iPatchMark] = createPatchMark(aStart, aEnd, bStart, bEnd, options);
 
     // If common subsequence is not at end, another patch follows it.
     if (!isAtEnd) {
@@ -332,7 +332,7 @@ const diffNoExpand = (
   if (aStart === 0 && aEnd === aLength && bStart === 0 && bEnd === bLength) {
     array.splice(0, 1); // delete placeholder line for patch mark
   } else {
-    array[iPatchMark] = createPatchMark(aStart, aEnd, bStart, bEnd);
+    array[iPatchMark] = createPatchMark(aStart, aEnd, bStart, bEnd, options);
   }
 
   return printAnnotation(options, changeCounts) + array.join('\n');

--- a/packages/jest-diff/src/getAlignedDiffs.ts
+++ b/packages/jest-diff/src/getAlignedDiffs.ts
@@ -8,7 +8,7 @@
 import {DIFF_DELETE, DIFF_EQUAL, DIFF_INSERT, Diff} from './cleanupSemantic';
 import {DiffOptionsColor} from './types';
 
-// Given change op and array of diffs, return concatenateRelevantDiffsd string:
+// Given change op and array of diffs, return concatenated string:
 // * include common strings
 // * include change strings which have argument op with changeColor
 // * exclude change strings which have opposite op

--- a/packages/jest-diff/src/getAlignedDiffs.ts
+++ b/packages/jest-diff/src/getAlignedDiffs.ts
@@ -5,19 +5,41 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {DIFF_DELETE, DIFF_INSERT, Diff} from './cleanupSemantic';
-import {invertChangedSubstrings} from './printDiffs';
+import {DIFF_DELETE, DIFF_EQUAL, DIFF_INSERT, Diff} from './cleanupSemantic';
+import {DiffOptionsColor} from './types';
+
+// Given change op and array of diffs, return concatenateRelevantDiffsd string:
+// * include common strings
+// * include change strings which have argument op with changeColor
+// * exclude change strings which have opposite op
+const concatenateRelevantDiffs = (
+  op: number,
+  diffs: Array<Diff>,
+  changeColor: DiffOptionsColor,
+): string =>
+  diffs.reduce(
+    (reduced: string, diff: Diff): string =>
+      reduced +
+      (diff[0] === DIFF_EQUAL
+        ? diff[1]
+        : diff[0] === op && diff[1].length !== 0 // empty if change is newline
+        ? changeColor(diff[1])
+        : ''),
+    '',
+  );
 
 // Encapsulate change lines until either a common newline or the end.
 class ChangeBuffer {
   private op: number;
   private line: Array<Diff>; // incomplete line
   private lines: Array<Diff>; // complete lines
+  private changeColor: DiffOptionsColor;
 
-  constructor(op: number) {
+  constructor(op: number, changeColor: DiffOptionsColor) {
     this.op = op;
     this.line = [];
     this.lines = [];
+    this.changeColor = changeColor;
   }
 
   private pushSubstring(substring: string): void {
@@ -33,7 +55,10 @@ class ChangeBuffer {
     // otherwise then it has line color only.
     this.lines.push(
       this.line.length !== 1
-        ? new Diff(this.op, invertChangedSubstrings(this.op, this.line))
+        ? new Diff(
+            this.op,
+            concatenateRelevantDiffs(this.op, this.line, this.changeColor),
+          )
         : this.line[0][0] === this.op
         ? this.line[0] // can use instance
         : new Diff(this.op, this.line[0][1]), // was common diff
@@ -180,9 +205,12 @@ class CommonBuffer {
 // Assume the function is not called:
 // * if either expected or received is empty string
 // * if neither expected nor received is multiline string
-const getAlignedDiffs = (diffs: Array<Diff>): Array<Diff> => {
-  const deleteBuffer = new ChangeBuffer(DIFF_DELETE);
-  const insertBuffer = new ChangeBuffer(DIFF_INSERT);
+const getAlignedDiffs = (
+  diffs: Array<Diff>,
+  changeColor: DiffOptionsColor,
+): Array<Diff> => {
+  const deleteBuffer = new ChangeBuffer(DIFF_DELETE, changeColor);
+  const insertBuffer = new ChangeBuffer(DIFF_INSERT, changeColor);
   const commonBuffer = new CommonBuffer(deleteBuffer, insertBuffer);
 
   diffs.forEach(diff => {

--- a/packages/jest-diff/src/joinAlignedDiffs.ts
+++ b/packages/jest-diff/src/joinAlignedDiffs.ts
@@ -144,7 +144,13 @@ export const joinAlignedDiffsNoExpand = (
             pushCommonLine(diffs[iCommon][1]);
           }
 
-          lines[jPatchMark] = createPatchMark(aStart, aEnd, bStart, bEnd);
+          lines[jPatchMark] = createPatchMark(
+            aStart,
+            aEnd,
+            bStart,
+            bEnd,
+            options,
+          );
           jPatchMark = lines.length;
           lines.push(''); // placeholder line for next patch mark
 
@@ -177,7 +183,7 @@ export const joinAlignedDiffsNoExpand = (
   }
 
   if (hasPatch) {
-    lines[jPatchMark] = createPatchMark(aStart, aEnd, bStart, bEnd);
+    lines[jPatchMark] = createPatchMark(aStart, aEnd, bStart, bEnd, options);
   }
 
   return lines.join('\n');

--- a/packages/jest-diff/src/normalizeDiffOptions.ts
+++ b/packages/jest-diff/src/normalizeDiffOptions.ts
@@ -18,12 +18,14 @@ const OPTIONS_DEFAULT: DiffOptionsNormalized = {
   bAnnotation: 'Received',
   bColor: chalk.red,
   bIndicator: '+',
+  changeColor: chalk.inverse,
   commonColor: chalk.dim,
   commonIndicator: ' ',
   contextLines: DIFF_CONTEXT_DEFAULT,
   expand: true,
   includeChangeCounts: false,
   omitAnnotationLines: false,
+  patchColor: chalk.yellow,
 };
 
 const getContextLines = (contextLines?: number): number =>

--- a/packages/jest-diff/src/printDiffs.ts
+++ b/packages/jest-diff/src/printDiffs.ts
@@ -5,8 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import chalk from 'chalk';
-
 import {
   DIFF_DELETE,
   DIFF_EQUAL,
@@ -23,28 +21,6 @@ import {
 } from './joinAlignedDiffs';
 import {normalizeDiffOptions} from './normalizeDiffOptions';
 import {DiffOptions, DiffOptionsNormalized} from './types';
-
-export const INVERTED_COLOR = chalk.inverse; // export for joinAlignedDiffs test
-const PATCH_COLOR = chalk.yellow;
-
-// Given change op and array of diffs, return concatenated string:
-// * include common strings
-// * include change strings which have argument op (inverse highlight)
-// * exclude change strings which have opposite op
-export const invertChangedSubstrings = (
-  op: number,
-  diffs: Array<Diff>,
-): string =>
-  diffs.reduce(
-    (reduced: string, diff: Diff): string =>
-      reduced +
-      (diff[0] === DIFF_EQUAL
-        ? diff[1]
-        : diff[0] === op
-        ? INVERTED_COLOR(diff[1])
-        : ''),
-    '',
-  );
 
 const NEWLINE_SYMBOL = '\u{21B5}'; // downwards arrow with corner leftwards
 const SPACE_SYMBOL = '\u{00B7}'; // middle dot
@@ -172,8 +148,9 @@ export const createPatchMark = (
   aEnd: number,
   bStart: number,
   bEnd: number,
+  {patchColor}: DiffOptionsNormalized,
 ): string =>
-  PATCH_COLOR(
+  patchColor(
     `@@ -${aStart + 1},${aEnd - aStart} +${bStart + 1},${bEnd - bStart} @@`,
   );
 
@@ -243,7 +220,7 @@ export const diffStringsUnified = (
   );
 
   if (hasCommonDiff(diffs, isMultiline)) {
-    const lines = getAlignedDiffs(diffs);
+    const lines = getAlignedDiffs(diffs, optionsNormalized.changeColor);
     return (
       printAnnotation(optionsNormalized, countChanges(lines)) +
       (optionsNormalized.expand

--- a/packages/jest-diff/src/types.ts
+++ b/packages/jest-diff/src/types.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-type DiffOptionsColor = (arg: string) => string; // subset of Chalk type
+export type DiffOptionsColor = (arg: string) => string; // subset of Chalk type
 
 export type DiffOptions = {
   aAnnotation?: string;
@@ -14,12 +14,14 @@ export type DiffOptions = {
   bAnnotation?: string;
   bColor?: DiffOptionsColor;
   bIndicator?: string;
+  changeColor?: DiffOptionsColor;
   commonColor?: DiffOptionsColor;
   commonIndicator?: string;
   contextLines?: number;
   expand?: boolean;
   includeChangeCounts?: boolean;
   omitAnnotationLines?: boolean;
+  patchColor?: DiffOptionsColor;
 };
 
 export type DiffOptionsNormalized = {
@@ -29,10 +31,12 @@ export type DiffOptionsNormalized = {
   bAnnotation: string;
   bColor: DiffOptionsColor;
   bIndicator: string;
+  changeColor: DiffOptionsColor;
   commonColor: DiffOptionsColor;
   commonIndicator: string;
   contextLines: number;
   expand: boolean;
   includeChangeCounts: boolean;
   omitAnnotationLines: boolean;
+  patchColor: DiffOptionsColor;
 };


### PR DESCRIPTION
## Summary

Provide options for the remaining 2 hard-coded colors used by `diffStringsUnified`

**Residue**: the default export can output 2 additional hard-coded colors in edge cases:

1. `cyan` for lines for which indentation is the only difference: will be superseded by `ignoreIndentation` option and no color distinction for such common lines
2. `bgYellow` for leading or trailing spaces in common lines, because inverse of dim is invisible, but it is not clear that they need formatting

@thymikee after the residue has been solved, it seems like the default `colors: false` option in `snapshot-diff` package can replace `strip-ansi` with identity function for `jest-diff` color options

## Test plan

Added 1 and updated 3 snapshots in `diffs.test.ts.snap`

Add string serializer to omit double quote marks and use options to omit line colors:

* Updated 24 snapshots in `getAlignedDiffs.test.ts.snap`
* Updated 6 snapshots in `joinAlignedDiffs.test.ts.snap`

See also pictures in the following comments

Baseline at left and **optional at right**