### PR TITLE
fix(jest-types): make `ConfigGlobal` an interace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixes
 
 - `[expect]` Handle readonly properties correctly ([#9575](https://github.com/facebook/jest/pull/9575))
+- `[@jest/types]` Make `ConfigGlobals` an interface to allow for declaration merging. ([#9570](https://github.com/facebook/jest/pull/9570))
 - `[jest-config]` Treat `setupFilesAfterEnv` like `setupFiles` when normalizing configs against presets ([#9495](https://github.com/facebook/jest/pull/9495))
 - `[jest-config]` Support `.mjs` config files on Windows as well ([#9558](https://github.com/facebook/jest/pull/9558))
 - `[jest-config]` Verify `rootDir` and all `roots` are directories ([#9569](https://github.com/facebook/jest/pull/9569))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@
 ### Fixes
 
 - `[expect]` Handle readonly properties correctly ([#9575](https://github.com/facebook/jest/pull/9575))
-- `[@jest/types]` Make `ConfigGlobals` an interface to allow for declaration merging. ([#9570](https://github.com/facebook/jest/pull/9570))
 - `[jest-config]` Treat `setupFilesAfterEnv` like `setupFiles` when normalizing configs against presets ([#9495](https://github.com/facebook/jest/pull/9495))
 - `[jest-config]` Support `.mjs` config files on Windows as well ([#9558](https://github.com/facebook/jest/pull/9558))
 - `[jest-config]` Verify `rootDir` and all `roots` are directories ([#9569](https://github.com/facebook/jest/pull/9569))
@@ -30,6 +29,7 @@
 - `[jest-snapshot]` Properly indent new snapshots in the presences of existing ones ([#9523](https://github.com/facebook/jest/pull/9523))
 - `[jest-transform]` Correct sourcemap behavior for transformed and instrumented code ([#9460](https://github.com/facebook/jest/pull/9460))
 - `[jest-transform]` Allow instrumentation of transformed files with weird file extensions ([#9589](https://github.com/facebook/jest/pull/9589))
+- `[@jest/types]` Make `ConfigGlobals` an interface to allow for declaration merging. ([#9570](https://github.com/facebook/jest/pull/9570))
 - `[pretty-format]` Export `OldPlugin` type ([#9491](https://github.com/facebook/jest/pull/9491))
 
 ### Chore & Maintenance

--- a/packages/jest-config/package.json
+++ b/packages/jest-config/package.json
@@ -15,6 +15,7 @@
     "@jest/types": "^25.1.0",
     "babel-jest": "^25.1.0",
     "chalk": "^3.0.0",
+    "deepmerge": "^4.2.2",
     "glob": "^7.1.1",
     "jest-environment-jsdom": "^25.1.0",
     "jest-environment-node": "^25.1.0",

--- a/packages/jest-config/src/__tests__/normalize.test.js
+++ b/packages/jest-config/src/__tests__/normalize.test.js
@@ -1251,9 +1251,11 @@ describe('preset with globals', () => {
       '/node_modules/global-foo/jest-preset.json',
       () => ({
         globals: {
+          __DEV__: false,
           config: {
             hereToStay: 'This should stay here',
           },
+          myString: 'hello world',
         },
       }),
       {virtual: true},
@@ -1268,9 +1270,11 @@ describe('preset with globals', () => {
     const {options} = normalize(
       {
         globals: {
+          __DEV__: true,
           config: {
             sideBySide: 'This should also live another day',
           },
+          myString: 'hello sunshine',
           textValue: 'This is just text',
         },
         preset: 'global-foo',
@@ -1279,17 +1283,15 @@ describe('preset with globals', () => {
       {},
     );
 
-    expect(options).toEqual(
-      expect.objectContaining({
-        globals: {
-          config: {
-            hereToStay: 'This should stay here',
-            sideBySide: 'This should also live another day',
-          },
-          textValue: 'This is just text',
-        },
-      }),
-    );
+    expect(options.globals).toEqual({
+      __DEV__: true,
+      config: {
+        hereToStay: 'This should stay here',
+        sideBySide: 'This should also live another day',
+      },
+      myString: 'hello sunshine',
+      textValue: 'This is just text',
+    });
   });
 });
 

--- a/packages/jest-config/src/normalize.ts
+++ b/packages/jest-config/src/normalize.ts
@@ -17,6 +17,7 @@ import micromatch = require('micromatch');
 import {sync as realpath} from 'realpath-native';
 import Resolver = require('jest-resolve');
 import {replacePathSepForRegex} from 'jest-regex-util';
+import merge = require('deepmerge');
 import validatePattern from './validatePattern';
 import getMaxWorkers from './getMaxWorkers';
 import {
@@ -112,12 +113,7 @@ const mergeGlobalsWithPreset = (
   preset: Config.InitialOptions,
 ) => {
   if (options['globals'] && preset['globals']) {
-    for (const p in preset['globals']) {
-      options['globals'][p] = {
-        ...preset['globals'][p],
-        ...options['globals'][p],
-      };
-    }
+    options['globals'] = merge(preset['globals'], options['globals']);
   }
 };
 

--- a/packages/jest-types/src/Config.ts
+++ b/packages/jest-types/src/Config.ts
@@ -27,7 +27,9 @@ export type HasteConfig = {
 export type ReporterConfig = [string, Record<string, unknown>];
 export type TransformerConfig = [string, Record<string, unknown>];
 
-export type ConfigGlobals = Record<string, any>;
+export interface ConfigGlobals {
+  [K: string]: any;
+}
 
 export type DefaultOptions = {
   automock: boolean;

--- a/packages/jest-types/src/Config.ts
+++ b/packages/jest-types/src/Config.ts
@@ -28,7 +28,7 @@ export type ReporterConfig = [string, Record<string, unknown>];
 export type TransformerConfig = [string, Record<string, unknown>];
 
 export interface ConfigGlobals {
-  [K: string]: any;
+  [K: string]: unknown;
 }
 
 export type DefaultOptions = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5221,6 +5221,11 @@ deepmerge@^3.2.0:
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-3.3.0.tgz#d3c47fd6f3a93d517b14426b0628a17b0125f5f7"
   integrity sha512-GRQOafGHwMHpjPx9iCvTgpu9NojZ49q794EEL94JVEw6VaeA8XTUyBKvAkOOjBX9oJNiV6G3P+T+tihFjo2TqA==
 
+deepmerge@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
+  integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
+
 defaults@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/defaults/-/defaults-1.0.3.tgz#c656051e9817d9ff08ed881477f3fe4019f3ef7d"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

As discussed [here](https://github.com/facebook/jest/issues/9529#issuecomment-583556696).

## Summary

Makes `ConfigGlobal` an interface to allow for declaration merging:

```
// ts-jest/index.d.ts
declare module '@jest/types' {
  namespace Config {
    interface ConfigGlobals {
      'ts-jest': TsJestGlobalOptions;
    }
  }
}

// jest.config.js
/** @type {import('@jest/types').Config.InitialOptions} */
const config= {
  globals: {
    'ts-jest': {
      isolatedModules: true,
      myProperty: 1 // error, "myProperty" is not defined!
    }
  }
}

module.exports = config;
```
## Test plan

None 😬 