### PR TITLE
docs: replace angle brackets to quotes

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -138,7 +138,7 @@ Deletes the Jest cache directory and then exits without running tests. Will dele
 
 ### `--collectCoverageFrom=<glob>`
 
-A glob pattern relative to <rootDir> matching the files that coverage info needs to be collected from.
+A glob pattern relative to `rootDir` matching the files that coverage info needs to be collected from.
 
 ### `--colors`
 
@@ -146,7 +146,7 @@ Forces test results output highlighting even if stdout is not a TTY.
 
 ### `--config=<path>`
 
-Alias: `-c`. The path to a Jest config file specifying how to find and execute tests. If no `rootDir` is set in the config, the directory containing the config file is assumed to be the rootDir for the project. This can also be a JSON-encoded value which Jest will use as configuration.
+Alias: `-c`. The path to a Jest config file specifying how to find and execute tests. If no `rootDir` is set in the config, the directory containing the config file is assumed to be the `rootDir` for the project. This can also be a JSON-encoded value which Jest will use as configuration.
 
 ### `--coverage[=<boolean>]`
 

--- a/docs/WatchPlugins.md
+++ b/docs/WatchPlugins.md
@@ -224,8 +224,8 @@ Any key not used by built-in functionality can be claimed, as you would expect. 
 
 Should your plugin attempt to overwrite a reserved key, Jest will error out with a descriptive message, something like:
 
-> Watch plugin YourFaultyPlugin attempted to register key <q>, that is reserved internally for quitting watch mode. Please change the configuration key for this plugin.
+> Watch plugin YourFaultyPlugin attempted to register key `q`, that is reserved internally for quitting watch mode. Please change the configuration key for this plugin.
 
 Third-party plugins are also forbidden to overwrite a key reserved already by another third-party plugin present earlier in the configured plugins list (`watchPlugins` array setting). When this happens, you’ll also get an error message that tries to help you fix that:
 
-> Watch plugins YourFaultyPlugin and TheirFaultyPlugin both attempted to register key <x>. Please change the key configuration for one of the conflicting plugins to avoid overlap.
+> Watch plugins YourFaultyPlugin and TheirFaultyPlugin both attempted to register key `x`. Please change the key configuration for one of the conflicting plugins to avoid overlap.

--- a/website/blog/2017-05-06-jest-20-delightful-testing-multi-project-runner.md
+++ b/website/blog/2017-05-06-jest-20-delightful-testing-multi-project-runner.md
@@ -37,7 +37,7 @@ Finally, we are now properly mapping code coverage when using TypeScript and we 
 We made a number of additions and improvements to the testing APIs which will help write more effective tests. We'd like to point out that all of these improvements were made entirely by community members!
 
 - **Better async testing:** Added new async/Promise support through resolves/rejects modifiers on expect: `expect(Promise(…)).resolves.toEqual(…)`. [See documentation](https://jestjs.io/docs/en/expect.html#resolves).
-- **Expect <n> assertions:** Along with the existing `expect.assertions(n)`, the new `expect.hasAssertions()` can be used to ensure a test has at least one assertion.
+- **Expect `n` assertions:** Along with the existing `expect.assertions(n)`, the new `expect.hasAssertions()` can be used to ensure a test has at least one assertion.
 - **Lint Plugin:** A `valid-expect` rule was added to `eslint-plugin-jest` to ensure that an assertion is called after invoking `expect`. This will prevent mistakes like a stray `expect(banana);` with a missing assertion call.
 - **Pretty-Format Plugins:** A number of new pretty-format plugins were added to Jest. We now pretty-print [Immutable.js](https://github.com/facebook/immutable-js/) data structures and HtmlElements in assertion failures and snapshots.
 - **Custom Environment:** It is now possible to add a `@jest-environment node|jsdom` annotation to the doc-block comment of a test file to use a test environment different from the default for individual tests.

--- a/website/versioned_docs/version-22.x/CLI.md
+++ b/website/versioned_docs/version-22.x/CLI.md
@@ -124,7 +124,7 @@ Deletes the Jest cache directory and then exits without running tests. Will dele
 
 ### `--collectCoverageFrom=<glob>`
 
-An array of glob patterns relative to <rootDir> matching the files that coverage info needs to be collected from.
+An array of glob patterns relative to `rootDir` matching the files that coverage info needs to be collected from.
 
 ### `--colors`
 
@@ -132,7 +132,7 @@ Forces test results output highlighting even if stdout is not a TTY.
 
 ### `--config=<path>`
 
-Alias: `-c`. The path to a Jest config file specifying how to find and execute tests. If no `rootDir` is set in the config, the directory containing the config file is assumed to be the rootDir for the project. This can also be a JSON-encoded value which Jest will use as configuration.
+Alias: `-c`. The path to a Jest config file specifying how to find and execute tests. If no `rootDir` is set in the config, the directory containing the config file is assumed to be the `rootDir` for the project. This can also be a JSON-encoded value which Jest will use as configuration.
 
 ### `--coverage`
 

--- a/website/versioned_docs/version-23.x/CLI.md
+++ b/website/versioned_docs/version-23.x/CLI.md
@@ -124,7 +124,7 @@ Deletes the Jest cache directory and then exits without running tests. Will dele
 
 ### `--collectCoverageFrom=<glob>`
 
-A glob pattern relative to <rootDir> matching the files that coverage info needs to be collected from.
+A glob pattern relative to `rootDir` matching the files that coverage info needs to be collected from.
 
 ### `--colors`
 
@@ -132,7 +132,7 @@ Forces test results output highlighting even if stdout is not a TTY.
 
 ### `--config=<path>`
 
-Alias: `-c`. The path to a Jest config file specifying how to find and execute tests. If no `rootDir` is set in the config, the directory containing the config file is assumed to be the rootDir for the project. This can also be a JSON-encoded value which Jest will use as configuration.
+Alias: `-c`. The path to a Jest config file specifying how to find and execute tests. If no `rootDir` is set in the config, the directory containing the config file is assumed to be the `rootDir` for the project. This can also be a JSON-encoded value which Jest will use as configuration.
 
 ### `--coverage`
 

--- a/website/versioned_docs/version-23.x/WatchPlugins.md
+++ b/website/versioned_docs/version-23.x/WatchPlugins.md
@@ -226,8 +226,8 @@ Any key not used by built-in functionality can be claimed, as you would expect. 
 
 Should your plugin attempt to overwrite a reserved key, Jest will error out with a descriptive message, something like:
 
-> Watch plugin YourFaultyPlugin attempted to register key <q>, that is reserved internally for quitting watch mode. Please change the configuration key for this plugin.
+> Watch plugin YourFaultyPlugin attempted to register key `q`, that is reserved internally for quitting watch mode. Please change the configuration key for this plugin.
 
 Third-party plugins are also forbidden to overwrite a key reserved already by another third-party plugin present earlier in the configured plugins list (`watchPlugins` array setting). When this happens, you’ll also get an error message that tries to help you fix that:
 
-> Watch plugins YourFaultyPlugin and TheirFaultyPlugin both attempted to register key <x>. Please change the key configuration for one of the conflicting plugins to avoid overlap.
+> Watch plugins YourFaultyPlugin and TheirFaultyPlugin both attempted to register key `x`. Please change the key configuration for one of the conflicting plugins to avoid overlap.

--- a/website/versioned_docs/version-24.x/CLI.md
+++ b/website/versioned_docs/version-24.x/CLI.md
@@ -139,7 +139,7 @@ Deletes the Jest cache directory and then exits without running tests. Will dele
 
 ### `--collectCoverageFrom=<glob>`
 
-A glob pattern relative to <rootDir> matching the files that coverage info needs to be collected from.
+A glob pattern relative to `rootDir` matching the files that coverage info needs to be collected from.
 
 ### `--colors`
 
@@ -147,7 +147,7 @@ Forces test results output highlighting even if stdout is not a TTY.
 
 ### `--config=<path>`
 
-Alias: `-c`. The path to a Jest config file specifying how to find and execute tests. If no `rootDir` is set in the config, the directory containing the config file is assumed to be the rootDir for the project. This can also be a JSON-encoded value which Jest will use as configuration.
+Alias: `-c`. The path to a Jest config file specifying how to find and execute tests. If no `rootDir` is set in the config, the directory containing the config file is assumed to be the `rootDir` for the project. This can also be a JSON-encoded value which Jest will use as configuration.
 
 ### `--coverage`
 

--- a/website/versioned_docs/version-24.x/WatchPlugins.md
+++ b/website/versioned_docs/version-24.x/WatchPlugins.md
@@ -225,8 +225,8 @@ Any key not used by built-in functionality can be claimed, as you would expect. 
 
 Should your plugin attempt to overwrite a reserved key, Jest will error out with a descriptive message, something like:
 
-> Watch plugin YourFaultyPlugin attempted to register key <q>, that is reserved internally for quitting watch mode. Please change the configuration key for this plugin.
+> Watch plugin YourFaultyPlugin attempted to register key `q`, that is reserved internally for quitting watch mode. Please change the configuration key for this plugin.
 
 Third-party plugins are also forbidden to overwrite a key reserved already by another third-party plugin present earlier in the configured plugins list (`watchPlugins` array setting). When this happens, you’ll also get an error message that tries to help you fix that:
 
-> Watch plugins YourFaultyPlugin and TheirFaultyPlugin both attempted to register key <x>. Please change the key configuration for one of the conflicting plugins to avoid overlap.
+> Watch plugins YourFaultyPlugin and TheirFaultyPlugin both attempted to register key `x`. Please change the key configuration for one of the conflicting plugins to avoid overlap.

--- a/website/versioned_docs/version-25.x/CLI.md
+++ b/website/versioned_docs/version-25.x/CLI.md
@@ -139,7 +139,7 @@ Deletes the Jest cache directory and then exits without running tests. Will dele
 
 ### `--collectCoverageFrom=<glob>`
 
-A glob pattern relative to <rootDir> matching the files that coverage info needs to be collected from.
+A glob pattern relative to `rootDir` matching the files that coverage info needs to be collected from.
 
 ### `--colors`
 
@@ -147,7 +147,7 @@ Forces test results output highlighting even if stdout is not a TTY.
 
 ### `--config=<path>`
 
-Alias: `-c`. The path to a Jest config file specifying how to find and execute tests. If no `rootDir` is set in the config, the directory containing the config file is assumed to be the rootDir for the project. This can also be a JSON-encoded value which Jest will use as configuration.
+Alias: `-c`. The path to a Jest config file specifying how to find and execute tests. If no `rootDir` is set in the config, the directory containing the config file is assumed to be the `rootDir` for the project. This can also be a JSON-encoded value which Jest will use as configuration.
 
 ### `--coverage[=<boolean>]`
 

--- a/website/versioned_docs/version-26.0/CLI.md
+++ b/website/versioned_docs/version-26.0/CLI.md
@@ -139,7 +139,7 @@ Deletes the Jest cache directory and then exits without running tests. Will dele
 
 ### `--collectCoverageFrom=<glob>`
 
-A glob pattern relative to <rootDir> matching the files that coverage info needs to be collected from.
+A glob pattern relative to `rootDir` matching the files that coverage info needs to be collected from.
 
 ### `--colors`
 
@@ -147,7 +147,7 @@ Forces test results output highlighting even if stdout is not a TTY.
 
 ### `--config=<path>`
 
-Alias: `-c`. The path to a Jest config file specifying how to find and execute tests. If no `rootDir` is set in the config, the directory containing the config file is assumed to be the rootDir for the project. This can also be a JSON-encoded value which Jest will use as configuration.
+Alias: `-c`. The path to a Jest config file specifying how to find and execute tests. If no `rootDir` is set in the config, the directory containing the config file is assumed to be the `rootDir` for the project. This can also be a JSON-encoded value which Jest will use as configuration.
 
 ### `--coverage[=<boolean>]`
 


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

It needed replace because markdown interprated `<rootDir>`, `<q>`, `<n>` and `<x>`
as html tags and don't show it.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

https://jestjs.io/docs/en/cli#--collectcoveragefromglob should view 
`A glob pattern relative to rootDir matching the files that coverage info needs to be collected from.`
instead of
`A glob pattern relative to matching the files that coverage info needs to be collected from.
`

https://jestjs.io/docs/en/watch-plugins#when-a-conflict-happens and https://jestjs.io/blog/2017/05/06/jest-20-delightful-testing-multi-project-runner#new--improved-testing-apis must have analog behavior