### PR TITLE
Fix lifecycle hook function types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- Fix lifecycle hook function types ([#10480](https://github.com/facebook/jest/pull/10480))
+
 ### Chore & Maintenance
 
 ### Performance

--- a/packages/jest-types/src/Global.ts
+++ b/packages/jest-types/src/Global.ts
@@ -47,6 +47,10 @@ type Each<EachCallback extends TestCallback> =
     ) => void)
   | (() => void);
 
+export interface HookBase {
+  (fn: HookFn, timeout?: number): void;
+}
+
 export interface ItBase {
   (testName: TestName, fn: TestFn, timeout?: number): void;
   each: Each<TestFn>;
@@ -91,10 +95,10 @@ export interface TestFrameworkGlobals {
   describe: Describe;
   xdescribe: DescribeBase;
   fdescribe: DescribeBase;
-  beforeAll: HookFn;
-  beforeEach: HookFn;
-  afterEach: HookFn;
-  afterAll: HookFn;
+  beforeAll: HookBase;
+  beforeEach: HookBase;
+  afterEach: HookBase;
+  afterAll: HookBase;
 }
 
 export interface GlobalAdditions extends TestFrameworkGlobals {

--- a/test-types/top-level-globals.test.ts
+++ b/test-types/top-level-globals.test.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @type ./empty.d.ts
+ */
+
+import {expectType} from 'mlh-tsd';
+//eslint-disable-next-line import/no-extraneous-dependencies
+import {afterAll, afterEach, beforeAll, beforeEach} from '@jest/globals';
+
+const fn = () => {};
+const timeout = 5;
+
+// https://jestjs.io/docs/en/api#methods
+expectType<void>(afterAll(fn));
+expectType<void>(afterAll(fn, timeout));
+expectType<void>(afterEach(fn));
+expectType<void>(afterEach(fn, timeout));
+expectType<void>(beforeAll(fn));
+expectType<void>(beforeAll(fn, timeout));
+expectType<void>(beforeEach(fn));
+expectType<void>(beforeEach(fn, timeout));


### PR DESCRIPTION
## Summary

Fixes #10066 

## Test plan

Added a new type test suite for the @jest/globals to ensure lifecycle hooks are not typed as `HookFn` that could return `Promise`, but are at least functions that return `void`.
