### PR TITLE
feat: add long test time threshold option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Features
 
-- `[jest-config, jest-reporter, jest-runner]` Add `slowTestThreshold` configuration option ([#9366](https://github.com/facebook/jest/pull/9366))
+- `[jest-config, jest-reporter, jest-runner, jest-test-sequencer]` Add `slowTestThreshold` configuration option ([#9366](https://github.com/facebook/jest/pull/9366))
 - `[jest-worker]` Added support for workers to send custom messages to parent in jest-worker ([#10293](https://github.com/facebook/jest/pull/10293))
 - `[pretty-format]` Added support for serializing custom elements (web components) ([#10217](https://github.com/facebook/jest/pull/10237))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 
+- `[jest-config, jest-reporter, jest-runner]` Add `slowTestThreshold` configuration option ([#9366](https://github.com/facebook/jest/pull/9366))
 - `[jest-worker]` Added support for workers to send custom messages to parent in jest-worker ([#10293](https://github.com/facebook/jest/pull/10293))
 - `[pretty-format]` Added support for serializing custom elements (web components) ([#10217](https://github.com/facebook/jest/pull/10237))
 

--- a/TestUtils.ts
+++ b/TestUtils.ts
@@ -102,6 +102,7 @@ const DEFAULT_PROJECT_CONFIG: Config.ProjectConfig = {
   setupFilesAfterEnv: [],
   skipFilter: false,
   skipNodeResolution: false,
+  slowTestThreshold: 5,
   snapshotResolver: undefined,
   snapshotSerializers: [],
   testEnvironment: 'node',

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -800,6 +800,12 @@ Example `jest.setup.js` file
 jest.setTimeout(10000); // in milliseconds
 ```
 
+### `slowTestThreshold` [number]
+
+Default: `5`
+
+A number of seconds after which a test is considered as slow and reported as such in the results.
+
 ### `snapshotResolver` [string]
 
 Default: `undefined`

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -804,7 +804,7 @@ jest.setTimeout(10000); // in milliseconds
 
 Default: `5`
 
-A number of seconds after which a test is considered as slow and reported as such in the results.
+The number of seconds after which a test is considered as slow and reported as such in the results.
 
 ### `snapshotResolver` [string]
 

--- a/e2e/__tests__/__snapshots__/showConfig.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/showConfig.test.ts.snap
@@ -48,6 +48,7 @@ exports[`--showConfig outputs config info and exits 1`] = `
       "setupFiles": [],
       "setupFilesAfterEnv": [],
       "skipFilter": false,
+      "slowTestThreshold": 5,
       "snapshotSerializers": [],
       "testEnvironment": "<<REPLACED_JEST_PACKAGES_DIR>>/jest-environment-jsdom/build/index.js",
       "testEnvironmentOptions": {},

--- a/packages/jest-cli/src/init/__tests__/__snapshots__/init.test.js.snap
+++ b/packages/jest-cli/src/init/__tests__/__snapshots__/init.test.js.snap
@@ -176,7 +176,7 @@ module.exports = {
   // A list of paths to modules that run some code to configure or set up the testing framework before each test
   // setupFilesAfterEnv: [],
 
-  // A number of seconds after which a test is considered as slow and reported as such in the results.
+  // The number of seconds after which a test is considered as slow and reported as such in the results.
   // slowTestThreshold: 5,
 
   // A list of paths to snapshot serializer modules Jest should use for snapshot testing

--- a/packages/jest-cli/src/init/__tests__/__snapshots__/init.test.js.snap
+++ b/packages/jest-cli/src/init/__tests__/__snapshots__/init.test.js.snap
@@ -176,6 +176,9 @@ module.exports = {
   // A list of paths to modules that run some code to configure or set up the testing framework before each test
   // setupFilesAfterEnv: [],
 
+  // A number of seconds after which a test is considered as slow and reported as such in the results.
+  // slowTestThreshold: 5,
+
   // A list of paths to snapshot serializer modules Jest should use for snapshot testing
   // snapshotSerializers: [],
 

--- a/packages/jest-config/src/Defaults.ts
+++ b/packages/jest-config/src/Defaults.ts
@@ -50,6 +50,7 @@ const defaultOptions: Config.DefaultOptions = {
   setupFiles: [],
   setupFilesAfterEnv: [],
   skipFilter: false,
+  slowTestThreshold: 5,
   snapshotSerializers: [],
   testEnvironment: 'jest-environment-jsdom',
   testEnvironmentOptions: {},

--- a/packages/jest-config/src/Descriptions.ts
+++ b/packages/jest-config/src/Descriptions.ts
@@ -67,6 +67,8 @@ const descriptions: {[key in keyof Config.InitialOptions]: string} = {
     'The paths to modules that run some code to configure or set up the testing environment before each test',
   setupFilesAfterEnv:
     'A list of paths to modules that run some code to configure or set up the testing framework before each test',
+  slowTestThreshold:
+    'A number of seconds after which a test is considered as slow and reported as such in the results.',
   snapshotSerializers:
     'A list of paths to snapshot serializer modules Jest should use for snapshot testing',
   testEnvironment: 'The test environment that will be used for testing',

--- a/packages/jest-config/src/Descriptions.ts
+++ b/packages/jest-config/src/Descriptions.ts
@@ -68,7 +68,7 @@ const descriptions: {[key in keyof Config.InitialOptions]: string} = {
   setupFilesAfterEnv:
     'A list of paths to modules that run some code to configure or set up the testing framework before each test',
   slowTestThreshold:
-    'A number of seconds after which a test is considered as slow and reported as such in the results.',
+    'The number of seconds after which a test is considered as slow and reported as such in the results.',
   snapshotSerializers:
     'A list of paths to snapshot serializer modules Jest should use for snapshot testing',
   testEnvironment: 'The test environment that will be used for testing',

--- a/packages/jest-config/src/ValidConfig.ts
+++ b/packages/jest-config/src/ValidConfig.ts
@@ -97,6 +97,7 @@ const initialOptions: Config.InitialOptions = {
   silent: true,
   skipFilter: false,
   skipNodeResolution: false,
+  slowTestThreshold: 5,
   snapshotResolver: '<rootDir>/snapshotResolver.js',
   snapshotSerializers: ['my-serializer-module'],
   testEnvironment: 'jest-environment-jsdom',

--- a/packages/jest-config/src/index.ts
+++ b/packages/jest-config/src/index.ts
@@ -205,6 +205,7 @@ const groupOptions = (
     setupFilesAfterEnv: options.setupFilesAfterEnv,
     skipFilter: options.skipFilter,
     skipNodeResolution: options.skipNodeResolution,
+    slowTestThreshold: options.slowTestThreshold,
     snapshotResolver: options.snapshotResolver,
     snapshotSerializers: options.snapshotSerializers,
     testEnvironment: options.testEnvironment,

--- a/packages/jest-config/src/normalize.ts
+++ b/packages/jest-config/src/normalize.ts
@@ -907,6 +907,7 @@ export default function normalize(
       case 'silent':
       case 'skipFilter':
       case 'skipNodeResolution':
+      case 'slowTestThreshold':
       case 'testEnvironment':
       case 'testEnvironmentOptions':
       case 'testFailureExitCode':

--- a/packages/jest-core/src/lib/__tests__/__snapshots__/log_debug_messages.test.ts.snap
+++ b/packages/jest-core/src/lib/__tests__/__snapshots__/log_debug_messages.test.ts.snap
@@ -38,6 +38,7 @@ exports[`prints the config object 1`] = `
     "setupFilesAfterEnv": [],
     "skipFilter": false,
     "skipNodeResolution": false,
+    "slowTestThreshold": 5,
     "snapshotSerializers": [],
     "testEnvironment": "node",
     "testEnvironmentOptions": {},

--- a/packages/jest-reporters/src/__tests__/get_result_header.test.js
+++ b/packages/jest-reporters/src/__tests__/get_result_header.test.js
@@ -20,6 +20,7 @@ const testResult = {
 const testResultSlow = {
   perfStats: {
     end: endTime,
+    runtime: testTime,
     slow: true,
     start: endTime - testTime,
   },
@@ -28,6 +29,7 @@ const testResultSlow = {
 const testResultFast = {
   perfStats: {
     end: endTime,
+    runtime: testTime,
     slow: false,
     start: endTime - testTime,
   },

--- a/packages/jest-reporters/src/__tests__/get_result_header.test.js
+++ b/packages/jest-reporters/src/__tests__/get_result_header.test.js
@@ -59,11 +59,11 @@ test('should render the terminal link', () => {
 test('should display test time for slow test', () => {
   const result = getResultHeader(testResultSlow, globalConfig);
 
-  expect(result).toContain(`${testTime / 1000}s`);
+  expect(result).toContain(`${testTime / 1000} s`);
 });
 
 test('should not display test time for fast test ', () => {
   const result = getResultHeader(testResultFast, globalConfig);
 
-  expect(result).not.toContain(`${testTime / 1000}s`);
+  expect(result).not.toContain(`${testTime / 1000} s`);
 });

--- a/packages/jest-reporters/src/__tests__/get_result_header.test.js
+++ b/packages/jest-reporters/src/__tests__/get_result_header.test.js
@@ -11,7 +11,26 @@ const terminalLink = require('terminal-link');
 
 jest.mock('terminal-link', () => jest.fn(() => 'wannabehyperlink'));
 
+const endTime = 1577717671160;
+const testTime = 5500;
+
 const testResult = {
+  testFilePath: '/foo',
+};
+const testResultSlow = {
+  perfStats: {
+    end: endTime,
+    slow: true,
+    start: endTime - testTime,
+  },
+  testFilePath: '/foo',
+};
+const testResultFast = {
+  perfStats: {
+    end: endTime,
+    slow: false,
+    start: endTime - testTime,
+  },
   testFilePath: '/foo',
 };
 
@@ -35,4 +54,16 @@ test('should render the terminal link', () => {
   const result = getResultHeader(testResult, globalConfig);
 
   expect(result).toContain('wannabehyperlink');
+});
+
+test('should display test time for slow test', () => {
+  const result = getResultHeader(testResultSlow, globalConfig);
+
+  expect(result).toContain(`${testTime / 1000}s`);
+});
+
+test('should not display test time for fast test ', () => {
+  const result = getResultHeader(testResultFast, globalConfig);
+
+  expect(result).not.toContain(`${testTime / 1000}s`);
 });

--- a/packages/jest-reporters/src/get_result_header.ts
+++ b/packages/jest-reporters/src/get_result_header.ts
@@ -44,7 +44,7 @@ export default (
 
   const testDetail = [];
 
-  if (result.perfStats && result.perfStats.slow) {
+  if (result.perfStats?.slow) {
     const runTime = (result.perfStats.end - result.perfStats.start) / 1000;
 
     testDetail.push(LONG_TEST_COLOR(formatTime(runTime, 0)));

--- a/packages/jest-reporters/src/get_result_header.ts
+++ b/packages/jest-reporters/src/get_result_header.ts
@@ -45,7 +45,7 @@ export default (
   const testDetail = [];
 
   if (result.perfStats?.slow) {
-    const runTime = (result.perfStats.end - result.perfStats.start) / 1000;
+    const runTime = result.perfStats.runtime / 1000;
 
     testDetail.push(LONG_TEST_COLOR(formatTime(runTime, 0)));
   }

--- a/packages/jest-reporters/src/get_result_header.ts
+++ b/packages/jest-reporters/src/get_result_header.ts
@@ -42,12 +42,11 @@ export default (
   const status =
     result.numFailingTests > 0 || result.testExecError ? FAIL : PASS;
 
-  const runTime = result.perfStats
-    ? (result.perfStats.end - result.perfStats.start) / 1000
-    : null;
-
   const testDetail = [];
-  if (runTime !== null && runTime > 5) {
+
+  if (result.perfStats && result.perfStats.slow) {
+    const runTime = (result.perfStats.end - result.perfStats.start) / 1000;
+
     testDetail.push(LONG_TEST_COLOR(formatTime(runTime, 0)));
   }
 

--- a/packages/jest-runner/src/runTest.ts
+++ b/packages/jest-runner/src/runTest.ts
@@ -267,9 +267,11 @@ async function runTestInternal(
       result.numTodoTests;
 
     const end = Date.now();
+    const testRuntime = end - start;
     result.perfStats = {
       end,
-      slow: (end - start) / 1000 > config.slowTestThreshold,
+      runtime: testRuntime,
+      slow: testRuntime / 1000 > config.slowTestThreshold,
       start,
     };
     result.testFilePath = path;

--- a/packages/jest-runner/src/runTest.ts
+++ b/packages/jest-runner/src/runTest.ts
@@ -266,7 +266,12 @@ async function runTestInternal(
       result.numPendingTests +
       result.numTodoTests;
 
-    result.perfStats = {end: Date.now(), start};
+    const end = Date.now();
+    result.perfStats = {
+      end,
+      slow: (end - start) / 1000 > config.slowTestThreshold,
+      start,
+    };
     result.testFilePath = path;
     result.console = testConsole.getBuffer();
     result.skipped = testCount === result.numPendingTests;

--- a/packages/jest-test-result/src/__tests__/formatTestResults.test.ts
+++ b/packages/jest-test-result/src/__tests__/formatTestResults.test.ts
@@ -19,7 +19,7 @@ describe('formatTestResults', () => {
     testResults: [
       {
         numFailingTests: 0,
-        perfStats: {end: 2, slow: false, start: 1},
+        perfStats: {end: 2, runtime: 1, slow: false, start: 1},
         // @ts-expect-error
         testResults: [assertion],
       },

--- a/packages/jest-test-result/src/__tests__/formatTestResults.test.ts
+++ b/packages/jest-test-result/src/__tests__/formatTestResults.test.ts
@@ -19,7 +19,7 @@ describe('formatTestResults', () => {
     testResults: [
       {
         numFailingTests: 0,
-        perfStats: {end: 2, start: 1},
+        perfStats: {end: 2, slow: false, start: 1},
         // @ts-expect-error
         testResults: [assertion],
       },

--- a/packages/jest-test-result/src/helpers.ts
+++ b/packages/jest-test-result/src/helpers.ts
@@ -58,6 +58,7 @@ export const buildFailureTestResult = (
   openHandles: [],
   perfStats: {
     end: 0,
+    slow: false,
     start: 0,
   },
   skipped: false,
@@ -155,6 +156,7 @@ export const createEmptyTestResult = (): TestResult => ({
   openHandles: [],
   perfStats: {
     end: 0,
+    slow: false,
     start: 0,
   },
   skipped: false,

--- a/packages/jest-test-result/src/helpers.ts
+++ b/packages/jest-test-result/src/helpers.ts
@@ -58,6 +58,7 @@ export const buildFailureTestResult = (
   openHandles: [],
   perfStats: {
     end: 0,
+    runtime: 0,
     slow: false,
     start: 0,
   },
@@ -156,6 +157,7 @@ export const createEmptyTestResult = (): TestResult => ({
   openHandles: [],
   perfStats: {
     end: 0,
+    runtime: 0,
     slow: false,
     start: 0,
   },

--- a/packages/jest-test-result/src/types.ts
+++ b/packages/jest-test-result/src/types.ts
@@ -92,6 +92,7 @@ export type TestResult = {
   openHandles: Array<Error>;
   perfStats: {
     end: Milliseconds;
+    slow: boolean;
     start: Milliseconds;
   };
   skipped: boolean;

--- a/packages/jest-test-result/src/types.ts
+++ b/packages/jest-test-result/src/types.ts
@@ -92,6 +92,7 @@ export type TestResult = {
   openHandles: Array<Error>;
   perfStats: {
     end: Milliseconds;
+    runtime: Milliseconds;
     slow: boolean;
     start: Milliseconds;
   };

--- a/packages/jest-test-sequencer/src/__tests__/test_sequencer.test.js
+++ b/packages/jest-test-sequencer/src/__tests__/test_sequencer.test.js
@@ -134,23 +134,23 @@ test('writes the cache based on results without existing cache', () => {
     testResults: [
       {
         numFailingTests: 0,
-        perfStats: {end: 2, start: 1},
+        perfStats: {end: 2, runtime: 1, start: 1},
         testFilePath: '/test-a.js',
       },
       {
         numFailingTests: 0,
-        perfStats: {end: 0, start: 0},
+        perfStats: {end: 0, runtime: 0, start: 0},
         skipped: true,
         testFilePath: '/test-b.js',
       },
       {
         numFailingTests: 1,
-        perfStats: {end: 4, start: 1},
+        perfStats: {end: 4, runtime: 3, start: 1},
         testFilePath: '/test-c.js',
       },
       {
         numFailingTests: 1,
-        perfStats: {end: 2, start: 1},
+        perfStats: {end: 2, runtime: 1, start: 1},
         testFilePath: '/test-x.js',
       },
     ],
@@ -177,23 +177,23 @@ test('writes the cache based on the results', () => {
     testResults: [
       {
         numFailingTests: 0,
-        perfStats: {end: 2, start: 1},
+        perfStats: {end: 2, runtime: 1, start: 1},
         testFilePath: '/test-a.js',
       },
       {
         numFailingTests: 0,
-        perfStats: {end: 0, start: 0},
+        perfStats: {end: 0, runtime: 0, start: 0},
         skipped: true,
         testFilePath: '/test-b.js',
       },
       {
         numFailingTests: 1,
-        perfStats: {end: 4, start: 1},
+        perfStats: {end: 4, runtime: 3, start: 1},
         testFilePath: '/test-c.js',
       },
       {
         numFailingTests: 1,
-        perfStats: {end: 2, start: 1},
+        perfStats: {end: 2, runtime: 1, start: 1},
         testFilePath: '/test-x.js',
       },
     ],
@@ -228,23 +228,23 @@ test('works with multiple contexts', () => {
     testResults: [
       {
         numFailingTests: 0,
-        perfStats: {end: 2, start: 1},
+        perfStats: {end: 2, runtime: 1, start: 1},
         testFilePath: '/test-a.js',
       },
       {
         numFailingTests: 0,
-        perfStats: {end: 0, start: 0},
+        perfStats: {end: 0, runtime: 1, start: 0},
         skipped: true,
         testFilePath: '/test-b.js',
       },
       {
         numFailingTests: 0,
-        perfStats: {end: 4, start: 1},
+        perfStats: {end: 4, runtime: 3, start: 1},
         testFilePath: '/test-c.js',
       },
       {
         numFailingTests: 1,
-        perfStats: {end: 2, start: 1},
+        perfStats: {end: 2, runtime: 1, start: 1},
         testFilePath: '/test-x.js',
       },
     ],

--- a/packages/jest-test-sequencer/src/index.ts
+++ b/packages/jest-test-sequencer/src/index.ts
@@ -118,7 +118,7 @@ export default class TestSequencer {
         const perf = testResult.perfStats;
         cache[testResult.testFilePath] = [
           testResult.numFailingTests ? FAIL : SUCCESS,
-          perf.end - perf.start || 0,
+          perf.runtime || 0,
         ];
       }
     });

--- a/packages/jest-transform/src/__tests__/__snapshots__/script_transformer.test.js.snap
+++ b/packages/jest-transform/src/__tests__/__snapshots__/script_transformer.test.js.snap
@@ -41,6 +41,7 @@ Object {
     "setupFilesAfterEnv": Array [],
     "skipFilter": false,
     "skipNodeResolution": false,
+    "slowTestThreshold": 5,
     "snapshotResolver": undefined,
     "snapshotSerializers": Array [],
     "testEnvironment": "node",
@@ -229,7 +230,7 @@ exports[`ScriptTransformer uses multiple preprocessors 1`] = `
 const TRANSFORMED = {
   filename: '/fruits/banana.js',
   script: 'module.exports = "banana";',
-  config: '{"automock":false,"cache":true,"cacheDirectory":"/cache/","clearMocks":false,"coveragePathIgnorePatterns":[],"cwd":"/test_root_dir/","detectLeaks":false,"detectOpenHandles":false,"errorOnDeprecated":false,"extraGlobals":[],"forceCoverageMatch":[],"globals":{},"haste":{},"moduleDirectories":[],"moduleFileExtensions":["js"],"moduleLoader":"/test_module_loader_path","moduleNameMapper":[],"modulePathIgnorePatterns":[],"modulePaths":[],"name":"test","prettierPath":"prettier","resetMocks":false,"resetModules":false,"restoreMocks":false,"rootDir":"/","roots":[],"runner":"jest-runner","setupFiles":[],"setupFilesAfterEnv":[],"skipFilter":false,"skipNodeResolution":false,"snapshotSerializers":[],"testEnvironment":"node","testEnvironmentOptions":{},"testLocationInResults":false,"testMatch":[],"testPathIgnorePatterns":[],"testRegex":["\\\\.test\\\\.js$"],"testRunner":"jest-jasmine2","testURL":"http://localhost","timers":"real","transform":[["^.+\\\\.js$","test_preprocessor"],["^.+\\\\.css$","css-preprocessor"]],"transformIgnorePatterns":["/node_modules/"],"watchPathIgnorePatterns":[]}',
+  config: '{"automock":false,"cache":true,"cacheDirectory":"/cache/","clearMocks":false,"coveragePathIgnorePatterns":[],"cwd":"/test_root_dir/","detectLeaks":false,"detectOpenHandles":false,"errorOnDeprecated":false,"extraGlobals":[],"forceCoverageMatch":[],"globals":{},"haste":{},"moduleDirectories":[],"moduleFileExtensions":["js"],"moduleLoader":"/test_module_loader_path","moduleNameMapper":[],"modulePathIgnorePatterns":[],"modulePaths":[],"name":"test","prettierPath":"prettier","resetMocks":false,"resetModules":false,"restoreMocks":false,"rootDir":"/","roots":[],"runner":"jest-runner","setupFiles":[],"setupFilesAfterEnv":[],"skipFilter":false,"skipNodeResolution":false,"slowTestThreshold":5,"snapshotSerializers":[],"testEnvironment":"node","testEnvironmentOptions":{},"testLocationInResults":false,"testMatch":[],"testPathIgnorePatterns":[],"testRegex":["\\\\.test\\\\.js$"],"testRunner":"jest-jasmine2","testURL":"http://localhost","timers":"real","transform":[["^.+\\\\.js$","test_preprocessor"],["^.+\\\\.css$","css-preprocessor"]],"transformIgnorePatterns":["/node_modules/"],"watchPathIgnorePatterns":[]}',
 };
 `;
 
@@ -246,7 +247,7 @@ exports[`ScriptTransformer uses the supplied preprocessor 1`] = `
 const TRANSFORMED = {
   filename: '/fruits/banana.js',
   script: 'module.exports = "banana";',
-  config: '{"automock":false,"cache":true,"cacheDirectory":"/cache/","clearMocks":false,"coveragePathIgnorePatterns":[],"cwd":"/test_root_dir/","detectLeaks":false,"detectOpenHandles":false,"errorOnDeprecated":false,"extraGlobals":[],"forceCoverageMatch":[],"globals":{},"haste":{},"moduleDirectories":[],"moduleFileExtensions":["js"],"moduleLoader":"/test_module_loader_path","moduleNameMapper":[],"modulePathIgnorePatterns":[],"modulePaths":[],"name":"test","prettierPath":"prettier","resetMocks":false,"resetModules":false,"restoreMocks":false,"rootDir":"/","roots":[],"runner":"jest-runner","setupFiles":[],"setupFilesAfterEnv":[],"skipFilter":false,"skipNodeResolution":false,"snapshotSerializers":[],"testEnvironment":"node","testEnvironmentOptions":{},"testLocationInResults":false,"testMatch":[],"testPathIgnorePatterns":[],"testRegex":["\\\\.test\\\\.js$"],"testRunner":"jest-jasmine2","testURL":"http://localhost","timers":"real","transform":[["^.+\\\\.js$","test_preprocessor"]],"transformIgnorePatterns":["/node_modules/"],"watchPathIgnorePatterns":[]}',
+  config: '{"automock":false,"cache":true,"cacheDirectory":"/cache/","clearMocks":false,"coveragePathIgnorePatterns":[],"cwd":"/test_root_dir/","detectLeaks":false,"detectOpenHandles":false,"errorOnDeprecated":false,"extraGlobals":[],"forceCoverageMatch":[],"globals":{},"haste":{},"moduleDirectories":[],"moduleFileExtensions":["js"],"moduleLoader":"/test_module_loader_path","moduleNameMapper":[],"modulePathIgnorePatterns":[],"modulePaths":[],"name":"test","prettierPath":"prettier","resetMocks":false,"resetModules":false,"restoreMocks":false,"rootDir":"/","roots":[],"runner":"jest-runner","setupFiles":[],"setupFilesAfterEnv":[],"skipFilter":false,"skipNodeResolution":false,"slowTestThreshold":5,"snapshotSerializers":[],"testEnvironment":"node","testEnvironmentOptions":{},"testLocationInResults":false,"testMatch":[],"testPathIgnorePatterns":[],"testRegex":["\\\\.test\\\\.js$"],"testRunner":"jest-jasmine2","testURL":"http://localhost","timers":"real","transform":[["^.+\\\\.js$","test_preprocessor"]],"transformIgnorePatterns":["/node_modules/"],"watchPathIgnorePatterns":[]}',
 };
 `;
 

--- a/packages/jest-types/src/Config.ts
+++ b/packages/jest-types/src/Config.ts
@@ -65,6 +65,7 @@ export type DefaultOptions = {
   setupFiles: Array<Path>;
   setupFilesAfterEnv: Array<Path>;
   skipFilter: boolean;
+  slowTestThreshold: number;
   snapshotSerializers: Array<Path>;
   testEnvironment: string;
   testEnvironmentOptions: Record<string, any>;
@@ -171,6 +172,7 @@ export type InitialOptions = Partial<{
   silent: boolean;
   skipFilter: boolean;
   skipNodeResolution: boolean;
+  slowTestThreshold: number;
   snapshotResolver: Path;
   snapshotSerializers: Array<Path>;
   errorOnDeprecated: boolean;
@@ -332,6 +334,7 @@ export type ProjectConfig = {
   setupFilesAfterEnv: Array<Path>;
   skipFilter: boolean;
   skipNodeResolution?: boolean;
+  slowTestThreshold: number;
   snapshotResolver?: Path;
   snapshotSerializers: Array<Path>;
   testEnvironment: string;


### PR DESCRIPTION
## Summary

Adds `slowTestThreshold` option to configure what is considered to be a long running test. Defaults to 5 seconds since it was the original hardcoded value. Based on suggestions from #7220.

Fixes #7220

## Test plan

I have added two new tests to `get_result_header.test.js`.
