### PR TITLE
Reduce micromatch overhead in jest-haste-map HasteFS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 
 ### Performance
 
+- `[jest-haste-map]` Reduce micromatch overhead in jest-haste-map HasteFS
+
 ## 26.0.1
 
 ### Fixes

--- a/packages/jest-haste-map/src/HasteFS.ts
+++ b/packages/jest-haste-map/src/HasteFS.ts
@@ -84,9 +84,12 @@ export default class HasteFS {
     root: Config.Path | null,
   ): Set<Config.Path> {
     const files = new Set<string>();
+
+    const matchers = globs.map(glob => micromatch.matcher(glob));
+
     for (const file of this.getAbsoluteFileIterator()) {
       const filePath = root ? fastPath.relative(root, file) : file;
-      if (micromatch([replacePathSepForGlob(filePath)], globs).length > 0) {
+      if (matchers.some(isMatch => isMatch(replacePathSepForGlob(filePath)))) {
         files.add(file);
       }
     }


### PR DESCRIPTION
I was profiling some Jest runs at Airbnb and noticed that on my
MacBook Pro, we can spend over 30 seconds after running Jest with code
coverage as the coverage reporter adds all of the untested files. I
believe that this will grow as the size of the codebase increases.

Looking at the call stacks, it appears to be calling micromatch
repeatedly, which calls picomatch, which builds a regex out of the
globs. It seems that the parsing and regex building also triggers the
garbage collector frequently.

Since this is in a tight loop and the globs won't change between
checks, we can greatly improve the performance here by using
micromatch.matcher.

This optimization reduces the block of time here from about 30s to
about 10s. The aggregated total time of coverage reporter's
onRunComplete goes from 23s to 600ms.

Before:

![image](https://user-images.githubusercontent.com/195534/83884747-fc24c080-a70a-11ea-8440-2c658b3dcce4.png)


After:

![image](https://user-images.githubusercontent.com/195534/83884781-08108280-a70b-11ea-9d63-5329fe726d31.png)


<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Motivation: Improve Jest performance when collecting coverage

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
I ran jest in the Airbnb frontend monorepo with and without coverage options, with a path argument.