### PR TITLE
Add an option to vscode settings to always use workspace TS

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,6 @@
   "jest.pathToJest": "yarn jest --",
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true
-  }
+  },
+  "typescript.tsdk": "node_modules/typescript/lib"
 }


### PR DESCRIPTION
## Summary

By default VSCode is using its own copy of TS instead of the workspace one. This is never something users want (when actually having their own TS) - not sure why VScode default has not been changed 🤷 Having it use the one built into VScode can cause ultimate confusion sometimes (e.g. seeing errors not reported by `tsc`)