### PR TITLE
Remove bash syntax highlighting from GitHub issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -32,6 +32,6 @@ Run npx envinfo --preset jest
 Paste the results here:
 -->
 
-```bash
+```
 
 ```


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

The output of envinfo is not executable bash script, so the highlighting won't do what was probably expected by the author. This PR removes highlighting.

## Test plan

before:

```bash
$ npx envinfo --preset jest
npx: installed 1 in 1.775s

  System:
    OS: macOS 10.15.2
    CPU: (4) x64 Intel(R) Core(TM) i7-7660U CPU @ 2.50GHz
  Binaries:
    Node: 10.18.0 - ~/.nvm/versions/node/v10.18.0/bin/node
    Yarn: 1.21.1 - /usr/local/bin/yarn
    npm: 6.13.6 - ~/.nvm/versions/node/v10.18.0/bin/npm
  npmPackages:
    jest: ^25.1.0 => 25.1.0
```

after:

```
$ npx envinfo --preset jest
npx: installed 1 in 1.775s

  System:
    OS: macOS 10.15.2
    CPU: (4) x64 Intel(R) Core(TM) i7-7660U CPU @ 2.50GHz
  Binaries:
    Node: 10.18.0 - ~/.nvm/versions/node/v10.18.0/bin/node
    Yarn: 1.21.1 - /usr/local/bin/yarn
    npm: 6.13.6 - ~/.nvm/versions/node/v10.18.0/bin/npm
  npmPackages:
    jest: ^25.1.0 => 25.1.0
```