### PR TITLE
feat: enable all babel syntax plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 
+- `[babel-preset-jest]` Enable all syntax plugins not enabled by default ([#9774](https://github.com/facebook/jest/pull/9774))
 - `[babel-jest]` Support passing `supportsDynamicImport` and `supportsStaticESM` ([#9766](https://github.com/facebook/jest/pull/9766))
 - `[jest-runtime, @jest/transformer]` Support passing `supportsDynamicImport` and `supportsStaticESM` ([#9597](https://github.com/facebook/jest/pull/9597))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ### Features
 
-- `[babel-preset-jest]` Enable all syntax plugins not enabled by default ([#9774](https://github.com/facebook/jest/pull/9774))
 - `[babel-jest]` Support passing `supportsDynamicImport` and `supportsStaticESM` ([#9766](https://github.com/facebook/jest/pull/9766))
+- `[babel-preset-jest]` Enable all syntax plugins not enabled by default that works on current version of Node ([#9774](https://github.com/facebook/jest/pull/9774))
 - `[jest-runtime, @jest/transformer]` Support passing `supportsDynamicImport` and `supportsStaticESM` ([#9597](https://github.com/facebook/jest/pull/9597))
 
 ### Fixes

--- a/packages/babel-jest/package.json
+++ b/packages/babel-jest/package.json
@@ -27,10 +27,10 @@
     "slash": "^3.0.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.1.0"
+    "@babel/core": "^7.8.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0"
+    "@babel/core": "^7.8.0"
   },
   "engines": {
     "node": ">= 8.3"

--- a/packages/babel-jest/package.json
+++ b/packages/babel-jest/package.json
@@ -27,10 +27,10 @@
     "slash": "^3.0.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.8.0"
+    "@babel/core": "^7.1.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.8.0"
+    "@babel/core": "^7.0.0"
   },
   "engines": {
     "node": ">= 8.3"

--- a/packages/babel-preset-jest/index.js
+++ b/packages/babel-preset-jest/index.js
@@ -8,7 +8,6 @@
 module.exports = () => ({
   plugins: [
     require.resolve('babel-plugin-jest-hoist'),
-    require.resolve('@babel/plugin-syntax-object-rest-spread'),
-    require.resolve('@babel/plugin-syntax-bigint'),
+    require.resolve('babel-preset-current-node-syntax'),
   ],
 });

--- a/packages/babel-preset-jest/index.js
+++ b/packages/babel-preset-jest/index.js
@@ -5,9 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-module.exports = () => ({
-  plugins: [
-    require.resolve('babel-plugin-jest-hoist'),
-    require.resolve('babel-preset-current-node-syntax'),
-  ],
-});
+const plugins = [
+  require.resolve('babel-plugin-jest-hoist'),
+  require.resolve('babel-preset-current-node-syntax'),
+];
+
+// @babel/core requires us to export a function
+module.exports = () => ({plugins});

--- a/packages/babel-preset-jest/index.js
+++ b/packages/babel-preset-jest/index.js
@@ -5,8 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const plugins = [require.resolve('babel-plugin-jest-hoist')];
-const presets = [require.resolve('babel-preset-current-node-syntax')];
+const jestPreset = {
+  plugins: [require.resolve('babel-plugin-jest-hoist')],
+  presets: [require.resolve('babel-preset-current-node-syntax')],
+};
 
 // @babel/core requires us to export a function
-module.exports = () => ({plugins, presets});
+module.exports = () => jestPreset;

--- a/packages/babel-preset-jest/index.js
+++ b/packages/babel-preset-jest/index.js
@@ -5,10 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const plugins = [
-  require.resolve('babel-plugin-jest-hoist'),
-  require.resolve('babel-preset-current-node-syntax'),
-];
+const plugins = [require.resolve('babel-plugin-jest-hoist')];
+const presets = [require.resolve('babel-preset-current-node-syntax')];
 
 // @babel/core requires us to export a function
-module.exports = () => ({plugins});
+module.exports = () => ({plugins, presets});

--- a/packages/babel-preset-jest/package.json
+++ b/packages/babel-preset-jest/package.json
@@ -9,12 +9,11 @@
   "license": "MIT",
   "main": "index.js",
   "dependencies": {
-    "@babel/plugin-syntax-bigint": "^7.0.0",
-    "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
-    "babel-plugin-jest-hoist": "^25.2.6"
+    "babel-plugin-jest-hoist": "^25.2.6",
+    "babel-preset-current-node-syntax": "^0.1.0"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0"
+    "@babel/core": "^7.8.0"
   },
   "engines": {
     "node": ">= 8.3"

--- a/packages/babel-preset-jest/package.json
+++ b/packages/babel-preset-jest/package.json
@@ -10,7 +10,7 @@
   "main": "index.js",
   "dependencies": {
     "babel-plugin-jest-hoist": "^25.2.6",
-    "babel-preset-current-node-syntax": "^0.1.1"
+    "babel-preset-current-node-syntax": "^0.1.2"
   },
   "peerDependencies": {
     "@babel/core": "^7.0.0"

--- a/packages/babel-preset-jest/package.json
+++ b/packages/babel-preset-jest/package.json
@@ -10,7 +10,7 @@
   "main": "index.js",
   "dependencies": {
     "babel-plugin-jest-hoist": "^25.2.6",
-    "babel-preset-current-node-syntax": "^0.1.0"
+    "babel-preset-current-node-syntax": "^0.1.1"
   },
   "peerDependencies": {
     "@babel/core": "^7.8.0"

--- a/packages/babel-preset-jest/package.json
+++ b/packages/babel-preset-jest/package.json
@@ -13,7 +13,7 @@
     "babel-preset-current-node-syntax": "^0.1.1"
   },
   "peerDependencies": {
-    "@babel/core": "^7.8.0"
+    "@babel/core": "^7.0.0"
   },
   "engines": {
     "node": ">= 8.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -55,7 +55,7 @@
     invariant "^2.2.4"
     semver "^5.5.0"
 
-"@babel/core@*", "@babel/core@^7.0.0", "@babel/core@^7.1.0", "@babel/core@^7.3.4", "@babel/core@^7.7.4", "@babel/core@^7.7.5":
+"@babel/core@*", "@babel/core@^7.0.0", "@babel/core@^7.1.0", "@babel/core@^7.3.4", "@babel/core@^7.7.4", "@babel/core@^7.7.5", "@babel/core@^7.8.0":
   version "7.9.0"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.9.0.tgz#ac977b538b77e132ff706f3b8a4dbad09c03c56e"
   integrity sha512-kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==
@@ -423,14 +423,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
-"@babel/plugin-syntax-bigint@^7.0.0":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz#4c9a6f669f5d0cdf1b90a1671e9a146be5300cea"
-  integrity sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.8.0"
-
-"@babel/plugin-syntax-class-properties@^7.0.0":
+"@babel/plugin-syntax-class-properties@^7.0.0", "@babel/plugin-syntax-class-properties@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.8.3.tgz#6cb933a8872c8d359bfde69bbeaae5162fd1e8f7"
   integrity sha512-UcAyQWg2bAN647Q+O811tG9MrJ38Z10jjhQdKNAL8fsyPzE3cCN/uT+f55cFVY4aGO4jqJAvmqsuY3GQDwAoXg==
@@ -476,6 +469,13 @@
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.8.3.tgz#521b06c83c40480f1e58b4fd33b92eceb1d6ea94"
   integrity sha512-WxdW9xyLgBdefoo0Ynn3MRSkhe5tFVxxKNVdnZSh318WrG2e2jH+E9wd/++JsqcLJZPfz87njQJ8j2Upjm0M0A==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.3"
+
+"@babel/plugin-syntax-logical-assignment-operators@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.8.3.tgz#3995d7d7ffff432f6ddc742b47e730c054599897"
+  integrity sha512-Zpg2Sgc++37kuFl6ppq2Q7Awc6E6AIW671x5PY8E/f7MCIyPPGK/EoeZXvvY3P42exZ3Q4/t3YOzP/HiN79jDg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
 
@@ -3442,6 +3442,15 @@ babel-polyfill@6.23.0:
     babel-runtime "^6.22.0"
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
+
+babel-preset-current-node-syntax@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-0.1.0.tgz#744b43eda7a164e5f90ad416dcd9615e8b7842c1"
+  integrity sha512-gVdIosHhVr8ZFaMo8FVOihafV0UOj26/v4A1etZAPy/XqrJO5dvTLfxGaIApumZ66n7AEkFy3e+SPGOv46YhKQ==
+  dependencies:
+    "@babel/plugin-syntax-class-properties" "^7.8.3"
+    "@babel/plugin-syntax-logical-assignment-operators" "^7.8.3"
+    "@babel/plugin-syntax-numeric-separator" "^7.8.3"
 
 babel-preset-fbjs@^3.1.2, babel-preset-fbjs@^3.2.0:
   version "3.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -416,10 +416,17 @@
     "@babel/helper-create-regexp-features-plugin" "^7.8.8"
     "@babel/helper-plugin-utils" "^7.8.3"
 
-"@babel/plugin-syntax-async-generators@^7.8.0":
+"@babel/plugin-syntax-async-generators@^7.8.0", "@babel/plugin-syntax-async-generators@^7.8.4":
   version "7.8.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz#a983fb1aeb2ec3f6ed042a210f640e90e786fe0d"
   integrity sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.0"
+
+"@babel/plugin-syntax-bigint@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz#4c9a6f669f5d0cdf1b90a1671e9a146be5300cea"
+  integrity sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
@@ -458,7 +465,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
 
-"@babel/plugin-syntax-json-strings@^7.8.0":
+"@babel/plugin-syntax-json-strings@^7.8.0", "@babel/plugin-syntax-json-strings@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz#01ca21b668cd8218c9e640cb6dd88c5412b2c96a"
   integrity sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==
@@ -479,7 +486,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
 
-"@babel/plugin-syntax-nullish-coalescing-operator@^7.8.0":
+"@babel/plugin-syntax-nullish-coalescing-operator@^7.8.0", "@babel/plugin-syntax-nullish-coalescing-operator@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz#167ed70368886081f74b5c36c65a88c03b66d1a9"
   integrity sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==
@@ -493,21 +500,21 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.3"
 
-"@babel/plugin-syntax-object-rest-spread@^7.0.0", "@babel/plugin-syntax-object-rest-spread@^7.8.0":
+"@babel/plugin-syntax-object-rest-spread@^7.0.0", "@babel/plugin-syntax-object-rest-spread@^7.8.0", "@babel/plugin-syntax-object-rest-spread@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz#60e225edcbd98a640332a2e72dd3e66f1af55871"
   integrity sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
-"@babel/plugin-syntax-optional-catch-binding@^7.8.0":
+"@babel/plugin-syntax-optional-catch-binding@^7.8.0", "@babel/plugin-syntax-optional-catch-binding@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz#6111a265bcfb020eb9efd0fdfd7d26402b9ed6c1"
   integrity sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
-"@babel/plugin-syntax-optional-chaining@^7.8.0":
+"@babel/plugin-syntax-optional-chaining@^7.8.0", "@babel/plugin-syntax-optional-chaining@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz#4f69c2ab95167e0180cd5336613f8c5788f7d48a"
   integrity sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==
@@ -3443,14 +3450,21 @@ babel-polyfill@6.23.0:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
 
-babel-preset-current-node-syntax@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-0.1.0.tgz#744b43eda7a164e5f90ad416dcd9615e8b7842c1"
-  integrity sha512-gVdIosHhVr8ZFaMo8FVOihafV0UOj26/v4A1etZAPy/XqrJO5dvTLfxGaIApumZ66n7AEkFy3e+SPGOv46YhKQ==
+babel-preset-current-node-syntax@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-0.1.1.tgz#5ee07a4150561245dceb3c36579113613f339e0b"
+  integrity sha512-1ez+0fDblFswjSvdnxBQpKd6UQgKKR91SA2NILzRdQf6u41cupRVrgV+Qc57PENcK+bzx5cYd65z9OO1NkPisg==
   dependencies:
+    "@babel/plugin-syntax-async-generators" "^7.8.4"
+    "@babel/plugin-syntax-bigint" "^7.8.3"
     "@babel/plugin-syntax-class-properties" "^7.8.3"
+    "@babel/plugin-syntax-json-strings" "^7.8.3"
     "@babel/plugin-syntax-logical-assignment-operators" "^7.8.3"
+    "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.3"
     "@babel/plugin-syntax-numeric-separator" "^7.8.3"
+    "@babel/plugin-syntax-object-rest-spread" "^7.8.3"
+    "@babel/plugin-syntax-optional-catch-binding" "^7.8.3"
+    "@babel/plugin-syntax-optional-chaining" "^7.8.3"
 
 babel-preset-fbjs@^3.1.2, babel-preset-fbjs@^3.2.0:
   version "3.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3450,10 +3450,10 @@ babel-polyfill@6.23.0:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
 
-babel-preset-current-node-syntax@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-0.1.1.tgz#5ee07a4150561245dceb3c36579113613f339e0b"
-  integrity sha512-1ez+0fDblFswjSvdnxBQpKd6UQgKKR91SA2NILzRdQf6u41cupRVrgV+Qc57PENcK+bzx5cYd65z9OO1NkPisg==
+babel-preset-current-node-syntax@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-0.1.2.tgz#fb4a4c51fe38ca60fede1dc74ab35eb843cb41d6"
+  integrity sha512-u/8cS+dEiK1SFILbOC8/rUI3ml9lboKuuMvZ/4aQnQmhecQAgPw5ew066C1ObnEAUmlx7dv/s2z52psWEtLNiw==
   dependencies:
     "@babel/plugin-syntax-async-generators" "^7.8.4"
     "@babel/plugin-syntax-bigint" "^7.8.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -55,7 +55,7 @@
     invariant "^2.2.4"
     semver "^5.5.0"
 
-"@babel/core@*", "@babel/core@^7.0.0", "@babel/core@^7.1.0", "@babel/core@^7.3.4", "@babel/core@^7.7.4", "@babel/core@^7.7.5", "@babel/core@^7.8.0":
+"@babel/core@*", "@babel/core@^7.0.0", "@babel/core@^7.1.0", "@babel/core@^7.3.4", "@babel/core@^7.7.4", "@babel/core@^7.7.5":
   version "7.9.0"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.9.0.tgz#ac977b538b77e132ff706f3b8a4dbad09c03c56e"
   integrity sha512-kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

~Breaking due to the increased peer dep, so let's land this in Jets 26.~

~Also needs https://github.com/nicolo-ribaudo/babel-preset-current-node-syntax/commit/565b63ac1b9876cb48bdb1dcc88121a7607624bf to be published~

Adds any babel syntax syntax plugins needed for the current runtime that exists in _some_ version of noe. Makes it so user don't have to care about the Babel implementation detail.

Ref
- #4519
- #6829
- #6492
- #8929
- #9768

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Not sure... It looks correct? 😀 

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
