### PR TITLE
docs: Warn about node-notifier caveat on windows systems.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Chore & Maintenance
 
 - `[website]` Update pictures of reports when matchers fail ([#9214](https://github.com/facebook/jest/pull/9214))
+- `[docs]` Warn about unexpected behavior / bug of node-notifier when using the `notify` options.
 
 ### Performance
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -506,6 +506,8 @@ Default: `false`
 
 Activates notifications for test results.
 
+**Beware:** Jest uses [node-notifier](https://github.com/mikaelbr/node-notifier) to display desktop notifications. On Windows, it creates a new start menu entry on the first use and not display the notification. Notifications will be properly displayed on subsequent runs
+
 ### `notifyMode` [string]
 
 Default: `failure-change`

--- a/website/versioned_docs/version-25.1/CLI.md
+++ b/website/versioned_docs/version-25.1/CLI.md
@@ -237,6 +237,8 @@ Disables stack trace in test results output.
 
 Activates notifications for test results. Good for when you don't want your consciousness to be able to focus on anything except JavaScript testing.
 
+**Beware:** Jest uses [node-notifier](https://github.com/mikaelbr/node-notifier) to display desktop notifications. On Windows, it creates a new start menu entry on the first use and not display the notification. Notifications will be properly displayed on subsequent runs
+
 ### `--onlyChanged`
 
 Alias: `-o`. Attempts to identify which tests to run based on which files have changed in the current repository. Only works if you're running tests in a git/hg repository at the moment and requires a static dependency graph (ie. no dynamic requires).


### PR DESCRIPTION
fixes #9452
## Summary

Fixes the issue #9452 by informing the user of the unexpected behavior of node-notifier when using ```--notify``` CLI param or the ```notify``` config option.

## Test plan

Green CI. Just a documentation change.
