### PR TITLE
chore: remove dependency on `realpath-native`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `[*]` [**BREAKING**] TypeScript definitions requires a minimum of TypeScript v3.8 ([#9823](https://github.com/facebook/jest/pull/9823))
 - `[*]` [**BREAKING**] Drop support for Node 8 ([#9423](https://github.com/facebook/jest/pull/9423))
 - `[*]` Upgrade to chalk@4 ([#9752](https://github.com/facebook/jest/pull/9752))
+- `[*]` Remove usage of `realpath-native`
 - `[jest-runtime]` [**BREAKING**] Remove long-deprecated `require.requireActual` and `require.requireMock` methods ([#9854](https://github.com/facebook/jest/pull/9854))
 - `[expect, jest-mock, pretty-format]` [**BREAKING**] Remove `build-es5` from package ([#9945](https://github.com/facebook/jest/pull/9945))
 - `[jest-haste-map]` [**BREAKING**] removed `providesModuleNodeModules` ([#8535](https://github.com/facebook/jest/pull/8535))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - `[*]` [**BREAKING**] TypeScript definitions requires a minimum of TypeScript v3.8 ([#9823](https://github.com/facebook/jest/pull/9823))
 - `[*]` [**BREAKING**] Drop support for Node 8 ([#9423](https://github.com/facebook/jest/pull/9423))
 - `[*]` Upgrade to chalk@4 ([#9752](https://github.com/facebook/jest/pull/9752))
-- `[*]` Remove usage of `realpath-native`
+- `[*]` Remove usage of `realpath-native` ([#9952](https://github.com/facebook/jest/pull/9952))
 - `[jest-runtime]` [**BREAKING**] Remove long-deprecated `require.requireActual` and `require.requireMock` methods ([#9854](https://github.com/facebook/jest/pull/9854))
 - `[expect, jest-mock, pretty-format]` [**BREAKING**] Remove `build-es5` from package ([#9945](https://github.com/facebook/jest/pull/9945))
 - `[jest-haste-map]` [**BREAKING**] removed `providesModuleNodeModules` ([#8535](https://github.com/facebook/jest/pull/8535))

--- a/e2e/__tests__/__snapshots__/moduleNameMapper.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/moduleNameMapper.test.ts.snap
@@ -36,7 +36,7 @@ FAIL __tests__/index.js
       12 | module.exports = () => 'test';
       13 | 
 
-      at createNoMappedModuleFoundError (../../packages/jest-resolve/build/index.js:542:17)
+      at createNoMappedModuleFoundError (../../packages/jest-resolve/build/index.js:541:17)
       at Object.require (index.js:10:1)
 `;
 
@@ -65,6 +65,6 @@ FAIL __tests__/index.js
       12 | module.exports = () => 'test';
       13 | 
 
-      at createNoMappedModuleFoundError (../../packages/jest-resolve/build/index.js:542:17)
+      at createNoMappedModuleFoundError (../../packages/jest-resolve/build/index.js:541:17)
       at Object.require (index.js:10:1)
 `;

--- a/e2e/__tests__/__snapshots__/resolveNoFileExtensions.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/resolveNoFileExtensions.test.ts.snap
@@ -37,6 +37,6 @@ FAIL __tests__/test.js
         |                  ^
       9 | 
 
-      at Resolver.resolveModule (../../packages/jest-resolve/build/index.js:297:11)
+      at Resolver.resolveModule (../../packages/jest-resolve/build/index.js:296:11)
       at Object.require (index.js:8:18)
 `;

--- a/e2e/__tests__/hasteMapSize.test.ts
+++ b/e2e/__tests__/hasteMapSize.test.ts
@@ -7,11 +7,11 @@
 
 import {tmpdir} from 'os';
 import * as path from 'path';
-import {readFileSync} from 'graceful-fs';
+import {realpathSync} from 'graceful-fs';
 import HasteMap = require('jest-haste-map');
 import {cleanup, writeFiles} from '../Utils';
 
-const DIR = path.resolve(readFileSync.native(tmpdir()), 'haste_map_size');
+const DIR = path.resolve(realpathSync.native(tmpdir()), 'haste_map_size');
 
 beforeEach(() => {
   cleanup(DIR);

--- a/e2e/__tests__/hasteMapSize.test.ts
+++ b/e2e/__tests__/hasteMapSize.test.ts
@@ -7,11 +7,11 @@
 
 import {tmpdir} from 'os';
 import * as path from 'path';
+import {readFileSync} from 'graceful-fs';
 import HasteMap = require('jest-haste-map');
-import {sync as realpath} from 'realpath-native';
 import {cleanup, writeFiles} from '../Utils';
 
-const DIR = path.resolve(realpath(tmpdir()), 'haste_map_size');
+const DIR = path.resolve(readFileSync.native(tmpdir()), 'haste_map_size');
 
 beforeEach(() => {
   cleanup(DIR);

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "prettier": "^2.0.1",
     "progress": "^2.0.0",
     "promise": "^8.0.2",
-    "realpath-native": "^2.0.0",
     "resolve": "^1.15.0",
     "rimraf": "^3.0.0",
     "semver": "^6.3.0",

--- a/packages/jest-cli/package.json
+++ b/packages/jest-cli/package.json
@@ -17,7 +17,6 @@
     "jest-util": "^26.0.0-alpha.0",
     "jest-validate": "^26.0.0-alpha.0",
     "prompts": "^2.0.1",
-    "realpath-native": "^2.0.0",
     "yargs": "^15.3.1"
   },
   "devDependencies": {

--- a/packages/jest-cli/src/cli/index.ts
+++ b/packages/jest-cli/src/cli/index.ts
@@ -15,7 +15,7 @@ import {getVersion, runCLI} from '@jest/core';
 import chalk = require('chalk');
 import exit = require('exit');
 import yargs = require('yargs');
-import {sync as realpath} from 'realpath-native';
+import {realpathSync} from 'graceful-fs';
 import init from '../init';
 import * as args from './args';
 
@@ -97,7 +97,17 @@ const getProjectListFromCLIArgs = (
 
   if (!projects.length && process.platform === 'win32') {
     try {
-      projects.push(realpath(process.cwd()));
+      let path = process.cwd();
+
+      try {
+        path = realpathSync.native(path);
+      } catch (error) {
+        if (error.code !== 'ENOENT') {
+          throw error;
+        }
+      }
+
+      projects.push(path);
     } catch (err) {
       // do nothing, just catch error
       // process.binding('fs').realpath can throw, e.g. on mapped drives

--- a/packages/jest-cli/src/cli/index.ts
+++ b/packages/jest-cli/src/cli/index.ts
@@ -8,14 +8,13 @@
 import * as path from 'path';
 import type {Config} from '@jest/types';
 import type {AggregatedResult} from '@jest/test-result';
-import {clearLine} from 'jest-util';
+import {clearLine, tryRealpath} from 'jest-util';
 import {validateCLIOptions} from 'jest-validate';
 import {deprecationEntries} from 'jest-config';
 import {getVersion, runCLI} from '@jest/core';
 import chalk = require('chalk');
 import exit = require('exit');
 import yargs = require('yargs');
-import {realpathSync} from 'graceful-fs';
 import init from '../init';
 import * as args from './args';
 
@@ -97,17 +96,7 @@ const getProjectListFromCLIArgs = (
 
   if (!projects.length && process.platform === 'win32') {
     try {
-      let path = process.cwd();
-
-      try {
-        path = realpathSync.native(path);
-      } catch (error) {
-        if (error.code !== 'ENOENT') {
-          throw error;
-        }
-      }
-
-      projects.push(path);
+      projects.push(tryRealpath(process.cwd()));
     } catch (err) {
       // do nothing, just catch error
       // process.binding('fs').realpath can throw, e.g. on mapped drives

--- a/packages/jest-cli/src/init/index.ts
+++ b/packages/jest-cli/src/init/index.ts
@@ -9,7 +9,6 @@ import * as path from 'path';
 import * as fs from 'graceful-fs';
 import chalk = require('chalk');
 import prompts = require('prompts');
-import {sync as realpath} from 'realpath-native';
 import {constants} from 'jest-config';
 import defaultQuestions, {testScriptQuestion} from './questions';
 import {MalformedPackageJsonError, NotFoundPackageJsonError} from './errors';
@@ -34,9 +33,17 @@ type PromptsResults = {
 
 const getConfigFilename = (ext: string) => JEST_CONFIG_BASE_NAME + ext;
 
-export default async (
-  rootDir: string = realpath(process.cwd()),
-): Promise<void> => {
+let cwd = process.cwd();
+
+try {
+  cwd = fs.realpathSync.native(cwd);
+} catch (error) {
+  if (error.code !== 'ENOENT') {
+    throw error;
+  }
+}
+
+export default async (rootDir: string = cwd): Promise<void> => {
   // prerequisite checks
   const projectPackageJsonPath: string = path.join(rootDir, PACKAGE_JSON);
 

--- a/packages/jest-cli/src/init/index.ts
+++ b/packages/jest-cli/src/init/index.ts
@@ -10,6 +10,7 @@ import * as fs from 'graceful-fs';
 import chalk = require('chalk');
 import prompts = require('prompts');
 import {constants} from 'jest-config';
+import {tryRealpath} from 'jest-util';
 import defaultQuestions, {testScriptQuestion} from './questions';
 import {MalformedPackageJsonError, NotFoundPackageJsonError} from './errors';
 import generateConfigFile from './generate_config_file';
@@ -33,17 +34,9 @@ type PromptsResults = {
 
 const getConfigFilename = (ext: string) => JEST_CONFIG_BASE_NAME + ext;
 
-let cwd = process.cwd();
-
-try {
-  cwd = fs.realpathSync.native(cwd);
-} catch (error) {
-  if (error.code !== 'ENOENT') {
-    throw error;
-  }
-}
-
-export default async (rootDir: string = cwd): Promise<void> => {
+export default async (
+  rootDir: string = tryRealpath(process.cwd()),
+): Promise<void> => {
   // prerequisite checks
   const projectPackageJsonPath: string = path.join(rootDir, PACKAGE_JSON);
 

--- a/packages/jest-config/package.json
+++ b/packages/jest-config/package.json
@@ -27,8 +27,7 @@
     "jest-util": "^26.0.0-alpha.0",
     "jest-validate": "^26.0.0-alpha.0",
     "micromatch": "^4.0.2",
-    "pretty-format": "^26.0.0-alpha.0",
-    "realpath-native": "^2.0.0"
+    "pretty-format": "^26.0.0-alpha.0"
   },
   "devDependencies": {
     "@types/babel__core": "^7.0.4",

--- a/packages/jest-config/src/getCacheDirectory.ts
+++ b/packages/jest-config/src/getCacheDirectory.ts
@@ -10,10 +10,9 @@ import {tmpdir} from 'os';
 import type {Config} from '@jest/types';
 import {tryRealpath} from 'jest-util';
 
-const tmpdirPath = path.join(tryRealpath(tmpdir()), 'jest');
-
 const getCacheDirectory: () => Config.Path = () => {
   const {getuid} = process;
+  const tmpdirPath = path.join(tryRealpath(tmpdir()), 'jest');
   if (getuid == null) {
     return tmpdirPath;
   } else {

--- a/packages/jest-config/src/getCacheDirectory.ts
+++ b/packages/jest-config/src/getCacheDirectory.ts
@@ -8,7 +8,7 @@
 import * as path from 'path';
 import {tmpdir} from 'os';
 import type {Config} from '@jest/types';
-import {tryRealpath} from './utils';
+import {tryRealpath} from 'jest-util';
 
 const tmpdirPath = path.join(tryRealpath(tmpdir()), 'jest');
 

--- a/packages/jest-config/src/getCacheDirectory.ts
+++ b/packages/jest-config/src/getCacheDirectory.ts
@@ -7,11 +7,13 @@
 
 import * as path from 'path';
 import {tmpdir} from 'os';
-import {sync as realpath} from 'realpath-native';
+import type {Config} from '@jest/types';
+import {tryRealpath} from './utils';
 
-const getCacheDirectory = () => {
+const tmpdirPath = path.join(tryRealpath(tmpdir()), 'jest');
+
+const getCacheDirectory: () => Config.Path = () => {
   const {getuid} = process;
-  const tmpdirPath = path.join(realpath(tmpdir()), 'jest');
   if (getuid == null) {
     return tmpdirPath;
   } else {

--- a/packages/jest-config/src/index.ts
+++ b/packages/jest-config/src/index.ts
@@ -8,8 +8,9 @@
 import * as path from 'path';
 import * as fs from 'graceful-fs';
 import type {Config} from '@jest/types';
+import {tryRealpath} from 'jest-util';
 import chalk = require('chalk');
-import {isJSONString, replaceRootDirInPath, tryRealpath} from './utils';
+import {isJSONString, replaceRootDirInPath} from './utils';
 import normalize from './normalize';
 import resolveConfigPath from './resolveConfigPath';
 import readConfigFileAndSetRootDir from './readConfigFileAndSetRootDir';

--- a/packages/jest-config/src/index.ts
+++ b/packages/jest-config/src/index.ts
@@ -9,8 +9,7 @@ import * as path from 'path';
 import * as fs from 'graceful-fs';
 import type {Config} from '@jest/types';
 import chalk = require('chalk');
-import {sync as realpath} from 'realpath-native';
-import {isJSONString, replaceRootDirInPath} from './utils';
+import {isJSONString, replaceRootDirInPath, tryRealpath} from './utils';
 import normalize from './normalize';
 import resolveConfigPath from './resolveConfigPath';
 import readConfigFileAndSetRootDir from './readConfigFileAndSetRootDir';
@@ -295,7 +294,7 @@ export async function readConfigs(
   if (projects.length > 0) {
     const projectIsCwd =
       process.platform === 'win32'
-        ? projects[0] === realpath(process.cwd())
+        ? projects[0] === tryRealpath(process.cwd())
         : projects[0] === process.cwd();
 
     const parsedConfigs = await Promise.all(

--- a/packages/jest-config/src/normalize.ts
+++ b/packages/jest-config/src/normalize.ts
@@ -11,7 +11,7 @@ import {statSync} from 'graceful-fs';
 import {sync as glob} from 'glob';
 import type {Config} from '@jest/types';
 import {ValidationError, validate} from 'jest-validate';
-import {clearLine, replacePathSepForGlob} from 'jest-util';
+import {clearLine, replacePathSepForGlob, tryRealpath} from 'jest-util';
 import chalk = require('chalk');
 import micromatch = require('micromatch');
 import Resolver = require('jest-resolve');
@@ -30,7 +30,6 @@ import {
   getWatchPlugin,
   replaceRootDirInPath,
   resolve,
-  tryRealpath,
 } from './utils';
 import {DEFAULT_JS_PATTERN, DEFAULT_REPORTER_LABEL} from './constants';
 import {validateReporters} from './ReporterValidationErrors';

--- a/packages/jest-config/src/normalize.ts
+++ b/packages/jest-config/src/normalize.ts
@@ -14,7 +14,6 @@ import {ValidationError, validate} from 'jest-validate';
 import {clearLine, replacePathSepForGlob} from 'jest-util';
 import chalk = require('chalk');
 import micromatch = require('micromatch');
-import {sync as realpath} from 'realpath-native';
 import Resolver = require('jest-resolve');
 import {replacePathSepForRegex} from 'jest-regex-util';
 import merge = require('deepmerge');
@@ -31,6 +30,7 @@ import {
   getWatchPlugin,
   replaceRootDirInPath,
   resolve,
+  tryRealpath,
 } from './utils';
 import {DEFAULT_JS_PATTERN, DEFAULT_REPORTER_LABEL} from './constants';
 import {validateReporters} from './ReporterValidationErrors';
@@ -391,7 +391,7 @@ const normalizeRootDir = (
 
   try {
     // try to resolve windows short paths, ignoring errors (permission errors, mostly)
-    options.rootDir = realpath(options.rootDir);
+    options.rootDir = tryRealpath(options.rootDir);
   } catch (e) {
     // ignored
   }
@@ -955,7 +955,7 @@ export default function normalize(
 
   try {
     // try to resolve windows short paths, ignoring errors (permission errors, mostly)
-    newOptions.cwd = realpath(process.cwd());
+    newOptions.cwd = tryRealpath(process.cwd());
   } catch (e) {
     // ignored
   }

--- a/packages/jest-config/src/utils.ts
+++ b/packages/jest-config/src/utils.ts
@@ -10,7 +10,6 @@ import type {Config} from '@jest/types';
 import {ValidationError} from 'jest-validate';
 import Resolver = require('jest-resolve');
 import chalk = require('chalk');
-import {realpathSync} from 'graceful-fs';
 
 type ResolveOptions = {
   rootDir: Config.Path;
@@ -249,15 +248,3 @@ export const getSequencer = (
     prefix: 'jest-sequencer-',
     rootDir,
   });
-
-export function tryRealpath(path: Config.Path): Config.Path {
-  try {
-    path = realpathSync.native(path);
-  } catch (error) {
-    if (error.code !== 'ENOENT') {
-      throw error;
-    }
-  }
-
-  return path;
-}

--- a/packages/jest-config/src/utils.ts
+++ b/packages/jest-config/src/utils.ts
@@ -10,6 +10,7 @@ import type {Config} from '@jest/types';
 import {ValidationError} from 'jest-validate';
 import Resolver = require('jest-resolve');
 import chalk = require('chalk');
+import {realpathSync} from 'graceful-fs';
 
 type ResolveOptions = {
   rootDir: Config.Path;
@@ -248,3 +249,15 @@ export const getSequencer = (
     prefix: 'jest-sequencer-',
     rootDir,
   });
+
+export function tryRealpath(path: Config.Path): Config.Path {
+  try {
+    path = realpathSync.native(path);
+  } catch (error) {
+    if (error.code !== 'ENOENT') {
+      throw error;
+    }
+  }
+
+  return path;
+}

--- a/packages/jest-core/package.json
+++ b/packages/jest-core/package.json
@@ -29,7 +29,6 @@
     "jest-watcher": "^26.0.0-alpha.0",
     "micromatch": "^4.0.2",
     "p-each-series": "^2.1.0",
-    "realpath-native": "^2.0.0",
     "rimraf": "^3.0.0",
     "slash": "^3.0.0",
     "strip-ansi": "^6.0.0"

--- a/packages/jest-core/src/runJest.ts
+++ b/packages/jest-core/src/runJest.ts
@@ -7,7 +7,6 @@
 
 import * as path from 'path';
 import chalk = require('chalk');
-import {sync as realpath} from 'realpath-native';
 import {CustomConsole} from '@jest/console';
 import {interopRequireDefault} from 'jest-util';
 import exit = require('exit');
@@ -23,6 +22,7 @@ import {
 } from '@jest/test-result';
 import type TestSequencer from '@jest/test-sequencer';
 import type {ChangedFiles, ChangedFilesPromise} from 'jest-changed-files';
+import {realpathSync} from 'graceful-fs';
 import getNoTestsFoundMessage from './getNoTestsFoundMessage';
 import runGlobalHook from './runGlobalHook';
 import SearchSource from './SearchSource';
@@ -31,6 +31,18 @@ import type FailedTestsCache from './FailedTestsCache';
 import collectNodeHandles from './collectHandles';
 import type TestWatcher from './TestWatcher';
 import type {Filter, TestRunData} from './types';
+
+function tryRealpath(path: Config.Path): Config.Path {
+  try {
+    path = realpathSync.native(path);
+  } catch (error) {
+    if (error.code !== 'ENOENT') {
+      throw error;
+    }
+  }
+
+  return path;
+}
 
 const getTestPaths = async (
   globalConfig: Config.GlobalConfig,
@@ -100,7 +112,7 @@ const processResults = (
   }
   if (isJSON) {
     if (outputFile) {
-      const cwd = realpath(process.cwd());
+      const cwd = tryRealpath(process.cwd());
       const filePath = path.resolve(cwd, outputFile);
 
       fs.writeFileSync(filePath, JSON.stringify(formatTestResults(runResults)));

--- a/packages/jest-core/src/runJest.ts
+++ b/packages/jest-core/src/runJest.ts
@@ -8,7 +8,7 @@
 import * as path from 'path';
 import chalk = require('chalk');
 import {CustomConsole} from '@jest/console';
-import {interopRequireDefault} from 'jest-util';
+import {interopRequireDefault, tryRealpath} from 'jest-util';
 import exit = require('exit');
 import * as fs from 'graceful-fs';
 import {JestHook, JestHookEmitter} from 'jest-watcher';
@@ -22,7 +22,6 @@ import {
 } from '@jest/test-result';
 import type TestSequencer from '@jest/test-sequencer';
 import type {ChangedFiles, ChangedFilesPromise} from 'jest-changed-files';
-import {realpathSync} from 'graceful-fs';
 import getNoTestsFoundMessage from './getNoTestsFoundMessage';
 import runGlobalHook from './runGlobalHook';
 import SearchSource from './SearchSource';
@@ -31,18 +30,6 @@ import type FailedTestsCache from './FailedTestsCache';
 import collectNodeHandles from './collectHandles';
 import type TestWatcher from './TestWatcher';
 import type {Filter, TestRunData} from './types';
-
-function tryRealpath(path: Config.Path): Config.Path {
-  try {
-    path = realpathSync.native(path);
-  } catch (error) {
-    if (error.code !== 'ENOENT') {
-      throw error;
-    }
-  }
-
-  return path;
-}
 
 const getTestPaths = async (
   globalConfig: Config.GlobalConfig,

--- a/packages/jest-resolve/package.json
+++ b/packages/jest-resolve/package.json
@@ -11,6 +11,7 @@
   "types": "build/index.d.ts",
   "dependencies": {
     "@jest/types": "^26.0.0-alpha.0",
+    "jest-util": "^26.0.0-alpha.0",
     "chalk": "^4.0.0",
     "graceful-fs": "^4.2.4",
     "jest-pnp-resolver": "^1.2.1",

--- a/packages/jest-resolve/package.json
+++ b/packages/jest-resolve/package.json
@@ -15,7 +15,6 @@
     "graceful-fs": "^4.2.4",
     "jest-pnp-resolver": "^1.2.1",
     "read-pkg-up": "^7.0.1",
-    "realpath-native": "^2.0.0",
     "resolve": "^1.17.0",
     "slash": "^3.0.0"
   },

--- a/packages/jest-resolve/src/__tests__/resolve.test.ts
+++ b/packages/jest-resolve/src/__tests__/resolve.test.ts
@@ -234,8 +234,11 @@ describe('Resolver.getModulePaths() -> nodeModulesPaths()', () => {
     // pathstrings instead of actually trying to access the physical directory.
     // This test suite won't work otherwise, since we cannot make assumptions
     // about the test environment when it comes to absolute paths.
-    jest.doMock('realpath-native', () => ({
-      sync: (dirInput: string) => dirInput,
+    jest.doMock('graceful-fs', () => ({
+      ...jest.requireActual('graceful-fs'),
+      realPathSync: {
+        native: (dirInput: string) => dirInput,
+      },
     }));
   });
 

--- a/packages/jest-resolve/src/defaultResolver.ts
+++ b/packages/jest-resolve/src/defaultResolver.ts
@@ -8,19 +8,8 @@
 import * as fs from 'graceful-fs';
 import {sync as resolveSync} from 'resolve';
 import pnpResolver from 'jest-pnp-resolver';
+import {tryRealpath} from 'jest-util';
 import type {Config} from '@jest/types';
-
-function tryRealpath(path: Config.Path): Config.Path {
-  try {
-    path = fs.realpathSync.native(path);
-  } catch (error) {
-    if (error.code !== 'ENOENT') {
-      throw error;
-    }
-  }
-
-  return path;
-}
 
 type ResolverOptions = {
   basedir: Config.Path;

--- a/packages/jest-resolve/src/defaultResolver.ts
+++ b/packages/jest-resolve/src/defaultResolver.ts
@@ -7,9 +7,20 @@
 
 import * as fs from 'graceful-fs';
 import {sync as resolveSync} from 'resolve';
-import {sync as realpath} from 'realpath-native';
 import pnpResolver from 'jest-pnp-resolver';
 import type {Config} from '@jest/types';
+
+function tryRealpath(path: Config.Path): Config.Path {
+  try {
+    path = fs.realpathSync.native(path);
+  } catch (error) {
+    if (error.code !== 'ENOENT') {
+      throw error;
+    }
+  }
+
+  return path;
+}
 
 type ResolverOptions = {
   basedir: Config.Path;
@@ -95,17 +106,7 @@ function realpathCached(path: Config.Path): Config.Path {
     return result;
   }
 
-  try {
-    result = realpath(path);
-  } catch (error) {
-    if (error.code !== 'ENOENT') {
-      throw error;
-    }
-  }
-
-  if (!result) {
-    result = path;
-  }
+  result = tryRealpath(path);
 
   checkedRealpathPaths.set(path, result);
 

--- a/packages/jest-resolve/src/index.ts
+++ b/packages/jest-resolve/src/index.ts
@@ -8,7 +8,7 @@
 import * as path from 'path';
 import type {Config} from '@jest/types';
 import type {ModuleMap} from 'jest-haste-map';
-import {realpathSync} from 'graceful-fs';
+import {tryRealpath} from 'jest-util';
 import nodeModulesPaths from './nodeModulesPaths';
 import isBuiltinModule from './isBuiltinModule';
 import defaultResolver, {clearDefaultResolverCache} from './defaultResolver';
@@ -16,18 +16,6 @@ import type {ResolverConfig} from './types';
 import ModuleNotFoundError from './ModuleNotFoundError';
 import shouldLoadAsEsm, {clearCachedLookups} from './shouldLoadAsEsm';
 import chalk = require('chalk');
-
-function tryRealpath(path: Config.Path): Config.Path {
-  try {
-    path = realpathSync.native(path);
-  } catch (error) {
-    if (error.code !== 'ENOENT') {
-      throw error;
-    }
-  }
-
-  return path;
-}
 
 type FindNodeModuleConfig = {
   basedir: Config.Path;

--- a/packages/jest-resolve/src/index.ts
+++ b/packages/jest-resolve/src/index.ts
@@ -8,14 +8,26 @@
 import * as path from 'path';
 import type {Config} from '@jest/types';
 import type {ModuleMap} from 'jest-haste-map';
-import {sync as realpath} from 'realpath-native';
-import chalk = require('chalk');
+import {realpathSync} from 'graceful-fs';
 import nodeModulesPaths from './nodeModulesPaths';
 import isBuiltinModule from './isBuiltinModule';
 import defaultResolver, {clearDefaultResolverCache} from './defaultResolver';
 import type {ResolverConfig} from './types';
 import ModuleNotFoundError from './ModuleNotFoundError';
 import shouldLoadAsEsm, {clearCachedLookups} from './shouldLoadAsEsm';
+import chalk = require('chalk');
+
+function tryRealpath(path: Config.Path): Config.Path {
+  try {
+    path = realpathSync.native(path);
+  } catch (error) {
+    if (error.code !== 'ENOENT') {
+      throw error;
+    }
+  }
+
+  return path;
+}
 
 type FindNodeModuleConfig = {
   basedir: Config.Path;
@@ -41,8 +53,7 @@ namespace Resolver {
 const NATIVE_PLATFORM = 'native';
 
 // We might be inside a symlink.
-const cwd = process.cwd();
-const resolvedCwd = realpath(cwd) || cwd;
+const resolvedCwd = tryRealpath(process.cwd());
 const {NODE_PATH} = process.env;
 const nodePaths = NODE_PATH
   ? NODE_PATH.split(path.delimiter)

--- a/packages/jest-resolve/src/nodeModulesPaths.ts
+++ b/packages/jest-resolve/src/nodeModulesPaths.ts
@@ -9,24 +9,12 @@
 
 import * as path from 'path';
 import type {Config} from '@jest/types';
-import {realpathSync} from 'graceful-fs';
+import {tryRealpath} from 'jest-util';
 
 type NodeModulesPathsOptions = {
   moduleDirectory?: Array<string>;
   paths?: Array<Config.Path>;
 };
-
-function tryRealpath(path: Config.Path): Config.Path {
-  try {
-    path = realpathSync.native(path);
-  } catch (error) {
-    if (error.code !== 'ENOENT') {
-      throw error;
-    }
-  }
-
-  return path;
-}
 
 export default function nodeModulesPaths(
   basedir: Config.Path,

--- a/packages/jest-runtime/package.json
+++ b/packages/jest-runtime/package.json
@@ -32,7 +32,6 @@
     "jest-snapshot": "^26.0.0-alpha.0",
     "jest-util": "^26.0.0-alpha.0",
     "jest-validate": "^26.0.0-alpha.0",
-    "realpath-native": "^2.0.0",
     "slash": "^3.0.0",
     "strip-bom": "^4.0.0",
     "yargs": "^15.3.1"

--- a/packages/jest-runtime/src/cli/index.ts
+++ b/packages/jest-runtime/src/cli/index.ts
@@ -12,25 +12,13 @@ import yargs = require('yargs');
 import type {Config} from '@jest/types';
 import type {JestEnvironment} from '@jest/environment';
 import {CustomConsole} from '@jest/console';
-import {setGlobal} from 'jest-util';
+import {setGlobal, tryRealpath} from 'jest-util';
 import {validateCLIOptions} from 'jest-validate';
 import {deprecationEntries, readConfig} from 'jest-config';
-import {realpathSync} from 'graceful-fs';
 import {VERSION} from '../version';
 import type {Context} from '../types';
 import * as args from './args';
 
-function tryRealpath(path: Config.Path): Config.Path {
-  try {
-    path = realpathSync.native(path);
-  } catch (error) {
-    if (error.code !== 'ENOENT') {
-      throw error;
-    }
-  }
-
-  return path;
-}
 export async function run(
   cliArgv?: Config.Argv,
   cliInfo?: Array<string>,

--- a/packages/jest-transform/package.json
+++ b/packages/jest-transform/package.json
@@ -22,7 +22,6 @@
     "jest-util": "^26.0.0-alpha.0",
     "micromatch": "^4.0.2",
     "pirates": "^4.0.1",
-    "realpath-native": "^2.0.0",
     "slash": "^3.0.0",
     "source-map": "^0.6.1",
     "write-file-atomic": "^3.0.0"

--- a/packages/jest-transform/src/ScriptTransformer.ts
+++ b/packages/jest-transform/src/ScriptTransformer.ts
@@ -8,7 +8,12 @@
 import {createHash} from 'crypto';
 import * as path from 'path';
 import type {Config} from '@jest/types';
-import {createDirectory, interopRequireDefault, isPromise} from 'jest-util';
+import {
+  createDirectory,
+  interopRequireDefault,
+  isPromise,
+  tryRealpath,
+} from 'jest-util';
 import * as fs from 'graceful-fs';
 import {transformSync as babelTransform} from '@babel/core';
 // @ts-ignore: should just be `require.resolve`, but the tests mess that up
@@ -19,7 +24,6 @@ import stableStringify = require('fast-json-stable-stringify');
 import slash = require('slash');
 import {sync as writeFileAtomic} from 'write-file-atomic';
 import {addHook} from 'pirates';
-import {realpathSync} from 'graceful-fs';
 import type {
   Options,
   TransformResult,
@@ -28,18 +32,6 @@ import type {
 } from './types';
 import shouldInstrument from './shouldInstrument';
 import handlePotentialSyntaxError from './enhanceUnexpectedTokenMessage';
-
-function tryRealpath(path: Config.Path): Config.Path {
-  try {
-    path = realpathSync.native(path);
-  } catch (error) {
-    if (error.code !== 'ENOENT') {
-      throw error;
-    }
-  }
-
-  return path;
-}
 
 type ProjectCache = {
   configString: string;

--- a/packages/jest-transform/src/__tests__/script_transformer.test.js
+++ b/packages/jest-transform/src/__tests__/script_transformer.test.js
@@ -29,7 +29,12 @@ jest
       }),
     }),
   )
-  .mock('graceful-fs')
+  .mock('graceful-fs', () => ({
+    ...jest.requireActual('graceful-fs'),
+    realPathSync: {
+      native: dirInput => dirInput,
+    },
+  }))
   .mock('jest-haste-map', () => ({
     getCacheFilePath: (cacheDir, baseDir, version) => cacheDir + baseDir,
   }))

--- a/packages/jest-util/src/index.ts
+++ b/packages/jest-util/src/index.ts
@@ -21,5 +21,6 @@ export {default as testPathPatternToRegExp} from './testPathPatternToRegExp';
 import * as preRunMessage from './preRunMessage';
 export {default as pluralize} from './pluralize';
 export {default as formatTime} from './formatTime';
+export {default as tryRealpath} from './tryRealpath';
 
 export {preRunMessage, specialChars};

--- a/packages/jest-util/src/tryRealpath.ts
+++ b/packages/jest-util/src/tryRealpath.ts
@@ -1,0 +1,14 @@
+import {realpathSync} from 'graceful-fs';
+import type {Config} from '@jest/types';
+
+export default function tryRealpath(path: Config.Path): Config.Path {
+  try {
+    path = realpathSync.native(path);
+  } catch (error) {
+    if (error.code !== 'ENOENT') {
+      throw error;
+    }
+  }
+
+  return path;
+}

--- a/packages/jest-util/src/tryRealpath.ts
+++ b/packages/jest-util/src/tryRealpath.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 import {realpathSync} from 'graceful-fs';
 import type {Config} from '@jest/types';
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

We don't need it anymore as node 10 has `realpathSync.native`

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Green CI

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
