### PR TITLE
chore(jest-jasmine2): remove usage of `Function` type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - `[jest-jasmine2]` Convert `PCancelable` to TypeScript ([#10215](https://github.com/facebook/jest/pull/10215))
 - `[jest-jasmine2]` Refine typings of `queueRunner` ([#10215](https://github.com/facebook/jest/pull/10215))
+- `[jest-jasmine2]` Remove usage of `Function` type ([#10216](https://github.com/facebook/jest/pull/10216))
 - `[jest-resolve]` Improve types ([#10239](https://github.com/facebook/jest/pull/10239))
 
 ### Performance

--- a/packages/jest-jasmine2/src/jasmine/Env.ts
+++ b/packages/jest-jasmine2/src/jasmine/Env.ts
@@ -41,7 +41,13 @@ import queueRunner, {
 import treeProcessor, {TreeNode} from '../treeProcessor';
 import isError from '../isError';
 import assertionErrorMessage from '../assertionErrorMessage';
-import type {AssertionErrorWithStack, Jasmine, Reporter, Spy} from '../types';
+import type {
+  AssertionErrorWithStack,
+  Jasmine,
+  Reporter,
+  SpecDefinitionsFn,
+  Spy,
+} from '../types';
 import type {default as Spec, SpecResult} from './Spec';
 import type Suite from './Suite';
 
@@ -64,7 +70,10 @@ export default function (j$: Jasmine) {
       runnablesToRun?: Array<string>,
       suiteTree?: Suite,
     ) => Promise<void>;
-    fdescribe: (description: string, specDefinitions: Function) => Suite;
+    fdescribe: (
+      description: string,
+      specDefinitions: SpecDefinitionsFn,
+    ) => Suite;
     spyOn: (
       obj: Record<string, Spy>,
       methodName: string,
@@ -78,15 +87,21 @@ export default function (j$: Jasmine) {
     clearReporters: () => void;
     addReporter: (reporterToAdd: Reporter) => void;
     it: (description: string, fn: QueueableFn['fn'], timeout?: number) => Spec;
-    xdescribe: (description: string, specDefinitions: Function) => Suite;
+    xdescribe: (
+      description: string,
+      specDefinitions: SpecDefinitionsFn,
+    ) => Suite;
     xit: (description: string, fn: QueueableFn['fn'], timeout?: number) => Spec;
     beforeAll: (beforeAllFunction: QueueableFn['fn'], timeout?: number) => void;
     todo: () => Spec;
     provideFallbackReporter: (reporterToAdd: Reporter) => void;
     allowRespy: (allow: boolean) => void;
-    describe: (description: string, specDefinitions: Function) => Suite;
+    describe: (
+      description: string,
+      specDefinitions: SpecDefinitionsFn,
+    ) => Suite;
 
-    constructor(_options?: object) {
+    constructor(_options?: Record<string, unknown>) {
       let totalSpecsDefined = 0;
 
       let catchExceptions = true;
@@ -411,13 +426,16 @@ export default function (j$: Jasmine) {
         return suite;
       };
 
-      const addSpecsToSuite = (suite: Suite, specDefinitions: Function) => {
+      const addSpecsToSuite = (
+        suite: Suite,
+        specDefinitions: SpecDefinitionsFn,
+      ) => {
         const parentSuite = currentDeclarationSuite;
         parentSuite.addChild(suite);
         currentDeclarationSuite = suite;
 
         let declarationError: undefined | Error = undefined;
-        let describeReturnValue: undefined | Error = undefined;
+        let describeReturnValue: unknown | Error;
         try {
           describeReturnValue = specDefinitions.call(suite);
         } catch (e) {

--- a/packages/jest-jasmine2/src/jasmine/Spec.ts
+++ b/packages/jest-jasmine2/src/jasmine/Spec.ts
@@ -171,7 +171,7 @@ export default class Spec {
     }
   }
 
-  execute(onComplete: Function, enabled: boolean) {
+  execute(onComplete?: () => void, enabled?: boolean) {
     const self = this;
 
     this.onStart(this);
@@ -203,7 +203,7 @@ export default class Spec {
 
     this.currentRun.then(() => complete(true));
 
-    function complete(enabledAgain: boolean) {
+    function complete(enabledAgain?: boolean) {
       self.result.status = self.status(enabledAgain);
       self.resultCallback(self.result);
 

--- a/packages/jest-jasmine2/src/jasmine/jasmineLight.ts
+++ b/packages/jest-jasmine2/src/jasmine/jasmineLight.ts
@@ -30,7 +30,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 /* eslint-disable sort-keys */
 
-import type {Jasmine} from '../types';
+import type {Jasmine, SpecDefinitionsFn} from '../types';
 import createSpy from './createSpy';
 import Env from './Env';
 import JsApiReporter from './JsApiReporter';
@@ -45,7 +45,7 @@ export const create = function (createOptions: Record<string, any>): Jasmine {
 
   j$._DEFAULT_TIMEOUT_INTERVAL = createOptions.testTimeout || 5000;
 
-  j$.getEnv = function (options?: object) {
+  j$.getEnv = function (options?: Record<string, unknown>) {
     const env = (j$.currentEnv_ = j$.currentEnv_ || new j$.Env(options));
     //jasmine. singletons in here (setTimeout blah blah).
     return env;
@@ -66,15 +66,15 @@ export const create = function (createOptions: Record<string, any>): Jasmine {
 // Interface is a reserved word in strict mode, so can't export it as ESM
 export const _interface = function (jasmine: Jasmine, env: any) {
   const jasmineInterface = {
-    describe(description: string, specDefinitions: Function) {
+    describe(description: string, specDefinitions: SpecDefinitionsFn) {
       return env.describe(description, specDefinitions);
     },
 
-    xdescribe(description: string, specDefinitions: Function) {
+    xdescribe(description: string, specDefinitions: SpecDefinitionsFn) {
       return env.xdescribe(description, specDefinitions);
     },
 
-    fdescribe(description: string, specDefinitions: Function) {
+    fdescribe(description: string, specDefinitions: SpecDefinitionsFn) {
       return env.fdescribe(description, specDefinitions);
     },
 

--- a/packages/jest-jasmine2/src/jestExpect.ts
+++ b/packages/jest-jasmine2/src/jestExpect.ts
@@ -14,17 +14,9 @@ import {
   toThrowErrorMatchingInlineSnapshot,
   toThrowErrorMatchingSnapshot,
 } from 'jest-snapshot';
-import type {Jasmine, RawMatcherFn} from './types';
+import type {Jasmine, JasmineMatchersObject, RawMatcherFn} from './types';
 
 declare const global: Global.Global;
-
-type JasmineMatcher = {
-  (matchersUtil: any, context: any): JasmineMatcher;
-  compare: () => RawMatcherFn;
-  negativeCompare: () => RawMatcherFn;
-};
-
-type JasmineMatchersObject = {[id: string]: JasmineMatcher};
 
 export default (config: {expand: boolean}): void => {
   global.expect = expect;

--- a/packages/jest-jasmine2/src/queueRunner.ts
+++ b/packages/jest-jasmine2/src/queueRunner.ts
@@ -20,8 +20,13 @@ export type Options = {
   userContext: any;
 };
 
+export interface DoneFn {
+  (error?: any): void;
+  fail: (error: Error) => void;
+}
+
 export type QueueableFn = {
-  fn: (done: (error?: any) => void) => void;
+  fn: (done: DoneFn) => void;
   timeout?: () => number;
   initError?: Error;
 };

--- a/packages/jest-jasmine2/src/types.ts
+++ b/packages/jest-jasmine2/src/types.ts
@@ -20,6 +20,8 @@ import type {default as Suite, SuiteResult} from './jasmine/Suite';
 import type SpyStrategy from './jasmine/SpyStrategy';
 import type CallTracker from './jasmine/CallTracker';
 
+export type SpecDefinitionsFn = () => void;
+
 export interface AssertionErrorWithStack extends AssertionError {
   stack: string;
 }
@@ -64,11 +66,21 @@ export interface Spy extends Record<string, any> {
   restoreObjectToOriginalState?: () => void;
 }
 
+type JasmineMatcher = {
+  (matchersUtil: unknown, context: unknown): JasmineMatcher;
+  compare: () => RawMatcherFn;
+  negativeCompare: () => RawMatcherFn;
+};
+
+export type JasmineMatchersObject = {[id: string]: JasmineMatcher};
+
 export type Jasmine = {
   _DEFAULT_TIMEOUT_INTERVAL: number;
   DEFAULT_TIMEOUT_INTERVAL: number;
   currentEnv_: ReturnType<typeof Env>['prototype'];
-  getEnv: (options?: object) => ReturnType<typeof Env>['prototype'];
+  getEnv: (
+    options?: Record<string, unknown>,
+  ) => ReturnType<typeof Env>['prototype'];
   createSpy: typeof createSpy;
   Env: ReturnType<typeof Env>;
   JsApiReporter: typeof JsApiReporter;
@@ -79,7 +91,7 @@ export type Jasmine = {
   Timer: typeof Timer;
   version: string;
   testPath: Config.Path;
-  addMatchers: Function;
+  addMatchers: (matchers: JasmineMatchersObject) => void;
 } & typeof expect &
   NodeJS.Global;
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Improves the types for `jest-jasmine2` to remove banned types (specifically `Function` & `object`) as part of #10177.

The only two files that have banned types (well, type: `Function`) are:
* `errorOnPrivate`: I suspect that `Function` might actually be the "right" type to use here, but more importantly it's usage is for a passthrough parameter to `ErrorWithStack` which comes from `jest-utils`, so the correct type will be whatever replaces the `Function` usage in that package.
* `jasmineAsyncInstall`: I've almost got this typed, but the remaining errors point towards a type being incorrect somewhere that I can't pin down. I think there's a bit of critical understanding that would make it all click that I'm missing.

  I've included the work in this commit, so CI will fail, but am happy to revert that section to get the rest of the changes landed.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

See if the tests pass :D