### PR TITLE
fix: Control no diff message color with diff options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - `[jest-jasmine2]` Stop adding `:` after an error that has no message ([#9990](https://github.com/facebook/jest/pull/9990))
+- `[jest-diff]` Control no diff message color with `commonColor` in diff options ([#9997](https://github.com/facebook/jest/pull/9997))
 
 ### Chore & Maintenance
 

--- a/packages/jest-diff/src/__tests__/__snapshots__/diff.test.ts.snap
+++ b/packages/jest-diff/src/__tests__/__snapshots__/diff.test.ts.snap
@@ -249,8 +249,10 @@ exports[`options change color diffStringsUnified 1`] = `
 <g>- changed <b>from</></>
 <r>+ changed <b>to</></>
 <r>+ insert</>
-<d>  common</>
+<y>  common</>
 `;
+
+exports[`options change color no diff 1`] = `<y>Compared values have no visual difference.</>`;
 
 exports[`options change indicators diff 1`] = `
 <g>< Expected</>

--- a/packages/jest-diff/src/__tests__/diff.test.ts
+++ b/packages/jest-diff/src/__tests__/diff.test.ts
@@ -14,12 +14,11 @@ import {diffLinesUnified, diffLinesUnified2} from '../diffLines';
 import {noColor} from '../normalizeDiffOptions';
 import {diffStringsUnified} from '../printDiffs';
 import {DiffOptions} from '../types';
+import {NO_DIFF_MESSAGE} from '../constants';
 
 const optionsCounts: DiffOptions = {
   includeChangeCounts: true,
 };
-
-const NO_DIFF_MESSAGE = 'Compared values have no visual difference.';
 
 // Use only in toBe assertions for edge case messages.
 const stripped = (a: unknown, b: unknown) => stripAnsi(diff(a, b) || '');
@@ -975,6 +974,7 @@ describe('options', () => {
   describe('change color', () => {
     const options = {
       changeColor: chalk.bold,
+      commonColor: chalk.yellow,
     };
 
     test('diffStringsUnified', () => {
@@ -982,16 +982,24 @@ describe('options', () => {
       const bChanged = b.join('\n').replace('change', 'changed');
       expect(diffStringsUnified(aChanged, bChanged, options)).toMatchSnapshot();
     });
+
+    test('no diff', () => {
+      expect(diff(a, a, options)).toMatchSnapshot();
+    });
   });
 
   describe('common', () => {
     const options = {
-      commonColor: line => line,
+      commonColor: noColor,
       commonIndicator: '=',
     };
 
     test('diff', () => {
       expect(diff(a, b, options)).toMatchSnapshot();
+    });
+
+    test('no diff', () => {
+      expect(diff(a, a, options)).toBe(NO_DIFF_MESSAGE);
     });
   });
 

--- a/packages/jest-diff/src/constants.ts
+++ b/packages/jest-diff/src/constants.ts
@@ -5,13 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import chalk = require('chalk');
+export const NO_DIFF_MESSAGE = 'Compared values have no visual difference.';
 
-export const NO_DIFF_MESSAGE = chalk.dim(
-  'Compared values have no visual difference.',
-);
-
-export const SIMILAR_MESSAGE = chalk.dim(
+export const SIMILAR_MESSAGE =
   'Compared values serialize to the same structure.\n' +
-    'Printing internal object structure without calling `toJSON` instead.',
-);
+  'Printing internal object structure without calling `toJSON` instead.';

--- a/packages/jest-diff/src/index.ts
+++ b/packages/jest-diff/src/index.ts
@@ -9,6 +9,7 @@ import prettyFormat = require('pretty-format');
 import chalk = require('chalk');
 import getType = require('jest-get-type');
 import {DIFF_DELETE, DIFF_EQUAL, DIFF_INSERT, Diff} from './cleanupSemantic';
+import {normalizeDiffOptions} from './normalizeDiffOptions';
 import {diffLinesRaw, diffLinesUnified, diffLinesUnified2} from './diffLines';
 import {diffStringsRaw, diffStringsUnified} from './printDiffs';
 import {NO_DIFF_MESSAGE, SIMILAR_MESSAGE} from './constants';
@@ -19,6 +20,11 @@ export type {DiffOptions, DiffOptionsColor} from './types';
 export {diffLinesRaw, diffLinesUnified, diffLinesUnified2};
 export {diffStringsRaw, diffStringsUnified};
 export {DIFF_DELETE, DIFF_EQUAL, DIFF_INSERT, Diff};
+
+const getCommonMessage = (message: string, options?: DiffOptions) => {
+  const {commonColor} = normalizeDiffOptions(options);
+  return commonColor(message);
+};
 
 const {
   AsymmetricMatcher,
@@ -53,7 +59,7 @@ const FALLBACK_FORMAT_OPTIONS_0 = {...FALLBACK_FORMAT_OPTIONS, indent: 0};
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 function diff(a: any, b: any, options?: DiffOptions): string | null {
   if (Object.is(a, b)) {
-    return NO_DIFF_MESSAGE;
+    return getCommonMessage(NO_DIFF_MESSAGE, options);
   }
 
   const aType = getType(a);
@@ -109,7 +115,7 @@ function comparePrimitive(
   const aFormat = prettyFormat(a, FORMAT_OPTIONS);
   const bFormat = prettyFormat(b, FORMAT_OPTIONS);
   return aFormat === bFormat
-    ? NO_DIFF_MESSAGE
+    ? getCommonMessage(NO_DIFF_MESSAGE, options)
     : diffLinesUnified(aFormat.split('\n'), bFormat.split('\n'), options);
 }
 
@@ -128,13 +134,14 @@ function compareObjects(
 ) {
   let difference;
   let hasThrown = false;
+  const noDiffMessage = getCommonMessage(NO_DIFF_MESSAGE, options);
 
   try {
     const aCompare = prettyFormat(a, FORMAT_OPTIONS_0);
     const bCompare = prettyFormat(b, FORMAT_OPTIONS_0);
 
     if (aCompare === bCompare) {
-      difference = NO_DIFF_MESSAGE;
+      difference = noDiffMessage;
     } else {
       const aDisplay = prettyFormat(a, FORMAT_OPTIONS);
       const bDisplay = prettyFormat(b, FORMAT_OPTIONS);
@@ -153,12 +160,12 @@ function compareObjects(
 
   // If the comparison yields no results, compare again but this time
   // without calling `toJSON`. It's also possible that toJSON might throw.
-  if (difference === undefined || difference === NO_DIFF_MESSAGE) {
+  if (difference === undefined || difference === noDiffMessage) {
     const aCompare = prettyFormat(a, FALLBACK_FORMAT_OPTIONS_0);
     const bCompare = prettyFormat(b, FALLBACK_FORMAT_OPTIONS_0);
 
     if (aCompare === bCompare) {
-      difference = NO_DIFF_MESSAGE;
+      difference = noDiffMessage;
     } else {
       const aDisplay = prettyFormat(a, FALLBACK_FORMAT_OPTIONS);
       const bDisplay = prettyFormat(b, FALLBACK_FORMAT_OPTIONS);
@@ -172,8 +179,9 @@ function compareObjects(
       );
     }
 
-    if (difference !== NO_DIFF_MESSAGE && !hasThrown) {
-      difference = SIMILAR_MESSAGE + '\n\n' + difference;
+    if (difference !== noDiffMessage && !hasThrown) {
+      difference =
+        getCommonMessage(SIMILAR_MESSAGE, options) + '\n\n' + difference;
     }
   }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

`snapshot-diff` has been [updated to make use of `jest-diff` options for no colors](https://github.com/jest-community/snapshot-diff/pull/123), as [provided in the documentation](https://github.com/facebook/jest/tree/d81464622dc8857ba995ed04e121af2b3e8e33bc/packages/jest-diff#example-of-options-for-no-colors). Unfortunately, the "no visual differences" message is still output with `chalk.dim` and doesn't make use of the options for no colors - this means that some [snapshot diffs are now outputting ansi escape codes](https://github.com/jest-community/snapshot-diff/issues/129).

This PR updates the `NO_DIFF_MESSAGE` and `SIMILAR_MESSAGE` messages to use the `commonColor` value from the diff options, which defaults to `chalk.dim`, but can now be overridden by the user.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

 - The existing test continue to work as expected
 - A new test has been added to confirm that when `commonColor` is set to `noColor` (identity), no ansi escape codes are output
 - A new test has been added to confirm that when `commonColor` is set to `chalk.yellow`, the `NO_DIFF_MESSAGE` is correctly set as yellow