### PR TITLE
chore (jest-reporters): add missing space in coverage report message

### DIFF
--- a/packages/jest-reporters/src/coverage_reporter.ts
+++ b/packages/jest-reporters/src/coverage_reporter.ts
@@ -245,7 +245,7 @@ export default class CoverageReporter extends BaseReporter {
             if (threshold < 0) {
               if (threshold * -1 < actualUncovered) {
                 errors.push(
-                  `Jest: Uncovered count for ${key} (${actualUncovered})` +
+                  `Jest: Uncovered count for ${key} (${actualUncovered}) ` +
                     `exceeds ${name} threshold (${-1 * threshold})`,
                 );
               }


### PR DESCRIPTION
Closes #10259 

## Summary

This changes resolves issue #10259 by adding missing space in terminal output to provide a better user experience.

## Test plan

Execute in test project based on https://github.com/KonH/JestMissingSpaceIssue:
```
nmp t
```

Before that change:
```
Jest: Uncovered count for statements (2)exceeds global threshold (1)
```

After that change:
```
Jest: Uncovered count for statements (2) exceeds global threshold (1)
```