### PR TITLE
Use preformatted styling for a code example

### DIFF
--- a/docs/MockFunctions.md
+++ b/docs/MockFunctions.md
@@ -130,7 +130,7 @@ export default Users;
 
 Now, in order to test this method without actually hitting the API (and thus creating slow and fragile tests), we can use the `jest.mock(...)` function to automatically mock the axios module.
 
-Once we mock the module we can provide a `mockResolvedValue` for `.get` that returns the data we want our test to assert against. In effect, we are saying that we want axios.get('/users.json') to return a fake response.
+Once we mock the module we can provide a `mockResolvedValue` for `.get` that returns the data we want our test to assert against. In effect, we are saying that we want `axios.get('/users.json')` to return a fake response.
 
 ```js
 // users.test.js


### PR DESCRIPTION
Small change in the docs -- currently the source code piece (axios.get('/users.json')) is rendered using default font, it should be rendered using monospace font.
