### PR TITLE
Simplify async .rejects examples

### DIFF
--- a/docs/TutorialAsync.md
+++ b/docs/TutorialAsync.md
@@ -145,7 +145,6 @@ The`.rejects` helper works like the `.resolves` helper. If the promise is fulfil
 ```js
 // Testing for async errors using `.rejects`.
 it('tests error with rejects', () => {
-  expect.assertions(1);
   return expect(user.getUserName(3)).rejects.toEqual({
     error: 'User with 3 not found.',
   });
@@ -153,7 +152,6 @@ it('tests error with rejects', () => {
 
 // Or using async/await with `.rejects`.
 it('tests error with async/await and rejects', async () => {
-  expect.assertions(1);
   await expect(user.getUserName(3)).rejects.toEqual({
     error: 'User with 3 not found.',
   });


### PR DESCRIPTION
The docs state that "If the promise is fulfilled, the test will automatically fail", so it is not necessary to include the `expect.assertions(1)` calls since the tests will fail automatically if the promise doesn't reject.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
