### PR TITLE
Float sig fig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@
 
 ### Performance
 
+## float_sig_fig
+
+### Features
+
+- `[expect]` Added  `toBeCloseToSigFig` matcher for matching real numbers in scientific notation.
+
+### Chore & Maintenance
+
+- `[docs]` Added toBeCloseToSigFig to "Using Matchers" and to "ExpectAPI"
+
 ## 25.5.2
 
 ### Fixes

--- a/docs/ExpectAPI.md
+++ b/docs/ExpectAPI.md
@@ -877,6 +877,20 @@ test('adding works sanely with decimals', () => {
 
 Because floating point errors are the problem that `toBeCloseTo` solves, it does not support big integer values.
 
+
+
+### `.toBeCloseToSigFig(number, sigFig?)`
+
+Use `toBeCloseToSigFig` to compare floating point numbers to be accurate to within a certain number of significant figures.
+
+This would be the natural choice for comparing real numbers thought of in scientific notation, eg  1.234e5  (1234000.0)
+
+`toBeCloseToSigFig` checks that the order of magnitude (the number after the 'e') is identcal and that the significand (the number before the e), when expressed in normalized scientific form (i.e. one digit shown before the decimal point), matches to within `sigFig` significant figures.
+
+`toBeCloseToSigFig` defaults to checking to 3 significant figures (equivilent to the behaviousr of `toBeCloseTo`) if the optional `sigFig` arguement is not given.  
+Note, `sigFig` must be positive.
+
+
 ### `.toBeDefined()`
 
 Use `.toBeDefined` to check that a variable is not undefined. For example, if you want to check that a function `fetchNewFlavorIdea()` returns _something_, you can write:

--- a/docs/UsingMatchers.md
+++ b/docs/UsingMatchers.md
@@ -103,6 +103,17 @@ test('adding floating point numbers', () => {
 });
 ```
 
+An alternative method for comparing floating points, `toBeCloseToSigFig` is available checking for floating points numbers contemplated in scientific notation to a number of significant figures.
+
+```js
+test('adding floating point numbers', () => {
+  const value = 1e5 + 23400;
+  expect(value).toBeCloseTo(1.234e5, 4);
+});
+```
+
+
+
 ## Strings
 
 You can check strings against regular expressions with `toMatch`:

--- a/docs/UsingMatchers.md
+++ b/docs/UsingMatchers.md
@@ -108,7 +108,7 @@ An alternative method for comparing floating points, `toBeCloseToSigFig` is avai
 ```js
 test('adding floating point numbers', () => {
   const value = 1e5 + 23400;
-  expect(value).toBeCloseTo(1.234e5, 4);
+  expect(value).toBeCloseToSigFig(1.234e5, 4);
 });
 ```
 

--- a/packages/expect/src/print.ts
+++ b/packages/expect/src/print.ts
@@ -89,6 +89,40 @@ export const printCloseTo = (
   );
 };
 
+export const printCloseToSigFig = (
+  receivedMagnitude: number,
+  expectedMagnitude: number,
+  allowableMantissaDiff: number,
+  receivedMantissaDiff: number,
+  precision: number,
+  isNot: boolean,
+): string => {
+  const allowableMantissaDiffString =
+    stringify(allowableMantissaDiff).includes('NaN') ||
+    stringify(allowableMantissaDiff).includes('Infinity')
+      ? stringify(allowableMantissaDiff)
+      : allowableMantissaDiff.toFixed(precision + 1);
+
+  const receivedMantissaDiffString =
+    stringify(receivedMantissaDiff).includes('NaN') ||
+    stringify(receivedMantissaDiff).includes('Infinity')
+      ? stringify(receivedMantissaDiff)
+      : receivedMantissaDiff.toFixed(precision + 1);
+
+  return (
+    `Order of magnitude: ${
+      receivedMagnitude == expectedMagnitude ? '    ' : 'not   '
+    } equal \n` +
+    `Expected precision:  ${isNot ? '    ' : ''}  ${stringify(precision)}\n` +
+    `Expected mantissa difference: ${isNot ? 'not ' : ''}< ${EXPECTED_COLOR(
+      allowableMantissaDiffString,
+    )}\n` +
+    `Expected mantissa difference: ${isNot ? '    ' : ''}  ${RECEIVED_COLOR(
+      receivedMantissaDiffString,
+    )}`
+  );
+};
+
 export const printExpectedConstructorName = (
   label: string,
   expected: Function,


### PR DESCRIPTION
…g scientific notation

## Summary

Added an alternative method for comparing floating points, `toBeCloseToSigFig`  for floating points numbers contemplated in scientific notation to a number of significant figures.  This should be a useful addition for anyone using jest to test engineering/scientific software.

## Test plan

.toBeCloseToSigFig added to matchers.test.js, based on the tests for .toBeCloseTo
