### PR TITLE
chore: update type definitions for coverageReporters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - `[jest-jasmine2]` Remove usage of `Function` type ([#10216](https://github.com/facebook/jest/pull/10216))
 - `[jest-resolve]` Improve types ([#10239](https://github.com/facebook/jest/pull/10239))
 - `[docs]` Clarify the [`jest.requireActual(moduleName)`](https://jestjs.io/docs/en/jest-object#jestrequireactualmodulename) example
+- `[jest-types]` Refine typings of `coverageReporters` ([#10275](https://github.com/facebook/jest/pull/10275))
 
 ### Performance
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -193,7 +193,7 @@ Indicates which provider should be used to instrument code for coverage. Allowed
 
 Note that using `v8` is considered experimental. This uses V8's builtin code coverage rather than one based on Babel. It is not as well tested, and it has also improved in the last few releases of Node. Using the latest versions of node (v14 at the time of this writing) will yield better results.
 
-### `coverageReporters` [array\<string | [string,any]>]
+### `coverageReporters` [array\<string | [string, options]>]
 
 Default: `["json", "lcov", "text", "clover"]`
 
@@ -206,6 +206,8 @@ _Note: You can pass additional options to the istanbul reporter using the tuple 
 ```json
 ["json", ["lcov", {"projectRoot": "../../"}]]
 ```
+
+For the additional information about the options object shape you can refer to CoverageReporterWithOptions type in the [type definitions](https://github.com/facebook/jest/tree/master/packages/jest-types/src/Config.ts)
 
 ### `coverageThreshold` [object]
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -207,7 +207,7 @@ _Note: You can pass additional options to the istanbul reporter using the tuple 
 ["json", ["lcov", {"projectRoot": "../../"}]]
 ```
 
-For the additional information about the options object shape you can refer to CoverageReporterWithOptions type in the [type definitions](https://github.com/facebook/jest/tree/master/packages/jest-types/src/Config.ts)
+For the additional information about the options object shape you can refer to `CoverageReporterWithOptions` type in the [type definitions](https://github.com/facebook/jest/tree/master/packages/jest-types/src/Config.ts).
 
 ### `coverageThreshold` [object]
 

--- a/packages/jest-types/src/Config.ts
+++ b/packages/jest-types/src/Config.ts
@@ -23,6 +23,20 @@ export type HasteConfig = {
   throwOnModuleCollision?: boolean;
 };
 
+export type CoverageReporterName = keyof ReportOptions;
+
+export type CoverageReporterWithOptions<
+  K = CoverageReporterName
+> = K extends CoverageReporterName
+  ? ReportOptions[K] extends never
+    ? never
+    : [K, Partial<ReportOptions[K]>]
+  : never;
+
+export type CoverageReporters = Array<
+  CoverageReporterName | CoverageReporterWithOptions
+>;
+
 export type ReporterConfig = [string, Record<string, unknown>];
 export type TransformerConfig = [string, Record<string, unknown>];
 
@@ -39,7 +53,7 @@ export type DefaultOptions = {
   clearMocks: boolean;
   collectCoverage: boolean;
   coveragePathIgnorePatterns: Array<string>;
-  coverageReporters: Array<string | [string, any]>;
+  coverageReporters: Array<CoverageReporterName>;
   coverageProvider: CoverageProvider;
   errorOnDeprecated: boolean;
   expand: boolean;
@@ -108,7 +122,7 @@ export type InitialOptions = Partial<{
   coverageDirectory: string;
   coveragePathIgnorePatterns: Array<string>;
   coverageProvider: CoverageProvider;
-  coverageReporters: Array<string>;
+  coverageReporters: CoverageReporters;
   coverageThreshold: {
     global: {
       [key: string]: number;
@@ -238,7 +252,7 @@ export type GlobalConfig = {
   coverageDirectory: string;
   coveragePathIgnorePatterns?: Array<string>;
   coverageProvider: CoverageProvider;
-  coverageReporters: Array<keyof ReportOptions | [keyof ReportOptions, any]>;
+  coverageReporters: CoverageReporters;
   coverageThreshold?: CoverageThreshold;
   detectLeaks: boolean;
   detectOpenHandles: boolean;


### PR DESCRIPTION
#### Summary
```javascript
import { Config } from '@jest/types';

const config: Config.InitialOptions = {
  coverageReporters: ['html', { subdir: 'dir' }] // typing error
}
```
Typing the config object as Config.InitialOptions resulted in error, because coverageReporters property in Config.InitialOptions was listed as an array of strings.

#### Test plan

Since there is only a change in typing precision, there is none.