### PR TITLE
noCodeFrame respects noStackTrace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@
 
 ### Fixes
 
+- `[jest-message-util]` Code frame printing should respect `--noStackTrace` flag ([#9866](https://github.com/facebook/jest/pull/9866))
 - `[jest-runtime]` Support importing CJS from ESM using `import` statements ([#9850](https://github.com/facebook/jest/pull/9850))
 - `[jest-runtime]` Support importing parallel dynamic `import`s ([#9858](https://github.com/facebook/jest/pull/9858))
-- `[jest-message-util]` Code frame printing should respect `--noStackTrace` flag ([#9866](https://github.com/facebook/jest/pull/9866))
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 - `[jest-runtime]` Support importing CJS from ESM using `import` statements ([#9850](https://github.com/facebook/jest/pull/9850))
 - `[jest-runtime]` Support importing parallel dynamic `import`s ([#9858](https://github.com/facebook/jest/pull/9858))
+- `[jest-message-util]` Code frame printing should respect `--noStackTrace` flag ([#9866](https://github.com/facebook/jest/pull/9866))
 
 ### Chore & Maintenance
 

--- a/packages/jest-message-util/src/__tests__/__snapshots__/messages.test.ts.snap
+++ b/packages/jest-message-util/src/__tests__/__snapshots__/messages.test.ts.snap
@@ -36,24 +36,24 @@ exports[`formatStackTrace should strip node internals 1`] = `
 `;
 
 exports[`getConsoleOutput does not print code frame when noCodeFrame = true 1`] = `
-"
-      <dim>at Object.<anonymous> (</>file.js<dim>:1:7)</>
-        "
+
+      [2mat Object.<anonymous> ([22mfile.js[2m:1:7)[22m
+        
 `;
 
 exports[`getConsoleOutput does not print codeframe when noStackTrace = true 1`] = `
-"
-      <dim>at Object.<anonymous> (</>file.js<dim>:1:7)</>
-        "
+
+      [2mat Object.<anonymous> ([22mfile.js[2m:1:7)[22m
+        
 `;
 
 exports[`getConsoleOutput prints code frame and stacktrace 1`] = `
-"
-    </><red><bold>></></><gray> 1 | </><cyan>throw</> <cyan>new</> <yellow>Error</>(<green>\\"Whoops!\\"</>)<yellow>;</></>
-    </> <gray>   | </>      <red><bold>^</></></>
 
-      <dim>at Object.<anonymous> (</>file.js<dim>:1:7)</>
-        "
+    [0m[31m[1m>[22m[39m[90m 1 | [39m[36mthrow[39m [36mnew[39m [33mError[39m([32m"Whoops!"[39m)[33m;[39m[0m
+    [0m [90m   | [39m      [31m[1m^[22m[39m[0m
+
+      [2mat Object.<anonymous> ([22mfile.js[2m:1:7)[22m
+        
 `;
 
 exports[`no codeframe 1`] = `

--- a/packages/jest-message-util/src/__tests__/__snapshots__/messages.test.ts.snap
+++ b/packages/jest-message-util/src/__tests__/__snapshots__/messages.test.ts.snap
@@ -36,24 +36,24 @@ exports[`formatStackTrace should strip node internals 1`] = `
 `;
 
 exports[`getConsoleOutput does not print code frame when noCodeFrame = true 1`] = `
-
-      [2mat Object.<anonymous> ([22mfile.js[2m:1:7)[22m
-        
+"
+      <dim>at Object.<anonymous> (</>file.js<dim>:1:7)</>
+        "
 `;
 
 exports[`getConsoleOutput does not print codeframe when noStackTrace = true 1`] = `
-
-      [2mat Object.<anonymous> ([22mfile.js[2m:1:7)[22m
-        
+"
+      <dim>at Object.<anonymous> (</>file.js<dim>:1:7)</>
+        "
 `;
 
 exports[`getConsoleOutput prints code frame and stacktrace 1`] = `
+"
+    </><red><bold>></></><gray> 1 | </><cyan>throw</> <cyan>new</> <yellow>Error</>(<green>\\"Whoops!\\"</>)<yellow>;</></>
+    </> <gray>   | </>      <red><bold>^</></></>
 
-    [0m[31m[1m>[22m[39m[90m 1 | [39m[36mthrow[39m [36mnew[39m [33mError[39m([32m"Whoops!"[39m)[33m;[39m[0m
-    [0m [90m   | [39m      [31m[1m^[22m[39m[0m
-
-      [2mat Object.<anonymous> ([22mfile.js[2m:1:7)[22m
-        
+      <dim>at Object.<anonymous> (</>file.js<dim>:1:7)</>
+        "
 `;
 
 exports[`no codeframe 1`] = `

--- a/packages/jest-message-util/src/__tests__/__snapshots__/messages.test.ts.snap
+++ b/packages/jest-message-util/src/__tests__/__snapshots__/messages.test.ts.snap
@@ -35,6 +35,27 @@ exports[`formatStackTrace should strip node internals 1`] = `
 "
 `;
 
+exports[`getConsoleOutput does not print code frame when noCodeFrame = true 1`] = `
+"
+      <dim>at Object.<anonymous> (</>file.js<dim>:1:7)</>
+        "
+`;
+
+exports[`getConsoleOutput does not print codeframe when noStackTrace = true 1`] = `
+"
+      <dim>at Object.<anonymous> (</>file.js<dim>:1:7)</>
+        "
+`;
+
+exports[`getConsoleOutput prints code frame and stacktrace 1`] = `
+"
+    </><red><bold>></></><gray> 1 | </><cyan>throw</> <cyan>new</> <yellow>Error</>(<green>\\"Whoops!\\"</>)<yellow>;</></>
+    </> <gray>   | </>      <red><bold>^</></></>
+
+      <dim>at Object.<anonymous> (</>file.js<dim>:1:7)</>
+        "
+`;
+
 exports[`no codeframe 1`] = `
 "  <bold>● </>Test suite failed to run
 

--- a/packages/jest-message-util/src/__tests__/messages.test.ts
+++ b/packages/jest-message-util/src/__tests__/messages.test.ts
@@ -9,7 +9,7 @@
 import {readFileSync} from 'fs';
 import slash = require('slash');
 import tempy = require('tempy');
-import {formatExecError, formatResultsErrors} from '..';
+import {formatExecError, formatResultsErrors, formatStackTrace} from '..';
 
 const rootDir = tempy.directory();
 
@@ -288,4 +288,80 @@ it('no stack', () => {
   );
 
   expect(message).toMatchSnapshot();
+});
+
+describe('getConsoleOutput', () =>{
+  it('prints code frame and stacktrace', () => {
+    readFileSync.mockImplementationOnce(() => 'throw new Error("Whoops!");');
+    const message = formatStackTrace(
+      `
+      at Object.<anonymous> (${slash(rootDir)}/file.js:1:7)
+      at Module._compile (internal/modules/cjs/loader.js:1158:30)
+      at Object.Module._extensions..js (internal/modules/cjs/loader.js:1178:10)
+      at Module.load (internal/modules/cjs/loader.js:1002:32)
+      at Function.Module._load (internal/modules/cjs/loader.js:901:14)
+      at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:74:12)
+  `,
+      {
+        rootDir,
+        testMatch: [],
+      },
+      {
+        noCodeFrame: false,
+        noStackTrace: false,
+      },
+      'path_test',
+    );
+  
+    expect(message).toMatchSnapshot();
+  });
+  
+  it('does not print code frame when noCodeFrame = true', () => {
+    readFileSync.mockImplementationOnce(() => 'throw new Error("Whoops!");');
+    const message = formatStackTrace(
+      `
+      at Object.<anonymous> (${slash(rootDir)}/file.js:1:7)
+      at Module._compile (internal/modules/cjs/loader.js:1158:30)
+      at Object.Module._extensions..js (internal/modules/cjs/loader.js:1178:10)
+      at Module.load (internal/modules/cjs/loader.js:1002:32)
+      at Function.Module._load (internal/modules/cjs/loader.js:901:14)
+      at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:74:12)
+  `,
+      {
+        rootDir,
+        testMatch: [],
+      },
+      {
+        noCodeFrame: true,
+        noStackTrace: false,
+      },
+      'path_test',
+    );
+  
+    expect(message).toMatchSnapshot();
+  });
+  
+  it('does not print codeframe when noStackTrace = true', () => {
+    readFileSync.mockImplementationOnce(() => 'throw new Error("Whoops!");');
+    const message = formatStackTrace(
+      `
+      at Object.<anonymous> (${slash(rootDir)}/file.js:1:7)
+      at Module._compile (internal/modules/cjs/loader.js:1158:30)
+      at Object.Module._extensions..js (internal/modules/cjs/loader.js:1178:10)
+      at Module.load (internal/modules/cjs/loader.js:1002:32)
+      at Function.Module._load (internal/modules/cjs/loader.js:901:14)
+      at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:74:12)
+  `,
+      {
+        rootDir,
+        testMatch: [],
+      },
+      {
+        noStackTrace: true,
+      },
+      'path_test',
+    );
+  
+    expect(message).toMatchSnapshot();
+  });
 });

--- a/packages/jest-message-util/src/__tests__/messages.test.ts
+++ b/packages/jest-message-util/src/__tests__/messages.test.ts
@@ -9,6 +9,7 @@
 import {readFileSync} from 'fs';
 import slash = require('slash');
 import tempy = require('tempy');
+import {wrap} from 'jest-snapshot-serializer-raw';
 import {formatExecError, formatResultsErrors, formatStackTrace} from '..';
 
 const rootDir = tempy.directory();
@@ -313,7 +314,7 @@ describe('getConsoleOutput', () => {
       'path_test',
     );
 
-    expect(message).toMatchSnapshot();
+    expect(wrap(message)).toMatchSnapshot();
   });
 
   it('does not print code frame when noCodeFrame = true', () => {
@@ -338,7 +339,7 @@ describe('getConsoleOutput', () => {
       'path_test',
     );
 
-    expect(message).toMatchSnapshot();
+    expect(wrap(message)).toMatchSnapshot();
   });
 
   it('does not print codeframe when noStackTrace = true', () => {
@@ -362,6 +363,6 @@ describe('getConsoleOutput', () => {
       'path_test',
     );
 
-    expect(message).toMatchSnapshot();
+    expect(wrap(message)).toMatchSnapshot();
   });
 });

--- a/packages/jest-message-util/src/__tests__/messages.test.ts
+++ b/packages/jest-message-util/src/__tests__/messages.test.ts
@@ -9,7 +9,6 @@
 import {readFileSync} from 'fs';
 import slash = require('slash');
 import tempy = require('tempy');
-import {wrap} from 'jest-snapshot-serializer-raw';
 import {formatExecError, formatResultsErrors, formatStackTrace} from '..';
 
 const rootDir = tempy.directory();
@@ -314,7 +313,7 @@ describe('getConsoleOutput', () => {
       'path_test',
     );
 
-    expect(wrap(message)).toMatchSnapshot();
+    expect(message).toMatchSnapshot();
   });
 
   it('does not print code frame when noCodeFrame = true', () => {
@@ -339,7 +338,7 @@ describe('getConsoleOutput', () => {
       'path_test',
     );
 
-    expect(wrap(message)).toMatchSnapshot();
+    expect(message).toMatchSnapshot();
   });
 
   it('does not print codeframe when noStackTrace = true', () => {
@@ -363,6 +362,6 @@ describe('getConsoleOutput', () => {
       'path_test',
     );
 
-    expect(wrap(message)).toMatchSnapshot();
+    expect(message).toMatchSnapshot();
   });
 });

--- a/packages/jest-message-util/src/__tests__/messages.test.ts
+++ b/packages/jest-message-util/src/__tests__/messages.test.ts
@@ -290,7 +290,7 @@ it('no stack', () => {
   expect(message).toMatchSnapshot();
 });
 
-describe('getConsoleOutput', () =>{
+describe('getConsoleOutput', () => {
   it('prints code frame and stacktrace', () => {
     readFileSync.mockImplementationOnce(() => 'throw new Error("Whoops!");');
     const message = formatStackTrace(
@@ -312,10 +312,10 @@ describe('getConsoleOutput', () =>{
       },
       'path_test',
     );
-  
+
     expect(message).toMatchSnapshot();
   });
-  
+
   it('does not print code frame when noCodeFrame = true', () => {
     readFileSync.mockImplementationOnce(() => 'throw new Error("Whoops!");');
     const message = formatStackTrace(
@@ -337,10 +337,10 @@ describe('getConsoleOutput', () =>{
       },
       'path_test',
     );
-  
+
     expect(message).toMatchSnapshot();
   });
-  
+
   it('does not print codeframe when noStackTrace = true', () => {
     readFileSync.mockImplementationOnce(() => 'throw new Error("Whoops!");');
     const message = formatStackTrace(
@@ -361,7 +361,7 @@ describe('getConsoleOutput', () =>{
       },
       'path_test',
     );
-  
+
     expect(message).toMatchSnapshot();
   });
 });

--- a/packages/jest-message-util/src/index.ts
+++ b/packages/jest-message-util/src/index.ts
@@ -283,9 +283,8 @@ export const formatStackTrace = (
     ? slash(path.relative(config.rootDir, testPath))
     : null;
 
-  if (!options.noCodeFrame) {
+  if ((!options.noStackTrace) && (!options.noCodeFrame)) {
     const topFrame = getTopFrame(lines);
-
     if (topFrame) {
       const {column, file: filename, line} = topFrame;
 

--- a/packages/jest-message-util/src/index.ts
+++ b/packages/jest-message-util/src/index.ts
@@ -283,7 +283,7 @@ export const formatStackTrace = (
     ? slash(path.relative(config.rootDir, testPath))
     : null;
 
-  if ((!options.noStackTrace) && (!options.noCodeFrame)) {
+  if (!options.noStackTrace && !options.noCodeFrame) {
     const topFrame = getTopFrame(lines);
     if (topFrame) {
       const {column, file: filename, line} = topFrame;


### PR DESCRIPTION


## Summary

When `--noStackTrace` flag is set, code frames should not be printed as mentioned [here](https://github.com/facebook/jest/pull/9741#issuecomment-617385240)

## Test plan

New snapshot test cases added.
