### PR TITLE
chore: fix yarn caching on circle ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,14 +1,11 @@
 aliases:
   - &restore-cache
-    keys:
-      - v3-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}
-      # Fallback in case checksum fails
-      - v3-dependencies-{{ .Branch }}-
+    keys: v4-dependencies-{{ checksum "yarn.lock" }}
 
   - &save-cache
     paths:
-      - ~/.cache/yarn
-    key: v3-dependencies-{{ .Branch }}-{{ checksum "yarn.lock" }}
+      - ~/.yarn/berry/cache
+    keys: v4-dependencies-{{ checksum "yarn.lock" }}
 
   - &filter-ignore-gh-pages
     branches:
@@ -23,6 +20,8 @@ jobs:
       - image: circleci/node:10
     steps:
       - checkout
+      - run:
+          command: yarn config get cacheFolder
       - restore-cache: *restore-cache
       - run: *install
       - save-cache: *save-cache
@@ -37,6 +36,8 @@ jobs:
       - image: circleci/node:12
     steps:
       - checkout
+      - run:
+          command: yarn config get cacheFolder
       - restore-cache: *restore-cache
       - run: *install
       - save-cache: *save-cache
@@ -51,6 +52,8 @@ jobs:
       - image: circleci/node:12
     steps:
       - checkout
+      - run:
+          command: yarn config get cacheFolder
       - restore-cache: *restore-cache
       - run: *install
       - save-cache: *save-cache
@@ -65,6 +68,8 @@ jobs:
       - image: circleci/node:13
     steps:
       - checkout
+      - run:
+          command: yarn config get cacheFolder
       - restore-cache: *restore-cache
       - run: *install
       - save-cache: *save-cache
@@ -79,6 +84,8 @@ jobs:
       - image: circleci/node:14
     steps:
       - checkout
+      - run:
+          command: yarn config get cacheFolder
       - restore-cache: *restore-cache
       - run: *install
       - save-cache: *save-cache
@@ -94,6 +101,8 @@ jobs:
     resource_class: large
     steps:
       - checkout
+      - run:
+          command: yarn config get cacheFolder
       - restore-cache: *restore-cache
       - run: *install
       - save-cache: *save-cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,11 @@
 aliases:
   - &restore-cache
-    keys: v4-dependencies-{{ checksum "yarn.lock" }}
+    key: v4-dependencies-{{ checksum "yarn.lock" }}
 
   - &save-cache
     paths:
       - ~/.yarn/berry/cache
-    keys: v4-dependencies-{{ checksum "yarn.lock" }}
+    key: v4-dependencies-{{ checksum "yarn.lock" }}
 
   - &filter-ignore-gh-pages
     branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,8 +20,6 @@ jobs:
       - image: circleci/node:10
     steps:
       - checkout
-      - run:
-          command: yarn config get cacheFolder
       - restore-cache: *restore-cache
       - run: *install
       - save-cache: *save-cache
@@ -36,8 +34,6 @@ jobs:
       - image: circleci/node:12
     steps:
       - checkout
-      - run:
-          command: yarn config get cacheFolder
       - restore-cache: *restore-cache
       - run: *install
       - save-cache: *save-cache
@@ -52,8 +48,6 @@ jobs:
       - image: circleci/node:12
     steps:
       - checkout
-      - run:
-          command: yarn config get cacheFolder
       - restore-cache: *restore-cache
       - run: *install
       - save-cache: *save-cache
@@ -68,8 +62,6 @@ jobs:
       - image: circleci/node:13
     steps:
       - checkout
-      - run:
-          command: yarn config get cacheFolder
       - restore-cache: *restore-cache
       - run: *install
       - save-cache: *save-cache
@@ -84,8 +76,6 @@ jobs:
       - image: circleci/node:14
     steps:
       - checkout
-      - run:
-          command: yarn config get cacheFolder
       - restore-cache: *restore-cache
       - run: *install
       - save-cache: *save-cache
@@ -101,8 +91,6 @@ jobs:
     resource_class: large
     steps:
       - checkout
-      - run:
-          command: yarn config get cacheFolder
       - restore-cache: *restore-cache
       - run: *install
       - save-cache: *save-cache


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Current one doesn't work due to looking for the wrong directory. Ideally we'd run `yarn config get cacheFolder` in order to get the directory rather than hard coding it, but I don't think that's possible.

Also make the cache be keyed only by checksum of the lockfile, not the branch name

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

I'll push another commit removing the debugging and verify it's a cache hit instead of a miss

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
