### PR TITLE
Preserve symlinks when node is configured to do so

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /examples/*/node_modules/
 /examples/mongodb/globalConfig.json
 
+/e2e/preserve-symlinks/*
 /e2e/*/node_modules
 /e2e/*/.pnp
 /e2e/*/.pnp.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Features
 
+- `[*]` Respect NODE_PRESERVE_SYMLINKS environment variable and --preserve-symlinks flag when resolving file paths ([#9732](https://github.com/facebook/jest/pull/9732))
+
 ### Fixes
 
 - `[jest-jasmine2]` Don't run `beforeAll` / `afterAll` in skipped describe block ([#9931](https://github.com/facebook/jest/pull/9931))

--- a/e2e/__tests__/__snapshots__/moduleNameMapper.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/moduleNameMapper.test.ts.snap
@@ -36,7 +36,7 @@ FAIL __tests__/index.js
       12 | module.exports = () => 'test';
       13 | 
 
-      at createNoMappedModuleFoundError (../../packages/jest-resolve/build/index.js:545:17)
+      at createNoMappedModuleFoundError (../../packages/jest-resolve/build/index.js:561:17)
       at Object.require (index.js:10:1)
 `;
 
@@ -65,6 +65,6 @@ FAIL __tests__/index.js
       12 | module.exports = () => 'test';
       13 | 
 
-      at createNoMappedModuleFoundError (../../packages/jest-resolve/build/index.js:545:17)
+      at createNoMappedModuleFoundError (../../packages/jest-resolve/build/index.js:561:17)
       at Object.require (index.js:10:1)
 `;

--- a/e2e/__tests__/__snapshots__/resolveNoFileExtensions.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/resolveNoFileExtensions.test.ts.snap
@@ -37,6 +37,6 @@ FAIL __tests__/test.js
         |                  ^
       9 | 
 
-      at Resolver.resolveModule (../../packages/jest-resolve/build/index.js:299:11)
+      at Resolver.resolveModule (../../packages/jest-resolve/build/index.js:315:11)
       at Object.require (index.js:8:18)
 `;

--- a/e2e/__tests__/preserveSymlinks.ts
+++ b/e2e/__tests__/preserveSymlinks.ts
@@ -1,0 +1,131 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {join, resolve} from 'path';
+import {
+  existsSync,
+  mkdirSync,
+  rmdirSync,
+  symlinkSync,
+  unlinkSync,
+} from 'graceful-fs';
+
+import runJest from '../runJest';
+import {extractSummary} from '../Utils';
+import HasteMap = require('jest-haste-map');
+
+const destRoot = resolve(__dirname, '../preserve-symlinks');
+const srcRoot = resolve(__dirname, '../symlinked-source-dir');
+
+const files = [
+  'package.json',
+  'a.js',
+  'b.js',
+  'ab.js',
+  '__tests__/a.test.js',
+  '__tests__/b.test.js',
+  '__tests__/ab.test.js',
+];
+
+function cleanup() {
+  files
+    .map(f => join(destRoot, f))
+    .filter(f => existsSync(f))
+    .forEach(f => {
+      unlinkSync(f);
+    });
+  if (existsSync(join(destRoot, '__tests__'))) {
+    rmdirSync(join(destRoot, '__tests__'));
+  }
+  if (existsSync(destRoot)) {
+    rmdirSync(destRoot);
+  }
+}
+
+beforeAll(() => {
+  cleanup();
+  mkdirSync(destRoot);
+  mkdirSync(join(destRoot, '__tests__'));
+  files.forEach(f => {
+    symlinkSync(join(srcRoot, f), join(destRoot, f));
+  });
+});
+
+afterAll(() => {
+  cleanup();
+});
+
+test('preserving symlinks with environment variable', () => {
+  const {stderr, exitCode} = runJest('preserve-symlinks', ['--no-watchman'], {
+    preserveSymlinks: '1',
+  });
+  const {summary, rest} = extractSummary(stderr);
+  expect(exitCode).toEqual(0);
+  expect(rest.split('\n').length).toEqual(3);
+  expect(rest).toMatch('PASS __tests__/ab.test.js');
+  expect(rest).toMatch('PASS __tests__/a.test.js');
+  expect(rest).toMatch('PASS __tests__/b.test.js');
+  expect(summary).toMatch('Test Suites: 3 passed, 3 total');
+  expect(summary).toMatch('Tests:       3 passed, 3 total');
+  expect(summary).toMatch('Snapshots:   0 total');
+});
+
+test('preserving symlinks with --preserve-symlinks node flag', () => {
+  const {stderr, exitCode} = runJest('preserve-symlinks', ['--no-watchman'], {
+    nodeFlags: ['--preserve-symlinks'],
+  });
+  const {summary, rest} = extractSummary(stderr);
+  expect(exitCode).toEqual(0);
+  expect(rest.split('\n').length).toEqual(3);
+  expect(rest).toMatch('PASS __tests__/ab.test.js');
+  expect(rest).toMatch('PASS __tests__/a.test.js');
+  expect(rest).toMatch('PASS __tests__/b.test.js');
+  expect(summary).toMatch('Test Suites: 3 passed, 3 total');
+  expect(summary).toMatch('Tests:       3 passed, 3 total');
+  expect(summary).toMatch('Snapshots:   0 total');
+});
+
+test('hasteMap finds symlinks correctly', async () => {
+  const options = {
+    extensions: ['js'],
+    forceNodeFilesystemAPI: true,
+    maxWorkers: 2,
+    mocksPattern: '',
+    name: 'tmp',
+    platforms: [],
+    preserveSymlinks: true,
+    retainAllFiles: true,
+    rootDir: resolve(__dirname, '../preserve-symlinks'),
+    roots: [resolve(__dirname, '../preserve-symlinks')],
+    useWatchman: false,
+    watch: false,
+  };
+  const hasteMap = new HasteMap(options);
+  const result = await hasteMap.build();
+  const files = result.hasteFS
+    .getAllFiles()
+    .map(f => f.split('preserve-symlinks').pop());
+
+  const expectedFiles = [
+    join('/__tests__', 'a.test.js'),
+    join('/__tests__', 'ab.test.js'),
+    join('/__tests__', 'b.test.js'),
+    join('/', 'a.js'),
+    join('/', 'ab.js'),
+    join('/', 'b.js'),
+  ];
+
+  expectedFiles.forEach(f => {
+    expect(files).toContain(f);
+  });
+});
+
+test('no preserve symlinks configuration', () => {
+  const {exitCode, stdout} = runJest('preserve-symlinks', ['--no-watchman']);
+  expect(exitCode).toEqual(1);
+  expect(stdout).toMatch('No tests found, exiting with code 1');
+});

--- a/e2e/runJest.ts
+++ b/e2e/runJest.ts
@@ -18,6 +18,8 @@ import {normalizeIcons} from './Utils';
 const JEST_PATH = path.resolve(__dirname, '../packages/jest-cli/bin/jest.js');
 
 type RunJestOptions = {
+  preserveSymlinks?: string;
+  nodeFlags?: Array<string>;
   nodeOptions?: string;
   nodePath?: string;
   skipPkgJsonCheck?: boolean; // don't complain if can't find package.json
@@ -74,11 +76,15 @@ function spawnJest(
     );
   }
   const env = Object.assign({}, process.env, {FORCE_COLOR: '0'});
-
   if (options.nodeOptions) env['NODE_OPTIONS'] = options.nodeOptions;
   if (options.nodePath) env['NODE_PATH'] = options.nodePath;
+  if (options.preserveSymlinks)
+    env['NODE_PRESERVE_SYMLINKS'] = options.preserveSymlinks;
 
   const spawnArgs = [JEST_PATH, ...args];
+  if (options.nodeFlags) {
+    spawnArgs.unshift(...options.nodeFlags);
+  }
   const spawnOptions = {
     cwd: dir,
     env,

--- a/e2e/symlinked-source-dir/__tests__/a.test.js
+++ b/e2e/symlinked-source-dir/__tests__/a.test.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+const a = require('../a');
+
+test('a', () => {
+  expect(a()).toEqual('a');
+});

--- a/e2e/symlinked-source-dir/__tests__/ab.test.js
+++ b/e2e/symlinked-source-dir/__tests__/ab.test.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+const ab = require('../ab');
+
+test('ab', () => {
+  expect(ab()).toEqual('ab');
+});

--- a/e2e/symlinked-source-dir/__tests__/b.test.js
+++ b/e2e/symlinked-source-dir/__tests__/b.test.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+const b = require('../b');
+
+test('b', () => {
+  expect(b()).toEqual('b');
+});

--- a/e2e/symlinked-source-dir/a.js
+++ b/e2e/symlinked-source-dir/a.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+module.exports = function a() {
+  return 'a';
+};

--- a/e2e/symlinked-source-dir/ab.js
+++ b/e2e/symlinked-source-dir/ab.js
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+const a = require('./a');
+const b = require('./b');
+
+module.exports = function ab() {
+  return a() + b();
+};

--- a/e2e/symlinked-source-dir/b.js
+++ b/e2e/symlinked-source-dir/b.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+module.exports = function b() {
+  return 'b';
+};

--- a/e2e/symlinked-source-dir/package.json
+++ b/e2e/symlinked-source-dir/package.json
@@ -1,0 +1,5 @@
+{
+  "jest": {
+    "testEnvironment": "node"
+  }
+}

--- a/packages/jest-cli/package.json
+++ b/packages/jest-cli/package.json
@@ -25,6 +25,7 @@
     "jest-validate": "^25.5.0",
     "prompts": "^2.0.1",
     "realpath-native": "^2.0.0",
+    "should-preserve-links": "^1.0.4",
     "yargs": "^15.3.1"
   },
   "devDependencies": {

--- a/packages/jest-cli/should-preserve-links.d.ts
+++ b/packages/jest-cli/should-preserve-links.d.ts
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+declare module 'should-preserve-links' {
+  export default function shouldPreserveLinks(): boolean;
+}

--- a/packages/jest-cli/src/cli/index.ts
+++ b/packages/jest-cli/src/cli/index.ts
@@ -15,9 +15,15 @@ import {getVersion, runCLI} from '@jest/core';
 import chalk = require('chalk');
 import exit = require('exit');
 import yargs = require('yargs');
-import {sync as realpath} from 'realpath-native';
+import {sync as _realpath} from 'realpath-native';
+import shouldPreserveSymlinks from 'should-preserve-links';
 import init from '../init';
 import * as args from './args';
+
+const preserveSymlinks = shouldPreserveSymlinks();
+function realpath(p: string) {
+  return preserveSymlinks ? p : _realpath(p);
+}
 
 export async function run(
   maybeArgv?: Array<string>,

--- a/packages/jest-cli/src/init/index.ts
+++ b/packages/jest-cli/src/init/index.ts
@@ -9,8 +9,9 @@ import * as path from 'path';
 import * as fs from 'graceful-fs';
 import chalk = require('chalk');
 import prompts = require('prompts');
-import {sync as realpath} from 'realpath-native';
+import {sync as _realpath} from 'realpath-native';
 import {constants} from 'jest-config';
+import shouldPreserveSymlinks from 'should-preserve-links';
 import defaultQuestions, {testScriptQuestion} from './questions';
 import {MalformedPackageJsonError, NotFoundPackageJsonError} from './errors';
 import generateConfigFile from './generate_config_file';
@@ -31,6 +32,11 @@ type PromptsResults = {
   environment: boolean;
   scripts: boolean;
 };
+
+const preserveSymlinks = shouldPreserveSymlinks();
+function realpath(p: string) {
+  return preserveSymlinks ? p : _realpath(p);
+}
 
 const getConfigFilename = (ext: string) => JEST_CONFIG_BASE_NAME + ext;
 

--- a/packages/jest-config/package.json
+++ b/packages/jest-config/package.json
@@ -35,7 +35,8 @@
     "jest-validate": "^25.5.0",
     "micromatch": "^4.0.2",
     "pretty-format": "^25.5.0",
-    "realpath-native": "^2.0.0"
+    "realpath-native": "^2.0.0",
+    "should-preserve-links": "^1.0.4"
   },
   "devDependencies": {
     "@types/babel__core": "^7.0.4",

--- a/packages/jest-config/should-preserve-links.d.ts
+++ b/packages/jest-config/should-preserve-links.d.ts
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+declare module 'should-preserve-links' {
+  export default function shouldPreserveLinks(): boolean;
+}

--- a/packages/jest-config/src/getCacheDirectory.ts
+++ b/packages/jest-config/src/getCacheDirectory.ts
@@ -7,7 +7,14 @@
 
 import * as path from 'path';
 import {tmpdir} from 'os';
-import {sync as realpath} from 'realpath-native';
+import {sync as _realpath} from 'realpath-native';
+
+import shouldPreserveSymlinks from 'should-preserve-links';
+
+const preserveSymlinks = shouldPreserveSymlinks();
+function realpath(p: string) {
+  return preserveSymlinks ? p : _realpath(p);
+}
 
 const getCacheDirectory = () => {
   const {getuid} = process;

--- a/packages/jest-config/src/index.ts
+++ b/packages/jest-config/src/index.ts
@@ -9,7 +9,8 @@ import * as path from 'path';
 import * as fs from 'graceful-fs';
 import type {Config} from '@jest/types';
 import chalk = require('chalk');
-import {sync as realpath} from 'realpath-native';
+import {sync as _realpath} from 'realpath-native';
+import shouldPreserveSymlinks from 'should-preserve-links';
 import {isJSONString, replaceRootDirInPath} from './utils';
 import normalize from './normalize';
 import resolveConfigPath from './resolveConfigPath';
@@ -22,6 +23,11 @@ export {default as defaults} from './Defaults';
 export {default as descriptions} from './Descriptions';
 import * as constants from './constants';
 export {constants};
+
+const preserveSymlinks = shouldPreserveSymlinks();
+function realpath(p: string) {
+  return preserveSymlinks ? p : _realpath(p);
+}
 
 type ReadConfig = {
   configPath: Config.Path | null | undefined;

--- a/packages/jest-config/src/normalize.ts
+++ b/packages/jest-config/src/normalize.ts
@@ -14,10 +14,11 @@ import {ValidationError, validate} from 'jest-validate';
 import {clearLine, replacePathSepForGlob} from 'jest-util';
 import chalk = require('chalk');
 import micromatch = require('micromatch');
-import {sync as realpath} from 'realpath-native';
+import {sync as _realpath} from 'realpath-native';
 import Resolver = require('jest-resolve');
 import {replacePathSepForRegex} from 'jest-regex-util';
 import merge = require('deepmerge');
+import shouldPreserveSymlinks from 'should-preserve-links';
 import validatePattern from './validatePattern';
 import getMaxWorkers from './getMaxWorkers';
 import {
@@ -44,6 +45,11 @@ const PRESET_EXTENSIONS = ['.json', '.js'];
 const PRESET_NAME = 'jest-preset';
 
 type AllOptions = Config.ProjectConfig & Config.GlobalConfig;
+
+const preserveSymlinks = shouldPreserveSymlinks();
+function realpath(p: string) {
+  return preserveSymlinks ? p : _realpath(p);
+}
 
 const createConfigError = (message: string) =>
   new ValidationError(ERROR, message, DOCUMENTATION_NOTE);

--- a/packages/jest-core/package.json
+++ b/packages/jest-core/package.json
@@ -38,6 +38,7 @@
     "p-each-series": "^2.1.0",
     "realpath-native": "^2.0.0",
     "rimraf": "^3.0.0",
+    "should-preserve-links": "^1.0.4",
     "slash": "^3.0.0",
     "strip-ansi": "^6.0.0"
   },

--- a/packages/jest-core/should-preserve-links.d.ts
+++ b/packages/jest-core/should-preserve-links.d.ts
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+declare module 'should-preserve-links' {
+  export default function shouldPreserveLinks(): boolean;
+}

--- a/packages/jest-core/src/runJest.ts
+++ b/packages/jest-core/src/runJest.ts
@@ -7,7 +7,7 @@
 
 import * as path from 'path';
 import chalk = require('chalk');
-import {sync as realpath} from 'realpath-native';
+import {sync as _realpath} from 'realpath-native';
 import {CustomConsole} from '@jest/console';
 import {interopRequireDefault} from 'jest-util';
 import exit = require('exit');
@@ -23,6 +23,7 @@ import {
 } from '@jest/test-result';
 import type TestSequencer from '@jest/test-sequencer';
 import type {ChangedFiles, ChangedFilesPromise} from 'jest-changed-files';
+import shouldPreserveSymlinks from 'should-preserve-links';
 import getNoTestsFoundMessage from './getNoTestsFoundMessage';
 import runGlobalHook from './runGlobalHook';
 import SearchSource from './SearchSource';
@@ -31,6 +32,11 @@ import type FailedTestsCache from './FailedTestsCache';
 import collectNodeHandles from './collectHandles';
 import type TestWatcher from './TestWatcher';
 import type {Filter, TestRunData} from './types';
+
+const preserveSymlinks = shouldPreserveSymlinks();
+function realpath(p: string) {
+  return preserveSymlinks ? p : _realpath(p);
+}
 
 const getTestPaths = async (
   globalConfig: Config.GlobalConfig,

--- a/packages/jest-haste-map/package.json
+++ b/packages/jest-haste-map/package.json
@@ -27,6 +27,7 @@
     "jest-worker": "^25.5.0",
     "micromatch": "^4.0.2",
     "sane": "^4.0.3",
+    "should-preserve-links": "^1.0.4",
     "walker": "^1.0.7",
     "which": "^2.0.2"
   },

--- a/packages/jest-haste-map/should-preserve-links.d.ts
+++ b/packages/jest-haste-map/should-preserve-links.d.ts
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+declare module 'should-preserve-links' {
+  export default function shouldPreserveLinks(): boolean;
+}

--- a/packages/jest-haste-map/src/index.ts
+++ b/packages/jest-haste-map/src/index.ts
@@ -15,6 +15,7 @@ import {NodeWatcher, Watcher as SaneWatcher} from 'sane';
 import type {Config} from '@jest/types';
 import serializer from 'jest-serializer';
 import Worker from 'jest-worker';
+import shouldPreserveSymlinks from 'should-preserve-links';
 import {getSha1, worker} from './worker';
 import getMockName from './getMockName';
 import getPlatformExtension from './lib/getPlatformExtension';
@@ -45,6 +46,8 @@ import type {
   WorkerMetadata,
 } from './types';
 
+const preserveSymlinks = shouldPreserveSymlinks();
+
 type HType = typeof H;
 
 type Options = {
@@ -61,6 +64,7 @@ type Options = {
   mocksPattern?: string;
   name: string;
   platforms: Array<string>;
+  preserveSymlinks?: boolean;
   providesModuleNodeModules?: Array<string>;
   resetCache?: boolean;
   retainAllFiles: boolean;
@@ -85,6 +89,7 @@ type InternalOptions = {
   mocksPattern: RegExp | null;
   name: string;
   platforms: Array<string>;
+  preserveSymlinks: boolean;
   resetCache?: boolean;
   retainAllFiles: boolean;
   rootDir: string;
@@ -264,6 +269,7 @@ class HasteMap extends EventEmitter {
         : null,
       name: options.name,
       platforms: options.platforms,
+      preserveSymlinks: options.preserveSymlinks || preserveSymlinks,
       resetCache: options.resetCache,
       retainAllFiles: options.retainAllFiles,
       rootDir: options.rootDir,
@@ -749,6 +755,7 @@ class HasteMap extends EventEmitter {
       extensions: options.extensions,
       forceNodeFilesystemAPI: options.forceNodeFilesystemAPI,
       ignore,
+      preserveSymlinks: options.preserveSymlinks,
       rootDir: options.rootDir,
       roots: options.roots,
     };

--- a/packages/jest-haste-map/src/types.ts
+++ b/packages/jest-haste-map/src/types.ts
@@ -35,6 +35,7 @@ export type CrawlerOptions = {
   forceNodeFilesystemAPI: boolean;
   ignore: IgnoreMatcher;
   rootDir: string;
+  preserveSymlinks: boolean;
   roots: Array<string>;
 };
 

--- a/packages/jest-resolve/package.json
+++ b/packages/jest-resolve/package.json
@@ -25,6 +25,7 @@
     "read-pkg-up": "^7.0.1",
     "realpath-native": "^2.0.0",
     "resolve": "^1.17.0",
+    "should-preserve-links": "^1.0.4",
     "slash": "^3.0.0"
   },
   "devDependencies": {

--- a/packages/jest-resolve/should-preserve-links.d.ts
+++ b/packages/jest-resolve/should-preserve-links.d.ts
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+declare module 'should-preserve-links' {
+  export default function shouldPreserveLinks(): boolean;
+}

--- a/packages/jest-resolve/src/defaultResolver.ts
+++ b/packages/jest-resolve/src/defaultResolver.ts
@@ -8,9 +8,16 @@
 import * as fs from 'graceful-fs';
 import {sync as resolveSync} from 'resolve';
 import {sync as browserResolve} from 'browser-resolve';
-import {sync as realpath} from 'realpath-native';
+import {sync as _realpath} from 'realpath-native';
 import pnpResolver from 'jest-pnp-resolver';
 import type {Config} from '@jest/types';
+
+import shouldPreserveSymlinks from 'should-preserve-links';
+
+const preserveSymlinks = shouldPreserveSymlinks();
+function realpath(p: string) {
+  return preserveSymlinks ? p : _realpath(p);
+}
 
 type ResolverOptions = {
   basedir: Config.Path;
@@ -40,7 +47,7 @@ export default function defaultResolver(
     isFile,
     moduleDirectory: options.moduleDirectory,
     paths: options.paths,
-    preserveSymlinks: false,
+    preserveSymlinks,
     // @ts-ignore: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44137
     realpathSync,
   });

--- a/packages/jest-resolve/src/index.ts
+++ b/packages/jest-resolve/src/index.ts
@@ -8,14 +8,20 @@
 import * as path from 'path';
 import type {Config} from '@jest/types';
 import type {ModuleMap} from 'jest-haste-map';
-import {sync as realpath} from 'realpath-native';
+import {sync as _realpath} from 'realpath-native';
 import chalk = require('chalk');
+import shouldPreserveSymlinks from 'should-preserve-links';
 import nodeModulesPaths from './nodeModulesPaths';
 import isBuiltinModule from './isBuiltinModule';
 import defaultResolver, {clearDefaultResolverCache} from './defaultResolver';
 import type {ResolverConfig} from './types';
 import ModuleNotFoundError from './ModuleNotFoundError';
 import shouldLoadAsEsm, {clearCachedLookups} from './shouldLoadAsEsm';
+
+const preserveSymlinks = shouldPreserveSymlinks();
+function realpath(p: string) {
+  return preserveSymlinks ? p : _realpath(p);
+}
 
 type FindNodeModuleConfig = {
   basedir: Config.Path;

--- a/packages/jest-resolve/src/nodeModulesPaths.ts
+++ b/packages/jest-resolve/src/nodeModulesPaths.ts
@@ -9,12 +9,19 @@
 
 import * as path from 'path';
 import type {Config} from '@jest/types';
-import {sync as realpath} from 'realpath-native';
+import {sync as _realpath} from 'realpath-native';
 
 type NodeModulesPathsOptions = {
   moduleDirectory?: Array<string>;
   paths?: Array<Config.Path>;
 };
+
+import shouldPreserveSymlinks from 'should-preserve-links';
+
+const preserveSymlinks = shouldPreserveSymlinks();
+function realpath(p: string) {
+  return preserveSymlinks ? p : _realpath(p);
+}
 
 export default function nodeModulesPaths(
   basedir: Config.Path,

--- a/packages/jest-runtime/package.json
+++ b/packages/jest-runtime/package.json
@@ -40,6 +40,7 @@
     "jest-util": "^25.5.0",
     "jest-validate": "^25.5.0",
     "realpath-native": "^2.0.0",
+    "should-preserve-links": "^1.0.4",
     "slash": "^3.0.0",
     "strip-bom": "^4.0.0",
     "yargs": "^15.3.1"

--- a/packages/jest-runtime/should-preserve-links.d.ts
+++ b/packages/jest-runtime/should-preserve-links.d.ts
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+declare module 'should-preserve-links' {
+  export default function shouldPreserveLinks(): boolean;
+}

--- a/packages/jest-runtime/src/cli/index.ts
+++ b/packages/jest-runtime/src/cli/index.ts
@@ -8,7 +8,7 @@
 import {cpus} from 'os';
 import * as path from 'path';
 import chalk = require('chalk');
-import {sync as realpath} from 'realpath-native';
+import {sync as _realpath} from 'realpath-native';
 import yargs = require('yargs');
 import type {Config} from '@jest/types';
 import type {JestEnvironment} from '@jest/environment';
@@ -16,9 +16,15 @@ import {CustomConsole} from '@jest/console';
 import {setGlobal} from 'jest-util';
 import {validateCLIOptions} from 'jest-validate';
 import {deprecationEntries, readConfig} from 'jest-config';
+import shouldPreserveSymlinks from 'should-preserve-links';
 import {VERSION} from '../version';
 import type {Context} from '../types';
 import * as args from './args';
+
+const preserveSymlinks = shouldPreserveSymlinks();
+function realpath(p: string) {
+  return preserveSymlinks ? p : _realpath(p);
+}
 
 export async function run(
   cliArgv?: Config.Argv,

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -43,6 +43,7 @@ import {
 import type {V8CoverageResult} from '@jest/test-result';
 import {CoverageInstrumenter, V8Coverage} from 'collect-v8-coverage';
 import * as fs from 'graceful-fs';
+import shouldPreserveSymlinks from 'should-preserve-links';
 import {run as cliRun} from './cli';
 import {options as cliOptions} from './cli/args';
 import {findSiblingsWithFileExtension} from './helpers';
@@ -85,6 +86,8 @@ type ResolveOptions = Parameters<typeof require.resolve>[1];
 
 type StringMap = Map<string, string>;
 type BooleanMap = Map<string, boolean>;
+
+const preserveSymlinks = shouldPreserveSymlinks();
 
 const fromEntries: typeof Object.fromEntries =
   Object.fromEntries ??
@@ -287,6 +290,7 @@ class Runtime {
       mocksPattern: escapePathForRegex(path.sep + '__mocks__' + path.sep),
       name: config.name,
       platforms: config.haste.platforms || ['ios', 'android'],
+      preserveSymlinks,
       providesModuleNodeModules: config.haste.providesModuleNodeModules,
       resetCache: options && options.resetCache,
       retainAllFiles: false,

--- a/packages/jest-transform/package.json
+++ b/packages/jest-transform/package.json
@@ -30,6 +30,7 @@
     "micromatch": "^4.0.2",
     "pirates": "^4.0.1",
     "realpath-native": "^2.0.0",
+    "should-preserve-links": "^1.0.4",
     "slash": "^3.0.0",
     "source-map": "^0.6.1",
     "write-file-atomic": "^3.0.0"

--- a/packages/jest-transform/should-preserve-links.d.ts
+++ b/packages/jest-transform/should-preserve-links.d.ts
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+declare module 'should-preserve-links' {
+  export default function shouldPreserveLinks(): boolean;
+}

--- a/packages/jest-transform/src/ScriptTransformer.ts
+++ b/packages/jest-transform/src/ScriptTransformer.ts
@@ -18,8 +18,9 @@ import HasteMap = require('jest-haste-map');
 import stableStringify = require('fast-json-stable-stringify');
 import slash = require('slash');
 import {sync as writeFileAtomic} from 'write-file-atomic';
-import {sync as realpath} from 'realpath-native';
+import {sync as _realpath} from 'realpath-native';
 import {addHook} from 'pirates';
+import shouldPreserveSymlinks from 'should-preserve-links';
 import type {
   Options,
   TransformResult,
@@ -28,6 +29,11 @@ import type {
 } from './types';
 import shouldInstrument from './shouldInstrument';
 import handlePotentialSyntaxError from './enhanceUnexpectedTokenMessage';
+
+const preserveSymlinks = shouldPreserveSymlinks();
+function realpath(p: string) {
+  return preserveSymlinks ? p : _realpath(p);
+}
 
 type ProjectCache = {
   configString: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -13165,6 +13165,11 @@ shellwords@^0.1.1:
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
+should-preserve-links@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/should-preserve-links/-/should-preserve-links-1.0.4.tgz#7b2a0b44efb9f0edd94332a06af92d84cc988876"
+  integrity sha512-73GxeFbAj4PAj/q4lHvui1hd1X6TWRgG41znftUvwQa+lNRz+X73od8Z5N4CyD2xCFE2PDMUvIfkYSyhwJaI4A==
+
 side-channel@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.2.tgz#df5d1abadb4e4bf4af1cd8852bf132d2f7876947"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

This updates jest to respect the behavior of the running node process with regard to preserving symlink paths. It is compatible with both the NODE_PRESERVE_SYMLINKS environment variable and the --preserve-symlinks flag. When node is configured to preserve symlinks, jest will not resolve symlinks via fs.realpath. Additionally, this fixes some bugs where symlinks were not correctly found during fs crawling.

See: https://github.com/facebook/jest/issues/5356

credit to @Globegitter for getting this started here: https://github.com/facebook/jest/pull/7364. This PR is adapted from that, taking a slightly different
approach.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Both integration tests and unit tests were added for the changes.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->