### PR TITLE
Cleanup `displayName` type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Chore & Maintenance
 
 - `[jest-core]` 🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉 ([#10000](https://github.com/facebook/jest/pull/10000))
+- `[jest-core, jest-reporters, jest-test-result, jest-types]` Cleanup `displayName` type ([#10049](https://github.com/facebook/jest/pull/10049))
 
 ### Performance
 

--- a/packages/jest-core/src/getProjectDisplayName.ts
+++ b/packages/jest-core/src/getProjectDisplayName.ts
@@ -14,11 +14,5 @@ export default function getProjectDisplayName(
   if (!displayName) {
     return undefined;
   }
-  if (typeof displayName === 'string') {
-    return displayName;
-  }
-  if (typeof displayName === 'object') {
-    return displayName.name;
-  }
-  return undefined;
+  return displayName.name;
 }

--- a/packages/jest-reporters/src/__tests__/utils.test.ts
+++ b/packages/jest-reporters/src/__tests__/utils.test.ts
@@ -118,7 +118,10 @@ describe('printDisplayName', () => {
     expect(
       printDisplayName(
         makeProjectConfig({
-          displayName: 'hello',
+          displayName: {
+            color: 'white',
+            name: 'hello',
+          },
         }),
       ),
     ).toMatchSnapshot();

--- a/packages/jest-reporters/src/utils.ts
+++ b/packages/jest-reporters/src/utils.ts
@@ -22,10 +22,6 @@ export const printDisplayName = (config: Config.ProjectConfig): string => {
     return '';
   }
 
-  if (typeof displayName === 'string') {
-    return chalk.supportsColor ? white(` ${displayName} `) : displayName;
-  }
-
   const {name, color} = displayName;
   const chosenColor = chalk.reset.inverse[color]
     ? chalk.reset.inverse[color]

--- a/packages/jest-test-result/src/helpers.ts
+++ b/packages/jest-test-result/src/helpers.ts
@@ -48,7 +48,7 @@ export const buildFailureTestResult = (
   err: SerializableError,
 ): TestResult => ({
   console: undefined,
-  displayName: '',
+  displayName: undefined,
   failureMessage: null,
   leaks: false,
   numFailingTests: 0,

--- a/packages/jest-types/src/Config.ts
+++ b/packages/jest-types/src/Config.ts
@@ -84,12 +84,10 @@ export type DefaultOptions = {
   watchman: boolean;
 };
 
-export type DisplayName =
-  | string
-  | {
-      name: string;
-      color: typeof chalk.Color;
-    };
+export type DisplayName = {
+  name: string;
+  color: typeof chalk.Color;
+};
 
 export type InitialOptionsWithRootDir = InitialOptions &
   Required<Pick<InitialOptions, 'rootDir'>>;
@@ -119,7 +117,7 @@ export type InitialOptions = Partial<{
   dependencyExtractor: string;
   detectLeaks: boolean;
   detectOpenHandles: boolean;
-  displayName: DisplayName;
+  displayName: string | DisplayName;
   expand: boolean;
   extraGlobals: Array<string>;
   filter: Path;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Fixes #10010 

If I understand correctly, the type of `displayName` in `ProjectConfig` type cannot be a string because it has been normalized, therefore I remove the `string` type in the `DisplayName` type. Since `InitialOptions` can still take in `string` I add it back there.

The rest is to change the places where `displayName` is treated as `string` (i.e. remove such codes because it will never happen)

TODOs:

- [x] Update CHANGELOG.md
- [x] Is there any more place that I should change?


## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Check CI results 😅 
