### PR TITLE
fix(mock): allow to mock methods in getters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Fixes
 
+- `[jest-mock]` Allow to mock methods in getters (TypeScript 3.9 export)
+
 ### Chore & Maintenance
 
 ### Performance

--- a/packages/jest-mock/src/__tests__/index.test.ts
+++ b/packages/jest-mock/src/__tests__/index.test.ts
@@ -1176,6 +1176,46 @@ describe('moduleMocker', () => {
       expect(spy1.mock.calls.length).toBe(1);
       expect(spy2.mock.calls.length).toBe(1);
     });
+
+    it('should work with getters', () => {
+      let isOriginalCalled = false;
+      let originalCallThis;
+      let originalCallArguments;
+      const obj = {
+        get method() {
+          return function () {
+            isOriginalCalled = true;
+            originalCallThis = this;
+            originalCallArguments = arguments;
+          };
+        },
+      };
+
+      const spy = moduleMocker.spyOn(obj, 'method');
+
+      const thisArg = {this: true};
+      const firstArg = {first: true};
+      const secondArg = {second: true};
+      obj.method.call(thisArg, firstArg, secondArg);
+      expect(isOriginalCalled).toBe(true);
+      expect(originalCallThis).toBe(thisArg);
+      expect(originalCallArguments.length).toBe(2);
+      expect(originalCallArguments[0]).toBe(firstArg);
+      expect(originalCallArguments[1]).toBe(secondArg);
+      expect(spy).toHaveBeenCalled();
+
+      isOriginalCalled = false;
+      originalCallThis = null;
+      originalCallArguments = null;
+      spy.mockRestore();
+      obj.method.call(thisArg, firstArg, secondArg);
+      expect(isOriginalCalled).toBe(true);
+      expect(originalCallThis).toBe(thisArg);
+      expect(originalCallArguments.length).toBe(2);
+      expect(originalCallArguments[0]).toBe(firstArg);
+      expect(originalCallArguments[1]).toBe(secondArg);
+      expect(spy).not.toHaveBeenCalled();
+    });
   });
 
   describe('spyOnProperty', () => {

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -985,17 +985,37 @@ class ModuleMockerClass {
 
       const isMethodOwner = object.hasOwnProperty(methodName);
 
-      // @ts-expect-error overriding original method with a Mock
-      object[methodName] = this._makeComponent({type: 'function'}, () => {
-        if (isMethodOwner) {
-          object[methodName] = original;
-        } else {
-          delete object[methodName];
-        }
-      });
+      let descriptor = Object.getOwnPropertyDescriptor(object, methodName);
+      let proto = Object.getPrototypeOf(object);
 
-      // @ts-expect-error original method is now a Mock
-      object[methodName].mockImplementation(function (this: unknown) {
+      while (!descriptor && proto !== null) {
+        descriptor = Object.getOwnPropertyDescriptor(proto, methodName);
+        proto = Object.getPrototypeOf(proto);
+      }
+
+      let mock: JestMock.Mock<unknown, Array<unknown>>;
+
+      if (descriptor && descriptor.get) {
+        const originalGet = descriptor.get;
+        mock = this._makeComponent({type: 'function'}, () => {
+          descriptor!.get = originalGet;
+          Object.defineProperty(object, methodName, descriptor!);
+        });
+        descriptor.get = () => mock;
+        Object.defineProperty(object, methodName, descriptor);
+      } else {
+        mock = this._makeComponent({type: 'function'}, () => {
+          if (isMethodOwner) {
+            object[methodName] = original;
+          } else {
+            delete object[methodName];
+          }
+        });
+        // @ts-expect-error overriding original method with a Mock
+        object[methodName] = mock;
+      }
+
+      mock.mockImplementation(function (this: unknown) {
         return original.apply(this, arguments);
       });
     }


### PR DESCRIPTION
## Summary

In TypeScript `3.9.x`, module "re-export" is done using readonly accessor.
It breaks all tests written using `jest.spyOn` mocks.
A solution is to automatically mock methods that are wrapped in getters.

## Test plan

```typescript
/**********************
 * module-a
 **********************/

// file: lib/feature.ts
export function myFunction(): boolean {
    return true;
}

// file: index.ts
export * from "./lib/feature.ts"

/**********************
 * submodule
 **********************/

// file: lib/subfeature.ts
import * as mod from "module-a";

export function mySubFunction(): boolean {
    return mod.myFunction();
}

// file: lib/subfeature.spec.ts
import * as submod from "./subfeature";
import * as mod from "module-a";

describe("mySubFunction", () => {
    let spy: jest.SpyInstance;
    beforeEach(() => { spy = jest.spyOn(mod, "myFunction"); });
    afterEach(() => { spy.mockRestore(); });

    it("should call mod.myFunction()", () => {
        submod.mySubFunction();
        expect(spy).toHaveBeenCalled();
    });
});
```

If `module-a` was built using TypeScript `< 3.9`, this will work.
If `module-a` was built using TypeScript `>= 3.9`, this will throw with error `TypeError: Cannot set property query of #<Object> which has only a getter`.
