### PR TITLE
mistake in example code

### DIFF
--- a/website/versioned_docs/version-26.2/UsingMatchers.md
+++ b/website/versioned_docs/version-26.2/UsingMatchers.md
@@ -147,7 +147,7 @@ function compileAndroidCode() {
 }
 
 test('compiling android goes as expected', () => {
-  expect(() => compileAndroidCode).toThrow();
+  expect(() => compileAndroidCode()).toThrow();
   expect(() => compileAndroidCode).toThrow(Error);
 
   // You can also use the exact error message or a regexp

--- a/website/versioned_docs/version-26.2/UsingMatchers.md
+++ b/website/versioned_docs/version-26.2/UsingMatchers.md
@@ -147,12 +147,12 @@ function compileAndroidCode() {
 }
 
 test('compiling android goes as expected', () => {
-  expect(compileAndroidCode).toThrow();
-  expect(compileAndroidCode).toThrow(Error);
+  expect(() => compileAndroidCode).toThrow();
+  expect(() => compileAndroidCode).toThrow(Error);
 
   // You can also use the exact error message or a regexp
-  expect(compileAndroidCode).toThrow('you are using the wrong JDK');
-  expect(compileAndroidCode).toThrow(/JDK/);
+  expect(() => compileAndroidCode).toThrow('you are using the wrong JDK');
+  expect(() => compileAndroidCode).toThrow(/JDK/);
 });
 ```
 

--- a/website/versioned_docs/version-26.2/UsingMatchers.md
+++ b/website/versioned_docs/version-26.2/UsingMatchers.md
@@ -148,11 +148,11 @@ function compileAndroidCode() {
 
 test('compiling android goes as expected', () => {
   expect(() => compileAndroidCode()).toThrow();
-  expect(() => compileAndroidCode).toThrow(Error);
+  expect(() => compileAndroidCode()).toThrow(Error);
 
   // You can also use the exact error message or a regexp
-  expect(() => compileAndroidCode).toThrow('you are using the wrong JDK');
-  expect(() => compileAndroidCode).toThrow(/JDK/);
+  expect(() => compileAndroidCode()).toThrow('you are using the wrong JDK');
+  expect(() => compileAndroidCode()).toThrow(/JDK/);
 });
 ```
 


### PR DESCRIPTION
Code throws error but jest can not catch them because of

> Note: You must wrap the code in a function, otherwise the error will not be caught and the assertion will fail.

[quoted from](https://jestjs.io/docs/en/expect.html#tothrowerror)

