### PR TITLE
Add console.timeLog function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - `[expect]` Match symbols and bigints in `any()` ([#10223](https://github.com/facebook/jest/pull/10223))
+- `[jest-console]` Add missing console.timeLog for compatability with Node ([#10209](https://github.com/facebook/jest/pull/10209))
 
 ### Chore & Maintenance
 

--- a/packages/jest-console/src/BufferedConsole.ts
+++ b/packages/jest-console/src/BufferedConsole.ts
@@ -159,6 +159,16 @@ export default class BufferedConsole extends Console {
     }
   }
 
+  timeLog(label = 'default', ...data: Array<unknown>): void {
+    const startTime = this._timers[label];
+
+    if (startTime) {
+      const endTime = new Date();
+      const time = endTime.getTime() - startTime.getTime();
+      this._log('time', format(`${label}: ${formatTime(time)}`, ...data));
+    }
+  }
+
   warn(firstArg: unknown, ...rest: Array<unknown>): void {
     this._log('warn', format(firstArg, ...rest));
   }

--- a/packages/jest-console/src/CustomConsole.ts
+++ b/packages/jest-console/src/CustomConsole.ts
@@ -136,6 +136,16 @@ export default class CustomConsole extends Console {
     }
   }
 
+  timeLog(label = 'default', ...data: Array<unknown>): void {
+    const startTime = this._timers[label];
+
+    if (startTime) {
+      const endTime = new Date();
+      const time = endTime.getTime() - startTime.getTime();
+      this._log('time', format(`${label}: ${formatTime(time)}`, ...data));
+    }
+  }
+
   warn(firstArg: unknown, ...args: Array<unknown>): void {
     this._logError('warn', format(firstArg, ...args));
   }

--- a/packages/jest-console/src/NullConsole.ts
+++ b/packages/jest-console/src/NullConsole.ts
@@ -16,6 +16,7 @@ export default class NullConsole extends CustomConsole {
   log(): void {}
   time(): void {}
   timeEnd(): void {}
+  timeLog(): void {}
   trace(): void {}
   warn(): void {}
   group(): void {}

--- a/packages/jest-console/src/__tests__/CustomConsole.test.ts
+++ b/packages/jest-console/src/__tests__/CustomConsole.test.ts
@@ -186,4 +186,42 @@ describe('CustomConsole', () => {
       expect(_stdout).toMatch('ms');
     });
   });
+
+  describe('timeLog', () => {
+    test('should return the time between time() and timeEnd() on default timer', () => {
+      _console.time();
+      _console.timeLog();
+
+      expect(_stdout).toMatch('default: ');
+      expect(_stdout).toMatch('ms');
+      _console.timeEnd();
+    });
+
+    test('should return the time between time() and timeEnd() on custom timer', () => {
+      _console.time('custom');
+      _console.timeLog('custom');
+
+      expect(_stdout).toMatch('custom: ');
+      expect(_stdout).toMatch('ms');
+      _console.timeEnd('custom');
+    });
+
+    test('default timer with data', () => {
+      _console.time();
+      _console.timeLog(undefined, 'foo', 5);
+
+      expect(_stdout).toMatch('default: ');
+      expect(_stdout).toMatch('ms foo 5');
+      _console.timeEnd();
+    });
+
+    test('custom timer with data', () => {
+      _console.time('custom');
+      _console.timeLog('custom', 'foo', 5);
+
+      expect(_stdout).toMatch('custom: ');
+      expect(_stdout).toMatch('ms foo 5');
+      _console.timeEnd('custom');
+    });
+  });
 });

--- a/packages/jest-console/src/__tests__/bufferedConsole.test.ts
+++ b/packages/jest-console/src/__tests__/bufferedConsole.test.ts
@@ -146,4 +146,42 @@ describe('CustomConsole', () => {
       expect(stdout()).toMatch('ms');
     });
   });
+
+  describe('timeLog', () => {
+    test('should return the time between time() and timeEnd() on default timer', () => {
+      _console.time();
+      _console.timeLog();
+
+      expect(stdout()).toMatch('default: ');
+      expect(stdout()).toMatch('ms');
+      _console.timeEnd();
+    });
+
+    test('should return the time between time() and timeEnd() on custom timer', () => {
+      _console.time('custom');
+      _console.timeLog('custom');
+
+      expect(stdout()).toMatch('custom: ');
+      expect(stdout()).toMatch('ms');
+      _console.timeEnd('custom');
+    });
+
+    test('default timer with data', () => {
+      _console.time();
+      _console.timeLog(undefined, 'foo', 5);
+
+      expect(stdout()).toMatch('default: ');
+      expect(stdout()).toMatch('ms foo 5');
+      _console.timeEnd();
+    });
+
+    test('custom timer with data', () => {
+      _console.time('custom');
+      _console.timeLog('custom', 'foo', 5);
+
+      expect(stdout()).toMatch('custom: ');
+      expect(stdout()).toMatch('ms foo 5');
+      _console.timeEnd('custom');
+    });
+  });
 });


### PR DESCRIPTION
Provide timeLog to be compatible with node.

## Summary

console.timeLog was added in node v10.7.0.  Jest gets errors when the function is used.  A [stackoverflow question](https://stackoverflow.com/questions/58961221/console-timelog-not-working-in-jest-tests) was never explained.

## Test plan

Tests were added to the files in the __test__ directory.  A [test run](https://github.com/webstech/jest/actions) was successful.  These are basic jest tests.
