### PR TITLE
Normalize --findRelatedTests paths on win32 platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - `[jest-config]` Merge preset globals with project globals ([#9027](https://github.com/facebook/jest/pull/9027))
 - `[jest-config]` Support `.cjs` config files ([#9291](https://github.com/facebook/jest/pull/9291))
 - `[jest-core]` Support reporters as default exports ([#9161](https://github.com/facebook/jest/pull/9161))
+- `[jest-core]` Support `--findRelatedTests` paths case insensitivity on Windows ([#8900](https://github.com/facebook/jest/issues/8900))
 - `[jest-diff]` Add options for colors and symbols ([#8841](https://github.com/facebook/jest/pull/8841))
 - `[jest-diff]` [**BREAKING**] Export as ECMAScript module ([#8873](https://github.com/facebook/jest/pull/8873))
 - `[jest-diff]` Add `includeChangeCounts` and rename `Indicator` options ([#8881](https://github.com/facebook/jest/pull/8881))

--- a/e2e/__tests__/findRelatedFiles.test.ts
+++ b/e2e/__tests__/findRelatedFiles.test.ts
@@ -38,6 +38,32 @@ describe('--findRelatedTests flag', () => {
     expect(stderr).toMatch(summaryMsg);
   });
 
+  test('runs tests related to uppercased filename on case-insensitive os', () => {
+    if (process.platform !== 'win32') {
+      // This test is Windows specific, skip it on other platforms.
+      return;
+    }
+
+    writeFiles(DIR, {
+      '.watchmanconfig': '',
+      '__tests__/test.test.js': `
+      const a = require('../a');
+      test('a', () => {});
+    `,
+      'a.js': 'module.exports = {};',
+      'package.json': JSON.stringify({jest: {testEnvironment: 'node'}}),
+    });
+
+    const {stdout} = runJest(DIR, ['A.JS']);
+    expect(stdout).toMatch('');
+
+    const {stderr} = runJest(DIR, ['--findRelatedTests', 'A.JS']);
+    expect(stderr).toMatch('PASS __tests__/test.test.js');
+
+    const summaryMsg = 'Ran all test suites related to files matching /A.JS/i.';
+    expect(stderr).toMatch(summaryMsg);
+  });
+
   test('runs tests related to filename with a custom dependency extractor', () => {
     writeFiles(DIR, {
       '.watchmanconfig': '',


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Hey, there is a fix for #8900 however I'm not sure this is the right place to normalize non flag arguments. 

## Test plan

I've made a few runs with "wrong" cased path on my machine. For `packages\jest-core\src\FailedTestsCache.ts` file I've run `jest --findRelatedTests  packages/jest-core/SRC/FailedTestsCache.ts` and that works well.

In addition I'll cover it with some test, just before do that I'm interested in your opinion about a correct place for paths normalization.