### PR TITLE
jest-circus: remove switch with single case

### DIFF
--- a/packages/jest-circus/src/formatNodeAssertErrors.ts
+++ b/packages/jest-circus/src/formatNodeAssertErrors.ts
@@ -39,32 +39,30 @@ const humanReadableOperators: Record<string, string> = {
 };
 
 const formatNodeAssertErrors = (event: Circus.Event, state: Circus.State) => {
-  switch (event.name) {
-    case 'test_done': {
-      event.test.errors = event.test.errors.map((errors: Circus.TestError) => {
-        let error;
-        if (Array.isArray(errors)) {
-          const [originalError, asyncError] = errors;
+  if (event.name === 'test_done') {
+    event.test.errors = event.test.errors.map((errors: Circus.TestError) => {
+      let error;
+      if (Array.isArray(errors)) {
+        const [originalError, asyncError] = errors;
 
-          if (originalError == null) {
-            error = asyncError;
-          } else if (!originalError.stack) {
-            error = asyncError;
+        if (originalError == null) {
+          error = asyncError;
+        } else if (!originalError.stack) {
+          error = asyncError;
 
-            error.message = originalError.message
-              ? originalError.message
-              : `thrown: ${prettyFormat(originalError, {maxDepth: 3})}`;
-          } else {
-            error = originalError;
-          }
+          error.message = originalError.message
+            ? originalError.message
+            : `thrown: ${prettyFormat(originalError, {maxDepth: 3})}`;
         } else {
-          error = errors;
+          error = originalError;
         }
-        return isAssertionError(error)
-          ? {message: assertionErrorMessage(error, {expand: state.expand})}
-          : errors;
-      });
-    }
+      } else {
+        error = errors;
+      }
+      return isAssertionError(error)
+        ? {message: assertionErrorMessage(error, {expand: state.expand})}
+        : errors;
+    });
   }
 };
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary
Removed `switch` with only one `case`(replaced by `if`).
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
