### PR TITLE
Document missing aliases

### DIFF
--- a/docs/GlobalAPI.md
+++ b/docs/GlobalAPI.md
@@ -528,7 +528,7 @@ test.each`
 
 ### `test.only(name, fn, timeout)`
 
-Also under the aliases: `it.only(name, fn, timeout)` and `fit(name, fn, timeout)`
+Also under the aliases: `ftest(name, fn, timeout)`, `it.only(name, fn, timeout)`, and `fit(name, fn, timeout)`
 
 When you are debugging a large test file, you will often only want to run a subset of tests. You can use `.only` to specify which tests are the only ones you want to run in that test file.
 
@@ -552,7 +552,7 @@ Usually you wouldn't check code using `test.only` into source control - you woul
 
 ### `test.only.each(table)(name, fn)`
 
-Also under the aliases: `it.only.each(table)(name, fn)`, `fit.each(table)(name, fn)`, `` it.only.each`table`(name, fn) `` and `` fit.each`table`(name, fn) ``
+Also under the aliases: `ftest.each(table)(name, fn)`, `it.only.each(table)(name, fn)`, `fit.each(table)(name, fn)`, `` ftest.each`table`(name, fn) ``, `` it.only.each`table`(name, fn) `` and `` fit.each`table`(name, fn) ``
 
 Use `test.only.each` if you want to only run specific tests with different test data.
 

--- a/docs/GlobalAPI.md
+++ b/docs/GlobalAPI.md
@@ -528,7 +528,7 @@ test.each`
 
 ### `test.only(name, fn, timeout)`
 
-Also under the aliases: `it.only(name, fn, timeout)` or `fit(name, fn, timeout)`
+Also under the aliases: `it.only(name, fn, timeout)` and `fit(name, fn, timeout)`
 
 When you are debugging a large test file, you will often only want to run a subset of tests. You can use `.only` to specify which tests are the only ones you want to run in that test file.
 
@@ -593,7 +593,7 @@ test('will not be ran', () => {
 
 ### `test.skip(name, fn)`
 
-Also under the aliases: `it.skip(name, fn)` or `xit(name, fn)` or `xtest(name, fn)`
+Also under the aliases: `it.skip(name, fn)`, `xit(name, fn)`, and `xtest(name, fn)`
 
 When you are maintaining a large codebase, you may sometimes find a test that is temporarily broken for some reason. If you want to skip running this test, but you don't want to delete this code, you can use `test.skip` to specify some tests to skip.
 

--- a/docs/GlobalAPI.md
+++ b/docs/GlobalAPI.md
@@ -656,6 +656,8 @@ test('will be ran', () => {
 
 ### `test.todo(name)`
 
+Also under the alias: `it.todo(name)`
+
 Use `test.todo` when you are planning on writing tests. These tests will be highlighted in the summary output at the end so you know how many tests you still need todo.
 
 _Note_: If you supply a test callback function then the `test.todo` will throw an error. If you have already implemented the test and it is broken and you do not want it to run, then use `test.skip` instead.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Adds missing aliases to API documentation:

- `ftest`
- `ftest.each(table)`
- `` ftest.each`table` ``
- `it.todo`

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

These undocumented aliases exist in the TypeScript type declarations for Jest tests