### PR TITLE
Suggesting to use node 12 as default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
   lint-and-typecheck:
     working_directory: ~/jest
     docker:
-      - image: circleci/node:10
+      - image: circleci/node:12
     steps:
       - checkout
       - restore-cache: *restore-cache

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ _Before_ submitting a pull request, please make sure the following is done…
     python --version
     ```
 
-1.  Make sure you have a compatible version of `node` installed (As of July 10th 2019, `v10.x` is recommended since there is a known issue with `v12.x` [#8490](https://github.com/facebook/jest/issues/8490)).
+1.  Make sure you have a compatible version of `node` installed (As of October 25th 2019, `v12.x` is recommended).
 
     ```sh
     node -v

--- a/packages/jest-worker/src/workers/NodeThreadsWorker.ts
+++ b/packages/jest-worker/src/workers/NodeThreadsWorker.ts
@@ -7,8 +7,6 @@
 
 import * as path from 'path';
 import {PassThrough} from 'stream';
-// ESLint doesn't know about this experimental module
-// eslint-disable-next-line import/no-unresolved
 import {Worker} from 'worker_threads';
 import mergeStream = require('merge-stream');
 

--- a/packages/jest-worker/src/workers/threadChild.ts
+++ b/packages/jest-worker/src/workers/threadChild.ts
@@ -5,8 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// ESLint doesn't know about this experimental module
-// eslint-disable-next-line import/no-unresolved
 import {isMainThread, parentPort} from 'worker_threads';
 
 import {


### PR DESCRIPTION
## Summary

Now in [CONTRIBUTING.md](https://github.com/facebook/jest/blob/master/CONTRIBUTING.md), it is recommended to use node `10.x` for development because of this bug #8490. Since that bug was fixed and node 12 [became LTS](https://medium.com/@nodejs/node-js-12-to-lts-and-node-js-13-is-here-e28d6a4a2bd), I suggest switching to node 12 as a recommendation for contributing and linting.

What this PR does:

1. Fix lint errors in node 12
2. Update CircleCI config to use node 12 for linting
3. Update contributing documentation

close #9015 

## Test plan

Green CI