### PR TITLE
Use half of the available cores when in watchAll mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 - `[expect]` Display `expectedDiff` more carefully in `toBeCloseTo` ([#8389](https://github.com/facebook/jest/pull/8389))
 - `[expect]` Avoid incorrect difference for subset when `toMatchObject` fails ([#9005](https://github.com/facebook/jest/pull/9005))
+- `[jest-config]` Use half of the available cores when `watchAll` mode is enabled ([#9117](https://github.com/facebook/jest/pull/9117))
 - `[jest-console]` Add missing `console.group` calls to `NullConsole` ([#9024](https://github.com/facebook/jest/pull/9024))
 - `[jest-core]` Don't include unref'd timers in --detectOpenHandles results ([#8941](https://github.com/facebook/jest/pull/8941))
 - `[jest-diff]` Do not inverse format if line consists of one change ([#8903](https://github.com/facebook/jest/pull/8903))

--- a/packages/jest-config/src/__tests__/getMaxWorkers.test.ts
+++ b/packages/jest-config/src/__tests__/getMaxWorkers.test.ts
@@ -33,6 +33,7 @@ describe('getMaxWorkers', () => {
   it('Returns based on the number of cpus', () => {
     expect(getMaxWorkers({})).toBe(3);
     expect(getMaxWorkers({watch: true})).toBe(2);
+    expect(getMaxWorkers({watchAll: true})).toBe(2);
   });
 
   describe('% based', () => {

--- a/packages/jest-config/src/getMaxWorkers.ts
+++ b/packages/jest-config/src/getMaxWorkers.ts
@@ -9,7 +9,9 @@ import {cpus} from 'os';
 import {Config} from '@jest/types';
 
 export default function getMaxWorkers(
-  argv: Partial<Pick<Config.Argv, 'maxWorkers' | 'runInBand' | 'watch' | 'watchAll'>>,
+  argv: Partial<
+    Pick<Config.Argv, 'maxWorkers' | 'runInBand' | 'watch' | 'watchAll'>
+  >,
   defaultOptions?: Partial<Pick<Config.Argv, 'maxWorkers'>>,
 ): number {
   if (argv.runInBand) {
@@ -22,7 +24,10 @@ export default function getMaxWorkers(
     // In watch mode, Jest should be unobtrusive and not use all available CPUs.
     const numCpus = cpus() ? cpus().length : 1;
     const isWatchModeEnabled = argv.watch || argv.watchAll;
-    return Math.max(isWatchModeEnabled ? Math.floor(numCpus / 2) : numCpus - 1, 1);
+    return Math.max(
+      isWatchModeEnabled ? Math.floor(numCpus / 2) : numCpus - 1,
+      1,
+    );
   }
 }
 

--- a/packages/jest-config/src/getMaxWorkers.ts
+++ b/packages/jest-config/src/getMaxWorkers.ts
@@ -9,7 +9,7 @@ import {cpus} from 'os';
 import {Config} from '@jest/types';
 
 export default function getMaxWorkers(
-  argv: Partial<Pick<Config.Argv, 'maxWorkers' | 'runInBand' | 'watch'>>,
+  argv: Partial<Pick<Config.Argv, 'maxWorkers' | 'runInBand' | 'watch' | 'watchAll'>>,
   defaultOptions?: Partial<Pick<Config.Argv, 'maxWorkers'>>,
 ): number {
   if (argv.runInBand) {
@@ -21,7 +21,8 @@ export default function getMaxWorkers(
   } else {
     // In watch mode, Jest should be unobtrusive and not use all available CPUs.
     const numCpus = cpus() ? cpus().length : 1;
-    return Math.max(argv.watch ? Math.floor(numCpus / 2) : numCpus - 1, 1);
+    const isWatchModeEnabled = argv.watch || argv.watchAll;
+    return Math.max(isWatchModeEnabled ? Math.floor(numCpus / 2) : numCpus - 1, 1);
   }
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Fixes #9116

## Test plan

Added a new condition in the `Returns based on the number of cpus` test of the `packages/jest-config/src/__tests__/getMaxWorkers.test.ts` file
