### PR TITLE
chore: move `TransformResult` to types package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Chore & Maintenance
 
+- `[@jest/test-result]` Remove dependency on `@jest/transform`, which lead to a sprawling dependency tree ([#9747](https://github.com/facebook/jest/pull/9747))
 - `[@jest/transform]` Expose type `TransformedSource` ([#9736](https://github.com/facebook/jest/pull/9736))
 
 ### Performance

--- a/packages/jest-test-result/package.json
+++ b/packages/jest-test-result/package.json
@@ -18,7 +18,6 @@
   },
   "dependencies": {
     "@jest/console": "^25.2.3",
-    "@jest/transform": "^25.2.4",
     "@jest/types": "^25.2.3",
     "@types/istanbul-lib-coverage": "^2.0.0",
     "collect-v8-coverage": "^1.0.0"

--- a/packages/jest-test-result/src/types.ts
+++ b/packages/jest-test-result/src/types.ts
@@ -7,12 +7,11 @@
 
 import type {CoverageMap, CoverageMapData} from 'istanbul-lib-coverage';
 import type {ConsoleBuffer} from '@jest/console';
-import type {Config} from '@jest/types';
+import type {Config, TransformTypes} from '@jest/types';
 import type {V8Coverage} from 'collect-v8-coverage';
-import type {TransformResult} from '@jest/transform';
 
 export type V8CoverageResult = Array<{
-  codeTransformResult: TransformResult | undefined;
+  codeTransformResult: TransformTypes.TransformResult | undefined;
   result: V8Coverage[number];
 }>;
 

--- a/packages/jest-test-result/tsconfig.json
+++ b/packages/jest-test-result/tsconfig.json
@@ -6,7 +6,6 @@
   },
   "references": [
     {"path": "../jest-console"},
-    {"path": "../jest-transform"},
     {"path": "../jest-types"}
   ]
 }

--- a/packages/jest-transform/src/types.ts
+++ b/packages/jest-transform/src/types.ts
@@ -6,7 +6,7 @@
  */
 
 import type {RawSourceMap} from 'source-map';
-import type {Config} from '@jest/types';
+import type {Config, TransformTypes} from '@jest/types';
 
 export type ShouldInstrumentOptions = Pick<
   Config.GlobalConfig,
@@ -36,12 +36,7 @@ export type TransformedSource =
   | {code: string; map?: FixedRawSourceMap | string | null}
   | string;
 
-export type TransformResult = {
-  code: string;
-  originalCode: string;
-  mapCoverage: boolean;
-  sourceMapPath: string | null;
-};
+export type TransformResult = TransformTypes.TransformResult;
 
 export type TransformOptions = {
   instrument: boolean;

--- a/packages/jest-types/src/Transform.ts
+++ b/packages/jest-types/src/Transform.ts
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// this is here to make it possible to avoid huge dependency trees just for types
+export type TransformResult = {
+  code: string;
+  originalCode: string;
+  mapCoverage: boolean;
+  sourceMapPath: string | null;
+};

--- a/packages/jest-types/src/index.ts
+++ b/packages/jest-types/src/index.ts
@@ -8,5 +8,6 @@
 import type * as Circus from './Circus';
 import type * as Config from './Config';
 import type * as Global from './Global';
+import type * as TransformTypes from './Transform';
 
-export type {Circus, Config, Global};
+export type {Circus, Config, Global, TransformTypes};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

`@jest/test-result` is used ina. bunch of places, and its dependency on `@jest/transform` led to everybody depending on babel, istanbul etc.

![image](https://user-images.githubusercontent.com/1404810/78223353-02a67a00-74c7-11ea-906e-c0a86407924f.png)

We might wanna do this in more places. It's essentially why `Config` is still in `@jest/types` - so modules can depend on the type without pulling in the huge `jest-config`. As longs as we still re-export the type from the specific package (like `@jest/transform` does in this case) so you don't need to care about it, I think this is a cleaner solution.

Should move `@jest/test-result` as well, so `jest-message-util` doesn't need it

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Green CI

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
