### PR TITLE
Fix misspell in ja/index.html

### DIFF
--- a/ja/index.html
+++ b/ja/index.html
@@ -26,7 +26,7 @@
 </span></div></div></div><div class="blockElement yellow alignCenter fourByGridBlock"><div class="blockContent"><h2><div><span><p>独立的</p>
 </span></div></h2><div><span><p>パフォーマンスを最大化するために、別々のプロセスで実行してテストを並列化します。</p>
 </span></div></div></div><div class="blockElement yellow alignCenter fourByGridBlock"><div class="blockContent"><h2><div><span><p>優れた API</p>
-</span></div></h2><div><span><p><code>it</code> から <code>expect</code> まで――。 Jest にはすべてのツールキットが1つにまとまっています。きちんとドキュメント化され、メンテナンスされている、よく出来たツールキットでｓ．</p>
+</span></div></h2><div><span><p><code>it</code> から <code>expect</code> まで――。 Jest にはすべてのツールキットが1つにまとまっています。きちんとドキュメント化され、メンテナンスされている、よく出来たツールキットです．</p>
 </span></div></div></div></div></div></div><div class="container section-container lightBackground paddingBottom paddingTop"><div class="wrapper"><div class="gridBlock"><div class="blockElement green imageAlignSide imageAlignLeft twoByGridBlock"><div class="blockImage"><img src="/img/content/feature-fast.png"/></div><div class="blockContent"><h2><div><span><p>高速で安全</p>
 </span></div></h2><div><span><p>By ensuring your tests have unique global state, Jest can reliably run tests in parallel. To make things quick, Jest runs previously failed tests first and re-organizes runs based on how long test files take.</p>
 </span></div></div></div></div></div></div><div class="container section-container paddingBottom paddingTop"><div class="wrapper"><div class="gridBlock"><div class="blockElement yellow imageAlignSide imageAlignRight twoByGridBlock"><div class="blockContent"><h2><div><span><p>コードカバレッジ</p>


### PR DESCRIPTION
## Summary

Fixed misspell on https://jestjs.io/ja/ page

## Test plan

'でｓ' would change into 'です'

![image](https://user-images.githubusercontent.com/972846/84112455-beee6480-aa63-11ea-97ef-f89af274866e.png)

