### PR TITLE
Support custom inline snapshot matchers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 
+- `[expect, jest-snapshot]` Support custom inline snapshot matchers ([#9278](https://github.com/facebook/jest/pull/9278))
 - `[babel-plugin-jest-hoist]` Show codeframe on static hoisting issues ([#8865](https://github.com/facebook/jest/pull/8865))
 - `[babel-plugin-jest-hoist]` Add `BigInt` to `WHITELISTED_IDENTIFIERS` ([#8382](https://github.com/facebook/jest/pull/8382))
 - `[babel-preset-jest]` Add `@babel/plugin-syntax-bigint` ([#8382](https://github.com/facebook/jest/pull/8382))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,12 @@
 
 ### Features
 
-- `[expect, jest-snapshot]` Support custom inline snapshot matchers ([#9278](https://github.com/facebook/jest/pull/9278))
 - `[babel-plugin-jest-hoist]` Show codeframe on static hoisting issues ([#8865](https://github.com/facebook/jest/pull/8865))
 - `[babel-plugin-jest-hoist]` Add `BigInt` to `WHITELISTED_IDENTIFIERS` ([#8382](https://github.com/facebook/jest/pull/8382))
 - `[babel-preset-jest]` Add `@babel/plugin-syntax-bigint` ([#8382](https://github.com/facebook/jest/pull/8382))
 - `[expect]` Add `BigInt` support to `toBeGreaterThan`, `toBeGreaterThanOrEqual`, `toBeLessThan` and `toBeLessThanOrEqual` ([#8382](https://github.com/facebook/jest/pull/8382))
 - `[expect, jest-matcher-utils]` Display change counts in annotation lines ([#9035](https://github.com/facebook/jest/pull/9035))
+- `[expect, jest-snapshot]` Support custom inline snapshot matchers ([#9278](https://github.com/facebook/jest/pull/9278))
 - `[jest-config]` Throw the full error message and stack when a Jest preset is missing a dependency ([#8924](https://github.com/facebook/jest/pull/8924))
 - `[jest-config]` [**BREAKING**] Set default display name color based on runner ([#8689](https://github.com/facebook/jest/pull/8689))
 - `[jest-config]` Merge preset globals with project globals ([#9027](https://github.com/facebook/jest/pull/9027))

--- a/docs/ExpectAPI.md
+++ b/docs/ExpectAPI.md
@@ -233,6 +233,28 @@ exports[`stores only 10 characters: toMatchTrimmedSnapshot 1`] = `"extra long"`;
 */
 ```
 
+It's also possible to create custom matchers for inline snapshots, the snapshots will be correctly added to the custom matchers. However, inline snapshot will always try to append to the first argument or the second when the first argument is the property matcher, so it's not possible to accept custom arguments in the custom matchers.
+
+```js
+const {toMatchInlineSnapshot} = require('jest-snapshot');
+
+expect.extend({
+  toMatchTrimmedInlineSnapshot(received) {
+    return toMatchInlineSnapshot.call(this, received.substring(0, 10));
+  },
+});
+
+it('stores only 10 characters', () => {
+  expect('extra long string oh my gerd').toMatchTrimmedInlineSnapshot();
+  /*
+  The snapshot will be added inline like
+  expect('extra long string oh my gerd').toMatchTrimmedInlineSnapshot(
+    `"extra long"`
+  );
+  */
+});
+```
+
 ### `expect.anything()`
 
 `expect.anything()` matches anything but `null` or `undefined`. You can use it inside `toEqual` or `toBeCalledWith` instead of a literal value. For example, if you want to check that a mock function is called with a non-null argument:

--- a/e2e/__tests__/__snapshots__/toMatchInlineSnapshot.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/toMatchInlineSnapshot.test.ts.snap
@@ -160,6 +160,23 @@ test('inline snapshots', async () => {
 
 `;
 
+exports[`supports custom matchers: custom matchers 1`] = `
+const {toMatchInlineSnapshot} = require('jest-snapshot');
+expect.extend({
+  toMatchCustomInlineSnapshot(received, ...args) {
+    return toMatchInlineSnapshot.call(this, received, ...args);
+  },
+});
+test('inline snapshots', () => {
+  expect({apple: 'original value'}).toMatchCustomInlineSnapshot(\`
+    Object {
+      "apple": "original value",
+    }
+  \`);
+});
+
+`;
+
 exports[`writes snapshots with non-literals in expect(...) 1`] = `
 it('works with inline snapshots', () => {
   expect({a: 1}).toMatchInlineSnapshot(\`

--- a/e2e/__tests__/__snapshots__/toMatchInlineSnapshot.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/toMatchInlineSnapshot.test.ts.snap
@@ -195,6 +195,54 @@ test('inline snapshots', async () => {
 
 `;
 
+exports[`supports custom matchers with property matcher: custom matchers with property matcher 1`] = `
+const {toMatchInlineSnapshot} = require('jest-snapshot');
+expect.extend({
+  toMatchCustomInlineSnapshot(received, ...args) {
+    return toMatchInlineSnapshot.call(this, received, ...args);
+  },
+  toMatchUserInlineSnapshot(received, ...args) {
+    return toMatchInlineSnapshot.call(
+      this,
+      received,
+      {
+        createdAt: expect.any(Date),
+        id: expect.any(Number),
+      },
+      ...args
+    );
+  },
+});
+test('inline snapshots', () => {
+  const user = {
+    createdAt: new Date(),
+    id: Math.floor(Math.random() * 20),
+    name: 'LeBron James',
+  };
+  expect(user).toMatchCustomInlineSnapshot(
+    {
+      createdAt: expect.any(Date),
+      id: expect.any(Number),
+    },
+    \`
+    Object {
+      "createdAt": Any<Date>,
+      "id": Any<Number>,
+      "name": "LeBron James",
+    }
+  \`
+  );
+  expect(user).toMatchUserInlineSnapshot(\`
+    Object {
+      "createdAt": Any<Date>,
+      "id": Any<Number>,
+      "name": "LeBron James",
+    }
+  \`);
+});
+
+`;
+
 exports[`supports custom matchers: custom matchers 1`] = `
 const {toMatchInlineSnapshot} = require('jest-snapshot');
 expect.extend({

--- a/e2e/__tests__/__snapshots__/toMatchInlineSnapshot.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/toMatchInlineSnapshot.test.ts.snap
@@ -120,6 +120,41 @@ test('handles property matchers', () => {
 
 `;
 
+exports[`multiple custom matchers and native matchers: multiple matchers 1`] = `
+const {toMatchInlineSnapshot} = require('jest-snapshot');
+expect.extend({
+  toMatchCustomInlineSnapshot(received, ...args) {
+    return toMatchInlineSnapshot.call(this, received, ...args);
+  },
+  toMatchCustomInlineSnapshot2(received, ...args) {
+    return toMatchInlineSnapshot.call(this, received, ...args);
+  },
+});
+test('inline snapshots', () => {
+  expect({apple: 'value 1'}).toMatchCustomInlineSnapshot(\`
+    Object {
+      "apple": "value 1",
+    }
+  \`);
+  expect({apple: 'value 2'}).toMatchInlineSnapshot(\`
+    Object {
+      "apple": "value 2",
+    }
+  \`);
+  expect({apple: 'value 3'}).toMatchCustomInlineSnapshot2(\`
+    Object {
+      "apple": "value 3",
+    }
+  \`);
+  expect({apple: 'value 4'}).toMatchInlineSnapshot(\`
+    Object {
+      "apple": "value 4",
+    }
+  \`);
+});
+
+`;
+
 exports[`removes obsolete external snapshots: external snapshot cleaned 1`] = `
 test('removes obsolete external snapshots', () => {
   expect('1').toMatchInlineSnapshot(\`"1"\`);

--- a/e2e/__tests__/toMatchInlineSnapshot.test.ts
+++ b/e2e/__tests__/toMatchInlineSnapshot.test.ts
@@ -266,3 +266,25 @@ test('handles mocking native modules prettier relies on', () => {
   expect(stderr).toMatch('1 snapshot written from 1 test suite.');
   expect(exitCode).toBe(0);
 });
+
+test('supports custom matchers', () => {
+  const filename = 'custom-matchers.test.js';
+  const test = `
+    const { toMatchInlineSnapshot } = require('jest-snapshot');
+    expect.extend({
+      toMatchCustomInlineSnapshot(received, ...args) {
+        return toMatchInlineSnapshot.call(this, received, ...args);
+      }
+    });
+    test('inline snapshots', () => {
+      expect({apple: "original value"}).toMatchCustomInlineSnapshot();
+    });
+  `;
+
+  writeFiles(TESTS_DIR, {[filename]: test});
+  const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+  const fileAfter = readFile(filename);
+  expect(stderr).toMatch('1 snapshot written from 1 test suite.');
+  expect(exitCode).toBe(0);
+  expect(wrap(fileAfter)).toMatchSnapshot('custom matchers');
+});

--- a/packages/expect/src/externalMatcherMark.ts
+++ b/packages/expect/src/externalMatcherMark.ts
@@ -1,9 +1,0 @@
-/**
- * This file is intentionally created for marking external matchers with
- * an explicit function call in the stack trace, benefiting the inline snapshot
- * system to correctly strip out user defined code when trying to locate the
- * top frame. This is required for custom inline snapshot matchers to work.
- */
-export default function noop<T>(any: T): T {
-  return any;
-}

--- a/packages/expect/src/externalMatcherMark.ts
+++ b/packages/expect/src/externalMatcherMark.ts
@@ -1,0 +1,9 @@
+/**
+ * This file is intentionally created for marking external matchers with
+ * an explicit function call in the stack trace, benefiting the inline snapshot
+ * system to correctly strip out user defined code when trying to locate the
+ * top frame. This is required for custom inline snapshot matchers to work.
+ */
+export default function noop<T>(any: T): T {
+  return any;
+}

--- a/packages/expect/src/index.ts
+++ b/packages/expect/src/index.ts
@@ -317,7 +317,10 @@ const makeThrowingMatcher = (
       potentialResult =
         matcher[INTERNAL_MATCHER_FLAG] === true
           ? matcher.call(matcherContext, actual, ...args)
-          : (function __EXTERNAL_MATCHER_TRAP__() {
+          : // It's a trap specifically for inline snapshot to capture this name
+            // in the stack trace, so that it can correctly get the custom matcher
+            // function call.
+            (function __EXTERNAL_MATCHER_TRAP__() {
               return matcher.call(matcherContext, actual, ...args);
             })();
 

--- a/packages/expect/src/index.ts
+++ b/packages/expect/src/index.ts
@@ -47,7 +47,6 @@ import {
   setState,
 } from './jestMatchersObject';
 import extractExpectedAssertionsErrors from './extractExpectedAssertionsErrors';
-import externalMatcherMark from './externalMatcherMark';
 
 class JestAssertionError extends Error {
   matcherResult?: SyncExpectationResult;
@@ -318,7 +317,9 @@ const makeThrowingMatcher = (
       potentialResult =
         matcher[INTERNAL_MATCHER_FLAG] === true
           ? matcher.call(matcherContext, actual, ...args)
-          : externalMatcherMark(matcher.call(matcherContext, actual, ...args));
+          : (function __EXTERNAL_MATCHER_TRAP__() {
+              return matcher.call(matcherContext, actual, ...args);
+            })();
 
       if (isPromise(potentialResult)) {
         const asyncResult = potentialResult as AsyncExpectationResult;

--- a/packages/jest-snapshot/src/State.ts
+++ b/packages/jest-snapshot/src/State.ts
@@ -14,6 +14,7 @@ import {
   getSnapshotData,
   keyToTestName,
   removeExtraLineBreaks,
+  removeLinesBeforeExternalMatcherMark,
   saveSnapshotFile,
   serialize,
   testNameToKey,
@@ -104,7 +105,9 @@ export default class SnapshotState {
     this._dirty = true;
     if (options.isInline) {
       const error = options.error || new Error();
-      const lines = getStackTraceLines(error.stack || '');
+      const lines = getStackTraceLines(
+        removeLinesBeforeExternalMatcherMark(error.stack || ''),
+      );
       const frame = getTopFrame(lines);
       if (!frame) {
         throw new Error(

--- a/packages/jest-snapshot/src/State.ts
+++ b/packages/jest-snapshot/src/State.ts
@@ -14,7 +14,7 @@ import {
   getSnapshotData,
   keyToTestName,
   removeExtraLineBreaks,
-  removeLinesBeforeExternalMatcherMark,
+  removeLinesBeforeExternalMatcherTrap,
   saveSnapshotFile,
   serialize,
   testNameToKey,
@@ -106,7 +106,7 @@ export default class SnapshotState {
     if (options.isInline) {
       const error = options.error || new Error();
       const lines = getStackTraceLines(
-        removeLinesBeforeExternalMatcherMark(error.stack || ''),
+        removeLinesBeforeExternalMatcherTrap(error.stack || ''),
       );
       const frame = getTopFrame(lines);
       if (!frame) {

--- a/packages/jest-snapshot/src/__tests__/utils.test.ts
+++ b/packages/jest-snapshot/src/__tests__/utils.test.ts
@@ -24,6 +24,7 @@ import {
   getSnapshotData,
   keyToTestName,
   removeExtraLineBreaks,
+  removeLinesBeforeExternalMatcherTrap,
   saveSnapshotFile,
   serialize,
   testNameToKey,
@@ -263,6 +264,43 @@ describe('ExtraLineBreaks', () => {
 
     expect(added).toBe('\n' + expected + '\n');
     expect(removed).toBe(expected);
+  });
+});
+
+describe('removeLinesBeforeExternalMatcherTrap', () => {
+  test('contains external matcher trap', () => {
+    const stack = `Error:
+    at SnapshotState._addSnapshot (/jest/packages/jest-snapshot/build/State.js:150:9)
+    at SnapshotState.match (/jest/packages/jest-snapshot/build/State.js:303:14)
+    at _toMatchSnapshot (/jest/packages/jest-snapshot/build/index.js:399:32)
+    at _toThrowErrorMatchingSnapshot (/jest/packages/jest-snapshot/build/index.js:585:10)
+    at Object.toThrowErrorMatchingInlineSnapshot (/jest/packages/jest-snapshot/build/index.js:504:10)
+    at Object.<anonymous> (/jest/packages/expect/build/index.js:138:20)
+    at __EXTERNAL_MATCHER_TRAP__ (/jest/packages/expect/build/index.js:378:30)
+    at throwingMatcher (/jest/packages/expect/build/index.js:379:15)
+    at /jest/packages/expect/build/index.js:285:72
+    at Object.<anonymous> (/jest/e2e/to-throw-error-matching-inline-snapshot/__tests__/should-support-rejecting-promises.test.js:3:7)`;
+
+    const expected = `    at throwingMatcher (/jest/packages/expect/build/index.js:379:15)
+    at /jest/packages/expect/build/index.js:285:72
+    at Object.<anonymous> (/jest/e2e/to-throw-error-matching-inline-snapshot/__tests__/should-support-rejecting-promises.test.js:3:7)`;
+
+    expect(removeLinesBeforeExternalMatcherTrap(stack)).toBe(expected);
+  });
+
+  test("doesn't contain external matcher trap", () => {
+    const stack = `Error:
+    at SnapshotState._addSnapshot (/jest/packages/jest-snapshot/build/State.js:150:9)
+    at SnapshotState.match (/jest/packages/jest-snapshot/build/State.js:303:14)
+    at _toMatchSnapshot (/jest/packages/jest-snapshot/build/index.js:399:32)
+    at _toThrowErrorMatchingSnapshot (/jest/packages/jest-snapshot/build/index.js:585:10)
+    at Object.toThrowErrorMatchingInlineSnapshot (/jest/packages/jest-snapshot/build/index.js:504:10)
+    at Object.<anonymous> (/jest/packages/expect/build/index.js:138:20)
+    at throwingMatcher (/jest/packages/expect/build/index.js:379:15)
+    at /jest/packages/expect/build/index.js:285:72
+    at Object.<anonymous> (/jest/e2e/to-throw-error-matching-inline-snapshot/__tests__/should-support-rejecting-promises.test.js:3:7)`;
+
+    expect(removeLinesBeforeExternalMatcherTrap(stack)).toBe(stack);
   });
 });
 

--- a/packages/jest-snapshot/src/inline_snapshots.ts
+++ b/packages/jest-snapshot/src/inline_snapshots.ts
@@ -133,7 +133,7 @@ const groupSnapshotsByFile = groupSnapshotsBy(({frame: {file}}) => file);
 
 const indent = (snapshot: string, numIndents: number, indentation: string) => {
   const lines = snapshot.split('\n');
-  // Prevent re-identation of inline snapshots.
+  // Prevent re-indentation of inline snapshots.
   if (
     lines.length >= 2 &&
     lines[1].startsWith(indentation.repeat(numIndents + 1))

--- a/packages/jest-snapshot/src/utils.ts
+++ b/packages/jest-snapshot/src/utils.ts
@@ -136,11 +136,11 @@ export const removeExtraLineBreaks = (string: string): string =>
     ? string.slice(1, -1)
     : string;
 
-export const removeLinesBeforeExternalMatcherMark = (stack: string): string => {
+export const removeLinesBeforeExternalMatcherTrap = (stack: string): string => {
   const lines = stack.split('\n');
 
   for (let i = 0; i < lines.length; i += 1) {
-    if (lines[i].match(/\/externalMatcherMark\.js:\d+:\d+\)$/)) {
+    if (lines[i].includes('__EXTERNAL_MATCHER_TRAP__')) {
       lines.splice(1, i);
       break;
     }

--- a/packages/jest-snapshot/src/utils.ts
+++ b/packages/jest-snapshot/src/utils.ts
@@ -143,12 +143,11 @@ export const removeLinesBeforeExternalMatcherTrap = (stack: string): string => {
     // It's a function name specified in `packages/expect/src/index.ts`
     // for external custom matchers.
     if (lines[i].includes('__EXTERNAL_MATCHER_TRAP__')) {
-      return lines.slice(i).join('\n');
-      break;
+      return lines.slice(i + 1).join('\n');
     }
   }
 
-  return lines;
+  return lines.join('\n');
 };
 
 const escapeRegex = true;

--- a/packages/jest-snapshot/src/utils.ts
+++ b/packages/jest-snapshot/src/utils.ts
@@ -136,6 +136,19 @@ export const removeExtraLineBreaks = (string: string): string =>
     ? string.slice(1, -1)
     : string;
 
+export const removeLinesBeforeExternalMatcherMark = (stack: string): string => {
+  const lines = stack.split('\n');
+
+  for (let i = 0; i < lines.length; i += 1) {
+    if (lines[i].match(/\/externalMatcherMark\.js:\d+:\d+\)$/)) {
+      lines.splice(1, i);
+      break;
+    }
+  }
+
+  return lines.join('\n');
+};
+
 const escapeRegex = true;
 const printFunctionName = false;
 

--- a/packages/jest-snapshot/src/utils.ts
+++ b/packages/jest-snapshot/src/utils.ts
@@ -140,6 +140,8 @@ export const removeLinesBeforeExternalMatcherTrap = (stack: string): string => {
   const lines = stack.split('\n');
 
   for (let i = 0; i < lines.length; i += 1) {
+    // It's a function name specified in `packages/expect/src/index.ts`
+    // for external custom matchers.
     if (lines[i].includes('__EXTERNAL_MATCHER_TRAP__')) {
       lines.splice(1, i);
       break;

--- a/packages/jest-snapshot/src/utils.ts
+++ b/packages/jest-snapshot/src/utils.ts
@@ -143,12 +143,12 @@ export const removeLinesBeforeExternalMatcherTrap = (stack: string): string => {
     // It's a function name specified in `packages/expect/src/index.ts`
     // for external custom matchers.
     if (lines[i].includes('__EXTERNAL_MATCHER_TRAP__')) {
-      lines.splice(1, i);
+      return lines.slice(i).join('\n');
       break;
     }
   }
 
-  return lines.join('\n');
+  return lines;
 };
 
 const escapeRegex = true;

--- a/packages/jest-snapshot/src/utils.ts
+++ b/packages/jest-snapshot/src/utils.ts
@@ -147,7 +147,7 @@ export const removeLinesBeforeExternalMatcherTrap = (stack: string): string => {
     }
   }
 
-  return lines.join('\n');
+  return stack;
 };
 
 const escapeRegex = true;


### PR DESCRIPTION
Fix #8181.

## Summary

Supports custom inline snapshot matchers, currently using them isn't possible.

## Test plan

```js
const { toMatchInlineSnapshot } = require("jest-snapshot");

expect.extend({
  toMatchCustomInlineSnapshot(received, ...args) {
    return toMatchInlineSnapshot.call(this, received, ...args);
  }
});

test("inline snapshots", () => {
  expect({ apple: "original value" }).toMatchCustomInlineSnapshot();
  // Will inject snapshot to
  expect({ apple: "original value" }).toMatchCustomInlineSnapshot(`
    Object {
      "apple": "original value",
    }
  `);
});
```

## How

The implementation is a bit of a hack, I'm not sure if it's suitable for production but it's the only better way I can think of for now.

<details>
<summary>To summarize the issue to those who is not familiar with how inline snapshots works, here is a simplified breakdown.</summary>
<p>

1. `snapshots` stack trace is generated upon runtime call, by calling [`new Error().stack`](https://github.com/facebook/jest/blob/9ac2dcd55c0204960285498c590c1aa7860e6aa8/packages/jest-snapshot/src/State.ts#L106)
2. In [`saveSnapshotsForFile`](https://github.com/facebook/jest/blob/9ac2dcd55c0204960285498c590c1aa7860e6aa8/packages/jest-snapshot/src/inline_snapshots.ts#L59-L101) function, it takes the `snapshots` coming from the previous step and the `sourceFilePath`

```js
expect(something).toMatchInlineSnapshot();
```

3. It inserts the snapshots if necessary to the source file in [`createInsertionParser`](https://github.com/facebook/jest/blob/9ac2dcd55c0204960285498c590c1aa7860e6aa8/packages/jest-snapshot/src/inline_snapshots.ts#L166-L227)

```js
expect(something).toMatchInlineSnapshot(`"SNAPSHOT...
NEXT LINE"`);
```

4. It [formats](https://github.com/facebook/jest/blob/9ac2dcd55c0204960285498c590c1aa7860e6aa8/packages/jest-snapshot/src/inline_snapshots.ts#L81-L89) the source file with the added snapshots with prettier

```js
expect(something).toMatchInlineSnapshot(`
"SNAPSHOT...
NEXT LINE"
`);
```

5. The indention is not yet correct, so it indents the snapshots to make them look good with the source again in [`createFormattingParser`](https://github.com/facebook/jest/blob/9ac2dcd55c0204960285498c590c1aa7860e6aa8/packages/jest-snapshot/src/inline_snapshots.ts#L95)

```js
expect(something).toMatchInlineSnapshot(`
  "SNAPSHOT...
  NEXT LINE"
`);
```

6. It [formats](https://github.com/facebook/jest/blob/9ac2dcd55c0204960285498c590c1aa7860e6aa8/packages/jest-snapshot/src/inline_snapshots.ts#L91-L96) the source file yet again to make the overall indention looks good

```js
expect(something).toMatchInlineSnapshot(`
  "SNAPSHOT...
  NEXT
  LINE"
`);
```

7. It overrides the file when done
   </p>
   </details>

There's a [tweet](https://twitter.com/lucasazzola/status/1102546183979884544) mentioned in the original issue stating that we should _need to be able to figure out that the call is coming from a custom matcher and skip those frames in order for this to work_. So this is exactly what I've done. I create a no-op **trap** for every external matcher, wrapping them with a function call so that it would show up in the stack trace.

The next step is to modify the logic where we get the top frame. We remove all stack trace lines before the **trap** function we just made (if it exists), so that when we try to get the top frame it won't get the native `toMatchInlineSnapshot` but the custom `toMatchCustomInlineSnapshot`.

We also have to update the babel traverse logic in `createFormattingParser`, or else it won't correctly indent the snapshots. Currently it only looks for matcher named `toMatchInlineSnapshot`, I modify it to record all the matcher names we've seen in the stack traces, and check them one by one in the parser.

---

I added an e2e test case to demonstrate the feature, please tell me if you have any other idea for tests, or edge cases I'm missing.

I'm also aware of that #7792 is near to be finished, this PR takes it into account and should be able to work just fine when it landed.

I'll update the CHANGELOG file once if you think it's a good idea :)
