### PR TITLE
Add jest-runner-vscode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - `[jest-resolver]` Use `resolve` package to implement custom module resolution ([#9520](https://github.com/facebook/jest/pull/9520))
 - `[@jest/reporters]` Remove unused dependencies and type exports ([#9462](https://github.com/facebook/jest/pull/9462))
 - `[website]` Update pictures of reports when matchers fail ([#9214](https://github.com/facebook/jest/pull/9214))
+- `[docs]` Add [jest-runner-vscode](https://github.com/bmealhouse/jest-runner-vscode) to list of example runners ([#9542](https://github.com/facebook/jest/pull/9542))
 
 ### Performance
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -734,6 +734,7 @@ This option allows you to use a custom runner instead of Jest's default test run
 - [`jest-runner-mocha`](https://github.com/rogeliog/jest-runner-mocha)
 - [`jest-runner-tsc`](https://github.com/azz/jest-runner-tsc)
 - [`jest-runner-prettier`](https://github.com/keplersj/jest-runner-prettier)
+- [`jest-runner-vscode`](https://github.com/bmealhouse/jest-runner-vscode)
 
 _Note: The `runner` property value can omit the `jest-runner-` prefix of the package name._
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Mocha is the only documented test runner for building VS Code extensions so I'm working with the VS Code team to have Jest documented as well (https://github.com/microsoft/vscode-docs/issues/3363).

I would like to add [jest-runner-vscode](https://github.com/bmealhouse/jest-runner-vscode) to the list of examples in the [`runner`](https://jestjs.io/docs/en/configuration#runner-string) section of the **Configuring Jest** docs.

I'm also curious if this warrants a **_"Testing VS Code Extensions"_** under the **Framework Guides** in the sidebar?

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

<img width="267" alt="Screen Shot 2020-02-09 at 8 42 14 AM" src="https://user-images.githubusercontent.com/3741255/74104435-2b8b3e00-4b1a-11ea-8613-092cce4c36a2.png">

