### PR TITLE
Fix type ellision of jest-runtime imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- `[jest-circus]` Fix type ellision of jest-runtime imports ([#9717](https://github.com/facebook/jest/pull/9717))
+
 ### Chore & Maintenance
 
 ### Performance

--- a/packages/jest-circus/package.json
+++ b/packages/jest-circus/package.json
@@ -28,6 +28,7 @@
     "jest-each": "^25.2.3",
     "jest-matcher-utils": "^25.2.3",
     "jest-message-util": "^25.2.3",
+    "jest-runtime": "^25.2.3",
     "jest-snapshot": "^25.2.3",
     "jest-util": "^25.2.3",
     "pretty-format": "^25.2.3",
@@ -41,8 +42,7 @@
     "@types/babel__traverse": "^7.0.4",
     "@types/co": "^4.6.0",
     "@types/stack-utils": "^1.0.1",
-    "execa": "^3.2.0",
-    "jest-runtime": "^25.2.3"
+    "execa": "^3.2.0"
   },
   "engines": {
     "node": ">= 8.3"

--- a/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapter.ts
+++ b/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapter.ts
@@ -9,7 +9,7 @@ import * as path from 'path';
 import type {Config} from '@jest/types';
 import type {JestEnvironment} from '@jest/environment';
 import type {TestResult} from '@jest/test-result';
-import Runtime = require('jest-runtime');
+import type {RuntimeType as Runtime} from 'jest-runtime';
 import type {SnapshotStateType} from 'jest-snapshot';
 
 const FRAMEWORK_INITIALIZER = require.resolve('./jestAdapterInit');

--- a/packages/jest-jasmine2/src/index.ts
+++ b/packages/jest-jasmine2/src/index.ts
@@ -10,7 +10,7 @@ import type {Config, Global} from '@jest/types';
 import type {AssertionResult, TestResult} from '@jest/test-result';
 import type {JestEnvironment} from '@jest/environment';
 import type {SnapshotStateType} from 'jest-snapshot';
-import Runtime = require('jest-runtime');
+import type {RuntimeType as Runtime} from 'jest-runtime';
 
 import {getCallsite} from '@jest/source-map';
 import installEach from './each';

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -64,6 +64,8 @@ type CacheFS = {[path: string]: string};
 
 namespace Runtime {
   export type Context = JestContext;
+  // ditch this export when moving to esm - for now we need it for to avoid faulty type elision
+  export type RuntimeType = Runtime;
 }
 
 const testTimeoutSymbol = Symbol.for('TEST_TIMEOUT_SYMBOL');


### PR DESCRIPTION
Fixes #9600.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

After refreshing my project's lockfile, I noticed an issue when running Jest with `jest-circus` as the runner due to a missing `jest-runtime` dependency. Making it a non-dev dependency should fix this.

## Test plan

Installing the dependency at the top level fixes the issue in my project, `npm` seems to install it in a nested node_modules folder otherwise.