### PR TITLE
chore: type TestScheduler's testRunners object

### DIFF
--- a/packages/jest-core/src/TestScheduler.ts
+++ b/packages/jest-core/src/TestScheduler.ts
@@ -175,7 +175,7 @@ export default class TestScheduler {
       showStatus: !runInBand,
     });
 
-    const testRunners = Object.create(null);
+    const testRunners: {[key: string]: TestRunner} = Object.create(null);
     contexts.forEach(({config}) => {
       if (!testRunners[config.runner]) {
         const Runner: typeof TestRunner = require(config.runner);

--- a/packages/jest-runner/src/index.ts
+++ b/packages/jest-runner/src/index.ts
@@ -44,6 +44,7 @@ namespace TestRunner {
 class TestRunner {
   private _globalConfig: Config.GlobalConfig;
   private _context: JestTestRunnerContext;
+  readonly isSerial?: boolean;
 
   constructor(
     globalConfig: Config.GlobalConfig,

--- a/packages/jest-runner/src/types.ts
+++ b/packages/jest-runner/src/types.ts
@@ -63,7 +63,6 @@ export type WatcherState = {
 };
 export interface TestWatcher extends EventEmitter {
   state: WatcherState;
-  new ({isWatchMode}: {isWatchMode: boolean}): TestWatcher;
   setState(state: WatcherState): void;
   isInterrupted(): boolean;
   isWatchMode(): boolean;


### PR DESCRIPTION
## Summary

There was an `any` object containing all of the TestRunners. I gave it a type.

## Test plan

Typescript build succeeded.