### PR TITLE
docs: correct confusing filename in `enableAutomock` example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Chore & Maintenance
 
+- `[docs]` Fix confuse filename on enableAutomock example ([#10055](https://github.com/facebook/jest/pull/10055))
 - `[jest-core]` 🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉 ([#10000](https://github.com/facebook/jest/pull/10000))
 
 ### Performance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### Chore & Maintenance
 
-- `[docs]` Fix confuse filename on enableAutomock example ([#10055](https://github.com/facebook/jest/pull/10055))
+- `[docs]` Correct confusing filename in `enableAutomock` example ([#10055](https://github.com/facebook/jest/pull/10055))
 - `[jest-core]` 🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉 ([#10000](https://github.com/facebook/jest/pull/10000))
 
 ### Performance

--- a/docs/JestObjectAPI.md
+++ b/docs/JestObjectAPI.md
@@ -76,7 +76,7 @@ export default {
 ```
 
 ```js
-// __tests__/disableAutomocking.js
+// __tests__/enableAutomocking.js
 jest.enableAutomock();
 
 import utils from '../utils';

--- a/website/versioned_docs/version-26.0/JestObjectAPI.md
+++ b/website/versioned_docs/version-26.0/JestObjectAPI.md
@@ -77,7 +77,7 @@ export default {
 ```
 
 ```js
-// __tests__/disableAutomocking.js
+// __tests__/enableAutomocking.js
 jest.enableAutomock();
 
 import utils from '../utils';


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Current example for `jest.enableAutomock()` functionality uses `disableAutomocking.js` as the filename for the example test file:

![image](https://user-images.githubusercontent.com/333268/82139767-8a073d00-982a-11ea-89e7-be5f555f9c3c.png)

it results confusing for the reader.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Here you can see a screenshot of the built website after the changes:
![image](https://user-images.githubusercontent.com/333268/82140002-b7ed8100-982c-11ea-849e-357d6718c1bc.png)
