### PR TITLE
docs/Configuration: Correct signature for testRunner

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -1056,7 +1056,8 @@ The test runner module must export a function with the following signature:
 
 ```ts
 function testRunner(
-  config: Config,
+  globalConfig: GlobalConfig,
+  config: ProjectConfig,
   environment: Environment,
   runtime: Runtime,
   testPath: string,

--- a/website/versioned_docs/version-22.x/Configuration.md
+++ b/website/versioned_docs/version-22.x/Configuration.md
@@ -809,7 +809,8 @@ The test runner module must export a function with the following signature:
 
 ```ts
 function testRunner(
-  config: Config,
+  globalConfig: GlobalConfig,
+  config: ProjectConfig,
   environment: Environment,
   runtime: Runtime,
   testPath: string,

--- a/website/versioned_docs/version-23.x/Configuration.md
+++ b/website/versioned_docs/version-23.x/Configuration.md
@@ -878,7 +878,8 @@ The test runner module must export a function with the following signature:
 
 ```ts
 function testRunner(
-  config: Config,
+  globalConfig: GlobalConfig,
+  config: ProjectConfig,
   environment: Environment,
   runtime: Runtime,
   testPath: string,

--- a/website/versioned_docs/version-24.x/Configuration.md
+++ b/website/versioned_docs/version-24.x/Configuration.md
@@ -1041,7 +1041,8 @@ The test runner module must export a function with the following signature:
 
 ```ts
 function testRunner(
-  config: Config,
+  globalConfig: GlobalConfig,
+  config: ProjectConfig,
   environment: Environment,
   runtime: Runtime,
   testPath: string,

--- a/website/versioned_docs/version-25.1/Configuration.md
+++ b/website/versioned_docs/version-25.1/Configuration.md
@@ -1050,7 +1050,8 @@ The test runner module must export a function with the following signature:
 
 ```ts
 function testRunner(
-  config: Config,
+  globalConfig: GlobalConfig,
+  config: ProjectConfig,
   environment: Environment,
   runtime: Runtime,
   testPath: string,


### PR DESCRIPTION
Commit 3749160188889142c2b904372f9b529e2180d3fb (v20.0.0~79, #3346) added the `globalConfig` parameter without updating this documentation.