### PR TITLE
fix: ensure all packages correctly downlevel TS files

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -41,6 +41,8 @@ jobs:
         run: node scripts/build.js
       - name: run tsc
         run: yarn build:ts
+      - name: verify ts 3.4 compatibility
+        run: yarn verify-old-ts
       - name: run eslint
         run: yarn lint
       - name: run eslint on browser builds
@@ -49,8 +51,6 @@ jobs:
         run: yarn lint:prettier:ci
       - name: check copyright headers
         run: yarn check-copyright-headers
-      - name: verify ts 3.4 compatibility
-        run: yarn verify-old-ts
   test:
     name: Node v${{ matrix.node-version }} on ${{ matrix.os }}
     strategy:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -49,6 +49,8 @@ jobs:
         run: yarn lint:prettier:ci
       - name: check copyright headers
         run: yarn check-copyright-headers
+      - name: verify ts 3.4 compatibility
+        run: yarn verify-old-ts
   test:
     name: Node v${{ matrix.node-version }} on ${{ matrix.os }}
     strategy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- `[*]` Verify all packages are properly downleveled for older versions of TypeScript
+
 ### Chore & Maintenance
 
 ### Performance
@@ -12,7 +14,7 @@
 
 ### Fixes
 
-- `[jest-environment-node]` Remove `getVmContext` from Node env on older versions of Node ([#9706](https://github.com/facebook/jest/pull/9706))
+- `[jest-environment-node]` Remove `getVmContext` from Node env on older versions of Node ([#9708](https://github.com/facebook/jest/pull/9708))
 - `[jest-runtime]` Return constructable class from `require('module')` ([#9711](https://github.com/facebook/jest/pull/9711))
 
 ## 25.2.1

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "slash": "^3.0.0",
     "string-length": "^3.1.0",
     "strip-ansi": "^6.0.0",
+    "tempy": "~0.3.0",
     "throat": "^5.0.0",
     "typescript": "^3.8.2",
     "webpack": "^4.28.4",
@@ -106,6 +107,7 @@
     "test-pretty-format-perf": "node packages/pretty-format/perf/test.js",
     "test-leak": "yarn jest -i --detectLeaks jest-mock jest-diff jest-repl",
     "test": "yarn lint && yarn jest",
+    "verify-old-ts": "node ./scripts/verifyOldTs.js",
     "watch": "yarn build && node ./scripts/watch.js",
     "watch:ts": "yarn build:ts --watch"
   },

--- a/packages/jest-console/src/CustomConsole.ts
+++ b/packages/jest-console/src/CustomConsole.ts
@@ -51,7 +51,8 @@ export default class CustomConsole extends Console {
     );
   }
 
-  assert(value: unknown, message?: string | Error): asserts value {
+  // use `asserts` when https://github.com/sandersn/downlevel-dts/issues/32 is fixed
+  assert(value: unknown, message?: string | Error): void {
     try {
       assert(value, message);
     } catch (error) {

--- a/packages/jest-core/package.json
+++ b/packages/jest-core/package.json
@@ -4,6 +4,13 @@
   "version": "25.2.2",
   "main": "build/jest.js",
   "types": "build/jest.d.ts",
+  "typesVersions": {
+    "<3.8": {
+      "build/*": [
+        "build/ts3.4/*"
+      ]
+    }
+  },
   "dependencies": {
     "@jest/console": "^25.2.1",
     "@jest/reporters": "^25.2.1",

--- a/packages/jest-docblock/package.json
+++ b/packages/jest-docblock/package.json
@@ -8,6 +8,14 @@
   },
   "license": "MIT",
   "main": "build/index.js",
+  "types": "build/index.d.ts",
+  "typesVersions": {
+    "<3.8": {
+      "build/*": [
+        "build/ts3.4/*"
+      ]
+    }
+  },
   "dependencies": {
     "detect-newline": "^3.0.0"
   },

--- a/packages/jest-phabricator/package.json
+++ b/packages/jest-phabricator/package.json
@@ -7,6 +7,13 @@
     "directory": "packages/jest-phabricator"
   },
   "types": "build/index.d.ts",
+  "typesVersions": {
+    "<3.8": {
+      "build/*": [
+        "build/ts3.4/*"
+      ]
+    }
+  },
   "dependencies": {
     "@jest/test-result": "^25.2.1"
   },

--- a/packages/jest-transform/package.json
+++ b/packages/jest-transform/package.json
@@ -8,6 +8,14 @@
   },
   "license": "MIT",
   "main": "build/index.js",
+  "types": "build/index.d.ts",
+  "typesVersions": {
+    "<3.8": {
+      "build/*": [
+        "build/ts3.4/*"
+      ]
+    }
+  },
   "dependencies": {
     "@babel/core": "^7.1.0",
     "@jest/types": "^25.2.1",

--- a/packages/jest-transform/src/types.ts
+++ b/packages/jest-transform/src/types.ts
@@ -24,11 +24,8 @@ export type Options = ShouldInstrumentOptions &
     isInternalModule: boolean;
   }>;
 
-// extends directly after https://github.com/sandersn/downlevel-dts/issues/33 is fixed
-type SourceMapWithVersion = Omit<RawSourceMap, 'version'>;
-
 // This is fixed in source-map@0.7.x, but we can't upgrade yet since it's async
-interface FixedRawSourceMap extends SourceMapWithVersion {
+interface FixedRawSourceMap extends Omit<RawSourceMap, 'version'> {
   version: number;
 }
 

--- a/packages/jest-transform/src/types.ts
+++ b/packages/jest-transform/src/types.ts
@@ -24,8 +24,11 @@ export type Options = ShouldInstrumentOptions &
     isInternalModule: boolean;
   }>;
 
+// extends directly after https://github.com/sandersn/downlevel-dts/issues/33 is fixed
+type SourceMapWithVersion = Omit<RawSourceMap, 'version'>;
+
 // This is fixed in source-map@0.7.x, but we can't upgrade yet since it's async
-interface FixedRawSourceMap extends Omit<RawSourceMap, 'version'> {
+interface FixedRawSourceMap extends SourceMapWithVersion {
   version: number;
 }
 

--- a/packages/jest-types/src/Global.ts
+++ b/packages/jest-types/src/Global.ts
@@ -83,8 +83,10 @@ export interface GlobalAdditions {
   spyOn: () => void;
   spyOnProperty: () => void;
 }
-export interface Global
-  extends GlobalAdditions,
-    Omit<NodeJS.Global, keyof GlobalAdditions> {
+
+// extends directly after https://github.com/sandersn/downlevel-dts/issues/33 is fixed
+type NodeGlobalWithoutAdditions = Omit<NodeJS.Global, keyof GlobalAdditions>;
+
+export interface Global extends GlobalAdditions, NodeGlobalWithoutAdditions {
   [extras: string]: any;
 }

--- a/packages/jest-watcher/package.json
+++ b/packages/jest-watcher/package.json
@@ -3,6 +3,14 @@
   "description": "Delightful JavaScript Testing.",
   "version": "25.2.1",
   "main": "build/index.js",
+  "types": "build/index.d.ts",
+  "typesVersions": {
+    "<3.8": {
+      "build/*": [
+        "build/ts3.4/*"
+      ]
+    }
+  },
   "dependencies": {
     "@jest/test-result": "^25.2.1",
     "@jest/types": "^25.2.1",

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -4,6 +4,13 @@
   "version": "25.2.2",
   "main": "build/jest.js",
   "types": "build/jest.d.ts",
+  "typesVersions": {
+    "<3.8": {
+      "build/*": [
+        "build/ts3.4/*"
+      ]
+    }
+  },
   "dependencies": {
     "@jest/core": "^25.2.2",
     "import-local": "^3.0.2",

--- a/scripts/buildTs.js
+++ b/scripts/buildTs.js
@@ -44,11 +44,30 @@ try {
   );
   console.error(e.stack);
   process.exitCode = 1;
+  return;
 }
 
 const downlevelArgs = ['--silent', 'downlevel-dts', 'build', 'build/ts3.4'];
 
 console.log(chalk.inverse(' Downleveling TypeScript definition files '));
+
+packagesWithTs.forEach(pkgDir => {
+  const pkg = require(pkgDir + '/package.json');
+
+  if (!pkg.types) {
+    throw new Error(`Package ${pkg.name} is missing \`types\` field`);
+  }
+
+  if (!pkg.typesVersions) {
+    throw new Error(`Package ${pkg.name} is missing \`typesVersions\` field`);
+  }
+
+  if (pkg.main.replace(/\.js$/, '.d.ts') !== pkg.types) {
+    throw new Error(
+      `\`main\` and \`types\` field of ${pkg.name} does not match`
+    );
+  }
+});
 
 // we want to limit the number of processes we spawn
 const cpus = Math.max(1, os.cpus().length - 1);

--- a/scripts/verifyOldTs.js
+++ b/scripts/verifyOldTs.js
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const execa = require('execa');
+const rimraf = require('rimraf');
+const tempy = require('tempy');
+
+const jestDirectory = path.resolve(__dirname, '../packages/jest');
+
+const tsConfig = {
+  compilerOptions: {
+    esModuleInterop: false,
+    lib: ['es2018'],
+    module: 'commonjs',
+    moduleResolution: 'node',
+    noEmit: true,
+    strict: true,
+    target: 'es5',
+  },
+};
+const cwd = tempy.directory();
+
+try {
+  execa.sync('yarn', ['init', '--yes'], {cwd, stdio: 'inherit'});
+  execa.sync('yarn', ['add', 'typescript@~3.4'], {cwd, stdio: 'inherit'});
+  fs.writeFileSync(
+    path.join(cwd, 'tsconfig.json'),
+    JSON.stringify(tsConfig, null, 2)
+  );
+  fs.writeFileSync(
+    path.join(cwd, 'index.ts'),
+    `import jest = require('${jestDirectory}');`
+  );
+  execa.sync('yarn', ['tsc', '--project', '.'], {cwd, stdio: 'inherit'});
+} finally {
+  rimraf.sync(cwd);
+}

--- a/scripts/verifyOldTs.js
+++ b/scripts/verifyOldTs.js
@@ -10,6 +10,7 @@
 const fs = require('fs');
 const path = require('path');
 
+const chalk = require('chalk');
 const execa = require('execa');
 const rimraf = require('rimraf');
 const tempy = require('tempy');
@@ -41,6 +42,10 @@ try {
     `import jest = require('${jestDirectory}');`
   );
   execa.sync('yarn', ['tsc', '--project', '.'], {cwd, stdio: 'inherit'});
+
+  console.log(
+    chalk.inverse.green(' Successfully compiled Jest with TypeScript 3.4 ')
+  );
 } finally {
   rimraf.sync(cwd);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4931,6 +4931,11 @@ crypto-browserify@^3.11.0:
     randombytes "^2.0.0"
     randomfill "^1.0.3"
 
+crypto-random-string@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-1.0.0.tgz#a230f64f568310e1498009940790ec99545bca7e"
+  integrity sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=
+
 css-color-names@0.0.4, css-color-names@^0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/css-color-names/-/css-color-names-0.0.4.tgz#808adc2e79cf84738069b646cb20ec27beb629e0"
@@ -13908,6 +13913,15 @@ tempfile@^2.0.0:
     temp-dir "^1.0.0"
     uuid "^3.0.1"
 
+tempy@~0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/tempy/-/tempy-0.3.0.tgz#6f6c5b295695a16130996ad5ab01a8bd726e8bf8"
+  integrity sha512-WrH/pui8YCwmeiAoxV+lpRH9HpRtgBhSR2ViBPgpGb/wnYDzp21R4MN45fsCGvLROvY67o3byhJRYRONJyImVQ==
+  dependencies:
+    temp-dir "^1.0.0"
+    type-fest "^0.3.1"
+    unique-string "^1.0.0"
+
 terminal-link@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/terminal-link/-/terminal-link-2.1.1.tgz#14a64a27ab3c0df933ea546fba55f2d078edc994"
@@ -14245,7 +14259,7 @@ type-fest@^0.11.0:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.11.0.tgz#97abf0872310fed88a5c466b25681576145e33f1"
   integrity sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==
 
-type-fest@^0.3.0:
+type-fest@^0.3.0, type-fest@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.3.1.tgz#63d00d204e059474fe5e1b7c011112bbd1dc29e1"
   integrity sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==
@@ -14410,6 +14424,13 @@ unique-slug@^2.0.0:
   integrity sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==
   dependencies:
     imurmurhash "^0.1.4"
+
+unique-string@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/unique-string/-/unique-string-1.0.0.tgz#9e1057cca851abb93398f8b33ae187b99caec11a"
+  integrity sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=
+  dependencies:
+    crypto-random-string "^1.0.0"
 
 unist-util-is@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

In #9705 I just tested with `pretty-format` - seems I forgot to update a few `package.json`s. This also uncovered a few missing `types` fields as well, so fixing those at the same time.

I also rolled back on syntax that downlevel [doesn't support](https://github.com/sandersn/downlevel-dts/issues/32) and worked around [another bug](https://github.com/sandersn/downlevel-dts/issues/33).

Fixes #9714.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

I've now verified `typescript@3.4` can compile the entire `jest` package, not just `pretty-format` and what that pulls in

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
