### PR TITLE
docs: Document `--testFailureExitCode`

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -1032,6 +1032,14 @@ Default: `{}`
 
 Test environment options that will be passed to the `testEnvironment`. The relevant options depend on the environment. For example you can override options given to [jsdom](https://github.com/jsdom/jsdom) such as `{userAgent: "Agent/007"}`.
 
+### `testFailureExitCode` [number]
+
+Default: `1`
+
+The exit code Jest returns on test failure.
+
+_Note: This does not change the exit code in the case of Jest errors (e.g. invalid configuration)._
+
 ### `testMatch` [array\<string>]
 
 (default: `[ "**/__tests__/**/*.[jt]s?(x)", "**/?(*.)+(spec|test).[jt]s?(x)" ]`)

--- a/website/versioned_docs/version-22.x/Configuration.md
+++ b/website/versioned_docs/version-22.x/Configuration.md
@@ -718,6 +718,14 @@ Default: `{}`
 
 Test environment options that will be passed to the `testEnvironment`. The relevant options depend on the environment. For example you can override options given to [jsdom](https://github.com/jsdom/jsdom) such as `{userAgent: "Agent/007"}`.
 
+### `testFailureExitCode` [number]
+
+Default: `1`
+
+The exit code Jest returns on test failure.
+
+_Note: This does not change the exit code in the case of Jest errors (e.g. invalid configuration)._
+
 ### `testMatch` [array\<string>]
 
 (default: `[ '**/__tests__/**/*.js?(x)', '**/?(*.)(spec|test).js?(x)' ]`)

--- a/website/versioned_docs/version-23.x/Configuration.md
+++ b/website/versioned_docs/version-23.x/Configuration.md
@@ -784,6 +784,14 @@ Default: `{}`
 
 Test environment options that will be passed to the `testEnvironment`. The relevant options depend on the environment. For example you can override options given to [jsdom](https://github.com/jsdom/jsdom) such as `{userAgent: "Agent/007"}`.
 
+### `testFailureExitCode` [number]
+
+Default: `1`
+
+The exit code Jest returns on test failure.
+
+_Note: This does not change the exit code in the case of Jest errors (e.g. invalid configuration)._
+
 ### `testMatch` [array\<string>]
 
 (default: `[ "**/__tests__/**/*.js?(x)", "**/?(*.)+(spec|test).js?(x)" ]`)

--- a/website/versioned_docs/version-24.x/Configuration.md
+++ b/website/versioned_docs/version-24.x/Configuration.md
@@ -946,6 +946,14 @@ Default: `{}`
 
 Test environment options that will be passed to the `testEnvironment`. The relevant options depend on the environment. For example you can override options given to [jsdom](https://github.com/jsdom/jsdom) such as `{userAgent: "Agent/007"}`.
 
+### `testFailureExitCode` [number]
+
+Default: `1`
+
+The exit code Jest returns on test failure.
+
+_Note: This does not change the exit code in the case of Jest errors (e.g. invalid configuration)._
+
 ### `testMatch` [array\<string>]
 
 (default: `[ "**/__tests__/**/*.[jt]s?(x)", "**/?(*.)+(spec|test).[jt]s?(x)" ]`)

--- a/website/versioned_docs/version-25.x/Configuration.md
+++ b/website/versioned_docs/version-25.x/Configuration.md
@@ -968,6 +968,14 @@ Default: `{}`
 
 Test environment options that will be passed to the `testEnvironment`. The relevant options depend on the environment. For example you can override options given to [jsdom](https://github.com/jsdom/jsdom) such as `{userAgent: "Agent/007"}`.
 
+### `testFailureExitCode` [number]
+
+Default: `1`
+
+The exit code Jest returns on test failure.
+
+_Note: This does not change the exit code in the case of Jest errors (e.g. invalid configuration)._
+
 ### `testMatch` [array\<string>]
 
 (default: `[ "**/__tests__/**/*.[jt]s?(x)", "**/?(*.)+(spec|test).[jt]s?(x)" ]`)

--- a/website/versioned_docs/version-26.0/Configuration.md
+++ b/website/versioned_docs/version-26.0/Configuration.md
@@ -968,6 +968,14 @@ Default: `{}`
 
 Test environment options that will be passed to the `testEnvironment`. The relevant options depend on the environment. For example, you can override options given to [jsdom](https://github.com/jsdom/jsdom) such as `{userAgent: "Agent/007"}`.
 
+### `testFailureExitCode` [number]
+
+Default: `1`
+
+The exit code Jest returns on test failure.
+
+_Note: This does not change the exit code in the case of Jest errors (e.g. invalid configuration)._
+
 ### `testMatch` [array\<string>]
 
 (default: `[ "**/__tests__/**/*.[jt]s?(x)", "**/?(*.)+(spec|test).[jt]s?(x)" ]`)

--- a/website/versioned_docs/version-26.2/Configuration.md
+++ b/website/versioned_docs/version-26.2/Configuration.md
@@ -984,6 +984,14 @@ Default: `{}`
 
 Test environment options that will be passed to the `testEnvironment`. The relevant options depend on the environment. For example you can override options given to [jsdom](https://github.com/jsdom/jsdom) such as `{userAgent: "Agent/007"}`.
 
+### `testFailureExitCode` [number]
+
+Default: `1`
+
+The exit code Jest returns on test failure.
+
+_Note: This does not change the exit code in the case of Jest errors (e.g. invalid configuration)._
+
 ### `testMatch` [array\<string>]
 
 (default: `[ "**/__tests__/**/*.[jt]s?(x)", "**/?(*.)+(spec|test).[jt]s?(x)" ]`)

--- a/website/versioned_docs/version-26.4/Configuration.md
+++ b/website/versioned_docs/version-26.4/Configuration.md
@@ -1015,6 +1015,14 @@ Default: `{}`
 
 Test environment options that will be passed to the `testEnvironment`. The relevant options depend on the environment. For example you can override options given to [jsdom](https://github.com/jsdom/jsdom) such as `{userAgent: "Agent/007"}`.
 
+### `testFailureExitCode` [number]
+
+Default: `1`
+
+The exit code Jest returns on test failure.
+
+_Note: This does not change the exit code in the case of Jest errors (e.g. invalid configuration)._
+
 ### `testMatch` [array\<string>]
 
 (default: `[ "**/__tests__/**/*.[jt]s?(x)", "**/?(*.)+(spec|test).[jt]s?(x)" ]`)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Includes the `--testFailureExitCode` config parameter in the documentation. This parameter was added in the 21.0.0 release by #4067 but wasn't included in the release notes or added to the documentation.

From a motivation perspective, at my company we're incorporating a variety of small `create-react-app`'s into a much larger product that has a handrolled continuous integration system. It considers a non-zero exit code of a testing tool to be a build environment failure and will abort subsequent steps (it scoops up the test reports and process them to determine test failures). Given Jest's default behaviour of returning `1` for both test failures and tool failures I was going to need to find a way to distinguish between a test and a tool failure. I tried searching for this exact configuration in the docs and generally on google and came up empty, and then randomly stumbled on this CLI/config parameter when playing with a custom test runner (the example logs the whole config object to the console).

It'd be nice for this to be included in the official documentation so (a) others could benefit and (b) we had some confidence that it's not going to silently dissapear or become broken.

I've backdated it through the past versions as it was added before the oldest version of the documentation currently on the website.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Ran up the website following contributor instructions (`yarn`, `yarn start` in the `website` directory). Item appears in the TOC and renders correctly.

![image](https://user-images.githubusercontent.com/1075910/93884672-c33e4500-fd15-11ea-988a-eb9ae0e2c464.png)

![image](https://user-images.githubusercontent.com/1075910/93884608-b3266580-fd15-11ea-9ba4-a12c4a846d4b.png)
