### PR TITLE
fix: vscode eslint on save settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,9 @@
     "**/node_modules": true,
     "**/build": true
   },
-  "eslint.autoFixOnSave": true,
   "javascript.validate.enable": false,
-  "jest.pathToJest": "yarn jest --"
+  "jest.pathToJest": "yarn jest --",
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  }
 }


### PR DESCRIPTION
## Summary

`eslint.autoFixOnSave` was deprecated.

## Test plan

VSCode on save runs eslint
