### PR TITLE
Fix NodeEnvironment import in README.md

### DIFF
--- a/packages/jest-circus/README.md
+++ b/packages/jest-circus/README.md
@@ -12,7 +12,7 @@ Circus is a flux-based test runner for Jest that is fast, easy to maintain, and 
 Circus allows you to bind to events via an optional event handler on any [custom environment](https://jestjs.io/docs/en/configuration#testenvironment-string). See the [type definitions](https://github.com/facebook/jest/blob/master/packages/jest-circus/src/types.ts) for more information on the events and state data currently available.
 
 ```js
-import {NodeEnvironment} from 'jest-environment-node';
+import NodeEnvironment from 'jest-environment-node';
 import {Event, State} from 'jest-circus';
 
 class MyCustomEnvironment extends NodeEnvironment {


### PR DESCRIPTION

## Summary

A minor yet important syntax fix in the main README.md. 'Had me confused...
Also, aligns it with the Jest's [environment associated documentation](https://jestjs.io/docs/en/configuration#testenvironment-string).

## Test plan

N/A