### PR TITLE
chore: downgrade jest-snapshot#semver to v6 to support node 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@
 
 ### Fixes
 
+- `[jest-snapshot]` Downgrade semver to v6 to support node 8 ([#9451](https://github.com/facebook/jest/pull/9451))
+
 ### Chore & Maintenance
 
 - `[website]` Update pictures of reports when matchers fail ([#9214](https://github.com/facebook/jest/pull/9214))
-- `[jest-snapshot]` downgrade semver to v6 to support node 8 ([#9451](https://github.com/facebook/jest/pull/9451))
 
 ### Performance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Chore & Maintenance
 
 - `[website]` Update pictures of reports when matchers fail ([#9214](https://github.com/facebook/jest/pull/9214))
+- `[jest-snapshot]` downgrade semver to v6 to support node 8 ([#9451](https://github.com/facebook/jest/pull/9451))
 
 ### Performance
 

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "lint:prettier": "yarn --silent lint:prettier:ci --fix",
     "lint:prettier:ci": "prettylint '**/*.{md,yml,yaml}' --ignore-path .gitignore",
     "postinstall": "opencollective postinstall && yarn build",
-    "install-no-ts-build": "node scripts/remove-postinstall && yarn --no-progress --frozen-lockfile --ignore-engines && node scripts/build",
+    "install-no-ts-build": "node scripts/remove-postinstall && yarn --no-progress --frozen-lockfile && node scripts/build",
     "publish": "yarn build-clean && yarn build && lerna publish --silent",
     "test-ci-es5-build-in-browser": "karma start --single-run",
     "test-ci": "yarn jest-coverage --color -i --config jest.config.ci.js && yarn test-leak && node scripts/mapCoverage.js && codecov",

--- a/packages/jest-snapshot/package.json
+++ b/packages/jest-snapshot/package.json
@@ -22,7 +22,7 @@
     "mkdirp": "^0.5.1",
     "natural-compare": "^1.4.0",
     "pretty-format": "^25.1.0",
-    "semver": "^7.1.1"
+    "semver": "^6.3.0"
   },
   "devDependencies": {
     "@babel/traverse": "^7.3.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12798,11 +12798,6 @@ semver@^6.0.0, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.1.1:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.1.1.tgz#29104598a197d6cbe4733eeecbe968f7b43a9667"
-  integrity sha512-WfuG+fl6eh3eZ2qAf6goB7nhiCd7NPXhmyFxigB/TOkQyeLP8w8GsVehvtGNtnNmyboz4TgeK40B1Kbql/8c5A==
-
 send@0.17.1:
   version "0.17.1"
   resolved "https://registry.yarnpkg.com/send/-/send-0.17.1.tgz#c1d8b059f7900f7466dd4938bdc44e11ddb376c8"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Downgrades the semver dependency in `jest-snapshot` to a version that supports node 8.

Fixes #9450 

## Test plan

N/A
