### PR TITLE
fix: limit number of workers when creating haste maps in projects

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,9 +5,7 @@
     "**/node_modules": true,
     "**/build": true
   },
-  "editor.formatOnSave": true,
-  "flow.useNPMPackagedFlow": true,
+  "eslint.autoFixOnSave": true,
   "javascript.validate.enable": false,
-  "jest.pathToJest": "yarn jest --",
-  "prettier.eslintIntegration": true
+  "jest.pathToJest": "yarn jest --"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 - `[jest-config]` Fix Jest multi project runner still cannot handle exactly one project ([#8894](https://github.com/facebook/jest/pull/8894))
 - `[jest-console]` Add missing `console.group` calls to `NullConsole` ([#9024](https://github.com/facebook/jest/pull/9024))
 - `[jest-core]` Don't include unref'd timers in --detectOpenHandles results ([#8941](https://github.com/facebook/jest/pull/8941))
+- `[jest-core]` Limit number of workers when creating haste maps in projects ([#9259](https://github.com/facebook/jest/pull/9259))
 - `[jest-diff]` Do not inverse format if line consists of one change ([#8903](https://github.com/facebook/jest/pull/8903))
 - `[jest-diff]` Rename some new options and change their default values ([#9077](https://github.com/facebook/jest/pull/9077))
 - `[jest-fake-timers]` `getTimerCount` will not include cancelled immediates ([#8764](https://github.com/facebook/jest/pull/8764))

--- a/packages/jest-core/src/cli/index.ts
+++ b/packages/jest-core/src/cli/index.ts
@@ -122,7 +122,10 @@ const buildContextsAndHasteMaps = async (
       createDirectory(config.cacheDirectory);
       const hasteMapInstance = Runtime.createHasteMap(config, {
         console: new CustomConsole(outputStream, outputStream),
-        maxWorkers: Math.max(1, globalConfig.maxWorkers / configs.length),
+        maxWorkers: Math.max(
+          1,
+          Math.floor(globalConfig.maxWorkers / configs.length),
+        ),
         resetCache: !config.cache,
         watch: globalConfig.watch || globalConfig.watchAll,
         watchman: globalConfig.watchman,

--- a/packages/jest-core/src/cli/index.ts
+++ b/packages/jest-core/src/cli/index.ts
@@ -122,7 +122,7 @@ const buildContextsAndHasteMaps = async (
       createDirectory(config.cacheDirectory);
       const hasteMapInstance = Runtime.createHasteMap(config, {
         console: new CustomConsole(outputStream, outputStream),
-        maxWorkers: globalConfig.maxWorkers,
+        maxWorkers: Math.max(1, globalConfig.maxWorkers / configs.length),
         resetCache: !config.cache,
         watch: globalConfig.watch || globalConfig.watchAll,
         watchman: globalConfig.watchman,

--- a/packages/jest-runtime/src/cli/index.ts
+++ b/packages/jest-runtime/src/cli/index.ts
@@ -35,7 +35,6 @@ export function run(cliArgv?: Config.Argv, cliInfo?: Array<string>) {
       .version(false)
       .options(args.options).argv;
 
-    // @ts-ignore: fix this at some point
     validateCLIOptions(argv, {...args.options, deprecationEntries});
   }
 
@@ -63,8 +62,6 @@ export function run(cliArgv?: Config.Argv, cliInfo?: Array<string>) {
     const info = cliInfo ? ', ' + cliInfo.join(', ') : '';
     console.log(`Using Jest Runtime v${VERSION}${info}`);
   }
-  // TODO: Figure this out
-  // @ts-ignore: this might not have the correct arguments
   const options = readConfig(argv, root);
   const globalConfig = options.globalConfig;
   // Always disable automocking in scripts.

--- a/packages/jest-worker/README.md
+++ b/packages/jest-worker/README.md
@@ -83,6 +83,12 @@ By default, no process is bound to any worker.
 
 The arguments that will be passed to the `setup` method during initialization.
 
+#### `WorkerPool: (workerPath: string, options?: WorkerPoolOptions) => WorkerPoolInterface` (optional)
+
+Provide a custom worker pool to be used for spawning child processes. By default, Jest will use a node thread pool if available and fall back to child process threads.
+
+The arguments that will be passed to the `setup` method during initialization.
+
 #### `enableWorkerThreads: boolean` (optional)
 
 `jest-worker` will automatically detect if `worker_threads` are available, but will not use them unless passed `enableWorkerThreads: true`.

--- a/packages/jest-worker/README.md
+++ b/packages/jest-worker/README.md
@@ -83,12 +83,6 @@ By default, no process is bound to any worker.
 
 The arguments that will be passed to the `setup` method during initialization.
 
-#### `workerPool: (workerPath: string, options?: WorkerPoolOptions) => WorkerPoolInterface` (optional)
-
-Provide a custom worker pool to be used for spawning child processes. By default, Jest will use a node thread pool if available and fall back to child process threads.
-
-The arguments that will be passed to the `setup` method during initialization.
-
 #### `enableWorkerThreads: boolean` (optional)
 
 `jest-worker` will automatically detect if `worker_threads` are available, but will not use them unless passed `enableWorkerThreads: true`.


### PR DESCRIPTION
## Summary

Partially addresses https://github.com/facebook/jest/issues/9236.

When creating haste contexts and maps, Jest currently spawns `maxWorkers` per "project". While it doesn't make a difference in a single-project workspace, it's a big deal for those using multiple projects. 

A quick-and-dirty-but-works solution is to limit the number of workers based on the projects number. It's sub-optimal, because we may have smaller and larger projects which we assign the same number of workers. However a proper solution would require more work. E.g. we could delegate `createHasteMap` of each project to a worker pool created in `jest-core`, instead of deferring parallelization to `createHasteMap` itself. Feel free to implement this solution. However, I'm not pursuing this, as @scotthovestadt has likely far more meaningful changes to haste map performance.

In Jest own test suite, this diff result in haste map creation time drop from 3.1s to 0.8s on my machine, which is noticeable.