### PR TITLE
chore: remove dated node 6 reference from docs

### DIFF
--- a/website/versioned_docs/version-25.1/Troubleshooting.md
+++ b/website/versioned_docs/version-25.1/Troubleshooting.md
@@ -1,6 +1,7 @@
 ---
-id: troubleshooting
+id: version-25.1-troubleshooting
 title: Troubleshooting
+original_id: troubleshooting
 ---
 
 Uh oh, something went wrong? Use this guide to resolve issues with Jest.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

We've dropped node 6, but unlike the time we dropped node 4 we don't support v6 _at all_. Engine warnings should crop up, so let's just delete the section.

(added a 25.1 version so all 25 versions of the docs gets the section removed)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Ran website locally

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
