### PR TITLE
fix: export `OldPlugin` from pretty-format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `[jest-snapshot]` Downgrade semver to v6 to support node 8 ([#9451](https://github.com/facebook/jest/pull/9451))
 - `[jest-transform]` Correct sourcemap behavior for transformed and instrumented code ([#9460](https://github.com/facebook/jest/pull/9460))
+- `[pretty-format]` Export `OldPlugin` type ([#9491](https://github.com/facebook/jest/pull/9491))
 
 ### Chore & Maintenance
 

--- a/packages/pretty-format/src/index.ts
+++ b/packages/pretty-format/src/index.ts
@@ -527,12 +527,13 @@ prettyFormat.plugins = {
   ReactTestComponent,
 };
 
-/* eslint-disable-next-line no-redeclare */
+// eslint-disable-next-line no-redeclare
 namespace prettyFormat {
   export type Colors = PrettyFormat.Colors;
   export type Config = PrettyFormat.Config;
   export type Options = PrettyFormat.Options;
   export type OptionsReceived = PrettyFormat.OptionsReceived;
+  export type OldPlugin = PrettyFormat.OldPlugin;
   export type NewPlugin = PrettyFormat.NewPlugin;
   export type Plugin = PrettyFormat.Plugin;
   export type Plugins = PrettyFormat.Plugins;

--- a/packages/pretty-format/src/types.ts
+++ b/packages/pretty-format/src/types.ts
@@ -101,7 +101,7 @@ type PluginOptions = {
   spacing: string;
 };
 
-type OldPlugin = {
+export type OldPlugin = {
   print: (
     val: any,
     print: Print,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Otherwise, people cannot specify that the `print` function is of the correct shape, as just `Plugin` can refer to both

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Not much... :P It _works_

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
