### PR TITLE
fix: include missing `@types/graceful-fs` dep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- `[jest-haste-map]` Add missing `@types/graceful-fs` dependency
+
 ### Chore & Maintenance
 
 ### Performance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- `[jest-haste-map]` Add missing `@types/graceful-fs` dependency
+- `[jest-haste-map]` Add missing `@types/graceful-fs` dependency ([#9913](https://github.com/facebook/jest/pull/9913))
 
 ### Chore & Maintenance
 

--- a/packages/jest-haste-map/package.json
+++ b/packages/jest-haste-map/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@jest/types": "^25.5.0",
+    "@types/graceful-fs": "^4.1.2",
     "anymatch": "^3.0.3",
     "fb-watchman": "^2.0.0",
     "graceful-fs": "^4.2.4",
@@ -33,7 +34,6 @@
     "@jest/test-utils": "^25.5.0",
     "@types/anymatch": "^1.3.1",
     "@types/fb-watchman": "^2.0.0",
-    "@types/graceful-fs": "^4.1.2",
     "@types/micromatch": "^4.0.0",
     "@types/node": "*",
     "@types/sane": "^2.0.0",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

See https://github.com/microsoft/playwright-runner/pull/38

```sh-session
$ grep 'graceful-fs' `find packages -iname '*.d.ts'`
packages/jest-haste-map/build/types.d.ts:import type { Stats } from 'graceful-fs';
packages/jest-haste-map/build/ts3.4/types.d.ts:import { Stats } from 'graceful-fs';
```

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

🤷 

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
