### PR TITLE
fix(cli): .cjs files support by "--config" option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - `[jest-config]` Support `.mjs` config files on Windows as well ([#9558](https://github.com/facebook/jest/pull/9558))
 - `[jest-config]` Verify `rootDir` and all `roots` are directories ([#9569](https://github.com/facebook/jest/pull/9569))
 - `[jest-cli]` Set `coverageProvider` correctly when provided in config ([#9562](https://github.com/facebook/jest/pull/9562))
+- `[jest-cli]` Allow specifying `.cjs` and `.mjs` config files by `--config` CLI option ([#9578](https://github.com/facebook/jest/pull/9578))
 - `[jest-config]` Ensure pattern of `replacePosixSep` is a string ([#9546]https://github.com/facebook/jest/pull/9546)
 - `[jest-matcher-utils]` Fix diff highlight of symbol-keyed object. ([#9499](https://github.com/facebook/jest/pull/9499))
 - `[@jest/reporters]` Notifications should be fire&forget rather than having a timeout ([#9567](https://github.com/facebook/jest/pull/9567))

--- a/packages/jest-cli/src/__tests__/cli/args.test.ts
+++ b/packages/jest-cli/src/__tests__/cli/args.test.ts
@@ -62,7 +62,32 @@ describe('check', () => {
   it('raises an exception if config is not a valid JSON string', () => {
     const argv = {config: 'x:1'} as Config.Argv;
     expect(() => check(argv)).toThrow(
-      'The --config option requires a JSON string literal, or a file path with a .js or .json extension',
+      'The --config option requires a JSON string literal, or a file path with a .js, .cjs, or .json extension',
+    );
+  });
+
+  it('raises an exception if config is not a js/cjs/json file path', () => {
+    expect(() =>
+      check({config: 'jest.config.js'} as Config.Argv),
+    ).not.toThrow();
+    expect(() =>
+      check({config: '../test/test/my_conf.js'} as Config.Argv),
+    ).not.toThrow();
+    expect(() =>
+      check({config: 'jest.config.cjs'} as Config.Argv),
+    ).not.toThrow();
+    expect(() =>
+      check({config: 'jest.config.json'} as Config.Argv),
+    ).not.toThrow();
+
+    const message =
+      'The --config option requires a JSON string literal, or a file path with a .js, .cjs, or .json extension';
+
+    expect(() => check({config: 'jest.config.mjs'} as Config.Argv)).toThrow(
+      message,
+    );
+    expect(() => check({config: 'jest.config.ts'} as Config.Argv)).toThrow(
+      message,
     );
   });
 });

--- a/packages/jest-cli/src/__tests__/cli/args.test.ts
+++ b/packages/jest-cli/src/__tests__/cli/args.test.ts
@@ -7,6 +7,7 @@
  */
 
 import {Config} from '@jest/types';
+import {constants} from 'jest-config';
 import {check} from '../../cli/args';
 import {buildArgv} from '../../cli';
 
@@ -59,34 +60,33 @@ describe('check', () => {
     expect(() => check(argv)).not.toThrow();
   });
 
+  test.each(constants.JEST_CONFIG_EXT_ORDER.map(e => e.substring(1)))(
+    'allows using "%s" file for --config option',
+    ext => {
+      expect(() =>
+        check({config: `jest.config.${ext}`} as Config.Argv),
+      ).not.toThrow();
+      expect(() =>
+        check({config: `../test/test/my_conf.${ext}`} as Config.Argv),
+      ).not.toThrow();
+    },
+  );
+
   it('raises an exception if config is not a valid JSON string', () => {
     const argv = {config: 'x:1'} as Config.Argv;
     expect(() => check(argv)).toThrow(
-      'The --config option requires a JSON string literal, or a file path with a .js, .cjs, or .json extension',
+      'The --config option requires a JSON string literal, or a file path with one of these extensions: .js, .mjs, .cjs, .json',
     );
   });
 
-  it('raises an exception if config is not a js/cjs/json file path', () => {
-    expect(() =>
-      check({config: 'jest.config.js'} as Config.Argv),
-    ).not.toThrow();
-    expect(() =>
-      check({config: '../test/test/my_conf.js'} as Config.Argv),
-    ).not.toThrow();
-    expect(() =>
-      check({config: 'jest.config.cjs'} as Config.Argv),
-    ).not.toThrow();
-    expect(() =>
-      check({config: 'jest.config.json'} as Config.Argv),
-    ).not.toThrow();
-
+  it('raises an exception if config is not a supported file type', () => {
     const message =
-      'The --config option requires a JSON string literal, or a file path with a .js, .cjs, or .json extension';
+      'The --config option requires a JSON string literal, or a file path with one of these extensions: .js, .mjs, .cjs, .json';
 
-    expect(() => check({config: 'jest.config.mjs'} as Config.Argv)).toThrow(
+    expect(() => check({config: 'jest.configjs'} as Config.Argv)).toThrow(
       message,
     );
-    expect(() => check({config: 'jest.config.ts'} as Config.Argv)).toThrow(
+    expect(() => check({config: 'jest.config.exe'} as Config.Argv)).toThrow(
       message,
     );
   });

--- a/packages/jest-cli/src/cli/args.ts
+++ b/packages/jest-cli/src/cli/args.ts
@@ -6,7 +6,7 @@
  */
 
 import {Config} from '@jest/types';
-import {isJSONString} from 'jest-config';
+import {constants, isJSONString} from 'jest-config';
 import isCI = require('is-ci');
 
 export function check(argv: Config.Argv): true {
@@ -52,11 +52,19 @@ export function check(argv: Config.Argv): true {
   if (
     argv.config &&
     !isJSONString(argv.config) &&
-    !argv.config.match(/\.(js|cjs|json)$/)
+    !argv.config.match(
+      new RegExp(
+        `\\.(${constants.JEST_CONFIG_EXT_ORDER.map(e => e.substring(1)).join(
+          '|',
+        )})$`,
+        'i',
+      ),
+    )
   ) {
     throw new Error(
-      'The --config option requires a JSON string literal, or a file path with a .js, .cjs, or .json extension.\n' +
-        'Example usage: jest --config ./jest.config.js',
+      `The --config option requires a JSON string literal, or a file path with one of these extensions: ${constants.JEST_CONFIG_EXT_ORDER.join(
+        ', ',
+      )}.\nExample usage: jest --config ./jest.config.js`,
     );
   }
 

--- a/packages/jest-cli/src/cli/args.ts
+++ b/packages/jest-cli/src/cli/args.ts
@@ -52,10 +52,10 @@ export function check(argv: Config.Argv): true {
   if (
     argv.config &&
     !isJSONString(argv.config) &&
-    !argv.config.match(/\.js(on)?$/)
+    !argv.config.match(/\.(js|cjs|json)$/)
   ) {
     throw new Error(
-      'The --config option requires a JSON string literal, or a file path with a .js or .json extension.\n' +
+      'The --config option requires a JSON string literal, or a file path with a .js, .cjs, or .json extension.\n' +
         'Example usage: jest --config ./jest.config.js',
     );
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Fixes `.cjs` file validation for CLI `--config` option. Jest supports such files already, but CLI args validation wasn't updated (#9086).

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Try to run jest by specifying a `.cjs` config manually:

```sh
$ jest --config path/jest.config.cjs
```

It should successfully load the config.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
