### PR TITLE
[jest-resolve] Add support for `packageFilter` for custom resolvers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Features
 
+- `[jest-resolve]` Add support for `packageFilter` on custom resolver ([#10393](https://github.com/facebook/jest/pull/10393))
+
 ### Fixes
 
 ### Chore & Maintenance

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -713,6 +713,38 @@ For example, if you want to respect Browserify's [`"browser"` field](https://git
 }
 ```
 
+By combining `defaultResolver` and `packageFilter` we can implement a `package.json` "pre-processor" that allows us to change how the default resolver will resolve modules. For example, imagine we want to use the field `"module"` if it is present, otherwise fallback to `"main"`:
+
+```json
+{
+  ...
+  "jest": {
+    "resolver": "my-module-resolve"
+  }
+}
+```
+
+```js
+// my-module-resolve package
+
+module.exports = (request, options) => {
+  // Call the defaultResolver, so we leverage its cache, error handling, etc.
+  return options.defaultResolver(request, {
+    ...options,
+    ...{
+      // Use packageFilter to process parsed `package.json` before the resolution (see https://www.npmjs.com/package/resolve#resolveid-opts-cb)
+      packageFilter: pkg => {
+        return {
+          ...pkg,
+          // Alter the value of `main` before resolving the package
+          main: pkg.module || pkg.main,
+        };
+      },
+    },
+  });
+};
+```
+
 ### `restoreMocks` [boolean]
 
 Default: `false`

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -693,7 +693,8 @@ This option allows the use of a custom resolver. This resolver must be a node mo
   "extensions": [string],
   "moduleDirectory": [string],
   "paths": [string],
-  "rootDir": [string]
+  "packageFilter": "function(pkg, pkgdir)",
+  "rootDir": [string],
 }
 ```
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -731,15 +731,13 @@ module.exports = (request, options) => {
   // Call the defaultResolver, so we leverage its cache, error handling, etc.
   return options.defaultResolver(request, {
     ...options,
-    ...{
-      // Use packageFilter to process parsed `package.json` before the resolution (see https://www.npmjs.com/package/resolve#resolveid-opts-cb)
-      packageFilter: pkg => {
-        return {
-          ...pkg,
-          // Alter the value of `main` before resolving the package
-          main: pkg.module || pkg.main,
-        };
-      },
+    // Use packageFilter to process parsed `package.json` before the resolution (see https://www.npmjs.com/package/resolve#resolveid-opts-cb)
+    packageFilter: pkg => {
+      return {
+        ...pkg,
+        // Alter the value of `main` before resolving the package
+        main: pkg.module || pkg.main,
+      };
     },
   });
 };

--- a/packages/jest-resolve/src/defaultResolver.ts
+++ b/packages/jest-resolve/src/defaultResolver.ts
@@ -6,11 +6,10 @@
  */
 
 import * as fs from 'graceful-fs';
-import {sync as resolveSync} from 'resolve';
+import {Opts as ResolveOpts, sync as resolveSync} from 'resolve';
 import pnpResolver from 'jest-pnp-resolver';
 import {tryRealpath} from 'jest-util';
 import type {Config} from '@jest/types';
-import type {Opts as ResolveOpts} from 'resolve';
 
 type ResolverOptions = {
   allowPnp?: boolean;

--- a/packages/jest-resolve/src/defaultResolver.ts
+++ b/packages/jest-resolve/src/defaultResolver.ts
@@ -10,6 +10,7 @@ import {sync as resolveSync} from 'resolve';
 import pnpResolver from 'jest-pnp-resolver';
 import {tryRealpath} from 'jest-util';
 import type {Config} from '@jest/types';
+import type {Opts as ResolveOpts} from 'resolve';
 
 type ResolverOptions = {
   allowPnp?: boolean;
@@ -20,7 +21,7 @@ type ResolverOptions = {
   moduleDirectory?: Array<string>;
   paths?: Array<Config.Path>;
   rootDir?: Config.Path;
-  packageFilter?: (pkg: any, pkgfile: string) => any;
+  packageFilter?: ResolveOpts['packageFilter'];
 };
 
 declare global {

--- a/packages/jest-resolve/src/defaultResolver.ts
+++ b/packages/jest-resolve/src/defaultResolver.ts
@@ -20,6 +20,7 @@ type ResolverOptions = {
   moduleDirectory?: Array<string>;
   paths?: Array<Config.Path>;
   rootDir?: Config.Path;
+  packageFilter?: (pkg: any, pkgfile: string) => any;
 };
 
 declare global {
@@ -45,6 +46,7 @@ export default function defaultResolver(
     isDirectory,
     isFile,
     moduleDirectory: options.moduleDirectory,
+    packageFilter: options.packageFilter,
     paths: options.paths,
     preserveSymlinks: false,
     realpathSync,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Forwards option `packageFilter` to `resolve`. This is useful in case a custom resolver wants to use it. The best example is #2702 (in particular, https://github.com/facebook/jest/issues/2702#issuecomment-671947783)

Fixes #2702

## Test plan

Write a custom resolver like

```
module.exports = ( request, options ) => {
	return options.defaultResolver( request, {
		...options,
		...{
			packageFilter: ( pkg ) => {
				return {
					...pkg,
					main: pkg.module || pkg.main,
				};
			},
		},
	} );
};
```

Then, in any jest test, when importing package `X`, it will try to load it from the field `module` first, with fallback to `main` if `module` doesn't exist.

