### PR TITLE
jest-snapshot: Fix regression in diff for jest-snapshot-serializer-raw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,6 @@
 - `[jest-snapshot]` [**BREAKING**] Distinguish empty string from internal snapshot not written ([#8898](https://github.com/facebook/jest/pull/8898))
 - `[jest-snapshot]` [**BREAKING**] Remove `report` method and throw matcher errors ([#9049](https://github.com/facebook/jest/pull/9049))
 - `[jest-snapshot]` Omit irrelevant `received` properties when property matchers fail ([#9198](https://github.com/facebook/jest/pull/9198))
-- `[jest-snapshot]` Fix regression in diff for `jest-snapshot-serializer-raw` ([#9419](https://github.com/facebook/jest/pull/9419))
 - `[jest-transform]` Properly cache transformed files across tests ([#8890](https://github.com/facebook/jest/pull/8890))
 - `[jest-transform]` Don't fail the test suite when a generated source map is invalid ([#9058](https://github.com/facebook/jest/pull/9058))
 - `[jest-types]` [**BREAKING**] Use less `null | undefined` in config types ([#9200](https://github.com/facebook/jest/pull/9200))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@
 - `[jest-snapshot]` [**BREAKING**] Distinguish empty string from internal snapshot not written ([#8898](https://github.com/facebook/jest/pull/8898))
 - `[jest-snapshot]` [**BREAKING**] Remove `report` method and throw matcher errors ([#9049](https://github.com/facebook/jest/pull/9049))
 - `[jest-snapshot]` Omit irrelevant `received` properties when property matchers fail ([#9198](https://github.com/facebook/jest/pull/9198))
+- `[jest-snapshot]` Fix regression in diff for `jest-snapshot-serializer-raw` ([#9419](https://github.com/facebook/jest/pull/9419))
 - `[jest-transform]` Properly cache transformed files across tests ([#8890](https://github.com/facebook/jest/pull/8890))
 - `[jest-transform]` Don't fail the test suite when a generated source map is invalid ([#9058](https://github.com/facebook/jest/pull/9058))
 - `[jest-types]` [**BREAKING**] Use less `null | undefined` in config types ([#9200](https://github.com/facebook/jest/pull/9200))

--- a/packages/jest-snapshot/src/printSnapshot.ts
+++ b/packages/jest-snapshot/src/printSnapshot.ts
@@ -311,12 +311,18 @@ export const printSnapshotAndReceived = (
     const aLines2 = a.split('\n');
     const bLines2 = b.split('\n');
 
-    const aLines0 = dedentLines(aLines2);
+    // Fall through to fix a regression for custom serializers
+    // like jest-snapshot-serializer-raw that ignore the indent option.
+    const b0 = serialize(received, 0);
+    if (b0 !== b) {
+      const aLines0 = dedentLines(aLines2);
 
-    if (aLines0 !== null) {
-      // Compare lines without indentation.
-      const bLines0 = serialize(received, 0).split('\n');
-      return diffLinesUnified2(aLines2, bLines2, aLines0, bLines0, options);
+      if (aLines0 !== null) {
+        // Compare lines without indentation.
+        const bLines0 = b0.split('\n');
+
+        return diffLinesUnified2(aLines2, bLines2, aLines0, bLines0, options);
+      }
     }
 
     // Fall back because:


### PR DESCRIPTION
## Summary

Found by @SimenB in a diff for `e2e/__tests__/__snapshots__/showConfig.test.ts.snap`

Ouch, I assumed that all snapshot serializers support the `indent` option.

But `jest-snapshot-serializer-raw` does not, because it deals with strings.

Because the snapshot is JSON serialization of an object, it can be dedented.

Therefore, the expected value has no indentation and the received value has default indentation. Only the opening and closing braces are in common.

As a future chore, add a minimal serializer to `test-utils` which does not use the object-with-symbol-key-idiom, for tests that do not need to distinguish top-level strings from lower-level strings (for example, array items, object keys or values). That will support substring diffs for Jest test files that serialize only strings (like the example e2e test of CLI output).

## Test plan

Verified locally for the example of adding `"moduleWrapper": true,` property:

1. Jest 24.9.0 reports `+ Received  + 1`
2. Without fix, Jest master reports `- Snapshot  - 122   + Received  + 123`
3. With fix, Jest master reports `+ Received  + 1`