### PR TITLE
jest-diff: Rename some new options and change their default values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - `[expect]` Avoid incorrect difference for subset when `toMatchObject` fails ([#9005](https://github.com/facebook/jest/pull/9005))
 - `[jest-core]` Don't include unref'd timers in --detectOpenHandles results ([#8941](https://github.com/facebook/jest/pull/8941))
 - `[jest-diff]` Do not inverse format if line consists of one change ([#8903](https://github.com/facebook/jest/pull/8903))
+- `[jest-diff]` Rename some new options and change their default values ([#9077](https://github.com/facebook/jest/pull/9077))
 - `[jest-fake-timers]` `getTimerCount` will not include cancelled immediates ([#8764](https://github.com/facebook/jest/pull/8764))
 - `[jest-leak-detector]` [**BREAKING**] Use `weak-napi` instead of `weak` package ([#8686](https://github.com/facebook/jest/pull/8686))
 - `[jest-mock]` Fix for mockReturnValue overriding mockImplementationOnce ([#8398](https://github.com/facebook/jest/pull/8398))

--- a/packages/jest-diff/README.md
+++ b/packages/jest-diff/README.md
@@ -370,10 +370,10 @@ For other applications, you can provide an options object as a third argument:
 | `bColor`                          | `chalk.red`     |
 | `bIndicator`                      | `'+'`           |
 | `changeColor`                     | `chalk.inverse` |
-| `changeLineTrailingSpaceColor`    | `noColor`       |
+| `changeLineTrailingSpaceColor`    | `arg => arg`    |
 | `commonColor`                     | `chalk.dim`     |
 | `commonIndicator`                 | `' '`           |
-| `commonLineTrailingSpaceColor`    | `noColor`       |
+| `commonLineTrailingSpaceColor`    | `arg => arg`    |
 | `contextLines`                    | `5`             |
 | `emptyFirstOrLastLinePlaceholder` | `''`            |
 | `expand`                          | `true`          |
@@ -470,7 +470,7 @@ import {DiffOptionsColor} from 'jest-diff';
 To store the difference in a file without escape codes for colors, provide an identity function:
 
 ```js
-const noColor = string => string;
+const noColor = arg => arg;
 
 const options = {
   aColor: noColor,

--- a/packages/jest-diff/README.md
+++ b/packages/jest-diff/README.md
@@ -434,8 +434,8 @@ const options = {
 
 Because the default export does not display substring differences within lines, formatting can help you see when lines differ by the presence or absence of trailing spaces found by `/\s+$/` regular expression.
 
-* If change lines have a background color, then you can see trailing spaces.
-* If common lines have default dim color, then you cannot see trailing spaces. You might want yellowish background color to see them.
+- If change lines have a background color, then you can see trailing spaces.
+- If common lines have default dim color, then you cannot see trailing spaces. You might want yellowish background color to see them.
 
 ```js
 const options = {

--- a/packages/jest-diff/README.md
+++ b/packages/jest-diff/README.md
@@ -361,24 +361,25 @@ For other applications, you can provide an options object as a third argument:
 
 ### Properties of options object
 
-| name                              | default          |
-| :-------------------------------- | :--------------- |
-| `aAnnotation`                     | `'Expected'`     |
-| `aColor`                          | `chalk.green`    |
-| `aIndicator`                      | `'-'`            |
-| `bAnnotation`                     | `'Received'`     |
-| `bColor`                          | `chalk.red`      |
-| `bIndicator`                      | `'+'`            |
-| `changeColor`                     | `chalk.inverse`  |
-| `commonColor`                     | `chalk.dim`      |
-| `commonIndicator`                 | `' '`            |
-| `contextLines`                    | `5`              |
-| `expand`                          | `true`           |
-| `firstOrLastEmptyLineReplacement` | `'↵'`            |
-| `includeChangeCounts`             | `false`          |
-| `omitAnnotationLines`             | `false`          |
-| `patchColor`                      | `chalk.yellow`   |
-| `trailingSpaceFormatter`          | `chalk.bgYellow` |
+| name                              | default         |
+| :-------------------------------- | :-------------- |
+| `aAnnotation`                     | `'Expected'`    |
+| `aColor`                          | `chalk.green`   |
+| `aIndicator`                      | `'-'`           |
+| `bAnnotation`                     | `'Received'`    |
+| `bColor`                          | `chalk.red`     |
+| `bIndicator`                      | `'+'`           |
+| `changeColor`                     | `chalk.inverse` |
+| `changeLineTrailingSpaceColor`    | `noColor`       |
+| `commonColor`                     | `chalk.dim`     |
+| `commonIndicator`                 | `' '`           |
+| `commonLineTrailingSpaceColor`    | `noColor`       |
+| `contextLines`                    | `5`             |
+| `emptyFirstOrLastLinePlaceholder` | `''`            |
+| `expand`                          | `true`          |
+| `includeChangeCounts`             | `false`         |
+| `omitAnnotationLines`             | `false`         |
+| `patchColor`                      | `chalk.yellow`  |
 
 For more information about the options, see the following examples.
 
@@ -425,7 +426,7 @@ Although the default inverse of foreground and background colors is hard to beat
 import chalk from 'chalk';
 
 const options = {
-  changeColor: chalk.bold.bgAnsi256(226), // #ffff00
+  changeColor: chalk.bold.bgYellowBright,
 };
 ```
 
@@ -433,19 +434,38 @@ const options = {
 
 Because the default export does not display substring differences within lines, formatting can help you see when lines differ by the presence or absence of trailing spaces found by `/\s+$/` regular expression.
 
-The formatter is a function, which given a string, returns a string.
+If change lines have a background color, then you change see trailing spaces.
 
-If instead of yellowish background color, you want to replace trailing spaces with middle dot characters:
+If you want yellowish background color in common lines which have dim color:
 
 ```js
 const options = {
-  trailingSpaceFormatter: string => '·'.repeat(string.length),
+  aColor: chalk.hex('800080').bgHex('ffd7ff'), // magenta
+  bColor: chalk.hex('005f00').bgHex('d7ffd7'), // green
+  commonLineTrailingSpaceColor: chalk.bgYellow,
 };
 ```
 
-### Example of options for no colors
+The value of a Color option is a function, which given a string, returns a string.
 
-The value of a color or formatter option is a function, which given a string, returns a string.
+If you want to replace trailing spaces with middle dot characters:
+
+```js
+const replaceSpacesWithMiddleDot = string => '·'.repeat(string.length);
+
+const options = {
+  changeLineTrailingSpaceColor: replaceSpacesWithMiddleDot,
+  commonLineTrailingSpaceColor: replaceSpacesWithMiddleDot,
+};
+```
+
+If you need the TypeScript type of a Color option:
+
+```ts
+import {DiffOptionsColor} from 'jest-diff';
+```
+
+### Example of options for no colors
 
 To store the difference in a file without escape codes for colors, provide an identity function:
 
@@ -458,7 +478,6 @@ const options = {
   changeColor: noColor,
   commonColor: noColor,
   patchColor: noColor,
-  trailingSpaceFormatter: noColor,
 };
 ```
 
@@ -551,19 +570,19 @@ const difference = diffStringsUnified(a, b, options);
 + changed to
 ```
 
-### Example of option not to replace first or last empty lines
+### Example of option for empty first or last lines
 
 If the **first** or **last** comparison line is **empty**, because the content is empty and the indicator is a space, you might not notice it.
 
-Also, because Jest trims the report when a matcher fails, it deletes an empty last line.
+The replacement option is a string whose default value is `''` empty string.
 
-The replacement is a string whose default value is `'↵'` U+21B5 downwards arrow with corner leftwards.
+Because Jest trims the report when a matcher fails, it deletes an empty last line.
 
-To store the difference in a file without a replacement, because it could be ambiguous with the content of the arguments, provide an empty string:
+Therefore, Jest uses as placeholder the downwards arrow with corner leftwards:
 
 ```js
 const options = {
-  firstOrLastEmptyLineReplacement: '',
+  emptyFirstOrLastLinePlaceholder: '↵', // U+21B5
 };
 ```
 

--- a/packages/jest-diff/README.md
+++ b/packages/jest-diff/README.md
@@ -361,25 +361,25 @@ For other applications, you can provide an options object as a third argument:
 
 ### Properties of options object
 
-| name                              | default         |
-| :-------------------------------- | :-------------- |
-| `aAnnotation`                     | `'Expected'`    |
-| `aColor`                          | `chalk.green`   |
-| `aIndicator`                      | `'-'`           |
-| `bAnnotation`                     | `'Received'`    |
-| `bColor`                          | `chalk.red`     |
-| `bIndicator`                      | `'+'`           |
-| `changeColor`                     | `chalk.inverse` |
-| `changeLineTrailingSpaceColor`    | `arg => arg`    |
-| `commonColor`                     | `chalk.dim`     |
-| `commonIndicator`                 | `' '`           |
-| `commonLineTrailingSpaceColor`    | `arg => arg`    |
-| `contextLines`                    | `5`             |
-| `emptyFirstOrLastLinePlaceholder` | `''`            |
-| `expand`                          | `true`          |
-| `includeChangeCounts`             | `false`         |
-| `omitAnnotationLines`             | `false`         |
-| `patchColor`                      | `chalk.yellow`  |
+| name                              | default            |
+| :-------------------------------- | :----------------- |
+| `aAnnotation`                     | `'Expected'`       |
+| `aColor`                          | `chalk.green`      |
+| `aIndicator`                      | `'-'`              |
+| `bAnnotation`                     | `'Received'`       |
+| `bColor`                          | `chalk.red`        |
+| `bIndicator`                      | `'+'`              |
+| `changeColor`                     | `chalk.inverse`    |
+| `changeLineTrailingSpaceColor`    | `string => string` |
+| `commonColor`                     | `chalk.dim`        |
+| `commonIndicator`                 | `' '`              |
+| `commonLineTrailingSpaceColor`    | `string => string` |
+| `contextLines`                    | `5`                |
+| `emptyFirstOrLastLinePlaceholder` | `''`               |
+| `expand`                          | `true`             |
+| `includeChangeCounts`             | `false`            |
+| `omitAnnotationLines`             | `false`            |
+| `patchColor`                      | `chalk.yellow`     |
 
 For more information about the options, see the following examples.
 
@@ -469,7 +469,7 @@ import {DiffOptionsColor} from 'jest-diff';
 To store the difference in a file without escape codes for colors, provide an identity function:
 
 ```js
-const noColor = arg => arg;
+const noColor = string => string;
 
 const options = {
   aColor: noColor,

--- a/packages/jest-diff/README.md
+++ b/packages/jest-diff/README.md
@@ -439,8 +439,8 @@ Because the default export does not display substring differences within lines, 
 
 ```js
 const options = {
-  aColor: chalk.hex('800080').bgHex('ffd7ff'), // magenta
-  bColor: chalk.hex('005f00').bgHex('d7ffd7'), // green
+  aColor: chalk.rgb(128, 0, 128).bgRgb(255, 215, 255), // magenta
+  bColor: chalk.rgb(0, 95, 0).bgRgb(215, 255, 215), // green
   commonLineTrailingSpaceColor: chalk.bgYellow,
 };
 ```

--- a/packages/jest-diff/README.md
+++ b/packages/jest-diff/README.md
@@ -434,9 +434,8 @@ const options = {
 
 Because the default export does not display substring differences within lines, formatting can help you see when lines differ by the presence or absence of trailing spaces found by `/\s+$/` regular expression.
 
-If change lines have a background color, then you change see trailing spaces.
-
-If you want yellowish background color in common lines which have dim color:
+* If change lines have a background color, then you can see trailing spaces.
+* If common lines have default dim color, then you cannot see trailing spaces. You might want yellowish background color to see them.
 
 ```js
 const options = {

--- a/packages/jest-diff/src/__tests__/__snapshots__/diff.test.ts.snap
+++ b/packages/jest-diff/src/__tests__/__snapshots__/diff.test.ts.snap
@@ -363,15 +363,15 @@ exports[`options omitAnnotationLines true diffStringsUnified and includeChangeCo
 
 exports[`options omitAnnotationLines true diffStringsUnified empty strings 1`] = ``;
 
-exports[`options trailingSpaceFormatter diffDefault default yellowish 1`] = `
+exports[`options trailingSpaceFormatter diffDefault default no color 1`] = `
 <g>- Expected</>
 <r>+ Received</>
 
-<g>- delete 1 trailing space:<Y> </></>
+<g>- delete 1 trailing space: </>
 <r>+ delete 1 trailing space:</>
-<d>  common 2 trailing spaces:<Y>  </></>
+<d>  common 2 trailing spaces:  </>
 <g>- insert 1 trailing space:</>
-<r>+ insert 1 trailing space:<Y> </></>
+<r>+ insert 1 trailing space: </>
 `;
 
 exports[`options trailingSpaceFormatter diffDefault middle dot 1`] = `
@@ -383,4 +383,15 @@ exports[`options trailingSpaceFormatter diffDefault middle dot 1`] = `
 <d>  common 2 trailing spaces:··</>
 <g>- insert 1 trailing space:</>
 <r>+ insert 1 trailing space:·</>
+`;
+
+exports[`options trailingSpaceFormatter diffDefault yellowish 1`] = `
+<g>- Expected</>
+<r>+ Received</>
+
+<g>- delete 1 trailing space:<Y> </></>
+<r>+ delete 1 trailing space:</>
+<d>  common 2 trailing spaces:<Y>  </></>
+<g>- insert 1 trailing space:</>
+<r>+ insert 1 trailing space:<Y> </></>
 `;

--- a/packages/jest-diff/src/__tests__/__snapshots__/diff.test.ts.snap
+++ b/packages/jest-diff/src/__tests__/__snapshots__/diff.test.ts.snap
@@ -385,13 +385,13 @@ exports[`options trailingSpaceFormatter diffDefault middle dot 1`] = `
 <r>+ insert 1 trailing space:·</>
 `;
 
-exports[`options trailingSpaceFormatter diffDefault yellowish 1`] = `
+exports[`options trailingSpaceFormatter diffDefault yellowish common 1`] = `
 <g>- Expected</>
 <r>+ Received</>
 
-<g>- delete 1 trailing space:<Y> </></>
+<g>- delete 1 trailing space: </>
 <r>+ delete 1 trailing space:</>
 <d>  common 2 trailing spaces:<Y>  </></>
 <g>- insert 1 trailing space:</>
-<r>+ insert 1 trailing space:<Y> </></>
+<r>+ insert 1 trailing space: </>
 `;

--- a/packages/jest-diff/src/__tests__/diff.test.ts
+++ b/packages/jest-diff/src/__tests__/diff.test.ts
@@ -919,9 +919,8 @@ describe('options', () => {
       expect(diff(aTrailingSpaces, bTrailingSpaces, options)).toMatchSnapshot();
     });
 
-    test('diffDefault yellowish', () => {
+    test('diffDefault yellowish common', () => {
       const options = {
-        changeLineTrailingSpaceColor: chalk.bgYellow,
         commonLineTrailingSpaceColor: chalk.bgYellow,
       };
 

--- a/packages/jest-diff/src/__tests__/diff.test.ts
+++ b/packages/jest-diff/src/__tests__/diff.test.ts
@@ -10,6 +10,7 @@ import stripAnsi from 'strip-ansi';
 import {alignedAnsiStyleSerializer} from '@jest/test-utils';
 
 import diff from '../';
+import {noColor} from '../normalizeDiffOptions';
 import {diffStringsUnified} from '../printDiffs';
 import {DiffOptions} from '../types';
 
@@ -23,7 +24,6 @@ const NO_DIFF_MESSAGE = 'Compared values have no visual difference.';
 const stripped = (a: unknown, b: unknown) => stripAnsi(diff(a, b) || '');
 
 // Use in toBe assertions for comparison lines.
-const noColor = (string: string) => string;
 const optionsBe: DiffOptions = {
   aColor: noColor,
   bColor: noColor,
@@ -905,13 +905,24 @@ describe('options', () => {
       'insert 1 trailing space: ',
     ].join('\n');
 
-    test('diffDefault default yellowish', () => {
+    test('diffDefault default no color', () => {
       expect(diff(aTrailingSpaces, bTrailingSpaces)).toMatchSnapshot();
     });
 
     test('diffDefault middle dot', () => {
+      const replaceSpacesWithMiddleDot = string => '·'.repeat(string.length);
       const options = {
-        trailingSpaceFormatter: string => '·'.repeat(string.length),
+        changeLineTrailingSpaceColor: replaceSpacesWithMiddleDot,
+        commonLineTrailingSpaceColor: replaceSpacesWithMiddleDot,
+      };
+
+      expect(diff(aTrailingSpaces, bTrailingSpaces, options)).toMatchSnapshot();
+    });
+
+    test('diffDefault yellowish', () => {
+      const options = {
+        changeLineTrailingSpaceColor: chalk.bgYellow,
+        commonLineTrailingSpaceColor: chalk.bgYellow,
       };
 
       expect(diff(aTrailingSpaces, bTrailingSpaces, options)).toMatchSnapshot();

--- a/packages/jest-diff/src/__tests__/joinAlignedDiffs.test.ts
+++ b/packages/jest-diff/src/__tests__/joinAlignedDiffs.test.ts
@@ -10,19 +10,19 @@ import {
   joinAlignedDiffsExpand,
   joinAlignedDiffsNoExpand,
 } from '../joinAlignedDiffs';
-import {normalizeDiffOptions} from '../normalizeDiffOptions';
+import {noColor, normalizeDiffOptions} from '../normalizeDiffOptions';
 
 // To align columns so people can review snapshots confidently:
 
 // 1. Use options to omit line colors.
-const identity = (string: string) => string;
 const changeColor = (string: string) => '<i>' + string + '</i>';
 const optionsNoColor = {
-  aColor: identity,
-  bColor: identity,
+  aColor: noColor,
+  bColor: noColor,
   changeColor,
-  commonColor: identity,
-  patchColor: identity,
+  commonColor: noColor,
+  emptyFirstOrLastLinePlaceholder: '↵', // U+21B5
+  patchColor: noColor,
 };
 
 // 2. Add string serializer to omit double quote marks.

--- a/packages/jest-diff/src/index.ts
+++ b/packages/jest-diff/src/index.ts
@@ -12,9 +12,13 @@ import {DIFF_DELETE, DIFF_EQUAL, DIFF_INSERT, Diff} from './cleanupSemantic';
 import {diffLinesRaw, diffLinesUnified, diffLinesUnified2} from './diffLines';
 import {diffStringsRaw, diffStringsUnified, splitLines0} from './printDiffs';
 import {NO_DIFF_MESSAGE, SIMILAR_MESSAGE} from './constants';
-import {DiffOptions as ImportDiffOptions} from './types';
+import {
+  DiffOptions as ImportDiffOptions,
+  DiffOptionsColor as ImportDiffOptionsColor,
+} from './types';
 
 export type DiffOptions = ImportDiffOptions;
+export type DiffOptionsColor = ImportDiffOptionsColor;
 
 export {diffLinesRaw, diffLinesUnified, diffLinesUnified2};
 export {diffStringsRaw, diffStringsUnified, splitLines0};

--- a/packages/jest-diff/src/normalizeDiffOptions.ts
+++ b/packages/jest-diff/src/normalizeDiffOptions.ts
@@ -9,6 +9,8 @@ import chalk from 'chalk';
 
 import {DiffOptions, DiffOptionsNormalized} from './types';
 
+export const noColor = (string: string) => string;
+
 const DIFF_CONTEXT_DEFAULT = 5;
 
 const OPTIONS_DEFAULT: DiffOptionsNormalized = {
@@ -19,15 +21,16 @@ const OPTIONS_DEFAULT: DiffOptionsNormalized = {
   bColor: chalk.red,
   bIndicator: '+',
   changeColor: chalk.inverse,
+  changeLineTrailingSpaceColor: noColor,
   commonColor: chalk.dim,
   commonIndicator: ' ',
+  commonLineTrailingSpaceColor: noColor,
   contextLines: DIFF_CONTEXT_DEFAULT,
+  emptyFirstOrLastLinePlaceholder: '',
   expand: true,
-  firstOrLastEmptyLineReplacement: '\u{21B5}', // downwards arrow with corner leftwards
   includeChangeCounts: false,
   omitAnnotationLines: false,
   patchColor: chalk.yellow,
-  trailingSpaceFormatter: chalk.bgYellow,
 };
 
 const getContextLines = (contextLines?: number): number =>

--- a/packages/jest-diff/src/printDiffs.ts
+++ b/packages/jest-diff/src/printDiffs.ts
@@ -32,8 +32,8 @@ const printDiffLine = (
   isFirstOrLast: boolean,
   color: DiffOptionsColor,
   indicator: string,
-  emptyFirstOrLastLinePlaceholder: string,
   trailingSpaceFormatter: DiffOptionsColor,
+  emptyFirstOrLastLinePlaceholder: string,
 ): string =>
   line.length !== 0
     ? color(
@@ -60,8 +60,8 @@ export const printDeleteLine = (
     isFirstOrLast,
     aColor,
     aIndicator,
-    emptyFirstOrLastLinePlaceholder,
     changeLineTrailingSpaceColor,
+    emptyFirstOrLastLinePlaceholder,
   );
 
 export const printInsertLine = (
@@ -79,8 +79,8 @@ export const printInsertLine = (
     isFirstOrLast,
     bColor,
     bIndicator,
-    emptyFirstOrLastLinePlaceholder,
     changeLineTrailingSpaceColor,
+    emptyFirstOrLastLinePlaceholder,
   );
 
 export const printCommonLine = (
@@ -98,8 +98,8 @@ export const printCommonLine = (
     isFirstOrLast,
     commonColor,
     commonIndicator,
-    emptyFirstOrLastLinePlaceholder,
     commonLineTrailingSpaceColor,
+    emptyFirstOrLastLinePlaceholder,
   );
 
 export const hasCommonDiff = (diffs: Array<Diff>, isMultiline: boolean) => {

--- a/packages/jest-diff/src/printDiffs.ts
+++ b/packages/jest-diff/src/printDiffs.ts
@@ -32,7 +32,7 @@ const printDiffLine = (
   isFirstOrLast: boolean,
   color: DiffOptionsColor,
   indicator: string,
-  firstOrLastEmptyLineReplacement: string,
+  emptyFirstOrLastLinePlaceholder: string,
   trailingSpaceFormatter: DiffOptionsColor,
 ): string =>
   line.length !== 0
@@ -41,8 +41,8 @@ const printDiffLine = (
       )
     : indicator !== ' '
     ? color(indicator)
-    : isFirstOrLast && firstOrLastEmptyLineReplacement.length !== 0
-    ? color(indicator + ' ' + firstOrLastEmptyLineReplacement)
+    : isFirstOrLast && emptyFirstOrLastLinePlaceholder.length !== 0
+    ? color(indicator + ' ' + emptyFirstOrLastLinePlaceholder)
     : '';
 
 export const printDeleteLine = (
@@ -51,8 +51,8 @@ export const printDeleteLine = (
   {
     aColor,
     aIndicator,
-    firstOrLastEmptyLineReplacement,
-    trailingSpaceFormatter,
+    changeLineTrailingSpaceColor,
+    emptyFirstOrLastLinePlaceholder,
   }: DiffOptionsNormalized,
 ): string =>
   printDiffLine(
@@ -60,8 +60,8 @@ export const printDeleteLine = (
     isFirstOrLast,
     aColor,
     aIndicator,
-    firstOrLastEmptyLineReplacement,
-    trailingSpaceFormatter,
+    emptyFirstOrLastLinePlaceholder,
+    changeLineTrailingSpaceColor,
   );
 
 export const printInsertLine = (
@@ -70,8 +70,8 @@ export const printInsertLine = (
   {
     bColor,
     bIndicator,
-    firstOrLastEmptyLineReplacement,
-    trailingSpaceFormatter,
+    changeLineTrailingSpaceColor,
+    emptyFirstOrLastLinePlaceholder,
   }: DiffOptionsNormalized,
 ): string =>
   printDiffLine(
@@ -79,8 +79,8 @@ export const printInsertLine = (
     isFirstOrLast,
     bColor,
     bIndicator,
-    firstOrLastEmptyLineReplacement,
-    trailingSpaceFormatter,
+    emptyFirstOrLastLinePlaceholder,
+    changeLineTrailingSpaceColor,
   );
 
 export const printCommonLine = (
@@ -89,8 +89,8 @@ export const printCommonLine = (
   {
     commonColor,
     commonIndicator,
-    firstOrLastEmptyLineReplacement,
-    trailingSpaceFormatter,
+    commonLineTrailingSpaceColor,
+    emptyFirstOrLastLinePlaceholder,
   }: DiffOptionsNormalized,
 ): string =>
   printDiffLine(
@@ -98,8 +98,8 @@ export const printCommonLine = (
     isFirstOrLast,
     commonColor,
     commonIndicator,
-    firstOrLastEmptyLineReplacement,
-    trailingSpaceFormatter,
+    emptyFirstOrLastLinePlaceholder,
+    commonLineTrailingSpaceColor,
   );
 
 export const hasCommonDiff = (diffs: Array<Diff>, isMultiline: boolean) => {

--- a/packages/jest-diff/src/types.ts
+++ b/packages/jest-diff/src/types.ts
@@ -15,15 +15,16 @@ export type DiffOptions = {
   bColor?: DiffOptionsColor;
   bIndicator?: string;
   changeColor?: DiffOptionsColor;
+  changeLineTrailingSpaceColor?: DiffOptionsColor;
   commonColor?: DiffOptionsColor;
   commonIndicator?: string;
+  commonLineTrailingSpaceColor?: DiffOptionsColor;
   contextLines?: number;
+  emptyFirstOrLastLinePlaceholder?: string;
   expand?: boolean;
   includeChangeCounts?: boolean;
   omitAnnotationLines?: boolean;
   patchColor?: DiffOptionsColor;
-  trailingSpaceFormatter?: DiffOptionsColor;
-  firstOrLastEmptyLineReplacement?: string;
 };
 
 export type DiffOptionsNormalized = {
@@ -34,13 +35,14 @@ export type DiffOptionsNormalized = {
   bColor: DiffOptionsColor;
   bIndicator: string;
   changeColor: DiffOptionsColor;
+  changeLineTrailingSpaceColor: DiffOptionsColor;
   commonColor: DiffOptionsColor;
   commonIndicator: string;
+  commonLineTrailingSpaceColor: DiffOptionsColor;
   contextLines: number;
+  emptyFirstOrLastLinePlaceholder: string;
   expand: boolean;
   includeChangeCounts: boolean;
   omitAnnotationLines: boolean;
   patchColor: DiffOptionsColor;
-  trailingSpaceFormatter: DiffOptionsColor;
-  firstOrLastEmptyLineReplacement: string;
 };

--- a/packages/jest-matcher-utils/src/index.ts
+++ b/packages/jest-matcher-utils/src/index.ts
@@ -324,6 +324,9 @@ export const printDiffOrStringify = (
       return diffStringsUnified(expected, received, {
         aAnnotation: expectedLabel,
         bAnnotation: receivedLabel,
+        changeLineTrailingSpaceColor: chalk.bgYellow,
+        commonLineTrailingSpaceColor: chalk.bgYellow,
+        emptyFirstOrLastLinePlaceholder: '↵', // U+21B5
         expand,
         includeChangeCounts: true,
       });

--- a/packages/jest-snapshot/src/printSnapshot.ts
+++ b/packages/jest-snapshot/src/printSnapshot.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import chalk from 'chalk';
 import {
   DIFF_DELETE,
   DIFF_EQUAL,
@@ -148,6 +149,9 @@ export const printDiffOrStringified = (
     aColor,
     bAnnotation,
     bColor,
+    changeLineTrailingSpaceColor: chalk.bgYellow,
+    commonLineTrailingSpaceColor: chalk.bgYellow,
+    emptyFirstOrLastLinePlaceholder: '↵', // U+21B5
     expand,
     includeChangeCounts: true,
   };


### PR DESCRIPTION
## Summary

1. Split and rename `trailingSpaceFormatter` option as prerequisite to improve snapshot colors:

    * `changeLineTrailingSpaceColor` because `aColor` and `bColor` might have background color
    * `commonLineTrailingSpaceColor` because `dim` does not modify like other colors

2. Rename `firstOrLastEmptyLineReplacement` as `emptyFirstOrLastLinePlaceholder`

3. Change default values so dependents can turn them on instead of need to turn them off (not breaking, because the new options have not yet been published)

4. Edit `README.md` table and examples of new options

5. Provide explicit values for these options in `jest-matcher-utils` and `jest-snapshot`

6. Export `DiffOptionsColor` type so `jest-snapshot` can declare `getSnapshotColor` and `getReceivedColor` with conditional expression of `chalk.level` to return improved colors

## Test plan

In `jest-diff` package:

* `diff.test.ts` add 1 test and update 2 tests for `trailingSpaceFormatter`
* `joinAlignedDiffs.test.ts` add `emptyFirstOrLastLinePlaceholder` which affects 3 tests