### PR TITLE
Add ref=nofollow to backers on the site

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -66,6 +66,7 @@ const Backer = ({
     className="backer-item"
     title={`$${totalDonations.value} by ${name || slug}`}
     target="_blank"
+    rel="nofollow"
     href={website || `https://opencollective.com/${slug}`}
   >
     {
@@ -538,9 +539,9 @@ class Index extends React.Component {
                   <MarkdownBlock>
                     <translate>
                       A lot of people! With
-                      [16m](https://www.npmjs.com/package/jest) downloads in the
-                      last 30 days, and used on over
-                      [1,130,000](https://github.com/facebook/jest/network/dependents)
+                      [20m](https://www.npmjs.com/package/jest) downloads in the
+                      last month, and used on over
+                      [1,293,000](https://github.com/facebook/jest/network/dependents)
                       public repos on GitHub. Jest is used extensively at these
                       companies:
                     </translate>

--- a/website/static/css/jest.css
+++ b/website/static/css/jest.css
@@ -23,7 +23,7 @@
 }
 
 .sponsor-item img {
-  background: #095708;
+  background: white;
 }
 
 .sponsor-avatar {


### PR DESCRIPTION
## Summary

We're starting to get quite a lot of people signing up for the SEO boost from sites that TBH Jest shouldn't be pushing (online casinos, textbook cheating etc) - that's a bit sucky, but it's also annoying that these company pretty regularly email or DM a few of the core devs about these links not appearing on the site instantly.

This should de-incentivize this behavior. Also makes the BG white instead of green.
