### PR TITLE
feat: make node-notifier an optional dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,9 @@
 - `[jest-fake-timers]` `getTimerCount` will not include cancelled immediates ([#8764](https://github.com/facebook/jest/pull/8764))
 - `[jest-leak-detector]` [**BREAKING**] Use `weak-napi` instead of `weak` package ([#8686](https://github.com/facebook/jest/pull/8686))
 - `[jest-mock]` Fix for mockReturnValue overriding mockImplementationOnce ([#8398](https://github.com/facebook/jest/pull/8398))
-- `[jest-snapshot]` Remove only the added newlines in multiline snapshots ([#8859](https://github.com/facebook/jest/pull/8859))
+- `[jest-reporters]` Make node-notifer an optional dependency ([#8918](https://github.com/facebook/jest/pull/8918))
 - `[jest-snapshot]` Distinguish empty string from external snapshot not written ([#8880](https://github.com/facebook/jest/pull/8880))
+- `[jest-snapshot]` Remove only the added newlines in multiline snapshots ([#8859](https://github.com/facebook/jest/pull/8859))
 - `[jest-snapshot]` [**BREAKING**] Distinguish empty string from internal snapshot not written ([#8898](https://github.com/facebook/jest/pull/8898))
 - `[jest-transform]` Properly cache transformed files across tests ([#8890](https://github.com/facebook/jest/pull/8890))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,8 @@
 - `[jest-leak-detector]` [**BREAKING**] Use `weak-napi` instead of `weak` package ([#8686](https://github.com/facebook/jest/pull/8686))
 - `[jest-mock]` Fix for mockReturnValue overriding mockImplementationOnce ([#8398](https://github.com/facebook/jest/pull/8398))
 - `[jest-reporters]` Make node-notifer an optional dependency ([#8918](https://github.com/facebook/jest/pull/8918))
-- `[jest-snapshot]` Distinguish empty string from external snapshot not written ([#8880](https://github.com/facebook/jest/pull/8880))
 - `[jest-snapshot]` Remove only the added newlines in multiline snapshots ([#8859](https://github.com/facebook/jest/pull/8859))
+- `[jest-snapshot]` Distinguish empty string from external snapshot not written ([#8880](https://github.com/facebook/jest/pull/8880))
 - `[jest-snapshot]` [**BREAKING**] Distinguish empty string from internal snapshot not written ([#8898](https://github.com/facebook/jest/pull/8898))
 - `[jest-transform]` Properly cache transformed files across tests ([#8890](https://github.com/facebook/jest/pull/8890))
 

--- a/packages/jest-reporters/package.json
+++ b/packages/jest-reporters/package.json
@@ -23,7 +23,6 @@
     "jest-runtime": "^24.9.0",
     "jest-util": "^24.9.0",
     "jest-worker": "^24.6.0",
-    "node-notifier": "^5.4.3",
     "slash": "^3.0.0",
     "source-map": "^0.6.0",
     "string-length": "^3.1.0"
@@ -38,6 +37,9 @@
     "@types/istanbul-reports": "^1.1.0",
     "@types/node-notifier": "^5.4.0",
     "strip-ansi": "^5.0.0"
+  },
+  "optionalDependencies": {
+    "node-notifier": "^5.4.3"
   },
   "engines": {
     "node": ">= 8"


### PR DESCRIPTION
## Summary

`notify` is an optional feature that is disabled by default. Its implementation requires [node-notifier](https://github.com/mikaelbr/node-notifier), which distributes snoreToast, a [LGPL-3.0 executable](https://github.com/mikaelbr/node-notifier/tree/master/vendor/snoreToast). node-notifier also includes terminal-notifier and notifu which are not MIT licensed.

My employer will not import node-notifier to our npm repository due to the LGPL executable which means we cannot use jest.

This pull request make node-notifier an optional dependency, so jest install will not fail if node-notifier cannot be found. jest will throw an error if notifications are enabled and node-notifier cannot be found.

## Test plan

Tested by running `jest --notify` after removing `node-notifier` from node_modules.
> jest errors with 'notify reporter requires optional dependency node-notifier but it was not found'

Tested by running `jest` after removing `node-notifier`
> jest completes successfully 

Tested by running `jest --notify` without removing `node-notifier`.
> jest completes successfully with notifications.