### PR TITLE
feat: experimental ES Modules support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - `[jest-console]` Add code frame to `console.error` and `console.warn` ([#9741](https://github.com/facebook/jest/pull/9741))
 - `[@jest/globals]` New package so Jest's globals can be explicitly imported ([#9801](https://github.com/facebook/jest/pull/9801))
+- `[jest-runtime, jest-jasmine2, jest-circus]` Experimental, limited ECMAScript Modules support ([#9772](https://github.com/facebook/jest/pull/9772))
 
 ### Fixes
 

--- a/e2e/__tests__/__snapshots__/moduleNameMapper.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/moduleNameMapper.test.ts.snap
@@ -36,7 +36,7 @@ FAIL __tests__/index.js
       12 | module.exports = () => 'test';
       13 | 
 
-      at createNoMappedModuleFoundError (../../packages/jest-resolve/build/index.js:540:17)
+      at createNoMappedModuleFoundError (../../packages/jest-resolve/build/index.js:545:17)
       at Object.require (index.js:10:1)
 `;
 
@@ -65,6 +65,6 @@ FAIL __tests__/index.js
       12 | module.exports = () => 'test';
       13 | 
 
-      at createNoMappedModuleFoundError (../../packages/jest-resolve/build/index.js:540:17)
+      at createNoMappedModuleFoundError (../../packages/jest-resolve/build/index.js:545:17)
       at Object.require (index.js:10:1)
 `;

--- a/e2e/__tests__/__snapshots__/nativeEsm.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/nativeEsm.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`on node ^12.16.0 || >=13.0.0 runs test with native ESM 1`] = `
 Test Suites: 1 passed, 1 total
-Tests:       3 passed, 3 total
+Tests:       4 passed, 4 total
 Snapshots:   0 total
 Time:        <<REPLACED>>
 Ran all test suites.

--- a/e2e/__tests__/__snapshots__/nativeEsm.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/nativeEsm.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`on node ^12.16.0 || >=13.0.0 runs test with native ESM 1`] = `
 Test Suites: 1 passed, 1 total
-Tests:       2 passed, 2 total
+Tests:       3 passed, 3 total
 Snapshots:   0 total
 Time:        <<REPLACED>>
 Ran all test suites.

--- a/e2e/__tests__/__snapshots__/nativeEsm.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/nativeEsm.test.ts.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`on node ^12.16.0 || >=13.0.0 runs test with native ESM 1`] = `
+Test Suites: 1 passed, 1 total
+Tests:       2 passed, 2 total
+Snapshots:   0 total
+Time:        <<REPLACED>>
+Ran all test suites.
+`;

--- a/e2e/__tests__/__snapshots__/nativeEsm.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/nativeEsm.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`on node ^12.16.0 || >=13.0.0 runs test with native ESM 1`] = `
+exports[`on node >=12.16.0 runs test with native ESM 1`] = `
 Test Suites: 1 passed, 1 total
 Tests:       4 passed, 4 total
 Snapshots:   0 total

--- a/e2e/__tests__/__snapshots__/resolveNoFileExtensions.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/resolveNoFileExtensions.test.ts.snap
@@ -37,6 +37,6 @@ FAIL __tests__/test.js
         |                  ^
       9 | 
 
-      at Resolver.resolveModule (../../packages/jest-resolve/build/index.js:296:11)
+      at Resolver.resolveModule (../../packages/jest-resolve/build/index.js:299:11)
       at Object.require (index.js:8:18)
 `;

--- a/e2e/__tests__/nativeEsm.test.ts
+++ b/e2e/__tests__/nativeEsm.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {resolve} from 'path';
+import wrap from 'jest-snapshot-serializer-raw';
+import {onNodeVersions} from '@jest/test-utils';
+import runJest, {getConfig} from '../runJest';
+import {extractSummary} from '../Utils';
+
+const DIR = resolve(__dirname, '../native-esm');
+
+test('test config is without transform', () => {
+  const {configs} = getConfig(DIR);
+
+  expect(configs).toHaveLength(1);
+  expect(configs[0].transform).toEqual([]);
+});
+
+// The versions vm.Module was introduced
+onNodeVersions('^12.16.0 || >=13.0.0', () => {
+  test('runs test with native ESM', () => {
+    const {exitCode, stderr, stdout} = runJest(DIR, [], {
+      nodeOptions: '--experimental-vm-modules',
+    });
+
+    const {summary} = extractSummary(stderr);
+
+    expect(wrap(summary)).toMatchSnapshot();
+    expect(stdout).toBe('');
+    expect(exitCode).toBe(0);
+  });
+});

--- a/e2e/__tests__/nativeEsm.test.ts
+++ b/e2e/__tests__/nativeEsm.test.ts
@@ -21,7 +21,7 @@ test('test config is without transform', () => {
 });
 
 // The versions vm.Module was introduced
-onNodeVersions('^12.16.0 || >=13.0.0', () => {
+onNodeVersions('>=12.16.0', () => {
   test('runs test with native ESM', () => {
     const {exitCode, stderr, stdout} = runJest(DIR, [], {
       nodeOptions: '--experimental-vm-modules',

--- a/e2e/native-esm/__tests__/native-esm.test.js
+++ b/e2e/native-esm/__tests__/native-esm.test.js
@@ -38,3 +38,10 @@ test('should support importing node core modules', () => {
     type: 'module',
   });
 });
+
+test('dynamic import should work', async () => {
+  const {double: importedDouble} = await import('../index');
+
+  expect(importedDouble).toBe(double);
+  expect(importedDouble(1)).toBe(2);
+});

--- a/e2e/native-esm/__tests__/native-esm.test.js
+++ b/e2e/native-esm/__tests__/native-esm.test.js
@@ -14,7 +14,6 @@ test('should have correct import.meta', () => {
   expect(typeof require).toBe('undefined');
   expect(typeof jest).toBe('undefined');
   expect(import.meta).toEqual({
-    jest: expect.anything(),
     url: expect.any(String),
   });
   expect(

--- a/e2e/native-esm/__tests__/native-esm.test.js
+++ b/e2e/native-esm/__tests__/native-esm.test.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {double} from '../index';
+
+test('should have correct import.meta', () => {
+  expect(typeof jest).toBe('undefined');
+  expect(import.meta).toEqual({
+    jest: expect.anything(),
+    url: expect.any(String),
+  });
+  expect(
+    import.meta.url.endsWith('/e2e/native-esm/__tests__/native-esm.test.js')
+  ).toBe(true);
+});
+
+test('should double stuff', () => {
+  expect(double(1)).toBe(2);
+});

--- a/e2e/native-esm/__tests__/native-esm.test.js
+++ b/e2e/native-esm/__tests__/native-esm.test.js
@@ -5,9 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import {readFileSync} from 'fs';
+import {dirname, resolve} from 'path';
+import {fileURLToPath} from 'url';
 import {double} from '../index';
 
 test('should have correct import.meta', () => {
+  expect(typeof require).toBe('undefined');
   expect(typeof jest).toBe('undefined');
   expect(import.meta).toEqual({
     jest: expect.anything(),
@@ -20,4 +24,17 @@ test('should have correct import.meta', () => {
 
 test('should double stuff', () => {
   expect(double(1)).toBe(2);
+});
+
+test('should support importing node core modules', () => {
+  const dir = dirname(fileURLToPath(import.meta.url));
+  const packageJsonPath = resolve(dir, '../package.json');
+
+  expect(JSON.parse(readFileSync(packageJsonPath, 'utf8'))).toEqual({
+    jest: {
+      testEnvironment: 'node',
+      transform: {},
+    },
+    type: 'module',
+  });
 });

--- a/e2e/native-esm/index.js
+++ b/e2e/native-esm/index.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export function double(num) {
+  return num * 2;
+}

--- a/e2e/native-esm/package.json
+++ b/e2e/native-esm/package.json
@@ -1,0 +1,7 @@
+{
+  "type": "module",
+  "jest": {
+    "testEnvironment": "node",
+    "transform": {}
+  }
+}

--- a/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapter.ts
+++ b/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapter.ts
@@ -76,9 +76,24 @@ const jestAdapter = async (
     }
   });
 
-  config.setupFilesAfterEnv.forEach(path => runtime.requireModule(path));
+  for (const path of config.setupFilesAfterEnv) {
+    const esm = runtime.unstable_shouldLoadAsEsm(path);
 
-  runtime.requireModule(testPath);
+    if (esm) {
+      await runtime.unstable_importModule(path);
+    } else {
+      runtime.requireModule(path);
+    }
+  }
+
+  const esm = runtime.unstable_shouldLoadAsEsm(testPath);
+
+  if (esm) {
+    await runtime.unstable_importModule(testPath);
+  } else {
+    runtime.requireModule(testPath);
+  }
+
   const results = await runAndTransformResultsToJestFormat({
     config,
     globalConfig,

--- a/packages/jest-jasmine2/src/index.ts
+++ b/packages/jest-jasmine2/src/index.ts
@@ -155,7 +155,15 @@ async function jasmine2(
       testPath,
     });
 
-  config.setupFilesAfterEnv.forEach(path => runtime.requireModule(path));
+  for (const path of config.setupFilesAfterEnv) {
+    const esm = runtime.unstable_shouldLoadAsEsm(path);
+
+    if (esm) {
+      await runtime.unstable_importModule(path);
+    } else {
+      runtime.requireModule(path);
+    }
+  }
 
   if (globalConfig.enabledTestsMap) {
     env.specFilter = (spec: Spec) => {
@@ -169,7 +177,14 @@ async function jasmine2(
     env.specFilter = (spec: Spec) => testNameRegex.test(spec.getFullName());
   }
 
-  runtime.requireModule(testPath);
+  const esm = runtime.unstable_shouldLoadAsEsm(testPath);
+
+  if (esm) {
+    await runtime.unstable_importModule(testPath);
+  } else {
+    runtime.requireModule(testPath);
+  }
+
   await env.execute();
 
   const results = await reporter.getResults();

--- a/packages/jest-resolve/package.json
+++ b/packages/jest-resolve/package.json
@@ -21,6 +21,7 @@
     "browser-resolve": "^1.11.3",
     "chalk": "^3.0.0",
     "jest-pnp-resolver": "^1.2.1",
+    "read-pkg-up": "^7.0.1",
     "realpath-native": "^2.0.0",
     "resolve": "^1.15.1",
     "slash": "^3.0.0"

--- a/packages/jest-resolve/src/index.ts
+++ b/packages/jest-resolve/src/index.ts
@@ -15,6 +15,7 @@ import isBuiltinModule from './isBuiltinModule';
 import defaultResolver, {clearDefaultResolverCache} from './defaultResolver';
 import type {ResolverConfig} from './types';
 import ModuleNotFoundError from './ModuleNotFoundError';
+import shouldLoadAsEsm, {clearCachedLookups} from './shouldLoadAsEsm';
 
 type FindNodeModuleConfig = {
   basedir: Config.Path;
@@ -100,6 +101,7 @@ class Resolver {
 
   static clearDefaultResolverCache(): void {
     clearDefaultResolverCache();
+    clearCachedLookups();
   }
 
   static findNodeModule(
@@ -128,6 +130,9 @@ class Resolver {
     }
     return null;
   }
+
+  // unstable as it should be replaced by https://github.com/nodejs/modules/issues/393, and we don't want people to use it
+  static unstable_shouldLoadAsEsm = shouldLoadAsEsm;
 
   resolveModuleFromDirIfExists(
     dirname: Config.Path,

--- a/packages/jest-resolve/src/shouldLoadAsEsm.ts
+++ b/packages/jest-resolve/src/shouldLoadAsEsm.ts
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {dirname, extname} from 'path';
+// @ts-ignore: experimental, not added to the types
+import {SourceTextModule} from 'vm';
+import type {Config} from '@jest/types';
+import readPkgUp = require('read-pkg-up');
+
+const runtimeSupportsVmModules = typeof SourceTextModule === 'function';
+
+const cachedLookups = new Map<string, boolean>();
+
+export function clearCachedLookups(): void {
+  cachedLookups.clear();
+}
+
+export default function cachedShouldLoadAsEsm(path: Config.Path): boolean {
+  let cachedLookup = cachedLookups.get(path);
+
+  if (cachedLookup === undefined) {
+    cachedLookup = shouldLoadAsEsm(path);
+    cachedLookups.set(path, cachedLookup);
+  }
+
+  return cachedLookup;
+}
+
+// this is a bad version of what https://github.com/nodejs/modules/issues/393 would provide
+function shouldLoadAsEsm(path: Config.Path): boolean {
+  if (!runtimeSupportsVmModules) {
+    return false;
+  }
+
+  const extension = extname(path);
+
+  if (extension === '.mjs') {
+    return true;
+  }
+
+  if (extension === '.cjs') {
+    return false;
+  }
+
+  // this isn't correct - we might wanna load any file as a module (using synthetic module)
+  // do we need an option to Jest so people can opt in to ESM for non-js?
+  if (extension !== '.js') {
+    return false;
+  }
+
+  const cwd = dirname(path);
+
+  // TODO: can we cache lookups somehow?
+  const pkg = readPkgUp.sync({cwd, normalize: false});
+
+  if (!pkg) {
+    return false;
+  }
+
+  return pkg.packageJson.type === 'module';
+}

--- a/packages/jest-resolve/src/shouldLoadAsEsm.ts
+++ b/packages/jest-resolve/src/shouldLoadAsEsm.ts
@@ -56,23 +56,23 @@ function shouldLoadAsEsm(path: Config.Path): boolean {
 
   const cwd = dirname(path);
 
-  const cachedLookup = cachedDirLookups.get(cwd);
+  let cachedLookup = cachedDirLookups.get(cwd);
 
-  if (cachedLookup !== undefined) {
-    return cachedLookup;
+  if (cachedLookup === undefined) {
+    cachedLookup = cachedPkgCheck(cwd);
+    cachedFileLookups.set(cwd, cachedLookup);
   }
 
+  return cachedLookup;
+}
+
+function cachedPkgCheck(cwd: Config.Path): boolean {
   // TODO: can we cache lookups somehow?
   const pkg = readPkgUp.sync({cwd, normalize: false});
 
   if (!pkg) {
-    cachedDirLookups.set(cwd, false);
     return false;
   }
 
-  const isTypeModule = pkg.packageJson.type === 'module';
-
-  cachedDirLookups.set(cwd, isTypeModule);
-
-  return isTypeModule;
+  return pkg.packageJson.type === 'module';
 }

--- a/packages/jest-runner/src/runTest.ts
+++ b/packages/jest-runner/src/runTest.ts
@@ -156,7 +156,15 @@ async function runTestInternal(
 
   const start = Date.now();
 
-  config.setupFiles.forEach(path => runtime.requireModule(path));
+  for (const path of config.setupFiles) {
+    const esm = runtime.unstable_shouldLoadAsEsm(path);
+
+    if (esm) {
+      await runtime.unstable_importModule(path);
+    } else {
+      runtime.requireModule(path);
+    }
+  }
 
   const sourcemapOptions: sourcemapSupport.Options = {
     environment: 'node',

--- a/packages/jest-runtime/src/__mocks__/createRuntime.js
+++ b/packages/jest-runtime/src/__mocks__/createRuntime.js
@@ -49,7 +49,15 @@ module.exports = async function createRuntime(filename, config) {
     Runtime.createResolver(config, hasteMap.moduleMap),
   );
 
-  config.setupFiles.forEach(path => runtime.requireModule(path));
+  for (const path of config.setupFiles) {
+    const esm = runtime.unstable_shouldLoadAsEsm(path);
+
+    if (esm) {
+      await runtime.unstable_importModule(path);
+    } else {
+      runtime.requireModule(path);
+    }
+  }
 
   runtime.__mockRootPath = path.join(config.rootDir, 'root.js');
   runtime.__mockSubdirPath = path.join(

--- a/packages/jest-runtime/src/cli/index.ts
+++ b/packages/jest-runtime/src/cli/index.ts
@@ -93,9 +93,22 @@ export async function run(
 
     const runtime = new Runtime(config, environment, hasteMap.resolver);
 
-    config.setupFiles.forEach(path => runtime.requireModule(path));
+    for (const path of config.setupFiles) {
+      const esm = runtime.unstable_shouldLoadAsEsm(path);
 
-    runtime.requireModule(filePath);
+      if (esm) {
+        await runtime.unstable_importModule(path);
+      } else {
+        runtime.requireModule(path);
+      }
+    }
+    const esm = runtime.unstable_shouldLoadAsEsm(filePath);
+
+    if (esm) {
+      await runtime.unstable_importModule(filePath);
+    } else {
+      runtime.requireModule(filePath);
+    }
   } catch (e) {
     console.error(chalk.red(e.stack || e));
     process.on('exit', () => (process.exitCode = 1));

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -672,6 +672,7 @@ class Runtime {
     this._isolatedMockRegistry = null;
     this._mockRegistry.clear();
     this._moduleRegistry.clear();
+    this._esmoduleRegistry.clear();
 
     if (this._environment) {
       if (this._environment.global) {

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -59,7 +59,7 @@ interface JestGlobalsValues extends Global.TestFrameworkGlobals {
 }
 
 interface JestImportMeta extends ImportMeta {
-  jest: Jest;
+  jest: JestGlobals.jest;
 }
 
 type HasteMapOptions = {
@@ -330,7 +330,12 @@ class Runtime {
     const cacheKey = modulePath + query;
 
     if (!this._esmoduleRegistry.has(cacheKey)) {
-      const context = this._environment.getVmContext!();
+      invariant(
+        typeof this._environment.getVmContext === 'function',
+        'ES Modules are only supported if your test environment has the `getVmContext` function',
+      );
+
+      const context = this._environment.getVmContext();
 
       invariant(context);
 
@@ -380,10 +385,6 @@ class Runtime {
     invariant(
       runtimeSupportsVmModules,
       'You need to run with a version of node that supports ES Modules in the VM API.',
-    );
-    invariant(
-      typeof this._environment.getVmContext === 'function',
-      'ES Modules are only supported if your test environment has the `getVmContext` function',
     );
 
     const modulePath = this._resolveModule(from, moduleName);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2435,6 +2435,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.11.1.tgz#49a2a83df9d26daacead30d0ccc8762b128d53c7"
   integrity sha512-eWQGP3qtxwL8FGneRrC5DwrJLGN4/dH1clNTuLfN81HCrxVtxRjygDTUoZJ5ASlDEeo0ppYFQjQIlXhtXpOn6g==
 
+"@types/normalize-package-data@^2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
+  integrity sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==
+
 "@types/prettier@^1.19.0":
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-1.19.1.tgz#33509849f8e679e4add158959fdb086440e9553f"
@@ -9178,6 +9183,11 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+lines-and-columns@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
+  integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
+
 list-item@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/list-item/-/list-item-1.1.1.tgz#0c65d00e287cb663ccb3cb3849a77e89ec268a56"
@@ -11200,6 +11210,16 @@ parse-json@^4.0.0:
     error-ex "^1.3.1"
     json-parse-better-errors "^1.0.1"
 
+parse-json@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-5.0.0.tgz#73e5114c986d143efa3712d4ea24db9a4266f60f"
+  integrity sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    error-ex "^1.3.1"
+    json-parse-better-errors "^1.0.1"
+    lines-and-columns "^1.1.6"
+
 parse-node-version@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/parse-node-version/-/parse-node-version-1.0.1.tgz#e2b5dbede00e7fa9bc363607f53327e8b073189b"
@@ -12272,6 +12292,15 @@ read-pkg-up@^3.0.0:
     find-up "^2.0.0"
     read-pkg "^3.0.0"
 
+read-pkg-up@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-7.0.1.tgz#f3a6135758459733ae2b95638056e1854e7ef507"
+  integrity sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==
+  dependencies:
+    find-up "^4.1.0"
+    read-pkg "^5.2.0"
+    type-fest "^0.8.1"
+
 read-pkg@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-1.1.0.tgz#f5ffaa5ecd29cb31c0474bca7d756b6bb29e3f28"
@@ -12298,6 +12327,16 @@ read-pkg@^3.0.0:
     load-json-file "^4.0.0"
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
+
+read-pkg@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-5.2.0.tgz#7bf295438ca5a33e56cd30e053b34ee7250c93cc"
+  integrity sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==
+  dependencies:
+    "@types/normalize-package-data" "^2.4.0"
+    normalize-package-data "^2.5.0"
+    parse-json "^5.0.0"
+    type-fest "^0.6.0"
 
 read@1, read@~1.0.1:
   version "1.0.7"
@@ -14292,6 +14331,11 @@ type-fest@^0.3.0, type-fest@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.3.1.tgz#63d00d204e059474fe5e1b7c011112bbd1dc29e1"
   integrity sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==
+
+type-fest@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.6.0.tgz#8d2a2370d3df886eb5c90ada1c5bf6188acf838b"
+  integrity sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==
 
 type-fest@^0.7.1:
   version "0.7.1"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

This adds _very_ basic support for running tests as native ES modules. 2 main limitations:
1. it does not support mixing ESM and CJS
1. the `jest` object on `import.meta` is an empty object. (meaning none of `jest.*` functions are available)

Another limitation is that the APIs we need only exist on node 13, and they're flagged as experimental

Like V8 test coverage, it only supports the node env, but using JSDOM 16 should also work, although I haven't bothered to verify.

Ref #9430.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Integration test added. More of a smoketest than anything else.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
