### PR TITLE
Fix dependency warning typo for `browser` config field

### DIFF
--- a/packages/jest-config/src/Deprecated.ts
+++ b/packages/jest-config/src/Deprecated.ts
@@ -15,7 +15,7 @@ export default {
     '"browser"',
   )} has been deprecated. Please install "browser-resolve" and use the "resolver" option in Jest configuration as follows:
   {
-    ${chalk.bold('"resolve"')}: ${chalk.bold('"browser-resolve"')}
+    ${chalk.bold('"resolver"')}: ${chalk.bold('"browser-resolve"')}
   }
   `,
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

When running `jest` v26 with the `browser` config field set, there's a deprecation warning in the console that contains a minor typo for the [`resolver`](https://jestjs.io/docs/en/configuration#resolver-string) field.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

This change only applies to the warning generating when using the `browser` config field for `jest` v26.