### PR TITLE
Use optional chaining in toHaveLength matcher

### DIFF
--- a/packages/expect/src/matchers.ts
+++ b/packages/expect/src/matchers.ts
@@ -628,10 +628,7 @@ const matchers: MatchersObject = {
       promise: this.promise,
     };
 
-    if (
-      typeof received !== 'string' &&
-      (!received || typeof received.length !== 'number')
-    ) {
+    if (typeof received?.length !== 'number') {
       throw new Error(
         matcherErrorMessage(
           matcherHint(matcherName, undefined, undefined, options),


### PR DESCRIPTION
Simplifies the check using optional chaining. Maybe the code can be simplified even further omitting the string check as well. WDYT?

Relates to #9796

cc @G-Rath @SimenB 