### PR TITLE
Document testTimeout configuration option

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -1083,6 +1083,12 @@ class CustomSequencer extends Sequencer {
 module.exports = CustomSequencer;
 ```
 
+### `testTimeout` [number]
+
+Default: `5000`
+
+Default timeout of a test in milliseconds.
+
 ### `testURL` [string]
 
 Default: `http://localhost`

--- a/website/versioned_docs/version-25.1/Configuration.md
+++ b/website/versioned_docs/version-25.1/Configuration.md
@@ -1084,6 +1084,12 @@ class CustomSequencer extends Sequencer {
 module.exports = CustomSequencer;
 ```
 
+### `testTimeout` [number]
+
+Default: `5000`
+
+Default timeout of a test in milliseconds.
+
 ### `testURL` [string]
 
 Default: `http://localhost`


### PR DESCRIPTION
The `testTimeout` configuration option was documented in the CLI docs but not the configuration docs so I wasn't completely sure if it was available to use in my package.json configuration, so I needed to try it and also dig into the jest source code to confirm. This simply documents the option in the config docs as well.

Fixes #9448