### PR TITLE
Add watch plugins config typespec

### DIFF
--- a/packages/jest-types/src/Config.ts
+++ b/packages/jest-types/src/Config.ts
@@ -25,6 +25,8 @@ export type HasteConfig = {
 export type ReporterConfig = [string, Record<string, unknown>];
 export type TransformerConfig = [string, Record<string, unknown>];
 
+export type WatchPluginsConfig = string | [string, Record<string, any>];
+
 export type ConfigGlobals = Record<string, any>;
 
 export type DefaultOptions = {
@@ -200,7 +202,7 @@ export type InitialOptions = Partial<{
   watch: boolean;
   watchAll: boolean;
   watchman: boolean;
-  watchPlugins: Array<string | [string, Record<string, any>]>;
+  watchPlugins: Array<WatchPluginsConfig>;
 }>;
 
 export type SnapshotUpdateState = 'all' | 'new' | 'none';
@@ -287,10 +289,7 @@ export type GlobalConfig = {
   watch: boolean;
   watchAll: boolean;
   watchman: boolean;
-  watchPlugins?: Array<{
-    path: string;
-    config: Record<string, any>;
-  }> | null;
+  watchPlugins?: Array<WatchPluginsConfig> | null;
 };
 
 export type ProjectConfig = {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Fix watchPlugins typespec

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

1. Create a function as follow

```ts
import { GlobalConfig } from '@jest/types/build/Config';

export function createConfig(): Partial<GlobalConfig> {
  return {
    watchPlugins: [
      'jest-watch-typeahead/filename',
      'jest-watch-typeahead/testname',
    ],
  };
}
```

2. The compiler shouldn't fail.