### PR TITLE
fix: add missing haste-map dep to jest-snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `[jest-jasmine2]` Stop adding `:` after an error that has no message ([#9990](https://github.com/facebook/jest/pull/9990))
 - `[jest-diff]` Control no diff message color with `commonColor` in diff options ([#9997](https://github.com/facebook/jest/pull/9997))
+- `[jest-snapshot]` Fix TypeScript compilation ([#10008](https://github.com/facebook/jest/pull/10008))
 
 ### Chore & Maintenance
 

--- a/packages/jest-snapshot/package.json
+++ b/packages/jest-snapshot/package.json
@@ -18,6 +18,7 @@
     "graceful-fs": "^4.2.4",
     "jest-diff": "^26.0.1",
     "jest-get-type": "^26.0.0",
+    "jest-haste-map": "^26.0.1",
     "jest-matcher-utils": "^26.0.1",
     "jest-message-util": "^26.0.1",
     "jest-resolve": "^26.0.1",
@@ -33,7 +34,6 @@
     "@types/semver": "^7.1.0",
     "ansi-regex": "^5.0.0",
     "ansi-styles": "^4.2.0",
-    "jest-haste-map": "^26.0.1",
     "prettier": "^1.19.1"
   },
   "engines": {


### PR DESCRIPTION
Hi there,

I recently updated to `jest-snapshot` version `26.0.1`, and was getting this TypeScript compilation error:

```
node_modules/jest-snapshot/build/index.d.ts:17:31 - error TS2307: Cannot find module 'jest-haste-map/build/HasteFS'.

17     cleanup: (hasteFS: import("jest-haste-map/build/HasteFS").default, update: Config.SnapshotUpdateState, snapshotResolver: JestSnapshotResolver, testPathIgnorePatterns?: string[] | undefined) => {
```

It appears `jest-haste-map` should no longer be a dev dependency of `jest-snapshot`?

PS: I raised this PR before raising an issue, feel free to 🔥it if there's already a fix underway (or if it's the wrong fix).