### PR TITLE
Update documentation to clarify --watch behavior.

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -1135,7 +1135,7 @@ An array of RegExp patterns that are matched against all source file paths befor
 
 These patterns match against the full path. Use the `<rootDir>` string token to include the path to your project's root directory to prevent it from accidentally ignoring all of your files in different environments that may have different root directories. Example: `["<rootDir>/node_modules/"]`.
 
-Even if nothing is specified here, the watcher will ignore changes to any file and folder that begins with a dot (`.`).
+Even if nothing is specified here, the watcher will ignore changes to any hidden files and directories, i.e. files and folders that begins with a dot (`.`).
 
 ### `watchPlugins` [array\<string | [string, Object]>]
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -1135,6 +1135,8 @@ An array of RegExp patterns that are matched against all source file paths befor
 
 These patterns match against the full path. Use the `<rootDir>` string token to include the path to your project's root directory to prevent it from accidentally ignoring all of your files in different environments that may have different root directories. Example: `["<rootDir>/node_modules/"]`.
 
+Even if nothing is specified here, the watcher will ignore changes to any file and folder that begins with a dot (`.`).
+
 ### `watchPlugins` [array\<string | [string, Object]>]
 
 Default: `[]`

--- a/website/versioned_docs/version-22.x/Configuration.md
+++ b/website/versioned_docs/version-22.x/Configuration.md
@@ -877,3 +877,5 @@ Default: `[]`
 An array of RegExp patterns that are matched against all source file paths before re-running tests in watch mode. If the file path matches any of the patterns, when it is updated, it will not trigger a re-run of tests.
 
 These patterns match against the full path. Use the `<rootDir>` string token to include the path to your project's root directory to prevent it from accidentally ignoring all of your files in different environments that may have different root directories. Example: `["<rootDir>/node_modules/"]`.
+
+Even if nothing is specified here, the watcher will ignore changes to any file and folder that begins with a dot (`.`).

--- a/website/versioned_docs/version-22.x/Configuration.md
+++ b/website/versioned_docs/version-22.x/Configuration.md
@@ -878,4 +878,4 @@ An array of RegExp patterns that are matched against all source file paths befor
 
 These patterns match against the full path. Use the `<rootDir>` string token to include the path to your project's root directory to prevent it from accidentally ignoring all of your files in different environments that may have different root directories. Example: `["<rootDir>/node_modules/"]`.
 
-Even if nothing is specified here, the watcher will ignore changes to any file and folder that begins with a dot (`.`).
+Even if nothing is specified here, the watcher will ignore changes to any hidden files and directories, i.e. files and folders that begins with a dot (`.`).

--- a/website/versioned_docs/version-23.x/Configuration.md
+++ b/website/versioned_docs/version-23.x/Configuration.md
@@ -947,6 +947,8 @@ An array of RegExp patterns that are matched against all source file paths befor
 
 These patterns match against the full path. Use the `<rootDir>` string token to include the path to your project's root directory to prevent it from accidentally ignoring all of your files in different environments that may have different root directories. Example: `["<rootDir>/node_modules/"]`.
 
+Even if nothing is specified here, the watcher will ignore changes to any file and folder that begins with a dot (`.`).
+
 ### `watchPlugins` [array\<string | [string, Object]>]
 
 Default: `[]`

--- a/website/versioned_docs/version-23.x/Configuration.md
+++ b/website/versioned_docs/version-23.x/Configuration.md
@@ -947,7 +947,7 @@ An array of RegExp patterns that are matched against all source file paths befor
 
 These patterns match against the full path. Use the `<rootDir>` string token to include the path to your project's root directory to prevent it from accidentally ignoring all of your files in different environments that may have different root directories. Example: `["<rootDir>/node_modules/"]`.
 
-Even if nothing is specified here, the watcher will ignore changes to any file and folder that begins with a dot (`.`).
+Even if nothing is specified here, the watcher will ignore changes to any hidden files and directories, i.e. files and folders that begins with a dot (`.`).
 
 ### `watchPlugins` [array\<string | [string, Object]>]
 

--- a/website/versioned_docs/version-24.0/Configuration.md
+++ b/website/versioned_docs/version-24.0/Configuration.md
@@ -1066,7 +1066,7 @@ An array of RegExp patterns that are matched against all source file paths befor
 
 These patterns match against the full path. Use the `<rootDir>` string token to include the path to your project's root directory to prevent it from accidentally ignoring all of your files in different environments that may have different root directories. Example: `["<rootDir>/node_modules/"]`.
 
-Even if nothing is specified here, the watcher will ignore changes to any file and folder that begins with a dot (`.`).
+Even if nothing is specified here, the watcher will ignore changes to any hidden files and directories, i.e. files and folders that begins with a dot (`.`).
 
 ### `watchPlugins` [array\<string | [string, Object]>]
 

--- a/website/versioned_docs/version-24.0/Configuration.md
+++ b/website/versioned_docs/version-24.0/Configuration.md
@@ -1066,6 +1066,8 @@ An array of RegExp patterns that are matched against all source file paths befor
 
 These patterns match against the full path. Use the `<rootDir>` string token to include the path to your project's root directory to prevent it from accidentally ignoring all of your files in different environments that may have different root directories. Example: `["<rootDir>/node_modules/"]`.
 
+Even if nothing is specified here, the watcher will ignore changes to any file and folder that begins with a dot (`.`).
+
 ### `watchPlugins` [array\<string | [string, Object]>]
 
 Default: `[]`

--- a/website/versioned_docs/version-24.1/Configuration.md
+++ b/website/versioned_docs/version-24.1/Configuration.md
@@ -1075,6 +1075,8 @@ An array of RegExp patterns that are matched against all source file paths befor
 
 These patterns match against the full path. Use the `<rootDir>` string token to include the path to your project's root directory to prevent it from accidentally ignoring all of your files in different environments that may have different root directories. Example: `["<rootDir>/node_modules/"]`.
 
+Even if nothing is specified here, the watcher will ignore changes to any file and folder that begins with a dot (`.`).
+
 ### `watchPlugins` [array\<string | [string, Object]>]
 
 Default: `[]`

--- a/website/versioned_docs/version-24.1/Configuration.md
+++ b/website/versioned_docs/version-24.1/Configuration.md
@@ -1075,7 +1075,7 @@ An array of RegExp patterns that are matched against all source file paths befor
 
 These patterns match against the full path. Use the `<rootDir>` string token to include the path to your project's root directory to prevent it from accidentally ignoring all of your files in different environments that may have different root directories. Example: `["<rootDir>/node_modules/"]`.
 
-Even if nothing is specified here, the watcher will ignore changes to any file and folder that begins with a dot (`.`).
+Even if nothing is specified here, the watcher will ignore changes to any hidden files and directories, i.e. files and folders that begins with a dot (`.`).
 
 ### `watchPlugins` [array\<string | [string, Object]>]
 

--- a/website/versioned_docs/version-24.6/Configuration.md
+++ b/website/versioned_docs/version-24.6/Configuration.md
@@ -1094,6 +1094,8 @@ An array of RegExp patterns that are matched against all source file paths befor
 
 These patterns match against the full path. Use the `<rootDir>` string token to include the path to your project's root directory to prevent it from accidentally ignoring all of your files in different environments that may have different root directories. Example: `["<rootDir>/node_modules/"]`.
 
+Even if nothing is specified here, the watcher will ignore changes to any file and folder that begins with a dot (`.`).
+
 ### `watchPlugins` [array\<string | [string, Object]>]
 
 Default: `[]`

--- a/website/versioned_docs/version-24.6/Configuration.md
+++ b/website/versioned_docs/version-24.6/Configuration.md
@@ -1094,7 +1094,7 @@ An array of RegExp patterns that are matched against all source file paths befor
 
 These patterns match against the full path. Use the `<rootDir>` string token to include the path to your project's root directory to prevent it from accidentally ignoring all of your files in different environments that may have different root directories. Example: `["<rootDir>/node_modules/"]`.
 
-Even if nothing is specified here, the watcher will ignore changes to any file and folder that begins with a dot (`.`).
+Even if nothing is specified here, the watcher will ignore changes to any hidden files and directories, i.e. files and folders that begins with a dot (`.`).
 
 ### `watchPlugins` [array\<string | [string, Object]>]
 

--- a/website/versioned_docs/version-24.8/Configuration.md
+++ b/website/versioned_docs/version-24.8/Configuration.md
@@ -1135,7 +1135,7 @@ An array of RegExp patterns that are matched against all source file paths befor
 
 These patterns match against the full path. Use the `<rootDir>` string token to include the path to your project's root directory to prevent it from accidentally ignoring all of your files in different environments that may have different root directories. Example: `["<rootDir>/node_modules/"]`.
 
-Even if nothing is specified here, the watcher will ignore changes to any file and folder that begins with a dot (`.`).
+Even if nothing is specified here, the watcher will ignore changes to any hidden files and directories, i.e. files and folders that begins with a dot (`.`).
 
 ### `watchPlugins` [array\<string | [string, Object]>]
 

--- a/website/versioned_docs/version-24.8/Configuration.md
+++ b/website/versioned_docs/version-24.8/Configuration.md
@@ -1135,6 +1135,8 @@ An array of RegExp patterns that are matched against all source file paths befor
 
 These patterns match against the full path. Use the `<rootDir>` string token to include the path to your project's root directory to prevent it from accidentally ignoring all of your files in different environments that may have different root directories. Example: `["<rootDir>/node_modules/"]`.
 
+Even if nothing is specified here, the watcher will ignore changes to any file and folder that begins with a dot (`.`).
+
 ### `watchPlugins` [array\<string | [string, Object]>]
 
 Default: `[]`

--- a/website/versioned_docs/version-24.9/Configuration.md
+++ b/website/versioned_docs/version-24.9/Configuration.md
@@ -1137,6 +1137,8 @@ An array of RegExp patterns that are matched against all source file paths befor
 
 These patterns match against the full path. Use the `<rootDir>` string token to include the path to your project's root directory to prevent it from accidentally ignoring all of your files in different environments that may have different root directories. Example: `["<rootDir>/node_modules/"]`.
 
+Even if nothing is specified here, the watcher will ignore changes to any file and folder that begins with a dot (`.`).
+
 ### `watchPlugins` [array\<string | [string, Object]>]
 
 Default: `[]`

--- a/website/versioned_docs/version-24.9/Configuration.md
+++ b/website/versioned_docs/version-24.9/Configuration.md
@@ -1137,7 +1137,7 @@ An array of RegExp patterns that are matched against all source file paths befor
 
 These patterns match against the full path. Use the `<rootDir>` string token to include the path to your project's root directory to prevent it from accidentally ignoring all of your files in different environments that may have different root directories. Example: `["<rootDir>/node_modules/"]`.
 
-Even if nothing is specified here, the watcher will ignore changes to any file and folder that begins with a dot (`.`).
+Even if nothing is specified here, the watcher will ignore changes to any hidden files and directories, i.e. files and folders that begins with a dot (`.`).
 
 ### `watchPlugins` [array\<string | [string, Object]>]
 


### PR DESCRIPTION
## Summary

In a recent project, I was totally stumped about how to get `jest --watch` working. The first run was fine, but it wouldn't re-run automatically in response to test file changes. (I verified that `git` could see the changes fine, and there were no visible errors). After two days of debugging/searching, I discovered that the reason: due to [this line](https://github.com/facebook/jest/blob/9ac2dcd55c0204960285498c590c1aa7860e6aa8/packages/jest-haste-map/src/index.ts#L826), the watcher will always ignore files and folders starting with a dot (`.`). (The project I inherited for some reason had all the tests in a folder called `.tests`).

As far as I can tell this isn't documented anywhere on the internet, and I though it would be a nice thing to do to put something out there to clarify and save other people the headache.

The contributing guide says that "significant changes to the documentation or website" should be documented in CHANGLOG.md, but I wouldn't call this 'significant' (although I'm happy to add an entry if anyone disagrees).

## Test plan

This just adds a sentence to the documentation, and I didn't think testing was necessary beyond spell checking and making sure it looked good in my markdown editor.
