### PR TITLE
fix: skip argv config option on projects if JSON config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 
 ### Fixes
 
+- `[jest-config]` skip argv config option on projects if JSON config ([#9096](https://github.com/facebook/jest/pull/9096))
 - `[expect]` Display `expectedDiff` more carefully in `toBeCloseTo` ([#8389](https://github.com/facebook/jest/pull/8389))
 - `[expect]` Avoid incorrect difference for subset when `toMatchObject` fails ([#9005](https://github.com/facebook/jest/pull/9005))
 - `[jest-config]` Use half of the available cores when `watchAll` mode is enabled ([#9117](https://github.com/facebook/jest/pull/9117))

--- a/packages/jest-config/src/__tests__/readConfig.test.ts
+++ b/packages/jest-config/src/__tests__/readConfig.test.ts
@@ -5,13 +5,30 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import {JEST_CONFIG} from '../constants';
 import {readConfig} from '../index';
+
+jest.mock('../resolveConfigPath', () => {
+  const {JEST_CONFIG} = jest.requireActual('../constants');
+  return {
+    ...jest.genMockFromModule('../resolveConfigPath'),
+    default: () => JEST_CONFIG,
+  };
+});
+
+jest.mock('../readConfigFileAndSetRootDir', () => ({
+  ...jest.genMockFromModule('../readConfigFileAndSetRootDir'),
+  default: () => ({
+    rootDir: '',
+  }),
+}));
 
 test('readConfig() throws when an object is passed without a file path', () => {
   expect(() => {
     readConfig(
       // @ts-ignore
       null /* argv */,
+      // @ts-ignore
       {} /* packageRootOrConfig */,
       false /* skipArgvConfigOption */,
       null /* parentConfigPath */,
@@ -19,4 +36,34 @@ test('readConfig() throws when an object is passed without a file path', () => {
   }).toThrowError(
     'Jest: Cannot use configuration as an object without a file path',
   );
+});
+
+describe('When called from readConfigs()', () => {
+  test('readConfig() does not use config path from parent', () => {
+    const projectConfig: any = readConfig(
+      // @ts-ignore
+      {config: 'parent.config.js', rootDir: ''} /* argv */,
+      '<rootDir>/A' /* packageRootOrConfig */,
+      true /* skipArgvConfigOption */,
+      null /* parentConfigPath */,
+    );
+
+    expect(projectConfig.configPath).toBe(JEST_CONFIG);
+  });
+
+  test('readConfig() does not use JSON config from parent', () => {
+    const JSONConfig = JSON.stringify({
+      projects: ['<rootDir>/A', '<rootDir>/B'],
+    });
+
+    const projectConfig: any = readConfig(
+      // @ts-ignore
+      {config: JSONConfig, rootDir: ''} /* argv */,
+      '<rootDir>/A' /* packageRootOrConfig */,
+      true /* skipArgvConfigOption */,
+      null /* parentConfigPath */,
+    );
+
+    expect(projectConfig.projects).not.toBeDefined();
+  });
 });

--- a/packages/jest-config/src/index.ts
+++ b/packages/jest-config/src/index.ts
@@ -53,7 +53,7 @@ export function readConfig(
         'Jest: Cannot use configuration as an object without a file path.',
       );
     }
-  } else if (isJSONString(argv.config)) {
+  } else if (!skipArgvConfigOption && isJSONString(argv.config)) {
     // A JSON string was passed to `--config` argument and we can parse it
     // and use as is.
     let config;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

I have a command line util to find all packages in a monorepo of a certain type to run their tests with jest. Because it is only a subset of packages, we inline a jest config rather than listing packages in a `jest.config.js` at the root of my monorepo.

But when using `jest --config '{"projects":"<rootDir>/packages/A","<rootDir>/packages/B"}'` the config of each package is ignored. Note that when using a root `jest.config.js` listing projects path (instead of inlining the config in args), it works as expected (each config file is read).

Looking at the code, I've noticed that `skipArgvConfigOption` was only taken into account when the config is not an object.