### PR TITLE
feat: transform file paths into hyperlinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - `[jest-runner]` Warn if a worker had to be force exited ([#8206](https://github.com/facebook/jest/pull/8206))
 - `[@jest/test-result]` Create method to create empty `TestResult` ([#8867](https://github.com/facebook/jest/pull/8867))
 - `[jest-worker]` [**BREAKING**] Return a promise from `end()`, resolving with the information whether workers exited gracefully ([#8206](https://github.com/facebook/jest/pull/8206))
+- `[jest-reporters]` Transform file paths into hyperlinks ([#8980](https://github.com/facebook/jest/pull/8980))
 
 ### Fixes
 

--- a/packages/jest-reporters/package.json
+++ b/packages/jest-reporters/package.json
@@ -25,7 +25,8 @@
     "jest-worker": "^24.6.0",
     "slash": "^3.0.0",
     "source-map": "^0.6.0",
-    "string-length": "^3.1.0"
+    "string-length": "^3.1.0",
+    "terminal-link": "^2.0.0"
   },
   "devDependencies": {
     "@types/exit": "^0.1.30",

--- a/packages/jest-reporters/src/__tests__/get_result_header.test.js
+++ b/packages/jest-reporters/src/__tests__/get_result_header.test.js
@@ -10,7 +10,7 @@ import {formatTestPath} from '../utils';
 import getResultHeader from '../get_result_header';
 const terminalLink = require('terminal-link');
 
-jest.mock('terminal-link', () => jest.fn());
+jest.mock('terminal-link', () => jest.fn(() => 'wannabehyperlink'));
 
 const testResult = {
   testFilePath: '/foo',
@@ -27,4 +27,10 @@ test('should call `terminal-link` correctly', () => {
   expect(terminalLink).toHaveBeenCalled();
   expect(call[0]).toBe(formatTestPath(globalConfig, testResult.testFilePath));
   expect(call[1]).toBe(`file://${testResult.testFilePath}`);
+});
+
+test('should render the output correctly', () => {
+  const result = getResultHeader(testResult, globalConfig);
+
+  expect(result).toMatch(/wannabehyperlink/);
 });

--- a/packages/jest-reporters/src/__tests__/get_result_header.test.js
+++ b/packages/jest-reporters/src/__tests__/get_result_header.test.js
@@ -6,7 +6,6 @@
  */
 
 import {makeGlobalConfig} from '../../../../TestUtils';
-import {formatTestPath} from '../utils';
 import getResultHeader from '../get_result_header';
 const terminalLink = require('terminal-link');
 
@@ -26,8 +25,8 @@ test('should call `terminal-link` correctly', () => {
   getResultHeader(testResult, globalConfig);
 
   expect(terminalLink).toBeCalledWith(
-    formatTestPath(globalConfig, testResult.testFilePath),
-    `file://${testResult.testFilePath}`,
+    expect.stringContaining('foo'),
+    'file:///foo',
     expect.objectContaining({fallback: expect.any(Function)}),
   );
 });

--- a/packages/jest-reporters/src/__tests__/get_result_header.test.js
+++ b/packages/jest-reporters/src/__tests__/get_result_header.test.js
@@ -18,19 +18,22 @@ const testResult = {
 
 const globalConfig = makeGlobalConfig();
 
-test('should call `terminal-link` correctly', () => {
+beforeEach(() => {
   terminalLink.mockClear();
-
-  getResultHeader(testResult, globalConfig);
-  const call = terminalLink.mock.calls[0];
-
-  expect(terminalLink).toHaveBeenCalled();
-  expect(call[0]).toBe(formatTestPath(globalConfig, testResult.testFilePath));
-  expect(call[1]).toBe(`file://${testResult.testFilePath}`);
 });
 
-test('should render the output correctly', () => {
+test('should call `terminal-link` correctly', () => {
+  getResultHeader(testResult, globalConfig);
+
+  expect(terminalLink).toBeCalledWith(
+    formatTestPath(globalConfig, testResult.testFilePath),
+    `file://${testResult.testFilePath}`,
+    expect.objectContaining({fallback: expect.any(Function)}),
+  );
+});
+
+test('should render the terminal link', () => {
   const result = getResultHeader(testResult, globalConfig);
 
-  expect(result).toMatch(/wannabehyperlink/);
+  expect(result).toContain('wannabehyperlink');
 });

--- a/packages/jest-reporters/src/__tests__/get_result_header.test.js
+++ b/packages/jest-reporters/src/__tests__/get_result_header.test.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {makeGlobalConfig} from '../../../../TestUtils';
+import {formatTestPath} from '../utils';
+import getResultHeader from '../get_result_header';
+const terminalLink = require('terminal-link');
+
+jest.mock('terminal-link', () => jest.fn());
+
+const testResult = {
+  testFilePath: '/foo',
+};
+
+const globalConfig = makeGlobalConfig();
+
+test('should call `terminal-link` correctly', () => {
+  terminalLink.mockClear();
+
+  getResultHeader(testResult, globalConfig);
+  const call = terminalLink.mock.calls[0];
+
+  expect(terminalLink).toHaveBeenCalled();
+  expect(call[0]).toBe(formatTestPath(globalConfig, testResult.testFilePath));
+  expect(call[1]).toBe(`file://${testResult.testFilePath}`);
+});

--- a/packages/jest-reporters/src/get_result_header.ts
+++ b/packages/jest-reporters/src/get_result_header.ts
@@ -9,6 +9,7 @@ import {Config} from '@jest/types';
 import {TestResult} from '@jest/test-result';
 import chalk from 'chalk';
 import {formatTestPath, printDisplayName} from './utils';
+import terminalLink = require('terminal-link');
 
 const LONG_TEST_COLOR = chalk.reset.bold.bgRed;
 // Explicitly reset for these messages since they can get written out in the
@@ -30,6 +31,13 @@ export default (
   projectConfig?: Config.ProjectConfig,
 ) => {
   const testPath = result.testFilePath;
+  const formattedTestPath = formatTestPath(
+    projectConfig ? projectConfig : globalConfig,
+    testPath,
+  );
+  const fileLink = terminalLink(formattedTestPath, `file://${testPath}`, {
+    fallback: () => formattedTestPath,
+  });
   const status =
     result.numFailingTests > 0 || result.testExecError ? FAIL : PASS;
 
@@ -53,9 +61,7 @@ export default (
       : '';
 
   return (
-    `${status} ${projectDisplayName}${formatTestPath(
-      projectConfig ? projectConfig : globalConfig,
-      testPath,
-    )}` + (testDetail.length ? ` (${testDetail.join(', ')})` : '')
+    `${status} ${projectDisplayName}${fileLink}` +
+    (testDetail.length ? ` (${testDetail.join(', ')})` : '')
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -13130,6 +13130,14 @@ supports-color@^7.0.0:
   dependencies:
     has-flag "^4.0.0"
 
+supports-hyperlinks@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/supports-hyperlinks/-/supports-hyperlinks-2.0.0.tgz#b1b94a159e9df00b0a554b2d5f0e0a89690334b0"
+  integrity sha512-bFhn0MQ8qefLyJ3K7PpHiPUTuTVPWw6RXfaMeV6xgJLXtBbszyboz1bvGTVv4R0YpQm2DqlXXn0fFHhxUHVE5w==
+  dependencies:
+    has-flag "^4.0.0"
+    supports-color "^7.0.0"
+
 svgo@^1.0.0, svgo@^1.0.5:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/svgo/-/svgo-1.3.0.tgz#bae51ba95ded9a33a36b7c46ce9c359ae9154313"
@@ -13244,6 +13252,14 @@ tempfile@^2.0.0:
   dependencies:
     temp-dir "^1.0.0"
     uuid "^3.0.1"
+
+terminal-link@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/terminal-link/-/terminal-link-2.0.0.tgz#daa5d9893d57d3a09f981e1a45be37daba3f0ce6"
+  integrity sha512-rdBAY35jUvVapqCuhehjenLbYY73cVgRQ6podD6u9EDBomBBHjCOtmq2InPgPpTysOIOsQ5PdBzwSC/sKjv6ew==
+  dependencies:
+    ansi-escapes "^4.2.1"
+    supports-hyperlinks "^2.0.0"
 
 terser-webpack-plugin@^1.4.1:
   version "1.4.1"


### PR DESCRIPTION
Closes #8937

## Summary

Straightforward change, file paths will now become hyperlinks in terminals that support it. In the ones that don't they will stay the same. I was thinking about displaying the paths somehow (flag??) as they are still clickable and quite useful in the Terminal.app even though they are not exactly hyperlinks.

I've used commonJS modules to import the lib as we don't have `esModuleInterop` flag in TS config, can you see any reasons for not using it?

## Test plan

Hyperlink in ITerm2:
<img width="640" alt="Zrzut ekranu 2019-09-25 o 19 33 57" src="https://user-images.githubusercontent.com/23037261/65625105-76714280-dfcb-11e9-9468-84907bd2edd4.png">

Hyperlink in ITerm2 when hovered with CMD pressed:
<img width="648" alt="Zrzut ekranu 2019-09-25 o 19 15 11" src="https://user-images.githubusercontent.com/23037261/65625056-5e99be80-dfcb-11e9-9f89-082129c9b4fa.png">

Hyperlink in Terminal.app without a fallback:
<img width="1151" alt="Zrzut ekranu 2019-09-25 o 19 16 14" src="https://user-images.githubusercontent.com/23037261/65625181-9ef93c80-dfcb-11e9-8720-05bbf062970d.png">
^ It's ugly, but useful which makes me wonder if it would be worth it to add some kind of flag for it.
