### PR TITLE
jest-reporters: Use global coverage thresholds as high watermarks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - `[jest-get-type]` Add `BigInt` support. ([#8382](https://github.com/facebook/jest/pull/8382))
 - `[jest-matcher-utils]` Add `BigInt` support to `ensureNumbers` `ensureActualIsNumber`, `ensureExpectedIsNumber` ([#8382](https://github.com/facebook/jest/pull/8382))
 - `[jest-reporters]` Export utils for path formatting ([#9162](https://github.com/facebook/jest/pull/9162))
+- `[jest-reporters]` Provide global coverage thresholds as watermarks for istanbul ([#TODO](https://github.com/facebook/jest/pull/TODO))
 - `[jest-runner]` Warn if a worker had to be force exited ([#8206](https://github.com/facebook/jest/pull/8206))
 - `[jest-runtime]` [**BREAKING**] Do not export `ScriptTransformer` - it can be imported from `@jest/transform` instead ([#9256](https://github.com/facebook/jest/pull/9256))
 - `[jest-runtime]` Use `JestEnvironment.compileFunction` if available to avoid the module wrapper ([#9252](https://github.com/facebook/jest/pull/9252))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
 - `[jest-get-type]` Add `BigInt` support. ([#8382](https://github.com/facebook/jest/pull/8382))
 - `[jest-matcher-utils]` Add `BigInt` support to `ensureNumbers` `ensureActualIsNumber`, `ensureExpectedIsNumber` ([#8382](https://github.com/facebook/jest/pull/8382))
 - `[jest-reporters]` Export utils for path formatting ([#9162](https://github.com/facebook/jest/pull/9162))
-- `[jest-reporters]` Provide global coverage thresholds as watermarks for istanbul ([#TODO](https://github.com/facebook/jest/pull/TODO))
+- `[jest-reporters]` Provides global coverage thresholds as watermarks for istanbul ([#9416](https://github.com/facebook/jest/pull/9416))
 - `[jest-runner]` Warn if a worker had to be force exited ([#8206](https://github.com/facebook/jest/pull/8206))
 - `[jest-runtime]` [**BREAKING**] Do not export `ScriptTransformer` - it can be imported from `@jest/transform` instead ([#9256](https://github.com/facebook/jest/pull/9256))
 - `[jest-runtime]` Use `JestEnvironment.compileFunction` if available to avoid the module wrapper ([#9252](https://github.com/facebook/jest/pull/9252))

--- a/packages/jest-reporters/src/__tests__/coverage_reporter.test.js
+++ b/packages/jest-reporters/src/__tests__/coverage_reporter.test.js
@@ -8,6 +8,7 @@
 jest
   .mock('istanbul-lib-source-maps')
   .mock('istanbul-lib-report', () => ({
+    ...jest.requireActual('istanbul-lib-report'),
     createContext: jest.fn(),
     summarizers: {pkg: jest.fn(() => ({visit: jest.fn()}))},
   }))

--- a/packages/jest-reporters/src/__tests__/coverage_reporter.test.js
+++ b/packages/jest-reporters/src/__tests__/coverage_reporter.test.js
@@ -17,6 +17,7 @@ jest
 let libCoverage;
 let libSourceMaps;
 let CoverageReporter;
+let consoleError;
 
 import path from 'path';
 import mock from 'mock-fs';
@@ -40,11 +41,15 @@ beforeEach(() => {
     'relative_path_file.js': '',
   };
 
+  consoleError = console.error;
+  console.error = jest.fn();
+
   mock(fileTree);
 });
 
 afterEach(() => {
   mock.restore();
+  console.error = consoleError;
 });
 
 describe('onRunComplete', () => {

--- a/packages/jest-reporters/src/__tests__/coverage_reporter.test.js
+++ b/packages/jest-reporters/src/__tests__/coverage_reporter.test.js
@@ -17,7 +17,6 @@ jest
 let libCoverage;
 let libSourceMaps;
 let CoverageReporter;
-let consoleError;
 
 import path from 'path';
 import mock from 'mock-fs';
@@ -41,15 +40,11 @@ beforeEach(() => {
     'relative_path_file.js': '',
   };
 
-  consoleError = console.error;
-  console.error = jest.fn();
-
   mock(fileTree);
 });
 
 afterEach(() => {
   mock.restore();
-  console.error = consoleError;
 });
 
 describe('onRunComplete', () => {

--- a/packages/jest-reporters/src/__tests__/get_watermarks.test.js
+++ b/packages/jest-reporters/src/__tests__/get_watermarks.test.js
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+import getWatermarks from '../get_watermarks';
+
+describe('getWatermarks', () => {
+  test(`that watermarks use thresholds as upper target`, () => {
+    const watermarks = getWatermarks({
+      coverageThreshold: {
+        global: {
+          branches: 100,
+          functions: 100,
+          lines: 100,
+          statements: 100,
+        },
+      },
+    });
+
+    expect(watermarks).toEqual({
+      branches: [expect.any(Number), 100],
+      functions: [expect.any(Number), 100],
+      lines: [expect.any(Number), 100],
+      statements: [expect.any(Number), 100],
+    });
+  });
+
+  test(`that watermars are created always created`, () => {
+    const watermarks = getWatermarks({});
+
+    expect(watermarks).toEqual({
+      branches: [expect.any(Number), expect.any(Number)],
+      functions: [expect.any(Number), expect.any(Number)],
+      lines: [expect.any(Number), expect.any(Number)],
+      statements: [expect.any(Number), expect.any(Number)],
+    });
+  });
+});

--- a/packages/jest-reporters/src/__tests__/get_watermarks.test.ts
+++ b/packages/jest-reporters/src/__tests__/get_watermarks.test.ts
@@ -5,22 +5,23 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-'use strict';
-
 import getWatermarks from '../get_watermarks';
+import {makeGlobalConfig} from '../../../../TestUtils';
 
 describe('getWatermarks', () => {
   test(`that watermarks use thresholds as upper target`, () => {
-    const watermarks = getWatermarks({
-      coverageThreshold: {
-        global: {
-          branches: 100,
-          functions: 100,
-          lines: 100,
-          statements: 100,
+    const watermarks = getWatermarks(
+      makeGlobalConfig({
+        coverageThreshold: {
+          global: {
+            branches: 100,
+            functions: 100,
+            lines: 100,
+            statements: 100,
+          },
         },
-      },
-    });
+      }),
+    );
 
     expect(watermarks).toEqual({
       branches: [expect.any(Number), 100],
@@ -31,7 +32,7 @@ describe('getWatermarks', () => {
   });
 
   test(`that watermars are created always created`, () => {
-    const watermarks = getWatermarks({});
+    const watermarks = getWatermarks(makeGlobalConfig());
 
     expect(watermarks).toEqual({
       branches: [expect.any(Number), expect.any(Number)],

--- a/packages/jest-reporters/src/__tests__/get_watermarks.test.ts
+++ b/packages/jest-reporters/src/__tests__/get_watermarks.test.ts
@@ -31,7 +31,7 @@ describe('getWatermarks', () => {
     });
   });
 
-  test(`that watermars are created always created`, () => {
+  test(`that watermarks are created always created`, () => {
     const watermarks = getWatermarks(makeGlobalConfig());
 
     expect(watermarks).toEqual({

--- a/packages/jest-reporters/src/coverage_reporter.ts
+++ b/packages/jest-reporters/src/coverage_reporter.ts
@@ -27,6 +27,7 @@ import {RawSourceMap} from 'source-map';
 import {TransformResult} from '@jest/transform';
 import BaseReporter from './base_reporter';
 import {Context, CoverageReporterOptions, CoverageWorker, Test} from './types';
+import getWatermarks from './get_watermarks';
 
 // This is fixed in a newer versions of source-map, but our dependencies are still stuck on old versions
 interface FixedRawSourceMap extends Omit<RawSourceMap, 'version'> {
@@ -494,6 +495,7 @@ export default class CoverageReporter extends BaseReporter {
         // @ts-ignore
         coverageMap: map,
         dir: this._globalConfig.coverageDirectory,
+        watermarks: getWatermarks(this._globalConfig),
       });
 
       return {map, reportContext};
@@ -506,6 +508,7 @@ export default class CoverageReporter extends BaseReporter {
       dir: this._globalConfig.coverageDirectory,
       // @ts-ignore
       sourceFinder: this._sourceMapStore.sourceFinder,
+      watermarks: getWatermarks(this._globalConfig),
     });
 
     // @ts-ignore

--- a/packages/jest-reporters/src/get_watermarks.ts
+++ b/packages/jest-reporters/src/get_watermarks.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {Config} from '@jest/types';
+import istanbulReport = require('istanbul-lib-report');
+
+export default function getWatermarks(
+  config: Config.GlobalConfig,
+): istanbulReport.Watermarks {
+  const defaultWatermarks = istanbulReport.getDefaultWatermarks();
+
+  const {coverageThreshold} = config;
+
+  if (!coverageThreshold || !coverageThreshold.global) {
+    return defaultWatermarks;
+  }
+
+  const keys: Array<keyof Config.CoverageThresholdValue> = [
+    'branches',
+    'functions',
+    'lines',
+    'statements',
+  ];
+  return keys.reduce((watermarks, key) => {
+    const value = coverageThreshold.global[key];
+    if (value !== undefined) {
+      watermarks[key][1] = value;
+    }
+
+    return watermarks;
+  }, defaultWatermarks);
+}


### PR DESCRIPTION
<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

When Istanbul generates the some reports (like html & lcov) it uses watermarks to to provide visual feedback with colors. The default watermarks are 50% and 80%. Which in the html reports means that coverage under 50% is red and coverage over 80% is green. But we have a coverage threshold of 100%, so using the report to find any file with coverage between 80% and 100% can be quite difficult as @nemoDreamer describes here: [#6578](https://github.com/facebook/jest/issues/6578). 

My solution is to provide istanbul with watermarks where the high watermarks are set to the global coverage threshold of each coverage category (branches, functions, lines, and statements)

## Test plan

I added unit tests for my use case and for not having any global coverage threshold and tested my changes using `yarn link`

![coverage](https://user-images.githubusercontent.com/3541952/72515871-fb20ee80-3850-11ea-8f7a-8896d11723b1.png)
