### PR TITLE
docs: add comment about 'cleanup' in react-testing-library example

### DIFF
--- a/docs/TutorialReact.md
+++ b/docs/TutorialReact.md
@@ -256,7 +256,8 @@ import React from 'react';
 import {cleanup, fireEvent, render} from '@testing-library/react';
 import CheckboxWithLabel from '../CheckboxWithLabel';
 
-// automatically unmount and cleanup DOM after the test is finished.
+// Note: running cleanup afterEach is done automatically for you in @testing-library/react@9.0.0 or higher
+// unmount and cleanup DOM after the test is finished.
 afterEach(cleanup);
 
 it('CheckboxWithLabel changes the text after click', () => {

--- a/examples/react-testing-library/__tests__/CheckboxWithLabel-test.js
+++ b/examples/react-testing-library/__tests__/CheckboxWithLabel-test.js
@@ -4,7 +4,8 @@ import React from 'react';
 import {cleanup, fireEvent, render} from '@testing-library/react';
 import CheckboxWithLabel from '../CheckboxWithLabel';
 
-// automatically unmount and cleanup DOM after the test is finished.
+// Note: running cleanup afterEach is done automatically for you in @testing-library/react@9.0.0 or higher
+// unmount and cleanup DOM after the test is finished.
 afterEach(cleanup);
 
 it('CheckboxWithLabel changes the text after click', () => {


### PR DESCRIPTION
## Summary
```react-testing-library``` automatically runs ```cleanup``` unless otherwise specified (https://github.com/testing-library/react-testing-library/pull/430). The change takes place in ```@testing-library/react@9.0.0``` (https://github.com/testing-library/react-testing-library/releases/tag/v9.0.0) and later.

I found the documentation to be contradictory as to whether ```afterEach(cleanup)``` should be called, and so hopefully this comment clarifies it for future users.

## Test plan
This is just adding a comment, so I do not believe any test plan is necessary.