### PR TITLE
docs: clarify error handling when using test callbacks

### DIFF
--- a/docs/TestingAsyncCode.md
+++ b/docs/TestingAsyncCode.md
@@ -34,7 +34,7 @@ test('the data is peanut butter', done => {
     try {
       expect(data).toBe('peanut butter');
       done();
-    } catch(error) {
+    } catch (error) {
       done(error);
     }
   }

--- a/docs/TestingAsyncCode.md
+++ b/docs/TestingAsyncCode.md
@@ -31,15 +31,21 @@ There is an alternate form of `test` that fixes this. Instead of putting the tes
 ```js
 test('the data is peanut butter', done => {
   function callback(data) {
-    expect(data).toBe('peanut butter');
-    done();
+    try {
+      expect(data).toBe('peanut butter');
+      done();
+    } catch(error) {
+      done(error);
+    }
   }
 
   fetchData(callback);
 });
 ```
 
-If `done()` is never called, the test will fail, which is what you want to happen.
+If `done()` is never called, the test will fail (with timeout error), which is what you want to happen.
+
+In case `expect` statement fails it throws an error and `done()` is not called. If we want to see in the test log why it failed, we have to wrap `expect` in `try` block and pass error in `catch` block to `done`. Otherwise, we end up with opaque timeout error and no knowledge of what value was received by `expect(data)`.
 
 ## Promises
 

--- a/website/versioned_docs/version-22.x/TestingAsyncCode.md
+++ b/website/versioned_docs/version-22.x/TestingAsyncCode.md
@@ -32,15 +32,21 @@ There is an alternate form of `test` that fixes this. Instead of putting the tes
 ```js
 test('the data is peanut butter', done => {
   function callback(data) {
-    expect(data).toBe('peanut butter');
-    done();
+    try {
+      expect(data).toBe('peanut butter');
+      done();
+    } catch (error) {
+      done(error);
+    }
   }
 
   fetchData(callback);
 });
 ```
 
-If `done()` is never called, the test will fail, which is what you want to happen.
+If `done()` is never called, the test will fail (with timeout error), which is what you want to happen.
+
+In case `expect` statement fails it throws an error and `done()` is not called. If we want to see in the test log why it failed, we have to wrap `expect` in `try` block and pass error in `catch` block to `done`. Otherwise, we end up with opaque timeout error and no knowledge of what value was received by `expect(data)`.
 
 ## Promises
 

--- a/website/versioned_docs/version-24.x/TestingAsyncCode.md
+++ b/website/versioned_docs/version-24.x/TestingAsyncCode.md
@@ -32,15 +32,21 @@ There is an alternate form of `test` that fixes this. Instead of putting the tes
 ```js
 test('the data is peanut butter', done => {
   function callback(data) {
-    expect(data).toBe('peanut butter');
-    done();
+    try {
+      expect(data).toBe('peanut butter');
+      done();
+    } catch (error) {
+      done(error);
+    }
   }
 
   fetchData(callback);
 });
 ```
 
-If `done()` is never called, the test will fail, which is what you want to happen.
+If `done()` is never called, the test will fail (with timeout error), which is what you want to happen.
+
+In case `expect` statement fails it throws an error and `done()` is not called. If we want to see in the test log why it failed, we have to wrap `expect` in `try` block and pass error in `catch` block to `done`. Otherwise, we end up with opaque timeout error and no knowledge of what value was received by `expect(data)`.
 
 ## Promises
 


### PR DESCRIPTION

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
The callback code sample was too simple leaving beginners them with the test which provides only useless timeout error in the log instead of received value causing fail if the test.

Improved callback code sample with the done parameter so beginners do not end up with opaque timeout error.  Added try-catch block and error handling in case expect matcher fails. Added explanation if importance to wrap expect in try statement in this scenario, what happens if the test fails and done() is not called.

## Test plan

No test needed. Changes only to the text of documentation.
