### PR TITLE
Remove leftover `providesModuleNodeModules`

### DIFF
--- a/packages/jest-core/src/__tests__/SearchSource.test.ts
+++ b/packages/jest-core/src/__tests__/SearchSource.test.ts
@@ -545,7 +545,6 @@ describe('SearchSource', () => {
               __dirname,
               '../../../jest-haste-map/src/__tests__/haste_impl.js',
             ),
-            providesModuleNodeModules: [],
           },
           name: 'SearchSource-findRelatedSourcesFromTestsInChangedFiles-tests',
           rootDir,


### PR DESCRIPTION
## Summary

Missed this one (probably was added recently).

## Test plan

No more validation warnings.