### PR TITLE
chore: Align snapshots in jest-diff

### DIFF
--- a/packages/jest-diff/src/__tests__/__snapshots__/diff.test.ts.snap
+++ b/packages/jest-diff/src/__tests__/__snapshots__/diff.test.ts.snap
@@ -1,386 +1,386 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`collapses big diffs to patch format 1`] = `
-"<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<yellow>@@ -6,9 +6,9 @@</>
-<dim>      4,</>
-<dim>      5,</>
-<dim>      6,</>
-<dim>      7,</>
-<dim>      8,</>
-<green>-     9,</>
-<dim>      10,</>
-<red>+     9,</>
-<dim>    ],</>
-<dim>  }</>"
+<y>@@ -6,9 +6,9 @@</>
+<d>      4,</>
+<d>      5,</>
+<d>      6,</>
+<d>      7,</>
+<d>      8,</>
+<g>-     9,</>
+<d>      10,</>
+<r>+     9,</>
+<d>    ],</>
+<d>  }</>
 `;
 
 exports[`color of text (expanded) 1`] = `
-"<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Object {</>
-<dim>    \\"searching\\": \\"\\",</>
-<green>-   \\"sorting\\": Object {</>
-<red>+   \\"sorting\\": Array [</>
-<red>+     Object {</>
-<dim>        \\"descending\\": false,</>
-<dim>        \\"fieldKey\\": \\"what\\",</>
-<dim>      },</>
-<red>+   ],</>
-<dim>  }</>"
+<d>  Object {</>
+<d>    "searching": "",</>
+<g>-   "sorting": Object {</>
+<r>+   "sorting": Array [</>
+<r>+     Object {</>
+<d>        "descending": false,</>
+<d>        "fieldKey": "what",</>
+<d>      },</>
+<r>+   ],</>
+<d>  }</>
 `;
 
 exports[`context number of lines: -1 (5 default) 1`] = `
-"<green>- Expected  1 -</>
-<red>+ Received  1 +</>
+<g>- Expected  1 -</>
+<r>+ Received  1 +</>
 
-<dim>@@ -6,9 +6,9 @@</>
-<dim>      4,</>
-<dim>      5,</>
-<dim>      6,</>
-<dim>      7,</>
-<dim>      8,</>
-<green>-     9,</>
-<dim>      10,</>
-<red>+     9,</>
-<dim>    ],</>
-<dim>  }</>"
+<d>@@ -6,9 +6,9 @@</>
+<d>      4,</>
+<d>      5,</>
+<d>      6,</>
+<d>      7,</>
+<d>      8,</>
+<g>-     9,</>
+<d>      10,</>
+<r>+     9,</>
+<d>    ],</>
+<d>  }</>
 `;
 
 exports[`context number of lines: 0  1`] = `
-"<green>- Expected  1 -</>
-<red>+ Received  1 +</>
+<g>- Expected  1 -</>
+<r>+ Received  1 +</>
 
-<yellow>@@ -11,1 +11,0 @@</>
-<green>-     9,</>
-<yellow>@@ -13,0 +12,1 @@</>
-<red>+     9,</>"
+<y>@@ -11,1 +11,0 @@</>
+<g>-     9,</>
+<y>@@ -13,0 +12,1 @@</>
+<r>+     9,</>
 `;
 
 exports[`context number of lines: 1  1`] = `
-"<green>- Expected  1 -</>
-<red>+ Received  1 +</>
+<g>- Expected  1 -</>
+<r>+ Received  1 +</>
 
-<yellow>@@ -10,4 +10,4 @@</>
-<dim>      8,</>
-<green>-     9,</>
-<dim>      10,</>
-<red>+     9,</>
-<dim>    ],</>"
+<y>@@ -10,4 +10,4 @@</>
+<d>      8,</>
+<g>-     9,</>
+<d>      10,</>
+<r>+     9,</>
+<d>    ],</>
 `;
 
 exports[`context number of lines: 2  1`] = `
-"<green>- Expected  1 -</>
-<red>+ Received  1 +</>
+<g>- Expected  1 -</>
+<r>+ Received  1 +</>
 
-<yellow>@@ -9,6 +9,6 @@</>
-<dim>      7,</>
-<dim>      8,</>
-<green>-     9,</>
-<dim>      10,</>
-<red>+     9,</>
-<dim>    ],</>
-<dim>  }</>"
+<y>@@ -9,6 +9,6 @@</>
+<d>      7,</>
+<d>      8,</>
+<g>-     9,</>
+<d>      10,</>
+<r>+     9,</>
+<d>    ],</>
+<d>  }</>
 `;
 
 exports[`context number of lines: 3.1 (5 default) 1`] = `
-"<green>- Expected  1 -</>
-<red>+ Received  1 +</>
+<g>- Expected  1 -</>
+<r>+ Received  1 +</>
 
-<dim>@@ -6,9 +6,9 @@</>
-<dim>      4,</>
-<dim>      5,</>
-<dim>      6,</>
-<dim>      7,</>
-<dim>      8,</>
-<green>-     9,</>
-<dim>      10,</>
-<red>+     9,</>
-<dim>    ],</>
-<dim>  }</>"
+<d>@@ -6,9 +6,9 @@</>
+<d>      4,</>
+<d>      5,</>
+<d>      6,</>
+<d>      7,</>
+<d>      8,</>
+<g>-     9,</>
+<d>      10,</>
+<r>+     9,</>
+<d>    ],</>
+<d>  }</>
 `;
 
 exports[`context number of lines: undefined (5 default) 1`] = `
-"<green>- Expected  1 -</>
-<red>+ Received  1 +</>
+<g>- Expected  1 -</>
+<r>+ Received  1 +</>
 
-<dim>@@ -6,9 +6,9 @@</>
-<dim>      4,</>
-<dim>      5,</>
-<dim>      6,</>
-<dim>      7,</>
-<dim>      8,</>
-<green>-     9,</>
-<dim>      10,</>
-<red>+     9,</>
-<dim>    ],</>
-<dim>  }</>"
+<d>@@ -6,9 +6,9 @@</>
+<d>      4,</>
+<d>      5,</>
+<d>      6,</>
+<d>      7,</>
+<d>      8,</>
+<g>-     9,</>
+<d>      10,</>
+<r>+     9,</>
+<d>    ],</>
+<d>  }</>
 `;
 
 exports[`diffStringsUnified edge cases empty both a and b 1`] = `
-"<green>- Expected  0 -</>
-<red>+ Received  0 +</>
+<g>- Expected  0 -</>
+<r>+ Received  0 +</>
 
-"
+
 `;
 
 exports[`diffStringsUnified edge cases empty only a 1`] = `
-"<green>- Expected  0 -</>
-<red>+ Received  1 +</>
+<g>- Expected  0 -</>
+<r>+ Received  1 +</>
 
-<red>+ one-line string</>"
+<r>+ one-line string</>
 `;
 
 exports[`diffStringsUnified edge cases empty only b 1`] = `
-"<green>- Expected  1 -</>
-<red>+ Received  0 +</>
+<g>- Expected  1 -</>
+<r>+ Received  0 +</>
 
-<green>- one-line string</>"
+<g>- one-line string</>
 `;
 
 exports[`diffStringsUnified edge cases equal both non-empty 1`] = `
-"<green>- Expected  0 -</>
-<red>+ Received  0 +</>
+<g>- Expected  0 -</>
+<r>+ Received  0 +</>
 
-<dim>  one-line string</>"
+<d>  one-line string</>
 `;
 
 exports[`diffStringsUnified edge cases multiline has no common after clean up chaff 1`] = `
-"<green>- Expected  2 -</>
-<red>+ Received  2 +</>
+<g>- Expected  2 -</>
+<r>+ Received  2 +</>
 
-<green>- delete</>
-<green>- two</>
-<red>+ insert</>
-<red>+ 2</>"
+<g>- delete</>
+<g>- two</>
+<r>+ insert</>
+<r>+ 2</>
 `;
 
 exports[`diffStringsUnified edge cases one-line has no common after clean up chaff 1`] = `
-"<green>- Expected  1 -</>
-<red>+ Received  1 +</>
+<g>- Expected  1 -</>
+<r>+ Received  1 +</>
 
-<green>- delete</>
-<red>+ insert</>"
+<g>- delete</>
+<r>+ insert</>
 `;
 
 exports[`falls back to not call toJSON if it throws and then objects have differences 1`] = `
-"<green>- Expected  1 -</>
-<red>+ Received  1 +</>
+<g>- Expected  1 -</>
+<r>+ Received  1 +</>
 
-<dim>  Object {</>
-<green>-   \\"line\\": 1,</>
-<red>+   \\"line\\": 2,</>
-<dim>    \\"toJSON\\": [Function toJSON],</>
-<dim>  }</>"
+<d>  Object {</>
+<g>-   "line": 1,</>
+<r>+   "line": 2,</>
+<d>    "toJSON": [Function toJSON],</>
+<d>  }</>
 `;
 
 exports[`falls back to not call toJSON if serialization has no differences but then objects have differences 1`] = `
-"<dim>Compared values serialize to the same structure.</>
-<dim>Printing internal object structure without calling \`toJSON\` instead.</>
+<d>Compared values serialize to the same structure.</>
+<d>Printing internal object structure without calling \`toJSON\` instead.</>
 
-<green>- Expected  1 -</>
-<red>+ Received  1 +</>
+<g>- Expected  1 -</>
+<r>+ Received  1 +</>
 
-<dim>  Object {</>
-<green>-   \\"line\\": 1,</>
-<red>+   \\"line\\": 2,</>
-<dim>    \\"toJSON\\": [Function toJSON],</>
-<dim>  }</>"
+<d>  Object {</>
+<g>-   "line": 1,</>
+<r>+   "line": 2,</>
+<d>    "toJSON": [Function toJSON],</>
+<d>  }</>
 `;
 
 exports[`oneline strings 1`] = `
-"<green>- Expected  1 -</>
-<red>+ Received  1 +</>
+<g>- Expected  1 -</>
+<r>+ Received  1 +</>
 
-<green>- ab</>
-<red>+ aa</>"
+<g>- ab</>
+<r>+ aa</>
 `;
 
 exports[`oneline strings 2`] = `
-"<green>- Expected  1 -</>
-<red>+ Received  1 +</>
+<g>- Expected  1 -</>
+<r>+ Received  1 +</>
 
-<green>- 123456789</>
-<red>+ 234567890</>"
+<g>- 123456789</>
+<r>+ 234567890</>
 `;
 
 exports[`oneline strings 3`] = `
-"<green>- Expected  1 -</>
-<red>+ Received  2 +</>
+<g>- Expected  1 -</>
+<r>+ Received  2 +</>
 
-<green>- oneline</>
-<red>+ multi</>
-<red>+ line</>"
+<g>- oneline</>
+<r>+ multi</>
+<r>+ line</>
 `;
 
 exports[`oneline strings 4`] = `
-"<green>- Expected  2 -</>
-<red>+ Received  1 +</>
+<g>- Expected  2 -</>
+<r>+ Received  1 +</>
 
-<green>- multi</>
-<green>- line</>
-<red>+ oneline</>"
+<g>- multi</>
+<g>- line</>
+<r>+ oneline</>
 `;
 
 exports[`options 7980 diff 1`] = `
-"<red>- Original</>
-<green>+ Modified</>
+<r>- Original</>
+<g>+ Modified</>
 
-<red>- \`\${Ti.App.name} \${Ti.App.version} \${Ti.Platform.name} \${Ti.Platform.version}\`</>
-<green>+ \`\${Ti.App.getName()} \${Ti.App.getVersion()} \${Ti.Platform.getName()} \${Ti.Platform.getVersion()}\`</>"
+<r>- \`\${Ti.App.name} \${Ti.App.version} \${Ti.Platform.name} \${Ti.Platform.version}\`</>
+<g>+ \`\${Ti.App.getName()} \${Ti.App.getVersion()} \${Ti.Platform.getName()} \${Ti.Platform.getVersion()}\`</>
 `;
 
 exports[`options 7980 diffStringsUnified 1`] = `
-"<red>- Original</>
-<green>+ Modified</>
+<r>- Original</>
+<g>+ Modified</>
 
-<red>- \`\${Ti.App.<inverse>n</>ame} \${Ti.App.<inverse>v</>ersion} \${Ti.Platform.<inverse>n</>ame} \${Ti.Platform.<inverse>v</>ersion}\`</>
-<green>+ \`\${Ti.App.<inverse>getN</>ame<inverse>()</>} \${Ti.App.<inverse>getV</>ersion<inverse>()</>} \${Ti.Platform.<inverse>getN</>ame<inverse>()</>} \${Ti.Platform.<inverse>getV</>ersion<inverse>()</>}\`</>"
+<r>- \`\${Ti.App.<i>n</i>ame} \${Ti.App.<i>v</i>ersion} \${Ti.Platform.<i>n</i>ame} \${Ti.Platform.<i>v</i>ersion}\`</>
+<g>+ \`\${Ti.App.<i>getN</i>ame<i>()</i>} \${Ti.App.<i>getV</i>ersion<i>()</i>} \${Ti.Platform.<i>getN</i>ame<i>()</i>} \${Ti.Platform.<i>getV</i>ersion<i>()</i>}\`</>
 `;
 
 exports[`options change color diffStringsUnified 1`] = `
-"<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<green>- delete</>
-<green>- changed <bold>from</></>
-<red>+ changed <bold>to</></>
-<red>+ insert</>
-<dim>  common</>"
+<g>- delete</>
+<g>- changed <b>from</></>
+<r>+ changed <b>to</></>
+<r>+ insert</>
+<d>  common</>
 `;
 
 exports[`options change indicators diff 1`] = `
-"<green>< Expected</>
-<red>> Received</>
+<g>< Expected</>
+<r>> Received</>
 
-<dim>  Array [</>
-<green><   \\"delete\\",</>
-<green><   \\"change from\\",</>
-<red>>   \\"change to\\",</>
-<red>>   \\"insert\\",</>
-<dim>    \\"common\\",</>
-<dim>  ]</>"
+<d>  Array [</>
+<g><   "delete",</>
+<g><   "change from",</>
+<r>>   "change to",</>
+<r>>   "insert",</>
+<d>    "common",</>
+<d>  ]</>
 `;
 
 exports[`options common diff 1`] = `
-"<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
 = Array [
-<green>-   \\"delete\\",</>
-<green>-   \\"change from\\",</>
-<red>+   \\"change to\\",</>
-<red>+   \\"insert\\",</>
-=   \\"common\\",
-= ]"
+<g>-   "delete",</>
+<g>-   "change from",</>
+<r>+   "change to",</>
+<r>+   "insert",</>
+=   "common",
+= ]
 `;
 
 exports[`options includeChangeCounts false diffLinesUnified 1`] = `
-"<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Array [</>
-<green>-   \\"delete\\",</>
-<green>-   \\"change from\\",</>
-<red>+   \\"change to\\",</>
-<red>+   \\"insert\\",</>
-<dim>    \\"common\\",</>
-<dim>  ]</>"
+<d>  Array [</>
+<g>-   "delete",</>
+<g>-   "change from",</>
+<r>+   "change to",</>
+<r>+   "insert",</>
+<d>    "common",</>
+<d>  ]</>
 `;
 
 exports[`options includeChangeCounts false diffStringsUnified 1`] = `
-"<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<green>- change <inverse>from</></>
-<red>+ change <inverse>to</></>
-<dim>  common</>"
+<g>- change <i>from</i></>
+<r>+ change <i>to</i></>
+<d>  common</>
 `;
 
 exports[`options includeChangeCounts true padding diffLinesUnified a has 2 digits 1`] = `
-"<green>- Before  10 -</>
-<red>+ After    1 +</>
+<g>- Before  10 -</>
+<r>+ After    1 +</>
 
-<dim>  common</>
-<green>- a</>
-<green>- a</>
-<green>- a</>
-<green>- a</>
-<green>- a</>
-<green>- a</>
-<green>- a</>
-<green>- a</>
-<green>- a</>
-<green>- a</>
-<red>+ b</>"
+<d>  common</>
+<g>- a</>
+<g>- a</>
+<g>- a</>
+<g>- a</>
+<g>- a</>
+<g>- a</>
+<g>- a</>
+<g>- a</>
+<g>- a</>
+<g>- a</>
+<r>+ b</>
 `;
 
 exports[`options includeChangeCounts true padding diffLinesUnified b has 2 digits 1`] = `
-"<green>- Before   1 -</>
-<red>+ After   10 +</>
+<g>- Before   1 -</>
+<r>+ After   10 +</>
 
-<dim>  common</>
-<green>- a</>
-<red>+ b</>
-<red>+ b</>
-<red>+ b</>
-<red>+ b</>
-<red>+ b</>
-<red>+ b</>
-<red>+ b</>
-<red>+ b</>
-<red>+ b</>
-<red>+ b</>"
+<d>  common</>
+<g>- a</>
+<r>+ b</>
+<r>+ b</>
+<r>+ b</>
+<r>+ b</>
+<r>+ b</>
+<r>+ b</>
+<r>+ b</>
+<r>+ b</>
+<r>+ b</>
+<r>+ b</>
 `;
 
 exports[`options includeChangeCounts true padding diffStringsUnified 1`] = `
-"<green>- Before  1 -</>
-<red>+ After   1 +</>
+<g>- Before  1 -</>
+<r>+ After   1 +</>
 
-<green>- change <inverse>from</></>
-<red>+ change <inverse>to</></>
-<dim>  common</>"
+<g>- change <i>from</i></>
+<r>+ change <i>to</i></>
+<d>  common</>
 `;
 
 exports[`options omitAnnotationLines true diff 1`] = `
-"<dim>  Array [</>
-<green>-   \\"delete\\",</>
-<green>-   \\"change from\\",</>
-<red>+   \\"change to\\",</>
-<red>+   \\"insert\\",</>
-<dim>    \\"common\\",</>
-<dim>  ]</>"
+<d>  Array [</>
+<g>-   "delete",</>
+<g>-   "change from",</>
+<r>+   "change to",</>
+<r>+   "insert",</>
+<d>    "common",</>
+<d>  ]</>
 `;
 
 exports[`options omitAnnotationLines true diffStringsUnified and includeChangeCounts true 1`] = `
-"<green>- change <inverse>from</></>
-<red>+ change <inverse>to</></>
-<dim>  common</>"
+<g>- change <i>from</i></>
+<r>+ change <i>to</i></>
+<d>  common</>
 `;
 
-exports[`options omitAnnotationLines true diffStringsUnified empty strings 1`] = `""`;
+exports[`options omitAnnotationLines true diffStringsUnified empty strings 1`] = ``;
 
 exports[`options trailingSpaceFormatter diffDefault default yellowish 1`] = `
-"<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<green>- delete 1 trailing space:<bgYellow> </></>
-<red>+ delete 1 trailing space:</>
-<dim>  common 2 trailing spaces:<bgYellow>  </></>
-<green>- insert 1 trailing space:</>
-<red>+ insert 1 trailing space:<bgYellow> </></>"
+<g>- delete 1 trailing space:<Y> </></>
+<r>+ delete 1 trailing space:</>
+<d>  common 2 trailing spaces:<Y>  </></>
+<g>- insert 1 trailing space:</>
+<r>+ insert 1 trailing space:<Y> </></>
 `;
 
 exports[`options trailingSpaceFormatter diffDefault middle dot 1`] = `
-"<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<green>- delete 1 trailing space:·</>
-<red>+ delete 1 trailing space:</>
-<dim>  common 2 trailing spaces:··</>
-<green>- insert 1 trailing space:</>
-<red>+ insert 1 trailing space:·</>"
+<g>- delete 1 trailing space:·</>
+<r>+ delete 1 trailing space:</>
+<d>  common 2 trailing spaces:··</>
+<g>- insert 1 trailing space:</>
+<r>+ insert 1 trailing space:·</>
 `;

--- a/packages/jest-diff/src/__tests__/diff.test.ts
+++ b/packages/jest-diff/src/__tests__/diff.test.ts
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import ansiRegex = require('ansi-regex');
+import * as style from 'ansi-styles';
 import chalk from 'chalk';
 import stripAnsi from 'strip-ansi';
 
@@ -12,19 +14,77 @@ import diff from '../';
 import {diffStringsUnified} from '../printDiffs';
 import {DiffOptions} from '../types';
 
-const optionsCounts = {
+const optionsCounts: DiffOptions = {
   includeChangeCounts: true,
 };
 
 const NO_DIFF_MESSAGE = 'Compared values have no visual difference.';
 
-const stripped = (a: unknown, b: unknown, options?: DiffOptions) =>
-  stripAnsi(diff(a, b, options) || '');
+// Use only in toBe assertions for edge case messages.
+const stripped = (a: unknown, b: unknown) => stripAnsi(diff(a, b) || '');
 
+// Use in toBe assertions for comparison lines.
+const noColor = (string: string) => string;
+const optionsBe: DiffOptions = {
+  aColor: noColor,
+  bColor: noColor,
+  commonColor: noColor,
+  omitAnnotationLines: true,
+};
+const unexpandedBe: DiffOptions = {
+  ...optionsBe,
+  expand: false,
+};
+const expandedBe: DiffOptions = {
+  ...optionsBe,
+  expand: true,
+};
+
+// Use for toMatchSnapshot assertions.
 const unexpanded = {expand: false};
 const expanded = {expand: true};
 
 const elementSymbol = Symbol.for('react.element');
+
+expect.addSnapshotSerializer({
+  serialize(val: string): string {
+    return val.replace(ansiRegex(), match => {
+      switch (match) {
+        case style.inverse.open:
+          return '<i>';
+        case style.inverse.close:
+          return '</i>';
+
+        case style.bold.open:
+          return '<b>';
+        case style.dim.open:
+          return '<d>';
+        case style.green.open:
+          return '<g>';
+        case style.red.open:
+          return '<r>';
+        case style.yellow.open:
+          return '<y>';
+        case style.bgYellow.open:
+          return '<Y>';
+
+        case style.bold.close:
+        case style.dim.close:
+        case style.green.close:
+        case style.red.close:
+        case style.yellow.close:
+        case style.bgYellow.close:
+          return '</>';
+
+        default:
+          return match;
+      }
+    });
+  },
+  test(val: any): val is string {
+    return typeof val === 'string';
+  },
+});
 
 describe('different types', () => {
   [
@@ -66,13 +126,8 @@ describe('no visual difference', () => {
   ].forEach(values => {
     test(`'${JSON.stringify(values[0])}' and '${JSON.stringify(
       values[1],
-    )}' (unexpanded)`, () => {
-      expect(stripped(values[0], values[1], unexpanded)).toBe(NO_DIFF_MESSAGE);
-    });
-    test(`'${JSON.stringify(values[0])}' and '${JSON.stringify(
-      values[1],
-    )}' (expanded)`, () => {
-      expect(stripped(values[0], values[1], expanded)).toBe(NO_DIFF_MESSAGE);
+    )}'`, () => {
+      expect(stripped(values[0], values[1])).toBe(NO_DIFF_MESSAGE);
     });
   });
 
@@ -134,7 +189,7 @@ describe('falls back to not call toJSON', () => {
 });
 
 // Some of the following assertions seem complex, but compare to alternatives:
-// * toMatch instead of toMatchSnapshot:
+// * toBe instead of toMatchSnapshot:
 //   * to avoid visual complexity of escaped quotes in expected string
 //   * to omit Expected/Received heading which is an irrelevant detail
 // * join lines of expected string instead of multiline string:
@@ -158,10 +213,10 @@ line 4`;
   ].join('\n');
 
   test('(unexpanded)', () => {
-    expect(stripped(a, b, unexpanded)).toMatch(expected);
+    expect(diff(a, b, unexpandedBe)).toBe(expected);
   });
   test('(expanded)', () => {
-    expect(stripped(a, b, expanded)).toMatch(expected);
+    expect(diff(a, b, expandedBe)).toBe(expected);
   });
 });
 
@@ -180,42 +235,36 @@ describe('objects', () => {
   ].join('\n');
 
   test('(unexpanded)', () => {
-    expect(stripped(a, b, unexpanded)).toMatch(expected);
+    expect(diff(a, b, unexpandedBe)).toBe(expected);
   });
   test('(expanded)', () => {
-    expect(stripped(a, b, expanded)).toMatch(expected);
+    expect(diff(a, b, expandedBe)).toBe(expected);
   });
 });
 
 test('numbers', () => {
-  expect(stripped(1, 2)).toEqual(expect.stringContaining('- 1\n+ 2'));
+  expect(diff(1, 2, optionsBe)).toBe('- 1\n+ 2');
 });
 
 test('-0 and 0', () => {
-  expect(stripped(-0, 0)).toEqual(expect.stringContaining('- -0\n+ 0'));
+  expect(diff(-0, 0, optionsBe)).toBe('- -0\n+ 0');
 });
 
 test('booleans', () => {
-  expect(stripped(false, true)).toEqual(
-    expect.stringContaining('- false\n+ true'),
-  );
+  expect(diff(false, true, optionsBe)).toBe('- false\n+ true');
 });
 
 describe('multiline string non-snapshot', () => {
   // For example, CLI output
   // toBe or toEqual for a string isn’t enclosed in double quotes.
-  const a = `
-Options:
+  const a = `Options:
 --help, -h  Show help                            [boolean]
 --bail, -b  Exit the test suite immediately upon the first
-            failing test.                        [boolean]
-`;
-  const b = `
-Options:
+            failing test.                        [boolean]`;
+  const b = `Options:
   --help, -h  Show help                            [boolean]
   --bail, -b  Exit the test suite immediately upon the first
-              failing test.                        [boolean]
-`;
+              failing test.                        [boolean]`;
   const expected = [
     '  Options:',
     '- --help, -h  Show help                            [boolean]',
@@ -227,32 +276,28 @@ Options:
   ].join('\n');
 
   test('(unexpanded)', () => {
-    expect(stripped(a, b, unexpanded)).toMatch(expected);
+    expect(diff(a, b, unexpandedBe)).toBe(expected);
   });
   test('(expanded)', () => {
-    expect(stripped(a, b, expanded)).toMatch(expected);
+    expect(diff(a, b, expandedBe)).toBe(expected);
   });
 });
 
 describe('multiline string snapshot', () => {
   // For example, CLI output
   // A snapshot of a string is enclosed in double quotes.
-  const a = `
-"
+  const a = `"
 Options:
 --help, -h  Show help                            [boolean]
 --bail, -b  Exit the test suite immediately upon the first
-            failing test.                        [boolean]"
-`;
-  const b = `
-"
+            failing test.                        [boolean]"`;
+  const b = `"
 Options:
   --help, -h  Show help                            [boolean]
   --bail, -b  Exit the test suite immediately upon the first
-              failing test.                        [boolean]"
-`;
+              failing test.                        [boolean]"`;
   const expected = [
-    ' "',
+    '  "',
     '  Options:',
     '- --help, -h  Show help                            [boolean]',
     '- --bail, -b  Exit the test suite immediately upon the first',
@@ -263,10 +308,10 @@ Options:
   ].join('\n');
 
   test('(unexpanded)', () => {
-    expect(stripped(a, b, unexpanded)).toMatch(expected);
+    expect(diff(a, b, unexpandedBe)).toBe(expected);
   });
   test('(expanded)', () => {
-    expect(stripped(a, b, expanded)).toMatch(expected);
+    expect(diff(a, b, expandedBe)).toBe(expected);
   });
 });
 
@@ -297,10 +342,10 @@ describe('React elements', () => {
   ].join('\n');
 
   test('(unexpanded)', () => {
-    expect(stripped(a, b, unexpanded)).toMatch(expected);
+    expect(diff(a, b, unexpandedBe)).toBe(expected);
   });
   test('(expanded)', () => {
-    expect(stripped(a, b, expanded)).toMatch(expected);
+    expect(diff(a, b, expandedBe)).toBe(expected);
   });
 });
 
@@ -324,10 +369,10 @@ describe('multiline string as value of object property', () => {
       points: '0.5,0.460\n0.5,0.875\n0.25,0.875',
     };
     test('(unexpanded)', () => {
-      expect(stripped(a, b, unexpanded)).toMatch(expected);
+      expect(diff(a, b, unexpandedBe)).toBe(expected);
     });
     test('(expanded)', () => {
-      expect(stripped(a, b, expanded)).toMatch(expected);
+      expect(diff(a, b, expandedBe)).toBe(expected);
     });
   });
 
@@ -348,10 +393,10 @@ describe('multiline string as value of object property', () => {
       '}',
     ].join('\n');
     test('(unexpanded)', () => {
-      expect(stripped(a, b, unexpanded)).toMatch(expected);
+      expect(diff(a, b, unexpandedBe)).toBe(expected);
     });
     test('(expanded)', () => {
-      expect(stripped(a, b, expanded)).toMatch(expected);
+      expect(diff(a, b, expandedBe)).toBe(expected);
     });
   });
 });
@@ -387,10 +432,10 @@ describe('indentation in JavaScript structures', () => {
     ].join('\n');
 
     test('(unexpanded)', () => {
-      expect(stripped(a, b, unexpanded)).toMatch(expected);
+      expect(diff(a, b, unexpandedBe)).toBe(expected);
     });
     test('(expanded)', () => {
-      expect(stripped(a, b, expanded)).toMatch(expected);
+      expect(diff(a, b, expandedBe)).toBe(expected);
     });
   });
 
@@ -410,10 +455,10 @@ describe('indentation in JavaScript structures', () => {
     ].join('\n');
 
     test('(unexpanded)', () => {
-      expect(stripped(b, a, unexpanded)).toMatch(expected);
+      expect(diff(b, a, unexpandedBe)).toBe(expected);
     });
     test('(expanded)', () => {
-      expect(stripped(b, a, expanded)).toMatch(expected);
+      expect(diff(b, a, expandedBe)).toBe(expected);
     });
   });
 });
@@ -487,10 +532,10 @@ describe('indentation in React elements (non-snapshot)', () => {
     ].join('\n');
 
     test('(unexpanded)', () => {
-      expect(stripped(a, b, unexpanded)).toMatch(expected);
+      expect(diff(a, b, unexpandedBe)).toBe(expected);
     });
     test('(expanded)', () => {
-      expect(stripped(a, b, expanded)).toMatch(expected);
+      expect(diff(a, b, expandedBe)).toBe(expected);
     });
   });
 
@@ -507,10 +552,10 @@ describe('indentation in React elements (non-snapshot)', () => {
     ].join('\n');
 
     test('(unexpanded)', () => {
-      expect(stripped(b, a, unexpanded)).toMatch(expected);
+      expect(diff(b, a, unexpandedBe)).toBe(expected);
     });
     test('(expanded)', () => {
-      expect(stripped(b, a, expanded)).toMatch(expected);
+      expect(diff(b, a, expandedBe)).toBe(expected);
     });
   });
 });
@@ -550,10 +595,10 @@ describe('indentation in React elements (snapshot)', () => {
     ].join('\n');
 
     test('(unexpanded)', () => {
-      expect(stripped(a, b, unexpanded)).toMatch(expected);
+      expect(diff(a, b, unexpandedBe)).toBe(expected);
     });
     test('(expanded)', () => {
-      expect(stripped(a, b, expanded)).toMatch(expected);
+      expect(diff(a, b, expandedBe)).toBe(expected);
     });
   });
 
@@ -573,10 +618,10 @@ describe('indentation in React elements (snapshot)', () => {
     ].join('\n');
 
     test('(unexpanded)', () => {
-      expect(stripped(b, a, unexpanded)).toMatch(expected);
+      expect(diff(b, a, unexpandedBe)).toBe(expected);
     });
     test('(expanded)', () => {
-      expect(stripped(b, a, expanded)).toMatch(expected);
+      expect(diff(b, a, expandedBe)).toBe(expected);
     });
   });
 });
@@ -620,10 +665,10 @@ describe('outer React element (non-snapshot)', () => {
     ].join('\n');
 
     test('(unexpanded)', () => {
-      expect(stripped(a, b, unexpanded)).toMatch(expected);
+      expect(diff(a, b, unexpandedBe)).toBe(expected);
     });
     test('(expanded)', () => {
-      expect(stripped(a, b, expanded)).toMatch(expected);
+      expect(diff(a, b, expandedBe)).toBe(expected);
     });
   });
 
@@ -641,10 +686,10 @@ describe('outer React element (non-snapshot)', () => {
     ].join('\n');
 
     test('(unexpanded)', () => {
-      expect(stripped(b, a, unexpanded)).toMatch(expected);
+      expect(diff(b, a, unexpandedBe)).toBe(expected);
     });
     test('(expanded)', () => {
-      expect(stripped(b, a, expanded)).toMatch(expected);
+      expect(diff(b, a, expandedBe)).toBe(expected);
     });
   });
 });
@@ -657,10 +702,10 @@ describe('trailing newline in multiline string not enclosed in quotes', () => {
     const expected = ['  line 1', '  line 2', '  line 3', '+ '].join('\n');
 
     test('(unexpanded)', () => {
-      expect(stripped(a, b, unexpanded)).toMatch(expected);
+      expect(diff(a, b, unexpandedBe)).toBe(expected);
     });
     test('(expanded)', () => {
-      expect(stripped(a, b, expanded)).toMatch(expected);
+      expect(diff(a, b, expandedBe)).toBe(expected);
     });
   });
 
@@ -668,10 +713,10 @@ describe('trailing newline in multiline string not enclosed in quotes', () => {
     const expected = ['  line 1', '  line 2', '  line 3', '- '].join('\n');
 
     test('(unexpanded)', () => {
-      expect(stripped(b, a, unexpanded)).toMatch(expected);
+      expect(diff(b, a, unexpandedBe)).toBe(expected);
     });
     test('(expanded)', () => {
-      expect(stripped(b, a, expanded)).toMatch(expected);
+      expect(diff(b, a, expandedBe)).toBe(expected);
     });
   });
 });


### PR DESCRIPTION
## Summary

Display colors concisely and clearly so you can review future changes quickly and confidently

Also omits distracting escape of double quote marks

* Use `addSnapshotSerializer` for only the expected colors with one-letter tag names
* Use `stripAnsi` only for edge case error messages
* Replace `stripAnsi` with options and `toMatch` with `toBe` in assertions for comparison lines (which as a future chore could become snapshots with the serializer and `omitAnnotationLines` option)

**Question**: Before I go on to 5 snapshot test files in `expect` package, do I need to consider an alternative to repetition of the same or very similar inline serializer?

## Test plan

* `diff.test.ts.snap` updated 35