### PR TITLE
Add generator function to accepted hook types

### DIFF
--- a/packages/jest-circus/src/utils.ts
+++ b/packages/jest-circus/src/utils.ts
@@ -214,17 +214,25 @@ export const callAsyncCircusFn = (
         });
       };
 
-      returnedValue = fn.call(testContext, done);
+      returnedValue = fn.call<
+        Circus.TestContext | undefined,
+        Array<typeof done>,
+        void | Promise<unknown> | Generator | undefined
+      >(testContext, done);
 
       return;
     }
 
-    let returnedValue;
+    let returnedValue: any;
     if (isGeneratorFn(fn)) {
       returnedValue = co.wrap(fn).call({});
     } else {
       try {
-        returnedValue = fn.call(testContext);
+        returnedValue = fn.call<
+          Circus.TestContext | undefined,
+          [],
+          void | Promise<unknown> | Generator | undefined
+        >(testContext);
       } catch (error) {
         reject(error);
         return;

--- a/packages/jest-types/src/Global.ts
+++ b/packages/jest-types/src/Global.ts
@@ -7,6 +7,11 @@
 
 import type {CoverageMapData} from 'istanbul-lib-coverage';
 
+// TypeScript's GeneratorFunction is too narrow
+interface GeneratorFn {
+  (...args: Array<any>): Generator;
+}
+
 export type DoneFn = (reason?: string | Error) => void;
 export type TestName = string;
 export type TestFn = (
@@ -17,7 +22,7 @@ export type ConcurrentTestFn = (
 ) => Promise<void | undefined | unknown>;
 export type BlockFn = () => void;
 export type BlockName = string;
-export type HookFn = TestFn;
+export type HookFn = TestFn | GeneratorFn;
 
 export type Col = unknown;
 export type Row = Array<Col>;

--- a/test-types/top-level-globals.test.ts
+++ b/test-types/top-level-globals.test.ts
@@ -20,6 +20,7 @@ import {
 
 const fn = () => {};
 const asyncFn = async () => {};
+const genFn = function* () {};
 const timeout = 5;
 const testName = 'Test name';
 const testTable = [[1, 2]];
@@ -27,15 +28,19 @@ const testTable = [[1, 2]];
 // https://jestjs.io/docs/en/api#methods
 expectType<void>(afterAll(fn));
 expectType<void>(afterAll(asyncFn));
+expectType<void>(afterAll(genFn));
 expectType<void>(afterAll(fn, timeout));
 expectType<void>(afterEach(fn));
 expectType<void>(afterEach(asyncFn));
+expectType<void>(afterEach(genFn));
 expectType<void>(afterEach(fn, timeout));
 expectType<void>(beforeAll(fn));
 expectType<void>(beforeAll(asyncFn));
+expectType<void>(beforeAll(genFn));
 expectType<void>(beforeAll(fn, timeout));
 expectType<void>(beforeEach(fn));
 expectType<void>(beforeEach(asyncFn));
+expectType<void>(beforeEach(genFn));
 expectType<void>(beforeEach(fn, timeout));
 
 expectType<void>(test.each(testTable)(testName, fn));


### PR DESCRIPTION
## Summary

Another go at #10066, generators weren't included in the last PR (#10480).

## Test plan

Added more type tests.

##  Details

Reviewers will notice some ugly stuff going on. For starters, that `isGeneratorFn` type guard is checking against the `GeneratorFunction` interface, which doesn't seem to be the correct approach here (it's badly misunderstood just like `Function`). If we try to use `GeneratorFunction` as the receiving type for hook functions, it will fail.

So I declared a makeshift interface that should hold any generator function. But then, for some reason the type inference of a few `fn.call` inside `jest-circus` broke. I have no idea why, but manually providing the type arguments was possible to please the compiler.

Then another type inference gone awry and I had to specify the `any` type for the `returnedValue` variable, otherwise TypeScript inferred its value as possibly a `Generator` (thanks for nothing on the above type guard).

So all in all I'm not very pleased with the way things are, but I wasn't able to remove any of this cruft. If someone else feels like trying to, they're welcomed to try and supersede this PR.