### PR TITLE
fix: stop printing the same error for each individual test caused by beforeAll when it fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `[jest-jasmine2]` Stop adding `:` after an error that has no message ([#9990](https://github.com/facebook/jest/pull/9990))
 - `[jest-diff]` Control no diff message color with `commonColor` in diff options ([#9997](https://github.com/facebook/jest/pull/9997))
+- `[jest-circus]` Stop printing errors for individual tests when beforeAll fails ([#10004](https://github.com/facebook/jest/pull/10004))
 
 ### Chore & Maintenance
 

--- a/packages/jest-circus/src/eventHandler.ts
+++ b/packages/jest-circus/src/eventHandler.ts
@@ -9,7 +9,6 @@ import type {Circus} from '@jest/types';
 import {TEST_TIMEOUT_SYMBOL} from './types';
 
 import {
-  addErrorToEachTestUnderDescribe,
   describeBlockHasTests,
   getTestDuration,
   invariant,
@@ -154,13 +153,8 @@ const eventHandler: Circus.EventHandler = (
     case 'hook_failure': {
       const {test, describeBlock, error, hook} = event;
       const {asyncError, type} = hook;
-
-      if (type === 'beforeAll') {
+      if (type === 'beforeAll' || type === 'afterAll') {
         invariant(describeBlock, 'always present for `*All` hooks');
-        addErrorToEachTestUnderDescribe(describeBlock, error, asyncError);
-      } else if (type === 'afterAll') {
-        // Attaching `afterAll` errors to each test makes execution flow
-        // too complicated, so we'll consider them to be global.
         state.unhandledErrors.push([error, asyncError]);
       } else {
         invariant(test, 'always present for `*Each` hooks');


### PR DESCRIPTION
## Summary
Closes #9901 

From my research, I found that the call of `addErrorToEachTestUnderDescribe` was causing this bug (line 160):
https://github.com/facebook/jest/blob/0a4e4a1657b42b21ebf3a969fbf3bbdd28ca930f/packages/jest-circus/src/eventHandler.ts#L154-L170

Removing this function call would stop printing error messages from beforeAll failure for each individual test, however, test suit would pass even though `beforeAll` failed. That's why I had to add an error to `state.unhandledErrors`, so it fails the test suit and prints an error message for `beforeAll` failure. 

Since the code is the same as as-if statement for `afterAll` type, I joined `type === 'beforeAll'` and `type === 'afterAll'`.

These changes haven't broken any existing test in the project, and it looks like it is much less confusing comparing to the previous version, though I would like to get confirmation that this is the expected behaviour.

## Test plan
Let's reuse the example from the issue description and see a new behaviour that this bug fix provides.

**Example:**
```js
describe('test that a 3rd party API remains consistent', () => {
  beforeAll(() => expect('login').toBe('successful')); // this will fail
  test('API function 1', () => expect(1).toBe(1)); // each...
  test('API function 2', () => expect(2).toBe(2)); // ...of these...
  test('API function 3', () => expect(3).toBe(3)); // ...will be reported as failed too
});
```

**New behaviour:**
```sh
 FAIL  ./beforeAllFails.test.js


  ● Test suite failed to run

    expect(received).toBe(expected) // Object.is equality

    Expected: "successful"
    Received: "login"

      1 | describe('test that a 3rd party API remains consistent', () => {
    > 2 |   beforeAll(() => expect('login').toBe('successful'));
        |                                   ^
      3 |   test('API function 1', () => expect(1).toBe(1));
      4 |   test('API function 2', () => expect(2).toBe(2)); // ...of these...
      5 |   test('API function 3', () => expect(3).toBe(3)); // ...will be reported as failed too

      at beforeAllFails.test.js:2:35

Test Suites: 1 failed, 1 total
Tests:       3 passed, 3 total
Snapshots:   0 total
Time:        3.559 s
```