### PR TITLE
Adding parcel bundler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - `[jest-fake-timers]` Update `now` param type to support `Date` in addition to `number`. ([#10169](https://github.com/facebook/jest/pull/10169))
 - `[docs]` Add param to `setSystemTime` docs and remove preceding period from it and `getRealSystemTime` ([#10169](https://github.com/facebook/jest/pull/10169))
 - `[jest-snapshot, jest-util]` Replace `make-dir` with `fs.mkdir` ([#10136](https://github.com/facebook/jest/pull/10136))
+- `[docs]` Added parcel-bundler documentation inside readme.md file
 
 ### Performance
 

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Jest can be used in projects that use [webpack](https://webpack.js.org/) to mana
 
 ### Using parcel
 
-Jest can be used in projects that use [parcel-bundler](https://parceljs.org/) to manage assests, styles, and compilation similar to webpack. Parcel bundler offers blazing fast performance utilizing multicore processing, and requires zero configuration.
+Jest can be used in projects that use [parcel-bundler](https://parceljs.org/) to manage assets, styles, and compilation similar to webpack. Parcel requires zero configuration.
 
 ### Using TypeScript
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
   - [Generate a basic configuration file](#generate-a-basic-configuration-file)
   - [Using Babel](#using-babel)
   - [Using Webpack](#using-webpack)
+  - [Using Parcel](#using-parcel)
   - [Using Typescript](#using-typescript)
 - [Documentation](#documentation)
 - [Badge](#badge)
@@ -169,6 +170,10 @@ module.exports = {
 ### Using webpack
 
 Jest can be used in projects that use [webpack](https://webpack.js.org/) to manage assets, styles, and compilation. webpack does offer some unique challenges over other tools. Refer to the [webpack guide](https://jestjs.io/docs/en/webpack) to get started.
+
+### Using parcel
+
+Jest can be used in projects that use [parcel-bundler](https://parceljs.org/) to manage assests, styles, and compilation similar to webpack. Parcel bundler offers blazing fast performance utilizing multicore processing, and requires zero configuration.
 
 ### Using TypeScript
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -155,6 +155,10 @@ While we generally recommend using the same version of every Jest package, this 
 
 Jest can be used in projects that use [webpack](https://webpack.js.org/) to manage assets, styles, and compilation. webpack does offer some unique challenges over other tools. Refer to the [webpack guide](Webpack.md) to get started.
 
+### Using parcel
+
+Jest can be used in projects that use [parcel-bundler](https://parceljs.org/) to manage assets, styles, and compilation similar to webpack. Parcel requires zero configuration. Refer to the official [docs](https://parceljs.org/getting_started.html) to get started.
+
 ### Using TypeScript
 
 Jest supports TypeScript, via Babel. First make sure you followed the instructions on [using Babel](#using-babel) above. Next install the `@babel/preset-typescript` via `yarn`:


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Jest is supported and can be integrated with parcel-bundler for testing of the applications and that was not listed under documentation so added that.

## Test plan

Changes were made inside the documentation part so there were no changes done in the codebase.
However, the installation code for parcel-bundler follows:

```
npm install -g parcel-bundler
or
yarn add parcel-bundler
```