### PR TITLE
Add a failing test for printSnapshotAndReceived incorrectly recognizing sometimes indented lines as changed

### DIFF
--- a/packages/jest-snapshot/src/__tests__/__snapshots__/printSnapshot.test.ts.snap
+++ b/packages/jest-snapshot/src/__tests__/__snapshots__/printSnapshot.test.ts.snap
@@ -375,6 +375,24 @@ Snapshot: <m>"delete"</>
 Received: <t>"insert"</>
 `;
 
+exports[`printSnapshotAndReceived ignore indentation ignores custom indentation of unchanged line 1`] = `
+<m>- Snapshot  - 2</>
+<t>+ Received  + 2</>
+
+<m>-   **some plugin-generated string with custom leading whitespace**</>
+<t>+   **some plugin-generated string with custom leading whitespace**</>
+
+<d>  Object {</>
+<d>    "props": Object {</>
+<d>      "alt": "Jest logo",</>
+<m>-     "class": "logo",</>
+<t>+     "class": "logo round",</>
+<d>      "src": "/img/jest.svg",</>
+<d>    },</>
+<d>    "type": "img",</>
+<d>  }</>
+`;
+
 exports[`printSnapshotAndReceived ignore indentation markup delete 1`] = `
 <m>- Snapshot  - 2</>
 <t>+ Received  + 0</>


### PR DESCRIPTION
## Summary

It has been reported to Emotion that each printed style property is being shown as changed in Jest 25 when anything changes between snapshots & received: https://github.com/emotion-js/emotion/issues/1847

It turned out that we currently ignore `indentation` because we use `OldPlugin` interface and we just print retrieved styles with always indented. We plan to fix this soon, but I believe the issue is still worth fixing in Jest itself - especially that the comment here:
https://github.com/facebook/jest/blob/32aaff83f02c347ccd591727544002490fb4ee9a/packages/jest-snapshot/src/printSnapshot.ts#L316-L317
suggests that this was supposed to be handled.

So far I've just added a failing test and would like to first check-in if there is an interest in fixing this before I dive into this further. I've also actually tried to fix this quickly by calling `dedentLines` on this:
https://github.com/facebook/jest/blob/32aaff83f02c347ccd591727544002490fb4ee9a/packages/jest-snapshot/src/printSnapshot.ts#L324
but while it has fixed my issue it has changed 2 other tests and it would require further investigation why this is happening and how the fix could be improved.