### PR TITLE
[WIP] fix: ignore hidden files by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixes
 
+- `[jest-config]` [**BREAKING**] Ignore hidden files by default ([#9887](https://github.com/facebook/jest/pull/9887))
 - `[@jest/environment]` Make sure not to reference Jest types ([#9875](https://github.com/facebook/jest/pull/9875))
 - `[jest-message-util]` Code frame printing should respect `--noStackTrace` flag ([#9866](https://github.com/facebook/jest/pull/9866))
 - `[jest-runtime]` Support importing CJS from ESM using `import` statements ([#9850](https://github.com/facebook/jest/pull/9850))

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -499,11 +499,14 @@ _Note: If you provide module name without boundaries `^$` it may cause hard to s
 
 ### `modulePathIgnorePatterns` [array\<string>]
 
-Default: `[]`
+Default: `['<rootDir>/\\.']`
 
 An array of regexp pattern strings that are matched against all module paths before those paths are to be considered 'visible' to the module loader. If a given module's path matches any of the patterns, it will not be `require()`-able in the test environment.
 
-These pattern strings match against the full path. Use the `<rootDir>` string token to include the path to your project's root directory to prevent it from accidentally ignoring all of your files in different environments that may have different root directories. Example: `["<rootDir>/build/"]`.
+These pattern strings match against the full path. Use the `<rootDir>` string token to include the path to your project's root directory to prevent it from accidentally ignoring all of your files in different environments that may have different root directories. Example: `["<rootDir>/build/"]
+
+Note: By default jest ignores hidden files, but if you need not to ignore hidden files you can change this option to `[]` or any other value, so the default value will not be applied.
+`.
 
 ### `modulePaths` [array\<string>]
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -505,8 +505,7 @@ An array of regexp pattern strings that are matched against all module paths bef
 
 These pattern strings match against the full path. Use the `<rootDir>` string token to include the path to your project's root directory to prevent it from accidentally ignoring all of your files in different environments that may have different root directories. Example: `["<rootDir>/build/"]
 
-Note: By default jest ignores hidden files, but if you need not to ignore hidden files you can change this option to `[]` or any other value, so the default value will not be applied.
-`.
+Note: By default jest ignores hidden files, but if you need not to ignore hidden files you can change this option to `[]` or any other value, so the default value will not be applied .
 
 ### `modulePaths` [array\<string>]
 

--- a/e2e/__tests__/__snapshots__/showConfig.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/showConfig.test.ts.snap
@@ -36,7 +36,9 @@ exports[`--showConfig outputs config info and exits 1`] = `
         "node"
       ],
       "moduleNameMapper": [],
-      "modulePathIgnorePatterns": [],
+      "modulePathIgnorePatterns": [
+        "<<REPLACED_ROOT_DIR>>/\\\\."
+      ],
       "name": "[md5 hash]",
       "prettierPath": "prettier",
       "resetMocks": false,

--- a/packages/jest-cli/src/init/__tests__/__snapshots__/init.test.js.snap
+++ b/packages/jest-cli/src/init/__tests__/__snapshots__/init.test.js.snap
@@ -130,7 +130,9 @@ module.exports = {
   // moduleNameMapper: {},
 
   // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
-  // modulePathIgnorePatterns: [],
+  // modulePathIgnorePatterns: [
+  //   \\"<rootDir>/\\\\\\\\.\\"
+  // ],
 
   // Activates notifications for test results
   // notify: false,

--- a/packages/jest-config/src/Defaults.ts
+++ b/packages/jest-config/src/Defaults.ts
@@ -38,7 +38,7 @@ const defaultOptions: Config.DefaultOptions = {
   moduleDirectories: ['node_modules'],
   moduleFileExtensions: ['js', 'json', 'jsx', 'ts', 'tsx', 'node'],
   moduleNameMapper: {},
-  modulePathIgnorePatterns: [],
+  modulePathIgnorePatterns: ['<rootDir>/\\.'],
   noStackTrace: false,
   notify: false,
   notifyMode: 'failure-change',

--- a/packages/jest-config/src/__tests__/normalize.test.js
+++ b/packages/jest-config/src/__tests__/normalize.test.js
@@ -624,6 +624,25 @@ describe('testPathIgnorePatterns', () => {
 });
 
 describe('modulePathIgnorePatterns', () => {
+  it('defaults to ignore hidden files', () => {
+    const {options} = normalize({rootDir: '/root'}, {});
+
+    expect(options.modulePathIgnorePatterns).toEqual([
+      joinForPattern('', 'root', '\\.'),
+    ]);
+  });
+
+  it('is overwritten by argv', () => {
+    const {options} = normalize(
+      {rootDir: '/root'},
+      {
+        modulePathIgnorePatterns: [],
+      },
+    );
+
+    expect(options.modulePathIgnorePatterns).toEqual([]);
+  });
+
   it('does not normalize paths relative to rootDir', () => {
     // This is a list of patterns, so we can't assume any of them are
     // directories

--- a/packages/jest-config/src/normalize.ts
+++ b/packages/jest-config/src/normalize.ts
@@ -551,6 +551,10 @@ export default function normalize(
     delete options.testPathDirs;
   }
 
+  if (!options.modulePathIgnorePatterns) {
+    options.modulePathIgnorePatterns = DEFAULT_CONFIG.modulePathIgnorePatterns;
+  }
+
   if (!options.roots) {
     options.roots = [options.rootDir];
   }

--- a/packages/jest-core/src/__tests__/SearchSource.test.ts
+++ b/packages/jest-core/src/__tests__/SearchSource.test.ts
@@ -118,6 +118,7 @@ describe('SearchSource', () => {
       const {options: config} = normalize(
         {
           moduleFileExtensions: ['js', 'jsx', 'txt'],
+          modulePathIgnorePatterns: [],
           name,
           rootDir,
           testMatch: undefined,
@@ -142,6 +143,7 @@ describe('SearchSource', () => {
       const {options: config} = normalize(
         {
           moduleFileExtensions: ['js', 'jsx', 'txt'],
+          modulePathIgnorePatterns: [],
           name,
           rootDir,
           testMatch: ['**/not-really-a-test.txt', '!**/do-not-match-me.txt'],


### PR DESCRIPTION
## Summary
Fix #9829 

I was thinking about adding an e2e test to `package.json` bug described in the issue above, but I was in doubt because probably the `modulePathIgnorePatterns` config behavior was tested in one of the existing e2e tests, so I only did unit tests. But if you think it's good to have e2e tests I can add it.

## Test plan
Unit tests added.