### PR TITLE
chore: mock stealthy-require in tests

### DIFF
--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -148,6 +148,7 @@ class Runtime {
   private _unmockList: RegExp | undefined;
   private _virtualMocks: BooleanObject;
   private _moduleImplementation?: typeof nativeModule.Module;
+  private _hasWarnedAboutRequireCacheModification = false;
 
   constructor(
     config: Config.ProjectConfig,
@@ -1273,9 +1274,13 @@ class Runtime {
     moduleRequire.resolve = resolve;
     moduleRequire.cache = (() => {
       const notPermittedMethod = () => {
-        this._environment.global.console.warn(
-          '`require.cache` modification is not permitted',
-        );
+        if (!this._hasWarnedAboutRequireCacheModification) {
+          this._environment.global.console.warn(
+            '`require.cache` modification is not permitted',
+          );
+
+          this._hasWarnedAboutRequireCacheModification = true;
+        }
         return true;
       };
       return new Proxy<RequireCache>(Object.create(null), {

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -1273,7 +1273,9 @@ class Runtime {
     moduleRequire.resolve = resolve;
     moduleRequire.cache = (() => {
       const notPermittedMethod = () => {
-        console.warn('`require.cache` modification is not permitted');
+        this._environment.global.console.warn(
+          '`require.cache` modification is not permitted',
+        );
         return true;
       };
       return new Proxy<RequireCache>(Object.create(null), {

--- a/testSetupFile.js
+++ b/testSetupFile.js
@@ -8,3 +8,6 @@
 // Some of the `jest-runtime` tests are very slow and cause
 // timeouts on travis
 jest.setTimeout(70000);
+
+// this module does some funky stuff with `require.cache`, flooding the terminal with output
+jest.mock('stealthy-require', () => (_, m) => m());


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

As mentioned here: https://github.com/facebook/jest/pull/9841#issuecomment-617413947

This makes me think that we might want to rethink the warning... Is it safe to include this change?

@antongolub @thymikee @jeysal would love your thoughts

EDIT: One thing we can do is only warn _once_ per `jest-runtime` (meaning per test file). Better than potentially flooding the output at least

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Green CI without flooded output
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
