### PR TITLE
feat: support `concurrent` in Jest Each

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 - `[jest-circus, jest-jasmine2]` Include `failureDetails` property in test results ([#9496](https://github.com/facebook/jest/pull/9496))
+- `[jest-each, jest-jasmine, jest-circus]` Add support for .concurrent.each ([#9326](https://github.com/facebook/jest/pull/9326))
 
 ### Fixes
 
@@ -35,7 +36,6 @@
 - `[jest-worker]` Added support for workers to send custom messages to parent in jest-worker ([#10293](https://github.com/facebook/jest/pull/10293))
 - `[jest-worker]` Support passing `resourceLimits` ([#10335](https://github.com/facebook/jest/pull/10335))
 - `[pretty-format]` Added support for serializing custom elements (web components) ([#10217](https://github.com/facebook/jest/pull/10237))
-- `[jest-each, jest-jasmine, jest-circus]` Add support for .concurrent.each ([#9326](https://github.com/facebook/jest/pull/9326))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - `[jest-worker]` Added support for workers to send custom messages to parent in jest-worker ([#10293](https://github.com/facebook/jest/pull/10293))
 - `[jest-worker]` Support passing `resourceLimits` ([#10335](https://github.com/facebook/jest/pull/10335))
 - `[pretty-format]` Added support for serializing custom elements (web components) ([#10217](https://github.com/facebook/jest/pull/10237))
+- `[jest-each, jest-jasmine, jest-circus]` Add support for .concurrent.each ([#9326](https://github.com/facebook/jest/pull/9326))
 
 ### Fixes
 

--- a/docs/GlobalAPI.md
+++ b/docs/GlobalAPI.md
@@ -587,7 +587,6 @@ test('will not be ran', () => {
 });
 ```
 
-
 ### `test.concurrent.skip.each(table)(name, fn)`
 
 Also under the alias: `it.concurrent.skip.each(table)(name, fn)`

--- a/docs/GlobalAPI.md
+++ b/docs/GlobalAPI.md
@@ -523,7 +523,7 @@ test.concurrent.each([
 });
 ```
 
-#### 2. `` test.each`table`(name, fn, timeout) ``
+#### 2. `` test.concurrent.each`table`(name, fn, timeout) ``
 
 - `table`: `Tagged Template Literal`
   - First row of variable name column headings separated with `|`
@@ -596,7 +596,7 @@ Use `test.concurrent.skip.each` if you want to stop running a collection of asyn
 
 `test.concurrent.skip.each` is available with two APIs:
 
-#### `test.skip.each(table)(name, fn)`
+#### `test.concurrent.skip.each(table)(name, fn)`
 
 ```js
 test.concurrent.skip.each([
@@ -612,7 +612,7 @@ test('will be ran', () => {
 });
 ```
 
-#### `` test.skip.each`table`(name, fn) ``
+#### `` test.concurrent.skip.each`table`(name, fn) ``
 
 ```js
 test.concurrent.skip.each`

--- a/docs/GlobalAPI.md
+++ b/docs/GlobalAPI.md
@@ -471,6 +471,8 @@ Also under the alias: `it.concurrent(name, fn, timeout)`
 
 Use `test.concurrent` if you want the test to run concurrently.
 
+> Note: `test.concurrent` is considered experimental - see [here])https://github.com/facebook/jest/labels/Area%3A%20Concurrent) for details on missing features and other issues
+
 The first argument is the test name; the second argument is an asynchronous function that contains the expectations to test. The third argument (optional) is `timeout` (in milliseconds) for specifying how long to wait before aborting. _Note: The default timeout is 5 seconds._
 
 ```

--- a/e2e/__tests__/circusConcurrentEach.test.ts
+++ b/e2e/__tests__/circusConcurrentEach.test.ts
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import {json as runWithJson} from '../runJest';
+
+it('works with concurrent.each', () => {
+  const {json} = runWithJson('circus-concurrent', [
+    'concurrent-each.test.js',
+    '--testRunner=jest-circus/runner',
+  ]);
+  expect(json.numTotalTests).toBe(4);
+  expect(json.numPassedTests).toBe(2);
+  expect(json.numFailedTests).toBe(0);
+  expect(json.numPendingTests).toBe(2);
+});
+
+it('works with concurrent.only.each', () => {
+  const {json} = runWithJson('circus-concurrent', [
+    'concurrent-only-each.test.js',
+    '--testRunner=jest-circus/runner',
+  ]);
+  expect(json.numTotalTests).toBe(4);
+  expect(json.numPassedTests).toBe(2);
+  expect(json.numFailedTests).toBe(0);
+  expect(json.numPendingTests).toBe(2);
+});

--- a/e2e/__tests__/jasmineAsync.test.ts
+++ b/e2e/__tests__/jasmineAsync.test.ts
@@ -128,6 +128,24 @@ describe('async jasmine', () => {
     expect(json.testResults[0].message).toMatch(/concurrent test fails/);
   });
 
+  it('works with concurrent.each', () => {
+    const {json} = runWithJson('jasmine-async', ['concurrent-each.test.js']);
+    expect(json.numTotalTests).toBe(4);
+    expect(json.numPassedTests).toBe(2);
+    expect(json.numFailedTests).toBe(0);
+    expect(json.numPendingTests).toBe(2);
+  });
+
+  it('works with concurrent.only.each', () => {
+    const {json} = runWithJson('jasmine-async', [
+      'concurrent-only-each.test.js',
+    ]);
+    expect(json.numTotalTests).toBe(4);
+    expect(json.numPassedTests).toBe(2);
+    expect(json.numFailedTests).toBe(0);
+    expect(json.numPendingTests).toBe(2);
+  });
+
   it("doesn't execute more than 5 tests simultaneously", () => {
     const {json} = runWithJson('jasmine-async', ['concurrent-many.test.js']);
     expect(json.numTotalTests).toBe(10);

--- a/e2e/circus-concurrent/__tests__/concurrent-each.test.js
+++ b/e2e/circus-concurrent/__tests__/concurrent-each.test.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+it.concurrent.each([
+  [1, 2],
+  [2, 3],
+])('adds one to number', async (a, b) => {
+  expect(a + 1).toBe(b);
+});
+
+it.concurrent.skip.each([
+  [1, 2],
+  [2, 3],
+])('should skip this test', Promise.resolve());

--- a/e2e/circus-concurrent/__tests__/concurrent-only-each.test.js
+++ b/e2e/circus-concurrent/__tests__/concurrent-only-each.test.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+it.concurrent.only.each([
+  [1, 2],
+  [2, 3],
+])('adds one to number', async (a, b) => {
+  expect(a + 1).toBe(b);
+});
+
+it.concurrent.each([
+  [1, 2],
+  [2, 3],
+])('adds one to number', async (a, b) => {
+  expect(a + 1).toBe(b);
+});

--- a/e2e/circus-concurrent/package.json
+++ b/e2e/circus-concurrent/package.json
@@ -1,0 +1,5 @@
+{
+  "jest": {
+    "testEnvironment": "node"
+  }
+}

--- a/e2e/jasmine-async/__tests__/concurrent-each.test.js
+++ b/e2e/jasmine-async/__tests__/concurrent-each.test.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+it.concurrent.each([
+  [1, 2],
+  [2, 3],
+])('adds one to number', async (a, b) => {
+  expect(a + 1).toBe(b);
+});
+
+it.concurrent.skip.each([
+  [1, 2],
+  [2, 3],
+])('should skip this test', Promise.resolve());

--- a/e2e/jasmine-async/__tests__/concurrent-only-each.test.js
+++ b/e2e/jasmine-async/__tests__/concurrent-only-each.test.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+it.concurrent.only.each([
+  [1, 2],
+  [2, 3],
+])('adds one to number', async (a, b) => {
+  expect(a + 1).toBe(b);
+});
+
+it.concurrent.each([
+  [1, 2],
+  [2, 3],
+])('adds one to number', async (a, b) => {
+  expect(a + 1).toBe(b);
+});

--- a/packages/jest-each/README.md
+++ b/packages/jest-each/README.md
@@ -195,9 +195,12 @@ each([
   [1, 1, 2],
   [1, 2, 3],
   [2, 1, 3],
-]).test.concurrent('returns the result of adding %d to %d', (a, b, expected) => {
-  expect(a + b).toBe(expected);
-});
+]).test.concurrent(
+  'returns the result of adding %d to %d',
+  (a, b, expected) => {
+    expect(a + b).toBe(expected);
+  },
+);
 ```
 
 #### `.test.concurrent.only(name, fn)`
@@ -209,9 +212,12 @@ each([
   [1, 1, 2],
   [1, 2, 3],
   [2, 1, 3],
-]).test.concurrent.only('returns the result of adding %d to %d', (a, b, expected) => {
-  expect(a + b).toBe(expected);
-});
+]).test.concurrent.only(
+  'returns the result of adding %d to %d',
+  (a, b, expected) => {
+    expect(a + b).toBe(expected);
+  },
+);
 ```
 
 #### `.test.concurrent.skip(name, fn)`
@@ -223,9 +229,12 @@ each([
   [1, 1, 2],
   [1, 2, 3],
   [2, 1, 3],
-]).test.concurrent.skip('returns the result of adding %d to %d', (a, b, expected) => {
-  expect(a + b).toBe(expected);
-});
+]).test.concurrent.skip(
+  'returns the result of adding %d to %d',
+  (a, b, expected) => {
+    expect(a + b).toBe(expected);
+  },
+);
 ```
 
 #### Asynchronous `.test(name, fn(done))`

--- a/packages/jest-each/README.md
+++ b/packages/jest-each/README.md
@@ -19,6 +19,12 @@ jest-each allows you to provide multiple arguments to your `test`/`describe` whi
   - Also under the aliases: `.it.only` or `.fit`
 - `.test.skip` to skip the parameterised tests
   - Also under the aliases: `.it.skip` or `.xit` or `.xtest`
+- `.test.concurrent`
+  - Also under the alias: `.it.concurrent`
+- `.test.concurrent.only`
+  - Also under the alias: `.it.concurrent.only`
+- `.test.concurrent.skip`
+  - Also under the alias: `.it.concurrent.skip`
 - `.describe` to runs test suites with parameterised data
 - `.describe.only` to only run the parameterised suite of tests
   - Also under the aliases: `.fdescribe`
@@ -176,6 +182,48 @@ each([
   [1, 2, 3],
   [2, 1, 3],
 ]).test.skip('returns the result of adding %d to %d', (a, b, expected) => {
+  expect(a + b).toBe(expected);
+});
+```
+
+#### `.test.concurrent(name, fn)`
+
+Aliases: `.it.concurrent(name, fn)`
+
+```js
+each([
+  [1, 1, 2],
+  [1, 2, 3],
+  [2, 1, 3],
+]).test.concurrent('returns the result of adding %d to %d', (a, b, expected) => {
+  expect(a + b).toBe(expected);
+});
+```
+
+#### `.test.concurrent.only(name, fn)`
+
+Aliases: `.it.concurrent.only(name, fn)`
+
+```js
+each([
+  [1, 1, 2],
+  [1, 2, 3],
+  [2, 1, 3],
+]).test.concurrent.only('returns the result of adding %d to %d', (a, b, expected) => {
+  expect(a + b).toBe(expected);
+});
+```
+
+#### `.test.concurrent.skip(name, fn)`
+
+Aliases: `.it.concurrent.skip(name, fn)`
+
+```js
+each([
+  [1, 1, 2],
+  [1, 2, 3],
+  [2, 1, 3],
+]).test.concurrent.skip('returns the result of adding %d to %d', (a, b, expected) => {
   expect(a + b).toBe(expected);
 });
 ```

--- a/packages/jest-each/src/__tests__/__snapshots__/array.test.ts.snap
+++ b/packages/jest-each/src/__tests__/__snapshots__/array.test.ts.snap
@@ -84,6 +84,42 @@ Instead was called with: undefined
 "
 `;
 
+exports[`jest-each .test.concurrent throws an error when called with an empty array 1`] = `
+"Error: \`.each\` called with an empty Array of table data.
+"
+`;
+
+exports[`jest-each .test.concurrent throws an error when not called with an array 1`] = `
+"\`.each\` must be called with an Array or Tagged Template Literal.
+
+Instead was called with: undefined
+"
+`;
+
+exports[`jest-each .test.concurrent.only throws an error when called with an empty array 1`] = `
+"Error: \`.each\` called with an empty Array of table data.
+"
+`;
+
+exports[`jest-each .test.concurrent.only throws an error when not called with an array 1`] = `
+"\`.each\` must be called with an Array or Tagged Template Literal.
+
+Instead was called with: undefined
+"
+`;
+
+exports[`jest-each .test.concurrent.skip throws an error when called with an empty array 1`] = `
+"Error: \`.each\` called with an empty Array of table data.
+"
+`;
+
+exports[`jest-each .test.concurrent.skip throws an error when not called with an array 1`] = `
+"\`.each\` must be called with an Array or Tagged Template Literal.
+
+Instead was called with: undefined
+"
+`;
+
 exports[`jest-each .test.only throws an error when called with an empty array 1`] = `
 "Error: \`.each\` called with an empty Array of table data.
 "

--- a/packages/jest-each/src/__tests__/__snapshots__/template.test.ts.snap
+++ b/packages/jest-each/src/__tests__/__snapshots__/template.test.ts.snap
@@ -273,6 +273,123 @@ exports[`jest-each .test throws error when there are no arguments for given head
 "
 `;
 
+exports[`jest-each .test.concurrent throws an error when called with an empty string 1`] = `
+"Error: \`.each\` called with an empty Tagged Template Literal of table data.
+"
+`;
+
+exports[`jest-each .test.concurrent throws error when there are fewer arguments than headings over multiple rows 1`] = `
+"Not enough arguments supplied for given headings:
+<green>a | b | expected</>
+
+Received:
+<red>Array [</>
+<red>  0,</>
+<red>  1,</>
+<red>  1,</>
+<red>  1,</>
+<red>  1,</>
+<red>]</>
+
+Missing <red>2</> arguments"
+`;
+
+exports[`jest-each .test.concurrent throws error when there are fewer arguments than headings when given one row 1`] = `
+"Not enough arguments supplied for given headings:
+<green>a | b | expected</>
+
+Received:
+<red>Array [</>
+<red>  0,</>
+<red>  1,</>
+<red>]</>
+
+Missing <red>2</> arguments"
+`;
+
+exports[`jest-each .test.concurrent throws error when there are no arguments for given headings 1`] = `
+"Error: \`.each\` called with a Tagged Template Literal with no data, remember to interpolate with \${expression} syntax.
+"
+`;
+
+exports[`jest-each .test.concurrent.only throws an error when called with an empty string 1`] = `
+"Error: \`.each\` called with an empty Tagged Template Literal of table data.
+"
+`;
+
+exports[`jest-each .test.concurrent.only throws error when there are fewer arguments than headings over multiple rows 1`] = `
+"Not enough arguments supplied for given headings:
+<green>a | b | expected</>
+
+Received:
+<red>Array [</>
+<red>  0,</>
+<red>  1,</>
+<red>  1,</>
+<red>  1,</>
+<red>  1,</>
+<red>]</>
+
+Missing <red>2</> arguments"
+`;
+
+exports[`jest-each .test.concurrent.only throws error when there are fewer arguments than headings when given one row 1`] = `
+"Not enough arguments supplied for given headings:
+<green>a | b | expected</>
+
+Received:
+<red>Array [</>
+<red>  0,</>
+<red>  1,</>
+<red>]</>
+
+Missing <red>2</> arguments"
+`;
+
+exports[`jest-each .test.concurrent.only throws error when there are no arguments for given headings 1`] = `
+"Error: \`.each\` called with a Tagged Template Literal with no data, remember to interpolate with \${expression} syntax.
+"
+`;
+
+exports[`jest-each .test.concurrent.skip throws an error when called with an empty string 1`] = `
+"Error: \`.each\` called with an empty Tagged Template Literal of table data.
+"
+`;
+
+exports[`jest-each .test.concurrent.skip throws error when there are fewer arguments than headings over multiple rows 1`] = `
+"Not enough arguments supplied for given headings:
+<green>a | b | expected</>
+
+Received:
+<red>Array [</>
+<red>  0,</>
+<red>  1,</>
+<red>  1,</>
+<red>  1,</>
+<red>  1,</>
+<red>]</>
+
+Missing <red>2</> arguments"
+`;
+
+exports[`jest-each .test.concurrent.skip throws error when there are fewer arguments than headings when given one row 1`] = `
+"Not enough arguments supplied for given headings:
+<green>a | b | expected</>
+
+Received:
+<red>Array [</>
+<red>  0,</>
+<red>  1,</>
+<red>]</>
+
+Missing <red>2</> arguments"
+`;
+
+exports[`jest-each .test.concurrent.skip throws error when there are no arguments for given headings 1`] = `
+"Error: \`.each\` called with a Tagged Template Literal with no data, remember to interpolate with \${expression} syntax.
+"
+`;
+
 exports[`jest-each .test.only throws an error when called with an empty string 1`] = `
 "Error: \`.each\` called with an empty Tagged Template Literal of table data.
 "

--- a/packages/jest-each/src/__tests__/array.test.ts
+++ b/packages/jest-each/src/__tests__/array.test.ts
@@ -28,6 +28,9 @@ const getGlobalTestMocks = () => {
   };
   globals.test.only = jest.fn();
   globals.test.skip = jest.fn();
+  globals.test.concurrent = jest.fn();
+  globals.test.concurrent.only = jest.fn();
+  globals.test.concurrent.skip = jest.fn();
   globals.it.only = jest.fn();
   globals.it.skip = jest.fn();
   globals.describe.only = jest.fn();
@@ -38,6 +41,9 @@ const getGlobalTestMocks = () => {
 describe('jest-each', () => {
   [
     ['test'],
+    ['test', 'concurrent'],
+    ['test', 'concurrent', 'only'],
+    ['test', 'concurrent', 'skip'],
     ['test', 'only'],
     ['it'],
     ['fit'],
@@ -289,6 +295,8 @@ describe('jest-each', () => {
     test.each([
       [['test']],
       [['test', 'only']],
+      [['test', 'concurrent']],
+      [['test', 'concurrent', 'only']],
       [['it']],
       [['fit']],
       [['it', 'only']],
@@ -327,6 +335,7 @@ describe('jest-each', () => {
   [
     ['xtest'],
     ['test', 'skip'],
+    ['test', 'concurrent', 'skip'],
     ['xit'],
     ['it', 'skip'],
     ['xdescribe'],

--- a/packages/jest-each/src/__tests__/index.test.ts
+++ b/packages/jest-each/src/__tests__/index.test.ts
@@ -20,6 +20,21 @@ describe('array', () => {
   });
 });
 
+describe('concurrent', () => {
+  describe('.add', () => {
+    each([
+      [0, 0, 0],
+      [0, 1, 1],
+      [1, 1, 2],
+    ]).test.concurrent(
+      'returns the result of adding %s to %s',
+      async (a, b, expected) => {
+        expect(a + b).toBe(expected);
+      },
+    );
+  });
+});
+
 describe('template', () => {
   describe('.add', () => {
     each`

--- a/packages/jest-each/src/__tests__/template.test.ts
+++ b/packages/jest-each/src/__tests__/template.test.ts
@@ -27,6 +27,9 @@ const getGlobalTestMocks = () => {
   };
   globals.test.only = jest.fn();
   globals.test.skip = jest.fn();
+  globals.test.concurrent = jest.fn();
+  globals.test.concurrent.only = jest.fn();
+  globals.test.concurrent.skip = jest.fn();
   globals.it.only = jest.fn();
   globals.it.skip = jest.fn();
   globals.describe.only = jest.fn();
@@ -37,6 +40,9 @@ const getGlobalTestMocks = () => {
 describe('jest-each', () => {
   [
     ['test'],
+    ['test', 'concurrent'],
+    ['test', 'concurrent', 'only'],
+    ['test', 'concurrent', 'skip'],
     ['test', 'only'],
     ['it'],
     ['fit'],
@@ -315,6 +321,7 @@ describe('jest-each', () => {
     test.each([
       [['test']],
       [['test', 'only']],
+      [['test', 'concurrent', 'only']],
       [['it']],
       [['fit']],
       [['it', 'only']],
@@ -361,6 +368,8 @@ describe('jest-each', () => {
   [
     ['xtest'],
     ['test', 'skip'],
+    ['test', 'concurrent'],
+    ['test', 'concurrent', 'skip'],
     ['xit'],
     ['it', 'skip'],
     ['xdescribe'],

--- a/packages/jest-each/src/bind.ts
+++ b/packages/jest-each/src/bind.ts
@@ -18,16 +18,20 @@ export type EachTests = Array<{
   arguments: Array<unknown>;
 }>;
 
-type TestFn = (done?: Global.DoneFn) => Promise<any> | void | undefined;
-type GlobalCallback = (testName: string, fn: TestFn, timeout?: number) => void;
+// type TestFn = (done?: Global.DoneFn) => Promise<any> | void | undefined;
+type GlobalCallback = (
+  testName: string,
+  fn: Global.ConcurrentTestFn,
+  timeout?: number,
+) => void;
 
-export default (cb: GlobalCallback, supportsDone: boolean = true) => (
-  table: Global.EachTable,
-  ...taggedTemplateData: Global.TemplateData
-) =>
+export default <A extends Global.TestCallback>(
+  cb: GlobalCallback,
+  supportsDone: boolean = true,
+) => (table: Global.EachTable, ...taggedTemplateData: Global.TemplateData) =>
   function eachBind(
     title: string,
-    test: Global.EachTestFn,
+    test: Global.EachTestFn<A>,
     timeout?: number,
   ): void {
     try {
@@ -70,11 +74,11 @@ const buildTemplateTests = (
 const getHeadingKeys = (headings: string): Array<string> =>
   headings.replace(/\s/g, '').split('|');
 
-const applyArguments = (
+const applyArguments = <A extends Global.TestCallback>(
   supportsDone: boolean,
   params: Array<unknown>,
-  test: Global.EachTestFn,
-): Global.EachTestFn =>
+  test: Global.EachTestFn<A>,
+): Global.EachTestFn<any> =>
   supportsDone && params.length < test.length
     ? (done: Global.DoneFn) => test(...params, done)
     : () => test(...params);

--- a/packages/jest-each/src/bind.ts
+++ b/packages/jest-each/src/bind.ts
@@ -25,13 +25,13 @@ type GlobalCallback = (
   timeout?: number,
 ) => void;
 
-export default <A extends Global.TestCallback>(
+export default <EachCallback extends Global.TestCallback>(
   cb: GlobalCallback,
   supportsDone: boolean = true,
 ) => (table: Global.EachTable, ...taggedTemplateData: Global.TemplateData) =>
   function eachBind(
     title: string,
-    test: Global.EachTestFn<A>,
+    test: Global.EachTestFn<EachCallback>,
     timeout?: number,
   ): void {
     try {
@@ -74,10 +74,10 @@ const buildTemplateTests = (
 const getHeadingKeys = (headings: string): Array<string> =>
   headings.replace(/\s/g, '').split('|');
 
-const applyArguments = <A extends Global.TestCallback>(
+const applyArguments = <EachCallback extends Global.TestCallback>(
   supportsDone: boolean,
   params: Array<unknown>,
-  test: Global.EachTestFn<A>,
+  test: Global.EachTestFn<EachCallback>,
 ): Global.EachTestFn<any> =>
   supportsDone && params.length < test.length
     ? (done: Global.DoneFn) => test(...params, done)

--- a/packages/jest-each/src/index.ts
+++ b/packages/jest-each/src/index.ts
@@ -22,15 +22,32 @@ const install = (
       '`.each` must only be called with an Array or Tagged Template Literal.',
     );
   }
-  const test = (title: string, test: Global.EachTestFn, timeout?: number) =>
-    bind(g.test)(table, ...data)(title, test, timeout);
+  const test = (
+    title: string,
+    test: Global.EachTestFn<Global.TestFn>,
+    timeout?: number,
+  ) => bind(g.test)(table, ...data)(title, test, timeout);
   test.skip = bind(g.test.skip)(table, ...data);
   test.only = bind(g.test.only)(table, ...data);
 
-  const it = (title: string, test: Global.EachTestFn, timeout?: number) =>
-    bind(g.it)(table, ...data)(title, test, timeout);
+  const testConcurrent = (
+    title: string,
+    test: Global.EachTestFn<Global.TestFn>,
+    timeout?: number,
+  ) => bind(g.test.concurrent)(table, ...data)(title, test, timeout);
+
+  test.concurrent = testConcurrent;
+  testConcurrent.only = bind(g.test.concurrent.only)(table, ...data);
+  testConcurrent.skip = bind(g.test.concurrent.skip)(table, ...data);
+
+  const it = (
+    title: string,
+    test: Global.EachTestFn<Global.TestFn>,
+    timeout?: number,
+  ) => bind(g.it)(table, ...data)(title, test, timeout);
   it.skip = bind(g.it.skip)(table, ...data);
   it.only = bind(g.it.only)(table, ...data);
+  it.concurrent = testConcurrent;
 
   const xit = bind(g.xit)(table, ...data);
   const fit = bind(g.fit)(table, ...data);
@@ -38,7 +55,7 @@ const install = (
 
   const describe = (
     title: string,
-    suite: Global.EachTestFn,
+    suite: Global.EachTestFn<Global.BlockFn>,
     timeout?: number,
   ) => bind(g.describe, false)(table, ...data)(title, suite, timeout);
   describe.skip = bind(g.describe.skip, false)(table, ...data);

--- a/packages/jest-jasmine2/src/__tests__/concurrent.test.ts
+++ b/packages/jest-jasmine2/src/__tests__/concurrent.test.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+describe('concurrent', () => {
+  test.concurrent.each([
+    [1, 2],
+    [2, 3],
+    [3, 4],
+  ])('should add 1 to number', async (a, sum) => {
+    expect(a + 1).toEqual(sum);
+  });
+});

--- a/packages/jest-jasmine2/src/each.ts
+++ b/packages/jest-jasmine2/src/each.ts
@@ -24,4 +24,16 @@ export default (environment: JestEnvironment): void => {
     environment.global.fdescribe,
     false,
   );
+  environment.global.it.concurrent.each = bindEach(
+    environment.global.it.concurrent,
+    false,
+  );
+  environment.global.it.concurrent.only.each = bindEach(
+    environment.global.it.concurrent.only,
+    false,
+  );
+  environment.global.it.concurrent.skip.each = bindEach(
+    environment.global.it.concurrent.skip,
+    false,
+  );
 };

--- a/packages/jest-jasmine2/src/jasmineAsyncInstall.ts
+++ b/packages/jest-jasmine2/src/jasmineAsyncInstall.ts
@@ -163,7 +163,11 @@ function makeConcurrent(
   env: Jasmine['currentEnv_'],
   mutex: ReturnType<typeof throat>,
 ): Global.ItConcurrentBase {
-  return function (specName, fn, timeout) {
+  const concurrentFn = function (
+    specName: string,
+    fn: Global.TestFn,
+    timeout?: number,
+  ) {
     let promise: Promise<unknown> = Promise.resolve();
 
     const spec = originalFn.call(env, specName, () => promise, timeout);
@@ -187,6 +191,8 @@ function makeConcurrent(
 
     return spec;
   };
+  concurrentFn.each = () => {};
+  return concurrentFn;
 }
 
 export default function jasmineAsyncInstall(

--- a/packages/jest-jasmine2/src/jasmineAsyncInstall.ts
+++ b/packages/jest-jasmine2/src/jasmineAsyncInstall.ts
@@ -191,6 +191,7 @@ function makeConcurrent(
 
     return spec;
   };
+  // each is binded after the function is made concurrent, so for now it is made noop
   concurrentFn.each = () => {};
   return concurrentFn;
 }

--- a/packages/jest-types/src/Global.ts
+++ b/packages/jest-types/src/Global.ts
@@ -29,18 +29,22 @@ export type EachTable = ArrayTable | TemplateTable;
 
 export type TestCallback = BlockFn | TestFn | ConcurrentTestFn;
 
-export type EachTestFn<A extends TestCallback> = (
+export type EachTestFn<EachCallback extends TestCallback> = (
   ...args: Array<any>
-) => ReturnType<A>;
+) => ReturnType<EachCallback>;
 
 // TODO: Get rid of this at some point
 type Jasmine = {_DEFAULT_TIMEOUT_INTERVAL?: number; addMatchers: Function};
 
-type Each<A extends TestCallback> =
+type Each<EachCallback extends TestCallback> =
   | ((
       table: EachTable,
       ...taggedTemplateData: Array<unknown>
-    ) => (title: string, test: EachTestFn<A>, timeout?: number) => void)
+    ) => (
+      title: string,
+      test: EachTestFn<EachCallback>,
+      timeout?: number,
+    ) => void)
   | (() => void);
 
 export interface ItBase {

--- a/packages/jest-types/src/Global.ts
+++ b/packages/jest-types/src/Global.ts
@@ -12,6 +12,9 @@ export type TestName = string;
 export type TestFn = (
   done?: DoneFn,
 ) => Promise<void | undefined | unknown> | void | undefined;
+export type ConcurrentTestFn = (
+  done?: DoneFn,
+) => Promise<void | undefined | unknown>;
 export type BlockFn = () => void;
 export type BlockName = string;
 export type HookFn = TestFn;
@@ -23,21 +26,24 @@ export type ArrayTable = Table | Row;
 export type TemplateTable = TemplateStringsArray;
 export type TemplateData = Array<unknown>;
 export type EachTable = ArrayTable | TemplateTable;
-export type EachTestFn = (
+
+export type TestCallback = BlockFn | TestFn | ConcurrentTestFn;
+
+export type EachTestFn<A extends TestCallback> = (
   ...args: Array<any>
-) => Promise<any> | void | undefined;
+) => ReturnType<A>;
 
 // TODO: Get rid of this at some point
 type Jasmine = {_DEFAULT_TIMEOUT_INTERVAL?: number; addMatchers: Function};
 
-type Each = (
+type Each<A extends TestCallback> = ((
   table: EachTable,
   ...taggedTemplateData: Array<unknown>
-) => (title: string, test: EachTestFn, timeout?: number) => void;
+) => (title: string, test: EachTestFn<A>, timeout?: number) => void) | (() => void);
 
 export interface ItBase {
   (testName: TestName, fn: TestFn, timeout?: number): void;
-  each: Each;
+  each: Each<TestFn>;
 }
 
 export interface It extends ItBase {
@@ -47,7 +53,8 @@ export interface It extends ItBase {
 }
 
 export interface ItConcurrentBase {
-  (testName: string, testFn: () => Promise<any>, timeout?: number): void;
+  (testName: string, testFn: ConcurrentTestFn, timeout?: number): void;
+  each: Each<ConcurrentTestFn>;
 }
 
 export interface ItConcurrentExtended extends ItConcurrentBase {
@@ -61,7 +68,7 @@ export interface ItConcurrent extends It {
 
 export interface DescribeBase {
   (blockName: BlockName, blockFn: BlockFn): void;
-  each: Each;
+  each: Each<BlockFn>;
 }
 
 export interface Describe extends DescribeBase {

--- a/packages/jest-types/src/Global.ts
+++ b/packages/jest-types/src/Global.ts
@@ -36,10 +36,12 @@ export type EachTestFn<A extends TestCallback> = (
 // TODO: Get rid of this at some point
 type Jasmine = {_DEFAULT_TIMEOUT_INTERVAL?: number; addMatchers: Function};
 
-type Each<A extends TestCallback> = ((
-  table: EachTable,
-  ...taggedTemplateData: Array<unknown>
-) => (title: string, test: EachTestFn<A>, timeout?: number) => void) | (() => void);
+type Each<A extends TestCallback> =
+  | ((
+      table: EachTable,
+      ...taggedTemplateData: Array<unknown>
+    ) => (title: string, test: EachTestFn<A>, timeout?: number) => void)
+  | (() => void);
 
 export interface ItBase {
   (testName: TestName, fn: TestFn, timeout?: number): void;


### PR DESCRIPTION
## Summary

Fixes #8985.

Supported .concurrent in test.each

## Open Points need to discuss

1) Is this `test.each.concurrent.only` valid?
2) Is this `test.concurrent.each` valid?
3) There does not seem to be tests for concurrent both in `jest-jasmine` and `jest-circus`, tests in `jest-circus` are using `execa` for running the tests I can't seem to run a test which has `test.concurrent`

## Notes on implementation

- Have updated types in Global.ts to accommodate `each.concurrent`
- Have created an additional method in `jest-each` `bindConcurrent`
- Currently there is code duplication in `jest-each`, will remove it raising as draft PR for now to get clarifications
- Have used `bindConcurrent` in `jest-jasmine` and `jest-circus`

## Example

```js
test.each.concurrent([1,2,3])('Name', (num)=> {
  // This function is executed concurrently with different `num`!
});
```

## Test plan

Have added tests in `jest-each`, `jest-jasmine`, as for `jest-circus` I've added an open point regarding this

\ cc @SimenB 
