### PR TITLE
Fix example code on `using matchers` docs

### DIFF
--- a/docs/UsingMatchers.md
+++ b/docs/UsingMatchers.md
@@ -142,12 +142,12 @@ If you want to test that a particular function throws an error when it's called,
 
 ```js
 function compileAndroidCode() {
-  throw new ConfigError('you are using the wrong JDK');
+  throw new Error('you are using the wrong JDK');
 }
 
 test('compiling android goes as expected', () => {
   expect(compileAndroidCode).toThrow();
-  expect(compileAndroidCode).toThrow(ConfigError);
+  expect(compileAndroidCode).toThrow(Error);
 
   // You can also use the exact error message or a regexp
   expect(compileAndroidCode).toThrow('you are using the wrong JDK');

--- a/website/versioned_docs/version-22.x/UsingMatchers.md
+++ b/website/versioned_docs/version-22.x/UsingMatchers.md
@@ -143,12 +143,12 @@ If you want to test that a particular function throws an error when it's called,
 
 ```js
 function compileAndroidCode() {
-  throw new ConfigError('you are using the wrong JDK');
+  throw new Error('you are using the wrong JDK');
 }
 
 test('compiling android goes as expected', () => {
   expect(compileAndroidCode).toThrow();
-  expect(compileAndroidCode).toThrow(ConfigError);
+  expect(compileAndroidCode).toThrow(Error);
 
   // You can also use the exact error message or a regexp
   expect(compileAndroidCode).toThrow('you are using the wrong JDK');


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary
The code snippet using on ['Using Matchers' docs under Exceptions section is broken](https://jestjs.io/docs/en/using-matchers#exceptions).

The code snippet is using, `ConfigError` inside `compileAndroidCode` function. Running the test, throws following error `ReferenceError: ConfigError is not defined`.

### Fix
I have changed, `ConfigError` to generic [`Error`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error).

So the original snippet of code now looks like this:
```js
function compileAndroidCode() {
  throw new Error('you are using the wrong JDK');
}

test('compiling android goes as expected', () => {
  expect(compileAndroidCode).toThrow();
  expect(compileAndroidCode).toThrow(Error);

  // You can also use the exact error message or a regexp
  expect(compileAndroidCode).toThrow('you are using the wrong JDK');
  expect(compileAndroidCode).toThrow(/JDK/);
});
```

Alternatively, a `TypeError` can be thrown, but that'll significantly change the example code. I have refrained myself from doing that, but here's snippet I would have used:
```js
function compileAndCheckForType() {
  throw new TypeError('you are using the wrong type.');
}

test('compiling android goes as expected', () => {
  expect(compileAndCheckForType).toThrow();
  expect(compileAndCheckForType).toThrow(TypeError);

  // You can also use the exact error message or a regexp
  expect(compileAndCheckForType).toThrow('you are using the wrong type.');
  expect(compileAndCheckForType).toThrow(/type/);
});
```

Let me know if the changelog is required to be update for this PR. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan
Not Applicable?
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
