### PR TITLE
Treat setupFilesAfterEnv like setupFiles when normalizing configs against presets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- `[jest-config]` Treat `setupFilesAfterEnv` like `setupFiles` when normalizing configs against presets ([#9495](https://github.com/facebook/jest/pull/9495))
 - `[jest-snapshot]` Downgrade semver to v6 to support node 8 ([#9451](https://github.com/facebook/jest/pull/9451))
 - `[jest-transform]` Correct sourcemap behavior for transformed and instrumented code ([#9460](https://github.com/facebook/jest/pull/9460))
 - `[pretty-format]` Export `OldPlugin` type ([#9491](https://github.com/facebook/jest/pull/9491))

--- a/packages/jest-config/src/__tests__/normalize.test.js
+++ b/packages/jest-config/src/__tests__/normalize.test.js
@@ -1137,6 +1137,7 @@ describe('preset', () => {
         preset: 'react-native',
         rootDir: '/root/path/foo',
         setupFiles: ['a'],
+        setupFilesAfterEnv: ['a'],
         transform: {a: 'a'},
       },
       {},
@@ -1148,6 +1149,10 @@ describe('preset', () => {
     ]);
     expect(options.modulePathIgnorePatterns).toEqual(['b', 'a']);
     expect(options.setupFiles.sort()).toEqual([
+      '/node_modules/a',
+      '/node_modules/b',
+    ]);
+    expect(options.setupFilesAfterEnv.sort()).toEqual([
       '/node_modules/a',
       '/node_modules/b',
     ]);
@@ -1278,45 +1283,48 @@ describe('preset with globals', () => {
   });
 });
 
-describe('preset without setupFiles', () => {
-  let Resolver;
-  beforeEach(() => {
-    Resolver = require('jest-resolve');
-    Resolver.findNodeModule = jest.fn(
-      name => path.sep + 'node_modules' + path.sep + name,
-    );
-  });
+describe.each(['setupFiles', 'setupFilesAfterEnv'])(
+  'preset without %s',
+  configKey => {
+    let Resolver;
+    beforeEach(() => {
+      Resolver = require('jest-resolve');
+      Resolver.findNodeModule = jest.fn(
+        name => path.sep + 'node_modules' + path.sep + name,
+      );
+    });
 
-  beforeAll(() => {
-    jest.doMock(
-      '/node_modules/react-foo/jest-preset',
-      () => ({
-        moduleNameMapper: {b: 'b'},
-        modulePathIgnorePatterns: ['b'],
-      }),
-      {virtual: true},
-    );
-  });
+    beforeAll(() => {
+      jest.doMock(
+        '/node_modules/react-foo/jest-preset',
+        () => ({
+          moduleNameMapper: {b: 'b'},
+          modulePathIgnorePatterns: ['b'],
+        }),
+        {virtual: true},
+      );
+    });
 
-  afterAll(() => {
-    jest.dontMock('/node_modules/react-foo/jest-preset');
-  });
+    afterAll(() => {
+      jest.dontMock('/node_modules/react-foo/jest-preset');
+    });
 
-  it('should normalize setupFiles correctly', () => {
-    const {options} = normalize(
-      {
-        preset: 'react-foo',
-        rootDir: '/root/path/foo',
-        setupFiles: ['a'],
-      },
-      {},
-    );
+    it(`should normalize ${configKey} correctly`, () => {
+      const {options} = normalize(
+        {
+          [configKey]: ['a'],
+          preset: 'react-foo',
+          rootDir: '/root/path/foo',
+        },
+        {},
+      );
 
-    expect(options).toEqual(
-      expect.objectContaining({setupFiles: ['/node_modules/a']}),
-    );
-  });
-});
+      expect(options).toEqual(
+        expect.objectContaining({[configKey]: ['/node_modules/a']}),
+      );
+    });
+  },
+);
 
 describe('runner', () => {
   let Resolver;

--- a/packages/jest-config/src/normalize.ts
+++ b/packages/jest-config/src/normalize.ts
@@ -156,6 +156,11 @@ const setupPreset = (
   if (options.setupFiles) {
     options.setupFiles = (preset.setupFiles || []).concat(options.setupFiles);
   }
+  if (options.setupFilesAfterEnv) {
+    options.setupFilesAfterEnv = (preset.setupFilesAfterEnv || []).concat(
+      options.setupFilesAfterEnv,
+    );
+  }
   if (options.modulePathIgnorePatterns && preset.modulePathIgnorePatterns) {
     options.modulePathIgnorePatterns = preset.modulePathIgnorePatterns.concat(
       options.modulePathIgnorePatterns,


### PR DESCRIPTION
The value of `setupFiles` from a local Jest config is concatenated to the value of `setupFiles` from a preset when the local Jest config specifies `preset` and `setupFiles`. The same should be true for `setupFilesAfterEnv`. Without this change, if the local Jest config wants to take advantage of the `setupFilesAfterEnv` files from the preset, it has to redeclare them:

```js
// jest-preset-foo
module.exports = {
  setupFilesAfterEnv: ['a'],
};

// local jest.config.js
module.exports = {
  preset: 'jest-preset-foo',
  setupFilesAfterEnv: ['b'],
};
```

Before:
Value of `setupFilesAfterEnv` = `['b']`

After:
Value of `setupFilesAfterEnv` = `['a', 'b']`



