### PR TITLE
fix(jest-resolve): don't confuse directories with files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - `[jest-config]` Treat `setupFilesAfterEnv` like `setupFiles` when normalizing configs against presets ([#9495](https://github.com/facebook/jest/pull/9495))
 - `[jest-matcher-utils]` Fix diff highlight of symbol-keyed object. ([#9499](https://github.com/facebook/jest/pull/9499))
 - `[jest-resolve]` Fix module identity preservation with symlinks and browser field resolution ([#9511](https://github.com/facebook/jest/pull/9511))
+- `[jest-resolve]` Do not confuse directories with files ([#8912](https://github.com/facebook/jest/pull/8912))
 - `[jest-snapshot]` Downgrade semver to v6 to support node 8 ([#9451](https://github.com/facebook/jest/pull/9451))
 - `[jest-transform]` Correct sourcemap behavior for transformed and instrumented code ([#9460](https://github.com/facebook/jest/pull/9460))
 - `[pretty-format]` Export `OldPlugin` type ([#9491](https://github.com/facebook/jest/pull/9491))

--- a/packages/jest-resolve/package.json
+++ b/packages/jest-resolve/package.json
@@ -15,7 +15,7 @@
     "chalk": "^3.0.0",
     "jest-pnp-resolver": "^1.2.1",
     "realpath-native": "^2.0.0",
-    "resolve": "^1.15.0"
+    "resolve": "^1.15.1"
   },
   "devDependencies": {
     "@types/browser-resolve": "^0.0.5",

--- a/packages/jest-resolve/src/__mocks__/foo/foo.js
+++ b/packages/jest-resolve/src/__mocks__/foo/foo.js
@@ -5,8 +5,4 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-'use strict';
-
-module.exports = function userResolver(path, options) {
-  return 'module';
-};
+module.exports = require.resolve('./');

--- a/packages/jest-resolve/src/__tests__/resolve.test.ts
+++ b/packages/jest-resolve/src/__tests__/resolve.test.ts
@@ -162,11 +162,13 @@ describe('resolveModule', () => {
       extensions: ['.js'],
     } as ResolverConfig);
     const mocksDirectory = path.resolve(__dirname, '../__mocks__');
-    const resolved = resolver.resolveModule(
-      path.join(mocksDirectory, 'foo/foo.js'),
-      './',
-    );
-    expect(resolved).toBe(path.join(mocksDirectory, 'foo/index.js'));
+    const fooSlashFoo = path.join(mocksDirectory, 'foo/foo.js');
+    const fooSlashIndex = path.join(mocksDirectory, 'foo/index.js');
+
+    const resolvedWithSlash = resolver.resolveModule(fooSlashFoo, './');
+    const resolvedWithDot = resolver.resolveModule(fooSlashFoo, '.');
+    expect(resolvedWithSlash).toBe(fooSlashIndex);
+    expect(resolvedWithSlash).toBe(resolvedWithDot);
   });
 });
 

--- a/packages/jest-resolve/src/__tests__/resolve.test.ts
+++ b/packages/jest-resolve/src/__tests__/resolve.test.ts
@@ -9,7 +9,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import {ModuleMap} from 'jest-haste-map';
-import Resolver from '../';
+import Resolver = require('../');
 // @ts-ignore: js file
 import userResolver from '../__mocks__/userResolver';
 import nodeModulesPaths from '../nodeModulesPaths';
@@ -83,7 +83,7 @@ describe('findNodeModule', () => {
 });
 
 describe('resolveModule', () => {
-  let moduleMap: typeof ModuleMap;
+  let moduleMap: ModuleMap;
   beforeEach(() => {
     moduleMap = ModuleMap.create('/');
   });
@@ -156,6 +156,18 @@ describe('resolveModule', () => {
     });
     expect(resolved).toBe(require.resolve('../__mocks__/mockJsDependency.js'));
   });
+
+  it('does not confuse directories with files', () => {
+    const resolver = new Resolver(moduleMap, {
+      extensions: ['.js'],
+    } as ResolverConfig);
+    const mocksDirectory = path.resolve(__dirname, '../__mocks__');
+    const resolved = resolver.resolveModule(
+      path.join(mocksDirectory, 'foo/foo.js'),
+      './',
+    );
+    expect(resolved).toBe(path.join(mocksDirectory, 'foo/index.js'));
+  });
 });
 
 describe('getMockModule', () => {
@@ -195,7 +207,7 @@ describe('nodeModulesPaths', () => {
 
 describe('Resolver.getModulePaths() -> nodeModulesPaths()', () => {
   const _path = path;
-  let moduleMap: typeof ModuleMap;
+  let moduleMap: ModuleMap;
 
   beforeEach(() => {
     jest.resetModules();

--- a/packages/jest-resolve/src/defaultResolver.ts
+++ b/packages/jest-resolve/src/defaultResolver.ts
@@ -69,7 +69,7 @@ function resolveSync(
   if (REGEX_RELATIVE_IMPORT.test(target)) {
     // resolve relative import
     let resolveTarget = path.resolve(basedir, target);
-    if (target === '..' || target.endsWith('/')) {
+    if (target === '.' || target === '..' || target.endsWith('/')) {
       resolveTarget += '/';
     }
     const result = tryResolve(resolveTarget);

--- a/packages/jest-resolve/src/defaultResolver.ts
+++ b/packages/jest-resolve/src/defaultResolver.ts
@@ -103,7 +103,7 @@ function resolveSync(
     const dir = path.dirname(name);
     let result;
     if (isDirectory(dir)) {
-      result = resolveAsFile(name) || resolveAsDirectory(name);
+      result = resolveAsDirectory(name) || resolveAsFile(name);
     }
     if (result) {
       // Dereference symlinks to ensure we don't create a separate

--- a/packages/jest-resolve/src/defaultResolver.ts
+++ b/packages/jest-resolve/src/defaultResolver.ts
@@ -68,7 +68,10 @@ function resolveSync(
 
   if (REGEX_RELATIVE_IMPORT.test(target)) {
     // resolve relative import
-    const resolveTarget = path.resolve(basedir, target);
+    let resolveTarget = path.resolve(basedir, target);
+    if (target === '..' || target.endsWith('/')) {
+      resolveTarget += '/';
+    }
     const result = tryResolve(resolveTarget);
     if (result) {
       return result;
@@ -103,7 +106,7 @@ function resolveSync(
     const dir = path.dirname(name);
     let result;
     if (isDirectory(dir)) {
-      result = resolveAsDirectory(name) || resolveAsFile(name);
+      result = resolveAsFile(name) || resolveAsDirectory(name);
     }
     if (result) {
       // Dereference symlinks to ensure we don't create a separate

--- a/yarn.lock
+++ b/yarn.lock
@@ -12567,10 +12567,10 @@ resolve@1.1.7:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
-resolve@^1.1.6, resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.15.0, resolve@^1.3.2, resolve@^1.5.0, resolve@^1.8.1:
-  version "1.15.0"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.15.0.tgz#1b7ca96073ebb52e741ffd799f6b39ea462c67f5"
-  integrity sha512-+hTmAldEGE80U2wJJDC1lebb5jWqvTYAfm3YZ1ckk1gBr0MnCqUKlwK1e+anaFljIl+F5tR5IoZcm4ZDA1zMQw==
+resolve@^1.1.6, resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.15.0, resolve@^1.15.1, resolve@^1.3.2, resolve@^1.5.0, resolve@^1.8.1:
+  version "1.15.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.15.1.tgz#27bdcdeffeaf2d6244b95bb0f9f4b4653451f3e8"
+  integrity sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==
   dependencies:
     path-parse "^1.0.6"
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Fixes #8910

This might be an inherited bug from `resolve`: https://github.com/browserify/resolve/blob/bd3f55188f0f3d1dac1e29c2f9a0eaa0878d4bd0/lib/sync.js#L69 which this code came from in #4315.
EDIT: No, seems like `resolve` works correctly

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Test added

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
