### PR TITLE
Update Open Collective sponsors integration

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -45,7 +45,7 @@ const Sponsor = ({
     className="sponsor-item"
     title={`$${totalDonations.value} by ${name || slug}`}
     target="_blank"
-    rel="nofollow noopener"
+    rel="sponsored nofollow noopener"
     href={website || `https://opencollective.com/${slug}`}
   >
     {
@@ -67,8 +67,8 @@ const Backer = ({
     className="backer-item"
     title={`$${totalDonations.value} by ${name || slug}`}
     target="_blank"
-    rel="nofollow noopener"
-    href={website || `https://opencollective.com/${slug}`}
+    rel="sponsored nofollow noopener"
+    href={`https://opencollective.com/${slug}`}
   >
     {
       <img


### PR DESCRIPTION
## Summary

It has come to our attention that Jest is heavily targeted by financial contributors who just want a cheap link on Jest homepage. It seems "nofollow" has not helped improve the situation.

To reduce this activity, I'm recommending:
- to limit direct links to the "Sponsor" tier and just link to the Open Collective profile for others
- to try the newer "[sponsored](https://support.google.com/webmasters/answer/96569?hl=en)" rel
- to update your Open Collective tiers (Backer and Sponsor) and clearly specify who will get a link or not. Check for example what [material-ui](https://opencollective.com/material-ui) is doing. 

Quick data point: out of **192** recurring financial contributors that seems only interested by a link on Jest homepage:
- **175** are lower than **$100**
- **165** are lower than **$10**
- **145** are lower than **$5**

As a follow up, we (Open Collective) are also working on a categorization scheme that should help you reject the contributions at the source, or filter them here on the website. Let us know if you're interested by one or the other.

We'll be engaging similarly with the other few projects that are heavily targeted by this kind of financial contributors.

## Changes

- don't link to website unless "sponsor" tier (more than $100 monthly)
- add "sponsored" rel to links