### PR TITLE
Fix message badge display under Windows Terminal.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - `[jest-leak-detector]` [**BREAKING**] Use `weak-napi` instead of `weak` package ([#8686](https://github.com/facebook/jest/pull/8686))
 - `[jest-mock]` Fix for mockReturnValue overriding mockImplementationOnce ([#8398](https://github.com/facebook/jest/pull/8398))
 - `[jest-reporters]` Make node-notifer an optional dependency ([#8918](https://github.com/facebook/jest/pull/8918))
+- `[jest-reporters]` Fix message badge display under Windows Terminal ([#9057](https://github.com/facebook/jest/pull/9057/files))
 - `[jest-snapshot]` Remove only the added newlines in multiline snapshots ([#8859](https://github.com/facebook/jest/pull/8859))
 - `[jest-snapshot]` Distinguish empty string from external snapshot not written ([#8880](https://github.com/facebook/jest/pull/8880))
 - `[jest-snapshot]` [**BREAKING**] Distinguish empty string from internal snapshot not written ([#8898](https://github.com/facebook/jest/pull/8898))

--- a/packages/jest-reporters/src/Status.ts
+++ b/packages/jest-reporters/src/Status.ts
@@ -18,7 +18,7 @@ import {
 } from './utils';
 
 const RUNNING_TEXT = ' RUNS ';
-const RUNNING = chalk.reset.inverse.yellow.bold(RUNNING_TEXT) + ' ';
+const RUNNING = chalk.reset.inverse.yellowBright(RUNNING_TEXT) + ' ';
 
 /**
  * This class is a perf optimization for sorting the list of currently

--- a/packages/jest-reporters/src/get_result_header.ts
+++ b/packages/jest-reporters/src/get_result_header.ts
@@ -18,11 +18,11 @@ const FAIL_TEXT = 'FAIL';
 const PASS_TEXT = 'PASS';
 
 const FAIL = chalk.supportsColor
-  ? chalk.reset.inverse.bold.red(` ${FAIL_TEXT} `)
+  ? chalk.reset.inverse.redBright(` ${FAIL_TEXT} `)
   : FAIL_TEXT;
 
 const PASS = chalk.supportsColor
-  ? chalk.reset.inverse.bold.green(` ${PASS_TEXT} `)
+  ? chalk.reset.inverse.greenBright(` ${PASS_TEXT} `)
   : PASS_TEXT;
 
 export default (

--- a/scripts/buildUtils.js
+++ b/scripts/buildUtils.js
@@ -12,7 +12,7 @@ const stringLength = require('string-length');
 
 const PACKAGES_DIR = path.resolve(__dirname, '../packages');
 
-const OK = chalk.reset.inverse.bold.green(' DONE ');
+const OK = chalk.reset.inverse.greenBright(' DONE ');
 
 // Get absolute paths of all directories under packages/*
 module.exports.getPackages = function getPackages() {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

In Windows Terminal, current Jest badges does not correctly display due to the Chalk call it used: `chalk.reset.inverse.bold.<color>`, etc. See https://github.com/microsoft/terminal/issues/3201 for more detail.

This change changes the Chalk call to `chalk.reset.inverse.<color>Bright` to avoid this problem.

## Test plan

Run the `jest test` under Windows Terminal, and the ` PASS `/` FAIL ` badge should have black text rather than gray.