### PR TITLE
feat: Add test file path in process.env (#9884)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 - `[@jest/globals]` New package so Jest's globals can be explicitly imported ([#9801](https://github.com/facebook/jest/pull/9801))
+- `[jest-runner]` Add path to current test file in `process.env.JEST_TEST_PATH` ([#9886](https://github.com/facebook/jest/pull/9886))
 - `[jest-runtime]` Populate `require.cache` ([#9841](https://github.com/facebook/jest/pull/9841))
 
 ### Fixes

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -762,7 +762,7 @@ If you need to restrict your test-runner to only run in serial rather than being
 
 Default: `[]`
 
-A list of paths to modules that run some code to configure or set up the testing environment. Each setupFile will be run once per test file. Since every test runs in its own environment, these scripts will be executed in the testing environment immediately before executing the test code itself.
+A list of paths to modules that run some code to configure or set up the testing environment. Each setupFile will be run once per test file. The absolute path to test file that will be running after the current setupFile is accessible through `JEST_TEST_PATH` environment variable. Since every test runs in its own environment, these scripts will be executed in the testing environment immediately before executing the test code itself.
 
 It's also worth noting that `setupFiles` will execute _before_ [`setupFilesAfterEnv`](#setupfilesafterenv-array).
 
@@ -770,7 +770,7 @@ It's also worth noting that `setupFiles` will execute _before_ [`setupFilesAfter
 
 Default: `[]`
 
-A list of paths to modules that run some code to configure or set up the testing framework before each test file in the suite is executed. Since [`setupFiles`](#setupfiles-array) executes before the test framework is installed in the environment, this script file presents you the opportunity of running some code immediately after the test framework has been installed in the environment.
+A list of paths to modules that run some code to configure or set up the testing framework before each test file in the suite is executed. The absolute path to test file that will be running after the current setupFile is accessible through `JEST_TEST_PATH` environment variable. Since [`setupFiles`](#setupfiles-array) executes before the test framework is installed in the environment, this script file presents you the opportunity of running some code immediately after the test framework has been installed in the environment.
 
 If you want a path to be [relative to the root directory of your project](#rootdir-string), please include `<rootDir>` inside a path's string, like `"<rootDir>/a-configs-folder"`.
 

--- a/e2e/transform-linked-modules/ignored/symlink.js
+++ b/e2e/transform-linked-modules/ignored/symlink.js
@@ -1,1 +1,0 @@
-../package/index.js

--- a/packages/jest-runner/src/__tests__/testRunner.test.ts
+++ b/packages/jest-runner/src/__tests__/testRunner.test.ts
@@ -7,6 +7,7 @@
  */
 
 import {TestWatcher} from '@jest/core';
+import {Config} from '@jest/types';
 import TestRunner from '../index';
 
 let mockWorkerFarm;
@@ -82,4 +83,30 @@ test('assign process.env.JEST_WORKER_ID = 1 when in runInBand mode', async () =>
   );
 
   expect(process.env.JEST_WORKER_ID).toBe('1');
+});
+
+test('put absolute path to test file in process.env.JEST_TEST_PATH', async () => {
+  const globalConfig = {maxWorkers: 2} as Config.GlobalConfig;
+  const context = {
+    config: {} as Config.ProjectConfig,
+    hasteFS: null,
+    moduleMap: null,
+    resolver: null,
+  };
+
+  const paths: Array<string> = [];
+
+  await new TestRunner(globalConfig).runTests(
+    [
+      {context, path: '/path/file.test.js'},
+      {context, path: '/path/file2.test.js'},
+    ],
+    new TestWatcher({isWatchMode: true}),
+    async () => {},
+    async () => {},
+    async () => void paths.push(process.env.JEST_TEST_PATH),
+    {serial: true},
+  );
+
+  expect(paths).toEqual(['/path/file.test.js', '/path/file2.test.js']);
 });

--- a/packages/jest-runner/src/runTest.ts
+++ b/packages/jest-runner/src/runTest.ts
@@ -83,6 +83,8 @@ async function runTestInternal(
   resolver: Resolver,
   context?: TestRunnerContext,
 ): Promise<RunTestInternalResult> {
+  process.env.JEST_TEST_PATH = path;
+
   const testSource = fs.readFileSync(path, 'utf8');
   const docblockPragmas = docblock.parse(docblock.extract(testSource));
   const customEnvironment = docblockPragmas['jest-environment'];


### PR DESCRIPTION
## Summary

This PR adds population of `process.env.JEST_TEST_PATH` with absolute path to test file right after it starts executing. This makes it accessible in setup files, specified in `setupFiles` and `setupFilesAfterEnv` configuration options.

Closes #9884

## Test plan

![image](https://user-images.githubusercontent.com/59528510/80286538-a7b61a80-8734-11ea-8476-ac761a29a79d.png)

