### PR TITLE
feat: Add `cacheIdentifier` to config option

### DIFF
--- a/e2e/__tests__/__snapshots__/showConfig.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/showConfig.test.ts.snap
@@ -7,6 +7,7 @@ exports[`--showConfig outputs config info and exits 1`] = `
       "automock": false,
       "cache": false,
       "cacheDirectory": "/tmp/jest",
+      "cacheIdentifier": "key",
       "clearMocks": false,
       "coveragePathIgnorePatterns": [
         "/node_modules/"

--- a/packages/jest-cli/src/cli/args.ts
+++ b/packages/jest-cli/src/cli/args.ts
@@ -127,7 +127,7 @@ export const options = {
   cacheIdentifier: {
     description:
       'A unique key, when change, forces the cache key to be changed',
-    type: 'string'
+    type: 'string',
   },
   changedFilesWithAncestor: {
     default: undefined,

--- a/packages/jest-cli/src/cli/args.ts
+++ b/packages/jest-cli/src/cli/args.ts
@@ -124,6 +124,11 @@ export const options = {
       ' dependency information.',
     type: 'string',
   },
+  cacheIdentifier: {
+    description:
+      'A unique key, when change, forces the cache key to be changed',
+    type: 'string'
+  },
   changedFilesWithAncestor: {
     default: undefined,
     description:

--- a/packages/jest-config/src/Defaults.ts
+++ b/packages/jest-config/src/Defaults.ts
@@ -17,6 +17,7 @@ const defaultOptions: Config.DefaultOptions = {
   bail: 0,
   cache: true,
   cacheDirectory: getCacheDirectory(),
+  cacheIdentifier: 'key',
   changedFilesWithAncestor: false,
   clearMocks: false,
   collectCoverage: false,

--- a/packages/jest-config/src/ValidConfig.ts
+++ b/packages/jest-config/src/ValidConfig.ts
@@ -17,6 +17,7 @@ const initialOptions: Config.InitialOptions = {
   bail: multipleValidOptions(false, 0),
   cache: true,
   cacheDirectory: '/tmp/user/jest',
+  cacheIdentifier: 'key',
   changedFilesWithAncestor: false,
   changedSince: 'master',
   clearMocks: false,

--- a/packages/jest-config/src/index.ts
+++ b/packages/jest-config/src/index.ts
@@ -171,6 +171,7 @@ const groupOptions = (
     automock: options.automock,
     cache: options.cache,
     cacheDirectory: options.cacheDirectory,
+    cacheIdentifier: options.cacheIdentifier,
     clearMocks: options.clearMocks,
     coveragePathIgnorePatterns: options.coveragePathIgnorePatterns,
     cwd: options.cwd,

--- a/packages/jest-config/src/normalize.ts
+++ b/packages/jest-config/src/normalize.ts
@@ -869,6 +869,7 @@ export default function normalize(
       }
       case 'automock':
       case 'cache':
+      case 'cacheIdentifier':
       case 'changedSince':
       case 'changedFilesWithAncestor':
       case 'clearMocks':

--- a/packages/jest-types/src/Config.ts
+++ b/packages/jest-types/src/Config.ts
@@ -35,6 +35,7 @@ export type DefaultOptions = {
   bail: number;
   cache: boolean;
   cacheDirectory: Path;
+  cacheIdentifier: string;
   changedFilesWithAncestor: boolean;
   clearMocks: boolean;
   collectCoverage: boolean;
@@ -97,6 +98,7 @@ export type InitialOptions = Partial<{
   bail: boolean | number;
   cache: boolean;
   cacheDirectory: Path;
+  cacheIdentifier: string;
   clearMocks: boolean;
   changedFilesWithAncestor: boolean;
   changedSince: string;
@@ -298,6 +300,7 @@ export type ProjectConfig = {
   automock: boolean;
   cache: boolean;
   cacheDirectory: Path;
+  cacheIdentifier: string;
   clearMocks: boolean;
   coveragePathIgnorePatterns: Array<string>;
   cwd: Path;
@@ -356,6 +359,7 @@ export type Argv = Arguments<
     bail: boolean | number;
     cache: boolean;
     cacheDirectory: string;
+    cacheIdentifier: string;
     changedFilesWithAncestor: boolean;
     changedSince: string;
     ci: boolean;

--- a/packages/jest-validate/src/__tests__/fixtures/jestConfig.ts
+++ b/packages/jest-validate/src/__tests__/fixtures/jestConfig.ts
@@ -24,6 +24,7 @@ const defaultConfig = {
   bail: 0,
   browser: false,
   cacheDirectory: path.join(tmpdir(), 'jest'),
+  cacheIdentifier: 'key',
   clearMocks: false,
   coveragePathIgnorePatterns: [NODE_MODULES_REGEXP],
   coverageReporters: ['json', 'text', 'lcov', 'clover'],


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->
This is a proof of concept

TODO:
- [ ]  update changelog
- [ ]  update docs

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
**Motivation**
[#7584](https://github.com/facebook/jest/issues/7584)

When change a version of bable or a version of a plugin/preset, cache invalidation does not occur. 

This PR adds new config option `cacheIdentifier` . The idea is provide to user side cache invalidation detection mechanism.
When parameter `cacheIdentifier` has changed, therefore `configString` also has changed, so a new `cacheKey` will be  created.

**Example:** 

jest.config.js
```
{
  cacheIdentifier:  require('babel-jest}/package.json').version
}
```

## Test plan

TODO:

- [ ]  write tests

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
