### PR TITLE
chore: remove Node 8 references and some dead code

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -158,7 +158,7 @@ Print debugging info about your Jest config.
 
 ### `--detectOpenHandles`
 
-Attempt to collect and print open handles preventing Jest from exiting cleanly. Use this in cases where you need to use `--forceExit` in order for Jest to exit to potentially track down the reason. This implies `--runInBand`, making tests run serially. Implemented using [`async_hooks`](https://nodejs.org/api/async_hooks.html), so it only works in Node 8 and newer. This option has a significant performance penalty and should only be used for debugging.
+Attempt to collect and print open handles preventing Jest from exiting cleanly. Use this in cases where you need to use `--forceExit` in order for Jest to exit to potentially track down the reason. This implies `--runInBand`, making tests run serially. Implemented using [`async_hooks`](https://nodejs.org/api/async_hooks.html). This option has a significant performance penalty and should only be used for debugging.
 
 ### `--env=<environment>`
 

--- a/jest.config.ci.js
+++ b/jest.config.ci.js
@@ -7,8 +7,8 @@
 
 'use strict';
 
-// Object spread is just node 8
-module.exports = Object.assign({}, require('./jest.config'), {
+module.exports = {
+  ...require('./jest.config'),
   coverageReporters: ['json'],
   reporters: [
     [
@@ -17,4 +17,4 @@ module.exports = Object.assign({}, require('./jest.config'), {
     ],
     ['jest-silent-reporter', {useDots: true}],
   ],
-});
+};

--- a/package.json
+++ b/package.json
@@ -144,6 +144,6 @@
     "logo": "https://opencollective.com/jest/logo.txt"
   },
   "engines": {
-    "node": ">= 8"
+    "node": ">= 8.3"
   }
 }

--- a/packages/babel-jest/package.json
+++ b/packages/babel-jest/package.json
@@ -26,7 +26,7 @@
     "@babel/core": "^7.0.0"
   },
   "engines": {
-    "node": ">= 8"
+    "node": ">= 8.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/babel-plugin-jest-hoist/package.json
+++ b/packages/babel-plugin-jest-hoist/package.json
@@ -7,7 +7,7 @@
     "directory": "packages/babel-plugin-jest-hoist"
   },
   "engines": {
-    "node": ">= 8"
+    "node": ">= 8.3"
   },
   "license": "MIT",
   "main": "build/index.js",

--- a/packages/babel-preset-jest/package.json
+++ b/packages/babel-preset-jest/package.json
@@ -17,7 +17,7 @@
     "@babel/core": "^7.0.0"
   },
   "engines": {
-    "node": ">= 8"
+    "node": ">= 8.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/diff-sequences/package.json
+++ b/packages/diff-sequences/package.json
@@ -16,7 +16,7 @@
     "diff"
   ],
   "engines": {
-    "node": ">= 8"
+    "node": ">= 8.3"
   },
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/packages/eslint-config-fb-strict/package.json
+++ b/packages/eslint-config-fb-strict/package.json
@@ -20,7 +20,7 @@
     "eslint-plugin-react": "^7.1.0"
   },
   "engines": {
-    "node": ">= 8"
+    "node": ">= 8.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/expect/package.json
+++ b/packages/expect/package.json
@@ -22,7 +22,7 @@
     "immutable": "^4.0.0-rc.12"
   },
   "engines": {
-    "node": ">= 8"
+    "node": ">= 8.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest-changed-files/package.json
+++ b/packages/jest-changed-files/package.json
@@ -15,7 +15,7 @@
     "throat": "^5.0.0"
   },
   "engines": {
-    "node": ">= 8"
+    "node": ">= 8.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest-circus/package.json
+++ b/packages/jest-circus/package.json
@@ -36,7 +36,7 @@
     "jest-runtime": "^24.9.0"
   },
   "engines": {
-    "node": ">= 8"
+    "node": ">= 8.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest-cli/package.json
+++ b/packages/jest-cli/package.json
@@ -29,7 +29,7 @@
     "jest": "./bin/jest.js"
   },
   "engines": {
-    "node": ">= 8"
+    "node": ">= 8.3"
   },
   "repository": {
     "type": "git",

--- a/packages/jest-config/package.json
+++ b/packages/jest-config/package.json
@@ -34,7 +34,7 @@
     "@types/micromatch": "^3.1.0"
   },
   "engines": {
-    "node": ">= 8"
+    "node": ">= 8.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest-console/package.json
+++ b/packages/jest-console/package.json
@@ -16,7 +16,7 @@
     "slash": "^3.0.0"
   },
   "engines": {
-    "node": ">= 8"
+    "node": ">= 8.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest-core/package.json
+++ b/packages/jest-core/package.json
@@ -42,7 +42,7 @@
     "@types/rimraf": "^2.0.2"
   },
   "engines": {
-    "node": ">= 8"
+    "node": ">= 8.3"
   },
   "repository": {
     "type": "git",

--- a/packages/jest-core/src/collectHandles.ts
+++ b/packages/jest-core/src/collectHandles.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import * as asyncHooks from 'async_hooks';
 import {Config} from '@jest/types';
 import {formatExecError} from 'jest-message-util';
 import {ErrorWithStack} from 'jest-util';
@@ -41,8 +42,6 @@ export default function collectHandles(): () => Array<Error> {
     number,
     {error: Error; isActive: () => boolean}
   > = new Map();
-
-  const asyncHooks: typeof import('async_hooks') = require('async_hooks');
   const hook = asyncHooks.createHook({
     destroy(asyncId) {
       activeHandles.delete(asyncId);

--- a/packages/jest-diff/package.json
+++ b/packages/jest-diff/package.json
@@ -19,7 +19,7 @@
     "strip-ansi": "^6.0.0"
   },
   "engines": {
-    "node": ">= 8"
+    "node": ">= 8.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest-docblock/package.json
+++ b/packages/jest-docblock/package.json
@@ -12,7 +12,7 @@
     "detect-newline": "^3.0.0"
   },
   "engines": {
-    "node": ">= 8"
+    "node": ">= 8.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest-each/package.json
+++ b/packages/jest-each/package.json
@@ -25,7 +25,7 @@
     "pretty-format": "^24.9.0"
   },
   "engines": {
-    "node": ">= 8"
+    "node": ">= 8.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest-environment-jsdom/package.json
+++ b/packages/jest-environment-jsdom/package.json
@@ -21,7 +21,7 @@
     "@types/jsdom": "^12.2.4"
   },
   "engines": {
-    "node": ">= 8"
+    "node": ">= 8.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest-environment-node/package.json
+++ b/packages/jest-environment-node/package.json
@@ -17,7 +17,7 @@
     "jest-util": "^24.9.0"
   },
   "engines": {
-    "node": ">= 8"
+    "node": ">= 8.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest-environment/package.json
+++ b/packages/jest-environment/package.json
@@ -15,7 +15,7 @@
     "jest-mock": "^24.9.0"
   },
   "engines": {
-    "node": ">= 8"
+    "node": ">= 8.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest-fake-timers/package.json
+++ b/packages/jest-fake-timers/package.json
@@ -20,7 +20,7 @@
     "@types/lolex": "^5.1.0"
   },
   "engines": {
-    "node": ">= 8"
+    "node": ">= 8.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest-get-type/package.json
+++ b/packages/jest-get-type/package.json
@@ -8,7 +8,7 @@
     "directory": "packages/jest-get-type"
   },
   "engines": {
-    "node": ">= 8"
+    "node": ">= 8.3"
   },
   "license": "MIT",
   "main": "build/index.js",

--- a/packages/jest-haste-map/package.json
+++ b/packages/jest-haste-map/package.json
@@ -32,7 +32,7 @@
     "fsevents": "^2.1.2"
   },
   "engines": {
-    "node": ">= 8"
+    "node": ">= 8.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest-jasmine2/package.json
+++ b/packages/jest-jasmine2/package.json
@@ -32,7 +32,7 @@
     "@types/babel__traverse": "^7.0.4"
   },
   "engines": {
-    "node": ">= 8"
+    "node": ">= 8.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest-leak-detector/package.json
+++ b/packages/jest-leak-detector/package.json
@@ -18,7 +18,7 @@
     "weak-napi": "^1.0.3"
   },
   "engines": {
-    "node": ">= 8"
+    "node": ">= 8.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest-matcher-utils/package.json
+++ b/packages/jest-matcher-utils/package.json
@@ -8,7 +8,7 @@
     "directory": "packages/jest-matcher-utils"
   },
   "engines": {
-    "node": ">= 8"
+    "node": ">= 8.3"
   },
   "license": "MIT",
   "main": "build/index.js",

--- a/packages/jest-message-util/package.json
+++ b/packages/jest-message-util/package.json
@@ -7,7 +7,7 @@
     "directory": "packages/jest-message-util"
   },
   "engines": {
-    "node": ">= 8"
+    "node": ">= 8.3"
   },
   "license": "MIT",
   "main": "build/index.js",

--- a/packages/jest-mock/package.json
+++ b/packages/jest-mock/package.json
@@ -7,7 +7,7 @@
     "directory": "packages/jest-mock"
   },
   "engines": {
-    "node": ">= 8"
+    "node": ">= 8.3"
   },
   "dependencies": {
     "@jest/types": "^24.9.0"

--- a/packages/jest-phabricator/package.json
+++ b/packages/jest-phabricator/package.json
@@ -11,7 +11,7 @@
     "@jest/test-result": "^24.9.0"
   },
   "engines": {
-    "node": ">= 8"
+    "node": ">= 8.3"
   },
   "license": "MIT",
   "main": "build/index.js",

--- a/packages/jest-regex-util/package.json
+++ b/packages/jest-regex-util/package.json
@@ -7,7 +7,7 @@
     "directory": "packages/jest-regex-util"
   },
   "engines": {
-    "node": ">= 8"
+    "node": ">= 8.3"
   },
   "license": "MIT",
   "main": "build/index.js",

--- a/packages/jest-repl/package.json
+++ b/packages/jest-repl/package.json
@@ -25,7 +25,7 @@
     "jest-repl": "./bin/jest-repl.js"
   },
   "engines": {
-    "node": ">= 8"
+    "node": ">= 8.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest-reporters/package.json
+++ b/packages/jest-reporters/package.json
@@ -43,7 +43,7 @@
     "node-notifier": "^6.0.0"
   },
   "engines": {
-    "node": ">= 8"
+    "node": ">= 8.3"
   },
   "repository": {
     "type": "git",

--- a/packages/jest-resolve-dependencies/package.json
+++ b/packages/jest-resolve-dependencies/package.json
@@ -20,7 +20,7 @@
     "jest-runtime": "^24.9.0"
   },
   "engines": {
-    "node": ">= 8"
+    "node": ">= 8.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest-resolve/package.json
+++ b/packages/jest-resolve/package.json
@@ -21,7 +21,7 @@
     "jest-haste-map": "^24.9.0"
   },
   "engines": {
-    "node": ">= 8"
+    "node": ">= 8.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest-runner/package.json
+++ b/packages/jest-runner/package.json
@@ -36,7 +36,7 @@
     "@types/source-map-support": "^0.5.0"
   },
   "engines": {
-    "node": ">= 8"
+    "node": ">= 8.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest-runtime/package.json
+++ b/packages/jest-runtime/package.json
@@ -44,7 +44,7 @@
     "jest-runtime": "./bin/jest-runtime.js"
   },
   "engines": {
-    "node": ">= 8"
+    "node": ">= 8.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest-serializer/package.json
+++ b/packages/jest-serializer/package.json
@@ -7,7 +7,7 @@
     "directory": "packages/jest-serializer"
   },
   "engines": {
-    "node": ">= 8"
+    "node": ">= 8.3"
   },
   "license": "MIT",
   "main": "build/index.js",

--- a/packages/jest-snapshot/package.json
+++ b/packages/jest-snapshot/package.json
@@ -34,7 +34,7 @@
     "prettier": "^1.13.4"
   },
   "engines": {
-    "node": ">= 8"
+    "node": ">= 8.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest-source-map/package.json
+++ b/packages/jest-source-map/package.json
@@ -18,7 +18,7 @@
     "@types/graceful-fs": "^4.1.2"
   },
   "engines": {
-    "node": ">= 8"
+    "node": ">= 8.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest-test-result/package.json
+++ b/packages/jest-test-result/package.json
@@ -15,7 +15,7 @@
     "@types/istanbul-lib-coverage": "^2.0.0"
   },
   "engines": {
-    "node": ">= 8"
+    "node": ">= 8.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest-test-sequencer/package.json
+++ b/packages/jest-test-sequencer/package.json
@@ -16,7 +16,7 @@
     "jest-runtime": "^24.9.0"
   },
   "engines": {
-    "node": ">= 8"
+    "node": ">= 8.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest-transform/package.json
+++ b/packages/jest-transform/package.json
@@ -36,7 +36,7 @@
     "dedent": "^0.7.0"
   },
   "engines": {
-    "node": ">= 8"
+    "node": ">= 8.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest-transform/src/types.ts
+++ b/packages/jest-transform/src/types.ts
@@ -19,11 +19,7 @@ export type Options = ShouldInstrumentOptions &
     isInternalModule: boolean;
   }>;
 
-// https://stackoverflow.com/a/48216010/1850276
-type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
-
-// This is fixed in a newer version, but that depends on Node 8 which is a
-// breaking change (engine warning when installing)
+// This is fixed in source-map@0.7.x, but we can't upgrade yet since it's async
 interface FixedRawSourceMap extends Omit<RawSourceMap, 'version'> {
   version: number;
 }

--- a/packages/jest-types/package.json
+++ b/packages/jest-types/package.json
@@ -7,7 +7,7 @@
     "directory": "packages/jest-types"
   },
   "engines": {
-    "node": ">= 8"
+    "node": ">= 8.3"
   },
   "license": "MIT",
   "main": "build/index.js",

--- a/packages/jest-util/package.json
+++ b/packages/jest-util/package.json
@@ -21,7 +21,7 @@
     "@types/mkdirp": "^0.5.2"
   },
   "engines": {
-    "node": ">= 8"
+    "node": ">= 8.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest-validate/package.json
+++ b/packages/jest-validate/package.json
@@ -18,7 +18,7 @@
     "pretty-format": "^24.9.0"
   },
   "engines": {
-    "node": ">= 8"
+    "node": ">= 8.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest-watcher/package.json
+++ b/packages/jest-watcher/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/facebook/jest/issues"
   },
   "engines": {
-    "node": ">= 8"
+    "node": ">= 8.3"
   },
   "homepage": "https://jestjs.io/",
   "license": "MIT",

--- a/packages/jest-worker/package.json
+++ b/packages/jest-worker/package.json
@@ -20,7 +20,7 @@
     "worker-farm": "^1.6.0"
   },
   "engines": {
-    "node": ">= 8"
+    "node": ">= 8.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -13,7 +13,7 @@
     "jest": "./bin/jest.js"
   },
   "engines": {
-    "node": ">= 8"
+    "node": ">= 8.3"
   },
   "repository": {
     "type": "git",

--- a/packages/pretty-format/package.json
+++ b/packages/pretty-format/package.json
@@ -28,7 +28,7 @@
     "react-test-renderer": "*"
   },
   "engines": {
-    "node": ">= 8"
+    "node": ">= 8.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/pretty-format/src/__tests__/prettyFormat.test.ts
+++ b/packages/pretty-format/src/__tests__/prettyFormat.test.ts
@@ -85,7 +85,7 @@ describe('prettyFormat()', () => {
     /* eslint-disable no-new-func */
     const val = new Function();
     /* eslint-enable no-new-func */
-    // In Node 8.1.4: val.name === 'anonymous'
+    // In Node >=8.1.4: val.name === 'anonymous'
     expect(prettyFormat(val)).toEqual('[Function anonymous]');
   });
 
@@ -95,7 +95,7 @@ describe('prettyFormat()', () => {
       val = cb;
     }
     f(() => {});
-    // In Node 8.1.4: val.name === ''
+    // In Node >=8.1.4: val.name === ''
     expect(prettyFormat(val)).toEqual('[Function anonymous]');
   });
 


### PR DESCRIPTION
## Summary

Less code is less code. I left 2 references in pretty-format, because our `engines` entry says `>= 8`. I think it should be higher, e.g. `async_hooks.createHook` is available since 8.1 according to the docs. 

I've also adjusted the comment about source-map typings, since now Node 8 requirement is gone, but it's still async

## Test plan

Usual.