### PR TITLE
Add `failureDetails` property to circus test results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Features
 
+- `[jest-circus, jest-jasmine2]` Include `failureDetails` property in test results ([#9496](https://github.com/facebook/jest/pull/9496))
+
 ### Fixes
 
 ### Chore & Maintenance

--- a/e2e/__tests__/failureDetailsProperty.test.ts
+++ b/e2e/__tests__/failureDetailsProperty.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {isJestCircusRun} from '@jest/test-utils';
+import runJest from '../runJest';
+
+const removeStackTraces = (stdout: string) =>
+  stdout.replace(
+    /at (new Promise \(<anonymous>\)|.+:\d+:\d+\)?)/g,
+    'at <stacktrace>',
+  );
+
+test('that the failureDetails property is set', () => {
+  const {stdout, stderr} = runJest('failureDetails-property', [
+    'tests.test.js',
+  ]);
+
+  // safety check: if the reporter errors it'll show up here
+  expect(stderr).toStrictEqual('');
+
+  const output = JSON.parse(removeStackTraces(stdout));
+
+  if (isJestCircusRun()) {
+    expect(output).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          Object {
+            "matcherResult": Object {
+              "actual": true,
+              "expected": false,
+              "name": "toBe",
+              "pass": false,
+            },
+          },
+        ],
+        Array [
+          Object {
+            "matcherResult": Object {
+              "actual": true,
+              "expected": false,
+              "name": "toBe",
+              "pass": false,
+            },
+          },
+        ],
+        Array [
+          Object {
+            "matcherResult": Object {
+              "actual": "Object {
+        \\"p1\\": \\"hello\\",
+        \\"p2\\": \\"world\\",
+      }",
+              "expected": "Object {
+        \\"p1\\": \\"hello\\",
+        \\"p2\\": \\"sunshine\\",
+      }",
+              "name": "toMatchInlineSnapshot",
+              "pass": false,
+            },
+          },
+        ],
+        Array [
+          Object {},
+        ],
+        Array [
+          Object {
+            "message": "expect(received).rejects.toThrowError()
+
+      Received promise resolved instead of rejected
+      Resolved to value: 1",
+          },
+        ],
+      ]
+    `);
+  } else {
+    expect(output).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          Object {
+            "actual": "",
+            "error": Object {
+              "matcherResult": Object {
+                "actual": true,
+                "expected": false,
+                "name": "toBe",
+                "pass": false,
+              },
+            },
+            "expected": "",
+            "matcherName": "",
+            "message": "Error: expect(received).toBe(expected) // Object.is equality
+
+      Expected: false
+      Received: true",
+            "passed": false,
+            "stack": "Error: expect(received).toBe(expected) // Object.is equality
+
+      Expected: false
+      Received: true
+          at <stacktrace>",
+          },
+        ],
+        Array [
+          Object {
+            "actual": "",
+            "error": Object {
+              "matcherResult": Object {
+                "actual": true,
+                "expected": false,
+                "name": "toBe",
+                "pass": false,
+              },
+            },
+            "expected": "",
+            "matcherName": "",
+            "message": "Error: expect(received).toBe(expected) // Object.is equality
+
+      Expected: false
+      Received: true",
+            "passed": false,
+            "stack": "Error: expect(received).toBe(expected) // Object.is equality
+
+      Expected: false
+      Received: true
+          at <stacktrace>",
+          },
+        ],
+        Array [
+          Object {
+            "actual": "",
+            "error": Object {
+              "matcherResult": Object {
+                "actual": "Object {
+        \\"p1\\": \\"hello\\",
+        \\"p2\\": \\"world\\",
+      }",
+                "expected": "Object {
+        \\"p1\\": \\"hello\\",
+        \\"p2\\": \\"sunshine\\",
+      }",
+                "name": "toMatchInlineSnapshot",
+                "pass": false,
+              },
+            },
+            "expected": "",
+            "matcherName": "",
+            "message": "expect(received).toMatchInlineSnapshot(snapshot)
+
+      Snapshot name: \`my test a snapshot failure 1\`
+
+      - Snapshot  - 1
+      + Received  + 1
+
+        Object {
+          \\"p1\\": \\"hello\\",
+      -   \\"p2\\": \\"sunshine\\",
+      +   \\"p2\\": \\"world\\",
+        }",
+            "passed": false,
+            "stack": "Error: expect(received).toMatchInlineSnapshot(snapshot)
+
+      Snapshot name: \`my test a snapshot failure 1\`
+
+      - Snapshot  - 1
+      + Received  + 1
+
+        Object {
+          \\"p1\\": \\"hello\\",
+      -   \\"p2\\": \\"sunshine\\",
+      +   \\"p2\\": \\"world\\",
+        }
+          at <stacktrace>",
+          },
+        ],
+        Array [
+          Object {
+            "actual": "",
+            "error": Object {},
+            "expected": "",
+            "matcherName": "",
+            "message": "Error",
+            "passed": false,
+            "stack": "Error: 
+          at <stacktrace>",
+          },
+        ],
+        Array [
+          Object {
+            "actual": "",
+            "error": Object {
+              "message": "expect(received).rejects.toThrowError()
+
+      Received promise resolved instead of rejected
+      Resolved to value: 1",
+            },
+            "expected": "",
+            "matcherName": "",
+            "message": "Error: expect(received).rejects.toThrowError()
+
+      Received promise resolved instead of rejected
+      Resolved to value: 1",
+            "passed": false,
+            "stack": "Error: expect(received).rejects.toThrowError()
+
+      Received promise resolved instead of rejected
+      Resolved to value: 1
+          at <stacktrace>",
+          },
+        ],
+      ]
+    `);
+  }
+});

--- a/e2e/failureDetails-property/__tests__/tests.test.js
+++ b/e2e/failureDetails-property/__tests__/tests.test.js
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+'use strict';
+
+describe('my test', () => {
+  test('it passes', () => {
+    expect(true).toBe(false);
+  });
+
+  it('fails :(', () => {
+    expect(true).toBe(false);
+  });
+
+  test('a snapshot failure', () => {
+    expect({
+      p1: 'hello',
+      p2: 'world',
+    }).toMatchInlineSnapshot(`
+      Object {
+        "p1": "hello",
+        "p2": "sunshine",
+      }
+    `);
+  });
+});
+
+it('throws!', () => {
+  throw new Error();
+});
+
+test('promise rejection', async () => {
+  await expect(Promise.resolve(1)).rejects.toThrowError();
+});

--- a/e2e/failureDetails-property/myreporter.js
+++ b/e2e/failureDetails-property/myreporter.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+class MyCustomReporter {
+  onRunComplete(contexts, results) {
+    console.log(
+      JSON.stringify(
+        results.testResults[0].testResults.map(f => f.failureDetails),
+        null,
+        2,
+      ),
+    );
+  }
+}
+
+module.exports = MyCustomReporter;

--- a/e2e/failureDetails-property/package.json
+++ b/e2e/failureDetails-property/package.json
@@ -1,0 +1,8 @@
+{
+  "jest": {
+    "testEnvironment": "node",
+    "reporters": [
+      "<rootDir>/myreporter.js"
+    ]
+  }
+}

--- a/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapterInit.ts
+++ b/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapterInit.ts
@@ -193,6 +193,7 @@ export const runAndTransformResultsToJestFormat = async ({
       return {
         ancestorTitles,
         duration: testResult.duration,
+        failureDetails: testResult.errorsDetailed,
         failureMessages: testResult.errors,
         fullName: title
           ? ancestorTitles.concat(title).join(' ')

--- a/packages/jest-circus/src/utils.ts
+++ b/packages/jest-circus/src/utils.ts
@@ -316,6 +316,7 @@ export const makeSingleTestResult = (
   return {
     duration: test.duration,
     errors: test.errors.map(_formatError),
+    errorsDetailed: test.errors,
     invocations: test.invocations,
     location,
     status,
@@ -433,6 +434,7 @@ export const parseSingleTestResult = (
   return {
     ancestorTitles,
     duration: testResult.duration,
+    failureDetails: testResult.errorsDetailed,
     failureMessages: Array.from(testResult.errors),
     fullName: title
       ? ancestorTitles.concat(title).join(' ')

--- a/packages/jest-circus/src/utils.ts
+++ b/packages/jest-circus/src/utils.ts
@@ -280,7 +280,7 @@ export const makeRunResult = (
   unhandledErrors: Array<Error>,
 ): Circus.RunResult => ({
   testResults: makeTestResults(describeBlock),
-  unhandledErrors: unhandledErrors.map(_formatError),
+  unhandledErrors: unhandledErrors.map(_getError).map(getErrorStack),
 });
 
 export const makeSingleTestResult = (
@@ -313,10 +313,12 @@ export const makeSingleTestResult = (
     }
   }
 
+  const errorsDetailed = test.errors.map(_getError);
+
   return {
     duration: test.duration,
-    errors: test.errors.map(_formatError),
-    errorsDetailed: test.errors.map(_getError),
+    errors: errorsDetailed.map(getErrorStack),
+    errorsDetailed,
     invocations: test.invocations,
     location,
     status,
@@ -381,13 +383,7 @@ const _getError = (
   return asyncError;
 };
 
-function _formatError(
-  errors?: Circus.Exception | [Circus.Exception | undefined, Circus.Exception],
-): string {
-  const error = _getError(errors);
-
-  return error.stack || error.message;
-}
+const getErrorStack = (error: Error): string => error.stack || error.message;
 
 export const addErrorToEachTestUnderDescribe = (
   describeBlock: Circus.DescribeBlock,

--- a/packages/jest-jasmine2/src/reporter.ts
+++ b/packages/jest-jasmine2/src/reporter.ts
@@ -141,6 +141,7 @@ export default class Jasmine2Reporter implements Reporter {
     const results: AssertionResult = {
       ancestorTitles,
       duration,
+      failureDetails: [],
       failureMessages: [],
       fullName: specResult.fullName,
       location,

--- a/packages/jest-jasmine2/src/reporter.ts
+++ b/packages/jest-jasmine2/src/reporter.ts
@@ -156,6 +156,7 @@ export default class Jasmine2Reporter implements Reporter {
           ? this._addMissingMessageToStack(failed.stack, failed.message)
           : failed.message || '';
       results.failureMessages.push(message);
+      results.failureDetails.push(failed);
     });
 
     return results;

--- a/packages/jest-types/src/Circus.ts
+++ b/packages/jest-types/src/Circus.ts
@@ -158,10 +158,18 @@ export type AsyncEvent =
       name: 'teardown';
     };
 
+export type MatcherResults = {
+  actual: unknown;
+  expected: unknown;
+  name: string;
+  pass: boolean;
+};
+
 export type TestStatus = 'skip' | 'done' | 'todo';
 export type TestResult = {
   duration?: number | null;
   errors: Array<FormattedError>;
+  errorsDetailed: Array<MatcherResults | unknown>;
   invocations: number;
   status: TestStatus;
   location?: {column: number; line: number} | null;

--- a/packages/jest-types/src/TestResult.ts
+++ b/packages/jest-types/src/TestResult.ts
@@ -18,6 +18,7 @@ type Callsite = {
 export type AssertionResult = {
   ancestorTitles: Array<string>;
   duration?: Milliseconds | null;
+  failureDetails: Array<unknown>;
   failureMessages: Array<string>;
   fullName: string;
   invocations?: number;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This is a first pass run at the second part of #8840

I used this to get the details:

```
class MyCustomReporter {
  onRunComplete(contexts, results) {
    console.log('Custom reporter output:');
    console.log(
      results.testResults[0].testResults.map(r =>
        r.failureDetails.filter(d => !!d).map(d => d.matcherResult)
      )
    );
  }
}

module.exports = MyCustomReporter;
```

This seems to be working nice, but the actual data type is interesting:

![image](https://user-images.githubusercontent.com/3151613/73601792-9abddb00-45cc-11ea-811d-87122ec2af52.png)

It's an array of what seems to be sometimes an array inside another array with just a stracktrace, sometimes it's got matcherResult - I'm sure some of it has good reason (i.e similar to why eslint takes an array of configurations for a rule rather than an object), but I imagine it'd make things easier for @segrey if we could ensure even a little bit of structure.

In saying that, I also would imagine there's only so much jest can do, since it's ultimately on the reporters to report their results.

The matchers results are definitely there:
![image](https://user-images.githubusercontent.com/3151613/73601786-61856b00-45cc-11ea-92b4-f442c7a5a4e3.png)

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Probably to have a custom reporter that expects the results from circus to include the `failureDetails` property.