### PR TITLE
chore: cleanup getConsoleOutput arguments

### DIFF
--- a/packages/jest-console/src/getConsoleOutput.ts
+++ b/packages/jest-console/src/getConsoleOutput.ts
@@ -6,24 +6,15 @@
  */
 
 import chalk = require('chalk');
-import {
-  StackTraceConfig,
-  StackTraceOptions,
-  formatStackTrace,
-} from 'jest-message-util';
+import {StackTraceOptions, formatStackTrace} from 'jest-message-util';
+import type {Config} from '@jest/types';
 import type {ConsoleBuffer} from './types';
 
-export default (
-  // TODO: remove in 26
-  root: string,
+export default function getConsoleOutput(
   verbose: boolean,
   buffer: ConsoleBuffer,
-  // TODO: make mandatory and take Config.ProjectConfig in 26
-  config: StackTraceConfig = {
-    rootDir: root,
-    testMatch: [],
-  },
-): string => {
+  config: Config.ProjectConfig,
+): string {
   const TITLE_INDENT = verbose ? '  ' : '    ';
   const CONSOLE_INDENT = TITLE_INDENT + '  ';
 
@@ -69,4 +60,4 @@ export default (
   }, '');
 
   return logEntries.trimRight() + '\n';
-};
+}

--- a/packages/jest-reporters/src/default_reporter.ts
+++ b/packages/jest-reporters/src/default_reporter.ts
@@ -179,7 +179,6 @@ export default class DefaultReporter extends BaseReporter {
           TITLE_BULLET +
           'Console\n\n' +
           getConsoleOutput(
-            config.cwd,
             !!this._globalConfig.verbose,
             result.console,
             config,

--- a/packages/jest-runner/src/runTest.ts
+++ b/packages/jest-runner/src/runTest.ts
@@ -116,7 +116,6 @@ async function runTestInternal(
   const consoleOut = globalConfig.useStderr ? process.stderr : process.stdout;
   const consoleFormatter = (type: LogType, message: LogMessage) =>
     getConsoleOutput(
-      config.cwd,
       !!globalConfig.verbose,
       // 4 = the console call is buried 4 stack frames deep
       BufferedConsole.write([], type, message, 4),


### PR DESCRIPTION
## Summary

Addressing TODO, remove `root` from `getConsoleOutput`, require full config.

## Test plan

CI
