### PR TITLE
fix(pretty-format): Use symbol safely only when it's defined

### DIFF
--- a/packages/pretty-format/src/index.ts
+++ b/packages/pretty-format/src/index.ts
@@ -27,7 +27,12 @@ const toString = Object.prototype.toString;
 const toISOString = Date.prototype.toISOString;
 const errorToString = Error.prototype.toString;
 const regExpToString = RegExp.prototype.toString;
-const symbolToString = Symbol.prototype.toString;
+const symbolToString =
+  typeof Symbol === 'function'
+    ? Symbol.prototype.toString
+    : function(this: Symbol) {
+        return String(this);
+      };
 
 /**
  * Explicitly comparing typeof constructor to function avoids undefined as name

--- a/packages/pretty-format/src/index.ts
+++ b/packages/pretty-format/src/index.ts
@@ -30,7 +30,7 @@ const regExpToString = RegExp.prototype.toString;
 const symbolToString =
   typeof Symbol === 'function'
     ? Symbol.prototype.toString
-    : function(this: Symbol) {
+    : function(this: symbol) {
         return String(this);
       };
 

--- a/packages/pretty-format/src/index.ts
+++ b/packages/pretty-format/src/index.ts
@@ -27,12 +27,6 @@ const toString = Object.prototype.toString;
 const toISOString = Date.prototype.toISOString;
 const errorToString = Error.prototype.toString;
 const regExpToString = RegExp.prototype.toString;
-const symbolToString =
-  typeof Symbol === 'function'
-    ? Symbol.prototype.toString
-    : function(this: symbol) {
-        return String(this);
-      };
 
 /**
  * Explicitly comparing typeof constructor to function avoids undefined as name
@@ -89,7 +83,7 @@ function printFunction(val: Function, printFunctionName: boolean): string {
 }
 
 function printSymbol(val: symbol): string {
-  return symbolToString.call(val).replace(SYMBOL_REGEXP, 'Symbol($1)');
+  return String(val).replace(SYMBOL_REGEXP, 'Symbol($1)');
 }
 
 function printError(val: Error): string {

--- a/packages/pretty-format/src/plugins/AsymmetricMatcher.ts
+++ b/packages/pretty-format/src/plugins/AsymmetricMatcher.ts
@@ -9,7 +9,10 @@ import {Config, NewPlugin, Printer, Refs} from '../types';
 
 import {printListItems, printObjectProperties} from '../collections';
 
-const asymmetricMatcher = Symbol.for('jest.asymmetricMatcher');
+const asymmetricMatcher =
+  typeof Symbol === 'function' && Symbol.for
+    ? Symbol.for('jest.asymmetricMatcher')
+    : 0x1357a5;
 const SPACE = ' ';
 
 export const serialize = (

--- a/packages/pretty-format/src/plugins/ReactTestComponent.ts
+++ b/packages/pretty-format/src/plugins/ReactTestComponent.ts
@@ -24,7 +24,10 @@ import {
   printProps,
 } from './lib/markup';
 
-const testSymbol = Symbol.for('react.test.json');
+const testSymbol =
+  typeof Symbol === 'function' && Symbol.for
+    ? Symbol.for('react.test.json')
+    : 0xea71357;
 
 const getPropKeys = (object: ReactTestObject) => {
   const {props} = object;


### PR DESCRIPTION
## Summary

`Symbol` is not defined in es5 environments but accessed regardless. The approach is similar to reacts:

https://github.com/facebook/react/blob/5faf377df5267c4248599e14311a75c2f46050c0/packages/shared/ReactSymbols.js#L14-L16

We use `1357` for `jest`:
```js
1357
jest
``` 

## Test plan

I haven't looked much into the test setup. At a surface level this should already throw in an es5 environment (which is implied by e.g. `lint-es5-build`).