### PR TITLE
Fix typo in JestPlatform.md

### DIFF
--- a/docs/JestPlatform.md
+++ b/docs/JestPlatform.md
@@ -119,7 +119,7 @@ You can read more about `jest-validate` in the [readme file](https://github.com/
 
 ## jest-worker
 
-Module used for parallelization of tasks. Exports a class `Worker` that takes the path of Node.js module and lets you call the module's exported methods as if they where class methods, returning a promise that resolves when the specified method finishes its execution in a forked process.
+Module used for parallelization of tasks. Exports a class `Worker` that takes the path of Node.js module and lets you call the module's exported methods as if they were class methods, returning a promise that resolves when the specified method finishes its execution in a forked process.
 
 ### Example
 

--- a/website/versioned_docs/version-22.x/JestPlatform.md
+++ b/website/versioned_docs/version-22.x/JestPlatform.md
@@ -120,7 +120,7 @@ You can read more about `jest-validate` in the [readme file](https://github.com/
 
 ## jest-worker
 
-Module used for parallelization of tasks. Exports a class `Worker` that takes the path of Node.js module and lets you call the module's exported methods as if they where class methods, returning a promise that resolves when the specified method finishes its execution in a forked process.
+Module used for parallelization of tasks. Exports a class `Worker` that takes the path of Node.js module and lets you call the module's exported methods as if they were class methods, returning a promise that resolves when the specified method finishes its execution in a forked process.
 
 ### Example
 

--- a/website/versioned_docs/version-24.0/JestPlatform.md
+++ b/website/versioned_docs/version-24.0/JestPlatform.md
@@ -120,7 +120,7 @@ You can read more about `jest-validate` in the [readme file](https://github.com/
 
 ## jest-worker
 
-Module used for parallelization of tasks. Exports a class `Worker` that takes the path of Node.js module and lets you call the module's exported methods as if they where class methods, returning a promise that resolves when the specified method finishes its execution in a forked process.
+Module used for parallelization of tasks. Exports a class `Worker` that takes the path of Node.js module and lets you call the module's exported methods as if they were class methods, returning a promise that resolves when the specified method finishes its execution in a forked process.
 
 ### Example
 


### PR DESCRIPTION
## Summary

Fix incorrect "where" => "were". It is already in another [pull request](https://github.com/facebook/jest/pull/9122) where are requested updates in versioned docs. But it was more than 2 weeks ago, so here are also those changes done.