### PR TITLE
fix: remove `getVmContext` from node env on older versions of node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- `[jest-environment-node]` Remove `getVmContext` from Node env on older versions of Node ([#9706](https://github.com/facebook/jest/pull/9706))
+
 ### Chore & Maintenance
 
 ### Performance

--- a/packages/jest-environment-node/package.json
+++ b/packages/jest-environment-node/package.json
@@ -21,7 +21,11 @@
     "@jest/fake-timers": "^25.2.1",
     "@jest/types": "^25.2.1",
     "jest-mock": "^25.2.1",
-    "jest-util": "^25.2.1"
+    "jest-util": "^25.2.1",
+    "semver": "^6.3.0"
+  },
+  "devDependencies": {
+    "@types/semver": "^6.2.1"
   },
   "engines": {
     "node": ">= 8.3"

--- a/packages/jest-environment-node/src/index.ts
+++ b/packages/jest-environment-node/src/index.ts
@@ -14,6 +14,7 @@ import {
   LolexFakeTimers,
 } from '@jest/fake-timers';
 import type {JestEnvironment} from '@jest/environment';
+import {lt as semverLt} from 'semver';
 
 type Timer = {
   id: number;
@@ -119,6 +120,13 @@ class NodeEnvironment implements JestEnvironment {
   getVmContext(): Context | null {
     return this.context;
   }
+}
+
+// node 10 had a bug in `vm.compileFunction` that was fixed in https://github.com/nodejs/node/pull/23206.
+// Let's just pretend the env doesn't support the function.
+// Make sure engine requirement is high enough when we drop node 8 so we can remove this condition
+if (semverLt(process.version, '10.14.2')) {
+  delete NodeEnvironment.prototype.getVmContext;
 }
 
 export = NodeEnvironment;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Should silently fix #9538 without people needing to upgrade their version of node

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

I tested with node 10.14.0 and 10.14.2 locally - seems to work correctly

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
