### PR TITLE
chore: replace `make-dir` with `fs.mkdir`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - `[jest-runtime]` Jest-internal sandbox escape hatch ([#9907](https://github.com/facebook/jest/pull/9907))
 - `[jest-fake-timers]` Update `now` param type to support `Date` in addition to `number`. ([#10169](https://github.com/facebook/jest/pull/10169))
 - `[docs]` Add param to `setSystemTime` docs and remove preceding period from it and `getRealSystemTime` ([#10169](https://github.com/facebook/jest/pull/10169))
+- `[jest-snapshot, jest-util]` Replace `make-dir` with `fs.mkdir` ([#10136](https://github.com/facebook/jest/pull/10136))
 
 ### Performance
 

--- a/e2e/Utils.ts
+++ b/e2e/Utils.ts
@@ -11,7 +11,6 @@ import type {Config} from '@jest/types';
 
 // eslint-disable-next-line import/named
 import {ExecaReturnValue, sync as spawnSync} from 'execa';
-import makeDir = require('make-dir');
 import rimraf = require('rimraf');
 import dedent = require('dedent');
 import which = require('which');
@@ -46,7 +45,7 @@ export const linkJestPackage = (packageName: string, cwd: Config.Path) => {
   const packagesDir = path.resolve(__dirname, '../packages');
   const packagePath = path.resolve(packagesDir, packageName);
   const destination = path.resolve(cwd, 'node_modules/', packageName);
-  makeDir.sync(destination);
+  fs.mkdirSync(destination, {recursive: true});
   rimraf.sync(destination);
   fs.symlinkSync(packagePath, destination, 'junction');
 };
@@ -77,12 +76,12 @@ export const writeFiles = (
   directory: string,
   files: {[filename: string]: string},
 ) => {
-  makeDir.sync(directory);
+  fs.mkdirSync(directory, {recursive: true});
   Object.keys(files).forEach(fileOrPath => {
     const dirname = path.dirname(fileOrPath);
 
     if (dirname !== '/') {
-      makeDir.sync(path.join(directory, dirname));
+      fs.mkdirSync(path.join(directory, dirname), {recursive: true});
     }
     fs.writeFileSync(
       path.resolve(directory, ...fileOrPath.split('/')),
@@ -95,13 +94,13 @@ export const writeSymlinks = (
   directory: string,
   symlinks: {[existingFile: string]: string},
 ) => {
-  makeDir.sync(directory);
+  fs.mkdirSync(directory, {recursive: true});
   Object.keys(symlinks).forEach(fileOrPath => {
     const symLinkPath = symlinks[fileOrPath];
     const dirname = path.dirname(symLinkPath);
 
     if (dirname !== '/') {
-      makeDir.sync(path.join(directory, dirname));
+      fs.mkdirSync(path.join(directory, dirname), {recursive: true});
     }
     fs.symlinkSync(
       path.resolve(directory, ...fileOrPath.split('/')),
@@ -165,7 +164,7 @@ export const createEmptyPackage = (
     },
   };
 
-  makeDir.sync(directory);
+  fs.mkdirSync(directory, {recursive: true});
   packageJson || (packageJson = DEFAULT_PACKAGE_JSON);
   fs.writeFileSync(
     path.resolve(directory, 'package.json'),

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "jest-watch-typeahead": "^0.5.0",
     "jquery": "^3.2.1",
     "lerna": "^3.20.2",
-    "make-dir": "^3.0.0",
     "micromatch": "^4.0.2",
     "mock-fs": "^4.4.1",
     "opencollective": "^1.0.3",

--- a/packages/jest-snapshot/package.json
+++ b/packages/jest-snapshot/package.json
@@ -22,7 +22,6 @@
     "jest-matcher-utils": "^26.0.1",
     "jest-message-util": "^26.0.1",
     "jest-resolve": "^26.0.1",
-    "make-dir": "^3.0.0",
     "natural-compare": "^1.4.0",
     "pretty-format": "^26.0.1",
     "semver": "^7.3.2"

--- a/packages/jest-snapshot/src/utils.ts
+++ b/packages/jest-snapshot/src/utils.ts
@@ -182,7 +182,7 @@ const printBacktickString = (str: string): string =>
 
 export const ensureDirectoryExists = (filePath: Config.Path): void => {
   try {
-    fs.mkdirSync(path.join(path.dirname(filePath)), {recursive: true})
+    fs.mkdirSync(path.join(path.dirname(filePath)), {recursive: true});
   } catch (e) {}
 };
 

--- a/packages/jest-snapshot/src/utils.ts
+++ b/packages/jest-snapshot/src/utils.ts
@@ -7,7 +7,6 @@
 
 import * as path from 'path';
 import * as fs from 'graceful-fs';
-import makeDir = require('make-dir');
 import naturalCompare = require('natural-compare');
 import chalk = require('chalk');
 import type {Config} from '@jest/types';
@@ -183,7 +182,7 @@ const printBacktickString = (str: string): string =>
 
 export const ensureDirectoryExists = (filePath: Config.Path): void => {
   try {
-    makeDir.sync(path.join(path.dirname(filePath)));
+    fs.mkdirSync(path.join(path.dirname(filePath)), {recursive: true})
   } catch (e) {}
 };
 

--- a/packages/jest-util/package.json
+++ b/packages/jest-util/package.json
@@ -13,8 +13,7 @@
     "@jest/types": "^26.0.1",
     "chalk": "^4.0.0",
     "graceful-fs": "^4.2.4",
-    "is-ci": "^2.0.0",
-    "make-dir": "^3.0.0"
+    "is-ci": "^2.0.0"
   },
   "devDependencies": {
     "@types/graceful-fs": "^4.1.2",

--- a/packages/jest-util/src/createDirectory.ts
+++ b/packages/jest-util/src/createDirectory.ts
@@ -5,12 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import makeDir = require('make-dir');
+import * as fs from 'graceful-fs';
 import type {Config} from '@jest/types';
 
 export default function createDirectory(path: Config.Path): void {
   try {
-    makeDir.sync(path);
+    fs.mkdirSync(path, {recursive: true});
   } catch (e) {
     if (e.code !== 'EEXIST') {
       throw e;

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -23,7 +23,6 @@
 const fs = require('fs');
 const path = require('path');
 const glob = require('glob');
-const makeDir = require('make-dir');
 
 const babel = require('@babel/core');
 const chalk = require('chalk');
@@ -83,7 +82,7 @@ function buildFile(file, silent) {
     return;
   }
 
-  makeDir.sync(path.dirname(destPath));
+  fs.mkdirSync(path.dirname(destPath), {recursive: true});
   if (
     !micromatch.isMatch(file, JS_FILES_PATTERN) &&
     !micromatch.isMatch(file, TS_FILES_PATTERN)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Builtin fs.mkdir supports recursive option since node v10.

See here https://nodejs.org/docs/latest-v10.x/api/fs.html#fs_fs_mkdirsync_path_option
