### PR TITLE
docs: Fix invalid Usage section for diff-sequences in README

### DIFF
--- a/packages/diff-sequences/README.md
+++ b/packages/diff-sequences/README.md
@@ -28,7 +28,7 @@ To add this package as a dependency of a project, do either of the following:
 
 To use `diff` as the name of the default export from this package, do either of the following:
 
-- `var diff = require('diff-sequences'); // CommonJS modules`
+- `var diff = require('diff-sequences').default; // CommonJS modules`
 - `import diff from 'diff-sequences'; // ECMAScript modules`
 
 Call `diff` with the **lengths** of sequences and your **callback** functions:


### PR DESCRIPTION
## Summary

It seems that the Usage section of README for `diff-sequences` is incorrect.

CommonJS users have to do `var diff = require('diff-sequences').default` in order to use `diff-sequences`. Not `var diff = require('diff-sequences')` as stated in the documentation.

## Test plan

Existing documentation of `diff-sequences` states the following:

> To use `diff` as the name of the default export from this package, do either of the following:
> - `var diff = require('diff-sequences'); // CommonJS modules`
> - `import diff from 'diff-sequences'; // ECMAScript modules`

Unfortunately the `require`-based version is not working as expected. Steps to reproduce:
```bash
mkdir repro
cd repro
npm init -y
npm i diff-sequences
echo "var diff = require('diff-sequences'); diff()" > main.js
node main.js # fails with error: diff is not a function
```

Side note: *The `import`-based version works perfectly well when using bundlers to deal with imports (eg.: rollup). It does not work with `--experimental-modules` of node but it seems to be expected as the package is packaged as cjs.*