### PR TITLE
jest-snapshot: Improve report when the matcher has properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - `[jest-matcher-utils]` Add `BigInt` support to `ensureNumbers` `ensureActualIsNumber`, `ensureExpectedIsNumber` ([#8382](https://github.com/facebook/jest/pull/8382))
 - `[jest-runner]` Warn if a worker had to be force exited ([#8206](https://github.com/facebook/jest/pull/8206))
 - `[jest-snapshot]` Display change counts in annotation lines ([#8982](https://github.com/facebook/jest/pull/8982))
+- `[jest-snapshot]` [**BREAKING**] Improve report when the matcher has properties ([#9104](https://github.com/facebook/jest/pull/9104))
 - `[@jest/test-result]` Create method to create empty `TestResult` ([#8867](https://github.com/facebook/jest/pull/8867))
 - `[jest-worker]` [**BREAKING**] Return a promise from `end()`, resolving with the information whether workers exited gracefully ([#8206](https://github.com/facebook/jest/pull/8206))
 - `[jest-reporters]` Transform file paths into hyperlinks ([#8980](https://github.com/facebook/jest/pull/8980))

--- a/e2e/__tests__/toMatchSnapshot.test.ts
+++ b/e2e/__tests__/toMatchSnapshot.test.ts
@@ -255,7 +255,7 @@ test('handles property matchers with hint', () => {
     expect(stderr).toMatch(
       'Snapshot name: `handles property matchers with hint: descriptive hint 1`',
     );
-    expect(stderr).toMatch('Expected properties:');
+    expect(stderr).toMatch('Expected properties');
     expect(stderr).toMatch('Snapshots:   1 failed, 1 total');
     expect(exitCode).toBe(1);
   }
@@ -287,7 +287,7 @@ test('handles property matchers with deep properties', () => {
     expect(stderr).toMatch(
       'Snapshot name: `handles property matchers with deep properties 1`',
     );
-    expect(stderr).toMatch('Expected properties:');
+    expect(stderr).toMatch('Expected properties');
     expect(stderr).toMatch('Snapshots:   1 failed, 1 total');
     expect(exitCode).toBe(1);
   }

--- a/packages/jest-snapshot/src/State.ts
+++ b/packages/jest-snapshot/src/State.ts
@@ -10,6 +10,7 @@ import {Config} from '@jest/types';
 
 import {getStackTraceLines, getTopFrame} from 'jest-message-util';
 import {
+  addExtraLineBreaks,
   getSnapshotData,
   keyToTestName,
   removeExtraLineBreaks,
@@ -198,7 +199,7 @@ export default class SnapshotState {
       this._uncheckedKeys.delete(key);
     }
 
-    const receivedSerialized = serialize(received);
+    const receivedSerialized = addExtraLineBreaks(serialize(received));
     const expected = isInline ? inlineSnapshot : this._snapshotData[key];
     const pass = expected === receivedSerialized;
     const hasSnapshot = expected !== undefined;

--- a/packages/jest-snapshot/src/__tests__/__snapshots__/printSnapshot.test.ts.snap
+++ b/packages/jest-snapshot/src/__tests__/__snapshots__/printSnapshot.test.ts.snap
@@ -70,9 +70,10 @@ Snapshot state has value: undefined
 exports[`matcher error toMatchSnapshot received value must be an object when the matcher has properties 1`] = `
 <d>expect(</><r>received</><d>).</>toMatchSnapshot<d>(</><g>properties</><d>)</>
 
-Snapshot state must be initialized
+<b>Matcher error</>: <r>received</> value must be an object when the matcher has <g>properties</>
 
-Snapshot state has value: undefined
+Received has type:  string
+Received has value: <r>"string"</>
 `;
 
 exports[`matcher error toThrowErrorMatchingInlineSnapshot Inline snapshot must be a string 1`] = `

--- a/packages/jest-snapshot/src/__tests__/__snapshots__/printSnapshot.test.ts.snap
+++ b/packages/jest-snapshot/src/__tests__/__snapshots__/printSnapshot.test.ts.snap
@@ -67,13 +67,21 @@ Snapshot state must be initialized
 Snapshot state has value: undefined
 `;
 
-exports[`matcher error toMatchSnapshot received value must be an object when the matcher has properties 1`] = `
+exports[`matcher error toMatchSnapshot received value must be an object (non-null) 1`] = `
 <d>expect(</><r>received</><d>).</>toMatchSnapshot<d>(</><g>properties</><d>)</>
 
 <b>Matcher error</>: <r>received</> value must be an object when the matcher has <g>properties</>
 
 Received has type:  string
 Received has value: <r>"string"</>
+`;
+
+exports[`matcher error toMatchSnapshot received value must be an object (null) 1`] = `
+<d>expect(</><r>received</><d>).</>toMatchSnapshot<d>(</><g>properties</><d>)</>
+
+<b>Matcher error</>: <r>received</> value must be an object when the matcher has <g>properties</>
+
+Received has value: <r>null</>
 `;
 
 exports[`matcher error toThrowErrorMatchingInlineSnapshot Inline snapshot must be a string 1`] = `

--- a/packages/jest-snapshot/src/__tests__/__snapshots__/printSnapshot.test.ts.snap
+++ b/packages/jest-snapshot/src/__tests__/__snapshots__/printSnapshot.test.ts.snap
@@ -38,7 +38,7 @@ exports[`matcher error toMatchSnapshot Expected properties must be an object (no
 <b>Matcher error</>: Expected <g>properties</> must be an object
 
 Expected properties has type:  function
-Expected properties has value: <g>[Function properties]</>
+Expected properties has value: <g>[Function]</>
 `;
 
 exports[`matcher error toMatchSnapshot Expected properties must be an object (null) with hint 1`] = `
@@ -61,6 +61,14 @@ Expected properties has value: <g>null</>
 
 exports[`matcher error toMatchSnapshot Snapshot state must be initialized 1`] = `
 <d>expect(</><r>received</><d>).</>resolves<d>.</>toMatchSnapshot<d>(</><b>hint</><d>)</>
+
+Snapshot state must be initialized
+
+Snapshot state has value: undefined
+`;
+
+exports[`matcher error toMatchSnapshot received value must be an object when the matcher has properties 1`] = `
+<d>expect(</><r>received</><d>).</>toMatchSnapshot<d>(</><g>properties</><d>)</>
 
 Snapshot state must be initialized
 
@@ -110,8 +118,15 @@ exports[`pass false toMatchInlineSnapshot with properties equals false with snap
 
 Snapshot name: \`with properties 1\`
 
-Expected properties: <g>{"id": "abcdef"}</>
-Received value:      <r>{"id": "abcdefg", "text": "Increase code coverage", "type": "ADD_ITEM"}</>
+<g>- Expected properties  - 1</>
+<r>+ Received value       + 3</>
+
+<d>  Object {</>
+<g>-   "id": "abcdef",</>
+<r>+   "id": "abcdefg",</>
+<r>+   "text": "Increase code coverage",</>
+<r>+   "type": "ADD_ITEM",</>
+<d>  }</>
 `;
 
 exports[`pass false toMatchInlineSnapshot with properties equals false without snapshot 1`] = `
@@ -119,8 +134,15 @@ exports[`pass false toMatchInlineSnapshot with properties equals false without s
 
 Snapshot name: \`with properties 1\`
 
-Expected properties: <g>{"id": "abcdef"}</>
-Received value:      <r>{"id": "abcdefg", "text": "Increase code coverage", "type": "ADD_ITEM"}</>
+<g>- Expected properties  - 1</>
+<r>+ Received value       + 3</>
+
+<d>  Object {</>
+<g>-   "id": "abcdef",</>
+<r>+   "id": "abcdefg",</>
+<r>+   "text": "Increase code coverage",</>
+<r>+   "type": "ADD_ITEM",</>
+<d>  }</>
 `;
 
 exports[`pass false toMatchInlineSnapshot with properties equals true 1`] = `
@@ -165,13 +187,29 @@ This is likely because this test is run in a continuous integration (CI) environ
 Received: <r>"Write me if you can!"</>
 `;
 
-exports[`pass false toMatchSnapshot with properties equals false 1`] = `
+exports[`pass false toMatchSnapshot with properties equals false isLineDiffable false 1`] = `
 <d>expect(</><r>received</><d>).</>toMatchSnapshot<d>(</><g>properties</><d>)</>
 
 Snapshot name: \`with properties 1\`
 
-Expected properties: <g>{"id": "abcdef"}</>
-Received value:      <r>{"id": "abcdefg", "text": "Increase code coverage", "type": "ADD_ITEM"}</>
+Expected properties: <g>{"name": "Error"}</>
+Received value:      <r>[RangeError: Invalid array length]</>
+`;
+
+exports[`pass false toMatchSnapshot with properties equals false isLineDiffable true 1`] = `
+<d>expect(</><r>received</><d>).</>toMatchSnapshot<d>(</><g>properties</><d>)</>
+
+Snapshot name: \`with properties 1\`
+
+<g>- Expected properties  - 1</>
+<r>+ Received value       + 3</>
+
+<d>  Object {</>
+<g>-   "id": "abcdef",</>
+<r>+   "id": "abcdefg",</>
+<r>+   "text": "Increase code coverage",</>
+<r>+   "type": "ADD_ITEM",</>
+<d>  }</>
 `;
 
 exports[`pass false toMatchSnapshot with properties equals true 1`] = `
@@ -199,17 +237,17 @@ Snapshot: <g>"inline snapshot"</>
 Received: <r>"received"</>
 `;
 
-exports[`printDiffOrStringified backtick single line expected and received 1`] = `
+exports[`printSnapshotAndReceived backtick single line expected and received 1`] = `
 Snapshot: <g>"var foo = \`backtick\`;"</>
 Received: <r>"var foo = <i>tag</i>\`backtick\`;"</>
 `;
 
-exports[`printDiffOrStringified empty string expected and received single line 1`] = `
+exports[`printSnapshotAndReceived empty string expected and received single line 1`] = `
 Snapshot: <g>""</>
 Received: <r>"single line string"</>
 `;
 
-exports[`printDiffOrStringified empty string received and expected multi line 1`] = `
+exports[`printSnapshotAndReceived empty string received and expected multi line 1`] = `
 <g>- Snapshot  - 3</>
 <r>+ Received  + 0</>
 
@@ -218,7 +256,7 @@ exports[`printDiffOrStringified empty string received and expected multi line 1`
 <g>- string</>
 `;
 
-exports[`printDiffOrStringified escape backslash in multi line string 1`] = `
+exports[`printSnapshotAndReceived escape backslash in multi line string 1`] = `
 <g>- Snapshot  - 1</>
 <r>+ Received  + 2</>
 
@@ -227,22 +265,22 @@ exports[`printDiffOrStringified escape backslash in multi line string 1`] = `
 <r>+ <i>B</i>ack \\ slash</>
 `;
 
-exports[`printDiffOrStringified escape backslash in single line string 1`] = `
+exports[`printSnapshotAndReceived escape backslash in single line string 1`] = `
 Snapshot: <g>"<i>f</i>orward / slash and back \\\\ slash"</>
 Received: <r>"<i>F</i>orward / slash and back \\\\ slash"</>
 `;
 
-exports[`printDiffOrStringified escape double quote marks in string 1`] = `
+exports[`printSnapshotAndReceived escape double quote marks in string 1`] = `
 Snapshot: <g>"What does \\"<i>oo</i>bleck\\" mean?"</>
 Received: <r>"What does \\"<i>ew</i>bleck\\" mean?"</>
 `;
 
-exports[`printDiffOrStringified escape regexp 1`] = `
+exports[`printSnapshotAndReceived escape regexp 1`] = `
 Snapshot: <g>/\\\\\\\\\\("\\)/g</>
 Received: <r>/\\\\\\\\\\("\\)/</>
 `;
 
-exports[`printDiffOrStringified expand false 1`] = `
+exports[`printSnapshotAndReceived expand false 1`] = `
 <g>- Snapshot  - 1</>
 <r>+ Received  + 3</>
 
@@ -259,7 +297,7 @@ exports[`printDiffOrStringified expand false 1`] = `
 <d>  ↵</>
 `;
 
-exports[`printDiffOrStringified expand true 1`] = `
+exports[`printSnapshotAndReceived expand true 1`] = `
 <g>- Snapshot  - 1</>
 <r>+ Received  + 3</>
 
@@ -286,7 +324,7 @@ exports[`printDiffOrStringified expand true 1`] = `
 <d>  ↵</>
 `;
 
-exports[`printDiffOrStringified fallback to line diff 1`] = `
+exports[`printSnapshotAndReceived fallback to line diff 1`] = `
 <g>- Snapshot  - 1</>
 <r>+ Received  + 8</>
 
@@ -306,7 +344,7 @@ exports[`printDiffOrStringified fallback to line diff 1`] = `
 <r>+ ================================================================================</>
 `;
 
-exports[`printDiffOrStringified has no common after clean up chaff array 1`] = `
+exports[`printSnapshotAndReceived has no common after clean up chaff array 1`] = `
 <g>- Snapshot  - 2</>
 <r>+ Received  + 2</>
 
@@ -318,44 +356,44 @@ exports[`printDiffOrStringified has no common after clean up chaff array 1`] = `
 <d>  ]</>
 `;
 
-exports[`printDiffOrStringified has no common after clean up chaff string single line 1`] = `
+exports[`printSnapshotAndReceived has no common after clean up chaff string single line 1`] = `
 Snapshot: <g>"delete"</>
 Received: <r>"insert"</>
 `;
 
-exports[`printDiffOrStringified isLineDiffable false asymmetric matcher 1`] = `
+exports[`printSnapshotAndReceived isLineDiffable false asymmetric matcher 1`] = `
 Snapshot: <g>null</>
 Received: <r>Object {</>
 <r>  "asymmetricMatch": [Function],</>
 <r>}</>
 `;
 
-exports[`printDiffOrStringified isLineDiffable false boolean 1`] = `
+exports[`printSnapshotAndReceived isLineDiffable false boolean 1`] = `
 Snapshot: <g>true</>
 Received: <r>false</>
 `;
 
-exports[`printDiffOrStringified isLineDiffable false date 1`] = `
+exports[`printSnapshotAndReceived isLineDiffable false date 1`] = `
 Snapshot: <g>2019-09-19T00:00:00.000Z</>
 Received: <r>2019-09-20T00:00:00.000Z</>
 `;
 
-exports[`printDiffOrStringified isLineDiffable false error 1`] = `
+exports[`printSnapshotAndReceived isLineDiffable false error 1`] = `
 Snapshot: <g>[Error: Cannot spread fragment "NameAndAppearances" within itself.]</>
 Received: <r>[Error: Cannot spread fragment "NameAndAppearancesAndFriends" within itself.]</>
 `;
 
-exports[`printDiffOrStringified isLineDiffable false function 1`] = `
+exports[`printSnapshotAndReceived isLineDiffable false function 1`] = `
 Snapshot: <g>undefined</>
 Received: <r>[Function]</>
 `;
 
-exports[`printDiffOrStringified isLineDiffable false number 1`] = `
+exports[`printSnapshotAndReceived isLineDiffable false number 1`] = `
 Snapshot: <g>-0</>
 Received: <r>NaN</>
 `;
 
-exports[`printDiffOrStringified isLineDiffable true array 1`] = `
+exports[`printSnapshotAndReceived isLineDiffable true array 1`] = `
 <g>- Snapshot  - 0</>
 <r>+ Received  + 2</>
 
@@ -373,7 +411,7 @@ exports[`printDiffOrStringified isLineDiffable true array 1`] = `
 <d>  ]</>
 `;
 
-exports[`printDiffOrStringified isLineDiffable true object 1`] = `
+exports[`printSnapshotAndReceived isLineDiffable true object 1`] = `
 <g>- Snapshot  - 2</>
 <r>+ Received  + 3</>
 
@@ -389,7 +427,7 @@ exports[`printDiffOrStringified isLineDiffable true object 1`] = `
 <d>  }</>
 `;
 
-exports[`printDiffOrStringified isLineDiffable true single line expected and multi line received 1`] = `
+exports[`printSnapshotAndReceived isLineDiffable true single line expected and multi line received 1`] = `
 <g>- Snapshot  - 1</>
 <r>+ Received  + 3</>
 
@@ -399,7 +437,7 @@ exports[`printDiffOrStringified isLineDiffable true single line expected and mul
 <r>+ ]</>
 `;
 
-exports[`printDiffOrStringified isLineDiffable true single line expected and received 1`] = `
+exports[`printSnapshotAndReceived isLineDiffable true single line expected and received 1`] = `
 <g>- Snapshot  - 1</>
 <r>+ Received  + 1</>
 
@@ -407,7 +445,7 @@ exports[`printDiffOrStringified isLineDiffable true single line expected and rec
 <r>+ Object {}</>
 `;
 
-exports[`printDiffOrStringified multi line small change in one line and other is unchanged 1`] = `
+exports[`printSnapshotAndReceived multi line small change in one line and other is unchanged 1`] = `
 <g>- Snapshot  - 1</>
 <r>+ Received  + 1</>
 
@@ -416,7 +454,7 @@ exports[`printDiffOrStringified multi line small change in one line and other is
 <d>  Must be one of: 'Home'</>
 `;
 
-exports[`printDiffOrStringified multi line small changes 1`] = `
+exports[`printSnapshotAndReceived multi line small changes 1`] = `
 <g>- Snapshot  - 7</>
 <r>+ Received  + 7</>
 
@@ -437,12 +475,12 @@ exports[`printDiffOrStringified multi line small changes 1`] = `
 <r>+     at Object.doesNotThrow (__tests__/assertionError.test.js:7<i>0</i>:10)</>
 `;
 
-exports[`printDiffOrStringified single line large changes 1`] = `
+exports[`printSnapshotAndReceived single line large changes 1`] = `
 Snapshot: <g>"<i>A</i>rray length<i> must be a finite positive integer</i>"</>
 Received: <r>"<i>Invalid a</i>rray length"</>
 `;
 
-exports[`printDiffOrStringified without serialize backtick single line expected and multi line received 1`] = `
+exports[`printSnapshotAndReceived without serialize backtick single line expected and multi line received 1`] = `
 <g>- Snapshot  - 1</>
 <r>+ Received  + 2</>
 
@@ -451,7 +489,7 @@ exports[`printDiffOrStringified without serialize backtick single line expected 
 <r>+ tick\`;</>
 `;
 
-exports[`printDiffOrStringified without serialize backtick single line expected and received 1`] = `
+exports[`printSnapshotAndReceived without serialize backtick single line expected and received 1`] = `
 <g>- Snapshot  - 1</>
 <r>+ Received  + 1</>
 
@@ -459,7 +497,7 @@ exports[`printDiffOrStringified without serialize backtick single line expected 
 <r>+ var foo = \`back<i>\${x}</i>tick\`;</>
 `;
 
-exports[`printDiffOrStringified without serialize has no common after clean up chaff multi line 1`] = `
+exports[`printSnapshotAndReceived without serialize has no common after clean up chaff multi line 1`] = `
 <g>- Snapshot  - 2</>
 <r>+ Received  + 2</>
 
@@ -469,7 +507,7 @@ exports[`printDiffOrStringified without serialize has no common after clean up c
 <r>+ 2</>
 `;
 
-exports[`printDiffOrStringified without serialize has no common after clean up chaff single line 1`] = `
+exports[`printSnapshotAndReceived without serialize has no common after clean up chaff single line 1`] = `
 <g>- Snapshot  - 1</>
 <r>+ Received  + 1</>
 
@@ -477,7 +515,7 @@ exports[`printDiffOrStringified without serialize has no common after clean up c
 <r>+ insert</>
 `;
 
-exports[`printDiffOrStringified without serialize prettier/pull/5590 1`] = `
+exports[`printSnapshotAndReceived without serialize prettier/pull/5590 1`] = `
 <g>- Snapshot  - 1</>
 <r>+ Received  + 1</>
 

--- a/packages/jest-snapshot/src/__tests__/printSnapshot.test.ts
+++ b/packages/jest-snapshot/src/__tests__/printSnapshot.test.ts
@@ -168,19 +168,26 @@ describe('matcher error', () => {
       }).toThrowErrorMatchingSnapshot();
     });
 
-    test('received value must be an object when the matcher has properties', () => {
+    describe('received value must be an object', () => {
       const context = {
         currentTestName: '',
         isNot: false,
         promise: '',
         snapshotState: {},
       };
-      const received = 'string';
       const properties = {};
 
-      expect(() => {
-        toMatchSnapshot.call(context, received, properties);
-      }).toThrowErrorMatchingSnapshot();
+      test('(non-null)', () => {
+        expect(() => {
+          toMatchSnapshot.call(context, 'string', properties);
+        }).toThrowErrorMatchingSnapshot();
+      });
+
+      test('(null)', () => {
+        expect(() => {
+          toMatchSnapshot.call(context, null, properties);
+        }).toThrowErrorMatchingSnapshot();
+      });
     });
 
     // Future test: Snapshot hint must be a string

--- a/packages/jest-snapshot/src/__tests__/printSnapshot.test.ts
+++ b/packages/jest-snapshot/src/__tests__/printSnapshot.test.ts
@@ -11,8 +11,8 @@ import chalk from 'chalk';
 import format = require('pretty-format');
 
 import jestSnapshot = require('../index');
-import {printDiffOrStringified} from '../printSnapshot';
-import {stringify} from '../utils';
+import {printSnapshotAndReceived} from '../printSnapshot';
+import {serialize} from '../utils';
 
 const convertAnsi = (val: string): string =>
   val.replace(ansiRegex(), match => {
@@ -162,6 +162,19 @@ describe('matcher error', () => {
         promise: '',
       };
       const properties = null;
+
+      expect(() => {
+        toMatchSnapshot.call(context, received, properties);
+      }).toThrowErrorMatchingSnapshot();
+    });
+
+    test('received value must be an object when the matcher has properties', () => {
+      const context = {
+        isNot: false,
+        promise: '',
+      };
+      const received = 'string';
+      const properties = {};
 
       expect(() => {
         toMatchSnapshot.call(context, received, properties);
@@ -433,7 +446,7 @@ describe('pass false', () => {
       const properties = {id};
       const type = 'ADD_ITEM';
 
-      test('equals false', () => {
+      describe('equals false', () => {
         const context = {
           currentTestName: 'with properties',
           equals: () => false,
@@ -447,19 +460,32 @@ describe('pass false', () => {
             subsetEquality: () => {},
           },
         };
-        const received = {
-          id: 'abcdefg',
-          text: 'Increase code coverage',
-          type,
-        };
 
-        const {message, pass} = toMatchSnapshot.call(
-          context,
-          received,
-          properties,
-        );
-        expect(pass).toBe(false);
-        expect(message()).toMatchSnapshot();
+        test('isLineDiffable false', () => {
+          const {message, pass} = toMatchSnapshot.call(
+            context,
+            new RangeError('Invalid array length'),
+            {name: 'Error'},
+          );
+          expect(pass).toBe(false);
+          expect(message()).toMatchSnapshot();
+        });
+
+        test('isLineDiffable true', () => {
+          const received = {
+            id: 'abcdefg',
+            text: 'Increase code coverage',
+            type,
+          };
+
+          const {message, pass} = toMatchSnapshot.call(
+            context,
+            received,
+            properties,
+          );
+          expect(pass).toBe(false);
+          expect(message()).toMatchSnapshot();
+        });
       });
 
       test('equals true', () => {
@@ -564,16 +590,16 @@ describe('pass true', () => {
   });
 });
 
-describe('printDiffOrStringified', () => {
+describe('printSnapshotAndReceived', () => {
   // Simulate default serialization.
   const testWithStringify = (
     expected: unknown,
     received: unknown,
     expand: boolean,
   ): string =>
-    printDiffOrStringified(
-      stringify(expected),
-      stringify(received),
+    printSnapshotAndReceived(
+      serialize(expected),
+      serialize(received),
       received,
       expand,
     );
@@ -583,7 +609,7 @@ describe('printDiffOrStringified', () => {
     expected: string,
     received: string,
     expand: boolean,
-  ): string => printDiffOrStringified(expected, received, received, expand);
+  ): string => printSnapshotAndReceived(expected, received, received, expand);
 
   describe('backtick', () => {
     test('single line expected and received', () => {
@@ -747,7 +773,7 @@ describe('printDiffOrStringified', () => {
 
       test('both are less', () => {
         const less2 = 'multi\nline';
-        const difference = printDiffOrStringified(less2, less, less, true);
+        const difference = printSnapshotAndReceived(less2, less, less, true);
 
         expect(difference).toMatch('- multi');
         expect(difference).toMatch('- line');
@@ -756,7 +782,7 @@ describe('printDiffOrStringified', () => {
       });
 
       test('expected is more', () => {
-        const difference = printDiffOrStringified(more, less, less, true);
+        const difference = printSnapshotAndReceived(more, less, less, true);
 
         expect(difference).toMatch('- multi line');
         expect(difference).toMatch('+ single line');
@@ -764,7 +790,7 @@ describe('printDiffOrStringified', () => {
       });
 
       test('received is more', () => {
-        const difference = printDiffOrStringified(less, more, more, true);
+        const difference = printSnapshotAndReceived(less, more, more, true);
 
         expect(difference).toMatch('- single line');
         expect(difference).toMatch('+ multi line');
@@ -782,7 +808,7 @@ describe('printDiffOrStringified', () => {
 
       test('both are less', () => {
         const lessQuoted2 = '"0 numbers"';
-        const stringified = printDiffOrStringified(
+        const stringified = printSnapshotAndReceived(
           lessQuoted2,
           lessQuoted,
           less,
@@ -795,7 +821,7 @@ describe('printDiffOrStringified', () => {
       });
 
       test('expected is more', () => {
-        const stringified = printDiffOrStringified(
+        const stringified = printSnapshotAndReceived(
           moreQuoted,
           lessQuoted,
           less,
@@ -809,7 +835,7 @@ describe('printDiffOrStringified', () => {
       });
 
       test('received is more', () => {
-        const stringified = printDiffOrStringified(
+        const stringified = printSnapshotAndReceived(
           lessQuoted,
           moreQuoted,
           more,

--- a/packages/jest-snapshot/src/__tests__/printSnapshot.test.ts
+++ b/packages/jest-snapshot/src/__tests__/printSnapshot.test.ts
@@ -170,8 +170,10 @@ describe('matcher error', () => {
 
     test('received value must be an object when the matcher has properties', () => {
       const context = {
+        currentTestName: '',
         isNot: false,
         promise: '',
+        snapshotState: {},
       };
       const received = 'string';
       const properties = {};

--- a/packages/jest-snapshot/src/__tests__/utils.test.ts
+++ b/packages/jest-snapshot/src/__tests__/utils.test.ts
@@ -191,7 +191,7 @@ test('serialize handles \\r\\n', () => {
   const data = '<div>\r\n</div>';
   const serializedData = serialize(data);
 
-  expect(serializedData).toBe('\n"<div>\n</div>"\n');
+  expect(serializedData).toBe('"<div>\n</div>"');
 });
 
 describe('ExtraLineBreaks', () => {

--- a/packages/jest-snapshot/src/index.ts
+++ b/packages/jest-snapshot/src/index.ts
@@ -16,8 +16,6 @@ import {
   RECEIVED_COLOR,
   matcherErrorMessage,
   matcherHint,
-  printExpected,
-  printReceived,
   printWithType,
   stringify,
 } from 'jest-matcher-utils';
@@ -34,7 +32,10 @@ import {
   SNAPSHOT_ARG,
   matcherHintFromConfig,
   noColor,
-  printDiffOrStringified,
+  printExpected,
+  printPropertiesAndReceived,
+  printReceived,
+  printSnapshotAndReceived,
 } from './printSnapshot';
 import {Context, MatchSnapshotConfig} from './types';
 import * as utils from './utils';
@@ -254,7 +255,7 @@ const toMatchInlineSnapshot = function(
         matcherErrorMessage(
           matcherHint(matcherName, undefined, PROPERTIES_ARG, options),
           `Inline snapshot must be a string`,
-          printWithType('Inline snapshot', inlineSnapshot, stringify),
+          printWithType('Inline snapshot', inlineSnapshot, utils.serialize),
         ),
       );
     }
@@ -301,6 +302,8 @@ const _toMatchSnapshot = (config: MatchSnapshotConfig) => {
 
   if (snapshotState == null) {
     // Because the state is the problem, this is not a matcher error.
+    // Call generic stringify from jest-matcher-utils package
+    // because uninitialized snapshot state does not need snapshot serializers.
     throw new Error(
       matcherHintFromConfig(config, false) +
         '\n\n' +
@@ -316,6 +319,20 @@ const _toMatchSnapshot = (config: MatchSnapshotConfig) => {
       : currentTestName || ''; // future BREAKING change: || hint
 
   if (typeof properties === 'object') {
+    if (typeof received !== 'object' || received === null) {
+      throw new Error(
+        matcherErrorMessage(
+          matcherHintFromConfig(config, false),
+          `${RECEIVED_COLOR(
+            'received',
+          )} value must be an object when the matcher has ${EXPECTED_COLOR(
+            'properties',
+          )}`,
+          printWithType('Received', received, printReceived),
+        ),
+      );
+    }
+
     const propertyPass = context.equals(received, properties, [
       context.utils.iterableEquality,
       context.utils.subsetEquality,
@@ -331,8 +348,7 @@ const _toMatchSnapshot = (config: MatchSnapshotConfig) => {
         '\n\n' +
         printSnapshotName(currentTestName, hint, count) +
         '\n\n' +
-        `Expected properties: ${printExpected(properties)}\n` +
-        `Received value:      ${printReceived(received)}`;
+        printPropertiesAndReceived(properties, received, snapshotState.expand);
 
       return {
         message,
@@ -376,7 +392,7 @@ const _toMatchSnapshot = (config: MatchSnapshotConfig) => {
           '\n\n' +
           printSnapshotName(currentTestName, hint, count) +
           '\n\n' +
-          printDiffOrStringified(
+          printSnapshotAndReceived(
             expected,
             actual,
             received,
@@ -437,7 +453,7 @@ const toThrowErrorMatchingInlineSnapshot = function(
       matcherErrorMessage(
         matcherHint(matcherName, undefined, SNAPSHOT_ARG, options),
         `Inline snapshot must be a string`,
-        printWithType('Inline snapshot', inlineSnapshot, stringify),
+        printWithType('Inline snapshot', inlineSnapshot, utils.serialize),
       ),
     );
   }

--- a/packages/jest-snapshot/src/utils.ts
+++ b/packages/jest-snapshot/src/utils.ts
@@ -136,20 +136,28 @@ export const removeExtraLineBreaks = (string: string): string =>
     ? string.slice(1, -1)
     : string;
 
-export const serialize = (val: unknown): string =>
-  addExtraLineBreaks(stringify(val));
+const escapeRegex = true;
+const printFunctionName = false;
 
-export const stringify = (val: unknown): string =>
+export const serialize = (val: unknown): string =>
   normalizeNewlines(
     prettyFormat(val, {
-      escapeRegex: true,
+      escapeRegex,
       plugins: getSerializers(),
-      printFunctionName: false,
+      printFunctionName,
     }),
   );
 
+export const minify = (val: unknown): string =>
+  prettyFormat(val, {
+    escapeRegex,
+    min: true,
+    plugins: getSerializers(),
+    printFunctionName,
+  });
+
 // Remove double quote marks and unescape double quotes and backslashes.
-export const unstringifyString = (stringified: string): string =>
+export const deserializeString = (stringified: string): string =>
   stringified.slice(1, -1).replace(/\\("|\\)/g, '$1');
 
 export const escapeBacktickString = (str: string): string =>


### PR DESCRIPTION
## Summary

Borrow some features from `toMatchObject` for reports when snapshot matchers fail:

1. Throw `Matcher error: received value must be an object when the matcher has properties` instead of

    * ordinary test failure
    * **BREAKING**: test success if received is a **string** see #8059

2. In an ordinary test failure because received object does not match properties, display comparison lines if `isLineDiffable`

A similarity with `toMatchObject` that I did **not** include is `getObjectSubset` because:

* it has known limitations
* it is not a public interface
* the long-term goal is to replace it with data-driven diff

Refactor for clearer distinction between snapshot and generic serialization:

* call `addExtraLineBreaks` in `State.ts` for symmetry with `removeExtraLineBreaks`
* change `serialize` not to call `addExtraLineBreaks`
* add `minify` to call `pretty-format` with `min: true` and other `serialize` options
* add `printExpected` and `printReceived` to call `minify` with colors
* call `stringify` from `jest-matcher-utils` only for `snapshotState` error

## Test plan

In `printSnapshot.test.ts`

* add 1 snapshot for matcher error
* add 1 snapshot for minified values if `!isLineDiffable`
* update 3 snapshots for comparison lines if `isLineDiffable`
* update 1 snapshot because `printExpected` uses snapshot serializer options
* update 30 snapshot names to replace `printDiffOrStringified` with `printSnapshotAndReceived`

In `utils.test.ts` edit 1 `toBe` because `serialize` does not call `addExtraLineBreaks`

In e2e `toMatchSnapshot.test.ts` edit 2 `toMatch` for comparison lines if `isLineDiffable`

See also pictures in the following comment