### PR TITLE
Improve error message format for Node's assert.fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@
 - `[jest-utils]` Allow querying process.domain ([#9136](https://github.com/facebook/jest/pull/9136))
 - `[pretty-format]` Correctly detect memoized elements ([#9196](https://github.com/facebook/jest/pull/9196))
 - `[jest-fake-timers]` Support `util.promisify` on `setTimeout` ([#9180](https://github.com/facebook/jest/pull/9180))
+- `[jest-jasmine2, jest-circus]` Improve error message format for Node's assert.fail ([#9262](https://github.com/facebook/jest/pull/9262))
 
 ### Chore & Maintenance
 

--- a/e2e/__tests__/__snapshots__/failures.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/failures.test.ts.snap
@@ -396,6 +396,8 @@ FAIL __tests__/assertionError.test.js
   ✕ assert.doesNotThrow
   ✕ assert.throws
   ✕ async
+  ✕ assert.fail
+  ✕ assert.fail with a message
 
   ● assert
 
@@ -772,8 +774,39 @@ FAIL __tests__/assertionError.test.js
          |          ^
       81 | });
       82 | 
+      83 | test('assert.fail', () => {
 
       at Object.equal (__tests__/assertionError.test.js:80:10)
+
+  ● assert.fail
+
+    assert.fail(received, expected)
+
+      82 | 
+      83 | test('assert.fail', () => {
+    > 84 |   assert.fail();
+         |          ^
+      85 | });
+      86 | 
+      87 | test('assert.fail with a message', () => {
+
+      at Object.fail (__tests__/assertionError.test.js:84:10)
+
+  ● assert.fail with a message
+
+    assert.fail(received, expected)
+
+    Message:
+      error!
+
+      86 | 
+      87 | test('assert.fail with a message', () => {
+    > 88 |   assert.fail('error!');
+         |          ^
+      89 | });
+      90 | 
+
+      at Object.fail (__tests__/assertionError.test.js:88:10)
 `;
 
 exports[`works with snapshot failures 1`] = `

--- a/e2e/failures/__tests__/assertionError.test.js
+++ b/e2e/failures/__tests__/assertionError.test.js
@@ -79,3 +79,11 @@ test('assert.throws', () => {
 test('async', async () => {
   assert.equal('hello\ngoodbye', 'hello', 'hmmm');
 });
+
+test('assert.fail', () => {
+  assert.fail();
+});
+
+test('assert.fail with a message', () => {
+  assert.fail('error!');
+});

--- a/packages/jest-circus/src/formatNodeAssertErrors.ts
+++ b/packages/jest-circus/src/formatNodeAssertErrors.ts
@@ -155,6 +155,14 @@ function assertionErrorMessage(
     );
   }
 
+  if (operatorName === 'fail') {
+    return (
+      buildHintString(assertMatcherHint(operator, operatorName, expected)) +
+      chalk.reset(hasCustomMessage ? 'Message:\n  ' + message : '') +
+      trimmedStack
+    );
+  }
+
   return (
     buildHintString(assertMatcherHint(operator, operatorName, expected)) +
     chalk.reset(`Expected value ${operatorMessage(operator)}`) +

--- a/packages/jest-circus/src/formatNodeAssertErrors.ts
+++ b/packages/jest-circus/src/formatNodeAssertErrors.ts
@@ -76,6 +76,7 @@ const getOperatorName = (operator: string | undefined, stack: string) => {
   if (stack.match('.throws')) {
     return 'throws';
   }
+  // this fallback is only needed for versions older than node 10
   if (stack.match('.fail')) {
     return 'fail';
   }

--- a/packages/jest-circus/src/formatNodeAssertErrors.ts
+++ b/packages/jest-circus/src/formatNodeAssertErrors.ts
@@ -76,6 +76,9 @@ const getOperatorName = (operator: string | undefined, stack: string) => {
   if (stack.match('.throws')) {
     return 'throws';
   }
+  if (stack.match('.fail')) {
+    return 'fail';
+  }
   return '';
 };
 

--- a/packages/jest-jasmine2/src/assertionErrorMessage.ts
+++ b/packages/jest-jasmine2/src/assertionErrorMessage.ts
@@ -42,6 +42,7 @@ const getOperatorName = (operator: string | null, stack: string) => {
   if (stack.match('.throws')) {
     return 'throws';
   }
+  // this fallback is only needed for versions older than node 10
   if (stack.match('.fail')) {
     return 'fail';
   }

--- a/packages/jest-jasmine2/src/assertionErrorMessage.ts
+++ b/packages/jest-jasmine2/src/assertionErrorMessage.ts
@@ -42,6 +42,9 @@ const getOperatorName = (operator: string | null, stack: string) => {
   if (stack.match('.throws')) {
     return 'throws';
   }
+  if (stack.match('.fail')) {
+    return 'fail';
+  }
   return '';
 };
 

--- a/packages/jest-jasmine2/src/assertionErrorMessage.ts
+++ b/packages/jest-jasmine2/src/assertionErrorMessage.ts
@@ -121,6 +121,14 @@ function assertionErrorMessage(
     );
   }
 
+  if (operatorName === 'fail') {
+    return (
+      buildHintString(assertMatcherHint(operator, operatorName, expected)) +
+      chalk.reset(hasCustomMessage ? 'Message:\n  ' + message : '') +
+      trimmedStack
+    );
+  }
+
   return (
     buildHintString(assertMatcherHint(operator, operatorName, expected)) +
     chalk.reset(`Expected value ${operatorMessage(operator)}`) +


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This PR fixes incorrect error message format when using Node's `assert.fail`.

Currently when using `assert.fail` in a test, We get a message that includes two parts that should be omitted:
- Expected/Received with `undefined`s
- An empty "Difference".

This was fixed by updating the node assert message helpers in both of `jest-jasmine2` and `jest-circus` to account for the `fail` operator.

**Before**

```
✕ does not print expected/received message for assert.fail (1ms)

● does not print expected/received message for assert.fail

  assert.fail(received, expected)

  Expected value fail to:
    undefined
  Received:
    undefined
  
  Message:
    nooooooo

  Difference:

  Compared values have no visual difference.

    2 | 
    3 | it('does not print expected/received message for assert.fail', () => {
  > 4 |   assert.fail('nooooooo');
      |          ^
    5 | })

    at Object.fail (test.js:4:10)
```

**After**

```
✕ does not print expected/received message for assert.fail (3ms)

● does not print expected/received message for assert.fail

  assert.fail(received, expected)

  Message:
    nooooooo

    2 | 
    3 | it('does not print expected/received message for assert.fail', () => {
  > 4 |   assert.fail('nooooooo');
      |          ^
    5 | })

    at Object.fail (test.js:4:10)
```

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Added two new tests to make sure the error message printed for `assert.fail` looks as expected.