### PR TITLE
add noJestGlobals config, if false, no jest-circus globals

### DIFF
--- a/packages/jest-circus/src/index.ts
+++ b/packages/jest-circus/src/index.ts
@@ -12,6 +12,8 @@ import {ErrorWithStack, isPromise} from 'jest-util';
 import {Circus, Global} from '@jest/types';
 import {dispatch} from './state';
 
+import expect = require('expect');
+
 type THook = (fn: Circus.HookFn, timeout?: number) => void;
 type DescribeFn = (
   blockName: Circus.BlockName,
@@ -215,6 +217,7 @@ export {
   beforeAll,
   beforeEach,
   describe,
+  expect,
   fdescribe,
   fit,
   it,
@@ -229,6 +232,7 @@ export default {
   beforeAll,
   beforeEach,
   describe,
+  expect,
   fdescribe,
   fit,
   it,

--- a/packages/jest-circus/src/index.ts
+++ b/packages/jest-circus/src/index.ts
@@ -199,17 +199,41 @@ const test: Global.It = (() => {
   return test;
 })();
 
-const it: Global.It = test;
+const it = test;
+
+const fdescribe = describe.only;
+const fit = it.only;
+const xit = it.skip;
+const xdescribe = describe.skip;
+const xtest = it.skip;
 
 export type Event = Circus.Event;
 export type State = Circus.State;
-export {afterAll, afterEach, beforeAll, beforeEach, describe, it, test};
+export {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  fdescribe,
+  fit,
+  it,
+  test,
+  xdescribe,
+  xit,
+  xtest,
+};
 export default {
   afterAll,
   afterEach,
   beforeAll,
   beforeEach,
   describe,
+  fdescribe,
+  fit,
   it,
   test,
+  xdescribe,
+  xit,
+  xtest,
 };

--- a/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapter.ts
+++ b/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapter.ts
@@ -30,6 +30,7 @@ const jestAdapter = async (
     .requireInternalModule(path.resolve(__dirname, './jestExpect.js'))
     .default({
       expand: globalConfig.expand,
+      noJestGlobals: !globalConfig.noJestGlobals && !config.noJestGlobals,
     });
 
   const getPrettier = () =>

--- a/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapterInit.ts
+++ b/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapterInit.ts
@@ -62,12 +62,6 @@ export const initialize = ({
   const nodeGlobal = global as Global.Global;
   Object.assign(nodeGlobal, globals);
 
-  nodeGlobal.xit = nodeGlobal.it.skip;
-  nodeGlobal.xtest = nodeGlobal.it.skip;
-  nodeGlobal.xdescribe = nodeGlobal.describe.skip;
-  nodeGlobal.fit = nodeGlobal.it.only;
-  nodeGlobal.fdescribe = nodeGlobal.describe.only;
-
   nodeGlobal.test.concurrent = (test => {
     const concurrent = (
       testName: string,

--- a/packages/jest-circus/src/legacy-code-todo-rewrite/jestExpect.ts
+++ b/packages/jest-circus/src/legacy-code-todo-rewrite/jestExpect.ts
@@ -15,8 +15,8 @@ import {
   toThrowErrorMatchingSnapshot,
 } from 'jest-snapshot';
 
-export default (config: {expand: boolean}) => {
-  global.expect = expect;
+export default (config: {expand: boolean; noJestGlobals: boolean}) => {
+  if (!config.noJestGlobals) global.expect = expect;
   expect.setState({
     expand: config.expand,
   });

--- a/packages/jest-types/src/Config.ts
+++ b/packages/jest-types/src/Config.ts
@@ -257,6 +257,7 @@ export type GlobalConfig = {
   listTests: boolean;
   maxConcurrency: number;
   maxWorkers: number;
+  noJestGlobals?: boolean;
   noStackTrace: boolean;
   nonFlagArgs: Array<string>;
   noSCM?: boolean;
@@ -319,6 +320,7 @@ export type ProjectConfig = {
   modulePathIgnorePatterns: Array<string>;
   modulePaths?: Array<string>;
   name: string;
+  noJestGlobals?: boolean;
   prettierPath: string;
   resetMocks: boolean;
   resetModules: boolean;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Summed up well by #7571, #4473, #5192 (and possibly some others). With this PR, one can `import { expect, describe, it, xtest, fit } from 'jest-circus'` etc (all but `jest`), as well as limit pollution of the global namespace (such that if you don’t import, trying to use a global will error)
- `test.concurrent` and `expect`'s snapshot matchers are still set, just on their imported variables instead of their global aliases like before
- the `xit`, `fdescribe` etc aliases are now exported like normal, not exclusively set on the global as they were before
- `expect` is re-exported from `jest-circus` so that everything can be imported from one place.

Some things I wasn't sure of how to change (first PR 👋 ):
- how to make sure `jest` isn't added to the global. I couldn't find a place where `global.jest` is set, but from what I could tell, it seemed like `jest-runtime` sets it(?), possibly with `constructInjectedModuleParameters()`? Was digging a bit of rabbit hole searching from `jest-mock` to `jest-environment` to `jest-runtime` searching where it gets set 😅
Not sure how to change this if that's the right place, but the `jest` functions do rely on a bunch of globals, so this is in last order to import directly (and likely the most complex).
- creating a `jest/no-globals` entry from which one could import instead (would basically re-export from `jest-circus`). not sure how entries are done in this repo.
- what to do if `globalConfig.noJestGlobals = false` but `projectConfig.noJestGlobals = true`? should the project override it if it is set to `true` specifically (vs. the default of `undefined`).

I didn't look too much into `jest-jasmine2`'s globals as it is being replaced and because it seems to rely on globals a lot more and isn't as easy to analyze/parse. Might check it out in the future.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

I also wasn't sure how to test this -- specifically, I need to change the jest config to set `noJestGlobals` to `true` for a single test suite for this, but I'm not sure where to actually change the config.
Once I figure out how to do that, I would think the tests would not be much more than the suite I have for [`jest-without-globals`](https://github.com/agilgur5/jest-without-globals), possibly adding some tests for `test.concurrent` (`test.each` probably?) and the expect snapshot matchers, since those are dynamically added by `jest-circus`

I also was not totally sure how/if some tests should be added to `jest-config` around validation or something for the new `noJestGlobals` config.