### PR TITLE
chore: don't publish pretty-format/perf to npm

### DIFF
--- a/packages/pretty-format/.npmignore
+++ b/packages/pretty-format/.npmignore
@@ -1,5 +1,6 @@
 **/__mocks__/**
 **/__tests__/**
 src
+perf
 tsconfig.json
 tsconfig.tsbuildinfo


### PR DESCRIPTION
## Summary

No need to publish perf directory from `pretty-format`. 106KB less to download by consumers.

Before -> After:
```
npm notice package size:  170.2 kB -> 64.1 kB
npm notice unpacked size: 526.6 kB -> 263.9 kB
```

## Test plan

npm pack