### PR TITLE
Add helpful error message to TimerMocks

### DIFF
--- a/docs/TimerMocks.md
+++ b/docs/TimerMocks.md
@@ -62,7 +62,15 @@ test('calls the callback after 1 second', () => {
 
 ## Run Pending Timers
 
-There are also scenarios where you might have a recursive timer -- that is a timer that sets a new timer in its own callback. For these, running all the timers would be an endless loop… so something like `jest.runAllTimers()` is not desirable. For these cases you might use `jest.runOnlyPendingTimers()`:
+There are also scenarios where you might have a recursive timer -- that is a timer that sets a new timer in its own callback. 
+
+For these, running all the timers would be an endless loop, throwing the following error:
+
+```Ran 100000 timers, and there are still more! Assuming we've hit an infinite recursion and bailing out...```
+
+So something like `jest.runAllTimers()` is not desirable.
+
+For these cases you might use `jest.runOnlyPendingTimers()`:
 
 ```javascript
 // infiniteTimerGame.js


### PR DESCRIPTION
## Summary

Help the reader to understand the context in which `jest.runOnlyPendingTimers()` is useful, by referring to the error that gets thrown when the timers are in an endless loop.