### PR TITLE
Add concurrent mode capability to `jest-each` types

### DIFF
--- a/packages/jest-each/src/index.ts
+++ b/packages/jest-each/src/index.ts
@@ -15,15 +15,32 @@ const install = (
   table: Global.EachTable,
   ...data: Global.TemplateData
 ) => {
-  const test = (title: string, test: Global.EachTestFn, timeout?: number) =>
-    bind(g.test)(table, ...data)(title, test, timeout);
+  const test = (
+    title: string,
+    test: Global.EachTestFn<Global.TestFn>,
+    timeout?: number,
+  ) => bind(g.test)(table, ...data)(title, test, timeout);
   test.skip = bind(g.test.skip)(table, ...data);
   test.only = bind(g.test.only)(table, ...data);
 
-  const it = (title: string, test: Global.EachTestFn, timeout?: number) =>
-    bind(g.it)(table, ...data)(title, test, timeout);
+  const testConcurrent = (
+    title: string,
+    test: Global.EachTestFn<Global.ConcurrentTestFn>,
+    timeout?: number,
+  ) => bind(g.test.concurrent)(table, ...data)(title, test, timeout);
+
+  test.concurrent = testConcurrent;
+  testConcurrent.only = bind(g.test.concurrent.only)(table, ...data);
+  testConcurrent.skip = bind(g.test.concurrent.skip)(table, ...data);
+
+  const it = (
+    title: string,
+    test: Global.EachTestFn<Global.TestFn>,
+    timeout?: number,
+  ) => bind(g.it)(table, ...data)(title, test, timeout);
   it.skip = bind(g.it.skip)(table, ...data);
   it.only = bind(g.it.only)(table, ...data);
+  it.concurrent = testConcurrent;
 
   const xit = bind(g.xit)(table, ...data);
   const fit = bind(g.fit)(table, ...data);
@@ -31,7 +48,7 @@ const install = (
 
   const describe = (
     title: string,
-    suite: Global.EachTestFn,
+    suite: Global.EachTestFn<Global.BlockFn>,
     timeout?: number,
   ) => bind(g.describe, false)(table, ...data)(title, suite, timeout);
   describe.skip = bind(g.describe.skip, false)(table, ...data);

--- a/packages/jest-jasmine2/src/each.ts
+++ b/packages/jest-jasmine2/src/each.ts
@@ -24,4 +24,17 @@ export default (environment: JestEnvironment): void => {
     environment.global.fdescribe,
     false,
   );
+
+  environment.global.it.concurrent.each = bindEach(
+    environment.global.it.concurrent,
+    false,
+  )
+  environment.global.it.concurrent.only.each = bindEach(
+    environment.global.it.concurrent.only,
+    false,
+  )
+  environment.global.it.concurrent.skip.each = bindEach(
+    environment.global.it.concurrent.skip,
+    false,
+  )
 };

--- a/packages/jest-types/src/Global.ts
+++ b/packages/jest-types/src/Global.ts
@@ -10,6 +10,7 @@ import {CoverageMapData} from 'istanbul-lib-coverage';
 export type DoneFn = (reason?: string | Error) => void;
 export type TestName = string;
 export type TestFn = (done?: DoneFn) => Promise<any> | void | undefined;
+export type ConcurrentTestFn = () => Promise<any>;
 export type BlockFn = () => void;
 export type BlockName = string;
 
@@ -20,21 +21,24 @@ export type ArrayTable = Table | Row;
 export type TemplateTable = TemplateStringsArray;
 export type TemplateData = Array<unknown>;
 export type EachTable = ArrayTable | TemplateTable;
-export type EachTestFn = (
+
+export type TestCallback = BlockFn | TestFn | ConcurrentTestFn;
+
+export type EachTestFn<A extends TestCallback> = (
   ...args: Array<any>
-) => Promise<any> | void | undefined;
+) => ReturnType<A>;
 
 // TODO: Get rid of this at some point
 type Jasmine = {_DEFAULT_TIMEOUT_INTERVAL?: number; addMatchers: Function};
 
-type Each = (
+type Each<A extends TestCallback> = (
   table: EachTable,
   ...taggedTemplateData: Array<unknown>
-) => (title: string, test: EachTestFn, timeout?: number) => void;
+) => (title: string, test: EachTestFn<A>, timeout?: number) => void;
 
 export interface ItBase {
   (testName: TestName, fn: TestFn, timeout?: number): void;
-  each: Each;
+  each: Each<TestFn>;
 }
 
 export interface It extends ItBase {
@@ -44,7 +48,8 @@ export interface It extends ItBase {
 }
 
 export interface ItConcurrentBase {
-  (testName: string, testFn: () => Promise<any>, timeout?: number): void;
+  (testName: string, testFn: ConcurrentTestFn, timeout?: number): void;
+  each: Each<ConcurrentTestFn>;
 }
 
 export interface ItConcurrentExtended extends ItConcurrentBase {
@@ -58,7 +63,7 @@ export interface ItConcurrent extends It {
 
 export interface DescribeBase {
   (blockName: BlockName, blockFn: BlockFn): void;
-  each: Each;
+  each: Each<BlockFn>;
 }
 
 export interface Describe extends DescribeBase {


### PR DESCRIPTION
## Summary

This PR relates to #8985 and  #9326. 

It demos how to update `EachTestFn` to take a parameterised return type that is derived from the supported `TestCallback` function types - allowing `bind` in `jest-each` to work for concurrent tests

## Test plan

 - Missing unit test (should be trivial to add)
 - Missing integration tests (just needs some examples of concurrent being used)