### PR TITLE
fix: handle `null` being passed to `createTransformer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixes
 
+- `[babel-jest]` Take a regression bug for createTransformer ([#9955](https://github.com/facebook/jest/pull/9955))
 - `[jest-circus, jest-console, jest-jasmine2, jest-reporters, jest-util, pretty-format]` Fix time durating formatting and consolidate time formatting code ([#9765](https://github.com/facebook/jest/pull/9765))
 - `[jest-circus]` [**BREAKING**] Fail tests if a test takes a done callback and have return values ([#9129](https://github.com/facebook/jest/pull/9129))
 - `[jest-circus]` [**BREAKING**] Throw a proper error if a test / hook is defined asynchronously ([#8096](https://github.com/facebook/jest/pull/8096))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixes
 
-- `[babel-jest]` Take a regression bug for createTransformer ([#9955](https://github.com/facebook/jest/pull/9955))
+- `[babel-jest]` Handle `null` being passed to `createTransformer` ([#9955](https://github.com/facebook/jest/pull/9955))
 - `[jest-circus, jest-console, jest-jasmine2, jest-reporters, jest-util, pretty-format]` Fix time durating formatting and consolidate time formatting code ([#9765](https://github.com/facebook/jest/pull/9765))
 - `[jest-circus]` [**BREAKING**] Fail tests if a test takes a done callback and have return values ([#9129](https://github.com/facebook/jest/pull/9129))
 - `[jest-circus]` [**BREAKING**] Throw a proper error if a test / hook is defined asynchronously ([#8096](https://github.com/facebook/jest/pull/8096))

--- a/e2e/__tests__/__snapshots__/transform.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/transform.test.ts.snap
@@ -6,7 +6,7 @@ FAIL __tests__/ignoredFile.test.js
 
     babel-jest: Babel ignores __tests__/ignoredFile.test.js - make sure to include the file in Jest's transformIgnorePatterns as well.
 
-      at loadBabelConfig (../../../packages/babel-jest/build/index.js:178:13)
+      at loadBabelConfig (../../../packages/babel-jest/build/index.js:180:13)
 `;
 
 exports[`babel-jest instruments only specific files and collects coverage 1`] = `

--- a/packages/babel-jest/src/__tests__/index.ts
+++ b/packages/babel-jest/src/__tests__/index.ts
@@ -97,3 +97,21 @@ describe('caller option correctly merges from defaults and options', () => {
     );
   });
 });
+
+test('can pass null to createTransformer', () => {
+  const transformer = babelJest.createTransformer(null);
+  transformer.process(sourceString, 'dummy_path.js', makeProjectConfig(), {
+    instrument: false,
+  });
+
+  expect(loadPartialConfig).toHaveBeenCalledTimes(1);
+  expect(loadPartialConfig).toHaveBeenCalledWith(
+    expect.objectContaining({
+      caller: {
+        name: 'babel-jest',
+        supportsDynamicImport: false,
+        supportsStaticESM: false,
+      },
+    }),
+  );
+});

--- a/packages/babel-jest/src/index.ts
+++ b/packages/babel-jest/src/index.ts
@@ -41,8 +41,9 @@ interface BabelJestTransformOptions extends TransformOptions {
 }
 
 const createTransformer = (
-  inputOptions: TransformOptions = {},
+  userOptions?: TransformOptions | null,
 ): BabelJestTransformer => {
+  const inputOptions: TransformOptions = userOptions ?? {};
   const options: BabelJestTransformOptions = {
     ...inputOptions,
     caller: {


### PR DESCRIPTION
## Summary

I took a regression bug in babel-jest. 
The regression bug occurs since https://github.com/facebook/jest/commit/bb720d2e180e15b0d0962d255bb8f76901da4a66#diff-ad0be0b5e1f4711c408a42bdbea512bcR43-R57 .

fixes https://github.com/facebook/jest/issues/9926