### PR TITLE
Fix dead link to coverage CLI option

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -376,7 +376,7 @@ class Index extends React.Component {
                   content: (
                     <translate>
                       Generate code coverage by adding the flag
-                      [`--coverage`](https://jestjs.io/docs/en/cli.html#coverage).
+                      [`--coverage`](https://jestjs.io/docs/en/cli.html#--coverageboolean).
                       No additional setup needed. Jest can collect code coverage
                       information from entire projects, including untested
                       files.


### PR DESCRIPTION
Fix dead link to coverage CLI option in website landing page (https://jestjs.io/)