### PR TITLE
fix: correctly handle arrays in snapshot deep merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - `[jest-reporters]` Fixes notify reporter on Linux (using notify-send) ([#10393](https://github.com/facebook/jest/pull/10400))
+- `[jest-snapshot]` Correctly handles arrays and property matchers in snapshots ([#10404](https://github.com/facebook/jest/pull/10404))
 
 ### Chore & Maintenance
 

--- a/packages/jest-snapshot/src/__tests__/utils.test.ts
+++ b/packages/jest-snapshot/src/__tests__/utils.test.ts
@@ -419,6 +419,26 @@ describe('DeepMerge with property matchers', () => {
         },
       },
     ],
+
+    [
+      'an array of objects',
+      // Target
+      [{name: 'one'}, {name: 'two'}, {name: 'three'}],
+      // Matchers
+      [{name: 'one'}, {name: matcher}, {name: matcher}],
+      // Expected
+      [{name: 'one'}, {name: matcher}, {name: matcher}],
+    ],
+
+    [
+      'an array of arrays',
+      // Target
+      [['one'], ['two'], ['three']],
+      // Matchers
+      [['one'], [matcher], [matcher]],
+      // Expected
+      [['one'], [matcher], [matcher]],
+    ],
   ];
   /* eslint-enable sort-keys */
 

--- a/packages/jest-snapshot/src/utils.ts
+++ b/packages/jest-snapshot/src/utils.ts
@@ -231,8 +231,9 @@ const deepMergeArray = (target: Array<any>, source: Array<any>) => {
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export const deepMerge = (target: any, source: any): any => {
-  const mergedOutput = {...target};
   if (isObject(target) && isObject(source)) {
+    const mergedOutput = {...target};
+
     Object.keys(source).forEach(key => {
       if (isObject(source[key]) && !source[key].$$typeof) {
         if (!(key in target)) Object.assign(mergedOutput, {[key]: source[key]});
@@ -243,6 +244,11 @@ export const deepMerge = (target: any, source: any): any => {
         Object.assign(mergedOutput, {[key]: source[key]});
       }
     });
+
+    return mergedOutput;
+  } else if (Array.isArray(target) && Array.isArray(source)) {
+    return deepMergeArray(target, source);
   }
-  return mergedOutput;
+
+  return target;
 };


### PR DESCRIPTION
## Summary

Fixes #10403.

## Test plan

Added tests.
