### PR TITLE
 Add `coverageProvider` to `jest --init` prompts 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - `[jest-config]` Support config files exporting (`async`) `function`s ([#10001](https://github.com/facebook/jest/pull/10001))
 - `[jest-cli, jest-core]` Add `--selectProjects` CLI argument to filter test suites by project name ([#8612](https://github.com/facebook/jest/pull/8612))
+- `[jest-cli, jest-init]` Add `coverageProvider` to `jest --init` prompts ([#10044](https://github.com/facebook/jest/pull/10044))
 
 ### Fixes
 

--- a/packages/jest-cli/src/init/__tests__/init.test.js
+++ b/packages/jest-cli/src/init/__tests__/init.test.js
@@ -93,6 +93,28 @@ describe('init', () => {
         expect(evaluatedConfig).toEqual({coverageDirectory: 'coverage'});
       });
 
+      it('should create configuration for {coverageProvider: "babel"}', async () => {
+        prompts.mockReturnValueOnce({coverageProvider: 'babel'});
+
+        await init(resolveFromFixture('only_package_json'));
+
+        const writtenJestConfig = fs.writeFileSync.mock.calls[0][1];
+        const evaluatedConfig = eval(writtenJestConfig);
+
+        expect(evaluatedConfig).toEqual({});
+      });
+
+      it('should create configuration for {coverageProvider: "v8"}', async () => {
+        prompts.mockReturnValueOnce({coverageProvider: 'v8'});
+
+        await init(resolveFromFixture('only_package_json'));
+
+        const writtenJestConfig = fs.writeFileSync.mock.calls[0][1];
+        const evaluatedConfig = eval(writtenJestConfig);
+
+        expect(evaluatedConfig).toEqual({coverageProvider: 'v8'});
+      });
+
       it('should create configuration for {environment: "jsdom"}', async () => {
         prompts.mockReturnValueOnce({environment: 'jsdom'});
 

--- a/packages/jest-cli/src/init/__tests__/init.test.js
+++ b/packages/jest-cli/src/init/__tests__/init.test.js
@@ -100,7 +100,7 @@ describe('init', () => {
 
         const writtenJestConfig = fs.writeFileSync.mock.calls[0][1];
         const evaluatedConfig = eval(writtenJestConfig);
-
+        // should modify when the default coverageProvider will be changed to "v8"
         expect(evaluatedConfig).toEqual({});
       });
 
@@ -111,7 +111,7 @@ describe('init', () => {
 
         const writtenJestConfig = fs.writeFileSync.mock.calls[0][1];
         const evaluatedConfig = eval(writtenJestConfig);
-
+        // should modify when the default coverageProvider will be changed to "v8"
         expect(evaluatedConfig).toEqual({coverageProvider: 'v8'});
       });
 

--- a/packages/jest-cli/src/init/generate_config_file.ts
+++ b/packages/jest-cli/src/init/generate_config_file.ts
@@ -35,13 +35,19 @@ const generateConfigFile = (
   results: Record<string, unknown>,
   generateEsm = false,
 ): string => {
-  const {coverage, clearMocks, environment} = results;
+  const {coverage, coverageProvider, clearMocks, environment} = results;
 
   const overrides: Record<string, any> = {};
 
   if (coverage) {
     Object.assign(overrides, {
       coverageDirectory: 'coverage',
+    });
+  }
+
+  if (coverageProvider === 'v8') {
+    Object.assign(overrides, {
+      coverageProvider: 'v8',
     });
   }
 

--- a/packages/jest-cli/src/init/index.ts
+++ b/packages/jest-cli/src/init/index.ts
@@ -28,6 +28,7 @@ const {
 type PromptsResults = {
   clearMocks: boolean;
   coverage: boolean;
+  coverageProvider: boolean;
   environment: boolean;
   scripts: boolean;
 };

--- a/packages/jest-cli/src/init/questions.ts
+++ b/packages/jest-cli/src/init/questions.ts
@@ -25,10 +25,14 @@ const defaultQuestions: Array<PromptObject> = [
     type: 'confirm',
   },
   {
-    initial: false,
-    message: 'Do you want to use V8 based code coverage as coverageProvider?',
-    name: 'v8',
-    type: 'confirm',
+    choices: [
+      {title: 'babel', value: 'babel'},
+      {title: 'v8', value: 'v8'},
+    ],
+    initial: 0,
+    message: 'which coverageProvider should be used to instrument code for coverage?',
+    name: 'coverageProvider',
+    type: 'select',
   },
   {
     initial: false,

--- a/packages/jest-cli/src/init/questions.ts
+++ b/packages/jest-cli/src/init/questions.ts
@@ -30,7 +30,7 @@ const defaultQuestions: Array<PromptObject> = [
       {title: 'v8', value: 'v8'},
     ],
     initial: 0,
-    message: 'Which coverageProvider should be used to instrument code for coverage?',
+    message: 'Which coverageProvider should be used to collect coverage?',
     name: 'coverageProvider',
     type: 'select',
   },

--- a/packages/jest-cli/src/init/questions.ts
+++ b/packages/jest-cli/src/init/questions.ts
@@ -26,6 +26,12 @@ const defaultQuestions: Array<PromptObject> = [
   },
   {
     initial: false,
+    message: 'Do you want to use V8 based code coverage as coverageProvider?',
+    name: 'v8',
+    type: 'confirm',
+  },
+  {
+    initial: false,
     message: 'Automatically clear mock calls and instances between every test?',
     name: 'clearMocks',
     type: 'confirm',

--- a/packages/jest-cli/src/init/questions.ts
+++ b/packages/jest-cli/src/init/questions.ts
@@ -30,7 +30,7 @@ const defaultQuestions: Array<PromptObject> = [
       {title: 'v8', value: 'v8'},
     ],
     initial: 0,
-    message: 'which coverageProvider should be used to instrument code for coverage?',
+    message: 'Which coverageProvider should be used to instrument code for coverage?',
     name: 'coverageProvider',
     type: 'select',
   },


### PR DESCRIPTION
Created This PR to resolve this issue #10015, to add 'coverageProvider' to 'jest --init' prompts

### Summary
We need  to encourage folks try out the V8 based code coverage, so the prompt in "--init" and its entry into the generated config file would be help.


