### PR TITLE
fix: fsync: false when writing cache files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `[jest-haste-map]` [**BREAKING**] Remove `mapper` option ([#9581](https://github.com/facebook/jest/pull/9581))
 - `[*]` Support array of paths for `moduleNameMapper` aliases ([#9465](https://github.com/facebook/jest/pull/9465))
 - `[jest-reporters]` Adds ability to pass options to the istanbul-reporter through `coverageReporters` ([#9572](https://github.com/facebook/jest/pull/9572))
+- `[jest-transform]` `writeCacheFile` no longer calls `fsync` ([#9695](https://github.com/facebook/jest/pull/9695))
 
 ### Fixes
 

--- a/packages/jest-transform/src/ScriptTransformer.ts
+++ b/packages/jest-transform/src/ScriptTransformer.ts
@@ -630,7 +630,7 @@ function readCodeCacheFile(cachePath: Config.Path): string | null {
  */
 const writeCacheFile = (cachePath: Config.Path, fileData: string) => {
   try {
-    writeFileAtomic(cachePath, fileData, {encoding: 'utf8'});
+    writeFileAtomic(cachePath, fileData, {encoding: 'utf8', fsync: false});
   } catch (e) {
     if (cacheWriteErrorSafeToIgnore(e, cachePath)) {
       return;

--- a/packages/jest-transform/src/__tests__/script_transformer.test.js
+++ b/packages/jest-transform/src/__tests__/script_transformer.test.js
@@ -407,6 +407,7 @@ describe('ScriptTransformer', () => {
     expect(writeFileAtomic.sync).toBeCalledTimes(2);
     expect(writeFileAtomic.sync).toBeCalledWith(result.sourceMapPath, mapStr, {
       encoding: 'utf8',
+      fsync: false,
     });
   });
 
@@ -438,7 +439,7 @@ describe('ScriptTransformer', () => {
     expect(writeFileAtomic.sync).toBeCalledWith(
       result.sourceMapPath,
       sourceMap,
-      {encoding: 'utf8'},
+      {encoding: 'utf8', fsync: false},
     );
   });
 
@@ -507,6 +508,7 @@ describe('ScriptTransformer', () => {
       JSON.stringify(map),
       {
         encoding: 'utf8',
+        fsync: false,
       },
     );
   });
@@ -574,6 +576,7 @@ describe('ScriptTransformer', () => {
       JSON.stringify(instrumentedCodeMap),
       {
         encoding: 'utf8',
+        fsync: false,
       },
     );
 
@@ -614,6 +617,7 @@ describe('ScriptTransformer', () => {
       JSON.stringify(instrumentedCodeMap),
       {
         encoding: 'utf8',
+        fsync: false,
       },
     );
 


### PR DESCRIPTION
##  Summary

`writeFileAtomic` defaults to running `fsync` on the file after use.

`fsync` is a nearly 3x slowdown for me, ts-jest'ing my whole codebase (~900 files in testcase).

`ubuntu` defaults to `/tmp` as regular filesystem (i.e. not tmpfs), and some filesystems/devices have a large overhead for these repeated `fsync`s. I happen to be on nvme (sm961), and `btrfs`.

We're using `writeFileAtomic` here in order to get atomic rename, not to get full system power failure resilience. Most(tm) filesystems will guarantee either/or during a system power failure here, which is plenty enough for us.

## Test plan

There should be no functional changes here (even during a system power failure), only a performance increase in all cases, and a drastic performance increase in some cases.