### PR TITLE
chore(jest-types): correct type testRegex for ProjectConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - `[*]` Replace `any`s with `unknown`s ([#9626](https://github.com/facebook/jest/pull/9626))
 - `[@jest/transform]` Expose type `CacheKeyOptions` for `getCacheKey` ([#9762](https://github.com/facebook/jest/pull/9762))
+- `[@jest/types]` Correct type `testRegex` for `ProjectConfig` ([#9780](https://github.com/facebook/jest/pull/9780))
 
 ### Performance
 

--- a/packages/jest-core/src/SearchSource.ts
+++ b/packages/jest-core/src/SearchSource.ts
@@ -40,8 +40,9 @@ export type TestSelectionConfig = {
 const globsToMatcher = (globs: Array<Config.Glob>) => (path: Config.Path) =>
   micromatch([replacePathSepForGlob(path)], globs, {dot: true}).length > 0;
 
-const regexToMatcher = (testRegex: Array<string>) => (path: Config.Path) =>
-  testRegex.some(testRegex => new RegExp(testRegex).test(path));
+const regexToMatcher = (testRegex: Config.ProjectConfig['testRegex']) => (
+  path: Config.Path,
+) => testRegex.some(testRegex => new RegExp(testRegex).test(path));
 
 const toTests = (context: Context, tests: Array<Config.Path>) =>
   tests.map(path => ({

--- a/packages/jest-types/src/Config.ts
+++ b/packages/jest-types/src/Config.ts
@@ -345,7 +345,7 @@ export type ProjectConfig = {
   testMatch: Array<Glob>;
   testLocationInResults: boolean;
   testPathIgnorePatterns: Array<string>;
-  testRegex: Array<string>;
+  testRegex: Array<string | RegExp>;
   testRunner: string;
   testURL: string;
   timers: 'real' | 'fake';


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Type of `testRegex` in `ProjectConfig` doesn't match with documentation and also not match with real capable value. It should be `string | string[] | RegExp[]`. This PR does 2 things:

- Add `Array<RegExp>` to the existing type of `testRegex` in `ProjectConfig`.
- Update documentation to add `Array<RegExp>` for `testRegex` in Configuration page.

I'm not entirely sure if `testRegex` in `ProjectConfig` can be string or not, but the documentation says it can be string as well. For now I just updated the type to add `Array<RegExp>` to the existing type. I observed that adding `string` will change quite something in internal codes so I won't touch.

## Test plan

Green CI probably ?
