### PR TITLE
[WIP] Replace deprecated findDOMNode call

### DIFF
--- a/examples/react/__tests__/CheckboxWithLabel-test.js
+++ b/examples/react/__tests__/CheckboxWithLabel-test.js
@@ -1,24 +1,24 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
 
-import React from 'react';
+import React, { useRef } from 'react';
 import ReactDOM from 'react-dom';
 import * as TestUtils from 'react-dom/test-utils';
 import CheckboxWithLabel from '../CheckboxWithLabel';
 
 it('CheckboxWithLabel changes the text after click', () => {
   // Render a checkbox with label in the document
+  const checkboxNodeRefRef = useRef(null);
+
   const checkbox = TestUtils.renderIntoDocument(
-    <CheckboxWithLabel labelOn="On" labelOff="Off" />
+    <CheckboxWithLabel ref={checkboxNodeRefRef} labelOn="On" labelOff="Off" />
   );
 
-  const checkboxNode = ReactDOM.findDOMNode(checkbox);
-
   // Verify that it's Off by default
-  expect(checkboxNode.textContent).toEqual('Off');
+  expect(checkboxNodeRef.current.textContent).toEqual('Off');
 
   // Simulate a click and verify that it is now On
   TestUtils.Simulate.change(
     TestUtils.findRenderedDOMComponentWithTag(checkbox, 'input')
   );
-  expect(checkboxNode.textContent).toEqual('On');
+  expect(checkboxNodeRef.current.textContent).toEqual('On');
 });

--- a/examples/react/__tests__/CheckboxWithLabel-test.js
+++ b/examples/react/__tests__/CheckboxWithLabel-test.js
@@ -1,16 +1,15 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
 
-import React, { useRef } from 'react';
-import ReactDOM from 'react-dom';
+import React, {useRef} from 'react';
 import * as TestUtils from 'react-dom/test-utils';
 import CheckboxWithLabel from '../CheckboxWithLabel';
 
 it('CheckboxWithLabel changes the text after click', () => {
   // Render a checkbox with label in the document
-  const checkboxNodeRefRef = useRef(null);
+  const checkboxNodeRef = useRef(null);
 
   const checkbox = TestUtils.renderIntoDocument(
-    <CheckboxWithLabel ref={checkboxNodeRefRef} labelOn="On" labelOff="Off" />
+    <CheckboxWithLabel ref={checkboxNodeRef} labelOn="On" labelOff="Off" />
   );
 
   // Verify that it's Off by default


### PR DESCRIPTION
## Summary

Closes #9043 by replacing the deprecated `.findDOMNode` call with the `useRef` React hook.