### PR TITLE
docs: fix markdown link syntax

### DIFF
--- a/docs/GlobalAPI.md
+++ b/docs/GlobalAPI.md
@@ -471,7 +471,7 @@ Also under the alias: `it.concurrent(name, fn, timeout)`
 
 Use `test.concurrent` if you want the test to run concurrently.
 
-> Note: `test.concurrent` is considered experimental - see [here])https://github.com/facebook/jest/labels/Area%3A%20Concurrent) for details on missing features and other issues
+> Note: `test.concurrent` is considered experimental - see [here](https://github.com/facebook/jest/labels/Area%3A%20Concurrent) for details on missing features and other issues
 
 The first argument is the test name; the second argument is an asynchronous function that contains the expectations to test. The third argument (optional) is `timeout` (in milliseconds) for specifying how long to wait before aborting. _Note: The default timeout is 5 seconds._
 

--- a/website/versioned_docs/version-26.4/GlobalAPI.md
+++ b/website/versioned_docs/version-26.4/GlobalAPI.md
@@ -472,7 +472,7 @@ Also under the alias: `it.concurrent(name, fn, timeout)`
 
 Use `test.concurrent` if you want the test to run concurrently.
 
-> Note: `test.concurrent` is considered experimental - see [here])https://github.com/facebook/jest/labels/Area%3A%20Concurrent) for details on missing features and other issues
+> Note: `test.concurrent` is considered experimental - see [here](https://github.com/facebook/jest/labels/Area%3A%20Concurrent) for details on missing features and other issues
 
 The first argument is the test name; the second argument is an asynchronous function that contains the expectations to test. The third argument (optional) is `timeout` (in milliseconds) for specifying how long to wait before aborting. _Note: The default timeout is 5 seconds._
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

One of the links in the documentation has a syntax error:

<img width="675" alt="link-failed-to-link" src="https://user-images.githubusercontent.com/10053423/93950311-6c7a4080-fd00-11ea-8795-03b55ff625db.png">

[Link to wonky docs](https://jestjs.io/docs/en/api#testconcurrentname-fn-timeout)

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Screenshot from locally hosted docs after the fix:
<img width="676" alt="moderately-passable-link" src="https://user-images.githubusercontent.com/10053423/93950490-db579980-fd00-11ea-9232-0a3738a40d88.png">

<!--
              !#########       #                 
            !########!          ##!              
         !########!               ###            
      !##########                  ####          
    ######### #####                ######        
     !###!      !####!              ######       
       !           #####            ######!      
                     !####!         #######      
                        #####       #######      
                          !####!   #######!      
                             ####!########       
          ##                   ##########        
        ,######!          !#############         
      ,#### ########################!####!       
    ,####'     ##################!'    #####     
  ,####'            #######              !####!  
 ####'                                      #####
 ~## 
-->