### PR TITLE
Fix missing test results for facebook/jest CI runs in Azure Pipelines

### DIFF
--- a/jest.config.ci.js
+++ b/jest.config.ci.js
@@ -11,7 +11,10 @@
 module.exports = Object.assign({}, require('./jest.config'), {
   coverageReporters: ['json'],
   reporters: [
-    ['jest-junit', {outputDirectory: 'reports/junit', outputName: 'js-test-results.xml'}],
+    [
+      'jest-junit',
+      {outputDirectory: 'reports/junit', outputName: 'js-test-results.xml'},
+    ],
     ['jest-silent-reporter', {useDots: true}],
   ],
 });

--- a/jest.config.ci.js
+++ b/jest.config.ci.js
@@ -11,7 +11,7 @@
 module.exports = Object.assign({}, require('./jest.config'), {
   coverageReporters: ['json'],
   reporters: [
-    ['jest-junit', {output: 'reports/junit/js-test-results.xml'}],
+    ['jest-junit', {outputDirectory: 'reports/junit', outputName: 'js-test-results.xml'}],
     ['jest-silent-reporter', {useDots: true}],
   ],
 });


### PR DESCRIPTION
## Summary

A breaking change in `jest-junit` 8.0.0 (https://github.com/jest-community/jest-junit/pull/101) caused test results to no longer appear for the facebook/jest CI pipeline in Azure Pipelines:

![image](https://user-images.githubusercontent.com/2503052/68797054-de362800-0621-11ea-8331-80ae6e885bd6.png)

[Example run](https://dev.azure.com/jestjs/jest/_build/results?buildId=3792&view=ms.vss-test-web.build-test-results-tab)

The jest-junit reporter is used in facebook/jest CI runs to produce XML Junit files which feed the Tests UX in Azure Pipelines. 

The breaking change replaced the `output` configuration option (used in `jest.config.ci.js`) with separate `outputDirectory` and `outputName` options. Moving to jest-junit 9.0.0 (#9114) caused the problem to surface.

## Test plan

With this fix, test results are now appearing again in Azure Pipelines:

![image](https://user-images.githubusercontent.com/2503052/68797247-3ec56500-0622-11ea-9a84-3030a615394b.png)
