### PR TITLE
[jest-config] Changed "Preset ... not found" validation error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ### Features
 
-- `[jest-config]` Throw the full error message and stack when a Jest preset is missing a dependency ([#8924](https://github.com/facebook/jest/pull/8924))
 - `[babel-plugin-jest-hoist]` Show codeframe on static hoisting issues ([#8865](https://github.com/facebook/jest/pull/8865))
 - `[babel-plugin-jest-hoist]` Add `BigInt` to `WHITELISTED_IDENTIFIERS` ([#8382](https://github.com/facebook/jest/pull/8382))
 - `[babel-preset-jest]` Add `@babel/plugin-syntax-bigint` ([#8382](https://github.com/facebook/jest/pull/8382))
 - `[expect]` Add `BigInt` support to `toBeGreaterThan`, `toBeGreaterThanOrEqual`, `toBeLessThan` and `toBeLessThanOrEqual` ([#8382](https://github.com/facebook/jest/pull/8382))
+- `[jest-config]` Throw the full error message and stack when a Jest preset is missing a dependency ([#8924](https://github.com/facebook/jest/pull/8924))
 - `[jest-config]` [**BREAKING**] Set default display name color based on runner ([#8689](https://github.com/facebook/jest/pull/8689))
 - `[jest-diff]` Add options for colors and symbols ([#8841](https://github.com/facebook/jest/pull/8841))
 - `[jest-diff]` [**BREAKING**] Export as ECMAScript module ([#8873](https://github.com/facebook/jest/pull/8873))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 
+- `[jest-config]` Throw the full error message and stack when a Jest preset is missing a dependency ([#8924](https://github.com/facebook/jest/pull/8924))
 - `[babel-plugin-jest-hoist]` Show codeframe on static hoisting issues ([#8865](https://github.com/facebook/jest/pull/8865))
 - `[babel-plugin-jest-hoist]` Add `BigInt` to `WHITELISTED_IDENTIFIERS` ([#8382](https://github.com/facebook/jest/pull/8382))
 - `[babel-preset-jest]` Add `@babel/plugin-syntax-bigint` ([#8382](https://github.com/facebook/jest/pull/8382))

--- a/packages/jest-config/src/__tests__/normalize.test.js
+++ b/packages/jest-config/src/__tests__/normalize.test.js
@@ -1041,6 +1041,29 @@ describe('preset', () => {
     }).toThrowErrorMatchingSnapshot();
   });
 
+  test('throws when a dependency is missing in the preset', () => {
+    jest.doMock(
+      '/node_modules/react-native-js-preset/jest-preset.js',
+      () => {
+        require('library-that-is-not-installed');
+        return {
+          transform: {},
+        };
+      },
+      {virtual: true},
+    );
+
+    expect(() => {
+      normalize(
+        {
+          preset: 'react-native-js-preset',
+          rootDir: '/root/path/foo',
+        },
+        {},
+      );
+    }).toThrowError(/Cannot find module 'library-that-is-not-installed'/);
+  });
+
   test('throws when preset is invalid', () => {
     jest.doMock('/node_modules/react-native/jest-preset.json', () =>
       jest.requireActual('./jest-preset.json'),

--- a/packages/jest-config/src/normalize.ts
+++ b/packages/jest-config/src/normalize.ts
@@ -108,24 +108,30 @@ const setupPreset = (
       );
     }
 
-    const preset = Resolver.findNodeModule(presetPath, {
-      basedir: options.rootDir,
-    });
-
-    if (preset) {
+    if (error.message.includes('Cannot find module')) {
+      if (error.message.includes(presetPath)) {
+        const preset = Resolver.findNodeModule(presetPath, {
+          basedir: options.rootDir,
+        });
+    
+        if (preset) {
+          throw createConfigError(
+            `  Module ${chalk.bold(
+              presetPath,
+            )} should have "jest-preset.js" or "jest-preset.json" file at the root.`,
+          );
+        }
+        throw createConfigError(`  Preset ${chalk.bold(presetPath)} not found.`);
+      }
       throw createConfigError(
-        `  Module ${chalk.bold(
-          presetPath,
-        )} should have "jest-preset.js" or "jest-preset.json" file at the root.`,
+        `  Missing dependency in ${chalk.bold(presetPath)}:\n\n  ${
+          error.message
+        }\n  ${error.stack}`,
       );
     }
 
-    if (error.message.includes('Cannot find module') && error.message.includes(presetPath)) {
-      throw createConfigError(`  Preset ${chalk.bold(presetPath)} not found.`);
-    }
-
     throw createConfigError(
-      `  Failed to load ${chalk.bold(presetPath)}:\n\n  ${
+      `  An unknown error occurred in ${chalk.bold(presetPath)}:\n\n  ${
         error.message
       }\n  ${error.stack}`,
     );

--- a/packages/jest-config/src/normalize.ts
+++ b/packages/jest-config/src/normalize.ts
@@ -113,7 +113,7 @@ const setupPreset = (
         const preset = Resolver.findNodeModule(presetPath, {
           basedir: options.rootDir,
         });
-    
+
         if (preset) {
           throw createConfigError(
             `  Module ${chalk.bold(
@@ -121,7 +121,9 @@ const setupPreset = (
             )} should have "jest-preset.js" or "jest-preset.json" file at the root.`,
           );
         }
-        throw createConfigError(`  Preset ${chalk.bold(presetPath)} not found.`);
+        throw createConfigError(
+          `  Preset ${chalk.bold(presetPath)} not found.`,
+        );
       }
       throw createConfigError(
         `  Missing dependency in ${chalk.bold(presetPath)}:\n\n  ${

--- a/packages/jest-config/src/normalize.ts
+++ b/packages/jest-config/src/normalize.ts
@@ -120,7 +120,11 @@ const setupPreset = (
       );
     }
 
-    throw createConfigError(`  Preset ${chalk.bold(presetPath)} not found.`);
+    throw createConfigError(
+      `  Error resolving ${chalk.bold(presetPath)}:\n\n  ${
+        error.message
+      }\n  ${error.stack}`,
+    );
   }
 
   if (options.setupFiles) {

--- a/packages/jest-config/src/normalize.ts
+++ b/packages/jest-config/src/normalize.ts
@@ -120,8 +120,12 @@ const setupPreset = (
       );
     }
 
+    if (error.message.includes('Cannot find module') && error.message.includes(presetPath)) {
+      throw createConfigError(`  Preset ${chalk.bold(presetPath)} not found.`);
+    }
+
     throw createConfigError(
-      `  Error resolving ${chalk.bold(presetPath)}:\n\n  ${
+      `  Failed to load ${chalk.bold(presetPath)}:\n\n  ${
         error.message
       }\n  ${error.stack}`,
     );


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

When using a jest preset that contains a general `Error` (not a `SyntaxError` or `TypeError`) `jest-config` throws a `"Preset ... not found"` validation error.
This is somewhat misleading for users of a broken preset that may just be missing a peer dependency. 

### Work-around

To get around this in `jest-expo` I wrap the requires of peer dependencies in try/catch, rethrow the meaningful error message, then exit the process to prevent users from thinking the preset is missing.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

- Attempting to require any missing library in a Jest preset should result in a useful error message like: 
```sh
● Validation Error:

  Error resolving jest-expo/web:

  Cannot find module 'react-native-web'
  Error: Cannot find module 'react-native-web'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:636:15)
    at Function.Module._load (internal/modules/cjs/loader.js:562:25)
    at Module.require (internal/modules/cjs/loader.js:690:17)
    at require (internal/modules/cjs/helpers.js:25:18)
    at getBaseWebPreset (/Users/evanbacon/Documents/GitHub/expo/packages/jest-expo/src/getPlatformPreset.js:50:3)
    at getWebPreset (/Users/evanbacon/Documents/GitHub/expo/packages/jest-expo/src/getPlatformPreset.js:67:10)
    at Object.<anonymous> (/Users/evanbacon/Documents/GitHub/expo/packages/jest-expo/web/jest-preset.js:3:18)
    at Module._compile (internal/modules/cjs/loader.js:776:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:787:10)
    at Module.load (internal/modules/cjs/loader.js:653:32)

  Configuration Documentation:
  https://jestjs.io/docs/configuration.html
```
As opposed to the current error message:
```sh
● Validation Error:

  Preset jest-expo/web not found.

  Configuration Documentation:
  https://jestjs.io/docs/configuration.html
```

- I'm willing to write a unit-test but would like to get validation on this approach first.
