### PR TITLE
Add support for workers to send custom messages to parent in jest-worker

### DIFF
--- a/packages/jest-worker/src/Farm.ts
+++ b/packages/jest-worker/src/Farm.ts
@@ -9,8 +9,10 @@ import {
   CHILD_MESSAGE_CALL,
   ChildMessage,
   FarmOptions,
+  OnCustomMessage,
   OnEnd,
   OnStart,
+  PromiseWithCustomMessage,
   QueueChildMessage,
   QueueItem,
   WorkerInterface,
@@ -44,41 +46,66 @@ export default class Farm {
     }
   }
 
-  doWork(method: string, ...args: Array<any>): Promise<unknown> {
-    return new Promise((resolve, reject) => {
-      const computeWorkerKey = this._computeWorkerKey;
-      const request: ChildMessage = [CHILD_MESSAGE_CALL, false, method, args];
+  doWork(
+    method: string,
+    ...args: Array<any>
+  ): PromiseWithCustomMessage<unknown> {
+    let customMessageListeners: Array<OnCustomMessage> = [];
 
-      let worker: WorkerInterface | null = null;
-      let hash: string | null = null;
-
-      if (computeWorkerKey) {
-        hash = computeWorkerKey.call(this, method, ...args);
-        worker = hash == null ? null : this._cacheKeys[hash];
-      }
-
-      const onStart: OnStart = (worker: WorkerInterface) => {
-        if (hash != null) {
-          this._cacheKeys[hash] = worker;
-        }
+    const addCustomMessageListener = (listener: OnCustomMessage) => {
+      customMessageListeners.push(listener);
+      return () => {
+        customMessageListeners = customMessageListeners.filter(
+          l => l !== listener,
+        );
       };
+    };
 
-      const onEnd: OnEnd = (error: Error | null, result: unknown) => {
-        if (error) {
-          reject(error);
+    const onCustomMessage: OnCustomMessage = (message: any) => {
+      customMessageListeners.forEach(listener => listener(message));
+    };
+
+    const promise: PromiseWithCustomMessage<unknown> = new Promise(
+      (resolve, reject) => {
+        const computeWorkerKey = this._computeWorkerKey;
+        const request: ChildMessage = [CHILD_MESSAGE_CALL, false, method, args];
+
+        let worker: WorkerInterface | null = null;
+        let hash: string | null = null;
+
+        if (computeWorkerKey) {
+          hash = computeWorkerKey.call(this, method, ...args);
+          worker = hash == null ? null : this._cacheKeys[hash];
+        }
+
+        const onStart: OnStart = (worker: WorkerInterface) => {
+          if (hash != null) {
+            this._cacheKeys[hash] = worker;
+          }
+        };
+
+        const onEnd: OnEnd = (error: Error | null, result: unknown) => {
+          customMessageListeners = [];
+          if (error) {
+            reject(error);
+          } else {
+            resolve(result);
+          }
+        };
+
+        const task = {onCustomMessage, onEnd, onStart, request};
+
+        if (worker) {
+          this._enqueue(task, worker.getWorkerId());
         } else {
-          resolve(result);
+          this._push(task);
         }
-      };
+      },
+    );
 
-      const task = {onEnd, onStart, request};
+    promise.onCustomMessage = addCustomMessageListener;
 
-      if (worker) {
-        this._enqueue(task, worker.getWorkerId());
-      } else {
-        this._push(task);
-      }
-    });
+    return promise;
   }
 
   private _getNextTask(workerId: number): QueueChildMessage | null {
@@ -114,7 +141,13 @@ export default class Farm {
     task.request[1] = true;
 
     this._lock(workerId);
-    this._callback(workerId, task.request, task.onStart, onEnd);
+    this._callback(
+      workerId,
+      task.request,
+      task.onStart,
+      onEnd,
+      task.onCustomMessage,
+    );
 
     return this;
   }

--- a/packages/jest-worker/src/WorkerPool.ts
+++ b/packages/jest-worker/src/WorkerPool.ts
@@ -9,6 +9,7 @@ import BaseWorkerPool from './base/BaseWorkerPool';
 
 import {
   ChildMessage,
+  OnCustomMessage,
   OnEnd,
   OnStart,
   WorkerInterface,
@@ -31,8 +32,9 @@ class WorkerPool extends BaseWorkerPool implements WorkerPoolInterface {
     request: ChildMessage,
     onStart: OnStart,
     onEnd: OnEnd,
+    onCustomMessage: OnCustomMessage,
   ): void {
-    this.getWorkerById(workerId).send(request, onStart, onEnd);
+    this.getWorkerById(workerId).send(request, onStart, onEnd, onCustomMessage);
   }
 
   createWorker(workerOptions: WorkerOptions): WorkerInterface {

--- a/packages/jest-worker/src/__tests__/Farm.test.js
+++ b/packages/jest-worker/src/__tests__/Farm.test.js
@@ -49,6 +49,7 @@ describe('Farm', () => {
       [1, true, 'foo', [42]],
       expect.any(Function),
       expect.any(Function),
+      expect.any(Function),
     );
   });
 
@@ -67,12 +68,15 @@ describe('Farm', () => {
       [1, true, 'foo', [42]],
       expect.any(Function),
       expect.any(Function),
+      expect.any(Function),
     );
     expect(callback).toHaveBeenNthCalledWith(
       2,
       1, // second worker
       [1, true, 'foo1', [43]],
       expect.any(Function),
+      expect.any(Function),
+
       expect.any(Function),
     );
     expect(callback).toHaveBeenNthCalledWith(
@@ -81,11 +85,13 @@ describe('Farm', () => {
       [1, true, 'foo2', [44]],
       expect.any(Function),
       expect.any(Function),
+      expect.any(Function),
     );
     expect(callback).toHaveBeenNthCalledWith(
       4,
       3, // fourth worker
       [1, true, 'foo3', [45]],
+      expect.any(Function),
       expect.any(Function),
       expect.any(Function),
     );
@@ -108,6 +114,7 @@ describe('Farm', () => {
       1,
       0, // first worker
       [1, true, 'foo', [42]],
+      expect.any(Function),
       expect.any(Function),
       expect.any(Function),
     );
@@ -146,6 +153,7 @@ describe('Farm', () => {
       [1, true, 'foo', [42]],
       expect.any(Function),
       expect.any(Function),
+      expect.any(Function),
     );
     expect(callback).toHaveBeenNthCalledWith(
       2,
@@ -153,11 +161,13 @@ describe('Farm', () => {
       [1, true, 'foo1', [43]],
       expect.any(Function),
       expect.any(Function),
+      expect.any(Function),
     );
     expect(callback).toHaveBeenNthCalledWith(
       3,
       0, // first worker again
       [1, true, 'foo2', [44]],
+      expect.any(Function),
       expect.any(Function),
       expect.any(Function),
     );
@@ -220,11 +230,13 @@ describe('Farm', () => {
       [1, true, 'car', ['plane']],
       expect.any(Function),
       expect.any(Function),
+      expect.any(Function),
     );
     expect(callback).toHaveBeenNthCalledWith(
       2,
       0, // first worker
       [1, true, 'foo', ['bar']],
+      expect.any(Function),
       expect.any(Function),
       expect.any(Function),
     );
@@ -261,11 +273,13 @@ describe('Farm', () => {
       [1, true, 'car', ['plane']],
       expect.any(Function),
       expect.any(Function),
+      expect.any(Function),
     );
     expect(callback).toHaveBeenNthCalledWith(
       2,
       0, // first worker
       [1, true, 'foo', ['bar']],
+      expect.any(Function),
       expect.any(Function),
       expect.any(Function),
     );

--- a/packages/jest-worker/src/__tests__/WorkerPool.test.js
+++ b/packages/jest-worker/src/__tests__/WorkerPool.test.js
@@ -71,6 +71,7 @@ describe('WorkerPool', () => {
       {foo: 'bar'},
       onStart,
       onEnd,
+      undefined,
     );
   });
 
@@ -100,6 +101,7 @@ describe('WorkerPool', () => {
       {foo: 'bar'},
       onStart,
       onEnd,
+      undefined,
     );
   });
 
@@ -128,6 +130,7 @@ describe('WorkerPool', () => {
       {foo: 'bar'},
       onStart,
       onEnd,
+      undefined,
     );
   });
 });

--- a/packages/jest-worker/src/base/BaseWorkerPool.ts
+++ b/packages/jest-worker/src/base/BaseWorkerPool.ts
@@ -94,7 +94,12 @@ export default class BaseWorkerPool {
     // We do not cache the request object here. If so, it would only be only
     // processed by one of the workers, and we want them all to close.
     const workerExitPromises = this._workers.map(async worker => {
-      worker.send([CHILD_MESSAGE_END, false], emptyMethod, emptyMethod);
+      worker.send(
+        [CHILD_MESSAGE_END, false],
+        emptyMethod,
+        emptyMethod,
+        emptyMethod,
+      );
 
       // Schedule a force exit in case worker fails to exit gracefully so
       // await worker.waitForExit() never takes longer than FORCE_EXIT_DELAY

--- a/packages/jest-worker/src/index.ts
+++ b/packages/jest-worker/src/index.ts
@@ -11,9 +11,11 @@ import Farm from './Farm';
 import {
   FarmOptions,
   PoolExitResult,
+  PromiseWithCustomMessage,
   WorkerPoolInterface,
   WorkerPoolOptions,
 } from './types';
+import _messageParent from './workers/messageParent';
 
 function getExposedMethods(
   workerPath: string,
@@ -146,3 +148,6 @@ export default class JestWorker {
     return this._workerPool.end();
   }
 }
+
+export {PromiseWithCustomMessage};
+export const messageParent = _messageParent;

--- a/packages/jest-worker/src/types.ts
+++ b/packages/jest-worker/src/types.ts
@@ -19,6 +19,7 @@ export const CHILD_MESSAGE_END: 2 = 2;
 export const PARENT_MESSAGE_OK: 0 = 0;
 export const PARENT_MESSAGE_CLIENT_ERROR: 1 = 1;
 export const PARENT_MESSAGE_SETUP_ERROR: 2 = 2;
+export const PARENT_MESSAGE_CUSTOM: -1 = -1;
 
 export type PARENT_MESSAGE_ERROR =
   | typeof PARENT_MESSAGE_CLIENT_ERROR
@@ -34,6 +35,7 @@ export interface WorkerPoolInterface {
     request: ChildMessage,
     onStart: OnStart,
     onEnd: OnEnd,
+    onCustomMessage: OnCustomMessage,
   ): void;
   end(): Promise<PoolExitResult>;
 }
@@ -43,6 +45,7 @@ export interface WorkerInterface {
     request: ChildMessage,
     onProcessStart: OnStart,
     onProcessEnd: OnEnd,
+    onCustomMessage: OnCustomMessage,
   ): void;
   waitForExit(): Promise<void>;
   forceExit(): void;
@@ -55,6 +58,10 @@ export interface WorkerInterface {
 export type PoolExitResult = {
   forceExited: boolean;
 };
+
+export interface PromiseWithCustomMessage<T> extends Promise<T> {
+  onCustomMessage?: (listener: OnCustomMessage) => () => void;
+}
 
 // Option objects.
 
@@ -128,6 +135,11 @@ export type ChildMessage =
 
 // Messages passed from the children to the parent.
 
+export type ParentMessageCustom = [
+  typeof PARENT_MESSAGE_CUSTOM, // type
+  unknown, // result
+];
+
 export type ParentMessageOk = [
   typeof PARENT_MESSAGE_OK, // type
   unknown, // result
@@ -141,17 +153,22 @@ export type ParentMessageError = [
   unknown, // extra
 ];
 
-export type ParentMessage = ParentMessageOk | ParentMessageError;
+export type ParentMessage =
+  | ParentMessageOk
+  | ParentMessageError
+  | ParentMessageCustom;
 
 // Queue types.
 
 export type OnStart = (worker: WorkerInterface) => void;
 export type OnEnd = (err: Error | null, result: unknown) => void;
+export type OnCustomMessage = (message: unknown) => void;
 
 export type QueueChildMessage = {
   request: ChildMessage;
   onStart: OnStart;
   onEnd: OnEnd;
+  onCustomMessage: OnCustomMessage;
 };
 
 export type QueueItem = {

--- a/packages/jest-worker/src/workers/__tests__/NodeThreadsWorker.test.js
+++ b/packages/jest-worker/src/workers/__tests__/NodeThreadsWorker.test.js
@@ -14,8 +14,10 @@ import {
   CHILD_MESSAGE_CALL,
   CHILD_MESSAGE_INITIALIZE,
   PARENT_MESSAGE_CLIENT_ERROR,
+  PARENT_MESSAGE_CUSTOM,
   PARENT_MESSAGE_OK,
 } from '../../types';
+import expectExport from 'expect';
 
 let Worker;
 let workerThreads;
@@ -231,6 +233,43 @@ it('calls the onProcessStart method synchronously if the queue is empty', () => 
   worker._worker.emit('message', [PARENT_MESSAGE_OK]);
 
   expect(onProcessEnd).toHaveBeenCalledTimes(1);
+});
+
+it('can send multiple messages to parent', () => {
+  const worker = new Worker({
+    forkOptions: {},
+    maxRetries: 3,
+    workerPath: '/tmp/foo',
+  });
+
+  const onProcessStart = jest.fn();
+  const onProcessEnd = jest.fn();
+  const onCustomMessage = jest.fn();
+
+  worker.send(
+    [CHILD_MESSAGE_CALL, false, 'foo', []],
+    onProcessStart,
+    onProcessEnd,
+    onCustomMessage,
+  );
+
+  // Only onProcessStart has been called
+  expect(onProcessStart).toHaveBeenCalledTimes(1);
+  expect(onProcessEnd).not.toHaveBeenCalled();
+  expect(onCustomMessage).not.toHaveBeenCalled();
+
+  // then first call replies...
+  worker._worker.emit('message', [
+    PARENT_MESSAGE_CUSTOM,
+    {message: 'foo bar', otherKey: 1},
+  ]);
+
+  expect(onProcessEnd).not.toHaveBeenCalled();
+  expect(onCustomMessage).toHaveBeenCalledTimes(1);
+  expect(onCustomMessage).toHaveBeenCalledWith({
+    message: 'foo bar',
+    otherKey: 1,
+  });
 });
 
 it('creates error instances for known errors', () => {

--- a/packages/jest-worker/src/workers/messageParent.ts
+++ b/packages/jest-worker/src/workers/messageParent.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {PARENT_MESSAGE_CUSTOM} from '../types';
+
+const isWorkerThread = () => {
+  try {
+    const {isMainThread, parentPort} = require('worker_threads');
+    return !isMainThread && parentPort;
+  } catch (_) {
+    return false;
+  }
+};
+
+const messageParent = (
+  message: any,
+  parentProcess: NodeJS.Process = process,
+) => {
+  if (isWorkerThread()) {
+    const {parentPort} = require('worker_threads');
+    parentPort.postMessage([PARENT_MESSAGE_CUSTOM, message]);
+  } else if (typeof parentProcess.send === 'function') {
+    parentProcess.send([PARENT_MESSAGE_CUSTOM, message]);
+  } else {
+    throw new Error('"messageParent" can only be used inside a worker');
+  }
+};
+
+export default messageParent;


### PR DESCRIPTION
## Summary

This PR part of an effort to break down PR #9001, so that we can eventually have #6616 

It adds jest-worker the ability for workers to send "custom messages" to their parent while they are still running. This will eventually allow us to report per test case updates to the reporter.

## Test plan

This should not break the API, and I added multiple tests for it. I should also add an e2e test for it, but that is still pending.

I intentionally kept it undocumented given that I'm still not 100% sure that this is the right interface. Currently it uses a `PromiseWithCustomMessage` interface, that allows to call `p.onCustomMessage(listener)` to a thenable.

```
export interface PromiseWithCustomMessage<T> extends Promise<T> {
  onCustomMessage?: (listener: OnCustomMessage) => () => void;
}
```

I would love feedback on that interface or potential new ideas for it.