### PR TITLE
chore: add `exports` field to all `package.json`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Chore & Maintenance
 
 - `[*]` [**BREAKING**] Only support Node LTS releases and Node 15 ([#10685](https://github.com/facebook/jest/pull/10685))
+- `[*]` [**BREAKING**] Add `exports` field to all `package.json`s ([#9921](https://github.com/facebook/jest/pull/9921))
 
 ### Performance
 

--- a/e2e/custom-resolver/resolver.js
+++ b/e2e/custom-resolver/resolver.js
@@ -5,10 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const {
-  default: defaultResolver,
-} = require('jest-resolve/build/defaultResolver');
-
 const exportedModules = new Map([
   ['foo', 'foo'],
   ['bar', 'bar'],
@@ -20,6 +16,6 @@ module.exports = (name, options) => {
   if (resolution) {
     return `${__dirname}/${resolution}.js`;
   } else {
-    return defaultResolver(name, options);
+    return options.defaultResolver(name, options);
   }
 };

--- a/packages/babel-jest/package.json
+++ b/packages/babel-jest/package.json
@@ -8,8 +8,12 @@
     "directory": "packages/babel-jest"
   },
   "license": "MIT",
-  "main": "build/index.js",
-  "types": "build/index.d.ts",
+  "main": "./build/index.js",
+  "types": "./build/index.d.ts",
+  "exports": {
+    ".": "./build/index.js",
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "@jest/transform": "^26.6.2",
     "@jest/types": "^26.6.2",

--- a/packages/babel-plugin-jest-hoist/package.json
+++ b/packages/babel-plugin-jest-hoist/package.json
@@ -10,8 +10,12 @@
     "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
   },
   "license": "MIT",
-  "main": "build/index.js",
-  "types": "build/index.d.ts",
+  "main": "./build/index.js",
+  "types": "./build/index.d.ts",
+  "exports": {
+    ".": "./build/index.js",
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "@babel/template": "^7.3.3",
     "@babel/types": "^7.3.3",

--- a/packages/babel-preset-jest/package.json
+++ b/packages/babel-preset-jest/package.json
@@ -7,7 +7,11 @@
     "directory": "packages/babel-preset-jest"
   },
   "license": "MIT",
-  "main": "index.js",
+  "main": "./index.js",
+  "exports": {
+    ".": "./index.js",
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "babel-plugin-jest-hoist": "^26.6.2",
     "babel-preset-current-node-syntax": "^1.0.0"

--- a/packages/diff-sequences/package.json
+++ b/packages/diff-sequences/package.json
@@ -18,8 +18,12 @@
   "engines": {
     "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
   },
-  "main": "build/index.js",
-  "types": "build/index.d.ts",
+  "main": "./build/index.js",
+  "types": "./build/index.d.ts",
+  "exports": {
+    ".": "./build/index.js",
+    "./package.json": "./package.json"
+  },
   "scripts": {
     "perf": "node --expose-gc perf/index.js"
   },

--- a/packages/expect/package.json
+++ b/packages/expect/package.json
@@ -7,8 +7,13 @@
     "directory": "packages/expect"
   },
   "license": "MIT",
-  "main": "build/index.js",
-  "types": "build/index.d.ts",
+  "main": "./build/index.js",
+  "types": "./build/index.d.ts",
+  "exports": {
+    ".": "./build/index.js",
+    "./package.json": "./package.json",
+    "./build/utils": "./build/utils.js"
+  },
   "dependencies": {
     "@jest/types": "^26.6.2",
     "ansi-styles": "^4.0.0",

--- a/packages/jest-changed-files/package.json
+++ b/packages/jest-changed-files/package.json
@@ -7,8 +7,12 @@
     "directory": "packages/jest-changed-files"
   },
   "license": "MIT",
-  "main": "build/index.js",
-  "types": "build/index.d.ts",
+  "main": "./build/index.js",
+  "types": "./build/index.d.ts",
+  "exports": {
+    ".": "./build/index.js",
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "@jest/types": "^26.6.2",
     "execa": "^4.0.0",

--- a/packages/jest-circus/package.json
+++ b/packages/jest-circus/package.json
@@ -7,8 +7,13 @@
     "directory": "packages/jest-circus"
   },
   "license": "MIT",
-  "main": "build/index.js",
-  "types": "build/index.d.ts",
+  "main": "./build/index.js",
+  "types": "./build/index.d.ts",
+  "exports": {
+    ".": "./build/index.js",
+    "./package.json": "./package.json",
+    "./runner": "./runner.js"
+  },
   "dependencies": {
     "@babel/traverse": "^7.1.0",
     "@jest/environment": "^26.6.2",

--- a/packages/jest-cli/package.json
+++ b/packages/jest-cli/package.json
@@ -2,8 +2,13 @@
   "name": "jest-cli",
   "description": "Delightful JavaScript Testing.",
   "version": "26.6.3",
-  "main": "build/index.js",
-  "types": "build/index.d.ts",
+  "main": "./build/index.js",
+  "types": "./build/index.d.ts",
+  "exports": {
+    ".": "./build/index.js",
+    "./package.json": "./package.json",
+    "./bin/jest": "./bin/jest.js"
+  },
   "dependencies": {
     "@jest/core": "^26.6.3",
     "@jest/test-result": "^26.6.2",

--- a/packages/jest-config/package.json
+++ b/packages/jest-config/package.json
@@ -7,8 +7,12 @@
     "directory": "packages/jest-config"
   },
   "license": "MIT",
-  "main": "build/index.js",
-  "types": "build/index.d.ts",
+  "main": "./build/index.js",
+  "types": "./build/index.d.ts",
+  "exports": {
+    ".": "./build/index.js",
+    "./package.json": "./package.json"
+  },
   "peerDependencies": {
     "ts-node": ">=9.0.0"
   },

--- a/packages/jest-console/package.json
+++ b/packages/jest-console/package.json
@@ -7,8 +7,12 @@
     "directory": "packages/jest-console"
   },
   "license": "MIT",
-  "main": "build/index.js",
-  "types": "build/index.d.ts",
+  "main": "./build/index.js",
+  "types": "./build/index.d.ts",
+  "exports": {
+    ".": "./build/index.js",
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "@jest/types": "^26.6.2",
     "@types/node": "*",

--- a/packages/jest-core/package.json
+++ b/packages/jest-core/package.json
@@ -2,8 +2,12 @@
   "name": "@jest/core",
   "description": "Delightful JavaScript Testing.",
   "version": "26.6.3",
-  "main": "build/jest.js",
-  "types": "build/jest.d.ts",
+  "main": "./build/jest.js",
+  "types": "./build/jest.d.ts",
+  "exports": {
+    ".": "./build/jest.js",
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "@jest/console": "^26.6.2",
     "@jest/reporters": "^26.6.2",

--- a/packages/jest-create-cache-key-function/package.json
+++ b/packages/jest-create-cache-key-function/package.json
@@ -16,8 +16,12 @@
     "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
   },
   "license": "MIT",
-  "main": "build/index.js",
-  "types": "build/index.d.ts",
+  "main": "./build/index.js",
+  "types": "./build/index.d.ts",
+  "exports": {
+    ".": "./build/index.js",
+    "./package.json": "./package.json"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/jest-diff/package.json
+++ b/packages/jest-diff/package.json
@@ -7,8 +7,12 @@
     "directory": "packages/jest-diff"
   },
   "license": "MIT",
-  "main": "build/index.js",
-  "types": "build/index.d.ts",
+  "main": "./build/index.js",
+  "types": "./build/index.d.ts",
+  "exports": {
+    ".": "./build/index.js",
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "chalk": "^4.0.0",
     "diff-sequences": "^26.6.2",

--- a/packages/jest-docblock/package.json
+++ b/packages/jest-docblock/package.json
@@ -7,8 +7,12 @@
     "directory": "packages/jest-docblock"
   },
   "license": "MIT",
-  "main": "build/index.js",
-  "types": "build/index.d.ts",
+  "main": "./build/index.js",
+  "types": "./build/index.d.ts",
+  "exports": {
+    ".": "./build/index.js",
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "detect-newline": "^3.0.0"
   },

--- a/packages/jest-each/package.json
+++ b/packages/jest-each/package.json
@@ -2,8 +2,12 @@
   "name": "jest-each",
   "version": "26.6.2",
   "description": "Parameterised tests for Jest",
-  "main": "build/index.js",
-  "types": "build/index.d.ts",
+  "main": "./build/index.js",
+  "types": "./build/index.d.ts",
+  "exports": {
+    ".": "./build/index.js",
+    "./package.json": "./package.json"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/facebook/jest.git",

--- a/packages/jest-environment-jsdom/package.json
+++ b/packages/jest-environment-jsdom/package.json
@@ -7,8 +7,12 @@
     "directory": "packages/jest-environment-jsdom"
   },
   "license": "MIT",
-  "main": "build/index.js",
-  "types": "build/index.d.ts",
+  "main": "./build/index.js",
+  "types": "./build/index.d.ts",
+  "exports": {
+    ".": "./build/index.js",
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "@jest/environment": "^26.6.2",
     "@jest/fake-timers": "^26.6.2",

--- a/packages/jest-environment-node/package.json
+++ b/packages/jest-environment-node/package.json
@@ -7,8 +7,12 @@
     "directory": "packages/jest-environment-node"
   },
   "license": "MIT",
-  "main": "build/index.js",
-  "types": "build/index.d.ts",
+  "main": "./build/index.js",
+  "types": "./build/index.d.ts",
+  "exports": {
+    ".": "./build/index.js",
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "@jest/environment": "^26.6.2",
     "@jest/fake-timers": "^26.6.2",

--- a/packages/jest-environment/package.json
+++ b/packages/jest-environment/package.json
@@ -7,8 +7,12 @@
     "directory": "packages/jest-environment"
   },
   "license": "MIT",
-  "main": "build/index.js",
-  "types": "build/index.d.ts",
+  "main": "./build/index.js",
+  "types": "./build/index.d.ts",
+  "exports": {
+    ".": "./build/index.js",
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "@jest/fake-timers": "^26.6.2",
     "@jest/types": "^26.6.2",

--- a/packages/jest-fake-timers/package.json
+++ b/packages/jest-fake-timers/package.json
@@ -7,8 +7,12 @@
     "directory": "packages/jest-fake-timers"
   },
   "license": "MIT",
-  "main": "build/index.js",
-  "types": "build/index.d.ts",
+  "main": "./build/index.js",
+  "types": "./build/index.d.ts",
+  "exports": {
+    ".": "./build/index.js",
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "@jest/types": "^26.6.2",
     "@sinonjs/fake-timers": "^6.0.1",

--- a/packages/jest-get-type/package.json
+++ b/packages/jest-get-type/package.json
@@ -11,8 +11,12 @@
     "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
   },
   "license": "MIT",
-  "main": "build/index.js",
-  "types": "build/index.d.ts",
+  "main": "./build/index.js",
+  "types": "./build/index.d.ts",
+  "exports": {
+    ".": "./build/index.js",
+    "./package.json": "./package.json"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/jest-globals/package.json
+++ b/packages/jest-globals/package.json
@@ -10,8 +10,12 @@
     "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
   },
   "license": "MIT",
-  "main": "build/index.js",
-  "types": "build/index.d.ts",
+  "main": "./build/index.js",
+  "types": "./build/index.d.ts",
+  "exports": {
+    ".": "./build/index.js",
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "@jest/environment": "^26.6.2",
     "@jest/types": "^26.6.2",

--- a/packages/jest-haste-map/package.json
+++ b/packages/jest-haste-map/package.json
@@ -7,8 +7,12 @@
     "directory": "packages/jest-haste-map"
   },
   "license": "MIT",
-  "main": "build/index.js",
-  "types": "build/index.d.ts",
+  "main": "./build/index.js",
+  "types": "./build/index.d.ts",
+  "exports": {
+    ".": "./build/index.js",
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "@jest/types": "^26.6.2",
     "@types/graceful-fs": "^4.1.2",

--- a/packages/jest-jasmine2/package.json
+++ b/packages/jest-jasmine2/package.json
@@ -7,8 +7,12 @@
     "directory": "packages/jest-jasmine2"
   },
   "license": "MIT",
-  "main": "build/index.js",
-  "types": "build/index.d.ts",
+  "main": "./build/index.js",
+  "types": "./build/index.d.ts",
+  "exports": {
+    ".": "./build/index.js",
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "@babel/traverse": "^7.1.0",
     "@jest/environment": "^26.6.2",

--- a/packages/jest-leak-detector/package.json
+++ b/packages/jest-leak-detector/package.json
@@ -7,8 +7,12 @@
     "directory": "packages/jest-leak-detector"
   },
   "license": "MIT",
-  "main": "build/index.js",
-  "types": "build/index.d.ts",
+  "main": "./build/index.js",
+  "types": "./build/index.d.ts",
+  "exports": {
+    ".": "./build/index.js",
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "jest-get-type": "^26.3.0",
     "pretty-format": "^26.6.2"

--- a/packages/jest-matcher-utils/package.json
+++ b/packages/jest-matcher-utils/package.json
@@ -11,8 +11,12 @@
     "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
   },
   "license": "MIT",
-  "main": "build/index.js",
-  "types": "build/index.d.ts",
+  "main": "./build/index.js",
+  "types": "./build/index.d.ts",
+  "exports": {
+    ".": "./build/index.js",
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "chalk": "^4.0.0",
     "jest-diff": "^26.6.2",

--- a/packages/jest-message-util/package.json
+++ b/packages/jest-message-util/package.json
@@ -10,8 +10,12 @@
     "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
   },
   "license": "MIT",
-  "main": "build/index.js",
-  "types": "build/index.d.ts",
+  "main": "./build/index.js",
+  "types": "./build/index.d.ts",
+  "exports": {
+    ".": "./build/index.js",
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "@babel/code-frame": "^7.0.0",
     "@jest/types": "^26.6.2",

--- a/packages/jest-mock/package.json
+++ b/packages/jest-mock/package.json
@@ -14,8 +14,12 @@
     "@types/node": "*"
   },
   "license": "MIT",
-  "main": "build/index.js",
-  "types": "build/index.d.ts",
+  "main": "./build/index.js",
+  "types": "./build/index.d.ts",
+  "exports": {
+    ".": "./build/index.js",
+    "./package.json": "./package.json"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/jest-phabricator/package.json
+++ b/packages/jest-phabricator/package.json
@@ -6,7 +6,11 @@
     "url": "https://github.com/facebook/jest.git",
     "directory": "packages/jest-phabricator"
   },
-  "types": "build/index.d.ts",
+  "types": "./build/index.d.ts",
+  "exports": {
+    ".": "./build/index.js",
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "@jest/test-result": "^26.6.2"
   },
@@ -14,7 +18,7 @@
     "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
   },
   "license": "MIT",
-  "main": "build/index.js",
+  "main": "./build/index.js",
   "publishConfig": {
     "access": "public"
   }

--- a/packages/jest-regex-util/package.json
+++ b/packages/jest-regex-util/package.json
@@ -13,8 +13,12 @@
     "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
   },
   "license": "MIT",
-  "main": "build/index.js",
-  "types": "build/index.d.ts",
+  "main": "./build/index.js",
+  "types": "./build/index.d.ts",
+  "exports": {
+    ".": "./build/index.js",
+    "./package.json": "./package.json"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/jest-repl/package.json
+++ b/packages/jest-repl/package.json
@@ -7,8 +7,13 @@
     "directory": "packages/jest-repl"
   },
   "license": "MIT",
-  "main": "build/index.js",
-  "types": "build/index.d.ts",
+  "main": "./build/index.js",
+  "types": "./build/index.d.ts",
+  "exports": {
+    ".": "./build/index.js",
+    "./package.json": "./package.json",
+    "./bin/jest-repl": "./bin/jest-repl.js"
+  },
   "dependencies": {
     "@jest/transform": "^26.6.2",
     "@jest/types": "^26.6.2",

--- a/packages/jest-reporters/package.json
+++ b/packages/jest-reporters/package.json
@@ -2,8 +2,12 @@
   "name": "@jest/reporters",
   "description": "Jest's reporters",
   "version": "26.6.2",
-  "main": "build/index.js",
-  "types": "build/index.d.ts",
+  "main": "./build/index.js",
+  "types": "./build/index.d.ts",
+  "exports": {
+    ".": "./build/index.js",
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "@bcoe/v8-coverage": "^0.2.3",
     "@jest/console": "^26.6.2",

--- a/packages/jest-resolve-dependencies/package.json
+++ b/packages/jest-resolve-dependencies/package.json
@@ -7,8 +7,12 @@
     "directory": "packages/jest-resolve-dependencies"
   },
   "license": "MIT",
-  "main": "build/index.js",
-  "types": "build/index.d.ts",
+  "main": "./build/index.js",
+  "types": "./build/index.d.ts",
+  "exports": {
+    ".": "./build/index.js",
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "@jest/types": "^26.6.2",
     "jest-regex-util": "^26.0.0",

--- a/packages/jest-resolve/package.json
+++ b/packages/jest-resolve/package.json
@@ -7,8 +7,12 @@
     "directory": "packages/jest-resolve"
   },
   "license": "MIT",
-  "main": "build/index.js",
-  "types": "build/index.d.ts",
+  "main": "./build/index.js",
+  "types": "./build/index.d.ts",
+  "exports": {
+    ".": "./build/index.js",
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "@jest/types": "^26.6.2",
     "chalk": "^4.0.0",

--- a/packages/jest-runner/package.json
+++ b/packages/jest-runner/package.json
@@ -7,8 +7,12 @@
     "directory": "packages/jest-runner"
   },
   "license": "MIT",
-  "main": "build/index.js",
-  "types": "build/index.d.ts",
+  "main": "./build/index.js",
+  "types": "./build/index.d.ts",
+  "exports": {
+    ".": "./build/index.js",
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "@jest/console": "^26.6.2",
     "@jest/environment": "^26.6.2",

--- a/packages/jest-runtime/package.json
+++ b/packages/jest-runtime/package.json
@@ -7,8 +7,13 @@
     "directory": "packages/jest-runtime"
   },
   "license": "MIT",
-  "main": "build/index.js",
-  "types": "build/index.d.ts",
+  "main": "./build/index.js",
+  "types": "./build/index.d.ts",
+  "exports": {
+    ".": "./build/index.js",
+    "./package.json": "./package.json",
+    "./bin/jest-runtime": "./bin/jest-runtime.js"
+  },
   "dependencies": {
     "@jest/console": "^26.6.2",
     "@jest/environment": "^26.6.2",

--- a/packages/jest-serializer/package.json
+++ b/packages/jest-serializer/package.json
@@ -17,8 +17,12 @@
     "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
   },
   "license": "MIT",
-  "main": "build/index.js",
-  "types": "build/index.d.ts",
+  "main": "./build/index.js",
+  "types": "./build/index.d.ts",
+  "exports": {
+    ".": "./build/index.js",
+    "./package.json": "./package.json"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/jest-snapshot/package.json
+++ b/packages/jest-snapshot/package.json
@@ -7,8 +7,12 @@
     "directory": "packages/jest-snapshot"
   },
   "license": "MIT",
-  "main": "build/index.js",
-  "types": "build/index.d.ts",
+  "main": "./build/index.js",
+  "types": "./build/index.d.ts",
+  "exports": {
+    ".": "./build/index.js",
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "@babel/types": "^7.0.0",
     "@jest/types": "^26.6.2",

--- a/packages/jest-snapshot/src/printSnapshot.ts
+++ b/packages/jest-snapshot/src/printSnapshot.ts
@@ -11,6 +11,7 @@ import chalk = require('chalk');
 // Temporary hack because getObjectSubset has known limitations,
 // is not in the public interface of the expect package,
 // and the long-term goal is to use a non-serialization diff.
+// Make sure to remove file from `exports` in `expect/package.json`.
 import {getObjectSubset} from 'expect/build/utils';
 import {
   DIFF_DELETE,

--- a/packages/jest-source-map/package.json
+++ b/packages/jest-source-map/package.json
@@ -7,8 +7,12 @@
     "directory": "packages/jest-source-map"
   },
   "license": "MIT",
-  "main": "build/index.js",
-  "types": "build/index.d.ts",
+  "main": "./build/index.js",
+  "types": "./build/index.d.ts",
+  "exports": {
+    ".": "./build/index.js",
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "callsites": "^3.0.0",
     "graceful-fs": "^4.2.4",

--- a/packages/jest-test-result/package.json
+++ b/packages/jest-test-result/package.json
@@ -7,8 +7,12 @@
     "directory": "packages/jest-test-result"
   },
   "license": "MIT",
-  "main": "build/index.js",
-  "types": "build/index.d.ts",
+  "main": "./build/index.js",
+  "types": "./build/index.d.ts",
+  "exports": {
+    ".": "./build/index.js",
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "@jest/console": "^26.6.2",
     "@jest/types": "^26.6.2",

--- a/packages/jest-test-sequencer/package.json
+++ b/packages/jest-test-sequencer/package.json
@@ -7,8 +7,12 @@
     "directory": "packages/jest-test-sequencer"
   },
   "license": "MIT",
-  "main": "build/index.js",
-  "types": "build/index.d.ts",
+  "main": "./build/index.js",
+  "types": "./build/index.d.ts",
+  "exports": {
+    ".": "./build/index.js",
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "@jest/test-result": "^26.6.2",
     "graceful-fs": "^4.2.4",

--- a/packages/jest-transform/package.json
+++ b/packages/jest-transform/package.json
@@ -7,8 +7,12 @@
     "directory": "packages/jest-transform"
   },
   "license": "MIT",
-  "main": "build/index.js",
-  "types": "build/index.d.ts",
+  "main": "./build/index.js",
+  "types": "./build/index.d.ts",
+  "exports": {
+    ".": "./build/index.js",
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "@babel/core": "^7.1.0",
     "@jest/types": "^26.6.2",

--- a/packages/jest-types/package.json
+++ b/packages/jest-types/package.json
@@ -10,8 +10,12 @@
     "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
   },
   "license": "MIT",
-  "main": "build/index.js",
-  "types": "build/index.d.ts",
+  "main": "./build/index.js",
+  "types": "./build/index.d.ts",
+  "exports": {
+    ".": "./build/index.js",
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "@types/istanbul-lib-coverage": "^2.0.0",
     "@types/istanbul-reports": "^3.0.0",

--- a/packages/jest-util/package.json
+++ b/packages/jest-util/package.json
@@ -7,8 +7,12 @@
     "directory": "packages/jest-util"
   },
   "license": "MIT",
-  "main": "build/index.js",
-  "types": "build/index.d.ts",
+  "main": "./build/index.js",
+  "types": "./build/index.d.ts",
+  "exports": {
+    ".": "./build/index.js",
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "@jest/types": "^26.6.2",
     "@types/node": "*",

--- a/packages/jest-validate/package.json
+++ b/packages/jest-validate/package.json
@@ -7,8 +7,12 @@
     "directory": "packages/jest-validate"
   },
   "license": "MIT",
-  "main": "build/index.js",
-  "types": "build/index.d.ts",
+  "main": "./build/index.js",
+  "types": "./build/index.d.ts",
+  "exports": {
+    ".": "./build/index.js",
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "@jest/types": "^26.6.2",
     "camelcase": "^6.0.0",

--- a/packages/jest-watcher/package.json
+++ b/packages/jest-watcher/package.json
@@ -2,8 +2,12 @@
   "name": "jest-watcher",
   "description": "Delightful JavaScript Testing.",
   "version": "26.6.2",
-  "main": "build/index.js",
-  "types": "build/index.d.ts",
+  "main": "./build/index.js",
+  "types": "./build/index.d.ts",
+  "exports": {
+    ".": "./build/index.js",
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "@jest/test-result": "^26.6.2",
     "@jest/types": "^26.6.2",

--- a/packages/jest-worker/package.json
+++ b/packages/jest-worker/package.json
@@ -7,8 +7,12 @@
     "directory": "packages/jest-worker"
   },
   "license": "MIT",
-  "main": "build/index.js",
-  "types": "build/index.d.ts",
+  "main": "./build/index.js",
+  "types": "./build/index.d.ts",
+  "exports": {
+    ".": "./build/index.js",
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "@types/node": "*",
     "merge-stream": "^2.0.0",

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -2,8 +2,13 @@
   "name": "jest",
   "description": "Delightful JavaScript Testing.",
   "version": "26.6.3",
-  "main": "build/jest.js",
-  "types": "build/jest.d.ts",
+  "main": "./build/jest.js",
+  "types": "./build/jest.d.ts",
+  "exports": {
+    ".": "./build/jest.js",
+    "./package.json": "./package.json",
+    "./bin/jest": "./bin/jest.js"
+  },
   "dependencies": {
     "@jest/core": "^26.6.3",
     "import-local": "^3.0.2",

--- a/packages/pretty-format/package.json
+++ b/packages/pretty-format/package.json
@@ -8,8 +8,12 @@
   },
   "license": "MIT",
   "description": "Stringify any JavaScript value.",
-  "main": "build/index.js",
-  "types": "build/index.d.ts",
+  "main": "./build/index.js",
+  "types": "./build/index.d.ts",
+  "exports": {
+    ".": "./build/index.js",
+    "./package.json": "./package.json"
+  },
   "author": "James Kyle <me@thejameskyle.com>",
   "dependencies": {
     "@jest/types": "^26.6.2",

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -3,8 +3,12 @@
   "version": "26.6.2",
   "private": true,
   "license": "MIT",
-  "main": "build/index.js",
-  "types": "build/index.d.ts",
+  "main": "./build/index.js",
+  "types": "./build/index.d.ts",
+  "exports": {
+    ".": "./build/index.js",
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "@jest/types": "^26.6.2",
     "@types/jest": "*",

--- a/scripts/buildUtils.js
+++ b/scripts/buildUtils.js
@@ -38,6 +38,23 @@ module.exports.getPackages = function getPackages() {
       nodeEngineRequirement,
       `Engine requirement in ${pkg.name} should match root`,
     );
+
+    assert.ok(pkg.exports, `Package ${pkg.name} is missing \`exports\` field`);
+    assert.deepStrictEqual(
+      pkg.exports,
+      {
+        '.': pkg.main,
+        './package.json': './package.json',
+        ...Object.values(pkg.bin || {}).reduce(
+          (mem, curr) =>
+            Object.assign(mem, {[curr.replace(/\.js$/, '')]: curr}),
+          {},
+        ),
+        ...(pkg.name === 'jest-circus' ? {'./runner': './runner.js'} : {}),
+        ...(pkg.name === 'expect' ? {'./build/utils': './build/utils.js'} : {}),
+      },
+      `Package ${pkg.name} does not export correct files`,
+    );
   });
 
   return packages;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

See https://nodejs.org/api/packages.html#packages_package_entry_points

This is breaking as node will throw on subpath access.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Green CI

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
