### PR TITLE
chore: fix symlink creation failures on windows in tests

### DIFF
--- a/e2e/Utils.ts
+++ b/e2e/Utils.ts
@@ -47,7 +47,7 @@ export const linkJestPackage = (packageName: string, cwd: Config.Path) => {
   const destination = path.resolve(cwd, 'node_modules/', packageName);
   makeDir.sync(destination);
   rimraf.sync(destination);
-  fs.symlinkSync(packagePath, destination, 'dir');
+  fs.symlinkSync(packagePath, destination, 'junction');
 };
 
 export const makeTemplate = (
@@ -105,6 +105,7 @@ export const writeSymlinks = (
     fs.symlinkSync(
       path.resolve(directory, ...fileOrPath.split('/')),
       path.resolve(directory, ...symLinkPath.split('/')),
+      'junction',
     );
   });
 };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Switching to `type=junction` in `fs.symlinks` seems to fix the issue.
Before that change, running `yarn test-ci` was failing due to symlinks on the tests:
- no babel-jest › fails with syntax error on flow types
- no babel-jest › instrumentation with no babel-jest

Here is a related ticket on node: https://github.com/nodejs/node/issues/18518

See comments https://github.com/nodejs/node/issues/18518#issuecomment-513809856 and https://github.com/nodejs/node/issues/18518#issuecomment-513866491

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

The tests relying on those helpers are now passing on my Windows machine without the need to have admit rights.

_Let see if they pass the CI_
