### PR TITLE
chore: run tsc and linting as GH action

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,19 +18,6 @@ aliases:
 
 version: 2
 jobs:
-  lint-and-typecheck:
-    working_directory: ~/jest
-    docker:
-      - image: circleci/node:12
-    steps:
-      - checkout
-      - restore-cache: *restore-cache
-      - run: yarn --no-progress --frozen-lockfile
-      - save-cache: *save-cache
-      - run: yarn lint --format junit -o reports/junit/js-lint-results.xml && yarn lint-es5-build --format junit -o reports/junit/js-es5-lint-results.xml  && yarn lint:prettier:ci && yarn check-copyright-headers
-      - store_test_results:
-          path: reports/junit
-
   test-node-8:
     working_directory: ~/jest
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,7 +118,6 @@ workflows:
   version: 2
   build-and-deploy:
     jobs:
-      - lint-and-typecheck
       - test-node-8
       - test-node-10
       - test-node-12

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,39 @@
+name: Node CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  lint-and-typecheck:
+    name: Running TypeScript compiler & ESLint
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Get yarn cache
+        id: yarn-cache
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v1
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: ubuntu-latest-node-12.x-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ubuntu-latest-node-12.x-yarn-
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+      - name: install
+        run: yarn
+      - name: run eslint
+        run: |
+          yarn lint
+          yarn lint-es5-build
+      - name: run prettier
+        run: yarn lint:prettier:ci
+      - name: check copyright headers
+        run: yarn check-copyright-headers

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -28,11 +28,15 @@ jobs:
         with:
           node-version: 12.x
       - name: install
-        run: yarn
+        run: yarn install-no-ts-build
+      - name: build
+        run: node scripts/build.js
+      - name: run tsc
+        run: yarn build:ts
       - name: run eslint
-        run: |
-          yarn lint
-          yarn lint-es5-build
+        run: yarn lint
+      - name: run eslint on browser builds
+        run: yarn lint-es5-build
       - name: run prettier
         run: yarn lint:prettier:ci
       - name: check copyright headers

--- a/packages/jest-transform/src/ScriptTransformer.ts
+++ b/packages/jest-transform/src/ScriptTransformer.ts
@@ -366,7 +366,7 @@ export default class ScriptTransformer {
         const transformedSource = this.transformSource(
           filename,
           content,
-          instrument,
+          instrument
         );
 
         wrappedCode = wrap(transformedSource.code, ...extraGlobals);

--- a/packages/jest-transform/src/ScriptTransformer.ts
+++ b/packages/jest-transform/src/ScriptTransformer.ts
@@ -366,7 +366,7 @@ export default class ScriptTransformer {
         const transformedSource = this.transformSource(
           filename,
           content,
-          instrument
+          instrument,
         );
 
         wrappedCode = wrap(transformedSource.code, ...extraGlobals);

--- a/packages/jest-transform/src/ScriptTransformer.ts
+++ b/packages/jest-transform/src/ScriptTransformer.ts
@@ -367,6 +367,7 @@ export default class ScriptTransformer {
           filename,
           content,
           instrument,
+          'some extra arg',
         );
 
         wrappedCode = wrap(transformedSource.code, ...extraGlobals);

--- a/packages/jest-transform/src/ScriptTransformer.ts
+++ b/packages/jest-transform/src/ScriptTransformer.ts
@@ -367,7 +367,6 @@ export default class ScriptTransformer {
           filename,
           content,
           instrument,
-          'back to type error',
         );
 
         wrappedCode = wrap(transformedSource.code, ...extraGlobals);

--- a/packages/jest-transform/src/ScriptTransformer.ts
+++ b/packages/jest-transform/src/ScriptTransformer.ts
@@ -366,7 +366,8 @@ export default class ScriptTransformer {
         const transformedSource = this.transformSource(
           filename,
           content,
-          instrument
+          instrument,
+          'back to type error',
         );
 
         wrappedCode = wrap(transformedSource.code, ...extraGlobals);

--- a/packages/jest-transform/src/ScriptTransformer.ts
+++ b/packages/jest-transform/src/ScriptTransformer.ts
@@ -366,8 +366,7 @@ export default class ScriptTransformer {
         const transformedSource = this.transformSource(
           filename,
           content,
-          instrument,
-          'some extra arg',
+          instrument
         );
 
         wrappedCode = wrap(transformedSource.code, ...extraGlobals);

--- a/scripts/buildTs.js
+++ b/scripts/buildTs.js
@@ -12,7 +12,7 @@ const path = require('path');
 
 const chalk = require('chalk');
 const execa = require('execa');
-const {getPackages, adjustToTerminalWidth, OK} = require('./buildUtils');
+const {getPackages} = require('./buildUtils');
 
 const packages = getPackages();
 
@@ -33,13 +33,14 @@ const args = [
 ];
 
 console.log(chalk.inverse('Building TypeScript definition files'));
-process.stdout.write(adjustToTerminalWidth('Building\n'));
 
 try {
   execa.sync('node', args, {stdio: 'inherit'});
-  process.stdout.write(`${OK}\n`);
+  console.log('Successfully built TypeScript definition files');
+  console.log(
+    chalk.inverse.green('Successfully built TypeScript definition files')
+  );
 } catch (e) {
-  process.stdout.write('\n');
   console.error(
     chalk.inverse.red('Unable to build TypeScript definition files')
   );


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

They have built in "problem matchers" that should report eslint and tsc errors - I wonder if that's cleaner than having it on circle?

Docs: https://github.com/actions/toolkit/blob/master/docs/problem-matchers.md

EDIT: Hmm, I was hoping it'd comment inlined

![image](https://user-images.githubusercontent.com/1404810/69407367-9e97cc00-0d04-11ea-8be2-4bbf94f9b0c7.png)

EDIT2: Hmmmmm, it did at least find the file for eslint, which is awesome

![image](https://user-images.githubusercontent.com/1404810/69408364-f8999100-0d06-11ea-9899-f0c6c2bc0831.png)

Might be due to our output

EDIT3: Yup, that was it

![image](https://user-images.githubusercontent.com/1404810/69408977-57abd580-0d08-11ea-8c30-d801148ccf58.png)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

I'll add a type error and lint error and see what it output

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
