### PR TITLE
Restrict node version to version specified in package.json

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+; During the installation of jest, npm will throw an error if the installed version of node isn't corresponding to requirement
+; specified in package.json
+engine-strict=true


### PR DESCRIPTION
This will prevent installation of jest when node version is incompatible with requirements specified in package.json. It is related to #10012
