### PR TITLE
[jest-haste-map] Remove `mapper` option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - `[jest-config]` Support ESM config files with `.js` extension ([#9573](https://github.com/facebook/jest/9573)).
 - `[jest-runtime]` Override `module.createRequire` to return a Jest-compatible `require` function ([#9469](https://github.com/facebook/jest/pull/9469))
+- `[jest-haste-map]` [**BREAKING**] Remove `mapper` option ([#9581](https://github.com/facebook/jest/pull/9581))
 - `[*]` Support array of paths for `moduleNameMapper` aliases ([#9465](https://github.com/facebook/jest/pull/9465))
 - `[jest-reporters]` Adds ability to pass options to the istanbul-reporter through `coverageReporters` ([#9572](https://github.com/facebook/jest/pull/9572))
 

--- a/packages/jest-haste-map/src/__tests__/index.test.js
+++ b/packages/jest-haste-map/src/__tests__/index.test.js
@@ -426,7 +426,6 @@ describe('HasteMap', () => {
         const hasteMap = new HasteMap({
           ...defaultConfig,
           computeSha1: true,
-          mapper: file => [file],
           maxWorkers: 1,
           useWatchman,
         });

--- a/packages/jest-haste-map/src/crawlers/__tests__/watchman.test.js
+++ b/packages/jest-haste-map/src/crawlers/__tests__/watchman.test.js
@@ -44,7 +44,6 @@ const STRAWBERRY_RELATIVE = path.join(FRUITS_RELATIVE, 'strawberry.js');
 const KIWI_RELATIVE = path.join(FRUITS_RELATIVE, 'kiwi.js');
 const TOMATO_RELATIVE = path.join(FRUITS_RELATIVE, 'tomato.js');
 const MELON_RELATIVE = path.join(VEGETABLES_RELATIVE, 'melon.json');
-const DURIAN_RELATIVE = path.join(VEGETABLES_RELATIVE, 'durian.zip');
 
 const WATCH_PROJECT_MOCK = {
   [FRUITS]: {
@@ -173,56 +172,6 @@ describe('watchman watch', () => {
 
       expect(client.end).toBeCalled();
     }));
-
-  test('applies the mapper when needed', () => {
-    mockResponse = {
-      'list-capabilities': {
-        [undefined]: {
-          capabilities: ['field-content.sha1hex'],
-        },
-      },
-      query: {
-        [ROOT_MOCK]: {
-          clock: 'c:fake-clock:1',
-          files: [
-            {
-              exists: true,
-              mtime_ms: {toNumber: () => 33},
-              name: 'vegetables/durian.zip',
-              size: 43,
-            },
-          ],
-          is_fresh_instance: true,
-          version: '4.5.0',
-        },
-      },
-      'watch-project': WATCH_PROJECT_MOCK,
-    };
-
-    return watchmanCrawl({
-      data: {
-        clocks: new Map(),
-        files: new Map(),
-      },
-      extensions: ['js', 'json', 'zip'],
-      ignore: pearMatcher,
-      mapper: n =>
-        n.endsWith('.zip')
-          ? [path.join(n, 'foo.1.js'), path.join(n, 'foo.2.js')]
-          : null,
-      rootDir: ROOT_MOCK,
-      roots: ROOTS,
-    }).then(({changedFiles, hasteMap, removedFiles}) => {
-      expect(changedFiles).toEqual(undefined);
-      expect(hasteMap.files).toEqual(
-        createMap({
-          [path.join(DURIAN_RELATIVE, 'foo.1.js')]: ['', 33, 43, 0, '', null],
-          [path.join(DURIAN_RELATIVE, 'foo.2.js')]: ['', 33, 43, 0, '', null],
-        }),
-      );
-      expect(removedFiles).toEqual(new Map());
-    });
-  });
 
   test('updates file map and removedFiles when the clock is given', () => {
     mockResponse = {

--- a/packages/jest-haste-map/src/crawlers/watchman.ts
+++ b/packages/jest-haste-map/src/crawlers/watchman.ts
@@ -235,23 +235,8 @@ export = async function watchmanCrawl(
           nextData = ['', mtime, size, 0, '', sha1hex];
         }
 
-        const mappings = options.mapper ? options.mapper(filePath) : null;
-
-        if (mappings) {
-          for (const absoluteVirtualFilePath of mappings) {
-            if (!ignore(absoluteVirtualFilePath)) {
-              const relativeVirtualFilePath = fastPath.relative(
-                rootDir,
-                absoluteVirtualFilePath,
-              );
-              files.set(relativeVirtualFilePath, nextData);
-              changedFiles.set(relativeVirtualFilePath, nextData);
-            }
-          }
-        } else {
-          files.set(relativeFilePath, nextData);
-          changedFiles.set(relativeFilePath, nextData);
-        }
+        files.set(relativeFilePath, nextData);
+        changedFiles.set(relativeFilePath, nextData);
       }
     }
   }

--- a/packages/jest-haste-map/src/index.ts
+++ b/packages/jest-haste-map/src/index.ts
@@ -39,7 +39,6 @@ import {
   HasteRegExp,
   InternalHasteMap,
   HasteMap as InternalHasteMapObject,
-  Mapper,
   MockData,
   ModuleMapData,
   ModuleMetaData,
@@ -58,7 +57,6 @@ type Options = {
   forceNodeFilesystemAPI?: boolean;
   hasteImplModulePath?: string;
   ignorePattern?: HasteRegExp;
-  mapper?: Mapper;
   maxWorkers: number;
   mocksPattern?: string;
   name: string;
@@ -83,7 +81,6 @@ type InternalOptions = {
   forceNodeFilesystemAPI: boolean;
   hasteImplModulePath?: string;
   ignorePattern?: HasteRegExp;
-  mapper?: Mapper;
   maxWorkers: number;
   mocksPattern: RegExp | null;
   name: string;
@@ -261,7 +258,6 @@ class HasteMap extends EventEmitter {
       forceNodeFilesystemAPI: !!options.forceNodeFilesystemAPI,
       hasteImplModulePath: options.hasteImplModulePath,
       ignorePattern: options.ignorePattern,
-      mapper: options.mapper,
       maxWorkers: options.maxWorkers,
       mocksPattern: options.mocksPattern
         ? new RegExp(options.mocksPattern)
@@ -755,7 +751,6 @@ class HasteMap extends EventEmitter {
       extensions: options.extensions,
       forceNodeFilesystemAPI: options.forceNodeFilesystemAPI,
       ignore,
-      mapper: options.mapper,
       rootDir: options.rootDir,
       roots: options.roots,
     };

--- a/packages/jest-haste-map/src/types.ts
+++ b/packages/jest-haste-map/src/types.ts
@@ -11,7 +11,6 @@ import ModuleMap from './ModuleMap';
 import HasteFS from './HasteFS';
 
 export type IgnoreMatcher = (item: string) => boolean;
-export type Mapper = (item: string) => Array<string> | null;
 
 export type WorkerMessage = {
   computeDependencies: boolean;
@@ -35,7 +34,6 @@ export type CrawlerOptions = {
   extensions: Array<string>;
   forceNodeFilesystemAPI: boolean;
   ignore: IgnoreMatcher;
-  mapper?: Mapper | null;
   rootDir: string;
   roots: Array<string>;
 };


### PR DESCRIPTION
## Summary
This option was added a while back to support some use-cases with Yarn PnP but it was neither documented nor is this how I would solve the problem of files not being materialized as this functionality has the potential to de-opt operations in Jest's haste map.

This PR removes the option.

## Test plan

yolo