### PR TITLE
fix(pretty-format): Crash in ES5 environments

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "@babel/plugin-proposal-class-properties": "^7.3.4",
     "@babel/plugin-syntax-dynamic-import": "^7.8.3",
     "@babel/plugin-transform-modules-commonjs": "^7.1.0",
+    "@babel/plugin-transform-runtime": "^7.8.3",
     "@babel/plugin-transform-strict-mode": "^7.0.0",
     "@babel/preset-env": "^7.1.0",
     "@babel/preset-react": "^7.0.0",

--- a/packages/expect/package.json
+++ b/packages/expect/package.json
@@ -11,6 +11,7 @@
   "types": "build/index.d.ts",
   "browser": "build-es5/index.js",
   "dependencies": {
+    "@babel/runtime-corejs3": "^7.8.7",
     "@jest/types": "^25.1.0",
     "ansi-styles": "^4.0.0",
     "jest-get-type": "^25.1.0",

--- a/packages/jest-mock/package.json
+++ b/packages/jest-mock/package.json
@@ -10,6 +10,7 @@
     "node": ">= 8.3"
   },
   "dependencies": {
+    "@babel/runtime-corejs3": "^7.8.7",
     "@jest/types": "^25.1.0"
   },
   "devDependencies": {

--- a/packages/pretty-format/package.json
+++ b/packages/pretty-format/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@jest/types": "^25.1.0",
     "ansi-regex": "^5.0.0",
-    "ansi-styles": "^4.0.0",
+    "ansi-styles": "^3.2.1",
     "react-is": "^16.12.0"
   },
   "devDependencies": {

--- a/packages/pretty-format/package.json
+++ b/packages/pretty-format/package.json
@@ -13,9 +13,10 @@
   "browser": "build-es5/index.js",
   "author": "James Kyle <me@thejameskyle.com>",
   "dependencies": {
+    "@babel/runtime-corejs3": "^7.8.7",
     "@jest/types": "^25.1.0",
     "ansi-regex": "^5.0.0",
-    "ansi-styles": "^3.2.1",
+    "ansi-styles": "^4.2.1",
     "react-is": "^16.12.0"
   },
   "devDependencies": {

--- a/scripts/browserBuild.js
+++ b/scripts/browserBuild.js
@@ -17,11 +17,21 @@ const babelEs5Options = {
   // Dont load other config files
   babelrc: false,
   configFile: false,
-  overrides: transformOptions.overrides,
-  plugins: [
-    '@babel/plugin-transform-strict-mode',
-    [require.resolve('@babel/plugin-transform-runtime'), {corejs: 3}],
-  ],
+  overrides: transformOptions.overrides.concat(
+    // `ansi-styles@4.x` uses Object.entries which is not supported in IE11
+    // we could transpile every node_modules but
+    // 1. It causes `$ is not a function` deep inside core-js. reason unknown
+    // 2. We keep the bundle smaller.
+    //    Transpiling with `transform-runtime` results in 537kB unminified vs
+    //    308kB unminified with just this override
+    {
+      plugins: [
+        [require.resolve('@babel/plugin-transform-runtime'), {corejs: 3}],
+      ],
+      test: /node_modules\/ansi-styles\//,
+    }
+  ),
+  plugins: ['@babel/plugin-transform-strict-mode'],
   presets: [
     [
       '@babel/preset-env',

--- a/scripts/browserBuild.js
+++ b/scripts/browserBuild.js
@@ -18,7 +18,10 @@ const babelEs5Options = {
   babelrc: false,
   configFile: false,
   overrides: transformOptions.overrides,
-  plugins: ['@babel/plugin-transform-strict-mode'],
+  plugins: [
+    '@babel/plugin-transform-strict-mode',
+    [require.resolve('@babel/plugin-transform-runtime'), {corejs: 3}],
+  ],
   presets: [
     [
       '@babel/preset-env',

--- a/yarn.lock
+++ b/yarn.lock
@@ -924,6 +924,14 @@
     pirates "^4.0.0"
     source-map-support "^0.5.16"
 
+"@babel/runtime-corejs3@^7.8.7":
+  version "7.8.7"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.8.7.tgz#8209d9dff2f33aa2616cb319c83fe159ffb07b8c"
+  integrity sha512-sc7A+H4I8kTd7S61dgB9RomXu/C+F4IrRr4Ytze4dnfx7AXEpCrejSNpjx7vq6y/Bak9S6Kbk65a/WgMLtg43Q==
+  dependencies:
+    core-js-pure "^3.0.0"
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.0.0", "@babel/runtime@^7.4.5", "@babel/runtime@^7.5.5":
   version "7.8.4"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.8.4.tgz#d79f5a2040f7caa24d53e563aad49cbc05581308"
@@ -2961,7 +2969,7 @@ ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
-ansi-styles@^4.0.0, ansi-styles@^4.1.0, ansi-styles@^4.2.0:
+ansi-styles@^4.0.0, ansi-styles@^4.1.0, ansi-styles@^4.2.0, ansi-styles@^4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.2.1.tgz#90ae75c424d008d2624c5bf29ead3177ebfcf359"
   integrity sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==
@@ -4731,6 +4739,11 @@ core-js-compat@^3.6.2:
   dependencies:
     browserslist "^4.8.3"
     semver "7.0.0"
+
+core-js-pure@^3.0.0:
+  version "3.6.4"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.6.4.tgz#4bf1ba866e25814f149d4e9aaa08c36173506e3a"
+  integrity sha512-epIhRLkXdgv32xIUFaaAry2wdxZYBi6bgM7cB136dzzXXa+dFyRLTZeLUJxnd8ShrmyVXBub63n2NHo2JAt8Cw==
 
 core-js@^1.0.0:
   version "1.2.7"
@@ -12323,6 +12336,11 @@ regenerator-runtime@^0.13.2:
   version "0.13.3"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz#7cf6a77d8f5c6f60eb73c5fc1955b2ceb01e6bf5"
   integrity sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==
+
+regenerator-runtime@^0.13.4:
+  version "0.13.4"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.4.tgz#e96bf612a3362d12bb69f7e8f74ffeab25c7ac91"
+  integrity sha512-plpwicqEzfEyTQohIKktWigcLzmNStMGwbOUbykx51/29Z3JOGYldaaNGK7ngNXV+UcoqvIMmloZ48Sr74sd+g==
 
 regenerator-transform@^0.14.0:
   version "0.14.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -752,7 +752,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
 
-"@babel/plugin-transform-runtime@^7.0.0":
+"@babel/plugin-transform-runtime@^7.0.0", "@babel/plugin-transform-runtime@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.8.3.tgz#c0153bc0a5375ebc1f1591cb7eea223adea9f169"
   integrity sha512-/vqUt5Yh+cgPZXXjmaG9NT8aVfThKk7G4OqkVhrXqwsC5soMn/qTCxs36rZ2QFhpfTJcjw4SNDIZ4RUb8OL4jQ==


### PR DESCRIPTION
## Summary
Fixes a crash in ES5 environments (or other environments not implementing Object.entries)

## Test plan
Edit: Only test I have is using [`prett-format@24`](https://app.circleci.com/jobs/github/mui-org/material-ui/143096) vs [`pretty-format@25`](https://app.circleci.com/jobs/github/mui-org/material-ui/143086)

Don't have any (because the dependency is inlined) unless you somehow build canaries that I can install. I know that [`ansi-styles@3` does not use `Object.entries`](https://unpkg.com/ansi-styles@3.2.1/index.js) while [`ansi-styles@4` does](https://unpkg.com/ansi-styles@4.2.1/index.js).
