### PR TITLE
Use fastest-levenshtein instead of leven

### DIFF
--- a/packages/jest-validate/package.json
+++ b/packages/jest-validate/package.json
@@ -13,8 +13,8 @@
     "@jest/types": "^26.1.0",
     "camelcase": "^6.0.0",
     "chalk": "^4.0.0",
+    "fastest-levenshtein": "^1.0.9",
     "jest-get-type": "^26.0.0",
-    "leven": "^3.1.0",
     "pretty-format": "^26.1.0"
   },
   "devDependencies": {

--- a/packages/jest-validate/src/utils.ts
+++ b/packages/jest-validate/src/utils.ts
@@ -7,7 +7,7 @@
 
 import chalk = require('chalk');
 import prettyFormat = require('pretty-format');
-import leven from 'leven';
+import levenshtein = require('fastest-levenshtein');
 
 const BULLET: string = chalk.bold('\u25cf');
 export const DEPRECATION = `${BULLET} Deprecation Warning`;
@@ -51,7 +51,7 @@ export const createDidYouMeanMessage = (
   allowedOptions: Array<string>,
 ): string => {
   const suggestion = allowedOptions.find(option => {
-    const steps: number = leven(option, unrecognized);
+    const steps: number = levenshtein.distance(option, unrecognized);
     return steps < 3;
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3,7 +3,7 @@
 
 __metadata:
   version: 4
-  cacheKey: 5
+  cacheKey: 6
 
 "@angular/common@npm:^10.0.2":
   version: 10.0.2
@@ -8439,6 +8439,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fastest-levenshtein@npm:^1.0.9":
+  version: 1.0.9
+  resolution: "fastest-levenshtein@npm:1.0.9"
+  checksum: 498a050331f0471d065529398d42717005b9787f19389e4ceba93fba349620ab8eba6da6c0becedad20678900e0e50b55b03cf9ac538c30113d995f25560b553
+  languageName: node
+  linkType: hard
+
 "fastq@npm:^1.6.0":
   version: 1.7.0
   resolution: "fastq@npm:1.7.0"
@@ -11621,8 +11628,8 @@ fsevents@^1.2.7:
     "@types/yargs": ^15.0.3
     camelcase: ^6.0.0
     chalk: ^4.0.0
+    fastest-levenshtein: ^1.0.9
     jest-get-type: ^26.0.0
-    leven: ^3.1.0
     pretty-format: ^26.1.0
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
`fastest-levenshtein` [(link)](https://github.com/ka-weihe/fastest-levenshtein) is much faster than `leven`. 

### Benchmarks
N = length of strings
Numbers are in ops/sec
Higher is better.
| Test Target               | N=4   | N=8   | N=16  | N=32 | N=64  | N=128 | N=256 | N=512 | N=1024 |
|---------------------------|-------|-------|-------|------|-------|-------|-------|-------|--------|
| fastest-levenshtein       | 44423 | 23702 | 10764 | 4595 | 1049  | 291.5 | 86.64 | 22.24 | 5.473  |
| leven                     | 19688 | 6884  | 1606  | 436  | 117   | 30.34 | 7.604 | 1.929 | 0.478  |
