### PR TITLE
docs: fix typo in configuration runner

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -756,7 +756,7 @@ async runTests(
 ): Promise<void>
 ```
 
-If you need to restrict your test-runner to only run in serial rather then being executed in parallel your class should have the property `isSerial` to be set as `true`.
+If you need to restrict your test-runner to only run in serial rather than being executed in parallel your class should have the property `isSerial` to be set as `true`.
 
 ### `setupFiles` [array]
 


### PR DESCRIPTION
Just fix a typo in Configuration.md `runner`