### PR TITLE
chore: quote globs in scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,12 +78,12 @@
     "which": "^2.0.1"
   },
   "scripts": {
-    "build-clean": "rimraf ./packages/*/build ./packages/*/build-es5 ./packages/*/tsconfig.tsbuildinfo",
-    "prebuild": "yarn build:ts",
-    "build": "node ./scripts/build.js",
+    "build-clean": "rimraf './packages/*/build' './packages/*/build-es5' './packages/*/tsconfig.tsbuildinfo'",
+    "build": "yarn build:js && yarn build:ts",
+    "build:js": "node ./scripts/build.js",
     "build:ts": "node ./scripts/buildTs.js",
     "check-copyright-headers": "node ./scripts/checkCopyrightHeaders.js",
-    "clean-all": "yarn clean-e2e && yarn build-clean && rimraf ./packages/*/node_modules && rimraf ./node_modules",
+    "clean-all": "yarn clean-e2e && yarn build-clean && rimraf './packages/*/node_modules' && rimraf './node_modules'",
     "clean-e2e": "node ./scripts/cleanE2e.js",
     "jest": "node ./packages/jest-cli/bin/jest.js",
     "jest-coverage": "yarn jest --coverage",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Rather than relying on the shell to expand the globs, pass it through to `rimraf`. Also ditches `prebuild` in favor of explicit `&&`.

This is needed for Yarn v2

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Green CI

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
