### PR TITLE
fix: downlevel .d.ts files for compat with older TS versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- `[*]` Downlevel TypeScript definitions files for compatibility with TS<3.8 ([#9705](https://github.com/facebook/jest/pull/9705))
+
 ### Chore & Maintenance
 
 ### Performance

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "codecov": "^3.0.0",
     "debug": "^4.0.1",
     "dedent": "^0.7.0",
+    "downlevel-dts": "^0.4.0",
     "eslint": "^6.2.2",
     "eslint-config-prettier": "^6.1.0",
     "eslint-plugin-babel": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "slash": "^3.0.0",
     "string-length": "^3.1.0",
     "strip-ansi": "^6.0.0",
+    "throat": "^5.0.0",
     "typescript": "^3.8.2",
     "webpack": "^4.28.4",
     "which": "^2.0.1"

--- a/packages/babel-jest/package.json
+++ b/packages/babel-jest/package.json
@@ -10,6 +10,13 @@
   "license": "MIT",
   "main": "build/index.js",
   "types": "build/index.d.ts",
+  "typesVersions": {
+    "<3.8": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  },
   "dependencies": {
     "@jest/transform": "^25.2.0",
     "@jest/types": "^25.2.0",

--- a/packages/babel-jest/package.json
+++ b/packages/babel-jest/package.json
@@ -12,8 +12,8 @@
   "types": "build/index.d.ts",
   "typesVersions": {
     "<3.8": {
-      "*": [
-        "ts3.4/*"
+      "build/*": [
+        "build/ts3.4/*"
       ]
     }
   },

--- a/packages/babel-plugin-jest-hoist/package.json
+++ b/packages/babel-plugin-jest-hoist/package.json
@@ -14,8 +14,8 @@
   "types": "build/index.d.ts",
   "typesVersions": {
     "<3.8": {
-      "*": [
-        "ts3.4/*"
+      "build/*": [
+        "build/ts3.4/*"
       ]
     }
   },

--- a/packages/babel-plugin-jest-hoist/package.json
+++ b/packages/babel-plugin-jest-hoist/package.json
@@ -12,6 +12,13 @@
   "license": "MIT",
   "main": "build/index.js",
   "types": "build/index.d.ts",
+  "typesVersions": {
+    "<3.8": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  },
   "dependencies": {
     "@types/babel__traverse": "^7.0.6"
   },

--- a/packages/diff-sequences/package.json
+++ b/packages/diff-sequences/package.json
@@ -20,6 +20,13 @@
   },
   "main": "build/index.js",
   "types": "build/index.d.ts",
+  "typesVersions": {
+    "<3.8": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  },
   "scripts": {
     "perf": "node --expose-gc perf/index.js"
   },

--- a/packages/diff-sequences/package.json
+++ b/packages/diff-sequences/package.json
@@ -22,8 +22,8 @@
   "types": "build/index.d.ts",
   "typesVersions": {
     "<3.8": {
-      "*": [
-        "ts3.4/*"
+      "build/*": [
+        "build/ts3.4/*"
       ]
     }
   },

--- a/packages/expect/package.json
+++ b/packages/expect/package.json
@@ -11,8 +11,8 @@
   "types": "build/index.d.ts",
   "typesVersions": {
     "<3.8": {
-      "*": [
-        "ts3.4/*"
+      "build/*": [
+        "build/ts3.4/*"
       ]
     }
   },

--- a/packages/expect/package.json
+++ b/packages/expect/package.json
@@ -9,6 +9,13 @@
   "license": "MIT",
   "main": "build/index.js",
   "types": "build/index.d.ts",
+  "typesVersions": {
+    "<3.8": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  },
   "browser": "build-es5/index.js",
   "dependencies": {
     "@jest/types": "^25.2.0",

--- a/packages/jest-changed-files/package.json
+++ b/packages/jest-changed-files/package.json
@@ -11,8 +11,8 @@
   "types": "build/index.d.ts",
   "typesVersions": {
     "<3.8": {
-      "*": [
-        "ts3.4/*"
+      "build/*": [
+        "build/ts3.4/*"
       ]
     }
   },

--- a/packages/jest-changed-files/package.json
+++ b/packages/jest-changed-files/package.json
@@ -9,6 +9,13 @@
   "license": "MIT",
   "main": "build/index.js",
   "types": "build/index.d.ts",
+  "typesVersions": {
+    "<3.8": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  },
   "dependencies": {
     "@jest/types": "^25.2.0",
     "execa": "^3.2.0",

--- a/packages/jest-circus/package.json
+++ b/packages/jest-circus/package.json
@@ -11,8 +11,8 @@
   "types": "build/index.d.ts",
   "typesVersions": {
     "<3.8": {
-      "*": [
-        "ts3.4/*"
+      "build/*": [
+        "build/ts3.4/*"
       ]
     }
   },

--- a/packages/jest-circus/package.json
+++ b/packages/jest-circus/package.json
@@ -9,6 +9,13 @@
   "license": "MIT",
   "main": "build/index.js",
   "types": "build/index.d.ts",
+  "typesVersions": {
+    "<3.8": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  },
   "dependencies": {
     "@babel/traverse": "^7.1.0",
     "@jest/environment": "^25.2.0",

--- a/packages/jest-cli/package.json
+++ b/packages/jest-cli/package.json
@@ -4,6 +4,13 @@
   "version": "25.2.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
+  "typesVersions": {
+    "<3.8": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  },
   "dependencies": {
     "@jest/core": "^25.2.0",
     "@jest/test-result": "^25.2.0",

--- a/packages/jest-cli/package.json
+++ b/packages/jest-cli/package.json
@@ -6,8 +6,8 @@
   "types": "build/index.d.ts",
   "typesVersions": {
     "<3.8": {
-      "*": [
-        "ts3.4/*"
+      "build/*": [
+        "build/ts3.4/*"
       ]
     }
   },

--- a/packages/jest-config/package.json
+++ b/packages/jest-config/package.json
@@ -11,8 +11,8 @@
   "types": "build/index.d.ts",
   "typesVersions": {
     "<3.8": {
-      "*": [
-        "ts3.4/*"
+      "build/*": [
+        "build/ts3.4/*"
       ]
     }
   },

--- a/packages/jest-config/package.json
+++ b/packages/jest-config/package.json
@@ -9,6 +9,13 @@
   "license": "MIT",
   "main": "build/index.js",
   "types": "build/index.d.ts",
+  "typesVersions": {
+    "<3.8": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  },
   "dependencies": {
     "@babel/core": "^7.1.0",
     "@jest/test-sequencer": "^25.2.0",

--- a/packages/jest-console/package.json
+++ b/packages/jest-console/package.json
@@ -9,6 +9,13 @@
   "license": "MIT",
   "main": "build/index.js",
   "types": "build/index.d.ts",
+  "typesVersions": {
+    "<3.8": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  },
   "dependencies": {
     "@jest/source-map": "^25.2.0",
     "chalk": "^3.0.0",

--- a/packages/jest-console/package.json
+++ b/packages/jest-console/package.json
@@ -11,8 +11,8 @@
   "types": "build/index.d.ts",
   "typesVersions": {
     "<3.8": {
-      "*": [
-        "ts3.4/*"
+      "build/*": [
+        "build/ts3.4/*"
       ]
     }
   },

--- a/packages/jest-diff/package.json
+++ b/packages/jest-diff/package.json
@@ -11,8 +11,8 @@
   "types": "build/index.d.ts",
   "typesVersions": {
     "<3.8": {
-      "*": [
-        "ts3.4/*"
+      "build/*": [
+        "build/ts3.4/*"
       ]
     }
   },

--- a/packages/jest-diff/package.json
+++ b/packages/jest-diff/package.json
@@ -9,6 +9,13 @@
   "license": "MIT",
   "main": "build/index.js",
   "types": "build/index.d.ts",
+  "typesVersions": {
+    "<3.8": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  },
   "dependencies": {
     "chalk": "^3.0.0",
     "diff-sequences": "^25.2.0",

--- a/packages/jest-each/package.json
+++ b/packages/jest-each/package.json
@@ -4,6 +4,13 @@
   "description": "Parameterised tests for Jest",
   "main": "build/index.js",
   "types": "build/index.d.ts",
+  "typesVersions": {
+    "<3.8": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/facebook/jest.git",

--- a/packages/jest-each/package.json
+++ b/packages/jest-each/package.json
@@ -6,8 +6,8 @@
   "types": "build/index.d.ts",
   "typesVersions": {
     "<3.8": {
-      "*": [
-        "ts3.4/*"
+      "build/*": [
+        "build/ts3.4/*"
       ]
     }
   },

--- a/packages/jest-environment-jsdom/package.json
+++ b/packages/jest-environment-jsdom/package.json
@@ -11,8 +11,8 @@
   "types": "build/index.d.ts",
   "typesVersions": {
     "<3.8": {
-      "*": [
-        "ts3.4/*"
+      "build/*": [
+        "build/ts3.4/*"
       ]
     }
   },

--- a/packages/jest-environment-jsdom/package.json
+++ b/packages/jest-environment-jsdom/package.json
@@ -9,6 +9,13 @@
   "license": "MIT",
   "main": "build/index.js",
   "types": "build/index.d.ts",
+  "typesVersions": {
+    "<3.8": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  },
   "dependencies": {
     "@jest/environment": "^25.2.0",
     "@jest/fake-timers": "^25.2.0",

--- a/packages/jest-environment-node/package.json
+++ b/packages/jest-environment-node/package.json
@@ -11,8 +11,8 @@
   "types": "build/index.d.ts",
   "typesVersions": {
     "<3.8": {
-      "*": [
-        "ts3.4/*"
+      "build/*": [
+        "build/ts3.4/*"
       ]
     }
   },

--- a/packages/jest-environment-node/package.json
+++ b/packages/jest-environment-node/package.json
@@ -9,6 +9,13 @@
   "license": "MIT",
   "main": "build/index.js",
   "types": "build/index.d.ts",
+  "typesVersions": {
+    "<3.8": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  },
   "dependencies": {
     "@jest/environment": "^25.2.0",
     "@jest/fake-timers": "^25.2.0",

--- a/packages/jest-environment/package.json
+++ b/packages/jest-environment/package.json
@@ -9,6 +9,13 @@
   "license": "MIT",
   "main": "build/index.js",
   "types": "build/index.d.ts",
+  "typesVersions": {
+    "<3.8": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  },
   "dependencies": {
     "@jest/fake-timers": "^25.2.0",
     "@jest/types": "^25.2.0",

--- a/packages/jest-environment/package.json
+++ b/packages/jest-environment/package.json
@@ -11,8 +11,8 @@
   "types": "build/index.d.ts",
   "typesVersions": {
     "<3.8": {
-      "*": [
-        "ts3.4/*"
+      "build/*": [
+        "build/ts3.4/*"
       ]
     }
   },

--- a/packages/jest-fake-timers/package.json
+++ b/packages/jest-fake-timers/package.json
@@ -11,8 +11,8 @@
   "types": "build/index.d.ts",
   "typesVersions": {
     "<3.8": {
-      "*": [
-        "ts3.4/*"
+      "build/*": [
+        "build/ts3.4/*"
       ]
     }
   },

--- a/packages/jest-fake-timers/package.json
+++ b/packages/jest-fake-timers/package.json
@@ -9,6 +9,13 @@
   "license": "MIT",
   "main": "build/index.js",
   "types": "build/index.d.ts",
+  "typesVersions": {
+    "<3.8": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  },
   "dependencies": {
     "@jest/types": "^25.2.0",
     "jest-message-util": "^25.2.0",

--- a/packages/jest-get-type/package.json
+++ b/packages/jest-get-type/package.json
@@ -13,6 +13,13 @@
   "license": "MIT",
   "main": "build/index.js",
   "types": "build/index.d.ts",
+  "typesVersions": {
+    "<3.8": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/jest-get-type/package.json
+++ b/packages/jest-get-type/package.json
@@ -15,8 +15,8 @@
   "types": "build/index.d.ts",
   "typesVersions": {
     "<3.8": {
-      "*": [
-        "ts3.4/*"
+      "build/*": [
+        "build/ts3.4/*"
       ]
     }
   },

--- a/packages/jest-haste-map/package.json
+++ b/packages/jest-haste-map/package.json
@@ -11,8 +11,8 @@
   "types": "build/index.d.ts",
   "typesVersions": {
     "<3.8": {
-      "*": [
-        "ts3.4/*"
+      "build/*": [
+        "build/ts3.4/*"
       ]
     }
   },

--- a/packages/jest-haste-map/package.json
+++ b/packages/jest-haste-map/package.json
@@ -9,6 +9,13 @@
   "license": "MIT",
   "main": "build/index.js",
   "types": "build/index.d.ts",
+  "typesVersions": {
+    "<3.8": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  },
   "dependencies": {
     "@jest/types": "^25.2.0",
     "anymatch": "^3.0.3",

--- a/packages/jest-jasmine2/package.json
+++ b/packages/jest-jasmine2/package.json
@@ -11,8 +11,8 @@
   "types": "build/index.d.ts",
   "typesVersions": {
     "<3.8": {
-      "*": [
-        "ts3.4/*"
+      "build/*": [
+        "build/ts3.4/*"
       ]
     }
   },

--- a/packages/jest-jasmine2/package.json
+++ b/packages/jest-jasmine2/package.json
@@ -9,6 +9,13 @@
   "license": "MIT",
   "main": "build/index.js",
   "types": "build/index.d.ts",
+  "typesVersions": {
+    "<3.8": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  },
   "dependencies": {
     "@babel/traverse": "^7.1.0",
     "@jest/environment": "^25.2.0",

--- a/packages/jest-leak-detector/package.json
+++ b/packages/jest-leak-detector/package.json
@@ -11,8 +11,8 @@
   "types": "build/index.d.ts",
   "typesVersions": {
     "<3.8": {
-      "*": [
-        "ts3.4/*"
+      "build/*": [
+        "build/ts3.4/*"
       ]
     }
   },

--- a/packages/jest-leak-detector/package.json
+++ b/packages/jest-leak-detector/package.json
@@ -9,6 +9,13 @@
   "license": "MIT",
   "main": "build/index.js",
   "types": "build/index.d.ts",
+  "typesVersions": {
+    "<3.8": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  },
   "dependencies": {
     "jest-get-type": "^25.1.0",
     "pretty-format": "^25.2.0"

--- a/packages/jest-matcher-utils/package.json
+++ b/packages/jest-matcher-utils/package.json
@@ -15,8 +15,8 @@
   "types": "build/index.d.ts",
   "typesVersions": {
     "<3.8": {
-      "*": [
-        "ts3.4/*"
+      "build/*": [
+        "build/ts3.4/*"
       ]
     }
   },

--- a/packages/jest-matcher-utils/package.json
+++ b/packages/jest-matcher-utils/package.json
@@ -13,6 +13,13 @@
   "license": "MIT",
   "main": "build/index.js",
   "types": "build/index.d.ts",
+  "typesVersions": {
+    "<3.8": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  },
   "dependencies": {
     "chalk": "^3.0.0",
     "jest-diff": "^25.2.0",

--- a/packages/jest-message-util/package.json
+++ b/packages/jest-message-util/package.json
@@ -14,8 +14,8 @@
   "types": "build/index.d.ts",
   "typesVersions": {
     "<3.8": {
-      "*": [
-        "ts3.4/*"
+      "build/*": [
+        "build/ts3.4/*"
       ]
     }
   },

--- a/packages/jest-message-util/package.json
+++ b/packages/jest-message-util/package.json
@@ -12,6 +12,13 @@
   "license": "MIT",
   "main": "build/index.js",
   "types": "build/index.d.ts",
+  "typesVersions": {
+    "<3.8": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  },
   "dependencies": {
     "@babel/code-frame": "^7.0.0",
     "@jest/test-result": "^25.2.0",

--- a/packages/jest-mock/package.json
+++ b/packages/jest-mock/package.json
@@ -20,8 +20,8 @@
   "types": "build/index.d.ts",
   "typesVersions": {
     "<3.8": {
-      "*": [
-        "ts3.4/*"
+      "build/*": [
+        "build/ts3.4/*"
       ]
     }
   },

--- a/packages/jest-mock/package.json
+++ b/packages/jest-mock/package.json
@@ -18,6 +18,13 @@
   "license": "MIT",
   "main": "build/index.js",
   "types": "build/index.d.ts",
+  "typesVersions": {
+    "<3.8": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  },
   "browser": "build-es5/index.js",
   "publishConfig": {
     "access": "public"

--- a/packages/jest-regex-util/package.json
+++ b/packages/jest-regex-util/package.json
@@ -15,6 +15,13 @@
   "license": "MIT",
   "main": "build/index.js",
   "types": "build/index.d.ts",
+  "typesVersions": {
+    "<3.8": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/jest-regex-util/package.json
+++ b/packages/jest-regex-util/package.json
@@ -17,8 +17,8 @@
   "types": "build/index.d.ts",
   "typesVersions": {
     "<3.8": {
-      "*": [
-        "ts3.4/*"
+      "build/*": [
+        "build/ts3.4/*"
       ]
     }
   },

--- a/packages/jest-repl/package.json
+++ b/packages/jest-repl/package.json
@@ -11,8 +11,8 @@
   "types": "build/index.d.ts",
   "typesVersions": {
     "<3.8": {
-      "*": [
-        "ts3.4/*"
+      "build/*": [
+        "build/ts3.4/*"
       ]
     }
   },

--- a/packages/jest-repl/package.json
+++ b/packages/jest-repl/package.json
@@ -9,6 +9,13 @@
   "license": "MIT",
   "main": "build/index.js",
   "types": "build/index.d.ts",
+  "typesVersions": {
+    "<3.8": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  },
   "dependencies": {
     "@jest/transform": "^25.2.0",
     "@jest/types": "^25.2.0",

--- a/packages/jest-reporters/package.json
+++ b/packages/jest-reporters/package.json
@@ -6,8 +6,8 @@
   "types": "build/index.d.ts",
   "typesVersions": {
     "<3.8": {
-      "*": [
-        "ts3.4/*"
+      "build/*": [
+        "build/ts3.4/*"
       ]
     }
   },

--- a/packages/jest-reporters/package.json
+++ b/packages/jest-reporters/package.json
@@ -4,6 +4,13 @@
   "version": "25.2.0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
+  "typesVersions": {
+    "<3.8": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  },
   "dependencies": {
     "@bcoe/v8-coverage": "^0.2.3",
     "@jest/console": "^25.2.0",

--- a/packages/jest-resolve-dependencies/package.json
+++ b/packages/jest-resolve-dependencies/package.json
@@ -11,8 +11,8 @@
   "types": "build/index.d.ts",
   "typesVersions": {
     "<3.8": {
-      "*": [
-        "ts3.4/*"
+      "build/*": [
+        "build/ts3.4/*"
       ]
     }
   },

--- a/packages/jest-resolve-dependencies/package.json
+++ b/packages/jest-resolve-dependencies/package.json
@@ -9,6 +9,13 @@
   "license": "MIT",
   "main": "build/index.js",
   "types": "build/index.d.ts",
+  "typesVersions": {
+    "<3.8": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  },
   "dependencies": {
     "@jest/types": "^25.2.0",
     "jest-regex-util": "^25.2.0",

--- a/packages/jest-resolve/package.json
+++ b/packages/jest-resolve/package.json
@@ -11,8 +11,8 @@
   "types": "build/index.d.ts",
   "typesVersions": {
     "<3.8": {
-      "*": [
-        "ts3.4/*"
+      "build/*": [
+        "build/ts3.4/*"
       ]
     }
   },

--- a/packages/jest-resolve/package.json
+++ b/packages/jest-resolve/package.json
@@ -9,6 +9,13 @@
   "license": "MIT",
   "main": "build/index.js",
   "types": "build/index.d.ts",
+  "typesVersions": {
+    "<3.8": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  },
   "dependencies": {
     "@jest/types": "^25.2.0",
     "browser-resolve": "^1.11.3",

--- a/packages/jest-runner/package.json
+++ b/packages/jest-runner/package.json
@@ -11,8 +11,8 @@
   "types": "build/index.d.ts",
   "typesVersions": {
     "<3.8": {
-      "*": [
-        "ts3.4/*"
+      "build/*": [
+        "build/ts3.4/*"
       ]
     }
   },

--- a/packages/jest-runner/package.json
+++ b/packages/jest-runner/package.json
@@ -9,6 +9,13 @@
   "license": "MIT",
   "main": "build/index.js",
   "types": "build/index.d.ts",
+  "typesVersions": {
+    "<3.8": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  },
   "dependencies": {
     "@jest/console": "^25.2.0",
     "@jest/environment": "^25.2.0",

--- a/packages/jest-runtime/package.json
+++ b/packages/jest-runtime/package.json
@@ -11,8 +11,8 @@
   "types": "build/index.d.ts",
   "typesVersions": {
     "<3.8": {
-      "*": [
-        "ts3.4/*"
+      "build/*": [
+        "build/ts3.4/*"
       ]
     }
   },

--- a/packages/jest-runtime/package.json
+++ b/packages/jest-runtime/package.json
@@ -9,6 +9,13 @@
   "license": "MIT",
   "main": "build/index.js",
   "types": "build/index.d.ts",
+  "typesVersions": {
+    "<3.8": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  },
   "dependencies": {
     "@jest/console": "^25.2.0",
     "@jest/environment": "^25.2.0",
@@ -41,7 +48,6 @@
     "@types/exit": "^0.1.30",
     "@types/glob": "^7.1.1",
     "@types/graceful-fs": "^4.1.2",
-    "@types/yargs": "^15.0.3",
     "execa": "^3.2.0",
     "jest-environment-node": "^25.2.0",
     "jest-snapshot-serializer-raw": "^1.1.0"

--- a/packages/jest-serializer/package.json
+++ b/packages/jest-serializer/package.json
@@ -15,6 +15,13 @@
   "license": "MIT",
   "main": "build/index.js",
   "types": "build/index.d.ts",
+  "typesVersions": {
+    "<3.8": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/jest-serializer/package.json
+++ b/packages/jest-serializer/package.json
@@ -17,8 +17,8 @@
   "types": "build/index.d.ts",
   "typesVersions": {
     "<3.8": {
-      "*": [
-        "ts3.4/*"
+      "build/*": [
+        "build/ts3.4/*"
       ]
     }
   },

--- a/packages/jest-snapshot/package.json
+++ b/packages/jest-snapshot/package.json
@@ -9,6 +9,13 @@
   "license": "MIT",
   "main": "build/index.js",
   "types": "build/index.d.ts",
+  "typesVersions": {
+    "<3.8": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  },
   "dependencies": {
     "@babel/types": "^7.0.0",
     "@jest/types": "^25.2.0",

--- a/packages/jest-snapshot/package.json
+++ b/packages/jest-snapshot/package.json
@@ -11,8 +11,8 @@
   "types": "build/index.d.ts",
   "typesVersions": {
     "<3.8": {
-      "*": [
-        "ts3.4/*"
+      "build/*": [
+        "build/ts3.4/*"
       ]
     }
   },

--- a/packages/jest-source-map/package.json
+++ b/packages/jest-source-map/package.json
@@ -11,8 +11,8 @@
   "types": "build/index.d.ts",
   "typesVersions": {
     "<3.8": {
-      "*": [
-        "ts3.4/*"
+      "build/*": [
+        "build/ts3.4/*"
       ]
     }
   },

--- a/packages/jest-source-map/package.json
+++ b/packages/jest-source-map/package.json
@@ -9,6 +9,13 @@
   "license": "MIT",
   "main": "build/index.js",
   "types": "build/index.d.ts",
+  "typesVersions": {
+    "<3.8": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  },
   "dependencies": {
     "callsites": "^3.0.0",
     "graceful-fs": "^4.2.3",

--- a/packages/jest-test-result/package.json
+++ b/packages/jest-test-result/package.json
@@ -9,6 +9,13 @@
   "license": "MIT",
   "main": "build/index.js",
   "types": "build/index.d.ts",
+  "typesVersions": {
+    "<3.8": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  },
   "dependencies": {
     "@jest/console": "^25.2.0",
     "@jest/transform": "^25.2.0",

--- a/packages/jest-test-result/package.json
+++ b/packages/jest-test-result/package.json
@@ -11,8 +11,8 @@
   "types": "build/index.d.ts",
   "typesVersions": {
     "<3.8": {
-      "*": [
-        "ts3.4/*"
+      "build/*": [
+        "build/ts3.4/*"
       ]
     }
   },

--- a/packages/jest-test-sequencer/package.json
+++ b/packages/jest-test-sequencer/package.json
@@ -9,6 +9,13 @@
   "license": "MIT",
   "main": "build/index.js",
   "types": "build/index.d.ts",
+  "typesVersions": {
+    "<3.8": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  },
   "dependencies": {
     "@jest/test-result": "^25.2.0",
     "jest-haste-map": "^25.2.0",

--- a/packages/jest-test-sequencer/package.json
+++ b/packages/jest-test-sequencer/package.json
@@ -11,8 +11,8 @@
   "types": "build/index.d.ts",
   "typesVersions": {
     "<3.8": {
-      "*": [
-        "ts3.4/*"
+      "build/*": [
+        "build/ts3.4/*"
       ]
     }
   },

--- a/packages/jest-types/package.json
+++ b/packages/jest-types/package.json
@@ -14,8 +14,8 @@
   "types": "build/index.d.ts",
   "typesVersions": {
     "<3.8": {
-      "*": [
-        "ts3.4/*"
+      "build/*": [
+        "build/ts3.4/*"
       ]
     }
   },

--- a/packages/jest-types/package.json
+++ b/packages/jest-types/package.json
@@ -12,6 +12,13 @@
   "license": "MIT",
   "main": "build/index.js",
   "types": "build/index.d.ts",
+  "typesVersions": {
+    "<3.8": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  },
   "dependencies": {
     "@types/istanbul-lib-coverage": "^2.0.0",
     "@types/istanbul-reports": "^1.1.1",

--- a/packages/jest-util/package.json
+++ b/packages/jest-util/package.json
@@ -11,8 +11,8 @@
   "types": "build/index.d.ts",
   "typesVersions": {
     "<3.8": {
-      "*": [
-        "ts3.4/*"
+      "build/*": [
+        "build/ts3.4/*"
       ]
     }
   },

--- a/packages/jest-util/package.json
+++ b/packages/jest-util/package.json
@@ -9,6 +9,13 @@
   "license": "MIT",
   "main": "build/index.js",
   "types": "build/index.d.ts",
+  "typesVersions": {
+    "<3.8": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  },
   "dependencies": {
     "@jest/types": "^25.2.0",
     "chalk": "^3.0.0",

--- a/packages/jest-validate/package.json
+++ b/packages/jest-validate/package.json
@@ -11,8 +11,8 @@
   "types": "build/index.d.ts",
   "typesVersions": {
     "<3.8": {
-      "*": [
-        "ts3.4/*"
+      "build/*": [
+        "build/ts3.4/*"
       ]
     }
   },

--- a/packages/jest-validate/package.json
+++ b/packages/jest-validate/package.json
@@ -9,6 +9,13 @@
   "license": "MIT",
   "main": "build/index.js",
   "types": "build/index.d.ts",
+  "typesVersions": {
+    "<3.8": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  },
   "dependencies": {
     "@jest/types": "^25.2.0",
     "camelcase": "^5.3.1",

--- a/packages/jest-worker/package.json
+++ b/packages/jest-worker/package.json
@@ -11,8 +11,8 @@
   "types": "build/index.d.ts",
   "typesVersions": {
     "<3.8": {
-      "*": [
-        "ts3.4/*"
+      "build/*": [
+        "build/ts3.4/*"
       ]
     }
   },

--- a/packages/jest-worker/package.json
+++ b/packages/jest-worker/package.json
@@ -9,6 +9,13 @@
   "license": "MIT",
   "main": "build/index.js",
   "types": "build/index.d.ts",
+  "typesVersions": {
+    "<3.8": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  },
   "dependencies": {
     "merge-stream": "^2.0.0",
     "supports-color": "^7.0.0"

--- a/packages/pretty-format/package.json
+++ b/packages/pretty-format/package.json
@@ -10,6 +10,13 @@
   "description": "Stringify any JavaScript value.",
   "main": "build/index.js",
   "types": "build/index.d.ts",
+  "typesVersions": {
+    "<3.8": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  },
   "browser": "build-es5/index.js",
   "author": "James Kyle <me@thejameskyle.com>",
   "dependencies": {

--- a/packages/pretty-format/package.json
+++ b/packages/pretty-format/package.json
@@ -12,8 +12,8 @@
   "types": "build/index.d.ts",
   "typesVersions": {
     "<3.8": {
-      "*": [
-        "ts3.4/*"
+      "build/*": [
+        "build/ts3.4/*"
       ]
     }
   },

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -7,8 +7,8 @@
   "types": "build/index.d.ts",
   "typesVersions": {
     "<3.8": {
-      "*": [
-        "ts3.4/*"
+      "build/*": [
+        "build/ts3.4/*"
       ]
     }
   },

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -5,6 +5,13 @@
   "license": "MIT",
   "main": "build/index.js",
   "types": "build/index.d.ts",
+  "typesVersions": {
+    "<3.8": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  },
   "dependencies": {
     "@types/jest": "*",
     "@types/node": "*",

--- a/scripts/buildTs.js
+++ b/scripts/buildTs.js
@@ -20,7 +20,13 @@ const packagesWithTs = packages.filter(p =>
   fs.existsSync(path.resolve(p, 'tsconfig.json'))
 );
 
-const args = ['tsc', '-b', ...packagesWithTs, ...process.argv.slice(2)];
+const args = [
+  '--silent',
+  'tsc',
+  '-b',
+  ...packagesWithTs,
+  ...process.argv.slice(2),
+];
 
 console.log(chalk.inverse(' Building TypeScript definition files '));
 
@@ -32,6 +38,28 @@ try {
 } catch (e) {
   console.error(
     chalk.inverse.red(' Unable to build TypeScript definition files ')
+  );
+  console.error(e.stack);
+  process.exitCode = 1;
+}
+
+console.log(chalk.inverse(' Downleveling TypeScript definition files '));
+
+try {
+  packagesWithTs.forEach(pkgDir => {
+    execa.sync('yarn', ['--silent', 'downlevel-dts', 'build', 'build/ts3.4'], {
+      cwd: pkgDir,
+      stdio: 'inherit',
+    });
+  });
+  console.log(
+    chalk.inverse.green(
+      ' Successfully downleveled TypeScript definition files '
+    )
+  );
+} catch (e) {
+  console.error(
+    chalk.inverse.red(' Unable to downlevel TypeScript definition files ')
   );
   console.error(e.stack);
   process.exitCode = 1;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5622,6 +5622,14 @@ dot-prop@^5.2.0:
   dependencies:
     is-obj "^2.0.0"
 
+downlevel-dts@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/downlevel-dts/-/downlevel-dts-0.4.0.tgz#43f9f649c8b137373d76b4ee396d5a0227c10ddb"
+  integrity sha512-nh5vM3n2pRhPwZqh0iWo5gpItPAYEGEWw9yd0YpI+lO60B7A3A6iJlxDbt7kKVNbqBXKsptL+jwE/Yg5Go66WQ==
+  dependencies:
+    shelljs "^0.8.3"
+    typescript "^3.8.0-dev.20200111"
+
 download@^6.2.2:
   version "6.2.5"
   resolved "https://registry.yarnpkg.com/download/-/download-6.2.5.tgz#acd6a542e4cd0bb42ca70cfc98c9e43b07039714"
@@ -14272,7 +14280,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@*, typescript@^3.8.2:
+typescript@*, typescript@^3.8.0-dev.20200111, typescript@^3.8.2:
   version "3.8.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
   integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

We shouldn't force consumers to update to TS 3.8. This will downlevel the `d.ts` files so it works down to TS 3.4.

Fixes #9703
Closes #9704

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

I'll publish a canary and try to build with an older version of TS.

EDIT: Seems to work. This is with typescript@3.4.5

![image](https://user-images.githubusercontent.com/1404810/77624304-e55f3200-6f41-11ea-95ce-f99988f99e16.png)

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
