### PR TITLE
Clarify usage of isNot in docs

### DIFF
--- a/docs/ExpectAPI.md
+++ b/docs/ExpectAPI.md
@@ -169,7 +169,7 @@ expect.extend({
       ? () =>
           this.utils.matcherHint('toBe', undefined, undefined, options) +
           '\n\n' +
-          `Expected: ${this.isNot ? 'not ' : ''}${this.utils.printExpected(expected)}\n` +
+          `Expected: not ${this.utils.printExpected(expected)}\n` +
           `Received: ${this.utils.printReceived(received)}`
       : () => {
           const diffString = diff(expected, received, {
@@ -180,7 +180,7 @@ expect.extend({
             '\n\n' +
             (diffString && diffString.includes('- Expect')
               ? `Difference:\n\n${diffString}`
-              : `Expected: ${this.isNot ? 'not ' : ''}${this.utils.printExpected(expected)}\n` +
+              : `Expected: ${this.utils.printExpected(expected)}\n` +
                 `Received: ${this.utils.printReceived(received)}`)
           );
         };

--- a/docs/ExpectAPI.md
+++ b/docs/ExpectAPI.md
@@ -129,7 +129,7 @@ These helper functions and properties can be found on `this` inside a custom mat
 
 #### `this.isNot`
 
-A boolean to let you know this matcher was called with the negated `.not` modifier allowing you to flip your assertion and display a clear and correct matcher hint (see example code).
+A boolean to let you know this matcher was called with the negated `.not` modifier allowing you to display a clear and correct matcher hint (see example code).
 
 #### `this.promise`
 
@@ -169,7 +169,7 @@ expect.extend({
       ? () =>
           this.utils.matcherHint('toBe', undefined, undefined, options) +
           '\n\n' +
-          `Expected: ${this.utils.printExpected(expected)}\n` +
+          `Expected: ${this.isNot ? 'not ' : ''}${this.utils.printExpected(expected)}\n` +
           `Received: ${this.utils.printReceived(received)}`
       : () => {
           const diffString = diff(expected, received, {
@@ -180,7 +180,7 @@ expect.extend({
             '\n\n' +
             (diffString && diffString.includes('- Expect')
               ? `Difference:\n\n${diffString}`
-              : `Expected: ${this.utils.printExpected(expected)}\n` +
+              : `Expected: ${this.isNot ? 'not ' : ''}${this.utils.printExpected(expected)}\n` +
                 `Received: ${this.utils.printReceived(received)}`)
           );
         };

--- a/website/versioned_docs/version-24.0/ExpectAPI.md
+++ b/website/versioned_docs/version-24.0/ExpectAPI.md
@@ -130,7 +130,7 @@ These helper functions and properties can be found on `this` inside a custom mat
 
 #### `this.isNot`
 
-A boolean to let you know this matcher was called with the negated `.not` modifier allowing you to flip your assertion and display a clear and correct matcher hint (see example code).
+A boolean to let you know this matcher was called with the negated `.not` modifier allowing you to display a clear and correct matcher hint (see example code).
 
 #### `this.promise`
 
@@ -170,7 +170,7 @@ expect.extend({
       ? () =>
           this.utils.matcherHint('toBe', undefined, undefined, options) +
           '\n\n' +
-          `Expected: ${this.utils.printExpected(expected)}\n` +
+          `Expected: not ${this.utils.printExpected(expected)}\n` +
           `Received: ${this.utils.printReceived(received)}`
       : () => {
           const diffString = diff(expected, received, {

--- a/website/versioned_docs/version-24.8/ExpectAPI.md
+++ b/website/versioned_docs/version-24.8/ExpectAPI.md
@@ -130,7 +130,7 @@ These helper functions and properties can be found on `this` inside a custom mat
 
 #### `this.isNot`
 
-A boolean to let you know this matcher was called with the negated `.not` modifier allowing you to flip your assertion and display a clear and correct matcher hint (see example code).
+A boolean to let you know this matcher was called with the negated `.not` modifier allowing you to display a clear and correct matcher hint (see example code).
 
 #### `this.promise`
 
@@ -170,7 +170,7 @@ expect.extend({
       ? () =>
           this.utils.matcherHint('toBe', undefined, undefined, options) +
           '\n\n' +
-          `Expected: ${this.utils.printExpected(expected)}\n` +
+          `Expected: not ${this.utils.printExpected(expected)}\n` +
           `Received: ${this.utils.printReceived(received)}`
       : () => {
           const diffString = diff(expected, received, {


### PR DESCRIPTION
## Summary

When reading expect API docs, I was confused about the usage of `isNot` in custom matchers. The original docs says that it allows to "flip your assertions", but in fact it's only used to display correct hint.

In the example, I think it'd be also helpful to show how `isNot` can be used when prefixing the "Expected" value.

## Test plan

N/A
