### PR TITLE
chore: use `makeProjectConfig` in tests

### DIFF
--- a/packages/babel-jest/src/__tests__/index.ts
+++ b/packages/babel-jest/src/__tests__/index.ts
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {Config} from '@jest/types';
 import babelJest from '../index';
+import {makeProjectConfig} from '../../../../TestUtils';
 
 //Mock data for all the tests
 const sourceString = `
@@ -21,15 +21,11 @@ const customMultiply = (obj, mul) => {
 customMultiply({a: 32, dummy: "test"}, 2);
 `;
 
-const mockConfig = {
-  moduleFileExtensions: [],
-};
-
 test(`Returns source string with inline maps when no transformOptions is passed`, () => {
   const result = babelJest.process(
     sourceString,
     'dummy_path.js',
-    (mockConfig as unknown) as Config.ProjectConfig,
+    makeProjectConfig(),
   ) as any;
   expect(typeof result).toBe('object');
   expect(result.code).toBeDefined();

--- a/packages/jest-core/src/__tests__/TestScheduler.test.js
+++ b/packages/jest-core/src/__tests__/TestScheduler.test.js
@@ -9,6 +9,7 @@
 import {SummaryReporter} from '@jest/reporters';
 import TestScheduler from '../TestScheduler';
 import * as testSchedulerHelper from '../testSchedulerHelper';
+import {makeProjectConfig} from '../../../../TestUtils';
 
 jest.mock('@jest/reporters');
 const mockSerialRunner = {
@@ -86,9 +87,9 @@ test('schedule tests run in parallel per default', async () => {
   const scheduler = new TestScheduler({}, {});
   const test = {
     context: {
-      config: {
+      config: makeProjectConfig({
         runner: 'jest-runner-parallel',
-      },
+      }),
       hasteFS: {
         matchFiles: jest.fn(() => []),
       },
@@ -107,9 +108,9 @@ test('schedule tests run in serial if the runner flags them', async () => {
   const scheduler = new TestScheduler({}, {});
   const test = {
     context: {
-      config: {
+      config: makeProjectConfig({
         runner: 'jest-runner-serial',
-      },
+      }),
       hasteFS: {
         matchFiles: jest.fn(() => []),
       },
@@ -128,10 +129,10 @@ test('should bail after `n` failures', async () => {
   const scheduler = new TestScheduler({bail: 2}, {});
   const test = {
     context: {
-      config: {
+      config: makeProjectConfig({
         rootDir: './',
         runner: 'jest-runner-serial',
-      },
+      }),
       hasteFS: {
         matchFiles: jest.fn(() => []),
       },
@@ -158,10 +159,10 @@ test('should not bail if less than `n` failures', async () => {
   const scheduler = new TestScheduler({bail: 2}, {});
   const test = {
     context: {
-      config: {
+      config: makeProjectConfig({
         rootDir: './',
         runner: 'jest-runner-serial',
-      },
+      }),
       hasteFS: {
         matchFiles: jest.fn(() => []),
       },
@@ -188,9 +189,9 @@ test('should set runInBand to run in serial', async () => {
   const scheduler = new TestScheduler({}, {});
   const test = {
     context: {
-      config: {
+      config: makeProjectConfig({
         runner: 'jest-runner-parallel',
-      },
+      }),
       hasteFS: {
         matchFiles: jest.fn(() => []),
       },
@@ -212,9 +213,9 @@ test('should set runInBand to not run in serial', async () => {
   const scheduler = new TestScheduler({}, {});
   const test = {
     context: {
-      config: {
+      config: makeProjectConfig({
         runner: 'jest-runner-parallel',
-      },
+      }),
       hasteFS: {
         matchFiles: jest.fn(() => []),
       },

--- a/packages/jest-snapshot/src/__tests__/snapshot_resolver.test.ts
+++ b/packages/jest-snapshot/src/__tests__/snapshot_resolver.test.ts
@@ -6,16 +6,16 @@
  */
 
 import * as path from 'path';
-import {Config} from '@jest/types';
+import {makeProjectConfig} from '../../../../TestUtils';
 
 import {SnapshotResolver, buildSnapshotResolver} from '../snapshot_resolver';
 
 describe('defaults', () => {
   let snapshotResolver: SnapshotResolver;
-  const projectConfig = {
+  const projectConfig = makeProjectConfig({
     rootDir: 'default',
     // snapshotResolver: null,
-  } as Config.ProjectConfig;
+  });
 
   beforeEach(() => {
     snapshotResolver = buildSnapshotResolver(projectConfig);
@@ -45,10 +45,10 @@ describe('custom resolver in project config', () => {
     'fixtures',
     'customSnapshotResolver.js',
   );
-  const projectConfig = {
+  const projectConfig = makeProjectConfig({
     rootDir: 'custom1',
     snapshotResolver: customSnapshotResolverFile,
-  } as Config.ProjectConfig;
+  });
 
   beforeEach(() => {
     snapshotResolver = buildSnapshotResolver(projectConfig);
@@ -82,10 +82,10 @@ describe('malformed custom resolver in project config', () => {
       'fixtures',
       filename,
     );
-    return {
+    return makeProjectConfig({
       rootDir: 'missing-resolveSnapshotPath',
       snapshotResolver: customSnapshotResolverFile,
-    } as Config.ProjectConfig;
+    });
   };
 
   it('missing resolveSnapshotPath throws ', () => {


### PR DESCRIPTION
## Summary

Some tests don't use `makeProjectConfig`, using `as Config.ProjectConfig` instead 😱
This is brittle as it means the tests can fail if the configuration changes. 

This changes that, so that all `as Config.ProjectConfig` usage in tests are replaced w/ `makeProjectConfig` to ensure the configurations have the correct default values.

## Test plan

Run the tests, check the CI output, then have a 🍺 when it's green.
