### PR TITLE
docs: Change `before` to `beforeEach`

### DIFF
--- a/docs/SetupAndTeardown.md
+++ b/docs/SetupAndTeardown.md
@@ -63,7 +63,7 @@ test('city database has San Juan', () => {
 
 ## Scoping
 
-By default, the `before` and `after` blocks apply to every test in a file. You can also group tests together using a `describe` block. When they are inside a `describe` block, the `before` and `after` blocks only apply to the tests within that `describe` block.
+By default, the `beforeEach` and `afterEach` blocks apply to every test in a file. You can also group tests together using a `describe` block. When they are inside a `describe` block, the `beforeEach` and `afterEach` blocks only apply to the tests within that `describe` block.
 
 For example, let's say we had not just a city database, but also a food database. We could do different setup for different tests:
 


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Simple doc update to Setup and Teardown

While reading, I was confused by references to `before` and `after`, which have been removed. It seems like these should be `beforeEach` and `afterEach` instead of `before` and `after`. Alternatively, we could use `before*` like in the `Order of execution` step, but it seems like `beforeEach`/`afterEach` are the better fit here.



<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan
N/A
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
