### PR TITLE
chore: add `allowWholeFile` to `disable-enable-pair` eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -146,6 +146,7 @@ module.exports = {
   plugins: ['markdown', 'import', 'prettier', 'eslint-comments'],
   rules: {
     'arrow-body-style': 2,
+    'eslint-comments/disable-enable-pair': [2, {allowWholeFile: true}],
     'eslint-comments/no-unused-disable': 2,
     'flowtype/boolean-style': 2,
     'flowtype/no-primitive-constructor-types': 2,

--- a/e2e/coverage-remapping/covered.ts
+++ b/e2e/coverage-remapping/covered.ts
@@ -15,5 +15,3 @@ export = function difference(a: number, b: number): number {
 
   return a - b;
 };
-
-/* eslint-enable */

--- a/e2e/focused-tests/__tests__/tests.js
+++ b/e2e/focused-tests/__tests__/tests.js
@@ -4,9 +4,10 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-'use strict';
 
 /* eslint-disable jest/no-focused-tests */
+
+'use strict';
 
 describe('describe', () => {
   it('it', () => {
@@ -23,5 +24,3 @@ describe.only('describe only', () => {
     expect(1).toBe(1);
   });
 });
-
-/* eslint-enable */

--- a/e2e/jasmine-async/__tests__/promiseFit.test.js
+++ b/e2e/jasmine-async/__tests__/promiseFit.test.js
@@ -18,5 +18,3 @@ describe('promise fit', () => {
 
   fit('will run and fail', () => Promise.reject());
 });
-
-/* eslint-enable */

--- a/packages/jest-cli/src/init/__tests__/init.test.js
+++ b/packages/jest-cli/src/init/__tests__/init.test.js
@@ -221,5 +221,3 @@ describe('init', () => {
     });
   });
 });
-
-/* eslint-enable */

--- a/packages/test-utils/src/ConditionalTest.ts
+++ b/packages/test-utils/src/ConditionalTest.ts
@@ -44,5 +44,3 @@ export function onNodeVersions(
     });
   }
 }
-
-/* eslint-enable */


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

Copied from https://github.com/facebook/jest/pull/10438/files#diff-e4403a877d80de653400d88d85e4801aR205 but also removed now unneeded `enable`s

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Green CI

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
