### PR TITLE
Fix module id preservation with symlinks when using browser field

### DIFF
--- a/packages/jest-resolve/src/defaultResolver.ts
+++ b/packages/jest-resolve/src/defaultResolver.ts
@@ -35,7 +35,7 @@ export default function defaultResolver(
 
   const resolve = options.browser ? browserResolve : resolveSync;
 
-  return resolve(path, {
+  let result = resolve(path, {
     basedir: options.basedir,
     defaultResolver,
     extensions: options.extensions,
@@ -43,6 +43,12 @@ export default function defaultResolver(
     paths: options.paths,
     rootDir: options.rootDir,
   });
+  if (result) {
+    // Dereference symlinks to ensure we don't create a separate
+    // module instance depending on how it was referenced.
+    result = fs.realpathSync(result);
+  }
+  return result;
 }
 
 export const clearDefaultResolverCache = () => {
@@ -97,11 +103,6 @@ function resolveSync(
     let result;
     if (isDirectory(dir)) {
       result = resolveAsFile(name) || resolveAsDirectory(name);
-    }
-    if (result) {
-      // Dereference symlinks to ensure we don't create a separate
-      // module instance depending on how it was referenced.
-      result = fs.realpathSync(result);
     }
     return result;
   }


### PR DESCRIPTION
## Summary

Fixes https://github.com/facebook/jest/issues/9510

## Test plan

I need to look into this further. The e2e test added in https://github.com/facebook/jest/pull/4761 seems to take advantage of existing packages (i.e. it didn't create a fixture package). I'd need to add some kind of fixture package with a browser field.
