### PR TITLE
Prints the Symbol name into the error message with a custom asymmetric matcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixes
 
+- `[expect]` Prints the Symbol name into the error message with a custom asymmetric matcher ([#9888](https://github.com/facebook/jest/pull/9888))
 - `[@jest/environment]` Make sure not to reference Jest types ([#9875](https://github.com/facebook/jest/pull/9875))
 - `[jest-message-util]` Code frame printing should respect `--noStackTrace` flag ([#9866](https://github.com/facebook/jest/pull/9866))
 - `[jest-runtime]` Support importing CJS from ESM using `import` statements ([#9850](https://github.com/facebook/jest/pull/9850))

--- a/packages/expect/src/__tests__/__snapshots__/extend.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/extend.test.js.snap
@@ -53,3 +53,15 @@ exports[`is available globally when matcher is unary 1`] = `expected 15 to be di
 exports[`is available globally when matcher is variadic 1`] = `expected 15 to be within range 1 - 3`;
 
 exports[`is ok if there is no message specified 1`] = `<r>No message was specified for this matcher.</>`;
+
+exports[`prints the Symbol into the error message 1`] = `
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
+
+<g>- Expected  - 1</>
+<r>+ Received  + 1</>
+
+<d>  Object {</>
+<g>-   "a": toBeSymbol<Symbol(bar)>,</>
+<r>+   "a": Symbol(foo),</>
+<d>  }</>
+`;

--- a/packages/expect/src/__tests__/extend.test.js
+++ b/packages/expect/src/__tests__/extend.test.js
@@ -23,6 +23,12 @@ jestExpect.extend({
 
     return {message, pass};
   },
+  toBeSymbol(actual, expected) {
+    const pass = actual === expected;
+    const message = () => `expected ${actual} to be Symbol ${expected}`;
+
+    return {message, pass};
+  },
   toBeWithinRange(actual, floor, ceiling) {
     const pass = actual >= floor && actual <= ceiling;
     const message = pass
@@ -136,4 +142,15 @@ it('defines asymmetric variadic matchers that can be prefixed by not', () => {
       value: jestExpect.not.toBeWithinRange(5, 7),
     }),
   ).not.toThrow();
+});
+
+it('prints the Symbol into the error message', () => {
+  const foo = Symbol('foo');
+  const bar = Symbol('bar');
+
+  expect(() =>
+    jestExpect({a: foo}).toEqual({
+      a: jestExpect.toBeSymbol(bar),
+    }),
+  ).toThrowErrorMatchingSnapshot();
 });

--- a/packages/expect/src/jestMatchersObject.ts
+++ b/packages/expect/src/jestMatchersObject.ts
@@ -78,7 +78,7 @@ export const setMatchers = (
         }
 
         toAsymmetricMatcher() {
-          return `${this.toString()}<${this.sample.join(', ')}>`;
+          return `${this.toString()}<${this.sample.map(String).join(', ')}>`;
         }
       }
 


### PR DESCRIPTION
…c matcher

Fixes #7534
