### PR TITLE
chore: replace `findDOMNode()` in examples/typescript

### DIFF
--- a/examples/typescript/CheckboxWithLabel.tsx
+++ b/examples/typescript/CheckboxWithLabel.tsx
@@ -3,6 +3,8 @@
 import * as React from 'react';
 
 interface CheckboxWithLabelProps {
+  labelRef: React.LegacyRef<HTMLLabelElement>;
+  inputRef: React.LegacyRef<HTMLInputElement>;
   labelOff: string;
   labelOn: string;
 }
@@ -22,8 +24,9 @@ class CheckboxWithLabel extends React.Component<
 
   render() {
     return (
-      <label>
+      <label ref={this.props.labelRef}>
         <input
+          ref={this.props.inputRef}
           type="checkbox"
           checked={this.state.isChecked}
           onChange={() =>

--- a/examples/typescript/__tests__/CheckboxWithLabel-test.tsx
+++ b/examples/typescript/__tests__/CheckboxWithLabel-test.tsx
@@ -1,25 +1,31 @@
 // Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
 
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
+// import * as ReactDOM from 'react-dom';
 import * as TestUtils from 'react-dom/test-utils';
 
 const CheckboxWithLabel = require('../CheckboxWithLabel').default;
 
 it('CheckboxWithLabel changes the text after click', () => {
+  const checkboxLabelRef: React.RefObject<HTMLLabelElement> = React.createRef();
+  const checkboxInputRef: React.RefObject<HTMLInputElement> = React.createRef();
   // Render a checkbox with label in the document
-  const checkbox = TestUtils.renderIntoDocument(
-    <CheckboxWithLabel labelOn="On" labelOff="Off" />
+  TestUtils.renderIntoDocument(
+    <CheckboxWithLabel
+      labelRef={checkboxLabelRef}
+      inputRef={checkboxInputRef}
+      labelOn="On"
+      labelOff="Off"
+    />
   );
 
-  const checkboxNode = ReactDOM.findDOMNode(checkbox);
+  const labelNode = checkboxLabelRef.current;
+  const inputNode = checkboxInputRef.current;
 
   // Verify that it's Off by default
-  expect(checkboxNode.textContent).toEqual('Off');
+  expect(labelNode.textContent).toEqual('Off');
 
   // Simulate a click and verify that it is now On
-  TestUtils.Simulate.change(
-    TestUtils.findRenderedDOMComponentWithTag(checkbox, 'input')
-  );
-  expect(checkboxNode.textContent).toEqual('On');
+  TestUtils.Simulate.change(inputNode);
+  expect(labelNode.textContent).toEqual('On');
 });

--- a/examples/typescript/__tests__/CheckboxWithLabel-test.tsx
+++ b/examples/typescript/__tests__/CheckboxWithLabel-test.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
 
 import * as React from 'react';
-// import * as ReactDOM from 'react-dom';
 import * as TestUtils from 'react-dom/test-utils';
 
 const CheckboxWithLabel = require('../CheckboxWithLabel').default;

--- a/examples/typescript/sub.ts
+++ b/examples/typescript/sub.ts
@@ -2,8 +2,6 @@
 
 import sum from './sum';
 
-const sub = (a: number, b: number): number => {
-  return sum(a, -b);
-};
+const sub = (a: number, b: number): number => sum(a, -b);
 
 export default sub;

--- a/examples/typescript/sub.ts
+++ b/examples/typescript/sub.ts
@@ -2,8 +2,8 @@
 
 import sum from './sum';
 
-function sub(a: number, b: number): number {
+const sub = (a: number, b: number): number => {
   return sum(a, -b);
-}
+};
 
 export default sub;

--- a/examples/typescript/sum.ts
+++ b/examples/typescript/sum.ts
@@ -1,7 +1,5 @@
 // Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
 
-const sum = (a: number, b: number): number => {
-  return a + b;
-};
+const sum = (a: number, b: number): number => a + b;
 
 export default sum;

--- a/examples/typescript/sum.ts
+++ b/examples/typescript/sum.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
 
-function sum(a: number, b: number): number {
+const sum = (a: number, b: number): number => {
   return a + b;
-}
+};
 
 export default sum;


### PR DESCRIPTION
## Summary

I imitated #9124 commit which is about deprcated findDomNode() using Typescript.
Plus, I refactored sum.ts and sub.ts with arrow functions.

## Test plan

yarn test

This is my first pull request. If you have any advice, please do it for me.