### PR TITLE
Fix typo in moduleNameMapper docs

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -487,7 +487,7 @@ Example:
 }
 ```
 
-The order in which the mappings are defined matters. Patterns are checked one by one until one fits. The most specific rule should be listed first. This is true for arrays of modules names as.
+The order in which the mappings are defined matters. Patterns are checked one by one until one fits. The most specific rule should be listed first. This is true for arrays of module names as well.
 
 _Note: If you provide module name without boundaries `^$` it may cause hard to spot errors. E.g. `relay` will replace all modules which contain `relay` as a substring in its name: `relay`, `react-relay` and `graphql-relay` will all be pointed to your stub._
 


### PR DESCRIPTION
Sorry for this, it was left from my previous PR. Thank you!