### PR TITLE
expect, jest-matcher-utils: Display change counts in annotation lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - `[babel-plugin-jest-hoist]` Add `BigInt` to `WHITELISTED_IDENTIFIERS` ([#8382](https://github.com/facebook/jest/pull/8382))
 - `[babel-preset-jest]` Add `@babel/plugin-syntax-bigint` ([#8382](https://github.com/facebook/jest/pull/8382))
 - `[expect]` Add `BigInt` support to `toBeGreaterThan`, `toBeGreaterThanOrEqual`, `toBeLessThan` and `toBeLessThanOrEqual` ([#8382](https://github.com/facebook/jest/pull/8382))
+- `[expect, jest-matcher-utils]` Display change counts in annotation lines ([#9035](https://github.com/facebook/jest/pull/9035))
 - `[jest-config]` Throw the full error message and stack when a Jest preset is missing a dependency ([#8924](https://github.com/facebook/jest/pull/8924))
 - `[jest-config]` [**BREAKING**] Set default display name color based on runner ([#8689](https://github.com/facebook/jest/pull/8689))
 - `[jest-diff]` Add options for colors and symbols ([#8841](https://github.com/facebook/jest/pull/8841))

--- a/e2e/__tests__/__snapshots__/failures.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/failures.test.ts.snap
@@ -288,8 +288,8 @@ FAIL __tests__/asyncFailures.test.js
 
     expect(received).resolves.toEqual(expected) // deep equality
 
-    - Expected
-    + Received
+    - Expected  - 1
+    + Received  + 1
 
       Object {
     -   "baz": "bar",
@@ -310,8 +310,8 @@ FAIL __tests__/asyncFailures.test.js
 
     expect(received).rejects.toEqual(expected) // deep equality
 
-    - Expected
-    + Received
+    - Expected  - 1
+    + Received  + 1
 
       Object {
     -   "baz": "bar",

--- a/packages/expect/src/__tests__/__snapshots__/extend.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/extend.test.js.snap
@@ -3,8 +3,8 @@
 exports[`defines asymmetric unary matchers 1`] = `
 <d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 1</>
+<r>+ Received  + 1</>
 
 <d>  Object {</>
 <g>-   "value": toBeDivisibleBy<2>,</>
@@ -15,8 +15,8 @@ exports[`defines asymmetric unary matchers 1`] = `
 exports[`defines asymmetric unary matchers that can be prefixed by not 1`] = `
 <d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 1</>
+<r>+ Received  + 1</>
 
 <d>  Object {</>
 <g>-   "value": not.toBeDivisibleBy<2>,</>
@@ -27,8 +27,8 @@ exports[`defines asymmetric unary matchers that can be prefixed by not 1`] = `
 exports[`defines asymmetric variadic matchers 1`] = `
 <d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 1</>
+<r>+ Received  + 1</>
 
 <d>  Object {</>
 <g>-   "value": toBeWithinRange<4, 11>,</>
@@ -39,8 +39,8 @@ exports[`defines asymmetric variadic matchers 1`] = `
 exports[`defines asymmetric variadic matchers that can be prefixed by not 1`] = `
 <d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 1</>
+<r>+ Received  + 1</>
 
 <d>  Object {</>
 <g>-   "value": not.toBeWithinRange<1, 3>,</>

--- a/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -227,8 +227,8 @@ Received has value: <r>undefined</>
 exports[`.toBe() does not crash on circular references 1`] = `
 <d>expect(</><r>received</><d>).</>toBe<d>(</><g>expected</><d>) // Object.is equality</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 1</>
+<r>+ Received  + 3</>
 
 <g>- Object {}</>
 <r>+ Object {</>
@@ -300,8 +300,8 @@ line
 string" 1`] = `
 <d>expect(</><r>received</><d>).</>toBe<d>(</><g>expected</><d>) // Object.is equality</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 1</>
+<r>+ Received  + 2</>
 
 <g>- 3</>
 <r>+ four</>
@@ -321,8 +321,8 @@ exports[`.toBe() fails for: "with
 trailing space" and "without trailing space" 1`] = `
 <d>expect(</><r>received</><d>).</>toBe<d>(</><g>expected</><d>) // Object.is equality</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 1</>
+<r>+ Received  + 2</>
 
 <g>- with<i>out</i> trailing space</>
 <r>+ with<Y> </></>
@@ -364,8 +364,8 @@ exports[`.toBe() fails for: {"a": [Function a], "b": 2} and {"a": Any<Function>,
 
 <d>If it should pass with deep equality, replace "toBe" with "toStrictEqual"</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 1</>
+<r>+ Received  + 1</>
 
 <d>  Object {</>
 <g>-   "a": Any<Function>,</>
@@ -386,8 +386,8 @@ Received: serializes to the same string
 exports[`.toBe() fails for: {"a": 1} and {"a": 5} 1`] = `
 <d>expect(</><r>received</><d>).</>toBe<d>(</><g>expected</><d>) // Object.is equality</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 1</>
+<r>+ Received  + 1</>
 
 <d>  Object {</>
 <g>-   "a": 5,</>
@@ -400,8 +400,8 @@ exports[`.toBe() fails for: {"a": undefined, "b": 2} and {"b": 2} 1`] = `
 
 <d>If it should pass with deep equality, replace "toBe" with "toEqual"</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 0</>
+<r>+ Received  + 1</>
 
 <d>  Object {</>
 <r>+   "a": undefined,</>
@@ -2012,8 +2012,8 @@ exports[`.toEqual() {pass: false} expect("type TypeName<T> = T extends Function 
 : \\"object\\";") 1`] = `
 <d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 3</>
+<r>+ Received  + 1</>
 
 <g>- type TypeName<T> = T extends Function</>
 <g>- ? "function"</>
@@ -2024,8 +2024,8 @@ exports[`.toEqual() {pass: false} expect("type TypeName<T> = T extends Function 
 exports[`.toEqual() {pass: false} expect([1, 2]).toEqual([2, 1]) 1`] = `
 <d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 1</>
+<r>+ Received  + 1</>
 
 <d>  Array [</>
 <g>-   2,</>
@@ -2044,8 +2044,8 @@ Received: <r>[1, 3]</>
 exports[`.toEqual() {pass: false} expect([1]).toEqual([2]) 1`] = `
 <d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 1</>
+<r>+ Received  + 1</>
 
 <d>  Array [</>
 <g>-   2,</>
@@ -2063,8 +2063,8 @@ Received: <r>{"a": 1, "b": 2}</>
 exports[`.toEqual() {pass: false} expect({"a": 1}).toEqual({"a": 2}) 1`] = `
 <d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 1</>
+<r>+ Received  + 1</>
 
 <d>  Object {</>
 <g>-   "a": 2,</>
@@ -2075,8 +2075,8 @@ exports[`.toEqual() {pass: false} expect({"a": 1}).toEqual({"a": 2}) 1`] = `
 exports[`.toEqual() {pass: false} expect({"a": 5}).toEqual({"b": 6}) 1`] = `
 <d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 1</>
+<r>+ Received  + 1</>
 
 <d>  Object {</>
 <g>-   "b": 6,</>
@@ -2087,8 +2087,8 @@ exports[`.toEqual() {pass: false} expect({"a": 5}).toEqual({"b": 6}) 1`] = `
 exports[`.toEqual() {pass: false} expect({"nodeName": "div", "nodeType": 1}).toEqual({"nodeName": "p", "nodeType": 1}) 1`] = `
 <d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 1</>
+<r>+ Received  + 1</>
 
 <d>  Object {</>
 <g>-   "nodeName": "p",</>
@@ -2100,8 +2100,8 @@ exports[`.toEqual() {pass: false} expect({"nodeName": "div", "nodeType": 1}).toE
 exports[`.toEqual() {pass: false} expect({"target": {"nodeType": 1, "value": "a"}}).toEqual({"target": {"nodeType": 1, "value": "b"}}) 1`] = `
 <d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 1</>
+<r>+ Received  + 1</>
 
 <d>  Object {</>
 <d>    "target": Object {</>
@@ -2150,8 +2150,8 @@ Received: <r>5e-324</>
 exports[`.toEqual() {pass: false} expect(Immutable.List [1, 2]).toEqual(Immutable.List [2, 1]) 1`] = `
 <d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 1</>
+<r>+ Received  + 1</>
 
 <d>  Immutable.List [</>
 <g>-   2,</>
@@ -2163,8 +2163,8 @@ exports[`.toEqual() {pass: false} expect(Immutable.List [1, 2]).toEqual(Immutabl
 exports[`.toEqual() {pass: false} expect(Immutable.List [1]).toEqual(Immutable.List [2]) 1`] = `
 <d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 1</>
+<r>+ Received  + 1</>
 
 <d>  Immutable.List [</>
 <g>-   2,</>
@@ -2175,8 +2175,8 @@ exports[`.toEqual() {pass: false} expect(Immutable.List [1]).toEqual(Immutable.L
 exports[`.toEqual() {pass: false} expect(Immutable.Map {"1": Immutable.Map {"2": {"a": 99}}}).toEqual(Immutable.Map {"1": Immutable.Map {"2": {"a": 11}}}) 1`] = `
 <d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 1</>
+<r>+ Received  + 1</>
 
 <d>  Immutable.Map {</>
 <d>    "1": Immutable.Map {</>
@@ -2191,8 +2191,8 @@ exports[`.toEqual() {pass: false} expect(Immutable.Map {"1": Immutable.Map {"2":
 exports[`.toEqual() {pass: false} expect(Immutable.Map {"a": 0}).toEqual(Immutable.Map {"b": 0}) 1`] = `
 <d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 1</>
+<r>+ Received  + 1</>
 
 <d>  Immutable.Map {</>
 <g>-   "b": 0,</>
@@ -2203,8 +2203,8 @@ exports[`.toEqual() {pass: false} expect(Immutable.Map {"a": 0}).toEqual(Immutab
 exports[`.toEqual() {pass: false} expect(Immutable.Map {"v": 1}).toEqual(Immutable.Map {"v": 2}) 1`] = `
 <d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 1</>
+<r>+ Received  + 1</>
 
 <d>  Immutable.Map {</>
 <g>-   "v": 2,</>
@@ -2215,8 +2215,8 @@ exports[`.toEqual() {pass: false} expect(Immutable.Map {"v": 1}).toEqual(Immutab
 exports[`.toEqual() {pass: false} expect(Immutable.OrderedMap {1: "one", 2: "two"}).toEqual(Immutable.OrderedMap {2: "two", 1: "one"}) 1`] = `
 <d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 1</>
+<r>+ Received  + 1</>
 
 <d>  Immutable.OrderedMap {</>
 <g>-   2: "two",</>
@@ -2228,8 +2228,8 @@ exports[`.toEqual() {pass: false} expect(Immutable.OrderedMap {1: "one", 2: "two
 exports[`.toEqual() {pass: false} expect(Immutable.OrderedSet [1, 2]).toEqual(Immutable.OrderedSet [2, 1]) 1`] = `
 <d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 1</>
+<r>+ Received  + 1</>
 
 <d>  Immutable.OrderedSet [</>
 <g>-   2,</>
@@ -2241,8 +2241,8 @@ exports[`.toEqual() {pass: false} expect(Immutable.OrderedSet [1, 2]).toEqual(Im
 exports[`.toEqual() {pass: false} expect(Immutable.Set [1, 2]).toEqual(Immutable.Set []) 1`] = `
 <d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 1</>
+<r>+ Received  + 4</>
 
 <g>- Immutable.Set []</>
 <r>+ Immutable.Set [</>
@@ -2254,8 +2254,8 @@ exports[`.toEqual() {pass: false} expect(Immutable.Set [1, 2]).toEqual(Immutable
 exports[`.toEqual() {pass: false} expect(Immutable.Set [1, 2]).toEqual(Immutable.Set [1, 2, 3]) 1`] = `
 <d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 1</>
+<r>+ Received  + 0</>
 
 <d>  Immutable.Set [</>
 <d>    1,</>
@@ -2267,8 +2267,8 @@ exports[`.toEqual() {pass: false} expect(Immutable.Set [1, 2]).toEqual(Immutable
 exports[`.toEqual() {pass: false} expect(Map {"a" => 0}).toEqual(Map {"b" => 0}) 1`] = `
 <d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 1</>
+<r>+ Received  + 1</>
 
 <d>  Map {</>
 <g>-   "b" => 0,</>
@@ -2279,8 +2279,8 @@ exports[`.toEqual() {pass: false} expect(Map {"a" => 0}).toEqual(Map {"b" => 0})
 exports[`.toEqual() {pass: false} expect(Map {"v" => 1}).toEqual(Map {"v" => 2}) 1`] = `
 <d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 1</>
+<r>+ Received  + 1</>
 
 <d>  Map {</>
 <g>-   "v" => 2,</>
@@ -2291,8 +2291,8 @@ exports[`.toEqual() {pass: false} expect(Map {"v" => 1}).toEqual(Map {"v" => 2})
 exports[`.toEqual() {pass: false} expect(Map {["v"] => 1}).toEqual(Map {["v"] => 2}) 1`] = `
 <d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 1</>
+<r>+ Received  + 1</>
 
 <d>  Map {</>
 <d>    Array [</>
@@ -2305,8 +2305,8 @@ exports[`.toEqual() {pass: false} expect(Map {["v"] => 1}).toEqual(Map {["v"] =>
 exports[`.toEqual() {pass: false} expect(Map {[1] => Map {[1] => "one"}}).toEqual(Map {[1] => Map {[1] => "two"}}) 1`] = `
 <d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 1</>
+<r>+ Received  + 1</>
 
 <y>@@ -2,8 +2,8 @@</>
 <d>    Array [</>
@@ -2330,8 +2330,8 @@ Received: <r>Map {}</>
 exports[`.toEqual() {pass: false} expect(Map {1 => "one", 2 => "two"}).toEqual(Map {1 => "one"}) 1`] = `
 <d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 0</>
+<r>+ Received  + 1</>
 
 <d>  Map {</>
 <d>    1 => "one",</>
@@ -2342,8 +2342,8 @@ exports[`.toEqual() {pass: false} expect(Map {1 => "one", 2 => "two"}).toEqual(M
 exports[`.toEqual() {pass: false} expect(Set {[1], [2]}).toEqual(Set {[1], [2], [2]}) 1`] = `
 <d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 3</>
+<r>+ Received  + 0</>
 
 <y>@@ -3,9 +3,6 @@</>
 <d>      1,</>
@@ -2360,8 +2360,8 @@ exports[`.toEqual() {pass: false} expect(Set {[1], [2]}).toEqual(Set {[1], [2], 
 exports[`.toEqual() {pass: false} expect(Set {[1], [2]}).toEqual(Set {[1], [2], [3]}) 1`] = `
 <d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 3</>
+<r>+ Received  + 0</>
 
 <y>@@ -3,9 +3,6 @@</>
 <d>      1,</>
@@ -2378,8 +2378,8 @@ exports[`.toEqual() {pass: false} expect(Set {[1], [2]}).toEqual(Set {[1], [2], 
 exports[`.toEqual() {pass: false} expect(Set {1, 2}).toEqual(Set {}) 1`] = `
 <d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 1</>
+<r>+ Received  + 4</>
 
 <g>- Set {}</>
 <r>+ Set {</>
@@ -2391,8 +2391,8 @@ exports[`.toEqual() {pass: false} expect(Set {1, 2}).toEqual(Set {}) 1`] = `
 exports[`.toEqual() {pass: false} expect(Set {1, 2}).toEqual(Set {1, 2, 3}) 1`] = `
 <d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 1</>
+<r>+ Received  + 0</>
 
 <d>  Set {</>
 <d>    1,</>
@@ -2404,8 +2404,8 @@ exports[`.toEqual() {pass: false} expect(Set {1, 2}).toEqual(Set {1, 2, 3}) 1`] 
 exports[`.toEqual() {pass: false} expect(Set {Set {1}, Set {2}}).toEqual(Set {Set {1}, Set {3}}) 1`] = `
 <d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 1</>
+<r>+ Received  + 1</>
 
 <d>  Set {</>
 <d>    Set {</>
@@ -3065,8 +3065,8 @@ exports[`.toHaveProperty() {pass: false} expect({"a": {"b": {"c": 5}}}).toHavePr
 
 Expected path: <g>"a.b"</>
 
-<g>- Expected value</>
-<r>+ Received value</>
+<g>- Expected value  - 1</>
+<r>+ Received value  + 1</>
 
 <d>  Object {</>
 <g>-   "c": 4,</>
@@ -3139,8 +3139,8 @@ Is good for you.") 1`] = `
 
 Expected path: <g>["children", 0]</>
 
-<g>- Expected value</>
-<r>+ Received value</>
+<g>- Expected value  - 3</>
+<r>+ Received value  + 3</>
 
 <g>- Roses are red<i>, v</i>iolets are blue.</>
 <r>+ Roses are red<i>.</i></>
@@ -3600,8 +3600,8 @@ Received: <r>"<i>Because TypeScript support in Babel is just transpilation,</i> 
 exports[`.toStrictEqual() displays substring diff for multiple lines 1`] = `
 <d>expect(</><r>received</><d>).</>toStrictEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 7</>
+<r>+ Received  + 7</>
 
 <g>-     6<i>9</i> |<Y> </></>
 <r>+     6<i>8</i> |<Y> </></>
@@ -3623,8 +3623,8 @@ exports[`.toStrictEqual() displays substring diff for multiple lines 1`] = `
 exports[`.toStrictEqual() matches the expected snapshot when it fails 1`] = `
 <d>expect(</><r>received</><d>).</>toStrictEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 4</>
+<r>+ Received  + 1</>
 
 <d>  Object {</>
 <g>-   "test": TestClassA {</>
@@ -3645,8 +3645,8 @@ Expected: not <g>{"test": {"a": 1, "b": 2}}</>
 exports[`toMatchObject() {pass: false} expect([0]).toMatchObject([-0]) 1`] = `
 <d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 1</>
+<r>+ Received  + 1</>
 
 <d>  Array [</>
 <g>-   -0,</>
@@ -3657,8 +3657,8 @@ exports[`toMatchObject() {pass: false} expect([0]).toMatchObject([-0]) 1`] = `
 exports[`toMatchObject() {pass: false} expect([1, 2, 3]).toMatchObject([1, 2, 2]) 1`] = `
 <d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 1</>
+<r>+ Received  + 1</>
 
 <d>  Array [</>
 <d>    1,</>
@@ -3671,8 +3671,8 @@ exports[`toMatchObject() {pass: false} expect([1, 2, 3]).toMatchObject([1, 2, 2]
 exports[`toMatchObject() {pass: false} expect([1, 2, 3]).toMatchObject([2, 3, 1]) 1`] = `
 <d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 1</>
+<r>+ Received  + 1</>
 
 <d>  Array [</>
 <r>+   1,</>
@@ -3685,8 +3685,8 @@ exports[`toMatchObject() {pass: false} expect([1, 2, 3]).toMatchObject([2, 3, 1]
 exports[`toMatchObject() {pass: false} expect([1, 2]).toMatchObject([1, 3]) 1`] = `
 <d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 1</>
+<r>+ Received  + 1</>
 
 <d>  Array [</>
 <d>    1,</>
@@ -3705,8 +3705,8 @@ Received: <r>[Error: foo]</>
 exports[`toMatchObject() {pass: false} expect({"a": "a", "c": "d"}).toMatchObject({"a": Any<Number>}) 1`] = `
 <d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 1</>
+<r>+ Received  + 1</>
 
 <d>  Object {</>
 <g>-   "a": Any<Number>,</>
@@ -3717,8 +3717,8 @@ exports[`toMatchObject() {pass: false} expect({"a": "a", "c": "d"}).toMatchObjec
 exports[`toMatchObject() {pass: false} expect({"a": "b", "c": "d"}).toMatchObject({"a": "b!", "c": "d"}) 1`] = `
 <d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 1</>
+<r>+ Received  + 1</>
 
 <d>  Object {</>
 <g>-   "a": "b!",</>
@@ -3730,8 +3730,8 @@ exports[`toMatchObject() {pass: false} expect({"a": "b", "c": "d"}).toMatchObjec
 exports[`toMatchObject() {pass: false} expect({"a": "b", "c": "d"}).toMatchObject({"e": "b"}) 1`] = `
 <d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 1</>
+<r>+ Received  + 2</>
 
 <d>  Object {</>
 <g>-   "e": "b",</>
@@ -3743,8 +3743,8 @@ exports[`toMatchObject() {pass: false} expect({"a": "b", "c": "d"}).toMatchObjec
 exports[`toMatchObject() {pass: false} expect({"a": "b", "t": {"x": {"r": "r"}, "z": "z"}}).toMatchObject({"a": "b", "t": {"z": [3]}}) 1`] = `
 <d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 3</>
+<r>+ Received  + 1</>
 
 <d>  Object {</>
 <d>    "a": "b",</>
@@ -3760,8 +3760,8 @@ exports[`toMatchObject() {pass: false} expect({"a": "b", "t": {"x": {"r": "r"}, 
 exports[`toMatchObject() {pass: false} expect({"a": "b", "t": {"x": {"r": "r"}, "z": "z"}}).toMatchObject({"t": {"l": {"r": "r"}}}) 1`] = `
 <d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 1</>
+<r>+ Received  + 2</>
 
 <d>  Object {</>
 <d>    "t": Object {</>
@@ -3777,8 +3777,8 @@ exports[`toMatchObject() {pass: false} expect({"a": "b", "t": {"x": {"r": "r"}, 
 exports[`toMatchObject() {pass: false} expect({"a": "b"}).toMatchObject({"c": "d"}) 1`] = `
 <d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 1</>
+<r>+ Received  + 1</>
 
 <d>  Object {</>
 <g>-   "c": "d",</>
@@ -3789,8 +3789,8 @@ exports[`toMatchObject() {pass: false} expect({"a": "b"}).toMatchObject({"c": "d
 exports[`toMatchObject() {pass: false} expect({"a": [{"a": "a", "b": "b"}]}).toMatchObject({"a": [{"a": "c"}]}) 1`] = `
 <d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 1</>
+<r>+ Received  + 1</>
 
 <d>  Object {</>
 <d>    "a": Array [</>
@@ -3805,8 +3805,8 @@ exports[`toMatchObject() {pass: false} expect({"a": [{"a": "a", "b": "b"}]}).toM
 exports[`toMatchObject() {pass: false} expect({"a": [3, 4, "v"], "b": "b"}).toMatchObject({"a": ["v"]}) 1`] = `
 <d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 0</>
+<r>+ Received  + 2</>
 
 <d>  Object {</>
 <d>    "a": Array [</>
@@ -3820,8 +3820,8 @@ exports[`toMatchObject() {pass: false} expect({"a": [3, 4, "v"], "b": "b"}).toMa
 exports[`toMatchObject() {pass: false} expect({"a": [3, 4, 5], "b": "b"}).toMatchObject({"a": [3, 4, 5, 6]}) 1`] = `
 <d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 1</>
+<r>+ Received  + 0</>
 
 <d>  Object {</>
 <d>    "a": Array [</>
@@ -3836,8 +3836,8 @@ exports[`toMatchObject() {pass: false} expect({"a": [3, 4, 5], "b": "b"}).toMatc
 exports[`toMatchObject() {pass: false} expect({"a": [3, 4, 5], "b": "b"}).toMatchObject({"a": [3, 4]}) 1`] = `
 <d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 0</>
+<r>+ Received  + 1</>
 
 <d>  Object {</>
 <d>    "a": Array [</>
@@ -3851,8 +3851,8 @@ exports[`toMatchObject() {pass: false} expect({"a": [3, 4, 5], "b": "b"}).toMatc
 exports[`toMatchObject() {pass: false} expect({"a": [3, 4, 5], "b": "b"}).toMatchObject({"a": {"b": 4}}) 1`] = `
 <d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 3</>
+<r>+ Received  + 5</>
 
 <d>  Object {</>
 <g>-   "a": Object {</>
@@ -3869,8 +3869,8 @@ exports[`toMatchObject() {pass: false} expect({"a": [3, 4, 5], "b": "b"}).toMatc
 exports[`toMatchObject() {pass: false} expect({"a": [3, 4, 5], "b": "b"}).toMatchObject({"a": {"b": Any<String>}}) 1`] = `
 <d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 3</>
+<r>+ Received  + 5</>
 
 <d>  Object {</>
 <g>-   "a": Object {</>
@@ -3887,8 +3887,8 @@ exports[`toMatchObject() {pass: false} expect({"a": [3, 4, 5], "b": "b"}).toMatc
 exports[`toMatchObject() {pass: false} expect({"a": 1, "b": 1, "c": 1, "d": {"e": {"f": 555}}}).toMatchObject({"d": {"e": {"f": 222}}}) 1`] = `
 <d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 1</>
+<r>+ Received  + 1</>
 
 <d>  Object {</>
 <d>    "d": Object {</>
@@ -3903,8 +3903,8 @@ exports[`toMatchObject() {pass: false} expect({"a": 1, "b": 1, "c": 1, "d": {"e"
 exports[`toMatchObject() {pass: false} expect({"a": 2015-11-30T00:00:00.000Z, "b": "b"}).toMatchObject({"a": 2015-10-10T00:00:00.000Z}) 1`] = `
 <d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 1</>
+<r>+ Received  + 1</>
 
 <d>  Object {</>
 <g>-   "a": 2015-10-10T00:00:00.000Z,</>
@@ -3915,8 +3915,8 @@ exports[`toMatchObject() {pass: false} expect({"a": 2015-11-30T00:00:00.000Z, "b
 exports[`toMatchObject() {pass: false} expect({"a": null, "b": "b"}).toMatchObject({"a": "4"}) 1`] = `
 <d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 1</>
+<r>+ Received  + 1</>
 
 <d>  Object {</>
 <g>-   "a": "4",</>
@@ -3927,8 +3927,8 @@ exports[`toMatchObject() {pass: false} expect({"a": null, "b": "b"}).toMatchObje
 exports[`toMatchObject() {pass: false} expect({"a": null, "b": "b"}).toMatchObject({"a": undefined}) 1`] = `
 <d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 1</>
+<r>+ Received  + 1</>
 
 <d>  Object {</>
 <g>-   "a": undefined,</>
@@ -3939,8 +3939,8 @@ exports[`toMatchObject() {pass: false} expect({"a": null, "b": "b"}).toMatchObje
 exports[`toMatchObject() {pass: false} expect({"a": undefined}).toMatchObject({"a": null}) 1`] = `
 <d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 1</>
+<r>+ Received  + 1</>
 
 <d>  Object {</>
 <g>-   "a": null,</>
@@ -3951,8 +3951,8 @@ exports[`toMatchObject() {pass: false} expect({"a": undefined}).toMatchObject({"
 exports[`toMatchObject() {pass: false} expect({}).toMatchObject({"a": undefined}) 1`] = `
 <d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 3</>
+<r>+ Received  + 1</>
 
 <g>- Object {</>
 <g>-   "a": undefined,</>
@@ -3970,8 +3970,8 @@ Received: <r>2015-11-30T00:00:00.000Z</>
 exports[`toMatchObject() {pass: false} expect(Set {1, 2}).toMatchObject(Set {2}) 1`] = `
 <d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 0</>
+<r>+ Received  + 1</>
 
 <d>  Set {</>
 <r>+   1,</>
@@ -4128,8 +4128,8 @@ Received:     <r>Set {1, 2}</>
 exports[`toMatchObject() circular references simple circular references {pass: false} expect({"a": "hello", "ref": [Circular]}).toMatchObject({"a": "world", "ref": [Circular]}) 1`] = `
 <d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 1</>
+<r>+ Received  + 1</>
 
 <d>  Object {</>
 <g>-   "a": "world",</>
@@ -4141,8 +4141,8 @@ exports[`toMatchObject() circular references simple circular references {pass: f
 exports[`toMatchObject() circular references simple circular references {pass: false} expect({"ref": "not a ref"}).toMatchObject({"a": "hello", "ref": [Circular]}) 1`] = `
 <d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 2</>
+<r>+ Received  + 1</>
 
 <d>  Object {</>
 <g>-   "a": "hello",</>
@@ -4154,8 +4154,8 @@ exports[`toMatchObject() circular references simple circular references {pass: f
 exports[`toMatchObject() circular references simple circular references {pass: false} expect({}).toMatchObject({"a": "hello", "ref": [Circular]}) 1`] = `
 <d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 4</>
+<r>+ Received  + 1</>
 
 <g>- Object {</>
 <g>-   "a": "hello",</>
@@ -4180,8 +4180,8 @@ Received:     <r>{"a": "hello", "ref": [Circular]}</>
 exports[`toMatchObject() circular references transitive circular references {pass: false} expect({"a": "world", "nestedObj": {"parentObj": [Circular]}}).toMatchObject({"a": "hello", "nestedObj": {"parentObj": [Circular]}}) 1`] = `
 <d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 1</>
+<r>+ Received  + 1</>
 
 <d>  Object {</>
 <g>-   "a": "hello",</>
@@ -4195,8 +4195,8 @@ exports[`toMatchObject() circular references transitive circular references {pas
 exports[`toMatchObject() circular references transitive circular references {pass: false} expect({"nestedObj": {"parentObj": "not the parent ref"}}).toMatchObject({"a": "hello", "nestedObj": {"parentObj": [Circular]}}) 1`] = `
 <d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 2</>
+<r>+ Received  + 1</>
 
 <d>  Object {</>
 <g>-   "a": "hello",</>
@@ -4210,8 +4210,8 @@ exports[`toMatchObject() circular references transitive circular references {pas
 exports[`toMatchObject() circular references transitive circular references {pass: false} expect({}).toMatchObject({"a": "hello", "nestedObj": {"parentObj": [Circular]}}) 1`] = `
 <d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 6</>
+<r>+ Received  + 1</>
 
 <g>- Object {</>
 <g>-   "a": "hello",</>
@@ -4238,8 +4238,8 @@ Received:     <r>{"a": "hello", "nestedObj": {"parentObj": [Circular]}}</>
 exports[`toMatchObject() does not match properties up in the prototype chain 1`] = `
 <d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 1</>
+<r>+ Received  + 0</>
 
 <d>  Object {</>
 <d>    "other": "child",</>

--- a/packages/expect/src/__tests__/__snapshots__/toThrowMatchers.test.ts.snap
+++ b/packages/expect/src/__tests__/__snapshots__/toThrowMatchers.test.ts.snap
@@ -164,8 +164,8 @@ Expected message: not <g>"Invalid array length"</>
 exports[`toThrow error-message fail multiline diff highlight incorrect expected space 1`] = `
 <d>expect(</><r>received</><d>).</>toThrow<d>(</><g>expected</><d>)</>
 
-<g>- Expected message</>
-<r>+ Received message</>
+<g>- Expected message  - 1</>
+<r>+ Received message  + 1</>
 
 <g>- There is no route defined for key Settings.<i> </i></>
 <r>+ There is no route defined for key Settings.</>
@@ -472,8 +472,8 @@ Expected message: not <g>"Invalid array length"</>
 exports[`toThrowError error-message fail multiline diff highlight incorrect expected space 1`] = `
 <d>expect(</><r>received</><d>).</>toThrowError<d>(</><g>expected</><d>)</>
 
-<g>- Expected message</>
-<r>+ Received message</>
+<g>- Expected message  - 1</>
+<r>+ Received message  + 1</>
 
 <g>- There is no route defined for key Settings.<i> </i></>
 <r>+ There is no route defined for key Settings.</>

--- a/packages/jest-matcher-utils/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/jest-matcher-utils/src/__tests__/__snapshots__/index.test.ts.snap
@@ -91,8 +91,8 @@ Expected has value: <g>null</>
 exports[`stringify() toJSON errors when comparing two objects 1`] = `
 <d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 1</>
+<r>+ Received  + 1</>
 
 <d>  Object {</>
 <g>-   "b": 1,</>

--- a/packages/jest-matcher-utils/src/__tests__/__snapshots__/printDiffOrStringify.test.ts.snap
+++ b/packages/jest-matcher-utils/src/__tests__/__snapshots__/printDiffOrStringify.test.ts.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`printDiffOrStringify expected and received are multi line with trailing spaces 1`] = `
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 3</>
+<r>+ Received  + 3</>
 
 <g>- <i>delete</i><Y> </></>
 <r>+ <i>insert</i><Y> </></>
@@ -29,8 +29,8 @@ Received: <r>""</>
 `;
 
 exports[`printDiffOrStringify has no common after clean up chaff multiline 1`] = `
-<g>- Expected</>
-<r>+ Received</>
+<g>- Expected  - 2</>
+<r>+ Received  + 2</>
 
 <g>- delete</>
 <g>- two</>

--- a/packages/jest-matcher-utils/src/index.ts
+++ b/packages/jest-matcher-utils/src/index.ts
@@ -6,7 +6,7 @@
  */
 
 import chalk from 'chalk';
-import diffLinesUnified, {
+import diffDefault, {
   DIFF_DELETE,
   DIFF_EQUAL,
   DIFF_INSERT,
@@ -325,6 +325,7 @@ export const printDiffOrStringify = (
         aAnnotation: expectedLabel,
         bAnnotation: receivedLabel,
         expand,
+        includeChangeCounts: true,
       });
     }
 
@@ -347,10 +348,11 @@ export const printDiffOrStringify = (
   }
 
   if (isLineDiffable(expected, received)) {
-    const difference = diffLinesUnified(expected, received, {
+    const difference = diffDefault(expected, received, {
       aAnnotation: expectedLabel,
       bAnnotation: receivedLabel,
       expand,
+      includeChangeCounts: true,
     });
 
     if (
@@ -390,7 +392,7 @@ const shouldPrintDiff = (actual: unknown, expected: unknown) => {
 };
 
 export const diff = (a: any, b: any, options?: DiffOptions): string | null =>
-  shouldPrintDiff(a, b) ? diffLinesUnified(a, b, options) : null;
+  shouldPrintDiff(a, b) ? diffDefault(a, b, options) : null;
 
 export const pluralize = (word: string, count: number) =>
   (NUMBERS[count] || count) + ' ' + word + (count === 1 ? '' : 's');


### PR DESCRIPTION
## Summary

In the `printDiffOrStringify` function, add `includeChangeCounts` option to calls:

* `diffStringsUnified`
* `diffDefault`

For consistency with #8982 to interpret differences when other assertions fail

**Residue**

Did not add `includeChangeCounts` option:

* to spy matchers because not separate annotations for multiple diffs per call
* to `diff` named export from `jest-matcher-utils` but caller can add it

I noticed something brittle about a few snapshots of matcher errors which contain diffs: when I tested with `--expand` option to see all of the lines in the snapshot to count changes, it affected the matcher, which is not correct.

## Test plan

Updated 76 snapshots

The differences between empty and non-empty map or object are example where change counts would be even clearer in a data-driven-diff

| | package | test file |
| ---: | ---: | :--- |
| 1 | `e2e` | `failures` |
| 4 | `expect` | `extend` |
| 66 | `expect` | `matchers` |
| 2 | `expect` | `toThrowMatchers` |
| 1 | `jest-matcher-utils` | `index` |
| 2 | `jest-matcher-utils` | `printDiffOrStringify` |

See also pictures in following comment: baseline is at left and improved is at right