### PR TITLE
fix: do not transform internally imported files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - `[jest-resolve]` Update `resolve` to a version using native `realpath`, which is faster than the default JS implementation ([#9872](https://github.com/facebook/jest/pull/9872))
 - `[jest-resolve]` Pass custom cached `realpath` function to `resolve` ([#9873](https://github.com/facebook/jest/pull/9873))
 - `[jest-runtime]` Add `teardown` method to clear any caches when tests complete ([#9906](https://github.com/facebook/jest/pull/9906))
+- `[jest-runtime]` Do not pass files required internally through transformation when loading them ([#9900](https://github.com/facebook/jest/pull/9900))
 
 ## 25.4.0
 

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -641,7 +641,7 @@ class Runtime {
     moduleRegistry: ModuleRegistry,
   ) {
     if (path.extname(modulePath) === '.json') {
-      const text = stripBOM(this.readFile(modulePath));
+      const text = stripBOM(fs.readFileSync(modulePath, 'utf8'));
 
       const transformedFile = this._scriptTransformer.transformJson(
         modulePath,
@@ -1059,16 +1059,14 @@ class Runtime {
     filename: string,
     options?: InternalModuleOptions,
   ): string {
-    const source = this.readFile(filename);
-
     if (options?.isInternalModule) {
-      return source;
+      return this._cacheFS[filename] ?? fs.readFileSync(filename, 'utf8');
     }
 
     const transformedFile = this._scriptTransformer.transform(
       filename,
       this._getFullTransformationOptions(options),
-      source,
+      this._cacheFS[filename],
     );
 
     this._fileTransforms.set(filename, transformedFile);
@@ -1637,18 +1635,6 @@ class Runtime {
       xit: this._environment.global.xit,
       xtest: this._environment.global.xtest,
     };
-  }
-
-  private readFile(filename: Config.Path): string {
-    let source = this._cacheFS[filename];
-
-    if (!source) {
-      source = fs.readFileSync(filename, 'utf8');
-
-      this._cacheFS[filename] = source;
-    }
-
-    return source;
   }
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Any internal module should never be transformed at runtime, so let's just bail early rather than having `ScriptTransformer` skip them (or not, which is super wasteful).

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Green CI

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
