### PR TITLE
Fix minor typo in JestPlatform.md

### DIFF
--- a/docs/JestPlatform.md
+++ b/docs/JestPlatform.md
@@ -119,7 +119,7 @@ You can read more about `jest-validate` in the [readme file](https://github.com/
 
 ## jest-worker
 
-Module used for parallelization of tasks. Exports a class `Worker` that takes the path of Node.js module and lets you call the module's exported methods as if they where class methods, returning a promise that resolves when the specified method finishes its execution in a forked process.
+Module used for parallelization of tasks. Exports a class `Worker` that takes the path of Node.js module and lets you call the module's exported methods as if they were class methods, returning a promise that resolves when the specified method finishes its execution in a forked process.
 
 ### Example
 


### PR DESCRIPTION
## Summary

There is an incorrect use of "where" when "were" was meant on the `JestPlatform.md` page.

## Test plan

It's such a minor change, I don't have one.
