### PR TITLE
chore: fix examples dependencies

### DIFF
--- a/examples/mongodb/package.json
+++ b/examples/mongodb/package.json
@@ -10,6 +10,8 @@
     "jest-environment-node": "*"
   },
   "devDependencies": {
+    "@babel/preset-env": "*",
+    "babel-jest": "*",
     "jest": "*"
   },
   "scripts": {

--- a/examples/react-native/package.json
+++ b/examples/react-native/package.json
@@ -16,6 +16,6 @@
     "babel-jest": "*",
     "jest": "*",
     "metro-react-native-babel-preset": "*",
-    "react-test-renderer": "*"
+    "react-test-renderer": "16.6.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11706,7 +11706,7 @@ react-error-overlay@^6.0.3:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.4.tgz#0d165d6d27488e660bc08e57bdabaad741366f7a"
   integrity sha512-ueZzLmHltszTshDMwyfELDq8zOA803wQ1ZuzCccXa1m57k1PxSHfflPD5W9YIiTXLs0JTLzoj6o1LuM5N6zzNA==
 
-react-is@^16.12.0, react-is@^16.8.1, react-is@^16.8.6, react-is@^16.9.0:
+react-is@^16.12.0, react-is@^16.6.3, react-is@^16.8.1, react-is@^16.8.6, react-is@^16.9.0:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
   integrity sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==
@@ -11792,6 +11792,16 @@ react-test-renderer@*, react-test-renderer@^16.0.0-0:
     prop-types "^15.6.2"
     react-is "^16.8.6"
     scheduler "^0.13.6"
+
+react-test-renderer@16.6.3:
+  version "16.6.3"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.6.3.tgz#5f3a1a7d5c3379d46f7052b848b4b72e47c89f38"
+  integrity sha512-B5bCer+qymrQz/wN03lT0LppbZUDRq6AMfzMKrovzkGzfO81a9T+PWQW6MzkWknbwODQH/qpJno/yFQLX5IWrQ==
+  dependencies:
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    react-is "^16.6.3"
+    scheduler "^0.11.2"
 
 react-transform-hmr@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
## Summary

Fixes dependencies of mongodb and react-native examples.

## Test plan

```
cd examples/mongodb
npm install
npm test
```

```
cd examples/react-native
npm install
npm test
```