### PR TITLE
Assign `process.env.JEST_RUN_IN_BAND` value to check if testing is running serially.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - `[jest-config]` [**BREAKING**] Set default display name color based on runner ([#8689](https://github.com/facebook/jest/pull/8689))
 - `[jest-config]` Merge preset globals with project globals ([#9027](https://github.com/facebook/jest/pull/9027))
 - `[jest-core]` Support reporters as default exports ([#9161](https://github.com/facebook/jest/pull/9161))
+- `[jest-core]` Assign `process.env.JEST_RUN_IN_BAND` value. It can be used to check if testing is running serially. ([#9280](https://github.com/facebook/jest/pull/9280))
 - `[jest-diff]` Add options for colors and symbols ([#8841](https://github.com/facebook/jest/pull/8841))
 - `[jest-diff]` [**BREAKING**] Export as ECMAScript module ([#8873](https://github.com/facebook/jest/pull/8873))
 - `[jest-diff]` Add `includeChangeCounts` and rename `Indicator` options ([#8881](https://github.com/facebook/jest/pull/8881))

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -248,6 +248,8 @@ Run tests with specified reporters. [Reporter options](configuration#reporters-a
 
 Alias: `-i`. Run all tests serially in the current process, rather than creating a worker pool of child processes that run tests. This can be useful for debugging.
 
+It will set `process.env.JEST_RUN_IN_BAND` to `'1'`
+
 ### `--runTestsByPath`
 
 Run only the tests that were specified with their exact paths.

--- a/packages/jest-core/src/TestScheduler.ts
+++ b/packages/jest-core/src/TestScheduler.ts
@@ -88,6 +88,7 @@ export default class TestScheduler {
     );
 
     const runInBand = shouldRunInBand(tests, timings, this._globalConfig);
+    process.env.JEST_RUN_IN_BAND = runInBand ? '1' : '0';
 
     const onResult = async (test: TestRunner.Test, testResult: TestResult) => {
       if (watcher.isInterrupted()) {

--- a/packages/jest-core/src/__tests__/TestScheduler.test.js
+++ b/packages/jest-core/src/__tests__/TestScheduler.test.js
@@ -207,6 +207,7 @@ test('should set runInBand to run in serial', async () => {
   expect(spyShouldRunInBand).toHaveBeenCalled();
   expect(mockParallelRunner.runTests).toHaveBeenCalled();
   expect(mockParallelRunner.runTests.mock.calls[0][5].serial).toBeTruthy();
+  expect(process.env.JEST_RUN_IN_BAND).toBe('1');
 });
 
 test('should set runInBand to not run in serial', async () => {
@@ -231,4 +232,5 @@ test('should set runInBand to not run in serial', async () => {
   expect(spyShouldRunInBand).toHaveBeenCalled();
   expect(mockParallelRunner.runTests).toHaveBeenCalled();
   expect(mockParallelRunner.runTests.mock.calls[0][5].serial).toBeFalsy();
+  expect(process.env.JEST_RUN_IN_BAND).toBe('0');
 });


### PR DESCRIPTION

## Summary

Issue #9231.

I think use `process.env.JEST_RUN_IN_BAND` can solve this issue, and easier.

## Test plan

Update `TestScheduler` tests, checking `process.env.JEST_RUN_IN_BAND` value.