### PR TITLE
fix: TS1005: '=' expected on tsc

### DIFF
--- a/packages/pretty-format/src/index.ts
+++ b/packages/pretty-format/src/index.ts
@@ -6,7 +6,7 @@
  */
 
 import style = require('ansi-styles');
-import type * as PrettyFormat from './types';
+import * as PrettyFormat from './types';
 
 import {
   printIteratorEntries,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
The problem occurs when i want to build my react app using create-react-library 
```
home/getspooky/Documents/project/node_modules/@types/testing-library__react/node_modules/pretty-format/build/index.d.ts
TypeScript error in /home/getspooky/Documents/project/node_modules/@types/testing-library__react/node_modules/pretty-format/build/index.d.ts(7,13):
'=' expected.  TS1005

     5 |  * LICENSE file in the root directory of this source tree.
     6 |  */
  >  7 | import type * as PrettyFormat from './types';
       |             ^
     8 | /**
     9 |  * Returns a presentation string of your `val` object
    10 |  * @param val any potential JavaScript object

```

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
