### PR TITLE
docs: Add `setupFilesAfterEnv` and `jest.setTimeout` example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 - `[jest-environment-jsdom]` [**BREAKING**] Upgrade JSDOM from v11 to v15 ([#8851](https://github.com/facebook/jest/pull/8851))
 - `[jest-util]` [**BREAKING**] Remove deprecated exports ([#8863](https://github.com/facebook/jest/pull/8863))
 - `[jest-validate]` [**BREAKING**] Use ESM exports ([#8874](https://github.com/facebook/jest/pull/8874))
+- `[docs]` setupFilesAfterEnv arr expansion and updated reference in JestObjectApi ([#8824](https://github.com/facebook/jest/pull/8971))
 
 ### Performance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,13 +43,13 @@
 - `[*]` [**BREAKING**] Upgrade to Micromatch v4 ([#8852](https://github.com/facebook/jest/pull/8852))
 - `[babel-plugin-jest-hoist]` [**BREAKING**] Use ESM exports ([#8874](https://github.com/facebook/jest/pull/8874))
 - `[docs]` Fix broken link pointing to legacy JS file in "Snapshot Testing".
+- `[docs]` Add `setupFilesAfterEnv` and `jest.setTimeout` example ([#8971](https://github.com/facebook/jest/pull/8971))
 - `[jest]` [**BREAKING**] Use ESM exports ([#8874](https://github.com/facebook/jest/pull/8874))
 - `[jest-cli]` [**BREAKING**] Use ESM exports ([#8874](https://github.com/facebook/jest/pull/8874))
 - `[jest-cli]` [**BREAKING**] Remove re-exports from `@jest/core` ([#8874](https://github.com/facebook/jest/pull/8874))
 - `[jest-environment-jsdom]` [**BREAKING**] Upgrade JSDOM from v11 to v15 ([#8851](https://github.com/facebook/jest/pull/8851))
 - `[jest-util]` [**BREAKING**] Remove deprecated exports ([#8863](https://github.com/facebook/jest/pull/8863))
 - `[jest-validate]` [**BREAKING**] Use ESM exports ([#8874](https://github.com/facebook/jest/pull/8874))
-- `[docs]` setupFilesAfterEnv arr expansion and updated reference in JestObjectApi ([#8824](https://github.com/facebook/jest/pull/8971))
 
 ### Performance
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -767,7 +767,6 @@ Example `jest.setup.js` file
 jest.setTimeout(10000); // in milliseconds
 ```
 
-
 ### `snapshotResolver` [string]
 
 Default: `undefined`

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -754,6 +754,20 @@ For example, Jest ships with several plug-ins to `jasmine` that work by monkey-p
 
 _Note: `setupTestFrameworkScriptFile` is deprecated in favor of `setupFilesAfterEnv`._
 
+Example `setupFilesAfterEnv` array in a jest.config.js:
+
+```js
+module.exports = {
+  setupFilesAfterEnv: ['./setup.js'],
+}
+```
+
+Example `setup.js` file
+```js
+jest.setTimeout(10000); // in milliseconds
+```
+
+
 ### `snapshotResolver` [string]
 
 Default: `undefined`

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -758,11 +758,11 @@ Example `setupFilesAfterEnv` array in a jest.config.js:
 
 ```js
 module.exports = {
-  setupFilesAfterEnv: ['./setup.js'],
+  setupFilesAfterEnv: ['./jest.setup.js'],
 }
 ```
 
-Example `setup.js` file
+Example `jest.setup.js` file
 ```js
 jest.setTimeout(10000); // in milliseconds
 ```

--- a/docs/JestObjectAPI.md
+++ b/docs/JestObjectAPI.md
@@ -647,7 +647,7 @@ Set the default timeout interval for tests and before/after hooks in millisecond
 
 _Note: The default timeout interval is 5 seconds if this method is not called._
 
-_Note: A good place to do this to increase all timeouts before all tests are run is with `setupFilesAfterEnv`._
+_Note: If you want to set the timeout for all test files, a good place to do this is in `setupFilesAfterEnv`._
 
 Example:
 

--- a/docs/JestObjectAPI.md
+++ b/docs/JestObjectAPI.md
@@ -647,7 +647,7 @@ Set the default timeout interval for tests and before/after hooks in millisecond
 
 _Note: The default timeout interval is 5 seconds if this method is not called._
 
-_Note: The method must be called after the test framework is installed in the environment and before the test runs. A good place to do this is in the `setupTestFrameworkScriptFile`._
+_Note: The method must be called after the test framework is installed in the environment and before the test runs. A good place to do this is in the `jest.config` with `setupFilesAfterEnv`._
 
 Example:
 

--- a/docs/JestObjectAPI.md
+++ b/docs/JestObjectAPI.md
@@ -647,7 +647,7 @@ Set the default timeout interval for tests and before/after hooks in millisecond
 
 _Note: The default timeout interval is 5 seconds if this method is not called._
 
-_Note: The method must be called after the test framework is installed in the environment and before the test runs. A good place to do this is in the `jest.config` with `setupFilesAfterEnv`._
+_Note: A good place to do this to increase all timeouts before all tests are run is with `setupFilesAfterEnv`._
 
 Example:
 

--- a/website/versioned_docs/version-22.x/JestObjectAPI.md
+++ b/website/versioned_docs/version-22.x/JestObjectAPI.md
@@ -542,7 +542,7 @@ Set the default timeout interval for tests and before/after hooks in millisecond
 
 _Note: The default timeout interval is 5 seconds if this method is not called._
 
-_Note: The method must be called after the test framework is installed in the environment and before the test runs. A good place to do this is in the `setupTestFrameworkScriptFile`._
+_Note: If you want to set the timeout for all test files, a good place to do this is in `setupFilesAfterEnv`._
 
 Example:
 

--- a/website/versioned_docs/version-23.x/JestObjectAPI.md
+++ b/website/versioned_docs/version-23.x/JestObjectAPI.md
@@ -558,7 +558,7 @@ Set the default timeout interval for tests and before/after hooks in millisecond
 
 _Note: The default timeout interval is 5 seconds if this method is not called._
 
-_Note: The method must be called after the test framework is installed in the environment and before the test runs. A good place to do this is in the `setupTestFrameworkScriptFile`._
+_Note: If you want to set the timeout for all test files, a good place to do this is in `setupFilesAfterEnv`._
 
 Example:
 

--- a/website/versioned_docs/version-24.0/Configuration.md
+++ b/website/versioned_docs/version-24.0/Configuration.md
@@ -727,6 +727,19 @@ For example, Jest ships with several plug-ins to `jasmine` that work by monkey-p
 
 _Note: `setupTestFrameworkScriptFile` is deprecated in favor of `setupFilesAfterEnv`._
 
+Example `setupFilesAfterEnv` array in a jest.config.js:
+
+```js
+module.exports = {
+  setupFilesAfterEnv: ['./jest.setup.js'],
+}
+```
+
+Example `jest.setup.js` file
+```js
+jest.setTimeout(10000); // in milliseconds
+```
+
 ### `snapshotResolver` [string]
 
 Default: `undefined`

--- a/website/versioned_docs/version-24.0/JestObjectAPI.md
+++ b/website/versioned_docs/version-24.0/JestObjectAPI.md
@@ -642,7 +642,7 @@ Set the default timeout interval for tests and before/after hooks in millisecond
 
 _Note: The default timeout interval is 5 seconds if this method is not called._
 
-_Note: The method must be called after the test framework is installed in the environment and before the test runs. A good place to do this is in the `setupTestFrameworkScriptFile`._
+_Note: If you want to set the timeout for all test files, a good place to do this is in `setupFilesAfterEnv`._
 
 Example:
 

--- a/website/versioned_docs/version-24.1/Configuration.md
+++ b/website/versioned_docs/version-24.1/Configuration.md
@@ -736,6 +736,19 @@ For example, Jest ships with several plug-ins to `jasmine` that work by monkey-p
 
 _Note: `setupTestFrameworkScriptFile` is deprecated in favor of `setupFilesAfterEnv`._
 
+Example `setupFilesAfterEnv` array in a jest.config.js:
+
+```js
+module.exports = {
+  setupFilesAfterEnv: ['./jest.setup.js'],
+}
+```
+
+Example `jest.setup.js` file
+```js
+jest.setTimeout(10000); // in milliseconds
+```
+
 ### `snapshotResolver` [string]
 
 Default: `undefined`

--- a/website/versioned_docs/version-24.6/Configuration.md
+++ b/website/versioned_docs/version-24.6/Configuration.md
@@ -755,6 +755,19 @@ For example, Jest ships with several plug-ins to `jasmine` that work by monkey-p
 
 _Note: `setupTestFrameworkScriptFile` is deprecated in favor of `setupFilesAfterEnv`._
 
+Example `setupFilesAfterEnv` array in a jest.config.js:
+
+```js
+module.exports = {
+  setupFilesAfterEnv: ['./jest.setup.js'],
+}
+```
+
+Example `jest.setup.js` file
+```js
+jest.setTimeout(10000); // in milliseconds
+```
+
 ### `snapshotResolver` [string]
 
 Default: `undefined`

--- a/website/versioned_docs/version-24.8/Configuration.md
+++ b/website/versioned_docs/version-24.8/Configuration.md
@@ -755,6 +755,19 @@ For example, Jest ships with several plug-ins to `jasmine` that work by monkey-p
 
 _Note: `setupTestFrameworkScriptFile` is deprecated in favor of `setupFilesAfterEnv`._
 
+Example `setupFilesAfterEnv` array in a jest.config.js:
+
+```js
+module.exports = {
+  setupFilesAfterEnv: ['./jest.setup.js'],
+}
+```
+
+Example `jest.setup.js` file
+```js
+jest.setTimeout(10000); // in milliseconds
+```
+
 ### `snapshotResolver` [string]
 
 Default: `undefined`

--- a/website/versioned_docs/version-24.9/Configuration.md
+++ b/website/versioned_docs/version-24.9/Configuration.md
@@ -755,6 +755,19 @@ For example, Jest ships with several plug-ins to `jasmine` that work by monkey-p
 
 _Note: `setupTestFrameworkScriptFile` is deprecated in favor of `setupFilesAfterEnv`._
 
+Example `setupFilesAfterEnv` array in a jest.config.js:
+
+```js
+module.exports = {
+  setupFilesAfterEnv: ['./jest.setup.js'],
+}
+```
+
+Example `jest.setup.js` file
+```js
+jest.setTimeout(10000); // in milliseconds
+```
+
 ### `snapshotResolver` [string]
 
 Default: `undefined`

--- a/website/versioned_docs/version-24.9/JestObjectAPI.md
+++ b/website/versioned_docs/version-24.9/JestObjectAPI.md
@@ -648,7 +648,7 @@ Set the default timeout interval for tests and before/after hooks in millisecond
 
 _Note: The default timeout interval is 5 seconds if this method is not called._
 
-_Note: The method must be called after the test framework is installed in the environment and before the test runs. A good place to do this is in the `setupTestFrameworkScriptFile`._
+_Note: If you want to set the timeout for all test files, a good place to do this is in `setupFilesAfterEnv`._
 
 Example:
 


### PR DESCRIPTION


<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

The current docs did not efficiently explain setupTestFrameworkScriptFile was deprecated nor give a clear example of how to use.

## Test plan

n/a as doc changes only 
