### PR TITLE
Remove bash syntax highlighting from GitHub issue template (regression)

### DIFF
--- a/.github/ISSUE_TEMPLATE/regression.md
+++ b/.github/ISSUE_TEMPLATE/regression.md
@@ -34,6 +34,6 @@ Issues without a reproduction link are likely to stall.
 
 Paste the results here:
 
-```bash
+```
 
 ```


### PR DESCRIPTION
## Summary

Same as #9474 but for the regression template.
Sorry, should've done both in one PR.