### PR TITLE
fix: correct check for compatible `find` binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- `[jest-haste-map]` Properly detect support for native `find`
+
 ### Chore & Maintenance
 
 ### Performance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- `[jest-haste-map]` Properly detect support for native `find`
+- `[jest-haste-map]` Properly detect support for native `find` ([#10346](https://github.com/facebook/jest/pull/10346))
 
 ### Chore & Maintenance
 

--- a/packages/jest-haste-map/src/crawlers/__tests__/node.test.js
+++ b/packages/jest-haste-map/src/crawlers/__tests__/node.test.js
@@ -282,7 +282,11 @@ describe('node crawler', () => {
       rootDir,
       roots: ['/project/fruits'],
     }).then(({hasteMap, removedFiles}) => {
-      expect(childProcess.spawn).lastCalledWith('find', ['.', '-iname', "''"]);
+      expect(childProcess.spawn).lastCalledWith(
+        'find',
+        ['.', '-type', 'f', '(', '-iname', '*.ts', '-o', '-iname', '*.js', ')'],
+        {cwd: expect.any(String)},
+      );
       expect(hasteMap.files).toEqual(
         createMap({
           'fruits/directory/strawberry.js': ['', 33, 42, 0, '', null],

--- a/packages/jest-haste-map/src/crawlers/node.ts
+++ b/packages/jest-haste-map/src/crawlers/node.ts
@@ -30,9 +30,20 @@ async function hasNativeFindSupport(
 
   try {
     return await new Promise(resolve => {
-      // Check the find binary supports the non-POSIX -iname parameter.
-      const args = ['.', '-iname', "''"];
-      const child = spawn('find', args);
+      // Check the find binary supports the non-POSIX -iname parameter wrapped in parens.
+      const args = [
+        '.',
+        '-type',
+        'f',
+        '(',
+        '-iname',
+        '*.ts',
+        '-o',
+        '-iname',
+        '*.js',
+        ')',
+      ];
+      const child = spawn('find', args, {cwd: __dirname});
       child.on('error', () => {
         resolve(false);
       });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Fixes #10339

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Verified on Windows VM. Not sure how to write a test for this… I'm quite confused by why our windows tests pass without this - I doubt watchman is installed. Maybe they have some other `find`?

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
