### PR TITLE
feat(jest-mock): Export Mock, MockInstance, SpyInstance types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 
+- `[jest-mock]` Export `Mock`, `MockInstance`, `SpyInstance` types ([#10138](https://github.com/facebook/jest/pull/10138))
 - `[jest-config]` Support config files exporting (`async`) `function`s ([#10001](https://github.com/facebook/jest/pull/10001))
 - `[jest-cli, jest-core]` Add `--selectProjects` CLI argument to filter test suites by project name ([#8612](https://github.com/facebook/jest/pull/8612))
 - `[jest-cli, jest-init]` Add `coverageProvider` to `jest --init` prompts ([#10044](https://github.com/facebook/jest/pull/10044))


### PR DESCRIPTION
## Summary
I'm maintaining a utility library that eases module mocking for TS projects: https://github.com/userlike/joke

While trying to fix `@userlike/joke` to be compatible with Jest 26, I've noticed that:
1) `@types/jest` is not needed anymore.
2) Although `fn` and `spyOn` are part of the public API, their return types are not directly exported. They can be indirectly acquired via `ReturnType`, but that causes loss of generic types. I see no reason why those types should not be exported as they are already part of the public contract.

So I modified `jest-mock` package to export `Mock`, `MockInstance` and `SpyInstance` types.