### PR TITLE
feat: add `@jest/globals` package for importing globals explicitly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Features
 
+- `[@jest/globals]` New package so Jest's globals can be explicitly imported ([#9801](https://github.com/facebook/jest/pull/9801))
+
 ### Fixes
 
 - `[expect]` Restore support for passing functions to `toHaveLength` matcher ([#9796](https://github.com/facebook/jest/pull/9796))

--- a/docs/GlobalAPI.md
+++ b/docs/GlobalAPI.md
@@ -3,7 +3,7 @@ id: api
 title: Globals
 ---
 
-In your test files, Jest puts each of these methods and objects into the global environment. You don't have to require or import anything to use them.
+In your test files, Jest puts each of these methods and objects into the global environment. You don't have to require or import anything to use them. However, if you prefer explicit imports, you can do `import {describe, expect, it} from '@jest/globals'`.
 
 ## Methods
 

--- a/docs/JestObjectAPI.md
+++ b/docs/JestObjectAPI.md
@@ -3,7 +3,7 @@ id: jest-object
 title: The Jest Object
 ---
 
-The `jest` object is automatically in scope within every test file. The methods in the `jest` object help create mocks and let you control Jest's overall behavior.
+The `jest` object is automatically in scope within every test file. The methods in the `jest` object help create mocks and let you control Jest's overall behavior. It can also be imported explicitly by via `import {jest} from '@jest/globals'`.
 
 ## Mock Modules
 

--- a/e2e/__tests__/importedGlobals.test.ts
+++ b/e2e/__tests__/importedGlobals.test.ts
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import runJest from '../runJest';
+
+test('imported globals', () => {
+  const result = runJest('imported-globals');
+  expect(result.exitCode).toBe(0);
+});

--- a/e2e/imported-globals/__tests__/env.test.js
+++ b/e2e/imported-globals/__tests__/env.test.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {
+  expect as importedExpect,
+  jest as importedJest,
+  test as importedTest,
+} from '@jest/globals';
+
+importedTest('they match the globals', () => {
+  importedExpect(importedExpect).toBe(expect);
+  importedExpect(importedJest).toBe(jest);
+  importedExpect(importedTest).toBe(test);
+
+  expect(importedExpect).toBe(expect);
+  expect(importedJest).toBe(jest);
+  expect(importedTest).toBe(test);
+});

--- a/e2e/imported-globals/babel.config.js
+++ b/e2e/imported-globals/babel.config.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+module.exports = require('../../babel.config');

--- a/e2e/imported-globals/package.json
+++ b/e2e/imported-globals/package.json
@@ -1,0 +1,5 @@
+{
+  "jest": {
+    "testEnvironment": "node"
+  }
+}

--- a/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapter.ts
+++ b/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapter.ts
@@ -12,7 +12,8 @@ import type {TestResult} from '@jest/test-result';
 import type {RuntimeType as Runtime} from 'jest-runtime';
 import type {SnapshotStateType} from 'jest-snapshot';
 
-const FRAMEWORK_INITIALIZER = require.resolve('./jestAdapterInit');
+const FRAMEWORK_INITIALIZER = path.resolve(__dirname, './jestAdapterInit.js');
+const EXPECT_INITIALIZER = path.resolve(__dirname, './jestExpect.js');
 
 const jestAdapter = async (
   globalConfig: Config.GlobalConfig,
@@ -24,15 +25,13 @@ const jestAdapter = async (
   const {
     initialize,
     runAndTransformResultsToJestFormat,
-  } = runtime.requireInternalModule(FRAMEWORK_INITIALIZER);
+  } = runtime.requireInternalModule<typeof import('./jestAdapterInit')>(
+    FRAMEWORK_INITIALIZER,
+  );
 
   runtime
-    .requireInternalModule<typeof import('./jestExpect')>(
-      path.resolve(__dirname, './jestExpect.js'),
-    )
-    .default({
-      expand: globalConfig.expand,
-    });
+    .requireInternalModule<typeof import('./jestExpect')>(EXPECT_INITIALIZER)
+    .default({expand: globalConfig.expand});
 
   const getPrettier = () =>
     config.prettierPath ? require(config.prettierPath) : null;

--- a/packages/jest-globals/.npmignore
+++ b/packages/jest-globals/.npmignore
@@ -1,0 +1,5 @@
+**/__mocks__/**
+**/__tests__/**
+src
+tsconfig.json
+tsconfig.tsbuildinfo

--- a/packages/jest-globals/package.json
+++ b/packages/jest-globals/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@jest/globals",
+  "version": "25.3.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/facebook/jest.git",
+    "directory": "packages/jest-globals"
+  },
+  "engines": {
+    "node": ">= 8.3"
+  },
+  "license": "MIT",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
+  "typesVersions": {
+    "<3.8": {
+      "build/*": [
+        "build/ts3.4/*"
+      ]
+    }
+  },
+  "dependencies": {
+    "@jest/environment": "^25.3.0",
+    "@jest/types": "^25.3.0",
+    "expect": "^25.3.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/jest-globals/src/__tests__/index.ts
+++ b/packages/jest-globals/src/__tests__/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+test('throw when directly imported', () => {
+  expect(() => require('../')).toThrowError(
+    'Do not import `@jest/globals` outside of the Jest test environment',
+  );
+});

--- a/packages/jest-globals/src/index.ts
+++ b/packages/jest-globals/src/index.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import importedExpect = require('expect');
+import type {Jest} from '@jest/environment';
+import type {Global} from '@jest/types';
+
+export declare type jest = Jest;
+
+export declare type expect = typeof importedExpect;
+
+export declare type it = Global.GlobalAdditions['it'];
+export declare type test = Global.GlobalAdditions['test'];
+export declare type fit = Global.GlobalAdditions['fit'];
+export declare type xit = Global.GlobalAdditions['xit'];
+export declare type xtest = Global.GlobalAdditions['xtest'];
+export declare type describe = Global.GlobalAdditions['describe'];
+export declare type xdescribe = Global.GlobalAdditions['xdescribe'];
+export declare type fdescribe = Global.GlobalAdditions['fdescribe'];
+
+throw new Error(
+  'Do not import `@jest/globals` outside of the Jest test environment',
+);

--- a/packages/jest-globals/src/index.ts
+++ b/packages/jest-globals/src/index.ts
@@ -21,6 +21,10 @@ export declare type xtest = Global.GlobalAdditions['xtest'];
 export declare type describe = Global.GlobalAdditions['describe'];
 export declare type xdescribe = Global.GlobalAdditions['xdescribe'];
 export declare type fdescribe = Global.GlobalAdditions['fdescribe'];
+export declare type beforeAll = Global.GlobalAdditions['beforeAll'];
+export declare type beforeEach = Global.GlobalAdditions['beforeEach'];
+export declare type afterEach = Global.GlobalAdditions['afterEach'];
+export declare type afterAll = Global.GlobalAdditions['afterAll'];
 
 throw new Error(
   'Do not import `@jest/globals` outside of the Jest test environment',

--- a/packages/jest-globals/tsconfig.json
+++ b/packages/jest-globals/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    // we don't want `@types/jest` to be referenced
+    "types": ["node"],
+    "rootDir": "src",
+    "outDir": "build"
+  },
+  "references": [
+    {"path": "../expect"},
+    {"path": "../jest-environment"},
+    {"path": "../jest-types"}
+  ]
+}

--- a/packages/jest-runtime/package.json
+++ b/packages/jest-runtime/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@jest/console": "^25.3.0",
     "@jest/environment": "^25.3.0",
+    "@jest/globals": "^25.3.0",
     "@jest/source-map": "^25.2.6",
     "@jest/test-result": "^25.3.0",
     "@jest/transform": "^25.3.0",

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -9,7 +9,7 @@ import {URL, fileURLToPath} from 'url';
 import * as path from 'path';
 import {Script, compileFunction} from 'vm';
 import * as nativeModule from 'module';
-import type {Config} from '@jest/types';
+import type {Config, Global} from '@jest/types';
 import type {
   Jest,
   JestEnvironment,
@@ -43,22 +43,10 @@ import Resolver = require('jest-resolve');
 import Snapshot = require('jest-snapshot');
 import stripBOM = require('strip-bom');
 
-type JestGlobalsValues = {
+interface JestGlobalsValues extends Global.TestFrameworkGlobals {
   jest: JestGlobals.jest;
   expect: JestGlobals.expect;
-  it: JestGlobals.it;
-  test: JestGlobals.test;
-  fit: JestGlobals.fit;
-  xit: JestGlobals.xit;
-  xtest: JestGlobals.xtest;
-  describe: JestGlobals.describe;
-  xdescribe: JestGlobals.xdescribe;
-  fdescribe: JestGlobals.fdescribe;
-  beforeAll: JestGlobals.beforeAll;
-  beforeEach: JestGlobals.beforeEach;
-  afterEach: JestGlobals.afterEach;
-  afterAll: JestGlobals.afterAll;
-};
+}
 
 type HasteMapOptions = {
   console?: Console;

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -54,6 +54,10 @@ type JestGlobalsValues = {
   describe: JestGlobals.describe;
   xdescribe: JestGlobals.xdescribe;
   fdescribe: JestGlobals.fdescribe;
+  beforeAll: JestGlobals.beforeAll;
+  beforeEach: JestGlobals.beforeEach;
+  afterEach: JestGlobals.afterEach;
+  afterAll: JestGlobals.afterAll;
 };
 
 type HasteMapOptions = {
@@ -1369,6 +1373,10 @@ class Runtime {
     invariant(jest, 'There should always be a Jest object already');
 
     return {
+      afterAll: this._environment.global.afterAll,
+      afterEach: this._environment.global.afterEach,
+      beforeAll: this._environment.global.beforeAll,
+      beforeEach: this._environment.global.beforeEach,
       describe: this._environment.global.describe,
       expect: this._environment.global.expect,
       fdescribe: this._environment.global.fdescribe,

--- a/packages/jest-runtime/tsconfig.json
+++ b/packages/jest-runtime/tsconfig.json
@@ -9,6 +9,7 @@
     {"path": "../jest-console"},
     {"path": "../jest-environment"},
     {"path": "../jest-environment-node"},
+    {"path": "../jest-globals"},
     {"path": "../jest-haste-map"},
     {"path": "../jest-message-util"},
     {"path": "../jest-mock"},

--- a/packages/jest-types/src/Circus.ts
+++ b/packages/jest-types/src/Circus.ts
@@ -16,7 +16,9 @@ export type BlockMode = void | 'skip' | 'only' | 'todo';
 export type TestMode = BlockMode;
 export type TestName = Global.TestName;
 export type TestFn = Global.TestFn;
-export type HookFn = (done?: DoneFn) => Promise<any> | null | undefined;
+export type HookFn = (
+  done?: DoneFn,
+) => Promise<unknown> | null | undefined | void;
 export type AsyncFn = TestFn | HookFn;
 export type SharedHookType = 'afterAll' | 'beforeAll';
 export type HookType = SharedHookType | 'afterEach' | 'beforeEach';

--- a/packages/jest-types/src/Circus.ts
+++ b/packages/jest-types/src/Circus.ts
@@ -16,9 +16,7 @@ export type BlockMode = void | 'skip' | 'only' | 'todo';
 export type TestMode = BlockMode;
 export type TestName = Global.TestName;
 export type TestFn = Global.TestFn;
-export type HookFn = (
-  done?: DoneFn,
-) => Promise<unknown> | null | undefined | void;
+export type HookFn = Global.HookFn;
 export type AsyncFn = TestFn | HookFn;
 export type SharedHookType = 'afterAll' | 'beforeAll';
 export type HookType = SharedHookType | 'afterEach' | 'beforeEach';

--- a/packages/jest-types/src/Global.ts
+++ b/packages/jest-types/src/Global.ts
@@ -66,7 +66,6 @@ export interface Describe extends DescribeBase {
   skip: DescribeBase;
 }
 
-// TODO: Maybe add `| Window` in the future?
 export interface GlobalAdditions {
   it: ItConcurrent;
   test: ItConcurrent;
@@ -76,6 +75,10 @@ export interface GlobalAdditions {
   describe: Describe;
   xdescribe: DescribeBase;
   fdescribe: DescribeBase;
+  beforeAll: TestFn;
+  beforeEach: TestFn;
+  afterEach: TestFn;
+  afterAll: TestFn;
   __coverage__: CoverageMapData;
   jasmine: Jasmine;
   fail: () => void;
@@ -84,6 +87,7 @@ export interface GlobalAdditions {
   spyOnProperty: () => void;
 }
 
+// TODO: Maybe add `| Window` in the future?
 // extends directly after https://github.com/sandersn/downlevel-dts/issues/33 is fixed
 type NodeGlobalWithoutAdditions = Omit<NodeJS.Global, keyof GlobalAdditions>;
 

--- a/packages/jest-types/src/Global.ts
+++ b/packages/jest-types/src/Global.ts
@@ -12,6 +12,7 @@ export type TestName = string;
 export type TestFn = (done?: DoneFn) => Promise<any> | void | undefined;
 export type BlockFn = () => void;
 export type BlockName = string;
+export type HookFn = TestFn;
 
 export type Col = unknown;
 export type Row = Array<Col>;
@@ -66,7 +67,7 @@ export interface Describe extends DescribeBase {
   skip: DescribeBase;
 }
 
-export interface GlobalAdditions {
+export interface TestFrameworkGlobals {
   it: ItConcurrent;
   test: ItConcurrent;
   fit: ItBase & {concurrent?: ItConcurrentBase};
@@ -75,10 +76,13 @@ export interface GlobalAdditions {
   describe: Describe;
   xdescribe: DescribeBase;
   fdescribe: DescribeBase;
-  beforeAll: TestFn;
-  beforeEach: TestFn;
-  afterEach: TestFn;
-  afterAll: TestFn;
+  beforeAll: HookFn;
+  beforeEach: HookFn;
+  afterEach: HookFn;
+  afterAll: HookFn;
+}
+
+export interface GlobalAdditions extends TestFrameworkGlobals {
   __coverage__: CoverageMapData;
   jasmine: Jasmine;
   fail: () => void;

--- a/packages/jest-types/src/Global.ts
+++ b/packages/jest-types/src/Global.ts
@@ -9,7 +9,7 @@ import type {CoverageMapData} from 'istanbul-lib-coverage';
 
 export type DoneFn = (reason?: string | Error) => void;
 export type TestName = string;
-export type TestFn = (done?: DoneFn) => Promise<unknown> | undefined | void;
+export type TestFn = (done?: DoneFn) => Promise<void | unknown> | void;
 export type BlockFn = () => void;
 export type BlockName = string;
 export type HookFn = TestFn;

--- a/packages/jest-types/src/Global.ts
+++ b/packages/jest-types/src/Global.ts
@@ -9,7 +9,9 @@ import type {CoverageMapData} from 'istanbul-lib-coverage';
 
 export type DoneFn = (reason?: string | Error) => void;
 export type TestName = string;
-export type TestFn = (done?: DoneFn) => Promise<void | unknown> | void;
+export type TestFn = (
+  done?: DoneFn,
+) => Promise<void | undefined | unknown> | void | undefined;
 export type BlockFn = () => void;
 export type BlockName = string;
 export type HookFn = TestFn;

--- a/packages/jest-types/src/Global.ts
+++ b/packages/jest-types/src/Global.ts
@@ -9,7 +9,7 @@ import type {CoverageMapData} from 'istanbul-lib-coverage';
 
 export type DoneFn = (reason?: string | Error) => void;
 export type TestName = string;
-export type TestFn = (done?: DoneFn) => Promise<any> | void | undefined;
+export type TestFn = (done?: DoneFn) => Promise<unknown> | undefined | void;
 export type BlockFn = () => void;
 export type BlockName = string;
 export type HookFn = TestFn;

--- a/scripts/buildTs.js
+++ b/scripts/buildTs.js
@@ -23,6 +23,24 @@ const packagesWithTs = packages.filter(p =>
   fs.existsSync(path.resolve(p, 'tsconfig.json'))
 );
 
+packagesWithTs.forEach(pkgDir => {
+  const pkg = require(pkgDir + '/package.json');
+
+  if (!pkg.types) {
+    throw new Error(`Package ${pkg.name} is missing \`types\` field`);
+  }
+
+  if (!pkg.typesVersions) {
+    throw new Error(`Package ${pkg.name} is missing \`typesVersions\` field`);
+  }
+
+  if (pkg.main.replace(/\.js$/, '.d.ts') !== pkg.types) {
+    throw new Error(
+      `\`main\` and \`types\` field of ${pkg.name} does not match`
+    );
+  }
+});
+
 const args = [
   '--silent',
   'tsc',
@@ -50,24 +68,6 @@ try {
 const downlevelArgs = ['--silent', 'downlevel-dts', 'build', 'build/ts3.4'];
 
 console.log(chalk.inverse(' Downleveling TypeScript definition files '));
-
-packagesWithTs.forEach(pkgDir => {
-  const pkg = require(pkgDir + '/package.json');
-
-  if (!pkg.types) {
-    throw new Error(`Package ${pkg.name} is missing \`types\` field`);
-  }
-
-  if (!pkg.typesVersions) {
-    throw new Error(`Package ${pkg.name} is missing \`typesVersions\` field`);
-  }
-
-  if (pkg.main.replace(/\.js$/, '.d.ts') !== pkg.types) {
-    throw new Error(
-      `\`main\` and \`types\` field of ${pkg.name} does not match`
-    );
-  }
-});
 
 // we want to limit the number of processes we spawn
 const cpus = Math.max(1, os.cpus().length - 1);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

People have asked for it, so why not. We still add to the global env - we can remove that later if we want to (via some config flag I guess). If we want to do that it should be pretty straight forward, just add a `runtime.registerGlobals` function or some such and get the globals from that rather than `environment.global`. I don't want it to be `import {test} from 'jest'` as that's difficult to type correctly - a separate package can both ensure types are correct and that it's only used in a Jest environment.

Fixes #4473
Fixes #5192
Closes #7571
Closes #9306

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Integration test added

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
