### PR TITLE
feat(jest-worker): support passing through ResourceLimits to worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 - `[jest-worker]` Added support for workers to send custom messages to parent in jest-worker ([#10293](https://github.com/facebook/jest/pull/10293))
+- `[jest-worker]` Support passing `resourceLimits` ([#10335](https://github.com/facebook/jest/pull/10335))
 - `[pretty-format]` Added support for serializing custom elements (web components) ([#10217](https://github.com/facebook/jest/pull/10237))
 
 ### Fixes

--- a/packages/jest-worker/src/base/BaseWorkerPool.ts
+++ b/packages/jest-worker/src/base/BaseWorkerPool.ts
@@ -40,12 +40,13 @@ export default class BaseWorkerPool {
     const stdout = mergeStream();
     const stderr = mergeStream();
 
-    const {forkOptions, maxRetries, setupArgs} = options;
+    const {forkOptions, maxRetries, resourceLimits, setupArgs} = options;
 
     for (let i = 0; i < options.numWorkers; i++) {
       const workerOptions: WorkerOptions = {
         forkOptions,
         maxRetries,
+        resourceLimits,
         setupArgs,
         workerId: i,
         workerPath,

--- a/packages/jest-worker/src/index.ts
+++ b/packages/jest-worker/src/index.ts
@@ -76,11 +76,12 @@ export default class JestWorker {
     this._ending = false;
 
     const workerPoolOptions: WorkerPoolOptions = {
-      enableWorkerThreads: this._options.enableWorkerThreads || false,
-      forkOptions: this._options.forkOptions || {},
-      maxRetries: this._options.maxRetries || 3,
-      numWorkers: this._options.numWorkers || Math.max(cpus().length - 1, 1),
-      setupArgs: this._options.setupArgs || [],
+      enableWorkerThreads: this._options.enableWorkerThreads ?? false,
+      forkOptions: this._options.forkOptions ?? {},
+      maxRetries: this._options.maxRetries ?? 3,
+      numWorkers: this._options.numWorkers ?? Math.max(cpus().length - 1, 1),
+      resourceLimits: this._options.resourceLimits ?? {},
+      setupArgs: this._options.setupArgs ?? [],
     };
 
     if (this._options.WorkerPool) {

--- a/packages/jest-worker/src/types.ts
+++ b/packages/jest-worker/src/types.ts
@@ -7,6 +7,7 @@
 
 import type {EventEmitter} from 'events';
 import type {ForkOptions} from 'child_process';
+import type {ResourceLimits} from 'worker_threads';
 
 // Because of the dynamic nature of a worker communication process, all messages
 // coming from any of the other processes cannot be typed. Thus, many types
@@ -65,12 +66,13 @@ export interface PromiseWithCustomMessage<T> extends Promise<T> {
 
 // Option objects.
 
-export type {ForkOptions};
+export type {ForkOptions, ResourceLimits};
 
 export type FarmOptions = {
   computeWorkerKey?: (method: string, ...args: Array<unknown>) => string | null;
   exposedMethods?: ReadonlyArray<string>;
   forkOptions?: ForkOptions;
+  resourceLimits?: ResourceLimits;
   setupArgs?: Array<unknown>;
   maxRetries?: number;
   numWorkers?: number;
@@ -84,6 +86,7 @@ export type FarmOptions = {
 export type WorkerPoolOptions = {
   setupArgs: Array<unknown>;
   forkOptions: ForkOptions;
+  resourceLimits: ResourceLimits;
   maxRetries: number;
   numWorkers: number;
   enableWorkerThreads: boolean;
@@ -91,6 +94,7 @@ export type WorkerPoolOptions = {
 
 export type WorkerOptions = {
   forkOptions: ForkOptions;
+  resourceLimits: ResourceLimits;
   setupArgs: Array<unknown>;
   maxRetries: number;
   workerId: number;

--- a/packages/jest-worker/src/workers/NodeThreadsWorker.ts
+++ b/packages/jest-worker/src/workers/NodeThreadsWorker.ts
@@ -62,6 +62,7 @@ export default class ExperimentalWorker implements WorkerInterface {
   initialize(): void {
     this._worker = new Worker(path.resolve(__dirname, './threadChild.js'), {
       eval: false,
+      resourceLimits: this._options.resourceLimits,
       stderr: true,
       stdout: true,
       workerData: {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

In the same way we allow passing `forkOptions` to `child_process`.

https://nodejs.org/api/worker_threads.html#worker_threads_new_worker_filename_options

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Green CI

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
