### PR TITLE
Improve Jest startup time and test runtime, particularly when running with coverage, by caching micromatch and avoiding recreating RegExp instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 
 ### Performance
 
-- `[jest-core, jest-transform]` Improve Jest startup time and test runtime, particularly when running with coverage, by caching micromatch and avoiding recreating RegExp instances ([#10131](https://github.com/facebook/jest/pull/10131))
+- `[jest-core, jest-transform, jest-haste-map]` Improve Jest startup time and test runtime, particularly when running with coverage, by caching micromatch and avoiding recreating RegExp instances ([#10131](https://github.com/facebook/jest/pull/10131))
 
 ## 26.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 
 ### Performance
 
+- `[jest-core]` Cache micromatch in SearchSource globsToMatcher ([#10131](https://github.com/facebook/jest/pull/10131))
+
 ## 26.0.1
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 
 ### Performance
 
-- `[jest-core]` Cache micromatch in SearchSource globsToMatcher and avoid recreating RegExp instances in regexToMatcher ([#10131](https://github.com/facebook/jest/pull/10131))
+- `[jest-core, jest-transform]` Improve Jest startup time and test runtime, particularly when running with coverage, by caching micromatch and avoiding recreating RegExp instances ([#10131](https://github.com/facebook/jest/pull/10131))
 
 ## 26.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 
 ### Performance
 
-- `[jest-core]` Cache micromatch in SearchSource globsToMatcher ([#10131](https://github.com/facebook/jest/pull/10131))
+- `[jest-core]` Cache micromatch in SearchSource globsToMatcher and avoid recreating RegExp instances in regexToMatcher ([#10131](https://github.com/facebook/jest/pull/10131))
 
 ## 26.0.1
 

--- a/packages/jest-core/src/SearchSource.ts
+++ b/packages/jest-core/src/SearchSource.ts
@@ -83,9 +83,19 @@ const globsToMatcher = (globs: Array<Config.Glob>) => {
   };
 };
 
-const regexToMatcher = (testRegex: Config.ProjectConfig['testRegex']) => (
-  path: Config.Path,
-) => testRegex.some(testRegex => new RegExp(testRegex).test(path));
+const regexToMatcher = (testRegex: Config.ProjectConfig['testRegex']) => {
+  const regexes = testRegex.map(testRegex => new RegExp(testRegex));
+
+  return (path: Config.Path) =>
+    regexes.some(regex => {
+      const result = regex.test(path);
+
+      // prevent stateful regexes from breaking, just in case
+      regex.lastIndex = 0;
+
+      return result;
+    });
+};
 
 const toTests = (context: Context, tests: Array<Config.Path>) =>
   tests.map(path => ({

--- a/packages/jest-core/src/__tests__/SearchSource.test.ts
+++ b/packages/jest-core/src/__tests__/SearchSource.test.ts
@@ -206,6 +206,34 @@ describe('SearchSource', () => {
       });
     });
 
+    it('finds tests matching a JS with overriding glob patterns', () => {
+      const {options: config} = normalize(
+        {
+          moduleFileExtensions: ['js', 'jsx'],
+          name,
+          rootDir,
+          testMatch: [
+            '**/*.js?(x)',
+            '!**/test.js?(x)',
+            '**/test.js',
+            '!**/test.js',
+          ],
+          testRegex: '',
+        },
+        {} as Config.Argv,
+      );
+
+      return findMatchingTests(config).then(data => {
+        const relPaths = toPaths(data.tests).map(absPath =>
+          path.relative(rootDir, absPath),
+        );
+        expect(relPaths.sort()).toEqual([
+          path.normalize('module.jsx'),
+          path.normalize('no_tests.js'),
+        ]);
+      });
+    });
+
     it('finds tests with default file extensions using testRegex', () => {
       const {options: config} = normalize(
         {

--- a/packages/jest-haste-map/src/HasteFS.ts
+++ b/packages/jest-haste-map/src/HasteFS.ts
@@ -5,8 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import micromatch = require('micromatch');
-import {replacePathSepForGlob} from 'jest-util';
+import {globsToMatcher, replacePathSepForGlob} from 'jest-util';
 import type {Config} from '@jest/types';
 import type {FileData} from './types';
 import * as fastPath from './lib/fast_path';
@@ -84,9 +83,11 @@ export default class HasteFS {
     root: Config.Path | null,
   ): Set<Config.Path> {
     const files = new Set<string>();
+    const matcher = globsToMatcher(globs);
+
     for (const file of this.getAbsoluteFileIterator()) {
       const filePath = root ? fastPath.relative(root, file) : file;
-      if (micromatch([replacePathSepForGlob(filePath)], globs).length > 0) {
+      if (matcher(replacePathSepForGlob(filePath))) {
         files.add(file);
       }
     }

--- a/packages/jest-util/package.json
+++ b/packages/jest-util/package.json
@@ -14,11 +14,13 @@
     "chalk": "^4.0.0",
     "graceful-fs": "^4.2.4",
     "is-ci": "^2.0.0",
-    "make-dir": "^3.0.0"
+    "make-dir": "^3.0.0",
+    "micromatch": "^4.0.2"
   },
   "devDependencies": {
     "@types/graceful-fs": "^4.1.2",
     "@types/is-ci": "^2.0.0",
+    "@types/micromatch": "^4.0.0",
     "@types/node": "*"
   },
   "engines": {

--- a/packages/jest-util/src/__tests__/globsToMatcher.test.ts
+++ b/packages/jest-util/src/__tests__/globsToMatcher.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import micromatch = require('micromatch');
+import globsToMatcher from '../globsToMatcher';
+
+it('works like micromatch with only positive globs', () => {
+  const globs = ['**/*.test.js', '**/*.test.jsx'];
+  const matcher = globsToMatcher(globs);
+
+  expect(matcher('some-module.js')).toBe(
+    micromatch(['some-module.js'], globs).length > 0,
+  );
+
+  expect(matcher('some-module.test.js')).toBe(
+    micromatch(['some-module.test.js'], globs).length > 0,
+  );
+});
+
+it('works like micromatch with a mix of overlapping positive and negative globs', () => {
+  const globs = ['**/*.js', '!**/*.test.js', '**/*.test.js'];
+  const matcher = globsToMatcher(globs);
+
+  expect(matcher('some-module.js')).toBe(
+    micromatch(['some-module.js'], globs).length > 0,
+  );
+
+  expect(matcher('some-module.test.js')).toBe(
+    micromatch(['some-module.test.js'], globs).length > 0,
+  );
+
+  const globs2 = ['**/*.js', '!**/*.test.js', '**/*.test.js', '!**/*.test.js'];
+  const matcher2 = globsToMatcher(globs2);
+
+  expect(matcher2('some-module.js')).toBe(
+    micromatch(['some-module.js'], globs2).length > 0,
+  );
+
+  expect(matcher2('some-module.test.js')).toBe(
+    micromatch(['some-module.test.js'], globs2).length > 0,
+  );
+});
+
+it('works like micromatch with only negative globs', () => {
+  const globs = ['!**/*.test.js', '!**/*.test.jsx'];
+  const matcher = globsToMatcher(globs);
+
+  expect(matcher('some-module.js')).toBe(
+    micromatch(['some-module.js'], globs).length > 0,
+  );
+
+  expect(matcher('some-module.test.js')).toBe(
+    micromatch(['some-module.test.js'], globs).length > 0,
+  );
+});

--- a/packages/jest-util/src/__tests__/globsToMatcher.test.ts
+++ b/packages/jest-util/src/__tests__/globsToMatcher.test.ts
@@ -57,3 +57,16 @@ it('works like micromatch with only negative globs', () => {
     micromatch(['some-module.test.js'], globs).length > 0,
   );
 });
+
+it('works like micromatch with empty globs', () => {
+  const globs = [];
+  const matcher = globsToMatcher(globs);
+
+  expect(matcher('some-module.js')).toBe(
+    micromatch(['some-module.js'], globs).length > 0,
+  );
+
+  expect(matcher('some-module.test.js')).toBe(
+    micromatch(['some-module.test.js'], globs).length > 0,
+  );
+});

--- a/packages/jest-util/src/globsToMatcher.ts
+++ b/packages/jest-util/src/globsToMatcher.ts
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import micromatch = require('micromatch');
+import type {Config} from '@jest/types';
+import replacePathSepForGlob from './replacePathSepForGlob';
+
+const globsMatchers = new Map<
+  string,
+  {
+    isMatch: (str: string) => boolean;
+    negated: boolean;
+  }
+>();
+
+export default function globsToMatcher(
+  globs: Array<Config.Glob>,
+): (path: Config.Path) => boolean {
+  const matchers = globs.map(glob => {
+    if (!globsMatchers.has(glob)) {
+      const state = micromatch.scan(glob, {dot: true});
+      const matcher = {
+        isMatch: micromatch.matcher(glob, {dot: true}),
+        negated: state.negated,
+      };
+      globsMatchers.set(glob, matcher);
+    }
+    return globsMatchers.get(glob)!;
+  });
+
+  return (path: Config.Path): boolean => {
+    const replacedPath = replacePathSepForGlob(path);
+    let kept = false;
+    let omitted = false;
+    let negatives = 0;
+
+    for (let i = 0; i < matchers.length; i++) {
+      const {isMatch, negated} = matchers[i];
+
+      if (negated) negatives++;
+
+      const matched = isMatch(replacedPath);
+
+      if (!matched && negated) {
+        kept = false;
+        omitted = true;
+      } else if (matched && !negated) {
+        kept = true;
+        omitted = false;
+      }
+    }
+
+    return negatives === matchers.length ? !omitted : kept && !omitted;
+  };
+}

--- a/packages/jest-util/src/globsToMatcher.ts
+++ b/packages/jest-util/src/globsToMatcher.ts
@@ -20,6 +20,10 @@ const globsMatchers = new Map<
 export default function globsToMatcher(
   globs: Array<Config.Glob>,
 ): (path: Config.Path) => boolean {
+  if (globs.length === 0) {
+    return (_: Config.Path): boolean => false;
+  }
+
   const matchers = globs.map(glob => {
     if (!globsMatchers.has(glob)) {
       const state = micromatch.scan(glob, {dot: true});

--- a/packages/jest-util/src/globsToMatcher.ts
+++ b/packages/jest-util/src/globsToMatcher.ts
@@ -9,7 +9,7 @@ import micromatch = require('micromatch');
 import type {Config} from '@jest/types';
 import replacePathSepForGlob from './replacePathSepForGlob';
 
-const globsMatchers = new Map<
+const globsToMatchersMap = new Map<
   string,
   {
     isMatch: (str: string) => boolean;
@@ -17,29 +17,54 @@ const globsMatchers = new Map<
   }
 >();
 
+const micromatchOptions = {dot: true};
+
+/**
+ * Converts a list of globs into a function that matches a path against the
+ * globs.
+ *
+ * Every time micromatch is called, it will parse the glob strings and turn
+ * them into regexp instances. Instead of calling micromatch repeatedly with
+ * the same globs, we can use this function which will build the micromatch
+ * matchers ahead of time and then have an optimized path for determining
+ * whether an individual path matches.
+ *
+ * This function is intended to match the behavior of `micromatch()`.
+ *
+ * @example
+ * const isMatch = globsToMatcher(['*.js', '!*.test.js']);
+ * isMatch('pizza.js'); // true
+ * isMatch('pizza.test.js'); // false
+ */
 export default function globsToMatcher(
   globs: Array<Config.Glob>,
 ): (path: Config.Path) => boolean {
   if (globs.length === 0) {
+    // Since there were no globs given, we can simply have a fast path here and
+    // return with a very simple function.
     return (_: Config.Path): boolean => false;
   }
 
   const matchers = globs.map(glob => {
-    if (!globsMatchers.has(glob)) {
-      const state = micromatch.scan(glob, {dot: true});
+    if (!globsToMatchersMap.has(glob)) {
+      // Matchers that are negated have different behavior than matchers that
+      // are not negated, so we need to store this information ahead of time.
+      const {negated} = micromatch.scan(glob, micromatchOptions);
+
       const matcher = {
-        isMatch: micromatch.matcher(glob, {dot: true}),
-        negated: state.negated,
+        isMatch: micromatch.matcher(glob, micromatchOptions),
+        negated,
       };
-      globsMatchers.set(glob, matcher);
+
+      globsToMatchersMap.set(glob, matcher);
     }
-    return globsMatchers.get(glob)!;
+
+    return globsToMatchersMap.get(glob)!;
   });
 
   return (path: Config.Path): boolean => {
     const replacedPath = replacePathSepForGlob(path);
-    let kept = false;
-    let omitted = false;
+    let kept = undefined;
     let negatives = 0;
 
     for (let i = 0; i < matchers.length; i++) {
@@ -50,14 +75,23 @@ export default function globsToMatcher(
       const matched = isMatch(replacedPath);
 
       if (!matched && negated) {
+        // The path was not matched, and the matcher is a negated matcher, so we
+        // want to omit the path. This means that the negative matcher is
+        // filtering the path out.
         kept = false;
-        omitted = true;
       } else if (matched && !negated) {
+        // The path was matched, and the matcher is not a negated matcher, so we
+        // want to keep the path.
         kept = true;
-        omitted = false;
       }
     }
 
-    return negatives === matchers.length ? !omitted : kept && !omitted;
+    // If all of the globs were negative globs, then we want to include the path
+    // as long as it was not explicitly not kept. Otherwise only include
+    // the path if it was kept. This allows sets of globs that are all negated
+    // to allow some paths to be matched, while sets of globs that are mixed
+    // negated and non-negated to cause the negated matchers to only omit paths
+    // and not keep them.
+    return negatives === matchers.length ? kept !== false : !!kept;
   };
 }

--- a/packages/jest-util/src/globsToMatcher.ts
+++ b/packages/jest-util/src/globsToMatcher.ts
@@ -70,7 +70,9 @@ export default function globsToMatcher(
     for (let i = 0; i < matchers.length; i++) {
       const {isMatch, negated} = matchers[i];
 
-      if (negated) negatives++;
+      if (negated) {
+        negatives++;
+      }
 
       const matched = isMatch(replacedPath);
 

--- a/packages/jest-util/src/index.ts
+++ b/packages/jest-util/src/index.ts
@@ -18,6 +18,7 @@ export {default as convertDescriptorToString} from './convertDescriptorToString'
 import * as specialChars from './specialChars';
 export {default as replacePathSepForGlob} from './replacePathSepForGlob';
 export {default as testPathPatternToRegExp} from './testPathPatternToRegExp';
+export {default as globsToMatcher} from './globsToMatcher';
 import * as preRunMessage from './preRunMessage';
 export {default as pluralize} from './pluralize';
 export {default as formatTime} from './formatTime';


### PR DESCRIPTION
I was profiling some Jest runs at Airbnb and noticed that on my
MacBook Pro, we can spend over 2 seconds at Jest startup time in
SearchSource getTestPaths. I believe that this will grow as the size
of the codebase increases.

Looking at the call stacks, it appears to be calling micromatch
repeatedly, which calls picomatch, which builds a regex out of the
globs. It seems that the parsing and regex building also triggers the
garbage collector frequently.

Upon testing, I noticed that the globs don't actually change between
these calls, so we can save a bunch of work by making a micromatch
matcher and reusing that function for all of the paths.

micromatch has some logic internally to handle lists of globs that
may include negated globs. A naive approach of just checking if it
matched any of the globs won't capture that, so I copied and
simplified the logic from within micromatch.

https://github.com/micromatch/micromatch/blob/fe4858b0/index.js#L27-L77

In my profiling of this change locally, this brings down the time of
startRun from about 2000ms to about 200ms.

Before:
![image](https://user-images.githubusercontent.com/195534/83883496-26757e80-a709-11ea-8521-2a71d27ca709.png)

Before, zoomed in:
![image](https://user-images.githubusercontent.com/195534/83971126-26a78280-a89f-11ea-889e-80e925878e43.png)


After:

![image](https://user-images.githubusercontent.com/195534/83883541-37be8b00-a709-11ea-9ee6-f6fdccced6fd.png)

---

**Avoid recreating RegExp instances in regexToMatcher**

After optimizing globsToMatcher, I noticed that there was still a
lot of unnecessary overhead at Jest startup time spent recreating
the same RegExp instances repeatedly. Thankfully, we can be a little
smarter about this and create them all ahead of time and just reuse
them.

On top of my globsToMatcher optimization, this brings the speed of
the ArrayMap in startRun down from about 160ms to about 7ms.

Before:
![image](https://user-images.githubusercontent.com/195534/84039093-5ff6f580-a966-11ea-8eab-282994c45dd5.png)

After:
![image](https://user-images.githubusercontent.com/195534/84039144-72712f00-a966-11ea-9f1f-b4d5e6a97acd.png)

---

**Optimize micromatch and RegExps in shouldInstrument**

I've been profiling running Jest with code coverage at Airbnb, and
noticed that shouldInstrument is called often and is fairly
expensive. It also seems to call micromatch and `new RegExp`
repeatedly, both of which can be optimized by caching the work to
convert globs and strings into matchers and regexes.

I profiled this change by running a set of 27 fairly simple tests.
Before this change, about 6-7 seconds was spent in shouldInstrument.
After this change, only 400-500 ms is spent there. I would expect
this delta to increase along with the number of tests and size of
their dependency graphs.

A typical shouldInstrument call before this change:
![image](https://user-images.githubusercontent.com/195534/84052508-48276d80-a976-11ea-8d6b-a8930d5a9e45.png)

A typical shouldInstrument call after this change (most are actually too fast to even show up in the profiler now):
![image](https://user-images.githubusercontent.com/195534/84052571-60978800-a976-11ea-800d-caf7d58d76fe.png)

---

I was profiling some Jest runs at Airbnb and noticed that on my
MacBook Pro, we can spend over 30 seconds after running Jest with code
coverage as the coverage reporter adds all of the untested files. I
believe that this will grow as the size of the codebase increases.

Looking at the call stacks, it appears to be calling micromatch
repeatedly, which calls picomatch, which builds a regex out of the
globs. It seems that the parsing and regex building also triggers the
garbage collector frequently.

Since this is in a tight loop and the globs won't change between
checks, we can greatly improve the performance here by using
micromatch.matcher.

This optimization reduces the block of time here from about 30s to
about 10s. The aggregated total time of coverage reporter's
onRunComplete goes from 23s to 600ms.

Before:

![image](https://user-images.githubusercontent.com/195534/83884747-fc24c080-a70a-11ea-8440-2c658b3dcce4.png)

Before, zoomed in:
![image](https://user-images.githubusercontent.com/195534/84053653-d819e700-a977-11ea-9597-4b650f4c26cb.png)



After:

![image](https://user-images.githubusercontent.com/195534/83884781-08108280-a70b-11ea-9d63-5329fe726d31.png)

After, zoomed in:
![image](https://user-images.githubusercontent.com/195534/84053716-f08a0180-a977-11ea-8dee-167ddef18ff0.png)


<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Motivation: Improve slow Jest startup and runtime speed, particularly when running with coverage

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

I ran jest in the Airbnb frontend monorepo with and without coverage options, with a path argument.