### PR TITLE
Show coverage of sources related to tests in changed files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 - `[@jest/globals]` New package so Jest's globals can be explicitly imported ([#9801](https://github.com/facebook/jest/pull/9801))
+- `[jest-core]` Show coverage of sources related to tests in changed files ([#9769](https://github.com/facebook/jest/pull/9769))
 - `[jest-runtime]` Populate `require.cache` ([#9841](https://github.com/facebook/jest/pull/9841))
 
 ### Fixes

--- a/e2e/__tests__/onlyChanged.test.ts
+++ b/e2e/__tests__/onlyChanged.test.ts
@@ -137,6 +137,39 @@ test('report test coverage for only changed files', () => {
   expect(stdout).not.toMatch('b.js');
 });
 
+test('report test coverage of source on test file change under only changed files', () => {
+  writeFiles(DIR, {
+    '__tests__/a.test.js': `
+    require('../a');
+    test('a1', () => expect(1).toBe(1));
+  `,
+    'a.js': 'module.exports = {}',
+    'package.json': JSON.stringify({
+      jest: {
+        collectCoverage: true,
+        coverageReporters: ['text'],
+        testEnvironment: 'node',
+      },
+    }),
+  });
+
+  run(`${GIT} init`, DIR);
+  run(`${GIT} add .`, DIR);
+  run(`${GIT} commit --no-gpg-sign -m "first"`, DIR);
+
+  writeFiles(DIR, {
+    '__tests__/a.test.js': `
+    require('../a');
+    test('a1', () => expect(1).toBe(1));
+    test('a2', () => expect(2).toBe(2));
+  `,
+  });
+
+  const {stdout} = runJest(DIR, ['-o']);
+
+  expect(stdout).toMatch('a.js');
+});
+
 test('do not pickup non-tested files when reporting coverage on only changed files', () => {
   writeFiles(DIR, {
     'a.js': 'module.exports = {}',

--- a/e2e/__tests__/onlyChanged.test.ts
+++ b/e2e/__tests__/onlyChanged.test.ts
@@ -165,7 +165,7 @@ test('report test coverage of source on test file change under only changed file
   `,
   });
 
-  const {stdout} = runJest(DIR, ['-o']);
+  const {stdout} = runJest(DIR, ['--only-changed']);
 
   expect(stdout).toMatch('a.js');
 });

--- a/packages/jest-core/src/SearchSource.ts
+++ b/packages/jest-core/src/SearchSource.ts
@@ -54,9 +54,7 @@ const toTests = (context: Context, tests: Array<Config.Path>) =>
 const hasSCM = (changedFilesInfo: ChangedFiles) => {
   const {repos} = changedFilesInfo;
   // no SCM (git/hg/...) is found in any of the roots.
-  const noSCM = (Object.keys(repos) as Array<
-    keyof ChangedFiles['repos']
-  >).every(scm => repos[scm].size === 0);
+  const noSCM = Object.values(repos).every(scm => scm.size === 0);
   return !noSCM;
 };
 
@@ -352,7 +350,7 @@ export default class SearchSource {
     );
     const relatedSourcesSet = new Set<string>();
     changedFiles.forEach(filePath => {
-      const isTestFile = this.isTestFilePath.bind(this)(filePath);
+      const isTestFile = this.isTestFilePath(filePath);
       if (isTestFile) {
         const sourcePaths = dependencyResolver.resolve(filePath, {
           skipNodeResolution: this._context.config.skipNodeResolution,

--- a/packages/jest-core/src/SearchSource.ts
+++ b/packages/jest-core/src/SearchSource.ts
@@ -247,14 +247,11 @@ export default class SearchSource {
     changedFilesInfo: ChangedFiles,
     collectCoverage: boolean,
   ): SearchResult {
-    const {repos, changedFiles} = changedFilesInfo;
-    // no SCM (git/hg/...) is found in any of the roots.
-    const noSCM = (Object.keys(repos) as Array<
-      keyof ChangedFiles['repos']
-    >).every(scm => repos[scm].size === 0);
-    return noSCM
-      ? {noSCM: true, tests: []}
-      : this.findRelatedTests(changedFiles, collectCoverage);
+    if (!hasSCM(changedFilesInfo)) {
+      return {noSCM: true, tests: []};
+    }
+    const {changedFiles} = changedFilesInfo;
+    return this.findRelatedTests(changedFiles, collectCoverage);
   }
 
   private _getTestPaths(

--- a/packages/jest-core/src/SearchSource.ts
+++ b/packages/jest-core/src/SearchSource.ts
@@ -352,8 +352,7 @@ export default class SearchSource {
     const dependencyResolver = this._getOrBuildDependencyResolver();
     const relatedSourcesSet = new Set<string>();
     changedFiles.forEach(filePath => {
-      const isTestFile = this.isTestFilePath(filePath);
-      if (isTestFile) {
+      if (this.isTestFilePath(filePath)) {
         const sourcePaths = dependencyResolver.resolve(filePath, {
           skipNodeResolution: this._context.config.skipNodeResolution,
         });

--- a/packages/jest-core/src/TestScheduler.ts
+++ b/packages/jest-core/src/TestScheduler.ts
@@ -181,9 +181,9 @@ export default class TestScheduler {
       if (!testRunners[config.runner]) {
         const Runner: typeof TestRunner = require(config.runner);
         testRunners[config.runner] = new Runner(this._globalConfig, {
-          changedFiles: this._context && this._context.changedFiles,
-          sourcesRelatedToTestsInChangedFiles:
-            this._context && this._context.sourcesRelatedToTestsInChangedFiles,
+          changedFiles: this._context?.changedFiles,
+          sourcesRelatedToTestsInChangedFiles: this._context
+            ?.sourcesRelatedToTestsInChangedFiles,
         });
       }
     });
@@ -275,9 +275,9 @@ export default class TestScheduler {
     if (!isDefault && collectCoverage) {
       this.addReporter(
         new CoverageReporter(this._globalConfig, {
-          changedFiles: this._context && this._context.changedFiles,
-          sourcesRelatedToTestsInChangedFiles:
-            this._context && this._context.sourcesRelatedToTestsInChangedFiles,
+          changedFiles: this._context?.changedFiles,
+          sourcesRelatedToTestsInChangedFiles: this._context
+            ?.sourcesRelatedToTestsInChangedFiles,
         }),
       );
     }
@@ -307,9 +307,9 @@ export default class TestScheduler {
     if (collectCoverage) {
       this.addReporter(
         new CoverageReporter(this._globalConfig, {
-          changedFiles: this._context && this._context.changedFiles,
-          sourcesRelatedToTestsInChangedFiles:
-            this._context && this._context.sourcesRelatedToTestsInChangedFiles,
+          changedFiles: this._context?.changedFiles,
+          sourcesRelatedToTestsInChangedFiles: this._context
+            ?.sourcesRelatedToTestsInChangedFiles,
         }),
       );
     }

--- a/packages/jest-core/src/TestScheduler.ts
+++ b/packages/jest-core/src/TestScheduler.ts
@@ -44,6 +44,7 @@ export type TestSchedulerContext = {
   firstRun: boolean;
   previousSuccess: boolean;
   changedFiles?: Set<Config.Path>;
+  sourcesRelatedToTestsInChangedFiles?: Set<Config.Path>;
 };
 export default class TestScheduler {
   private _dispatcher: ReporterDispatcher;
@@ -181,6 +182,8 @@ export default class TestScheduler {
         const Runner: typeof TestRunner = require(config.runner);
         testRunners[config.runner] = new Runner(this._globalConfig, {
           changedFiles: this._context && this._context.changedFiles,
+          sourcesRelatedToTestsInChangedFiles:
+            this._context && this._context.sourcesRelatedToTestsInChangedFiles,
         });
       }
     });
@@ -273,6 +276,8 @@ export default class TestScheduler {
       this.addReporter(
         new CoverageReporter(this._globalConfig, {
           changedFiles: this._context && this._context.changedFiles,
+          sourcesRelatedToTestsInChangedFiles:
+            this._context && this._context.sourcesRelatedToTestsInChangedFiles,
         }),
       );
     }
@@ -303,6 +308,8 @@ export default class TestScheduler {
       this.addReporter(
         new CoverageReporter(this._globalConfig, {
           changedFiles: this._context && this._context.changedFiles,
+          sourcesRelatedToTestsInChangedFiles:
+            this._context && this._context.sourcesRelatedToTestsInChangedFiles,
         }),
       );
     }

--- a/packages/jest-core/src/__tests__/SearchSource.test.ts
+++ b/packages/jest-core/src/__tests__/SearchSource.test.ts
@@ -538,7 +538,7 @@ describe('SearchSource', () => {
       '../../../jest-runtime/src/__tests__/test_root',
     );
 
-    beforeEach(done => {
+    beforeEach(async () => {
       const {options: config} = normalize(
         {
           haste: {
@@ -553,12 +553,11 @@ describe('SearchSource', () => {
         },
         {} as Config.Argv,
       );
-      Runtime.createContext(config, {maxWorkers, watchman: false}).then(
-        context => {
-          searchSource = new SearchSource(context);
-          done();
-        },
-      );
+      const context = await Runtime.createContext(config, {
+        maxWorkers,
+        watchman: false,
+      });
+      searchSource = new SearchSource(context);
     });
 
     it('return empty set if no SCM', () => {

--- a/packages/jest-core/src/__tests__/SearchSource.test.ts
+++ b/packages/jest-core/src/__tests__/SearchSource.test.ts
@@ -533,30 +533,18 @@ describe('SearchSource', () => {
   });
 
   describe('findRelatedSourcesFromTestsInChangedFiles', () => {
-    const rootDir = path.join(
+    const rootDir = path.resolve(
       __dirname,
-      '..',
-      '..',
-      '..',
-      'jest-runtime',
-      'src',
-      '__tests__',
-      'test_root',
+      '../../../jest-runtime/src/__tests__/test_root',
     );
 
     beforeEach(done => {
       const {options: config} = normalize(
         {
           haste: {
-            hasteImplModulePath: path.join(
+            hasteImplModulePath: path.resolve(
               __dirname,
-              '..',
-              '..',
-              '..',
-              'jest-haste-map',
-              'src',
-              '__tests__',
-              'haste_impl.js',
+              '../../../jest-haste-map/src/__tests__/haste_impl.js',
             ),
             providesModuleNodeModules: [],
           },

--- a/packages/jest-core/src/runJest.ts
+++ b/packages/jest-core/src/runJest.ts
@@ -242,9 +242,22 @@ export default async function runJest({
   }
 
   if (changedFilesPromise) {
-    testSchedulerContext.changedFiles = (
-      await changedFilesPromise
-    ).changedFiles;
+    const changedFilesInfo = await changedFilesPromise;
+    testSchedulerContext.changedFiles = changedFilesInfo.changedFiles;
+    if (testSchedulerContext.changedFiles) {
+      const sourcesRelatedToTestsInChangedFilesArray = contexts
+        .map(context => {
+          const searchSource = new SearchSource(context);
+          const relatedSourceFromTestsInChangedFiles = searchSource.findRelatedSourcesFromTestsInChangedFiles(
+            changedFilesInfo,
+          );
+          return relatedSourceFromTestsInChangedFiles;
+        })
+        .reduce((total, paths) => [...total, ...paths], []);
+      testSchedulerContext.sourcesRelatedToTestsInChangedFiles = new Set(
+        sourcesRelatedToTestsInChangedFilesArray,
+      );
+    }
   }
 
   const results = await new TestScheduler(

--- a/packages/jest-core/src/runJest.ts
+++ b/packages/jest-core/src/runJest.ts
@@ -243,8 +243,8 @@ export default async function runJest({
 
   if (changedFilesPromise) {
     const changedFilesInfo = await changedFilesPromise;
-    testSchedulerContext.changedFiles = changedFilesInfo.changedFiles;
-    if (testSchedulerContext.changedFiles) {
+    if (changedFilesInfo.changedFiles) {
+      testSchedulerContext.changedFiles = changedFilesInfo.changedFiles;
       const sourcesRelatedToTestsInChangedFilesArray = contexts
         .map(context => {
           const searchSource = new SearchSource(context);
@@ -253,7 +253,7 @@ export default async function runJest({
           );
           return relatedSourceFromTestsInChangedFiles;
         })
-        .reduce((total, paths) => [...total, ...paths], []);
+        .reduce((total, paths) => total.concat(paths), []);
       testSchedulerContext.sourcesRelatedToTestsInChangedFiles = new Set(
         sourcesRelatedToTestsInChangedFilesArray,
       );

--- a/packages/jest-reporters/src/__tests__/coverage_worker.test.js
+++ b/packages/jest-reporters/src/__tests__/coverage_worker.test.js
@@ -41,6 +41,7 @@ test('resolves to the result of generateEmptyCoverage upon success', async () =>
     globalConfig,
     config,
     undefined,
+    undefined,
   );
 
   expect(result).toEqual(42);

--- a/packages/jest-reporters/src/coverage_reporter.ts
+++ b/packages/jest-reporters/src/coverage_reporter.ts
@@ -204,6 +204,9 @@ export default class CoverageReporter extends BaseReporter {
               changedFiles:
                 this._options.changedFiles &&
                 Array.from(this._options.changedFiles),
+              sourcesRelatedToTestsInChangedFiles:
+                this._options.sourcesRelatedToTestsInChangedFiles &&
+                Array.from(this._options.sourcesRelatedToTestsInChangedFiles),
             },
             path: filename,
           });

--- a/packages/jest-reporters/src/coverage_worker.ts
+++ b/packages/jest-reporters/src/coverage_worker.ts
@@ -40,9 +40,8 @@ export function worker({
     path,
     globalConfig,
     config,
-    options && options.changedFiles && new Set(options.changedFiles),
-    options &&
-      options.sourcesRelatedToTestsInChangedFiles &&
+    options?.changedFiles && new Set(options.changedFiles),
+    options?.sourcesRelatedToTestsInChangedFiles &&
       new Set(options.sourcesRelatedToTestsInChangedFiles),
   );
 }

--- a/packages/jest-reporters/src/coverage_worker.ts
+++ b/packages/jest-reporters/src/coverage_worker.ts
@@ -41,5 +41,8 @@ export function worker({
     globalConfig,
     config,
     options && options.changedFiles && new Set(options.changedFiles),
+    options &&
+      options.sourcesRelatedToTestsInChangedFiles &&
+      new Set(options.sourcesRelatedToTestsInChangedFiles),
   );
 }

--- a/packages/jest-reporters/src/generateEmptyCoverage.ts
+++ b/packages/jest-reporters/src/generateEmptyCoverage.ts
@@ -31,6 +31,7 @@ export default function (
   globalConfig: Config.GlobalConfig,
   config: Config.ProjectConfig,
   changedFiles?: Set<Config.Path>,
+  sourcesRelatedToTestsInChangedFiles?: Set<Config.Path>,
 ): CoverageWorkerResult | null {
   const coverageOptions = {
     changedFiles,
@@ -38,6 +39,7 @@ export default function (
     collectCoverageFrom: globalConfig.collectCoverageFrom,
     collectCoverageOnlyFrom: globalConfig.collectCoverageOnlyFrom,
     coverageProvider: globalConfig.coverageProvider,
+    sourcesRelatedToTestsInChangedFiles,
   };
   let coverageWorkerResult: CoverageWorkerResult | null = null;
   if (shouldInstrument(filename, coverageOptions, config)) {

--- a/packages/jest-reporters/src/types.ts
+++ b/packages/jest-reporters/src/types.ts
@@ -37,10 +37,12 @@ export type CoverageWorker = {worker: typeof worker};
 
 export type CoverageReporterOptions = {
   changedFiles?: Set<Config.Path>;
+  sourcesRelatedToTestsInChangedFiles?: Set<Config.Path>;
 };
 
 export type CoverageReporterSerializedOptions = {
   changedFiles?: Array<Config.Path>;
+  sourcesRelatedToTestsInChangedFiles?: Array<Config.Path>;
 };
 
 export type OnTestStart = (test: Test) => Promise<void>;

--- a/packages/jest-runner/src/runTest.ts
+++ b/packages/jest-runner/src/runTest.ts
@@ -152,6 +152,8 @@ async function runTestInternal(
     collectCoverageFrom: globalConfig.collectCoverageFrom,
     collectCoverageOnlyFrom: globalConfig.collectCoverageOnlyFrom,
     coverageProvider: globalConfig.coverageProvider,
+    sourcesRelatedToTestsInChangedFiles:
+      context && context.sourcesRelatedToTestsInChangedFiles,
   });
 
   const start = Date.now();

--- a/packages/jest-runner/src/runTest.ts
+++ b/packages/jest-runner/src/runTest.ts
@@ -147,13 +147,13 @@ async function runTestInternal(
   setGlobal(environment.global, 'console', testConsole);
 
   const runtime = new Runtime(config, environment, resolver, cacheFS, {
-    changedFiles: context && context.changedFiles,
+    changedFiles: context?.changedFiles,
     collectCoverage: globalConfig.collectCoverage,
     collectCoverageFrom: globalConfig.collectCoverageFrom,
     collectCoverageOnlyFrom: globalConfig.collectCoverageOnlyFrom,
     coverageProvider: globalConfig.coverageProvider,
     sourcesRelatedToTestsInChangedFiles:
-      context && context.sourcesRelatedToTestsInChangedFiles,
+      context?.sourcesRelatedToTestsInChangedFiles,
   });
 
   const start = Date.now();

--- a/packages/jest-runner/src/types.ts
+++ b/packages/jest-runner/src/types.ts
@@ -51,6 +51,7 @@ export type TestRunnerOptions = {
 
 export type TestRunnerContext = {
   changedFiles?: Set<Config.Path>;
+  sourcesRelatedToTestsInChangedFiles?: Set<Config.Path>;
 };
 
 export type TestRunnerSerializedContext = {

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -171,6 +171,7 @@ class Runtime {
       collectCoverageFrom: [],
       collectCoverageOnlyFrom: undefined,
       coverageProvider: 'babel',
+      sourcesRelatedToTestsInChangedFiles: undefined,
     };
     this._currentlyExecutingModulePath = '';
     this._environment = environment;

--- a/packages/jest-transform/src/shouldInstrument.ts
+++ b/packages/jest-transform/src/shouldInstrument.ts
@@ -93,14 +93,12 @@ export default function shouldInstrument(
     return false;
   }
 
-  if (options.changedFiles) {
-    if (!options.changedFiles.has(filename)) {
-      if (!options.sourcesRelatedToTestsInChangedFiles) {
-        return false;
-      }
-      if (!options.sourcesRelatedToTestsInChangedFiles.has(filename)) {
-        return false;
-      }
+  if (options.changedFiles && !options.changedFiles.has(filename)) {
+    if (!options.sourcesRelatedToTestsInChangedFiles) {
+      return false;
+    }
+    if (!options.sourcesRelatedToTestsInChangedFiles.has(filename)) {
+      return false;
     }
   }
 

--- a/packages/jest-transform/src/shouldInstrument.ts
+++ b/packages/jest-transform/src/shouldInstrument.ts
@@ -93,8 +93,15 @@ export default function shouldInstrument(
     return false;
   }
 
-  if (options.changedFiles && !options.changedFiles.has(filename)) {
-    return false;
+  if (options.changedFiles) {
+    if (!options.changedFiles.has(filename)) {
+      if (!options.sourcesRelatedToTestsInChangedFiles) {
+        return false;
+      }
+      if (!options.sourcesRelatedToTestsInChangedFiles.has(filename)) {
+        return false;
+      }
+    }
   }
 
   return true;

--- a/packages/jest-transform/src/types.ts
+++ b/packages/jest-transform/src/types.ts
@@ -16,6 +16,7 @@ export type ShouldInstrumentOptions = Pick<
   | 'coverageProvider'
 > & {
   changedFiles?: Set<Config.Path>;
+  sourcesRelatedToTestsInChangedFiles?: Set<Config.Path>;
 };
 
 export type Options = ShouldInstrumentOptions &


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary
This PR fixes #8545 . It will show coverage of sources related to tests when jest is in watch mode (`--watch`) or `--onlyChange`.

As for implementation, this PR added `findRelatedSourceFromTestsInChangedFiles` in `SearchSource`, and apply it when there are `changedFiles`, then pass the results into options of `shouldInstrument`. When `changedFiles` exist and the file is not in changedFiles nor `sourcesRelatedToTestsInChangedFiles`, we will not instrument it.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Add an e2e test case for the use case and some unit test case for `SearchSource`.
