### PR TITLE
Replace non-inclusive "blacklist" term with "exclude" in jest-haste-map

### DIFF
--- a/packages/jest-haste-map/src/ModuleMap.ts
+++ b/packages/jest-haste-map/src/ModuleMap.ts
@@ -235,7 +235,7 @@ class DuplicateHasteCandidatesError extends Error {
         `cannot be resolved, because there exists several different ` +
         `files, or packages, that provide a module for ` +
         `that particular name and platform. ${platformMessage} You must ` +
-        `delete or blacklist files until there remains only one of these:\n\n` +
+        `delete or exclude files until there remains only one of these:\n\n` +
         Array.from(duplicatesSet)
           .map(
             ([dupFilePath, dupFileType]) =>

--- a/packages/jest-haste-map/src/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/jest-haste-map/src/__tests__/__snapshots__/index.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`HasteMap file system changes processing recovery from duplicate module IDs recovers when the most recent duplicate is fixed 1`] = `
-The name \`Pear\` was looked up in the Haste module map. It cannot be resolved, because there exists several different files, or packages, that provide a module for that particular name and platform. The platform is generic (no extension). You must delete or blacklist files until there remains only one of these:
+The name \`Pear\` was looked up in the Haste module map. It cannot be resolved, because there exists several different files, or packages, that provide a module for that particular name and platform. The platform is generic (no extension). You must delete or exclude files until there remains only one of these:
 
   * \`/project/fruits/Pear.js\` (module)
   * \`/project/fruits/another/Pear.js\` (module)
@@ -9,7 +9,7 @@ The name \`Pear\` was looked up in the Haste module map. It cannot be resolved, 
 `;
 
 exports[`HasteMap file system changes processing recovery from duplicate module IDs recovers when the oldest version of the duplicates is fixed 1`] = `
-The name \`Pear\` was looked up in the Haste module map. It cannot be resolved, because there exists several different files, or packages, that provide a module for that particular name and platform. The platform is generic (no extension). You must delete or blacklist files until there remains only one of these:
+The name \`Pear\` was looked up in the Haste module map. It cannot be resolved, because there exists several different files, or packages, that provide a module for that particular name and platform. The platform is generic (no extension). You must delete or exclude files until there remains only one of these:
 
   * \`/project/fruits/Pear.js\` (module)
   * \`/project/fruits/another/Pear.js\` (module)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Part **3 of 4** of continuous effort to get rid of non-inclusive terms like "whitelist" and "blacklist" implying that white = good and black = bad.

## Test plan

n/a