### PR TITLE
Use rel="noopener" on backer links (possible security risk with some sketchy websites)

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -66,7 +66,7 @@ const Backer = ({
     className="backer-item"
     title={`$${totalDonations.value} by ${name || slug}`}
     target="_blank"
-    rel="nofollow"
+    rel="nofollow noopener"
     href={website || `https://opencollective.com/${slug}`}
   >
     {


### PR DESCRIPTION
## Summary

Hi there! I noticed that you list financial backers on your homepage (which is _awesome_ by the way) and even allow them to link to their own websites — but as of now you have links to a few dozen random sites (and some pretty sketchy ones [[1]](https://buycheaprdp.com/) [[2]](https://tips4videotodvd.co.uk/) [[3]](https://playroulette.co.uk/) [[4]](https://www.windows-10.nl/) to be blunt) without using `rel=noopener` which is an understated security risk. @mathiasbynens does a better job of explaining/demonstrating this than I could ever do here: https://mathiasbynens.github.io/rel-noopener/ 

It might be a good practice to add this to all external links to be super safe, but I've only added it to the links to lower-tier backers that are pulled automatically from Open Collective.

(I'd probably suggest removing these links all together, as generous as they are, or just linking to Open Collective profiles, or adding a disclaimer that Jest/Facebook doesn't endorse the content of these sites... but that's probably a bigger discussion?)

Thanks!

## Test plan

Ran `yarn start` and all seems good, but this is my first contribution here so please let me know if I'm missing anything. :)