### PR TITLE
Update jsdom dependency to fix npm audit warnings

### DIFF
--- a/packages/jest-environment-jsdom/package.json
+++ b/packages/jest-environment-jsdom/package.json
@@ -15,7 +15,7 @@
     "@jest/types": "^25.1.0",
     "jest-mock": "^25.1.0",
     "jest-util": "^25.1.0",
-    "jsdom": "^15.1.1"
+    "jsdom": "^16.2.1"
   },
   "devDependencies": {
     "@types/jsdom": "^12.2.4"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Currently jest raises npm audit warnings because of acorn vulnerabilities (jsdom dependency):
https://www.npmjs.com/advisories/1488

It was fixed in a 7.1.1 acorn patch and 16.2.1 jsdom version so the package should probably updated to that version.
