### PR TITLE
property-based test for Node `deepStrictEqual` equivalence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@
 
 - `[expect]` Display `expectedDiff` more carefully in `toBeCloseTo` ([#8389](https://github.com/facebook/jest/pull/8389))
 - `[expect]` Avoid incorrect difference for subset when `toMatchObject` fails ([#9005](https://github.com/facebook/jest/pull/9005))
+- `[expect]` Consider all RegExp flags for equality ([#9167](https://github.com/facebook/jest/pull/9167))
+- `[expect]` [**BREAKING**] Consider primitives different from wrappers instantiated with `new` ([#9167](https://github.com/facebook/jest/pull/9167))
 - `[jest-config]` Use half of the available cores when `watchAll` mode is enabled ([#9117](https://github.com/facebook/jest/pull/9117))
 - `[jest-console]` Add missing `console.group` calls to `NullConsole` ([#9024](https://github.com/facebook/jest/pull/9024))
 - `[jest-core]` Don't include unref'd timers in --detectOpenHandles results ([#8941](https://github.com/facebook/jest/pull/8941))
@@ -63,6 +65,7 @@
 - `[docs]` Add alias and optional boolean value to `coverage` CLI Reference ([#8996](https://github.com/facebook/jest/pull/8996))
 - `[docs]` Fix broken link pointing to legacy JS file in "Snapshot Testing".
 - `[docs]` Add `setupFilesAfterEnv` and `jest.setTimeout` example ([#8971](https://github.com/facebook/jest/pull/8971))
+- `[expect]` Test that `toStrictEqual` is equivalent to Node's `assert.deepStrictEqual` ([#9167](https://github.com/facebook/jest/pull/9167))
 - `[jest]` [**BREAKING**] Use ESM exports ([#8874](https://github.com/facebook/jest/pull/8874))
 - `[jest-cli]` [**BREAKING**] Use ESM exports ([#8874](https://github.com/facebook/jest/pull/8874))
 - `[jest-cli]` [**BREAKING**] Remove re-exports from `@jest/core` ([#8874](https://github.com/facebook/jest/pull/8874))

--- a/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -1986,6 +1986,13 @@ Expected: <g>{"asymmetricMatch": [Function asymmetricMatch]}</>
 Received: <r>"Eve"</>
 `;
 
+exports[`.toEqual() {pass: false} expect("abc").toEqual({"0": "a", "1": "b", "2": "c"}) 1`] = `
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
+
+Expected: <g>{"0": "a", "1": "b", "2": "c"}</>
+Received: <r>"abc"</>
+`;
+
 exports[`.toEqual() {pass: false} expect("abd").toEqual(StringContaining "bc") 1`] = `
 <d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
@@ -2021,6 +2028,13 @@ exports[`.toEqual() {pass: false} expect("type TypeName<T> = T extends Function 
 <r>+ type TypeName<T> = T extends Function<i> </i>? "function"<i> </i>: "object";</>
 `;
 
+exports[`.toEqual() {pass: false} expect(/abc/gy).toEqual(/abc/g) 1`] = `
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
+
+Expected: <g>/abc/g</>
+Received: <r>/abc/gy</>
+`;
+
 exports[`.toEqual() {pass: false} expect([1, 2]).toEqual([2, 1]) 1`] = `
 <d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
@@ -2051,6 +2065,13 @@ exports[`.toEqual() {pass: false} expect([1]).toEqual([2]) 1`] = `
 <g>-   2,</>
 <r>+   1,</>
 <d>  ]</>
+`;
+
+exports[`.toEqual() {pass: false} expect({"0": "a", "1": "b", "2": "c"}).toEqual("abc") 1`] = `
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
+
+Expected: <g>"abc"</>
+Received: <r>{"0": "a", "1": "b", "2": "c"}</>
 `;
 
 exports[`.toEqual() {pass: false} expect({"a": 1, "b": 2}).toEqual(ObjectContaining {"a": 2}) 1`] = `
@@ -2110,6 +2131,27 @@ exports[`.toEqual() {pass: false} expect({"target": {"nodeType": 1, "value": "a"
 <r>+     "value": "a",</>
 <d>    },</>
 <d>  }</>
+`;
+
+exports[`.toEqual() {pass: false} expect({}).toEqual({}) 1`] = `
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
+
+Expected: <g>{}</>
+Received: serializes to the same string
+`;
+
+exports[`.toEqual() {pass: false} expect({}).toEqual(0) 1`] = `
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
+
+Expected: <g>0</>
+Received: <r>{}</>
+`;
+
+exports[`.toEqual() {pass: false} expect(0).toEqual({}) 1`] = `
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
+
+Expected: <g>{}</>
+Received: <r>0</>
 `;
 
 exports[`.toEqual() {pass: false} expect(0).toEqual(-0) 1`] = `
@@ -2467,11 +2509,18 @@ Expected: not <g>"abc"</>
 
 `;
 
-exports[`.toEqual() {pass: true} expect("abc").not.toEqual({"0": "a", "1": "b", "2": "c"}) 1`] = `
+exports[`.toEqual() {pass: true} expect("abc").not.toEqual("abc") 2`] = `
 <d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: not <g>{"0": "a", "1": "b", "2": "c"}</>
-Received:     <r>"abc"</>
+Expected: not <g>"abc"</>
+
+`;
+
+exports[`.toEqual() {pass: true} expect("abc").not.toEqual("abc") 3`] = `
+<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
+
+Expected: not <g>"abc"</>
+
 `;
 
 exports[`.toEqual() {pass: true} expect("abcd").not.toEqual(StringContaining "bc") 1`] = `
@@ -2516,13 +2565,6 @@ Expected: not <g>Any<Function></>
 Received:     <r>[Function anonymous]</>
 `;
 
-exports[`.toEqual() {pass: true} expect({"0": "a", "1": "b", "2": "c"}).not.toEqual("abc") 1`] = `
-<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
-
-Expected: not <g>"abc"</>
-Received:     <r>{"0": "a", "1": "b", "2": "c"}</>
-`;
-
 exports[`.toEqual() {pass: true} expect({"a": 1, "b": [Function b], "c": true}).not.toEqual({"a": 1, "b": Any<Function>, "c": Anything}) 1`] = `
 <d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
@@ -2558,18 +2600,25 @@ Expected: not <g>{}</>
 
 `;
 
-exports[`.toEqual() {pass: true} expect({}).not.toEqual(0) 1`] = `
-<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
-
-Expected: not <g>0</>
-Received:     <r>{}</>
-`;
-
-exports[`.toEqual() {pass: true} expect(0).not.toEqual({}) 1`] = `
+exports[`.toEqual() {pass: true} expect({}).not.toEqual({}) 2`] = `
 <d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
 Expected: not <g>{}</>
-Received:     <r>0</>
+
+`;
+
+exports[`.toEqual() {pass: true} expect(0).not.toEqual(0) 1`] = `
+<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
+
+Expected: not <g>0</>
+
+`;
+
+exports[`.toEqual() {pass: true} expect(0).not.toEqual(0) 2`] = `
+<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
+
+Expected: not <g>0</>
+
 `;
 
 exports[`.toEqual() {pass: true} expect(1).not.toEqual(1) 1`] = `

--- a/packages/expect/src/__tests__/matchers-toContain.property.test.ts
+++ b/packages/expect/src/__tests__/matchers-toContain.property.test.ts
@@ -11,6 +11,7 @@ import {
   anythingSettings,
   assertSettings,
 } from './__arbitraries__/sharedSettings';
+import expect from '..';
 
 describe('toContain', () => {
   it('should always find the value when inside the array', () => {

--- a/packages/expect/src/__tests__/matchers-toContainEqual.property.test.ts
+++ b/packages/expect/src/__tests__/matchers-toContainEqual.property.test.ts
@@ -11,6 +11,7 @@ import {
   anythingSettings,
   assertSettings,
 } from './__arbitraries__/sharedSettings';
+import expect from '..';
 
 describe('toContainEqual', () => {
   it('should always find the value when inside the array', () => {

--- a/packages/expect/src/__tests__/matchers-toEqual.property.test.ts
+++ b/packages/expect/src/__tests__/matchers-toEqual.property.test.ts
@@ -11,6 +11,7 @@ import {
   anythingSettings,
   assertSettings,
 } from './__arbitraries__/sharedSettings';
+import expect from '..';
 
 describe('toEqual', () => {
   it('should be reflexive', () => {

--- a/packages/expect/src/__tests__/matchers-toStrictEqual.property.test.ts
+++ b/packages/expect/src/__tests__/matchers-toStrictEqual.property.test.ts
@@ -6,13 +6,32 @@
  *
  */
 
+import assert from 'assert';
+import {onNodeVersions} from '@jest/test-utils';
 import fc from 'fast-check';
 import {
   anythingSettings,
   assertSettings,
 } from './__arbitraries__/sharedSettings';
+import expect from '..';
 
 describe('toStrictEqual', () => {
+  const safeExpectStrictEqual = (a, b) => {
+    try {
+      expect(a).toStrictEqual(b);
+      return true;
+    } catch (err) {
+      return false;
+    }
+  };
+  const safeAssertDeepStrictEqual = (a, b) => {
+    try {
+      assert.deepStrictEqual(a, b);
+      return true;
+    } catch (err) {
+      return false;
+    }
+  };
   it('should be reflexive', () => {
     fc.assert(
       fc.property(fc.dedup(fc.anything(anythingSettings), 2), ([a, b]) => {
@@ -24,14 +43,6 @@ describe('toStrictEqual', () => {
   });
 
   it('should be symmetric', () => {
-    const safeExpectStrictEqual = (a, b) => {
-      try {
-        expect(a).toStrictEqual(b);
-        return true;
-      } catch (err) {
-        return false;
-      }
-    };
     fc.assert(
       fc.property(
         fc.anything(anythingSettings),
@@ -45,5 +56,22 @@ describe('toStrictEqual', () => {
       ),
       assertSettings,
     );
+  });
+
+  onNodeVersions('>=9', () => {
+    it('should be equivalent to Node deepStrictEqual', () => {
+      fc.assert(
+        fc.property(
+          fc.anything(anythingSettings),
+          fc.anything(anythingSettings),
+          (a, b) => {
+            expect(safeExpectStrictEqual(a, b)).toBe(
+              safeAssertDeepStrictEqual(a, b),
+            );
+          },
+        ),
+        assertSettings,
+      );
+    });
   });
 });

--- a/packages/expect/src/__tests__/matchers.test.js
+++ b/packages/expect/src/__tests__/matchers.test.js
@@ -419,12 +419,19 @@ describe('.toStrictEqual()', () => {
 });
 
 describe('.toEqual()', () => {
+  /* eslint-disable no-new-wrappers */
   [
     [true, false],
     [1, 2],
     [0, -0],
     [0, Number.MIN_VALUE], // issues/7941
     [Number.MIN_VALUE, 0],
+    [0, new Number(0)],
+    [new Number(0), 0],
+    [new Number(0), new Number(1)],
+    ['abc', new String('abc')],
+    [new String('abc'), 'abc'],
+    [/abc/gsy, /abc/g],
     [{a: 1}, {a: 2}],
     [{a: 5}, {b: 6}],
     ['banana', 'apple'],
@@ -548,15 +555,12 @@ describe('.toEqual()', () => {
     [true, true],
     [1, 1],
     [NaN, NaN],
-    // eslint-disable-next-line no-new-wrappers
-    [0, new Number(0)],
-    // eslint-disable-next-line no-new-wrappers
-    [new Number(0), 0],
+    [0, Number(0)],
+    [Number(0), 0],
+    [new Number(0), new Number(0)],
     ['abc', 'abc'],
-    // eslint-disable-next-line no-new-wrappers
-    [new String('abc'), 'abc'],
-    // eslint-disable-next-line no-new-wrappers
-    ['abc', new String('abc')],
+    [String('abc'), 'abc'],
+    ['abc', String('abc')],
     [[1], [1]],
     [
       [1, 2],
@@ -856,6 +860,7 @@ describe('.toEqual()', () => {
       expect(d).not.toEqual(c);
     });
   });
+  /* eslint-enable */
 });
 
 describe('.toBeInstanceOf()', () => {

--- a/packages/expect/src/jasmineUtils.ts
+++ b/packages/expect/src/jasmineUtils.ts
@@ -100,29 +100,29 @@ function eq(
     return false;
   }
   switch (className) {
-    // Strings, numbers, dates, and booleans are compared by value.
-    case '[object String]':
-      // Primitives and their corresponding object wrappers are equivalent; thus, `"5"` is
-      // equivalent to `new String("5")`.
-      return a == String(b);
-    case '[object Number]':
-      return Object.is(Number(a), Number(b));
-    case '[object Date]':
     case '[object Boolean]':
-      // Coerce dates and booleans to numeric primitive values. Dates are compared by their
+    case '[object String]':
+    case '[object Number]':
+      if (typeof a !== typeof b) {
+        // One is a primitive, one a `new Primitive()`
+        return false;
+      } else if (typeof a !== 'object' && typeof b !== 'object') {
+        // both are proper primitives
+        return Object.is(a, b);
+      } else {
+        // both are `new Primitive()`s
+        return Object.is(a.valueOf(), b.valueOf());
+      }
+    case '[object Date]':
+      // Coerce dates to numeric primitive values. Dates are compared by their
       // millisecond representations. Note that invalid dates with millisecond representations
       // of `NaN` are not equivalent.
       return +a == +b;
     // RegExps are compared by their source patterns and flags.
     case '[object RegExp]':
-      return (
-        a.source == b.source &&
-        a.global == b.global &&
-        a.multiline == b.multiline &&
-        a.ignoreCase == b.ignoreCase
-      );
+      return a.source === b.source && a.flags === b.flags;
   }
-  if (typeof a != 'object' || typeof b != 'object') {
+  if (typeof a !== 'object' || typeof b !== 'object') {
     return false;
   }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Builds on the awesome work of @dubzzz by adding a test that our `expect.toStrictEqual` is equivalent to Node's `assert.deepStrictEqual`. Even though I disagree with the behavior of `deepStrictEqual` [in some situations](https://github.com/facebook/jest/pull/7730), I think these are not too important and aligning with other equality implementations `deepStrictEqual` is more important. @SimenB @pedrottimark do you agree?

Running this a couple of times uncovered one mismatch:
Node (this btw means `fast-deep-equal` afaik) considers a primitive different from a `new Primitive()` (while it is of course equal to a `Primitive()` without `new`). This makes sense to me (they do not even have the same `typeof`!), and fwiw I tried `concordance` (=> AVA) and it agrees with Node.
I fixed this, which is breaking, but since using primitive constructors like `new Number()` etc. is a bad pattern anyway (without new is recommended) I do not think this will affect many users.

Also sneaked in a fix ensuring that all `RegExp` flags are considered for equality to avoid false negatives.

Side note:
I am not very happy with our equality implementation when comparing it to `fast-deep-equal` or `concordance` in terms of structure / maintainability. It needs a rewrite (possibly in line with refactors for https://github.com/facebook/jest/issues/6184), or replacement with an external lib.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Added property-based test as described.
Changed existing property-based tests to `import expect` so that they do not require rebuilds to be up to date.
Added specific test cases for the changed equality behavior.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
