### PR TITLE
Make `@types/graceful-fs` a dev dependency

### DIFF
--- a/packages/jest-haste-map/package.json
+++ b/packages/jest-haste-map/package.json
@@ -11,7 +11,6 @@
   "types": "build/index.d.ts",
   "dependencies": {
     "@jest/types": "^26.3.0",
-    "@types/graceful-fs": "^4.1.2",
     "@types/node": "*",
     "anymatch": "^3.0.3",
     "fb-watchman": "^2.0.0",
@@ -28,6 +27,7 @@
     "@jest/test-utils": "^26.3.0",
     "@types/anymatch": "^1.3.1",
     "@types/fb-watchman": "^2.0.0",
+    "@types/graceful-fs": "^4.1.2",
     "@types/micromatch": "^4.0.0",
     "@types/sane": "^2.0.0",
     "slash": "^3.0.0"


### PR DESCRIPTION
## Summary

When upgrading our project to React Native 0.63, we upgraded Jest from 24.7 to 25.5, as specified by the React Native upgrade helper. After doing this, when type-checking our app with TypeScript 3.7, we got errors from global APIs like `setInterval`. It turns out Typescript was type-checking the timeout APIs using `@types/node`. This dependency was brought in via `jest-haste-map@25.5.1`, via `@types/graceful-fs`.

From our `yarn.lock` file:
```
jest-haste-map@^25.5.1:
  version "25.5.1"
  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-25.5.1.tgz#1df10f716c1d94e60a1ebf7798c9fb3da2620943"
  integrity sha512-dddgh9UZjV7SCDQUrQ+5t9yy8iEgKc1AKqZR9YDww8xsVOtzPQSMVLDChc21+g29oTRexb9/B0bIlZL+sWmvAQ==
  dependencies:
    "@jest/types" "^25.5.0"
    "@types/graceful-fs" "^4.1.2"
    anymatch "^3.0.3"
    fb-watchman "^2.0.0"
    graceful-fs "^4.2.4"
    jest-serializer "^25.5.0"
    jest-util "^25.5.0"
    jest-worker "^25.5.0"
    micromatch "^4.0.2"
    sane "^4.0.3"
    walker "^1.0.7"
    which "^2.0.2"
  optionalDependencies:
    fsevents "^2.1.2"
```

Including `@types/node` in a React Native TypeScript application causes type collisions with global APIs such as `setTimeout` and `setInterval`.

Other jest packages, such as `jest-config`, do not include "@types/" dependencies.

## Test plan

Running `yarn build` does not show any errors related to `@types/graceful-fs`.
