### PR TITLE
chore(jest-console): migrate function signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Chore & Maintenance
 
+- `[jest-console]` [**BREAKING**] Move `root` into `config` and take `GlobalConfig` as mandatory parameter for `getConsoleOutput` ([#10126](https://github.com/facebook/jest/pull/10126))
 - `[*]` [**BREAKING**] Only support Node LTS releases and Node 15 ([#10685](https://github.com/facebook/jest/pull/10685))
 - `[*]` [**BREAKING**] Add `exports` field to all `package.json`s ([#9921](https://github.com/facebook/jest/pull/9921))
 - `[*]` Make it easier for Jest's packages to use the VM escape hatch ([#10824](https://github.com/facebook/jest/pull/10824))

--- a/packages/jest-console/src/__tests__/getConsoleOutput.test.ts
+++ b/packages/jest-console/src/__tests__/getConsoleOutput.test.ts
@@ -35,8 +35,6 @@ describe('getConsoleOutput', () => {
     ${'warn'}
   `('takes noStackTrace and pass it on for $logType', logType => {
     getConsoleOutput(
-      'someRootPath',
-      true,
       BufferedConsole.write([], logType as LogType, 'message', 4),
       {
         rootDir: 'root',

--- a/packages/jest-console/src/getConsoleOutput.ts
+++ b/packages/jest-console/src/getConsoleOutput.ts
@@ -15,20 +15,11 @@ import {
 import type {ConsoleBuffer} from './types';
 
 export default (
-  // TODO: remove in 27
-  root: string,
-  // TODO: this is covered by GlobalConfig, switch over in 27
-  verbose: boolean,
   buffer: ConsoleBuffer,
-  // TODO: make mandatory and take Config.ProjectConfig in 27
-  config: StackTraceConfig = {
-    rootDir: root,
-    testMatch: [],
-  },
-  // TODO: make mandatory in 27
-  globalConfig?: Config.GlobalConfig,
+  config: StackTraceConfig,
+  globalConfig: Config.GlobalConfig,
 ): string => {
-  const TITLE_INDENT = verbose ? '  ' : '    ';
+  const TITLE_INDENT = globalConfig.verbose ? '  ' : '    ';
   const CONSOLE_INDENT = TITLE_INDENT + '  ';
 
   const logEntries = buffer.reduce((output, {type, message, origin}) => {

--- a/packages/jest-reporters/src/DefaultReporter.ts
+++ b/packages/jest-reporters/src/DefaultReporter.ts
@@ -186,13 +186,7 @@ export default class DefaultReporter extends BaseReporter {
         '  ' +
           TITLE_BULLET +
           'Console\n\n' +
-          getConsoleOutput(
-            config.cwd,
-            !!this._globalConfig.verbose,
-            result.console,
-            config,
-            this._globalConfig,
-          ),
+          getConsoleOutput(result.console, config, this._globalConfig),
       );
     }
   }

--- a/packages/jest-runner/src/runTest.ts
+++ b/packages/jest-runner/src/runTest.ts
@@ -120,8 +120,6 @@ async function runTestInternal(
   const consoleOut = globalConfig.useStderr ? process.stderr : process.stdout;
   const consoleFormatter = (type: LogType, message: LogMessage) =>
     getConsoleOutput(
-      config.cwd,
-      !!globalConfig.verbose,
       // 4 = the console call is buried 4 stack frames deep
       BufferedConsole.write([], type, message, 4),
       config,


### PR DESCRIPTION

## Summary
PR for #10112 
The breaking changes to `getConsoleOutput`: removing unused parameter, making new parameters mandatory.

## Test plan

Pass existing test cases.
