### PR TITLE
Docs: Removed condescending language

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,7 +121,7 @@ Ran all test suites.
 
 ##### Using jest-circus
 
-There may be cases where you want to run jest using `jest-circus` instead of `jest-jasmine2` (which is the default runner) for integration testing. In situations like this just set the environment variable `JEST_CIRCUS` to 1. That will configure jest to use `jest-circus`. So something like this.
+There may be cases where you want to run jest using `jest-circus` instead of `jest-jasmine2` (which is the default runner) for integration testing. In situations like this, set the environment variable `JEST_CIRCUS` to 1. That will configure jest to use `jest-circus`. So something like this.
 
 ```bash
 JEST_CIRCUS=1 yarn jest

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ module.exports = {
 };
 ```
 
-Note, there are some [caveats](https://babeljs.io/docs/en/next/babel-plugin-transform-typescript.html#caveats) to using TypeScript with Babel. Because TypeScript support in Babel is just transpilation, Jest will not type-check your tests as they are ran. If you want that, you can use [ts-jest](https://github.com/kulshekhar/ts-jest).
+Note, there are some [caveats](https://babeljs.io/docs/en/next/babel-plugin-transform-typescript.html#caveats) to using TypeScript with Babel. Because TypeScript support in Babel is transpilation, Jest will not type-check your tests as they are ran. If you want that, you can use [ts-jest](https://github.com/kulshekhar/ts-jest).
 
 <!-- end copied -->
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -86,7 +86,7 @@ test('if utils mocked automatically', () => {
   expect(utils.isAuthorized.mock).toBeTruthy();
 
   // You can provide them with your own implementation
-  // or just pass the expected return value
+  // or pass the expected return value
   utils.authorize.mockReturnValue('mocked_token');
   utils.isAuthorized.mockReturnValue(true);
 

--- a/docs/Es6ClassMocks.md
+++ b/docs/Es6ClassMocks.md
@@ -190,7 +190,7 @@ describe('When SoundPlayer throws an error', () => {
 
 ## In depth: Understanding mock constructor functions
 
-Building your constructor function mock using `jest.fn().mockImplementation()` makes mocks appear more complicated than they really are. This section shows how you can create your own simple mocks to illustrate how mocking works.
+Building your constructor function mock using `jest.fn().mockImplementation()` makes mocks appear more complicated than they really are. This section shows how you can create your own smaller mocks to illustrate how mocking works.
 
 ### Manual mock that is another ES6 class
 
@@ -211,7 +211,7 @@ export default class SoundPlayer {
 }
 ```
 
-### Simple mock using module factory parameter
+### Mock using module factory parameter
 
 The module factory function passed to `jest.mock(path, moduleFactory)` can be a HOF that returns a function\*. This will allow calling `new` on the mock. Again, this allows you to inject different behavior for testing, but does not provide a way to spy on calls.
 

--- a/docs/ExpectAPI.md
+++ b/docs/ExpectAPI.md
@@ -207,7 +207,7 @@ When an assertion fails, the error message should give as much signal as necessa
 
 To use snapshot testing inside of your custom matcher you can import `jest-snapshot` and use it from within your matcher.
 
-Here's a simple snapshot matcher that trims a string to store for a given length, `.toMatchTrimmedSnapshot(length)`:
+Here's a snapshot matcher that trims a string to store for a given length, `.toMatchTrimmedSnapshot(length)`:
 
 ```js
 const {toMatchSnapshot} = require('jest-snapshot');
@@ -798,7 +798,7 @@ const houseForSale = {
 };
 
 test('this house has my desired features', () => {
-  // Simple Referencing
+  // Example Referencing
   expect(houseForSale).toHaveProperty('bath');
   expect(houseForSale).toHaveProperty('bedrooms', 4);
 
@@ -838,7 +838,7 @@ The optional `numDigits` argument limits the number of digits to check **after**
 Intuitive equality comparisons often fail, because arithmetic on decimal (base 10) values often have rounding errors in limited precision binary (base 2) representation. For example, this test fails:
 
 ```js
-test('adding works sanely with simple decimals', () => {
+test('adding works sanely with decimals', () => {
   expect(0.2 + 0.1).toBe(0.3); // Fails!
 });
 ```
@@ -848,7 +848,7 @@ It fails because in JavaScript, `0.2 + 0.1` is actually `0.30000000000000004`.
 For example, this test passes with a precision of 5 digits:
 
 ```js
-test('adding works sanely with simple decimals', () => {
+test('adding works sanely with decimals', () => {
   expect(0.2 + 0.1).toBeCloseTo(0.3, 5);
 });
 ```

--- a/docs/ExpectAPI.md
+++ b/docs/ExpectAPI.md
@@ -857,7 +857,7 @@ Because floating point errors are the problem that `toBeCloseTo` solves, it does
 
 ### `.toBeDefined()`
 
-Use `.toBeDefined` to check that a variable is not undefined. For example, if you just want to check that a function `fetchNewFlavorIdea()` returns _something_, you can write:
+Use `.toBeDefined` to check that a variable is not undefined. For example, if you want to check that a function `fetchNewFlavorIdea()` returns _something_, you can write:
 
 ```js
 test('there is a new flavor idea', () => {
@@ -869,7 +869,7 @@ You could write `expect(fetchNewFlavorIdea()).not.toBe(undefined)`, but it's bet
 
 ### `.toBeFalsy()`
 
-Use `.toBeFalsy` when you don't care what a value is, you just want to ensure a value is false in a boolean context. For example, let's say you have some application code that looks like:
+Use `.toBeFalsy` when you don't care what a value is and you want to ensure a value is false in a boolean context. For example, let's say you have some application code that looks like:
 
 ```js
 drinkSomeLaCroix();
@@ -957,7 +957,7 @@ test('bloop returns null', () => {
 
 ### `.toBeTruthy()`
 
-Use `.toBeTruthy` when you don't care what a value is, you just want to ensure a value is true in a boolean context. For example, let's say you have some application code that looks like:
+Use `.toBeTruthy` when you don't care what a value is and you want to ensure a value is true in a boolean context. For example, let's say you have some application code that looks like:
 
 ```js
 drinkSomeLaCroix();
@@ -966,7 +966,7 @@ if (thirstInfo()) {
 }
 ```
 
-You may not care what `thirstInfo` returns, specifically - it might return `true` or a complex object, and your code would still work. So if you just want to test that `thirstInfo` will be truthy after drinking some La Croix, you could write:
+You may not care what `thirstInfo` returns, specifically - it might return `true` or a complex object, and your code would still work. So if you want to test that `thirstInfo` will be truthy after drinking some La Croix, you could write:
 
 ```js
 test('drinking La Croix leads to having thirst info', () => {

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -175,4 +175,4 @@ module.exports = {
 };
 ```
 
-However, there are some [caveats](https://babeljs.io/docs/en/next/babel-plugin-transform-typescript.html#caveats) to using TypeScript with Babel. Because TypeScript support in Babel is just transpilation, Jest will not type-check your tests as they are ran. If you want that, you can use [ts-jest](https://github.com/kulshekhar/ts-jest).
+However, there are some [caveats](https://babeljs.io/docs/en/next/babel-plugin-transform-typescript.html#caveats) to using TypeScript with Babel. Because TypeScript support in Babel is transpilation, Jest will not type-check your tests as they are ran. If you want that, you can use [ts-jest](https://github.com/kulshekhar/ts-jest).

--- a/docs/GlobalAPI.md
+++ b/docs/GlobalAPI.md
@@ -123,7 +123,7 @@ test('can find things', () => {
 });
 ```
 
-Here the `beforeAll` ensures that the database is set up before tests run. If setup was synchronous, you could just do this without `beforeAll`. The key is that Jest will wait for a promise to resolve, so you can have asynchronous setup as well.
+Here the `beforeAll` ensures that the database is set up before tests run. If setup was synchronous, you could do this without `beforeAll`. The key is that Jest will wait for a promise to resolve, so you can have asynchronous setup as well.
 
 If `beforeAll` is inside a `describe` block, it runs at the beginning of the describe block.
 
@@ -190,7 +190,7 @@ describe('my beverage', () => {
 });
 ```
 
-This isn't required - you can just write the `test` blocks directly at the top level. But this can be handy if you prefer your tests to be organized into groups.
+This isn't required - you can write the `test` blocks directly at the top level. But this can be handy if you prefer your tests to be organized into groups.
 
 You can also nest `describe` blocks if you have a hierarchy of tests:
 
@@ -388,7 +388,7 @@ describe.skip('my other beverage', () => {
 });
 ```
 
-Using `describe.skip` is often just an easier alternative to temporarily commenting out a chunk of tests.
+Using `describe.skip` is often a cleaner alternative to temporarily commenting out a chunk of tests.
 
 ### `describe.skip.each(table)(name, fn)`
 
@@ -544,7 +544,7 @@ test('it is not snowing', () => {
 
 Only the "it is raining" test will run in that test file, since it is run with `test.only`.
 
-Usually you wouldn't check code using `test.only` into source control - you would use it just for debugging, and remove it once you have fixed the broken tests.
+Usually you wouldn't check code using `test.only` into source control - you would use it for debugging, and remove it once you have fixed the broken tests.
 
 ### `test.only.each(table)(name, fn)`
 
@@ -590,7 +590,7 @@ test('will not be ran', () => {
 
 Also under the aliases: `it.skip(name, fn)` or `xit(name, fn)` or `xtest(name, fn)`
 
-When you are maintaining a large codebase, you may sometimes find a test that is temporarily broken for some reason. If you want to skip running this test, but you don't want to just delete this code, you can use `test.skip` to specify some tests to skip.
+When you are maintaining a large codebase, you may sometimes find a test that is temporarily broken for some reason. If you want to skip running this test, but you don't want to delete this code, you can use `test.skip` to specify some tests to skip.
 
 For example, let's say you had these tests:
 
@@ -606,7 +606,7 @@ test.skip('it is not snowing', () => {
 
 Only the "it is raining" test will run, since the other test is run with `test.skip`.
 
-You could simply comment the test out, but it's often a bit nicer to use `test.skip` because it will maintain indentation and syntax highlighting.
+You could comment the test out, but it's often a bit nicer to use `test.skip` because it will maintain indentation and syntax highlighting.
 
 ### `test.skip.each(table)(name, fn)`
 

--- a/docs/ManualMocks.md
+++ b/docs/ManualMocks.md
@@ -124,7 +124,7 @@ describe('listFilesInDirectorySync', () => {
 });
 ```
 
-The example mock shown here uses [`jest.genMockFromModule`](JestObjectAPI.md#jestgenmockfrommodulemodulename) to generate an automatic mock, and overrides its default behavior. This is the recommended approach, but is completely optional. If you do not want to use the automatic mock at all, you can simply export your own functions from the mock file. One downside to fully manual mocks is that they're manual – meaning you have to manually update them any time the module they are mocking changes. Because of this, it's best to use or extend the automatic mock when it works for your needs.
+The example mock shown here uses [`jest.genMockFromModule`](JestObjectAPI.md#jestgenmockfrommodulemodulename) to generate an automatic mock, and overrides its default behavior. This is the recommended approach, but is completely optional. If you do not want to use the automatic mock at all, you can export your own functions from the mock file. One downside to fully manual mocks is that they're manual – meaning you have to manually update them any time the module they are mocking changes. Because of this, it's best to use or extend the automatic mock when it works for your needs.
 
 To ensure that a manual mock and its real implementation stay in sync, it might be useful to require the real module using [`jest.requireActual(moduleName)`](JestObjectAPI.md#jestrequireactualmodulename) in your manual mock and amending it with mock functions before exporting it.
 

--- a/docs/MigrationGuide.md
+++ b/docs/MigrationGuide.md
@@ -5,7 +5,7 @@ title: Migrating to Jest
 
 If you'd like to try out Jest with an existing codebase, there are a number of ways to convert to Jest:
 
-- If you are using Jasmine, or a Jasmine like API (for example [Mocha](https://mochajs.org)), Jest should be mostly compatible and easy to migrate to.
+- If you are using Jasmine, or a Jasmine like API (for example [Mocha](https://mochajs.org)), Jest should be mostly compatible, which makes it less complicated to migrate to.
 - If you are using AVA, Expect.js (by Automattic), Jasmine, Mocha, proxyquire, Should.js or Tape you can automatically migrate with Jest Codemods (see below).
 - If you like [chai](http://chaijs.com/), you can upgrade to Jest and continue using chai. However, we recommend trying out Jest's assertions and their failure messages. Jest Codemods can migrate from chai (see below).
 

--- a/docs/MockFunctionAPI.md
+++ b/docs/MockFunctionAPI.md
@@ -3,7 +3,7 @@ id: mock-function-api
 title: Mock Functions
 ---
 
-Mock functions are also known as "spies", because they let you spy on the behavior of a function that is called indirectly by some other code, rather than just testing the output. You can create a mock function with `jest.fn()`. If no implementation is given, the mock function will return `undefined` when invoked.
+Mock functions are also known as "spies", because they let you spy on the behavior of a function that is called indirectly by some other code, rather than only testing the output. You can create a mock function with `jest.fn()`. If no implementation is given, the mock function will return `undefined` when invoked.
 
 ## Methods
 

--- a/docs/MockFunctions.md
+++ b/docs/MockFunctions.md
@@ -256,7 +256,7 @@ expect(mockFunc).lastCalledWith(arg1, arg2);
 expect(mockFunc).toMatchSnapshot();
 ```
 
-These matchers are really just sugar for common forms of inspecting the `.mock` property. You can always do this manually yourself if that's more to your taste or if you need to do something more specific:
+These matchers are sugar for common forms of inspecting the `.mock` property. You can always do this manually yourself if that's more to your taste or if you need to do something more specific:
 
 ```javascript
 // The mock function was called at least once

--- a/docs/MockFunctions.md
+++ b/docs/MockFunctions.md
@@ -3,7 +3,7 @@ id: mock-functions
 title: Mock Functions
 ---
 
-Mock functions make it easy to test the links between code by erasing the actual implementation of a function, capturing calls to the function (and the parameters passed in those calls), capturing instances of constructor functions when instantiated with `new`, and allowing test-time configuration of return values.
+Mock functions allow you to test the links between code by erasing the actual implementation of a function, capturing calls to the function (and the parameters passed in those calls), capturing instances of constructor functions when instantiated with `new`, and allowing test-time configuration of return values.
 
 There are two ways to mock functions: Either by creating a mock function to use in test code, or writing a [`manual mock`](ManualMocks.md) to override a module dependency.
 
@@ -240,7 +240,7 @@ const myMockFn = jest
 
 ## Custom Matchers
 
-Finally, in order to make it simpler to assert how mock functions have been called, we've added some custom matcher functions for you:
+Finally, in order to make it less demanding to assert how mock functions have been called, we've added some custom matcher functions for you:
 
 ```javascript
 // The mock function was called at least once

--- a/docs/MoreResources.md
+++ b/docs/MoreResources.md
@@ -3,7 +3,7 @@ id: more-resources
 title: More Resources
 ---
 
-By now you should have a good idea of how Jest can make it easy to test your applications. If you're interested in learning more, here's some related stuff you might want to check out.
+By now you should have a good idea of how Jest can help you test your applications. If you're interested in learning more, here's some related stuff you might want to check out.
 
 ## Browse the docs
 

--- a/docs/SetupAndTeardown.md
+++ b/docs/SetupAndTeardown.md
@@ -39,7 +39,7 @@ beforeEach(() => {
 
 ## One-Time Setup
 
-In some cases, you only need to do setup once, at the beginning of a file. This can be especially bothersome when the setup is asynchronous, so you can't just do it inline. Jest provides `beforeAll` and `afterAll` to handle this situation.
+In some cases, you only need to do setup once, at the beginning of a file. This can be especially bothersome when the setup is asynchronous, so you can't do it inline. Jest provides `beforeAll` and `afterAll` to handle this situation.
 
 For example, if both `initializeCityDatabase` and `clearCityDatabase` returned promises, and the city database could be reused between tests, we could change our test code to:
 
@@ -175,7 +175,7 @@ describe('outer', () => {
 
 ## General Advice
 
-If a test is failing, one of the first things to check should be whether the test is failing when it's the only test that runs. In Jest it's simple to run only one test - just temporarily change that `test` command to a `test.only`:
+If a test is failing, one of the first things to check should be whether the test is failing when it's the only test that runs. To run only one test with Jest, temporarily change that `test` command to a `test.only`:
 
 ```js
 test.only('this will be the only test that runs', () => {
@@ -187,4 +187,4 @@ test('this test will not run', () => {
 });
 ```
 
-If you have a test that often fails when it's run as part of a larger suite, but doesn't fail when you run it alone, it's a good bet that something from a different test is interfering with this one. You can often fix this by clearing some shared state with `beforeEach`. If you're not sure whether some shared state is being modified, you can also try a `beforeEach` that just logs data.
+If you have a test that often fails when it's run as part of a larger suite, but doesn't fail when you run it alone, it's a good bet that something from a different test is interfering with this one. You can often fix this by clearing some shared state with `beforeEach`. If you're not sure whether some shared state is being modified, you can also try a `beforeEach` that logs data.

--- a/docs/SnapshotTesting.md
+++ b/docs/SnapshotTesting.md
@@ -39,7 +39,7 @@ exports[`renders correctly 1`] = `
 `;
 ```
 
-The snapshot artifact should be committed alongside code changes, and reviewed as part of your code review process. Jest uses [pretty-format](https://github.com/facebook/jest/tree/master/packages/pretty-format) to make snapshots human-readable during code review. On subsequent test runs Jest will simply compare the rendered output with the previous snapshot. If they match, the test will pass. If they don't match, either the test runner found a bug in your code (in this case, it's `<Link>` component) that should be fixed, or the implementation has changed and the snapshot needs to be updated.
+The snapshot artifact should be committed alongside code changes, and reviewed as part of your code review process. Jest uses [pretty-format](https://github.com/facebook/jest/tree/master/packages/pretty-format) to make snapshots human-readable during code review. On subsequent test runs Jest will compare the rendered output with the previous snapshot. If they match, the test will pass. If they don't match, either the test runner found a bug in your code (in this case, it's `<Link>` component) that should be fixed, or the implementation has changed and the snapshot needs to be updated.
 
 > Note: The snapshot is directly scoped to the data you render – in our example it's `<Link />` component with page prop passed to it. This implies that even if any other file has missing props (Say, `App.js`) in the `<Link />` component, it will still pass the test as the test doesn't know the usage of `<Link />` component and it's scoped only to the `Link.react.js`. Also, Rendering the same component with different props in other snapshot tests will not affect the first one, as the tests don't know about each other.
 
@@ -225,7 +225,7 @@ Ensure that your snapshots are readable by keeping them focused, short, and by u
 
 As mentioned previously, Jest uses [`pretty-format`](https://yarnpkg.com/en/package/pretty-format) to make snapshots human-readable, but you may find it useful to introduce additional tools, like [`eslint-plugin-jest`](https://yarnpkg.com/en/package/eslint-plugin-jest) with its [`no-large-snapshots`](https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/no-large-snapshots.md) option, or [`snapshot-diff`](https://yarnpkg.com/en/package/snapshot-diff) with its component snapshot comparison feature, to promote committing short, focused assertions.
 
-The goal is to make it easy to review snapshots in pull requests, and fight against the habit of simply regenerating snapshots when test suites fail instead of examining the root causes of their failure.
+The goal is to make it easy to review snapshots in pull requests, and fight against the habit of regenerating snapshots when test suites fail instead of examining the root causes of their failure.
 
 ### 2. Tests should be deterministic
 
@@ -315,4 +315,4 @@ Although it is possible to write snapshot files manually, that is usually not ap
 
 ### Does code coverage work with snapshot testing?
 
-Yes, just like with any other test.
+Yes, as well as with any other test.

--- a/docs/SnapshotTesting.md
+++ b/docs/SnapshotTesting.md
@@ -9,7 +9,7 @@ A typical snapshot test case for a mobile app renders a UI component, takes a sn
 
 ## Snapshot Testing with Jest
 
-A similar approach can be taken when it comes to testing your React components. Instead of rendering the graphical UI, which would require building the entire app, you can use a test renderer to quickly generate a serializable value for your React tree. Consider this [example test](https://github.com/facebook/jest/blob/master/examples/snapshot/__tests__/link.react.test.js) for a simple [Link component](https://github.com/facebook/jest/blob/master/examples/snapshot/Link.react.js):
+A similar approach can be taken when it comes to testing your React components. Instead of rendering the graphical UI, which would require building the entire app, you can use a test renderer to quickly generate a serializable value for your React tree. Consider this [example test](https://github.com/facebook/jest/blob/master/examples/snapshot/__tests__/link.react.test.js) for a [Link component](https://github.com/facebook/jest/blob/master/examples/snapshot/Link.react.js):
 
 ```javascript
 import React from 'react';
@@ -267,7 +267,7 @@ exports[`<UserName /> should render Alan Turing`] = `
 `;
 ```
 
-Since the later describes exactly what's expected in the output, it's easy to see when it's wrong:
+Since the later describes exactly what's expected in the output, it's more clear to see when it's wrong:
 
 ```js
 exports[`<UserName /> should render null`] = `

--- a/docs/TestingAsyncCode.md
+++ b/docs/TestingAsyncCode.md
@@ -9,7 +9,7 @@ It's common in JavaScript for code to run asynchronously. When you have code tha
 
 The most common asynchronous pattern is callbacks.
 
-For example, let's say that you have a `fetchData(callback)` function that fetches some data and calls `callback(data)` when it is complete. You want to test that this returned data is just the string `'peanut butter'`.
+For example, let's say that you have a `fetchData(callback)` function that fetches some data and calls `callback(data)` when it is complete. You want to test that this returned data is the string `'peanut butter'`.
 
 By default, Jest tests complete once they reach the end of their execution. That means this test will _not_ work as intended:
 
@@ -43,7 +43,7 @@ If `done()` is never called, the test will fail, which is what you want to happe
 
 ## Promises
 
-If your code uses promises, there is a simpler way to handle asynchronous tests. Just return a promise from your test, and Jest will wait for that promise to resolve. If the promise is rejected, the test will automatically fail.
+If your code uses promises, there is a simpler way to handle asynchronous tests. Return a promise from your test, and Jest will wait for that promise to resolve. If the promise is rejected, the test will automatically fail.
 
 For example, let's say that `fetchData`, instead of using a callback, returns a promise that is supposed to resolve to the string `'peanut butter'`. We could test it with:
 
@@ -88,7 +88,7 @@ test('the fetch fails with an error', () => {
 
 ## Async/Await
 
-Alternatively, you can use `async` and `await` in your tests. To write an async test, just use the `async` keyword in front of the function passed to `test`. For example, the same `fetchData` scenario can be tested with:
+Alternatively, you can use `async` and `await` in your tests. To write an async test, use the `async` keyword in front of the function passed to `test`. For example, the same `fetchData` scenario can be tested with:
 
 ```js
 test('the data is peanut butter', async () => {
@@ -118,6 +118,6 @@ test('the fetch fails with an error', async () => {
 });
 ```
 
-In these cases, `async` and `await` are effectively just syntactic sugar for the same logic as the promises example uses.
+In these cases, `async` and `await` are effectively syntactic sugar for the same logic as the promises example uses.
 
 None of these forms is particularly superior to the others, and you can mix and match them across a codebase or even in a single file. It just depends on which style makes your tests simpler.

--- a/docs/TestingAsyncCode.md
+++ b/docs/TestingAsyncCode.md
@@ -43,7 +43,7 @@ If `done()` is never called, the test will fail, which is what you want to happe
 
 ## Promises
 
-If your code uses promises, there is a simpler way to handle asynchronous tests. Return a promise from your test, and Jest will wait for that promise to resolve. If the promise is rejected, the test will automatically fail.
+If your code uses promises, there is a more straightforward way to handle asynchronous tests. Return a promise from your test, and Jest will wait for that promise to resolve. If the promise is rejected, the test will automatically fail.
 
 For example, let's say that `fetchData`, instead of using a callback, returns a promise that is supposed to resolve to the string `'peanut butter'`. We could test it with:
 
@@ -106,7 +106,7 @@ test('the fetch fails with an error', async () => {
 });
 ```
 
-Of course, you can combine `async` and `await` with `.resolves` or `.rejects`.
+You can combine `async` and `await` with `.resolves` or `.rejects`.
 
 ```js
 test('the data is peanut butter', async () => {
@@ -120,4 +120,4 @@ test('the fetch fails with an error', async () => {
 
 In these cases, `async` and `await` are effectively syntactic sugar for the same logic as the promises example uses.
 
-None of these forms is particularly superior to the others, and you can mix and match them across a codebase or even in a single file. It just depends on which style makes your tests simpler.
+None of these forms is particularly superior to the others, and you can mix and match them across a codebase or even in a single file. It just depends on which style you feel makes your tests simpler.

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -19,9 +19,9 @@ node --inspect-brk ./node_modules/jest/bin/jest.js --runInBand [any other argume
 
 This will run Jest in a Node process that an external debugger can connect to. Note that the process will pause until the debugger has connected to it.
 
-To debug in Google Chrome (or any Chromium-based browser), simply open your browser and go to `chrome://inspect` and click on "Open Dedicated DevTools for Node", which will give you a list of available node instances you can connect to. Simply click on the address displayed in the terminal (usually something like `localhost:9229`) after running the above command, and you will be able to debug Jest using Chrome's DevTools.
+To debug in Google Chrome (or any Chromium-based browser), open your browser and go to `chrome://inspect` and click on "Open Dedicated DevTools for Node", which will give you a list of available node instances you can connect to. Click on the address displayed in the terminal (usually something like `localhost:9229`) after running the above command, and you will be able to debug Jest using Chrome's DevTools.
 
-The Chrome Developer Tools will be displayed, and a breakpoint will be set at the first line of the Jest CLI script (this is done simply to give you time to open the developer tools and to prevent Jest from executing before you have time to do so). Click the button that looks like a "play" button in the upper right hand side of the screen to continue execution. When Jest executes the test that contains the `debugger` statement, execution will pause and you can examine the current scope and call stack.
+The Chrome Developer Tools will be displayed, and a breakpoint will be set at the first line of the Jest CLI script (this is done to give you time to open the developer tools and to prevent Jest from executing before you have time to do so). Click the button that looks like a "play" button in the upper right hand side of the screen to continue execution. When Jest executes the test that contains the `debugger` statement, execution will pause and you can examine the current scope and call stack.
 
 > Note: the `--runInBand` cli option makes sure Jest runs test in the same process rather than spawning processes for individual tests. Normally Jest parallelizes test runs across processes but it is hard to debug many processes at the same time.
 

--- a/docs/TutorialAsync.md
+++ b/docs/TutorialAsync.md
@@ -5,7 +5,7 @@ title: An Async Example
 
 First, enable Babel support in Jest as documented in the [Getting Started](GettingStarted.md#using-babel) guide.
 
-Let's implement a simple module that fetches user data from an API and returns the user name.
+Let's implement a module that fetches user data from an API and returns the user name.
 
 ```js
 // user.js
@@ -91,7 +91,7 @@ it('works with resolves', () => {
 
 ## `async`/`await`
 
-Writing tests using the `async`/`await` syntax is easy. Here is how you'd write the same examples from before:
+Writing tests using the `async`/`await` syntax is less complicated than you might expect. Here is how you'd write the same examples from before:
 
 ```js
 // async/await can be used.

--- a/docs/TutorialReact.md
+++ b/docs/TutorialReact.md
@@ -214,7 +214,7 @@ If you'd like to assert, and manipulate your rendered components you can use [re
 
 You have to run `yarn add --dev @testing-library/react` to use react-testing-library.
 
-Let's implement a simple checkbox which swaps between two labels:
+Let's implement a checkbox which swaps between two labels:
 
 ```javascript
 // CheckboxWithLabel.js

--- a/docs/TutorialReact.md
+++ b/docs/TutorialReact.md
@@ -9,7 +9,7 @@ At Facebook, we use Jest to test [React](http://facebook.github.io/react/) appli
 
 ### Setup with Create React App
 
-If you are just getting started with React, we recommend using [Create React App](https://github.com/facebookincubator/create-react-app). It is ready to use and [ships with Jest](https://facebook.github.io/create-react-app/docs/running-tests#docsNav)! You will only need to add `react-test-renderer` for rendering snapshots.
+If you are new to React, we recommend using [Create React App](https://github.com/facebookincubator/create-react-app). It is ready to use and [ships with Jest](https://facebook.github.io/create-react-app/docs/running-tests#docsNav)! You will only need to add `react-test-renderer` for rendering snapshots.
 
 Run
 

--- a/docs/TutorialReactNative.md
+++ b/docs/TutorialReactNative.md
@@ -23,7 +23,7 @@ Starting from react-native version 0.38, a Jest setup is included by default whe
 
 _Note: If you are upgrading your react-native application and previously used the `jest-react-native` preset, remove the dependency from your `package.json` file and change the preset to `react-native` instead._
 
-Simply run `yarn test` to run tests with Jest.
+Run `yarn test` to run tests with Jest.
 
 ## Snapshot Test
 

--- a/docs/Webpack.md
+++ b/docs/Webpack.md
@@ -169,7 +169,7 @@ Similarly webpack's `resolve.root` option functions like setting the `NODE_PATH`
 }
 ```
 
-And finally we just have the webpack `alias` left to handle. For that we can make use of the `moduleNameMapper` option again.
+And finally, we have to handle the webpack `alias`. For that we can make use of the `moduleNameMapper` option again.
 
 ```json
 // package.json

--- a/packages/babel-jest/README.md
+++ b/packages/babel-jest/README.md
@@ -4,7 +4,7 @@
 
 ## Usage
 
-If you are already using `jest-cli`, just add `babel-jest` and it will automatically compile JavaScript code using Babel.
+If you are already using `jest-cli`, add `babel-jest` and it will automatically compile JavaScript code using Babel.
 
 ```bash
 yarn add --dev babel-jest @babel/core

--- a/packages/jest-circus/README.md
+++ b/packages/jest-circus/README.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-Circus is a flux-based test runner for Jest that is fast, easy to maintain, and simple to extend.
+Circus is a flux-based test runner for Jest that is fast, maintainable, and simple to extend.
 
 Circus allows you to bind to events via an optional event handler on any [custom environment](https://jestjs.io/docs/en/configuration#testenvironment-string). See the [type definitions](https://github.com/facebook/jest/blob/master/packages/jest-circus/src/types.ts) for more information on the events and state data currently available.
 

--- a/packages/jest-mock/README.md
+++ b/packages/jest-mock/README.md
@@ -23,7 +23,7 @@ Inspects the argument and returns its schema in the following recursive format:
 }
 ```
 
-Where type is one of `array`, `object`, `function`, or `ref`, and members is an optional dictionary where the keys are member names and the values are metadata objects. Function prototypes are defined by defining metadata for the `member.prototype` of the function. The type of a function prototype should always be `object`. For instance, a simple class might be defined like this:
+Where type is one of `array`, `object`, `function`, or `ref`, and members is an optional dictionary where the keys are member names and the values are metadata objects. Function prototypes are defined by defining metadata for the `member.prototype` of the function. The type of a function prototype should always be `object`. For instance, a class might be defined like this:
 
 ```js
 const classDef = {

--- a/packages/jest-mock/README.md
+++ b/packages/jest-mock/README.md
@@ -23,7 +23,7 @@ Inspects the argument and returns its schema in the following recursive format:
 }
 ```
 
-Where type is one of `array`, `object`, `function`, or `ref`, and members is an optional dictionary where the keys are member names and the values are metadata objects. Function prototypes are defined simply by defining metadata for the `member.prototype` of the function. The type of a function prototype should always be `object`. For instance, a simple class might be defined like this:
+Where type is one of `array`, `object`, `function`, or `ref`, and members is an optional dictionary where the keys are member names and the values are metadata objects. Function prototypes are defined by defining metadata for the `member.prototype` of the function. The type of a function prototype should always be `object`. For instance, a simple class might be defined like this:
 
 ```js
 const classDef = {

--- a/packages/pretty-format/README.md
+++ b/packages/pretty-format/README.md
@@ -230,7 +230,7 @@ Some properties in `config` are derived from `min` in `options`:
 
 ### Example of serialize and test
 
-This plugin is a pattern you can apply to serialize composite data types. Of course, `pretty-format` does not need a plugin to serialize arrays :)
+This plugin is a pattern you can apply to serialize composite data types. `pretty-format` does not need a plugin to serialize arrays.
 
 ```js
 // We reused more code when we factored out a function for child items

--- a/website/README.md
+++ b/website/README.md
@@ -17,7 +17,7 @@ yarn start
 Open http://localhost:3000
 ```
 
-Anytime you change the contents, just refresh the page and it's going to be updated
+Anytime you change the contents, refresh the page and it's going to be updated
 
 # Publish the website
 

--- a/website/versioned_docs/version-22.x/Configuration.md
+++ b/website/versioned_docs/version-22.x/Configuration.md
@@ -73,7 +73,7 @@ test('if utils mocked automatically', () => {
   expect(utils.isAuthorized.mock).toBeTruthy();
 
   // You can provide them with your own implementation
-  // or just pass the expected return value
+  // or pass the expected return value
   utils.authorize.mockReturnValue('mocked_token');
   utils.isAuthorized.mockReturnValue(true);
 

--- a/website/versioned_docs/version-22.x/ExpectAPI.md
+++ b/website/versioned_docs/version-22.x/ExpectAPI.md
@@ -579,7 +579,7 @@ The default for `numDigits` is 2, which has proved to be a good default in most 
 
 ### `.toBeDefined()`
 
-Use `.toBeDefined` to check that a variable is not undefined. For example, if you just want to check that a function `fetchNewFlavorIdea()` returns _something_, you can write:
+Use `.toBeDefined` to check that a variable is not undefined. For example, if you want to check that a function `fetchNewFlavorIdea()` returns _something_, you can write:
 
 ```js
 test('there is a new flavor idea', () => {
@@ -591,7 +591,7 @@ You could write `expect(fetchNewFlavorIdea()).not.toBe(undefined)`, but it's bet
 
 ### `.toBeFalsy()`
 
-Use `.toBeFalsy` when you don't care what a value is, you just want to ensure a value is false in a boolean context. For example, let's say you have some application code that looks like:
+Use `.toBeFalsy` when you don't care what a value is and you want to ensure a value is false in a boolean context. For example, let's say you have some application code that looks like:
 
 ```js
 drinkSomeLaCroix();
@@ -679,7 +679,7 @@ test('bloop returns null', () => {
 
 ### `.toBeTruthy()`
 
-Use `.toBeTruthy` when you don't care what a value is, you just want to ensure a value is true in a boolean context. For example, let's say you have some application code that looks like:
+Use `.toBeTruthy` when you don't care what a value is and you want to ensure a value is true in a boolean context. For example, let's say you have some application code that looks like:
 
 ```js
 drinkSomeLaCroix();
@@ -688,7 +688,7 @@ if (thirstInfo()) {
 }
 ```
 
-You may not care what `thirstInfo` returns, specifically - it might return `true` or a complex object, and your code would still work. So if you just want to test that `thirstInfo` will be truthy after drinking some La Croix, you could write:
+You may not care what `thirstInfo` returns, specifically - it might return `true` or a complex object, and your code would still work. So if you want to test that `thirstInfo` will be truthy after drinking some La Croix, you could write:
 
 ```js
 test('drinking La Croix leads to having thirst info', () => {

--- a/website/versioned_docs/version-22.x/ExpectAPI.md
+++ b/website/versioned_docs/version-22.x/ExpectAPI.md
@@ -527,7 +527,7 @@ const houseForSale = {
 };
 
 test('this house has my desired features', () => {
-  // Simple Referencing
+  // Example Referencing
   expect(houseForSale).toHaveProperty('bath');
   expect(houseForSale).toHaveProperty('bedrooms', 4);
 
@@ -560,7 +560,7 @@ test('this house has my desired features', () => {
 Using exact equality with floating point numbers is a bad idea. Rounding means that intuitive things fail. For example, this test fails:
 
 ```js
-test('adding works sanely with simple decimals', () => {
+test('adding works sanely with decimals', () => {
   expect(0.2 + 0.1).toBe(0.3); // Fails!
 });
 ```
@@ -570,7 +570,7 @@ It fails because in JavaScript, `0.2 + 0.1` is actually `0.30000000000000004`. S
 Instead, use `.toBeCloseTo`. Use `numDigits` to control how many digits after the decimal point to check. For example, if you want to be sure that `0.2 + 0.1` is equal to `0.3` with a precision of 5 decimal digits, you can use this test:
 
 ```js
-test('adding works sanely with simple decimals', () => {
+test('adding works sanely with decimals', () => {
   expect(0.2 + 0.1).toBeCloseTo(0.3, 5);
 });
 ```

--- a/website/versioned_docs/version-22.x/GlobalAPI.md
+++ b/website/versioned_docs/version-22.x/GlobalAPI.md
@@ -124,7 +124,7 @@ test('can find things', () => {
 });
 ```
 
-Here the `beforeAll` ensures that the database is set up before tests run. If setup was synchronous, you could just do this without `beforeAll`. The key is that Jest will wait for a promise to resolve, so you can have asynchronous setup as well.
+Here the `beforeAll` ensures that the database is set up before tests run. If setup was synchronous, you could do this without `beforeAll`. The key is that Jest will wait for a promise to resolve, so you can have asynchronous setup as well.
 
 If `beforeAll` is inside a `describe` block, it runs at the beginning of the describe block.
 
@@ -191,7 +191,7 @@ describe('my beverage', () => {
 });
 ```
 
-This isn't required - you can just write the `test` blocks directly at the top level. But this can be handy if you prefer your tests to be organized into groups.
+This isn't required - you can write the `test` blocks directly at the top level. But this can be handy if you prefer your tests to be organized into groups.
 
 You can also nest `describe` blocks if you have a hierarchy of tests:
 
@@ -317,13 +317,13 @@ test('it is not snowing', () => {
 
 Only the "it is raining" test will run in that test file, since it is run with `test.only`.
 
-Usually you wouldn't check code using `test.only` into source control - you would use it just for debugging, and remove it once you have fixed the broken tests.
+Usually you wouldn't check code using `test.only` into source control - you would use it for debugging, and remove it once you have fixed the broken tests.
 
 ### `test.skip(name, fn)`
 
 Also under the aliases: `it.skip(name, fn)` or `xit(name, fn)` or `xtest(name, fn)`
 
-When you are maintaining a large codebase, you may sometimes find a test that is temporarily broken for some reason. If you want to skip running this test, but you don't want to just delete this code, you can use `test.skip` to specify some tests to skip.
+When you are maintaining a large codebase, you may sometimes find a test that is temporarily broken for some reason. If you want to skip running this test, but you don't want to delete this code, you can use `test.skip` to specify some tests to skip.
 
 For example, let's say you had these tests:
 
@@ -339,4 +339,4 @@ test.skip('it is not snowing', () => {
 
 Only the "it is raining" test will run, since the other test is run with `test.skip`.
 
-You could simply comment the test out, but it's often a bit nicer to use `test.skip` because it will maintain indentation and syntax highlighting.
+You could comment the test out, but it's often a bit nicer to use `test.skip` because it will maintain indentation and syntax highlighting.

--- a/website/versioned_docs/version-22.x/ManualMocks.md
+++ b/website/versioned_docs/version-22.x/ManualMocks.md
@@ -123,7 +123,7 @@ describe('listFilesInDirectorySync', () => {
 });
 ```
 
-The example mock shown here uses [`jest.genMockFromModule`](JestObjectAPI.md#jestgenmockfrommodulemodulename) to generate an automatic mock, and overrides its default behavior. This is the recommended approach, but is completely optional. If you do not want to use the automatic mock at all, you can simply export your own functions from the mock file. One downside to fully manual mocks is that they're manual – meaning you have to manually update them any time the module they are mocking changes. Because of this, it's best to use or extend the automatic mock when it works for your needs.
+The example mock shown here uses [`jest.genMockFromModule`](JestObjectAPI.md#jestgenmockfrommodulemodulename) to generate an automatic mock, and overrides its default behavior. This is the recommended approach, but is completely optional. If you do not want to use the automatic mock at all, you can export your own functions from the mock file. One downside to fully manual mocks is that they're manual – meaning you have to manually update them any time the module they are mocking changes. Because of this, it's best to use or extend the automatic mock when it works for your needs.
 
 To ensure that a manual mock and its real implementation stay in sync, it might be useful to require the real module using [`jest.requireActual(moduleName)`](JestObjectAPI.md#jestrequireactualmodulename) in your manual mock and amending it with mock functions before exporting it.
 

--- a/website/versioned_docs/version-22.x/MigrationGuide.md
+++ b/website/versioned_docs/version-22.x/MigrationGuide.md
@@ -6,7 +6,7 @@ original_id: migration-guide
 
 If you'd like to try out Jest with an existing codebase, there are a number of ways to convert to Jest:
 
-- If you are using Jasmine, or a Jasmine like API (for example [Mocha](https://mochajs.org)), Jest should be mostly compatible and easy to migrate to.
+- If you are using Jasmine, or a Jasmine like API (for example [Mocha](https://mochajs.org)), Jest should be mostly compatible, which makes it less complicated to migrate to.
 - If you are using AVA, Expect.js (by Automattic), Jasmine, Mocha, proxyquire, Should.js or Tape you can automatically migrate with Jest Codemods (see below).
 - If you like [chai](http://chaijs.com/), you can upgrade to Jest and continue using chai. However, we recommend trying out Jest's assertions and their failure messages. Jest Codemods can migrate from chai (see below).
 

--- a/website/versioned_docs/version-22.x/MockFunctionAPI.md
+++ b/website/versioned_docs/version-22.x/MockFunctionAPI.md
@@ -4,7 +4,7 @@ title: Mock Functions
 original_id: mock-function-api
 ---
 
-Mock functions are also known as "spies", because they let you spy on the behavior of a function that is called indirectly by some other code, rather than just testing the output. You can create a mock function with `jest.fn()`. If no implementation is given, the mock function will return `undefined` when invoked.
+Mock functions are also known as "spies", because they let you spy on the behavior of a function that is called indirectly by some other code, rather than only testing the output. You can create a mock function with `jest.fn()`. If no implementation is given, the mock function will return `undefined` when invoked.
 
 ## Methods
 

--- a/website/versioned_docs/version-22.x/MockFunctions.md
+++ b/website/versioned_docs/version-22.x/MockFunctions.md
@@ -214,7 +214,7 @@ expect(mockFunc).lastCalledWith(arg1, arg2);
 expect(mockFunc).toMatchSnapshot();
 ```
 
-These matchers are really just sugar for common forms of inspecting the `.mock` property. You can always do this manually yourself if that's more to your taste or if you need to do something more specific:
+These matchers are sugar for common forms of inspecting the `.mock` property. You can always do this manually yourself if that's more to your taste or if you need to do something more specific:
 
 ```javascript
 // The mock function was called at least once

--- a/website/versioned_docs/version-22.x/MockFunctions.md
+++ b/website/versioned_docs/version-22.x/MockFunctions.md
@@ -4,7 +4,7 @@ title: Mock Functions
 original_id: mock-functions
 ---
 
-Mock functions make it easy to test the links between code by erasing the actual implementation of a function, capturing calls to the function (and the parameters passed in those calls), capturing instances of constructor functions when instantiated with `new`, and allowing test-time configuration of return values.
+Mock functions allow you to test the links between code by erasing the actual implementation of a function, capturing calls to the function (and the parameters passed in those calls), capturing instances of constructor functions when instantiated with `new`, and allowing test-time configuration of return values.
 
 There are two ways to mock functions: Either by creating a mock function to use in test code, or writing a [`manual mock`](ManualMocks.md) to override a module dependency.
 
@@ -198,7 +198,7 @@ const myMockFn = jest
 
 ## Custom Matchers
 
-Finally, in order to make it simpler to assert how mock functions have been called, we've added some custom matcher functions for you:
+Finally, in order to make it less demanding to assert how mock functions have been called, we've added some custom matcher functions for you:
 
 ```javascript
 // The mock function was called at least once

--- a/website/versioned_docs/version-22.x/MoreResources.md
+++ b/website/versioned_docs/version-22.x/MoreResources.md
@@ -4,7 +4,7 @@ title: More Resources
 original_id: more-resources
 ---
 
-By now you should have a good idea of how Jest can make it easy to test your applications. If you're interested in learning more, here's some related stuff you might want to check out.
+By now you should have a good idea of how Jest can help you test your applications. If you're interested in learning more, here's some related stuff you might want to check out.
 
 ## Browse the docs
 

--- a/website/versioned_docs/version-22.x/SetupAndTeardown.md
+++ b/website/versioned_docs/version-22.x/SetupAndTeardown.md
@@ -40,7 +40,7 @@ beforeEach(() => {
 
 ## One-Time Setup
 
-In some cases, you only need to do setup once, at the beginning of a file. This can be especially bothersome when the setup is asynchronous, so you can't just do it inline. Jest provides `beforeAll` and `afterAll` to handle this situation.
+In some cases, you only need to do setup once, at the beginning of a file. This can be especially bothersome when the setup is asynchronous, so you can't do it inline. Jest provides `beforeAll` and `afterAll` to handle this situation.
 
 For example, if both `initializeCityDatabase` and `clearCityDatabase` returned promises, and the city database could be reused between tests, we could change our test code to:
 
@@ -176,7 +176,7 @@ describe('outer', () => {
 
 ## General Advice
 
-If a test is failing, one of the first things to check should be whether the test is failing when it's the only test that runs. In Jest it's simple to run only one test - just temporarily change that `test` command to a `test.only`:
+If a test is failing, one of the first things to check should be whether the test is failing when it's the only test that runs. To run only one test with Jest, temporarily change that `test` command to a `test.only`:
 
 ```js
 test.only('this will be the only test that runs', () => {
@@ -188,4 +188,4 @@ test('this test will not run', () => {
 });
 ```
 
-If you have a test that often fails when it's run as part of a larger suite, but doesn't fail when you run it alone, it's a good bet that something from a different test is interfering with this one. You can often fix this by clearing some shared state with `beforeEach`. If you're not sure whether some shared state is being modified, you can also try a `beforeEach` that just logs data.
+If you have a test that often fails when it's run as part of a larger suite, but doesn't fail when you run it alone, it's a good bet that something from a different test is interfering with this one. You can often fix this by clearing some shared state with `beforeEach`. If you're not sure whether some shared state is being modified, you can also try a `beforeEach` that logs data.

--- a/website/versioned_docs/version-22.x/SnapshotTesting.md
+++ b/website/versioned_docs/version-22.x/SnapshotTesting.md
@@ -40,7 +40,7 @@ exports[`renders correctly 1`] = `
 `;
 ```
 
-The snapshot artifact should be committed alongside code changes, and reviewed as part of your code review process. Jest uses [pretty-format](https://github.com/facebook/jest/tree/master/packages/pretty-format) to make snapshots human-readable during code review. On subsequent test runs Jest will simply compare the rendered output with the previous snapshot. If they match, the test will pass. If they don't match, either the test runner found a bug in your code that should be fixed, or the implementation has changed and the snapshot needs to be updated.
+The snapshot artifact should be committed alongside code changes, and reviewed as part of your code review process. Jest uses [pretty-format](https://github.com/facebook/jest/tree/master/packages/pretty-format) to make snapshots human-readable during code review. On subsequent test runs Jest will compare the rendered output with the previous snapshot. If they match, the test will pass. If they don't match, either the test runner found a bug in your code that should be fixed, or the implementation has changed and the snapshot needs to be updated.
 
 More information on how snapshot testing works and why we built it can be found on the [release blog post](https://jestjs.io/blog/2016/07/27/jest-14.html). We recommend reading [this blog post](http://benmccormick.org/2016/09/19/testing-with-jest-snapshots-first-impressions/) to get a good sense of when you should use snapshot testing. We also recommend watching this [egghead video](https://egghead.io/lessons/javascript-use-jest-s-snapshot-testing-feature?pl=testing-javascript-with-jest-a36c4074) on Snapshot Testing with Jest.
 
@@ -126,4 +126,4 @@ Although it is possible to write snapshot files manually, that is usually not ap
 
 ### Does code coverage work with snapshots testing?
 
-Yes, just like with any other test.
+Yes, as well as with any other test.

--- a/website/versioned_docs/version-22.x/SnapshotTesting.md
+++ b/website/versioned_docs/version-22.x/SnapshotTesting.md
@@ -10,7 +10,7 @@ A typical snapshot test case for a mobile app renders a UI component, takes a sc
 
 ## Snapshot Testing with Jest
 
-A similar approach can be taken when it comes to testing your React components. Instead of rendering the graphical UI, which would require building the entire app, you can use a test renderer to quickly generate a serializable value for your React tree. Consider this [example test](https://github.com/facebook/jest/blob/master/examples/snapshot/__tests__/link.react.test.js) for a simple [Link component](https://github.com/facebook/jest/blob/master/examples/snapshot/Link.react.js):
+A similar approach can be taken when it comes to testing your React components. Instead of rendering the graphical UI, which would require building the entire app, you can use a test renderer to quickly generate a serializable value for your React tree. Consider this [example test](https://github.com/facebook/jest/blob/master/examples/snapshot/__tests__/link.react.test.js) for a [Link component](https://github.com/facebook/jest/blob/master/examples/snapshot/Link.react.js):
 
 ```javascript
 import React from 'react';

--- a/website/versioned_docs/version-22.x/TestingAsyncCode.md
+++ b/website/versioned_docs/version-22.x/TestingAsyncCode.md
@@ -10,7 +10,7 @@ It's common in JavaScript for code to run asynchronously. When you have code tha
 
 The most common asynchronous pattern is callbacks.
 
-For example, let's say that you have a `fetchData(callback)` function that fetches some data and calls `callback(data)` when it is complete. You want to test that this returned data is just the string `'peanut butter'`.
+For example, let's say that you have a `fetchData(callback)` function that fetches some data and calls `callback(data)` when it is complete. You want to test that this returned data is the string `'peanut butter'`.
 
 By default, Jest tests complete once they reach the end of their execution. That means this test will _not_ work as intended:
 
@@ -44,7 +44,7 @@ If `done()` is never called, the test will fail, which is what you want to happe
 
 ## Promises
 
-If your code uses promises, there is a simpler way to handle asynchronous tests. Just return a promise from your test, and Jest will wait for that promise to resolve. If the promise is rejected, the test will automatically fail.
+If your code uses promises, there is a simpler way to handle asynchronous tests. Return a promise from your test, and Jest will wait for that promise to resolve. If the promise is rejected, the test will automatically fail.
 
 For example, let's say that `fetchData`, instead of using a callback, returns a promise that is supposed to resolve to the string `'peanut butter'`. We could test it with:
 
@@ -94,7 +94,7 @@ test('the fetch fails with an error', () => {
 
 ## Async/Await
 
-Alternatively, you can use `async` and `await` in your tests. To write an async test, just use the `async` keyword in front of the function passed to `test`. For example, the same `fetchData` scenario can be tested with:
+Alternatively, you can use `async` and `await` in your tests. To write an async test, use the `async` keyword in front of the function passed to `test`. For example, the same `fetchData` scenario can be tested with:
 
 ```js
 test('the data is peanut butter', async () => {
@@ -126,6 +126,6 @@ test('the fetch fails with an error', async () => {
 });
 ```
 
-In these cases, `async` and `await` are effectively just syntactic sugar for the same logic as the promises example uses.
+In these cases, `async` and `await` are effectively syntactic sugar for the same logic as the promises example uses.
 
 None of these forms is particularly superior to the others, and you can mix and match them across a codebase or even in a single file. It just depends on which style makes your tests simpler.

--- a/website/versioned_docs/version-22.x/TestingAsyncCode.md
+++ b/website/versioned_docs/version-22.x/TestingAsyncCode.md
@@ -44,7 +44,7 @@ If `done()` is never called, the test will fail, which is what you want to happe
 
 ## Promises
 
-If your code uses promises, there is a simpler way to handle asynchronous tests. Return a promise from your test, and Jest will wait for that promise to resolve. If the promise is rejected, the test will automatically fail.
+If your code uses promises, there is a more straightforward way to handle asynchronous tests. Return a promise from your test, and Jest will wait for that promise to resolve. If the promise is rejected, the test will automatically fail.
 
 For example, let's say that `fetchData`, instead of using a callback, returns a promise that is supposed to resolve to the string `'peanut butter'`. We could test it with:
 
@@ -112,7 +112,7 @@ test('the fetch fails with an error', async () => {
 });
 ```
 
-Of course, you can combine `async` and `await` with `.resolves` or `.rejects` (available in Jest **20.0.0+**).
+You can combine `async` and `await` with `.resolves` or `.rejects` (available in Jest **20.0.0+**).
 
 ```js
 test('the data is peanut butter', async () => {
@@ -128,4 +128,4 @@ test('the fetch fails with an error', async () => {
 
 In these cases, `async` and `await` are effectively syntactic sugar for the same logic as the promises example uses.
 
-None of these forms is particularly superior to the others, and you can mix and match them across a codebase or even in a single file. It just depends on which style makes your tests simpler.
+None of these forms is particularly superior to the others, and you can mix and match them across a codebase or even in a single file. It just depends on which style you feel makes your tests simpler.

--- a/website/versioned_docs/version-22.x/Troubleshooting.md
+++ b/website/versioned_docs/version-22.x/Troubleshooting.md
@@ -20,9 +20,9 @@ node --inspect-brk ./node_modules/jest/bin/jest.js --runInBand [any other argume
 
 This will run Jest in a Node process that an external debugger can connect to. Note that the process will pause until the debugger has connected to it.
 
-To debug in Google Chrome (or any Chromium-based browser), simply open your browser and go to `chrome://inspect` and click on "Open Dedicated DevTools for Node", which will give you a list of available node instances you can connect to. Simply click on the address displayed in the terminal (usually something like `localhost:9229`) after running the above command, and you will be able to debug Jest using Chrome's DevTools.
+To debug in Google Chrome (or any Chromium-based browser), open your browser and go to `chrome://inspect` and click on "Open Dedicated DevTools for Node", which will give you a list of available node instances you can connect to. Click on the address displayed in the terminal (usually something like `localhost:9229`) after running the above command, and you will be able to debug Jest using Chrome's DevTools.
 
-The Chrome Developer Tools will be displayed, and a breakpoint will be set at the first line of the Jest CLI script (this is done simply to give you time to open the developer tools and to prevent Jest from executing before you have time to do so). Click the button that looks like a "play" button in the upper right hand side of the screen to continue execution. When Jest executes the test that contains the `debugger` statement, execution will pause and you can examine the current scope and call stack.
+The Chrome Developer Tools will be displayed, and a breakpoint will be set at the first line of the Jest CLI script (this is done to give you time to open the developer tools and to prevent Jest from executing before you have time to do so). Click the button that looks like a "play" button in the upper right hand side of the screen to continue execution. When Jest executes the test that contains the `debugger` statement, execution will pause and you can examine the current scope and call stack.
 
 > Note: the `--runInBand` cli option makes sure Jest runs test in the same process rather than spawning processes for individual tests. Normally Jest parallelizes test runs across processes but it is hard to debug many processes at the same time.
 

--- a/website/versioned_docs/version-22.x/TutorialAsync.md
+++ b/website/versioned_docs/version-22.x/TutorialAsync.md
@@ -6,7 +6,7 @@ original_id: tutorial-async
 
 First, enable Babel support in Jest as documented in the [Getting Started](GettingStarted.md#using-babel) guide.
 
-Let's implement a simple module that fetches user data from an API and returns the user name.
+Let's implement a module that fetches user data from an API and returns the user name.
 
 ```js
 // user.js
@@ -94,7 +94,7 @@ it('works with resolves', () => {
 
 ## `async`/`await`
 
-Writing tests using the `async`/`await` syntax is easy. Here is how you'd write the same examples from before:
+Writing tests using the `async`/`await` syntax is less complicated than you might expect. Here is how you'd write the same examples from before:
 
 ```js
 // async/await can be used.

--- a/website/versioned_docs/version-22.x/TutorialReact.md
+++ b/website/versioned_docs/version-22.x/TutorialReact.md
@@ -10,7 +10,7 @@ At Facebook, we use Jest to test [React](http://facebook.github.io/react/) appli
 
 ### Setup with Create React App
 
-If you are just getting started with React, we recommend using [Create React App](https://github.com/facebookincubator/create-react-app). It is ready to use and [ships with Jest](https://github.com/facebookincubator/create-react-app)! You don't need to do any extra steps for setup, and can head straight to the next section.
+If you are new to React, we recommend using [Create React App](https://github.com/facebookincubator/create-react-app). It is ready to use and [ships with Jest](https://github.com/facebookincubator/create-react-app)! You don't need to do any extra steps for setup, and can head straight to the next section.
 
 ### Setup without Create React App
 

--- a/website/versioned_docs/version-22.x/TutorialReact.md
+++ b/website/versioned_docs/version-22.x/TutorialReact.md
@@ -202,7 +202,7 @@ If you'd like to assert, and manipulate your rendered components you can use [En
 
 You have to run `yarn add --dev enzyme` to use Enzyme. If you are using a React version below 15.5.0, you will also need to install `react-addons-test-utils`.
 
-Let's implement a simple checkbox which swaps between two labels:
+Let's implement a checkbox which swaps between two labels:
 
 ```javascript
 // CheckboxWithLabel.js

--- a/website/versioned_docs/version-22.x/TutorialReactNative.md
+++ b/website/versioned_docs/version-22.x/TutorialReactNative.md
@@ -24,7 +24,7 @@ Starting from react-native version 0.38, a Jest setup is included by default whe
 
 _Note: If you are upgrading your react-native application and previously used the `jest-react-native` preset, remove the dependency from your `package.json` file and change the preset to `react-native` instead._
 
-Simply run `yarn test` to run tests with Jest.
+Run `yarn test` to run tests with Jest.
 
 ## Snapshot Test
 

--- a/website/versioned_docs/version-22.x/Webpack.md
+++ b/website/versioned_docs/version-22.x/Webpack.md
@@ -170,7 +170,7 @@ Similarly webpack's `resolve.root` option functions like setting the `NODE_PATH`
 }
 ```
 
-And finally we just have the webpack `alias` left to handle. For that we can make use of the `moduleNameMapper` option again.
+And finally, we have to handle the webpack `alias`. For that we can make use of the `moduleNameMapper` option again.
 
 ```json
 // package.json

--- a/website/versioned_docs/version-23.x/Es6ClassMocks.md
+++ b/website/versioned_docs/version-23.x/Es6ClassMocks.md
@@ -191,7 +191,7 @@ describe('When SoundPlayer throws an error', () => {
 
 ## In depth: Understanding mock constructor functions
 
-Building your constructor function mock using `jest.fn().mockImplementation()` makes mocks appear more complicated than they really are. This section shows how you can create your own simple mocks to illustrate how mocking works.
+Building your constructor function mock using `jest.fn().mockImplementation()` makes mocks appear more complicated than they really are. This section shows how you can create your own smaller mocks to illustrate how mocking works.
 
 ### Manual mock that is another ES6 class
 
@@ -212,7 +212,7 @@ export default class SoundPlayer {
 }
 ```
 
-### Simple mock using module factory parameter
+### Mock using module factory parameter
 
 The module factory function passed to `jest.mock(path, moduleFactory)` can be a HOF that returns a function\*. This will allow calling `new` on the mock. Again, this allows you to inject different behavior for testing, but does not provide a way to spy on calls.
 

--- a/website/versioned_docs/version-23.x/ExpectAPI.md
+++ b/website/versioned_docs/version-23.x/ExpectAPI.md
@@ -197,7 +197,7 @@ When an assertion fails, the error message should give as much signal as necessa
 
 To use snapshot testing inside of your custom matcher you can import `jest-snapshot` and use it from within your matcher.
 
-Here's a simple snapshot matcher that trims a string to store for a given length, `.toMatchTrimmedSnapshot(length)`:
+Here's a snapshot matcher that trims a string to store for a given length, `.toMatchTrimmedSnapshot(length)`:
 
 ```js
 const {toMatchSnapshot} = require('jest-snapshot');
@@ -788,7 +788,7 @@ const houseForSale = {
 };
 
 test('this house has my desired features', () => {
-  // Simple Referencing
+  // Example Referencing
   expect(houseForSale).toHaveProperty('bath');
   expect(houseForSale).toHaveProperty('bedrooms', 4);
 
@@ -824,7 +824,7 @@ test('this house has my desired features', () => {
 Using exact equality with floating point numbers is a bad idea. Rounding means that intuitive things fail. For example, this test fails:
 
 ```js
-test('adding works sanely with simple decimals', () => {
+test('adding works sanely with decimals', () => {
   expect(0.2 + 0.1).toBe(0.3); // Fails!
 });
 ```
@@ -834,7 +834,7 @@ It fails because in JavaScript, `0.2 + 0.1` is actually `0.30000000000000004`. S
 Instead, use `.toBeCloseTo`. Use `numDigits` to control how many digits after the decimal point to check. For example, if you want to be sure that `0.2 + 0.1` is equal to `0.3` with a precision of 5 decimal digits, you can use this test:
 
 ```js
-test('adding works sanely with simple decimals', () => {
+test('adding works sanely with decimals', () => {
   expect(0.2 + 0.1).toBeCloseTo(0.3, 5);
 });
 ```

--- a/website/versioned_docs/version-23.x/ExpectAPI.md
+++ b/website/versioned_docs/version-23.x/ExpectAPI.md
@@ -843,7 +843,7 @@ The default for `numDigits` is 2, which has proved to be a good default in most 
 
 ### `.toBeDefined()`
 
-Use `.toBeDefined` to check that a variable is not undefined. For example, if you just want to check that a function `fetchNewFlavorIdea()` returns _something_, you can write:
+Use `.toBeDefined` to check that a variable is not undefined. For example, if you want to check that a function `fetchNewFlavorIdea()` returns _something_, you can write:
 
 ```js
 test('there is a new flavor idea', () => {
@@ -855,7 +855,7 @@ You could write `expect(fetchNewFlavorIdea()).not.toBe(undefined)`, but it's bet
 
 ### `.toBeFalsy()`
 
-Use `.toBeFalsy` when you don't care what a value is, you just want to ensure a value is false in a boolean context. For example, let's say you have some application code that looks like:
+Use `.toBeFalsy` when you don't care what a value is and you want to ensure a value is false in a boolean context. For example, let's say you have some application code that looks like:
 
 ```js
 drinkSomeLaCroix();
@@ -943,7 +943,7 @@ test('bloop returns null', () => {
 
 ### `.toBeTruthy()`
 
-Use `.toBeTruthy` when you don't care what a value is, you just want to ensure a value is true in a boolean context. For example, let's say you have some application code that looks like:
+Use `.toBeTruthy` when you don't care what a value is and you want to ensure a value is true in a boolean context. For example, let's say you have some application code that looks like:
 
 ```js
 drinkSomeLaCroix();
@@ -952,7 +952,7 @@ if (thirstInfo()) {
 }
 ```
 
-You may not care what `thirstInfo` returns, specifically - it might return `true` or a complex object, and your code would still work. So if you just want to test that `thirstInfo` will be truthy after drinking some La Croix, you could write:
+You may not care what `thirstInfo` returns, specifically - it might return `true` or a complex object, and your code would still work. So if you want to test that `thirstInfo` will be truthy after drinking some La Croix, you could write:
 
 ```js
 test('drinking La Croix leads to having thirst info', () => {

--- a/website/versioned_docs/version-23.x/GlobalAPI.md
+++ b/website/versioned_docs/version-23.x/GlobalAPI.md
@@ -124,7 +124,7 @@ test('can find things', () => {
 });
 ```
 
-Here the `beforeAll` ensures that the database is set up before tests run. If setup was synchronous, you could just do this without `beforeAll`. The key is that Jest will wait for a promise to resolve, so you can have asynchronous setup as well.
+Here the `beforeAll` ensures that the database is set up before tests run. If setup was synchronous, you could do this without `beforeAll`. The key is that Jest will wait for a promise to resolve, so you can have asynchronous setup as well.
 
 If `beforeAll` is inside a `describe` block, it runs at the beginning of the describe block.
 
@@ -191,7 +191,7 @@ describe('my beverage', () => {
 });
 ```
 
-This isn't required - you can just write the `test` blocks directly at the top level. But this can be handy if you prefer your tests to be organized into groups.
+This isn't required - you can write the `test` blocks directly at the top level. But this can be handy if you prefer your tests to be organized into groups.
 
 You can also nest `describe` blocks if you have a hierarchy of tests:
 
@@ -389,7 +389,7 @@ describe.skip('my other beverage', () => {
 });
 ```
 
-Using `describe.skip` is often just an easier alternative to temporarily commenting out a chunk of tests.
+Using `describe.skip` is often a cleaner alternative to temporarily commenting out a chunk of tests.
 
 ### `describe.skip.each(table)(name, fn)`
 
@@ -545,7 +545,7 @@ test('it is not snowing', () => {
 
 Only the "it is raining" test will run in that test file, since it is run with `test.only`.
 
-Usually you wouldn't check code using `test.only` into source control - you would use it just for debugging, and remove it once you have fixed the broken tests.
+Usually you wouldn't check code using `test.only` into source control - you would use it for debugging, and remove it once you have fixed the broken tests.
 
 ### `test.only.each(table)(name, fn)`
 
@@ -591,7 +591,7 @@ test('will not be ran', () => {
 
 Also under the aliases: `it.skip(name, fn)` or `xit(name, fn)` or `xtest(name, fn)`
 
-When you are maintaining a large codebase, you may sometimes find a test that is temporarily broken for some reason. If you want to skip running this test, but you don't want to just delete this code, you can use `test.skip` to specify some tests to skip.
+When you are maintaining a large codebase, you may sometimes find a test that is temporarily broken for some reason. If you want to skip running this test, but you don't want to delete this code, you can use `test.skip` to specify some tests to skip.
 
 For example, let's say you had these tests:
 
@@ -607,7 +607,7 @@ test.skip('it is not snowing', () => {
 
 Only the "it is raining" test will run, since the other test is run with `test.skip`.
 
-You could simply comment the test out, but it's often a bit nicer to use `test.skip` because it will maintain indentation and syntax highlighting.
+You could comment the test out, but it's often a bit nicer to use `test.skip` because it will maintain indentation and syntax highlighting.
 
 ### `test.skip.each(table)(name, fn)`
 

--- a/website/versioned_docs/version-23.x/ManualMocks.md
+++ b/website/versioned_docs/version-23.x/ManualMocks.md
@@ -125,7 +125,7 @@ describe('listFilesInDirectorySync', () => {
 });
 ```
 
-The example mock shown here uses [`jest.genMockFromModule`](JestObjectAPI.md#jestgenmockfrommodulemodulename) to generate an automatic mock, and overrides its default behavior. This is the recommended approach, but is completely optional. If you do not want to use the automatic mock at all, you can simply export your own functions from the mock file. One downside to fully manual mocks is that they're manual – meaning you have to manually update them any time the module they are mocking changes. Because of this, it's best to use or extend the automatic mock when it works for your needs.
+The example mock shown here uses [`jest.genMockFromModule`](JestObjectAPI.md#jestgenmockfrommodulemodulename) to generate an automatic mock, and overrides its default behavior. This is the recommended approach, but is completely optional. If you do not want to use the automatic mock at all, you can export your own functions from the mock file. One downside to fully manual mocks is that they're manual – meaning you have to manually update them any time the module they are mocking changes. Because of this, it's best to use or extend the automatic mock when it works for your needs.
 
 To ensure that a manual mock and its real implementation stay in sync, it might be useful to require the real module using [`jest.requireActual(moduleName)`](JestObjectAPI.md#jestrequireactualmodulename) in your manual mock and amending it with mock functions before exporting it.
 

--- a/website/versioned_docs/version-23.x/MockFunctionAPI.md
+++ b/website/versioned_docs/version-23.x/MockFunctionAPI.md
@@ -4,7 +4,7 @@ title: Mock Functions
 original_id: mock-function-api
 ---
 
-Mock functions are also known as "spies", because they let you spy on the behavior of a function that is called indirectly by some other code, rather than just testing the output. You can create a mock function with `jest.fn()`. If no implementation is given, the mock function will return `undefined` when invoked.
+Mock functions are also known as "spies", because they let you spy on the behavior of a function that is called indirectly by some other code, rather than only testing the output. You can create a mock function with `jest.fn()`. If no implementation is given, the mock function will return `undefined` when invoked.
 
 ## Methods
 

--- a/website/versioned_docs/version-23.x/MockFunctions.md
+++ b/website/versioned_docs/version-23.x/MockFunctions.md
@@ -4,7 +4,7 @@ title: Mock Functions
 original_id: mock-functions
 ---
 
-Mock functions make it easy to test the links between code by erasing the actual implementation of a function, capturing calls to the function (and the parameters passed in those calls), capturing instances of constructor functions when instantiated with `new`, and allowing test-time configuration of return values.
+Mock functions allow you to test the links between code by erasing the actual implementation of a function, capturing calls to the function (and the parameters passed in those calls), capturing instances of constructor functions when instantiated with `new`, and allowing test-time configuration of return values.
 
 There are two ways to mock functions: Either by creating a mock function to use in test code, or writing a [`manual mock`](ManualMocks.md) to override a module dependency.
 
@@ -244,7 +244,7 @@ const myMockFn = jest
 
 ## Custom Matchers
 
-Finally, in order to make it simpler to assert how mock functions have been called, we've added some custom matcher functions for you:
+Finally, in order to make it less demanding to assert how mock functions have been called, we've added some custom matcher functions for you:
 
 ```javascript
 // The mock function was called at least once

--- a/website/versioned_docs/version-23.x/MockFunctions.md
+++ b/website/versioned_docs/version-23.x/MockFunctions.md
@@ -260,7 +260,7 @@ expect(mockFunc).lastCalledWith(arg1, arg2);
 expect(mockFunc).toMatchSnapshot();
 ```
 
-These matchers are really just sugar for common forms of inspecting the `.mock` property. You can always do this manually yourself if that's more to your taste or if you need to do something more specific:
+These matchers are sugar for common forms of inspecting the `.mock` property. You can always do this manually yourself if that's more to your taste or if you need to do something more specific:
 
 ```javascript
 // The mock function was called at least once

--- a/website/versioned_docs/version-23.x/MoreResources.md
+++ b/website/versioned_docs/version-23.x/MoreResources.md
@@ -4,7 +4,7 @@ title: More Resources
 original_id: more-resources
 ---
 
-By now you should have a good idea of how Jest can make it easy to test your applications. If you're interested in learning more, here's some related stuff you might want to check out.
+By now you should have a good idea of how Jest can help you test your applications. If you're interested in learning more, here's some related stuff you might want to check out.
 
 ## Browse the docs
 

--- a/website/versioned_docs/version-23.x/SnapshotTesting.md
+++ b/website/versioned_docs/version-23.x/SnapshotTesting.md
@@ -10,7 +10,7 @@ A typical snapshot test case for a mobile app renders a UI component, takes a sc
 
 ## Snapshot Testing with Jest
 
-A similar approach can be taken when it comes to testing your React components. Instead of rendering the graphical UI, which would require building the entire app, you can use a test renderer to quickly generate a serializable value for your React tree. Consider this [example test](https://github.com/facebook/jest/blob/master/examples/snapshot/__tests__/link.react.test.js) for a simple [Link component](https://github.com/facebook/jest/blob/master/examples/snapshot/Link.react.js):
+A similar approach can be taken when it comes to testing your React components. Instead of rendering the graphical UI, which would require building the entire app, you can use a test renderer to quickly generate a serializable value for your React tree. Consider this [example test](https://github.com/facebook/jest/blob/master/examples/snapshot/__tests__/link.react.test.js) for a [Link component](https://github.com/facebook/jest/blob/master/examples/snapshot/Link.react.js):
 
 ```javascript
 import React from 'react';
@@ -268,7 +268,7 @@ exports[`<UserName /> should render Alan Turing`] = `
 `;
 ```
 
-Since the later describes exactly what's expected in the output, it's easy to see when it's wrong:
+Since the later describes exactly what's expected in the output, it's more clear to see when it's wrong:
 
 ```js
 exports[`<UserName /> should render null`] = `

--- a/website/versioned_docs/version-23.x/SnapshotTesting.md
+++ b/website/versioned_docs/version-23.x/SnapshotTesting.md
@@ -40,7 +40,7 @@ exports[`renders correctly 1`] = `
 `;
 ```
 
-The snapshot artifact should be committed alongside code changes, and reviewed as part of your code review process. Jest uses [pretty-format](https://github.com/facebook/jest/tree/master/packages/pretty-format) to make snapshots human-readable during code review. On subsequent test runs Jest will simply compare the rendered output with the previous snapshot. If they match, the test will pass. If they don't match, either the test runner found a bug in your code (in this case, it's `<Link>` component) that should be fixed, or the implementation has changed and the snapshot needs to be updated.
+The snapshot artifact should be committed alongside code changes, and reviewed as part of your code review process. Jest uses [pretty-format](https://github.com/facebook/jest/tree/master/packages/pretty-format) to make snapshots human-readable during code review. On subsequent test runs Jest will compare the rendered output with the previous snapshot. If they match, the test will pass. If they don't match, either the test runner found a bug in your code (in this case, it's `<Link>` component) that should be fixed, or the implementation has changed and the snapshot needs to be updated.
 
 > Note: The snapshot is directly scoped to the data you render – in our example it's `<Link />` component with page prop passed to it. This implies that even if any other file has missing props (Say, `App.js`) in the `<Link />` component, it will still pass the test as the test doesn't know the usage of `<Link />` component and it's scoped only to the `Link.react.js`. Also, Rendering the same component with different props in other snapshot test will not affect the first one, as the tests don't know about each other.
 
@@ -226,7 +226,7 @@ Ensure that your snapshots are readable by keeping them focused, short, and by u
 
 As mentioned previously, Jest uses [`pretty-format`](https://yarnpkg.com/en/package/pretty-format) to make snapshots human-readable, but you may find it useful to introduce additional tools, like [`eslint-plugin-jest`](https://yarnpkg.com/en/package/eslint-plugin-jest) with its [`no-large-snapshots`](https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/no-large-snapshots.md) option, or [`snapshot-diff`](https://yarnpkg.com/en/package/snapshot-diff) with its component snapshot comparison feature, to promote committing short, focused assertions.
 
-The goal is to make it easy to review snapshots in pull requests, and fight against the habit of simply regenerating snapshots when test suites fail instead of examining the root causes of their failure.
+The goal is to make it easy to review snapshots in pull requests, and fight against the habit of regenerating snapshots when test suites fail instead of examining the root causes of their failure.
 
 ### 2. Tests should be deterministic
 
@@ -316,4 +316,4 @@ Although it is possible to write snapshot files manually, that is usually not ap
 
 ### Does code coverage work with snapshot testing?
 
-Yes, just like with any other test.
+Yes, as well as with any other test.

--- a/website/versioned_docs/version-23.x/Troubleshooting.md
+++ b/website/versioned_docs/version-23.x/Troubleshooting.md
@@ -20,9 +20,9 @@ node --inspect-brk ./node_modules/jest/bin/jest.js --runInBand [any other argume
 
 This will run Jest in a Node process that an external debugger can connect to. Note that the process will pause until the debugger has connected to it.
 
-To debug in Google Chrome (or any Chromium-based browser), simply open your browser and go to `chrome://inspect` and click on "Open Dedicated DevTools for Node", which will give you a list of available node instances you can connect to. Simply click on the address displayed in the terminal (usually something like `localhost:9229`) after running the above command, and you will be able to debug Jest using Chrome's DevTools.
+To debug in Google Chrome (or any Chromium-based browser), open your browser and go to `chrome://inspect` and click on "Open Dedicated DevTools for Node", which will give you a list of available node instances you can connect to. Click on the address displayed in the terminal (usually something like `localhost:9229`) after running the above command, and you will be able to debug Jest using Chrome's DevTools.
 
-The Chrome Developer Tools will be displayed, and a breakpoint will be set at the first line of the Jest CLI script (this is done simply to give you time to open the developer tools and to prevent Jest from executing before you have time to do so). Click the button that looks like a "play" button in the upper right hand side of the screen to continue execution. When Jest executes the test that contains the `debugger` statement, execution will pause and you can examine the current scope and call stack.
+The Chrome Developer Tools will be displayed, and a breakpoint will be set at the first line of the Jest CLI script (this is done to give you time to open the developer tools and to prevent Jest from executing before you have time to do so). Click the button that looks like a "play" button in the upper right hand side of the screen to continue execution. When Jest executes the test that contains the `debugger` statement, execution will pause and you can examine the current scope and call stack.
 
 > Note: the `--runInBand` cli option makes sure Jest runs test in the same process rather than spawning processes for individual tests. Normally Jest parallelizes test runs across processes but it is hard to debug many processes at the same time.
 

--- a/website/versioned_docs/version-23.x/TutorialAsync.md
+++ b/website/versioned_docs/version-23.x/TutorialAsync.md
@@ -6,7 +6,7 @@ original_id: tutorial-async
 
 First, enable Babel support in Jest as documented in the [Getting Started](GettingStarted.md#using-babel) guide.
 
-Let's implement a simple module that fetches user data from an API and returns the user name.
+Let's implement a module that fetches user data from an API and returns the user name.
 
 ```js
 // user.js
@@ -92,7 +92,7 @@ it('works with resolves', () => {
 
 ## `async`/`await`
 
-Writing tests using the `async`/`await` syntax is easy. Here is how you'd write the same examples from before:
+Writing tests using the `async`/`await` syntax is less complicated than you might expect. Here is how you'd write the same examples from before:
 
 ```js
 // async/await can be used.

--- a/website/versioned_docs/version-23.x/TutorialReact.md
+++ b/website/versioned_docs/version-23.x/TutorialReact.md
@@ -10,7 +10,7 @@ At Facebook, we use Jest to test [React](http://facebook.github.io/react/) appli
 
 ### Setup with Create React App
 
-If you are just getting started with React, we recommend using [Create React App](https://github.com/facebookincubator/create-react-app). It is ready to use and [ships with Jest](https://github.com/facebookincubator/create-react-app)! You will only need to add `react-test-renderer` for rendering snapshots.
+If you are new to React, we recommend using [Create React App](https://github.com/facebookincubator/create-react-app). It is ready to use and [ships with Jest](https://github.com/facebookincubator/create-react-app)! You will only need to add `react-test-renderer` for rendering snapshots.
 
 Run
 

--- a/website/versioned_docs/version-23.x/TutorialReact.md
+++ b/website/versioned_docs/version-23.x/TutorialReact.md
@@ -213,7 +213,7 @@ If you'd like to assert, and manipulate your rendered components you can use [En
 
 You have to run `yarn add --dev enzyme` to use Enzyme. If you are using a React version below 15.5.0, you will also need to install `react-addons-test-utils`.
 
-Let's implement a simple checkbox which swaps between two labels:
+Let's implement a checkbox which swaps between two labels:
 
 ```javascript
 // CheckboxWithLabel.js

--- a/website/versioned_docs/version-23.x/Webpack.md
+++ b/website/versioned_docs/version-23.x/Webpack.md
@@ -170,7 +170,7 @@ Similarly webpack's `resolve.root` option functions like setting the `NODE_PATH`
 }
 ```
 
-And finally we just have the webpack `alias` left to handle. For that we can make use of the `moduleNameMapper` option again.
+And finally, we have to handle the webpack `alias`. For that we can make use of the `moduleNameMapper` option again.
 
 ```json
 // package.json

--- a/website/versioned_docs/version-24.0/Configuration.md
+++ b/website/versioned_docs/version-24.0/Configuration.md
@@ -87,7 +87,7 @@ test('if utils mocked automatically', () => {
   expect(utils.isAuthorized.mock).toBeTruthy();
 
   // You can provide them with your own implementation
-  // or just pass the expected return value
+  // or pass the expected return value
   utils.authorize.mockReturnValue('mocked_token');
   utils.isAuthorized.mockReturnValue(true);
 

--- a/website/versioned_docs/version-24.0/Es6ClassMocks.md
+++ b/website/versioned_docs/version-24.0/Es6ClassMocks.md
@@ -191,7 +191,7 @@ describe('When SoundPlayer throws an error', () => {
 
 ## In depth: Understanding mock constructor functions
 
-Building your constructor function mock using `jest.fn().mockImplementation()` makes mocks appear more complicated than they really are. This section shows how you can create your own simple mocks to illustrate how mocking works.
+Building your constructor function mock using `jest.fn().mockImplementation()` makes mocks appear more complicated than they really are. This section shows how you can create your own smaller mocks to illustrate how mocking works.
 
 ### Manual mock that is another ES6 class
 
@@ -212,7 +212,7 @@ export default class SoundPlayer {
 }
 ```
 
-### Simple mock using module factory parameter
+### Mock using module factory parameter
 
 The module factory function passed to `jest.mock(path, moduleFactory)` can be a HOF that returns a function\*. This will allow calling `new` on the mock. Again, this allows you to inject different behavior for testing, but does not provide a way to spy on calls.
 

--- a/website/versioned_docs/version-24.0/ExpectAPI.md
+++ b/website/versioned_docs/version-24.0/ExpectAPI.md
@@ -208,7 +208,7 @@ When an assertion fails, the error message should give as much signal as necessa
 
 To use snapshot testing inside of your custom matcher you can import `jest-snapshot` and use it from within your matcher.
 
-Here's a simple snapshot matcher that trims a string to store for a given length, `.toMatchTrimmedSnapshot(length)`:
+Here's a snapshot matcher that trims a string to store for a given length, `.toMatchTrimmedSnapshot(length)`:
 
 ```js
 const {toMatchSnapshot} = require('jest-snapshot');
@@ -799,7 +799,7 @@ const houseForSale = {
 };
 
 test('this house has my desired features', () => {
-  // Simple Referencing
+  // Example Referencing
   expect(houseForSale).toHaveProperty('bath');
   expect(houseForSale).toHaveProperty('bedrooms', 4);
 
@@ -835,7 +835,7 @@ test('this house has my desired features', () => {
 Using exact equality with floating point numbers is a bad idea. Rounding means that intuitive things fail. For example, this test fails:
 
 ```js
-test('adding works sanely with simple decimals', () => {
+test('adding works sanely with decimals', () => {
   expect(0.2 + 0.1).toBe(0.3); // Fails!
 });
 ```
@@ -845,7 +845,7 @@ It fails because in JavaScript, `0.2 + 0.1` is actually `0.30000000000000004`. S
 Instead, use `.toBeCloseTo`. Use `numDigits` to control how many digits after the decimal point to check. For example, if you want to be sure that `0.2 + 0.1` is equal to `0.3` with a precision of 5 decimal digits, you can use this test:
 
 ```js
-test('adding works sanely with simple decimals', () => {
+test('adding works sanely with decimals', () => {
   expect(0.2 + 0.1).toBeCloseTo(0.3, 5);
 });
 ```

--- a/website/versioned_docs/version-24.0/ExpectAPI.md
+++ b/website/versioned_docs/version-24.0/ExpectAPI.md
@@ -854,7 +854,7 @@ The optional `numDigits` argument has default value `2` which means the criterio
 
 ### `.toBeDefined()`
 
-Use `.toBeDefined` to check that a variable is not undefined. For example, if you just want to check that a function `fetchNewFlavorIdea()` returns _something_, you can write:
+Use `.toBeDefined` to check that a variable is not undefined. For example, if you want to check that a function `fetchNewFlavorIdea()` returns _something_, you can write:
 
 ```js
 test('there is a new flavor idea', () => {
@@ -866,7 +866,7 @@ You could write `expect(fetchNewFlavorIdea()).not.toBe(undefined)`, but it's bet
 
 ### `.toBeFalsy()`
 
-Use `.toBeFalsy` when you don't care what a value is, you just want to ensure a value is false in a boolean context. For example, let's say you have some application code that looks like:
+Use `.toBeFalsy` when you don't care what a value is and you want to ensure a value is false in a boolean context. For example, let's say you have some application code that looks like:
 
 ```js
 drinkSomeLaCroix();
@@ -954,7 +954,7 @@ test('bloop returns null', () => {
 
 ### `.toBeTruthy()`
 
-Use `.toBeTruthy` when you don't care what a value is, you just want to ensure a value is true in a boolean context. For example, let's say you have some application code that looks like:
+Use `.toBeTruthy` when you don't care what a value is and you want to ensure a value is true in a boolean context. For example, let's say you have some application code that looks like:
 
 ```js
 drinkSomeLaCroix();
@@ -963,7 +963,7 @@ if (thirstInfo()) {
 }
 ```
 
-You may not care what `thirstInfo` returns, specifically - it might return `true` or a complex object, and your code would still work. So if you just want to test that `thirstInfo` will be truthy after drinking some La Croix, you could write:
+You may not care what `thirstInfo` returns, specifically - it might return `true` or a complex object, and your code would still work. So if you want to test that `thirstInfo` will be truthy after drinking some La Croix, you could write:
 
 ```js
 test('drinking La Croix leads to having thirst info', () => {

--- a/website/versioned_docs/version-24.0/GlobalAPI.md
+++ b/website/versioned_docs/version-24.0/GlobalAPI.md
@@ -124,7 +124,7 @@ test('can find things', () => {
 });
 ```
 
-Here the `beforeAll` ensures that the database is set up before tests run. If setup was synchronous, you could just do this without `beforeAll`. The key is that Jest will wait for a promise to resolve, so you can have asynchronous setup as well.
+Here the `beforeAll` ensures that the database is set up before tests run. If setup was synchronous, you could do this without `beforeAll`. The key is that Jest will wait for a promise to resolve, so you can have asynchronous setup as well.
 
 If `beforeAll` is inside a `describe` block, it runs at the beginning of the describe block.
 
@@ -191,7 +191,7 @@ describe('my beverage', () => {
 });
 ```
 
-This isn't required - you can just write the `test` blocks directly at the top level. But this can be handy if you prefer your tests to be organized into groups.
+This isn't required - you can write the `test` blocks directly at the top level. But this can be handy if you prefer your tests to be organized into groups.
 
 You can also nest `describe` blocks if you have a hierarchy of tests:
 
@@ -389,7 +389,7 @@ describe.skip('my other beverage', () => {
 });
 ```
 
-Using `describe.skip` is often just an easier alternative to temporarily commenting out a chunk of tests.
+Using `describe.skip` is often a cleaner alternative to temporarily commenting out a chunk of tests.
 
 ### `describe.skip.each(table)(name, fn)`
 
@@ -545,7 +545,7 @@ test('it is not snowing', () => {
 
 Only the "it is raining" test will run in that test file, since it is run with `test.only`.
 
-Usually you wouldn't check code using `test.only` into source control - you would use it just for debugging, and remove it once you have fixed the broken tests.
+Usually you wouldn't check code using `test.only` into source control - you would use it for debugging, and remove it once you have fixed the broken tests.
 
 ### `test.only.each(table)(name, fn)`
 
@@ -591,7 +591,7 @@ test('will not be ran', () => {
 
 Also under the aliases: `it.skip(name, fn)` or `xit(name, fn)` or `xtest(name, fn)`
 
-When you are maintaining a large codebase, you may sometimes find a test that is temporarily broken for some reason. If you want to skip running this test, but you don't want to just delete this code, you can use `test.skip` to specify some tests to skip.
+When you are maintaining a large codebase, you may sometimes find a test that is temporarily broken for some reason. If you want to skip running this test, but you don't want to delete this code, you can use `test.skip` to specify some tests to skip.
 
 For example, let's say you had these tests:
 
@@ -607,7 +607,7 @@ test.skip('it is not snowing', () => {
 
 Only the "it is raining" test will run, since the other test is run with `test.skip`.
 
-You could simply comment the test out, but it's often a bit nicer to use `test.skip` because it will maintain indentation and syntax highlighting.
+You could comment the test out, but it's often a bit nicer to use `test.skip` because it will maintain indentation and syntax highlighting.
 
 ### `test.skip.each(table)(name, fn)`
 

--- a/website/versioned_docs/version-24.0/MockFunctionAPI.md
+++ b/website/versioned_docs/version-24.0/MockFunctionAPI.md
@@ -4,7 +4,7 @@ title: Mock Functions
 original_id: mock-function-api
 ---
 
-Mock functions are also known as "spies", because they let you spy on the behavior of a function that is called indirectly by some other code, rather than just testing the output. You can create a mock function with `jest.fn()`. If no implementation is given, the mock function will return `undefined` when invoked.
+Mock functions are also known as "spies", because they let you spy on the behavior of a function that is called indirectly by some other code, rather than only testing the output. You can create a mock function with `jest.fn()`. If no implementation is given, the mock function will return `undefined` when invoked.
 
 ## Methods
 

--- a/website/versioned_docs/version-24.0/MockFunctions.md
+++ b/website/versioned_docs/version-24.0/MockFunctions.md
@@ -257,7 +257,7 @@ expect(mockFunc).lastCalledWith(arg1, arg2);
 expect(mockFunc).toMatchSnapshot();
 ```
 
-These matchers are really just sugar for common forms of inspecting the `.mock` property. You can always do this manually yourself if that's more to your taste or if you need to do something more specific:
+These matchers are sugar for common forms of inspecting the `.mock` property. You can always do this manually yourself if that's more to your taste or if you need to do something more specific:
 
 ```javascript
 // The mock function was called at least once

--- a/website/versioned_docs/version-24.0/MockFunctions.md
+++ b/website/versioned_docs/version-24.0/MockFunctions.md
@@ -4,7 +4,7 @@ title: Mock Functions
 original_id: mock-functions
 ---
 
-Mock functions make it easy to test the links between code by erasing the actual implementation of a function, capturing calls to the function (and the parameters passed in those calls), capturing instances of constructor functions when instantiated with `new`, and allowing test-time configuration of return values.
+Mock functions allow you to test the links between code by erasing the actual implementation of a function, capturing calls to the function (and the parameters passed in those calls), capturing instances of constructor functions when instantiated with `new`, and allowing test-time configuration of return values.
 
 There are two ways to mock functions: Either by creating a mock function to use in test code, or writing a [`manual mock`](ManualMocks.md) to override a module dependency.
 
@@ -241,7 +241,7 @@ const myMockFn = jest
 
 ## Custom Matchers
 
-Finally, in order to make it simpler to assert how mock functions have been called, we've added some custom matcher functions for you:
+Finally, in order to make it less demanding to assert how mock functions have been called, we've added some custom matcher functions for you:
 
 ```javascript
 // The mock function was called at least once

--- a/website/versioned_docs/version-24.0/SnapshotTesting.md
+++ b/website/versioned_docs/version-24.0/SnapshotTesting.md
@@ -40,7 +40,7 @@ exports[`renders correctly 1`] = `
 `;
 ```
 
-The snapshot artifact should be committed alongside code changes, and reviewed as part of your code review process. Jest uses [pretty-format](https://github.com/facebook/jest/tree/master/packages/pretty-format) to make snapshots human-readable during code review. On subsequent test runs Jest will simply compare the rendered output with the previous snapshot. If they match, the test will pass. If they don't match, either the test runner found a bug in your code (in this case, it's `<Link>` component) that should be fixed, or the implementation has changed and the snapshot needs to be updated.
+The snapshot artifact should be committed alongside code changes, and reviewed as part of your code review process. Jest uses [pretty-format](https://github.com/facebook/jest/tree/master/packages/pretty-format) to make snapshots human-readable during code review. On subsequent test runs Jest will compare the rendered output with the previous snapshot. If they match, the test will pass. If they don't match, either the test runner found a bug in your code (in this case, it's `<Link>` component) that should be fixed, or the implementation has changed and the snapshot needs to be updated.
 
 > Note: The snapshot is directly scoped to the data you render – in our example it's `<Link />` component with page prop passed to it. This implies that even if any other file has missing props (Say, `App.js`) in the `<Link />` component, it will still pass the test as the test doesn't know the usage of `<Link />` component and it's scoped only to the `Link.react.js`. Also, Rendering the same component with different props in other snapshot tests will not affect the first one, as the tests don't know about each other.
 
@@ -226,7 +226,7 @@ Ensure that your snapshots are readable by keeping them focused, short, and by u
 
 As mentioned previously, Jest uses [`pretty-format`](https://yarnpkg.com/en/package/pretty-format) to make snapshots human-readable, but you may find it useful to introduce additional tools, like [`eslint-plugin-jest`](https://yarnpkg.com/en/package/eslint-plugin-jest) with its [`no-large-snapshots`](https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/no-large-snapshots.md) option, or [`snapshot-diff`](https://yarnpkg.com/en/package/snapshot-diff) with its component snapshot comparison feature, to promote committing short, focused assertions.
 
-The goal is to make it easy to review snapshots in pull requests, and fight against the habit of simply regenerating snapshots when test suites fail instead of examining the root causes of their failure.
+The goal is to make it easy to review snapshots in pull requests, and fight against the habit of regenerating snapshots when test suites fail instead of examining the root causes of their failure.
 
 ### 2. Tests should be deterministic
 
@@ -316,4 +316,4 @@ Although it is possible to write snapshot files manually, that is usually not ap
 
 ### Does code coverage work with snapshot testing?
 
-Yes, just like with any other test.
+Yes, as well as with any other test.

--- a/website/versioned_docs/version-24.0/SnapshotTesting.md
+++ b/website/versioned_docs/version-24.0/SnapshotTesting.md
@@ -10,7 +10,7 @@ A typical snapshot test case for a mobile app renders a UI component, takes a sn
 
 ## Snapshot Testing with Jest
 
-A similar approach can be taken when it comes to testing your React components. Instead of rendering the graphical UI, which would require building the entire app, you can use a test renderer to quickly generate a serializable value for your React tree. Consider this [example test](https://github.com/facebook/jest/blob/master/examples/snapshot/__tests__/link.react.test.js) for a simple [Link component](https://github.com/facebook/jest/blob/master/examples/snapshot/Link.react.js):
+A similar approach can be taken when it comes to testing your React components. Instead of rendering the graphical UI, which would require building the entire app, you can use a test renderer to quickly generate a serializable value for your React tree. Consider this [example test](https://github.com/facebook/jest/blob/master/examples/snapshot/__tests__/link.react.test.js) for a [Link component](https://github.com/facebook/jest/blob/master/examples/snapshot/Link.react.js):
 
 ```javascript
 import React from 'react';
@@ -268,7 +268,7 @@ exports[`<UserName /> should render Alan Turing`] = `
 `;
 ```
 
-Since the later describes exactly what's expected in the output, it's easy to see when it's wrong:
+Since the later describes exactly what's expected in the output, it's more clear to see when it's wrong:
 
 ```js
 exports[`<UserName /> should render null`] = `

--- a/website/versioned_docs/version-24.0/TestingAsyncCode.md
+++ b/website/versioned_docs/version-24.0/TestingAsyncCode.md
@@ -44,7 +44,7 @@ If `done()` is never called, the test will fail, which is what you want to happe
 
 ## Promises
 
-If your code uses promises, there is a simpler way to handle asynchronous tests. Return a promise from your test, and Jest will wait for that promise to resolve. If the promise is rejected, the test will automatically fail.
+If your code uses promises, there is a more straightforward way to handle asynchronous tests. Return a promise from your test, and Jest will wait for that promise to resolve. If the promise is rejected, the test will automatically fail.
 
 For example, let's say that `fetchData`, instead of using a callback, returns a promise that is supposed to resolve to the string `'peanut butter'`. We could test it with:
 
@@ -107,7 +107,7 @@ test('the fetch fails with an error', async () => {
 });
 ```
 
-Of course, you can combine `async` and `await` with `.resolves` or `.rejects`.
+You can combine `async` and `await` with `.resolves` or `.rejects`.
 
 ```js
 test('the data is peanut butter', async () => {
@@ -121,4 +121,4 @@ test('the fetch fails with an error', async () => {
 
 In these cases, `async` and `await` are effectively syntactic sugar for the same logic as the promises example uses.
 
-None of these forms is particularly superior to the others, and you can mix and match them across a codebase or even in a single file. It just depends on which style makes your tests simpler.
+None of these forms is particularly superior to the others, and you can mix and match them across a codebase or even in a single file. It just depends on which style you feel makes your tests simpler.

--- a/website/versioned_docs/version-24.0/TestingAsyncCode.md
+++ b/website/versioned_docs/version-24.0/TestingAsyncCode.md
@@ -10,7 +10,7 @@ It's common in JavaScript for code to run asynchronously. When you have code tha
 
 The most common asynchronous pattern is callbacks.
 
-For example, let's say that you have a `fetchData(callback)` function that fetches some data and calls `callback(data)` when it is complete. You want to test that this returned data is just the string `'peanut butter'`.
+For example, let's say that you have a `fetchData(callback)` function that fetches some data and calls `callback(data)` when it is complete. You want to test that this returned data is the string `'peanut butter'`.
 
 By default, Jest tests complete once they reach the end of their execution. That means this test will _not_ work as intended:
 
@@ -44,7 +44,7 @@ If `done()` is never called, the test will fail, which is what you want to happe
 
 ## Promises
 
-If your code uses promises, there is a simpler way to handle asynchronous tests. Just return a promise from your test, and Jest will wait for that promise to resolve. If the promise is rejected, the test will automatically fail.
+If your code uses promises, there is a simpler way to handle asynchronous tests. Return a promise from your test, and Jest will wait for that promise to resolve. If the promise is rejected, the test will automatically fail.
 
 For example, let's say that `fetchData`, instead of using a callback, returns a promise that is supposed to resolve to the string `'peanut butter'`. We could test it with:
 
@@ -89,7 +89,7 @@ test('the fetch fails with an error', () => {
 
 ## Async/Await
 
-Alternatively, you can use `async` and `await` in your tests. To write an async test, just use the `async` keyword in front of the function passed to `test`. For example, the same `fetchData` scenario can be tested with:
+Alternatively, you can use `async` and `await` in your tests. To write an async test, use the `async` keyword in front of the function passed to `test`. For example, the same `fetchData` scenario can be tested with:
 
 ```js
 test('the data is peanut butter', async () => {
@@ -119,6 +119,6 @@ test('the fetch fails with an error', async () => {
 });
 ```
 
-In these cases, `async` and `await` are effectively just syntactic sugar for the same logic as the promises example uses.
+In these cases, `async` and `await` are effectively syntactic sugar for the same logic as the promises example uses.
 
 None of these forms is particularly superior to the others, and you can mix and match them across a codebase or even in a single file. It just depends on which style makes your tests simpler.

--- a/website/versioned_docs/version-24.0/Troubleshooting.md
+++ b/website/versioned_docs/version-24.0/Troubleshooting.md
@@ -20,9 +20,9 @@ node --inspect-brk ./node_modules/jest/bin/jest.js --runInBand [any other argume
 
 This will run Jest in a Node process that an external debugger can connect to. Note that the process will pause until the debugger has connected to it.
 
-To debug in Google Chrome (or any Chromium-based browser), simply open your browser and go to `chrome://inspect` and click on "Open Dedicated DevTools for Node", which will give you a list of available node instances you can connect to. Simply click on the address displayed in the terminal (usually something like `localhost:9229`) after running the above command, and you will be able to debug Jest using Chrome's DevTools.
+To debug in Google Chrome (or any Chromium-based browser), open your browser and go to `chrome://inspect` and click on "Open Dedicated DevTools for Node", which will give you a list of available node instances you can connect to. Click on the address displayed in the terminal (usually something like `localhost:9229`) after running the above command, and you will be able to debug Jest using Chrome's DevTools.
 
-The Chrome Developer Tools will be displayed, and a breakpoint will be set at the first line of the Jest CLI script (this is done simply to give you time to open the developer tools and to prevent Jest from executing before you have time to do so). Click the button that looks like a "play" button in the upper right hand side of the screen to continue execution. When Jest executes the test that contains the `debugger` statement, execution will pause and you can examine the current scope and call stack.
+The Chrome Developer Tools will be displayed, and a breakpoint will be set at the first line of the Jest CLI script (this is done to give you time to open the developer tools and to prevent Jest from executing before you have time to do so). Click the button that looks like a "play" button in the upper right hand side of the screen to continue execution. When Jest executes the test that contains the `debugger` statement, execution will pause and you can examine the current scope and call stack.
 
 > Note: the `--runInBand` cli option makes sure Jest runs test in the same process rather than spawning processes for individual tests. Normally Jest parallelizes test runs across processes but it is hard to debug many processes at the same time.
 

--- a/website/versioned_docs/version-24.0/TutorialAsync.md
+++ b/website/versioned_docs/version-24.0/TutorialAsync.md
@@ -6,7 +6,7 @@ original_id: tutorial-async
 
 First, enable Babel support in Jest as documented in the [Getting Started](GettingStarted.md#using-babel) guide.
 
-Let's implement a simple module that fetches user data from an API and returns the user name.
+Let's implement a module that fetches user data from an API and returns the user name.
 
 ```js
 // user.js
@@ -92,7 +92,7 @@ it('works with resolves', () => {
 
 ## `async`/`await`
 
-Writing tests using the `async`/`await` syntax is easy. Here is how you'd write the same examples from before:
+Writing tests using the `async`/`await` syntax is less complicated than you might expect. Here is how you'd write the same examples from before:
 
 ```js
 // async/await can be used.

--- a/website/versioned_docs/version-24.0/TutorialReact.md
+++ b/website/versioned_docs/version-24.0/TutorialReact.md
@@ -215,7 +215,7 @@ If you'd like to assert, and manipulate your rendered components you can use [re
 
 You have to run `yarn add --dev @testing-library/react` to use react-testing-library.
 
-Let's implement a simple checkbox which swaps between two labels:
+Let's implement a checkbox which swaps between two labels:
 
 ```javascript
 // CheckboxWithLabel.js

--- a/website/versioned_docs/version-24.0/TutorialReact.md
+++ b/website/versioned_docs/version-24.0/TutorialReact.md
@@ -10,7 +10,7 @@ At Facebook, we use Jest to test [React](http://facebook.github.io/react/) appli
 
 ### Setup with Create React App
 
-If you are just getting started with React, we recommend using [Create React App](https://github.com/facebookincubator/create-react-app). It is ready to use and [ships with Jest](https://github.com/facebookincubator/create-react-app)! You will only need to add `react-test-renderer` for rendering snapshots.
+If you are new to React, we recommend using [Create React App](https://github.com/facebookincubator/create-react-app). It is ready to use and [ships with Jest](https://github.com/facebookincubator/create-react-app)! You will only need to add `react-test-renderer` for rendering snapshots.
 
 Run
 

--- a/website/versioned_docs/version-24.0/TutorialReactNative.md
+++ b/website/versioned_docs/version-24.0/TutorialReactNative.md
@@ -24,7 +24,7 @@ Starting from react-native version 0.38, a Jest setup is included by default whe
 
 _Note: If you are upgrading your react-native application and previously used the `jest-react-native` preset, remove the dependency from your `package.json` file and change the preset to `react-native` instead._
 
-Simply run `yarn test` to run tests with Jest.
+Run `yarn test` to run tests with Jest.
 
 ## Snapshot Test
 

--- a/website/versioned_docs/version-24.0/Webpack.md
+++ b/website/versioned_docs/version-24.0/Webpack.md
@@ -170,7 +170,7 @@ Similarly webpack's `resolve.root` option functions like setting the `NODE_PATH`
 }
 ```
 
-And finally we just have the webpack `alias` left to handle. For that we can make use of the `moduleNameMapper` option again.
+And finally, we have to handle the webpack `alias`. For that we can make use of the `moduleNameMapper` option again.
 
 ```json
 // package.json

--- a/website/versioned_docs/version-24.1/Configuration.md
+++ b/website/versioned_docs/version-24.1/Configuration.md
@@ -87,7 +87,7 @@ test('if utils mocked automatically', () => {
   expect(utils.isAuthorized.mock).toBeTruthy();
 
   // You can provide them with your own implementation
-  // or just pass the expected return value
+  // or pass the expected return value
   utils.authorize.mockReturnValue('mocked_token');
   utils.isAuthorized.mockReturnValue(true);
 

--- a/website/versioned_docs/version-24.6/Configuration.md
+++ b/website/versioned_docs/version-24.6/Configuration.md
@@ -87,7 +87,7 @@ test('if utils mocked automatically', () => {
   expect(utils.isAuthorized.mock).toBeTruthy();
 
   // You can provide them with your own implementation
-  // or just pass the expected return value
+  // or pass the expected return value
   utils.authorize.mockReturnValue('mocked_token');
   utils.isAuthorized.mockReturnValue(true);
 

--- a/website/versioned_docs/version-24.6/GettingStarted.md
+++ b/website/versioned_docs/version-24.6/GettingStarted.md
@@ -176,4 +176,4 @@ module.exports = {
 };
 ```
 
-However, there are some [caveats](https://babeljs.io/docs/en/next/babel-plugin-transform-typescript.html#caveats) to using TypeScript with Babel. Because TypeScript support in Babel is just transpilation, Jest will not type-check your tests as they are ran. If you want that, you can use [ts-jest](https://github.com/kulshekhar/ts-jest).
+However, there are some [caveats](https://babeljs.io/docs/en/next/babel-plugin-transform-typescript.html#caveats) to using TypeScript with Babel. Because TypeScript support in Babel is transpilation, Jest will not type-check your tests as they are ran. If you want that, you can use [ts-jest](https://github.com/kulshekhar/ts-jest).

--- a/website/versioned_docs/version-24.6/MigrationGuide.md
+++ b/website/versioned_docs/version-24.6/MigrationGuide.md
@@ -6,7 +6,7 @@ original_id: migration-guide
 
 If you'd like to try out Jest with an existing codebase, there are a number of ways to convert to Jest:
 
-- If you are using Jasmine, or a Jasmine like API (for example [Mocha](https://mochajs.org)), Jest should be mostly compatible and easy to migrate to.
+- If you are using Jasmine, or a Jasmine like API (for example [Mocha](https://mochajs.org)), Jest should be mostly compatible, which makes it less complicated to migrate to.
 - If you are using AVA, Expect.js (by Automattic), Jasmine, Mocha, proxyquire, Should.js or Tape you can automatically migrate with Jest Codemods (see below).
 - If you like [chai](http://chaijs.com/), you can upgrade to Jest and continue using chai. However, we recommend trying out Jest's assertions and their failure messages. Jest Codemods can migrate from chai (see below).
 

--- a/website/versioned_docs/version-24.8/Configuration.md
+++ b/website/versioned_docs/version-24.8/Configuration.md
@@ -87,7 +87,7 @@ test('if utils mocked automatically', () => {
   expect(utils.isAuthorized.mock).toBeTruthy();
 
   // You can provide them with your own implementation
-  // or just pass the expected return value
+  // or pass the expected return value
   utils.authorize.mockReturnValue('mocked_token');
   utils.isAuthorized.mockReturnValue(true);
 

--- a/website/versioned_docs/version-24.8/ExpectAPI.md
+++ b/website/versioned_docs/version-24.8/ExpectAPI.md
@@ -208,7 +208,7 @@ When an assertion fails, the error message should give as much signal as necessa
 
 To use snapshot testing inside of your custom matcher you can import `jest-snapshot` and use it from within your matcher.
 
-Here's a simple snapshot matcher that trims a string to store for a given length, `.toMatchTrimmedSnapshot(length)`:
+Here's a snapshot matcher that trims a string to store for a given length, `.toMatchTrimmedSnapshot(length)`:
 
 ```js
 const {toMatchSnapshot} = require('jest-snapshot');
@@ -799,7 +799,7 @@ const houseForSale = {
 };
 
 test('this house has my desired features', () => {
-  // Simple Referencing
+  // Example Referencing
   expect(houseForSale).toHaveProperty('bath');
   expect(houseForSale).toHaveProperty('bedrooms', 4);
 
@@ -835,7 +835,7 @@ test('this house has my desired features', () => {
 Using exact equality with floating point numbers is a bad idea. Rounding means that intuitive things fail. For example, this test fails:
 
 ```js
-test('adding works sanely with simple decimals', () => {
+test('adding works sanely with decimals', () => {
   expect(0.2 + 0.1).toBe(0.3); // Fails!
 });
 ```
@@ -845,7 +845,7 @@ It fails because in JavaScript, `0.2 + 0.1` is actually `0.30000000000000004`. S
 Instead, use `.toBeCloseTo`. Use `numDigits` to control how many digits after the decimal point to check. For example, if you want to be sure that `0.2 + 0.1` is equal to `0.3` with a precision of 5 decimal digits, you can use this test:
 
 ```js
-test('adding works sanely with simple decimals', () => {
+test('adding works sanely with decimals', () => {
   expect(0.2 + 0.1).toBeCloseTo(0.3, 5);
 });
 ```

--- a/website/versioned_docs/version-24.8/ExpectAPI.md
+++ b/website/versioned_docs/version-24.8/ExpectAPI.md
@@ -854,7 +854,7 @@ The optional `numDigits` argument has default value `2` which means the criterio
 
 ### `.toBeDefined()`
 
-Use `.toBeDefined` to check that a variable is not undefined. For example, if you just want to check that a function `fetchNewFlavorIdea()` returns _something_, you can write:
+Use `.toBeDefined` to check that a variable is not undefined. For example, if you want to check that a function `fetchNewFlavorIdea()` returns _something_, you can write:
 
 ```js
 test('there is a new flavor idea', () => {
@@ -866,7 +866,7 @@ You could write `expect(fetchNewFlavorIdea()).not.toBe(undefined)`, but it's bet
 
 ### `.toBeFalsy()`
 
-Use `.toBeFalsy` when you don't care what a value is, you just want to ensure a value is false in a boolean context. For example, let's say you have some application code that looks like:
+Use `.toBeFalsy` when you don't care what a value is and you want to ensure a value is false in a boolean context. For example, let's say you have some application code that looks like:
 
 ```js
 drinkSomeLaCroix();
@@ -954,7 +954,7 @@ test('bloop returns null', () => {
 
 ### `.toBeTruthy()`
 
-Use `.toBeTruthy` when you don't care what a value is, you just want to ensure a value is true in a boolean context. For example, let's say you have some application code that looks like:
+Use `.toBeTruthy` when you don't care what a value is and you want to ensure a value is true in a boolean context. For example, let's say you have some application code that looks like:
 
 ```js
 drinkSomeLaCroix();
@@ -963,7 +963,7 @@ if (thirstInfo()) {
 }
 ```
 
-You may not care what `thirstInfo` returns, specifically - it might return `true` or a complex object, and your code would still work. So if you just want to test that `thirstInfo` will be truthy after drinking some La Croix, you could write:
+You may not care what `thirstInfo` returns, specifically - it might return `true` or a complex object, and your code would still work. So if you want to test that `thirstInfo` will be truthy after drinking some La Croix, you could write:
 
 ```js
 test('drinking La Croix leads to having thirst info', () => {

--- a/website/versioned_docs/version-24.8/TutorialReact.md
+++ b/website/versioned_docs/version-24.8/TutorialReact.md
@@ -10,7 +10,7 @@ At Facebook, we use Jest to test [React](http://facebook.github.io/react/) appli
 
 ### Setup with Create React App
 
-If you are just getting started with React, we recommend using [Create React App](https://github.com/facebookincubator/create-react-app). It is ready to use and [ships with Jest](https://facebook.github.io/create-react-app/docs/running-tests#docsNav)! You will only need to add `react-test-renderer` for rendering snapshots.
+If you are new to React, we recommend using [Create React App](https://github.com/facebookincubator/create-react-app). It is ready to use and [ships with Jest](https://facebook.github.io/create-react-app/docs/running-tests#docsNav)! You will only need to add `react-test-renderer` for rendering snapshots.
 
 Run
 

--- a/website/versioned_docs/version-24.8/TutorialReact.md
+++ b/website/versioned_docs/version-24.8/TutorialReact.md
@@ -215,7 +215,7 @@ If you'd like to assert, and manipulate your rendered components you can use [re
 
 You have to run `yarn add --dev @testing-library/react` to use react-testing-library.
 
-Let's implement a simple checkbox which swaps between two labels:
+Let's implement a checkbox which swaps between two labels:
 
 ```javascript
 // CheckboxWithLabel.js

--- a/website/versioned_docs/version-24.8/Webpack.md
+++ b/website/versioned_docs/version-24.8/Webpack.md
@@ -170,7 +170,7 @@ Similarly webpack's `resolve.root` option functions like setting the `NODE_PATH`
 }
 ```
 
-And finally we just have the webpack `alias` left to handle. For that we can make use of the `moduleNameMapper` option again.
+And finally, we have to handle the webpack `alias`. For that we can make use of the `moduleNameMapper` option again.
 
 ```json
 // package.json

--- a/website/versioned_docs/version-24.9/Configuration.md
+++ b/website/versioned_docs/version-24.9/Configuration.md
@@ -87,7 +87,7 @@ test('if utils mocked automatically', () => {
   expect(utils.isAuthorized.mock).toBeTruthy();
 
   // You can provide them with your own implementation
-  // or just pass the expected return value
+  // or pass the expected return value
   utils.authorize.mockReturnValue('mocked_token');
   utils.isAuthorized.mockReturnValue(true);
 


### PR DESCRIPTION
Closes #9039 

## Summary

As discussed in the issue, this PR attempts to remove as many instances of condescending or isolating language (ie. simple, easy, just, of course, etc) as possible in the documentation. I updated all versions that were flagged in my search. While most of the changes are removing the word, some involved altering the text. 

Disclaimer: There are some parts of the altered text that I'm... less sure about 😂 so I'll leave it to your judgment. Feel free to revert or ask me to fix. If even a fraction of these changes can be merged then it will be a huge step towards making the documentation more inclusive!

## Test plan

Only word changes, so as long as the documentation still builds and renders - I'd say we're good 👐 
