### PR TITLE
chore: remove extraGlobals from GlobalConfig

### DIFF
--- a/TestUtils.ts
+++ b/TestUtils.ts
@@ -23,7 +23,6 @@ const DEFAULT_GLOBAL_CONFIG: Config.GlobalConfig = {
   enabledTestsMap: null,
   errorOnDeprecated: false,
   expand: false,
-  extraGlobals: [],
   filter: null,
   findRelatedTests: false,
   forceExit: false,

--- a/e2e/__tests__/__snapshots__/showConfig.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/showConfig.test.ts.snap
@@ -94,7 +94,6 @@ exports[`--showConfig outputs config info and exits 1`] = `
     "detectOpenHandles": false,
     "errorOnDeprecated": false,
     "expand": false,
-    "extraGlobals": [],
     "findRelatedTests": false,
     "forceExit": false,
     "json": false,

--- a/packages/jest-config/src/index.ts
+++ b/packages/jest-config/src/index.ts
@@ -117,7 +117,6 @@ const groupOptions = (
     enabledTestsMap: options.enabledTestsMap,
     errorOnDeprecated: options.errorOnDeprecated,
     expand: options.expand,
-    extraGlobals: options.extraGlobals,
     filter: options.filter,
     findRelatedTests: options.findRelatedTests,
     forceExit: options.forceExit,

--- a/packages/jest-core/src/lib/__tests__/__snapshots__/log_debug_messages.test.ts.snap
+++ b/packages/jest-core/src/lib/__tests__/__snapshots__/log_debug_messages.test.ts.snap
@@ -80,7 +80,6 @@ exports[`prints the config object 1`] = `
     "enabledTestsMap": null,
     "errorOnDeprecated": false,
     "expand": false,
-    "extraGlobals": [],
     "filter": null,
     "findRelatedTests": false,
     "forceExit": false,

--- a/packages/jest-transform/src/types.ts
+++ b/packages/jest-transform/src/types.ts
@@ -17,7 +17,7 @@ export type ShouldInstrumentOptions = Pick<
 };
 
 export type Options = ShouldInstrumentOptions &
-  Partial<Pick<Config.GlobalConfig, 'extraGlobals'>> & {
+  Partial<Pick<Config.ProjectConfig, 'extraGlobals'>> & {
     isCoreModule?: boolean;
     isInternalModule?: boolean;
   };

--- a/packages/jest-types/src/Config.ts
+++ b/packages/jest-types/src/Config.ts
@@ -246,7 +246,6 @@ export type GlobalConfig = {
     };
   };
   expand: boolean;
-  extraGlobals: Array<string>;
   filter?: Path;
   findRelatedTests: boolean;
   forceExit: boolean;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

It's currently on both `ProjectConfig` and `GlobalConfig` - the correct one is `ProjectConfig`

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Green CI

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
