### PR TITLE
Check threshold only for changed files

### DIFF
--- a/packages/jest-reporters/src/coverage_reporter.ts
+++ b/packages/jest-reporters/src/coverage_reporter.ts
@@ -226,7 +226,7 @@ export default class CoverageReporter extends BaseReporter {
   }
 
   private _checkThreshold(map: istanbulCoverage.CoverageMap) {
-    const {coverageThreshold} = this._globalConfig;
+    const {coverageThreshold, findRelatedTests} = this._globalConfig;
 
     if (coverageThreshold) {
       function check(
@@ -347,7 +347,17 @@ export default class CoverageReporter extends BaseReporter {
 
       let errors: Array<string> = [];
 
-      thresholdGroups.forEach(thresholdGroup => {
+      const groupsForCheck = findRelatedTests
+        ? thresholdGroups.filter(
+            group =>
+              group === THRESHOLD_GROUP_TYPES.GLOBAL ||
+              coveredFilesSortedIntoThresholdGroup.some(
+                fileWithGroup => fileWithGroup[1] === group,
+              ),
+          )
+        : thresholdGroups;
+
+      groupsForCheck.forEach(thresholdGroup => {
         switch (groupTypeByThresholdGroup[thresholdGroup]) {
           case THRESHOLD_GROUP_TYPES.GLOBAL: {
             const coverage = combineCoverage(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Currently if we use `findRelatedTests`  jest will check thresholds for every group from `coverageThreshold`. So it always fails and it's impossible to run tests only for changed files on CI for example. 

 This fix filters `thresholdGroups` by files from `coveredFilesSortedIntoThresholdGroup` if `findRelatedTests` set and checks only filtered groups. 

If it looks good, I will add tests and changelog entry.

Also we can add same logic for all changes-related options: `--onlyChanged`, `--changedFilesWithAncestor`, `--changedSince`.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Add `coverageThreshold` in jest config 

```js
  coverageThreshold: {
    'packages/jest-each': {
      branches: 100,
    },
  }
```

and then run some tests with coverage not related to one in threshold configuration. For example: `yarn jest --findRelatedTests packages/jest-snapshot/src/dedentLines.ts --coverage --collectCoverageFrom packages/jest-snapshot/src/dedentLines.ts` (collectCoverageFrom is required beacuse of facebook/jest#10083 issue). It should pass

