### PR TITLE
chore: Align snapshots in expect

### DIFF
--- a/packages/expect/src/__tests__/__snapshots__/assertionCounts.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/assertionCounts.test.js.snap
@@ -1,10 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.hasAssertions() throws if expected is not undefined 1`] = `
-"<dim>expect(</><red>received</><dim>)[.not].hasAssertions()</>
+<d>expect(</><r>received</><d>)[.not].hasAssertions()</>
 
-<bold>Matcher error</>: this matcher must not have an expected argument
+<b>Matcher error</>: this matcher must not have an expected argument
 
 Expected has type:  number
-Expected has value: <green>2</>"
+Expected has value: <g>2</>
 `;

--- a/packages/expect/src/__tests__/__snapshots__/extend.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/extend.test.js.snap
@@ -1,55 +1,55 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`defines asymmetric unary matchers 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Object {</>
-<green>-   \\"value\\": toBeDivisibleBy<2>,</>
-<red>+   \\"value\\": 3,</>
-<dim>  }</>"
+<d>  Object {</>
+<g>-   "value": toBeDivisibleBy<2>,</>
+<r>+   "value": 3,</>
+<d>  }</>
 `;
 
 exports[`defines asymmetric unary matchers that can be prefixed by not 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Object {</>
-<green>-   \\"value\\": not.toBeDivisibleBy<2>,</>
-<red>+   \\"value\\": 2,</>
-<dim>  }</>"
+<d>  Object {</>
+<g>-   "value": not.toBeDivisibleBy<2>,</>
+<r>+   "value": 2,</>
+<d>  }</>
 `;
 
 exports[`defines asymmetric variadic matchers 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Object {</>
-<green>-   \\"value\\": toBeWithinRange<4, 11>,</>
-<red>+   \\"value\\": 3,</>
-<dim>  }</>"
+<d>  Object {</>
+<g>-   "value": toBeWithinRange<4, 11>,</>
+<r>+   "value": 3,</>
+<d>  }</>
 `;
 
 exports[`defines asymmetric variadic matchers that can be prefixed by not 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Object {</>
-<green>-   \\"value\\": not.toBeWithinRange<1, 3>,</>
-<red>+   \\"value\\": 2,</>
-<dim>  }</>"
+<d>  Object {</>
+<g>-   "value": not.toBeWithinRange<1, 3>,</>
+<r>+   "value": 2,</>
+<d>  }</>
 `;
 
-exports[`is available globally when matcher is unary 1`] = `"expected 15 to be divisible by 2"`;
+exports[`is available globally when matcher is unary 1`] = `expected 15 to be divisible by 2`;
 
-exports[`is available globally when matcher is variadic 1`] = `"expected 15 to be within range 1 - 3"`;
+exports[`is available globally when matcher is variadic 1`] = `expected 15 to be within range 1 - 3`;
 
-exports[`is ok if there is no message specified 1`] = `"<red>No message was specified for this matcher.</>"`;
+exports[`is ok if there is no message specified 1`] = `<r>No message was specified for this matcher.</>`;

--- a/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -1,295 +1,295 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`.rejects fails for promise that resolves 1`] = `
-"<dim>expect(</><red>received</><dim>).</>rejects<dim>.</>toBe<dim>()</>
+<d>expect(</><r>received</><d>).</>rejects<d>.</>toBe<d>()</>
 
 Received promise resolved instead of rejected
-Resolved to value: <red>4</>"
+Resolved to value: <r>4</>
 `;
 
 exports[`.rejects fails non-promise value "a" 1`] = `
-"<dim>expect(</><red>received</><dim>).</>rejects<dim>.</>toBeDefined<dim>()</>
+<d>expect(</><r>received</><d>).</>rejects<d>.</>toBeDefined<d>()</>
 
-<bold>Matcher error</>: <red>received</> value must be a promise
+<b>Matcher error</>: <r>received</> value must be a promise
 
 Received has type:  string
-Received has value: <red>\\"a\\"</>"
+Received has value: <r>"a"</>
 `;
 
 exports[`.rejects fails non-promise value [1] 1`] = `
-"<dim>expect(</><red>received</><dim>).</>rejects<dim>.</>toBeDefined<dim>()</>
+<d>expect(</><r>received</><d>).</>rejects<d>.</>toBeDefined<d>()</>
 
-<bold>Matcher error</>: <red>received</> value must be a promise
+<b>Matcher error</>: <r>received</> value must be a promise
 
 Received has type:  array
-Received has value: <red>[1]</>"
+Received has value: <r>[1]</>
 `;
 
 exports[`.rejects fails non-promise value [Function anonymous] 1`] = `
-"<dim>expect(</><red>received</><dim>).</>rejects<dim>.</>toBeDefined<dim>()</>
+<d>expect(</><r>received</><d>).</>rejects<d>.</>toBeDefined<d>()</>
 
-<bold>Matcher error</>: <red>received</> value must be a promise
+<b>Matcher error</>: <r>received</> value must be a promise
 
 Received has type:  function
-Received has value: <red>[Function anonymous]</>"
+Received has value: <r>[Function anonymous]</>
 `;
 
 exports[`.rejects fails non-promise value {"a": 1} 1`] = `
-"<dim>expect(</><red>received</><dim>).</>rejects<dim>.</>toBeDefined<dim>()</>
+<d>expect(</><r>received</><d>).</>rejects<d>.</>toBeDefined<d>()</>
 
-<bold>Matcher error</>: <red>received</> value must be a promise
+<b>Matcher error</>: <r>received</> value must be a promise
 
 Received has type:  object
-Received has value: <red>{\\"a\\": 1}</>"
+Received has value: <r>{"a": 1}</>
 `;
 
 exports[`.rejects fails non-promise value 4 1`] = `
-"<dim>expect(</><red>received</><dim>).</>rejects<dim>.</>not<dim>.</>toBeDefined<dim>()</>
+<d>expect(</><r>received</><d>).</>rejects<d>.</>not<d>.</>toBeDefined<d>()</>
 
-<bold>Matcher error</>: <red>received</> value must be a promise
+<b>Matcher error</>: <r>received</> value must be a promise
 
 Received has type:  number
-Received has value: <red>4</>"
+Received has value: <r>4</>
 `;
 
 exports[`.rejects fails non-promise value null 1`] = `
-"<dim>expect(</><red>received</><dim>).</>rejects<dim>.</>not<dim>.</>toBeDefined<dim>()</>
+<d>expect(</><r>received</><d>).</>rejects<d>.</>not<d>.</>toBeDefined<d>()</>
 
-<bold>Matcher error</>: <red>received</> value must be a promise
+<b>Matcher error</>: <r>received</> value must be a promise
 
-Received has value: <red>null</>"
+Received has value: <r>null</>
 `;
 
 exports[`.rejects fails non-promise value true 1`] = `
-"<dim>expect(</><red>received</><dim>).</>rejects<dim>.</>not<dim>.</>toBeDefined<dim>()</>
+<d>expect(</><r>received</><d>).</>rejects<d>.</>not<d>.</>toBeDefined<d>()</>
 
-<bold>Matcher error</>: <red>received</> value must be a promise
+<b>Matcher error</>: <r>received</> value must be a promise
 
 Received has type:  boolean
-Received has value: <red>true</>"
+Received has value: <r>true</>
 `;
 
 exports[`.rejects fails non-promise value undefined 1`] = `
-"<dim>expect(</><red>received</><dim>).</>rejects<dim>.</>not<dim>.</>toBeDefined<dim>()</>
+<d>expect(</><r>received</><d>).</>rejects<d>.</>not<d>.</>toBeDefined<d>()</>
 
-<bold>Matcher error</>: <red>received</> value must be a promise
+<b>Matcher error</>: <r>received</> value must be a promise
 
-Received has value: <red>undefined</>"
+Received has value: <r>undefined</>
 `;
 
 exports[`.resolves fails for promise that rejects 1`] = `
-"<dim>expect(</><red>received</><dim>).</>resolves<dim>.</>toBe<dim>()</>
+<d>expect(</><r>received</><d>).</>resolves<d>.</>toBe<d>()</>
 
 Received promise rejected instead of resolved
-Rejected to value: <red>4</>"
+Rejected to value: <r>4</>
 `;
 
 exports[`.resolves fails non-promise value "a" 1`] = `
-"<dim>expect(</><red>received</><dim>).</>resolves<dim>.</>toBeDefined<dim>()</>
+<d>expect(</><r>received</><d>).</>resolves<d>.</>toBeDefined<d>()</>
 
-<bold>Matcher error</>: <red>received</> value must be a promise
+<b>Matcher error</>: <r>received</> value must be a promise
 
 Received has type:  string
-Received has value: <red>\\"a\\"</>"
+Received has value: <r>"a"</>
 `;
 
 exports[`.resolves fails non-promise value "a" synchronously 1`] = `
-"<dim>expect(</><red>received</><dim>).</>resolves<dim>.</>toBeDefined<dim>()</>
+<d>expect(</><r>received</><d>).</>resolves<d>.</>toBeDefined<d>()</>
 
-<bold>Matcher error</>: <red>received</> value must be a promise
+<b>Matcher error</>: <r>received</> value must be a promise
 
 Received has type:  string
-Received has value: <red>\\"a\\"</>"
+Received has value: <r>"a"</>
 `;
 
 exports[`.resolves fails non-promise value [1] 1`] = `
-"<dim>expect(</><red>received</><dim>).</>resolves<dim>.</>toBeDefined<dim>()</>
+<d>expect(</><r>received</><d>).</>resolves<d>.</>toBeDefined<d>()</>
 
-<bold>Matcher error</>: <red>received</> value must be a promise
+<b>Matcher error</>: <r>received</> value must be a promise
 
 Received has type:  array
-Received has value: <red>[1]</>"
+Received has value: <r>[1]</>
 `;
 
 exports[`.resolves fails non-promise value [1] synchronously 1`] = `
-"<dim>expect(</><red>received</><dim>).</>resolves<dim>.</>toBeDefined<dim>()</>
+<d>expect(</><r>received</><d>).</>resolves<d>.</>toBeDefined<d>()</>
 
-<bold>Matcher error</>: <red>received</> value must be a promise
+<b>Matcher error</>: <r>received</> value must be a promise
 
 Received has type:  array
-Received has value: <red>[1]</>"
+Received has value: <r>[1]</>
 `;
 
 exports[`.resolves fails non-promise value [Function anonymous] 1`] = `
-"<dim>expect(</><red>received</><dim>).</>resolves<dim>.</>toBeDefined<dim>()</>
+<d>expect(</><r>received</><d>).</>resolves<d>.</>toBeDefined<d>()</>
 
-<bold>Matcher error</>: <red>received</> value must be a promise
+<b>Matcher error</>: <r>received</> value must be a promise
 
 Received has type:  function
-Received has value: <red>[Function anonymous]</>"
+Received has value: <r>[Function anonymous]</>
 `;
 
 exports[`.resolves fails non-promise value [Function anonymous] synchronously 1`] = `
-"<dim>expect(</><red>received</><dim>).</>resolves<dim>.</>toBeDefined<dim>()</>
+<d>expect(</><r>received</><d>).</>resolves<d>.</>toBeDefined<d>()</>
 
-<bold>Matcher error</>: <red>received</> value must be a promise
+<b>Matcher error</>: <r>received</> value must be a promise
 
 Received has type:  function
-Received has value: <red>[Function anonymous]</>"
+Received has value: <r>[Function anonymous]</>
 `;
 
 exports[`.resolves fails non-promise value {"a": 1} 1`] = `
-"<dim>expect(</><red>received</><dim>).</>resolves<dim>.</>toBeDefined<dim>()</>
+<d>expect(</><r>received</><d>).</>resolves<d>.</>toBeDefined<d>()</>
 
-<bold>Matcher error</>: <red>received</> value must be a promise
+<b>Matcher error</>: <r>received</> value must be a promise
 
 Received has type:  object
-Received has value: <red>{\\"a\\": 1}</>"
+Received has value: <r>{"a": 1}</>
 `;
 
 exports[`.resolves fails non-promise value {"a": 1} synchronously 1`] = `
-"<dim>expect(</><red>received</><dim>).</>resolves<dim>.</>toBeDefined<dim>()</>
+<d>expect(</><r>received</><d>).</>resolves<d>.</>toBeDefined<d>()</>
 
-<bold>Matcher error</>: <red>received</> value must be a promise
+<b>Matcher error</>: <r>received</> value must be a promise
 
 Received has type:  object
-Received has value: <red>{\\"a\\": 1}</>"
+Received has value: <r>{"a": 1}</>
 `;
 
 exports[`.resolves fails non-promise value 4 1`] = `
-"<dim>expect(</><red>received</><dim>).</>resolves<dim>.</>not<dim>.</>toBeDefined<dim>()</>
+<d>expect(</><r>received</><d>).</>resolves<d>.</>not<d>.</>toBeDefined<d>()</>
 
-<bold>Matcher error</>: <red>received</> value must be a promise
+<b>Matcher error</>: <r>received</> value must be a promise
 
 Received has type:  number
-Received has value: <red>4</>"
+Received has value: <r>4</>
 `;
 
 exports[`.resolves fails non-promise value 4 synchronously 1`] = `
-"<dim>expect(</><red>received</><dim>).</>resolves<dim>.</>not<dim>.</>toBeDefined<dim>()</>
+<d>expect(</><r>received</><d>).</>resolves<d>.</>not<d>.</>toBeDefined<d>()</>
 
-<bold>Matcher error</>: <red>received</> value must be a promise
+<b>Matcher error</>: <r>received</> value must be a promise
 
 Received has type:  number
-Received has value: <red>4</>"
+Received has value: <r>4</>
 `;
 
 exports[`.resolves fails non-promise value null 1`] = `
-"<dim>expect(</><red>received</><dim>).</>resolves<dim>.</>not<dim>.</>toBeDefined<dim>()</>
+<d>expect(</><r>received</><d>).</>resolves<d>.</>not<d>.</>toBeDefined<d>()</>
 
-<bold>Matcher error</>: <red>received</> value must be a promise
+<b>Matcher error</>: <r>received</> value must be a promise
 
-Received has value: <red>null</>"
+Received has value: <r>null</>
 `;
 
 exports[`.resolves fails non-promise value null synchronously 1`] = `
-"<dim>expect(</><red>received</><dim>).</>resolves<dim>.</>not<dim>.</>toBeDefined<dim>()</>
+<d>expect(</><r>received</><d>).</>resolves<d>.</>not<d>.</>toBeDefined<d>()</>
 
-<bold>Matcher error</>: <red>received</> value must be a promise
+<b>Matcher error</>: <r>received</> value must be a promise
 
-Received has value: <red>null</>"
+Received has value: <r>null</>
 `;
 
 exports[`.resolves fails non-promise value true 1`] = `
-"<dim>expect(</><red>received</><dim>).</>resolves<dim>.</>not<dim>.</>toBeDefined<dim>()</>
+<d>expect(</><r>received</><d>).</>resolves<d>.</>not<d>.</>toBeDefined<d>()</>
 
-<bold>Matcher error</>: <red>received</> value must be a promise
+<b>Matcher error</>: <r>received</> value must be a promise
 
 Received has type:  boolean
-Received has value: <red>true</>"
+Received has value: <r>true</>
 `;
 
 exports[`.resolves fails non-promise value true synchronously 1`] = `
-"<dim>expect(</><red>received</><dim>).</>resolves<dim>.</>not<dim>.</>toBeDefined<dim>()</>
+<d>expect(</><r>received</><d>).</>resolves<d>.</>not<d>.</>toBeDefined<d>()</>
 
-<bold>Matcher error</>: <red>received</> value must be a promise
+<b>Matcher error</>: <r>received</> value must be a promise
 
 Received has type:  boolean
-Received has value: <red>true</>"
+Received has value: <r>true</>
 `;
 
 exports[`.resolves fails non-promise value undefined 1`] = `
-"<dim>expect(</><red>received</><dim>).</>resolves<dim>.</>not<dim>.</>toBeDefined<dim>()</>
+<d>expect(</><r>received</><d>).</>resolves<d>.</>not<d>.</>toBeDefined<d>()</>
 
-<bold>Matcher error</>: <red>received</> value must be a promise
+<b>Matcher error</>: <r>received</> value must be a promise
 
-Received has value: <red>undefined</>"
+Received has value: <r>undefined</>
 `;
 
 exports[`.resolves fails non-promise value undefined synchronously 1`] = `
-"<dim>expect(</><red>received</><dim>).</>resolves<dim>.</>not<dim>.</>toBeDefined<dim>()</>
+<d>expect(</><r>received</><d>).</>resolves<d>.</>not<d>.</>toBeDefined<d>()</>
 
-<bold>Matcher error</>: <red>received</> value must be a promise
+<b>Matcher error</>: <r>received</> value must be a promise
 
-Received has value: <red>undefined</>"
+Received has value: <r>undefined</>
 `;
 
 exports[`.toBe() does not crash on circular references 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBe<dim>(</><green>expected</><dim>) // Object.is equality</>
+<d>expect(</><r>received</><d>).</>toBe<d>(</><g>expected</><d>) // Object.is equality</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<green>- Object {}</>
-<red>+ Object {</>
-<red>+   \\"circular\\": [Circular],</>
-<red>+ }</>"
+<g>- Object {}</>
+<r>+ Object {</>
+<r>+   "circular": [Circular],</>
+<r>+ }</>
 `;
 
 exports[`.toBe() fails for '"a"' with '.not' 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBe<dim>(</><green>expected</><dim>) // Object.is equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBe<d>(</><g>expected</><d>) // Object.is equality</>
 
-Expected: not <green>\\"a\\"</>"
+Expected: not <g>"a"</>
 `;
 
 exports[`.toBe() fails for '[]' with '.not' 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBe<dim>(</><green>expected</><dim>) // Object.is equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBe<d>(</><g>expected</><d>) // Object.is equality</>
 
-Expected: not <green>[]</>"
+Expected: not <g>[]</>
 `;
 
 exports[`.toBe() fails for '{}' with '.not' 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBe<dim>(</><green>expected</><dim>) // Object.is equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBe<d>(</><g>expected</><d>) // Object.is equality</>
 
-Expected: not <green>{}</>"
+Expected: not <g>{}</>
 `;
 
 exports[`.toBe() fails for '1' with '.not' 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBe<dim>(</><green>expected</><dim>) // Object.is equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBe<d>(</><g>expected</><d>) // Object.is equality</>
 
-Expected: not <green>1</>"
+Expected: not <g>1</>
 `;
 
 exports[`.toBe() fails for 'false' with '.not' 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBe<dim>(</><green>expected</><dim>) // Object.is equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBe<d>(</><g>expected</><d>) // Object.is equality</>
 
-Expected: not <green>false</>"
+Expected: not <g>false</>
 `;
 
 exports[`.toBe() fails for 'null' with '.not' 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBe<dim>(</><green>expected</><dim>) // Object.is equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBe<d>(</><g>expected</><d>) // Object.is equality</>
 
-Expected: not <green>null</>"
+Expected: not <g>null</>
 `;
 
 exports[`.toBe() fails for 'undefined' with '.not' 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBe<dim>(</><green>expected</><dim>) // Object.is equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBe<d>(</><g>expected</><d>) // Object.is equality</>
 
-Expected: not <green>undefined</>"
+Expected: not <g>undefined</>
 `;
 
 exports[`.toBe() fails for: "" and "compare one-line string to empty string" 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBe<dim>(</><green>expected</><dim>) // Object.is equality</>
+<d>expect(</><r>received</><d>).</>toBe<d>(</><g>expected</><d>) // Object.is equality</>
 
-Expected: <green>\\"compare one-line string to empty string\\"</>
-Received: <red>\\"\\"</>"
+Expected: <g>"compare one-line string to empty string"</>
+Received: <r>""</>
 `;
 
 exports[`.toBe() fails for: "abc" and "cde" 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBe<dim>(</><green>expected</><dim>) // Object.is equality</>
+<d>expect(</><r>received</><d>).</>toBe<d>(</><g>expected</><d>) // Object.is equality</>
 
-Expected: <green>\\"cde\\"</>
-Received: <red>\\"abc\\"</>"
+Expected: <g>"cde"</>
+Received: <r>"abc"</>
 `;
 
 exports[`.toBe() fails for: "four
@@ -298,2836 +298,2836 @@ line
 string" and "3
 line
 string" 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBe<dim>(</><green>expected</><dim>) // Object.is equality</>
+<d>expect(</><r>received</><d>).</>toBe<d>(</><g>expected</><d>) // Object.is equality</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<green>- 3</>
-<red>+ four</>
-<red>+ 4</>
-<dim>  line</>
-<dim>  string</>"
+<g>- 3</>
+<r>+ four</>
+<r>+ 4</>
+<d>  line</>
+<d>  string</>
 `;
 
 exports[`.toBe() fails for: "painless JavaScript testing" and "delightful JavaScript testing" 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBe<dim>(</><green>expected</><dim>) // Object.is equality</>
+<d>expect(</><r>received</><d>).</>toBe<d>(</><g>expected</><d>) // Object.is equality</>
 
-Expected: <green>\\"<inverse>delightful</> JavaScript testing\\"</>
-Received: <red>\\"<inverse>painless</> JavaScript testing\\"</>"
+Expected: <g>"<i>delightful</i> JavaScript testing"</>
+Received: <r>"<i>painless</i> JavaScript testing"</>
 `;
 
 exports[`.toBe() fails for: "with 
 trailing space" and "without trailing space" 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBe<dim>(</><green>expected</><dim>) // Object.is equality</>
+<d>expect(</><r>received</><d>).</>toBe<d>(</><g>expected</><d>) // Object.is equality</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<green>- with<inverse>out</> trailing space</>
-<red>+ with<bgYellow> </></>
-<red>+ trailing space</>"
+<g>- with<i>out</i> trailing space</>
+<r>+ with<Y> </></>
+<r>+ trailing space</>
 `;
 
 exports[`.toBe() fails for: /received/ and /expected/ 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBe<dim>(</><green>expected</><dim>) // Object.is equality</>
+<d>expect(</><r>received</><d>).</>toBe<d>(</><g>expected</><d>) // Object.is equality</>
 
-Expected: <green>/expected/</>
-Received: <red>/received/</>"
+Expected: <g>/expected/</>
+Received: <r>/received/</>
 `;
 
 exports[`.toBe() fails for: [] and [] 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBe<dim>(</><green>expected</><dim>) // Object.is equality</>
+<d>expect(</><r>received</><d>).</>toBe<d>(</><g>expected</><d>) // Object.is equality</>
 
-<dim>If it should pass with deep equality, replace \\"toBe\\" with \\"toStrictEqual\\"</>
+<d>If it should pass with deep equality, replace "toBe" with "toStrictEqual"</>
 
-Expected: <green>[]</>
-Received: serializes to the same string"
+Expected: <g>[]</>
+Received: serializes to the same string
 `;
 
 exports[`.toBe() fails for: [Error: received] and [Error: expected] 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBe<dim>(</><green>expected</><dim>) // Object.is equality</>
+<d>expect(</><r>received</><d>).</>toBe<d>(</><g>expected</><d>) // Object.is equality</>
 
-Expected: <green>[Error: expected]</>
-Received: <red>[Error: received]</>"
+Expected: <g>[Error: expected]</>
+Received: <r>[Error: received]</>
 `;
 
 exports[`.toBe() fails for: [Function anonymous] and [Function anonymous] 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBe<dim>(</><green>expected</><dim>) // Object.is equality</>
+<d>expect(</><r>received</><d>).</>toBe<d>(</><g>expected</><d>) // Object.is equality</>
 
-Expected: <green>[Function anonymous]</>
-Received: serializes to the same string"
+Expected: <g>[Function anonymous]</>
+Received: serializes to the same string
 `;
 
 exports[`.toBe() fails for: {"a": [Function a], "b": 2} and {"a": Any<Function>, "b": 2} 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBe<dim>(</><green>expected</><dim>) // Object.is equality</>
+<d>expect(</><r>received</><d>).</>toBe<d>(</><g>expected</><d>) // Object.is equality</>
 
-<dim>If it should pass with deep equality, replace \\"toBe\\" with \\"toStrictEqual\\"</>
+<d>If it should pass with deep equality, replace "toBe" with "toStrictEqual"</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Object {</>
-<green>-   \\"a\\": Any<Function>,</>
-<red>+   \\"a\\": [Function a],</>
-<dim>    \\"b\\": 2,</>
-<dim>  }</>"
+<d>  Object {</>
+<g>-   "a": Any<Function>,</>
+<r>+   "a": [Function a],</>
+<d>    "b": 2,</>
+<d>  }</>
 `;
 
 exports[`.toBe() fails for: {"a": 1} and {"a": 1} 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBe<dim>(</><green>expected</><dim>) // Object.is equality</>
+<d>expect(</><r>received</><d>).</>toBe<d>(</><g>expected</><d>) // Object.is equality</>
 
-<dim>If it should pass with deep equality, replace \\"toBe\\" with \\"toStrictEqual\\"</>
+<d>If it should pass with deep equality, replace "toBe" with "toStrictEqual"</>
 
-Expected: <green>{\\"a\\": 1}</>
-Received: serializes to the same string"
+Expected: <g>{"a": 1}</>
+Received: serializes to the same string
 `;
 
 exports[`.toBe() fails for: {"a": 1} and {"a": 5} 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBe<dim>(</><green>expected</><dim>) // Object.is equality</>
+<d>expect(</><r>received</><d>).</>toBe<d>(</><g>expected</><d>) // Object.is equality</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Object {</>
-<green>-   \\"a\\": 5,</>
-<red>+   \\"a\\": 1,</>
-<dim>  }</>"
+<d>  Object {</>
+<g>-   "a": 5,</>
+<r>+   "a": 1,</>
+<d>  }</>
 `;
 
 exports[`.toBe() fails for: {"a": undefined, "b": 2} and {"b": 2} 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBe<dim>(</><green>expected</><dim>) // Object.is equality</>
+<d>expect(</><r>received</><d>).</>toBe<d>(</><g>expected</><d>) // Object.is equality</>
 
-<dim>If it should pass with deep equality, replace \\"toBe\\" with \\"toEqual\\"</>
+<d>If it should pass with deep equality, replace "toBe" with "toEqual"</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Object {</>
-<red>+   \\"a\\": undefined,</>
-<dim>    \\"b\\": 2,</>
-<dim>  }</>"
+<d>  Object {</>
+<r>+   "a": undefined,</>
+<d>    "b": 2,</>
+<d>  }</>
 `;
 
 exports[`.toBe() fails for: {} and {} 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBe<dim>(</><green>expected</><dim>) // Object.is equality</>
+<d>expect(</><r>received</><d>).</>toBe<d>(</><g>expected</><d>) // Object.is equality</>
 
-<dim>If it should pass with deep equality, replace \\"toBe\\" with \\"toStrictEqual\\"</>
+<d>If it should pass with deep equality, replace "toBe" with "toStrictEqual"</>
 
-Expected: <green>{}</>
-Received: serializes to the same string"
+Expected: <g>{}</>
+Received: serializes to the same string
 `;
 
 exports[`.toBe() fails for: -0 and 0 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBe<dim>(</><green>expected</><dim>) // Object.is equality</>
+<d>expect(</><r>received</><d>).</>toBe<d>(</><g>expected</><d>) // Object.is equality</>
 
-Expected: <green>0</>
-Received: <red>-0</>"
+Expected: <g>0</>
+Received: <r>-0</>
 `;
 
 exports[`.toBe() fails for: 1 and 2 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBe<dim>(</><green>expected</><dim>) // Object.is equality</>
+<d>expect(</><r>received</><d>).</>toBe<d>(</><g>expected</><d>) // Object.is equality</>
 
-Expected: <green>2</>
-Received: <red>1</>"
+Expected: <g>2</>
+Received: <r>1</>
 `;
 
 exports[`.toBe() fails for: 2020-02-20T00:00:00.000Z and 2020-02-20T00:00:00.000Z 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBe<dim>(</><green>expected</><dim>) // Object.is equality</>
+<d>expect(</><r>received</><d>).</>toBe<d>(</><g>expected</><d>) // Object.is equality</>
 
-<dim>If it should pass with deep equality, replace \\"toBe\\" with \\"toStrictEqual\\"</>
+<d>If it should pass with deep equality, replace "toBe" with "toStrictEqual"</>
 
-Expected: <green>2020-02-20T00:00:00.000Z</>
-Received: serializes to the same string"
+Expected: <g>2020-02-20T00:00:00.000Z</>
+Received: serializes to the same string
 `;
 
 exports[`.toBe() fails for: 2020-02-21T00:00:00.000Z and 2020-02-20T00:00:00.000Z 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBe<dim>(</><green>expected</><dim>) // Object.is equality</>
+<d>expect(</><r>received</><d>).</>toBe<d>(</><g>expected</><d>) // Object.is equality</>
 
-Expected: <green>2020-02-20T00:00:00.000Z</>
-Received: <red>2020-02-21T00:00:00.000Z</>"
+Expected: <g>2020-02-20T00:00:00.000Z</>
+Received: <r>2020-02-21T00:00:00.000Z</>
 `;
 
 exports[`.toBe() fails for: Symbol(received) and Symbol(expected) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBe<dim>(</><green>expected</><dim>) // Object.is equality</>
+<d>expect(</><r>received</><d>).</>toBe<d>(</><g>expected</><d>) // Object.is equality</>
 
-Expected: <green>Symbol(expected)</>
-Received: <red>Symbol(received)</>"
+Expected: <g>Symbol(expected)</>
+Received: <r>Symbol(received)</>
 `;
 
 exports[`.toBe() fails for: null and undefined 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBe<dim>(</><green>expected</><dim>) // Object.is equality</>
+<d>expect(</><r>received</><d>).</>toBe<d>(</><g>expected</><d>) // Object.is equality</>
 
-Expected: <green>undefined</>
-Received: <red>null</>"
+Expected: <g>undefined</>
+Received: <r>null</>
 `;
 
 exports[`.toBe() fails for: true and false 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBe<dim>(</><green>expected</><dim>) // Object.is equality</>
+<d>expect(</><r>received</><d>).</>toBe<d>(</><g>expected</><d>) // Object.is equality</>
 
-Expected: <green>false</>
-Received: <red>true</>"
+Expected: <g>false</>
+Received: <r>true</>
 `;
 
 exports[`.toBeCloseTo {pass: false} expect(-Infinity).toBeCloseTo(-1.23) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeCloseTo<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toBeCloseTo<d>(</><g>expected</><d>)</>
 
-Expected: <green>-1.23</>
-Received: <red>-Infinity</>
+Expected: <g>-1.23</>
+Received: <r>-Infinity</>
 
 Expected precision:    2
-Expected difference: < <green>0.005</>
-Received difference:   <red>Infinity</>"
+Expected difference: < <g>0.005</>
+Received difference:   <r>Infinity</>
 `;
 
 exports[`.toBeCloseTo {pass: false} expect(0).toBeCloseTo(0.01) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeCloseTo<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toBeCloseTo<d>(</><g>expected</><d>)</>
 
-Expected: <green>0.01</>
-Received: <red>0</>
+Expected: <g>0.01</>
+Received: <r>0</>
 
 Expected precision:    2
-Expected difference: < <green>0.005</>
-Received difference:   <red>0.01</>"
+Expected difference: < <g>0.005</>
+Received difference:   <r>0.01</>
 `;
 
 exports[`.toBeCloseTo {pass: false} expect(1).toBeCloseTo(1.23) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeCloseTo<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toBeCloseTo<d>(</><g>expected</><d>)</>
 
-Expected: <green>1.23</>
-Received: <red>1</>
+Expected: <g>1.23</>
+Received: <r>1</>
 
 Expected precision:    2
-Expected difference: < <green>0.005</>
-Received difference:   <red>0.22999999999999998</>"
+Expected difference: < <g>0.005</>
+Received difference:   <r>0.22999999999999998</>
 `;
 
 exports[`.toBeCloseTo {pass: false} expect(1.23).toBeCloseTo(1.2249999) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeCloseTo<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toBeCloseTo<d>(</><g>expected</><d>)</>
 
-Expected: <green>1.2249999</>
-Received: <red>1.23</>
+Expected: <g>1.2249999</>
+Received: <r>1.23</>
 
 Expected precision:    2
-Expected difference: < <green>0.005</>
-Received difference:   <red>0.005000099999999952</>"
+Expected difference: < <g>0.005</>
+Received difference:   <r>0.005000099999999952</>
 `;
 
 exports[`.toBeCloseTo {pass: false} expect(3.141592e-7).toBeCloseTo(3e-7, 8) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeCloseTo<dim>(</><green>expected</><dim>, </>precision<dim>)</>
+<d>expect(</><r>received</><d>).</>toBeCloseTo<d>(</><g>expected</><d>, </>precision<d>)</>
 
-Expected: <green>3e-7</>
-Received: <red>3.141592e-7</>
+Expected: <g>3e-7</>
+Received: <r>3.141592e-7</>
 
 Expected precision:    8
-Expected difference: < <green>5e-9</>
-Received difference:   <red>1.4159200000000025e-8</>"
+Expected difference: < <g>5e-9</>
+Received difference:   <r>1.4159200000000025e-8</>
 `;
 
 exports[`.toBeCloseTo {pass: false} expect(56789).toBeCloseTo(51234, -4) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeCloseTo<dim>(</><green>expected</><dim>, </>precision<dim>)</>
+<d>expect(</><r>received</><d>).</>toBeCloseTo<d>(</><g>expected</><d>, </>precision<d>)</>
 
-Expected: <green>51234</>
-Received: <red>56789</>
+Expected: <g>51234</>
+Received: <r>56789</>
 
 Expected precision:    -4
-Expected difference: < <green>5000</>
-Received difference:   <red>5555</>"
+Expected difference: < <g>5000</>
+Received difference:   <r>5555</>
 `;
 
 exports[`.toBeCloseTo {pass: false} expect(Infinity).toBeCloseTo(-Infinity) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeCloseTo<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toBeCloseTo<d>(</><g>expected</><d>)</>
 
-Expected: <green>-Infinity</>
-Received: <red>Infinity</>
+Expected: <g>-Infinity</>
+Received: <r>Infinity</>
 
 Expected precision:    2
-Expected difference: < <green>0.005</>
-Received difference:   <red>Infinity</>"
+Expected difference: < <g>0.005</>
+Received difference:   <r>Infinity</>
 `;
 
 exports[`.toBeCloseTo {pass: false} expect(Infinity).toBeCloseTo(1.23) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeCloseTo<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toBeCloseTo<d>(</><g>expected</><d>)</>
 
-Expected: <green>1.23</>
-Received: <red>Infinity</>
+Expected: <g>1.23</>
+Received: <r>Infinity</>
 
 Expected precision:    2
-Expected difference: < <green>0.005</>
-Received difference:   <red>Infinity</>"
+Expected difference: < <g>0.005</>
+Received difference:   <r>Infinity</>
 `;
 
 exports[`.toBeCloseTo {pass: true} expect(-Infinity).toBeCloseTo(-Infinity) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeCloseTo<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeCloseTo<d>(</><g>expected</><d>)</>
 
-Expected: not <green>-Infinity</>
-"
+Expected: not <g>-Infinity</>
+
 `;
 
 exports[`.toBeCloseTo {pass: true} expect(0).toBeCloseTo(0) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeCloseTo<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeCloseTo<d>(</><g>expected</><d>)</>
 
-Expected: not <green>0</>
-"
+Expected: not <g>0</>
+
 `;
 
 exports[`.toBeCloseTo {pass: true} expect(0).toBeCloseTo(0.000004, 5) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeCloseTo<dim>(</><green>expected</><dim>, </>precision<dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeCloseTo<d>(</><g>expected</><d>, </>precision<d>)</>
 
-Expected: not <green>0.000004</>
-Received:     <red>0</>
+Expected: not <g>0.000004</>
+Received:     <r>0</>
 
 Expected precision:        5
-Expected difference: not < <green>0.000005</>
-Received difference:       <red>0.000004</>"
+Expected difference: not < <g>0.000005</>
+Received difference:       <r>0.000004</>
 `;
 
 exports[`.toBeCloseTo {pass: true} expect(0).toBeCloseTo(0.0001, 3) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeCloseTo<dim>(</><green>expected</><dim>, </>precision<dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeCloseTo<d>(</><g>expected</><d>, </>precision<d>)</>
 
-Expected: not <green>0.0001</>
-Received:     <red>0</>
+Expected: not <g>0.0001</>
+Received:     <r>0</>
 
 Expected precision:        3
-Expected difference: not < <green>0.0005</>
-Received difference:       <red>0.0001</>"
+Expected difference: not < <g>0.0005</>
+Received difference:       <r>0.0001</>
 `;
 
 exports[`.toBeCloseTo {pass: true} expect(0).toBeCloseTo(0.001) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeCloseTo<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeCloseTo<d>(</><g>expected</><d>)</>
 
-Expected: not <green>0.001</>
-Received:     <red>0</>
+Expected: not <g>0.001</>
+Received:     <r>0</>
 
 Expected precision:        2
-Expected difference: not < <green>0.005</>
-Received difference:       <red>0.001</>"
+Expected difference: not < <g>0.005</>
+Received difference:       <r>0.001</>
 `;
 
 exports[`.toBeCloseTo {pass: true} expect(0).toBeCloseTo(0.1, 0) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeCloseTo<dim>(</><green>expected</><dim>, </>precision<dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeCloseTo<d>(</><g>expected</><d>, </>precision<d>)</>
 
-Expected: not <green>0.1</>
-Received:     <red>0</>
+Expected: not <g>0.1</>
+Received:     <r>0</>
 
 Expected precision:        0
-Expected difference: not < <green>0.5</>
-Received difference:       <red>0.1</>"
+Expected difference: not < <g>0.5</>
+Received difference:       <r>0.1</>
 `;
 
 exports[`.toBeCloseTo {pass: true} expect(1.23).toBeCloseTo(1.225) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeCloseTo<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeCloseTo<d>(</><g>expected</><d>)</>
 
-Expected: not <green>1.225</>
-Received:     <red>1.23</>
+Expected: not <g>1.225</>
+Received:     <r>1.23</>
 
 Expected precision:        2
-Expected difference: not < <green>0.005</>
-Received difference:       <red>0.004999999999999893</>"
+Expected difference: not < <g>0.005</>
+Received difference:       <r>0.004999999999999893</>
 `;
 
 exports[`.toBeCloseTo {pass: true} expect(1.23).toBeCloseTo(1.226) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeCloseTo<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeCloseTo<d>(</><g>expected</><d>)</>
 
-Expected: not <green>1.226</>
-Received:     <red>1.23</>
+Expected: not <g>1.226</>
+Received:     <r>1.23</>
 
 Expected precision:        2
-Expected difference: not < <green>0.005</>
-Received difference:       <red>0.0040000000000000036</>"
+Expected difference: not < <g>0.005</>
+Received difference:       <r>0.0040000000000000036</>
 `;
 
 exports[`.toBeCloseTo {pass: true} expect(1.23).toBeCloseTo(1.229) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeCloseTo<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeCloseTo<d>(</><g>expected</><d>)</>
 
-Expected: not <green>1.229</>
-Received:     <red>1.23</>
+Expected: not <g>1.229</>
+Received:     <r>1.23</>
 
 Expected precision:        2
-Expected difference: not < <green>0.005</>
-Received difference:       <red>0.0009999999999998899</>"
+Expected difference: not < <g>0.005</>
+Received difference:       <r>0.0009999999999998899</>
 `;
 
 exports[`.toBeCloseTo {pass: true} expect(1.23).toBeCloseTo(1.234) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeCloseTo<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeCloseTo<d>(</><g>expected</><d>)</>
 
-Expected: not <green>1.234</>
-Received:     <red>1.23</>
+Expected: not <g>1.234</>
+Received:     <r>1.23</>
 
 Expected precision:        2
-Expected difference: not < <green>0.005</>
-Received difference:       <red>0.0040000000000000036</>"
+Expected difference: not < <g>0.005</>
+Received difference:       <r>0.0040000000000000036</>
 `;
 
 exports[`.toBeCloseTo {pass: true} expect(2.0000002).toBeCloseTo(2, 5) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeCloseTo<dim>(</><green>expected</><dim>, </>precision<dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeCloseTo<d>(</><g>expected</><d>, </>precision<d>)</>
 
-Expected: not <green>2</>
-Received:     <red>2.0000002</>
+Expected: not <g>2</>
+Received:     <r>2.0000002</>
 
 Expected precision:        5
-Expected difference: not < <green>5e-6</>
-Received difference:       <red>2.0000000011677344e-7</>"
+Expected difference: not < <g>5e-6</>
+Received difference:       <r>2.0000000011677344e-7</>
 `;
 
 exports[`.toBeCloseTo {pass: true} expect(Infinity).toBeCloseTo(Infinity) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeCloseTo<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeCloseTo<d>(</><g>expected</><d>)</>
 
-Expected: not <green>Infinity</>
-"
+Expected: not <g>Infinity</>
+
 `;
 
 exports[`.toBeCloseTo throws: Matcher error promise empty isNot false received 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeCloseTo<dim>(</><green>expected</><dim>, </>precision<dim>)</>
+<d>expect(</><r>received</><d>).</>toBeCloseTo<d>(</><g>expected</><d>, </>precision<d>)</>
 
-<bold>Matcher error</>: <red>received</> value must be a number
+<b>Matcher error</>: <r>received</> value must be a number
 
 Received has type:  string
-Received has value: <red>\\"\\"</>"
+Received has value: <r>""</>
 `;
 
 exports[`.toBeCloseTo throws: Matcher error promise empty isNot true expected 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeCloseTo<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeCloseTo<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a number
+<b>Matcher error</>: <g>expected</> value must be a number
 
-Expected has value: <green>undefined</>"
+Expected has value: <g>undefined</>
 `;
 
 exports[`.toBeCloseTo throws: Matcher error promise rejects isNot false expected 1`] = `
-"<dim>expect(</><red>received</><dim>).</>rejects<dim>.</>toBeCloseTo<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>rejects<d>.</>toBeCloseTo<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a number
+<b>Matcher error</>: <g>expected</> value must be a number
 
 Expected has type:  string
-Expected has value: <green>\\"0\\"</>"
+Expected has value: <g>"0"</>
 `;
 
 exports[`.toBeCloseTo throws: Matcher error promise rejects isNot true received 1`] = `
-"<dim>expect(</><red>received</><dim>).</>rejects<dim>.</>not<dim>.</>toBeCloseTo<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>rejects<d>.</>not<d>.</>toBeCloseTo<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <red>received</> value must be a number
+<b>Matcher error</>: <r>received</> value must be a number
 
 Received has type:  symbol
-Received has value: <red>Symbol(0.1)</>"
+Received has value: <r>Symbol(0.1)</>
 `;
 
 exports[`.toBeCloseTo throws: Matcher error promise resolves isNot false received 1`] = `
-"<dim>expect(</><red>received</><dim>).</>resolves<dim>.</>toBeCloseTo<dim>(</><green>expected</><dim>, </>precision<dim>)</>
+<d>expect(</><r>received</><d>).</>resolves<d>.</>toBeCloseTo<d>(</><g>expected</><d>, </>precision<d>)</>
 
-<bold>Matcher error</>: <red>received</> value must be a number
+<b>Matcher error</>: <r>received</> value must be a number
 
 Received has type:  boolean
-Received has value: <red>false</>"
+Received has value: <r>false</>
 `;
 
 exports[`.toBeCloseTo throws: Matcher error promise resolves isNot true expected 1`] = `
-"<dim>expect(</><red>received</><dim>).</>resolves<dim>.</>not<dim>.</>toBeCloseTo<dim>(</><green>expected</><dim>, </>precision<dim>)</>
+<d>expect(</><r>received</><d>).</>resolves<d>.</>not<d>.</>toBeCloseTo<d>(</><g>expected</><d>, </>precision<d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a number
+<b>Matcher error</>: <g>expected</> value must be a number
 
-Expected has value: <green>null</>"
+Expected has value: <g>null</>
 `;
 
 exports[`.toBeDefined(), .toBeUndefined() '"a"' is defined 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeDefined<dim>()</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeDefined<d>()</>
 
-Received: <red>\\"a\\"</>"
+Received: <r>"a"</>
 `;
 
 exports[`.toBeDefined(), .toBeUndefined() '"a"' is defined 2`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeUndefined<dim>()</>
+<d>expect(</><r>received</><d>).</>toBeUndefined<d>()</>
 
-Received: <red>\\"a\\"</>"
+Received: <r>"a"</>
 `;
 
 exports[`.toBeDefined(), .toBeUndefined() '[]' is defined 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeDefined<dim>()</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeDefined<d>()</>
 
-Received: <red>[]</>"
+Received: <r>[]</>
 `;
 
 exports[`.toBeDefined(), .toBeUndefined() '[]' is defined 2`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeUndefined<dim>()</>
+<d>expect(</><r>received</><d>).</>toBeUndefined<d>()</>
 
-Received: <red>[]</>"
+Received: <r>[]</>
 `;
 
 exports[`.toBeDefined(), .toBeUndefined() '[Function anonymous]' is defined 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeDefined<dim>()</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeDefined<d>()</>
 
-Received: <red>[Function anonymous]</>"
+Received: <r>[Function anonymous]</>
 `;
 
 exports[`.toBeDefined(), .toBeUndefined() '[Function anonymous]' is defined 2`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeUndefined<dim>()</>
+<d>expect(</><r>received</><d>).</>toBeUndefined<d>()</>
 
-Received: <red>[Function anonymous]</>"
+Received: <r>[Function anonymous]</>
 `;
 
 exports[`.toBeDefined(), .toBeUndefined() '{}' is defined 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeDefined<dim>()</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeDefined<d>()</>
 
-Received: <red>{}</>"
+Received: <r>{}</>
 `;
 
 exports[`.toBeDefined(), .toBeUndefined() '{}' is defined 2`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeUndefined<dim>()</>
+<d>expect(</><r>received</><d>).</>toBeUndefined<d>()</>
 
-Received: <red>{}</>"
+Received: <r>{}</>
 `;
 
 exports[`.toBeDefined(), .toBeUndefined() '0.5' is defined 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeDefined<dim>()</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeDefined<d>()</>
 
-Received: <red>0.5</>"
+Received: <r>0.5</>
 `;
 
 exports[`.toBeDefined(), .toBeUndefined() '0.5' is defined 2`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeUndefined<dim>()</>
+<d>expect(</><r>received</><d>).</>toBeUndefined<d>()</>
 
-Received: <red>0.5</>"
+Received: <r>0.5</>
 `;
 
 exports[`.toBeDefined(), .toBeUndefined() '1' is defined 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeDefined<dim>()</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeDefined<d>()</>
 
-Received: <red>1</>"
+Received: <r>1</>
 `;
 
 exports[`.toBeDefined(), .toBeUndefined() '1' is defined 2`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeUndefined<dim>()</>
+<d>expect(</><r>received</><d>).</>toBeUndefined<d>()</>
 
-Received: <red>1</>"
+Received: <r>1</>
 `;
 
 exports[`.toBeDefined(), .toBeUndefined() 'Infinity' is defined 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeDefined<dim>()</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeDefined<d>()</>
 
-Received: <red>Infinity</>"
+Received: <r>Infinity</>
 `;
 
 exports[`.toBeDefined(), .toBeUndefined() 'Infinity' is defined 2`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeUndefined<dim>()</>
+<d>expect(</><r>received</><d>).</>toBeUndefined<d>()</>
 
-Received: <red>Infinity</>"
+Received: <r>Infinity</>
 `;
 
 exports[`.toBeDefined(), .toBeUndefined() 'Map {}' is defined 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeDefined<dim>()</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeDefined<d>()</>
 
-Received: <red>Map {}</>"
+Received: <r>Map {}</>
 `;
 
 exports[`.toBeDefined(), .toBeUndefined() 'Map {}' is defined 2`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeUndefined<dim>()</>
+<d>expect(</><r>received</><d>).</>toBeUndefined<d>()</>
 
-Received: <red>Map {}</>"
+Received: <r>Map {}</>
 `;
 
 exports[`.toBeDefined(), .toBeUndefined() 'true' is defined 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeDefined<dim>()</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeDefined<d>()</>
 
-Received: <red>true</>"
+Received: <r>true</>
 `;
 
 exports[`.toBeDefined(), .toBeUndefined() 'true' is defined 2`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeUndefined<dim>()</>
+<d>expect(</><r>received</><d>).</>toBeUndefined<d>()</>
 
-Received: <red>true</>"
+Received: <r>true</>
 `;
 
 exports[`.toBeDefined(), .toBeUndefined() undefined is undefined 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeDefined<dim>()</>
+<d>expect(</><r>received</><d>).</>toBeDefined<d>()</>
 
-Received: <red>undefined</>"
+Received: <r>undefined</>
 `;
 
 exports[`.toBeDefined(), .toBeUndefined() undefined is undefined 2`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeUndefined<dim>()</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeUndefined<d>()</>
 
-Received: <red>undefined</>"
+Received: <r>undefined</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() equal numbers: [-Infinity, -Infinity] 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeGreaterThanOrEqual<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeGreaterThanOrEqual<d>(</><g>expected</><d>)</>
 
-Expected: not >= <green>-Infinity</>
-Received:        <red>-Infinity</>"
+Expected: not >= <g>-Infinity</>
+Received:        <r>-Infinity</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() equal numbers: [-Infinity, -Infinity] 2`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeLessThanOrEqual<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeLessThanOrEqual<d>(</><g>expected</><d>)</>
 
-Expected: not <= <green>-Infinity</>
-Received:        <red>-Infinity</>"
+Expected: not <= <g>-Infinity</>
+Received:        <r>-Infinity</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() equal numbers: [1, 1] 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeGreaterThanOrEqual<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeGreaterThanOrEqual<d>(</><g>expected</><d>)</>
 
-Expected: not >= <green>1</>
-Received:        <red>1</>"
+Expected: not >= <g>1</>
+Received:        <r>1</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() equal numbers: [1, 1] 2`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeLessThanOrEqual<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeLessThanOrEqual<d>(</><g>expected</><d>)</>
 
-Expected: not <= <green>1</>
-Received:        <red>1</>"
+Expected: not <= <g>1</>
+Received:        <r>1</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() equal numbers: [1.7976931348623157e+308, 1.7976931348623157e+308] 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeGreaterThanOrEqual<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeGreaterThanOrEqual<d>(</><g>expected</><d>)</>
 
-Expected: not >= <green>1.7976931348623157e+308</>
-Received:        <red>1.7976931348623157e+308</>"
+Expected: not >= <g>1.7976931348623157e+308</>
+Received:        <r>1.7976931348623157e+308</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() equal numbers: [1.7976931348623157e+308, 1.7976931348623157e+308] 2`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeLessThanOrEqual<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeLessThanOrEqual<d>(</><g>expected</><d>)</>
 
-Expected: not <= <green>1.7976931348623157e+308</>
-Received:        <red>1.7976931348623157e+308</>"
+Expected: not <= <g>1.7976931348623157e+308</>
+Received:        <r>1.7976931348623157e+308</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() equal numbers: [5e-324, 5e-324] 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeGreaterThanOrEqual<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeGreaterThanOrEqual<d>(</><g>expected</><d>)</>
 
-Expected: not >= <green>5e-324</>
-Received:        <red>5e-324</>"
+Expected: not >= <g>5e-324</>
+Received:        <r>5e-324</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() equal numbers: [5e-324, 5e-324] 2`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeLessThanOrEqual<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeLessThanOrEqual<d>(</><g>expected</><d>)</>
 
-Expected: not <= <green>5e-324</>
-Received:        <red>5e-324</>"
+Expected: not <= <g>5e-324</>
+Received:        <r>5e-324</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() equal numbers: [Infinity, Infinity] 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeGreaterThanOrEqual<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeGreaterThanOrEqual<d>(</><g>expected</><d>)</>
 
-Expected: not >= <green>Infinity</>
-Received:        <red>Infinity</>"
+Expected: not >= <g>Infinity</>
+Received:        <r>Infinity</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() equal numbers: [Infinity, Infinity] 2`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeLessThanOrEqual<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeLessThanOrEqual<d>(</><g>expected</><d>)</>
 
-Expected: not <= <green>Infinity</>
-Received:        <red>Infinity</>"
+Expected: not <= <g>Infinity</>
+Received:        <r>Infinity</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [-Infinity, Infinity] 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeGreaterThan<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toBeGreaterThan<d>(</><g>expected</><d>)</>
 
-Expected: > <green>Infinity</>
-Received:   <red>-Infinity</>"
+Expected: > <g>Infinity</>
+Received:   <r>-Infinity</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [-Infinity, Infinity] 2`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeLessThan<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeLessThan<d>(</><g>expected</><d>)</>
 
-Expected: not < <green>Infinity</>
-Received:       <red>-Infinity</>"
+Expected: not < <g>Infinity</>
+Received:       <r>-Infinity</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [-Infinity, Infinity] 3`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeGreaterThan<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeGreaterThan<d>(</><g>expected</><d>)</>
 
-Expected: not > <green>-Infinity</>
-Received:       <red>Infinity</>"
+Expected: not > <g>-Infinity</>
+Received:       <r>Infinity</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [-Infinity, Infinity] 4`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeLessThan<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toBeLessThan<d>(</><g>expected</><d>)</>
 
-Expected: < <green>-Infinity</>
-Received:   <red>Infinity</>"
+Expected: < <g>-Infinity</>
+Received:   <r>Infinity</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [-Infinity, Infinity] 5`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeGreaterThanOrEqual<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toBeGreaterThanOrEqual<d>(</><g>expected</><d>)</>
 
-Expected: >= <green>Infinity</>
-Received:    <red>-Infinity</>"
+Expected: >= <g>Infinity</>
+Received:    <r>-Infinity</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [-Infinity, Infinity] 6`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeLessThanOrEqual<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeLessThanOrEqual<d>(</><g>expected</><d>)</>
 
-Expected: not <= <green>Infinity</>
-Received:        <red>-Infinity</>"
+Expected: not <= <g>Infinity</>
+Received:        <r>-Infinity</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [-Infinity, Infinity] 7`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeGreaterThanOrEqual<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeGreaterThanOrEqual<d>(</><g>expected</><d>)</>
 
-Expected: not >= <green>-Infinity</>
-Received:        <red>Infinity</>"
+Expected: not >= <g>-Infinity</>
+Received:        <r>Infinity</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [-Infinity, Infinity] 8`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeLessThanOrEqual<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toBeLessThanOrEqual<d>(</><g>expected</><d>)</>
 
-Expected: <= <green>-Infinity</>
-Received:    <red>Infinity</>"
+Expected: <= <g>-Infinity</>
+Received:    <r>Infinity</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [0.1, 0.2] 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeGreaterThan<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toBeGreaterThan<d>(</><g>expected</><d>)</>
 
-Expected: > <green>0.2</>
-Received:   <red>0.1</>"
+Expected: > <g>0.2</>
+Received:   <r>0.1</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [0.1, 0.2] 2`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeLessThan<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeLessThan<d>(</><g>expected</><d>)</>
 
-Expected: not < <green>0.2</>
-Received:       <red>0.1</>"
+Expected: not < <g>0.2</>
+Received:       <r>0.1</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [0.1, 0.2] 3`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeGreaterThan<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeGreaterThan<d>(</><g>expected</><d>)</>
 
-Expected: not > <green>0.1</>
-Received:       <red>0.2</>"
+Expected: not > <g>0.1</>
+Received:       <r>0.2</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [0.1, 0.2] 4`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeLessThan<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toBeLessThan<d>(</><g>expected</><d>)</>
 
-Expected: < <green>0.1</>
-Received:   <red>0.2</>"
+Expected: < <g>0.1</>
+Received:   <r>0.2</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [0.1, 0.2] 5`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeGreaterThanOrEqual<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toBeGreaterThanOrEqual<d>(</><g>expected</><d>)</>
 
-Expected: >= <green>0.2</>
-Received:    <red>0.1</>"
+Expected: >= <g>0.2</>
+Received:    <r>0.1</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [0.1, 0.2] 6`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeLessThanOrEqual<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeLessThanOrEqual<d>(</><g>expected</><d>)</>
 
-Expected: not <= <green>0.2</>
-Received:        <red>0.1</>"
+Expected: not <= <g>0.2</>
+Received:        <r>0.1</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [0.1, 0.2] 7`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeGreaterThanOrEqual<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeGreaterThanOrEqual<d>(</><g>expected</><d>)</>
 
-Expected: not >= <green>0.1</>
-Received:        <red>0.2</>"
+Expected: not >= <g>0.1</>
+Received:        <r>0.2</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [0.1, 0.2] 8`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeLessThanOrEqual<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toBeLessThanOrEqual<d>(</><g>expected</><d>)</>
 
-Expected: <= <green>0.1</>
-Received:    <red>0.2</>"
+Expected: <= <g>0.1</>
+Received:    <r>0.2</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [1, 2] 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeGreaterThan<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toBeGreaterThan<d>(</><g>expected</><d>)</>
 
-Expected: > <green>2</>
-Received:   <red>1</>"
+Expected: > <g>2</>
+Received:   <r>1</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [1, 2] 2`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeLessThan<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeLessThan<d>(</><g>expected</><d>)</>
 
-Expected: not < <green>2</>
-Received:       <red>1</>"
+Expected: not < <g>2</>
+Received:       <r>1</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [1, 2] 3`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeGreaterThan<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeGreaterThan<d>(</><g>expected</><d>)</>
 
-Expected: not > <green>1</>
-Received:       <red>2</>"
+Expected: not > <g>1</>
+Received:       <r>2</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [1, 2] 4`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeLessThan<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toBeLessThan<d>(</><g>expected</><d>)</>
 
-Expected: < <green>1</>
-Received:   <red>2</>"
+Expected: < <g>1</>
+Received:   <r>2</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [1, 2] 5`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeGreaterThanOrEqual<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toBeGreaterThanOrEqual<d>(</><g>expected</><d>)</>
 
-Expected: >= <green>2</>
-Received:    <red>1</>"
+Expected: >= <g>2</>
+Received:    <r>1</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [1, 2] 6`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeLessThanOrEqual<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeLessThanOrEqual<d>(</><g>expected</><d>)</>
 
-Expected: not <= <green>2</>
-Received:        <red>1</>"
+Expected: not <= <g>2</>
+Received:        <r>1</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [1, 2] 7`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeGreaterThanOrEqual<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeGreaterThanOrEqual<d>(</><g>expected</><d>)</>
 
-Expected: not >= <green>1</>
-Received:        <red>2</>"
+Expected: not >= <g>1</>
+Received:        <r>2</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [1, 2] 8`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeLessThanOrEqual<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toBeLessThanOrEqual<d>(</><g>expected</><d>)</>
 
-Expected: <= <green>1</>
-Received:    <red>2</>"
+Expected: <= <g>1</>
+Received:    <r>2</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [3, 7] 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeGreaterThan<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toBeGreaterThan<d>(</><g>expected</><d>)</>
 
-Expected: > <green>7</>
-Received:   <red>3</>"
+Expected: > <g>7</>
+Received:   <r>3</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [3, 7] 2`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeLessThan<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeLessThan<d>(</><g>expected</><d>)</>
 
-Expected: not < <green>7</>
-Received:       <red>3</>"
+Expected: not < <g>7</>
+Received:       <r>3</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [3, 7] 3`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeGreaterThan<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeGreaterThan<d>(</><g>expected</><d>)</>
 
-Expected: not > <green>3</>
-Received:       <red>7</>"
+Expected: not > <g>3</>
+Received:       <r>7</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [3, 7] 4`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeLessThan<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toBeLessThan<d>(</><g>expected</><d>)</>
 
-Expected: < <green>3</>
-Received:   <red>7</>"
+Expected: < <g>3</>
+Received:   <r>7</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [3, 7] 5`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeGreaterThanOrEqual<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toBeGreaterThanOrEqual<d>(</><g>expected</><d>)</>
 
-Expected: >= <green>7</>
-Received:    <red>3</>"
+Expected: >= <g>7</>
+Received:    <r>3</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [3, 7] 6`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeLessThanOrEqual<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeLessThanOrEqual<d>(</><g>expected</><d>)</>
 
-Expected: not <= <green>7</>
-Received:        <red>3</>"
+Expected: not <= <g>7</>
+Received:        <r>3</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [3, 7] 7`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeGreaterThanOrEqual<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeGreaterThanOrEqual<d>(</><g>expected</><d>)</>
 
-Expected: not >= <green>3</>
-Received:        <red>7</>"
+Expected: not >= <g>3</>
+Received:        <r>7</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [3, 7] 8`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeLessThanOrEqual<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toBeLessThanOrEqual<d>(</><g>expected</><d>)</>
 
-Expected: <= <green>3</>
-Received:    <red>7</>"
+Expected: <= <g>3</>
+Received:    <r>7</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [5e-324, 1.7976931348623157e+308] 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeGreaterThan<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toBeGreaterThan<d>(</><g>expected</><d>)</>
 
-Expected: > <green>1.7976931348623157e+308</>
-Received:   <red>5e-324</>"
+Expected: > <g>1.7976931348623157e+308</>
+Received:   <r>5e-324</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [5e-324, 1.7976931348623157e+308] 2`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeLessThan<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeLessThan<d>(</><g>expected</><d>)</>
 
-Expected: not < <green>1.7976931348623157e+308</>
-Received:       <red>5e-324</>"
+Expected: not < <g>1.7976931348623157e+308</>
+Received:       <r>5e-324</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [5e-324, 1.7976931348623157e+308] 3`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeGreaterThan<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeGreaterThan<d>(</><g>expected</><d>)</>
 
-Expected: not > <green>5e-324</>
-Received:       <red>1.7976931348623157e+308</>"
+Expected: not > <g>5e-324</>
+Received:       <r>1.7976931348623157e+308</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [5e-324, 1.7976931348623157e+308] 4`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeLessThan<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toBeLessThan<d>(</><g>expected</><d>)</>
 
-Expected: < <green>5e-324</>
-Received:   <red>1.7976931348623157e+308</>"
+Expected: < <g>5e-324</>
+Received:   <r>1.7976931348623157e+308</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [5e-324, 1.7976931348623157e+308] 5`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeGreaterThanOrEqual<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toBeGreaterThanOrEqual<d>(</><g>expected</><d>)</>
 
-Expected: >= <green>1.7976931348623157e+308</>
-Received:    <red>5e-324</>"
+Expected: >= <g>1.7976931348623157e+308</>
+Received:    <r>5e-324</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [5e-324, 1.7976931348623157e+308] 6`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeLessThanOrEqual<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeLessThanOrEqual<d>(</><g>expected</><d>)</>
 
-Expected: not <= <green>1.7976931348623157e+308</>
-Received:        <red>5e-324</>"
+Expected: not <= <g>1.7976931348623157e+308</>
+Received:        <r>5e-324</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [5e-324, 1.7976931348623157e+308] 7`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeGreaterThanOrEqual<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeGreaterThanOrEqual<d>(</><g>expected</><d>)</>
 
-Expected: not >= <green>5e-324</>
-Received:        <red>1.7976931348623157e+308</>"
+Expected: not >= <g>5e-324</>
+Received:        <r>1.7976931348623157e+308</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [5e-324, 1.7976931348623157e+308] 8`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeLessThanOrEqual<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toBeLessThanOrEqual<d>(</><g>expected</><d>)</>
 
-Expected: <= <green>5e-324</>
-Received:    <red>1.7976931348623157e+308</>"
+Expected: <= <g>5e-324</>
+Received:    <r>1.7976931348623157e+308</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [9, 18] 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeGreaterThan<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toBeGreaterThan<d>(</><g>expected</><d>)</>
 
-Expected: > <green>18</>
-Received:   <red>9</>"
+Expected: > <g>18</>
+Received:   <r>9</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [9, 18] 2`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeLessThan<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeLessThan<d>(</><g>expected</><d>)</>
 
-Expected: not < <green>18</>
-Received:       <red>9</>"
+Expected: not < <g>18</>
+Received:       <r>9</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [9, 18] 3`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeGreaterThan<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeGreaterThan<d>(</><g>expected</><d>)</>
 
-Expected: not > <green>9</>
-Received:       <red>18</>"
+Expected: not > <g>9</>
+Received:       <r>18</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [9, 18] 4`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeLessThan<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toBeLessThan<d>(</><g>expected</><d>)</>
 
-Expected: < <green>9</>
-Received:   <red>18</>"
+Expected: < <g>9</>
+Received:   <r>18</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [9, 18] 5`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeGreaterThanOrEqual<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toBeGreaterThanOrEqual<d>(</><g>expected</><d>)</>
 
-Expected: >= <green>18</>
-Received:    <red>9</>"
+Expected: >= <g>18</>
+Received:    <r>9</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [9, 18] 6`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeLessThanOrEqual<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeLessThanOrEqual<d>(</><g>expected</><d>)</>
 
-Expected: not <= <green>18</>
-Received:        <red>9</>"
+Expected: not <= <g>18</>
+Received:        <r>9</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [9, 18] 7`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeGreaterThanOrEqual<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeGreaterThanOrEqual<d>(</><g>expected</><d>)</>
 
-Expected: not >= <green>9</>
-Received:        <red>18</>"
+Expected: not >= <g>9</>
+Received:        <r>18</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [9, 18] 8`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeLessThanOrEqual<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toBeLessThanOrEqual<d>(</><g>expected</><d>)</>
 
-Expected: <= <green>9</>
-Received:    <red>18</>"
+Expected: <= <g>9</>
+Received:    <r>18</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [17, 34] 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeGreaterThan<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toBeGreaterThan<d>(</><g>expected</><d>)</>
 
-Expected: > <green>34</>
-Received:   <red>17</>"
+Expected: > <g>34</>
+Received:   <r>17</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [17, 34] 2`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeLessThan<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeLessThan<d>(</><g>expected</><d>)</>
 
-Expected: not < <green>34</>
-Received:       <red>17</>"
+Expected: not < <g>34</>
+Received:       <r>17</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [17, 34] 3`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeGreaterThan<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeGreaterThan<d>(</><g>expected</><d>)</>
 
-Expected: not > <green>17</>
-Received:       <red>34</>"
+Expected: not > <g>17</>
+Received:       <r>34</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [17, 34] 4`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeLessThan<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toBeLessThan<d>(</><g>expected</><d>)</>
 
-Expected: < <green>17</>
-Received:   <red>34</>"
+Expected: < <g>17</>
+Received:   <r>34</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [17, 34] 5`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeGreaterThanOrEqual<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toBeGreaterThanOrEqual<d>(</><g>expected</><d>)</>
 
-Expected: >= <green>34</>
-Received:    <red>17</>"
+Expected: >= <g>34</>
+Received:    <r>17</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [17, 34] 6`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeLessThanOrEqual<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeLessThanOrEqual<d>(</><g>expected</><d>)</>
 
-Expected: not <= <green>34</>
-Received:        <red>17</>"
+Expected: not <= <g>34</>
+Received:        <r>17</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [17, 34] 7`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeGreaterThanOrEqual<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeGreaterThanOrEqual<d>(</><g>expected</><d>)</>
 
-Expected: not >= <green>17</>
-Received:        <red>34</>"
+Expected: not >= <g>17</>
+Received:        <r>34</>
 `;
 
 exports[`.toBeGreaterThan(), .toBeLessThan(), .toBeGreaterThanOrEqual(), .toBeLessThanOrEqual() throws: [17, 34] 8`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeLessThanOrEqual<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toBeLessThanOrEqual<d>(</><g>expected</><d>)</>
 
-Expected: <= <green>17</>
-Received:    <red>34</>"
+Expected: <= <g>17</>
+Received:    <r>34</>
 `;
 
 exports[`.toBeInstanceOf() failing "a" and [Function String] 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeInstanceOf<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toBeInstanceOf<d>(</><g>expected</><d>)</>
 
-Expected constructor: <green>String</>
+Expected constructor: <g>String</>
 
 Received value has no prototype
-Received value: <red>\\"a\\"</>"
+Received value: <r>"a"</>
 `;
 
 exports[`.toBeInstanceOf() failing /\\w+/ and [Function anonymous] 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeInstanceOf<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toBeInstanceOf<d>(</><g>expected</><d>)</>
 
 Expected constructor name is an empty string
-Received constructor: <red>RegExp</>
-"
+Received constructor: <r>RegExp</>
+
 `;
 
 exports[`.toBeInstanceOf() failing {} and [Function A] 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeInstanceOf<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toBeInstanceOf<d>(</><g>expected</><d>)</>
 
-Expected constructor: <green>A</>
+Expected constructor: <g>A</>
 
 Received value has no prototype
-Received value: <red>{}</>"
+Received value: <r>{}</>
 `;
 
 exports[`.toBeInstanceOf() failing {} and [Function B] 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeInstanceOf<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toBeInstanceOf<d>(</><g>expected</><d>)</>
 
-Expected constructor: <green>B</>
-Received constructor: <red>A</>
-"
+Expected constructor: <g>B</>
+Received constructor: <r>A</>
+
 `;
 
 exports[`.toBeInstanceOf() failing {} and [Function RegExp] 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeInstanceOf<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toBeInstanceOf<d>(</><g>expected</><d>)</>
 
-Expected constructor: <green>RegExp</>
+Expected constructor: <g>RegExp</>
 Received constructor name is an empty string
-"
+
 `;
 
 exports[`.toBeInstanceOf() failing 1 and [Function Number] 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeInstanceOf<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toBeInstanceOf<d>(</><g>expected</><d>)</>
 
-Expected constructor: <green>Number</>
+Expected constructor: <g>Number</>
 
 Received value has no prototype
-Received value: <red>1</>"
+Received value: <r>1</>
 `;
 
 exports[`.toBeInstanceOf() failing null and [Function String] 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeInstanceOf<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toBeInstanceOf<d>(</><g>expected</><d>)</>
 
-Expected constructor: <green>String</>
+Expected constructor: <g>String</>
 
 Received value has no prototype
-Received value: <red>null</>"
+Received value: <r>null</>
 `;
 
 exports[`.toBeInstanceOf() failing true and [Function Boolean] 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeInstanceOf<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toBeInstanceOf<d>(</><g>expected</><d>)</>
 
-Expected constructor: <green>Boolean</>
+Expected constructor: <g>Boolean</>
 
 Received value has no prototype
-Received value: <red>true</>"
+Received value: <r>true</>
 `;
 
 exports[`.toBeInstanceOf() failing undefined and [Function String] 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeInstanceOf<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toBeInstanceOf<d>(</><g>expected</><d>)</>
 
-Expected constructor: <green>String</>
+Expected constructor: <g>String</>
 
 Received value has no prototype
-Received value: <red>undefined</>"
+Received value: <r>undefined</>
 `;
 
 exports[`.toBeInstanceOf() passing [] and [Function Array] 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeInstanceOf<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeInstanceOf<d>(</><g>expected</><d>)</>
 
-Expected constructor: not <green>Array</>
-"
+Expected constructor: not <g>Array</>
+
 `;
 
 exports[`.toBeInstanceOf() passing {} and [Function A] 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeInstanceOf<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeInstanceOf<d>(</><g>expected</><d>)</>
 
-Expected constructor: not <green>A</>
-"
+Expected constructor: not <g>A</>
+
 `;
 
 exports[`.toBeInstanceOf() passing {} and [Function B] 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeInstanceOf<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeInstanceOf<d>(</><g>expected</><d>)</>
 
-Expected constructor: not <green>B</>
-Received constructor:     <red>C</> extends <green>B</>
-"
+Expected constructor: not <g>B</>
+Received constructor:     <r>C</> extends <g>B</>
+
 `;
 
 exports[`.toBeInstanceOf() passing {} and [Function B] 2`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeInstanceOf<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeInstanceOf<d>(</><g>expected</><d>)</>
 
-Expected constructor: not <green>B</>
-Received constructor:     <red>E</> extends … extends <green>B</>
-"
+Expected constructor: not <g>B</>
+Received constructor:     <r>E</> extends … extends <g>B</>
+
 `;
 
 exports[`.toBeInstanceOf() passing {} and [Function B] 3`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeInstanceOf<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeInstanceOf<d>(</><g>expected</><d>)</>
 
-Expected constructor: not <green>B</>
+Expected constructor: not <g>B</>
 Received constructor name is not a string
-"
+
 `;
 
 exports[`.toBeInstanceOf() passing {} and [Function anonymous] 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeInstanceOf<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeInstanceOf<d>(</><g>expected</><d>)</>
 
 Expected constructor name is an empty string
-Received constructor: <red>SubHasNameProp</>
-"
+Received constructor: <r>SubHasNameProp</>
+
 `;
 
 exports[`.toBeInstanceOf() passing {} and [Function name() {}] 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeInstanceOf<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeInstanceOf<d>(</><g>expected</><d>)</>
 
 Expected constructor name is not a string
-"
+
 `;
 
 exports[`.toBeInstanceOf() passing Map {} and [Function Map] 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeInstanceOf<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeInstanceOf<d>(</><g>expected</><d>)</>
 
-Expected constructor: not <green>Map</>
-"
+Expected constructor: not <g>Map</>
+
 `;
 
 exports[`.toBeInstanceOf() throws if constructor is not a function 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeInstanceOf<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toBeInstanceOf<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a function
+<b>Matcher error</>: <g>expected</> value must be a function
 
 Expected has type:  number
-Expected has value: <green>4</>"
+Expected has value: <g>4</>
 `;
 
 exports[`.toBeNaN() {pass: true} expect(NaN).toBeNaN() 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeNaN<dim>()</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeNaN<d>()</>
 
-Received: <red>NaN</>"
+Received: <r>NaN</>
 `;
 
 exports[`.toBeNaN() {pass: true} expect(NaN).toBeNaN() 2`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeNaN<dim>()</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeNaN<d>()</>
 
-Received: <red>NaN</>"
+Received: <r>NaN</>
 `;
 
 exports[`.toBeNaN() {pass: true} expect(NaN).toBeNaN() 3`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeNaN<dim>()</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeNaN<d>()</>
 
-Received: <red>NaN</>"
+Received: <r>NaN</>
 `;
 
 exports[`.toBeNaN() {pass: true} expect(NaN).toBeNaN() 4`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeNaN<dim>()</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeNaN<d>()</>
 
-Received: <red>NaN</>"
+Received: <r>NaN</>
 `;
 
 exports[`.toBeNaN() throws 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeNaN<dim>()</>
+<d>expect(</><r>received</><d>).</>toBeNaN<d>()</>
 
-Received: <red>1</>"
+Received: <r>1</>
 `;
 
 exports[`.toBeNaN() throws 2`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeNaN<dim>()</>
+<d>expect(</><r>received</><d>).</>toBeNaN<d>()</>
 
-Received: <red>\\"\\"</>"
+Received: <r>""</>
 `;
 
 exports[`.toBeNaN() throws 3`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeNaN<dim>()</>
+<d>expect(</><r>received</><d>).</>toBeNaN<d>()</>
 
-Received: <red>null</>"
+Received: <r>null</>
 `;
 
 exports[`.toBeNaN() throws 4`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeNaN<dim>()</>
+<d>expect(</><r>received</><d>).</>toBeNaN<d>()</>
 
-Received: <red>undefined</>"
+Received: <r>undefined</>
 `;
 
 exports[`.toBeNaN() throws 5`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeNaN<dim>()</>
+<d>expect(</><r>received</><d>).</>toBeNaN<d>()</>
 
-Received: <red>{}</>"
+Received: <r>{}</>
 `;
 
 exports[`.toBeNaN() throws 6`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeNaN<dim>()</>
+<d>expect(</><r>received</><d>).</>toBeNaN<d>()</>
 
-Received: <red>[]</>"
+Received: <r>[]</>
 `;
 
 exports[`.toBeNaN() throws 7`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeNaN<dim>()</>
+<d>expect(</><r>received</><d>).</>toBeNaN<d>()</>
 
-Received: <red>0.2</>"
+Received: <r>0.2</>
 `;
 
 exports[`.toBeNaN() throws 8`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeNaN<dim>()</>
+<d>expect(</><r>received</><d>).</>toBeNaN<d>()</>
 
-Received: <red>0</>"
+Received: <r>0</>
 `;
 
 exports[`.toBeNaN() throws 9`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeNaN<dim>()</>
+<d>expect(</><r>received</><d>).</>toBeNaN<d>()</>
 
-Received: <red>Infinity</>"
+Received: <r>Infinity</>
 `;
 
 exports[`.toBeNaN() throws 10`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeNaN<dim>()</>
+<d>expect(</><r>received</><d>).</>toBeNaN<d>()</>
 
-Received: <red>-Infinity</>"
+Received: <r>-Infinity</>
 `;
 
 exports[`.toBeNull() fails for '"a"' 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeNull<dim>()</>
+<d>expect(</><r>received</><d>).</>toBeNull<d>()</>
 
-Received: <red>\\"a\\"</>"
+Received: <r>"a"</>
 `;
 
 exports[`.toBeNull() fails for '[]' 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeNull<dim>()</>
+<d>expect(</><r>received</><d>).</>toBeNull<d>()</>
 
-Received: <red>[]</>"
+Received: <r>[]</>
 `;
 
 exports[`.toBeNull() fails for '[Function anonymous]' 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeNull<dim>()</>
+<d>expect(</><r>received</><d>).</>toBeNull<d>()</>
 
-Received: <red>[Function anonymous]</>"
+Received: <r>[Function anonymous]</>
 `;
 
 exports[`.toBeNull() fails for '{}' 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeNull<dim>()</>
+<d>expect(</><r>received</><d>).</>toBeNull<d>()</>
 
-Received: <red>{}</>"
+Received: <r>{}</>
 `;
 
 exports[`.toBeNull() fails for '0.5' 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeNull<dim>()</>
+<d>expect(</><r>received</><d>).</>toBeNull<d>()</>
 
-Received: <red>0.5</>"
+Received: <r>0.5</>
 `;
 
 exports[`.toBeNull() fails for '1' 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeNull<dim>()</>
+<d>expect(</><r>received</><d>).</>toBeNull<d>()</>
 
-Received: <red>1</>"
+Received: <r>1</>
 `;
 
 exports[`.toBeNull() fails for 'Infinity' 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeNull<dim>()</>
+<d>expect(</><r>received</><d>).</>toBeNull<d>()</>
 
-Received: <red>Infinity</>"
+Received: <r>Infinity</>
 `;
 
 exports[`.toBeNull() fails for 'Map {}' 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeNull<dim>()</>
+<d>expect(</><r>received</><d>).</>toBeNull<d>()</>
 
-Received: <red>Map {}</>"
+Received: <r>Map {}</>
 `;
 
 exports[`.toBeNull() fails for 'true' 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeNull<dim>()</>
+<d>expect(</><r>received</><d>).</>toBeNull<d>()</>
 
-Received: <red>true</>"
+Received: <r>true</>
 `;
 
 exports[`.toBeNull() fails for null with .not 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeNull<dim>()</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeNull<d>()</>
 
-Received: <red>null</>"
+Received: <r>null</>
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() '""' is falsy 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeTruthy<dim>()</>
+<d>expect(</><r>received</><d>).</>toBeTruthy<d>()</>
 
-Received: <red>\\"\\"</>"
+Received: <r>""</>
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() '""' is falsy 2`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeFalsy<dim>()</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeFalsy<d>()</>
 
-Received: <red>\\"\\"</>"
+Received: <r>""</>
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() '"a"' is truthy 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeTruthy<dim>()</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeTruthy<d>()</>
 
-Received: <red>\\"a\\"</>"
+Received: <r>"a"</>
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() '"a"' is truthy 2`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeFalsy<dim>()</>
+<d>expect(</><r>received</><d>).</>toBeFalsy<d>()</>
 
-Received: <red>\\"a\\"</>"
+Received: <r>"a"</>
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() '[]' is truthy 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeTruthy<dim>()</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeTruthy<d>()</>
 
-Received: <red>[]</>"
+Received: <r>[]</>
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() '[]' is truthy 2`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeFalsy<dim>()</>
+<d>expect(</><r>received</><d>).</>toBeFalsy<d>()</>
 
-Received: <red>[]</>"
+Received: <r>[]</>
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() '[Function anonymous]' is truthy 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeTruthy<dim>()</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeTruthy<d>()</>
 
-Received: <red>[Function anonymous]</>"
+Received: <r>[Function anonymous]</>
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() '[Function anonymous]' is truthy 2`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeFalsy<dim>()</>
+<d>expect(</><r>received</><d>).</>toBeFalsy<d>()</>
 
-Received: <red>[Function anonymous]</>"
+Received: <r>[Function anonymous]</>
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() '{}' is truthy 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeTruthy<dim>()</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeTruthy<d>()</>
 
-Received: <red>{}</>"
+Received: <r>{}</>
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() '{}' is truthy 2`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeFalsy<dim>()</>
+<d>expect(</><r>received</><d>).</>toBeFalsy<d>()</>
 
-Received: <red>{}</>"
+Received: <r>{}</>
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() '0' is falsy 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeTruthy<dim>()</>
+<d>expect(</><r>received</><d>).</>toBeTruthy<d>()</>
 
-Received: <red>0</>"
+Received: <r>0</>
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() '0' is falsy 2`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeFalsy<dim>()</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeFalsy<d>()</>
 
-Received: <red>0</>"
+Received: <r>0</>
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() '0.5' is truthy 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeTruthy<dim>()</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeTruthy<d>()</>
 
-Received: <red>0.5</>"
+Received: <r>0.5</>
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() '0.5' is truthy 2`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeFalsy<dim>()</>
+<d>expect(</><r>received</><d>).</>toBeFalsy<d>()</>
 
-Received: <red>0.5</>"
+Received: <r>0.5</>
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() '1' is truthy 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeTruthy<dim>()</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeTruthy<d>()</>
 
-Received: <red>1</>"
+Received: <r>1</>
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() '1' is truthy 2`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeFalsy<dim>()</>
+<d>expect(</><r>received</><d>).</>toBeFalsy<d>()</>
 
-Received: <red>1</>"
+Received: <r>1</>
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() 'Infinity' is truthy 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeTruthy<dim>()</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeTruthy<d>()</>
 
-Received: <red>Infinity</>"
+Received: <r>Infinity</>
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() 'Infinity' is truthy 2`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeFalsy<dim>()</>
+<d>expect(</><r>received</><d>).</>toBeFalsy<d>()</>
 
-Received: <red>Infinity</>"
+Received: <r>Infinity</>
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() 'Map {}' is truthy 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeTruthy<dim>()</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeTruthy<d>()</>
 
-Received: <red>Map {}</>"
+Received: <r>Map {}</>
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() 'Map {}' is truthy 2`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeFalsy<dim>()</>
+<d>expect(</><r>received</><d>).</>toBeFalsy<d>()</>
 
-Received: <red>Map {}</>"
+Received: <r>Map {}</>
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() 'NaN' is falsy 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeTruthy<dim>()</>
+<d>expect(</><r>received</><d>).</>toBeTruthy<d>()</>
 
-Received: <red>NaN</>"
+Received: <r>NaN</>
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() 'NaN' is falsy 2`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeFalsy<dim>()</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeFalsy<d>()</>
 
-Received: <red>NaN</>"
+Received: <r>NaN</>
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() 'false' is falsy 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeTruthy<dim>()</>
+<d>expect(</><r>received</><d>).</>toBeTruthy<d>()</>
 
-Received: <red>false</>"
+Received: <r>false</>
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() 'false' is falsy 2`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeFalsy<dim>()</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeFalsy<d>()</>
 
-Received: <red>false</>"
+Received: <r>false</>
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() 'null' is falsy 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeTruthy<dim>()</>
+<d>expect(</><r>received</><d>).</>toBeTruthy<d>()</>
 
-Received: <red>null</>"
+Received: <r>null</>
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() 'null' is falsy 2`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeFalsy<dim>()</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeFalsy<d>()</>
 
-Received: <red>null</>"
+Received: <r>null</>
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() 'true' is truthy 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeTruthy<dim>()</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeTruthy<d>()</>
 
-Received: <red>true</>"
+Received: <r>true</>
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() 'true' is truthy 2`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeFalsy<dim>()</>
+<d>expect(</><r>received</><d>).</>toBeFalsy<d>()</>
 
-Received: <red>true</>"
+Received: <r>true</>
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() 'undefined' is falsy 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeTruthy<dim>()</>
+<d>expect(</><r>received</><d>).</>toBeTruthy<d>()</>
 
-Received: <red>undefined</>"
+Received: <r>undefined</>
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() 'undefined' is falsy 2`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeFalsy<dim>()</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeFalsy<d>()</>
 
-Received: <red>undefined</>"
+Received: <r>undefined</>
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() does not accept arguments 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeTruthy<dim>()</>
+<d>expect(</><r>received</><d>).</>toBeTruthy<d>()</>
 
-<bold>Matcher error</>: this matcher must not have an expected argument
+<b>Matcher error</>: this matcher must not have an expected argument
 
-Expected has value: <green>null</>"
+Expected has value: <g>null</>
 `;
 
 exports[`.toBeTruthy(), .toBeFalsy() does not accept arguments 2`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeFalsy<dim>()</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeFalsy<d>()</>
 
-<bold>Matcher error</>: this matcher must not have an expected argument
+<b>Matcher error</>: this matcher must not have an expected argument
 
-Expected has value: <green>null</>"
+Expected has value: <g>null</>
 `;
 
 exports[`.toContain(), .toContainEqual() '"11112111"' contains '"2"' 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toContain<dim>(</><green>expected</><dim>) // indexOf</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toContain<d>(</><g>expected</><d>) // indexOf</>
 
-Expected substring: not <green>\\"2\\"</>
-Received string:        <red>\\"1111<inverse>2</>111\\"</>"
+Expected substring: not <g>"2"</>
+Received string:        <r>"1111<i>2</i>111"</>
 `;
 
 exports[`.toContain(), .toContainEqual() '"abcdef"' contains '"abc"' 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toContain<dim>(</><green>expected</><dim>) // indexOf</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toContain<d>(</><g>expected</><d>) // indexOf</>
 
-Expected substring: not <green>\\"abc\\"</>
-Received string:        <red>\\"<inverse>abc</>def\\"</>"
+Expected substring: not <g>"abc"</>
+Received string:        <r>"<i>abc</i>def"</>
 `;
 
 exports[`.toContain(), .toContainEqual() '["a", "b", "c", "d"]' contains '"a"' 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toContain<dim>(</><green>expected</><dim>) // indexOf</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toContain<d>(</><g>expected</><d>) // indexOf</>
 
-Expected value: not <green>\\"a\\"</>
-Received array:     <red>[<inverse>\\"a\\"</>, \\"b\\", \\"c\\", \\"d\\"]</>"
+Expected value: not <g>"a"</>
+Received array:     <r>[<i>"a"</i>, "b", "c", "d"]</>
 `;
 
 exports[`.toContain(), .toContainEqual() '["a", "b", "c", "d"]' contains a value equal to '"a"' 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toContainEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toContainEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected value: not <green>\\"a\\"</>
-Received array:     <red>[<inverse>\\"a\\"</>, \\"b\\", \\"c\\", \\"d\\"]</>"
+Expected value: not <g>"a"</>
+Received array:     <r>[<i>"a"</i>, "b", "c", "d"]</>
 `;
 
 exports[`.toContain(), .toContainEqual() '[{"a": "b"}, {"a": "c"}]' contains a value equal to '{"a": "b"}' 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toContainEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toContainEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected value: not <green>{\\"a\\": \\"b\\"}</>
-Received array:     <red>[<inverse>{\\"a\\": \\"b\\"}</>, {\\"a\\": \\"c\\"}]</>"
+Expected value: not <g>{"a": "b"}</>
+Received array:     <r>[<i>{"a": "b"}</i>, {"a": "c"}]</>
 `;
 
 exports[`.toContain(), .toContainEqual() '[{"a": "b"}, {"a": "c"}]' does not contain a value equal to'{"a": "d"}' 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toContainEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>toContainEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected value: <green>{\\"a\\": \\"d\\"}</>
-Received array: <red>[{\\"a\\": \\"b\\"}, {\\"a\\": \\"c\\"}]</>"
+Expected value: <g>{"a": "d"}</>
+Received array: <r>[{"a": "b"}, {"a": "c"}]</>
 `;
 
 exports[`.toContain(), .toContainEqual() '[{}, []]' does not contain '[]' 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toContain<dim>(</><green>expected</><dim>) // indexOf</>
+<d>expect(</><r>received</><d>).</>toContain<d>(</><g>expected</><d>) // indexOf</>
 
-Expected value: <green>[]</>
-Received array: <red>[{}, []]</>
+Expected value: <g>[]</>
+Received array: <r>[{}, []]</>
 
-<dim>Looks like you wanted to test for object/array equality with the stricter \`toContain\` matcher. You probably need to use \`toContainEqual\` instead.</>"
+<d>Looks like you wanted to test for object/array equality with the stricter \`toContain\` matcher. You probably need to use \`toContainEqual\` instead.</>
 `;
 
 exports[`.toContain(), .toContainEqual() '[{}, []]' does not contain '{}' 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toContain<dim>(</><green>expected</><dim>) // indexOf</>
+<d>expect(</><r>received</><d>).</>toContain<d>(</><g>expected</><d>) // indexOf</>
 
-Expected value: <green>{}</>
-Received array: <red>[{}, []]</>
+Expected value: <g>{}</>
+Received array: <r>[{}, []]</>
 
-<dim>Looks like you wanted to test for object/array equality with the stricter \`toContain\` matcher. You probably need to use \`toContainEqual\` instead.</>"
+<d>Looks like you wanted to test for object/array equality with the stricter \`toContain\` matcher. You probably need to use \`toContainEqual\` instead.</>
 `;
 
 exports[`.toContain(), .toContainEqual() '[0, 1]' contains '1' 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toContain<dim>(</><green>expected</><dim>) // indexOf</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toContain<d>(</><g>expected</><d>) // indexOf</>
 
-Expected value:  not <green>1</>
-Received object:     <red>[0, 1]</>"
+Expected value:  not <g>1</>
+Received object:     <r>[0, 1]</>
 `;
 
 exports[`.toContain(), .toContainEqual() '[0, 1]' contains a value equal to '1' 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toContainEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toContainEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected value:  not <green>1</>
-Received object:     <red>[0, 1]</>"
+Expected value:  not <g>1</>
+Received object:     <r>[0, 1]</>
 `;
 
 exports[`.toContain(), .toContainEqual() '[1, 2, 3, 4]' contains '1' 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toContain<dim>(</><green>expected</><dim>) // indexOf</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toContain<d>(</><g>expected</><d>) // indexOf</>
 
-Expected value: not <green>1</>
-Received array:     <red>[<inverse>1</>, 2, 3, 4]</>"
+Expected value: not <g>1</>
+Received array:     <r>[<i>1</i>, 2, 3, 4]</>
 `;
 
 exports[`.toContain(), .toContainEqual() '[1, 2, 3, 4]' contains a value equal to '1' 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toContainEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toContainEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected value: not <green>1</>
-Received array:     <red>[<inverse>1</>, 2, 3, 4]</>"
+Expected value: not <g>1</>
+Received array:     <r>[<i>1</i>, 2, 3, 4]</>
 `;
 
 exports[`.toContain(), .toContainEqual() '[1, 2, 3]' does not contain '4' 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toContain<dim>(</><green>expected</><dim>) // indexOf</>
+<d>expect(</><r>received</><d>).</>toContain<d>(</><g>expected</><d>) // indexOf</>
 
-Expected value: <green>4</>
-Received array: <red>[1, 2, 3]</>"
+Expected value: <g>4</>
+Received array: <r>[1, 2, 3]</>
 `;
 
 exports[`.toContain(), .toContainEqual() '[Symbol(a)]' contains 'Symbol(a)' 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toContain<dim>(</><green>expected</><dim>) // indexOf</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toContain<d>(</><g>expected</><d>) // indexOf</>
 
-Expected value: not <green>Symbol(a)</>
-Received array:     <red>[<inverse>Symbol(a)</>]</>"
+Expected value: not <g>Symbol(a)</>
+Received array:     <r>[<i>Symbol(a)</i>]</>
 `;
 
 exports[`.toContain(), .toContainEqual() '[Symbol(a)]' contains a value equal to 'Symbol(a)' 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toContainEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toContainEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected value: not <green>Symbol(a)</>
-Received array:     <red>[<inverse>Symbol(a)</>]</>"
+Expected value: not <g>Symbol(a)</>
+Received array:     <r>[<i>Symbol(a)</i>]</>
 `;
 
 exports[`.toContain(), .toContainEqual() '[null, undefined]' does not contain '1' 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toContain<dim>(</><green>expected</><dim>) // indexOf</>
+<d>expect(</><r>received</><d>).</>toContain<d>(</><g>expected</><d>) // indexOf</>
 
-Expected value: <green>1</>
-Received array: <red>[null, undefined]</>"
+Expected value: <g>1</>
+Received array: <r>[null, undefined]</>
 `;
 
 exports[`.toContain(), .toContainEqual() '[undefined, null]' contains 'null' 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toContain<dim>(</><green>expected</><dim>) // indexOf</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toContain<d>(</><g>expected</><d>) // indexOf</>
 
-Expected value: not <green>null</>
-Received array:     <red>[undefined, <inverse>null</>]</>"
+Expected value: not <g>null</>
+Received array:     <r>[undefined, <i>null</i>]</>
 `;
 
 exports[`.toContain(), .toContainEqual() '[undefined, null]' contains 'undefined' 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toContain<dim>(</><green>expected</><dim>) // indexOf</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toContain<d>(</><g>expected</><d>) // indexOf</>
 
-Expected value: not <green>undefined</>
-Received array:     <red>[<inverse>undefined</>, null]</>"
+Expected value: not <g>undefined</>
+Received array:     <r>[<i>undefined</i>, null]</>
 `;
 
 exports[`.toContain(), .toContainEqual() '[undefined, null]' contains a value equal to 'null' 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toContainEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toContainEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected value: not <green>null</>
-Received array:     <red>[undefined, <inverse>null</>]</>"
+Expected value: not <g>null</>
+Received array:     <r>[undefined, <i>null</i>]</>
 `;
 
 exports[`.toContain(), .toContainEqual() '[undefined, null]' contains a value equal to 'undefined' 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toContainEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toContainEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected value: not <green>undefined</>
-Received array:     <red>[<inverse>undefined</>, null]</>"
+Expected value: not <g>undefined</>
+Received array:     <r>[<i>undefined</i>, null]</>
 `;
 
 exports[`.toContain(), .toContainEqual() 'Set {"abc", "def"}' contains '"abc"' 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toContain<dim>(</><green>expected</><dim>) // indexOf</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toContain<d>(</><g>expected</><d>) // indexOf</>
 
-Expected value: not <green>\\"abc\\"</>
-Received set:       <red>Set {\\"abc\\", \\"def\\"}</>"
+Expected value: not <g>"abc"</>
+Received set:       <r>Set {"abc", "def"}</>
 `;
 
 exports[`.toContain(), .toContainEqual() 'Set {1, 2, 3, 4}' contains a value equal to '1' 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toContainEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toContainEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected value: not <green>1</>
-Received set:       <red>Set {1, 2, 3, 4}</>"
+Expected value: not <g>1</>
+Received set:       <r>Set {1, 2, 3, 4}</>
 `;
 
 exports[`.toContain(), .toContainEqual() error cases 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toContain<dim>(</><green>expected</><dim>) // indexOf</>
+<d>expect(</><r>received</><d>).</>toContain<d>(</><g>expected</><d>) // indexOf</>
 
-<bold>Matcher error</>: <red>received</> value must not be null nor undefined
+<b>Matcher error</>: <r>received</> value must not be null nor undefined
 
-Received has value: <red>null</>"
+Received has value: <r>null</>
 `;
 
 exports[`.toContain(), .toContainEqual() error cases for toContainEqual 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toContainEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>toContainEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<bold>Matcher error</>: <red>received</> value must not be null nor undefined
+<b>Matcher error</>: <r>received</> value must not be null nor undefined
 
-Received has value: <red>null</>"
+Received has value: <r>null</>
 `;
 
 exports[`.toEqual() {pass: false} expect("1 234,57 $").toEqual("1 234,57 $") 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: <green>\\"1<inverse> </>234,57<inverse> </>$\\"</>
-Received: <red>\\"1<inverse> </>234,57<inverse> </>$\\"</>"
+Expected: <g>"1<i> </i>234,57<i> </i>$"</>
+Received: <r>"1<i> </i>234,57<i> </i>$"</>
 `;
 
 exports[`.toEqual() {pass: false} expect("Eve").toEqual({"asymmetricMatch": [Function asymmetricMatch]}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: <green>{\\"asymmetricMatch\\": [Function asymmetricMatch]}</>
-Received: <red>\\"Eve\\"</>"
+Expected: <g>{"asymmetricMatch": [Function asymmetricMatch]}</>
+Received: <r>"Eve"</>
 `;
 
 exports[`.toEqual() {pass: false} expect("abd").toEqual(StringContaining "bc") 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: <green>StringContaining \\"bc\\"</>
-Received: <red>\\"abd\\"</>"
+Expected: <g>StringContaining "bc"</>
+Received: <r>"abd"</>
 `;
 
 exports[`.toEqual() {pass: false} expect("abd").toEqual(StringMatching /bc/i) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: <green>StringMatching /bc/i</>
-Received: <red>\\"abd\\"</>"
+Expected: <g>StringMatching /bc/i</>
+Received: <r>"abd"</>
 `;
 
 exports[`.toEqual() {pass: false} expect("banana").toEqual("apple") 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: <green>\\"apple\\"</>
-Received: <red>\\"banana\\"</>"
+Expected: <g>"apple"</>
+Received: <r>"banana"</>
 `;
 
 exports[`.toEqual() {pass: false} expect("type TypeName<T> = T extends Function ? \\"function\\" : \\"object\\";").toEqual("type TypeName<T> = T extends Function
 ? \\"function\\"
 : \\"object\\";") 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<green>- type TypeName<T> = T extends Function</>
-<green>- ? \\"function\\"</>
-<green>- : \\"object\\";</>
-<red>+ type TypeName<T> = T extends Function<inverse> </>? \\"function\\"<inverse> </>: \\"object\\";</>"
+<g>- type TypeName<T> = T extends Function</>
+<g>- ? "function"</>
+<g>- : "object";</>
+<r>+ type TypeName<T> = T extends Function<i> </i>? "function"<i> </i>: "object";</>
 `;
 
 exports[`.toEqual() {pass: false} expect([1, 2]).toEqual([2, 1]) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Array [</>
-<green>-   2,</>
-<dim>    1,</>
-<red>+   2,</>
-<dim>  ]</>"
+<d>  Array [</>
+<g>-   2,</>
+<d>    1,</>
+<r>+   2,</>
+<d>  ]</>
 `;
 
 exports[`.toEqual() {pass: false} expect([1, 3]).toEqual(ArrayContaining [1, 2]) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: <green>ArrayContaining [1, 2]</>
-Received: <red>[1, 3]</>"
+Expected: <g>ArrayContaining [1, 2]</>
+Received: <r>[1, 3]</>
 `;
 
 exports[`.toEqual() {pass: false} expect([1]).toEqual([2]) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Array [</>
-<green>-   2,</>
-<red>+   1,</>
-<dim>  ]</>"
+<d>  Array [</>
+<g>-   2,</>
+<r>+   1,</>
+<d>  ]</>
 `;
 
 exports[`.toEqual() {pass: false} expect({"a": 1, "b": 2}).toEqual(ObjectContaining {"a": 2}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: <green>ObjectContaining {\\"a\\": 2}</>
-Received: <red>{\\"a\\": 1, \\"b\\": 2}</>"
+Expected: <g>ObjectContaining {"a": 2}</>
+Received: <r>{"a": 1, "b": 2}</>
 `;
 
 exports[`.toEqual() {pass: false} expect({"a": 1}).toEqual({"a": 2}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Object {</>
-<green>-   \\"a\\": 2,</>
-<red>+   \\"a\\": 1,</>
-<dim>  }</>"
+<d>  Object {</>
+<g>-   "a": 2,</>
+<r>+   "a": 1,</>
+<d>  }</>
 `;
 
 exports[`.toEqual() {pass: false} expect({"a": 5}).toEqual({"b": 6}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Object {</>
-<green>-   \\"b\\": 6,</>
-<red>+   \\"a\\": 5,</>
-<dim>  }</>"
+<d>  Object {</>
+<g>-   "b": 6,</>
+<r>+   "a": 5,</>
+<d>  }</>
 `;
 
 exports[`.toEqual() {pass: false} expect({"nodeName": "div", "nodeType": 1}).toEqual({"nodeName": "p", "nodeType": 1}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Object {</>
-<green>-   \\"nodeName\\": \\"p\\",</>
-<red>+   \\"nodeName\\": \\"div\\",</>
-<dim>    \\"nodeType\\": 1,</>
-<dim>  }</>"
+<d>  Object {</>
+<g>-   "nodeName": "p",</>
+<r>+   "nodeName": "div",</>
+<d>    "nodeType": 1,</>
+<d>  }</>
 `;
 
 exports[`.toEqual() {pass: false} expect({"target": {"nodeType": 1, "value": "a"}}).toEqual({"target": {"nodeType": 1, "value": "b"}}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Object {</>
-<dim>    \\"target\\": Object {</>
-<dim>      \\"nodeType\\": 1,</>
-<green>-     \\"value\\": \\"b\\",</>
-<red>+     \\"value\\": \\"a\\",</>
-<dim>    },</>
-<dim>  }</>"
+<d>  Object {</>
+<d>    "target": Object {</>
+<d>      "nodeType": 1,</>
+<g>-     "value": "b",</>
+<r>+     "value": "a",</>
+<d>    },</>
+<d>  }</>
 `;
 
 exports[`.toEqual() {pass: false} expect(0).toEqual(-0) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: <green>-0</>
-Received: <red>0</>"
+Expected: <g>-0</>
+Received: <r>0</>
 `;
 
 exports[`.toEqual() {pass: false} expect(0).toEqual(5e-324) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: <green>5e-324</>
-Received: <red>0</>"
+Expected: <g>5e-324</>
+Received: <r>0</>
 `;
 
 exports[`.toEqual() {pass: false} expect(1).toEqual(2) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: <green>2</>
-Received: <red>1</>"
+Expected: <g>2</>
+Received: <r>1</>
 `;
 
 exports[`.toEqual() {pass: false} expect(1).toEqual(ArrayContaining [1, 2]) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: <green>ArrayContaining [1, 2]</>
-Received: <red>1</>"
+Expected: <g>ArrayContaining [1, 2]</>
+Received: <r>1</>
 `;
 
 exports[`.toEqual() {pass: false} expect(5e-324).toEqual(0) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: <green>0</>
-Received: <red>5e-324</>"
+Expected: <g>0</>
+Received: <r>5e-324</>
 `;
 
 exports[`.toEqual() {pass: false} expect(Immutable.List [1, 2]).toEqual(Immutable.List [2, 1]) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Immutable.List [</>
-<green>-   2,</>
-<dim>    1,</>
-<red>+   2,</>
-<dim>  ]</>"
+<d>  Immutable.List [</>
+<g>-   2,</>
+<d>    1,</>
+<r>+   2,</>
+<d>  ]</>
 `;
 
 exports[`.toEqual() {pass: false} expect(Immutable.List [1]).toEqual(Immutable.List [2]) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Immutable.List [</>
-<green>-   2,</>
-<red>+   1,</>
-<dim>  ]</>"
+<d>  Immutable.List [</>
+<g>-   2,</>
+<r>+   1,</>
+<d>  ]</>
 `;
 
 exports[`.toEqual() {pass: false} expect(Immutable.Map {"1": Immutable.Map {"2": {"a": 99}}}).toEqual(Immutable.Map {"1": Immutable.Map {"2": {"a": 11}}}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Immutable.Map {</>
-<dim>    \\"1\\": Immutable.Map {</>
-<dim>      \\"2\\": Object {</>
-<green>-       \\"a\\": 11,</>
-<red>+       \\"a\\": 99,</>
-<dim>      },</>
-<dim>    },</>
-<dim>  }</>"
+<d>  Immutable.Map {</>
+<d>    "1": Immutable.Map {</>
+<d>      "2": Object {</>
+<g>-       "a": 11,</>
+<r>+       "a": 99,</>
+<d>      },</>
+<d>    },</>
+<d>  }</>
 `;
 
 exports[`.toEqual() {pass: false} expect(Immutable.Map {"a": 0}).toEqual(Immutable.Map {"b": 0}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Immutable.Map {</>
-<green>-   \\"b\\": 0,</>
-<red>+   \\"a\\": 0,</>
-<dim>  }</>"
+<d>  Immutable.Map {</>
+<g>-   "b": 0,</>
+<r>+   "a": 0,</>
+<d>  }</>
 `;
 
 exports[`.toEqual() {pass: false} expect(Immutable.Map {"v": 1}).toEqual(Immutable.Map {"v": 2}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Immutable.Map {</>
-<green>-   \\"v\\": 2,</>
-<red>+   \\"v\\": 1,</>
-<dim>  }</>"
+<d>  Immutable.Map {</>
+<g>-   "v": 2,</>
+<r>+   "v": 1,</>
+<d>  }</>
 `;
 
 exports[`.toEqual() {pass: false} expect(Immutable.OrderedMap {1: "one", 2: "two"}).toEqual(Immutable.OrderedMap {2: "two", 1: "one"}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Immutable.OrderedMap {</>
-<green>-   2: \\"two\\",</>
-<dim>    1: \\"one\\",</>
-<red>+   2: \\"two\\",</>
-<dim>  }</>"
+<d>  Immutable.OrderedMap {</>
+<g>-   2: "two",</>
+<d>    1: "one",</>
+<r>+   2: "two",</>
+<d>  }</>
 `;
 
 exports[`.toEqual() {pass: false} expect(Immutable.OrderedSet [1, 2]).toEqual(Immutable.OrderedSet [2, 1]) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Immutable.OrderedSet [</>
-<green>-   2,</>
-<dim>    1,</>
-<red>+   2,</>
-<dim>  ]</>"
+<d>  Immutable.OrderedSet [</>
+<g>-   2,</>
+<d>    1,</>
+<r>+   2,</>
+<d>  ]</>
 `;
 
 exports[`.toEqual() {pass: false} expect(Immutable.Set [1, 2]).toEqual(Immutable.Set []) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<green>- Immutable.Set []</>
-<red>+ Immutable.Set [</>
-<red>+   1,</>
-<red>+   2,</>
-<red>+ ]</>"
+<g>- Immutable.Set []</>
+<r>+ Immutable.Set [</>
+<r>+   1,</>
+<r>+   2,</>
+<r>+ ]</>
 `;
 
 exports[`.toEqual() {pass: false} expect(Immutable.Set [1, 2]).toEqual(Immutable.Set [1, 2, 3]) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Immutable.Set [</>
-<dim>    1,</>
-<dim>    2,</>
-<green>-   3,</>
-<dim>  ]</>"
+<d>  Immutable.Set [</>
+<d>    1,</>
+<d>    2,</>
+<g>-   3,</>
+<d>  ]</>
 `;
 
 exports[`.toEqual() {pass: false} expect(Map {"a" => 0}).toEqual(Map {"b" => 0}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Map {</>
-<green>-   \\"b\\" => 0,</>
-<red>+   \\"a\\" => 0,</>
-<dim>  }</>"
+<d>  Map {</>
+<g>-   "b" => 0,</>
+<r>+   "a" => 0,</>
+<d>  }</>
 `;
 
 exports[`.toEqual() {pass: false} expect(Map {"v" => 1}).toEqual(Map {"v" => 2}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Map {</>
-<green>-   \\"v\\" => 2,</>
-<red>+   \\"v\\" => 1,</>
-<dim>  }</>"
+<d>  Map {</>
+<g>-   "v" => 2,</>
+<r>+   "v" => 1,</>
+<d>  }</>
 `;
 
 exports[`.toEqual() {pass: false} expect(Map {["v"] => 1}).toEqual(Map {["v"] => 2}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Map {</>
-<dim>    Array [</>
-<dim>      \\"v\\",</>
-<green>-   ] => 2,</>
-<red>+   ] => 1,</>
-<dim>  }</>"
+<d>  Map {</>
+<d>    Array [</>
+<d>      "v",</>
+<g>-   ] => 2,</>
+<r>+   ] => 1,</>
+<d>  }</>
 `;
 
 exports[`.toEqual() {pass: false} expect(Map {[1] => Map {[1] => "one"}}).toEqual(Map {[1] => Map {[1] => "two"}}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<yellow>@@ -2,8 +2,8 @@</>
-<dim>    Array [</>
-<dim>      1,</>
-<dim>    ] => Map {</>
-<dim>      Array [</>
-<dim>        1,</>
-<green>-     ] => \\"two\\",</>
-<red>+     ] => \\"one\\",</>
-<dim>    },</>
-<dim>  }</>"
+<y>@@ -2,8 +2,8 @@</>
+<d>    Array [</>
+<d>      1,</>
+<d>    ] => Map {</>
+<d>      Array [</>
+<d>        1,</>
+<g>-     ] => "two",</>
+<r>+     ] => "one",</>
+<d>    },</>
+<d>  }</>
 `;
 
 exports[`.toEqual() {pass: false} expect(Map {}).toEqual(Set {}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: <green>Set {}</>
-Received: <red>Map {}</>"
+Expected: <g>Set {}</>
+Received: <r>Map {}</>
 `;
 
 exports[`.toEqual() {pass: false} expect(Map {1 => "one", 2 => "two"}).toEqual(Map {1 => "one"}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Map {</>
-<dim>    1 => \\"one\\",</>
-<red>+   2 => \\"two\\",</>
-<dim>  }</>"
+<d>  Map {</>
+<d>    1 => "one",</>
+<r>+   2 => "two",</>
+<d>  }</>
 `;
 
 exports[`.toEqual() {pass: false} expect(Set {[1], [2]}).toEqual(Set {[1], [2], [2]}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<yellow>@@ -3,9 +3,6 @@</>
-<dim>      1,</>
-<dim>    ],</>
-<dim>    Array [</>
-<dim>      2,</>
-<dim>    ],</>
-<green>-   Array [</>
-<green>-     2,</>
-<green>-   ],</>
-<dim>  }</>"
+<y>@@ -3,9 +3,6 @@</>
+<d>      1,</>
+<d>    ],</>
+<d>    Array [</>
+<d>      2,</>
+<d>    ],</>
+<g>-   Array [</>
+<g>-     2,</>
+<g>-   ],</>
+<d>  }</>
 `;
 
 exports[`.toEqual() {pass: false} expect(Set {[1], [2]}).toEqual(Set {[1], [2], [3]}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<yellow>@@ -3,9 +3,6 @@</>
-<dim>      1,</>
-<dim>    ],</>
-<dim>    Array [</>
-<dim>      2,</>
-<dim>    ],</>
-<green>-   Array [</>
-<green>-     3,</>
-<green>-   ],</>
-<dim>  }</>"
+<y>@@ -3,9 +3,6 @@</>
+<d>      1,</>
+<d>    ],</>
+<d>    Array [</>
+<d>      2,</>
+<d>    ],</>
+<g>-   Array [</>
+<g>-     3,</>
+<g>-   ],</>
+<d>  }</>
 `;
 
 exports[`.toEqual() {pass: false} expect(Set {1, 2}).toEqual(Set {}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<green>- Set {}</>
-<red>+ Set {</>
-<red>+   1,</>
-<red>+   2,</>
-<red>+ }</>"
+<g>- Set {}</>
+<r>+ Set {</>
+<r>+   1,</>
+<r>+   2,</>
+<r>+ }</>
 `;
 
 exports[`.toEqual() {pass: false} expect(Set {1, 2}).toEqual(Set {1, 2, 3}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Set {</>
-<dim>    1,</>
-<dim>    2,</>
-<green>-   3,</>
-<dim>  }</>"
+<d>  Set {</>
+<d>    1,</>
+<d>    2,</>
+<g>-   3,</>
+<d>  }</>
 `;
 
 exports[`.toEqual() {pass: false} expect(Set {Set {1}, Set {2}}).toEqual(Set {Set {1}, Set {3}}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Set {</>
-<dim>    Set {</>
-<dim>      1,</>
-<dim>    },</>
-<dim>    Set {</>
-<green>-     3,</>
-<red>+     2,</>
-<dim>    },</>
-<dim>  }</>"
+<d>  Set {</>
+<d>    Set {</>
+<d>      1,</>
+<d>    },</>
+<d>    Set {</>
+<g>-     3,</>
+<r>+     2,</>
+<d>    },</>
+<d>  }</>
 `;
 
 exports[`.toEqual() {pass: false} expect(false).toEqual(ObjectContaining {"a": 2}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: <green>ObjectContaining {\\"a\\": 2}</>
-Received: <red>false</>"
+Expected: <g>ObjectContaining {"a": 2}</>
+Received: <r>false</>
 `;
 
 exports[`.toEqual() {pass: false} expect(null).toEqual(undefined) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: <green>undefined</>
-Received: <red>null</>"
+Expected: <g>undefined</>
+Received: <r>null</>
 `;
 
 exports[`.toEqual() {pass: false} expect(true).toEqual(false) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: <green>false</>
-Received: <red>true</>"
+Expected: <g>false</>
+Received: <r>true</>
 `;
 
 exports[`.toEqual() {pass: false} expect(undefined).toEqual(Any<Function>) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: <green>Any<Function></>
-Received: <red>undefined</>"
+Expected: <g>Any<Function></>
+Received: <r>undefined</>
 `;
 
 exports[`.toEqual() {pass: false} expect(undefined).toEqual(Anything) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: <green>Anything</>
-Received: <red>undefined</>"
+Expected: <g>Anything</>
+Received: <r>undefined</>
 `;
 
 exports[`.toEqual() {pass: true} expect("Alice").not.toEqual({"asymmetricMatch": [Function asymmetricMatch]}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: not <green>{\\"asymmetricMatch\\": [Function asymmetricMatch]}</>
-Received:     <red>\\"Alice\\"</>"
+Expected: not <g>{"asymmetricMatch": [Function asymmetricMatch]}</>
+Received:     <r>"Alice"</>
 `;
 
 exports[`.toEqual() {pass: true} expect("abc").not.toEqual("abc") 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: not <green>\\"abc\\"</>
-"
+Expected: not <g>"abc"</>
+
 `;
 
 exports[`.toEqual() {pass: true} expect("abc").not.toEqual({"0": "a", "1": "b", "2": "c"}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: not <green>{\\"0\\": \\"a\\", \\"1\\": \\"b\\", \\"2\\": \\"c\\"}</>
-Received:     <red>\\"abc\\"</>"
+Expected: not <g>{"0": "a", "1": "b", "2": "c"}</>
+Received:     <r>"abc"</>
 `;
 
 exports[`.toEqual() {pass: true} expect("abcd").not.toEqual(StringContaining "bc") 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: not <green>StringContaining \\"bc\\"</>
-Received:     <red>\\"abcd\\"</>"
+Expected: not <g>StringContaining "bc"</>
+Received:     <r>"abcd"</>
 `;
 
 exports[`.toEqual() {pass: true} expect("abcd").not.toEqual(StringMatching /bc/) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: not <green>StringMatching /bc/</>
-Received:     <red>\\"abcd\\"</>"
+Expected: not <g>StringMatching /bc/</>
+Received:     <r>"abcd"</>
 `;
 
 exports[`.toEqual() {pass: true} expect([1, 2, 3]).not.toEqual(ArrayContaining [2, 3]) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: not <green>ArrayContaining [2, 3]</>
-Received:     <red>[1, 2, 3]</>"
+Expected: not <g>ArrayContaining [2, 3]</>
+Received:     <r>[1, 2, 3]</>
 `;
 
 exports[`.toEqual() {pass: true} expect([1, 2]).not.toEqual([1, 2]) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: not <green>[1, 2]</>
-"
+Expected: not <g>[1, 2]</>
+
 `;
 
 exports[`.toEqual() {pass: true} expect([1]).not.toEqual([1]) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: not <green>[1]</>
-"
+Expected: not <g>[1]</>
+
 `;
 
 exports[`.toEqual() {pass: true} expect([Function anonymous]).not.toEqual(Any<Function>) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: not <green>Any<Function></>
-Received:     <red>[Function anonymous]</>"
+Expected: not <g>Any<Function></>
+Received:     <r>[Function anonymous]</>
 `;
 
 exports[`.toEqual() {pass: true} expect({"0": "a", "1": "b", "2": "c"}).not.toEqual("abc") 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: not <green>\\"abc\\"</>
-Received:     <red>{\\"0\\": \\"a\\", \\"1\\": \\"b\\", \\"2\\": \\"c\\"}</>"
+Expected: not <g>"abc"</>
+Received:     <r>{"0": "a", "1": "b", "2": "c"}</>
 `;
 
 exports[`.toEqual() {pass: true} expect({"a": 1, "b": [Function b], "c": true}).not.toEqual({"a": 1, "b": Any<Function>, "c": Anything}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: not <green>{\\"a\\": 1, \\"b\\": Any<Function>, \\"c\\": Anything}</>
-Received:     <red>{\\"a\\": 1, \\"b\\": [Function b], \\"c\\": true}</>"
+Expected: not <g>{"a": 1, "b": Any<Function>, "c": Anything}</>
+Received:     <r>{"a": 1, "b": [Function b], "c": true}</>
 `;
 
 exports[`.toEqual() {pass: true} expect({"a": 1, "b": 2}).not.toEqual(ObjectContaining {"a": 1}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: not <green>ObjectContaining {\\"a\\": 1}</>
-Received:     <red>{\\"a\\": 1, \\"b\\": 2}</>"
+Expected: not <g>ObjectContaining {"a": 1}</>
+Received:     <r>{"a": 1, "b": 2}</>
 `;
 
 exports[`.toEqual() {pass: true} expect({"a": 99}).not.toEqual({"a": 99}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: not <green>{\\"a\\": 99}</>
-"
+Expected: not <g>{"a": 99}</>
+
 `;
 
 exports[`.toEqual() {pass: true} expect({"nodeName": "div", "nodeType": 1}).not.toEqual({"nodeName": "div", "nodeType": 1}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: not <green>{\\"nodeName\\": \\"div\\", \\"nodeType\\": 1}</>
-"
+Expected: not <g>{"nodeName": "div", "nodeType": 1}</>
+
 `;
 
 exports[`.toEqual() {pass: true} expect({}).not.toEqual({}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: not <green>{}</>
-"
+Expected: not <g>{}</>
+
 `;
 
 exports[`.toEqual() {pass: true} expect({}).not.toEqual(0) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: not <green>0</>
-Received:     <red>{}</>"
+Expected: not <g>0</>
+Received:     <r>{}</>
 `;
 
 exports[`.toEqual() {pass: true} expect(0).not.toEqual({}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: not <green>{}</>
-Received:     <red>0</>"
+Expected: not <g>{}</>
+Received:     <r>0</>
 `;
 
 exports[`.toEqual() {pass: true} expect(1).not.toEqual(1) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: not <green>1</>
-"
+Expected: not <g>1</>
+
 `;
 
 exports[`.toEqual() {pass: true} expect(Immutable.List [1, 2]).not.toEqual(Immutable.List [1, 2]) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: not <green>Immutable.List [1, 2]</>
-"
+Expected: not <g>Immutable.List [1, 2]</>
+
 `;
 
 exports[`.toEqual() {pass: true} expect(Immutable.List [1]).not.toEqual(Immutable.List [1]) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: not <green>Immutable.List [1]</>
-"
+Expected: not <g>Immutable.List [1]</>
+
 `;
 
 exports[`.toEqual() {pass: true} expect(Immutable.Map {"1": Immutable.Map {"2": {"a": 99}}}).not.toEqual(Immutable.Map {"1": Immutable.Map {"2": {"a": 99}}}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: not <green>Immutable.Map {\\"1\\": Immutable.Map {\\"2\\": {\\"a\\": 99}}}</>
-"
+Expected: not <g>Immutable.Map {"1": Immutable.Map {"2": {"a": 99}}}</>
+
 `;
 
 exports[`.toEqual() {pass: true} expect(Immutable.Map {}).not.toEqual(Immutable.Map {}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: not <green>Immutable.Map {}</>
-"
+Expected: not <g>Immutable.Map {}</>
+
 `;
 
 exports[`.toEqual() {pass: true} expect(Immutable.Map {1: "one", 2: "two"}).not.toEqual(Immutable.Map {1: "one", 2: "two"}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: not <green>Immutable.Map {1: \\"one\\", 2: \\"two\\"}</>
-"
+Expected: not <g>Immutable.Map {1: "one", 2: "two"}</>
+
 `;
 
 exports[`.toEqual() {pass: true} expect(Immutable.Map {1: "one", 2: "two"}).not.toEqual(Immutable.Map {2: "two", 1: "one"}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: not <green>Immutable.Map {2: \\"two\\", 1: \\"one\\"}</>
-Received:     <red>Immutable.Map {1: \\"one\\", 2: \\"two\\"}</>"
+Expected: not <g>Immutable.Map {2: "two", 1: "one"}</>
+Received:     <r>Immutable.Map {1: "one", 2: "two"}</>
 `;
 
 exports[`.toEqual() {pass: true} expect(Immutable.OrderedMap {1: "one", 2: "two"}).not.toEqual(Immutable.OrderedMap {1: "one", 2: "two"}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: not <green>Immutable.OrderedMap {1: \\"one\\", 2: \\"two\\"}</>
-"
+Expected: not <g>Immutable.OrderedMap {1: "one", 2: "two"}</>
+
 `;
 
 exports[`.toEqual() {pass: true} expect(Immutable.OrderedSet []).not.toEqual(Immutable.OrderedSet []) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: not <green>Immutable.OrderedSet []</>
-"
+Expected: not <g>Immutable.OrderedSet []</>
+
 `;
 
 exports[`.toEqual() {pass: true} expect(Immutable.OrderedSet [1, 2]).not.toEqual(Immutable.OrderedSet [1, 2]) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: not <green>Immutable.OrderedSet [1, 2]</>
-"
+Expected: not <g>Immutable.OrderedSet [1, 2]</>
+
 `;
 
 exports[`.toEqual() {pass: true} expect(Immutable.Set []).not.toEqual(Immutable.Set []) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: not <green>Immutable.Set []</>
-"
+Expected: not <g>Immutable.Set []</>
+
 `;
 
 exports[`.toEqual() {pass: true} expect(Immutable.Set [1, 2]).not.toEqual(Immutable.Set [1, 2]) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: not <green>Immutable.Set [1, 2]</>
-"
+Expected: not <g>Immutable.Set [1, 2]</>
+
 `;
 
 exports[`.toEqual() {pass: true} expect(Immutable.Set [1, 2]).not.toEqual(Immutable.Set [2, 1]) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: not <green>Immutable.Set [2, 1]</>
-Received:     <red>Immutable.Set [1, 2]</>"
+Expected: not <g>Immutable.Set [2, 1]</>
+Received:     <r>Immutable.Set [1, 2]</>
 `;
 
 exports[`.toEqual() {pass: true} expect(Map {[1] => "one", [2] => "two", [3] => "three", [3] => "four"}).not.toEqual(Map {[3] => "three", [3] => "four", [2] => "two", [1] => "one"}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: not <green>Map {[3] => \\"three\\", [3] => \\"four\\", [2] => \\"two\\", [1] => \\"one\\"}</>
-Received:     <red>Map {[1] => \\"one\\", [2] => \\"two\\", [3] => \\"three\\", [3] => \\"four\\"}</>"
+Expected: not <g>Map {[3] => "three", [3] => "four", [2] => "two", [1] => "one"}</>
+Received:     <r>Map {[1] => "one", [2] => "two", [3] => "three", [3] => "four"}</>
 `;
 
 exports[`.toEqual() {pass: true} expect(Map {[1] => "one", [2] => "two"}).not.toEqual(Map {[2] => "two", [1] => "one"}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: not <green>Map {[2] => \\"two\\", [1] => \\"one\\"}</>
-Received:     <red>Map {[1] => \\"one\\", [2] => \\"two\\"}</>"
+Expected: not <g>Map {[2] => "two", [1] => "one"}</>
+Received:     <r>Map {[1] => "one", [2] => "two"}</>
 `;
 
 exports[`.toEqual() {pass: true} expect(Map {[1] => Map {[1] => "one"}, [2] => Map {[2] => "two"}}).not.toEqual(Map {[2] => Map {[2] => "two"}, [1] => Map {[1] => "one"}}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: not <green>Map {[2] => Map {[2] => \\"two\\"}, [1] => Map {[1] => \\"one\\"}}</>
-Received:     <red>Map {[1] => Map {[1] => \\"one\\"}, [2] => Map {[2] => \\"two\\"}}</>"
+Expected: not <g>Map {[2] => Map {[2] => "two"}, [1] => Map {[1] => "one"}}</>
+Received:     <r>Map {[1] => Map {[1] => "one"}, [2] => Map {[2] => "two"}}</>
 `;
 
 exports[`.toEqual() {pass: true} expect(Map {{"a": 1} => "one", {"b": 2} => "two"}).not.toEqual(Map {{"b": 2} => "two", {"a": 1} => "one"}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: not <green>Map {{\\"b\\": 2} => \\"two\\", {\\"a\\": 1} => \\"one\\"}</>
-Received:     <red>Map {{\\"a\\": 1} => \\"one\\", {\\"b\\": 2} => \\"two\\"}</>"
+Expected: not <g>Map {{"b": 2} => "two", {"a": 1} => "one"}</>
+Received:     <r>Map {{"a": 1} => "one", {"b": 2} => "two"}</>
 `;
 
 exports[`.toEqual() {pass: true} expect(Map {}).not.toEqual(Map {}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: not <green>Map {}</>
-"
+Expected: not <g>Map {}</>
+
 `;
 
 exports[`.toEqual() {pass: true} expect(Map {1 => "one", 2 => "two"}).not.toEqual(Map {1 => "one", 2 => "two"}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: not <green>Map {1 => \\"one\\", 2 => \\"two\\"}</>
-"
+Expected: not <g>Map {1 => "one", 2 => "two"}</>
+
 `;
 
 exports[`.toEqual() {pass: true} expect(Map {1 => "one", 2 => "two"}).not.toEqual(Map {2 => "two", 1 => "one"}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: not <green>Map {2 => \\"two\\", 1 => \\"one\\"}</>
-Received:     <red>Map {1 => \\"one\\", 2 => \\"two\\"}</>"
+Expected: not <g>Map {2 => "two", 1 => "one"}</>
+Received:     <r>Map {1 => "one", 2 => "two"}</>
 `;
 
 exports[`.toEqual() {pass: true} expect(Map {1 => ["one"], 2 => ["two"]}).not.toEqual(Map {2 => ["two"], 1 => ["one"]}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: not <green>Map {2 => [\\"two\\"], 1 => [\\"one\\"]}</>
-Received:     <red>Map {1 => [\\"one\\"], 2 => [\\"two\\"]}</>"
+Expected: not <g>Map {2 => ["two"], 1 => ["one"]}</>
+Received:     <r>Map {1 => ["one"], 2 => ["two"]}</>
 `;
 
 exports[`.toEqual() {pass: true} expect(NaN).not.toEqual(NaN) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: not <green>NaN</>
-"
+Expected: not <g>NaN</>
+
 `;
 
 exports[`.toEqual() {pass: true} expect(Set {[1], [2], [3], [3]}).not.toEqual(Set {[3], [3], [2], [1]}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: not <green>Set {[3], [3], [2], [1]}</>
-Received:     <red>Set {[1], [2], [3], [3]}</>"
+Expected: not <g>Set {[3], [3], [2], [1]}</>
+Received:     <r>Set {[1], [2], [3], [3]}</>
 `;
 
 exports[`.toEqual() {pass: true} expect(Set {[1], [2]}).not.toEqual(Set {[2], [1]}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: not <green>Set {[2], [1]}</>
-Received:     <red>Set {[1], [2]}</>"
+Expected: not <g>Set {[2], [1]}</>
+Received:     <r>Set {[1], [2]}</>
 `;
 
 exports[`.toEqual() {pass: true} expect(Set {{"a": 1}, {"b": 2}}).not.toEqual(Set {{"b": 2}, {"a": 1}}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: not <green>Set {{\\"b\\": 2}, {\\"a\\": 1}}</>
-Received:     <red>Set {{\\"a\\": 1}, {\\"b\\": 2}}</>"
+Expected: not <g>Set {{"b": 2}, {"a": 1}}</>
+Received:     <r>Set {{"a": 1}, {"b": 2}}</>
 `;
 
 exports[`.toEqual() {pass: true} expect(Set {}).not.toEqual(Set {}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: not <green>Set {}</>
-"
+Expected: not <g>Set {}</>
+
 `;
 
 exports[`.toEqual() {pass: true} expect(Set {1, 2}).not.toEqual(Set {1, 2}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: not <green>Set {1, 2}</>
-"
+Expected: not <g>Set {1, 2}</>
+
 `;
 
 exports[`.toEqual() {pass: true} expect(Set {1, 2}).not.toEqual(Set {2, 1}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: not <green>Set {2, 1}</>
-Received:     <red>Set {1, 2}</>"
+Expected: not <g>Set {2, 1}</>
+Received:     <r>Set {1, 2}</>
 `;
 
 exports[`.toEqual() {pass: true} expect(Set {Set {[1]}, Set {[2]}}).not.toEqual(Set {Set {[2]}, Set {[1]}}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: not <green>Set {Set {[2]}, Set {[1]}}</>
-Received:     <red>Set {Set {[1]}, Set {[2]}}</>"
+Expected: not <g>Set {Set {[2]}, Set {[1]}}</>
+Received:     <r>Set {Set {[1]}, Set {[2]}}</>
 `;
 
 exports[`.toEqual() {pass: true} expect(true).not.toEqual(Anything) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: not <green>Anything</>
-Received:     <red>true</>"
+Expected: not <g>Anything</>
+Received:     <r>true</>
 `;
 
 exports[`.toEqual() {pass: true} expect(true).not.toEqual(true) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: not <green>true</>
-"
+Expected: not <g>true</>
+
 `;
 
 exports[`.toHaveLength {pass: false} expect("").toHaveLength(1) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveLength<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toHaveLength<d>(</><g>expected</><d>)</>
 
-Expected length: <green>1</>
-Received length: <red>0</>
-Received string: <red>\\"\\"</>"
+Expected length: <g>1</>
+Received length: <r>0</>
+Received string: <r>""</>
 `;
 
 exports[`.toHaveLength {pass: false} expect("abc").toHaveLength(66) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveLength<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toHaveLength<d>(</><g>expected</><d>)</>
 
-Expected length: <green>66</>
-Received length: <red>3</>
-Received string: <red>\\"abc\\"</>"
+Expected length: <g>66</>
+Received length: <r>3</>
+Received string: <r>"abc"</>
 `;
 
 exports[`.toHaveLength {pass: false} expect(["a", "b"]).toHaveLength(99) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveLength<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toHaveLength<d>(</><g>expected</><d>)</>
 
-Expected length: <green>99</>
-Received length: <red>2</>
-Received array:  <red>[\\"a\\", \\"b\\"]</>"
+Expected length: <g>99</>
+Received length: <r>2</>
+Received array:  <r>["a", "b"]</>
 `;
 
 exports[`.toHaveLength {pass: false} expect([]).toHaveLength(1) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveLength<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toHaveLength<d>(</><g>expected</><d>)</>
 
-Expected length: <green>1</>
-Received length: <red>0</>
-Received array:  <red>[]</>"
+Expected length: <g>1</>
+Received length: <r>0</>
+Received array:  <r>[]</>
 `;
 
 exports[`.toHaveLength {pass: false} expect([1, 2]).toHaveLength(3) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveLength<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toHaveLength<d>(</><g>expected</><d>)</>
 
-Expected length: <green>3</>
-Received length: <red>2</>
-Received array:  <red>[1, 2]</>"
+Expected length: <g>3</>
+Received length: <r>2</>
+Received array:  <r>[1, 2]</>
 `;
 
 exports[`.toHaveLength {pass: true} expect("").toHaveLength(0) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveLength<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toHaveLength<d>(</><g>expected</><d>)</>
 
-Expected length: not <green>0</>
-Received string:     <red>\\"\\"</>"
+Expected length: not <g>0</>
+Received string:     <r>""</>
 `;
 
 exports[`.toHaveLength {pass: true} expect("abc").toHaveLength(3) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveLength<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toHaveLength<d>(</><g>expected</><d>)</>
 
-Expected length: not <green>3</>
-Received string:     <red>\\"abc\\"</>"
+Expected length: not <g>3</>
+Received string:     <r>"abc"</>
 `;
 
 exports[`.toHaveLength {pass: true} expect(["a", "b"]).toHaveLength(2) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveLength<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toHaveLength<d>(</><g>expected</><d>)</>
 
-Expected length: not <green>2</>
-Received array:      <red>[\\"a\\", \\"b\\"]</>"
+Expected length: not <g>2</>
+Received array:      <r>["a", "b"]</>
 `;
 
 exports[`.toHaveLength {pass: true} expect([]).toHaveLength(0) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveLength<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toHaveLength<d>(</><g>expected</><d>)</>
 
-Expected length: not <green>0</>
-Received array:      <red>[]</>"
+Expected length: not <g>0</>
+Received array:      <r>[]</>
 `;
 
 exports[`.toHaveLength {pass: true} expect([1, 2]).toHaveLength(2) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveLength<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toHaveLength<d>(</><g>expected</><d>)</>
 
-Expected length: not <green>2</>
-Received array:      <red>[1, 2]</>"
+Expected length: not <g>2</>
+Received array:      <r>[1, 2]</>
 `;
 
 exports[`.toHaveLength error cases 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveLength<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toHaveLength<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <red>received</> value must have a length property whose value must be a number
+<b>Matcher error</>: <r>received</> value must have a length property whose value must be a number
 
 Received has type:  object
-Received has value: <red>{\\"a\\": 9}</>"
+Received has value: <r>{"a": 9}</>
 `;
 
 exports[`.toHaveLength error cases 2`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveLength<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toHaveLength<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <red>received</> value must have a length property whose value must be a number
+<b>Matcher error</>: <r>received</> value must have a length property whose value must be a number
 
 Received has type:  number
-Received has value: <red>0</>"
+Received has value: <r>0</>
 `;
 
 exports[`.toHaveLength error cases 3`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveLength<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toHaveLength<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <red>received</> value must have a length property whose value must be a number
+<b>Matcher error</>: <r>received</> value must have a length property whose value must be a number
 
-Received has value: <red>undefined</>"
+Received has value: <r>undefined</>
 `;
 
 exports[`.toHaveLength matcher error expected length not number 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveLength<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toHaveLength<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a non-negative integer
+<b>Matcher error</>: <g>expected</> value must be a non-negative integer
 
 Expected has type:  string
-Expected has value: <green>\\"3\\"</>"
+Expected has value: <g>"3"</>
 `;
 
 exports[`.toHaveLength matcher error expected length number Infinity 1`] = `
-"<dim>expect(</><red>received</><dim>).</>rejects<dim>.</>toHaveLength<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>rejects<d>.</>toHaveLength<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a non-negative integer
+<b>Matcher error</>: <g>expected</> value must be a non-negative integer
 
 Expected has type:  number
-Expected has value: <green>Infinity</>"
+Expected has value: <g>Infinity</>
 `;
 
 exports[`.toHaveLength matcher error expected length number NaN 1`] = `
-"<dim>expect(</><red>received</><dim>).</>rejects<dim>.</>not<dim>.</>toHaveLength<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>rejects<d>.</>not<d>.</>toHaveLength<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a non-negative integer
+<b>Matcher error</>: <g>expected</> value must be a non-negative integer
 
 Expected has type:  number
-Expected has value: <green>NaN</>"
+Expected has value: <g>NaN</>
 `;
 
 exports[`.toHaveLength matcher error expected length number float 1`] = `
-"<dim>expect(</><red>received</><dim>).</>resolves<dim>.</>toHaveLength<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>resolves<d>.</>toHaveLength<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a non-negative integer
+<b>Matcher error</>: <g>expected</> value must be a non-negative integer
 
 Expected has type:  number
-Expected has value: <green>0.5</>"
+Expected has value: <g>0.5</>
 `;
 
 exports[`.toHaveLength matcher error expected length number negative integer 1`] = `
-"<dim>expect(</><red>received</><dim>).</>resolves<dim>.</>not<dim>.</>toHaveLength<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>resolves<d>.</>not<d>.</>toHaveLength<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a non-negative integer
+<b>Matcher error</>: <g>expected</> value must be a non-negative integer
 
 Expected has type:  number
-Expected has value: <green>-3</>"
+Expected has value: <g>-3</>
 `;
 
 exports[`.toHaveProperty() {error} expect({"a": {"b": {}}}).toHaveProperty('1') 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveProperty<dim>(</><green>path</><dim>)</>
+<d>expect(</><r>received</><d>).</>toHaveProperty<d>(</><g>path</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> path must be a string or array
+<b>Matcher error</>: <g>expected</> path must be a string or array
 
 Expected has type:  number
-Expected has value: <green>1</>"
+Expected has value: <g>1</>
 `;
 
 exports[`.toHaveProperty() {error} expect({"a": {"b": {}}}).toHaveProperty('null') 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveProperty<dim>(</><green>path</><dim>)</>
+<d>expect(</><r>received</><d>).</>toHaveProperty<d>(</><g>path</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> path must be a string or array
+<b>Matcher error</>: <g>expected</> path must be a string or array
 
-Expected has value: <green>null</>"
+Expected has value: <g>null</>
 `;
 
 exports[`.toHaveProperty() {error} expect({"a": {"b": {}}}).toHaveProperty('undefined') 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveProperty<dim>(</><green>path</><dim>)</>
+<d>expect(</><r>received</><d>).</>toHaveProperty<d>(</><g>path</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> path must be a string or array
+<b>Matcher error</>: <g>expected</> path must be a string or array
 
-Expected has value: <green>undefined</>"
+Expected has value: <g>undefined</>
 `;
 
 exports[`.toHaveProperty() {error} expect({}).toHaveProperty('') 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveProperty<dim>(</><green>path</><dim>)</>
+<d>expect(</><r>received</><d>).</>toHaveProperty<d>(</><g>path</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> path must not be an empty array
+<b>Matcher error</>: <g>expected</> path must not be an empty array
 
 Expected has type:  array
-Expected has value: <green>[]</>"
+Expected has value: <g>[]</>
 `;
 
 exports[`.toHaveProperty() {error} expect(null).toHaveProperty('a.b') 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveProperty<dim>(</><green>path</><dim>)</>
+<d>expect(</><r>received</><d>).</>toHaveProperty<d>(</><g>path</><d>)</>
 
-<bold>Matcher error</>: <red>received</> value must not be null nor undefined
+<b>Matcher error</>: <r>received</> value must not be null nor undefined
 
-Received has value: <red>null</>"
+Received has value: <r>null</>
 `;
 
 exports[`.toHaveProperty() {error} expect(undefined).toHaveProperty('a') 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveProperty<dim>(</><green>path</><dim>)</>
+<d>expect(</><r>received</><d>).</>toHaveProperty<d>(</><g>path</><d>)</>
 
-<bold>Matcher error</>: <red>received</> value must not be null nor undefined
+<b>Matcher error</>: <r>received</> value must not be null nor undefined
 
-Received has value: <red>undefined</>"
+Received has value: <r>undefined</>
 `;
 
 exports[`.toHaveProperty() {pass: false} expect("").toHaveProperty('key') 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveProperty<dim>(</><green>path</><dim>)</>
+<d>expect(</><r>received</><d>).</>toHaveProperty<d>(</><g>path</><d>)</>
 
-Expected path: <green>\\"key\\"</>
-Received path: <red>[]</>
+Expected path: <g>"key"</>
+Received path: <r>[]</>
 
-Received value: <red>\\"\\"</>"
+Received value: <r>""</>
 `;
 
 exports[`.toHaveProperty() {pass: false} expect("abc").toHaveProperty('a.b.c') 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveProperty<dim>(</><green>path</><dim>)</>
+<d>expect(</><r>received</><d>).</>toHaveProperty<d>(</><g>path</><d>)</>
 
-Expected path: <green>\\"a.b.c\\"</>
-Received path: <red>[]</>
+Expected path: <g>"a.b.c"</>
+Received path: <r>[]</>
 
-Received value: <red>\\"abc\\"</>"
+Received value: <r>"abc"</>
 `;
 
 exports[`.toHaveProperty() {pass: false} expect("abc").toHaveProperty('a.b.c', {"a": 5}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
+<d>expect(</><r>received</><d>).</>toHaveProperty<d>(</><g>path</><d>, </><g>value</><d>)</>
 
-Expected path: <green>\\"a.b.c\\"</>
-Received path: <red>[]</>
+Expected path: <g>"a.b.c"</>
+Received path: <r>[]</>
 
-Expected value: <green>{\\"a\\": 5}</>
-Received value: <red>\\"abc\\"</>"
+Expected value: <g>{"a": 5}</>
+Received value: <r>"abc"</>
 `;
 
 exports[`.toHaveProperty() {pass: false} expect({"a": {"b": {"c": {"d": 1}}}}).toHaveProperty('a,b,c,d', 2) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
+<d>expect(</><r>received</><d>).</>toHaveProperty<d>(</><g>path</><d>, </><g>value</><d>)</>
 
-Expected path: <green>[\\"a\\", \\"b\\", \\"c\\", \\"d\\"]</>
+Expected path: <g>["a", "b", "c", "d"]</>
 
-Expected value: <green>2</>
-Received value: <red>1</>"
+Expected value: <g>2</>
+Received value: <r>1</>
 `;
 
 exports[`.toHaveProperty() {pass: false} expect({"a": {"b": {"c": {"d": 1}}}}).toHaveProperty('a.b.c.d', 2) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
+<d>expect(</><r>received</><d>).</>toHaveProperty<d>(</><g>path</><d>, </><g>value</><d>)</>
 
-Expected path: <green>\\"a.b.c.d\\"</>
+Expected path: <g>"a.b.c.d"</>
 
-Expected value: <green>2</>
-Received value: <red>1</>"
+Expected value: <g>2</>
+Received value: <r>1</>
 `;
 
 exports[`.toHaveProperty() {pass: false} expect({"a": {"b": {"c": {"d": 1}}}}).toHaveProperty('a.b.ttt.d', 1) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
+<d>expect(</><r>received</><d>).</>toHaveProperty<d>(</><g>path</><d>, </><g>value</><d>)</>
 
-Expected path: <green>\\"a.b.ttt.d\\"</>
-Received path: <red>\\"a.b\\"</>
+Expected path: <g>"a.b.ttt.d"</>
+Received path: <r>"a.b"</>
 
-Expected value: <green>1</>
-Received value: <red>{\\"c\\": {\\"d\\": 1}}</>"
+Expected value: <g>1</>
+Received value: <r>{"c": {"d": 1}}</>
 `;
 
 exports[`.toHaveProperty() {pass: false} expect({"a": {"b": {"c": {}}}}).toHaveProperty('a.b.c.d') 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveProperty<dim>(</><green>path</><dim>)</>
+<d>expect(</><r>received</><d>).</>toHaveProperty<d>(</><g>path</><d>)</>
 
-Expected path: <green>\\"a.b.c.d\\"</>
-Received path: <red>\\"a.b.c\\"</>
+Expected path: <g>"a.b.c.d"</>
+Received path: <r>"a.b.c"</>
 
-Received value: <red>{}</>"
+Received value: <r>{}</>
 `;
 
 exports[`.toHaveProperty() {pass: false} expect({"a": {"b": {"c": {}}}}).toHaveProperty('a.b.c.d', 1) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
+<d>expect(</><r>received</><d>).</>toHaveProperty<d>(</><g>path</><d>, </><g>value</><d>)</>
 
-Expected path: <green>\\"a.b.c.d\\"</>
-Received path: <red>\\"a.b.c\\"</>
+Expected path: <g>"a.b.c.d"</>
+Received path: <r>"a.b.c"</>
 
-Expected value: <green>1</>
-Received value: <red>{}</>"
+Expected value: <g>1</>
+Received value: <r>{}</>
 `;
 
 exports[`.toHaveProperty() {pass: false} expect({"a": {"b": {"c": 5}}}).toHaveProperty('a.b', {"c": 4}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
+<d>expect(</><r>received</><d>).</>toHaveProperty<d>(</><g>path</><d>, </><g>value</><d>)</>
 
-Expected path: <green>\\"a.b\\"</>
+Expected path: <g>"a.b"</>
 
-<green>- Expected value</>
-<red>+ Received value</>
+<g>- Expected value</>
+<r>+ Received value</>
 
-<dim>  Object {</>
-<green>-   \\"c\\": 4,</>
-<red>+   \\"c\\": 5,</>
-<dim>  }</>"
+<d>  Object {</>
+<g>-   "c": 4,</>
+<r>+   "c": 5,</>
+<d>  }</>
 `;
 
 exports[`.toHaveProperty() {pass: false} expect({"a": {"b": 3}}).toHaveProperty('a.b', undefined) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
+<d>expect(</><r>received</><d>).</>toHaveProperty<d>(</><g>path</><d>, </><g>value</><d>)</>
 
-Expected path: <green>\\"a.b\\"</>
+Expected path: <g>"a.b"</>
 
-Expected value: <green>undefined</>
-Received value: <red>3</>"
+Expected value: <g>undefined</>
+Received value: <r>3</>
 `;
 
 exports[`.toHaveProperty() {pass: false} expect({"a": 1}).toHaveProperty('a.b.c.d') 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveProperty<dim>(</><green>path</><dim>)</>
+<d>expect(</><r>received</><d>).</>toHaveProperty<d>(</><g>path</><d>)</>
 
-Expected path: <green>\\"a.b.c.d\\"</>
-Received path: <red>\\"a\\"</>
+Expected path: <g>"a.b.c.d"</>
+Received path: <r>"a"</>
 
-Received value: <red>1</>"
+Received value: <r>1</>
 `;
 
 exports[`.toHaveProperty() {pass: false} expect({"a": 1}).toHaveProperty('a.b.c.d', 5) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
+<d>expect(</><r>received</><d>).</>toHaveProperty<d>(</><g>path</><d>, </><g>value</><d>)</>
 
-Expected path: <green>\\"a.b.c.d\\"</>
-Received path: <red>\\"a\\"</>
+Expected path: <g>"a.b.c.d"</>
+Received path: <r>"a"</>
 
-Expected value: <green>5</>
-Received value: <red>1</>"
+Expected value: <g>5</>
+Received value: <r>1</>
 `;
 
 exports[`.toHaveProperty() {pass: false} expect({"a.b.c.d": 1}).toHaveProperty('a.b.c.d', 2) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
+<d>expect(</><r>received</><d>).</>toHaveProperty<d>(</><g>path</><d>, </><g>value</><d>)</>
 
-Expected path: <green>\\"a.b.c.d\\"</>
-Received path: <red>[]</>
+Expected path: <g>"a.b.c.d"</>
+Received path: <r>[]</>
 
-Expected value: <green>2</>
-Received value: <red>{\\"a.b.c.d\\": 1}</>"
+Expected value: <g>2</>
+Received value: <r>{"a.b.c.d": 1}</>
 `;
 
 exports[`.toHaveProperty() {pass: false} expect({"a.b.c.d": 1}).toHaveProperty('a.b.c.d', 2) 2`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
+<d>expect(</><r>received</><d>).</>toHaveProperty<d>(</><g>path</><d>, </><g>value</><d>)</>
 
-Expected path: <green>[\\"a.b.c.d\\"]</>
+Expected path: <g>["a.b.c.d"]</>
 
-Expected value: <green>2</>
-Received value: <red>1</>"
+Expected value: <g>2</>
+Received value: <r>1</>
 `;
 
 exports[`.toHaveProperty() {pass: false} expect({"children": ["\\"That cartoon\\""], "props": null, "type": "p"}).toHaveProperty('children,0', "\\"That cat cartoon\\"") 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
+<d>expect(</><r>received</><d>).</>toHaveProperty<d>(</><g>path</><d>, </><g>value</><d>)</>
 
-Expected path: <green>[\\"children\\", 0]</>
+Expected path: <g>["children", 0]</>
 
-Expected value: <green>\\"\\\\\\"That <inverse>cat </>cartoon\\\\\\"\\"</>
-Received value: <red>\\"\\\\\\"That cartoon\\\\\\"\\"</>"
+Expected value: <g>"\\"That <i>cat </i>cartoon\\""</>
+Received value: <r>"\\"That cartoon\\""</>
 `;
 
 exports[`.toHaveProperty() {pass: false} expect({"children": ["Roses are red.
@@ -3135,1200 +3135,1200 @@ Violets are blue.
 Testing with Jest is good for you."], "props": null, "type": "pre"}).toHaveProperty('children,0', "Roses are red, violets are blue.
 Testing with Jest
 Is good for you.") 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
+<d>expect(</><r>received</><d>).</>toHaveProperty<d>(</><g>path</><d>, </><g>value</><d>)</>
 
-Expected path: <green>[\\"children\\", 0]</>
+Expected path: <g>["children", 0]</>
 
-<green>- Expected value</>
-<red>+ Received value</>
+<g>- Expected value</>
+<r>+ Received value</>
 
-<green>- Roses are red<inverse>, v</>iolets are blue.</>
-<red>+ Roses are red<inverse>.</></>
-<red>+ <inverse>V</>iolets are blue.</>
-<green>- Testing with Jest</>
-<green>- <inverse>I</>s good for you.</>
-<red>+ Testing with Jest<inverse> i</>s good for you.</>"
+<g>- Roses are red<i>, v</i>iolets are blue.</>
+<r>+ Roses are red<i>.</i></>
+<r>+ <i>V</i>iolets are blue.</>
+<g>- Testing with Jest</>
+<g>- <i>I</i>s good for you.</>
+<r>+ Testing with Jest<i> i</i>s good for you.</>
 `;
 
 exports[`.toHaveProperty() {pass: false} expect({"key": 1}).toHaveProperty('not') 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveProperty<dim>(</><green>path</><dim>)</>
+<d>expect(</><r>received</><d>).</>toHaveProperty<d>(</><g>path</><d>)</>
 
-Expected path: <green>\\"not\\"</>
-Received path: <red>[]</>
+Expected path: <g>"not"</>
+Received path: <r>[]</>
 
-Received value: <red>{\\"key\\": 1}</>"
+Received value: <r>{"key": 1}</>
 `;
 
 exports[`.toHaveProperty() {pass: false} expect({}).toHaveProperty('a') 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveProperty<dim>(</><green>path</><dim>)</>
+<d>expect(</><r>received</><d>).</>toHaveProperty<d>(</><g>path</><d>)</>
 
-Expected path: <green>\\"a\\"</>
-Received path: <red>[]</>
+Expected path: <g>"a"</>
+Received path: <r>[]</>
 
-Received value: <red>{}</>"
+Received value: <r>{}</>
 `;
 
 exports[`.toHaveProperty() {pass: false} expect({}).toHaveProperty('a', "a") 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
+<d>expect(</><r>received</><d>).</>toHaveProperty<d>(</><g>path</><d>, </><g>value</><d>)</>
 
-Expected path: <green>\\"a\\"</>
+Expected path: <g>"a"</>
 
-Expected value: <green>\\"a\\"</>
-Received value: <red>undefined</>"
+Expected value: <g>"a"</>
+Received value: <r>undefined</>
 `;
 
 exports[`.toHaveProperty() {pass: false} expect({}).toHaveProperty('a', "test") 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
+<d>expect(</><r>received</><d>).</>toHaveProperty<d>(</><g>path</><d>, </><g>value</><d>)</>
 
-Expected path: <green>\\"a\\"</>
-Received path: <red>[]</>
+Expected path: <g>"a"</>
+Received path: <r>[]</>
 
-Expected value: <green>\\"test\\"</>
-Received value: <red>{}</>"
+Expected value: <g>"test"</>
+Received value: <r>{}</>
 `;
 
 exports[`.toHaveProperty() {pass: false} expect({}).toHaveProperty('b', undefined) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
+<d>expect(</><r>received</><d>).</>toHaveProperty<d>(</><g>path</><d>, </><g>value</><d>)</>
 
-Expected path: <green>\\"b\\"</>
+Expected path: <g>"b"</>
 
-Expected value: <green>undefined</>
-Received value: <red>\\"b\\"</>"
+Expected value: <g>undefined</>
+Received value: <r>"b"</>
 `;
 
 exports[`.toHaveProperty() {pass: false} expect(0).toHaveProperty('key') 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveProperty<dim>(</><green>path</><dim>)</>
+<d>expect(</><r>received</><d>).</>toHaveProperty<d>(</><g>path</><d>)</>
 
-Expected path: <green>\\"key\\"</>
-Received path: <red>[]</>
+Expected path: <g>"key"</>
+Received path: <r>[]</>
 
-Received value: <red>0</>"
+Received value: <r>0</>
 `;
 
 exports[`.toHaveProperty() {pass: false} expect(1).toHaveProperty('a.b.c') 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveProperty<dim>(</><green>path</><dim>)</>
+<d>expect(</><r>received</><d>).</>toHaveProperty<d>(</><g>path</><d>)</>
 
-Expected path: <green>\\"a.b.c\\"</>
-Received path: <red>[]</>
+Expected path: <g>"a.b.c"</>
+Received path: <r>[]</>
 
-Received value: <red>1</>"
+Received value: <r>1</>
 `;
 
 exports[`.toHaveProperty() {pass: false} expect(1).toHaveProperty('a.b.c', "test") 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
+<d>expect(</><r>received</><d>).</>toHaveProperty<d>(</><g>path</><d>, </><g>value</><d>)</>
 
-Expected path: <green>\\"a.b.c\\"</>
-Received path: <red>[]</>
+Expected path: <g>"a.b.c"</>
+Received path: <r>[]</>
 
-Expected value: <green>\\"test\\"</>
-Received value: <red>1</>"
+Expected value: <g>"test"</>
+Received value: <r>1</>
 `;
 
 exports[`.toHaveProperty() {pass: false} expect(Symbol()).toHaveProperty('key') 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveProperty<dim>(</><green>path</><dim>)</>
+<d>expect(</><r>received</><d>).</>toHaveProperty<d>(</><g>path</><d>)</>
 
-Expected path: <green>\\"key\\"</>
-Received path: <red>[]</>
+Expected path: <g>"key"</>
+Received path: <r>[]</>
 
-Received value: <red>Symbol()</>"
+Received value: <r>Symbol()</>
 `;
 
 exports[`.toHaveProperty() {pass: false} expect(false).toHaveProperty('key') 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveProperty<dim>(</><green>path</><dim>)</>
+<d>expect(</><r>received</><d>).</>toHaveProperty<d>(</><g>path</><d>)</>
 
-Expected path: <green>\\"key\\"</>
-Received path: <red>[]</>
+Expected path: <g>"key"</>
+Received path: <r>[]</>
 
-Received value: <red>false</>"
+Received value: <r>false</>
 `;
 
 exports[`.toHaveProperty() {pass: true} expect("").toHaveProperty('length', 0) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toHaveProperty<d>(</><g>path</><d>, </><g>value</><d>)</>
 
-Expected path: <green>\\"length\\"</>
+Expected path: <g>"length"</>
 
-Expected value: not <green>0</>"
+Expected value: not <g>0</>
 `;
 
 exports[`.toHaveProperty() {pass: true} expect([Function memoized]).toHaveProperty('memo', []) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toHaveProperty<d>(</><g>path</><d>, </><g>value</><d>)</>
 
-Expected path: <green>\\"memo\\"</>
+Expected path: <g>"memo"</>
 
-Expected value: not <green>[]</>"
+Expected value: not <g>[]</>
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({"a": {"b": [1, 2, 3]}}).toHaveProperty('a,b,1') 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveProperty<dim>(</><green>path</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toHaveProperty<d>(</><g>path</><d>)</>
 
-Expected path: not <green>[\\"a\\", \\"b\\", 1]</>
+Expected path: not <g>["a", "b", 1]</>
 
-Received value: <red>2</>"
+Received value: <r>2</>
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({"a": {"b": [1, 2, 3]}}).toHaveProperty('a,b,1', 2) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toHaveProperty<d>(</><g>path</><d>, </><g>value</><d>)</>
 
-Expected path: <green>[\\"a\\", \\"b\\", 1]</>
+Expected path: <g>["a", "b", 1]</>
 
-Expected value: not <green>2</>"
+Expected value: not <g>2</>
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({"a": {"b": [1, 2, 3]}}).toHaveProperty('a,b,1', Any<Number>) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toHaveProperty<d>(</><g>path</><d>, </><g>value</><d>)</>
 
-Expected path: <green>[\\"a\\", \\"b\\", 1]</>
+Expected path: <g>["a", "b", 1]</>
 
-Expected value: not <green>Any<Number></>
-Received value:     <red>2</>"
+Expected value: not <g>Any<Number></>
+Received value:     <r>2</>
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({"a": {"b": {"c": {"d": 1}}}}).toHaveProperty('a,b,c,d') 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveProperty<dim>(</><green>path</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toHaveProperty<d>(</><g>path</><d>)</>
 
-Expected path: not <green>[\\"a\\", \\"b\\", \\"c\\", \\"d\\"]</>
+Expected path: not <g>["a", "b", "c", "d"]</>
 
-Received value: <red>1</>"
+Received value: <r>1</>
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({"a": {"b": {"c": {"d": 1}}}}).toHaveProperty('a,b,c,d', 1) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toHaveProperty<d>(</><g>path</><d>, </><g>value</><d>)</>
 
-Expected path: <green>[\\"a\\", \\"b\\", \\"c\\", \\"d\\"]</>
+Expected path: <g>["a", "b", "c", "d"]</>
 
-Expected value: not <green>1</>"
+Expected value: not <g>1</>
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({"a": {"b": {"c": {"d": 1}}}}).toHaveProperty('a.b.c.d') 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveProperty<dim>(</><green>path</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toHaveProperty<d>(</><g>path</><d>)</>
 
-Expected path: not <green>\\"a.b.c.d\\"</>
+Expected path: not <g>"a.b.c.d"</>
 
-Received value: <red>1</>"
+Received value: <r>1</>
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({"a": {"b": {"c": {"d": 1}}}}).toHaveProperty('a.b.c.d', 1) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toHaveProperty<d>(</><g>path</><d>, </><g>value</><d>)</>
 
-Expected path: <green>\\"a.b.c.d\\"</>
+Expected path: <g>"a.b.c.d"</>
 
-Expected value: not <green>1</>"
+Expected value: not <g>1</>
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({"a": {"b": {"c": 5}}}).toHaveProperty('a.b', {"c": 5}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toHaveProperty<d>(</><g>path</><d>, </><g>value</><d>)</>
 
-Expected path: <green>\\"a.b\\"</>
+Expected path: <g>"a.b"</>
 
-Expected value: not <green>{\\"c\\": 5}</>"
+Expected value: not <g>{"c": 5}</>
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({"a": {"b": undefined}}).toHaveProperty('a.b') 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveProperty<dim>(</><green>path</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toHaveProperty<d>(</><g>path</><d>)</>
 
-Expected path: not <green>\\"a.b\\"</>
+Expected path: not <g>"a.b"</>
 
-Received value: <red>undefined</>"
+Received value: <r>undefined</>
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({"a": {"b": undefined}}).toHaveProperty('a.b', undefined) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toHaveProperty<d>(</><g>path</><d>, </><g>value</><d>)</>
 
-Expected path: <green>\\"a.b\\"</>
+Expected path: <g>"a.b"</>
 
-Expected value: not <green>undefined</>"
+Expected value: not <g>undefined</>
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({"a": {}}).toHaveProperty('a.b', undefined) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toHaveProperty<d>(</><g>path</><d>, </><g>value</><d>)</>
 
-Expected path: <green>\\"a.b\\"</>
-Received path: <red>\\"a\\"</>
+Expected path: <g>"a.b"</>
+Received path: <r>"a"</>
 
-Expected value: not <green>undefined</>
-Received value:     <red>{}</>
+Expected value: not <g>undefined</>
+Received value:     <r>{}</>
 
-<dim>Because a positive assertion passes for expected value undefined if the property does not exist, this negative assertion fails unless the property does exist and has a defined value</>"
+<d>Because a positive assertion passes for expected value undefined if the property does not exist, this negative assertion fails unless the property does exist and has a defined value</>
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({"a": 0}).toHaveProperty('a') 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveProperty<dim>(</><green>path</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toHaveProperty<d>(</><g>path</><d>)</>
 
-Expected path: not <green>\\"a\\"</>
+Expected path: not <g>"a"</>
 
-Received value: <red>0</>"
+Received value: <r>0</>
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({"a": 0}).toHaveProperty('a', 0) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toHaveProperty<d>(</><g>path</><d>, </><g>value</><d>)</>
 
-Expected path: <green>\\"a\\"</>
+Expected path: <g>"a"</>
 
-Expected value: not <green>0</>"
+Expected value: not <g>0</>
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({"a.b.c.d": 1}).toHaveProperty('a.b.c.d') 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveProperty<dim>(</><green>path</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toHaveProperty<d>(</><g>path</><d>)</>
 
-Expected path: not <green>[\\"a.b.c.d\\"]</>
+Expected path: not <g>["a.b.c.d"]</>
 
-Received value: <red>1</>"
+Received value: <r>1</>
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({"a.b.c.d": 1}).toHaveProperty('a.b.c.d', 1) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toHaveProperty<d>(</><g>path</><d>, </><g>value</><d>)</>
 
-Expected path: <green>[\\"a.b.c.d\\"]</>
+Expected path: <g>["a.b.c.d"]</>
 
-Expected value: not <green>1</>"
+Expected value: not <g>1</>
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({"nodeName": "DIV"}).toHaveProperty('nodeType', 1) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toHaveProperty<d>(</><g>path</><d>, </><g>value</><d>)</>
 
-Expected path: <green>\\"nodeType\\"</>
+Expected path: <g>"nodeType"</>
 
-Expected value: not <green>1</>"
+Expected value: not <g>1</>
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({"property": 1}).toHaveProperty('property', 1) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toHaveProperty<d>(</><g>path</><d>, </><g>value</><d>)</>
 
-Expected path: <green>\\"property\\"</>
+Expected path: <g>"property"</>
 
-Expected value: not <green>1</>"
+Expected value: not <g>1</>
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({"val": true}).toHaveProperty('a', undefined) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toHaveProperty<d>(</><g>path</><d>, </><g>value</><d>)</>
 
-Expected path: <green>\\"a\\"</>
+Expected path: <g>"a"</>
 
-Expected value: not <green>undefined</>"
+Expected value: not <g>undefined</>
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({"val": true}).toHaveProperty('c', "c") 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toHaveProperty<d>(</><g>path</><d>, </><g>value</><d>)</>
 
-Expected path: <green>\\"c\\"</>
+Expected path: <g>"c"</>
 
-Expected value: not <green>\\"c\\"</>"
+Expected value: not <g>"c"</>
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({"val": true}).toHaveProperty('val', true) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toHaveProperty<d>(</><g>path</><d>, </><g>value</><d>)</>
 
-Expected path: <green>\\"val\\"</>
+Expected path: <g>"val"</>
 
-Expected value: not <green>true</>"
+Expected value: not <g>true</>
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({}).toHaveProperty('a', undefined) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toHaveProperty<d>(</><g>path</><d>, </><g>value</><d>)</>
 
-Expected path: <green>\\"a\\"</>
+Expected path: <g>"a"</>
 
-Expected value: not <green>undefined</>"
+Expected value: not <g>undefined</>
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({}).toHaveProperty('b', "b") 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toHaveProperty<d>(</><g>path</><d>, </><g>value</><d>)</>
 
-Expected path: <green>\\"b\\"</>
+Expected path: <g>"b"</>
 
-Expected value: not <green>\\"b\\"</>"
+Expected value: not <g>"b"</>
 `;
 
 exports[`.toHaveProperty() {pass: true} expect({}).toHaveProperty('setter', undefined) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveProperty<dim>(</><green>path</><dim>, </><green>value</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toHaveProperty<d>(</><g>path</><d>, </><g>value</><d>)</>
 
-Expected path: <green>\\"setter\\"</>
+Expected path: <g>"setter"</>
 
-Expected value: not <green>undefined</>"
+Expected value: not <g>undefined</>
 `;
 
 exports[`.toMatch() {pass: true} expect(Foo bar).toMatch(/^foo/i) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toMatch<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toMatch<d>(</><g>expected</><d>)</>
 
-Expected pattern: not <green>/^foo/i</>
-Received string:      <red>\\"<inverse>Foo</> bar\\"</>"
+Expected pattern: not <g>/^foo/i</>
+Received string:      <r>"<i>Foo</i> bar"</>
 `;
 
 exports[`.toMatch() {pass: true} expect(foo).toMatch(foo) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toMatch<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toMatch<d>(</><g>expected</><d>)</>
 
-Expected substring: not <green>\\"foo\\"</>
-Received string:        <red>\\"<inverse>foo</>\\"</>"
+Expected substring: not <g>"foo"</>
+Received string:        <r>"<i>foo</i>"</>
 `;
 
 exports[`.toMatch() throws if non String actual value passed: [/foo/i, "foo"] 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toMatch<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toMatch<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <red>received</> value must be a string
+<b>Matcher error</>: <r>received</> value must be a string
 
 Received has type:  regexp
-Received has value: <red>/foo/i</>"
+Received has value: <r>/foo/i</>
 `;
 
 exports[`.toMatch() throws if non String actual value passed: [[], "foo"] 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toMatch<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toMatch<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <red>received</> value must be a string
+<b>Matcher error</>: <r>received</> value must be a string
 
 Received has type:  array
-Received has value: <red>[]</>"
+Received has value: <r>[]</>
 `;
 
 exports[`.toMatch() throws if non String actual value passed: [[Function anonymous], "foo"] 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toMatch<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toMatch<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <red>received</> value must be a string
+<b>Matcher error</>: <r>received</> value must be a string
 
 Received has type:  function
-Received has value: <red>[Function anonymous]</>"
+Received has value: <r>[Function anonymous]</>
 `;
 
 exports[`.toMatch() throws if non String actual value passed: [{}, "foo"] 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toMatch<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toMatch<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <red>received</> value must be a string
+<b>Matcher error</>: <r>received</> value must be a string
 
 Received has type:  object
-Received has value: <red>{}</>"
+Received has value: <r>{}</>
 `;
 
 exports[`.toMatch() throws if non String actual value passed: [1, "foo"] 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toMatch<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toMatch<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <red>received</> value must be a string
+<b>Matcher error</>: <r>received</> value must be a string
 
 Received has type:  number
-Received has value: <red>1</>"
+Received has value: <r>1</>
 `;
 
 exports[`.toMatch() throws if non String actual value passed: [true, "foo"] 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toMatch<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toMatch<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <red>received</> value must be a string
+<b>Matcher error</>: <r>received</> value must be a string
 
 Received has type:  boolean
-Received has value: <red>true</>"
+Received has value: <r>true</>
 `;
 
 exports[`.toMatch() throws if non String actual value passed: [undefined, "foo"] 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toMatch<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toMatch<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <red>received</> value must be a string
+<b>Matcher error</>: <r>received</> value must be a string
 
-Received has value: <red>undefined</>"
+Received has value: <r>undefined</>
 `;
 
 exports[`.toMatch() throws if non String/RegExp expected value passed: ["foo", []] 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toMatch<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toMatch<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a string or regular expression
+<b>Matcher error</>: <g>expected</> value must be a string or regular expression
 
 Expected has type:  array
-Expected has value: <green>[]</>"
+Expected has value: <g>[]</>
 `;
 
 exports[`.toMatch() throws if non String/RegExp expected value passed: ["foo", [Function anonymous]] 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toMatch<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toMatch<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a string or regular expression
+<b>Matcher error</>: <g>expected</> value must be a string or regular expression
 
 Expected has type:  function
-Expected has value: <green>[Function anonymous]</>"
+Expected has value: <g>[Function anonymous]</>
 `;
 
 exports[`.toMatch() throws if non String/RegExp expected value passed: ["foo", {}] 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toMatch<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toMatch<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a string or regular expression
+<b>Matcher error</>: <g>expected</> value must be a string or regular expression
 
 Expected has type:  object
-Expected has value: <green>{}</>"
+Expected has value: <g>{}</>
 `;
 
 exports[`.toMatch() throws if non String/RegExp expected value passed: ["foo", 1] 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toMatch<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toMatch<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a string or regular expression
+<b>Matcher error</>: <g>expected</> value must be a string or regular expression
 
 Expected has type:  number
-Expected has value: <green>1</>"
+Expected has value: <g>1</>
 `;
 
 exports[`.toMatch() throws if non String/RegExp expected value passed: ["foo", true] 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toMatch<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toMatch<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a string or regular expression
+<b>Matcher error</>: <g>expected</> value must be a string or regular expression
 
 Expected has type:  boolean
-Expected has value: <green>true</>"
+Expected has value: <g>true</>
 `;
 
 exports[`.toMatch() throws if non String/RegExp expected value passed: ["foo", undefined] 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toMatch<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toMatch<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a string or regular expression
+<b>Matcher error</>: <g>expected</> value must be a string or regular expression
 
-Expected has value: <green>undefined</>"
+Expected has value: <g>undefined</>
 `;
 
 exports[`.toMatch() throws: [bar, /foo/] 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toMatch<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toMatch<d>(</><g>expected</><d>)</>
 
-Expected pattern: <green>/foo/</>
-Received string:  <red>\\"bar\\"</>"
+Expected pattern: <g>/foo/</>
+Received string:  <r>"bar"</>
 `;
 
 exports[`.toMatch() throws: [bar, foo] 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toMatch<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toMatch<d>(</><g>expected</><d>)</>
 
-Expected substring: <green>\\"foo\\"</>
-Received string:    <red>\\"bar\\"</>"
+Expected substring: <g>"foo"</>
+Received string:    <r>"bar"</>
 `;
 
 exports[`.toStrictEqual() displays substring diff 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toStrictEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>toStrictEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: <green>\\"<inverse>Another caveat is that</> Jest will not typecheck your tests.\\"</>
-Received: <red>\\"<inverse>Because TypeScript support in Babel is just transpilation,</> Jest will not type<inverse>-</>check your tests<inverse> as they run</>.\\"</>"
+Expected: <g>"<i>Another caveat is that</i> Jest will not typecheck your tests."</>
+Received: <r>"<i>Because TypeScript support in Babel is just transpilation,</i> Jest will not type<i>-</i>check your tests<i> as they run</i>."</>
 `;
 
 exports[`.toStrictEqual() displays substring diff for multiple lines 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toStrictEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>toStrictEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<green>-     6<inverse>9</> |<bgYellow> </></>
-<red>+     6<inverse>8</> |<bgYellow> </></>
-<green>-     <inverse>70</> | test('assert.doesNotThrow', () => {</>
-<red>+     <inverse>69</> | test('assert.doesNotThrow', () => {</>
-<green>-   > 7<inverse>1</> |   assert.doesNotThrow(() => {</>
-<red>+   > 7<inverse>0</> |   assert.doesNotThrow(() => {</>
-<dim>         |          ^</>
-<green>-     7<inverse>2</> |     throw Error('err!');</>
-<red>+     7<inverse>1</> |     throw Error('err!');</>
-<green>-     7<inverse>3</> |   });</>
-<red>+     7<inverse>2</> |   });</>
-<green>-     7<inverse>4</> | });</>
-<red>+     7<inverse>3</> | });</>
-<green>-     at Object.doesNotThrow (__tests__/assertionError.test.js:7<inverse>1</>:10)</>
-<red>+     at Object.doesNotThrow (__tests__/assertionError.test.js:7<inverse>0</>:10)</>"
+<g>-     6<i>9</i> |<Y> </></>
+<r>+     6<i>8</i> |<Y> </></>
+<g>-     <i>70</i> | test('assert.doesNotThrow', () => {</>
+<r>+     <i>69</i> | test('assert.doesNotThrow', () => {</>
+<g>-   > 7<i>1</i> |   assert.doesNotThrow(() => {</>
+<r>+   > 7<i>0</i> |   assert.doesNotThrow(() => {</>
+<d>         |          ^</>
+<g>-     7<i>2</i> |     throw Error('err!');</>
+<r>+     7<i>1</i> |     throw Error('err!');</>
+<g>-     7<i>3</i> |   });</>
+<r>+     7<i>2</i> |   });</>
+<g>-     7<i>4</i> | });</>
+<r>+     7<i>3</i> | });</>
+<g>-     at Object.doesNotThrow (__tests__/assertionError.test.js:7<i>1</i>:10)</>
+<r>+     at Object.doesNotThrow (__tests__/assertionError.test.js:7<i>0</i>:10)</>
 `;
 
 exports[`.toStrictEqual() matches the expected snapshot when it fails 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toStrictEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>toStrictEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Object {</>
-<green>-   \\"test\\": TestClassA {</>
-<green>-     \\"a\\": 1,</>
-<green>-     \\"b\\": 2,</>
-<green>-   },</>
-<red>+   \\"test\\": 2,</>
-<dim>  }</>"
+<d>  Object {</>
+<g>-   "test": TestClassA {</>
+<g>-     "a": 1,</>
+<g>-     "b": 2,</>
+<g>-   },</>
+<r>+   "test": 2,</>
+<d>  }</>
 `;
 
 exports[`.toStrictEqual() matches the expected snapshot when it fails 2`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toStrictEqual<dim>(</><green>expected</><dim>) // deep equality</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toStrictEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: not <green>{\\"test\\": {\\"a\\": 1, \\"b\\": 2}}</>
-"
+Expected: not <g>{"test": {"a": 1, "b": 2}}</>
+
 `;
 
 exports[`toMatchObject() {pass: false} expect([0]).toMatchObject([-0]) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Array [</>
-<green>-   -0,</>
-<red>+   0,</>
-<dim>  ]</>"
+<d>  Array [</>
+<g>-   -0,</>
+<r>+   0,</>
+<d>  ]</>
 `;
 
 exports[`toMatchObject() {pass: false} expect([1, 2, 3]).toMatchObject([1, 2, 2]) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Array [</>
-<dim>    1,</>
-<dim>    2,</>
-<green>-   2,</>
-<red>+   3,</>
-<dim>  ]</>"
+<d>  Array [</>
+<d>    1,</>
+<d>    2,</>
+<g>-   2,</>
+<r>+   3,</>
+<d>  ]</>
 `;
 
 exports[`toMatchObject() {pass: false} expect([1, 2, 3]).toMatchObject([2, 3, 1]) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Array [</>
-<red>+   1,</>
-<dim>    2,</>
-<dim>    3,</>
-<green>-   1,</>
-<dim>  ]</>"
+<d>  Array [</>
+<r>+   1,</>
+<d>    2,</>
+<d>    3,</>
+<g>-   1,</>
+<d>  ]</>
 `;
 
 exports[`toMatchObject() {pass: false} expect([1, 2]).toMatchObject([1, 3]) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Array [</>
-<dim>    1,</>
-<green>-   3,</>
-<red>+   2,</>
-<dim>  ]</>"
+<d>  Array [</>
+<d>    1,</>
+<g>-   3,</>
+<r>+   2,</>
+<d>  ]</>
 `;
 
 exports[`toMatchObject() {pass: false} expect([Error: foo]).toMatchObject([Error: bar]) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-Expected: <green>[Error: bar]</>
-Received: <red>[Error: foo]</>"
+Expected: <g>[Error: bar]</>
+Received: <r>[Error: foo]</>
 `;
 
 exports[`toMatchObject() {pass: false} expect({"a": "a", "c": "d"}).toMatchObject({"a": Any<Number>}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Object {</>
-<green>-   \\"a\\": Any<Number>,</>
-<red>+   \\"a\\": \\"a\\",</>
-<dim>  }</>"
+<d>  Object {</>
+<g>-   "a": Any<Number>,</>
+<r>+   "a": "a",</>
+<d>  }</>
 `;
 
 exports[`toMatchObject() {pass: false} expect({"a": "b", "c": "d"}).toMatchObject({"a": "b!", "c": "d"}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Object {</>
-<green>-   \\"a\\": \\"b!\\",</>
-<red>+   \\"a\\": \\"b\\",</>
-<dim>    \\"c\\": \\"d\\",</>
-<dim>  }</>"
+<d>  Object {</>
+<g>-   "a": "b!",</>
+<r>+   "a": "b",</>
+<d>    "c": "d",</>
+<d>  }</>
 `;
 
 exports[`toMatchObject() {pass: false} expect({"a": "b", "c": "d"}).toMatchObject({"e": "b"}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Object {</>
-<green>-   \\"e\\": \\"b\\",</>
-<red>+   \\"a\\": \\"b\\",</>
-<red>+   \\"c\\": \\"d\\",</>
-<dim>  }</>"
+<d>  Object {</>
+<g>-   "e": "b",</>
+<r>+   "a": "b",</>
+<r>+   "c": "d",</>
+<d>  }</>
 `;
 
 exports[`toMatchObject() {pass: false} expect({"a": "b", "t": {"x": {"r": "r"}, "z": "z"}}).toMatchObject({"a": "b", "t": {"z": [3]}}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Object {</>
-<dim>    \\"a\\": \\"b\\",</>
-<dim>    \\"t\\": Object {</>
-<green>-     \\"z\\": Array [</>
-<green>-       3,</>
-<green>-     ],</>
-<red>+     \\"z\\": \\"z\\",</>
-<dim>    },</>
-<dim>  }</>"
+<d>  Object {</>
+<d>    "a": "b",</>
+<d>    "t": Object {</>
+<g>-     "z": Array [</>
+<g>-       3,</>
+<g>-     ],</>
+<r>+     "z": "z",</>
+<d>    },</>
+<d>  }</>
 `;
 
 exports[`toMatchObject() {pass: false} expect({"a": "b", "t": {"x": {"r": "r"}, "z": "z"}}).toMatchObject({"t": {"l": {"r": "r"}}}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Object {</>
-<dim>    \\"t\\": Object {</>
-<green>-     \\"l\\": Object {</>
-<red>+     \\"x\\": Object {</>
-<dim>        \\"r\\": \\"r\\",</>
-<dim>      },</>
-<red>+     \\"z\\": \\"z\\",</>
-<dim>    },</>
-<dim>  }</>"
+<d>  Object {</>
+<d>    "t": Object {</>
+<g>-     "l": Object {</>
+<r>+     "x": Object {</>
+<d>        "r": "r",</>
+<d>      },</>
+<r>+     "z": "z",</>
+<d>    },</>
+<d>  }</>
 `;
 
 exports[`toMatchObject() {pass: false} expect({"a": "b"}).toMatchObject({"c": "d"}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Object {</>
-<green>-   \\"c\\": \\"d\\",</>
-<red>+   \\"a\\": \\"b\\",</>
-<dim>  }</>"
+<d>  Object {</>
+<g>-   "c": "d",</>
+<r>+   "a": "b",</>
+<d>  }</>
 `;
 
 exports[`toMatchObject() {pass: false} expect({"a": [{"a": "a", "b": "b"}]}).toMatchObject({"a": [{"a": "c"}]}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Object {</>
-<dim>    \\"a\\": Array [</>
-<dim>      Object {</>
-<green>-       \\"a\\": \\"c\\",</>
-<red>+       \\"a\\": \\"a\\",</>
-<dim>      },</>
-<dim>    ],</>
-<dim>  }</>"
+<d>  Object {</>
+<d>    "a": Array [</>
+<d>      Object {</>
+<g>-       "a": "c",</>
+<r>+       "a": "a",</>
+<d>      },</>
+<d>    ],</>
+<d>  }</>
 `;
 
 exports[`toMatchObject() {pass: false} expect({"a": [3, 4, "v"], "b": "b"}).toMatchObject({"a": ["v"]}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Object {</>
-<dim>    \\"a\\": Array [</>
-<red>+     3,</>
-<red>+     4,</>
-<dim>      \\"v\\",</>
-<dim>    ],</>
-<dim>  }</>"
+<d>  Object {</>
+<d>    "a": Array [</>
+<r>+     3,</>
+<r>+     4,</>
+<d>      "v",</>
+<d>    ],</>
+<d>  }</>
 `;
 
 exports[`toMatchObject() {pass: false} expect({"a": [3, 4, 5], "b": "b"}).toMatchObject({"a": [3, 4, 5, 6]}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Object {</>
-<dim>    \\"a\\": Array [</>
-<dim>      3,</>
-<dim>      4,</>
-<dim>      5,</>
-<green>-     6,</>
-<dim>    ],</>
-<dim>  }</>"
+<d>  Object {</>
+<d>    "a": Array [</>
+<d>      3,</>
+<d>      4,</>
+<d>      5,</>
+<g>-     6,</>
+<d>    ],</>
+<d>  }</>
 `;
 
 exports[`toMatchObject() {pass: false} expect({"a": [3, 4, 5], "b": "b"}).toMatchObject({"a": [3, 4]}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Object {</>
-<dim>    \\"a\\": Array [</>
-<dim>      3,</>
-<dim>      4,</>
-<red>+     5,</>
-<dim>    ],</>
-<dim>  }</>"
+<d>  Object {</>
+<d>    "a": Array [</>
+<d>      3,</>
+<d>      4,</>
+<r>+     5,</>
+<d>    ],</>
+<d>  }</>
 `;
 
 exports[`toMatchObject() {pass: false} expect({"a": [3, 4, 5], "b": "b"}).toMatchObject({"a": {"b": 4}}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Object {</>
-<green>-   \\"a\\": Object {</>
-<green>-     \\"b\\": 4,</>
-<green>-   },</>
-<red>+   \\"a\\": Array [</>
-<red>+     3,</>
-<red>+     4,</>
-<red>+     5,</>
-<red>+   ],</>
-<dim>  }</>"
+<d>  Object {</>
+<g>-   "a": Object {</>
+<g>-     "b": 4,</>
+<g>-   },</>
+<r>+   "a": Array [</>
+<r>+     3,</>
+<r>+     4,</>
+<r>+     5,</>
+<r>+   ],</>
+<d>  }</>
 `;
 
 exports[`toMatchObject() {pass: false} expect({"a": [3, 4, 5], "b": "b"}).toMatchObject({"a": {"b": Any<String>}}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Object {</>
-<green>-   \\"a\\": Object {</>
-<green>-     \\"b\\": Any<String>,</>
-<green>-   },</>
-<red>+   \\"a\\": Array [</>
-<red>+     3,</>
-<red>+     4,</>
-<red>+     5,</>
-<red>+   ],</>
-<dim>  }</>"
+<d>  Object {</>
+<g>-   "a": Object {</>
+<g>-     "b": Any<String>,</>
+<g>-   },</>
+<r>+   "a": Array [</>
+<r>+     3,</>
+<r>+     4,</>
+<r>+     5,</>
+<r>+   ],</>
+<d>  }</>
 `;
 
 exports[`toMatchObject() {pass: false} expect({"a": 1, "b": 1, "c": 1, "d": {"e": {"f": 555}}}).toMatchObject({"d": {"e": {"f": 222}}}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Object {</>
-<dim>    \\"d\\": Object {</>
-<dim>      \\"e\\": Object {</>
-<green>-       \\"f\\": 222,</>
-<red>+       \\"f\\": 555,</>
-<dim>      },</>
-<dim>    },</>
-<dim>  }</>"
+<d>  Object {</>
+<d>    "d": Object {</>
+<d>      "e": Object {</>
+<g>-       "f": 222,</>
+<r>+       "f": 555,</>
+<d>      },</>
+<d>    },</>
+<d>  }</>
 `;
 
 exports[`toMatchObject() {pass: false} expect({"a": 2015-11-30T00:00:00.000Z, "b": "b"}).toMatchObject({"a": 2015-10-10T00:00:00.000Z}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Object {</>
-<green>-   \\"a\\": 2015-10-10T00:00:00.000Z,</>
-<red>+   \\"a\\": 2015-11-30T00:00:00.000Z,</>
-<dim>  }</>"
+<d>  Object {</>
+<g>-   "a": 2015-10-10T00:00:00.000Z,</>
+<r>+   "a": 2015-11-30T00:00:00.000Z,</>
+<d>  }</>
 `;
 
 exports[`toMatchObject() {pass: false} expect({"a": null, "b": "b"}).toMatchObject({"a": "4"}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Object {</>
-<green>-   \\"a\\": \\"4\\",</>
-<red>+   \\"a\\": null,</>
-<dim>  }</>"
+<d>  Object {</>
+<g>-   "a": "4",</>
+<r>+   "a": null,</>
+<d>  }</>
 `;
 
 exports[`toMatchObject() {pass: false} expect({"a": null, "b": "b"}).toMatchObject({"a": undefined}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Object {</>
-<green>-   \\"a\\": undefined,</>
-<red>+   \\"a\\": null,</>
-<dim>  }</>"
+<d>  Object {</>
+<g>-   "a": undefined,</>
+<r>+   "a": null,</>
+<d>  }</>
 `;
 
 exports[`toMatchObject() {pass: false} expect({"a": undefined}).toMatchObject({"a": null}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Object {</>
-<green>-   \\"a\\": null,</>
-<red>+   \\"a\\": undefined,</>
-<dim>  }</>"
+<d>  Object {</>
+<g>-   "a": null,</>
+<r>+   "a": undefined,</>
+<d>  }</>
 `;
 
 exports[`toMatchObject() {pass: false} expect({}).toMatchObject({"a": undefined}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<green>- Object {</>
-<green>-   \\"a\\": undefined,</>
-<green>- }</>
-<red>+ Object {}</>"
+<g>- Object {</>
+<g>-   "a": undefined,</>
+<g>- }</>
+<r>+ Object {}</>
 `;
 
 exports[`toMatchObject() {pass: false} expect(2015-11-30T00:00:00.000Z).toMatchObject(2015-10-10T00:00:00.000Z) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-Expected: <green>2015-10-10T00:00:00.000Z</>
-Received: <red>2015-11-30T00:00:00.000Z</>"
+Expected: <g>2015-10-10T00:00:00.000Z</>
+Received: <r>2015-11-30T00:00:00.000Z</>
 `;
 
 exports[`toMatchObject() {pass: false} expect(Set {1, 2}).toMatchObject(Set {2}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Set {</>
-<red>+   1,</>
-<dim>    2,</>
-<dim>  }</>"
+<d>  Set {</>
+<r>+   1,</>
+<d>    2,</>
+<d>  }</>
 `;
 
 exports[`toMatchObject() {pass: true} expect([]).toMatchObject([]) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toMatchObject<d>(</><g>expected</><d>)</>
 
-Expected: not <green>[]</>"
+Expected: not <g>[]</>
 `;
 
 exports[`toMatchObject() {pass: true} expect([1, 2]).toMatchObject([1, 2]) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toMatchObject<d>(</><g>expected</><d>)</>
 
-Expected: not <green>[1, 2]</>"
+Expected: not <g>[1, 2]</>
 `;
 
 exports[`toMatchObject() {pass: true} expect([Error: bar]).toMatchObject({"message": "bar"}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toMatchObject<d>(</><g>expected</><d>)</>
 
-Expected: not <green>{\\"message\\": \\"bar\\"}</>
-Received:     <red>[Error: bar]</>"
+Expected: not <g>{"message": "bar"}</>
+Received:     <r>[Error: bar]</>
 `;
 
 exports[`toMatchObject() {pass: true} expect([Error: foo]).toMatchObject([Error: foo]) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toMatchObject<d>(</><g>expected</><d>)</>
 
-Expected: not <green>[Error: foo]</>"
+Expected: not <g>[Error: foo]</>
 `;
 
 exports[`toMatchObject() {pass: true} expect({"a": "b", "c": "d"}).toMatchObject({"a": "b", "c": "d"}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toMatchObject<d>(</><g>expected</><d>)</>
 
-Expected: not <green>{\\"a\\": \\"b\\", \\"c\\": \\"d\\"}</>"
+Expected: not <g>{"a": "b", "c": "d"}</>
 `;
 
 exports[`toMatchObject() {pass: true} expect({"a": "b", "c": "d"}).toMatchObject({"a": "b"}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toMatchObject<d>(</><g>expected</><d>)</>
 
-Expected: not <green>{\\"a\\": \\"b\\"}</>
-Received:     <red>{\\"a\\": \\"b\\", \\"c\\": \\"d\\"}</>"
+Expected: not <g>{"a": "b"}</>
+Received:     <r>{"a": "b", "c": "d"}</>
 `;
 
 exports[`toMatchObject() {pass: true} expect({"a": "b", "t": {"x": {"r": "r"}, "z": "z"}}).toMatchObject({"a": "b", "t": {"z": "z"}}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toMatchObject<d>(</><g>expected</><d>)</>
 
-Expected: not <green>{\\"a\\": \\"b\\", \\"t\\": {\\"z\\": \\"z\\"}}</>
-Received:     <red>{\\"a\\": \\"b\\", \\"t\\": {\\"x\\": {\\"r\\": \\"r\\"}, \\"z\\": \\"z\\"}}</>"
+Expected: not <g>{"a": "b", "t": {"z": "z"}}</>
+Received:     <r>{"a": "b", "t": {"x": {"r": "r"}, "z": "z"}}</>
 `;
 
 exports[`toMatchObject() {pass: true} expect({"a": "b", "t": {"x": {"r": "r"}, "z": "z"}}).toMatchObject({"t": {"x": {"r": "r"}}}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toMatchObject<d>(</><g>expected</><d>)</>
 
-Expected: not <green>{\\"t\\": {\\"x\\": {\\"r\\": \\"r\\"}}}</>
-Received:     <red>{\\"a\\": \\"b\\", \\"t\\": {\\"x\\": {\\"r\\": \\"r\\"}, \\"z\\": \\"z\\"}}</>"
+Expected: not <g>{"t": {"x": {"r": "r"}}}</>
+Received:     <r>{"a": "b", "t": {"x": {"r": "r"}, "z": "z"}}</>
 `;
 
 exports[`toMatchObject() {pass: true} expect({"a": "b"}).toMatchObject({"a": "b"}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toMatchObject<d>(</><g>expected</><d>)</>
 
-Expected: not <green>{\\"a\\": \\"b\\"}</>"
+Expected: not <g>{"a": "b"}</>
 `;
 
 exports[`toMatchObject() {pass: true} expect({"a": [{"a": "a", "b": "b"}]}).toMatchObject({"a": [{"a": "a"}]}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toMatchObject<d>(</><g>expected</><d>)</>
 
-Expected: not <green>{\\"a\\": [{\\"a\\": \\"a\\"}]}</>
-Received:     <red>{\\"a\\": [{\\"a\\": \\"a\\", \\"b\\": \\"b\\"}]}</>"
+Expected: not <g>{"a": [{"a": "a"}]}</>
+Received:     <r>{"a": [{"a": "a", "b": "b"}]}</>
 `;
 
 exports[`toMatchObject() {pass: true} expect({"a": [3, 4, 5, "v"], "b": "b"}).toMatchObject({"a": [3, 4, 5, "v"]}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toMatchObject<d>(</><g>expected</><d>)</>
 
-Expected: not <green>{\\"a\\": [3, 4, 5, \\"v\\"]}</>
-Received:     <red>{\\"a\\": [3, 4, 5, \\"v\\"], \\"b\\": \\"b\\"}</>"
+Expected: not <g>{"a": [3, 4, 5, "v"]}</>
+Received:     <r>{"a": [3, 4, 5, "v"], "b": "b"}</>
 `;
 
 exports[`toMatchObject() {pass: true} expect({"a": [3, 4, 5], "b": "b"}).toMatchObject({"a": [3, 4, 5]}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toMatchObject<d>(</><g>expected</><d>)</>
 
-Expected: not <green>{\\"a\\": [3, 4, 5]}</>
-Received:     <red>{\\"a\\": [3, 4, 5], \\"b\\": \\"b\\"}</>"
+Expected: not <g>{"a": [3, 4, 5]}</>
+Received:     <r>{"a": [3, 4, 5], "b": "b"}</>
 `;
 
 exports[`toMatchObject() {pass: true} expect({"a": {"x": "x", "y": "y"}}).toMatchObject({"a": {"x": Any<String>}}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toMatchObject<d>(</><g>expected</><d>)</>
 
-Expected: not <green>{\\"a\\": {\\"x\\": Any<String>}}</>
-Received:     <red>{\\"a\\": {\\"x\\": \\"x\\", \\"y\\": \\"y\\"}}</>"
+Expected: not <g>{"a": {"x": Any<String>}}</>
+Received:     <r>{"a": {"x": "x", "y": "y"}}</>
 `;
 
 exports[`toMatchObject() {pass: true} expect({"a": 1, "c": 2}).toMatchObject({"a": Any<Number>}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toMatchObject<d>(</><g>expected</><d>)</>
 
-Expected: not <green>{\\"a\\": Any<Number>}</>
-Received:     <red>{\\"a\\": 1, \\"c\\": 2}</>"
+Expected: not <g>{"a": Any<Number>}</>
+Received:     <r>{"a": 1, "c": 2}</>
 `;
 
 exports[`toMatchObject() {pass: true} expect({"a": 2015-11-30T00:00:00.000Z, "b": "b"}).toMatchObject({"a": 2015-11-30T00:00:00.000Z}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toMatchObject<d>(</><g>expected</><d>)</>
 
-Expected: not <green>{\\"a\\": 2015-11-30T00:00:00.000Z}</>
-Received:     <red>{\\"a\\": 2015-11-30T00:00:00.000Z, \\"b\\": \\"b\\"}</>"
+Expected: not <g>{"a": 2015-11-30T00:00:00.000Z}</>
+Received:     <r>{"a": 2015-11-30T00:00:00.000Z, "b": "b"}</>
 `;
 
 exports[`toMatchObject() {pass: true} expect({"a": null, "b": "b"}).toMatchObject({"a": null}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toMatchObject<d>(</><g>expected</><d>)</>
 
-Expected: not <green>{\\"a\\": null}</>
-Received:     <red>{\\"a\\": null, \\"b\\": \\"b\\"}</>"
+Expected: not <g>{"a": null}</>
+Received:     <r>{"a": null, "b": "b"}</>
 `;
 
 exports[`toMatchObject() {pass: true} expect({"a": undefined, "b": "b"}).toMatchObject({"a": undefined}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toMatchObject<d>(</><g>expected</><d>)</>
 
-Expected: not <green>{\\"a\\": undefined}</>
-Received:     <red>{\\"a\\": undefined, \\"b\\": \\"b\\"}</>"
+Expected: not <g>{"a": undefined}</>
+Received:     <r>{"a": undefined, "b": "b"}</>
 `;
 
 exports[`toMatchObject() {pass: true} expect({"a": undefined}).toMatchObject({"a": undefined}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toMatchObject<d>(</><g>expected</><d>)</>
 
-Expected: not <green>{\\"a\\": undefined}</>"
+Expected: not <g>{"a": undefined}</>
 `;
 
 exports[`toMatchObject() {pass: true} expect({}).toMatchObject({"a": undefined, "b": "b"}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toMatchObject<d>(</><g>expected</><d>)</>
 
-Expected: not <green>{\\"a\\": undefined, \\"b\\": \\"b\\"}</>
-Received:     <red>{}</>"
+Expected: not <g>{"a": undefined, "b": "b"}</>
+Received:     <r>{}</>
 `;
 
 exports[`toMatchObject() {pass: true} expect(2015-11-30T00:00:00.000Z).toMatchObject(2015-11-30T00:00:00.000Z) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toMatchObject<d>(</><g>expected</><d>)</>
 
-Expected: not <green>2015-11-30T00:00:00.000Z</>"
+Expected: not <g>2015-11-30T00:00:00.000Z</>
 `;
 
 exports[`toMatchObject() {pass: true} expect(Set {1, 2}).toMatchObject(Set {1, 2}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toMatchObject<d>(</><g>expected</><d>)</>
 
-Expected: not <green>Set {1, 2}</>"
+Expected: not <g>Set {1, 2}</>
 `;
 
 exports[`toMatchObject() {pass: true} expect(Set {1, 2}).toMatchObject(Set {2, 1}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toMatchObject<d>(</><g>expected</><d>)</>
 
-Expected: not <green>Set {2, 1}</>
-Received:     <red>Set {1, 2}</>"
+Expected: not <g>Set {2, 1}</>
+Received:     <r>Set {1, 2}</>
 `;
 
 exports[`toMatchObject() circular references simple circular references {pass: false} expect({"a": "hello", "ref": [Circular]}).toMatchObject({"a": "world", "ref": [Circular]}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Object {</>
-<green>-   \\"a\\": \\"world\\",</>
-<red>+   \\"a\\": \\"hello\\",</>
-<dim>    \\"ref\\": [Circular],</>
-<dim>  }</>"
+<d>  Object {</>
+<g>-   "a": "world",</>
+<r>+   "a": "hello",</>
+<d>    "ref": [Circular],</>
+<d>  }</>
 `;
 
 exports[`toMatchObject() circular references simple circular references {pass: false} expect({"ref": "not a ref"}).toMatchObject({"a": "hello", "ref": [Circular]}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Object {</>
-<green>-   \\"a\\": \\"hello\\",</>
-<green>-   \\"ref\\": [Circular],</>
-<red>+   \\"ref\\": \\"not a ref\\",</>
-<dim>  }</>"
+<d>  Object {</>
+<g>-   "a": "hello",</>
+<g>-   "ref": [Circular],</>
+<r>+   "ref": "not a ref",</>
+<d>  }</>
 `;
 
 exports[`toMatchObject() circular references simple circular references {pass: false} expect({}).toMatchObject({"a": "hello", "ref": [Circular]}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<green>- Object {</>
-<green>-   \\"a\\": \\"hello\\",</>
-<green>-   \\"ref\\": [Circular],</>
-<green>- }</>
-<red>+ Object {}</>"
+<g>- Object {</>
+<g>-   "a": "hello",</>
+<g>-   "ref": [Circular],</>
+<g>- }</>
+<r>+ Object {}</>
 `;
 
 exports[`toMatchObject() circular references simple circular references {pass: true} expect({"a": "hello", "ref": [Circular]}).toMatchObject({"a": "hello", "ref": [Circular]}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toMatchObject<d>(</><g>expected</><d>)</>
 
-Expected: not <green>{\\"a\\": \\"hello\\", \\"ref\\": [Circular]}</>"
+Expected: not <g>{"a": "hello", "ref": [Circular]}</>
 `;
 
 exports[`toMatchObject() circular references simple circular references {pass: true} expect({"a": "hello", "ref": [Circular]}).toMatchObject({}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toMatchObject<d>(</><g>expected</><d>)</>
 
-Expected: not <green>{}</>
-Received:     <red>{\\"a\\": \\"hello\\", \\"ref\\": [Circular]}</>"
+Expected: not <g>{}</>
+Received:     <r>{"a": "hello", "ref": [Circular]}</>
 `;
 
 exports[`toMatchObject() circular references transitive circular references {pass: false} expect({"a": "world", "nestedObj": {"parentObj": [Circular]}}).toMatchObject({"a": "hello", "nestedObj": {"parentObj": [Circular]}}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Object {</>
-<green>-   \\"a\\": \\"hello\\",</>
-<red>+   \\"a\\": \\"world\\",</>
-<dim>    \\"nestedObj\\": Object {</>
-<dim>      \\"parentObj\\": [Circular],</>
-<dim>    },</>
-<dim>  }</>"
+<d>  Object {</>
+<g>-   "a": "hello",</>
+<r>+   "a": "world",</>
+<d>    "nestedObj": Object {</>
+<d>      "parentObj": [Circular],</>
+<d>    },</>
+<d>  }</>
 `;
 
 exports[`toMatchObject() circular references transitive circular references {pass: false} expect({"nestedObj": {"parentObj": "not the parent ref"}}).toMatchObject({"a": "hello", "nestedObj": {"parentObj": [Circular]}}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Object {</>
-<green>-   \\"a\\": \\"hello\\",</>
-<dim>    \\"nestedObj\\": Object {</>
-<green>-     \\"parentObj\\": [Circular],</>
-<red>+     \\"parentObj\\": \\"not the parent ref\\",</>
-<dim>    },</>
-<dim>  }</>"
+<d>  Object {</>
+<g>-   "a": "hello",</>
+<d>    "nestedObj": Object {</>
+<g>-     "parentObj": [Circular],</>
+<r>+     "parentObj": "not the parent ref",</>
+<d>    },</>
+<d>  }</>
 `;
 
 exports[`toMatchObject() circular references transitive circular references {pass: false} expect({}).toMatchObject({"a": "hello", "nestedObj": {"parentObj": [Circular]}}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<green>- Object {</>
-<green>-   \\"a\\": \\"hello\\",</>
-<green>-   \\"nestedObj\\": Object {</>
-<green>-     \\"parentObj\\": [Circular],</>
-<green>-   },</>
-<green>- }</>
-<red>+ Object {}</>"
+<g>- Object {</>
+<g>-   "a": "hello",</>
+<g>-   "nestedObj": Object {</>
+<g>-     "parentObj": [Circular],</>
+<g>-   },</>
+<g>- }</>
+<r>+ Object {}</>
 `;
 
 exports[`toMatchObject() circular references transitive circular references {pass: true} expect({"a": "hello", "nestedObj": {"parentObj": [Circular]}}).toMatchObject({"a": "hello", "nestedObj": {"parentObj": [Circular]}}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toMatchObject<d>(</><g>expected</><d>)</>
 
-Expected: not <green>{\\"a\\": \\"hello\\", \\"nestedObj\\": {\\"parentObj\\": [Circular]}}</>"
+Expected: not <g>{"a": "hello", "nestedObj": {"parentObj": [Circular]}}</>
 `;
 
 exports[`toMatchObject() circular references transitive circular references {pass: true} expect({"a": "hello", "nestedObj": {"parentObj": [Circular]}}).toMatchObject({}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toMatchObject<d>(</><g>expected</><d>)</>
 
-Expected: not <green>{}</>
-Received:     <red>{\\"a\\": \\"hello\\", \\"nestedObj\\": {\\"parentObj\\": [Circular]}}</>"
+Expected: not <g>{}</>
+Received:     <r>{"a": "hello", "nestedObj": {"parentObj": [Circular]}}</>
 `;
 
 exports[`toMatchObject() does not match properties up in the prototype chain 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Object {</>
-<dim>    \\"other\\": \\"child\\",</>
-<green>-   \\"ref\\": [Circular],</>
-<dim>  }</>"
+<d>  Object {</>
+<d>    "other": "child",</>
+<g>-   "ref": [Circular],</>
+<d>  }</>
 `;
 
 exports[`toMatchObject() throws expect("44").toMatchObject({}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <red>received</> value must be a non-null object
+<b>Matcher error</>: <r>received</> value must be a non-null object
 
 Received has type:  string
-Received has value: <red>\\"44\\"</>"
+Received has value: <r>"44"</>
 `;
 
 exports[`toMatchObject() throws expect({}).toMatchObject("some string") 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a non-null object
+<b>Matcher error</>: <g>expected</> value must be a non-null object
 
 Expected has type:  string
-Expected has value: <green>\\"some string\\"</>"
+Expected has value: <g>"some string"</>
 `;
 
 exports[`toMatchObject() throws expect({}).toMatchObject(4) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a non-null object
+<b>Matcher error</>: <g>expected</> value must be a non-null object
 
 Expected has type:  number
-Expected has value: <green>4</>"
+Expected has value: <g>4</>
 `;
 
 exports[`toMatchObject() throws expect({}).toMatchObject(null) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a non-null object
+<b>Matcher error</>: <g>expected</> value must be a non-null object
 
-Expected has value: <green>null</>"
+Expected has value: <g>null</>
 `;
 
 exports[`toMatchObject() throws expect({}).toMatchObject(true) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a non-null object
+<b>Matcher error</>: <g>expected</> value must be a non-null object
 
 Expected has type:  boolean
-Expected has value: <green>true</>"
+Expected has value: <g>true</>
 `;
 
 exports[`toMatchObject() throws expect({}).toMatchObject(undefined) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a non-null object
+<b>Matcher error</>: <g>expected</> value must be a non-null object
 
-Expected has value: <green>undefined</>"
+Expected has value: <g>undefined</>
 `;
 
 exports[`toMatchObject() throws expect(4).toMatchObject({}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <red>received</> value must be a non-null object
+<b>Matcher error</>: <r>received</> value must be a non-null object
 
 Received has type:  number
-Received has value: <red>4</>"
+Received has value: <r>4</>
 `;
 
 exports[`toMatchObject() throws expect(null).toMatchObject({}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <red>received</> value must be a non-null object
+<b>Matcher error</>: <r>received</> value must be a non-null object
 
-Received has value: <red>null</>"
+Received has value: <r>null</>
 `;
 
 exports[`toMatchObject() throws expect(true).toMatchObject({}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <red>received</> value must be a non-null object
+<b>Matcher error</>: <r>received</> value must be a non-null object
 
 Received has type:  boolean
-Received has value: <red>true</>"
+Received has value: <r>true</>
 `;
 
 exports[`toMatchObject() throws expect(undefined).toMatchObject({}) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toMatchObject<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <red>received</> value must be a non-null object
+<b>Matcher error</>: <r>received</> value must be a non-null object
 
-Received has value: <red>undefined</>"
+Received has value: <r>undefined</>
 `;

--- a/packages/expect/src/__tests__/__snapshots__/spyMatchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/spyMatchers.test.js.snap
@@ -1,2877 +1,2877 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`lastCalledWith includes the custom mock name in the error message 1`] = `
-"<dim>expect(</><red>named-mock</><dim>).</>not<dim>.</>lastCalledWith<dim>(</><green>...expected</><dim>)</>
+<d>expect(</><r>named-mock</><d>).</>not<d>.</>lastCalledWith<d>(</><g>...expected</><d>)</>
 
-Expected: not <green>\\"foo\\"</>, <green>\\"bar\\"</>
+Expected: not <g>"foo"</>, <g>"bar"</>
 
-Number of calls: <red>1</>"
+Number of calls: <r>1</>
 `;
 
 exports[`lastCalledWith works only on spies or jest.fn 1`] = `
-"<dim>expect(</><red>received</><dim>).</>lastCalledWith<dim>(</><green>...expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>lastCalledWith<d>(</><g>...expected</><d>)</>
 
-<bold>Matcher error</>: <red>received</> value must be a mock or spy function
+<b>Matcher error</>: <r>received</> value must be a mock or spy function
 
 Received has type:  function
-Received has value: <red>[Function fn]</>"
+Received has value: <r>[Function fn]</>
 `;
 
 exports[`lastCalledWith works when not called 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>lastCalledWith<dim>(</><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>lastCalledWith<d>(</><g>...expected</><d>)</>
 
-Expected: <green>\\"foo\\"</>, <green>\\"bar\\"</>
+Expected: <g>"foo"</>, <g>"bar"</>
 
-Number of calls: <red>0</>"
+Number of calls: <r>0</>
 `;
 
 exports[`lastCalledWith works with Immutable.js objects 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>lastCalledWith<dim>(</><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>lastCalledWith<d>(</><g>...expected</><d>)</>
 
-Expected: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>, <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
+Expected: not <g>Immutable.Map {"a": {"b": "c"}}</>, <g>Immutable.Map {"a": {"b": "c"}}</>
 
-Number of calls: <red>1</>"
+Number of calls: <r>1</>
 `;
 
 exports[`lastCalledWith works with Map 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>lastCalledWith<dim>(</><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>lastCalledWith<d>(</><g>...expected</><d>)</>
 
-Expected: not <green>Map {1 => 2, 2 => 1}</>
+Expected: not <g>Map {1 => 2, 2 => 1}</>
 
-Number of calls: <red>1</>"
+Number of calls: <r>1</>
 `;
 
 exports[`lastCalledWith works with Map 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>lastCalledWith<dim>(</><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>lastCalledWith<d>(</><g>...expected</><d>)</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Map {</>
-<green>-   \\"a\\" => \\"b\\",</>
-<green>-   \\"b\\" => \\"a\\",</>
-<red>+   1 => 2,</>
-<red>+   2 => 1,</>
-<dim>  }</>,
+<d>  Map {</>
+<g>-   "a" => "b",</>
+<g>-   "b" => "a",</>
+<r>+   1 => 2,</>
+<r>+   2 => 1,</>
+<d>  }</>,
 
-Number of calls: <red>1</>"
+Number of calls: <r>1</>
 `;
 
 exports[`lastCalledWith works with Set 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>lastCalledWith<dim>(</><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>lastCalledWith<d>(</><g>...expected</><d>)</>
 
-Expected: not <green>Set {1, 2}</>
+Expected: not <g>Set {1, 2}</>
 
-Number of calls: <red>1</>"
+Number of calls: <r>1</>
 `;
 
 exports[`lastCalledWith works with Set 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>lastCalledWith<dim>(</><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>lastCalledWith<d>(</><g>...expected</><d>)</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Set {</>
-<green>-   3,</>
-<green>-   4,</>
-<red>+   1,</>
-<red>+   2,</>
-<dim>  }</>,
+<d>  Set {</>
+<g>-   3,</>
+<g>-   4,</>
+<r>+   1,</>
+<r>+   2,</>
+<d>  }</>,
 
-Number of calls: <red>1</>"
+Number of calls: <r>1</>
 `;
 
 exports[`lastCalledWith works with arguments that don't match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>lastCalledWith<dim>(</><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>lastCalledWith<d>(</><g>...expected</><d>)</>
 
-Expected: <green>\\"foo\\"</>, <green>\\"bar\\"</>
-Received: <dim>\\"foo\\"</>, <red>\\"bar1\\"</>
+Expected: <g>"foo"</>, <g>"bar"</>
+Received: <d>"foo"</>, <r>"bar1"</>
 
-Number of calls: <red>1</>"
+Number of calls: <r>1</>
 `;
 
 exports[`lastCalledWith works with arguments that match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>lastCalledWith<dim>(</><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>lastCalledWith<d>(</><g>...expected</><d>)</>
 
-Expected: not <green>\\"foo\\"</>, <green>\\"bar\\"</>
+Expected: not <g>"foo"</>, <g>"bar"</>
 
-Number of calls: <red>1</>"
+Number of calls: <r>1</>
 `;
 
 exports[`lastCalledWith works with many arguments 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>lastCalledWith<dim>(</><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>lastCalledWith<d>(</><g>...expected</><d>)</>
 
-Expected: not <green>\\"foo\\"</>, <green>\\"bar\\"</>
+Expected: not <g>"foo"</>, <g>"bar"</>
 Received
-       2:     <dim>\\"foo\\"</>, <red>\\"bar1\\"</>
-->     3:     <dim>\\"foo\\"</>, <dim>\\"bar\\"</>
+       2:     <d>"foo"</>, <r>"bar1"</>
+->     3:     <d>"foo"</>, <d>"bar"</>
 
-Number of calls: <red>3</>"
+Number of calls: <r>3</>
 `;
 
 exports[`lastCalledWith works with many arguments that don't match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>lastCalledWith<dim>(</><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>lastCalledWith<d>(</><g>...expected</><d>)</>
 
-Expected: <green>\\"foo\\"</>, <green>\\"bar\\"</>
+Expected: <g>"foo"</>, <g>"bar"</>
 Received
-       2: <dim>\\"foo\\"</>, <red>\\"bar2\\"</>
-->     3: <dim>\\"foo\\"</>, <red>\\"bar3\\"</>
+       2: <d>"foo"</>, <r>"bar2"</>
+->     3: <d>"foo"</>, <r>"bar3"</>
 
-Number of calls: <red>3</>"
+Number of calls: <r>3</>
 `;
 
 exports[`lastCalledWith works with trailing undefined arguments 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>lastCalledWith<dim>(</><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>lastCalledWith<d>(</><g>...expected</><d>)</>
 
-Expected: <green>\\"foo\\"</>
-Received: <dim>\\"foo\\"</>, <red>undefined</>
+Expected: <g>"foo"</>
+Received: <d>"foo"</>, <r>undefined</>
 
-Number of calls: <red>1</>"
+Number of calls: <r>1</>
 `;
 
 exports[`lastReturnedWith a call that throws is not considered to have returned 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>lastReturnedWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>lastReturnedWith<d>(</><g>expected</><d>)</>
 
-Expected: <green>undefined</>
+Expected: <g>undefined</>
 Received: function call threw an error
 
-Number of returns: <red>0</>
-Number of calls:   <red>1</>"
+Number of returns: <r>0</>
+Number of calls:   <r>1</>
 `;
 
 exports[`lastReturnedWith a call that throws undefined is not considered to have returned 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>lastReturnedWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>lastReturnedWith<d>(</><g>expected</><d>)</>
 
-Expected: <green>undefined</>
+Expected: <g>undefined</>
 Received: function call threw an error
 
-Number of returns: <red>0</>
-Number of calls:   <red>1</>"
+Number of returns: <r>0</>
+Number of calls:   <r>1</>
 `;
 
 exports[`lastReturnedWith includes the custom mock name in the error message 1`] = `
-"<dim>expect(</><red>named-mock</><dim>).</>lastReturnedWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>named-mock</><d>).</>lastReturnedWith<d>(</><g>expected</><d>)</>
 
-Expected: <green>\\"foo\\"</>
+Expected: <g>"foo"</>
 
-Number of returns: <red>0</>"
+Number of returns: <r>0</>
 `;
 
 exports[`lastReturnedWith lastReturnedWith incomplete recursive calls are handled properly 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>lastReturnedWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>lastReturnedWith<d>(</><g>expected</><d>)</>
 
-Expected: <green>0</>
+Expected: <g>0</>
 Received
        3: function call has not returned yet
 ->     4: function call has not returned yet
 
-Number of returns: <red>0</>
-Number of calls:   <red>4</>"
+Number of returns: <r>0</>
+Number of calls:   <r>4</>
 `;
 
 exports[`lastReturnedWith lastReturnedWith works with three calls 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>lastReturnedWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>lastReturnedWith<d>(</><g>expected</><d>)</>
 
-Expected: not <green>\\"foo3\\"</>
+Expected: not <g>"foo3"</>
 Received
-       2:     <red>\\"foo2\\"</>
-->     3:     <dim>\\"foo3\\"</>
+       2:     <r>"foo2"</>
+->     3:     <d>"foo3"</>
 
-Number of returns: <red>3</>"
+Number of returns: <r>3</>
 `;
 
 exports[`lastReturnedWith works only on spies or jest.fn 1`] = `
-"<dim>expect(</><red>received</><dim>).</>lastReturnedWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>lastReturnedWith<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <red>received</> value must be a mock function
+<b>Matcher error</>: <r>received</> value must be a mock function
 
 Received has type:  function
-Received has value: <red>[Function fn]</>"
+Received has value: <r>[Function fn]</>
 `;
 
 exports[`lastReturnedWith works when not called 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>lastReturnedWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>lastReturnedWith<d>(</><g>expected</><d>)</>
 
-Expected: <green>\\"foo\\"</>
+Expected: <g>"foo"</>
 
-Number of returns: <red>0</>"
+Number of returns: <r>0</>
 `;
 
 exports[`lastReturnedWith works with Immutable.js objects directly created 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>lastReturnedWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>lastReturnedWith<d>(</><g>expected</><d>)</>
 
-Expected: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
+Expected: not <g>Immutable.Map {"a": {"b": "c"}}</>
 
-Number of returns: <red>1</>"
+Number of returns: <r>1</>
 `;
 
 exports[`lastReturnedWith works with Immutable.js objects indirectly created 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>lastReturnedWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>lastReturnedWith<d>(</><g>expected</><d>)</>
 
-Expected: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
+Expected: not <g>Immutable.Map {"a": {"b": "c"}}</>
 
-Number of returns: <red>1</>"
+Number of returns: <r>1</>
 `;
 
 exports[`lastReturnedWith works with Map 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>lastReturnedWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>lastReturnedWith<d>(</><g>expected</><d>)</>
 
-Expected: not <green>Map {1 => 2, 2 => 1}</>
+Expected: not <g>Map {1 => 2, 2 => 1}</>
 
-Number of returns: <red>1</>"
+Number of returns: <r>1</>
 `;
 
 exports[`lastReturnedWith works with Map 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>lastReturnedWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>lastReturnedWith<d>(</><g>expected</><d>)</>
 
-Expected: <green>Map {\\"a\\" => \\"b\\", \\"b\\" => \\"a\\"}</>
-Received: <red>Map {1 => 2, 2 => 1}</>
+Expected: <g>Map {"a" => "b", "b" => "a"}</>
+Received: <r>Map {1 => 2, 2 => 1}</>
 
-Number of returns: <red>1</>"
+Number of returns: <r>1</>
 `;
 
 exports[`lastReturnedWith works with Set 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>lastReturnedWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>lastReturnedWith<d>(</><g>expected</><d>)</>
 
-Expected: not <green>Set {1, 2}</>
+Expected: not <g>Set {1, 2}</>
 
-Number of returns: <red>1</>"
+Number of returns: <r>1</>
 `;
 
 exports[`lastReturnedWith works with Set 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>lastReturnedWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>lastReturnedWith<d>(</><g>expected</><d>)</>
 
-Expected: <green>Set {3, 4}</>
-Received: <red>Set {1, 2}</>
+Expected: <g>Set {3, 4}</>
+Received: <r>Set {1, 2}</>
 
-Number of returns: <red>1</>"
+Number of returns: <r>1</>
 `;
 
 exports[`lastReturnedWith works with argument that does match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>lastReturnedWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>lastReturnedWith<d>(</><g>expected</><d>)</>
 
-Expected: not <green>\\"foo\\"</>
+Expected: not <g>"foo"</>
 
-Number of returns: <red>1</>"
+Number of returns: <r>1</>
 `;
 
 exports[`lastReturnedWith works with argument that does not match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>lastReturnedWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>lastReturnedWith<d>(</><g>expected</><d>)</>
 
-Expected: <green>\\"bar\\"</>
-Received: <red>\\"foo\\"</>
+Expected: <g>"bar"</>
+Received: <r>"foo"</>
 
-Number of returns: <red>1</>"
+Number of returns: <r>1</>
 `;
 
 exports[`lastReturnedWith works with undefined 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>lastReturnedWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>lastReturnedWith<d>(</><g>expected</><d>)</>
 
-Expected: not <green>undefined</>
+Expected: not <g>undefined</>
 
-Number of returns: <red>1</>"
+Number of returns: <r>1</>
 `;
 
 exports[`nthCalledWith includes the custom mock name in the error message 1`] = `
-"<dim>expect(</><red>named-mock</><dim>).</>not<dim>.</>nthCalledWith<dim>(</>n<dim>, </><green>...expected</><dim>)</>
+<d>expect(</><r>named-mock</><d>).</>not<d>.</>nthCalledWith<d>(</>n<d>, </><g>...expected</><d>)</>
 
 n: 1
-Expected: not <green>\\"foo\\"</>, <green>\\"bar\\"</>
+Expected: not <g>"foo"</>, <g>"bar"</>
 
-Number of calls: <red>1</>"
+Number of calls: <r>1</>
 `;
 
 exports[`nthCalledWith negative throw matcher error for n that is not integer 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>nthCalledWith<dim>(</>n<dim>, </><green>...expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>nthCalledWith<d>(</>n<d>, </><g>...expected</><d>)</>
 
-<bold>Matcher error</>: n must be a positive integer
+<b>Matcher error</>: n must be a positive integer
 
 n has type:  number
-n has value: Infinity"
+n has value: Infinity
 `;
 
 exports[`nthCalledWith positive throw matcher error for n that is not integer 1`] = `
-"<dim>expect(</><red>received</><dim>).</>nthCalledWith<dim>(</>n<dim>, </><green>...expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>nthCalledWith<d>(</>n<d>, </><g>...expected</><d>)</>
 
-<bold>Matcher error</>: n must be a positive integer
+<b>Matcher error</>: n must be a positive integer
 
 n has type:  number
-n has value: 0.1"
+n has value: 0.1
 `;
 
 exports[`nthCalledWith positive throw matcher error for n that is not positive integer 1`] = `
-"<dim>expect(</><red>received</><dim>).</>nthCalledWith<dim>(</>n<dim>, </><green>...expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>nthCalledWith<d>(</>n<d>, </><g>...expected</><d>)</>
 
-<bold>Matcher error</>: n must be a positive integer
+<b>Matcher error</>: n must be a positive integer
 
 n has type:  number
-n has value: 0"
+n has value: 0
 `;
 
 exports[`nthCalledWith works only on spies or jest.fn 1`] = `
-"<dim>expect(</><red>received</><dim>).</>nthCalledWith<dim>(</>n<dim>, </><green>...expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>nthCalledWith<d>(</>n<d>, </><g>...expected</><d>)</>
 
-<bold>Matcher error</>: <red>received</> value must be a mock or spy function
+<b>Matcher error</>: <r>received</> value must be a mock or spy function
 
 Received has type:  function
-Received has value: <red>[Function fn]</>"
+Received has value: <r>[Function fn]</>
 `;
 
 exports[`nthCalledWith works when not called 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>nthCalledWith<dim>(</>n<dim>, </><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>nthCalledWith<d>(</>n<d>, </><g>...expected</><d>)</>
 
 n: 1
-Expected: <green>\\"foo\\"</>, <green>\\"bar\\"</>
+Expected: <g>"foo"</>, <g>"bar"</>
 
-Number of calls: <red>0</>"
+Number of calls: <r>0</>
 `;
 
 exports[`nthCalledWith works with Immutable.js objects 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthCalledWith<dim>(</>n<dim>, </><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>nthCalledWith<d>(</>n<d>, </><g>...expected</><d>)</>
 
 n: 1
-Expected: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>, <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
+Expected: not <g>Immutable.Map {"a": {"b": "c"}}</>, <g>Immutable.Map {"a": {"b": "c"}}</>
 
-Number of calls: <red>1</>"
+Number of calls: <r>1</>
 `;
 
 exports[`nthCalledWith works with Map 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthCalledWith<dim>(</>n<dim>, </><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>nthCalledWith<d>(</>n<d>, </><g>...expected</><d>)</>
 
 n: 1
-Expected: not <green>Map {1 => 2, 2 => 1}</>
+Expected: not <g>Map {1 => 2, 2 => 1}</>
 
-Number of calls: <red>1</>"
+Number of calls: <r>1</>
 `;
 
 exports[`nthCalledWith works with Map 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>nthCalledWith<dim>(</>n<dim>, </><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>nthCalledWith<d>(</>n<d>, </><g>...expected</><d>)</>
 
 n: 1
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Map {</>
-<green>-   \\"a\\" => \\"b\\",</>
-<green>-   \\"b\\" => \\"a\\",</>
-<red>+   1 => 2,</>
-<red>+   2 => 1,</>
-<dim>  }</>,
+<d>  Map {</>
+<g>-   "a" => "b",</>
+<g>-   "b" => "a",</>
+<r>+   1 => 2,</>
+<r>+   2 => 1,</>
+<d>  }</>,
 
-Number of calls: <red>1</>"
+Number of calls: <r>1</>
 `;
 
 exports[`nthCalledWith works with Set 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthCalledWith<dim>(</>n<dim>, </><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>nthCalledWith<d>(</>n<d>, </><g>...expected</><d>)</>
 
 n: 1
-Expected: not <green>Set {1, 2}</>
+Expected: not <g>Set {1, 2}</>
 
-Number of calls: <red>1</>"
+Number of calls: <r>1</>
 `;
 
 exports[`nthCalledWith works with Set 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>nthCalledWith<dim>(</>n<dim>, </><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>nthCalledWith<d>(</>n<d>, </><g>...expected</><d>)</>
 
 n: 1
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Set {</>
-<green>-   3,</>
-<green>-   4,</>
-<red>+   1,</>
-<red>+   2,</>
-<dim>  }</>,
+<d>  Set {</>
+<g>-   3,</>
+<g>-   4,</>
+<r>+   1,</>
+<r>+   2,</>
+<d>  }</>,
 
-Number of calls: <red>1</>"
+Number of calls: <r>1</>
 `;
 
 exports[`nthCalledWith works with arguments that don't match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>nthCalledWith<dim>(</>n<dim>, </><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>nthCalledWith<d>(</>n<d>, </><g>...expected</><d>)</>
 
 n: 1
-Expected: <green>\\"foo\\"</>, <green>\\"bar\\"</>
-Received: <dim>\\"foo\\"</>, <red>\\"bar1\\"</>
+Expected: <g>"foo"</>, <g>"bar"</>
+Received: <d>"foo"</>, <r>"bar1"</>
 
-Number of calls: <red>1</>"
+Number of calls: <r>1</>
 `;
 
 exports[`nthCalledWith works with arguments that match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthCalledWith<dim>(</>n<dim>, </><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>nthCalledWith<d>(</>n<d>, </><g>...expected</><d>)</>
 
 n: 1
-Expected: not <green>\\"foo\\"</>, <green>\\"bar\\"</>
+Expected: not <g>"foo"</>, <g>"bar"</>
 
-Number of calls: <red>1</>"
+Number of calls: <r>1</>
 `;
 
 exports[`nthCalledWith works with three calls 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthCalledWith<dim>(</>n<dim>, </><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>nthCalledWith<d>(</>n<d>, </><g>...expected</><d>)</>
 
 n: 1
-Expected: not <green>\\"foo1\\"</>, <green>\\"bar\\"</>
+Expected: not <g>"foo1"</>, <g>"bar"</>
 Received
-->     1:     <dim>\\"foo1\\"</>, <dim>\\"bar\\"</>
-       2:     <red>\\"foo\\"</>, <red>\\"bar1\\"</>
+->     1:     <d>"foo1"</>, <d>"bar"</>
+       2:     <r>"foo"</>, <r>"bar1"</>
 
-Number of calls: <red>3</>"
+Number of calls: <r>3</>
 `;
 
 exports[`nthCalledWith works with trailing undefined arguments 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>nthCalledWith<dim>(</>n<dim>, </><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>nthCalledWith<d>(</>n<d>, </><g>...expected</><d>)</>
 
 n: 1
-Expected: <green>\\"foo\\"</>
-Received: <dim>\\"foo\\"</>, <red>undefined</>
+Expected: <g>"foo"</>
+Received: <d>"foo"</>, <r>undefined</>
 
-Number of calls: <red>1</>"
+Number of calls: <r>1</>
 `;
 
 exports[`nthReturnedWith a call that throws is not considered to have returned 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>nthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>nthReturnedWith<d>(</>n<d>, </><g>expected</><d>)</>
 
 n: 1
-Expected: <green>undefined</>
+Expected: <g>undefined</>
 Received: function call threw an error
 
-Number of returns: <red>0</>
-Number of calls:   <red>1</>"
+Number of returns: <r>0</>
+Number of calls:   <r>1</>
 `;
 
 exports[`nthReturnedWith a call that throws undefined is not considered to have returned 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>nthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>nthReturnedWith<d>(</>n<d>, </><g>expected</><d>)</>
 
 n: 1
-Expected: <green>undefined</>
+Expected: <g>undefined</>
 Received: function call threw an error
 
-Number of returns: <red>0</>
-Number of calls:   <red>1</>"
+Number of returns: <r>0</>
+Number of calls:   <r>1</>
 `;
 
 exports[`nthReturnedWith includes the custom mock name in the error message 1`] = `
-"<dim>expect(</><red>named-mock</><dim>).</>nthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
+<d>expect(</><r>named-mock</><d>).</>nthReturnedWith<d>(</>n<d>, </><g>expected</><d>)</>
 
 n: 1
-Expected: <green>\\"foo\\"</>
+Expected: <g>"foo"</>
 
-Number of returns: <red>0</>"
+Number of returns: <r>0</>
 `;
 
 exports[`nthReturnedWith nthReturnedWith incomplete recursive calls are handled properly 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>nthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>nthReturnedWith<d>(</>n<d>, </><g>expected</><d>)</>
 
 n: 1
-Expected: <green>6</>
+Expected: <g>6</>
 Received
 ->     1: function call has not returned yet
        2: function call has not returned yet
 
-Number of returns: <red>2</>
-Number of calls:   <red>4</>"
+Number of returns: <r>2</>
+Number of calls:   <r>4</>
 `;
 
 exports[`nthReturnedWith nthReturnedWith incomplete recursive calls are handled properly 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>nthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>nthReturnedWith<d>(</>n<d>, </><g>expected</><d>)</>
 
 n: 2
-Expected: <green>3</>
+Expected: <g>3</>
 Received
        1: function call has not returned yet
 ->     2: function call has not returned yet
-       3: <red>1</>
+       3: <r>1</>
 
-Number of returns: <red>2</>
-Number of calls:   <red>4</>"
+Number of returns: <r>2</>
+Number of calls:   <r>4</>
 `;
 
 exports[`nthReturnedWith nthReturnedWith incomplete recursive calls are handled properly 3`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>nthReturnedWith<d>(</>n<d>, </><g>expected</><d>)</>
 
 n: 3
-Expected: not <green>1</>
+Expected: not <g>1</>
 Received
        2:     function call has not returned yet
-->     3:     <dim>1</>
-       4:     <red>0</>
+->     3:     <d>1</>
+       4:     <r>0</>
 
-Number of returns: <red>2</>
-Number of calls:   <red>4</>"
+Number of returns: <r>2</>
+Number of calls:   <r>4</>
 `;
 
 exports[`nthReturnedWith nthReturnedWith incomplete recursive calls are handled properly 4`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>nthReturnedWith<d>(</>n<d>, </><g>expected</><d>)</>
 
 n: 4
-Expected: not <green>0</>
+Expected: not <g>0</>
 Received
-       3:     <red>1</>
-->     4:     <dim>0</>
+       3:     <r>1</>
+->     4:     <d>0</>
 
-Number of returns: <red>2</>
-Number of calls:   <red>4</>"
+Number of returns: <r>2</>
+Number of calls:   <r>4</>
 `;
 
 exports[`nthReturnedWith nthReturnedWith negative throw matcher error for n that is not number 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>nthReturnedWith<d>(</>n<d>, </><g>expected</><d>)</>
 
-<bold>Matcher error</>: n must be a positive integer
+<b>Matcher error</>: n must be a positive integer
 
-n has value: undefined"
+n has value: undefined
 `;
 
 exports[`nthReturnedWith nthReturnedWith positive throw matcher error for n that is not integer 1`] = `
-"<dim>expect(</><red>received</><dim>).</>nthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>nthReturnedWith<d>(</>n<d>, </><g>expected</><d>)</>
 
-<bold>Matcher error</>: n must be a positive integer
+<b>Matcher error</>: n must be a positive integer
 
 n has type:  number
-n has value: 0.1"
+n has value: 0.1
 `;
 
 exports[`nthReturnedWith nthReturnedWith positive throw matcher error for n that is not positive integer 1`] = `
-"<dim>expect(</><red>received</><dim>).</>nthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>nthReturnedWith<d>(</>n<d>, </><g>expected</><d>)</>
 
-<bold>Matcher error</>: n must be a positive integer
+<b>Matcher error</>: n must be a positive integer
 
 n has type:  number
-n has value: 0"
+n has value: 0
 `;
 
 exports[`nthReturnedWith nthReturnedWith should reject nth value greater than number of calls 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>nthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>nthReturnedWith<d>(</>n<d>, </><g>expected</><d>)</>
 
 n: 4
-Expected: <green>\\"foo\\"</>
+Expected: <g>"foo"</>
 Received
-       3: <dim>\\"foo\\"</>
+       3: <d>"foo"</>
 
-Number of returns: <red>3</>"
+Number of returns: <r>3</>
 `;
 
 exports[`nthReturnedWith nthReturnedWith should replace 1st, 2nd, 3rd with first, second, third 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>nthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>nthReturnedWith<d>(</>n<d>, </><g>expected</><d>)</>
 
 n: 1
-Expected: <green>\\"bar1\\"</>
+Expected: <g>"bar1"</>
 Received
-->     1: <red>\\"foo1\\"</>
-       2: <red>\\"foo2\\"</>
+->     1: <r>"foo1"</>
+       2: <r>"foo2"</>
 
-Number of returns: <red>3</>"
+Number of returns: <r>3</>
 `;
 
 exports[`nthReturnedWith nthReturnedWith should replace 1st, 2nd, 3rd with first, second, third 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>nthReturnedWith<d>(</>n<d>, </><g>expected</><d>)</>
 
 n: 1
-Expected: not <green>\\"foo1\\"</>
+Expected: not <g>"foo1"</>
 Received
-->     1:     <dim>\\"foo1\\"</>
-       2:     <red>\\"foo2\\"</>
+->     1:     <d>"foo1"</>
+       2:     <r>"foo2"</>
 
-Number of returns: <red>3</>"
+Number of returns: <r>3</>
 `;
 
 exports[`nthReturnedWith nthReturnedWith works with three calls 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>nthReturnedWith<d>(</>n<d>, </><g>expected</><d>)</>
 
 n: 1
-Expected: not <green>\\"foo1\\"</>
+Expected: not <g>"foo1"</>
 Received
-->     1:     <dim>\\"foo1\\"</>
-       2:     <red>\\"foo2\\"</>
+->     1:     <d>"foo1"</>
+       2:     <r>"foo2"</>
 
-Number of returns: <red>3</>"
+Number of returns: <r>3</>
 `;
 
 exports[`nthReturnedWith works only on spies or jest.fn 1`] = `
-"<dim>expect(</><red>received</><dim>).</>nthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>nthReturnedWith<d>(</>n<d>, </><g>expected</><d>)</>
 
-<bold>Matcher error</>: <red>received</> value must be a mock function
+<b>Matcher error</>: <r>received</> value must be a mock function
 
 Received has type:  function
-Received has value: <red>[Function fn]</>"
+Received has value: <r>[Function fn]</>
 `;
 
 exports[`nthReturnedWith works when not called 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>nthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>nthReturnedWith<d>(</>n<d>, </><g>expected</><d>)</>
 
 n: 1
-Expected: <green>\\"foo\\"</>
+Expected: <g>"foo"</>
 
-Number of returns: <red>0</>"
+Number of returns: <r>0</>
 `;
 
 exports[`nthReturnedWith works with Immutable.js objects directly created 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>nthReturnedWith<d>(</>n<d>, </><g>expected</><d>)</>
 
 n: 1
-Expected: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
+Expected: not <g>Immutable.Map {"a": {"b": "c"}}</>
 
-Number of returns: <red>1</>"
+Number of returns: <r>1</>
 `;
 
 exports[`nthReturnedWith works with Immutable.js objects indirectly created 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>nthReturnedWith<d>(</>n<d>, </><g>expected</><d>)</>
 
 n: 1
-Expected: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
+Expected: not <g>Immutable.Map {"a": {"b": "c"}}</>
 
-Number of returns: <red>1</>"
+Number of returns: <r>1</>
 `;
 
 exports[`nthReturnedWith works with Map 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>nthReturnedWith<d>(</>n<d>, </><g>expected</><d>)</>
 
 n: 1
-Expected: not <green>Map {1 => 2, 2 => 1}</>
+Expected: not <g>Map {1 => 2, 2 => 1}</>
 
-Number of returns: <red>1</>"
+Number of returns: <r>1</>
 `;
 
 exports[`nthReturnedWith works with Map 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>nthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>nthReturnedWith<d>(</>n<d>, </><g>expected</><d>)</>
 
 n: 1
-Expected: <green>Map {\\"a\\" => \\"b\\", \\"b\\" => \\"a\\"}</>
-Received: <red>Map {1 => 2, 2 => 1}</>
+Expected: <g>Map {"a" => "b", "b" => "a"}</>
+Received: <r>Map {1 => 2, 2 => 1}</>
 
-Number of returns: <red>1</>"
+Number of returns: <r>1</>
 `;
 
 exports[`nthReturnedWith works with Set 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>nthReturnedWith<d>(</>n<d>, </><g>expected</><d>)</>
 
 n: 1
-Expected: not <green>Set {1, 2}</>
+Expected: not <g>Set {1, 2}</>
 
-Number of returns: <red>1</>"
+Number of returns: <r>1</>
 `;
 
 exports[`nthReturnedWith works with Set 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>nthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>nthReturnedWith<d>(</>n<d>, </><g>expected</><d>)</>
 
 n: 1
-Expected: <green>Set {3, 4}</>
-Received: <red>Set {1, 2}</>
+Expected: <g>Set {3, 4}</>
+Received: <r>Set {1, 2}</>
 
-Number of returns: <red>1</>"
+Number of returns: <r>1</>
 `;
 
 exports[`nthReturnedWith works with argument that does match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>nthReturnedWith<d>(</>n<d>, </><g>expected</><d>)</>
 
 n: 1
-Expected: not <green>\\"foo\\"</>
+Expected: not <g>"foo"</>
 
-Number of returns: <red>1</>"
+Number of returns: <r>1</>
 `;
 
 exports[`nthReturnedWith works with argument that does not match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>nthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>nthReturnedWith<d>(</>n<d>, </><g>expected</><d>)</>
 
 n: 1
-Expected: <green>\\"bar\\"</>
-Received: <red>\\"foo\\"</>
+Expected: <g>"bar"</>
+Received: <r>"foo"</>
 
-Number of returns: <red>1</>"
+Number of returns: <r>1</>
 `;
 
 exports[`nthReturnedWith works with undefined 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>nthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>nthReturnedWith<d>(</>n<d>, </><g>expected</><d>)</>
 
 n: 1
-Expected: not <green>undefined</>
+Expected: not <g>undefined</>
 
-Number of returns: <red>1</>"
+Number of returns: <r>1</>
 `;
 
 exports[`toBeCalled .not fails with any argument passed 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeCalled<dim>()</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeCalled<d>()</>
 
-<bold>Matcher error</>: this matcher must not have an expected argument
+<b>Matcher error</>: this matcher must not have an expected argument
 
 Expected has type:  number
-Expected has value: <green>555</>"
+Expected has value: <g>555</>
 `;
 
 exports[`toBeCalled .not passes when called 1`] = `
-"<dim>expect(</><red>spy</><dim>).</>toBeCalled<dim>()</>
+<d>expect(</><r>spy</><d>).</>toBeCalled<d>()</>
 
-Expected number of calls: >= <green>1</>
-Received number of calls:    <red>0</>"
+Expected number of calls: >= <g>1</>
+Received number of calls:    <r>0</>
 `;
 
 exports[`toBeCalled fails with any argument passed 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeCalled<dim>()</>
+<d>expect(</><r>received</><d>).</>toBeCalled<d>()</>
 
-<bold>Matcher error</>: this matcher must not have an expected argument
+<b>Matcher error</>: this matcher must not have an expected argument
 
 Expected has type:  number
-Expected has value: <green>555</>"
+Expected has value: <g>555</>
 `;
 
 exports[`toBeCalled includes the custom mock name in the error message 1`] = `
-"<dim>expect(</><red>named-mock</><dim>).</>not<dim>.</>toBeCalled<dim>()</>
+<d>expect(</><r>named-mock</><d>).</>not<d>.</>toBeCalled<d>()</>
 
-Expected number of calls: <green>0</>
-Received number of calls: <red>1</>
+Expected number of calls: <g>0</>
+Received number of calls: <r>1</>
 
-1: called with 0 arguments"
+1: called with 0 arguments
 `;
 
 exports[`toBeCalled passes when called 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toBeCalled<dim>()</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toBeCalled<d>()</>
 
-Expected number of calls: <green>0</>
-Received number of calls: <red>1</>
+Expected number of calls: <g>0</>
+Received number of calls: <r>1</>
 
-1: <red>\\"arg0\\"</>, <red>\\"arg1\\"</>, <red>\\"arg2\\"</>"
+1: <r>"arg0"</>, <r>"arg1"</>, <r>"arg2"</>
 `;
 
 exports[`toBeCalled works only on spies or jest.fn 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeCalled<dim>()</>
+<d>expect(</><r>received</><d>).</>toBeCalled<d>()</>
 
-<bold>Matcher error</>: <red>received</> value must be a mock or spy function
+<b>Matcher error</>: <r>received</> value must be a mock or spy function
 
 Received has type:  function
-Received has value: <red>[Function fn]</>"
+Received has value: <r>[Function fn]</>
 `;
 
 exports[`toBeCalledTimes .not only accepts a number argument 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeCalledTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeCalledTimes<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a non-negative integer
+<b>Matcher error</>: <g>expected</> value must be a non-negative integer
 
 Expected has type:  object
-Expected has value: <green>{}</>"
+Expected has value: <g>{}</>
 `;
 
 exports[`toBeCalledTimes .not only accepts a number argument 2`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeCalledTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeCalledTimes<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a non-negative integer
+<b>Matcher error</>: <g>expected</> value must be a non-negative integer
 
 Expected has type:  array
-Expected has value: <green>[]</>"
+Expected has value: <g>[]</>
 `;
 
 exports[`toBeCalledTimes .not only accepts a number argument 3`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeCalledTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeCalledTimes<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a non-negative integer
+<b>Matcher error</>: <g>expected</> value must be a non-negative integer
 
 Expected has type:  boolean
-Expected has value: <green>true</>"
+Expected has value: <g>true</>
 `;
 
 exports[`toBeCalledTimes .not only accepts a number argument 4`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeCalledTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeCalledTimes<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a non-negative integer
+<b>Matcher error</>: <g>expected</> value must be a non-negative integer
 
 Expected has type:  string
-Expected has value: <green>\\"a\\"</>"
+Expected has value: <g>"a"</>
 `;
 
 exports[`toBeCalledTimes .not only accepts a number argument 5`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeCalledTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeCalledTimes<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a non-negative integer
+<b>Matcher error</>: <g>expected</> value must be a non-negative integer
 
 Expected has type:  map
-Expected has value: <green>Map {}</>"
+Expected has value: <g>Map {}</>
 `;
 
 exports[`toBeCalledTimes .not only accepts a number argument 6`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeCalledTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeCalledTimes<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a non-negative integer
+<b>Matcher error</>: <g>expected</> value must be a non-negative integer
 
 Expected has type:  function
-Expected has value: <green>[Function anonymous]</>"
+Expected has value: <g>[Function anonymous]</>
 `;
 
 exports[`toBeCalledTimes .not passes if function called less than expected times 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toBeCalledTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toBeCalledTimes<d>(</><g>expected</><d>)</>
 
-Expected number of calls: <green>2</>
-Received number of calls: <red>1</>"
+Expected number of calls: <g>2</>
+Received number of calls: <r>1</>
 `;
 
 exports[`toBeCalledTimes .not passes if function called more than expected times 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toBeCalledTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toBeCalledTimes<d>(</><g>expected</><d>)</>
 
-Expected number of calls: <green>2</>
-Received number of calls: <red>3</>"
+Expected number of calls: <g>2</>
+Received number of calls: <r>3</>
 `;
 
 exports[`toBeCalledTimes .not works only on spies or jest.fn 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toBeCalledTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toBeCalledTimes<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <red>received</> value must be a mock or spy function
+<b>Matcher error</>: <r>received</> value must be a mock or spy function
 
 Received has type:  function
-Received has value: <red>[Function fn]</>"
+Received has value: <r>[Function fn]</>
 `;
 
 exports[`toBeCalledTimes includes the custom mock name in the error message 1`] = `
-"<dim>expect(</><red>named-mock</><dim>).</>toBeCalledTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>named-mock</><d>).</>toBeCalledTimes<d>(</><g>expected</><d>)</>
 
-Expected number of calls: <green>2</>
-Received number of calls: <red>1</>"
+Expected number of calls: <g>2</>
+Received number of calls: <r>1</>
 `;
 
 exports[`toBeCalledTimes only accepts a number argument 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeCalledTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toBeCalledTimes<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a non-negative integer
+<b>Matcher error</>: <g>expected</> value must be a non-negative integer
 
 Expected has type:  object
-Expected has value: <green>{}</>"
+Expected has value: <g>{}</>
 `;
 
 exports[`toBeCalledTimes only accepts a number argument 2`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeCalledTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toBeCalledTimes<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a non-negative integer
+<b>Matcher error</>: <g>expected</> value must be a non-negative integer
 
 Expected has type:  array
-Expected has value: <green>[]</>"
+Expected has value: <g>[]</>
 `;
 
 exports[`toBeCalledTimes only accepts a number argument 3`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeCalledTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toBeCalledTimes<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a non-negative integer
+<b>Matcher error</>: <g>expected</> value must be a non-negative integer
 
 Expected has type:  boolean
-Expected has value: <green>true</>"
+Expected has value: <g>true</>
 `;
 
 exports[`toBeCalledTimes only accepts a number argument 4`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeCalledTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toBeCalledTimes<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a non-negative integer
+<b>Matcher error</>: <g>expected</> value must be a non-negative integer
 
 Expected has type:  string
-Expected has value: <green>\\"a\\"</>"
+Expected has value: <g>"a"</>
 `;
 
 exports[`toBeCalledTimes only accepts a number argument 5`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeCalledTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toBeCalledTimes<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a non-negative integer
+<b>Matcher error</>: <g>expected</> value must be a non-negative integer
 
 Expected has type:  map
-Expected has value: <green>Map {}</>"
+Expected has value: <g>Map {}</>
 `;
 
 exports[`toBeCalledTimes only accepts a number argument 6`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeCalledTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toBeCalledTimes<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a non-negative integer
+<b>Matcher error</>: <g>expected</> value must be a non-negative integer
 
 Expected has type:  function
-Expected has value: <green>[Function anonymous]</>"
+Expected has value: <g>[Function anonymous]</>
 `;
 
 exports[`toBeCalledTimes passes if function called equal to expected times 1`] = `
-"<dim>expect(</><red>spy</><dim>).</>not<dim>.</>toBeCalledTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>spy</><d>).</>not<d>.</>toBeCalledTimes<d>(</><g>expected</><d>)</>
 
-Expected number of calls: not <green>2</>"
+Expected number of calls: not <g>2</>
 `;
 
 exports[`toBeCalledWith includes the custom mock name in the error message 1`] = `
-"<dim>expect(</><red>named-mock</><dim>).</>not<dim>.</>toBeCalledWith<dim>(</><green>...expected</><dim>)</>
+<d>expect(</><r>named-mock</><d>).</>not<d>.</>toBeCalledWith<d>(</><g>...expected</><d>)</>
 
-Expected: not <green>\\"foo\\"</>, <green>\\"bar\\"</>
+Expected: not <g>"foo"</>, <g>"bar"</>
 
-Number of calls: <red>1</>"
+Number of calls: <r>1</>
 `;
 
 exports[`toBeCalledWith works only on spies or jest.fn 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toBeCalledWith<dim>(</><green>...expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toBeCalledWith<d>(</><g>...expected</><d>)</>
 
-<bold>Matcher error</>: <red>received</> value must be a mock or spy function
+<b>Matcher error</>: <r>received</> value must be a mock or spy function
 
 Received has type:  function
-Received has value: <red>[Function fn]</>"
+Received has value: <r>[Function fn]</>
 `;
 
 exports[`toBeCalledWith works when not called 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toBeCalledWith<dim>(</><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toBeCalledWith<d>(</><g>...expected</><d>)</>
 
-Expected: <green>\\"foo\\"</>, <green>\\"bar\\"</>
+Expected: <g>"foo"</>, <g>"bar"</>
 
-Number of calls: <red>0</>"
+Number of calls: <r>0</>
 `;
 
 exports[`toBeCalledWith works with Immutable.js objects 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toBeCalledWith<dim>(</><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toBeCalledWith<d>(</><g>...expected</><d>)</>
 
-Expected: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>, <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
+Expected: not <g>Immutable.Map {"a": {"b": "c"}}</>, <g>Immutable.Map {"a": {"b": "c"}}</>
 
-Number of calls: <red>1</>"
+Number of calls: <r>1</>
 `;
 
 exports[`toBeCalledWith works with Map 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toBeCalledWith<dim>(</><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toBeCalledWith<d>(</><g>...expected</><d>)</>
 
-Expected: not <green>Map {1 => 2, 2 => 1}</>
+Expected: not <g>Map {1 => 2, 2 => 1}</>
 
-Number of calls: <red>1</>"
+Number of calls: <r>1</>
 `;
 
 exports[`toBeCalledWith works with Map 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toBeCalledWith<dim>(</><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toBeCalledWith<d>(</><g>...expected</><d>)</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Map {</>
-<green>-   \\"a\\" => \\"b\\",</>
-<green>-   \\"b\\" => \\"a\\",</>
-<red>+   1 => 2,</>
-<red>+   2 => 1,</>
-<dim>  }</>,
+<d>  Map {</>
+<g>-   "a" => "b",</>
+<g>-   "b" => "a",</>
+<r>+   1 => 2,</>
+<r>+   2 => 1,</>
+<d>  }</>,
 
-Number of calls: <red>1</>"
+Number of calls: <r>1</>
 `;
 
 exports[`toBeCalledWith works with Set 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toBeCalledWith<dim>(</><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toBeCalledWith<d>(</><g>...expected</><d>)</>
 
-Expected: not <green>Set {1, 2}</>
+Expected: not <g>Set {1, 2}</>
 
-Number of calls: <red>1</>"
+Number of calls: <r>1</>
 `;
 
 exports[`toBeCalledWith works with Set 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toBeCalledWith<dim>(</><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toBeCalledWith<d>(</><g>...expected</><d>)</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Set {</>
-<green>-   3,</>
-<green>-   4,</>
-<red>+   1,</>
-<red>+   2,</>
-<dim>  }</>,
+<d>  Set {</>
+<g>-   3,</>
+<g>-   4,</>
+<r>+   1,</>
+<r>+   2,</>
+<d>  }</>,
 
-Number of calls: <red>1</>"
+Number of calls: <r>1</>
 `;
 
 exports[`toBeCalledWith works with arguments that don't match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toBeCalledWith<dim>(</><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toBeCalledWith<d>(</><g>...expected</><d>)</>
 
-Expected: <green>\\"foo\\"</>, <green>\\"bar\\"</>
-Received: <dim>\\"foo\\"</>, <red>\\"bar1\\"</>
+Expected: <g>"foo"</>, <g>"bar"</>
+Received: <d>"foo"</>, <r>"bar1"</>
 
-Number of calls: <red>1</>"
+Number of calls: <r>1</>
 `;
 
 exports[`toBeCalledWith works with arguments that match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toBeCalledWith<dim>(</><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toBeCalledWith<d>(</><g>...expected</><d>)</>
 
-Expected: not <green>\\"foo\\"</>, <green>\\"bar\\"</>
+Expected: not <g>"foo"</>, <g>"bar"</>
 
-Number of calls: <red>1</>"
+Number of calls: <r>1</>
 `;
 
 exports[`toBeCalledWith works with many arguments 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toBeCalledWith<dim>(</><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toBeCalledWith<d>(</><g>...expected</><d>)</>
 
-Expected: not <green>\\"foo\\"</>, <green>\\"bar\\"</>
+Expected: not <g>"foo"</>, <g>"bar"</>
 Received
-       3:     <dim>\\"foo\\"</>, <dim>\\"bar\\"</>
+       3:     <d>"foo"</>, <d>"bar"</>
 
-Number of calls: <red>3</>"
+Number of calls: <r>3</>
 `;
 
 exports[`toBeCalledWith works with many arguments that don't match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toBeCalledWith<dim>(</><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toBeCalledWith<d>(</><g>...expected</><d>)</>
 
-Expected: <green>\\"foo\\"</>, <green>\\"bar\\"</>
+Expected: <g>"foo"</>, <g>"bar"</>
 Received
-       1: <dim>\\"foo\\"</>, <red>\\"bar1\\"</>
-       2: <dim>\\"foo\\"</>, <red>\\"bar2\\"</>
-       3: <dim>\\"foo\\"</>, <red>\\"bar3\\"</>
+       1: <d>"foo"</>, <r>"bar1"</>
+       2: <d>"foo"</>, <r>"bar2"</>
+       3: <d>"foo"</>, <r>"bar3"</>
 
-Number of calls: <red>3</>"
+Number of calls: <r>3</>
 `;
 
 exports[`toBeCalledWith works with trailing undefined arguments 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toBeCalledWith<dim>(</><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toBeCalledWith<d>(</><g>...expected</><d>)</>
 
-Expected: <green>\\"foo\\"</>
-Received: <dim>\\"foo\\"</>, <red>undefined</>
+Expected: <g>"foo"</>
+Received: <d>"foo"</>, <r>undefined</>
 
-Number of calls: <red>1</>"
+Number of calls: <r>1</>
 `;
 
 exports[`toHaveBeenCalled .not fails with any argument passed 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveBeenCalled<dim>()</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toHaveBeenCalled<d>()</>
 
-<bold>Matcher error</>: this matcher must not have an expected argument
+<b>Matcher error</>: this matcher must not have an expected argument
 
 Expected has type:  number
-Expected has value: <green>555</>"
+Expected has value: <g>555</>
 `;
 
 exports[`toHaveBeenCalled .not passes when called 1`] = `
-"<dim>expect(</><red>spy</><dim>).</>toHaveBeenCalled<dim>()</>
+<d>expect(</><r>spy</><d>).</>toHaveBeenCalled<d>()</>
 
-Expected number of calls: >= <green>1</>
-Received number of calls:    <red>0</>"
+Expected number of calls: >= <g>1</>
+Received number of calls:    <r>0</>
 `;
 
 exports[`toHaveBeenCalled fails with any argument passed 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveBeenCalled<dim>()</>
+<d>expect(</><r>received</><d>).</>toHaveBeenCalled<d>()</>
 
-<bold>Matcher error</>: this matcher must not have an expected argument
+<b>Matcher error</>: this matcher must not have an expected argument
 
 Expected has type:  number
-Expected has value: <green>555</>"
+Expected has value: <g>555</>
 `;
 
 exports[`toHaveBeenCalled includes the custom mock name in the error message 1`] = `
-"<dim>expect(</><red>named-mock</><dim>).</>not<dim>.</>toHaveBeenCalled<dim>()</>
+<d>expect(</><r>named-mock</><d>).</>not<d>.</>toHaveBeenCalled<d>()</>
 
-Expected number of calls: <green>0</>
-Received number of calls: <red>1</>
+Expected number of calls: <g>0</>
+Received number of calls: <r>1</>
 
-1: called with 0 arguments"
+1: called with 0 arguments
 `;
 
 exports[`toHaveBeenCalled passes when called 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveBeenCalled<dim>()</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toHaveBeenCalled<d>()</>
 
-Expected number of calls: <green>0</>
-Received number of calls: <red>1</>
+Expected number of calls: <g>0</>
+Received number of calls: <r>1</>
 
-1: <red>\\"arg0\\"</>, <red>\\"arg1\\"</>, <red>\\"arg2\\"</>"
+1: <r>"arg0"</>, <r>"arg1"</>, <r>"arg2"</>
 `;
 
 exports[`toHaveBeenCalled works only on spies or jest.fn 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveBeenCalled<dim>()</>
+<d>expect(</><r>received</><d>).</>toHaveBeenCalled<d>()</>
 
-<bold>Matcher error</>: <red>received</> value must be a mock or spy function
+<b>Matcher error</>: <r>received</> value must be a mock or spy function
 
 Received has type:  function
-Received has value: <red>[Function fn]</>"
+Received has value: <r>[Function fn]</>
 `;
 
 exports[`toHaveBeenCalledTimes .not only accepts a number argument 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveBeenCalledTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toHaveBeenCalledTimes<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a non-negative integer
+<b>Matcher error</>: <g>expected</> value must be a non-negative integer
 
 Expected has type:  object
-Expected has value: <green>{}</>"
+Expected has value: <g>{}</>
 `;
 
 exports[`toHaveBeenCalledTimes .not only accepts a number argument 2`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveBeenCalledTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toHaveBeenCalledTimes<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a non-negative integer
+<b>Matcher error</>: <g>expected</> value must be a non-negative integer
 
 Expected has type:  array
-Expected has value: <green>[]</>"
+Expected has value: <g>[]</>
 `;
 
 exports[`toHaveBeenCalledTimes .not only accepts a number argument 3`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveBeenCalledTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toHaveBeenCalledTimes<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a non-negative integer
+<b>Matcher error</>: <g>expected</> value must be a non-negative integer
 
 Expected has type:  boolean
-Expected has value: <green>true</>"
+Expected has value: <g>true</>
 `;
 
 exports[`toHaveBeenCalledTimes .not only accepts a number argument 4`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveBeenCalledTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toHaveBeenCalledTimes<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a non-negative integer
+<b>Matcher error</>: <g>expected</> value must be a non-negative integer
 
 Expected has type:  string
-Expected has value: <green>\\"a\\"</>"
+Expected has value: <g>"a"</>
 `;
 
 exports[`toHaveBeenCalledTimes .not only accepts a number argument 5`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveBeenCalledTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toHaveBeenCalledTimes<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a non-negative integer
+<b>Matcher error</>: <g>expected</> value must be a non-negative integer
 
 Expected has type:  map
-Expected has value: <green>Map {}</>"
+Expected has value: <g>Map {}</>
 `;
 
 exports[`toHaveBeenCalledTimes .not only accepts a number argument 6`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveBeenCalledTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toHaveBeenCalledTimes<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a non-negative integer
+<b>Matcher error</>: <g>expected</> value must be a non-negative integer
 
 Expected has type:  function
-Expected has value: <green>[Function anonymous]</>"
+Expected has value: <g>[Function anonymous]</>
 `;
 
 exports[`toHaveBeenCalledTimes .not passes if function called less than expected times 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveBeenCalledTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toHaveBeenCalledTimes<d>(</><g>expected</><d>)</>
 
-Expected number of calls: <green>2</>
-Received number of calls: <red>1</>"
+Expected number of calls: <g>2</>
+Received number of calls: <r>1</>
 `;
 
 exports[`toHaveBeenCalledTimes .not passes if function called more than expected times 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveBeenCalledTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toHaveBeenCalledTimes<d>(</><g>expected</><d>)</>
 
-Expected number of calls: <green>2</>
-Received number of calls: <red>3</>"
+Expected number of calls: <g>2</>
+Received number of calls: <r>3</>
 `;
 
 exports[`toHaveBeenCalledTimes .not works only on spies or jest.fn 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveBeenCalledTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toHaveBeenCalledTimes<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <red>received</> value must be a mock or spy function
+<b>Matcher error</>: <r>received</> value must be a mock or spy function
 
 Received has type:  function
-Received has value: <red>[Function fn]</>"
+Received has value: <r>[Function fn]</>
 `;
 
 exports[`toHaveBeenCalledTimes includes the custom mock name in the error message 1`] = `
-"<dim>expect(</><red>named-mock</><dim>).</>toHaveBeenCalledTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>named-mock</><d>).</>toHaveBeenCalledTimes<d>(</><g>expected</><d>)</>
 
-Expected number of calls: <green>2</>
-Received number of calls: <red>1</>"
+Expected number of calls: <g>2</>
+Received number of calls: <r>1</>
 `;
 
 exports[`toHaveBeenCalledTimes only accepts a number argument 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveBeenCalledTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toHaveBeenCalledTimes<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a non-negative integer
+<b>Matcher error</>: <g>expected</> value must be a non-negative integer
 
 Expected has type:  object
-Expected has value: <green>{}</>"
+Expected has value: <g>{}</>
 `;
 
 exports[`toHaveBeenCalledTimes only accepts a number argument 2`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveBeenCalledTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toHaveBeenCalledTimes<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a non-negative integer
+<b>Matcher error</>: <g>expected</> value must be a non-negative integer
 
 Expected has type:  array
-Expected has value: <green>[]</>"
+Expected has value: <g>[]</>
 `;
 
 exports[`toHaveBeenCalledTimes only accepts a number argument 3`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveBeenCalledTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toHaveBeenCalledTimes<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a non-negative integer
+<b>Matcher error</>: <g>expected</> value must be a non-negative integer
 
 Expected has type:  boolean
-Expected has value: <green>true</>"
+Expected has value: <g>true</>
 `;
 
 exports[`toHaveBeenCalledTimes only accepts a number argument 4`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveBeenCalledTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toHaveBeenCalledTimes<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a non-negative integer
+<b>Matcher error</>: <g>expected</> value must be a non-negative integer
 
 Expected has type:  string
-Expected has value: <green>\\"a\\"</>"
+Expected has value: <g>"a"</>
 `;
 
 exports[`toHaveBeenCalledTimes only accepts a number argument 5`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveBeenCalledTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toHaveBeenCalledTimes<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a non-negative integer
+<b>Matcher error</>: <g>expected</> value must be a non-negative integer
 
 Expected has type:  map
-Expected has value: <green>Map {}</>"
+Expected has value: <g>Map {}</>
 `;
 
 exports[`toHaveBeenCalledTimes only accepts a number argument 6`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveBeenCalledTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toHaveBeenCalledTimes<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a non-negative integer
+<b>Matcher error</>: <g>expected</> value must be a non-negative integer
 
 Expected has type:  function
-Expected has value: <green>[Function anonymous]</>"
+Expected has value: <g>[Function anonymous]</>
 `;
 
 exports[`toHaveBeenCalledTimes passes if function called equal to expected times 1`] = `
-"<dim>expect(</><red>spy</><dim>).</>not<dim>.</>toHaveBeenCalledTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>spy</><d>).</>not<d>.</>toHaveBeenCalledTimes<d>(</><g>expected</><d>)</>
 
-Expected number of calls: not <green>2</>"
+Expected number of calls: not <g>2</>
 `;
 
 exports[`toHaveBeenCalledWith includes the custom mock name in the error message 1`] = `
-"<dim>expect(</><red>named-mock</><dim>).</>not<dim>.</>toHaveBeenCalledWith<dim>(</><green>...expected</><dim>)</>
+<d>expect(</><r>named-mock</><d>).</>not<d>.</>toHaveBeenCalledWith<d>(</><g>...expected</><d>)</>
 
-Expected: not <green>\\"foo\\"</>, <green>\\"bar\\"</>
+Expected: not <g>"foo"</>, <g>"bar"</>
 
-Number of calls: <red>1</>"
+Number of calls: <r>1</>
 `;
 
 exports[`toHaveBeenCalledWith works only on spies or jest.fn 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveBeenCalledWith<dim>(</><green>...expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toHaveBeenCalledWith<d>(</><g>...expected</><d>)</>
 
-<bold>Matcher error</>: <red>received</> value must be a mock or spy function
+<b>Matcher error</>: <r>received</> value must be a mock or spy function
 
 Received has type:  function
-Received has value: <red>[Function fn]</>"
+Received has value: <r>[Function fn]</>
 `;
 
 exports[`toHaveBeenCalledWith works when not called 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveBeenCalledWith<dim>(</><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toHaveBeenCalledWith<d>(</><g>...expected</><d>)</>
 
-Expected: <green>\\"foo\\"</>, <green>\\"bar\\"</>
+Expected: <g>"foo"</>, <g>"bar"</>
 
-Number of calls: <red>0</>"
+Number of calls: <r>0</>
 `;
 
 exports[`toHaveBeenCalledWith works with Immutable.js objects 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveBeenCalledWith<dim>(</><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toHaveBeenCalledWith<d>(</><g>...expected</><d>)</>
 
-Expected: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>, <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
+Expected: not <g>Immutable.Map {"a": {"b": "c"}}</>, <g>Immutable.Map {"a": {"b": "c"}}</>
 
-Number of calls: <red>1</>"
+Number of calls: <r>1</>
 `;
 
 exports[`toHaveBeenCalledWith works with Map 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveBeenCalledWith<dim>(</><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toHaveBeenCalledWith<d>(</><g>...expected</><d>)</>
 
-Expected: not <green>Map {1 => 2, 2 => 1}</>
+Expected: not <g>Map {1 => 2, 2 => 1}</>
 
-Number of calls: <red>1</>"
+Number of calls: <r>1</>
 `;
 
 exports[`toHaveBeenCalledWith works with Map 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveBeenCalledWith<dim>(</><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toHaveBeenCalledWith<d>(</><g>...expected</><d>)</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Map {</>
-<green>-   \\"a\\" => \\"b\\",</>
-<green>-   \\"b\\" => \\"a\\",</>
-<red>+   1 => 2,</>
-<red>+   2 => 1,</>
-<dim>  }</>,
+<d>  Map {</>
+<g>-   "a" => "b",</>
+<g>-   "b" => "a",</>
+<r>+   1 => 2,</>
+<r>+   2 => 1,</>
+<d>  }</>,
 
-Number of calls: <red>1</>"
+Number of calls: <r>1</>
 `;
 
 exports[`toHaveBeenCalledWith works with Set 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveBeenCalledWith<dim>(</><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toHaveBeenCalledWith<d>(</><g>...expected</><d>)</>
 
-Expected: not <green>Set {1, 2}</>
+Expected: not <g>Set {1, 2}</>
 
-Number of calls: <red>1</>"
+Number of calls: <r>1</>
 `;
 
 exports[`toHaveBeenCalledWith works with Set 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveBeenCalledWith<dim>(</><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toHaveBeenCalledWith<d>(</><g>...expected</><d>)</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Set {</>
-<green>-   3,</>
-<green>-   4,</>
-<red>+   1,</>
-<red>+   2,</>
-<dim>  }</>,
+<d>  Set {</>
+<g>-   3,</>
+<g>-   4,</>
+<r>+   1,</>
+<r>+   2,</>
+<d>  }</>,
 
-Number of calls: <red>1</>"
+Number of calls: <r>1</>
 `;
 
 exports[`toHaveBeenCalledWith works with arguments that don't match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveBeenCalledWith<dim>(</><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toHaveBeenCalledWith<d>(</><g>...expected</><d>)</>
 
-Expected: <green>\\"foo\\"</>, <green>\\"bar\\"</>
-Received: <dim>\\"foo\\"</>, <red>\\"bar1\\"</>
+Expected: <g>"foo"</>, <g>"bar"</>
+Received: <d>"foo"</>, <r>"bar1"</>
 
-Number of calls: <red>1</>"
+Number of calls: <r>1</>
 `;
 
 exports[`toHaveBeenCalledWith works with arguments that match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveBeenCalledWith<dim>(</><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toHaveBeenCalledWith<d>(</><g>...expected</><d>)</>
 
-Expected: not <green>\\"foo\\"</>, <green>\\"bar\\"</>
+Expected: not <g>"foo"</>, <g>"bar"</>
 
-Number of calls: <red>1</>"
+Number of calls: <r>1</>
 `;
 
 exports[`toHaveBeenCalledWith works with many arguments 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveBeenCalledWith<dim>(</><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toHaveBeenCalledWith<d>(</><g>...expected</><d>)</>
 
-Expected: not <green>\\"foo\\"</>, <green>\\"bar\\"</>
+Expected: not <g>"foo"</>, <g>"bar"</>
 Received
-       3:     <dim>\\"foo\\"</>, <dim>\\"bar\\"</>
+       3:     <d>"foo"</>, <d>"bar"</>
 
-Number of calls: <red>3</>"
+Number of calls: <r>3</>
 `;
 
 exports[`toHaveBeenCalledWith works with many arguments that don't match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveBeenCalledWith<dim>(</><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toHaveBeenCalledWith<d>(</><g>...expected</><d>)</>
 
-Expected: <green>\\"foo\\"</>, <green>\\"bar\\"</>
+Expected: <g>"foo"</>, <g>"bar"</>
 Received
-       1: <dim>\\"foo\\"</>, <red>\\"bar1\\"</>
-       2: <dim>\\"foo\\"</>, <red>\\"bar2\\"</>
-       3: <dim>\\"foo\\"</>, <red>\\"bar3\\"</>
+       1: <d>"foo"</>, <r>"bar1"</>
+       2: <d>"foo"</>, <r>"bar2"</>
+       3: <d>"foo"</>, <r>"bar3"</>
 
-Number of calls: <red>3</>"
+Number of calls: <r>3</>
 `;
 
 exports[`toHaveBeenCalledWith works with trailing undefined arguments 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveBeenCalledWith<dim>(</><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toHaveBeenCalledWith<d>(</><g>...expected</><d>)</>
 
-Expected: <green>\\"foo\\"</>
-Received: <dim>\\"foo\\"</>, <red>undefined</>
+Expected: <g>"foo"</>
+Received: <d>"foo"</>, <r>undefined</>
 
-Number of calls: <red>1</>"
+Number of calls: <r>1</>
 `;
 
 exports[`toHaveBeenLastCalledWith includes the custom mock name in the error message 1`] = `
-"<dim>expect(</><red>named-mock</><dim>).</>not<dim>.</>toHaveBeenLastCalledWith<dim>(</><green>...expected</><dim>)</>
+<d>expect(</><r>named-mock</><d>).</>not<d>.</>toHaveBeenLastCalledWith<d>(</><g>...expected</><d>)</>
 
-Expected: not <green>\\"foo\\"</>, <green>\\"bar\\"</>
+Expected: not <g>"foo"</>, <g>"bar"</>
 
-Number of calls: <red>1</>"
+Number of calls: <r>1</>
 `;
 
 exports[`toHaveBeenLastCalledWith works only on spies or jest.fn 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveBeenLastCalledWith<dim>(</><green>...expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toHaveBeenLastCalledWith<d>(</><g>...expected</><d>)</>
 
-<bold>Matcher error</>: <red>received</> value must be a mock or spy function
+<b>Matcher error</>: <r>received</> value must be a mock or spy function
 
 Received has type:  function
-Received has value: <red>[Function fn]</>"
+Received has value: <r>[Function fn]</>
 `;
 
 exports[`toHaveBeenLastCalledWith works when not called 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveBeenLastCalledWith<dim>(</><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toHaveBeenLastCalledWith<d>(</><g>...expected</><d>)</>
 
-Expected: <green>\\"foo\\"</>, <green>\\"bar\\"</>
+Expected: <g>"foo"</>, <g>"bar"</>
 
-Number of calls: <red>0</>"
+Number of calls: <r>0</>
 `;
 
 exports[`toHaveBeenLastCalledWith works with Immutable.js objects 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveBeenLastCalledWith<dim>(</><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toHaveBeenLastCalledWith<d>(</><g>...expected</><d>)</>
 
-Expected: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>, <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
+Expected: not <g>Immutable.Map {"a": {"b": "c"}}</>, <g>Immutable.Map {"a": {"b": "c"}}</>
 
-Number of calls: <red>1</>"
+Number of calls: <r>1</>
 `;
 
 exports[`toHaveBeenLastCalledWith works with Map 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveBeenLastCalledWith<dim>(</><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toHaveBeenLastCalledWith<d>(</><g>...expected</><d>)</>
 
-Expected: not <green>Map {1 => 2, 2 => 1}</>
+Expected: not <g>Map {1 => 2, 2 => 1}</>
 
-Number of calls: <red>1</>"
+Number of calls: <r>1</>
 `;
 
 exports[`toHaveBeenLastCalledWith works with Map 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveBeenLastCalledWith<dim>(</><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toHaveBeenLastCalledWith<d>(</><g>...expected</><d>)</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Map {</>
-<green>-   \\"a\\" => \\"b\\",</>
-<green>-   \\"b\\" => \\"a\\",</>
-<red>+   1 => 2,</>
-<red>+   2 => 1,</>
-<dim>  }</>,
+<d>  Map {</>
+<g>-   "a" => "b",</>
+<g>-   "b" => "a",</>
+<r>+   1 => 2,</>
+<r>+   2 => 1,</>
+<d>  }</>,
 
-Number of calls: <red>1</>"
+Number of calls: <r>1</>
 `;
 
 exports[`toHaveBeenLastCalledWith works with Set 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveBeenLastCalledWith<dim>(</><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toHaveBeenLastCalledWith<d>(</><g>...expected</><d>)</>
 
-Expected: not <green>Set {1, 2}</>
+Expected: not <g>Set {1, 2}</>
 
-Number of calls: <red>1</>"
+Number of calls: <r>1</>
 `;
 
 exports[`toHaveBeenLastCalledWith works with Set 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveBeenLastCalledWith<dim>(</><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toHaveBeenLastCalledWith<d>(</><g>...expected</><d>)</>
 
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Set {</>
-<green>-   3,</>
-<green>-   4,</>
-<red>+   1,</>
-<red>+   2,</>
-<dim>  }</>,
+<d>  Set {</>
+<g>-   3,</>
+<g>-   4,</>
+<r>+   1,</>
+<r>+   2,</>
+<d>  }</>,
 
-Number of calls: <red>1</>"
+Number of calls: <r>1</>
 `;
 
 exports[`toHaveBeenLastCalledWith works with arguments that don't match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveBeenLastCalledWith<dim>(</><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toHaveBeenLastCalledWith<d>(</><g>...expected</><d>)</>
 
-Expected: <green>\\"foo\\"</>, <green>\\"bar\\"</>
-Received: <dim>\\"foo\\"</>, <red>\\"bar1\\"</>
+Expected: <g>"foo"</>, <g>"bar"</>
+Received: <d>"foo"</>, <r>"bar1"</>
 
-Number of calls: <red>1</>"
+Number of calls: <r>1</>
 `;
 
 exports[`toHaveBeenLastCalledWith works with arguments that match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveBeenLastCalledWith<dim>(</><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toHaveBeenLastCalledWith<d>(</><g>...expected</><d>)</>
 
-Expected: not <green>\\"foo\\"</>, <green>\\"bar\\"</>
+Expected: not <g>"foo"</>, <g>"bar"</>
 
-Number of calls: <red>1</>"
+Number of calls: <r>1</>
 `;
 
 exports[`toHaveBeenLastCalledWith works with many arguments 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveBeenLastCalledWith<dim>(</><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toHaveBeenLastCalledWith<d>(</><g>...expected</><d>)</>
 
-Expected: not <green>\\"foo\\"</>, <green>\\"bar\\"</>
+Expected: not <g>"foo"</>, <g>"bar"</>
 Received
-       2:     <dim>\\"foo\\"</>, <red>\\"bar1\\"</>
-->     3:     <dim>\\"foo\\"</>, <dim>\\"bar\\"</>
+       2:     <d>"foo"</>, <r>"bar1"</>
+->     3:     <d>"foo"</>, <d>"bar"</>
 
-Number of calls: <red>3</>"
+Number of calls: <r>3</>
 `;
 
 exports[`toHaveBeenLastCalledWith works with many arguments that don't match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveBeenLastCalledWith<dim>(</><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toHaveBeenLastCalledWith<d>(</><g>...expected</><d>)</>
 
-Expected: <green>\\"foo\\"</>, <green>\\"bar\\"</>
+Expected: <g>"foo"</>, <g>"bar"</>
 Received
-       2: <dim>\\"foo\\"</>, <red>\\"bar2\\"</>
-->     3: <dim>\\"foo\\"</>, <red>\\"bar3\\"</>
+       2: <d>"foo"</>, <r>"bar2"</>
+->     3: <d>"foo"</>, <r>"bar3"</>
 
-Number of calls: <red>3</>"
+Number of calls: <r>3</>
 `;
 
 exports[`toHaveBeenLastCalledWith works with trailing undefined arguments 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveBeenLastCalledWith<dim>(</><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toHaveBeenLastCalledWith<d>(</><g>...expected</><d>)</>
 
-Expected: <green>\\"foo\\"</>
-Received: <dim>\\"foo\\"</>, <red>undefined</>
+Expected: <g>"foo"</>
+Received: <d>"foo"</>, <r>undefined</>
 
-Number of calls: <red>1</>"
+Number of calls: <r>1</>
 `;
 
 exports[`toHaveBeenNthCalledWith includes the custom mock name in the error message 1`] = `
-"<dim>expect(</><red>named-mock</><dim>).</>not<dim>.</>toHaveBeenNthCalledWith<dim>(</>n<dim>, </><green>...expected</><dim>)</>
+<d>expect(</><r>named-mock</><d>).</>not<d>.</>toHaveBeenNthCalledWith<d>(</>n<d>, </><g>...expected</><d>)</>
 
 n: 1
-Expected: not <green>\\"foo\\"</>, <green>\\"bar\\"</>
+Expected: not <g>"foo"</>, <g>"bar"</>
 
-Number of calls: <red>1</>"
+Number of calls: <r>1</>
 `;
 
 exports[`toHaveBeenNthCalledWith negative throw matcher error for n that is not integer 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveBeenNthCalledWith<dim>(</>n<dim>, </><green>...expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toHaveBeenNthCalledWith<d>(</>n<d>, </><g>...expected</><d>)</>
 
-<bold>Matcher error</>: n must be a positive integer
+<b>Matcher error</>: n must be a positive integer
 
 n has type:  number
-n has value: Infinity"
+n has value: Infinity
 `;
 
 exports[`toHaveBeenNthCalledWith positive throw matcher error for n that is not integer 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveBeenNthCalledWith<dim>(</>n<dim>, </><green>...expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toHaveBeenNthCalledWith<d>(</>n<d>, </><g>...expected</><d>)</>
 
-<bold>Matcher error</>: n must be a positive integer
+<b>Matcher error</>: n must be a positive integer
 
 n has type:  number
-n has value: 0.1"
+n has value: 0.1
 `;
 
 exports[`toHaveBeenNthCalledWith positive throw matcher error for n that is not positive integer 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveBeenNthCalledWith<dim>(</>n<dim>, </><green>...expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toHaveBeenNthCalledWith<d>(</>n<d>, </><g>...expected</><d>)</>
 
-<bold>Matcher error</>: n must be a positive integer
+<b>Matcher error</>: n must be a positive integer
 
 n has type:  number
-n has value: 0"
+n has value: 0
 `;
 
 exports[`toHaveBeenNthCalledWith works only on spies or jest.fn 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveBeenNthCalledWith<dim>(</>n<dim>, </><green>...expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toHaveBeenNthCalledWith<d>(</>n<d>, </><g>...expected</><d>)</>
 
-<bold>Matcher error</>: <red>received</> value must be a mock or spy function
+<b>Matcher error</>: <r>received</> value must be a mock or spy function
 
 Received has type:  function
-Received has value: <red>[Function fn]</>"
+Received has value: <r>[Function fn]</>
 `;
 
 exports[`toHaveBeenNthCalledWith works when not called 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveBeenNthCalledWith<dim>(</>n<dim>, </><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toHaveBeenNthCalledWith<d>(</>n<d>, </><g>...expected</><d>)</>
 
 n: 1
-Expected: <green>\\"foo\\"</>, <green>\\"bar\\"</>
+Expected: <g>"foo"</>, <g>"bar"</>
 
-Number of calls: <red>0</>"
+Number of calls: <r>0</>
 `;
 
 exports[`toHaveBeenNthCalledWith works with Immutable.js objects 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveBeenNthCalledWith<dim>(</>n<dim>, </><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toHaveBeenNthCalledWith<d>(</>n<d>, </><g>...expected</><d>)</>
 
 n: 1
-Expected: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>, <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
+Expected: not <g>Immutable.Map {"a": {"b": "c"}}</>, <g>Immutable.Map {"a": {"b": "c"}}</>
 
-Number of calls: <red>1</>"
+Number of calls: <r>1</>
 `;
 
 exports[`toHaveBeenNthCalledWith works with Map 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveBeenNthCalledWith<dim>(</>n<dim>, </><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toHaveBeenNthCalledWith<d>(</>n<d>, </><g>...expected</><d>)</>
 
 n: 1
-Expected: not <green>Map {1 => 2, 2 => 1}</>
+Expected: not <g>Map {1 => 2, 2 => 1}</>
 
-Number of calls: <red>1</>"
+Number of calls: <r>1</>
 `;
 
 exports[`toHaveBeenNthCalledWith works with Map 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveBeenNthCalledWith<dim>(</>n<dim>, </><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toHaveBeenNthCalledWith<d>(</>n<d>, </><g>...expected</><d>)</>
 
 n: 1
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Map {</>
-<green>-   \\"a\\" => \\"b\\",</>
-<green>-   \\"b\\" => \\"a\\",</>
-<red>+   1 => 2,</>
-<red>+   2 => 1,</>
-<dim>  }</>,
+<d>  Map {</>
+<g>-   "a" => "b",</>
+<g>-   "b" => "a",</>
+<r>+   1 => 2,</>
+<r>+   2 => 1,</>
+<d>  }</>,
 
-Number of calls: <red>1</>"
+Number of calls: <r>1</>
 `;
 
 exports[`toHaveBeenNthCalledWith works with Set 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveBeenNthCalledWith<dim>(</>n<dim>, </><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toHaveBeenNthCalledWith<d>(</>n<d>, </><g>...expected</><d>)</>
 
 n: 1
-Expected: not <green>Set {1, 2}</>
+Expected: not <g>Set {1, 2}</>
 
-Number of calls: <red>1</>"
+Number of calls: <r>1</>
 `;
 
 exports[`toHaveBeenNthCalledWith works with Set 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveBeenNthCalledWith<dim>(</>n<dim>, </><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toHaveBeenNthCalledWith<d>(</>n<d>, </><g>...expected</><d>)</>
 
 n: 1
-<green>- Expected</>
-<red>+ Received</>
+<g>- Expected</>
+<r>+ Received</>
 
-<dim>  Set {</>
-<green>-   3,</>
-<green>-   4,</>
-<red>+   1,</>
-<red>+   2,</>
-<dim>  }</>,
+<d>  Set {</>
+<g>-   3,</>
+<g>-   4,</>
+<r>+   1,</>
+<r>+   2,</>
+<d>  }</>,
 
-Number of calls: <red>1</>"
+Number of calls: <r>1</>
 `;
 
 exports[`toHaveBeenNthCalledWith works with arguments that don't match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveBeenNthCalledWith<dim>(</>n<dim>, </><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toHaveBeenNthCalledWith<d>(</>n<d>, </><g>...expected</><d>)</>
 
 n: 1
-Expected: <green>\\"foo\\"</>, <green>\\"bar\\"</>
-Received: <dim>\\"foo\\"</>, <red>\\"bar1\\"</>
+Expected: <g>"foo"</>, <g>"bar"</>
+Received: <d>"foo"</>, <r>"bar1"</>
 
-Number of calls: <red>1</>"
+Number of calls: <r>1</>
 `;
 
 exports[`toHaveBeenNthCalledWith works with arguments that match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveBeenNthCalledWith<dim>(</>n<dim>, </><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toHaveBeenNthCalledWith<d>(</>n<d>, </><g>...expected</><d>)</>
 
 n: 1
-Expected: not <green>\\"foo\\"</>, <green>\\"bar\\"</>
+Expected: not <g>"foo"</>, <g>"bar"</>
 
-Number of calls: <red>1</>"
+Number of calls: <r>1</>
 `;
 
 exports[`toHaveBeenNthCalledWith works with three calls 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveBeenNthCalledWith<dim>(</>n<dim>, </><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toHaveBeenNthCalledWith<d>(</>n<d>, </><g>...expected</><d>)</>
 
 n: 1
-Expected: not <green>\\"foo1\\"</>, <green>\\"bar\\"</>
+Expected: not <g>"foo1"</>, <g>"bar"</>
 Received
-->     1:     <dim>\\"foo1\\"</>, <dim>\\"bar\\"</>
-       2:     <red>\\"foo\\"</>, <red>\\"bar1\\"</>
+->     1:     <d>"foo1"</>, <d>"bar"</>
+       2:     <r>"foo"</>, <r>"bar1"</>
 
-Number of calls: <red>3</>"
+Number of calls: <r>3</>
 `;
 
 exports[`toHaveBeenNthCalledWith works with trailing undefined arguments 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveBeenNthCalledWith<dim>(</>n<dim>, </><green>...expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toHaveBeenNthCalledWith<d>(</>n<d>, </><g>...expected</><d>)</>
 
 n: 1
-Expected: <green>\\"foo\\"</>
-Received: <dim>\\"foo\\"</>, <red>undefined</>
+Expected: <g>"foo"</>
+Received: <d>"foo"</>, <r>undefined</>
 
-Number of calls: <red>1</>"
+Number of calls: <r>1</>
 `;
 
 exports[`toHaveLastReturnedWith a call that throws is not considered to have returned 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveLastReturnedWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toHaveLastReturnedWith<d>(</><g>expected</><d>)</>
 
-Expected: <green>undefined</>
+Expected: <g>undefined</>
 Received: function call threw an error
 
-Number of returns: <red>0</>
-Number of calls:   <red>1</>"
+Number of returns: <r>0</>
+Number of calls:   <r>1</>
 `;
 
 exports[`toHaveLastReturnedWith a call that throws undefined is not considered to have returned 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveLastReturnedWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toHaveLastReturnedWith<d>(</><g>expected</><d>)</>
 
-Expected: <green>undefined</>
+Expected: <g>undefined</>
 Received: function call threw an error
 
-Number of returns: <red>0</>
-Number of calls:   <red>1</>"
+Number of returns: <r>0</>
+Number of calls:   <r>1</>
 `;
 
 exports[`toHaveLastReturnedWith includes the custom mock name in the error message 1`] = `
-"<dim>expect(</><red>named-mock</><dim>).</>toHaveLastReturnedWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>named-mock</><d>).</>toHaveLastReturnedWith<d>(</><g>expected</><d>)</>
 
-Expected: <green>\\"foo\\"</>
+Expected: <g>"foo"</>
 
-Number of returns: <red>0</>"
+Number of returns: <r>0</>
 `;
 
 exports[`toHaveLastReturnedWith lastReturnedWith incomplete recursive calls are handled properly 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveLastReturnedWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toHaveLastReturnedWith<d>(</><g>expected</><d>)</>
 
-Expected: <green>0</>
+Expected: <g>0</>
 Received
        3: function call has not returned yet
 ->     4: function call has not returned yet
 
-Number of returns: <red>0</>
-Number of calls:   <red>4</>"
+Number of returns: <r>0</>
+Number of calls:   <r>4</>
 `;
 
 exports[`toHaveLastReturnedWith lastReturnedWith works with three calls 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveLastReturnedWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toHaveLastReturnedWith<d>(</><g>expected</><d>)</>
 
-Expected: not <green>\\"foo3\\"</>
+Expected: not <g>"foo3"</>
 Received
-       2:     <red>\\"foo2\\"</>
-->     3:     <dim>\\"foo3\\"</>
+       2:     <r>"foo2"</>
+->     3:     <d>"foo3"</>
 
-Number of returns: <red>3</>"
+Number of returns: <r>3</>
 `;
 
 exports[`toHaveLastReturnedWith works only on spies or jest.fn 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveLastReturnedWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toHaveLastReturnedWith<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <red>received</> value must be a mock function
+<b>Matcher error</>: <r>received</> value must be a mock function
 
 Received has type:  function
-Received has value: <red>[Function fn]</>"
+Received has value: <r>[Function fn]</>
 `;
 
 exports[`toHaveLastReturnedWith works when not called 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveLastReturnedWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toHaveLastReturnedWith<d>(</><g>expected</><d>)</>
 
-Expected: <green>\\"foo\\"</>
+Expected: <g>"foo"</>
 
-Number of returns: <red>0</>"
+Number of returns: <r>0</>
 `;
 
 exports[`toHaveLastReturnedWith works with Immutable.js objects directly created 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveLastReturnedWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toHaveLastReturnedWith<d>(</><g>expected</><d>)</>
 
-Expected: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
+Expected: not <g>Immutable.Map {"a": {"b": "c"}}</>
 
-Number of returns: <red>1</>"
+Number of returns: <r>1</>
 `;
 
 exports[`toHaveLastReturnedWith works with Immutable.js objects indirectly created 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveLastReturnedWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toHaveLastReturnedWith<d>(</><g>expected</><d>)</>
 
-Expected: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
+Expected: not <g>Immutable.Map {"a": {"b": "c"}}</>
 
-Number of returns: <red>1</>"
+Number of returns: <r>1</>
 `;
 
 exports[`toHaveLastReturnedWith works with Map 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveLastReturnedWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toHaveLastReturnedWith<d>(</><g>expected</><d>)</>
 
-Expected: not <green>Map {1 => 2, 2 => 1}</>
+Expected: not <g>Map {1 => 2, 2 => 1}</>
 
-Number of returns: <red>1</>"
+Number of returns: <r>1</>
 `;
 
 exports[`toHaveLastReturnedWith works with Map 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveLastReturnedWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toHaveLastReturnedWith<d>(</><g>expected</><d>)</>
 
-Expected: <green>Map {\\"a\\" => \\"b\\", \\"b\\" => \\"a\\"}</>
-Received: <red>Map {1 => 2, 2 => 1}</>
+Expected: <g>Map {"a" => "b", "b" => "a"}</>
+Received: <r>Map {1 => 2, 2 => 1}</>
 
-Number of returns: <red>1</>"
+Number of returns: <r>1</>
 `;
 
 exports[`toHaveLastReturnedWith works with Set 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveLastReturnedWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toHaveLastReturnedWith<d>(</><g>expected</><d>)</>
 
-Expected: not <green>Set {1, 2}</>
+Expected: not <g>Set {1, 2}</>
 
-Number of returns: <red>1</>"
+Number of returns: <r>1</>
 `;
 
 exports[`toHaveLastReturnedWith works with Set 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveLastReturnedWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toHaveLastReturnedWith<d>(</><g>expected</><d>)</>
 
-Expected: <green>Set {3, 4}</>
-Received: <red>Set {1, 2}</>
+Expected: <g>Set {3, 4}</>
+Received: <r>Set {1, 2}</>
 
-Number of returns: <red>1</>"
+Number of returns: <r>1</>
 `;
 
 exports[`toHaveLastReturnedWith works with argument that does match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveLastReturnedWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toHaveLastReturnedWith<d>(</><g>expected</><d>)</>
 
-Expected: not <green>\\"foo\\"</>
+Expected: not <g>"foo"</>
 
-Number of returns: <red>1</>"
+Number of returns: <r>1</>
 `;
 
 exports[`toHaveLastReturnedWith works with argument that does not match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveLastReturnedWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toHaveLastReturnedWith<d>(</><g>expected</><d>)</>
 
-Expected: <green>\\"bar\\"</>
-Received: <red>\\"foo\\"</>
+Expected: <g>"bar"</>
+Received: <r>"foo"</>
 
-Number of returns: <red>1</>"
+Number of returns: <r>1</>
 `;
 
 exports[`toHaveLastReturnedWith works with undefined 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveLastReturnedWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toHaveLastReturnedWith<d>(</><g>expected</><d>)</>
 
-Expected: not <green>undefined</>
+Expected: not <g>undefined</>
 
-Number of returns: <red>1</>"
+Number of returns: <r>1</>
 `;
 
 exports[`toHaveNthReturnedWith a call that throws is not considered to have returned 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveNthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toHaveNthReturnedWith<d>(</>n<d>, </><g>expected</><d>)</>
 
 n: 1
-Expected: <green>undefined</>
+Expected: <g>undefined</>
 Received: function call threw an error
 
-Number of returns: <red>0</>
-Number of calls:   <red>1</>"
+Number of returns: <r>0</>
+Number of calls:   <r>1</>
 `;
 
 exports[`toHaveNthReturnedWith a call that throws undefined is not considered to have returned 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveNthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toHaveNthReturnedWith<d>(</>n<d>, </><g>expected</><d>)</>
 
 n: 1
-Expected: <green>undefined</>
+Expected: <g>undefined</>
 Received: function call threw an error
 
-Number of returns: <red>0</>
-Number of calls:   <red>1</>"
+Number of returns: <r>0</>
+Number of calls:   <r>1</>
 `;
 
 exports[`toHaveNthReturnedWith includes the custom mock name in the error message 1`] = `
-"<dim>expect(</><red>named-mock</><dim>).</>toHaveNthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
+<d>expect(</><r>named-mock</><d>).</>toHaveNthReturnedWith<d>(</>n<d>, </><g>expected</><d>)</>
 
 n: 1
-Expected: <green>\\"foo\\"</>
+Expected: <g>"foo"</>
 
-Number of returns: <red>0</>"
+Number of returns: <r>0</>
 `;
 
 exports[`toHaveNthReturnedWith nthReturnedWith incomplete recursive calls are handled properly 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveNthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toHaveNthReturnedWith<d>(</>n<d>, </><g>expected</><d>)</>
 
 n: 1
-Expected: <green>6</>
+Expected: <g>6</>
 Received
 ->     1: function call has not returned yet
        2: function call has not returned yet
 
-Number of returns: <red>2</>
-Number of calls:   <red>4</>"
+Number of returns: <r>2</>
+Number of calls:   <r>4</>
 `;
 
 exports[`toHaveNthReturnedWith nthReturnedWith incomplete recursive calls are handled properly 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveNthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toHaveNthReturnedWith<d>(</>n<d>, </><g>expected</><d>)</>
 
 n: 2
-Expected: <green>3</>
+Expected: <g>3</>
 Received
        1: function call has not returned yet
 ->     2: function call has not returned yet
-       3: <red>1</>
+       3: <r>1</>
 
-Number of returns: <red>2</>
-Number of calls:   <red>4</>"
+Number of returns: <r>2</>
+Number of calls:   <r>4</>
 `;
 
 exports[`toHaveNthReturnedWith nthReturnedWith incomplete recursive calls are handled properly 3`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toHaveNthReturnedWith<d>(</>n<d>, </><g>expected</><d>)</>
 
 n: 3
-Expected: not <green>1</>
+Expected: not <g>1</>
 Received
        2:     function call has not returned yet
-->     3:     <dim>1</>
-       4:     <red>0</>
+->     3:     <d>1</>
+       4:     <r>0</>
 
-Number of returns: <red>2</>
-Number of calls:   <red>4</>"
+Number of returns: <r>2</>
+Number of calls:   <r>4</>
 `;
 
 exports[`toHaveNthReturnedWith nthReturnedWith incomplete recursive calls are handled properly 4`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toHaveNthReturnedWith<d>(</>n<d>, </><g>expected</><d>)</>
 
 n: 4
-Expected: not <green>0</>
+Expected: not <g>0</>
 Received
-       3:     <red>1</>
-->     4:     <dim>0</>
+       3:     <r>1</>
+->     4:     <d>0</>
 
-Number of returns: <red>2</>
-Number of calls:   <red>4</>"
+Number of returns: <r>2</>
+Number of calls:   <r>4</>
 `;
 
 exports[`toHaveNthReturnedWith nthReturnedWith negative throw matcher error for n that is not number 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toHaveNthReturnedWith<d>(</>n<d>, </><g>expected</><d>)</>
 
-<bold>Matcher error</>: n must be a positive integer
+<b>Matcher error</>: n must be a positive integer
 
-n has value: undefined"
+n has value: undefined
 `;
 
 exports[`toHaveNthReturnedWith nthReturnedWith positive throw matcher error for n that is not integer 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveNthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toHaveNthReturnedWith<d>(</>n<d>, </><g>expected</><d>)</>
 
-<bold>Matcher error</>: n must be a positive integer
+<b>Matcher error</>: n must be a positive integer
 
 n has type:  number
-n has value: 0.1"
+n has value: 0.1
 `;
 
 exports[`toHaveNthReturnedWith nthReturnedWith positive throw matcher error for n that is not positive integer 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveNthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toHaveNthReturnedWith<d>(</>n<d>, </><g>expected</><d>)</>
 
-<bold>Matcher error</>: n must be a positive integer
+<b>Matcher error</>: n must be a positive integer
 
 n has type:  number
-n has value: 0"
+n has value: 0
 `;
 
 exports[`toHaveNthReturnedWith nthReturnedWith should reject nth value greater than number of calls 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveNthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toHaveNthReturnedWith<d>(</>n<d>, </><g>expected</><d>)</>
 
 n: 4
-Expected: <green>\\"foo\\"</>
+Expected: <g>"foo"</>
 Received
-       3: <dim>\\"foo\\"</>
+       3: <d>"foo"</>
 
-Number of returns: <red>3</>"
+Number of returns: <r>3</>
 `;
 
 exports[`toHaveNthReturnedWith nthReturnedWith should replace 1st, 2nd, 3rd with first, second, third 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveNthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toHaveNthReturnedWith<d>(</>n<d>, </><g>expected</><d>)</>
 
 n: 1
-Expected: <green>\\"bar1\\"</>
+Expected: <g>"bar1"</>
 Received
-->     1: <red>\\"foo1\\"</>
-       2: <red>\\"foo2\\"</>
+->     1: <r>"foo1"</>
+       2: <r>"foo2"</>
 
-Number of returns: <red>3</>"
+Number of returns: <r>3</>
 `;
 
 exports[`toHaveNthReturnedWith nthReturnedWith should replace 1st, 2nd, 3rd with first, second, third 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toHaveNthReturnedWith<d>(</>n<d>, </><g>expected</><d>)</>
 
 n: 1
-Expected: not <green>\\"foo1\\"</>
+Expected: not <g>"foo1"</>
 Received
-->     1:     <dim>\\"foo1\\"</>
-       2:     <red>\\"foo2\\"</>
+->     1:     <d>"foo1"</>
+       2:     <r>"foo2"</>
 
-Number of returns: <red>3</>"
+Number of returns: <r>3</>
 `;
 
 exports[`toHaveNthReturnedWith nthReturnedWith works with three calls 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toHaveNthReturnedWith<d>(</>n<d>, </><g>expected</><d>)</>
 
 n: 1
-Expected: not <green>\\"foo1\\"</>
+Expected: not <g>"foo1"</>
 Received
-->     1:     <dim>\\"foo1\\"</>
-       2:     <red>\\"foo2\\"</>
+->     1:     <d>"foo1"</>
+       2:     <r>"foo2"</>
 
-Number of returns: <red>3</>"
+Number of returns: <r>3</>
 `;
 
 exports[`toHaveNthReturnedWith works only on spies or jest.fn 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveNthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toHaveNthReturnedWith<d>(</>n<d>, </><g>expected</><d>)</>
 
-<bold>Matcher error</>: <red>received</> value must be a mock function
+<b>Matcher error</>: <r>received</> value must be a mock function
 
 Received has type:  function
-Received has value: <red>[Function fn]</>"
+Received has value: <r>[Function fn]</>
 `;
 
 exports[`toHaveNthReturnedWith works when not called 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveNthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toHaveNthReturnedWith<d>(</>n<d>, </><g>expected</><d>)</>
 
 n: 1
-Expected: <green>\\"foo\\"</>
+Expected: <g>"foo"</>
 
-Number of returns: <red>0</>"
+Number of returns: <r>0</>
 `;
 
 exports[`toHaveNthReturnedWith works with Immutable.js objects directly created 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toHaveNthReturnedWith<d>(</>n<d>, </><g>expected</><d>)</>
 
 n: 1
-Expected: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
+Expected: not <g>Immutable.Map {"a": {"b": "c"}}</>
 
-Number of returns: <red>1</>"
+Number of returns: <r>1</>
 `;
 
 exports[`toHaveNthReturnedWith works with Immutable.js objects indirectly created 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toHaveNthReturnedWith<d>(</>n<d>, </><g>expected</><d>)</>
 
 n: 1
-Expected: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
+Expected: not <g>Immutable.Map {"a": {"b": "c"}}</>
 
-Number of returns: <red>1</>"
+Number of returns: <r>1</>
 `;
 
 exports[`toHaveNthReturnedWith works with Map 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toHaveNthReturnedWith<d>(</>n<d>, </><g>expected</><d>)</>
 
 n: 1
-Expected: not <green>Map {1 => 2, 2 => 1}</>
+Expected: not <g>Map {1 => 2, 2 => 1}</>
 
-Number of returns: <red>1</>"
+Number of returns: <r>1</>
 `;
 
 exports[`toHaveNthReturnedWith works with Map 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveNthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toHaveNthReturnedWith<d>(</>n<d>, </><g>expected</><d>)</>
 
 n: 1
-Expected: <green>Map {\\"a\\" => \\"b\\", \\"b\\" => \\"a\\"}</>
-Received: <red>Map {1 => 2, 2 => 1}</>
+Expected: <g>Map {"a" => "b", "b" => "a"}</>
+Received: <r>Map {1 => 2, 2 => 1}</>
 
-Number of returns: <red>1</>"
+Number of returns: <r>1</>
 `;
 
 exports[`toHaveNthReturnedWith works with Set 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toHaveNthReturnedWith<d>(</>n<d>, </><g>expected</><d>)</>
 
 n: 1
-Expected: not <green>Set {1, 2}</>
+Expected: not <g>Set {1, 2}</>
 
-Number of returns: <red>1</>"
+Number of returns: <r>1</>
 `;
 
 exports[`toHaveNthReturnedWith works with Set 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveNthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toHaveNthReturnedWith<d>(</>n<d>, </><g>expected</><d>)</>
 
 n: 1
-Expected: <green>Set {3, 4}</>
-Received: <red>Set {1, 2}</>
+Expected: <g>Set {3, 4}</>
+Received: <r>Set {1, 2}</>
 
-Number of returns: <red>1</>"
+Number of returns: <r>1</>
 `;
 
 exports[`toHaveNthReturnedWith works with argument that does match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toHaveNthReturnedWith<d>(</>n<d>, </><g>expected</><d>)</>
 
 n: 1
-Expected: not <green>\\"foo\\"</>
+Expected: not <g>"foo"</>
 
-Number of returns: <red>1</>"
+Number of returns: <r>1</>
 `;
 
 exports[`toHaveNthReturnedWith works with argument that does not match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveNthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toHaveNthReturnedWith<d>(</>n<d>, </><g>expected</><d>)</>
 
 n: 1
-Expected: <green>\\"bar\\"</>
-Received: <red>\\"foo\\"</>
+Expected: <g>"bar"</>
+Received: <r>"foo"</>
 
-Number of returns: <red>1</>"
+Number of returns: <r>1</>
 `;
 
 exports[`toHaveNthReturnedWith works with undefined 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveNthReturnedWith<dim>(</>n<dim>, </><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toHaveNthReturnedWith<d>(</>n<d>, </><g>expected</><d>)</>
 
 n: 1
-Expected: not <green>undefined</>
+Expected: not <g>undefined</>
 
-Number of returns: <red>1</>"
+Number of returns: <r>1</>
 `;
 
 exports[`toHaveReturned .not fails with any argument passed 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveReturned<dim>()</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toHaveReturned<d>()</>
 
-<bold>Matcher error</>: this matcher must not have an expected argument
+<b>Matcher error</>: this matcher must not have an expected argument
 
 Expected has type:  number
-Expected has value: <green>555</>"
+Expected has value: <g>555</>
 `;
 
 exports[`toHaveReturned .not passes when a call throws undefined 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveReturned<dim>()</>
+<d>expect(</><r>jest.fn()</><d>).</>toHaveReturned<d>()</>
 
-Expected number of returns: >= <green>1</>
-Received number of returns:    <red>0</>
-Received number of calls:      <red>1</>"
+Expected number of returns: >= <g>1</>
+Received number of returns:    <r>0</>
+Received number of calls:      <r>1</>
 `;
 
 exports[`toHaveReturned .not passes when all calls throw 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveReturned<dim>()</>
+<d>expect(</><r>jest.fn()</><d>).</>toHaveReturned<d>()</>
 
-Expected number of returns: >= <green>1</>
-Received number of returns:    <red>0</>
-Received number of calls:      <red>2</>"
+Expected number of returns: >= <g>1</>
+Received number of returns:    <r>0</>
+Received number of calls:      <r>2</>
 `;
 
 exports[`toHaveReturned .not passes when not returned 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveReturned<dim>()</>
+<d>expect(</><r>jest.fn()</><d>).</>toHaveReturned<d>()</>
 
-Expected number of returns: >= <green>1</>
-Received number of returns:    <red>0</>"
+Expected number of returns: >= <g>1</>
+Received number of returns:    <r>0</>
 `;
 
 exports[`toHaveReturned .not works only on jest.fn 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveReturned<dim>()</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toHaveReturned<d>()</>
 
-<bold>Matcher error</>: <red>received</> value must be a mock function
+<b>Matcher error</>: <r>received</> value must be a mock function
 
 Received has type:  function
-Received has value: <red>[Function fn]</>"
+Received has value: <r>[Function fn]</>
 `;
 
 exports[`toHaveReturned fails with any argument passed 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveReturned<dim>()</>
+<d>expect(</><r>received</><d>).</>toHaveReturned<d>()</>
 
-<bold>Matcher error</>: this matcher must not have an expected argument
+<b>Matcher error</>: this matcher must not have an expected argument
 
 Expected has type:  number
-Expected has value: <green>555</>"
+Expected has value: <g>555</>
 `;
 
 exports[`toHaveReturned includes the custom mock name in the error message 1`] = `
-"<dim>expect(</><red>named-mock</><dim>).</>not<dim>.</>toHaveReturned<dim>()</>
+<d>expect(</><r>named-mock</><d>).</>not<d>.</>toHaveReturned<d>()</>
 
-Expected number of returns: <green>0</>
-Received number of returns: <red>1</>
+Expected number of returns: <g>0</>
+Received number of returns: <r>1</>
 
-1: <red>42</>"
+1: <r>42</>
 `;
 
 exports[`toHaveReturned incomplete recursive calls are handled properly 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveReturned<dim>()</>
+<d>expect(</><r>jest.fn()</><d>).</>toHaveReturned<d>()</>
 
-Expected number of returns: >= <green>1</>
-Received number of returns:    <red>0</>
-Received number of calls:      <red>4</>"
+Expected number of returns: >= <g>1</>
+Received number of returns:    <r>0</>
+Received number of calls:      <r>4</>
 `;
 
 exports[`toHaveReturned passes when at least one call does not throw 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveReturned<dim>()</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toHaveReturned<d>()</>
 
-Expected number of returns: <green>0</>
-Received number of returns: <red>2</>
+Expected number of returns: <g>0</>
+Received number of returns: <r>2</>
 
-1: <red>42</>
-3: <red>42</>
+1: <r>42</>
+3: <r>42</>
 
-Received number of calls:   <red>3</>"
+Received number of calls:   <r>3</>
 `;
 
 exports[`toHaveReturned passes when returned 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveReturned<dim>()</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toHaveReturned<d>()</>
 
-Expected number of returns: <green>0</>
-Received number of returns: <red>1</>
+Expected number of returns: <g>0</>
+Received number of returns: <r>1</>
 
-1: <red>42</>"
+1: <r>42</>
 `;
 
 exports[`toHaveReturned passes when undefined is returned 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveReturned<dim>()</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toHaveReturned<d>()</>
 
-Expected number of returns: <green>0</>
-Received number of returns: <red>1</>
+Expected number of returns: <g>0</>
+Received number of returns: <r>1</>
 
-1: <red>undefined</>"
+1: <r>undefined</>
 `;
 
 exports[`toHaveReturned throw matcher error if received is spy 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveReturned<dim>()</>
+<d>expect(</><r>received</><d>).</>toHaveReturned<d>()</>
 
-<bold>Matcher error</>: <red>received</> value must be a mock function
+<b>Matcher error</>: <r>received</> value must be a mock function
 
 Received has type:  function
-Received has value: <red>[Function spy]</>"
+Received has value: <r>[Function spy]</>
 `;
 
 exports[`toHaveReturnedTimes .not only accepts a number argument 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveReturnedTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toHaveReturnedTimes<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a non-negative integer
+<b>Matcher error</>: <g>expected</> value must be a non-negative integer
 
 Expected has type:  object
-Expected has value: <green>{}</>"
+Expected has value: <g>{}</>
 `;
 
 exports[`toHaveReturnedTimes .not only accepts a number argument 2`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveReturnedTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toHaveReturnedTimes<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a non-negative integer
+<b>Matcher error</>: <g>expected</> value must be a non-negative integer
 
 Expected has type:  array
-Expected has value: <green>[]</>"
+Expected has value: <g>[]</>
 `;
 
 exports[`toHaveReturnedTimes .not only accepts a number argument 3`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveReturnedTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toHaveReturnedTimes<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a non-negative integer
+<b>Matcher error</>: <g>expected</> value must be a non-negative integer
 
 Expected has type:  boolean
-Expected has value: <green>true</>"
+Expected has value: <g>true</>
 `;
 
 exports[`toHaveReturnedTimes .not only accepts a number argument 4`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveReturnedTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toHaveReturnedTimes<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a non-negative integer
+<b>Matcher error</>: <g>expected</> value must be a non-negative integer
 
 Expected has type:  string
-Expected has value: <green>\\"a\\"</>"
+Expected has value: <g>"a"</>
 `;
 
 exports[`toHaveReturnedTimes .not only accepts a number argument 5`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveReturnedTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toHaveReturnedTimes<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a non-negative integer
+<b>Matcher error</>: <g>expected</> value must be a non-negative integer
 
 Expected has type:  map
-Expected has value: <green>Map {}</>"
+Expected has value: <g>Map {}</>
 `;
 
 exports[`toHaveReturnedTimes .not only accepts a number argument 6`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveReturnedTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toHaveReturnedTimes<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a non-negative integer
+<b>Matcher error</>: <g>expected</> value must be a non-negative integer
 
 Expected has type:  function
-Expected has value: <green>[Function anonymous]</>"
+Expected has value: <g>[Function anonymous]</>
 `;
 
 exports[`toHaveReturnedTimes .not passes if function called less than expected times 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveReturnedTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toHaveReturnedTimes<d>(</><g>expected</><d>)</>
 
-Expected number of returns: <green>2</>
-Received number of returns: <red>1</>"
+Expected number of returns: <g>2</>
+Received number of returns: <r>1</>
 `;
 
 exports[`toHaveReturnedTimes .not passes if function returned more than expected times 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveReturnedTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toHaveReturnedTimes<d>(</><g>expected</><d>)</>
 
-Expected number of returns: <green>2</>
-Received number of returns: <red>3</>"
+Expected number of returns: <g>2</>
+Received number of returns: <r>3</>
 `;
 
 exports[`toHaveReturnedTimes calls that return undefined are counted as returns 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveReturnedTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toHaveReturnedTimes<d>(</><g>expected</><d>)</>
 
-Expected number of returns: not <green>2</>"
+Expected number of returns: not <g>2</>
 `;
 
 exports[`toHaveReturnedTimes calls that throw are not counted 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveReturnedTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toHaveReturnedTimes<d>(</><g>expected</><d>)</>
 
-Expected number of returns: <green>3</>
-Received number of returns: <red>2</>
-Received number of calls:   <red>3</>"
+Expected number of returns: <g>3</>
+Received number of returns: <r>2</>
+Received number of calls:   <r>3</>
 `;
 
 exports[`toHaveReturnedTimes calls that throw undefined are not counted 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveReturnedTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toHaveReturnedTimes<d>(</><g>expected</><d>)</>
 
-Expected number of returns: not <green>2</>
+Expected number of returns: not <g>2</>
 
-Received number of calls:       <red>3</>"
+Received number of calls:       <r>3</>
 `;
 
 exports[`toHaveReturnedTimes includes the custom mock name in the error message 1`] = `
-"<dim>expect(</><red>named-mock</><dim>).</>toHaveReturnedTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>named-mock</><d>).</>toHaveReturnedTimes<d>(</><g>expected</><d>)</>
 
-Expected number of returns: <green>1</>
-Received number of returns: <red>2</>"
+Expected number of returns: <g>1</>
+Received number of returns: <r>2</>
 `;
 
 exports[`toHaveReturnedTimes incomplete recursive calls are handled properly 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveReturnedTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toHaveReturnedTimes<d>(</><g>expected</><d>)</>
 
-Expected number of returns: not <green>2</>
+Expected number of returns: not <g>2</>
 
-Received number of calls:       <red>4</>"
+Received number of calls:       <r>4</>
 `;
 
 exports[`toHaveReturnedTimes only accepts a number argument 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveReturnedTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toHaveReturnedTimes<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a non-negative integer
+<b>Matcher error</>: <g>expected</> value must be a non-negative integer
 
 Expected has type:  object
-Expected has value: <green>{}</>"
+Expected has value: <g>{}</>
 `;
 
 exports[`toHaveReturnedTimes only accepts a number argument 2`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveReturnedTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toHaveReturnedTimes<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a non-negative integer
+<b>Matcher error</>: <g>expected</> value must be a non-negative integer
 
 Expected has type:  array
-Expected has value: <green>[]</>"
+Expected has value: <g>[]</>
 `;
 
 exports[`toHaveReturnedTimes only accepts a number argument 3`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveReturnedTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toHaveReturnedTimes<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a non-negative integer
+<b>Matcher error</>: <g>expected</> value must be a non-negative integer
 
 Expected has type:  boolean
-Expected has value: <green>true</>"
+Expected has value: <g>true</>
 `;
 
 exports[`toHaveReturnedTimes only accepts a number argument 4`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveReturnedTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toHaveReturnedTimes<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a non-negative integer
+<b>Matcher error</>: <g>expected</> value must be a non-negative integer
 
 Expected has type:  string
-Expected has value: <green>\\"a\\"</>"
+Expected has value: <g>"a"</>
 `;
 
 exports[`toHaveReturnedTimes only accepts a number argument 5`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveReturnedTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toHaveReturnedTimes<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a non-negative integer
+<b>Matcher error</>: <g>expected</> value must be a non-negative integer
 
 Expected has type:  map
-Expected has value: <green>Map {}</>"
+Expected has value: <g>Map {}</>
 `;
 
 exports[`toHaveReturnedTimes only accepts a number argument 6`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveReturnedTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toHaveReturnedTimes<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a non-negative integer
+<b>Matcher error</>: <g>expected</> value must be a non-negative integer
 
 Expected has type:  function
-Expected has value: <green>[Function anonymous]</>"
+Expected has value: <g>[Function anonymous]</>
 `;
 
 exports[`toHaveReturnedTimes passes if function returned equal to expected times 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveReturnedTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toHaveReturnedTimes<d>(</><g>expected</><d>)</>
 
-Expected number of returns: not <green>2</>"
+Expected number of returns: not <g>2</>
 `;
 
 exports[`toHaveReturnedTimes throw matcher error if received is spy 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toHaveReturnedTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toHaveReturnedTimes<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <red>received</> value must be a mock function
+<b>Matcher error</>: <r>received</> value must be a mock function
 
 Received has type:  function
-Received has value: <red>[Function spy]</>"
+Received has value: <r>[Function spy]</>
 `;
 
 exports[`toHaveReturnedWith a call that throws is not considered to have returned 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveReturnedWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toHaveReturnedWith<d>(</><g>expected</><d>)</>
 
-Expected: <green>undefined</>
+Expected: <g>undefined</>
 Received: function call threw an error
 
-Number of returns: <red>0</>
-Number of calls:   <red>1</>"
+Number of returns: <r>0</>
+Number of calls:   <r>1</>
 `;
 
 exports[`toHaveReturnedWith a call that throws undefined is not considered to have returned 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveReturnedWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toHaveReturnedWith<d>(</><g>expected</><d>)</>
 
-Expected: <green>undefined</>
+Expected: <g>undefined</>
 Received: function call threw an error
 
-Number of returns: <red>0</>
-Number of calls:   <red>1</>"
+Number of returns: <r>0</>
+Number of calls:   <r>1</>
 `;
 
 exports[`toHaveReturnedWith includes the custom mock name in the error message 1`] = `
-"<dim>expect(</><red>named-mock</><dim>).</>toHaveReturnedWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>named-mock</><d>).</>toHaveReturnedWith<d>(</><g>expected</><d>)</>
 
-Expected: <green>\\"foo\\"</>
+Expected: <g>"foo"</>
 
-Number of returns: <red>0</>"
+Number of returns: <r>0</>
 `;
 
 exports[`toHaveReturnedWith returnedWith incomplete recursive calls are handled properly 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveReturnedWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toHaveReturnedWith<d>(</><g>expected</><d>)</>
 
-Expected: <green>undefined</>
+Expected: <g>undefined</>
 Received
        1: function call has not returned yet
        2: function call has not returned yet
        3: function call has not returned yet
 
-Number of returns: <red>0</>
-Number of calls:   <red>4</>"
+Number of returns: <r>0</>
+Number of calls:   <r>4</>
 `;
 
 exports[`toHaveReturnedWith returnedWith works with more calls than the limit 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveReturnedWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toHaveReturnedWith<d>(</><g>expected</><d>)</>
 
-Expected: <green>\\"bar\\"</>
+Expected: <g>"bar"</>
 Received
-       1: <red>\\"foo1\\"</>
-       2: <red>\\"foo2\\"</>
-       3: <red>\\"foo3\\"</>
+       1: <r>"foo1"</>
+       2: <r>"foo2"</>
+       3: <r>"foo3"</>
 
-Number of returns: <red>6</>"
+Number of returns: <r>6</>
 `;
 
 exports[`toHaveReturnedWith works only on spies or jest.fn 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toHaveReturnedWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toHaveReturnedWith<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <red>received</> value must be a mock function
+<b>Matcher error</>: <r>received</> value must be a mock function
 
 Received has type:  function
-Received has value: <red>[Function fn]</>"
+Received has value: <r>[Function fn]</>
 `;
 
 exports[`toHaveReturnedWith works when not called 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveReturnedWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toHaveReturnedWith<d>(</><g>expected</><d>)</>
 
-Expected: <green>\\"foo\\"</>
+Expected: <g>"foo"</>
 
-Number of returns: <red>0</>"
+Number of returns: <r>0</>
 `;
 
 exports[`toHaveReturnedWith works with Immutable.js objects directly created 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveReturnedWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toHaveReturnedWith<d>(</><g>expected</><d>)</>
 
-Expected: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
+Expected: not <g>Immutable.Map {"a": {"b": "c"}}</>
 
-Number of returns: <red>1</>"
+Number of returns: <r>1</>
 `;
 
 exports[`toHaveReturnedWith works with Immutable.js objects indirectly created 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveReturnedWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toHaveReturnedWith<d>(</><g>expected</><d>)</>
 
-Expected: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
+Expected: not <g>Immutable.Map {"a": {"b": "c"}}</>
 
-Number of returns: <red>1</>"
+Number of returns: <r>1</>
 `;
 
 exports[`toHaveReturnedWith works with Map 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveReturnedWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toHaveReturnedWith<d>(</><g>expected</><d>)</>
 
-Expected: not <green>Map {1 => 2, 2 => 1}</>
+Expected: not <g>Map {1 => 2, 2 => 1}</>
 
-Number of returns: <red>1</>"
+Number of returns: <r>1</>
 `;
 
 exports[`toHaveReturnedWith works with Map 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveReturnedWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toHaveReturnedWith<d>(</><g>expected</><d>)</>
 
-Expected: <green>Map {\\"a\\" => \\"b\\", \\"b\\" => \\"a\\"}</>
-Received: <red>Map {1 => 2, 2 => 1}</>
+Expected: <g>Map {"a" => "b", "b" => "a"}</>
+Received: <r>Map {1 => 2, 2 => 1}</>
 
-Number of returns: <red>1</>"
+Number of returns: <r>1</>
 `;
 
 exports[`toHaveReturnedWith works with Set 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveReturnedWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toHaveReturnedWith<d>(</><g>expected</><d>)</>
 
-Expected: not <green>Set {1, 2}</>
+Expected: not <g>Set {1, 2}</>
 
-Number of returns: <red>1</>"
+Number of returns: <r>1</>
 `;
 
 exports[`toHaveReturnedWith works with Set 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveReturnedWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toHaveReturnedWith<d>(</><g>expected</><d>)</>
 
-Expected: <green>Set {3, 4}</>
-Received: <red>Set {1, 2}</>
+Expected: <g>Set {3, 4}</>
+Received: <r>Set {1, 2}</>
 
-Number of returns: <red>1</>"
+Number of returns: <r>1</>
 `;
 
 exports[`toHaveReturnedWith works with argument that does match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveReturnedWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toHaveReturnedWith<d>(</><g>expected</><d>)</>
 
-Expected: not <green>\\"foo\\"</>
+Expected: not <g>"foo"</>
 
-Number of returns: <red>1</>"
+Number of returns: <r>1</>
 `;
 
 exports[`toHaveReturnedWith works with argument that does not match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toHaveReturnedWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toHaveReturnedWith<d>(</><g>expected</><d>)</>
 
-Expected: <green>\\"bar\\"</>
-Received: <red>\\"foo\\"</>
+Expected: <g>"bar"</>
+Received: <r>"foo"</>
 
-Number of returns: <red>1</>"
+Number of returns: <r>1</>
 `;
 
 exports[`toHaveReturnedWith works with undefined 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toHaveReturnedWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toHaveReturnedWith<d>(</><g>expected</><d>)</>
 
-Expected: not <green>undefined</>
+Expected: not <g>undefined</>
 
-Number of returns: <red>1</>"
+Number of returns: <r>1</>
 `;
 
 exports[`toReturn .not fails with any argument passed 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toReturn<dim>()</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toReturn<d>()</>
 
-<bold>Matcher error</>: this matcher must not have an expected argument
+<b>Matcher error</>: this matcher must not have an expected argument
 
 Expected has type:  number
-Expected has value: <green>555</>"
+Expected has value: <g>555</>
 `;
 
 exports[`toReturn .not passes when a call throws undefined 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toReturn<dim>()</>
+<d>expect(</><r>jest.fn()</><d>).</>toReturn<d>()</>
 
-Expected number of returns: >= <green>1</>
-Received number of returns:    <red>0</>
-Received number of calls:      <red>1</>"
+Expected number of returns: >= <g>1</>
+Received number of returns:    <r>0</>
+Received number of calls:      <r>1</>
 `;
 
 exports[`toReturn .not passes when all calls throw 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toReturn<dim>()</>
+<d>expect(</><r>jest.fn()</><d>).</>toReturn<d>()</>
 
-Expected number of returns: >= <green>1</>
-Received number of returns:    <red>0</>
-Received number of calls:      <red>2</>"
+Expected number of returns: >= <g>1</>
+Received number of returns:    <r>0</>
+Received number of calls:      <r>2</>
 `;
 
 exports[`toReturn .not passes when not returned 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toReturn<dim>()</>
+<d>expect(</><r>jest.fn()</><d>).</>toReturn<d>()</>
 
-Expected number of returns: >= <green>1</>
-Received number of returns:    <red>0</>"
+Expected number of returns: >= <g>1</>
+Received number of returns:    <r>0</>
 `;
 
 exports[`toReturn .not works only on jest.fn 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toReturn<dim>()</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toReturn<d>()</>
 
-<bold>Matcher error</>: <red>received</> value must be a mock function
+<b>Matcher error</>: <r>received</> value must be a mock function
 
 Received has type:  function
-Received has value: <red>[Function fn]</>"
+Received has value: <r>[Function fn]</>
 `;
 
 exports[`toReturn fails with any argument passed 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toReturn<dim>()</>
+<d>expect(</><r>received</><d>).</>toReturn<d>()</>
 
-<bold>Matcher error</>: this matcher must not have an expected argument
+<b>Matcher error</>: this matcher must not have an expected argument
 
 Expected has type:  number
-Expected has value: <green>555</>"
+Expected has value: <g>555</>
 `;
 
 exports[`toReturn includes the custom mock name in the error message 1`] = `
-"<dim>expect(</><red>named-mock</><dim>).</>not<dim>.</>toReturn<dim>()</>
+<d>expect(</><r>named-mock</><d>).</>not<d>.</>toReturn<d>()</>
 
-Expected number of returns: <green>0</>
-Received number of returns: <red>1</>
+Expected number of returns: <g>0</>
+Received number of returns: <r>1</>
 
-1: <red>42</>"
+1: <r>42</>
 `;
 
 exports[`toReturn incomplete recursive calls are handled properly 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toReturn<dim>()</>
+<d>expect(</><r>jest.fn()</><d>).</>toReturn<d>()</>
 
-Expected number of returns: >= <green>1</>
-Received number of returns:    <red>0</>
-Received number of calls:      <red>4</>"
+Expected number of returns: >= <g>1</>
+Received number of returns:    <r>0</>
+Received number of calls:      <r>4</>
 `;
 
 exports[`toReturn passes when at least one call does not throw 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toReturn<dim>()</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toReturn<d>()</>
 
-Expected number of returns: <green>0</>
-Received number of returns: <red>2</>
+Expected number of returns: <g>0</>
+Received number of returns: <r>2</>
 
-1: <red>42</>
-3: <red>42</>
+1: <r>42</>
+3: <r>42</>
 
-Received number of calls:   <red>3</>"
+Received number of calls:   <r>3</>
 `;
 
 exports[`toReturn passes when returned 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toReturn<dim>()</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toReturn<d>()</>
 
-Expected number of returns: <green>0</>
-Received number of returns: <red>1</>
+Expected number of returns: <g>0</>
+Received number of returns: <r>1</>
 
-1: <red>42</>"
+1: <r>42</>
 `;
 
 exports[`toReturn passes when undefined is returned 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toReturn<dim>()</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toReturn<d>()</>
 
-Expected number of returns: <green>0</>
-Received number of returns: <red>1</>
+Expected number of returns: <g>0</>
+Received number of returns: <r>1</>
 
-1: <red>undefined</>"
+1: <r>undefined</>
 `;
 
 exports[`toReturn throw matcher error if received is spy 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toReturn<dim>()</>
+<d>expect(</><r>received</><d>).</>toReturn<d>()</>
 
-<bold>Matcher error</>: <red>received</> value must be a mock function
+<b>Matcher error</>: <r>received</> value must be a mock function
 
 Received has type:  function
-Received has value: <red>[Function spy]</>"
+Received has value: <r>[Function spy]</>
 `;
 
 exports[`toReturnTimes .not only accepts a number argument 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toReturnTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toReturnTimes<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a non-negative integer
+<b>Matcher error</>: <g>expected</> value must be a non-negative integer
 
 Expected has type:  object
-Expected has value: <green>{}</>"
+Expected has value: <g>{}</>
 `;
 
 exports[`toReturnTimes .not only accepts a number argument 2`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toReturnTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toReturnTimes<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a non-negative integer
+<b>Matcher error</>: <g>expected</> value must be a non-negative integer
 
 Expected has type:  array
-Expected has value: <green>[]</>"
+Expected has value: <g>[]</>
 `;
 
 exports[`toReturnTimes .not only accepts a number argument 3`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toReturnTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toReturnTimes<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a non-negative integer
+<b>Matcher error</>: <g>expected</> value must be a non-negative integer
 
 Expected has type:  boolean
-Expected has value: <green>true</>"
+Expected has value: <g>true</>
 `;
 
 exports[`toReturnTimes .not only accepts a number argument 4`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toReturnTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toReturnTimes<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a non-negative integer
+<b>Matcher error</>: <g>expected</> value must be a non-negative integer
 
 Expected has type:  string
-Expected has value: <green>\\"a\\"</>"
+Expected has value: <g>"a"</>
 `;
 
 exports[`toReturnTimes .not only accepts a number argument 5`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toReturnTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toReturnTimes<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a non-negative integer
+<b>Matcher error</>: <g>expected</> value must be a non-negative integer
 
 Expected has type:  map
-Expected has value: <green>Map {}</>"
+Expected has value: <g>Map {}</>
 `;
 
 exports[`toReturnTimes .not only accepts a number argument 6`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toReturnTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toReturnTimes<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a non-negative integer
+<b>Matcher error</>: <g>expected</> value must be a non-negative integer
 
 Expected has type:  function
-Expected has value: <green>[Function anonymous]</>"
+Expected has value: <g>[Function anonymous]</>
 `;
 
 exports[`toReturnTimes .not passes if function called less than expected times 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toReturnTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toReturnTimes<d>(</><g>expected</><d>)</>
 
-Expected number of returns: <green>2</>
-Received number of returns: <red>1</>"
+Expected number of returns: <g>2</>
+Received number of returns: <r>1</>
 `;
 
 exports[`toReturnTimes .not passes if function returned more than expected times 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toReturnTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toReturnTimes<d>(</><g>expected</><d>)</>
 
-Expected number of returns: <green>2</>
-Received number of returns: <red>3</>"
+Expected number of returns: <g>2</>
+Received number of returns: <r>3</>
 `;
 
 exports[`toReturnTimes calls that return undefined are counted as returns 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toReturnTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toReturnTimes<d>(</><g>expected</><d>)</>
 
-Expected number of returns: not <green>2</>"
+Expected number of returns: not <g>2</>
 `;
 
 exports[`toReturnTimes calls that throw are not counted 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toReturnTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toReturnTimes<d>(</><g>expected</><d>)</>
 
-Expected number of returns: <green>3</>
-Received number of returns: <red>2</>
-Received number of calls:   <red>3</>"
+Expected number of returns: <g>3</>
+Received number of returns: <r>2</>
+Received number of calls:   <r>3</>
 `;
 
 exports[`toReturnTimes calls that throw undefined are not counted 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toReturnTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toReturnTimes<d>(</><g>expected</><d>)</>
 
-Expected number of returns: not <green>2</>
+Expected number of returns: not <g>2</>
 
-Received number of calls:       <red>3</>"
+Received number of calls:       <r>3</>
 `;
 
 exports[`toReturnTimes includes the custom mock name in the error message 1`] = `
-"<dim>expect(</><red>named-mock</><dim>).</>toReturnTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>named-mock</><d>).</>toReturnTimes<d>(</><g>expected</><d>)</>
 
-Expected number of returns: <green>1</>
-Received number of returns: <red>2</>"
+Expected number of returns: <g>1</>
+Received number of returns: <r>2</>
 `;
 
 exports[`toReturnTimes incomplete recursive calls are handled properly 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toReturnTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toReturnTimes<d>(</><g>expected</><d>)</>
 
-Expected number of returns: not <green>2</>
+Expected number of returns: not <g>2</>
 
-Received number of calls:       <red>4</>"
+Received number of calls:       <r>4</>
 `;
 
 exports[`toReturnTimes only accepts a number argument 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toReturnTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toReturnTimes<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a non-negative integer
+<b>Matcher error</>: <g>expected</> value must be a non-negative integer
 
 Expected has type:  object
-Expected has value: <green>{}</>"
+Expected has value: <g>{}</>
 `;
 
 exports[`toReturnTimes only accepts a number argument 2`] = `
-"<dim>expect(</><red>received</><dim>).</>toReturnTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toReturnTimes<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a non-negative integer
+<b>Matcher error</>: <g>expected</> value must be a non-negative integer
 
 Expected has type:  array
-Expected has value: <green>[]</>"
+Expected has value: <g>[]</>
 `;
 
 exports[`toReturnTimes only accepts a number argument 3`] = `
-"<dim>expect(</><red>received</><dim>).</>toReturnTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toReturnTimes<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a non-negative integer
+<b>Matcher error</>: <g>expected</> value must be a non-negative integer
 
 Expected has type:  boolean
-Expected has value: <green>true</>"
+Expected has value: <g>true</>
 `;
 
 exports[`toReturnTimes only accepts a number argument 4`] = `
-"<dim>expect(</><red>received</><dim>).</>toReturnTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toReturnTimes<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a non-negative integer
+<b>Matcher error</>: <g>expected</> value must be a non-negative integer
 
 Expected has type:  string
-Expected has value: <green>\\"a\\"</>"
+Expected has value: <g>"a"</>
 `;
 
 exports[`toReturnTimes only accepts a number argument 5`] = `
-"<dim>expect(</><red>received</><dim>).</>toReturnTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toReturnTimes<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a non-negative integer
+<b>Matcher error</>: <g>expected</> value must be a non-negative integer
 
 Expected has type:  map
-Expected has value: <green>Map {}</>"
+Expected has value: <g>Map {}</>
 `;
 
 exports[`toReturnTimes only accepts a number argument 6`] = `
-"<dim>expect(</><red>received</><dim>).</>toReturnTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toReturnTimes<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a non-negative integer
+<b>Matcher error</>: <g>expected</> value must be a non-negative integer
 
 Expected has type:  function
-Expected has value: <green>[Function anonymous]</>"
+Expected has value: <g>[Function anonymous]</>
 `;
 
 exports[`toReturnTimes passes if function returned equal to expected times 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toReturnTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toReturnTimes<d>(</><g>expected</><d>)</>
 
-Expected number of returns: not <green>2</>"
+Expected number of returns: not <g>2</>
 `;
 
 exports[`toReturnTimes throw matcher error if received is spy 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toReturnTimes<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toReturnTimes<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <red>received</> value must be a mock function
+<b>Matcher error</>: <r>received</> value must be a mock function
 
 Received has type:  function
-Received has value: <red>[Function spy]</>"
+Received has value: <r>[Function spy]</>
 `;
 
 exports[`toReturnWith a call that throws is not considered to have returned 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toReturnWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toReturnWith<d>(</><g>expected</><d>)</>
 
-Expected: <green>undefined</>
+Expected: <g>undefined</>
 Received: function call threw an error
 
-Number of returns: <red>0</>
-Number of calls:   <red>1</>"
+Number of returns: <r>0</>
+Number of calls:   <r>1</>
 `;
 
 exports[`toReturnWith a call that throws undefined is not considered to have returned 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toReturnWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toReturnWith<d>(</><g>expected</><d>)</>
 
-Expected: <green>undefined</>
+Expected: <g>undefined</>
 Received: function call threw an error
 
-Number of returns: <red>0</>
-Number of calls:   <red>1</>"
+Number of returns: <r>0</>
+Number of calls:   <r>1</>
 `;
 
 exports[`toReturnWith includes the custom mock name in the error message 1`] = `
-"<dim>expect(</><red>named-mock</><dim>).</>toReturnWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>named-mock</><d>).</>toReturnWith<d>(</><g>expected</><d>)</>
 
-Expected: <green>\\"foo\\"</>
+Expected: <g>"foo"</>
 
-Number of returns: <red>0</>"
+Number of returns: <r>0</>
 `;
 
 exports[`toReturnWith returnedWith incomplete recursive calls are handled properly 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toReturnWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toReturnWith<d>(</><g>expected</><d>)</>
 
-Expected: <green>undefined</>
+Expected: <g>undefined</>
 Received
        1: function call has not returned yet
        2: function call has not returned yet
        3: function call has not returned yet
 
-Number of returns: <red>0</>
-Number of calls:   <red>4</>"
+Number of returns: <r>0</>
+Number of calls:   <r>4</>
 `;
 
 exports[`toReturnWith returnedWith works with more calls than the limit 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toReturnWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toReturnWith<d>(</><g>expected</><d>)</>
 
-Expected: <green>\\"bar\\"</>
+Expected: <g>"bar"</>
 Received
-       1: <red>\\"foo1\\"</>
-       2: <red>\\"foo2\\"</>
-       3: <red>\\"foo3\\"</>
+       1: <r>"foo1"</>
+       2: <r>"foo2"</>
+       3: <r>"foo3"</>
 
-Number of returns: <red>6</>"
+Number of returns: <r>6</>
 `;
 
 exports[`toReturnWith works only on spies or jest.fn 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toReturnWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toReturnWith<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <red>received</> value must be a mock function
+<b>Matcher error</>: <r>received</> value must be a mock function
 
 Received has type:  function
-Received has value: <red>[Function fn]</>"
+Received has value: <r>[Function fn]</>
 `;
 
 exports[`toReturnWith works when not called 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toReturnWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toReturnWith<d>(</><g>expected</><d>)</>
 
-Expected: <green>\\"foo\\"</>
+Expected: <g>"foo"</>
 
-Number of returns: <red>0</>"
+Number of returns: <r>0</>
 `;
 
 exports[`toReturnWith works with Immutable.js objects directly created 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toReturnWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toReturnWith<d>(</><g>expected</><d>)</>
 
-Expected: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
+Expected: not <g>Immutable.Map {"a": {"b": "c"}}</>
 
-Number of returns: <red>1</>"
+Number of returns: <r>1</>
 `;
 
 exports[`toReturnWith works with Immutable.js objects indirectly created 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toReturnWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toReturnWith<d>(</><g>expected</><d>)</>
 
-Expected: not <green>Immutable.Map {\\"a\\": {\\"b\\": \\"c\\"}}</>
+Expected: not <g>Immutable.Map {"a": {"b": "c"}}</>
 
-Number of returns: <red>1</>"
+Number of returns: <r>1</>
 `;
 
 exports[`toReturnWith works with Map 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toReturnWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toReturnWith<d>(</><g>expected</><d>)</>
 
-Expected: not <green>Map {1 => 2, 2 => 1}</>
+Expected: not <g>Map {1 => 2, 2 => 1}</>
 
-Number of returns: <red>1</>"
+Number of returns: <r>1</>
 `;
 
 exports[`toReturnWith works with Map 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toReturnWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toReturnWith<d>(</><g>expected</><d>)</>
 
-Expected: <green>Map {\\"a\\" => \\"b\\", \\"b\\" => \\"a\\"}</>
-Received: <red>Map {1 => 2, 2 => 1}</>
+Expected: <g>Map {"a" => "b", "b" => "a"}</>
+Received: <r>Map {1 => 2, 2 => 1}</>
 
-Number of returns: <red>1</>"
+Number of returns: <r>1</>
 `;
 
 exports[`toReturnWith works with Set 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toReturnWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toReturnWith<d>(</><g>expected</><d>)</>
 
-Expected: not <green>Set {1, 2}</>
+Expected: not <g>Set {1, 2}</>
 
-Number of returns: <red>1</>"
+Number of returns: <r>1</>
 `;
 
 exports[`toReturnWith works with Set 2`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toReturnWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toReturnWith<d>(</><g>expected</><d>)</>
 
-Expected: <green>Set {3, 4}</>
-Received: <red>Set {1, 2}</>
+Expected: <g>Set {3, 4}</>
+Received: <r>Set {1, 2}</>
 
-Number of returns: <red>1</>"
+Number of returns: <r>1</>
 `;
 
 exports[`toReturnWith works with argument that does match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toReturnWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toReturnWith<d>(</><g>expected</><d>)</>
 
-Expected: not <green>\\"foo\\"</>
+Expected: not <g>"foo"</>
 
-Number of returns: <red>1</>"
+Number of returns: <r>1</>
 `;
 
 exports[`toReturnWith works with argument that does not match 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>toReturnWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>toReturnWith<d>(</><g>expected</><d>)</>
 
-Expected: <green>\\"bar\\"</>
-Received: <red>\\"foo\\"</>
+Expected: <g>"bar"</>
+Received: <r>"foo"</>
 
-Number of returns: <red>1</>"
+Number of returns: <r>1</>
 `;
 
 exports[`toReturnWith works with undefined 1`] = `
-"<dim>expect(</><red>jest.fn()</><dim>).</>not<dim>.</>toReturnWith<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toReturnWith<d>(</><g>expected</><d>)</>
 
-Expected: not <green>undefined</>
+Expected: not <g>undefined</>
 
-Number of returns: <red>1</>"
+Number of returns: <r>1</>
 `;

--- a/packages/expect/src/__tests__/__snapshots__/toThrowMatchers.test.ts.snap
+++ b/packages/expect/src/__tests__/__snapshots__/toThrowMatchers.test.ts.snap
@@ -1,617 +1,617 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`toThrow asymmetric any-Class fail isNot false 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toThrow<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toThrow<d>(</><g>expected</><d>)</>
 
-Expected asymmetric matcher: <green>Any<Err2></>
+Expected asymmetric matcher: <g>Any<Err2></>
 
-Received name:    <red>\\"Error\\"</>
-Received message: <red>\\"apple\\"</>
+Received name:    <r>"Error"</>
+Received message: <r>"apple"</>
 
-      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+      <d>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<d>:24:74)</>
 `;
 
 exports[`toThrow asymmetric any-Class fail isNot true 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrow<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toThrow<d>(</><g>expected</><d>)</>
 
-Expected asymmetric matcher: not <green>Any<Err></>
+Expected asymmetric matcher: not <g>Any<Err></>
 
-Received name:    <red>\\"Error\\"</>
-Received message: <red>\\"apple\\"</>
+Received name:    <r>"Error"</>
+Received message: <r>"apple"</>
 
-      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+      <d>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<d>:24:74)</>
 `;
 
 exports[`toThrow asymmetric anything fail isNot false 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toThrow<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toThrow<d>(</><g>expected</><d>)</>
 
-Expected asymmetric matcher: <green>Anything</>
+Expected asymmetric matcher: <g>Anything</>
 
-Thrown value: <red>null</>
-"
+Thrown value: <r>null</>
+
 `;
 
 exports[`toThrow asymmetric anything fail isNot true 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrow<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toThrow<d>(</><g>expected</><d>)</>
 
-Expected asymmetric matcher: not <green>Anything</>
+Expected asymmetric matcher: not <g>Anything</>
 
-Received name:    <red>\\"Error\\"</>
-Received message: <red>\\"apple\\"</>
+Received name:    <r>"Error"</>
+Received message: <r>"apple"</>
 
-      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+      <d>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<d>:24:74)</>
 `;
 
 exports[`toThrow asymmetric no-symbol fail isNot false 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toThrow<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toThrow<d>(</><g>expected</><d>)</>
 
-Expected asymmetric matcher: <green>{\\"asymmetricMatch\\": [Function asymmetricMatch]}</>
+Expected asymmetric matcher: <g>{"asymmetricMatch": [Function asymmetricMatch]}</>
 
-Received name:    <red>\\"Error\\"</>
-Received message: <red>\\"apple\\"</>
+Received name:    <r>"Error"</>
+Received message: <r>"apple"</>
 
-      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+      <d>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<d>:24:74)</>
 `;
 
 exports[`toThrow asymmetric no-symbol fail isNot true 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrow<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toThrow<d>(</><g>expected</><d>)</>
 
-Expected asymmetric matcher: not <green>{\\"asymmetricMatch\\": [Function asymmetricMatch]}</>
+Expected asymmetric matcher: not <g>{"asymmetricMatch": [Function asymmetricMatch]}</>
 
-Received name:    <red>\\"Error\\"</>
-Received message: <red>\\"apple\\"</>
+Received name:    <r>"Error"</>
+Received message: <r>"apple"</>
 
-      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+      <d>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<d>:24:74)</>
 `;
 
 exports[`toThrow asymmetric objectContaining fail isNot false 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toThrow<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toThrow<d>(</><g>expected</><d>)</>
 
-Expected asymmetric matcher: <green>ObjectContaining {\\"name\\": \\"NotError\\"}</>
+Expected asymmetric matcher: <g>ObjectContaining {"name": "NotError"}</>
 
-Received name:    <red>\\"Error\\"</>
-Received message: <red>\\"apple\\"</>
+Received name:    <r>"Error"</>
+Received message: <r>"apple"</>
 
-      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+      <d>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<d>:24:74)</>
 `;
 
 exports[`toThrow asymmetric objectContaining fail isNot true 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrow<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toThrow<d>(</><g>expected</><d>)</>
 
-Expected asymmetric matcher: not <green>ObjectContaining {\\"name\\": \\"Error\\"}</>
+Expected asymmetric matcher: not <g>ObjectContaining {"name": "Error"}</>
 
-Received name:    <red>\\"Error\\"</>
-Received message: <red>\\"apple\\"</>
+Received name:    <r>"Error"</>
+Received message: <r>"apple"</>
 
-      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+      <d>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<d>:24:74)</>
 `;
 
 exports[`toThrow error class did not throw at all 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toThrow<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toThrow<d>(</><g>expected</><d>)</>
 
-Expected constructor: <green>Err</>
+Expected constructor: <g>Err</>
 
-Received function did not throw"
+Received function did not throw
 `;
 
 exports[`toThrow error class threw, but class did not match (error) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toThrow<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toThrow<d>(</><g>expected</><d>)</>
 
-Expected constructor: <green>Err2</>
-Received constructor: <red>Err</>
+Expected constructor: <g>Err2</>
+Received constructor: <r>Err</>
 
-Received message: <red>\\"apple\\"</>
+Received message: <r>"apple"</>
 
-      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+      <d>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<d>:24:74)</>
 `;
 
 exports[`toThrow error class threw, but class did not match (non-error falsey) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toThrow<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toThrow<d>(</><g>expected</><d>)</>
 
-Expected constructor: <green>Err2</>
+Expected constructor: <g>Err2</>
 
-Received value: <red>undefined</>
-"
+Received value: <r>undefined</>
+
 `;
 
 exports[`toThrow error class threw, but class should not match (error subclass) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrow<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toThrow<d>(</><g>expected</><d>)</>
 
-Expected constructor: not <green>Err</>
-Received constructor:     <red>SubErr</> extends <green>Err</>
+Expected constructor: not <g>Err</>
+Received constructor:     <r>SubErr</> extends <g>Err</>
 
-Received message: <red>\\"apple\\"</>
+Received message: <r>"apple"</>
 
-      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+      <d>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<d>:24:74)</>
 `;
 
 exports[`toThrow error class threw, but class should not match (error subsubclass) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrow<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toThrow<d>(</><g>expected</><d>)</>
 
-Expected constructor: not <green>Err</>
-Received constructor:     <red>SubSubErr</> extends … extends <green>Err</>
+Expected constructor: not <g>Err</>
+Received constructor:     <r>SubSubErr</> extends … extends <g>Err</>
 
-Received message: <red>\\"apple\\"</>
+Received message: <r>"apple"</>
 
-      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+      <d>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<d>:24:74)</>
 `;
 
 exports[`toThrow error class threw, but class should not match (error) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrow<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toThrow<d>(</><g>expected</><d>)</>
 
-Expected constructor: not <green>Err</>
+Expected constructor: not <g>Err</>
 
-Received message: <red>\\"apple\\"</>
+Received message: <r>"apple"</>
 
-      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+      <d>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<d>:24:74)</>
 `;
 
 exports[`toThrow error-message fail isNot false 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toThrow<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toThrow<d>(</><g>expected</><d>)</>
 
-Expected message: <green>\\"apple\\"</>
-Received message: <red>\\"banana\\"</>
-"
+Expected message: <g>"apple"</>
+Received message: <r>"banana"</>
+
 `;
 
 exports[`toThrow error-message fail isNot true 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrow<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toThrow<d>(</><g>expected</><d>)</>
 
-Expected message: not <green>\\"Invalid array length\\"</>
-"
+Expected message: not <g>"Invalid array length"</>
+
 `;
 
 exports[`toThrow error-message fail multiline diff highlight incorrect expected space 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toThrow<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toThrow<d>(</><g>expected</><d>)</>
 
-<green>- Expected message</>
-<red>+ Received message</>
+<g>- Expected message</>
+<r>+ Received message</>
 
-<green>- There is no route defined for key Settings.<inverse> </></>
-<red>+ There is no route defined for key Settings.</>
-<dim>  Must be one of: 'Home'</>
-"
+<g>- There is no route defined for key Settings.<i> </i></>
+<r>+ There is no route defined for key Settings.</>
+<d>  Must be one of: 'Home'</>
+
 `;
 
 exports[`toThrow expected is undefined threw, but should not have (non-error falsey) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrow<dim>()</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toThrow<d>()</>
 
-Thrown value: <red>null</>
-"
+Thrown value: <r>null</>
+
 `;
 
 exports[`toThrow invalid actual 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toThrow<dim>()</>
+<d>expect(</><r>received</><d>).</>toThrow<d>()</>
 
-<bold>Matcher error</>: <red>received</> value must be a function
+<b>Matcher error</>: <r>received</> value must be a function
 
 Received has type:  string
-Received has value: <red>\\"a string\\"</>"
+Received has value: <r>"a string"</>
 `;
 
 exports[`toThrow invalid arguments 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrow<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toThrow<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a string or regular expression or class or error
+<b>Matcher error</>: <g>expected</> value must be a string or regular expression or class or error
 
 Expected has type:  number
-Expected has value: <green>111</>"
+Expected has value: <g>111</>
 `;
 
 exports[`toThrow promise/async throws if Error-like object is returned did not throw at all 1`] = `
-"<dim>expect(</><red>received</><dim>).</>rejects<dim>.</>toThrow<dim>()</>
+<d>expect(</><r>received</><d>).</>rejects<d>.</>toThrow<d>()</>
 
-Received function did not throw"
+Received function did not throw
 `;
 
 exports[`toThrow promise/async throws if Error-like object is returned threw, but class did not match 1`] = `
-"<dim>expect(</><red>received</><dim>).</>rejects<dim>.</>toThrow<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>rejects<d>.</>toThrow<d>(</><g>expected</><d>)</>
 
-Expected constructor: <green>Err2</>
-Received constructor: <red>Err</>
+Expected constructor: <g>Err2</>
+Received constructor: <r>Err</>
 
-Received message: <red>\\"async apple\\"</>
+Received message: <r>"async apple"</>
 
-      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+      <d>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<d>:24:74)</>
 `;
 
 exports[`toThrow promise/async throws if Error-like object is returned threw, but should not have 1`] = `
-"<dim>expect(</><red>received</><dim>).</>rejects<dim>.</>not<dim>.</>toThrow<dim>()</>
+<d>expect(</><r>received</><d>).</>rejects<d>.</>not<d>.</>toThrow<d>()</>
 
-Error name:    <red>\\"Error\\"</>
-Error message: <red>\\"async apple\\"</>
+Error name:    <r>"Error"</>
+Error message: <r>"async apple"</>
 
-      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+      <d>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<d>:24:74)</>
 `;
 
 exports[`toThrow regexp did not throw at all 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toThrow<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toThrow<d>(</><g>expected</><d>)</>
 
-Expected pattern: <green>/apple/</>
+Expected pattern: <g>/apple/</>
 
-Received function did not throw"
+Received function did not throw
 `;
 
 exports[`toThrow regexp threw, but message did not match (error) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toThrow<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toThrow<d>(</><g>expected</><d>)</>
 
-Expected pattern: <green>/banana/</>
-Received message: <red>\\"apple\\"</>
+Expected pattern: <g>/banana/</>
+Received message: <r>"apple"</>
 
-      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+      <d>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<d>:24:74)</>
 `;
 
 exports[`toThrow regexp threw, but message did not match (non-error falsey) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toThrow<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toThrow<d>(</><g>expected</><d>)</>
 
-Expected pattern: <green>/^[123456789]\\\\d*/</>
-Received value:   <red>0</>
-"
+Expected pattern: <g>/^[123456789]\\d*/</>
+Received value:   <r>0</>
+
 `;
 
 exports[`toThrow regexp threw, but message should not match (error) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrow<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toThrow<d>(</><g>expected</><d>)</>
 
-Expected pattern: not <green>/ array /</>
-Received message:     <red>\\"Invalid<inverse> array </>length\\"</>
+Expected pattern: not <g>/ array /</>
+Received message:     <r>"Invalid<i> array </i>length"</>
 
-      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+      <d>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<d>:24:74)</>
 `;
 
 exports[`toThrow regexp threw, but message should not match (non-error truthy) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrow<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toThrow<d>(</><g>expected</><d>)</>
 
-Expected pattern: not <green>/^[123456789]\\\\d*/</>
-Received value:       <red>404</>
-"
+Expected pattern: not <g>/^[123456789]\\d*/</>
+Received value:       <r>404</>
+
 `;
 
 exports[`toThrow substring did not throw at all 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toThrow<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toThrow<d>(</><g>expected</><d>)</>
 
-Expected substring: <green>\\"apple\\"</>
+Expected substring: <g>"apple"</>
 
-Received function did not throw"
+Received function did not throw
 `;
 
 exports[`toThrow substring threw, but message did not match (error) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toThrow<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toThrow<d>(</><g>expected</><d>)</>
 
-Expected substring: <green>\\"banana\\"</>
-Received message:   <red>\\"apple\\"</>
+Expected substring: <g>"banana"</>
+Received message:   <r>"apple"</>
 
-      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+      <d>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<d>:24:74)</>
 `;
 
 exports[`toThrow substring threw, but message did not match (non-error falsey) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toThrow<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toThrow<d>(</><g>expected</><d>)</>
 
-Expected substring: <green>\\"Server Error\\"</>
-Received value:     <red>\\"\\"</>
-"
+Expected substring: <g>"Server Error"</>
+Received value:     <r>""</>
+
 `;
 
 exports[`toThrow substring threw, but message should not match (error) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrow<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toThrow<d>(</><g>expected</><d>)</>
 
-Expected substring: not <green>\\"array\\"</>
-Received message:       <red>\\"Invalid <inverse>array</> length\\"</>
+Expected substring: not <g>"array"</>
+Received message:       <r>"Invalid <i>array</i> length"</>
 
-      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+      <d>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<d>:24:74)</>
 `;
 
 exports[`toThrow substring threw, but message should not match (non-error truthy) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrow<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toThrow<d>(</><g>expected</><d>)</>
 
-Expected substring: not <green>\\"Server Error\\"</>
-Received value:         <red>\\"Internal Server Error\\"</>
-"
+Expected substring: not <g>"Server Error"</>
+Received value:         <r>"Internal Server Error"</>
+
 `;
 
 exports[`toThrowError asymmetric any-Class fail isNot false 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toThrowError<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toThrowError<d>(</><g>expected</><d>)</>
 
-Expected asymmetric matcher: <green>Any<Err2></>
+Expected asymmetric matcher: <g>Any<Err2></>
 
-Received name:    <red>\\"Error\\"</>
-Received message: <red>\\"apple\\"</>
+Received name:    <r>"Error"</>
+Received message: <r>"apple"</>
 
-      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+      <d>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<d>:24:74)</>
 `;
 
 exports[`toThrowError asymmetric any-Class fail isNot true 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrowError<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toThrowError<d>(</><g>expected</><d>)</>
 
-Expected asymmetric matcher: not <green>Any<Err></>
+Expected asymmetric matcher: not <g>Any<Err></>
 
-Received name:    <red>\\"Error\\"</>
-Received message: <red>\\"apple\\"</>
+Received name:    <r>"Error"</>
+Received message: <r>"apple"</>
 
-      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+      <d>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<d>:24:74)</>
 `;
 
 exports[`toThrowError asymmetric anything fail isNot false 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toThrowError<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toThrowError<d>(</><g>expected</><d>)</>
 
-Expected asymmetric matcher: <green>Anything</>
+Expected asymmetric matcher: <g>Anything</>
 
-Thrown value: <red>null</>
-"
+Thrown value: <r>null</>
+
 `;
 
 exports[`toThrowError asymmetric anything fail isNot true 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrowError<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toThrowError<d>(</><g>expected</><d>)</>
 
-Expected asymmetric matcher: not <green>Anything</>
+Expected asymmetric matcher: not <g>Anything</>
 
-Received name:    <red>\\"Error\\"</>
-Received message: <red>\\"apple\\"</>
+Received name:    <r>"Error"</>
+Received message: <r>"apple"</>
 
-      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+      <d>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<d>:24:74)</>
 `;
 
 exports[`toThrowError asymmetric no-symbol fail isNot false 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toThrowError<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toThrowError<d>(</><g>expected</><d>)</>
 
-Expected asymmetric matcher: <green>{\\"asymmetricMatch\\": [Function asymmetricMatch]}</>
+Expected asymmetric matcher: <g>{"asymmetricMatch": [Function asymmetricMatch]}</>
 
-Received name:    <red>\\"Error\\"</>
-Received message: <red>\\"apple\\"</>
+Received name:    <r>"Error"</>
+Received message: <r>"apple"</>
 
-      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+      <d>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<d>:24:74)</>
 `;
 
 exports[`toThrowError asymmetric no-symbol fail isNot true 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrowError<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toThrowError<d>(</><g>expected</><d>)</>
 
-Expected asymmetric matcher: not <green>{\\"asymmetricMatch\\": [Function asymmetricMatch]}</>
+Expected asymmetric matcher: not <g>{"asymmetricMatch": [Function asymmetricMatch]}</>
 
-Received name:    <red>\\"Error\\"</>
-Received message: <red>\\"apple\\"</>
+Received name:    <r>"Error"</>
+Received message: <r>"apple"</>
 
-      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+      <d>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<d>:24:74)</>
 `;
 
 exports[`toThrowError asymmetric objectContaining fail isNot false 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toThrowError<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toThrowError<d>(</><g>expected</><d>)</>
 
-Expected asymmetric matcher: <green>ObjectContaining {\\"name\\": \\"NotError\\"}</>
+Expected asymmetric matcher: <g>ObjectContaining {"name": "NotError"}</>
 
-Received name:    <red>\\"Error\\"</>
-Received message: <red>\\"apple\\"</>
+Received name:    <r>"Error"</>
+Received message: <r>"apple"</>
 
-      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+      <d>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<d>:24:74)</>
 `;
 
 exports[`toThrowError asymmetric objectContaining fail isNot true 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrowError<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toThrowError<d>(</><g>expected</><d>)</>
 
-Expected asymmetric matcher: not <green>ObjectContaining {\\"name\\": \\"Error\\"}</>
+Expected asymmetric matcher: not <g>ObjectContaining {"name": "Error"}</>
 
-Received name:    <red>\\"Error\\"</>
-Received message: <red>\\"apple\\"</>
+Received name:    <r>"Error"</>
+Received message: <r>"apple"</>
 
-      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+      <d>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<d>:24:74)</>
 `;
 
 exports[`toThrowError error class did not throw at all 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toThrowError<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toThrowError<d>(</><g>expected</><d>)</>
 
-Expected constructor: <green>Err</>
+Expected constructor: <g>Err</>
 
-Received function did not throw"
+Received function did not throw
 `;
 
 exports[`toThrowError error class threw, but class did not match (error) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toThrowError<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toThrowError<d>(</><g>expected</><d>)</>
 
-Expected constructor: <green>Err2</>
-Received constructor: <red>Err</>
+Expected constructor: <g>Err2</>
+Received constructor: <r>Err</>
 
-Received message: <red>\\"apple\\"</>
+Received message: <r>"apple"</>
 
-      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+      <d>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<d>:24:74)</>
 `;
 
 exports[`toThrowError error class threw, but class did not match (non-error falsey) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toThrowError<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toThrowError<d>(</><g>expected</><d>)</>
 
-Expected constructor: <green>Err2</>
+Expected constructor: <g>Err2</>
 
-Received value: <red>undefined</>
-"
+Received value: <r>undefined</>
+
 `;
 
 exports[`toThrowError error class threw, but class should not match (error subclass) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrowError<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toThrowError<d>(</><g>expected</><d>)</>
 
-Expected constructor: not <green>Err</>
-Received constructor:     <red>SubErr</> extends <green>Err</>
+Expected constructor: not <g>Err</>
+Received constructor:     <r>SubErr</> extends <g>Err</>
 
-Received message: <red>\\"apple\\"</>
+Received message: <r>"apple"</>
 
-      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+      <d>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<d>:24:74)</>
 `;
 
 exports[`toThrowError error class threw, but class should not match (error subsubclass) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrowError<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toThrowError<d>(</><g>expected</><d>)</>
 
-Expected constructor: not <green>Err</>
-Received constructor:     <red>SubSubErr</> extends … extends <green>Err</>
+Expected constructor: not <g>Err</>
+Received constructor:     <r>SubSubErr</> extends … extends <g>Err</>
 
-Received message: <red>\\"apple\\"</>
+Received message: <r>"apple"</>
 
-      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+      <d>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<d>:24:74)</>
 `;
 
 exports[`toThrowError error class threw, but class should not match (error) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrowError<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toThrowError<d>(</><g>expected</><d>)</>
 
-Expected constructor: not <green>Err</>
+Expected constructor: not <g>Err</>
 
-Received message: <red>\\"apple\\"</>
+Received message: <r>"apple"</>
 
-      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+      <d>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<d>:24:74)</>
 `;
 
 exports[`toThrowError error-message fail isNot false 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toThrowError<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toThrowError<d>(</><g>expected</><d>)</>
 
-Expected message: <green>\\"apple\\"</>
-Received message: <red>\\"banana\\"</>
-"
+Expected message: <g>"apple"</>
+Received message: <r>"banana"</>
+
 `;
 
 exports[`toThrowError error-message fail isNot true 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrowError<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toThrowError<d>(</><g>expected</><d>)</>
 
-Expected message: not <green>\\"Invalid array length\\"</>
-"
+Expected message: not <g>"Invalid array length"</>
+
 `;
 
 exports[`toThrowError error-message fail multiline diff highlight incorrect expected space 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toThrowError<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toThrowError<d>(</><g>expected</><d>)</>
 
-<green>- Expected message</>
-<red>+ Received message</>
+<g>- Expected message</>
+<r>+ Received message</>
 
-<green>- There is no route defined for key Settings.<inverse> </></>
-<red>+ There is no route defined for key Settings.</>
-<dim>  Must be one of: 'Home'</>
-"
+<g>- There is no route defined for key Settings.<i> </i></>
+<r>+ There is no route defined for key Settings.</>
+<d>  Must be one of: 'Home'</>
+
 `;
 
 exports[`toThrowError expected is undefined threw, but should not have (non-error falsey) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrowError<dim>()</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toThrowError<d>()</>
 
-Thrown value: <red>null</>
-"
+Thrown value: <r>null</>
+
 `;
 
 exports[`toThrowError invalid actual 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toThrowError<dim>()</>
+<d>expect(</><r>received</><d>).</>toThrowError<d>()</>
 
-<bold>Matcher error</>: <red>received</> value must be a function
+<b>Matcher error</>: <r>received</> value must be a function
 
 Received has type:  string
-Received has value: <red>\\"a string\\"</>"
+Received has value: <r>"a string"</>
 `;
 
 exports[`toThrowError invalid arguments 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrowError<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toThrowError<d>(</><g>expected</><d>)</>
 
-<bold>Matcher error</>: <green>expected</> value must be a string or regular expression or class or error
+<b>Matcher error</>: <g>expected</> value must be a string or regular expression or class or error
 
 Expected has type:  number
-Expected has value: <green>111</>"
+Expected has value: <g>111</>
 `;
 
 exports[`toThrowError promise/async throws if Error-like object is returned did not throw at all 1`] = `
-"<dim>expect(</><red>received</><dim>).</>rejects<dim>.</>toThrowError<dim>()</>
+<d>expect(</><r>received</><d>).</>rejects<d>.</>toThrowError<d>()</>
 
-Received function did not throw"
+Received function did not throw
 `;
 
 exports[`toThrowError promise/async throws if Error-like object is returned threw, but class did not match 1`] = `
-"<dim>expect(</><red>received</><dim>).</>rejects<dim>.</>toThrowError<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>rejects<d>.</>toThrowError<d>(</><g>expected</><d>)</>
 
-Expected constructor: <green>Err2</>
-Received constructor: <red>Err</>
+Expected constructor: <g>Err2</>
+Received constructor: <r>Err</>
 
-Received message: <red>\\"async apple\\"</>
+Received message: <r>"async apple"</>
 
-      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+      <d>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<d>:24:74)</>
 `;
 
 exports[`toThrowError promise/async throws if Error-like object is returned threw, but should not have 1`] = `
-"<dim>expect(</><red>received</><dim>).</>rejects<dim>.</>not<dim>.</>toThrowError<dim>()</>
+<d>expect(</><r>received</><d>).</>rejects<d>.</>not<d>.</>toThrowError<d>()</>
 
-Error name:    <red>\\"Error\\"</>
-Error message: <red>\\"async apple\\"</>
+Error name:    <r>"Error"</>
+Error message: <r>"async apple"</>
 
-      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+      <d>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<d>:24:74)</>
 `;
 
 exports[`toThrowError regexp did not throw at all 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toThrowError<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toThrowError<d>(</><g>expected</><d>)</>
 
-Expected pattern: <green>/apple/</>
+Expected pattern: <g>/apple/</>
 
-Received function did not throw"
+Received function did not throw
 `;
 
 exports[`toThrowError regexp threw, but message did not match (error) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toThrowError<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toThrowError<d>(</><g>expected</><d>)</>
 
-Expected pattern: <green>/banana/</>
-Received message: <red>\\"apple\\"</>
+Expected pattern: <g>/banana/</>
+Received message: <r>"apple"</>
 
-      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+      <d>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<d>:24:74)</>
 `;
 
 exports[`toThrowError regexp threw, but message did not match (non-error falsey) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toThrowError<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toThrowError<d>(</><g>expected</><d>)</>
 
-Expected pattern: <green>/^[123456789]\\\\d*/</>
-Received value:   <red>0</>
-"
+Expected pattern: <g>/^[123456789]\\d*/</>
+Received value:   <r>0</>
+
 `;
 
 exports[`toThrowError regexp threw, but message should not match (error) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrowError<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toThrowError<d>(</><g>expected</><d>)</>
 
-Expected pattern: not <green>/ array /</>
-Received message:     <red>\\"Invalid<inverse> array </>length\\"</>
+Expected pattern: not <g>/ array /</>
+Received message:     <r>"Invalid<i> array </i>length"</>
 
-      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+      <d>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<d>:24:74)</>
 `;
 
 exports[`toThrowError regexp threw, but message should not match (non-error truthy) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrowError<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toThrowError<d>(</><g>expected</><d>)</>
 
-Expected pattern: not <green>/^[123456789]\\\\d*/</>
-Received value:       <red>404</>
-"
+Expected pattern: not <g>/^[123456789]\\d*/</>
+Received value:       <r>404</>
+
 `;
 
 exports[`toThrowError substring did not throw at all 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toThrowError<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toThrowError<d>(</><g>expected</><d>)</>
 
-Expected substring: <green>\\"apple\\"</>
+Expected substring: <g>"apple"</>
 
-Received function did not throw"
+Received function did not throw
 `;
 
 exports[`toThrowError substring threw, but message did not match (error) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toThrowError<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toThrowError<d>(</><g>expected</><d>)</>
 
-Expected substring: <green>\\"banana\\"</>
-Received message:   <red>\\"apple\\"</>
+Expected substring: <g>"banana"</>
+Received message:   <r>"apple"</>
 
-      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+      <d>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<d>:24:74)</>
 `;
 
 exports[`toThrowError substring threw, but message did not match (non-error falsey) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>toThrowError<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>toThrowError<d>(</><g>expected</><d>)</>
 
-Expected substring: <green>\\"Server Error\\"</>
-Received value:     <red>\\"\\"</>
-"
+Expected substring: <g>"Server Error"</>
+Received value:     <r>""</>
+
 `;
 
 exports[`toThrowError substring threw, but message should not match (error) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrowError<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toThrowError<d>(</><g>expected</><d>)</>
 
-Expected substring: not <green>\\"array\\"</>
-Received message:       <red>\\"Invalid <inverse>array</> length\\"</>
+Expected substring: not <g>"array"</>
+Received message:       <r>"Invalid <i>array</i> length"</>
 
-      <dim>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<dim>:24:74)</>"
+      <d>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<d>:24:74)</>
 `;
 
 exports[`toThrowError substring threw, but message should not match (non-error truthy) 1`] = `
-"<dim>expect(</><red>received</><dim>).</>not<dim>.</>toThrowError<dim>(</><green>expected</><dim>)</>
+<d>expect(</><r>received</><d>).</>not<d>.</>toThrowError<d>(</><g>expected</><d>)</>
 
-Expected substring: not <green>\\"Server Error\\"</>
-Received value:         <red>\\"Internal Server Error\\"</>
-"
+Expected substring: not <g>"Server Error"</>
+Received value:         <r>"Internal Server Error"</>
+
 `;

--- a/packages/expect/src/__tests__/assertionCounts.test.js
+++ b/packages/expect/src/__tests__/assertionCounts.test.js
@@ -8,7 +8,10 @@
 
 'use strict';
 
+const {alignedAnsiStyleSerializer} = require('@jest/test-utils');
 const jestExpect = require('../');
+
+expect.addSnapshotSerializer(alignedAnsiStyleSerializer);
 
 describe('.assertions()', () => {
   it('does not throw', () => {

--- a/packages/expect/src/__tests__/extend.test.js
+++ b/packages/expect/src/__tests__/extend.test.js
@@ -7,9 +7,12 @@
  */
 
 const matcherUtils = require('jest-matcher-utils');
+const {alignedAnsiStyleSerializer} = require('@jest/test-utils');
 const {iterableEquality, subsetEquality} = require('../utils');
 const {equals} = require('../jasmineUtils');
 const jestExpect = require('../');
+
+expect.addSnapshotSerializer(alignedAnsiStyleSerializer);
 
 jestExpect.extend({
   toBeDivisibleBy(actual, expected) {

--- a/packages/expect/src/__tests__/matchers.test.js
+++ b/packages/expect/src/__tests__/matchers.test.js
@@ -6,10 +6,13 @@
  */
 
 const {stringify} = require('jest-matcher-utils');
+const {alignedAnsiStyleSerializer} = require('@jest/test-utils');
 const jestExpect = require('../');
 const Immutable = require('immutable');
 const chalk = require('chalk');
 const chalkEnabled = chalk.enabled;
+
+expect.addSnapshotSerializer(alignedAnsiStyleSerializer);
 
 beforeAll(() => {
   chalk.enabled = true;

--- a/packages/expect/src/__tests__/spyMatchers.test.js
+++ b/packages/expect/src/__tests__/spyMatchers.test.js
@@ -6,7 +6,10 @@
  */
 
 const Immutable = require('immutable');
+const {alignedAnsiStyleSerializer} = require('@jest/test-utils');
 const jestExpect = require('../');
+
+expect.addSnapshotSerializer(alignedAnsiStyleSerializer);
 
 // Given a Jest mock function, return a minimal mock of a Jasmine spy.
 const createSpy = fn => {

--- a/packages/expect/src/__tests__/toThrowMatchers.test.ts
+++ b/packages/expect/src/__tests__/toThrowMatchers.test.ts
@@ -5,7 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import {alignedAnsiStyleSerializer} from '@jest/test-utils';
 import jestExpect from '../';
+
+expect.addSnapshotSerializer(alignedAnsiStyleSerializer);
 
 // Custom Error class because node versions have different stack trace strings.
 class CustomError extends Error {

--- a/packages/expect/tsconfig.json
+++ b/packages/expect/tsconfig.json
@@ -9,6 +9,7 @@
     {"path": "../jest-matcher-utils"},
     {"path": "../jest-message-util"},
     {"path": "../jest-regex-util"},
-    {"path": "../jest-types"}
+    {"path": "../jest-types"},
+    {"path": "../test-utils"}
   ]
 }


### PR DESCRIPTION
##  Summary

Display colors concisely and clearly to review changes quickly and confidently

Too bad about the blame, but the next pull request to `expect` will illustrate the benefit

## Test plan

Updated 903 snapshots:

| | file |
| ---: | :--- |
| 1 | `assertionCounts.test.ts.snap` |
| 7 | `extend.test.ts.snap` |
| 521 | `matchers.test.ts.snap` |
| 308 | `spyMatchers.test.ts.snap` |
| 66 | `toThrowMatchers.test.ts.snap` |

Substring differences for the win to review changes locally before updating snapshots :)

But double tests for spy and toThrow matchers added insult to eye injury :(