### PR TITLE
Update links to Reactiflux

### DIFF
--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,7 +1,7 @@
 ---
 name: 💬 Questions / Help
 label: ':speech_balloon: Question'
-about: If you have questions, please check our Discord or StackOverflow
+about: If you have questions, please check Reactiflux or StackOverflow
 ---
 
 <!-- Love Jest? Please consider supporting our collective: 👉  https://opencollective.com/jest/donate -->
@@ -13,5 +13,5 @@ about: If you have questions, please check our Discord or StackOverflow
 For questions or help please see:
 
 - [The Jest help page](https://jestjs.io/en/help.html)
-- [Our discord channel in Reactiflux](https://discord.gg/MWRhKCj)
+- [Our `#testing` channel in Reactiflux](https://www.reactiflux.com/)
 - The [jestjs](https://stackoverflow.com/questions/tagged/jestjs) tag on [StackOverflow](https://stackoverflow.com/questions/ask)

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,3 +1,3 @@
-Please note this issue tracker is not a help forum. We recommend using [StackOverflow](https://stackoverflow.com/questions/tagged/jest) or our [discord channel](https://discord.gg/MWRhKCj) for questions.
+Please note this issue tracker is not a help forum. We recommend using [StackOverflow](https://stackoverflow.com/questions/tagged/jest) or [Reactiflux](https://www.reactiflux.com/) for questions.
 
 <!-- Love Jest? Please consider supporting our collective: 👉  https://opencollective.com/jest/donate -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -211,7 +211,7 @@ Facebook has a [bounty program](https://www.facebook.com/whitehat/) for the safe
 
 ## How to Get in Touch
 
-- Discord - [#jest](https://discord.gg/MWRhKCj) on [Reactiflux](http://www.reactiflux.com/)
+`#testing` on [Reactiflux](https://www.reactiflux.com/)
 
 ## Code Conventions
 

--- a/docs/MoreResources.md
+++ b/docs/MoreResources.md
@@ -19,6 +19,6 @@ You will find a number of example test cases in the [`examples`](https://github.
 
 ## Join the community
 
-Ask questions and find answers from other Jest users like you. [Reactiflux](http://www.reactiflux.com/) is a Discord chat where a lot of Jest discussion happens. Check out the [#jest](https://discord.gg/MWRhKCj) channel.
+Ask questions and find answers from other Jest users like you. [Reactiflux](https://www.reactiflux.com/) is a Discord chat where a lot of Jest discussion happens. Check out the `#testing` channel.
 
 Follow the [Jest Twitter account](https://twitter.com/fbjest) and [blog](/blog/) to find out what's happening in the world of Jest.

--- a/website/blog/2017-05-06-jest-20-delightful-testing-multi-project-runner.md
+++ b/website/blog/2017-05-06-jest-20-delightful-testing-multi-project-runner.md
@@ -87,4 +87,4 @@ Recently the Jest core team and other contributors started to talk more about Je
 - Rogelio Guzman did a talk about [Jest Snapshots and Beyond](https://www.youtube.com/watch?time_continue=416&v=HAuXJVI_bUs) at React Conf.
 - I spoke about [Building High-Quality JavaScript Tools](https://developers.facebook.com/videos/f8-2017/building-high-quality-javascript-tools/) at Facebook's F8 conference.
 
-_As always, this release couldn't have been possible without you, the JavaScript community. We are incredibly grateful that we get the opportunity to work on improving JavaScript testing together. If you'd like to contribute to Jest, please don't hesitate to reach out to us on [GitHub](https://github.com/facebook/jest) or on [Discord](https://discord.gg/MWRhKCj)._
+_As always, this release couldn't have been possible without you, the JavaScript community. We are incredibly grateful that we get the opportunity to work on improving JavaScript testing together. If you'd like to contribute to Jest, please don't hesitate to reach out to us on [GitHub](https://github.com/facebook/jest) or on [Discord](https://www.reactiflux.com/)._

--- a/website/blog/2018-05-29-jest-23-blazing-fast-delightful-testing.md
+++ b/website/blog/2018-05-29-jest-23-blazing-fast-delightful-testing.md
@@ -130,4 +130,4 @@ Full talk is available [here](https://www.youtube.com/watch?v=cAKYQpTC7MA).
 
 The turnout was amazing, and we were able to meet a lot of the London-based community in person. Thank you to everyone who joined us and for your continued support! Stay tuned for our next post which will outline the Jest Open Collective and the plans we have for the future.
 
-_As always, this release couldn't have been possible without you, the JavaScript community. We are incredibly grateful that we get the opportunity to work on improving JavaScript testing together. If you'd like to contribute to Jest, please don't hesitate to reach out to us on_ _[GitHub](https://github.com/facebook/jest) or on_ _[Discord](https://discord.gg/MWRhKCj)._
+_As always, this release couldn't have been possible without you, the JavaScript community. We are incredibly grateful that we get the opportunity to work on improving JavaScript testing together. If you'd like to contribute to Jest, please don't hesitate to reach out to us on_ _[GitHub](https://github.com/facebook/jest) or on_ _[Discord](https://www.reactiflux.com/)._

--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -62,7 +62,7 @@ class Footer extends React.Component {
             >
               Stack Overflow
             </a>
-            <a href="https://discord.gg/MWRhKCj">Jest Chat</a>
+            <a href="https://www.reactiflux.com/">Reactiflux</a>
             <a href="https://twitter.com/fbjest" target="_blank">
               Twitter
             </a>

--- a/website/pages/en/help.js
+++ b/website/pages/en/help.js
@@ -33,8 +33,8 @@ class Help extends React.Component {
         content: (
           <translate>
             Ask questions and find answers from other Jest users like you.\n\n-
-            Join the [#jest](https://discord.gg/MWRhKCj) channel on
-            [Reactiflux](http://www.reactiflux.com/), a Discord community.\n-
+            Join the `#testing` channel on
+            [Reactiflux](https://www.reactiflux.com/), a Discord community.\n-
             Many members of the community use Stack Overflow. Read through the
             [existing
             questions](https://stackoverflow.com/questions/tagged/jestjs) tagged

--- a/website/versioned_docs/version-22.x/MoreResources.md
+++ b/website/versioned_docs/version-22.x/MoreResources.md
@@ -20,6 +20,6 @@ You will find a number of example test cases in the [`examples`](https://github.
 
 ## Join the community
 
-Ask questions and find answers from other Jest users like you. [Reactiflux](http://www.reactiflux.com/) is a Discord chat where a lot of Jest discussion happens. Check out the [#jest](https://discordapp.com/channels/102860784329052160/103622435865104384) channel.
+Ask questions and find answers from other Jest users like you. [Reactiflux](https://www.reactiflux.com/) is a Discord chat where a lot of Jest discussion happens. Check out the `#testing` channel.
 
 Follow the [Jest Twitter account](https://twitter.com/fbjest) and [blog](/blog/) to find out what's happening in the world of Jest.

--- a/website/versioned_docs/version-23.x/MoreResources.md
+++ b/website/versioned_docs/version-23.x/MoreResources.md
@@ -20,6 +20,6 @@ You will find a number of example test cases in the [`examples`](https://github.
 
 ## Join the community
 
-Ask questions and find answers from other Jest users like you. [Reactiflux](http://www.reactiflux.com/) is a Discord chat where a lot of Jest discussion happens. Check out the [#jest](https://discord.gg/MWRhKCj) channel.
+Ask questions and find answers from other Jest users like you. [Reactiflux](https://www.reactiflux.com/) is a Discord chat where a lot of Jest discussion happens. Check out the `#testing` channel.
 
 Follow the [Jest Twitter account](https://twitter.com/fbjest) and [blog](/blog/) to find out what's happening in the world of Jest.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

We're planning on some changes to channels on Reactiflux, such as merging the `#jest` channel into `#testing` (which is more active and mostly about Jest anyway) and showing a rules/CoC document when accessing the server for the first time. The website and docs are currently linking directly to the `#jest` channel that we're planning on removing, so we'd like to change Jest's links first to prevent any interruptions or confusion for users.