### PR TITLE
chore: remove unused deps from @jest/reporters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Chore & Maintenance
 
+- `[@jest/reporters]` Remove unused dependencies and type exports ([#9462](https://github.com/facebook/jest/pull/9462))
 - `[website]` Update pictures of reports when matchers fail ([#9214](https://github.com/facebook/jest/pull/9214))
 
 ### Performance

--- a/packages/jest-reporters/package.json
+++ b/packages/jest-reporters/package.json
@@ -7,7 +7,6 @@
   "dependencies": {
     "@bcoe/v8-coverage": "^0.2.3",
     "@jest/console": "^25.1.0",
-    "@jest/environment": "^25.1.0",
     "@jest/test-result": "^25.1.0",
     "@jest/transform": "^25.1.0",
     "@jest/types": "^25.1.0",
@@ -22,7 +21,6 @@
     "istanbul-reports": "^3.0.0",
     "jest-haste-map": "^25.1.0",
     "jest-resolve": "^25.1.0",
-    "jest-runtime": "^25.1.0",
     "jest-util": "^25.1.0",
     "jest-worker": "^25.1.0",
     "slash": "^3.0.0",

--- a/packages/jest-reporters/src/types.ts
+++ b/packages/jest-reporters/src/types.ts
@@ -11,10 +11,8 @@ import {
   SerializableError,
   TestResult,
 } from '@jest/test-result';
-import {JestEnvironment as Environment} from '@jest/environment';
 import {FS as HasteFS, ModuleMap} from 'jest-haste-map';
 import HasteResolver = require('jest-resolve');
-import Runtime = require('jest-runtime');
 import {worker} from './coverage_worker';
 
 export type ReporterOnStartOptions = {
@@ -76,20 +74,8 @@ export type SummaryOptions = {
   width?: number;
 };
 
-export type TestFramework = (
-  globalConfig: Config.GlobalConfig,
-  config: Config.ProjectConfig,
-  environment: Environment,
-  runtime: Runtime,
-  testPath: string,
-) => Promise<TestResult>;
-
 export type TestRunnerOptions = {
   serial: boolean;
-};
-
-export type TestRunnerContext = {
-  changedFiles?: Set<Config.Path>;
 };
 
 export type TestRunData = Array<{

--- a/packages/jest-reporters/tsconfig.json
+++ b/packages/jest-reporters/tsconfig.json
@@ -6,10 +6,8 @@
   },
   "references": [
     {"path": "../jest-console"},
-    {"path": "../jest-environment"},
     {"path": "../jest-haste-map"},
     {"path": "../jest-resolve"},
-    {"path": "../jest-runtime"},
     {"path": "../jest-test-result"},
     {"path": "../jest-types"},
     {"path": "../jest-util"},


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Noticed when I was messing with the reporters. Technically breaking for TS users if they import these types, but meh. They should import `TestFramework` from https://github.com/facebook/jest/blob/eee81208163d2b64171a6b7eec13a8a1aebfc901/packages/jest-runner/src/types.ts#L40-L46

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Green CI

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
