### PR TITLE
Add cli flag --passWithNoCoverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - `[jest-runner]` Warn if a worker had to be force exited ([#8206](https://github.com/facebook/jest/pull/8206))
 - `[@jest/test-result]` Create method to create empty `TestResult` ([#8867](https://github.com/facebook/jest/pull/8867))
 - `[jest-worker]` [**BREAKING**] Return a promise from `end()`, resolving with the information whether workers exited gracefully ([#8206](https://github.com/facebook/jest/pull/8206))
+- `[jest-core]` Add `--passWithNoCoverage` flag ([#9019](https://github.com/facebook/jest/pull/9019))
 
 ### Fixes
 

--- a/TestUtils.ts
+++ b/TestUtils.ts
@@ -43,6 +43,7 @@ const DEFAULT_GLOBAL_CONFIG: Config.GlobalConfig = {
   onlyChanged: false,
   onlyFailures: false,
   outputFile: null,
+  passWithNoCoverage: false,
   passWithNoTests: false,
   projects: [],
   replname: null,

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -230,6 +230,10 @@ Activates notifications for test results. Good for when you don't want your cons
 
 Alias: `-o`. Attempts to identify which tests to run based on which files have changed in the current repository. Only works if you're running tests in a git/hg repository at the moment and requires a static dependency graph (ie. no dynamic requires).
 
+### `--passWithNoCoverage`
+
+Allows the test suite to pass when no files are found in coverage matching on defined in coverageThreshold.
+
 ### `--passWithNoTests`
 
 Allows the test suite to pass when no files are found.

--- a/e2e/__tests__/__snapshots__/coverageThreshold.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/coverageThreshold.test.ts.snap
@@ -34,6 +34,15 @@ All files  |      100 |      100 |      100 |      100 |                   |
 -----------|----------|----------|----------|----------|-------------------|
 `;
 
+exports[`exits with 0 if path threshold group is not found in coverage data and passWithNoCoverage is true: stdout 1`] = `
+----------|----------|----------|----------|----------|-------------------|
+File      |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
+----------|----------|----------|----------|----------|-------------------|
+All files |      100 |      100 |      100 |      100 |                   |
+ grape.js |      100 |      100 |      100 |      100 |                   |
+----------|----------|----------|----------|----------|-------------------|
+`;
+
 exports[`exits with 1 if coverage threshold is not met 1`] = `
 PASS __tests__/a-banana.js
   ✓ banana

--- a/e2e/__tests__/__snapshots__/coverageThreshold.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/coverageThreshold.test.ts.snap
@@ -34,6 +34,19 @@ All files  |      100 |      100 |      100 |      100 |                   |
 -----------|----------|----------|----------|----------|-------------------|
 `;
 
+exports[`exits with 0 if path threshold group is not found in coverage data and passWithNoCoverage is true 1`] = `
+PASS __tests__/grape.test.js
+  ✓ grape
+`;
+
+exports[`exits with 0 if path threshold group is not found in coverage data and passWithNoCoverage is true 2`] = `
+Test Suites: 1 passed, 1 total
+Tests:       1 passed, 1 total
+Snapshots:   0 total
+Time:        <<REPLACED>>
+Ran all test suites.
+`;
+
 exports[`exits with 0 if path threshold group is not found in coverage data and passWithNoCoverage is true: stdout 1`] = `
 ----------|----------|----------|----------|----------|-------------------|
 File      |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |

--- a/e2e/__tests__/__snapshots__/showConfig.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/showConfig.test.ts.snap
@@ -109,6 +109,7 @@ exports[`--showConfig outputs config info and exits 1`] = `
     "nonFlagArgs": [],
     "notify": false,
     "notifyMode": "failure-change",
+    "passWithNoCoverage": false,
     "passWithNoTests": false,
     "projects": null,
     "rootDir": "<<REPLACED_ROOT_DIR>>",

--- a/e2e/__tests__/coverageThreshold.test.ts
+++ b/e2e/__tests__/coverageThreshold.test.ts
@@ -228,3 +228,42 @@ test('file is matched by all path and glob threshold groups', () => {
   expect(wrap(summary)).toMatchSnapshot();
   expect(wrap(stdout)).toMatchSnapshot('stdout');
 });
+
+test('exits with 0 if path threshold group is not found in coverage data and passWithNoCoverage is true', () => {
+  const pkgJson = {
+    jest: {
+      collectCoverage: true,
+      collectCoverageFrom: ['**/*.js'],
+      coverageThreshold: {
+        global: {
+          lines: 100,
+        },
+        'pear.js': {
+          lines: 100,
+        },
+      },
+    },
+  };
+
+  writeFiles(DIR, {
+    '__tests__/grape.test.js': `
+      const grape = require('../grape.js');
+      test('grape', () => expect(grape()).toBe(3));
+    `,
+    'grape.js': `
+      module.exports = () => {
+        return 1 + 2;
+      };
+    `,
+    'package.json': JSON.stringify(pkgJson, null, 2),
+  });
+
+  const {stdout, exitCode} = runJest(
+    DIR,
+    ['--coverage', '--ci=false', '--passWithNoCoverage'],
+    {stripAnsi: true},
+  );
+
+  expect(exitCode).toBe(0);
+  expect(wrap(stdout)).toMatchSnapshot('stdout');
+});

--- a/e2e/__tests__/coverageThreshold.test.ts
+++ b/e2e/__tests__/coverageThreshold.test.ts
@@ -258,12 +258,15 @@ test('exits with 0 if path threshold group is not found in coverage data and pas
     'package.json': JSON.stringify(pkgJson, null, 2),
   });
 
-  const {stdout, exitCode} = runJest(
+  const {stdout, stderr, exitCode} = runJest(
     DIR,
     ['--coverage', '--ci=false', '--passWithNoCoverage'],
     {stripAnsi: true},
   );
+  const {rest, summary} = extractSummary(stderr);
 
   expect(exitCode).toBe(0);
+  expect(wrap(rest)).toMatchSnapshot();
+  expect(wrap(summary)).toMatchSnapshot();
   expect(wrap(stdout)).toMatchSnapshot('stdout');
 });

--- a/packages/jest-cli/src/cli/args.ts
+++ b/packages/jest-cli/src/cli/args.ts
@@ -428,6 +428,13 @@ export const options = {
       'also specified.',
     type: 'string',
   },
+  passWithNoCoverage: {
+    default: false,
+    description:
+      'Will not fail if no coverage data is found ' +
+      'for a file defined in coverageThreshold.',
+    type: 'boolean',
+  },
   passWithNoTests: {
     default: false,
     description:

--- a/packages/jest-config/src/index.ts
+++ b/packages/jest-config/src/index.ts
@@ -136,6 +136,7 @@ const groupOptions = (
     onlyChanged: options.onlyChanged,
     onlyFailures: options.onlyFailures,
     outputFile: options.outputFile,
+    passWithNoCoverage: options.passWithNoCoverage,
     passWithNoTests: options.passWithNoTests,
     projects: options.projects,
     replname: options.replname,

--- a/packages/jest-config/src/normalize.ts
+++ b/packages/jest-config/src/normalize.ts
@@ -845,6 +845,7 @@ export default function normalize(
       case 'notifyMode':
       case 'onlyChanged':
       case 'outputFile':
+      case 'passWithNoCoverage':
       case 'passWithNoTests':
       case 'replname':
       case 'reporters':

--- a/packages/jest-core/src/__tests__/__snapshots__/watch_filename_pattern_mode.test.js.snap
+++ b/packages/jest-core/src/__tests__/__snapshots__/watch_filename_pattern_mode.test.js.snap
@@ -83,6 +83,7 @@ exports[`Watch mode flows Pressing "P" enters pattern mode 8`] = `
 exports[`Watch mode flows Pressing "P" enters pattern mode 9`] = `
 Object {
   "onlyChanged": false,
+  "passWithNoCoverage": true,
   "passWithNoTests": true,
   "testPathPattern": "p.*3",
   "watch": true,

--- a/packages/jest-core/src/lib/__tests__/__snapshots__/log_debug_messages.test.ts.snap
+++ b/packages/jest-core/src/lib/__tests__/__snapshots__/log_debug_messages.test.ts.snap
@@ -100,6 +100,7 @@ exports[`prints the config object 1`] = `
     "onlyChanged": false,
     "onlyFailures": false,
     "outputFile": null,
+    "passWithNoCoverage": false,
     "passWithNoTests": false,
     "projects": [],
     "replname": null,

--- a/packages/jest-core/src/lib/update_global_config.ts
+++ b/packages/jest-core/src/lib/update_global_config.ts
@@ -10,7 +10,7 @@ import {Config} from '@jest/types';
 import {AllowedConfigOptions} from 'jest-watcher';
 
 type ExtraConfigOptions = Partial<
-  Pick<Config.GlobalConfig, 'noSCM' | 'passWithNoTests'>
+  Pick<Config.GlobalConfig, 'noSCM' | 'passWithNoTests' | 'passWithNoCoverage'>
 >;
 
 export default (
@@ -86,6 +86,10 @@ export default (
 
   if (options.onlyFailures !== undefined) {
     newConfig.onlyFailures = options.onlyFailures || false;
+  }
+
+  if (options.passWithNoCoverage !== undefined) {
+    newConfig.passWithNoCoverage = true;
   }
 
   if (options.passWithNoTests !== undefined) {

--- a/packages/jest-core/src/watch.ts
+++ b/packages/jest-core/src/watch.ts
@@ -96,6 +96,7 @@ export default function watch(
 
   globalConfig = updateGlobalConfig(globalConfig, {
     mode: globalConfig.watch ? 'watch' : 'watchAll',
+    passWithNoCoverage: true,
     passWithNoTests: true,
   });
 

--- a/packages/jest-reporters/src/coverage_reporter.ts
+++ b/packages/jest-reporters/src/coverage_reporter.ts
@@ -379,7 +379,10 @@ export default class CoverageReporter extends BaseReporter {
             break;
           default:
             // If the file specified by path is not found, error is returned.
-            if (thresholdGroup !== THRESHOLD_GROUP_TYPES.GLOBAL) {
+            if (
+              thresholdGroup !== THRESHOLD_GROUP_TYPES.GLOBAL &&
+              !globalConfig.passWithNoCoverage
+            ) {
               errors = errors.concat(
                 `Jest: Coverage data for ${thresholdGroup} was not found.`,
               );

--- a/packages/jest-types/src/Config.ts
+++ b/packages/jest-types/src/Config.ts
@@ -173,6 +173,7 @@ export type InitialOptions = {
   notifyMode?: string;
   onlyChanged?: boolean;
   outputFile?: Path;
+  passWithNoCoverage?: boolean;
   passWithNoTests?: boolean;
   preprocessorIgnorePatterns?: Array<Glob>;
   preset?: string | null | undefined;
@@ -334,6 +335,7 @@ export type GlobalConfig = {
   outputFile: Path | null | undefined;
   onlyChanged: boolean;
   onlyFailures: boolean;
+  passWithNoCoverage: boolean;
   passWithNoTests: boolean;
   projects: Array<Glob>;
   replname: string | null | undefined;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary
Fixes: https://github.com/facebook/jest/issues/8474

This PR is adding a new flag (`--passWithNoCoverage`) that can be passed when running jest with code coverage in combination with `coverageThreshold`.  This flag makes tests not fail when there is are `coverageThresholds` set for a specific file, and a subset of tests are run with coverage that do not touch all files specified in the `coverageThreshold` configuration.

## Test plan

An end to end test was added with this PR that demonstrates the expected behavior of the flag.  The following configuration of files, tests, and configuration will now pass when jest is executed with the `--passWithNoCoverage` flag.

**package.json**
```
jest: {
  collectCoverage: true,
  collectCoverageFrom: ['**/*.js'],
  coverageThreshold: {
    global: {
      lines: 100
    },
    'pear.js': {
      lines: 100
    }
  }
}
```

**grape.js**
```
module.exports = () => {
  return 1 + 2;
};
```

**grape.test.js**
```
const grape = require('../grape.js');
test('grape', () => expect(grape()).toBe(3));
```

**jest run command**
```
$> jest --coverage --passWithNoCoverage
PASS __tests__/grape.test.js
  ✓ grape

----------|----------|----------|----------|----------|-------------------|
File      |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
----------|----------|----------|----------|----------|-------------------|
All files |      100 |      100 |      100 |      100 |                   |
 grape.js |      100 |      100 |      100 |      100 |                   |
----------|----------|----------|----------|----------|-------------------|
Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        1s
Ran all test suites.
$> echo $?
0
```