### PR TITLE
[jest-haste-map] reduce the number of lstat calls in node crawler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - `[jest-snapshot]` Downgrade semver to v6 to support node 8 ([#9451](https://github.com/facebook/jest/pull/9451))
 - `[jest-transform]` Correct sourcemap behavior for transformed and instrumented code ([#9460](https://github.com/facebook/jest/pull/9460))
 - `[pretty-format]` Export `OldPlugin` type ([#9491](https://github.com/facebook/jest/pull/9491))
+- `[jest-haste-map]` Reduce number of lstat calls in node crawler
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@
 - `[jest-snapshot]` Downgrade semver to v6 to support node 8 ([#9451](https://github.com/facebook/jest/pull/9451))
 - `[jest-transform]` Correct sourcemap behavior for transformed and instrumented code ([#9460](https://github.com/facebook/jest/pull/9460))
 - `[pretty-format]` Export `OldPlugin` type ([#9491](https://github.com/facebook/jest/pull/9491))
-- `[jest-haste-map]` Reduce number of lstat calls in node crawler
 
 ### Chore & Maintenance
 
@@ -21,6 +20,8 @@
 - `[docs]` Warn about unexpected behavior / bug of node-notifier when using the `notify` options.
 
 ### Performance
+
+- `[jest-haste-map]` Reduce number of `lstat` calls in node crawler ([#9514](https://github.com/facebook/jest/pull/9514))
 
 ## 25.1.0
 

--- a/packages/jest-haste-map/src/crawlers/__tests__/node.test.js
+++ b/packages/jest-haste-map/src/crawlers/__tests__/node.test.js
@@ -31,6 +31,8 @@ jest.mock('child_process', () => ({
   }),
 }));
 
+let mockHasReaddirWithFileTypesSupport = false;
+
 jest.mock('fs', () => {
   let mtime = 32;
   const size = 42;
@@ -42,7 +44,7 @@ jest.mock('fs', () => {
             return path.endsWith('/directory');
           },
           isSymbolicLink() {
-            return false;
+            return path.endsWith('symlink');
           },
           mtime: {
             getTime() {
@@ -66,12 +68,56 @@ jest.mock('fs', () => {
         }
         throw new Error('readdir: callback is not a function!');
       }
-      if (dir === '/project/fruits') {
-        setTimeout(() => callback(null, ['directory', 'tomato.js']), 0);
-      } else if (dir === '/project/fruits/directory') {
-        setTimeout(() => callback(null, ['strawberry.js']), 0);
-      } else if (dir == '/error') {
-        setTimeout(() => callback({code: 'ENOTDIR'}, undefined), 0);
+
+      if (mockHasReaddirWithFileTypesSupport) {
+        if (dir === '/project/fruits') {
+          setTimeout(
+            () =>
+              callback(null, [
+                {
+                  isDirectory: () => true,
+                  isSymbolicLink: () => false,
+                  name: 'directory',
+                },
+                {
+                  isDirectory: () => false,
+                  isSymbolicLink: () => false,
+                  name: 'tomato.js',
+                },
+                {
+                  isDirectory: () => false,
+                  isSymbolicLink: () => true,
+                  name: 'symlink',
+                },
+              ]),
+            0,
+          );
+        } else if (dir === '/project/fruits/directory') {
+          setTimeout(
+            () =>
+              callback(null, [
+                {
+                  isDirectory: () => false,
+                  isSymbolicLink: () => false,
+                  name: 'strawberry.js',
+                },
+              ]),
+            0,
+          );
+        } else if (dir == '/error') {
+          setTimeout(() => callback({code: 'ENOTDIR'}, undefined), 0);
+        }
+      } else {
+        if (dir === '/project/fruits') {
+          setTimeout(
+            () => callback(null, ['directory', 'tomato.js', 'symlink']),
+            0,
+          );
+        } else if (dir === '/project/fruits/directory') {
+          setTimeout(() => callback(null, ['strawberry.js']), 0);
+        } else if (dir == '/error') {
+          setTimeout(() => callback({code: 'ENOTDIR'}, undefined), 0);
+        }
       }
     }),
     stat: jest.fn(stat),
@@ -303,6 +349,67 @@ describe('node crawler', () => {
     }).then(({hasteMap, removedFiles}) => {
       expect(hasteMap.files).toEqual(new Map());
       expect(removedFiles).toEqual(new Map());
+    });
+  });
+
+  describe('readdir withFileTypes support', () => {
+    it('calls lstat for directories and symlinks if readdir withFileTypes is not supported', () => {
+      nodeCrawl = require('../node');
+      const fs = require('fs');
+
+      const files = new Map();
+      return nodeCrawl({
+        data: {files},
+        extensions: ['js'],
+        forceNodeFilesystemAPI: true,
+        ignore: pearMatcher,
+        rootDir,
+        roots: ['/project/fruits'],
+      }).then(({hasteMap, removedFiles}) => {
+        expect(hasteMap.files).toEqual(
+          createMap({
+            'fruits/directory/strawberry.js': ['', 33, 42, 0, '', null],
+            'fruits/tomato.js': ['', 32, 42, 0, '', null],
+          }),
+        );
+        expect(removedFiles).toEqual(new Map());
+        // once for /project/fruits, once for /project/fruits/directory
+        expect(fs.readdir).toHaveBeenCalledTimes(2);
+        // once for each of:
+        // 1. /project/fruits/directory
+        // 2. /project/fruits/directory/strawberry.js
+        // 3. /project/fruits/tomato.js
+        // 4. /project/fruits/symlink
+        // (we never call lstat on the root /project/fruits, since we know it's a directory)
+        expect(fs.lstat).toHaveBeenCalledTimes(4);
+      });
+    });
+    it('avoids calling lstat for directories and symlinks if readdir withFileTypes is supported', () => {
+      mockHasReaddirWithFileTypesSupport = true;
+      nodeCrawl = require('../node');
+      const fs = require('fs');
+
+      const files = new Map();
+      return nodeCrawl({
+        data: {files},
+        extensions: ['js'],
+        forceNodeFilesystemAPI: true,
+        ignore: pearMatcher,
+        rootDir,
+        roots: ['/project/fruits'],
+      }).then(({hasteMap, removedFiles}) => {
+        expect(hasteMap.files).toEqual(
+          createMap({
+            'fruits/directory/strawberry.js': ['', 33, 42, 0, '', null],
+            'fruits/tomato.js': ['', 32, 42, 0, '', null],
+          }),
+        );
+        expect(removedFiles).toEqual(new Map());
+        // once for /project/fruits, once for /project/fruits/directory
+        expect(fs.readdir).toHaveBeenCalledTimes(2);
+        // once for strawberry.js, once for tomato.js
+        expect(fs.lstat).toHaveBeenCalledTimes(2);
+      });
     });
   });
 });

--- a/packages/jest-haste-map/src/crawlers/__tests__/node.test.js
+++ b/packages/jest-haste-map/src/crawlers/__tests__/node.test.js
@@ -56,7 +56,16 @@ jest.mock('fs', () => {
   };
   return {
     lstat: jest.fn(stat),
-    readdir: jest.fn((dir, callback) => {
+    readdir: jest.fn((dir, options, callback) => {
+      // readdir has an optional `options` arg that's in the middle of the args list.
+      // we always provide it in practice, but let's try to handle the case where it's not
+      // provided too
+      if (typeof callback === 'undefined') {
+        if (typeof options === 'function') {
+          callback = options;
+        }
+        throw new Error('readdir: callback is not a function!');
+      }
       if (dir === '/project/fruits') {
         setTimeout(() => callback(null, ['directory', 'tomato.js']), 0);
       } else if (dir === '/project/fruits/directory') {

--- a/packages/jest-haste-map/src/crawlers/node.ts
+++ b/packages/jest-haste-map/src/crawlers/node.ts
@@ -61,26 +61,17 @@ function find(
           }
         }
 
-        // If we made it here and had dirent support, we know that
-        // this is a normal file and can skip some checks in the lstat callback below
-        let passedFiletypeChecks = typeof entry !== 'string';
-
         activeCalls++;
 
         fs.lstat(file, (err, stat) => {
           activeCalls--;
 
-          if (!err && stat) {
-            if (!passedFiletypeChecks) {
-              if (stat.isSymbolicLink()) {
-                // do nothing
-              } else if (stat.isDirectory()) {
-                search(file);
-              } else {
-                passedFiletypeChecks = true;
-              }
-            }
-            if (passedFiletypeChecks) {
+          // This logic is unnecessary for node > v10.10, but leaving it in
+          // since we need it for backwards-compatibility still.
+          if (!err && stat && !stat.isSymbolicLink()) {
+            if (stat.isDirectory()) {
+              search(file);
+            } else {
               const ext = path.extname(file).substr(1);
               if (extensions.indexOf(ext) !== -1) {
                 result.push([file, stat.mtime.getTime(), stat.size]);

--- a/packages/jest-haste-map/src/crawlers/node.ts
+++ b/packages/jest-haste-map/src/crawlers/node.ts
@@ -61,17 +61,26 @@ function find(
           }
         }
 
+        // If we made it here and had dirent support, we know that
+        // this is a normal file and can skip some checks in the lstat callback below
+        let passedFiletypeChecks = typeof entry !== 'string';
+
         activeCalls++;
 
         fs.lstat(file, (err, stat) => {
           activeCalls--;
 
-          // This logic is unnecessary for node > v10.10, but leaving it in
-          // since we need it for backwards-compatibility still.
-          if (!err && stat && !stat.isSymbolicLink()) {
-            if (stat.isDirectory()) {
-              search(file);
-            } else {
+          if (!err && stat) {
+            if (!passedFiletypeChecks) {
+              if (stat.isSymbolicLink()) {
+                // do nothing
+              } else if (stat.isDirectory()) {
+                search(file);
+              } else {
+                passedFiletypeChecks = true;
+              }
+            }
+            if (passedFiletypeChecks) {
               const ext = path.extname(file).substr(1);
               if (extensions.indexOf(ext) !== -1) {
                 result.push([file, stat.mtime.getTime(), stat.size]);

--- a/packages/jest-haste-map/src/crawlers/node.ts
+++ b/packages/jest-haste-map/src/crawlers/node.ts
@@ -38,19 +38,19 @@ function find(
         callback(result);
         return;
       }
+      // node < v10.10 does not support the withFileTypes option, and
+      // entry will be a string.
       entries.forEach((entry: string | fs.Dirent) => {
-        let file: string;
-        // node < v10.10 does not support the withFileTypes option, and
-        // entry will be a string.
-        if (typeof entry === 'string') {
-          file = path.join(directory, entry);
-        } else {
-          file = path.join(directory, entry.name);
+        const file = path.join(
+          directory,
+          typeof entry === 'string' ? entry : entry.name,
+        );
 
-          if (ignore(file)) {
-            return;
-          }
+        if (ignore(file)) {
+          return;
+        }
 
+        if (typeof entry !== 'string') {
           if (entry.isSymbolicLink()) {
             return;
           }

--- a/packages/jest-haste-map/src/crawlers/node.ts
+++ b/packages/jest-haste-map/src/crawlers/node.ts
@@ -32,7 +32,7 @@ function find(
 
   function search(directory: string): void {
     activeCalls++;
-    fs.readdir(directory, { withFileTypes: true }, (err, entries) => {
+    fs.readdir(directory, {withFileTypes: true}, (err, entries) => {
       activeCalls--;
       if (err) {
         callback(result);


### PR DESCRIPTION
## Summary

`fs.readdir` has a withFileTypes option that will tell us if the file is a symlink or directory. Therefore, there's no need to make and wait for an lstat call before taking the appropriate actions for those file types (skip and recurse, respectively). 

This drastically improves the initial crawl time when using the node watcher.

## Test plan

Applied changes and ran it against my project. The activeCalls counter is a little tricky, but I'm fairly certain I've handled it correctly here since I'd expect an infinite loop if I got it wrong. 

