### PR TITLE
fix(jest-cli): use correct filename to override config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- `[jest-cli]` Use correct file name to override exisiting jest config on init ([#10337](https://github.com/facebook/jest/pull/10337))
+- `[jest-cli]` Use correct file name to override existing jest config on init ([#10337](https://github.com/facebook/jest/pull/10337))
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- `[jest-cli]` Use correct file name to override exisiting jest config on init ([#10337](https://github.com/facebook/jest/pull/10337))
+
 ### Chore & Maintenance
 
 ### Performance

--- a/packages/jest-cli/src/init/__tests__/init.test.js
+++ b/packages/jest-cli/src/init/__tests__/init.test.js
@@ -175,8 +175,10 @@ describe('init', () => {
 
           expect(prompts.mock.calls[0][0]).toMatchSnapshot();
 
+          const jestConfigFileName = fs.writeFileSync.mock.calls[0][0];
           const writtenJestConfig = fs.writeFileSync.mock.calls[0][1];
 
+          expect(jestConfigFileName).toBe(`jest.config.${extension}`);
           expect(writtenJestConfig).toBeDefined();
         });
 

--- a/packages/jest-cli/src/init/index.ts
+++ b/packages/jest-cli/src/init/index.ts
@@ -61,21 +61,21 @@ export default async (
     hasJestProperty = true;
   }
 
-  const existingJestConfigPath = JEST_CONFIG_EXT_ORDER.find(ext =>
+  const existingJestConfigExt = JEST_CONFIG_EXT_ORDER.find(ext =>
     fs.existsSync(path.join(rootDir, getConfigFilename(ext))),
   );
-  const jestConfigPath =
-    existingJestConfigPath ||
-    path.join(
-      rootDir,
-      getConfigFilename(
-        projectPackageJson.type === 'module'
-          ? JEST_CONFIG_EXT_MJS
-          : JEST_CONFIG_EXT_JS,
-      ),
-    );
+  const jestConfigPath = existingJestConfigExt
+    ? getConfigFilename(existingJestConfigExt)
+    : path.join(
+        rootDir,
+        getConfigFilename(
+          projectPackageJson.type === 'module'
+            ? JEST_CONFIG_EXT_MJS
+            : JEST_CONFIG_EXT_JS,
+        ),
+      );
 
-  if (hasJestProperty || existingJestConfigPath) {
+  if (hasJestProperty || existingJestConfigExt) {
     const result: {continue: boolean} = await prompts({
       initial: true,
       message:


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Init with existing config should override the config with correct filename.

## Test plan
Bug
<img width="642" alt="Screenshot 2020-07-30 at 8 09 41 PM" src="https://user-images.githubusercontent.com/20282546/88936529-a69b0900-d2a0-11ea-902b-13fcf6a4f60e.png">

When overriding jest config it creates a file only with extension.

Fix

<img width="638" alt="Screenshot 2020-07-30 at 8 11 35 PM" src="https://user-images.githubusercontent.com/20282546/88936777-e661f080-d2a0-11ea-9347-914f596ec6dc.png">
