### PR TITLE
docs: Add collectCoverage to Reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - `[*]` Add Node 12 to CI ([#8411](https://github.com/facebook/jest/pull/8411))
 - `[*]` [**BREAKING**] Upgrade to Micromatch v4 ([#8852](https://github.com/facebook/jest/pull/8852))
 - `[babel-plugin-jest-hoist]` [**BREAKING**] Use ESM exports ([#8874](https://github.com/facebook/jest/pull/8874))
+- `[docs]` Add `collectCoverage` to CLI Reference ([#8996](https://github.com/facebook/jest/pull/8996))
 - `[docs]` Fix broken link pointing to legacy JS file in "Snapshot Testing".
 - `[docs]` Add `setupFilesAfterEnv` and `jest.setTimeout` example ([#8971](https://github.com/facebook/jest/pull/8971))
 - `[jest]` [**BREAKING**] Use ESM exports ([#8874](https://github.com/facebook/jest/pull/8874))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@
 - `[*]` Add Node 12 to CI ([#8411](https://github.com/facebook/jest/pull/8411))
 - `[*]` [**BREAKING**] Upgrade to Micromatch v4 ([#8852](https://github.com/facebook/jest/pull/8852))
 - `[babel-plugin-jest-hoist]` [**BREAKING**] Use ESM exports ([#8874](https://github.com/facebook/jest/pull/8874))
-- `[docs]` Add `collectCoverage` to CLI Reference ([#8996](https://github.com/facebook/jest/pull/8996))
+- `[docs]` Add alias and optional boolean value to `coverage` CLI Reference ([#8996](https://github.com/facebook/jest/pull/8996))
 - `[docs]` Fix broken link pointing to legacy JS file in "Snapshot Testing".
 - `[docs]` Add `setupFilesAfterEnv` and `jest.setTimeout` example ([#8971](https://github.com/facebook/jest/pull/8971))
 - `[jest]` [**BREAKING**] Use ESM exports ([#8874](https://github.com/facebook/jest/pull/8874))

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -136,10 +136,6 @@ When this option is provided, Jest will assume it is running in a CI environment
 
 Deletes the Jest cache directory and then exits without running tests. Will delete `cacheDirectory` if the option is passed, or Jest's default cache directory. The default cache directory can be found by calling `jest --showConfig`. _Note: clearing the cache will reduce performance._
 
-### `--collectCoverage[=<boolean>]`
-
-Collect coverage information while executing the test. Optionally pass `<boolean>` to override option set in configuration.
-
 ### `--collectCoverageFrom=<glob>`
 
 A glob pattern relative to <rootDir> matching the files that coverage info needs to be collected from.
@@ -152,9 +148,9 @@ Forces test results output highlighting even if stdout is not a TTY.
 
 Alias: `-c`. The path to a Jest config file specifying how to find and execute tests. If no `rootDir` is set in the config, the directory containing the config file is assumed to be the rootDir for the project. This can also be a JSON-encoded value which Jest will use as configuration.
 
-### `--coverage`
+### `--coverage[=<boolean>]`
 
-Indicates that test coverage information should be collected and reported in the output. This option is also aliased by `--collectCoverage`.
+Alias: `--collectCoverage`. Indicates that test coverage information should be collected and reported in the output. Optionally pass `<boolean>` to override option set in configuration.
 
 ### `--debug`
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -136,6 +136,10 @@ When this option is provided, Jest will assume it is running in a CI environment
 
 Deletes the Jest cache directory and then exits without running tests. Will delete `cacheDirectory` if the option is passed, or Jest's default cache directory. The default cache directory can be found by calling `jest --showConfig`. _Note: clearing the cache will reduce performance._
 
+### `--collectCoverage[=<boolean>]`
+
+Collect coverage information while executing the test. Optionally pass `<boolean>` to override option set in configuration.
+
 ### `--collectCoverageFrom=<glob>`
 
 A glob pattern relative to <rootDir> matching the files that coverage info needs to be collected from.


### PR DESCRIPTION
## Summary

Having been confused myself, as well as noting the same confusion in forums. Many people cannot figure out how to turn off coverage reports, if the option has been set via Configuration.

Note, a similar confusion/change apply to other boolean options as well, but that's not covered in this PR.

## Test plan

n/a
