### PR TITLE
fix(jest-resolve-dependencies): resolve mocks as dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 - `[jest-environment-jsdom]` [**BREAKING**] Upgrade JSDOM from v11 to v15 ([#8851](https://github.com/facebook/jest/pull/8851))
 - `[jest-util]` [**BREAKING**] Remove deprecated exports ([#8863](https://github.com/facebook/jest/pull/8863))
 - `[jest-validate]` [**BREAKING**] Use ESM exports ([#8874](https://github.com/facebook/jest/pull/8874))
+- `[jest-resolve-dependencies]` Resolve mocks as dependencies ([#8952](https://github.com/facebook/jest/pull/8952))
 
 ### Performance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,11 +30,11 @@
 - `[jest-leak-detector]` [**BREAKING**] Use `weak-napi` instead of `weak` package ([#8686](https://github.com/facebook/jest/pull/8686))
 - `[jest-mock]` Fix for mockReturnValue overriding mockImplementationOnce ([#8398](https://github.com/facebook/jest/pull/8398))
 - `[jest-reporters]` Make node-notifer an optional dependency ([#8918](https://github.com/facebook/jest/pull/8918))
+- `[jest-resolve-dependencies]` Resolve mocks as dependencies ([#8952](https://github.com/facebook/jest/pull/8952))
 - `[jest-snapshot]` Remove only the added newlines in multiline snapshots ([#8859](https://github.com/facebook/jest/pull/8859))
 - `[jest-snapshot]` Distinguish empty string from external snapshot not written ([#8880](https://github.com/facebook/jest/pull/8880))
 - `[jest-snapshot]` [**BREAKING**] Distinguish empty string from internal snapshot not written ([#8898](https://github.com/facebook/jest/pull/8898))
 - `[jest-transform]` Properly cache transformed files across tests ([#8890](https://github.com/facebook/jest/pull/8890))
-- `[jest-resolve-dependencies]` Resolve mocks as dependencies ([#8952](https://github.com/facebook/jest/pull/8952))
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - `[jest-snapshot]` Distinguish empty string from external snapshot not written ([#8880](https://github.com/facebook/jest/pull/8880))
 - `[jest-snapshot]` [**BREAKING**] Distinguish empty string from internal snapshot not written ([#8898](https://github.com/facebook/jest/pull/8898))
 - `[jest-transform]` Properly cache transformed files across tests ([#8890](https://github.com/facebook/jest/pull/8890))
+- `[jest-resolve-dependencies]` Resolve mocks as dependencies ([#8952](https://github.com/facebook/jest/pull/8952))
 
 ### Chore & Maintenance
 
@@ -48,7 +49,6 @@
 - `[jest-environment-jsdom]` [**BREAKING**] Upgrade JSDOM from v11 to v15 ([#8851](https://github.com/facebook/jest/pull/8851))
 - `[jest-util]` [**BREAKING**] Remove deprecated exports ([#8863](https://github.com/facebook/jest/pull/8863))
 - `[jest-validate]` [**BREAKING**] Use ESM exports ([#8874](https://github.com/facebook/jest/pull/8874))
-- `[jest-resolve-dependencies]` Resolve mocks as dependencies ([#8952](https://github.com/facebook/jest/pull/8952))
 
 ### Performance
 

--- a/packages/jest-resolve-dependencies/src/__tests__/__fixtures__/hasMocked/__mocks__/file.js
+++ b/packages/jest-resolve-dependencies/src/__tests__/__fixtures__/hasMocked/__mocks__/file.js
@@ -1,0 +1,9 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+module.exports = jest.fn();

--- a/packages/jest-resolve-dependencies/src/__tests__/__fixtures__/hasMocked/file.js
+++ b/packages/jest-resolve-dependencies/src/__tests__/__fixtures__/hasMocked/file.js
@@ -1,0 +1,9 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+module.exports = str => str;

--- a/packages/jest-resolve-dependencies/src/__tests__/__fixtures__/hasMocked/file.test.js
+++ b/packages/jest-resolve-dependencies/src/__tests__/__fixtures__/hasMocked/file.test.js
@@ -1,0 +1,9 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+require('./file');

--- a/packages/jest-resolve-dependencies/src/__tests__/dependency_resolver.test.ts
+++ b/packages/jest-resolve-dependencies/src/__tests__/dependency_resolver.test.ts
@@ -60,7 +60,7 @@ test('resolves dependencies for existing path', () => {
 
 test('includes the mocks of dependencies as dependencies', () => {
   const resolved = dependencyResolver.resolve(
-    path.resolve(__dirname, '__fixtures__', 'hasMocked', 'file.test.js'),
+    path.resolve(__dirname, '__fixtures__/hasMocked/file.test.js'),
   );
 
   expect(resolved).toEqual([

--- a/packages/jest-resolve-dependencies/src/__tests__/dependency_resolver.test.ts
+++ b/packages/jest-resolve-dependencies/src/__tests__/dependency_resolver.test.ts
@@ -100,6 +100,19 @@ test('resolves inverse dependencies for existing path', () => {
   ]);
 });
 
+test('resolves inverse dependencies of mock', () => {
+  const paths = new Set([
+    path.resolve(__dirname, '__fixtures__/hasMocked/__mocks__/file.js'),
+  ]);
+  const resolved = dependencyResolver.resolveInverse(paths, filter);
+
+  expect(resolved).toEqual([
+    expect.stringContaining(
+      path.join('__tests__', '__fixtures__', 'hasMocked', 'file.test.js'),
+    ),
+  ]);
+});
+
 test('resolves inverse dependencies from available snapshot', () => {
   const paths = new Set([
     path.resolve(__dirname, '__fixtures__/file.js'),

--- a/packages/jest-resolve-dependencies/src/__tests__/dependency_resolver.test.ts
+++ b/packages/jest-resolve-dependencies/src/__tests__/dependency_resolver.test.ts
@@ -58,6 +58,17 @@ test('resolves dependencies for existing path', () => {
   ]);
 });
 
+test('includes the mocks of dependencies as dependencies', () => {
+  const resolved = dependencyResolver.resolve(
+    path.resolve(__dirname, '__fixtures__', 'hasMocked', 'file.test.js'),
+  );
+
+  expect(resolved).toEqual([
+    expect.stringContaining(path.join('hasMocked', 'file.js')),
+    expect.stringContaining(path.join('hasMocked', '__mocks__', 'file.js')),
+  ]);
+});
+
 test('resolves dependencies for scoped packages', () => {
   const resolved = dependencyResolver.resolve(
     path.resolve(__dirname, '__fixtures__', 'scoped.js'),

--- a/packages/jest-resolve-dependencies/src/index.ts
+++ b/packages/jest-resolve-dependencies/src/index.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import * as path from 'path';
 import {Config} from '@jest/types';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import {FS as HasteFS} from 'jest-haste-map';
@@ -51,7 +52,9 @@ class DependencyResolver {
       if (this._resolver.isCoreModule(dependency)) {
         return acc;
       }
+
       let resolvedDependency;
+      let resolvedMockDependency;
       try {
         resolvedDependency = this._resolver.resolveModule(
           file,
@@ -59,11 +62,22 @@ class DependencyResolver {
           options,
         );
       } catch (e) {
-        resolvedDependency = this._resolver.getMockModule(file, dependency);
+        resolvedMockDependency = this._resolver.getMockModule(file, dependency);
       }
 
       if (resolvedDependency) {
         acc.push(resolvedDependency);
+
+        // If we resolve a dependency, then look for a mock dependency
+        // of the same name in that dependency's directory.
+        resolvedMockDependency = this._resolver.getMockModule(
+          path.dirname(resolvedDependency),
+          path.basename(dependency),
+        );
+      }
+
+      if (resolvedMockDependency) {
+        acc.push(resolvedMockDependency);
       }
 
       return acc;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Fixes issue #8907 
dependencyResolver.resolve does not take the mocks of functional dependencies into account, meaning that, as layed out in the above issue, changes to a mock will not register as an affecting change when resolving related tests.

My changes include the mocks of any dependencies found by the resolver, based on having the same name as a given dependency.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Here's the output of running the dependency resolver tests after my changes: 
```
 PASS  packages/jest-resolve-dependencies/src/__tests__/dependency_resolver.test.ts
  ✓ resolves no dependencies for non-existent path (225ms)
  ✓ resolves dependencies for existing path (13ms)
  ✓ includes the mocks of dependencies as dependencies (8ms)
  ✓ resolves dependencies for scoped packages (9ms)
  ✓ resolves no inverse dependencies for empty paths set (8ms)
  ✓ resolves no inverse dependencies for set of non-existent paths (12ms)
  ✓ resolves inverse dependencies for existing path (10ms)
  ✓ resolves inverse dependencies from available snapshot (10ms)

Test Suites: 1 passed, 1 total
Tests:       8 passed, 8 total
Snapshots:   0 total
Time:        0.753s, estimated 2s
Ran all test suites matching /\/home\/pete\/Code\/contributions\/jest\/jest\/packages\/jest-resolve-dependencies\/src\/__tests__\/dependency_resolver.test.ts/i
```
I also tested this change against the [example repo](https://github.com/tomasz-sodzawiczny/jest-only-changed-vs-mocks) from the issue referenced above, and it appears to fix the problem. 

This is my first contribution, so apologies for any missteps!