### PR TITLE
chore: skip mercurial tests when no hg installed

### DIFF
--- a/e2e/Utils.ts
+++ b/e2e/Utils.ts
@@ -263,5 +263,10 @@ export const normalizeIcons = (str: string) => {
 };
 
 // Certain environments (like CITGM and GH Actions) do not come with mercurial installed
-export const hgIsInstalled = which.sync('hg', {nothrow: true}) !== null;
-export const testIfHg = hgIsInstalled ? test : test.skip;
+export const buildTestIfHg = () => {
+  const hgIsInstalled = which.sync('hg', {nothrow: true}) !== null;
+  if (!hgIsInstalled) {
+    console.warn('Mercurial (hg) is not installed - skipping some tests');
+  }
+  return hgIsInstalled ? test : test.skip;
+};

--- a/e2e/Utils.ts
+++ b/e2e/Utils.ts
@@ -265,9 +265,7 @@ export const normalizeIcons = (str: string) => {
 // Certain environments (like CITGM and GH Actions) do not come with mercurial installed
 let hgIsInstalled: boolean | null = null;
 
-export const testIfHg = (
-  ...args: Parameters<typeof test>
-) => {
+export const testIfHg = (...args: Parameters<typeof test>) => {
   if (hgIsInstalled === null) {
     hgIsInstalled = which.sync('hg', {nothrow: true}) !== null;
   }

--- a/e2e/Utils.ts
+++ b/e2e/Utils.ts
@@ -263,10 +263,18 @@ export const normalizeIcons = (str: string) => {
 };
 
 // Certain environments (like CITGM and GH Actions) do not come with mercurial installed
-export const buildTestIfHg = () => {
-  const hgIsInstalled = which.sync('hg', {nothrow: true}) !== null;
-  if (!hgIsInstalled) {
-    console.warn('Mercurial (hg) is not installed - skipping some tests');
+let hgIsInstalled: boolean | null = null;
+
+export const testIfHg: typeof test = (...args) => {
+  if (hgIsInstalled === null) {
+    hgIsInstalled = which.sync('hg', {nothrow: true}) !== null;
   }
-  return hgIsInstalled ? test : test.skip;
+  
+  if (hgIsInstalled) {
+    test(...args);
+  } else {
+    console.warn('Mercurial (hg) is not installed - skipping some tests');
+
+    test.skip(...args);
+  }
 };

--- a/e2e/Utils.ts
+++ b/e2e/Utils.ts
@@ -267,15 +267,15 @@ let hgIsInstalled: boolean | null = null;
 
 export const testIfHg = (
   ...args: Parameters<typeof test>
-): ReturnType<typeof test> => {
+) => {
   if (hgIsInstalled === null) {
     hgIsInstalled = which.sync('hg', {nothrow: true}) !== null;
   }
 
   if (hgIsInstalled) {
-    return test(...args);
+    test(...args);
   } else {
     console.warn('Mercurial (hg) is not installed - skipping some tests');
-    return test.skip(...args);
+    test.skip(...args);
   }
 };

--- a/e2e/Utils.ts
+++ b/e2e/Utils.ts
@@ -265,16 +265,17 @@ export const normalizeIcons = (str: string) => {
 // Certain environments (like CITGM and GH Actions) do not come with mercurial installed
 let hgIsInstalled: boolean | null = null;
 
-export const testIfHg: typeof test = (...args) => {
+export const testIfHg = (
+  ...args: Parameters<typeof test>
+): ReturnType<typeof test> => {
   if (hgIsInstalled === null) {
     hgIsInstalled = which.sync('hg', {nothrow: true}) !== null;
   }
-  
+
   if (hgIsInstalled) {
-    test(...args);
+    return test(...args);
   } else {
     console.warn('Mercurial (hg) is not installed - skipping some tests');
-
-    test.skip(...args);
+    return test.skip(...args);
   }
 };

--- a/e2e/Utils.ts
+++ b/e2e/Utils.ts
@@ -14,6 +14,7 @@ import {ExecaReturnValue, sync as spawnSync} from 'execa';
 import makeDir = require('make-dir');
 import rimraf = require('rimraf');
 import dedent = require('dedent');
+import which = require('which');
 
 interface RunResult extends ExecaReturnValue {
   status: number;
@@ -260,3 +261,7 @@ export const normalizeIcons = (str: string) => {
     .replace(new RegExp('\u00D7', 'g'), '\u2715')
     .replace(new RegExp('\u221A', 'g'), '\u2713');
 };
+
+// Certain environments (like CITGM and GH Actions) do not come with mercurial installed
+export const hgIsInstalled = which.sync('hg', {nothrow: true}) !== null;
+export const testIfHg = hgIsInstalled ? test : test.skip;

--- a/e2e/__tests__/jestChangedFiles.test.ts
+++ b/e2e/__tests__/jestChangedFiles.test.ts
@@ -10,7 +10,7 @@ import * as path from 'path';
 import {wrap} from 'jest-snapshot-serializer-raw';
 import {findRepos, getChangedFilesForRoots} from 'jest-changed-files';
 import {skipSuiteOnWindows} from '@jest/test-utils';
-import {cleanup, hgIsInstalled, run, testIfHg, writeFiles} from '../Utils';
+import {buildTestIfHg, cleanup, run, writeFiles} from '../Utils';
 import runJest from '../runJest';
 
 skipSuiteOnWindows();
@@ -19,13 +19,10 @@ const DIR = path.resolve(tmpdir(), 'jest-changed-files-test-dir');
 
 const GIT = 'git -c user.name=jest_test -c user.email=jest_test@test.com';
 const HG = 'hg --config ui.username=jest_test';
+const testIfHg = buildTestIfHg();
 
 beforeEach(() => cleanup(DIR));
 afterEach(() => cleanup(DIR));
-
-if (!hgIsInstalled) {
-  console.warn('Mercurial (hg) is not installed - skipping some tests');
-}
 
 testIfHg('gets hg SCM roots and dedupes them', async () => {
   writeFiles(DIR, {

--- a/e2e/__tests__/jestChangedFiles.test.ts
+++ b/e2e/__tests__/jestChangedFiles.test.ts
@@ -10,7 +10,7 @@ import * as path from 'path';
 import {wrap} from 'jest-snapshot-serializer-raw';
 import {findRepos, getChangedFilesForRoots} from 'jest-changed-files';
 import {skipSuiteOnWindows} from '@jest/test-utils';
-import {buildTestIfHg, cleanup, run, writeFiles} from '../Utils';
+import {cleanup, run, testIfHg, writeFiles} from '../Utils';
 import runJest from '../runJest';
 
 skipSuiteOnWindows();
@@ -19,7 +19,6 @@ const DIR = path.resolve(tmpdir(), 'jest-changed-files-test-dir');
 
 const GIT = 'git -c user.name=jest_test -c user.email=jest_test@test.com';
 const HG = 'hg --config ui.username=jest_test';
-const testIfHg = buildTestIfHg();
 
 beforeEach(() => cleanup(DIR));
 afterEach(() => cleanup(DIR));

--- a/e2e/__tests__/jestChangedFiles.test.ts
+++ b/e2e/__tests__/jestChangedFiles.test.ts
@@ -10,8 +10,7 @@ import * as path from 'path';
 import {wrap} from 'jest-snapshot-serializer-raw';
 import {findRepos, getChangedFilesForRoots} from 'jest-changed-files';
 import {skipSuiteOnWindows} from '@jest/test-utils';
-import which = require('which');
-import {cleanup, run, writeFiles} from '../Utils';
+import {cleanup, hgIsInstalled, run, testIfHg, writeFiles} from '../Utils';
 import runJest from '../runJest';
 
 skipSuiteOnWindows();
@@ -23,10 +22,6 @@ const HG = 'hg --config ui.username=jest_test';
 
 beforeEach(() => cleanup(DIR));
 afterEach(() => cleanup(DIR));
-
-// Certain environments (like CITGM and GH Actions) do not come with mercurial installed
-const hgIsInstalled = which.sync('hg', {nothrow: true}) !== null;
-const testIfHg = hgIsInstalled ? test : test.skip;
 
 if (!hgIsInstalled) {
   console.warn('Mercurial (hg) is not installed - skipping some tests');

--- a/e2e/__tests__/onlyChanged.test.ts
+++ b/e2e/__tests__/onlyChanged.test.ts
@@ -8,18 +8,15 @@
 import {tmpdir} from 'os';
 import * as path from 'path';
 import runJest from '../runJest';
-import {cleanup, hgIsInstalled, run, testIfHg, writeFiles} from '../Utils';
+import {buildTestIfHg, cleanup, run, writeFiles} from '../Utils';
 
 const DIR = path.resolve(tmpdir(), 'jest_only_changed');
 const GIT = 'git -c user.name=jest_test -c user.email=jest_test@test.com';
 const HG = 'hg --config ui.username=jest_test';
+const testIfHg = buildTestIfHg();
 
 beforeEach(() => cleanup(DIR));
 afterEach(() => cleanup(DIR));
-
-if (!hgIsInstalled) {
-  console.warn('Mercurial (hg) is not installed - skipping some tests');
-}
 
 test('run for "onlyChanged" and "changedSince"', () => {
   writeFiles(DIR, {

--- a/e2e/__tests__/onlyChanged.test.ts
+++ b/e2e/__tests__/onlyChanged.test.ts
@@ -8,12 +8,11 @@
 import {tmpdir} from 'os';
 import * as path from 'path';
 import runJest from '../runJest';
-import {buildTestIfHg, cleanup, run, writeFiles} from '../Utils';
+import {cleanup, run, testIfHg, writeFiles} from '../Utils';
 
 const DIR = path.resolve(tmpdir(), 'jest_only_changed');
 const GIT = 'git -c user.name=jest_test -c user.email=jest_test@test.com';
 const HG = 'hg --config ui.username=jest_test';
-const testIfHg = buildTestIfHg();
 
 beforeEach(() => cleanup(DIR));
 afterEach(() => cleanup(DIR));

--- a/e2e/__tests__/onlyChanged.test.ts
+++ b/e2e/__tests__/onlyChanged.test.ts
@@ -7,9 +7,8 @@
 
 import {tmpdir} from 'os';
 import * as path from 'path';
-import which = require('which');
 import runJest from '../runJest';
-import {cleanup, run, writeFiles} from '../Utils';
+import {cleanup, hgIsInstalled, run, testIfHg, writeFiles} from '../Utils';
 
 const DIR = path.resolve(tmpdir(), 'jest_only_changed');
 const GIT = 'git -c user.name=jest_test -c user.email=jest_test@test.com';
@@ -17,10 +16,6 @@ const HG = 'hg --config ui.username=jest_test';
 
 beforeEach(() => cleanup(DIR));
 afterEach(() => cleanup(DIR));
-
-// Certain environments (like CITGM and GH Actions) do not come with mercurial installed
-const hgIsInstalled = which.sync('hg', {nothrow: true}) !== null;
-const testIfHg = hgIsInstalled ? test : test.skip;
 
 if (!hgIsInstalled) {
   console.warn('Mercurial (hg) is not installed - skipping some tests');


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

DISCLAIMER: Feel free to close this PR if it does not make sense.

When running `yarn test-ci` on my machine not having `hg` installed, I saw that some tests requiring `hg` were explicitely skipped while others were still executed.

I just applied what was done in `jestChangedFiles.test.ts` on another test that needs `hg` to run.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
