### PR TITLE
fix: strip added indent in error inline snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - `[expect]` Match symbols and bigints in `any()` ([#10223](https://github.com/facebook/jest/pull/10223))
+- `[jest-snapshot]` Strip added indentation for inline error snapshots ([#10217](https://github.com/facebook/jest/pull/10217))
 
 ### Chore & Maintenance
 

--- a/packages/jest-snapshot/src/__tests__/inline_snapshots.test.ts
+++ b/packages/jest-snapshot/src/__tests__/inline_snapshots.test.ts
@@ -260,20 +260,20 @@ test('saveInlineSnapshots() does not re-indent error snapshots', () => {
   expect(fs.writeFileSync).toHaveBeenCalledWith(
     filename,
     "it('is an error test', () => {\n" +
-    '  expect(() => {\n' +
-    "    throw new Error(['a', 'b'].join('\\n'));\n" +
-    '  }).toThrowErrorMatchingInlineSnapshot(`\n' +
-    '    "a\n' +
-    '    b"\n' +
-    '  `);\n' +
-    '});\n' +
-    "it('is another test', () => {\n" +
-    "  expect({a: 'a'}).toMatchInlineSnapshot(`\n" +
-    '    Object {\n' +
-    "      a: 'a'\n" +
-    '    }\n' +
-    '  `);\n' +
-    '});\n',
+      '  expect(() => {\n' +
+      "    throw new Error(['a', 'b'].join('\\n'));\n" +
+      '  }).toThrowErrorMatchingInlineSnapshot(`\n' +
+      '    "a\n' +
+      '    b"\n' +
+      '  `);\n' +
+      '});\n' +
+      "it('is another test', () => {\n" +
+      "  expect({a: 'a'}).toMatchInlineSnapshot(`\n" +
+      '    Object {\n' +
+      "      a: 'a'\n" +
+      '    }\n' +
+      '  `);\n' +
+      '});\n',
   );
 });
 

--- a/packages/jest-snapshot/src/__tests__/inline_snapshots.test.ts
+++ b/packages/jest-snapshot/src/__tests__/inline_snapshots.test.ts
@@ -225,6 +225,58 @@ test('saveInlineSnapshots() indents multi-line snapshots with spaces', () => {
   );
 });
 
+test('saveInlineSnapshots() does not re-indent error snapshots', () => {
+  const filename = path.join(__dirname, 'my.test.js');
+  (fs.readFileSync as jest.Mock).mockImplementation(
+    () =>
+      "it('is an error test', () => {\n" +
+      '  expect(() => {\n' +
+      "    throw new Error(['a', 'b'].join('\\n'));\n" +
+      '  }).toThrowErrorMatchingInlineSnapshot(`\n' +
+      '    "a\n' +
+      '    b"\n' +
+      '  `);\n' +
+      '});\n' +
+      "it('is another test', () => {\n" +
+      "  expect({a: 'a'}).toMatchInlineSnapshot();\n" +
+      '});\n',
+  );
+  (prettier.resolveConfig.sync as jest.Mock).mockReturnValue({
+    bracketSpacing: false,
+    singleQuote: true,
+  });
+
+  saveInlineSnapshots(
+    [
+      {
+        frame: {column: 20, file: filename, line: 10} as Frame,
+        snapshot: `\nObject {\n  a: 'a'\n}\n`,
+      },
+    ],
+    prettier,
+    babelTraverse,
+  );
+
+  expect(fs.writeFileSync).toHaveBeenCalledWith(
+    filename,
+    "it('is an error test', () => {\n" +
+    '  expect(() => {\n' +
+    "    throw new Error(['a', 'b'].join('\\n'));\n" +
+    '  }).toThrowErrorMatchingInlineSnapshot(`\n' +
+    '    "a\n' +
+    '    b"\n' +
+    '  `);\n' +
+    '});\n' +
+    "it('is another test', () => {\n" +
+    "  expect({a: 'a'}).toMatchInlineSnapshot(`\n" +
+    '    Object {\n' +
+    "      a: 'a'\n" +
+    '    }\n' +
+    '  `);\n' +
+    '});\n',
+  );
+});
+
 test('saveInlineSnapshots() does not re-indent already indented snapshots', () => {
   const filename = path.join(__dirname, 'my.test.js');
   (fs.readFileSync as jest.Mock).mockImplementation(
@@ -233,7 +285,7 @@ test('saveInlineSnapshots() does not re-indent already indented snapshots', () =
       "  expect({a: 'a'}).toMatchInlineSnapshot();\n" +
       '});\n' +
       "it('is a another test', () => {\n" +
-      "  expect({a: 'a'}).toMatchInlineSnapshot(`\n" +
+      "  expect({b: 'b'}).toMatchInlineSnapshot(`\n" +
       '    Object {\n' +
       "      b: 'b'\n" +
       '    }\n' +
@@ -266,7 +318,7 @@ test('saveInlineSnapshots() does not re-indent already indented snapshots', () =
       '  `);\n' +
       '});\n' +
       "it('is a another test', () => {\n" +
-      "  expect({a: 'a'}).toMatchInlineSnapshot(`\n" +
+      "  expect({b: 'b'}).toMatchInlineSnapshot(`\n" +
       '    Object {\n' +
       "      b: 'b'\n" +
       '    }\n' +

--- a/packages/jest-snapshot/src/index.ts
+++ b/packages/jest-snapshot/src/index.ts
@@ -462,7 +462,10 @@ const toThrowErrorMatchingInlineSnapshot = function (
   return _toThrowErrorMatchingSnapshot(
     {
       context: this,
-      inlineSnapshot,
+      inlineSnapshot:
+        inlineSnapshot !== undefined
+          ? stripAddedIndentation(inlineSnapshot)
+          : undefined,
       isInline: true,
       matcherName,
       received,


### PR DESCRIPTION
## Summary

Currently, `jest-snapshot` does not strip added white space characters when comparing inline snapshots for errors. Test will pass on the first run (when the snapshot is written), but will fail in any subsequent runs. This mainly only affects errors with multi-line messages.

## Test plan

Run this code (I'm happy to move this into a test case if required):

```js
it('should pass', () => {
  // This will fail when the snapshot is written
  expect(() => {
    throw new Error(['Line 1', 'Line 2'].join('\n'));
  }).toThrowErrorMatchingInlineSnapshot();
});
```

Before the change, the test fails.
It passes afterwards.
