### PR TITLE
Don't include unref'd timers in --detectOpenHandles results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 ### Fixes
 
 - `[expect]` Display expectedDiff more carefully in toBeCloseTo ([#8389](https://github.com/facebook/jest/pull/8389))
+- `[jest-core]` Don't include unref'd timers in --detectOpenHandles results ([#8941](https://github.com/facebook/jest/pull/8941))
 - `[jest-diff]` Do not inverse format if line consists of one change ([#8903](https://github.com/facebook/jest/pull/8903))
 - `[jest-fake-timers]` `getTimerCount` will not include cancelled immediates ([#8764](https://github.com/facebook/jest/pull/8764))
 - `[jest-leak-detector]` [**BREAKING**] Use `weak-napi` instead of `weak` package ([#8686](https://github.com/facebook/jest/pull/8686))

--- a/e2e/__tests__/detectOpenHandles.ts
+++ b/e2e/__tests__/detectOpenHandles.ts
@@ -7,7 +7,7 @@
 
 import {wrap} from 'jest-snapshot-serializer-raw';
 import runJest, {until} from '../runJest';
-import { onNodeVersions } from '../../packages/test-utils';
+import {onNodeVersions} from '../../packages/test-utils';
 
 try {
   require('async_hooks');

--- a/e2e/__tests__/detectOpenHandles.ts
+++ b/e2e/__tests__/detectOpenHandles.ts
@@ -69,6 +69,21 @@ it('does not report promises', () => {
   expect(textAfterTest).toBe('');
 });
 
+const nodeMajorVersion = Number(process.versions.node.split('.')[0]);
+
+if (nodeMajorVersion >= 11) {
+  it('does not report timeouts using unref', () => {
+    // The test here is basically that it exits cleanly without reporting anything (does not need `until`)
+    const {stderr} = runJest('detect-open-handles', [
+      'unref',
+      '--detectOpenHandles',
+    ]);
+    const textAfterTest = getTextAfterTest(stderr);
+
+    expect(textAfterTest).toBe('');
+  });
+}
+
 it('prints out info about open handlers from inside tests', async () => {
   const {stderr} = await until(
     'detect-open-handles',

--- a/e2e/__tests__/detectOpenHandles.ts
+++ b/e2e/__tests__/detectOpenHandles.ts
@@ -7,6 +7,7 @@
 
 import {wrap} from 'jest-snapshot-serializer-raw';
 import runJest, {until} from '../runJest';
+import { onNodeVersions } from '../../packages/test-utils';
 
 try {
   require('async_hooks');
@@ -69,9 +70,7 @@ it('does not report promises', () => {
   expect(textAfterTest).toBe('');
 });
 
-const nodeMajorVersion = Number(process.versions.node.split('.')[0]);
-
-if (nodeMajorVersion >= 11) {
+onNodeVersions('>=11', () => {
   it('does not report timeouts using unref', () => {
     // The test here is basically that it exits cleanly without reporting anything (does not need `until`)
     const {stderr} = runJest('detect-open-handles', [
@@ -82,7 +81,7 @@ if (nodeMajorVersion >= 11) {
 
     expect(textAfterTest).toBe('');
   });
-}
+});
 
 it('prints out info about open handlers from inside tests', async () => {
   const {stderr} = await until(

--- a/e2e/detect-open-handles/__tests__/unref.js
+++ b/e2e/detect-open-handles/__tests__/unref.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+test('something', () => {
+  const timeout = setTimeout(() => {}, 30000);
+  timeout.unref();
+  expect(true).toBe(true);
+});

--- a/packages/test-utils/src/ConditionalTest.ts
+++ b/packages/test-utils/src/ConditionalTest.ts
@@ -7,6 +7,8 @@
 
 /* eslint-disable jest/no-focused-tests */
 
+import semver = require('semver');
+
 export function isJestCircusRun() {
   return process.env.JEST_CIRCUS === '1';
 }
@@ -32,5 +34,15 @@ export function skipSuiteOnWindows() {
     test.only('does not work on Windows', () => {
       console.warn('[SKIP] Does not work on Windows');
     });
+  }
+}
+
+export function onNodeVersions(versionRange: string, testBody: () => void) {
+  if (!semver.satisfies(process.versions.node, versionRange)) {
+    describe.skip(`[SKIP] tests that require node ${versionRange}`, () => {
+      testBody();
+    });
+  } else {
+    testBody();
   }
 }

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -10,5 +10,5 @@ export {
   skipSuiteOnJasmine,
   skipSuiteOnJestCircus,
   skipSuiteOnWindows,
-  onNodeVersions
+  onNodeVersions,
 } from './ConditionalTest';

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -10,4 +10,5 @@ export {
   skipSuiteOnJasmine,
   skipSuiteOnJestCircus,
   skipSuiteOnWindows,
+  onNodeVersions
 } from './ConditionalTest';


### PR DESCRIPTION
Fix #8939 

Note that this shouldn't affect any behaviour in Node < 11, and because of that the test is skipped in older versions. It passes happily for me locally with Node 12.9.1 though.

It would be possible to extend this to cover old versions later on (by wrapping `ref()`/`unref()`) if that seems worthwhile for somebody.