### PR TITLE
Fix diff highlight of symbol-keyed object.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixes
 
+- `[jest-matcher-utils]` Fix diff highlight of symbol-keyed object. ([#9499](https://github.com/facebook/jest/pull/9499))
 - `[jest-snapshot]` Downgrade semver to v6 to support node 8 ([#9451](https://github.com/facebook/jest/pull/9451))
 - `[jest-transform]` Correct sourcemap behavior for transformed and instrumented code ([#9460](https://github.com/facebook/jest/pull/9460))
 - `[pretty-format]` Export `OldPlugin` type ([#9491](https://github.com/facebook/jest/pull/9491))

--- a/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -2155,6 +2155,19 @@ Expected: <g>0</>
 Received: <r>{}</>
 `;
 
+exports[`.toEqual() {pass: false} expect({Symbol(foo): 1, Symbol(bar): 2}).toEqual({Symbol(foo): Any<Number>, Symbol(bar): 1}) 1`] = `
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
+
+<g>- Expected  - 1</>
+<r>+ Received  + 1</>
+
+<d>  Object {</>
+<d>    Symbol(foo): Any<Number>,</>
+<g>-   Symbol(bar): 1,</>
+<r>+   Symbol(bar): 2,</>
+<d>  }</>
+`;
+
 exports[`.toEqual() {pass: false} expect(0).toEqual({}) 1`] = `
 <d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
@@ -2620,6 +2633,13 @@ exports[`.toEqual() {pass: true} expect({}).not.toEqual({}) 2`] = `
 
 Expected: not <g>{}</>
 
+`;
+
+exports[`.toEqual() {pass: true} expect({Symbol(foo): 1, Symbol(bar): 2}).not.toEqual({Symbol(foo): Any<Number>, Symbol(bar): 2}) 1`] = `
+<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
+
+Expected: not <g>{Symbol(foo): Any<Number>, Symbol(bar): 2}</>
+Received:     <r>{Symbol(foo): 1, Symbol(bar): 2}</>
 `;
 
 exports[`.toEqual() {pass: true} expect(0).not.toEqual(0) 1`] = `
@@ -3778,6 +3798,19 @@ exports[`toMatchObject() {pass: false} expect({"a": "a", "c": "d"}).toMatchObjec
 <d>  }</>
 `;
 
+exports[`toMatchObject() {pass: false} expect({"a": "b", "c": "d", Symbol(jest): "jest"}).toMatchObject({"a": "c", Symbol(jest): Any<String>}) 1`] = `
+<d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
+
+<g>- Expected  - 2</>
+<r>+ Received  + 1</>
+
+<d>  Object {</>
+<g>-   "a": "c",</>
+<g>-   Symbol(jest): Any<String>,</>
+<r>+   "a": "b",</>
+<d>  }</>
+`;
+
 exports[`toMatchObject() {pass: false} expect({"a": "b", "c": "d"}).toMatchObject({"a": "b!", "c": "d"}) 1`] = `
 <d>expect(</><r>received</><d>).</>toMatchObject<d>(</><g>expected</><d>)</>
 
@@ -4066,6 +4099,19 @@ exports[`toMatchObject() {pass: true} expect([Error: foo]).toMatchObject([Error:
 <d>expect(</><r>received</><d>).</>not<d>.</>toMatchObject<d>(</><g>expected</><d>)</>
 
 Expected: not <g>[Error: foo]</>
+`;
+
+exports[`toMatchObject() {pass: true} expect({"a": "b", "c": "d", Symbol(jest): "jest"}).toMatchObject({"a": "b", "c": "d", Symbol(jest): "jest"}) 1`] = `
+<d>expect(</><r>received</><d>).</>not<d>.</>toMatchObject<d>(</><g>expected</><d>)</>
+
+Expected: not <g>{"a": "b", "c": "d", Symbol(jest): "jest"}</>
+`;
+
+exports[`toMatchObject() {pass: true} expect({"a": "b", "c": "d", Symbol(jest): "jest"}).toMatchObject({"a": "b", Symbol(jest): "jest"}) 1`] = `
+<d>expect(</><r>received</><d>).</>not<d>.</>toMatchObject<d>(</><g>expected</><d>)</>
+
+Expected: not <g>{"a": "b", Symbol(jest): "jest"}</>
+Received:     <r>{"a": "b", "c": "d", Symbol(jest): "jest"}</>
 `;
 
 exports[`toMatchObject() {pass: true} expect({"a": "b", "c": "d"}).toMatchObject({"a": "b", "c": "d"}) 1`] = `

--- a/packages/expect/src/__tests__/matchers.test.js
+++ b/packages/expect/src/__tests__/matchers.test.js
@@ -529,6 +529,16 @@ describe('.toEqual()', () => {
         nodeType: 1,
       },
     ],
+    [
+      {
+        [Symbol.for('foo')]: 1,
+        [Symbol.for('bar')]: 2,
+      },
+      {
+        [Symbol.for('foo')]: jestExpect.any(Number),
+        [Symbol.for('bar')]: 1,
+      },
+    ],
   ].forEach(([a, b]) => {
     test(`{pass: false} expect(${stringify(a)}).toEqual(${stringify(
       b,
@@ -725,6 +735,16 @@ describe('.toEqual()', () => {
       {
         nodeName: 'div',
         nodeType: 1,
+      },
+    ],
+    [
+      {
+        [Symbol.for('foo')]: 1,
+        [Symbol.for('bar')]: 2,
+      },
+      {
+        [Symbol.for('foo')]: jestExpect.any(Number),
+        [Symbol.for('bar')]: 2,
       },
     ],
   ].forEach(([a, b]) => {
@@ -2006,6 +2026,14 @@ describe('toMatchObject()', () => {
     [new Error('bar'), {message: 'bar'}],
     [new Foo(), {a: undefined, b: 'b'}],
     [Object.assign(Object.create(null), {a: 'b'}), {a: 'b'}],
+    [
+      {a: 'b', c: 'd', [Symbol.for('jest')]: 'jest'},
+      {a: 'b', [Symbol.for('jest')]: 'jest'},
+    ],
+    [
+      {a: 'b', c: 'd', [Symbol.for('jest')]: 'jest'},
+      {a: 'b', c: 'd', [Symbol.for('jest')]: 'jest'},
+    ],
   ]);
 
   testToMatchSnapshots([
@@ -2049,6 +2077,10 @@ describe('toMatchObject()', () => {
     ],
     [new Error('foo'), new Error('bar')],
     [Object.assign(Object.create(null), {a: 'b'}), {c: 'd'}],
+    [
+      {a: 'b', c: 'd', [Symbol.for('jest')]: 'jest'},
+      {a: 'c', [Symbol.for('jest')]: expect.any(String)},
+    ],
   ]);
 
   [

--- a/packages/jest-matcher-utils/src/Replaceable.ts
+++ b/packages/jest-matcher-utils/src/Replaceable.ts
@@ -34,6 +34,12 @@ export default class Replaceable {
       Object.entries(this.object).forEach(([key, value]) => {
         cb(value, key, this.object);
       });
+      Object.getOwnPropertySymbols(this.object).forEach(key => {
+        const descriptor = Object.getOwnPropertyDescriptor(this.object, key);
+        if ((descriptor as PropertyDescriptor).enumerable) {
+          cb(this.object[key], key, this.object);
+        }
+      });
     } else {
       this.object.forEach(cb);
     }

--- a/packages/jest-matcher-utils/src/__tests__/Replaceable.test.ts
+++ b/packages/jest-matcher-utils/src/__tests__/Replaceable.test.ts
@@ -99,11 +99,27 @@ describe('Replaceable', () => {
 
   describe('forEach', () => {
     test('object forEach', () => {
-      const replaceable = new Replaceable({a: 1, b: 2});
+      const symbolKey = Symbol('jest');
+      const object = {a: 1, b: 2, [symbolKey]: 3};
+      const replaceable = new Replaceable(object);
       const cb = jest.fn();
       replaceable.forEach(cb);
-      expect(cb.mock.calls[0]).toEqual([1, 'a', {a: 1, b: 2}]);
-      expect(cb.mock.calls[1]).toEqual([2, 'b', {a: 1, b: 2}]);
+      expect(cb.mock.calls.length).toBe(3);
+      expect(cb.mock.calls[0]).toEqual([1, 'a', object]);
+      expect(cb.mock.calls[1]).toEqual([2, 'b', object]);
+      expect(cb.mock.calls[2]).toEqual([3, symbolKey, object]);
+    });
+
+    test('object forEach do not iterate none enumerable symbol key', () => {
+      const symbolKey = Symbol('jest');
+      const object = {a: 1, b: 2};
+      Object.defineProperty(object, symbolKey, {enumerable: false});
+      const replaceable = new Replaceable(object);
+      const cb = jest.fn();
+      replaceable.forEach(cb);
+      expect(cb.mock.calls.length).toBe(2);
+      expect(cb.mock.calls[0]).toEqual([1, 'a', object]);
+      expect(cb.mock.calls[1]).toEqual([2, 'b', object]);
     });
 
     test('array forEach', () => {

--- a/packages/jest-matcher-utils/src/__tests__/__snapshots__/printDiffOrStringify.test.ts.snap
+++ b/packages/jest-matcher-utils/src/__tests__/__snapshots__/printDiffOrStringify.test.ts.snap
@@ -85,6 +85,7 @@ exports[`printDiffOrStringify asymmetricMatcher jest asymmetricMatcher 1`] = `
 <d>    },</>
 <g>-   "g": true,</>
 <r>+   "g": false,</>
+<d>    Symbol(h): Any<String>,</>
 <d>  }</>
 `;
 

--- a/packages/jest-matcher-utils/src/__tests__/printDiffOrStringify.test.ts
+++ b/packages/jest-matcher-utils/src/__tests__/printDiffOrStringify.test.ts
@@ -106,6 +106,7 @@ describe('printDiffOrStringify', () => {
           b: 'jest is awesome',
         },
         g: true,
+        [Symbol.for('h')]: 'jest is awesome',
       };
       const received = {
         a: 1,
@@ -117,6 +118,7 @@ describe('printDiffOrStringify', () => {
           a: expect.any(Date),
         }),
         g: false,
+        [Symbol.for('h')]: expect.any(String),
       };
 
       expect(testDiffOrStringify(expected, received)).toMatchSnapshot();


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Fixes #9432.

Use `Object.getOwnPropertySymbols` to traverse object's symbol key can fix this issue.

Thanks @pedrottimark to point out this edge case.

## Test plan

Add  symbol-keyed object tests.
