### PR TITLE
Add an example for mocking non-default module export class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 ### Chore & Maintenance
 
+- `[docs]` Add an example for mocking non-default export class
+
 ### Performance
 
 - `[jest-resolve]` Update `resolve` to a version using native `realpath`, which is faster than the default JS implementation ([#9872](https://github.com/facebook/jest/pull/9872))

--- a/docs/Es6ClassMocks.md
+++ b/docs/Es6ClassMocks.md
@@ -262,6 +262,23 @@ jest.mock('./sound-player', () => {
 
 This will let us inspect usage of our mocked class, using `SoundPlayer.mock.calls`: `expect(SoundPlayer).toHaveBeenCalled();` or near-equivalent: `expect(SoundPlayer.mock.calls.length).toEqual(1);`
 
+### Mocking non default class exports
+
+If the class is the default export from the module then you need to return an object with the key that is the same as the module export name.
+
+```javascript
+import { SoundPlayer } from './sound-player';
+jest.mock('./sound-player', () => {
+  // Works and lets you check for constructor calls:
+  return {
+    SoundPlayer: jest.fn().mockImplementation(() => {
+      return { playSoundFile: () => {} }
+    })
+  }
+}
+});
+```
+
 ### Spying on methods of our class
 
 Our mocked class will need to provide any member functions (`playSoundFile` in the example) that will be called during our tests, or else we'll get an error for calling a function that doesn't exist. But we'll probably want to also spy on calls to those methods, to ensure that they were called with the expected parameters.

--- a/docs/Es6ClassMocks.md
+++ b/docs/Es6ClassMocks.md
@@ -267,14 +267,14 @@ This will let us inspect usage of our mocked class, using `SoundPlayer.mock.call
 If the class is **not** the default export from the module then you need to return an object with the key that is the same as the class export name.
 
 ```javascript
-import { SoundPlayer } from './sound-player';
+import {SoundPlayer} from './sound-player';
 jest.mock('./sound-player', () => {
   // Works and lets you check for constructor calls:
   return {
     SoundPlayer: jest.fn().mockImplementation(() => {
-      return { playSoundFile: () => {}};
-    });
-  }
+      return {playSoundFile: () => {}};
+    }),
+  };
 });
 ```
 

--- a/docs/Es6ClassMocks.md
+++ b/docs/Es6ClassMocks.md
@@ -272,10 +272,9 @@ jest.mock('./sound-player', () => {
   // Works and lets you check for constructor calls:
   return {
     SoundPlayer: jest.fn().mockImplementation(() => {
-      return { playSoundFile: () => {} }
-    })
+      return { playSoundFile: () => {}};
+    });
   }
-}
 });
 ```
 

--- a/docs/Es6ClassMocks.md
+++ b/docs/Es6ClassMocks.md
@@ -264,7 +264,7 @@ This will let us inspect usage of our mocked class, using `SoundPlayer.mock.call
 
 ### Mocking non default class exports
 
-If the class is the default export from the module then you need to return an object with the key that is the same as the module export name.
+If the class is **not** the default export from the module then you need to return an object with the key that is the same as the class export name.
 
 ```javascript
 import { SoundPlayer } from './sound-player';


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary
All examples for mocking ES6 classes assume that the class is exported as the default export. If that's not the case then mocking is done a little bit differently.

Users are confused about why the mock is not working `[*Exported function name] is not a constructor` is the error when you try to instantiate the mocked instance.

This pull request adds an example of how to mock a class which is not the default export from the module.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
