### PR TITLE
Fix roots on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Fixes
 
 - `[jest-config]` Treat `setupFilesAfterEnv` like `setupFiles` when normalizing configs against presets ([#9495](https://github.com/facebook/jest/pull/9495))
+- `[jest-haste-map]` Return correctly from crawler if `readdir` errors ([#9549](https://github.com/facebook/jest/pull/9549))
 - `[jest-matcher-utils]` Fix diff highlight of symbol-keyed object. ([#9499](https://github.com/facebook/jest/pull/9499))
 - `[jest-resolve]` Fix module identity preservation with symlinks and browser field resolution ([#9511](https://github.com/facebook/jest/pull/9511))
 - `[jest-resolve]` Do not confuse directories with files ([#8912](https://github.com/facebook/jest/pull/8912))

--- a/packages/jest-haste-map/src/crawlers/node.ts
+++ b/packages/jest-haste-map/src/crawlers/node.ts
@@ -35,7 +35,9 @@ function find(
     fs.readdir(directory, {withFileTypes: true}, (err, entries) => {
       activeCalls--;
       if (err) {
-        callback(result);
+        if (activeCalls === 0) {
+          callback(result);
+        }
         return;
       }
       // node < v10.10 does not support the withFileTypes option, and


### PR DESCRIPTION
I noticed that on Windows, if you had one bad route in your jest.config.js, it would return 0 route found.
It looked like a bug to me, because this was not what happened on Linux, and there were no error message directly saying a root was wrong.
This simple fix ensure that all roots are checked and registered in the result array before returning anything to callback. What was happening is that the calls being asynchronous and the error check being at the beginning, when it encountered a bad root, it would return the callback and ignore the other roots, which could be ok.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
