### PR TITLE
feat: onTestProgress callback for runners

### DIFF
--- a/packages/jest-core/src/ReporterDispatcher.ts
+++ b/packages/jest-core/src/ReporterDispatcher.ts
@@ -5,7 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import type {AggregatedResult, TestResult} from '@jest/test-result';
+import type {
+  AggregatedResult,
+  TestProgress,
+  TestResult,
+} from '@jest/test-result';
 import type {Test} from 'jest-runner';
 import type {Context} from 'jest-runtime';
 import type {Reporter, ReporterOnStartOptions} from '@jest/reporters';
@@ -46,6 +50,13 @@ export default class ReporterDispatcher {
   async onTestStart(test: Test): Promise<void> {
     for (const reporter of this._reporters) {
       reporter.onTestStart && (await reporter.onTestStart(test));
+    }
+  }
+
+  async onTestProgress(test: Test, progress: TestProgress): Promise<void> {
+    for (const reporter of this._reporters) {
+      reporter.onTestProgress &&
+        (await reporter.onTestProgress(test, progress));
     }
   }
 

--- a/packages/jest-core/src/TestScheduler.ts
+++ b/packages/jest-core/src/TestScheduler.ts
@@ -23,6 +23,7 @@ import exit = require('exit');
 import {
   AggregatedResult,
   SerializableError,
+  TestProgress,
   TestResult,
   addResult,
   buildFailureTestResult,
@@ -146,6 +147,16 @@ export default class TestScheduler {
       await this._dispatcher.onTestResult(test, testResult, aggregatedResults);
     };
 
+    const onTestProgress = async (
+      test: TestRunner.Test,
+      progress: TestProgress,
+    ) => {
+      if (watcher.isInterrupted()) {
+        return;
+      }
+      this._dispatcher.onTestProgress(test, progress);
+    };
+
     const updateSnapshotState = () => {
       contexts.forEach(context => {
         const status = snapshot.cleanup(
@@ -197,6 +208,7 @@ export default class TestScheduler {
             onResult,
             onFailure,
             {
+              onTestProgress,
               serial: runInBand || Boolean(testRunners[runner].isSerial),
             },
           );

--- a/packages/jest-reporters/src/default_reporter.ts
+++ b/packages/jest-reporters/src/default_reporter.ts
@@ -6,7 +6,11 @@
  */
 
 import type {Config} from '@jest/types';
-import type {AggregatedResult, TestResult} from '@jest/test-result';
+import type {
+  AggregatedResult,
+  TestProgress,
+  TestResult,
+} from '@jest/test-result';
 import {clearLine, isInteractive} from 'jest-util';
 import {getConsoleOutput} from '@jest/console';
 import chalk = require('chalk');
@@ -157,6 +161,10 @@ export default class DefaultReporter extends BaseReporter {
       );
     }
     this.forceFlushBufferedOutput();
+  }
+
+  onTestProgress(test: Test, progress: TestProgress): void {
+    this._status.testProgress(test.path, progress);
   }
 
   testFinished(

--- a/packages/jest-reporters/src/types.ts
+++ b/packages/jest-reporters/src/types.ts
@@ -9,6 +9,7 @@ import type {Config} from '@jest/types';
 import type {
   AggregatedResult,
   SerializableError,
+  TestProgress,
   TestResult,
 } from '@jest/test-result';
 import type {FS as HasteFS, ModuleMap} from 'jest-haste-map';
@@ -61,6 +62,10 @@ export interface Reporter {
     options: ReporterOnStartOptions,
   ) => Promise<void> | void;
   readonly onTestStart: (test: Test) => Promise<void> | void;
+  readonly onTestProgress?: (
+    test: Test,
+    progress: TestProgress,
+  ) => Promise<void> | void;
   readonly onRunComplete: (
     contexts: Set<Context>,
     results: AggregatedResult,

--- a/packages/jest-runner/src/types.ts
+++ b/packages/jest-runner/src/types.ts
@@ -7,7 +7,11 @@
 
 import type {EventEmitter} from 'events';
 import type {Config} from '@jest/types';
-import type {SerializableError, TestResult} from '@jest/test-result';
+import type {
+  SerializableError,
+  TestProgress,
+  TestResult,
+} from '@jest/test-result';
 import type {JestEnvironment} from '@jest/environment';
 import type {FS as HasteFS, ModuleMap} from 'jest-haste-map';
 import HasteResolver = require('jest-resolve');
@@ -46,6 +50,7 @@ export type TestFramework = (
 ) => Promise<TestResult>;
 
 export type TestRunnerOptions = {
+  onTestProgress?: (test: Test, progress: TestProgress) => void;
   serial: boolean;
 };
 

--- a/packages/jest-test-result/src/index.ts
+++ b/packages/jest-test-result/src/index.ts
@@ -24,5 +24,6 @@ export type {
   Status,
   Suite,
   TestResult,
+  TestProgress,
   V8CoverageResult,
 } from './types';

--- a/packages/jest-test-result/src/types.ts
+++ b/packages/jest-test-result/src/types.ts
@@ -113,6 +113,11 @@ export type TestResult = {
   v8Coverage?: V8CoverageResult;
 };
 
+export type TestProgress = {
+  numRanTests: number;
+  numTotalTests: number;
+};
+
 export type FormattedTestResult = {
   message: string;
   name: string;


### PR DESCRIPTION
## Summary

While most JSDOM tests with jest are very quick, async end-to-end tests can be a lot slower. When a file has a lot of tests in it, it would be nice to report progress on the individual tests in the file.

This patch does not change the behavior of the default `jest-runner`. It just allows for other runners to report progress per test.

#6616

See this screenshot, with `(2/6)` listed for test suite in progress.

![image](https://user-images.githubusercontent.com/4624233/79435109-1d2b2980-7f84-11ea-99c7-aa5cea8836ca.png)

## Test plan

I'm not sure where the right place to add a test for this is. Can someone point me in the right direction? Thanks!
