### PR TITLE
docs: remove expect.assertions(1) in rejects example of TutorialAsync.md

### DIFF
--- a/docs/TutorialAsync.md
+++ b/docs/TutorialAsync.md
@@ -140,7 +140,7 @@ it('tests error with async/await', async () => {
 
 ## `.rejects`
 
-The`.rejects` helper works like the `.resolves` helper. If the promise is fulfilled, the test will automatically fail. `expect.assertions(number)` is not required but recommended to verify that a certain number of [assertions](https://jestjs.io/docs/en/expect#expectassertionsnumber) are called during a test. It is otherwise easy to forget to await a .resolves assertion. it is otherwise easy to forget to `return`/`await` the `expect.resolves`.
+The`.rejects` helper works like the `.resolves` helper. If the promise is fulfilled, the test will automatically fail. `expect.assertions(number)` is not required but recommended to verify that a certain number of [assertions](https://jestjs.io/docs/en/expect#expectassertionsnumber) are called during a test. It is otherwise easy to forget to `return`/`await` the `expect.resolves`.
 
 ```js
 // Testing for async errors using `.rejects`.

--- a/docs/TutorialAsync.md
+++ b/docs/TutorialAsync.md
@@ -140,11 +140,12 @@ it('tests error with async/await', async () => {
 
 ## `.rejects`
 
-The`.rejects` helper works like the `.resolves` helper. If the promise is fulfilled, the test will automatically fail.
+The`.rejects` helper works like the `.resolves` helper. If the promise is fulfilled, the test will automatically fail. `expect.assertions(number)` is not required but recommended to verify that a certain number of [assertions](https://jestjs.io/docs/en/expect#expectassertionsnumber) are called during a test.
 
 ```js
 // Testing for async errors using `.rejects`.
 it('tests error with rejects', () => {
+  expect.assertions(1);
   return expect(user.getUserName(3)).rejects.toEqual({
     error: 'User with 3 not found.',
   });
@@ -152,6 +153,7 @@ it('tests error with rejects', () => {
 
 // Or using async/await with `.rejects`.
 it('tests error with async/await and rejects', async () => {
+  expect.assertions(1);
   await expect(user.getUserName(3)).rejects.toEqual({
     error: 'User with 3 not found.',
   });

--- a/docs/TutorialAsync.md
+++ b/docs/TutorialAsync.md
@@ -140,7 +140,7 @@ it('tests error with async/await', async () => {
 
 ## `.rejects`
 
-The`.rejects` helper works like the `.resolves` helper. If the promise is fulfilled, the test will automatically fail. `expect.assertions(number)` is not required but recommended to verify that a certain number of [assertions](https://jestjs.io/docs/en/expect#expectassertionsnumber) are called during a test. It is otherwise easy to forget to `return`/`await` the `expect.resolves`.
+The`.rejects` helper works like the `.resolves` helper. If the promise is fulfilled, the test will automatically fail. `expect.assertions(number)` is not required but recommended to verify that a certain number of [assertions](https://jestjs.io/docs/en/expect#expectassertionsnumber) are called during a test. It is otherwise easy to forget to `await` the `.resolves` assertions.
 
 ```js
 // Testing for async errors using `.rejects`.

--- a/docs/TutorialAsync.md
+++ b/docs/TutorialAsync.md
@@ -140,7 +140,7 @@ it('tests error with async/await', async () => {
 
 ## `.rejects`
 
-The`.rejects` helper works like the `.resolves` helper. If the promise is fulfilled, the test will automatically fail. `expect.assertions(number)` is not required but recommended to verify that a certain number of [assertions](https://jestjs.io/docs/en/expect#expectassertionsnumber) are called during a test. It is otherwise easy to forget to `await` the `.resolves` assertions.
+The`.rejects` helper works like the `.resolves` helper. If the promise is fulfilled, the test will automatically fail. `expect.assertions(number)` is not required but recommended to verify that a certain number of [assertions](https://jestjs.io/docs/en/expect#expectassertionsnumber) are called during a test. It is otherwise easy to forget to `return`/`await` the `.resolves` assertions.
 
 ```js
 // Testing for async errors using `.rejects`.

--- a/docs/TutorialAsync.md
+++ b/docs/TutorialAsync.md
@@ -140,7 +140,7 @@ it('tests error with async/await', async () => {
 
 ## `.rejects`
 
-The`.rejects` helper works like the `.resolves` helper. If the promise is fulfilled, the test will automatically fail. `expect.assertions(number)` is not required but recommended to verify that a certain number of [assertions](https://jestjs.io/docs/en/expect#expectassertionsnumber) are called during a test.
+The`.rejects` helper works like the `.resolves` helper. If the promise is fulfilled, the test will automatically fail. `expect.assertions(number)` is not required but recommended to verify that a certain number of [assertions](https://jestjs.io/docs/en/expect#expectassertionsnumber) are called during a test. It is otherwise easy to forget to await a .resolves assertion. it is otherwise easy to forget to `return`/`await` the `expect.resolves`.
 
 ```js
 // Testing for async errors using `.rejects`.

--- a/docs/TutorialAsync.md
+++ b/docs/TutorialAsync.md
@@ -145,7 +145,6 @@ The`.rejects` helper works like the `.resolves` helper. If the promise is fulfil
 ```js
 // Testing for async errors using `.rejects`.
 it('tests error with rejects', () => {
-  expect.assertions(1);
   return expect(user.getUserName(3)).rejects.toEqual({
     error: 'User with 3 not found.',
   });
@@ -153,7 +152,6 @@ it('tests error with rejects', () => {
 
 // Or using async/await with `.rejects`.
 it('tests error with async/await and rejects', async () => {
-  expect.assertions(1);
   await expect(user.getUserName(3)).rejects.toEqual({
     error: 'User with 3 not found.',
   });


### PR DESCRIPTION
Hi. 
a few days ago, i registered issue #9143 
please, read that issue.
i suggest how about removing expect.assertions(1); code in rejects example of TutorialAsync.md
becauese i was not sure whether I should used assertions.

thank u.