### PR TITLE
Fix subsetEquality: same referenced object on same level node of tree is regarded as circular reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@
 - `[jest-utils]` Allow querying process.domain ([#9136](https://github.com/facebook/jest/pull/9136))
 - `[pretty-format]` Correctly detect memoized elements ([#9196](https://github.com/facebook/jest/pull/9196))
 - `[jest-fake-timers]` Support `util.promisify` on `setTimeout` ([#9180](https://github.com/facebook/jest/pull/9180))
+- `[expect]` Fix subsetEquality: fix circular reference handling logic ([#9322](https://github.com/facebook/jest/pull/9322))
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 - `[expect]` Avoid incorrect difference for subset when `toMatchObject` fails ([#9005](https://github.com/facebook/jest/pull/9005))
 - `[expect]` Consider all RegExp flags for equality ([#9167](https://github.com/facebook/jest/pull/9167))
 - `[expect]` [**BREAKING**] Consider primitives different from wrappers instantiated with `new` ([#9167](https://github.com/facebook/jest/pull/9167))
+- `[expect]` Fix subsetEquality false circular reference detection ([#9322](https://github.com/facebook/jest/pull/9322))
 - `[jest-config]` Use half of the available cores when `watchAll` mode is enabled ([#9117](https://github.com/facebook/jest/pull/9117))
 - `[jest-config]` Fix Jest multi project runner still cannot handle exactly one project ([#8894](https://github.com/facebook/jest/pull/8894))
 - `[jest-console]` Add missing `console.group` calls to `NullConsole` ([#9024](https://github.com/facebook/jest/pull/9024))
@@ -73,7 +74,6 @@
 - `[jest-utils]` Allow querying process.domain ([#9136](https://github.com/facebook/jest/pull/9136))
 - `[pretty-format]` Correctly detect memoized elements ([#9196](https://github.com/facebook/jest/pull/9196))
 - `[jest-fake-timers]` Support `util.promisify` on `setTimeout` ([#9180](https://github.com/facebook/jest/pull/9180))
-- `[expect]` Fix subsetEquality: fix circular reference handling logic ([#9322](https://github.com/facebook/jest/pull/9322))
 
 ### Chore & Maintenance
 

--- a/packages/expect/src/__tests__/utils.test.js
+++ b/packages/expect/src/__tests__/utils.test.js
@@ -333,6 +333,19 @@ describe('subsetEquality()', () => {
       expect(subsetEquality(primitiveInsteadOfRef, circularObjA1)).toBe(false);
     });
 
+    test('referenced object on same level should not regarded as circular reference', () => {
+      const referencedObj = {abc: 'def'};
+      const object = {
+        a: {abc: 'def'},
+        b: {abc: 'def', zzz: 'zzz'},
+      };
+      const thisIsNotCircular = {
+        a: referencedObj,
+        b: referencedObj,
+      };
+      expect(subsetEquality(object, thisIsNotCircular)).toBeTruthy();
+    });
+
     test('transitive circular references', () => {
       const transitiveCircularObjA1 = {a: 'hello'};
       transitiveCircularObjA1.nestedObj = {parentObj: transitiveCircularObjA1};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This fixes https://github.com/facebook/jest/issues/9089
This bug is introduced by this PR https://github.com/facebook/jest/pull/8687
So basically, there is a flaw on the circular reference logic within a function called `subsetEquality`.
The logic is that, to avoid circular reference, it stores the references of nodes that it has been through within one singleton variable `seenReferences`. Whenever we have seen the same node (using the reference), we skip the subset equality checking (which is done recursively) and do deep equality checking instead.
The implication is that nodes within the same level of tree will use the same reference `seenReferences`. It's a problem because then it will cause an invalid handling on this case :
```
const referencedObj = {abc: 'def'};
const object = {
  a: {abc: 'def'},
  b: {abc: 'def', zzz: 'zzz'},
};
const thisIsNotCircular = {
  a: referencedObj,
  b: referencedObj,
};
expect(subsetEquality(object, thisIsNotCircular)).toBeTruthy(); // this test fails while it should succeed
```
On current logic, above case is considered circular referenced which isn't supposed to be. It will result in incorrect handling because circular reference does not check for subset equality and only check for plain equality instead. It makes sense for circular referenced object but not for normal object.

What we should do is to keep the `seenReferences` only for parent node and its children. The solution is quite simple, we only need to remove the reference immediately after the recursive function is done called for all of a node's children.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

I have added one test case using example above which would fail previously.
After the fix, now it succeeds.
