### PR TITLE
docs: Use `Object.defineProperty()` for stubbing global properties

### DIFF
--- a/docs/ManualMocks.md
+++ b/docs/ManualMocks.md
@@ -141,8 +141,9 @@ If some code uses a method which JSDOM (the DOM implementation used by Jest) has
 In this case, mocking `matchMedia` in the test file should solve the issue:
 
 ```js
-window.matchMedia = jest.fn().mockImplementation(query => {
-  return {
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: {
     matches: false,
     media: query,
     onchange: null,
@@ -151,7 +152,7 @@ window.matchMedia = jest.fn().mockImplementation(query => {
     addEventListener: jest.fn(),
     removeEventListener: jest.fn(),
     dispatchEvent: jest.fn(),
-  };
+  },
 });
 ```
 

--- a/docs/ManualMocks.md
+++ b/docs/ManualMocks.md
@@ -143,7 +143,7 @@ In this case, mocking `matchMedia` in the test file should solve the issue:
 ```js
 Object.defineProperty(window, 'matchMedia', {
   writable: true,
-  value: query => ({
+  value: jest.fn().mockImplementation(query => ({
     matches: false,
     media: query,
     onchange: null,
@@ -152,7 +152,7 @@ Object.defineProperty(window, 'matchMedia', {
     addEventListener: jest.fn(),
     removeEventListener: jest.fn(),
     dispatchEvent: jest.fn(),
-  }),
+  })),
 });
 ```
 

--- a/docs/ManualMocks.md
+++ b/docs/ManualMocks.md
@@ -143,7 +143,7 @@ In this case, mocking `matchMedia` in the test file should solve the issue:
 ```js
 Object.defineProperty(window, 'matchMedia', {
   writable: true,
-  value: {
+  value: query => ({
     matches: false,
     media: query,
     onchange: null,
@@ -152,7 +152,7 @@ Object.defineProperty(window, 'matchMedia', {
     addEventListener: jest.fn(),
     removeEventListener: jest.fn(),
     dispatchEvent: jest.fn(),
-  },
+  }),
 });
 ```
 

--- a/website/versioned_docs/version-23.x/ManualMocks.md
+++ b/website/versioned_docs/version-23.x/ManualMocks.md
@@ -142,8 +142,9 @@ If some code uses a method which JSDOM (the DOM implementation used by Jest) has
 In this case, mocking `matchMedia` in the test file should solve the issue:
 
 ```js
-window.matchMedia = jest.fn().mockImplementation(query => {
-  return {
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: query => ({
     matches: false,
     media: query,
     onchange: null,
@@ -152,7 +153,7 @@ window.matchMedia = jest.fn().mockImplementation(query => {
     addEventListener: jest.fn(),
     removeEventListener: jest.fn(),
     dispatchEvent: jest.fn(),
-  };
+  }),
 });
 ```
 

--- a/website/versioned_docs/version-23.x/ManualMocks.md
+++ b/website/versioned_docs/version-23.x/ManualMocks.md
@@ -144,7 +144,7 @@ In this case, mocking `matchMedia` in the test file should solve the issue:
 ```js
 Object.defineProperty(window, 'matchMedia', {
   writable: true,
-  value: query => ({
+  value: jest.fn().mockImplementation(query => ({
     matches: false,
     media: query,
     onchange: null,
@@ -153,7 +153,7 @@ Object.defineProperty(window, 'matchMedia', {
     addEventListener: jest.fn(),
     removeEventListener: jest.fn(),
     dispatchEvent: jest.fn(),
-  }),
+  })),
 });
 ```
 


### PR DESCRIPTION
Direct assignments to `window` properties fails silently if they are not
writable, so `Object.defineProperty()` should be used when stubbing
global properties.

Closes #9287

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

#9287

## Test plan

This is a documentation-only change.
