### PR TITLE
Show error in cli in case of multiple configs

### DIFF
--- a/packages/jest-config/src/index.ts
+++ b/packages/jest-config/src/index.ts
@@ -18,6 +18,7 @@ export {getTestEnvironment, isJSONString} from './utils';
 export {default as normalize} from './normalize';
 export {default as deprecationEntries} from './Deprecated';
 export {replaceRootDirInPath} from './utils';
+export {checkMultipleConfigs} from './resolveConfigPath';
 export {default as defaults} from './Defaults';
 export {default as descriptions} from './Descriptions';
 import * as constants from './constants';

--- a/packages/jest-config/src/resolveConfigPath.ts
+++ b/packages/jest-config/src/resolveConfigPath.ts
@@ -83,6 +83,30 @@ const resolveConfigPathByTraversing = (
   );
 };
 
+export const checkMultipleConfigs = (pathToResolve: Config.Path): boolean => {
+  const jestConfig = JEST_CONFIG_EXT_ORDER.map(ext =>
+    path.resolve(pathToResolve, getConfigFilename(ext)),
+  ).find(isFile);
+
+  if (!jestConfig) {
+    return false;
+  }
+
+  const packageJson = path.resolve(pathToResolve, PACKAGE_JSON);
+
+  if (!isFile(packageJson)) {
+    return false;
+  }
+
+  const configObject = require(packageJson);
+
+  if (!configObject.jest) {
+    return false;
+  }
+
+  return true;
+};
+
 const makeResolutionErrorMessage = (
   initialPath: Config.Path,
   cwd: Config.Path,

--- a/packages/jest-core/src/cli/index.ts
+++ b/packages/jest-core/src/cli/index.ts
@@ -9,7 +9,7 @@ import type {Config} from '@jest/types';
 import type {AggregatedResult} from '@jest/test-result';
 import {CustomConsole} from '@jest/console';
 import {createDirectory, preRunMessage} from 'jest-util';
-import {readConfigs} from 'jest-config';
+import {checkMultipleConfigs, readConfigs} from 'jest-config';
 import Runtime = require('jest-runtime');
 import type {ChangedFilesPromise} from 'jest-changed-files';
 import HasteMap = require('jest-haste-map');
@@ -47,6 +47,28 @@ export async function runCLI(
   // it'll break the JSON structure and it won't be valid.
   const outputStream =
     argv.json || argv.useStderr ? process.stderr : process.stdout;
+
+  if (!argv.config) {
+    projects.forEach(project => {
+      const hasMultipleConfigs = checkMultipleConfigs(project);
+      if (hasMultipleConfigs) {
+        console.warn(
+          chalk.yellow(
+            chalk.bold(`Multiple configurations found:
+
+              Jest will use 'jest.config.js' for configuration, but Jest also 
+              found a configuration in 'package.json'. Delete the 'jest' key 
+              in that file to silence this warning, or delete the 'jest.config.js' file 
+              to use the configuration from 'package.json'.
+
+              Configuration Documentation:
+              https://jestjs.io/docs/en/configuration.html`
+            )
+          ),
+        );
+      }
+    });
+  }
 
   const {globalConfig, configs, hasDeprecationWarnings} = await readConfigs(
     argv,


### PR DESCRIPTION
## Summary

Helps the user have correct and consistent configuration and helps when trying to debug why config is not applied.

As mentioned in https://github.com/facebook/jest/issues/10124 and https://github.com/facebook/jest/issues/10123.

Warns in case of multiple configs, however the warning is overriden in case of the usage of --config.

## Test plan

Tested it locally by trying a development build of jest in another package.
However, I'm unsure of writing the tests with respect to this functionality.
If someone could point me in the right direction (in case tests are necessary for this use case), it would be really helpful.
