### PR TITLE
issue 9701

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 - `[jest-leak-detector]` Wait properly for GC runs due to changes in Node 14.7 ([#10366](https://github.com/facebook/jest/pull/10366))
 - `[jest-worker]` Downgrade minimum node version to 10.13 ([#10352](https://github.com/facebook/jest/pull/10352))
+- `[jest-reporters]` Use correct 'timeout' value to re-activate Notifications as per issue 9701 - ([#10384](https://github.com/facebook/jest/pull/10384))
 
 ### Chore & Maintenance
 

--- a/packages/jest-reporters/src/notify_reporter.ts
+++ b/packages/jest-reporters/src/notify_reporter.ts
@@ -79,7 +79,7 @@ export default class NotifyReporter extends BaseReporter {
         result.numPassedTests,
       )} passed`;
 
-      this._notifier.notify({icon, message, timeout: false, title});
+      this._notifier.notify({icon, message, timeout: 5, title});
     } else if (
       testsHaveRun &&
       !success &&
@@ -107,7 +107,7 @@ export default class NotifyReporter extends BaseReporter {
       const quitAnswer = 'Exit tests';
 
       if (!watchMode) {
-        this._notifier.notify({icon, message, timeout: false, title});
+        this._notifier.notify({icon, message, timeout: 5, title});
       } else {
         this._notifier.notify(
           {
@@ -115,7 +115,7 @@ export default class NotifyReporter extends BaseReporter {
             closeLabel: 'Close',
             icon,
             message,
-            timeout: false,
+            timeout: 5,
             title,
             // https://github.com/DefinitelyTyped/DefinitelyTyped/pull/42303
           } as any,


### PR DESCRIPTION
<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Proposal fix for https://github.com/facebook/jest/issues/9701

Timeout parameter is a value in seconds, according to [node-notifier documentation](https://www.npmjs.com/package/node-notifier)
