### PR TITLE
chore: duplicate `@typescript-eslint/ban-types` locally to allow warning

### DIFF
--- a/.eslintplugin/index.js
+++ b/.eslintplugin/index.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc. All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+exports.rules = {
+  'ban-types-eventually': require('@typescript-eslint/eslint-plugin').rules[
+    'ban-types'
+  ],
+};

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,14 +19,10 @@ module.exports = {
       extends: ['plugin:@typescript-eslint/eslint-recommended'],
       files: ['*.ts', '*.tsx'],
       parser: '@typescript-eslint/parser',
-      plugins: ['@typescript-eslint/eslint-plugin'],
+      plugins: ['@typescript-eslint/eslint-plugin', 'local'],
       rules: {
         '@typescript-eslint/array-type': ['error', {default: 'generic'}],
-        '@typescript-eslint/ban-types': [
-          'error',
-          // TODO: remove these overrides: https://github.com/facebook/jest/issues/10177
-          {types: {Function: false, object: false, '{}': false}},
-        ],
+        '@typescript-eslint/ban-types': 'error',
         '@typescript-eslint/no-unused-vars': [
           'error',
           {argsIgnorePattern: '^_'},
@@ -42,6 +38,66 @@ module.exports = {
         'prefer-spread': 'off',
       },
     },
+    {
+      files: [
+        'e2e/babel-plugin-jest-hoist/__tests__/typescript.test.ts',
+        'e2e/coverage-remapping/covered.ts',
+        'packages/expect/src/jestMatchersObject.ts',
+        'packages/expect/src/matchers.ts',
+        'packages/expect/src/print.ts',
+        'packages/expect/src/toThrowMatchers.ts',
+        'packages/expect/src/types.ts',
+        'packages/expect/src/utils.ts',
+        'packages/jest-core/src/ReporterDispatcher.ts',
+        'packages/jest-core/src/TestScheduler.ts',
+        'packages/jest-core/src/collectHandles.ts',
+        'packages/jest-core/src/plugins/update_snapshots_interactive.ts',
+        'packages/jest-environment/src/index.ts',
+        'packages/jest-fake-timers/src/legacyFakeTimers.ts',
+        'packages/jest-haste-map/src/index.ts',
+        'packages/jest-haste-map/src/lib/FSEventsWatcher.ts',
+        'packages/jest-jasmine2/src/errorOnPrivate.ts',
+        'packages/jest-jasmine2/src/jasmine/SpyStrategy.ts',
+        'packages/jest-jasmine2/src/jasmine/Suite.ts',
+        'packages/jest-leak-detector/src/index.ts',
+        'packages/jest-matcher-utils/src/index.ts',
+        'packages/jest-mock/src/__tests__/index.test.ts',
+        'packages/jest-mock/src/index.ts',
+        'packages/jest-resolve/src/isBuiltinModule.ts',
+        'packages/jest-snapshot/src/index.ts',
+        'packages/jest-snapshot/src/printSnapshot.ts',
+        'packages/jest-snapshot/src/types.ts',
+        'packages/jest-types/src/Global.ts',
+        'packages/jest-util/src/ErrorWithStack.ts',
+        'packages/jest-util/src/convertDescriptorToString.ts',
+        'packages/jest-validate/src/types.ts',
+        'packages/jest-worker/src/Farm.ts',
+        'packages/jest-worker/src/index.ts',
+        'packages/pretty-format/src/index.ts',
+        'packages/pretty-format/src/plugins/DOMCollection.ts',
+      ],
+      rules: {
+        '@typescript-eslint/ban-types': [
+          'error',
+          // TODO: remove these overrides: https://github.com/facebook/jest/issues/10177
+          {types: {Function: false, object: false, '{}': false}},
+        ],
+        'local/ban-types-eventually': [
+          'warn',
+          {
+            types: {
+              // none of these types are in use, so can be errored on
+              Boolean: false,
+              Number: false,
+              Object: false,
+              String: false,
+              Symbol: false,
+            },
+          },
+        ],
+      },
+    },
+
     // to make it more suitable for running on code examples in docs/ folder
     {
       files: ['*.md'],
@@ -146,6 +202,7 @@ module.exports = {
   plugins: ['markdown', 'import', 'prettier', 'eslint-comments'],
   rules: {
     'arrow-body-style': 2,
+    'eslint-comments/disable-enable-pair': ['error', {allowWholeFile: true}],
     'eslint-comments/no-unused-disable': 2,
     'flowtype/boolean-style': 2,
     'flowtype/no-primitive-constructor-types': 2,

--- a/e2e/babel-plugin-jest-hoist/__tests__/typescript.test.ts
+++ b/e2e/babel-plugin-jest-hoist/__tests__/typescript.test.ts
@@ -6,6 +6,8 @@
  *
  */
 
+/* eslint-disable local/ban-types-eventually */
+
 import type {Color} from '../types';
 import {color} from '../entry';
 

--- a/e2e/coverage-remapping/covered.ts
+++ b/e2e/coverage-remapping/covered.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable local/ban-types-eventually, @typescript-eslint/no-unused-vars */
 
 export = function difference(a: number, b: number): number {
   const branch1: boolean = true ? 1 : 0;

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "eslint-plugin-import": "^2.6.0",
     "eslint-plugin-jest": "^24.0.0",
     "eslint-plugin-jsx-a11y": "^6.0.2",
+    "eslint-plugin-local": "^1.0.0",
     "eslint-plugin-markdown": "^1.0.0",
     "eslint-plugin-prettier": "^3.0.1",
     "eslint-plugin-react": "^7.1.0",

--- a/packages/expect/src/matchers.ts
+++ b/packages/expect/src/matchers.ts
@@ -6,6 +6,8 @@
  *
  */
 
+/* eslint-disable local/ban-types-eventually */
+
 import getType = require('jest-get-type');
 import {
   DIM_COLOR,

--- a/packages/expect/src/print.ts
+++ b/packages/expect/src/print.ts
@@ -6,6 +6,8 @@
  *
  */
 
+/* eslint-disable local/ban-types-eventually */
+
 import {
   EXPECTED_COLOR,
   INVERTED_COLOR,

--- a/packages/expect/src/toThrowMatchers.ts
+++ b/packages/expect/src/toThrowMatchers.ts
@@ -6,6 +6,8 @@
  *
  */
 
+/* eslint-disable local/ban-types-eventually */
+
 import {formatStackTrace, separateMessageFromStack} from 'jest-message-util';
 import {
   EXPECTED_COLOR,

--- a/packages/expect/src/types.ts
+++ b/packages/expect/src/types.ts
@@ -5,6 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
+
+/* eslint-disable local/ban-types-eventually */
+
 import type {Config} from '@jest/types';
 import type * as jestMatcherUtils from 'jest-matcher-utils';
 import {INTERNAL_MATCHER_FLAG} from './jestMatchersObject';

--- a/packages/expect/src/utils.ts
+++ b/packages/expect/src/utils.ts
@@ -6,6 +6,8 @@
  *
  */
 
+/* eslint-disable local/ban-types-eventually */
+
 import {isPrimitive} from 'jest-get-type';
 import {
   equals,
@@ -100,7 +102,7 @@ export const getObjectSubset = (
   subset: any,
   seenReferences: WeakMap<object, boolean> = new WeakMap(),
 ): any => {
-  /* eslint-enable */
+  /* eslint-enable @typescript-eslint/explicit-module-boundary-types */
   if (Array.isArray(object)) {
     if (Array.isArray(subset) && subset.length === object.length) {
       // The map method returns correct subclass of subset.
@@ -143,7 +145,7 @@ const hasIterator = (object: any) =>
 export const iterableEquality = (
   a: any,
   b: any,
-  /* eslint-enable */
+  /* eslint-enable @typescript-eslint/explicit-module-boundary-types */
   aStack: Array<any> = [],
   bStack: Array<any> = [],
 ): boolean | undefined => {

--- a/packages/jest-core/src/ReporterDispatcher.ts
+++ b/packages/jest-core/src/ReporterDispatcher.ts
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+/* eslint-disable local/ban-types-eventually */
+
 import type {
   AggregatedResult,
   TestCaseResult,

--- a/packages/jest-core/src/TestScheduler.ts
+++ b/packages/jest-core/src/TestScheduler.ts
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+/* eslint-disable local/ban-types-eventually */
+
 import chalk = require('chalk');
 import {formatExecError} from 'jest-message-util';
 import type {Config} from '@jest/types';

--- a/packages/jest-core/src/collectHandles.ts
+++ b/packages/jest-core/src/collectHandles.ts
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+/* eslint-disable local/ban-types-eventually */
+
 import * as asyncHooks from 'async_hooks';
 import type {Config} from '@jest/types';
 import {formatExecError} from 'jest-message-util';

--- a/packages/jest-core/src/plugins/update_snapshots_interactive.ts
+++ b/packages/jest-core/src/plugins/update_snapshots_interactive.ts
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+/* eslint-disable local/ban-types-eventually */
+
 import type {Config} from '@jest/types';
 import type {AggregatedResult, AssertionLocation} from '@jest/test-result';
 import {BaseWatchPlugin, JestHookSubscriber, UsageData} from 'jest-watcher';

--- a/packages/jest-environment/src/index.ts
+++ b/packages/jest-environment/src/index.ts
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+/* eslint-disable local/ban-types-eventually */
+
 import type {Context, Script} from 'vm';
 import type {Circus, Config, Global} from '@jest/types';
 import jestMock = require('jest-mock');

--- a/packages/jest-fake-timers/src/legacyFakeTimers.ts
+++ b/packages/jest-fake-timers/src/legacyFakeTimers.ts
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+/* eslint-disable local/ban-types-eventually */
+
 import util = require('util');
 import type {ModuleMocker} from 'jest-mock';
 import {StackTraceConfig, formatStackTrace} from 'jest-message-util';

--- a/packages/jest-haste-map/src/index.ts
+++ b/packages/jest-haste-map/src/index.ts
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+/* eslint-disable local/ban-types-eventually */
+
 import {execSync} from 'child_process';
 import {createHash} from 'crypto';
 import {EventEmitter} from 'events';

--- a/packages/jest-haste-map/src/lib/FSEventsWatcher.ts
+++ b/packages/jest-haste-map/src/lib/FSEventsWatcher.ts
@@ -6,6 +6,8 @@
  *
  */
 
+/* eslint-disable local/ban-types-eventually */
+
 import * as path from 'path';
 import {EventEmitter} from 'events';
 import * as fs from 'graceful-fs';

--- a/packages/jest-jasmine2/src/errorOnPrivate.ts
+++ b/packages/jest-jasmine2/src/errorOnPrivate.ts
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+/* eslint-disable local/ban-types-eventually */
+
 import type {Global} from '@jest/types';
 import {ErrorWithStack} from 'jest-util';
 import type {Jasmine} from './types';

--- a/packages/jest-jasmine2/src/jasmine/SpyStrategy.ts
+++ b/packages/jest-jasmine2/src/jasmine/SpyStrategy.ts
@@ -29,6 +29,8 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
+/* eslint-disable local/ban-types-eventually */
+
 export default class SpyStrategy {
   identity: () => string;
   exec: (...args: Array<any>) => unknown;

--- a/packages/jest-jasmine2/src/jasmine/Suite.ts
+++ b/packages/jest-jasmine2/src/jasmine/Suite.ts
@@ -28,7 +28,8 @@ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
-/* eslint-disable sort-keys */
+
+/* eslint-disable local/ban-types-eventually, sort-keys */
 
 import {convertDescriptorToString} from 'jest-util';
 import type {Config} from '@jest/types';

--- a/packages/jest-leak-detector/src/index.ts
+++ b/packages/jest-leak-detector/src/index.ts
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+/* eslint-disable local/ban-types-eventually */
+
 import {setFlagsFromString} from 'v8';
 import {runInNewContext} from 'vm';
 import {promisify} from 'util';

--- a/packages/jest-matcher-utils/src/index.ts
+++ b/packages/jest-matcher-utils/src/index.ts
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+/* eslint-disable local/ban-types-eventually */
+
 import chalk = require('chalk');
 import diffDefault, {
   DIFF_DELETE,

--- a/packages/jest-mock/src/__tests__/index.test.ts
+++ b/packages/jest-mock/src/__tests__/index.test.ts
@@ -6,6 +6,8 @@
  *
  */
 
+/* eslint-disable local/ban-types-eventually */
+
 import vm, {Context} from 'vm';
 import {ModuleMocker} from '../';
 

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+/* eslint-disable local/ban-types-eventually */
+
 type Global = NodeJS.Global; // | Window – add once TS improves typings;
 
 namespace JestMock {

--- a/packages/jest-resolve/src/isBuiltinModule.ts
+++ b/packages/jest-resolve/src/isBuiltinModule.ts
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+/* eslint-disable local/ban-types-eventually */
+
 import module = require('module');
 
 // "private" api

--- a/packages/jest-snapshot/src/index.ts
+++ b/packages/jest-snapshot/src/index.ts
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+/* eslint-disable local/ban-types-eventually */
+
 import * as fs from 'graceful-fs';
 import type {Config} from '@jest/types';
 import type {FS as HasteFS} from 'jest-haste-map';

--- a/packages/jest-snapshot/src/printSnapshot.ts
+++ b/packages/jest-snapshot/src/printSnapshot.ts
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+/* eslint-disable local/ban-types-eventually */
+
 import chalk = require('chalk');
 // Temporary hack because getObjectSubset has known limitations,
 // is not in the public interface of the expect package,

--- a/packages/jest-snapshot/src/types.ts
+++ b/packages/jest-snapshot/src/types.ts
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+/* eslint-disable local/ban-types-eventually */
+
 import type {MatcherState} from 'expect';
 import type SnapshotState from './State';
 

--- a/packages/jest-types/src/Global.ts
+++ b/packages/jest-types/src/Global.ts
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+/* eslint-disable local/ban-types-eventually */
+
 import type {CoverageMapData} from 'istanbul-lib-coverage';
 
 export type DoneFn = (reason?: string | Error) => void;

--- a/packages/jest-util/src/ErrorWithStack.ts
+++ b/packages/jest-util/src/ErrorWithStack.ts
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+/* eslint-disable local/ban-types-eventually */
+
 export default class ErrorWithStack extends Error {
   constructor(message: string | undefined, callsite: Function) {
     super(message);

--- a/packages/jest-util/src/convertDescriptorToString.ts
+++ b/packages/jest-util/src/convertDescriptorToString.ts
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+/* eslint-disable local/ban-types-eventually */
+
 // See: https://github.com/facebook/jest/pull/5154
 export default function convertDescriptorToString<
   T extends number | string | Function | undefined

--- a/packages/jest-worker/src/Farm.ts
+++ b/packages/jest-worker/src/Farm.ts
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+/* eslint-disable local/ban-types-eventually */
+
 import {
   CHILD_MESSAGE_CALL,
   ChildMessage,

--- a/packages/jest-worker/src/index.ts
+++ b/packages/jest-worker/src/index.ts
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+/* eslint-disable local/ban-types-eventually */
+
 import {cpus} from 'os';
 import WorkerPool from './WorkerPool';
 import Farm from './Farm';

--- a/packages/pretty-format/src/index.ts
+++ b/packages/pretty-format/src/index.ts
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+/* eslint-disable local/ban-types-eventually */
+
 import style = require('ansi-styles');
 import type * as PrettyFormat from './types';
 

--- a/packages/pretty-format/src/plugins/DOMCollection.ts
+++ b/packages/pretty-format/src/plugins/DOMCollection.ts
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+/* eslint-disable local/ban-types-eventually */
+
 import type {Config, NewPlugin, Printer, Refs} from '../types';
 
 import {printListItems, printObjectProperties} from '../collections';

--- a/yarn.lock
+++ b/yarn.lock
@@ -7965,6 +7965,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-plugin-local@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "eslint-plugin-local@npm:1.0.0"
+  checksum: 369263373b645b3024b974c799454cb05c283cd735abab86c25d65fe54027b3d1a8533bd895d3e8ff281ea370669e6e3d6ac700a8fe751933889868cc57de447
+  languageName: node
+  linkType: hard
+
 "eslint-plugin-markdown@npm:^1.0.0":
   version: 1.0.2
   resolution: "eslint-plugin-markdown@npm:1.0.2"
@@ -17053,6 +17060,7 @@ fsevents@^1.2.7:
     eslint-plugin-import: ^2.6.0
     eslint-plugin-jest: ^24.0.0
     eslint-plugin-jsx-a11y: ^6.0.2
+    eslint-plugin-local: ^1.0.0
     eslint-plugin-markdown: ^1.0.0
     eslint-plugin-prettier: ^3.0.1
     eslint-plugin-react: ^7.1.0


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Duplicates the `@typescript-eslint/ban-types` rule locally so that we can warn on types like `Function` that we want to ban, but are used too much in the codebase to be fixed all at once.

As mentioned in [these comments](https://github.com/facebook/jest/pull/10437#issuecomment-678713953).

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
