### PR TITLE
`[jest-runner]` Don't print warning to stdout when using `--json`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - `[jest-circus]` Throw on nested test definitions ([#9828](https://github.com/facebook/jest/pull/9828))
 - `[jest-changed-files]` `--only-changed` should include staged files ([#9799](https://github.com/facebook/jest/pull/9799))
 - `[jest-each]` `each` will throw an error when called with too many arguments ([#9818](https://github.com/facebook/jest/pull/9818))
+- `[jest-runner]` Don't print warning to stdout when using `--json` ([#9843](https://github.com/facebook/jest/pull/9843))
 
 ### Chore & Maintenance
 

--- a/e2e/__tests__/workerForceExit.test.ts
+++ b/e2e/__tests__/workerForceExit.test.ts
@@ -42,11 +42,11 @@ test('prints a warning if a worker is force exited', () => {
       });
     `,
   });
-  const {exitCode, stderr, stdout} = runJest(DIR, ['--maxWorkers=2']);
+  const {exitCode, stderr} = runJest(DIR, ['--maxWorkers=2']);
 
   expect(exitCode).toBe(0);
   verifyNumPassed(stderr);
-  expect(stdout).toContain('A worker process has failed to exit gracefully');
+  expect(stderr).toContain('A worker process has failed to exit gracefully');
 });
 
 test('force exits a worker that fails to exit gracefully', async () => {

--- a/packages/jest-runner/src/index.ts
+++ b/packages/jest-runner/src/index.ts
@@ -194,7 +194,7 @@ class TestRunner {
     const cleanup = async () => {
       const {forceExited} = await worker.end();
       if (forceExited) {
-        console.log(
+        console.error(
           chalk.yellow(
             'A worker process has failed to exit gracefully and has been force exited. ' +
               'This is likely caused by tests leaking due to improper teardown. ' +


### PR DESCRIPTION
## Summary

This warning should go to `stderr`, otherwise when you have a test that leaks while using `--json` it will produce invalid JSON when reading the `stdout` of a Jest process.

## Test plan

This regressed in Jest through #8206 and made Jest on CI at FB fail. Verified this change fixes it.