### PR TITLE
fix: Bumps node-notifier to v8.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- `[jest-reporters]` Fixes notify reporter on Linux (using notify-send) ([#10393](https://github.com/facebook/jest/pull/10400))
+
 ### Chore & Maintenance
 
 ### Performance

--- a/packages/jest-reporters/package.json
+++ b/packages/jest-reporters/package.json
@@ -44,7 +44,7 @@
     "strip-ansi": "^6.0.0"
   },
   "optionalDependencies": {
-    "node-notifier": "^7.0.0"
+    "node-notifier": "^8.0.0"
   },
   "engines": {
     "node": ">= 10.14.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1871,7 +1871,7 @@ __metadata:
     jest-util: ^26.3.0
     jest-worker: ^26.3.0
     mock-fs: ^4.4.1
-    node-notifier: ^7.0.0
+    node-notifier: ^8.0.0
     slash: ^3.0.0
     source-map: ^0.6.0
     string-length: ^4.0.1
@@ -13860,17 +13860,17 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"node-notifier@npm:^7.0.0":
-  version: 7.0.2
-  resolution: "node-notifier@npm:7.0.2"
+"node-notifier@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "node-notifier@npm:8.0.0"
   dependencies:
     growly: ^1.3.0
     is-wsl: ^2.2.0
     semver: ^7.3.2
     shellwords: ^0.1.1
-    uuid: ^8.2.0
+    uuid: ^8.3.0
     which: ^2.0.2
-  checksum: 61d77d6c98454235efdd9bb278ec6fa044e4e4d9066c60c46ca801d9022f9888e7a52d8b90bb2fd34c7e8c71e7c14660eb7de319df37923b8944a408562065dc
+  checksum: 3016eccb32cbfc0ec26129500570a0d875c32e28c43aef9c32d4cea24617cdd870eaf39247faffed5b89f78ef69ca4506270d2f8f76f027222597b700cc8aec9
   languageName: node
   linkType: hard
 
@@ -18958,7 +18958,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"uuid@npm:^8.2.0":
+"uuid@npm:^8.2.0, uuid@npm:^8.3.0":
   version: 8.3.0
   resolution: "uuid@npm:8.3.0"
   bin:


### PR DESCRIPTION
## Summary

There was an issue with Linux systems and node-notifier dependency (https://github.com/facebook/jest/issues/9701). This PR bumps node-notifier to v8.0.0 which should fix these issues. Should get the people experiencing issues to confirm.

cc @millette @mpareja

Fixes #9701

## Test plan

Shouldn't be any changes other than patch fix for Jest usage. Timeout for Linux systems will change, but no API changes. Types definitions on definitely typed aren't updated, but it is inconsequential for this PR as I see it.