### PR TITLE
chore(test-result): remove deprecated `sourcemap` property

### DIFF
--- a/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapterInit.ts
+++ b/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapterInit.ts
@@ -259,7 +259,6 @@ export const runAndTransformResultsToJestFormat = async ({
     numPassingTests,
     numPendingTests,
     numTodoTests,
-    sourceMaps: {},
     testExecError,
     testFilePath: testPath,
     testResults: assertionResults,

--- a/packages/jest-core/src/ReporterDispatcher.ts
+++ b/packages/jest-core/src/ReporterDispatcher.ts
@@ -47,7 +47,6 @@ export default class ReporterDispatcher {
     }
 
     // Release memory if unused later.
-    testResult.sourceMaps = undefined;
     testResult.coverage = undefined;
     testResult.console = undefined;
   }

--- a/packages/jest-test-result/src/helpers.ts
+++ b/packages/jest-test-result/src/helpers.ts
@@ -72,7 +72,6 @@ export const buildFailureTestResult = (
     unmatched: 0,
     updated: 0,
   },
-  sourceMaps: {},
   testExecError: err,
   testFilePath: testPath,
   testResults: [],

--- a/packages/jest-test-result/src/types.ts
+++ b/packages/jest-test-result/src/types.ts
@@ -113,10 +113,6 @@ export type TestResult = {
     unmatched: number;
     updated: number;
   };
-  // TODO - Remove in Jest 26
-  sourceMaps?: {
-    [sourcePath: string]: string;
-  };
   testExecError?: SerializableError;
   testFilePath: Config.Path;
   testResults: Array<AssertionResult>;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

More minor cleanup - can break out into another PR if you want to land some before Jest 27

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Let CI do its thing.
