### PR TITLE
fix: improve open handles detection

### DIFF
--- a/e2e/__tests__/__snapshots__/detectOpenHandles.ts.snap
+++ b/e2e/__tests__/__snapshots__/detectOpenHandles.ts.snap
@@ -9,16 +9,16 @@ There were no uncollected handles - this is unexpected if your tests do not exit
 Collected handles:
   ●  TCPSERVERWRAP
 
-      4 |   const server = http.createServer();
-      5 |   await new Promise(resolve => {
-    > 6 |     server.listen(resolve);
-        |            ^
-      7 |   });
-      8 |   await new Promise((resolve, reject) => {
-      9 |     server.close(err => {
+      11 |   const server = http.createServer();
+      12 |   await new Promise(resolve => {
+    > 13 |     server.listen(resolve);
+         |            ^
+      14 |   });
+      15 |   await new Promise((resolve, reject) => {
+      16 |     server.close(err => {
 
-      at listen (__tests__/http.js:6:12)
-      at Object.<anonymous> (__tests__/http.js:5:9)
+      at listen (__tests__/http.js:13:12)
+      at Object.<anonymous> (__tests__/http.js:12:9)
 `;
 
 exports[`prints message about flag on forceExit 1`] = `Force exiting Jest: Have you considered using \`--detectOpenHandles\` to detect async operations that kept running after all tests finished?`;

--- a/e2e/__tests__/__snapshots__/detectOpenHandles.ts.snap
+++ b/e2e/__tests__/__snapshots__/detectOpenHandles.ts.snap
@@ -9,7 +9,7 @@ This usually means that there are asynchronous operations that weren't stopped i
 `;
 
 exports[`prints out info about open handlers 1`] = `
-Jest has detected the following 1 open handle potentially keeping Jest from exiting:
+Jest has detected the following 1 open handle potentially preventing Jest from exiting:
 
   ●  GETADDRINFOREQWRAP
 
@@ -24,7 +24,7 @@ Jest has detected the following 1 open handle potentially keeping Jest from exit
 `;
 
 exports[`prints out info about open handlers from inside tests 1`] = `
-Jest has detected the following 1 open handle potentially keeping Jest from exiting:
+Jest has detected the following 1 open handle potentially preventing Jest from exiting:
 
   ●  Timeout
 

--- a/e2e/__tests__/__snapshots__/detectOpenHandles.ts.snap
+++ b/e2e/__tests__/__snapshots__/detectOpenHandles.ts.snap
@@ -36,6 +36,9 @@ These are sometimes useful to look at as they might have spawned other handles t
 Uncollected handles:
   ●  DNSCHANNEL
 
+      at internal/dns/utils.js:101:23
+      at dns.js:38:5
+
   ●  TCPSERVERWRAP
 
 Collected handles:

--- a/e2e/__tests__/__snapshots__/detectOpenHandles.ts.snap
+++ b/e2e/__tests__/__snapshots__/detectOpenHandles.ts.snap
@@ -33,6 +33,7 @@ exports[`prints out info about open handlers 1`] = `
 Jest has detected the following 3 open handles potentially preventing Jest from exiting:
 Of them 1 was collected within 100ms of the tests completing.
 These are sometimes useful to look at as they might have spawned other handles that remain open, but that we have lost the origin of.
+
   ●  DNSCHANNEL (uncollected, potential leak)
 
       at internal/dns/utils.js:101:23
@@ -54,6 +55,7 @@ These are sometimes useful to look at as they might have spawned other handles t
 
 exports[`prints out info about open handlers from inside tests 1`] = `
 Jest has detected the following 1 open handle potentially preventing Jest from exiting:
+
   ●  Timeout (uncollected, potential leak)
 
        7 | 

--- a/e2e/__tests__/__snapshots__/detectOpenHandles.ts.snap
+++ b/e2e/__tests__/__snapshots__/detectOpenHandles.ts.snap
@@ -4,10 +4,10 @@ exports[`deals with http servers and promises 1`] = `
 Jest has detected the following 1 open handle potentially preventing Jest from exiting:
 Of them 1 was collected within 100ms of the tests completing.
 These are sometimes useful to look at as they might have spawned other handles that remain open, but that we have lost the origin of.
-There were no uncollected handles - this is unexpected if your tests do not exit cleanly.
 
-Collected handles:
-  ●  TCPSERVERWRAP
+There were no uncollected handles - this is unexpected if your tests do not exit cleanly!
+
+  ●  TCPSERVERWRAP (collected within 100ms)
 
       11 |   const server = http.createServer();
       12 |   await new Promise(resolve => {
@@ -33,16 +33,14 @@ exports[`prints out info about open handlers 1`] = `
 Jest has detected the following 3 open handles potentially preventing Jest from exiting:
 Of them 1 was collected within 100ms of the tests completing.
 These are sometimes useful to look at as they might have spawned other handles that remain open, but that we have lost the origin of.
-Uncollected handles:
-  ●  DNSCHANNEL
+  ●  DNSCHANNEL (uncollected, potential leak)
 
       at internal/dns/utils.js:101:23
       at dns.js:38:5
 
-  ●  TCPSERVERWRAP
+  ●  TCPSERVERWRAP (uncollected, potential leak)
 
-Collected handles:
-  ●  GETADDRINFOREQWRAP
+  ●  GETADDRINFOREQWRAP (collected within 100ms)
 
       12 | const app = new Server();
       13 | 
@@ -56,8 +54,7 @@ Collected handles:
 
 exports[`prints out info about open handlers from inside tests 1`] = `
 Jest has detected the following 1 open handle potentially preventing Jest from exiting:
-Uncollected handles:
-  ●  Timeout
+  ●  Timeout (uncollected, potential leak)
 
        7 | 
        8 | test('something', () => {

--- a/e2e/__tests__/__snapshots__/detectOpenHandles.ts.snap
+++ b/e2e/__tests__/__snapshots__/detectOpenHandles.ts.snap
@@ -36,9 +36,6 @@ These are sometimes useful to look at as they might have spawned other handles t
 
   ●  DNSCHANNEL (uncollected, potential leak)
 
-      at internal/dns/utils.js:101:23
-      at dns.js:38:5
-
   ●  TCPSERVERWRAP (uncollected, potential leak)
 
   ●  GETADDRINFOREQWRAP (collected within 100ms)

--- a/e2e/__tests__/__snapshots__/detectOpenHandles.ts.snap
+++ b/e2e/__tests__/__snapshots__/detectOpenHandles.ts.snap
@@ -1,5 +1,26 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`deals with http servers and promises 1`] = `
+Jest has detected the following 1 open handle potentially preventing Jest from exiting:
+Of them 1 was collected within 100ms of the tests completing.
+These are sometimes useful to look at as they might have spawned other handles that remain open, but that we have lost the origin of.
+There were no uncollected handles - this is unexpected if your tests do not exit cleanly.
+
+Collected handles:
+  ●  TCPSERVERWRAP
+
+      4 |   const server = http.createServer();
+      5 |   await new Promise(resolve => {
+    > 6 |     server.listen(resolve);
+        |            ^
+      7 |   });
+      8 |   await new Promise((resolve, reject) => {
+      9 |     server.close(err => {
+
+      at listen (__tests__/http.js:6:12)
+      at Object.<anonymous> (__tests__/http.js:5:9)
+`;
+
 exports[`prints message about flag on forceExit 1`] = `Force exiting Jest: Have you considered using \`--detectOpenHandles\` to detect async operations that kept running after all tests finished?`;
 
 exports[`prints message about flag on slow tests 1`] = `
@@ -9,8 +30,15 @@ This usually means that there are asynchronous operations that weren't stopped i
 `;
 
 exports[`prints out info about open handlers 1`] = `
-Jest has detected the following 1 open handle potentially preventing Jest from exiting:
+Jest has detected the following 3 open handles potentially preventing Jest from exiting:
+Of them 1 was collected within 100ms of the tests completing.
+These are sometimes useful to look at as they might have spawned other handles that remain open, but that we have lost the origin of.
+Uncollected handles:
+  ●  DNSCHANNEL
 
+  ●  TCPSERVERWRAP
+
+Collected handles:
   ●  GETADDRINFOREQWRAP
 
       12 | const app = new Server();
@@ -25,7 +53,7 @@ Jest has detected the following 1 open handle potentially preventing Jest from e
 
 exports[`prints out info about open handlers from inside tests 1`] = `
 Jest has detected the following 1 open handle potentially preventing Jest from exiting:
-
+Uncollected handles:
   ●  Timeout
 
        7 | 

--- a/e2e/__tests__/detectOpenHandles.ts
+++ b/e2e/__tests__/detectOpenHandles.ts
@@ -68,7 +68,7 @@ it('does not report promises', () => {
   ]);
   const textAfterTest = getTextAfterTest(stderr);
 
-  expect(textAfterTest).toBe('');
+  expect(textAfterTest).toBe('Jest was unable to detect any open handles');
 });
 
 onNodeVersions('>=11.10.0', () => {
@@ -108,13 +108,25 @@ onNodeVersions('>=11', () => {
     ]);
     const textAfterTest = getTextAfterTest(stderr);
 
-    expect(textAfterTest).toBe('');
+    expect(textAfterTest).toBe('Jest was unable to detect any open handles');
   });
 });
 
 it('prints out info about open handlers from inside tests', async () => {
   const run = runContinuous('detect-open-handles', [
     'inside',
+    '--detectOpenHandles',
+  ]);
+  await run.waitUntil(({stderr}) => stderr.includes('Jest has detected'));
+  const {stderr} = await run.end();
+  const textAfterTest = getTextAfterTest(stderr);
+
+  expect(wrap(textAfterTest)).toMatchSnapshot();
+});
+
+it('deals with http servers and promises', async () => {
+  const run = runContinuous('detect-open-handles', [
+    'http',
     '--detectOpenHandles',
   ]);
   await run.waitUntil(({stderr}) => stderr.includes('Jest has detected'));

--- a/e2e/detect-open-handles/__tests__/http.js
+++ b/e2e/detect-open-handles/__tests__/http.js
@@ -1,0 +1,17 @@
+const http = require('http');
+
+it('should not timeout', async () => {
+  const server = http.createServer();
+  await new Promise(resolve => {
+    server.listen(resolve);
+  });
+  await new Promise((resolve, reject) => {
+    server.close(err => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve();
+      }
+    });
+  });
+});

--- a/e2e/detect-open-handles/__tests__/http.js
+++ b/e2e/detect-open-handles/__tests__/http.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 const http = require('http');
 
 it('should not timeout', async () => {

--- a/packages/jest-core/src/cli/index.ts
+++ b/packages/jest-core/src/cli/index.ts
@@ -114,7 +114,7 @@ export async function runCLI(
 
     const message =
       chalk.red(
-        `\nJest has detected the following ${openHandlesString} potentially keeping Jest from exiting:\n\n`,
+        `\nJest has detected the following ${openHandlesString} potentially preventing Jest from exiting:\n\n`,
       ) + formatted.join('\n\n');
 
     console.error(message);

--- a/packages/jest-core/src/cli/index.ts
+++ b/packages/jest-core/src/cli/index.ts
@@ -126,13 +126,13 @@ export async function runCLI(
           : `${collectedHandles.length} were`;
 
       let heading = chalk.red(
-        `Jest has detected the following ${openHandlesString} potentially preventing Jest from exiting:`,
+        `Jest has detected the following ${openHandlesString} potentially preventing Jest from exiting:\n`,
       );
 
       if (alreadyCollectedString) {
-        heading += `\n${chalk.yellow(
+        heading += `${chalk.yellow(
           `Of them ${alreadyCollectedString} collected within 100ms of the tests completing.\nThese are sometimes useful to look at as they might have spawned other handles that remain open, but that we have lost the origin of.`,
-        )}`;
+        )}\n`;
       }
 
       const uncollectedHandlesWarning =
@@ -140,13 +140,13 @@ export async function runCLI(
           ? `\n${chalk.red(
               'There were no uncollected handles - this is unexpected if your tests do not exit cleanly!',
             )}\n\n`
-          : '';
+          : '\n';
 
       const handles = [...uncollectedHandles, ...collectedHandles]
         .map(line => line.trimRight())
         .join('\n\n');
 
-      const message = `\n${heading}\n${uncollectedHandlesWarning}${handles}`;
+      const message = `\n${heading}${uncollectedHandlesWarning}${handles}`;
 
       console.error(message);
     } else {

--- a/packages/jest-core/src/cli/index.ts
+++ b/packages/jest-core/src/cli/index.ts
@@ -130,26 +130,23 @@ export async function runCLI(
       );
 
       if (alreadyCollectedString) {
-        heading += chalk.yellow(
-          `\nOf them ${alreadyCollectedString} collected within 100ms of the tests completing.\nThese are sometimes useful to look at as they might have spawned other handles that remain open, but that we have lost the origin of.`,
-        );
+        heading += `\n${chalk.yellow(
+          `Of them ${alreadyCollectedString} collected within 100ms of the tests completing.\nThese are sometimes useful to look at as they might have spawned other handles that remain open, but that we have lost the origin of.`,
+        )}`;
       }
 
-      const uncollectedHandlesString =
-        uncollectedHandles.length > 0
-          ? `Uncollected handles:\n${uncollectedHandles
-              .map(line => line.trimRight())
-              .join('\n\n')}`
-          : 'There were no uncollected handles - this is unexpected if your tests do not exit cleanly.';
-
-      const collectedHandlesString =
-        collectedHandles.length > 0
-          ? `\n\nCollected handles:\n${collectedHandles
-              .map(line => line.trimRight())
-              .join('\n\n')}`
+      const uncollectedHandlesWarning =
+        uncollectedHandles.length === 0
+          ? `\n${chalk.red(
+              'There were no uncollected handles - this is unexpected if your tests do not exit cleanly!',
+            )}\n\n`
           : '';
 
-      const message = `\n\n${heading}\n${uncollectedHandlesString}${collectedHandlesString}`;
+      const handles = [...uncollectedHandles, ...collectedHandles]
+        .map(line => line.trimRight())
+        .join('\n\n');
+
+      const message = `\n${heading}\n${uncollectedHandlesWarning}${handles}`;
 
       console.error(message);
     } else {

--- a/packages/jest-core/src/cli/index.ts
+++ b/packages/jest-core/src/cli/index.ts
@@ -296,11 +296,11 @@ const runWithoutWatch = async (
   changedFilesPromise?: ChangedFilesPromise,
   filter?: Filter,
 ) => {
-  const startRun = async (): Promise<void | null> => {
+  const startRun = async (): Promise<void> => {
     if (!globalConfig.listTests) {
       preRunMessagePrint(outputStream);
     }
-    return runJest({
+    await runJest({
       changedFilesPromise,
       contexts,
       failedTestsCache: undefined,

--- a/packages/jest-core/src/collectHandles.ts
+++ b/packages/jest-core/src/collectHandles.ts
@@ -11,6 +11,7 @@ import {formatExecError} from 'jest-message-util';
 import {ErrorWithStack} from 'jest-util';
 import stripAnsi = require('strip-ansi');
 import type {AggregatedResult} from '@jest/test-result';
+import chalk = require('chalk');
 
 export type OpenHandleError = AggregatedResult['openHandles'][number];
 
@@ -141,6 +142,15 @@ export function formatHandleErrors(
         stacks.add(stackWithoutHeading);
 
         return true;
+      })
+      .map(({stack, wasCollected}) => {
+        const [heading, ...rest] = stack.split('\n');
+
+        const tweakedHeading = wasCollected
+          ? chalk.yellow(`${heading} (collected within 100ms)`)
+          : chalk.red(`${heading} (uncollected, potential leak)`);
+
+        return {stack: [tweakedHeading, ...rest].join('\n'), wasCollected};
       })
   );
 }

--- a/packages/jest-core/src/collectHandles.ts
+++ b/packages/jest-core/src/collectHandles.ts
@@ -22,8 +22,9 @@ function isSafeJestInternal(stack: string) {
     .split('\n')
     .some(
       line =>
-        line.includes('at Status._debouncedEmit') &&
-        line.includes('build/Status.js'),
+        line.includes('build/Status.js') &&
+        (line.includes('at Status._debouncedEmit') ||
+          line.includes('at Status.runStarted')),
     );
 }
 

--- a/packages/jest-core/src/runJest.ts
+++ b/packages/jest-core/src/runJest.ts
@@ -85,6 +85,8 @@ async function createOpenHandlesResult(
   // wait 100ms to allow some handles to be cleaned up, including Jest's internal timeouts
   // make sure _not_ to unref it, otherwise the promise won't actually be waited for if there's nothing else to do
   await new Promise(resolve => setTimeout(resolve, 100));
+  // wait one extra tick so the timeout ^ is not counted.
+  await Promise.resolve();
 
   const handlesAfterWait = collectHandles(false);
   const handlesAfterStack = handlesAfterWait.map(handle => handle.stack);

--- a/packages/jest-core/src/runJest.ts
+++ b/packages/jest-core/src/runJest.ts
@@ -273,6 +273,11 @@ export default async function runJest({
     await runGlobalHook({allTests, globalConfig, moduleName: 'globalTeardown'});
   }
 
+  if (collectHandles) {
+    // wait 100ms to allow some handles to be cleaned up, including Jest's internal timeouts
+    await new Promise(resolve => setTimeout(resolve, 100));
+  }
+
   await processResults(results, {
     collectHandles,
     json: globalConfig.json,

--- a/packages/jest-message-util/src/index.ts
+++ b/packages/jest-message-util/src/index.ts
@@ -22,23 +22,10 @@ type Path = Config.Path;
 // stack utils tries to create pretty stack by making paths relative.
 const stackUtils = new StackUtils({cwd: 'something which does not exist'});
 
-let nodeInternals: ReadonlyArray<RegExp> = [];
+let nodeInternals: Array<RegExp> = [];
 
 try {
-  // `reduce` is workaround for https://github.com/tapjs/stack-utils/issues/48
-  nodeInternals = StackUtils.nodeInternals().reduce<Array<RegExp>>(
-    (internals, internal) => {
-      const sourceWithoutParens = internal.source
-        // remove leading and trailing parens (which are escaped) and the $
-        .slice(2, internal.source.length - 3);
-
-      return internals.concat(
-        internal,
-        new RegExp(`at ${sourceWithoutParens}$`),
-      );
-    },
-    [],
-  );
+  nodeInternals = StackUtils.nodeInternals();
 } catch {
   // `StackUtils.nodeInternals()` fails in browsers. We don't need to remove
   // node internals in the browser though, so no issue.

--- a/packages/jest-runner/src/runTest.ts
+++ b/packages/jest-runner/src/runTest.ts
@@ -304,9 +304,9 @@ async function runTestInternal(
     }
 
     // Delay the resolution to allow log messages to be output.
-    return new Promise(resolve => {
-      setImmediate(() => resolve({leakDetector, result}));
-    });
+    await new Promise(resolve => setImmediate(resolve));
+
+    return {leakDetector, result};
   } finally {
     await environment.teardown();
     // TODO: this function might be missing, remove ? in Jest 26

--- a/packages/jest-test-result/src/types.ts
+++ b/packages/jest-test-result/src/types.ts
@@ -49,6 +49,10 @@ export type FormattedAssertionResult = Pick<
   failureMessages: AssertionResult['failureMessages'] | null;
 };
 
+interface OpenHandleError extends Error {
+  wasCollected: boolean;
+}
+
 export type AggregatedResultWithoutCoverage = {
   numFailedTests: number;
   numFailedTestSuites: number;
@@ -60,7 +64,7 @@ export type AggregatedResultWithoutCoverage = {
   numRuntimeErrorTestSuites: number;
   numTotalTests: number;
   numTotalTestSuites: number;
-  openHandles: Array<Error>;
+  openHandles: Array<OpenHandleError>;
   snapshot: SnapshotSummary;
   startTime: number;
   success: boolean;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Our current implementation is often fooled by promises, and we lose track of stack traces across async boundaries, meaning https://github.com/facebook/jest/blob/481077b09b05dc659b1fbd9ecf34a6486425208d/packages/jest-core/src/collectHandles.ts#L14 returns false negatives.

This is a work project before and after this fix

![image](https://user-images.githubusercontent.com/1404810/74023082-1938c500-499f-11ea-8c68-65432c219a79.png)

![image](https://user-images.githubusercontent.com/1404810/74023146-37062a00-499f-11ea-954b-f5045a7e47a0.png)

I honestly don't know about the first one (it's a false positive), but the second one lead to us fixing upstream here: https://github.com/valery-barysok/session-file-store/pull/84

Fixes #8554.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

This breaks the stack trace of the existing server test. We get our current trace from the `GETADDRINFOREQWRAP` event, but that's gone in favour of `TCPSERVERWRAP` by the time the test exits, which does not have a stack trace. Unsure how to best deal with it

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
