### PR TITLE
refactor: Replaces findDomNode() with refs

### DIFF
--- a/examples/react/CheckboxWithLabel.js
+++ b/examples/react/CheckboxWithLabel.js
@@ -14,8 +14,9 @@ export default class CheckboxWithLabel extends React.Component {
 
   render() {
     return (
-      <label>
+      <label ref={this.props.labelRef}>
         <input
+          ref={this.props.inputRef}
           type="checkbox"
           checked={this.state.isChecked}
           onChange={this.onChange}

--- a/examples/react/__tests__/CheckboxWithLabel-test.js
+++ b/examples/react/__tests__/CheckboxWithLabel-test.js
@@ -1,24 +1,30 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
 
-import React from 'react';
-import ReactDOM from 'react-dom';
+import React, {createRef} from 'react';
+
 import * as TestUtils from 'react-dom/test-utils';
 import CheckboxWithLabel from '../CheckboxWithLabel';
 
 it('CheckboxWithLabel changes the text after click', () => {
+  const checkboxLabelRef = createRef();
+  const checkboxInputRef = createRef();
   // Render a checkbox with label in the document
-  const checkbox = TestUtils.renderIntoDocument(
-    <CheckboxWithLabel labelOn="On" labelOff="Off" />
+  TestUtils.renderIntoDocument(
+    <CheckboxWithLabel
+      labelRef={checkboxLabelRef}
+      inputRef={checkboxInputRef}
+      labelOn="On"
+      labelOff="Off"
+    />
   );
 
-  const checkboxNode = ReactDOM.findDOMNode(checkbox);
+  const labelNode = checkboxLabelRef.current;
+  const inputNode = checkboxInputRef.current;
 
   // Verify that it's Off by default
-  expect(checkboxNode.textContent).toEqual('Off');
+  expect(labelNode.textContent).toEqual('Off');
 
   // Simulate a click and verify that it is now On
-  TestUtils.Simulate.change(
-    TestUtils.findRenderedDOMComponentWithTag(checkbox, 'input')
-  );
-  expect(checkboxNode.textContent).toEqual('On');
+  TestUtils.Simulate.change(inputNode);
+  expect(labelNode.textContent).toEqual('On');
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary



As mentioned in #9043 usage of `findDomeNode()` is deprecated and have rule against its usage in ESLint. This PR Closes #9043 by removing `findDomeNode()` usage in the example and replaces it with `createRef()`.  

Since the test required accessing two different DOM nodes (`label` and `input`), ref forwarding is used for both of them

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

`yarn test`