### PR TITLE
chore: make script transform snapshots more readable

### DIFF
--- a/packages/jest-transform/package.json
+++ b/packages/jest-transform/package.json
@@ -32,7 +32,8 @@
     "@types/fast-json-stable-stringify": "^2.0.0",
     "@types/graceful-fs": "^4.1.2",
     "@types/micromatch": "^3.1.0",
-    "@types/write-file-atomic": "^2.1.1"
+    "@types/write-file-atomic": "^2.1.1",
+    "dedent": "^0.7.0"
   },
   "engines": {
     "node": ">= 8"

--- a/packages/jest-transform/src/__tests__/__snapshots__/script_transformer.test.js.snap
+++ b/packages/jest-transform/src/__tests__/__snapshots__/script_transformer.test.js.snap
@@ -75,16 +75,16 @@ Object {
 `;
 
 exports[`ScriptTransformer transforms a file properly 1`] = `
-"({\\"Object.<anonymous>\\":function(module,exports,require,__dirname,__filename,global,jest){/* istanbul ignore next */
+({"Object.<anonymous>":function(module,exports,require,__dirname,__filename,global,jest){/* istanbul ignore next */
 function cov_25u22311x4() {
-  var path = \\"/fruits/banana.js\\";
-  var hash = \\"4be0f6184160be573fc43f7c2a5877c28b7ce249\\";
-  var global = new Function(\\"return this\\")();
-  var gcv = \\"__coverage__\\";
+  var path = "/fruits/banana.js";
+  var hash = "4be0f6184160be573fc43f7c2a5877c28b7ce249";
+  var global = new Function("return this")();
+  var gcv = "__coverage__";
   var coverageData = {
-    path: \\"/fruits/banana.js\\",
+    path: "/fruits/banana.js",
     statementMap: {
-      \\"0\\": {
+      "0": {
         start: {
           line: 1,
           column: 0
@@ -98,12 +98,12 @@ function cov_25u22311x4() {
     fnMap: {},
     branchMap: {},
     s: {
-      \\"0\\": 0
+      "0": 0
     },
     f: {},
     b: {},
-    _coverageSchema: \\"1a1c01bbd47fc00a2c39e90264f33305004495a9\\",
-    hash: \\"4be0f6184160be573fc43f7c2a5877c28b7ce249\\"
+    _coverageSchema: "1a1c01bbd47fc00a2c39e90264f33305004495a9",
+    hash: "4be0f6184160be573fc43f7c2a5877c28b7ce249"
   };
   var coverage = global[gcv] || (global[gcv] = {});
 
@@ -121,21 +121,21 @@ function cov_25u22311x4() {
 }
 
 cov_25u22311x4().s[0]++;
-module.exports = \\"banana\\";
-}});"
+module.exports = "banana";
+}});
 `;
 
 exports[`ScriptTransformer transforms a file properly 2`] = `
-"({\\"Object.<anonymous>\\":function(module,exports,require,__dirname,__filename,global,jest){/* istanbul ignore next */
+({"Object.<anonymous>":function(module,exports,require,__dirname,__filename,global,jest){/* istanbul ignore next */
 function cov_23yvu8etmu() {
-  var path = \\"/fruits/kiwi.js\\";
-  var hash = \\"7705dd5fcfbc884dcea7062944cfb8cc5d141d1a\\";
-  var global = new Function(\\"return this\\")();
-  var gcv = \\"__coverage__\\";
+  var path = "/fruits/kiwi.js";
+  var hash = "7705dd5fcfbc884dcea7062944cfb8cc5d141d1a";
+  var global = new Function("return this")();
+  var gcv = "__coverage__";
   var coverageData = {
-    path: \\"/fruits/kiwi.js\\",
+    path: "/fruits/kiwi.js",
     statementMap: {
-      \\"0\\": {
+      "0": {
         start: {
           line: 1,
           column: 0
@@ -145,7 +145,7 @@ function cov_23yvu8etmu() {
           column: 30
         }
       },
-      \\"1\\": {
+      "1": {
         start: {
           line: 1,
           column: 23
@@ -157,8 +157,8 @@ function cov_23yvu8etmu() {
       }
     },
     fnMap: {
-      \\"0\\": {
-        name: \\"(anonymous_0)\\",
+      "0": {
+        name: "(anonymous_0)",
         decl: {
           start: {
             line: 1,
@@ -184,15 +184,15 @@ function cov_23yvu8etmu() {
     },
     branchMap: {},
     s: {
-      \\"0\\": 0,
-      \\"1\\": 0
+      "0": 0,
+      "1": 0
     },
     f: {
-      \\"0\\": 0
+      "0": 0
     },
     b: {},
-    _coverageSchema: \\"1a1c01bbd47fc00a2c39e90264f33305004495a9\\",
-    hash: \\"7705dd5fcfbc884dcea7062944cfb8cc5d141d1a\\"
+    _coverageSchema: "1a1c01bbd47fc00a2c39e90264f33305004495a9",
+    hash: "7705dd5fcfbc884dcea7062944cfb8cc5d141d1a"
   };
   var coverage = global[gcv] || (global[gcv] = {});
 
@@ -215,56 +215,50 @@ module.exports = () => {
   /* istanbul ignore next */
   cov_23yvu8etmu().f[0]++;
   cov_23yvu8etmu().s[1]++;
-  return \\"kiwi\\";
+  return "kiwi";
 };
-}});"
+}});
 `;
 
 exports[`ScriptTransformer transforms a file properly 3`] = `
-"({\\"Object.<anonymous>\\":function(module,exports,require,__dirname,__filename,global,jest,Math){module.exports = \\"banana\\";
-}});"
+({"Object.<anonymous>":function(module,exports,require,__dirname,__filename,global,jest,Math){module.exports = "banana";
+}});
 `;
 
 exports[`ScriptTransformer uses multiple preprocessors 1`] = `
-"({\\"Object.<anonymous>\\":function(module,exports,require,__dirname,__filename,global,jest){
-          const TRANSFORMED = {
-            filename: '/fruits/banana.js',
-            script: 'module.exports = \\"banana\\";',
-            config: '{\\"automock\\":false,\\"browser\\":false,\\"cache\\":true,\\"cacheDirectory\\":\\"/cache/\\",\\"clearMocks\\":false,\\"coveragePathIgnorePatterns\\":[],\\"cwd\\":\\"/test_root_dir/\\",\\"detectLeaks\\":false,\\"detectOpenHandles\\":false,\\"errorOnDeprecated\\":false,\\"extraGlobals\\":[],\\"filter\\":null,\\"forceCoverageMatch\\":[],\\"globalSetup\\":null,\\"globalTeardown\\":null,\\"globals\\":{},\\"haste\\":{\\"providesModuleNodeModules\\":[]},\\"moduleDirectories\\":[],\\"moduleFileExtensions\\":[\\"js\\"],\\"moduleLoader\\":\\"/test_module_loader_path\\",\\"moduleNameMapper\\":[],\\"modulePathIgnorePatterns\\":[],\\"modulePaths\\":[],\\"name\\":\\"test\\",\\"prettierPath\\":\\"prettier\\",\\"resetMocks\\":false,\\"resetModules\\":false,\\"resolver\\":null,\\"restoreMocks\\":false,\\"rootDir\\":\\"/\\",\\"roots\\":[],\\"runner\\":\\"jest-runner\\",\\"setupFiles\\":[],\\"setupFilesAfterEnv\\":[],\\"skipFilter\\":false,\\"skipNodeResolution\\":false,\\"snapshotResolver\\":null,\\"snapshotSerializers\\":[],\\"testEnvironment\\":\\"node\\",\\"testEnvironmentOptions\\":{},\\"testLocationInResults\\":false,\\"testMatch\\":[],\\"testPathIgnorePatterns\\":[],\\"testRegex\\":[\\"\\\\\\\\.test\\\\\\\\.js$\\"],\\"testRunner\\":\\"jest-jasmine2\\",\\"testURL\\":\\"http://localhost\\",\\"timers\\":\\"real\\",\\"transform\\":[[\\"^.+\\\\\\\\.js$\\",\\"test_preprocessor\\"],[\\"^.+\\\\\\\\.css$\\",\\"css-preprocessor\\"]],\\"transformIgnorePatterns\\":[\\"/node_modules/\\"],\\"unmockedModulePathPatterns\\":null,\\"watchPathIgnorePatterns\\":[]}',
-          };
-        
-}});"
+({"Object.<anonymous>":function(module,exports,require,__dirname,__filename,global,jest){const TRANSFORMED = {
+  filename: '/fruits/banana.js',
+  script: 'module.exports = "banana";',
+  config: '{"automock":false,"browser":false,"cache":true,"cacheDirectory":"/cache/","clearMocks":false,"coveragePathIgnorePatterns":[],"cwd":"/test_root_dir/","detectLeaks":false,"detectOpenHandles":false,"errorOnDeprecated":false,"extraGlobals":[],"filter":null,"forceCoverageMatch":[],"globalSetup":null,"globalTeardown":null,"globals":{},"haste":{"providesModuleNodeModules":[]},"moduleDirectories":[],"moduleFileExtensions":["js"],"moduleLoader":"/test_module_loader_path","moduleNameMapper":[],"modulePathIgnorePatterns":[],"modulePaths":[],"name":"test","prettierPath":"prettier","resetMocks":false,"resetModules":false,"resolver":null,"restoreMocks":false,"rootDir":"/","roots":[],"runner":"jest-runner","setupFiles":[],"setupFilesAfterEnv":[],"skipFilter":false,"skipNodeResolution":false,"snapshotResolver":null,"snapshotSerializers":[],"testEnvironment":"node","testEnvironmentOptions":{},"testLocationInResults":false,"testMatch":[],"testPathIgnorePatterns":[],"testRegex":["\\\\.test\\\\.js$"],"testRunner":"jest-jasmine2","testURL":"http://localhost","timers":"real","transform":[["^.+\\\\.js$","test_preprocessor"],["^.+\\\\.css$","css-preprocessor"]],"transformIgnorePatterns":["/node_modules/"],"unmockedModulePathPatterns":null,"watchPathIgnorePatterns":[]}',
+};
+}});
 `;
 
 exports[`ScriptTransformer uses multiple preprocessors 2`] = `
-"({\\"Object.<anonymous>\\":function(module,exports,require,__dirname,__filename,global,jest){
-          module.exports = {
-            filename: /styles/App.css,
-            rawFirstLine: root {,
-          };
-        
-}});"
+({"Object.<anonymous>":function(module,exports,require,__dirname,__filename,global,jest){module.exports = {
+  filename: /styles/App.css,
+  rawFirstLine: root {,
+};
+}});
 `;
 
 exports[`ScriptTransformer uses multiple preprocessors 3`] = `
-"({\\"Object.<anonymous>\\":function(module,exports,require,__dirname,__filename,global,jest){module.exports = \\"react\\";
-}});"
+({"Object.<anonymous>":function(module,exports,require,__dirname,__filename,global,jest){module.exports = "react";
+}});
 `;
 
 exports[`ScriptTransformer uses the supplied preprocessor 1`] = `
-"({\\"Object.<anonymous>\\":function(module,exports,require,__dirname,__filename,global,jest){
-          const TRANSFORMED = {
-            filename: '/fruits/banana.js',
-            script: 'module.exports = \\"banana\\";',
-            config: '{\\"automock\\":false,\\"browser\\":false,\\"cache\\":true,\\"cacheDirectory\\":\\"/cache/\\",\\"clearMocks\\":false,\\"coveragePathIgnorePatterns\\":[],\\"cwd\\":\\"/test_root_dir/\\",\\"detectLeaks\\":false,\\"detectOpenHandles\\":false,\\"errorOnDeprecated\\":false,\\"extraGlobals\\":[],\\"filter\\":null,\\"forceCoverageMatch\\":[],\\"globalSetup\\":null,\\"globalTeardown\\":null,\\"globals\\":{},\\"haste\\":{\\"providesModuleNodeModules\\":[]},\\"moduleDirectories\\":[],\\"moduleFileExtensions\\":[\\"js\\"],\\"moduleLoader\\":\\"/test_module_loader_path\\",\\"moduleNameMapper\\":[],\\"modulePathIgnorePatterns\\":[],\\"modulePaths\\":[],\\"name\\":\\"test\\",\\"prettierPath\\":\\"prettier\\",\\"resetMocks\\":false,\\"resetModules\\":false,\\"resolver\\":null,\\"restoreMocks\\":false,\\"rootDir\\":\\"/\\",\\"roots\\":[],\\"runner\\":\\"jest-runner\\",\\"setupFiles\\":[],\\"setupFilesAfterEnv\\":[],\\"skipFilter\\":false,\\"skipNodeResolution\\":false,\\"snapshotResolver\\":null,\\"snapshotSerializers\\":[],\\"testEnvironment\\":\\"node\\",\\"testEnvironmentOptions\\":{},\\"testLocationInResults\\":false,\\"testMatch\\":[],\\"testPathIgnorePatterns\\":[],\\"testRegex\\":[\\"\\\\\\\\.test\\\\\\\\.js$\\"],\\"testRunner\\":\\"jest-jasmine2\\",\\"testURL\\":\\"http://localhost\\",\\"timers\\":\\"real\\",\\"transform\\":[[\\"^.+\\\\\\\\.js$\\",\\"test_preprocessor\\"]],\\"transformIgnorePatterns\\":[\\"/node_modules/\\"],\\"unmockedModulePathPatterns\\":null,\\"watchPathIgnorePatterns\\":[]}',
-          };
-        
-}});"
+({"Object.<anonymous>":function(module,exports,require,__dirname,__filename,global,jest){const TRANSFORMED = {
+  filename: '/fruits/banana.js',
+  script: 'module.exports = "banana";',
+  config: '{"automock":false,"browser":false,"cache":true,"cacheDirectory":"/cache/","clearMocks":false,"coveragePathIgnorePatterns":[],"cwd":"/test_root_dir/","detectLeaks":false,"detectOpenHandles":false,"errorOnDeprecated":false,"extraGlobals":[],"filter":null,"forceCoverageMatch":[],"globalSetup":null,"globalTeardown":null,"globals":{},"haste":{"providesModuleNodeModules":[]},"moduleDirectories":[],"moduleFileExtensions":["js"],"moduleLoader":"/test_module_loader_path","moduleNameMapper":[],"modulePathIgnorePatterns":[],"modulePaths":[],"name":"test","prettierPath":"prettier","resetMocks":false,"resetModules":false,"resolver":null,"restoreMocks":false,"rootDir":"/","roots":[],"runner":"jest-runner","setupFiles":[],"setupFilesAfterEnv":[],"skipFilter":false,"skipNodeResolution":false,"snapshotResolver":null,"snapshotSerializers":[],"testEnvironment":"node","testEnvironmentOptions":{},"testLocationInResults":false,"testMatch":[],"testPathIgnorePatterns":[],"testRegex":["\\\\.test\\\\.js$"],"testRunner":"jest-jasmine2","testURL":"http://localhost","timers":"real","transform":[["^.+\\\\.js$","test_preprocessor"]],"transformIgnorePatterns":["/node_modules/"],"unmockedModulePathPatterns":null,"watchPathIgnorePatterns":[]}',
+};
+}});
 `;
 
 exports[`ScriptTransformer uses the supplied preprocessor 2`] = `
-"({\\"Object.<anonymous>\\":function(module,exports,require,__dirname,__filename,global,jest){module.exports = \\"react\\";
-}});"
+({"Object.<anonymous>":function(module,exports,require,__dirname,__filename,global,jest){module.exports = "react";
+}});
 `;
 
-exports[`ScriptTransformer warns of unparseable inlined source maps from the preprocessor 1`] = `"jest-transform: The source map produced for the file /fruits/banana.js by preprocessor-with-sourcemaps was invalid. Proceeding without source mapping for that file."`;
+exports[`ScriptTransformer warns of unparseable inlined source maps from the preprocessor 1`] = `jest-transform: The source map produced for the file /fruits/banana.js by preprocessor-with-sourcemaps was invalid. Proceeding without source mapping for that file.`;

--- a/packages/jest-transform/src/__tests__/script_transformer.test.js
+++ b/packages/jest-transform/src/__tests__/script_transformer.test.js
@@ -6,6 +6,7 @@
  *
  */
 
+import {wrap} from 'jest-snapshot-serializer-raw';
 import {makeGlobalConfig, makeProjectConfig} from '../../../../TestUtils';
 
 jest
@@ -46,7 +47,7 @@ jest.mock(
 
     return {
       getCacheKey: jest.fn((content, filename, configStr) => 'ab'),
-      process: (content, filename, config) => `
+      process: (content, filename, config) => jest.requireActual('dedent')`
           const TRANSFORMED = {
             filename: '${escapeStrings(filename)}',
             script: '${escapeStrings(content)}',
@@ -81,7 +82,7 @@ jest.mock(
   'css-preprocessor',
   () => ({
     getCacheKey: jest.fn((content, filename, configStr) => 'cd'),
-    process: (content, filename, config) => `
+    process: (content, filename, config) => jest.requireActual('dedent')`
           module.exports = {
             filename: ${filename},
             rawFirstLine: ${content.split('\n')[0]},
@@ -218,7 +219,7 @@ describe('ScriptTransformer', () => {
     ).script;
 
     expect(response instanceof vm.Script).toBe(true);
-    expect(vm.Script.mock.calls[0][0]).toMatchSnapshot();
+    expect(wrap(vm.Script.mock.calls[0][0])).toMatchSnapshot();
 
     // no-cache case
     expect(fs.readFileSync).toHaveBeenCalledTimes(1);
@@ -236,7 +237,7 @@ describe('ScriptTransformer', () => {
       makeGlobalConfig({collectCoverage: true}),
     );
     const snapshot = vm.Script.mock.calls[1][0];
-    expect(snapshot).toMatchSnapshot();
+    expect(wrap(snapshot)).toMatchSnapshot();
 
     scriptTransformer.transform(
       '/fruits/kiwi.js',
@@ -257,7 +258,7 @@ describe('ScriptTransformer', () => {
       // to make sure jest isn't declared twice
       extraGlobals: ['Math', 'jest'],
     }).script;
-    expect(vm.Script.mock.calls[3][0]).toMatchSnapshot();
+    expect(wrap(vm.Script.mock.calls[3][0])).toMatchSnapshot();
   });
 
   it('does not transform Node core modules', () => {
@@ -361,11 +362,11 @@ describe('ScriptTransformer', () => {
 
     expect(require('test_preprocessor').getCacheKey).toBeCalled();
 
-    expect(vm.Script.mock.calls[0][0]).toMatchSnapshot();
+    expect(wrap(vm.Script.mock.calls[0][0])).toMatchSnapshot();
 
     scriptTransformer.transform('/node_modules/react.js', {});
     // ignores preprocessor
-    expect(vm.Script.mock.calls[1][0]).toMatchSnapshot();
+    expect(wrap(vm.Script.mock.calls[1][0])).toMatchSnapshot();
   });
 
   it('uses multiple preprocessors', () => {
@@ -383,12 +384,12 @@ describe('ScriptTransformer', () => {
 
     expect(require('test_preprocessor').getCacheKey).toBeCalled();
     expect(require('css-preprocessor').getCacheKey).toBeCalled();
-    expect(vm.Script.mock.calls[0][0]).toMatchSnapshot();
-    expect(vm.Script.mock.calls[1][0]).toMatchSnapshot();
+    expect(wrap(vm.Script.mock.calls[0][0])).toMatchSnapshot();
+    expect(wrap(vm.Script.mock.calls[1][0])).toMatchSnapshot();
 
     scriptTransformer.transform('/node_modules/react.js', {});
     // ignores preprocessor
-    expect(vm.Script.mock.calls[2][0]).toMatchSnapshot();
+    expect(wrap(vm.Script.mock.calls[2][0])).toMatchSnapshot();
   });
 
   it('writes source map if preprocessor supplies it', () => {
@@ -491,7 +492,7 @@ describe('ScriptTransformer', () => {
     expect(writeFileAtomic.sync).toBeCalledTimes(1);
 
     expect(console.warn).toHaveBeenCalledTimes(1);
-    expect(console.warn.mock.calls[0][0]).toMatchSnapshot();
+    expect(wrap(console.warn.mock.calls[0][0])).toMatchSnapshot();
     console.warn = warn;
   });
 

--- a/packages/jest-transform/src/__tests__/script_transformer.test.js
+++ b/packages/jest-transform/src/__tests__/script_transformer.test.js
@@ -47,7 +47,7 @@ jest.mock(
 
     return {
       getCacheKey: jest.fn((content, filename, configStr) => 'ab'),
-      process: (content, filename, config) => jest.requireActual('dedent')`
+      process: (content, filename, config) => require('dedent')`
           const TRANSFORMED = {
             filename: '${escapeStrings(filename)}',
             script: '${escapeStrings(content)}',
@@ -82,7 +82,7 @@ jest.mock(
   'css-preprocessor',
   () => ({
     getCacheKey: jest.fn((content, filename, configStr) => 'cd'),
-    process: (content, filename, config) => jest.requireActual('dedent')`
+    process: (content, filename, config) => require('dedent')`
           module.exports = {
             filename: ${filename},
             rawFirstLine: ${content.split('\n')[0]},


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

While working on #9253 I found it very difficult to read the snapshots. Which also means changes to them are hard to read, so I decided to land this separately. It does this by using `dedent` to avoid the extra indentation and `jest-serializer-raw` to avoid the wrapping double quotes and escaped inner double quotes

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan
Green CI

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
