### PR TITLE
chore: fix linting error on macOS

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -105,6 +105,7 @@ module.exports = {
         ],
       },
     ],
+    'import/no-unresolved': [2, {ignore: ['fsevents']}],
     // This has to be disabled until all type and module imports are combined
     // https://github.com/benmosher/eslint-plugin-import/issues/645
     'import/order': 0,

--- a/packages/jest-haste-map/src/lib/FSEventsWatcher.ts
+++ b/packages/jest-haste-map/src/lib/FSEventsWatcher.ts
@@ -11,7 +11,6 @@ import * as path from 'path';
 import {EventEmitter} from 'events';
 import anymatch, {Matcher} from 'anymatch';
 import micromatch = require('micromatch');
-// eslint-disable-next-line
 import {Watcher} from 'fsevents';
 // @ts-ignore no types
 import walker from 'walker';


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Related issue #9015
On macOS, the 'import/no-unresolved' rule doesn't throw an error when importing 'fsevents' module. Therefore it does not need to disable this rule, because eslint throws an error when `--report-unused-disable-directives` is used. In my opinion, the best way is to ignore `fsevents` import.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Linting without caching:
`eslint . --report-unused-disable-directives --ext js,jsx,ts,tsx,md`
