### PR TITLE
feat: implement `mockRestoreInitialImplementation` and `restoreAllInitialMockImplementations`

### DIFF
--- a/packages/jest-environment/src/index.ts
+++ b/packages/jest-environment/src/index.ts
@@ -191,6 +191,15 @@ export interface Jest {
    */
   resetModules(): Jest;
   /**
+   * Restores all mocks back to the initial mock implementation (or none if no
+   * implementation has been set) and clears the mock. Equivalent to calling
+   * `.mockRestoreInitialImplementation` on every mocked function.
+   *
+   * Beware that jest.restoreAllInitialMockImplementations() will only restore the
+   * initial mocked implementation, it will not restore the original implementation.
+   */
+  restoreAllInitialMockImplementations(): Jest;
+  /**
    * Restores all mocks back to their original value. Equivalent to calling
    * `.mockRestore` on every mocked function.
    *

--- a/packages/jest-mock/src/__tests__/index.test.ts
+++ b/packages/jest-mock/src/__tests__/index.test.ts
@@ -536,6 +536,49 @@ describe('moduleMocker', () => {
         expect(fn2()).not.toEqual('abcd');
       });
 
+      it('supports restoring the initial implementation', () => {
+        const fn = moduleMocker.fn();
+        fn.mockImplementation(() => 'initial result');
+
+        const initial = fn();
+        expect(initial).toEqual('initial result');
+
+        fn.mockImplementation(() => 'overridden result');
+        const overridden = fn();
+        expect(overridden).toEqual('overridden result');
+
+        fn.mockRestoreInitialImplementation();
+        const restored = fn();
+        expect(restored).toEqual('initial result');
+      });
+
+      it('supports restoring all initial mock implementations', () => {
+        const fn1 = moduleMocker.fn();
+        fn1.mockImplementation(() => 'fn1-before');
+        expect(fn1(1, 2, 3)).toEqual('fn1-before');
+        expect(fn1).toHaveBeenCalledWith(1, 2, 3);
+
+        fn1.mockImplementation(() => 'fn1-after');
+        expect(fn1('a', 'b', 'c')).toEqual('fn1-after');
+        expect(fn1).toHaveBeenCalledWith('a', 'b', 'c');
+
+        const fn2 = moduleMocker.fn();
+        fn2.mockImplementation(() => 'fn2-before');
+        expect(fn2(3, 2, 1)).toEqual('fn2-before');
+        expect(fn2).toHaveBeenCalledWith(3, 2, 1);
+
+        fn2.mockImplementation(() => 'fn2-after');
+        expect(fn2('a', 'b', 'c')).toEqual('fn2-after');
+        expect(fn2).toHaveBeenCalledWith('a', 'b', 'c');
+
+        moduleMocker.restoreAllInitialMockImplementations();
+        expect(fn1).not.toHaveBeenCalled();
+        expect(fn2).not.toHaveBeenCalled();
+
+        expect(fn1()).toEqual('fn1-before');
+        expect(fn2()).toEqual('fn2-before');
+      });
+
       it('maintains function arity', () => {
         const mockFunctionArity1 = moduleMocker.fn(x => x);
         const mockFunctionArity2 = moduleMocker.fn((x, y) => y);

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -614,6 +614,10 @@ class Runtime {
     this._moduleMocker.clearAllMocks();
   }
 
+  restoreAllInitialMockImplementations() {
+    this._moduleMocker.restoreAllInitialMockImplementations();
+  }
+
   private _resolveModule(from: Config.Path, to?: string) {
     return to ? this._resolver.resolveModule(from, to) : from;
   }
@@ -1018,6 +1022,10 @@ class Runtime {
       this.restoreAllMocks();
       return jestObject;
     };
+    const restoreAllInitialMockImplementations = () => {
+      this.restoreAllInitialMockImplementations();
+      return jestObject;
+    };
     const useFakeTimers = () => {
       _getFakeTimers().useFakeTimers();
       return jestObject;
@@ -1093,6 +1101,7 @@ class Runtime {
       resetAllMocks,
       resetModuleRegistry: resetModules,
       resetModules,
+      restoreAllInitialMockImplementations,
       restoreAllMocks,
       retryTimes,
       runAllImmediates: () => _getFakeTimers().runAllImmediates(),


### PR DESCRIPTION
## Summary

This is an attempt to cover a commen use case (for me) that I think needs improvement:
- There's a bunch of tests in one file
- Most tests use the same set of mock implementations
- One of the tests needs a custom mock implementation

I would currently solve this in one of two ways:
- Use `mockImplementationOnce` and cross my fingers that the mock is called exactly once
- Use a `beforeEach` that overwrite each implementation one by one. This takes up a lot of space and doesn't work very well with manual mocks.

This PR causes each mock to remember it's initial implementation, and provides a way to restore it, so that:
1. Initial mock implementations can be used as the "default" implementations throughout a test file.
2. Individual tests can override one or more implementations if necessary.
3. The initial implementation can be restored by either:
    - Restoring each individual mock directly with `mock.mockRestoreInitialImplementation()`\*.
    - Restoring all mocks with `jest.restoreAllInitialMockImplementations()`\* (possibly in a beforeEach/afterEach hook)

\* I'm not 100% happy about these long method names, I would prefer something shorter but still precise.

~~I don't know for sure if the current commit is enough for `jest.mock` (and manual mocks) to work, if not, point me in the right direction and I'll do my best to make it work.~~

Update: This works with `jest.mock`, and also with manual mocks if they are jest functions - which makes a lot of sense since you would otherwise not be able to override one for a single spec.

I'll be happy to add documentation, additional tests etc. should you decide to like the idea.

## Test plan
I added a tests for the two added methods `mockRestoreInitialImplementation` and `restoreAllInitialMockImplementations`.