### PR TITLE
expect: Avoid incorrect difference for subset when toMatchObject fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,8 @@
 
 ### Fixes
 
-- `[expect]` Display expectedDiff more carefully in toBeCloseTo ([#8389](https://github.com/facebook/jest/pull/8389))
+- `[expect]` Display `expectedDiff` more carefully in `toBeCloseTo` ([#8389](https://github.com/facebook/jest/pull/8389))
+- `[expect]` Avoid incorrect difference for subset when `toMatchObject` fails ([#9005](https://github.com/facebook/jest/pull/9005))
 - `[jest-core]` Don't include unref'd timers in --detectOpenHandles results ([#8941](https://github.com/facebook/jest/pull/8941))
 - `[jest-diff]` Do not inverse format if line consists of one change ([#8903](https://github.com/facebook/jest/pull/8903))
 - `[jest-fake-timers]` `getTimerCount` will not include cancelled immediates ([#8764](https://github.com/facebook/jest/pull/8764))

--- a/packages/expect/src/__tests__/utils.test.js
+++ b/packages/expect/src/__tests__/utils.test.js
@@ -147,7 +147,7 @@ describe('hasOwnProperty', () => {
   });
 });
 
-describe('getObjectSubset()', () => {
+describe('getObjectSubset', () => {
   [
     [{a: 'b', c: 'd'}, {a: 'd'}, {a: 'b'}],
     [{a: [1, 2], b: 'b'}, {a: [3, 4]}, {a: [1, 2]}],
@@ -163,6 +163,43 @@ describe('getObjectSubset()', () => {
         expect(getObjectSubset(object, subset)).toEqual(expected);
       },
     );
+  });
+
+  describe('returns object instance', () => {
+    test('Date', () => {
+      const object = new Date('2015-11-30');
+      const subset = new Date('2016-12-30');
+
+      expect(getObjectSubset(object, subset)).toBe(object);
+    });
+  });
+
+  describe('returns subset instance', () => {
+    test('Object', () => {
+      const object = {key0: 'zero', key1: 'one', key2: 'two'};
+      const subset = {key0: 'zero', key2: 'two'};
+
+      expect(getObjectSubset(object, subset)).toBe(subset);
+    });
+
+    describe('Uint8Array', () => {
+      const equalObject = {'0': 0, '1': 0, '2': 0};
+      const typedArray = new Uint8Array(3);
+
+      test('expected', () => {
+        const object = equalObject;
+        const subset = typedArray;
+
+        expect(getObjectSubset(object, subset)).toBe(subset);
+      });
+
+      test('received', () => {
+        const object = typedArray;
+        const subset = equalObject;
+
+        expect(getObjectSubset(object, subset)).toBe(subset);
+      });
+    });
   });
 
   describe('calculating subsets of objects with circular references', () => {

--- a/packages/expect/src/__tests__/utils.test.js
+++ b/packages/expect/src/__tests__/utils.test.js
@@ -165,7 +165,7 @@ describe('getObjectSubset', () => {
     );
   });
 
-  describe('returns object instance', () => {
+  describe('returns the object instance if the subset has no extra properties', () => {
     test('Date', () => {
       const object = new Date('2015-11-30');
       const subset = new Date('2016-12-30');
@@ -174,7 +174,7 @@ describe('getObjectSubset', () => {
     });
   });
 
-  describe('returns subset instance', () => {
+  describe('returns the subset instance if its property values are equal', () => {
     test('Object', () => {
       const object = {key0: 'zero', key1: 'one', key2: 'two'};
       const subset = {key0: 'zero', key2: 'two'};

--- a/packages/expect/src/utils.ts
+++ b/packages/expect/src/utils.ts
@@ -111,6 +111,7 @@ export const getObjectSubset = (
 ): any => {
   if (Array.isArray(object)) {
     if (Array.isArray(subset) && subset.length === object.length) {
+      // The map method returns correct subclass of subset.
       return subset.map((sub: any, i: number) =>
         getObjectSubset(object[i], sub),
       );
@@ -119,6 +120,7 @@ export const getObjectSubset = (
     return object;
   } else if (isObject(object) && isObject(subset)) {
     if (equals(object, subset, [iterableEquality, subsetEquality])) {
+      // Avoid unnecessary copy which might return Object instead of subclass.
       return subset;
     }
 

--- a/packages/expect/src/utils.ts
+++ b/packages/expect/src/utils.ts
@@ -118,6 +118,10 @@ export const getObjectSubset = (
   } else if (object instanceof Date) {
     return object;
   } else if (isObject(object) && isObject(subset)) {
+    if (equals(object, subset, [iterableEquality, subsetEquality])) {
+      return subset;
+    }
+
     const trimmed: any = {};
     seenReferences.set(object, trimmed);
 


### PR DESCRIPTION
## Summary

Fixes #8947

When the `getObjectSubset` function copies the relevant subset of object properties recursively, it creates ordinary `Object` instances. If expected and received values are a subclass or typed array, then the type change of the received subset becomes an incorrect change in the difference when `toMatchObject` fails.

If corresponding values:

* are subset match, then return the expected value instead of a copy of the received value
* are not subset match, then incorrect type difference is still possible

Although the function returns an unnecessary copy for arrays, I left it as is, because the `map` method returns the same array class as the subset

Background information:

* `toMatchObject` does not require same type: like `toEqual` and unlike `toStrictEqual`
* `Array.isArray` returns `false` for typed arrays

## Test plan

Separate tests for deep equality versus referential identity of returned subset

Add 3 new tests which failed before the code change

See also pictures in following comments: baseline is at left and improved is at right