### PR TITLE
feat: return transformed code as a string, do not wrap in `vm.Script`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 - `[jest-snapshot]` Improve colors when snapshots are updatable ([#9132](https://github.com/facebook/jest/pull/9132))
 - `[jest-snapshot]` Ignore indentation for most serialized objects ([#9203](https://github.com/facebook/jest/pull/9203))
 - `[jest-transform]` Create `createTranspilingRequire` function for easy transpiling modules ([#9194](https://github.com/facebook/jest/pull/9194))
-- `[jest-transform]` [**BREAKING**] Do not automatically pass arguments to the script wrapper ([#9253](https://github.com/facebook/jest/pull/9253))
+- `[jest-transform]` [**BREAKING**] Return transformed code as a string, do not wrap in `vm.Script` ([#9253](https://github.com/facebook/jest/pull/9253))
 - `[@jest/test-result]` Create method to create empty `TestResult` ([#8867](https://github.com/facebook/jest/pull/8867))
 - `[jest-worker]` [**BREAKING**] Return a promise from `end()`, resolving with the information whether workers exited gracefully ([#8206](https://github.com/facebook/jest/pull/8206))
 - `[jest-reporters]` Transform file paths into hyperlinks ([#8980](https://github.com/facebook/jest/pull/8980))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - `[jest-snapshot]` Improve colors when snapshots are updatable ([#9132](https://github.com/facebook/jest/pull/9132))
 - `[jest-snapshot]` Ignore indentation for most serialized objects ([#9203](https://github.com/facebook/jest/pull/9203))
 - `[jest-transform]` Create `createTranspilingRequire` function for easy transpiling modules ([#9194](https://github.com/facebook/jest/pull/9194))
+- `[jest-transform]` [**BREAKING**] Do not automatically wrap functions in a module wrapper ([#9253](https://github.com/facebook/jest/pull/9253))
 - `[@jest/test-result]` Create method to create empty `TestResult` ([#8867](https://github.com/facebook/jest/pull/8867))
 - `[jest-worker]` [**BREAKING**] Return a promise from `end()`, resolving with the information whether workers exited gracefully ([#8206](https://github.com/facebook/jest/pull/8206))
 - `[jest-reporters]` Transform file paths into hyperlinks ([#8980](https://github.com/facebook/jest/pull/8980))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 - `[jest-snapshot]` Improve colors when snapshots are updatable ([#9132](https://github.com/facebook/jest/pull/9132))
 - `[jest-snapshot]` Ignore indentation for most serialized objects ([#9203](https://github.com/facebook/jest/pull/9203))
 - `[jest-transform]` Create `createTranspilingRequire` function for easy transpiling modules ([#9194](https://github.com/facebook/jest/pull/9194))
-- `[jest-transform]` [**BREAKING**] Do not automatically wrap functions in a module wrapper ([#9253](https://github.com/facebook/jest/pull/9253))
+- `[jest-transform]` [**BREAKING**] Do not automatically pass arguments to the script wrapper ([#9253](https://github.com/facebook/jest/pull/9253))
 - `[@jest/test-result]` Create method to create empty `TestResult` ([#8867](https://github.com/facebook/jest/pull/8867))
 - `[jest-worker]` [**BREAKING**] Return a promise from `end()`, resolving with the information whether workers exited gracefully ([#8206](https://github.com/facebook/jest/pull/8206))
 - `[jest-reporters]` Transform file paths into hyperlinks ([#8980](https://github.com/facebook/jest/pull/8980))

--- a/packages/jest-environment/package.json
+++ b/packages/jest-environment/package.json
@@ -11,7 +11,6 @@
   "types": "build/index.d.ts",
   "dependencies": {
     "@jest/fake-timers": "^24.9.0",
-    "@jest/transform": "^24.9.0",
     "@jest/types": "^24.9.0",
     "jest-mock": "^24.9.0"
   },

--- a/packages/jest-environment/src/index.ts
+++ b/packages/jest-environment/src/index.ts
@@ -27,6 +27,7 @@ export type EnvironmentContext = Partial<{
 
 // Different Order than https://nodejs.org/api/modules.html#modules_the_module_wrapper , however needs to be in the form [jest-transform]ScriptTransformer accepts
 export type ModuleWrapper = (
+  this: Module['exports'],
   module: Module,
   exports: Module['exports'],
   require: Module['require'],

--- a/packages/jest-environment/src/index.ts
+++ b/packages/jest-environment/src/index.ts
@@ -27,7 +27,6 @@ export type EnvironmentContext = Partial<{
 
 // Different Order than https://nodejs.org/api/modules.html#modules_the_module_wrapper , however needs to be in the form [jest-transform]ScriptTransformer accepts
 export type ModuleWrapper = (
-  this: Module['exports'],
   module: Module,
   exports: Module['exports'],
   require: Module['require'],

--- a/packages/jest-environment/src/index.ts
+++ b/packages/jest-environment/src/index.ts
@@ -8,7 +8,6 @@
 import {Script} from 'vm';
 import {Circus, Config, Global} from '@jest/types';
 import jestMock = require('jest-mock');
-import {ScriptTransformer} from '@jest/transform';
 import {
   JestFakeTimers as LegacyFakeTimers,
   LolexFakeTimers,
@@ -44,9 +43,7 @@ export declare class JestEnvironment {
   fakeTimers: LegacyFakeTimers<unknown> | null;
   fakeTimersLolex: LolexFakeTimers | null;
   moduleMocker: jestMock.ModuleMocker | null;
-  runScript(
-    script: Script,
-  ): {[ScriptTransformer.EVAL_RESULT_VARIABLE]: ModuleWrapper} | null;
+  runScript<T = unknown>(script: Script): T | null;
   setup(): Promise<void>;
   teardown(): Promise<void>;
   handleTestEvent?(event: Circus.Event, state: Circus.State): void;

--- a/packages/jest-environment/tsconfig.json
+++ b/packages/jest-environment/tsconfig.json
@@ -6,7 +6,6 @@
   },
   "references": [
     {"path": "../jest-fake-timers"},
-    {"path": "../jest-transform"},
     {"path": "../jest-types"},
     {"path": "../jest-util"}
   ]

--- a/packages/jest-runtime/src/__tests__/__snapshots__/runtime_wrap.js.snap
+++ b/packages/jest-runtime/src/__tests__/__snapshots__/runtime_wrap.js.snap
@@ -1,11 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Runtime wrap generates the correct args for the module wrapper 1`] = `
+exports[`Runtime wrapCodeInModuleWrapper generates the correct args for the module wrapper 1`] = `
 ({"Object.<anonymous>":function(module,exports,require,__dirname,__filename,global,jest){module.exports = "Hello!"
 }});
 `;
 
-exports[`Runtime wrap injects "extra globals" 1`] = `
+exports[`Runtime wrapCodeInModuleWrapper injects "extra globals" 1`] = `
 ({"Object.<anonymous>":function(module,exports,require,__dirname,__filename,global,jest,Math){module.exports = "Hello!"
 }});
 `;

--- a/packages/jest-runtime/src/__tests__/__snapshots__/runtime_wrap.js.snap
+++ b/packages/jest-runtime/src/__tests__/__snapshots__/runtime_wrap.js.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Runtime wrap generates the correct args for the module wrapper 1`] = `
+({"Object.<anonymous>":function(module,exports,require,__dirname,__filename,global,jest){module.exports = "Hello!"
+}});
+`;
+
+exports[`Runtime wrap injects "extra globals" 1`] = `
+({"Object.<anonymous>":function(module,exports,require,__dirname,__filename,global,jest,Math){module.exports = "Hello!"
+}});
+`;

--- a/packages/jest-runtime/src/__tests__/instrumentation.test.ts
+++ b/packages/jest-runtime/src/__tests__/instrumentation.test.ts
@@ -6,7 +6,6 @@
  *
  */
 
-import * as vm from 'vm';
 import * as path from 'path';
 import * as os from 'os';
 import {ScriptTransformer} from '@jest/transform';
@@ -32,10 +31,9 @@ it('instruments files', () => {
       ...makeGlobalConfig({collectCoverage: true}),
       changedFiles: undefined,
     },
-  ).script;
-  expect(instrumented instanceof vm.Script).toBe(true);
+  );
   // We can't really snapshot the resulting coverage, because it depends on
   // absolute path of the file, which will be different on different
   // machines
-  expect(vm.Script.mock.calls[0][0]).toMatch(`gcv = "__coverage__"`);
+  expect(instrumented.code).toMatch(`gcv = "__coverage__"`);
 });

--- a/packages/jest-runtime/src/__tests__/runtime_require_module.test.js
+++ b/packages/jest-runtime/src/__tests__/runtime_require_module.test.js
@@ -371,7 +371,7 @@ describe('Runtime requireModule', () => {
       '__filename',
       'global',
       'jest',
-      'Math'
+      'Math',
     ]);
   });
 });

--- a/packages/jest-runtime/src/__tests__/runtime_require_module.test.js
+++ b/packages/jest-runtime/src/__tests__/runtime_require_module.test.js
@@ -347,31 +347,4 @@ describe('Runtime requireModule', () => {
       );
       expect(exports.isJSONModuleEncodedInUTF8WithBOM).toBe(true);
     }));
-
-  it('generates the correct args for the module wrapper', async () => {
-    let runtime = await createRuntime(__filename);
-
-    expect(runtime.constructInjectedModuleArguments()).toEqual([
-      'module',
-      'exports',
-      'require',
-      '__dirname',
-      '__filename',
-      'global',
-      'jest',
-    ]);
-
-    runtime = await createRuntime(__filename, {extraGlobals: ['Math']});
-
-    expect(runtime.constructInjectedModuleArguments()).toEqual([
-      'module',
-      'exports',
-      'require',
-      '__dirname',
-      '__filename',
-      'global',
-      'jest',
-      'Math',
-    ]);
-  });
 });

--- a/packages/jest-runtime/src/__tests__/runtime_require_module.test.js
+++ b/packages/jest-runtime/src/__tests__/runtime_require_module.test.js
@@ -347,4 +347,31 @@ describe('Runtime requireModule', () => {
       );
       expect(exports.isJSONModuleEncodedInUTF8WithBOM).toBe(true);
     }));
+
+  it('generates the correct args for the module wrapper', async () => {
+    let runtime = await createRuntime(__filename);
+
+    expect(runtime.constructInjectedModuleArguments()).toEqual([
+      'module',
+      'exports',
+      'require',
+      '__dirname',
+      '__filename',
+      'global',
+      'jest',
+    ]);
+
+    runtime = await createRuntime(__filename, {extraGlobals: ['Math']});
+
+    expect(runtime.constructInjectedModuleArguments()).toEqual([
+      'module',
+      'exports',
+      'require',
+      '__dirname',
+      '__filename',
+      'global',
+      'jest',
+      'Math'
+    ]);
+  });
 });

--- a/packages/jest-runtime/src/__tests__/runtime_wrap.js
+++ b/packages/jest-runtime/src/__tests__/runtime_wrap.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {wrap} from 'jest-snapshot-serializer-raw';
+let createRuntime;
+
+describe('Runtime', () => {
+  beforeEach(() => {
+    createRuntime = require('createRuntime');
+  });
+
+  describe('wrap', () => {
+    it('generates the correct args for the module wrapper', async () => {
+      const runtime = await createRuntime(__filename);
+
+      expect(wrap(runtime.wrap('module.exports = "Hello!"'))).toMatchSnapshot();
+    });
+
+    it('injects "extra globals"', async () => {
+      const runtime = await createRuntime(__filename, {extraGlobals: ['Math']});
+
+      expect(wrap(runtime.wrap('module.exports = "Hello!"'))).toMatchSnapshot();
+    });
+  });
+});

--- a/packages/jest-runtime/src/__tests__/runtime_wrap.js
+++ b/packages/jest-runtime/src/__tests__/runtime_wrap.js
@@ -14,17 +14,21 @@ describe('Runtime', () => {
     createRuntime = require('createRuntime');
   });
 
-  describe('wrap', () => {
+  describe('wrapCodeInModuleWrapper', () => {
     it('generates the correct args for the module wrapper', async () => {
       const runtime = await createRuntime(__filename);
 
-      expect(wrap(runtime.wrap('module.exports = "Hello!"'))).toMatchSnapshot();
+      expect(
+        wrap(runtime.wrapCodeInModuleWrapper('module.exports = "Hello!"')),
+      ).toMatchSnapshot();
     });
 
     it('injects "extra globals"', async () => {
       const runtime = await createRuntime(__filename, {extraGlobals: ['Math']});
 
-      expect(wrap(runtime.wrap('module.exports = "Hello!"'))).toMatchSnapshot();
+      expect(
+        wrap(runtime.wrapCodeInModuleWrapper('module.exports = "Hello!"')),
+      ).toMatchSnapshot();
     });
   });
 });

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -12,7 +12,6 @@ import {
   JestEnvironment,
   LocalModuleRequire,
   Module,
-  ModuleWrapper,
 } from '@jest/environment';
 import {SourceMapRegistry} from '@jest/source-map';
 import jestMock = require('jest-mock');
@@ -737,7 +736,9 @@ class Runtime {
       return;
     }
 
-    const args: Parameters<ModuleWrapper> = [
+    //Wrapper
+    runScript[ScriptTransformer.EVAL_RESULT_VARIABLE].call(
+      localModule.exports,
       localModule as NodeModule, // module object
       localModule.exports, // module exports
       localModule.require as NodeRequireFunction, // require implementation
@@ -757,20 +758,6 @@ class Runtime {
           `You have requested '${globalVariable}' as a global variable, but it was not present. Please check your config or your global environment.`,
         );
       }),
-    ];
-
-    const injectedModuleArguments = this.constructInjectedModuleArguments();
-
-    if (injectedModuleArguments.length !== args.length) {
-      throw new ReferenceError(
-        `We are injecting ${args.length} arguments into module wrapper, expected ${injectedModuleArguments.length}.\n\nThis is a bug in Jest, please report it`,
-      );
-    }
-
-    //Wrapper
-    runScript[ScriptTransformer.EVAL_RESULT_VARIABLE].apply(
-      localModule.exports,
-      args,
     );
 
     this._isCurrentlyExecutingManualMock = origCurrExecutingManualMock;

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -489,7 +489,7 @@ class Runtime {
       collectCoverage: this._coverageOptions.collectCoverage,
       collectCoverageFrom: this._coverageOptions.collectCoverageFrom,
       collectCoverageOnlyFrom: this._coverageOptions.collectCoverageOnlyFrom,
-      extraGlobals: this._config.extraGlobals,
+      moduleArguments: this.constructInjectedModuleArguments(),
     };
   }
 
@@ -1085,6 +1085,19 @@ class Runtime {
       `\n${message}\n` +
         formatStackTrace(stack, this._config, {noStackTrace: false}),
     );
+  }
+
+  private constructInjectedModuleArguments() {
+    return [
+      'module',
+      'exports',
+      'require',
+      '__dirname',
+      '__filename',
+      'global',
+      'jest',
+      ...this._config.extraGlobals,
+    ];
   }
 }
 

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -731,12 +731,15 @@ class Runtime {
       }
     }
 
-    const script = new Script(this.wrap(transformedFile.code), {
-      displayErrors: true,
-      filename: this._resolver.isCoreModule(filename)
-        ? `jest-nodejs-core-${filename}`
-        : filename,
-    });
+    const script = new Script(
+      this.wrapCodeInModuleWrapper(transformedFile.code),
+      {
+        displayErrors: true,
+        filename: this._resolver.isCoreModule(filename)
+          ? `jest-nodejs-core-${filename}`
+          : filename,
+      },
+    );
 
     const runScript = this._environment.runScript<RunScriptEvalResult>(script);
 
@@ -1099,7 +1102,7 @@ class Runtime {
     );
   }
 
-  private wrap(content: string) {
+  private wrapCodeInModuleWrapper(content: string) {
     const args = [
       'module',
       'exports',

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -1100,17 +1100,7 @@ class Runtime {
   }
 
   private wrap(content: string) {
-    return (
-      '({"' +
-      EVAL_RESULT_VARIABLE +
-      `":function(${this.constructInjectedModuleArguments().join(',')}){` +
-      content +
-      '\n}});'
-    );
-  }
-
-  private constructInjectedModuleArguments() {
-    return [
+    const args = [
       'module',
       'exports',
       'require',
@@ -1120,6 +1110,14 @@ class Runtime {
       'jest',
       ...this._config.extraGlobals,
     ];
+
+    return (
+      '({"' +
+      EVAL_RESULT_VARIABLE +
+      `":function(${args.join(',')}){` +
+      content +
+      '\n}});'
+    );
   }
 }
 

--- a/packages/jest-transform/src/ScriptTransformer.ts
+++ b/packages/jest-transform/src/ScriptTransformer.ts
@@ -27,7 +27,7 @@ import {
   Transformer,
 } from './types';
 import shouldInstrument from './shouldInstrument';
-import enhanceUnexpectedTokenMessage from './enhanceUnexpectedTokenMessage';
+import handlePotentialSyntaxError from './enhanceUnexpectedTokenMessage';
 
 type ProjectCache = {
   configString: string;
@@ -377,20 +377,7 @@ export default class ScriptTransformer {
         sourceMapPath,
       };
     } catch (e) {
-      if (e.codeFrame) {
-        e.stack = e.message + '\n' + e.codeFrame;
-      }
-
-      if (
-        e instanceof SyntaxError &&
-        (e.message.includes('Unexpected token') ||
-          e.message.includes('Cannot use import')) &&
-        !e.message.includes(' expected')
-      ) {
-        throw enhanceUnexpectedTokenMessage(e);
-      }
-
-      throw e;
+      throw handlePotentialSyntaxError(e);
     }
   }
 

--- a/packages/jest-transform/src/__tests__/__snapshots__/script_transformer.test.js.snap
+++ b/packages/jest-transform/src/__tests__/__snapshots__/script_transformer.test.js.snap
@@ -75,7 +75,7 @@ Object {
 `;
 
 exports[`ScriptTransformer transforms a file properly 1`] = `
-({"Object.<anonymous>":function(){/* istanbul ignore next */
+/* istanbul ignore next */
 function cov_25u22311x4() {
   var path = "/fruits/banana.js";
   var hash = "4be0f6184160be573fc43f7c2a5877c28b7ce249";
@@ -122,11 +122,10 @@ function cov_25u22311x4() {
 
 cov_25u22311x4().s[0]++;
 module.exports = "banana";
-}});
 `;
 
 exports[`ScriptTransformer transforms a file properly 2`] = `
-({"Object.<anonymous>":function(){/* istanbul ignore next */
+/* istanbul ignore next */
 function cov_23yvu8etmu() {
   var path = "/fruits/kiwi.js";
   var hash = "7705dd5fcfbc884dcea7062944cfb8cc5d141d1a";
@@ -217,48 +216,33 @@ module.exports = () => {
   cov_23yvu8etmu().s[1]++;
   return "kiwi";
 };
-}});
-`;
-
-exports[`ScriptTransformer transforms a file properly 3`] = `
-({"Object.<anonymous>":function(){module.exports = "banana";
-}});
 `;
 
 exports[`ScriptTransformer uses multiple preprocessors 1`] = `
-({"Object.<anonymous>":function(){const TRANSFORMED = {
+const TRANSFORMED = {
   filename: '/fruits/banana.js',
   script: 'module.exports = "banana";',
   config: '{"automock":false,"browser":false,"cache":true,"cacheDirectory":"/cache/","clearMocks":false,"coveragePathIgnorePatterns":[],"cwd":"/test_root_dir/","detectLeaks":false,"detectOpenHandles":false,"errorOnDeprecated":false,"extraGlobals":[],"filter":null,"forceCoverageMatch":[],"globalSetup":null,"globalTeardown":null,"globals":{},"haste":{"providesModuleNodeModules":[]},"moduleDirectories":[],"moduleFileExtensions":["js"],"moduleLoader":"/test_module_loader_path","moduleNameMapper":[],"modulePathIgnorePatterns":[],"modulePaths":[],"name":"test","prettierPath":"prettier","resetMocks":false,"resetModules":false,"resolver":null,"restoreMocks":false,"rootDir":"/","roots":[],"runner":"jest-runner","setupFiles":[],"setupFilesAfterEnv":[],"skipFilter":false,"skipNodeResolution":false,"snapshotResolver":null,"snapshotSerializers":[],"testEnvironment":"node","testEnvironmentOptions":{},"testLocationInResults":false,"testMatch":[],"testPathIgnorePatterns":[],"testRegex":["\\\\.test\\\\.js$"],"testRunner":"jest-jasmine2","testURL":"http://localhost","timers":"real","transform":[["^.+\\\\.js$","test_preprocessor"],["^.+\\\\.css$","css-preprocessor"]],"transformIgnorePatterns":["/node_modules/"],"unmockedModulePathPatterns":null,"watchPathIgnorePatterns":[]}',
 };
-}});
 `;
 
 exports[`ScriptTransformer uses multiple preprocessors 2`] = `
-({"Object.<anonymous>":function(){module.exports = {
+module.exports = {
   filename: /styles/App.css,
   rawFirstLine: root {,
 };
-}});
 `;
 
-exports[`ScriptTransformer uses multiple preprocessors 3`] = `
-({"Object.<anonymous>":function(){module.exports = "react";
-}});
-`;
+exports[`ScriptTransformer uses multiple preprocessors 3`] = `module.exports = "react";`;
 
 exports[`ScriptTransformer uses the supplied preprocessor 1`] = `
-({"Object.<anonymous>":function(){const TRANSFORMED = {
+const TRANSFORMED = {
   filename: '/fruits/banana.js',
   script: 'module.exports = "banana";',
   config: '{"automock":false,"browser":false,"cache":true,"cacheDirectory":"/cache/","clearMocks":false,"coveragePathIgnorePatterns":[],"cwd":"/test_root_dir/","detectLeaks":false,"detectOpenHandles":false,"errorOnDeprecated":false,"extraGlobals":[],"filter":null,"forceCoverageMatch":[],"globalSetup":null,"globalTeardown":null,"globals":{},"haste":{"providesModuleNodeModules":[]},"moduleDirectories":[],"moduleFileExtensions":["js"],"moduleLoader":"/test_module_loader_path","moduleNameMapper":[],"modulePathIgnorePatterns":[],"modulePaths":[],"name":"test","prettierPath":"prettier","resetMocks":false,"resetModules":false,"resolver":null,"restoreMocks":false,"rootDir":"/","roots":[],"runner":"jest-runner","setupFiles":[],"setupFilesAfterEnv":[],"skipFilter":false,"skipNodeResolution":false,"snapshotResolver":null,"snapshotSerializers":[],"testEnvironment":"node","testEnvironmentOptions":{},"testLocationInResults":false,"testMatch":[],"testPathIgnorePatterns":[],"testRegex":["\\\\.test\\\\.js$"],"testRunner":"jest-jasmine2","testURL":"http://localhost","timers":"real","transform":[["^.+\\\\.js$","test_preprocessor"]],"transformIgnorePatterns":["/node_modules/"],"unmockedModulePathPatterns":null,"watchPathIgnorePatterns":[]}',
 };
-}});
 `;
 
-exports[`ScriptTransformer uses the supplied preprocessor 2`] = `
-({"Object.<anonymous>":function(){module.exports = "react";
-}});
-`;
+exports[`ScriptTransformer uses the supplied preprocessor 2`] = `module.exports = "react";`;
 
 exports[`ScriptTransformer warns of unparseable inlined source maps from the preprocessor 1`] = `jest-transform: The source map produced for the file /fruits/banana.js by preprocessor-with-sourcemaps was invalid. Proceeding without source mapping for that file.`;

--- a/packages/jest-transform/src/__tests__/__snapshots__/script_transformer.test.js.snap
+++ b/packages/jest-transform/src/__tests__/__snapshots__/script_transformer.test.js.snap
@@ -75,7 +75,7 @@ Object {
 `;
 
 exports[`ScriptTransformer transforms a file properly 1`] = `
-({"Object.<anonymous>":function(module,exports,require,__dirname,__filename,global,jest){/* istanbul ignore next */
+({"Object.<anonymous>":function(){/* istanbul ignore next */
 function cov_25u22311x4() {
   var path = "/fruits/banana.js";
   var hash = "4be0f6184160be573fc43f7c2a5877c28b7ce249";
@@ -126,7 +126,7 @@ module.exports = "banana";
 `;
 
 exports[`ScriptTransformer transforms a file properly 2`] = `
-({"Object.<anonymous>":function(module,exports,require,__dirname,__filename,global,jest){/* istanbul ignore next */
+({"Object.<anonymous>":function(){/* istanbul ignore next */
 function cov_23yvu8etmu() {
   var path = "/fruits/kiwi.js";
   var hash = "7705dd5fcfbc884dcea7062944cfb8cc5d141d1a";
@@ -221,12 +221,12 @@ module.exports = () => {
 `;
 
 exports[`ScriptTransformer transforms a file properly 3`] = `
-({"Object.<anonymous>":function(module,exports,require,__dirname,__filename,global,jest,Math){module.exports = "banana";
+({"Object.<anonymous>":function(){module.exports = "banana";
 }});
 `;
 
 exports[`ScriptTransformer uses multiple preprocessors 1`] = `
-({"Object.<anonymous>":function(module,exports,require,__dirname,__filename,global,jest){const TRANSFORMED = {
+({"Object.<anonymous>":function(){const TRANSFORMED = {
   filename: '/fruits/banana.js',
   script: 'module.exports = "banana";',
   config: '{"automock":false,"browser":false,"cache":true,"cacheDirectory":"/cache/","clearMocks":false,"coveragePathIgnorePatterns":[],"cwd":"/test_root_dir/","detectLeaks":false,"detectOpenHandles":false,"errorOnDeprecated":false,"extraGlobals":[],"filter":null,"forceCoverageMatch":[],"globalSetup":null,"globalTeardown":null,"globals":{},"haste":{"providesModuleNodeModules":[]},"moduleDirectories":[],"moduleFileExtensions":["js"],"moduleLoader":"/test_module_loader_path","moduleNameMapper":[],"modulePathIgnorePatterns":[],"modulePaths":[],"name":"test","prettierPath":"prettier","resetMocks":false,"resetModules":false,"resolver":null,"restoreMocks":false,"rootDir":"/","roots":[],"runner":"jest-runner","setupFiles":[],"setupFilesAfterEnv":[],"skipFilter":false,"skipNodeResolution":false,"snapshotResolver":null,"snapshotSerializers":[],"testEnvironment":"node","testEnvironmentOptions":{},"testLocationInResults":false,"testMatch":[],"testPathIgnorePatterns":[],"testRegex":["\\\\.test\\\\.js$"],"testRunner":"jest-jasmine2","testURL":"http://localhost","timers":"real","transform":[["^.+\\\\.js$","test_preprocessor"],["^.+\\\\.css$","css-preprocessor"]],"transformIgnorePatterns":["/node_modules/"],"unmockedModulePathPatterns":null,"watchPathIgnorePatterns":[]}',
@@ -235,7 +235,7 @@ exports[`ScriptTransformer uses multiple preprocessors 1`] = `
 `;
 
 exports[`ScriptTransformer uses multiple preprocessors 2`] = `
-({"Object.<anonymous>":function(module,exports,require,__dirname,__filename,global,jest){module.exports = {
+({"Object.<anonymous>":function(){module.exports = {
   filename: /styles/App.css,
   rawFirstLine: root {,
 };
@@ -243,12 +243,12 @@ exports[`ScriptTransformer uses multiple preprocessors 2`] = `
 `;
 
 exports[`ScriptTransformer uses multiple preprocessors 3`] = `
-({"Object.<anonymous>":function(module,exports,require,__dirname,__filename,global,jest){module.exports = "react";
+({"Object.<anonymous>":function(){module.exports = "react";
 }});
 `;
 
 exports[`ScriptTransformer uses the supplied preprocessor 1`] = `
-({"Object.<anonymous>":function(module,exports,require,__dirname,__filename,global,jest){const TRANSFORMED = {
+({"Object.<anonymous>":function(){const TRANSFORMED = {
   filename: '/fruits/banana.js',
   script: 'module.exports = "banana";',
   config: '{"automock":false,"browser":false,"cache":true,"cacheDirectory":"/cache/","clearMocks":false,"coveragePathIgnorePatterns":[],"cwd":"/test_root_dir/","detectLeaks":false,"detectOpenHandles":false,"errorOnDeprecated":false,"extraGlobals":[],"filter":null,"forceCoverageMatch":[],"globalSetup":null,"globalTeardown":null,"globals":{},"haste":{"providesModuleNodeModules":[]},"moduleDirectories":[],"moduleFileExtensions":["js"],"moduleLoader":"/test_module_loader_path","moduleNameMapper":[],"modulePathIgnorePatterns":[],"modulePaths":[],"name":"test","prettierPath":"prettier","resetMocks":false,"resetModules":false,"resolver":null,"restoreMocks":false,"rootDir":"/","roots":[],"runner":"jest-runner","setupFiles":[],"setupFilesAfterEnv":[],"skipFilter":false,"skipNodeResolution":false,"snapshotResolver":null,"snapshotSerializers":[],"testEnvironment":"node","testEnvironmentOptions":{},"testLocationInResults":false,"testMatch":[],"testPathIgnorePatterns":[],"testRegex":["\\\\.test\\\\.js$"],"testRunner":"jest-jasmine2","testURL":"http://localhost","timers":"real","transform":[["^.+\\\\.js$","test_preprocessor"]],"transformIgnorePatterns":["/node_modules/"],"unmockedModulePathPatterns":null,"watchPathIgnorePatterns":[]}',
@@ -257,7 +257,7 @@ exports[`ScriptTransformer uses the supplied preprocessor 1`] = `
 `;
 
 exports[`ScriptTransformer uses the supplied preprocessor 2`] = `
-({"Object.<anonymous>":function(module,exports,require,__dirname,__filename,global,jest){module.exports = "react";
+({"Object.<anonymous>":function(){module.exports = "react";
 }});
 `;
 

--- a/packages/jest-transform/src/__tests__/script_transformer.test.js
+++ b/packages/jest-transform/src/__tests__/script_transformer.test.js
@@ -686,4 +686,34 @@ describe('ScriptTransformer', () => {
       ['test_preprocessor', expect.any(Object)],
     ]);
   });
+
+  it('adds `moduleArguments` to transform wrapper', () => {
+    config = {...config, transform: [['^.+\\.js$', 'test_preprocessor']]};
+    const scriptTransformer = new ScriptTransformer(config);
+    const {scriptContent} = scriptTransformer.transform('/fruits/banana.js', {
+      moduleArguments: ['foo', 'bar', 'foobar'],
+    });
+
+    expect(scriptContent.split('\n')[0]).toEqual(
+      '({"Object.<anonymous>":function(foo,bar,foobar){const TRANSFORMED = {',
+    );
+  });
+
+  it('moduleArguments should be part of cache key', () => {
+    config = {...config, transform: [['^.+\\.js$', 'test_preprocessor']]};
+    const scriptTransformer = new ScriptTransformer(config);
+    let result = scriptTransformer.transform('/fruits/banana.js', {});
+
+    expect(result.scriptContent.split('\n')[0]).toEqual(
+      '({"Object.<anonymous>":function(){const TRANSFORMED = {',
+    );
+
+    result = scriptTransformer.transform('/fruits/banana.js', {
+      moduleArguments: ['foo', 'bar', 'foobar'],
+    });
+
+    expect(result.scriptContent.split('\n')[0]).toEqual(
+      '({"Object.<anonymous>":function(foo,bar,foobar){const TRANSFORMED = {',
+    );
+  });
 });

--- a/packages/jest-transform/src/__tests__/script_transformer.test.js
+++ b/packages/jest-transform/src/__tests__/script_transformer.test.js
@@ -141,7 +141,6 @@ let config;
 let fs;
 let mockFs;
 let object;
-let vm;
 let writeFileAtomic;
 
 jest.mock('write-file-atomic', () => ({
@@ -155,8 +154,6 @@ describe('ScriptTransformer', () => {
     jest.resetModules();
 
     object = data => Object.assign(Object.create(null), data);
-
-    vm = require('vm');
 
     mockFs = object({
       '/fruits/banana.js': ['module.exports = "banana";'].join('\n'),
@@ -237,11 +234,6 @@ describe('ScriptTransformer', () => {
       makeGlobalConfig({collectCoverage: true}),
     );
     expect(wrap(transformedKiwiWithCoverage.code)).toMatchSnapshot();
-
-    const transformedKiwiWithCoverageAgain = scriptTransformer.transform(
-      '/fruits/kiwi.js',
-      makeGlobalConfig({collectCoverage: true}),
-    );
 
     expect(transformedBananaWithCoverage.code).not.toEqual(
       transformedKiwiWithCoverage.code,

--- a/packages/jest-transform/src/enhanceUnexpectedTokenMessage.ts
+++ b/packages/jest-transform/src/enhanceUnexpectedTokenMessage.ts
@@ -9,7 +9,9 @@ import chalk = require('chalk');
 
 const DOT = ' \u2022 ';
 
-export default function handlePotentialSyntaxError(e: Error & {codeFrame?: string}) {
+export default function handlePotentialSyntaxError(
+  e: Error & {codeFrame?: string},
+) {
   if (e.codeFrame) {
     e.stack = e.message + '\n' + e.codeFrame;
   }

--- a/packages/jest-transform/src/enhanceUnexpectedTokenMessage.ts
+++ b/packages/jest-transform/src/enhanceUnexpectedTokenMessage.ts
@@ -9,7 +9,24 @@ import chalk = require('chalk');
 
 const DOT = ' \u2022 ';
 
-export default function enhanceUnexpectedTokenMessage(e: Error) {
+export default function handlePotentialSyntaxError(e: Error & {codeFrame?: string}) {
+  if (e.codeFrame) {
+    e.stack = e.message + '\n' + e.codeFrame;
+  }
+
+  if (
+    e instanceof SyntaxError &&
+    (e.message.includes('Unexpected token') ||
+      e.message.includes('Cannot use import')) &&
+    !e.message.includes(' expected')
+  ) {
+    throw enhanceUnexpectedTokenMessage(e);
+  }
+
+  return e;
+}
+
+export function enhanceUnexpectedTokenMessage(e: Error) {
   e.stack =
     `${chalk.bold.red('Jest encountered an unexpected token')}
 

--- a/packages/jest-transform/src/index.ts
+++ b/packages/jest-transform/src/index.ts
@@ -15,3 +15,4 @@ export {
   ShouldInstrumentOptions,
   Options as TransformationOptions,
 } from './types';
+export {default as handlePotentialSyntaxError} from './enhanceUnexpectedTokenMessage';

--- a/packages/jest-transform/src/types.ts
+++ b/packages/jest-transform/src/types.ts
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {Script} from 'vm';
 import {RawSourceMap} from 'source-map';
 import {Config} from '@jest/types';
 
@@ -18,7 +17,6 @@ export type Options = ShouldInstrumentOptions &
   Partial<{
     isCoreModule: boolean;
     isInternalModule: boolean;
-    moduleArguments: Array<string>;
   }>;
 
 // https://stackoverflow.com/a/48216010/1850276
@@ -36,8 +34,7 @@ export type TransformedSource = {
 };
 
 export type TransformResult = {
-  script: Script;
-  scriptContent: string;
+  code: string;
   mapCoverage: boolean;
   sourceMapPath: string | null;
 };

--- a/packages/jest-transform/src/types.ts
+++ b/packages/jest-transform/src/types.ts
@@ -12,15 +12,14 @@ import {Config} from '@jest/types';
 export type ShouldInstrumentOptions = Pick<
   Config.GlobalConfig,
   'collectCoverage' | 'collectCoverageFrom' | 'collectCoverageOnlyFrom'
-> & {
-  changedFiles?: Set<Config.Path>;
-};
+> & {changedFiles?: Set<Config.Path>};
 
 export type Options = ShouldInstrumentOptions &
-  Partial<Pick<Config.ProjectConfig, 'extraGlobals'>> & {
-    isCoreModule?: boolean;
-    isInternalModule?: boolean;
-  };
+  Partial<{
+    isCoreModule: boolean;
+    isInternalModule: boolean;
+    moduleArguments: Array<string>;
+  }>;
 
 // https://stackoverflow.com/a/48216010/1850276
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
@@ -38,6 +37,7 @@ export type TransformedSource = {
 
 export type TransformResult = {
   script: Script;
+  scriptContent: string;
   mapCoverage: boolean;
   sourceMapPath: string | null;
 };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Extracted from #9252. Since `jest-runtime` is the one injecting arguments into the module wrapper, it should also say _which_ arguments those are. This makes `@jest/transform` less coupled to the module wrapper, and thus to Jest's use case. It's marked as a breaking change since it changes `@jest/transform`'s interface, but it's not a breaking change for users of Jest.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Added some tests

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
