### PR TITLE
chore: move execution of `setupFiles` to `jest-runner`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@
 
 - `[docs]` Warn about unexpected behavior / bug of node-notifier when using the `notify` options.
 - `[jest-resolver]` Use `resolve` package to implement custom module resolution ([#9520](https://github.com/facebook/jest/pull/9520))
-- `[jest-runtime]` Move execution of `setupFiles` to `jest-runner`
+- `[jest-runtime]` Move execution of `setupFiles` to `jest-runner` ([#9596](https://github.com/facebook/jest/pull/9596))
 - `[@jest/reporters]` Remove unused dependencies and type exports ([#9462](https://github.com/facebook/jest/pull/9462))
 - `[website]` Update pictures of reports when matchers fail ([#9214](https://github.com/facebook/jest/pull/9214))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 
 - `[docs]` Warn about unexpected behavior / bug of node-notifier when using the `notify` options.
 - `[jest-resolver]` Use `resolve` package to implement custom module resolution ([#9520](https://github.com/facebook/jest/pull/9520))
+- `[jest-runtime]` Move execution of `setupFiles` to `jest-runner`
 - `[@jest/reporters]` Remove unused dependencies and type exports ([#9462](https://github.com/facebook/jest/pull/9462))
 - `[website]` Update pictures of reports when matchers fail ([#9214](https://github.com/facebook/jest/pull/9214))
 

--- a/packages/jest-jasmine2/src/index.ts
+++ b/packages/jest-jasmine2/src/index.ts
@@ -155,9 +155,7 @@ async function jasmine2(
       testPath,
     });
 
-  config.setupFilesAfterEnv.forEach((path: Config.Path) =>
-    runtime.requireModule(path),
-  );
+  config.setupFilesAfterEnv.forEach(path => runtime.requireModule(path));
 
   if (globalConfig.enabledTestsMap) {
     env.specFilter = (spec: Spec) => {

--- a/packages/jest-runner/src/runTest.ts
+++ b/packages/jest-runner/src/runTest.ts
@@ -163,6 +163,8 @@ async function runTestInternal(
 
   const start = Date.now();
 
+  config.setupFiles.forEach(path => runtime!.requireModule(path));
+
   const sourcemapOptions: sourcemapSupport.Options = {
     environment: 'node',
     handleUncaughtExceptions: false,

--- a/packages/jest-runtime/src/cli/index.ts
+++ b/packages/jest-runtime/src/cli/index.ts
@@ -93,6 +93,9 @@ export async function run(
     setGlobal(environment.global, 'jestGlobalConfig', globalConfig);
 
     const runtime = new Runtime(config, environment, hasteMap.resolver);
+
+    config.setupFiles.forEach(path => runtime.requireModule(path));
+
     runtime.requireModule(filePath);
   } catch (e) {
     console.error(chalk.red(e.stack || e));

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -185,12 +185,6 @@ class Runtime {
     }
 
     this.resetModules();
-
-    if (config.setupFiles.length) {
-      for (let i = 0; i < config.setupFiles.length; i++) {
-        this.requireModule(config.setupFiles[i]);
-      }
-    }
   }
 
   static shouldInstrument = shouldInstrument;

--- a/packages/jest-util/src/index.ts
+++ b/packages/jest-util/src/index.ts
@@ -5,36 +5,20 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import clearLine from './clearLine';
-import createDirectory from './createDirectory';
-import ErrorWithStack from './ErrorWithStack';
-import installCommonGlobals from './installCommonGlobals';
-import interopRequireDefault from './interopRequireDefault';
-import isInteractive from './isInteractive';
-import isPromise from './isPromise';
-import setGlobal from './setGlobal';
-import deepCyclicCopy from './deepCyclicCopy';
-import convertDescriptorToString from './convertDescriptorToString';
+export {default as clearLine} from './clearLine';
+export {default as createDirectory} from './createDirectory';
+export {default as ErrorWithStack} from './ErrorWithStack';
+export {default as installCommonGlobals} from './installCommonGlobals';
+export {default as interopRequireDefault} from './interopRequireDefault';
+export {default as isInteractive} from './isInteractive';
+export {default as isPromise} from './isPromise';
+export {default as setGlobal} from './setGlobal';
+export {default as deepCyclicCopy} from './deepCyclicCopy';
+export {default as convertDescriptorToString} from './convertDescriptorToString';
 import * as specialChars from './specialChars';
-import replacePathSepForGlob from './replacePathSepForGlob';
-import testPathPatternToRegExp from './testPathPatternToRegExp';
+export {default as replacePathSepForGlob} from './replacePathSepForGlob';
+export {default as testPathPatternToRegExp} from './testPathPatternToRegExp';
 import * as preRunMessage from './preRunMessage';
-import pluralize from './pluralize';
+export {default as pluralize} from './pluralize';
 
-export {
-  ErrorWithStack,
-  clearLine,
-  convertDescriptorToString,
-  createDirectory,
-  deepCyclicCopy,
-  installCommonGlobals,
-  interopRequireDefault,
-  isInteractive,
-  isPromise,
-  pluralize,
-  preRunMessage,
-  replacePathSepForGlob,
-  setGlobal,
-  specialChars,
-  testPathPatternToRegExp,
-};
+export {preRunMessage, specialChars};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Since ESM is asynchronous we cannot run this as part of `jest-runtime`'s constructor.

This is technically a breaking change, but I'd be hugely surprised if someone either uses a custom runtime or uses `jest-runtime` directly. Can hold off on merging until Jest 26 changes start landing, but that'll make it impossible to land any kind of support for ESM in `setupFiles`. Maybe not a biggie 🙂 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Green CI

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
