### PR TITLE
Fix hanging if there are too many errors from native find

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - `[jest-jasmine2]` Stop adding `:` after an error that has no message ([#9990](https://github.com/facebook/jest/pull/9990))
 - `[jest-diff]` Control no diff message color with `commonColor` in diff options ([#9997](https://github.com/facebook/jest/pull/9997))
 - `[jest-snapshot]` Fix TypeScript compilation ([#10008](https://github.com/facebook/jest/pull/10008))
+- `[jest-haste-map]` Fix hanging when there are many non-readable directories ([#10038](https://github.com/facebook/jest/pull/10038))
 
 ### Chore & Maintenance
 

--- a/packages/jest-haste-map/src/crawlers/node.ts
+++ b/packages/jest-haste-map/src/crawlers/node.ts
@@ -146,6 +146,9 @@ function findNative(
   child.stdout.setEncoding('utf-8');
   child.stdout.on('data', data => (stdout += data));
 
+  // just throw away stderr to make sure it won't get overflown
+  child.stderr.on('data', () => {});
+
   child.stdout.on('close', () => {
     const lines = stdout
       .trim()


### PR DESCRIPTION
When using native find command for crawling, `find` subprocess might stuck if stderr size is greater than internal buffer because node process doesn't read from stderr.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

Just hangs because I have huge `data` folder in the root of my project with tons of root-owned subdirectories. Jest is using native find command to crawl project directory, but it hangs because jest process doesn't read from find's stderr. So if find command is having many error messages to be written into stderr, it eventually get stuck and just waiting for the node process to pull data from stderr buffer.

Proposed silly fix is just reading and throwing out data from stderr which perfectly fixes by use case.

## Test plan

(I've checked this on Linux)

1. Create empty directory and empty jest.config.js (`module.exports = {}`)
2. Install jest: `npm install jest`
3. Create tons of non-readable directories:
```bash
mkdir data
for n in {1..1000}; do mkdir data/$n; done
chmod 000 data/*
```
4. Run jest: `./node_modules/.bin/jest`
5. Check how it will just hang without this fix and will successfully run with one