### PR TITLE
chore: add babel classProperties plugin to snapshot example

### DIFF
--- a/examples/snapshot/.babelrc.js
+++ b/examples/snapshot/.babelrc.js
@@ -2,4 +2,5 @@
 
 module.exports = {
   presets: ['@babel/preset-env', '@babel/preset-react'],
+  plugins: ['@babel/plugin-proposal-class-properties']
 };

--- a/examples/snapshot/package.json
+++ b/examples/snapshot/package.json
@@ -7,6 +7,7 @@
   },
   "devDependencies": {
     "@babel/core": "*",
+    "@babel/plugin-proposal-class-properties": "^7.7.4",
     "@babel/preset-env": "*",
     "@babel/preset-react": "*",
     "babel-jest": "*",

--- a/examples/snapshot/package.json
+++ b/examples/snapshot/package.json
@@ -7,7 +7,7 @@
   },
   "devDependencies": {
     "@babel/core": "*",
-    "@babel/plugin-proposal-class-properties": "^7.7.4",
+    "@babel/plugin-proposal-class-properties": "*",
     "@babel/preset-env": "*",
     "@babel/preset-react": "*",
     "babel-jest": "*",


### PR DESCRIPTION
## Summary

The snapshot example tests do not pass as is. This pull request adds babel configuration and dependency to fix this issue.

## Test plan

```
cd examples/snapshots
npm install
npm test
```

Expected result:   
```
> jest

 PASS  __tests__/clock.react.test.js
 PASS  __tests__/link.react.test.js

Test Suites: 2 passed, 2 total
Tests:       5 passed, 5 total
Snapshots:   7 passed, 7 total
Time:        1.851s, estimated 2s
Ran all test suites
```
