### PR TITLE
chore: target node 8.3, not 8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Chore & Maintenance
 
 - `[*]` Do not generate TypeScript declaration source maps ([#9822](https://github.com/facebook/jest/pull/9822))
+- `[*]` Transpile code for Node 8.3, not 8.0 ([#9827](https://github.com/facebook/jest/pull/9827))
 
 ### Performance
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -31,7 +31,7 @@ module.exports = {
           {
             exclude: ['@babel/plugin-proposal-dynamic-import'],
             shippedProposals: true,
-            targets: {node: 8},
+            targets: {node: '8.3'},
           },
         ],
       ],
@@ -48,7 +48,7 @@ module.exports = {
       '@babel/preset-env',
       {
         shippedProposals: true,
-        targets: {node: 8},
+        targets: {node: '8.3'},
       },
     ],
   ],

--- a/e2e/__tests__/__snapshots__/transform.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/transform.test.ts.snap
@@ -6,7 +6,7 @@ FAIL __tests__/ignoredFile.test.js
 
     babel-jest: Babel ignores __tests__/ignoredFile.test.js - make sure to include the file in Jest's transformIgnorePatterns as well.
 
-      at loadBabelConfig (../../../packages/babel-jest/build/index.js:227:13)
+      at loadBabelConfig (../../../packages/babel-jest/build/index.js:178:13)
 `;
 
 exports[`babel-jest instruments only specific files and collects coverage 1`] = `


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

This drops the `objectSpread` babel helper, resulting in these sorts of diffs:

![image](https://user-images.githubusercontent.com/1404810/79465487-afbadf80-7ffb-11ea-8c26-302b08b1b388.png)

![image](https://user-images.githubusercontent.com/1404810/79467134-bea29180-7ffd-11ea-9c3a-aa3b8d3322cd.png)

Should in theory be faster on newer nodes as well, as the engine can optimize it

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Green CI

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
