### PR TITLE
setSystemTime and getRealSystemTime type and doc update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 - `[jest-core]` 🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉 ([#10000](https://github.com/facebook/jest/pull/10000))
 - `[jest-core, jest-reporters, jest-test-result, jest-types]` Cleanup `displayName` type ([#10049](https://github.com/facebook/jest/pull/10049))
 - `[jest-runtime]` Jest-internal sandbox escape hatch ([#9907](https://github.com/facebook/jest/pull/9907))
+- `[jest-fake-timers]` Update `now` param type to support `Date` in addition to `number`. ([#10169](https://github.com/facebook/jest/pull/10169))
+- `[docs]` Add param to `setSystemTime` docs and remove preceding period from it and `getRealSystemTime` ([#10169](https://github.com/facebook/jest/pull/10169))
 
 ### Performance
 

--- a/docs/JestObjectAPI.md
+++ b/docs/JestObjectAPI.md
@@ -647,7 +647,7 @@ This means, if any timers have been scheduled (but have not yet executed), they 
 
 Returns the number of fake timers still left to run.
 
-### `.jest.setSystemTime()`
+### `.jest.setSystemTime(now?: number | Date)`
 
 Set the current system time used by fake timers. Simulates a user changing the system clock while your program is running. It affects the current time but it does not in itself cause e.g. timers to fire; they will fire exactly as they would have done without the call to `jest.setSystemTime()`.
 

--- a/docs/JestObjectAPI.md
+++ b/docs/JestObjectAPI.md
@@ -647,13 +647,13 @@ This means, if any timers have been scheduled (but have not yet executed), they 
 
 Returns the number of fake timers still left to run.
 
-### `.jest.setSystemTime(now?: number | Date)`
+### `jest.setSystemTime(now?: number | Date)`
 
 Set the current system time used by fake timers. Simulates a user changing the system clock while your program is running. It affects the current time but it does not in itself cause e.g. timers to fire; they will fire exactly as they would have done without the call to `jest.setSystemTime()`.
 
 > Note: This function is only available when using modern fake timers implementation
 
-### `.jest.getRealSystemTime()`
+### `jest.getRealSystemTime()`
 
 When mocking time, `Date.now()` will also be mocked. If you for some reason need access to the real current time, you can invoke this function.
 

--- a/e2e/modern-fake-timers/from-config/__tests__/test.js
+++ b/e2e/modern-fake-timers/from-config/__tests__/test.js
@@ -7,8 +7,18 @@
 
 'use strict';
 
-test('fake timers', () => {
+test('fake timers with number argument', () => {
   jest.setSystemTime(0);
+
+  expect(Date.now()).toBe(0);
+
+  jest.setSystemTime(1000);
+
+  expect(Date.now()).toBe(1000);
+});
+
+test('fake timers with Date argument', () => {
+  jest.setSystemTime(new Date(0));
 
   expect(Date.now()).toBe(0);
 

--- a/e2e/modern-fake-timers/from-config/__tests__/test.js
+++ b/e2e/modern-fake-timers/from-config/__tests__/test.js
@@ -22,7 +22,7 @@ test('fake timers with Date argument', () => {
 
   expect(Date.now()).toBe(0);
 
-  jest.setSystemTime(1000);
+  jest.setSystemTime(new Date(1000));
 
   expect(Date.now()).toBe(1000);
 });

--- a/e2e/modern-fake-timers/from-jest-object/__tests__/test.js
+++ b/e2e/modern-fake-timers/from-jest-object/__tests__/test.js
@@ -7,10 +7,22 @@
 
 'use strict';
 
-test('fake timers', () => {
+test('fake timers with number argument', () => {
   jest.useFakeTimers('modern');
 
   jest.setSystemTime(0);
+
+  expect(Date.now()).toBe(0);
+
+  jest.setSystemTime(1000);
+
+  expect(Date.now()).toBe(1000);
+});
+
+test('fake timers with Date argument', () => {
+  jest.useFakeTimers('modern');
+
+  jest.setSystemTime(new Date(0));
 
   expect(Date.now()).toBe(0);
 

--- a/e2e/modern-fake-timers/from-jest-object/__tests__/test.js
+++ b/e2e/modern-fake-timers/from-jest-object/__tests__/test.js
@@ -26,7 +26,7 @@ test('fake timers with Date argument', () => {
 
   expect(Date.now()).toBe(0);
 
-  jest.setSystemTime(1000);
+  jest.setSystemTime(new Date(1000));
 
   expect(Date.now()).toBe(1000);
 });

--- a/packages/jest-environment/src/index.ts
+++ b/packages/jest-environment/src/index.ts
@@ -306,5 +306,5 @@ export interface Jest {
    *
    *  > Note: This function is only available when using Lolex as fake timers implementation
    */
-  setSystemTime(now?: number): void;
+  setSystemTime(now?: number | Date): void;
 }

--- a/packages/jest-fake-timers/src/modernFakeTimers.ts
+++ b/packages/jest-fake-timers/src/modernFakeTimers.ts
@@ -118,7 +118,7 @@ export default class FakeTimers {
     }
   }
 
-  setSystemTime(now?: number): void {
+  setSystemTime(now?: number | Date): void {
     if (this._checkFakeTimers()) {
       this._clock.setSystemTime(now);
     }

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -1559,7 +1559,7 @@ class Runtime {
         _getFakeTimers().advanceTimersByTime(msToRun),
       setMock: (moduleName: string, mock: unknown) =>
         setMockFactory(moduleName, () => mock),
-      setSystemTime: (now?: number) => {
+      setSystemTime: (now?: number | Date) => {
         const fakeTimers = _getFakeTimers();
 
         if (fakeTimers instanceof ModernFakeTimers) {

--- a/website/versioned_docs/version-26.0/JestObjectAPI.md
+++ b/website/versioned_docs/version-26.0/JestObjectAPI.md
@@ -648,7 +648,7 @@ This means, if any timers have been scheduled (but have not yet executed), they 
 
 Returns the number of fake timers still left to run.
 
-### `.jest.setSystemTime()`
+### `.jest.setSystemTime(now?: number | Date)`
 
 Set the current system time used by fake timers. Simulates a user changing the system clock while your program is running. It affects the current time but it does not in itself cause e.g. timers to fire; they will fire exactly as they would have done without the call to `jest.setSystemTime()`.
 

--- a/website/versioned_docs/version-26.0/JestObjectAPI.md
+++ b/website/versioned_docs/version-26.0/JestObjectAPI.md
@@ -648,13 +648,13 @@ This means, if any timers have been scheduled (but have not yet executed), they 
 
 Returns the number of fake timers still left to run.
 
-### `.jest.setSystemTime(now?: number | Date)`
+### `jest.setSystemTime(now?: number | Date)`
 
 Set the current system time used by fake timers. Simulates a user changing the system clock while your program is running. It affects the current time but it does not in itself cause e.g. timers to fire; they will fire exactly as they would have done without the call to `jest.setSystemTime()`.
 
 > Note: This function is only available when using modern fake timers implementation
 
-### `.jest.getRealSystemTime()`
+### `jest.getRealSystemTime()`
 
 When mocking time, `Date.now()` will also be mocked. If you for some reason need access to the real current time, you can invoke this function.
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

This PR does two (related) things. 

#### Update `setSystemTime` `now` param types to allow `Date` 
The internal types for `setSystemTime` are currently `now?: number`, but in using jest I found passing a `Date` also worked and was a bit more ergonomic in some cases. For example:

```ts
    // if Date is not in the union, this errors:
    jest.setSystemTime(new Date('2020-06-15T00:00:00.933Z'));
    
    // you'd have to do:
    jest.setSystemTime(new Date('2020-06-15T00:00:00.933Z').getTime());
```

The types for the underlying `this._clock.setSystemTime` call in `jest-fake-timers/src/modernFakeTimers.ts` support `Date`, so echoing that in `setSystemTime` seemed reasonable. I was looking into this while working on a PR to add types for `setSystemTime` and `getRealSystemTime` to DefinitelyTyped, and wanted to make sure that those types matched jest's codebase's types and the intended usage.

#### Update `setSystemTime` and `getRealSystemTime` docs
1. The documentation for `setSystemTime` did not directly document its params, so they took me as a user a bit of time to figure out. I wasn't sure what the format for these should be. [`advanceTimersToNextTimer`](https://jestjs.io/docs/en/jest-object#jestadvancetimerstonexttimersteps) just has `jest.advanceTimersToNextTimer(steps)` (no types), whereas [`useFakeTimers`](https://jestjs.io/docs/en/jest-object#jestusefaketimersimplementation-modern--legacy) has `jest.useFakeTimers(implementation?: 'modern' | 'legacy')`. I erred on the side of adding a type to the param, the union members are native and I think the types would be useful to both js and ts folks.
2. The documentation for `setSystemTime` and `getRealSystemTime` both have a preceding `.` char, which I removed. I'm not sure if this was intentional, but the other functions/headers in that doc do not have one and I didn't see any reference to them being experimental or anything (aside from requiring the "modern" timers).

## Test plan

For the new type, I added test cases for `setSystemTime(now: Date)` wherever I saw test cases for `setSystemTime(now: number)`. I ran the tests locally (albeit without mercurial installed, which didn't seem to affect these particular files).

I took a look at the doc changes to make sure they looked alright. They look like:
![image](https://user-images.githubusercontent.com/5359538/84673609-ef1c8400-aef7-11ea-86ea-7558f9003068.png)

Whereas on the live site, they look like:
![image](https://user-images.githubusercontent.com/5359538/84673682-09566200-aef8-11ea-8e2f-8573b4c81cd7.png)