### PR TITLE
fix: drop getters and setters when diffing objects for error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### Features
 
 ### Fixes
+
+- `[jest-matcher-utils]` Do not override properties with setters when diffing objects
 - `[@jest/watcher]` Correct return type of `shouldRunTestSuite` for `JestHookEmitter` ([#9753](https://github.com/facebook/jest/pull/9753))
 
 ### Chore & Maintenance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- `[jest-matcher-utils]` Do not override properties with setters when diffing objects ([#9757](https://github.com/facebook/jest/pull/9757))
+- `[jest-matcher-utils]` Replace accessors with values to avoid calling setters in object descriptors when computing diffs for error reporting ([#9757](https://github.com/facebook/jest/pull/9757))
 - `[@jest/watcher]` Correct return type of `shouldRunTestSuite` for `JestHookEmitter` ([#9753](https://github.com/facebook/jest/pull/9753))
 
 ### Chore & Maintenance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- `[jest-matcher-utils]` Do not override properties with setters when diffing objects
+- `[jest-matcher-utils]` Do not override properties with setters when diffing objects ([#9757](https://github.com/facebook/jest/pull/9757))
 - `[@jest/watcher]` Correct return type of `shouldRunTestSuite` for `JestHookEmitter` ([#9753](https://github.com/facebook/jest/pull/9753))
 
 ### Chore & Maintenance

--- a/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -2082,18 +2082,6 @@ Expected: <g>"abc"</>
 Received: <r>{"0": "a", "1": "b", "2": "c"}</>
 `;
 
-exports[`.toEqual() {pass: false} expect({"a": "foo"}).toEqual({"a": "bar"}) 1`] = `
-<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
-
-<g>- Expected  - 1</>
-<r>+ Received  + 1</>
-
-<d>  Object {</>
-<g>-   "a": "bar",</>
-<r>+   "a": "foo",</>
-<d>  }</>
-`;
-
 exports[`.toEqual() {pass: false} expect({"a": 1, "b": 2}).toEqual(ObjectContaining {"a": 2}) 1`] = `
 <d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
@@ -2125,6 +2113,18 @@ exports[`.toEqual() {pass: false} expect({"a": 5}).toEqual({"b": 6}) 1`] = `
 <d>  }</>
 `;
 
+exports[`.toEqual() {pass: false} expect({"foo": "foo"}).toEqual({"foo": "bar"}) 1`] = `
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
+
+<g>- Expected  - 1</>
+<r>+ Received  + 1</>
+
+<d>  Object {</>
+<g>-   "foo": "bar",</>
+<r>+   "foo": "foo",</>
+<d>  }</>
+`;
+
 exports[`.toEqual() {pass: false} expect({"foo": {"bar": 1}}).toEqual({"foo": {}}) 1`] = `
 <d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
@@ -2136,6 +2136,18 @@ exports[`.toEqual() {pass: false} expect({"foo": {"bar": 1}}).toEqual({"foo": {}
 <r>+   "foo": Object {</>
 <r>+     "bar": 1,</>
 <r>+   },</>
+<d>  }</>
+`;
+
+exports[`.toEqual() {pass: false} expect({"foobar": "foo"}).toEqual({"foobar": "bar"}) 1`] = `
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
+
+<g>- Expected  - 1</>
+<r>+ Received  + 1</>
+
+<d>  Object {</>
+<g>-   "foobar": "bar",</>
+<r>+   "foobar": "foo",</>
 <d>  }</>
 `;
 

--- a/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -2082,6 +2082,18 @@ Expected: <g>"abc"</>
 Received: <r>{"0": "a", "1": "b", "2": "c"}</>
 `;
 
+exports[`.toEqual() {pass: false} expect({"a": "foo"}).toEqual({"a": "bar"}) 1`] = `
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
+
+<g>- Expected  - 1</>
+<r>+ Received  + 1</>
+
+<d>  Object {</>
+<g>-   "a": "bar",</>
+<r>+   "a": "foo",</>
+<d>  }</>
+`;
+
 exports[`.toEqual() {pass: false} expect({"a": 1, "b": 2}).toEqual(ObjectContaining {"a": 2}) 1`] = `
 <d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 

--- a/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -2113,18 +2113,6 @@ exports[`.toEqual() {pass: false} expect({"a": 5}).toEqual({"b": 6}) 1`] = `
 <d>  }</>
 `;
 
-exports[`.toEqual() {pass: false} expect({"foo": "foo"}).toEqual({"foo": "bar"}) 1`] = `
-<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
-
-<g>- Expected  - 1</>
-<r>+ Received  + 1</>
-
-<d>  Object {</>
-<g>-   "foo": "bar",</>
-<r>+   "foo": "foo",</>
-<d>  }</>
-`;
-
 exports[`.toEqual() {pass: false} expect({"foo": {"bar": 1}}).toEqual({"foo": {}}) 1`] = `
 <d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
@@ -2139,15 +2127,63 @@ exports[`.toEqual() {pass: false} expect({"foo": {"bar": 1}}).toEqual({"foo": {}
 <d>  }</>
 `;
 
-exports[`.toEqual() {pass: false} expect({"foobar": "foo"}).toEqual({"foobar": "bar"}) 1`] = `
+exports[`.toEqual() {pass: false} expect({"frozenGetter": "foo"}).toEqual({"frozenGetter": "bar"}) 1`] = `
 <d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
 <g>- Expected  - 1</>
 <r>+ Received  + 1</>
 
 <d>  Object {</>
-<g>-   "foobar": "bar",</>
-<r>+   "foobar": "foo",</>
+<g>-   "frozenGetter": "bar",</>
+<r>+   "frozenGetter": "foo",</>
+<d>  }</>
+`;
+
+exports[`.toEqual() {pass: false} expect({"frozenGetterAndSetter": "foo"}).toEqual({"frozenGetterAndSetter": "bar"}) 1`] = `
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
+
+<g>- Expected  - 1</>
+<r>+ Received  + 1</>
+
+<d>  Object {</>
+<g>-   "frozenGetterAndSetter": "bar",</>
+<r>+   "frozenGetterAndSetter": "foo",</>
+<d>  }</>
+`;
+
+exports[`.toEqual() {pass: false} expect({"frozenSetter": undefined}).toEqual({"frozenSetter": "bar"}) 1`] = `
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
+
+<g>- Expected  - 1</>
+<r>+ Received  + 1</>
+
+<d>  Object {</>
+<g>-   "frozenSetter": "bar",</>
+<r>+   "frozenSetter": undefined,</>
+<d>  }</>
+`;
+
+exports[`.toEqual() {pass: false} expect({"getter": "foo"}).toEqual({"getter": "bar"}) 1`] = `
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
+
+<g>- Expected  - 1</>
+<r>+ Received  + 1</>
+
+<d>  Object {</>
+<g>-   "getter": "bar",</>
+<r>+   "getter": "foo",</>
+<d>  }</>
+`;
+
+exports[`.toEqual() {pass: false} expect({"getterAndSetter": "foo"}).toEqual({"getterAndSetter": "bar"}) 1`] = `
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
+
+<g>- Expected  - 1</>
+<r>+ Received  + 1</>
+
+<d>  Object {</>
+<g>-   "getterAndSetter": "bar",</>
+<r>+   "getterAndSetter": "foo",</>
 <d>  }</>
 `;
 
@@ -2161,6 +2197,18 @@ exports[`.toEqual() {pass: false} expect({"nodeName": "div", "nodeType": 1}).toE
 <g>-   "nodeName": "p",</>
 <r>+   "nodeName": "div",</>
 <d>    "nodeType": 1,</>
+<d>  }</>
+`;
+
+exports[`.toEqual() {pass: false} expect({"setter": undefined}).toEqual({"setter": "bar"}) 1`] = `
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
+
+<g>- Expected  - 1</>
+<r>+ Received  + 1</>
+
+<d>  Object {</>
+<g>-   "setter": "bar",</>
+<r>+   "setter": undefined,</>
 <d>  }</>
 `;
 

--- a/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -2127,63 +2127,73 @@ exports[`.toEqual() {pass: false} expect({"foo": {"bar": 1}}).toEqual({"foo": {}
 <d>  }</>
 `;
 
-exports[`.toEqual() {pass: false} expect({"frozenGetter": "foo"}).toEqual({"frozenGetter": "bar"}) 1`] = `
+exports[`.toEqual() {pass: false} expect({"frozenGetter": {}}).toEqual({"frozenGetter": {"foo": "bar"}}) 1`] = `
 <d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<g>- Expected  - 1</>
+<g>- Expected  - 3</>
 <r>+ Received  + 1</>
 
 <d>  Object {</>
-<g>-   "frozenGetter": "bar",</>
-<r>+   "frozenGetter": "foo",</>
+<g>-   "frozenGetter": Object {</>
+<g>-     "foo": "bar",</>
+<g>-   },</>
+<r>+   "frozenGetter": Object {},</>
 <d>  }</>
 `;
 
-exports[`.toEqual() {pass: false} expect({"frozenGetterAndSetter": "foo"}).toEqual({"frozenGetterAndSetter": "bar"}) 1`] = `
+exports[`.toEqual() {pass: false} expect({"frozenGetterAndSetter": {}}).toEqual({"frozenGetterAndSetter": {"foo": "bar"}}) 1`] = `
 <d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<g>- Expected  - 1</>
+<g>- Expected  - 3</>
 <r>+ Received  + 1</>
 
 <d>  Object {</>
-<g>-   "frozenGetterAndSetter": "bar",</>
-<r>+   "frozenGetterAndSetter": "foo",</>
+<g>-   "frozenGetterAndSetter": Object {</>
+<g>-     "foo": "bar",</>
+<g>-   },</>
+<r>+   "frozenGetterAndSetter": Object {},</>
 <d>  }</>
 `;
 
-exports[`.toEqual() {pass: false} expect({"frozenSetter": undefined}).toEqual({"frozenSetter": "bar"}) 1`] = `
+exports[`.toEqual() {pass: false} expect({"frozenSetter": undefined}).toEqual({"frozenSetter": {"foo": "bar"}}) 1`] = `
 <d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<g>- Expected  - 1</>
+<g>- Expected  - 3</>
 <r>+ Received  + 1</>
 
 <d>  Object {</>
-<g>-   "frozenSetter": "bar",</>
+<g>-   "frozenSetter": Object {</>
+<g>-     "foo": "bar",</>
+<g>-   },</>
 <r>+   "frozenSetter": undefined,</>
 <d>  }</>
 `;
 
-exports[`.toEqual() {pass: false} expect({"getter": "foo"}).toEqual({"getter": "bar"}) 1`] = `
+exports[`.toEqual() {pass: false} expect({"getter": {}}).toEqual({"getter": {"foo": "bar"}}) 1`] = `
 <d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<g>- Expected  - 1</>
+<g>- Expected  - 3</>
 <r>+ Received  + 1</>
 
 <d>  Object {</>
-<g>-   "getter": "bar",</>
-<r>+   "getter": "foo",</>
+<g>-   "getter": Object {</>
+<g>-     "foo": "bar",</>
+<g>-   },</>
+<r>+   "getter": Object {},</>
 <d>  }</>
 `;
 
-exports[`.toEqual() {pass: false} expect({"getterAndSetter": "foo"}).toEqual({"getterAndSetter": "bar"}) 1`] = `
+exports[`.toEqual() {pass: false} expect({"getterAndSetter": {}}).toEqual({"getterAndSetter": {"foo": "bar"}}) 1`] = `
 <d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<g>- Expected  - 1</>
+<g>- Expected  - 3</>
 <r>+ Received  + 1</>
 
 <d>  Object {</>
-<g>-   "getterAndSetter": "bar",</>
-<r>+   "getterAndSetter": "foo",</>
+<g>-   "getterAndSetter": Object {</>
+<g>-     "foo": "bar",</>
+<g>-   },</>
+<r>+   "getterAndSetter": Object {},</>
 <d>  }</>
 `;
 
@@ -2200,14 +2210,16 @@ exports[`.toEqual() {pass: false} expect({"nodeName": "div", "nodeType": 1}).toE
 <d>  }</>
 `;
 
-exports[`.toEqual() {pass: false} expect({"setter": undefined}).toEqual({"setter": "bar"}) 1`] = `
+exports[`.toEqual() {pass: false} expect({"setter": undefined}).toEqual({"setter": {"foo": "bar"}}) 1`] = `
 <d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-<g>- Expected  - 1</>
+<g>- Expected  - 3</>
 <r>+ Received  + 1</>
 
 <d>  Object {</>
-<g>-   "setter": "bar",</>
+<g>-   "setter": Object {</>
+<g>-     "foo": "bar",</>
+<g>-   },</>
 <r>+   "setter": undefined,</>
 <d>  }</>
 `;

--- a/packages/expect/src/__tests__/matchers.test.js
+++ b/packages/expect/src/__tests__/matchers.test.js
@@ -437,14 +437,22 @@ describe('.toEqual()', () => {
     [Object.freeze({foo: {bar: 1}}), {foo: {}}],
     [
       {
-        get a() {
+        get foo() {
           return 'foo';
         },
-        set a(value) {
+        set foo(value) {
           throw new Error('noo');
         },
       },
-      {a: 'bar'},
+      {foo: 'bar'},
+    ],
+    [
+      Object.freeze({
+        get foobar() {
+          return 'foo';
+        },
+      }),
+      {foobar: 'bar'},
     ],
     ['banana', 'apple'],
     ['1\u{00A0}234,57\u{00A0}$', '1 234,57 $'], // issues/6881

--- a/packages/expect/src/__tests__/matchers.test.js
+++ b/packages/expect/src/__tests__/matchers.test.js
@@ -438,40 +438,40 @@ describe('.toEqual()', () => {
     [
       {
         get getterAndSetter() {
-          return 'foo';
+          return {};
         },
         set getterAndSetter(value) {
           throw new Error('noo');
         },
       },
-      {getterAndSetter: 'bar'},
+      {getterAndSetter: {foo: 'bar'}},
     ],
     [
       Object.freeze({
         get frozenGetterAndSetter() {
-          return 'foo';
+          return {};
         },
         set frozenGetterAndSetter(value) {
           throw new Error('noo');
         },
       }),
-      {frozenGetterAndSetter: 'bar'},
+      {frozenGetterAndSetter: {foo: 'bar'}},
     ],
     [
       {
         get getter() {
-          return 'foo';
+          return {};
         },
       },
-      {getter: 'bar'},
+      {getter: {foo: 'bar'}},
     ],
     [
       Object.freeze({
         get frozenGetter() {
-          return 'foo';
+          return {};
         },
       }),
-      {frozenGetter: 'bar'},
+      {frozenGetter: {foo: 'bar'}},
     ],
     [
       {
@@ -480,7 +480,7 @@ describe('.toEqual()', () => {
           throw new Error('noo');
         },
       },
-      {setter: 'bar'},
+      {setter: {foo: 'bar'}},
     ],
     [
       Object.freeze({
@@ -489,7 +489,7 @@ describe('.toEqual()', () => {
           throw new Error('noo');
         },
       }),
-      {frozenSetter: 'bar'},
+      {frozenSetter: {foo: 'bar'}},
     ],
     ['banana', 'apple'],
     ['1\u{00A0}234,57\u{00A0}$', '1 234,57 $'], // issues/6881

--- a/packages/expect/src/__tests__/matchers.test.js
+++ b/packages/expect/src/__tests__/matchers.test.js
@@ -435,6 +435,17 @@ describe('.toEqual()', () => {
     [{a: 1}, {a: 2}],
     [{a: 5}, {b: 6}],
     [Object.freeze({foo: {bar: 1}}), {foo: {}}],
+    [
+      {
+        get a() {
+          return 'foo';
+        },
+        set a(value) {
+          throw new Error('noo');
+        },
+      },
+      {a: 'bar'},
+    ],
     ['banana', 'apple'],
     ['1\u{00A0}234,57\u{00A0}$', '1 234,57 $'], // issues/6881
     [

--- a/packages/expect/src/__tests__/matchers.test.js
+++ b/packages/expect/src/__tests__/matchers.test.js
@@ -437,22 +437,59 @@ describe('.toEqual()', () => {
     [Object.freeze({foo: {bar: 1}}), {foo: {}}],
     [
       {
-        get foo() {
+        get getterAndSetter() {
           return 'foo';
         },
-        set foo(value) {
+        set getterAndSetter(value) {
           throw new Error('noo');
         },
       },
-      {foo: 'bar'},
+      {getterAndSetter: 'bar'},
     ],
     [
       Object.freeze({
-        get foobar() {
+        get frozenGetterAndSetter() {
+          return 'foo';
+        },
+        set frozenGetterAndSetter(value) {
+          throw new Error('noo');
+        },
+      }),
+      {frozenGetterAndSetter: 'bar'},
+    ],
+    [
+      {
+        get getter() {
+          return 'foo';
+        },
+      },
+      {getter: 'bar'},
+    ],
+    [
+      Object.freeze({
+        get frozenGetter() {
           return 'foo';
         },
       }),
-      {foobar: 'bar'},
+      {frozenGetter: 'bar'},
+    ],
+    [
+      {
+        // eslint-disable-next-line accessor-pairs
+        set setter(value) {
+          throw new Error('noo');
+        },
+      },
+      {setter: 'bar'},
+    ],
+    [
+      Object.freeze({
+        // eslint-disable-next-line accessor-pairs
+        set frozenSetter(value) {
+          throw new Error('noo');
+        },
+      }),
+      {frozenSetter: 'bar'},
     ],
     ['banana', 'apple'],
     ['1\u{00A0}234,57\u{00A0}$', '1 234,57 $'], // issues/6881

--- a/packages/jest-matcher-utils/src/Replaceable.ts
+++ b/packages/jest-matcher-utils/src/Replaceable.ts
@@ -57,12 +57,7 @@ export default class Replaceable {
     if (this.type === 'map') {
       this.object.set(key, value);
     } else {
-      const descriptor = Object.getOwnPropertyDescriptor(this.object, key);
-
-      // do not try to assign to anything that has a setter
-      if (descriptor?.set === undefined) {
-        this.object[key] = value;
-      }
+      this.object[key] = value;
     }
   }
 }

--- a/packages/jest-matcher-utils/src/Replaceable.ts
+++ b/packages/jest-matcher-utils/src/Replaceable.ts
@@ -37,7 +37,7 @@ export default class Replaceable {
       });
       Object.getOwnPropertySymbols(this.object).forEach(key => {
         const descriptor = Object.getOwnPropertyDescriptor(this.object, key);
-        if ((descriptor as PropertyDescriptor).enumerable) {
+        if (descriptor?.enumerable) {
           cb(this.object[key], key, this.object);
         }
       });
@@ -57,7 +57,12 @@ export default class Replaceable {
     if (this.type === 'map') {
       this.object.set(key, value);
     } else {
-      this.object[key] = value;
+      const descriptor = Object.getOwnPropertyDescriptor(this.object, key);
+
+      // do not try to assign to anything that has a setter
+      if (descriptor?.set === undefined) {
+        this.object[key] = value;
+      }
     }
   }
 }

--- a/packages/jest-matcher-utils/src/Replaceable.ts
+++ b/packages/jest-matcher-utils/src/Replaceable.ts
@@ -36,10 +36,7 @@ export default class Replaceable {
         cb(value, key, this.object);
       });
       Object.getOwnPropertySymbols(this.object).forEach(key => {
-        const descriptor = Object.getOwnPropertyDescriptor(this.object, key);
-        if (descriptor?.enumerable) {
-          cb(this.object[key], key, this.object);
-        }
+        cb(this.object[key], key, this.object);
       });
     } else {
       this.object.forEach(cb);

--- a/packages/jest-matcher-utils/src/Replaceable.ts
+++ b/packages/jest-matcher-utils/src/Replaceable.ts
@@ -36,7 +36,10 @@ export default class Replaceable {
         cb(value, key, this.object);
       });
       Object.getOwnPropertySymbols(this.object).forEach(key => {
-        cb(this.object[key], key, this.object);
+        const descriptor = Object.getOwnPropertyDescriptor(this.object, key);
+        if (descriptor?.enumerable) {
+          cb(this.object[key], key, this.object);
+        }
       });
     } else {
       this.object.forEach(cb);

--- a/packages/jest-matcher-utils/src/__tests__/Replaceable.test.ts
+++ b/packages/jest-matcher-utils/src/__tests__/Replaceable.test.ts
@@ -110,22 +110,11 @@ describe('Replaceable', () => {
       expect(cb.mock.calls[2]).toEqual([3, symbolKey, object]);
     });
 
-    test('object forEach do not iterate none enumerable symbol key', () => {
-      const symbolKey = Symbol('jest');
-      const object = {a: 1, b: 2};
-      Object.defineProperty(object, symbolKey, {enumerable: false});
-      const replaceable = new Replaceable(object);
-      const cb = jest.fn();
-      replaceable.forEach(cb);
-      expect(cb).toHaveBeenCalledTimes(2);
-      expect(cb.mock.calls[0]).toEqual([1, 'a', object]);
-      expect(cb.mock.calls[1]).toEqual([2, 'b', object]);
-    });
-
     test('array forEach', () => {
       const replaceable = new Replaceable([1, 2, 3]);
       const cb = jest.fn();
       replaceable.forEach(cb);
+      expect(cb).toHaveBeenCalledTimes(3);
       expect(cb.mock.calls[0]).toEqual([1, 0, [1, 2, 3]]);
       expect(cb.mock.calls[1]).toEqual([2, 1, [1, 2, 3]]);
       expect(cb.mock.calls[2]).toEqual([3, 2, [1, 2, 3]]);
@@ -139,6 +128,7 @@ describe('Replaceable', () => {
       const replaceable = new Replaceable(map);
       const cb = jest.fn();
       replaceable.forEach(cb);
+      expect(cb).toHaveBeenCalledTimes(2);
       expect(cb.mock.calls[0]).toEqual([1, 'a', map]);
       expect(cb.mock.calls[1]).toEqual([2, 'b', map]);
     });

--- a/packages/jest-matcher-utils/src/__tests__/Replaceable.test.ts
+++ b/packages/jest-matcher-utils/src/__tests__/Replaceable.test.ts
@@ -104,7 +104,7 @@ describe('Replaceable', () => {
       const replaceable = new Replaceable(object);
       const cb = jest.fn();
       replaceable.forEach(cb);
-      expect(cb.mock.calls.length).toBe(3);
+      expect(cb).toHaveBeenCalledTimes(3);
       expect(cb.mock.calls[0]).toEqual([1, 'a', object]);
       expect(cb.mock.calls[1]).toEqual([2, 'b', object]);
       expect(cb.mock.calls[2]).toEqual([3, symbolKey, object]);
@@ -117,7 +117,7 @@ describe('Replaceable', () => {
       const replaceable = new Replaceable(object);
       const cb = jest.fn();
       replaceable.forEach(cb);
-      expect(cb.mock.calls.length).toBe(2);
+      expect(cb).toHaveBeenCalledTimes(2);
       expect(cb.mock.calls[0]).toEqual([1, 'a', object]);
       expect(cb.mock.calls[1]).toEqual([2, 'b', object]);
     });

--- a/packages/jest-matcher-utils/src/__tests__/deepCyclicCopyReplaceable.test.ts
+++ b/packages/jest-matcher-utils/src/__tests__/deepCyclicCopyReplaceable.test.ts
@@ -20,20 +20,6 @@ test('returns the same value for primitive or function values', () => {
   expect(deepCyclicCopyReplaceable(fn)).toBe(fn);
 });
 
-test('does not execute getters/setters, but copies them', () => {
-  const fn = jest.fn();
-  const obj = {
-    // @ts-ignore
-    get foo() {
-      fn();
-    },
-  };
-  const copy = deepCyclicCopyReplaceable(obj);
-
-  expect(Object.getOwnPropertyDescriptor(copy, 'foo')).toBeDefined();
-  expect(fn).not.toBeCalled();
-});
-
 test('copies symbols', () => {
   const symbol = Symbol('foo');
   const obj = {[symbol]: 42};

--- a/packages/jest-matcher-utils/src/__tests__/deepCyclicCopyReplaceable.test.ts
+++ b/packages/jest-matcher-utils/src/__tests__/deepCyclicCopyReplaceable.test.ts
@@ -43,6 +43,15 @@ test('convert accessor descriptor into value descriptor', () => {
   });
 });
 
+test('skips non-enumerables', () => {
+  const obj = {};
+  Object.defineProperty(obj, 'foo', {enumerable: false, value: 'bar'});
+
+  const copy = deepCyclicCopyReplaceable(obj);
+
+  expect(Object.getOwnPropertyDescriptors(copy)).toEqual({});
+});
+
 test('copies symbols', () => {
   const symbol = Symbol('foo');
   const obj = {[symbol]: 42};

--- a/packages/jest-matcher-utils/src/__tests__/deepCyclicCopyReplaceable.test.ts
+++ b/packages/jest-matcher-utils/src/__tests__/deepCyclicCopyReplaceable.test.ts
@@ -20,6 +20,29 @@ test('returns the same value for primitive or function values', () => {
   expect(deepCyclicCopyReplaceable(fn)).toBe(fn);
 });
 
+test('convert accessor descriptor into value descriptor', () => {
+  const obj = {
+    set foo(_) {},
+    get foo() {
+      return 'bar';
+    },
+  };
+  expect(Object.getOwnPropertyDescriptor(obj, 'foo')).toEqual({
+    configurable: true,
+    enumerable: true,
+    get: expect.any(Function),
+    set: expect.any(Function),
+  });
+  const copy = deepCyclicCopyReplaceable(obj);
+
+  expect(Object.getOwnPropertyDescriptor(copy, 'foo')).toEqual({
+    configurable: true,
+    enumerable: true,
+    value: 'bar',
+    writable: true,
+  });
+});
+
 test('copies symbols', () => {
   const symbol = Symbol('foo');
   const obj = {[symbol]: 42};

--- a/packages/jest-matcher-utils/src/deepCyclicCopyReplaceable.ts
+++ b/packages/jest-matcher-utils/src/deepCyclicCopyReplaceable.ts
@@ -61,7 +61,7 @@ function deepCyclicCopyObject<T>(object: T, cycles: WeakMap<any, any>): T {
 
     if ('set' in descriptor) {
       descriptor.set = undefined;
-    } else {
+    } else if (!('get' in descriptor)) {
       descriptor.writable = true;
     }
 

--- a/packages/jest-matcher-utils/src/deepCyclicCopyReplaceable.ts
+++ b/packages/jest-matcher-utils/src/deepCyclicCopyReplaceable.ts
@@ -55,7 +55,7 @@ function deepCyclicCopyObject<T>(object: T, cycles: WeakMap<any, any>): T {
 
   Object.keys(descriptors).forEach(key => {
     const descriptor = descriptors[key];
-    if (typeof descriptor.value !== 'undefined') {
+    if (descriptor.hasOwnProperty('value')) {
       descriptor.value = deepCyclicCopyReplaceable(descriptor.value, cycles);
     }
 

--- a/packages/jest-matcher-utils/src/deepCyclicCopyReplaceable.ts
+++ b/packages/jest-matcher-utils/src/deepCyclicCopyReplaceable.ts
@@ -59,7 +59,9 @@ function deepCyclicCopyObject<T>(object: T, cycles: WeakMap<any, any>): T {
       descriptor.value = deepCyclicCopyReplaceable(descriptor.value, cycles);
     }
 
-    if (!('set' in descriptor)) {
+    if ('set' in descriptor) {
+      descriptor.set = undefined;
+    } else {
       descriptor.writable = true;
     }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Fixes #9745. Not sure if it makes sense to drop the fix from #9575? I can check if it's `writeable` at the same time I now check for a setter, which makes the test added at that time pass.

/cc @WeiAnAn 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Unit test added.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
