### PR TITLE
feat: add `buildDefaultResolverRequire`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - `[jest-snapshot]` [**BREAKING**] Improve report when the matcher has properties ([#9104](https://github.com/facebook/jest/pull/9104))
 - `[jest-snapshot]` Improve colors when snapshots are updatable ([#9132](https://github.com/facebook/jest/pull/9132))
 - `[jest-snapshot]` Ignore indentation for most serialized objects ([#9203](https://github.com/facebook/jest/pull/9203))
+- `[jest-transform]` Create `createTranspilingRequire` function for easy transpiling modules ([#9194](https://github.com/facebook/jest/pull/9194))
 - `[@jest/test-result]` Create method to create empty `TestResult` ([#8867](https://github.com/facebook/jest/pull/8867))
 - `[jest-worker]` [**BREAKING**] Return a promise from `end()`, resolving with the information whether workers exited gracefully ([#8206](https://github.com/facebook/jest/pull/8206))
 - `[jest-reporters]` Transform file paths into hyperlinks ([#8980](https://github.com/facebook/jest/pull/8980))

--- a/packages/jest-transform/src/ScriptTransformer.ts
+++ b/packages/jest-transform/src/ScriptTransformer.ts
@@ -9,7 +9,7 @@ import {createHash} from 'crypto';
 import * as path from 'path';
 import {Script} from 'vm';
 import {Config} from '@jest/types';
-import {createDirectory, isPromise} from 'jest-util';
+import {createDirectory, interopRequireDefault, isPromise} from 'jest-util';
 import * as fs from 'graceful-fs';
 import {transformSync as babelTransform} from '@babel/core';
 // @ts-ignore: should just be `require.resolve`, but the tests mess that up
@@ -532,6 +532,23 @@ export default class ScriptTransformer {
       !!this._config.transform && !!this._config.transform.length && !isIgnored
     );
   }
+}
+
+export function createTranspilingRequire(config: Config.ProjectConfig) {
+  const transformer = new ScriptTransformer(config);
+
+  return function requireAndTranspileModule<TModuleType = unknown>(
+    resolverPath: string,
+    applyInteropRequireDefault: boolean = false,
+  ): TModuleType {
+    const transpiledModule = transformer.requireAndTranspileModule<TModuleType>(
+      resolverPath,
+    );
+
+    return applyInteropRequireDefault
+      ? interopRequireDefault(transpiledModule).default
+      : transpiledModule;
+  };
 }
 
 const removeFile = (path: Config.Path) => {

--- a/packages/jest-transform/src/index.ts
+++ b/packages/jest-transform/src/index.ts
@@ -5,7 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-export {default as ScriptTransformer} from './ScriptTransformer';
+export {
+  default as ScriptTransformer,
+  createTranspilingRequire,
+} from './ScriptTransformer';
 export {default as shouldInstrument} from './shouldInstrument';
 export {
   Transformer,


### PR DESCRIPTION
This is a breaking out of [`buildDefaultResolverRequire`](https://github.com/facebook/jest/pull/8829/files#diff-79e46c9e92027daadc4fc85b7b71ae2dR27-R32) from #8829 as [requested](https://github.com/facebook/jest/pull/8829#issuecomment-522338238)

@SimenB I've not written tests or add an entry in the changelog as it seemed like a bit of overkill for something that is going to be used in future PRs.

I did a sweep of the codebase, and the only place this could actually be used right now is in `jest-core`, but that'd require implementing support for the callback parameters 🤷‍♀

It'll be nice to trim down the transformer PRs a bit :)