### PR TITLE
fix: verify `rootDir` and all `roots` are directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 - `[jest-config]` Treat `setupFilesAfterEnv` like `setupFiles` when normalizing configs against presets ([#9495](https://github.com/facebook/jest/pull/9495))
 - `[jest-config]` Support `.mjs` config files on Windows as well ([#9558](https://github.com/facebook/jest/pull/9558))
-- `[jest-config]` Verify `rootDir` and all `roots` are directories
+- `[jest-config]` Verify `rootDir` and all `roots` are directories ([#9569](https://github.com/facebook/jest/pull/9569))
 - `[jest-cli]` Set `coverageProvider` correctly when provided in config ([#9562](https://github.com/facebook/jest/pull/9562))
 - `[jest-matcher-utils]` Fix diff highlight of symbol-keyed object. ([#9499](https://github.com/facebook/jest/pull/9499))
 - `[@jest/reporters]` Notifications should be fire&forget rather than having a timeout ([#9567](https://github.com/facebook/jest/pull/9567))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 - `[jest-config]` Treat `setupFilesAfterEnv` like `setupFiles` when normalizing configs against presets ([#9495](https://github.com/facebook/jest/pull/9495))
 - `[jest-config]` Support `.mjs` config files on Windows as well ([#9558](https://github.com/facebook/jest/pull/9558))
+- `[jest-config]` Verify `rootDir` and all `roots` are directories
 - `[jest-cli]` Set `coverageProvider` correctly when provided in config ([#9562](https://github.com/facebook/jest/pull/9562))
 - `[jest-matcher-utils]` Fix diff highlight of symbol-keyed object. ([#9499](https://github.com/facebook/jest/pull/9499))
 - `[@jest/reporters]` Notifications should be fire&forget rather than having a timeout ([#9567](https://github.com/facebook/jest/pull/9567))

--- a/e2e/__tests__/existentRoots.test.ts
+++ b/e2e/__tests__/existentRoots.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import * as path from 'path';
+import {tmpdir} from 'os';
+import {cleanup, writeFiles} from '../Utils';
+import runJest from '../runJest';
+
+const DIR = path.resolve(tmpdir(), 'existent-roots');
+
+beforeEach(() => cleanup(DIR));
+afterAll(() => cleanup(DIR));
+
+function writeConfig(rootDir: string, roots?: Array<string>) {
+  const config = {rootDir, roots};
+  const testFiles = {
+    'jest.config.js': `
+      module.exports = ${JSON.stringify(config, null, 2)};
+    `,
+  };
+
+  writeFiles(DIR, {
+    ...testFiles,
+    'package.json': '{}',
+  });
+}
+
+test('error when rootDir does not exist', () => {
+  const fakeRootDir = path.join(DIR, 'foobar');
+  writeConfig(fakeRootDir);
+
+  const {exitCode, stderr} = runJest(DIR);
+
+  expect(exitCode).toBe(1);
+  expect(stderr).toContain(
+    `Directory ${fakeRootDir} in the rootDir option was not found.`,
+  );
+});
+
+test('error when rootDir is a file', () => {
+  const fakeRootDir = path.join(DIR, 'jest.config.js');
+  writeConfig(fakeRootDir);
+
+  const {exitCode, stderr} = runJest(DIR);
+
+  expect(exitCode).toBe(1);
+  expect(stderr).toContain(
+    `${fakeRootDir} in the rootDir option is not a directory.`,
+  );
+});
+
+test('error when roots directory does not exist', () => {
+  const fakeRootDir = path.join(DIR, 'foobar');
+  writeConfig(DIR, ['<rootDir>', fakeRootDir]);
+
+  const {exitCode, stderr} = runJest(DIR);
+
+  expect(exitCode).toBe(1);
+  expect(stderr).toContain(
+    `Directory ${fakeRootDir} in the roots[1] option was not found.`,
+  );
+});
+
+test('error when roots is a file', () => {
+  const fakeRootDir = path.join(DIR, 'jest.config.js');
+  writeConfig(DIR, ['<rootDir>', fakeRootDir]);
+
+  const {exitCode, stderr} = runJest(DIR);
+
+  expect(exitCode).toBe(1);
+  expect(stderr).toContain(
+    `${fakeRootDir} in the roots[1] option is not a directory.`,
+  );
+});

--- a/e2e/__tests__/existentRoots.test.ts
+++ b/e2e/__tests__/existentRoots.test.ts
@@ -7,6 +7,7 @@
 
 import * as path from 'path';
 import {tmpdir} from 'os';
+import {skipSuiteOnWindows} from '@jest/test-utils';
 import {cleanup, writeFiles} from '../Utils';
 import runJest from '../runJest';
 
@@ -14,6 +15,8 @@ const DIR = path.resolve(tmpdir(), 'existent-roots');
 
 beforeEach(() => cleanup(DIR));
 afterAll(() => cleanup(DIR));
+
+skipSuiteOnWindows();
 
 function writeConfig(rootDir: string, roots?: Array<string>) {
   writeFiles(DIR, {

--- a/e2e/__tests__/existentRoots.test.ts
+++ b/e2e/__tests__/existentRoots.test.ts
@@ -16,15 +16,10 @@ beforeEach(() => cleanup(DIR));
 afterAll(() => cleanup(DIR));
 
 function writeConfig(rootDir: string, roots?: Array<string>) {
-  const config = {rootDir, roots};
-  const testFiles = {
-    'jest.config.js': `
-      module.exports = ${JSON.stringify(config, null, 2)};
-    `,
-  };
-
   writeFiles(DIR, {
-    ...testFiles,
+    'jest.config.js': `
+      module.exports = ${JSON.stringify({rootDir, roots}, null, 2)};
+    `,
     'package.json': '{}',
   });
 }

--- a/e2e/__tests__/existentRoots.test.ts
+++ b/e2e/__tests__/existentRoots.test.ts
@@ -7,15 +7,10 @@
 
 import * as path from 'path';
 import {tmpdir} from 'os';
-import {sync as realpath} from 'realpath-native';
 import {cleanup, writeFiles} from '../Utils';
 import runJest from '../runJest';
 
-let DIR = path.resolve(tmpdir(), 'existent-roots');
-
-try {
-  DIR = realpath(DIR);
-} catch {}
+const DIR = path.resolve(tmpdir(), 'existent-roots');
 
 beforeEach(() => cleanup(DIR));
 afterAll(() => cleanup(DIR));

--- a/e2e/__tests__/existentRoots.test.ts
+++ b/e2e/__tests__/existentRoots.test.ts
@@ -7,10 +7,15 @@
 
 import * as path from 'path';
 import {tmpdir} from 'os';
+import {sync as realpath} from 'realpath-native';
 import {cleanup, writeFiles} from '../Utils';
 import runJest from '../runJest';
 
-const DIR = path.resolve(tmpdir(), 'existent-roots');
+let DIR = path.resolve(tmpdir(), 'existent-roots');
+
+try {
+  DIR = realpath(DIR);
+} catch {}
 
 beforeEach(() => cleanup(DIR));
 afterAll(() => cleanup(DIR));

--- a/packages/jest-config/src/__tests__/normalize.test.js
+++ b/packages/jest-config/src/__tests__/normalize.test.js
@@ -16,7 +16,17 @@ import {DEFAULT_JS_PATTERN} from '../constants';
 
 const DEFAULT_CSS_PATTERN = '^.+\\.(css)$';
 
-jest.mock('jest-resolve').mock('path', () => jest.requireActual('path').posix);
+jest
+  .mock('jest-resolve')
+  .mock('path', () => jest.requireActual('path').posix)
+  .mock('fs', () => {
+    const realFs = jest.requireActual('fs');
+
+    return {
+      ...realFs,
+      statSync: () => ({isDirectory: () => true}),
+    };
+  });
 
 let root;
 let expectedPathFooBar;

--- a/packages/jest-core/src/__tests__/SearchSource.test.ts
+++ b/packages/jest-core/src/__tests__/SearchSource.test.ts
@@ -15,6 +15,21 @@ import SearchSource, {SearchResult} from '../SearchSource';
 
 jest.setTimeout(15000);
 
+jest.mock('fs', () => {
+  const realFs = jest.requireActual('fs');
+
+  return {
+    ...realFs,
+    statSync: path => {
+      if (path === '/foo/bar/prefix') {
+        return {isDirectory: () => true};
+      }
+
+      return realFs.statSync(path);
+    },
+  };
+});
+
 const rootDir = path.resolve(__dirname, 'test_root');
 const testRegex = path.sep + '__testtests__' + path.sep;
 const testMatch = ['**/__testtests__/**/*'];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

See #9549 for background.

This _could_ be considered a breaking change and I can print a warning instead?. Also, as mentioned in #9549, should we verify that `roots` exist in `jest-haste-map` as well? Not sure how that affects Metro, but `jest-haste-map` is super inconsistent in how it handles missing `roots` depending on whether Watchman is used and if the OS is Windows.

Closes #9549.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Integration tests added

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
