### PR TITLE
Don't fail the test suite when convert-source-map throws an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - `[jest-snapshot]` Distinguish empty string from external snapshot not written ([#8880](https://github.com/facebook/jest/pull/8880))
 - `[jest-snapshot]` [**BREAKING**] Distinguish empty string from internal snapshot not written ([#8898](https://github.com/facebook/jest/pull/8898))
 - `[jest-transform]` Properly cache transformed files across tests ([#8890](https://github.com/facebook/jest/pull/8890))
+- `[jest-transform]` Don't fail the test suite when convert-source-map throws an error ([#9058](https://github.com/facebook/jest/pull/9058))
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@
 - `[jest-snapshot]` Distinguish empty string from external snapshot not written ([#8880](https://github.com/facebook/jest/pull/8880))
 - `[jest-snapshot]` [**BREAKING**] Distinguish empty string from internal snapshot not written ([#8898](https://github.com/facebook/jest/pull/8898))
 - `[jest-transform]` Properly cache transformed files across tests ([#8890](https://github.com/facebook/jest/pull/8890))
-- `[jest-transform]` Don't fail the test suite when convert-source-map throws an error ([#9058](https://github.com/facebook/jest/pull/9058))
+- `[jest-transform]` Don't fail the test suite when a generated source map is invalid ([#9058](https://github.com/facebook/jest/pull/9058))
 
 ### Chore & Maintenance
 

--- a/packages/jest-transform/src/ScriptTransformer.ts
+++ b/packages/jest-transform/src/ScriptTransformer.ts
@@ -296,12 +296,16 @@ export default class ScriptTransformer {
     }
 
     if (!transformed.map) {
-      //Could be a potential freeze here.
-      //See: https://github.com/facebook/jest/pull/5177#discussion_r158883570
-      const inlineSourceMap = sourcemapFromSource(transformed.code);
+      try {
+        //Could be a potential freeze here.
+        //See: https://github.com/facebook/jest/pull/5177#discussion_r158883570
+        const inlineSourceMap = sourcemapFromSource(transformed.code);
 
-      if (inlineSourceMap) {
-        transformed.map = inlineSourceMap.toJSON();
+        if (inlineSourceMap) {
+          transformed.map = inlineSourceMap.toJSON();
+        }
+      } catch (e) {
+        // Error processing the source map; proceed as if it doesn't exist.
       }
     }
 

--- a/packages/jest-transform/src/ScriptTransformer.ts
+++ b/packages/jest-transform/src/ScriptTransformer.ts
@@ -305,7 +305,10 @@ export default class ScriptTransformer {
           transformed.map = inlineSourceMap.toJSON();
         }
       } catch (e) {
-        // Error processing the source map; proceed as if it doesn't exist.
+        console.warn(
+          `jest-transform: The source map produced for the file ${filename} ` +
+            'was invalid. Proceeding without source mapping for that file.',
+        );
       }
     }
 

--- a/packages/jest-transform/src/ScriptTransformer.ts
+++ b/packages/jest-transform/src/ScriptTransformer.ts
@@ -305,9 +305,11 @@ export default class ScriptTransformer {
           transformed.map = inlineSourceMap.toJSON();
         }
       } catch (e) {
+        const transformPath = this._getTransformPath(filename);
         console.warn(
           `jest-transform: The source map produced for the file ${filename} ` +
-            'was invalid. Proceeding without source mapping for that file.',
+            `by ${transformPath} was invalid. Proceeding without source ` +
+            'mapping for that file.',
         );
       }
     }

--- a/packages/jest-transform/src/__tests__/__snapshots__/script_transformer.test.js.snap
+++ b/packages/jest-transform/src/__tests__/__snapshots__/script_transformer.test.js.snap
@@ -254,3 +254,5 @@ exports[`ScriptTransformer uses the supplied preprocessor 2`] = `
 "({\\"Object.<anonymous>\\":function(module,exports,require,__dirname,__filename,global,jest){module.exports = \\"react\\";
 }});"
 `;
+
+exports[`ScriptTransformer warns of unparseable inlined source maps from the preprocessor 1`] = `"jest-transform: The source map produced for the file /fruits/banana.js by preprocessor-with-sourcemaps was invalid. Proceeding without source mapping for that file."`;

--- a/packages/jest-transform/src/__tests__/script_transformer.test.js
+++ b/packages/jest-transform/src/__tests__/script_transformer.test.js
@@ -459,7 +459,9 @@ describe('ScriptTransformer', () => {
     const content =
       'var x = 1;\n' +
       '//# sourceMappingURL=data:application/json;base64,' +
-      Buffer.from(sourceMap).toString('base64').slice(0, 16);
+      Buffer.from(sourceMap)
+        .toString('base64')
+        .slice(0, 16);
 
     require('preprocessor-with-sourcemaps').process.mockReturnValue(content);
 

--- a/packages/jest-transform/src/__tests__/script_transformer.test.js
+++ b/packages/jest-transform/src/__tests__/script_transformer.test.js
@@ -443,7 +443,10 @@ describe('ScriptTransformer', () => {
     );
   });
 
-  it('ignores the inlined source map from the preprocessor if parsing it fails', () => {
+  it('warns of unparseable inlined source maps from the preprocessor', () => {
+    const warn = console.warn;
+    console.warn = jest.fn();
+
     config = {
       ...config,
       transform: [['^.+\\.js$', 'preprocessor-with-sourcemaps']],
@@ -470,6 +473,10 @@ describe('ScriptTransformer', () => {
     });
     expect(result.sourceMapPath).toBeNull();
     expect(writeFileAtomic.sync).toBeCalledTimes(1);
+
+    expect(console.warn).toHaveBeenCalledTimes(1);
+    expect(console.warn.mock.calls[0][0]).toMatchSnapshot();
+    console.warn = warn;
   });
 
   it('writes source maps if given by the transformer', () => {


### PR DESCRIPTION
Fixes #8966.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

This prevents rare, non-deterministic errors of the following type (further described in #8966):
```
SyntaxError: Unexpected end of JSON input
        at JSON.parse (<anonymous>)

      at new Converter (../../node_modules/convert-source-map/index.js:50:48)
      at Object.exports.fromComment (../../node_modules/convert-source-map/index.js:106:10)
      at Object.exports.fromSource (../../node_modules/convert-source-map/index.js:116:22)
      at ScriptTransformer.transformSource (../../node_modules/@jest/transform/build/ScriptTransformer.js:468:61)
      at ScriptTransformer._transformAndBuildScript (../../node_modules/@jest/transform/build/ScriptTransformer.js:524:40)
      at ScriptTransformer.transform (../../node_modules/@jest/transform/build/ScriptTransformer.js:568:25)
```

The change treats cases in which the `convertSourceMap.fromSource` operation throws an exception as the same as if it had returned a falsy value; the code already handles the latter case.

## Test plan

This includes a unit test for ScriptTransformer. The test fails with `SyntaxError: Unexpected end of JSON input` when run without the new try-catch block; with the new change, the test passes.