### PR TITLE
Add `coverageProvider` to `jest --init` prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - `[jest-config]` Support config files exporting (`async`) `function`s ([#10001](https://github.com/facebook/jest/pull/10001))
 - `[jest-cli, jest-core]` Add `--selectProjects` CLI argument to filter test suites by project name ([#8612](https://github.com/facebook/jest/pull/8612))
+- `[jest-cli, jest-init]` Add `coverageProvider` to `jest --init` prompts ([#10044](https://github.com/facebook/jest/pull/10044))
 
 ### Fixes
 

--- a/packages/jest-cli/src/init/__tests__/__snapshots__/init.test.js.snap
+++ b/packages/jest-cli/src/init/__tests__/__snapshots__/init.test.js.snap
@@ -76,6 +76,9 @@ module.exports = {
   //   \\"/node_modules/\\"
   // ],
 
+  // Indicates which provider should be used to instrument code for coverage
+  // coverageProvider: \\"babel\\",
+
   // A list of reporter names that Jest uses when writing coverage reports
   // coverageReporters: [
   //   \\"json\\",

--- a/packages/jest-cli/src/init/__tests__/init.test.js
+++ b/packages/jest-cli/src/init/__tests__/init.test.js
@@ -93,6 +93,28 @@ describe('init', () => {
         expect(evaluatedConfig).toEqual({coverageDirectory: 'coverage'});
       });
 
+      it('should create configuration for {coverageProvider: "babel"}', async () => {
+        prompts.mockReturnValueOnce({coverageProvider: 'babel'});
+
+        await init(resolveFromFixture('only_package_json'));
+
+        const writtenJestConfig = fs.writeFileSync.mock.calls[0][1];
+        const evaluatedConfig = eval(writtenJestConfig);
+        // should modify when the default coverageProvider will be changed to "v8"
+        expect(evaluatedConfig).toEqual({});
+      });
+
+      it('should create configuration for {coverageProvider: "v8"}', async () => {
+        prompts.mockReturnValueOnce({coverageProvider: 'v8'});
+
+        await init(resolveFromFixture('only_package_json'));
+
+        const writtenJestConfig = fs.writeFileSync.mock.calls[0][1];
+        const evaluatedConfig = eval(writtenJestConfig);
+        // should modify when the default coverageProvider will be changed to "v8"
+        expect(evaluatedConfig).toEqual({coverageProvider: 'v8'});
+      });
+
       it('should create configuration for {environment: "jsdom"}', async () => {
         prompts.mockReturnValueOnce({environment: 'jsdom'});
 

--- a/packages/jest-cli/src/init/generate_config_file.ts
+++ b/packages/jest-cli/src/init/generate_config_file.ts
@@ -35,13 +35,19 @@ const generateConfigFile = (
   results: Record<string, unknown>,
   generateEsm = false,
 ): string => {
-  const {coverage, clearMocks, environment} = results;
+  const {coverage, coverageProvider, clearMocks, environment} = results;
 
   const overrides: Record<string, any> = {};
 
   if (coverage) {
     Object.assign(overrides, {
       coverageDirectory: 'coverage',
+    });
+  }
+
+  if (coverageProvider === 'v8') {
+    Object.assign(overrides, {
+      coverageProvider: 'v8',
     });
   }
 

--- a/packages/jest-cli/src/init/index.ts
+++ b/packages/jest-cli/src/init/index.ts
@@ -28,6 +28,7 @@ const {
 type PromptsResults = {
   clearMocks: boolean;
   coverage: boolean;
+  coverageProvider: boolean;
   environment: boolean;
   scripts: boolean;
 };

--- a/packages/jest-cli/src/init/questions.ts
+++ b/packages/jest-cli/src/init/questions.ts
@@ -25,6 +25,16 @@ const defaultQuestions: Array<PromptObject> = [
     type: 'confirm',
   },
   {
+    choices: [
+      {title: 'v8', value: 'v8'},
+      {title: 'babel', value: 'babel'},
+    ],
+    initial: 0,
+    message: 'Which provider should be used to instrument code for coverage?',
+    name: 'coverageProvider',
+    type: 'select',
+  },
+  {
     initial: false,
     message: 'Automatically clear mock calls and instances between every test?',
     name: 'clearMocks',

--- a/packages/jest-config/src/Descriptions.ts
+++ b/packages/jest-config/src/Descriptions.ts
@@ -21,6 +21,8 @@ const descriptions: {[key in keyof Config.InitialOptions]: string} = {
     'The directory where Jest should output its coverage files',
   coveragePathIgnorePatterns:
     'An array of regexp pattern strings used to skip coverage collection',
+  coverageProvider:
+    'Indicates which provider should be used to instrument code for coverage',
   coverageReporters:
     'A list of reporter names that Jest uses when writing coverage reports',
   coverageThreshold:


### PR DESCRIPTION
Created This PR to resolve this issue #10015, to add 'coverageProvider' to 'jest --init' prompts

### Summary
We need  to encourage folks try out the V8 based code coverage, so the prompt in "--init" and its entry into the generated config file would be help.


