### PR TITLE
chore: bump @types/micromatch to ^4.0.0

### DIFF
--- a/packages/jest-config/package.json
+++ b/packages/jest-config/package.json
@@ -31,7 +31,7 @@
   "devDependencies": {
     "@types/babel__core": "^7.0.4",
     "@types/glob": "^7.1.1",
-    "@types/micromatch": "^3.1.0"
+    "@types/micromatch": "^4.0.0"
   },
   "engines": {
     "node": ">= 8.3"

--- a/packages/jest-core/package.json
+++ b/packages/jest-core/package.json
@@ -38,7 +38,7 @@
     "@jest/test-sequencer": "^24.9.0",
     "@types/exit": "^0.1.30",
     "@types/graceful-fs": "^4.1.2",
-    "@types/micromatch": "^3.1.0",
+    "@types/micromatch": "^4.0.0",
     "@types/rimraf": "^2.0.2"
   },
   "engines": {

--- a/packages/jest-haste-map/package.json
+++ b/packages/jest-haste-map/package.json
@@ -25,7 +25,7 @@
     "@types/anymatch": "^1.3.1",
     "@types/fb-watchman": "^2.0.0",
     "@types/graceful-fs": "^4.1.2",
-    "@types/micromatch": "^3.1.0",
+    "@types/micromatch": "^4.0.0",
     "@types/sane": "^2.0.0"
   },
   "optionalDependencies": {

--- a/packages/jest-message-util/package.json
+++ b/packages/jest-message-util/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@types/babel__code-frame": "^7.0.0",
-    "@types/micromatch": "^3.1.0"
+    "@types/micromatch": "^4.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest-transform/package.json
+++ b/packages/jest-transform/package.json
@@ -31,7 +31,7 @@
     "@types/convert-source-map": "^1.5.1",
     "@types/fast-json-stable-stringify": "^2.0.0",
     "@types/graceful-fs": "^4.1.2",
-    "@types/micromatch": "^3.1.0",
+    "@types/micromatch": "^4.0.0",
     "@types/write-file-atomic": "^3.0.0",
     "dedent": "^0.7.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2032,10 +2032,10 @@
   dependencies:
     "@types/node" "*"
 
-"@types/micromatch@^3.1.0":
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/@types/micromatch/-/micromatch-3.1.1.tgz#98eac88894da6606c2690624a9893a59c812d9fa"
-  integrity sha512-Wr5y4uv3r7JP4jEUqv7rZeYiMBGRHcbojDVsl11wq6gw1v/ZZQvJexd9rtvVx3EIVqw8dwtcRjSs8m2DV9qHjQ==
+"@types/micromatch@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@types/micromatch/-/micromatch-4.0.0.tgz#c57e0b11518c930465ce923f44342e1bb4bef309"
+  integrity sha512-bavSCssCRRlbUI639WG0Y30AOowkI5CdxyyrC5eVbsb0BJIbgS5ROfwlwDYHsOmgS59iYlre9sstIA5wfVNKBA==
   dependencies:
     "@types/braces" "*"
 


### PR DESCRIPTION
## Summary

`micromatchv4.+` has breaking changes. This update should help avoid runtime errors.

## Test plan

Green CI