### PR TITLE
Update .vscode/launch.json settings

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
       "request": "launch",
       "name": "Jest Current File",
       "program": "${workspaceFolder}/node_modules/.bin/jest",
-      "args": ["${fileBasenameNoExtension}", "--config", "jest.config.js"],
+      "args": ["${fileBasenameNoExtension}"],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen",
       "disableOptimisticBPs": true,

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,10 +7,15 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Debug Jest with current test file",
-      "program": "${workspaceFolder}/packages/jest-cli/bin/jest.js",
-      "args": ["--runInBand", "${file}"],
-      "runtimeArgs": ["-r", "flow-remove-types/register"]
+      "name": "Jest Current File",
+      "program": "${workspaceFolder}/node_modules/.bin/jest",
+      "args": ["${fileBasenameNoExtension}", "--config", "jest.config.js"],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "disableOptimisticBPs": true,
+      "windows": {
+        "program": "${workspaceFolder}/node_modules/jest/bin/jest"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary

I've tried to use the existing setting but it was outdated and couldn't be used - it was referencing `flow-remove-types/register` which you no longer use. So I've updated it locally for the config recommended here: https://github.com/microsoft/vscode-recipes/tree/master/debugging-jest-tests#configure-launchjson-file-for-your-test-framework and used it with success. It differs slightly from what you had configured previously - I'm not too familiar with those options so I'm not in a position of adjusting the previous config (instead of just using a new one). 