### PR TITLE
refactor(jest-snapshot): move type deps to devDeps

### DIFF
--- a/packages/jest-snapshot/package.json
+++ b/packages/jest-snapshot/package.json
@@ -11,8 +11,6 @@
   "types": "build/index.d.ts",
   "dependencies": {
     "@babel/types": "^7.0.0",
-    "@jest/types": "^26.0.1",
-    "@types/prettier": "^2.0.0",
     "chalk": "^4.0.0",
     "expect": "^26.0.1",
     "graceful-fs": "^4.2.4",
@@ -29,8 +27,10 @@
   },
   "devDependencies": {
     "@babel/traverse": "^7.3.4",
+    "@jest/types": "^26.0.1",
     "@types/graceful-fs": "^4.1.3",
     "@types/natural-compare": "^1.4.0",
+    "@types/prettier": "^2.0.0",
     "@types/semver": "^7.1.0",
     "ansi-regex": "^5.0.0",
     "ansi-styles": "^4.2.0",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

I noticed that `prettier` was ending up in a `yarn.lock` for my project, and it was coming from Jest

This seems like accidental dependency bloat

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

I didn't test this; I made the PR to ask a question – though if CI passes, then I think we're probably fine to merge this?
