### PR TITLE
fix: check `find` binary supports the `-iname` parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - `[expect]` Match symbols and bigints in `any()` ([#10223](https://github.com/facebook/jest/pull/10223))
 - `[jest-changed-files]` Use `git diff` instead of `git log` for `--changedSince` ([#10155](https://github.com/facebook/jest/pull/10155))
 - `[jest-console]` Add missing console.timeLog for compatability with Node ([#10209](https://github.com/facebook/jest/pull/10209))
+- `[jest-haste-map]` Check find binary supports the `-iname` parameter ([#10308](https://github.com/facebook/jest/pull/10308))
 - `[jest-snapshot]` Strip added indentation for inline error snapshots ([#10217](https://github.com/facebook/jest/pull/10217))
 
 ### Chore & Maintenance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@
 
 - `[expect]` Match symbols and bigints in `any()` ([#10223](https://github.com/facebook/jest/pull/10223))
 - `[jest-changed-files]` Use `git diff` instead of `git log` for `--changedSince` ([#10155](https://github.com/facebook/jest/pull/10155))
-- `[jest-console]` Add missing console.timeLog for compatability with Node ([#10209](https://github.com/facebook/jest/pull/10209))
-- `[jest-haste-map]` Check find binary supports the `-iname` parameter ([#10308](https://github.com/facebook/jest/pull/10308))
+- `[jest-console]` Add missing `console.timeLog` for compatibility with Node ([#10209](https://github.com/facebook/jest/pull/10209))
+- `[jest-haste-map]` Check `find` binary supports the `-iname` parameter ([#10308](https://github.com/facebook/jest/pull/10308))
 - `[jest-snapshot]` Strip added indentation for inline error snapshots ([#10217](https://github.com/facebook/jest/pull/10217))
 
 ### Chore & Maintenance

--- a/packages/jest-haste-map/package.json
+++ b/packages/jest-haste-map/package.json
@@ -28,7 +28,8 @@
     "@types/anymatch": "^1.3.1",
     "@types/fb-watchman": "^2.0.0",
     "@types/micromatch": "^4.0.0",
-    "@types/sane": "^2.0.0"
+    "@types/sane": "^2.0.0",
+    "slash": "^3.0.0"
   },
   "optionalDependencies": {
     "fsevents": "^2.1.2"

--- a/packages/jest-haste-map/package.json
+++ b/packages/jest-haste-map/package.json
@@ -21,16 +21,14 @@
     "jest-worker": "^26.1.0",
     "micromatch": "^4.0.2",
     "sane": "^4.0.3",
-    "walker": "^1.0.7",
-    "which": "^2.0.2"
+    "walker": "^1.0.7"
   },
   "devDependencies": {
     "@jest/test-utils": "^26.0.0",
     "@types/anymatch": "^1.3.1",
     "@types/fb-watchman": "^2.0.0",
     "@types/micromatch": "^4.0.0",
-    "@types/sane": "^2.0.0",
-    "@types/which": "^1.3.2"
+    "@types/sane": "^2.0.0"
   },
   "optionalDependencies": {
     "fsevents": "^2.1.2"

--- a/packages/jest-haste-map/src/crawlers/node.ts
+++ b/packages/jest-haste-map/src/crawlers/node.ts
@@ -8,7 +8,6 @@
 import * as path from 'path';
 import {spawn} from 'child_process';
 import * as fs from 'graceful-fs';
-import which = require('which');
 import H from '../constants';
 import * as fastPath from '../lib/fast_path';
 import type {
@@ -30,13 +29,15 @@ async function hasNativeFindSupport(
   }
 
   try {
-    await which('find');
     return await new Promise(resolve => {
       // Check the find binary supports the non-POSIX -iname parameter.
       const args = ['.', '-iname', "''"];
       const child = spawn('find', args);
+      child.on('error', () => {
+        resolve(false);
+      });
       child.on('exit', code => {
-        resolve(code == 0);
+        resolve(code === 0);
       });
     });
   } catch {

--- a/packages/jest-haste-map/src/crawlers/node.ts
+++ b/packages/jest-haste-map/src/crawlers/node.ts
@@ -24,7 +24,7 @@ type Callback = (result: Result) => void;
 async function hasNativeFindSupport(
   forceNodeFilesystemAPI: boolean,
 ): Promise<boolean> {
-  if (forceNodeFilesystemAPI || process.platform === 'win32') {
+  if (forceNodeFilesystemAPI) {
     return false;
   }
 

--- a/packages/jest-haste-map/src/crawlers/node.ts
+++ b/packages/jest-haste-map/src/crawlers/node.ts
@@ -31,7 +31,14 @@ async function hasNativeFindSupport(
 
   try {
     await which('find');
-    return true;
+    return await new Promise(resolve => {
+      // Check the find binary supports the non-POSIX -iname parameter.
+      const args = ['.', '-iname', "''"];
+      const child = spawn('find', args);
+      child.on('exit', code => {
+        resolve(code == 0);
+      });
+    });
   } catch {
     return false;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11217,6 +11217,7 @@ fsevents@^1.2.7:
     jest-worker: ^26.1.0
     micromatch: ^4.0.2
     sane: ^4.0.3
+    slash: ^3.0.0
     walker: ^1.0.7
   dependenciesMeta:
     fsevents:

--- a/yarn.lock
+++ b/yarn.lock
@@ -11208,7 +11208,6 @@ fsevents@^1.2.7:
     "@types/micromatch": ^4.0.0
     "@types/node": "*"
     "@types/sane": ^2.0.0
-    "@types/which": ^1.3.2
     anymatch: ^3.0.3
     fb-watchman: ^2.0.0
     fsevents: ^2.1.2
@@ -11219,7 +11218,6 @@ fsevents@^1.2.7:
     micromatch: ^4.0.2
     sane: ^4.0.3
     walker: ^1.0.7
-    which: ^2.0.2
   dependenciesMeta:
     fsevents:
       optional: true


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
The `-iname` parameter is a non-POSIX extension and may not be supported
by a POSIX compliant find binary. Add a check that the parameter is
supported when determining whether to use the native find binary.

Fixes: https://github.com/facebook/jest/issues/10263

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Wrote included test first that failed. Test passes with changes.
