### PR TITLE
jest-snapshot: Ignore indentation for most serialized objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - `[jest-snapshot]` Display change counts in annotation lines ([#8982](https://github.com/facebook/jest/pull/8982))
 - `[jest-snapshot]` [**BREAKING**] Improve report when the matcher has properties ([#9104](https://github.com/facebook/jest/pull/9104))
 - `[jest-snapshot]` Improve colors when snapshots are updatable ([#9132](https://github.com/facebook/jest/pull/9132))
+- `[jest-snapshot]` Ignore indentation for most serialized objects ([#9203](https://github.com/facebook/jest/pull/9203))
 - `[@jest/test-result]` Create method to create empty `TestResult` ([#8867](https://github.com/facebook/jest/pull/8867))
 - `[jest-worker]` [**BREAKING**] Return a promise from `end()`, resolving with the information whether workers exited gracefully ([#8206](https://github.com/facebook/jest/pull/8206))
 - `[jest-reporters]` Transform file paths into hyperlinks ([#8980](https://github.com/facebook/jest/pull/8980))

--- a/packages/jest-snapshot/src/__tests__/__snapshots__/printSnapshot.test.ts.snap
+++ b/packages/jest-snapshot/src/__tests__/__snapshots__/printSnapshot.test.ts.snap
@@ -375,6 +375,90 @@ Snapshot: <m>"delete"</>
 Received: <t>"insert"</>
 `;
 
+exports[`printSnapshotAndReceived ignore indentation markup delete 1`] = `
+<m>- Snapshot  - 2</>
+<t>+ Received  + 0</>
+
+<d>  <div></>
+<m>-   <div></>
+<d>    <h3></>
+<d>      Ignore indentation for most serialized objects</>
+<d>    </h3></>
+<d>    <p></>
+<d>      Call<Y> </Y></>
+<d>      <code></>
+<d>        diffLinesUnified2</>
+<d>      </code></>
+<d>       to compare without indentation</>
+<d>    </p></>
+<m>-   </div></>
+<d>  </div></>
+`;
+
+exports[`printSnapshotAndReceived ignore indentation markup fall back 1`] = `
+<m>- Snapshot  - 5</>
+<t>+ Received  + 7</>
+
+<m>- <pre</>
+<m>-   className="language-js"</>
+<m>- ></>
+<m>-   for (key in foo) {</>
+<t>+ <div></>
+<t>+   <pre</>
+<t>+     className="language-js"</>
+<t>+   ></>
+<t>+     for (key in foo) {</>
+<d>    if (Object.prototype.hasOwnProperty.call(foo, key)) {</>
+<d>      doSomething(key);</>
+<d>    }</>
+<d>  }</>
+<m>- </pre></>
+<t>+   </pre></>
+<t>+ </div></>
+`;
+
+exports[`printSnapshotAndReceived ignore indentation markup insert 1`] = `
+<m>- Snapshot  - 0</>
+<t>+ Received  + 7</>
+
+<d>  <th></>
+<t>+   <span></>
+<d>      when</>
+<t>+   </span></>
+<t>+   <abbr</>
+<t>+     title="ascending from older to newer"</>
+<t>+   ></>
+<t>+     ↓</>
+<t>+   </abbr></>
+<d>  </th></>
+`;
+
+exports[`printSnapshotAndReceived ignore indentation object delete 1`] = `
+<m>- Snapshot  - 2</>
+<t>+ Received  + 0</>
+
+<d>  Object {</>
+<m>-   "payload": Object {</>
+<d>    "text": "Ignore indentation in snapshot",</>
+<d>    "time": "2019-11-11",</>
+<m>-   },</>
+<d>    "type": "CREATE_ITEM",</>
+<d>  }</>
+`;
+
+exports[`printSnapshotAndReceived ignore indentation object insert 1`] = `
+<m>- Snapshot  - 0</>
+<t>+ Received  + 2</>
+
+<d>  Object {</>
+<t>+   "payload": Object {</>
+<d>      "text": "Ignore indentation in snapshot",</>
+<d>      "time": "2019-11-11",</>
+<t>+   },</>
+<d>    "type": "CREATE_ITEM",</>
+<d>  }</>
+`;
+
 exports[`printSnapshotAndReceived isLineDiffable false asymmetric matcher 1`] = `
 Snapshot: <m>null</>
 Received: <t>Object {</>

--- a/packages/jest-snapshot/src/__tests__/dedentLines.test.ts
+++ b/packages/jest-snapshot/src/__tests__/dedentLines.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import format = require('pretty-format');
+import {dedentLines} from '../dedentLines';
+
+const $$typeof = Symbol.for('react.test.json');
+const plugins = [format.plugins.ReactTestComponent];
+
+const formatLines2 = val => format(val, {indent: 2, plugins}).split('\n');
+const formatLines0 = val => format(val, {indent: 0, plugins}).split('\n');
+
+describe('dedentLines non-null', () => {
+  test('no lines', () => {
+    const indented = [];
+    const dedented = indented;
+
+    expect(dedentLines(indented)).toEqual(dedented);
+  });
+
+  test('one line empty string', () => {
+    const indented = [''];
+    const dedented = indented;
+
+    expect(dedentLines(indented)).toEqual(dedented);
+  });
+
+  test('one line empty object', () => {
+    const val = {};
+    const indented = formatLines2(val);
+    const dedented = formatLines0(val);
+
+    expect(dedentLines(indented)).toEqual(dedented);
+  });
+
+  test('one line self-closing element', () => {
+    const val = {
+      $$typeof,
+      children: null,
+      type: 'br',
+    };
+    const indented = formatLines2(val);
+    const dedented = formatLines0(val);
+
+    expect(dedentLines(indented)).toEqual(dedented);
+  });
+
+  test('object value empty string', () => {
+    const val = {
+      key: '',
+    };
+    const indented = formatLines2(val);
+    const dedented = formatLines0(val);
+
+    expect(dedentLines(indented)).toEqual(dedented);
+  });
+
+  test('object value string includes double-quote marks', () => {
+    const val = {
+      key: '"Always bet on JavaScript",',
+    };
+    const indented = formatLines2(val);
+    const dedented = formatLines0(val);
+
+    expect(dedentLines(indented)).toEqual(dedented);
+  });
+
+  test('markup with props and text', () => {
+    const val = {
+      $$typeof,
+      children: [
+        {
+          $$typeof,
+          props: {
+            alt: 'Jest logo',
+            src: 'jest.svg',
+          },
+          type: 'img',
+        },
+        {
+          $$typeof,
+          children: ['Delightful JavaScript testing'],
+          type: 'h2',
+        },
+      ],
+      type: 'header',
+    };
+    const indented = formatLines2(val);
+    const dedented = formatLines0(val);
+
+    expect(dedentLines(indented)).toEqual(dedented);
+  });
+
+  test('markup with components as props', () => {
+    // https://daveceddia.com/pluggable-slots-in-react-components/
+    const val = {
+      $$typeof,
+      children: null,
+      props: {
+        content: {
+          $$typeof,
+          children: ['main content here'],
+          type: 'Content',
+        },
+        sidebar: {
+          $$typeof,
+          children: null,
+          props: {
+            user: '0123456789abcdef',
+          },
+          type: 'UserStats',
+        },
+      },
+      type: 'Body',
+    };
+    const indented = formatLines2(val);
+    const dedented = formatLines0(val);
+
+    expect(dedentLines(indented)).toEqual(dedented);
+  });
+});
+
+describe('dedentLines null', () => {
+  test('object key multi-line', () => {
+    const val = {
+      'multi\nline\nstring': false,
+    };
+    const indented = formatLines2(val);
+
+    expect(dedentLines(indented)).toEqual(null);
+  });
+
+  test('object value multi-line', () => {
+    const val = {
+      key: 'multi\nline\nstring',
+    };
+    const indented = formatLines2(val);
+
+    expect(dedentLines(indented)).toEqual(null);
+  });
+
+  test('object key and value multi-line', () => {
+    const val = {
+      'multi\nline\nstring': '\nleading newline',
+    };
+    const indented = formatLines2(val);
+
+    expect(dedentLines(indented)).toEqual(null);
+  });
+
+  test('markup prop multi-line', () => {
+    const val = {
+      $$typeof,
+      children: null,
+      props: {
+        alt: 'trailing newline\n',
+        src: 'jest.svg',
+      },
+      type: 'img',
+    };
+    const indented = formatLines2(val);
+
+    expect(dedentLines(indented)).toEqual(null);
+  });
+
+  test('markup prop component with multi-line text', () => {
+    // https://daveceddia.com/pluggable-slots-in-react-components/
+    const val = {
+      $$typeof,
+      children: [
+        {
+          $$typeof,
+          children: null,
+          props: {
+            content: {
+              $$typeof,
+              children: ['\n'],
+              type: 'Content',
+            },
+            sidebar: {
+              $$typeof,
+              children: null,
+              props: {
+                user: '0123456789abcdef',
+              },
+              type: 'UserStats',
+            },
+          },
+          type: 'Body',
+        },
+      ],
+      type: 'main',
+    };
+    const indented = formatLines2(val);
+
+    expect(dedentLines(indented)).toEqual(null);
+  });
+
+  test('markup text multi-line', () => {
+    const text = [
+      'for (key in foo) {',
+      '  if (Object.prototype.hasOwnProperty.call(foo, key)) {',
+      '    doSomething(key);',
+      '  }',
+      '}',
+    ].join('\n');
+    const val = {
+      $$typeof,
+      children: [
+        {
+          $$typeof,
+          children: [text],
+          props: {
+            className: 'language-js',
+          },
+          type: 'pre',
+        },
+      ],
+      type: 'div',
+    };
+    const indented = formatLines2(val);
+
+    expect(dedentLines(indented)).toEqual(null);
+  });
+
+  test('markup text multiple lines', () => {
+    const lines = [
+      'for (key in foo) {',
+      '  if (Object.prototype.hasOwnProperty.call(foo, key)) {',
+      '    doSomething(key);',
+      '  }',
+      '}',
+    ];
+    const val = {
+      $$typeof,
+      children: [
+        {
+          $$typeof,
+          children: lines,
+          props: {
+            className: 'language-js',
+          },
+          type: 'pre',
+        },
+      ],
+      type: 'div',
+    };
+    const indented = formatLines2(val);
+
+    expect(dedentLines(indented)).toEqual(null);
+  });
+
+  test('markup unclosed self-closing start tag', () => {
+    const indented = ['<img', '  alt="Jest logo"', '  src="jest.svg"'];
+
+    expect(dedentLines(indented)).toEqual(null);
+  });
+
+  test('markup unclosed because no end tag', () => {
+    const indented = ['<p>', '  Delightful JavaScript testing'];
+
+    expect(dedentLines(indented)).toEqual(null);
+  });
+});

--- a/packages/jest-snapshot/src/__tests__/dedentLines.test.ts
+++ b/packages/jest-snapshot/src/__tests__/dedentLines.test.ts
@@ -125,31 +125,12 @@ describe('dedentLines non-null', () => {
 });
 
 describe('dedentLines null', () => {
-  test('object key multi-line', () => {
-    const val = {
-      'multi\nline\nstring': false,
-    };
-    const indented = formatLines2(val);
-
-    expect(dedentLines(indented)).toEqual(null);
-  });
-
-  test('object value multi-line', () => {
-    const val = {
-      key: 'multi\nline\nstring',
-    };
-    const indented = formatLines2(val);
-
-    expect(dedentLines(indented)).toEqual(null);
-  });
-
-  test('object key and value multi-line', () => {
-    const val = {
-      'multi\nline\nstring': '\nleading newline',
-    };
-    const indented = formatLines2(val);
-
-    expect(dedentLines(indented)).toEqual(null);
+  test.each([
+    ['object key multi-line', {'multi\nline\nkey': false}],
+    ['object value multi-line', {key: 'multi\nline\nvalue'}],
+    ['object key and value multi-line', {'multi\nline': '\nleading nl'}],
+  ])('%s', (name, val) => {
+    expect(dedentLines(formatLines2(val))).toEqual(null);
   });
 
   test('markup prop multi-line', () => {

--- a/packages/jest-snapshot/src/__tests__/printSnapshot.test.ts
+++ b/packages/jest-snapshot/src/__tests__/printSnapshot.test.ts
@@ -1176,6 +1176,152 @@ describe('printSnapshotAndReceived', () => {
     expect(testWithStringify(expected, received, false)).toMatchSnapshot();
   });
 
+  describe('ignore indentation', () => {
+    const $$typeof = Symbol.for('react.test.json');
+
+    test('markup delete', () => {
+      const expected = {
+        $$typeof,
+        children: [
+          {
+            $$typeof,
+            children: [
+              {
+                $$typeof,
+                children: ['Ignore indentation for most serialized objects'],
+                type: 'h3',
+              },
+              {
+                $$typeof,
+                children: [
+                  'Call ',
+                  {
+                    $$typeof,
+                    children: ['diffLinesUnified2'],
+                    type: 'code',
+                  },
+                  ' to compare without indentation',
+                ],
+                type: 'p',
+              },
+            ],
+            type: 'div',
+          },
+        ],
+        type: 'div',
+      };
+      const received = {
+        $$typeof,
+        children: [
+          {
+            $$typeof,
+            children: ['Ignore indentation for most serialized objects'],
+            type: 'h3',
+          },
+          {
+            $$typeof,
+            children: [
+              'Call ',
+              {
+                $$typeof,
+                children: ['diffLinesUnified2'],
+                type: 'code',
+              },
+              ' to compare without indentation',
+            ],
+            type: 'p',
+          },
+        ],
+        type: 'div',
+      };
+
+      expect(testWithStringify(expected, received, false)).toMatchSnapshot();
+    });
+
+    test('markup fall back', () => {
+      // Because text has more than one adjacent line.
+      const text = [
+        'for (key in foo) {',
+        '  if (Object.prototype.hasOwnProperty.call(foo, key)) {',
+        '    doSomething(key);',
+        '  }',
+        '}',
+      ].join('\n');
+
+      const expected = {
+        $$typeof,
+        children: [text],
+        props: {
+          className: 'language-js',
+        },
+        type: 'pre',
+      };
+      const received = {
+        $$typeof,
+        children: [expected],
+        type: 'div',
+      };
+
+      expect(testWithStringify(expected, received, false)).toMatchSnapshot();
+    });
+
+    test('markup insert', () => {
+      const text = 'when';
+      const expected = {
+        $$typeof,
+        children: [text],
+        type: 'th',
+      };
+      const received = {
+        $$typeof,
+        children: [
+          {
+            $$typeof,
+            children: [text],
+            type: 'span',
+          },
+          {
+            $$typeof,
+            children: ['↓'],
+            props: {
+              title: 'ascending from older to newer',
+            },
+            type: 'abbr',
+          },
+        ],
+        type: 'th',
+      };
+
+      expect(testWithStringify(expected, received, false)).toMatchSnapshot();
+    });
+
+    describe('object', () => {
+      const text = 'Ignore indentation in snapshot';
+      const time = '2019-11-11';
+      const type = 'CREATE_ITEM';
+      const less = {
+        text,
+        time,
+        type,
+      };
+      const more = {
+        payload: {
+          text,
+          time,
+        },
+        type,
+      };
+
+      test('delete', () => {
+        expect(testWithStringify(more, less, false)).toMatchSnapshot();
+      });
+
+      test('insert', () => {
+        expect(testWithStringify(less, more, false)).toMatchSnapshot();
+      });
+    });
+  });
+
   describe('without serialize', () => {
     test('backtick single line expected and received', () => {
       const expected = 'var foo = `backtick`;';

--- a/packages/jest-snapshot/src/__tests__/printSnapshot.test.ts
+++ b/packages/jest-snapshot/src/__tests__/printSnapshot.test.ts
@@ -1180,36 +1180,6 @@ describe('printSnapshotAndReceived', () => {
     const $$typeof = Symbol.for('react.test.json');
 
     test('markup delete', () => {
-      const expected = {
-        $$typeof,
-        children: [
-          {
-            $$typeof,
-            children: [
-              {
-                $$typeof,
-                children: ['Ignore indentation for most serialized objects'],
-                type: 'h3',
-              },
-              {
-                $$typeof,
-                children: [
-                  'Call ',
-                  {
-                    $$typeof,
-                    children: ['diffLinesUnified2'],
-                    type: 'code',
-                  },
-                  ' to compare without indentation',
-                ],
-                type: 'p',
-              },
-            ],
-            type: 'div',
-          },
-        ],
-        type: 'div',
-      };
       const received = {
         $$typeof,
         children: [
@@ -1232,6 +1202,11 @@ describe('printSnapshotAndReceived', () => {
             type: 'p',
           },
         ],
+        type: 'div',
+      };
+      const expected = {
+        $$typeof,
+        children: [received],
         type: 'div',
       };
 

--- a/packages/jest-snapshot/src/dedentLines.ts
+++ b/packages/jest-snapshot/src/dedentLines.ts
@@ -1,0 +1,149 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const getIndentationLength = (line: string): number => {
+  const result = /^( {2})+/.exec(line);
+  return result === null ? 0 : result[0].length;
+};
+
+const dedentLine = (line: string): string =>
+  line.slice(getIndentationLength(line));
+
+// Return true if:
+// "key": "value has multiple lines\n…
+// "key has multiple lines\n…
+const hasUnmatchedDoubleQuoteMarks = (string: string): boolean => {
+  let n = 0;
+
+  let i = string.indexOf('"', 0);
+  while (i !== -1) {
+    if (i === 0 || string[i - 1] !== '\\') {
+      n += 1;
+    }
+
+    i = string.indexOf('"', i + 1);
+  }
+
+  return n % 2 !== 0;
+};
+
+const isFirstLineOfTag = (line: string) => /^( {2})*\</.test(line);
+
+// The length of the output array is the index of the next input line.
+
+// Push dedented lines of start tag onto output and return true;
+// otherwise return false because:
+// * props include a multiline string (or text node, if props have markup)
+// * start tag does not close
+const dedentStartTag = (
+  input: Array<string>,
+  output: Array<string>,
+): boolean => {
+  let line = input[output.length];
+  output.push(dedentLine(line));
+
+  if (line.includes('>')) {
+    return true;
+  }
+
+  while (output.length < input.length) {
+    line = input[output.length];
+
+    if (hasUnmatchedDoubleQuoteMarks(line)) {
+      return false; // because props include a multiline string
+    } else if (isFirstLineOfTag(line)) {
+      // Recursion only if props have markup.
+      if (!dedentMarkup(input, output)) {
+        return false;
+      }
+    } else {
+      output.push(dedentLine(line));
+
+      if (line.includes('>')) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+};
+
+// Push dedented lines of markup onto output and return true;
+// otherwise return false because:
+// * props include a multiline string
+// * text has more than one adjacent line
+// * markup does not close
+const dedentMarkup = (input: Array<string>, output: Array<string>): boolean => {
+  let line = input[output.length];
+
+  if (!dedentStartTag(input, output)) {
+    return false;
+  }
+
+  if (input[output.length - 1].includes('/>')) {
+    return true;
+  }
+
+  let isText = false;
+  const stack: Array<number> = [];
+  stack.push(getIndentationLength(line));
+
+  while (stack.length > 0 && output.length < input.length) {
+    line = input[output.length];
+
+    if (isFirstLineOfTag(line)) {
+      if (line.includes('</')) {
+        output.push(dedentLine(line));
+        stack.pop();
+      } else {
+        if (!dedentStartTag(input, output)) {
+          return false;
+        }
+
+        if (!input[output.length - 1].includes('/>')) {
+          stack.push(getIndentationLength(line));
+        }
+      }
+      isText = false;
+    } else {
+      if (isText) {
+        return false; // because text has more than one adjacent line
+      }
+
+      const indentationLengthOfTag = stack[stack.length - 1];
+      output.push(line.slice(indentationLengthOfTag + 2));
+      isText = true;
+    }
+  }
+
+  return stack.length === 0;
+};
+
+// Return lines unindented by heuristic;
+// otherwise return null because:
+// * props include a multiline string
+// * text has more than one adjacent line
+// * markup does not close
+export const dedentLines = (input: Array<string>): Array<string> | null => {
+  const output: Array<string> = [];
+
+  while (output.length < input.length) {
+    const line = input[output.length];
+
+    if (hasUnmatchedDoubleQuoteMarks(line)) {
+      return null;
+    } else if (isFirstLineOfTag(line)) {
+      if (!dedentMarkup(input, output)) {
+        return null;
+      }
+    } else {
+      output.push(dedentLine(line));
+    }
+  }
+
+  return output;
+};

--- a/packages/jest-snapshot/src/utils.ts
+++ b/packages/jest-snapshot/src/utils.ts
@@ -139,10 +139,11 @@ export const removeExtraLineBreaks = (string: string): string =>
 const escapeRegex = true;
 const printFunctionName = false;
 
-export const serialize = (val: unknown): string =>
+export const serialize = (val: unknown, indent = 2): string =>
   normalizeNewlines(
     prettyFormat(val, {
       escapeRegex,
+      indent,
       plugins: getSerializers(),
       printFunctionName,
     }),


### PR DESCRIPTION
## Summary

Fixes #8626

Call `diffLinesUnified2` to compare without indentation:

* add optional `indent` arg to serialize received without indentation
* call `dedentLines` heuristic to remove indentation from snapshot

Fall back to baseline `diffLinesUnified` in edge case of multi-line strings:

* text node child of markup element
* key or value of object property
* item of array

## Test plan

* added 17 tests to new `dedent.test.ts`
* added 5 snapshots to `printSnapshot.test.ts` (although my eyes have already adjusted to magenta and teal in console, `<m>` and `<t>` in snapshots will take a while longer)

See also pictures in following comment

Example pictures **baseline** at left and **improved** at right