### PR TITLE
chore(jest-types): correct return type of shouldRunTestSuite for JestHookEmitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- `[@jest/watcher]` Correct return type of `shouldRunTestSuite` for `JestHookEmitter`.
+- `[@jest/watcher]` Correct return type of `shouldRunTestSuite` for `JestHookEmitter`  ([#9753](https://github.com/facebook/jest/pull/9753))
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- `[@jest/watcher]` Correct return type of `shouldRunTestSuite` for `JestHookEmitter`.
+
 ### Chore & Maintenance
 
 ### Performance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,7 @@
 ### Features
 
 ### Fixes
-
-- `[@jest/watcher]` Correct return type of `shouldRunTestSuite` for `JestHookEmitter`  ([#9753](https://github.com/facebook/jest/pull/9753))
+- `[@jest/watcher]` Correct return type of `shouldRunTestSuite` for `JestHookEmitter` ([#9753](https://github.com/facebook/jest/pull/9753))
 
 ### Chore & Maintenance
 

--- a/packages/jest-watcher/src/types.ts
+++ b/packages/jest-watcher/src/types.ts
@@ -36,7 +36,9 @@ export type JestHookSubscriber = {
 export type JestHookEmitter = {
   onFileChange: (fs: JestHookExposedFS) => void;
   onTestRunComplete: (results: AggregatedResult) => void;
-  shouldRunTestSuite: (testSuiteInfo: TestSuiteInfo) => Promise<boolean>;
+  shouldRunTestSuite: (
+    testSuiteInfo: TestSuiteInfo,
+  ) => Promise<boolean> | boolean;
 };
 
 export type UsageData = {


### PR DESCRIPTION
## Summary

close #9725 

## Test plan

Green CI