### PR TITLE
adds ability to pass custom reporter options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - `[jest-runtime]` Override `module.createRequire` to return a Jest-compatible `require` function ([#9469](https://github.com/facebook/jest/pull/9469))
 - `[*]` Support array of paths for `moduleNameMapper` aliases ([#9465](https://github.com/facebook/jest/pull/9465))
+- `[jest-reporters]` Adds ability to pass options to the istanbul-reporter through `coverageReporters` ([#9572](https://github.com/facebook/jest/pull/9572))
 
 ### Fixes
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -195,13 +195,19 @@ Note that using `v8` is considered experimental. This uses V8's builtin code cov
 1. Tests needs to run in Node test environment (support for `jsdom` requires [`jest-environment-jsdom-sixteen`](https://www.npmjs.com/package/jest-environment-jsdom-sixteen))
 1. V8 has way better data in the later versions, so using the latest versions of node (v13 at the time of this writing) will yield better results
 
-### `coverageReporters` [array\<string>]
+### `coverageReporters` [array\<string | [string,any]>]
 
 Default: `["json", "lcov", "text", "clover"]`
 
 A list of reporter names that Jest uses when writing coverage reports. Any [istanbul reporter](https://github.com/istanbuljs/istanbuljs/tree/master/packages/istanbul-reports/lib) can be used.
 
 _Note: Setting this option overwrites the default values. Add `"text"` or `"text-summary"` to see a coverage summary in the console output._
+
+_Nost: You can pass additional options to the istanbul reporter using the tuple form. For example:
+
+```js
+["json", ["lcov", { "projectRoot": "../../"}]]
+```
 
 ### `coverageThreshold` [object]
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -203,10 +203,10 @@ A list of reporter names that Jest uses when writing coverage reports. Any [ista
 
 _Note: Setting this option overwrites the default values. Add `"text"` or `"text-summary"` to see a coverage summary in the console output._
 
-_Nost: You can pass additional options to the istanbul reporter using the tuple form. For example:
+_Note: You can pass additional options to the istanbul reporter using the tuple form. For example:_
 
-```js
-["json", ["lcov", { "projectRoot": "../../"}]]
+```json
+["json", ["lcov", {"projectRoot": "../../"}]]
 ```
 
 ### `coverageThreshold` [object]

--- a/packages/jest-reporters/src/__tests__/coverage_reporter.test.js
+++ b/packages/jest-reporters/src/__tests__/coverage_reporter.test.js
@@ -20,6 +20,7 @@ jest
 let libCoverage;
 let libSourceMaps;
 let CoverageReporter;
+let istanbulReports;
 
 import path from 'path';
 import mock from 'mock-fs';
@@ -28,6 +29,7 @@ beforeEach(() => {
   CoverageReporter = require('../coverage_reporter').default;
   libCoverage = require('istanbul-lib-coverage');
   libSourceMaps = require('istanbul-lib-source-maps');
+  istanbulReports = require('istanbul-reports');
 
   const fileTree = {};
   fileTree[process.cwd() + '/path-test-files'] = {
@@ -414,6 +416,25 @@ describe('onRunComplete', () => {
     return testReporter
       .onRunComplete(new Set(), {}, mockAggResults)
       .then(() => {
+        expect(testReporter.getLastError()).toBeUndefined();
+      });
+  });
+
+  test(`that it passes custom options when creating reporters`, () => {
+    const testReporter = new CoverageReporter({
+      coverageReporters: ['json', ['lcov', {maxCols: 10, projectRoot: './'}]],
+    });
+    testReporter.log = jest.fn();
+    return testReporter
+      .onRunComplete(new Set(), {}, mockAggResults)
+      .then(() => {
+        expect(istanbulReports.create).toHaveBeenCalledWith('json', {
+          maxCols: process.stdout.columns || Infinity,
+        });
+        expect(istanbulReports.create).toHaveBeenCalledWith('lcov', {
+          maxCols: process.stdout.columns || Infinity,
+          projectRoot: './',
+        });
         expect(testReporter.getLastError()).toBeUndefined();
       });
   });

--- a/packages/jest-reporters/src/__tests__/coverage_reporter.test.js
+++ b/packages/jest-reporters/src/__tests__/coverage_reporter.test.js
@@ -432,7 +432,7 @@ describe('onRunComplete', () => {
           maxCols: process.stdout.columns || Infinity,
         });
         expect(istanbulReports.create).toHaveBeenCalledWith('lcov', {
-          maxCols: process.stdout.columns || Infinity,
+          maxCols: 10,
           projectRoot: './',
         });
         expect(testReporter.getLastError()).toBeUndefined();

--- a/packages/jest-reporters/src/coverage_reporter.ts
+++ b/packages/jest-reporters/src/coverage_reporter.ts
@@ -104,8 +104,15 @@ export default class CoverageReporter extends BaseReporter {
         coverageReporters.push('text-summary');
       }
       coverageReporters.forEach(reporter => {
+        let additionalOptions = {};
+        if (Array.isArray(reporter)) {
+          [reporter, additionalOptions] = reporter;
+        }
         istanbulReports
-          .create(reporter, {maxCols: process.stdout.columns || Infinity})
+          .create(reporter, {
+            ...additionalOptions,
+            maxCols: process.stdout.columns || Infinity,
+          })
           // @ts-ignore
           .execute(reportContext);
       });

--- a/packages/jest-reporters/src/coverage_reporter.ts
+++ b/packages/jest-reporters/src/coverage_reporter.ts
@@ -110,8 +110,8 @@ export default class CoverageReporter extends BaseReporter {
         }
         istanbulReports
           .create(reporter, {
-            ...additionalOptions,
             maxCols: process.stdout.columns || Infinity,
+            ...additionalOptions,
           })
           // @ts-ignore
           .execute(reportContext);

--- a/packages/jest-types/src/Config.ts
+++ b/packages/jest-types/src/Config.ts
@@ -39,7 +39,7 @@ export type DefaultOptions = {
   clearMocks: boolean;
   collectCoverage: boolean;
   coveragePathIgnorePatterns: Array<string>;
-  coverageReporters: Array<string>;
+  coverageReporters: Array<string | [string, any]>;
   coverageProvider: CoverageProvider;
   errorOnDeprecated: boolean;
   expand: boolean;
@@ -241,7 +241,7 @@ export type GlobalConfig = {
   coverageDirectory: string;
   coveragePathIgnorePatterns?: Array<string>;
   coverageProvider: CoverageProvider;
-  coverageReporters: Array<keyof ReportOptions>;
+  coverageReporters: Array<keyof ReportOptions | [keyof ReportOptions, any]>;
   coverageThreshold?: CoverageThreshold;
   detectLeaks: boolean;
   detectOpenHandles: boolean;


### PR DESCRIPTION
Istanbul-reporters recently [changed](https://github.com/istanbuljs/istanbuljs/issues/529) their coverage reporting behaviour by introducing the `projectRoot` options.

This PR attempts to right the wrong and let a jest user configure the `projectRoot` right from the jest config by introducing the configuration through the well known tuple pattern.

Fixes #4103