### PR TITLE
getConsoleOutput receives global noStackTrace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - `[jest-cli, jest-init]` Add `coverageProvider` to `jest --init` prompts ([#10044](https://github.com/facebook/jest/pull/10044))
 
 ### Fixes
-
+- `[jest-console]` `getConsoleOutput` to receive global stack trace config and use it to format stack trace ([#10081](https://github.com/facebook/jest/pull/10081))
 - `[jest-jasmine2]` Stop adding `:` after an error that has no message ([#9990](https://github.com/facebook/jest/pull/9990))
 - `[jest-diff]` Control no diff message color with `commonColor` in diff options ([#9997](https://github.com/facebook/jest/pull/9997))
 - `[jest-snapshot]` Fix TypeScript compilation ([#10008](https://github.com/facebook/jest/pull/10008))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `[jest-cli, jest-init]` Add `coverageProvider` to `jest --init` prompts ([#10044](https://github.com/facebook/jest/pull/10044))
 
 ### Fixes
+
 - `[jest-console]` `getConsoleOutput` to receive global stack trace config and use it to format stack trace ([#10081](https://github.com/facebook/jest/pull/10081))
 - `[jest-jasmine2]` Stop adding `:` after an error that has no message ([#9990](https://github.com/facebook/jest/pull/9990))
 - `[jest-diff]` Control no diff message color with `commonColor` in diff options ([#9997](https://github.com/facebook/jest/pull/9997))

--- a/e2e/__tests__/__snapshots__/console.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/console.test.ts.snap
@@ -145,6 +145,78 @@ Snapshots:   0 total
 Time:        <<REPLACED>>
 `;
 
+exports[`respects --noStackTrace 1`] = `
+  console.log
+    This is a log message.
+
+      at Object.log (__tests__/console.test.js:10:11)
+
+  console.info
+    This is an info message.
+
+      at Object.info (__tests__/console.test.js:12:11)
+
+  console.warn
+    This is a warning message.
+
+      at Object.warn (__tests__/console.test.js:14:11)
+
+  console.error
+    This is an error message.
+
+      at Object.error (__tests__/console.test.js:16:11)
+
+`;
+
+exports[`respects --noStackTrace 2`] = `
+PASS __tests__/console.test.js
+  ✓ works just fine
+`;
+
+exports[`respects --noStackTrace 3`] = `
+Test Suites: 1 passed, 1 total
+Tests:       1 passed, 1 total
+Snapshots:   0 total
+Time:        <<REPLACED>>
+Ran all test suites.
+`;
+
+exports[`respects noStackTrace in config 1`] = `
+  console.log
+    This is a log message.
+
+      at Object.log (__tests__/console.test.js:10:11)
+
+  console.info
+    This is an info message.
+
+      at Object.info (__tests__/console.test.js:12:11)
+
+  console.warn
+    This is a warning message.
+
+      at Object.warn (__tests__/console.test.js:14:11)
+
+  console.error
+    This is an error message.
+
+      at Object.error (__tests__/console.test.js:16:11)
+
+`;
+
+exports[`respects noStackTrace in config 2`] = `
+PASS __tests__/console.test.js
+  ✓ works just fine
+`;
+
+exports[`respects noStackTrace in config 3`] = `
+Test Suites: 1 passed, 1 total
+Tests:       1 passed, 1 total
+Snapshots:   0 total
+Time:        <<REPLACED>>
+Ran all test suites.
+`;
+
 exports[`the jsdom console is the same as the test console 1`] = ``;
 
 exports[`the jsdom console is the same as the test console 2`] = `

--- a/e2e/__tests__/console.test.ts
+++ b/e2e/__tests__/console.test.ts
@@ -50,6 +50,42 @@ test('does not print to console with --silent', () => {
   expect(wrap(summary)).toMatchSnapshot();
 });
 
+test('respects --noStackTrace', () => {
+  const {stderr, stdout, exitCode} = runJest('console', [
+    // Need to pass --config because console test specifies `verbose: false`
+    '--config=' +
+      JSON.stringify({
+        testEnvironment: 'node',
+      }),
+    '--noStackTrace',
+    '--no-cache',
+  ]);
+  const {summary, rest} = extractSummary(stderr);
+
+  expect(exitCode).toBe(0);
+  expect(wrap(stdout)).toMatchSnapshot();
+  expect(wrap(rest)).toMatchSnapshot();
+  expect(wrap(summary)).toMatchSnapshot();
+});
+
+test('respects noStackTrace in config', () => {
+  const {stderr, stdout, exitCode} = runJest('console', [
+    // Need to pass --config because console test specifies `verbose: false`
+    '--config=' +
+      JSON.stringify({
+        noStackTrace: true,
+        testEnvironment: 'node',
+      }),
+    '--no-cache',
+  ]);
+  const {summary, rest} = extractSummary(stderr);
+
+  expect(exitCode).toBe(0);
+  expect(wrap(stdout)).toMatchSnapshot();
+  expect(wrap(rest)).toMatchSnapshot();
+  expect(wrap(summary)).toMatchSnapshot();
+});
+
 // issue: https://github.com/facebook/jest/issues/5223
 test('the jsdom console is the same as the test console', () => {
   const {stderr, stdout, exitCode} = runJest('console-jsdom');

--- a/packages/jest-console/src/__tests__/getConsoleOutput.test.ts
+++ b/packages/jest-console/src/__tests__/getConsoleOutput.test.ts
@@ -5,42 +5,53 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {formatStackTrace} from 'jest-message-util';
-import getConsoleOutput from '../getConsoleOutput';
 import BufferedConsole from '../BufferedConsole';
-import { LogType } from '../types';
+import getConsoleOutput from '../getConsoleOutput';
+import {formatStackTrace} from 'jest-message-util';
+import {LogType} from '../types';
 
 jest.mock('jest-message-util', () => ({
-    formatStackTrace: jest.fn(),
+  formatStackTrace: jest.fn(),
 }));
 
-describe('getConsoleOutput', ()=>{
-    formatStackTrace.mockImplementation(()=>'throw new Error("Whoops!");');
-    let cases = ['assert', 'count', 'debug', 'dir', 'dirxml', 'error', 'group', 'groupCollapsed', 'info', 'log', 'time', 'warn'];
-   
-    cases.forEach((logType)=>{
-        it(`takes noStackTrace and pass it on for ${logType}`, ()=>{
-            getConsoleOutput(
-                'someRootPath',
-                true,
-                BufferedConsole.write([], logType as LogType, 'message', 4),
-                {
-                    rootDir: 'root',
-                    testMatch: [],
-                },
-                true
-            );
-            expect(formatStackTrace).toHaveBeenCalled();
-            expect(formatStackTrace).toHaveBeenCalledWith(
-                expect.anything(),
-                expect.anything(),
-                expect.objectContaining(
-                    {
-                        noStackTrace: true,
-                        noCodeFrame: expect.anything()
-                    }
-                )
-            );
-        });
+describe('getConsoleOutput', () => {
+  formatStackTrace.mockImplementation(() => 'throw new Error("Whoops!");');
+  const cases = [
+    'assert',
+    'count',
+    'debug',
+    'dir',
+    'dirxml',
+    'error',
+    'group',
+    'groupCollapsed',
+    'info',
+    'log',
+    'time',
+    'warn',
+  ];
+
+  cases.forEach(logType => {
+    it(`takes noStackTrace and pass it on for ${logType}`, () => {
+      getConsoleOutput(
+        'someRootPath',
+        true,
+        BufferedConsole.write([], logType as LogType, 'message', 4),
+        {
+          rootDir: 'root',
+          testMatch: [],
+        },
+        true,
+      );
+      expect(formatStackTrace).toHaveBeenCalled();
+      expect(formatStackTrace).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({
+          noCodeFrame: expect.anything(),
+          noStackTrace: true,
+        }),
+      );
     });
+  });
 });

--- a/packages/jest-console/src/__tests__/getConsoleOutput.test.ts
+++ b/packages/jest-console/src/__tests__/getConsoleOutput.test.ts
@@ -5,9 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import BufferedConsole from '../BufferedConsole';
-import getConsoleOutput from '../getConsoleOutput';
 import {formatStackTrace} from 'jest-message-util';
+import getConsoleOutput from '../getConsoleOutput';
+import BufferedConsole from '../BufferedConsole';
 import {LogType} from '../types';
 
 jest.mock('jest-message-util', () => ({

--- a/packages/jest-console/src/__tests__/getConsoleOutput.test.ts
+++ b/packages/jest-console/src/__tests__/getConsoleOutput.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {formatStackTrace} from 'jest-message-util';
+import getConsoleOutput from '../getConsoleOutput';
+import BufferedConsole from '../BufferedConsole';
+import { LogType } from '../types';
+
+jest.mock('jest-message-util', () => ({
+    formatStackTrace: jest.fn(),
+}));
+
+describe('getConsoleOutput', ()=>{
+    formatStackTrace.mockImplementation(()=>'throw new Error("Whoops!");');
+    let cases = ['assert', 'count', 'debug', 'dir', 'dirxml', 'error', 'group', 'groupCollapsed', 'info', 'log', 'time', 'warn'];
+   
+    cases.forEach((logType)=>{
+        it(`takes noStackTrace and pass it on for ${logType}`, ()=>{
+            getConsoleOutput(
+                'someRootPath',
+                true,
+                BufferedConsole.write([], logType as LogType, 'message', 4),
+                {
+                    rootDir: 'root',
+                    testMatch: [],
+                },
+                true
+            );
+            expect(formatStackTrace).toHaveBeenCalled();
+            expect(formatStackTrace).toHaveBeenCalledWith(
+                expect.anything(),
+                expect.anything(),
+                expect.objectContaining(
+                    {
+                        noStackTrace: true,
+                        noCodeFrame: expect.anything()
+                    }
+                )
+            );
+        });
+    });
+});

--- a/packages/jest-console/src/__tests__/getConsoleOutput.test.ts
+++ b/packages/jest-console/src/__tests__/getConsoleOutput.test.ts
@@ -8,50 +8,50 @@
 import {formatStackTrace} from 'jest-message-util';
 import getConsoleOutput from '../getConsoleOutput';
 import BufferedConsole from '../BufferedConsole';
-import {LogType} from '../types';
+import type {LogType} from '../types';
+import {makeGlobalConfig} from '../../../../TestUtils';
 
 jest.mock('jest-message-util', () => ({
   formatStackTrace: jest.fn(),
 }));
 
 describe('getConsoleOutput', () => {
+  const globalConfig = makeGlobalConfig({noStackTrace: true});
   formatStackTrace.mockImplementation(() => 'throw new Error("Whoops!");');
-  const cases = [
-    'assert',
-    'count',
-    'debug',
-    'dir',
-    'dirxml',
-    'error',
-    'group',
-    'groupCollapsed',
-    'info',
-    'log',
-    'time',
-    'warn',
-  ];
 
-  cases.forEach(logType => {
-    it(`takes noStackTrace and pass it on for ${logType}`, () => {
-      getConsoleOutput(
-        'someRootPath',
-        true,
-        BufferedConsole.write([], logType as LogType, 'message', 4),
-        {
-          rootDir: 'root',
-          testMatch: [],
-        },
-        true,
-      );
-      expect(formatStackTrace).toHaveBeenCalled();
-      expect(formatStackTrace).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.anything(),
-        expect.objectContaining({
-          noCodeFrame: expect.anything(),
-          noStackTrace: true,
-        }),
-      );
-    });
+  it.each`
+    logType
+    ${'assert'}
+    ${'count'}
+    ${'debug'}
+    ${'dir'}
+    ${'dirxml'}
+    ${'error'}
+    ${'group'}
+    ${'groupCollapsed'}
+    ${'info'}
+    ${'log'}
+    ${'time'}
+    ${'warn'}
+  `('takes noStackTrace and pass it on for $logType', logType => {
+    getConsoleOutput(
+      'someRootPath',
+      true,
+      BufferedConsole.write([], logType as LogType, 'message', 4),
+      {
+        rootDir: 'root',
+        testMatch: [],
+      },
+      globalConfig,
+    );
+    expect(formatStackTrace).toHaveBeenCalled();
+    expect(formatStackTrace).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({
+        noCodeFrame: expect.anything(),
+        noStackTrace: true,
+      }),
+    );
   });
 });

--- a/packages/jest-console/src/getConsoleOutput.ts
+++ b/packages/jest-console/src/getConsoleOutput.ts
@@ -14,15 +14,16 @@ import {
 import type {ConsoleBuffer} from './types';
 
 export default (
-  // TODO: remove in 26
+  // TODO: remove in 27
   root: string,
   verbose: boolean,
   buffer: ConsoleBuffer,
-  // TODO: make mandatory and take Config.ProjectConfig in 26
+  // TODO: make mandatory and take Config.ProjectConfig in 27
   config: StackTraceConfig = {
     rootDir: root,
     testMatch: [],
   },
+  globalNoStackTrace: boolean,
 ): string => {
   const TITLE_INDENT = verbose ? '  ' : '    ';
   const CONSOLE_INDENT = TITLE_INDENT + '  ';
@@ -40,12 +41,12 @@ export default (
     if (type === 'warn') {
       message = chalk.yellow(message);
       typeMessage = chalk.yellow(typeMessage);
-      noStackTrace = false;
+      noStackTrace = false || globalNoStackTrace;
       noCodeFrame = false;
     } else if (type === 'error') {
       message = chalk.red(message);
       typeMessage = chalk.red(typeMessage);
-      noStackTrace = false;
+      noStackTrace = false || globalNoStackTrace;
       noCodeFrame = false;
     }
 

--- a/packages/jest-console/src/getConsoleOutput.ts
+++ b/packages/jest-console/src/getConsoleOutput.ts
@@ -25,7 +25,8 @@ export default (
     rootDir: root,
     testMatch: [],
   },
-  globalConfig: Config.GlobalConfig,
+  // TODO: make mandatory in 27
+  globalConfig?: Config.GlobalConfig,
 ): string => {
   const TITLE_INDENT = verbose ? '  ' : '    ';
   const CONSOLE_INDENT = TITLE_INDENT + '  ';
@@ -43,12 +44,12 @@ export default (
     if (type === 'warn') {
       message = chalk.yellow(message);
       typeMessage = chalk.yellow(typeMessage);
-      noStackTrace = false || globalConfig.noStackTrace;
+      noStackTrace = globalConfig ? globalConfig.noStackTrace : false;
       noCodeFrame = false;
     } else if (type === 'error') {
       message = chalk.red(message);
       typeMessage = chalk.red(typeMessage);
-      noStackTrace = false || globalConfig.noStackTrace;
+      noStackTrace = globalConfig ? globalConfig.noStackTrace : false;
       noCodeFrame = false;
     }
 

--- a/packages/jest-console/src/getConsoleOutput.ts
+++ b/packages/jest-console/src/getConsoleOutput.ts
@@ -11,11 +11,13 @@ import {
   StackTraceOptions,
   formatStackTrace,
 } from 'jest-message-util';
+import type {Config} from '@jest/types';
 import type {ConsoleBuffer} from './types';
 
 export default (
   // TODO: remove in 27
   root: string,
+  // TODO: this is covered by GlobalConfig, switch over in 27
   verbose: boolean,
   buffer: ConsoleBuffer,
   // TODO: make mandatory and take Config.ProjectConfig in 27
@@ -23,7 +25,7 @@ export default (
     rootDir: root,
     testMatch: [],
   },
-  globalNoStackTrace: boolean,
+  globalConfig: Config.GlobalConfig,
 ): string => {
   const TITLE_INDENT = verbose ? '  ' : '    ';
   const CONSOLE_INDENT = TITLE_INDENT + '  ';
@@ -41,12 +43,12 @@ export default (
     if (type === 'warn') {
       message = chalk.yellow(message);
       typeMessage = chalk.yellow(typeMessage);
-      noStackTrace = false || globalNoStackTrace;
+      noStackTrace = false || globalConfig.noStackTrace;
       noCodeFrame = false;
     } else if (type === 'error') {
       message = chalk.red(message);
       typeMessage = chalk.red(typeMessage);
-      noStackTrace = false || globalNoStackTrace;
+      noStackTrace = false || globalConfig.noStackTrace;
       noCodeFrame = false;
     }
 

--- a/packages/jest-console/src/getConsoleOutput.ts
+++ b/packages/jest-console/src/getConsoleOutput.ts
@@ -44,12 +44,12 @@ export default (
     if (type === 'warn') {
       message = chalk.yellow(message);
       typeMessage = chalk.yellow(typeMessage);
-      noStackTrace = globalConfig ? globalConfig.noStackTrace : false;
+      noStackTrace = globalConfig?.noStackTrace ?? false;
       noCodeFrame = false;
     } else if (type === 'error') {
       message = chalk.red(message);
       typeMessage = chalk.red(typeMessage);
-      noStackTrace = globalConfig ? globalConfig.noStackTrace : false;
+      noStackTrace = globalConfig?.noStackTrace ?? false;
       noCodeFrame = false;
     }
 

--- a/packages/jest-message-util/src/__tests__/__snapshots__/messages.test.ts.snap
+++ b/packages/jest-message-util/src/__tests__/__snapshots__/messages.test.ts.snap
@@ -19,6 +19,27 @@ exports[`codeframe 1`] = `
 "
 `;
 
+exports[`formatStackTrace does not print code frame when noCodeFrame = true 1`] = `
+"
+      <dim>at Object.<anonymous> (</>file.js<dim>:1:7)</>
+        "
+`;
+
+exports[`formatStackTrace does not print codeframe when noStackTrace = true 1`] = `
+"
+      <dim>at Object.<anonymous> (</>file.js<dim>:1:7)</>
+        "
+`;
+
+exports[`formatStackTrace prints code frame and stacktrace 1`] = `
+"
+    </><red><bold>></></><gray> 1 | </><cyan>throw</> <cyan>new</> <yellow>Error</>(<green>\\"Whoops!\\"</>)<yellow>;</></>
+    </> <gray>   | </>      <red><bold>^</></></>
+
+      <dim>at Object.<anonymous> (</>file.js<dim>:1:7)</>
+        "
+`;
+
 exports[`formatStackTrace should strip node internals 1`] = `
 "<bold><red>  <bold>● </><bold>Unix test</></>
 
@@ -32,27 +53,6 @@ exports[`formatStackTrace should strip node internals 1`] = `
 <dim></>
 <dim>      <dim>at Object.it (</><dim>__tests__/test.js<dim>:8:14)</><dim></>
 "
-`;
-
-exports[`getConsoleOutput does not print code frame when noCodeFrame = true 1`] = `
-"
-      <dim>at Object.<anonymous> (</>file.js<dim>:1:7)</>
-        "
-`;
-
-exports[`getConsoleOutput does not print codeframe when noStackTrace = true 1`] = `
-"
-      <dim>at Object.<anonymous> (</>file.js<dim>:1:7)</>
-        "
-`;
-
-exports[`getConsoleOutput prints code frame and stacktrace 1`] = `
-"
-    </><red><bold>></></><gray> 1 | </><cyan>throw</> <cyan>new</> <yellow>Error</>(<green>\\"Whoops!\\"</>)<yellow>;</></>
-    </> <gray>   | </>      <red><bold>^</></></>
-
-      <dim>at Object.<anonymous> (</>file.js<dim>:1:7)</>
-        "
 `;
 
 exports[`no codeframe 1`] = `

--- a/packages/jest-message-util/src/__tests__/messages.test.ts
+++ b/packages/jest-message-util/src/__tests__/messages.test.ts
@@ -290,7 +290,7 @@ it('no stack', () => {
   expect(message).toMatchSnapshot();
 });
 
-describe('getConsoleOutput', () => {
+describe('formatStackTrace', () => {
   it('prints code frame and stacktrace', () => {
     readFileSync.mockImplementationOnce(() => 'throw new Error("Whoops!");');
     const message = formatStackTrace(

--- a/packages/jest-reporters/src/default_reporter.ts
+++ b/packages/jest-reporters/src/default_reporter.ts
@@ -183,6 +183,7 @@ export default class DefaultReporter extends BaseReporter {
             !!this._globalConfig.verbose,
             result.console,
             config,
+            this._globalConfig.noStackTrace,
           ),
       );
     }

--- a/packages/jest-reporters/src/default_reporter.ts
+++ b/packages/jest-reporters/src/default_reporter.ts
@@ -183,7 +183,7 @@ export default class DefaultReporter extends BaseReporter {
             !!this._globalConfig.verbose,
             result.console,
             config,
-            this._globalConfig.noStackTrace,
+            this._globalConfig,
           ),
       );
     }

--- a/packages/jest-runner/src/runTest.ts
+++ b/packages/jest-runner/src/runTest.ts
@@ -121,6 +121,7 @@ async function runTestInternal(
       // 4 = the console call is buried 4 stack frames deep
       BufferedConsole.write([], type, message, 4),
       config,
+      globalConfig.noStackTrace,
     );
 
   let testConsole;

--- a/packages/jest-runner/src/runTest.ts
+++ b/packages/jest-runner/src/runTest.ts
@@ -121,7 +121,7 @@ async function runTestInternal(
       // 4 = the console call is buried 4 stack frames deep
       BufferedConsole.write([], type, message, 4),
       config,
-      globalConfig.noStackTrace,
+      globalConfig,
     );
 
   let testConsole;


### PR DESCRIPTION
## Summary
Although `formatStackTrace` acts according to `StackTraceOptions`, `getConsoleOutput` needs to take `noStackTrace` value in global config and use it to override the options passed to `formatStackTrace`. This will resolve the bug mentioned [here](https://github.com/facebook/jest/issues/8819#issuecomment-632763136)

## Test plan
Pass existing test cases. Adding new test case to ensure `getConsoleOutput` does override corresponding configuration.
