### PR TITLE
fix(expect): `objectContaining` should recurse into sub-objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixes
 
 - `[jest-mock]` Allow to mock methods in getters (TypeScript 3.9 export)
+- `[expect]` Fix `objectContaining` to work recursively into sub-objects ([#10508](https://github.com/facebook/jest/pull/10508))
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
 
 ### Fixes
 
-- `[jest-mock]` Allow to mock methods in getters (TypeScript 3.9 export)
 - `[expect]` Fix `objectContaining` to work recursively into sub-objects ([#10508](https://github.com/facebook/jest/pull/10508))
+- `[jest-mock]` Allow to mock methods in getters (TypeScript 3.9 export) ([#10156](https://github.com/facebook/jest/pull/10156))
 
 ### Chore & Maintenance
 

--- a/packages/expect/src/__tests__/asymmetricMatchers.test.ts
+++ b/packages/expect/src/__tests__/asymmetricMatchers.test.ts
@@ -163,6 +163,9 @@ test('ObjectContaining matches', () => {
     objectContaining({}).asymmetricMatch('jest'),
     objectContaining({foo: 'foo'}).asymmetricMatch({foo: 'foo', jest: 'jest'}),
     objectContaining({foo: undefined}).asymmetricMatch({foo: undefined}),
+    objectContaining({foo: {bar: [1]}}).asymmetricMatch({
+      foo: {bar: [1], qux: []},
+    }),
     objectContaining({first: objectContaining({second: {}})}).asymmetricMatch({
       first: {second: {}},
     }),

--- a/packages/expect/src/asymmetricMatchers.ts
+++ b/packages/expect/src/asymmetricMatchers.ts
@@ -179,6 +179,15 @@ class ObjectContaining extends AsymmetricMatcher<Record<string, unknown>> {
     } else {
       for (const property in this.sample) {
         if (
+          typeof this.sample[property] === 'object' &&
+          !(this.sample[property] instanceof AsymmetricMatcher)
+        ) {
+          this.sample[property] = objectContaining(
+            this.sample[property] as Record<string, unknown>,
+          );
+        }
+
+        if (
           !hasProperty(other, property) ||
           !equals(this.sample[property], other[property])
         ) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

Addressing bug report facebook/jest#10462. According to the docs, ```objectContaining``` should apply in a recursive sense, however it doesn't seem to do this currently.
 
<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

This change will make ```objectContaining``` work recursively into sub-objects.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Included a unit test for the new behavior, and confirmed that all older tests still pass.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
