### PR TITLE
chore(website): minor CSS improvements to logos

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -12,7 +12,6 @@ const Container = CompLibrary.Container;
 const GridBlock = CompLibrary.GridBlock;
 
 const translate = require('../../server/translate.js').translate;
-const backers = require(process.cwd() + '/backers.json');
 const siteConfig = require(process.cwd() + '/siteConfig.js');
 const getDocsUrl = (url, language) =>
   siteConfig.baseUrl + 'docs/' + language + url;
@@ -181,13 +180,6 @@ const HeroInteractive = ({config: {repoUrl}, language}) => (
 
 class Index extends React.Component {
   render() {
-    const sponsorCount = backers.filter(
-      b => b.tier && b.tier.slug === 'sponsor'
-    ).length;
-
-    const backerCount = backers.filter(b => b.tier && b.tier.slug === 'backer')
-      .length;
-
     const showcase = siteConfig.users.map((user, i) => (
       <a href={user.infoLink} key={i}>
         <img src={user.image} title={user.caption} />

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -12,6 +12,7 @@ const Container = CompLibrary.Container;
 const GridBlock = CompLibrary.GridBlock;
 
 const translate = require('../../server/translate.js').translate;
+const backers = require(process.cwd() + '/backers.json');
 const siteConfig = require(process.cwd() + '/siteConfig.js');
 const getDocsUrl = (url, language) =>
   siteConfig.baseUrl + 'docs/' + language + url;
@@ -34,6 +35,90 @@ class Button extends React.Component {
 Button.defaultProps = {
   target: '_self',
 };
+
+const Sponsor = ({
+  fromAccount: {name, slug, website, imageUrl},
+  totalDonations,
+}) => (
+  <a
+    key={slug}
+    className="sponsor-item"
+    title={`$${totalDonations.value} by ${name || slug}`}
+    target="_blank"
+    rel="nofollow noopener"
+    href={website || `https://opencollective.com/${slug}`}
+  >
+    {
+      <img
+        className="sponsor-avatar"
+        src={imageUrl}
+        alt={name || slug ? `${name || slug}'s avatar` : 'avatar'}
+      />
+    }
+  </a>
+);
+
+const Backer = ({
+  fromAccount: {name, slug, website, imageUrl},
+  totalDonations,
+}) => (
+  <a
+    key={slug}
+    className="backer-item"
+    title={`$${totalDonations.value} by ${name || slug}`}
+    target="_blank"
+    rel="nofollow noopener"
+    href={website || `https://opencollective.com/${slug}`}
+  >
+    {
+      <img
+        className="backer-avatar"
+        src={imageUrl}
+        alt={name || slug ? `${name || slug}'s avatar` : 'avatar'}
+      />
+    }
+  </a>
+);
+
+class Contributors extends React.Component {
+  render() {
+    return (
+      <div className="opencollective">
+        <h3>
+          <translate>Sponsors</translate>
+        </h3>
+        <p>
+          <translate>
+            Sponsors are those who contribute $100 or more per month to Jest
+          </translate>
+        </p>
+        <div>
+          {backers
+            .filter(b => b.tier && b.tier.slug === 'sponsor')
+            .map(Sponsor)}
+        </div>
+        <h3>
+          <translate>Backers</translate>
+        </h3>
+        <p>
+          <translate>
+            Backers are those who contribute $2 or more per month to Jest
+          </translate>
+        </p>
+        <div>
+          {backers
+            .filter(
+              b =>
+                b.tier &&
+                b.tier.slug === 'backer' &&
+                !b.fromAccount.slug.includes('adult')
+            )
+            .map(Backer)}
+        </div>
+      </div>
+    );
+  }
+}
 
 class Card extends React.Component {
   render() {
@@ -446,13 +531,7 @@ class Index extends React.Component {
                       non-Facebook contributors.
                     </translate>
                   </MarkdownBlock>
-                  <MarkdownBlock>
-                    <translate>
-                      We have over 50 Sponsors who contribute $100 or more per
-                      month, and over 450 Backers who have contributed $2 or
-                      more to Jest.
-                    </translate>
-                  </MarkdownBlock>
+                  <Contributors />
                 </div>
                 <div className="blockContent yellow">
                   <h2>
@@ -470,7 +549,7 @@ class Index extends React.Component {
                   </MarkdownBlock>
                   <div className="gridBlock logos">
                     {showcase}
-                    <p className="others">And many others</p>
+                    <p>And many others</p>
                   </div>
                 </div>
               </div>

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -549,7 +549,7 @@ class Index extends React.Component {
                   </MarkdownBlock>
                   <div className="gridBlock logos">
                     {showcase}
-                    <p>And many others</p>
+                    <p className="others">And many others</p>
                   </div>
                 </div>
               </div>

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -36,90 +36,6 @@ Button.defaultProps = {
   target: '_self',
 };
 
-const Sponsor = ({
-  fromAccount: {name, slug, website, imageUrl},
-  totalDonations,
-}) => (
-  <a
-    key={slug}
-    className="sponsor-item"
-    title={`$${totalDonations.value} by ${name || slug}`}
-    target="_blank"
-    rel="nofollow noopener"
-    href={website || `https://opencollective.com/${slug}`}
-  >
-    {
-      <img
-        className="sponsor-avatar"
-        src={imageUrl}
-        alt={name || slug ? `${name || slug}'s avatar` : 'avatar'}
-      />
-    }
-  </a>
-);
-
-const Backer = ({
-  fromAccount: {name, slug, website, imageUrl},
-  totalDonations,
-}) => (
-  <a
-    key={slug}
-    className="backer-item"
-    title={`$${totalDonations.value} by ${name || slug}`}
-    target="_blank"
-    rel="nofollow noopener"
-    href={website || `https://opencollective.com/${slug}`}
-  >
-    {
-      <img
-        className="backer-avatar"
-        src={imageUrl}
-        alt={name || slug ? `${name || slug}'s avatar` : 'avatar'}
-      />
-    }
-  </a>
-);
-
-class Contributors extends React.Component {
-  render() {
-    return (
-      <div className="opencollective">
-        <h3>
-          <translate>Sponsors</translate>
-        </h3>
-        <p>
-          <translate>
-            Sponsors are those who contribute $100 or more per month to Jest
-          </translate>
-        </p>
-        <div>
-          {backers
-            .filter(b => b.tier && b.tier.slug === 'sponsor')
-            .map(Sponsor)}
-        </div>
-        <h3>
-          <translate>Backers</translate>
-        </h3>
-        <p>
-          <translate>
-            Backers are those who contribute $2 or more per month to Jest
-          </translate>
-        </p>
-        <div>
-          {backers
-            .filter(
-              b =>
-                b.tier &&
-                b.tier.slug === 'backer' &&
-                !b.fromAccount.slug.includes('adult')
-            )
-            .map(Backer)}
-        </div>
-      </div>
-    );
-  }
-}
-
 class Card extends React.Component {
   render() {
     const {index} = this.props;
@@ -265,6 +181,13 @@ const HeroInteractive = ({config: {repoUrl}, language}) => (
 
 class Index extends React.Component {
   render() {
+    const sponsorCount = backers.filter(
+      b => b.tier && b.tier.slug === 'sponsor'
+    ).length;
+
+    const backerCount = backers.filter(b => b.tier && b.tier.slug === 'backer')
+      .length;
+
     const showcase = siteConfig.users.map((user, i) => (
       <a href={user.infoLink} key={i}>
         <img src={user.image} title={user.caption} />
@@ -531,7 +454,13 @@ class Index extends React.Component {
                       non-Facebook contributors.
                     </translate>
                   </MarkdownBlock>
-                  <Contributors />
+                  <MarkdownBlock>
+                    <translate>
+                      We have over 50 Sponsors who contribute $100 or more per
+                      month, and over 450 Backers who have contributed $2 or
+                      more to Jest.
+                    </translate>
+                  </MarkdownBlock>
                 </div>
                 <div className="blockContent yellow">
                   <h2>
@@ -549,7 +478,7 @@ class Index extends React.Component {
                   </MarkdownBlock>
                   <div className="gridBlock logos">
                     {showcase}
-                    <p>And many others</p>
+                    <p className="others">And many others</p>
                   </div>
                 </div>
               </div>

--- a/website/static/css/jest.css
+++ b/website/static/css/jest.css
@@ -152,8 +152,12 @@
   padding-top: 10px;
 }
 
-.logos {
-  align-items: center;
+.logos > a {
+  margin-left: 0;
+}
+
+.logos > p.others {
+  padding-top: 1.5rem !important;
 }
 
 @media only screen and (min-width: 736px) {


### PR DESCRIPTION
## Summary

![Screen Shot 2020-08-15 at 7 50 20 AM](https://user-images.githubusercontent.com/49038/90311700-dadf0e00-decb-11ea-94a0-87d9cbf61732.png)

Switches the open collective info from showing logos to not, there's a trade-off here where we could have continued to make a more complex filter for what we show. But TBH, it's not really something we want to be actively keeping an eye on. So, rather than play whack-a-mole on the sponsors, this PR drops is completely.