### PR TITLE
fix(worker): downgrade minimum required node version to 10.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Fixes
 
+- `[jest-worker]` Downgrade minimum node version to 10.13 ([#10352](https://github.com/facebook/jest/pull/10352))
+
 ### Chore & Maintenance
 
 ### Performance

--- a/packages/jest-worker/package.json
+++ b/packages/jest-worker/package.json
@@ -21,7 +21,7 @@
     "worker-farm": "^1.6.0"
   },
   "engines": {
-    "node": ">= 10.14.2"
+    "node": ">= 10.14.2 || >= 10.13.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/jest-worker/package.json
+++ b/packages/jest-worker/package.json
@@ -21,7 +21,7 @@
     "worker-farm": "^1.6.0"
   },
   "engines": {
-    "node": ">= 10.14.2 || >= 10.13.0"
+    "node": ">= 10.13.0"
   },
   "publishConfig": {
     "access": "public"

--- a/scripts/buildUtils.js
+++ b/scripts/buildUtils.js
@@ -34,7 +34,7 @@ module.exports.getPackages = function getPackages() {
 
     assert.equal(
       pkg.engines.node,
-      nodeEngineRequiremnt,
+      pkg.name === 'jest-worker' ? '>= 10.13.0' : nodeEngineRequiremnt,
       `Engine requirement in ${pkg.name} should match root`,
     );
   });


### PR DESCRIPTION
<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary
Fixes #10142
Closes #10145

Change requested to downgrade the minimum required version of node to 10.13 to solve an issue people were experiencing when using the jest-worker as a dependency
