### PR TITLE
Replace `test` with `it` in TutorialAsync.md

### DIFF
--- a/docs/TutorialAsync.md
+++ b/docs/TutorialAsync.md
@@ -116,7 +116,7 @@ Errors can be handled using the `.catch` method. Make sure to add `expect.assert
 
 ```js
 // Testing for async errors using Promise.catch.
-test('tests error with promises', () => {
+it('tests error with promises', () => {
   expect.assertions(1);
   return user.getUserName(2).catch(e =>
     expect(e).toEqual({


### PR DESCRIPTION
`it` is used everywhere in TutorialAsync.md except for one test where `test` is used. This commit replaces that `test` with an `it` to keep things consistent and because there does not seem to be a good reason to use `test` over `it` here.