### PR TITLE
fix: fix any() for symbols and bigints (#10179)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- `[expect]` Match symbols and bigints in `any()`; stop matching `null` ([#10223](https://github.com/facebook/jest/pull/10223))
+
 ### Chore & Maintenance
 
 ### Performance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- `[expect]` Match symbols and bigints in `any()`; stop matching `null` ([#10223](https://github.com/facebook/jest/pull/10223))
+- `[expect]` Match symbols and bigints in `any()` ([#10223](https://github.com/facebook/jest/pull/10223))
 
 ### Chore & Maintenance
 

--- a/packages/expect/src/__tests__/asymmetricMatchers.test.ts
+++ b/packages/expect/src/__tests__/asymmetricMatchers.test.ts
@@ -29,7 +29,11 @@ test('Any.asymmetricMatch()', () => {
     any(Number).asymmetricMatch(1),
     any(Function).asymmetricMatch(() => {}),
     any(Boolean).asymmetricMatch(true),
+    /* global BigInt */
+    any(BigInt).asymmetricMatch(1n),
+    any(Symbol).asymmetricMatch(Symbol()),
     any(Object).asymmetricMatch({}),
+    !any(Object).asymmetricMatch(null),
     any(Array).asymmetricMatch([]),
     any(Thing).asymmetricMatch(new Thing()),
   ].forEach(test => {

--- a/packages/expect/src/__tests__/asymmetricMatchers.test.ts
+++ b/packages/expect/src/__tests__/asymmetricMatchers.test.ts
@@ -33,7 +33,7 @@ test('Any.asymmetricMatch()', () => {
     any(BigInt).asymmetricMatch(1n),
     any(Symbol).asymmetricMatch(Symbol()),
     any(Object).asymmetricMatch({}),
-    !any(Object).asymmetricMatch(null),
+    any(Object).asymmetricMatch(null),
     any(Array).asymmetricMatch([]),
     any(Thing).asymmetricMatch(new Thing()),
   ].forEach(test => {

--- a/packages/expect/src/asymmetricMatchers.ts
+++ b/packages/expect/src/asymmetricMatchers.ts
@@ -46,7 +46,7 @@ class Any extends AsymmetricMatcher<any> {
     }
 
     if (this.sample == Object) {
-      return typeof other == 'object' && other !== null;
+      return typeof other == 'object';
     }
 
     if (this.sample == Boolean) {

--- a/packages/expect/src/asymmetricMatchers.ts
+++ b/packages/expect/src/asymmetricMatchers.ts
@@ -46,11 +46,20 @@ class Any extends AsymmetricMatcher<any> {
     }
 
     if (this.sample == Object) {
-      return typeof other == 'object';
+      return typeof other == 'object' && other !== null;
     }
 
     if (this.sample == Boolean) {
       return typeof other == 'boolean';
+    }
+
+    /* global BigInt */
+    if (this.sample == BigInt) {
+      return typeof other == 'bigint';
+    }
+
+    if (this.sample == Symbol) {
+      return typeof other == 'symbol';
     }
 
     return other instanceof this.sample;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Adds clauses to `expect`'s `Any.asymmetricMatch()` to handle `Symbol` and `BigInt` analogously to other primitives, i.e., using `typeof` instead of `instanceof`. This makes `expect.any()`'s behavior more consistent across primitive types.

Adds a clause to `Any.asymmetricMatch()` to exclude `null` from `expect.any(Object)`. This makes `expect.any()`'s behavior more consistent with its [documentation](https://jestjs.io/docs/en/expect#expectanyconstructor); `null` is not created with the `Object` constructor, and so should not be matched.

Closes #10179.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Added checks to the list in `asymmetricMatchers.test.ts` `test('Any.asymmetricMatch())'` to cover the changed behavior.