### PR TITLE
Fix TextEncoder.encode not referencing same global Uint8Array constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@
 - `[jest-utils]` Allow querying process.domain ([#9136](https://github.com/facebook/jest/pull/9136))
 - `[pretty-format]` Correctly detect memoized elements ([#9196](https://github.com/facebook/jest/pull/9196))
 - `[jest-fake-timers]` Support `util.promisify` on `setTimeout` ([#9180](https://github.com/facebook/jest/pull/9180))
+- `[jest-environment-node]` Fix `TextEncoder.encode` not referencing same global `Uint8Array` constructor ([#9261](https://github.com/facebook/jest/pull/9261))
 
 ### Chore & Maintenance
 

--- a/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -2537,13 +2537,6 @@ Expected: not <g>StringMatching /bc/</>
 Received:     <r>"abcd"</>
 `;
 
-exports[`.toEqual() {pass: true} expect([1, 2, 3]).not.toEqual([1, 2, 3]) 1`] = `
-<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
-
-Expected: not <g>[1, 2, 3]</>
-
-`;
-
 exports[`.toEqual() {pass: true} expect([1, 2, 3]).not.toEqual(ArrayContaining [2, 3]) 1`] = `
 <d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
@@ -2566,6 +2559,13 @@ Expected: not <g>[1]</>
 `;
 
 exports[`.toEqual() {pass: true} expect([97, 98, 99]).not.toEqual([97, 98, 99]) 1`] = `
+<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
+
+Expected: not <g>[97, 98, 99]</>
+
+`;
+
+exports[`.toEqual() {pass: true} expect([97, 98, 99]).not.toEqual([97, 98, 99]) 2`] = `
 <d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
 Expected: not <g>[97, 98, 99]</>

--- a/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -2067,6 +2067,20 @@ exports[`.toEqual() {pass: false} expect([1]).toEqual([2]) 1`] = `
 <d>  ]</>
 `;
 
+exports[`.toEqual() {pass: false} expect([97, 98, 99]).toEqual([97, 98, 100]) 1`] = `
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
+
+<g>- Expected  - 1</>
+<r>+ Received  + 1</>
+
+<d>  Uint8Array [</>
+<d>    97,</>
+<d>    98,</>
+<g>-   100,</>
+<r>+   99,</>
+<d>  ]</>
+`;
+
 exports[`.toEqual() {pass: false} expect({"0": "a", "1": "b", "2": "c"}).toEqual("abc") 1`] = `
 <d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 

--- a/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -2558,6 +2558,13 @@ Expected: not <g>[1]</>
 
 `;
 
+exports[`.toEqual() {pass: true} expect([97, 98, 99]).not.toEqual([97, 98, 99]) 1`] = `
+<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
+
+Expected: not <g>[97, 98, 99]</>
+
+`;
+
 exports[`.toEqual() {pass: true} expect([Function anonymous]).not.toEqual(Any<Function>) 1`] = `
 <d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 

--- a/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -2537,6 +2537,13 @@ Expected: not <g>StringMatching /bc/</>
 Received:     <r>"abcd"</>
 `;
 
+exports[`.toEqual() {pass: true} expect([1, 2, 3]).not.toEqual([1, 2, 3]) 1`] = `
+<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
+
+Expected: not <g>[1, 2, 3]</>
+
+`;
+
 exports[`.toEqual() {pass: true} expect([1, 2, 3]).not.toEqual(ArrayContaining [2, 3]) 1`] = `
 <d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
@@ -2555,6 +2562,13 @@ exports[`.toEqual() {pass: true} expect([1]).not.toEqual([1]) 1`] = `
 <d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
 Expected: not <g>[1]</>
+
+`;
+
+exports[`.toEqual() {pass: true} expect([97, 98, 99]).not.toEqual([97, 98, 99]) 1`] = `
+<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
+
+Expected: not <g>[97, 98, 99]</>
 
 `;
 

--- a/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -2558,20 +2558,6 @@ Expected: not <g>[1]</>
 
 `;
 
-exports[`.toEqual() {pass: true} expect([97, 98, 99]).not.toEqual([97, 98, 99]) 1`] = `
-<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
-
-Expected: not <g>[97, 98, 99]</>
-
-`;
-
-exports[`.toEqual() {pass: true} expect([97, 98, 99]).not.toEqual([97, 98, 99]) 2`] = `
-<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
-
-Expected: not <g>[97, 98, 99]</>
-
-`;
-
 exports[`.toEqual() {pass: true} expect([Function anonymous]).not.toEqual(Any<Function>) 1`] = `
 <d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 

--- a/packages/expect/src/__tests__/matchers.test.js
+++ b/packages/expect/src/__tests__/matchers.test.js
@@ -24,6 +24,7 @@ afterAll(() => {
 
 /* global BigInt */
 const isBigIntDefined = typeof BigInt === 'function';
+const isTextEncoderDefined = typeof TextEncoder === 'function';
 
 it('should throw if passed two arguments', () => {
   expect(() => jestExpect('foo', 'bar')).toThrow(
@@ -689,8 +690,6 @@ describe('.toEqual()', () => {
       Immutable.Map({1: Immutable.Map({2: {a: 99}})}),
       Immutable.Map({1: Immutable.Map({2: {a: 99}})}),
     ],
-    [new Uint8Array([1, 2, 3]), new Uint8Array([1, 2, 3])],
-    [new TextEncoder().encode('abc'), new Uint8Array([97, 98, 99])],
     [{a: 1, b: 2}, jestExpect.objectContaining({a: 1})],
     [[1, 2, 3], jestExpect.arrayContaining([2, 3])],
     ['abcd', jestExpect.stringContaining('bc')],
@@ -735,6 +734,22 @@ describe('.toEqual()', () => {
       expect(() => jestExpect(a).not.toEqual(b)).toThrowErrorMatchingSnapshot();
     });
   });
+
+  if (isTextEncoderDefined) {
+    [
+      [new Uint8Array([97, 98, 99]), new Uint8Array([97, 98, 99])],
+      [new TextEncoder().encode('abc'), new Uint8Array([97, 98, 99])],
+    ].forEach(([a, b]) => {
+      test(`{pass: true} expect(${stringify(a)}).not.toEqual(${stringify(
+        b,
+      )})`, () => {
+        jestExpect(a).toEqual(b);
+        expect(() =>
+          jestExpect(a).not.toEqual(b),
+        ).toThrowErrorMatchingSnapshot();
+      });
+    });
+  }
 
   if (isBigIntDefined) {
     [

--- a/packages/expect/src/__tests__/matchers.test.js
+++ b/packages/expect/src/__tests__/matchers.test.js
@@ -689,6 +689,8 @@ describe('.toEqual()', () => {
       Immutable.Map({1: Immutable.Map({2: {a: 99}})}),
       Immutable.Map({1: Immutable.Map({2: {a: 99}})}),
     ],
+    [new Uint8Array([1, 2, 3]), new Uint8Array([1, 2, 3])],
+    [new TextEncoder().encode('abc'), new Uint8Array([97, 98, 99])],
     [{a: 1, b: 2}, jestExpect.objectContaining({a: 1})],
     [[1, 2, 3], jestExpect.arrayContaining([2, 3])],
     ['abcd', jestExpect.stringContaining('bc')],

--- a/packages/expect/src/__tests__/matchers.test.js
+++ b/packages/expect/src/__tests__/matchers.test.js
@@ -744,9 +744,7 @@ describe('.toEqual()', () => {
         b,
       )})`, () => {
         jestExpect(a).toEqual(b);
-        expect(() =>
-          jestExpect(a).not.toEqual(b),
-        ).toThrowErrorMatchingSnapshot();
+        expect(() => jestExpect(a).not.toEqual(b)).toThrowError('toEqual');
       });
     });
   }

--- a/packages/expect/src/__tests__/matchers.test.js
+++ b/packages/expect/src/__tests__/matchers.test.js
@@ -488,6 +488,7 @@ describe('.toEqual()', () => {
       Immutable.Map({1: Immutable.Map({2: {a: 99}})}),
       Immutable.Map({1: Immutable.Map({2: {a: 11}})}),
     ],
+    [new Uint8Array([97, 98, 99]), new Uint8Array([97, 98, 100])],
     [{a: 1, b: 2}, jestExpect.objectContaining({a: 2})],
     [false, jestExpect.objectContaining({a: 2})],
     [[1, 3], jestExpect.arrayContaining([1, 2])],

--- a/packages/expect/src/__tests__/matchers.test.js
+++ b/packages/expect/src/__tests__/matchers.test.js
@@ -24,7 +24,6 @@ afterAll(() => {
 
 /* global BigInt */
 const isBigIntDefined = typeof BigInt === 'function';
-const isTextEncoderDefined = typeof TextEncoder === 'function';
 
 it('should throw if passed two arguments', () => {
   expect(() => jestExpect('foo', 'bar')).toThrow(
@@ -690,6 +689,7 @@ describe('.toEqual()', () => {
       Immutable.Map({1: Immutable.Map({2: {a: 99}})}),
       Immutable.Map({1: Immutable.Map({2: {a: 99}})}),
     ],
+    [new Uint8Array([97, 98, 99]), new Uint8Array([97, 98, 99])],
     [{a: 1, b: 2}, jestExpect.objectContaining({a: 1})],
     [[1, 2, 3], jestExpect.arrayContaining([2, 3])],
     ['abcd', jestExpect.stringContaining('bc')],
@@ -734,20 +734,6 @@ describe('.toEqual()', () => {
       expect(() => jestExpect(a).not.toEqual(b)).toThrowErrorMatchingSnapshot();
     });
   });
-
-  if (isTextEncoderDefined) {
-    [
-      [new Uint8Array([97, 98, 99]), new Uint8Array([97, 98, 99])],
-      [new TextEncoder().encode('abc'), new Uint8Array([97, 98, 99])],
-    ].forEach(([a, b]) => {
-      test(`{pass: true} expect(${stringify(a)}).not.toEqual(${stringify(
-        b,
-      )})`, () => {
-        jestExpect(a).toEqual(b);
-        expect(() => jestExpect(a).not.toEqual(b)).toThrowError('toEqual');
-      });
-    });
-  }
 
   if (isBigIntDefined) {
     [

--- a/packages/jest-environment-node/src/__tests__/node_environment.test.ts
+++ b/packages/jest-environment-node/src/__tests__/node_environment.test.ts
@@ -8,6 +8,8 @@
 import NodeEnvironment = require('../');
 import {makeProjectConfig} from '../../../../TestUtils';
 
+const isTextEncoderDefined = typeof TextEncoder === 'function';
+
 describe('NodeEnvironment', () => {
   it('uses a copy of the process object', () => {
     const env1 = new NodeEnvironment(makeProjectConfig());
@@ -49,4 +51,10 @@ describe('NodeEnvironment', () => {
 
     expect(env.fakeTimersLolex).toBeDefined();
   });
+
+  if (isTextEncoderDefined) {
+    test('TextEncoder references the same global Uint8Array constructor', () => {
+      expect(new TextEncoder().encode('abc')).toBeInstanceOf(Uint8Array);
+    });
+  }
 });

--- a/packages/jest-environment-node/src/index.ts
+++ b/packages/jest-environment-node/src/index.ts
@@ -46,6 +46,11 @@ class NodeEnvironment implements JestEnvironment {
     global.setInterval = setInterval;
     global.setTimeout = setTimeout;
     global.ArrayBuffer = ArrayBuffer;
+    // TextEncoder (global or via 'util') references a Uint8Array constructor
+    // different than the global one used by users in tests. This makes sure the
+    // same constructor is referenced by both.
+    global.Uint8Array = Uint8Array;
+
     // URL and URLSearchParams are global in Node >= 10
     if (typeof URL !== 'undefined' && typeof URLSearchParams !== 'undefined') {
       global.URL = URL;
@@ -58,7 +63,6 @@ class NodeEnvironment implements JestEnvironment {
     ) {
       global.TextEncoder = TextEncoder;
       global.TextDecoder = TextDecoder;
-      global.Uint8Array = Uint8Array;
     }
     // queueMicrotask is global in Node >= 11
     if (typeof queueMicrotask !== 'undefined') {

--- a/packages/jest-environment-node/src/index.ts
+++ b/packages/jest-environment-node/src/index.ts
@@ -58,6 +58,7 @@ class NodeEnvironment implements JestEnvironment {
     ) {
       global.TextEncoder = TextEncoder;
       global.TextDecoder = TextDecoder;
+      global.Uint8Array = Uint8Array;
     }
     // queueMicrotask is global in Node >= 11
     if (typeof queueMicrotask !== 'undefined') {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Fixes #9204 

This is a follow up for my comment: https://github.com/facebook/jest/issues/9204#issuecomment-561438263

Currently the following tests are failing in Jest:

- **Using global TextEncoder (node v11 and above)**

```js
it('TextEncoder.encode references the same global Uint8Array constructor', () => {
  const actual = new TextEncoder().encode('foo');
  expect(actual).toEqual(new Uint8Array([102, 111, 111])); // fails
  expect(actual).toBeInstanceOf(Uint8Array); // fails
});
```

- **Importing TextEncoder from the 'util' module (not using global TextEncoder)**

```js
const {TextEncoder} = require('util');

it('TextEncoder.encode references the same global Uint8Array constructor', () => {
  const actual = new TextEncoder().encode('foo');
  expect(actual).toEqual(new Uint8Array([102, 111, 111])); // fails
  expect(actual).toBeInstanceOf(Uint8Array); // fails
});
```

---

It seems that the constructor of the `Uint8Array` returned from `TextEncoder.prototype.encode` and the global `Uint8Array` constructor **are not the same** (**causing some matchers to fail via the `iterableEquality`**); note that this only happens in the jest node environment.

```js
// in Jest (using the node environment)
new TextEncoder().encode('').constructor === Uint8Array // false

// outside Jest (regular node runtime)
new TextEncoder().encode('').constructor === Uint8Array // true
```

I'm not exactly sure why these two are referencing different constructors, or where either one of them is referencing a different one. I'm wondering if anyone has any pointers on this – I'm really curious!

That said, updating jest-environment-node's `global` to reference the actual `Uint8Array` seems to resolve this issue.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

The following test should pass on this branch:

```js
test('TextEncoder references the same global Uint8Array constructor', () => {
  expect(new TextEncoder().encode('abc')).toBeInstanceOf(Uint8Array);
});
```

I added some new tests that would have failed outside of this PR.