### PR TITLE
fix: don't run beforeAll/afterAll in skipped block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- `[jest-jasmine2]` Don't run `beforeAll` / `afterAll` in skipped describe block ([#9931](https://github.com/facebook/jest/pull/9931))
+
 ### Chore & Maintenance
 
 ### Performance

--- a/e2e/__tests__/skipBeforeAfterAll.test.ts
+++ b/e2e/__tests__/skipBeforeAfterAll.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+let hasBeforeAllRun = false;
+let hasAfterAllRun = false;
+
+describe.skip('in describe.skip', () => {
+  describe('in describe', () => {
+    beforeAll(() => {
+      hasBeforeAllRun = true;
+    });
+
+    afterAll(() => {
+      hasAfterAllRun = true;
+    });
+
+    test('it should be skipped', () => {
+      throw new Error('This should never happen');
+    });
+  });
+});
+
+test('describe.skip should not run beforeAll', () => {
+  expect(hasBeforeAllRun).toBe(false);
+});
+
+test('describe.skip should not run afterAll', () => {
+  expect(hasAfterAllRun).toBe(false);
+});
+
+let hasBeforeAllRun2 = false;
+let hasAfterAllRun2 = false;
+
+describe('in describe', () => {
+  beforeAll(() => {
+    hasBeforeAllRun2 = true;
+  });
+
+  afterAll(() => {
+    hasAfterAllRun2 = true;
+  });
+
+  test.skip('it should be skipped', () => {
+    throw new Error('This should never happen');
+  });
+});
+
+test('describe having only skipped test should not run beforeAll', () => {
+  expect(hasBeforeAllRun2).toBe(false);
+});
+
+test('describe having only skipped test should not run afterAll', () => {
+  expect(hasAfterAllRun2).toBe(false);
+});

--- a/e2e/__tests__/skipBeforeAfterAll.test.ts
+++ b/e2e/__tests__/skipBeforeAfterAll.test.ts
@@ -5,54 +5,15 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-let hasBeforeAllRun = false;
-let hasAfterAllRun = false;
+import * as path from 'path';
+import {json as runWithJson} from '../runJest';
 
-describe.skip('in describe.skip', () => {
-  describe('in describe', () => {
-    beforeAll(() => {
-      hasBeforeAllRun = true;
-    });
+const DIR = path.resolve(__dirname, '../before-all-skipped');
 
-    afterAll(() => {
-      hasAfterAllRun = true;
-    });
+test('correctly skip `beforeAll`s in skipped tests', () => {
+  const {json} = runWithJson(DIR);
 
-    test('it should be skipped', () => {
-      throw new Error('This should never happen');
-    });
-  });
-});
-
-test('describe.skip should not run beforeAll', () => {
-  expect(hasBeforeAllRun).toBe(false);
-});
-
-test('describe.skip should not run afterAll', () => {
-  expect(hasAfterAllRun).toBe(false);
-});
-
-let hasBeforeAllRun2 = false;
-let hasAfterAllRun2 = false;
-
-describe('in describe', () => {
-  beforeAll(() => {
-    hasBeforeAllRun2 = true;
-  });
-
-  afterAll(() => {
-    hasAfterAllRun2 = true;
-  });
-
-  test.skip('it should be skipped', () => {
-    throw new Error('This should never happen');
-  });
-});
-
-test('describe having only skipped test should not run beforeAll', () => {
-  expect(hasBeforeAllRun2).toBe(false);
-});
-
-test('describe having only skipped test should not run afterAll', () => {
-  expect(hasAfterAllRun2).toBe(false);
+  expect(json.numTotalTests).toBe(6);
+  expect(json.numPassedTests).toBe(4);
+  expect(json.numPendingTests).toBe(2);
 });

--- a/e2e/before-all-skipped/__tests__/beforeAllFiltered.test.js
+++ b/e2e/before-all-skipped/__tests__/beforeAllFiltered.test.js
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+let hasBeforeAllRun = false;
+let hasAfterAllRun = false;
+
+describe.skip('in describe.skip', () => {
+  describe('in describe', () => {
+    beforeAll(() => {
+      hasBeforeAllRun = true;
+    });
+
+    afterAll(() => {
+      hasAfterAllRun = true;
+    });
+
+    test('it should be skipped', () => {
+      throw new Error('This should never happen');
+    });
+  });
+});
+
+test('describe.skip should not run beforeAll', () => {
+  expect(hasBeforeAllRun).toBe(false);
+});
+
+test('describe.skip should not run afterAll', () => {
+  expect(hasAfterAllRun).toBe(false);
+});
+
+let hasBeforeAllRun2 = false;
+let hasAfterAllRun2 = false;
+
+describe('in describe', () => {
+  beforeAll(() => {
+    hasBeforeAllRun2 = true;
+  });
+
+  afterAll(() => {
+    hasAfterAllRun2 = true;
+  });
+
+  test.skip('it should be skipped', () => {
+    throw new Error('This should never happen');
+  });
+});
+
+test('describe having only skipped test should not run beforeAll', () => {
+  expect(hasBeforeAllRun2).toBe(false);
+});
+
+test('describe having only skipped test should not run afterAll', () => {
+  expect(hasAfterAllRun2).toBe(false);
+});

--- a/e2e/before-all-skipped/package.json
+++ b/e2e/before-all-skipped/package.json
@@ -1,0 +1,5 @@
+{
+  "jest": {
+    "testEnvironment": "node"
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #6755
Fixes #8379

## Test plan

`e2e/__tests__/skipBeforeAfterAll.test.ts` corresponds to #8379 example. I checked it failed on previous revision.