### PR TITLE
feat: pass ESM options to transformers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 - `[babel-jest]` Support passing `supportsDynamicImport` and `supportsStaticESM` ([#9766](https://github.com/facebook/jest/pull/9766))
+- `[jest-runtime, @jest/transformer]` Support passing `supportsDynamicImport` and `supportsStaticESM` ([#9597](https://github.com/facebook/jest/pull/9597))
 
 ### Fixes
 

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -52,6 +52,14 @@ type HasteMapOptions = {
 
 type InternalModuleOptions = {
   isInternalModule: boolean;
+  supportsDynamicImport: boolean;
+  supportsStaticESM: boolean;
+};
+
+const defaultTransformOptions: InternalModuleOptions = {
+  isInternalModule: false,
+  supportsDynamicImport: false,
+  supportsStaticESM: false,
 };
 
 type InitialModule = Partial<Module> &
@@ -368,7 +376,11 @@ class Runtime {
   }
 
   requireInternalModule<T = unknown>(from: Config.Path, to?: string): T {
-    return this.requireModule(from, to, {isInternalModule: true});
+    return this.requireModule(from, to, {
+      isInternalModule: true,
+      supportsDynamicImport: false,
+      supportsStaticESM: false,
+    });
   }
 
   requireActual<T = unknown>(from: Config.Path, moduleName: string): T {
@@ -493,7 +505,7 @@ class Runtime {
   }
 
   private _getFullTransformationOptions(
-    options: InternalModuleOptions | undefined,
+    options: InternalModuleOptions = defaultTransformOptions,
   ): TransformationOptions {
     return {
       ...options,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

When `jest-runtime` supports ESM, then babel can leave those statements alone. While not usable yet, this helps reduce the eventual diff for ESM.

## Test plan

~Added some unit tests to some funky merging code, otherwise~ this is not really testable until we land more ESM stuff. While it's all added as optional to avoid a breaking change, `jest-runtime` explicitly opts out if it, so no real way of triggering this.