### PR TITLE
fix: update anchor link to doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - `[jest-runtime]` Move execution of `setupFiles` to `jest-runner` ([#9596](https://github.com/facebook/jest/pull/9596))
 - `[@jest/reporters]` Remove unused dependencies and type exports ([#9462](https://github.com/facebook/jest/pull/9462))
 - `[website]` Update pictures of reports when matchers fail ([#9214](https://github.com/facebook/jest/pull/9214))
+- `[jest-runtime]` Update anchor link in `helpers` ([#9616](https://github.com/facebook/jest/pull/9616))
 
 ### Performance
 

--- a/e2e/__tests__/__snapshots__/resolveNoFileExtensions.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/resolveNoFileExtensions.test.ts.snap
@@ -24,7 +24,7 @@ FAIL __tests__/test.js
 
     You might want to include a file extension in your import, or update your 'moduleFileExtensions', which is currently ['js'].
 
-    See https://jestjs.io/docs/en/configuration#modulefileextensions-array-string
+    See https://jestjs.io/docs/en/configuration#modulefileextensions-arraystring
 
       6 |  */
       7 | 

--- a/packages/jest-runtime/src/__tests__/__snapshots__/runtime_require_module_no_ext.test.js.snap
+++ b/packages/jest-runtime/src/__tests__/__snapshots__/runtime_require_module_no_ext.test.js.snap
@@ -8,5 +8,5 @@ However, Jest was able to find:
 
 You might want to include a file extension in your import, or update your 'moduleFileExtensions', which is currently ['js', 'json', 'jsx', 'ts', 'tsx', 'node'].
 
-See https://jestjs.io/docs/en/configuration#modulefileextensions-array-string"
+See https://jestjs.io/docs/en/configuration#modulefileextensions-arraystring"
 `;

--- a/packages/jest-runtime/src/helpers.ts
+++ b/packages/jest-runtime/src/helpers.ts
@@ -45,7 +45,7 @@ export const findSiblingsWithFileExtension = (
         return (
           foundMessage +
           "\n\nYou might want to include a file extension in your import, or update your 'moduleFileExtensions', which is currently " +
-          `[${mappedModuleFileExtensions}].\n\nSee https://jestjs.io/docs/en/configuration#modulefileextensions-array-string`
+          `[${mappedModuleFileExtensions}].\n\nSee https://jestjs.io/docs/en/configuration#modulefileextensions-arraystring`
         );
       }
     } catch (ignored) {}


### PR DESCRIPTION
## Summary

Anchor link to doc is broken, due to removed hypen in actual doc :+1: 

```
    You might want to include a file extension in your import, or update your 'moduleFileExtensions', which is currently ['js', 'json', 'jsx', 'ts', 'tsx', 'node'].

    See https://jestjs.io/docs/en/configuration#modulefileextensions-array-string
```
Working link : https://jestjs.io/docs/en/configuration#modulefileextensions-arraystring

## Test plan

Unable to test. Stumbled on this issue :
https://github.com/nodkz/mongodb-memory-server/issues/131
